### PR TITLE
ci(release): macOS x86_64 packages on self-hosted c2pool-mac-intel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,7 @@ jobs:
           - arch: arm64
             runner: macos-14
           - arch: x86_64
-            runner: macos-13
+            runner: [self-hosted, macOS, X64, c2pool-mac-intel]
     steps:
       - uses: actions/checkout@v6
 
@@ -199,6 +199,21 @@ jobs:
           else
             echo "exists=0" >> "$GITHUB_OUTPUT"
             echo "::warning::c2pool-${{ matrix.coin }} source not on this ref — no ${{ matrix.coin }} macOS ${{ matrix.arch }} package will be produced."
+          fi
+
+      - name: Set up Homebrew PATH
+        # Self-hosted Intel runner (macpro-intel-204) launches Actions from
+        # launchd, whose PATH omits Homebrew's /usr/local/bin (#100: brew exit
+        # 127). GitHub-hosted arm64 keeps /opt/homebrew on PATH. Append whichever
+        # prefix actually has brew so later steps inherit it via $GITHUB_PATH.
+        run: |
+          if [ -x /opt/homebrew/bin/brew ]; then
+            echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
+          elif [ -x /usr/local/bin/brew ]; then
+            echo "/usr/local/bin" >> "$GITHUB_PATH"
+          else
+            echo "::error::Homebrew not found at /opt/homebrew or /usr/local on ${RUNNER_NAME:-runner}" >&2
+            exit 1
           fi
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -328,17 +328,22 @@ jobs:
           VERSION="${{ steps.ver.outputs.version }}"
           COIN="${{ matrix.coin }}"
           PKG="c2pool-${COIN}-${VERSION}-macos-universal"
+          # The per-arch upload preserved its staged top-level dir, so each
+          # download-artifact unpacks ONE level deep: arm64/<pkgdir>/c2pool-<coin>
+          # (not arm64/c2pool-<coin>). Resolve that nested tree per arch.
+          ARM_SRC="arm64/c2pool-${COIN}-${VERSION}-macos-arm64"
+          X86_SRC="x86_64/c2pool-${COIN}-${VERSION}-macos-x86_64"
           # config/web-static/explorer/start.sh are arch-independent; seed the
           # universal package from the arm64 tree, then overwrite the binary
           # and every dylib with their lipo-merged universal counterparts.
-          cp -R arm64 "${PKG}"
+          cp -R "${ARM_SRC}" "${PKG}"
           rm -f "${PKG}/c2pool-${COIN}"
-          lipo -create "arm64/c2pool-${COIN}" "x86_64/c2pool-${COIN}" -output "${PKG}/c2pool-${COIN}"
+          lipo -create "${ARM_SRC}/c2pool-${COIN}" "${X86_SRC}/c2pool-${COIN}" -output "${PKG}/c2pool-${COIN}"
           chmod +x "${PKG}/c2pool-${COIN}"
-          for lib in arm64/lib/*.dylib; do
+          for lib in "${ARM_SRC}"/lib/*.dylib; do
             base=$(basename "$lib")
-            if [ -f "x86_64/lib/${base}" ]; then
-              lipo -create "$lib" "x86_64/lib/${base}" -output "${PKG}/lib/${base}"
+            if [ -f "${X86_SRC}/lib/${base}" ]; then
+              lipo -create "$lib" "${X86_SRC}/lib/${base}" -output "${PKG}/lib/${base}"
             else
               cp "$lib" "${PKG}/lib/${base}"
             fi


### PR DESCRIPTION
Repoints the release matrix macOS **x86_64** cell from GitHub-hosted `macos-13` to the self-hosted Intel runner `[self-hosted, macOS, X64, c2pool-mac-intel]` (macpro-intel-204), mirroring build.yml. arm64 stays on `macos-14`.

- Ports the launchd Homebrew-PATH guard (#100) so `brew` resolves under the launchd service PATH.
- Fork-PR RCE gate already enforced: repo approval_policy = all_external_contributors (approval required for all outside contributors before any self-hosted run).
- Proof pending: workflow_dispatch dry-run on this branch — x86_64 cells must land on macpro-intel-204 and go green.

Revert: restore `runner: macos-13` and drop the Set up Homebrew PATH step. Non-destructive; arm64 + Linux lanes untouched.