### PR TITLE
ci(build): run macOS x86_64 lane on self-hosted c2pool-mac-intel runner (#42)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -433,6 +433,22 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Set up Homebrew PATH
+        # Self-hosted Intel runner (macpro-intel-204) launches the Actions
+        # service from launchd, whose PATH omits Homebrew's /usr/local/bin
+        # (#100: brew exit 127). GitHub-hosted arm64 keeps /opt/homebrew on PATH.
+        # Append whichever prefix actually has brew so every later step
+        # (cmake, brew --prefix) inherits it via $GITHUB_PATH.
+        run: |
+          if [ -x /opt/homebrew/bin/brew ]; then
+            echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
+          elif [ -x /usr/local/bin/brew ]; then
+            echo "/usr/local/bin" >> "$GITHUB_PATH"
+          else
+            echo "::error::Homebrew not found at /opt/homebrew or /usr/local on ${RUNNER_NAME:-runner}" >&2
+            exit 1
+          fi
+
       - name: Install dependencies
         run: brew install cmake boost leveldb secp256k1 nlohmann-json yaml-cpp
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -415,12 +415,21 @@ jobs:
           build_btc/src/c2pool/c2pool-btc --help 2>&1 | head -3 || true
 
   # ════════════════════════════════════════════════════════════════════════════
-  # macOS (Apple Silicon arm64 — GitHub only provides ARM runners now)
-  # Intel x86_64 macOS binary is built locally; see doc/build-macos.md
+  # macOS (matrix: arm64 on GitHub-hosted macos-14, x86_64 on the self-hosted
+  # Intel runner labeled c2pool-mac-intel). The self-hosted lane resolves the
+  # macOS x86_64 CI starvation (#42) — macpro-intel-204 standup 2026-06-16.
   # ════════════════════════════════════════════════════════════════════════════
   macos:
-    name: macOS arm64
-    runs-on: macos-14
+    name: macOS ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            runner: macos-14
+          - arch: x86_64
+            runner: [self-hosted, macOS, X64, c2pool-mac-intel]
     steps:
       - uses: actions/checkout@v6
 
@@ -440,17 +449,18 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          PKG="c2pool-${VERSION}-macos-arm64"
+          PKG="c2pool-${VERSION}-macos-${{ matrix.arch }}"
+          BREW="$(brew --prefix)"
           mkdir -p "${PKG}/lib" "${PKG}/config" "${PKG}/web-static" "${PKG}/explorer"
           cp build/src/c2pool/c2pool "${PKG}/"
           strip "${PKG}/c2pool"
-          for dylib in $(otool -L "${PKG}/c2pool" | grep "/opt/homebrew" | awk '{print $1}'); do
+          for dylib in $(otool -L "${PKG}/c2pool" | grep "${BREW}" | awk '{print $1}'); do
             base=$(basename "$dylib")
             cp "$dylib" "${PKG}/lib/${base}"
             install_name_tool -change "$dylib" "@executable_path/lib/${base}" "${PKG}/c2pool"
           done
           for lib in "${PKG}"/lib/*.dylib; do
-            for ref in $(otool -L "$lib" | grep "/opt/homebrew" | awk '{print $1}'); do
+            for ref in $(otool -L "$lib" | grep "${BREW}" | awk '{print $1}'); do
               base=$(basename "$ref")
               [ -f "${PKG}/lib/${base}" ] && install_name_tool -change "$ref" "@executable_path/lib/${base}" "$lib"
             done
@@ -467,8 +477,8 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         uses: actions/upload-artifact@v7
         with:
-          name: macos-arm64
-          path: c2pool-*-macos-arm64.zip*
+          name: macos-${{ matrix.arch }}
+          path: c2pool-*-macos-${{ matrix.arch }}.zip*
 
   # ════════════════════════════════════════════════════════════════════════════
   # Windows (MSVC 2022, Conan)


### PR DESCRIPTION
## What

Convert the single arm64-only `macos` job in `build.yml` into an arch **matrix**:

| arch | runner | hosting |
|------|--------|---------|
| `arm64` | `macos-14` | GitHub-hosted (unchanged) |
| `x86_64` | `[self-hosted, macOS, X64, c2pool-mac-intel]` | **self-hosted (macpro-intel-204)** |

This activates the idle `macpro-intel-204` self-hosted Intel runner that was stood up 2026-06-16, putting the macOS x86_64 lane on a native runner and resolving the GitHub-hosted `macos-13` Intel-runner **starvation (#42)**. The arm64 GitHub-hosted lane is untouched.

Tag-only packaging is parameterized by `${{ matrix.arch }}` and derives the Homebrew prefix via `brew --prefix`, so it is correct on both Apple Silicon (`/opt/homebrew`) and Intel (`/usr/local`).

## Fork-PR RCE gate — CONFIRMED in place

Required before exposing a self-hosted runner on a **public** repo. Verified via the API prior to opening this PR:

```
$ gh api repos/frstrtr/c2pool/actions/permissions/fork-pr-contributor-approval
{"approval_policy":"all_external_contributors"}
```

`all_external_contributors` is the strictest setting — "Require approval for all outside collaborators." No untrusted fork code can reach the self-hosted runner without a maintainer first approving the workflow run.

## Proof

This PR's own CI exercises `build.yml` on `pull_request`. A green macOS x86_64 check running on the self-hosted runner (job picked up, busy then success) is the live proof the lane works. Runner-pickup evidence to follow in a PR comment.

## Notes

- Merge-gated: awaiting operator push-approval. Do not self-merge.
- Scope is `.github/workflows/build.yml` only.
