### PR TITLE
ci(safe-cosmetic): HMAC-authorized, label-gated auto-merge workflow

### DIFF
--- a/.github/workflows/safe-cosmetic-automerge.yml
+++ b/.github/workflows/safe-cosmetic-automerge.yml
@@ -2,7 +2,8 @@ name: SAFE-COSMETIC auto-merge
 
 # Operator-sanctioned exception to the per-push approval rule
 # (operator pick 2026-06-06 13:52 +04, relayed by integrator). Auto-merges a PR
-# carrying the `SAFE-COSMETIC` label once ALL required Linux green contexts pass.
+# carrying the `SAFE-COSMETIC` label once ALL required Linux green contexts pass
+# AND a head-SHA-bound HMAC authorization from the integrator is present.
 # Intended scope: comment / whitespace / doc-only cosmetic changes.
 #
 # SAFETY CONTROLS (all must hold to merge):
@@ -11,6 +12,8 @@ name: SAFE-COSMETIC auto-merge
 #   3. PR base branch == master                       (stated merge target)
 #   4. PR open, not draft
 #   5. Every context in REQUIRED below == success
+#   6. A valid HMAC-SHA256 authorization comment bound to the CURRENT head SHA
+#      (operator-ratified 2026-06-06; see HMAC GATE below). Fail-closed.
 #
 # CHECK-RUN NAME MATCHING — DO NOT "FIX" TO THE UI FORM:
 #   The check-runs REST API returns the BARE job `name:` ("Linux x86_64"), NOT
@@ -19,6 +22,17 @@ name: SAFE-COSMETIC auto-merge
 #   literally "(AsAN+UBSan)" (sic). Both verified against live check-run data on
 #   PR #68 on 2026-06-06. The legacy "BTC embedded smoke (Linux x86_64)" job is
 #   deliberately NOT required here (coin-matrix "btc smoke" is the live gate).
+#
+# HMAC GATE — why head-SHA binding matters:
+#   The integrator posts a PR comment of the EXACT shape:
+#     SAFE-COSMETIC-AUTH: <hmac> head=<head-sha>
+#   where <hmac> = HMAC-SHA256(INTEGRATOR_LABEL_KEY, "<repo>:<pr>:<head-sha>")
+#   as lowercase hex. The workflow recomputes the expected value over the PR's
+#   CURRENT head SHA and only merges if a matching comment exists. Any new push
+#   changes the head SHA and silently invalidates every prior signature, so an
+#   authorization can never be replayed across PRs or across SHAs. The signing
+#   key lives only as the INTEGRATOR_LABEL_KEY Actions secret; this workflow
+#   never emits it.
 
 on:
   check_suite:
@@ -39,11 +53,12 @@ jobs:
   evaluate:
     runs-on: ubuntu-24.04
     steps:
-      - name: Evaluate gate and merge if all required contexts are green
+      - name: Evaluate gate and merge if green and authorized
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           ENABLED: ${{ vars.SAFE_COSMETIC_ENABLED }}
+          INTEGRATOR_LABEL_KEY: ${{ secrets.INTEGRATOR_LABEL_KEY }}
         run: |
           set -euo pipefail
 
@@ -95,11 +110,40 @@ jobs:
               [ "$concl" = "success" ] || ok=0
             done
 
-            if [ "$ok" = "1" ]; then
-              echo "All required contexts green on PR #$PR — merging into $BASE_REQUIRED."
-              gh pr merge "$PR" --repo "$REPO" --merge --delete-branch=false
-            else
-              echo "Gate NOT satisfied for PR #$PR — not merging."
+            if [ "$ok" != "1" ]; then
+              echo "Required contexts not all green for PR #$PR — not merging (waiting)."
+              echo "::endgroup::"
+              continue
             fi
