### PR TITLE
btc: guard think()-watchdog backtrace behind #ifndef _WIN32

### DIFF
--- a/src/impl/btc/node.cpp
+++ b/src/impl/btc/node.cpp
@@ -12,7 +12,9 @@
 #include <iomanip>
 #include <random>
 
-#include <execinfo.h>  // backtrace() for think() watchdog stack dump
+#ifndef _WIN32
+#include <execinfo.h>  // backtrace() for think() watchdog stack dump (glibc-only)
+#endif
 
 // Static members for DensePPLNSWindow precomputed decay table
 std::vector<uint64_t> btc::DensePPLNSWindow::s_decay_table;
@@ -1427,6 +1429,7 @@ void NodeImpl::arm_think_watchdog()
                   << THINK_WATCHDOG_SECONDS << "s (gen=" << gen
                   << ", pending_adds=" << m_pending_adds.size()
                   << ") — compute thread appears wedged; recovering pipeline";
+#ifndef _WIN32
         {
             void* frames[64];
             int n = ::backtrace(frames, 64);
@@ -1437,6 +1440,10 @@ void NodeImpl::arm_think_watchdog()
                 ::free(syms);
             }
         }
+#else
+        // Native backtrace is glibc-only (execinfo.h); on MSVC the timeout log
+        // above plus pending_adds is the diagnostic. Recovery below is identical.
+#endif
 
         // (2)+(3) Flag the cycle aborted and reset the running flag so the
         // pipeline recovers. NOTE: this does NOT forcibly unwind the compute


### PR DESCRIPTION
Mirror of LTC `eafcb498b` into the BTC node twin.

## What
The BTC `think()`-watchdog (`src/impl/btc/node.cpp` `arm_think_watchdog`) dumps a stack via `execinfo.h` (`::backtrace` / `::backtrace_symbols`), which is glibc-only. This guards both the `#include <execinfo.h>` and the dump block behind `#ifndef _WIN32` so the BTC node builds on MSVC/Windows, matching what LTC already does.

## Why
The freeze-fix architecture (compute-thread post + `try_to_lock` IO + watchdog + Phase-1 verify budget) is **already present** in the BTC twin; the only LTC watchdog refinement not yet mirrored was this portability guard. On non-glibc the timeout log line plus `pending_adds` remains the diagnostic; the recovery path (reset `m_think_running` / deadline) is identical and stays active on all platforms.

## Scope / safety
- Touches `src/impl/btc/node.cpp` only — per-coin isolation respected, no shared-layer touch.
- No behavioral change on Linux/glibc: the active path is byte-identical (preprocessor guard inactive on Linux).
- Classification: **compat / portability** (per-coin baseline), not a v36-native standardized structure.

## Verify
- `make btc` → `[100%] Built target btc`, exit 0 (Linux/glibc).
- Commit GPG-signed.