### PR TITLE
[dash][S4-pre] payout-credit foundation — advance block.m_txs (leaf, single-coin)

### DIFF
--- a/src/impl/dash/coin/block.hpp
+++ b/src/impl/dash/coin/block.hpp
@@ -3,13 +3,20 @@
 // Dash block types: standard Bitcoin 80-byte header, no MWEB.
 // Uses generic headers from bitcoin_family.
 //
-// S3 (SPV header-chain) consumes headers only, so BlockType is a header-only
-// block here. The full block body (std::vector<MutableTransaction> m_txs +
-// transaction-aware (de)serialization) lands in S5 (block-replay) together
-// with the dash transaction type; defining it now would force a complete
-// MutableTransaction that S3 does not yet provide.
+// NOTE: the `m_txs` block-body member below was ADVANCED FROM S5 (block-replay)
+// into the S4-pre foundation (branch dash/pr0-foundation-s4) to close
+// credit_pool.apply_block(), which walks block.m_txs for asset-lock/unlock
+// accounting. This is the SINGLE canonical declaration of the member: S5 builds
+// on it (adding the transaction-aware (de)serialization of m_txs) rather than
+// re-authoring it, to avoid a double-add collision on this struct.
+//
+// S3/S4-pre serialization stays HEADER-ONLY here; transaction-aware
+// (de)serialization of m_txs remains deferred to S5 along with the wire format.
 
 #include <impl/bitcoin_family/coin/base_block.hpp>
