### PR TITLE
nmc(PF): pin auxpow_activation_height per-net from namecoin-core chainparams

### DIFF
--- a/src/impl/nmc/coin/header_chain.hpp
+++ b/src/impl/nmc/coin/header_chain.hpp
@@ -529,8 +529,11 @@ struct NMCChainParams {
     // auxpow_activation_height: the height at/after which a Namecoin block MAY
     //   (and on mainnet, MUST) carry an AuxPow. Historically cited as 19200 on
     //   Namecoin mainnet — but this is left UNBAKED on purpose; -1 = unpinned.
-    int32_t auxpow_activation_height{-1};   // TO-CONFIRM: mainnet ~19200 (unpinned sentinel)
-    int32_t testnet_auxpow_activation_height{-1}; // TO-CONFIRM: testnet analog (unpinned sentinel)
+    // PINNED per-network in mainnet()/testnet() factories below against
+    // namecoin-core src/kernel/chainparams.cpp (consensus.nAuxpowStartHeight):
+    // mainnet=19200, testnet=0, regtest/signet=0. Default -1 = unpinned so a
+    // hand-built Params never claims merge-mining is active off a placeholder.
+    int32_t auxpow_activation_height{-1};   // -1 = unpinned default; pinned per-net in factory
     // aux_chain_id: the chain id this NMC instance claims in the parent's
     //   merged-mining tree. -1 = unpinned sentinel.
     int32_t aux_chain_id{1};                // Namecoin nAuxpowChainId = 0x0001 (both nets); see chainparams.cpp
@@ -566,7 +569,10 @@ struct NMCChainParams {
         // network constant, distinct from the genesis hash which stays
         // TO-CONFIRM pending a mainnet namecoind.)
         p.p2p_magic = {{ 0xf9, 0xbe, 0xb4, 0xfe }};
-        // TO-CONFIRM: activation height + chain id stay unpinned (-1).
+        // PINNED: namecoin-core CMainParams consensus.nAuxpowStartHeight = 19200
+        // (src/kernel/chainparams.cpp). AuxPoW MAY appear at/after height 19200;
+        // chain_id stays 1 (field default, nAuxpowChainId = 0x0001).
+        p.auxpow_activation_height = 19200;
         return p;
     }
 
@@ -587,6 +593,10 @@ struct NMCChainParams {
         // pchMessageStart = { 0xfa, 0xbf, 0xb5, 0xfe } (testnet3 -- matches the
         // pinned testnet3 genesis time=1296688602 above; testnet4 differs).
         p.p2p_magic = {{ 0xfa, 0xbf, 0xb5, 0xfe }};
+        // PINNED: namecoin-core CTestNetParams consensus.nAuxpowStartHeight = 0
+        // (fStrictChainId=false). AuxPoW is active from genesis on testnet, so
+        // is_auxpow_active(0) must be true.
+        p.auxpow_activation_height = 0;
         return p;
     }
 

--- a/src/impl/nmc/test/auxpow_merkle_test.cpp
+++ b/src/impl/nmc/test/auxpow_merkle_test.cpp
@@ -568,6 +568,9 @@ static NMCChainParams params_chain_id_1()
 {
     NMCChainParams p = NMCChainParams::mainnet();
     p.aux_chain_id = 1;
+    // mainnet() now PINS auxpow_activation_height=19200; these fixtures exercise
+    // the unpinned refuse-to-judge gate, so force the sentinel back explicitly.
+    p.auxpow_activation_height = -1;
     return p;
 }
 
@@ -641,22 +644,23 @@ TEST(NmcP1dGate, MissingAuxBitsKeepsProofIncompleteAndRejected)
 // P1e: activation-height admission gate KATs (NmcP1eActivationGate).
 // Exercise HeaderChain::check_activation_gate() - the height-derived MM
 // activation gate, factored like the P1d proof gate so it is testable without
-// the deferred storage path. The production activation height stays the -1
-// sentinel; these fixtures pin a TEST-only height (19200, the historically
-// cited NMC mainnet value) purely to drive the gate - no consensus promotion.
+// the deferred storage path. The production height is now PINNED (mainnet=19200
+// via the factory, against namecoin-core chainparams.cpp); these P1e fixtures
+// still inject a height explicitly to drive every gate branch in isolation.
+// See NmcPFActivationPin for the production-factory pin assertions.
 // ---------------------------------------------------------------------------
 static NMCChainParams params_activation(int32_t act_height)
 {
     NMCChainParams p = NMCChainParams::mainnet();
     p.aux_chain_id = 1;
-    p.auxpow_activation_height = act_height;   // TEST-only pin; production stays -1
+    p.auxpow_activation_height = act_height;   // TEST-only override of the pinned production height
     return p;
 }
 
 TEST(NmcP1eActivationGate, UnpinnedActivationRefusesToJudge)
 {
-    // mainnet() leaves auxpow_activation_height at -1: the gate must refuse
-    // rather than guess, regardless of whether the header carries an AuxPow.
+    // params_chain_id_1() forces auxpow_activation_height to -1 (unpinned): the
+    // gate must refuse rather than guess, regardless of AuxPow presence.
     HeaderChain chain_(params_chain_id_1());
     EXPECT_EQ(chain_.check_activation_gate(50000, /*has_auxpow=*/true),
               HeaderChain::AdmitResult::REJECT_UNPINNED);
@@ -696,6 +700,34 @@ TEST(NmcP1eActivationGate, ActivationBoundaryIsInclusive)
               HeaderChain::AdmitResult::ADMIT);
     EXPECT_EQ(chain_.check_activation_gate(19200, /*has_auxpow=*/false),
               HeaderChain::AdmitResult::REJECT_MISSING_AUXPOW);
+}
+
+// ---------------------------------------------------------------------------
+// PF-conformance: production auxpow_activation_height pin (NmcPFActivationPin).
+// Unlike the P1e gate KATs above (which inject a TEST-only height), these
+// exercise the values baked into the mainnet()/testnet() factories, pinned
+// against namecoin-core src/kernel/chainparams.cpp consensus.nAuxpowStartHeight:
+// mainnet=19200 (CMainParams), testnet=0 (CTestNetParams, MM active from
+// genesis). A regression here means the production pin drifted from source.
+// ---------------------------------------------------------------------------
+TEST(NmcPFActivationPin, MainnetActivatesAt19200)
+{
+    NMCChainParams p = NMCChainParams::mainnet();
+    EXPECT_EQ(p.auxpow_activation_height, 19200);
+    EXPECT_EQ(p.aux_chain_id, 1);               // nAuxpowChainId = 0x0001
+    EXPECT_FALSE(p.is_auxpow_active(19199));     // one below activation: inactive
+    EXPECT_TRUE(p.is_auxpow_active(19200));      // boundary inclusive: active
+    EXPECT_TRUE(p.is_auxpow_active(250000));     // well past activation: active
+}
+
+TEST(NmcPFActivationPin, TestnetActivatesFromGenesis)
+{
+    NMCChainParams p = NMCChainParams::testnet();
+    EXPECT_EQ(p.auxpow_activation_height, 0);
+    // nAuxpowStartHeight=0 / fStrictChainId=false: AuxPoW is active from genesis
+    // on Namecoin testnet, so height 0 must already report active.
+    EXPECT_TRUE(p.is_auxpow_active(0));
+    EXPECT_TRUE(p.is_auxpow_active(1));
 }
 
 


