### PR TITLE
dgb: KAT compute_share_target genesis clamp [MAX_TARGET/30, MAX_TARGET]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
                     dgb_gentx_coinbase_test dgb_connection_coinbase_test dgb_pplns_payout_split_test nmc_auxpow_merkle_test nmc_template_builder_test nmc_auxpow_wire_test nmc_reconstruct_won_block_test dgb_gentx_share_path_test dgb_other_tx_resolver_test \
                     dgb_other_tx_assembler_test dgb_reconstruct_won_block_test dgb_reconstruct_closure_test dgb_gentx_unpack_test dgb_work_source_test dgb_template_builder_test dgb_embedded_coin_node_test dgb_embedded_tx_select_test dgb_template_other_txs_test dgb_coinbase_value_parity_test dgb_submit_classify_test dgb_aux_parent_coinbase_parity_test dgb_template_capture_test dgb_aux_doge_db_commitment_bind_test \
                     rpc_request_test softfork_check_test genesis_check_test algo_select_test digishield_walk_test header_chain_test \
-                    dgb_coin_node_seam_test dgb_block_broadcast_test dgb_won_block_dispatch_test dgb_forced_won_share_dualpath_test dgb_scrypt_pow_test dgb_nonce_grinder_test dgb_regrind_block_test dgb_won_block_finalize_test v37_test \
+                    dgb_coin_node_seam_test dgb_block_broadcast_test dgb_won_block_dispatch_test dgb_forced_won_share_dualpath_test dgb_scrypt_pow_test dgb_nonce_grinder_test dgb_regrind_block_test dgb_won_block_finalize_test dgb_share_target_genesis_test v37_test \
             -j$(nproc)
 
       - name: Run tests
@@ -216,7 +216,7 @@ jobs:
                     dgb_gentx_coinbase_test dgb_connection_coinbase_test dgb_pplns_payout_split_test nmc_auxpow_merkle_test nmc_template_builder_test nmc_auxpow_wire_test nmc_reconstruct_won_block_test dgb_gentx_share_path_test dgb_other_tx_resolver_test \
                     dgb_other_tx_assembler_test dgb_reconstruct_won_block_test dgb_reconstruct_closure_test dgb_gentx_unpack_test dgb_work_source_test dgb_template_builder_test dgb_embedded_coin_node_test dgb_embedded_tx_select_test dgb_template_other_txs_test dgb_coinbase_value_parity_test dgb_submit_classify_test dgb_aux_parent_coinbase_parity_test dgb_template_capture_test dgb_aux_doge_db_commitment_bind_test \
                     rpc_request_test softfork_check_test genesis_check_test algo_select_test digishield_walk_test header_chain_test \
-                    dgb_coin_node_seam_test dgb_block_broadcast_test dgb_won_block_dispatch_test dgb_forced_won_share_dualpath_test dgb_scrypt_pow_test dgb_nonce_grinder_test dgb_regrind_block_test dgb_won_block_finalize_test test_coin_broadcaster test_multiaddress_pplns test_pplns_stress \
+                    dgb_coin_node_seam_test dgb_block_broadcast_test dgb_won_block_dispatch_test dgb_forced_won_share_dualpath_test dgb_scrypt_pow_test dgb_nonce_grinder_test dgb_regrind_block_test dgb_won_block_finalize_test dgb_share_target_genesis_test test_coin_broadcaster test_multiaddress_pplns test_pplns_stress \
                     v37_test \
             -j$(nproc)
 

--- a/src/impl/dgb/test/CMakeLists.txt
+++ b/src/impl/dgb/test/CMakeLists.txt
@@ -536,4 +536,18 @@ if (BUILD_TESTING AND GTest_FOUND)
         c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage
         dgb_coin pool sharechain)
     gtest_add_tests(dgb_aux_doge_db_commitment_bind_test "" AUTO)
+
+    # dgb_share_target_genesis_test: FENCED KAT pinning ShareTracker::compute_
+    # share_target genesis/unknown-prev clamp to [MAX_TARGET/30, MAX_TARGET] vs
+    # the DGB oracle data.py generate_transaction. Links the same proven set as
+    # dgb_share_test (ShareTracker pulls in the pool/share TU). MUST also be in
+    # the build.yml --target allowlist (#143).
+    add_executable(dgb_share_target_genesis_test share_target_genesis_test.cpp)
+    target_link_libraries(dgb_share_target_genesis_test PRIVATE
+        GTest::gtest_main GTest::gtest
+        core dgb
+        c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage
+        dgb_coin pool sharechain)
+    gtest_add_tests(dgb_share_target_genesis_test "" AUTO)
+
 endif()

