### PR TITLE
dgb(phase-b): node-local Redistribute V2 policy port + conformance KAT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
                     test_phase4_embedded \
                     test_mweb_builder \
                     test_address_resolution test_compute_share_target \
-                    test_utxo test_dgb_subsidy test_dgb_coinbase_value dgb_share_test dgb_block_assembly_test dgb_header_sample_build_test dgb_header_ingest_test dgb_mempool_ingest_test \
+                    test_utxo test_dgb_subsidy test_dgb_coinbase_value dgb_share_test dgb_redistribute_test dgb_block_assembly_test dgb_header_sample_build_test dgb_header_ingest_test dgb_mempool_ingest_test \
                     dgb_gentx_coinbase_test nmc_auxpow_merkle_test nmc_template_builder_test nmc_auxpow_wire_test nmc_reconstruct_won_block_test dgb_gentx_share_path_test dgb_other_tx_resolver_test \
 <<<<<<< HEAD
                     dgb_other_tx_assembler_test dgb_reconstruct_won_block_test dgb_reconstruct_closure_test dgb_gentx_unpack_test dgb_work_source_test dgb_template_builder_test dgb_embedded_coin_node_test dgb_embedded_tx_select_test dgb_template_other_txs_test dgb_coinbase_value_parity_test dgb_submit_classify_test dgb_aux_parent_coinbase_parity_test \
@@ -216,7 +216,7 @@ jobs:
                     test_phase4_embedded \
                     test_mweb_builder \
                     test_address_resolution test_compute_share_target \
-                    test_utxo test_dgb_subsidy test_dgb_coinbase_value dgb_share_test dgb_block_assembly_test dgb_header_sample_build_test dgb_header_ingest_test dgb_mempool_ingest_test \
+                    test_utxo test_dgb_subsidy test_dgb_coinbase_value dgb_share_test dgb_redistribute_test dgb_block_assembly_test dgb_header_sample_build_test dgb_header_ingest_test dgb_mempool_ingest_test \
                     dgb_gentx_coinbase_test nmc_auxpow_merkle_test nmc_template_builder_test nmc_auxpow_wire_test nmc_reconstruct_won_block_test dgb_gentx_share_path_test dgb_other_tx_resolver_test \
 <<<<<<< HEAD
                     dgb_other_tx_assembler_test dgb_reconstruct_won_block_test dgb_reconstruct_closure_test dgb_gentx_unpack_test dgb_work_source_test dgb_template_builder_test dgb_embedded_coin_node_test dgb_embedded_tx_select_test dgb_template_other_txs_test dgb_coinbase_value_parity_test dgb_submit_classify_test dgb_aux_parent_coinbase_parity_test \

