### PR TITLE
bch(share): canonical 60% work-weighted version-switch boundary (drop 95% flat-count punish)

### DIFF
--- a/src/impl/bch/share_check.hpp
+++ b/src/impl/bch/share_check.hpp
@@ -1722,31 +1722,72 @@ bool share_check(const ShareT& share,
     if (share.m_timestamp > now + 600)
         throw std::invalid_argument("share timestamp is too far in the future");
 
-    // 2. Version counting — AutoRatchet upgrade enforcement
-    // p2pool data.py:1400-1414: version switch validation only at BOUNDARIES
-    // (when share.VERSION != parent.VERSION). Shares that match their parent's
-    // version are always valid — they were correct when created.
-    // Previous code rejected ALL v35 shares retroactively after 95% activation.
+    // 2. Version switch enforcement — canonical 60% weighted switch rule.
+    // p2pool data.py check() (lines 1396-1414): a version BOUNDARY
+    // (share.version != parent.version) is only valid when, in the sampling
+    // window [CHAIN_LENGTH*9/10, CHAIN_LENGTH] behind the PARENT, the new
+    // version holds >= 60% of the PPLNS-WEIGHTED desired-version counts.
+    // The weight is target_to_average_attempts per share — get_desired_version_weights,
+    // matching canonical get_desired_version_counts (data.py:2651) — NOT a flat count.
+    // F10/(b): the prior non-canonical 95%-flat-count should_punish_version
+    // punish is removed; the canonical 60% switch rule is now the ONLY version
+    // gate. AutoRatchet stays work-weighted (#290) and does not gate peer
+    // shares here. This couples the accept gate to the mint guard so an
+    // activated node can never mint a boundary share its peers reject.
     {
-        auto lookbehind = static_cast<int32_t>(PoolConfig::chain_length());
-        if (tracker.chain.contains(share.m_hash) &&
-            !share.m_prev_hash.IsNull() && tracker.chain.contains(share.m_prev_hash))
+        auto chain_length = static_cast<int32_t>(PoolConfig::chain_length());
+        if (!share.m_prev_hash.IsNull() && tracker.chain.contains(share.m_prev_hash))
         {
-            // Get parent's share version
+            // Parent's share version (the type the incoming share must legally follow)
             int64_t parent_version = 0;
             tracker.chain.get_share(share.m_prev_hash).invoke([&](auto* obj) {
                 parent_version = std::remove_pointer_t<decltype(obj)>::version;
             });
+            int64_t share_ver = share.version;
 
-            // Only enforce version obsolescence at version BOUNDARIES
-            if (share.version != parent_version)
+            auto prev_height = tracker.chain.get_height(share.m_prev_hash);
+            if (prev_height >= chain_length)
             {
-                auto height = tracker.chain.get_height(share.m_hash);
-                if (height >= lookbehind)
+                if (share_ver == parent_version)
                 {
-                    if (tracker.should_punish_version(share.m_hash, share.version, lookbehind))
-                        throw std::invalid_argument("share version too old — newer version has 95%+ activation");
+                    // same version — always valid (correct when created)
                 }
+                else if (share_ver == parent_version + 1)
+                {
+                    // Upgrade by one version: requires >= 60% weighted support in
+                    // window [CHAIN_LENGTH*9/10, CHAIN_LENGTH] behind the parent.
+                    uint32_t window_start = (static_cast<uint32_t>(chain_length) * 9) / 10;
+                    uint32_t window_size  = static_cast<uint32_t>(chain_length) / 10;
+                    auto ancestor = tracker.chain.get_nth_parent_key(share.m_prev_hash, window_start);
+                    auto weights = tracker.get_desired_version_weights(
+                        ancestor, static_cast<int32_t>(window_size));
+
+                    uint288 new_ver_weight;   // weight of shares desiring exactly share_ver
+                    uint288 total_weight;
+                    for (auto& [ver, w] : weights)
+                    {
+                        total_weight = total_weight + w;
+                        if (static_cast<int64_t>(ver) == share_ver)
+                            new_ver_weight = new_ver_weight + w;
+                    }
+                    // Canonical: counts.get(self.VERSION,0) < sum(counts)*60//100
+                    if (new_ver_weight * uint32_t(100) < total_weight * uint32_t(60))
+                        throw std::invalid_argument("switch without enough hash power upgraded");
+                }
+                else if (parent_version == share_ver + 1)
+                {
+                    // Downgrade by one (AutoRatchet deactivation: V35 may follow V36)
+                }
+                else
+                {
+                    throw std::invalid_argument("invalid version jump from "
+                        + std::to_string(parent_version) + " to " + std::to_string(share_ver));
+                }
+            }
+            else if (share_ver == parent_version + 1)
+            {
+                // Not enough history for an upgrade boundary
+                throw std::invalid_argument("switch without enough history");
             }
         }
     }

--- a/src/impl/bch/share_tracker.hpp
+++ b/src/impl/bch/share_tracker.hpp
@@ -686,6 +686,34 @@ public:
 
         return attempts / uint288(time_span);
     }
