### PR TITLE
ci(conan): disable boost cobalt to unblock fresh boost/1.90.0 builds

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -7,6 +7,7 @@ leveldb/1.23
 
 [options]
 boost/*:without_exception=False
+boost/*:without_cobalt=True
 
 [generators]
 CMakeDeps


### PR DESCRIPTION
## What

Add `boost/*:without_cobalt=True` to conanfile.txt [options].

## Why

boost/1.90.0's conan-center recipe fails at `package_info()` with "boost_cobalt_io_ssl built but not used in any boost module" — a deterministic recipe-level module-map regression (not a cache artifact; clearing ~/.conan2 does not help). It breaks **every fresh boost build** across all coin worktrees, since conanfile.txt pins boost/1.90.0 uniformly. This currently blocks btc-heap-opt's critical-path .53 RSS fix from compiling.

## Fix rationale

c2pool uses zero cobalt (grep-clean in src/). `without_cobalt=True` is functionally invisible, keeps boost pinned at 1.90.0 (no version regression), and the recipe auto-generates the `without_<lib>` option. Validated green via a standalone `conan install` carrying the option (install finished successfully).

## Scope

One line in conanfile.txt. CI-behavior change (merge-gate hardening), not cosmetic. Insurance ahead of the V36 window (06-09).

## Merge

Requires operator push-approval — **do not merge** without it.