### PR TITLE
nmc(PF): pin mainnet_genesis_header() 80-byte seed (node-verified)

### DIFF
--- a/src/impl/nmc/coin/header_chain.hpp
+++ b/src/impl/nmc/coin/header_chain.hpp
@@ -606,6 +606,27 @@ struct NMCChainParams {
         g.m_nonce     = 384568319;
         return g;
     }
+
+    /// Namecoin MAINNET genesis header (the 80-byte parent the HeaderChain seeds
+    /// at height 0). Fields PINNED against a live SYNCED mainnet namecoind
+    /// (getblockhash 0 / getblockheader <hash> false, .140 PID 5860,
+    /// blocks=830010 IBD=false, 2026-06-20):
+    ///   version=1  time=1303000001  bits=0x1c007fff  nonce=0xa21ea192
+    ///   merkleroot=41c62dbd9068c89a449525e3cd5ac61b20ece28c3c38b3f35b2161f0e6d3cb0d
+    /// SHA256d(header) == 000000000062b72c..c770 == mainnet genesis_hash
+    /// (verified locally + by the MainnetHeaderRederivesPinnedHash KAT). This
+    /// retires the deferred mainnet_genesis_header() seed; the expected hash is
+    /// external daemon truth, not self-derived from the header fields.
+    static BlockHeaderType mainnet_genesis_header() {
+        BlockHeaderType g;
+        g.m_previous_block.SetNull();
+        g.m_version = 1;
+        g.m_merkle_root.SetHex("41c62dbd9068c89a449525e3cd5ac61b20ece28c3c38b3f35b2161f0e6d3cb0d");
+        g.m_timestamp = 1303000001;
+        g.m_bits      = 0x1c007fff;
+        g.m_nonce     = 0xa21ea192;  // 2719621522
+        return g;
+    }
 };
 
 // ─── Index Entry ─────────────────────────────────────────────────────────────

--- a/src/impl/nmc/test/auxpow_wire_test.cpp
+++ b/src/impl/nmc/test/auxpow_wire_test.cpp
@@ -285,6 +285,36 @@ TEST(NmcP1Genesis, TestnetHeaderRederivesPinnedHash)
 }
 
 // ---------------------------------------------------------------------------
+// MAINNET genesis pin KAT (P1 PF, retires the deferred mainnet seed).
+// NMCChainParams::mainnet_genesis_header() is the 80-byte parent the embedded
+// HeaderChain seeds at height 0. Its SHA256d MUST reproduce the Namecoin
+// mainnet genesis hash pinned against a live SYNCED mainnet namecoind
+// (getblockhash 0 / getblockheader <hash> false; .140 PID 5860, blocks=830010,
+// IBD=false; 2026-06-20). The expected hash is asserted as an external literal,
+// NOT params.genesis_hash, so the guard holds regardless of merge order with
+// the mainnet genesis_hash pin (#261). A wrong field (endianness, bits, nonce,
+// merkleroot) makes the re-derived hash diverge from daemon truth.
+// ---------------------------------------------------------------------------
+TEST(NmcP1Genesis, MainnetHeaderRederivesPinnedHash)
+{
+    const auto g = nmc::coin::NMCChainParams::mainnet_genesis_header();
+
+    EXPECT_TRUE(g.m_previous_block.IsNull());
+    EXPECT_EQ(g.m_version, 1);
+    EXPECT_EQ(g.m_timestamp, 1303000001u);
+    EXPECT_EQ(g.m_bits, 0x1c007fffu);
+    EXPECT_EQ(g.m_nonce, 0xa21ea192u);
+
+    uint256 expect;
+    expect.SetHex("000000000062b72c5e2ceb45fbc8587e807c155b0da735e6483dfba2f0a9c770");
+    EXPECT_EQ(nmc::coin::block_hash(g), expect);
+
+    // Mainnet and testnet genesis headers must NOT collide (network isolation).
+    EXPECT_NE(nmc::coin::block_hash(g),
+              nmc::coin::block_hash(nmc::coin::NMCChainParams::testnet_genesis_header()));
+}
+
+// ---------------------------------------------------------------------------
 // P2P network-magic pin KAT (P1 PE 2b-ii). NMCChainParams::p2p_magic is the
 // 4-byte frame prefix the embedded won-block broadcaster (PE) puts on every
 // parent-NMC P2P message. Pinned from namecoin-core src/kernel/chainparams.cpp


### PR DESCRIPTION
## NMC PF — retire the deferred mainnet genesis-header seed

Adds `NMCChainParams::mainnet_genesis_header()` (mirror of the existing `testnet_genesis_header()`) + the `MainnetHeaderRederivesPinnedHash` KAT.

### Source (node truth, not memory)
Fields pinned against a **live SYNCED mainnet namecoind** on .140 (PID 5860, `blocks=830010`, `initialblockdownload=false`), 2026-06-20:
```
getblockhash 0            -> 000000000062b72c5e2ceb45fbc8587e807c155b0da735e6483dfba2f0a9c770
getblockheader <hash> false -> 0100...0dcbd3e6..bd2dc641 c133aa4d ff7f001c 92a11ea2 (80 bytes)
```
Parsed: `version=1 time=1303000001 bits=0x1c007fff nonce=0xa21ea192 merkleroot=41c62dbd..cb0d`. `SHA256d(header)` reproduces the genesis hash exactly (verified locally + by KAT).

### Fence / CI
- Fenced to `src/impl/nmc/` — no shared core, no other coin touched.
- KAT rides the allowlisted `nmc_auxpow_wire_test` exe; **no build.yml touch** (avoids the NOT_BUILT sentinel).
- KAT asserts against the **external literal** hash, not `params.genesis_hash`, so it is independent of merge order with the genesis_hash pin (#261). Non-colliding regions with #261.

### Verification
```
cmake --build build --target nmc_auxpow_wire_test  # green
./nmc_auxpow_wire_test --gtest_filter=*Genesis*    # 3/3 PASSED, exit 0
```

Consensus-VALUE pin -> operator tap (same class as #258/#259/#261). I do not self-merge.