### PR TITLE
dgb: fix compute_ref_hash_for_work segwit-field parity (+ emission==verification KAT)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
                     test_mweb_builder \
                     test_address_resolution test_compute_share_target \
                     test_utxo test_dgb_subsidy test_dgb_coinbase_value dgb_share_test dgb_redistribute_test dgb_block_assembly_test dgb_header_sample_build_test dgb_header_ingest_test dgb_mempool_ingest_test \
-                    dgb_gentx_coinbase_test dgb_connection_coinbase_test dgb_pplns_payout_split_test nmc_auxpow_merkle_test nmc_template_builder_test nmc_auxpow_wire_test nmc_reconstruct_won_block_test dgb_gentx_share_path_test dgb_other_tx_resolver_test \
+                    dgb_gentx_coinbase_test dgb_connection_coinbase_test dgb_pplns_payout_split_test nmc_auxpow_merkle_test nmc_template_builder_test nmc_auxpow_wire_test nmc_reconstruct_won_block_test dgb_gentx_share_path_test dgb_conn_pplns_producer_test dgb_other_tx_resolver_test \
                     dgb_other_tx_assembler_test dgb_reconstruct_won_block_test dgb_reconstruct_closure_test dgb_gentx_unpack_test dgb_work_source_test dgb_template_builder_test dgb_embedded_coin_node_test dgb_embedded_tx_select_test dgb_template_other_txs_test dgb_coinbase_value_parity_test dgb_submit_classify_test dgb_aux_parent_coinbase_parity_test dgb_template_capture_test dgb_aux_doge_db_commitment_bind_test \
                     rpc_request_test softfork_check_test genesis_check_test algo_select_test digishield_walk_test header_chain_test \
                     dgb_coin_node_seam_test dgb_block_broadcast_test dgb_won_block_dispatch_test dgb_forced_won_share_dualpath_test dgb_scrypt_pow_test dgb_nonce_grinder_test dgb_regrind_block_test dgb_won_block_finalize_test v37_test \
@@ -213,7 +213,7 @@ jobs:
                     test_mweb_builder \
                     test_address_resolution test_compute_share_target \
                     test_utxo test_dgb_subsidy test_dgb_coinbase_value dgb_share_test dgb_redistribute_test dgb_block_assembly_test dgb_header_sample_build_test dgb_header_ingest_test dgb_mempool_ingest_test \
-                    dgb_gentx_coinbase_test dgb_connection_coinbase_test dgb_pplns_payout_split_test nmc_auxpow_merkle_test nmc_template_builder_test nmc_auxpow_wire_test nmc_reconstruct_won_block_test dgb_gentx_share_path_test dgb_other_tx_resolver_test \
+                    dgb_gentx_coinbase_test dgb_connection_coinbase_test dgb_pplns_payout_split_test nmc_auxpow_merkle_test nmc_template_builder_test nmc_auxpow_wire_test nmc_reconstruct_won_block_test dgb_gentx_share_path_test dgb_conn_pplns_producer_test dgb_other_tx_resolver_test \
                     dgb_other_tx_assembler_test dgb_reconstruct_won_block_test dgb_reconstruct_closure_test dgb_gentx_unpack_test dgb_work_source_test dgb_template_builder_test dgb_embedded_coin_node_test dgb_embedded_tx_select_test dgb_template_other_txs_test dgb_coinbase_value_parity_test dgb_submit_classify_test dgb_aux_parent_coinbase_parity_test dgb_template_capture_test dgb_aux_doge_db_commitment_bind_test \
                     rpc_request_test softfork_check_test genesis_check_test algo_select_test digishield_walk_test header_chain_test \
                     dgb_coin_node_seam_test dgb_block_broadcast_test dgb_won_block_dispatch_test dgb_forced_won_share_dualpath_test dgb_scrypt_pow_test dgb_nonce_grinder_test dgb_regrind_block_test dgb_won_block_finalize_test test_coin_broadcaster test_multiaddress_pplns test_pplns_stress \

