### PR TITLE
dgb: delegate V36 version-gate sites to core::version_gate SSOT (#148)

### DIFF
--- a/src/impl/dgb/share.hpp
+++ b/src/impl/dgb/share.hpp
@@ -8,6 +8,7 @@
 #include <core/pack_types.hpp>
 #include <core/netaddress.hpp>
 #include <core/uint256.hpp>
+#include <core/version_gate.hpp>   // SSOT: core::version_gate::is_v36_active
 #include <core/target_utils.hpp>
 
 #include <map>
@@ -159,7 +160,7 @@ struct Formatter
         );
         
         // Address handling — version-dependent
-        if constexpr (version >= 36)
+        if constexpr (core::version_gate::is_v36_active(version))
         {
             READWRITE(obj->m_pubkey_hash);   // IntType(160)
             READWRITE(obj->m_pubkey_type);   // IntType(8)
@@ -174,7 +175,7 @@ struct Formatter
         }
 
         // Subsidy — V36 uses VarInt, others use fixed uint64
-        if constexpr (version >= 36)
+        if constexpr (core::version_gate::is_v36_active(version))
         {
             READWRITE(VarInt(obj->m_subsidy));
         }
@@ -195,7 +196,7 @@ struct Formatter
         }
 
         // V36: merged_addresses (after segwit_data, before far_share_hash)
-        if constexpr (version >= 36)
+        if constexpr (core::version_gate::is_v36_active(version))
         {
             READWRITE(obj->m_merged_addresses);
         }
@@ -214,7 +215,7 @@ struct Formatter
         );
 
         // Abswork — V36 uses VarInt-encoded uint64, others use fixed uint128
-        if constexpr (version >= 36)
+        if constexpr (core::version_gate::is_v36_active(version))
         {
             READWRITE(Using<AbsworkV36Format>(obj->m_abswork));
         }
@@ -224,7 +225,7 @@ struct Formatter
         }
 
         // V36: merged_coinbase_info + merged_payout_hash (after abswork)
-        if constexpr (version >= 36)
+        if constexpr (core::version_gate::is_v36_active(version))
         {
             READWRITE(obj->m_merged_coinbase_info);
             READWRITE(obj->m_merged_payout_hash);
@@ -244,7 +245,7 @@ struct Formatter
         );
 
         // V36: message_data (at the end)
-        if constexpr (version >= 36)
+        if constexpr (core::version_gate::is_v36_active(version))
         {
             READWRITE(obj->m_message_data);
         }

--- a/src/impl/dgb/share_check.hpp
+++ b/src/impl/dgb/share_check.hpp
@@ -15,6 +15,7 @@
 #include <core/pow.hpp>
 #include <core/target_utils.hpp>
 #include <core/uint256.hpp>
+#include <core/version_gate.hpp>   // SSOT: core::version_gate::is_v36_active
 #include <btclibs/crypto/common.h>
 #include <btclibs/crypto/sha256.h>
 #include <btclibs/crypto/scrypt.h>
