### PR TITLE
dgb(phase-b): wire --redistribute selector into the won-block payout path (follow-up to #307)

### DIFF
--- a/src/c2pool/main_dgb.cpp
+++ b/src/c2pool/main_dgb.cpp
@@ -43,6 +43,8 @@
 #include <impl/dgb/coin/header_ingest.hpp>
 #include <impl/dgb/coin/mempool_ingest.hpp>
 #include <impl/dgb/stratum/work_source.hpp>
+#include <impl/dgb/redistribute.hpp>    // Redistribute V2 node-local payout policy (#307)
+#include <impl/dgb/config_pool.hpp>     // PoolConfig::COMBINED_DONATION_SCRIPT (donate identity)
 #include <impl/dgb/coin/p2p_node.hpp>
 #include <impl/dgb/coin/rpc.hpp>        // NodeRPC — external-daemon submitblock arm (#82)
 #include <impl/dgb/coin/rpc_conf.hpp>   // digibyte.conf creds resolution (rpcpassword off argv)
@@ -93,7 +95,8 @@ void print_banner(const char* argv0, const core::CoinParams& p)
         << "Usage: " << argv0
         << " [--version] [--help] [--selftest] [--run] [--stratum [H:]P]\n"
         << "       [--coin-daemon H:P] [--coin-magic HEX] [--regtest]\n"
-        << "       [--regtest-force-won-share] [--no-p2p-relay]\n\n"
+        << "       [--regtest-force-won-share] [--no-p2p-relay]\n"
+        << "       [--redistribute SPEC]\n\n"
         << "Status: pool/sharechain pillars live (Phase B); run-loop up\n"
         << "        (--run: io_context + sharechain peer + Stratum standup).\n"
         << "        --stratum [HOST:]PORT binds a miner-facing TCP listener\n"
@@ -155,7 +158,8 @@ int run_node(const core::CoinParams& params, bool testnet,
              const std::string& rpc_endpoint,
              const std::string& rpc_conf_path,
              bool regtest = false, bool force_won_share = false,
-             bool no_p2p_relay = false)
+             bool no_p2p_relay = false,
+             const std::string& redistribute_spec = "")
 {
     io::io_context ioc;
 
@@ -615,6 +619,59 @@ int run_node(const core::CoinParams& params, bool testnet,
         header_chain, mempool, testnet, std::move(stratum_submit_fn),
         params.subsidy_func);
 
+    // -- --redistribute: node-local payout policy (Redistribute V2, #307) ------
+    // Opt-in ONLY. Chooses the pubkey this node stamps onto shares minted from
+    // submissions whose stratum username carries no valid payout address. It
+    // touches NOTHING on the sharechain (validation/codec/PPLNS unchanged) -- it
+    // is node-local and consensus-safe. Absent --redistribute the fallback stays
+    // unbound and the empty-credential path is byte-identical to prior builds.
+    if (!redistribute_spec.empty()) {
+        auto redistributor = std::make_shared<dgb::Redistributor>();
+        redistributor->set_hybrid_weights(dgb::parse_redistribute_spec(redistribute_spec));
+        // "donate" identity: P2SH hash160 == COMBINED_DONATION_SCRIPT[2..22]
+        // (V36 1-of-2 forrestv+maintainer combined donation, byte-identical to
+        // the gentx donation output). "fee" needs an operator payout identity
+        // not yet plumbed here -> pick() returns a null hash for it and the
+        // fallback yields an empty script (fail-safe: never a burn output).
+        {
+            const auto& ds = dgb::PoolConfig::COMBINED_DONATION_SCRIPT;
+            uint160 donation_hash;
+            std::memcpy(donation_hash.data(), ds.data() + 2, 20);
+            redistributor->set_donation_identity(donation_hash, /*P2SH=*/2);
+        }
+        auto& redist_tracker = p2p_node.tracker();
+        work_source->set_fallback_payout_fn(
+            [redistributor, &redist_tracker, ws = work_source.get()]()
+                -> std::vector<unsigned char> {
+                uint256 best;
+                if (auto bf = ws->get_best_share_hash_fn()) best = bf();
+                const dgb::RedistributeResult r = redistributor->pick(redist_tracker, best);
+                if (r.pubkey_hash.IsNull())
+                    return {};   // unconfigured identity -> fail-safe (no burn)
+                // Build the scriptPubKey from the RAW 20-byte hash (storage
+                // order). NB: do NOT route through uint160::GetHex() -- it
+                // emits reversed (big-endian) hex, which would stamp a byte-
+                // reversed hash. .data() gives the script-order bytes verbatim.
+                unsigned char hb[20];
+                std::memcpy(hb, r.pubkey_hash.data(), 20);
+                std::vector<unsigned char> script;
+                if (r.pubkey_type == 2) {            // P2SH: a9 14 <hash160> 87
+                    script = {0xa9, 0x14};
+                    script.insert(script.end(), hb, hb + 20);
+                    script.push_back(0x87);
+                } else {                             // P2PKH: 76 a9 14 <hash160> 88 ac
+                    script = {0x76, 0xa9, 0x14};
+                    script.insert(script.end(), hb, hb + 20);
+                    script.push_back(0x88);
+                    script.push_back(0xac);
+                }
+                return script;
+            });
+        std::cout << "[DGB] redistribute policy ENABLED: \"" << redistribute_spec
+                  << "\" (node-local payout for unnamed miners; consensus-safe)"
+                  << std::endl;
+    }
+
     if (stratum_port != 0) {
         stratum_server = std::make_unique<core::StratumServer>(
             ioc, stratum_addr, stratum_port, work_source);
@@ -864,6 +921,7 @@ int main(int argc, char** argv)
     uint256 coin_genesis;                   // --coin-genesis HASH (initial getheaders locator base)
     std::string rpc_endpoint;               // --coin-rpc HOST:PORT (external digibyted submit arm)
     std::string rpc_conf_path;              // --coin-rpc-auth PATH to digibyte.conf (creds source)
+    std::string redistribute_spec;         // --redistribute SPEC (node-local payout policy, #307)
     // ── #82 regtest-gated forced-won-share LIVE seam (decision (a), 2026-06-21) ──
     // --regtest-force-won-share synthesizes ONE won share into the live
     // ShareTracker and fires m_on_block_found AFTER both broadcast arms are
@@ -915,6 +973,9 @@ int main(int argc, char** argv)
         if (std::strcmp(argv[i], "--regtest-force-won-share") == 0)
             force_won_share = true;                 // gated below: regtest-ONLY
         if (std::strcmp(argv[i], "--no-p2p-relay") == 0) no_p2p_relay = true;
+        if (std::strcmp(argv[i], "--redistribute") == 0 && i + 1 < argc) {
+            redistribute_spec = argv[++i];     // pplns|fee|boost|donate or hybrid "boost:70,donate:20"
+        }
     }
 
     const core::CoinParams params = dgb::make_coin_params(/*testnet=*/false);
@@ -928,7 +989,8 @@ int main(int argc, char** argv)
         return run_node(params, /*testnet=*/false, stratum_addr, stratum_port,
                         coin_daemon, coin_magic, coin_genesis,
                         rpc_endpoint, rpc_conf_path,
-                        regtest, force_won_share, no_p2p_relay);
+                        regtest, force_won_share, no_p2p_relay,
+                        redistribute_spec);
 
     // --selftest, or a bare invocation: drive the live score path so the
     // binary exercises real consensus code, then exit cleanly.

