### PR TITLE
nmc(P1b): wire AuxPow::check_proof chain-merkle leg (step 1) + KATs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,7 @@ jobs:
                     test_mweb_builder \
                     test_address_resolution test_compute_share_target \
                     test_utxo test_dgb_subsidy dgb_share_test dgb_block_assembly_test dgb_gentx_coinbase_test \
+                    nmc_auxpow_merkle_test \
                     rpc_request_test softfork_check_test genesis_check_test algo_select_test digishield_walk_test header_chain_test \
                     v37_test \
             -j$(nproc)
@@ -198,6 +199,7 @@ jobs:
                     test_mweb_builder \
                     test_address_resolution test_compute_share_target \
                     test_utxo test_dgb_subsidy dgb_share_test dgb_block_assembly_test dgb_gentx_coinbase_test \
+                    nmc_auxpow_merkle_test \
                     rpc_request_test softfork_check_test genesis_check_test algo_select_test digishield_walk_test header_chain_test \
                     test_coin_broadcaster test_multiaddress_pplns test_pplns_stress \
                     v37_test \

--- a/src/impl/nmc/CMakeLists.txt
+++ b/src/impl/nmc/CMakeLists.txt
@@ -1,3 +1,8 @@
 # NMC (embedded merge-mined Namecoin) — P0 structural leaf.
 # Only the coin tree exists at P0. node/stratum/share layers come later.
 add_subdirectory(coin)
+
+# P1: NMC module tests (AuxPow merkle-walk KAT). Gated on BUILD_TESTING.
+if (BUILD_TESTING)
+    add_subdirectory(test)
+endif()

