### PR TITLE
ci(coin-matrix): fix BTC entrypoint gate (src/c2pool/main_<coin>.cpp)

### DIFF
--- a/.github/workflows/coin-matrix.yml
+++ b/.github/workflows/coin-matrix.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Check source presence
         id: presence
         run: |
-          if [ -f "src/impl/${{ matrix.coin }}/main_${{ matrix.coin }}.cpp" ] && [ -d "src/impl/${{ matrix.coin }}" ]; then
+          if [ -f "src/c2pool/main_${{ matrix.coin }}.cpp" ] && [ -d "src/impl/${{ matrix.coin }}" ]; then
             echo "exists=1" >> "$GITHUB_OUTPUT"
             echo "::notice::c2pool-${{ matrix.coin }} source present — building."
           else


### PR DESCRIPTION
## What

The coin-matrix smoke gate keyed presence on `src/impl/<coin>/main_<coin>.cpp`, but the per-coin entrypoint actually lives at `src/c2pool/main_<coin>.cpp` — the convention already documented in the file header comment.

## Why it matters

The BTC binary entrypoint is `src/c2pool/main_btc.cpp`; there is **no** `src/impl/btc/main_btc.cpp`. So when btc source lands, the `btc` matrix job silently skips — a **false green**. This fix makes the gate match the real entrypoint path while retaining the `src/impl/<coin>/` directory check. Generalizes correctly across ltc/doge/dash/btc.

## Scope

One-line change to `.github/workflows/coin-matrix.yml`. Independent of btc-heap-opt's btc-embedded preservation/rebase plan.

Merge gated on operator push-approval.