+#include <impl/dash/coin/transaction.hpp>  // complete MutableTransaction for m_txs member
+
+#include <vector>
 
 namespace dash
 {
@@ -21,6 +28,10 @@ using bitcoin_family::coin::BlockHeaderType;
 
 struct BlockType : BlockHeaderType
 {
+    // Advanced from S5 to close credit_pool.apply_block(). Transaction-aware
+    // (de)serialization of this member lands in S5; not serialized here.
+    std::vector<MutableTransaction> m_txs;
+
     template <typename Stream>
     void Serialize(Stream& s) const {
         BlockHeaderType::Serialize(s);
@@ -32,7 +43,7 @@ struct BlockType : BlockHeaderType
     }
 
     BlockType() : BlockHeaderType() { }
-    void SetNull() { BlockHeaderType::SetNull(); }
+    void SetNull() { BlockHeaderType::SetNull(); m_txs.clear(); }
     bool IsNull() const { return BlockHeaderType::IsNull(); }
 };
 

--- a/src/impl/dash/coin/credit_pool.hpp
+++ b/src/impl/dash/coin/credit_pool.hpp
@@ -1,0 +1,128 @@
+#pragma once
+
+/// Phase C-TEMPLATE step 13: DIP-0027 credit-pool state machine.
+///
+/// Tracks the running creditPoolBalance reported in CCbTx.creditPoolBalance
+/// (CCbTx.VERSION_CLSIG_AND_BALANCE / version 3+).
+///
+/// Per-block delta from dashcore evo/creditpool.cpp::DiffFromBlock:
+///   For each tx in the block (excluding coinbase):
+///     - Type 8 (TRANSACTION_ASSET_LOCK):
+///         pool += sum(payload.creditOutputs.value)
+///     - Type 9 (TRANSACTION_ASSET_UNLOCK):
+///         pool -= sum(tx.vout.value)   // gross withdrawal; the
+///                                      // payload.fee is paid to the
+///                                      // miner from the unlock total
+///                                      // and does NOT come back into
+///                                      // the pool
+///
+/// Bootstrap: seed from the first observed CCbTx.creditPoolBalance
+/// before applying any deltas (similar pattern to MnStateMachine
+/// bootstrap from snapshot). Persistence via CreditPoolDb (sister of
+/// SMLDb / QuorumDb / MnStateDb).
+///
+/// At MVP (this commit): in-memory only. Persistence + sentinel
+/// cross-check land in step 13b. Cold-start re-seeds from the first
+/// post-restart observed CCbTx.
+
+#include <impl/dash/coin/vendor/assetlock.hpp>
+#include <impl/dash/coin/vendor/cbtx.hpp>
+#include <impl/dash/coin/transaction.hpp>
+#include <impl/dash/coin/block.hpp>
+
+#include <core/log.hpp>
+
+#include <cstdint>
+#include <optional>
+
+namespace dash {
+namespace coin {
+
+class CreditPool
+{
+public:
+    /// Apply a block to the pool. Returns the per-block delta on
+    /// success, or std::nullopt if the pool is uninitialized (no seed
+    /// observed yet — caller should seed from CCbTx.creditPoolBalance).
+    std::optional<int64_t> apply_block(
+        const BlockType& block, uint32_t height)
+    {
+        if (!m_initialized) return std::nullopt;
+
+        int64_t delta = 0;
+        size_t locks = 0, unlocks = 0;
+
+        // Skip cb (index 0) — it's the special-tx-5 CCbTx itself,
+        // which doesn't carry asset-lock/unlock payloads.
+        for (size_t i = 1; i < block.m_txs.size(); ++i) {
+            const auto& tx = block.m_txs[i];
+            if (tx.type == vendor::CAssetLockPayload::SPECIALTX_TYPE
+                && !tx.extra_payload.empty()) {
+                vendor::CAssetLockPayload p;
+                if (vendor::parse_assetlock_payload(tx.extra_payload, p)) {
+                    delta += p.total_credit();
+                    ++locks;
+                }
+                // parse failures already log; skip the tx for accounting
+            } else if (tx.type == vendor::CAssetUnlockPayload::SPECIALTX_TYPE) {
+                // For unlocks, the deduction is sum of vout values
+                // (gross withdrawal). Payload parse is informational —
+                // not strictly required for the balance math, but we
+                // do it to keep the [ASSETUNLOCK] log consistent and
+                // catch wire-format drift early.
+                int64_t out_sum = 0;
+                for (const auto& v : tx.vout) out_sum += v.value;
+                delta -= out_sum;
+                ++unlocks;
+                // Optional payload parse for diagnostics.
+                if (!tx.extra_payload.empty()) {
+                    vendor::CAssetUnlockPayload up;
+                    vendor::parse_assetunlock_payload(tx.extra_payload, up);
+                }
+            }
+        }
+
+        m_balance += delta;
+        m_height = height;
+
+        if (delta != 0 || locks != 0 || unlocks != 0) {
+            LOG_INFO << "[CREDITPOOL] h=" << height
+                     << " delta=" << delta
+                     << " locks=" << locks
+                     << " unlocks=" << unlocks
+                     << " balance=" << m_balance;
+        }
+        return delta;
+    }
+
+    /// Seed the pool from an observed CCbTx.creditPoolBalance. The
+    /// CCbTx field reports the balance AFTER applying that block's
+    /// activity, so on the next block we apply deltas on top of this.
+    void seed(int64_t balance, uint32_t height)
+    {
+        m_balance     = balance;
+        m_height      = height;
+        m_initialized = true;
+        LOG_INFO << "[CREDITPOOL] seeded h=" << height
+                 << " balance=" << balance;
+    }
+
+    int64_t balance() const { return m_balance; }
+    uint32_t height() const { return m_height; }
+    bool initialized() const { return m_initialized; }
+
+    void clear()
+    {
+        m_balance = 0;
+        m_height = 0;
+        m_initialized = false;
+    }
+
+private:
+    int64_t  m_balance{0};
+    uint32_t m_height{0};
+    bool     m_initialized{false};
+};
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/credit_pool_db.hpp
+++ b/src/impl/dash/coin/credit_pool_db.hpp
@@ -1,0 +1,136 @@
+#pragma once
+
+/// Phase C-TEMPLATE step 13b: persistent CreditPool state.
+///
+/// Schema (single 'B' key — the pool is just one int64, no per-entry
+/// table needed unlike SMLDb / QuorumDb / MnStateDb):
+///   key = "B"
+///   value = [32B block_hash] [4B LE height] [8B LE int64 balance]
+///                                                     [1B initialized flag]
+///
+/// On open(), load the value if present. On every successful
+/// CreditPool::apply_block() in main_dash, write the new state.
+///
+/// Sentinel cross-check on startup: best_hash must match SMLDb's.
+/// On mismatch, the credit pool is wiped and re-seeds from the next
+/// observed CCbTx (same fail-safe pattern as the other dbs).
+
+#include <core/leveldb_store.hpp>
+#include <core/uint256.hpp>
+#include <core/log.hpp>
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace dash {
+namespace coin {
+
+class CreditPoolDb
+{
+public:
+    explicit CreditPoolDb(const std::string& db_path,
+                          const ::core::LevelDBOptions& opts = {})
+        : m_store(db_path, opts) {}
+
+    bool open()
+    {
+        if (!m_store.open()) return false;
+        load_state();
+        LOG_INFO << "[CP-DB] opened best_height=" << m_best_height
+                 << " best_hash=" << m_best_hash.GetHex().substr(0, 16)
+                 << " balance=" << m_balance
+                 << " initialized=" << (m_initialized ? "yes" : "no");
+        return true;
+    }
+
+    void close() { m_store.close(); }
+    bool is_open() const { return m_store.is_open(); }
+
+    uint256  get_best_hash() const   { return m_best_hash; }
+    uint32_t get_best_height() const { return m_best_height; }
+    int64_t  get_balance() const     { return m_balance; }
+    bool     is_initialized() const  { return m_initialized; }
+
+    // Atomic write of the full state.
+    bool write_state(const uint256& best_hash,
+                     uint32_t       best_height,
+                     int64_t        balance,
+                     bool           initialized)
+    {
+        auto batch = m_store.create_batch();
+        batch.put(make_state_key(),
+                  encode_state(best_hash, best_height, balance, initialized));
+        if (!batch.commit()) {
+            LOG_WARNING << "[CP-DB] write_state batch commit failed";
+            return false;
+        }
+        m_best_hash   = best_hash;
+        m_best_height = best_height;
+        m_balance     = balance;
+        m_initialized = initialized;
+        return true;
+    }
+
+    bool clear()
+    {
+        auto batch = m_store.create_batch();
+        batch.remove(make_state_key());
+        if (!batch.commit()) return false;
+        m_best_hash   = uint256{};
+        m_best_height = 0;
+        m_balance     = 0;
+        m_initialized = false;
+        LOG_INFO << "[CP-DB] cleared";
+        return true;
+    }
+
+private:
+    ::core::LevelDBStore m_store;
+    uint256              m_best_hash;
+    uint32_t             m_best_height{0};
+    int64_t              m_balance{0};
+    bool                 m_initialized{false};
+
+    static std::string make_state_key() { return std::string(1, 'B'); }
+
+    static std::vector<uint8_t> encode_state(const uint256& hash,
+                                             uint32_t       height,
+                                             int64_t        balance,
+                                             bool           initialized)
+    {
+        std::vector<uint8_t> out(45);
+        std::memcpy(out.data(), hash.data(), 32);
+        out[32] = static_cast<uint8_t>( height        & 0xFF);
+        out[33] = static_cast<uint8_t>((height >>  8) & 0xFF);
+        out[34] = static_cast<uint8_t>((height >> 16) & 0xFF);
+        out[35] = static_cast<uint8_t>((height >> 24) & 0xFF);
+        uint64_t u = static_cast<uint64_t>(balance);
+        for (int i = 0; i < 8; ++i)
+            out[36 + i] = static_cast<uint8_t>((u >> (8 * i)) & 0xFF);
+        out[44] = initialized ? 1 : 0;
+        return out;
+    }
+
+    void load_state()
+    {
+        std::vector<uint8_t> data;
+        if (!m_store.get(make_state_key(), data) || data.size() < 45) {
+            return;
+        }
+        std::memcpy(m_best_hash.data(), data.data(), 32);
+        m_best_height = uint32_t(data[32])
+                      | (uint32_t(data[33]) <<  8)
+                      | (uint32_t(data[34]) << 16)
+                      | (uint32_t(data[35]) << 24);
+        uint64_t u = 0;
+        for (int i = 0; i < 8; ++i)
+            u |= uint64_t(data[36 + i]) << (8 * i);
+        m_balance     = static_cast<int64_t>(u);
+        m_initialized = data[44] != 0;
+    }
+};
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/rpc_data.hpp
+++ b/src/impl/dash/coin/rpc_data.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+// Parsed getblocktemplate response with Dash-specific fields.
+// Reference: ref/p2pool-dash/p2pool/dash/helper.py::getwork()
+
+#include "transaction.hpp"
+
+#include <string>
+#include <vector>
+#include <cstdint>
+
+#include <core/uint256.hpp>
+#include <nlohmann/json.hpp>
+
+namespace dash
+{
+namespace coin
+{
+
+// One masternode / superblock / platform payment entry after normalization.
+// payee == "!" + hex_script when the payment is a raw script (OP_RETURN
+// platform payment); otherwise payee is a base58 address.
+struct PackedPayment {
+    std::string payee;
+    uint64_t    amount{0};
+};
+
+struct DashWorkData {
+    // Raw getblocktemplate JSON response (kept for fallback access to fields
+    // we haven't promoted to members yet).
+    nlohmann::json m_raw;
+
+    // Standard Bitcoin-family fields.
+    int32_t               m_version{0};
+    uint256               m_previous_block;
+    uint32_t              m_height{0};
+    uint64_t              m_coinbase_value{0};   // "coinbasevalue" in sat
+    uint32_t              m_bits{0};
+    uint32_t              m_curtime{0};
+    uint32_t              m_mintime{0};
+    std::string           m_coinbase_flags_hex;
+
+    // Transactions from GBT (parsed into full tx objects + their ids).
+    std::vector<Transaction> m_txs;
+    std::vector<uint256>  m_tx_hashes;
+    std::vector<uint64_t> m_tx_fees;
+    // Raw "data" hex for each transaction — kept so we can assemble a full
+    // block to submit via submitblock when a miner wins.
+    std::vector<std::string> m_tx_data_hex;
+
+    // Dash-specific ------------------------------------------------------------
+    // Normalized list of masternode + superblock + platform payments, in the
+    // exact order they must appear in the coinbase outputs.
+    std::vector<PackedPayment> m_packed_payments;
+
+    // Sum of all m_packed_payments[i].amount — this is the portion of the
+    // block reward that miners do NOT receive (masternode+treasury share).
+    uint64_t m_payment_amount{0};
+
+    // DIP3/DIP4 coinbase extra payload (raw bytes, hex-decoded from GBT).
+    // Empty if the daemon did not return one.
+    std::vector<uint8_t> m_coinbase_payload;
+
+    // RPC round-trip latency (seconds).
+    int64_t m_latency{0};
+};
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/transaction.hpp
+++ b/src/impl/dash/coin/transaction.hpp
@@ -1,0 +1,107 @@
+#pragma once
+
+// Dash transaction types: standard Bitcoin transactions + DIP3/DIP4 CBTX support.
+// No MWEB, no HogEx. Has extra_payload for coinbase special transactions (type=5).
+
+#include <impl/bitcoin_family/coin/base_transaction.hpp>
+
+#include <core/pack.hpp>
+#include <core/opscript.hpp>
+#include <core/uint256.hpp>
+
+#include <optional>
+#include <vector>
+
+namespace dash
+{
+namespace coin
+{
+
+// Import generic tx primitives from bitcoin_family
+using bitcoin_family::coin::TxParams;
+using bitcoin_family::coin::TX_WITH_WITNESS;
+using bitcoin_family::coin::TX_NO_WITNESS;
+using bitcoin_family::coin::TxPrevOut;
+using bitcoin_family::coin::TxIn;
+using bitcoin_family::coin::TxOut;
+
+// Dash transaction type field (nType in serialization)
+// type=0: standard, type=5: CBTX (coinbase with DIP3/DIP4 payload)
+struct MutableTransaction
+{
+    std::vector<TxIn> vin;
+    std::vector<TxOut> vout;
+    int32_t version{1};
+    uint16_t type{0};           // Dash-specific: transaction type
+    uint32_t locktime{0};
+    std::vector<unsigned char> extra_payload; // DIP3/DIP4 payload (for type=5 CBTX)
+
+    MutableTransaction() = default;
+
+    bool HasWitness() const { return false; } // Dash has no segwit
+
+    // Dash has no MWEB / HogEx. The field exists only so the
+    // generic `core::coin::UTXOViewCache::connect_block<BlockType>`
+    // template (shared with LTC) can treat every Dash tx as a normal
+    // (non-pegout) block tx without specialisation. Always false.
+    static constexpr bool m_hogEx = false;
+
+    template <typename StreamType>
+    void Serialize(StreamType& s) const
+    {
+        // Dash uses version | (type << 16) in the version field
+        int32_t version_with_type = version | (static_cast<int32_t>(type) << 16);
+        s << version_with_type;
+        s << vin;
+        s << vout;
+        s << locktime;
+        // Extra payload for special transactions (CBTX type=5)
+        if (type != 0 && !extra_payload.empty()) {
+            BaseScript ep;
+            ep.m_data = extra_payload;
+            s << ep;
+        }
+    }
+
+    template <typename StreamType>
+    void Unserialize(StreamType& s)
+    {
+        int32_t version_with_type;
+        s >> version_with_type;
+        version = version_with_type & 0xFFFF;
+        type = static_cast<uint16_t>((version_with_type >> 16) & 0xFFFF);
+        s >> vin;
+        s >> vout;
+        s >> locktime;
+        // Read extra payload for special transactions
+        extra_payload.clear();
+        if (type != 0) {
+            BaseScript ep;
+            s >> ep;
+            extra_payload = std::move(ep.m_data);
+        }
+    }
+};
+
+// Immutable transaction (for txid computation — non-witness serialization)
+class Transaction
+{
+public:
+    static const int32_t CURRENT_VERSION = 1;
+
+    std::vector<TxIn> vin;
+    std::vector<TxOut> vout;
+    int32_t version{1};
+    uint16_t type{0};
+    uint32_t locktime{0};
+    std::vector<unsigned char> extra_payload;
+
+    explicit Transaction(const MutableTransaction& tx)
+        : vin(tx.vin), vout(tx.vout), version(tx.version),
+          type(tx.type), locktime(tx.locktime), extra_payload(tx.extra_payload) {}
+
+    bool HasWitness() const { return false; }
+};
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/vendor/assetlock.hpp
+++ b/src/impl/dash/coin/vendor/assetlock.hpp
@@ -1,0 +1,154 @@
+#pragma once
+
+// Vendored from dashcore/src/evo/assetlocktx.h @ develop cfad414
+// Phase C-TEMPLATE step 13: DIP-0027 asset-lock special tx payloads.
+//
+// Two payload types:
+//
+//   CAssetLockPayload   — special tx type 8 (TRANSACTION_ASSET_LOCK)
+//                         Locks DASH from regular UTXO inputs into the
+//                         credit pool. The tx vouts are OP_RETURN
+//                         markers; the actual credit amounts come from
+//                         the payload's creditOutputs vector. Pool
+//                         balance changes by +sum(creditOutputs.value).
+//
+//   CAssetUnlockPayload — special tx type 9 (TRANSACTION_ASSET_UNLOCK)
+//                         Mints UTXO from the credit pool. The tx has
+//                         NO regular inputs (treasury-class spend
+//                         secured by the LLMQ signature in payload).
+//                         Pool balance changes by -sum(tx.vouts.value).
+//                         (The 'fee' field in the payload is the
+//                         miner fee deducted from the unlock total —
+//                         it goes to the miner's coinbase, NOT into
+//                         the credit pool, so it doesn't appear in
+//                         the credit-pool delta.)
+//
+// Adaptations from upstream:
+//   1. CBLSSignature (96-byte BLS sig) → std::array<uint8_t, 96>.
+//      We store wire bytes opaquely; verification is Phase L material.
+//   2. CTxOut → c2pool's TxOut (same wire format: int64 value +
+//      OPScript scriptPubKey).
+//   3. SERIALIZE_METHODS body re-expressed in pack.hpp form.
+//
+// What's NOT vendored (kept as TODO for full DIP-0027 enforcement):
+//   - GetRequestId() — derives the BLS sign-id for the unlock; needs
+//     LLMQ params + the active quorum set
+//   - VerifyQuorumSig() — full BLS verification
+//   - GetMaximumAssetLockTxSize() / GetMaximumAssetUnlockTxSize() —
+//     ConsensusLimit checks
+//   - Limits on consecutive unlock heights, quorum-rotation
+//     constraints, etc.
+//
+// At MVP this is balance-accounting only: scan blocks, sum the
+// payload deltas, compare against the next-block CCbTx.creditPoolBalance.
+
+#include <impl/dash/coin/vendor/shim.hpp>
+#include <impl/bitcoin_family/coin/base_transaction.hpp>
+
+#include <core/uint256.hpp>
+#include <core/pack.hpp>
+#include <core/pack_types.hpp>
+#include <core/log.hpp>
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+namespace dash {
+namespace coin {
+namespace vendor {
+
+using ::bitcoin_family::coin::TxOut;
+
+struct CAssetLockPayload
+{
+    static constexpr uint16_t SPECIALTX_TYPE     = 8;
+    static constexpr uint8_t  CURRENT_VERSION    = 1;
+
+    uint8_t                nVersion{CURRENT_VERSION};
+    std::vector<TxOut>     creditOutputs;
+
+    SERIALIZE_METHODS(CAssetLockPayload)
+    {
+        READWRITE(obj.nVersion, obj.creditOutputs);
+    }
+
+    int64_t total_credit() const
+    {
+        int64_t sum = 0;
+        for (const auto& o : creditOutputs) sum += o.value;
+        return sum;
+    }
+};
+
+struct CAssetUnlockPayload
+{
+    static constexpr uint16_t SPECIALTX_TYPE     = 9;
+    static constexpr uint8_t  CURRENT_VERSION    = 1;
+    static constexpr size_t   BLS_SIG_SIZE       = 96;
+
+    uint8_t                            nVersion{CURRENT_VERSION};
+    uint64_t                           index{0};
+    uint32_t                           fee{0};
+    uint32_t                           requestedHeight{0};
+    uint256                            quorumHash;
+    std::array<uint8_t, BLS_SIG_SIZE>  quorumSig{};
+
+    SERIALIZE_METHODS(CAssetUnlockPayload)
+    {
+        READWRITE(obj.nVersion, obj.index, obj.fee, obj.requestedHeight,
+                  obj.quorumHash,
+                  Using<RawBytesFormat<BLS_SIG_SIZE>>(obj.quorumSig));
+    }
+};
+
+/// Decode a CAssetLockPayload from a tx's extra_payload bytes. Returns
+/// false on empty / malformed / trailing-garbage payload.
+inline bool parse_assetlock_payload(
+    const std::vector<unsigned char>& extra_payload, CAssetLockPayload& out)
+{
+    if (extra_payload.empty()) return false;
+    try {
+        ::PackStream s(extra_payload);
+        s >> out;
+        if (s.cursor_size() != 0) {
+            LOG_WARNING << "[ASSETLOCK] " << s.cursor_size()
+                        << " trailing bytes after CAssetLockPayload "
+                           "(v=" << static_cast<int>(out.nVersion)
+                        << ") — possible wire-format drift";
+            return false;
+        }
+        return true;
+    } catch (const std::exception& e) {
+        LOG_WARNING << "[ASSETLOCK] parse failed: " << e.what()
+                    << " payload_size=" << extra_payload.size();
+        return false;
+    }
+}
+
+/// Decode a CAssetUnlockPayload from a tx's extra_payload bytes.
+inline bool parse_assetunlock_payload(
+    const std::vector<unsigned char>& extra_payload, CAssetUnlockPayload& out)
+{
+    if (extra_payload.empty()) return false;
+    try {
+        ::PackStream s(extra_payload);
+        s >> out;
+        if (s.cursor_size() != 0) {
+            LOG_WARNING << "[ASSETUNLOCK] " << s.cursor_size()
+                        << " trailing bytes after CAssetUnlockPayload "
+                           "(v=" << static_cast<int>(out.nVersion)
+                        << ") — possible wire-format drift";
+            return false;
+        }
+        return true;
+    } catch (const std::exception& e) {
+        LOG_WARNING << "[ASSETUNLOCK] parse failed: " << e.what()
+                    << " payload_size=" << extra_payload.size();
+        return false;
+    }
+}
+
+} // namespace vendor
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/vendor/assetlock.hpp
+++ b/src/impl/dash/coin/vendor/assetlock.hpp
@@ -68,7 +68,7 @@ struct CAssetLockPayload
     uint8_t                nVersion{CURRENT_VERSION};
     std::vector<TxOut>     creditOutputs;
 
-    SERIALIZE_METHODS(CAssetLockPayload)
+    C2POOL_SERIALIZE_METHODS(CAssetLockPayload)
     {
         READWRITE(obj.nVersion, obj.creditOutputs);
     }
@@ -94,7 +94,7 @@ struct CAssetUnlockPayload
     uint256                            quorumHash;
     std::array<uint8_t, BLS_SIG_SIZE>  quorumSig{};
 
-    SERIALIZE_METHODS(CAssetUnlockPayload)
+    C2POOL_SERIALIZE_METHODS(CAssetUnlockPayload)
     {
         READWRITE(obj.nVersion, obj.index, obj.fee, obj.requestedHeight,
                   obj.quorumHash,

--- a/src/impl/dash/coin/vendor/cbtx.hpp
+++ b/src/impl/dash/coin/vendor/cbtx.hpp
@@ -1,0 +1,125 @@
+#pragma once
+
+// Vendored from dashcore/src/evo/cbtx.h @ develop cfad414
+// (Dash Core v23.1-dev, current `develop` branch as of 2026-04-23).
+//
+// Adaptations from upstream:
+//   1. CCbTx::Version is an `enum class` upstream, kept serializable via
+//      `is_serializable_enum` template specialization. pack.hpp doesn't
+//      have an equivalent specialization machinery; we store nVersion as
+//      a raw uint16_t and expose the named values as constexpr constants.
+//   2. CBLSSignature is replaced by a 96-byte std::array. We don't
+//      verify BLS signatures at Phase C-SML — Phase L will introduce a
+//      real BLS lib and migrate this field. The wire bytes are
+//      preserved unchanged so future verification can re-hydrate.
+//   3. CAmount → int64_t (c2pool has no CAmount typedef; the wire
+//      width is identical, signed 64-bit LE).
+//   4. SERIALIZE_METHODS body re-expressed in pack.hpp form. See
+//      vendor/shim.hpp preamble for why pack.hpp + btclibs/serialize.h
+//      cannot share a translation unit.
+//   5. The validation functions (CheckCbTx, CalcCbTxMerkleRootQuorums,
+//      GetNonNullCoinbaseChainlock) are NOT vendored — they require
+//      ChainstateManager + CDeterministicMNList + LLMQ infrastructure
+//      we don't have. We only need wire decode + the merkleRootMNList
+//      field to verify against our own SML in Phase C-SML step 7.
+
+#include <impl/dash/coin/vendor/shim.hpp>
+
+#include <core/uint256.hpp>
+#include <core/pack.hpp>
+#include <core/pack_types.hpp>
+#include <core/log.hpp>
+
+#include <array>
+#include <cstdint>
+#include <sstream>
+#include <vector>
+
+namespace dash {
+namespace coin {
+namespace vendor {
+
+struct CCbTx
+{
+    static constexpr uint16_t VERSION_INVALID             = 0;
+    static constexpr uint16_t VERSION_MERKLE_ROOT_MNLIST  = 1;
+    static constexpr uint16_t VERSION_MERKLE_ROOT_QUORUMS = 2;
+    static constexpr uint16_t VERSION_CLSIG_AND_BALANCE   = 3;
+
+    static constexpr size_t BLS_SIG_SIZE = 96;
+
+    uint16_t                          nVersion{VERSION_MERKLE_ROOT_QUORUMS};
+    int32_t                           nHeight{0};
+    uint256                           merkleRootMNList;
+    uint256                           merkleRootQuorums;
+    uint32_t                          bestCLHeightDiff{0};
+    std::array<uint8_t, BLS_SIG_SIZE> bestCLSignature{};
+    int64_t                           creditPoolBalance{0};
+
+    SERIALIZE_METHODS(CCbTx)
+    {
+        READWRITE(obj.nVersion, obj.nHeight, obj.merkleRootMNList);
+        if (obj.nVersion >= VERSION_MERKLE_ROOT_QUORUMS) {
+            READWRITE(obj.merkleRootQuorums);
+            if (obj.nVersion >= VERSION_CLSIG_AND_BALANCE) {
+                READWRITE(VarInt(obj.bestCLHeightDiff));
+                READWRITE(Using<RawBytesFormat<BLS_SIG_SIZE>>(obj.bestCLSignature));
+                READWRITE(obj.creditPoolBalance);
+            }
+        }
+    }
+
+    // True if any byte of bestCLSignature is non-zero. Empty (all-zero)
+    // sigs are valid wire encodings — they signal "no chainlock for the
+    // window" — and must NOT be treated as verification failures.
+    bool has_best_cl_signature() const
+    {
+        for (auto b : bestCLSignature) if (b != 0) return true;
+        return false;
+    }
+
+    std::string short_str() const
+    {
+        std::ostringstream os;
+        os << "v=" << nVersion
+           << " h=" << nHeight
+           << " mnlist=" << merkleRootMNList.GetHex().substr(0, 16);
+        if (nVersion >= VERSION_MERKLE_ROOT_QUORUMS)
+            os << " quorums=" << merkleRootQuorums.GetHex().substr(0, 16);
+        if (nVersion >= VERSION_CLSIG_AND_BALANCE) {
+            os << " clHeightDiff=" << bestCLHeightDiff
+               << " clSig=" << (has_best_cl_signature() ? "set" : "null")
+               << " creditPool=" << creditPoolBalance;
+        }
+        return os.str();
+    }
+};
+
+// Decode CCbTx from a coinbase tx's extra_payload bytes. Returns false
+// if the payload is empty, malformed, or has trailing garbage.
+inline bool parse_cbtx(const std::vector<unsigned char>& extra_payload, CCbTx& out)
+{
+    if (extra_payload.empty()) return false;
+    try {
+        ::PackStream s(extra_payload);
+        s >> out;
+        // Strict: trailing bytes after the CCbTx mean we have a wrong
+        // version assumption or upstream added a new field. Either way
+        // the merkle-root-mn-list field we just read may be off.
+        if (s.cursor_size() != 0) {
+            LOG_WARNING << "[CBTX] " << s.cursor_size()
+                        << " trailing bytes after CCbTx (v=" << out.nVersion
+                        << ") — possible wire-format drift";
+            return false;
+        }
+        return true;
+    } catch (const std::exception& e) {
+        LOG_WARNING << "[CBTX] parse failed: " << e.what()
+                    << " payload_size=" << extra_payload.size();
+        return false;
+    }
+}
+
+} // namespace vendor
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/vendor/cbtx.hpp
+++ b/src/impl/dash/coin/vendor/cbtx.hpp
@@ -56,7 +56,7 @@ struct CCbTx
     std::array<uint8_t, BLS_SIG_SIZE> bestCLSignature{};
     int64_t                           creditPoolBalance{0};
 
-    SERIALIZE_METHODS(CCbTx)
+    C2POOL_SERIALIZE_METHODS(CCbTx)
     {
         READWRITE(obj.nVersion, obj.nHeight, obj.merkleRootMNList);
         if (obj.nVersion >= VERSION_MERKLE_ROOT_QUORUMS) {

--- a/src/impl/dash/coin/vendor/shim.hpp
+++ b/src/impl/dash/coin/vendor/shim.hpp
@@ -1,0 +1,196 @@
+#pragma once
+
+// Adapter shim mapping dashcore's blockencodings type names and custom
+// formatters onto c2pool's pack.hpp serialization framework.
+//
+// Why this exists: c2pool has two serialization frameworks in the tree —
+// the Bitcoin-Core-derived btclibs/serialize.h (SERIALIZE_METHODS macro
+// taking (cls, obj), VectorFormatter/CustomUintFormatter/DifferenceFormatter,
+// ser_action.ForRead()) and c2pool's own pack.hpp (SERIALIZE_METHODS(TYPE),
+// ListType/IntType/BigEndianFormat, formatter-variable-based
+// discrimination). They collide when pulled into the same translation
+// unit because the Serialize/Unserialize overloads and CompactSize
+// helpers both live in the global namespace. p2p_messages.hpp is built on
+// pack.hpp, and this vendor has to coexist with it.
+//
+// So instead of dragging btclibs/serialize.h into the vendor file, this
+// shim provides drop-in replacements that mimic dashcore's formatter
+// interface on top of pack.hpp. Byte-for-byte wire compatibility is
+// preserved; only the C++ surface changes.
+//
+// Vendored files keep dashcore's class names and algorithmic bodies
+// verbatim; the SERIALIZE_METHODS bodies are re-expressed in c2pool's
+// FORMAT_METHODS style (single Write/Read split via the formatter-type
+// discriminator — see vendor/blockencodings.hpp).
+
+#include <impl/dash/coin/block.hpp>
+#include <impl/dash/coin/transaction.hpp>
+
+#include <core/pack.hpp>
+#include <core/pack_types.hpp>
+
+#include <cassert>
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <utility>
+
+namespace dash {
+namespace coin {
+namespace vendor {
+
+// ── Type mapping to c2pool primitives ──────────────────────────────────────
+//
+// Dashcore passes transactions by `CTransactionRef = shared_ptr<const CTransaction>`.
+// c2pool-dash doesn't have an immutable serialisable `Transaction` type;
+// `MutableTransaction` is the serialisable one. Keep the shared-ptr-of-const
+// discipline so callers can't mutate a shared payload in-place.
+using CTransactionRef = std::shared_ptr<const ::dash::coin::MutableTransaction>;
+
+inline CTransactionRef MakeTransactionRef(const ::dash::coin::MutableTransaction& tx) {
+    return std::make_shared<::dash::coin::MutableTransaction>(tx);
+}
+
+inline CTransactionRef MakeTransactionRef(::dash::coin::MutableTransaction&& tx) {
+    return std::make_shared<::dash::coin::MutableTransaction>(std::move(tx));
+}
+
+using CBlockHeader = ::dash::coin::BlockHeaderType;
+using CBlock       = ::dash::coin::BlockType;
+
+// ── Mempool snapshot provider ──────────────────────────────────────────────
+//
+// Replaces the raw `CTxMemPool*` dashcore threads through
+// PartiallyDownloadedBlock. The provider returns a snapshot of
+// (txid, tx) pairs for the reassembler to try matching against the
+// compact block's short IDs. Dashcore iterates `pool->vTxHashes`
+// directly under its mempool lock; we ask the caller for a vector so
+// the mempool-lock policy stays on their side.
+//
+// Phase M (mempool) returns a real snapshot here; pre-Phase-M the
+// provider is null and every cmpctblock falls through to a full
+// getblocktxn round-trip.
+using MempoolShortIdProvider =
+    std::function<std::vector<std::pair<uint256, CTransactionRef>>()>;
+
+// ── Formatters bridging dashcore idioms to pack.hpp ────────────────────────
+
+// 6-byte little-endian uint64 (BIP 152 SHORTTXIDS_LENGTH). Replaces
+// dashcore's CustomUintFormatter<6>. Values above 2^48-1 are rejected on
+// write; reads zero-extend from the 6 stream bytes.
+struct ShortTxIdFormat
+{
+    template <typename Stream>
+    static void Write(Stream& s, uint64_t v)
+    {
+        assert(v <= 0xFFFFFFFFFFFFULL);
+        uint8_t buf[6];
+        for (int i = 0; i < 6; ++i)
+            buf[i] = static_cast<uint8_t>((v >> (i * 8)) & 0xff);
+        s.write(std::as_bytes(std::span{buf}));
+    }
+
+    template <typename Stream>
+    static void Read(Stream& s, uint64_t& v)
+    {
+        uint8_t buf[6];
+        s.read(std::as_writable_bytes(std::span{buf}));
+        v = 0;
+        for (int i = 0; i < 6; ++i)
+            v |= static_cast<uint64_t>(buf[i]) << (i * 8);
+    }
+};
+
+// Transaction compression = default serialization for CTransactionRef.
+// Dashcore hides this behind `TransactionCompression = DefaultFormatter`
+// and expects shared_ptr<const T> to round-trip; we unpack the shared_ptr
+// manually to avoid needing a deserialize_type constructor on
+// MutableTransaction (that constructor would force btclibs/serialize.h
+// into the widely-included transaction.hpp — see shim.hpp preamble).
+struct TxCompressionFormat
+{
+    template <typename Stream>
+    static void Write(Stream& s, const CTransactionRef& p)
+    {
+        assert(p);
+        s << *p;
+    }
+
+    template <typename Stream>
+    static void Read(Stream& s, CTransactionRef& p)
+    {
+        auto tx = std::make_shared<::dash::coin::MutableTransaction>();
+        s >> *tx;
+        p = std::const_pointer_cast<const ::dash::coin::MutableTransaction>(tx);
+    }
+};
+
+// Fixed-size raw byte sequence — no length prefix, just N bytes
+// written/read directly. Used by Phase C-SML for opaque BLS public
+// keys (48 B), key IDs (20 B), and BLS signatures (96 B) — we don't
+// validate them at MVP, just pass-through-correct serialization so
+// merkle-root calculations match dashcore bit-exact.
+template <size_t N>
+struct RawBytesFormat
+{
+    template <typename Stream>
+    static void Write(Stream& s, const std::array<uint8_t, N>& arr)
+    {
+        s.write(std::as_bytes(std::span{arr}));
+    }
+
+    template <typename Stream>
+    static void Read(Stream& s, std::array<uint8_t, N>& arr)
+    {
+        s.read(std::as_writable_bytes(std::span{arr}));
+    }
+};
+
+// Differential compact-size vector encoding. Vendored verbatim from
+// dashcore/src/blockencodings.h (DifferenceFormatter), re-expressed as
+// a c2pool per-vector Format rather than a per-element Formatter.
+// First entry writes as its absolute value; each subsequent entry is
+// (current - previous - 1) so a strictly-increasing sequence stays
+// compact. Required by BIP 152 getblocktxn wire layout.
+struct DifferenceListFormat
+{
+    template <typename Stream, typename V>
+    static void Write(Stream& s, const V& values)
+    {
+        WriteCompactSize(s, values.size());
+        uint64_t shift = 0;
+        for (const auto& v : values) {
+            if (static_cast<uint64_t>(v) < shift ||
+                static_cast<uint64_t>(v) >= std::numeric_limits<uint64_t>::max())
+                throw std::ios_base::failure("differential value overflow");
+            WriteCompactSize(s, static_cast<uint64_t>(v) - shift);
+            shift = static_cast<uint64_t>(v) + 1;
+        }
+    }
+
+    template <typename Stream, typename V>
+    static void Read(Stream& s, V& values)
+    {
+        using I = typename V::value_type;
+        values.clear();
+        auto n = ReadCompactSize(s);
+        values.reserve(n);
+        uint64_t shift = 0;
+        for (size_t i = 0; i < n; ++i) {
+            uint64_t delta = ReadCompactSize(s);
+            shift += delta;
+            if (shift < delta
+                || shift >= std::numeric_limits<uint64_t>::max()
+                || shift < std::numeric_limits<I>::min()
+                || shift > std::numeric_limits<I>::max())
+                throw std::ios_base::failure("differential value overflow");
+            values.push_back(static_cast<I>(shift));
+            ++shift;
+        }
+    }
+};
+
+} // namespace vendor
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coinbase_builder.hpp
+++ b/src/impl/dash/coinbase_builder.hpp
@@ -1,0 +1,451 @@
+#pragma once
+
+// Dash coinbase TX assembly for p2pool-dash v16 compatible Stratum mining.
+//
+// The layout is dictated by the hash_link mechanism documented in
+// share_check.hpp::compute_gentx_before_refhash:
+//
+//   [ver|type int32]
+//   [vin VarInt = 1]
+//   [TxIn:
+//      [prev_hash 32B zeros][prev_n 0xFFFFFFFF]
+//      [VarStr scriptSig:
+//         [BIP34 height push][pool_tag]          ← no extranonce here anymore
+//      ]
+//      [sequence 0xFFFFFFFF]
+//   ]
+//   [vout VarInt]
+//     [worker_payouts…]                          ← PPLNS splits
+//     [packed_payments…]                         ← masternode/superblock/platform
+//     [donation_output:
+//        [value i64][VarStr DONATION_SCRIPT]     ← constant tail; value usually 0
+//     ]
+//     [op_return_output:
+//        [value i64 = 0][VarStr (42B):
+//           [0x6a OP_RETURN][0x28 push40]
+//           [ref_hash 32B]      ← pool fills; PPLNS commitment
+//           [nonce64 8B]        ← miner fills via Stratum extranonce2
+//        ]
+//     ]
+//   [locktime 4B = 0]
+//   [optional VarStr extra_payload]              ← DIP3/DIP4 CBTX
+//
+// The 8-byte `nonce64` placeholder is the Stratum extranonce2 slot.
+// Coinb1 = bytes[0 : nonce64_offset]      ( includes ref_hash )
+// Coinb2 = bytes[nonce64_offset + 8 : ]   ( starts at locktime )
+
+#include "coin/transaction.hpp"
+#include "coin/rpc_data.hpp"
+#include "share_check.hpp"                 // decode_payee_script, pubkey_hash_to_script2, DONATION_SCRIPT
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <span>
+#include <string>
+#include <vector>
+
+#include <core/pack.hpp>
+#include <core/uint256.hpp>
+#include <core/hash.hpp>
+#include <core/coin_params.hpp>
+#include <btclibs/util/strencodings.h>
+
+namespace dash {
+namespace coinbase {
+
+static constexpr size_t EXTRANONCE2_SIZE = 8;          // = nonce64 width
+
+// One miner payout row: scriptPubKey + amount (sat).
+struct MinerPayout {
+    std::vector<unsigned char> script;
+    uint64_t                   amount{0};
+};
+
+// Replica of p2pool-dash/p2pool/data.py:181-231 generate_transaction
+// tx_outs construction. Returns tx_outs in the exact on-wire order:
+//     worker_tx (sorted by script bytes, excluding DONATION) ||
+//     payments_tx (packed_payments in GBT order)             ||
+//     donation_tx (always one entry, even at value 0)
+// Does NOT include the OP_RETURN — coinbase::build() appends that.
+//
+// For genesis (no previous shares on the chain), pass an empty weights
+// map and total_weight == 0. For non-genesis shares the caller supplies
+// tracker-derived PPLNS weights from share_builder::walk_cumulative_weights
+// (a linear port of p2pool-dash's WeightsSkipList — O(N) per call rather
+// than the Python upstream's O(log N), but consensus-equivalent since
+// chain_length=4320 makes the walk cheap).
+inline std::vector<MinerPayout> compute_dash_payouts(
+    uint64_t subsidy,
+    const std::vector<dash::coin::PackedPayment>& packed_payments,
+    const uint160& miner_pubkey_hash,
+    const std::map<std::vector<unsigned char>, uint64_t>& weights,
+    uint64_t total_weight,
+    const core::CoinParams& params)
+{
+    using Script = std::vector<unsigned char>;
+    const Script donation_script(dash::DONATION_SCRIPT.begin(),
+                                  dash::DONATION_SCRIPT.end());
+
+    // 1. payments_tx: preserves GBT order, drops zero-value entries + undecodable payees.
+    std::vector<MinerPayout> payments_tx;
+    payments_tx.reserve(packed_payments.size());
+    uint64_t total_payments = 0;
+    for (const auto& p : packed_payments) {
+        if (p.amount == 0) continue;
+        auto pm_script = dash::decode_payee_script(
+            p.payee, params.address_version, params.address_p2sh_version);
+        if (pm_script.empty()) continue;
+        MinerPayout out;
+        out.amount = p.amount;
+        out.script = std::move(pm_script);
+        payments_tx.push_back(std::move(out));
+        total_payments += p.amount;
+    }
+
+    // 2. worker_payout = subsidy - Σpayment_amounts
+    uint64_t worker_payout = (subsidy > total_payments) ? (subsidy - total_payments) : 0;
+
+    // 3. amounts[script] = worker_payout * 49 * weight / (50 * total_weight)
+    //    (skipped for genesis where total_weight==0; populated for
+    //    non-genesis shares via walk_cumulative_weights).
+    std::map<Script, uint64_t> amounts;
+    if (total_weight > 0) {
+        // uint128-ish: worker_payout < 2^50, 49 < 2^6, weight < ~2^80 for a few
+        // shares; use explicit 128-bit to avoid silent overflow.
+        __uint128_t den = static_cast<__uint128_t>(total_weight) * 50;
+        for (const auto& [script, w] : weights) {
+            __uint128_t num = static_cast<__uint128_t>(w)
+                            * static_cast<__uint128_t>(worker_payout)
+                            * 49;
+            amounts[script] = static_cast<uint64_t>(num / den);
+        }
+    }
+
+    // 4. amounts[this_script] += worker_payout // 50  (2 % block-finder).
+    auto this_script = dash::pubkey_hash_to_script2(miner_pubkey_hash);
+    amounts[this_script] = amounts[this_script] + (worker_payout / 50);
+
+    // 5. amounts[DONATION] += worker_payout - Σamounts  (remainder incl. rounding).
+    uint64_t current_sum = 0;
+    for (const auto& [s, a] : amounts) current_sum += a;
+    uint64_t donation_remainder = (worker_payout > current_sum)
+        ? (worker_payout - current_sum) : 0;
+    amounts[donation_script] = amounts[donation_script] + donation_remainder;
+
+    // Sanity: Σ(amounts) == worker_payout (matches p2pool-dash assertion).
+    {
+        uint64_t check = 0;
+        for (const auto& [s, a] : amounts) check += a;
+        if (check != worker_payout) {
+            LOG_WARNING << "[compute_dash_payouts] sum mismatch: worker_payout="
+                        << worker_payout << " check=" << check
+                        << " diff=" << (check > worker_payout
+                                        ? (check - worker_payout)
+                                        : (worker_payout - check))
+                        << " total_weight=" << total_weight
+                        << " weights_count=" << weights.size()
+                        << " this_script_in_weights="
+                        << (weights.count(this_script) ? "yes" : "no")
+                        << " subsidy=" << subsidy
+                        << " total_payments=" << total_payments
+                        << " current_sum_before_donation=" << current_sum
+                        << " donation_remainder=" << donation_remainder;
+            throw std::runtime_error("compute_dash_payouts: amounts sum mismatch");
+        }
+    }
+
+    // 6. worker_tx = amounts sorted by script bytes, excluding DONATION,
+    //               dropping zero-value entries. std::map is already sorted.
+    std::vector<MinerPayout> worker_tx;
+    worker_tx.reserve(amounts.size());
+    for (const auto& [script, amount] : amounts) {
+        if (script == donation_script) continue;
+        if (amount == 0) continue;
+        MinerPayout out;
+        out.amount = amount;
+        out.script = script;
+        worker_tx.push_back(std::move(out));
+    }
+
+    // 7. donation_tx — always emitted even at value 0.
+    MinerPayout donation_out;
+    donation_out.amount = amounts[donation_script];
+    donation_out.script = donation_script;
+
+    // 8. Final order: worker_tx || payments_tx || donation_tx.
+    std::vector<MinerPayout> result;
+    result.reserve(worker_tx.size() + payments_tx.size() + 1);
+    for (auto& o : worker_tx)   result.push_back(std::move(o));
+    for (auto& o : payments_tx) result.push_back(std::move(o));
+    result.push_back(std::move(donation_out));
+    return result;
+}
+
+// Result of build(): raw coinbase bytes + key offsets.
+struct CoinbaseLayout {
+    std::vector<unsigned char> bytes;
+    size_t ref_hash_offset{0};   // first byte of the 32B ref_hash region
+    size_t nonce64_offset{0};    // first byte of the 8B nonce64 placeholder
+                                 // (always == ref_hash_offset + 32)
+};
+
+// BIP34 minimal push of a positive integer. Writes length byte + height LE.
+inline std::vector<unsigned char> push_bip34_height(uint32_t height)
+{
+    std::vector<unsigned char> le;
+    le.reserve(4);
+    uint32_t h = height;
+    while (h) {
+        le.push_back(static_cast<unsigned char>(h & 0xff));
+        h >>= 8;
+    }
+    if (le.empty()) le.push_back(0x00);                 // push 0 → [01 00]
+    if (le.back() & 0x80) le.push_back(0x00);           // avoid sign
+
+    std::vector<unsigned char> out;
+    out.reserve(1 + le.size());
+    out.push_back(static_cast<unsigned char>(le.size()));
+    out.insert(out.end(), le.begin(), le.end());
+    return out;
+}
+
+// Convert compact nbits → share difficulty (Bitcoin bdiff formula).
+inline double bits_to_difficulty(uint32_t nbits)
+{
+    uint256 target;
+    target.SetCompact(nbits);
+    if (target.IsNull()) return 0.0;
+    uint256 shifted = target >> 192;
+    uint64_t top = shifted.GetLow64();
+    if (top == 0) return 0.0;
+    const double bdiff_const = 4294901760.0;  // 0xffff0000
+    return bdiff_const / static_cast<double>(top);
+}
+
+// Build the coinbase TX in the p2pool-dash v16 layout.
+//
+//   work             — parsed GBT
+//   tx_outs_ordered  — full output list in p2pool-dash generate_transaction
+//                      order: worker_tx || payments_tx || donation_tx.
+//                      Must end with a donation output whose script ==
+//                      DONATION_SCRIPT so gentx_before_refhash lines up.
+//                      Zero-value entries are emitted as-is (callers that
+//                      want to strip them should do so before calling).
+//   pool_tag         — short tag in coinbase scriptSig (no extranonce)
+//   params           — coin params (unused here; retained for symmetry)
+//   ref_hash         — 32B PPLNS commitment embedded in OP_RETURN
+inline CoinbaseLayout build(const dash::coin::DashWorkData& work,
+                            const std::vector<MinerPayout>& tx_outs_ordered,
+                            const std::string& pool_tag,
+                            const core::CoinParams& params,
+                            const uint256& ref_hash)
+{
+    (void)params;
+    using namespace dash::coin;
+
+    MutableTransaction tx;
+
+    // ── Input ───────────────────────────────────────────────────────────
+    TxIn in;
+    in.prevout.hash  = uint256::ZERO;
+    in.prevout.index = 0xFFFFFFFFu;
+    in.sequence      = 0xFFFFFFFFu;
+    {
+        std::vector<unsigned char> script;
+        auto h_push = push_bip34_height(work.m_height);
+        script.insert(script.end(), h_push.begin(), h_push.end());
+        script.insert(script.end(), pool_tag.begin(), pool_tag.end());
+        in.scriptSig = OPScript(script.data(), script.data() + script.size());
+    }
+    tx.vin.push_back(std::move(in));
+
+    // ── Outputs (caller-ordered tx_outs + OP_RETURN) ────────────────────
+    //
+    // Caller (share_builder / compute_dash_payouts) has already put the
+    // tx_outs into the exact p2pool-dash generate_transaction order,
+    // including a guaranteed donation output at the tail. We trust that
+    // and just append.
+    if (tx_outs_ordered.empty())
+        throw std::runtime_error("coinbase_builder: empty tx_outs_ordered");
+    if (tx_outs_ordered.back().script !=
+        std::vector<unsigned char>(dash::DONATION_SCRIPT.begin(),
+                                    dash::DONATION_SCRIPT.end()))
+        throw std::runtime_error(
+            "coinbase_builder: last output must be DONATION_SCRIPT");
+
+    for (const auto& p : tx_outs_ordered) {
+        TxOut o;
+        o.value = static_cast<int64_t>(p.amount);
+        o.scriptPubKey = OPScript(
+            p.script.data(), p.script.data() + p.script.size());
+        tx.vout.push_back(std::move(o));
+    }
+    // OP_RETURN output carrying [0x6a][0x28][ref_hash 32B][nonce64 8B].
+    {
+        std::vector<unsigned char> op_ret;
+        op_ret.reserve(2 + 32 + 8);
+        op_ret.push_back(0x6a);                             // OP_RETURN
+        op_ret.push_back(0x28);                             // push 40 bytes
+        op_ret.insert(op_ret.end(), ref_hash.data(), ref_hash.data() + 32);
+        op_ret.insert(op_ret.end(), EXTRANONCE2_SIZE, 0x00); // nonce64 placeholder
+        TxOut o;
+        o.value = 0;
+        o.scriptPubKey = OPScript(op_ret.data(), op_ret.data() + op_ret.size());
+        tx.vout.push_back(std::move(o));
+    }
+
+    // ── DIP3/DIP4 ───────────────────────────────────────────────────────
+    if (!work.m_coinbase_payload.empty()) {
+        tx.version = 3;
+        tx.type    = 5;
+        tx.extra_payload = work.m_coinbase_payload;
+    }
+    tx.locktime = 0;
+
+    // ── Serialize ───────────────────────────────────────────────────────
+    auto packed = pack(tx);
+    auto raw = packed.get_span();
+    CoinbaseLayout out;
+    out.bytes.reserve(raw.size());
+    for (auto b : raw) out.bytes.push_back(static_cast<unsigned char>(b));
+
+    // ── Locate ref_hash / nonce64 positions from the tail ───────────────
+    // Tail layout (bytes, from end of tx moving toward start):
+    //   [VarStr extra_payload]?   — length = payload_varstr_size
+    //   [locktime 4B]
+    //   [nonce64 8B]              ← EXTRANONCE2_SIZE bytes of zeros (miner fills)
+    //   [ref_hash 32B]            ← the ref_hash we just embedded
+    //   [0x28 push40]
+    //   [0x6a OP_RETURN]
+    //   [0x2a VarInt script_len 42]
+    //   [value i64 = 0]
+    //
+    // So offsets-from-end:
+    //   nonce64_offset  = total - payload_varstr_size - 4 - 8
+    //   ref_hash_offset = total - payload_varstr_size - 4 - 8 - 32
+    size_t payload_varstr_size = 0;
+    if (tx.type != 0 && !tx.extra_payload.empty()) {
+        PackStream ps;
+        BaseScript bs; bs.m_data = tx.extra_payload;
+        ps << bs;
+        payload_varstr_size = ps.size();
+    }
+    const size_t total = out.bytes.size();
+    if (total < payload_varstr_size + 4 + 8 + 32)
+        throw std::runtime_error("coinbase_builder: tx shorter than known tail");
+    out.nonce64_offset  = total - payload_varstr_size - 4 - 8;
+    out.ref_hash_offset = out.nonce64_offset - 32;
+
+    // Sanity: bytes at ref_hash_offset must equal the ref_hash we embedded.
+    if (std::memcmp(out.bytes.data() + out.ref_hash_offset, ref_hash.data(), 32) != 0)
+        throw std::runtime_error("coinbase_builder: ref_hash offset mismatch");
+    // Sanity: bytes at nonce64_offset must be 8 zero bytes.
+    for (size_t i = 0; i < EXTRANONCE2_SIZE; ++i) {
+        if (out.bytes[out.nonce64_offset + i] != 0x00)
+            throw std::runtime_error("coinbase_builder: nonce64 placeholder not zeroed");
+    }
+
+    return out;
+}
+
+// Split coinbase bytes into coinb1 / coinb2 hex around the 8-byte nonce64
+// slot. The miner inserts its extranonce2 in that slot.
+struct CoinbSplit {
+    std::string coinb1_hex;
+    std::string coinb2_hex;
+};
+
+inline CoinbSplit split_coinb(const CoinbaseLayout& lay)
+{
+    if (lay.nonce64_offset + EXTRANONCE2_SIZE > lay.bytes.size())
+        throw std::runtime_error("split_coinb: bad nonce64 offset");
+    std::span<const unsigned char> b1(lay.bytes.data(), lay.nonce64_offset);
+    std::span<const unsigned char> b2(
+        lay.bytes.data() + lay.nonce64_offset + EXTRANONCE2_SIZE,
+        lay.bytes.size() - lay.nonce64_offset - EXTRANONCE2_SIZE);
+    return CoinbSplit{HexStr(b1), HexStr(b2)};
+}
+
+// Compute sha256d of concatenated bytes.
+inline uint256 sha256d(std::span<const unsigned char> a)
+{
+    return Hash(a);
+}
+
+// Merkle branches for index 0 with placeholder at [0]. (Siblings along the
+// path do not depend on [0] even though it participates in the reduction.)
+inline std::vector<uint256> merkle_branches_raw(
+    const std::vector<uint256>& tx_hashes_including_coinbase_placeholder)
+{
+    std::vector<uint256> out;
+    if (tx_hashes_including_coinbase_placeholder.size() <= 1) return out;
+
+    std::vector<uint256> layer = tx_hashes_including_coinbase_placeholder;
+    while (layer.size() > 1) {
+        out.push_back(layer[1]);
+        if (layer.size() % 2 == 1)
+            layer.push_back(layer.back());
+        std::vector<uint256> next;
+        next.reserve(layer.size() / 2);
+        for (size_t i = 0; i + 1 < layer.size(); i += 2) {
+            std::vector<unsigned char> buf(64);
+            std::memcpy(buf.data(),      layer[i].data(),     32);
+            std::memcpy(buf.data() + 32, layer[i + 1].data(), 32);
+            next.push_back(sha256d(buf));
+        }
+        layer.swap(next);
+    }
+    return out;
+}
+
+inline std::vector<std::string> merkle_branches_hex(const std::vector<uint256>& raw)
+{
+    // Stratum convention for merkle branches: send the LE internal bytes
+    // directly as hex, NOT the reversed display form. cpuminer ParseHex's
+    // the hex into a byte array and uses those bytes verbatim in its
+    // merkle walk (SHA256d(root_LE || branch_LE)). Our server walks the
+    // same way using h.GetChars() (LE internal). Using h.GetHex() here —
+    // which reverses bytes for the block-explorer display form — made
+    // the miner's walk produce a different root than the server's, every
+    // submit failed with "hash > target" (hash was essentially random).
+    // Reference: p2pool-dash dash/stratum.py packs merkle branches as
+    //   [pack.IntType(256).pack(s).encode('hex') for s in link.branch]
+    // which is LE bytes as hex — NOT the reversed display form.
+    std::vector<std::string> out;
+    out.reserve(raw.size());
+    for (const auto& h : raw) {
+        auto c = h.GetChars();
+        out.push_back(HexStr(std::span<const unsigned char>(c.data(), c.size())));
+    }
+    return out;
+}
+
+// ── Stratum wire formatting helpers ─────────────────────────────────────────
+
+inline std::string swap4_hex(std::span<const unsigned char> data)
+{
+    if (data.size() % 4 != 0) throw std::runtime_error("swap4_hex: len %4 != 0");
+    std::vector<unsigned char> out(data.size());
+    for (size_t i = 0; i < data.size(); i += 4) {
+        out[i + 0] = data[i + 3];
+        out[i + 1] = data[i + 2];
+        out[i + 2] = data[i + 1];
+        out[i + 3] = data[i + 0];
+    }
+    return HexStr(out);
+}
+
+inline std::string be_hex_u32(uint32_t v)
+{
+    unsigned char b[4] = {
+        static_cast<unsigned char>((v >> 24) & 0xff),
+        static_cast<unsigned char>((v >> 16) & 0xff),
+        static_cast<unsigned char>((v >>  8) & 0xff),
+        static_cast<unsigned char>((v >>  0) & 0xff),
+    };
+    return HexStr(std::span<const unsigned char>(b, 4));
+}
+
+} // namespace coinbase
+} // namespace dash

--- a/src/impl/dash/coinbase_builder.hpp
+++ b/src/impl/dash/coinbase_builder.hpp
@@ -49,6 +49,7 @@
 #include <core/uint256.hpp>
 #include <core/hash.hpp>
 #include <core/coin_params.hpp>
+#include <core/log.hpp>
 #include <btclibs/util/strencodings.h>
 
 namespace dash {

--- a/src/impl/dash/pplns.hpp
+++ b/src/impl/dash/pplns.hpp
@@ -1,0 +1,187 @@
+#pragma once
+
+// PPLNS payout computation for c2pool-dash.
+//
+// Walks the Dash sharechain backward from a tip, aggregates weight per
+// recipient pubkey_hash, and splits a total miner_value proportionally.
+// Dust-sized allocations are dropped and their residue pushed onto the
+// largest remaining payout.
+//
+// If the chain has fewer than min_shares_for_pplns reachable ancestors,
+// compute_payouts() falls back to a single-recipient payout to the caller's
+// fallback_script (typically --mining-address). This mirrors p2pool's
+// genesis behavior: when no share history exists, the node mines solo.
+//
+// Scope boundary:
+//   * We treat the chain's recorded shares as authoritative contributors.
+//     Shares we received from the network count — that's the whole point
+//     of p2pool cooperative mining.
+//   * We do NOT (yet) create shares from our own miner's submits; that's
+//     Phase 5c. Until then, our local miner only gets payouts via the
+//     fallback path (cold chain) or via ambient shares we may have
+//     previously produced and downloaded back via peer gossip.
+
+#include "share_chain.hpp"                 // dash::ShareChain, DashShare
+#include "share_check.hpp"                 // dash::pubkey_hash_to_script2
+#include "coinbase_builder.hpp"            // dash::coinbase::bits_to_difficulty
+
+#include <algorithm>
+#include <map>
+#include <string>
+#include <vector>
+#include <type_traits>
+
+#include <core/uint256.hpp>
+#include <core/log.hpp>
+
+namespace dash {
+namespace pplns {
+
+struct Payout {
+    std::vector<unsigned char> script;   // scriptPubKey for the recipient
+    uint64_t                   amount{0};
+};
+
+struct Result {
+    std::vector<Payout> payouts;
+    size_t shares_used{0};               // how many shares contributed weight
+    bool   used_fallback{false};         // true when chain is cold/insufficient
+    double total_weight{0.0};            // sum of all share weights (diagnostic)
+};
+
+inline Result compute_payouts(
+    dash::ShareChain& chain,
+    const uint256& best_share_hash,
+    size_t window_size,
+    uint64_t miner_value,
+    const std::vector<unsigned char>& fallback_script,
+    size_t   min_shares_for_pplns = 20,
+    uint64_t dust_threshold       = 54600)   // Dash dust sat
+{
+    Result r;
+    if (miner_value == 0 || fallback_script.empty()) return r;
+
+    auto use_fallback = [&]() {
+        r.used_fallback = true;
+        r.payouts.clear();
+        r.payouts.push_back({fallback_script, miner_value});
+    };
+
+    if (best_share_hash.IsNull() || !chain.contains(best_share_hash)) {
+        use_fallback();
+        return r;
+    }
+    int32_t avail = 0;
+    try { avail = chain.get_height(best_share_hash); }
+    catch (...) { use_fallback(); return r; }
+    if (avail < static_cast<int32_t>(min_shares_for_pplns)) {
+        use_fallback();
+        return r;
+    }
+    size_t win = std::min<size_t>(window_size, static_cast<size_t>(avail));
+    if (win == 0) { use_fallback(); return r; }
+
+    // Aggregate weight by pubkey_hash. Key on pubkey hex for deterministic
+    // iteration; value carries the original uint160 for script building.
+    // Per-share weight splits into worker portion and donation portion —
+    // p2pool-dash WeightsSkipList returns (weights, total_weight,
+    // donation_weight) where each share contributes:
+    //   worker_w   = w * (65535 - share.donation) / 65535
+    //   donation_w = w * share.donation          / 65535
+    // and total_weight = Σ(worker_w) + donation_weight. Shares with
+    // donation=0 behave identically to the previous all-worker path.
+    struct Entry { uint160 pubkey_hash; double weight{0.0}; };
+    std::map<std::string, Entry> by_key;
+    double worker_total_weight = 0.0;
+    double donation_weight     = 0.0;
+    size_t shares_seen  = 0;
+
+    try {
+        for (auto&& [h, data] : chain.get_chain(best_share_hash, win)) {
+            (void)h;
+            data.share.invoke([&](auto* obj) {
+                using S = std::remove_pointer_t<decltype(obj)>;
+                if constexpr (std::is_same_v<S, dash::DashShare>) {
+                    double w = dash::coinbase::bits_to_difficulty(obj->m_bits);
+                    if (w <= 0.0) return;
+                    double dono_frac = static_cast<double>(obj->m_donation)
+                                     / 65535.0;
+                    if (dono_frac < 0.0) dono_frac = 0.0;
+                    if (dono_frac > 1.0) dono_frac = 1.0;
+                    double worker_w = w * (1.0 - dono_frac);
+                    double dono_w   = w * dono_frac;
+
+                    std::string key = obj->m_pubkey_hash.ToString();
+                    auto& e = by_key[key];
+                    e.pubkey_hash = obj->m_pubkey_hash;
+                    e.weight += worker_w;
+                    worker_total_weight += worker_w;
+                    donation_weight += dono_w;
+                    shares_seen += 1;
+                }
+            });
+        }
+    } catch (const std::exception& e) {
+        LOG_WARNING << "[PPLNS] walk failed: " << e.what();
+        use_fallback();
+        return r;
+    }
+    double total_weight = worker_total_weight + donation_weight;
+
+    r.total_weight = total_weight;
+    r.shares_used  = shares_seen;
+
+    if (total_weight <= 0.0 || by_key.empty()) {
+        use_fallback();
+        return r;
+    }
+
+    // Proportional split with dust handling.
+    std::vector<Payout> tentative;
+    uint64_t allocated = 0;
+    for (auto& [key, e] : by_key) {
+        double frac = e.weight / total_weight;
+        uint64_t amt = static_cast<uint64_t>(frac * static_cast<double>(miner_value));
+        if (amt < dust_threshold) continue;
+        tentative.push_back({
+            dash::pubkey_hash_to_script2(e.pubkey_hash),
+            amt
+        });
+        allocated += amt;
+    }
+
+    if (tentative.empty()) {
+        use_fallback();
+        return r;
+    }
+
+    // Donation line — ALWAYS emitted (matches p2pool-dash data.py:685
+    // get_expected_payouts unconditional res[DONATION_SCRIPT] = ...
+    // entry). The amount is miner_value - Σworkers; typically a tiny
+    // rounding leftover, sometimes 0. Emitting zero-value donations keeps
+    // the dashboard tooltip consistent across every share (no missing
+    // donation line when integer arithmetic happens to sum exactly).
+    {
+        std::vector<unsigned char> donation_script(
+            dash::DONATION_SCRIPT.begin(), dash::DONATION_SCRIPT.end());
+        uint64_t residue = (miner_value > allocated)
+                         ? (miner_value - allocated) : 0;
+        auto existing = std::find_if(tentative.begin(), tentative.end(),
+            [&](const Payout& p) { return p.script == donation_script; });
+        if (existing != tentative.end()) {
+            existing->amount += residue;
+        } else {
+            tentative.push_back({std::move(donation_script), residue});
+        }
+    }
+
+    // Deterministic coinbase output order: sort by script bytes.
+    std::sort(tentative.begin(), tentative.end(),
+        [](const Payout& a, const Payout& b) { return a.script < b.script; });
+
+    r.payouts = std::move(tentative);
+    return r;
+}
+
+} // namespace pplns
+} // namespace dash

--- a/src/impl/dash/share.hpp
+++ b/src/impl/dash/share.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+// Dash p2pool Share v16.
+// Reference: ref/p2pool-dash/p2pool/data.py Share class (lines 68-127)
+
+#include "share_types.hpp"
+#include <impl/bitcoin_family/coin/base_block.hpp>
+#include <sharechain/share.hpp>
+
+#include <core/netaddress.hpp>
+#include <core/uint256.hpp>
+#include <core/pack_types.hpp>
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace dash
+{
+
+// Dash Share v16 — inherits from BaseShare<uint256, 16>
+// Wire format: [VarInt type=16][VarStr packed_contents]
+struct DashShare : chain::BaseShare<uint256, 16>
+{
+    // === min_header (SmallBlockHeaderType) ===
+    bitcoin_family::coin::SmallBlockHeaderType m_min_header;
+
+    // === share_data ===
+    uint256 m_prev_hash;            // previous_share_hash (PossiblyNone)
+    BaseScript m_coinbase;          // VarStr, 2-100 bytes
+    BaseScript m_coinbase_payload;  // PossiblyNone('', VarStr) — DIP3/DIP4 CBTX
+    uint32_t m_nonce{0};            // share nonce (not block nonce)
+    uint160 m_pubkey_hash;          // miner's pubkey hash
+    uint64_t m_subsidy{0};          // block reward
+    uint16_t m_donation{0};         // donation percentage (bps)
+    StaleInfo m_stale_info{StaleInfo::none};
+    uint64_t m_desired_version{16};
+    uint64_t m_payment_amount{0};   // total masternode payment amount
+    std::vector<PackedPayment> m_packed_payments; // masternode/superblock/platform
+
+    // === share_info (non-share_data fields) ===
+    std::vector<uint256> m_new_transaction_hashes;
+    std::vector<uint64_t> m_transaction_hash_refs; // pairs: [share_count, tx_count]
+    uint256 m_far_share_hash;       // PossiblyNone
+    uint32_t m_max_bits{0};
+    uint32_t m_bits{0};
+    uint32_t m_timestamp{0};
+    uint32_t m_absheight{0};
+    uint128 m_abswork;
+
+    // === Remaining share fields ===
+    MerkleLink m_ref_merkle_link;
+    uint64_t m_last_txout_nonce{0};
+    HashLinkType m_hash_link;
+    MerkleLink m_merkle_link;
+    BaseScript m_coinbase_payload_outer; // PossiblyNone('', VarStr) — outer coinbase_payload
+
+    // Identity hash (computed, not serialized)
+    uint256 m_hash;
+
+    // Ingestion metadata — the peer we learned this share from. Not part
+    // of the on-wire format; populated in load_share so the dashboard /
+    // audit trail can show which peer gossiped each share (matches LTC
+    // share.hpp's NetService peer_addr field).
+    NetService peer_addr;
+};
+
+} // namespace dash

--- a/src/impl/dash/share_chain.hpp
+++ b/src/impl/dash/share_chain.hpp
@@ -1,0 +1,240 @@
+#pragma once
+
+// Dash share chain types: ShareType variant, ShareIndex, ShareChain.
+// Uses the generic sharechain infrastructure from c2pool/sharechain/.
+// Only v16 shares exist for Dash.
+
+#include "share.hpp"
+#include "share_types.hpp"
+
+#include <sharechain/share.hpp>
+#include <sharechain/sharechain.hpp>
+#include <core/target_utils.hpp>
+
+#include <chrono>
+
+namespace dash
+{
+
+// DoS-cap for resize() inputs read from the wire as VarInt(uint64_t), which
+// uses ReadCompactSize(false) (range_check disabled — see core/pack_types.hpp).
+// A malformed peer can send a 9-byte VarInt of UINT64_MAX, and an unguarded
+// resize() then throws std::length_error("vector::_M_default_append") and
+// kills the process via the top-level catch in main_dash.cpp:4453. Cap to
+// values comfortably above any legitimate share but well below allocator
+// max_size — exceeding the cap throws ios_base::failure, which the share
+// parser catches cleanly without process exit.
+//
+// MAX_PAYMENTS_PER_SHARE: legitimate shares carry one entry per payee in
+// the PPLNS window plus MN payouts. Real-world: ~10-50. Cap: 10000.
+//
+// MAX_TX_HASH_REF_PAIRS: one pair per non-coinbase tx in the block. A Dash
+// block holds ~few hundred tx; even worst-case dust is ~10000. Cap: 100000.
+inline constexpr uint64_t MAX_PAYMENTS_PER_SHARE   = 10000;
+inline constexpr uint64_t MAX_TX_HASH_REF_PAIRS    = 100000;
+
+// ── Formatter for v16 share serialization ────────────────────────────────────
+
+struct DashFormatter
+{
+    // Full v16 share wire deserialization.
+    // Reference: ref/p2pool-dash/p2pool/data.py Share.share_type (lines 108-122)
+    //
+    // Wire order:
+    //   min_header (SmallBlockHeaderType)
+    //   share_info { share_data { prev_hash, coinbase, coinbase_payload, nonce,
+    //     pubkey_hash, subsidy, donation, stale_info, desired_version,
+    //     payment_amount, packed_payments },
+    //     new_tx_hashes, tx_hash_refs, far_share_hash,
+    //     max_bits, bits, timestamp, absheight, abswork }
+    //   ref_merkle_link { branch, index(0-width) }
+    //   last_txout_nonce
+    //   hash_link { state, extra_data, length }
+    //   merkle_link { branch, index(0-width) }
+    //   coinbase_payload (outer, PossiblyNone)
+
+    template <typename StreamType, typename ShareT>
+    static void Read(StreamType& is, ShareT* share)
+    {
+        // ── min_header ──
+        is >> share->m_min_header;
+
+        // ── share_data ──
+        is >> share->m_prev_hash;           // PossiblyNone(0, IntType(256))
+        is >> share->m_coinbase;            // VarStr
+        is >> share->m_coinbase_payload;    // PossiblyNone('', VarStr)
+        is >> share->m_nonce;               // uint32
+        is >> share->m_pubkey_hash;         // uint160
+        is >> share->m_subsidy;             // uint64
+        is >> share->m_donation;            // uint16
+        {
+            uint8_t si;
+            is >> si;
+            share->m_stale_info = static_cast<dash::StaleInfo>(si);
+        }
+        { uint64_t dv; ::Unserialize(is, VarInt(dv)); share->m_desired_version = dv; }
+        is >> share->m_payment_amount;      // uint64
+
+        // packed_payments: ListType(ComposedType([payee(PossiblyNone VarStr), amount(PossiblyNone uint64)]))
+        {
+            uint64_t count;
+            ::Unserialize(is, VarInt(count));
+            if (count > MAX_PAYMENTS_PER_SHARE) {
+                throw std::ios_base::failure("packed_payments count exceeds cap");
+            }
+            share->m_packed_payments.resize(count);
+            for (uint64_t i = 0; i < count; ++i) {
+                BaseScript payee_bs;
+                is >> payee_bs;
+                share->m_packed_payments[i].m_payee.assign(
+                    payee_bs.m_data.begin(), payee_bs.m_data.end());
+                is >> share->m_packed_payments[i].m_amount;
+            }
+        }
+
+        // ── share_info (non-share_data) ──
+        is >> share->m_new_transaction_hashes;  // ListType(IntType(256))
+
+        // transaction_hash_refs: ListType(VarIntType(), 2) — count of PAIRS, then count*2 VarInts
+        {
+            uint64_t pair_count;
+            ::Unserialize(is, VarInt(pair_count));
+            if (pair_count > MAX_TX_HASH_REF_PAIRS) {
+                throw std::ios_base::failure("tx_hash_refs pair_count exceeds cap");
+            }
+            // pair_count is now <= MAX_TX_HASH_REF_PAIRS, so * 2 cannot overflow.
+            share->m_transaction_hash_refs.resize(pair_count * 2);
+            for (uint64_t i = 0; i < pair_count * 2; ++i) {
+                uint64_t v;
+                ::Unserialize(is, VarInt(v));
+                share->m_transaction_hash_refs[i] = v;
+            }
+        }
+
+        is >> share->m_far_share_hash;      // PossiblyNone(0, IntType(256))
+        is >> share->m_max_bits;            // FloatingInteger (uint32)
+        is >> share->m_bits;                // FloatingInteger (uint32)
+        is >> share->m_timestamp;           // uint32
+        is >> share->m_absheight;           // uint32
+        is >> share->m_abswork;             // uint128
+
+        // ── ref_merkle_link ──
+        is >> share->m_ref_merkle_link.m_branch;  // ListType(IntType(256))
+        // index is IntType(0) — zero-width, not serialized, always 0
+        share->m_ref_merkle_link.m_index = 0;
+
+        // ── last_txout_nonce ──
+        is >> share->m_last_txout_nonce;    // uint64
+
+        // ── hash_link ──
+        is >> share->m_hash_link;           // {state(FixedStr32), extra_data(VarStr), length(VarInt)}
+
+        // ── merkle_link ──
+        is >> share->m_merkle_link.m_branch;
+        share->m_merkle_link.m_index = 0;   // IntType(0) — always 0
+
+        // ── coinbase_payload (outer) ──
+        is >> share->m_coinbase_payload_outer;  // PossiblyNone('', VarStr)
+    }
+
+    template <typename StreamType, typename ShareT>
+    static void Write(StreamType& os, const ShareT* share)
+    {
+        os << share->m_min_header;
+        os << share->m_prev_hash;
+        os << share->m_coinbase;
+        os << share->m_coinbase_payload;
+        os << share->m_nonce;
+        os << share->m_pubkey_hash;
+        os << share->m_subsidy;
+        os << share->m_donation;
+        { uint8_t si = static_cast<uint8_t>(share->m_stale_info); os << si; }
+        ::Serialize(os, VarInt(share->m_desired_version));
+        os << share->m_payment_amount;
+        {
+            uint64_t count = share->m_packed_payments.size();
+            ::Serialize(os, VarInt(count));
+            for (auto& pay : share->m_packed_payments) {
+                BaseScript bs;
+                bs.m_data.assign(pay.m_payee.begin(), pay.m_payee.end());
+                os << bs;
+                os << pay.m_amount;
+            }
+        }
+        os << share->m_new_transaction_hashes;
+        {
+            uint64_t pair_count = share->m_transaction_hash_refs.size() / 2;
+            ::Serialize(os, VarInt(pair_count));
+            for (auto& v : share->m_transaction_hash_refs)
+                ::Serialize(os, VarInt(v));
+        }
+        os << share->m_far_share_hash;
+        os << share->m_max_bits;
+        os << share->m_bits;
+        os << share->m_timestamp;
+        os << share->m_absheight;
+        os << share->m_abswork;
+        os << share->m_ref_merkle_link.m_branch;
+        os << share->m_last_txout_nonce;
+        os << share->m_hash_link;
+        os << share->m_merkle_link.m_branch;
+        os << share->m_coinbase_payload_outer;
+    }
+};
+
+// ── ShareType: variant containing only v16 ───────────────────────────────────
+// For Dash, there's only one share version (v16).
+
+using ShareType = chain::ShareVariants<DashFormatter, DashShare>;
+
+// ── Load share from wire format ──────────────────────────────────────────────
+
+inline ShareType load_share(chain::RawShare& rshare, NetService peer_addr)
+{
+    auto stream = rshare.contents.as_stream();
+    auto share = ShareType::load(rshare.type, stream);
+    // Propagate ingestion source to the share so the dashboard / audit
+    // trail can show which peer gossiped it. Matches LTC share.hpp:260.
+    share.ACTION({ obj->peer_addr = peer_addr; });
+    return share;
+}
+
+// ── ShareHasher ──────────────────────────────────────────────────────────────
+
+struct ShareHasher
+{
+    size_t operator()(const uint256& hash) const
+    {
+        return hash.GetLow64();
+    }
+};
+
+// ── ShareIndex: per-share metadata in the chain ──────────────────────────────
+
+class ShareIndex : public chain::ShareIndex<uint256, ShareType, ShareHasher, ShareIndex>
+{
+    using base_index = chain::ShareIndex<uint256, ShareType, ShareHasher, ShareIndex>;
+
+public:
+    uint288 work;
+    uint288 min_work;
+    int64_t time_seen{0};
+
+    ShareIndex() : base_index(), work(0), min_work(0) {}
+
+    template <typename ShareT> ShareIndex(ShareT* share) : base_index(share)
+    {
+        work = chain::target_to_average_attempts(chain::bits_to_target(share->m_bits));
+        min_work = chain::target_to_average_attempts(chain::bits_to_target(share->m_max_bits));
+        time_seen = std::chrono::duration_cast<std::chrono::seconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+    }
+};
+
+// ── ShareChain ───────────────────────────────────────────────────────────────
+
+struct ShareChain : chain::ShareChain<ShareIndex>
+{
+};
+
+} // namespace dash

--- a/src/impl/dash/share_check.hpp
+++ b/src/impl/dash/share_check.hpp
@@ -1,0 +1,590 @@
+#pragma once
+
+// Dash share v16 verification: hash_link, merkle, X11 PoW.
+// Simplified from LTC share_check.hpp — no segwit, no merged mining.
+// Reference: ref/p2pool-dash/p2pool/data.py Share.__init__() + check()
+//
+// PPLNS formula (v16, pre-V36 linear weights):
+//   weight_per_share = target_to_average_attempts(share.target) * (65535 - donation_field)
+//   max_weight = target_to_average_attempts(block_target) * 65535 * SPREAD
+//   worker_payout = subsidy - sum(masternode/superblock/platform payments)
+//   amount[script] = worker_payout * 49 * weight / (50 * total_weight)  — 98% PPLNS
+//   amount[finder]  += worker_payout / 50                                — 2% finder fee
+//   amount[donation] = worker_payout - sum(all amounts)                  — rounding remainder
+//
+// Coinbase output order: [worker_tx (sorted)] [payments_tx (masternode/superblock/platform)] [donation_tx] [OP_RETURN ref_hash]
+//
+// Masternode/superblock payments come from getblocktemplate and are subtracted
+// from worker_payout BEFORE PPLNS distribution. They are NOT part of PPLNS weights.
+// Platform payments use "!" prefix encoding for OP_RETURN scripts.
+
+#include "share.hpp"
+#include "share_types.hpp"
+
+#include <core/coin_params.hpp>
+#include <core/hash.hpp>
+#include <core/pack.hpp>
+#include <core/pack_types.hpp>
+#include <core/pow.hpp>
+#include <core/target_utils.hpp>
+#include <core/uint256.hpp>
+#include <btclibs/base58.h>
+#include <btclibs/crypto/common.h>
+#include <btclibs/crypto/sha256.h>
+
+#include <algorithm>
+#include <cstring>
+#include <stdexcept>
+#include <vector>
+
+namespace dash
+{
+
+// ── check_hash_link (same algorithm as LTC) ──────────────────────────────────
+inline uint256 check_hash_link(const HashLinkType& hash_link,
+                               const std::vector<unsigned char>& data,
+                               const std::vector<unsigned char>& const_ending = {})
+{
+    const uint64_t extra_length = hash_link.m_length % 64;
+
+    std::vector<unsigned char> extra;
+    extra.assign(hash_link.m_extra_data.m_data.begin(),
+                 hash_link.m_extra_data.m_data.end());
+    if (extra.size() < extra_length)
+    {
+        auto needed = extra_length - extra.size();
+        if (const_ending.size() >= needed)
+            extra.insert(extra.end(), const_ending.end() - needed, const_ending.end());
+    }
+    if (extra.size() != extra_length)
+        throw std::runtime_error("check_hash_link: extra size mismatch");
+
+    const auto& state_bytes = hash_link.m_state.m_data;
+    uint32_t init_state[8] = {
+        ReadBE32(state_bytes.data() +  0), ReadBE32(state_bytes.data() +  4),
+        ReadBE32(state_bytes.data() +  8), ReadBE32(state_bytes.data() + 12),
+        ReadBE32(state_bytes.data() + 16), ReadBE32(state_bytes.data() + 20),
+        ReadBE32(state_bytes.data() + 24), ReadBE32(state_bytes.data() + 28),
+    };
+
+    unsigned char out1[CSHA256::OUTPUT_SIZE];
+    CSHA256(init_state, extra, hash_link.m_length)
+        .Write(data.data(), data.size())
+        .Finalize(out1);
+
+    unsigned char out2[CSHA256::OUTPUT_SIZE];
+    CSHA256().Write(out1, CSHA256::OUTPUT_SIZE).Finalize(out2);
+
+    uint256 result;
+    std::memcpy(result.data(), out2, 32);
+    return result;
+}
+
+// ── check_merkle_link ────────────────────────────────────────────────────────
+inline uint256 check_merkle_link(const uint256& tip_hash, const MerkleLink& link)
+{
+    uint256 cur = tip_hash;
+    for (size_t i = 0; i < link.m_branch.size(); ++i)
+    {
+        PackStream ps;
+        if ((link.m_index >> i) & 1)
+        {
+            ps << link.m_branch[i];
+            ps << cur;
+        }
+        else
+        {
+            ps << cur;
+            ps << link.m_branch[i];
+        }
+        auto sp = std::span<const unsigned char>(
+            reinterpret_cast<const unsigned char*>(ps.data()), ps.size());
+        cur = Hash(sp);
+    }
+    return cur;
+}
+
+// ── Donation script (P2PKH for XdgF55wEHBRWwbuBniNYH4GvvaoYMgL84u) ─────────
+// Reference: ref/p2pool-dash/p2pool/data.py DONATION_SCRIPT
+static const std::vector<unsigned char> DONATION_SCRIPT = {
+    0x76, 0xa9, 0x14,
+    0x20, 0xcb, 0x5c, 0x22, 0xb1, 0xe4, 0xd5, 0x94,
+    0x7e, 0x5c, 0x11, 0x2c, 0x76, 0x96, 0xb5, 0x1a,
+    0xd9, 0xaf, 0x3c, 0x61,
+    0x88, 0xac
+};
+
+// ── compute_gentx_before_refhash (Dash v16) ──────────────────────────────────
+inline std::vector<unsigned char> compute_gentx_before_refhash()
+{
+    std::vector<unsigned char> result;
+
+    // VarStr(DONATION_SCRIPT)
+    {
+        PackStream s;
+        BaseScript bs;
+        bs.m_data = DONATION_SCRIPT;
+        s << bs;
+        auto* p = reinterpret_cast<const unsigned char*>(s.data());
+        result.insert(result.end(), p, p + s.size());
+    }
+    // int64(0)
+    {
+        uint64_t zero64 = 0;
+        auto* p = reinterpret_cast<const unsigned char*>(&zero64);
+        result.insert(result.end(), p, p + 8);
+    }
+    // VarStr(0x6a 0x28 + int256(0) + int64(0))[:3]
+    {
+        PackStream inner;
+        unsigned char prefix[2] = {0x6a, 0x28};
+        inner.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(prefix), 2));
+        uint256 zero256;
+        inner << zero256;
+        uint64_t zero64 = 0;
+        inner.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(&zero64), 8));
+
+        PackStream outer;
+        BaseScript bs;
+        bs.m_data.resize(inner.size());
+        std::memcpy(bs.m_data.data(), inner.data(), inner.size());
+        outer << bs;
+
+        auto* p = reinterpret_cast<const unsigned char*>(outer.data());
+        result.insert(result.end(), p, p + std::min<size_t>(3, outer.size()));
+    }
+
+    return result;
+}
+
+// ── share_init_verify (Dash v16) ─────────────────────────────────────────────
+// Verifies PoW, hash_link, merkle_link. Returns share hash (SHA256d of header).
+inline uint256 share_init_verify(const DashShare& share,
+                                 const core::CoinParams& params,
+                                 bool check_pow = true)
+{
+    if (share.m_coinbase.m_data.size() < 2 || share.m_coinbase.m_data.size() > 100)
+        throw std::invalid_argument("bad coinbase size");
+
+    // ── Compute ref_hash ──
+    PackStream ref_stream;
+    {
+        auto hex = params.active_identifier_hex();
+        for (size_t i = 0; i + 1 < hex.size(); i += 2)
+        {
+            unsigned char byte = static_cast<unsigned char>(
+                std::stoul(hex.substr(i, 2), nullptr, 16));
+            ref_stream.write(std::span<const std::byte>(
+                reinterpret_cast<const std::byte*>(&byte), 1));
+        }
+    }
+
+    // share_info serialization (v16 format)
+    {
+        // share_data
+        ref_stream << share.m_prev_hash;
+        ref_stream << share.m_coinbase;
+        ref_stream << share.m_coinbase_payload;
+        ref_stream << share.m_nonce;
+        ref_stream << share.m_pubkey_hash;
+        ref_stream << share.m_subsidy;
+        ref_stream << share.m_donation;
+        { uint8_t si = static_cast<uint8_t>(share.m_stale_info); ref_stream << si; }
+        ::Serialize(ref_stream, VarInt(share.m_desired_version));
+        ref_stream << share.m_payment_amount;
+        ref_stream << share.m_packed_payments;
+
+        // share_info (non-share_data)
+        ref_stream << share.m_new_transaction_hashes;
+        // transaction_hash_refs: ListType(VarIntType(), 2) — writes count/2 then all elements
+        {
+            uint64_t pair_count = share.m_transaction_hash_refs.size() / 2;
+            ::Serialize(ref_stream, VarInt(pair_count));
+            for (auto& v : share.m_transaction_hash_refs)
+                ::Serialize(ref_stream, VarInt(v));
+        }
+        ref_stream << share.m_far_share_hash;
+        ref_stream << share.m_max_bits;
+        ref_stream << share.m_bits;
+        ref_stream << share.m_timestamp;
+        ref_stream << share.m_absheight;
+        ref_stream << share.m_abswork;
+    }
+
+    auto ref_span = std::span<const unsigned char>(
+        reinterpret_cast<const unsigned char*>(ref_stream.data()), ref_stream.size());
+    uint256 hash_ref = Hash(ref_span);
+    uint256 ref_hash = check_merkle_link(hash_ref, share.m_ref_merkle_link);
+
+    // ── Build hash_link_data ──
+    // Python: get_ref_hash(...) + pack.IntType(64).pack(last_txout_nonce) + pack.IntType(32).pack(0) + coinbase_payload_data
+    std::vector<unsigned char> hash_link_data;
+    hash_link_data.insert(hash_link_data.end(), ref_hash.data(), ref_hash.data() + 32);
+    {
+        uint64_t nonce = share.m_last_txout_nonce;
+        auto* p = reinterpret_cast<const unsigned char*>(&nonce);
+        hash_link_data.insert(hash_link_data.end(), p, p + 8);
+    }
+    {
+        uint32_t zero = 0;
+        auto* p = reinterpret_cast<const unsigned char*>(&zero);
+        hash_link_data.insert(hash_link_data.end(), p, p + 4);
+    }
+    // Append outer coinbase_payload (coinbase_payload_data in Python)
+    // Reference: data.py line 342-348
+    {
+        auto& cpd = share.m_coinbase_payload_outer.m_data;
+        if (!cpd.empty())
+            hash_link_data.insert(hash_link_data.end(), cpd.begin(), cpd.end());
+    }
+
+    auto gentx_before_refhash = compute_gentx_before_refhash();
+
+    // ── check_hash_link → gentx_hash ──
+    uint256 gentx_hash = check_hash_link(share.m_hash_link, hash_link_data, gentx_before_refhash);
+
+    // ── Merkle root (no segwit for Dash) ──
+    uint256 merkle_root = check_merkle_link(gentx_hash, share.m_merkle_link);
+
+    // ── Reconstruct block header ──
+    PackStream header_stream;
+    {
+        uint32_t hdr_version = static_cast<uint32_t>(share.m_min_header.m_version);
+        header_stream << hdr_version;
+    }
+    header_stream << share.m_min_header.m_previous_block;
+    header_stream << merkle_root;
+    header_stream << share.m_min_header.m_timestamp;
+    header_stream << share.m_min_header.m_bits;
+    header_stream << share.m_min_header.m_nonce;
+
+    // Dash: both BLOCKHASH_FUNC and POW_FUNC are X11
+    // share_hash = X11(header) — block identity AND PoW check
+    auto hdr_span = std::span<const unsigned char>(
+        reinterpret_cast<const unsigned char*>(header_stream.data()), header_stream.size());
+    uint256 share_hash = params.pow_func(hdr_span);
+
+    // ── X11 PoW check ──
+    if (check_pow)
+    {
+        uint256 target = chain::bits_to_target(share.m_bits);
+        if (target.IsNull())
+            throw std::invalid_argument("share target is zero");
+
+        if (share_hash > target)
+            throw std::invalid_argument("share PoW hash does not meet target");
+    }
+
+    return share_hash;
+}
+
+// ── decode_payee_script: "!" prefix → raw hex script, else → address_to_script2
+// Reference: ref/p2pool-dash/p2pool/data.py lines 189-217
+// "!" is not in base58 alphabet, used as prefix for raw hex-encoded scripts
+inline std::vector<unsigned char> decode_payee_script(
+    const std::string& payee, uint8_t address_version, uint8_t p2sh_version)
+{
+    if (payee.empty())
+        return {};
+
+    if (payee[0] == '!') {
+        // Raw hex script: "!6a28..." → decode hex after "!"
+        std::vector<unsigned char> script;
+        auto hex = payee.substr(1);
+        script.reserve(hex.size() / 2);
+        for (size_t i = 0; i + 1 < hex.size(); i += 2)
+            script.push_back(static_cast<unsigned char>(
+                std::stoul(hex.substr(i, 2), nullptr, 16)));
+        return script;
+    }
+
+    // Regular base58 address → P2PKH or P2SH script
+    std::vector<unsigned char> decoded;
+    if (DecodeBase58Check(payee, decoded, 21) && decoded.size() == 21) {
+        uint8_t ver = decoded[0];
+        if (ver == address_version) {
+            // P2PKH: OP_DUP OP_HASH160 <20> OP_EQUALVERIFY OP_CHECKSIG
+            std::vector<unsigned char> script = {0x76, 0xa9, 0x14};
+            script.insert(script.end(), decoded.begin() + 1, decoded.end());
+            script.push_back(0x88);
+            script.push_back(0xac);
+            return script;
+        }
+        if (ver == p2sh_version) {
+            // P2SH: OP_HASH160 <20> OP_EQUAL
+            std::vector<unsigned char> script = {0xa9, 0x14};
+            script.insert(script.end(), decoded.begin() + 1, decoded.end());
+            script.push_back(0x87);
+            return script;
+        }
+    }
+
+    return {};
+}
+
+// ── pubkey_hash_to_script2 (Dash: always P2PKH, no segwit) ──────────────────
+inline std::vector<unsigned char> pubkey_hash_to_script2(const uint160& hash)
+{
+    auto h = hash.GetChars();
+    std::vector<unsigned char> script;
+    script.reserve(25);
+    script.push_back(0x76); // OP_DUP
+    script.push_back(0xa9); // OP_HASH160
+    script.push_back(0x14); // Push 20 bytes
+    script.insert(script.end(), h.begin(), h.end());
+    script.push_back(0x88); // OP_EQUALVERIFY
+    script.push_back(0xac); // OP_CHECKSIG
+    return script;
+}
+
+// ── generate_share_transaction (Dash v16 PPLNS) ─────────────────────────────
+// Reconstructs the expected coinbase from PPLNS weights.
+// Uses the OLD p2pool formula (pre-V36):
+//   49/50 to PPLNS weighted workers, 1/50 to finder, remainder to donation.
+//   Masternode/superblock/platform payments subtracted from worker_payout first.
+//
+// Reference: ref/p2pool-dash/p2pool/data.py generate_transaction() lines 131-269
+// ─────────────────────────────────────────────────────────────────────────────
+template <typename TrackerT>
+uint256 generate_share_transaction(const DashShare& share, TrackerT& tracker,
+                                   const core::CoinParams& params)
+{
+    const uint64_t subsidy = share.m_subsidy;
+
+    // ── 1. Compute worker_payout (subsidy minus masternode/superblock payments) ──
+    uint64_t payment_total = 0;
+    for (auto& pay : share.m_packed_payments)
+        payment_total += pay.m_amount;
+    uint64_t worker_payout = (subsidy > payment_total) ? (subsidy - payment_total) : 0;
+
+    // ── 2. Compute PPLNS weights (linear, pre-V36) ──
+    auto prev_hash = share.m_prev_hash;
+    std::map<std::vector<unsigned char>, uint288> weights;
+    uint288 total_weight;
+    uint288 donation_weight;
+
+    if (!prev_hash.IsNull() && tracker.chain.contains(prev_hash))
+    {
+        auto height = tracker.chain.get_height(prev_hash);
+        auto chain_len = std::max(0, std::min(height, static_cast<int32_t>(params.real_chain_length)) - 1);
+
+        auto block_target = chain::bits_to_target(share.m_min_header.m_bits);
+        auto max_weight = chain::target_to_average_attempts(block_target)
+                          * params.spread * 65535;
+
+        // Walk chain and accumulate per-script weights (linear, no decay)
+        // Python: get_cumulative_weights starts from previous_share.previous_share_hash
+        auto walk_count = static_cast<size_t>(chain_len);
+        auto walk_view = tracker.chain.get_chain(prev_hash, walk_count);
+
+        for (auto& [hash, data] : walk_view)
+        {
+            uint288 share_att;
+            uint32_t share_don = 0;
+            std::vector<unsigned char> script;
+
+            data.share.invoke([&](auto* obj) {
+                auto target = chain::bits_to_target(obj->m_bits);
+                share_att = chain::target_to_average_attempts(target);
+                share_don = obj->m_donation;
+                script = pubkey_hash_to_script2(obj->m_pubkey_hash);
+            });
+
+            uint288 share_total = share_att * 65535;
+            uint288 share_don_w = share_att * share_don;
+
+            if (total_weight + share_total > max_weight)
+            {
+                auto remaining = max_weight - total_weight;
+                auto share_addr_weight = share_att * static_cast<uint32_t>(65535 - share_don);
+
+                uint288 partial_addr;
+                if (!share_total.IsNull())
+                    partial_addr = remaining / 65535 * share_addr_weight / (share_total / 65535);
+
+                if (weights.contains(script))
+                    weights[script] += partial_addr;
+                else
+                    weights[script] = partial_addr;
+
+                uint288 partial_donation;
+                if (!share_total.IsNull())
+                    partial_donation = remaining / 65535 * share_don_w / (share_total / 65535);
+
+                donation_weight += partial_donation;
+                total_weight = max_weight;
+                break;
+            }
+
+            auto share_addr_weight = share_att * static_cast<uint32_t>(65535 - share_don);
+            if (weights.contains(script))
+                weights[script] += share_addr_weight;
+            else
+                weights[script] = share_addr_weight;
+
+            total_weight += share_total;
+            donation_weight += share_don_w;
+        }
+    }
+
+    // ── 3. Convert weights to payout amounts (49/50 + 1/50 finder) ──
+    std::map<std::vector<unsigned char>, uint64_t> amounts;
+
+    if (!total_weight.IsNull())
+    {
+        for (auto& [script, weight] : weights)
+        {
+            // amounts[script] = worker_payout * 49 * weight / (50 * total_weight)
+            uint288 num = uint288(worker_payout) * (weight * 49);
+            uint288 den = total_weight * 50;
+            uint64_t amount = (num / den).GetLow64();
+            if (amount > 0)
+                amounts[script] = amount;
+        }
+    }
+
+    // Finder fee: 2% (1/50) to block creator
+    auto finder_script = pubkey_hash_to_script2(share.m_pubkey_hash);
+    amounts[finder_script] += worker_payout / 50;
+
+    // Donation: remainder (rounding + donation weight)
+    uint64_t sum_amounts = 0;
+    for (auto& [s, a] : amounts)
+        sum_amounts += a;
+    uint64_t donation_amount = (worker_payout > sum_amounts) ? (worker_payout - sum_amounts) : 0;
+
+    // ── 4. Build sorted output list ──
+    // worker_scripts: sorted, excluding donation
+    std::vector<std::pair<std::vector<unsigned char>, uint64_t>> worker_outputs;
+    for (auto& [script, amount] : amounts)
+    {
+        if (script != DONATION_SCRIPT && amount > 0)
+            worker_outputs.emplace_back(script, amount);
+    }
+    std::sort(worker_outputs.begin(), worker_outputs.end());
+
+    // ── 5. Build coinbase TX ──
+    // Output order: worker_tx + payments_tx + donation_tx + OP_RETURN
+    PackStream tx;
+
+    // tx version (DIP3/DIP4: version=3, type=5 for CBTX)
+    bool has_cbtx = !share.m_coinbase_payload.m_data.empty();
+    if (has_cbtx) {
+        int32_t ver_with_type = 3 | (5 << 16);
+        tx.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(&ver_with_type), 4));
+    } else {
+        uint32_t v = 1;
+        tx.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(&v), 4));
+    }
+
+    // vin[0]: coinbase
+    { unsigned char one = 1; tx.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(&one), 1)); }
+    { uint256 z; tx << z; }
+    { uint32_t idx = 0xffffffff; tx.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(&idx), 4)); }
+    tx << share.m_coinbase;
+    { uint32_t seq = 0xffffffff; tx.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(&seq), 4)); }
+
+    // Count outputs
+    size_t n_outs = worker_outputs.size() + share.m_packed_payments.size() + 1 /* donation */ + 1 /* OP_RETURN */;
+    if (n_outs < 253) {
+        uint8_t cnt = static_cast<uint8_t>(n_outs);
+        tx.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(&cnt), 1));
+    } else {
+        uint8_t marker = 0xfd;
+        tx.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(&marker), 1));
+        uint16_t cnt = static_cast<uint16_t>(n_outs);
+        tx.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(&cnt), 2));
+    }
+
+    auto write_txout = [&](uint64_t value, const std::vector<unsigned char>& script) {
+        tx.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(&value), 8));
+        BaseScript bs;
+        bs.m_data = script;
+        tx << bs;
+    };
+
+    // Worker outputs (sorted)
+    for (auto& [script, amount] : worker_outputs)
+        write_txout(amount, script);
+
+    // Masternode/superblock/platform payments
+    for (auto& pay : share.m_packed_payments)
+    {
+        if (pay.m_amount == 0) continue;
+        auto pay_script = decode_payee_script(
+            pay.m_payee, params.address_version, params.address_p2sh_version);
+        if (!pay_script.empty())
+            write_txout(pay.m_amount, pay_script);
+    }
+
+    // Donation output
+    write_txout(donation_amount, DONATION_SCRIPT);
+
+    // OP_RETURN ref_hash output (last)
+    {
+        // Recompute ref_hash (same as share_init_verify)
+        PackStream ref_stream;
+        {
+            auto hex = params.active_identifier_hex();
+            for (size_t i = 0; i + 1 < hex.size(); i += 2)
+            {
+                unsigned char byte = static_cast<unsigned char>(
+                    std::stoul(hex.substr(i, 2), nullptr, 16));
+                ref_stream.write(std::span<const std::byte>(
+                    reinterpret_cast<const std::byte*>(&byte), 1));
+            }
+        }
+        // share_info (same serialization as share_init_verify)
+        ref_stream << share.m_prev_hash;
+        ref_stream << share.m_coinbase;
+        ref_stream << share.m_coinbase_payload;
+        ref_stream << share.m_nonce;
+        ref_stream << share.m_pubkey_hash;
+        ref_stream << share.m_subsidy;
+        ref_stream << share.m_donation;
+        { uint8_t si = static_cast<uint8_t>(share.m_stale_info); ref_stream << si; }
+        ::Serialize(ref_stream, VarInt(share.m_desired_version));
+        ref_stream << share.m_payment_amount;
+        ref_stream << share.m_packed_payments;
+        ref_stream << share.m_new_transaction_hashes;
+        for (auto& v : share.m_transaction_hash_refs)
+            ::Serialize(ref_stream, VarInt(v));
+        ref_stream << share.m_far_share_hash;
+        ref_stream << share.m_max_bits;
+        ref_stream << share.m_bits;
+        ref_stream << share.m_timestamp;
+        ref_stream << share.m_absheight;
+        ref_stream << share.m_abswork;
+
+        auto rspan = std::span<const unsigned char>(
+            reinterpret_cast<const unsigned char*>(ref_stream.data()), ref_stream.size());
+        uint256 hash_ref = Hash(rspan);
+        uint256 ref_hash = check_merkle_link(hash_ref, share.m_ref_merkle_link);
+
+        std::vector<unsigned char> op_return_script;
+        op_return_script.push_back(0x6a);
+        op_return_script.push_back(0x28);
+        op_return_script.insert(op_return_script.end(), ref_hash.data(), ref_hash.data() + 32);
+        {
+            uint64_t nonce = share.m_last_txout_nonce;
+            auto* p = reinterpret_cast<const unsigned char*>(&nonce);
+            op_return_script.insert(op_return_script.end(), p, p + 8);
+        }
+        write_txout(0, op_return_script);
+    }
+
+    // locktime
+    { uint32_t lt = 0; tx.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(&lt), 4)); }
+
+    // DIP3/DIP4 extra_payload
+    if (has_cbtx) {
+        tx << share.m_coinbase_payload;
+    }
+
+    // ── 6. Compute txid ──
+    auto tx_span = std::span<const unsigned char>(
+        reinterpret_cast<const unsigned char*>(tx.data()), tx.size());
+    return Hash(tx_span);
+}
+
+} // namespace dash

