### PR TITLE
nmc(P1 PE 2b-0): pin testnet genesis + chain_id=1 in NMCChainParams

### DIFF
--- a/src/impl/nmc/coin/header_chain.hpp
+++ b/src/impl/nmc/coin/header_chain.hpp
@@ -526,7 +526,7 @@ struct NMCChainParams {
     int32_t testnet_auxpow_activation_height{-1}; // TO-CONFIRM: testnet analog (unpinned sentinel)
     // aux_chain_id: the chain id this NMC instance claims in the parent's
     //   merged-mining tree. -1 = unpinned sentinel.
-    int32_t aux_chain_id{-1};               // TO-CONFIRM: Namecoin mainnet chain id (unpinned)
+    int32_t aux_chain_id{1};                // Namecoin nAuxpowChainId = 0x0001 (both nets); see chainparams.cpp
 
     int64_t difficulty_adjustment_interval() const {
         return target_timespan / target_spacing;
@@ -565,11 +565,30 @@ struct NMCChainParams {
         p.target_spacing  = TESTNET_TARGET_SPACING;
         p.allow_min_difficulty = TESTNET_ALLOW_MIN_DIFF;
         p.no_retargeting = false;
-        // TO-CONFIRM: Namecoin testnet powLimit (placeholder = BTC default).
+        // Namecoin testnet powLimit = Bitcoin default (chainparams.cpp CTestNetParams).
         p.pow_limit.SetHex("00000000ffff0000000000000000000000000000000000000000000000000000");
-        // TO-CONFIRM: Namecoin testnet genesis hash (placeholder = null).
-        p.genesis_hash.SetNull();
+        // Genesis PINNED against a live namecoind on namecoin testnet
+        // (getblockhash 0 / getblockheader, 2026-06-19). block_hash(genesis_header)
+        // re-derives this value (nmc_auxpow_wire_test GenesisTestnet KAT).
+        p.genesis_hash.SetHex("00000007199508e34a9ff81e6ec0c477a4cccff2a4767a8eee39c11db367b008");
         return p;
+    }
+
+    /// Namecoin testnet genesis header (the 80-byte parent the HeaderChain seeds
+    /// at height 0). Fields PINNED against a live namecoind getblockheader on
+    /// namecoin testnet, 2026-06-19:
+    ///   version=1  time=1296688602  bits=0x1d07fff8  nonce=384568319
+    ///   merkleroot=4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b
+    /// SHA256d(header) == genesis_hash() above (verified locally + by KAT).
+    static BlockHeaderType testnet_genesis_header() {
+        BlockHeaderType g;
+        g.m_previous_block.SetNull();
+        g.m_version = 1;
+        g.m_merkle_root.SetHex("4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b");
+        g.m_timestamp = 1296688602;
+        g.m_bits      = 0x1d07fff8;
+        g.m_nonce     = 384568319;
+        return g;
     }
 };
 

--- a/src/impl/nmc/test/auxpow_wire_test.cpp
+++ b/src/impl/nmc/test/auxpow_wire_test.cpp
@@ -258,4 +258,29 @@ TEST(NmcP1AuxPowWire, MainnetBlock829949RoundTrip)
     EXPECT_LT(80 + auxlen, total);
 }
 
+// ---------------------------------------------------------------------------
+// Genesis pin KAT (P1 PE 2b-0). NMCChainParams::testnet_genesis_header() is the
+// 80-byte parent the embedded HeaderChain seeds at height 0. Its SHA256d MUST
+// reproduce NMCChainParams::testnet().genesis_hash, which was pinned against a
+// live namecoind (getblockhash 0 / getblockheader) on namecoin testnet,
+// 2026-06-19. A wrong field (endianness, bits, nonce, merkleroot) makes the
+// re-derived hash diverge from the daemon-sourced value rather than be mirrored
+// -- the expected hash is external truth, not self-derived from the header.
+// chain_id is also pinned to Namecoin's nAuxpowChainId (0x0001).
+// ---------------------------------------------------------------------------
+TEST(NmcP1Genesis, TestnetHeaderRederivesPinnedHash)
+{
+    const auto params = nmc::coin::NMCChainParams::testnet();
+    const auto g      = nmc::coin::NMCChainParams::testnet_genesis_header();
+
+    EXPECT_TRUE(g.m_previous_block.IsNull());
+    EXPECT_EQ(nmc::coin::block_hash(g), params.genesis_hash);
+
+    uint256 expect;
+    expect.SetHex("00000007199508e34a9ff81e6ec0c477a4cccff2a4767a8eee39c11db367b008");
+    EXPECT_EQ(params.genesis_hash, expect);
+
+    EXPECT_EQ(params.aux_chain_id, 1);  // Namecoin nAuxpowChainId = 0x0001
+}
+
 }  // namespace


### PR DESCRIPTION
## NMC P1 PE — slice 2b-0 (genesis pin, prerequisite to the cid=1 registration block)

Replaces the `TO-CONFIRM` placeholders in `NMCChainParams::testnet()` with the **real Namecoin testnet genesis**, pinned against a **live namecoind** on .140 (`getblockhash 0` / `getblockheader`, 2026-06-19) and re-derived locally:

| field | value |
|---|---|
| version | 1 |
| time | 1296688602 |
| bits | 0x1d07fff8 |
| nonce | 384568319 |
| merkleroot | 4a5e1e4b…deda33b |
| **genesis hash** | 00000007199508e34a9ff81e6ec0c477a4cccff2a4767a8eee39c11db367b008 |

Also adds `NMCChainParams::testnet_genesis_header()` (the 80-byte parent the embedded HeaderChain will seed at height 0) and pins `aux_chain_id = 1` (Namecoin `nAuxpowChainId = 0x0001`, both nets) — the cid the registration block (2b) keys on.

### Test
New `NmcP1Genesis.TestnetHeaderRederivesPinnedHash` KAT re-derives the pinned hash via `block_hash()` — the expected hash is **external daemon truth**, not self-derived from the header. Rides the allowlisted `nmc_auxpow_wire_test` exe → **no build.yml change**. `nmc_auxpow_wire_test`: 3/3 PASS.

### Fence / isolation
- Diff confined to **src/impl/nmc/** (`git diff --name-only`: coin/header_chain.hpp, test/auxpow_wire_test.cpp). No shared seam, no other coin tree, no CI change.
- chain_id is an **isolation primitive** (bucket-1) — pinned per-coin, never unified.

### Known limitation (carried to 2b)
Mainnet genesis stays `TO-CONFIRM`: pinning needs a namecoin **MAINNET** node. .140 is currently on **testnet, height 0** (card237 recorded it as a synced mainnet node — it has since been repointed). The 2e won-block proof for the mainnet path needs a mainnet namecoind back online.

Signed, zero-attribution. NMC-tree-only → auto-merge-eligible; I do not self-merge.