### PR TITLE
dgb: bootstrap src/impl/dgb skeleton (M2)

### DIFF
--- a/src/impl/dgb/CMakeLists.txt
+++ b/src/impl/dgb/CMakeLists.txt
@@ -1,0 +1,24 @@
+# c2pool-dgb coin module (V36). Built when -DCOIN_DGB=ON.
+# Mirrors src/impl/btc/CMakeLists.txt; emits the c2pool-dgb binary.
+# Per-coin binary scheme: project_v36_per_coin_binary_v37_unified_process.
+# Impl plan: c2pool-dgb-embedded-impl-plan.md (frstrtr/the docs/v36, 8ef8d2d).
+#
+# SCOPE (M1 / project_v36_dgb_scrypt_only): V36 validates SCRYPT blocks only.
+# Other 4 DGB algos (SHA256d, Skein, Qubit, Odocrypt) = accept-by-continuity
+# or ignored. Full 5-algo validation is DEFERRED TO V37.
+#
+# -DAUX_DOGE opt-in (DGB-as-DOGE-parent, the dual-parent stretch) is NOT wired
+# in this module yet: parked behind the Phase 5.8 settle (ltc-doge owns the
+# shared DOGE-aux surface). Do not add AUX_DOGE plumbing here at M2.
+#
+# TODO(M3): add_library(impl_dgb ...) sources as an OBJECT lib (ci-steward
+# PR-CMake-object-library convention; impl_dgb = 1 of 5 per-coin OBJECT libs),
+# link bitcoin_family/Scrypt shared base, wire embedded DigiByte Core daemon
+# slice under daemon/. Top-level add_subdirectory(src/impl/dgb) registration
+# follows the OBJECT-lib convention PR; held ~2-3 heartbeats, not raced here.
+if(COIN_DGB)
+  message(STATUS "c2pool: DGB Scrypt-only coin module enabled (skeleton)")
+  # add_subdirectory(coin)
+  # add_subdirectory(daemon)
+  # add_subdirectory(test)
+endif()

--- a/src/impl/dgb/coin/header_chain.hpp
+++ b/src/impl/dgb/coin/header_chain.hpp
@@ -1,0 +1,20 @@
+#pragma once
+// DGB header-chain validation. Mirrors src/impl/btc/coin/header_chain.hpp,
+// shares the Scrypt PoW path with src/impl/ltc (identical Scrypt to LTC).
+//
+// >>> SCRYPT-ONLY VALIDATION POINT (M1 §2, project_v36_dgb_scrypt_only) <<<
+// DGB is a 5-algo chain (Scrypt, SHA256d, Skein, Qubit, Odocrypt). In V36
+// c2pool-dgb validates the SCRYPT path ONLY:
+//   - Scrypt block header        -> full PoW validate (this slice)
+//   - non-Scrypt block header     -> accept-by-continuity (extend headers,
+//                                    do NOT PoW-validate) OR ignore
+//   - malformed / wrong-magic     -> reject
+// Algo is selected from the DGB version field (multi-algo encoding). Full
+// 5-algo validation is V37 scope — do NOT add Skein/Qubit/Odocrypt/SHA256d
+// PoW here.
+//
+// >>> DIGISHIELD INSERTION POINT (M1 §2) <<<
+// DGB uses DigiShield/MultiShield per-algo difficulty retarget, NOT BTC's
+// 2016-block retarget. TODO(M3): port per-algo DigiShield target calc for the
+// Scrypt algo lane only.
+namespace c2pool::dgb { /* TODO(M3): HeaderChain w/ Scrypt-only validate() + accept-by-continuity */ }

--- a/src/impl/dgb/coin/header_chain.hpp
+++ b/src/impl/dgb/coin/header_chain.hpp
@@ -13,8 +13,26 @@
 // 5-algo validation is V37 scope — do NOT add Skein/Qubit/Odocrypt/SHA256d
 // PoW here.
 //
+// >>> THIRD INVARIANT: ACCEPT-BY-CONTINUITY HEADERS ARE WORK-NEUTRAL <<<
+// (PR #60, dash-consensus review)
+// A non-Scrypt header accepted by continuity extends the header chain, but its
+// un-validated PoW MUST NOT contribute to sharechain cumulative work or
+// best-chain selection. Continuity headers carry zero weight in work
+// accounting. Otherwise an attacker feeds cheap non-Scrypt headers to inflate
+// cumulative work — a consensus divergence vs p2pool-merged-v36 AND a DoS
+// surface. This is the multi-algo analogue of the DASH case where DGW fully
+// overrides the base 2016-block retarget (the base path is never reached).
+// M3 MUST honor this in BOTH HeaderChain::validate() (no work credited for
+// continuity headers) and the DigiShield window (continuity headers excluded
+// from the retarget walk — see below).
+//
 // >>> DIGISHIELD INSERTION POINT (M1 §2) <<<
 // DGB uses DigiShield/MultiShield per-algo difficulty retarget, NOT BTC's
 // 2016-block retarget. TODO(M3): port per-algo DigiShield target calc for the
 // Scrypt algo lane only.
