### PR TITLE
dgb: v36 donation version-gate (pillar 4 of modern-layer activation)

### DIFF
--- a/src/impl/dgb/config_pool.hpp
+++ b/src/impl/dgb/config_pool.hpp
@@ -69,8 +69,28 @@ public:
     }
 
     // -----------------------------------------------------------------------
-    // Donation scripts — DGB p2pool uses the same c2pool dev key as LTC
+    // Donation scripts — version-gated migration (pillar 4)
+    //   pre-V36 : farsider350 2-of-3 bare multisig (DGB v35 canonical donation)
+    //   V36+    : shared COMBINED P2SH 1-of-2 (byte-identical to LTC network)
+    // get_donation_script(version) selects per share version, matching the
+    // donation transition in p2pool-merged-v36. Source of truth for the v35
+    // bytes: farsider350 p2pool-dgb-scrypt-350 p2pool/data.py:66 DONATION_SCRIPT.
     // -----------------------------------------------------------------------
+
+    // Pre-V36 DONATION_SCRIPT (OP_2 <3x33B pubkey> OP_3 OP_CHECKMULTISIG)
+    static constexpr std::array<uint8_t, 105> DONATION_SCRIPT = {
+        0x52,                                   // OP_2
+        0x21, 0x02, 0xd9, 0x22, 0x34, 0x77, 0x7b, 0x63,  // push33 pubkey 1
+              0xf6, 0xdb, 0xc0, 0xa0, 0x38, 0x2b, 0xbc, 0xb5, 0x4e, 0x0b, 0xef, 0xb0, 0x1f, 0x6a, 0x4b, 0x06,
+              0x21, 0x22, 0xfa, 0xda, 0xb0, 0x44, 0xaf, 0x6c, 0x06, 0x88,
+        0x21, 0x03, 0xb2, 0x7b, 0xbc, 0x50, 0x19, 0xd3,  // push33 pubkey 2
+              0x54, 0x35, 0x86, 0x48, 0x2a, 0x99, 0x5e, 0x8f, 0x57, 0xc6, 0xad, 0x50, 0x6a, 0x4d, 0xaf, 0xa6,
+              0xbf, 0x7c, 0xc8, 0x95, 0x33, 0xb8, 0xdc, 0xb2, 0xdf, 0x1b,
+        0x21, 0x02, 0x91, 0x1f, 0xf8, 0x7e, 0x79, 0x2e,  // push33 pubkey 3
+              0xc7, 0x5b, 0x3a, 0x30, 0xdc, 0x11, 0x5d, 0xfd, 0x06, 0xec, 0x27, 0xc9, 0x3b, 0x27, 0x03, 0x4a,
+              0xa8, 0xe7, 0xce, 0xfb, 0xee, 0x64, 0x77, 0xe5, 0xd0, 0x34,
+        0x53, 0xae                              // OP_3 OP_CHECKMULTISIG
+    };
 
     // V36+ combined donation (P2SH 1-of-2 multisig, same as LTC network)
     static constexpr std::array<uint8_t, 23> COMBINED_DONATION_SCRIPT = {
@@ -83,7 +103,9 @@ public:
 
     static std::vector<unsigned char> get_donation_script(int64_t share_version)
     {
-        return {COMBINED_DONATION_SCRIPT.begin(), COMBINED_DONATION_SCRIPT.end()};
+        if (share_version >= 36)
+            return {COMBINED_DONATION_SCRIPT.begin(), COMBINED_DONATION_SCRIPT.end()};
+        return {DONATION_SCRIPT.begin(), DONATION_SCRIPT.end()};
     }
 
     // P2Pool network framing (from p2pool-merged-v36/p2pool/networks/digibyte.py)


### PR DESCRIPTION
## Scope: pillar 4 (donation migration) only — pillar 1 has no activation surface yet

This PR lands the one part of the v36 modern-layer activation that has a real,
isolated surface in `src/impl/dgb/` today: the **version-gated donation script**.

### What changed (`src/impl/dgb/config_pool.hpp`, additive, header-only)
- Add the pre-V36 `DONATION_SCRIPT` (105-byte OP_2 / 3x33B pubkey / OP_3
  OP_CHECKMULTISIG bare multisig). Bytes are the **DGB v35 canonical** donation
  from farsider350 `p2pool-dgb-scrypt-350` `p2pool/data.py:66` — generated
  programmatically from the verified hex, not hand-transcribed.
- Gate `get_donation_script(version)`: `>=36` -> shared `COMBINED` P2SH 1-of-2
  (byte-identical to LTC); `<36` -> the farsider350 2-of-3.

Previously `get_donation_script()` ignored the version and always returned
COMBINED — DGB was **missing its pre-V36 donation entirely**. The DGB v35 form is
the 2-of-3 multisig, **not** the LTC/BTC P2PK form, so this migration is
DGB-specific. Constants confirmed against the directive + operator-confirmed scope.

### Why pillar 1 (version-voting / AutoRatchet) is NOT in this PR
Mirroring BTC #81 presumes a modern sharechain stack that **DGB does not have yet**:
- no `src/c2pool/main_dgb.cpp` (only `c2pool-btc` is an executable target)
- no `src/impl/dgb/auto_ratchet.hpp`
- no `src/impl/dgb/share_check.hpp` / `share_tracker.hpp`
- no `src/impl/dgb/stratum/work_source.{hpp,cpp}`

There are **zero hardcoded `share_version=35` sites** to replace because DGB has
no share-creation/gentx path. Pillar 1 activation first requires porting the LTC
modern layer (~6.8K LOC) into `src/impl/dgb/` + creating `main_dgb.cpp` + a
`c2pool-dgb` executable target. That is multi-day work (overlaps M3 Phase C),
surfaced to integrator as a discovery/scope decision — not foldable into a
short-turn activation PR.

### Pillars 2/3
Both **absent** (not present-inert): no DensePPLNSRing, no anti-hop — the
share_tracker/PPLNS layer is unported.

### Boundary / safety
- `src/impl/dgb/` only. Did NOT touch `share_check.hpp` F10, ltc/, or core.
- GPG-signed, no third-party attribution. Build-inert (skeleton dormant; nothing
  calls `get_donation_script` until the gentx path lands).
- **Preflight waiver**: `c2pool-preflight.sh` exits RED on pre-existing
  `src/impl/doge/coin/*` -> `impl/ltc/coin/*` cross-coin includes (shared DOGE-aux
  module, not my domain) + a core `sharechain.hpp` iterator WARN. None touch this
  diff, which only adds two `constexpr std::array` members to a dgb header.
