### PR TITLE
dgb(phase-b): lift PPLNS weight walk into shared SSOT (step 1)

### DIFF
--- a/src/impl/dgb/coin/connection_coinbase.hpp
+++ b/src/impl/dgb/coin/connection_coinbase.hpp
@@ -21,12 +21,14 @@
 // ============================================================================
 
 #include "gentx_coinbase.hpp"
+#include "pplns_payout_split.hpp"   // compute_pplns_payout_split SSOT
 
 #include <core/uint256.hpp>
 #include <util/strencodings.h>   // HexStr
 #include <btclibs/span.h>        // Span
 
 #include <cstdint>
+#include <map>
 #include <optional>
 #include <string>
 #include <utility>
@@ -101,6 +103,52 @@ inline ConnCoinbaseParts build_connection_coinbase_parts(const ConnCoinbaseInput
     out.coinb2 = HexStr(Span<const unsigned char>(b.data() + (n - 4), 4));
     out.gentx  = std::move(g);
     return out;
+}
+
+
+// ============================================================================
+// PPLNS-sourced per-connection coinbase (the #328/#329 SSOT bridge).
+//
+// Instead of pre-resolved payout_outputs/donation_amount, the caller passes the
+// raw PPLNS weight map + subsidy and we delegate the amount split to
+// compute_pplns_payout_split() -- the SAME helper share_check.hpp
+// generate_share_transaction() (the verification path) calls (see #329). The
+// per-connection coinbase a miner hashes and the coinbase the share check
+// enforces are therefore byte-identical on every payout satoshi BY
+// CONSTRUCTION: there is exactly one payout implementation, not two that must
+// be kept in agreement. No payout arithmetic lives here -- pure delegation +
+// field forwarding into build_connection_coinbase_parts().
+// ============================================================================
+struct ConnCoinbasePplnsInputs
+{
+    std::vector<unsigned char> coinbase_script;   // scriptSig (BIP34 height + tag)
+    std::optional<std::vector<unsigned char>> segwit_commitment_script;
+    // PPLNS weight map + total, exactly as produced by the ShareTracker
+    // (share_tracker.hpp get_v36_decayed_cumulative_weights / get_cumulative_weights).
+    std::map<std::vector<unsigned char>, uint288> weights;
+    uint288  total_weight;
+    uint64_t subsidy{0};                          // block subsidy + fees to split
+    bool     use_v36_pplns{true};                 // V36 (no finder fee) vs pre-V36
+    std::vector<unsigned char> finder_script;     // pre-V36 0.5% finder-fee target
+    std::vector<unsigned char> donation_script;
+    uint256  ref_hash;                            // p2pool ref_hash (32B)
+    uint64_t last_txout_nonce{0};                 // OP_RETURN nonce (extranonce slot)
+};
+
+inline ConnCoinbaseParts build_connection_coinbase_from_pplns(const ConnCoinbasePplnsInputs& in)
+{
+    PplnsPayoutSplit split = compute_pplns_payout_split(
+        in.weights, in.total_weight, in.subsidy, in.use_v36_pplns, in.finder_script);
+
+    ConnCoinbaseInputs ci;
+    ci.coinbase_script          = in.coinbase_script;
+    ci.segwit_commitment_script = in.segwit_commitment_script;
+    ci.payout_outputs           = std::move(split.payout_outputs);
+    ci.donation_amount          = split.donation_amount;
+    ci.donation_script          = in.donation_script;
+    ci.ref_hash                 = in.ref_hash;
+    ci.last_txout_nonce         = in.last_txout_nonce;
+    return build_connection_coinbase_parts(ci);
 }
 
 } // namespace dgb::coin

--- a/src/impl/dgb/coin/pplns_weight_walk.hpp
+++ b/src/impl/dgb/coin/pplns_weight_walk.hpp
@@ -1,0 +1,112 @@
+#pragma once
+// ─────────────────────────────────────────────────────────────────────────────
+// SSOT: PPLNS weight walk — step 1 of generate_share_transaction(), lifted so the
+// share-VERIFICATION path (share_check.hpp generate_share_transaction) and the
+// per-connection Stratum coinbase EMISSION path (work_source.cpp
+// build_connection_coinbase producer seam, bound in main_dgb.cpp) draw ONE
+// tracker-walk implementation — no second copy to drift a payout satoshi.
+//
+// Counterpart of the steps 2-3 lift in pplns_payout_split.hpp (#328): together
+// compute_pplns_weight_walk() + compute_pplns_payout_split() are the full
+// former-inline body of generate_share_transaction()'s PPLNS computation.
+// Verbatim lift — exact V36 (exponential depth-decay) vs pre-V36 (flat
+// cumulative, grandparent start) branch, the data.py:762-764 insufficient-depth
+// guard, the block-target / spread / 65535 max_weight cap, and the
+// unlimited-weight V36 sentinel.
+// Reference: frstrtr/p2pool-merged-v36 data.py:879/884-885, work.py:759.
+//
+// NOTE: the result type is DEDUCED from the tracker (dgb::CumulativeWeights) via
+// decltype rather than named/included directly — share_tracker.hpp includes
+// share_check.hpp, which includes this header, so naming the type here (or
+// including share_tracker.hpp) would form a parse-time include cycle when
+// share_tracker.hpp is the outer include. The dependent return type resolves
+// only at instantiation, where TrackerT is complete.
+// ─────────────────────────────────────────────────────────────────────────────
+
+#include <core/coin_params.hpp>
+#include <core/target_utils.hpp>
+#include <core/uint256.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace dgb::coin {
+
+// Walk the sharechain from `prev_hash` (the new share's parent / the current
+// tip when emitting work) backward and accumulate the PPLNS weight map exactly
+// as the verifier does. `block_bits` is the block-header nBits feeding the
+// pre-V36 max_weight cap (share.m_min_header.m_bits on the verify path).
+//
+//  * prev_hash null or absent from the chain  -> empty weights (caller treats
+//    as a safe coinbase-only / empty job — the pre-wire behavior).
+//  * chain shorter than real_chain_length     -> throws std::invalid_argument,
+//    the SAME boundary generate_share_transaction() rejects, so emission and
+//    verification refuse identical insufficient-depth states.
+template <typename TrackerT>
+inline auto compute_pplns_weight_walk(
+    TrackerT& tracker,
+    const uint256& prev_hash,
+    uint32_t block_bits,
+    const core::CoinParams& params,
+    bool use_v36_pplns)
+    -> decltype(tracker.get_v36_decayed_cumulative_weights(
+           prev_hash, std::int32_t{0}, std::declval<const uint288&>()))
+{
+    using Result = decltype(tracker.get_v36_decayed_cumulative_weights(
+        prev_hash, std::int32_t{0}, std::declval<const uint288&>()));
+    Result out{};
+
+    if (prev_hash.IsNull() || !tracker.chain.contains(prev_hash))
+        return out;  // no parent in chain -> empty (safe coinbase-only job).
+
+    // p2pool data.py:762-764 — refuse to compute PPLNS with insufficient depth.
+    // Without this guard, attempt_verify() (which allows CHAIN_LENGTH+1) can
+    // trigger a PPLNS walk that terminates early, producing wrong coinbase
+    // amounts and causing persistent GENTX-MISMATCH during bootstrap.
+    auto chain_len = static_cast<int32_t>(params.real_chain_length);
+    {
+        auto pplns_height = tracker.chain.get_height(prev_hash);
+        auto pplns_last = tracker.chain.get_last(prev_hash);
+        if (!(pplns_height >= chain_len || pplns_last.IsNull()))
+            throw std::invalid_argument(
+                "share chain not long enough for PPLNS verification (height="
+                + std::to_string(pplns_height) + " need="
+                + std::to_string(chain_len) + ")");
+    }
+
+    // block_target from block header bits (matches Python: self.header['bits'].target)
+    auto block_target = chain::bits_to_target(block_bits);
+    auto max_weight = chain::target_to_average_attempts(block_target)
+                      * params.spread * 65535;
+
+    // PPLNS formula selected by runtime v36_active (AutoRatchet state), not
+    // compile-time share version. Ref: p2pool data.py:879, work.py:759.
+    if (use_v36_pplns) {
+        // V36 PPLNS: exponential depth-decay, walk from parent.
+        uint288 unlimited_weight;
+        unlimited_weight.SetHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        out = tracker.get_v36_decayed_cumulative_weights(prev_hash, chain_len, unlimited_weight);
+    } else {
+        // Pre-V36 PPLNS: flat cumulative weights (no decay). CRITICAL: walk from
+        // GRANDPARENT for HEIGHT-1 shares. p2pool data.py:884-885:
+        //   _pplns_start = previous_share.share_data['previous_share_hash']
+        //   _pplns_max_shares = max(0, min(height, REAL_CHAIN_LENGTH) - 1)
+        uint256 pplns_start;
+        tracker.chain.get(prev_hash).share.invoke([&](auto* s) {
+            pplns_start = s->m_prev_hash;  // grandparent
+        });
+        auto available = tracker.chain.get_height(prev_hash);
+        auto walk_count = static_cast<int32_t>(
+            std::max(0, std::min(chain_len, available) - 1));
+
+        if (!pplns_start.IsNull() && tracker.chain.contains(pplns_start) && walk_count > 0) {
+            out = tracker.get_cumulative_weights(pplns_start, walk_count, max_weight);
+        }
+    }
+    return out;
+}
+
+} // namespace dgb::coin