@@ -374,7 +375,7 @@ inline std::pair<uint256, uint64_t> compute_ref_hash_for_work(const RefHashParam
 
     ref_stream << p.share_nonce;
 
-    if (p.share_version >= 36) {
+    if (core::version_gate::is_v36_active(p.share_version)) {
         // V36: pubkey_hash (uint160) + pubkey_type (uint8)
         ref_stream << p.pubkey_hash;
         ref_stream << p.pubkey_type;
@@ -399,7 +400,7 @@ inline std::pair<uint256, uint64_t> compute_ref_hash_for_work(const RefHashParam
         ref_stream << p.segwit_data;
 
     // V36: merged_addresses (after segwit_data, before far_share_hash)
-    if (p.share_version >= 36)
+    if (core::version_gate::is_v36_active(p.share_version))
         ref_stream << p.merged_addresses;
 
     ref_stream << p.far_share_hash;
@@ -408,7 +409,7 @@ inline std::pair<uint256, uint64_t> compute_ref_hash_for_work(const RefHashParam
     ref_stream << p.timestamp;
     ref_stream << p.absheight;
 
-    if (p.share_version >= 36) {
+    if (core::version_gate::is_v36_active(p.share_version)) {
         ::Serialize(ref_stream, Using<AbsworkV36Format>(p.abswork));
         ref_stream << p.merged_coinbase_info;
         ref_stream << p.merged_payout_hash;
@@ -426,10 +427,10 @@ inline std::pair<uint256, uint64_t> compute_ref_hash_for_work(const RefHashParam
     {
         static int rfn_log = 0;
         static int rfn_v36_log = 0;
-        bool should_log = (rfn_log < 3) || (p.share_version >= 36 && rfn_v36_log < 5);
+        bool should_log = (rfn_log < 3) || (core::version_gate::is_v36_active(p.share_version) && rfn_v36_log < 5);
         if (should_log) {
             rfn_log++;
-            if (p.share_version >= 36) rfn_v36_log++;
+            if (core::version_gate::is_v36_active(p.share_version)) rfn_v36_log++;
             static const char* HX = "0123456789abcdef";
             std::string hex;
             auto* rd = reinterpret_cast<const unsigned char*>(ref_stream.data());
@@ -543,7 +544,7 @@ uint256 share_init_verify(const ShareT& share, const core::CoinParams& params, b
             ref_stream << share.m_pubkey_hash;
 
         // subsidy: VarInt for V36+, raw uint64_t LE for older
-        if constexpr (ver >= 36)
+        if constexpr (core::version_gate::is_v36_active(ver))
             ::Serialize(ref_stream, VarInt(share.m_subsidy));
         else
             ref_stream << share.m_subsidy;
@@ -578,7 +579,7 @@ uint256 share_init_verify(const ShareT& share, const core::CoinParams& params, b
         }
 
         // merged_addresses (V36+)
-        if constexpr (ver >= 36)
+        if constexpr (core::version_gate::is_v36_active(ver))
         {
             if constexpr (requires { share.m_merged_addresses; })
                 ref_stream << share.m_merged_addresses;
@@ -599,7 +600,7 @@ uint256 share_init_verify(const ShareT& share, const core::CoinParams& params, b
         ref_stream << share.m_absheight;
 
         // abswork: AbsworkV36Format for V36+, raw uint128 LE for older
-        if constexpr (ver >= 36)
+        if constexpr (core::version_gate::is_v36_active(ver))
         {
             if constexpr (requires { share.m_abswork; })
                 ::Serialize(ref_stream, Using<AbsworkV36Format>(share.m_abswork));
@@ -610,7 +611,7 @@ uint256 share_init_verify(const ShareT& share, const core::CoinParams& params, b
         }
 
         // V36+ merged mining commitment fields
-        if constexpr (ver >= 36)
+        if constexpr (core::version_gate::is_v36_active(ver))
         {
             if constexpr (requires { share.m_merged_coinbase_info; })
                 ref_stream << share.m_merged_coinbase_info;
@@ -621,7 +622,7 @@ uint256 share_init_verify(const ShareT& share, const core::CoinParams& params, b
 
     // V36 ref_type includes message_data as PossiblyNoneType(b'', VarStrType())
     // When m_message_data is empty, BaseScript serialises as varint(0) = 0x00.
-    if constexpr (ver >= 36)
+    if constexpr (core::version_gate::is_v36_active(ver))
     {
         if constexpr (requires { share.m_message_data; })
             ref_stream << share.m_message_data;
@@ -937,7 +938,7 @@ uint256 generate_share_transaction(const ShareT& share, TrackerT& tracker, const
     // p2pool selects PPLNS formula by runtime AutoRatchet state, not compile-time
     // share version. When v36_active is true (AutoRatchet ACTIVATED/CONFIRMED),
     // use v36 PPLNS even for v35 shares. Ref: p2pool data.py:879, work.py:759.
-    const bool use_v36_pplns = v36_active || (ver >= 36);
+    const bool use_v36_pplns = v36_active || (core::version_gate::is_v36_active(ver));
     const uint64_t subsidy = share.m_subsidy;
     const uint16_t donation = share.m_donation;
 
@@ -1270,7 +1271,7 @@ uint256 generate_share_transaction(const ShareT& share, TrackerT& tracker, const
             else
                 ref_stream << share.m_pubkey_hash;
 
-            if constexpr (ver >= 36)
+            if constexpr (core::version_gate::is_v36_active(ver))
                 ::Serialize(ref_stream, VarInt(share.m_subsidy));
             else
                 ref_stream << share.m_subsidy;
@@ -1299,7 +1300,7 @@ uint256 generate_share_transaction(const ShareT& share, TrackerT& tracker, const
                 }
             }
 
-            if constexpr (ver >= 36)
+            if constexpr (core::version_gate::is_v36_active(ver))
             {
                 if constexpr (requires { share.m_merged_addresses; })
                     ref_stream << share.m_merged_addresses;
@@ -1317,7 +1318,7 @@ uint256 generate_share_transaction(const ShareT& share, TrackerT& tracker, const
             ref_stream << share.m_timestamp;
             ref_stream << share.m_absheight;
 
-            if constexpr (ver >= 36)
+            if constexpr (core::version_gate::is_v36_active(ver))
             {
                 if constexpr (requires { share.m_abswork; })
                     ::Serialize(ref_stream, Using<AbsworkV36Format>(share.m_abswork));
@@ -1327,7 +1328,7 @@ uint256 generate_share_transaction(const ShareT& share, TrackerT& tracker, const
                 ref_stream << share.m_abswork;
             }
 
-            if constexpr (ver >= 36)
+            if constexpr (core::version_gate::is_v36_active(ver))
             {
                 if constexpr (requires { share.m_merged_coinbase_info; })
                     ref_stream << share.m_merged_coinbase_info;
@@ -1337,7 +1338,7 @@ uint256 generate_share_transaction(const ShareT& share, TrackerT& tracker, const
         }
 
         // V36 ref_type includes message_data (must match verify_share)
-        if constexpr (ver >= 36)
+        if constexpr (core::version_gate::is_v36_active(ver))
         {
             if constexpr (requires { share.m_message_data; })
                 ref_stream << share.m_message_data;
@@ -1779,7 +1780,7 @@ bool share_check(const ShareT& share,
     // This ensures V35 shares always verify with V35 PPLNS formula, even after
     // the AutoRatchet transitions to ACTIVATED.
     constexpr int64_t share_ver = ShareT::version;
-    bool v36_active = (share_ver >= 36);
+    bool v36_active = (core::version_gate::is_v36_active(share_ver));
     if (!share.m_prev_hash.IsNull() && tracker.chain.contains(share.m_prev_hash))
     {
         uint256 expected_gentx = generate_share_transaction(share, tracker, params, false, v36_active);
@@ -1903,7 +1904,7 @@ bool share_check(const ShareT& share,
     // independently compute from the share chain. Without this, a malicious
     // node could steal all merged chain (DOGE) rewards while appearing honest
     // on the parent chain (LTC payouts are consensus-enforced via gentx above).
-    if constexpr (ShareT::version >= 36)
+    if constexpr (core::version_gate::is_v36_active(ShareT::version))
     {
         if constexpr (requires { share.m_merged_payout_hash; })
         {
@@ -1931,7 +1932,7 @@ bool share_check(const ShareT& share,
 
     // 5. V36+ merged coinbase commitment verification (7-step chain)
     // Verifies the actual merged coinbase matches canonical PPLNS construction.
-    if constexpr (ShareT::version >= 36)
+    if constexpr (core::version_gate::is_v36_active(ShareT::version))
     {
         auto mcv_err = verify_merged_coinbase_commitment(share, tracker, params);
         if (!mcv_err.empty())
@@ -2001,7 +2002,7 @@ uint256 verify_share(const ShareT& share, TrackerT& tracker, const core::CoinPar
         else
             ref_stream << share.m_pubkey_hash;
 
-        if constexpr (ver >= 36)
+        if constexpr (core::version_gate::is_v36_active(ver))
             ::Serialize(ref_stream, VarInt(share.m_subsidy));
         else
             ref_stream << share.m_subsidy;
@@ -2029,7 +2030,7 @@ uint256 verify_share(const ShareT& share, TrackerT& tracker, const core::CoinPar
             }
         }
 
-        if constexpr (ver >= 36)
+        if constexpr (core::version_gate::is_v36_active(ver))
         {
             if constexpr (requires { share.m_merged_addresses; })
                 ref_stream << share.m_merged_addresses;
@@ -2047,7 +2048,7 @@ uint256 verify_share(const ShareT& share, TrackerT& tracker, const core::CoinPar
         ref_stream << share.m_timestamp;
         ref_stream << share.m_absheight;
 
-        if constexpr (ver >= 36)
+        if constexpr (core::version_gate::is_v36_active(ver))
         {
             if constexpr (requires { share.m_abswork; })
                 ::Serialize(ref_stream, Using<AbsworkV36Format>(share.m_abswork));
@@ -2057,7 +2058,7 @@ uint256 verify_share(const ShareT& share, TrackerT& tracker, const core::CoinPar
             ref_stream << share.m_abswork;
         }
 
-        if constexpr (ver >= 36)
+        if constexpr (core::version_gate::is_v36_active(ver))
         {
             if constexpr (requires { share.m_merged_coinbase_info; })
                 ref_stream << share.m_merged_coinbase_info;
@@ -2067,7 +2068,7 @@ uint256 verify_share(const ShareT& share, TrackerT& tracker, const core::CoinPar
     }
 
     // V36 ref_type includes message_data
-    if constexpr (ver >= 36)
+    if constexpr (core::version_gate::is_v36_active(ver))
     {
         if constexpr (requires { share.m_message_data; })
             ref_stream << share.m_message_data;
@@ -2092,7 +2093,7 @@ uint256 verify_share(const ShareT& share, TrackerT& tracker, const core::CoinPar
     uint256 gentx_hash = check_hash_link(share.m_hash_link, hash_link_data, gentx_before_refhash);
 
     // V36+: Validate message_data (reject shares with invalid encrypted messages)
-    if constexpr (ver >= 36)
+    if constexpr (core::version_gate::is_v36_active(ver))
     {
         if constexpr (requires { share.m_message_data; })
         {
@@ -3280,7 +3281,7 @@ uint256 create_local_share(
     {
         static int xcheck_count = 0;
         if (true) { // Always cross-check (was: xcheck_count < 5)
-            uint256 verify_hash = generate_share_transaction<MergedMiningShare>(*heap_share, tracker, params, true, (MergedMiningShare::version >= 36));
+            uint256 verify_hash = generate_share_transaction<MergedMiningShare>(*heap_share, tracker, params, true, (core::version_gate::is_v36_active(MergedMiningShare::version)));
             bool xcheck_ok = (verify_hash == gentx_hash_for_header);
             if (xcheck_ok) {
                 LOG_INFO << "[Pool] Cross-check PASSED";

--- a/src/impl/dgb/share_tracker.hpp
+++ b/src/impl/dgb/share_tracker.hpp
@@ -27,6 +27,7 @@ inline uint64_t mul128_shift(uint64_t a, uint64_t b, unsigned shift) {
 #include <core/target_utils.hpp>
 #include <core/coin_params.hpp>
 #include <core/uint256.hpp>
+#include <core/version_gate.hpp>   // SSOT: core::version_gate::is_v36_active
 #include <core/netaddress.hpp>
 #include <sharechain/weights_skiplist.hpp>
 #include <btclibs/base58.h>
@@ -958,7 +959,7 @@ public:
                         prev_hash = obj->m_prev_hash;
                         share_ver = obj->version;
                     });
-                    if (share_ver >= 36) {
+                    if (core::version_gate::is_v36_active(share_ver)) {
 
                         if (!prev_hash.IsNull() && chain.contains(prev_hash)) {
                             if (!pplns_active) {


### PR DESCRIPTION
## What

Points DGB per-coin V36 version-gate call sites at the merged `core::version_gate` SSOT (`is_v36_active`, #148 @ebfb9609), mirroring the BTC reference adoption site-for-site.

## Sites delegated (33, = BTC count)
- `share.hpp` x6 — `if constexpr (version >= 36)`
- `share_tracker.hpp` x1 — runtime `share_ver` gate
- `share_check.hpp` x26 — ref-serialization gates, PPLNS-formula select, log guards, constexpr branches

## Pure-mechanical / byte-identical
The V36 boundary stays the uniform cross-coin `36`; this only re-points the literals at the one SSOT — **no semantic change**.

- Only positive `>= 36` gate sites delegated.
- Inverse forms left verbatim, matching BTC: `version < 36`, `share_version <= 35`, `m_desired_version < 36` (distinct field), and `BaseShare<36>` template args.
- Donation-script gate (`config_pool`) left untouched — that is the separate `core::donation` delegation (FLAG6), not this task.

No coin-specific divergence found vs `core::version_gate` (per the #161 inst#4 caution).

## Scope
DGB-only. Orthogonal to in-flight #158 (M3 scrypt-digest, touches coin/header_chain + tests).

## Verification
- configure `-DCOIN_DGB=ON` + build `c2pool-dgb` + `dgb_share_test`: EXIT=0
- `dgb_share_test`: 5/5 PASS
- `c2pool-dgb --selftest`: OK

No self-merge — HOLD for integrator verify-vs-core + operator tap.