### PR TITLE
dgb: wire worker->mint callback in run-loop (Phase B, stacked on #305)

### DIFF
--- a/src/c2pool/main_dgb.cpp
+++ b/src/c2pool/main_dgb.cpp
@@ -43,6 +43,7 @@
 #include <impl/dgb/coin/header_ingest.hpp>
 #include <impl/dgb/coin/mempool_ingest.hpp>
 #include <impl/dgb/stratum/work_source.hpp>
+#include <impl/dgb/run_loop_mint.hpp>   // Phase B: worker->mint run-loop bind (mint_local_share_locked)
 #include <impl/dgb/coin/p2p_node.hpp>
 #include <impl/dgb/coin/rpc.hpp>        // NodeRPC — external-daemon submitblock arm (#82)
 #include <impl/dgb/coin/rpc_conf.hpp>   // digibyte.conf creds resolution (rpcpassword off argv)
@@ -608,12 +609,38 @@ int run_node(const core::CoinParams& params, bool testnet,
             return ok;
         };
 
+    // AutoRatchet mint-side state machine (base_version=35, target=36; oracle
+    // frstrtr/p2pool-dgb-scrypt @22761e7). Declared BEFORE work_source so it
+    // OUTLIVES the mint callback that captures it by reference. In-memory for
+    // now (no state-file path wired -- a restart re-bootstraps to VOTING, which
+    // is safe: it never regresses a crossed share; persistence is a follow-up).
+    // Accessed ONLY from the mint closure below, and only while that closure
+    // holds the tracker write-lock, so its state is serialized -- no extra mutex.
+    dgb::AutoRatchet dgb_mint_ratchet = dgb::make_dgb_ratchet();
+
     // DGBWorkSource holds non-owning refs to chain + mempool; both outlive it
     // (declared just above, same scope). The StratumServer co-owns the work
     // source via shared_ptr.
     auto work_source = std::make_shared<dgb::stratum::DGBWorkSource>(
         header_chain, mempool, testnet, std::move(stratum_submit_fn),
         params.subsidy_func);
+
+    // -- Phase B worker->mint run-loop bind --------------------------------
+    // Complete the worker->mint path: when mining_submit classifies a Scrypt
+    // submission as ShareAccept (meets the SHARE target but NOT the block
+    // target), DGBWorkSource::try_mint_share invokes this. mint_local_share_
+    // locked mints the found share into the LIVE sharechain tracker under the
+    // tracker write-lock -- taken NON-BLOCKING on this Stratum-submission thread
+    // (declined, never blocked, if think() holds the exclusive lock; the
+    // ShareAccept handler logs minted-vs-no-credit off the returned hash) --
+    // stamping the AutoRatchet-selected {mint=35, vote=36} version pair. This
+    // replaces the unbound no-op (set_mint_share_fn previously never called).
+    work_source->set_mint_share_fn(
+        [&p2p_node, &params, &dgb_mint_ratchet](
+            const dgb::stratum::DGBWorkSource::MintShareInputs& in) -> uint256 {
+            return dgb::mint_local_share_locked(
+                in, p2p_node, params, dgb_mint_ratchet);
+        });
 
     if (stratum_port != 0) {
         stratum_server = std::make_unique<core::StratumServer>(

--- a/src/impl/dgb/run_loop_mint.hpp
+++ b/src/impl/dgb/run_loop_mint.hpp
@@ -29,7 +29,9 @@
 // prev_share, merkle_branches, payout_script, segwit_active } binds — in
 // production that is DGBWorkSource::MintShareInputs.
 
+#include <mutex>
 #include <optional>
+#include <shared_mutex>
 #include <vector>
 
 #include <core/pack.hpp>                  // PackStream, operator>>
@@ -108,6 +110,38 @@ inline uint256 mint_local_share_with_ratchet(
         std::vector<unsigned char>{},        // frozen_merged_coinbase_info
         static_cast<int64_t>(mint_version),  // share_version (ratchet-selected)
         static_cast<uint64_t>(vote_version)); // desired_version (always target)
+}
+
+// -- Lock-guarded run-loop mint (worker->mint on the Stratum-submission thread) --
+//
+// main_dgb.cpp binds DGBWorkSource::set_mint_share_fn to this. A ShareAccept
+// submission is classified + dispatched on the Stratum-submission thread, which
+// is NOT the compute (think()) thread -- so, unlike the m_on_block_found won-block
+// path, this path does NOT already hold the tracker lock. create_local_share is a
+// tracker WRITE, so the mint MUST take the lock. Per the NodeImpl locking
+// discipline (node.hpp:83-92, mirrored by node.cpp processing_shares_phase2) an
+// IO-thread write takes unique_lock(try_to_lock) and NEVER blocks the io_context
+// on the compute thread exclusive hold. If think() holds the lock the mint is
+// DECLINED this round (NULL uint256; the caller logs the no-credit outcome -- no
+// silent drop, the worker simply earns no sharechain credit until its next
+// submission) rather than blocking the reactor or racing the tracker. A durable
+// defer-queue (cf. the node.cpp pending-share batches) is a tracked follow-up.
+//
+// Duck-typed on NodeT: any node exposing tracker() (-> ShareTracker&) and
+// tracker_mutex() (-> std::shared_mutex&) binds -- in production that is
+// dgb::Node (pool::NodeBridge<NodeImpl, ...>, which inherits both).
+template <typename NodeT, typename InputsT>
+inline uint256 mint_local_share_locked(
+    const InputsT&          in,
+    NodeT&                  node,
+    const core::CoinParams& params,
+    AutoRatchet&            ratchet,
+    uint16_t                donation = 50)
+{
+    std::unique_lock<std::shared_mutex> lock(node.tracker_mutex(), std::try_to_lock);
+    if (!lock.owns_lock())
+        return uint256();  // tracker busy (think() holds exclusive) -- declined, caller logs
+    return mint_local_share_with_ratchet(in, node.tracker(), params, ratchet, donation);
 }
 
 } // namespace dgb

--- a/src/impl/dgb/test/share_test.cpp
+++ b/src/impl/dgb/test/share_test.cpp
@@ -537,3 +537,65 @@ TEST(DGB_run_loop_mint, AdapterFailsClosedOnShortHeader)
     uint256 h = dgb::mint_local_share_with_ratchet(in, tracker, params, ratchet);
     EXPECT_TRUE(h.IsNull());
 }