--- a/src/impl/dgb/redistribute.hpp
+++ b/src/impl/dgb/redistribute.hpp
@@ -1,0 +1,499 @@
+#pragma once
+
+// Redistribute V2: advanced redistribution policy for shares from miners
+// with empty/invalid/broken stratum credentials.
+//
+// V1 modes (4):
+//   pplns  : distribute by PPLNS weight proportionally (default)
+//   fee    : 100% to node operator
+//   boost  : give to active stratum miners with ZERO PPLNS shares
+//   donate : 100% to donation script
+//
+// V2 enhancements:
+//   Graduated boost  : weight by uptime × pseudoshares × difficulty
+//   Hybrid mode      : --redistribute boost:70,donate:20,fee:10
+//   Threshold boost  : boost "unlucky" miners with < 10% expected PPLNS weight
+//   Explicit opt-in  : miners signal via stratum password "boost:true"
+//
+// Consensus-safe: only affects pubkey_hash stamped into shares on this node.
+//
+// Port of p2pool-v36 work.py --redistribute (commit de76224a) + FUTURE.md V2 spec.
+
+#include "config_pool.hpp"
+#include "share_tracker.hpp"
+#include "share_check.hpp"
+
+#include <core/log.hpp>
+#include <core/target_utils.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <map>
+#include <numeric>
+#include <random>
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace dgb
+{
+
+enum class RedistributeMode
+{
+    PPLNS,   // distribute by PPLNS weight proportionally (default)
+    FEE,     // 100% to node operator
+    BOOST,   // give to active miners with zero/low PPLNS shares
+    DONATE   // 100% to donation script
+};
+
+inline RedistributeMode parse_single_mode(const std::string& s)
+{
+    if (s == "fee")    return RedistributeMode::FEE;
+    if (s == "boost")  return RedistributeMode::BOOST;
+    if (s == "donate") return RedistributeMode::DONATE;
+    return RedistributeMode::PPLNS;
+}
+
+inline const char* redistribute_mode_str(RedistributeMode m)
+{
+    switch (m)
+    {
+    case RedistributeMode::FEE:    return "fee";
+    case RedistributeMode::BOOST:  return "boost";
+    case RedistributeMode::DONATE: return "donate";
+    default:                       return "pplns";
+    }
+}
+
+// --- V2: Hybrid mode weight entry ---
+struct HybridWeight
+{
+    RedistributeMode mode;
+    uint32_t weight;
+};
+
+// Parse hybrid mode string: "boost:70,donate:20,fee:10" or single "boost"
+inline std::vector<HybridWeight> parse_redistribute_spec(const std::string& spec)
+{
+    std::vector<HybridWeight> result;
+    if (spec.empty())
+    {
+        result.push_back({RedistributeMode::PPLNS, 100});
+        return result;
+    }
+
+    // Check for hybrid format (contains ':')
+    if (spec.find(':') != std::string::npos)
+    {
+        std::istringstream ss(spec);
+        std::string token;
+        while (std::getline(ss, token, ','))
+        {
+            auto colon = token.find(':');
+            if (colon != std::string::npos)
+            {
+                auto mode_str = token.substr(0, colon);
+                auto weight_str = token.substr(colon + 1);
+                auto mode = parse_single_mode(mode_str);
+                uint32_t w = 0;
+                try { w = static_cast<uint32_t>(std::stoul(weight_str)); } catch (...) {}
+                if (w > 0)
+                    result.push_back({mode, w});
+            }
+        }
+    }
+
+    // Single mode fallback
+    if (result.empty())
+        result.push_back({parse_single_mode(spec), 100});
+
+    return result;
+}
+
+// Backward-compatible: returns the primary mode (first/only entry)
+inline RedistributeMode parse_redistribute_mode(const std::string& spec)
+{
+    auto weights = parse_redistribute_spec(spec);
+    return weights.empty() ? RedistributeMode::PPLNS : weights[0].mode;
+}
+
+// Format hybrid weights for display
+inline std::string format_hybrid_weights(const std::vector<HybridWeight>& weights)
+{
+    if (weights.size() == 1)
+        return redistribute_mode_str(weights[0].mode);
+    std::ostringstream oss;
+    for (size_t i = 0; i < weights.size(); ++i) {
+        if (i > 0) oss << ",";
+        oss << redistribute_mode_str(weights[i].mode) << ":" << weights[i].weight;
+    }
+    return oss.str();
+}
+
+struct RedistributeResult
+{
+    uint160 pubkey_hash;
+    uint8_t pubkey_type = 0; // 0=P2PKH, 1=P2WPKH, 2=P2SH
+};
+
+// --- V2: Graduated boost entry with scoring ---
+struct GraduatedMinerInfo
+{
+    uint160 pubkey_hash;
+    uint8_t pubkey_type = 0;
+    double  uptime_hours = 0;        // connection duration (capped at 24)
+    uint64_t pseudoshares = 0;        // accepted pseudoshare count
+    double  difficulty = 0;           // current stratum difficulty
+    bool    opt_in_boost = false;     // explicit opt-in via password
+};
+
+// --- V2: Stratum password options ---
+struct StratumPasswordOpts
+{
+    bool boost = false;       // boost:true
+    double min_diff = 0;      // d=N
+};
+
+inline StratumPasswordOpts parse_stratum_password(const std::string& password)
+{
+    StratumPasswordOpts opts;
+    if (password.empty()) return opts;
+
+    std::istringstream ss(password);
+    std::string token;
+    while (std::getline(ss, token, ','))
+    {
+        auto eq = token.find(':');
+        if (eq == std::string::npos) eq = token.find('=');
+        if (eq == std::string::npos) continue;
+
+        auto key = token.substr(0, eq);
+        auto val = token.substr(eq + 1);
+
+        if (key == "boost")
+            opts.boost = (val == "true" || val == "1" || val == "yes");
+        else if (key == "d")
+            try { opts.min_diff = std::stod(val); } catch (...) {}
+    }
+    return opts;
+}
+
+class Redistributor
+{
+public:
+    Redistributor() = default;
+
+    // V1: single mode
+    void set_mode(RedistributeMode mode)
+    {
+        hybrid_weights_.clear();
+        hybrid_weights_.push_back({mode, 100});
+    }
+    RedistributeMode mode() const
+    {
+        return hybrid_weights_.empty() ? RedistributeMode::PPLNS : hybrid_weights_[0].mode;
+    }
+
+    // V2: hybrid mode
+    void set_hybrid_weights(const std::vector<HybridWeight>& weights)
+    {
+        hybrid_weights_ = weights;
+    }
+    const std::vector<HybridWeight>& hybrid_weights() const { return hybrid_weights_; }
+
+    // V2: threshold ratio (default 0.1 = 10% of expected weight)
+    void set_threshold_ratio(double ratio) { threshold_ratio_ = ratio; }
+
+    // Set the node operator's payout identity (for "fee" mode)
+    void set_operator_identity(const uint160& hash, uint8_t type)
+    {
+        operator_hash_ = hash;
+        operator_type_ = type;
+    }
+
+    // Set the donation script identity (for "donate" mode)
+    void set_donation_identity(const uint160& hash, uint8_t type)
+    {
+        donation_hash_ = hash;
+        donation_type_ = type;
+    }
+
+    // Pick a (pubkey_hash, pubkey_type) for shares from unnamed/broken miners.
+    RedistributeResult pick(ShareTracker& tracker, const uint256& best_share_hash)
+    {
+        if (hybrid_weights_.empty())
+            return {operator_hash_, operator_type_};
+
+        // V2: Hybrid mode — roll random, pick mode by weight
+        RedistributeMode selected_mode;
+        if (hybrid_weights_.size() == 1)
+        {
+            selected_mode = hybrid_weights_[0].mode;
+        }
+        else
+        {
+            uint32_t total_weight = 0;
+            for (auto& hw : hybrid_weights_) total_weight += hw.weight;
+            std::uniform_int_distribution<uint32_t> dist(0, total_weight - 1);
+            uint32_t r = dist(rng_);
+            uint32_t cumul = 0;
+            selected_mode = hybrid_weights_.back().mode;
+            for (auto& hw : hybrid_weights_)
+            {
+                cumul += hw.weight;
+                if (r < cumul) { selected_mode = hw.mode; break; }
+            }
+        }
+
+        return pick_for_mode(selected_mode, tracker, best_share_hash);
+    }
+
+    // Register a callback that returns connected miner stats (V2 graduated).
+    using graduated_miners_fn = std::function<std::vector<GraduatedMinerInfo>()>;
+    void set_graduated_miners_fn(graduated_miners_fn fn) { graduated_miners_fn_ = std::move(fn); }
+
+    // V1 compat: register simple connected miners callback
+    using connected_miners_fn = std::function<std::vector<RedistributeResult>()>;
+    void set_connected_miners_fn(connected_miners_fn fn) { connected_miners_fn_ = std::move(fn); }
+
+    // V2: pool hashrate callback (for threshold boost)
+    using pool_hashrate_fn = std::function<double()>;
+    void set_pool_hashrate_fn(pool_hashrate_fn fn) { pool_hashrate_fn_ = std::move(fn); }
+
+private:
+    std::vector<HybridWeight> hybrid_weights_ = {{RedistributeMode::PPLNS, 100}};
+    double threshold_ratio_ = 0.1; // 10% of expected weight
+    uint160 operator_hash_;
+    uint8_t operator_type_ = 0;
+    uint160 donation_hash_;
+    uint8_t donation_type_ = 2; // P2SH for combined donation
+    std::mt19937 rng_{std::random_device{}()};
+
+    // PPLNS cache
+    struct PplnsEntry { std::vector<unsigned char> script; uint160 hash; uint8_t type; uint64_t weight; };
+    std::vector<PplnsEntry> pplns_cache_;
+    int64_t pplns_cache_ts_ = 0;
+
+    graduated_miners_fn graduated_miners_fn_;
+    connected_miners_fn connected_miners_fn_;
+    pool_hashrate_fn pool_hashrate_fn_;
+
+    RedistributeResult pick_for_mode(RedistributeMode mode, ShareTracker& tracker, const uint256& best)
+    {
+        switch (mode)
+        {
+        case RedistributeMode::FEE:
+            return {operator_hash_, operator_type_};
+
+        case RedistributeMode::DONATE:
+            return {donation_hash_, donation_type_};
+
+        case RedistributeMode::BOOST:
+            return pick_boost(tracker, best);
+
+        case RedistributeMode::PPLNS:
+        default:
+            return pick_pplns(tracker, best);
+        }
+    }
+
+    // V2: graduated boost with threshold support
+    RedistributeResult pick_boost(ShareTracker& tracker, const uint256& best)
+    {
+        // Try V2 graduated boost first
+        if (graduated_miners_fn_)
+        {
+            auto miners = graduated_miners_fn_();
+            refresh_pplns_cache(tracker, best);
+
+            // Build PPLNS address set + weight map
+            std::set<uint160> pplns_addrs;
+            std::map<uint160, uint64_t> pplns_weight_map;
+            uint64_t total_pplns_weight = 0;
+            for (auto& e : pplns_cache_)
+            {
+                pplns_addrs.insert(e.hash);
+                pplns_weight_map[e.hash] = e.weight;
+                total_pplns_weight += e.weight;
+            }
+
+            // Score each miner
+            struct ScoredMiner { RedistributeResult result; double score; };
+            std::vector<ScoredMiner> candidates;
+
+            for (auto& m : miners)
+            {
+                bool is_zero_share = (pplns_addrs.find(m.pubkey_hash) == pplns_addrs.end());
+                bool is_threshold_eligible = false;
+
+                // V2: threshold boost — check luck ratio
+                if (!is_zero_share && total_pplns_weight > 0 && m.difficulty > 0)
+                {
+                    double actual_weight = static_cast<double>(pplns_weight_map[m.pubkey_hash]);
+                    double actual_ratio = actual_weight / static_cast<double>(total_pplns_weight);
+
+                    // Estimate expected ratio from miner's hashrate
+                    double pool_hr = pool_hashrate_fn_ ? pool_hashrate_fn_() : 0;
+                    if (pool_hr > 0)
+                    {
+                        double miner_hr = m.pseudoshares * m.difficulty / std::max(m.uptime_hours * 3600.0, 1.0);
+                        double expected_ratio = miner_hr / pool_hr;
+                        double luck_ratio = (expected_ratio > 0) ? (actual_ratio / expected_ratio) : 1.0;
+                        is_threshold_eligible = (luck_ratio < threshold_ratio_);
+                    }
+                }
+
+                // Eligible: zero-share miners, threshold-eligible miners, or opt-in miners
+                if (is_zero_share || is_threshold_eligible || m.opt_in_boost)
+                {
+                    // V2: graduated score = uptime × pseudoshares × difficulty
+                    double uptime_w = std::min(m.uptime_hours, 24.0);
+                    double pseudo_w = static_cast<double>(m.pseudoshares + 1);
+                    double diff_w = std::max(m.difficulty, 0.001);
+                    double score = uptime_w * pseudo_w * diff_w;
+
+                    // Threshold-eligible miners get inverse-luck bonus
+                    if (is_threshold_eligible && total_pplns_weight > 0)
+                    {
+                        double actual = static_cast<double>(pplns_weight_map[m.pubkey_hash]);
+                        double ratio = actual / static_cast<double>(total_pplns_weight);
+                        score *= 1.0 / std::max(ratio, 0.001); // unluckier = higher score
+                    }
+
+                    if (score > 0)
+                        candidates.push_back({{m.pubkey_hash, m.pubkey_type}, score});
+                }
+            }
+
+            if (!candidates.empty())
+            {
+                // Weighted random selection by score
+                double total_score = 0;
+                for (auto& c : candidates) total_score += c.score;
+                std::uniform_real_distribution<double> dist(0, total_score);
+                double r = dist(rng_);
+                double cumul = 0;
+                for (auto& c : candidates)
+                {
+                    cumul += c.score;
+                    if (r < cumul)
+                        return c.result;
+                }
+                return candidates.back().result;
+            }
+        }
+
+        // V1 fallback: simple zero-share boost
+        if (connected_miners_fn_)
+        {
+            auto connected = connected_miners_fn_();
+            refresh_pplns_cache(tracker, best);
+            std::set<uint160> pplns_addrs;
+            for (auto& e : pplns_cache_) pplns_addrs.insert(e.hash);
+
+            std::vector<RedistributeResult> zero_miners;
+            for (auto& m : connected)
+            {
+                if (pplns_addrs.find(m.pubkey_hash) == pplns_addrs.end())
+                    zero_miners.push_back(m);
+            }
+            if (!zero_miners.empty())
+            {
+                std::uniform_int_distribution<size_t> dist(0, zero_miners.size() - 1);
+                return zero_miners[dist(rng_)];
+            }
+        }
+
+        // Final fallback: PPLNS
+        return pick_pplns(tracker, best);
+    }
+
+    RedistributeResult pick_pplns(ShareTracker& tracker, const uint256& best)
+    {
+        refresh_pplns_cache(tracker, best);
+
+        if (pplns_cache_.empty())
+            return {operator_hash_, operator_type_};
+
+        uint64_t total = 0;
+        for (auto& e : pplns_cache_) total += e.weight;
+        if (total == 0)
+            return {operator_hash_, operator_type_};
+
+        std::uniform_int_distribution<uint64_t> dist(0, total - 1);
+        uint64_t r = dist(rng_);
+        uint64_t cumulative = 0;
+        for (auto& e : pplns_cache_)
+        {
+            cumulative += e.weight;
+            if (r < cumulative)
+                return {e.hash, e.type};
+        }
+        return {pplns_cache_.back().hash, pplns_cache_.back().type};
+    }
+
+    void refresh_pplns_cache(ShareTracker& tracker, const uint256& best)
+    {
+        auto now = std::chrono::duration_cast<std::chrono::seconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+        if (now - pplns_cache_ts_ < 30 && !pplns_cache_.empty())
+            return;
+
+        pplns_cache_.clear();
+        pplns_cache_ts_ = now;
+
+        if (best.IsNull())
+            return;
+
+        auto [height, last] = tracker.chain.get_height_and_last(best);
+        int32_t depth = std::min(height, static_cast<int32_t>(PoolConfig::real_chain_length()));
+        if (depth < 1)
+            return;
+
+        struct AccumEntry { std::vector<unsigned char> script; uint160 hash; uint8_t type; uint64_t weight; };
+        std::map<std::vector<unsigned char>, AccumEntry> addr_work;
+        auto chain_view = tracker.chain.get_chain(best, depth);
+        for (auto [hash, data] : chain_view)
+        {
+            std::vector<unsigned char> script;
+            uint160 pk_hash;
+            uint8_t pk_type = 0;
+            uint64_t work = 0;
+            data.share.invoke([&](auto* obj) {
+                script = get_share_script(obj);
+                auto target = chain::bits_to_target(obj->m_bits);
+                auto att = chain::target_to_average_attempts(target);
+                work = att.GetLow64();
+                if constexpr (requires { obj->m_pubkey_type; }) {
+                    pk_hash = obj->m_pubkey_hash;
+                    pk_type = obj->m_pubkey_type;
+                } else if constexpr (requires { obj->m_pubkey_hash; }) {
+                    pk_hash = obj->m_pubkey_hash;
+                    pk_type = 0;
+                } else {
+                    if (script.size() == 25 && script[0] == 0x76 && script[1] == 0xa9)
+                        std::memcpy(pk_hash.data(), script.data() + 3, 20);
+                    else if (script.size() >= 22 && script[0] == 0x00 && script[1] == 0x14)
+                        std::memcpy(pk_hash.data(), script.data() + 2, 20);
+                    else if (script.size() >= 20)
+                        std::memcpy(pk_hash.data(), script.data(), 20);
+                }
+            });
+            auto& entry = addr_work[script];
+            entry.script = script;
+            entry.hash = pk_hash;
+            entry.type = pk_type;
+            entry.weight += work;
+        }
+
+        pplns_cache_.reserve(addr_work.size());
+        for (auto& [_, e] : addr_work)
+            pplns_cache_.push_back({e.script, e.hash, e.type, e.weight});
+    }
+};
+
+} // namespace dgb

