### PR TITLE
dgb: collapse last_txout_nonce into oracle-faithful SSOT [fyi]

### DIFF
--- a/src/impl/dgb/coin/last_txout_nonce.hpp
+++ b/src/impl/dgb/coin/last_txout_nonce.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+// SSOT: last_txout_nonce generation for the OP_RETURN extranonce slot.
+//
+// p2pool draws this value as a uniform 64-bit random number purely to make the
+// coinbase OP_RETURN unique per share (work.py: last_txout_nonce =
+// random.randrange(2**64)). The value is consensus-irrelevant: whatever is
+// generated here is carried verbatim into the minted share and re-read on the
+// verify path, so any draw satisfies uniqueness. Three ad-hoc time-XOR formulas
+// had drifted across share_check.hpp; this collapses them to one oracle-faithful
+// uniform draw and removes the unintended std::time() clock read (which made the
+// value low-entropy and straddle-flaky across a 1-second boundary).
+//
+// NOT a cross-coin standardization item — coin-local, consensus-neutral hygiene.
+
+#include <cstdint>
+#include <random>
+
+namespace dgb
+{
+
+// Oracle-faithful uniform 64-bit draw (mirrors random.randrange(2**64)).
+// thread_local engine matches the per-thread mt19937_64 idiom already used in
+// node.hpp / node.cpp; seeded once per thread from std::random_device.
+inline uint64_t make_last_txout_nonce()
+{
+    static thread_local std::mt19937_64 rng(std::random_device{}());
+    return rng();
+}
+
+} // namespace dgb

--- a/src/impl/dgb/share_check.hpp
+++ b/src/impl/dgb/share_check.hpp
@@ -11,6 +11,7 @@
 #include <impl/dgb/coin/gentx_coinbase.hpp>
 #include <impl/dgb/coin/pplns_payout_split.hpp>
 #include <impl/dgb/coin/pplns_weight_walk.hpp>   // SSOT: PPLNS step-1 tracker walk (shared w/ emission)
+#include <impl/dgb/coin/last_txout_nonce.hpp> // SSOT: oracle-faithful OP_RETURN extranonce draw
 
 #include <core/coin_params.hpp>
 #include <core/hash.hpp>
@@ -448,9 +449,7 @@ inline std::pair<uint256, uint64_t> compute_ref_hash_for_work(const RefHashParam
     }
 
     // Generate a random-ish last_txout_nonce
-    uint64_t nonce = static_cast<uint64_t>(std::time(nullptr)) ^
-                     (static_cast<uint64_t>(p.timestamp) << 32) ^
-                     (static_cast<uint64_t>(p.absheight) << 16);
+    uint64_t nonce = make_last_txout_nonce();
 
     return {ref_hash, nonce};
 }
@@ -2114,8 +2113,7 @@ uint256 create_local_share_v35(
     }
 
     // Random last_txout_nonce
-    share.m_last_txout_nonce = static_cast<uint64_t>(std::time(nullptr)) ^
-                               (static_cast<uint64_t>(min_header.m_nonce) << 32);
+    share.m_last_txout_nonce = make_last_txout_nonce();
 
     // ref_merkle_link: empty
     share.m_ref_merkle_link.m_branch.clear();
@@ -2578,8 +2576,7 @@ uint256 create_local_share(
     }
 
     // Random last_txout_nonce for OP_RETURN uniqueness
-    share.m_last_txout_nonce = static_cast<uint64_t>(std::time(nullptr)) ^
-                               (static_cast<uint64_t>(min_header.m_nonce) << 32);
+    share.m_last_txout_nonce = make_last_txout_nonce();
 
     // --- Build the p2pool coinbase via the SSOT assemble_gentx_coinbase() ---
     // (identical wire layout to generate_share_transaction; one byte path, not a twin)

--- a/src/impl/dgb/test/connection_coinbase_test.cpp
+++ b/src/impl/dgb/test/connection_coinbase_test.cpp
@@ -17,8 +17,10 @@
 
 #include <gtest/gtest.h>
 #include <impl/dgb/coin/connection_coinbase.hpp>
+#include <impl/dgb/coin/last_txout_nonce.hpp>
 
 #include <map>
+#include <set>
 #include <optional>
 #include <string>
 #include <utility>
@@ -202,6 +204,43 @@ TEST(ConnCoinbasePplns, ValueAnchorAscendingPayoutOrder) {
     EXPECT_EQ(split.payout_outputs, expect);
     EXPECT_EQ(split.donation_amount, 1u);
     // The wired coinbase is assembled from exactly this split (covered by (5)-(7)).
+}
+
+
+// ============================================================================
+// last_txout_nonce SSOT (coin/last_txout_nonce.hpp) -- oracle-faithful uniform
+// 64-bit draw. Replaced three drifted std::time()-XOR formulas in
+// share_check.hpp. The value is consensus-irrelevant (carried verbatim into the
+// minted share, re-read on verify), so these KATs pin the DRAW PROPERTY, not a
+// fixed vector: full-width entropy + uniqueness -- exactly what the old
+// clock-seeded, low-entropy formulas did not provide.
+// ============================================================================
+
+// (A) Full-width entropy: over many draws every bit position is observed both
+//     set and clear. The old time-XOR formulas left whole sub-words constrained
+//     (low half = std::time, high half = header nonce); a uniform draw saturates
+//     all 64 bits. Failure probability for a real uniform source is ~2^-N.
+TEST(LastTxoutNonceSsot, FullWidthEntropy) {
+    constexpr int N = 4096;
+    uint64_t or_acc = 0;
+    uint64_t and_acc = ~0ull;
+    for (int i = 0; i < N; ++i) {
+        const uint64_t v = dgb::make_last_txout_nonce();
+        or_acc  |= v;
+        and_acc &= v;
+    }
+    EXPECT_EQ(or_acc, ~0ull);   // every bit set at least once
+    EXPECT_EQ(and_acc, 0ull);   // every bit clear at least once
+}
+
+// (B) Uniqueness intent: the draw exists to make the OP_RETURN unique per share.
+//     Over N draws in a 2^64 space collisions are astronomically unlikely, so
+//     the full set must be distinct (birthday collision prob here ~2^-40).
+TEST(LastTxoutNonceSsot, DrawsAreDistinct) {
+    constexpr int N = 4096;
+    std::set<uint64_t> seen;
+    for (int i = 0; i < N; ++i) seen.insert(dgb::make_last_txout_nonce());
+    EXPECT_EQ(seen.size(), static_cast<size_t>(N));
 }
 
 } // namespace


### PR DESCRIPTION
Coin-local, consensus-neutral hygiene. Off master, independent of held #336/#337 heads.

Collapses three drifted std::time()-XOR formulas for the OP_RETURN extranonce (last_txout_nonce) in share_check.hpp into one SSOT make_last_txout_nonce() — an oracle-faithful uniform 64-bit draw (random.randrange(2**64)), per the deferred-cleanup decision in the nonce-provenance thread. The value is consensus-irrelevant (carried verbatim into the minted share, re-read on verify), so any unique draw is valid; the clock read was the source of the 1-second straddle flakiness noted on the pre-stage anchor. Removes the unintended std::time() read.

Tests: connection_coinbase_test +2 (full-width entropy, draw uniqueness) -> 6/6; dgb_share_test 28/28 green (confirms share_check.hpp compiles+passes). No CMake/allowlist change (header consumed by already-wired targets).

HOLD merge — integrator taps with operator approval.