### PR TITLE
dgb: fix master-RED conn-pplns delegation tests (dead-base race #337 vs #338)

### DIFF
--- a/src/impl/dgb/test/conn_pplns_producer_test.cpp
+++ b/src/impl/dgb/test/conn_pplns_producer_test.cpp
@@ -102,9 +102,15 @@ TEST(ConnPplnsProducer, RefHashDelegatesToVerifierPrimitiveNoSegwit) {
 
     auto out = dgb::make_conn_pplns_inputs(make_assembly_inputs(rp), params);
 
-    const auto [ref_hash, nonce] = dgb::compute_ref_hash_for_work(rp, params);
+    // Delegation invariant: the producers ref_hash IS the verifier primitives
+    // output verbatim. The ref preimage is a pure function of the ref params and
+    // does NOT commit to last_txout_nonce, so this equality is deterministic.
+    // last_txout_nonce is an independent uniform 64-bit draw per call (the #338
+    // SSOT, mirroring oracle random.randrange(2**64)); two draws never match, so
+    // it is NOT asserted here -- its real contract (carried verbatim into the
+    // coinbase OP_RETURN) is pinned by RoundTripEmbedsRefInOpReturn below.
+    const auto ref_hash = dgb::compute_ref_hash_for_work(rp, params).first;
     EXPECT_EQ(out.ref_hash, ref_hash);
-    EXPECT_EQ(out.last_txout_nonce, nonce);
     EXPECT_FALSE(out.ref_hash.IsNull());
 }
 
@@ -117,9 +123,10 @@ TEST(ConnPplnsProducer, RefHashDelegatesToVerifierPrimitiveWithSegwit) {
 
     auto out = dgb::make_conn_pplns_inputs(make_assembly_inputs(rp), params);
 
-    const auto [ref_hash, nonce] = dgb::compute_ref_hash_for_work(rp, params);
+    // Same delegation invariant as the no-segwit case: ref_hash is deterministic;
+    // last_txout_nonce is an independent per-call draw (see note above).
+    const auto ref_hash = dgb::compute_ref_hash_for_work(rp, params).first;
     EXPECT_EQ(out.ref_hash, ref_hash);
-    EXPECT_EQ(out.last_txout_nonce, nonce);
 }
 
 // (2) Caller-resolved PPLNS weights + design points forward verbatim.


### PR DESCRIPTION
## master is RED on dffbcd06

Post-merge CI on the #336/#337/#338 fold fails the plain Linux x86_64 ctest stage (exit 8, 2 of 1105):

- 137 ConnPplnsProducer.RefHashDelegatesToVerifierPrimitiveNoSegwit
- 138 ConnPplnsProducer.RefHashDelegatesToVerifierPrimitiveWithSegwit

## Root cause — dead-base race, both PRs correct in isolation

- #337 added these tests. Each calls compute_ref_hash_for_work a SECOND time and asserts the producer last_txout_nonce equals that second calls nonce.
- #338 (nonce SSOT) correctly replaced the old std::time()-XOR nonce with a uniform 64-bit random draw per call (oracle random.randrange(2**64)). Under the old time-seeded value two draws in the same wall-clock second usually matched, so the assertion passed on #337s base. Under the correct uniform draw two independent draws never match -> deterministic failure once both fold onto master (confirmed 5/5 locally).

The ref_hash preimage does NOT commit to the nonce (pure function of the ref params), so the ref_hash delegation equality is deterministic and is KEPT. Only the invalid two-independent-draws nonce equality is dropped. The nonces real contract — carried verbatim into the coinbase OP_RETURN — is already pinned by RoundTripEmbedsRefInOpReturn in the same file.

## Change
Test-only. No consensus or production code touched. Fenced.

## Evidence
dgb_conn_pplns_producer_test: 4/4 PASSED, deterministic across 6 consecutive runs (was 0/2 on the two delegation tests, 5/5 fail, pre-fix). GPG-signed.