### PR TITLE
btc: --regtest CLI substrate for PE-2e won-block soak (additive)

### DIFF
--- a/src/c2pool/c2pool_refactored.cpp
+++ b/src/c2pool/c2pool_refactored.cpp
@@ -363,6 +363,7 @@ void print_help() {
     std::cout << "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n";
     std::cout << "  --help, -h                Show this help message and exit\n";
     std::cout << "  --testnet                 Use testnet instead of mainnet\n";
+    std::cout << "  --regtest                 Use regtest (trivial-difficulty parent; won-block soak only)\n";
     std::cout << "  --integrated              Full P2P pool with sharechain (DEFAULT)\n";
     std::cout << "  --solo                    Solo pool mode (no P2P sharechain, local payouts)\n";
     std::cout << "  --custodial               Custodial pool (coinbase to --address, stratum for accounting)\n";
@@ -747,6 +748,10 @@ int main(int argc, char* argv[]) {
         else if (arg == "--testnet") {
             settings->m_testnet = true;
             cli_explicit.insert("testnet");
+        }
+        else if (arg == "--regtest") {
+            settings->m_regtest = true;
+            cli_explicit.insert("regtest");
         }
         // Log level (p2pool: --debug; c2pool extends with standard levels)
         else if (arg == "--loglevel-trace")    { cli_log_level = "trace"; cli_explicit.insert("log_level"); }

--- a/src/core/settings.hpp
+++ b/src/core/settings.hpp
@@ -27,6 +27,7 @@ protected:
 
 public:
     bool m_testnet;
+    bool m_regtest{false};   // --regtest: trivial-difficulty parent for PE-2e won-block soak (additive)
     std::vector<std::string> m_networks;
     float m_fee;
 

--- a/src/impl/btc/coin/header_chain.hpp
+++ b/src/impl/btc/coin/header_chain.hpp
@@ -212,6 +212,27 @@ struct BTCChainParams {
         return p;
     }
 
+    /// BTC regtest params (Bitcoin Core CRegTestParams). Trivial-difficulty
+    /// parent substrate for the embedded won-block soak (PE-2e): no_retargeting
+    /// keeps the target pinned at pow_limit so a freshly built share clears the
+    /// parent target, letting on_block_found actually fire under a deterministic
+    /// regtest namecoind. STRICTLY additive — selected only under --regtest;
+    /// mainnet/testnet/testnet4 paths are untouched. Constants per
+    /// ref/bitcoin/src/kernel/chainparams.cpp (CRegTestParams).
+    static BTCChainParams regtest() {
+        BTCChainParams p;
+        p.target_timespan = MAINNET_TARGET_TIMESPAN;
+        p.target_spacing  = MAINNET_TARGET_SPACING;
+        p.allow_min_difficulty = true;   // fPowAllowMinDifficultyBlocks
+        p.no_retargeting = true;         // fPowNoRetargeting -- the PE-2e hook
+        // CRegTestParams consensus.powLimit = ~uint256(0) >> 1.
+        p.pow_limit.SetHex("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        // CRegTestParams hashGenesisBlock.
+        p.genesis_hash.SetHex("0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206");
+        p.fast_start_checkpoint = Checkpoint{0, p.genesis_hash};
+        return p;
+    }
+
     int64_t difficulty_adjustment_interval() const {
         return target_timespan / target_spacing;
     }


### PR DESCRIPTION
Additive --regtest CLI substrate so the embedded BTC parent can run a trivial-difficulty regtest target — the in-loop c2pool process the PE-2e won-block soak harness (#251) needs to drive on_block_found deterministically (integrator UID1683).

Files (all strictly additive, fenced):
- core/settings.hpp: m_regtest{false}
- c2pool_refactored.cpp: --regtest parse + --help
- btc/coin/header_chain.hpp: BTCChainParams::regtest() (no_retargeting=true, regtest pow_limit + genesis 0f9188f1.., per ref/bitcoin CRegTestParams)

No mainnet/testnet/testnet4 path altered. Parent-param SELECTION wiring is a follow-up slice (routing question open to integrator). NOT self-merged.