### PR TITLE
dgb: fill pow_hash=scrypt(header) at embedded ingest (live PoW satisfaction gate)

### DIFF
--- a/src/impl/dgb/coin/header_sample_build.hpp
+++ b/src/impl/dgb/coin/header_sample_build.hpp
@@ -23,12 +23,14 @@
 //                   big-endian explorer/GBT hash. This is what lights up
 //                   HeaderChain::tip_hash() -> previousblockhash in the work
 //                   template (previously always nullopt: "0 == not populated").
-//   * pow_hash   <- 0  -- LEFT UNSET HERE. block_hash is sha256d (cheap,
-//                   daemon-independent); pow_hash is scrypt(header), filled at
-//                   the embedded-daemon port boundary in a following slice
-//                   (the scrypt CALL pulls btclibs scrypt; the satisfaction
-//                   gate already compares pow_hash <= target with the SAME u256
-//                   shape, so dropping the digest in later is a no-op rewire).
+//   * pow_hash   <- scrypt(80-byte header) for Scrypt-algo headers, else 0.
+//                   This is the field validate_and_append's PoW-satisfaction
+//                   gate (pow_hash <= target) consumes, and that gate runs only
+//                   on the VALIDATE_SCRYPT disposition -- so non-Scrypt
+//                   continuity headers leave it 0 (their gate never reads it).
+//                   Stored little-endian via from_le_bytes, the SAME u256
+//                   convention as target, so the two compare directly. (Lands
+//                   the scrypt(header) fill deferred from the #227 skeleton.)
 //
 // btclibs-bearing: includes core/pow.hpp's Hash (sha256d) and core/pack.hpp, so
 // this header is for the FULL build + a btclibs-linking test TU, NOT the
@@ -36,12 +38,15 @@
 // ---------------------------------------------------------------------------
 
 #include <cstdint>
+#include <span>
 
 #include <core/pack.hpp>
 #include <core/hash.hpp>
+#include <core/pow.hpp>                     // core::pow::scrypt (80-byte hdr -> uint256)
 #include <core/uint256.hpp>
 
 #include <impl/dgb/coin/block.hpp>          // dgb::coin::BlockHeaderType
+#include <impl/dgb/coin/dgb_block_algo.hpp> // dgb::coin::is_scrypt_header
 #include <impl/dgb/coin/header_chain.hpp>   // c2pool::dgb::HeaderSample, u256
 
 namespace c2pool::dgb {
@@ -86,14 +91,33 @@ inline HeaderSample make_header_sample(const ::dgb::coin::BlockHeaderType& h)
     s.n_time    = static_cast<int64_t>(h.m_timestamp);
     s.target    = compact_to_target(h.m_bits);
 
+    // Serialize once: the block-identity hash and the Scrypt PoW digest are
+    // both pure functions of the same canonical 80-byte header.
+    auto packed = pack(h);
+    auto header_span = packed.get_span();
+
     // sha256d over the canonical 80-byte serialization (params.hpp block hash
     // func). uint256 stores the digest little-endian; from_le_bytes reads it in
     // the SAME order so u256_be_display_hex round-trips to GetHex().
-    uint256 id = Hash(pack(h).get_span());
+    uint256 id = Hash(header_span);
     s.block_hash = u256::from_le_bytes(
         reinterpret_cast<const unsigned char*>(id.begin()));
 
-    s.pow_hash = 0;  // filled with scrypt(header) at the embedded-daemon port
+    // pow_hash = scrypt(header) for Scrypt-algo headers ONLY. The satisfaction
+    // gate (pow_hash <= target) runs solely on the VALIDATE_SCRYPT disposition;
+    // non-Scrypt continuity (and reject-disposition) headers leave pow_hash == 0
+    // -- their gate never reads it, and scrypt over a non-Scrypt header would be
+    // a meaningless cycle. from_le_bytes gives the SAME u256 shape as target so
+    // the gate compares them directly.
+    if (::dgb::coin::is_scrypt_header(s.n_version)) {
+        uint256 ph = core::pow::scrypt(std::span<const unsigned char>(
+            reinterpret_cast<const unsigned char*>(header_span.data()),
+            header_span.size()));
+        s.pow_hash = u256::from_le_bytes(
+            reinterpret_cast<const unsigned char*>(ph.begin()));
+    } else {
+        s.pow_hash = 0;
+    }
     return s;
 }
 

--- a/src/impl/dgb/test/header_ingest_test.cpp
+++ b/src/impl/dgb/test/header_ingest_test.cpp
@@ -18,6 +18,14 @@
 //      REJECTS (unknown algo bits) never reaches the chain; the connector adds
 //      no policy of its own and never force-appends.
 //
