### PR TITLE
[nmc 2c] generic aux payout chain_id loop across parent trackers (v37 bucket-2)

### DIFF
--- a/src/impl/btc/share_tracker.hpp
+++ b/src/impl/btc/share_tracker.hpp
@@ -19,6 +19,8 @@ inline uint64_t mul128_shift(uint64_t a, uint64_t b, unsigned shift) {
 #endif
 
 #include "share.hpp"
+#include <impl/doge/coin/chain_params.hpp>  // DOGEChainParams::AUXPOW_CHAIN_ID (aux payout diag SSOT)
+#include <impl/nmc/coin/aux_id.hpp>          // nmc::coin::NMC_AUXPOW_CHAIN_ID (v37 bucket-2)
 #include <core/version_gate.hpp>   // SSOT: core::version_gate::is_v36_active
 #include "share_check.hpp"
 #include "config_pool.hpp"
@@ -2413,15 +2415,20 @@ public:
                 }
                 LOG_INFO << "[MERGED-PPLNS]   hash=" << hash_result.GetHex();
 
-                // DOGE payout weights (chain_id=98, with Tier 1/1.5/2 resolution)
-                // This is what actually determines DOGE coinbase outputs.
-                // During death valley, compare address count and keys vs [MERGED-PPLNS].
-                constexpr uint32_t DOGE_CHAIN_ID = 98;
-                uint288 doge_unlimited;
-                doge_unlimited.SetHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-                auto doge_result = get_merged_cumulative_weights(
-                    prev_share_hash, chain_len, doge_unlimited, DOGE_CHAIN_ID);
-                auto classify_doge = [](const std::vector<unsigned char>& s) -> const char* {
+                // Per-aux-chain payout weights (Tier 1/1.5/2 resolution) -- the
+                // distribution that drives each merged child's coinbase outputs.
+                // During death valley, compare address count and keys vs
+                // [MERGED-PPLNS]. chain_id is sourced from each backend's own
+                // params (v37 bucket-2 standardization, note #2): no hardcoded
+                // chain_id literal lives in this shared path.
+                struct AuxPayoutChain { const char* name; uint32_t chain_id; };
+                static constexpr AuxPayoutChain kAuxPayoutChains[] = {
+                    { "DOGE", doge::coin::DOGEChainParams::AUXPOW_CHAIN_ID }, // 0x0062
+                    { "NMC",  nmc::coin::NMC_AUXPOW_CHAIN_ID },               // 0x0001
+                };
+                uint288 aux_unlimited;
+                aux_unlimited.SetHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+                auto classify_aux = [](const std::vector<unsigned char>& s) -> const char* {
                     if (is_merged_key(s)) return "MERGED";
                     if (s.size() == 25 && s[0] == 0x76 && s[1] == 0xa9) return "P2PKH";
                     if (s.size() == 23 && s[0] == 0xa9) return "P2SH";
@@ -2430,19 +2437,24 @@ public:
                     if (s.size() == 34 && s[0] == 0x51 && s[1] == 0x20) return "P2TR-RAW";
                     return "OTHER";
                 };
-                auto doge_miner_w = doge_result.total_weight - doge_result.total_donation_weight;
-                LOG_INFO << "[DOGE-PAYOUT] height=" << height
-                         << " addrs=" << doge_result.weights.size()
-                         << " total_w=" << to_decimal(doge_result.total_weight)
-                         << " don_w=" << to_decimal(doge_result.total_donation_weight);
-                for (const auto& [script, w] : doge_result.weights) {
-                    double pct = 0;
-                    if (!doge_miner_w.IsNull())
-                        pct = (w * 10000 / doge_miner_w).GetLow64() / 100.0;
-                    LOG_INFO << "[DOGE-PAYOUT]   " << classify_doge(script)
-                             << " " << script_to_hex(script).substr(0, 50)
-                             << " w=" << to_decimal(w)
-                             << " pct=" << std::fixed << std::setprecision(2) << pct << "%";
+                for (const auto& aux : kAuxPayoutChains) {
+                    auto aux_result = get_merged_cumulative_weights(
+                        prev_share_hash, chain_len, aux_unlimited, aux.chain_id);
+                    auto aux_miner_w = aux_result.total_weight - aux_result.total_donation_weight;
+                    LOG_INFO << "[" << aux.name << "-PAYOUT] height=" << height
+                             << " chain_id=" << aux.chain_id
+                             << " addrs=" << aux_result.weights.size()
+                             << " total_w=" << to_decimal(aux_result.total_weight)
+                             << " don_w=" << to_decimal(aux_result.total_donation_weight);
+                    for (const auto& [script, w] : aux_result.weights) {
+                        double pct = 0;
+                        if (!aux_miner_w.IsNull())
+                            pct = (w * 10000 / aux_miner_w).GetLow64() / 100.0;
+                        LOG_INFO << "[" << aux.name << "-PAYOUT]   " << classify_aux(script)
+                                 << " " << script_to_hex(script).substr(0, 50)
+                                 << " w=" << to_decimal(w)
+                                 << " pct=" << std::fixed << std::setprecision(2) << pct << "%";
+                    }
                 }
             }
         }

