### PR TITLE
dgb: SSOT for requester-side download stops-list + conformance KAT (Phase-B pool/share)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
                     dgb_gentx_coinbase_test dgb_connection_coinbase_test dgb_pplns_payout_split_test nmc_auxpow_merkle_test nmc_template_builder_test nmc_auxpow_wire_test nmc_reconstruct_won_block_test dgb_gentx_share_path_test dgb_conn_pplns_producer_test dgb_other_tx_resolver_test \
                     dgb_other_tx_assembler_test dgb_reconstruct_won_block_test dgb_reconstruct_closure_test dgb_gentx_unpack_test dgb_work_source_test dgb_template_builder_test dgb_embedded_coin_node_test dgb_embedded_tx_select_test dgb_template_other_txs_test dgb_coinbase_value_parity_test dgb_submit_classify_test dgb_aux_parent_coinbase_parity_test dgb_template_capture_test dgb_aux_doge_db_commitment_bind_test \
                     rpc_request_test softfork_check_test genesis_check_test algo_select_test digishield_walk_test header_chain_test \
-                    dgb_coin_node_seam_test dgb_block_broadcast_test dgb_won_block_dispatch_test dgb_forced_won_share_dualpath_test dgb_scrypt_pow_test dgb_nonce_grinder_test dgb_regrind_block_test dgb_won_block_finalize_test dgb_share_target_genesis_test dgb_pool_msg_wire_test dgb_get_shares_walk_test v37_test \
+                    dgb_coin_node_seam_test dgb_block_broadcast_test dgb_won_block_dispatch_test dgb_forced_won_share_dualpath_test dgb_scrypt_pow_test dgb_nonce_grinder_test dgb_regrind_block_test dgb_won_block_finalize_test dgb_share_target_genesis_test dgb_pool_msg_wire_test dgb_get_shares_walk_test dgb_download_stops_test v37_test \
             -j$(nproc)
 
       - name: Run tests
@@ -216,7 +216,7 @@ jobs:
                     dgb_gentx_coinbase_test dgb_connection_coinbase_test dgb_pplns_payout_split_test nmc_auxpow_merkle_test nmc_template_builder_test nmc_auxpow_wire_test nmc_reconstruct_won_block_test dgb_gentx_share_path_test dgb_conn_pplns_producer_test dgb_other_tx_resolver_test \
                     dgb_other_tx_assembler_test dgb_reconstruct_won_block_test dgb_reconstruct_closure_test dgb_gentx_unpack_test dgb_work_source_test dgb_template_builder_test dgb_embedded_coin_node_test dgb_embedded_tx_select_test dgb_template_other_txs_test dgb_coinbase_value_parity_test dgb_submit_classify_test dgb_aux_parent_coinbase_parity_test dgb_template_capture_test dgb_aux_doge_db_commitment_bind_test \
                     rpc_request_test softfork_check_test genesis_check_test algo_select_test digishield_walk_test header_chain_test \
-                    dgb_coin_node_seam_test dgb_block_broadcast_test dgb_won_block_dispatch_test dgb_forced_won_share_dualpath_test dgb_scrypt_pow_test dgb_nonce_grinder_test dgb_regrind_block_test dgb_won_block_finalize_test dgb_share_target_genesis_test dgb_pool_msg_wire_test dgb_get_shares_walk_test test_coin_broadcaster test_multiaddress_pplns test_pplns_stress \
+                    dgb_coin_node_seam_test dgb_block_broadcast_test dgb_won_block_dispatch_test dgb_forced_won_share_dualpath_test dgb_scrypt_pow_test dgb_nonce_grinder_test dgb_regrind_block_test dgb_won_block_finalize_test dgb_share_target_genesis_test dgb_pool_msg_wire_test dgb_get_shares_walk_test dgb_download_stops_test test_coin_broadcaster test_multiaddress_pplns test_pplns_stress \
                     v37_test \
             -j$(nproc)
 

