### PR TITLE
nmc(P1e): cumulative-work summation sub-leg (+6 KATs, 40->46)

### DIFF
--- a/src/impl/nmc/coin/header_chain.hpp
+++ b/src/impl/nmc/coin/header_chain.hpp
@@ -553,6 +553,20 @@ struct IndexEntry {
     std::optional<AuxPow>  auxpow;       // merge-mining proof (P0: stored, unverified)
 };
 
+/// Work represented by a compact target. Mirror of btc::coin::get_block_proof
+/// (src/impl/btc/coin/header_chain.hpp) — NMC is a SHA256d Bitcoin fork, so the
+/// work metric is identical. Kept local to the NMC lane (btc tree is read-only;
+/// core/ is an exceptional SSOT) rather than cross-including the btc header.
+///   work = 2^256 / (target + 1) = ~target / (target + 1) + 1
+inline uint256 get_block_proof(uint32_t bits) {
+    bool negative, overflow;
+    uint256 target;
+    target.SetCompact(bits, &negative, &overflow);
+    if (negative || target.IsNull() || overflow)
+        return uint256::ZERO;
+    return (~target / (target + uint256::ONE)) + uint256::ONE;
+}
+
 // ─── HeaderChain ─────────────────────────────────────────────────────────────
 
 /// Header-only chain skeleton for embedded NMC. Mirrors the public surface of
@@ -763,14 +777,19 @@ private:
         e.header     = header;
         e.block_hash = bh;
         e.height     = static_cast<uint32_t>(height);
-        e.chain_work = parent_work;             // cumulative-work summation = next sub-leg
+        // cumulative-work summation: this header's chain_work is the parent's
+        // running total plus its own block proof (work-based reorg fork-choice
+        // is still a later sub-leg; tip selection stays height-proxy below).
+        e.chain_work = parent_work + get_block_proof(header.m_bits);
         e.status     = has_auxpow ? HEADER_VALID_CHAIN : HEADER_VALID_TREE;
         e.auxpow     = auxpow;
+        const uint256 entry_work = e.chain_work;
         m_index.emplace(bh, std::move(e));
 
         if (m_tip.IsNull() || height > static_cast<int32_t>(m_tip_height)) {
             m_tip        = bh;                  // height-proxy tip (no work reorg yet)
             m_tip_height = static_cast<uint32_t>(height);
+            m_best_work  = entry_work;          // cumulative work at the new tip
         }
         return true;
     }

--- a/src/impl/nmc/test/auxpow_merkle_test.cpp
+++ b/src/impl/nmc/test/auxpow_merkle_test.cpp
@@ -802,4 +802,83 @@ TEST(NmcP1eStore, PrematureAuxPowIsRejectedByStoreEvenWhenProofValid)
     EXPECT_EQ(chain_.height(), 0u);
 }
 