--- a/src/impl/dash/share_types.hpp
+++ b/src/impl/dash/share_types.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+// Dash p2pool share v16 serialization types.
+// Reference: ref/p2pool-dash/p2pool/data.py lines 68-127
+
+#include <core/uint256.hpp>
+#include <core/pack_types.hpp>
+#include <core/pack.hpp>
+
+namespace dash
+{
+
+enum StaleInfo : uint8_t
+{
+    none = 0,
+    orphan = 253,
+    doa = 254
+};
+
+// Merkle link (same as LTC but index is always 0 for Dash v16)
+struct MerkleLink
+{
+    std::vector<uint256> m_branch;
+    uint32_t m_index{0};
+
+    SERIALIZE_METHODS(MerkleLink) { READWRITE(obj.m_branch); /* index always 0, not serialized */ }
+};
+
+// Hash link (same structure as LTC)
+struct HashLinkType
+{
+    FixedStrType<32> m_state;
+    BaseScript m_extra_data;  // VarStr
+    uint64_t m_length;
+
+    SERIALIZE_METHODS(HashLinkType) { READWRITE(obj.m_state, obj.m_extra_data, VarInt(obj.m_length)); }
+};
+
+// Packed payment entry (masternode/superblock/platform)
+// payee: address string or "!<hex>" for script-encoded payments
+// amount: satoshis
+struct PackedPayment
+{
+    std::string m_payee;     // PossiblyNone('', VarStr)
+    uint64_t m_amount{0};    // PossiblyNone(0, IntType(64))
+
+    template <typename StreamType>
+    void Serialize(StreamType& os) const
+    {
+        // PossiblyNone for payee: empty string = None
+        BaseScript bs;
+        bs.m_data.assign(m_payee.begin(), m_payee.end());
+        ::Serialize(os, bs);
+        ::Serialize(os, m_amount);
+    }
+
+    template <typename StreamType>
+    void Unserialize(StreamType& is)
+    {
+        BaseScript bs;
+        ::Unserialize(is, bs);
+        m_payee.assign(bs.m_data.begin(), bs.m_data.end());
+        ::Unserialize(is, m_amount);
+    }
+};
+
+} // namespace dash