+// LIVE PoW gate: make_header_sample now fills pow_hash = scrypt(header) for
+// Scrypt-algo headers, so validate_and_append's satisfaction check (pow_hash <=
+// target) fires on the ingest path. The Scrypt fixtures below therefore carry
+// GENUINE PoW: an easy max-compact target plus a nonce searched until the real
+// scrypt digest satisfies it (~2 scrypt evaluations). This keeps the WIRING
+// assertions deterministic without hand-mining a hard block -- the sha256d
+// block-id KAT (Bitcoin genesis) lives in dgb_header_sample_build_test.
+//
 // Pulls dgb::interfaces::Node (block.hpp codec) + header_chain.hpp + the
 // make_header_sample SSOT, so it links the proven dgb OBJECT-lib SCC set like
 // dgb_header_sample_build_test. MUST also appear in BOTH build.yml --target
@@ -45,33 +53,35 @@ using dgb::coin::DGB_BLOCK_VERSION_ALGO;
 
 namespace {
 
-// Canonical Bitcoin genesis header -- same 80-byte serialization DGB uses, and
-// a Scrypt header (version 1 -> algo nibble 0 == SCRYPT), so it walks the
-// VALIDATE_SCRYPT path. pow_hash is left 0 by make_header_sample (trivially
-// satisfies any target), and a default-ctor HeaderChain leaves pow_limit /
-// target_timespan 0 so the ceiling + DigiShield gates are no-ops -- exactly the
-// bootstrap posture the embedded port starts from.
-BlockHeaderType genesis_header()
+// An easy max-compact target: nBits 0x207fffff expands (compact_to_target,
+// arith_uint256::SetCompact) to ~2^255, comfortably below the unconfigured
+// chain's (absent) pow_limit ceiling. A uniformly-random scrypt digest lands at
+// or under it with ~1/2 probability, so the nonce search below terminates in a
+// couple of evaluations.
+constexpr uint32_t EASY_BITS = 0x207fffffu;
+
+// Build a Scrypt header (version 1 -> algo nibble 0 == SCRYPT) carrying real,
+// satisfiable PoW: starting from seed_nonce, advance the nonce until the live
+// make_header_sample scrypt(header) digest is <= the declared target. Returns a
+// header validate_and_append's now-live satisfaction gate accepts.
+BlockHeaderType satisfiable_scrypt_header(uint32_t seed_nonce, uint32_t timestamp)
 {
     BlockHeaderType h;
     h.m_version = 1;
     h.m_previous_block.SetNull();
     h.m_merkle_root.SetHex(
         "4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
-    h.m_timestamp = 1231006505u;
-    h.m_bits      = 0x1d00ffffu;
-    h.m_nonce     = 2083236893u;
-    return h;
-}
+    h.m_timestamp = timestamp;
+    h.m_bits      = EASY_BITS;
 
-// A second Scrypt header whose nTime is strictly greater than genesis' (the MTP
-// monotonicity gate requires nTime > median-of-ancestors), with a distinct
-// nonce so its sha256d block id differs from genesis'.
-BlockHeaderType second_scrypt_header()
-{
-    BlockHeaderType h = genesis_header();
-    h.m_timestamp = 1231006506u;  // genesis + 1 -> passes MTP over [genesis]
-    h.m_nonce     = 12345u;       // distinct id
+    for (uint32_t n = seed_nonce; n < seed_nonce + 1000000u; ++n) {
+        h.m_nonce = n;
+        auto s = make_header_sample(h);
+        if (!(s.pow_hash > s.target))   // pow_hash <= target -> PoW satisfied
+            return h;
+    }
+    ADD_FAILURE() << "no satisfiable nonce found for EASY_BITS (astronomically "
+                     "unlikely -- check compact_to_target / scrypt wiring)";
     return h;
 }
 
@@ -79,13 +89,10 @@ BlockHeaderType second_scrypt_header()
 // dgb_header_disposition() -> REJECT. validate_and_append must drop it.
 BlockHeaderType unknown_algo_header()
 {
-    BlockHeaderType h = genesis_header();
+    BlockHeaderType h = satisfiable_scrypt_header(0, 1231006505u);
     h.m_version = 1 | 0x0100;  // nibble 1 == ALGO_UNKNOWN
     return h;
 }
-
-const std::string GENESIS_ID =
-    "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f";
 
 } // namespace
 
@@ -99,35 +106,42 @@ TEST(HeaderIngest, EmptyChainHasNoTip)
 
 // 1. A Scrypt header announced on new_headers is ingested through
 //    make_header_sample + validate_and_append: the chain grows and tip_hash()
-//    is the header's sha256d block id (the well-known genesis hash).
+//    is the header's sha256d block id. The live scrypt PoW gate accepts it
+//    because the fixture carries genuine (easy-target) PoW.
 TEST(HeaderIngest, AnnouncedScryptHeaderIsIngested)
 {
     HeaderChain chain;
     dgb::interfaces::Node node;
     auto sub = wire_header_ingest(node, chain);
 
-    node.new_headers.happened(std::vector<BlockHeaderType>{ genesis_header() });
+    BlockHeaderType h = satisfiable_scrypt_header(0, 1231006505u);
+    node.new_headers.happened(std::vector<BlockHeaderType>{ h });
 
     ASSERT_TRUE(chain.tip_height().has_value());
     ASSERT_TRUE(chain.tip_hash().has_value());
-    EXPECT_EQ(u256_be_display_hex(*chain.tip_hash()), GENESIS_ID);
+    EXPECT_EQ(u256_be_display_hex(*chain.tip_hash()),
+              u256_be_display_hex(make_header_sample(h).block_hash));
 }
 
 // 2. A multi-header batch is ingested in arrival order: the tip is the LAST
 //    header, and the chain grew by the full batch length (height delta == 1
-//    versus a single-header chain).
+//    versus a single-header chain). The second header's nTime is strictly
+//    greater (MTP monotonicity gate) and its nonce-search seed distinct, so it
+//    is a different, independently-satisfiable Scrypt block.
 TEST(HeaderIngest, BatchIngestedInArrivalOrder)
 {
+    BlockHeaderType h1 = satisfiable_scrypt_header(0, 1231006505u);
+    BlockHeaderType h2 = satisfiable_scrypt_header(1000, 1231006506u);
+
     HeaderChain one;
     dgb::interfaces::Node node_one;
     auto sub_one = wire_header_ingest(node_one, one);
-    node_one.new_headers.happened(std::vector<BlockHeaderType>{ genesis_header() });
+    node_one.new_headers.happened(std::vector<BlockHeaderType>{ h1 });
 
     HeaderChain two;
     dgb::interfaces::Node node_two;
     auto sub_two = wire_header_ingest(node_two, two);
-    node_two.new_headers.happened(
-        std::vector<BlockHeaderType>{ genesis_header(), second_scrypt_header() });
+    node_two.new_headers.happened(std::vector<BlockHeaderType>{ h1, h2 });
 
     ASSERT_TRUE(one.tip_height().has_value());
     ASSERT_TRUE(two.tip_height().has_value());
@@ -136,8 +150,9 @@ TEST(HeaderIngest, BatchIngestedInArrivalOrder)
     // Tip is the LAST header of the batch, not the first.
     ASSERT_TRUE(two.tip_hash().has_value());
     EXPECT_EQ(u256_be_display_hex(*two.tip_hash()),
-              u256_be_display_hex(make_header_sample(second_scrypt_header()).block_hash));
-    EXPECT_NE(u256_be_display_hex(*two.tip_hash()), GENESIS_ID);
+              u256_be_display_hex(make_header_sample(h2).block_hash));
+    EXPECT_NE(u256_be_display_hex(*two.tip_hash()),
+              u256_be_display_hex(make_header_sample(h1).block_hash));
 }
 
 // 3. The connector is the driver: a node with NO ingest subscription appends
