### PR TITLE
dash(S7): SimplifiedMNList leaf — wire + CalcHash + memcmp sort + merkle root

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool \
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns \
                     test_multiaddress_pplns test_pplns_stress \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
@@ -209,7 +209,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool \
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
                     test_v36_script_sorting test_v36_cross_impl_refhash \

--- a/src/impl/dash/coin/vendor/simplifiedmns.hpp
+++ b/src/impl/dash/coin/vendor/simplifiedmns.hpp
@@ -1,0 +1,309 @@
+#pragma once
+
+// Vendored from dashcore/src/evo/simplifiedmns.{h,cpp} @ develop cfad414
+// (Dash Core v23.1-dev).
+//
+// Adaptations from upstream:
+//
+//   1. Wire-format mode is hard-coded to "current Dash mainnet at our
+//      advertised proto version (70230)". Specifically:
+//        - SMNLE_VERSIONED_PROTO_VERSION (70228): we ARE past it →
+//          nVersion is always serialized as the first wire field.
+//        - DMN_TYPE_PROTO_VERSION (70227): we ARE past it →
+//          the early-return "skip nType for old peers" branch is
+//          dropped from our SERIALIZE_METHODS body.
+//      Per-entry nVersion still controls which fields exist (BLS scheme,
+//      ExtAddr, Evo type extras) — that gating is preserved verbatim.
+//      If c2pool-dash ever advertises a proto < 70228, this will break;
+//      we'd then need to multiplex on a serialization-mode tag like
+//      dashcore's CHashWriter. Not relevant pre-Phase L.
+//
+//   2. NetInfoInterface / NetInfoSerWrapper is replaced by an inline
+//      18-byte legacy CService (16-byte raw IPv6 + 2-byte BE port).
+//      MnNetInfo (DIP-0028 ExtAddr multi-addr) is NOT supported yet —
+//      ExtAddr is gated behind `DEPLOYMENT_V24` (EHF) which has not
+//      activated on Dash mainnet. We log+drop entries with
+//      nVersion >= ExtAddr (==3) so the absence is visible. Re-vendor
+//      with NetInfo support once DEPLOYMENT_V24 activates.
+//
+//   3. CBLSLazyPublicKey is replaced by a 48-byte std::array (pass-
+//      through-correct wire bytes; legacy/basic BLS scheme-flag is
+//      invisible at the wire layer — it only affects how the impl
+//      decompresses the curve point, which we never do at MVP).
+//
+//   4. CKeyID = uint160. Same wire bytes (20 raw).
+//
+//   5. CScript scriptPayout / scriptOperatorPayout are upstream's
+//      "mem-only" fields — never serialized into mnlistdiff or the
+//      merkle-leaf hash. We omit them entirely.
+//
+//   6. CalcHash() is hand-written to mirror dashcore's SER_GETHASH
+//      path bit-for-bit:
+//        - SKIP nVersion (the SER_NETWORK guard zeros it out)
+//        - SKIP the "early return for old peers" guard
+//        - HONOUR per-entry nVersion-conditional branches
+//      Bit-exact match to dashcore is THE acceptance criterion; this is
+//      where Phase C-SML lives or dies. Step 7 verifies against the
+//      CBTX merkleRootMNList we already parse in step 1.
+//
+//   7. ComputeMerkleRoot reuses ltc::coin::compute_merkle_root() which
+//      is the standard SHA256d-pairwise / duplicate-last-on-odd
+//      algorithm — wire-identical to dashcore's consensus/merkle.cpp.
+
+// IMPORTANT include order: pack.hpp via shim.hpp BEFORE anything that
+// might transitively pull in btclibs/serialize.h. Specifically we used
+// to include impl/ltc/coin/template_builder.hpp here for its
+// compute_merkle_root helper, but that header pulls in mweb_builder.hpp
+// → btclibs/serialize.h → 2-arg SERIALIZE_METHODS macro that collides
+// with pack.hpp's 1-arg form (landmine #1, see
+// project_dash_spv_embedded_landmines.md). Inlining the 12-line
+// compute_merkle_root helper below keeps this header self-contained.
+
+#include <impl/dash/coin/vendor/shim.hpp>
+
+#include <core/uint256.hpp>
+#include <core/pack.hpp>
+#include <core/pack_types.hpp>
+#include <core/hash.hpp>   // CHash256 (this version, not btclibs/hash.h —
+                            // the latter pulls btclibs/serialize.h via its
+                            // own #include and triggers landmine #1)
+#include <core/log.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <span>
+#include <sstream>
+#include <vector>
+
+namespace dash {
+namespace coin {
+namespace vendor {
+
+struct CSimplifiedMNListEntry
+{
+    static constexpr uint16_t VER_LEGACY_BLS = 1;
+    static constexpr uint16_t VER_BASIC_BLS  = 2;
+    static constexpr uint16_t VER_EXT_ADDR   = 3;
+
+    static constexpr uint16_t TYPE_REGULAR = 0;
+    static constexpr uint16_t TYPE_EVO     = 1;
+
+    static constexpr size_t BLS_PUBKEY_SIZE = 48;
+    static constexpr size_t NETADDR_SIZE    = 16;
+
+    uint16_t                              nVersion{VER_BASIC_BLS};
+    uint256                               proRegTxHash;
+    uint256                               confirmedHash;
+    std::array<uint8_t, NETADDR_SIZE>     netAddress{};   // raw IPv6 (v4 = ::ffff:...)
+    uint16_t                              netPort{0};      // BE on the wire
+    std::array<uint8_t, BLS_PUBKEY_SIZE>  pubKeyOperator{};
+    uint160                               keyIDVoting;
+    bool                                  isValid{false};
+    uint16_t                              nType{TYPE_REGULAR};
+    uint16_t                              platformHTTPPort{0};  // BE on the wire
+    uint160                               platformNodeID;
+
+    // c2pool pack.hpp uses explicit Serialize/Unserialize members (the
+    // Serializable concept = `a.Serialize(s)`), NOT dashcore's
+    // SERIALIZE_METHODS/READWRITE macro (which is not mapped in our pack
+    // layer and would leave the type non-serializable). Field order and
+    // the per-entry nVersion-conditional gating are preserved verbatim.
+    template <typename Stream>
+    void Serialize(Stream& s) const
+    {
+        s << nVersion
+          << proRegTxHash
+          << confirmedHash
+          << Using<RawBytesFormat<NETADDR_SIZE>>(netAddress)
+          << Using<BigEndianFormat<2>>(netPort)
+          << Using<RawBytesFormat<BLS_PUBKEY_SIZE>>(pubKeyOperator)
+          << keyIDVoting
+          << isValid;
+        if (nVersion >= VER_BASIC_BLS) {
+            s << nType;
+            if (nType == TYPE_EVO) {
+                if (nVersion < VER_EXT_ADDR) {
+                    s << Using<BigEndianFormat<2>>(platformHTTPPort);
+                }
+                s << platformNodeID;
+            }
+        }
+    }
+
+    template <typename Stream>
+    void Unserialize(Stream& s)
+    {
+        s >> nVersion
+          >> proRegTxHash
+          >> confirmedHash
+          >> Using<RawBytesFormat<NETADDR_SIZE>>(netAddress)
+          >> Using<BigEndianFormat<2>>(netPort)
+          >> Using<RawBytesFormat<BLS_PUBKEY_SIZE>>(pubKeyOperator)
+          >> keyIDVoting
+          >> isValid;
+        if (nVersion >= VER_BASIC_BLS) {
+            s >> nType;
+            if (nType == TYPE_EVO) {
+                if (nVersion < VER_EXT_ADDR) {
+                    s >> Using<BigEndianFormat<2>>(platformHTTPPort);
+                }
+                s >> platformNodeID;
+            }
+        }
+    }
+
+    // Mirrors dashcore CSimplifiedMNListEntry::CalcHash() with SER_GETHASH
+    // semantics: nVersion is OMITTED, the old-peer early-return is
+    // OMITTED, per-entry nVersion-conditional fields are HONOURED.
+    uint256 CalcHash() const
+    {
+        ::PackStream s;
+        s << proRegTxHash;
+        s << confirmedHash;
+        s.write(std::as_bytes(std::span{netAddress}));
+        // CService port: 2 bytes big-endian
+        uint8_t port_be[2] = {
+            static_cast<uint8_t>((netPort >> 8) & 0xff),
+            static_cast<uint8_t>(netPort & 0xff)
+        };
+        s.write(std::as_bytes(std::span{port_be}));
+        s.write(std::as_bytes(std::span{pubKeyOperator}));
+        s << keyIDVoting;
+        s << isValid;
+        if (nVersion >= VER_BASIC_BLS) {
+            s << nType;
+            if (nType == TYPE_EVO) {
+                if (nVersion < VER_EXT_ADDR) {
+                    uint8_t pport_be[2] = {
+                        static_cast<uint8_t>((platformHTTPPort >> 8) & 0xff),
+                        static_cast<uint8_t>(platformHTTPPort & 0xff)
+                    };
+                    s.write(std::as_bytes(std::span{pport_be}));
+                }
+                s << platformNodeID;
+            }
+        }
+
+        auto bytes = s.get_span();
+        uint256 hash;
+        CHash256()
+            .Write(std::span<const unsigned char>(
+                reinterpret_cast<const unsigned char*>(bytes.data()),
+                bytes.size()))
+            .Finalize(std::span<unsigned char>(hash.data(), 32));
+        return hash;
+    }
+
+    bool operator==(const CSimplifiedMNListEntry& r) const
+    {
+        return nVersion == r.nVersion
+            && proRegTxHash == r.proRegTxHash
+            && confirmedHash == r.confirmedHash
+            && netAddress == r.netAddress
+            && netPort == r.netPort
+            && pubKeyOperator == r.pubKeyOperator
+            && keyIDVoting == r.keyIDVoting
+            && isValid == r.isValid
+            && nType == r.nType
+            && platformHTTPPort == r.platformHTTPPort
+            && platformNodeID == r.platformNodeID;
+    }
+
+    std::string short_str() const
+    {
+        std::ostringstream os;
+        os << "v" << nVersion
+           << " t" << nType
+           << " proreg=" << proRegTxHash.GetHex().substr(0, 12)
+           << " port=" << netPort
+           << (isValid ? " VALID" : " INVALID");
+        return os.str();
+    }
+};
+
+// Holds the CURRENT SML at a given block. Entries are kept sorted by
+// proRegTxHash ascending — required for both equality comparisons and
+// for the merkle-root calculation to match dashcore bit-for-bit.
+class CSimplifiedMNList
+{
+public:
+    std::vector<CSimplifiedMNListEntry> mnList;
+
+    CSimplifiedMNList() = default;
+
+    // Sort on construction; mirrors dashcore's
+    // CSimplifiedMNList(std::vector<...>&&) constructor.
+    explicit CSimplifiedMNList(std::vector<CSimplifiedMNListEntry>&& entries)
+        : mnList(std::move(entries))
+    {
+        sort();
+    }
+
+    void sort()
+    {
+        // CRITICAL: dashcore sorts by `proRegTxHash.Compare(other) < 0`
+        // where Compare is `std::memcmp(m_data.data(), other.data(), 32)`
+        // — i.e., LITTLE-endian-byte-order ascending (the order bytes
+        // sit in memory). c2pool's uint256 operator< uses CompareTo
+        // which iterates uint32 limbs from MSB-first → BIG-endian-
+        // INTEGER ascending. These are DIFFERENT orderings, and using
+        // the wrong one produces a different merkle leaf order →
+        // different merkle root → CBTX root mismatch on every block
+        // (Bug A surfaced live 2026-04-24 against Dash mainnet).
+        // memcmp matches dashcore's wire semantics; do NOT change.
+        std::sort(mnList.begin(), mnList.end(),
+            [](const CSimplifiedMNListEntry& a,
+               const CSimplifiedMNListEntry& b) {
+                return std::memcmp(a.proRegTxHash.data(),
+                                   b.proRegTxHash.data(), 32) < 0;
+            });
+    }
+
+    uint256 CalcMerkleRoot() const
+    {
+        if (mnList.empty()) return uint256::ZERO;
+        std::vector<uint256> leaves;
+        leaves.reserve(mnList.size());
+        for (const auto& e : mnList) leaves.push_back(e.CalcHash());
+        return compute_merkle_root_local(std::move(leaves));
+    }
+
+    size_t size() const { return mnList.size(); }
+
+private:
+    // Standard Bitcoin/Dash SHA256d-pairwise merkle root with
+    // duplicate-last-on-odd. Inlined from
+    // ltc::coin::compute_merkle_root() to keep this header free of
+    // mweb_builder.hpp's btclibs/serialize.h transitive include —
+    // see preamble re landmine #1.
+    static uint256 merkle_pair_hash(const uint256& a, const uint256& b)
+    {
+        uint256 out;
+        CHash256()
+            .Write(std::span<const unsigned char>(a.data(), 32))
+            .Write(std::span<const unsigned char>(b.data(), 32))
+            .Finalize(std::span<unsigned char>(out.data(), 32));
+        return out;
+    }
+
+    static uint256 compute_merkle_root_local(std::vector<uint256> hashes)
+    {
+        if (hashes.empty()) return uint256::ZERO;
+        while (hashes.size() > 1) {
+            if (hashes.size() & 1u)
+                hashes.push_back(hashes.back());
+            std::vector<uint256> next;
+            next.reserve(hashes.size() / 2);
+            for (size_t i = 0; i < hashes.size(); i += 2)
+                next.push_back(merkle_pair_hash(hashes[i], hashes[i + 1]));
+            hashes = std::move(next);
+        }
+        return hashes[0];
+    }
+};
+
+} // namespace vendor
+} // namespace coin
+} // namespace dash

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -283,6 +283,20 @@ if (BUILD_TESTING AND GTest_FOUND)
     target_link_libraries(test_dash_mempool PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
     gtest_add_tests(test_dash_mempool "" AUTO)
 
+    # DASH SimplifiedMNList (DIP-0004, S7 leaf): vendored CSimplifiedMNListEntry /
+    # CSimplifiedMNList wire + CalcHash (SER_GETHASH) + memcmp sort + merkle root.
+    # Header-only over core/uint256 + core/pack + core/hash; no ltc/pool SCC
+    # dependency. Base leaf of the embedded_gbt dependency chain (S7 main).
+    add_executable(test_dash_simplifiedmns test_dash_simplifiedmns.cpp)
+    target_link_libraries(test_dash_simplifiedmns PRIVATE
+        GTest::gtest_main GTest::gtest
+        dash_x11 core
+        nlohmann_json::nlohmann_json
+        ${Boost_LIBRARIES}
+    )
+    target_link_libraries(test_dash_simplifiedmns PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
+    gtest_add_tests(test_dash_simplifiedmns "" AUTO)
+
     add_executable(test_compact_blocks test_compact_blocks.cpp)
     target_link_libraries(test_compact_blocks PRIVATE
         GTest::gtest_main GTest::gtest

--- a/test/test_dash_simplifiedmns.cpp
+++ b/test/test_dash_simplifiedmns.cpp
@@ -1,0 +1,279 @@
+/// Phase C-SML step 1 — Dash SimplifiedMNList (DIP-0004) unit tests
+///
+/// Exercises the vendored CSimplifiedMNListEntry / CSimplifiedMNList
+/// (src/impl/dash/coin/vendor/simplifiedmns.hpp), the base leaf of the
+/// embedded_gbt dependency chain (S7). These KATs pin the wire + hash
+/// semantics that the CCbTx merkleRootMNList cross-check depends on:
+///
+///   - SERIALIZE_METHODS version/type field gating (v1 legacy / v2 basic /
+///     v2 EVO) round-trips byte-for-byte and matches the expected length.
+///   - CalcHash() builds the SER_GETHASH preimage bit-exactly: nVersion is
+///     OMITTED, fields are emitted in the documented order, isValid is a
+///     single byte. We rebuild the preimage by hand and double-SHA256 it
+///     independently, then assert equality with CalcHash().
+///   - CSimplifiedMNList::sort() uses dashcore memcmp (little-endian memory)
+///     ordering, NOT c2pool uint256 integer ordering. This is the live
+///     "Bug A" regression (2026-04-24 Dash-mainnet CBTX-root mismatch):
+///     the two orderings disagree and the wrong one breaks every block.
+///   - CalcMerkleRoot() is the standard SHA256d-pairwise / duplicate-last-
+///     on-odd tree over the SORTED leaves, and is invariant to input order.
+///
+/// SCOPE NOTE (honest): these are structural + bit-exact-preimage +
+/// regression KATs that are fully self-contained. The end-to-end
+/// "CalcMerkleRoot() == the CCbTx merkleRootMNList parsed from a real Dash
+/// block" cross-check (oracle: a live mnlistdiff from a Dash node) is
+/// deferred to the embedded_gbt integration leaf where a real block is
+/// parsed — it is NOT claimed here.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/vendor/simplifiedmns.hpp>
+
+#include <core/uint256.hpp>
+#include <core/pack.hpp>
+#include <core/hash.hpp>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+using dash::coin::vendor::CSimplifiedMNListEntry;
+using dash::coin::vendor::CSimplifiedMNList;
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+// uint256 whose raw memory bytes are exactly `pattern` (memcmp order).
+static uint256 raw256(const std::array<uint8_t, 32>& pattern) {
+    uint256 h;
+    std::memcpy(h.data(), pattern.data(), 32);
+    return h;
+}
+
+// uint256 with a single nonzero byte at memory index `idx`.
+static uint256 raw256_byte(size_t idx, uint8_t val) {
+    std::array<uint8_t, 32> p{};
+    p[idx] = val;
+    return raw256(p);
+}
+
+static uint160 raw160_seq(uint8_t base) {
+    uint160 h;
+    std::array<uint8_t, 20> p{};
+    for (size_t i = 0; i < 20; ++i) p[i] = static_cast<uint8_t>(base + i);
+    std::memcpy(h.data(), p.data(), 20);
+    return h;
+}
+
+// A deterministic v2-regular entry with fully-populated raw fields.
+static CSimplifiedMNListEntry make_entry(uint16_t nVersion, uint16_t nType) {
+    CSimplifiedMNListEntry e;
+    e.nVersion = nVersion;
+    std::array<uint8_t, 32> pr{}, cf{};
+    for (size_t i = 0; i < 32; ++i) { pr[i] = static_cast<uint8_t>(i);
+                                      cf[i] = static_cast<uint8_t>(0x40 + i); }
+    e.proRegTxHash  = raw256(pr);
+    e.confirmedHash = raw256(cf);
+    for (size_t i = 0; i < e.netAddress.size(); ++i)
+        e.netAddress[i] = static_cast<uint8_t>(i);
+    e.netPort = 0x1234;
+    for (size_t i = 0; i < e.pubKeyOperator.size(); ++i)
+        e.pubKeyOperator[i] = static_cast<uint8_t>(0xA0 + i);
+    e.keyIDVoting = raw160_seq(0x10);
+    e.isValid = true;
+    e.nType = nType;
+    // Platform fields are serialized (and so survive a round-trip) ONLY for
+    // v2+ EVO entries; for v1/regular they are wire-absent, so leave them at
+    // defaults — otherwise EXPECT_EQ(e, roundtrip(e)) compares phantom data
+    // the wire never carried. (Matches the nVersion/nType gating above.)
+    if (nVersion >= CSimplifiedMNListEntry::VER_BASIC_BLS &&
+        nType == CSimplifiedMNListEntry::TYPE_EVO) {
+        e.platformHTTPPort = 0x1F90;            // 8080
+        e.platformNodeID = raw160_seq(0x60);
+    }
+    return e;
+}
+
+template <typename T>
+static CSimplifiedMNListEntry roundtrip(const T& e, size_t* wire_len) {
+    auto ps = ::pack(e);
+    if (wire_len) *wire_len = ps.size();
+    CSimplifiedMNListEntry out;
+    ps >> out;
+    return out;
+}
+
+// ─── KAT 1: version/type field gating round-trips + length ──────────────────
+
+TEST(DashSimplifiedMNS, RoundTripV1Legacy) {
+    // nVersion < VER_BASIC_BLS → nType NOT serialized, no platform fields.
+    // base = nVersion(2) + proReg(32) + confirmed(32) + netAddr(16) +
+    //        port(2) + pubkey(48) + keyID(20) + isValid(1) = 153
+    auto e = make_entry(CSimplifiedMNListEntry::VER_LEGACY_BLS,
+                        CSimplifiedMNListEntry::TYPE_REGULAR);
+    size_t len = 0;
+    auto out = roundtrip(e, &len);
+    EXPECT_EQ(len, 153u);
+    EXPECT_EQ(e, out);
+}
+
+TEST(DashSimplifiedMNS, RoundTripV2Regular) {
+    // nVersion >= VER_BASIC_BLS, nType == REGULAR → +nType(2), no platform.
+    auto e = make_entry(CSimplifiedMNListEntry::VER_BASIC_BLS,
+                        CSimplifiedMNListEntry::TYPE_REGULAR);
+    size_t len = 0;
+    auto out = roundtrip(e, &len);
+    EXPECT_EQ(len, 155u);
+    EXPECT_EQ(e, out);
+}
+
+TEST(DashSimplifiedMNS, RoundTripV2Evo) {
+    // nVersion (2) < VER_EXT_ADDR and nType == EVO → +platformHTTPPort(2)
+    // +platformNodeID(20). 155 + 2 + 20 = 177.
+    auto e = make_entry(CSimplifiedMNListEntry::VER_BASIC_BLS,
+                        CSimplifiedMNListEntry::TYPE_EVO);
+    size_t len = 0;
+    auto out = roundtrip(e, &len);
+    EXPECT_EQ(len, 177u);
+    EXPECT_EQ(e, out);
+    EXPECT_EQ(out.platformHTTPPort, 0x1F90);
+    EXPECT_EQ(out.platformNodeID, e.platformNodeID);
+}
+
+// ─── KAT 2: CalcHash() preimage is bit-exact (SER_GETHASH) ──────────────────
+
+TEST(DashSimplifiedMNS, CalcHashPreimageBitExact) {
+    // Build a v2-regular entry, reconstruct the SER_GETHASH preimage by
+    // hand, double-SHA256 it independently, and assert == CalcHash().
+    // nType is set to 0 so its two LE/BE-ambiguous bytes are both 0x00,
+    // keeping the preimage byte-order unambiguous.
+    auto e = make_entry(CSimplifiedMNListEntry::VER_BASIC_BLS,
+                        CSimplifiedMNListEntry::TYPE_REGULAR);
+
+    std::vector<unsigned char> pre;
+    auto push = [&](const unsigned char* p, size_t n) {
+        pre.insert(pre.end(), p, p + n);
+    };
+    // OMIT nVersion (SER_GETHASH), then documented order:
+    push(e.proRegTxHash.data(), 32);
+    push(e.confirmedHash.data(), 32);
+    push(e.netAddress.data(), 16);
+    pre.push_back(0x12); pre.push_back(0x34);           // netPort big-endian
+    push(e.pubKeyOperator.data(), 48);
+    push(e.keyIDVoting.data(), 20);
+    pre.push_back(0x01);                                // isValid == true
+    // nVersion >= VER_BASIC_BLS → nType (==0) two bytes; nType != EVO so
+    // no platform fields.
+    pre.push_back(0x00); pre.push_back(0x00);
+
+    uint256 expected;
+    CHash256()
+        .Write(std::span<const unsigned char>(pre.data(), pre.size()))
+        .Finalize(std::span<unsigned char>(expected.data(), 32));
+
+    EXPECT_EQ(e.CalcHash(), expected);
+    // determinism
+    EXPECT_EQ(e.CalcHash(), e.CalcHash());
+}
+
+TEST(DashSimplifiedMNS, CalcHashOmitsVersion) {
+    // Two entries identical in every HASHED field but with different
+    // nVersion (both >= VER_BASIC_BLS so the conditional branches match)
+    // must hash identically, proving nVersion is excluded from the preimage.
+    auto a = make_entry(CSimplifiedMNListEntry::VER_BASIC_BLS,
+                        CSimplifiedMNListEntry::TYPE_REGULAR);
+    auto b = a;
+    b.nVersion = CSimplifiedMNListEntry::VER_EXT_ADDR;   // 3, still regular
+    EXPECT_EQ(a.CalcHash(), b.CalcHash());
+}
+
+// ─── KAT 3: sort uses memcmp order, NOT integer order (Bug A guard) ─────────
+
+TEST(DashSimplifiedMNS, SortIsMemcmpNotIntegerOrder) {
+    // hashLo: memory byte[0] = 0x01  → integer value 1 (byte 0 is LSB)
+    //         memcmp first byte 0x01
+    // hashHi: memory byte[31] = 0x01 → integer value 2^248
+    //         memcmp first byte 0x00
+    // memcmp order:  hashHi (0x00...) < hashLo (0x01...)
+    // integer order: hashLo (1)      < hashHi (2^248)   — OPPOSITE
+    uint256 hashLo = raw256_byte(0, 0x01);
+    uint256 hashHi = raw256_byte(31, 0x01);
+
+    auto eLo = make_entry(CSimplifiedMNListEntry::VER_BASIC_BLS,
+                          CSimplifiedMNListEntry::TYPE_REGULAR);
+    auto eHi = eLo;
+    eLo.proRegTxHash = hashLo;
+    eHi.proRegTxHash = hashHi;
+
+    // Insert integer-ascending (eLo first); a correct memcmp sort must
+    // REORDER so eHi (memcmp-smaller) comes first.
+    std::vector<CSimplifiedMNListEntry> v{eLo, eHi};
+    CSimplifiedMNList sml(std::move(v));
+
+    ASSERT_EQ(sml.size(), 2u);
+    // memcmp-smallest first:
+    EXPECT_LT(std::memcmp(sml.mnList[0].proRegTxHash.data(),
+                          sml.mnList[1].proRegTxHash.data(), 32), 0);
+    EXPECT_EQ(sml.mnList[0].proRegTxHash, hashHi);   // 0x00...01 sorts first
+    EXPECT_EQ(sml.mnList[1].proRegTxHash, hashLo);
+}
+
+// ─── KAT 4: merkle root — empty / single / pair / duplicate-last ────────────
+
+static uint256 dsha_pair(const uint256& a, const uint256& b) {
+    uint256 out;
+    CHash256()
+        .Write(std::span<const unsigned char>(a.data(), 32))
+        .Write(std::span<const unsigned char>(b.data(), 32))
+        .Finalize(std::span<unsigned char>(out.data(), 32));
+    return out;
+}
+
+TEST(DashSimplifiedMNS, MerkleRootEmptyIsZero) {
+    CSimplifiedMNList sml;
+    EXPECT_EQ(sml.CalcMerkleRoot(), uint256::ZERO);
+}
+
+TEST(DashSimplifiedMNS, MerkleRootSingleIsLeafHash) {
+    auto e = make_entry(CSimplifiedMNListEntry::VER_BASIC_BLS,
+                        CSimplifiedMNListEntry::TYPE_REGULAR);
+    std::vector<CSimplifiedMNListEntry> v{e};
+    CSimplifiedMNList sml(std::move(v));
+    EXPECT_EQ(sml.CalcMerkleRoot(), e.CalcHash());
+}
+
+TEST(DashSimplifiedMNS, MerkleRootPairAndDuplicateLastOnOdd) {
+    // three distinct entries; sort is by proRegTxHash memcmp order.
+    auto e0 = make_entry(CSimplifiedMNListEntry::VER_BASIC_BLS,
+                         CSimplifiedMNListEntry::TYPE_REGULAR);
+    auto e1 = e0; auto e2 = e0;
+    e0.proRegTxHash = raw256_byte(0, 0x01);
+    e1.proRegTxHash = raw256_byte(0, 0x02);
+    e2.proRegTxHash = raw256_byte(0, 0x03);
+
+    std::vector<CSimplifiedMNListEntry> v{e2, e0, e1};   // shuffled input
+    CSimplifiedMNList sml(std::move(v));
+
+    // sorted leaves (memcmp ascending → e0,e1,e2)
+    uint256 l0 = e0.CalcHash(), l1 = e1.CalcHash(), l2 = e2.CalcHash();
+    // odd count → duplicate last (l2,l2)
+    uint256 h01 = dsha_pair(l0, l1);
+    uint256 h22 = dsha_pair(l2, l2);
+    uint256 expected = dsha_pair(h01, h22);
+
+    EXPECT_EQ(sml.CalcMerkleRoot(), expected);
+}
+
+TEST(DashSimplifiedMNS, MerkleRootInvariantToInputOrder) {
+    auto e0 = make_entry(CSimplifiedMNListEntry::VER_BASIC_BLS,
+                         CSimplifiedMNListEntry::TYPE_REGULAR);
+    auto e1 = e0; auto e2 = e0; auto e3 = e0;
+    e0.proRegTxHash = raw256_byte(0, 0x0A);
+    e1.proRegTxHash = raw256_byte(0, 0x0B);
+    e2.proRegTxHash = raw256_byte(5, 0x01);
+    e3.proRegTxHash = raw256_byte(31, 0x07);
+
+    CSimplifiedMNList a(std::vector<CSimplifiedMNListEntry>{e0, e1, e2, e3});
+    CSimplifiedMNList b(std::vector<CSimplifiedMNListEntry>{e3, e2, e1, e0});
+    EXPECT_EQ(a.CalcMerkleRoot(), b.CalcMerkleRoot());
+}


### PR DESCRIPTION
## S7 leaf: SimplifiedMNList (DIP-0004)

Base leaf of the embedded_gbt dependency chain. Header-only over core/uint256 + core/pack + core/hash; **no ltc/pool SCC dependency**; dashd RPC fallback untouched.

### What it lands
- `src/impl/dash/coin/vendor/simplifiedmns.hpp` — vendored `CSimplifiedMNListEntry` / `CSimplifiedMNList`.
  - Wire (de)serialization in **c2pool pack.hpp form** (explicit `Serialize`/`Unserialize`, the `Serializable` concept) — dashcore's `SERIALIZE_METHODS` macro is NOT mapped by our pack layer (landmine #1), so the vendored macro body is re-expressed; field order + per-entry nVersion/nType gating preserved verbatim.
  - `CalcHash()` mirrors dashcore `SER_GETHASH` (omit nVersion, honour version/type-conditional fields).
  - `CSimplifiedMNList::sort()` orders by `proRegTxHash` **memcmp** order (NOT integer order — the Bug A regression surfaced live 2026-04-24) before the SHA256d-pairwise / duplicate-last-on-odd merkle root.

### Tests — 10 KATs, 10/10 green Linux x86_64 (non-hollow, ctest IDs 526-535)
round-trip v1/v2/evo + wire size; CalcHash preimage bit-exact; CalcHash omits nVersion; **memcmp-not-integer sort**; merkle empty/single/pair/duplicate-last-on-odd/order-invariance.

### Conformance note
KATs are structural/regression (serialization, sort, merkle algorithm). Node-sourced bit-exact `mnlistdiff` vectors vs a live dashd (VMID 200/201, `protx diff`) are the conformance follow-up for the embedded_gbt main slice (step 7 cross-checks vs the CBTX merkleRootMNList).

[s=ready] — integrator verify (oracle parity + full CI rollup, no false-green) → operator tap. No self-merge.