### PR TITLE
fix(dgb): P0 master-red — pin reconstruct test merkle_root to actual tx-vector root

### DIFF
--- a/src/impl/dgb/test/reconstruct_won_block_test.cpp
+++ b/src/impl/dgb/test/reconstruct_won_block_test.cpp
@@ -196,8 +196,20 @@ TEST(DgbReconstructWonBlock, CoinbaseFirstThenRefOrder)
     BlockType blk;
     ps >> blk;
 
-    EXPECT_EQ(blk.m_merkle_root, gh);          // empty link => root == gentx_hash
     ASSERT_EQ(blk.m_txs.size(), 3u);           // gentx + 2 others
+    // Header merkle_root is recomputed over the ACTUAL block tx vector
+    // ([gentx_hash] ++ each other-tx txid), per the #303 bad-txnmrklroot fix --
+    // NOT the empty-merkle_link walk (which would yield gentx_hash alone).  Pin
+    // header/body consistency via the same build_block_merkle_root SSOT.
+    {
+        std::vector<uint256> expect_txids = {
+            gh,
+            dgb::coin::compute_txid(blk.m_txs[1]),
+            dgb::coin::compute_txid(blk.m_txs[2]),
+        };
+        EXPECT_EQ(blk.m_merkle_root,
+                  dgb::coin::build_block_merkle_root(expect_txids));
+    }
     EXPECT_EQ(blk.m_txs[0].vin[0].prevout.index, 0xffffffffu); // coinbase at 0
     EXPECT_TRUE(blk.m_txs[0].vin[0].prevout.hash.IsNull());
     EXPECT_EQ(blk.m_txs[1].vout[0].value, 11); // c1 -> make_tx(11), ref order


### PR DESCRIPTION
P0 master-CI-red fix.

DgbReconstructWonBlock.CoinbaseFirstThenRefOrder failed on master head ee24e55d (1 failed / 1028). Root cause: the test asserted the won-block header merkle_root == gentx_hash for the empty-merkle_link case, which only held under the old reconstruct_block_header merkle_link walk. b91facef8 (#303 bad-txnmrklroot fix) correctly recomputes the header root over the ACTUAL block tx vector ([gentx_hash] ++ other-tx txids) so header/body stay consistent for tx-bearing won blocks — with 2 other_txs the root is no longer gentx_hash, so the stale assertion fired.

Fix is test-only: re-pin the assertion to the production invariant via the same build_block_merkle_root + compute_txid SSOT the assembler uses. No source/behavior change. Local: dgb_reconstruct_won_block_test 9/9 green.

Per-coin isolation: src/impl/dgb/ only. p2pool-merged-v36 surface: none.