### PR TITLE
bch(config): route donation gate through core::version_gate::is_v36_active (SSOT)

### DIFF
--- a/src/impl/bch/config_pool.hpp
+++ b/src/impl/bch/config_pool.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <core/config.hpp>
+#include <core/version_gate.hpp>   // SSOT: core::version_gate::is_v36_active
 #include <core/fileconfig.hpp>
 #include <core/netaddress.hpp>
 #include <btclibs/util/strencodings.h>
@@ -153,7 +154,7 @@ public:
     // use the combined P2SH 1-of-2 multisig script. Same shape as BTC/LTC.
     static std::vector<unsigned char> get_donation_script(int64_t share_version)
     {
-        if (share_version >= 36)
+        if (core::version_gate::is_v36_active(share_version))
             return {COMBINED_DONATION_SCRIPT.begin(), COMBINED_DONATION_SCRIPT.end()};
         return {DONATION_SCRIPT.begin(), DONATION_SCRIPT.end()};
     }


### PR DESCRIPTION
Residual #3 from the BCH version_gate SSOT sweep: get_donation_script (config_pool.hpp) used a bare `share_version >= 36` literal -- the last un-delegated V36 gate site in the BCH tree.

Verified before routing (per integrator hold): is_v36_active is `return version >= V36_ACTIVATION_VERSION` with V36_ACTIVATION_VERSION = 36 -- byte-for-byte the raw comparison, NO confirmed-state / weighted-activation semantics. The call site (share_version always non-negative) is therefore exactly equivalent. This is a pure SSOT-consistency cleanup, not a consensus-gate change.

Scope: single-coin fenced to src/impl/bch/config_pool.hpp (+include core/version_gate.hpp). Brings donation-script activation in line with the other 27 delegating sites. Syntax-clean (-fsyntax-only, C++20). GPG-signed. Merge operator-gated.