### PR TITLE
rename DensePPLNSRing -> DensePPLNSWindow (ltc + btc), SAFE-COSMETIC

### DIFF
--- a/src/impl/btc/node.cpp
+++ b/src/impl/btc/node.cpp
@@ -12,10 +12,10 @@
 #include <iomanip>
 #include <random>
 
-// Static members for DensePPLNSRing precomputed decay table
-std::vector<uint64_t> btc::DensePPLNSRing::s_decay_table;
-uint64_t btc::DensePPLNSRing::s_decay_per = 0;
-bool btc::DensePPLNSRing::s_table_initialized = false;
+// Static members for DensePPLNSWindow precomputed decay table
+std::vector<uint64_t> btc::DensePPLNSWindow::s_decay_table;
+uint64_t btc::DensePPLNSWindow::s_decay_per = 0;
+bool btc::DensePPLNSWindow::s_table_initialized = false;
 
 // Helper: read current RSS from /proc/self/status (Linux only)
 static long get_rss_mb() {

--- a/src/impl/btc/share_tracker.hpp
+++ b/src/impl/btc/share_tracker.hpp
@@ -145,7 +145,7 @@ struct PPLNSEntry {
     std::vector<unsigned char> script;      // payout script (variable-length)
 };
 
-class DensePPLNSRing {
+class DensePPLNSWindow {
 public:
     static constexpr uint64_t DECAY_PRECISION = 40;
     static constexpr uint64_t DECAY_SCALE = uint64_t(1) << DECAY_PRECISION;
@@ -244,7 +244,7 @@ public:
 };
 
 // ── Head-Level Incremental PPLNS ─────────────────────────────────────────
-// Maintains a DensePPLNSRing + cached CumulativeWeights per active head.
+// Maintains a DensePPLNSWindow + cached CumulativeWeights per active head.
 // When verifying consecutive shares along a chain:
 //   1. rebuild() at first share's parent: O(chain_len) — one hash map walk
 //   2. extend() for each subsequent share: O(1) ring push + O(chain_len) dense recompute
@@ -252,7 +252,7 @@ public:
 // vs current: O(N × chain_len) random hash map ops — ~10x faster per op.
 
 class HeadPPLNS {
-    DensePPLNSRing m_ring;
+    DensePPLNSWindow m_ring;
     CumulativeWeights m_cached;
     bool m_dirty{true};
 
@@ -306,7 +306,7 @@ public:
 
     bool valid() const { return !m_ring.empty(); }
     int32_t window_size() const { return m_ring.size(); }
-    const DensePPLNSRing& ring() const { return m_ring; }
+    const DensePPLNSWindow& ring() const { return m_ring; }
 };
 
 // --- ShareTracker ---

--- a/src/impl/ltc/node.cpp
+++ b/src/impl/ltc/node.cpp
@@ -12,10 +12,10 @@
 #include <iomanip>
 #include <random>
 
-// Static members for DensePPLNSRing precomputed decay table
-std::vector<uint64_t> ltc::DensePPLNSRing::s_decay_table;
-uint64_t ltc::DensePPLNSRing::s_decay_per = 0;
-bool ltc::DensePPLNSRing::s_table_initialized = false;
+// Static members for DensePPLNSWindow precomputed decay table
+std::vector<uint64_t> ltc::DensePPLNSWindow::s_decay_table;
+uint64_t ltc::DensePPLNSWindow::s_decay_per = 0;
+bool ltc::DensePPLNSWindow::s_table_initialized = false;
 
 // Helper: read current RSS from /proc/self/status (Linux only)
 static long get_rss_mb() {

--- a/src/impl/ltc/share_tracker.hpp
+++ b/src/impl/ltc/share_tracker.hpp
@@ -145,7 +145,7 @@ struct PPLNSEntry {
     std::vector<unsigned char> script;      // payout script (variable-length)
 };
 
-class DensePPLNSRing {
+class DensePPLNSWindow {
 public:
     static constexpr uint64_t DECAY_PRECISION = 40;
     static constexpr uint64_t DECAY_SCALE = uint64_t(1) << DECAY_PRECISION;
@@ -244,7 +244,7 @@ public:
 };
 
 // ── Head-Level Incremental PPLNS ─────────────────────────────────────────
-// Maintains a DensePPLNSRing + cached CumulativeWeights per active head.
+// Maintains a DensePPLNSWindow + cached CumulativeWeights per active head.
 // When verifying consecutive shares along a chain:
 //   1. rebuild() at first share's parent: O(chain_len) — one hash map walk
 //   2. extend() for each subsequent share: O(1) ring push + O(chain_len) dense recompute
@@ -252,7 +252,7 @@ public:
 // vs current: O(N × chain_len) random hash map ops — ~10x faster per op.
 
 class HeadPPLNS {
-    DensePPLNSRing m_ring;
+    DensePPLNSWindow m_ring;
     CumulativeWeights m_cached;
     bool m_dirty{true};
 
@@ -306,7 +306,7 @@ public:
 
     bool valid() const { return !m_ring.empty(); }
     int32_t window_size() const { return m_ring.size(); }
-    const DensePPLNSRing& ring() const { return m_ring; }
+    const DensePPLNSWindow& ring() const { return m_ring; }
 };
 
 // --- ShareTracker ---


### PR DESCRIPTION
## #85 — pure rename DensePPLNSRing -> DensePPLNSWindow

**Rationale (operator-confirmed):** the class is a `std::deque` sliding *window*, not a ring buffer. The name was a misnomer; the actual ring buffer is the V37 work (already on `v37-dev`). Renaming on master removes the confusion before the BTC pillars build on it.

**Scope:** symbol + comments only, **zero behavior change**.
- 4 files, 16 sites renamed (8 ltc, 8 btc) — branched off master `f5324290`.
- Per-coin isolation invariant holds: only the two coins' `share_tracker` / `node.cpp` touched, no cross-coin entanglement.
- Two commits, split per coin (`115e4f00` ltc, `52491e92` btc) so btc-heap-opt's #84 rebase has a clean btc-only commit.

**Not in scope (intentional):** the member `m_ring` and accessor `ring()` keep their names — renaming them would ripple to callers and break the symbol-only / zero-behavior invariant. Flagging for a separate follow-up if desired.

Label: **SAFE-COSMETIC** (auto-merge eligible on CI + preflight + ctest + census green). Merge stays operator-gated.