--- a/src/impl/dgb/download_stops.hpp
+++ b/src/impl/dgb/download_stops.hpp
@@ -1,0 +1,83 @@
+#pragma once
+
+// SSOT for the requester-side download stops-list — the bound that
+// NodeImpl::download_shares puts on a SHAREREQ so a peer cannot dump an
+// unbounded single-branch burst in reply.  This is the mirror of the
+// responder-side get_shares_walk.hpp: the walk decides how far a peer walks UP
+// from each requested hash; the stops list tells it where to STOP, namely at
+// any share we already hold.  Until now this computation was inline in
+// download_shares() with ZERO coverage in any tree — a drift in the nth-parent
+// depth, the head-inclusion, the null-parent skip, or the 100-cap would let a
+// c2pool-dgb peer (or a c2pool-dgb peer vs a p2pool-merged-v36 reference node)
+// silently request the wrong span with no compile error, and on the bootstrap
+// path (parents=random(500)) overgrow one lineage past 2*CHAIN_LENGTH+10 until
+// clean_tracker drop-tails collapse the branch and verified resets to 0 (the
+// exact failure the inline comment documents).
+//
+// Oracle: p2pool node.py download_shares():
+//     stops=list(set(tracker.heads) | set(
+//         tracker.get_nth_parent_hash(head, min(max(0, height-1), 10))
+//         for head in tracker.heads))[:100]
+//
+// Per-coin isolation: dgb/ only.  Header-only, additive; this slice does not
+// rewire node.cpp (that is the byte-identity-fenced delegation follow-on) — it
+// pins the stops construction as a free function so the KAT can exercise it
+// against a fake head set with no NodeImpl/tracker standup.  Determinism note:
+// the survivor set under the 100-cap is fixed by std::set<uint256> ordering, so
+// the function reproduces the inline std::set insert + ordered-iteration exactly.
+
+#include <algorithm>
+#include <cstddef>
+#include <functional>
+#include <set>
+#include <vector>
+
+#include <core/uint256.hpp>
+
+namespace dgb {
+
+// Per-head nth-parent depth — p2pool: min(max(0, height-1), 10).  height is the
+// accumulated height of the head share; a head at height <= 1 contributes only
+// itself (nth == 0 -> no parent inserted).
+inline int download_stops_nth(int acc_height)
+{
+    return std::min(std::max(0, acc_height - 1), 10);
+}
+
+// Build the stops list for a SHAREREQ.  heads is the current head-hash set;
+// get_acc_height(head) returns the head accumulated height; get_nth_parent(head,
+// nth) returns the nth ancestor (or a null uint256 if it cannot be resolved,
+// which is skipped, matching the inline guard).  cap bounds the result (p2pool
+// [:100]); survivors under the cap are the ordered-first entries of the
+// deduplicated set, exactly as the inline std::set<uint256> iteration yields.
+inline std::vector<uint256> compute_download_stops(
+    const std::vector<uint256>& heads,
+    const std::function<int(const uint256&)>& get_acc_height,
+    const std::function<uint256(const uint256&, int)>& get_nth_parent,
+    std::size_t cap = 100)
+{
+    std::set<uint256> stop_set;
+    for (const auto& head_hash : heads)
+    {
+        stop_set.insert(head_hash);
+        int nth = download_stops_nth(get_acc_height(head_hash));
+        if (nth > 0)
+        {
+            uint256 parent = get_nth_parent(head_hash, nth);
+            if (!parent.IsNull())
+                stop_set.insert(parent);
+        }
+    }
+
+    std::vector<uint256> stops;
+    std::size_t count = 0;
+    for (const auto& s : stop_set)
+    {
+        if (count++ >= cap)
+            break;
+        stops.push_back(s);
+    }
+    return stops;
+}
+
+} // namespace dgb

--- a/src/impl/dgb/test/CMakeLists.txt
+++ b/src/impl/dgb/test/CMakeLists.txt
@@ -591,4 +591,18 @@ if (BUILD_TESTING AND GTest_FOUND)
         dgb_coin pool sharechain)
     gtest_add_tests(dgb_get_shares_walk_test "" AUTO)
 
+    # dgb_download_stops_test: FENCED, additive KAT pinning the requester-side
+    # SHAREREQ stops-list in download_stops.hpp vs the p2pool node.py
+    # download_shares oracle (heads | nth-parent at min(max(0,height-1),10),
+    # null-parent skip, dedup, [:100] cap). Pure header + fakes -> links only
+    # core (uint256). MUST also be in the build.yml --target allowlist
+    # (#143 NOT_BUILT trap).
+    add_executable(dgb_download_stops_test download_stops_test.cpp)
+    target_link_libraries(dgb_download_stops_test PRIVATE
+        GTest::gtest_main GTest::gtest
+        core dgb
+        c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage
+        dgb_coin pool sharechain)
+    gtest_add_tests(dgb_download_stops_test "" AUTO)
+
 endif()

