### PR TITLE
bch: bootstrap src/impl/bch skeleton (M2)

### DIFF
--- a/src/impl/bch/CMakeLists.txt
+++ b/src/impl/bch/CMakeLists.txt
@@ -1,0 +1,12 @@
+# c2pool-bch coin module (V36). Built when -DCOIN_BCH=ON.
+# Mirrors src/impl/btc/CMakeLists.txt; emits the c2pool-bch binary.
+# Per-coin binary scheme: project_v36_per_coin_binary_v37_unified_process.
+#
+# TODO(M3): add_library(impl_bch ...) sources, link bitcoin_family shared base,
+# wire embedded BCHN daemon slice under daemon/. Stub only at M2.
+if(COIN_BCH)
+  message(STATUS "c2pool: BCH coin module enabled (skeleton)")
+  # add_subdirectory(coin)
+  # add_subdirectory(daemon)
+  # add_subdirectory(test)
+endif()

--- a/src/impl/bch/coin/header_chain.hpp
+++ b/src/impl/bch/coin/header_chain.hpp
@@ -1,0 +1,8 @@
+#pragma once
+// BCH header-chain validation. Mirrors src/impl/btc/coin/header_chain.hpp.
+//
+// >>> ASERT INSERTION POINT (M1 §4.3) <<<
+// BCH uses ASERT (aserti3-2d) difficulty adjustment since the Nov 2020
+// upgrade, NOT BTC retarget. Net-new c2pool code (one of two BCH-specific
+// validation slices). TODO(M3): port aserti3-2d target calc + anchor block.
+namespace c2pool::bch { /* TODO(M3): HeaderChain w/ ASERT validate_target() */ }

--- a/src/impl/bch/coin/template_builder.hpp
+++ b/src/impl/bch/coin/template_builder.hpp
@@ -1,0 +1,13 @@
+#pragma once
+// BCH block-template builder. Mirrors src/impl/btc/coin/template_builder.hpp.
+// Must emit p2pool-merged-v36-compatible templates (V36 master compat).
+//
+// >>> CTOR INSERTION POINT (M1 §4.3) <<<
+// BCH requires CTOR: canonical (lexicographic txid) ordering of mempool txs
+// in the block body, coinbase first. Net-new c2pool code (second BCH slice).
+// TODO(M3): CTOR re-sort pass over selected txs before template assembly.
+//
+// CashTokens (May 2023) awareness: token-bearing outputs must round-trip
+// intact through template assembly. TODO(M3): preserve token prefix bytes.
+// HogEx: NOT applicable (see config_coin.hpp scope note).
+namespace c2pool::bch { /* TODO(M3): TemplateBuilder w/ CTOR re-sort */ }

--- a/src/impl/bch/config_coin.hpp
+++ b/src/impl/bch/config_coin.hpp
@@ -1,0 +1,23 @@
+#pragma once
+// c2pool-bch :: BCH coin parameters (V36)
+// Skeleton per c2pool-bch-embedded-impl-plan.md (frstrtr/the docs/v36) §3.
+// Embedded daemon forked from Bitcoin Cash Node (BCHN). SHA256d family.
+//
+// SCOPE NOTE (M1 §4.2): HogEx is a SmartBCH sidechain construct, NOT BCH
+// mainchain. It is explicitly OUT OF SCOPE for this template/coin module.
+// Do not add HogEx commitment handling here. See feedback: hogex-not-bch.
+//
+// CashAddr scaffolding: BCH address encoding diverges from BTC base58/bech32.
+// TODO(M3): port CashAddr (prefix "bitcoincash:") encode/decode at vendoring.
+
+namespace c2pool::bch {
+
+struct CoinParams {
+    // TODO(M3): fill from BCHN chainparams at vendoring (confirm commit/tag).
+    static constexpr const char* ticker      = "BCH";
+    static constexpr const char* cashaddr_hrp = "bitcoincash";
+    // ASERT DAA (May 2020) anchor — see coin/header_chain.hpp insertion point.
+    // CTOR (Nov 2018) canonical tx ordering — see coin/template_builder.hpp.
+};
+
+} // namespace c2pool::bch

--- a/src/impl/bch/daemon/README.txt
+++ b/src/impl/bch/daemon/README.txt
@@ -1,0 +1,5 @@
+Embedded BCHN daemon slice (M3). Forked from Bitcoin Cash Node, lowest
+divergence from Bitcoin Core (same root as c2pool-btc embedded daemon).
+Vendoring policy: NO in-tree vendor of BCHN; reference clone built siblingly,
+artifacts into worktree only (M1 §1.1). Scope: SPV + P2P + mempool + template
+builder. Confirm BCHN commit/tag at vendoring. Stub placeholder at M2.

--- a/src/impl/bch/test/README.txt
+++ b/src/impl/bch/test/README.txt
@@ -1,0 +1,3 @@
+BCH module tests (M3). Mirror src/impl/btc/test: template_parity_test (vs
+p2pool-merged-v36 reference fixtures), share_test. Adds: ASERT vector test,
+CTOR ordering test, CashAddr round-trip. Stub placeholder at M2.


### PR DESCRIPTION
## M2: bootstrap src/impl/bch skeleton

Bootstraps the BCH (Bitcoin Cash) V36 coin module skeleton. Implements M2 of the c2pool-bch-embedded-impl-plan (frstrtr/the docs, master d6ee6f0). Companion to dgb #60 / per-coin binary scheme.

### Shape
Inert-guard skeleton, matching the dgb #60 precedent exactly:
- `src/impl/bch/CMakeLists.txt`: `if(COIN_BCH)` guard, `message(STATUS ...)`, sub-`add_subdirectory`/`add_library` left as commented TODO(M3).
- Built only under `-DCOIN_BCH=ON`; emits the `c2pool-bch` binary at M3.
- Mirrors `src/impl/btc/` layout: `coin/` (header_chain, template_builder stubs), `daemon/`, `test/`, `config_coin.hpp`.

### Registration / OBJECT-lib convention
Per dgb #60, the active `add_library(impl_bch OBJECT ...)` and the top-level `add_subdirectory(src/impl/bch)` registration are the **OBJECT-lib convention PR** (ci-steward owns), deliberately not raced into the bootstrap. No LINK_GROUP (supersedes the earlier #54 LINK_GROUP approach). This PR therefore configures cleanly as a no-op: the module is present in-tree but not yet wired into the build graph — identical to dgb at #60.

If ci-steward wants the active top-level `add_subdirectory` + `add_library(impl_bch OBJECT)` to land *in this PR* (bch as the convention first-mover rather than waiting on the convention PR), I can amend within a heartbeat — flagging on the task thread.

### Scope / safety
- BCH-specific code only; no `src/impl/btc/` or `bitcoin_family/` changes.
- p2pool-merged-v36 compatibility: skeleton-only, no interop surface yet.
- Headers empty/stubbed; no functional logic at M2.

Diff: 6 files, +64.
