### PR TITLE
ci: trigger CI + coin-matrix on dgb/pool-pillars-port (DGB integration lane)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,10 @@ name: CI
 
 on:
   push:
-    branches: [master, btc-embedded, dash-spv-embedded, windows-build, service-update]
+    branches: [master, btc-embedded, dash-spv-embedded, dgb/pool-pillars-port, windows-build, service-update]
     tags: ['v*']
   pull_request:
-    branches: [master, btc-embedded, dash-spv-embedded, dgb/slice4-skeleton]
+    branches: [master, btc-embedded, dash-spv-embedded, dgb/slice4-skeleton, dgb/pool-pillars-port]
 
 jobs:
   # ════════════════════════════════════════════════════════════════════════════

--- a/.github/workflows/coin-matrix.yml
+++ b/.github/workflows/coin-matrix.yml
@@ -13,9 +13,9 @@ name: Coin matrix
 
 on:
   push:
-    branches: [master, btc-embedded, dash-spv-embedded, windows-build, service-update]
+    branches: [master, btc-embedded, dash-spv-embedded, dgb/pool-pillars-port, windows-build, service-update]
   pull_request:
-    branches: [master, btc-embedded, dash-spv-embedded, dgb/slice4-skeleton]
+    branches: [master, btc-embedded, dash-spv-embedded, dgb/slice4-skeleton, dgb/pool-pillars-port]
 
 jobs:
   coin:


### PR DESCRIPTION
Adds the DGB integration branch `dgb/pool-pillars-port` to the `push` and `pull_request` branch filters in build.yml and coin-matrix.yml, alongside the other per-coin integration branches (btc-embedded, dash-spv-embedded).

Why: PR #99 (into dgb/pool-pillars-port) reported ZERO checks — a PR/push targeting that branch matched no workflow trigger, so no CI was eligible. This is the same per-coin enablement already in place for btc/dash.

Scope: additive YAML only (4 lines). Revert = drop the two dgb/pool-pillars-port entries. The base branch dgb/pool-pillars-port already carries this commit (1e08f861) so PR #99 can validate now; this PR is the canonical landing on master.

NOTE: known follow-up — the coin-matrix `dgb` cell still presence-gates on src/c2pool/main_dgb.cpp (absent at M1) and no job configures -DCOIN_DGB, so the dgb OBJECT lib (b1_smoke) is not yet compiled by CI. Tracking separately.