### PR TITLE
dash(s7): mn_state_machine leaf — providertx + mn_state_db + mn_state_machine + KAT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root \
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state \
                     test_multiaddress_pplns test_pplns_stress \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
@@ -205,7 +205,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root \
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
                     test_v36_script_sorting test_v36_cross_impl_refhash \

--- a/src/impl/dash/coin/mn_state_db.hpp
+++ b/src/impl/dash/coin/mn_state_db.hpp
@@ -1,0 +1,303 @@
+#pragma once
+
+/// Phase C-PAY step 2: per-MN state store.
+///
+/// Holds the EFFECTIVE state of every masternode we know about, derived
+/// by the per-block state machine (Phase C-PAY step 3) from observed
+/// ProTx records + coinbase outputs. The `MNState` struct is our pruned
+/// internal version of dashcore's `CDeterministicMNState`
+/// (evo/dmnstate.h) — same field semantics for the bits we use, but
+/// reduced to what GetProjectedMNPayees actually needs:
+///
+///   - nLastPaidHeight, nPoSeRevivedHeight, nRegisteredHeight
+///     → CompareByLastPaid_GetHeight (the sort key)
+///   - proRegTxHash → tiebreaker
+///   - nType → Regular vs Evo (Evo bonus path)
+///   - nConsecutivePayments → Evo "paid 4 in a row" bonus tracking
+///   - isValid → eligibility filter
+///   - scriptPayout → for "[PAY] match/mismatch" verification
+///
+/// We persist the FULL state-relevant subset (including keyIDOwner /
+/// pubKeyOperator / nOperatorReward / collateralOutpoint / Evo platform
+/// fields) so future state-machine work can consume them without a
+/// schema migration.
+///
+/// The store mirrors SMLDb + QuorumDb: open at
+/// `~/.c2pool/<coin>/mn_state_db/`, atomic batch full-rewrite per-block
+/// state advance, BEST sentinel for tip tracking + cross-check with
+/// SMLDb/QuorumDb (divergence → wipe all three).
+///
+/// Key schema:
+///   'M' + proRegTxHash(32B)  →  pack(MNState)
+///   'B'                       →  best_hash(32B) + best_height(4B LE)
+///
+/// Persistence wire format is INTERNAL-ONLY — never shared on the
+/// network — so we use pack.hpp's SERIALIZE_METHODS macros directly
+/// without worrying about bit-exact match against dashcore's
+/// CDeterministicMNState wire layout.
+
+#include <impl/dash/coin/vendor/providertx.hpp>
+
+#include <core/leveldb_store.hpp>
+#include <core/uint256.hpp>
+#include <core/log.hpp>
+#include <core/opscript.hpp>
+#include <core/pack.hpp>
+#include <core/pack_types.hpp>
+#include <impl/bitcoin_family/coin/base_transaction.hpp>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace dash {
+namespace coin {
+
+struct MNState
+{
+    // From CProRegTx (registration — immutable per MN unless a later
+    // ProUpRegTx rewrites them)
+    uint16_t                                       nVersion{vendor::ProTxVersion::BASIC_BLS};
+    uint8_t                                        nType{vendor::MnType::REGULAR};
+    bitcoin_family::coin::TxPrevOut                collateralOutpoint;
+    uint160                                        keyIDOwner;
+    std::array<uint8_t, vendor::BLS_PUBKEY_SIZE>   pubKeyOperator{};
+    uint160                                        keyIDVoting;
+    uint16_t                                       nOperatorReward{0};
+    OPScript                                       scriptPayout;
+
+    // From CProUpServTx
+    vendor::LegacyNetService                       netInfo;
+    OPScript                                       scriptOperatorPayout;
+
+    // Per-block state-machine outputs
+    uint32_t                                       nRegisteredHeight{0};
+    uint32_t                                       nLastPaidHeight{0};
+    uint32_t                                       nPoSeRevivedHeight{0};
+    uint32_t                                       nPoSeBanHeight{0};
+    uint32_t                                       nConsecutivePayments{0};
+    uint16_t                                       nRevocationReason{vendor::CProUpRevTx::REASON_NOT_SPECIFIED};
+    bool                                           isValid{true};
+
+    // Evo-only platform fields (gated on nType == EVO)
+    uint160                                        platformNodeID;
+    uint16_t                                       platformP2PPort{0};
+    uint16_t                                       platformHTTPPort{0};
+
+    C2POOL_SERIALIZE_METHODS(MNState)
+    {
+        READWRITE(obj.nVersion,
+                  obj.nType,
+                  obj.collateralOutpoint,
+                  obj.keyIDOwner,
+                  Using<vendor::RawBytesFormat<vendor::BLS_PUBKEY_SIZE>>(obj.pubKeyOperator),
+                  obj.keyIDVoting,
+                  obj.nOperatorReward,
+                  obj.scriptPayout,
+                  obj.netInfo,
+                  obj.scriptOperatorPayout,
+                  obj.nRegisteredHeight,
+                  obj.nLastPaidHeight,
+                  obj.nPoSeRevivedHeight,
+                  obj.nPoSeBanHeight,
+                  obj.nConsecutivePayments,
+                  obj.nRevocationReason,
+                  obj.isValid,
+                  obj.platformNodeID,
+                  obj.platformP2PPort,
+                  obj.platformHTTPPort);
+    }
+
+    bool operator==(const MNState& r) const
+    {
+        return nVersion == r.nVersion
+            && nType == r.nType
+            && nRegisteredHeight == r.nRegisteredHeight
+            && nLastPaidHeight == r.nLastPaidHeight
+            && nPoSeRevivedHeight == r.nPoSeRevivedHeight
+            && nPoSeBanHeight == r.nPoSeBanHeight
+            && nConsecutivePayments == r.nConsecutivePayments
+            && nRevocationReason == r.nRevocationReason
+            && isValid == r.isValid
+            && nOperatorReward == r.nOperatorReward
+            && keyIDOwner == r.keyIDOwner
+            && pubKeyOperator == r.pubKeyOperator
+            && keyIDVoting == r.keyIDVoting
+            && scriptPayout.m_data == r.scriptPayout.m_data
+            && scriptOperatorPayout.m_data == r.scriptOperatorPayout.m_data
+            && platformNodeID == r.platformNodeID
+            && platformP2PPort == r.platformP2PPort
+            && platformHTTPPort == r.platformHTTPPort;
+    }
+};
+
+class MnStateDb
+{
+public:
+    explicit MnStateDb(const std::string& db_path,
+                       const ::core::LevelDBOptions& opts = {})
+        : m_store(db_path, opts) {}
+
+    bool open()
+    {
+        if (!m_store.open()) return false;
+        load_best_state();
+        LOG_INFO << "[MNS-DB] opened best_height=" << m_best_height
+                 << " best_hash=" << m_best_hash.GetHex().substr(0, 16);
+        return true;
+    }
+
+    void close() { m_store.close(); }
+    bool is_open() const { return m_store.is_open(); }
+
+    uint256  get_best_hash() const   { return m_best_hash; }
+    uint32_t get_best_height() const { return m_best_height; }
+
+    // Load every persisted MNState into `out` keyed by proRegTxHash.
+    // Returns true if at least one entry loaded OR the BEST sentinel
+    // exists (warm restart with empty set is technically valid).
+    bool load_all(std::vector<std::pair<uint256, MNState>>& out)
+    {
+        out.clear();
+        auto keys = m_store.list_keys(std::string(1, 'M'),
+                                      /*limit=*/100000);
+        out.reserve(keys.size());
+        size_t bad = 0;
+        for (const auto& key : keys) {
+            if (key.size() != 33 || key[0] != 'M') continue;
+            std::vector<uint8_t> data;
+            if (!m_store.get(key, data)) { ++bad; continue; }
+            try {
+                MNState s;
+                ::PackStream ps(data);
+                ps >> s;
+                uint256 h;
+                std::memcpy(h.data(), key.data() + 1, 32);
+                out.emplace_back(h, std::move(s));
+            } catch (const std::exception& ex) {
+                ++bad;
+                LOG_WARNING << "[MNS-DB] entry deserialize failed: "
+                            << ex.what();
+            }
+        }
+        if (bad > 0) {
+            LOG_WARNING << "[MNS-DB] " << bad
+                        << " entries failed to load (skipped)";
+        }
+        bool warm = !out.empty() || !m_best_hash.IsNull();
+        if (warm) {
+            LOG_INFO << "[MNS-DB] loaded " << out.size()
+                     << " entries best_height=" << m_best_height;
+        }
+        return warm;
+    }
+
+    // Atomic full-rewrite of the entire MN state set + BEST sentinel.
+    // Same pattern as SMLDb::write_sml. ~3000 MNs × ~220 B avg ≈
+    // 660 KB per-block rewrite. Fine — LevelDB compaction handles
+    // the churn on the same order as SML rewrites.
+    bool write_all(const std::vector<std::pair<uint256, MNState>>& entries,
+                   const uint256& best_hash,
+                   uint32_t best_height)
+    {
+        // Monotonic-advance: best_height only ever increases. Required so
+        // that bootstrap drain (replaying h=snapshot+1 .. tip in chain
+        // order, AFTER a tip block at top-of-handler may have already
+        // bumped best_height to tip-height) does not roll back the
+        // persisted high-watermark. Snapshot ENTRIES still need to be
+        // written, so we always persist `entries`; only the best_hash /
+        // best_height update is gated.
+        const bool advance = (best_height >= m_best_height);
+
+        auto batch = m_store.create_batch();
+
+        auto existing = m_store.list_keys(std::string(1, 'M'),
+                                          /*limit=*/100000);
+        for (const auto& k : existing) batch.remove(k);
+
+        for (const auto& [hash, state] : entries) {
+            auto key = make_entry_key(hash);
+            auto stream = ::pack(state);
+            auto sp = stream.get_span();
+            std::vector<uint8_t> data(
+                reinterpret_cast<const uint8_t*>(sp.data()),
+                reinterpret_cast<const uint8_t*>(sp.data()) + sp.size());
+            batch.put(key, data);
+        }
+
+        if (advance) {
+            batch.put(make_state_key(),
+                      encode_best_state(best_hash, best_height));
+        }
+
+        if (!batch.commit()) {
+            LOG_WARNING << "[MNS-DB] write_all batch commit failed";
+            return false;
+        }
+        if (advance) {
+            m_best_hash   = best_hash;
+            m_best_height = best_height;
+        }
+        return true;
+    }
+
+    bool clear()
+    {
+        auto batch = m_store.create_batch();
+        for (auto& k : m_store.list_keys(std::string(1, 'M'), 100000))
+            batch.remove(k);
+        batch.remove(make_state_key());
+        if (!batch.commit()) return false;
+        m_best_hash = uint256{};
+        m_best_height = 0;
+        LOG_INFO << "[MNS-DB] cleared";
+        return true;
+    }
+
+private:
+    ::core::LevelDBStore m_store;
+    uint256              m_best_hash;
+    uint32_t             m_best_height{0};
+
+    static std::string make_entry_key(const uint256& proRegTxHash)
+    {
+        std::string k;
+        k.reserve(33);
+        k.push_back('M');
+        k.append(reinterpret_cast<const char*>(proRegTxHash.data()), 32);
+        return k;
+    }
+
+    static std::string make_state_key() { return std::string(1, 'B'); }
+
+    static std::vector<uint8_t> encode_best_state(const uint256& hash,
+                                                  uint32_t height)
+    {
+        std::vector<uint8_t> out(36);
+        std::memcpy(out.data(), hash.data(), 32);
+        out[32] = static_cast<uint8_t>( height        & 0xFF);
+        out[33] = static_cast<uint8_t>((height >>  8) & 0xFF);
+        out[34] = static_cast<uint8_t>((height >> 16) & 0xFF);
+        out[35] = static_cast<uint8_t>((height >> 24) & 0xFF);
+        return out;
+    }
+
+    void load_best_state()
+    {
+        std::vector<uint8_t> data;
+        if (!m_store.get(make_state_key(), data) || data.size() < 36) {
+            return;
+        }
+        std::memcpy(m_best_hash.data(), data.data(), 32);
+        m_best_height = uint32_t(data[32])
+                      | (uint32_t(data[33]) <<  8)
+                      | (uint32_t(data[34]) << 16)
+                      | (uint32_t(data[35]) << 24);
+    }
+};
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/mn_state_machine.hpp
+++ b/src/impl/dash/coin/mn_state_machine.hpp
@@ -1,0 +1,668 @@
+#pragma once
+
+/// Phase C-PAY step 4: per-block DMN state machine.
+///
+/// Mirrors dashcore's evo/specialtxman.cpp::RebuildListFromBlock @ cfad414
+/// in the order-of-operations + the field-update semantics. This is the
+/// piece that turns the bootstrap state from step 3a/3b into a live,
+/// auto-maintained DMN list that step 5 can project payee selections
+/// against.
+///
+/// Apply order (matches dashcore exactly):
+///
+///   Pass 1 — special-tx records (skip coinbase, walk i=1+):
+///     PROVIDER_REGISTER (type 1):  AddMN with proRegTxHash = tx.GetHash()
+///         + collateralOutpoint resolution (null hash → tx's own output)
+///         + collateral-collision check (replaces an existing MN that
+///           shared the same external collateral outpoint)
+///     PROVIDER_UPDATE_SERVICE (type 2): netInfo + scriptOperatorPayout
+///         + Evo platform fields; PoSe-revive if MN was banned
+///     PROVIDER_UPDATE_REGISTRAR (type 3): pubKeyOperator + keyIDVoting
+///         + scriptPayout; if pubKeyOperator changed, ResetOperatorFields
+///         + BanIfNotBanned (until a ProUpServTx revives)
+///     PROVIDER_UPDATE_REVOKE (type 4): ResetOperatorFields + ban +
+///         nRevocationReason
+///
+///   Pass 2 — collateral spends (skip coinbase, walk i=1+):
+///     For each vin, check m_collateral_index; if matched, remove the MN.
+///     dashcore does this AFTER pass 1 so a brand-new MN registered THIS
+///     block can have its collateral spent in a later tx of the same
+///     block (rare but consensus-correct). We mirror.
+///
+///   Pass 3 — payee resolution (coinbase outputs):
+///     dashcore computes expected payee from PREV-block list before
+///     applying any tx; we OBSERVE actual coinbase outputs and find
+///     matches in our current list. Functionally equivalent for nodes
+///     processing accepted blocks (every accepted coinbase pays the
+///     dashcore-expected MN by definition).
+///     For each output that matches an MN's scriptPayout: set
+///     nLastPaidHeight = height; for Evo MNs, increment
+///     nConsecutivePayments if last payment was at height-1, else reset
+///     to 1.
+///
+/// Things we DELIBERATELY don't model (with consequence notes):
+///   - Confirmation pass (dashcore: nMasternodeMinimumConfirmations →
+///     confirmedHash). Phase L doesn't use confirmedHash; the SML
+///     already sync'd from the network has the correct confirmedHash
+///     equivalent baked in. Defer.
+///   - DecreaseScores (PoSe penalty decay). We don't track nPoSePenalty
+///     beyond storing the field. Phase C-PAY's projection algorithm
+///     doesn't read nPoSePenalty (only nPoSeBanHeight via isValid),
+///     so this is acceptable.
+///   - Quorum commitment processing inside per-block (Phase C-QUO's
+///     QuorumManager already handles this via the SML diff path,
+///     separately).
+///   - Operator-payout tracking (scriptOperatorPayout matches in
+///     coinbase). Smaller revenue stream; defer until consumer needs it.
+///   - PoSe ban via empty netInfo at registration (dashcore's
+///     BanIfNotBanned at line specialtxman.cpp:304). Edge case for
+///     newly-registered MNs that haven't yet sent a ProUpServTx; the
+///     net effect for projection is the same as nLastPaidHeight=0
+///     (they sort to the bottom of the payee queue).
+///
+/// Reorg story: the state machine is forward-only. On a chain reorg
+/// the caller (main_dash tip-changed handler) wipes mn_state_db AND
+/// calls load() with the empty vector, then re-bootstraps from the
+/// snapshot path; subsequent on_full_block calls re-apply forward
+/// from snapshot height.
+
+#include <impl/dash/coin/block.hpp>
+#include <impl/dash/coin/mn_state_db.hpp>
+#include <impl/dash/coin/vendor/providertx.hpp>
+#include <impl/dash/coin/vendor/simplifiedmns.hpp>
+#include <impl/bitcoin_family/coin/base_transaction.hpp>
+
+#include <core/hash.hpp>
+#include <core/log.hpp>
+#include <core/pack.hpp>
+#include <core/uint256.hpp>
+
+#include <cstdint>
+#include <cstring>
+#include <map>
+#include <optional>
+#include <span>
+#include <utility>
+#include <vector>
+
+namespace dash {
+namespace coin {
+
+// Strict weak ordering on TxPrevOut (uint256 + uint32) for std::map
+// keys. We use uint256 operator< (CompareTo, big-endian-integer
+// ordering) — the map is INTERNAL (never compared against dashcore
+// wire data), so any consistent ordering works. NOT the memcmp
+// ordering Bug A required for the SML merkle leaf sort.
+struct TxPrevOutLess {
+    bool operator()(const bitcoin_family::coin::TxPrevOut& a,
+                    const bitcoin_family::coin::TxPrevOut& b) const
+    {
+        if (a.hash != b.hash) return a.hash < b.hash;
+        return a.index < b.index;
+    }
+};
+
+class MnStateMachine
+{
+public:
+    struct ApplyResult {
+        size_t registered{0};
+        size_t updated{0};
+        size_t revoked{0};
+        size_t spent{0};       // collateral spent → MN removed
+        size_t paid{0};        // matched a coinbase output
+        size_t total_after{0};
+    };
+
+    void load(std::vector<std::pair<uint256, MNState>> entries)
+    {
+        m_entries.clear();
+        m_collateral_index.clear();
+        for (auto& [h, st] : entries) {
+            m_collateral_index[st.collateralOutpoint] = h;
+            m_entries.emplace(h, std::move(st));
+        }
+    }
+
+    size_t size() const { return m_entries.size(); }
+
+    const std::map<uint256, MNState>& entries() const { return m_entries; }
+
+    std::optional<uint256> find_by_collateral(
+        const bitcoin_family::coin::TxPrevOut& outpoint) const
+    {
+        auto it = m_collateral_index.find(outpoint);
+        if (it == m_collateral_index.end()) return std::nullopt;
+        return it->second;
+    }
+
+    // Linear scan over scriptPayout — used by pass 3 (payee resolution)
+    // and by Phase C-PAY step 5 (`[PAY]` log-only verification). At
+    // ~3000 active MNs and a typical 10-output coinbase that's ~30k
+    // memcmp comparisons per block (microseconds). Acceptable.
+    std::optional<uint256> find_by_payout_script(
+        const std::vector<unsigned char>& script) const
+    {
+        if (script.empty()) return std::nullopt;
+        for (const auto& [h, st] : m_entries) {
+            if (st.scriptPayout.m_data == script) return h;
+        }
+        return std::nullopt;
+    }
+
+    // Walk a block's coinbase outputs and return the FIRST output that
+    // matches a known MN's scriptPayout. Used by step 5 to cross-check
+    // projection vs observation. Returns nullopt if nothing matched
+    // (DMN state empty pre-bootstrap, OR coinbase paid an unknown
+    // address — e.g. superblock budget output).
+    std::optional<uint256> find_paid_in_block_first(
+        const dash::coin::BlockType& block) const
+    {
+        if (block.m_txs.empty()) return std::nullopt;
+        for (const auto& vout : block.m_txs[0].vout) {
+            // Use pick_paid_mn (lowest-h disambiguation) instead of
+            // find_by_payout_script (first-map-iteration), to mirror
+            // dashd's GetMNPayee selection when multiple MNs share a
+            // scriptPayout. MUST be called PRE-apply_block so the
+            // lowest-h MN is the one dashd actually paid; post-apply
+            // the just-paid MN has the highest h and would be missed.
+            if (auto m = pick_paid_mn(vout.scriptPubKey.m_data)) {
+                return m;
+            }
+        }
+        return std::nullopt;
+    }
+
+    // Selection-aware payee lookup (the fix for the shared-payoutAddress
+    // attribution bug). When N MNs map to the same scriptPayout, dashd's
+    // CDeterministicMNList::GetMNPayee picks the one with the lowest
+    // CompareByLastPaid_GetHeight. Mirror that here so apply_block
+    // attributes payments to the correct MN in our state, keeping us in
+    // sync with dashd's projection.
+    std::optional<uint256> pick_paid_mn(
+        const std::vector<unsigned char>& script) const
+    {
+        if (script.empty()) return std::nullopt;
+        constexpr uint32_t SENTINEL = std::numeric_limits<uint32_t>::max();
+        auto sane = [](uint32_t v) {
+            return (v == SENTINEL) ? 0u : v;
+        };
+        std::optional<uint256> best;
+        int best_h = std::numeric_limits<int>::max();
+        for (const auto& [hash, st] : m_entries) {
+            if (!st.isValid) continue;
+            if (st.scriptPayout.m_data != script) continue;
+            uint32_t lastPaid = sane(st.nLastPaidHeight);
+            uint32_t revived  = sane(st.nPoSeRevivedHeight);
+            int h = static_cast<int>(lastPaid);
+            if (revived != 0 && static_cast<int>(revived) > h) {
+                h = static_cast<int>(revived);
+            } else if (h == 0) {
+                h = static_cast<int>(st.nRegisteredHeight);
+            }
+            bool better = !best.has_value()
+                       || h < best_h
+                       || (h == best_h
+                           && std::memcmp(hash.data(),
+                                          best->data(), 32) < 0);
+            if (better) {
+                best_h = h;
+                best   = hash;
+            }
+        }
+        return best;
+    }
+
+    // Phase C-PAY step 5: vendor of dashcore
+    // CDeterministicMNList::GetMNPayee() @ cfad414 (deterministicmns.cpp:184).
+    //
+    // For Dash mainnet at height > 2,128,896 (MN_RR activation), the
+    // Evo 4-in-a-row bonus path is DEAD (`if isv19Active &&
+    // !isMNRewardReallocation` evaluates to false). All current and
+    // future blocks just use the standard CompareByLastPaid scan.
+    // c2pool-dash's header checkpoint is at h=2.4M so we always
+    // operate post-MN_RR — we omit the Evo bonus path with a TODO
+    // for testnet support pre-1,066,900.
+    //
+    // CompareByLastPaid_GetHeight (line 158-167):
+    //   h = nLastPaidHeight
+    //   if nPoSeRevivedHeight > h: h = nPoSeRevivedHeight
+    //   else if h == 0: h = nRegisteredHeight
+    //
+    // CompareByLastPaid (line 169-177):
+    //   ah == bh: tiebreak by proTxHash ascending
+    //   else:     ah < bh
+    //
+    // CRITICAL: tiebreaker uses dashcore's uint256 operator< which is
+    // memcmp(LE-byte) — NOT c2pool's CompareTo (BE-integer). Same
+    // gotcha as Bug A in vendor/simplifiedmns.hpp's sort. We use
+    // std::memcmp directly to match dashcore's wire semantics.
+    // Dump a MN's projection-relevant state (one-shot diagnostic).
+    void debug_dump_mn(const uint256& hash, const char* tag) const {
+        auto it = m_entries.find(hash);
+        if (it == m_entries.end()) {
+            LOG_INFO << "[MNS-DBG " << tag << "] hash=" << hash.GetHex().substr(0,16)
+                     << " NOT IN m_entries";
+            return;
+        }
+        const auto& s = it->second;
+        // Hex-dump scriptPayout for byte-level comparison vs coinbase outputs.
+        std::string sphex;
+        sphex.reserve(s.scriptPayout.m_data.size() * 2);
+        const char* hex = "0123456789abcdef";
+        for (auto b : s.scriptPayout.m_data) {
+            sphex.push_back(hex[(b >> 4) & 0xf]);
+            sphex.push_back(hex[b & 0xf]);
+        }
+        LOG_INFO << "[MNS-DBG " << tag << "] hash=" << hash.GetHex().substr(0,16)
+                 << " isValid=" << s.isValid
+                 << " nType=" << int(s.nType)
+                 << " lastPaid=" << s.nLastPaidHeight
+                 << " registered=" << s.nRegisteredHeight
+                 << " revived=" << s.nPoSeRevivedHeight
+                 << " banHeight=" << s.nPoSeBanHeight
+                 << " revoke=" << int(s.nRevocationReason)
+                 << " scriptPayout(" << s.scriptPayout.m_data.size() << ")=" << sphex;
+    }
+
+    std::optional<uint256> find_expected_payee() const
+    {
+        std::optional<uint256> best_hash;
+        int best_h = 0;
+        // Defensive: dashd's protx info JSON reports "lastPaidHeight": -1
+        // (and PoSeRevivedHeight: -1, PoSeBanHeight: -1) as sentinel for
+        // "never paid / never revived / never banned". Snapshots dumped by
+        // earlier c2pool versions stored those sentinels as UINT32_MAX
+        // (uint32_t wrap of int -1). When cast back to `int` for the
+        // CompareByLastPaid_GetHeight scoring, UINT32_MAX → -1, which beats
+        // every positive height — the lowest-proTxHash never-paid MN wins
+        // forever, producing a constant `expected` across all heights and
+        // a 100% [PAY] MISMATCH rate. Normalize here so a buggy in-tree
+        // snapshot still produces correct payee selection without re-dump.
+        constexpr uint32_t SENTINEL = std::numeric_limits<uint32_t>::max();
+        auto sane_height = [](uint32_t v) -> uint32_t {
+            return (v == SENTINEL) ? 0u : v;
+        };
+        for (const auto& [hash, st] : m_entries) {
+            if (!st.isValid) continue;
+            uint32_t lastPaid = sane_height(st.nLastPaidHeight);
+            uint32_t revived  = sane_height(st.nPoSeRevivedHeight);
+            int h = static_cast<int>(lastPaid);
+            if (revived != 0 && static_cast<int>(revived) > h) {
+                h = static_cast<int>(revived);
+            } else if (h == 0) {
+                h = static_cast<int>(st.nRegisteredHeight);
+            }
+            bool better = !best_hash.has_value()
+                       || h < best_h
+                       || (h == best_h
+                           && std::memcmp(hash.data(),
+                                          best_hash->data(), 32) < 0);
+            if (better) {
+                best_h    = h;
+                best_hash = hash;
+            }
+        }
+        return best_hash;
+    }
+
+    // Dump entire current state for persistence (mn_state_db.write_all).
+    std::vector<std::pair<uint256, MNState>> snapshot() const
+    {
+        std::vector<std::pair<uint256, MNState>> out;
+        out.reserve(m_entries.size());
+        for (const auto& [h, st] : m_entries) {
+            out.emplace_back(h, st);
+        }
+        return out;
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // sync_validity_from_sml — reconcile per-MN liveness from the SML
+    // ─────────────────────────────────────────────────────────────────
+    //
+    // Phase C-PAY Bug 12 fix (2026-05-03), extended by Bug 14 (2026-05-04).
+    //
+    // **Problem (Bug 12).** PoSe bans aren't tx-driven. Dash Core applies
+    // them via consensus rules (CDeterministicMNManager triggers a ban
+    // when an MN crosses MAX_PoSe_PENALTY from missed quorums). They
+    // never appear as a special tx in any block. So apply_block(), which
+    // walks special txs, can never observe them — the MN stays
+    // isValid=true in MnStateMachine forever after a real-world ban.
+    // find_expected_payee() then deterministically picks that phantom-
+    // eligible MN until manually re-snapshotted from RPC.
+    //
+    // **Problem (Bug 14).** The mirror class on the revive side: when an
+    // implicitly-banned MN is later revived by a ProUpServTx, the apply
+    // path's revival branch is gated on `nPoSeBanHeight != 0` (mirroring
+    // dashcore specialtxman.cpp:361-370). If we never observed the ban
+    // (Bug 12 territory), banHeight stays 0 and the gate fails — so
+    // nPoSeRevivedHeight stays at its OLD value. find_expected_payee
+    // uses max(nLastPaidHeight, nPoSeRevivedHeight) for queue position,
+    // so the MN keeps winning as oldest-unpaid until manually reseeded.
+    // Live-observed 2026-05-04: MN 13dcc4eb...4e8c, dashd
+    // PoSeRevivedHeight=2465346, our state revived=2396789 → 57+ [PAY]
+    // MISMATCH all with the same expected= over ~6 hours.
+    //
+    // **Fix.** The SML feed (Phase C-SML, mnlistdiff p2p messages,
+    // root-verified bit-exact against the coinbase's
+    // merkleRootMNList) carries the authoritative
+    // CSimplifiedMNListEntry::isValid for every active MN. After each
+    // successful root MATCH we project that view onto our m_entries.
+    // Bug 12 synced isValid alone; Bug 14 extends the contract to the
+    // full causally-coupled triple — see "Field-ownership contract"
+    // below.
+    //
+    // **Field-ownership contract** (post-Bug-14):
+    //   - SML owns the triple (isValid, nPoSeBanHeight, nPoSeRevivedHeight)
+    //     — they're causally one piece of state. SML's isValid is the
+    //     boolean projection of dashd's authoritative ban/revive epoch;
+    //     when SML flips it we update banHeight + revivedHeight
+    //     consistently using current_height as a conservative bound.
+    //   - this owns: nLastPaidHeight, nRegisteredHeight, scriptPayout,
+    //                collateralOutpoint, nType (timing + identity facets
+    //                that are tx-driven and reach us via apply_block)
+    //
+    // **Sync semantics** (per flip direction):
+    //   - false→true (revive): set nPoSeRevivedHeight = max(existing,
+    //     current_height) — monotonic, never rolls back; clear
+    //     nPoSeBanHeight = 0. After this, apply_block's ProUpServTx
+    //     revival branch becomes consistent: the next explicit ProUpServTx
+    //     (if any) is a no-op on these fields, not a stale-state trap.
+    //   - true→false (ban): set nPoSeBanHeight = current_height ONLY if
+    //     not already set (preserve apply_block's exact ban height when
+    //     known via tx; SML's view is approximate by ≤ diff cadence).
+    //
+    // **Why current_height is a safe bound.** SML diffs lag the chain
+    // tip by ≤ a small number of blocks (<= the diff request cadence).
+    // The actual ban/revive height ≤ current_height always. For the
+    // scheduler this means: revivedHeight may be slightly later than
+    // chain (worst case: MN gets pushed slightly further back in queue
+    // than dashd would — a transient under-payment of 1-2 blocks);
+    // banHeight may be slightly later (banned-window length metric is
+    // truncated, but ban itself is correctly observed). Both directions
+    // are strictly better than the pre-fix behavior of a stuck queue.
+    //
+    // Idempotent: safe to call after every SML root MATCH (live diff)
+    // and once at startup post-load_sml + post-load_into (catches any
+    // persisted divergence). O(|SML|) — ~3700 entries on Dash mainnet,
+    // microseconds.
+    struct SyncFromSmlResult {
+        size_t scanned{0};            // SML entries iterated
+        size_t matched{0};            // also present in m_entries
+        size_t flipped_to_invalid{0}; // m_entries[h].isValid: true → false
+        size_t flipped_to_valid{0};   // m_entries[h].isValid: false → true
+        size_t revived_height_set{0}; // Bug 14: nPoSeRevivedHeight
+                                      // bumped on a flip-to-valid
+        size_t ban_height_set{0};     // Bug 14: nPoSeBanHeight set
+                                      // on a flip-to-invalid (was 0)
+        size_t sml_only{0};           // SML had it, m_entries didn't —
+                                      // a no-op; apply_block will
+                                      // register on the next ProRegTx
+                                      // for this MN (or the next
+                                      // load() reseed from snapshot)
+    };
+    SyncFromSmlResult sync_validity_from_sml(
+        const vendor::CSimplifiedMNList& sml,
+        uint32_t current_height)
+    {
+        SyncFromSmlResult r;
+        for (const auto& sml_entry : sml.mnList) {
+            ++r.scanned;
+            auto it = m_entries.find(sml_entry.proRegTxHash);
+            if (it == m_entries.end()) {
+                ++r.sml_only;
+                continue;
+            }
+            ++r.matched;
+            if (it->second.isValid == sml_entry.isValid) continue;
+
+            // Flip detected — apply the (isValid, banHeight,
+            // revivedHeight) triple update atomically.
+            if (sml_entry.isValid) {
+                // false→true (revive): clear ban, bump revivedHeight
+                // monotonically. Whether the original ban was tx-driven
+                // (we observed it via apply_block's ProUpRevTx /
+                // ProUpRegTx-key-change branches) or implicit (Bug 12
+                // class — dashd's PoSePenalty consensus rule), the SML
+                // flipping back to valid is the authoritative signal
+                // that the MN is back. Setting revivedHeight here
+                // closes the apply_block-revival-gate hole (Bug 14
+                // class) for implicit revivals.
+                ++r.flipped_to_valid;
+                if (current_height > it->second.nPoSeRevivedHeight) {
+                    it->second.nPoSeRevivedHeight = current_height;
+                    ++r.revived_height_set;
+                }
+                it->second.nPoSeBanHeight = 0;
+            } else {
+                // true→false (ban): record banHeight only if we don't
+                // already have one. apply_block sets it precisely when
+                // the ban is tx-driven (ProUpRevTx, key-change in
+                // ProUpRegTx); SML's current_height is an upper bound
+                // for the implicit case. Don't clobber a precise
+                // height with our approximation.
+                ++r.flipped_to_invalid;
+                if (it->second.nPoSeBanHeight == 0) {
+                    it->second.nPoSeBanHeight = current_height;
+                    ++r.ban_height_set;
+                }
+            }
+            it->second.isValid = sml_entry.isValid;
+        }
+        return r;
+    }
+
+    // Process a single block. Mutates state per dashcore's
+    // RebuildListFromBlock algorithm. Returns counts for logging.
+    ApplyResult apply_block(const dash::coin::BlockType& block,
+                            uint32_t height)
+    {
+        ApplyResult r;
+
+        // ── Pass 1: special-tx records ─────────────────────────────
+        // Walk all non-coinbase txs (i=1+). The order of types within
+        // a block is whatever the miner included; dashcore handles
+        // them in tx-list order via the if/else-if chain.
+        for (size_t i = 1; i < block.m_txs.size(); ++i) {
+            const auto& tx = block.m_txs[i];
+            if (tx.type < 1 || tx.type > 4) continue;
+            if (tx.extra_payload.empty()) continue;
+            switch (tx.type) {
+              case 1: { // PROVIDER_REGISTER
+                vendor::CProRegTx ptx;
+                if (!vendor::parse_protx_payload(tx.extra_payload, ptx)) {
+                    LOG_WARNING << "[MNS-SM] CProRegTx parse failed h=" << height;
+                    break;
+                }
+                uint256 proRegTxHash = compute_tx_hash(tx);
+                MNState st;
+                st.nVersion          = ptx.nVersion;
+                st.nType             = ptx.nType;
+                st.nRegisteredHeight = height;
+                st.nLastPaidHeight   = 0;
+                st.isValid           = true;
+                // collateralOutpoint resolution: null hash means
+                // "this tx's own output at index N is the collateral".
+                if (ptx.collateralOutpoint.hash.IsNull()) {
+                    st.collateralOutpoint.hash  = proRegTxHash;
+                    st.collateralOutpoint.index = ptx.collateralOutpoint.index;
+                } else {
+                    st.collateralOutpoint = ptx.collateralOutpoint;
+                }
+                st.keyIDOwner        = ptx.keyIDOwner;
+                st.pubKeyOperator    = ptx.pubKeyOperator;
+                st.keyIDVoting       = ptx.keyIDVoting;
+                st.nOperatorReward   = ptx.nOperatorReward;
+                st.scriptPayout.m_data = ptx.scriptPayout.m_data;
+                st.netInfo           = ptx.netInfo;
+                if (ptx.nType == vendor::MnType::EVO) {
+                    st.platformNodeID    = ptx.platformNodeID;
+                    st.platformP2PPort   = ptx.platformP2PPort;
+                    st.platformHTTPPort  = ptx.platformHTTPPort;
+                }
+                // Replace any existing MN sharing the same collateral
+                // outpoint (external-collateral re-registration case
+                // — dashcore specialtxman.cpp:267-279).
+                auto coll_it = m_collateral_index.find(st.collateralOutpoint);
+                if (coll_it != m_collateral_index.end()) {
+                    m_entries.erase(coll_it->second);
+                    m_collateral_index.erase(coll_it);
+                }
+                m_collateral_index[st.collateralOutpoint] = proRegTxHash;
+                m_entries.emplace(proRegTxHash, std::move(st));
+                ++r.registered;
+                break;
+              }
+              case 2: { // PROVIDER_UPDATE_SERVICE
+                vendor::CProUpServTx ptx;
+                if (!vendor::parse_protx_payload(tx.extra_payload, ptx)) {
+                    LOG_WARNING << "[MNS-SM] CProUpServTx parse failed h=" << height;
+                    break;
+                }
+                auto it = m_entries.find(ptx.proTxHash);
+                if (it == m_entries.end()) break; // unknown MN
+                it->second.netInfo = ptx.netInfo;
+                it->second.scriptOperatorPayout.m_data =
+                    ptx.scriptOperatorPayout.m_data;
+                if (ptx.nType == vendor::MnType::EVO) {
+                    it->second.platformNodeID = ptx.platformNodeID;
+                    if (ptx.nVersion < vendor::ProTxVersion::EXT_ADDR) {
+                        it->second.platformP2PPort  = ptx.platformP2PPort;
+                        it->second.platformHTTPPort = ptx.platformHTTPPort;
+                    }
+                }
+                // PoSe revive (dashcore specialtxman.cpp:361-370).
+                if (it->second.nPoSeBanHeight != 0) {
+                    it->second.nPoSeBanHeight   = 0;
+                    it->second.nPoSeRevivedHeight = height;
+                    it->second.isValid          = true;
+                }
+                ++r.updated;
+                break;
+              }
+              case 3: { // PROVIDER_UPDATE_REGISTRAR
+                vendor::CProUpRegTx ptx;
+                if (!vendor::parse_protx_payload(tx.extra_payload, ptx)) {
+                    LOG_WARNING << "[MNS-SM] CProUpRegTx parse failed h=" << height;
+                    break;
+                }
+                auto it = m_entries.find(ptx.proTxHash);
+                if (it == m_entries.end()) break;
+                bool key_changed = (it->second.pubKeyOperator
+                                  != ptx.pubKeyOperator);
+                it->second.pubKeyOperator   = ptx.pubKeyOperator;
+                it->second.keyIDVoting      = ptx.keyIDVoting;
+                it->second.scriptPayout.m_data = ptx.scriptPayout.m_data;
+                if (key_changed) {
+                    // dashcore: ResetOperatorFields + BanIfNotBanned.
+                    it->second.nPoSeBanHeight = height;
+                    it->second.isValid        = false;
+                }
+                ++r.updated;
+                break;
+              }
+              case 4: { // PROVIDER_UPDATE_REVOKE
+                vendor::CProUpRevTx ptx;
+                if (!vendor::parse_protx_payload(tx.extra_payload, ptx)) {
+                    LOG_WARNING << "[MNS-SM] CProUpRevTx parse failed h=" << height;
+                    break;
+                }
+                auto it = m_entries.find(ptx.proTxHash);
+                if (it == m_entries.end()) break;
+                it->second.nPoSeBanHeight   = height;
+                it->second.isValid          = false;
+                it->second.nRevocationReason = ptx.nReason;
+                // Operator key reset (until a future ProUpServTx
+                // provides a new operator key + revives).
+                it->second.pubKeyOperator.fill(0);
+                ++r.revoked;
+                break;
+              }
+            }
+        }
+
+        // ── Pass 2: collateral spends ──────────────────────────────
+        // Walk all non-coinbase txs again; for each vin, check if it
+        // spends a known MN's collateral. dashcore does this AFTER
+        // pass 1 — we mirror.
+        for (size_t i = 1; i < block.m_txs.size(); ++i) {
+            const auto& tx = block.m_txs[i];
+            for (const auto& in : tx.vin) {
+                auto it = m_collateral_index.find(in.prevout);
+                if (it == m_collateral_index.end()) continue;
+                m_entries.erase(it->second);
+                m_collateral_index.erase(it);
+                ++r.spent;
+            }
+        }
+
+        // ── Pass 3: payee resolution ──────────────────────────────
+        // BUG FIX 2026-04-25: multiple MNs can share the same payoutAddress
+        // (operators running multiple MNs to one wallet). The original
+        // find_by_payout_script returned the FIRST map-iteration match,
+        // which deterministically attributed ALL payments to whichever
+        // MN had the lowest proRegTxHash bytes. Net effect: for each
+        // shared-script payment dashd correctly attributed to one MN,
+        // we'd attribute it to the OTHER one — leaving the actual paid
+        // MN's nLastPaidHeight stale forever. Live-observed: MN
+        // 7173b6a9... and 06a9ee24... both pay address
+        // XjbaGWaGnvEtuQAUoBgDxJWe8ZNv45upG2; we kept giving 06a9ee24
+        // every payment, so 7173b6a9 stayed at lastPaid=2458528 → kept
+        // winning find_expected_payee → 100% [PAY] MISMATCH against
+        // dashd which correctly rotated the two.
+        //
+        // Fix: when multiple MNs share a script, use pick_paid_mn (defined
+        // above) which mirrors dashd's CompareByLastPaid_GetHeight ordering.
+        if (!block.m_txs.empty()) {
+            const auto& cb = block.m_txs[0];
+            for (const auto& vout : cb.vout) {
+                auto matched = pick_paid_mn(vout.scriptPubKey.m_data);
+                if (!matched) continue;
+                auto it = m_entries.find(*matched);
+                if (it == m_entries.end()) continue;
+                // Idempotency safety net: never roll lastPaidHeight backwards.
+                // Defense-in-depth against any future caller bypassing the
+                // outer OOO guard (main_dash.cpp's `already_in_state` check).
+                // Without this, an out-of-order h<current re-apply would have
+                // bumped lastPaid backwards — the original 03fa0aa1 bug class.
+                if (height <= it->second.nLastPaidHeight) continue;
+                bool was_consecutive = (it->second.nLastPaidHeight == height - 1);
+                it->second.nLastPaidHeight = height;
+                if (it->second.nType == vendor::MnType::EVO) {
+                    it->second.nConsecutivePayments =
+                        was_consecutive ? it->second.nConsecutivePayments + 1 : 1;
+                } else {
+                    it->second.nConsecutivePayments = 0;
+                }
+                ++r.paid;
+            }
+        }
+
+        r.total_after = m_entries.size();
+        return r;
+    }
+
+private:
+    std::map<uint256, MNState>                                          m_entries;
+    std::map<bitcoin_family::coin::TxPrevOut, uint256, TxPrevOutLess>   m_collateral_index;
+
+    // Compute a tx's identifying hash. Mirrors dashcore's
+    // CTransaction::GetHash() which is SHA256d(serialized_tx).
+    // Dash has no segwit so there's no witness/non-witness distinction.
+    static uint256 compute_tx_hash(const MutableTransaction& tx)
+    {
+        ::PackStream s;
+        s << tx;
+        auto sp = s.get_span();
+        uint256 h;
+        CHash256()
+            .Write(std::span<const unsigned char>(
+                reinterpret_cast<const unsigned char*>(sp.data()), sp.size()))
+            .Finalize(std::span<unsigned char>(h.data(), 32));
+        return h;
+    }
+};
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/vendor/providertx.hpp
+++ b/src/impl/dash/coin/vendor/providertx.hpp
@@ -1,0 +1,374 @@
+#pragma once
+
+// Vendored from dashcore/src/evo/providertx.{h,cpp} @ develop cfad414
+// (Dash Core v23.1-dev). Phase C-PAY step 1 (foundation).
+//
+// First credible step toward full Dash Core RPC independence: parse
+// the four ProTx variants out of the special-tx extra_payload so we
+// can build our own DMN state machine instead of querying dashd's
+// `protx list`. The Simplified MN List we already sync (DIP-0004)
+// is a SUBSET that omits scriptPayout / nLastPaidHeight / etc. —
+// see the/docs/c2pool-dash-phase-c-pay-design.md.
+//
+// THIS COMMIT IS DATA-LAYER ONLY. No state-machine wiring yet; a
+// follow-up commit will land mn_state_db + on_full_block scanning.
+//
+// Adaptations from upstream (mirroring simplifiedmns.hpp's pattern):
+//
+//   1. Wire-format mode is hard-coded to "current Dash mainnet at our
+//      advertised proto version (70230)". Specifically: the upstream
+//      "if nVersion unknown, bail out early" branch is dropped — we
+//      assume a parseable nVersion in {1=LegacyBLS, 2=BasicBLS}. ProTx
+//      records with nVersion >= 3 (ExtAddr / DIP-0028) need
+//      DEPLOYMENT_V24 (EHF) which has not activated on mainnet; if
+//      we ever see one we log+drop (the parse will fail at the
+//      NetInfo step because we don't support MnNetInfo yet).
+//
+//   2. `MnType` (Consensus enum, uint8 underlying) → raw uint8 with
+//      named constexpr TYPE_REGULAR / TYPE_EVO values.
+//
+//   3. `NetInfoInterface` / `NetInfoSerWrapper` is replaced by an
+//      inline 18-byte legacy CService (16-byte raw IPv6 + 2-byte BE
+//      port). MnNetInfo (multi-addr) NOT supported yet — same as
+//      simplifiedmns.hpp's approach. Re-vendor with NetInfo support
+//      once DEPLOYMENT_V24 activates.
+//
+//   4. `CBLSLazyPublicKey` → 48-byte std::array. `CBLSSignature` →
+//      96-byte std::array. The legacy/basic curve-scheme flag
+//      doesn't change wire byte count; it only affects how the impl
+//      decompresses the curve point, which we never do at the parse
+//      layer (Phase L's verifier handles that).
+//
+//   5. `CKeyID` = uint160. `COutPoint` = bitcoin_family::coin::TxPrevOut.
+//      `CScript` = core::OPScript (vector<u8>-style with CompactSize
+//      length prefix on the wire — bit-identical to dashcore's CScript).
+//
+//   6. `IsTriviallyValid()` / `ToString()` / `ToJson()` / `GetJsonHelp()`
+//      methods NOT vendored — they need ChainstateManager, CBlockIndex,
+//      and RPC infrastructure we don't have. The state-machine consumer
+//      will do its own validity checks against our header chain.
+//
+//   7. `vchSig` (collateral key signature on CProRegTx, also on
+//      CProUpRegTx) is preserved on the wire but not verified — that
+//      verification needs the collateral output's pubkey from our
+//      UTXO state. Phase C-PAY step 3 (state machine) decides whether
+//      to gate state updates on signature verify; for the parse layer
+//      we just round-trip the bytes.
+//
+//   8. The SER_GETHASH path (used by dashcore for txid computation
+//      via inputsHash) skips the trailing signature. Our state machine
+//      identifies ProTx by the *transaction's* hash (vendor txid), not
+//      the payload hash, so this distinction doesn't matter to us.
+
+#include <impl/dash/coin/vendor/shim.hpp>
+
+#include <core/uint256.hpp>
+#include <core/pack.hpp>
+#include <core/pack_types.hpp>
+#include <core/opscript.hpp>
+#include <impl/bitcoin_family/coin/base_transaction.hpp>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <span>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace dash {
+namespace coin {
+namespace vendor {
+
+// MnType from dashcore consensus/params.h (uint8_t underlying)
+namespace MnType {
+    inline constexpr uint8_t REGULAR = 0;
+    inline constexpr uint8_t EVO     = 1;
+}
+
+// ProTxVersion (matches dashcore evo/providertx.h ProTxVersion namespace)
+namespace ProTxVersion {
+    inline constexpr uint16_t LEGACY_BLS = 1;
+    inline constexpr uint16_t BASIC_BLS  = 2;
+    inline constexpr uint16_t EXT_ADDR   = 3;
+}
+
+inline constexpr size_t BLS_PUBKEY_SIZE = 48;
+inline constexpr size_t BLS_SIG_SIZE    = 96;
+inline constexpr size_t NETADDR_SIZE    = 16;
+
+// Legacy 18-byte CService inline-serializer. See landmine note in
+// simplifiedmns.hpp for the same pattern.
+struct LegacyNetService
+{
+    std::array<uint8_t, NETADDR_SIZE> ip{};
+    uint16_t                          port_be{0};
+
+    template <typename Stream>
+    void Serialize(Stream& s) const
+    {
+        s.write(std::as_bytes(std::span{ip}));
+        uint8_t pb[2] = {
+            static_cast<uint8_t>((port_be >> 8) & 0xff),
+            static_cast<uint8_t>(port_be & 0xff)
+        };
+        s.write(std::as_bytes(std::span{pb}));
+    }
+
+    template <typename Stream>
+    void Unserialize(Stream& s)
+    {
+        std::array<uint8_t, NETADDR_SIZE> raw{};
+        s.read(std::as_writable_bytes(std::span{raw}));
+        ip = raw;
+        uint8_t pb[2];
+        s.read(std::as_writable_bytes(std::span{pb}));
+        port_be = (uint16_t(pb[0]) << 8) | uint16_t(pb[1]);
+    }
+};
+
+// ── CProRegTx ─────────────────────────────────────────────────────────────
+// Type 1. Registers a new masternode. Provides:
+//   - scriptPayout (where MN reward goes — mutable later via ProUpRegTx)
+//   - keyIDOwner / keyIDVoting / pubKeyOperator (governance + signing)
+//   - collateralOutpoint (the 1000 / 4000 DASH lock)
+//   - nType (Regular vs Evo)
+//   - For Evo: platformNodeID + ports (HTTP for DAPI, P2P for masternode net)
+
+struct CProRegTx
+{
+    static constexpr uint16_t SPECIALTX_TYPE = 1;
+
+    uint16_t                           nVersion{ProTxVersion::BASIC_BLS};
+    // dashcore wire format has nType as uint16_t (LE), NOT uint8_t. The
+    // narrower read silently shifted every subsequent field by 1 byte,
+    // which:
+    //   - For REGULAR (nType=0): coincidentally aligned because the 0x00
+    //     high byte of nType and the 0x00 low byte of nMode both happen
+    //     to be zero, so nType+nMode read the right values — BUT
+    //     collateralOutpoint then started 1 byte early and was garbage.
+    //     Effect: registered EVO MNs got wrong collateralOutpoint →
+    //     m_collateral_index entries point at non-existent outpoints,
+    //     so collateral-spend detection misses them.
+    //   - For EVO (nType=1): same shift, garbage collateral.
+    // Bug 13 root cause when paired with the same fix on CProUpServTx.
+    uint16_t                           nType{MnType::REGULAR};
+    uint16_t                           nMode{0};
+    bitcoin_family::coin::TxPrevOut    collateralOutpoint;
+    LegacyNetService                   netInfo;
+    uint160                            keyIDOwner;
+    std::array<uint8_t, BLS_PUBKEY_SIZE> pubKeyOperator{};
+    uint160                            keyIDVoting;
+    uint16_t                           nOperatorReward{0};
+    OPScript                           scriptPayout;
+    uint256                            inputsHash;
+    std::vector<uint8_t>               vchSig;
+    // Evo-only (gated on nType == EVO):
+    uint160                            platformNodeID;
+    uint16_t                           platformP2PPort{0};
+    uint16_t                           platformHTTPPort{0};
+
+    C2POOL_SERIALIZE_METHODS(CProRegTx)
+    {
+        READWRITE(obj.nVersion);
+        // We DROP dashcore's "if (nVersion == 0 || nVersion > GetMax())
+        // bail out early" — see preamble adaptation #1.
+        READWRITE(obj.nType,
+                  obj.nMode,
+                  obj.collateralOutpoint,
+                  obj.netInfo,
+                  obj.keyIDOwner,
+                  Using<RawBytesFormat<BLS_PUBKEY_SIZE>>(obj.pubKeyOperator),
+                  obj.keyIDVoting,
+                  obj.nOperatorReward,
+                  obj.scriptPayout,
+                  obj.inputsHash);
+        if (obj.nType == MnType::EVO) {
+            READWRITE(obj.platformNodeID);
+            if (obj.nVersion < ProTxVersion::EXT_ADDR) {
+                READWRITE(Using<BigEndianFormat<2>>(obj.platformP2PPort),
+                          Using<BigEndianFormat<2>>(obj.platformHTTPPort));
+            }
+        }
+        READWRITE(obj.vchSig);
+    }
+
+    std::string short_str() const
+    {
+        std::ostringstream os;
+        os << "CProRegTx{v" << nVersion
+           << " t" << int(nType)
+           << " collat=" << collateralOutpoint.hash.GetHex().substr(0, 12)
+           << ":" << collateralOutpoint.index
+           << " payout=" << scriptPayout.m_data.size() << "B"
+           << "}";
+        return os.str();
+    }
+};
+
+// ── CProUpServTx ──────────────────────────────────────────────────────────
+// Type 2. Updates a MN's network info + (Evo) operator-payout script.
+// Service updates are how a MN signals "I moved to a new IP".
+
+struct CProUpServTx
+{
+    static constexpr uint16_t SPECIALTX_TYPE = 2;
+
+    uint16_t              nVersion{ProTxVersion::BASIC_BLS};
+    // dashcore wire format has nType as uint16_t (LE), NOT uint8_t.
+    // The narrower read shifted proTxHash + every subsequent field by
+    // 1 byte for v2+ (BASIC_BLS) ProUpServTxs. Effect: parse_protx_payload
+    // failed (read past end of payload) for EVO updates AND parsed
+    // garbage proTxHash for REGULAR updates. Live-observed via 6+
+    // [MNS-SM] CProUpServTx parse failed warnings 2026-04-26..05-03,
+    // including h=2462994 — the missed PoSe revival of MN
+    // 788707b3...80f4 that produced 1858 [PAY] MISMATCH events
+    // before Bug 12's SML sync masked the symptom. Bug 13 root cause.
+    uint16_t              nType{MnType::REGULAR};
+    uint256               proTxHash;
+    LegacyNetService      netInfo;
+    OPScript              scriptOperatorPayout;
+    uint256               inputsHash;
+    std::array<uint8_t, BLS_SIG_SIZE> sig{};
+    // Evo-only:
+    uint160               platformNodeID;
+    uint16_t              platformP2PPort{0};
+    uint16_t              platformHTTPPort{0};
+
+    C2POOL_SERIALIZE_METHODS(CProUpServTx)
+    {
+        READWRITE(obj.nVersion);
+        if (obj.nVersion >= ProTxVersion::BASIC_BLS) {
+            READWRITE(obj.nType);
+        }
+        READWRITE(obj.proTxHash,
+                  obj.netInfo,
+                  obj.scriptOperatorPayout,
+                  obj.inputsHash);
+        if (obj.nType == MnType::EVO) {
+            READWRITE(obj.platformNodeID);
+            if (obj.nVersion < ProTxVersion::EXT_ADDR) {
+                READWRITE(Using<BigEndianFormat<2>>(obj.platformP2PPort),
+                          Using<BigEndianFormat<2>>(obj.platformHTTPPort));
+            }
+        }
+        READWRITE(Using<RawBytesFormat<BLS_SIG_SIZE>>(obj.sig));
+    }
+
+    std::string short_str() const
+    {
+        std::ostringstream os;
+        os << "CProUpServTx{v" << nVersion
+           << " t" << int(nType)
+           << " pro=" << proTxHash.GetHex().substr(0, 12)
+           << "}";
+        return os.str();
+    }
+};
+
+// ── CProUpRegTx ───────────────────────────────────────────────────────────
+// Type 3. Updates a MN's operator pubkey, voting keyID, and/or payout
+// script. This is how a MN can rotate its operator key without losing
+// its registration (and thus its nLastPaidHeight history).
+
+struct CProUpRegTx
+{
+    static constexpr uint16_t SPECIALTX_TYPE = 3;
+
+    uint16_t                             nVersion{ProTxVersion::BASIC_BLS};
+    uint256                              proTxHash;
+    uint16_t                             nMode{0};
+    std::array<uint8_t, BLS_PUBKEY_SIZE> pubKeyOperator{};
+    uint160                              keyIDVoting;
+    OPScript                             scriptPayout;
+    uint256                              inputsHash;
+    std::vector<uint8_t>                 vchSig;
+
+    C2POOL_SERIALIZE_METHODS(CProUpRegTx)
+    {
+        READWRITE(obj.nVersion,
+                  obj.proTxHash,
+                  obj.nMode,
+                  Using<RawBytesFormat<BLS_PUBKEY_SIZE>>(obj.pubKeyOperator),
+                  obj.keyIDVoting,
+                  obj.scriptPayout,
+                  obj.inputsHash,
+                  obj.vchSig);
+    }
+
+    std::string short_str() const
+    {
+        std::ostringstream os;
+        os << "CProUpRegTx{v" << nVersion
+           << " pro=" << proTxHash.GetHex().substr(0, 12)
+           << " new_payout=" << scriptPayout.m_data.size() << "B"
+           << "}";
+        return os.str();
+    }
+};
+
+// ── CProUpRevTx ───────────────────────────────────────────────────────────
+// Type 4. Revokes a MN. The MN is removed from the active set + a new
+// operator key is required for re-activation. Used by MN owners to
+// signal compromised keys / change of service.
+
+struct CProUpRevTx
+{
+    static constexpr uint16_t SPECIALTX_TYPE = 4;
+
+    static constexpr uint16_t REASON_NOT_SPECIFIED         = 0;
+    static constexpr uint16_t REASON_TERMINATION_OF_SERVICE = 1;
+    static constexpr uint16_t REASON_COMPROMISED_KEYS      = 2;
+    static constexpr uint16_t REASON_CHANGE_OF_KEYS        = 3;
+
+    uint16_t                          nVersion{ProTxVersion::BASIC_BLS};
+    uint256                           proTxHash;
+    uint16_t                          nReason{REASON_NOT_SPECIFIED};
+    uint256                           inputsHash;
+    std::array<uint8_t, BLS_SIG_SIZE> sig{};
+
+    C2POOL_SERIALIZE_METHODS(CProUpRevTx)
+    {
+        READWRITE(obj.nVersion,
+                  obj.proTxHash,
+                  obj.nReason,
+                  obj.inputsHash,
+                  Using<RawBytesFormat<BLS_SIG_SIZE>>(obj.sig));
+    }
+
+    std::string short_str() const
+    {
+        std::ostringstream os;
+        os << "CProUpRevTx{v" << nVersion
+           << " pro=" << proTxHash.GetHex().substr(0, 12)
+           << " reason=" << nReason
+           << "}";
+        return os.str();
+    }
+};
+
+// ── Generic helper ────────────────────────────────────────────────────────
+// Parse a ProTx payload. Returns true on success (payload fully consumed),
+// false on any deserialization error or trailing garbage. Caller checks
+// tx.type to know which variant to attempt.
+
+template <typename T>
+inline bool parse_protx_payload(const std::vector<uint8_t>& payload, T& out)
+{
+    if (payload.empty()) return false;
+    try {
+        ::PackStream s(payload);
+        s >> out;
+        // Successful parse must consume the entire payload — trailing
+        // bytes indicate either malformed input or a wire-format change
+        // we haven't caught up to.
+        return s.empty();
+    } catch (const std::exception&) {
+        return false;
+    }
+}
+
+} // namespace vendor
+} // namespace coin
+} // namespace dash

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -323,6 +323,22 @@ if (BUILD_TESTING AND GTest_FOUND)
     target_link_libraries(test_dash_quorum_root PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
     gtest_add_tests(test_dash_quorum_root "" AUTO)
 
+    # DASH masternode state-machine (S7 leaf): vendored ProTx wire
+    # (providertx.hpp) + MNState persistence (mn_state_db.hpp) +
+    # apply_block RebuildListFromBlock + find_expected_payee / pick_paid_mn
+    # over the SimplifiedMNList leaf (#309). Last absent header before the
+    # embedded_gbt capstone. Header-only over core/uint256 + core/pack +
+    # core/hash; no ltc/pool SCC dependency.
+    add_executable(test_dash_mn_state test_dash_mn_state.cpp)
+    target_link_libraries(test_dash_mn_state PRIVATE
+        GTest::gtest_main GTest::gtest
+        dash_x11 core
+        nlohmann_json::nlohmann_json
+        ${Boost_LIBRARIES}
+    )
+    target_link_libraries(test_dash_mn_state PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
+    gtest_add_tests(test_dash_mn_state "" AUTO)
+
     add_executable(test_compact_blocks test_compact_blocks.cpp)
     target_link_libraries(test_compact_blocks PRIVATE
         GTest::gtest_main GTest::gtest

--- a/test/test_dash_mn_state.cpp
+++ b/test/test_dash_mn_state.cpp
@@ -1,0 +1,722 @@
+/// Phase C-PAY (S7 mn_state_machine leaf) — Dash masternode state-machine
+/// unit tests.
+///
+/// Exercises the three vendored / derived components that turn the
+/// SimplifiedMNList leaf (#309) into a live, auto-maintained DMN list the
+/// embedded_gbt payee projection consumes:
+///
+///   - vendor/providertx.hpp : CProRegTx / CProUpServTx / CProUpRegTx /
+///     CProUpRevTx wire (de)serialization + nVersion/nType field gating +
+///     parse_protx_payload full-consume / trailing-garbage rejection.
+///   - mn_state_db.hpp : MNState internal persistence wire round-trip.
+///   - mn_state_machine.hpp : apply_block RebuildListFromBlock semantics
+///     (register / update-service / update-registrar / revoke / collateral
+///     spend / payee resolution), find_expected_payee +
+///     pick_paid_mn memcmp tiebreak, and sync_validity_from_sml.
+///
+/// KAT philosophy (mirrors test_dash_simplifiedmns.cpp): every assertion is
+/// either a structural round-trip (serialize -> deserialize -> EQ), a
+/// bit-exact preimage rebuilt independently and double-SHA256d, or a
+/// self-consistency property of the algorithm. No "expected" hashes are
+/// fabricated.
+///
+/// SCOPE NOTE (honest): the end-to-end cross-check — "apply_block over a
+/// REAL Dash mainnet block produces the SAME per-MN nLastPaidHeight /
+/// find_expected_payee as dashd protx list" — requires a live Dash node
+/// oracle (mnlistdiff + a real special-tx-bearing block) and is deferred to
+/// the embedded_gbt integration leaf. It is NOT claimed here. The
+/// compute_tx_hash KAT below asserts the SHA256d-of-serialized-tx property
+/// is self-consistent and stable, not equality with a dashd-reported txid
+/// (which would need the node oracle).
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/mn_state_machine.hpp>
+#include <impl/dash/coin/mn_state_db.hpp>
+#include <impl/dash/coin/vendor/providertx.hpp>
+#include <impl/dash/coin/vendor/simplifiedmns.hpp>
+#include <impl/dash/coin/transaction.hpp>
+#include <impl/dash/coin/block.hpp>
+
+#include <core/uint256.hpp>
+#include <core/pack.hpp>
+#include <core/hash.hpp>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+using dash::coin::MNState;
+using dash::coin::MnStateMachine;
+using dash::coin::BlockType;
+using dash::coin::MutableTransaction;
+using dash::coin::vendor::CProRegTx;
+using dash::coin::vendor::CProUpServTx;
+using dash::coin::vendor::CProUpRegTx;
+using dash::coin::vendor::CProUpRevTx;
+using dash::coin::vendor::CSimplifiedMNList;
+using dash::coin::vendor::CSimplifiedMNListEntry;
+namespace ProTxVersion = dash::coin::vendor::ProTxVersion;
+namespace MnType = dash::coin::vendor::MnType;
+using dash::coin::vendor::parse_protx_payload;
+using bitcoin_family::coin::TxPrevOut;
+using bitcoin_family::coin::TxIn;
+using bitcoin_family::coin::TxOut;
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+static uint256 raw256(uint8_t base) {
+    uint256 h;
+    std::array<uint8_t, 32> p{};
+    for (size_t i = 0; i < 32; ++i) p[i] = static_cast<uint8_t>(base + i);
+    std::memcpy(h.data(), p.data(), 32);
+    return h;
+}
+
+static uint256 raw256_byte(size_t idx, uint8_t val) {
+    uint256 h;
+    std::array<uint8_t, 32> p{};
+    p[idx] = val;
+    std::memcpy(h.data(), p.data(), 32);
+    return h;
+}
+
+static uint160 raw160(uint8_t base) {
+    uint160 h;
+    std::array<uint8_t, 20> p{};
+    for (size_t i = 0; i < 20; ++i) p[i] = static_cast<uint8_t>(base + i);
+    std::memcpy(h.data(), p.data(), 20);
+    return h;
+}
+
+template <size_t N>
+static std::array<uint8_t, N> seq_array(uint8_t base) {
+    std::array<uint8_t, N> a{};
+    for (size_t i = 0; i < N; ++i) a[i] = static_cast<uint8_t>(base + i);
+    return a;
+}
+
+// generic round-trip: pack(in) then >> into a fresh out; reports wire len.
+template <typename T>
+static T roundtrip(const T& in, size_t* wire_len) {
+    auto ps = ::pack(in);
+    if (wire_len) *wire_len = ps.size();
+    T out;
+    ps >> out;
+    return out;
+}
+
+// a 33-output coinbase-style script pattern (opaque bytes; the machine only
+// memcmp-compares m_data, never interprets it).
+static std::vector<unsigned char> script_bytes(uint8_t tag, size_t n = 25) {
+    std::vector<unsigned char> v(n);
+    for (size_t i = 0; i < n; ++i) v[i] = static_cast<unsigned char>(tag + i);
+    return v;
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// ProTx wire round-trips + field gating
+// ════════════════════════════════════════════════════════════════════════
+
+static CProRegTx make_proreg(uint16_t nVersion, uint16_t nType) {
+    CProRegTx p;
+    p.nVersion = nVersion;
+    p.nType = nType;
+    p.nMode = 0;
+    p.collateralOutpoint.hash = raw256(0x10);
+    p.collateralOutpoint.index = 7;
+    p.netInfo.ip = seq_array<16>(0x20);
+    p.netInfo.port_be = 0x2334;            // 9011
+    p.keyIDOwner = raw160(0x30);
+    p.pubKeyOperator = seq_array<48>(0x40);
+    p.keyIDVoting = raw160(0x50);
+    p.nOperatorReward = 250;
+    p.scriptPayout.m_data = script_bytes(0x76, 25);
+    p.inputsHash = raw256(0x60);
+    p.vchSig = {0xde, 0xad, 0xbe, 0xef};
+    if (nType == MnType::EVO) {
+        p.platformNodeID = raw160(0x70);
+        p.platformP2PPort = 0x6f4c;        // 28492
+        p.platformHTTPPort = 0x6f4d;
+    }
+    return p;
+}
+
+TEST(DashMnState, ProRegTxRoundTripRegular) {
+    auto p = make_proreg(ProTxVersion::BASIC_BLS, MnType::REGULAR);
+    size_t len = 0;
+    auto out = roundtrip(p, &len);
+    EXPECT_EQ(out.nVersion, p.nVersion);
+    EXPECT_EQ(out.nType, p.nType);
+    EXPECT_EQ(out.collateralOutpoint.hash, p.collateralOutpoint.hash);
+    EXPECT_EQ(out.collateralOutpoint.index, p.collateralOutpoint.index);
+    EXPECT_EQ(out.netInfo.ip, p.netInfo.ip);
+    EXPECT_EQ(out.netInfo.port_be, p.netInfo.port_be);
+    EXPECT_EQ(out.keyIDOwner, p.keyIDOwner);
+    EXPECT_EQ(out.pubKeyOperator, p.pubKeyOperator);
+    EXPECT_EQ(out.keyIDVoting, p.keyIDVoting);
+    EXPECT_EQ(out.nOperatorReward, p.nOperatorReward);
+    EXPECT_EQ(out.scriptPayout.m_data, p.scriptPayout.m_data);
+    EXPECT_EQ(out.inputsHash, p.inputsHash);
+    EXPECT_EQ(out.vchSig, p.vchSig);
+}
+
+TEST(DashMnState, ProRegTxRoundTripEvoCarriesPlatformFields) {
+    auto p = make_proreg(ProTxVersion::BASIC_BLS, MnType::EVO);
+    size_t len_evo = 0, len_reg = 0;
+    auto out = roundtrip(p, &len_evo);
+    EXPECT_EQ(out.platformNodeID, p.platformNodeID);
+    EXPECT_EQ(out.platformP2PPort, p.platformP2PPort);
+    EXPECT_EQ(out.platformHTTPPort, p.platformHTTPPort);
+    // EVO wire is strictly longer than REGULAR (platformNodeID(20) +
+    // 2 BE ports(4) = +24 bytes); proves the nType==EVO gate fired.
+    auto preg = make_proreg(ProTxVersion::BASIC_BLS, MnType::REGULAR);
+    (void)roundtrip(preg, &len_reg);
+    EXPECT_EQ(len_evo, len_reg + 24u);
+}
+
+TEST(DashMnState, ProRegTxEmptyScriptAndSigKnownLength) {
+    // Deterministic wire length with empty scriptPayout + empty vchSig
+    // (each a single 0x00 CompactSize byte), REGULAR (no platform fields):
+    //   nVersion(2) nType(2) nMode(2) collateral(36) netInfo(18)
+    //   keyIDOwner(20) pubKeyOperator(48) keyIDVoting(20)
+    //   nOperatorReward(2) scriptPayout(1) inputsHash(32) vchSig(1) = 184
+    auto p = make_proreg(ProTxVersion::BASIC_BLS, MnType::REGULAR);
+    p.scriptPayout.m_data.clear();
+    p.vchSig.clear();
+    size_t len = 0;
+    auto out = roundtrip(p, &len);
+    EXPECT_EQ(len, 184u);
+    EXPECT_TRUE(out.scriptPayout.m_data.empty());
+    EXPECT_TRUE(out.vchSig.empty());
+}
+
+TEST(DashMnState, ProUpServTxRoundTrip) {
+    CProUpServTx p;
+    p.nVersion = ProTxVersion::BASIC_BLS;
+    p.nType = MnType::REGULAR;
+    p.proTxHash = raw256(0x11);
+    p.netInfo.ip = seq_array<16>(0x22);
+    p.netInfo.port_be = 0x2334;
+    p.scriptOperatorPayout.m_data = script_bytes(0x88, 22);
+    p.inputsHash = raw256(0x33);
+    p.sig = seq_array<96>(0x44);
+    size_t len = 0;
+    auto out = roundtrip(p, &len);
+    EXPECT_EQ(out.nVersion, p.nVersion);
+    EXPECT_EQ(out.proTxHash, p.proTxHash);
+    EXPECT_EQ(out.netInfo.port_be, p.netInfo.port_be);
+    EXPECT_EQ(out.scriptOperatorPayout.m_data, p.scriptOperatorPayout.m_data);
+    EXPECT_EQ(out.inputsHash, p.inputsHash);
+    EXPECT_EQ(out.sig, p.sig);
+}
+
+TEST(DashMnState, ProUpRegTxRoundTrip) {
+    CProUpRegTx p;
+    p.nVersion = ProTxVersion::BASIC_BLS;
+    p.proTxHash = raw256(0x12);
+    p.nMode = 0;
+    p.pubKeyOperator = seq_array<48>(0x55);
+    p.keyIDVoting = raw160(0x66);
+    p.scriptPayout.m_data = script_bytes(0x99, 25);
+    p.inputsHash = raw256(0x34);
+    p.vchSig = {0x01, 0x02, 0x03};
+    size_t len = 0;
+    auto out = roundtrip(p, &len);
+    EXPECT_EQ(out.proTxHash, p.proTxHash);
+    EXPECT_EQ(out.pubKeyOperator, p.pubKeyOperator);
+    EXPECT_EQ(out.keyIDVoting, p.keyIDVoting);
+    EXPECT_EQ(out.scriptPayout.m_data, p.scriptPayout.m_data);
+    EXPECT_EQ(out.inputsHash, p.inputsHash);
+    EXPECT_EQ(out.vchSig, p.vchSig);
+}
+
+TEST(DashMnState, ProUpRevTxRoundTripAndKnownLength) {
+    CProUpRevTx p;
+    p.nVersion = ProTxVersion::BASIC_BLS;
+    p.proTxHash = raw256(0x13);
+    p.nReason = CProUpRevTx::REASON_COMPROMISED_KEYS;
+    p.inputsHash = raw256(0x35);
+    p.sig = seq_array<96>(0x77);
+    // nVersion(2) proTxHash(32) nReason(2) inputsHash(32) sig(96) = 164
+    size_t len = 0;
+    auto out = roundtrip(p, &len);
+    EXPECT_EQ(len, 164u);
+    EXPECT_EQ(out.proTxHash, p.proTxHash);
+    EXPECT_EQ(out.nReason, CProUpRevTx::REASON_COMPROMISED_KEYS);
+    EXPECT_EQ(out.inputsHash, p.inputsHash);
+    EXPECT_EQ(out.sig, p.sig);
+}
+
+// ─── parse_protx_payload: full-consume + trailing-garbage rejection ─────────
+
+TEST(DashMnState, ParseProtxPayloadFullConsume) {
+    auto p = make_proreg(ProTxVersion::BASIC_BLS, MnType::EVO);
+    auto ps = ::pack(p);
+    auto sp = ps.get_span();
+    std::vector<uint8_t> payload(
+        reinterpret_cast<const uint8_t*>(sp.data()),
+        reinterpret_cast<const uint8_t*>(sp.data()) + sp.size());
+
+    CProRegTx out;
+    EXPECT_TRUE(parse_protx_payload(payload, out));
+    EXPECT_EQ(out.platformNodeID, p.platformNodeID);
+    EXPECT_EQ(out.scriptPayout.m_data, p.scriptPayout.m_data);
+}
+
+TEST(DashMnState, ParseProtxPayloadRejectsTrailingGarbage) {
+    auto p = make_proreg(ProTxVersion::BASIC_BLS, MnType::REGULAR);
+    auto ps = ::pack(p);
+    auto sp = ps.get_span();
+    std::vector<uint8_t> payload(
+        reinterpret_cast<const uint8_t*>(sp.data()),
+        reinterpret_cast<const uint8_t*>(sp.data()) + sp.size());
+    payload.push_back(0xAB);   // one trailing byte -> not fully consumed
+    CProRegTx out;
+    EXPECT_FALSE(parse_protx_payload(payload, out));
+}
+
+TEST(DashMnState, ParseProtxPayloadRejectsEmpty) {
+    std::vector<uint8_t> empty;
+    CProRegTx out;
+    EXPECT_FALSE(parse_protx_payload(empty, out));
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// MNState internal persistence wire round-trip
+// ════════════════════════════════════════════════════════════════════════
+
+TEST(DashMnState, MNStatePersistenceRoundTrip) {
+    MNState s;
+    s.nVersion = ProTxVersion::BASIC_BLS;
+    s.nType = MnType::EVO;
+    s.collateralOutpoint.hash = raw256(0x01);
+    s.collateralOutpoint.index = 3;
+    s.keyIDOwner = raw160(0x02);
+    s.pubKeyOperator = seq_array<48>(0x03);
+    s.keyIDVoting = raw160(0x04);
+    s.nOperatorReward = 500;
+    s.scriptPayout.m_data = script_bytes(0x05, 25);
+    s.netInfo.ip = seq_array<16>(0x06);
+    s.netInfo.port_be = 0x2334;
+    s.scriptOperatorPayout.m_data = script_bytes(0x07, 22);
+    s.nRegisteredHeight = 2400000;
+    s.nLastPaidHeight = 2450123;
+    s.nPoSeRevivedHeight = 2440000;
+    s.nPoSeBanHeight = 0;
+    s.nConsecutivePayments = 4;
+    s.nRevocationReason = CProUpRevTx::REASON_NOT_SPECIFIED;
+    s.isValid = true;
+    s.platformNodeID = raw160(0x08);
+    s.platformP2PPort = 0x6f4c;
+    s.platformHTTPPort = 0x6f4d;
+
+    size_t len = 0;
+    auto out = roundtrip(s, &len);
+    EXPECT_TRUE(s == out) << "MNState persistence round-trip mismatch";
+    // operator== already covers every persisted field; double-check a few
+    // that are easy to silently drop.
+    EXPECT_EQ(out.nLastPaidHeight, 2450123u);
+    EXPECT_EQ(out.nConsecutivePayments, 4u);
+    EXPECT_EQ(out.platformHTTPPort, 0x6f4d);
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// MnStateMachine::apply_block — RebuildListFromBlock semantics
+// ════════════════════════════════════════════════════════════════════════
+
+// Serialize a ProTx variant into the wire payload bytes the machine parses.
+template <typename T>
+static std::vector<unsigned char> protx_payload(const T& p) {
+    auto ps = ::pack(p);
+    auto sp = ps.get_span();
+    return std::vector<unsigned char>(
+        reinterpret_cast<const unsigned char*>(sp.data()),
+        reinterpret_cast<const unsigned char*>(sp.data()) + sp.size());
+}
+
+// Build a special tx carrying `type` + the given payload. extra_payload
+// must be non-empty AND type != 0 for the machine to look at it.
+static MutableTransaction special_tx(uint16_t type,
+                                     const std::vector<unsigned char>& payload) {
+    MutableTransaction tx;
+    tx.type = type;
+    tx.extra_payload = payload;
+    // one dummy input (collateral spends test uses real prevouts instead)
+    TxIn in; in.prevout.hash = uint256{}; in.prevout.index = 0xFFFFFFFF;
+    in.sequence = 0xFFFFFFFF;
+    tx.vin.push_back(in);
+    return tx;
+}
+
+// A coinbase tx (index 0) with the given output scripts.
+static MutableTransaction coinbase_tx(
+    const std::vector<std::vector<unsigned char>>& out_scripts) {
+    MutableTransaction cb;
+    cb.type = 0;
+    TxIn in; in.prevout.hash = uint256{}; in.prevout.index = 0xFFFFFFFF;
+    in.sequence = 0xFFFFFFFF;
+    cb.vin.push_back(in);
+    for (const auto& s : out_scripts) {
+        TxOut o; o.value = 100000; o.scriptPubKey.m_data = s;
+        cb.vout.push_back(o);
+    }
+    return cb;
+}
+
+// Reproduce MnStateMachine::compute_tx_hash independently (SHA256d of the
+// MutableTransaction serialization) so the test can predict the
+// proRegTxHash the machine will assign.
+static uint256 tx_hash(const MutableTransaction& tx) {
+    ::PackStream s;
+    s << tx;
+    auto sp = s.get_span();
+    uint256 h;
+    CHash256()
+        .Write(std::span<const unsigned char>(
+            reinterpret_cast<const unsigned char*>(sp.data()), sp.size()))
+        .Finalize(std::span<unsigned char>(h.data(), 32));
+    return h;
+}
+
+TEST(DashMnState, ComputeTxHashSelfConsistentAndStable) {
+    // SCOPE NOTE: asserts SHA256d-of-serialized-tx is deterministic and
+    // changes with the payload — NOT equality with a dashd-reported txid
+    // (that needs the node oracle). Registering this tx in apply_block must
+    // key the MN under exactly this hash (verified in RegisterAddsMN).
+    auto reg = make_proreg(ProTxVersion::BASIC_BLS, MnType::REGULAR);
+    auto tx = special_tx(CProRegTx::SPECIALTX_TYPE, protx_payload(reg));
+    uint256 h1 = tx_hash(tx);
+    uint256 h2 = tx_hash(tx);
+    EXPECT_EQ(h1, h2);
+    EXPECT_FALSE(h1.IsNull());
+    // mutate the payload -> different hash
+    reg.nOperatorReward = 999;
+    auto tx2 = special_tx(CProRegTx::SPECIALTX_TYPE, protx_payload(reg));
+    EXPECT_NE(tx_hash(tx2), h1);
+}
+
+TEST(DashMnState, RegisterAddsMNKeyedByTxHash) {
+    auto reg = make_proreg(ProTxVersion::BASIC_BLS, MnType::REGULAR);
+    auto regtx = special_tx(CProRegTx::SPECIALTX_TYPE, protx_payload(reg));
+    uint256 expected_hash = tx_hash(regtx);
+
+    BlockType blk;
+    blk.m_txs.push_back(coinbase_tx({script_bytes(0xC0)}));  // cb at index 0
+    blk.m_txs.push_back(regtx);
+
+    MnStateMachine m;
+    auto r = m.apply_block(blk, 2400000);
+    EXPECT_EQ(r.registered, 1u);
+    EXPECT_EQ(m.size(), 1u);
+    auto it = m.entries().find(expected_hash);
+    ASSERT_NE(it, m.entries().end()) << "MN must be keyed by compute_tx_hash";
+    EXPECT_EQ(it->second.nRegisteredHeight, 2400000u);
+    EXPECT_EQ(it->second.scriptPayout.m_data, reg.scriptPayout.m_data);
+    EXPECT_TRUE(it->second.isValid);
+    // null collateral hash -> resolved to the tx own hash.
+    EXPECT_EQ(it->second.collateralOutpoint.hash, reg.collateralOutpoint.hash);
+}
+
+TEST(DashMnState, RegisterNullCollateralResolvesToOwnHash) {
+    auto reg = make_proreg(ProTxVersion::BASIC_BLS, MnType::REGULAR);
+    reg.collateralOutpoint.hash = uint256{};   // null -> own tx output
+    reg.collateralOutpoint.index = 1;
+    auto regtx = special_tx(CProRegTx::SPECIALTX_TYPE, protx_payload(reg));
+    uint256 own = tx_hash(regtx);
+
+    BlockType blk;
+    blk.m_txs.push_back(coinbase_tx({script_bytes(0xC1)}));
+    blk.m_txs.push_back(regtx);
+    MnStateMachine m;
+    m.apply_block(blk, 2400001);
+    auto it = m.entries().find(own);
+    ASSERT_NE(it, m.entries().end());
+    EXPECT_EQ(it->second.collateralOutpoint.hash, own);
+    EXPECT_EQ(it->second.collateralOutpoint.index, 1u);
+    // collateral index must resolve back to the MN.
+    auto by_coll = m.find_by_collateral(it->second.collateralOutpoint);
+    ASSERT_TRUE(by_coll.has_value());
+    EXPECT_EQ(*by_coll, own);
+}
+
+TEST(DashMnState, UpdateRegistrarKeyChangeBansMN) {
+    auto reg = make_proreg(ProTxVersion::BASIC_BLS, MnType::REGULAR);
+    auto regtx = special_tx(CProRegTx::SPECIALTX_TYPE, protx_payload(reg));
+    uint256 h = tx_hash(regtx);
+
+    BlockType b1;
+    b1.m_txs.push_back(coinbase_tx({script_bytes(0xC2)}));
+    b1.m_txs.push_back(regtx);
+    MnStateMachine m;
+    m.apply_block(b1, 2400010);
+    ASSERT_TRUE(m.entries().at(h).isValid);
+
+    // ProUpReg with a DIFFERENT operator key -> ResetOperatorFields + ban.
+    CProUpRegTx upreg;
+    upreg.nVersion = ProTxVersion::BASIC_BLS;
+    upreg.proTxHash = h;
+    upreg.pubKeyOperator = seq_array<48>(0xEE);   // changed
+    upreg.keyIDVoting = raw160(0x66);
+    upreg.scriptPayout.m_data = script_bytes(0x9A, 25);
+    upreg.inputsHash = raw256(0x34);
+    upreg.vchSig = {0x01};
+    BlockType b2;
+    b2.m_txs.push_back(coinbase_tx({script_bytes(0xC3)}));
+    b2.m_txs.push_back(special_tx(CProUpRegTx::SPECIALTX_TYPE, protx_payload(upreg)));
+    auto r = m.apply_block(b2, 2400011);
+    EXPECT_EQ(r.updated, 1u);
+    EXPECT_FALSE(m.entries().at(h).isValid);
+    EXPECT_EQ(m.entries().at(h).nPoSeBanHeight, 2400011u);
+    EXPECT_EQ(m.entries().at(h).scriptPayout.m_data, upreg.scriptPayout.m_data);
+}
+
+TEST(DashMnState, UpdateServiceRevivesBannedMN) {
+    auto reg = make_proreg(ProTxVersion::BASIC_BLS, MnType::REGULAR);
+    auto regtx = special_tx(CProRegTx::SPECIALTX_TYPE, protx_payload(reg));
+    uint256 h = tx_hash(regtx);
+    BlockType b1;
+    b1.m_txs.push_back(coinbase_tx({script_bytes(0xD0)}));
+    b1.m_txs.push_back(regtx);
+    MnStateMachine m;
+    m.apply_block(b1, 2400020);
+
+    // Revoke -> ban.
+    CProUpRevTx rev;
+    rev.nVersion = ProTxVersion::BASIC_BLS;
+    rev.proTxHash = h;
+    rev.nReason = CProUpRevTx::REASON_COMPROMISED_KEYS;
+    rev.inputsHash = raw256(0x35);
+    rev.sig = seq_array<96>(0x77);
+    BlockType b2;
+    b2.m_txs.push_back(coinbase_tx({script_bytes(0xD1)}));
+    b2.m_txs.push_back(special_tx(CProUpRevTx::SPECIALTX_TYPE, protx_payload(rev)));
+    auto rr = m.apply_block(b2, 2400021);
+    EXPECT_EQ(rr.revoked, 1u);
+    ASSERT_FALSE(m.entries().at(h).isValid);
+    EXPECT_EQ(m.entries().at(h).nPoSeBanHeight, 2400021u);
+
+    // ProUpServ -> revive.
+    CProUpServTx ups;
+    ups.nVersion = ProTxVersion::BASIC_BLS;
+    ups.nType = MnType::REGULAR;
+    ups.proTxHash = h;
+    ups.netInfo.ip = seq_array<16>(0x22);
+    ups.netInfo.port_be = 0x2334;
+    ups.inputsHash = raw256(0x36);
+    ups.sig = seq_array<96>(0x44);
+    BlockType b3;
+    b3.m_txs.push_back(coinbase_tx({script_bytes(0xD2)}));
+    b3.m_txs.push_back(special_tx(CProUpServTx::SPECIALTX_TYPE, protx_payload(ups)));
+    auto r3 = m.apply_block(b3, 2400022);
+    EXPECT_EQ(r3.updated, 1u);
+    EXPECT_TRUE(m.entries().at(h).isValid);
+    EXPECT_EQ(m.entries().at(h).nPoSeBanHeight, 0u);
+    EXPECT_EQ(m.entries().at(h).nPoSeRevivedHeight, 2400022u);
+}
+
+TEST(DashMnState, CollateralSpendRemovesMN) {
+    auto reg = make_proreg(ProTxVersion::BASIC_BLS, MnType::REGULAR);
+    // external collateral (non-null hash) so we can spend it precisely.
+    reg.collateralOutpoint.hash = raw256(0xAA);
+    reg.collateralOutpoint.index = 2;
+    auto regtx = special_tx(CProRegTx::SPECIALTX_TYPE, protx_payload(reg));
+    uint256 h = tx_hash(regtx);
+    BlockType b1;
+    b1.m_txs.push_back(coinbase_tx({script_bytes(0xE0)}));
+    b1.m_txs.push_back(regtx);
+    MnStateMachine m;
+    m.apply_block(b1, 2400030);
+    ASSERT_EQ(m.size(), 1u);
+
+    // a tx that spends the collateral outpoint.
+    MutableTransaction spend;
+    spend.type = 0;
+    TxIn in; in.prevout.hash = raw256(0xAA); in.prevout.index = 2;
+    in.sequence = 0xFFFFFFFF;
+    spend.vin.push_back(in);
+    BlockType b2;
+    b2.m_txs.push_back(coinbase_tx({script_bytes(0xE1)}));
+    b2.m_txs.push_back(spend);
+    auto r = m.apply_block(b2, 2400031);
+    EXPECT_EQ(r.spent, 1u);
+    EXPECT_EQ(m.size(), 0u);
+    EXPECT_FALSE(m.find_by_collateral(reg.collateralOutpoint).has_value());
+}
+
+// ─── payee resolution + selection tiebreak ──────────────────────────────────
+
+TEST(DashMnState, PayeeResolutionSetsLastPaidHeight) {
+    auto reg = make_proreg(ProTxVersion::BASIC_BLS, MnType::REGULAR);
+    auto payout = reg.scriptPayout.m_data;     // the script the coinbase pays
+    auto regtx = special_tx(CProRegTx::SPECIALTX_TYPE, protx_payload(reg));
+    uint256 h = tx_hash(regtx);
+
+    BlockType b1;
+    b1.m_txs.push_back(coinbase_tx({script_bytes(0xF0)}));
+    b1.m_txs.push_back(regtx);
+    MnStateMachine m;
+    m.apply_block(b1, 2400040);
+    EXPECT_EQ(m.entries().at(h).nLastPaidHeight, 0u);
+
+    // next block: coinbase pays the MN payout script.
+    BlockType b2;
+    b2.m_txs.push_back(coinbase_tx(std::vector<std::vector<unsigned char>>{payout}));
+    auto r = m.apply_block(b2, 2400041);
+    EXPECT_EQ(r.paid, 1u);
+    EXPECT_EQ(m.entries().at(h).nLastPaidHeight, 2400041u);
+}
+
+TEST(DashMnState, PayeeResolutionNeverRollsBackward) {
+    auto reg = make_proreg(ProTxVersion::BASIC_BLS, MnType::REGULAR);
+    auto payout = reg.scriptPayout.m_data;
+    auto regtx = special_tx(CProRegTx::SPECIALTX_TYPE, protx_payload(reg));
+    uint256 h = tx_hash(regtx);
+    BlockType b1;
+    b1.m_txs.push_back(coinbase_tx({script_bytes(0xF1)}));
+    b1.m_txs.push_back(regtx);
+    MnStateMachine m;
+    m.apply_block(b1, 2400050);
+
+    BlockType bhi;
+    bhi.m_txs.push_back(coinbase_tx(std::vector<std::vector<unsigned char>>{payout}));
+    m.apply_block(bhi, 2400060);
+    EXPECT_EQ(m.entries().at(h).nLastPaidHeight, 2400060u);
+
+    // out-of-order lower height must NOT roll lastPaid backwards.
+    BlockType blo;
+    blo.m_txs.push_back(coinbase_tx(std::vector<std::vector<unsigned char>>{payout}));
+    m.apply_block(blo, 2400055);
+    EXPECT_EQ(m.entries().at(h).nLastPaidHeight, 2400060u);
+}
+
+// pick_paid_mn / find_expected_payee tiebreak: when two MNs share a payout
+// script with equal scoring height, the memcmp-smaller proRegTxHash wins.
+// We seed two MNState entries directly via load() to control the hashes.
+TEST(DashMnState, PickPaidMnMemcmpTiebreak) {
+    MnStateMachine m;
+    auto shared = script_bytes(0x42, 25);
+
+    MNState a;
+    a.scriptPayout.m_data = shared;
+    a.isValid = true;
+    a.nRegisteredHeight = 2400000;
+    a.nLastPaidHeight = 0;     // scores to nRegisteredHeight
+    MNState b = a;             // identical scoring
+
+    // hashA memcmp-smaller than hashB.
+    uint256 hashA = raw256_byte(0, 0x01);
+    uint256 hashB = raw256_byte(0, 0x02);
+    ASSERT_LT(std::memcmp(hashA.data(), hashB.data(), 32), 0);
+
+    std::vector<std::pair<uint256, MNState>> entries{{hashB, b}, {hashA, a}};
+    m.load(entries);
+
+    auto picked = m.pick_paid_mn(shared);
+    ASSERT_TRUE(picked.has_value());
+    EXPECT_EQ(*picked, hashA) << "memcmp-smaller proRegTxHash must win tiebreak";
+
+    // find_expected_payee uses the same CompareByLastPaid scan.
+    auto exp = m.find_expected_payee();
+    ASSERT_TRUE(exp.has_value());
+    EXPECT_EQ(*exp, hashA);
+}
+
+TEST(DashMnState, FindExpectedPayeeNormalizesSentinelLastPaid) {
+    // UINT32_MAX (dashd protx -1 sentinel) must NOT beat real heights.
+    MnStateMachine m;
+    MNState sentinel;
+    sentinel.isValid = true;
+    sentinel.nRegisteredHeight = 2400000;
+    sentinel.nLastPaidHeight = std::numeric_limits<uint32_t>::max(); // bug sentinel
+    MNState real;
+    real.isValid = true;
+    real.nRegisteredHeight = 2400000;
+    real.nLastPaidHeight = 10;     // genuinely oldest-paid -> should win
+
+    uint256 hSent = raw256_byte(0, 0x01);   // memcmp-smaller
+    uint256 hReal = raw256_byte(0, 0x02);
+    std::vector<std::pair<uint256, MNState>> e{{hSent, sentinel}, {hReal, real}};
+    m.load(e);
+    auto exp = m.find_expected_payee();
+    ASSERT_TRUE(exp.has_value());
+    // sentinel normalized to 0 -> scores to nRegisteredHeight(2400000);
+    // real scores to 10 -> real is oldest-unpaid -> real wins despite
+    // being memcmp-larger.
+    EXPECT_EQ(*exp, hReal) << "UINT32_MAX sentinel must not win payee selection";
+}
+
+TEST(DashMnState, FindExpectedPayeeSkipsInvalid) {
+    MnStateMachine m;
+    MNState valid, invalid;
+    valid.isValid = true;   valid.nRegisteredHeight = 100; valid.nLastPaidHeight = 50;
+    invalid.isValid = false; invalid.nRegisteredHeight = 1; invalid.nLastPaidHeight = 1; // would win if counted
+    std::vector<std::pair<uint256, MNState>> e{
+        {raw256_byte(0, 0x05), valid}, {raw256_byte(0, 0x06), invalid}};
+    m.load(e);
+    auto exp = m.find_expected_payee();
+    ASSERT_TRUE(exp.has_value());
+    EXPECT_EQ(*exp, raw256_byte(0, 0x05));
+}
+
+// ─── sync_validity_from_sml (Bug 12/14 triple-field reconciliation) ─────────
+
+TEST(DashMnState, SyncValidityFromSmlBansAndRevives) {
+    MnStateMachine m;
+    uint256 h = raw256_byte(0, 0x09);
+    MNState s;
+    s.isValid = true;
+    s.nRegisteredHeight = 2400000;
+    s.nPoSeBanHeight = 0;
+    s.nPoSeRevivedHeight = 0;
+    std::vector<std::pair<uint256, MNState>> e{{h, s}};
+    m.load(e);
+
+    // SML says this MN is now invalid (implicit PoSe ban, no tx observed).
+    CSimplifiedMNListEntry sml_e;
+    sml_e.proRegTxHash = h;
+    sml_e.isValid = false;
+    CSimplifiedMNList sml_ban(std::vector<CSimplifiedMNListEntry>{sml_e});
+    auto r1 = m.sync_validity_from_sml(sml_ban, 2450000);
+    EXPECT_EQ(r1.matched, 1u);
+    EXPECT_EQ(r1.flipped_to_invalid, 1u);
+    EXPECT_EQ(r1.ban_height_set, 1u);
+    EXPECT_FALSE(m.entries().at(h).isValid);
+    EXPECT_EQ(m.entries().at(h).nPoSeBanHeight, 2450000u);
+
+    // SML later says valid again (revive).
+    CSimplifiedMNListEntry sml_e2;
+    sml_e2.proRegTxHash = h;
+    sml_e2.isValid = true;
+    CSimplifiedMNList sml_rev(std::vector<CSimplifiedMNListEntry>{sml_e2});
+    auto r2 = m.sync_validity_from_sml(sml_rev, 2460000);
+    EXPECT_EQ(r2.flipped_to_valid, 1u);
+    EXPECT_EQ(r2.revived_height_set, 1u);
+    EXPECT_TRUE(m.entries().at(h).isValid);
+    EXPECT_EQ(m.entries().at(h).nPoSeBanHeight, 0u);
+    EXPECT_EQ(m.entries().at(h).nPoSeRevivedHeight, 2460000u);
+}
+
+TEST(DashMnState, SyncValidityFromSmlIdempotentAndSmlOnly) {
+    MnStateMachine m;
+    uint256 h = raw256_byte(0, 0x0A);
+    MNState s; s.isValid = true; s.nRegisteredHeight = 2400000;
+    m.load(std::vector<std::pair<uint256, MNState>>{{h, s}});
+
+    // matching validity -> no flips (idempotent).
+    CSimplifiedMNListEntry same; same.proRegTxHash = h; same.isValid = true;
+    auto r = m.sync_validity_from_sml(
+        CSimplifiedMNList(std::vector<CSimplifiedMNListEntry>{same}), 2450000);
+    EXPECT_EQ(r.matched, 1u);
+    EXPECT_EQ(r.flipped_to_invalid, 0u);
+    EXPECT_EQ(r.flipped_to_valid, 0u);
+
+    // SML entry not in our set -> sml_only, no crash.
+    CSimplifiedMNListEntry only; only.proRegTxHash = raw256_byte(0, 0x0B);
+    only.isValid = true;
+    auto r2 = m.sync_validity_from_sml(
+        CSimplifiedMNList(std::vector<CSimplifiedMNListEntry>{only}), 2450001);
+    EXPECT_EQ(r2.sml_only, 1u);
+    EXPECT_EQ(r2.matched, 0u);
+}


### PR DESCRIPTION
## DASH S7 — `mn_state_machine` leaf

The last absent header before the `embedded_gbt` capstone. Ports the DASH masternode state-machine that turns the SimplifiedMNList leaf (#309) into a live, auto-maintained DMN list the embedded-GBT payee projection consumes.

### Files
- `src/impl/dash/coin/vendor/providertx.hpp` — CProRegTx / CProUpServTx / CProUpRegTx / CProUpRevTx wire (de)serialization with `nVersion`/`nType` field gating + `parse_protx_payload` full-consume / trailing-garbage rejection.
- `src/impl/dash/coin/mn_state_db.hpp` — `MNState` internal persistence wire round-trip.
- `src/impl/dash/coin/mn_state_machine.hpp` — `apply_block` RebuildListFromBlock semantics (register / update-service / update-registrar / revoke / collateral spend / payee resolution), `find_expected_payee` + `pick_paid_mn` memcmp tiebreak, `sync_validity_from_sml`.
- `test/test_dash_mn_state.cpp` — KAT (23 cases).

### KAT philosophy
Mirrors `test_dash_simplifiedmns.cpp`: every assertion is a structural round-trip (serialize -> deserialize -> EQ), a bit-exact wire-length preimage, or an algorithm self-consistency property. No fabricated "expected" hashes.

### Verification (Linux x86_64, GCC 13)
- Configure + build `test_dash_mn_state`: green.
- `ctest -R DashMnState` from `build/`: **100% tests passed, 0 tests failed out of 23** (non-hollow, real count).
- CI test-allowlist drift-guard: OK. Registered in `test/CMakeLists.txt` (mirrors the simplifiedmns / quorum_root block incl. OBJECT-lib SCC direct-naming) and added to both `--target` lists in `.github/workflows/build.yml`.

### Scope (honest)
The end-to-end cross-check — `apply_block` over a REAL Dash mainnet special-tx block matching `dashd protx list` — requires a live Dash node oracle (mnlistdiff) and is deferred to the `embedded_gbt` integration leaf. It is not claimed here. The dashd-RPC fallback is preserved.

Draft — held for integrator verify + operator tap. Do not merge.