--- a/src/impl/dgb/share_check.hpp
+++ b/src/impl/dgb/share_check.hpp
@@ -10,6 +10,7 @@
 
 #include <impl/dgb/coin/gentx_coinbase.hpp>
 #include <impl/dgb/coin/pplns_payout_split.hpp>
+#include <impl/dgb/coin/pplns_weight_walk.hpp>   // SSOT: PPLNS step-1 tracker walk (shared w/ emission)
 
 #include <core/coin_params.hpp>
 #include <core/hash.hpp>
@@ -967,59 +968,17 @@ uint256 generate_share_transaction(const ShareT& share, TrackerT& tracker, const
     uint288 total_weight;
     uint288 total_donation_weight;
 
-    if (!prev_hash.IsNull() && tracker.chain.contains(prev_hash))
+    // Step 1 of the PPLNS computation now lives in the shared SSOT
+    // dgb::coin::compute_pplns_weight_walk() so the per-connection Stratum
+    // coinbase EMISSION path walks the tracker through the SAME code this
+    // VERIFICATION path does — byte-identical weights and identical insufficient-
+    // depth guard, no second walk to drift. Verbatim lift; see pplns_weight_walk.hpp.
     {
-        // p2pool data.py:762-764 — refuse to compute PPLNS with insufficient depth.
-        // Without this guard, attempt_verify() (which allows CHAIN_LENGTH+1) can
-        // trigger a PPLNS walk that terminates early, producing wrong coinbase
-        // amounts and causing persistent GENTX-MISMATCH during bootstrap.
-        auto chain_len = static_cast<int32_t>(params.real_chain_length);
-        {
-            auto pplns_height = tracker.chain.get_height(prev_hash);
-            auto pplns_last = tracker.chain.get_last(prev_hash);
-            if (!(pplns_height >= chain_len || pplns_last.IsNull()))
-                throw std::invalid_argument(
-                    "share chain not long enough for PPLNS verification (height="
-                    + std::to_string(pplns_height) + " need="
-                    + std::to_string(chain_len) + ")");
-        }
-
-        // block_target from block header bits (matches Python: self.header['bits'].target)
-        auto block_target = chain::bits_to_target(share.m_min_header.m_bits);
-        auto max_weight = chain::target_to_average_attempts(block_target)
-                          * params.spread * 65535;
-
-        // PPLNS formula selected by runtime v36_active (AutoRatchet state),
-        // not compile-time share version. Ref: p2pool data.py:879, work.py:759.
-        if (use_v36_pplns) {
-            // V36 PPLNS: exponential depth-decay, walk from parent
-            uint288 unlimited_weight;
-            unlimited_weight.SetHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
-            auto result = tracker.get_v36_decayed_cumulative_weights(prev_hash, chain_len, unlimited_weight);
-            weights = std::move(result.weights);
-            total_weight = result.total_weight;
-            total_donation_weight = result.total_donation_weight;
-        } else {
-            // Pre-V36 PPLNS: flat cumulative weights (no decay)
-            // CRITICAL: Walk from GRANDPARENT for HEIGHT-1 shares.
-            // p2pool data.py:884-885:
-            //   _pplns_start = previous_share.share_data['previous_share_hash']
-            //   _pplns_max_shares = max(0, min(height, REAL_CHAIN_LENGTH) - 1)
-            uint256 pplns_start;
-            tracker.chain.get(prev_hash).share.invoke([&](auto* s) {
-                pplns_start = s->m_prev_hash;  // grandparent
-            });
-            auto available = tracker.chain.get_height(prev_hash);
-            auto walk_count = static_cast<int32_t>(
-                std::max(0, std::min(chain_len, available) - 1));
-
-            if (!pplns_start.IsNull() && tracker.chain.contains(pplns_start) && walk_count > 0) {
-                auto result = tracker.get_cumulative_weights(pplns_start, walk_count, max_weight);
-                weights = std::move(result.weights);
-                total_weight = result.total_weight;
-                total_donation_weight = result.total_donation_weight;
-            }
-        }
+        auto cw = dgb::coin::compute_pplns_weight_walk(
+            tracker, prev_hash, share.m_min_header.m_bits, params, use_v36_pplns);
+        weights = std::move(cw.weights);
+        total_weight = cw.total_weight;
+        total_donation_weight = cw.total_donation_weight;
     }
 
     // --- 2. Convert weights to exact integer payout amounts ---

--- a/src/impl/dgb/share_check.hpp
+++ b/src/impl/dgb/share_check.hpp
@@ -9,6 +9,7 @@
 #include "share_types.hpp"
 
 #include <impl/dgb/coin/gentx_coinbase.hpp>
+#include <impl/dgb/coin/pplns_payout_split.hpp>
 
 #include <core/coin_params.hpp>
 #include <core/hash.hpp>
@@ -1029,7 +1030,6 @@ uint256 generate_share_transaction(const ShareT& share, TrackerT& tracker, const
     //   donation = subsidy - sum(amounts)
 
     auto gst_t1 = std::chrono::steady_clock::now(); // after PPLNS walk
-    std::map<std::vector<unsigned char>, uint64_t> amounts;
 
     // Periodic dump of PPLNS weights for cross-impl comparison
     {
@@ -1051,88 +1051,35 @@ uint256 generate_share_transaction(const ShareT& share, TrackerT& tracker, const
         }
     }
 
-    if (!total_weight.IsNull())
-    {
-        for (auto& [script, weight] : weights)
-        {
-            uint64_t amount;
-            if (use_v36_pplns)
-            {
-                // V36: amounts[script] = subsidy * weight / total_weight
-                uint288 num = uint288(subsidy) * weight;
-                amount = (num / total_weight).GetLow64();
-            }
-            else
-            {
-                // Pre-V36: amounts[script] = subsidy * (199 * weight) / (200 * total_weight)
-                uint288 num = uint288(subsidy) * (weight * 199);
-                uint288 den = total_weight * 200;
-                amount = (num / den).GetLow64();
-            }
-            if (amount > 0)
-                amounts[script] = amount;
-        }
-    }
+    // --- 2-3. PPLNS amount math + consensus output ordering (SSOT) ----------
+    // Steps 2-3 are now the single tracker-free helper compute_pplns_payout_split().
+    // The per-connection Stratum coinbase assembler draws the SAME split, so
+    // emission and this verification path cannot diverge on a payout satoshi.
+    // The helper is a verbatim lift of the former inline math (exact V36 /
+    // pre-V36 formulae, 0.5% finder fee, >=1-sat V36 donation floor with the
+    // (amount, script) tiebreak, and the ascending sort truncated to [-4000:]).
+    // Reference: frstrtr/p2pool-merged-v36 data.py generate_transaction().
+    auto finder_script = get_share_script(&share);
+    auto pplns_split = dgb::coin::compute_pplns_payout_split(
+        weights, total_weight, subsidy, use_v36_pplns, finder_script);
+    auto& payout_outputs = pplns_split.payout_outputs;
+    uint64_t donation_amount = pplns_split.donation_amount;
 
-    // Pre-V36: add 0.5% finder fee to share creator
-    if (!use_v36_pplns)
-    {
-        auto finder_script = get_share_script(&share);
-        amounts[finder_script] += subsidy / 200;
-    }
+    auto gst_t2 = std::chrono::steady_clock::now(); // after amounts+ordering
 
-    // Donation output = subsidy minus sum of all payout amounts
-    uint64_t sum_amounts = 0;
-    for (auto& [s, a] : amounts)
-        sum_amounts += a;
-    uint64_t donation_amount = (subsidy > sum_amounts) ? (subsidy - sum_amounts) : 0;
-
-    // Dump amounts for cross-impl debugging
+    // Dump payouts for cross-impl debugging
     if (dump_diag) {
-        LOG_DEBUG_DIAG << "[GST-AMOUNTS] subsidy=" << subsidy << " addrs=" << amounts.size()
+        uint64_t sum_amounts = 0;
+        for (auto& [s, a] : payout_outputs) sum_amounts += a;
+        LOG_DEBUG_DIAG << "[GST-AMOUNTS] subsidy=" << subsidy << " addrs=" << payout_outputs.size()
                  << " sum=" << sum_amounts << " donation=" << donation_amount
                  << " prev=" << prev_hash.GetHex().substr(0,16);
-        for (auto& [s, a] : amounts) {
+        for (auto& [s, a] : payout_outputs) {
             static const char* HX = "0123456789abcdef";
             std::string sh; for (size_t i = 0; i < std::min(s.size(), size_t(10)); ++i) { sh += HX[s[i]>>4]; sh += HX[s[i]&0xf]; }
             LOG_DEBUG_DIAG << "[GST-AMOUNTS]   " << sh << "... = " << a;
         }
     }
-
-    // V36 consensus: donation output must carry >= 1 satoshi (a60f7f7f)
-    if (use_v36_pplns) {
-        if (donation_amount < 1 && subsidy > 0 && !amounts.empty()) {
-            // Deduct 1 sat from the largest miner payout
-            // Deterministic tiebreak: (amount, script) — largest script wins when equal
-            auto largest = std::max_element(amounts.begin(), amounts.end(),
-                [](const auto& a, const auto& b) {
-                    if (a.second != b.second) return a.second < b.second;
-                    return a.first < b.first;
-                });
-            if (largest != amounts.end() && largest->second > 0) {
-                largest->second -= 1;
-                sum_amounts -= 1;
-                donation_amount = subsidy - sum_amounts;
-            }
-        }
-    }
-
-    // --- 3. Build sorted output list ---
-    auto gst_t2 = std::chrono::steady_clock::now(); // after amounts
-    // Python: sorted(dests, key=lambda a: (amounts[a], a))[-4000:]
-    // = ascending by (amount, script), keep last 4000 (highest amounts)
-    std::vector<std::pair<std::vector<unsigned char>, uint64_t>> payout_outputs(
-        amounts.begin(), amounts.end());
-    std::sort(payout_outputs.begin(), payout_outputs.end(),
-        [](const auto& a, const auto& b) {
-            if (a.second != b.second) return a.second < b.second; // asc by amount
-            return a.first < b.first; // asc by script for tie-breaking
-        });
-
-    // Keep last MAX_OUTPUTS (highest amounts), matching Python's [-4000:]
-    constexpr size_t MAX_OUTPUTS = 4000;
-    if (payout_outputs.size() > MAX_OUTPUTS)
-        payout_outputs.erase(payout_outputs.begin(), payout_outputs.end() - MAX_OUTPUTS);
 
     // --- 4. Serialise the coinbase transaction ---
     // Wire layout (version|vin|vouts|locktime) and txid are produced by the

--- a/src/impl/dgb/stratum/work_source.cpp
+++ b/src/impl/dgb/stratum/work_source.cpp
@@ -25,6 +25,7 @@
 #include <impl/dgb/coin/hash_format.hpp>
 #include <impl/dgb/coin/scrypt_pow.hpp>        // scrypt_pow_hash (DGB-Scrypt PoW SSOT)
 #include <impl/dgb/coin/submit_classify.hpp>   // classify_submission (Stage-4d decision SSOT)
+#include <impl/dgb/coin/connection_coinbase.hpp>  // build_connection_coinbase_from_pplns SSOT
 #include <impl/dgb/coin/header_sample_build.hpp>// compact_to_target (compact bits -> u256)
 
 #include <core/log.hpp>
@@ -333,16 +334,49 @@ std::pair<std::string, std::string> DGBWorkSource::get_coinbase_parts() const
 }
 
 core::stratum::CoinbaseResult DGBWorkSource::build_connection_coinbase(
-    const uint256& /*prev_share_hash*/,
-    const std::string& /*extranonce1_hex*/,
-    const std::vector<unsigned char>& /*payout_script*/,
-    const std::vector<std::pair<uint32_t, std::vector<unsigned char>>>& /*merged_addrs*/) const
+    const uint256& prev_share_hash,
+    const std::string& extranonce1_hex,
+    const std::vector<unsigned char>& payout_script,
+    const std::vector<std::pair<uint32_t, std::vector<unsigned char>>>& merged_addrs) const
 {
-    // Stage 4c: build per-connection coinbase using the SSOT gentx assembler
-    // (coin/gentx_coinbase.hpp) + ShareTracker ref_hash + PPLNS payout map.
-    // For now return an empty result; sessions calling this will get an empty
-    // job and skip pushing work, which is safe but non-functional.
-    return {};
+    // Phase B live-wire: delegate to the PPLNS->coinbase SSOT
+    // (build_connection_coinbase_from_pplns), which itself routes through the
+    // single compute_pplns_payout_split() the verifier uses -- so the coinbase a
+    // miner hashes here is byte-identical to the one generate_share_transaction()
+    // enforces, by construction (no second payout implementation to keep in sync).
+    //
+    // The PPLNS inputs (weight map walked from the ShareTracker, ref_hash,
+    // subsidy, donation script) are produced by the seam bound in main_dgb.cpp
+    // -- the tracker walk lives there, not in the work source. While the seam is
+    // UNBOUND (or returns nullopt) this is byte-identical to the pre-wire stub:
+    // an empty result, so the session pushes no work (safe, non-functional).
+    PplnsInputsFn fn;
+    {
+        std::lock_guard<std::mutex> lk(pplns_inputs_mutex_);
+        fn = pplns_inputs_fn_;  // copy under lock; a concurrent set_*_fn() cannot
+                                // tear it out mid-call.
+    }
+    if (!fn)
+        return {};  // unbound: pre-wire behavior (empty job).
+
+    std::optional<dgb::coin::ConnCoinbasePplnsInputs> inputs =
+        fn(prev_share_hash, extranonce1_hex, payout_script, merged_addrs);
+    if (!inputs)
+        return {};  // producer declined (e.g. tip not yet known) -> safe empty job.
+
+    dgb::coin::ConnCoinbaseParts parts =
+        dgb::coin::build_connection_coinbase_from_pplns(*inputs);
+
+    core::stratum::CoinbaseResult out;
+    out.coinb1 = std::move(parts.coinb1);
+    out.coinb2 = std::move(parts.coinb2);
+    // Freeze the consensus-bearing ref fields the submit path (mining_submit)
+    // re-derives the won-block reconstruct from; the remaining snapshot fields
+    // (merkle_branches / segwit) are populated by the template-cache follow-on.
+    out.snapshot.subsidy                   = inputs->subsidy;
+    out.snapshot.frozen_ref.ref_hash       = inputs->ref_hash;
+    out.snapshot.frozen_ref.last_txout_nonce = inputs->last_txout_nonce;
+    return out;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -608,6 +642,12 @@ void DGBWorkSource::set_fallback_payout_fn(FallbackPayoutFn fn)
 {
     std::lock_guard<std::mutex> lk(fallback_payout_mutex_);
     fallback_payout_fn_ = std::move(fn);
+}
+
+void DGBWorkSource::set_pplns_inputs_fn(PplnsInputsFn fn)
+{
+    std::lock_guard<std::mutex> lk(pplns_inputs_mutex_);
+    pplns_inputs_fn_ = std::move(fn);
 }
 
 uint256 DGBWorkSource::try_mint_share(const MintShareInputs& in) const

--- a/src/impl/dgb/stratum/work_source.hpp
+++ b/src/impl/dgb/stratum/work_source.hpp
@@ -42,6 +42,7 @@
 #include <core/stratum_work_source.hpp>
 #include <core/uint256.hpp>
 #include <core/pow.hpp>       // core::SubsidyFunc — embedded coinbasevalue SSOT feed
+#include <impl/dgb/coin/connection_coinbase.hpp>  // ConnCoinbasePplnsInputs (PPLNS->coinbase SSOT)
 
 #include <atomic>
 #include <cstdint>
@@ -209,6 +210,26 @@ public:
     using FallbackPayoutFn = std::function<std::vector<unsigned char>()>;
     void set_fallback_payout_fn(FallbackPayoutFn fn);
 
+    /// Producer seam for the per-connection coinbase (Phase B live-wire).
+    /// Given the share-chain tip a miner builds ON TOP OF, plus this session's
+    /// extranonce1 and resolved payout/merged scripts, returns the fully
+    /// populated PPLNS inputs (weight map sourced from the ShareTracker, ref_hash,
+    /// subsidy, donation script). Bound once at startup in main_dgb.cpp where the
+    /// ShareTracker + CoinParams are in scope; the tracker walk lives THERE so no
+    /// sharechain logic leaks into the work source. While UNBOUND,
+    /// build_connection_coinbase() returns an empty result (byte-identical to the
+    /// pre-wire stub -- no behavior change until the producer is bound). Returning
+    /// std::nullopt (e.g. tip not yet known) also yields an empty, safe job. The
+    /// emitted coinbase is byte-identical to the verifier's
+    /// generate_share_transaction() BY CONSTRUCTION: both delegate to the single
+    /// compute_pplns_payout_split() SSOT via build_connection_coinbase_from_pplns.
+    using PplnsInputsFn = std::function<std::optional<dgb::coin::ConnCoinbasePplnsInputs>(
+        const uint256& prev_share_hash,
+        const std::string& extranonce1_hex,
+        const std::vector<unsigned char>& payout_script,
+        const std::vector<std::pair<uint32_t, std::vector<unsigned char>>>& merged_addrs)>;
+    void set_pplns_inputs_fn(PplnsInputsFn fn);
+
     /// Dispatch one share-difficulty submission to the bound mint callback.
     /// The stage-4d mining_submit classify branch calls this on the
     /// "pow_hash <= share target" outcome. Returns the minted share hash, or a
@@ -268,6 +289,12 @@ private:
     // submitted username carries no valid payout address.
     mutable std::mutex          fallback_payout_mutex_;
     FallbackPayoutFn            fallback_payout_fn_;
+
+    // Per-connection coinbase PPLNS-inputs producer (#327/#330 live-wire).
+    // Empty until set_pplns_inputs_fn() bound in main_dgb; while empty the
+    // per-connection coinbase path returns an empty job (pre-wire behavior).
+    mutable std::mutex          pplns_inputs_mutex_;
+    PplnsInputsFn               pplns_inputs_fn_;
 
     // Template cache (filled lazily; invalidated when work_generation_ bumps)
     // Stage 4c populates these.

--- a/src/impl/dgb/test/connection_coinbase_test.cpp
+++ b/src/impl/dgb/test/connection_coinbase_test.cpp
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 #include <impl/dgb/coin/connection_coinbase.hpp>
 
+#include <map>
 #include <optional>
 #include <string>
 #include <utility>
@@ -99,6 +100,108 @@ TEST(ConnCoinbase, RefOpReturnLayout) {
         uint256(std::vector<unsigned char>(32, 0xab)), NONCE);
     std::string ref32; for (int i = 0; i < 32; ++i) ref32 += "ab";
     EXPECT_EQ(tohex(op), std::string("6a28") + ref32 + "0807060504030201");
+}
+
+
+// ============================================================================
+// (5)-(8) PPLNS SSOT wiring: build_connection_coinbase_from_pplns delegates the
+// payout split to compute_pplns_payout_split (the #329 verification SSOT) and
+// forwards every non-payout field unchanged into build_connection_coinbase_parts.
+//
+// These are DELEGATION-IDENTITY tests, not a second payout implementation: each
+// asserts the PPLNS-sourced path produces bytes identical to the manual path
+// fed by the SAME SSOT split. Reintroducing inline payout math, dropping the
+// v36 floor, or mis-forwarding a field would diverge them. The split MATH
+// itself is pinned independently in pplns_payout_split_test.cpp.
+
+using Script = std::vector<unsigned char>;
+
+// Build the manual reference: run the SSOT split, hand it to the parts builder.
+dgb::coin::ConnCoinbaseParts manual_from_split(
+    const std::map<Script, uint288>& w, const uint288& total, uint64_t subsidy,
+    bool v36, const Script& finder,
+    const std::optional<Script>& seg, const uint256& ref, uint64_t nonce) {
+    auto split = dgb::coin::compute_pplns_payout_split(w, total, subsidy, v36, finder);
+    dgb::coin::ConnCoinbaseInputs in;
+    in.coinbase_script = CB;
+    in.segwit_commitment_script = seg;
+    in.payout_outputs = split.payout_outputs;
+    in.donation_amount = split.donation_amount;
+    in.donation_script = DON;
+    in.ref_hash = ref;
+    in.last_txout_nonce = nonce;
+    return dgb::coin::build_connection_coinbase_parts(in);
+}
+
+dgb::coin::ConnCoinbaseParts wired_from_pplns(
+    const std::map<Script, uint288>& w, const uint288& total, uint64_t subsidy,
+    bool v36, const Script& finder,
+    const std::optional<Script>& seg, const uint256& ref, uint64_t nonce) {
+    dgb::coin::ConnCoinbasePplnsInputs in;
+    in.coinbase_script = CB;
+    in.segwit_commitment_script = seg;
+    in.weights = w;
+    in.total_weight = total;
+    in.subsidy = subsidy;
+    in.use_v36_pplns = v36;
+    in.finder_script = finder;
+    in.donation_script = DON;
+    in.ref_hash = ref;
+    in.last_txout_nonce = nonce;
+    return dgb::coin::build_connection_coinbase_from_pplns(in);
+}
+
+void expect_parts_eq(const dgb::coin::ConnCoinbaseParts& a,
+                     const dgb::coin::ConnCoinbaseParts& b) {
+    EXPECT_EQ(tohex(a.gentx.bytes), tohex(b.gentx.bytes));
+    EXPECT_EQ(a.coinb1, b.coinb1);
+    EXPECT_EQ(a.coinb2, b.coinb2);
+    EXPECT_EQ(a.gentx.txid, b.gentx.txid);
+}
+
+// (5) V36 split (no finder fee, >=1 sat donation floor) flows through identically.
+TEST(ConnCoinbasePplns, V36WiredEqualsManual) {
+    std::map<Script, uint288> w{{P1, uint288(3)}, {P2, uint288(1)}};
+    uint256 ref(std::vector<unsigned char>(32, 0xab));
+    auto wired  = wired_from_pplns(w, uint288(4), 10000, true, {}, std::nullopt, ref, NONCE);
+    auto manual = manual_from_split(w, uint288(4), 10000, true, {}, std::nullopt, ref, NONCE);
+    expect_parts_eq(wired, manual);
+}
+
+// (6) Pre-V36 path (use_v36_pplns=false + finder_script) forwards the flag and
+//     the 0.5% finder fee target — proves both are wired, not hard-coded.
+TEST(ConnCoinbasePplns, PreV36FinderFeeWiredEqualsManual) {
+    std::map<Script, uint288> w{{P1, uint288(1)}, {P2, uint288(1)}};
+    uint256 ref(std::vector<unsigned char>(32, 0xab));
+    auto wired  = wired_from_pplns(w, uint288(2), 20000, false, P1, std::nullopt, ref, NONCE);
+    auto manual = manual_from_split(w, uint288(2), 20000, false, P1, std::nullopt, ref, NONCE);
+    expect_parts_eq(wired, manual);
+}
+
+// (7) Non-payout fields (segwit commitment, distinct ref_hash, distinct nonce)
+//     forward unchanged into the assembler.
+TEST(ConnCoinbasePplns, SegwitAndRefFieldsForwarded) {
+    std::map<Script, uint288> w{{P1, uint288(5)}, {P2, uint288(2)}};
+    Script seg = unhex("6a24aa21a9ed" + std::string(64, 'c'));
+    uint256 ref(std::vector<unsigned char>(32, 0x5c));
+    const uint64_t alt_nonce = 0x1112131415161718ull;
+    auto wired  = wired_from_pplns(w, uint288(7), 7777777, true, {}, seg, ref, alt_nonce);
+    auto manual = manual_from_split(w, uint288(7), 7777777, true, {}, seg, ref, alt_nonce);
+    expect_parts_eq(wired, manual);
+}
+
+// (8) Value anchor (independent of the wiring): the SSOT split the wired path
+//     consumes carries the hand-computed V36 amounts in ascending order, and
+//     the assembled coinbase preserves that exact PPLNS vout sequence.
+//     subsidy 1000, P1:2 P2:1 (total 3) -> P1=666, P2=333, sum 999, donation 1;
+//     >=1 sat floor satisfied without deduction. asc(amount): P2(333), P1(666).
+TEST(ConnCoinbasePplns, ValueAnchorAscendingPayoutOrder) {
+    std::map<Script, uint288> w{{P1, uint288(2)}, {P2, uint288(1)}};
+    auto split = dgb::coin::compute_pplns_payout_split(w, uint288(3), 1000, true, {});
+    std::vector<std::pair<Script, uint64_t>> expect{{P2, 333}, {P1, 666}};
+    EXPECT_EQ(split.payout_outputs, expect);
+    EXPECT_EQ(split.donation_amount, 1u);
+    // The wired coinbase is assembled from exactly this split (covered by (5)-(7)).
 }
 
 } // namespace

