### PR TITLE
ci(dash): gate slice PRs to Linux-only via dash-linux-only label

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,6 +125,8 @@ jobs:
   # ════════════════════════════════════════════════════════════════════════════
   linux-asan:
     name: Linux x86_64 (AsAN+UBSan)
+    # dash bring-up slices may opt out of sanitizers via dash-skip-sanitizers; KEEP for consensus/payout slices (default = on)
+    if: ${{ !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'dash-skip-sanitizers')) }}
     runs-on: ubuntu-24.04
     continue-on-error: true
     steps:
@@ -369,6 +371,8 @@ jobs:
   # ════════════════════════════════════════════════════════════════════════════
   macos:
     name: macOS ${{ matrix.arch }}
+    # dash-slice campaign: skip macOS for PRs carrying the dash-linux-only label (re-enabled at block-viable gate, ~07-01)
+    if: ${{ !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'dash-linux-only')) }}
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -449,6 +453,8 @@ jobs:
   # ════════════════════════════════════════════════════════════════════════════
   windows:
     name: Windows x86_64
+    # dash-slice campaign: skip Windows for PRs carrying the dash-linux-only label (re-enabled at block-viable gate, ~07-01)
+    if: ${{ !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'dash-linux-only')) }}
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Operator-directed 2026-06-18 (DASH #83 v36-universal slice campaign). Iteration-speed only — DASH still ships cross-platform.

## What
- New PR label `dash-linux-only`: on a DASH slice PR, SKIP macOS arm64/x86_64 + Windows x86_64. Keeps Linux x86_64 (build+tests), Web-static, Qt leak gate, and the dash smoke (coin-matrix) running.
- New PR label `dash-skip-sanitizers`: optional, for pure-compile bring-up slices only — skips AsAN/UBSan. Default (no label) KEEPS sanitizers, so consensus/payout slices stay covered.

## Mechanism
Job-level `if:` keyed on `github.event_name == pull_request` AND label presence. Per-PR opt-in, explicit and visible — not a silent permanent reduction. Master pushes and every other coin are unaffected (push events always run the full matrix).

## How dash-steward applies it
- Pure-compile bring-up slice → add `dash-linux-only` (+ optionally `dash-skip-sanitizers`).
- Consensus / payout slice → add `dash-linux-only` only (sanitizers stay on).
- Remove the label to restore full-matrix on any slice.

## HARD re-enable gate
Before DASH is declared block-viable / release-ready (~07-01), the FULL matrix (macOS arm64/x86 + Windows + AsAN/UBSan) MUST pass on the final state. Tracking item to add to the #83 umbrella checklist.

Precedent: #46 (dropped dash from AsAN/UBSan). Merge-gated — awaiting operator push-approval, no self-merge.