### PR TITLE
nmc(P1c): AuxPow::check_proof parent-coinbase tx-merkle leg (step 3) + witness-stripped txid KAT

### DIFF
--- a/src/impl/nmc/coin/header_chain.hpp
+++ b/src/impl/nmc/coin/header_chain.hpp
@@ -117,6 +117,23 @@ inline uint256 aux_merkle_root(const uint256& leaf,
     return cur;
 }
 
+// ─── Parent-coinbase txid (P1c: AuxPow step-3 leaf identity) ───────
+
+/// Witness-stripped transaction id of the parent (BTC) coinbase.
+///
+/// AuxPow step 3 proves the parent coinbase is committed in the parent
+/// block's transaction merkle root. That tree commits *txids*, NOT wtxids —
+/// so the coinbase id MUST be hashed over the LEGACY (no-witness, no segwit
+/// marker/flag) serialization even though a real BTC coinbase carries a
+/// witness (the BIP141 segwit-commitment reserved value). Byte-for-byte
+/// identical to the btc tree's compute_txid() (mempool.hpp) but kept
+/// NMC-LOCAL per the coin fence: consumes only the nmc::coin transaction
+/// serializer (TX_NO_WITNESS) + core::Hash, no btc include.
+inline uint256 parent_coinbase_txid(const MutableTransaction& tx) {
+    auto packed = pack(TX_NO_WITNESS(tx));
+    return Hash(packed.get_span());
+}
+
 // ─── AuxPow (merge-mining proof) ─────────────────────────────────────────────
 
 /// One aux-chain slot inside a parent coinbase's merged-mining merkle tree.
