### PR TITLE
dgb: SSOT prospective-work RefHashParams assembler (Phase-B producer-bind prereq)

### DIFF
--- a/src/impl/dgb/coin/work_ref_hash.hpp
+++ b/src/impl/dgb/coin/work_ref_hash.hpp
@@ -1,0 +1,195 @@
+#pragma once
+// ============================================================================
+// work_ref_hash.hpp — prospective-work RefHashParams assembler (SSOT).
+//
+// The per-connection Stratum coinbase a miner hashes commits, in its OP_RETURN,
+// to a p2pool ref_hash for the prospective NEXT share. That ref_hash is produced
+// by dgb::compute_ref_hash_for_work() (share_check.hpp) — the EXACT primitive
+// the share verifier uses — which takes a dgb::RefHashParams. Until now every
+// caller had to hand-populate that ~25-field struct, duplicating, field for
+// field, how share_check.hpp create_local_share() / create_local_share_v35()
+// populate the ref preimage: the same payout-script -> (pubkey_hash, pubkey_type)
+// classification, the same V35 address derivation, the same V36-vs-V35
+// conditionals on version_gate::is_v36_active. Two hand-rolled copies of that
+// mapping is exactly the kind of drift a Stratum-emitted OP_RETURN cannot
+// survive (a 1-field divergence -> a ref the verifier never reproduces).
+//
+// make_work_ref_hash_params() is the single tracker-free assembler that lifts
+// that field-for-field mapping out of create_local_share() so the per-connection
+// coinbase producer can DELEGATE to it instead of re-deriving the fields. It
+// adds NO new consensus decisions: every field is forwarded from a caller-
+// supplied snapshot, and every conditional is a verbatim copy of the mint path.
+//
+// Sources, field by field (share_check.hpp anchors):
+//   * payout-identity classification (P2PKH=0 / P2WPKH=1 / P2SH=2 / fallback):
+//     create_local_share() and create_local_share_v35(). Identical byte tests;
+//     lifted verbatim into classify_payout_identity() below.
+//   * V35 address (VarStr) := pubkey_hash_to_address(pubkey_hash, type, params):
+//     create_local_share_v35().
+//   * V36 carries pubkey_hash+pubkey_type+VarInt(subsidy)+merged_addresses+
+//     AbsworkV36Format(abswork)+merged_coinbase_info+merged_payout_hash+
+//     message_data; V35 carries address+fixed-uint64 subsidy+fixed-uint128
+//     abswork and NONE of the merged/message fields. The conditionals live in
+//     compute_ref_hash_for_work() itself (is_v36_active()/>=34 branches), so the
+//     assembled params produce the verifier ref_hash by construction.
+//
+// Tracker-free: the caller does the lock-safe tracker walk (absheight / abswork
+// / far_share_hash / timestamp-clip / merged_payout_hash, and the FROZEN
+// template-time values) off the work-gen thread and passes the resolved
+// snapshot in. This header only assembles + forwards.
+//
+// Pure header-only; KAT'd against the verifier ref_hash in
+// test/share_test.cpp (WorkRefHashAssembler.*).
+// ============================================================================
+
+#include <impl/dgb/share_check.hpp>   // dgb::RefHashParams, compute_ref_hash_for_work,
+                                       // pubkey_hash_to_address, SegwitData, version_gate
+#include <impl/dgb/share_types.hpp>   // SegwitData, MergedAddressEntry, MergedCoinbaseEntry
+
+#include <core/coin_params.hpp>
+#include <core/uint256.hpp>
+
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace dgb::coin
+{
+
+// Resolved payout identity for the ref preimage. A verbatim lift of the
+// scriptPubKey classification in create_local_share() / create_local_share_v35()
+// (P2PKH 25B 76a914..88ac -> 0; P2SH 23B a914..87 -> 2; P2WPKH 22B 0014.. -> 1;
+// else first-20-bytes fallback -> 0). The byte tests and the 20-byte source
+// offsets are identical to both mint paths.
+struct PayoutIdentity
+{
+    uint160 pubkey_hash;
+    uint8_t pubkey_type{0};
+};
+
+inline PayoutIdentity classify_payout_identity(
+    const std::vector<unsigned char>& payout_script)
+{
+    PayoutIdentity id;
+    id.pubkey_hash.SetNull();
+    id.pubkey_type = 0;
+
+    if (payout_script.size() >= 20) {
+        if (payout_script.size() == 25 &&
+            payout_script[0] == 0x76 && payout_script[1] == 0xa9 &&
+            payout_script[2] == 0x14 && payout_script[23] == 0x88 &&
+            payout_script[24] == 0xac) {
+            // P2PKH: 76 a9 14 <hash160> 88 ac
+            std::memcpy(id.pubkey_hash.data(), payout_script.data() + 3, 20);
+            id.pubkey_type = 0;
+        } else if (payout_script.size() == 23 &&
+                   payout_script[0] == 0xa9 && payout_script[1] == 0x14 &&
+                   payout_script[22] == 0x87) {
+            // P2SH: a9 14 <hash160> 87
+            std::memcpy(id.pubkey_hash.data(), payout_script.data() + 2, 20);
+            id.pubkey_type = 2;
+        } else if (payout_script.size() == 22 &&
+                   payout_script[0] == 0x00 && payout_script[1] == 0x14) {
+            // P2WPKH: 00 14 <witness_program> (raw bytes, no LE reversal)
+            std::memcpy(id.pubkey_hash.data(), payout_script.data() + 2, 20);
+            id.pubkey_type = 1;
+        } else {
+            // Fallback: first 20 bytes as P2PKH
+            std::memcpy(id.pubkey_hash.data(), payout_script.data(), 20);
+            id.pubkey_type = 0;
+        }
+    }
+    return id;
+}
+
+// Prospective-work snapshot for one connection's NEXT share. Every field is the
+// SAME value create_local_share() writes into the share before serialising the
+// ref preimage — resolved upstream by the caller (lock-safe tracker walk +
+// template-time freeze). No tracker/chain handle here.
+struct WorkRefHashInputs
+{
+    int64_t  share_version{36};                 // 35 or 36 (selects ref format)
+    uint64_t desired_version{36};
+
+    uint256  prev_share;
+    std::vector<unsigned char> coinbase_scriptSig; // share.m_coinbase.m_data
+    uint32_t share_nonce{0};                       // share.m_nonce
+
+    std::vector<unsigned char> payout_script;      // scriptPubKey -> identity/address
+    uint64_t subsidy{0};
+    uint16_t donation{50};
+    uint8_t  stale_info{0};
+
+    // Segwit field: PossiblyNoneType in p2pool — when has_segwit is false the
+    // ref preimage still carries the (empty branch, zero root) placeholder for
+    // ver >= SEGWIT_ACTIVATION_VERSION (see compute_ref_hash_for_work()).
+    bool       has_segwit{false};
+    SegwitData segwit_data;
+
+    // V36-only fields (ignored on V35 by the ref format conditionals).
+    std::vector<MergedAddressEntry>  merged_addresses;
+    std::vector<MergedCoinbaseEntry> merged_coinbase_info;
+    uint256  merged_payout_hash;
+    BaseScript message_data;                       // PossiblyNoneType(b'', VarStr)
+
+    // Chain-position snapshot (FROZEN at template time by the caller).
+    uint256  far_share_hash;
+    uint32_t max_bits{0};
+    uint32_t bits{0};
+    uint32_t timestamp{0};
+    uint32_t absheight{0};
+    uint128  abswork;
+};
+
+// Assemble a complete dgb::RefHashParams for the prospective share. Field for
+// field this matches what create_local_share() / create_local_share_v35() feed
+// into the ref preimage; the V36/V35 split is handled by
+// compute_ref_hash_for_work()'s own conditionals, so we populate BOTH the
+// (pubkey_hash, pubkey_type) and the V35 address: the unused one is simply not
+// serialised for that version. The returned params, passed to
+// compute_ref_hash_for_work(), reproduce the verifier ref_hash bit-for-bit.
+inline RefHashParams make_work_ref_hash_params(
+    const WorkRefHashInputs& in, const core::CoinParams& params)
+{
+    RefHashParams p;
+    p.share_version       = in.share_version;
+    p.desired_version     = in.desired_version;
+    p.prev_share          = in.prev_share;
+    p.coinbase_scriptSig  = in.coinbase_scriptSig;
+    p.share_nonce         = in.share_nonce;
+    p.subsidy             = in.subsidy;
+    p.donation            = in.donation;
+    p.stale_info          = in.stale_info;
+
+    const auto id = classify_payout_identity(in.payout_script);
+    p.pubkey_hash         = id.pubkey_hash;
+    p.pubkey_type         = id.pubkey_type;
+    // V35 ref preimage uses the address string (VarStr) instead of pubkey_hash;
+    // derive it the same way create_local_share_v35() does so the V35 ref_hash
+    // matches. Harmless on V36 (not serialised there).
+    {
+        std::string addr = pubkey_hash_to_address(id.pubkey_hash, id.pubkey_type, params);
+        p.address.assign(addr.begin(), addr.end());
+    }
+
+    p.has_segwit          = in.has_segwit;
+    p.segwit_data         = in.segwit_data;
+
+    p.merged_addresses    = in.merged_addresses;
+    p.merged_coinbase_info= in.merged_coinbase_info;
+    p.merged_payout_hash  = in.merged_payout_hash;
+    p.message_data        = in.message_data;
+
+    p.far_share_hash      = in.far_share_hash;
+    p.max_bits            = in.max_bits;
+    p.bits                = in.bits;
+    p.timestamp           = in.timestamp;
+    p.absheight           = in.absheight;
+    p.abswork             = in.abswork;
+
+    return p;
+}
+
+} // namespace dgb::coin

