### PR TITLE
dgb: wire AutoRatchet mint baseline base_version=35 (oracle-resolved) [HOLD/surface-for-tap]

### DIFF
--- a/src/impl/dgb/auto_ratchet.hpp
+++ b/src/impl/dgb/auto_ratchet.hpp
@@ -24,15 +24,16 @@
 // Port of p2pool-v36 data.py AutoRatchet (lines 2109-2344), mirroring
 // src/impl/ltc/auto_ratchet.hpp.
 //
-// DGB DIVERGENCE FROM LTC (per operator 2026-06-17 re-scope): DGB's live
-// pre-v36 baseline is NOT necessarily V35 — it conforms to the DGB oracle
-// frstrtr/p2pool-dgb-scrypt, which runs an OLDER share version than LTC's
-// v35. The VOTING-state output version is therefore a CONSTRUCTOR PARAMETER
-// (base_version_), NOT the ltc hardcode `target_version_ - 1`. The exact live
-// value is a [decision-needed] for the wiring step; the default below keeps
-// the module compilable and KAT-exercisable but MUST be overridden at the
-// run-loop wire-in once confirmed against the oracle. Until then this module
-// is surface-for-tap (unwired).
+// DGB DIVERGENCE FROM LTC (per operator 2026-06-17 re-scope): DGB's
+// VOTING-state output version is a CONSTRUCTOR PARAMETER (base_version_), NOT
+// the ltc hardcode `target_version_ - 1`. The "older than LTC" axis is the P2P
+// PROTOCOL version (p2p.py VERSION=3501 vs LTC 3503), not the share version.
+// BASELINE RESOLVED 2026-06-21: oracle frstrtr/p2pool-dgb-scrypt @22761e7
+// mints share VERSION=35 (data.py:636, SUCCESSOR=None) => base_version=35.
+// The production wire-in pins this constant in auto_ratchet_wire.hpp
+// (make_dgb_ratchet); this module keeps the parameter explicit so the v37
+// unified shape stays clean. The compile default (target-1) only applies to
+// bare AutoRatchet(...) construction in tests.
 
 #include "config_pool.hpp"
 #include "share_tracker.hpp"

--- a/src/impl/dgb/auto_ratchet_wire.hpp
+++ b/src/impl/dgb/auto_ratchet_wire.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+// auto_ratchet_wire.hpp — DGB production wire-in for the AutoRatchet mint-side
+// share-version ratchet.
+//
+// This is the run-loop seam that turns the (otherwise compile-default)
+// AutoRatchet into a node that mints the CORRECT DGB baseline share version
+// while voting for the V36 target. It exists as a separate translation unit
+// from auto_ratchet.hpp so the consensus-bearing baseline constant lives in
+// exactly one production location and can be tap-reviewed on its own.
+//
+// BASELINE RESOLVED (was a [decision-needed]; closed 2026-06-21):
+//   Oracle = frstrtr/p2pool-dgb-scrypt @ 22761e7 (2026-06-17).
+//     data.py:636                  Share.VERSION = 35, VOTING_VERSION = 35,
+//                                  SUCCESSOR = None, share_versions = {35: Share}
+//     networks/digibyte.py:26      SEGWIT_ACTIVATION_VERSION = 35
+//   SUCCESSOR=None => 35 is the format the live node currently mints, so the
+//   VOTING-state output (base_version) is unambiguously 35. DGB's "older than
+//   LTC" axis is the P2P PROTOCOL version (p2p.py VERSION = 3501 vs LTC 3503),
+//   NOT the share version — both share versions are 35. base_version=35
+//   therefore coincides with LTC's target-1, but stays an explicit constant
+//   here because the v37 unified shape wants it explicit and the protocol-gap
+//   is real elsewhere.
+//
+// Bucket-2 (v36-native shared structure): the ratchet SHAPE is standardized
+// cross-coin toward the v37 unified form; only the per-coin baseline constant
+// below is DGB-specific. The work-weighted tail guard inside
+// AutoRatchet::get_share_version keeps mint activation subordinate to the
+// 60%-by-work accept gate (#249/#289) — this seam adds no new policy, it only
+// pins the constants and hands callers the {mint, vote} version pair.
+
+#include "auto_ratchet.hpp"
+
+namespace dgb
+{
+
+// DGB live-baseline share version minted while VOTING (oracle 22761e7).
+inline constexpr int64_t DGB_BASE_VERSION   = 35;
+// V36 crossing target.
+inline constexpr int64_t DGB_TARGET_VERSION = 36;
+
+// Production factory: construct the DGB AutoRatchet with the oracle-confirmed
+// baseline. state_file_path persists VOTING/ACTIVATED/CONFIRMED across restarts
+// so a crossed node never regresses. This is THE place base_version=35 enters
+// production code.
+inline AutoRatchet make_dgb_ratchet(const std::string& state_file_path = "")
+{
+    return AutoRatchet(state_file_path, DGB_TARGET_VERSION, DGB_BASE_VERSION);
+}
+
+// Run-loop selector: given the live tracker + current best share, return the
+// {share_version_to_mint, desired_version_to_vote} pair the node should stamp
+// onto the share it is about to create. Thin pass-through over the state
+// machine so the run-loop never re-implements the gate; centralizes the call
+// the eventual create_local_share() caller binds to.
+inline std::pair<int64_t, int64_t> dgb_select_mint_versions(
+    AutoRatchet& ratchet, ShareTracker& tracker, const uint256& best_share_hash)
+{
+    return ratchet.get_share_version(tracker, best_share_hash);
+}
+
+} // namespace dgb

