### PR TITLE
[BCH M5] reorg re-request recovery — block-connect re-getdata sink (fenced, src/impl/bch)

### DIFF
--- a/src/impl/bch/coin/block_connector.hpp
+++ b/src/impl/bch/coin/block_connector.hpp
@@ -63,6 +63,7 @@
 #include <deque>
 #include <memory>
 #include <optional>
+#include <functional>
 #include <unordered_map>
 #include <vector>
 
@@ -88,6 +89,18 @@ public:
     /// (txid/spent-outpoint based) still run fully, so cold-start/headers-only
     /// is safe.
     void set_utxo(core::coin::UTXOViewCache* u) { m_utxo = u; }
+
+    /// Optional re-request sink. A reorg deeper than the remembered-block
+    /// ring (or a headers-first reorg whose intermediate new-branch blocks
+    /// have not been downloaded yet) can no longer reconnect from cache; the
+    /// missing new-branch hashes are handed here -- wire it to
+    /// BlockDownloadWindow::enqueue() so they are re-getdata'd and the reorg
+    /// completes on their re-delivery, instead of stranding the UTXO view at
+    /// the fork. Left unset the connector falls back to the warn-and-hold
+    /// behaviour (UTXO safely parked at the fork until an external resync).
+    void set_block_requester(std::function<void(const std::vector<uint256>&)> req) {
+        m_request_blocks = std::move(req);
+    }
 
     /// Wire to a node's full_block event. Retained internally, torn down on
     /// destruction (or detach()). Call once, after node + chain + pool exist.
@@ -314,9 +327,22 @@ private:
         for (auto it = connect_path.rbegin(); it != connect_path.rend(); ++it) {
             const BlockType* blk = recall_block(*it);
             if (!blk) {
+                // Reorg deeper than the remembered ring (or a headers-first
+                // reorg whose intermediate new-branch blocks were not yet
+                // downloaded): this block and every block still above it on
+                // the path are absent from the cache. Re-request them for
+                // getdata so the reorg completes on their re-delivery instead
+                // of stranding the UTXO at the fork. The sink (enqueue())
+                // dedupes, so an overlapping request never double-getdata's.
+                // `it .. rend()` is exactly the not-yet-connected tail, in
+                // fork->tip connect order.
+                std::vector<uint256> missing(it, connect_path.rend());
                 LOG_WARNING << "[EMB-BCH] reorg: new-branch block "
                                   << it->GetHex().substr(0, 16)
-                                  << "... not retained -- UTXO left at fork, awaiting resync";
+                                  << "... not retained -- re-requesting " << missing.size()
+                                  << " block(s), UTXO held at fork until re-delivery";
+                if (m_request_blocks)
+                    m_request_blocks(missing);
                 return;
             }
             auto e = m_chain.get_header(*it);
@@ -327,6 +353,9 @@ private:
     HeaderChain&                 m_chain;
     Mempool&                     m_pool;
     core::coin::UTXOViewCache*   m_utxo {nullptr};   // optional UTXO view
+    // Re-request sink for reorg blocks absent from the remembered ring
+    // (see set_block_requester). Unset -> warn-and-hold at the fork.
+    std::function<void(const std::vector<uint256>&)> m_request_blocks;
 
     uint256                      m_connected_tip {}; // null = nothing applied yet
     std::vector<ConnectedEntry>  m_undo_stack;       // applied best-chain blocks

--- a/src/impl/bch/test/CMakeLists.txt
+++ b/src/impl/bch/test/CMakeLists.txt
@@ -103,6 +103,24 @@ if(BUILD_TESTING)
         btclibs)
     add_test(NAME bch_reorg_connect_test COMMAND bch_reorg_connect_test)
 
