### PR TITLE
doge: template embedded AuxPoW parent coinbase on ParentCoinbaseTx (unblock DGB-as-parent)

### DIFF
--- a/src/impl/dgb/test/aux_parent_coinbase_parity_test.cpp
+++ b/src/impl/dgb/test/aux_parent_coinbase_parity_test.cpp
@@ -127,8 +127,8 @@ const uint256 MERKLE_BRANCH_0 =
     uint256S("ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100");
 constexpr uint32_t MERKLE_INDEX = 1;
 
-doge::coin::CMerkleTx build_merkle_tx() {
-    doge::coin::CMerkleTx mt;
+doge::coin::CMerkleTx<> build_merkle_tx() {
+    doge::coin::CMerkleTx<> mt;
     mt.m_tx = build_parent_coinbase<ltc::coin::MutableTransaction>();
     mt.m_block_hash = BLOCK_HASH;
     mt.m_merkle_link.m_branch = {MERKLE_BRANCH_0};
@@ -182,7 +182,7 @@ TEST(DGB_AuxParentCoinbaseParity, MerkleTxWireGoldenAnchored) {
 TEST(DGB_AuxParentCoinbaseParity, MerkleTxRoundTripStable) {
     auto mt = build_merkle_tx();
     auto packed = pack(mt);
-    doge::coin::CMerkleTx rt;
+    doge::coin::CMerkleTx<> rt;
     packed >> rt;
     EXPECT_EQ(pack_hex(rt), MERKLE_TX_WIRE);
 }

--- a/src/impl/doge/coin/auxpow.hpp
+++ b/src/impl/doge/coin/auxpow.hpp
@@ -72,9 +72,10 @@ struct CMerkleLink
 ///     ('tx',          tx_id_type)        -> m_tx  (witness-stripped; see §12-Q1)
 ///     ('block_hash',  IntType(256))      -> m_block_hash
 ///     ('merkle_link', merkle_link_type)  -> m_merkle_link
+template <typename ParentCoinbaseTx = ltc::coin::MutableTransaction>
 struct CMerkleTx
 {
-    ltc::coin::MutableTransaction m_tx;          // parent-chain (LTC) coinbase == gentx
+    ParentCoinbaseTx m_tx;          // parent-chain coinbase == gentx (default LTC; DGB binds dgb::coin::MutableTransaction)
     uint256                       m_block_hash;
     CMerkleLink                   m_merkle_link;
 
@@ -91,7 +92,7 @@ struct CMerkleTx
     }
 
     void SetNull() {
-        m_tx = ltc::coin::MutableTransaction{};
+        m_tx = ParentCoinbaseTx{};
         m_block_hash.SetNull();
         m_merkle_link.SetNull();
     }
@@ -101,9 +102,10 @@ struct CMerkleTx
 ///     ('merkle_tx',           merkle_tx_type)    -> m_merkle_tx
 ///     ('merkle_link',         merkle_link_type)  -> m_chain_merkle_link
 ///     ('parent_block_header', block_header_type) -> m_parent_block_header
+template <typename ParentCoinbaseTx = ltc::coin::MutableTransaction>
 struct CAuxPow
 {
-    CMerkleTx        m_merkle_tx;            // parent coinbase + branch to parent merkle root
+    CMerkleTx<ParentCoinbaseTx> m_merkle_tx;  // parent coinbase + branch to parent merkle root
     CMerkleLink      m_chain_merkle_link;    // aux/chain merkle branch + slot index
     CPureBlockHeader m_parent_block_header;  // parent (LTC) 80-byte header
 
@@ -144,8 +146,8 @@ inline bool is_auxpow_version(int32_t version) { return (version & 0x100) != 0; 
 /// pack.hpp surface, not merely skipped. The 80-byte base header is what
 /// HeaderChain consumes; `out_aux` carries the proof for validation
 /// (CAuxPow::check_proof, future milestone). Throws on truncation/parse failure.
-template <typename Stream>
-CPureBlockHeader parse_aux_header(Stream& s, CAuxPow& out_aux, bool& has_aux)
+template <typename Stream, typename ParentCoinbaseTx = ltc::coin::MutableTransaction>
+CPureBlockHeader parse_aux_header(Stream& s, CAuxPow<ParentCoinbaseTx>& out_aux, bool& has_aux)
 {
     CPureBlockHeader hdr;
     ::Unserialize(s, hdr);                                  // 80-byte base header

--- a/src/impl/doge/coin/auxpow.hpp
+++ b/src/impl/doge/coin/auxpow.hpp
@@ -68,6 +68,26 @@ struct CMerkleLink
     bool IsNull() const { return m_branch.empty() && m_index == 0; }
 };
 
+/// Witness-strip params for the PARENT coinbase tx (tx_id_type, data.py:232).
+/// Each parent chain owns its TxParams *type*: LTC/DASH reuse
+/// bitcoin_family::coin::TxParams via a using-declaration, while DGB declares
+/// its own dgb::coin::TxParams. The no-witness wrapper must therefore resolve
+/// from the PARENT type instead of hardcoding bitcoin_family's -- a DGB parent
+/// coinbase handed a bitcoin_family::coin::TxParams cannot serialize through
+/// dgb's SerializeTransaction (distinct type -> hard compile error). LTC is
+/// only spared today because it shares bitcoin_family's TxParams type.
+///
+/// Primary template -> bitcoin_family's TX_NO_WITNESS: byte-identical to the
+/// pre-template hardcode for every parent that reuses bitcoin_family TxParams
+/// (LTC, DASH). A parent with its OWN TxParams type specializes this in ITS
+/// OWN tree (never here) to point at its namespace TX_NO_WITNESS, keeping this
+/// shared module free of any per-parent (e.g. DGB) include.
+template <typename ParentCoinbaseTx>
+struct parent_coinbase_no_witness
+{
+    static constexpr auto value = bitcoin_family::coin::TX_NO_WITNESS;
+};
+
 /// merkle_tx_type (data.py:231-235)
 ///     ('tx',          tx_id_type)        -> m_tx  (witness-stripped; see §12-Q1)
 ///     ('block_hash',  IntType(256))      -> m_block_hash
@@ -81,12 +101,12 @@ struct CMerkleTx
 
     // tx_id_type == witness-stripped tx serialization (data.py:232).
     template <typename Stream> void Serialize(Stream& s) const {
-        ::Serialize(s, bitcoin_family::coin::TX_NO_WITNESS(m_tx));
+        ::Serialize(s, parent_coinbase_no_witness<ParentCoinbaseTx>::value(m_tx));
         ::Serialize(s, m_block_hash);
         ::Serialize(s, m_merkle_link);
     }
     template <typename Stream> void Unserialize(Stream& s) {
-        ::Unserialize(s, bitcoin_family::coin::TX_NO_WITNESS(m_tx));
+        ::Unserialize(s, parent_coinbase_no_witness<ParentCoinbaseTx>::value(m_tx));
         ::Unserialize(s, m_block_hash);
         ::Unserialize(s, m_merkle_link);
     }

--- a/src/impl/doge/coin/auxpow_header.hpp
+++ b/src/impl/doge/coin/auxpow_header.hpp
@@ -55,7 +55,7 @@ inline BlockHeaderType parse_doge_header(const uint8_t*& pos, const uint8_t* end
         static_cast<size_t>(end - pos)));
     const size_t avail = ps.cursor_size();
 
-    CAuxPow aux;
+    CAuxPow<> aux;
     bool has_aux = false;
     BlockHeaderType hdr = parse_aux_header(ps, aux, has_aux);
 
@@ -90,7 +90,7 @@ inline std::vector<BlockHeaderType> parse_doge_headers_message(
     // A 'headers' message carries at most 2000; cap the speculative reserve.
     result.reserve(static_cast<size_t>(std::min<uint64_t>(count, 4096)));
 
-    CAuxPow aux;
+    CAuxPow<> aux;
     bool has_aux = false;
     for (uint64_t i = 0; i < count && ps.cursor_size() > 0; ++i) {
         try {
@@ -117,7 +117,7 @@ inline ltc::coin::BlockType parse_doge_block(const uint8_t* data, size_t len)
     PackStream ps(std::span<const std::byte>(
         reinterpret_cast<const std::byte*>(data), len));
 
-    CAuxPow aux;
+    CAuxPow<> aux;
     bool has_aux = false;
     BlockHeaderType hdr = parse_aux_header(ps, aux, has_aux);
 

--- a/test/test_doge_chain.cpp
+++ b/test/test_doge_chain.cpp
@@ -293,7 +293,7 @@ namespace {
 // proof + tx_count(CompactSize). Mirrors the DOGE 'headers'-message wire layout.
 std::vector<uint8_t> build_extended_header(
     const bitcoin_family::coin::BlockHeaderType& base,
-    const doge::coin::CAuxPow* aux)
+    const doge::coin::CAuxPow<>* aux)
 {
     PackStream ps;
     ::Serialize(ps, base);
@@ -305,9 +305,9 @@ std::vector<uint8_t> build_extended_header(
     return std::vector<uint8_t>(b, b + sp.size());
 }
 
-doge::coin::CAuxPow make_sample_auxpow()
+doge::coin::CAuxPow<> make_sample_auxpow()
 {
-    doge::coin::CAuxPow aux;
+    doge::coin::CAuxPow<> aux;
 
     // Parent-chain (LTC) coinbase == the pool's own gentx, carried in the proof
     // witness-stripped via tx_id_type (auxpow.hpp §12-Q1). Give it a realistic
@@ -392,7 +392,7 @@ TEST(AuxPowStructuredTest, ParseAuxPowHeaderRoundTripsProof) {
 
     PackStream ps(std::span<const std::byte>(
         reinterpret_cast<const std::byte*>(blob.data()), blob.size()));
-    doge::coin::CAuxPow out;
+    doge::coin::CAuxPow<> out;
     bool has_aux = false;
     auto hdr = doge::coin::parse_aux_header(ps, out, has_aux);
 
@@ -430,7 +430,7 @@ TEST(AuxPowStructuredTest, HasAuxFalseForPlainHeader) {
 
     PackStream ps(std::span<const std::byte>(
         reinterpret_cast<const std::byte*>(blob.data()), blob.size()));
-    doge::coin::CAuxPow out;
+    doge::coin::CAuxPow<> out;
     bool has_aux = true;
     auto hdr = doge::coin::parse_aux_header(ps, out, has_aux);
     EXPECT_FALSE(has_aux);
@@ -555,7 +555,7 @@ TEST(AuxPowKnownAnswerTest, Mainnet371337StructuredDecodesRealProof) {
     auto blob = hex_to_bytes(DOGE_371337_EXTHEADER);
     PackStream ps(std::span<const std::byte>(
         reinterpret_cast<const std::byte*>(blob.data()), blob.size()));
-    doge::coin::CAuxPow out;
+    doge::coin::CAuxPow<> out;
     bool has_aux = false;
     auto hdr = doge::coin::parse_aux_header(ps, out, has_aux);
 
@@ -623,7 +623,7 @@ TEST(AuxPowKnownAnswerTest, RegtestH20CAuxPowDecodesRealProof) {
 
     PackStream ps(std::span<const std::byte>(
         reinterpret_cast<const std::byte*>(blob.data()), blob.size()));
-    doge::coin::CAuxPow out;
+    doge::coin::CAuxPow<> out;
     ::Unserialize(ps, out);   // c2pool CAuxPow parser, on dogecoind's own bytes
 
     // Parent coinbase: single null-prevout input carrying the merged-mining


### PR DESCRIPTION
## Why
DGB phase DB (DGB+DOGE merged mining) is blocked: the shared embedded DOGE aux module hard-typed the parent-chain coinbase in the AuxPoW proof to ltc::coin::MutableTransaction, so DGB-as-parent could not bind under -DAUX_DOGE=ON. DGBs MutableTransaction is structurally distinct (no MWEB/HogEx).

## What
Template CMerkleTx, CAuxPow, and parse_aux_header on a ParentCoinbaseTx type parameter, default ltc::coin::MutableTransaction. The default makes the live LTC+DOGE build a no-op (same instantiation, byte-identical wire). DGB binds by instantiating with dgb::coin::MutableTransaction.

## Scope (audit reconciliation)
dgb D0 named 3 sites; only one is genuine parent coupling:
- Site 2 (fixed) auxpow.hpp CMerkleTx::m_tx — parent coinbase, templated here.
- Site 1 (no change) aux_chain_embedded.hpp ltc::coin::Mempool& — embedded DOGE child mempool, ltc-format by fork, parent-independent.
- Site 3 (no change) auxpow_header.hpp BlockHeaderType/BlockType — DOGE child block/header types, ltc by fork.
Parent header in the proof was already neutral (CPureBlockHeader = bitcoin_family::coin::BlockHeaderType).

Single shared-module scope; not bundled into a coin tree. Full neutralize-to-Scrypt-base is the v37 target.

## Test
c2pool/c2pool_enhanced build clean; 23/23 ltc+doge smokes green incl. the real-dogecoind RegtestH20CAuxPowDecodesRealProof KAT (217-byte blob consumed exactly).