### PR TITLE
A5a: Bug-9 wire-input hardening backport (4 GPG-signed cherry-picks on 0c840a61)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,6 +106,109 @@ jobs:
         with: { name: test-results-linux, path: build_ci/Testing/, retention-days: 7 }
 
   # ════════════════════════════════════════════════════════════════════════════
+  # Linux AddressSanitizer + UBSan (informational, not gating yet)
+  #
+  # Builds c2pool + the full test suite with -fsanitize=address,undefined and
+  # runs ctest under ASAN/UBSAN_OPTIONS. Catches use-after-free, heap overflow,
+  # uninitialized read, integer overflow, etc. at PR time instead of via 12-h
+  # soaks. Conan deps stay un-sanitized (static libs); libasan still intercepts
+  # all allocations including those from deps, so UAFs that touch our code are
+  # caught.
+  #
+  # Currently `continue-on-error: true` so reports are visible without blocking
+  # merges while we work through the audit (Phase 1 of the socket-lifecycle
+  # fundamental fix; see frstrtr/the/docs/c2pool-socket-lifecycle-fundamental-fix.md).
+  # Will flip to required once known UAFs are fixed (Phase 7).
+  # ════════════════════════════════════════════════════════════════════════════
+  linux-asan:
+    name: Linux x86_64 (AsAN+UBSan)
+    runs-on: ubuntu-24.04
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            g++ cmake make libleveldb-dev libsecp256k1-dev
+
+      - uses: actions/setup-python@v6
+        with: { python-version: '3.12' }
+
+      - name: Install Conan 2
+        run: pip install "conan>=2.0,<3.0"
+
+      - name: Detect Conan profile
+        run: |
+          conan profile detect --force
+          sed -i 's/compiler.cppstd=.*/compiler.cppstd=20/' "$(conan profile path default)"
+
+      - name: Restore Conan cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.conan2
+          key: conan2-ubuntu24-gcc13-${{ hashFiles('conanfile.txt') }}
+
+      - name: Conan install
+        run: conan install . --build=missing --output-folder=build_asan --settings=build_type=Release
+
+      - name: Configure (Release + AsAN + UBSan)
+        # NOTE 1: must match the build_type passed to `conan install` (Release).
+        # Conan generates `*-Target-release.cmake` with INTERFACE_INCLUDE_DIRECTORIES
+        # wrapped in $<$<CONFIG:Release>:...>, so a mismatched cmake build type
+        # (e.g. RelWithDebInfo) silently drops every conan dep's include path.
+        # We get full optimization + debug symbols via -g in CXX_FLAGS.
+        #
+        # NOTE 2: -fno-sanitize=vptr disables the UBSan vptr check, which would
+        # require leveldb (and other foreign polymorphic types) to expose their
+        # typeinfo. leveldb is built without that, causing "undefined reference
+        # to typeinfo for leveldb::DB" link errors. All other UBSan checks
+        # remain on.
+        run: |
+          cmake -S . -B build_asan \
+            -DCMAKE_TOOLCHAIN_FILE=build_asan/conan_toolchain.cmake \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-sanitize=vptr -fno-omit-frame-pointer -fno-sanitize-recover=undefined -g" \
+            -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined -fno-sanitize=vptr" \
+            -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=address,undefined -fno-sanitize=vptr"
+
+      - name: Build c2pool + tests
+        run: |
+          cmake --build build_asan \
+            --target c2pool \
+                    test_hardening test_share_messages \
+                    test_redistribute_address test_redistribute test_auto_ratchet \
+                    test_stratum_extensions \
+                    core_test sharechain_test share_test \
+                    test_threading test_weights \
+                    test_header_chain test_mempool test_template_builder \
+                    test_doge_chain test_compact_blocks \
+                    test_hash_link test_decay_pplns \
+                    test_pplns_consensus \
+                    test_v36_script_sorting test_v36_cross_impl_refhash \
+                    test_phase4_embedded \
+                    test_mweb_builder \
+                    test_address_resolution test_compute_share_target \
+                    test_utxo \
+                    test_dash_credit_pool test_dash_subsidy test_dash_battletest_regressions \
+                    test_dash_pay_attribution \
+                    test_coin_broadcaster test_multiaddress_pplns test_pplns_stress \
+            -j$(nproc)
+
+      - name: Run tests under sanitizers
+        working-directory: build_asan
+        env:
+          ASAN_OPTIONS: detect_leaks=0:check_initialization_order=1:strict_string_checks=1:abort_on_error=0
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=0
+        run: ctest --output-on-failure -j$(nproc) --exclude-regex "LiveTest\."
+
+      - name: Upload sanitizer test results on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with: { name: test-results-linux-asan, path: build_asan/Testing/, retention-days: 7 }
+
+  # ════════════════════════════════════════════════════════════════════════════
   # Web-static JS verify (typecheck + build + tests + bundle-size gate)
   # Covers web-static/sharechain-explorer/: the Explorer + PPLNS View
   # bundles + Plugin SDK. Fast job (< 1 min); runs regardless of path so

