### PR TITLE
core/pack: rename c2pool SERIALIZE_METHODS family to C2POOL_SERIALIZE_METHODS (fix message_sendaddrv2 macro collision)

### DIFF
--- a/src/core/message_macro.hpp
+++ b/src/core/message_macro.hpp
@@ -52,7 +52,7 @@
         stream >> *result;\
         return result;\
     }\
-    SERIALIZE_METHODS(message_type)
+    C2POOL_SERIALIZE_METHODS(message_type)
     
 #define WITHOUT_MESSAGE_FIELDS()\
     static PackStream make()\
@@ -72,7 +72,7 @@
         auto result = std::make_unique<message_type>();\
         return result;\
     }\
-    SERIALIZE_METHODS(message_type)
+    C2POOL_SERIALIZE_METHODS(message_type)
 
 
 #define END_MESSAGE() };

--- a/src/core/netaddress.hpp
+++ b/src/core/netaddress.hpp
@@ -135,7 +135,7 @@ public:
     std::string port_str() const { return std::to_string(m_port); }
     std::string to_string() const { return m_ip + ":" + port_str(); }
 
-    SERIALIZE_METHODS(NetService) { READWRITE(AsBase<NetAddress>(obj), Using<IntType<16, true>>(obj.m_port)); }
+    C2POOL_SERIALIZE_METHODS(NetService) { READWRITE(AsBase<NetAddress>(obj), Using<IntType<16, true>>(obj.m_port)); }
 
     friend bool operator==(const NetService& l, const NetService& r)
     { return (l.m_type == r.m_type) && (l.m_ip == r.m_ip) && (l.m_port == r.m_port); }
@@ -184,7 +184,7 @@ struct addr_t
     addr_t() { }
     addr_t(uint64_t services, NetService endpoint) : m_services(services), m_endpoint(endpoint) { }
 
-    SERIALIZE_METHODS(addr_t) { READWRITE(obj.m_services, obj.m_endpoint); }
+    C2POOL_SERIALIZE_METHODS(addr_t) { READWRITE(obj.m_services, obj.m_endpoint); }
 };
 
 struct addr_record_t : addr_t
@@ -195,7 +195,7 @@ struct addr_record_t : addr_t
     addr_record_t(addr_t addr, uint64_t timestamp) : addr_t(addr), m_timestamp(timestamp) { }
     addr_record_t(uint64_t services, NetService endpoint, uint64_t timestamp) : addr_t(services, endpoint), m_timestamp(timestamp) {}
 
-    SERIALIZE_METHODS(addr_record_t) { READWRITE(obj.m_timestamp, AsBase<addr_t>(obj)); }
+    C2POOL_SERIALIZE_METHODS(addr_record_t) { READWRITE(obj.m_timestamp, AsBase<addr_t>(obj)); }
 };
 
 

--- a/src/core/opscript.hpp
+++ b/src/core/opscript.hpp
@@ -15,7 +15,7 @@ public:
     friend bool operator==(const OPScript& l, const OPScript& r) { return l.m_data == r.m_data; }
     friend bool operator!=(const OPScript& l, const OPScript& r) { return !(l==r); }
 
-    SERIALIZE_METHODS(OPScript) { READWRITE(AsBase<BaseScript>(obj)); }
+    C2POOL_SERIALIZE_METHODS(OPScript) { READWRITE(AsBase<BaseScript>(obj)); }
 };
 
 struct OPScriptWitness

--- a/src/core/pack.hpp
+++ b/src/core/pack.hpp
@@ -253,7 +253,7 @@ const Out& AsBase(const In& x)
         Read(is, *this);\
     }
 
-#define SERIALIZE_METHODS(TYPE)\
+#define C2POOL_SERIALIZE_METHODS(TYPE)\
     BASE_SERIALIZE_METHODS(TYPE)\
     FORMAT_METHODS(TYPE)
 

--- a/src/core/pack_types.hpp
+++ b/src/core/pack_types.hpp
@@ -224,7 +224,7 @@ struct BaseScript
     friend bool operator==(const BaseScript& l, const BaseScript& r) { return l.m_data == r.m_data; }
     friend bool operator!=(const BaseScript& l, const BaseScript& r) { return !(l==r); }
 