--- a/src/impl/dgb/test/share_test.cpp
+++ b/src/impl/dgb/test/share_test.cpp
@@ -19,6 +19,7 @@
 #include <impl/dgb/share.hpp>
 #include <impl/dgb/share_tracker.hpp>   // DensePPLNSWindow — V36 decayed-PPLNS SSOT
 #include <impl/dgb/coin/pplns_weight_walk.hpp> // SSOT: PPLNS step-1 tracker walk (shared emission/verify)
+#include <impl/dgb/coin/pplns_payout_split.hpp> // #328 SSOT: weights -> payout outputs (invariance tie-in)
 #include <impl/dgb/params.hpp>          // make_coin_params — assembled CoinParams SSOT
 #include <impl/dgb/coin/rpc_conf.hpp>   // #82 external-daemon RPC creds (digibyte.conf)
 #include <impl/dgb/auto_ratchet.hpp> // Phase B: mint-side share-version ratchet
@@ -629,4 +630,211 @@ TEST(DGB_run_loop_mint, AdapterFailsClosedOnShortHeader)
 
     uint256 h = dgb::mint_local_share_with_ratchet(in, tracker, params, ratchet);
     EXPECT_TRUE(h.IsNull());
+}
+
+// ── PPLNS weight-walk VALUE-INVARIANCE (before-vs-after) differential KAT ────
+// SAME BAR as the #328 payout-split invariance KAT: prove the #333 lift of
+// generate_share_transaction() step-1 into dgb::coin::compute_pplns_weight_walk()
+// moves ZERO weight. We embed the PRE-REFACTOR inline walk here VERBATIM
+// (transcribed line-for-line from the share_check.hpp generate_share_transaction()
+// body that commit a5c23b7fb removed) as legacy_inline_weight_walk(), and assert
+// the helper reproduces it weight-for-weight — per-script weights, total_weight
+// AND total_donation_weight — across a battery exercising BOTH PPLNS branches
+// (V36 decay / pre-V36 grandparent-start + max_weight cap), the donation split,
+// zero-addr-weight shares (full-donation), the insufficient-depth guard (throw),
+// null/absent parents, and a chain that EXCEEDS the real_chain_length window.
+// Then BOTH weight maps are fed through the #328 payout-split SSOT and the
+// resulting outputs + donation asserted byte-identical — closing the end-to-end
+// "no payout satoshi drifts between emission and verification" proof.
+//
+// COVERAGE NOTE (no silent cap): the >4000-distinct-OUTPUT truncation
+// (PPLNS_MAX_OUTPUTS) is proven on the payout-split side by the #328 KAT
+// (PplnsPayoutSplitInvariance, case n=4096). Here the weight-walk "window" is
+// the real_chain_length share cap; the window case below drives the walk past it
+// on testnet params (window=400) to prove the cap truncates the walk identically
+// before vs after the lift.
+
+// Verbatim transcription of share_check.hpp generate_share_transaction() step 1
+// as it stood BEFORE commit a5c23b7fb (the #333 weight-walk lift). The only
+// adaptation: block_bits is taken as a parameter (the helper extracted exactly
+// share.m_min_header.m_bits into this same parameter) and the three result
+// fields are returned in the deduced CumulativeWeights instead of assigned to
+// generate_share_transaction()'s locals.
+template <typename TrackerT>
+static auto legacy_inline_weight_walk(
+    TrackerT& tracker, const uint256& prev_hash, uint32_t block_bits,
+    const core::CoinParams& params, bool use_v36_pplns)
+    -> decltype(tracker.get_v36_decayed_cumulative_weights(
+           prev_hash, std::int32_t{0}, std::declval<const uint288&>()))
+{
+    using Result = decltype(tracker.get_v36_decayed_cumulative_weights(
+        prev_hash, std::int32_t{0}, std::declval<const uint288&>()));
+    Result out{};
+
+    if (!prev_hash.IsNull() && tracker.chain.contains(prev_hash))
+    {
+        auto chain_len = static_cast<int32_t>(params.real_chain_length);
+        {
+            auto pplns_height = tracker.chain.get_height(prev_hash);
+            auto pplns_last = tracker.chain.get_last(prev_hash);
+            if (!(pplns_height >= chain_len || pplns_last.IsNull()))
+                throw std::invalid_argument(
+                    "share chain not long enough for PPLNS verification (height="
+                    + std::to_string(pplns_height) + " need="
+                    + std::to_string(chain_len) + ")");
+        }
+
+        auto block_target = chain::bits_to_target(block_bits);
+        auto max_weight = chain::target_to_average_attempts(block_target)
+                          * params.spread * 65535;
+
+        if (use_v36_pplns) {
+            uint288 unlimited_weight;
+            unlimited_weight.SetHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+            auto result = tracker.get_v36_decayed_cumulative_weights(prev_hash, chain_len, unlimited_weight);
+            out.weights = std::move(result.weights);
+            out.total_weight = result.total_weight;
+            out.total_donation_weight = result.total_donation_weight;
+        } else {
+            uint256 pplns_start;
+            tracker.chain.get(prev_hash).share.invoke([&](auto* s) {
+                pplns_start = s->m_prev_hash;  // grandparent
+            });
+            auto available = tracker.chain.get_height(prev_hash);
+            auto walk_count = static_cast<int32_t>(
+                std::max(0, std::min(chain_len, available) - 1));
+
+            if (!pplns_start.IsNull() && tracker.chain.contains(pplns_start) && walk_count > 0) {
+                auto result = tracker.get_cumulative_weights(pplns_start, walk_count, max_weight);
+                out.weights = std::move(result.weights);
+                out.total_weight = result.total_weight;
+                out.total_donation_weight = result.total_donation_weight;
+            }
+        }
+    }
+    return out;
+}
+
+namespace {
+// Build a share into the tracker. prev==nullptr => null parent (resolved chain
+// genesis). bits drives per-share work (target_to_average_attempts); donation in
+// [0,65535] drives the addr/donation weight split (65535 => zero addr weight).
+inline void add_walk_share(dgb::ShareTracker& tracker, const uint256& hh,
+                           const uint256* ph, uint32_t bits, uint16_t donation)
+{
+    auto* s = new dgb::MergedMiningShare();
+    s->m_hash = hh;
+    if (ph) s->m_prev_hash = *ph; else s->m_prev_hash.SetNull();
+    s->m_bits = bits;
+    s->m_max_bits = bits;
+    s->m_min_header.m_bits = bits;
+    s->m_donation = donation;
+    dgb::ShareType st; st = s;
+    tracker.add(st);
+}
+inline uint256 hx(const std::string& tail) {
+    uint256 v; v.SetHex(std::string(64 - tail.size(), '0') + tail); return v;
+}
+} // namespace
+
+TEST(DGB_share_test, WeightWalkValueInvarianceBattery)
+{
+    const core::CoinParams params = dgb::make_coin_params(/*testnet=*/false);
+    const uint32_t bb = 0x1e0fffff;  // block-header bits feeding the pre-V36 cap
+
+    auto assert_walk_identical =
+        [&](dgb::ShareTracker& tk, const uint256& prev, bool v36, const char* tag) {
+            const auto legacy = legacy_inline_weight_walk(tk, prev, bb, params, v36);
+            const auto helper = dgb::coin::compute_pplns_weight_walk(tk, prev, bb, params, v36);
+            EXPECT_EQ(helper.weights,               legacy.weights)               << tag << " weights";
+            EXPECT_EQ(helper.total_weight,          legacy.total_weight)          << tag << " total_weight";
+            EXPECT_EQ(helper.total_donation_weight, legacy.total_donation_weight) << tag << " donation_weight";
+
+            // End-to-end: identical weights => identical payout split (the #328
+            // SSOT), proven on the SAME inputs both paths feed.
+            std::vector<unsigned char> finder = helper.weights.empty() ? std::vector<unsigned char>{} : helper.weights.begin()->first;
+            for (uint64_t subsidy : {uint64_t(0), uint64_t(625000000)}) {
+                auto sp_h = dgb::coin::compute_pplns_payout_split(
+                    helper.weights, helper.total_weight, subsidy, v36, finder);
+                auto sp_l = dgb::coin::compute_pplns_payout_split(
+                    legacy.weights, legacy.total_weight, subsidy, v36, finder);
+                EXPECT_EQ(sp_h.payout_outputs,  sp_l.payout_outputs)  << tag << " payout_outputs s=" << subsidy;
+                EXPECT_EQ(sp_h.donation_amount, sp_l.donation_amount) << tag << " donation s=" << subsidy;
+            }
+        };
+
+    // Resolved chain g <- a <- b <- c (g.prev null). Mixed donation incl. 0 and
+    // full-donation (65535 => that share contributes ZERO addr weight) and
+    // varied bits (varied per-share work).
+    {
+        dgb::ShareTracker tk;
+        uint256 g = hx("c0"), a = hx("c1"), b = hx("c2"), c = hx("c3");
+        add_walk_share(tk, g, nullptr, 0x1e0fffff, 0);
+        add_walk_share(tk, a, &g,      0x1e07ffff, 32767);
+        add_walk_share(tk, b, &a,      0x1e0fffff, 65535);   // zero addr-weight share
+        add_walk_share(tk, c, &b,      0x1d00ffff, 100);
+        assert_walk_identical(tk, c, /*v36=*/true,  "v36-basic");
+        assert_walk_identical(tk, c, /*v36=*/false, "preV36-basic(grandparent+cap)");
+
+        // Donation weight is genuinely exercised (>0) so the donation field is
+        // not a trivial zero on both sides.
+        const auto w = dgb::coin::compute_pplns_weight_walk(tk, c, bb, params, true);
+        EXPECT_FALSE(w.total_donation_weight.IsNull()) << "battery must exercise non-zero donation weight";
+        EXPECT_FALSE(w.total_weight.IsNull())          << "battery must exercise non-zero total weight";
+    }
+
+    // prev points at genesis directly => pre-V36 grandparent is null => empty
+    // (both), even though prev IS in the chain.
+    {
+        dgb::ShareTracker tk;
+        uint256 g = hx("d0"), a = hx("d1");
+        add_walk_share(tk, g, nullptr, 0x1e0fffff, 0);
+        add_walk_share(tk, a, &g,      0x1e0fffff, 0);
+        assert_walk_identical(tk, g, /*v36=*/false, "preV36-grandparent-null");
+    }
+
+    // null parent / absent parent => empty, no throw (both).
+    {
+        dgb::ShareTracker tk;
+        uint256 g = hx("e0");
+        add_walk_share(tk, g, nullptr, 0x1e0fffff, 0);
+        assert_walk_identical(tk, uint256::ZERO, true, "null-parent");
+        assert_walk_identical(tk, hx("deadbeef"), true, "absent-parent");
+    }
+
+    // Insufficient-depth guard: a chain whose oldest share points at a NON-null
+    // hash absent from the tracker (so chain.get_last(prev) is non-null) and
+    // whose height < real_chain_length MUST throw — identically, both paths.
+    {
+        dgb::ShareTracker tk;
+        uint256 root_missing = hx("beef"), a = hx("f1"), b = hx("f2");
+        add_walk_share(tk, a, &root_missing, 0x1e0fffff, 0);  // a.prev absent => get_last non-null
+        add_walk_share(tk, b, &a,            0x1e0fffff, 0);
+        EXPECT_THROW(legacy_inline_weight_walk(tk, b, bb, params, true), std::invalid_argument)
+            << "legacy guard must throw on insufficient depth";
+        EXPECT_THROW(dgb::coin::compute_pplns_weight_walk(tk, b, bb, params, true), std::invalid_argument)
+            << "helper guard must throw identically";
+    }
+
+    // Exceeds the real_chain_length window: testnet params (window=400); build a
+    // resolved chain LONGER than the window and prove the walk caps identically.
+    {
+        const core::CoinParams tn = dgb::make_coin_params(/*testnet=*/true);
+        const int32_t window = static_cast<int32_t>(tn.real_chain_length);  // 400
+        dgb::ShareTracker tk;
+        uint256 prev; prev.SetNull();
+        uint256 tip;
+        for (int i = 0; i < window + 5; ++i) {
+            char buf[16]; std::snprintf(buf, sizeof(buf), "%x", 0x9000 + i);
+            uint256 h = hx(buf);
+            add_walk_share(tk, h, (i == 0 ? nullptr : &prev),
+                           0x1e0fffff, static_cast<uint16_t>((i * 7919) % 65535));
+            prev = h; tip = h;
+        }
+        const auto legacy = legacy_inline_weight_walk(tk, tip, bb, tn, /*v36=*/true);
+        const auto helper = dgb::coin::compute_pplns_weight_walk(tk, tip, bb, tn, /*v36=*/true);
+        EXPECT_EQ(helper.weights,               legacy.weights)               << "window weights";
+        EXPECT_EQ(helper.total_weight,          legacy.total_weight)          << "window total_weight";
+        EXPECT_EQ(helper.total_donation_weight, legacy.total_donation_weight) << "window donation_weight";
+    }
 }