--- a/src/impl/dgb/share_tracker.hpp
+++ b/src/impl/dgb/share_tracker.hpp
@@ -21,6 +21,8 @@ inline uint64_t mul128_shift(uint64_t a, uint64_t b, unsigned shift) {
 #endif
 
 #include "share.hpp"
+#include <impl/doge/coin/chain_params.hpp>  // DOGEChainParams::AUXPOW_CHAIN_ID (aux payout diag SSOT)
+#include <impl/nmc/coin/aux_id.hpp>          // nmc::coin::NMC_AUXPOW_CHAIN_ID (v37 bucket-2)
 #include "share_check.hpp"
 #include "config_pool.hpp"
 
@@ -2476,15 +2478,20 @@ public:
                 }
                 LOG_INFO << "[MERGED-PPLNS]   hash=" << hash_result.GetHex();
 
-                // DOGE payout weights (chain_id=98, with Tier 1/1.5/2 resolution)
-                // This is what actually determines DOGE coinbase outputs.
-                // During death valley, compare address count and keys vs [MERGED-PPLNS].
-                constexpr uint32_t DOGE_CHAIN_ID = 98;
-                uint288 doge_unlimited;
-                doge_unlimited.SetHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-                auto doge_result = get_merged_cumulative_weights(
-                    prev_share_hash, chain_len, doge_unlimited, DOGE_CHAIN_ID);
-                auto classify_doge = [](const std::vector<unsigned char>& s) -> const char* {
+                // Per-aux-chain payout weights (Tier 1/1.5/2 resolution) -- the
+                // distribution that drives each merged child's coinbase outputs.
+                // During death valley, compare address count and keys vs
+                // [MERGED-PPLNS]. chain_id is sourced from each backend's own
+                // params (v37 bucket-2 standardization, note #2): no hardcoded
+                // chain_id literal lives in this shared path.
+                struct AuxPayoutChain { const char* name; uint32_t chain_id; };
+                static constexpr AuxPayoutChain kAuxPayoutChains[] = {
+                    { "DOGE", doge::coin::DOGEChainParams::AUXPOW_CHAIN_ID }, // 0x0062
+                    { "NMC",  nmc::coin::NMC_AUXPOW_CHAIN_ID },               // 0x0001
+                };
+                uint288 aux_unlimited;
+                aux_unlimited.SetHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+                auto classify_aux = [](const std::vector<unsigned char>& s) -> const char* {
                     if (is_merged_key(s)) return "MERGED";
                     if (s.size() == 25 && s[0] == 0x76 && s[1] == 0xa9) return "P2PKH";
                     if (s.size() == 23 && s[0] == 0xa9) return "P2SH";
@@ -2493,19 +2500,24 @@ public:
                     if (s.size() == 34 && s[0] == 0x51 && s[1] == 0x20) return "P2TR-RAW";
                     return "OTHER";
                 };
-                auto doge_miner_w = doge_result.total_weight - doge_result.total_donation_weight;
-                LOG_INFO << "[DOGE-PAYOUT] height=" << height
-                         << " addrs=" << doge_result.weights.size()
-                         << " total_w=" << to_decimal(doge_result.total_weight)
-                         << " don_w=" << to_decimal(doge_result.total_donation_weight);
-                for (const auto& [script, w] : doge_result.weights) {
-                    double pct = 0;
-                    if (!doge_miner_w.IsNull())
-                        pct = (w * 10000 / doge_miner_w).GetLow64() / 100.0;
-                    LOG_INFO << "[DOGE-PAYOUT]   " << classify_doge(script)
-                             << " " << script_to_hex(script).substr(0, 50)
-                             << " w=" << to_decimal(w)
-                             << " pct=" << std::fixed << std::setprecision(2) << pct << "%";
+                for (const auto& aux : kAuxPayoutChains) {
+                    auto aux_result = get_merged_cumulative_weights(
+                        prev_share_hash, chain_len, aux_unlimited, aux.chain_id);
+                    auto aux_miner_w = aux_result.total_weight - aux_result.total_donation_weight;
+                    LOG_INFO << "[" << aux.name << "-PAYOUT] height=" << height
+                             << " chain_id=" << aux.chain_id
+                             << " addrs=" << aux_result.weights.size()
+                             << " total_w=" << to_decimal(aux_result.total_weight)
+                             << " don_w=" << to_decimal(aux_result.total_donation_weight);
+                    for (const auto& [script, w] : aux_result.weights) {
+                        double pct = 0;
+                        if (!aux_miner_w.IsNull())
+                            pct = (w * 10000 / aux_miner_w).GetLow64() / 100.0;
+                        LOG_INFO << "[" << aux.name << "-PAYOUT]   " << classify_aux(script)
+                                 << " " << script_to_hex(script).substr(0, 50)
+                                 << " w=" << to_decimal(w)
+                                 << " pct=" << std::fixed << std::setprecision(2) << pct << "%";
+                    }
                 }
             }
         }

