### PR TITLE
nmc(PF): pin powLimit + mainnet genesis from namecoin-core (consensus values)

### DIFF
--- a/src/impl/nmc/coin/header_chain.hpp
+++ b/src/impl/nmc/coin/header_chain.hpp
@@ -547,20 +547,23 @@ struct NMCChainParams {
         return height >= auxpow_activation_height;
     }
 
-    /// NMC mainnet params skeleton.
-    /// TO-CONFIRM: pow_limit + genesis_hash below are placeholders copied from
-    /// the Bitcoin-family default; they MUST be replaced with Namecoin's actual
-    /// chainparams values before any validation use.
+    /// NMC mainnet params skeleton. pow_limit + genesis_hash PINNED from
+    /// namecoin-core src/kernel/chainparams.cpp (CMainParams). The 80-byte
+    /// mainnet_genesis_header() seed (SHA256d cross-check) stays deferred.
     static NMCChainParams mainnet() {
         NMCChainParams p;
         p.target_timespan = MAINNET_TARGET_TIMESPAN;
         p.target_spacing  = MAINNET_TARGET_SPACING;
         p.allow_min_difficulty = MAINNET_ALLOW_MIN_DIFF;
         p.no_retargeting = false;
-        // TO-CONFIRM: Namecoin mainnet powLimit (placeholder = BTC default).
-        p.pow_limit.SetHex("00000000ffff0000000000000000000000000000000000000000000000000000");
-        // TO-CONFIRM: Namecoin mainnet genesis hash (placeholder = null).
-        p.genesis_hash.SetNull();
+        // Namecoin mainnet powLimit = 2^224-1, PINNED from namecoin-core
+        // src/kernel/chainparams.cpp:151 (CMainParams consensus.powLimit). Feeds
+        // the retarget clamp (apply_retarget below); a genuine consensus value,
+        // NOT the 0x1c007fff genesis-bits expansion the placeholder carried.
+        p.pow_limit.SetHex("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        // Namecoin mainnet genesis hash PINNED from namecoin-core
+        // src/kernel/chainparams.cpp:202 (CMainParams hashGenesisBlock assert).
+        p.genesis_hash.SetHex("000000000062b72c5e2ceb45fbc8587e807c155b0da735e6483dfba2f0a9c770");
         // P2P magic PINNED: namecoin-core kernel/chainparams.cpp CMainParams
         // pchMessageStart = { 0xf9, 0xbe, 0xb4, 0xfe }. (Magic is a published
         // network constant, distinct from the genesis hash which stays
@@ -570,15 +573,19 @@ struct NMCChainParams {
         return p;
     }
 
-    /// NMC testnet params skeleton (same TO-CONFIRM caveats as mainnet()).
+    /// NMC testnet params skeleton. pow_limit PINNED (CTestNetParams); genesis
+    /// PINNED + KAT-cross-checked against testnet_genesis_header().
     static NMCChainParams testnet() {
         NMCChainParams p;
         p.target_timespan = TESTNET_TARGET_TIMESPAN;
         p.target_spacing  = TESTNET_TARGET_SPACING;
         p.allow_min_difficulty = TESTNET_ALLOW_MIN_DIFF;
         p.no_retargeting = false;
-        // Namecoin testnet powLimit = Bitcoin default (chainparams.cpp CTestNetParams).
-        p.pow_limit.SetHex("00000000ffff0000000000000000000000000000000000000000000000000000");
+        // Namecoin testnet powLimit = 2^228-1, PINNED from namecoin-core
+        // src/kernel/chainparams.cpp:314 (CTestNetParams consensus.powLimit).
+        // Distinct from mainnet 2^224-1; consistent with the testnet3 genesis
+        // bits=0x1d07fff8 pinned below (genesis target < powLimit).
+        p.pow_limit.SetHex("0000000fffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         // Genesis PINNED against a live namecoind on namecoin testnet
         // (getblockhash 0 / getblockheader, 2026-06-19). block_hash(genesis_header)
         // re-derives this value (nmc_auxpow_wire_test GenesisTestnet KAT).

--- a/src/impl/nmc/test/auxpow_wire_test.cpp
+++ b/src/impl/nmc/test/auxpow_wire_test.cpp
@@ -306,4 +306,42 @@ TEST(NmcP1Genesis, P2PMagicPinned)
               nmc::coin::NMCChainParams::testnet().p2p_magic);
 }
 
+
+// ---------------------------------------------------------------------------
+// powLimit / genesis-hash consensus-value pin KAT (P1 PF). These are genuine
+// consensus VALUES (pow_limit feeds the retarget clamp in apply_retarget),
+// source-verified against namecoin-core src/kernel/chainparams.cpp and pinned
+// so silent drift reddens CI rather than mis-clamping difficulty. The prior
+// placeholders were the BTC genesis-bits expansion (00000000ffff0000..), NOT
+// the actual powLimit -- a real consensus divergence, caught by this guard.
+//   mainnet powLimit = 2^224-1  (chainparams.cpp:151)
+//   testnet powLimit = 2^228-1  (chainparams.cpp:314, one nibble wider)
+//   mainnet genesis  = 000000000062b72c...c770 (chainparams.cpp:202)
+// ---------------------------------------------------------------------------
+TEST(NmcPFConsensusPin, PowLimitAndGenesisMatchNamecoinCore)
+{
+    const auto main = nmc::coin::NMCChainParams::mainnet();
+    const auto test = nmc::coin::NMCChainParams::testnet();
+
+    uint256 main_pow, test_pow, main_gen;
+    main_pow.SetHex("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    test_pow.SetHex("0000000fffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    main_gen.SetHex("000000000062b72c5e2ceb45fbc8587e807c155b0da735e6483dfba2f0a9c770");
+
+    EXPECT_EQ(main.pow_limit, main_pow);   // 2^224-1
+    EXPECT_EQ(test.pow_limit, test_pow);   // 2^228-1
+    EXPECT_EQ(main.genesis_hash, main_gen);
+
+    // Networks' powLimits must differ (testnet one nibble wider) and neither
+    // may regress to the old genesis-bits-expansion placeholder.
+    EXPECT_NE(main.pow_limit, test.pow_limit);
+    uint256 stale;
+    stale.SetHex("00000000ffff0000000000000000000000000000000000000000000000000000");
+    EXPECT_NE(main.pow_limit, stale);
+    EXPECT_NE(test.pow_limit, stale);
+
+    // Mainnet genesis must no longer be the null sentinel the placeholder used.
+    EXPECT_FALSE(main.genesis_hash.IsNull());
+}
+
 }  // namespace


### PR DESCRIPTION
## What
Pins the NMCChainParams pow_limit / mainnet genesis_hash placeholders to their **source-verified namecoin-core values**. The placeholders were the BTC genesis-bits expansion (`00000000ffff0000..`), **not** Namecoins actual powLimit. Because `pow_limit` feeds the retarget clamp (`apply_retarget`), this was a genuine consensus delta, not cosmetic.

Source: namecoin-core `src/kernel/chainparams.cpp`
| param | value | line |
|---|---|---|
| mainnet powLimit | 2^224-1 (`00000000ffff..ffff`) | CMainParams:151 |
| mainnet genesis | `000000000062b72c..c770` | CMainParams:202 |
| testnet powLimit | 2^228-1 (`0000000fffff..ffff`) | CTestNetParams:314 |

testnet powLimit is one nibble wider than mainnet and is consistent with the already-pinned testnet3 genesis `bits=0x1d07fff8` (genesis target < powLimit).

## Scope / isolation
- **Fenced to `src/impl/nmc/` only.** LTC/DOGE/DGB/DASH/BCH retarget-clamp paths are byte-for-byte unchanged (each coin has its own `header_chain.hpp`).
- KAT `NmcPFConsensusPin.PowLimitAndGenesisMatchNamecoinCore` rides the **allowlisted** `nmc_auxpow_wire_test` exe — **no build.yml touch** (avoids the NOT_BUILT sentinel). 5/5 green locally.

## Deferred (follow-up)
- 80-byte `mainnet_genesis_header()` seed for a SHA256d cross-check KAT — needs `.140 getblockheader 0` hex.

## Merge
Expresses consensus **VALUES** → **operator tap**, same convention as #258. Not auto-merge.