+// ---------------------------------------------------------------------------
+// P1e cumulative-work summation sub-leg KATs (NmcP1eWork). chain_work is now
+// parent.chain_work + get_block_proof(nBits); cumulative_work() tracks the tip.
+// Fork-choice stays height-proxy (work-based reorg is a still-later sub-leg).
+// ---------------------------------------------------------------------------
+TEST(NmcP1eWork, GetBlockProofMatchesTwoToThe256OverTargetPlusOne)
+{
+    using nmc::coin::get_block_proof;
+    // For bits=0x207fffff the target fills (almost) the whole 256-bit range, so
+    // the proof is tiny; for a harder target the proof is strictly larger.
+    uint256 easy = get_block_proof(0x207fffffu);   // regtest-easy target
+    uint256 hard = get_block_proof(0x1d00ffffu);   // BTC genesis-era target
+    EXPECT_FALSE(easy.IsNull());
+    EXPECT_TRUE(hard > easy);                       // harder target => more work
+}
+
+TEST(NmcP1eWork, MalformedBitsContributeZeroWork)
+{
+    using nmc::coin::get_block_proof;
+    EXPECT_TRUE(get_block_proof(0u).IsNull());      // null target => zero work
+}
+
+TEST(NmcP1eWork, GenesisChainWorkIsItsOwnBlockProof)
+{
+    using nmc::coin::get_block_proof;
+    HeaderChain chain_(params_activation(19200));
+    uint256 z; z.SetNull();
+    BlockHeaderType g = plain_header(z, 0x1d00ffffu, 1);
+    ASSERT_TRUE(chain_.add_header(g));
+    EXPECT_EQ(chain_.cumulative_work(), get_block_proof(0x1d00ffffu));
+    ASSERT_TRUE(chain_.tip().has_value());
+    EXPECT_EQ(chain_.tip()->chain_work, get_block_proof(0x1d00ffffu));
+}
+
+TEST(NmcP1eWork, ChildChainWorkIsParentPlusOwnProof)
+{
+    using nmc::coin::get_block_proof;
+    HeaderChain chain_(params_activation(19200));
+    uint256 z; z.SetNull();
+    BlockHeaderType g = plain_header(z, 0x1d00ffffu, 1);
+    ASSERT_TRUE(chain_.add_header(g));
+    BlockHeaderType c = plain_header(block_hash(g), 0x1d00ffffu, 2);
+    ASSERT_TRUE(chain_.add_header(c));
+    uint256 want = get_block_proof(0x1d00ffffu) + get_block_proof(0x1d00ffffu);
+    EXPECT_EQ(chain_.cumulative_work(), want);
+    ASSERT_TRUE(chain_.tip().has_value());
+    EXPECT_EQ(chain_.tip()->chain_work, want);
+}
+
+TEST(NmcP1eWork, CumulativeWorkAccumulatesMonotonicallyAcrossAChain)
+{
+    HeaderChain chain_(params_activation(19200));
+    uint256 z; z.SetNull();
+    BlockHeaderType prev = plain_header(z, 0x1d00ffffu, 1);
+    ASSERT_TRUE(chain_.add_header(prev));
+    uint256 last = chain_.cumulative_work();
+    for (uint32_t i = 2; i <= 6; ++i) {
+        BlockHeaderType c = plain_header(block_hash(prev), 0x1d00ffffu, i);
+        ASSERT_TRUE(chain_.add_header(c));
+        uint256 now = chain_.cumulative_work();
+        EXPECT_TRUE(now > last);                    // strictly increasing per block
+        last = now;
+        prev = c;
+    }
+    EXPECT_EQ(chain_.height(), 5u);
+}
+
+TEST(NmcP1eWork, RejectedHeaderDoesNotAdvanceCumulativeWork)
+{
+    HeaderChain chain_(params_activation(19200));
+    uint256 z; z.SetNull();
+    BlockHeaderType g = plain_header(z, 0x1d00ffffu, 1);
+    ASSERT_TRUE(chain_.add_header(g));
+    uint256 before = chain_.cumulative_work();
+    BlockHeaderType orphan = plain_header(leaf_of(0xAB), 0x1d00ffffu, 99);
+    EXPECT_FALSE(chain_.add_header(orphan));         // unknown parent
+    EXPECT_EQ(chain_.cumulative_work(), before);     // work unchanged on reject
+}
+
 } // namespace


### PR DESCRIPTION
Stacked on #192 (nmc/p1e-storage-leg). The storage leg connected headers but left chain_work as a bare copy of the parent total and never updated m_best_work, so cumulative_work() returned null. This sub-leg closes that gap.

## What
- chain_work = parent.chain_work + get_block_proof(nBits) in connect_locked().
- cumulative_work() now tracks the tip via m_best_work, advanced on the height-proxy tip move.
- Local get_block_proof() mirroring btc::coin::get_block_proof (NMC is a SHA256d Bitcoin fork; work metric identical). Kept lane-local: btc tree is read-only, core/ is an exceptional SSOT, so no cross-include / no shared-core edit.

## Not in scope (still later sub-leg)
- Work-based reorg fork-choice. Tip selection stays height-proxy; this leg only makes the work *metric* correct.

## Tests
+6 KATs (NmcP1eWork): block-proof monotonicity vs target, malformed-bits => zero work, genesis chain_work == own proof, child == parent+own proof, monotonic accumulation across a 6-block chain, rejected header leaves cumulative work unchanged.

NMC ctest 40 -> 46, 100% green locally (ctest -R Nmc). Build clean (nmc_auxpow_merkle_test). Merge operator-gated; I do not self-merge.