### PR TITLE
btc(v36): segwit gate consumes PoolConfig SSOT (FLAG 2) + FLAG 4 comment refresh

### DIFF
--- a/src/impl/btc/config_pool.hpp
+++ b/src/impl/btc/config_pool.hpp
@@ -119,9 +119,11 @@ public:
 
     // V36+ COMBINED_DONATION_SCRIPT (P2SH: OP_HASH160 <hash160(redeem)> OP_EQUAL)
     // 1-of-2 multisig: forrestv + frstrtr/c2pool dev key.
-    // LTC-specific (BTC stays at v35 per jtoomim — see plan v2 §3); kept
-    // here as inert byte data so get_donation_script() compiles for both
-    // BTC v35 (returns the P2PK above) and LTC v36 paths.
+    // LTC P2SH donation target. BTC now runs v36-active shares, but its
+    // donation leg intentionally stays the V35 P2PK above (forrestv
+    // canonical BTC-mainnet donation); this COMBINED P2SH is LTC-only,
+    // kept here as inert byte data so get_donation_script() compiles for
+    // both the BTC (P2PK) and LTC v36 (P2SH) paths.
     // Address: MLhSmVQxMusLE3pjGFvp4unFckgjeD8LUA (LTC mainnet P2SH).
     static constexpr std::array<uint8_t, 23> COMBINED_DONATION_SCRIPT = {
         0xa9, // OP_HASH160

--- a/src/impl/btc/share_check.hpp
+++ b/src/impl/btc/share_check.hpp
@@ -485,7 +485,7 @@ uint256 share_init_verify(const ShareT& share, bool check_pow = true)
 
     constexpr int64_t ver = ShareT::version;
 
-    if constexpr (ver >= btc::SEGWIT_ACTIVATION_VERSION)
+    if constexpr (ver >= btc::PoolConfig::SEGWIT_ACTIVATION_VERSION)
     {
         if constexpr (requires { share.m_segwit_data; })
         {
@@ -563,7 +563,7 @@ uint256 share_init_verify(const ShareT& share, bool check_pow = true)
         // segwit_data (optional)
         if constexpr (requires { share.m_segwit_data; })
         {
-            if constexpr (ver >= btc::SEGWIT_ACTIVATION_VERSION)
+            if constexpr (ver >= btc::PoolConfig::SEGWIT_ACTIVATION_VERSION)
             {
                 // PossiblyNoneType: ALWAYS serialize (p2pool writes default when None)
                 if (share.m_segwit_data.has_value()) {
@@ -671,7 +671,7 @@ uint256 share_init_verify(const ShareT& share, bool check_pow = true)
     // --- Merkle root ---
     // For segwit-activated shares, use segwit_data.txid_merkle_link; otherwise merkle_link
     uint256 merkle_root;
-    if constexpr (ver >= btc::SEGWIT_ACTIVATION_VERSION)
+    if constexpr (ver >= btc::PoolConfig::SEGWIT_ACTIVATION_VERSION)
     {
         if constexpr (requires { share.m_segwit_data; })
         {
@@ -1163,7 +1163,7 @@ uint256 generate_share_transaction(const ShareT& share, TrackerT& tracker, bool 
     size_t n_outs = payout_outputs.size() + 1 /* donation */ + 1 /* OP_RETURN commitment */;
     // Segwit commitment output (if applicable)
     bool has_segwit = false;
-    if constexpr (ver >= btc::SEGWIT_ACTIVATION_VERSION)
+    if constexpr (ver >= btc::PoolConfig::SEGWIT_ACTIVATION_VERSION)
     {
         if constexpr (requires { share.m_segwit_data; })
         {
@@ -1282,7 +1282,7 @@ uint256 generate_share_transaction(const ShareT& share, TrackerT& tracker, bool 
 
             if constexpr (requires { share.m_segwit_data; })
             {
-                if constexpr (ver >= btc::SEGWIT_ACTIVATION_VERSION)
+                if constexpr (ver >= btc::PoolConfig::SEGWIT_ACTIVATION_VERSION)
                 {
                     // PossiblyNoneType: ALWAYS serialize (p2pool writes default when None).
                     // Must match share_init_verify — both paths must produce identical ref_hash.
@@ -1973,7 +1973,7 @@ uint256 verify_share(const ShareT& share, TrackerT& tracker)
 
         if constexpr (requires { share.m_segwit_data; })
         {
-            if constexpr (ver >= btc::SEGWIT_ACTIVATION_VERSION)
+            if constexpr (ver >= btc::PoolConfig::SEGWIT_ACTIVATION_VERSION)
             {
                 // PossiblyNoneType: ALWAYS serialize (p2pool writes default when None)
                 if (share.m_segwit_data.has_value()) {

--- a/src/impl/btc/share_types.hpp
+++ b/src/impl/btc/share_types.hpp
@@ -3,15 +3,15 @@
 #include <core/uint256.hpp>
 #include <core/pack_types.hpp>
 #include <core/pack.hpp>
+#include "config_pool.hpp"   // SSOT: PoolConfig::SEGWIT_ACTIVATION_VERSION
 
 namespace btc
 {
 
-const uint64_t SEGWIT_ACTIVATION_VERSION = 17;
 
 constexpr bool is_segwit_activated(uint64_t version)
 {
-    return version >= SEGWIT_ACTIVATION_VERSION;
+    return version >= PoolConfig::SEGWIT_ACTIVATION_VERSION;
 }
 
 enum StaleInfo


### PR DESCRIPTION
## FLAG 2 — segwit activation single-source-of-truth (BTC-only)

V36 pre-scan (#119 follow-up) surfaced a structural divergence: `share_check.hpp` gated all segwit serialization/merkle paths on the **namespace-local** `btc::SEGWIT_ACTIVATION_VERSION` (`share_types.hpp` = **17**) rather than the declared SSOT `PoolConfig::SEGWIT_ACTIVATION_VERSION` (= **33**, jtoomim `bitcoin.py:35`).

### Change (per-coin isolated — touches only `src/impl/btc/`)
- `share_types.hpp`: retire the local `= 17` constant; route `is_segwit_activated()` at `PoolConfig::SEGWIT_ACTIVATION_VERSION`; add `config_pool.hpp` include (no cycle — `config_pool` has no `share_types` dep).
- `share_check.hpp`: all 6 gate sites `btc::SEGWIT_ACTIVATION_VERSION` -> `btc::PoolConfig::SEGWIT_ACTIVATION_VERSION`.
- `config_pool.hpp` (FLAG 4, comment-only): refresh the stale `COMBINED_DONATION_SCRIPT` comment ("BTC stays at v35") to reflect v36-active BTC shares; donation leg intentionally stays V35 P2PK (forrestv canonical), COMBINED P2SH remains LTC-only. No byte change.

### Risk
Low live risk — only legacy v17..v32 fall in the gap; the live sharechain is v35/v36. Genuine structural fix: the gate now agrees with config across every path.

### Status
- Cross-check (LTC/DGB): **BTC-only** — LTC is 17->17 no-op (skipped per integrator), DGB rides LTC path (config consistent). One PR per coin; this is the BTC tree only.
- **NOT built** — staged read-only under the capacity-return hold.
- **Do not merge** — merge is operator-gated.

base `fd8f99ca` (master) · commit `c40869df` (signed)