### PR TITLE
dgb(#82): regtest-aware daemon softfork readiness gate

### DIFF
--- a/src/impl/dgb/coin/rpc.cpp
+++ b/src/impl/dgb/coin/rpc.cpp
@@ -264,8 +264,22 @@ bool NodeRPC::check()
 		}
 	}
 
+	// Regtest does not deploy the DGB-specific algo softforks (reservealgo, odo)
+	// nor nversionbips — those are mainnet/testnet deployments, so a regtest
+	// digibyted legitimately signals only csv/segwit/taproot. Gating startup on
+	// deployments the connected chain cannot carry would make the regtest
+	// won-block path (and CI against regtest) impossible to start, with no
+	// consensus benefit. Relax ONLY on regtest; mainnet/testnet keep the full
+	// SSOT requirement set. Non-consensus startup readiness gate only.
+	std::set<std::string> required = dgb::PoolConfig::SOFTFORKS_REQUIRED;
+	if (blockchaininfo.value("chain", std::string{}) == "regtest")
+	{
+		for (const char* algo_fork : {"reservealgo", "odo", "nversionbips"})
+			required.erase(algo_fork);
+	}
+
 	std::vector<std::string> missing;
-	for (const auto& req : dgb::PoolConfig::SOFTFORKS_REQUIRED)
+	for (const auto& req : required)
 	{
 		if (!softforks_supported.contains(req))
 			missing.push_back(req);


### PR DESCRIPTION
## What
NodeRPC::check (startup readiness gate) relaxes the DGB-specific algo softfork requirements (`reservealgo`, `odo`, `nversionbips`) ONLY when chain==regtest. A regtest digibyted legitimately deploys just csv/segwit/taproot; those three are mainnet/testnet deployments not carried on regtest, so the mainnet-oriented gate could never pass against a regtest daemon.

## Why
Unblocks the #82 regtest won-block-reaches-network test (integrator-greenlit). Before this, the armed run-loop spun in a `Refusing to start ... Retry after 15 seconds` loop and the work source never came up against regtest.

## Scope / safety
- Single file: `src/impl/dgb/coin/rpc.cpp`. Single-coin, DGB-only.
- Non-consensus: startup readiness gate, NOT block validation.
- SSOT `PoolConfig::SOFTFORKS_REQUIRED` and its KAT untouched; mainnet/testnet keep the full required set.
- p2pool-merged-v36 surface: none.

## Verification (live, regtest)
- BEFORE: `missing required softfork features: nversionbips, odo, reservealgo` -> `Refusing to start` retry loop.
- AFTER: `...CoindRPC connected!`, work source + Stratum up, embedded P2P handshake OK, walk-forward getheaders.
- build EXIT=0; dgb_share_test 16/16.

HOLD merge — integrator merges with operator push approval.