### PR TITLE
ltc: lower minimum_protocol_version floor 3600->3301 (admit v35 for crossing)

### DIFF
--- a/src/impl/ltc/params.hpp
+++ b/src/impl/ltc/params.hpp
@@ -61,7 +61,7 @@ inline core::CoinParams make_coin_params(bool testnet)
 
     p.target_lookbehind        = 200;
     p.spread                   = 3;
-    p.minimum_protocol_version = 3600;
+    p.minimum_protocol_version = 3301;  // accept v35 (3502) peers for v35->v36 AutoRatchet crossing
     p.block_max_size           = 1000000;
     p.block_max_weight         = 4000000;
 


### PR DESCRIPTION
## What
`src/impl/ltc/params.hpp:64`: `p.minimum_protocol_version` `3600` -> `3301`. **LTC tree only.** One file.

## Why
The live LTC peer-admission gate is `CoinParams.minimum_protocol_version` (params.hpp:64), read at `ltc/node.cpp:307`. Hardcoded `3600` (== our ADVERTISED v36) rejects every v35 (3502) peer at handshake. A 3600 hard floor defeats the v35->v36 transition **by construction**: AutoRatchet needs a mixed v35/v36 population to ratchet against, and the constant comment itself says "accept v35".

Completes 0f997546c, which lowered the **vestigial** `config_pool.hpp:37` constant to 3301 but missed the runtime struct that `ltc/node.cpp` actually gates on. (Confirmed: `ltc/node.cpp:307` reads `m_params->minimum_protocol_version`; the `PoolConfig` constant is NOT consulted on the LTC path.) Conformance, not a posture change.

## Routing / scope notes (per integrator constraints)
- **Per-coin isolation:** touches only `src/impl/ltc/`. No DOGE/DGB/BTC trees.
- **DOGE floor naming flag:** there is **no** `src/impl/doge/` pool floor — `src/impl/doge/` contains only `coin/` (the merged-mining coin def). DOGE rides this same LTC sharechain, so **this PR covers the LTC+DOGE crossing**. The 3600 floor at `src/impl/dgb/config_pool.hpp:34` belongs to **DigiByte (DGB)**, a separate coin/sharechain (and DGB gates via the `PoolConfig` constant, not params) — handled as a separate decision, not bundled here.
- **v36<->v36 unaffected:** both prod peers advertise 3600 >= 3301; runtime-behavior-preserving for the live crossing soak.

## Gating
Per-coin LTC smoke. HOLD merge for operator approval (standing rule).