### PR TITLE
nmc: PE dual-path fallback-leg KAT (submit_aux_block vs P2P relay)

### DIFF
--- a/src/impl/nmc/test/nmc_template_builder_test.cpp
+++ b/src/impl/nmc/test/nmc_template_builder_test.cpp
@@ -361,5 +361,30 @@ TEST(NmcAuxChainEmbedded, SubmitBlockNeverSilentDropOnZeroPeers)
     EXPECT_EQ(backend.get_block_hex("any"), hex);  // hex still cached
 }
 
+// PE dual-path gate (integrator note #3): the FALLBACK leg. submit_block() above
+// is the P2P-primary route; submit_aux_block() is the submitauxblock RPC fallback.
+// In embedded mode there is no daemon to RPC, so the fallback acknowledges (the
+// P2P relay leg is authoritative) WITHOUT claiming a daemon submission - and,
+// crucially, unlike submit_block() it does NOT populate the block-hex cache.
+// This pins the two legs as DISTINCT (P2P-primary cached vs RPC-fallback no-cache),
+// the both-paths-fire gate proven at unit level ahead of the live .140 won-block
+// soak (which is daemon-gated). A coin is not block-viable until both legs exist.
+TEST(NmcAuxChainEmbedded, SubmitAuxBlockFallbackLegIsDistinctFromP2PRelay)
+{
+    HeaderChain chain(params_pinned());
+    Mempool pool;
+    AuxChainEmbedded backend(chain, pool, params_pinned(), nmc_aux_config());
+
+    uint256 aux_hash; aux_hash.SetNull();
+    const std::string auxpow_hex(120, static_cast<char>(0x64));
+
+    // Fallback leg acknowledges: embedded has no daemon, P2P relay is primary,
+    // so the caller is not hard-failed (the block already went out over P2P).
+    EXPECT_TRUE(backend.submit_aux_block(aux_hash, auxpow_hex));
+    // ...but the RPC-fallback leg leaves the P2P submit_block() hex cache UNTOUCHED:
+    // the two broadcaster legs are independent, not aliases of one path.
+    EXPECT_EQ(backend.get_block_hex("any"), std::string(""));
+}
+
 
 } // namespace


### PR DESCRIPTION
Closes the second half of the PE both-paths broadcaster gate (integrator note #3) at unit level.

The P2P-primary leg (submit_block) already had three KATs: no-relay->false, relay->N->true, 0-peers->false (never-silent-drop, BTC #162). This adds the missing FALLBACK leg KAT: submit_aux_block() (submitauxblock RPC path) acknowledges in embedded mode (no daemon; P2P relay authoritative) but leaves the submit_block hex cache UNTOUCHED -> the two legs are independent routes, not aliases.

- Additive to allowlisted nmc_template_builder_test (16->17 green locally)
- Own NMC coin tree only; NO build.yml change, NO shared-host edit
- Cut off origin/master (f9fe01eba), not stacked
- The live dual-path won-block proof (2e) stays daemon-gated on .140 (operator re-auth pending); this is its unit-level precursor.