### PR TITLE
btc: SERIALIZE macro fix (C2POOL_SERIALIZE_METHODS, PR#71 lockstep) [PR-B/3]

### DIFF
--- a/src/impl/btc/coin/block.hpp
+++ b/src/impl/btc/coin/block.hpp
@@ -20,7 +20,7 @@ struct SmallBlockHeaderType
     uint32_t m_bits{};
     uint32_t m_nonce{};
 
-    SERIALIZE_METHODS(SmallBlockHeaderType) { READWRITE(VarInt(obj.m_version), obj.m_previous_block, obj.m_timestamp, obj.m_bits, obj.m_nonce); }
+    C2POOL_SERIALIZE_METHODS(SmallBlockHeaderType) { READWRITE(VarInt(obj.m_version), obj.m_previous_block, obj.m_timestamp, obj.m_bits, obj.m_nonce); }
 
     SmallBlockHeaderType() {}
 

--- a/src/impl/btc/coin/p2p_messages.hpp
+++ b/src/impl/btc/coin/p2p_messages.hpp
@@ -27,7 +27,7 @@ struct btc_addr_record_t : addr_t
 
     btc_addr_record_t() : addr_t() {}
 
-    SERIALIZE_METHODS(btc_addr_record_t) { READWRITE(obj.m_timestamp, AsBase<addr_t>(obj)); }
+    C2POOL_SERIALIZE_METHODS(btc_addr_record_t) { READWRITE(obj.m_timestamp, AsBase<addr_t>(obj)); }
 };
 //[+] void handle_message_tx(std::shared_ptr<coind::messages::message_tx> msg, CoindProtocol* protocol); //
 //[+] void handle_message_block(std::shared_ptr<coind::messages::message_block> msg, CoindProtocol* protocol); //
@@ -118,7 +118,7 @@ struct inventory_type
         return (static_cast<uint32_t>(m_type) & MSG_WITNESS_FLAG) != 0;
     }
 
-    SERIALIZE_METHODS(inventory_type) {READWRITE(Using<EnumType<IntType<32>>>(obj.m_type), obj.m_hash);}
+    C2POOL_SERIALIZE_METHODS(inventory_type) {READWRITE(Using<EnumType<IntType<32>>>(obj.m_type), obj.m_hash);}
 };
 
 BEGIN_MESSAGE(inv)

--- a/src/impl/btc/coin/transaction.hpp
+++ b/src/impl/btc/coin/transaction.hpp
@@ -28,7 +28,7 @@ public:
     uint256 hash;
     uint32_t index;
 
-    SERIALIZE_METHODS(TxPrevOut) { READWRITE(obj.hash, obj.index); }
+    C2POOL_SERIALIZE_METHODS(TxPrevOut) { READWRITE(obj.hash, obj.index); }
 };
 
 class TxIn
@@ -39,7 +39,7 @@ public:
     uint32_t sequence;
     OPScriptWitness scriptWitness; //!< Only serialized through Transaction
 
-    SERIALIZE_METHODS(TxIn) { READWRITE(obj.prevout, obj.scriptSig, obj.sequence); }
+    C2POOL_SERIALIZE_METHODS(TxIn) { READWRITE(obj.prevout, obj.scriptSig, obj.sequence); }
 };
 
 class TxOut
@@ -48,7 +48,7 @@ public:
     int64_t value;
     OPScript scriptPubKey;
 
-    SERIALIZE_METHODS(TxOut) { READWRITE(obj.value, obj.scriptPubKey); }
+    C2POOL_SERIALIZE_METHODS(TxOut) { READWRITE(obj.value, obj.scriptPubKey); }
 };
 
 class Transaction

--- a/src/impl/btc/share_types.hpp
+++ b/src/impl/btc/share_types.hpp
@@ -75,7 +75,7 @@ struct SegwitData
     SegwitData() {}
     SegwitData(MerkleLink txid_merkle_link, uint256 wtxid) : m_txid_merkle_link(txid_merkle_link), m_wtxid_merkle_root(wtxid) { }
 
-    SERIALIZE_METHODS(SegwitData) { READWRITE(MERKLE_LINK_SMALL(obj.m_txid_merkle_link), obj.m_wtxid_merkle_root); }
+    C2POOL_SERIALIZE_METHODS(SegwitData) { READWRITE(MERKLE_LINK_SMALL(obj.m_txid_merkle_link), obj.m_wtxid_merkle_root); }
 };
 
 struct SegwitDataDefault
