### PR TITLE
ci: glob dgb/** branch filter so stacked stage-PRs do not go dark

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,10 @@ name: CI
 
 on:
   push:
-    branches: [master, btc-embedded, dash-spv-embedded, dgb/pool-pillars-port, windows-build, service-update]
+    branches: [master, btc-embedded, dash-spv-embedded, dgb/**, windows-build, service-update]
     tags: ['v*']
   pull_request:
-    branches: [master, btc-embedded, dash-spv-embedded, dgb/slice4-skeleton, dgb/pool-pillars-port]
+    branches: [master, btc-embedded, dash-spv-embedded, dgb/**]
 
 jobs:
   # ════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Problem
Stage-4 stack #216/#217/#219/#222 went dark (no CI matrix run) because their PRs were based on `dgb/stage-4*` branches outside the enumerated `push`/`pull_request` allowlist. `pull_request` matches the BASE ref, so the matrix never enqueued (same failure class as #113).

## Fix
Collapse the per-branch dgb entries (`dgb/pool-pillars-port`, `dgb/slice4-skeleton`) into a single `dgb/**` glob on **both** the `push` and `pull_request` branch filters. Any future `dgb/` stack now gates in place automatically -- no more enumerating ephemeral stage branches.

## Safety
- Branch filter gates only **WHEN** CI runs, not job logic.
- No change to the per-coin source-presence guards (PR #47) -- those are CMake-level (`-DCOIN_DGB=ON` configure), not branch-keyed.
- Only other branch-conditional logic in the workflow is tag-release gating (`refs/tags/v`), untouched.

GPG-signed.