### PR TITLE
dgb: standardize AutoRatchet mint gate to work-weighted accept gate (contract)

### DIFF
--- a/src/impl/dgb/share_check.hpp
+++ b/src/impl/dgb/share_check.hpp
@@ -1654,8 +1654,12 @@ bool share_check(const ShareT& share,
     // The weight is target_to_average_attempts per share — get_desired_version_weights,
     // matching canonical get_desired_version_counts (data.py:2651) — NOT a flat count.
     // F10/(b): the prior non-canonical 95%-obsolescence punish is removed; the
-    // canonical 60% switch rule is now the ONLY version gate. AutoRatchet stays
-    // count-based and does not gate peer shares here.
+    // canonical 60% weighted switch rule is now the ONLY version gate, and it does
+    // not gate the local mint decision here. When the DGB AutoRatchet minter is
+    // ported (Phase B) its activation tail guard MUST be work-weighted to match
+    // this gate (get_desired_version_weights, share_tracker.hpp), superseding the
+    // F10 flat-count choice the LTC crossing soak proved unsafe — mirrors ltc
+    // 865fdd78.
     {
         auto chain_length = static_cast<int32_t>(params.chain_length);
         if (!share.m_prev_hash.IsNull() && tracker.chain.contains(share.m_prev_hash))

--- a/src/impl/dgb/share_tracker.hpp
+++ b/src/impl/dgb/share_tracker.hpp
@@ -2126,10 +2126,17 @@ public:
     // Canonical p2pool get_desired_version_counts (data.py:2651) weights each
     // share by target_to_average_attempts(share.target) — NOT a flat count.
     // The check()-phase 60% switch rule (share_check step 2) is a consensus gate
-    // and MUST use these weights to stay byte-identical with p2pool. AutoRatchet
-    // and its tail guard deliberately keep the FLAT-COUNT variant above
-    // (count-based per F10 finding #1 — weighting them would shift activation
-    // timing across the soak). Weight = ShareIndex::work (share.hpp).
+    // and MUST use these weights to stay byte-identical with p2pool. When the
+    // DGB AutoRatchet minter is ported (Phase B) its activation tail guard MUST
+    // ALSO read these work-weights over the SAME [9/10*CL, CL] window at the SAME
+    // 60% threshold the accept gate enforces (share_check step 2), so activation
+    // strictly implies the accept rule and a minted boundary share can never be
+    // rejected. This SUPERSEDES the earlier F10 keep-flat-count choice, which the
+    // LTC v35->v36 crossing soak (#97) proved unsafe: under heterogeneous hashrate
+    // a 95%-by-COUNT activation outruns the 60%-by-WORK accept gate and wedges the
+    // crossing. Cross-coin v36-native standardization (mirrors ltc 865fdd78). The
+    // flat-count accessor above stays for diagnostics/KAT only, never the gate.
+    // Weight = ShareIndex::work (share.hpp).
     std::map<uint64_t, uint288> get_desired_version_weights(const uint256& share_hash, int32_t lookbehind)
     {
         std::map<uint64_t, uint288> weights;
@@ -2643,7 +2650,8 @@ public:
 
     // F10/(b): should_punish_version (the 95%-obsolescence punish) was removed.
     // It was non-canonical — canonical p2pool check() has no 95% obsolescence
-    // rule; the count-based AutoRatchet plus the 60% weighted switch rule
+    // rule; the AutoRatchet (work-weighted at Phase-B port, per 865fdd78) plus the
+    // 60% weighted switch rule
     // (share_check step 2) are the only version gates. Keeping it would
     // punish/score-down shares canonical accepts, breaking the #81 zero-
     // divergence gate. Head-scoring (Phase 4) now punishes only naughty heads.


### PR DESCRIPTION
## What

Mirrors the **intent** of ltc `865fdd78` (AutoRatchet mint↔accept coupling) onto the DGB lane, as a **v36-native standardization** (consensus version-signaling) for a clean v37 migration. Per-coin isolation: touches `src/impl/dgb/` only — **not** bundled with the LTC/BTC PRs.

## Why this is comment-only on DGB

DGB carries **no AutoRatchet minter yet** (no `src/impl/dgb/auto_ratchet.hpp`; the minter lands in Phase B). So there is no executable flat-count tally to swap — the LTC wedge is **structurally absent** on this lane today. Two relevant facts on DGB:

- The accept gate (`share_check.hpp` version-switch rule, ~L1684) is **already work-weighted/canonical** via `get_desired_version_weights`, KAT-pinned by #249.
- The **only** artifact of the unsafe F10 flat-count choice on this lane is the design-contract recorded in comments (`share_tracker.hpp` ~L2129/L2646, `share_check.hpp` ~L1657), which would seed the exact wedge into the future port.

This corrects those comments so DGB's AutoRatchet is **born work-weighted**: its activation tail guard MUST read `get_desired_version_weights` over the same `[9/10·CL, CL]` window at the same 60% threshold the accept gate enforces, superseding F10.

## Bucket classification (3-bucket rule)

Bucket 2 — **v36-native shared structure** (consensus version-signaling): standardize cross-coin toward the v37 shape.

## Risk

Comment-only. **Zero behavior change** (no minter exists to alter); confirmed no non-comment lines in the diff. No re-soak applies (nothing executable changed); the Phase-B minter port will carry its own crossing-soak gate.

HOLD merge — operator-tap-gated per consensus-version-signaling policy.
