### PR TITLE
dash(slice1): embedded compiling base — build-glue + web_server SSOT reconcile

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -4709,6 +4709,17 @@ nlohmann::json MiningInterface::rest_web_currency_info()
     default:                   result["share_version"] = 36; break;
     }
 
+    // p2pool share version for the current coin — consumed by the
+    // bundled @c2pool/sharechain-explorer to classify share cells.
+    // Dash = v16, LTC/DOGE/BTC = v36.
+    switch (m_blockchain) {
+    case Blockchain::DASH:     result["share_version"] = 16; break;
+    case Blockchain::LITECOIN:
+    case Blockchain::BITCOIN:
+    case Blockchain::DOGECOIN:
+    default:                   result["share_version"] = 36; break;
+    }
+
     return result;
 }
 


### PR DESCRIPTION
## DASH Slice-1 — embedded compiling base (build-glue + web_server reconcile)

Gating slice for the ~06-23 / ~07-01 embedded re-land campaign. Branched off current master (`81fef6a0`, a descendant of `d96eda60` → satisfies `d96eda60+`).

### web_server 3-way reconcile (the named conflict) — DONE @ `af37332e`
Key finding: **master already absorbed the bulk of the embedded web_server work** through the S5/S6 slice campaign. Concrete surface vs the merge-base premise:
- `web_server.hpp`: **byte-identical** master↔embedded — zero reconcile.
- `web_server.cpp`: real divergence is only **51/-49 lines**, and it is **not** a "+200/-29 preserve-both" merge — it is an **API-direction divergence** on the coin-node seam:
  - master (SSOT): `set_coin_node(core::coin::ICoinNode*)`
  - embedded (older): `set_coin_rpc(NodeRPC*,Node*)` + `set_embedded_node(CoinNodeInterface*)`
- Resolved to **master SSOT (ICoinNode)** per the version-gate-SSOT directive; re-applied the one genuinely-additive embedded-only hunk (`share_version` per blockchain). Compile-safe (references only `m_blockchain`).

### build-glue — sequencing note (ETA work)
The `c2pool-dash` executable target in `src/impl/dash/CMakeLists.txt` references ~37 S7/S8 source files **absent on master** (master has 48 dash files, embedded 85). A fully-green configure needs build-glue + embedded source **sequenced together** (next slices), or the expanded target gated. The dependency-level glue (relic asm / dashbls CMakeLists, `bitcoin_family`, test harness) lands independently.

CI: `dash-linux-only` (#164) — Linux x86_64 + dash smoke.