+
+// ----------------------------------------------------------------------------
+// mint_local_share_locked -- the run-loop bind main_dgb.cpp installs into
+// DGBWorkSource::set_mint_share_fn. It takes the tracker write-lock NON-BLOCKING
+// (the Stratum-submission thread is NOT the compute thread, so it MUST lock, but
+// must never block the io_context on think()s exclusive hold) and declines the
+// mint when the tracker is busy. These pin the lock discipline -- the novel,
+// thread-safety-critical code of this slice.
+// ----------------------------------------------------------------------------
+
+namespace {
+// Minimal node stand-in exposing the two accessors mint_local_share_locked is
+// duck-typed on, over a caller-owned tracker + shared_mutex (production: dgb::Node).
+struct FakeMintNode {
+    dgb::ShareTracker&   t;
+    std::shared_mutex&   m;
+    dgb::ShareTracker&   tracker()       { return t; }
+    std::shared_mutex&   tracker_mutex() { return m; }
+};
+} // namespace
+
+// When think() holds the tracker exclusively, the mint is DECLINED immediately
+// (NULL, no block -- the test would hang if it blocked) and the tracker is left
+// untouched (no silent racy write).
+TEST(DGB_run_loop_mint, LockedMintDeclinesWhenTrackerBusyNoBlock)
+{
+    dgb::ShareTracker tracker;
+    std::shared_mutex mtx;
+    FakeMintNode node{tracker, mtx};
+    auto params  = dgb::make_coin_params(/*testnet=*/false);
+    auto ratchet = dgb::make_dgb_ratchet();
+
+    MintInputsKAT in;
+    in.header_bytes = std::vector<unsigned char>(80, 0);  // would-be-valid length
+
+    std::unique_lock<std::shared_mutex> held(mtx);  // simulate think() exclusive hold
+    const size_t before = tracker.chain.size();
+    uint256 h = dgb::mint_local_share_locked(in, node, params, ratchet);
+    EXPECT_TRUE(h.IsNull());                      // declined, not minted, not blocked
+    EXPECT_EQ(tracker.chain.size(), before);      // tracker untouched under contention
+}
+
+// With the tracker lock FREE, the helper acquires it, runs the adapter, and
+// RELEASES it (RAII) -- proven by re-acquiring exclusively afterward. The short
+// header makes the adapter fail-closed (NULL), which is irrelevant here: the
+// point is the lock was taken and dropped, never held or leaked.
+TEST(DGB_run_loop_mint, LockedMintAcquiresAndReleasesFreeTrackerLock)
+{
+    dgb::ShareTracker tracker;
+    std::shared_mutex mtx;
+    FakeMintNode node{tracker, mtx};
+    auto params  = dgb::make_coin_params(/*testnet=*/false);
+    auto ratchet = dgb::make_dgb_ratchet();
+
+    MintInputsKAT in;
+    in.header_bytes = std::vector<unsigned char>(40, 0);  // short -> adapter fail-closed
+    uint256 h = dgb::mint_local_share_locked(in, node, params, ratchet);
+    EXPECT_TRUE(h.IsNull());
+
+    std::unique_lock<std::shared_mutex> reacquire(mtx, std::try_to_lock);
+    EXPECT_TRUE(reacquire.owns_lock());           // helper released the tracker lock
+}