-    SERIALIZE_METHODS(BaseScript) { READWRITE(obj.m_data); }
+    C2POOL_SERIALIZE_METHODS(BaseScript) { READWRITE(obj.m_data); }
 };
 
 template <size_t Size>

--- a/src/core/test/pack_test.cpp
+++ b/src/core/test/pack_test.cpp
@@ -80,7 +80,7 @@ struct custom
         return !(*this == c);
     }
 
-    SERIALIZE_METHODS(custom) { READWRITE(obj.m_i, obj.m_str, obj.m_h); }
+    C2POOL_SERIALIZE_METHODS(custom) { READWRITE(obj.m_i, obj.m_str, obj.m_h); }
 };
 
 TEST(Pack, CUSTOM_TYPE)
@@ -341,7 +341,7 @@ struct opt_custom
         return !(*this == c);
     }
 
-    SERIALIZE_METHODS(opt_custom) 
+    C2POOL_SERIALIZE_METHODS(opt_custom) 
     { READWRITE(Optional(obj.m_c, DefaultCustom)); }
     // { formatter.action(stream, Using<OptionalType<DefaultCustom>>(obj.m_c)); }
     // { formatter.action(stream, *obj.m_c); }

--- a/src/impl/bitcoin_family/coin/base_block.hpp
+++ b/src/impl/bitcoin_family/coin/base_block.hpp
@@ -26,7 +26,7 @@ struct SmallBlockHeaderType
     uint32_t m_bits{};
     uint32_t m_nonce{};
 
-    SERIALIZE_METHODS(SmallBlockHeaderType) { READWRITE(VarInt(obj.m_version), obj.m_previous_block, obj.m_timestamp, obj.m_bits, obj.m_nonce); }
+    C2POOL_SERIALIZE_METHODS(SmallBlockHeaderType) { READWRITE(VarInt(obj.m_version), obj.m_previous_block, obj.m_timestamp, obj.m_bits, obj.m_nonce); }
 
     SmallBlockHeaderType() {}
 

--- a/src/impl/bitcoin_family/coin/base_p2p_messages.hpp
+++ b/src/impl/bitcoin_family/coin/base_p2p_messages.hpp
@@ -34,7 +34,7 @@ struct btc_addr_record_t : addr_t
 
     btc_addr_record_t() : addr_t() {}
 
-    SERIALIZE_METHODS(btc_addr_record_t) { READWRITE(obj.m_timestamp, AsBase<addr_t>(obj)); }
+    C2POOL_SERIALIZE_METHODS(btc_addr_record_t) { READWRITE(obj.m_timestamp, AsBase<addr_t>(obj)); }
 };
 
 // message_version
@@ -121,7 +121,7 @@ struct inventory_type
         return (static_cast<uint32_t>(m_type) & MSG_WITNESS_FLAG) != 0;
     }
 
-    SERIALIZE_METHODS(inventory_type) {READWRITE(Using<EnumType<IntType<32>>>(obj.m_type), obj.m_hash);}
+    C2POOL_SERIALIZE_METHODS(inventory_type) {READWRITE(Using<EnumType<IntType<32>>>(obj.m_type), obj.m_hash);}
 };
 
 BEGIN_MESSAGE(inv)
@@ -299,7 +299,7 @@ struct btc_addrv2_record_t
 
     btc_addrv2_record_t() = default;
 
-    SERIALIZE_METHODS(btc_addrv2_record_t)
+    C2POOL_SERIALIZE_METHODS(btc_addrv2_record_t)
     {
         READWRITE(obj.m_time,
                   VarInt(obj.m_services),

--- a/src/impl/bitcoin_family/coin/base_transaction.hpp
+++ b/src/impl/bitcoin_family/coin/base_transaction.hpp
@@ -30,7 +30,7 @@ public:
     uint256 hash;
     uint32_t index;
 
-    SERIALIZE_METHODS(TxPrevOut) { READWRITE(obj.hash, obj.index); }
+    C2POOL_SERIALIZE_METHODS(TxPrevOut) { READWRITE(obj.hash, obj.index); }
 };
 
 class TxIn
@@ -41,7 +41,7 @@ public:
     uint32_t sequence;
     OPScriptWitness scriptWitness; //!< Only serialized through Transaction
 
-    SERIALIZE_METHODS(TxIn) { READWRITE(obj.prevout, obj.scriptSig, obj.sequence); }
+    C2POOL_SERIALIZE_METHODS(TxIn) { READWRITE(obj.prevout, obj.scriptSig, obj.sequence); }
 };
 
 class TxOut
