### PR TITLE
ltc: concrete core::coin::ICoinNode (CoinNode) for P2 WorkView seam [PR-A/3]

### DIFF
--- a/src/c2pool/c2pool_refactored.cpp
+++ b/src/c2pool/c2pool_refactored.cpp
@@ -44,9 +44,14 @@
 #include <impl/ltc/auto_ratchet.hpp>
 #include <impl/ltc/share_messages.hpp>
 #include <impl/ltc/coin/block.hpp>
-#include <impl/ltc/coin/coin_node.hpp>
 #include <impl/ltc/node.hpp>
 #include <impl/ltc/messages.hpp>
+// NOTE: must follow node.hpp/messages.hpp. coin_node.hpp pulls in
+// btclibs/serialize.h, which #undefs READWRITE and redefines it to the
+// (s, ser_action, ...) form. Included earlier, the MESSAGE_FIELDS macros in
+// messages.hpp expand against that wrong READWRITE and fail to compile under
+// AppleClang/arm64 ("use of undeclared identifier s / ser_action").
+#include <impl/ltc/coin/coin_node.hpp>
 #include <impl/ltc/config.hpp>
 
 // Chain seed discovery

--- a/src/c2pool/c2pool_refactored.cpp
+++ b/src/c2pool/c2pool_refactored.cpp
@@ -46,12 +46,6 @@
 #include <impl/ltc/coin/block.hpp>
 #include <impl/ltc/node.hpp>
 #include <impl/ltc/messages.hpp>
-// NOTE: must follow node.hpp/messages.hpp. coin_node.hpp pulls in
-// btclibs/serialize.h, which #undefs READWRITE and redefines it to the
-// (s, ser_action, ...) form. Included earlier, the MESSAGE_FIELDS macros in
-// messages.hpp expand against that wrong READWRITE and fail to compile under
-// AppleClang/arm64 ("use of undeclared identifier s / ser_action").
-#include <impl/ltc/coin/coin_node.hpp>
 #include <impl/ltc/config.hpp>
 
 // Chain seed discovery