@@ -147,7 +162,8 @@ TEST(HeaderIngest, UnwiredNodeIngestsNothing)
     HeaderChain chain;
     dgb::interfaces::Node node;  // deliberately NOT wired
 
-    node.new_headers.happened(std::vector<BlockHeaderType>{ genesis_header() });
+    node.new_headers.happened(
+        std::vector<BlockHeaderType>{ satisfiable_scrypt_header(0, 1231006505u) });
 
     EXPECT_FALSE(chain.tip_height().has_value());
     EXPECT_FALSE(chain.tip_hash().has_value());

--- a/src/impl/dgb/test/header_sample_build_test.cpp
+++ b/src/impl/dgb/test/header_sample_build_test.cpp
@@ -25,8 +25,13 @@
 #include <string>
 
 #include <core/uint256.hpp>
+#include <span>
+
+#include <core/pack.hpp>
+#include <core/pow.hpp>
 
 #include "../coin/block.hpp"
+#include "../coin/dgb_block_algo.hpp"
 #include "../coin/hash_format.hpp"
 #include "../coin/header_sample_build.hpp"
 
@@ -82,15 +87,51 @@ TEST(MakeHeaderSample, GenesisBlockHash)
         "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
 }
 
-// Scalar fields pass through verbatim; target decodes the header's nBits;
-// pow_hash stays 0 (scrypt digest lands at the daemon-port boundary).
-TEST(MakeHeaderSample, ScalarFieldsAndTargetAndPowHash)
+// Scalar fields pass through verbatim; target decodes the header's nBits.
+TEST(MakeHeaderSample, ScalarFieldsAndTarget)
 {
     HeaderSample s = make_header_sample(genesis_header());
     EXPECT_EQ(s.n_version, 1);
     EXPECT_EQ(s.n_time, 1231006505);
     EXPECT_EQ(u256_be_display_hex(s.target),
         "00000000ffff0000000000000000000000000000000000000000000000000000");
+}
+
+// A Scrypt-disposition header (algo bits == 0; the Bitcoin-genesis v1 used here
+// qualifies under DGB's GetAlgo mask) gets pow_hash = scrypt(80-byte header),
+// stored little-endian like target. Self-consistency KAT: the field must equal
+// an INDEPENDENT scrypt over the same canonical serialization routed through the
+// SAME from_le_bytes convention -- proving make_header_sample wires header bytes
+// -> core::pow::scrypt -> pow_hash with no byte-order drift, and that the
+// previously-stubbed (== 0) field is now live for the satisfaction gate.
+TEST(MakeHeaderSample, ScryptHeaderPowHashFilled)
+{
+    BlockHeaderType h = genesis_header();
+    ASSERT_TRUE(::dgb::coin::is_scrypt_header(static_cast<int32_t>(h.m_version)));
+
+    HeaderSample s = make_header_sample(h);
+
+    auto packed = pack(h);
+    auto tspan = packed.get_span();
+    uint256 ph = core::pow::scrypt(std::span<const unsigned char>(
+        reinterpret_cast<const unsigned char*>(tspan.data()), tspan.size()));
+    dgb::coin::u256 expected = dgb::coin::u256::from_le_bytes(
+        reinterpret_cast<const unsigned char*>(ph.begin()));
+
+    EXPECT_EQ(u256_be_display_hex(s.pow_hash), u256_be_display_hex(expected));
+    EXPECT_FALSE(s.pow_hash.is_zero());
+}
+
+// A non-Scrypt header (SHA256D algo bits) is accept-by-continuity in V36; its
+// PoW gate never runs, so make_header_sample leaves pow_hash == 0 rather than
+// computing a scrypt digest nothing reads.
+TEST(MakeHeaderSample, NonScryptHeaderPowHashZero)
+{
+    BlockHeaderType h = genesis_header();
+    h.m_version = ::dgb::coin::DGB_BLOCK_VERSION_SHA256D;  // 0x0200 algo bits
+    ASSERT_FALSE(::dgb::coin::is_scrypt_header(static_cast<int32_t>(h.m_version)));
+
+    HeaderSample s = make_header_sample(h);
     EXPECT_TRUE(s.pow_hash.is_zero());
 }
 


