### PR TITLE
dgb: pool P2P wire-message conformance KAT (Phase-B pool/share)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
                     dgb_gentx_coinbase_test dgb_connection_coinbase_test dgb_pplns_payout_split_test nmc_auxpow_merkle_test nmc_template_builder_test nmc_auxpow_wire_test nmc_reconstruct_won_block_test dgb_gentx_share_path_test dgb_conn_pplns_producer_test dgb_other_tx_resolver_test \
                     dgb_other_tx_assembler_test dgb_reconstruct_won_block_test dgb_reconstruct_closure_test dgb_gentx_unpack_test dgb_work_source_test dgb_template_builder_test dgb_embedded_coin_node_test dgb_embedded_tx_select_test dgb_template_other_txs_test dgb_coinbase_value_parity_test dgb_submit_classify_test dgb_aux_parent_coinbase_parity_test dgb_template_capture_test dgb_aux_doge_db_commitment_bind_test \
                     rpc_request_test softfork_check_test genesis_check_test algo_select_test digishield_walk_test header_chain_test \
-                    dgb_coin_node_seam_test dgb_block_broadcast_test dgb_won_block_dispatch_test dgb_forced_won_share_dualpath_test dgb_scrypt_pow_test dgb_nonce_grinder_test dgb_regrind_block_test dgb_won_block_finalize_test dgb_share_target_genesis_test v37_test \
+                    dgb_coin_node_seam_test dgb_block_broadcast_test dgb_won_block_dispatch_test dgb_forced_won_share_dualpath_test dgb_scrypt_pow_test dgb_nonce_grinder_test dgb_regrind_block_test dgb_won_block_finalize_test dgb_share_target_genesis_test dgb_pool_msg_wire_test v37_test \
             -j$(nproc)
 
       - name: Run tests
@@ -216,7 +216,7 @@ jobs:
                     dgb_gentx_coinbase_test dgb_connection_coinbase_test dgb_pplns_payout_split_test nmc_auxpow_merkle_test nmc_template_builder_test nmc_auxpow_wire_test nmc_reconstruct_won_block_test dgb_gentx_share_path_test dgb_conn_pplns_producer_test dgb_other_tx_resolver_test \
                     dgb_other_tx_assembler_test dgb_reconstruct_won_block_test dgb_reconstruct_closure_test dgb_gentx_unpack_test dgb_work_source_test dgb_template_builder_test dgb_embedded_coin_node_test dgb_embedded_tx_select_test dgb_template_other_txs_test dgb_coinbase_value_parity_test dgb_submit_classify_test dgb_aux_parent_coinbase_parity_test dgb_template_capture_test dgb_aux_doge_db_commitment_bind_test \
                     rpc_request_test softfork_check_test genesis_check_test algo_select_test digishield_walk_test header_chain_test \
-                    dgb_coin_node_seam_test dgb_block_broadcast_test dgb_won_block_dispatch_test dgb_forced_won_share_dualpath_test dgb_scrypt_pow_test dgb_nonce_grinder_test dgb_regrind_block_test dgb_won_block_finalize_test dgb_share_target_genesis_test test_coin_broadcaster test_multiaddress_pplns test_pplns_stress \
+                    dgb_coin_node_seam_test dgb_block_broadcast_test dgb_won_block_dispatch_test dgb_forced_won_share_dualpath_test dgb_scrypt_pow_test dgb_nonce_grinder_test dgb_regrind_block_test dgb_won_block_finalize_test dgb_share_target_genesis_test dgb_pool_msg_wire_test test_coin_broadcaster test_multiaddress_pplns test_pplns_stress \
                     v37_test \
             -j$(nproc)
 

--- a/src/impl/dgb/test/CMakeLists.txt
+++ b/src/impl/dgb/test/CMakeLists.txt
@@ -563,4 +563,18 @@ if (BUILD_TESTING AND GTest_FOUND)
         dgb_coin pool sharechain)
     gtest_add_tests(dgb_share_target_genesis_test "" AUTO)
 