+
+            # --- HMAC authorization gate (operator-ratified 2026-06-06) ---
+            # Only enforced once the PR is otherwise mergeable, so an in-flight
+            # (not-yet-green) PR is never punished for a missing signature. When a
+            # PR IS green but lacks valid authorization bound to the current head,
+            # fail closed: strip the label, post a refusal, and fail the job.
+            if [ -z "${INTEGRATOR_LABEL_KEY:-}" ]; then
+              echo "INTEGRATOR_LABEL_KEY secret unavailable — cannot verify authorization. Fail-closed."
+              exit 1
+            fi
+
+            MSG="$REPO:$PR:$SHA"
+            EXPECTED=$(printf '%s' "$MSG" | openssl dgst -sha256 -hmac "$INTEGRATOR_LABEL_KEY" | awk '{print $NF}')
+            WANT="SAFE-COSMETIC-AUTH: $EXPECTED head=$SHA"
+            echo "  Authorization required for head $SHA (HMAC over \"$MSG\")."
+
+            if gh api "repos/$REPO/issues/$PR/comments" --paginate --jq '.[].body' \
+                 | tr -d '\r' | grep -Fqx "$WANT"; then
+              echo "  Valid SAFE-COSMETIC authorization found for head $SHA — proceeding."
+            else
+              echo "  NO valid authorization comment bound to head $SHA — fail-closed."
+              gh api -X DELETE "repos/$REPO/issues/$PR/labels/$LABEL" >/dev/null 2>&1 || true
+              gh pr comment "$PR" --repo "$REPO" --body \
+                "SAFE-COSMETIC auto-merge refused: no valid integrator authorization bound to head \`$SHA\`. The \`$LABEL\` label has been removed. Re-apply it after the integrator posts a fresh \`SAFE-COSMETIC-AUTH:\` signature for this exact head SHA." || true
+              exit 1
+            fi
+            # --- end HMAC gate ---
+
+            echo "All required contexts green AND authorization valid on PR #$PR — merging into $BASE_REQUIRED."
+            gh pr merge "$PR" --repo "$REPO" --merge --delete-branch=false
             echo "::endgroup::"
           done

