### PR TITLE
dgb: conform share/coin params to p2pool-dgb-scrypt oracle

### DIFF
--- a/src/impl/dgb/config_coin.hpp
+++ b/src/impl/dgb/config_coin.hpp
@@ -27,7 +27,7 @@ namespace config
 } // config
 
 /// DigiByte Scrypt coin parameters.
-/// Source: p2pool-merged-v36/p2pool/bitcoin/networks/digibyte.py
+/// Source of truth: p2pool-dgb-scrypt oracle bitcoin/networks/digibyte.py
 ///
 /// DGB uses 5 algorithms rotating every 15 seconds. Scrypt is one of them.
 /// When running as a P2Pool parent chain, we request getblocktemplate with
@@ -49,8 +49,10 @@ public:
     static constexpr uint16_t MAINNET_RPC_PORT = 14024;
     static constexpr uint16_t TESTNET_RPC_PORT = 14025;
 
-    // Block timing: 75s total / 5 algos = 15s per algo
-    static constexpr uint32_t BLOCK_PERIOD     = 15;   // seconds (Scrypt algo rotation)
+    // Block timing: Scrypt-only parent block period (oracle PARENT.BLOCK_PERIOD).
+    // DGB mints a block ~every 15s across 5 rotating algos; one algo (Scrypt)
+    // lands ~every 75s, which is the period a Scrypt-only parent observes.
+    static constexpr uint32_t BLOCK_PERIOD     = 75;   // seconds (Scrypt algo period)
 
     // -----------------------------------------------------------------------
     // Address encoding
@@ -71,7 +73,7 @@ public:
 
     // -----------------------------------------------------------------------
     // DGB subsidy schedule (3-phase decay)
-    // Source: p2pool-merged-v36/p2pool/bitcoin/networks/digibyte.py
+    // Source: p2pool-dgb-scrypt oracle bitcoin/networks/digibyte.py
     // -----------------------------------------------------------------------
     static uint64_t subsidy(uint32_t height)
     {

--- a/src/impl/dgb/config_pool.hpp
+++ b/src/impl/dgb/config_pool.hpp
@@ -28,21 +28,21 @@ public:
 
     // -----------------------------------------------------------------------
     // Static DGB Scrypt p2pool network constants
-    // Source: p2pool-merged-v36/p2pool/networks/digibyte.py
+    // Source of truth: p2pool-dgb-scrypt oracle networks/digibyte.py
     // -----------------------------------------------------------------------
     static constexpr uint16_t P2P_PORT                  = 5024;
-    static constexpr uint32_t SPREAD                    = 30;
-    static constexpr uint32_t TARGET_LOOKBEHIND         = 200;
+    static constexpr uint32_t SPREAD                    = 24;
+    static constexpr uint32_t TARGET_LOOKBEHIND         = 100;
     static constexpr uint32_t MINIMUM_PROTOCOL_VERSION    = 1700;  // floor (p2pool-dgb-scrypt digibyte.py NEW_MIN)
     static constexpr uint32_t ADVERTISED_PROTOCOL_VERSION = 3301;  // advertised capability (p2pool-dgb-scrypt p2p.py VERSION)
-    static constexpr uint32_t SEGWIT_ACTIVATION_VERSION = 17;
-    static constexpr uint32_t BLOCK_MAX_SIZE            = 1000000;
-    static constexpr uint32_t BLOCK_MAX_WEIGHT          = 4000000;
+    static constexpr uint32_t SEGWIT_ACTIVATION_VERSION = 35;
+    static constexpr uint32_t BLOCK_MAX_SIZE            = 32000000;
+    static constexpr uint32_t BLOCK_MAX_WEIGHT          = 128000000;
 
     // Mainnet constants
-    static constexpr uint32_t SHARE_PERIOD              = 25;      // seconds
-    static constexpr uint32_t CHAIN_LENGTH              = 8640;    // ~24 hours at 25s
-    static constexpr uint32_t REAL_CHAIN_LENGTH         = 8640;
+    static constexpr uint32_t SHARE_PERIOD              = 15;      // seconds (oracle SHARE_PERIOD)
+    static constexpr uint32_t CHAIN_LENGTH              = 2880;    // 12*60*60//15 — ~12h at 15s
+    static constexpr uint32_t REAL_CHAIN_LENGTH         = 2880;
 
     // Testnet constants
     static constexpr uint32_t TESTNET_SHARE_PERIOD      = 4;
@@ -124,7 +124,7 @@ public:
     }
 
     static inline const std::set<std::string> SOFTFORKS_REQUIRED = {
-        "csv", "segwit"
+        "nversionbips", "csv", "segwit", "reservealgo", "odo", "taproot"
     };
 
     // Bootstrap peers for the DGB Scrypt p2pool network

