### PR TITLE
core: break SCC link cycle via core_util leaf library (SAFE-REFACTOR)

### DIFF
--- a/src/c2pool/CMakeLists.txt
+++ b/src/c2pool/CMakeLists.txt
@@ -111,7 +111,7 @@ endif()
 
 # Test applications
 add_executable(test_ltc_node test_ltc_node.cpp)
-target_link_libraries(test_ltc_node $<LINK_GROUP:RESCAN,core,btclibs,pool,ltc,c2pool_payout,c2pool_hashrate,c2pool_merged_mining>)
+target_link_libraries(test_ltc_node $<LINK_GROUP:RESCAN,core,sharechain,btclibs,pool,ltc,ltc_coin,c2pool_storage,c2pool_payout,c2pool_hashrate,c2pool_merged_mining>)
 target_link_libraries(test_ltc_node nlohmann_json::nlohmann_json)
 
 # Legacy applications have been archived to ../../archive/

--- a/src/c2pool/CMakeLists.txt
+++ b/src/c2pool/CMakeLists.txt
@@ -111,7 +111,7 @@ endif()
 
 # Test applications
 add_executable(test_ltc_node test_ltc_node.cpp)
-target_link_libraries(test_ltc_node core btclibs pool ltc)
+target_link_libraries(test_ltc_node $<LINK_GROUP:RESCAN,core,btclibs,pool,ltc,c2pool_payout,c2pool_hashrate,c2pool_merged_mining>)
 target_link_libraries(test_ltc_node nlohmann_json::nlohmann_json)
 
 # Legacy applications have been archived to ../../archive/

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -38,8 +38,13 @@ set(source
 
 find_package(yaml-cpp REQUIRED)
 
+# core_util: dependency-free leaf carrying core::timestamp(), split out to
+# break the core <-> {pool,ltc,c2pool} static-link SCC (V36 gate). Source
+# half landed in 07165699; this wires the leaf library into the build.
+add_library(core_util STATIC core_util.cpp)
+
 add_library(core STATIC ${source})
-target_link_libraries(core btclibs)
+target_link_libraries(core core_util btclibs)
 
 target_link_libraries(core Boost::headers Boost::exception Boost::log Boost::log_setup Boost::thread Boost::filesystem yaml-cpp nlohmann_json::nlohmann_json ${LEVELDB_LIBRARIES})
 

--- a/src/core/common.cpp
+++ b/src/core/common.cpp
@@ -1,10 +1,5 @@
 #include "common.hpp"
-namespace core
-{
 
-uint32_t timestamp()
-{
-    return std::time(nullptr);
-}
-
-} // namespace core
+// core::timestamp() moved to the dependency-free core_util leaf
+// (src/core/core_util.cpp) to break the core<->{pool,ltc,c2pool}
+// static-link cycle. This translation unit is intentionally minimal.

--- a/src/core/common.hpp
+++ b/src/core/common.hpp
@@ -6,6 +6,8 @@
 #include <iomanip>
 #include <functional>
 
+#include <core/core_util.hpp>
+
 namespace core
 {
 
@@ -47,6 +49,7 @@ struct debug_timestamp
     }
 };
 
-uint32_t timestamp();
+// core::timestamp() is declared in <core/core_util.hpp> (included above),
+// the dependency-free leaf that breaks the core<->{pool,ltc,c2pool} cycle.
 
 } // namespace core

--- a/src/core/core_util.cpp
+++ b/src/core/core_util.cpp
@@ -1,0 +1,13 @@
+#include <core/core_util.hpp>
+
+#include <ctime>
+
+namespace core
+{
+
+uint32_t timestamp()
+{
+    return std::time(nullptr);
+}
+
+} // namespace core

--- a/src/core/core_util.hpp
+++ b/src/core/core_util.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <cstdint>
+
+namespace core
+{
+
+// Wall-clock seconds since the Unix epoch.
+//
+// Lives in the dependency-free core_util leaf so that the pool / ltc /
+// c2pool libraries can reference it without linking the full core static
+// library. Moving this single out-of-line symbol out of core breaks the
+// core <-> {pool, ltc, c2pool} static-link cycle (V36 SCC gate).
+uint32_t timestamp();
+
+} // namespace core

--- a/src/impl/ltc/test/CMakeLists.txt
+++ b/src/impl/ltc/test/CMakeLists.txt
@@ -2,7 +2,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     add_executable(share_test share_test.cpp)
     target_link_libraries(share_test PRIVATE
         GTest::gtest_main GTest::gtest
-        core sharechain
+        $<LINK_GROUP:RESCAN,core,sharechain,pool,ltc,btclibs,c2pool_payout,c2pool_hashrate,c2pool_merged_mining>
     )
 
     include(GoogleTest)

