### PR TITLE
btc(stratum): memoize tx_data across work-gen calls (H5 leak fix)

### DIFF
--- a/src/impl/btc/stratum/work_source.cpp
+++ b/src/impl/btc/stratum/work_source.cpp
@@ -633,11 +633,39 @@ core::stratum::CoinbaseResult BTCWorkSource::build_connection_coinbase(
         // a1 (shared_ptr + lazy materialize): build the per-tx hex vector ONCE
         // and hand the snapshot a shared_ptr to it, so the copies made along
         // CoinbaseResult -> JobSnapshot -> JobEntry become refcount bumps, not
-        // deep copies of the full mempool tx hex (the H5 churn site).
-        auto txd = std::make_shared<std::vector<std::string>>();
-        for (const auto& t : *txs_field) {
-            if (t.is_object() && t.contains("data") && t["data"].is_string())
-                txd->push_back(t["data"].get<std::string>());
+        // deep copies of the full mempool tx hex.
+        //
+        // H5 (memoize across calls): a1 collapsed the per-job copies, but the
+        // vector itself was still rebuilt from scratch on every call to this
+        // method even when the mempool tx set had not changed -- the dominant
+        // leak/churn site (work_source.cpp:634, 768MB / 1.2M calls). Fingerprint
+        // the template tx set over wd->m_hashes (the merkle leaf set, in
+        // merkle-leaf order) and reuse the memoized shared_ptr on a match.
+        // The fingerprint keys on the SAME leaves that built this job's merkle,
+        // so a hit is atomic with the witness_commitment/merkle captured for
+        // the job (no stale-tx-vs-fresh-merkle mismatch on submit). Single slot
+        // -> bounded memory (one tx set retained), self-evicting on tx-set roll.
+        CHash256 fp_hasher;
+        for (const auto& h : wd->m_hashes)
+            fp_hasher.Write(std::span<const unsigned char>(h.data(), 32));
+        uint256 fp;
+        fp_hasher.Finalize(std::span<unsigned char>(fp.data(), 32));
+
+        std::shared_ptr<std::vector<std::string>> txd;
+        {
+            std::lock_guard<std::mutex> lk(template_mutex_);
+            if (tx_data_memo_ && tx_data_fp_ == fp) {
+                txd = tx_data_memo_;  // unchanged tx set -> refcount bump, no rebuild
+            } else {
+                txd = std::make_shared<std::vector<std::string>>();
+                txd->reserve(txs_field->size());
+                for (const auto& t : *txs_field) {
+                    if (t.is_object() && t.contains("data") && t["data"].is_string())
+                        txd->push_back(t["data"].get<std::string>());
+                }
+                tx_data_fp_   = fp;    // single slot: overwrite, prior set refcount drops
+                tx_data_memo_ = txd;
+            }
         }
         snap.tx_data = std::move(txd);
     }

--- a/src/impl/btc/stratum/work_source.hpp
+++ b/src/impl/btc/stratum/work_source.hpp
@@ -266,7 +266,20 @@ private:
     // Template cache (filled lazily; invalidated when work_generation_ bumps)
     // Stage 4c populates these.
     mutable std::mutex          template_mutex_;
-    // ... cache fields land here in stage 4c
+    // H5 fix: single-slot tx_data memo. build_connection_coinbase rebuilt
+    // the per-tx hex vector on every call; for an unchanged mempool tx set
+    // that is pure churn (768MB / 1.2M calls in the 2026-06-02 trace, ~78%
+    // of total leaked bytes). Memoize the shared_ptr keyed to a fingerprint
+    // over wd->m_hashes (the merkle leaf set, in merkle-leaf order) so a
+    // repeat call against the same tx set returns a refcount bump instead
+    // of a fresh deep copy. Single slot: only the latest tx set is ever
+    // needed, so the memo is O(1) and self-evicting (a new fingerprint
+    // overwrites the prior entry, dropping its refcount). Guarded by
+    // template_mutex_. Atomic-with-merkle by construction: the key is the
+    // exact leaf set that produced this job, so a memo hit implies an
+    // identical merkle (no stale-tx-vs-fresh-merkle submit mismatch).
+    mutable uint256                                   tx_data_fp_;
+    mutable std::shared_ptr<std::vector<std::string>> tx_data_memo_;
 };
 
 }  // namespace btc::stratum


