### PR TITLE
test(dgb): de-dup garbled comment in template_builder no-bits guard

### DIFF
--- a/src/impl/dgb/test/template_builder_test.cpp
+++ b/src/impl/dgb/test/template_builder_test.cpp
@@ -87,9 +87,8 @@ TEST(DgbTemplateBuilder, EmptyChainMintimeIsZero)
 }
 
 // transactions[] is an empty array BY DEFAULT (no tx source wired into the
-// inputs); bits is NEVER emitted (MultiShield V4 next-target is V37 -- the
-// bits is NEVER emitted (MultiShield V4 next-target is V37 — a Scrypt-only
-// walk would be a known-wrong difficulty).
+// inputs); bits is NEVER emitted (MultiShield V4 next-target is V37 — a
+// Scrypt-only walk would be a known-wrong difficulty).
 TEST(DgbTemplateBuilder, EmptyTransactionsAndNoBits)
 {
     auto t = build_work_template(make_inputs());


### PR DESCRIPTION
Comment-only cleanup in the consensus-invariant guard `template_builder_test.cpp`. The `EmptyTransactionsAndNoBits` rationale block carried a botched edit — a half-overwritten duplicate line that left a dangling `-- the` and stated the MultiShield-V4 / V37 reasoning twice. Collapsed to one coherent sentence.

Fenced/test-only, no assertion or behavior change. The guard still pins: empty `transactions[]` by default and `bits` is never emitted (a Scrypt-only walk cannot reconstruct MultiShield-V4 global-window next-target — that is V37).