--- a/src/impl/dgb/test/CMakeLists.txt
+++ b/src/impl/dgb/test/CMakeLists.txt
@@ -471,4 +471,20 @@ if (BUILD_TESTING AND GTest_FOUND)
         nlohmann_json::nlohmann_json)
     gtest_add_tests(dgb_template_capture_test "" AUTO)
 
+    # dgb_redistribute_test: pins src/impl/dgb/redistribute.hpp, the node-local
+    # Redistribute V2 policy ported byte-for-byte from src/impl/ltc (namespace
+    # flip only) -- mode/spec parsing, hybrid format round-trip, stratum-password
+    # options, and the deterministic FEE/DONATE/empty-PPLNS pick branches. The
+    # header consumes share_tracker + share_check + config_pool, so it links the
+    # same set as dgb_share_test. CONSENSUS-SAFE (only the locally-stamped
+    # pubkey_hash), bucket-2 cross-coin standardization. MUST also be in BOTH
+    # build.yml --target allowlists (#143 NOT_BUILT trap).
+    add_executable(dgb_redistribute_test redistribute_test.cpp)
+    target_link_libraries(dgb_redistribute_test PRIVATE
+        GTest::gtest_main GTest::gtest
+        core dgb
+        c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage
+        dgb_coin pool sharechain)
+    gtest_add_tests(dgb_redistribute_test "" AUTO)
+
 endif()