@@ -218,21 +235,25 @@ struct AuxPow {
     /// Until all four steps exist, NMC MUST NOT block-validate off this leaf.
     CheckResult check_proof(const uint256& aux_block_hash,
                             int32_t expected_chain_id) const {
-        // P1b — chain-merkle leg (step 1). Walk the aux (NMC) block hash up
-        // through chain_merkle_branch/chain_merkle_index to reconstruct the
-        // merged-mining merkle root via aux_merkle_root(). The remaining steps
-        // are NOT built yet: step 2 (confirm that root is committed in the
-        // parent coinbase MM marker, with the chain_id/slot binding), step 3
-        // (parent-coinbase tx-merkle leg — needs the witness-stripped BTC
-        // coinbase txid), step 4 (parent PoW vs target, consumed from the btc
-        // tree READ-ONLY). A structurally-consistent chain-merkle walk therefore
-        // returns INCOMPLETE, never VALID — NMC still MUST NOT block-validate
-        // off this leaf.
+        // P1b+P1c — two merkle legs wired. Step 1 (chain-merkle) walks the
+        // aux (NMC) block hash through chain_merkle_branch/index to reconstruct
+        // the merged-mining root; step 3 (parent-coinbase tx-merkle) walks the
+        // witness-stripped parent coinbase txid through
+        // parent_coinbase_branch/index and, when a parent header is present,
+        // requires it to reproduce that header's tx-merkle-root. The remaining
+        // steps are NOT built yet: step 2 (confirm the reconstructed MM root is
+        // committed in the parent coinbase's MM marker, with the chain_id/slot
+        // binding) and step 4 (parent PoW vs target, consumed from the btc tree
+        // READ-ONLY). Because those gates do not exist yet, a structurally-
+        // consistent proof returns INCOMPLETE, never VALID — NMC still MUST NOT
+        // block-validate off this leaf. Any malformed leg (negative slot index,
+        // an index wider than its branch depth, or a parent-coinbase leg that
+        // does not reconstruct the parent header's tx-merkle-root) is INVALID.
         (void)expected_chain_id;  // step-2 (chain_id/slot) binding lands later
 
+        // ── step 1 (P1b): chain-merkle leg ──
         if (chain_merkle_index < 0)
             return CheckResult::INVALID;  // negative slot index is malformed
-
         try {
             // Reconstructed MM root; its commitment check is step 2 (pending).
             (void)aux_merkle_root(
@@ -241,6 +262,25 @@ struct AuxPow {
         } catch (const std::invalid_argument&) {
             return CheckResult::INVALID;  // branch index out of range for depth
         }
+
+        // ── step 3 (P1c): parent-coinbase tx-merkle leg ──
+        if (parent_coinbase_index < 0)
+            return CheckResult::INVALID;  // negative slot index is malformed
+        uint256 reconstructed_parent_merkle;
+        try {
+            // The parent tx-merkle tree commits the WITNESS-STRIPPED txid.
+            reconstructed_parent_merkle = aux_merkle_root(
+                parent_coinbase_txid(parent_coinbase), parent_coinbase_branch,
+                static_cast<uint32_t>(parent_coinbase_index));
+        } catch (const std::invalid_argument&) {
+            return CheckResult::INVALID;  // branch index out of range for depth
+        }
+        // The equality gate only fires once a parent header is present: a real
+        // proof always carries one, but a leg-only structural fixture leaves it
+        // null and has nothing to match against yet (steps 2/4 still pending).
+        if (!parent_header.IsNull() &&
+            reconstructed_parent_merkle != parent_header.m_merkle_root)
+            return CheckResult::INVALID;
 
         return CheckResult::INCOMPLETE;
     }

--- a/src/impl/nmc/test/auxpow_merkle_test.cpp
+++ b/src/impl/nmc/test/auxpow_merkle_test.cpp
@@ -150,4 +150,125 @@ TEST(NmcAuxCheckProof, ChainIndexTooWideForDepthIsInvalid)
               AuxPow::CheckResult::INVALID);
 }
 
+// ---------------------------------------------------------------------------
+// P1c: AuxPow::check_proof parent-coinbase tx-merkle leg (step 3) wiring.
+//
+// step 3 reconstructs the parent block's transaction merkle root from the
+// WITNESS-STRIPPED parent coinbase txid through parent_coinbase_branch/index
+// via aux_merkle_root(), and (once a parent header is present) requires it to
+// equal parent_header.m_merkle_root. The load-bearing test asserts the exact
+// byte serialization of the txid: it is hashed over the LEGACY (no-witness)
+// layout -- txid, NOT wtxid -- so a coinbase carrying the BIP141 segwit
+// reserved value still hashes witness-stripped. The legacy preimage is
+// re-derived here field-by-field WITHOUT calling SerializeTransaction's
+// witness/marker path, so a stray marker/flag byte is caught, not mirrored.
+// Per-coin isolation: src/impl/nmc/ only; btc tree consumed READ-ONLY.
+// ---------------------------------------------------------------------------
+
+using nmc::coin::MutableTransaction;
+using nmc::coin::TxIn;
+using nmc::coin::TxOut;
+using nmc::coin::parent_coinbase_txid;
+
+// A minimal parent (BTC) coinbase carrying the BIP141 witness reserved value
+// (single 32-byte zero stack item) -- exactly what a real segwit coinbase
+// carries, so the txid path is forced to strip a present witness.
+static MutableTransaction make_parent_coinbase()
+{
+    MutableTransaction tx;
+    tx.version = 1;
+    tx.locktime = 0;
+    TxIn in;
+    in.prevout.hash.SetNull();
+    in.prevout.index = 0xffffffffu;
+    static const unsigned char sig[] = {0x03, 0x4e, 0x4d, 0x43};  // arbitrary scriptSig
+    in.scriptSig = OPScript(sig, sig + sizeof(sig));
+    in.sequence = 0xffffffffu;
+    tx.vin.push_back(in);
+    TxOut out;
+    out.value = 5000000000LL;
+    tx.vout.push_back(out);
+    tx.vin[0].scriptWitness.stack.assign(1, std::vector<unsigned char>(32, 0x00));
+    return tx;
+}
+
+// Independent legacy (no-witness) txid: lay out version|vin|vout|locktime via
+// PackStream directly (the TxIn serializer writes prevout+scriptSig+sequence,
+// NO witness) and double-SHA256 it -- never touching parent_coinbase_txid's
+// SerializeTransaction path.
+static uint256 legacy_txid(const MutableTransaction& tx)
+{
+    PackStream ref;
+    ref << tx.version;
+    ref << tx.vin;
+    ref << tx.vout;
+    ref << tx.locktime;
+    auto sp = std::span<const unsigned char>(
+        reinterpret_cast<const unsigned char*>(ref.data()), ref.size());
+    return Hash(sp);
+}
+
+TEST(NmcAuxParentCoinbase, TxidIsWitnessStrippedLegacyHashNotWtxid)
+{
+    auto cb = make_parent_coinbase();
+    ASSERT_TRUE(cb.HasWitness());  // a real BTC coinbase carries the reserved value
+
+    // (a) txid is hashed over the independently-laid-out legacy serialization.
+    EXPECT_EQ(parent_coinbase_txid(cb), legacy_txid(cb));
+
+    // (b) txid != wtxid: the with-witness hash differs precisely because the
+    //     witness is present and the txid path must strip it.
+    auto wpacked = pack(nmc::coin::TX_WITH_WITNESS(cb));
+    uint256 wtxid = Hash(wpacked.get_span());
+    EXPECT_NE(parent_coinbase_txid(cb), wtxid);
+}
+
+TEST(NmcAuxCheckProof, ParentLegReconstructingHeaderMerkleIsIncomplete)
+{
+    AuxPow ap;
+    ap.parent_coinbase = make_parent_coinbase();
+    uint256 cbid = parent_coinbase_txid(ap.parent_coinbase);
+    uint256 sib  = leaf_of(0x55);
+    ap.parent_coinbase_branch = {sib};
+    ap.parent_coinbase_index  = 0;            // bit0=0 => coinbase LEFT
+    // parent header commits the reconstructed tx-merkle-root; mark it non-null.
+    ap.parent_header.m_merkle_root = combine(cbid, sib);
+    ap.parent_header.m_bits = 1;              // non-null so the equality gate fires
+    // chain leg left at defaults (empty branch, index 0) => passes step 1.
+    EXPECT_EQ(ap.check_proof(leaf_of(0x01), 1),
+              AuxPow::CheckResult::INCOMPLETE);
+}
+
+TEST(NmcAuxCheckProof, ParentLegNotReconstructingHeaderMerkleIsInvalid)
+{
+    AuxPow ap;
+    ap.parent_coinbase = make_parent_coinbase();
+    ap.parent_coinbase_branch = {leaf_of(0x55)};
+    ap.parent_coinbase_index  = 0;
+    ap.parent_header.m_merkle_root = leaf_of(0x99);  // deliberately wrong root
+    ap.parent_header.m_bits = 1;                     // non-null => equality gate fires
+    EXPECT_EQ(ap.check_proof(leaf_of(0x01), 1),
+              AuxPow::CheckResult::INVALID);
+}
+
+TEST(NmcAuxCheckProof, NegativeParentCoinbaseIndexIsInvalid)
+{
+    AuxPow ap;
+    ap.parent_coinbase = make_parent_coinbase();
+    ap.parent_coinbase_branch = {leaf_of(0x55)};
+    ap.parent_coinbase_index  = -1;
+    EXPECT_EQ(ap.check_proof(leaf_of(0x01), 1),
+              AuxPow::CheckResult::INVALID);
+}
+
+TEST(NmcAuxCheckProof, ParentCoinbaseIndexTooWideForDepthIsInvalid)
+{
+    AuxPow ap;
+    ap.parent_coinbase = make_parent_coinbase();
+    ap.parent_coinbase_branch = {leaf_of(0x55)};  // depth 1 => max index 1
+    ap.parent_coinbase_index  = 2;
+    EXPECT_EQ(ap.check_proof(leaf_of(0x01), 1),
+              AuxPow::CheckResult::INVALID);
+}
+
 } // namespace