--- a/src/impl/ltc/share_tracker.hpp
+++ b/src/impl/ltc/share_tracker.hpp
@@ -19,6 +19,8 @@ inline uint64_t mul128_shift(uint64_t a, uint64_t b, unsigned shift) {
 #endif
 
 #include "share.hpp"
+#include <impl/doge/coin/chain_params.hpp>  // DOGEChainParams::AUXPOW_CHAIN_ID (aux payout diag SSOT)
+#include <impl/nmc/coin/aux_id.hpp>          // nmc::coin::NMC_AUXPOW_CHAIN_ID (v37 bucket-2)
 #include "share_check.hpp"
 #include "config_pool.hpp"
 
@@ -2471,15 +2473,20 @@ public:
                 }
                 LOG_INFO << "[MERGED-PPLNS]   hash=" << hash_result.GetHex();
 
-                // DOGE payout weights (chain_id=98, with Tier 1/1.5/2 resolution)
-                // This is what actually determines DOGE coinbase outputs.
-                // During death valley, compare address count and keys vs [MERGED-PPLNS].
-                constexpr uint32_t DOGE_CHAIN_ID = 98;
-                uint288 doge_unlimited;
-                doge_unlimited.SetHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-                auto doge_result = get_merged_cumulative_weights(
-                    prev_share_hash, chain_len, doge_unlimited, DOGE_CHAIN_ID);
-                auto classify_doge = [](const std::vector<unsigned char>& s) -> const char* {
+                // Per-aux-chain payout weights (Tier 1/1.5/2 resolution) -- the
+                // distribution that drives each merged child's coinbase outputs.
+                // During death valley, compare address count and keys vs
+                // [MERGED-PPLNS]. chain_id is sourced from each backend's own
+                // params (v37 bucket-2 standardization, note #2): no hardcoded
+                // chain_id literal lives in this shared path.
+                struct AuxPayoutChain { const char* name; uint32_t chain_id; };
+                static constexpr AuxPayoutChain kAuxPayoutChains[] = {
+                    { "DOGE", doge::coin::DOGEChainParams::AUXPOW_CHAIN_ID }, // 0x0062
+                    { "NMC",  nmc::coin::NMC_AUXPOW_CHAIN_ID },               // 0x0001
+                };
+                uint288 aux_unlimited;
+                aux_unlimited.SetHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+                auto classify_aux = [](const std::vector<unsigned char>& s) -> const char* {
                     if (is_merged_key(s)) return "MERGED";
                     if (s.size() == 25 && s[0] == 0x76 && s[1] == 0xa9) return "P2PKH";
                     if (s.size() == 23 && s[0] == 0xa9) return "P2SH";
@@ -2488,19 +2495,24 @@ public:
                     if (s.size() == 34 && s[0] == 0x51 && s[1] == 0x20) return "P2TR-RAW";
                     return "OTHER";
                 };
-                auto doge_miner_w = doge_result.total_weight - doge_result.total_donation_weight;
-                LOG_INFO << "[DOGE-PAYOUT] height=" << height
-                         << " addrs=" << doge_result.weights.size()
-                         << " total_w=" << to_decimal(doge_result.total_weight)
-                         << " don_w=" << to_decimal(doge_result.total_donation_weight);
-                for (const auto& [script, w] : doge_result.weights) {
-                    double pct = 0;
-                    if (!doge_miner_w.IsNull())
-                        pct = (w * 10000 / doge_miner_w).GetLow64() / 100.0;
-                    LOG_INFO << "[DOGE-PAYOUT]   " << classify_doge(script)
-                             << " " << script_to_hex(script).substr(0, 50)
-                             << " w=" << to_decimal(w)
-                             << " pct=" << std::fixed << std::setprecision(2) << pct << "%";
+                for (const auto& aux : kAuxPayoutChains) {
+                    auto aux_result = get_merged_cumulative_weights(
+                        prev_share_hash, chain_len, aux_unlimited, aux.chain_id);
+                    auto aux_miner_w = aux_result.total_weight - aux_result.total_donation_weight;
+                    LOG_INFO << "[" << aux.name << "-PAYOUT] height=" << height
+                             << " chain_id=" << aux.chain_id
+                             << " addrs=" << aux_result.weights.size()
+                             << " total_w=" << to_decimal(aux_result.total_weight)
+                             << " don_w=" << to_decimal(aux_result.total_donation_weight);
+                    for (const auto& [script, w] : aux_result.weights) {
+                        double pct = 0;
+                        if (!aux_miner_w.IsNull())
+                            pct = (w * 10000 / aux_miner_w).GetLow64() / 100.0;
+                        LOG_INFO << "[" << aux.name << "-PAYOUT]   " << classify_aux(script)
+                                 << " " << script_to_hex(script).substr(0, 50)
+                                 << " w=" << to_decimal(w)
+                                 << " pct=" << std::fixed << std::setprecision(2) << pct << "%";
+                    }
                 }
             }
         }

