### PR TITLE
web: /api/coin_peers returns {} not a hardcoded {ltc,doge} skeleton

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -4631,9 +4631,13 @@ nlohmann::json MiningInterface::rest_coin_peers(const std::string& remote_ip)
         }
     }
 
+    // No embedded-coin-peer source wired for this node: return an EMPTY
+    // object rather than a fabricated {ltc,doge} skeleton. Inventing a fixed
+    // LTC+DOGE shape lies about a node that may run a different coin set (or
+    // none) -- the dashboard must reflect THIS node's real topology, never a
+    // hardcoded one. Empty object => dashboard shows no embedded chains.
     if (!m_coin_peers_fn)
-        return {{"ltc", nlohmann::json::array()},
-                {"doge", nlohmann::json::array()}};
+        return nlohmann::json::object();
 
     return m_coin_peers_fn();
 }


### PR DESCRIPTION
## What
When no embedded-coin-peer source is wired, `rest_coin_peers()` (web_server.cpp:4635) returned a fabricated `{"ltc":[],"doge":[]}` shape — asserting an LTC+DOGE topology on a node that may run a different coin set (or none). It now returns an empty object so the dashboard reflects **this node** real embedded chains, never a hardcoded one. This is the same no-hardcoded-LTC+DOGE-shape principle already stated at web_server.cpp:5120.

## Safety
Consumers unaffected: `coin_peer_manager::http_fetch_coin_peers()` guards on `j.contains(chain_key)`, so `{}` yields zero peers exactly as the old empty arrays did — behaviorally identical for peer bootstrap, truthful for topology reporting.

## Scope
Web/diagnostic layer only (non-consensus). No pool-aggregate or consensus path touched.