--- a/src/impl/dgb/stratum/work_source.cpp
+++ b/src/impl/dgb/stratum/work_source.cpp
@@ -513,6 +513,22 @@ nlohmann::json DGBWorkSource::mining_submit(
         in.prev_share      = job->prev_share_hash;
         in.merkle_branches = branch_hashes;
         in.payout_script   = core::address_to_script(username);
+        // Redistribute V2 (#307): a miner with empty/broken stratum creds
+        // yields no payout script. When the operator opted into a
+        // --redistribute policy (fallback bound) let it choose the pubkey this
+        // node stamps onto the minted share; else leave it empty (byte-
+        // identical to before). Fail-safe: an empty fallback is left empty.
+        if (in.payout_script.empty()) {
+            FallbackPayoutFn fb;
+            { std::lock_guard<std::mutex> lk(fallback_payout_mutex_); fb = fallback_payout_fn_; }
+            if (fb) {
+                in.payout_script = fb();
+                if (!in.payout_script.empty())
+                    LOG_INFO << "[DGB-STRATUM-SHARE] empty payout addr (user=" << username
+                             << ") -> redistribute policy stamped fallback script ("
+                             << in.payout_script.size() << "B)";
+            }
+        }
         in.segwit_active   = job->segwit_active;
 
         uint256 share_hash = try_mint_share(in);
@@ -570,6 +586,12 @@ void DGBWorkSource::set_mint_share_fn(MintShareFn fn)
 {
     std::lock_guard<std::mutex> lk(mint_share_mutex_);
     mint_share_fn_ = std::move(fn);
+}
+
+void DGBWorkSource::set_fallback_payout_fn(FallbackPayoutFn fn)
+{
+    std::lock_guard<std::mutex> lk(fallback_payout_mutex_);
+    fallback_payout_fn_ = std::move(fn);
 }
 
 uint256 DGBWorkSource::try_mint_share(const MintShareInputs& in) const

--- a/src/impl/dgb/stratum/work_source.hpp
+++ b/src/impl/dgb/stratum/work_source.hpp
@@ -199,6 +199,16 @@ public:
     /// silently dropping an accepted share.
     void set_mint_share_fn(MintShareFn fn);
 
+    /// Optional node-local fallback payout selector (Redistribute V2, #307).
+    /// Invoked by the ShareAccept mint path when a submission's stratum
+    /// username yields NO valid payout script (empty/broken credentials): it
+    /// returns the scriptPubKey this node stamps onto the minted share per the
+    /// operator's --redistribute policy. Empty until bound (opt-in only);
+    /// while unbound the empty-credential path is byte-identical to before.
+    /// Consensus-safe: chooses only this node's own stamp, not sharechain rules.
+    using FallbackPayoutFn = std::function<std::vector<unsigned char>()>;
+    void set_fallback_payout_fn(FallbackPayoutFn fn);
+
     /// Dispatch one share-difficulty submission to the bound mint callback.
     /// The stage-4d mining_submit classify branch calls this on the
     /// "pow_hash <= share target" outcome. Returns the minted share hash, or a
@@ -252,6 +262,12 @@ private:
     // mining_submit classify branch no-ops the mint when unbound.
     mutable std::mutex          mint_share_mutex_;
     MintShareFn                 mint_share_fn_;
+
+    // Node-local --redistribute fallback payout selector (#307). Empty until
+    // bound in main_dgb; consumed by the ShareAccept mint path when a
+    // submitted username carries no valid payout address.
+    mutable std::mutex          fallback_payout_mutex_;
+    FallbackPayoutFn            fallback_payout_fn_;
 
     // Template cache (filled lazily; invalidated when work_generation_ bumps)
     // Stage 4c populates these.

--- a/src/impl/dgb/test/redistribute_test.cpp
+++ b/src/impl/dgb/test/redistribute_test.cpp
@@ -21,6 +21,7 @@
 
 #include <impl/dgb/redistribute.hpp>
 #include <impl/dgb/share_tracker.hpp>
+#include <impl/dgb/config_pool.hpp>
 
 namespace {
 
@@ -134,6 +135,65 @@ TEST(DgbRedistribute, DeterministicPickPaths)
 
     // Mode accessor reflects the last single-mode set.
     EXPECT_EQ(r.mode(), dgb::RedistributeMode::PPLNS);
+}
+
+// --- #307 follow-up: --redistribute arg-spec -> configured policy + the
+//     node-local fallback payout SELECTOR wired in main_dgb. The donate
+//     identity must resolve byte-for-byte to the canonical V36 combined-
+//     donation P2SH; fee without an operator identity is fail-safe null;
+//     the arg spec must drive the hybrid weights. --------------------------
+TEST(DgbRedistribute, ArgSpecConfiguresHybridWeights)
+{
+    dgb::Redistributor r;
+    r.set_hybrid_weights(dgb::parse_redistribute_spec("boost:70,donate:20,fee:10"));
+    ASSERT_EQ(r.hybrid_weights().size(), 3u);
+    EXPECT_EQ(r.hybrid_weights()[0].mode, dgb::RedistributeMode::BOOST);
+    EXPECT_EQ(r.hybrid_weights()[0].weight, 70u);
+    EXPECT_EQ(r.hybrid_weights()[1].mode, dgb::RedistributeMode::DONATE);
+    EXPECT_EQ(r.hybrid_weights()[2].mode, dgb::RedistributeMode::FEE);
+}
+
+TEST(DgbRedistribute, DonateIdentityRoundTripsCombinedDonationP2SH)
+{
+    // Reproduce exactly what main_dgb does: donation hash160 == bytes [2..22]
+    // of the canonical V36 combined-donation P2SH script, type P2SH (2).
+    uint160 dh;
+    std::memcpy(dh.data(), dgb::PoolConfig::COMBINED_DONATION_SCRIPT.data() + 2, 20);
+    dgb::Redistributor r;
+    r.set_donation_identity(dh, /*P2SH*/ 2);
+    r.set_mode(dgb::RedistributeMode::DONATE);
+
+    dgb::ShareTracker tracker;   // empty
+    uint256 best;                // null
+    auto res = r.pick(tracker, best);
+    EXPECT_EQ(res.pubkey_hash, dh);
+    EXPECT_EQ(res.pubkey_type, 2);
+
+    // Rebuild the P2SH scriptPubKey the main_dgb fallback would stamp (same
+    // RAW 20-byte path -- NOT GetHex, which reverses) and assert byte-identity
+    // with the canonical combined-donation script.
+    unsigned char hb[20];
+    std::memcpy(hb, res.pubkey_hash.data(), 20);
+    std::vector<unsigned char> script = {0xa9, 0x14};
+    script.insert(script.end(), hb, hb + 20);
+    script.push_back(0x87);
+    const std::vector<unsigned char> expected(
+        dgb::PoolConfig::COMBINED_DONATION_SCRIPT.begin(),
+        dgb::PoolConfig::COMBINED_DONATION_SCRIPT.end());
+    EXPECT_EQ(script, expected);
+}
+
+TEST(DgbRedistribute, FeeWithoutOperatorIdentityIsFailSafeNull)
+{
+    // main_dgb does not (yet) plumb an operator payout identity, so a bare
+    // --redistribute fee must yield a NULL pubkey -> the fallback returns an
+    // empty script (never a burn output to the all-zero hash).
+    dgb::Redistributor r;
+    r.set_mode(dgb::RedistributeMode::FEE);   // operator identity unset
+    dgb::ShareTracker tracker;
+    uint256 best;
+    auto res = r.pick(tracker, best);
+    EXPECT_TRUE(res.pubkey_hash.IsNull());
 }
 
 } // namespace


