### PR TITLE
dgb: make_header_sample embedded-ingest builder (block_hash + SetCompact target)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
                     test_phase4_embedded \
                     test_mweb_builder \
                     test_address_resolution test_compute_share_target \
-                    test_utxo test_dgb_subsidy test_dgb_coinbase_value dgb_share_test dgb_block_assembly_test \
+                    test_utxo test_dgb_subsidy test_dgb_coinbase_value dgb_share_test dgb_block_assembly_test dgb_header_sample_build_test \
                     dgb_gentx_coinbase_test nmc_auxpow_merkle_test nmc_template_builder_test nmc_auxpow_wire_test dgb_gentx_share_path_test dgb_other_tx_resolver_test \
                     dgb_other_tx_assembler_test dgb_reconstruct_won_block_test dgb_gentx_unpack_test dgb_work_source_test dgb_template_builder_test dgb_embedded_coin_node_test \
                     rpc_request_test softfork_check_test genesis_check_test algo_select_test digishield_walk_test header_chain_test \
@@ -200,7 +200,7 @@ jobs:
                     test_phase4_embedded \
                     test_mweb_builder \
                     test_address_resolution test_compute_share_target \
-                    test_utxo test_dgb_subsidy test_dgb_coinbase_value dgb_share_test dgb_block_assembly_test \
+                    test_utxo test_dgb_subsidy test_dgb_coinbase_value dgb_share_test dgb_block_assembly_test dgb_header_sample_build_test \
                     dgb_gentx_coinbase_test nmc_auxpow_merkle_test nmc_template_builder_test nmc_auxpow_wire_test dgb_gentx_share_path_test dgb_other_tx_resolver_test \
                     dgb_other_tx_assembler_test dgb_reconstruct_won_block_test dgb_gentx_unpack_test dgb_work_source_test dgb_template_builder_test dgb_embedded_coin_node_test \
                     rpc_request_test softfork_check_test genesis_check_test algo_select_test digishield_walk_test header_chain_test \

--- a/src/impl/dgb/coin/header_sample_build.hpp
+++ b/src/impl/dgb/coin/header_sample_build.hpp
@@ -1,0 +1,100 @@
+#pragma once
+// ---------------------------------------------------------------------------
+// c2pool::dgb::make_header_sample -- embedded-ingest SSOT that builds a
+// HeaderSample (coin/header_chain.hpp) from a fully-parsed DigiByte block
+// header (coin/block.hpp BlockHeaderType). This is the boundary the embedded
+// P2P header-download path crosses to feed HeaderChain::validate_and_append:
+// it is the ONE place a wire header becomes the algo-agnostic sample the
+// Scrypt-only retarget/continuity walk consumes.
+//
+// What it populates (each a pure function of the header bytes):
+//   * n_version  <- m_version       (drives dgb_header_disposition: Scrypt vs
+//                                     continuity vs reject)
+//   * n_time     <- m_timestamp     (MTP monotonicity gate + retarget timespan)
+//   * target     <- compact_to_target(m_bits)  -- the declared PoW target,
+//                   expanded from nBits exactly as DigiByte Core's
+//                   arith_uint256::SetCompact (bnTarget). Required: a sample
+//                   with target == 0 is rejected by validate_and_append, so an
+//                   ingestable sample MUST decode bits here.
+//   * block_hash <- sha256d(80-byte header)     -- DGB's block identity hash
+//                   (params.hpp block_hash_func == core::pow::sha256d), stored
+//                   little-endian via u256::from_le_bytes so that
+//                   u256_be_display_hex(block_hash) renders the canonical
+//                   big-endian explorer/GBT hash. This is what lights up
+//                   HeaderChain::tip_hash() -> previousblockhash in the work
+//                   template (previously always nullopt: "0 == not populated").
+//   * pow_hash   <- 0  -- LEFT UNSET HERE. block_hash is sha256d (cheap,
+//                   daemon-independent); pow_hash is scrypt(header), filled at
+//                   the embedded-daemon port boundary in a following slice
+//                   (the scrypt CALL pulls btclibs scrypt; the satisfaction
+//                   gate already compares pow_hash <= target with the SAME u256
+//                   shape, so dropping the digest in later is a no-op rewire).
+//
+// btclibs-bearing: includes core/pow.hpp's Hash (sha256d) and core/pack.hpp, so
+// this header is for the FULL build + a btclibs-linking test TU, NOT the
+// deliberately btclibs-free header_chain.hpp/dgb_arith256.hpp limited TU.
+// ---------------------------------------------------------------------------
+
+#include <cstdint>
+
+#include <core/pack.hpp>
+#include <core/hash.hpp>
+#include <core/uint256.hpp>
+
+#include <impl/dgb/coin/block.hpp>          // dgb::coin::BlockHeaderType
+#include <impl/dgb/coin/header_chain.hpp>   // c2pool::dgb::HeaderSample, u256
+
+namespace c2pool::dgb {
+
+// Expand a compact "nBits" difficulty target into a full 256-bit value,
+// mirroring DigiByte Core arith_uint256::SetCompact (Bitcoin's bnTarget
+// decode): the high byte is a base-256 exponent, the low 3 bytes the mantissa.
+//
+//   target = mantissa * 256^(exponent - 3)
+//
+// The sign bit (0x00800000) and the overflow/negative flags SetCompact sets
+// are not reproduced: a block header's declared target is never negative, and
+// an over-pow_limit mantissa is caught by validate_and_append's pow_limit
+// ceiling -- so the numeric expansion is all the ingest path needs. The
+// multiply runs through u256::mul_u64(256), which truncates at 256 bits exactly
+// as arith_uint256 does, so a pathological huge exponent saturates rather than
+// wrapping into a small value.
+inline u256 compact_to_target(uint32_t bits)
+{
+    const uint32_t mantissa = bits & 0x007fffffu;
+    const uint32_t exponent = bits >> 24;
+
+    u256 target = u256::from_u64(mantissa);
+    if (exponent <= 3) {
+        for (uint32_t i = 0, n = 3 - exponent; i < n; ++i)
+            target = target.div_u64(256);
+    } else {
+        for (uint32_t i = 0, n = exponent - 3; i < n; ++i)
+            target = target.mul_u64(256);
+    }
+    return target;
+}
+
+// Build the ingestable HeaderSample from a parsed block header. Pure function
+// of the header bytes -- no chain state, no daemon. See file header for the
+// per-field rationale; pow_hash is intentionally left 0 (scrypt digest lands
+// at the daemon-port boundary).
+inline HeaderSample make_header_sample(const ::dgb::coin::BlockHeaderType& h)
+{
+    HeaderSample s;
+    s.n_version = static_cast<int32_t>(h.m_version);
+    s.n_time    = static_cast<int64_t>(h.m_timestamp);
+    s.target    = compact_to_target(h.m_bits);
+
+    // sha256d over the canonical 80-byte serialization (params.hpp block hash
+    // func). uint256 stores the digest little-endian; from_le_bytes reads it in
+    // the SAME order so u256_be_display_hex round-trips to GetHex().
+    uint256 id = Hash(pack(h).get_span());
+    s.block_hash = u256::from_le_bytes(
+        reinterpret_cast<const unsigned char*>(id.begin()));
+
+    s.pow_hash = 0;  // filled with scrypt(header) at the embedded-daemon port
+    return s;
+}
+
+} // namespace c2pool::dgb

