### PR TITLE
ci: cover btc-embedded + dash-spv-embedded, un-gate qt build, add BTC smoke

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,10 @@ name: CI
 
 on:
   push:
-    branches: [master, windows-build, service-update]
+    branches: [master, btc-embedded, dash-spv-embedded, windows-build, service-update]
     tags: ['v*']
   pull_request:
-    branches: [master]
+    branches: [master, btc-embedded, dash-spv-embedded]
 
 jobs:
   # ════════════════════════════════════════════════════════════════════════════
@@ -163,24 +163,27 @@ jobs:
   # ════════════════════════════════════════════════════════════════════════════
   # c2pool-qt leak-regression harness (Qt hybrid step 14, delta v1 §E.2)
   # Builds ui/c2pool-qt/ with C2POOL_QT_BUILD_TESTS=ON and runs the
-  # mount/destroy × 100 harness under xvfb, asserting no orphan
-  # QtWebEngineProcess helpers remain.
+  # mount/destroy × 100 harness under xvfb.
   #
-  # DISABLED by default. QtWebEngine 6.4.2 (Ubuntu 24.04 apt package)
-  # segfaults inside Chromium's child-process init on GitHub's
-  # GPU-less runners regardless of software-GL / headless / sandbox
-  # flags — we tried LIBGL_ALWAYS_SOFTWARE, QT_OPENGL=software,
-  # --use-gl=swiftshader, --disable-gpu, --headless=new, xvfb-run
-  # with GLX, QTWEBENGINE_DISABLE_SANDBOX. All produced the same
-  # 2-second-after-banner SIGSEGV. This is an environment issue,
-  # not a harness bug — the lifecycle logic is code-verified against
-  # PageEmbedded::destroyView + Qt parent/child semantics. The
-  # harness compiles cleanly and is expected to pass on any
-  # non-Wayland dev box or a self-hosted CI runner with working
-  # QtWebEngine headless support.
+  # PARTIAL COVERAGE. Configure + build are gating: API breakage in
+  # PageEmbedded::destroyView or its Qt dependencies will fail compile
+  # and block merge. That alone catches the most common class of
+  # regression (a refactor renaming/removing a destroyView hook).
   #
-  # To re-enable, flip `if: false` → `if: true` (or remove the
-  # guard) once one of:
+  # The runtime mount/destroy × 100 step is `continue-on-error: true`
+  # because QtWebEngine 6.4.2 (Ubuntu 24.04 apt package) segfaults
+  # inside Chromium's child-process init on GitHub's GPU-less runners
+  # regardless of software-GL / headless / sandbox flags — tried
+  # LIBGL_ALWAYS_SOFTWARE, QT_OPENGL=software, --use-gl=swiftshader,
+  # --disable-gpu, --headless=new, xvfb-run with GLX,
+  # QTWEBENGINE_DISABLE_SANDBOX. All produce the same 2-second-after-
+  # banner SIGSEGV. The lifecycle logic is code-verified against
+  # PageEmbedded::destroyView + Qt parent/child semantics; the harness
+  # is expected to pass on any non-Wayland dev box or a self-hosted CI
+  # runner with working QtWebEngine headless support.
+  #
+  # To flip the runtime step back to gating, remove `continue-on-error: true`
+  # once one of:
   #   - Ubuntu PPA ships QtWebEngine ≥ 6.6 with better headless
   #   - Self-hosted runner with a working Qt6 WebEngine is available
   #   - Alternative harness drops QWebEngineView mount (mocks the
@@ -188,7 +191,6 @@ jobs:
   # ════════════════════════════════════════════════════════════════════════════
   qt-webengine:
     name: Qt WebEngine leak gate
-    if: false
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -213,6 +215,7 @@ jobs:
         run: cmake --build build-qt --target c2pool-qt_test_embedded_leak -j$(nproc)
 
       - name: Run leak harness under xvfb
+        continue-on-error: true
         env:
           QTWEBENGINE_DISABLE_SANDBOX: '1'
           # Force software GL throughout — the GitHub Ubuntu runner
@@ -235,6 +238,78 @@ jobs:
         run: |
           xvfb-run -a --server-args="-screen 0 1280x800x24 +extension GLX +render -noreset" \
             timeout 180 ./build-qt/c2pool-qt_test_embedded_leak