--- a/src/impl/dgb/test/download_stops_test.cpp
+++ b/src/impl/dgb/test/download_stops_test.cpp
@@ -1,0 +1,148 @@
+// dgb download stops-list — requester-side SHAREREQ bound conformance KAT.
+//
+// FENCED, additive (no production code touched this slice). Pins
+// src/impl/dgb/download_stops.hpp against the p2pool node.py download_shares
+// oracle:
+//     stops=list(set(tracker.heads) | set(
+//         tracker.get_nth_parent_hash(head, min(max(0, height-1), 10))
+//         for head in tracker.heads))[:100]
+//
+// Expectations are hand-derived from the oracle formula, NOT read from the code
+// under test. The per-head depth min(max(0,height-1),10) and the head-inclusion
+// / null-parent-skip / dedup behaviour are oracle-faithful. The 100-cap survivor
+// SELECTION is a c2pool determinism choice (Python set() iteration order is
+// arbitrary; c2pool pins std::set<uint256> ascending order) — the cap test below
+// constructs numerically-ordered hashes so the expected survivors (the 100
+// smallest) are hand-computable, pinning that documented contract non-vacuously.
+//
+// No NodeImpl / ShareTracker standup: heads + acc-height + nth-parent are fakes.
+// MUST appear in BOTH this dir CMakeLists.txt AND the build.yml --target
+// allowlist, or it becomes a #143 NOT_BUILT sentinel.
+
+#include <impl/dgb/download_stops.hpp>
+
+#include <core/uint256.hpp>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <functional>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace {
+
+uint256 u256(const char* hex) {
+    uint256 t;
+    t.SetHex(hex);
+    return t;
+}
+
+// 64-hex-char zero-padded id so numeric uint256 ordering == ascending id:
+// id 1 -> 0x..0001 < id 2 -> 0x..0002 < ...  Lets the 100-cap survivors be hand-named.
+uint256 id256(int id) {
+    char buf[65];
+    std::snprintf(buf, sizeof(buf),
+        "%064x", id);
+    return u256(buf);
+}
+
+const uint256 NULLH; // default uint256 == null
+
+} // namespace
+
+// --- depth formula: min(max(0, height-1), 10), hand-tabulated --------------
+TEST(DgbDownloadStops, NthDepthFormulaMatchesOracle) {
+    EXPECT_EQ(dgb::download_stops_nth(0), 0);   // max(0,-1)=0
+    EXPECT_EQ(dgb::download_stops_nth(1), 0);   // max(0,0)=0
+    EXPECT_EQ(dgb::download_stops_nth(2), 1);
+    EXPECT_EQ(dgb::download_stops_nth(5), 4);
+    EXPECT_EQ(dgb::download_stops_nth(11), 10);
+    EXPECT_EQ(dgb::download_stops_nth(12), 10); // capped at 10
+    EXPECT_EQ(dgb::download_stops_nth(1000), 10);
+}
+
+// --- two deep heads -> head + 10th-parent each = 4 distinct stops ----------
+TEST(DgbDownloadStops, TwoDeepHeadsIncludeHeadAndNthParent) {
+    uint256 h1 = id256(0x11), h2 = id256(0x22);
+    uint256 p1 = id256(0x01), p2 = id256(0x02);
+    std::vector<uint256> heads{h1, h2};
+
+    auto height = [](const uint256&) { return 20; };           // nth = 10
+    auto nthp = [&](const uint256& h, int nth) -> uint256 {
+        EXPECT_EQ(nth, 10);
+        return h == h1 ? p1 : p2;
+    };
+
+    auto stops = dgb::compute_download_stops(heads, height, nthp);
+    std::set<uint256> got(stops.begin(), stops.end());
+    EXPECT_EQ(stops.size(), 4u);
+    EXPECT_EQ(got, (std::set<uint256>{h1, h2, p1, p2}));
+}
+
+// --- head at height 1 contributes only itself, nth-parent NEVER queried ----
+TEST(DgbDownloadStops, HeightOneHeadHasNoParentAndSkipsLookup) {
+    uint256 h = id256(0x33);
+    bool nth_called = false;
+    auto height = [](const uint256&) { return 1; };            // nth = 0
+    auto nthp = [&](const uint256&, int) -> uint256 { nth_called = true; return NULLH; };
+
+    auto stops = dgb::compute_download_stops({h}, height, nthp);
+    EXPECT_EQ(stops.size(), 1u);
+    EXPECT_EQ(stops[0], h);
+    EXPECT_FALSE(nth_called); // nth==0 -> no get_nth_parent call (inline guard)
+}
+
+// --- null nth-parent is skipped (head still included) ----------------------
+TEST(DgbDownloadStops, NullNthParentSkipped) {
+    uint256 h = id256(0x44);
+    auto height = [](const uint256&) { return 5; };            // nth = 4
+    auto nthp = [&](const uint256&, int nth) -> uint256 {
+        EXPECT_EQ(nth, 4);
+        return NULLH; // unresolved
+    };
+    auto stops = dgb::compute_download_stops({h}, height, nthp);
+    EXPECT_EQ(stops.size(), 1u);
+    EXPECT_EQ(stops[0], h);
+}
+
+// --- two heads sharing one nth-parent dedups via the set -------------------
+TEST(DgbDownloadStops, SharedNthParentDeduped) {
+    uint256 h1 = id256(0x55), h2 = id256(0x66), shared = id256(0x07);
+    auto height = [](const uint256&) { return 20; };
+    auto nthp = [&](const uint256&, int) -> uint256 { return shared; };
+    auto stops = dgb::compute_download_stops({h1, h2}, height, nthp);
+    EXPECT_EQ(stops.size(), 3u); // {h1, h2, shared}, NOT 4
+    std::set<uint256> got(stops.begin(), stops.end());
+    EXPECT_EQ(got, (std::set<uint256>{h1, h2, shared}));
+}
+
+// --- 100-cap: 150 height-1 heads -> 100 smallest in ascending order --------
+TEST(DgbDownloadStops, CapAt100KeepsSmallestAscending) {
+    std::vector<uint256> heads;
+    for (int i = 1; i <= 150; ++i) heads.push_back(id256(i)); // distinct, only-self
+    auto height = [](const uint256&) { return 1; };           // nth = 0, no parents
+    auto nthp = [&](const uint256&, int) -> uint256 { return NULLH; };
+
+    auto stops = dgb::compute_download_stops(heads, height, nthp);
+    ASSERT_EQ(stops.size(), 100u);                            // [:100]
+    for (int i = 0; i < 100; ++i)
+        EXPECT_EQ(stops[i], id256(i + 1)) << "survivor " << i; // ids 1..100, ascending
+    EXPECT_TRUE(std::is_sorted(stops.begin(), stops.end()));
+}
+
+// --- custom cap argument honoured ------------------------------------------
+TEST(DgbDownloadStops, CustomCapHonoured) {
+    std::vector<uint256> heads;
+    for (int i = 1; i <= 10; ++i) heads.push_back(id256(i));
+    auto height = [](const uint256&) { return 1; };
+    auto nthp = [&](const uint256&, int) -> uint256 { return NULLH; };
+    auto stops = dgb::compute_download_stops(heads, height, nthp, 3);
+    ASSERT_EQ(stops.size(), 3u);
+    EXPECT_EQ(stops[0], id256(1));
+    EXPECT_EQ(stops[1], id256(2));
+    EXPECT_EQ(stops[2], id256(3));
+}


