### PR TITLE
dgb: name sharechain LevelDB store per-coin (digibyte), not litecoin

### DIFF
--- a/src/impl/dgb/node.hpp
+++ b/src/impl/dgb/node.hpp
@@ -181,8 +181,11 @@ public:
         // Route m_chain (used by BaseNode) to the tracker's main chain
         m_chain = &m_tracker.chain;
 
-        // Open LevelDB storage and load any persisted shares
-        std::string net_name = config->m_testnet ? "litecoin_testnet" : "litecoin";
+        // Open LevelDB storage and load any persisted shares. The net_name keys the
+        // per-coin LevelDB directory (SharechainStorage -> config_path/<net_name>), so
+        // it MUST be DGB-specific: an LTC-mirror "litecoin" here would collide the DGB
+        // sharechain DB with c2pool-ltc on a shared host. Bucket-1 isolation primitive.
+        std::string net_name = config->m_testnet ? "digibyte_testnet" : "digibyte";
         m_storage = std::make_unique<c2pool::storage::SharechainStorage>(net_name);
         load_persisted_shares();
 


### PR DESCRIPTION
## What
NodeImpl(ctx,config) opened its persisted-sharechain LevelDB store under net_name `litecoin`/`litecoin_testnet` — an unrenamed holdover from the LTC node this tree was ported from.

Sibling coins each use their own name (btc->`bitcoin`, bch->`bitcoincash`, ltc->`litecoin`); dgb was left on `litecoin`. Renamed to `digibyte`/`digibyte_testnet`.

## Why
`net_name` keys the per-coin LevelDB directory (`SharechainStorage` -> `config_path/<net_name>`). On a host also running c2pool-ltc, the DGB node would open and persist its sharechain into litecoin's store — a cross-coin collision. The store name is a **bucket-1 per-coin isolation primitive** and MUST be DGB-specific. Invariant documented inline.

## Scope / safety
- Single-coin (`src/impl/dgb/node.hpp` only); no shared base / CMake / build.yml touch.
- Precondition for the #82 run-loop node-construction slice (which opens this DB live).

## Verify
- Build: `c2pool-dgb` links **EXIT=0** (`-DCOIN_DGB=ON`).
- Smoke: `--selftest` **OK** (oracle identifier 4b62545b, block_period=75s SSOT).

HOLD merge — operator push-approval gated.