--- a/src/impl/nmc/coin/aux_id.hpp
+++ b/src/impl/nmc/coin/aux_id.hpp
@@ -1,0 +1,20 @@
+#pragma once
+#include <cstdint>
+
+// ---------------------------------------------------------------------------
+// NMC merged-mining chain-id SSOT (v37 bucket-2 standardization, note #2).
+//
+// Lightweight, dependency-free home for the single consensus chain-id constant
+// the parent share trackers need when enumerating aux payout chains, so they
+// need NOT pull the full embedded header_chain.hpp (leveldb/block/transaction)
+// just to read a chain id. NMCChainParams::aux_chain_id defaults to this.
+//
+// Namecoin nAuxpowChainId = 0x0001 on both mainnet and testnet
+// (Namecoin src/chainparams.cpp). NOT DOGE's 0x0062.
+namespace nmc {
+namespace coin {
+
+inline constexpr uint32_t NMC_AUXPOW_CHAIN_ID = 0x0001;
+
+} // namespace coin
+} // namespace nmc

--- a/src/impl/nmc/coin/header_chain.hpp
+++ b/src/impl/nmc/coin/header_chain.hpp
@@ -35,6 +35,7 @@
 
 #include "block.hpp"
 #include "transaction.hpp"
+#include "aux_id.hpp"        // NMC_AUXPOW_CHAIN_ID SSOT
 
 #include <core/uint256.hpp>
 #include <core/pack.hpp>
