### PR TITLE
ltc: fix NodeRPC::Send UAF (thread-race on shared HTTP client) — .157 crash-loop ship-blocker

### DIFF
--- a/src/impl/ltc/coin/rpc.cpp
+++ b/src/impl/ltc/coin/rpc.cpp
@@ -132,6 +132,7 @@ void NodeRPC::sync_reconnect()
 
 std::string NodeRPC::Send(const std::string &request)
 {
+	std::lock_guard<std::mutex> _rpc_lock(m_rpc_mutex);
 	// Retry once after synchronous reconnect on write/read failure
 	for (int attempt = 0; attempt < 2; ++attempt)
 	{

--- a/src/impl/ltc/coin/rpc.hpp
+++ b/src/impl/ltc/coin/rpc.hpp
@@ -5,6 +5,7 @@
 #include "node_interface.hpp"
 
 #include <iostream>
+#include <mutex>
 
 #include <core/uint256.hpp>
 #include <core/timer.hpp>
@@ -38,6 +39,11 @@ private:
     beast::tcp_stream m_stream;
     boost::asio::ip::tcp::resolver m_resolver;
     http::request<http::string_body> m_http_request; 
+    // Serializes Send(): m_http_request + m_stream are NOT thread-safe. The asio
+    // thread_pool worker (clean_tracker->think->score->getblockheader) and the main
+    // thread both drive Send() on this single shared client; without this lock T0's
+    // prepare_payload() frees the Content-Length field element mid-write on T8 -> UAF.
+    std::mutex m_rpc_mutex;
 
     std::unique_ptr<RPCAuthData> m_auth;
     jsonrpccxx::JsonRpcClient m_client;


### PR DESCRIPTION
## Ship-blocker: .157 v36-crossing crash-loop, root-caused

The .157 soak SEGV-loop (~every 25-50 min during reorg/clean churn, inside malloc) is **not** a sharechain reorg-prune bug as earlier hypothesized. A firewall-isolated **ASan** sibling (BuildId `9a12b6bc`) captured a definitive heap-use-after-free:

```
heap-use-after-free, READ size 21 in read_iovec (boost::beast http::write), thread T8
  T8 (asio thread_pool): NodeImpl::clean_tracker -> ShareTracker::think (share_tracker.hpp:1122)
     -> score (share_tracker.hpp:622) -> score-callback (c2pool_refactored.cpp:2650)
     -> NodeRPC::getblockheader (rpc.cpp:440) -> NodeRPC::Send (rpc.cpp:139)
  freed by T0 (main): NodeRPC::Send -> prepare_payload -> set_content_length_impl
     -> delete_element  (frees the Content-Length field element T8 is still serializing)
```

### Root cause
`ltc::coin::NodeRPC` holds a **single shared** `m_http_request` + `m_stream` and `Send()` had **no mutex**. The asio pool worker (clean_tracker -> think -> score fires a *blocking* getblockheader) and the main thread both drive `Send()` on the same client. One thread mid-`http::write` while the other re-runs `prepare_payload()` frees/reallocs the header element under it -> UAF. In the non-ASan build this is the SEGV-inside-malloc crash-loop (heap corruption is the downstream symptom). Crossing churn just raises clean_tracker frequency, widening the window — which is why it looked crossing-specific.

### Fix
Serialize the full write+read cycle in `Send()` under a per-client `std::mutex`. A single HTTP connection cannot interleave two request/response pairs anyway, so the lock adds no stall beyond what correctness already requires. +7 lines, no behavior change on the single-threaded path.

### Verification
- Builds clean (`c2pool` target, exit 0).
- Next: rebuild .157, re-run the v35->v36 crossing under the same ASan sibling to confirm the UAF is gone.

### Follow-up (separate PR, non-blocking on cutover)
Get `think()`/`score()` off the synchronous-RPC-on-pool-thread path: cache header height instead of a live `getblockheader` in the score callback. Also consider guarding the reconnect-timer path against `Send()` (rarer race on `m_stream`).
