### PR TITLE
bucket-A4: cap Packet read-constructor prefix_length (SAFE-ADDITIVE, Bug-9 hardening)

### DIFF
--- a/src/core/packet.hpp
+++ b/src/core/packet.hpp
@@ -44,6 +44,17 @@ public:
     // read
     Packet(size_t prefix_length)
     {
+        // Bug 9 hardening: prefix_length comes from m_node->get_prefix().size()
+        // in Socket::init(). If m_node has been destroyed mid-handshake (UAF
+        // from rapid disconnect-reconnect — Bug-3-family), the vector's size
+        // field reads garbage and resize() throws std::length_error
+        // ("vector::_M_default_append") which kills the process. All known
+        // protocols have a 4-byte magic prefix; cap at 16 to reject UAF
+        // garbage cleanly and let the connection fail without crashing.
+        constexpr size_t MAX_PREFIX_LENGTH = 16;
+        if (prefix_length > MAX_PREFIX_LENGTH) {
+            throw std::ios_base::failure("Packet prefix_length exceeds cap (likely UAF on m_node)");
+        }
         prefix.resize(prefix_length);
     }
 


### PR DESCRIPTION
## Summary

Adds a bounds guard to `Packet(size_t prefix_length)`: caps `prefix_length` at 16 and throws `std::ios_base::failure` if exceeded, instead of letting `prefix.resize()` throw `std::length_error` (`vector::_M_default_append`) and abort the process. **Additive hardening — no change to valid-traffic behavior** (audit classification: SAFE-ADDITIVE).

1 file, +11:
- **modified** — `src/core/packet.hpp`

Cherry-picked from `dash-spv-embedded` HEAD `8249dc28`.

## Context

Part 4 of the bucket-A sub-PRs for the multi-coin landing strategy. Follows #46 (A1), #48 (A2), #49 (A3). Independent of A1–A3 (different file, no shared symbols).

## Why this is safe for LTC+DOGE

- `prefix_length` flows from `m_node->get_prefix().size()` in `Socket::init()`. All known protocols use a **4-byte magic prefix**, so the cap at 16 is never reached in normal operation — the `resize(prefix_length)` path is unchanged for every valid connection.
- The guard only fires in the Bug-3 UAF class (rapid disconnect-reconnect destroys `m_node` mid-handshake → the vector's size field reads garbage → unguarded `resize()` aborts). It converts that crash into a clean per-connection failure (`std::ios_base::failure`, already the connection-teardown exception type).
- This is the exact line that has run in the Dash mainnet soak for weeks (it's part of the Bug-9 hardening set).

## CI expectation

- Legacy `linux:` + cross-platform + CodeQL: **green**.
- coin-matrix entries: skip fast on this branch.

## Reviewer

Agent-side reviewer: **ltc-doge-production-steward** (watches the branch). Integrator (cc) routes human review.

## Test plan

- [ ] Legacy `linux:` CI green (full test suite — exercises the Packet read path on valid LTC/DOGE traffic)
- [ ] CodeQL + cross-platform green
- [ ] No file other than `src/core/packet.hpp` touched (directory-contract spot-check)