### PR TITLE
dgb: delegate think() Phase-1 walk bounds to SSOT + non-circular KAT

### DIFF
--- a/src/impl/dgb/share_tracker.hpp
+++ b/src/impl/dgb/share_tracker.hpp
@@ -24,6 +24,7 @@ inline uint64_t mul128_shift(uint64_t a, uint64_t b, unsigned shift) {
 #include <impl/doge/coin/chain_params.hpp>  // DOGEChainParams::AUXPOW_CHAIN_ID (aux payout diag SSOT)
 #include <impl/nmc/coin/aux_id.hpp>          // nmc::coin::NMC_AUXPOW_CHAIN_ID (v37 bucket-2)
 #include "share_check.hpp"
+#include "think_p1_walk_bounds.hpp"  // SSOT: think_p1_walk_count / think_p1_in_pruning_zone
 #include "config_pool.hpp"
 
 #include <core/target_utils.hpp>
@@ -707,9 +708,11 @@ public:
                 // get_height now returns accumulated height (including parent
                 // chain for new_fork shares). get_last follows segments to
                 // the true last. No special fork detection needed.
-                auto walk_count = last.IsNull()
-                    ? head_height
-                    : std::min(5, std::max(0, head_height - static_cast<int32_t>(PoolConfig::chain_length())));
+                // Delegated to SSOT (think_p1_walk_bounds.hpp): full height when
+                // unrooted, else clamp-5 over shares above CHAIN_LENGTH.
+                auto walk_count = think_p1_walk_count(
+                    head_height, !last.IsNull(),
+                    static_cast<int32_t>(PoolConfig::chain_length()));
 
                 if (walk_count <= 0) {
                     ++p1_walk0;
@@ -723,7 +726,7 @@ public:
                         // pruning zone (height >= 2*CHAIN_LENGTH+10). These parents
                         // would be immediately re-pruned by clean_tracker.
                         auto CL_prune = static_cast<int32_t>(PoolConfig::chain_length());
-                        if (head_height >= 2 * CL_prune + 10) {
+                        if (think_p1_in_pruning_zone(head_height, CL_prune)) {
                             static int prune_skip_log = 0;
                             if (prune_skip_log++ % 20 == 0)
                                 LOG_INFO << "[think-P1] pruning-zone skip: head="
@@ -777,7 +780,7 @@ public:
                 {
                     // Option A: skip if chain already in pruning zone
                     auto CL_prune = static_cast<int32_t>(PoolConfig::chain_length());
-                    if (head_height >= 2 * CL_prune + 10) {
+                    if (think_p1_in_pruning_zone(head_height, CL_prune)) {
                         static int prune_skip2_log = 0;
                         if (prune_skip2_log++ % 20 == 0)
                             LOG_INFO << "[think-P1] pruning-zone skip (for/else): head="

--- a/src/impl/dgb/test/think_p1_walk_bounds_test.cpp
+++ b/src/impl/dgb/test/think_p1_walk_bounds_test.cpp
@@ -64,4 +64,52 @@ TEST(ThinkP1WalkBounds, PruningZoneInclusiveThreshold)
     EXPECT_TRUE (dgb::think_p1_in_pruning_zone(58, CL2));
 }
 
+// ---- Non-circular delegation proof ---------------------------------------
+// share_tracker.hpp think() Phase-1 was rewired to CALL the SSOT functions
+// above (the walk_count ternary + the two prune-zone guards). This test does
+// NOT stand up a ShareTracker; instead it re-implements the EXACT pre-delegation
+// inline expressions verbatim (copied from the share_tracker.hpp think() body
+// as it stood before this slice) and asserts they are byte-identical to the SSOT
+// across a dense input grid. Independent code path => non-circular: if the
+// delegation ever drifts from the open-coded original, this fails.
+namespace {
+
+// Verbatim copy of the pre-delegation inline walk_count expression.
+// Original: last.IsNull() ? head_height
+//                         : std::min(5, std::max(0, head_height - CHAIN_LENGTH))
+inline int32_t inline_walk_count_verbatim(int32_t head_height, bool last_is_null,
+                                          int32_t chain_length)
+{
+    return last_is_null
+        ? head_height
+        : std::min(5, std::max(0, head_height - chain_length));
+}
+
+// Verbatim copy of the pre-delegation inline prune-zone guard.
+// Original: head_height >= 2 * CL_prune + 10
+inline bool inline_in_pruning_zone_verbatim(int32_t head_height, int32_t chain_length)
+{
+    return head_height >= 2 * chain_length + 10;
+}
+
+} // namespace
+
+TEST(ThinkP1WalkBounds, DelegationMatchesPreDelegationInlineWalk)
+{
+    for (int32_t CL : {1, 8, 10, 16, 24, 50}) {
+        for (int32_t h = 0; h <= 4 * CL + 30; ++h) {
+            for (bool last_is_null : {false, true}) {
+                // last_is_null == true  -> unrooted head (has_last == false)
+                EXPECT_EQ(dgb::think_p1_walk_count(h, /*has_last=*/!last_is_null, CL),
+                          inline_walk_count_verbatim(h, last_is_null, CL))
+                    << "walk_count drift @ h=" << h << " CL=" << CL
+                    << " last_is_null=" << last_is_null;
+            }
+            EXPECT_EQ(dgb::think_p1_in_pruning_zone(h, CL),
+                      inline_in_pruning_zone_verbatim(h, CL))
+                << "prune-zone drift @ h=" << h << " CL=" << CL;
+        }
+    }
+}
+
 } // namespace


### PR DESCRIPTION
## Phase-B pool/share — think() Phase-1 delegation onto walk-bounds SSOT

Follow-on to the walk-bounds SSOT PR (#353), same `#344 -> #346` delegation shape. Stacked on `dgb/think-p1-walk-bounds`; retarget to `master` after #353 lands.

### What
`share_tracker.hpp` `think()` Phase-1 now **calls** the SSOT from `think_p1_walk_bounds.hpp` instead of re-deriving the bounds inline:
- walk_count ternary -> `think_p1_walk_count(head_height, !last.IsNull(), CL)`
- prune-zone guard (walk0 branch) -> `think_p1_in_pruning_zone(head_height, CL_prune)`
- prune-zone guard (for/else branch) -> same

The three open-coded copies (`min(5,max(0,h-CL))` once, `h>=2*CL+10` twice) collapse to single-call sites.

### Proof (non-circular)
New `DelegationMatchesPreDelegationInlineWalk` KAT re-implements the **exact pre-delegation inline expressions** as independent local code and asserts byte-identity with the SSOT across a dense `(CL in {1,8,10,16,24,50}, height 0..4*CL+30, has_last in {0,1})` grid. If the delegation ever drifts from the original open-coded formula, it fails. `dgb_think_p1_walk_bounds_test` 4/4 green; `c2pool-dgb` links.

### Fence
- `src/impl/dgb/` only — no allowlist/CMake/consensus touch (target already registered by #353).
- Consensus-neutral: pure arithmetic, no value semantics changed; byte-identity preserving.

No self-merge — surface-for-tap; integrator taps once own-head rollup is CLEAN.
