### PR TITLE
dgb: AutoRatchet 95/50/2x threshold seam (slice #2, SAFE-ADDITIVE, fenced)

### DIFF
--- a/src/impl/dgb/auto_ratchet.hpp
+++ b/src/impl/dgb/auto_ratchet.hpp
@@ -7,19 +7,61 @@
 /// ratchet window) is the F10-fenced path. This pillar stays a STUB until the
 /// F10 capture PR clears — see [[dgb-modern-layer-activation]] memory.
 ///
-/// Target shape: mirror src/impl/ltc/auto_ratchet.hpp (AutoRatchet, target
-/// version = 36), reading live voted version from the sharechain. DGB-Scrypt
-/// uses the same ratchet math as LTC — Scrypt-only, no algo divergence here.
+/// SOAK FREEZE: the ratchet thresholds below are carried verbatim from
+/// src/impl/ltc/auto_ratchet.hpp, but the transition state machine
+/// (get_share_version / load / save) stays a fenced TODO until the LTC soak
+/// freezes the reference (see share.hpp conformance note). DGB-Scrypt uses the
+/// SAME ratchet math as LTC — Scrypt-only, no algo divergence — so when the
+/// fence lifts the port is a namespace change, not a re-derivation.
 ///
 /// COMPAT: must match frstrtr/p2pool-merged-v36 version-voting + ratchet rules
 /// exactly. Any divergence => [decision-needed] to integrator (V37 by def).
 
+#include <cstdint>
+
 namespace dgb
 {
 
-// TODO(Phase B, F10-gated): port ltc::AutoRatchet -> dgb::AutoRatchet.
-// Do NOT author the share_check version-acceptance path until F10 capture
-// PR lands. Pillar-1 core cannot fully land before then.
-class AutoRatchet; // forward-declared only; definition deferred behind F10.
+enum class RatchetState : uint8_t
+{
+    VOTING    = 0,  // producing old-format shares, voting for upgrade
+    ACTIVATED = 1,  // producing new-format shares, monitoring support
+    CONFIRMED = 2   // permanent: new format confirmed, survives restart
+};
+
+inline const char* ratchet_state_str(RatchetState s)
+{
+    switch (s) {
+    case RatchetState::VOTING:    return "VOTING";
+    case RatchetState::ACTIVATED: return "ACTIVATED";
+    case RatchetState::CONFIRMED: return "CONFIRMED";
+    }
+    return "UNKNOWN";
+}
+
+// AutoRatchet: autonomous V35 -> V36 share-version transition state machine.
+// Mirrors ltc::AutoRatchet (p2pool-v36 data.py AutoRatchet, lines 2109-2344).
+//
+// Thresholds are FROZEN here (95 / 50 / 2x) to match the Python reference and
+// ltc::AutoRatchet byte-for-byte. The transition logic is intentionally NOT
+// authored yet — see the F10 + soak-freeze fences above.
+class AutoRatchet
+{
+public:
+    // Ratchet thresholds — must match p2pool-merged-v36 + ltc::AutoRatchet exactly.
+    static constexpr int ACTIVATION_THRESHOLD    = 95;  // % votes to activate (VOTING -> ACTIVATED)
+    static constexpr int DEACTIVATION_THRESHOLD  = 50;  // % below which to revert (ACTIVATED -> VOTING)
+    static constexpr int CONFIRMATION_MULTIPLIER = 2;   // confirm after 2x CHAIN_LENGTH sustained
+    static constexpr int SWITCH_THRESHOLD        = 60;  // % tail-guard floor for format switch (jtoomim rule)
+
+    // TODO(Phase B, F10-gated + post-soak-freeze): port the ltc::AutoRatchet
+    // state machine into dgb:: once the F10 version-acceptance capture PR lands
+    // AND the LTC soak freezes the reference:
+    //   - ctor(state_file_path, target_version = 36) + JSON load()/save()
+    //   - get_share_version(ShareTracker&, best_share_hash):
+    //       VOTING/ACTIVATED/CONFIRMED transitions, tail guard, retroactive credit
+    //   - state() / target_version() accessors + RatchetState members
+    // Do NOT author the share_check version-acceptance path before F10 clears.
+};
 
 } // namespace dgb


### PR DESCRIPTION
## DGB pillar 1 — slice #2: AutoRatchet threshold seam (SAFE-ADDITIVE, single-coin)

Ports the `ltc::AutoRatchet` **threshold surface** into `dgb::AutoRatchet` as a structural seam only. No transition state machine is authored in this slice.

### Scope
- Single file: `src/impl/dgb/auto_ratchet.hpp` (+49/-7). `src/impl/dgb/` only — no `ltc/`, `doge/`, `btc/`, or shared-base touch.

### What it carries (byte-for-byte from `ltc/auto_ratchet.hpp` == p2pool-merged-v36 `data.py` AutoRatchet)
- `ACTIVATION_THRESHOLD = 95` (VOTING -> ACTIVATED)
- `DEACTIVATION_THRESHOLD = 50` (ACTIVATED -> VOTING)
- `CONFIRMATION_MULTIPLIER = 2` (confirm after 2x CHAIN_LENGTH)
- `SWITCH_THRESHOLD = 60` (tail-guard floor)
- `RatchetState` enum + `ratchet_state_str`

### What stays fenced (NOT in this slice)
- The transition state machine (`get_share_version` / `load` / `save`) remains a TODO behind the **existing F10 version-acceptance gate** AND the **post-soak-freeze fence** (per share.hpp conformance note).
- No `share_check` version-acceptance path is authored. Do not read the fenced TODO as live transition logic.

### Compat
p2pool-merged-v36 compatibility preserved — DGB-Scrypt shares LTC ratchet math, so this is a namespace change, not a re-derivation.

Base: `dgb/pool-pillars-port` (stacked; auto_ratchet.hpp base exists only on that branch). Operator merges.