--- a/src/impl/dash/share_types.hpp
+++ b/src/impl/dash/share_types.hpp
@@ -23,7 +23,7 @@ struct MerkleLink
     std::vector<uint256> m_branch;
     uint32_t m_index{0};
 
-    SERIALIZE_METHODS(MerkleLink) { READWRITE(obj.m_branch); /* index always 0, not serialized */ }
+    C2POOL_SERIALIZE_METHODS(MerkleLink) { READWRITE(obj.m_branch); /* index always 0, not serialized */ }
 };
 
 // Hash link (same structure as LTC)
@@ -33,7 +33,7 @@ struct HashLinkType
     BaseScript m_extra_data;  // VarStr
     uint64_t m_length;
 
-    SERIALIZE_METHODS(HashLinkType) { READWRITE(obj.m_state, obj.m_extra_data, VarInt(obj.m_length)); }
+    C2POOL_SERIALIZE_METHODS(HashLinkType) { READWRITE(obj.m_state, obj.m_extra_data, VarInt(obj.m_length)); }
 };
 
 // Packed payment entry (masternode/superblock/platform)


### PR DESCRIPTION
## S4-pre: payout-credit foundation (dash, single-coin)

Foundation slice for the DASH pay stage under seq(a): share-chain + coin-tx headers, `credit_pool.apply_block` body, and the advanced `block.m_txs` member it consumes.

