### PR TITLE
dgb: walk-forward getheaders — embedded sync past 2000-header cap

### DIFF
--- a/src/impl/dgb/coin/p2p_node.hpp
+++ b/src/impl/dgb/coin/p2p_node.hpp
@@ -706,6 +706,22 @@ private:
                              << bhash.GetHex().substr(0, 16) << "...";
                 }
             }
+            // Walk-forward sync: a full (non-announcement) batch means the
+            // peer likely has more headers past our new tip. Re-issue
+            // getheaders anchored on the last header received so initial sync
+            // advances past the 2000-header-per-message cap until the peer
+            // returns a short batch (caught up -> empty -> loop terminates).
+            // Producer-transport only, non-consensus.
+            else if (vheaders.size() > 3 && m_peer) {
+                auto packed_tip = pack(vheaders.back());
+                auto tip_hash = Hash(packed_tip.get_span());
+                auto getheaders_msg = message_getheaders::make_raw(
+                    1, {tip_hash}, uint256());
+                m_peer->write(getheaders_msg);
+                LOG_INFO << "[" << m_chain_label << "] Walk-forward getheaders from "
+                         << tip_hash.GetHex().substr(0, 16) << "..."
+                         << " (batch=" << vheaders.size() << ")";
+            }
         }
     }
 


### PR DESCRIPTION
Phase B (NodeP2P producer follow-up to #256). The producer fired new_headers per batch but never re-requested, stalling initial header sync at the per-message 2000-header cap. On a full (non-announcement) batch this re-issues getheaders anchored on the last header received; the loop terminates when the peer returns a short/empty batch (caught up).

Scope: src/impl/dgb/coin/p2p_node.hpp only — producer transport, non-consensus, single-coin. Build c2pool-dgb EXIT=0. HOLD merge (operator tap).