### PR TITLE
dgb: SSOT for pool GetShares walk + conformance KAT (Phase-B pool/share)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
                     dgb_gentx_coinbase_test dgb_connection_coinbase_test dgb_pplns_payout_split_test nmc_auxpow_merkle_test nmc_template_builder_test nmc_auxpow_wire_test nmc_reconstruct_won_block_test dgb_gentx_share_path_test dgb_conn_pplns_producer_test dgb_other_tx_resolver_test \
                     dgb_other_tx_assembler_test dgb_reconstruct_won_block_test dgb_reconstruct_closure_test dgb_gentx_unpack_test dgb_work_source_test dgb_template_builder_test dgb_embedded_coin_node_test dgb_embedded_tx_select_test dgb_template_other_txs_test dgb_coinbase_value_parity_test dgb_submit_classify_test dgb_aux_parent_coinbase_parity_test dgb_template_capture_test dgb_aux_doge_db_commitment_bind_test \
                     rpc_request_test softfork_check_test genesis_check_test algo_select_test digishield_walk_test header_chain_test \
-                    dgb_coin_node_seam_test dgb_block_broadcast_test dgb_won_block_dispatch_test dgb_forced_won_share_dualpath_test dgb_scrypt_pow_test dgb_nonce_grinder_test dgb_regrind_block_test dgb_won_block_finalize_test dgb_share_target_genesis_test dgb_pool_msg_wire_test v37_test \
+                    dgb_coin_node_seam_test dgb_block_broadcast_test dgb_won_block_dispatch_test dgb_forced_won_share_dualpath_test dgb_scrypt_pow_test dgb_nonce_grinder_test dgb_regrind_block_test dgb_won_block_finalize_test dgb_share_target_genesis_test dgb_pool_msg_wire_test dgb_get_shares_walk_test v37_test \
             -j$(nproc)
 
       - name: Run tests
@@ -216,7 +216,7 @@ jobs:
                     dgb_gentx_coinbase_test dgb_connection_coinbase_test dgb_pplns_payout_split_test nmc_auxpow_merkle_test nmc_template_builder_test nmc_auxpow_wire_test nmc_reconstruct_won_block_test dgb_gentx_share_path_test dgb_conn_pplns_producer_test dgb_other_tx_resolver_test \
                     dgb_other_tx_assembler_test dgb_reconstruct_won_block_test dgb_reconstruct_closure_test dgb_gentx_unpack_test dgb_work_source_test dgb_template_builder_test dgb_embedded_coin_node_test dgb_embedded_tx_select_test dgb_template_other_txs_test dgb_coinbase_value_parity_test dgb_submit_classify_test dgb_aux_parent_coinbase_parity_test dgb_template_capture_test dgb_aux_doge_db_commitment_bind_test \
                     rpc_request_test softfork_check_test genesis_check_test algo_select_test digishield_walk_test header_chain_test \
-                    dgb_coin_node_seam_test dgb_block_broadcast_test dgb_won_block_dispatch_test dgb_forced_won_share_dualpath_test dgb_scrypt_pow_test dgb_nonce_grinder_test dgb_regrind_block_test dgb_won_block_finalize_test dgb_share_target_genesis_test dgb_pool_msg_wire_test test_coin_broadcaster test_multiaddress_pplns test_pplns_stress \
+                    dgb_coin_node_seam_test dgb_block_broadcast_test dgb_won_block_dispatch_test dgb_forced_won_share_dualpath_test dgb_scrypt_pow_test dgb_nonce_grinder_test dgb_regrind_block_test dgb_won_block_finalize_test dgb_share_target_genesis_test dgb_pool_msg_wire_test dgb_get_shares_walk_test test_coin_broadcaster test_multiaddress_pplns test_pplns_stress \
                     v37_test \
             -j$(nproc)
 