### PR DESCRIPTION
## What
Pins the NMC merge-mining activation height (`auxpow_activation_height`) per-network against the authoritative source, replacing the unpinned `-1` TO-CONFIRM sentinels.

Source: namecoin-core `src/kernel/chainparams.cpp` `consensus.nAuxpowStartHeight` (cloned + verified at-source on workstation, not from memory):
- **mainnet** (CMainParams) = **19200** — AuxPoW MAY appear at/after height 19200
- **testnet** (CTestNetParams) = **0** — AuxPoW active from genesis (fStrictChainId=false)
- regtest/signet = 0 (confirmed, not used by NMC instance yet)

The testnet value is the trap: pinning the testnet analog to 19200 would be wrong by construction (AuxPoW is active from genesis on Namecoin testnet).

## Changes
- `mainnet()`/`testnet()` factories set `auxpow_activation_height` (19200 / 0).
- Removed dead `testnet_auxpow_activation_height` field (no readers).
- `params_chain_id_1()` test fixture forces `-1` explicitly to keep exercising the unpinned refuse-to-judge gate.
- New boundary KATs **NmcPFActivationPin**: mainnet 19199 inactive / 19200 active / 250000 active; testnet height 0 active.

## Verification
- `nmc_auxpow_merkle_test`: 69 -> **71 PASS** (+2 NmcPFActivationPin)
- `nmc_template_builder_test`: **17/17 PASS**
- Fenced to `src/impl/nmc/` only — no core, no host init, no build.yml.

## Merge note
This is a **consensus-value** change. Per standing rule I do NOT self-merge — surface for operator tap once the full CI rollup is CLEAN.