### PR TITLE
btc(donation): forrestv P2PK on v36 gentx, not LTC P2SH (FLAG6) [cut-only, do-not-merge]

### DIFF
--- a/src/impl/btc/config_pool.hpp
+++ b/src/impl/btc/config_pool.hpp
@@ -134,13 +134,14 @@ public:
         0x87  // OP_EQUAL
     };
 
-    // Returns the correct donation script based on share version.
-    // Pre-V36 shares use the original P2PK donation script.
-    // V36+ shares use the combined P2SH 1-of-2 multisig script.
-    static std::vector<unsigned char> get_donation_script(int64_t share_version)
+    // BTC donation leg is forrestv's canonical P2PK on ALL share versions,
+    // including v36+ (FLAG6 conformance vs BTC's own jtoomim/forrestv baseline).
+    // The COMBINED P2SH script above is the LTC v36 donation target and is
+    // NEVER selected for BTC: returning it from a BTC gentx would pay the LTC
+    // dev-fund P2SH instead of forrestv's BTC-mainnet P2PK. The version arg is
+    // retained for signature parity with the LTC config but is ignored here.
+    static std::vector<unsigned char> get_donation_script(int64_t /*share_version*/)
     {
-        if (share_version >= 36)
-            return {COMBINED_DONATION_SCRIPT.begin(), COMBINED_DONATION_SCRIPT.end()};
         return {DONATION_SCRIPT.begin(), DONATION_SCRIPT.end()};
     }
 


### PR DESCRIPTION
## FLAG6 — BTC v36 donation redeem-script conformance (BTC-only)

### Problem
`btc/config_pool.hpp::get_donation_script(int64_t share_version)` returned the
**LTC** `COMBINED_DONATION_SCRIPT` (a 23-byte P2SH `OP_HASH160 <hash160> OP_EQUAL`,
LTC mainnet dev-fund address `MLhSmVQxMusLE3pjGFvp4unFckgjeD8LUA`) for any
`share_version >= 36`. The BTC v36 gentx leg at `share_check.hpp:2940`
(`get_donation_script(int64_t(36))`) therefore emitted the **LTC** P2SH donation
output on BTC v36 shares — contradicting the in-code comment, which states the
BTC donation leg intentionally stays forrestv's canonical **BTC-mainnet P2PK**.

This is **latent**: it fires only once BTC v36 is *confirmed* active. The
deployed canary build (`2f2e8282`, a1) predates the v36 layer, so vote-state is
unobserved — this determination is **static-analysis-backed (code-derived), not
node-confirmed**.

### Fix (BTC-only)
`get_donation_script()` now returns the 67-byte forrestv P2PK
(`0x41` OP_PUSHBYTES_65 · `04ffd03de4…664b` · `0xac` OP_CHECKSIG) on **all**
share versions, including v36+. The LTC `COMBINED_DONATION_SCRIPT` constant is
retained as inert byte data (LTC-only; never selected for BTC). The version arg
is kept for signature parity with the LTC config but is ignored.

Touches only `src/impl/btc/config_pool.hpp`. No other coin's config is affected.

### gentx verification (static)
- `DONATION_SCRIPT` = 67 bytes, leading `0x41` (OP_PUSHBYTES_65), pubkey
  `04ffd03de4…`, trailing `0xac` (OP_CHECKSIG) — forrestv canonical BTC P2PK.
- Post-fix, the v36 gentx path (`share_check.hpp:2940`) writes this 67-byte P2PK
  txout, matching the v35 leg (`share_check.hpp:2387`).

### Scope
Per operator approval (decisions@ ✅) and integrator GO: **cut only** — this PR is
NOT for merge. The consensus merge into a release path requires a separate
explicit operator approval on its own card.
