### PR TITLE
dgb: M3 wire external-daemon RPC transport into build + real ctor

### DIFF
--- a/src/impl/dgb/coin/CMakeLists.txt
+++ b/src/impl/dgb/coin/CMakeLists.txt
@@ -7,7 +7,9 @@
 
 set(dgb_coin_impl
     rpc_data.hpp
-    rpc.hpp
+    rpc.hpp rpc.cpp
+    rpc_request.hpp
+    softfork_check.hpp
     p2p_connection.hpp p2p_connection.cpp
     p2p_node.cpp p2p_node.hpp
     p2p_messages.hpp

--- a/src/impl/dgb/coin/node.hpp
+++ b/src/impl/dgb/coin/node.hpp
@@ -64,18 +64,25 @@ class Node : public dgb::interfaces::Node
 
     config_t* m_config = nullptr;
 
+    // Real io_context for the M3 NodeRPC transport (mirrors btc node.hpp).
+    // rpc.hpp brings boost::asio in transitively; no extra include needed.
+    boost::asio::io_context* m_context = nullptr;
+
     std::unique_ptr<NodeRPC> m_rpc;
 
 public:
-    Node(auto* /*context*/, auto* config) : m_config(config)
+    Node(auto* context, auto* config) : m_config(config), m_context(context)
     {
     }
 
     void run()
     {
-        // Stub NodeRPC: constructed so has-rpc presence wiring can be
-        // exercised, but no transport connect until M3.
-        m_rpc = std::make_unique<NodeRPC>(this);
+        // M3: real NodeRPC transport (external-daemon FALLBACK path that V36
+        // mandates persist alongside the embedded daemon). Mirrors btc
+        // node.hpp; testnet drives the chain-identity genesis probe in
+        // NodeRPC::check(). connect() (transport bring-up) is driven by the
+        // pool-layer seam once an RPC endpoint is configured.
+        m_rpc = std::make_unique<NodeRPC>(m_context, this, m_config->m_testnet);
     }
 
     NodeRPC* rpc() { return m_rpc.get(); }


### PR DESCRIPTION
## M3 — wire external-daemon RPC transport into the build

Closes the deferred Option-B wiring from #149. The M3 RPC transport (`rpc.cpp` + the `rpc_request.hpp`/`softfork_check.hpp` SSOTs) landed as additive coin-layer source in #149 but was **never registered in CMake**, so it never compiled into the build — and the node owner still constructed the 1-arg stub `NodeRPC`.

### Changes (src/impl/dgb/ only)
- **coin/CMakeLists.txt**: add `rpc.cpp` + `rpc_request.hpp` + `softfork_check.hpp` to `dgb_coin_impl` so the transport TU compiles and links.
- **coin/node.hpp**: capture the `io_context` in the `Node` ctor and construct the real `NodeRPC(m_context, this, m_config->m_testnet)`, replacing the stub. This is the external-daemon **FALLBACK** path V36 mandates persists alongside the embedded daemon; `testnet` drives `NodeRPC::check()` chain-identity genesis probe.

### Verification (local)
- `dgb_coin` + `c2pool-dgb` build `EXIT=0` (rpc.cpp now compiles into `libdgb_coin.a`, exe links).
- M3 guard tests **30/30**: rpc_request 8, softfork 8, genesis 7, dgb_share 5, subsidy 2.

### CI notes
- No new test target → no build.yml allowlist change needed; `rpc.cpp` compiles via the existing **dgb smoke** (builds `c2pool-dgb` → links `dgb_coin`).
- Touches the live transport TU → **ASan+UBSan gate** is the acceptance check (as integrator flagged for the transport path).

p2pool-dgb-scrypt parity preserved. HOLD merge for operator push-approval.
