### PR TITLE
nmc(PE-2d/1): CoinBroadcaster::submit_block_raw returns relayed-peer count

### DIFF
--- a/src/c2pool/merged/coin_broadcaster.hpp
+++ b/src/c2pool/merged/coin_broadcaster.hpp
@@ -251,7 +251,11 @@ public:
     }
 
     /// Broadcast raw block bytes to ALL connected peers (parent chain).
-    void submit_block_raw(const std::vector<unsigned char>& block_bytes)
+    /// Relay a raw block to every connected peer. Returns the number of peers
+    /// the block was successfully sent to (0 => NOT broadcast). Embedded aux
+    /// backends rely on this count to honour the never-silent-drop invariant
+    /// (#162): a found block that reached 0 peers must surface as a failure.
+    size_t submit_block_raw(const std::vector<unsigned char>& block_bytes)
     {
         std::lock_guard<std::mutex> lock(m_mutex);
         int sent = 0, failed = 0;
@@ -275,6 +279,7 @@ public:
                      << sent << "/" << (sent + failed) << " peers ("
                      << block_bytes.size() << " bytes)";
         }
+        return static_cast<size_t>(sent);
     }
 
     /// Send inv announcement to ALL connected peers (merged chain relay).

--- a/test/test_coin_broadcaster.cpp
+++ b/test/test_coin_broadcaster.cpp
@@ -500,6 +500,22 @@ TEST(CoinBroadcaster, ConstructionDefaults)
     EXPECT_EQ(bc.connected_count(), 0);
 }
 
+// PE never-silent-drop (#162): with no peers connected, submit_block_raw must
+// report 0 relays so embedded aux backends surface a found block as a failure
+// rather than claiming a phantom broadcast.
+TEST(CoinBroadcaster, SubmitBlockRawNoPeersReturnsZero)
+{
+    boost::asio::io_context ioc;
+    std::vector<std::byte> prefix = {std::byte{0xfd}, std::byte{0xd2},
+                                      std::byte{0xc8}, std::byte{0xf1}};
+    CoinBroadcaster bc(ioc, "LTC", prefix, NetService("192.168.1.1", 19335));
+
+    ASSERT_EQ(bc.connected_count(), 0);
+    std::vector<unsigned char> dummy_block(80, 0x00);
+    EXPECT_EQ(bc.submit_block_raw(dummy_block), 0u)
+        << "no peers => 0 relays => caller must NOT claim broadcast success";
+}
+
 TEST(CoinBroadcaster, ConstructionWithConfig)
 {
     boost::asio::io_context ioc;


### PR DESCRIPTION
## What
`CoinBroadcaster::submit_block_raw` now returns `size_t` = number of peers the block was successfully relayed to (was `void`).

## Why
This is the prerequisite for **NMC PE-2d item (1)** — wiring the embedded NMC `AuxChainEmbedded::set_block_relay` (`BlockRelayFn = size_t(block_hex)`) to a CoinBroadcaster at host init. The backend needs the relayed-peer count to honour the never-silent-drop invariant (#162 / PR #253): a found block that reached **0 peers** must surface as a failure, not a phantom success. The broadcaster already counted `sent` internally but discarded it.

## Scope / safety
- Single shared file `src/c2pool/merged/coin_broadcaster.hpp` + 1 KAT.
- **Backward-compatible**: the only host caller (mm_manager block-relay lambda, c2pool_refactored.cpp:5937) ignores the return value.
- No host-init, no build.yml, no core, no consensus values.
- Non-colliding with the open tap stack (#247 aux_id/header_chain/share_tracker, #251 scripts, #253 nmc/).

## Test
`test_coin_broadcaster` 65/65 PASS (exit 0), +1 KAT `CoinBroadcaster.SubmitBlockRawNoPeersReturnsZero` (no peers => returns 0u). Local build clean.

Shared-tree change → operator-tap, NOT auto-merge. I do not self-merge.