--- a/src/impl/ltc/test/CMakeLists.txt
+++ b/src/impl/ltc/test/CMakeLists.txt
@@ -2,7 +2,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     add_executable(share_test share_test.cpp)
     target_link_libraries(share_test PRIVATE
         GTest::gtest_main GTest::gtest
-        $<LINK_GROUP:RESCAN,core,sharechain,pool,ltc,btclibs,c2pool_payout,c2pool_hashrate,c2pool_merged_mining>
+        $<LINK_GROUP:RESCAN,core,sharechain,pool,ltc,btclibs,ltc_coin,c2pool_storage,c2pool_payout,c2pool_hashrate,c2pool_merged_mining>
     )
 
     include(GoogleTest)

--- a/src/sharechain/test/CMakeLists.txt
+++ b/src/sharechain/test/CMakeLists.txt
@@ -2,7 +2,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     add_executable(sharechain_test share_test.cpp)
     target_link_libraries(sharechain_test PRIVATE
         GTest::gtest_main GTest::gtest
-        $<LINK_GROUP:RESCAN,core,sharechain,pool,ltc,btclibs,c2pool_payout,c2pool_hashrate,c2pool_merged_mining>
+        $<LINK_GROUP:RESCAN,core,sharechain,pool,ltc,btclibs,ltc_coin,c2pool_storage,c2pool_payout,c2pool_hashrate,c2pool_merged_mining>
     )
 
     include(GoogleTest)

--- a/src/sharechain/test/CMakeLists.txt
+++ b/src/sharechain/test/CMakeLists.txt
@@ -2,7 +2,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     add_executable(sharechain_test share_test.cpp)
     target_link_libraries(sharechain_test PRIVATE
         GTest::gtest_main GTest::gtest
-        core sharechain
+        $<LINK_GROUP:RESCAN,core,sharechain,pool,ltc,btclibs,c2pool_payout,c2pool_hashrate,c2pool_merged_mining>
     )
 
     include(GoogleTest)


### PR DESCRIPTION
**STATUS — MERGED 2026-06-01 as `81cab0d5`.** Scope of this PR: CMake SCC break via leaf-hoist **plus 4 `src/core/` files** carrying the relocated `core::timestamp()` definition — `common.cpp` + `common.hpp` modified and new `core_util.cpp` + `core_util.hpp` (byte-identical symbol relocation, no semantic shift; dash UID-292 posture-check verdict GREEN). The earlier draft framing of this change as CI/CMake-only "no source touch" was scoped ONLY to the `$<LINK_GROUP:RESCAN,...>` test-link fixup cherry-picks `5174aeaa` + `507a98c9` (which are genuinely CMake-only) and did not describe the PR as a whole. Corrected here for audit-trail accuracy.

---

## SCC break: hoist `core::timestamp()` into dependency-free `core_util` leaf

Breaks the `core` link cycle by extracting the dependency-free `timestamp()` helper into a new `core_util` leaf library, then rewiring CMake so `core` links it.

### What landed
- `07165699` — leaf-hoist of `core::timestamp()` into new dependency-free `core_util` (ltc-doge, source half)
- `47ae9a96` — CMake wiring `add_library(core_util STATIC core_util.cpp)` + `target_link_libraries(core core_util btclibs)` PUBLIC (ci-steward, CMake half)
- `5174aeaa` — scope-trio RESCAN wrap of the shared test link graph (cherry-pick of `5edeb308`, re-signed)
- `507a98c9` — fixup enclosing the full SCC in the RESCAN group to fix the CMake generate step (cherry-pick of `d7cb8932`, re-signed)

### What was verified
- Tests-enabled build `BUILD_RC=0` — link cycle broken (this was the entire purpose)
- `core_test` 32 passing
- `sharechain_test` links + runs clean (exit 0)
- `share_test` (ltc) 1 passing (`LTC_share_test.Init`)
- `test_ltc_node` runs to `=== Test completed successfully ===` (exit 0)
- `test_doge_chain` 29 passing

### What was NOT verified (scope disclaimer)
- `coin-matrix.yml` four-coin smoke gate is **vacuously skipped** — per-coin `c2pool-<coin>` binaries / `main_<coin>.cpp` do not exist on this branch yet (Bucket-B per-coin split has not landed)
- Full bucket-wide ctest gate **deferred to post-Bucket-B**
- `ltc_coin_test` (SIGABRT) and `ltc_pool_test` (300s timeout) are **pre-existing environmental failures** — they require external litecoind RPC + a running pool server, and are **NOT regressions** from this PR

### Why this is independently valuable (V36 critical path)
- Unblocks ltc-doge A5 backport-diff (needs a clean build)
- Unblocks the PPLNS parity HARD GATE work (needs the full-test runtime validation path)
- Coupling this to Bucket-B (multi-day-to-week) purely to satisfy a vacuous matrix gate does not serve the V36 critical path

### Label
SAFE-REFACTOR — structural change spanning CMake target wiring AND a byte-identical core::timestamp() symbol relocation across 4 src/core/ files (common.{cpp,hpp} modified, core_util.{cpp,hpp} new); no behavior change to any binary.

### Review
- ltc-doge: please re-verify the leaf-hoist intent and that the CMake delta matches your handoff spec
- dash: cross-coin review — any test bucket you care about that may be affected

Comment-thread-as-review. Merge gates on operator `push approved` (integrator merges).
