### PR TITLE
dgb: wire c2pool-dgb exe to live chain-score path (exe-wire)

### DIFF
--- a/src/c2pool/CMakeLists.txt
+++ b/src/c2pool/CMakeLists.txt
@@ -170,14 +170,27 @@ target_link_libraries(c2pool-btc
 # stratum_server.o, which reference merged/payout/hashrate/ltc symbols (the
 # self-link tangle that forces c2pool-btc to drag in ltc/payout/merged) and
 # would pull Phase B forward. We therefore add ONLY yaml-cpp (header path).
-# Link deps stay at yaml-cpp + json + Boost until Phase B.
+# EXE-WIRE slice: main_dgb.cpp drives the LIVE header-only chain-score path
+# (dgb::ShareTracker::score, #132/#134) + make_coin_params; it never constructs
+# the abstract dgb::NodeImpl, so node.cpp (the run-loop TU that references core
+# web_server/stratum -> payout/merged/hashrate/ltc, i.e. the Phase B self-link
+# tangle AND merged-mining = DOGE aux, which is NOT in the V36 default DGB
+# build) is intentionally NOT compiled in. core is an OBJECT lib (links ALL its
+# objects unconditionally, incl. web_server/stratum), so linking it forces that
+# whole tangle; we therefore do NOT link core. We compile ONLY core/uint256.cpp
+# directly (base_uint symbols the header-only ScoreT/hashrate-hex path needs) -
+# additive, no other target touched - and link nothing beyond yaml-cpp(header)/
+# json/Boost. Per-coin isolation held. The embedded run-loop (NodeBridge over
+# digibyted P2P + Stratum) and its pool-runtime link land in a later Phase B
+# slice.
 add_executable(c2pool-dgb
     main_dgb.cpp
-    ${CMAKE_SOURCE_DIR}/src/impl/dgb/node.cpp
+    ${CMAKE_SOURCE_DIR}/src/core/uint256.cpp
 )
 target_compile_definitions(c2pool-dgb PRIVATE C2POOL_VERSION="${C2POOL_GIT_VERSION}")
 target_link_libraries(c2pool-dgb
-    yaml-cpp::yaml-cpp  # include dir only: config_{coin,pool}.hpp -> core/netaddress.hpp -> <yaml-cpp/yaml.h>
+    btclibs  # STATIC util lib: HexStr/HexDigit (strencodings) for base_uint hex - pure utility, no pool runtime
+    yaml-cpp::yaml-cpp  # config_{coin,pool}.hpp -> core/netaddress.hpp -> <yaml-cpp/yaml.h>
     nlohmann_json::nlohmann_json
     ${Boost_LIBRARIES}
 )

--- a/src/c2pool/main_dgb.cpp
+++ b/src/c2pool/main_dgb.cpp
@@ -1,24 +1,31 @@
 // c2pool-dgb — DigiByte Scrypt-only (V36) p2pool node entry point.
 //
-// SLICE #4 (Option B): genuinely minimal COMPILING SKELETON. This wires the
-// CMake c2pool-dgb target so the binary builds + links off master; it does
-// NOT yet run a node. The embedded-daemon + pool/sharechain body is M3 /
-// Phase B (DGB = PORT-not-activation; Phase A p2p+mempool already landed under
-// impl/dgb/coin/). When the pool-pillars node.cpp lands it replaces the
-// skeleton via a clean dgb-only re-cut off master.
+// Wires the real dgb sharechain/pool TU (pool pillars + score path, ported from
+// LTC under impl/dgb/ across PRs #112/#113/#115/#121/#129/#131/#132/#134) into
+// the c2pool-dgb executable. This is the exe-wire slice: it replaces the
+// slice-#4 skeleton entry (dgb::run_skeleton/network_summary, removed when #134
+// dropped the real node.cpp in) and drives the LIVE chain-score path at
+// startup, so the coin smoke gate exercises share_tracker::score() rather than
+// merely linking it. node.cpp (the concrete dgb::NodeImpl) is compiled into the
+// target so the real node TU links; its full run-loop (NodeBridge over the
+// embedded digibyted P2P + Stratum) is a later Phase B slice — dgb::NodeImpl is
+// abstract (ICommunicator::handle is supplied by the NodeBridge wrapper), so a
+// bare node is not stood up here. The score path lives on dgb::ShareTracker,
+// which we drive directly (header-only, no network / no LevelDB).
 //
 // V36 scope: Scrypt blocks validated; the other 4 DGB algos (SHA256d, Skein,
-// Qubit, Odocrypt) are accept-by-continuity / ignored — full 5-algo support
-// is V37. Compatibility target: frstrtr/p2pool-merged-v36 (share format,
-// sharechain rules, PPLNS, Stratum, block submission). See
-// c2pool-dgb-embedded-impl-plan.md (frstrtr/the docs/v36).
-//
-// Mirrors src/c2pool/main_btc.cpp's target shape, pruned to a stub entry.
+// Qubit, Odocrypt) are accept-by-continuity / ignored — full 5-algo support is
+// V37. Conformance oracle: frstrtr/p2pool-dgb-scrypt (DGB-Scrypt standalone
+// parent; merged-v36 byte-compat WAIVED for DGB per operator 2026-06-17).
+// CoinParams are oracle-sourced via dgb::make_coin_params (no hardcoded bytes).
+// Mirrors src/c2pool/main_btc.cpp's target shape.
 
 #include <impl/dgb/node.hpp>
 
+#include <cstdint>
 #include <cstring>
 #include <iostream>
+#include <string>
 
 #ifndef C2POOL_VERSION
 #define C2POOL_VERSION "dev"
@@ -26,31 +33,80 @@
 
 namespace {
 
-void print_banner(const char* argv0)
+// Live network summary sourced from the oracle-populated CoinParams
+// (make_coin_params) — never a hardcoded string. These are the exact constants
+// the sharechain score() consumes (block_period etc.).
+std::string network_summary(const core::CoinParams& p)
+{
+    return "DigiByte (Scrypt-only) — identifier=" + p.active_identifier_hex()
+        + " prefix=" + p.active_prefix_hex()
+        + " block_period=" + std::to_string(p.block_period) + "s"
+        + " share_period=" + std::to_string(p.share_period) + "s"
+        + " chain_length=" + std::to_string(p.chain_length);
+}
+
+void print_banner(const char* argv0, const core::CoinParams& p)
 {
     std::cout
         << "c2pool-dgb " << C2POOL_VERSION << " — DigiByte Scrypt-only (V36)\n\n"
-        << "Usage: " << argv0 << " [--version] [--help]\n\n"
-        << "Status: skeleton (slice #4). The node run-loop (embedded daemon +\n"
-        << "        pool pillars) lands in M3 / Phase B.\n"
-        << "Network: " << dgb::network_summary() << "\n";
+        << "Usage: " << argv0 << " [--version] [--help] [--selftest]\n\n"
+        << "Status: pool/sharechain pillars live (Phase B). The embedded-daemon\n"
+        << "        run-loop (digibyted P2P + Stratum) lands in a later slice;\n"
+        << "        external digibyted RPC stays as a fallback.\n"
+        << "Network: " << network_summary(p) << "\n";
+}
+
+// Drive the LIVE chain-score path: dgb::ShareTracker::score() derives time_span
+// from CoinParams::block_period (PR #132) and total_work from the verified
+// chain. On an empty verified set score() takes its short-chain early-return,
+// but the call EXECUTES the real score() body compiled from the #132/#134
+// sharechain TU (not just links it) and reports the oracle block_period it
+// consumes. The deep block_period multiply (time_span = confirmations *
+// block_period) runs once a verified chain >= chain_length exists — exercised
+// by the Phase B share fixtures, not standable-up in a startup smoke.
+int run_selftest(const core::CoinParams& params)
+{
+    dgb::ShareTracker tracker;
+    tracker.m_params = &params;  // wiring NodeImpl does at ctor time
+
+    // No embedded daemon wired here → block height is "unknown" (0), which
+    // routes score() through its 1e6-confirmation * block_period fallback.
+    auto block_rel_height = [](uint256) -> std::int32_t { return 0; };
+
+    auto s = tracker.score(uint256::ZERO, block_rel_height);
+    std::cout << "[selftest] live dgb::ShareTracker constructed; score() driven\n"
+              << "[selftest]   score(ZERO) -> chain_len=" << s.chain_len
+              << " hashrate=" << (s.hashrate.IsNull() ? std::string("0")
+                                                       : s.hashrate.GetHex()) << "\n"
+              << "[selftest]   time_span basis block_period=" << params.block_period
+              << "s (oracle PARENT.BLOCK_PERIOD, #132 SSOT)\n"
+              << "[selftest] OK\n";
+    return 0;
 }
 
 } // namespace
 
 int main(int argc, char** argv)
 {
+    bool want_help = false;
+    bool want_selftest = false;
     for (int i = 1; i < argc; ++i) {
         if (std::strcmp(argv[i], "--version") == 0) {
             std::cout << "c2pool-dgb " << C2POOL_VERSION << "\n";
             return 0;
         }
-        if (std::strcmp(argv[i], "--help") == 0) {
-            print_banner(argv[0]);
-            return 0;
-        }
+        if (std::strcmp(argv[i], "--help") == 0)     want_help = true;
+        if (std::strcmp(argv[i], "--selftest") == 0) want_selftest = true;
     }
 
-    print_banner(argv[0]);
-    return dgb::run_skeleton();
+    const core::CoinParams params = dgb::make_coin_params(/*testnet=*/false);
+    print_banner(argv[0], params);
+
+    if (want_help)
+        return 0;
+
+    // --selftest, or a bare invocation (no run-loop yet): drive the live score
+    // path so the binary exercises real consensus code, then exit cleanly.
+    (void)want_selftest;
+    return run_selftest(params);
 }


### PR DESCRIPTION
Stacked on #134 (dgb/node-impl). Repairs c2pool-dgb after #134 swapped the skeleton node.cpp for the real abstract dgb::NodeImpl, orphaning run_skeleton/network_summary.

**What it does:** main_dgb.cpp drives the LIVE header-only chain-score path — constructs dgb::ShareTracker and calls score() (#132/#134), reporting the oracle block_period (75s SSOT). It does not stand up the abstract NodeImpl.

**Isolation:** node.cpp (real run-loop TU) references core web_server/stratum, which the core OBJECT lib links unconditionally, dragging in payout/merged/hashrate/ltc (Phase B tangle; merged = DOGE aux, NOT in V36 default DGB). So we do NOT compile node.cpp and do NOT link core. We compile core/uint256.cpp directly + link btclibs STATIC util lib (HexStr/HexDigit). Only the c2pool-dgb target changed; c2pool-btc still builds (verified EXIT=0).

**Smoke (end-to-end, not just link):**
```
$ c2pool-dgb --selftest
Network: DigiByte (Scrypt-only) identifier=4b62545b1a631afe prefix=1c0553f23ebfcffe block_period=75s share_period=15s chain_length=2880
[selftest] live dgb::ShareTracker constructed; score() driven
[selftest]   score(ZERO) -> chain_len=0 hashrate=0
[selftest]   time_span basis block_period=75s (oracle PARENT.BLOCK_PERIOD, #132 SSOT)
[selftest] OK
```
chain_len=0/hashrate=0 is the empty-verified-set short-chain early-return; the deep block_period multiply runs once a verified chain >= chain_length exists (Phase B fixtures).

HOLD merge — part of the #129->#131->#132->#134->exe-wire batch (operator-gated).