### PR TITLE
ci(coin-matrix): add dgb and bch smoke jobs

### DIFF
--- a/.github/workflows/coin-matrix.yml
+++ b/.github/workflows/coin-matrix.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        coin: [ltc, doge, dash, btc]
+        coin: [ltc, doge, dash, btc, dgb, bch]
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Adds `dgb smoke (Linux x86_64)` and `bch smoke (Linux x86_64)` to the coin matrix so all five release coins have CI coverage, per integrator dispatch 2026-06-10.

Both cells are presence-gated (`src/c2pool/main_<coin>.cpp` + `src/impl/<coin>`) — they no-op on every ref until dgb-scrypt-steward (#70 ICoinNode) and bch-embedded (M3) land their entrypoint splits, then activate automatically with no further YAML change. Landing this now means zero timing coordination: their first linking binary gets smoke coverage on its own PR.

One-line matrix change; no behavior change for ltc/doge/dash/btc.

**Merge is gated on operator push-approval — do not merge.**