@@ -50,7 +50,7 @@ public:
     int64_t value;
     OPScript scriptPubKey;
 
-    SERIALIZE_METHODS(TxOut) { READWRITE(obj.value, obj.scriptPubKey); }
+    C2POOL_SERIALIZE_METHODS(TxOut) { READWRITE(obj.value, obj.scriptPubKey); }
 };
 
 } // namespace coin

--- a/src/impl/ltc/coin/mweb_builder.hpp
+++ b/src/impl/ltc/coin/mweb_builder.hpp
@@ -22,7 +22,7 @@
 /// macros with a one-argument signature. The two can coexist within a
 /// single translation unit ONLY if:
 ///
-///   1. Every pack.hpp-style `BEGIN_MESSAGE` / `SERIALIZE_METHODS(TYPE)`
+///   1. Every pack.hpp-style `BEGIN_MESSAGE` / `C2POOL_SERIALIZE_METHODS(TYPE)`
 ///      header is included FIRST, so its macros expand against pack.hpp's
 ///      definitions before btclibs swaps them out.
 ///   2. mweb_builder.hpp (this file) comes AFTER those includes.
@@ -31,7 +31,7 @@
 /// message header expands BEGIN_MESSAGE against pack.hpp between there
 /// and line 265, and mweb_builder.hpp itself is included at line 266.
 /// That order is load-bearing — breaking it causes silent macro-binding
-/// errors where later `SERIALIZE_METHODS(TYPE)` calls resolve against
+/// errors where later `C2POOL_SERIALIZE_METHODS(TYPE)` calls resolve against
 /// btclibs's two-argument macro and fail to compile, or worse bind to
 /// btclibs's read/write dispatch and silently corrupt wire format.
 ///

--- a/src/impl/ltc/share_types.hpp
+++ b/src/impl/ltc/share_types.hpp
@@ -75,7 +75,7 @@ struct SegwitData
     SegwitData() {}
     SegwitData(MerkleLink txid_merkle_link, uint256 wtxid) : m_txid_merkle_link(txid_merkle_link), m_wtxid_merkle_root(wtxid) { }
 
-    SERIALIZE_METHODS(SegwitData) { READWRITE(MERKLE_LINK_SMALL(obj.m_txid_merkle_link), obj.m_wtxid_merkle_root); }
+    C2POOL_SERIALIZE_METHODS(SegwitData) { READWRITE(MERKLE_LINK_SMALL(obj.m_txid_merkle_link), obj.m_wtxid_merkle_root); }
 };
 
 struct SegwitDataDefault
@@ -98,7 +98,7 @@ struct TxHashRefs
     TxHashRefs() = default;
     TxHashRefs(uint64_t share, uint64_t tx) : m_share_count(share), m_tx_count(tx) {}
 
-    SERIALIZE_METHODS(TxHashRefs) { READWRITE(VarInt(obj.m_share_count), VarInt(obj.m_tx_count)); }
+    C2POOL_SERIALIZE_METHODS(TxHashRefs) { READWRITE(VarInt(obj.m_share_count), VarInt(obj.m_tx_count)); }
 };
 
 struct ShareTxInfo
@@ -111,7 +111,7 @@ struct ShareTxInfo
     ShareTxInfo(const auto& new_tx_hashes, const auto& tx_hash_refs) 
         : m_new_transaction_hashes(new_tx_hashes), m_transaction_hash_refs(tx_hash_refs) { }
 