--- a/src/impl/dgb/conn_pplns_producer.hpp
+++ b/src/impl/dgb/conn_pplns_producer.hpp
@@ -1,0 +1,98 @@
+#pragma once
+// ============================================================================
+// conn_pplns_producer.hpp — per-connection PPLNS-inputs producer-assembly SSOT.
+//
+// The per-connection Stratum coinbase a miner hashes commits, in its OP_RETURN,
+// to a p2pool ref_hash for the prospective NEXT share. That ref_hash MUST be
+// computed by the EXACT primitive the share verifier uses
+// (dgb::compute_ref_hash_for_work — share_check.hpp), or a Stratum-emitted
+// share can never match the share it commits to. This is precisely the latent
+// no-segwit-v36 gap fixed in compute_ref_hash_for_work (the ref preimage always
+// carries the segwit field for ver >= SEGWIT_ACTIVATION_VERSION); the
+// per-connection coinbase producer is that primitive's FIRST live caller.
+//
+// make_conn_pplns_inputs() is the single seam that binds the verifier ref-hash
+// primitive onto the per-connection PPLNS inputs. The caller (main_dgb) does
+// the lock-safe tracker walk and resolves the two oracle-pinned design points:
+//
+//   subsidy        == DGBWorkSource::coinbase_value(height, fees, gbt)
+//                     i.e. the SAME block-template value the miner solves
+//                     (oracle work.py get_work: subsidy=current_work['subsidy']).
+//   use_v36_pplns  == is_v36_active(ratchet-selected mint version)
+//                     i.e. the formula the NEXT share will be minted under
+//                     (oracle work.py: share_type via AutoRatchet switchover),
+//                     NOT a separate runtime flag.
+//
+// This header adds NO payout or ref arithmetic of its own: it forwards the
+// already-walked PPLNS weights into ConnCoinbasePplnsInputs (which delegates the
+// amount split to compute_pplns_payout_split — the verifier's SSOT) and fills
+// ref_hash/last_txout_nonce from compute_ref_hash_for_work. Emission and
+// verification therefore share ONE ref-hash implementation and ONE payout
+// implementation, by construction — not two kept in agreement.
+//
+// Pure / tracker-free: weights + RefHashParams are caller-supplied inputs, so
+// the assembled output is directly KAT-able against the verifier primitive
+// (see test/conn_pplns_producer_test.cpp).
+// ============================================================================
+
+#include "share_check.hpp"                       // dgb::compute_ref_hash_for_work, dgb::RefHashParams
+#include <impl/dgb/coin/connection_coinbase.hpp> // dgb::coin::ConnCoinbasePplnsInputs
+
+#include <core/coin_params.hpp>
+#include <core/uint256.hpp>
+
+#include <map>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace dgb
+{
+
+// Caller-resolved inputs for one connection's prospective-next-share coinbase.
+// weights/total_weight come from a lock-safe compute_pplns_weight_walk() over
+// the live ShareTracker (done upstream, off the work-gen thread under the
+// tracker read lock). ref_params carries the prospective share's fields that
+// feed the ref preimage.
+struct ConnPplnsAssemblyInputs
+{
+    // PPLNS weight map + total, exactly as compute_pplns_weight_walk() produced.
+    std::map<std::vector<unsigned char>, uint288> weights;
+    uint288  total_weight;
+
+    uint64_t subsidy{0};                          // == coinbase_value(height,fees,gbt)
+    bool     use_v36_pplns{true};                 // == is_v36_active(mint version)
+
+    std::vector<unsigned char> coinbase_script;   // scriptSig (BIP34 height + tag)
+    std::optional<std::vector<unsigned char>> segwit_commitment_script;
+    std::vector<unsigned char> finder_script;     // pre-V36 0.5% finder-fee target
+    std::vector<unsigned char> donation_script;
+
+    RefHashParams ref_params;                     // feeds compute_ref_hash_for_work
+};
+
+// Assemble a complete ConnCoinbasePplnsInputs for one connection. ref_hash and
+// last_txout_nonce are computed HERE via the verifier's
+// compute_ref_hash_for_work primitive, so the emitted OP_RETURN commits to a
+// ref the verifier reproduces bit-for-bit (no second ref-hash implementation).
+inline dgb::coin::ConnCoinbasePplnsInputs make_conn_pplns_inputs(
+    const ConnPplnsAssemblyInputs& in, const core::CoinParams& params)
+{
+    const auto [ref_hash, last_txout_nonce] =
+        compute_ref_hash_for_work(in.ref_params, params);
+
+    dgb::coin::ConnCoinbasePplnsInputs out;
+    out.coinbase_script          = in.coinbase_script;
+    out.segwit_commitment_script = in.segwit_commitment_script;
+    out.weights                  = in.weights;
+    out.total_weight             = in.total_weight;
+    out.subsidy                  = in.subsidy;
+    out.use_v36_pplns            = in.use_v36_pplns;
+    out.finder_script            = in.finder_script;
+    out.donation_script          = in.donation_script;
+    out.ref_hash                 = ref_hash;
+    out.last_txout_nonce         = last_txout_nonce;
+    return out;
+}
+
+} // namespace dgb