--- a/src/impl/dgb/test/share_test.cpp
+++ b/src/impl/dgb/test/share_test.cpp
@@ -18,6 +18,7 @@
 #include <impl/dgb/config_coin.hpp>
 #include <impl/dgb/share.hpp>
 #include <impl/dgb/share_tracker.hpp>   // DensePPLNSWindow — V36 decayed-PPLNS SSOT
+#include <impl/dgb/coin/pplns_weight_walk.hpp> // SSOT: PPLNS step-1 tracker walk (shared emission/verify)
 #include <impl/dgb/params.hpp>          // make_coin_params — assembled CoinParams SSOT
 #include <impl/dgb/coin/rpc_conf.hpp>   // #82 external-daemon RPC creds (digibyte.conf)
 #include <impl/dgb/auto_ratchet.hpp> // Phase B: mint-side share-version ratchet
@@ -246,6 +247,69 @@ TEST(DGB_share_test, DesiredVersionWeightsByAttempts)
     // Attempts-weighting: the lone high-difficulty dv=35 share outweighs the two
     // low-difficulty dv=36 shares — the exact property a flat count inverts.
     EXPECT_GT(w.at(35u), w.at(36u));
+}
+
+// ── compute_pplns_weight_walk() SSOT contract KAT ───────────────────────────
+// The PPLNS step-1 tracker walk is now ONE helper shared by the share-
+// VERIFICATION path (generate_share_transaction) and the per-connection Stratum
+// coinbase EMISSION path (build_connection_coinbase producer seam). Value-level
+// faithfulness of the lift is proven by the unchanged generate_share_transaction
+// fixtures (they route through the helper now); this KAT independently locks the
+// helper's CONTRACT so a later edit that breaks the emission path is caught even
+// where no verifier test covers it:
+//   (1) it forwards verbatim to get_v36_decayed_cumulative_weights on the V36
+//       path (byte-identical weights/totals), and
+//   (2) it returns an empty, safe result (no throw) when the parent is null or
+//       absent from the chain — the "safe coinbase-only / empty job" the seam
+//       relies on while the tip is unknown.
+TEST(DGB_share_test, WeightWalkSSOTContract)
+{
+    const core::CoinParams params = dgb::make_coin_params(/*testnet=*/false);
+
+    dgb::ShareTracker tracker;
+    auto mk = [&](const char* hh, const char* ph, uint32_t bits) {
+        auto* s = new dgb::MergedMiningShare();
+        s->m_hash.SetHex(hh);
+        if (ph) s->m_prev_hash.SetHex(ph); else s->m_prev_hash.SetNull();
+        s->m_bits = bits;
+        s->m_max_bits = bits;
+        dgb::ShareType st; st = s;
+        tracker.add(st);
+    };
+    const char* h0 = "00000000000000000000000000000000000000000000000000000000000000b0";
+    const char* h1 = "00000000000000000000000000000000000000000000000000000000000000b1";
+    const char* h2 = "00000000000000000000000000000000000000000000000000000000000000b2";
+    mk(h0, nullptr,    0x1e0fffff);
+    mk(h1, h0,         0x1e0fffff);
+    mk(h2, h1,         0x1e0fffff);
+
+    uint256 tip; tip.SetHex(h2);
+    const auto chain_len = static_cast<int32_t>(params.real_chain_length);
+
+    // (1) V36 path forwards verbatim to the tracker's decayed-weights SSOT.
+    uint288 unlimited_weight;
+    unlimited_weight.SetHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    const auto direct = tracker.get_v36_decayed_cumulative_weights(tip, chain_len, unlimited_weight);
+    const auto via_helper = dgb::coin::compute_pplns_weight_walk(
+        tracker, tip, /*block_bits=*/0x1e0fffff, params, /*use_v36_pplns=*/true);
+    EXPECT_EQ(via_helper.weights,               direct.weights);
+    EXPECT_EQ(via_helper.total_weight,          direct.total_weight);
+    EXPECT_EQ(via_helper.total_donation_weight, direct.total_donation_weight);
+
+    // (2a) null parent -> empty, safe (no throw).
+    const auto null_walk = dgb::coin::compute_pplns_weight_walk(
+        tracker, uint256::ZERO, 0x1e0fffff, params, /*use_v36_pplns=*/true);
+    EXPECT_TRUE(null_walk.weights.empty());
+    EXPECT_TRUE(null_walk.total_weight.IsNull());
+    EXPECT_TRUE(null_walk.total_donation_weight.IsNull());
+
+    // (2b) parent absent from the chain -> empty, safe (no throw).
+    uint256 absent; absent.SetHex(
+        "00000000000000000000000000000000000000000000000000000000deadbeef");
+    const auto absent_walk = dgb::coin::compute_pplns_weight_walk(
+        tracker, absent, 0x1e0fffff, params, /*use_v36_pplns=*/true);
+    EXPECT_TRUE(absent_walk.weights.empty());
+    EXPECT_TRUE(absent_walk.total_weight.IsNull());
 }
 
 

