### PR TITLE
bch(M5): handshake-gated auto-getheaders kick — embedded header-sync self-start

### DIFF
--- a/src/c2pool/main_bch.cpp
+++ b/src/c2pool/main_bch.cpp
@@ -68,7 +68,7 @@ void print_banner(const char* argv0)
     std::cout
         << "c2pool-bch " << C2POOL_VERSION << " — Bitcoin Cash (SHA256d, V36)\n\n"
         << "Usage: " << argv0 << " [--version] [--help] [--selftest]\n"
-        << "       " << argv0 << " --ibd [--testnet] [--near-tip] [--peer HOST:PORT] [--max-seconds N]\n"
+        << "       " << argv0 << " --ibd [--testnet] [--near-tip] [--auto-kick] [--peer HOST:PORT] [--max-seconds N]\n"
         << "       " << argv0 << " --leg-c-capture [--rpc-conf PATH]\n"
         << "       " << argv0 << " --leg-c-capture-p2p [--rpc-conf PATH] [--p2p-port N]\n\n"
         << "Status: M5 pool/sharechain + embedded-daemon assembly live.\n"
@@ -123,7 +123,7 @@ int run_selftest()
 // handshake is up, and logs the evidence tuple every TICK seconds until the
 // chain catches the peer tip (with no in-flight blocks) or the deadline fires.
 int run_ibd(const std::string& host, uint16_t port, bool testnet, uint32_t max_seconds,
-             bool near_tip)
+             bool near_tip, bool auto_kick)
 {
     boost::asio::io_context ctx;
 
@@ -157,6 +157,16 @@ int run_ibd(const std::string& host, uint16_t port, bool testnet, uint32_t max_s
     else
         daemon.start_ibd(peer);
 
+    // --auto-kick proves the handshake-gated self-start: arm the embedded
+    // header-sync kick on the P2P node and DO NOT poll ibd_kick_sync(). If the
+    // synced height advances, the verack handler self-issued the initial
+    // getheaders on-wire with no external kick (production run() contract).
+    if (auto_kick) {
+        daemon.arm_auto_getheaders();
+        std::cout << "[ibd] auto-kick armed — header sync self-starts at handshake"
+                     " (no manual getheaders poll)\n";
+    }
+
     const uint32_t init_height = daemon.ibd_synced_height();
     std::cout << "[ibd] read-only sync vs " << host << ":" << port
               << (testnet ? " (testnet)" : " (mainnet)")
@@ -172,10 +182,16 @@ int run_ibd(const std::string& host, uint16_t port, bool testnet, uint32_t max_s
     tick.start(TICK, [&]() {
         elapsed += TICK;
         if (!kicked && daemon.ibd_handshake_ready()) {
-            daemon.ibd_kick_sync();
+            if (!auto_kick) {
+                daemon.ibd_kick_sync();
+                std::cout << "[ibd] handshake up; getheaders kicked from height "
+                          << daemon.ibd_synced_height() << "\n";
+            } else {
+                std::cout << "[ibd] handshake up; AUTO getheaders self-started"
+                             " (no manual kick) from height "
+                          << daemon.ibd_synced_height() << "\n";
+            }
             kicked = true;
-            std::cout << "[ibd] handshake up; getheaders kicked from height "
-                      << daemon.ibd_synced_height() << "\n";
         }
         const uint32_t h   = daemon.ibd_synced_height();
         const uint32_t tip = daemon.ibd_peer_tip();
@@ -462,6 +478,7 @@ int main(int argc, char** argv)
     std::string rpc_conf;
     bool testnet = false;
     bool near_tip = false;
+    bool auto_kick = false;
     std::string host = "192.168.86.110";   // VM300 bchn-bch
     uint16_t port = 8333;
     uint32_t max_seconds = 600;
@@ -480,6 +497,7 @@ int main(int argc, char** argv)
         if (std::strcmp(argv[i], "--rpc-conf") == 0 && i + 1 < argc) rpc_conf = argv[++i];
         if (std::strcmp(argv[i], "--testnet") == 0) { testnet = true; port = 18333; }
         if (std::strcmp(argv[i], "--near-tip") == 0) near_tip = true;
+        if (std::strcmp(argv[i], "--auto-kick") == 0) auto_kick = true;
         if (std::strcmp(argv[i], "--peer") == 0 && i + 1 < argc) {
             std::string hp = argv[++i];
             const auto c = hp.rfind(char(58));  // ASCII colon
@@ -515,7 +533,7 @@ int main(int argc, char** argv)
     }
 
     if (want_ibd)
-        return run_ibd(host, port, testnet, max_seconds, near_tip);
+        return run_ibd(host, port, testnet, max_seconds, near_tip, auto_kick);
 
     // Default / --selftest: drive the live ABLA budget path, then exit.
     return run_selftest();

--- a/src/impl/bch/coin/embedded_daemon.hpp
+++ b/src/impl/bch/coin/embedded_daemon.hpp
@@ -182,6 +182,15 @@ public:
         m_node.send_getheaders(70016, m_chain.get_locator(), uint256::ZERO);
     }
 
+    /// Arm the handshake-gated header-sync self-start on the harness P2P node
+    /// (the same enable as the production maybe_start_p2p path). With this set,
+    /// the verack handler self-issues the initial getheaders -- the --ibd
+    /// harness needs NO ibd_kick_sync() poll. Call after start_ibd*/start_p2p.
+    void arm_auto_getheaders() {
+        if (auto* p2p = m_node.p2p())
+            p2p->enable_auto_getheaders();
+    }
+
     /// NETWORK-FREE assembly of the in-process daemon graph: close the ABLA
     /// size loop (full_block --> feed --> tracker --> EmbeddedCoinNode budget)
     /// and build the CoinNode seam (core::coin::ICoinNode) embedded-primary.
@@ -255,6 +264,8 @@ public:
             return false;
         m_node.start_p2p(peer);           // embedded BCHN P2P relay/IBD transport
         bind_locator_provider();          // HeaderChain back-off locator for ContinueSync
+        if (auto* p2p = m_node.p2p())     // self-start IBD: kick getheaders at handshake
+            p2p->enable_auto_getheaders();
         return true;
     }
 

--- a/src/impl/bch/coin/p2p_node.hpp
+++ b/src/impl/bch/coin/p2p_node.hpp
@@ -130,6 +130,12 @@ private:
     std::chrono::steady_clock::time_point m_connected_at{std::chrono::steady_clock::now()};
     // BIP 35: request full mempool inventory after handshake
     bool m_request_mempool_on_connect{false};
+    // Embedded header-sync self-start: when set, the handshake completion
+    // (verack) self-issues the initial getheaders using the HeaderChain
+    // back-off locator, so the embedded P2P node drives IBD without an
+    // external getheaders kick. Off by default: tests that drive header sync
+    // manually (and the BCHN-RPC fallback path) keep the prior behaviour.
+    bool m_auto_getheaders_on_handshake{false};
     // Compact block reconstruction state: pending compact block awaiting blocktxn
     std::unique_ptr<CompactBlock> m_pending_cmpct;
     std::vector<uint32_t> m_pending_missing_indexes;
@@ -440,6 +446,13 @@ public:
     /// Call after UTXO is initialized so incoming txs can have fees computed.
     void enable_mempool_request() { m_request_mempool_on_connect = true; }
 
+    /// Enable embedded header-sync self-start: the handshake-complete (verack)
+    /// path self-issues the initial getheaders from the HeaderChain back-off
+    /// locator. Requires a locator provider (set_locator_provider) for a
+    /// well-anchored kick; without one it falls back to an empty locator
+    /// (peer serves from its best header). Idempotent.
+    void enable_auto_getheaders() { m_auto_getheaders_on_handshake = true; }
+
     /// Relay a pre-serialized block via P2P.
     /// Uses compact block format (BIP 152 v1) for peers that support it,
     /// falling back to full block otherwise.
@@ -668,6 +681,21 @@ private:
                          << " — peer lacks NODE_BLOOM (0x" << std::hex << m_peer_services
                          << std::dec << "), would cause disconnect";
             }
+        }
+
+        // Embedded header-sync self-start. The HeaderChain-backed locator is
+        // anchored at our current tip and carries exponential back-off, so the
+        // peer can find a common ancestor even on a minority fork; with no
+        // provider we send an empty locator (peer serves from its best header).
+        // Mirrors the ContinueSync getheaders policy for the INITIAL batch.
+        if (m_auto_getheaders_on_handshake && m_peer) {
+            std::vector<uint256> locator;
+            if (m_locator_provider)
+                locator = m_locator_provider();
+            send_getheaders(m_peer_version ? m_peer_version : 1,
+                            locator, uint256::ZERO);
+            LOG_INFO << "[" << m_chain_label << "] IBD: auto getheaders kick ("
+                     << locator.size() << "-hash locator)";
         }
     }
 


