### PR TITLE
btc(v36): complete livelock mirror — hold tracker lock across IO-thread share mutations

### DIFF
--- a/src/impl/btc/node.cpp
+++ b/src/impl/btc/node.cpp
@@ -393,34 +393,38 @@ void NodeImpl::processing_shares_phase2(HandleSharesData& data, NetService addr)
     // Non-blocking mutex: if think() holds the exclusive lock on the compute
     // thread, queue this batch for processing after think() releases. The IO
     // thread never blocks — keepalive timers and network I/O continue.
-    {
-        std::unique_lock lock(m_tracker_mutex, std::try_to_lock);
-        if (!lock.owns_lock()) {
-            // ── Backpressure (V36 livelock defense-in-depth) ──────────────
-            // If think() is wedged/slow the deferred queue could grow without
-            // bound and blow memory. Cap it: over MAX_PENDING_ADDS we DROP the
-            // new batch (peers re-advertise their best share, so dropped shares
-            // are re-requested later) and warn instead of growing unbounded.
-            if (m_pending_adds.size() >= MAX_PENDING_ADDS) {
-                LOG_WARNING << "[ASYNC-DEFER] BACKPRESSURE: pending_adds at cap ("
-                            << m_pending_adds.size() << "/" << MAX_PENDING_ADDS
-                            << "), dropping batch of " << data.m_items.size()
-                            << " shares from " << addr.to_string()
-                            << " — think() may be wedged";
-                return;
-            }
-            LOG_INFO << "[ASYNC-DEFER] processing_shares_phase2: mutex busy, queuing "
-                     << data.m_items.size() << " shares from " << addr.to_string()
-                     << " (pending=" << m_pending_adds.size() + 1 << ")";
-            m_pending_adds.push_back(PendingShareBatch{
-                std::make_unique<HandleSharesData>(std::move(data)), addr});
+    //
+    // HOLD this lock across the entire mutation body below (mirrors LTC f445db8e).
+    // try_to_lock keeps the IO thread non-blocking — busy => queue + return. Once
+    // acquired we must NOT release until all m_tracker.chain mutations are done:
+    // the prior code released here and ran the body lock-free, letting the
+    // compute-thread clean_tracker() exclusive prune (drop_tails) free chain nodes
+    // mid-mutation -> SIGSEGV (kr1z1s LTC/DGB). Released just before run_think().
+    std::unique_lock lock(m_tracker_mutex, std::try_to_lock);
+    if (!lock.owns_lock()) {
+        // ── Backpressure (V36 livelock defense-in-depth) ──────────────
+        // If think() is wedged/slow the deferred queue could grow without
+        // bound and blow memory. Cap it: over MAX_PENDING_ADDS we DROP the
+        // new batch (peers re-advertise their best share, so dropped shares
+        // are re-requested later) and warn instead of growing unbounded.
+        if (m_pending_adds.size() >= MAX_PENDING_ADDS) {
+            LOG_WARNING << "[ASYNC-DEFER] BACKPRESSURE: pending_adds at cap ("
+                        << m_pending_adds.size() << "/" << MAX_PENDING_ADDS
+                        << "), dropping batch of " << data.m_items.size()
+                        << " shares from " << addr.to_string()
+                        << " — think() may be wedged";
             return;
         }
+        LOG_INFO << "[ASYNC-DEFER] processing_shares_phase2: mutex busy, queuing "
+                 << data.m_items.size() << " shares from " << addr.to_string()
+                 << " (pending=" << m_pending_adds.size() + 1 << ")";
+        m_pending_adds.push_back(PendingShareBatch{
+            std::make_unique<HandleSharesData>(std::move(data)), addr});
+        return;
     }
-    // Lock released — proceed with normal processing.
-    // No lock needed for the rest: we only enter here when think() is NOT
-    // running (m_tracker_mutex was available), and ASIO single-thread
-    // guarantees no other IO handler overlaps.
+    // Lock acquired and HELD across the mutation body below; released just before
+    // the async run_think() trigger so the compute thread can take the exclusive
+    // lock. ASIO single-thread still guarantees no overlapping IO handler.
 
     // Step 1: collect verified shares (skip any that failed verification, hash still null)
     std::vector<ShareType> valid_shares;
@@ -580,6 +584,11 @@ void NodeImpl::processing_shares_phase2(HandleSharesData& data, NetService addr)
                  << source << "... (dup=" << dup_count
                  << " chain=" << m_tracker.chain.size() << ")";
     }
+
+    // Release the tracker lock before triggering think(): run_think() posts the
+    // think+prune job to the compute thread, which needs the exclusive lock. All
+    // chain mutations above are complete at this point.
+    lock.unlock();
 
     // Trigger think() after every share batch (p2pool: set_best_share after handle_shares).
     // p2pool calls set_best_share() after EVERY batch with new_count > 0 — no size gate.
@@ -805,14 +814,18 @@ void NodeImpl::notify_local_share(const uint256& share_hash)
 {
     // p2pool: set_best_share() → think() synchronously on the reactor thread.
     // Use think() for ALL best_share decisions, matching p2pool exactly.
-    if (share_hash.IsNull() || !m_tracker.chain.contains(share_hash))
+    if (share_hash.IsNull())
         return;
 
-    // Try inline verify — if think() holds the mutex, defer to next think() cycle.
-    // The share is already in the chain; think() will verify + score it.
+    // Both the chain.contains() read AND attempt_verify() run UNDER the tracker
+    // lock (mirrors LTC f445db8e). A bare m_tracker.chain.contains() here (the
+    // prior code) raced the compute-thread clean_tracker() exclusive prune freeing
+    // chain nodes -> SIGSEGV (kr1z1s LTC/DGB). try_to_lock keeps the IO thread
+    // non-blocking; if think()/clean holds the lock we skip the inline verify —
+    // the share is already in-chain and run_think() below will score it next cycle.
     {
         std::unique_lock lock(m_tracker_mutex, std::try_to_lock);
-        if (lock.owns_lock())
+        if (lock.owns_lock() && m_tracker.chain.contains(share_hash))
             m_tracker.attempt_verify(share_hash);
     }
 


### PR DESCRIPTION
Completes the BTC twin of the contabo run_think() livelock / kr1z1s SIGSEGV fix.

## Gate
LTC fix has landed on master:
- `f445db8e` ltc/node: hold tracker lock across chain access in IO-thread share paths
- `2f9d3e1a` Fix event-loop freeze: try_to_lock in IO-thread tracker accesses

PR #97 (`ee906e8a`) landed only the **watchdog** half of the BTC mirror; the **lock-yield** half was inert (test-then-release). This PR mirrors `f445db8e` 1:1 onto `src/impl/btc/node.cpp`.

## Changes (BTC-only)
1. **processing_shares_phase2()** — previously held the `try_to_lock` only to TEST availability, released it, then ran `m_tracker.add()` lock-free on the "think() isnt running" assumption. The compute-thread `clean_tracker()` prune could grab the lock the instant phase2 released it and free chain nodes mid-mutation → SIGSEGV. The `unique_lock` is now held across the whole mutation body and released (`lock.unlock()`) immediately before the async `run_think()` trigger. BTC-only backpressure cap (`MAX_PENDING_ADDS`) preserved inside the `!owns_lock()` branch.
2. **notify_local_share()** — bare `m_tracker.chain.contains()` in the early-return ran outside the lock. Moved under the existing `try_to_lock` guard (`owns_lock() && contains()`); on contention the inline verify is skipped and `run_think()` scores the share next cycle.

## Verification
- Builds clean: `cmake --build build --target c2pool-btc -j16` → BUILD_EXIT=0 (warnings only).
- Diff: 1 file, +42/-29, no cross-coin surface (BTC-only, no 4-coin smoke gate).
- Commit `e8abf28d` GPG-signed.

Merge operator-gated.