### PR TITLE
ci: fix coin-matrix guard path

### DIFF
--- a/.github/workflows/coin-matrix.yml
+++ b/.github/workflows/coin-matrix.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Check source presence
         id: presence
         run: |
-          if [ -f "src/c2pool/main_${{ matrix.coin }}.cpp" ] && [ -d "src/impl/${{ matrix.coin }}" ]; then
+          if [ -f "src/impl/${{ matrix.coin }}/main_${{ matrix.coin }}.cpp" ] && [ -d "src/impl/${{ matrix.coin }}" ]; then
             echo "exists=1" >> "$GITHUB_OUTPUT"
             echo "::notice::c2pool-${{ matrix.coin }} source present — building."
           else


### PR DESCRIPTION
## What

One-line fix to the source-presence guard in `.github/workflows/coin-matrix.yml`.

The guard checked for `src/c2pool/main_<coin>.cpp`, but the actual on-disk
directory contract is `src/impl/<coin>/main_<coin>.cpp` (confirmed against
`src/impl/dash/main_dash.cpp` in the dash session). The wrong path matched
nothing on every branch, so the guard set `exists=0` for all four coins and
silently skipped every build/smoke step.

```diff
-          if [ -f "src/c2pool/main_${{ matrix.coin }}.cpp" ] && [ -d "src/impl/${{ matrix.coin }}" ]; then
+          if [ -f "src/impl/${{ matrix.coin }}/main_${{ matrix.coin }}.cpp" ] && [ -d "src/impl/${{ matrix.coin }}" ]; then
```

## Why it matters

PR #45's coin-matrix went **green by accident**: every job no-op'd through
the guard rather than actually building anything. The matrix was providing
zero real coverage. With the corrected path, each coin's job activates the
moment its `src/impl/<coin>/main_<coin>.cpp` split lands, which is the whole
point of the forward-compatible guard.

No build behavior changes on master today (the splits haven't landed yet),
so this stays green until a coin's source is actually present — at which
point it will start building for real.

## Scope

- One-line change. No other edits.