--- a/src/impl/dgb/params.hpp
+++ b/src/impl/dgb/params.hpp
@@ -30,7 +30,7 @@ inline core::CoinParams make_coin_params(bool testnet)
 
     // ===== Coin-level (net.PARENT) — from dgb::CoinParams (config_coin.hpp) =====
     p.symbol       = "DGB";
-    p.block_period = CoinParams::BLOCK_PERIOD;  // 15s (Scrypt algo rotation slot)
+    p.block_period = CoinParams::BLOCK_PERIOD;  // 75s (Scrypt-only parent period, oracle PARENT.BLOCK_PERIOD)
 
     // Address encoding
     if (testnet) {
@@ -42,8 +42,10 @@ inline core::CoinParams make_coin_params(bool testnet)
         p.address_p2sh_version = CoinParams::ADDRESS_P2SH_VERSION;     // 63 (S...)
         p.bech32_hrp           = CoinParams::BECH32_HRP;               // "dgb"
     }
-    // address_p2sh_version2: DGB legacy P2SH prefix (5). Affects address-parse
-    // leniency only, NOT block/share validation. [confirm-vs-oracle]
+    // address_p2sh_version2: secondary P2SH prefix for parse leniency only, NOT
+    // block/share validation. The oracle defines a SINGLE P2SH version (63); it
+    // is silent on a second prefix, so 5 (DGB legacy) is NOT oracle-sourced.
+    // [confirm-vs-oracle] kept open — see oracle-conformance report.
     p.address_p2sh_version2 = testnet ? 0 : 5;
 
     // PoW: Scrypt work, SHA256d block identity (same shape as LTC)
@@ -55,17 +57,18 @@ inline core::CoinParams make_coin_params(bool testnet)
         return CoinParams::subsidy(height);
     };
 
-    // Dust threshold: 0.001 DGB. Local relay policy, not consensus. [confirm-vs-oracle]
+    // Dust threshold: 0.001 DGB = 100000 sat. Confirmed vs oracle DUST_THRESHOLD
+    // (0.001e8). Local relay policy, not consensus.
     p.dust_threshold = 100000;
 
-    // Softforks — from PoolConfig SSOT (DGB oracle: csv + segwit)
+    // Softforks — from PoolConfig SSOT (oracle: nversionbips,csv,segwit,reservealgo,odo,taproot)
     p.softforks_required        = PoolConfig::SOFTFORKS_REQUIRED;
-    p.segwit_activation_version = PoolConfig::SEGWIT_ACTIVATION_VERSION;  // 17
+    p.segwit_activation_version = PoolConfig::SEGWIT_ACTIVATION_VERSION;  // 35
 
     // ===== Pool-level (net) — from dgb::PoolConfig (config_pool.hpp) =====
     p.p2p_port    = PoolConfig::P2P_PORT;  // 5024 (DGB sharechain P2P)
-    // worker_port: DGB Stratum port. Operator-overridable via pool.yaml; the
-    // default below is provisional pending oracle confirmation. [confirm-vs-oracle]
+    // worker_port: DGB Stratum port. Confirmed vs oracle WORKER_PORT = 5025.
+    // Operator-overridable via pool.yaml.
     p.worker_port = 5025;
 
     if (testnet) {
@@ -73,13 +76,13 @@ inline core::CoinParams make_coin_params(bool testnet)
         p.chain_length     = PoolConfig::TESTNET_CHAIN_LENGTH;       // 400
         p.real_chain_length = PoolConfig::TESTNET_REAL_CHAIN_LENGTH;  // 400
     } else {
-        p.share_period     = PoolConfig::SHARE_PERIOD;              // 25
-        p.chain_length     = PoolConfig::CHAIN_LENGTH;             // 8640
-        p.real_chain_length = PoolConfig::REAL_CHAIN_LENGTH;        // 8640
+        p.share_period     = PoolConfig::SHARE_PERIOD;              // 15
+        p.chain_length     = PoolConfig::CHAIN_LENGTH;             // 2880
+        p.real_chain_length = PoolConfig::REAL_CHAIN_LENGTH;        // 2880
     }
 