--- a/src/impl/dgb/share_check.hpp
+++ b/src/impl/dgb/share_check.hpp
@@ -400,8 +400,25 @@ inline std::pair<uint256, uint64_t> compute_ref_hash_for_work(const RefHashParam
     ref_stream << p.stale_info;
     ::Serialize(ref_stream, VarInt(p.desired_version));
 
-    if (p.has_segwit)
-        ref_stream << p.segwit_data;
+    // Segwit field (PARITY FIX): for share versions >= SEGWIT_ACTIVATION_VERSION
+    // the ref preimage ALWAYS carries a segwit field -- the SegwitData when
+    // present, else an explicit (empty merkle branch, zero wtxid root)
+    // placeholder. This mirrors generate_share_transaction() / share_init_verify()
+    // byte-for-byte (PossiblyNoneType writes the default when None). The prior
+    // `if (p.has_segwit)` omitted the placeholder, so a no-segwit v36 share got a
+    // ref_hash 33 bytes shorter than the verifier computes -- a Stratum-emitted
+    // OP_RETURN would never match the share it commits to. Latent until now: no
+    // live DGB caller until the per-connection coinbase producer seam is bound.
+    if (p.share_version >= dgb::SEGWIT_ACTIVATION_VERSION) {
+        if (p.has_segwit) {
+            ref_stream << p.segwit_data;
+        } else {
+            std::vector<uint256> empty_branch;
+            ref_stream << empty_branch;
+            uint256 zero_root;
+            ref_stream << zero_root;
+        }
+    }
 
     // V36: merged_addresses (after segwit_data, before far_share_hash)
     if (core::version_gate::is_v36_active(p.share_version))

--- a/src/impl/dgb/test/CMakeLists.txt
+++ b/src/impl/dgb/test/CMakeLists.txt
@@ -190,6 +190,19 @@ if (BUILD_TESTING AND GTest_FOUND)
         dgb_coin pool sharechain)
     gtest_add_tests(dgb_gentx_share_path_test "" AUTO)
 
+    # --- Phase B: per-connection PPLNS-inputs producer-assembly KAT ---------
+    # conn_pplns_producer.hpp binds the verifier ref-hash primitive
+    # (compute_ref_hash_for_work, #336) onto the per-connection coinbase inputs.
+    # Links the dgb OBJECT-lib SCC set like dgb_gentx_share_path_test (pulls
+    # share_check.hpp). MUST also be in the build.yml --target allowlist (#143).
+    add_executable(dgb_conn_pplns_producer_test conn_pplns_producer_test.cpp)
+    target_link_libraries(dgb_conn_pplns_producer_test PRIVATE
+        GTest::gtest_main GTest::gtest
+        core dgb
+        c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage
+        dgb_coin pool sharechain)
+    gtest_add_tests(dgb_conn_pplns_producer_test "" AUTO)
+
     # --- #82 sub-slice 1: transaction_hash_refs -> other_tx hash walk -------
     # coin/other_tx_resolver.hpp is the won-block reconstructor`s connecting
     # tissue (faithful get_other_tx_hashes ancestry resolution). It pulls