--- a/src/impl/nmc/coin/header_chain.hpp
+++ b/src/impl/nmc/coin/header_chain.hpp
@@ -193,6 +193,7 @@ struct AuxPow {
     /// Result of a (future) AuxPow verification.
     enum class CheckResult {
         NOT_IMPLEMENTED_P0,   //!< P0 leaf — verification path not built yet
+        INCOMPLETE,           //!< P1b — merkle leg(s) wired; steps 2/3/4 pending
         VALID,
         INVALID,
     };
@@ -200,7 +201,8 @@ struct AuxPow {
     /// Verify that this AuxPow actually proves work for `aux_block_hash`
     /// against the given expected aux chain id.
     ///
-    /// P0-DEFER: NOT IMPLEMENTED in P0. The real implementation must, against
+    /// P1b: step 1 (chain-merkle leg) is wired below via aux_merkle_root().
+    /// The FULL implementation must, against
     /// a properly-pinned Namecoin chainparams:
     ///   1. recompute the merged-mining merkle root from `chain_merkle_branch`
     ///      + `chain_merkle_index` starting at `aux_block_hash`, and confirm
@@ -216,10 +218,31 @@ struct AuxPow {
     /// Until all four steps exist, NMC MUST NOT block-validate off this leaf.
     CheckResult check_proof(const uint256& aux_block_hash,
                             int32_t expected_chain_id) const {
-        // P0-DEFER: structural stub. Deliberately performs NO verification.
-        (void)aux_block_hash;
-        (void)expected_chain_id;
-        return CheckResult::NOT_IMPLEMENTED_P0;
+        // P1b — chain-merkle leg (step 1). Walk the aux (NMC) block hash up
+        // through chain_merkle_branch/chain_merkle_index to reconstruct the
+        // merged-mining merkle root via aux_merkle_root(). The remaining steps
+        // are NOT built yet: step 2 (confirm that root is committed in the
+        // parent coinbase MM marker, with the chain_id/slot binding), step 3
+        // (parent-coinbase tx-merkle leg — needs the witness-stripped BTC
+        // coinbase txid), step 4 (parent PoW vs target, consumed from the btc
+        // tree READ-ONLY). A structurally-consistent chain-merkle walk therefore
+        // returns INCOMPLETE, never VALID — NMC still MUST NOT block-validate
+        // off this leaf.
+        (void)expected_chain_id;  // step-2 (chain_id/slot) binding lands later
+
+        if (chain_merkle_index < 0)
+            return CheckResult::INVALID;  // negative slot index is malformed
+
+        try {
+            // Reconstructed MM root; its commitment check is step 2 (pending).
+            (void)aux_merkle_root(
+                aux_block_hash, chain_merkle_branch,
+                static_cast<uint32_t>(chain_merkle_index));
+        } catch (const std::invalid_argument&) {
+            return CheckResult::INVALID;  // branch index out of range for depth
+        }
+
+        return CheckResult::INCOMPLETE;
     }
 };
 

--- a/src/impl/nmc/coin/header_chain.hpp
+++ b/src/impl/nmc/coin/header_chain.hpp
@@ -48,6 +48,8 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <span>
+#include <stdexcept>
 #include <vector>
 
 namespace nmc {
@@ -75,6 +77,44 @@ inline uint256 block_hash(const BlockHeaderType& header) {
 inline uint256 pow_hash(const BlockHeaderType& header) {
     auto packed = pack(header);
     return Hash(packed.get_span());
+}
+
+// ─── Merkle-branch walk (P1: AuxPow merkle-proof primitive) ────────────────
+
+/// Walk a merkle BRANCH up to its root, starting from `leaf`.
+///
+/// The core primitive of AuxPow verification: BOTH legs of the proof are
+/// merkle-branch walks — the chain-merkle leg (aux block hash → merged-mining
+/// root, AuxPow::check_proof step 1) and the parent-coinbase leg (coinbase
+/// txid → parent block tx-merkle-root, step 3). At level i, bit i of `index`
+/// selects the side: if set, branch[i] is the LEFT sibling (running hash on the
+/// right); else branch[i] is on the right. Each pair is SHA256d'd (the
+/// Bitcoin/Namecoin merkle convention).
+///
+/// Byte-faithful port of legacy libcoind/data.cpp check_merkle_link() — the
+/// same SSOT btc/ltc use — kept NMC-LOCAL per the coin fence (no btc/ltc
+/// include; only core/* primitives: Hash, PackStream).
+inline uint256 aux_merkle_root(const uint256& leaf,
+                               const std::vector<uint256>& branch,
+                               uint32_t index) {
+    if (!branch.empty() && index >= (1u << branch.size()))
+        throw std::invalid_argument("aux_merkle_root: index too large for branch depth");
+
+    uint256 cur = leaf;
+    for (size_t i = 0; i < branch.size(); ++i) {
+        PackStream ps;
+        if ((index >> i) & 1u) {
+            ps << branch[i];   // sibling on the left
+            ps << cur;
+        } else {
+            ps << cur;
+            ps << branch[i];   // sibling on the right
+        }
+        auto sp = std::span<const unsigned char>(
+            reinterpret_cast<const unsigned char*>(ps.data()), ps.size());
+        cur = Hash(sp);        // SHA256d of the 64-byte concatenation
+    }
+    return cur;
 }
 
 // ─── AuxPow (merge-mining proof) ─────────────────────────────────────────────

--- a/src/impl/nmc/test/CMakeLists.txt
+++ b/src/impl/nmc/test/CMakeLists.txt
@@ -19,6 +19,10 @@ if (BUILD_TESTING AND GTest_FOUND)
     # share/coin libs are needed -- this KAT only folds with core::Hash.
     target_link_libraries(nmc_auxpow_merkle_test PRIVATE
         c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage)
+    # P1b: the check_proof KATs construct AuxPow, whose parent_coinbase member
+    # is an nmc::coin::MutableTransaction with an out-of-line ctor -> link the
+    # nmc_coin lib (transaction.cpp). Still no node/pool/share libs (none exist).
+    target_link_libraries(nmc_auxpow_merkle_test PRIVATE nmc_coin)
 
     include(GoogleTest)
     include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})

--- a/src/impl/nmc/test/CMakeLists.txt
+++ b/src/impl/nmc/test/CMakeLists.txt
@@ -1,0 +1,26 @@
+# NMC module tests (P1). Mirrors the dgb header-only guard registration in
+# src/impl/dgb/test/CMakeLists.txt: gated on BUILD_TESTING + GTest, registered
+# via gtest_add_tests for the CI --target allowlist.
+#
+# nmc_auxpow_merkle_test pins the aux_merkle_root walk in coin/header_chain.hpp
+# (the AuxPow merge-mining merkle-branch walk). It links core because the walk
+# folds nodes with core::Hash / PackStream; it does NOT link any node/pool/
+# share OBJECT lib (none exist for NMC yet -- P0/P1 is coin-tree only).
+#
+# Each target MUST appear in BOTH this registration AND the build.yml
+# --target allowlist, or it becomes a NOT_BUILT sentinel that reds master.
+if (BUILD_TESTING AND GTest_FOUND)
+    add_executable(nmc_auxpow_merkle_test auxpow_merkle_test.cpp)
+    target_link_libraries(nmc_auxpow_merkle_test PRIVATE
+        GTest::gtest_main GTest::gtest
+        core nlohmann_json::nlohmann_json)
+    # core pulls stratum_server.cpp (hashrate refs); link the same OBJECT-lib
+    # SCC the sibling dgb merkle test links so core resolves. No node/pool/
+    # share/coin libs are needed -- this KAT only folds with core::Hash.
+    target_link_libraries(nmc_auxpow_merkle_test PRIVATE
+        c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage)
+
+    include(GoogleTest)
+    include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
+    gtest_add_tests(nmc_auxpow_merkle_test "" AUTO)
+endif()

--- a/src/impl/nmc/test/auxpow_merkle_test.cpp
+++ b/src/impl/nmc/test/auxpow_merkle_test.cpp
@@ -1,0 +1,103 @@
+// ---------------------------------------------------------------------------
+// nmc::coin::aux_merkle_root KAT (P1 — AuxPow merkle-proof walk).
+//
+// Pins the merge-mining merkle-branch walk that AuxPow::check_proof() (still a
+// P-DEFER stub) will consume for step-1 (chain-merkle-root) and step-3 (parent
+// tx-merkle-root). The walk is a byte-faithful port of legacy
+// libcoind/data.cpp check_merkle_link() — the same SSOT btc uses — so these
+// KATs lock the consensus-relevant ordering:
+//   * empty branch        => root == leaf (identity);
+//   * index bit i selects whether branch[i] is the LEFT or RIGHT sibling at
+//     depth i, folded with double-SHA256 of the 64-byte concatenation;
+//   * an index that does not fit in branch.size() bits is rejected.
+//
+// Expected roots are derived INDEPENDENTLY here via core::Hash on the explicit
+// concatenation (not by calling aux_merkle_root), so a side-swap or fold bug in
+// the walk is caught rather than mirrored. Self-derived => no fixture file.
+//
+// Per-coin isolation: src/impl/nmc/ only; btc tree consumed READ-ONLY (this is
+// an independent NMC-local re-derivation, fence #4). MUST appear in BOTH
+// test/CMakeLists.txt AND the build.yml --target allowlist or it becomes a
+// NOT_BUILT sentinel that reds master.
+// ---------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+#include <vector>
+
+#include <core/hash.hpp>
+#include <core/pack.hpp>
+#include <core/uint256.hpp>
+
+#include "../coin/header_chain.hpp"
+
+namespace {
+
+using nmc::coin::aux_merkle_root;
+
+// Build a uint256 whose first byte is `b` (rest zero) — distinct, legible leaves.
+static uint256 leaf_of(unsigned char b)
+{
+    uint256 u;
+    u.SetNull();
+    *(u.begin()) = b;
+    return u;
+}
+
+// Independent reference combine: double-SHA256 of l||r, mirroring the legacy
+// merkle node hash but computed here WITHOUT touching aux_merkle_root.
+static uint256 combine(const uint256& l, const uint256& r)
+{
+    PackStream ps;
+    ps << l;
+    ps << r;
+    auto sp = std::span<const unsigned char>(
+        reinterpret_cast<const unsigned char*>(ps.data()), ps.size());
+    return Hash(sp);
+}
+
+TEST(NmcAuxMerkle, EmptyBranchIsIdentity)
+{
+    uint256 leaf = leaf_of(0x11);
+    EXPECT_EQ(aux_merkle_root(leaf, {}, 0), leaf);
+    // index is ignored when there is no branch to walk.
+    EXPECT_EQ(aux_merkle_root(leaf, {}, 12345u), leaf);
+}
+
+TEST(NmcAuxMerkle, SingleStepIndexZeroLeafOnLeft)
+{
+    uint256 leaf = leaf_of(0x11);
+    uint256 sib  = leaf_of(0x22);
+    // index bit 0 == 0  => leaf is LEFT, sibling RIGHT.
+    EXPECT_EQ(aux_merkle_root(leaf, {sib}, 0), combine(leaf, sib));
+}
+
+TEST(NmcAuxMerkle, SingleStepIndexOneLeafOnRight)
+{
+    uint256 leaf = leaf_of(0x11);
+    uint256 sib  = leaf_of(0x22);
+    // index bit 0 == 1  => sibling LEFT, leaf RIGHT.
+    EXPECT_EQ(aux_merkle_root(leaf, {sib}, 1), combine(sib, leaf));
+}
+
+TEST(NmcAuxMerkle, TwoStepFoldRespectsPerLevelIndexBits)
+{
+    uint256 leaf = leaf_of(0x11);
+    uint256 b0   = leaf_of(0x22);
+    uint256 b1   = leaf_of(0x33);
+    // index = 0b10: level0 bit=0 (leaf left), level1 bit=1 (accum right).
+    uint256 lvl0 = combine(leaf, b0);
+    uint256 want = combine(b1, lvl0);
+    EXPECT_EQ(aux_merkle_root(leaf, {b0, b1}, 0b10u), want);
+}
+
+TEST(NmcAuxMerkle, IndexTooLargeForBranchThrows)
+{
+    uint256 leaf = leaf_of(0x11);
+    uint256 sib  = leaf_of(0x22);
+    // one-element branch admits indices 0..1; 2 overflows the implied tree.
+    EXPECT_THROW(aux_merkle_root(leaf, {sib}, 2u), std::invalid_argument);
+}
+
+} // namespace

--- a/src/impl/nmc/test/auxpow_merkle_test.cpp
+++ b/src/impl/nmc/test/auxpow_merkle_test.cpp
@@ -35,6 +35,7 @@
 namespace {
 
 using nmc::coin::aux_merkle_root;
+using nmc::coin::AuxPow;
 
 // Build a uint256 whose first byte is `b` (rest zero) — distinct, legible leaves.
 static uint256 leaf_of(unsigned char b)
@@ -98,6 +99,55 @@ TEST(NmcAuxMerkle, IndexTooLargeForBranchThrows)
     uint256 sib  = leaf_of(0x22);
     // one-element branch admits indices 0..1; 2 overflows the implied tree.
     EXPECT_THROW(aux_merkle_root(leaf, {sib}, 2u), std::invalid_argument);
+}
+
+
+// ---------------------------------------------------------------------------
+// P1b: AuxPow::check_proof chain-merkle leg (step 1) wiring.
+//
+// check_proof() now reconstructs the merged-mining merkle root from the aux
+// block hash through chain_merkle_branch/index via aux_merkle_root(). Steps 2
+// (MM-marker commitment), 3 (parent-coinbase tx-merkle leg) and 4 (parent PoW)
+// are NOT built, so a structurally-consistent walk returns INCOMPLETE — never
+// VALID. A malformed slot index (negative, or wider than the branch depth)
+// returns INVALID. These KATs pin exactly that boundary so the leg can never
+// silently regress into asserting VALID before the rest of the proof exists.
+// ---------------------------------------------------------------------------
+
+TEST(NmcAuxCheckProof, ChainLegStructurallyValidIsIncomplete)
+{
+    AuxPow ap;
+    ap.chain_merkle_branch = {leaf_of(0xbe)};
+    ap.chain_merkle_index = 0;
+    EXPECT_EQ(ap.check_proof(leaf_of(0x01), /*expected_chain_id=*/1),
+              AuxPow::CheckResult::INCOMPLETE);
+}
+
+TEST(NmcAuxCheckProof, EmptyChainBranchIsIncompleteNeverValid)
+{
+    AuxPow ap;  // empty branch, index 0 => identity walk, still not provable
+    EXPECT_EQ(ap.check_proof(leaf_of(0x07), 1),
+              AuxPow::CheckResult::INCOMPLETE);
+    EXPECT_NE(ap.check_proof(leaf_of(0x07), 1),
+              AuxPow::CheckResult::VALID);
+}
+
+TEST(NmcAuxCheckProof, NegativeChainIndexIsInvalid)
+{
+    AuxPow ap;
+    ap.chain_merkle_branch = {leaf_of(0x0a)};
+    ap.chain_merkle_index = -1;
+    EXPECT_EQ(ap.check_proof(leaf_of(0x02), 1),
+              AuxPow::CheckResult::INVALID);
+}
+
+TEST(NmcAuxCheckProof, ChainIndexTooWideForDepthIsInvalid)
+{
+    AuxPow ap;
+    ap.chain_merkle_branch = {leaf_of(0x0a)};  // depth 1 => max index 1
+    ap.chain_merkle_index = 2;
+    EXPECT_EQ(ap.check_proof(leaf_of(0x02), 1),
+              AuxPow::CheckResult::INVALID);
 }
 
 } // namespace


### PR DESCRIPTION
## P1b — AuxPow::check_proof chain-merkle leg (step 1)

Builds on P1a (PR #178, aux_merkle_root primitive). Wires **step 1** of the 4-step AuxPow verification: reconstruct the merged-mining merkle root from the aux (NMC) block hash through chain_merkle_branch/chain_merkle_index via aux_merkle_root().

### Safety
New CheckResult::INCOMPLETE state. A structurally-consistent chain-merkle walk returns **INCOMPLETE, never VALID** — steps 2 (MM-marker commitment + chain_id/slot binding), 3 (parent-coinbase tx-merkle leg, needs witness-stripped BTC coinbase txid), 4 (parent PoW vs target) are NOT built. NMC still MUST NOT block-validate off this leaf. Malformed slot indices (negative / wider than branch depth) return INVALID.

### Tests
4 new KATs (NmcAuxCheckProof) pin the INCOMPLETE-vs-INVALID boundary. **9/9 PASS** (5 P1a + 4 P1b), build green. Test target name unchanged → CI --target allowlist needs no edit. nmc_coin linked (AuxPow ctor pulls MutableTransaction).

### Fence
NMC-local only; btc tree consumed READ-ONLY. Merge gated (I do not self-merge).

### Next (P1c)
step 3 parent-coinbase tx-merkle leg — requires pinning the witness-stripped BTC coinbase txid serialization params (separate slice + KAT).