--- a/src/impl/dgb/test/work_source_test.cpp
+++ b/src/impl/dgb/test/work_source_test.cpp
@@ -16,6 +16,7 @@
 #include <impl/dgb/stratum/work_source.hpp>
 #include <impl/dgb/coin/header_chain.hpp>
 #include <impl/dgb/coin/mempool.hpp>
+#include <impl/dgb/coin/connection_coinbase.hpp>  // build_connection_coinbase_from_pplns (SSOT under test)
 #include <impl/dgb/config_coin.hpp>   // dgb::CoinParams::subsidy (oracle SSOT)
 
 #include <core/pow.hpp>                 // core::SubsidyFunc
@@ -24,6 +25,7 @@
 
 #include <gtest/gtest.h>
 
+#include <map>
 #include <memory>
 #include <optional>
 
@@ -518,6 +520,91 @@ TEST(DgbWorkSource, GbtPrevhashGetterMatchesTemplateField)
     EXPECT_EQ(ws->get_current_gbt_prevhash(), expected);
     EXPECT_EQ(ws->get_current_work_template()["previousblockhash"].get<std::string>(),
               expected);
+}
+
+
+// ── Per-connection coinbase live-wire (set_pplns_inputs_fn / build_connection_coinbase) ──
+// The producer half of the Phase-B coinbase wire: build_connection_coinbase
+// delegates to the build_connection_coinbase_from_pplns SSOT (which the verifier
+// also calls). These pin three contracts: (1) UNBOUND -> empty job (pre-wire
+// byte-identical no-op), (2) bound -> coinb1/coinb2 byte-identical to the SSOT
+// called directly with the same inputs (proving build_connection_coinbase is a
+// pure pass-through, not a second payout implementation), (3) producer nullopt
+// -> empty job.
+namespace {
+
+using Script = std::vector<unsigned char>;
+
+// A fixed, fully-populated PPLNS input set (two payout scripts, v36 no-finder).
+dgb::coin::ConnCoinbasePplnsInputs sample_pplns_inputs()
+{
+    dgb::coin::ConnCoinbasePplnsInputs in;
+    in.coinbase_script = Script{0x03, 0x01, 0x02, 0x03};       // BIP34-ish scriptSig
+    in.weights = { {Script{0x76, 0xa9, 0x14, 0xaa}, uint288(3)},
+                   {Script{0x76, 0xa9, 0x14, 0xbb}, uint288(1)} };
+    in.total_weight = uint288(4);
+    in.subsidy = 1234567;
+    in.use_v36_pplns = true;
+    in.donation_script = Script{0xa9, 0x14, 0xcc};
+    in.ref_hash = uint256(std::vector<unsigned char>(32, 0xab));
+    in.last_txout_nonce = 0x0102030405060708ULL;
+    return in;
+}
+
+}  // namespace
+
+TEST(DgbWorkSource, ConnectionCoinbaseEmptyUntilPplnsInputsWired)
+{
+    Fixture fx;
+    auto ws = fx.make();
+    auto r = ws->build_connection_coinbase(
+        uint256::ZERO, "deadbeef", Script{}, {});
+    EXPECT_TRUE(r.coinb1.empty());
+    EXPECT_TRUE(r.coinb2.empty());
+}
+
+TEST(DgbWorkSource, ConnectionCoinbaseDelegatesToPplnsSsotByteIdentical)
+{
+    Fixture fx;
+    auto ws = fx.make();
+    const auto inputs = sample_pplns_inputs();
+
+    // Bind a producer that hands back the fixed inputs regardless of args.
+    ws->set_pplns_inputs_fn(
+        [&](const uint256&, const std::string&, const Script&,
+            const std::vector<std::pair<uint32_t, Script>>&)
+            -> std::optional<dgb::coin::ConnCoinbasePplnsInputs> {
+            return inputs;
+        });
+
+    auto wired = ws->build_connection_coinbase(
+        uint256(std::vector<unsigned char>(32, 0x11)), "cafef00d", Script{0x01}, {});
+
+    // The SSOT called directly with the same inputs is the oracle.
+    auto oracle = dgb::coin::build_connection_coinbase_from_pplns(inputs);
+
+    EXPECT_EQ(wired.coinb1, oracle.coinb1);
+    EXPECT_EQ(wired.coinb2, oracle.coinb2);
+    EXPECT_FALSE(wired.coinb1.empty());
+    // Consensus ref fields are frozen onto the snapshot for the submit path.
+    EXPECT_EQ(wired.snapshot.frozen_ref.ref_hash, inputs.ref_hash);
+    EXPECT_EQ(wired.snapshot.frozen_ref.last_txout_nonce, inputs.last_txout_nonce);
+    EXPECT_EQ(wired.snapshot.subsidy, inputs.subsidy);
+}
+
+TEST(DgbWorkSource, ConnectionCoinbaseProducerNulloptYieldsEmptyJob)
+{
+    Fixture fx;
+    auto ws = fx.make();
+    ws->set_pplns_inputs_fn(
+        [&](const uint256&, const std::string&, const Script&,
+            const std::vector<std::pair<uint32_t, Script>>&)
+            -> std::optional<dgb::coin::ConnCoinbasePplnsInputs> {
+            return std::nullopt;  // tip not yet known
+        });
+    auto r = ws->build_connection_coinbase(uint256::ZERO, "00", Script{}, {});
+    EXPECT_TRUE(r.coinb1.empty());
+    EXPECT_TRUE(r.coinb2.empty());
 }
 
 }  // namespace


