### PR TITLE
fix(btc): guard glibc-only malloc_trim behind __GLIBC__ (release-matrix macOS/Windows)

### DIFF
--- a/src/c2pool/main_btc.cpp
+++ b/src/c2pool/main_btc.cpp
@@ -53,7 +53,9 @@
 #include <chrono>
 #include <cstdint>
 #include <cstdio>           // [MEM] periodic logger reads /proc/self/status
-#include <malloc.h>         // [MEM] periodic malloc_trim(0) bounds glibc pool fragmentation
+#if defined(__GLIBC__)
+#include <malloc.h>         // [MEM] periodic malloc_trim(0) bounds glibc pool fragmentation (glibc-only)
+#endif
 #include <filesystem>
 #include <functional>
 #include <iostream>
@@ -584,7 +586,11 @@ int main(int argc, char* argv[])
             // true heap leak. malloc_trim(0) walks the top chunk of every arena
             // and madvise(MADV_DONTNEED)s pages that are free. Cheap (~ms) on
             // typical heap sizes, returns 1 if it actually released memory.
+#if defined(__GLIBC__)
             int trimmed = ::malloc_trim(0);
+#else
+            int trimmed = 0;   // malloc_trim is a glibc extension; no-op on macOS/MSVC
+#endif
             LOG_INFO << "[MEM] vmrss=" << vm_rss_kb << "kB"
                      << " vmsize=" << vm_size_kb << "kB"
                      << " vmdata=" << vm_data_kb << "kB"


### PR DESCRIPTION
Release matrix validation run 27505713713 failed two btc cells:

- btc arm64 (macOS build), job 81296434793 — Build c2pool-btc: `fatal error: malloc.h file not found` (main_btc.cpp:56).
- btc package (Windows x86_64), job 81296435217 — `error C2039/C3861: malloc_trim not found` (main_btc.cpp:587).

Single root cause: the [MEM] periodic RSS-trim feature in main_btc.cpp uses the glibc extensions `<malloc.h>` and `::malloc_trim(0)` unconditionally. macOS clang and MSVC have neither. Linux x86_64 btc cell is green and stays green.

Fix: guard both the include and the call with `#if defined(__GLIBC__)`; non-glibc targets compile a no-op `trimmed=0` so the [MEM] logger still builds. Code bug (portability), not CI drift.

Merge gated on operator push-approval. Real validation = re-run release matrix after merge.