--- a/src/impl/dgb/test/share_target_genesis_test.cpp
+++ b/src/impl/dgb/test/share_target_genesis_test.cpp
@@ -1,0 +1,77 @@
+// dgb::ShareTracker::compute_share_target — genesis/unknown-prev branch KAT.
+//
+// FENCED conformance test (no production code touched). Pins the share-target
+// clamp that p2pool-v36 BaseShare.generate_transaction applies when the
+// previous share is unknown (genesis / chain not yet seeded): the new share
+// target is clipped to [MAX_TARGET/30, MAX_TARGET] and max_bits is taken from
+// MAX_TARGET. Oracle SSOT: frstrtr/p2pool-dgb-scrypt bitcoin/data.py
+// generate_transaction (pre_target clip path) with MAX_TARGET from
+// networks/digibyte.py = 2**256//2**20 - 1 (2^236 - 1).
+//
+// compute_share_target had NO direct coverage before this slice; the genesis
+// branch is the one path fully deterministic without a seeded chain, so it is
+// the right anchor for a self-contained KAT.
+//
+// MUST appear in BOTH the ctest registration (this dir CMakeLists.txt) AND the
+// build.yml --target allowlist, or it becomes a #143-style NOT_BUILT sentinel
+// that reds master.
+
+#include <impl/dgb/share_tracker.hpp>
+#include <impl/dgb/config_pool.hpp>
+#include <core/target_utils.hpp>
+#include <core/uint256.hpp>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+// A desired_target far above MAX_TARGET (forces the hi clamp).
+uint256 all_ones() {
+    uint256 t;
+    t.SetHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    return t;
+}
+
+// The genesis branch ignores desired_timestamp; any value is fine.
+constexpr uint32_t kTs = 1700000000u;
+
+TEST(DgbShareTargetGenesis, MaxBitsFromMaxTarget) {
+    dgb::ShareTracker tracker;
+    const uint256 MAX_TARGET = dgb::PoolConfig::max_target();
+    auto st = tracker.compute_share_target(uint256(), kTs, MAX_TARGET);
+    EXPECT_EQ(st.max_bits, chain::target_to_bits_upper_bound(MAX_TARGET));
+}
+
+TEST(DgbShareTargetGenesis, DesiredAboveMaxClampsToMax) {
+    dgb::ShareTracker tracker;
+    const uint256 MAX_TARGET = dgb::PoolConfig::max_target();
+    auto st = tracker.compute_share_target(uint256(), kTs, all_ones());
+    // bits_target clipped to MAX_TARGET -> bits == max_bits.
+    EXPECT_EQ(st.bits, chain::target_to_bits_upper_bound(MAX_TARGET));
+    EXPECT_EQ(st.bits, st.max_bits);
+    // resulting target never easier than MAX_TARGET.
+    EXPECT_TRUE(!(chain::bits_to_target(st.bits) > MAX_TARGET));
+}
+
+TEST(DgbShareTargetGenesis, DesiredBelowFloorClampsToMaxOver30) {
+    dgb::ShareTracker tracker;
+    const uint256 MAX_TARGET = dgb::PoolConfig::max_target();
+    const uint256 floor = MAX_TARGET / 30;
+    // desired_target = 0 -> clipped up to MAX_TARGET/30 (data.py min clip).
+    auto st = tracker.compute_share_target(uint256(), kTs, uint256());
+    EXPECT_EQ(st.bits, chain::target_to_bits_upper_bound(floor));
+}
+
+TEST(DgbShareTargetGenesis, DesiredInRangePreserved) {
+    dgb::ShareTracker tracker;
+    const uint256 MAX_TARGET = dgb::PoolConfig::max_target();
+    const uint256 mid = MAX_TARGET / 2;  // within (MAX_TARGET/30, MAX_TARGET)
+    auto st = tracker.compute_share_target(uint256(), kTs, mid);
+    EXPECT_EQ(st.bits, chain::target_to_bits_upper_bound(mid));
+    // invariant: MAX_TARGET/30 <= resulting target <= MAX_TARGET.
+    const uint256 tgt = chain::bits_to_target(st.bits);
+    EXPECT_TRUE(!(tgt > MAX_TARGET));
+    EXPECT_TRUE(!(tgt < (MAX_TARGET / 30)));
+}
+
+}  // namespace


### PR DESCRIPTION
Fenced test-only slice (DGB lane idle-fill, integrator-approved).

Pins the previously-uncovered genesis / unknown-previous-share branch of compute_share_target against the DGB oracle frstrtr/p2pool-dgb-scrypt:
- max_bits derived from MAX_TARGET (2^236-1)
- genesis clamp band [MAX_TARGET/30, MAX_TARGET]

Scope:
- Additive KAT only; no consensus-value change.
- Fenced to src/impl/dgb/ test tree; no shared or other-coin tree touched.
- Registered in src/impl/dgb/test/CMakeLists.txt and both CI allowlist lines (no NOT_BUILT sentinel trip).
- GPG-signed; attribution-clean.

Local: 4/4 PASS. Surfacing for full gh rollup verification.