-    p.target_lookbehind        = PoolConfig::TARGET_LOOKBEHIND;          // 200
-    p.spread                   = PoolConfig::SPREAD;                     // 30
+    p.target_lookbehind        = PoolConfig::TARGET_LOOKBEHIND;          // 100
+    p.spread                   = PoolConfig::SPREAD;                     // 24
     p.minimum_protocol_version = PoolConfig::MINIMUM_PROTOCOL_VERSION;   // 1700 floor
     p.block_max_size           = PoolConfig::BLOCK_MAX_SIZE;
     p.block_max_weight         = PoolConfig::BLOCK_MAX_WEIGHT;

--- a/src/impl/dgb/params.hpp
+++ b/src/impl/dgb/params.hpp
@@ -1,0 +1,113 @@
+#pragma once
+
+// DGB CoinParams factory: builds a fully populated core::CoinParams for the
+// DigiByte-Scrypt p2pool parent chain.
+//
+// SOURCE OF TRUTH: the DGB oracle frstrtr/p2pool-dgb-scrypt (operator ruling
+// 2026-06-17, "switch-oracle" / Option B). The V36-master byte-compat
+// constraint with p2pool-merged-v36 is FORMALLY WAIVED for DGB by that ruling.
+//
+// CONSENSUS-NEUTRALITY: this factory holds NO hardcoded consensus bytes of its
+// own. Every consensus-critical value is sourced from the single-source-of-truth
+// static members of dgb::CoinParams (config_coin.hpp) and dgb::PoolConfig
+// (config_pool.hpp), so there is exactly one place a DGB constant can drift.
+//
+// Scrypt-only (V36): pow_func = scrypt; other DGB algos are accept-by-continuity
+// per project_v36_dgb_scrypt_only and never reach Scrypt share validation.
+
+#include "config_coin.hpp"
+#include "config_pool.hpp"
+
+#include <core/coin_params.hpp>
+#include <core/pow.hpp>
+
+namespace dgb
+{
+
+inline core::CoinParams make_coin_params(bool testnet)
+{
+    core::CoinParams p;
+
+    // ===== Coin-level (net.PARENT) — from dgb::CoinParams (config_coin.hpp) =====
+    p.symbol       = "DGB";
+    p.block_period = CoinParams::BLOCK_PERIOD;  // 15s (Scrypt algo rotation slot)
+
+    // Address encoding
+    if (testnet) {
+        p.address_version      = CoinParams::TESTNET_ADDRESS_VERSION;  // 126
+        p.address_p2sh_version = CoinParams::TESTNET_P2SH_VERSION;     // 140
+        p.bech32_hrp           = CoinParams::TESTNET_BECH32_HRP;       // "dgbt"
+    } else {
+        p.address_version      = CoinParams::ADDRESS_VERSION;          // 30 (D...)
+        p.address_p2sh_version = CoinParams::ADDRESS_P2SH_VERSION;     // 63 (S...)
+        p.bech32_hrp           = CoinParams::BECH32_HRP;               // "dgb"
+    }
+    // address_p2sh_version2: DGB legacy P2SH prefix (5). Affects address-parse
+    // leniency only, NOT block/share validation. [confirm-vs-oracle]
+    p.address_p2sh_version2 = testnet ? 0 : 5;
+
+    // PoW: Scrypt work, SHA256d block identity (same shape as LTC)
+    p.pow_func        = core::pow::scrypt;
+    p.block_hash_func = core::pow::sha256d;
+
+    // Subsidy: DGB 3-phase decay schedule (config_coin.hpp SSOT)
+    p.subsidy_func = [](uint32_t height) -> uint64_t {
+        return CoinParams::subsidy(height);
+    };
+
+    // Dust threshold: 0.001 DGB. Local relay policy, not consensus. [confirm-vs-oracle]
+    p.dust_threshold = 100000;
+
+    // Softforks — from PoolConfig SSOT (DGB oracle: csv + segwit)
+    p.softforks_required        = PoolConfig::SOFTFORKS_REQUIRED;
+    p.segwit_activation_version = PoolConfig::SEGWIT_ACTIVATION_VERSION;  // 17
+
+    // ===== Pool-level (net) — from dgb::PoolConfig (config_pool.hpp) =====
+    p.p2p_port    = PoolConfig::P2P_PORT;  // 5024 (DGB sharechain P2P)
+    // worker_port: DGB Stratum port. Operator-overridable via pool.yaml; the
+    // default below is provisional pending oracle confirmation. [confirm-vs-oracle]
+    p.worker_port = 5025;
+
+    if (testnet) {
+        p.share_period     = PoolConfig::TESTNET_SHARE_PERIOD;       // 4
+        p.chain_length     = PoolConfig::TESTNET_CHAIN_LENGTH;       // 400
+        p.real_chain_length = PoolConfig::TESTNET_REAL_CHAIN_LENGTH;  // 400
+    } else {
+        p.share_period     = PoolConfig::SHARE_PERIOD;              // 25
+        p.chain_length     = PoolConfig::CHAIN_LENGTH;             // 8640
+        p.real_chain_length = PoolConfig::REAL_CHAIN_LENGTH;        // 8640
+    }
+
+    p.target_lookbehind        = PoolConfig::TARGET_LOOKBEHIND;          // 200
+    p.spread                   = PoolConfig::SPREAD;                     // 30
+    p.minimum_protocol_version = PoolConfig::MINIMUM_PROTOCOL_VERSION;   // 1700 floor
+    p.block_max_size           = PoolConfig::BLOCK_MAX_SIZE;
+    p.block_max_weight         = PoolConfig::BLOCK_MAX_WEIGHT;
+
+    // Max target (share difficulty floor) — PoolConfig SSOT, testnet-aware
+    PoolConfig::is_testnet = testnet;
+    p.max_target = PoolConfig::max_target();
+
+    // Network identification — DGB oracle (switch-oracle Option B)
+    p.identifier_hex         = PoolConfig::IDENTIFIER_HEX;          // 4b62545b1a631afe
+    p.prefix_hex             = PoolConfig::DEFAULT_PREFIX_HEX;      // 1c0553f23ebfcffe
+    p.testnet_identifier_hex = PoolConfig::TESTNET_IDENTIFIER_HEX;
+    p.testnet_prefix_hex     = PoolConfig::TESTNET_PREFIX_HEX;
+
+    // Bootstrap peers (populated as DGB p2pool nodes come online)
+    p.bootstrap_addrs = PoolConfig::DEFAULT_BOOTSTRAP_HOSTS;
+
+    // Donation scripts (consensus-critical) — version-gated selection lives in
+    // PoolConfig::get_donation_script (SSOT). v35 = forrestv P2PK (4104ffd0...),
+    // v36+ = combined P2SH 1-of-2.
+    p.donation_script_func = [](int64_t share_version) -> std::vector<unsigned char> {
+        return PoolConfig::get_donation_script(share_version);
+    };
+
+    p.current_share_version = 36;
+    p.is_testnet            = testnet;
+
+    return p;
+}
+
+} // namespace dgb