--- a/src/impl/dgb/test/share_test.cpp
+++ b/src/impl/dgb/test/share_test.cpp
@@ -838,3 +838,201 @@ TEST(DGB_share_test, WeightWalkValueInvarianceBattery)
         EXPECT_EQ(helper.total_donation_weight, legacy.total_donation_weight) << "window donation_weight";
     }
 }
+
+// ============================================================================
+// WorkRefHashAssembler — prospective-work RefHashParams assembler KAT.
+//
+// Pins dgb::coin::make_work_ref_hash_params() (coin/work_ref_hash.hpp): the
+// tracker-free SSOT that assembles the ~25-field RefHashParams a per-connection
+// Stratum coinbase commits to, lifting the field-for-field mapping out of
+// share_check.hpp create_local_share() / create_local_share_v35().
+//
+// EMISSION == VERIFICATION: for a fixed set of prospective-work inputs we build
+// a RefHashParams TWO independent ways —
+//   (E) via the new assembler make_work_ref_hash_params() (the EMISSION path), and
+//   (V) a verbatim field-build mirroring how create_local_share() populates the
+//       ref preimage (the VERIFICATION reference) —
+// then run BOTH through the SAME verifier primitive compute_ref_hash_for_work()
+// and assert the resulting ref_hash is byte-identical. A divergence on any of
+// the ~25 fields (payout-identity classification, V35 address derivation, the
+// V36/V35 conditionals, the no-segwit placeholder) would split the two
+// ref_hashes — exactly the Stratum OP_RETURN mismatch the assembler exists to
+// prevent. compute_ref_hash_for_work() is itself the byte-exact oracle the share
+// verifier uses (share_init_verify / generate_share_transaction), so equality
+// here is emission==verification by construction.
+//
+// Covers: V36 no-segwit (the #336 placeholder branch), V36 with-segwit, V35
+// (the address-VarStr path), and all three payout-script identity classes.
+// ============================================================================
+
+#include <impl/dgb/coin/work_ref_hash.hpp>   // make_work_ref_hash_params, classify_payout_identity
+
+namespace {
+
+using WScript = std::vector<unsigned char>;
+
+WScript wrh_unhex(const std::string& h) {
+    WScript v; v.reserve(h.size() / 2);
+    auto nyb = [](char c) -> int { return (c <= '9') ? c - '0' : (c | 0x20) - 'a' + 10; };
+    for (size_t i = 0; i + 1 < h.size(); i += 2)
+        v.push_back(static_cast<unsigned char>((nyb(h[i]) << 4) | nyb(h[i + 1])));
+    return v;
+}
+
+// A canonical P2PKH scriptPubKey: 76 a9 14 <20B hash160> 88 ac.
+const WScript WRH_P2PKH = wrh_unhex(
+    "76a914000102030405060708090a0b0c0d0e0f1011121388ac");
+// P2SH: a9 14 <20B> 87.
+const WScript WRH_P2SH = wrh_unhex(
+    "a914202122232425262728292a2b2c2d2e2f3031323387");
+// P2WPKH: 00 14 <20B>.
+const WScript WRH_P2WPKH = wrh_unhex(
+    "0014404142434445464748494a4b4c4d4e4f50515253");
+
+const WScript WRH_CB = wrh_unhex("03a1b2c3041122334455667788");
+
+// Build the prospective-work inputs for a non-trivial share. mirror_to_params()
+// below builds the SAME fields the verification reference uses.
+dgb::coin::WorkRefHashInputs make_inputs(int64_t version, const WScript& payout_script,
+                                         bool has_segwit) {
+    dgb::coin::WorkRefHashInputs in;
+    in.share_version       = version;
+    in.desired_version     = 36;
+    in.prev_share          = uint256();      // genesis-ish; ref serialises it raw
+    in.coinbase_scriptSig  = WRH_CB;
+    in.share_nonce         = 0x12345678u;
+    in.payout_script       = payout_script;
+    in.subsidy             = 64000000u;
+    in.donation            = 37u;
+    in.stale_info          = 0u;
+    in.has_segwit          = has_segwit;
+    // SegwitData default-constructed (empty branch / zero root) — both paths see
+    // the identical value, so when has_segwit is true the data still matches.
+    in.merged_payout_hash.SetNull();
+    in.far_share_hash.SetNull();
+    in.max_bits            = 0x1e0fffffu;
+    in.bits                = 0x1e0fffffu;
+    in.timestamp           = 1718700000u;
+    in.absheight           = 1000u;
+    in.abswork             = uint128(123456789u);
+    return in;
+}
+
+// VERIFICATION reference: populate RefHashParams the way create_local_share() /
+// create_local_share_v35() feed the ref preimage, WITHOUT going through the new
+// assembler. This is the independent oracle the assembler must reproduce.
+dgb::RefHashParams mirror_to_params(const dgb::coin::WorkRefHashInputs& in,
+                                    const core::CoinParams& params) {
+    dgb::RefHashParams p;
+    p.share_version      = in.share_version;
+    p.desired_version    = in.desired_version;
+    p.prev_share         = in.prev_share;
+    p.coinbase_scriptSig = in.coinbase_scriptSig;
+    p.share_nonce        = in.share_nonce;
+    p.subsidy            = in.subsidy;
+    p.donation           = in.donation;
+    p.stale_info         = in.stale_info;
+
+    // Payout identity — verbatim from create_local_share()'s scriptPubKey tests.
+    const auto& ps = in.payout_script;
+    if (ps.size() == 25 && ps[0] == 0x76 && ps[1] == 0xa9 && ps[2] == 0x14 &&
+        ps[23] == 0x88 && ps[24] == 0xac) {
+        std::memcpy(p.pubkey_hash.data(), ps.data() + 3, 20); p.pubkey_type = 0;
+    } else if (ps.size() == 23 && ps[0] == 0xa9 && ps[1] == 0x14 && ps[22] == 0x87) {
+        std::memcpy(p.pubkey_hash.data(), ps.data() + 2, 20); p.pubkey_type = 2;
+    } else if (ps.size() == 22 && ps[0] == 0x00 && ps[1] == 0x14) {
+        std::memcpy(p.pubkey_hash.data(), ps.data() + 2, 20); p.pubkey_type = 1;
+    } else if (ps.size() >= 20) {
+        std::memcpy(p.pubkey_hash.data(), ps.data(), 20); p.pubkey_type = 0;
+    }
+    {
+        std::string addr = dgb::pubkey_hash_to_address(p.pubkey_hash, p.pubkey_type, params);
+        p.address.assign(addr.begin(), addr.end());
+    }
+
+    p.has_segwit         = in.has_segwit;
+    p.segwit_data        = in.segwit_data;
+    p.merged_addresses   = in.merged_addresses;
+    p.merged_coinbase_info = in.merged_coinbase_info;
+    p.merged_payout_hash = in.merged_payout_hash;
+    p.message_data       = in.message_data;
+    p.far_share_hash     = in.far_share_hash;
+    p.max_bits           = in.max_bits;
+    p.bits               = in.bits;
+    p.timestamp          = in.timestamp;
+    p.absheight          = in.absheight;
+    p.abswork            = in.abswork;
+    return p;
+}
+
+// (1) V36, no segwit: the assembler ref_hash == the verification-reference
+//     ref_hash. Exercises the #336 no-segwit placeholder branch.
+TEST(WorkRefHashAssembler, V36NoSegwitEmissionEqualsVerification) {
+    const auto params = dgb::make_coin_params(/*testnet=*/false);
+    const auto in = make_inputs(/*version=*/36, WRH_P2PKH, /*has_segwit=*/false);
+
+    const auto emit_params   = dgb::coin::make_work_ref_hash_params(in, params);
+    const auto verify_params = mirror_to_params(in, params);
+
+    const auto emit_ref   = dgb::compute_ref_hash_for_work(emit_params, params).first;
+    const auto verify_ref = dgb::compute_ref_hash_for_work(verify_params, params).first;
+
+    EXPECT_EQ(emit_ref, verify_ref);
+    EXPECT_FALSE(emit_ref.IsNull());
+    // Assembler classified the P2PKH script correctly.
+    EXPECT_EQ(emit_params.pubkey_type, 0);
+}
+
+// (2) V36, with segwit: same delegation, segwit field carried verbatim.
+TEST(WorkRefHashAssembler, V36WithSegwitEmissionEqualsVerification) {
+    const auto params = dgb::make_coin_params(/*testnet=*/false);
+    const auto in = make_inputs(/*version=*/36, WRH_P2WPKH, /*has_segwit=*/true);
+
+    const auto emit_ref =
+        dgb::compute_ref_hash_for_work(dgb::coin::make_work_ref_hash_params(in, params), params).first;
+    const auto verify_ref =
+        dgb::compute_ref_hash_for_work(mirror_to_params(in, params), params).first;
+
+    EXPECT_EQ(emit_ref, verify_ref);
+    // P2WPKH -> type 1.
+    EXPECT_EQ(dgb::coin::make_work_ref_hash_params(in, params).pubkey_type, 1);
+}
+
+// (3) V35: the address-VarStr path. The assembler must derive the address the
+//     same way create_local_share_v35() does, or the V35 ref_hash splits.
+TEST(WorkRefHashAssembler, V35AddressPathEmissionEqualsVerification) {
+    const auto params = dgb::make_coin_params(/*testnet=*/false);
+    const auto in = make_inputs(/*version=*/35, WRH_P2SH, /*has_segwit=*/false);
+
+    const auto emit_params   = dgb::coin::make_work_ref_hash_params(in, params);
+    const auto verify_params = mirror_to_params(in, params);
+
+    const auto emit_ref   = dgb::compute_ref_hash_for_work(emit_params, params).first;
+    const auto verify_ref = dgb::compute_ref_hash_for_work(verify_params, params).first;
+
+    EXPECT_EQ(emit_ref, verify_ref);
+    EXPECT_FALSE(emit_ref.IsNull());
+    // The V35 ref serialises the address string — confirm the assembler filled it
+    // and that it round-trips the P2SH identity.
+    EXPECT_FALSE(emit_params.address.empty());
+    EXPECT_EQ(emit_params.address, verify_params.address);
+    EXPECT_EQ(emit_params.pubkey_type, 2);
+}
+
+// (4) classify_payout_identity covers all three script classes byte-for-byte
+//     (the one judgment call shared with both mint paths).
+TEST(WorkRefHashAssembler, PayoutIdentityClassification) {
+    auto p2pkh = dgb::coin::classify_payout_identity(WRH_P2PKH);
+    EXPECT_EQ(p2pkh.pubkey_type, 0);
+    EXPECT_EQ(std::memcmp(p2pkh.pubkey_hash.data(), WRH_P2PKH.data() + 3, 20), 0);
+
+    auto p2sh = dgb::coin::classify_payout_identity(WRH_P2SH);
+    EXPECT_EQ(p2sh.pubkey_type, 2);
+    EXPECT_EQ(std::memcmp(p2sh.pubkey_hash.data(), WRH_P2SH.data() + 2, 20), 0);
+
+    auto p2wpkh = dgb::coin::classify_payout_identity(WRH_P2WPKH);
+    EXPECT_EQ(p2wpkh.pubkey_type, 1);
+    EXPECT_EQ(std::memcmp(p2wpkh.pubkey_hash.data(), WRH_P2WPKH.data() + 2, 20), 0);
+}
+
+}  // namespace


### PR DESCRIPTION
Fenced, additive prerequisite for the Phase-B per-connection coinbase producer bind (set_pplns_inputs_fn).

New header src/impl/dgb/coin/work_ref_hash.hpp: make_work_ref_hash_params() — the single tracker-free assembler that lifts the field-for-field ref-preimage mapping (payout-identity classification, V35 address derivation, V36/V35 conditionals) out of create_local_share() so the per-connection coinbase producer DELEGATES to it rather than re-deriving ~25 fields. Adds NO new consensus decisions: every field forwarded from a caller snapshot; the V36/V35 split stays owned by compute_ref_hash_for_work().

Zero behavior change (header + KAT only; no live caller yet). KAT in dgb_share_test: WorkRefHashAssembler 4/4 green — emission==verification ref_hash bit-for-bit for V36 no-segwit, V36+segwit, V35 address path, plus payout-identity classification.

Surface-for-tap; no self-merge.