### PR TITLE
dgb: delegate handle_get_share to get_shares_walk SSOT (Phase-B pool/share)

### DIFF
--- a/src/impl/dgb/node.cpp
+++ b/src/impl/dgb/node.cpp
@@ -5,6 +5,7 @@
 #include <core/random.hpp>
 #include <core/target_utils.hpp>
 #include <sharechain/prepared_list.hpp>
+#include <impl/dgb/get_shares_walk.hpp>
 
 #include <algorithm>
 #include <filesystem>
@@ -599,30 +600,25 @@ std::vector<dgb::ShareType> NodeImpl::handle_get_share(std::vector<uint256> hash
         return {};
     }
 
-    parents = std::min(parents, (uint64_t)1000/hashes.size());
-	std::vector<dgb::ShareType> shares;
-	for (const auto& handle_hash : hashes)
-	{
-		if (!m_chain->contains(handle_hash))
-		{
-			static int miss_log = 0;
-			if (miss_log++ < 5)
-				LOG_WARNING << "[handle_get_share] hash NOT in chain: "
-				            << handle_hash.ToString().substr(0, 16)
-				            << " chain_size=" << m_chain->size()
-				            << " tracker_chain_size=" << m_tracker.chain.size();
-			continue;
-		}
-		uint64_t n = std::min(parents+1, (uint64_t) m_chain->get_height(handle_hash));
-		for (auto [hash, data] : m_chain->get_chain(handle_hash, n))
-        {
-			if (std::find(stops.begin(), stops.end(), hash) != stops.end())
-				break;
-			if (m_rejected_share_hashes.count(hash))
-				continue;
-			shares.push_back(data.share);
-		}
-	}
+    // Delegate the walk to the SSOT (get_shares_walk.hpp) so the parents cap,
+    // the per-hash walk bound, the stop-hash break, and the missing/rejected
+    // skips stay byte-identical to the p2pool node.py oracle and are pinned by
+    // the get_shares_walk conformance KAT. The try_to_lock guard above and the
+    // node-local logging stay here; only the pure walk moves to the SSOT.
+    auto shares = dgb::collect_get_shares<dgb::ShareType>(
+        *m_chain,
+        hashes,
+        parents,
+        stops,
+        [this](const uint256& h) { return m_rejected_share_hashes.count(h) != 0; },
+        [this](const uint256& handle_hash) {
+            static int miss_log = 0;
+            if (miss_log++ < 5)
+                LOG_WARNING << "[handle_get_share] hash NOT in chain: "
+                            << handle_hash.ToString().substr(0, 16)
+                            << " chain_size=" << m_chain->size()
+                            << " tracker_chain_size=" << m_tracker.chain.size();
+        });
 
 	if (!shares.empty())
 	{

--- a/src/impl/dgb/test/get_shares_walk_test.cpp
+++ b/src/impl/dgb/test/get_shares_walk_test.cpp
@@ -196,3 +196,61 @@ TEST(DgbGetSharesWalk, MultiHashSharedCap) {
     // tip: min(501, height=6)=6 -> 5,4,3,2,1,0 ; mid: min(501, height=3)=3 -> 2,1,0
     EXPECT_EQ(ids(shares), (std::vector<int>{5, 4, 3, 2, 1, 0, 2, 1, 0}));
 }
+
+// --------------------------------------------------------------------------
+// 9. DELEGATION EQUIVALENCE — node.cpp NodeImpl::handle_get_share was rewired
+//    to call collect_get_shares (was an inline walk). This pins that the SSOT
+//    reproduces the EXACT pre-delegation node.cpp walk, byte-for-byte, across a
+//    combined scenario (absent hash + rejected share + stop-hash + multi-hash).
+//    inline_walk_oracle below is the verbatim pre-delegation node.cpp body — an
+//    independent subject — and the result is ALSO pinned to a hand-walked value
+//    so the check is not circular.
+// --------------------------------------------------------------------------
+namespace {
+// Verbatim copy of the node.cpp inline walk as it stood BEFORE the SSOT
+// delegation (rejected = set<string-of-hash>, on_missing = skip). If a future
+// edit drifts the SSOT from this captured behavior, this test fails.
+std::vector<FakeShare> inline_walk_oracle(
+    const FakeChain& chain,
+    std::vector<uint256> hashes,
+    uint64_t parents,
+    const std::vector<uint256>& stops,
+    const std::set<std::string>& rejected) {
+    std::vector<FakeShare> shares;
+    if (hashes.empty()) return shares;
+    parents = std::min(parents, (uint64_t)1000 / hashes.size());
+    for (const auto& handle_hash : hashes) {
+        if (!chain.contains(handle_hash)) continue;
+        uint64_t n = std::min(parents + 1, (uint64_t)chain.get_height(handle_hash));
+        for (auto [hash, data] : chain.get_chain(handle_hash, n)) {
+            if (std::find(stops.begin(), stops.end(), hash) != stops.end()) break;
+            if (rejected.count(hash.ToString()) > 0) continue;
+            shares.push_back(data.share);
+        }
+    }
+    return shares;
+}
+} // namespace
+
+TEST(DgbGetSharesWalk, DelegationMatchesPreDelegationInlineWalk) {
+    FakeChain c = make_chain();
+    uint256 absent = u256("deadbeef");
+    uint256 tip = c.m_order.back();      // position 5
+    uint256 mid = c.m_order[2];          // position 2 (height 3)
+    std::vector<uint256> hashes{absent, tip, mid};
+    uint64_t parents = 3;
+    std::vector<uint256> stops{ c.m_order[1] };          // position 1 is a stop
+    std::set<std::string> rejected{ c.m_order[4].ToString() };  // position 4 rejected
+    auto is_rejected = [&](const uint256& h){ return rejected.count(h.ToString()) > 0; };
+
+    auto via_ssot = dgb::collect_get_shares<FakeShare>(
+        c, hashes, parents, stops, is_rejected);
+    auto via_inline = inline_walk_oracle(c, hashes, parents, stops, rejected);
+
+    // SSOT == verbatim pre-delegation inline walk.
+    EXPECT_EQ(ids(via_ssot), ids(via_inline));
+    // ... and both == the hand-walked span:
+    //   absent -> skip; tip(5): walk 5,4,3,2 with 4 rejected -> [5,3,2];
+    //   mid(2): walk 2,1,0 with 1=stop -> break after 2 -> [2].
+    EXPECT_EQ(ids(via_ssot), (std::vector<int>{5, 3, 2, 2}));
+}


### PR DESCRIPTION
Phase-B pool/share follow-on to #344 (integrator-greenlit). Delegates the live share-exchange handler onto the get_shares_walk SSOT.

WHAT
- src/impl/dgb/node.cpp NodeImpl::handle_get_share: inline GetShares walk replaced by a call to dgb::collect_get_shares (the header-only SSOT from #344). The try_to_lock IO-thread guard and node-local logging stay; only the pure walk moves.

WHY
- #344 staged the walk as a free function with ZERO production consumers — node.cpp still carried the inline copy. This closes that gap so the parents cap / walk bound / stop-break / missing+rejected skips have a single source pinned to the p2pool node.py handle_get_shares oracle.

PROVEN EQUIVALENT (not assumed)
- The #344 get_shares_walk KAT passes UNCHANGED.
- New case DelegationMatchesPreDelegationInlineWalk carries a verbatim copy of the pre-delegation node.cpp walk and asserts SSOT == inline over a combined absent-hash + rejected-share + stop-hash + multi-hash request, also pinned to a hand-walked span (non-circular). 9/9 green.

SCOPE
- DGB-tree-local (src/impl/dgb/ only) — no bitcoin_family/ or src/core/ reach. Fenced/behavior-preserving. c2pool-dgb binary links.
- Side effect of delegation: the empty-request divide-by-zero latent in the old inline cap is now guarded by the SSOT (no change for any well-formed request).

No self-merge — integrator taps on full-rollup CLEAN.
