### PR TITLE
build(cmake): RESCAN core <-> c2pool_merged_mining cycle for test binaries (mirrors 507a98c9 from #54)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,8 +2,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     add_executable(test_coin_broadcaster test_coin_broadcaster.cpp)
     target_link_libraries(test_coin_broadcaster PRIVATE
         GTest::gtest_main GTest::gtest
-        c2pool_merged_mining
-        core ltc
+        $<LINK_GROUP:RESCAN,core,sharechain,pool,ltc,btclibs,ltc_coin,c2pool_storage,c2pool_payout,c2pool_hashrate,c2pool_merged_mining>
         nlohmann_json::nlohmann_json
         ${Boost_LIBRARIES}
     )
@@ -45,8 +44,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     add_executable(test_phase0_live test_phase0_live.cpp)
     target_link_libraries(test_phase0_live PRIVATE
         GTest::gtest_main GTest::gtest
-        c2pool_merged_mining
-        core ltc
+        $<LINK_GROUP:RESCAN,core,sharechain,pool,ltc,btclibs,ltc_coin,c2pool_storage,c2pool_payout,c2pool_hashrate,c2pool_merged_mining>
         nlohmann_json::nlohmann_json
         ${Boost_LIBRARIES}
     )
@@ -62,8 +60,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     add_executable(test_phase1_live test_phase1_live.cpp)
     target_link_libraries(test_phase1_live PRIVATE
         GTest::gtest_main GTest::gtest
-        c2pool_merged_mining
-        core ltc
+        $<LINK_GROUP:RESCAN,core,sharechain,pool,ltc,btclibs,ltc_coin,c2pool_storage,c2pool_payout,c2pool_hashrate,c2pool_merged_mining>
         nlohmann_json::nlohmann_json
         ${Boost_LIBRARIES}
     )
@@ -79,8 +76,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     add_executable(test_phase2_live test_phase2_live.cpp)
     target_link_libraries(test_phase2_live PRIVATE
         GTest::gtest_main GTest::gtest
-        c2pool_merged_mining
-        core ltc
+        $<LINK_GROUP:RESCAN,core,sharechain,pool,ltc,btclibs,ltc_coin,c2pool_storage,c2pool_payout,c2pool_hashrate,c2pool_merged_mining>
         nlohmann_json::nlohmann_json
         ${Boost_LIBRARIES}
     )
@@ -96,8 +92,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     add_executable(test_phase3_live test_phase3_live.cpp)
     target_link_libraries(test_phase3_live PRIVATE
         GTest::gtest_main GTest::gtest
-        c2pool_merged_mining
-        core ltc
+        $<LINK_GROUP:RESCAN,core,sharechain,pool,ltc,btclibs,ltc_coin,c2pool_storage,c2pool_payout,c2pool_hashrate,c2pool_merged_mining>
         nlohmann_json::nlohmann_json
         ${Boost_LIBRARIES}
     )


### PR DESCRIPTION
## Summary

Wraps the `core` <-> `c2pool_merged_mining` static-library cycle in a `$<LINK_GROUP:RESCAN,...>` genex for five test binaries, mirroring the fix applied in commit `507a98c9` from PR #54.

This is a **pre-existing build-infrastructure gap**, surfaced during PR-Bug3 verification. It is **NOT introduced by Bug-3** — the same five binaries fail to link on a clean build of the Bug-3 branch and on master tip (`81cab0d5`) alike. PR-Bug3 will rebase on top of this once it merges.

## Affected binaries (5)

- `test_coin_broadcaster`
- `test_phase0_live`
- `test_phase1_live`
- `test_phase2_live`
- `test_phase3_live`

These reference symbols that pull the cycle edge at link time and fail with undefined references under the default static-archive ordering.

## SCC family parallel with #54

The `core` <-> `c2pool_merged_mining` cycle is the same strongly connected component resolved in #54 (`507a98c9`) for the `share_test` / `sharechain_test` / `test_ltc_node` targets. As that commit established, the **entire SCC** must be enclosed in the link group (`core, sharechain, pool, ltc, btclibs, ltc_coin, c2pool_storage, c2pool_payout, c2pool_hashrate, c2pool_merged_mining`) — enclosing only the minimal pair leaves a cycle edge crossing the group boundary, which fails the CMake *generate* step.

## Verification (Linux x86_64, conan-release)

- CMake generate: clean (no group-depends-on-group failure)
- Full build: exit 0; all five binaries link with **0 undefined references**
- Full `ctest`: **582/582 passed, 0 failed**
- LiveTest family (`Phase0/1/2/3LiveTest`) link successfully and run-time **skip** as before (no live daemon) — behavior unchanged; the goal here is link success.

## Notes

- Commit is GPG-signed.
- Three other binaries (`test_phase4_live`, `test_multiaddress_pplns`, `test_pplns_stress`) carry the identical link line but currently link successfully (archive-member pull is symbol-driven, not declaration-driven), so they are intentionally left out of scope per the ratified dispatch.