--- a/src/impl/dgb/test/CMakeLists.txt
+++ b/src/impl/dgb/test/CMakeLists.txt
@@ -32,6 +32,22 @@ if (BUILD_TESTING AND GTest_FOUND)
         dgb_coin pool sharechain)
     gtest_add_tests(dgb_block_assembly_test "" AUTO)
 
+    # --- embedded-ingest HeaderSample builder ---------------------------------
+    # Pins coin/header_sample_build.hpp: a parsed BlockHeaderType -> HeaderSample
+    # (block_hash = sha256d(80-byte header), target = SetCompact(nBits)), the
+    # boundary that feeds HeaderChain::validate_and_append and lights up
+    # tip_hash() -> previousblockhash. Links the dgb OBJECT lib like
+    # dgb_block_assembly_test because it pulls block.hpp (BlockHeaderType codec)
+    # + core Hash/pack. MUST appear in BOTH this registration AND the build.yml
+    # --target allowlist.
+    add_executable(dgb_header_sample_build_test header_sample_build_test.cpp)
+    target_link_libraries(dgb_header_sample_build_test PRIVATE
+        GTest::gtest_main GTest::gtest
+        core dgb
+        c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage
+        dgb_coin pool sharechain)
+    gtest_add_tests(dgb_header_sample_build_test "" AUTO)
+
     # --- #82: won-block reconstructor BODY (as_block composition) ----------
     # Pins coin/reconstruct_won_block.hpp: the single composition the dispatch
     # handler injects as its WonBlockReconstructor (resolve_other_tx_hashes ->

