### PR TITLE
dgb(tracker): derive chain-score time_span from CoinParams::block_period (drop farsider350 holdover)

### DIFF
--- a/src/impl/dgb/share_tracker.hpp
+++ b/src/impl/dgb/share_tracker.hpp
@@ -635,14 +635,16 @@ public:
         // oscillation where short chains beat long chains simply because the
         // long chain's old blocks are unresolvable.
         if (!block_height.has_value() || block_height.value() <= 0)
-            block_height = 1000000;  // ~1M confirmations → time_span ≈ 150M seconds
+            block_height = 1000000;  // ~1M confirmations → time_span ≈ 75M seconds
 
         // p2pool: self.verified.get_delta(share_hash, end_point).work
         auto total_work = verified.get_delta_work(share_hash, end_point);
 
         // p2pool: (0 - block_height + 1) * BLOCK_PERIOD
-        // c2pool confirmations: 1=tip → 150s, 4 → 600s (matches p2pool).
-        auto time_span = block_height.value() * 15;  // DGB BLOCK_PERIOD = 15s (farsider350 digibyte.py:21)
+        // c2pool confirmations: 1=tip → 75s, 4 → 300s (matches p2pool).
+        // BLOCK_PERIOD sourced from the make_coin_params-populated CoinParams
+        // (oracle PARENT.BLOCK_PERIOD, config_coin.hpp = 75s) — no hardcoded holdover.
+        auto time_span = block_height.value() * static_cast<int32_t>(m_params->block_period);
         if (time_span <= 0)
             time_span = 1;
 


### PR DESCRIPTION
Stacked on #131 (dgb/oracle-conformance).

## What
best-chain score() computed time_span = block_height * 15 with a hardcoded 15s period and a dead farsider350 digibyte.py:21 comment. That bypassed the oracle-conformed PARENT.BLOCK_PERIOD (75s, config_coin.hpp set in #131). This sources it from the make_coin_params-populated m_params->block_period so there is ONE SSOT for the DGB Scrypt-only parent period in the score path — no hardcoded consensus holdover. Stale confirmation comments updated (1=tip -> 75s, ~75M fallback).

## Bucket (v36 standardization)
PRE-V36 holdover removal -> conform to own oracle frstrtr/p2pool-dgb-scrypt. Coin-specific consensus value; per-coin, not a cross-coin standardization target.

## Scope / safety
- dgb-only (src/impl/dgb/share_tracker.hpp); no shared-base / bitcoin_family touch.
- c2pool-dgb builds clean (EXIT=0, binary links). NOTE: share_tracker.hpp is header-only and not yet pulled into a compiled TU (node is still the skeleton; the pool layer that instantiates the tracker lands in the stacked pool/share slices) — so the line is not compile-exercised by the current smoke. It is valid in the context it will compile (m_params is an established member, block_period a CoinParams field).

NO AI/model attribution. GPG-signed (c0ea7c75).