### PR DESCRIPTION
Follow-up slice to #307 (Redistribute V2 policy port), per integrator direction: arg parsing + selector into the DGB won-block coinbase pubkey path. Stacked on #307 (consumes `src/impl/dgb/redistribute.hpp`); retarget to master once #307 lands.

## What
- **main_dgb**: parse `--redistribute SPEC` (opt-in), build a configured `dgb::Redistributor`, bind `DGBWorkSource::set_fallback_payout_fn` (new producer seam, parallel to `set_mint_share_fn`). Threaded through `run_node()`.
- **work_source**: `FallbackPayoutFn` seam consumed at the **ShareAccept** mint branch *only* when `address_to_script(username)` yields empty (empty/broken stratum creds). Unbound => byte-identical to before (default run unchanged).
- **donate** identity resolves byte-for-byte to the canonical V36 combined-donation P2SH. scriptPubKey is built from the **raw 20-byte hash160** — explicitly NOT `uint160::GetHex()`, which reverses byte order and would stamp a reversed hash (caught by KAT during bring-up).
- **redistribute_test**: +3 KAT (arg-spec -> hybrid weights; donate -> byte-identical combined-donation P2SH; fee-without-operator -> fail-safe null). **8/8 green**; `c2pool-dgb` links + `--selftest` OK.

## Safety
- Node-local, **consensus-safe**: sharechain validation/codec/PPLNS untouched — only the locally-stamped pubkey on shares this node mints.
- **Fail-safe**: empty fallback left empty; unconfigured (null-hash) identity yields no script — never a burn output to the all-zero hash.
- Per-coin isolation holds: `src/impl/dgb/` + `src/c2pool/main_dgb.cpp` only; no ltc/doge/btc/shared-base touch.
- Bucket-2 (cross-coin standardization). **Payout-adjacent -> surface-for-tap**, no self-merge.

## Deferred (next slice)
- pplns/boost/fee script derivation through the generic `pick()` path (raw-byte conversion already in place; needs identity plumbing + live tracker-walk threading review). Operator payout identity for `fee` not yet plumbed -> fail-safe null today.