--- a/src/impl/dgb/test/share_test.cpp
+++ b/src/impl/dgb/test/share_test.cpp
@@ -21,6 +21,7 @@
 #include <impl/dgb/params.hpp>          // make_coin_params — assembled CoinParams SSOT
 #include <impl/dgb/coin/rpc_conf.hpp>   // #82 external-daemon RPC creds (digibyte.conf)
 #include <impl/dgb/auto_ratchet.hpp> // Phase B: mint-side share-version ratchet
+#include <impl/dgb/auto_ratchet_wire.hpp> // Phase B: production wire-in (base_version=35)
 #include <unistd.h>                  // getpid (AutoRatchet KAT temp state file)
 
 #include <cstdio>
@@ -433,4 +434,34 @@ TEST(DGB_share_test, AutoRatchetStatePersistsAcrossRestart)
     EXPECT_EQ(mint, 36);
     EXPECT_EQ(vote, 36);
     std::remove(path.c_str());
+}
+
+// ----------------------------------------------------------------------------
+// Production wire-in (auto_ratchet_wire.hpp). The DGB baseline [decision-needed]
+// is RESOLVED: oracle frstrtr/p2pool-dgb-scrypt @22761e7 mints share VERSION=35
+// (SUCCESSOR=None), so base_version=35. These KATs pin that constant where it
+// enters production code, so a future edit that regresses it to the ltc
+// hardcode fails loudly.
+// ----------------------------------------------------------------------------
+TEST(DGB_share_test, AutoRatchetWireBaselineConstantsFromOracle)
+{
+    EXPECT_EQ(dgb::DGB_BASE_VERSION,   35);
+    EXPECT_EQ(dgb::DGB_TARGET_VERSION, 36);
+
+    auto ar = dgb::make_dgb_ratchet();
+    EXPECT_EQ(ar.base_version(),   35);   // oracle 22761e7, NOT a hardcode coincidence
+    EXPECT_EQ(ar.target_version(), 36);
+    EXPECT_EQ(ar.state(), dgb::RatchetState::VOTING);
+}
+
+// A freshly-started production node votes V36 but MINTS the V35 baseline — it
+// must not skip ahead of the network on an empty tracker.
+TEST(DGB_share_test, AutoRatchetWireBootstrapMints35Votes36)
+{
+    auto ar = dgb::make_dgb_ratchet();
+    dgb::ShareTracker tracker;
+    auto [mint, vote] = dgb::dgb_select_mint_versions(ar, tracker, uint256{});
+    EXPECT_EQ(mint, 35);   // baseline share version (oracle)
+    EXPECT_EQ(vote, 36);   // always vote target
+    EXPECT_EQ(ar.state(), dgb::RatchetState::VOTING);
 }


### PR DESCRIPTION
## DGB Phase B — AutoRatchet mint baseline wire-in (base_version=35)

Closes the `[decision-needed]` that held #292: DGB's VOTING-state baseline share version.

**Resolved against the oracle** `frstrtr/p2pool-dgb-scrypt @22761e7` (2026-06-17):
- `data.py:636` — `Share.VERSION=35, VOTING_VERSION=35, SUCCESSOR=None, share_versions={35:Share}`
- `networks/digibyte.py:26` — `SEGWIT_ACTIVATION_VERSION=35`

`SUCCESSOR=None` ⇒ 35 is the format the live node currently mints ⇒ `base_version=35` is unambiguous. The "older than LTC" axis is the **P2P protocol** version (`p2p.py VERSION=3501` vs LTC `3503`), *not* the share version.

### What this does
- New fenced header `auto_ratchet_wire.hpp` — single production home of the baseline constant. `make_dgb_ratchet()` constructs `AutoRatchet(target=36, base=35)`; `dgb_select_mint_versions()` is the run-loop selector that returns `{mint, vote}`.
- Work-weighted tail guard already inside `get_share_version` keeps mint activation subordinate to the 60%-by-work accept gate (#249/#289) — **no new policy** here.
- De-staled the `[decision-needed]` notes in `auto_ratchet.hpp` + `share_test.cpp`.
- +2 KATs (constants from oracle; bootstrap mint=35/vote=36). `dgb_share_test` 22/22 green.

### Review posture
- **Surface-for-tap** — consensus-bearing (version-gate transition). NOT auto-merge. **HOLD** for operator tap + testbed crossing run.
- Stacked on #292 (`dgb/auto-ratchet-mint`) which supplies `auto_ratchet.hpp`; this is the SEPARATE wire-in PR integrator requested. Touches `src/impl/dgb/` only.
- Bucket-2 (v36-native shared structure); ltc-doge canonical owner of the ratchet shape — cc'd.
