### PR TITLE
ci(qt): cap Qt WebEngine leak gate with timeout-minutes: 20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -302,6 +302,11 @@ jobs:
   qt-webengine:
     name: Qt WebEngine leak gate
     runs-on: ubuntu-24.04
+    # Hard ceiling: orphaned QtWebEngine/Chromium helper children survive
+    # the inner `timeout 180`, holding the xvfb pipe open and hanging the
+    # job to the 360-min runner default. Cap it so a hung leak gate is
+    # force-killed (with its whole process tree) in minutes, not hours.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Problem
The `qt-webengine` leak gate wraps its run in `timeout 180`, but that only SIGTERMs the immediate child. QtWebEngine spawns Chromium zygote/helper processes that survive, hold the `xvfb-run` pipe open, and hang the job to the **360-min runner default**. Observed cost: ~35 min × 3 today; #165 had to be closed/reopened to clear a stuck run.

## Fix
Add a job-level `timeout-minutes: 20` so the runner force-kills the whole process tree when the gate hangs. A healthy run (apt + Qt harness build + 180s harness) finishes well under 20 min; a hang now costs ~20 min instead of hours.

Scope: one line (+ comment) in build.yml. `continue-on-error` is unchanged — the gate stays advisory during Qt bring-up.

Merge-gated: holding for operator push-approval.