### PR TITLE
ci: add dgb/pool-pillars-port to PR branch filters (symmetry)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     branches: [master, btc-embedded, dash-spv-embedded, windows-build, service-update]
     tags: ['v*']
   pull_request:
-    branches: [master, btc-embedded, dash-spv-embedded]
+    branches: [master, btc-embedded, dash-spv-embedded, dgb/pool-pillars-port]
 
 jobs:
   # ════════════════════════════════════════════════════════════════════════════

--- a/.github/workflows/coin-matrix.yml
+++ b/.github/workflows/coin-matrix.yml
@@ -15,7 +15,7 @@ on:
   push:
     branches: [master, btc-embedded, dash-spv-embedded, windows-build, service-update]
   pull_request:
-    branches: [master, btc-embedded, dash-spv-embedded]
+    branches: [master, btc-embedded, dash-spv-embedded, dgb/pool-pillars-port]
 
 jobs:
   coin:


### PR DESCRIPTION
Additive-only: appends `dgb/pool-pillars-port` to the `pull_request.branches` allow-list in build.yml and coin-matrix.yml, mirroring the existing `btc-embedded` and `dash-spv-embedded` entries already on master.

**Why:** btc-embedded and dash-spv-embedded are on master for symmetry; leaving dgb out makes the canonical filter list inconsistent and invites the next contributor to hit the ZERO-CI footgun before their branch merges up. Redundant once pool-pillars-port lands, but the consistency is cheap (two filter lines, no job/behavior change).

Scope: 2 lines, both `pull_request.branches` only. No push-trigger or job changes.

Merge-gated: holding for operator push-approval per standing rule.