### PR TITLE
dgb(#82): wire won-block P2P-relay PRIMARY arm to live coin-daemon producer

### DIFF
--- a/src/c2pool/main_dgb.cpp
+++ b/src/c2pool/main_dgb.cpp
@@ -249,6 +249,11 @@ int run_node(const core::CoinParams& params, bool testnet,
     // audited rather than silently dropped, and NO malformed block is emitted.
     // Assigned at setup (single-threaded, pre-ioc.run) — the only safe point to
     // touch tracker() off the compute thread.
+    // Declared ahead of the m_on_block_found binding so the won-block P2P-relay
+    // sink below can capture it. Constructed later only when --coin-daemon is
+    // supplied (stays null otherwise -> sink no-ops, RPC fallback still fires).
+    std::unique_ptr<dgb::coin::p2p::NodeP2P<dgb::Config>> coin_p2p;
+
     p2p_node.tracker().m_on_block_found = dgb::coin::make_on_block_found(
         /*reconstruct=*/[](const uint256& share_hash)
             -> std::optional<std::pair<std::vector<unsigned char>, std::string>> {
@@ -257,7 +262,17 @@ int run_node(const core::CoinParams& params, bool testnet,
                          "pending Phase B); not broadcast this build" << std::endl;
             return std::nullopt;
         },
-        /*p2p_relay=*/dgb::coin::P2pRelaySink{},  // no embedded P2P sink yet (guarded)
+        /*p2p_relay=*/[&ioc, &coin_p2p](const std::vector<unsigned char>& block_bytes) {
+            // #82 PRIMARY arm: relay the won block over the embedded coin-daemon
+            // P2P producer. The sink fires from the compute thread, so post the
+            // peer write onto the io thread (NodeP2P is single-thread-confined).
+            // No-op when --coin-daemon is absent (coin_p2p null) — the RPC
+            // fallback below still fires (dual-path rule).
+            if (!coin_p2p) return;
+            io::post(ioc, [&coin_p2p, bytes = block_bytes]() {
+                if (coin_p2p) coin_p2p->submit_block_p2p_raw(bytes);
+            });
+        },
         /*seam=*/&coin_node);                     // external-digibyted submitblock fallback
 
     // ── #82 dual-path won-block CLOSER: miner-facing Stratum standup ───────
@@ -320,7 +335,6 @@ int run_node(const core::CoinParams& params, bool testnet,
     //
     // No behavior change when --coin-daemon is absent: coin_p2p stays null, the
     // consumer seam idles exactly as before this slice.
-    std::unique_ptr<dgb::coin::p2p::NodeP2P<dgb::Config>> coin_p2p;
     io::steady_timer coin_getheaders_timer(ioc);
     if (!coin_daemon.empty()) {
         if (coin_magic.empty())

--- a/src/impl/dgb/coin/p2p_node.hpp
+++ b/src/impl/dgb/coin/p2p_node.hpp
@@ -276,6 +276,25 @@ public:
         }
     }
 
+    // Broadcast an ALREADY-serialized won block to the connected coin daemon as
+    // a `block` P2P message. The #82 won-block dispatcher hands raw block bytes
+    // (the reconstructed blob), so unlike submit_block(BlockType&) this frames
+    // the pre-serialized payload directly — no decode/re-encode round trip. The
+    // embedded P2P-relay (PRIMARY) arm of the dual-path broadcaster binds this.
+    void submit_block_p2p_raw(const std::vector<unsigned char>& raw_block)
+    {
+        if (!m_peer)
+        {
+            LOG_ERROR << "[" << m_chain_label << "] No coin-daemon connection; "
+                         "cannot relay won block over embedded P2P";
+            return;
+        }
+        auto rmsg = std::make_unique<RawMessage>("block", PackStream(raw_block));
+        m_peer->write(rmsg);
+        LOG_INFO << "[" << m_chain_label << "] won-block relayed over embedded P2P ("
+                 << raw_block.size() << " bytes)";
+    }
+
     /// Set callback for received addr messages (peer discovery).
     void set_addr_callback(AddrCallback cb) { m_addr_callback = std::move(cb); }
     /// Set callback for peer's reported chain height (from version message).


### PR DESCRIPTION
## What
Adds `NodeP2P::submit_block_p2p_raw(raw_bytes)` — frames an already-serialized won block as a `block` P2P message and writes it to the connected coin daemon (no decode/re-encode round trip, unlike `submit_block(BlockType&)`).

In `main_dgb run_node`, hoists the `coin_p2p` producer declaration ahead of the `m_on_block_found` binding and binds the dual-path broadcaster `P2pRelaySink` to post `submit_block_p2p_raw` onto the io thread.

## Why now
The live `NodeP2P` producer landed on master (`e5c12cbe7`). The PRIMARY P2P-relay arm of the #82 dual-path broadcaster was previously guarded (`P2pRelaySink{}`) for lack of a live producer to bind — it now has a real sink. RPC fallback leg unchanged (dual-path rule preserved).

## Safety / scope
- **Surface-for-tap, NO behavior change**: the reconstruct closure still returns `nullopt` (faithful gentx reassembly is Phase B embedded), so `broadcast_won_block` is never called with a real block this build.
- Thread-safe: sink fires on the compute thread, posts the peer write onto the io thread (NodeP2P is single-thread-confined).
- Fenced to `src/impl/dgb/coin/p2p_node.hpp` + `src/c2pool/main_dgb.cpp`. No shared-base / bitcoin_family / doge-aux touch.
- Local build: `c2pool-dgb` links EXIT=0.

HOLD merge — operator tap.