--- a/src/core/socket.cpp
+++ b/src/core/socket.cpp
@@ -1,38 +1,142 @@
 #include "socket.hpp"
+#include "factory.hpp"   // INetwork complete definition for weak_ptr<INetwork>::lock()
 #include "log.hpp"
 #include <btclibs/util/strencodings.h>
 
 namespace core
 {
 
+Socket::Socket(std::unique_ptr<boost::asio::ip::tcp::socket> socket,
+               connection_type conn_type,
+               ICommunicator* communicator,
+               std::weak_ptr<INetwork> node_lifetime,
+               bool was_managed)
+    : m_socket(std::move(socket))
+    , m_conn_type(conn_type)
+    , m_node(communicator)
+    , m_node_lifetime(std::move(node_lifetime))
+    , m_was_managed(was_managed)
+    , m_status(true)
+{
+}
+
+bool Socket::acquire_node(std::shared_ptr<INetwork>& strong_out)
+{
+    strong_out = m_node_lifetime.lock();
+    if (!m_was_managed) {
+        // Unmanaged legacy node (LTC/DOGE pool pre-make_shared): no liveness
+        // tracking available, fall back to raw m_node behavior. Returns true
+        // unconditionally so the existing call path is preserved.
+        return true;
+    }
+    // Managed node (Dash NodeP2P after c42d0f5c). lock() returning null
+    // means the node has been freed mid-flight — abort the connection.
+    return strong_out != nullptr;
+}
+
+void Socket::abort_connection()
+{
+    m_status = false;
+    if (m_socket && m_socket->is_open()) {
+        boost::system::error_code ec;
+        m_socket->close(ec);
+    }
+}
+
+// ASYNC_READ: every async-read callback locks the node lifetime at entry. If
+// the node was managed and is now freed, the connection aborts cleanly without
+// dereferencing m_node — preventing the Bug 9 / Bug-3-family UAF class.
+//
+// `strong_node` is in scope for the user-supplied `handler` and keeps the
+// node alive for that scope's duration; m_node access inside the handler is
+// safe.
 #define ASYNC_READ(buffer, handler)\
     if (!m_status || !m_socket || !m_socket->is_open()) return;\
     boost::asio::async_read(*m_socket, buffer, [self = shared_from_this(), this, packet](const auto& ec, std::size_t len) {\
         if (!m_status) return; /* socket closed between dispatch and callback */\
         if (!ec) g_bytes_recv.fetch_add(len, std::memory_order_relaxed);\
+        std::shared_ptr<INetwork> strong_node;\
+        if (!acquire_node(strong_node)) {\
+            LOG_DEBUG_OTHER << "Socket: aborting connection (node freed mid-flight)";\
+            abort_connection();\
+            return;\
+        }\
+        (void)strong_node; /* keeps node alive for handler scope */\
         handler\
     })
 
+void Socket::init()
+{
+    // init addrs — guard against socket being closed before init() dispatched
+    boost::system::error_code ec;
+    auto ep_local  = m_socket->local_endpoint(ec);
+    if (ec) { m_status = false; m_socket->close(); return; }
+    auto ep_remote = m_socket->remote_endpoint(ec);
+    if (ec) { m_status = false; m_socket->close(); return; }
+    m_addr_local = NetService(ep_local);
+    m_addr       = NetService(ep_remote);
+
+    // start for reading socket data
+    read();
+}
+
+void Socket::read()
+{
+    // Acquire the node before touching m_node->get_prefix() — without this,
+    // a freed m_node returns garbage from get_prefix().size() and the Packet
+    // ctor's prefix.resize() throws std::length_error (the original Bug 9
+    // symptom). The Packet ctor's 16-byte cap from 0f91b499 stays as
+    // belt-and-braces defense-in-depth.
+    std::shared_ptr<INetwork> strong_node;
+    if (!acquire_node(strong_node)) {
+        LOG_DEBUG_OTHER << "Socket::read: aborting connection (node freed mid-flight)";
+        abort_connection();
+        return;
+    }
+    (void)strong_node;
+
+    std::shared_ptr<Packet> packet;
+    try {
+        packet = std::make_shared<Packet>(m_node->get_prefix().size());
+    } catch (const std::exception& e) {
+        LOG_WARNING << "Socket::read: aborting connection (" << e.what() << ")";
+        abort_connection();
+        return;
+    }
+    read_prefix(packet);
+}
+
+void Socket::write(std::unique_ptr<RawMessage> msg_data)
+{
+    if (!m_status || !m_socket || !m_socket->is_open()) return;  // closed/disconnected
+
+    // Acquire the node so get_prefix() and the error() callback don't UAF.
+    std::shared_ptr<INetwork> strong_node;
+    if (!acquire_node(strong_node)) {
+        LOG_DEBUG_OTHER << "Socket::write: aborting (node freed mid-flight)";
+        abort_connection();
+        return;
+    }
+
+    auto packet = std::make_shared<PackStream>(Packet::from_message(m_node->get_prefix(), msg_data));
+    boost::asio::async_write(*m_socket, boost::asio::buffer(packet->data(), packet->size()),
+        [self = shared_from_this(), this, packet](const boost::system::error_code& ec, std::size_t length)
+        {
+            if (!ec) g_bytes_sent.fetch_add(length, std::memory_order_relaxed);
+            if (ec) {
+                std::shared_ptr<INetwork> strong;
+                if (!acquire_node(strong)) {
+                    abort_connection();
+                    return;
+                }
+                m_node->error("Socket::write error: " + ec.message(), get_addr());
+            }
+        }
+    );
+}
+
 void Socket::read_prefix(std::shared_ptr<Packet> packet)
 {
-    // if (!m_status) return;
-    // // auto ptr = shared_from_this();
-    // boost::asio::async_read(*m_socket, boost::asio::buffer(&packet->prefix[0], packet->prefix.size()),
-    //     [this/*, ptr = ptr*/, packet](const auto& ec, std::size_t len)
-    //     {
-    //         if (ec)
-    //         {
-    //             m_node->error(ec, get_addr());
-    //             return;
-    //         }
-
-    //         if (packet->prefix == m_node->get_prefix())
-    //             read_command(packet);
-    //         else
-    //             m_node->error("prefix doesn't match", get_addr());
-    //     }
-    // );
-
     ASYNC_READ(boost::asio::buffer(&packet->prefix[0], packet->prefix.size()),
         {
             if (ec)
@@ -130,14 +234,14 @@ void Socket::read_payload(std::shared_ptr<Packet> packet)
 
 void Socket::message_processing(std::shared_ptr<Packet> packet)
 {
-    // checksum 
+    // checksum
     uint256 hash_checksum = Hash(std::span<std::byte>(packet->payload.data(), packet->payload.size()));
     if (hash_checksum.pn[0] != packet->checksum)
     {
         m_node->error("Socket::message_processing missmatch checksum!", get_addr());
         return;
     }
-    
+
     auto msg = packet->to_message();
     m_node->handle(std::move(msg), m_addr);
 }

--- a/src/core/socket.cpp
+++ b/src/core/socket.cpp
@@ -75,7 +75,19 @@ void Socket::read_length(std::shared_ptr<Packet> packet)
                 m_node->error(ec, get_addr());
                 return;
             }
-            // std::cout << "message_length: " << packet->message_length << std::endl;
+            // DoS cap: a malicious or corrupt peer can send a huge length here
+            // and crash us with std::bad_alloc / std::length_error from the
+            // payload resize. Bitcoin Core uses MAX_PROTOCOL_MESSAGE_LENGTH=4MiB;
+            // we use 32MiB to accommodate Dash's larger mnlistdiff messages with
+            // headroom. Disconnect cleanly on cap exceedance.
+            constexpr uint32_t MAX_MESSAGE_LENGTH = 32u * 1024u * 1024u;
+            if (packet->message_length > MAX_MESSAGE_LENGTH)
+            {
+                m_node->error("message_length " + std::to_string(packet->message_length)
+                              + " exceeds cap " + std::to_string(MAX_MESSAGE_LENGTH),
+                              get_addr());
+                return;
+            }
             packet->payload.resize(packet->message_length);
             read_checksum(packet);
         }

--- a/src/core/socket.hpp
+++ b/src/core/socket.hpp
@@ -7,6 +7,7 @@
 
 #include <boost/asio.hpp>
 
+#include <core/log.hpp>
 #include <core/pack.hpp>
 #include <core/pack_types.hpp>
 #include <core/message.hpp>
@@ -54,8 +55,23 @@ public:
 private:
     void read()
     {
-        auto packet = std::make_shared<Packet>(m_node->get_prefix().size());
-		read_prefix(packet);
+        // Bug 9 hardening: Packet ctor caps prefix_length to defend against
+        // a UAF on m_node where get_prefix().size() returns garbage. If the
+        // cap fires, just close the socket cleanly instead of letting the
+        // exception escape to ioc.run() and kill the process.
+        std::shared_ptr<Packet> packet;
+        try {
+            packet = std::make_shared<Packet>(m_node->get_prefix().size());
+        } catch (const std::exception& e) {
+            LOG_WARNING << "Socket::read: aborting connection (" << e.what() << ")";
+            m_status = false;
+            if (m_socket && m_socket->is_open()) {
+                boost::system::error_code ec;
+                m_socket->close(ec);
+            }
+            return;
+        }
+        read_prefix(packet);
     }
 
     void read_prefix(std::shared_ptr<Packet> packet);

--- a/src/core/socket.hpp
+++ b/src/core/socket.hpp
@@ -3,6 +3,7 @@
 #include <map>
 #include <vector>
 #include <string>
+#include <memory>
 #include <source_location>
 
 #include <boost/asio.hpp>
@@ -18,6 +19,11 @@
 
 namespace core
 {
+
+// Forward-declared to avoid circular include with factory.hpp (which includes
+// socket.hpp). Socket needs INetwork only for weak_ptr<INetwork> liveness
+// tracking; full definition is needed in socket.cpp via factory.hpp.
+struct INetwork;
 
 enum connection_type
 {
@@ -41,7 +47,27 @@ class Socket : public std::enable_shared_from_this<Socket>
 {
     std::unique_ptr<boost::asio::ip::tcp::socket> m_socket;
     connection_type m_conn_type {unknown};
-    ICommunicator* m_node {nullptr};
+
+    // Node lifetime tracking — fundamental fix for the Bug 9 / Bug-3-family
+    // UAF class (see frstrtr/the/docs/c2pool-socket-lifecycle-fundamental-fix.md).
+    //
+    // m_node is the raw ICommunicator* used for fast access in async callbacks.
+    // m_node_lifetime is a weak_ptr to the same object's INetwork interface,
+    // which tracks the underlying lifetime via enable_shared_from_this. At
+    // every async-callback entry, we lock m_node_lifetime; if the node has
+    // been freed mid-flight (returns null AND was_managed is true), we abort
+    // the connection cleanly instead of dereferencing m_node and crashing.
+    //
+    // m_was_managed records whether the node was shared_ptr-managed at
+    // construction time. For unmanaged nodes (legacy LTC/DOGE pool pattern,
+    // not migrated to make_shared yet), weak_ptr.lock() always returns null
+    // but was_managed is false, so the lock-or-bail check is skipped and
+    // behavior matches the pre-fix raw-pointer code. This keeps LTC mainnet
+    // pool unchanged while the Dash side gets the fix.
+    ICommunicator*           m_node {nullptr};
+    std::weak_ptr<INetwork>  m_node_lifetime;
+    bool                     m_was_managed {false};
+
     bool m_status; // connected/disconnected
 
     NetService m_addr;
@@ -53,26 +79,20 @@ public:
     static inline std::atomic<uint64_t> g_bytes_sent{0};
 
 private:
-    void read()
-    {
-        // Bug 9 hardening: Packet ctor caps prefix_length to defend against
-        // a UAF on m_node where get_prefix().size() returns garbage. If the
-        // cap fires, just close the socket cleanly instead of letting the
-        // exception escape to ioc.run() and kill the process.
-        std::shared_ptr<Packet> packet;
-        try {
-            packet = std::make_shared<Packet>(m_node->get_prefix().size());
-        } catch (const std::exception& e) {
-            LOG_WARNING << "Socket::read: aborting connection (" << e.what() << ")";
-            m_status = false;
-            if (m_socket && m_socket->is_open()) {
-                boost::system::error_code ec;
-                m_socket->close(ec);
-            }
-            return;
-        }
-        read_prefix(packet);
-    }
+    // Lock the node lifetime. Returns true if it's safe to use m_node:
+    //   - was_managed=false (unmanaged legacy node) → always returns true
+    //   - was_managed=true and lock succeeded → returns true; strong_out
+    //     keeps the node alive for the duration of the caller's scope
+    //   - was_managed=true and lock returned null → returns false; the node
+    //     has been freed mid-flight, the connection should abort
+    // Defined out-of-line in socket.cpp where INetwork is complete.
+    bool acquire_node(std::shared_ptr<INetwork>& strong_out);
+
+    // Cleanly abort the connection without dereferencing m_node (used when
+    // acquire_node fails). Also called from the Bug 9 Packet-cap path.
+    void abort_connection();
+
+    void read();   // moved out-of-line; needs INetwork complete via acquire_node
 
     void read_prefix(std::shared_ptr<Packet> packet);
 	void read_command(std::shared_ptr<Packet> packet);
@@ -81,24 +101,16 @@ private:
 	void read_payload(std::shared_ptr<Packet> packet);
 	void message_processing(std::shared_ptr<Packet> packet);
 
-public:    
-    Socket(std::unique_ptr<boost::asio::ip::tcp::socket> socket, connection_type conn_type, ICommunicator* node) : m_socket(std::move(socket)), m_conn_type(conn_type), m_node(node), m_status(true)
-    {
-    }
+public:
+    // Defined out-of-line in socket.cpp; needs INetwork complete to construct
+    // the weak_ptr from a shared_ptr<INetwork>.
+    Socket(std::unique_ptr<boost::asio::ip::tcp::socket> socket,
+           connection_type conn_type,
+           ICommunicator* communicator,
+           std::weak_ptr<INetwork> node_lifetime,
+           bool was_managed);
 
-    void init()
-    {
-        // init addrs — guard against socket being closed before init() dispatched
-        boost::system::error_code ec;
-        auto ep_local  = m_socket->local_endpoint(ec);
-        auto ep_remote = m_socket->remote_endpoint(ec);
-        if (ec) { m_status = false; m_socket->close(); return; }
-        m_addr_local = NetService(ep_local);
-        m_addr       = NetService(ep_remote);
-
-        // start for reading socket data
-        read();
-    }
+    void init();   // out-of-line; calls read() which needs acquire_node
 
     connection_type type()
     {
@@ -137,30 +149,34 @@ public:
     }
     //=====================
 
-    void write(std::unique_ptr<RawMessage> msg_data)
-    {
-        if (!m_status || !m_socket || !m_socket->is_open()) return;  // closed/disconnected
-        auto packet = std::make_shared<PackStream>(Packet::from_message(m_node->get_prefix(), msg_data));
-        boost::asio::async_write(*m_socket, boost::asio::buffer(packet->data(), packet->size()),
-            [self = shared_from_this(), this, packet](const boost::system::error_code& ec, std::size_t length)
-            {
-                if (!ec) g_bytes_sent.fetch_add(length, std::memory_order_relaxed);
-                if (ec)
-                {
-                    m_node->error("Socket::write error: " + ec.message(), get_addr());
-                }
-            }
-        );
-    }
+    void write(std::unique_ptr<RawMessage> msg_data);  // out-of-line; uses acquire_node
 };
 
+// Construct a Socket. Computes the weak_ptr<INetwork> liveness tracker from
+// the node's shared_from_this() if it's shared_ptr-managed (modern Dash node
+// pattern after c42d0f5c), or stores an empty weak_ptr + was_managed=false
+// for legacy unmanaged nodes (LTC/DOGE pool today).
+//
+// Defined inline as a template so the caller's full INetwork type is
+// available for the dynamic_cast + weak_from_this() call.
 template <typename CommunicatorNode>
-std::shared_ptr<core::Socket> make_socket(std::unique_ptr<boost::asio::ip::tcp::socket> tcp_socket, core::connection_type type, CommunicatorNode* node)
+std::shared_ptr<core::Socket> make_socket(
+    std::unique_ptr<boost::asio::ip::tcp::socket> tcp_socket,
+    core::connection_type type,
+    CommunicatorNode* node)
 {
-	auto communicator = dynamic_cast<core::ICommunicator*>(node);
-	assert(communicator && "INetwork can't be cast to ICommunicator!");
-	auto socket = std::make_shared<core::Socket>(std::move(tcp_socket), type, communicator);
-    return socket;
+    auto communicator = dynamic_cast<core::ICommunicator*>(node);
+    assert(communicator && "node can't be cast to ICommunicator!");
+    auto network = dynamic_cast<core::INetwork*>(node);
+    std::weak_ptr<core::INetwork> weak_node;
+    bool was_managed = false;
+    if (network) {
+        weak_node = network->weak_from_this();
+        was_managed = (weak_node.lock() != nullptr);
+    }
+    return std::make_shared<core::Socket>(
+        std::move(tcp_socket), type, communicator,
+        std::move(weak_node), was_managed);
 }
 
 } // namespace core

--- a/src/core/timer.hpp
+++ b/src/core/timer.hpp
@@ -25,8 +25,16 @@ private:
     {
         if (*m_destroyed) return;
         m_timer.expires_after(boost::asio::chrono::seconds(m_t));
+        // Bug-3-family UAF fix (paired with the Socket::m_node weak_ptr fix
+        // c558fe92): m_handler() and m_cancel() are user callbacks that can
+        // synchronously destroy *this (e.g. reply_matcher.hpp:92 erases the
+        // ResponseWrapper that owns this Timer). The lambda's `[&]` capture
+        // makes any post-callback this-relative access (m_repeat, m_cancel,
+        // restart()) a use-after-free. Capture m_repeat by value and re-check
+        // *destroyed before touching anything on this after each user callback.
         m_timer.async_wait(
-            [&, destroyed = m_destroyed](const boost::system::error_code& ec)
+            [&, destroyed = m_destroyed, repeat = m_repeat]
+            (const boost::system::error_code& ec)
             {
                 if (*destroyed)
                     return;
@@ -34,12 +42,17 @@ private:
                 if (!ec)
                 {
                     m_handler();
-                    if (m_repeat && !*destroyed)
+                    // m_handler() may have destroyed *this — re-check before
+                    // any this-relative access.
+                    if (*destroyed) return;
+                    if (repeat)
                         restart();
                 } else
                 {
-                    if (m_cancel && !*destroyed)
+                    if (m_cancel)
                         m_cancel();
+                    // m_cancel() may also destroy *this; nothing else to do
+                    // afterward, but documenting the invariant for future devs.
                 }
             }
         );


### PR DESCRIPTION
## A5a — Bug-9 wire-input hardening backport (LTC + DOGE production perspective)

Backports the 4-commit Bug-9 fix set onto current master (`0c840a61`, post PR #56 Bug-3 merge). All commits GPG-signed.

### Commits
- `4705a278` Bug 9 fix: cap unguarded vector `resize()` inputs from wire
- `1a525137` Bug 9 root cause: cap `Packet` prefix_length + catch in `Socket::read()`
- `47b8c2b5` Bug 9 fundamental fix: `Socket::m_node` weak_ptr<INetwork> (lifetime) + ASan CI
- `5df3bb9d` Bug 9 follow-up: fix `Timer` UAF surfaced by ASan

### Rationale
Hardens deserialization against malformed/hostile wire input: bounds unguarded resize/prefix-length reads, and fixes two use-after-free lifetimes (`Socket::m_node`, `Timer`) under the same network path. Runtime-behavior-preserving for well-formed peers; rejects malformed frames cleanly instead of over-allocating or touching freed memory.

### Verification
- Rebase current: merge-base == master tip `0c840a61`, no conflicts.
- Linux x86_64 conan-release ctest: **582/582 passed, 0 failed** (35.4s).
- All 4 commits GPG-signed, good signatures.
- ASan overlay pass queued as optional follow-up.

Review-only from this side; merge is operator/integrator-gated.