### PR DESCRIPTION
## Summary
The embedded BCH P2P node now self-starts header sync at handshake. The verack handler self-issues the initial getheaders from the HeaderChain back-off locator when armed, so production run() drives IBD without an external getheaders poll.

- p2p_node.hpp: m_auto_getheaders_on_handshake + enable_auto_getheaders(); verack tail self-issues getheaders (mirrors the ContinueSync locator policy for the INITIAL batch).
- embedded_daemon.hpp: maybe_start_p2p() arms it (gated on configured peer); arm_auto_getheaders() accessor for the harness.
- main_bch.cpp: --auto-kick harness flag — arms the self-start and skips the manual ibd_kick_sync poll.

Off by default: the --ibd evidence harness and manual-drive tests keep prior behaviour; no-peer/RPC-only contract and the BCHN-RPC fallback are untouched.

## Verification
- bch suite 22/22 green (ctest -R ^bch_).
- c2pool-bch binary builds.
- Live VM300 .110:8333 read-only on-wire proof (--auto-kick, NO manual kick): handshake -> AUTO getheaders self-started, synced 955700->956034 (peer tip, advanced=yes), in_flight drained 0, false_evict=0, reissue=0, ABLA cursor 955700->956034.

## Scope
p2pool-merged-v36 surface: NONE (local SPV wire-sync transport only). src/impl/bch + harness only. VM300 read-only (P2P connect issues no qm op). Merge operator-gated.