### PR TITLE
nmc(P1e): work-based reorg fork-choice (+6 KATs, 46->52)

### DIFF
--- a/src/impl/nmc/coin/header_chain.hpp
+++ b/src/impl/nmc/coin/header_chain.hpp
@@ -729,9 +729,10 @@ private:
     // P1e storage leg: shared in-memory connect path for plain and merge-mined
     // headers. Caller holds m_mutex. Derives the connected height from the
     // parent (or 0 for the chain-root seed), runs the activation gate, and on
-    // ADMIT inserts the IndexEntry and advances the tip (height-proxy fork
-    // choice; work-based reorg is a later leg). Returns false -- nothing
-    // persisted -- on already-known / orphan / activation-gate rejection.
+    // ADMIT inserts the IndexEntry and advances the tip by WORK-BASED fork
+    // choice (most-cumulative-work wins, with an equal-work tie-break at the
+    // tip height). Returns false -- nothing persisted -- on already-known /
+    // orphan / activation-gate rejection.
     bool connect_locked(const BlockHeaderType& header,
                         const std::optional<AuxPow>& auxpow) {
         const uint256 bh = block_hash(header);
@@ -778,18 +779,40 @@ private:
         e.block_hash = bh;
         e.height     = static_cast<uint32_t>(height);
         // cumulative-work summation: this header's chain_work is the parent's
-        // running total plus its own block proof (work-based reorg fork-choice
-        // is still a later sub-leg; tip selection stays height-proxy below).
+        // running total plus its own block proof.
         e.chain_work = parent_work + get_block_proof(header.m_bits);
         e.status     = has_auxpow ? HEADER_VALID_CHAIN : HEADER_VALID_TREE;
         e.auxpow     = auxpow;
         const uint256 entry_work = e.chain_work;
         m_index.emplace(bh, std::move(e));
 
-        if (m_tip.IsNull() || height > static_cast<int32_t>(m_tip_height)) {
-            m_tip        = bh;                  // height-proxy tip (no work reorg yet)
+        // Work-based fork choice (mirror of btc::coin::HeaderChain): the best
+        // chain is the one with the most CUMULATIVE work, not the greatest
+        // height -- so a heavier competing branch reorgs the tip even when it
+        // is shorter. An equal-work header at the tip height also switches the
+        // tip: it represents network consensus on a tie, which matters on
+        // min-difficulty testnet where every block carries identical work.
+        // Re-receiving a stored header is the idempotent reject above, so the
+        // switch cannot flip-flop.
+        const bool first        = m_tip.IsNull();
+        const bool dominated    = entry_work > m_best_work;
+        const bool equal_at_tip = entry_work == m_best_work
+                               && height == static_cast<int32_t>(m_tip_height)
+                               && bh != m_tip;
+        if (first || dominated || equal_at_tip) {
+            const uint32_t old_height = m_tip_height;
+            const uint256  old_tip    = m_tip;
+            m_tip        = bh;
             m_tip_height = static_cast<uint32_t>(height);
             m_best_work  = entry_work;          // cumulative work at the new tip
+            if (!first && (equal_at_tip
+                           || height <= static_cast<int32_t>(old_height))) {
+                LOG_WARNING << "[EMB-NMC] "
+                            << (equal_at_tip ? "EQUAL-WORK REORG" : "REORG")
+                            << " at height " << height
+                            << ": old_tip=" << old_tip.ToString().substr(0, 16)
+                            << " new_tip=" << bh.ToString().substr(0, 16);
+            }
         }
         return true;
     }

--- a/src/impl/nmc/test/auxpow_merkle_test.cpp
+++ b/src/impl/nmc/test/auxpow_merkle_test.cpp
@@ -805,7 +805,7 @@ TEST(NmcP1eStore, PrematureAuxPowIsRejectedByStoreEvenWhenProofValid)
 // ---------------------------------------------------------------------------
 // P1e cumulative-work summation sub-leg KATs (NmcP1eWork). chain_work is now
 // parent.chain_work + get_block_proof(nBits); cumulative_work() tracks the tip.
-// Fork-choice stays height-proxy (work-based reorg is a still-later sub-leg).
+// (Tip selection itself is covered by the NmcP1eForkChoice suite below.)
 // ---------------------------------------------------------------------------
 TEST(NmcP1eWork, GetBlockProofMatchesTwoToThe256OverTargetPlusOne)
 {
@@ -879,6 +879,138 @@ TEST(NmcP1eWork, RejectedHeaderDoesNotAdvanceCumulativeWork)
     BlockHeaderType orphan = plain_header(leaf_of(0xAB), 0x1d00ffffu, 99);
     EXPECT_FALSE(chain_.add_header(orphan));         // unknown parent
     EXPECT_EQ(chain_.cumulative_work(), before);     // work unchanged on reject
+}
+
+// ---------------------------------------------------------------------------
+// P1e work-based reorg fork-choice sub-leg KATs (NmcP1eForkChoice). The tip is
+// now the header with the most CUMULATIVE work, not the greatest height: a
+// heavier competing branch reorgs the tip even when it is shorter, and an
+// equal-work header at the tip height switches the tip (network-consensus
+// tie-break). Mirrors btc::coin::HeaderChain fork choice.
+// ---------------------------------------------------------------------------
+namespace {
+constexpr uint32_t kEasyBits = 0x1d00ffffu;   // BTC genesis-era target
+constexpr uint32_t kHardBits = 0x1c0fffffu;   // ~16x more work per block
+}
+
+TEST(NmcP1eForkChoice, HeavierSingleBlockReorgsOverLongerLighterChain)
+{
+    using nmc::coin::get_block_proof;
+    HeaderChain chain_(params_activation(19200));
+    uint256 z; z.SetNull();
+    // Long, light chain: g <- a1 <- a2 <- a3  (height 3).
+    BlockHeaderType g  = plain_header(z, kEasyBits, 1);
+    ASSERT_TRUE(chain_.add_header(g));
+    BlockHeaderType a1 = plain_header(block_hash(g),  kEasyBits, 2);
+    ASSERT_TRUE(chain_.add_header(a1));
+    BlockHeaderType a2 = plain_header(block_hash(a1), kEasyBits, 3);
+    ASSERT_TRUE(chain_.add_header(a2));
+    BlockHeaderType a3 = plain_header(block_hash(a2), kEasyBits, 4);
+    ASSERT_TRUE(chain_.add_header(a3));
+    EXPECT_EQ(chain_.height(), 3u);
+    EXPECT_EQ(chain_.tip()->block_hash, block_hash(a3));
+
+    // One much-heavier sibling at height 1 outweighs the whole easy chain.
+    EXPECT_TRUE(get_block_proof(kHardBits)
+                > get_block_proof(kEasyBits) + get_block_proof(kEasyBits)
+                  + get_block_proof(kEasyBits));
+    BlockHeaderType b1 = plain_header(block_hash(g), kHardBits, 5);
+    ASSERT_TRUE(chain_.add_header(b1));
+    EXPECT_EQ(chain_.height(), 1u);                      // reorg shortened the tip
+    EXPECT_EQ(chain_.tip()->block_hash, block_hash(b1));
+    EXPECT_EQ(chain_.cumulative_work(),
+              get_block_proof(kEasyBits) + get_block_proof(kHardBits));
+}
+
+TEST(NmcP1eForkChoice, LighterSiblingIsStoredButDoesNotReorg)
+{
+    HeaderChain chain_(params_activation(19200));
+    uint256 z; z.SetNull();
+    BlockHeaderType g  = plain_header(z, kEasyBits, 1);
+    ASSERT_TRUE(chain_.add_header(g));
+    BlockHeaderType a1 = plain_header(block_hash(g), kHardBits, 2);   // heavy tip
+    ASSERT_TRUE(chain_.add_header(a1));
+    uint256 work_at_tip = chain_.cumulative_work();
+
+    BlockHeaderType b1 = plain_header(block_hash(g), kEasyBits, 3);   // lighter sibling
+    EXPECT_TRUE(chain_.add_header(b1));                 // stored...
+    EXPECT_TRUE(chain_.has_header(block_hash(b1)));
+    EXPECT_EQ(chain_.size(), 3u);
+    EXPECT_EQ(chain_.tip()->block_hash, block_hash(a1)); // ...but tip unchanged
+    EXPECT_EQ(chain_.cumulative_work(), work_at_tip);
+}
+
+TEST(NmcP1eForkChoice, EqualWorkSiblingAtTipHeightSwitchesTip)
+{
+    HeaderChain chain_(params_activation(19200));
+    uint256 z; z.SetNull();
+    BlockHeaderType g  = plain_header(z, kEasyBits, 1);
+    ASSERT_TRUE(chain_.add_header(g));
+    BlockHeaderType a1 = plain_header(block_hash(g), kEasyBits, 2);
+    ASSERT_TRUE(chain_.add_header(a1));
+    EXPECT_EQ(chain_.tip()->block_hash, block_hash(a1));
+    uint256 work_at_tip = chain_.cumulative_work();
+
+    // Same parent + same difficulty, different nonce => equal work, new hash.
+    BlockHeaderType b1 = plain_header(block_hash(g), kEasyBits, 99);
+    EXPECT_TRUE(chain_.add_header(b1));
+    EXPECT_EQ(chain_.tip()->block_hash, block_hash(b1)); // equal-work tie-break switch
+    EXPECT_EQ(chain_.height(), 1u);
+    EXPECT_EQ(chain_.cumulative_work(), work_at_tip);    // work identical
+}
+
+TEST(NmcP1eForkChoice, ReReceivingHeadersDoesNotFlipFlopTheTip)
+{
+    HeaderChain chain_(params_activation(19200));
+    uint256 z; z.SetNull();
+    BlockHeaderType g  = plain_header(z, kEasyBits, 1);
+    ASSERT_TRUE(chain_.add_header(g));
+    BlockHeaderType a1 = plain_header(block_hash(g), kEasyBits, 2);
+    ASSERT_TRUE(chain_.add_header(a1));
+    BlockHeaderType b1 = plain_header(block_hash(g), kHardBits, 3);   // reorg to heavy
+    ASSERT_TRUE(chain_.add_header(b1));
+    EXPECT_EQ(chain_.tip()->block_hash, block_hash(b1));
+    uint256 work_at_tip = chain_.cumulative_work();
+
+    // Re-receiving either stored header is an idempotent no-op; tip is stable.
+    EXPECT_FALSE(chain_.add_header(a1));
+    EXPECT_FALSE(chain_.add_header(b1));
+    EXPECT_EQ(chain_.tip()->block_hash, block_hash(b1));
+    EXPECT_EQ(chain_.cumulative_work(), work_at_tip);
+}
+
+TEST(NmcP1eForkChoice, TipExtendsAfterAWorkReorg)
+{
+    using nmc::coin::get_block_proof;
+    HeaderChain chain_(params_activation(19200));
+    uint256 z; z.SetNull();
+    BlockHeaderType g  = plain_header(z, kEasyBits, 1);
+    ASSERT_TRUE(chain_.add_header(g));
+    BlockHeaderType a1 = plain_header(block_hash(g), kEasyBits, 2);
+    ASSERT_TRUE(chain_.add_header(a1));
+    BlockHeaderType b1 = plain_header(block_hash(g), kHardBits, 3);   // reorg
+    ASSERT_TRUE(chain_.add_header(b1));
+    EXPECT_EQ(chain_.height(), 1u);
+
+    BlockHeaderType b2 = plain_header(block_hash(b1), kEasyBits, 4);  // extend heavy tip
+    ASSERT_TRUE(chain_.add_header(b2));
+    EXPECT_EQ(chain_.height(), 2u);
+    EXPECT_EQ(chain_.tip()->block_hash, block_hash(b2));
+    EXPECT_EQ(chain_.cumulative_work(),
+              get_block_proof(kEasyBits) + get_block_proof(kHardBits)
+              + get_block_proof(kEasyBits));
+}
+
+TEST(NmcP1eForkChoice, FirstHeaderBecomesTipRegardlessOfPriorState)
+{
+    HeaderChain chain_(params_activation(19200));
+    EXPECT_FALSE(chain_.tip().has_value());
+    uint256 z; z.SetNull();
+    BlockHeaderType g = plain_header(z, kEasyBits, 1);
+    ASSERT_TRUE(chain_.add_header(g));
+    ASSERT_TRUE(chain_.tip().has_value());
+    EXPECT_EQ(chain_.tip()->block_hash, block_hash(g));
+    EXPECT_EQ(chain_.cumulative_work(), nmc::coin::get_block_proof(kEasyBits));
 }
 
 } // namespace


### PR DESCRIPTION
## What

`HeaderChain::connect_locked` now selects the chain tip by **most cumulative work** (with an equal-work tie-break at the tip height), not greatest height — mirroring `btc::coin::HeaderChain`. Closes the last P1e fork-choice sub-leg; the prior leg only summed work, tip selection stayed height-proxy.

- Heavier competing branch reorgs the tip even when shorter.
- Equal-work sibling at the tip height switches the tip (network-consensus tie-break; matters on min-difficulty testnet where every block carries identical per-block work).
- Idempotent reject of known hashes makes the switch flip-flop-proof.
- Emits `[EMB-NMC] REORG` / `EQUAL-WORK REORG` log on branch switch.

## Tests

New `NmcP1eForkChoice` suite (6 KATs): heavier-short-branch reorg, lighter-sibling no-reorg, equal-work switch, re-receive stability, post-reorg extend, first-header-is-tip.

`nmc_auxpow_merkle_test` **52/52 PASS** (was 46). Build green; rides the allowlisted target, no CI change.

## Scope

NMC tree only (`src/impl/nmc/coin/header_chain.hpp` + test). No cross-coin, no shared `src/core`.