### PR TITLE
test: deflake middleware error-taxonomy smoke (disable retry in fixture)

### DIFF
--- a/web-static/sharechain-explorer/tests/unit/smoke.test.ts
+++ b/web-static/sharechain-explorer/tests/unit/smoke.test.ts
@@ -141,13 +141,18 @@ test('Middleware chain: error-taxonomy normalises thrown errors', async () => {
     ...mockTransport(),
     fetchWindow: async () => { throw { status: 429, retryAfter: 2000 }; },
   };
-  // Bound retries and skip timeout so this test fences in ~ms, not the
-  // D7 unbounded production default.
+  // This test's subject is error-taxonomy normalisation, not retry/timeout.
+  // Disable both transport retry and timeout so the normalised error
+  // propagates immediately. (With retry enabled, the chain honours the
+  // server-supplied Retry-After of 2000ms — Math.max(delay, retryAfterMs)
+  // in retry.ts — and sleeps the full 2s before the final throw, pushing
+  // this test onto the CI per-test deadline. maxAttempts:1 still performs
+  // one retry, so it does not avoid the sleep.)
   await host.init({
     kind: 'shared-core',
     transport: angryTransport,
     plugins: {
-      'core.transport.retry': { baseMs: 1, capMs: 2, multiplier: 2, jitterPct: 0, maxAttempts: 1 },
+      'core.transport.retry': false,
       'core.transport.timeout': false,
     },
   });


### PR DESCRIPTION
Fixes the Web-static verify flake blocking the DGB embedded-ingest stack (#227->#230).

Root cause (explorer-merged triage): smoke.test.ts "Middleware chain: error-taxonomy normalises thrown errors" throws a 429 with retryAfter:2000 while leaving core.transport.retry enabled at maxAttempts:1. retry.ts honors server Retry-After, so the single retry sleeps the full 2000ms and parks on the 2s per-test deadline — deterministic, not flaky. Product code is correct; only the fixture was wrong.

Fix: the test subject is error normalisation, not retry, so retry is disabled for this fixture. rate_limited / retryAfterMs===2000 assertions still hold; runtime drops from 2007ms to ~ms.

Verified on workstation: full npm run verify green (257 tests, 245 pass, 0 fail), no test over 1500ms. GPG-signed, off origin/master.

SHA: d67e7c854258ac543af8db80b593439959be2264

EXECUTOR: integrator (merge on operator approval)