### PR DESCRIPTION
## Phase-B pool/share — requester-side download stops-list SSOT + KAT

FENCED, additive, DGB-tree-local (`src/impl/dgb/` only). The requester-side mirror of the `get_shares_walk.hpp` SSOT landed in #344/#346: the walk decides how far a peer climbs from each requested hash; the **stops list** tells it where to halt (at any share we already hold), bounding a SHAREREQ reply to the real info-gap between our chain and the peer's.

### What
Lift the inline stops-list computation in `NodeImpl::download_shares` into a header-only SSOT `src/impl/dgb/download_stops.hpp` (`compute_download_stops` + `download_stops_nth`). This slice does **not** rewire `node.cpp` — the byte-identity delegation is the follow-on, exactly as #344 (SSOT) preceded #346 (delegation).

### Oracle
p2pool `node.py download_shares()`:
```
stops=list(set(tracker.heads) | set(
    tracker.get_nth_parent_hash(head, min(max(0, height-1), 10))
    for head in tracker.heads))[:100]
```

### Proof — 7/7, hand-derived from the oracle (not the code)
- depth formula `min(max(0,height-1),10)` tabulated;
- head always included; `nth==0` skips the parent lookup entirely;
- null nth-parent skipped (head still included);
- shared nth-parent deduped via the set;
- the `[:100]` cap — a c2pool `std::set<uint256>`-ascending determinism choice over the arbitrary Python `set()` iteration order — pinned with numerically-ordered hashes so the 100 smallest survivors are hand-named;
- custom cap honoured.

In **both** `build.yml --target` arms (#143 NOT_BUILT guard) + this dir's CMakeLists.txt.

No consensus-value change; no self-merge.
