### PR TITLE
dgb: wire impl_dgb pool/share OBJECT lib (B1 build gate)

### DIFF
--- a/src/impl/dgb/CMakeLists.txt
+++ b/src/impl/dgb/CMakeLists.txt
@@ -29,6 +29,25 @@
 if(COIN_DGB)
   message(STATUS "c2pool: DGB Scrypt-only coin module enabled (skeleton)")
   add_subdirectory(coin)
-  # add_subdirectory(daemon)
-  # add_subdirectory(test)
+
+  # impl_dgb pool/share-layer OBJECT lib (Phase B / B1). Mirrors the ltc OBJECT
+  # lib (dgb was ported verbatim from src/impl/ltc, Scrypt parent) per the
+  # ci-steward OBJECT-lib direct-naming convention (#22/#39). B1 is header-only,
+  # so b1_smoke.cpp is the sole compile unit giving the surface a whole-target
+  # build gate; real TUs (config_pool.cpp/node.cpp/protocol_actual.cpp/
+  # protocol_legacy.cpp) replace it as dgb-scrypt-steward lands them.
+  add_library(dgb OBJECT
+      b1_smoke.cpp
+      share_types.hpp share.hpp
+      share_tracker.hpp share_check.hpp share_messages.hpp
+      redistribute.hpp
+      config_coin.hpp config_pool.hpp
+      messages.hpp node.hpp peer.hpp
+      # auto_ratchet.hpp / donation_consensus.hpp: PILLAR 1/4, gated -- not compiled here
+  )
+
+  target_link_libraries(dgb core pool sharechain dgb_coin btclibs c2pool_storage ${SECP256K1_LIBRARIES})
+
+  # add_subdirectory(daemon)  # M3
+  # add_subdirectory(test)    # B-later: share_test references LTC types
 endif()

--- a/src/impl/dgb/b1_smoke.cpp
+++ b/src/impl/dgb/b1_smoke.cpp
@@ -1,0 +1,20 @@
+// DGB Phase B (B1) sharechain-verify surface — compile-gate translation unit.
+//
+// The B1 surface (share_types / share / share_tracker / share_check /
+// share_messages / redistribute) is header-only at B1: each header passes
+// g++ -std=c++20 -fsyntax-only individually, but nothing instantiates them
+// inside a real translation unit, so a whole-target compile gate did not yet
+// exist. This TU gives the dgb OBJECT lib one compilable source so the surface
+// builds AS A UNIT (per-coin dgb smoke gate), turning header-graph breakage
+// into a build failure instead of latent rot.
+//
+// ci-steward build-gate scaffolding (dgb-tree-only). REMOVE this file once the
+// real dgb pool-layer translation units land (config_pool.cpp / node.cpp /
+// protocol_actual.cpp / protocol_legacy.cpp, owned by dgb-scrypt-steward) and
+// supply the OBJECT lib with genuine symbols.
+#include "share_types.hpp"
+#include "share.hpp"
+#include "share_tracker.hpp"
+#include "share_check.hpp"
+#include "share_messages.hpp"
+#include "redistribute.hpp"


### PR DESCRIPTION
Unblocks dgb-scrypt-steward whole-target compile of the B1 sharechain-verify surface (integrator task 2026-06-16).

## What
- Adds the `dgb` OBJECT lib to `src/impl/dgb/CMakeLists.txt` under `COIN_DGB`, mirroring the `ltc` OBJECT lib the B1 surface was ported from (direct-naming convention #22/#39): links `core pool sharechain dgb_coin btclibs c2pool_storage ${SECP256K1_LIBRARIES}`.
- Adds `src/impl/dgb/b1_smoke.cpp` — the B1 surface (share_types/share/share_tracker/share_check/share_messages/redistribute) is header-only, so this is the sole compile unit giving it a whole-target build gate. Removable once real pool-layer TUs (config_pool.cpp/node.cpp/protocol_actual.cpp/protocol_legacy.cpp) land.

## Verification
- `cmake -S . -B build_ci -DCOIN_DGB=ON` → configure clean.
- `cmake --build build_ci --target dgb` → green: `[100%] Built target dgb` (b1_smoke.cpp.o compiled; full chain core/sharechain/pool/dgb_coin built).
- Pre-flight: 6 B1 headers compile as one TU (-fsyntax-only, exit 0).

## Scope / invariants
- dgb-tree-only scaffolding. No change to the per-coin source-presence guards (PR #47 fix preserved). Single-coin dgb smoke gate; per-coin isolation intact.
- Commit GPG-signed (50AB1379285EFE76).

Base is `dgb/pool-pillars-port` so it stacks into the B1 PR. Merge gated on operator push-approval.