--- a/src/impl/dgb/test/conn_pplns_producer_test.cpp
+++ b/src/impl/dgb/test/conn_pplns_producer_test.cpp
@@ -1,0 +1,155 @@
+// DGB Phase B — per-connection PPLNS-inputs producer-assembly KAT.
+//
+// Locks dgb::make_conn_pplns_inputs() (conn_pplns_producer.hpp): the seam that
+// binds the verifier ref-hash primitive (compute_ref_hash_for_work, the #336
+// parity-fixed path) onto the per-connection coinbase PPLNS inputs. A PASS
+// proves the producer-assembly path:
+//
+//   1. derives ref_hash / last_txout_nonce from the SAME primitive the share
+//      verifier uses — for BOTH the no-segwit-v36 case (the latent gap #336
+//      fixed: the producer is that primitive's FIRST live caller) and the
+//      with-segwit case — so a Stratum-emitted OP_RETURN matches the share it
+//      commits to by construction, not by a second ref-hash implementation;
+//   2. forwards the caller-resolved PPLNS weights + the two oracle-pinned
+//      design points (subsidy == template value, use_v36_pplns == minted
+//      formula) verbatim into ConnCoinbasePplnsInputs; and
+//   3. round-trips through build_connection_coinbase_from_pplns so the emitted
+//      coinbase embeds exactly that ref_hash + nonce in its OP_RETURN.
+//
+// Pure / tracker-free: weights + RefHashParams are fixed inputs, so the
+// assembled output is checked against the verifier primitive directly — not
+// self-generated.
+//
+// MUST appear in BOTH test/CMakeLists.txt AND the build.yml --target allowlist
+// or it becomes a #143-style NOT_BUILT sentinel that reds master.
+
+#include <gtest/gtest.h>
+
+#include <impl/dgb/conn_pplns_producer.hpp>
+#include <impl/dgb/share_check.hpp>
+#include <impl/dgb/coin/connection_coinbase.hpp>
+#include <impl/dgb/params.hpp>
+
+#include <core/uint256.hpp>
+
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using Script = std::vector<unsigned char>;
+
+std::vector<unsigned char> unhex(const std::string& h) {
+    std::vector<unsigned char> v; v.reserve(h.size() / 2);
+    auto nyb = [](char c) -> int { return (c <= '9') ? c - '0' : (c | 0x20) - 'a' + 10; };
+    for (size_t i = 0; i + 1 < h.size(); i += 2)
+        v.push_back(static_cast<unsigned char>((nyb(h[i]) << 4) | nyb(h[i + 1])));
+    return v;
+}
+
+// Donation script: byte-identical to the oracle wire vector (4104ffd0...ac).
+const Script DON = unhex("4104ffd03de44a6e11b9917f3a29f9443283d9871c9d743ef30d5eddcd37094b64d1b3d8090496b53256786bf5c82932ec23c3b74d9f05a6f95a8b5529352656664bac");
+const Script SA{0x01};
+const Script SB{0x02};
+const Script CB = unhex("03a1b2c3041122334455667788");
+
+// A v36 RefHashParams with non-trivial fields (mirrors gentx_share_path_test's
+// make_v36_share). has_segwit defaults false => exercises the #336 placeholder.
+dgb::RefHashParams make_v36_ref_params() {
+    dgb::RefHashParams p;
+    p.share_version    = 36;
+    p.prev_share.SetNull();
+    p.coinbase_scriptSig = CB;
+    p.share_nonce      = 0x12345678;
+    p.pubkey_hash.SetNull();
+    p.pubkey_type      = 0;
+    p.subsidy          = 10000;
+    p.donation         = 0;
+    p.stale_info       = 0;
+    p.desired_version  = 36;
+    p.has_segwit       = false;
+    p.far_share_hash.SetNull();
+    p.max_bits         = 0x1e0fffff;
+    p.bits             = 0x1e0fffff;
+    p.timestamp        = 1718700000;
+    p.absheight        = 1000;
+    p.merged_payout_hash.SetNull();
+    return p;
+}
+
+dgb::ConnPplnsAssemblyInputs make_assembly_inputs(const dgb::RefHashParams& rp) {
+    dgb::ConnPplnsAssemblyInputs in;
+    in.weights = std::map<Script, uint288>{{SA, uint288(3)}, {SB, uint288(1)}};
+    in.total_weight             = uint288(4);
+    in.subsidy                  = 10000;           // == coinbase_value(...) [design #1]
+    in.use_v36_pplns            = true;            // == is_v36_active(mint ver) [design #2]
+    in.coinbase_script          = CB;
+    in.segwit_commitment_script = std::nullopt;    // no-segwit v36
+    in.finder_script            = {};
+    in.donation_script          = DON;
+    in.ref_params               = rp;
+    return in;
+}
+
+// (1a) No-segwit v36: ref_hash/nonce come from the verifier primitive verbatim.
+TEST(ConnPplnsProducer, RefHashDelegatesToVerifierPrimitiveNoSegwit) {
+    const auto params = dgb::make_coin_params(/*testnet=*/false);
+    auto rp = make_v36_ref_params();
+    ASSERT_FALSE(rp.has_segwit);   // the #336 placeholder branch
+
+    auto out = dgb::make_conn_pplns_inputs(make_assembly_inputs(rp), params);
+
+    const auto [ref_hash, nonce] = dgb::compute_ref_hash_for_work(rp, params);
+    EXPECT_EQ(out.ref_hash, ref_hash);
+    EXPECT_EQ(out.last_txout_nonce, nonce);
+    EXPECT_FALSE(out.ref_hash.IsNull());
+}
+
+// (1b) With-segwit v36: same delegation (the producer never re-implements the
+//      ref preimage — it always tracks the verifier primitive).
+TEST(ConnPplnsProducer, RefHashDelegatesToVerifierPrimitiveWithSegwit) {
+    const auto params = dgb::make_coin_params(/*testnet=*/false);
+    auto rp = make_v36_ref_params();
+    rp.has_segwit = true;          // SegwitData default-constructed
+
+    auto out = dgb::make_conn_pplns_inputs(make_assembly_inputs(rp), params);
+
+    const auto [ref_hash, nonce] = dgb::compute_ref_hash_for_work(rp, params);
+    EXPECT_EQ(out.ref_hash, ref_hash);
+    EXPECT_EQ(out.last_txout_nonce, nonce);
+}
+
+// (2) Caller-resolved PPLNS weights + design points forward verbatim.
+TEST(ConnPplnsProducer, ForwardsWeightsAndDesignPoints) {
+    const auto params = dgb::make_coin_params(/*testnet=*/false);
+    auto in  = make_assembly_inputs(make_v36_ref_params());
+    auto out = dgb::make_conn_pplns_inputs(in, params);
+
+    EXPECT_EQ(out.weights, in.weights);
+    EXPECT_EQ(out.total_weight, in.total_weight);
+    EXPECT_EQ(out.subsidy, in.subsidy);
+    EXPECT_EQ(out.use_v36_pplns, in.use_v36_pplns);
+    EXPECT_EQ(out.coinbase_script, in.coinbase_script);
+    EXPECT_EQ(out.donation_script, in.donation_script);
+    EXPECT_FALSE(out.segwit_commitment_script.has_value());
+}
+
+// (3) The assembled inputs round-trip through the coinbase SSOT and the emitted
+//     OP_RETURN embeds exactly the producer's ref_hash + nonce.
+TEST(ConnPplnsProducer, RoundTripEmbedsRefInOpReturn) {
+    const auto params = dgb::make_coin_params(/*testnet=*/false);
+    auto out = dgb::make_conn_pplns_inputs(make_assembly_inputs(make_v36_ref_params()), params);
+
+    auto parts = dgb::coin::build_connection_coinbase_from_pplns(out);
+    const auto want = dgb::coin::build_ref_op_return(out.ref_hash, out.last_txout_nonce);
+
+    const auto& bytes = parts.gentx.bytes;
+    auto it = std::search(bytes.begin(), bytes.end(), want.begin(), want.end());
+    EXPECT_NE(it, bytes.end());   // the OP_RETURN commitment is present verbatim
+    EXPECT_FALSE(parts.coinb1.empty());
+}
+
+}  // namespace