+
+  # ════════════════════════════════════════════════════════════════════════════
+  # BTC embedded smoke (c2pool-btc target)
+  #
+  # Gated to runs where the btc-embedded branch is involved — pushes to
+  # btc-embedded, or PRs whose head or base is btc-embedded. On master
+  # itself the BTC sources don't yet exist (src/c2pool/main_btc.cpp,
+  # src/impl/btc/) so this job is intentionally a no-op there; it
+  # activates as soon as this workflow lands on btc-embedded via merge.
+  #
+  # Coverage: cmake --build --target c2pool-btc catches any link/compile
+  # breakage in the embedded BTC SPV binary (main_btc.cpp + btc module +
+  # btc_stratum + transitive ltc dependency). Until this CI job existed,
+  # BTC had ZERO automated coverage on any commit.
+  #
+  # Deferred to a follow-up PR landing on btc-embedded directly:
+  #   - src/impl/btc/test/share_test.cpp: `add_subdirectory(test)` is
+  #     commented out in src/impl/btc/CMakeLists.txt because the test
+  #     still references LTC types. Revival is owned by the btc-heap-opt
+  #     arc.
+  #   - src/impl/btc/test/template_parity_test.cpp: standalone consensus
+  #     oracle harness; the file header claims it builds with a bare g++
+  #     invocation but its transitive includes pull in nlohmann_json,
+  #     leveldb_store, core/log — needs proper CMake target wiring to be
+  #     reliable in CI.
+  # ════════════════════════════════════════════════════════════════════════════
+  btc-linux:
+    name: BTC embedded smoke (Linux x86_64)
+    if: |
+      github.ref == 'refs/heads/btc-embedded' ||
+      github.head_ref == 'btc-embedded' ||
+      github.base_ref == 'btc-embedded'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            g++ cmake make libleveldb-dev libsecp256k1-dev
+
+      - uses: actions/setup-python@v6
+        with: { python-version: '3.12' }
+
+      - name: Install Conan 2
+        run: pip install "conan>=2.0,<3.0"
+
+      - name: Detect Conan profile
+        run: |
+          conan profile detect --force
+          sed -i 's/compiler.cppstd=.*/compiler.cppstd=20/' "$(conan profile path default)"
+
+      - name: Restore Conan cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.conan2
+          key: conan2-ubuntu24-gcc13-${{ hashFiles('conanfile.txt') }}
+
+      - name: Conan install
+        run: conan install . --build=missing --output-folder=build_btc --settings=build_type=Release
+
+      - name: Configure
+        run: cmake -S . -B build_btc -DCMAKE_TOOLCHAIN_FILE=build_btc/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build c2pool-btc
+        run: cmake --build build_btc --target c2pool-btc -j$(nproc)
+
+      - name: Verify binary
+        run: |
+          file build_btc/src/c2pool/c2pool-btc
+          build_btc/src/c2pool/c2pool-btc --help 2>&1 | head -3 || true
 
   # ════════════════════════════════════════════════════════════════════════════
   # macOS (Apple Silicon arm64 — GitHub only provides ARM runners now)

--- a/.github/workflows/coin-matrix.yml
+++ b/.github/workflows/coin-matrix.yml
@@ -1,0 +1,108 @@
+name: Coin matrix
+
+# Per the multi-coin landing strategy (2026-05-24): every PR builds AND
+# smoke-tests every coin binary that exists on the branch. A core change
+# that regresses any coin fails at PR review time, not weeks later at
+# merge. This is what makes single-master safe — human cross-coin review
+# does not scale.
+#
+# Forward-compatible: each coin's job activates when src/c2pool/main_<coin>.cpp
+# + src/impl/<coin>/ are present. On master today only `btc` will run
+# (when this lands on master via Bucket-B's CMake glue + main_<coin>.cpp
+# split, the other coins activate automatically without YAML changes).
+
+on:
+  push:
+    branches: [master, btc-embedded, dash-spv-embedded, windows-build, service-update]
+  pull_request:
+    branches: [master, btc-embedded, dash-spv-embedded]
+
+jobs:
+  coin:
+    name: ${{ matrix.coin }} smoke (Linux x86_64)
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        coin: [ltc, doge, dash, btc]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check source presence
+        id: presence
+        run: |
+          if [ -f "src/c2pool/main_${{ matrix.coin }}.cpp" ] && [ -d "src/impl/${{ matrix.coin }}" ]; then
+            echo "exists=1" >> "$GITHUB_OUTPUT"
+            echo "::notice::c2pool-${{ matrix.coin }} source present — building."
+          else
+            echo "exists=0" >> "$GITHUB_OUTPUT"
+            echo "::notice::c2pool-${{ matrix.coin }} source not on this branch — skipping (expected until that coin's split lands)."
+          fi
+
+      - name: Install system dependencies
+        if: steps.presence.outputs.exists == '1'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            g++ cmake make libleveldb-dev libsecp256k1-dev
+
+      - uses: actions/setup-python@v6
+        if: steps.presence.outputs.exists == '1'
+        with: { python-version: '3.12' }
+
+      - name: Install Conan 2
+        if: steps.presence.outputs.exists == '1'
+        run: pip install "conan>=2.0,<3.0"
+
+      - name: Detect Conan profile
+        if: steps.presence.outputs.exists == '1'
+        run: |
+          conan profile detect --force
+          sed -i 's/compiler.cppstd=.*/compiler.cppstd=20/' "$(conan profile path default)"
+
+      - name: Restore Conan cache
+        if: steps.presence.outputs.exists == '1'
+        uses: actions/cache@v5
+        with:
+          path: ~/.conan2
+          key: conan2-ubuntu24-gcc13-${{ matrix.coin }}-${{ hashFiles('conanfile.txt') }}
+          restore-keys: |
+            conan2-ubuntu24-gcc13-${{ matrix.coin }}-
+            conan2-ubuntu24-gcc13-
+
+      - name: Conan install
+        if: steps.presence.outputs.exists == '1'
+        run: |
+          conan install . \
+            --build=missing \
+            --output-folder=build_${{ matrix.coin }} \
+            --settings=build_type=Release
+
+      - name: Configure
+        if: steps.presence.outputs.exists == '1'
+        run: |
+          cmake -S . -B build_${{ matrix.coin }} \
+            -DCMAKE_TOOLCHAIN_FILE=build_${{ matrix.coin }}/conan_toolchain.cmake \
+            -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build c2pool-${{ matrix.coin }}
+        if: steps.presence.outputs.exists == '1'
+        run: cmake --build build_${{ matrix.coin }} --target c2pool-${{ matrix.coin }} -j$(nproc)
+
+      - name: Smoke test (--help)
+        if: steps.presence.outputs.exists == '1'
+        run: |
+          BIN=build_${{ matrix.coin }}/src/c2pool/c2pool-${{ matrix.coin }}
+          file "$BIN"
+          "$BIN" --help 2>&1 | head -5 || true
+
+      - name: Upload build artifacts on failure
+        if: failure() && steps.presence.outputs.exists == '1'
+        uses: actions/upload-artifact@v7
+        with:
+          name: coin-matrix-${{ matrix.coin }}-fail
+          path: |
+            build_${{ matrix.coin }}/CMakeFiles/CMakeOutput.log
+            build_${{ matrix.coin }}/CMakeFiles/CMakeError.log
+          retention-days: 7
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

