### PR TITLE
bch(node): align local predicate name v36 -> v36_active (cosmetic, version-gate consistency)

### DIFF
--- a/src/impl/bch/node.hpp
+++ b/src/impl/bch/node.hpp
@@ -291,9 +291,9 @@ public:
         chain.get_share(share_hash).invoke([&](auto* s) {
             using ST = std::remove_pointer_t<decltype(s)>;
             constexpr int64_t ver = ST::version;
-            const bool v36 = core::version_gate::is_v36_active(ver);
+            const bool v36_active = core::version_gate::is_v36_active(ver);
             const uint256 gentx_hash =
-                generate_share_transaction(*s, m_tracker, false, v36, &gentx_bytes);
+                generate_share_transaction(*s, m_tracker, false, v36_active, &gentx_bytes);
             const uint256 merkle_root =
                 check_merkle_link(gentx_hash, s->m_merkle_link);
             uint32_t hdr_version = static_cast<uint32_t>(s->m_min_header.m_version);


### PR DESCRIPTION
Cosmetic no-op rename of a local predicate in src/impl/bch/node.hpp (v36 -> v36_active) for naming consistency with the core::version_gate::is_v36_active SSOT.

Scope: src/impl/bch/node.hpp only, +2/-2. No v36 surface change, no behavior change — pure rename. Per-coin isolation invariant respected (single file, BCH-only). Single-coin smoke gate suffices.

NOT conformance-crossing work — this is code hygiene, independent of the bch-conformance LTC-soak fence. Merge operator-gated as always.