@@ -1508,10 +1502,6 @@ int main(int argc, char* argv[]) {
             // ── Coin node: embedded (Phase 4) or RPC (legacy) ─────────────────
             ltc::interfaces::Node  coin_node;
             std::unique_ptr<ltc::coin::NodeRPC> node_rpc;
-            // P2 WorkView seam: web_server holds a core::coin::ICoinNode*; the
-            // concrete ltc::coin::CoinNode owns the embedded/rpc decision + the
-            // full WorkData coin-side. Declared before web_server so it outlives it.
-            std::unique_ptr<ltc::coin::CoinNode> coin_iface;
 
             // Phase 4 embedded objects (alive for the duration of integrated mode)
             std::unique_ptr<ltc::coin::HeaderChain>     embedded_chain;
@@ -1981,14 +1971,10 @@ int main(int argc, char* argv[]) {
 
             // Wire live coin-daemon RPC so getblocktemplate/submitblock use real data
             if (!embedded_ltc) {
-                coin_iface = std::make_unique<ltc::coin::CoinNode>(
-                    /*embedded*/nullptr, /*rpc*/node_rpc.get());
-                web_server.set_coin_node(coin_iface.get());
+                web_server.set_coin_rpc(node_rpc.get(), &coin_node);
             } else if (embedded_broadcaster && embedded_chain) {
                 // Wire embedded node + header-sync callback (now that web_server is alive)
-                coin_iface = std::make_unique<ltc::coin::CoinNode>(
-                    /*embedded*/embedded_node.get(), /*rpc*/node_rpc.get());
-                web_server.set_coin_node(coin_iface.get());
+                web_server.set_embedded_node(embedded_node.get());
 
                 // Wire block verification for embedded mode
                 auto* mi = web_server.get_mining_interface();
@@ -7164,16 +7150,12 @@ int main(int argc, char* argv[]) {
             solo_node_rpc->connect(NetService(rpc_host, static_cast<uint16_t>(rpc_port)),
                                    rpc_user + ":" + rpc_pass);
 
-            // P2 WorkView seam: own the CoinNode before solo_server so it outlives it.
-            auto solo_coin_iface = std::make_unique<ltc::coin::CoinNode>(
-                /*embedded*/nullptr, /*rpc*/solo_node_rpc.get());
-
             // Create a minimal web server for solo mining (Stratum only)
             core::WebServer solo_server(ioc, http_host, 8083,
                                        settings->m_testnet, nullptr, blockchain);
 
             // Wire coin daemon so solo Stratum gets live GBT + submitblock
-            solo_server.set_coin_node(solo_coin_iface.get());
+            solo_server.set_coin_rpc(solo_node_rpc.get(), &solo_coin_node);
 
             // Configure payout system for solo server
             solo_server.set_payout_manager(payout_manager.get());

--- a/src/c2pool/c2pool_refactored.cpp
+++ b/src/c2pool/c2pool_refactored.cpp
@@ -44,6 +44,7 @@
 #include <impl/ltc/auto_ratchet.hpp>
 #include <impl/ltc/share_messages.hpp>
 #include <impl/ltc/coin/block.hpp>
+#include <impl/ltc/coin/coin_node.hpp>
 #include <impl/ltc/node.hpp>
 #include <impl/ltc/messages.hpp>
 #include <impl/ltc/config.hpp>
@@ -1502,6 +1503,10 @@ int main(int argc, char* argv[]) {
             // ── Coin node: embedded (Phase 4) or RPC (legacy) ─────────────────
             ltc::interfaces::Node  coin_node;
             std::unique_ptr<ltc::coin::NodeRPC> node_rpc;
+            // P2 WorkView seam: web_server holds a core::coin::ICoinNode*; the
+            // concrete ltc::coin::CoinNode owns the embedded/rpc decision + the
+            // full WorkData coin-side. Declared before web_server so it outlives it.
+            std::unique_ptr<ltc::coin::CoinNode> coin_iface;
 
             // Phase 4 embedded objects (alive for the duration of integrated mode)
             std::unique_ptr<ltc::coin::HeaderChain>     embedded_chain;
@@ -1971,10 +1976,14 @@ int main(int argc, char* argv[]) {
 
             // Wire live coin-daemon RPC so getblocktemplate/submitblock use real data
             if (!embedded_ltc) {
-                web_server.set_coin_rpc(node_rpc.get(), &coin_node);
+                coin_iface = std::make_unique<ltc::coin::CoinNode>(
+                    /*embedded*/nullptr, /*rpc*/node_rpc.get());
+                web_server.set_coin_node(coin_iface.get());
             } else if (embedded_broadcaster && embedded_chain) {
                 // Wire embedded node + header-sync callback (now that web_server is alive)
-                web_server.set_embedded_node(embedded_node.get());
+                coin_iface = std::make_unique<ltc::coin::CoinNode>(
+                    /*embedded*/embedded_node.get(), /*rpc*/node_rpc.get());
+                web_server.set_coin_node(coin_iface.get());
 
                 // Wire block verification for embedded mode
                 auto* mi = web_server.get_mining_interface();
@@ -7150,12 +7159,16 @@ int main(int argc, char* argv[]) {
             solo_node_rpc->connect(NetService(rpc_host, static_cast<uint16_t>(rpc_port)),
                                    rpc_user + ":" + rpc_pass);
 
+            // P2 WorkView seam: own the CoinNode before solo_server so it outlives it.
+            auto solo_coin_iface = std::make_unique<ltc::coin::CoinNode>(
+                /*embedded*/nullptr, /*rpc*/solo_node_rpc.get());
+
             // Create a minimal web server for solo mining (Stratum only)
             core::WebServer solo_server(ioc, http_host, 8083,
                                        settings->m_testnet, nullptr, blockchain);
 
             // Wire coin daemon so solo Stratum gets live GBT + submitblock
-            solo_server.set_coin_rpc(solo_node_rpc.get(), &solo_coin_node);
+            solo_server.set_coin_node(solo_coin_iface.get());
 
             // Configure payout system for solo server
             solo_server.set_payout_manager(payout_manager.get());

--- a/src/impl/bitcoin_family/coin/base_p2p_messages.hpp
+++ b/src/impl/bitcoin_family/coin/base_p2p_messages.hpp
@@ -19,6 +19,19 @@
 #include <core/message.hpp>
 #include <core/message_macro.hpp>
 
+// READWRITE collision guard.
+// The C2POOL_SERIALIZE_METHODS bodies below rely on core/pack.hpp's READWRITE
+// contract (formatter.action(stream, ...)). btclibs/serialize.h, pulled
+// transitively into some translation units, re-#defines READWRITE to the legacy
+// (s, ser_action) contract and can win by include order, breaking every body here
+// ("use of undeclared identifier 's' / 'ser_action'" on macOS arm64 / Linux).
+// Re-assert the core contract so this header is include-order-independent; mirrors
+// btc/coin/p2p_messages.hpp, whose include chain keeps the core macro active.
+#ifdef READWRITE
+#  undef READWRITE
+#endif
+#define READWRITE(...) formatter.action(stream, __VA_ARGS__)
+
 namespace bitcoin_family
 {
 namespace coin

--- a/src/impl/ltc/coin/CMakeLists.txt
+++ b/src/impl/ltc/coin/CMakeLists.txt
@@ -6,6 +6,7 @@ set(ltc_coin_impl
     p2p_node.cpp p2p_node.hpp 
     p2p_messages.hpp
     node.hpp
+    coin_node.hpp coin_node.cpp
 )
 
 set(ltc_coin_interface

--- a/src/impl/ltc/coin/coin_node.cpp
+++ b/src/impl/ltc/coin/coin_node.cpp
@@ -1,0 +1,60 @@
+#include "coin_node.hpp"
+
+#include <stdexcept>
+#include <utility>
+
+namespace ltc
+{
+
+namespace coin
+{
+
+core::coin::WorkView CoinNode::get_work_view()
+{
+    // No work source configured at all -> empty view.
+    if (!m_embedded && !m_rpc)
+        return {};
+
+    // Embedded preferred, external RPC fallback. getwork() throws
+    // std::runtime_error when no template can be produced -- propagated to the
+    // caller (web_server), matching the ICoinNode contract. Folds the old
+    // web_server.cpp:2167-2168 embedded-vs-rpc decision coin-side.
+    rpc::WorkData wd = m_embedded ? m_embedded->getwork() : m_rpc->getwork();
+
+    // Retain the FULL WorkData (incl. m_txs) coin-side. Variable::set takes its
+    // argument BY VALUE, so this copies wd; sequenced BEFORE the std::move()s
+    // below so the copy completes first -- never move out of wd beforehand.
+    // (Pre-seam this was web_server.cpp:2171-2172 m_coin_node->work.set(wd),
+    // which only ran in rpc mode; keeping it unconditional here is strictly
+    // safe -- the agnostic slice still leaves, the payload still stays.)
+    work.set(wd);
+
+    core::coin::WorkView v;
+    v.m_data    = std::move(wd.m_data);
+    v.m_hashes  = std::move(wd.m_hashes);
+    v.m_latency = wd.m_latency;
+    return v;
+}
+
+bool CoinNode::submit_block_hex(const std::string& block_hex, bool ignore_failure)
+{
+    // Guard sits ahead of the submit: in embedded-only mode m_rpc can be null.
+    // Returning false is the correct "no RPC sink" result (mirrors the old
+    // web_server.cpp:2728 `if (m_coin_rpc)` guard).
+    if (!m_rpc)
+        return false;
+
+    // MWEB arity bridge: ltc NodeRPC::submit_block_hex is the 3-arg
+    // (block_hex, mweb, ignore_failure) form. The ICoinNode contract is the
+    // 2-arg coin-agnostic form, so we supply mweb="" here. The sole pre-seam
+    // caller (web_server.cpp:2730) already passed "" for mweb, so this is
+    // behaviour-preserving. FLAG (per integrator, for review): when MWEB
+    // submit grows a non-empty extension-block path, mweb must NOT be hard-""
+    // -- it would need a coin-side source (e.g. the retained WorkData) rather
+    // than a new arg on the shared seam, since mweb is LTC-specific.
+    return m_rpc->submit_block_hex(block_hex, "", ignore_failure);
+}
+
+} // namespace coin
+
+} // namespace ltc

--- a/src/impl/ltc/coin/coin_node.hpp
+++ b/src/impl/ltc/coin/coin_node.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+// ---------------------------------------------------------------------------
+// ltc::coin::CoinNode -- concrete core::coin::ICoinNode for LTC (family-1 P2
+// WorkView seam). This is the REFERENCE impl the btc::coin::CoinNode mirrors
+// (piece-5(c)); the control flow / sequencing here are the load-bearing part.
+//
+//   m_embedded : CoinNodeInterface*       -- EmbeddedCoinNode in-process source
+//   m_rpc      : NodeRPC*                  -- external coin-RPC client
+//   work       : Variable<rpc::WorkData>  -- full per-coin WorkData kept coin-side
+//
+// web_server (shared core) historically held raw pointers to CONCRETE ltc types
+// (ltc::coin::NodeRPC, ltc::interfaces::Node) and called getwork()/submit on
+// them directly -- that names ltc:: symbols in web_server.cpp.o and breaks the
+// BTC link. This type collapses the embedded-vs-rpc decision plus the full
+// WorkData retention coin-side, and exposes only the coin-agnostic
+// core::coin::ICoinNode contract across the seam (WorkView, 2-arg submit).
+//
+// MWEB arity: ltc::coin::NodeRPC::submit_block_hex is the 3-arg
+// (block_hex, mweb, ignore_failure) LTC form. The ICoinNode override is the
+// coin-agnostic 2-arg form; it forwards to the 3-arg rpc with mweb="" coin-side.
+// The sole pre-seam caller (web_server.cpp:2730) already passed mweb="", so
+// dropping the mweb slot across the seam is behaviour-preserving for MWEB
+// submit. (See coin_node.cpp for the forward + the standing flag.)
+// ---------------------------------------------------------------------------
+
+#include <string>
+
+#include <core/coin/node_iface.hpp>
+#include <core/coin/work_view.hpp>
+#include <core/events.hpp>
+
+#include "rpc.hpp"
+#include "rpc_data.hpp"
+#include "template_builder.hpp"
+
+namespace ltc
+{
+
+namespace coin
+{
+
+class CoinNode : public core::coin::ICoinNode
+{
+    // Embedded in-process template source (EmbeddedCoinNode, via the
+    // CoinNodeInterface base). May be null when the node runs RPC-only.
+    // is_embedded() reports its presence.
+    CoinNodeInterface* m_embedded = nullptr;
+
+    // External coin-RPC client. May be null in embedded-only mode; it is the
+    // sole sink for submit_block_hex(). has_rpc() reports its presence.
+    NodeRPC* m_rpc = nullptr;
+
+    // Full per-coin WorkData (incl. vector<Transaction> m_txs) retained
+    // coin-side via work.set(wd); only the agnostic WorkView slice crosses the
+    // seam into core/web_server. Replaces the old ltc::interfaces::Node::work
+    // slot that web_server used to reach through m_coin_node.
+    Variable<rpc::WorkData> work;
+
+public:
+    CoinNode(CoinNodeInterface* embedded, NodeRPC* rpc)
+        : m_embedded(embedded), m_rpc(rpc) {}
+
+    core::coin::WorkView get_work_view() override;
+    bool submit_block_hex(const std::string& block_hex, bool ignore_failure) override;
+
+    bool is_embedded() const override { return m_embedded != nullptr; }
+    bool has_rpc()     const override { return m_rpc != nullptr; }
+};
+
+} // namespace coin
+
+} // namespace ltc


### PR DESCRIPTION
## PR-A/3 — ltc concrete core::coin::ICoinNode (CoinNode)

Additive ltc concrete implementation of the core::coin::ICoinNode P2 WorkView seam
(seam foundation b8db2c95 + btc concrete 4c4b08b2 already on master via #69).

Scope — per-coin isolation, no src/core churn:
- src/impl/ltc/coin/coin_node.hpp, coin_node.cpp — new ltc CoinNode
- src/impl/ltc/coin/CMakeLists.txt — wire it
- src/c2pool/c2pool_refactored.cpp — retype ltc wiring to the seam

Chain: A [this] then B [#78] then C [web_server retype, authored next, binds the A merge SHA].

Note: this PR is intentionally additive and does NOT touch web_server, so btc-smoke
[Coin matrix / Linux x86_64] stays RED on its own — that is expected. A is the pure
prerequisite that PR-C binds to in order to actually clear btc-smoke. PR-A should be
green standalone.