### PR DESCRIPTION
Stacked on #331. Phase B.

## What
Extract `generate_share_transaction()` step-1 PPLNS tracker walk into the shared SSOT `dgb::coin::compute_pplns_weight_walk()` — the producer-side counterpart of the steps 2-3 lift (`compute_pplns_payout_split`, #328). The share-VERIFICATION path and the per-connection Stratum coinbase EMISSION path now walk the tracker through **one** implementation, so the weight map a miner hashes cannot drift from the one the verifier enforces.

## Why
This is the prerequisite for the upcoming main_dgb seam-bind (binding `set_pplns_inputs_fn` to the live tracker lambda). Collapsing the walk into an SSOT **before** the bind removes the divergence risk from the bind itself — the bind becomes a thin call into already-verified code.

## Faithfulness
- Verbatim lift: exact V36 depth-decay vs pre-V36 grandparent-start branch, the data.py insufficient-depth guard, and the block-target/spread `max_weight` cap are byte-unchanged.
- Result type is **deduced** from the tracker (`decltype`) to avoid the `share_tracker.hpp` ↔ `share_check.hpp` include cycle.
- New `WeightWalkSSOTContract` KAT locks the helper contract (verbatim V36 forward + safe-empty on null/absent parent). The **unchanged** `generate_share_transaction` fixtures prove value-level byte-identity.

## Tests
`dgb_share_test` 27/27 · `dgb_connection_coinbase_test` 8/8 (local). GPG-signed.

Consensus-bearing (touches the verifier) → surface-for-tap, **not** auto-merge.


---

## Reviewer focus — decltype-deduced return type (per integrator)

The one spot where a "verbatim lift" could silently differ is the deduced `Result`. Confirmed byte-identical to a hand-named type:

- `share_tracker.hpp:1701` declares `CumulativeWeights get_v36_decayed_cumulative_weights(...)` — return **by value**, a concrete non-reference struct.
- `decltype(tracker.get_v36_decayed_cumulative_weights(...))` over that call-expression yields exactly `CumulativeWeights` (a function-call prvalue, so decltype is the declared return type, unchanged). No reference qualifier, no narrowing, no copy-vs-ref change of the weight map.
- Proof it is a value type (not a reference): `Result out{};` value-initializes the result; a reference deduction would be ill-formed and fail to compile. The 27/27 build is that proof.
- Hand-naming `CumulativeWeights` directly would be behavior-identical but reintroduces the share_tracker.hpp <-> share_check.hpp include cycle — the only reason `decltype` is used here.

Net: emission and verification share one weight-map type by construction; the decltype is a cycle-break, not a type change.