### PR TITLE
nmc: P1 PE 2b-i — register NMC P2P port in host get_coin_p2p_port (RPC-first cid=1)

### DIFF
--- a/src/c2pool/c2pool_refactored.cpp
+++ b/src/c2pool/c2pool_refactored.cpp
@@ -677,6 +677,7 @@ int main(int argc, char* argv[]) {
     auto get_coin_p2p_port = [](const std::string& symbol, bool testnet) -> int {
         if (symbol == "LTC"   || symbol == "ltc")   return testnet ? 19335 : 9333;
         if (symbol == "DOGE"  || symbol == "doge")  return testnet ? 44556 : 22556;
+        if (symbol == "NMC"   || symbol == "nmc")   return testnet ? 18334 : 8334;   // SSOT: src/impl/nmc/coin/chain_seeds.hpp (namecoind addrman)
         if (symbol == "BTC"   || symbol == "btc")   return testnet ? 18333 : 8333;
         if (symbol == "DGB"   || symbol == "dgb")   return testnet ? 12026 : 12024;
         if (symbol == "PEP"   || symbol == "pep")   return testnet ? 44874 : 33874;


### PR DESCRIPTION
P1 PE leg **2b-i** (RPC-first ordering). Single additive host hunk: NMC well-known P2P port (8334 mainnet / 18334 testnet) in get_coin_p2p_port.

**Why minimal:** the chain_id-generic merged path already admits NMC on cid=1 — `--merged NMC:1:host:port:user:pass` parses generically (spec parser stoul(parts[1])) and registers via add_chain + submitblock RPC-fallback with no host change. This commit adds the only host hunk the RPC-first leg needs.

**Sourcing:** port from src/impl/nmc/coin/chain_seeds.hpp SSOT (harvested live from a namecoind addrman), not memory.

**Deferred (by design):** get_chain_p2p_prefix NMC magic case — network pchMessageStart not yet pinned in nmc SSOT (daemon-gate); the fast P2P relay leg lands with the embedded backend in 2b-ii.

DOGE(98)/LTC byte-isolated, no build.yml. Shared host file -> NOT auto-merge-fenced; operator tap on full-rollup green. I do not self-merge.