### PR TITLE
btc(v36): complete twin-parity — think-independent 10s re-advert timer leg (follow-up to merged #105)

### DIFF
--- a/src/impl/btc/node.cpp
+++ b/src/impl/btc/node.cpp
@@ -1624,6 +1624,21 @@ void NodeImpl::run_think()
                             << " verified_heads=" << m_tracker.verified.get_heads().size();
             }
 
+            // ROOT-2: fire ONE think-independent delayed re-advert when the
+            // verified chain first becomes non-empty.  Covers peers that
+            // handshook during the empty window and so never see a best-change
+            // event.  The one-shot timer runs on the IO thread, so it still
+            // fires even if a later think() cycle wedges (composes with the
+            // #97 think-watchdog).  Pure reads; broadcast stays try_to_lock.
+            if (m_verified_was_empty && m_tracker.verified.size() > 0) {
+                m_verified_was_empty = false;
+                if (!m_readvert_timer)
+                    m_readvert_timer = std::make_unique<core::Timer>(m_context, false);
+                m_readvert_timer->start(10, [this]() { readvertise_best(); });
+                LOG_INFO << "[readvertise] verified chain populated — scheduled "
+                            "10s re-advert (ROOT-2)";
+            }
+
             // Drain share batches queued while think() held the mutex
             LOG_INFO << "[ASYNC-THINK] IO-phase: draining " << m_pending_adds.size()
                      << " pending batches, peers=" << m_peers.size();

--- a/src/impl/btc/node.hpp
+++ b/src/impl/btc/node.hpp
@@ -517,6 +517,7 @@ protected:
     size_t m_max_peers = 30;
     size_t m_target_outbound_peers = DEFAULT_TARGET_OUTBOUND_PEERS;
     std::unique_ptr<core::Timer> m_connect_timer;
+    std::unique_ptr<core::Timer> m_readvert_timer; // one-shot ROOT-2 re-advert
     std::set<NetService> m_pending_outbound;   // addresses currently being dialed
     std::set<NetService> m_outbound_addrs;     // successfully connected outbound peers
 
@@ -552,6 +553,10 @@ protected:
     // Cached best share hash from the most recent think() cycle
     uint256 m_best_share_hash;
 
+    // ROOT-2: fire exactly one delayed re-advert when the verified chain
+    // first transitions from empty to non-empty (peers that handshook
+    // during the empty window otherwise never see a best-change event).
+    bool m_verified_was_empty = true;
 
     // Cache of original raw serialized bytes keyed by share hash.
     // Used for relay so we send the exact bytes we received, avoiding


### PR DESCRIPTION
Follow-up to #105, which **merged at 11:06:55Z carrying only the event-leg half-fix** (659b95c2) — one minute before integrator froze the merge tap. Master therefore currently has the timer-LESS half-fix (the same shape disavowed for LTC, #103). This PR lands the orphaned timer leg `f3539c16` to complete twin-parity with #104/e01c1606.

Adds `m_readvert_timer` (one-shot core::Timer, 10s -> readvertise_best()), armed lazily in the run_think IO-phase, fired exactly once when the verified chain first becomes non-empty. The event leg dies when think() wedges; this think-independent leg survives a wedged think() (composes with merged #97 watchdog). Livelock-safe by construction: pure reads, broadcast stays try_to_lock, no new mutex.

Gate: ctest + twin-parity re-confirm by claudecode before merge tap.