--- a/src/impl/dgb/test/gentx_share_path_test.cpp
+++ b/src/impl/dgb/test/gentx_share_path_test.cpp
@@ -38,6 +38,7 @@
 #include <core/uint256.hpp>
 
 #include <cstdint>
+#include <cstring>
 #include <optional>
 #include <span>
 #include <utility>
@@ -303,6 +304,119 @@ TEST(DgbGentxSharePath, SsotGentxBytesExposedForReconstruct)
         reinterpret_cast<const unsigned char*>(repacked.data()),
         reinterpret_cast<const unsigned char*>(repacked.data()) + repacked.size());
     EXPECT_EQ(rebytes, gc.bytes) << "coinbase tx does not round-trip the SSOT bytes";
+}
+
+
+// ============================================================================
+// Emission==verification ref_hash parity KAT.
+//
+// dgb::compute_ref_hash_for_work() is the Stratum WORK-GENERATION ref_hash SSOT
+// the per-connection coinbase producer seam (set_pplns_inputs_fn) will call to
+// build each connection's OP_RETURN commitment. generate_share_transaction() is
+// the VERIFICATION SSOT. The OP_RETURN a miner hashes MUST commit to the exact
+// ref_hash the verifier recomputes for the share that mines it, or the won
+// block / share is rejected.
+//
+// This pins them production-vs-production: the ref_hash compute_ref_hash_for_work
+// returns must equal the 32 bytes generate_share_transaction actually embeds in
+// the gentx OP_RETURN (6a 28 <ref32> <nonce8>) for the SAME share. No test-side
+// re-serialization -- both sides are production code.
+//
+// REGRESSION CAUGHT: for ver >= SEGWIT_ACTIVATION_VERSION (=35) the verifier
+// ALWAYS serializes a segwit field -- the SegwitData, or an (empty branch, zero
+// root) placeholder when None. The prior compute_ref_hash_for_work wrote the
+// field ONLY when has_segwit, so a no-segwit v36 share got a 33-byte-shorter
+// preimage and a non-matching ref_hash. There is no live DGB caller yet (work
+// path is the 4a skeleton), so this was latent until the producer seam binds.
+namespace {
+dgb::RefHashParams ref_params_from_share(const dgb::MergedMiningShare& s)
+{
+    dgb::RefHashParams p;
+    p.share_version      = dgb::MergedMiningShare::version;   // 36
+    p.prev_share         = s.m_prev_hash;
+    p.coinbase_scriptSig = s.m_coinbase.m_data;
+    p.share_nonce        = s.m_nonce;
+    p.pubkey_hash        = s.m_pubkey_hash;
+    p.pubkey_type        = s.m_pubkey_type;
+    p.subsidy            = s.m_subsidy;
+    p.donation           = s.m_donation;
+    p.stale_info         = static_cast<uint8_t>(s.m_stale_info);
+    p.desired_version    = s.m_desired_version;
+    p.has_segwit         = s.m_segwit_data.has_value();
+    if (p.has_segwit) p.segwit_data = s.m_segwit_data.value();
+    p.merged_addresses     = s.m_merged_addresses;
+    p.far_share_hash       = s.m_far_share_hash;
+    p.max_bits             = s.m_max_bits;
+    p.bits                 = s.m_bits;
+    p.timestamp            = s.m_timestamp;
+    p.absheight            = s.m_absheight;
+    p.abswork              = s.m_abswork;
+    p.merged_coinbase_info = s.m_merged_coinbase_info;
+    p.merged_payout_hash   = s.m_merged_payout_hash;
+    p.message_data         = s.m_message_data;
+    return p;
+}
+
+// Extract the 32 ref_hash bytes from the gentx OP_RETURN (6a 28 <ref32><nonce8>).
+uint256 op_return_ref_hash(const std::vector<unsigned char>& gentx_bytes)
+{
+    for (size_t i = 0; i + 42 <= gentx_bytes.size(); ++i) {
+        if (gentx_bytes[i] == 0x6a && gentx_bytes[i + 1] == 0x28) {
+            uint256 rh;
+            std::memcpy(rh.data(), gentx_bytes.data() + i + 2, 32);
+            return rh;
+        }
+    }
+    return uint256::ZERO;
+}
+} // namespace (parity helpers)
+
+TEST(DgbGentxSharePath, RefHashWorkPathMatchesVerifierOpReturn_NoSegwit)
+{
+    auto params = dgb::make_coin_params(/*testnet=*/false);
+    dgb::ShareTracker tracker;                 // empty chain (null parent share)
+    auto share = make_v36_share();             // v36, no segwit_data
+
+    // Verification side: the ref_hash generate_share_transaction embeds.
+    dgb::coin::GentxCoinbase gc;
+    dgb::generate_share_transaction(
+        share, tracker, params, /*dump_diag=*/false, /*v36_active=*/true, &gc);
+    ASSERT_FALSE(gc.bytes.empty());
+    uint256 verifier_ref = op_return_ref_hash(gc.bytes);
+    ASSERT_FALSE(verifier_ref.IsNull()) << "no OP_RETURN ref commitment found in gentx";
+
+    // Emission side: the work-generation SSOT the producer seam will call.
+    auto [work_ref, nonce] = dgb::compute_ref_hash_for_work(
+        ref_params_from_share(share), params);
+
+    EXPECT_EQ(work_ref, verifier_ref)
+        << "compute_ref_hash_for_work ref_hash != verifier OP_RETURN ref_hash "
+           "(no-segwit v36 segwit-placeholder parity)";
+}
+
+// Guards the fix from regressing back to `if (p.has_segwit)`: toggling has_segwit
+// MUST change the emitted ref_hash, proving the segwit field (value-or-
+// placeholder) is now part of the preimage for ver >= SEGWIT_ACTIVATION_VERSION.
+TEST(DgbGentxSharePath, RefHashWorkPathSegwitFieldIsLoadBearing)
+{
+    auto params = dgb::make_coin_params(/*testnet=*/false);
+    auto share = make_v36_share();
+
+    auto base = ref_params_from_share(share);
+    base.has_segwit = false;
+    auto [ref_placeholder, n0] = dgb::compute_ref_hash_for_work(base, params);
+
+    auto withseg = base;
+    withseg.has_segwit = true;                 // serialize SegwitData instead of placeholder
+    // A DEFAULT SegwitData serializes byte-identically to the (empty branch,
+    // zero root) placeholder, so give it a non-zero wtxid root to prove the
+    // field is genuinely part of the preimage.
+    withseg.segwit_data.m_wtxid_merkle_root.SetHex(
+        "00000000000000000000000000000000000000000000000000000000deadbeef");
+    auto [ref_value, n1] = dgb::compute_ref_hash_for_work(withseg, params);
+
+    EXPECT_NE(ref_placeholder, ref_value)
+        << "segwit field not reaching the ref preimage -- placeholder regressed away";
 }
 
 } // namespace