@@ -98,7 +98,7 @@ struct TxHashRefs
     TxHashRefs() = default;
     TxHashRefs(uint64_t share, uint64_t tx) : m_share_count(share), m_tx_count(tx) {}
 
-    SERIALIZE_METHODS(TxHashRefs) { READWRITE(VarInt(obj.m_share_count), VarInt(obj.m_tx_count)); }
+    C2POOL_SERIALIZE_METHODS(TxHashRefs) { READWRITE(VarInt(obj.m_share_count), VarInt(obj.m_tx_count)); }
 };
 
 struct ShareTxInfo
@@ -111,7 +111,7 @@ struct ShareTxInfo
     ShareTxInfo(const auto& new_tx_hashes, const auto& tx_hash_refs) 
         : m_new_transaction_hashes(new_tx_hashes), m_transaction_hash_refs(tx_hash_refs) { }
 
-    SERIALIZE_METHODS(ShareTxInfo) { READWRITE(obj.m_new_transaction_hashes, obj.m_transaction_hash_refs); }
+    C2POOL_SERIALIZE_METHODS(ShareTxInfo) { READWRITE(obj.m_new_transaction_hashes, obj.m_transaction_hash_refs); }
 };
 
 struct HashLinkType
@@ -120,7 +120,7 @@ struct HashLinkType
     // FixedStrType<0> m_extra_data; //pack.FixedStrType(0) # bit of a hack, but since the donation script is at the end, const_ending is long enough to always make this empty
     uint64_t m_length;        //pack.VarIntType()
 
-    SERIALIZE_METHODS(HashLinkType) { READWRITE(obj.m_state, /*obj.m_extra_data,*/ VarInt(obj.m_length)); }
+    C2POOL_SERIALIZE_METHODS(HashLinkType) { READWRITE(obj.m_state, /*obj.m_extra_data,*/ VarInt(obj.m_length)); }
 };
 
 // V36 hash link — extra_data becomes VarStr (was FixedStr(0) pre-V36)
@@ -130,7 +130,7 @@ struct V36HashLinkType
     BaseScript m_extra_data;     // VarStr in V36
     uint64_t m_length;
 
-    SERIALIZE_METHODS(V36HashLinkType) { READWRITE(obj.m_state, obj.m_extra_data, VarInt(obj.m_length)); }
+    C2POOL_SERIALIZE_METHODS(V36HashLinkType) { READWRITE(obj.m_state, obj.m_extra_data, VarInt(obj.m_length)); }
 };
 
 // V36 merged mining: per-chain address entry
@@ -139,7 +139,7 @@ struct MergedAddressEntry
     uint32_t m_chain_id;
     BaseScript m_script;
 
-    SERIALIZE_METHODS(MergedAddressEntry) { READWRITE(obj.m_chain_id, obj.m_script); }
+    C2POOL_SERIALIZE_METHODS(MergedAddressEntry) { READWRITE(obj.m_chain_id, obj.m_script); }
 };
 
 // V36 merged mining: per-chain coinbase verification entry


### PR DESCRIPTION
## PR-B of 3 — btc SERIALIZE macro fix (btc-only)

Renames the single-arg `SERIALIZE_METHODS` -> `C2POOL_SERIALIZE_METHODS` in the
btc variant, in lockstep with PR#71 which removed the no-arg alias. Fixes the
btc compile break at `src/impl/btc/coin/transaction.hpp:51`; btc now builds
through to the LINK stage.

### Scope (per-coin isolation invariant)
Touches `src/impl/btc/` ONLY — 4 files:
- `src/impl/btc/coin/block.hpp`
- `src/impl/btc/coin/p2p_messages.hpp`
- `src/impl/btc/coin/transaction.hpp`
- `src/impl/btc/share_types.hpp`

No `src/core`, no `src/impl/ltc`. Does NOT make any smoke green on its own:
btc smoke is still RED at LINK because `core/web_server.cpp` is hard-typed to
`ltc::coin::NodeRPC`. That is cleared by PR-C (web_server -> `core::coin::ICoinNode`
retype), which binds to the ltc concrete CoinNode added in PR-A.

### Sequence
- PR-A (ltc-doge): additive ltc concrete CoinNode — the gate PR-C binds to.
- **PR-B (this): btc serialize fix.**
- PR-C (me): web_server retype + caller updates — the green-gate, folds onto
  this branch after PR-A lands on master.

Not requesting a standalone merge; batch with PR-C per integrator.