### Decision context
Per integrator (advance-the-member): `m_txs` pulled forward from S5 into this foundation so `apply_block` lands as a coherent, testable slice rather than a dead stub. `apply_block` body unchanged from `27f2aaf0` (UID 942 closed — not re-authored).

### Condition 1 — leaf accessor ✅
`block.m_txs` is a leaf over the block tx vector. `src/impl/dash/coin/block.hpp` includes only `bitcoin_family/coin/base_block.hpp` + `dash/coin/transaction.hpp` (coin-tx layer, part of this foundation) — **no** `share_chain.hpp`/`share_check.hpp` S5 share-chain consumer imports. No S5 types dragged in.

### Condition 2 — isolation ✅ single-coin
The advanced member is defined in `src/impl/dash/coin/block.hpp` (single dash tree), **not** in `bitcoin_family/` or `src/core/`. → **single dash smoke gate suffices**; not a shared-scaffolding change, no four-coin sweep required.

### DIP-0027 separation ✅
Payout-credit path (`credit_pool.apply_block`, walks `block.m_txs` for PPLNS accounting) is kept strictly separate from Dash DIP-0027 asset-lock / CreditPool semantics. The `credit_pool_binding.hpp` seam that conflated the two is **excluded** from this PR (held as S4-pay WIP). The assetlock/cbtx changes here are the `C2POOL_SERIALIZE_METHODS` collision rename only — no asset-lock semantic change.

### Commits
- `27f2aaf0` foundation (share-chain + coin-tx headers, advance `block.m_txs`)
- `fadf44d7` build fix: `C2POOL_SERIALIZE_METHODS` collision rename (assetlock/cbtx/share_types) + `<core/log.hpp>` include

Local `-fsyntax-only` (gnu++20) clean on touched headers. Full Linux x86_64 dash smoke via CI on this PR.