### PR DESCRIPTION
Stacked on #129 (params.hpp factory). HOLD merge — integrator merges on operator approval.

## What
Migrates DGB share-layer + parent-period constants from stale merged-v36/farsider holdovers to the **canonical DGB oracle** `frstrtr/p2pool-dgb-scrypt` (operator ruling 2026-06-17, Option B "switch-oracle"; merged-v36 byte-compat WAIVED for DGB). The oracle-switch only carried IDENTIFIER/PREFIX/donation/minproto — the rest of the sharechain identity was never migrated.

## Adjudication table (config SSOT vs oracle)
| const | was | oracle | file |
|---|---|---|---|
| SPREAD | 30 | **24** | config_pool |
| TARGET_LOOKBEHIND | 200 | **100** | config_pool |
| SHARE_PERIOD | 25 | **15** | config_pool |
| CHAIN_LENGTH / REAL | 8640 | **2880** (12h@15s) | config_pool |
| SEGWIT_ACTIVATION_VERSION | 17 | **35** | config_pool |
| BLOCK_MAX_SIZE | 1M | **32M** | config_pool |
| BLOCK_MAX_WEIGHT | 4M | **128M** | config_pool |
| SOFTFORKS_REQUIRED | {csv,segwit} | **+nversionbips,reservealgo,odo,taproot** | config_pool |
| BLOCK_PERIOD | 15 | **75** | config_coin |

✅ already matched (unchanged): IDENTIFIER, PREFIX, P2P_PORT 5024, MAX_TARGET, donation P2PK, ADDRESS_VERSION 30 / P2SH 63, magic, HRP, dust 0.001e8, worker_port 5025.

## Still OPEN [confirm-vs-oracle] — deliberately NOT changed here (need adjudication)
1. **subsidy()** — oracle get_subsidy uses `weeks=(blocks/period)+1` (off-by-one vs our loop) and a local `COIN=1e6` (vs our 1e8). Needs careful review before touching consensus subsidy math.
2. **parent daemon ports** — config 12024/14024 vs oracle 12029/14029. Connection defaults, operator-overridable, non-consensus; 12024 is the documented DigiByte Core default.
3. **address_p2sh_version2=5** — oracle defines a single P2SH version (63), silent on a 2nd prefix. Parse-leniency only, not consensus.

GPG-signed c51f39b5.