+    # reorg_rerequest_test: M5 reorg recovery leg -- the COMPLEMENT of
+    # reorg_connect_test. When the new branch's intermediate blocks are NOT
+    # in the remembered ring (headers-first race, or a reorg deeper than the
+    # ring retains), the connector hands the missing new-branch hashes to a
+    # set_block_requester() sink (wired to BlockDownloadWindow::enqueue) so
+    # they are re-getdata'd and the reorg completes on re-delivery, instead
+    # of stranding the UTXO at the fork. Same link set + transaction.cpp TU;
+    # no impl_bch coin lib -> per-coin isolation holds.
+    add_executable(bch_reorg_rerequest_test
+        reorg_rerequest_test.cpp
+        ${CMAKE_SOURCE_DIR}/src/impl/bch/coin/transaction.cpp)
+    target_include_directories(bch_reorg_rerequest_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
+    target_link_libraries(bch_reorg_rerequest_test PRIVATE
+        core pool sharechain
+        c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage c2pool_difficulty
+        btclibs)
+    add_test(NAME bch_reorg_rerequest_test COMMAND bch_reorg_rerequest_test)
+
     # compact_block_connector_test: M5 (b) -- BIP152 compact-block depth on the
     # connector seam. on_compact_block reconstructs from prefilled + mempool; a
     # missing tx drives a getblocktxn round that on_block_txn closes out before

--- a/src/impl/bch/test/reorg_rerequest_test.cpp
+++ b/src/impl/bch/test/reorg_rerequest_test.cpp
@@ -1,0 +1,169 @@
+// ---------------------------------------------------------------------------
+// bch::coin reorg re-request test (M5 full-block body).
+//
+// The BlockConnector reconnects a reorg's new branch from its bounded
+// remembered-block ring. When the chain advances to a new tip whose
+// intermediate new-branch blocks have NOT been delivered as full blocks yet
+// (the normal headers-first case: headers race ahead of block downloads) or
+// when a reorg runs deeper than the ring retains, recall_block() returns null
+// and the old behaviour was to log a warning and strand the UTXO at the fork
+// with NO recovery. This test pins the now-live recovery leg:
+//
+//   * a set_block_requester() sink, when wired, is handed exactly the
+//     not-yet-connected new-branch hashes (fork->tip order) so they can be
+//     re-getdata'd (BlockDownloadWindow::enqueue) and the reorg completes on
+//     re-delivery -- instead of silently holding at the fork;
+//   * the fork-point block stays connected (it is at/below the fork, never
+//     disconnected) so the UTXO view is left consistent, not corrupted;
+//   * with NO sink wired the connector still falls back to warn-and-hold
+//     (no crash, no throw) -- the cold-start / unwired contract holds.
+//
+// Build posture mirrors utxo_connect_test: header-only over coin/*.hpp +
+// <core/*> plus coin/transaction.cpp; NO impl_bch coin lib (per-coin isolation
+// stays clean). All heights sit far below the mainnet ASERT anchor so the
+// header chain trusts difficulty structurally, and peer_tip is set high so PoW
+// is skipped -- this builds a deterministic 3-block fork with no PoW grinding.
+// p2pool-merged-v36 surface: NONE (local block-connect / download plumbing).
+// ---------------------------------------------------------------------------
+
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+#include "../coin/block.hpp"
+#include "../coin/block_connector.hpp"
+#include "../coin/header_chain.hpp"
+#include "../coin/mempool.hpp"
+#include "../coin/transaction.hpp"
+
+#include <core/coin/utxo_view_cache.hpp>
+
+namespace {
+
+int failures = 0;
+#define CHECK(cond) do { if (!(cond)) { \
+    std::cerr << "FAIL: " #cond " @ line " << __LINE__ << "\n"; ++failures; } } while (0)
+
+bch::coin::MutableTransaction make_cb(const char* prev_hex, int64_t out_value) {
+    bch::coin::MutableTransaction tx;
+    bch::coin::TxIn in;
+    in.prevout.hash.SetHex(prev_hex);
+    in.prevout.index = 0;
+    in.sequence = 0xffffffff;
+    tx.vin.push_back(in);
+    bch::coin::TxOut out;
+    out.value = out_value;
+    tx.vout.push_back(out);
+    return tx;
+}
+
+// A header building on `prev` with a distinct nonce (=> distinct hash).
+bch::coin::BlockType make_block(const uint256& prev, uint32_t nonce) {
+    bch::coin::BlockType b;
+    b.m_version = 0x20000000;
+    b.m_previous_block = prev;
+    b.m_merkle_root.SetHex(
+        "1111111111111111111111111111111111111111111111111111111111111111");
+    b.m_timestamp = 1700000000 + nonce;
+    b.m_bits = 0x1d00ffff;
+    b.m_nonce = nonce;
+    return b;
+}
+
+const char* OUTPOINT_A = "aa00000000000000000000000000000000000000000000000000000000000000";
+
+// Header chain whose fast-start checkpoint IS block1's hash at height H, so the
+// connector sees block1 as the tip without fighting PoW.
+bch::coin::HeaderChain make_chain(const uint256& tip_hash, uint32_t H) {
+    using namespace bch::coin;
+    BCHChainParams params = BCHChainParams::mainnet();
+    params.fast_start_checkpoint = BCHChainParams::Checkpoint{H, tip_hash};
+    return HeaderChain(params);
+}
+
+} // namespace
+
+int main() {
+    using namespace bch::coin;
+
+    // Heights far below the mainnet ASERT anchor (661647) => difficulty trusted
+    // structurally; peer_tip high => PoW skipped. Deterministic 3-block fork.
+    const uint32_t H = 1000;
+
+    uint256 root_prev; root_prev.SetHex(
+        "00000000000000000001a2b3c4d5e6f700000000000000000000000000000000");
+    BlockType block1 = make_block(root_prev, /*nonce=*/1);
+    block1.m_txs.push_back(make_cb(OUTPOINT_A, 100));   // coinbase-position tx
+    const uint256 h1 = block_hash(static_cast<const BlockHeaderType&>(block1));
+
+    BlockType block2 = make_block(h1, /*nonce=*/2);     // intermediate, NEVER delivered
+    const uint256 h2 = block_hash(static_cast<const BlockHeaderType&>(block2));
+    BlockType block3 = make_block(h2, /*nonce=*/3);      // new tip, delivered
+    const uint256 h3 = block_hash(static_cast<const BlockHeaderType&>(block3));
+    CHECK(h1 != h2); CHECK(h2 != h3); CHECK(h1 != h3);
+
+    // ---- 1) Sink wired: missing new-branch hashes are re-requested ---------
+    {
+        HeaderChain chain = make_chain(h1, H);
+        CHECK(chain.init());
+        chain.set_peer_tip_height(H + 100000);   // skip PoW for these heights
+
+        core::coin::UTXOViewCache utxo(nullptr);
+        Mempool pool;
+
+        BlockConnector conn(chain, pool);
+        conn.set_utxo(&utxo);
+
+        std::vector<uint256> requested;
+        int sink_calls = 0;
+        conn.set_block_requester([&](const std::vector<uint256>& v) {
+            requested = v; ++sink_calls;
+        });
+
+        // Cold-start forward-extend: connect block1 (the checkpoint tip).
+        conn.on_full_block(block1);
+
+        // Chain advances to block3 via headers only; block2's full block never
+        // arrives, so it is absent from the connector's remembered ring.
+        CHECK(chain.add_header(static_cast<const BlockHeaderType&>(block2)));
+        CHECK(chain.add_header(static_cast<const BlockHeaderType&>(block3)));
+        auto tip = chain.tip();
+        CHECK(tip.has_value() && tip->block_hash == h3);   // block3 is best tip
+
+        // Deliver block3: reorg fork=block1 -> [block2, block3]; block2 missing.
+        conn.on_full_block(block3);
+
+        CHECK(sink_calls == 1);
+        CHECK(requested.size() == 2);
+        if (requested.size() == 2) {
+            CHECK(requested[0] == h2);   // fork->tip order: missing intermediate first
+            CHECK(requested[1] == h3);
+        }
+    }
+
+    // ---- 2) No sink wired: warn-and-hold, no crash/throw -------------------
+    {
+        HeaderChain chain = make_chain(h1, H);
+        CHECK(chain.init());
+        chain.set_peer_tip_height(H + 100000);
+
+        core::coin::UTXOViewCache utxo(nullptr);
+        Mempool pool;
+
+        BlockConnector conn(chain, pool);
+        conn.set_utxo(&utxo);
+        // NO set_block_requester()
+
+        conn.on_full_block(block1);
+        CHECK(chain.add_header(static_cast<const BlockHeaderType&>(block2)));
+        CHECK(chain.add_header(static_cast<const BlockHeaderType&>(block3)));
+        conn.on_full_block(block3);      // must not throw / crash
+    }
+
+    if (failures == 0) {
+        std::cout << "reorg_rerequest_test: ALL PASS\n";
+        return 0;
+    }
+    std::cerr << "reorg_rerequest_test: " << failures << " FAILURE(S)\n";
+    return 1;
+}


### PR DESCRIPTION
## BCH M5 embedded-body slice — reorg strand-the-UTXO recovery

SHA: 639edf5b3 (GPG-signed EDDSA, attribution-clean)
Scope: single-coin src/impl/bch only — 3 files (block_connector.hpp + reorg_rerequest_test). Zero p2pool-merged-v36 surface. Per-coin isolation intact (no impl_bch coin-lib link; mirrors utxo_connect_test posture).

### What it does
Closes the reorg gap in BlockConnector where a new branch has intermediate blocks NOT in the bounded remembered-block ring (normal headers-first race, or reorg deeper than the ring retains). Previously recall_block() returned null -> warn + park UTXO at the fork with no recovery. Now an optional set_block_requester() sink receives the not-yet-connected new-branch hashes in fork->tip order for re-getdata (wire to BlockDownloadWindow::enqueue, which dedupes), so the reorg completes on re-delivery. Sink unset -> existing warn-and-hold fallback preserved (cold-start/unwired contract holds, no crash).

### Evidence (local)
- cmake -DCOIN_BCH=ON build green
- new bch_reorg_rerequest_test ALL PASS — both legs: sink-wired re-request order (h2 before h3) and unwired warn-and-hold no-throw
- ctest bch_reorg group 2/2 passed

BCHN submitblock RPC fallback untouched and retained.

Merge gate: operator-tap after full CI rollup (Linux/ASan/Windows) green + mergeStateStatus CLEAN re-verify.

bch-embedded-steward