### PR DESCRIPTION
Lands the **scrypt(header) -> pow_hash** fill deferred from the #227 skeleton slice (integrator-approved NEXT, ref msgid <178189274397...@morisguide.com>). Fenced to `src/impl/dgb/`.

## What
- `make_header_sample` computes `scrypt(80-byte header)` into `HeaderSample::pow_hash` for **Scrypt-algo headers only** (algo nibble 0 == SCRYPT); non-Scrypt continuity (and reject-disposition) headers stay `pow_hash == 0` (their gate never reads it).
- Digest stored little-endian via `u256::from_le_bytes` — same convention as `target` — so `validate_and_append`s satisfaction gate (`pow_hash <= target`) compares them directly. No shape change (same u256), so this is a no-op rewire of the previously-stubbed field going live.

## Why this is the right layer
`make_header_sample` is the embedded P2P header-download boundary; the satisfaction gate already lived in `validate_and_append` keyed on the `VALIDATE_SCRYPT` disposition and was a no-op only because `pow_hash` was always 0. Filling it here turns the gate live on the ingest path — exactly the deferral the #227 comment described.

## Tests (all local green)
- `dgb_header_sample_build_test` 7/7 — +2: Scrypt pow_hash **self-consistency KAT** (field == an independent scrypt over the same canonical serialization through the same `from_le_bytes`), and non-Scrypt stays 0. Genesis(v1) is a Scrypt header under DGBs GetAlgo mask, so its assertion moved from `is_zero()` to the live digest.
- `dgb_header_ingest_test` 5/5 — fixtures now carry **genuine easy-target PoW** (nonce searched until `scrypt(header) <= target`, ~2 evals) so the wiring assertions stay deterministic against the now-live gate. sha256d block-id KAT (Bitcoin genesis) remains in `dgb_header_sample_build_test`.
- `header_chain_test` 35/35 unaffected (satisfaction gate untouched; it still fires with `pow_limit==0` per its contract).

## Scope / safety
- 3 files, all `src/impl/dgb/`. No shared base, no `bitcoin_family`, no CMake, no `build.yml` (both targets already allowlisted, #143 trap clear). GPG-signed, no attribution.
- **HOLD merge** — fenced auto-merge on full-matrix green only. Stacks on #230 (`make_header_sample` lives there); **retarget base to master** once #227/#230 land.
- p2pool-merged-v36 compat: this is the daemon-independent CheckProofOfWork second half (hash <= declared target), which the reference also enforces — no divergence.