+
+    // -- AutoRatchet: PPLNS-weighted desired-version tally (canonical) --
+    // Mirrors p2pool get_desired_version_counts (data.py:2651): walk `lookbehind`
+    // shares back from share_hash and accumulate per-desired-version WORK weight
+    // (idx->work = target_to_average_attempts), NOT a flat share count. Consumed by
+    // share_check's 60% weighted version-switch boundary gate. BCH is a standalone
+    // SHA256d parent — no merged/aux dimension here.
+    std::map<uint64_t, uint288> get_desired_version_weights(const uint256& share_hash, int32_t lookbehind)
+    {
+        std::map<uint64_t, uint288> weights;
+        if (!chain.contains(share_hash))
+            return weights;
+        auto height = chain.get_height(share_hash);
+        auto actual = std::min(lookbehind, height);
+        if (actual <= 0)
+            return weights;
+
+        auto view = chain.get_chain(share_hash, actual);
+        for (auto [hash, data] : view)
+        {
+            uint64_t dv = 0;
+            data.share.invoke([&](auto* obj) { dv = obj->m_desired_version; });
+            auto* idx = chain.get_index(hash);
+            if (idx)
+                weights[dv] = weights[dv] + idx->work;
+        }
+        return weights;
+    }
 };
 
 } // namespace bch


### PR DESCRIPTION
## What
Ports the canonical AutoRatchet version-switch boundary rule into BCH share validation, replacing the non-canonical 95%-flat-count `should_punish_version` gate.

- **share_check.hpp**: version BOUNDARY (share.version != parent.version) is valid only when the new version holds >= 60% of PPLNS **work-weighted** desired-version support in window [CHAIN_LENGTH*9/10, CHAIN_LENGTH] behind the parent. One-step downgrade allowed (AutoRatchet deactivation); larger jumps rejected; insufficient history rejected.
- **share_tracker.hpp**: add `get_desired_version_weights` — per-desired-version WORK tally (idx->work = target_to_average_attempts), mirroring p2pool `get_desired_version_counts` (data.py:2651). NOT a flat count.

## Why
BCH still called the 95%-flat-count `should_punish_version` (no BCH tracker even defined it — survived only as an uninstantiated dependent template expr). LTC/DGB removed it; BTC replaced it with the canonical 60% work-weighted switch (F10/(b), #290). This brings BCH to parity — **v36-native bucket-2 standardization** toward the v37 unified shape. Couples the accept gate to the work-weighted mint guard so an activated node cannot mint a boundary share its peers reject.

## Conformance
- Oracle: p2pool-merged-v36 `data.py` check() 1396-1414 + get_desired_version_counts 2651. No v36 wire-surface change — same accept semantics as BTC/LTC/DGB.
- Per-coin isolation: src/impl/bch/ ONLY. No shared bitcoin_family/ or peer-coin trees touched.

## Verify
- Both BCH headers `-fsyntax-only` clean (rc=0).
- No `should_punish_version` call remains (only the F10/(b) explanatory comment).

GPG-signed. Merge operator-gated (I author/review; integrator merges on `push approved`).