+// TODO(M3): the DigiShield difficulty window MUST walk Scrypt-algo ancestors
+// ONLY — never the interleaved multi-algo header chain. On a mixed-algo chain
+// the previous-block / window walk must skip non-Scrypt (continuity) headers;
+// folding them into the window corrupts the Scrypt retarget and re-introduces
+// the work-neutrality break above. Easy to get wrong on a mixed-algo chain.
 namespace c2pool::dgb { /* TODO(M3): HeaderChain w/ Scrypt-only validate() + accept-by-continuity */ }

--- a/src/impl/dgb/coin/template_builder.hpp
+++ b/src/impl/dgb/coin/template_builder.hpp
@@ -1,0 +1,13 @@
+#pragma once
+// DGB block-template builder. Mirrors src/impl/btc/coin/template_builder.hpp.
+// Must emit p2pool-merged-v36-compatible templates (V36 master compat).
+//
+// >>> SCRYPT GBT FILTER POINT (M1 §3) <<<
+// DGB multi-algo: getblocktemplate is requested with rules=["scrypt"] so the
+// embedded daemon only returns Scrypt-eligible templates. The builder assembles
+// and submits Scrypt blocks only in V36. (config_coin.hpp CoinParams::GBT_ALGO.)
+//
+// Share/PoW format is identical to LTC Scrypt; share assembly reuses the shared
+// Scrypt-family path (do NOT fork LTC share logic — per-coin isolation).
+// TODO(M3): TemplateBuilder emitting p2pool-merged-v36-parity Scrypt templates.
+namespace c2pool::dgb { /* TODO(M3): TemplateBuilder, Scrypt GBT */ }

--- a/src/impl/dgb/daemon/README.txt
+++ b/src/impl/dgb/daemon/README.txt
@@ -1,0 +1,7 @@
+Embedded DigiByte Core daemon slice (M3). Forked from upstream DigiByte Core
+(github.com/DigiByte-Core/digibyte). Vendoring policy: NO in-tree vendor;
+reference clone built siblingly, artifacts into worktree only (M1 §1).
+Scope: SPV + P2P + mempool + template builder, Scrypt-algo lane only
+(project_embedded_coin_daemons_primary). Confirm DigiByte Core commit/tag at
+vendoring. Non-Scrypt algo lanes (SHA256d/Skein/Qubit/Odocrypt) are NOT driven
+in V36. Stub placeholder at M2.

--- a/src/impl/dgb/test/README.txt
+++ b/src/impl/dgb/test/README.txt
@@ -1,0 +1,6 @@
+DGB module tests (M3). Mirror src/impl/btc/test: template_parity_test (vs
+p2pool-merged-v36 reference fixtures), share_test (Scrypt shares == LTC format).
+Adds: Scrypt block-validation fixtures; multi-algo handling test (non-Scrypt
+headers accepted-by-continuity, never PoW-validated, never rejected on algo);
+DigiShield per-algo retarget vectors (Scrypt lane). DOGE-aux integration tests
+under -DAUX_DOGE=ON are STRETCH (§X), deferred behind Phase 5.8. Stub at M2.


### PR DESCRIPTION
## M2: `src/impl/dgb` skeleton — DGB Scrypt-only V36 coin module

Structural bootstrap of the DGB Scrypt-only coin module, following the approved M1 implementation plan `c2pool-dgb-embedded-impl-plan.md` (frstrtr/the docs, 8ef8d2d). V36 ratification context: `project_v36_dgb_scrypt_only`.

**Scope: M2 structural skeleton only.** `node.cpp` + share commit/validation wiring, Scrypt-only template-builder fill, and DigiShield finalization land in **M3**. Mirrors the bch M2 bootstrap discipline.

### Per-coin isolation invariant
- `src/impl/dgb/` **only** — no `src/core/` or `bitcoin_family/` touches.
- **No `-DAUX_DOGE`** plumbing (the dual-parent stretch / §X is parked behind Phase 5.8; ltc-doge owns the shared DOGE-aux surface).
- Verified diff vs `origin/master`: 6 files, all under `src/impl/dgb/`.

### CMake registration held
- **No top-level `CMakeLists.txt` change in this PR.** The `if(COIN_DGB)` guard lives inside `src/impl/dgb/CMakeLists.txt` (message-only at M2; `coin/`, `daemon/`, `test/` subdirs commented out).
- Top-level `add_subdirectory(src/impl/dgb)` registration is **held** until ci-steward's PR-CMake-object-library convention lands; `impl_dgb` registers as 1 of 5 per-coin OBJECT libs at that point (M3).

### Files (6)
- `coin/header_chain.hpp` — Scrypt-only validation point; non-Scrypt algos accept-by-continuity (full 5-algo deferred to V37); DigiShield insertion point.
- `coin/template_builder.hpp` — GBT `rules=[scrypt]`; p2pool-merged-v36 parity point.
- `daemon/README.txt` — embedded DigiByte Core slice scope (no in-tree vendor).
- `test/README.txt` — Scrypt fixtures + multi-algo accept-by-continuity + parity outline.
- `CMakeLists.txt` (+ `coin/CMakeLists.txt`) — `-DCOIN_DGB=ON` build gate, guarded.

### Requested reviewers
- **bch-embedded-steward** — cross-coin M2 parity (mirrors `bch/bootstrap-skeleton`).
- **ci-steward** — OBJECT-lib seam compat (`if(COIN_DGB)` must compose with the forthcoming convention).
- **dash** (optional) — sharechain-validation invariants.
