### PR TITLE
web: per-D9 miner_hash_rates keying (ADDRESS.worker)

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -4337,8 +4337,13 @@ nlohmann::json MiningInterface::rest_local_stats()
     {
         auto workers = get_stratum_workers();
         for (const auto& [sid, w] : workers) {
-            // Aggregate by username (address) — multiple workers may share same address
-            std::string key = w.username;
+            // Key by the FULL stratum username (ADDRESS.worker) so each D9/worker
+            // gets its own bucket; fall back to the bare address when no worker
+            // suffix was supplied. Read/web-stats path only — pool-wide aggregates
+            // (poolhashps, shares, payouts) are unchanged.
+            std::string key = w.worker_name.empty()
+                                  ? w.username
+                                  : w.username + "." + w.worker_name;
             double existing = miner_rates.value(key, 0.0);
             miner_rates[key] = existing + w.hashrate;
             double existing_dead = miner_dead.value(key, 0.0);


### PR DESCRIPTION
## What

`rest_local_stats()` keyed `miner_hash_rates` / `miner_dead_hash_rates` by the bare payout **address**, collapsing every D9/worker that shares one address into a single bucket. Confirmed live on contabo prod: a single key `LRF2Z9pmn1Mv4AxBkteNpzTn2gQj9G9DDp` with no `.worker` suffix.

This keys by the **full stratum username (`ADDRESS.worker`)** instead, falling back to the bare address when no worker suffix was supplied — matching the classic p2pool legacy dashboard shape. `WorkerInfo` already carries `worker_name`; no new state.

## Scope / safety

- **Read / web-stats path only.** Pool-wide aggregates (`poolhashps`, `shares`, payouts, consensus) are untouched.
- **Non-consensus**, web layer only.
- Sampler + uptime API (D-MINER.1/.2) are keying-agnostic, so the finer key drops in with zero history loss.

## Provenance

Operator-approved (Option A) per-D9 split for the D-MINER arc.
