### PR TITLE
Phase 5.8 M3: structured AuxPoW header parser (parse_aux_header)

### DIFF
--- a/src/impl/doge/coin/auxpow.hpp
+++ b/src/impl/doge/coin/auxpow.hpp
@@ -52,7 +52,17 @@ struct CMerkleLink
     std::vector<uint256> m_branch;
     uint32_t             m_index{0};
 
-    SERIALIZE_METHODS(CMerkleLink) { READWRITE(obj.m_branch, obj.m_index); }
+    // Hand-written to stay independent of which SERIALIZE_METHODS macro is
+    // active in the TU: core/pack.hpp defines a 1-arg form, btclibs/serialize.h
+    // a 2-arg one, and CMerkleTx::m_tx pulls btclibs into this header's TUs.
+    template <typename Stream> void Serialize(Stream& s) const {
+        ::Serialize(s, m_branch);
+        ::Serialize(s, m_index);
+    }
+    template <typename Stream> void Unserialize(Stream& s) {
+        ::Unserialize(s, m_branch);
+        ::Unserialize(s, m_index);
+    }
 
     void SetNull() { m_branch.clear(); m_index = 0; }
     bool IsNull() const { return m_branch.empty() && m_index == 0; }
@@ -68,9 +78,16 @@ struct CMerkleTx
     uint256                       m_block_hash;
     CMerkleLink                   m_merkle_link;
 
