### PR TITLE
nmc(P1-PE-2a): embedded NMC DNS + fixed seed tables

### DIFF
--- a/src/impl/nmc/coin/CMakeLists.txt
+++ b/src/impl/nmc/coin/CMakeLists.txt
@@ -8,6 +8,7 @@ set(nmc_coin_interface
     block.hpp
     mempool.hpp
     header_chain.hpp
+    chain_seeds.hpp
     rpc_data.hpp
     template_builder.hpp
     coin_smoke.cpp

--- a/src/impl/nmc/coin/chain_seeds.hpp
+++ b/src/impl/nmc/coin/chain_seeds.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+/// DNS seed hostnames and hardcoded fallback IPs for Namecoin P2P networks.
+/// Sources:
+///   - DNS seeds: Namecoin Core chainparams.cpp (CMainParams::vSeeds).
+///   - Fixed seeds: live reachable peers harvested from a synced mainnet
+///     namecoind addrman (getnodeaddresses) on 2026-06-19, port 8334.
+/// Mirrors src/impl/doge/coin/chain_seeds.hpp. Namecoin has a single
+/// mainnet and a single testnet (no testnet4alpha variant).
+
+#include <core/dns_seeder.hpp>
+#include <core/netaddress.hpp>
+#include <vector>
+
+namespace nmc {
+namespace coin {
+
+/// DNS seeds for Namecoin mainnet (P2P port 8334).
+/// From Namecoin Core chainparams.cpp. Several historical seeds are dead;
+/// the fixed_seeds below (live-sourced) provide actual connectivity.
+inline std::vector<c2pool::dns::DnsSeed> nmc_mainnet_dns_seeds()
+{
+    return {
+        {"nmc.seed.quisquis.de",          8334},
+        {"dnsseed.namecoin.webbtc.com",   8334},
+        {"seed.nmc.markasoftware.com",    8334},
+    };
+}
+
+/// DNS seeds for Namecoin testnet (P2P port 18334).
+inline std::vector<c2pool::dns::DnsSeed> nmc_testnet_dns_seeds()
+{
+    return {
+        {"dnsseed.test.namecoin.webbtc.com", 18334},
+    };
+}
+
+/// Hardcoded fallback peers for Namecoin mainnet.
+/// Harvested 2026-06-19 from a synced mainnet namecoind addrman, port 8334.
+inline std::vector<NetService> nmc_mainnet_fixed_seeds()
+{
+    return {
+        {"23.106.38.114",   8334},
+        {"174.95.154.115",  8334},
+        {"212.67.235.211",  8334},
+        {"23.19.112.151",   8334},
+        {"83.217.13.217",   8334},
+        {"166.70.96.250",   8334},
+        {"66.45.249.52",    8334},
+    };
+}
+
+/// Hardcoded fallback peers for Namecoin testnet.
+/// No public fixed peers wired -- connect via --nmc-p2p-address to a known
+/// namecoind, consistent with the doge testnet stance.
+inline std::vector<NetService> nmc_testnet_fixed_seeds()
+{
+    return {};
+}
+
+/// Get DNS seeds for the appropriate NMC network.
+inline std::vector<c2pool::dns::DnsSeed> nmc_dns_seeds(bool testnet)
+{
+    return testnet ? nmc_testnet_dns_seeds() : nmc_mainnet_dns_seeds();
+}
+
+/// Get fixed fallback seeds for the appropriate NMC network.
+inline std::vector<NetService> nmc_fixed_seeds(bool testnet)
+{
+    return testnet ? nmc_testnet_fixed_seeds() : nmc_mainnet_fixed_seeds();
+}
+
+} // namespace coin
+} // namespace nmc

--- a/src/impl/nmc/coin/coin_smoke.cpp
+++ b/src/impl/nmc/coin/coin_smoke.cpp
@@ -11,6 +11,7 @@
 #include "mempool.hpp"
 #include "rpc_data.hpp"
 #include "template_builder.hpp"
+#include "chain_seeds.hpp"
 
 namespace nmc {
 namespace coin {
@@ -49,6 +50,12 @@ void nmc_coin_p0_smoke()
     EmbeddedCoinNode node(chain, pool, /*testnet=*/false);
     (void)node.getblockchaininfo();
     (void)node.is_synced();
+
+    // P1 PE 2a: force-compile embedded NMC seed tables (DNS + fixed).
+    (void)nmc_dns_seeds(false);
+    (void)nmc_fixed_seeds(false);
+    (void)nmc_dns_seeds(true);
+    (void)nmc_fixed_seeds(true);
 }
 
 } // namespace coin


### PR DESCRIPTION
Slice 2a of NMC P1 PE (per integrator greenlight on e2d90ec6 baseline).

**What:** adds `src/impl/nmc/coin/chain_seeds.hpp` mirroring `doge/coin/chain_seeds.hpp` — `nmc_dns_seeds(testnet)` / `nmc_fixed_seeds(testnet)` returning per-network DNS hostnames + hardcoded fallback peers.

**Genuine sources (reuse-genuine-source):**
- DNS seeds: Namecoin Core `chainparams.cpp` (CMainParams::vSeeds).
- Mainnet fixed seeds: live reachable peers harvested from a synced mainnet namecoind addrman (`getnodeaddresses`) on 2026-06-19, P2P port 8334.

**Fence:** changes confined to `src/impl/nmc/coin/` (chain_seeds.hpp + force-compile hook in coin_smoke.cpp + local CMakeLists set-list entry). Rides the allowlisted nmc_coin exe. **No build.yml touched.**

**Build:** `cmake --build build --target nmc_coin` EXIT=0 (coin_smoke.cpp force-compiles all four seed accessors).

This is the fenced, auto-merge-eligible leg of slice 2/2; the host-relay wiring (2b-2d, touches c2pool_refactored.cpp) surfaces separately for operator tap. I do not self-merge.