### PR TITLE
ltc: split advertised protocol version from accept-floor (3600/3301)

### DIFF
--- a/src/core/coin_params.hpp
+++ b/src/core/coin_params.hpp
@@ -61,6 +61,7 @@ struct CoinParams
     uint32_t target_lookbehind = 0;          // shares to look back for target calc
     uint32_t spread = 0;                     // PPLNS spread multiplier
     uint32_t minimum_protocol_version = 0;   // min p2pool protocol version
+    uint32_t advertised_protocol_version = 0; // version we ADVERTISE (our capability); >= floor, separate from accept-floor per p2pool
     uint32_t block_max_size = 0;
     uint32_t block_max_weight = 0;
 

--- a/src/impl/ltc/node.cpp
+++ b/src/impl/ltc/node.cpp
@@ -247,7 +247,7 @@ int NodeImpl::get_verified_count() const { return get_tracker_snapshot().verifie
 void NodeImpl::send_version(peer_ptr peer)
 {
     auto rmsg = ltc::message_version::make_raw(
-        m_tracker.m_params->minimum_protocol_version,
+        m_tracker.m_params->advertised_protocol_version,  // advertise our V36 capability, NOT the accept-floor (handle_version:328 keeps floor)
         1,                                    // services
         addr_t{1, peer->addr()},              // addr_to (the remote)
         addr_t{1, NetService{"0.0.0.0", m_tracker.m_params->p2p_port}}, // addr_from (us)

--- a/src/impl/ltc/params.hpp
+++ b/src/impl/ltc/params.hpp
@@ -62,6 +62,7 @@ inline core::CoinParams make_coin_params(bool testnet)
     p.target_lookbehind        = 200;
     p.spread                   = 3;
     p.minimum_protocol_version = 3301;  // accept v35 (3502) peers for v35->v36 AutoRatchet crossing
+    p.advertised_protocol_version = 3600;  // advertise V36 capability; >= .82 latched min (3503) so crossing peers accept us
     p.block_max_size           = 1000000;
     p.block_max_weight         = 4000000;
 


### PR DESCRIPTION
## proto-version split: advertised (3600) vs accept-floor (3301)

Clean, pure-master follow-up to the live-deployed crossing-soak binary (`842ae99b`). This is the upstreamable form of the fix already running on the #97 soak.

### Rationale
`send_version` was advertising our *accept-floor* (`min_protocol_version`) rather than a higher *advertised* protocol version. At high v36 saturation a crossing peer (e.g. `.82`) whose own accept-floor has ratcheted up rejects us as "peer too old" — even though we are fully V36-capable. The split decouples the two:

- **advertised_protocol_version = 3600** — what we announce in `send_version` (our true capability).
- **accept-floor = 3301** — the floor we still *accept* inbound peers at, so we never drop a legitimately older crossing peer mid-soak.

Diff is 3 lines across 3 files: `src/core/coin_params.hpp` (+1 field), `src/impl/ltc/node.cpp` (advertise the new field), `src/impl/ltc/params.hpp` (+1 const). Base `df9cfb0f`.

### Evidence
- **BuildID 842ae99b** — matches the binary live on the soak.
- **LTC ctest: 7/7 green** (Linux x86_64).
- **ASYNC-DEFER string-gate = 1** (event-loop starvation fix present in tree, confirming non-stale build).

### Merge note
This is **consensus-bearing** (proto-version-gate values). Per policy it is NOT auto-merged — integrator surfaces it for a separate explicit operator merge-tap once full CI is green. This PR is for visibility + CI only; it does not touch the running soak (already on the deployed `842ae99b`).