--- a/src/impl/dgb/get_shares_walk.hpp
+++ b/src/impl/dgb/get_shares_walk.hpp
@@ -1,0 +1,109 @@
+#pragma once
+
+// SSOT for the pool share-exchange GetShares walk — the SHAREREQ -> SHAREREPLY
+// path consumed by both protocol_actual.cpp and protocol_legacy.cpp via
+// NodeImpl::handle_get_share.  Until now this walk had ZERO coverage in any
+// tree (dgb/ltc/btc/core); a drift in the parents cap, the per-hash walk bound,
+// the stop-hash break, or the missing-hash skip would let two c2pool-dgb peers
+// (or a c2pool-dgb peer and a p2pool-merged-v36 reference node) silently fail
+// to exchange the right share span with no compile error.
+//
+// Oracle: p2pool node.py  Node.handle_get_shares(hashes, parents, stops, peer):
+//     parents = min(parents, 1000//len(hashes))
+//     stops = set(stops)
+//     shares = []
+//     for share_hash in hashes:
+//         for share in self.tracker.get_chain(
+//                 share_hash, min(parents + 1, self.tracker.get_height(share_hash))):
+//             if share.hash in stops:
+//                 break
+//             shares.append(share)
+//     return shares
+//
+// c2pool adds two node-local defensive guards that are CONSISTENT with p2pool's
+// downloader contract (node.py:120 picks a random peer per request and retries,
+// so a partial/empty hit just shifts to another peer):
+//   (a) skip a requested hash not currently in our chain (continue), and
+//   (b) skip any locally-rejected share hash.
+// Neither changes the oracle walk for a well-formed in-chain request against a
+// peer holding no rejections — the common case — so the byte span is identical.
+//
+// Per-coin isolation: dgb/ only.  Header-only, additive; this slice does not yet
+// rewire node.cpp (that is the byte-identity-fenced delegation follow-on) — it
+// pins the walk as a free function so the KAT can exercise it against a fake
+// chain with no NodeImpl/tracker standup.
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+#include <core/uint256.hpp>
+
+namespace dgb {
+
+// parents cap — p2pool node.py handle_get_shares first line: min(parents,
+// 1000//len(hashes)).  Integer division matches Python //.  n_hashes is
+// guaranteed >= 1 by the caller (an empty SHAREREQ produces no work and never
+// reaches the walk); we still guard divide-by-zero by returning parents
+// unchanged for an empty request rather than faulting.
+inline uint64_t get_shares_parents_cap(uint64_t parents, std::size_t n_hashes)
+{
+    if (n_hashes == 0)
+        return parents;
+    return std::min(parents, static_cast<uint64_t>(1000) / static_cast<uint64_t>(n_hashes));
+}
+
+// per-hash walk length — min(parents+1, height).  Never request more shares
+// above the requested hash than the chain actually holds.
+inline uint64_t get_shares_walk_count(uint64_t capped_parents, uint64_t height)
+{
+    return std::min(capped_parents + 1, height);
+}
+
+// The full GetShares walk, generic over the chain accessor and the share type.
+//   Chain must provide:  bool contains(const uint256&),
+//                        int-ish get_height(const uint256&),
+//                        ChainView get_chain(const uint256&, uint64_t)
+//                          yielding structured [hash, data] with data.share.
+//   is_rejected(hash) -> bool   skips a locally-rejected share.
+//   on_missing(hash)            optional side-effect for a not-in-chain request.
+template <class ShareT, class Chain, class RejectedPred>
+std::vector<ShareT> collect_get_shares(
+    Chain& chain,
+    const std::vector<uint256>& hashes,
+    uint64_t parents,
+    const std::vector<uint256>& stops,
+    RejectedPred is_rejected,
+    const std::function<void(const uint256&)>& on_missing = {})
+{
+    std::vector<ShareT> shares;
+    if (hashes.empty())
+        return shares;
+
+    parents = get_shares_parents_cap(parents, hashes.size());
+
+    for (const auto& handle_hash : hashes)
+    {
+        if (!chain.contains(handle_hash))
+        {
+            if (on_missing)
+                on_missing(handle_hash);
+            continue;
+        }
+
+        uint64_t n = get_shares_walk_count(parents, static_cast<uint64_t>(chain.get_height(handle_hash)));
+        for (auto [hash, data] : chain.get_chain(handle_hash, n))
+        {
+            if (std::find(stops.begin(), stops.end(), hash) != stops.end())
+                break;
+            if (is_rejected(hash))
+                continue;
+            shares.push_back(data.share);
+        }
+    }
+    return shares;
+}
+
+} // namespace dgb

