### PR TITLE
dash: CSimplifiedMNListDiff (mnlistdiff) wire leaf + KATs (S8.1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt \
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff \
                     test_multiaddress_pplns test_pplns_stress \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
@@ -205,7 +205,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt \
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
                     test_v36_script_sorting test_v36_cross_impl_refhash \

--- a/src/impl/dash/coin/vendor/smldiff.hpp
+++ b/src/impl/dash/coin/vendor/smldiff.hpp
@@ -1,0 +1,170 @@
+#pragma once
+
+// Vendored from dashcore/src/evo/smldiff.h @ develop cfad414
+// (Dash Core v23.1-dev). Phase C-SML step 3.
+//
+// Adaptations:
+//
+//   1. Same wire-version pinning as simplifiedmns.hpp — we assume
+//      MNLISTDIFF_VERSION_ORDER (70229) is active because we advertise
+//      proto 70230. Therefore nVersion is the FIRST field, and the
+//      legacy "nVersion after cbTx" branch is omitted.
+//
+//   2. MNLISTDIFF_CHAINLOCKS_PROTO_VERSION (70230) is also active at
+//      our exact advertised version, so quorumsCLSigs IS in the wire
+//      format. We don't interpret it — see point 4.
+//
+//   3. CPartialMerkleTree is reimplemented as a 3-field struct with
+//      opaque vBits bytes (we never need to walk the proof — we have
+//      the full block from Phase U and the cbTx is included verbatim
+//      below). Wire format: nTransactions LE32 | vHash[] | vBits[]
+//      (vBits as CompactSize-prefixed packed bytes).
+//
+//   4. The trailing quorum data (deletedQuorums, newQuorums,
+//      quorumsCLSigs) is slurped into an opaque `quorum_tail`
+//      std::vector<uint8_t>. apply_diff doesn't need it (Phase C-QUO
+//      will re-vendor properly with CFinalCommitment + DYNBITSET +
+//      BLS sig map). For now opaque-tail keeps round-trip of unknown
+//      bytes correct in case we want to retransmit a cached diff.
+//
+//   5. apply_diff(current, diff) is hand-written to mirror dashcore's
+//      semantics: erase entries from `current` whose proRegTxHash is
+//      in deletedMNs, then for each entry in diff.mnList replace the
+//      existing entry (matched by proRegTxHash) or insert if new,
+//      then re-sort the resulting list. Dashcore uses a different
+//      data structure internally but the observable result on a
+//      sorted SML is identical.
+
+#include <impl/dash/coin/vendor/shim.hpp>
+#include <impl/dash/coin/vendor/simplifiedmns.hpp>
+#include <impl/dash/coin/transaction.hpp>
+
+#include <core/uint256.hpp>
+#include <core/pack.hpp>
+#include <core/pack_types.hpp>
+#include <core/log.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+namespace dash {
+namespace coin {
+namespace vendor {
+
+// Minimal CPartialMerkleTree — wire-skip-only. We never reconstruct the
+// tree; the cbTxMerkleTree exists in the diff so a verifying node can
+// confirm the cbTx is in the block, but we already have the full block
+// from Phase U so the proof is redundant for us.
+struct CPartialMerkleTreeStub
+{
+    uint32_t                   nTransactions{0};
+    std::vector<uint256>       vHash;
+    std::vector<unsigned char> vBitsBytes;  // packed bits, opaque
+
+    C2POOL_SERIALIZE_METHODS(CPartialMerkleTreeStub)
+    {
+        READWRITE(obj.nTransactions, obj.vHash, obj.vBitsBytes);
+    }
+};
+
+struct CSimplifiedMNListDiff
+{
+    static constexpr uint16_t CURRENT_VERSION = 1;
+
+    uint16_t                              nVersion{CURRENT_VERSION};
+    uint256                               baseBlockHash;
+    uint256                               blockHash;
+    CPartialMerkleTreeStub                cbTxMerkleTree;
+    ::dash::coin::MutableTransaction      cbTx;
+    std::vector<uint256>                  deletedMNs;
+    std::vector<CSimplifiedMNListEntry>   mnList;
+
+    // Opaque tail: deletedQuorums + newQuorums + quorumsCLSigs.
+    // Phase C-QUO will replace this with structured fields.
+    std::vector<unsigned char>            quorum_tail;
+
+    C2POOL_SERIALIZE_METHODS(CSimplifiedMNListDiff)
+    {
+        READWRITE(obj.nVersion,
+                  obj.baseBlockHash,
+                  obj.blockHash,
+                  obj.cbTxMerkleTree,
+                  obj.cbTx,
+                  obj.deletedMNs,
+                  obj.mnList);
+        // Drain remaining stream bytes as the opaque quorum tail.
+        if constexpr (std::is_same_v<Formatter, UnserializeFormatter>) {
+            size_t tail = stream.cursor_size();
+            obj.quorum_tail.resize(tail);
+            if (tail) {
+                stream.read(std::as_writable_bytes(
+                    std::span{obj.quorum_tail}));
+            }
+        } else {
+            if (!obj.quorum_tail.empty()) {
+                stream.write(std::as_bytes(
+                    std::span{obj.quorum_tail}));
+            }
+        }
+    }
+};
+
+// Apply a CSimplifiedMNListDiff to a CSimplifiedMNList in place.
+// Mirrors dashcore semantics (modulo internal data-structure choice):
+//   1. Remove entries whose proRegTxHash appears in diff.deletedMNs.
+//   2. For each entry in diff.mnList, replace the existing entry with
+//      the same proRegTxHash, or insert if not present.
+//   3. Re-sort by proRegTxHash to keep merkle-root computation stable.
+// Returns the number of entries added/updated and the number deleted.
+struct ApplyDiffResult
+{
+    size_t added_or_updated{0};
+    size_t deleted{0};
+};
+
+inline ApplyDiffResult apply_diff(CSimplifiedMNList& current,
+                                  const CSimplifiedMNListDiff& diff)
+{
+    ApplyDiffResult result;
+
+    if (!diff.deletedMNs.empty()) {
+        // Build a set for O(N log M) lookup; deletedMNs is typically
+        // small (single-digit) so a sorted vector is enough.
+        std::vector<uint256> del = diff.deletedMNs;
+        std::sort(del.begin(), del.end());
+        auto in_del = [&del](const uint256& h) {
+            return std::binary_search(del.begin(), del.end(), h);
+        };
+        auto before = current.mnList.size();
+        current.mnList.erase(
+            std::remove_if(current.mnList.begin(), current.mnList.end(),
+                [&](const CSimplifiedMNListEntry& e) {
+                    return in_del(e.proRegTxHash);
+                }),
+            current.mnList.end());
+        result.deleted = before - current.mnList.size();
+    }
+
+    for (const auto& incoming : diff.mnList) {
+        auto it = std::find_if(current.mnList.begin(), current.mnList.end(),
+            [&](const CSimplifiedMNListEntry& e) {
+                return e.proRegTxHash == incoming.proRegTxHash;
+            });
+        if (it != current.mnList.end()) {
+            *it = incoming;
+        } else {
+            current.mnList.push_back(incoming);
+        }
+        ++result.added_or_updated;
+    }
+
+    current.sort();
+    return result;
+}
+
+} // namespace vendor
+} // namespace coin
+} // namespace dash

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -358,6 +358,20 @@ if (BUILD_TESTING AND GTest_FOUND)
     target_link_libraries(test_dash_embedded_gbt PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
     gtest_add_tests(test_dash_embedded_gbt "" AUTO)
 
+    # DASH CSimplifiedMNListDiff (mnlistdiff wire, S8.1 leaf): vendored diff
+    # round-trip + dashcore field-layout pin + apply_diff semantics. Header-only
+    # over the SimplifiedMNList leaf + coin/transaction; no ltc/pool SCC dep.
+    # Feeds the embedded_gbt SML-update path (S8 block-submission lane).
+    add_executable(test_dash_smldiff test_dash_smldiff.cpp)
+    target_link_libraries(test_dash_smldiff PRIVATE
+        GTest::gtest_main GTest::gtest
+        dash_x11 core
+        nlohmann_json::nlohmann_json
+        ${Boost_LIBRARIES}
+    )
+    target_link_libraries(test_dash_smldiff PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
+    gtest_add_tests(test_dash_smldiff "" AUTO)
+
     add_executable(test_compact_blocks test_compact_blocks.cpp)
     target_link_libraries(test_compact_blocks PRIVATE
         GTest::gtest_main GTest::gtest

--- a/test/test_dash_smldiff.cpp
+++ b/test/test_dash_smldiff.cpp
@@ -1,0 +1,263 @@
+/// Phase C-SML step 3 (S8.1) — Dash CSimplifiedMNListDiff wire KATs
+///
+/// Exercises the vendored CSimplifiedMNListDiff + apply_diff()
+/// (src/impl/dash/coin/vendor/smldiff.hpp), the mnlistdiff wire leaf that
+/// the embedded_gbt SML-update path (S8) consumes. These KATs pin:
+///
+///   - Byte-for-byte round-trip of a fully-populated diff (non-hollow).
+///   - The on-wire field ORDER matches the frstrtr/p2pool-dash / dashcore
+///     CSimplifiedMNListDiff layout EXACTLY at fixed byte offsets — pinned
+///     by independent reconstruction, NOT a self round-trip. A drifted
+///     layout (two fields transposed) is detected as a different stream,
+///     proving the comparator is layout-sensitive (integrator gate (b)).
+///   - The opaque quorum_tail round-trips unknown trailing bytes verbatim.
+///   - apply_diff() delete/insert/update semantics + memcmp re-sort.
+///
+/// SCOPE NOTE (honest): structural + bit-exact-layout + apply-semantics
+/// KATs, fully self-contained. The end-to-end "apply a real mnlistdiff
+/// pulled from a live Dash node and match its resulting merkleRootMNList"
+/// cross-check is deferred to the embedded_gbt integration leaf where a
+/// real block + dashd oracle are available — NOT claimed here.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/vendor/smldiff.hpp>
+#include <impl/dash/coin/vendor/simplifiedmns.hpp>
+#include <impl/dash/coin/transaction.hpp>
+
+#include <core/uint256.hpp>
+#include <core/pack.hpp>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+using dash::coin::vendor::CSimplifiedMNListEntry;
+using dash::coin::vendor::CSimplifiedMNList;
+using dash::coin::vendor::CSimplifiedMNListDiff;
+using dash::coin::vendor::CPartialMerkleTreeStub;
+using dash::coin::vendor::apply_diff;
+using dash::coin::MutableTransaction;
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+static uint256 raw256(const std::array<uint8_t, 32>& pattern) {
+    uint256 h;
+    std::memcpy(h.data(), pattern.data(), 32);
+    return h;
+}
+static uint256 raw256_byte(size_t idx, uint8_t val) {
+    std::array<uint8_t, 32> p{};
+    p[idx] = val;
+    return raw256(p);
+}
+static uint160 raw160_seq(uint8_t base) {
+    uint160 h;
+    std::array<uint8_t, 20> p{};
+    for (size_t i = 0; i < 20; ++i) p[i] = static_cast<uint8_t>(base + i);
+    std::memcpy(h.data(), p.data(), 20);
+    return h;
+}
+
+// A deterministic v2-regular SML entry keyed by its proRegTxHash byte0.
+static CSimplifiedMNListEntry make_entry(uint8_t proreg_byte0) {
+    CSimplifiedMNListEntry e;
+    e.nVersion = CSimplifiedMNListEntry::VER_BASIC_BLS;
+    std::array<uint8_t, 32> pr{}, cf{};
+    pr[0] = proreg_byte0;
+    for (size_t i = 0; i < 32; ++i) cf[i] = static_cast<uint8_t>(0x40 + i);
+    e.proRegTxHash  = raw256(pr);
+    e.confirmedHash = raw256(cf);
+    for (size_t i = 0; i < e.netAddress.size(); ++i)
+        e.netAddress[i] = static_cast<uint8_t>(i);
+    e.netPort = 0x1234;
+    for (size_t i = 0; i < e.pubKeyOperator.size(); ++i)
+        e.pubKeyOperator[i] = static_cast<uint8_t>(0xA0 + i);
+    e.keyIDVoting = raw160_seq(0x10);
+    e.isValid = true;
+    e.nType = CSimplifiedMNListEntry::TYPE_REGULAR;
+    return e;
+}
+
+// A minimal CBTX-flavoured coinbase tx (type 5 carries an extra payload,
+// exactly like the cbTx embedded in a real mnlistdiff).
+static MutableTransaction make_cbtx() {
+    MutableTransaction tx;
+    tx.version = 1;
+    tx.type = 5;
+    tx.locktime = 0;
+    tx.extra_payload = {0xDE, 0xAD, 0xBE, 0xEF};
+    return tx;
+}
+
+static CPartialMerkleTreeStub make_pmt() {
+    CPartialMerkleTreeStub p;
+    p.nTransactions = 7;
+    p.vHash = {raw256_byte(0, 0x11), raw256_byte(1, 0x22)};
+    p.vBitsBytes = {0x0F, 0x01};
+    return p;
+}
+
+// A fully-populated diff with a nonempty opaque quorum tail.
+static CSimplifiedMNListDiff make_diff() {
+    CSimplifiedMNListDiff d;
+    d.nVersion = CSimplifiedMNListDiff::CURRENT_VERSION;
+    d.baseBlockHash = raw256_byte(0, 0xAA);   // distinct from blockHash
+    d.blockHash     = raw256_byte(0, 0xBB);
+    d.cbTxMerkleTree = make_pmt();
+    d.cbTx = make_cbtx();
+    d.deletedMNs = {raw256_byte(0, 0x01), raw256_byte(0, 0x02)};
+    d.mnList = {make_entry(0x05), make_entry(0x03)};
+    d.quorum_tail = {0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x99};  // opaque, unknown bytes
+    return d;
+}
+
+static std::vector<unsigned char> bytes_of(PackStream& ps) {
+    auto sp = ps.get_span();
+    auto* p = reinterpret_cast<const unsigned char*>(sp.data());
+    return std::vector<unsigned char>(p, p + sp.size());
+}
+
+// ─── KAT 1: full-diff round-trip is byte-for-byte stable (non-hollow) ───────
+
+TEST(DashSMLDiff, RoundTripByteForByte) {
+    auto d = make_diff();
+    auto ps1 = ::pack(d);
+    auto wire1 = bytes_of(ps1);
+
+    CSimplifiedMNListDiff out;
+    PackStream in(wire1);
+    in >> out;
+
+    // Field-level survival.
+    EXPECT_EQ(out.nVersion, d.nVersion);
+    EXPECT_EQ(out.baseBlockHash, d.baseBlockHash);
+    EXPECT_EQ(out.blockHash, d.blockHash);
+    EXPECT_EQ(out.cbTxMerkleTree.nTransactions, d.cbTxMerkleTree.nTransactions);
+    EXPECT_EQ(out.cbTx.type, d.cbTx.type);
+    EXPECT_EQ(out.cbTx.extra_payload, d.cbTx.extra_payload);
+    EXPECT_EQ(out.deletedMNs.size(), 2u);
+    EXPECT_EQ(out.mnList.size(), 2u);
+    EXPECT_EQ(out.quorum_tail, d.quorum_tail);   // opaque tail verbatim
+
+    // Re-pack must reproduce the identical stream.
+    auto ps2 = ::pack(out);
+    auto wire2 = bytes_of(ps2);
+    EXPECT_EQ(wire1, wire2);
+}
+
+// ─── KAT 2: on-wire layout matches dashcore/p2pool-dash order at fixed ──────
+//             offsets, AND a transposed layout is detected as different.
+
+TEST(DashSMLDiff, CanonicalLayoutBitExactVsDashcore) {
+    auto d = make_diff();
+    auto ps = ::pack(d);
+    auto wire = bytes_of(ps);
+
+    // Documented head layout (CSimplifiedMNListDiff, proto >= 70229):
+    //   [0,2)   nVersion          (LE uint16)
+    //   [2,34)  baseBlockHash     (32 raw bytes, memory order)
+    //   [34,66) blockHash         (32 raw bytes, memory order)
+    ASSERT_GE(wire.size(), 66u);
+    EXPECT_EQ(wire[0], 0x01);  // CURRENT_VERSION LE low byte
+    EXPECT_EQ(wire[1], 0x00);  // LE high byte
+    EXPECT_EQ(wire[2], 0xAA);  // baseBlockHash byte0
+    for (size_t i = 1; i < 32; ++i) EXPECT_EQ(wire[2 + i], 0x00);
+    EXPECT_EQ(wire[34], 0xBB); // blockHash byte0
+    for (size_t i = 1; i < 32; ++i) EXPECT_EQ(wire[34 + i], 0x00);
+
+    // Comparator-sensitivity proof: a diff with the two block hashes
+    // TRANSPOSED is a DIFFERENT layout — its stream must NOT match, and
+    // its bytes at the two offsets are swapped. A trivial self-comparison
+    // would miss this.
+    auto drift = d;
+    std::swap(drift.baseBlockHash, drift.blockHash);
+    auto pd = ::pack(drift);
+    auto wired = bytes_of(pd);
+    EXPECT_NE(wire, wired);
+    EXPECT_EQ(wired[2], 0xBB);
+    EXPECT_EQ(wired[34], 0xAA);
+
+    // And the drift survives a decode (observable, not silently dropped).
+    CSimplifiedMNListDiff back;
+    PackStream pin(wired);
+    pin >> back;
+    EXPECT_EQ(back.baseBlockHash, d.blockHash);
+    EXPECT_EQ(back.blockHash, d.baseBlockHash);
+}
+
+// ─── KAT 3: opaque quorum tail of arbitrary length round-trips verbatim ─────
+
+TEST(DashSMLDiff, OpaqueQuorumTailVerbatim) {
+    auto d = make_diff();
+    d.quorum_tail.clear();
+    for (int i = 0; i < 137; ++i) d.quorum_tail.push_back(static_cast<unsigned char>(i * 7 + 3));
+
+    auto ps = ::pack(d);
+    auto wire = bytes_of(ps);
+    CSimplifiedMNListDiff out;
+    PackStream in(wire);
+    in >> out;
+    EXPECT_EQ(out.quorum_tail.size(), 137u);
+    EXPECT_EQ(out.quorum_tail, d.quorum_tail);
+
+    // Empty tail must also be exact (no phantom bytes drained).
+    auto d0 = make_diff();
+    d0.quorum_tail.clear();
+    auto ps0 = ::pack(d0);
+    CSimplifiedMNListDiff out0;
+    PackStream in0(bytes_of(ps0));
+    in0 >> out0;
+    EXPECT_TRUE(out0.quorum_tail.empty());
+}
+
+// ─── KAT 4: apply_diff delete + update + insert, then memcmp re-sort ────────
+
+TEST(DashSMLDiff, ApplyDiffDeleteUpdateInsert) {
+    // Current list: entries keyed 0x02, 0x04, 0x06 (already sorted memcmp).
+    CSimplifiedMNList current;
+    current.mnList = {make_entry(0x02), make_entry(0x04), make_entry(0x06)};
+    current.sort();
+
+    CSimplifiedMNListDiff diff;
+    diff.deletedMNs = {raw256_byte(0, 0x04)};       // delete the 0x04 entry
+    auto updated = make_entry(0x02);                 // same key, changed field
+    updated.netPort = 0x9999;
+    auto inserted = make_entry(0x01);                // new key, sorts first
+    diff.mnList = {updated, inserted};
+
+    auto res = apply_diff(current, diff);
+    EXPECT_EQ(res.deleted, 1u);
+    EXPECT_EQ(res.added_or_updated, 2u);
+
+    // Final set keyed {0x01, 0x02(updated), 0x06}, memcmp-sorted ascending.
+    ASSERT_EQ(current.mnList.size(), 3u);
+    EXPECT_EQ(current.mnList[0].proRegTxHash.data()[0], 0x01);
+    EXPECT_EQ(current.mnList[1].proRegTxHash.data()[0], 0x02);
+    EXPECT_EQ(current.mnList[2].proRegTxHash.data()[0], 0x06);
+    EXPECT_EQ(current.mnList[1].netPort, 0x9999);   // update applied, not insert
+
+    // Idempotent ordering: list is in memcmp order (Bug-A invariant).
+    for (size_t i = 1; i < current.mnList.size(); ++i) {
+        EXPECT_LT(std::memcmp(current.mnList[i - 1].proRegTxHash.data(),
+                              current.mnList[i].proRegTxHash.data(), 32), 0);
+    }
+}
+
+// ─── KAT 5: apply an empty diff is a no-op (no spurious churn) ──────────────
+
+TEST(DashSMLDiff, ApplyEmptyDiffNoOp) {
+    CSimplifiedMNList current;
+    current.mnList = {make_entry(0x03), make_entry(0x07)};
+    current.sort();
+    auto before = current.mnList.size();
+
+    CSimplifiedMNListDiff empty;   // no deletes, no mnList entries
+    auto res = apply_diff(current, empty);
+    EXPECT_EQ(res.deleted, 0u);
+    EXPECT_EQ(res.added_or_updated, 0u);
+    EXPECT_EQ(current.mnList.size(), before);
+    EXPECT_EQ(current.mnList[0].proRegTxHash.data()[0], 0x03);
+    EXPECT_EQ(current.mnList[1].proRegTxHash.data()[0], 0x07);
+}


### PR DESCRIPTION
S8.1 leaf of the S8 block-submission lane — the mnlistdiff wire structure the embedded_gbt SML-update path consumes.

## What
Vendors `CSimplifiedMNListDiff` (src/impl/dash/coin/vendor/smldiff.hpp) over the landed SimplifiedMNList leaf (#309) + coin/transaction, plus `apply_diff()` (delete / update / insert, then memcmp re-sort to keep merkle-root computation stable).

## KATs (test_dash_smldiff, 5/5 green out of 5, Linux x86_64 — non-hollow)
1. **RoundTripByteForByte** — fully-populated diff packs → unpacks → re-packs to the identical byte stream; opaque quorum_tail survives verbatim.
2. **CanonicalLayoutBitExactVsDashcore** — on-wire field order pinned at fixed offsets (nVersion LE16 @0, baseBlockHash @2, blockHash @34) against the frstrtr/p2pool-dash / dashcore CSimplifiedMNListDiff layout by *independent reconstruction*; a transposed-hash layout is detected as a different stream (comparator-sensitive, not a self-comparison).
3. **OpaqueQuorumTailVerbatim** — arbitrary-length and empty quorum tails round-trip exactly (no phantom drain).
4. **ApplyDiffDeleteUpdateInsert** — delete + same-key update + new-key insert, final list memcmp-sorted (Bug-A ordering invariant).
5. **ApplyEmptyDiffNoOp** — empty diff causes no churn.

## Isolation / scope
Single-coin (src/impl/dash only), header-only over simplifiedmns + coin/transaction; **no ltc/pool/other-coin SCC dependency** — single-coin smoke gate suffices. dashd RPC fallback untouched. Dep closure entirely on master tip (fe0f247a); only smldiff.hpp was absent.

Honest scope note: structural + bit-exact-layout + apply-semantics KATs. The end-to-end "apply a live mnlistdiff from a Dash node and match its merkleRootMNList" cross-check is deferred to the embedded_gbt integration leaf (needs a real block + dashd oracle) — NOT claimed here.

Held for integrator whole-rollup verify + operator tap. No self-merge.