### PR TITLE
v36 audit: C2/C4 intentional-divergence + node-local doc annotations

### DIFF
--- a/src/c2pool/merged/merged_mining.cpp
+++ b/src/c2pool/merged/merged_mining.cpp
@@ -1272,6 +1272,11 @@ void MergedMiningManager::set_block_relay_fn(BlockRelayFn fn)
 
 // ─── Shared helpers ──────────────────────────────────────────────────────────
 
+// [v36-audit C4] Output ordering here is NODE-LOCAL and NOT consensus-bearing:
+// the assembled DOGE coinbase is submitted only to dogecoind, which accepts any
+// valid ordering. The sharechain commits to merged work via the AuxPoW merkle
+// proof, not by re-deriving these outputs across peers. Donation split + dust
+// tiebreak below are deterministic purely for stable local block assembly.
 /*static*/ std::string MergedMiningManager::build_pplns_coinbase_hex(
     int height,
     const std::vector<std::pair<std::vector<unsigned char>, uint64_t>>& payouts,

--- a/src/impl/ltc/share_tracker.hpp
+++ b/src/impl/ltc/share_tracker.hpp
@@ -2304,6 +2304,10 @@ public:
 
         delta.total_weight = att * 65535;
         delta.total_donation_weight = att * static_cast<uint32_t>(obj->m_donation);
+        // [v36-audit C2] INTENTIONAL DIVERGENCE: merged-chain weights are FLAT
+        // (att-weighted, no time-decay). Only the parent/LTC chain applies decay.
+        // Mirrors p2pool get_v36_merged_weights (flat + cap, data.py:2657) vs the
+        // parent decayed-cumulative skiplist. Verified intentional, not a bug.
         delta.weights[weight_key] = att * static_cast<uint32_t>(65535 - obj->m_donation);
         return delta;
     }
@@ -2512,6 +2516,12 @@ public:
     //   per_miner = miners_reward * w // accepted_total
     //   rounding_remainder = miners_reward - sum(per_miner)
     //   final_donation = donation_amount + rounding_remainder
+    // [v36-audit C4] NODE-LOCAL / NON-CONSENSUS. Despite the name, this derives
+    // THIS node's intended DOGE aux-coinbase payout split from PPLNS weights to
+    // build the block submitted to dogecoind. Sole caller = the MM payout_provider
+    // (c2pool_refactored.cpp); never invoked from share verification. Peers validate
+    // the merged commitment via the AuxPoW merkle proof, NOT by re-deriving these
+    // outputs, so output ordering is node-local (dogecoind accepts any valid order).
     std::map<std::vector<unsigned char>, uint64_t>
     get_merged_expected_payouts(const uint256& best_share_hash,
                                 const uint256& block_target,


### PR DESCRIPTION
Doc-only audit annotations from the C1–C7 v36 consensus cross-check. **No code changes** — 15 comment lines across 2 files, off master 3de14bac (commit 894593ed, GPG-signed).

## Annotations
- **C2** — `src/impl/ltc/share_tracker.hpp:2307`: marks the merged-chain FLAT (att-weighted, no time-decay) weighting as an INTENTIONAL divergence from the parent/LTC decayed-cumulative path. Mirrors p2pool `get_v36_merged_weights` (flat + cap, data.py:2657). Verified intentional, not a bug.
- **C4** — `get_merged_expected_payouts` (share_tracker.hpp) + `build_pplns_coinbase_hex` (merged_mining.cpp): annotates both as NODE-LOCAL / NON-CONSENSUS. Output ordering feeds only the locally-assembled DOGE aux-coinbase submitted to dogecoind; peers validate the merged commitment via the AuxPoW merkle proof, not by re-deriving outputs.
- **C7** — CHAIN_LENGTH=8640 confirmed no-change (cross-check finding; no code touched).

## Scope / safety
- Comment-only; additions only; no runtime behavior change.
- No third-party attribution.
- Merge stays operator-held — review/merge per integrator.