@@ -533,7 +534,7 @@ struct NMCChainParams {
     int32_t testnet_auxpow_activation_height{-1}; // TO-CONFIRM: testnet analog (unpinned sentinel)
     // aux_chain_id: the chain id this NMC instance claims in the parent's
     //   merged-mining tree. -1 = unpinned sentinel.
-    int32_t aux_chain_id{1};                // Namecoin nAuxpowChainId = 0x0001 (both nets); see chainparams.cpp
+    int32_t aux_chain_id{static_cast<int32_t>(NMC_AUXPOW_CHAIN_ID)};                // Namecoin nAuxpowChainId = 0x0001 (both nets); see chainparams.cpp
 
     int64_t difficulty_adjustment_interval() const {
         return target_timespan / target_spacing;


### PR DESCRIPTION
## NMC P1 PE 2c — generic aux payout chain_id loop (v37 bucket-2 standardization, note #2)

### What
Replaces the three hardcoded `chain_id = 98` literals in the shared aux-payout diagnostic path of `src/impl/{btc,dgb,ltc}/share_tracker.hpp` with a single generic `kAuxPayoutChains[]` enumeration loop, and folds embedded NMC in at cid=1.

### Cross-coin justification (EXCEPTIONAL shared-edit rationale — required by per-coin isolation invariant)
This touches three `src/impl/<coin>/share_tracker.hpp` trees, which is **EXCEPTIONAL, not SAFE-ADDITIVE** under the per-coin isolation invariant. The written rationale:

- The aux-payout chain enumeration is a **v36-native SHARED STRUCTURE** (bucket-2), not an isolation primitive. Standardizing it toward the v37 unified `vector<ParentChainInstance>` shape is the explicit goal; leaving three divergent hardcoded `98`s would force a reconciliation at v37 migration instead of a clean lift.
- **No isolation primitive is touched.** Per-coin PREFIX / IDENTIFIER namespaces are unchanged. This is the shared aux STRUCTURE, not a namespace.
- **chain_id is sourced from each backend's own params, never relocated to a shared literal:**
  - DOGE: `doge::coin::DOGEChainParams::AUXPOW_CHAIN_ID` (0x0062) — canonical source unchanged at `chain_params.hpp:43`
  - NMC : `nmc::coin::NMC_AUXPOW_CHAIN_ID` (0x0001) — new dependency-free `src/impl/nmc/coin/aux_id.hpp` SSOT (Namecoin nAuxpowChainId, mainnet+testnet), so parent trackers need not pull the full embedded `header_chain.hpp` (leveldb/block/transaction) just to read a chain id.
  - The win is **deleting the three `98`s**, not relocating them — no coin-specific literal is reintroduced in any shared path.

### Consensus / parity
- DOGE PPLNS payout-weight path (where this hardcode lived) **preserved** — same chain_id value (0x0062), now sourced symbolically.
- Non-aux coins **unchanged**.

### Merge gate
- Operator-tap class (multi-coin-tree edit) — **do NOT auto-merge / self-merge.**
- Requires full `gh` CI rollup **CLEAN** (not UNSTABLE) on head SHA + all four coin smokes (ltc/doge/dgb/dash) green.

Tagged: v37 bucket-2 standardization (note #2).