-    SERIALIZE_METHODS(CMerkleTx) {
-        // tx_id_type == witness-stripped tx serialization (data.py:232)
-        READWRITE(TX_NO_WITNESS(obj.m_tx), obj.m_block_hash, obj.m_merkle_link);
+    // tx_id_type == witness-stripped tx serialization (data.py:232).
+    template <typename Stream> void Serialize(Stream& s) const {
+        ::Serialize(s, bitcoin_family::coin::TX_NO_WITNESS(m_tx));
+        ::Serialize(s, m_block_hash);
+        ::Serialize(s, m_merkle_link);
+    }
+    template <typename Stream> void Unserialize(Stream& s) {
+        ::Unserialize(s, bitcoin_family::coin::TX_NO_WITNESS(m_tx));
+        ::Unserialize(s, m_block_hash);
+        ::Unserialize(s, m_merkle_link);
     }
 
     void SetNull() {
@@ -90,8 +107,15 @@ struct CAuxPow
     CMerkleLink      m_chain_merkle_link;    // aux/chain merkle branch + slot index
     CPureBlockHeader m_parent_block_header;  // parent (LTC) 80-byte header
 
-    SERIALIZE_METHODS(CAuxPow) {
-        READWRITE(obj.m_merkle_tx, obj.m_chain_merkle_link, obj.m_parent_block_header);
+    template <typename Stream> void Serialize(Stream& s) const {
+        ::Serialize(s, m_merkle_tx);
+        ::Serialize(s, m_chain_merkle_link);
+        ::Serialize(s, m_parent_block_header);
+    }
+    template <typename Stream> void Unserialize(Stream& s) {
+        ::Unserialize(s, m_merkle_tx);
+        ::Unserialize(s, m_chain_merkle_link);
+        ::Unserialize(s, m_parent_block_header);
     }
 
     void SetNull() {
@@ -113,10 +137,26 @@ inline bool is_auxpow_version(int32_t version) { return (version & 0x100) != 0; 
 
 /// M3: structured parse of a (possibly AuxPoW-extended) DOGE header from `s`.
 ///   - reads CPureBlockHeader (80B)
-///   - if is_auxpow_version(version): reads CAuxPow into `out_aux`, sets has_aux
-/// Supersedes the skip-only parser in auxpow_header.hpp. Declared here; M3 impl.
+///   - if is_auxpow_version(version): deserializes CAuxPow into `out_aux`, has_aux=true
+///   - else: clears `out_aux`, has_aux=false
+/// Supersedes the byte-skip parser in auxpow_header.hpp: the AuxPoW proof is now
+/// deserialized into the CAuxPow/CMerkleTx/CMerkleLink hierarchy via the standard
+/// pack.hpp surface, not merely skipped. The 80-byte base header is what
+/// HeaderChain consumes; `out_aux` carries the proof for validation
+/// (CAuxPow::check_proof, future milestone). Throws on truncation/parse failure.
 template <typename Stream>
-CPureBlockHeader parse_aux_header(Stream& s, CAuxPow& out_aux, bool& has_aux);
+CPureBlockHeader parse_aux_header(Stream& s, CAuxPow& out_aux, bool& has_aux)
+{
+    CPureBlockHeader hdr;
+    ::Unserialize(s, hdr);                                  // 80-byte base header
+    has_aux = is_auxpow_version(static_cast<int32_t>(hdr.m_version));
+    if (has_aux) {
+        ::Unserialize(s, out_aux);                          // structured CAuxPow proof
+    } else {
+        out_aux.SetNull();
+    }
+    return hdr;
+}
 
 } // namespace coin
 } // namespace doge

--- a/src/impl/doge/coin/auxpow_header.hpp
+++ b/src/impl/doge/coin/auxpow_header.hpp
@@ -1,228 +1,105 @@
 #pragma once
 
-/// DOGE AuxPoW Header Parser — Phase 5.8
+/// DOGE AuxPoW Header Parser — Phase 5.8 (M3: structured parser)
 ///
 /// Dogecoin blocks after AuxPoW activation (height 371,337 mainnet, 0 testnet4alpha)
-/// have EXTENDED headers in P2P messages:
+/// carry EXTENDED headers in P2P messages:
 ///
 ///   CPureBlockHeader (80 bytes)   — standard Bitcoin header
-///   + CAuxPow (variable)          — merge-mining proof (if IsAuxpow())
-///   + tx_count (varint)           — always 0 in 'headers' message
+///   + CAuxPow (variable)          — merge-mining proof (present iff IsAuxpow())
+///   + tx_count (CompactSize)      — 0 in a 'headers' message
 ///
-/// CAuxPow = CMerkleTx + vChainMerkleBranch + nChainIndex + parentBlock(80B)
-/// CMerkleTx = CTransaction(variable) + hashBlock(32B) + vMerkleBranch + nIndex(4B)
+/// M3 replaces the byte-skip parser with a STRUCTURED parse: the AuxPoW proof is
+/// deserialized into the CAuxPow / CMerkleTx / CMerkleLink types declared in
+/// auxpow.hpp (Phase 5.8 M2) through the standard pack.hpp serialization surface,
+/// rather than merely advancing the stream cursor past it. The 80-byte base
+/// header is still what HeaderChain consumes; the populated CAuxPow is now
+/// available for proof validation (CAuxPow::check_proof, future milestone).
 ///
-/// We only need the 80-byte base header for HeaderChain validation.
-/// This parser reads and SKIPS the AuxPoW data to advance the stream.
+/// The structured single-header primitive is doge::coin::parse_aux_header
+/// (defined in auxpow.hpp). This file provides the P2P message-level glue:
+///   - parse_doge_header          — legacy pos/end shim (one extended header)
+///   - parse_doge_headers_message — a 'headers' batch (CompactSize count + N)
+///   - parse_doge_block           — a full block (header + AuxPoW + tx list)
 
+#include <impl/doge/coin/auxpow.hpp>
 #include <impl/ltc/coin/block.hpp>
 #include <core/pack.hpp>
 
+#include <algorithm>
 #include <cstdint>
-#include <vector>
 #include <span>
+#include <vector>
 
 namespace doge {
 namespace coin {
 
 using ltc::coin::BlockHeaderType;
 
-/// Check if a block version indicates AuxPoW (version bit 0x100 set).
-/// Matches dogecoin/src/primitives/pureheader.h CPureBlockHeader::IsAuxpow()
-inline bool is_auxpow_version(int32_t version) {
-    return (version & 0x100) != 0;
-}
+// is_auxpow_version() and parse_aux_header() are provided by auxpow.hpp.
 
-/// Parse a DOGE extended header from a byte stream.
-/// Extracts the 80-byte base header and skips AuxPoW data if present.
+/// Parse one DOGE extended header from a raw byte range, advancing `pos`.
 ///
-/// Returns the base header, or throws on parse failure.
-/// The stream position advances past the full extended header.
-///
-/// Wire format:
-///   [base_header: 80B]
-///   [if IsAuxpow(version):]
-///     [coinbase_tx: CTransaction — variable]
-///     [hashBlock: 32B]
-///     [vMerkleBranch: varint_count + N*32B]
-///     [nIndex: 4B]
-///     [vChainMerkleBranch: varint_count + N*32B]
-///     [nChainIndex: 4B]
-///     [parentBlock: 80B — CPureBlockHeader]
-///   [tx_count: varint — always 0 in headers message]
+/// Structured parse: reads the 80-byte base header, deserializes the AuxPoW
+/// proof into a CAuxPow when IsAuxpow(version) is set, then consumes the
+/// trailing tx_count (CompactSize, always 0 in a 'headers' message).
+/// Returns the base header; `pos` is advanced past the full extended header.
+/// Throws on truncation/parse failure.
 inline BlockHeaderType parse_doge_header(const uint8_t*& pos, const uint8_t* end)
 {
-    // Need at least 80 bytes for base header
     if (end - pos < 80)
         throw std::runtime_error("DOGE header: not enough data for base header");
 
-    // Parse 80-byte base header
-    BlockHeaderType hdr;
-    {
-        PackStream ps(std::span<const std::byte>(
-            reinterpret_cast<const std::byte*>(pos), 80));
-        ps >> hdr;
-    }
-    pos += 80;
+    PackStream ps(std::span<const std::byte>(
+        reinterpret_cast<const std::byte*>(pos),
+        static_cast<size_t>(end - pos)));
+    const size_t avail = ps.cursor_size();
 
-    // If AuxPoW version, skip the AuxPoW proof data
-    if (is_auxpow_version(hdr.m_version)) {
-        // Skip CMerkleTx: CTransaction + hashBlock + vMerkleBranch + nIndex
+    CAuxPow aux;
+    bool has_aux = false;
+    BlockHeaderType hdr = parse_aux_header(ps, aux, has_aux);
 
-        // 1. Skip CTransaction (variable length)
-        //    Format: version(4) + [marker(1) + flag(1) if segwit] +
-        //            vin_count(varint) + vins + vout_count(varint) + vouts +
-        //            [witness data if segwit] + locktime(4)
-        {
-            if (end - pos < 4) throw std::runtime_error("DOGE auxpow: truncated tx version");
-            // TX version
-            pos += 4;
-            // Check for segwit marker (0x00 0x01)
-            bool is_segwit = false;
-            if (end - pos >= 2 && pos[0] == 0x00 && pos[1] != 0x00) {
-                is_segwit = true;
-                pos += 2; // skip marker + flag
-            }
-            // Read vin_count
-            auto read_varint = [&]() -> uint64_t {
-                if (pos >= end) throw std::runtime_error("DOGE auxpow: truncated varint");
-                uint8_t first = *pos++;
-                if (first < 0xfd) return first;
-                if (first == 0xfd) {
-                    if (end - pos < 2) throw std::runtime_error("truncated varint16");
-                    uint16_t v = pos[0] | (pos[1] << 8); pos += 2; return v;
-                }
-                if (first == 0xfe) {
-                    if (end - pos < 4) throw std::runtime_error("truncated varint32");
-                    uint32_t v = pos[0] | (pos[1]<<8) | (pos[2]<<16) | (pos[3]<<24);
-                    pos += 4; return v;
-                }
-                // 0xff
-                if (end - pos < 8) throw std::runtime_error("truncated varint64");
-                uint64_t v = 0;
-                for (int i = 0; i < 8; i++) v |= (uint64_t(pos[i]) << (i*8));
-                pos += 8; return v;
-            };
+    // tx_count (CompactSize) — always 0 in a 'headers' message.
+    if (ps.cursor_size() > 0)
+        (void)ReadCompactSize(ps);
 
-            // Skip vins
-            uint64_t vin_count = read_varint();
-            for (uint64_t i = 0; i < vin_count; i++) {
-                if (end - pos < 36) throw std::runtime_error("truncated vin");
-                pos += 32; // prev_hash
-                pos += 4;  // prev_index
-                uint64_t script_len = read_varint();
-                if (end - pos < static_cast<ptrdiff_t>(script_len)) throw std::runtime_error("truncated vin script");
-                pos += script_len;
-                if (end - pos < 4) throw std::runtime_error("truncated vin sequence");
-                pos += 4; // sequence
-            }
-            // Skip vouts
-            uint64_t vout_count = read_varint();
-            for (uint64_t i = 0; i < vout_count; i++) {
-                if (end - pos < 8) throw std::runtime_error("truncated vout value");
-                pos += 8; // value
-                uint64_t script_len = read_varint();
-                if (end - pos < static_cast<ptrdiff_t>(script_len)) throw std::runtime_error("truncated vout script");
-                pos += script_len;
-            }
-            // Skip witness data if segwit
-            if (is_segwit) {
-                for (uint64_t i = 0; i < vin_count; i++) {
-                    uint64_t stack_items = read_varint();
-                    for (uint64_t j = 0; j < stack_items; j++) {
-                        uint64_t item_len = read_varint();
-                        if (end - pos < static_cast<ptrdiff_t>(item_len)) throw std::runtime_error("truncated witness");
-                        pos += item_len;
-                    }
-                }
-            }
-            // Skip locktime
-            if (end - pos < 4) throw std::runtime_error("truncated locktime");
-            pos += 4;
-        }
-
-        // 2. Skip hashBlock (32 bytes)
-        if (end - pos < 32) throw std::runtime_error("truncated hashBlock");
-        pos += 32;
-
-        // 3. Skip vMerkleBranch (varint count + N*32 bytes)
-        {
-            auto read_varint = [&]() -> uint64_t {
-                if (pos >= end) throw std::runtime_error("truncated varint");
-                uint8_t first = *pos++;
-                if (first < 0xfd) return first;
-                if (first == 0xfd) { uint16_t v = pos[0]|(pos[1]<<8); pos+=2; return v; }
-                if (first == 0xfe) { uint32_t v = pos[0]|(pos[1]<<8)|(pos[2]<<16)|(pos[3]<<24); pos+=4; return v; }
-                uint64_t v = 0; for(int i=0;i<8;i++) v|=(uint64_t(pos[i])<<(i*8)); pos+=8; return v;
-            };
-            uint64_t count = read_varint();
-            if (end - pos < static_cast<ptrdiff_t>(count * 32)) throw std::runtime_error("truncated merkle branch");
-            pos += count * 32;
-        }
-
-        // 4. Skip nIndex (4 bytes)
-        if (end - pos < 4) throw std::runtime_error("truncated nIndex");
-        pos += 4;
-
-        // 5. Skip vChainMerkleBranch (varint count + N*32 bytes)
-        {
-            auto read_varint = [&]() -> uint64_t {
-                if (pos >= end) throw std::runtime_error("truncated varint");
-                uint8_t first = *pos++;
-                if (first < 0xfd) return first;
-                if (first == 0xfd) { uint16_t v = pos[0]|(pos[1]<<8); pos+=2; return v; }
-                if (first == 0xfe) { uint32_t v = pos[0]|(pos[1]<<8)|(pos[2]<<16)|(pos[3]<<24); pos+=4; return v; }
-                uint64_t v = 0; for(int i=0;i<8;i++) v|=(uint64_t(pos[i])<<(i*8)); pos+=8; return v;
-            };
-            uint64_t count = read_varint();
-            if (end - pos < static_cast<ptrdiff_t>(count * 32)) throw std::runtime_error("truncated chain merkle branch");
-            pos += count * 32;
-        }
-
-        // 6. Skip nChainIndex (4 bytes)
-        if (end - pos < 4) throw std::runtime_error("truncated nChainIndex");
-        pos += 4;
-
-        // 7. Skip parentBlock (80-byte CPureBlockHeader)
-        if (end - pos < 80) throw std::runtime_error("truncated parentBlock");
-        pos += 80;
-    }
-
-    // Skip tx_count varint (always 0 in headers message)
-    if (pos < end) {
-        uint8_t tx_count = *pos++;
-        (void)tx_count; // should be 0
-    }
-
+    pos += avail - ps.cursor_size();
     return hdr;
 }
 
 /// Parse a batch of DOGE headers from a P2P 'headers' message payload.
-/// Returns vector of base BlockHeaderType (80-byte headers only, AuxPoW skipped).
+/// Returns the vector of base BlockHeaderType (AuxPoW proofs are parsed then
+/// dropped; HeaderChain validates against the 80-byte base header).
 inline std::vector<BlockHeaderType> parse_doge_headers_message(
     const uint8_t* data, size_t len)
 {
     std::vector<BlockHeaderType> result;
-    const uint8_t* pos = data;
-    const uint8_t* end = data + len;
+    if (data == nullptr || len == 0)
+        return result;
 
-    // First: read the header count varint
-    if (pos >= end) return result;
+    PackStream ps(std::span<const std::byte>(
+        reinterpret_cast<const std::byte*>(data), len));
+
     uint64_t count = 0;
-    {
-        uint8_t first = *pos++;
-        if (first < 0xfd) count = first;
-        else if (first == 0xfd && end - pos >= 2) { count = pos[0]|(pos[1]<<8); pos+=2; }
-        else if (first == 0xfe && end - pos >= 4) { count = pos[0]|(pos[1]<<8)|(pos[2]<<16)|(pos[3]<<24); pos+=4; }
-        else return result;
+    try {
+        count = ReadCompactSize(ps);
+    } catch (const std::exception&) {
+        return result;
     }
 
-    result.reserve(static_cast<size_t>(count));
-    for (uint64_t i = 0; i < count && pos < end; i++) {
+    // A 'headers' message carries at most 2000; cap the speculative reserve.
+    result.reserve(static_cast<size_t>(std::min<uint64_t>(count, 4096)));
+
+    CAuxPow aux;
+    bool has_aux = false;
+    for (uint64_t i = 0; i < count && ps.cursor_size() > 0; ++i) {
         try {
-            result.push_back(parse_doge_header(pos, end));
-        } catch (const std::exception& e) {
-            // Truncated header — return what we have
+            result.push_back(parse_aux_header(ps, aux, has_aux));
+            // tx_count (CompactSize) — always 0 in a 'headers' message.
+            if (ps.cursor_size() > 0)
+                (void)ReadCompactSize(ps);
+        } catch (const std::exception&) {
+            // Truncated header — return what parsed cleanly.
             break;
         }
     }
@@ -230,137 +107,23 @@ inline std::vector<BlockHeaderType> parse_doge_headers_message(
 }
 
 /// Parse a DOGE full block from raw P2P bytes.
-/// Handles AuxPoW: reads 80-byte header, skips AuxPoW proof if present,
-/// then reads the standard transaction list.
-///
-/// Returns a BlockType with the correct header and transactions.
+/// Structured parse of the header + AuxPoW proof, then the standard tx list.
+/// Returns a BlockType with the base header and transactions.
 /// Throws on parse failure.
 inline ltc::coin::BlockType parse_doge_block(const uint8_t* data, size_t len)
 {
     using ltc::coin::BlockType;
-    using ltc::coin::BlockHeaderType;
 
-    const uint8_t* pos = data;
-    const uint8_t* end = data + len;
+    PackStream ps(std::span<const std::byte>(
+        reinterpret_cast<const std::byte*>(data), len));
 
-    // Step 1: Parse 80-byte base header
-    if (end - pos < 80)
-        throw std::runtime_error("DOGE block: not enough data for header");
+    CAuxPow aux;
+    bool has_aux = false;
+    BlockHeaderType hdr = parse_aux_header(ps, aux, has_aux);
 
-    BlockHeaderType hdr;
-    {
-        PackStream ps(std::span<const std::byte>(
-            reinterpret_cast<const std::byte*>(pos), 80));
-        ps >> hdr;
-    }
-    pos += 80;
-
-    // Step 2: Skip AuxPoW if present
-    if (is_auxpow_version(hdr.m_version)) {
-        // Reuse the same AuxPoW skip logic from parse_doge_header.
-        // We need to skip: CTransaction + hashBlock(32) + vMerkleBranch + nIndex(4)
-        //                 + vChainMerkleBranch + nChainIndex(4) + parentBlock(80)
-        auto read_varint = [&]() -> uint64_t {
-            if (pos >= end) throw std::runtime_error("DOGE block auxpow: truncated varint");
-            uint8_t first = *pos++;
-            if (first < 0xfd) return first;
-            if (first == 0xfd) {
-                if (end - pos < 2) throw std::runtime_error("truncated varint16");
-                uint16_t v = pos[0] | (pos[1] << 8); pos += 2; return v;
-            }
-            if (first == 0xfe) {
-                if (end - pos < 4) throw std::runtime_error("truncated varint32");
-                uint32_t v = pos[0] | (pos[1]<<8) | (pos[2]<<16) | (pos[3]<<24);
-                pos += 4; return v;
-            }
-            if (end - pos < 8) throw std::runtime_error("truncated varint64");
-            uint64_t v = 0;
-            for (int i = 0; i < 8; i++) v |= (uint64_t(pos[i]) << (i*8));
-            pos += 8; return v;
-        };
-
-        // 1. Skip CTransaction (coinbase of parent block)
-        {
-            if (end - pos < 4) throw std::runtime_error("DOGE block auxpow: truncated tx version");
-            pos += 4; // tx version
-            bool is_segwit = false;
-            if (end - pos >= 2 && pos[0] == 0x00 && pos[1] != 0x00) {
-                is_segwit = true;
-                pos += 2;
-            }
-            uint64_t vin_count = read_varint();
-            for (uint64_t i = 0; i < vin_count; i++) {
-                if (end - pos < 36) throw std::runtime_error("truncated vin");
-                pos += 32 + 4; // prev_hash + prev_index
-                uint64_t script_len = read_varint();
-                if (end - pos < static_cast<ptrdiff_t>(script_len)) throw std::runtime_error("truncated vin script");
-                pos += script_len;
-                if (end - pos < 4) throw std::runtime_error("truncated vin sequence");
-                pos += 4;
-            }
-            uint64_t vout_count = read_varint();
-            for (uint64_t i = 0; i < vout_count; i++) {
-                if (end - pos < 8) throw std::runtime_error("truncated vout value");
-                pos += 8;
-                uint64_t script_len = read_varint();
-                if (end - pos < static_cast<ptrdiff_t>(script_len)) throw std::runtime_error("truncated vout script");
-                pos += script_len;
-            }
-            if (is_segwit) {
-                for (uint64_t i = 0; i < vin_count; i++) {
-                    uint64_t stack_items = read_varint();
-                    for (uint64_t j = 0; j < stack_items; j++) {
-                        uint64_t item_len = read_varint();
-                        if (end - pos < static_cast<ptrdiff_t>(item_len)) throw std::runtime_error("truncated witness");
-                        pos += item_len;
-                    }
-                }
-            }
-            if (end - pos < 4) throw std::runtime_error("truncated locktime");
-            pos += 4;
-        }
-
-        // 2. Skip hashBlock (32 bytes)
-        if (end - pos < 32) throw std::runtime_error("truncated hashBlock");
-        pos += 32;
-
-        // 3. Skip vMerkleBranch
-        {
-            uint64_t count = read_varint();
-            if (end - pos < static_cast<ptrdiff_t>(count * 32)) throw std::runtime_error("truncated merkle branch");
-            pos += count * 32;
-        }
-
-        // 4. Skip nIndex (4 bytes)
-        if (end - pos < 4) throw std::runtime_error("truncated nIndex");
-        pos += 4;
-
-        // 5. Skip vChainMerkleBranch
-        {
-            uint64_t count = read_varint();
-            if (end - pos < static_cast<ptrdiff_t>(count * 32)) throw std::runtime_error("truncated chain merkle branch");
-            pos += count * 32;
-        }
-
-        // 6. Skip nChainIndex (4 bytes)
-        if (end - pos < 4) throw std::runtime_error("truncated nChainIndex");
-        pos += 4;
-
-        // 7. Skip parentBlock (80 bytes)
-        if (end - pos < 80) throw std::runtime_error("truncated parentBlock");
-        pos += 80;
-    }
-
-    // Step 3: Parse transaction list from remaining bytes
     BlockType block;
     static_cast<BlockHeaderType&>(block) = hdr;
-    {
-        size_t remaining = end - pos;
-        PackStream ps(std::span<const std::byte>(
-            reinterpret_cast<const std::byte*>(pos), remaining));
-        ::Unserialize(ps, TX_WITH_WITNESS(block.m_txs));
-    }
-
+    ::Unserialize(ps, TX_WITH_WITNESS(block.m_txs));
     return block;
 }
 

--- a/test/test_doge_chain.cpp
+++ b/test/test_doge_chain.cpp
@@ -308,9 +308,40 @@ std::vector<uint8_t> build_extended_header(
 doge::coin::CAuxPow make_sample_auxpow()
 {
     doge::coin::CAuxPow aux;
+
+    // Parent-chain (LTC) coinbase == the pool's own gentx, carried in the proof
+    // witness-stripped via tx_id_type (auxpow.hpp §12-Q1). Give it a realistic
+    // coinbase shape — null prevout, 0xffffffff index, a scriptSig and an
+    // output — so the variable-length tx body is genuinely round-tripped rather
+    // than left default-empty.
+    ltc::coin::MutableTransaction& cb = aux.m_merkle_tx.m_tx;
+    cb.version = 1;
+    cb.locktime = 0;
+    ltc::coin::TxIn cb_in;
+    cb_in.prevout.hash.SetNull();          // coinbase has a null prevout...
+    cb_in.prevout.index = 0xffffffff;      // ...and the 0xffffffff sentinel index
+    cb_in.scriptSig.m_data = {0x03, 0x99, 0x96, 0x06, 0x04, 0xde, 0xad, 0xbe, 0xef};
+    cb_in.sequence = 0xffffffff;
+    cb.vin.push_back(cb_in);
+    ltc::coin::TxOut cb_out;
+    cb_out.value = 5000000000LL;           // 50.00000000
+    cb_out.scriptPubKey.m_data = {
+        0x76, 0xa9, 0x14,                  // OP_DUP OP_HASH160 PUSH(20)
+        0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa,
+        0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11, 0x22, 0x33, 0x44,
+        0x88, 0xac};                       // OP_EQUALVERIFY OP_CHECKSIG
+    cb.vout.push_back(cb_out);
+
     aux.m_merkle_tx.m_block_hash.SetHex(
         "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899");
-    aux.m_merkle_tx.m_merkle_link.m_index = 0;
+    // Coinbase merkle branch: the path from the coinbase (leaf 0) up to the
+    // parent block's merkle root. Populate it (was empty) so the second
+    // variable-length proof component is exercised on the round-trip.
+    uint256 cb_b0; cb_b0.SetHex("00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff");
+    uint256 cb_b1; cb_b1.SetHex("123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0");
+    aux.m_merkle_tx.m_merkle_link.m_branch = {cb_b0, cb_b1};
+    aux.m_merkle_tx.m_merkle_link.m_index = 0;  // coinbase is always leaf 0
+
     uint256 b0; b0.SetHex("01");
     uint256 b1; b1.SetHex("02");
     aux.m_chain_merkle_link.m_branch = {b0, b1};
@@ -373,6 +404,22 @@ TEST(AuxPowStructuredTest, ParseAuxPowHeaderRoundTripsProof) {
     EXPECT_EQ(out.m_chain_merkle_link.m_branch[1], aux.m_chain_merkle_link.m_branch[1]);
     EXPECT_EQ(out.m_chain_merkle_link.m_index, 3u);
     EXPECT_EQ(out.m_parent_block_header.m_nonce, 0x0000c0deu);
+
+    // The two most variable-length parts of the proof — the parent coinbase tx
+    // body and the coinbase merkle branch — must round-trip WITH content, so a
+    // wrong-length read in either path is caught (not masked by empty defaults).
+    ASSERT_EQ(out.m_merkle_tx.m_tx.vin.size(), 1u);
+    EXPECT_EQ(out.m_merkle_tx.m_tx.vin[0].prevout.index, 0xffffffffu);
+    EXPECT_EQ(out.m_merkle_tx.m_tx.vin[0].scriptSig.m_data,
+              aux.m_merkle_tx.m_tx.vin[0].scriptSig.m_data);
+    ASSERT_EQ(out.m_merkle_tx.m_tx.vout.size(), 1u);
+    EXPECT_EQ(out.m_merkle_tx.m_tx.vout[0].value, 5000000000LL);
+    EXPECT_EQ(out.m_merkle_tx.m_tx.vout[0].scriptPubKey.m_data,
+              aux.m_merkle_tx.m_tx.vout[0].scriptPubKey.m_data);
+    ASSERT_EQ(out.m_merkle_tx.m_merkle_link.m_branch.size(), 2u);
+    EXPECT_EQ(out.m_merkle_tx.m_merkle_link.m_branch[0], aux.m_merkle_tx.m_merkle_link.m_branch[0]);
+    EXPECT_EQ(out.m_merkle_tx.m_merkle_link.m_branch[1], aux.m_merkle_tx.m_merkle_link.m_branch[1]);
+    EXPECT_EQ(out.m_merkle_tx.m_merkle_link.m_index, 0u);
 }
 
 TEST(AuxPowStructuredTest, HasAuxFalseForPlainHeader) {

--- a/test/test_doge_chain.cpp
+++ b/test/test_doge_chain.cpp
@@ -286,6 +286,147 @@ TEST(AuxPowParserTest, SingleNonAuxPowMessage) {
     EXPECT_EQ(result[0].m_version, 4);
 }
 
+// ─── AuxPoW Structured Parser Tests (M3) ─────────────────────────────────────
+
+namespace {
+// Build a raw extended-header blob: 80-byte base header + (optional) CAuxPow
+// proof + tx_count(CompactSize). Mirrors the DOGE 'headers'-message wire layout.
+std::vector<uint8_t> build_extended_header(
+    const bitcoin_family::coin::BlockHeaderType& base,
+    const doge::coin::CAuxPow* aux)
+{
+    PackStream ps;
+    ::Serialize(ps, base);
+    if (aux)
+        ::Serialize(ps, *aux);
+    WriteCompactSize(ps, 0); // tx_count — always 0 in a 'headers' message
+    auto sp = ps.get_span();
+    auto* b = reinterpret_cast<const uint8_t*>(sp.data());
+    return std::vector<uint8_t>(b, b + sp.size());
+}
+
+doge::coin::CAuxPow make_sample_auxpow()
+{
+    doge::coin::CAuxPow aux;
+    aux.m_merkle_tx.m_block_hash.SetHex(
+        "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899");
+    aux.m_merkle_tx.m_merkle_link.m_index = 0;
+    uint256 b0; b0.SetHex("01");
+    uint256 b1; b1.SetHex("02");
+    aux.m_chain_merkle_link.m_branch = {b0, b1};
+    aux.m_chain_merkle_link.m_index = 3;
+    aux.m_parent_block_header.m_version = 2;
+    aux.m_parent_block_header.m_timestamp = 0x499602d2;
+    aux.m_parent_block_header.m_bits = 0x1e0ffff0;
+    aux.m_parent_block_header.m_nonce = 0x0000c0de;
+    return aux;
+}
+} // namespace
+
+TEST(AuxPowStructuredTest, ParseAuxPowHeaderConsumesProof) {
+    bitcoin_family::coin::BlockHeaderType base;
+    base.m_version = 0x00620102;  // chain_id=98, AuxPoW bit set, version 2
+    base.m_previous_block.SetHex("1111111111111111111111111111111111111111111111111111111111111111");
+    base.m_merkle_root.SetHex("2222222222222222222222222222222222222222222222222222222222222222");
+    base.m_timestamp = 0x5a5a5a5a;
+    base.m_bits = 0x1e0ffff0;
+    base.m_nonce = 0x12345678;
+
+    auto aux = make_sample_auxpow();
+    auto blob = build_extended_header(base, &aux);
+
+    const uint8_t* pos = blob.data();
+    const uint8_t* end = blob.data() + blob.size();
+    auto hdr = doge::coin::parse_doge_header(pos, end);
+
+    // Base header is recovered intact past the variable-length AuxPoW proof.
+    EXPECT_EQ(hdr.m_version, 0x00620102u);
+    EXPECT_EQ(hdr.m_timestamp, 0x5a5a5a5au);
+    EXPECT_EQ(hdr.m_bits, 0x1e0ffff0u);
+    EXPECT_EQ(hdr.m_nonce, 0x12345678u);
+    EXPECT_EQ(hdr.m_previous_block, base.m_previous_block);
+    EXPECT_EQ(hdr.m_merkle_root, base.m_merkle_root);
+    EXPECT_EQ(pos, end) << "Structured parser must consume the full AuxPoW header";
+}
+
+TEST(AuxPowStructuredTest, ParseAuxPowHeaderRoundTripsProof) {
+    // Verify parse_aux_header deserializes the proof structurally (not skipped):
+    // the CAuxPow read back must equal the one we serialized.
+    bitcoin_family::coin::BlockHeaderType base;
+    base.m_version = 0x00620104;  // AuxPoW bit set
+    base.m_bits = 0x1e0ffff0;
+
+    auto aux = make_sample_auxpow();
+    auto blob = build_extended_header(base, &aux);
+
+    PackStream ps(std::span<const std::byte>(
+        reinterpret_cast<const std::byte*>(blob.data()), blob.size()));
+    doge::coin::CAuxPow out;
+    bool has_aux = false;
+    auto hdr = doge::coin::parse_aux_header(ps, out, has_aux);
+
+    EXPECT_TRUE(has_aux);
+    EXPECT_EQ(hdr.m_version, 0x00620104u);
+    EXPECT_EQ(out.m_merkle_tx.m_block_hash, aux.m_merkle_tx.m_block_hash);
+    ASSERT_EQ(out.m_chain_merkle_link.m_branch.size(), 2u);
+    EXPECT_EQ(out.m_chain_merkle_link.m_branch[0], aux.m_chain_merkle_link.m_branch[0]);
+    EXPECT_EQ(out.m_chain_merkle_link.m_branch[1], aux.m_chain_merkle_link.m_branch[1]);
+    EXPECT_EQ(out.m_chain_merkle_link.m_index, 3u);
+    EXPECT_EQ(out.m_parent_block_header.m_nonce, 0x0000c0deu);
+}
+
+TEST(AuxPowStructuredTest, HasAuxFalseForPlainHeader) {
+    bitcoin_family::coin::BlockHeaderType base;
+    base.m_version = 4;  // no AuxPoW bit
+    base.m_bits = 0x1e0ffff0;
+    auto blob = build_extended_header(base, nullptr);
+
+    PackStream ps(std::span<const std::byte>(
+        reinterpret_cast<const std::byte*>(blob.data()), blob.size()));
+    doge::coin::CAuxPow out;
+    bool has_aux = true;
+    auto hdr = doge::coin::parse_aux_header(ps, out, has_aux);
+    EXPECT_FALSE(has_aux);
+    EXPECT_EQ(hdr.m_version, 4u);
+}
+
+TEST(AuxPowStructuredTest, BatchParsesAuxPowHeader) {
+    // count=1 followed by a single AuxPoW-extended header.
+    bitcoin_family::coin::BlockHeaderType base;
+    base.m_version = 0x00620102;
+    base.m_bits = 0x1e0ffff0;
+    base.m_nonce = 0xdeadbeef;
+    auto aux = make_sample_auxpow();
+
+    std::vector<uint8_t> msg;
+    msg.push_back(0x01); // CompactSize count = 1
+    auto hdr_blob = build_extended_header(base, &aux);
+    msg.insert(msg.end(), hdr_blob.begin(), hdr_blob.end());
+
+    auto result = doge::coin::parse_doge_headers_message(msg.data(), msg.size());
+    ASSERT_EQ(result.size(), 1u);
+    EXPECT_EQ(result[0].m_version, 0x00620102u);
+    EXPECT_EQ(result[0].m_nonce, 0xdeadbeefu);
+}
+
+TEST(AuxPowStructuredTest, BatchStopsAtTruncatedHeader) {
+    // count=2, but only the first header is complete; second is truncated.
+    bitcoin_family::coin::BlockHeaderType base;
+    base.m_version = 0x00620102;
+    base.m_bits = 0x1e0ffff0;
+    auto aux = make_sample_auxpow();
+
+    std::vector<uint8_t> msg;
+    msg.push_back(0x02); // claims 2 headers
+    auto hdr_blob = build_extended_header(base, &aux);
+    msg.insert(msg.end(), hdr_blob.begin(), hdr_blob.end());
+    // Append a truncated second header (only 10 bytes of the 80-byte base).
+    msg.insert(msg.end(), 10, 0x00);
+
+    auto result = doge::coin::parse_doge_headers_message(msg.data(), msg.size());
+    EXPECT_EQ(result.size(), 1u) << "Truncated tail header must be dropped, first kept";
+}
+
 // ─── Mersenne Twister Uniform Int Tests ─────────────────────────────────────
 
 TEST(MersenneTwisterTest, BoostCompatibleOutput) {


### PR DESCRIPTION
## Phase 5.8 M3 — part 1 of 2: structured parser

Replaces the byte-skip DOGE extended-header parser with a **structured** parse that deserializes the AuxPoW proof into the `CAuxPow` / `CMerkleTx` / `CMerkleLink` hierarchy (M2 skeletons) via the standard `core/pack.hpp` surface.

### What changed
- **`auxpow.hpp`** — `parse_aux_header(s, out_aux, has_aux)`: reads 80B base header; deserializes `CAuxPow` when `is_auxpow_version()`, else `SetNull()`. Hand-written `Serialize`/`Unserialize` on `CMerkleLink`/`CMerkleTx`/`CAuxPow` to stay independent of which `SERIALIZE_METHODS` macro is active per-TU.
- **`auxpow_header.hpp`** — `parse_doge_header` / `parse_doge_headers_message` / `parse_doge_block` route through `parse_aux_header` + `ReadCompactSize`; ~210 lines of hand-rolled varint/segwit skip logic removed.
- **`test_doge_chain.cpp`** — 5 new tests: round-trips the proof, `has_aux` gating, batch parse, truncated-tail drop.

### Scope / invariants
- Confined to `src/impl/doge/` + `test/`. **No `src/core/` or `src/impl/bitcoin_family/` touch.**
- ctest **587/587 green** (Linux x86_64; 582 baseline + 5 new).
- Commit GPG-signed.

### ⚠️ Open question — `CAuxPow::check_proof` (the other half of M3)
`check_proof` is still **declared-only**. Implementing it requires verifying the **parent block PoW** + merkle-link checks. Parent-PoW hashing lives in `src/core/pow.hpp` / `src/core/coin_params.hpp` / `src/impl/bitcoin_family/coin/chain_params.hpp` — i.e. correct `check_proof` cannot be done purely inside `src/impl/doge/`, which trips the per-coin isolation invariant. **Flagged to integrator before any core/bitcoin_family touch.** This PR lands the parser half; `check_proof` follows as M3b once the isolation question is resolved.