### PR TITLE
ci: build test_dgb_subsidy in both Linux test jobs (fix master-red NOT_BUILT)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
                     test_phase4_embedded \
                     test_mweb_builder \
                     test_address_resolution test_compute_share_target \
-                    test_utxo \
+                    test_utxo test_dgb_subsidy \
                     v37_test \
             -j$(nproc)
 
@@ -193,7 +193,7 @@ jobs:
                     test_phase4_embedded \
                     test_mweb_builder \
                     test_address_resolution test_compute_share_target \
-                    test_utxo \
+                    test_utxo test_dgb_subsidy \
                     test_coin_broadcaster test_multiaddress_pplns test_pplns_stress \
                     v37_test \
             -j$(nproc)


### PR DESCRIPTION
## Problem
master CI is red on the Linux x86_64 and Linux x86_64 (AsAN+UBSan) jobs. The Run tests step exits 8 with:

    36 - test_dgb_subsidy_NOT_BUILT (Not Run)
    99% tests passed, 1 tests failed out of 616

Confirmed on the #138 merge run (27717734612) too, so it is pre-existing on master, not introduced by any open DGB PR.

## Root cause
test_dgb_subsidy is registered in test/CMakeLists.txt via gtest_discover_tests with DISCOVERY_MODE PRE_TEST, but it was never added to the explicit cmake --build --target allowlist in the build.yml "Build tests" (Linux) and "Build c2pool + tests" (AsAN) steps. The executable is therefore absent at ctest time, CTest registers the *_NOT_BUILT sentinel, and the step fails. This regression landed when #137 added the test without wiring it into the CI allowlist.

## Fix
Add test_dgb_subsidy to both target lists (2-line diff). The target builds clean and both subsidy oracle tests pass locally:

    [  PASSED  ] 2 tests. (DgbSubsidy.MatchesOracleVectors, DgbSubsidy.NeverBelowCoinFloor)

DGB-domain (completes the #137 landing). GPG-signed. HOLD merge -- integrator merges on operator tap.