### PR DESCRIPTION
## What

The Stratum work-generation ref_hash SSOT `dgb::compute_ref_hash_for_work()` omitted the segwit field for no-segwit shares, while the verification SSOT (`generate_share_transaction` / `share_init_verify`) ALWAYS serializes it for share versions >= `SEGWIT_ACTIVATION_VERSION` (35): the `SegwitData` when present, else an (empty merkle branch, zero wtxid root) placeholder.

Result: a no-segwit v36 share got a 33-byte-shorter work-path preimage and a `ref_hash` that does not match the verifier — a Stratum-emitted OP_RETURN would commit to a ref_hash the share it mines is rejected for.

## Why latent

`compute_ref_hash_for_work` has **no live DGB caller** today (work path is the 4a skeleton; the per-connection coinbase producer seam `set_pplns_inputs_fn` is unbound, so sessions push empty jobs). It becomes load-bearing the moment that seam is bound — this is upstream of the empty-jobs producer wiring. No behaviour change to any live path.

## Fix

Mirror the verifier exactly: serialize the segwit field (value or placeholder) for `share_version >= SEGWIT_ACTIVATION_VERSION`.

## Test

Production-vs-production KAT in `dgb_gentx_share_path_test` (existing target, already on the build.yml allowlist):
- `RefHashWorkPathMatchesVerifierOpReturn_NoSegwit` — `compute_ref_hash_for_work` equals the 32 ref bytes `generate_share_transaction` embeds in the gentx OP_RETURN for the same share (no test-side re-serialization).
- `RefHashWorkPathSegwitFieldIsLoadBearing` — a non-zero segwit field changes the preimage.

6/6 green locally (`dgb_gentx_share_path_test`).

## Scope

`src/impl/dgb/` only. Per-coin isolation held. **HOLD for integrator full-CI verification — do not merge.** btc/ltc carry their own `compute_ref_hash_for_work`; a separate cross-coin [fyi] to those owners re: the same potential gap (not touched here).