-    SERIALIZE_METHODS(ShareTxInfo) { READWRITE(obj.m_new_transaction_hashes, obj.m_transaction_hash_refs); }
+    C2POOL_SERIALIZE_METHODS(ShareTxInfo) { READWRITE(obj.m_new_transaction_hashes, obj.m_transaction_hash_refs); }
 };
 
 struct HashLinkType
@@ -120,7 +120,7 @@ struct HashLinkType
     // FixedStrType<0> m_extra_data; //pack.FixedStrType(0) # bit of a hack, but since the donation script is at the end, const_ending is long enough to always make this empty
     uint64_t m_length;        //pack.VarIntType()
 
-    SERIALIZE_METHODS(HashLinkType) { READWRITE(obj.m_state, /*obj.m_extra_data,*/ VarInt(obj.m_length)); }
+    C2POOL_SERIALIZE_METHODS(HashLinkType) { READWRITE(obj.m_state, /*obj.m_extra_data,*/ VarInt(obj.m_length)); }
 };
 
 // V36 hash link — extra_data becomes VarStr (was FixedStr(0) pre-V36)
@@ -130,7 +130,7 @@ struct V36HashLinkType
     BaseScript m_extra_data;     // VarStr in V36
     uint64_t m_length;
 
-    SERIALIZE_METHODS(V36HashLinkType) { READWRITE(obj.m_state, obj.m_extra_data, VarInt(obj.m_length)); }
+    C2POOL_SERIALIZE_METHODS(V36HashLinkType) { READWRITE(obj.m_state, obj.m_extra_data, VarInt(obj.m_length)); }
 };
 
 // V36 merged mining: per-chain address entry
@@ -139,7 +139,7 @@ struct MergedAddressEntry
     uint32_t m_chain_id;
     BaseScript m_script;
 
-    SERIALIZE_METHODS(MergedAddressEntry) { READWRITE(obj.m_chain_id, obj.m_script); }
+    C2POOL_SERIALIZE_METHODS(MergedAddressEntry) { READWRITE(obj.m_chain_id, obj.m_script); }
 };
 
 // V36 merged mining: per-chain coinbase verification entry

--- a/src/sharechain/share.hpp
+++ b/src/sharechain/share.hpp
@@ -19,7 +19,7 @@ struct RawShare
     RawShare(uint64_t version, BaseScript script) : type(version), contents(script) { }
     RawShare(uint64_t version, PackStream stream) : type(version), contents(stream) { }
 
-    SERIALIZE_METHODS(RawShare) { READWRITE(VarInt(obj.type), obj.contents); }
+    C2POOL_SERIALIZE_METHODS(RawShare) { READWRITE(VarInt(obj.type), obj.contents); }
 };
 
 template <typename HashType, int64_t Version>


### PR DESCRIPTION
## What

Renames the c2pool 1-arg `SERIALIZE_METHODS(TYPE)` macro family to `C2POOL_SERIALIZE_METHODS(TYPE)` to resolve the collision with the vendored btclibs 2-arg `SERIALIZE_METHODS(cls, obj)` (btclibs/serialize.h:186).

## Root cause

The `message_sendaddrv2` Unserialize failure was **not** a missing serializer. After folding 1902d7e7 (pragma-once skip exposed vendored serialize.h), c2pool pack.hpp:256 (1-arg) and vendored btclibs serialize.h:186 (2-arg) defined the same macro name `SERIALIZE_METHODS`, and whichever included last won — breaking the other family. Fix is a clean rename of the c2pool-side macro so the two never collide.

## Changes

12 files, +26/-26. Renamed every c2pool-side 1-arg callsite + the `#define` in pack.hpp. Vendored btclibs (serialize.h, script.h) keeps its own 2-arg `SERIALIZE_METHODS` untouched — that is the point of the rename.

## Verification

- Rebased clean on master 037698da.
- GPG-signed (a56ea9b2).
- Full tree builds; **Linux x86_64 ctest: 590/590 passed, 0 failed (35.3s)**, verified first-hand at this HEAD.
- Re-grep confirms zero stale 1-arg c2pool callsites remain.

Held for operator merge-tap — I do not merge.