### PR TITLE
dgb: wire -DAUX_DOGE build-flag seam (phase DA)

### DIFF
--- a/src/impl/dgb/CMakeLists.txt
+++ b/src/impl/dgb/CMakeLists.txt
@@ -6,9 +6,10 @@
 # Other 4 DGB algos (SHA256d, Skein, Qubit, Odocrypt) = accept-by-continuity
 # or ignored. Full 5-algo validation is DEFERRED TO V37.
 #
-# -DAUX_DOGE opt-in (DGB-as-DOGE-parent, the dual-parent stretch) is NOT wired
-# in this module yet: parked behind the Phase 5.8 settle (ltc-doge owns the
-# shared DOGE-aux surface). Do not add AUX_DOGE plumbing here at M2.
+# -DAUX_DOGE opt-in (DGB-as-DOGE-parent, the dual-parent stretch): the build-flag
+# seam is wired below (phase DA, post-#82). It only compiles the INERT aux seam in
+# coin/node.hpp; the shared DOGE-aux surface (ltc-doge owns) is CONSUMED at M3/DB,
+# not here. Default OFF -> standalone Scrypt-only parent.
 #
 # LIB GATING (mirrors btc/ltc): the dgb_coin (coin-layer), dgb_stratum
 # (miner-facing IWorkSource) and dgb (pool-layer) OBJECT libs are defined
@@ -17,6 +18,20 @@
 # of the flag (gating them behind COIN_DGB makes the linker fall back to raw
 # -ldgb/-ldgb_coin/-ldgb_stratum and fail). Only the test subtree stays behind
 # COIN_DGB; build.yml sets -DCOIN_DGB=ON and builds those targets.
+# -DAUX_DOGE=ON: DGB-as-DOGE-parent dual-parent merged-mining STRETCH opt-in
+# (phase DA). Defines the AUX_DOGE compile macro across the dgb subtree so the
+# inert aux seam in coin/node.hpp compiles (forward-decl + AuxChainBackend type
+# alias + bind_aux_doge_parsers() declaration -- no body, never ODR-used). The
+# shared src/impl/doge aux module is CONSUMED only at M3/DB, when the real
+# <impl/doge/coin/aux_chain_embedded.hpp> include and the bind body land
+# (ltc-doge owns and is the sole modifier of that surface). Default OFF keeps the
+# standalone Scrypt-only parent build with zero DOGE coupling.
+option(AUX_DOGE "DGB-as-DOGE-parent dual-parent merged-mining stretch (consumes shared src/impl/doge aux module at M3)" OFF)
+if(AUX_DOGE)
+  message(STATUS "c2pool-dgb: AUX_DOGE dual-parent stretch ENABLED (DGB-as-DOGE-parent)")
+  add_compile_definitions(AUX_DOGE)
+endif()
+
 add_subdirectory(coin)
 add_subdirectory(stratum)   # dgb_stratum: IWorkSource (#82 miner-facing path)
 # add_subdirectory(daemon)


### PR DESCRIPTION
## DGB+DOGE merged-mining phase DA — build-flag seam

Un-stubs the parked `AUX_DOGE` option in `src/impl/dgb/CMakeLists.txt` so the DGB-as-DOGE-parent dual-parent stretch can be opted in at configure time. With `-DAUX_DOGE=ON` the `AUX_DOGE` compile macro is defined across the dgb subtree, compiling the **inert** aux seam already present in `coin/node.hpp` (forward-decl of `doge::coin::AuxChainEmbedded`, the `AuxChainBackend` type alias, and the `bind_aux_doge_parsers()` declaration — no body, never ODR-used).

### Fence (dgb-only)
- One file: `src/impl/dgb/CMakeLists.txt`. No shared-base / ltc / doge touch.
- Default **OFF** leaves the standalone Scrypt-only parent build byte-unchanged (`add_compile_definitions` is inside `if(AUX_DOGE)`).
- **No shared-module dependency**: the shared `src/impl/doge` aux module (ltc-doge owns) is CONSUMED only at M3/DB, when the real `aux_chain_embedded.hpp` include + bind body land. This slice only lights up the inert seam.

### Verification
- `cmake -DCOIN_DGB=ON -DAUX_DOGE=ON` configure EXIT=0 (ENABLED message fires)
- `dgb_aux_parent_coinbase_parity_test` builds EXIT=0 under the macro, runs **4/4 green**

### Notes
- Prereq #82 (own-block broadcaster) is closed; D0 parity baseline landed in #298.
- Follow-up (separate): add a `-DAUX_DOGE=ON` configure arm to the dgb CI matrix so the path cannot silently rot.
- **HOLD** — no self-merge; integrator merges on operator approval.

Bucket: per-coin (DGB) isolation primitive untouched; build-flag plumbing only.