### PR TITLE
nmc(P1c-step2): AuxPow::check_proof MM-marker commitment + chain_id/slot binding

### DIFF
--- a/src/impl/nmc/coin/header_chain.hpp
+++ b/src/impl/nmc/coin/header_chain.hpp
@@ -193,6 +193,7 @@ struct AuxPow {
     /// Result of a (future) AuxPow verification.
     enum class CheckResult {
         NOT_IMPLEMENTED_P0,   //!< P0 leaf — verification path not built yet
+        INCOMPLETE,           //!< P1b — merkle leg(s) wired; steps 2/3/4 pending
         VALID,
         INVALID,
     };
@@ -200,7 +201,8 @@ struct AuxPow {
     /// Verify that this AuxPow actually proves work for `aux_block_hash`
     /// against the given expected aux chain id.
     ///
-    /// P0-DEFER: NOT IMPLEMENTED in P0. The real implementation must, against
+    /// P1b: step 1 (chain-merkle leg) is wired below via aux_merkle_root().
+    /// The FULL implementation must, against
     /// a properly-pinned Namecoin chainparams:
     ///   1. recompute the merged-mining merkle root from `chain_merkle_branch`
     ///      + `chain_merkle_index` starting at `aux_block_hash`, and confirm
@@ -216,10 +218,31 @@ struct AuxPow {
     /// Until all four steps exist, NMC MUST NOT block-validate off this leaf.
     CheckResult check_proof(const uint256& aux_block_hash,
                             int32_t expected_chain_id) const {
-        // P0-DEFER: structural stub. Deliberately performs NO verification.
-        (void)aux_block_hash;
-        (void)expected_chain_id;
-        return CheckResult::NOT_IMPLEMENTED_P0;
+        // P1b — chain-merkle leg (step 1). Walk the aux (NMC) block hash up
+        // through chain_merkle_branch/chain_merkle_index to reconstruct the
+        // merged-mining merkle root via aux_merkle_root(). The remaining steps
+        // are NOT built yet: step 2 (confirm that root is committed in the
+        // parent coinbase MM marker, with the chain_id/slot binding), step 3
+        // (parent-coinbase tx-merkle leg — needs the witness-stripped BTC
+        // coinbase txid), step 4 (parent PoW vs target, consumed from the btc
+        // tree READ-ONLY). A structurally-consistent chain-merkle walk therefore
+        // returns INCOMPLETE, never VALID — NMC still MUST NOT block-validate
+        // off this leaf.
+        (void)expected_chain_id;  // step-2 (chain_id/slot) binding lands later
+
+        if (chain_merkle_index < 0)
+            return CheckResult::INVALID;  // negative slot index is malformed
+
+        try {
+            // Reconstructed MM root; its commitment check is step 2 (pending).
+            (void)aux_merkle_root(
+                aux_block_hash, chain_merkle_branch,
+                static_cast<uint32_t>(chain_merkle_index));
+        } catch (const std::invalid_argument&) {
+            return CheckResult::INVALID;  // branch index out of range for depth
+        }
+
+        return CheckResult::INCOMPLETE;
     }
 };
 

--- a/src/impl/nmc/coin/header_chain.hpp
+++ b/src/impl/nmc/coin/header_chain.hpp
@@ -117,6 +117,23 @@ inline uint256 aux_merkle_root(const uint256& leaf,
     return cur;
 }
 
+// ─── Parent-coinbase txid (P1c: AuxPow step-3 leaf identity) ───────
+
+/// Witness-stripped transaction id of the parent (BTC) coinbase.
+///
+/// AuxPow step 3 proves the parent coinbase is committed in the parent
+/// block's transaction merkle root. That tree commits *txids*, NOT wtxids —
+/// so the coinbase id MUST be hashed over the LEGACY (no-witness, no segwit
+/// marker/flag) serialization even though a real BTC coinbase carries a
+/// witness (the BIP141 segwit-commitment reserved value). Byte-for-byte
+/// identical to the btc tree's compute_txid() (mempool.hpp) but kept
+/// NMC-LOCAL per the coin fence: consumes only the nmc::coin transaction
+/// serializer (TX_NO_WITNESS) + core::Hash, no btc include.
+inline uint256 parent_coinbase_txid(const MutableTransaction& tx) {
+    auto packed = pack(TX_NO_WITNESS(tx));
+    return Hash(packed.get_span());
+}
+
 // ─── AuxPow (merge-mining proof) ─────────────────────────────────────────────
 
 /// One aux-chain slot inside a parent coinbase's merged-mining merkle tree.
@@ -218,21 +235,25 @@ struct AuxPow {
     /// Until all four steps exist, NMC MUST NOT block-validate off this leaf.
     CheckResult check_proof(const uint256& aux_block_hash,
                             int32_t expected_chain_id) const {
-        // P1b — chain-merkle leg (step 1). Walk the aux (NMC) block hash up
-        // through chain_merkle_branch/chain_merkle_index to reconstruct the
-        // merged-mining merkle root via aux_merkle_root(). The remaining steps
-        // are NOT built yet: step 2 (confirm that root is committed in the
-        // parent coinbase MM marker, with the chain_id/slot binding), step 3
-        // (parent-coinbase tx-merkle leg — needs the witness-stripped BTC
-        // coinbase txid), step 4 (parent PoW vs target, consumed from the btc
-        // tree READ-ONLY). A structurally-consistent chain-merkle walk therefore
-        // returns INCOMPLETE, never VALID — NMC still MUST NOT block-validate
-        // off this leaf.
+        // P1b+P1c — two merkle legs wired. Step 1 (chain-merkle) walks the
+        // aux (NMC) block hash through chain_merkle_branch/index to reconstruct
+        // the merged-mining root; step 3 (parent-coinbase tx-merkle) walks the
+        // witness-stripped parent coinbase txid through
+        // parent_coinbase_branch/index and, when a parent header is present,
+        // requires it to reproduce that header's tx-merkle-root. The remaining
+        // steps are NOT built yet: step 2 (confirm the reconstructed MM root is
+        // committed in the parent coinbase's MM marker, with the chain_id/slot
+        // binding) and step 4 (parent PoW vs target, consumed from the btc tree
+        // READ-ONLY). Because those gates do not exist yet, a structurally-
+        // consistent proof returns INCOMPLETE, never VALID — NMC still MUST NOT
+        // block-validate off this leaf. Any malformed leg (negative slot index,
+        // an index wider than its branch depth, or a parent-coinbase leg that
+        // does not reconstruct the parent header's tx-merkle-root) is INVALID.
         (void)expected_chain_id;  // step-2 (chain_id/slot) binding lands later
 
+        // ── step 1 (P1b): chain-merkle leg ──
         if (chain_merkle_index < 0)
             return CheckResult::INVALID;  // negative slot index is malformed
-
         try {
             // Reconstructed MM root; its commitment check is step 2 (pending).
             (void)aux_merkle_root(
@@ -241,6 +262,25 @@ struct AuxPow {
         } catch (const std::invalid_argument&) {
             return CheckResult::INVALID;  // branch index out of range for depth
         }
+
+        // ── step 3 (P1c): parent-coinbase tx-merkle leg ──
+        if (parent_coinbase_index < 0)
+            return CheckResult::INVALID;  // negative slot index is malformed
+        uint256 reconstructed_parent_merkle;
+        try {
+            // The parent tx-merkle tree commits the WITNESS-STRIPPED txid.
+            reconstructed_parent_merkle = aux_merkle_root(
+                parent_coinbase_txid(parent_coinbase), parent_coinbase_branch,
+                static_cast<uint32_t>(parent_coinbase_index));
+        } catch (const std::invalid_argument&) {
+            return CheckResult::INVALID;  // branch index out of range for depth
+        }
+        // The equality gate only fires once a parent header is present: a real
+        // proof always carries one, but a leg-only structural fixture leaves it
+        // null and has nothing to match against yet (steps 2/4 still pending).
+        if (!parent_header.IsNull() &&
+            reconstructed_parent_merkle != parent_header.m_merkle_root)
+            return CheckResult::INVALID;
 
         return CheckResult::INCOMPLETE;
     }

--- a/src/impl/nmc/coin/header_chain.hpp
+++ b/src/impl/nmc/coin/header_chain.hpp
@@ -41,6 +41,7 @@
 #include <core/hash.hpp>
 #include <core/log.hpp>
 
+#include <algorithm>
 #include <atomic>
 #include <cstdint>
 #include <functional>
@@ -132,6 +133,105 @@ inline uint256 aux_merkle_root(const uint256& leaf,
 inline uint256 parent_coinbase_txid(const MutableTransaction& tx) {
     auto packed = pack(TX_NO_WITNESS(tx));
     return Hash(packed.get_span());
+}
+
+// ─── Merged-mining commitment scan (P1c-step2: AuxPow step-2 binding) ──
+
+/// pchMergedMiningHeader — the 4-byte magic tag that precedes the merged-mining
+/// commitment inside the parent coinbase scriptSig. Byte-faithful with
+/// Namecoin/Bitcoin auxpow.cpp (the same SSOT btc/doge consume); kept NMC-LOCAL
+/// per the coin fence (only std + core types, no btc include).
+inline constexpr unsigned char MM_HEADER_MAGIC[4] = {0xfa, 0xbe, 'm', 'm'};
+
+/// Read a little-endian uint32 from 4 bytes WITHOUT a host-endian memcpy: the
+/// on-wire MM size/nonce fields are always little-endian.
+inline uint32_t read_le32(const unsigned char* p) {
+    return  static_cast<uint32_t>(p[0])
+         | (static_cast<uint32_t>(p[1]) << 8)
+         | (static_cast<uint32_t>(p[2]) << 16)
+         | (static_cast<uint32_t>(p[3]) << 24);
+}
+
+/// Deterministic chain-merkle slot for a (nonce, chain_id, height) triple.
+/// Byte-faithful port of Namecoin/Bitcoin CAuxPow::getExpectedIndex: pins each
+/// aux chain to a pseudo-random-but-fixed slot so the same parent work cannot be
+/// replayed for two chains and inter-chain slot clashes are minimised. The
+/// arithmetic is intentionally wrap-around uint32 (LCG constants 1103515245 /
+/// 12345) to match the reference bit-for-bit.
+inline uint32_t aux_expected_index(uint32_t nonce, int32_t chain_id, unsigned height) {
+    uint32_t rnd = nonce;
+    rnd = rnd * 1103515245u + 12345u;
+    rnd += static_cast<uint32_t>(chain_id);
+    rnd = rnd * 1103515245u + 12345u;
+    return rnd % (1u << height);
+}
+
+/// Result of scanning a parent coinbase scriptSig for the merged-mining
+/// commitment of a given chain-merkle root.
+enum class MMScan {
+    ABSENT,    //!< no MM magic in the scriptSig — nothing to assert (staged leg)
+    MATCH,     //!< magic found and root/size/nonce/slot all bind correctly
+    MISMATCH,  //!< magic found but the commitment is malformed or inconsistent
+};
+
+/// Step 2 of AuxPow verification: confirm the reconstructed chain-merkle root is
+/// the one committed inside the parent coinbase's merged-mining marker, and that
+/// this chain occupies the slot the (nonce, chain_id) binding demands.
+///
+/// Byte-faithful port of the coinbase scan in Namecoin/Bitcoin auxpow.cpp
+/// (CAuxPow::check), kept NMC-LOCAL per the coin fence (only std + core types):
+///   * the 4-byte MM magic must appear exactly once;
+///   * the chain-merkle root must follow the magic immediately, stored in the
+///     REVERSED (big-endian display) byte order auxpow.cpp uses;
+///   * the next 4 LE bytes are the tree size and MUST equal 2^height;
+///   * the following 4 LE bytes are the nonce, and chain_index MUST equal
+///     aux_expected_index(nonce, chain_id, height).
+/// Returns ABSENT when the magic is absent entirely — the staged-leg posture
+/// (mirrors the null-parent-header gate in step 3): step 2 cannot be asserted off
+/// a fixture carrying no marker, and the proof never upgrades to VALID regardless.
+/// NOTE (constant-pinning): the legacy no-magic "root in the first 20 bytes"
+/// back-compat branch of the reference is intentionally NOT honoured — post-
+/// activation Namecoin merge-mining always carries the magic; the final
+/// endianness/layout cross-check happens against a live namecoind at pinning.
+/// chain_merkle_root is taken by value (base_uint::begin() is non-const).
+inline MMScan scan_mm_commitment(const std::vector<unsigned char>& script,
+                                 uint256 chain_merkle_root,
+                                 unsigned chain_height,
+                                 int32_t expected_chain_id,
+                                 uint32_t chain_index) {
+    const unsigned char* magic = MM_HEADER_MAGIC;
+    auto magic_it = std::search(script.begin(), script.end(), magic, magic + 4);
+    if (magic_it == script.end())
+        return MMScan::ABSENT;  // staged: no commitment to bind against yet
+
+    // Replay guard: exactly one MM header may appear (the reference rejects a
+    // second so one parent block cannot smuggle two commitments for one chain).
+    if (std::search(magic_it + 4, script.end(), magic, magic + 4) != script.end())
+        return MMScan::MISMATCH;
+
+    // The chain-merkle root is committed reversed (big-endian display order).
+    const unsigned char* rb =
+        reinterpret_cast<const unsigned char*>(chain_merkle_root.begin());
+    std::vector<unsigned char> root_be(rb, rb + uint256::BYTES);
+    std::reverse(root_be.begin(), root_be.end());
+
+    auto root_pos = magic_it + 4;
+    if (static_cast<size_t>(script.end() - root_pos) < root_be.size())
+        return MMScan::MISMATCH;  // truncated before the root
+    if (!std::equal(root_be.begin(), root_be.end(), root_pos))
+        return MMScan::MISMATCH;  // magic present but commits a different root
+
+    auto pc = root_pos + static_cast<std::ptrdiff_t>(root_be.size());
+    if (script.end() - pc < 8)
+        return MMScan::MISMATCH;  // missing the 4-byte size + 4-byte nonce
+    uint32_t n_size  = read_le32(&*pc);
+    uint32_t n_nonce = read_le32(&*(pc + 4));
+    if (n_size != (1u << chain_height))
+        return MMScan::MISMATCH;  // tree size disagrees with the branch depth
+    if (chain_index != aux_expected_index(n_nonce, expected_chain_id, chain_height))
+        return MMScan::MISMATCH;  // chain sits in the wrong deterministic slot
+
+    return MMScan::MATCH;
 }
 
 // ─── AuxPow (merge-mining proof) ─────────────────────────────────────────────
@@ -235,32 +335,53 @@ struct AuxPow {
     /// Until all four steps exist, NMC MUST NOT block-validate off this leaf.
     CheckResult check_proof(const uint256& aux_block_hash,
                             int32_t expected_chain_id) const {
-        // P1b+P1c — two merkle legs wired. Step 1 (chain-merkle) walks the
+        // P1b+P1c — three merkle legs wired. Step 1 (chain-merkle) walks the
         // aux (NMC) block hash through chain_merkle_branch/index to reconstruct
-        // the merged-mining root; step 3 (parent-coinbase tx-merkle) walks the
-        // witness-stripped parent coinbase txid through
+        // the merged-mining root; step 2 (MM-marker) confirms that root is the
+        // one committed inside the parent coinbase's merged-mining marker, with
+        // the (nonce, chain_id) slot binding; step 3 (parent-coinbase tx-merkle)
+        // walks the witness-stripped parent coinbase txid through
         // parent_coinbase_branch/index and, when a parent header is present,
         // requires it to reproduce that header's tx-merkle-root. The remaining
-        // steps are NOT built yet: step 2 (confirm the reconstructed MM root is
-        // committed in the parent coinbase's MM marker, with the chain_id/slot
-        // binding) and step 4 (parent PoW vs target, consumed from the btc tree
-        // READ-ONLY). Because those gates do not exist yet, a structurally-
-        // consistent proof returns INCOMPLETE, never VALID — NMC still MUST NOT
-        // block-validate off this leaf. Any malformed leg (negative slot index,
-        // an index wider than its branch depth, or a parent-coinbase leg that
-        // does not reconstruct the parent header's tx-merkle-root) is INVALID.
-        (void)expected_chain_id;  // step-2 (chain_id/slot) binding lands later
+        // step 4 (parent PoW vs target, consumed from the btc tree READ-ONLY) is
+        // NOT built yet. Because step 4 does not exist, a structurally-consistent
+        // proof returns INCOMPLETE, never VALID — NMC still MUST NOT block-
+        // validate off this leaf. Any malformed leg (negative slot index, an
+        // index wider than its branch depth, a parent-coinbase leg that does not
+        // reconstruct the parent header's tx-merkle-root, or an MM marker that
+        // commits a different root / wrong tree-size / wrong slot) is INVALID.
 
         // ── step 1 (P1b): chain-merkle leg ──
         if (chain_merkle_index < 0)
             return CheckResult::INVALID;  // negative slot index is malformed
+        uint256 reconstructed_mm_root;
         try {
-            // Reconstructed MM root; its commitment check is step 2 (pending).
-            (void)aux_merkle_root(
+            // Reconstruct the merged-mining merkle root; step 2 binds it to the
+            // parent coinbase commitment.
+            reconstructed_mm_root = aux_merkle_root(
                 aux_block_hash, chain_merkle_branch,
                 static_cast<uint32_t>(chain_merkle_index));
         } catch (const std::invalid_argument&) {
             return CheckResult::INVALID;  // branch index out of range for depth
+        }
+
+        // ── step 2 (P1c-step2): MM-marker commitment + chain_id/slot binding ──
+        // Confirm the reconstructed MM root is the one committed inside the
+        // parent coinbase's merged-mining marker, with the (nonce, chain_id)
+        // slot binding. When the coinbase carries no marker (a leg-only
+        // structural fixture, or an empty parent coinbase) there is nothing to
+        // assert yet — staged posture, mirrors the null-parent-header gate in
+        // step 3. A marker present but committing a different root / wrong size /
+        // wrong slot is INVALID.
+        if (!parent_coinbase.vin.empty()) {
+            MMScan scan = scan_mm_commitment(
+                parent_coinbase.vin[0].scriptSig.m_data,
+                reconstructed_mm_root,
+                static_cast<unsigned>(chain_merkle_branch.size()),
+                expected_chain_id,
+                static_cast<uint32_t>(chain_merkle_index));
+            if (scan == MMScan::MISMATCH)
+                return CheckResult::INVALID;
         }
 
         // ── step 3 (P1c): parent-coinbase tx-merkle leg ──

--- a/src/impl/nmc/test/CMakeLists.txt
+++ b/src/impl/nmc/test/CMakeLists.txt
@@ -19,6 +19,10 @@ if (BUILD_TESTING AND GTest_FOUND)
     # share/coin libs are needed -- this KAT only folds with core::Hash.
     target_link_libraries(nmc_auxpow_merkle_test PRIVATE
         c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage)
+    # P1b: the check_proof KATs construct AuxPow, whose parent_coinbase member
+    # is an nmc::coin::MutableTransaction with an out-of-line ctor -> link the
+    # nmc_coin lib (transaction.cpp). Still no node/pool/share libs (none exist).
+    target_link_libraries(nmc_auxpow_merkle_test PRIVATE nmc_coin)
 
     include(GoogleTest)
     include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})

--- a/src/impl/nmc/test/auxpow_merkle_test.cpp
+++ b/src/impl/nmc/test/auxpow_merkle_test.cpp
@@ -23,6 +23,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <stdexcept>
 #include <vector>
 
@@ -269,6 +270,180 @@ TEST(NmcAuxCheckProof, ParentCoinbaseIndexTooWideForDepthIsInvalid)
     ap.parent_coinbase_index  = 2;
     EXPECT_EQ(ap.check_proof(leaf_of(0x01), 1),
               AuxPow::CheckResult::INVALID);
+}
+
+
+// ---------------------------------------------------------------------------
+// P1c-step2: AuxPow::check_proof MM-marker commitment + chain_id/slot binding.
+//
+// step 2 confirms the chain-merkle root reconstructed in step 1 is the one
+// committed inside the parent coinbase's merged-mining marker (pchMergedMiningHeader
+// = fa be 6d 6d), that the marker's tree size == 2^height, and that the chain
+// occupies the slot aux_expected_index(nonce, chain_id, height) demands. A
+// coinbase with NO marker leaves the proof INCOMPLETE (staged: nothing to
+// assert, mirrors the null-parent-header gate). A marker present but committing
+// a different root / wrong size / wrong slot, or a duplicated marker, is INVALID.
+// The proof never reaches VALID — step 4 (parent PoW) is still unbuilt.
+//
+// aux_expected_index is pinned against values computed OFFLINE (not by calling
+// the production helper), so an LCG-constant/typo in the port is caught. The
+// committed root is laid out here by hand (magic|reversed-root|LE size|LE nonce)
+// without touching scan_mm_commitment, so a scan/parse bug is caught not mirrored.
+// Per-coin isolation: src/impl/nmc/ only; btc tree consumed READ-ONLY.
+// ---------------------------------------------------------------------------
+
+using nmc::coin::scan_mm_commitment;
+using nmc::coin::aux_expected_index;
+using nmc::coin::MMScan;
+
+static const unsigned char MM_MAGIC[4] = {0xfa, 0xbe, 'm', 'm'};
+
+static void put_le32(std::vector<unsigned char>& v, uint32_t x)
+{
+    v.push_back(static_cast<unsigned char>( x        & 0xff));
+    v.push_back(static_cast<unsigned char>((x >> 8)  & 0xff));
+    v.push_back(static_cast<unsigned char>((x >> 16) & 0xff));
+    v.push_back(static_cast<unsigned char>((x >> 24) & 0xff));
+}
+
+// The chain-merkle root as committed: reversed (big-endian display) byte order,
+// derived here without touching scan_mm_commitment.
+static std::vector<unsigned char> root_reversed(uint256 r)
+{
+    const unsigned char* p = reinterpret_cast<const unsigned char*>(r.begin());
+    std::vector<unsigned char> v(p, p + uint256::BYTES);
+    std::reverse(v.begin(), v.end());
+    return v;
+}
+
+// [dummy coinbase-height prefix][magic][reversed root][LE size][LE nonce].
+static std::vector<unsigned char> mm_script(const std::vector<unsigned char>& reversed_root,
+                                            uint32_t size, uint32_t nonce)
+{
+    std::vector<unsigned char> s = {0x03, 0x11, 0x22, 0x33};  // arbitrary prefix
+    s.insert(s.end(), MM_MAGIC, MM_MAGIC + 4);
+    s.insert(s.end(), reversed_root.begin(), reversed_root.end());
+    put_le32(s, size);
+    put_le32(s, nonce);
+    return s;
+}
+
+static MutableTransaction coinbase_with_script(const std::vector<unsigned char>& script)
+{
+    MutableTransaction tx;
+    tx.version = 1; tx.locktime = 0;
+    TxIn in;
+    in.prevout.hash.SetNull();
+    in.prevout.index = 0xffffffffu;
+    in.scriptSig = OPScript(script.data(), script.data() + script.size());
+    in.sequence = 0xffffffffu;
+    tx.vin.push_back(in);
+    TxOut out; out.value = 5000000000LL; tx.vout.push_back(out);
+    tx.vin[0].scriptWitness.stack.assign(1, std::vector<unsigned char>(32, 0x00));
+    return tx;
+}
+
+TEST(NmcAuxExpectedIndex, MatchesPinnedOfflineReference)
+{
+    // values computed offline via the LCG (1103515245 / 12345), chain_id = 1.
+    EXPECT_EQ(aux_expected_index(0,     1, 3), 3u);
+    EXPECT_EQ(aux_expected_index(1,     1, 3), 4u);
+    EXPECT_EQ(aux_expected_index(7,     1, 3), 2u);
+    EXPECT_EQ(aux_expected_index(0,     1, 1), 1u);
+    EXPECT_EQ(aux_expected_index(1,     1, 1), 0u);
+    EXPECT_EQ(aux_expected_index(12345, 1, 4), 12u);
+}
+
+TEST(NmcAuxStep2, ScanReturnsMatchAbsentMismatch)
+{
+    uint256 aux = leaf_of(0x01), sib = leaf_of(0x55);
+    uint256 root = combine(aux, sib);          // index bit0=0 => leaf left
+    unsigned h = 1; int32_t cid = 1; uint32_t nonce = 1; uint32_t index = 0;  // slot 0
+
+    auto good = mm_script(root_reversed(root), 1u << h, nonce);
+    EXPECT_EQ(scan_mm_commitment(good, root, h, cid, index), MMScan::MATCH);
+
+    std::vector<unsigned char> nomagic = {0x03, 0x11, 0x22, 0x33};
+    EXPECT_EQ(scan_mm_commitment(nomagic, root, h, cid, index), MMScan::ABSENT);
+
+    auto badroot = mm_script(root_reversed(leaf_of(0x99)), 1u << h, nonce);
+    EXPECT_EQ(scan_mm_commitment(badroot, root, h, cid, index), MMScan::MISMATCH);
+}
+
+TEST(NmcAuxStep2, ValidCommitmentIsIncompleteNeverValid)
+{
+    uint256 aux = leaf_of(0x01), sib = leaf_of(0x55);
+    uint256 root = combine(aux, sib);
+    auto script = mm_script(root_reversed(root), /*size=*/2, /*nonce=*/1);  // slot 0
+
+    AuxPow ap;
+    ap.parent_coinbase = coinbase_with_script(script);
+    ap.chain_merkle_branch = {sib};
+    ap.chain_merkle_index = 0;
+    // parent_header null => step 3 equality skipped; step 2 MATCH; step 4 unbuilt.
+    EXPECT_EQ(ap.check_proof(aux, 1), AuxPow::CheckResult::INCOMPLETE);
+    EXPECT_NE(ap.check_proof(aux, 1), AuxPow::CheckResult::VALID);
+}
+
+TEST(NmcAuxStep2, WrongCommittedRootIsInvalid)
+{
+    uint256 aux = leaf_of(0x01), sib = leaf_of(0x55);
+    auto script = mm_script(root_reversed(leaf_of(0x99)), 2, 1);  // commits wrong root
+    AuxPow ap;
+    ap.parent_coinbase = coinbase_with_script(script);
+    ap.chain_merkle_branch = {sib};
+    ap.chain_merkle_index = 0;
+    EXPECT_EQ(ap.check_proof(aux, 1), AuxPow::CheckResult::INVALID);
+}
+
+TEST(NmcAuxStep2, WrongTreeSizeIsInvalid)
+{
+    uint256 aux = leaf_of(0x01), sib = leaf_of(0x55);
+    uint256 root = combine(aux, sib);
+    auto script = mm_script(root_reversed(root), /*size=*/4, /*nonce=*/1);  // h=1 wants 2
+    AuxPow ap;
+    ap.parent_coinbase = coinbase_with_script(script);
+    ap.chain_merkle_branch = {sib};
+    ap.chain_merkle_index = 0;
+    EXPECT_EQ(ap.check_proof(aux, 1), AuxPow::CheckResult::INVALID);
+}
+
+TEST(NmcAuxStep2, WrongDeterministicSlotIsInvalid)
+{
+    uint256 aux = leaf_of(0x01), sib = leaf_of(0x55);
+    uint256 root = combine(aux, sib);          // correct root for index 0
+    // nonce 0 => expected slot 1 (pinned) != chain_merkle_index 0 => binding fails;
+    // root + size are correct so only the slot check rejects this.
+    auto script = mm_script(root_reversed(root), 2, /*nonce=*/0);
+    AuxPow ap;
+    ap.parent_coinbase = coinbase_with_script(script);
+    ap.chain_merkle_branch = {sib};
+    ap.chain_merkle_index = 0;
+    EXPECT_EQ(ap.check_proof(aux, 1), AuxPow::CheckResult::INVALID);
+}
+
+TEST(NmcAuxStep2, DuplicateMergedMiningHeaderIsInvalid)
+{
+    uint256 aux = leaf_of(0x01), sib = leaf_of(0x55);
+    uint256 root = combine(aux, sib);
+    auto script = mm_script(root_reversed(root), 2, 1);
+    script.insert(script.end(), MM_MAGIC, MM_MAGIC + 4);  // a second, illegal header
+    AuxPow ap;
+    ap.parent_coinbase = coinbase_with_script(script);
+    ap.chain_merkle_branch = {sib};
+    ap.chain_merkle_index = 0;
+    EXPECT_EQ(ap.check_proof(aux, 1), AuxPow::CheckResult::INVALID);
+}
+
+TEST(NmcAuxStep2, NoMarkerLeavesProofIncomplete)
+{
+    uint256 aux = leaf_of(0x01), sib = leaf_of(0x55);
+    std::vector<unsigned char> nomagic = {0x03, 0x4e, 0x4d, 0x43};  // no MM magic
+    AuxPow ap;
+    ap.parent_coinbase = coinbase_with_script(nomagic);
+    ap.chain_merkle_branch = {sib};
+    ap.chain_merkle_index = 0;
+    EXPECT_EQ(ap.check_proof(aux, 1), AuxPow::CheckResult::INCOMPLETE);
 }
 
 } // namespace

--- a/src/impl/nmc/test/auxpow_merkle_test.cpp
+++ b/src/impl/nmc/test/auxpow_merkle_test.cpp
@@ -35,6 +35,7 @@
 namespace {
 
 using nmc::coin::aux_merkle_root;
+using nmc::coin::AuxPow;
 
 // Build a uint256 whose first byte is `b` (rest zero) — distinct, legible leaves.
 static uint256 leaf_of(unsigned char b)
@@ -98,6 +99,55 @@ TEST(NmcAuxMerkle, IndexTooLargeForBranchThrows)
     uint256 sib  = leaf_of(0x22);
     // one-element branch admits indices 0..1; 2 overflows the implied tree.
     EXPECT_THROW(aux_merkle_root(leaf, {sib}, 2u), std::invalid_argument);
+}
+
+
+// ---------------------------------------------------------------------------
+// P1b: AuxPow::check_proof chain-merkle leg (step 1) wiring.
+//
+// check_proof() now reconstructs the merged-mining merkle root from the aux
+// block hash through chain_merkle_branch/index via aux_merkle_root(). Steps 2
+// (MM-marker commitment), 3 (parent-coinbase tx-merkle leg) and 4 (parent PoW)
+// are NOT built, so a structurally-consistent walk returns INCOMPLETE — never
+// VALID. A malformed slot index (negative, or wider than the branch depth)
+// returns INVALID. These KATs pin exactly that boundary so the leg can never
+// silently regress into asserting VALID before the rest of the proof exists.
+// ---------------------------------------------------------------------------
+
+TEST(NmcAuxCheckProof, ChainLegStructurallyValidIsIncomplete)
+{
+    AuxPow ap;
+    ap.chain_merkle_branch = {leaf_of(0xbe)};
+    ap.chain_merkle_index = 0;
+    EXPECT_EQ(ap.check_proof(leaf_of(0x01), /*expected_chain_id=*/1),
+              AuxPow::CheckResult::INCOMPLETE);
+}
+
+TEST(NmcAuxCheckProof, EmptyChainBranchIsIncompleteNeverValid)
+{
+    AuxPow ap;  // empty branch, index 0 => identity walk, still not provable
+    EXPECT_EQ(ap.check_proof(leaf_of(0x07), 1),
+              AuxPow::CheckResult::INCOMPLETE);
+    EXPECT_NE(ap.check_proof(leaf_of(0x07), 1),
+              AuxPow::CheckResult::VALID);
+}
+
+TEST(NmcAuxCheckProof, NegativeChainIndexIsInvalid)
+{
+    AuxPow ap;
+    ap.chain_merkle_branch = {leaf_of(0x0a)};
+    ap.chain_merkle_index = -1;
+    EXPECT_EQ(ap.check_proof(leaf_of(0x02), 1),
+              AuxPow::CheckResult::INVALID);
+}
+
+TEST(NmcAuxCheckProof, ChainIndexTooWideForDepthIsInvalid)
+{
+    AuxPow ap;
+    ap.chain_merkle_branch = {leaf_of(0x0a)};  // depth 1 => max index 1
+    ap.chain_merkle_index = 2;
+    EXPECT_EQ(ap.check_proof(leaf_of(0x02), 1),
+              AuxPow::CheckResult::INVALID);
 }
 
 } // namespace

--- a/src/impl/nmc/test/auxpow_merkle_test.cpp
+++ b/src/impl/nmc/test/auxpow_merkle_test.cpp
@@ -150,4 +150,125 @@ TEST(NmcAuxCheckProof, ChainIndexTooWideForDepthIsInvalid)
               AuxPow::CheckResult::INVALID);
 }
 
+// ---------------------------------------------------------------------------
+// P1c: AuxPow::check_proof parent-coinbase tx-merkle leg (step 3) wiring.
+//
+// step 3 reconstructs the parent block's transaction merkle root from the
+// WITNESS-STRIPPED parent coinbase txid through parent_coinbase_branch/index
+// via aux_merkle_root(), and (once a parent header is present) requires it to
+// equal parent_header.m_merkle_root. The load-bearing test asserts the exact
+// byte serialization of the txid: it is hashed over the LEGACY (no-witness)
+// layout -- txid, NOT wtxid -- so a coinbase carrying the BIP141 segwit
+// reserved value still hashes witness-stripped. The legacy preimage is
+// re-derived here field-by-field WITHOUT calling SerializeTransaction's
+// witness/marker path, so a stray marker/flag byte is caught, not mirrored.
+// Per-coin isolation: src/impl/nmc/ only; btc tree consumed READ-ONLY.
+// ---------------------------------------------------------------------------
+
+using nmc::coin::MutableTransaction;
+using nmc::coin::TxIn;
+using nmc::coin::TxOut;
+using nmc::coin::parent_coinbase_txid;
+
+// A minimal parent (BTC) coinbase carrying the BIP141 witness reserved value
+// (single 32-byte zero stack item) -- exactly what a real segwit coinbase
+// carries, so the txid path is forced to strip a present witness.
+static MutableTransaction make_parent_coinbase()
+{
+    MutableTransaction tx;
+    tx.version = 1;
+    tx.locktime = 0;
+    TxIn in;
+    in.prevout.hash.SetNull();
+    in.prevout.index = 0xffffffffu;
+    static const unsigned char sig[] = {0x03, 0x4e, 0x4d, 0x43};  // arbitrary scriptSig
+    in.scriptSig = OPScript(sig, sig + sizeof(sig));
+    in.sequence = 0xffffffffu;
+    tx.vin.push_back(in);
+    TxOut out;
+    out.value = 5000000000LL;
+    tx.vout.push_back(out);
+    tx.vin[0].scriptWitness.stack.assign(1, std::vector<unsigned char>(32, 0x00));
+    return tx;
+}
+
+// Independent legacy (no-witness) txid: lay out version|vin|vout|locktime via
+// PackStream directly (the TxIn serializer writes prevout+scriptSig+sequence,
+// NO witness) and double-SHA256 it -- never touching parent_coinbase_txid's
+// SerializeTransaction path.
+static uint256 legacy_txid(const MutableTransaction& tx)
+{
+    PackStream ref;
+    ref << tx.version;
+    ref << tx.vin;
+    ref << tx.vout;
+    ref << tx.locktime;
+    auto sp = std::span<const unsigned char>(
+        reinterpret_cast<const unsigned char*>(ref.data()), ref.size());
+    return Hash(sp);
+}
+
+TEST(NmcAuxParentCoinbase, TxidIsWitnessStrippedLegacyHashNotWtxid)
+{
+    auto cb = make_parent_coinbase();
+    ASSERT_TRUE(cb.HasWitness());  // a real BTC coinbase carries the reserved value
+
+    // (a) txid is hashed over the independently-laid-out legacy serialization.
+    EXPECT_EQ(parent_coinbase_txid(cb), legacy_txid(cb));
+
+    // (b) txid != wtxid: the with-witness hash differs precisely because the
+    //     witness is present and the txid path must strip it.
+    auto wpacked = pack(nmc::coin::TX_WITH_WITNESS(cb));
+    uint256 wtxid = Hash(wpacked.get_span());
+    EXPECT_NE(parent_coinbase_txid(cb), wtxid);
+}
+
+TEST(NmcAuxCheckProof, ParentLegReconstructingHeaderMerkleIsIncomplete)
+{
+    AuxPow ap;
+    ap.parent_coinbase = make_parent_coinbase();
+    uint256 cbid = parent_coinbase_txid(ap.parent_coinbase);
+    uint256 sib  = leaf_of(0x55);
+    ap.parent_coinbase_branch = {sib};
+    ap.parent_coinbase_index  = 0;            // bit0=0 => coinbase LEFT
+    // parent header commits the reconstructed tx-merkle-root; mark it non-null.
+    ap.parent_header.m_merkle_root = combine(cbid, sib);
+    ap.parent_header.m_bits = 1;              // non-null so the equality gate fires
+    // chain leg left at defaults (empty branch, index 0) => passes step 1.
+    EXPECT_EQ(ap.check_proof(leaf_of(0x01), 1),
+              AuxPow::CheckResult::INCOMPLETE);
+}
+
+TEST(NmcAuxCheckProof, ParentLegNotReconstructingHeaderMerkleIsInvalid)
+{
+    AuxPow ap;
+    ap.parent_coinbase = make_parent_coinbase();
+    ap.parent_coinbase_branch = {leaf_of(0x55)};
+    ap.parent_coinbase_index  = 0;
+    ap.parent_header.m_merkle_root = leaf_of(0x99);  // deliberately wrong root
+    ap.parent_header.m_bits = 1;                     // non-null => equality gate fires
+    EXPECT_EQ(ap.check_proof(leaf_of(0x01), 1),
+              AuxPow::CheckResult::INVALID);
+}
+
+TEST(NmcAuxCheckProof, NegativeParentCoinbaseIndexIsInvalid)
+{
+    AuxPow ap;
+    ap.parent_coinbase = make_parent_coinbase();
+    ap.parent_coinbase_branch = {leaf_of(0x55)};
+    ap.parent_coinbase_index  = -1;
+    EXPECT_EQ(ap.check_proof(leaf_of(0x01), 1),
+              AuxPow::CheckResult::INVALID);
+}
+
+TEST(NmcAuxCheckProof, ParentCoinbaseIndexTooWideForDepthIsInvalid)
+{
+    AuxPow ap;
+    ap.parent_coinbase = make_parent_coinbase();
+    ap.parent_coinbase_branch = {leaf_of(0x55)};  // depth 1 => max index 1
+    ap.parent_coinbase_index  = 2;
+    EXPECT_EQ(ap.check_proof(leaf_of(0x01), 1),
+              AuxPow::CheckResult::INVALID);
+}
+
 } // namespace


### PR DESCRIPTION
Wires the merge-mining marker (step 2) leg of NMC AuxPow::check_proof: scans parent coinbase for the MM magic commitment, validates committed aux-root, tree-size (2^height), and chain slot via byte-faithful aux_expected_index (CAuxPow::getExpectedIndex LCG). Absent marker -> step 2 skipped (staged posture, mirrors null-parent gate). Proof never reaches VALID — step 4 (parent PoW vs target, btc tree READ-ONLY) unbuilt, so a structurally-consistent proof stays INCOMPLETE; NMC MUST NOT block-validate off this leaf yet.\n\nKATs: aux_expected_index pinned to offline LCG values; committed root laid out by hand (magic|reversed-root|LE size|LE nonce) so a parse/scan bug is caught not mirrored. nmc_auxpow_merkle_test 22/22 PASS exit 0 (+8).\n\nStacks on #181 (step 3 tx-merkle leg @89b321e1).