### PR DESCRIPTION
**Stacked on #305** (base `dgb/phase-b-mint-adapter`). Completes the Phase B worker->mint path.

### What
#305 re-landed the `mint_local_share_with_ratchet` adapter but left `set_mint_share_fn` **unbound** in `main_dgb` — a Scrypt submission classified `ShareAccept` reached `try_mint_share`, found no callback, and earned no sharechain credit (loud no-op, never a silent drop). This binds it.

1. **`run_loop_mint.hpp`** — new `mint_local_share_locked(node, ...)` helper. The mint fires on the **Stratum-submission thread**, *not* the compute (`think()`) thread — so unlike the `m_on_block_found` won-block path it does **not** already hold the tracker lock, and `create_local_share` is a tracker **write**. Per the `NodeImpl` locking discipline (`node.hpp:83-92`, mirrored by `node.cpp` `processing_shares_phase2`) the helper takes `unique_lock(try_to_lock)` and **never blocks the io_context** on `think()`'s exclusive hold: if the tracker is busy the mint is **declined** this round (NULL; the worker earns no credit until its next submission) — never blocked, never a racy write. Durable defer-queue is a tracked follow-up. Duck-typed on the node (`tracker()`/`tracker_mutex()`).
2. **`main_dgb.cpp`** — long-lived `AutoRatchet` (`make_dgb_ratchet`, base 35 / target 36, oracle `22761e7`) declared ahead of `work_source` so it outlives the callback; bound via `set_mint_share_fn`. The ratchet is touched only inside the closure under the tracker lock → state serialized, no extra mutex. In-memory for now (persistence follow-up; a restart re-bootstraps to VOTING, which never regresses a crossed share).

### The lock I take (per integrator's call-out)
`std::unique_lock<std::shared_mutex>(p2p_node.tracker_mutex(), std::try_to_lock)` — non-blocking; declines on contention. This is the deliberate thread-safety choice the adapter punted to the caller.

### Tests / verification
- `share_test.cpp` +2: declines without blocking & leaves the tracker untouched when the lock is held; acquires + releases (RAII) when free.
- `dgb_share_test` **27/27** green; `c2pool-dgb` links.

### Fence
`src/impl/dgb/run_loop_mint.hpp`, `src/c2pool/main_dgb.cpp`, `src/impl/dgb/test/share_test.cpp` only. No shared / `bitcoin_family` / `src/core` / other-coin touch. No new test target → no `build.yml` allowlist change.

**HOLD merge** — consumer-binds the ratchet (consensus-adjacent); surface for operator tap, do not self-merge. Stacked; land after #305.