--- a/src/impl/dgb/test/redistribute_test.cpp
+++ b/src/impl/dgb/test/redistribute_test.cpp
@@ -1,0 +1,139 @@
+// DGB Scrypt-only coin module — Redistribute V2 conformance fixtures (Phase B).
+// Mirrors src/impl/dgb/redistribute.hpp, ported byte-for-byte from
+// src/impl/ltc/redistribute.hpp (namespace flip only). Pins the deterministic
+// surface of the node-local redistribution policy against the documented
+// p2pool-v36 work.py --redistribute spec (commit de76224a) + FUTURE.md V2:
+// mode parsing, hybrid spec parse/format round-trip, stratum-password options,
+// and the deterministic FEE/DONATE/empty-PPLNS pick paths.
+//
+// CONSENSUS-SAFE: redistribute only chooses the pubkey_hash this node stamps
+// into its own shares — it never alters sharechain validation, so this is a
+// bucket-2 v36-native standardization slice (cross-coin parity toward the ltc
+// shape), node-local, no operator tap. The RNG-weighted boost/PPLNS selection
+// paths are intentionally NOT pinned here (non-deterministic by design); the
+// single-candidate and fallback branches that ARE deterministic are pinned.
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include <impl/dgb/redistribute.hpp>
+#include <impl/dgb/share_tracker.hpp>
+
+namespace {
+
+// --- mode <-> string round-trip (work.py mode names) ----------------------
+TEST(DgbRedistribute, ParseSingleModeAndStringRoundTrip)
+{
+    EXPECT_EQ(dgb::parse_single_mode("pplns"),  dgb::RedistributeMode::PPLNS);
+    EXPECT_EQ(dgb::parse_single_mode("fee"),    dgb::RedistributeMode::FEE);
+    EXPECT_EQ(dgb::parse_single_mode("boost"),  dgb::RedistributeMode::BOOST);
+    EXPECT_EQ(dgb::parse_single_mode("donate"), dgb::RedistributeMode::DONATE);
+    // Unknown / empty defaults to PPLNS (work.py default).
+    EXPECT_EQ(dgb::parse_single_mode("garbage"), dgb::RedistributeMode::PPLNS);
+    EXPECT_EQ(dgb::parse_single_mode(""),        dgb::RedistributeMode::PPLNS);
+
+    EXPECT_STREQ(dgb::redistribute_mode_str(dgb::RedistributeMode::PPLNS),  "pplns");
+    EXPECT_STREQ(dgb::redistribute_mode_str(dgb::RedistributeMode::FEE),    "fee");
+    EXPECT_STREQ(dgb::redistribute_mode_str(dgb::RedistributeMode::BOOST),  "boost");
+    EXPECT_STREQ(dgb::redistribute_mode_str(dgb::RedistributeMode::DONATE), "donate");
+}
+
+// --- single-mode spec parse -----------------------------------------------
+TEST(DgbRedistribute, ParseSpecSingleMode)
+{
+    auto w = dgb::parse_redistribute_spec("boost");
+    ASSERT_EQ(w.size(), 1u);
+    EXPECT_EQ(w[0].mode, dgb::RedistributeMode::BOOST);
+    EXPECT_EQ(w[0].weight, 100u);
+
+    // Empty spec -> implicit pplns:100
+    auto e = dgb::parse_redistribute_spec("");
+    ASSERT_EQ(e.size(), 1u);
+    EXPECT_EQ(e[0].mode, dgb::RedistributeMode::PPLNS);
+    EXPECT_EQ(e[0].weight, 100u);
+
+    EXPECT_EQ(dgb::parse_redistribute_mode("donate"), dgb::RedistributeMode::DONATE);
+}
+
+// --- hybrid spec parse + format round-trip --------------------------------
+TEST(DgbRedistribute, ParseHybridSpecAndFormatRoundTrip)
+{
+    auto w = dgb::parse_redistribute_spec("boost:70,donate:20,fee:10");
+    ASSERT_EQ(w.size(), 3u);
+    EXPECT_EQ(w[0].mode, dgb::RedistributeMode::BOOST);  EXPECT_EQ(w[0].weight, 70u);
+    EXPECT_EQ(w[1].mode, dgb::RedistributeMode::DONATE); EXPECT_EQ(w[1].weight, 20u);
+    EXPECT_EQ(w[2].mode, dgb::RedistributeMode::FEE);    EXPECT_EQ(w[2].weight, 10u);
+
+    // Primary mode is the first entry.
+    EXPECT_EQ(dgb::parse_redistribute_mode("boost:70,donate:20,fee:10"),
+              dgb::RedistributeMode::BOOST);
+
+    // Format round-trip: hybrid renders mode:weight CSV, single renders bare.
+    EXPECT_EQ(dgb::format_hybrid_weights(w), "boost:70,donate:20,fee:10");
+    auto single = dgb::parse_redistribute_spec("fee");
+    EXPECT_EQ(dgb::format_hybrid_weights(single), "fee");
+
+    // Zero-weight entries are dropped (w>0 guard).
+    auto z = dgb::parse_redistribute_spec("boost:0,donate:50");
+    ASSERT_EQ(z.size(), 1u);
+    EXPECT_EQ(z[0].mode, dgb::RedistributeMode::DONATE);
+    EXPECT_EQ(z[0].weight, 50u);
+}
+
+// --- stratum password options (boost opt-in, min diff) --------------------
+TEST(DgbRedistribute, ParseStratumPassword)
+{
+    auto a = dgb::parse_stratum_password("boost:true");
+    EXPECT_TRUE(a.boost);
+
+    auto b = dgb::parse_stratum_password("boost=1,d=1024");
+    EXPECT_TRUE(b.boost);
+    EXPECT_DOUBLE_EQ(b.min_diff, 1024.0);
+
+    auto c = dgb::parse_stratum_password("boost:false");
+    EXPECT_FALSE(c.boost);
+
+    auto d = dgb::parse_stratum_password("");
+    EXPECT_FALSE(d.boost);
+    EXPECT_DOUBLE_EQ(d.min_diff, 0.0);
+}
+
+// --- deterministic pick paths (FEE / DONATE / empty-PPLNS fallback) -------
+TEST(DgbRedistribute, DeterministicPickPaths)
+{
+    dgb::Redistributor r;
+
+    uint160 op_hash;  std::memset(op_hash.data(),  0xAA, 20);
+    uint160 don_hash; std::memset(don_hash.data(), 0xBB, 20);
+    r.set_operator_identity(op_hash, /*P2PKH*/ 0);
+    r.set_donation_identity(don_hash, /*P2SH*/ 2);
+
+    dgb::ShareTracker tracker;     // empty
+    uint256 best;                  // null -> PPLNS short-circuits to operator
+
+    // FEE -> 100% operator identity.
+    r.set_mode(dgb::RedistributeMode::FEE);
+    auto fee = r.pick(tracker, best);
+    EXPECT_EQ(fee.pubkey_hash, op_hash);
+    EXPECT_EQ(fee.pubkey_type, 0);
+
+    // DONATE -> 100% donation identity (P2SH type 2 for combined donation).
+    r.set_mode(dgb::RedistributeMode::DONATE);
+    auto don = r.pick(tracker, best);
+    EXPECT_EQ(don.pubkey_hash, don_hash);
+    EXPECT_EQ(don.pubkey_type, 2);
+
+    // PPLNS over an empty tracker -> operator fallback (no shares to weight).
+    r.set_mode(dgb::RedistributeMode::PPLNS);
+    auto pplns = r.pick(tracker, best);
+    EXPECT_EQ(pplns.pubkey_hash, op_hash);
+    EXPECT_EQ(pplns.pubkey_type, 0);
+
+    // Mode accessor reflects the last single-mode set.
+    EXPECT_EQ(r.mode(), dgb::RedistributeMode::PPLNS);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary
Phase B pool/share slice. Ports `src/impl/ltc/redistribute.hpp` into `src/impl/dgb/` (namespace flip only; zero internal `ltc::` qualifiers) so the DGB node gains the same `--redistribute` pubkey-stamping policy as the LTC reference: pplns/fee/boost/donate modes, hybrid weighting, graduated/threshold boost, stratum-password opt-in.

**Consensus-safe / node-local:** redistribute only chooses the `pubkey_hash` THIS node stamps into its own shares. Sharechain validation, share codec, and PPLNS math are untouched. No divergence from `p2pool-merged-v36` / the `frstrtr/p2pool-dgb-scrypt` oracle.

**3-bucket classification:** bucket-2 (v36-native SHARED STRUCTURE). The redistribution policy is cross-coin shared structure ported toward the unified v37 shape, not re-invented per coin.

## Scope (fence)
- `src/impl/dgb/redistribute.hpp` (new, ported)
- `src/impl/dgb/test/redistribute_test.cpp` (new, 5 KATs)
- `src/impl/dgb/test/CMakeLists.txt` (register `dgb_redistribute_test`)
- `.github/workflows/build.yml` (BOTH --target allowlists, #143 trap)

No shared-base / bitcoin_family / ltc / doge / btc touch.

## Tests
`dgb_redistribute_test` 5/5 green locally (Release, COIN_DGB=ON): mode/spec parse, hybrid format round-trip, stratum-password options, FEE/DONATE/empty-PPLNS deterministic pick branches vs documented work.py --redistribute spec (de76224a).

## Follow-up (not in this slice)
`main_dgb` `--redistribute` arg parsing + Redistributor wiring into the won-block coinbase pubkey selection (mirrors `c2pool_refactored.cpp` for the ltc binary).

HOLD merge — surfaced for review; integrator merges on operator push approval.