### PR TITLE
ci: drop dash test targets from AsAN+UBSan build until spv-embedded lands

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,8 +191,6 @@ jobs:
                     test_mweb_builder \
                     test_address_resolution test_compute_share_target \
                     test_utxo \
-                    test_dash_credit_pool test_dash_subsidy test_dash_battletest_regressions \
-                    test_dash_pay_attribution \
                     test_coin_broadcaster test_multiaddress_pplns test_pplns_stress \
             -j$(nproc)
 


### PR DESCRIPTION
## Summary

The AsAN+UBSan job in `.github/workflows/build.yml` references four dash-specific test targets that do not exist on master:

- `test_dash_credit_pool`
- `test_dash_subsidy`
- `test_dash_battletest_regressions`
- `test_dash_pay_attribution`

These were authored on the `dash-spv-embedded` branch in commit `43ef108f` (PR #43, 226-commit rebase in flight) and will land on master when that rebase completes.

## Symptom on every push to master

```
gmake: *** No rule to make target test_dash_credit_pool.  Stop.
```

## Why other jobs pass

- **Linux x86_64** (regular): does NOT list these targets (around line 55-69 of build.yml). Passes.
- **Coin matrix**: passes.
- **CodeQL / Web-static verify / Qt WebEngine leak gate**: pass.
- **Windows + macOS**: fail for an unrelated, known reason (`LINK_GROUP:RESCAN` is GNU-ld-only; tracked under PR-CMake-object-library).

## Fix scope

Remove the two lines containing the four dash test references (lines 194-195) so the AsAN+UBSan target list matches the regular Linux job. No code/source change; CI workflow only.

## When dash-spv-embedded lands

The dash author/reviewer can re-add the four target names in the same PR that lands the tests, keeping the AsAN+UBSan job sanitizer-instrumented from day one.

## Verification

- Linux x86_64 (regular) build matrix already passes without these targets on master
- Diff is +0/-2 (`gh pr diff` to confirm), strictly subtractive in YAML
- Branch: `ci/asan-drop-dash-tests-until-spv-embedded-lands` off master `cd324735`

## Test plan

- [ ] AsAN+UBSan CI job turns green on this PR
- [ ] All other CI jobs unchanged (Linux x86_64, Coin matrix, etc.)
- [ ] When dash-spv-embedded lands, re-add the four test targets in that PR