--- a/src/impl/dgb/test/header_sample_build_test.cpp
+++ b/src/impl/dgb/test/header_sample_build_test.cpp
@@ -1,0 +1,97 @@
+// ---------------------------------------------------------------------------
+// c2pool::dgb::make_header_sample / compact_to_target test (embedded-ingest
+// HeaderSample builder).
+//
+// Pins the boundary where a parsed BlockHeaderType becomes the HeaderSample
+// HeaderChain::validate_and_append consumes -- in particular the two pieces
+// that were stubbed out as "filled at the embedded-daemon port":
+//   * block_hash = sha256d(80-byte header), stored so u256_be_display_hex()
+//     renders the canonical big-endian explorer hash. Lights up tip_hash() ->
+//     previousblockhash in the work template.
+//   * target = compact_to_target(nBits), arith_uint256::SetCompact expansion.
+//
+// External KAT: the Bitcoin genesis header (identical 80-byte layout to DGB's
+// BlockHeaderType) hashes to the universally-known genesis block id, and its
+// 0x1d00ffff nBits expands to the canonical difficulty-1 target -- so a byte-
+// order or SetCompact regression fails loudly against values anyone can verify.
+//
+// MUST appear in BOTH test/CMakeLists.txt AND the build.yml --target allowlist
+// or it becomes a #143-style NOT_BUILT sentinel that reds master.
+// ---------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+
+#include <core/uint256.hpp>
+
+#include "../coin/block.hpp"
+#include "../coin/hash_format.hpp"
+#include "../coin/header_sample_build.hpp"
+
+namespace {
+
+using ::dgb::coin::BlockHeaderType;
+using ::dgb::coin::u256_be_display_hex;
+using c2pool::dgb::compact_to_target;
+using c2pool::dgb::make_header_sample;
+using c2pool::dgb::HeaderSample;
+
+// Canonical Bitcoin genesis header -- same 80-byte serialization DGB uses.
+BlockHeaderType genesis_header()
+{
+    BlockHeaderType h;
+    h.m_version = 1;
+    h.m_previous_block.SetNull();
+    h.m_merkle_root.SetHex(
+        "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+    h.m_timestamp = 1231006505u;
+    h.m_bits      = 0x1d00ffffu;
+    h.m_nonce     = 2083236893u;
+    return h;
+}
+
+// nBits 0x1d00ffff expands to the canonical difficulty-1 target.
+TEST(CompactToTarget, Difficulty1)
+{
+    EXPECT_EQ(u256_be_display_hex(compact_to_target(0x1d00ffffu)),
+        "00000000ffff0000000000000000000000000000000000000000000000000000");
+}
+
+// A small in-range mantissa with a low exponent (no truncation): 0x05009234
+// -> 0x9234 * 256^(5-3) = 0x9234 * 65536 = 0x92340000.
+TEST(CompactToTarget, LowExponent)
+{
+    EXPECT_EQ(u256_be_display_hex(compact_to_target(0x05009234u)),
+        "0000000000000000000000000000000000000000000000000000000092340000");
+}
+
+// exponent <= 3 right-shifts the mantissa: 0x03001234 -> 0x1234 * 256^0.
+TEST(CompactToTarget, ExponentThreeIsMantissa)
+{
+    EXPECT_EQ(u256_be_display_hex(compact_to_target(0x03001234u)),
+        "0000000000000000000000000000000000000000000000000000000000001234");
+}
+
+// block_hash = sha256d(header) rendered big-endian == the well-known genesis id.
+TEST(MakeHeaderSample, GenesisBlockHash)
+{
+    HeaderSample s = make_header_sample(genesis_header());
+    EXPECT_EQ(u256_be_display_hex(s.block_hash),
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
+}
+
+// Scalar fields pass through verbatim; target decodes the header's nBits;
+// pow_hash stays 0 (scrypt digest lands at the daemon-port boundary).
+TEST(MakeHeaderSample, ScalarFieldsAndTargetAndPowHash)
+{
+    HeaderSample s = make_header_sample(genesis_header());
+    EXPECT_EQ(s.n_version, 1);
+    EXPECT_EQ(s.n_time, 1231006505);
+    EXPECT_EQ(u256_be_display_hex(s.target),
+        "00000000ffff0000000000000000000000000000000000000000000000000000");
+    EXPECT_TRUE(s.pow_hash.is_zero());
+}
+
+} // namespace


### PR DESCRIPTION
Populate `HeaderSample.block_hash` at the embedded-ingest boundary — the named NEXT after the Stage-4 stack landed.

## What
New `src/impl/dgb/coin/header_sample_build.hpp` SSOT: parsed `BlockHeaderType` -> the `HeaderSample` that `HeaderChain::validate_and_append` consumes.

- `block_hash = sha256d(80-byte header)` (params.hpp `block_hash_func`), stored little-endian via `u256::from_le_bytes` so `u256_be_display_hex` renders the canonical big-endian hash. **This is what lights up `tip_hash() -> previousblockhash`** (was always nullopt: `0 == not populated`).
- `target = compact_to_target(nBits)` — arith_uint256 `SetCompact` expansion (required: a `target==0` sample is rejected by `validate_and_append`).
- `n_version`/`n_time` pass through; `pow_hash` stays 0 (scrypt digest lands at the embedded-daemon port; same u256 shape -> no-op rewire later).

## Test (5/5 PASS local)
`dgb_header_sample_build_test`: difficulty-1 `SetCompact` KAT + the **Bitcoin genesis header external KAT** (identical 80-byte layout) -> the universally-known genesis block id, so a byte-order/SetCompact regression fails loudly. Wired into `test/CMakeLists.txt` + **both** build.yml `--target` allowlists (#143 trap avoided).

## Scope / fencing
Single-coin: `src/impl/dgb/` only, additive build.yml. **No shared-base touch.** Fenced-eligible per integrator note (block_hash ingest = dgb-local plumbing); HOLD merge for the verified-CLEAN full rollup + head-SHA reconfirm.

bits accessor / MultiShield-V4 retarget remain HELD as [decision-needed] = V37.