### PR DESCRIPTION
Stacked PR — review order **P1a (#178) -> P1b (#180) -> P1c (this)**. Base is the P1b branch so this diff is P1c-only; each leg is independently revertable.

## What
Third leg of `AuxPow::check_proof()`: the **parent-coinbase tx-merkle** proof (step 3 of 4).

- New `nmc::coin::parent_coinbase_txid()` — `Hash(pack(TX_NO_WITNESS(tx)))`, byte-identical to the btc tree's `compute_txid()` (mempool.hpp) but **NMC-local** per the coin fence (only `nmc::coin` serializer + `core::Hash`; no btc include).
- `check_proof` step 3: reconstruct the parent block tx-merkle-root from the **witness-stripped** coinbase txid through `parent_coinbase_branch`/`parent_coinbase_index` via `aux_merkle_root()`. When a parent header is present the reconstructed root MUST equal `parent_header.m_merkle_root`, else **INVALID**. Negative/too-wide index => **INVALID**.

## Still INCOMPLETE-never-VALID
Steps 2 (MM-marker commitment + chain_id/slot binding) and 4 (parent PoW vs target, btc tree READ-ONLY) are unbuilt. A structurally-consistent proof returns **INCOMPLETE** — NMC MUST NOT block-validate off this leaf. No leaf can block-validate until all four legs land, so this carries no merge risk.

## Tests — `nmc_auxpow_merkle_test` 14/14 PASS exit 0 (was 9/9)
- **Load-bearing byte-exactness KAT**: txid is hashed over the LEGACY (no-witness) layout — **txid, NOT wtxid** — re-derived field-by-field WITHOUT `SerializeTransaction`'s witness/marker path (catches a stray marker/flag), and shown to differ from the wtxid for a coinbase carrying the BIP141 reserved value.
- 4 `check_proof` boundary KATs: match=>INCOMPLETE, mismatch/negative/too-wide=>INVALID.

## Fences
NMC-local (`src/impl/nmc/` only), btc tree READ-ONLY, GPG-signed, zero-attribution, test target name unchanged (CI `--target` allowlist untouched). I do not self-merge.

Next: P1c-step2 (coinbase MM-marker scan + chain_id pin), then step 4 (parent PoW).