### PR TITLE
ltc: couple AutoRatchet mint gate to the work-weighted accept gate (fix #97 crossing wedge)

### DIFF
--- a/src/impl/ltc/auto_ratchet.hpp
+++ b/src/impl/ltc/auto_ratchet.hpp
@@ -140,25 +140,41 @@ public:
                 // (jtoomim rule). Prevents activation before the entire PPLNS
                 // window has transitioned — p2pool check() rejects V36 shares
                 // when the oldest 10% has < 60% signaling.
+                // WORK-WEIGHTED tail guard (mint<->accept coupling). The
+                // consensus accept gate (share_check step 2 / p2pool check()
+                // data.py:1399) keys the 60% switch rule off
+                // get_desired_version_counts, which in canonical p2pool
+                // (data.py:2651) weights each share by
+                // target_to_average_attempts(target) -- i.e. WORK, not a flat
+                // head-count. AutoRatchet must evaluate the SAME work-weighted
+                // 60% rule over the SAME [9/10*CL, CL] window before it
+                // activates; otherwise a 95%-by-COUNT activation can outrun the
+                // 60%-by-WORK accept gate under heterogeneous hashrate, the node
+                // mints a V36 boundary share that every peer rejects, and the
+                // crossing wedges. The weighted tally makes activation strictly
+                // imply the accept gate, so a minted boundary share can never be
+                // rejected.
                 uint32_t tail_start = (chain_length * 9) / 10;
                 uint32_t tail_size  = chain_length / 10;
                 auto tail_ancestor = tracker.chain.get_nth_parent_key(best_share_hash, tail_start);
-                auto tail_counts = tracker.get_desired_version_counts(tail_ancestor, tail_size);
+                auto tail_weights = tracker.get_desired_version_weights(tail_ancestor, tail_size);
 
-                int64_t tail_target = 0, tail_total = 0;
-                for (auto& [ver, cnt] : tail_counts) {
-                    tail_total += cnt;
-                    if (ver >= target_version_)
-                        tail_target += cnt;
+                // mapped_type is the work-weight accumulator (uint288); default 0.
+                decltype(tail_weights)::mapped_type tail_target{}, tail_total{};
+                for (auto& [ver, w] : tail_weights) {
+                    tail_total = tail_total + w;
+                    if (static_cast<int64_t>(ver) >= target_version_)
+                        tail_target = tail_target + w;
                 }
-                int tail_pct = (tail_total > 0) ? static_cast<int>(tail_target * 100 / tail_total) : 0;
+                // Canonical: counts.get(VERSION,0) < sum(counts)*60//100
+                bool tail_ok = !(tail_target * uint32_t(100) < tail_total * uint32_t(SWITCH_THRESHOLD));
 
-                if (tail_pct < SWITCH_THRESHOLD) {
+                if (!tail_ok) {
                     static int tail_log = 0;
                     if (tail_log++ % 20 == 0)
                         LOG_INFO << "[AutoRatchet] VOTING: full window " << vote_pct
-                                 << "% >= " << ACTIVATION_THRESHOLD << "% but oldest 10% only "
-                                 << tail_pct << "% (need " << SWITCH_THRESHOLD << "%) — waiting";
+                                 << "% >= " << ACTIVATION_THRESHOLD << "% but oldest 10% work-weighted V"
+                                 << target_version_ << " desire < " << SWITCH_THRESHOLD << "%) — waiting";
                     // Don't transition yet
                 }
                 else


### PR DESCRIPTION
## Problem
The #97 v35->v36 crossing soak wedged. Root cause (source-localized at `share_check.hpp:1753-1754` vs `ltc/auto_ratchet.hpp`): the **mint/activate gate and the accept gate use different metrics**.

- **Accept gate** (consensus; `share_check` step 2, mirrors p2pool `check()` data.py:1399): a V36 boundary share is admitted only when desired-version reaches **60% by WORK** over the `[9/10*CL, CL]` window. Canonical `get_desired_version_counts` (data.py:2651) weights each share by `target_to_average_attempts(target)` -- it is work-weighted despite the name.
- **Mint/activate gate** (`AutoRatchet`): activated on a **95% by flat COUNT** desired-version tally (one vote per share); tail guard also flat count.

Under heterogeneous hashrate a small miner set pushes the COUNT past 95% while the work-weighted tail is still below 60%. AutoRatchet activates, the node mints a V36 boundary share, and **every peer rejects it** -> the crossing freezes.

## Fix
Switch the AutoRatchet tail guard from flat-count `get_desired_version_counts` to work-weighted `get_desired_version_weights`, over the **same window at the same 60% threshold** the accept gate enforces. Activation now **strictly implies** the accept rule, so a minted boundary share can never be rejected. Arithmetic mirrors the proven accept-gate path exactly (`tail_target * 100 < tail_total * 60`).

Supersedes the earlier F10 finding-#1 decision to keep activation flat-count; the production soak proved it unsafe. Covers LTC and DOGE (merged; rides the LTC AutoRatchet).

## Verification
- Builds clean: `c2pool` LTC target relinked, no new errors.
- Empirical mechanism-validation in progress on .157 (unwedged via a hand-fed v35 rig): work-weighted desire 98.5%, v36-contiguous-from-tip 33->178, share_pct 8.25->44.5%.
- **Shippable PASS = a clean crossing on THIS fixed binary** (no hand-fed v35 rig needed). Re-soak before contabo prod cutover.

## Merge
Hold -- reviewer-authored. Integrator/operator merges after CI green + re-soak.
