### PR TITLE
web: per-node topology auto-detect + per-coin stats seam (D0.2/D0.3)

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -380,6 +380,8 @@ void HttpSession::process_request()
                 rest_result = mining_interface_->rest_stale_rates();
             else if (target == "/node_info")
                 rest_result = mining_interface_->rest_node_info();
+            else if (target == "/api/node_topology")
+                rest_result = mining_interface_->rest_node_topology();
             else if (target == "/luck_stats")
                 rest_result = mining_interface_->rest_luck_stats();
             else if (target == "/ban_stats")
@@ -5105,6 +5107,79 @@ void MiningInterface::auto_detect_external_info()
     // Version is set at build time via C2POOL_VERSION from git describe.
     // No runtime GitHub fetch needed (requires HTTPS which we can't do
     // with raw TCP sockets).
+}
+
+// D0.2/D0.3 -- truthful per-node topology. Each node in the 6-coin fleet
+// (LTC/DOGE/BTC/DGB/DASH/BCH) runs a different coin set + embedded daemons;
+// the dashboard must reflect THAT node's REAL shape, auto-detected from live
+// state -- never a hardcoded LTC+DOGE shape. Web/diagnostic layer only.
+nlohmann::json MiningInterface::rest_node_topology()
+{
+    // D0.3 seam: prefer the per-coin StatsProvider hook when the wiring layer
+    // feeds one (richer -- per-coin synced flag + hashrate). Falls back to the
+    // D0.2 auto-detect below when unset, so the endpoint is always truthful.
+    if (m_node_topology_fn) {
+        auto t = m_node_topology_fn();
+        if (!t.is_null())
+            return t;
+    }
+
+    auto upper = [](std::string str) {
+        for (auto& ch : str)
+            if (ch >= 'a' && ch <= 'z') ch = static_cast<char>(ch - 32);
+        return str;
+    };
+
+    // This node's own chain.
+    std::string primary;
+    switch (m_blockchain) {
+    case Blockchain::LITECOIN: primary = "LTC";  break;
+    case Blockchain::BITCOIN:  primary = "BTC";  break;
+    case Blockchain::DOGECOIN: primary = "DOGE"; break;
+    case Blockchain::DASH:     primary = "DASH"; break;
+    }
+
+    nlohmann::json coins = nlohmann::json::array();
+    auto has_coin = [&](const std::string& sym) {
+        for (const auto& c : coins)
+            if (c.value("coin", std::string{}) == sym) return true;
+        return false;
+    };
+    auto add_coin = [&](const std::string& sym, bool is_primary, int peers) {
+        if (sym.empty() || has_coin(sym)) return;
+        nlohmann::json entry = nlohmann::json::object();
+        entry["coin"]    = sym;
+        entry["primary"] = is_primary;
+        entry["peers"]   = peers;
+        if (is_primary) {
+            // Real embedded/RPC flags for this node's own daemon.
+            entry["embedded"] = (m_coin_node && m_coin_node->is_embedded());
+            entry["has_rpc"]  = (m_coin_node && m_coin_node->has_rpc());
+        }
+        coins.push_back(std::move(entry));
+    };
+
+    // Auto-detect the embedded/aux coin set from the live coin-peer map keys
+    // (e.g. an LTC node also runs embedded DOGE) -- the node's REAL shape, not
+    // a baked-in assumption.
+    nlohmann::json peer_map = m_coin_peers_fn ? m_coin_peers_fn()
+                                              : nlohmann::json::object();
+    if (peer_map.is_object()) {
+        for (auto it = peer_map.begin(); it != peer_map.end(); ++it) {
+            std::string sym = upper(it.key());
+            int peers = it.value().is_array()
+                          ? static_cast<int>(it.value().size()) : 0;
+            add_coin(sym, sym == primary, peers);
+        }
+    }
+    // Guarantee the primary chain is always present even if absent from the map.
+    add_coin(primary, true, 0);
+
+    nlohmann::json result = nlohmann::json::object();
+    result["node_symbol"]   = primary;
+    result["auto_detected"] = true;
+    result["coins"]         = coins;
+    return result;
 }
 
 nlohmann::json MiningInterface::rest_node_info()

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -506,6 +506,15 @@ public:
     void set_coin_peers_fn(coin_peers_fn_t fn) { m_coin_peers_fn = std::move(fn); }
     nlohmann::json rest_coin_peers(const std::string& remote_ip);
 
+    // D0.3 per-coin stats seam + D0.2 auto-detect. node_topology_fn, when set
+    // by the wiring layer, feeds the real per-coin embedded-daemon topology
+    // (coin label, embedded/has_rpc/synced, peers, hashrate). When unset,
+    // rest_node_topology() auto-detects the node's real coin set from the live
+    // coin-peer map + m_blockchain -- never a hardcoded {ltc,doge} shape.
+    using node_topology_fn_t = std::function<nlohmann::json()>;
+    void set_node_topology_fn(node_topology_fn_t fn) { m_node_topology_fn = std::move(fn); }
+    nlohmann::json rest_node_topology();              // /api/node_topology
+
     // Sharechain stats callback — returns live tracker data for the /sharechain/stats endpoint
     using sharechain_stats_fn_t = std::function<nlohmann::json()>;
     void set_sharechain_stats_fn(sharechain_stats_fn_t fn) { m_sharechain_stats_fn = thread_safe_wrap(std::move(fn)); }
@@ -1016,6 +1025,7 @@ private:
     sharechain_stats_fn_t m_sharechain_stats_fn;
     spv_progress_fn_t m_spv_progress_fn;
     coin_peers_fn_t m_coin_peers_fn;
+    node_topology_fn_t m_node_topology_fn;  // D0.3 per-coin stats provider (optional)
     // Rate limiter for /api/coin_peers: IP → last request time
     std::map<std::string, std::chrono::steady_clock::time_point> m_coin_peers_rate_limit;
     sharechain_window_fn_t m_sharechain_window_fn;


### PR DESCRIPTION
## What
Adds `GET /api/node_topology` — the truthful per-node topology surface for the 6-coin fleet (LTC/DOGE/BTC/DGB/DASH/BCH). Each node runs a different coin set + embedded daemons; the dashboard must reflect **that node's real shape**, not a hardcoded LTC+DOGE assumption.

## D0.2 — auto-detect
`rest_node_topology()` derives the coin set from live state:
- keys of the live coin-peer map (an LTC node also runs embedded DOGE, etc.)
- this node's own chain (`m_blockchain`), always present
- primary coin labeled with the **real** `is_embedded()`/`has_rpc()` flags from the connected coin node

No baked-in coin shape.

## D0.3 — seam
Optional `node_topology_fn` provider hook. When the wiring layer registers one it supplies richer per-coin stats (synced flag, per-coin hashrate) and overrides the auto-detect; when unset the auto-detect keeps the endpoint truthful. Clean override-or-detect seam for each coin to feed its own real stats.

## Scope / safety
Purely **additive** — new endpoint + new optional hook, no change to existing endpoints. Web/diagnostic layer only — **no consensus, sharechain, or wire change.** Fenced to `core/web_server.{hpp,cpp}`. `web_server.cpp.o` compiles clean locally.

Follows #304 (un-stub) on the dashboard-steward plan: D0.1 ✓ → **D0.2/D0.3 (this)** → D-LTC V36 ratchet visibility next.