--- a/.github/workflows/safe-cosmetic-automerge.yml
+++ b/.github/workflows/safe-cosmetic-automerge.yml
@@ -1,0 +1,105 @@
+name: SAFE-COSMETIC auto-merge
+
+# Operator-sanctioned exception to the per-push approval rule
+# (operator pick 2026-06-06 13:52 +04, relayed by integrator). Auto-merges a PR
+# carrying the `SAFE-COSMETIC` label once ALL required Linux green contexts pass.
+# Intended scope: comment / whitespace / doc-only cosmetic changes.
+#
+# SAFETY CONTROLS (all must hold to merge):
+#   1. Repo variable SAFE_COSMETIC_ENABLED == "true"  (operator kill-switch; fail-closed)
+#   2. PR carries the `SAFE-COSMETIC` label           (applied by integrator only)
+#   3. PR base branch == master                       (stated merge target)
+#   4. PR open, not draft
+#   5. Every context in REQUIRED below == success
+#
+# CHECK-RUN NAME MATCHING — DO NOT "FIX" TO THE UI FORM:
+#   The check-runs REST API returns the BARE job `name:` ("Linux x86_64"), NOT
+#   the "Workflow / Job" form shown in the PR UI ("CI / Linux x86_64"). Matching
+#   the prefixed strings makes the gate silently never fire. The ASan job name is
+#   literally "(AsAN+UBSan)" (sic). Both verified against live check-run data on
+#   PR #68 on 2026-06-06. The legacy "BTC embedded smoke (Linux x86_64)" job is
+#   deliberately NOT required here (coin-matrix "btc smoke" is the live gate).
+
+on:
+  check_suite:
+    types: [completed]
+  pull_request_target:
+    types: [labeled, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+
+concurrency:
+  group: safe-cosmetic-automerge-${{ github.event.pull_request.number || github.event.check_suite.head_sha }}
+  cancel-in-progress: false
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Evaluate gate and merge if all required contexts are green
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ENABLED: ${{ vars.SAFE_COSMETIC_ENABLED }}
+        run: |
+          set -euo pipefail
+
+          if [ "${ENABLED:-}" != "true" ]; then
+            echo "SAFE_COSMETIC_ENABLED != true (kill-switch off) — auto-merge disabled. Exiting."
+            exit 0
+          fi
+
+          LABEL="SAFE-COSMETIC"
+          BASE_REQUIRED="master"
+          REQUIRED=(
+            "Linux x86_64"
+            "Linux x86_64 (AsAN+UBSan)"
+            "ltc smoke (Linux x86_64)"
+            "doge smoke (Linux x86_64)"
+            "dash smoke (Linux x86_64)"
+            "btc smoke (Linux x86_64)"
+          )
+
+          # Candidate PR numbers from whichever event fired.
+          PRS=$(jq -r '[ .pull_request.number, (.check_suite.pull_requests[]?.number) ] | map(select(. != null)) | unique | .[]' "$GITHUB_EVENT_PATH")
+          if [ -z "${PRS:-}" ]; then
+            echo "No candidate PRs in event payload — nothing to do."
+            exit 0
+          fi
+
+          for PR in $PRS; do
+            echo "::group::Evaluating PR #$PR"
+            META=$(gh api "repos/$REPO/pulls/$PR" --jq '{state:.state, draft:.draft, base:.base.ref, sha:.head.sha, labels:[.labels[].name]}')
+            STATE=$(jq -r '.state' <<<"$META")
+            DRAFT=$(jq -r '.draft' <<<"$META")
+            BASE=$(jq  -r '.base'  <<<"$META")
+            SHA=$(jq   -r '.sha'   <<<"$META")
+            HAS_LABEL=$(jq -r --arg L "$LABEL" 'any(.labels[]; . == $L)' <<<"$META")
+
+            [ "$STATE" = "open" ]          || { echo "PR not open — skip.";                echo "::endgroup::"; continue; }
+            [ "$DRAFT" = "false" ]         || { echo "PR is draft — skip.";                echo "::endgroup::"; continue; }
+            [ "$HAS_LABEL" = "true" ]      || { echo "No $LABEL label — skip.";            echo "::endgroup::"; continue; }
+            [ "$BASE" = "$BASE_REQUIRED" ] || { echo "Base $BASE != $BASE_REQUIRED — out of scope, skip."; echo "::endgroup::"; continue; }
+
+            RUNS=$(gh api "repos/$REPO/commits/$SHA/check-runs" --paginate \
+                   --jq '.check_runs[] | "\(.name)\t\(.conclusion)"')
+
+            ok=1
+            for ctx in "${REQUIRED[@]}"; do
+              concl=$(awk -F'\t' -v c="$ctx" '$1==c {print $2; exit}' <<<"$RUNS" || true)
+              if [ -z "$concl" ]; then echo "  MISSING required context: $ctx"; ok=0; continue; fi
+              echo "  $ctx => $concl"
+              [ "$concl" = "success" ] || ok=0
+            done
+
+            if [ "$ok" = "1" ]; then
+              echo "All required contexts green on PR #$PR — merging into $BASE_REQUIRED."
+              gh pr merge "$PR" --repo "$REPO" --merge --delete-branch=false
+            else
+              echo "Gate NOT satisfied for PR #$PR — not merging."
+            fi
+            echo "::endgroup::"
+          done


### PR DESCRIPTION
Adds the operator-sanctioned SAFE-COSMETIC auto-merge workflow with a head-SHA-bound HMAC authorization gate (operator-ratified 2026-06-06).

## Gate (all must hold to merge)
1. `SAFE_COSMETIC_ENABLED` repo variable == `true` — operator kill-switch, fail-closed.
2. PR carries the `SAFE-COSMETIC` label.
3. PR base == `master` (STRICT).
4. PR open, not draft.
5. All required Linux contexts green (bare check-run names; `(AsAN+UBSan)` literal): `Linux x86_64`, `Linux x86_64 (AsAN+UBSan)`, plus `ltc/doge/dash/btc smoke (Linux x86_64)`.
6. Valid integrator HMAC authorization bound to the current head SHA.

## HMAC authorization
The integrator posts a comment of the exact shape:

    SAFE-COSMETIC-AUTH: <hmac> head=<head-sha>

where `<hmac> = HMAC-SHA256(INTEGRATOR_LABEL_KEY, "<repo>:<pr>:<head-sha>")` lowercase hex. The workflow recomputes the expected value over the PRs current head and merges only on an exact full-line match. A new push changes the head SHA and silently invalidates any prior signature — authorizations cannot be replayed across PRs or SHAs. The key lives only as the `INTEGRATOR_LABEL_KEY` Actions secret and is never emitted.

Enforced only once a PR is otherwise green; on a green PR lacking valid authorization the gate fails closed (strips the label, posts a refusal, fails the job).

Merge remains operator push-approval gated.