### PR TITLE
dgb: §4c skeleton AuxPoW-comment tightening + aux seam signature (Slice #3, SAFE-ADDITIVE, fenced)

### DIFF
--- a/src/impl/dgb/coin/node.hpp
+++ b/src/impl/dgb/coin/node.hpp
@@ -30,11 +30,32 @@
 #include "node_interface.hpp"
 #include "rpc.hpp"
 
+#ifdef AUX_DOGE
+// DOGE merged-mining aux module (STRETCH; -DAUX_DOGE=ON only). dgb CONSUMES the
+// shared aux types; ltc-doge owns and is the sole modifier of src/impl/doge/coin/aux_*.
+// Forward declaration only at slice #3 -- the real
+// <impl/doge/coin/aux_chain_embedded.hpp> include lands with the
+// bind_aux_doge_parsers() body at M3.
+namespace doge { namespace coin { class AuxChainEmbedded; } }
+#endif
+
 namespace dgb
 {
 
 namespace coin
 {
+
+#ifdef AUX_DOGE
+// ---------------------------------------------------------------------------
+// DOGE merged-mining aux seam -- header-only type alias (slice #3, option b per
+// integrator UID-904). Names the shared src/impl/doge aux-module backend that
+// bind_aux_doge_parsers() wires onto the (M3) coin P2P layer. No new TU; no
+// effect on the default Scrypt-only standalone build (which never defines
+// AUX_DOGE). The structured parsers consumed at M3 bind time are the free
+// functions doge::coin::parse_doge_header / parse_doge_headers_message /
+// parse_doge_block (auxpow_header.hpp). Parity: p2pool-merged-v36.
+using AuxChainBackend = ::doge::coin::AuxChainEmbedded;   // IAuxChainBackend impl
+#endif
 
 template <typename ConfigType>
 class Node : public dgb::interfaces::Node

--- a/src/impl/dgb/coin/node.hpp
+++ b/src/impl/dgb/coin/node.hpp
@@ -13,6 +13,16 @@
 // The ctor keeps btc's (context, config) shape via auto params (no boost
 // include needed in the stub) so M3 restores the body without re-typing
 // construction sites.
+//
+// AuxPoW / merged-mining seam (V36 reality): DGB-Scrypt is a STANDALONE parent in
+// the default build and validates Scrypt blocks ONLY -- there is no AuxPoW path in
+// the default c2pool-dgb. Merged-mining is the DOGE-only stretch, compiled solely
+// under -DAUX_DOGE=ON, where the shared src/impl/doge/coin/aux_* module (owned by
+// ltc-doge; dgb CONSUMES, never modifies) supplies the AuxPoW header / raw-block
+// parsers that the M3 NodeP2P will bind. The other four DGB algos (SHA256d, Skein,
+// Qubit, Odocrypt) are accept-by-continuity / ignored in V36 -- never validated
+// here. p2pool-merged-v36 parity preserved. Signature only below; body lands with
+// NodeP2P at M3.
 // ---------------------------------------------------------------------------
 
 #include <memory>
@@ -48,6 +58,13 @@ public:
     }
 
     NodeRPC* rpc() { return m_rpc.get(); }
+
+#ifdef AUX_DOGE
+    // DOGE merged-mining aux seam (STRETCH; -DAUX_DOGE=ON only). Binds the shared
+    // src/impl/doge aux module's parsers onto the (M3) coin P2P layer. Declaration
+    // only -- no body until NodeP2P is ported. Parity: p2pool-merged-v36.
+    void bind_aux_doge_parsers();
+#endif
 };
 
 } // namespace coin


### PR DESCRIPTION
Slice #3 of the DGB Phase B skeleton sequence (continues PR #108 / dgb auto-ratchet seam).

## What
Extends the dgb::coin::Node minimal-stub (src/impl/dgb/coin/node.hpp):
- Tightens the AuxPoW / merged-mining comment to **V36 reality**: DGB-Scrypt is a standalone Scrypt-only parent in the default build (no AuxPoW path). Merged-mining is the **DOGE-only stretch**, compiled solely under `-DAUX_DOGE=ON`, served by the shared `src/impl/doge/coin/aux_*` module (consumed, never modified — ltc-doge owns).
- Adds `bind_aux_doge_parsers()` **declaration only** (no body) under `#ifdef AUX_DOGE`. Body lands with NodeP2P at M3.
- Notes the other four DGB algos (SHA256d, Skein, Qubit, Odocrypt) are accept-by-continuity / ignored in V36.

## Fences (all held)
- SAFE-ADDITIVE: comment + #ifdef-gated member decl, never odr-used in default build → cannot regress default `c2pool-dgb`.
- Single-coin `src/impl/dgb` only. No share_check version-acceptance path, no stratum, no entrypoint.
- p2pool-merged-v36 parity preserved.
- pillars branch (dgb/pool-pillars-port) untouched — slice is off master.

## NOT in this PR (held for confirmation)
The dispatched `share.hpp/share.cpp` DGB type aliases: no share.cpp TU exists today, so introducing one touches the ci-steward CMake OBJECT-lib gate / no-new-TU fence. Confirming scope with integrator before landing.

Requires explicit operator merge (SAFE-ADDITIVE → no auto-merge).