### PR TITLE
btc(donation): clarify combined P2SH is intentional unified v36 target (FLAG6)

### DIFF
--- a/src/impl/btc/config_pool.hpp
+++ b/src/impl/btc/config_pool.hpp
@@ -118,13 +118,19 @@ public:
     };
 
     // V36+ COMBINED_DONATION_SCRIPT (P2SH: OP_HASH160 <hash160(redeem)> OP_EQUAL)
-    // 1-of-2 multisig: forrestv + frstrtr/c2pool dev key.
-    // LTC P2SH donation target. BTC now runs v36-active shares, but its
-    // donation leg intentionally stays the V35 P2PK above (forrestv
-    // canonical BTC-mainnet donation); this COMBINED P2SH is LTC-only,
-    // kept here as inert byte data so get_donation_script() compiles for
-    // both the BTC (P2PK) and LTC v36 (P2SH) paths.
-    // Address: MLhSmVQxMusLE3pjGFvp4unFckgjeD8LUA (LTC mainnet P2SH).
+    // 1-of-2 multisig redeem: forrestv + frstrtr/c2pool dev key.
+    //
+    // INTENTIONAL unified cross-coin v36 donation target. This is NOT inert and
+    // NOT LTC-only: BTC v36 coinbases deliberately pay this combined P2SH. The
+    // identical 20-byte hash160 (8c627262..8e85) is emitted by EVERY coin's v36
+    // gentx (btc/ltc/bch/dgb) via PoolConfig::get_donation_script(>=36). Per-coin
+    // baseline conformance (vs each coin's own p2pool source) still governs every
+    // OTHER consensus aspect; the v36 donation target is the one deliberate
+    // cross-coin exception (operator FLAG6 ruling 2026-06-17, option-b).
+    //
+    // The hash160 renders as MLhSmVQxMusLE3pjGFvp4unFckgjeD8LUA under the LTC
+    // mainnet P2SH prefix; the same hash160 is the shared target on all coins
+    // (only the base58 rendering differs per coin prefix, the redeem does not).
     static constexpr std::array<uint8_t, 23> COMBINED_DONATION_SCRIPT = {
         0xa9, // OP_HASH160
         0x14, // PUSH 20 bytes


### PR DESCRIPTION
Comment-only. No gentx behavior change → CI trivially green.

## FLAG6 decision (operator 2026-06-17, option-b)
The v36 donation target is a **deliberate unified cross-coin combined P2SH** (1-of-2 multisig: forrestv + c2pool dev key) for ALL coins — not a bug, not reverted to per-coin P2PK. PR #127 (option-a P2PK revert) was closed.

## Change
Rewrites the stale/misleading comment above `COMBINED_DONATION_SCRIPT` in `src/impl/btc/config_pool.hpp`. The old comment claimed the combined P2SH was "LTC-only ... inert byte data" for BTC and that BTC v36 stays on V35 P2PK. That is false: the live path `share_check.hpp:2940` `get_donation_script(36) -> COMBINED_DONATION_SCRIPT` means BTC v36 coinbases intentionally pay the combined P2SH. New comment states this plainly and notes per-coin baseline conformance still governs every other consensus aspect; the donation target is the deliberate exception.

## Uniformity verification (step 3)
Confirmed the unified P2SH path is applied **uniformly across all coins** v36 gentx, not BTC-only:

| coin | get_donation_script(>=36) | hash160 |
|------|---------------------------|---------|
| btc  | COMBINED_DONATION_SCRIPT  | 8c627262..8e85 |
| ltc  | COMBINED_DONATION_SCRIPT  | 8c627262..8e85 |
| bch  | COMBINED_DONATION_SCRIPT  | 8c627262..8e85 |
| dgb  | COMBINED_DONATION_SCRIPT  | 8c627262..8e85 |
| dash | (no donation layer)       | N/A |

All route through `PoolConfig::get_donation_script(share_version)` via each coin's `donation_consensus.hpp`. The 20-byte redeem hash160 is byte-identical across btc/ltc/bch/dgb. **No coin diverges from the combined P2SH.**

## Live path — unchanged (left as-is per decision)
`src/impl/btc/share_check.hpp:2940`: `write_txout(donation_amount, PoolConfig::get_donation_script(int64_t(36)))`.