### PR TITLE
bucket-A4 fast-follow: Packet prefix-cap boundary tests (SAFE-COSMETIC)

### DIFF
--- a/src/core/test/CMakeLists.txt
+++ b/src/core/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 if (BUILD_TESTING AND (GTest_FOUND OR GTEST_FOUND))
-    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp)
-    target_link_libraries(core_test PRIVATE GTest::gtest_main core GTest::gtest)
+    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp)
+    target_link_libraries(core_test PRIVATE GTest::gtest_main core c2pool_merged_mining GTest::gtest)
 
     include(GoogleTest)
     include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})

--- a/src/core/test/packet_test.cpp
+++ b/src/core/test/packet_test.cpp
@@ -1,0 +1,64 @@
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <limits>
+#include <ios>
+#include <vector>
+
+#include <core/pack.hpp>
+#include <core/pack_types.hpp>
+#include <core/message.hpp>
+#include <core/hash.hpp>
+#include <core/packet.hpp>
+
+// A4 (Bug-9 hardening) cap-boundary tests for the Packet read-constructor.
+// The read ctor caps prefix_length at MAX_PREFIX_LENGTH (16) and throws
+// std::ios_base::failure on over-cap values, which is how UAF garbage from a
+// destroyed m_node (Bug-3-family rapid disconnect/reconnect) is rejected
+// without crashing the process. See src/core/packet.hpp.
+namespace {
+
+constexpr size_t kCap = 16; // must track MAX_PREFIX_LENGTH in packet.hpp
+
+// --- at/under the cap: must succeed and size the prefix exactly ---
+
+TEST(PacketPrefixCap, ZeroLengthSucceeds)
+{
+    core::Packet p(0);
+    EXPECT_EQ(p.prefix.size(), 0u);
+}
+
+TEST(PacketPrefixCap, JustUnderCapSucceeds)
+{
+    core::Packet p(kCap - 1);
+    EXPECT_EQ(p.prefix.size(), kCap - 1);
+}
+
+TEST(PacketPrefixCap, AtCapSucceeds)
+{
+    // Boundary: exactly at the cap is the largest accepted value.
+    core::Packet p(kCap);
+    EXPECT_EQ(p.prefix.size(), kCap);
+}
+
+// --- over the cap: must throw cleanly, never resize ---
+
+TEST(PacketPrefixCap, JustOverCapThrows)
+{
+    EXPECT_THROW({ core::Packet p(kCap + 1); }, std::ios_base::failure);
+}
+
+TEST(PacketPrefixCap, WayOverCapThrows)
+{
+    EXPECT_THROW({ core::Packet p(1024); }, std::ios_base::failure);
+}
+
+TEST(PacketPrefixCap, UafGarbageMaxSizeThrows)
+{
+    // Simulates the garbage size_t read from a freed m_node vector; pre-cap
+    // this reached resize() and aborted via std::length_error.
+    EXPECT_THROW({ core::Packet p(std::numeric_limits<size_t>::max()); },
+                 std::ios_base::failure);
+}
+
+} // namespace


### PR DESCRIPTION
## bucket-A4 fast-follow — Packet prefix-cap boundary tests

Adds `src/core/test/packet_test.cpp`: a `PacketPrefixCap` GTest suite covering the `MAX_PREFIX_LENGTH` (16) boundary of the `Packet` read-constructor hardened in #50 (Bug-9 / UAF-on-`m_node` defense). Six cases: zero-length, just-under-cap, at-cap succeed; just-over-cap, way-over-cap, and UAF garbage `size_t` all throw `std::ios_base::failure` without crashing.

Wires `packet_test.cpp` into `core_test` and corrects the pre-existing static-link order so `core_test` links: `libltc_coin.a` is pulled in transitively and references `core::timestamp()` after `ld` has already processed `core`, leaving it undefined; linking `c2pool_merged_mining` after `core` re-injects `core` via the merged_mining PUBLIC dependency, resolving the late reference. CMake-only, runtime-behaviour preserving.

### Scope / verification
- **`core_test` 32/32 GREEN** — includes all 6 `PacketPrefixCap` cap-boundary tests (verified on this branch, Linux x86_64, `conan-release`).
- **Full 582-suite remains RED** due to a pre-existing circular static-archive dependency between `core` and `ltc_coin`/`pool` — a single-pass `ld` cannot satisfy the cycle (empirically confirmed; reorder alone is insufficient).
- **Bucket-wide fix tracked separately** under `ci-steward/cmake-link-group-rescan` (`LINK_GROUP:RESCAN`, CMake 4.2.3) — commit `5edeb308`, in flight.
- **This PR is the cap-boundary unit test only**; the bucket-wide link fix is a separate concern outside a4-ff scope.

### Label
**SAFE-COSMETIC** — new `packet_test.cpp` + mechanical link-line edit in `src/core/test/CMakeLists.txt`. No change to packet-handling behaviour.

cc dash-consensus-pay-replay — comment-thread-as-review; your substantive verdict gates merge. Merge by integrator on operator `push approved`.