--- a/src/impl/dgb/test/CMakeLists.txt
+++ b/src/impl/dgb/test/CMakeLists.txt
@@ -577,4 +577,18 @@ if (BUILD_TESTING AND GTest_FOUND)
         dgb_coin pool sharechain)
     gtest_add_tests(dgb_pool_msg_wire_test "" AUTO)
 
+    # dgb_get_shares_walk_test: FENCED, additive KAT pinning the pool share-
+    # exchange GetShares walk (SHAREREQ -> SHAREREPLY) in get_shares_walk.hpp vs
+    # the p2pool node.py handle_get_shares oracle (parents cap, per-hash walk
+    # bound, stop-hash break, missing-hash + rejected-share skip). Pure header +
+    # fake chain -> links only core (uint256). MUST also be in the build.yml
+    # --target allowlist (#143 NOT_BUILT trap).
+    add_executable(dgb_get_shares_walk_test get_shares_walk_test.cpp)
+    target_link_libraries(dgb_get_shares_walk_test PRIVATE
+        GTest::gtest_main GTest::gtest
+        core dgb
+        c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage
+        dgb_coin pool sharechain)
+    gtest_add_tests(dgb_get_shares_walk_test "" AUTO)
+
 endif()

--- a/src/impl/dgb/test/get_shares_walk_test.cpp
+++ b/src/impl/dgb/test/get_shares_walk_test.cpp
@@ -1,0 +1,198 @@
+// dgb GetShares walk — share-exchange (SHAREREQ -> SHAREREPLY) conformance KAT.
+//
+// FENCED, additive (no production code touched this slice). Pins
+// src/impl/dgb/get_shares_walk.hpp against the p2pool node.py
+// Node.handle_get_shares oracle:
+//     parents = min(parents, 1000//len(hashes))
+//     for share_hash in hashes:
+//         for share in get_chain(share_hash, min(parents+1, get_height(share_hash))):
+//             if share.hash in stops: break
+//             shares.append(share)
+// plus the two c2pool node-local guards (skip not-in-chain hash; skip rejected
+// share) the dgb walk adds.
+//
+// Expectations are derived from the oracle formula / hand-walked chain spans,
+// NOT from the code under test — a conformance KAT that reads its answers from
+// its subject passes vacuously.
+//
+// The chain is a FAKE (no NodeImpl / ShareTracker / LevelDB standup): a linear
+// genesis..tip vector exposing the same contains/get_height/get_chain contract
+// the real sharechain::Chain does. MUST appear in BOTH this dir's CMakeLists.txt
+// AND the build.yml --target allowlist, or it becomes a #143 NOT_BUILT sentinel.
+
+#include <impl/dgb/get_shares_walk.hpp>
+
+#include <core/uint256.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+uint256 u256(const char* hex) {
+    uint256 t;
+    t.SetHex(hex);
+    return t;
+}
+
+struct FakeShare { int id = 0; };
+struct ChainData { FakeShare share; };
+
+// Linear chain: m_order[0] = genesis ... m_order[back] = tip. Each entry's
+// FakeShare.id == its index, so a collected id sequence reads as positions.
+// get_height(h) = (index of h) + 1  — shares from genesis up to and incl. h.
+// get_chain(h, n) = n entries starting AT h walking toward genesis: h, parent,
+//                   grandparent, ...  (p2pool get_chain walks back through parents)
+class FakeChain {
+public:
+    std::vector<uint256> m_order;  // genesis-first
+
+    void append(const uint256& h) { m_order.push_back(h); }
+
+    int index_of(const uint256& h) const {
+        for (int i = 0; i < (int)m_order.size(); ++i)
+            if (m_order[i] == h) return i;
+        return -1;
+    }
+
+    bool contains(const uint256& h) const { return index_of(h) >= 0; }
+
+    int32_t get_height(const uint256& h) const {
+        int i = index_of(h);
+        return i < 0 ? 0 : (int32_t)(i + 1);
+    }
+
+    std::vector<std::pair<uint256, ChainData>> get_chain(const uint256& h, uint64_t n) const {
+        std::vector<std::pair<uint256, ChainData>> out;
+        int i = index_of(h);
+        for (uint64_t k = 0; k < n && i - (int)k >= 0; ++k) {
+            int pos = i - (int)k;
+            out.push_back({ m_order[pos], ChainData{ FakeShare{ pos } } });
+        }
+        return out;
+    }
+};
+
+// Build a 6-deep chain: ids/positions 0..5, tip = position 5.
+FakeChain make_chain() {
+    FakeChain c;
+    for (int i = 0; i < 6; ++i)
+        c.append(u256(std::to_string(10 + i).c_str()));  // distinct non-colliding hashes
+    return c;
+}
+
+std::vector<int> ids(const std::vector<FakeShare>& v) {
+    std::vector<int> out;
+    for (const auto& s : v) out.push_back(s.id);
+    return out;
+}
+
+const auto NO_REJECT = [](const uint256&) { return false; };
+
+} // namespace
+
+// --------------------------------------------------------------------------
+// 1. parents cap — min(parents, 1000//len(hashes)). Integer division.
+// --------------------------------------------------------------------------
+TEST(DgbGetSharesWalk, ParentsCapMatchesOracle) {
+    EXPECT_EQ(dgb::get_shares_parents_cap(5000, 1), 1000u);  // 1000//1
+    EXPECT_EQ(dgb::get_shares_parents_cap(600, 2), 500u);    // 1000//2 caps below 600
+    EXPECT_EQ(dgb::get_shares_parents_cap(100, 2), 100u);    // request below cap: unchanged
+    EXPECT_EQ(dgb::get_shares_parents_cap(5000, 3), 333u);   // 1000//3 == 333 (floor)
+    EXPECT_EQ(dgb::get_shares_parents_cap(7, 0), 7u);        // empty-request divzero guard
+}
+
+// --------------------------------------------------------------------------
+// 2. per-hash walk length — min(parents+1, height).
+// --------------------------------------------------------------------------
+TEST(DgbGetSharesWalk, WalkCountMatchesOracle) {
+    EXPECT_EQ(dgb::get_shares_walk_count(2, 10), 3u);  // parents+1 binds
+    EXPECT_EQ(dgb::get_shares_walk_count(10, 2), 2u);  // height binds
+    EXPECT_EQ(dgb::get_shares_walk_count(0, 5), 1u);   // parents=0 -> just the hash
+}
+
+// --------------------------------------------------------------------------
+// 3. full walk, single in-chain hash — returns [tip, parent, grandparent].
+// --------------------------------------------------------------------------
+TEST(DgbGetSharesWalk, SingleHashWalksParentsPlusOne) {
+    FakeChain c = make_chain();
+    uint256 tip = c.m_order.back();  // position 5
+    auto shares = dgb::collect_get_shares<FakeShare>(
+        c, {tip}, /*parents=*/2, /*stops=*/{}, NO_REJECT);
+    // min(parents+1, height=6) = 3 -> positions 5,4,3
+    EXPECT_EQ(ids(shares), (std::vector<int>{5, 4, 3}));
+}
+
+// --------------------------------------------------------------------------
+// 4. stop-hash BREAKS the walk before appending the stop (and the rest).
+// --------------------------------------------------------------------------
+TEST(DgbGetSharesWalk, StopHashBreaks) {
+    FakeChain c = make_chain();
+    uint256 tip = c.m_order.back();          // position 5
+    uint256 stop = c.m_order[4];             // position 4 is a stop
+    auto shares = dgb::collect_get_shares<FakeShare>(
+        c, {tip}, /*parents=*/3, /*stops=*/{stop}, NO_REJECT);
+    // walk yields 5 then 4(stop)->break: only [5]
+    EXPECT_EQ(ids(shares), (std::vector<int>{5}));
+}
+
+// --------------------------------------------------------------------------
+// 5. not-in-chain hash is SKIPPED (continue) and fires on_missing; other
+//    requested hashes still walk.
+// --------------------------------------------------------------------------
+TEST(DgbGetSharesWalk, MissingHashSkippedOnMissingFires) {
+    FakeChain c = make_chain();
+    uint256 tip = c.m_order.back();
+    uint256 absent = u256("deadbeef");
+    int missing_calls = 0;
+    auto shares = dgb::collect_get_shares<FakeShare>(
+        c, {absent, tip}, /*parents=*/1, /*stops=*/{}, NO_REJECT,
+        [&](const uint256& h){ EXPECT_EQ(h, absent); ++missing_calls; });
+    EXPECT_EQ(missing_calls, 1);
+    // tip walk: min(parents+1=2, height=6)=2 -> positions 5,4
+    EXPECT_EQ(ids(shares), (std::vector<int>{5, 4}));
+}
+
+// --------------------------------------------------------------------------
+// 6. locally-rejected share is SKIPPED (continue) — walk does not stop.
+// --------------------------------------------------------------------------
+TEST(DgbGetSharesWalk, RejectedShareSkippedNotStopped) {
+    FakeChain c = make_chain();
+    uint256 tip = c.m_order.back();          // position 5
+    std::set<std::string> rejected{ c.m_order[4].ToString() };  // position 4 rejected
+    auto is_rejected = [&](const uint256& h){ return rejected.count(h.ToString()) > 0; };
+    auto shares = dgb::collect_get_shares<FakeShare>(
+        c, {tip}, /*parents=*/2, /*stops=*/{}, is_rejected);
+    // walk 5(keep),4(rejected->continue),3(keep): [5,3]
+    EXPECT_EQ(ids(shares), (std::vector<int>{5, 3}));
+}
+
+// --------------------------------------------------------------------------
+// 7. empty request -> empty reply (never reaches the walk / divzero).
+// --------------------------------------------------------------------------
+TEST(DgbGetSharesWalk, EmptyRequestEmptyReply) {
+    FakeChain c = make_chain();
+    auto shares = dgb::collect_get_shares<FakeShare>(
+        c, {}, /*parents=*/10, /*stops=*/{}, NO_REJECT);
+    EXPECT_TRUE(shares.empty());
+}
+
+// --------------------------------------------------------------------------
+// 8. multi-hash request — parents cap applies once, each hash walks the
+//    capped span.
+// --------------------------------------------------------------------------
+TEST(DgbGetSharesWalk, MultiHashSharedCap) {
+    FakeChain c = make_chain();
+    uint256 tip = c.m_order.back();   // position 5
+    uint256 mid = c.m_order[2];       // position 2 (height 3)
+    // parents=600, 2 hashes -> cap=min(600,500)=500 -> walk_count bounded by height
+    auto shares = dgb::collect_get_shares<FakeShare>(
+        c, {tip, mid}, /*parents=*/600, /*stops=*/{}, NO_REJECT);
+    // tip: min(501, height=6)=6 -> 5,4,3,2,1,0 ; mid: min(501, height=3)=3 -> 2,1,0
+    EXPECT_EQ(ids(shares), (std::vector<int>{5, 4, 3, 2, 1, 0, 2, 1, 0}));
+}


### PR DESCRIPTION
Phase-B pool/share. Closes the zero-coverage gap on the share-exchange SHAREREQ -> SHAREREPLY walk (NodeImpl::handle_get_share, consumed by protocol_actual + protocol_legacy).

**SSOT** (src/impl/dgb/get_shares_walk.hpp, header-only): parents cap min(parents, 1000/len(hashes)); per-hash bound min(parents+1, height); stop-hash break; not-in-chain skip; locally-rejected skip — faithful to the p2pool node.py handle_get_shares oracle, with the two c2pool node-local guards documented.

**Fenced/additive**: no production code rewired in this slice. The byte-identity delegation of node.cpp -> collect_get_shares is the follow-on. The KAT drives the real walk through a fake chain (no NodeImpl/tracker/LevelDB standup); expectations are hand-derived from the oracle formula and chain spans, not read from the code under test. 8/8 local green.

Registered in test CMakeLists + both build.yml --target allowlist arms (no #143 NOT_BUILT sentinel). No self-merge — integrator taps on full rollup.