### PR TITLE
dash: refresh WebServer coin-node seam comment (PR-C, SAFE-COSMETIC)

### DIFF
--- a/src/impl/dash/main_dash.cpp
+++ b/src/impl/dash/main_dash.cpp
@@ -1310,10 +1310,10 @@ int main(int argc, char* argv[])
 
     // ── Web dashboard (optional; enabled when --http-port > 0) ──────────
     // Coin-agnostic path: constructor takes IMiningNode (our EnhancedNode)
-    // and Blockchain::DASH. We do NOT call set_coin_rpc() — that signature
-    // is hardcoded to ltc::coin::NodeRPC* and would require ICoinRPC
-    // extraction. Our GBT/submitblock path stays in the existing stratum
-    // handler. The dashboard serves mining stats via IMiningNode only.
+    // and Blockchain::DASH. We deliberately leave the WebServer coin-node
+    // seam unset (no set_coin_node; nullptr by design): dash owns its
+    // own GBT/submitblock pipeline via the stratum handler, so the
+    // dashboard serves mining stats via IMiningNode only.
     // set_stratum_port(0) prevents WebServer from launching its own
     // StratumServer (we run dash::stratum::Server ourselves).
     std::unique_ptr<core::WebServer> web_server;


### PR DESCRIPTION
Comment-only cleanup on src/impl/dash/main_dash.cpp (the WebServer coin-node seam block).

Reconcile (ltc-doge-production-steward, 2026-06-05) closed PR-C as stale-comment cleanup: no ICoinNode inherit, no stub, no all-coin RED window. The dash nullptr config is unchanged — no set_coin_node, stratum_port(0) — so both Cluster-A crossings stay skipped.

The old comment justified skipping set_coin_rpc() by the absence of an ICoinRPC seam; the coin-node seam (core::coin::ICoinNode) is now being extracted via the web_server rewire, so that rationale is stale. The comment now states the intent directly: dash deliberately leaves the WebServer coin-node seam unset (nullptr by design) and owns its own GBT/submitblock pipeline via the stratum handler.

Scope: 1 file, comment-only, no behavior change. Signed commit.