### PR DESCRIPTION
## BTC H5 leak fix — memoize `tx_data` across work-gen calls

**Leak site:** `src/impl/btc/stratum/work_source.cpp:634` — `build_connection_coinbase` re-materialized the per-job transaction hex vector on **every** call, even when the mempool tx set was unchanged.

### Before (2026-06-02 fixture, `print-2026-06-02.txt`)
- `work_source.cpp:634` leaked **768.18 MB / 1.2M calls** = ~96% of all leaked string bytes, **78% of total leaked bytes**, linear/unbounded over the ~1h50m trace.
- This is the per-job `tx_data` duplication, NOT collapsed by a1.

### Fix
Single-slot memo keyed to a fingerprint over `wd->m_hashes` (the merkle leaf set). On a repeat call against the same tx set, the cached `shared_ptr` is returned (refcount bump) instead of re-serializing the whole mempool.

### Two confirmations integrator asked for
1. **Deterministic key:** the fingerprint is `CHash256` (double-SHA256) over `wd->m_hashes` iterated in **merkle-leaf order** (the vector order), each leaf fed as its 32 raw bytes. Same tx set => same leaf order => same fingerprint, across calls. Because a txid IS the hash of its tx, identical `m_hashes` => identical `tx_data`, so the key uniquely determines the cached value (no collision-driven mismatch).
2. **Bounded eviction:** the memo is a **single slot** (`tx_data_fp_` + `tx_data_memo_`). A new fingerprint overwrites the prior entry, dropping its refcount — at most one tx set is retained. No unbounded map; we never need more than the latest tx set.

### Atomic-with-merkle
The key is the exact leaf set that produced this job's merkle / witness_commitment (captured at `stratum_server.cpp:1395`). A memo hit therefore implies an identical merkle — no stale-tx-vs-fresh-merkle mismatch on submit. This is why the key is the tx-set fingerprint, not `work_generation_`: on BTC `work_generation_` bumps tip-only (`main_btc.cpp:1212/1215`, no mempool-arrival subscriber) while `build_template` reads live `mempool_` per call, so a work-gen-keyed memo could serve stale `tx_data` against a fresh merkle.

### a504426b / a1 reconciliation
- `a504426b` is an ancestor of this branch base (`1040edec`, merge of #114).
- a1 is already landed: the `shared_ptr` conversion at `work_source.cpp:637` (per-job COPIES -> refcount bumps) and the `active_jobs_` `MAX_ACTIVE_JOBS=256` bound at `stratum_server.cpp:1375` are both present on the base.
- **This memo lands as an additive refinement on top of a1** — it removes the *rebuild-every-call* churn that a1 did not address. No re-fix, no conflict. Prod (.53 PID 14308, sha 2f2e8282) is running a1; this is the next layer.

### Tests
`ctest`: **60/60** BTC stratum / template-builder / mining-interface tests pass (100%). (The 9 Dash X11/DGW KAT entries reported by a full `ctest` run are `***Not Run` — their executables are not built in this incremental build dir; out of the BTC lane and not affected by this BTC-local change.)

### Acceptance gate — post-patch heaptrack (IN FLIGHT)
Per the task, the acceptance gate is a post-patch heaptrack on the 2026-06-02 fixture: the retention curve at `work_source.cpp:634` must flatten. **Queued next heartbeat** (30–60 min run); before/after curve will be appended to this PR before merge.

### Scope / safety
BTC-local: only `src/impl/btc/stratum/work_source.{cpp,hpp}`. Zero core edits, zero cross-coin footprint (`tx_data` populated at this one impl site; all other coins carry null). Commit signed `b000c323`. **Push held — merge operator-gated.**