+    # dgb_pool_msg_wire_test: FENCED conformance KAT for the pool P2P wire-message
+    # layer (messages.hpp) — command-name parity, scalar LE byte pins, and
+    # serialize/read-back field equality vs p2pool-merged-v36 message numbering.
+    # First coverage of this layer in the repo. Same proven link set as
+    # dgb_share_test (messages.hpp pulls coin/block + sharechain share). MUST
+    # also be in the build.yml --target allowlist (#143 NOT_BUILT trap).
+    add_executable(dgb_pool_msg_wire_test dgb_pool_msg_wire_test.cpp)
+    target_link_libraries(dgb_pool_msg_wire_test PRIVATE
+        GTest::gtest_main GTest::gtest
+        core dgb
+        c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage
+        dgb_coin pool sharechain)
+    gtest_add_tests(dgb_pool_msg_wire_test "" AUTO)
+
 endif()

--- a/src/impl/dgb/test/dgb_pool_msg_wire_test.cpp
+++ b/src/impl/dgb/test/dgb_pool_msg_wire_test.cpp
@@ -1,0 +1,206 @@
+// dgb pool wire-message layer — serialization conformance KAT.
+//
+// FENCED conformance test (no production code touched). src/impl/dgb/messages.hpp
+// carries the V36 DGB-Scrypt pool P2P wire-message set and asserts in its header
+// comment "message format byte-parity with p2pool-merged-v36" — yet NO test in
+// the repo (dgb, ltc, btc or core) pinned any of it. A silent drift in a field
+// order, a READWRITE list, a vector framing, or a command name would let two
+// c2pool-dgb peers (or a c2pool-dgb peer and a p2pool-merged-v36 reference node)
+// fail to exchange shares with no compile error. This KAT closes that gap.
+//
+// Three invariants, oracle-aligned with p2pool-merged-v36 / frstrtr/p2pool-dgb-
+// scrypt p2p/p2protocol message numbering:
+//   1. WIRE COMMAND NAMES — the routing key MessageHandler dispatches on. These
+//      strings ARE the protocol; a typo silently un-routes a message type.
+//   2. SCALAR LE BYTE PINS — the deterministic-format messages (ping/getaddrs/
+//      addrme) serialize to exact, hand-derivable little-endian bytes.
+//   3. ROUND-TRIP FIELD EQUALITY — pack(populated) -> read back -> fields equal,
+//      exercising both directions of every READWRITE for the share-exchange and
+//      tx-gossip messages (sharereq/sharereply/shares/have_tx/losing_tx/
+//      forget_tx/remember_tx) plus the version handshake.
+//
+// Per-coin isolation: src/impl/dgb/ only; messages.hpp is a namespace-only
+// divergence from src/impl/ltc/messages.hpp, so this anchors the shared Scrypt-
+// family wire shape for the dgb tree without touching ltc.
+//
+// MUST appear in BOTH the ctest registration (this dir CMakeLists.txt) AND the
+// build.yml --target allowlist, or it becomes a #143-style NOT_BUILT sentinel
+// that reds master.
+
+#include <impl/dgb/messages.hpp>
+
+#include <core/pack.hpp>
+#include <core/uint256.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace {
+
+// Copy a freshly-packed PackStream's bytes out as a flat vector (the on-wire
+// payload), so we can re-open it from cursor 0 for the read-back leg.
+std::vector<unsigned char> wire_bytes(PackStream& s) {
+    auto* p = reinterpret_cast<unsigned char*>(s.data());
+    return std::vector<unsigned char>(p, p + s.size());
+}
+
+std::string tohex(const std::vector<unsigned char>& v) {
+    static const char* H = "0123456789abcdef";
+    std::string out;
+    out.reserve(v.size() * 2);
+    for (unsigned char b : v) { out.push_back(H[b >> 4]); out.push_back(H[b & 0xf]); }
+    return out;
+}
+
+uint256 u256(const char* hex) {
+    uint256 t;
+    t.SetHex(hex);
+    return t;
+}
+
+// --------------------------------------------------------------------------
+// 1. Wire command-name parity — the dispatch keys MessageHandler routes on.
+// --------------------------------------------------------------------------
+TEST(DgbPoolMsgWire, CommandNames) {
+    EXPECT_EQ(dgb::message_version().m_command,     "version");
+    EXPECT_EQ(dgb::message_ping().m_command,        "ping");
+    EXPECT_EQ(dgb::message_addrme().m_command,      "addrme");
+    EXPECT_EQ(dgb::message_getaddrs().m_command,    "getaddrs");
+    EXPECT_EQ(dgb::message_addrs().m_command,       "addrs");
+    EXPECT_EQ(dgb::message_shares().m_command,      "shares");
+    EXPECT_EQ(dgb::message_sharereq().m_command,    "sharereq");
+    EXPECT_EQ(dgb::message_sharereply().m_command,  "sharereply");
+    EXPECT_EQ(dgb::message_bestblock().m_command,   "bestblock");
+    EXPECT_EQ(dgb::message_have_tx().m_command,     "have_tx");
+    EXPECT_EQ(dgb::message_losing_tx().m_command,   "losing_tx");
+    EXPECT_EQ(dgb::message_forget_tx().m_command,   "forget_tx");
+    EXPECT_EQ(dgb::message_remember_tx().m_command, "remember_tx");
+}
+
+// --------------------------------------------------------------------------
+// 2. Deterministic-format messages -> exact little-endian wire bytes.
+// --------------------------------------------------------------------------
+TEST(DgbPoolMsgWire, PingIsEmptyPayload) {
+    auto ps = dgb::message_ping::make();
+    EXPECT_EQ(ps.size(), 0u);
+}
+
+TEST(DgbPoolMsgWire, GetaddrsUint32LittleEndian) {
+    auto ps = dgb::message_getaddrs::make(static_cast<uint32_t>(0x01020304));
+    EXPECT_EQ(tohex(wire_bytes(ps)), "04030201");
+}
+
+TEST(DgbPoolMsgWire, AddrmeUint16LittleEndian) {
+    auto ps = dgb::message_addrme::make(static_cast<uint16_t>(0x1234));
+    EXPECT_EQ(tohex(wire_bytes(ps)), "3412");
+}
+
+// --------------------------------------------------------------------------
+// 3. Round-trip field equality — pack(populated) -> read back -> equal.
+// --------------------------------------------------------------------------
+TEST(DgbPoolMsgWire, SharereqRoundTrip) {
+    const uint256 id = u256("11");
+    std::vector<uint256> hashes{ u256("aa"), u256("bb") };
+    std::vector<uint256> stops{ u256("cc") };
+    const uint64_t parents = 7;
+
+    auto ps = dgb::message_sharereq::make(id, hashes, parents, stops);
+    auto bytes = wire_bytes(ps);
+    PackStream rs(bytes);
+    auto m = dgb::message_sharereq::make(rs);
+
+    EXPECT_EQ(m->m_id, id);
+    EXPECT_EQ(m->m_parents, parents);
+    ASSERT_EQ(m->m_hashes.size(), hashes.size());
+    EXPECT_EQ(m->m_hashes[0], hashes[0]);
+    EXPECT_EQ(m->m_hashes[1], hashes[1]);
+    ASSERT_EQ(m->m_stops.size(), stops.size());
+    EXPECT_EQ(m->m_stops[0], stops[0]);
+}
+
+TEST(DgbPoolMsgWire, SharereplyRoundTripResultEnum) {
+    const uint256 id = u256("22");
+    auto ps = dgb::message_sharereply::make(id, dgb::too_long,
+                                            std::vector<chain::RawShare>{});
+    auto bytes = wire_bytes(ps);
+    PackStream rs(bytes);
+    auto m = dgb::message_sharereply::make(rs);
+
+    EXPECT_EQ(m->m_id, id);
+    EXPECT_EQ(m->m_result, dgb::too_long);
+    EXPECT_TRUE(m->m_shares.empty());
+}
+
+TEST(DgbPoolMsgWire, TxGossipHashVectorsRoundTrip) {
+    std::vector<uint256> hs{ u256("01"), u256("02"), u256("03") };
+
+    auto rt = [&](auto packed) {
+        auto bytes = wire_bytes(packed);
+        PackStream rs(bytes);
+        return rs;
+    };
+
+    {
+        auto ps = dgb::message_have_tx::make(hs);
+        auto rs = rt(std::move(ps));
+        auto m = dgb::message_have_tx::make(rs);
+        ASSERT_EQ(m->m_tx_hashes.size(), hs.size());
+        EXPECT_EQ(m->m_tx_hashes[2], hs[2]);
+    }
+    {
+        auto ps = dgb::message_losing_tx::make(hs);
+        auto rs = rt(std::move(ps));
+        auto m = dgb::message_losing_tx::make(rs);
+        EXPECT_EQ(m->m_tx_hashes.size(), hs.size());
+    }
+    {
+        auto ps = dgb::message_forget_tx::make(hs);
+        auto rs = rt(std::move(ps));
+        auto m = dgb::message_forget_tx::make(rs);
+        EXPECT_EQ(m->m_tx_hashes.size(), hs.size());
+    }
+}
+
+TEST(DgbPoolMsgWire, SharesEmptyVectorRoundTrip) {
+    auto ps = dgb::message_shares::make(std::vector<chain::RawShare>{});
+    auto bytes = wire_bytes(ps);
+    PackStream rs(bytes);
+    auto m = dgb::message_shares::make(rs);
+    EXPECT_TRUE(m->m_shares.empty());
+}
+
+TEST(DgbPoolMsgWire, RememberTxEmptyRoundTrip) {
+    auto ps = dgb::message_remember_tx::make(std::vector<uint256>{},
+                                             std::vector<dgb::coin::MutableTransaction>{});
+    auto bytes = wire_bytes(ps);
+    PackStream rs(bytes);
+    auto m = dgb::message_remember_tx::make(rs);
+    EXPECT_TRUE(m->m_tx_hashes.empty());
+    EXPECT_TRUE(m->m_txs.empty());
+}
+
+TEST(DgbPoolMsgWire, VersionDefaultRoundTrip) {
+    dgb::message_version v;
+    v.m_version = 3501;
+    v.m_services = 0;
+    v.m_nonce = 0xdeadbeefcafef00dULL;
+    v.m_subversion = "c2pool-dgb";
+    v.m_mode = 1;  // always 1 for legacy compatibility
+    v.m_best_share = u256("7f");
+
+    auto ps = pack(v);
+    auto bytes = wire_bytes(ps);
+    PackStream rs(bytes);
+    auto m = dgb::message_version::make(rs);
+
+    EXPECT_EQ(m->m_version, 3501u);
+    EXPECT_EQ(m->m_nonce, 0xdeadbeefcafef00dULL);
+    EXPECT_EQ(m->m_subversion, "c2pool-dgb");
+    EXPECT_EQ(m->m_mode, 1u);
+    EXPECT_EQ(m->m_best_share, u256("7f"));
+}
+
+} // namespace


### PR DESCRIPTION
Phase-B pool/share slice. First repo coverage of the src/impl/dgb/messages.hpp pool wire-message layer (it asserts byte-parity with p2pool-merged-v36 but had zero tests anywhere in the repo).

KAT pins three invariants, oracle-aligned with p2pool-merged-v36 message numbering:
1. Wire command names — the MessageHandler dispatch keys (a typo silently un-routes a message type).
2. Scalar LE byte pins — ping (empty), getaddrs (uint32 LE), addrme (uint16 LE).
3. Serialize/read-back field equality — sharereq, sharereply (incl. result enum), shares, have_tx/losing_tx/forget_tx, remember_tx, and the version handshake.

Fenced test-only; no production code touched. messages.hpp is a namespace-only divergence from src/impl/ltc/messages.hpp, so this anchors the shared Scrypt-family wire shape in the dgb tree. Registered in src/impl/dgb/test/CMakeLists.txt and both build.yml --target allowlist arms. 10/10 green locally.