### PR TITLE
web: report real c2pool peer count + pool hashrate in getinfo/getstats

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -2837,6 +2837,18 @@ nlohmann::json MiningInterface::getinfo(const std::string& request_id)
         connections = m_node->get_connected_peers_count();
     }
     
+    // Prefer the live MiningInterface hooks over the m_node accessors.
+    // In the embedded prod build m_node is the unpopulated enhanced_node stub
+    // whose peer/hashrate accessors return 0 -- the source of the false
+    // "no peers / 0 hashrate" dashboard alarms. m_peer_info_fn (real c2pool
+    // share peers) and m_pool_hashrate_fn (real attempts/s) are wired live.
+    if (m_peer_info_fn) {
+        auto pi = m_peer_info_fn();
+        if (pi.is_array()) connections = pi.size();
+    }
+    if (double real_hs = get_pool_hashrate(); real_hs > 0.0)
+        pool_hashrate = real_hs;
+
     // Read block height from cached template
     uint64_t block_height = 0;
     double network_hashps = 0.0;
@@ -2894,6 +2906,14 @@ nlohmann::json MiningInterface::getstats(const std::string& request_id)
         if (ds.contains("global_pool_difficulty"))
             difficulty = ds["global_pool_difficulty"];
     }
+
+    // Prefer live hooks over the empty m_node stub (see getinfo above).
+    if (m_peer_info_fn) {
+        auto pi = m_peer_info_fn();
+        if (pi.is_array()) connected_peers = pi.size();
+    }
+    if (double real_hs = get_pool_hashrate(); real_hs > 0.0)
+        pool_hashrate = real_hs;
 
     auto* pm = m_payout_manager_ptr ? m_payout_manager_ptr : m_payout_manager.get();
     if (pm)


### PR DESCRIPTION
## Problem
Operator hit two false "no peers / 0 hashrate" alarms: the dashboard/API (`getinfo`/`getstats`) reported `connections=0` and `poolhashps=0` while the node actually had ~30 LTC peers and ~129 GH/s live (visible in debug.log).

## Root cause
`getinfo()`/`getstats()` read peer count + hashrate from the `m_node` accessors (`get_connected_peers_count()` / `get_hashrate_stats()`). In the embedded prod build `m_node` is the unpopulated `enhanced_node` stub object — those accessors return 0. The REAL values are already wired into the MiningInterface via `m_peer_info_fn` (real c2pool share peers) and `m_pool_hashrate_fn` (real attempts/s from get_pool_attempts_per_second), and are already trusted by `rest_local_stats`.

## Fix
`getinfo`/`getstats` now prefer the live hooks, falling back to the `m_node` accessor only when a hook is unset. Web/diagnostic layer only — no consensus / sharechain / wire change. Single-TU compile verified locally.

## Follow-up (NOT in this PR)
Separately-labeled embedded **LTC** and **DOGE core-daemon** peer counts. Their source is genuinely ambiguous (external litecoind/dogecoind RPC getpeerinfo vs embedded SPV single-peer vs merged coin_peer_manager) and I will not ship a third potentially-misleading number by guessing. Tracking separately; need a one-line confirm on the intended source.