### PR TITLE
chore: ignore underscore-separated build_*/ trees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,8 @@ tools/
 # CMake out-of-source build trees (any name starting with `build-`).
 # Catches build-spv/, build-qt/, build-relwithdebinfo/, etc.
 /build-*/
+# Same, underscore-separated (build_dgb/, build_spv/, etc.).
+/build_*/
 
 # Vendored third-party libraries under external/ (e.g. external/dashbls).
 # Source is tracked on the relevant branch; these are autotools/CMake/


### PR DESCRIPTION
One-line additive .gitignore rule.

`/build-*/` already catches hyphen-named out-of-source CMake trees (build-spv/, build-qt/, build-dgb-wire/). The underscore convention `build_dgb/` matches no existing rule, so an in-root cmake build can sweep binaries into a commit (observed: a 59MB artifact). Add `/build_*/` directly alongside it.

Scope: shared scaffolding only, additive, no coin tree touched. Isolated from #155 (which carries a DGB-scrypt thesis) per review guidance.