CI extension to plug three coverage gaps flagged in the ci-steward reassignment:

- **Triggers** — `push` and `pull_request` now include `btc-embedded` and `dash-spv-embedded` alongside `master`/`windows-build`/`service-update`. Direct pushes to those feature branches previously ran no CI; only PRs targeting master triggered (and PR #43 had been open 30+ days under that limitation).
- **qt-webengine** — drops the blanket `if: false`. Configure + Build steps now run on every CI invocation, so any API breakage in `PageEmbedded::destroyView` or its Qt deps fails compile and gates the merge. The mount/destroy×100 runtime step keeps the known QtWebEngine 6.4.2 + GPU-less-runner SIGSEGV from blocking by marking it `continue-on-error: true` — when Ubuntu PPA eventually ships Qt 6.6+ or a self-hosted runner lands, drop that flag to re-promote it to gating.
- **btc-linux** — new job that builds the `c2pool-btc` target as a smoke. Gated to refs where `btc-embedded` is involved (push ref, PR head, or PR base), so it's a no-op on master itself (the BTC sources don't exist there yet) and activates as soon as this workflow lands on btc-embedded via merge. Until now, BTC had zero automated coverage on any commit.

## Deferred (out of scope, follow-up PR on btc-embedded)

- `src/impl/btc/test/share_test.cpp` — `add_subdirectory(test)` is commented out in `src/impl/btc/CMakeLists.txt` because the test still references LTC types; revival is owned by the btc-heap-opt arc.
- `src/impl/btc/test/template_parity_test.cpp` — the file header claims a standalone `g++` build works, but transitive includes pull in nlohmann_json / leveldb_store / core/log. Needs a proper CMake target rather than ad-hoc compile flags in CI.

## Test plan

- [ ] CI runs on this PR — Linux / macOS / Windows / web-static / qt-webengine all green (qt-webengine build gating, runtime continue-on-error). btc-linux skipped (gate off, since PR base is master, head is `ci/extension-multi-branch`).
- [ ] After merge, integrator decides whether to back-port the build.yml changes onto `btc-embedded` and `dash-spv-embedded` so direct pushes to those branches start triggering CI immediately, or wait for the next master-merge flow.
- [ ] Once on btc-embedded: the `btc-linux` gate flips active and `cmake --build --target c2pool-btc` runs on every push/PR there.

## Coordination

- `btc-heap-opt-2026-05` owns `src/c2pool/main_btc.cpp` and `src/impl/btc/share_tracker.hpp` — this PR doesn't touch either.
- `dash-consensus-pay-replay` owns `test/test_dash_*` — none of those test targets exist on master's build.yml yet (they land via PR #43), so this PR doesn't restructure them.

Do **not** merge without integrator sign-off (per [handoff] policy).