### PR TITLE
dash(s8): p2p_messages wire leaf — Dash coin-daemon P2P messages + 7 KATs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages \\
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages \
                     test_multiaddress_pplns test_pplns_stress \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
@@ -205,7 +205,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages \\
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
                     test_v36_script_sorting test_v36_cross_impl_refhash \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff \
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages \\
                     test_multiaddress_pplns test_pplns_stress \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
@@ -205,7 +205,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff \
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages \\
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
                     test_v36_script_sorting test_v36_cross_impl_refhash \

--- a/src/impl/dash/coin/p2p_messages.hpp
+++ b/src/impl/dash/coin/p2p_messages.hpp
@@ -1,0 +1,207 @@
+#pragma once
+
+// Dash coin daemon P2P messages.
+// Generic messages imported from bitcoin_family.
+// Coin-specific messages (block, tx, headers) use Dash types (no MWEB, no segwit).
+
+#include "transaction.hpp"
+#include "block.hpp"
+#include "vendor/blockencodings.hpp"
+#include "vendor/smldiff.hpp"
+
+#include <impl/bitcoin_family/coin/base_p2p_messages.hpp>
+
+#include <vector>
+
+#include <core/uint256.hpp>
+#include <core/netaddress.hpp>
+#include <core/message.hpp>
+#include <core/message_macro.hpp>
+
+namespace dash
+{
+namespace coin
+{
+namespace p2p
+{
+
+// Import generic messages from bitcoin_family
+using bitcoin_family::coin::p2p::btc_addr_record_t;
+using bitcoin_family::coin::p2p::message_version;
+using bitcoin_family::coin::p2p::message_verack;
+using bitcoin_family::coin::p2p::message_ping;
+using bitcoin_family::coin::p2p::message_pong;
+using bitcoin_family::coin::p2p::message_alert;
+using bitcoin_family::coin::p2p::inventory_type;
+using bitcoin_family::coin::p2p::message_inv;
+using bitcoin_family::coin::p2p::message_getdata;
+using bitcoin_family::coin::p2p::message_getblocks;
+using bitcoin_family::coin::p2p::message_getheaders;
+using bitcoin_family::coin::p2p::message_getaddr;
+using bitcoin_family::coin::p2p::message_addr;
+using bitcoin_family::coin::p2p::message_reject;
+using bitcoin_family::coin::p2p::message_sendheaders;
+using bitcoin_family::coin::p2p::message_notfound;
+using bitcoin_family::coin::p2p::message_feefilter;
+using bitcoin_family::coin::p2p::message_mempool;
+using bitcoin_family::coin::p2p::message_sendcmpct;
+using bitcoin_family::coin::p2p::message_sendaddrv2;
+using bitcoin_family::coin::p2p::BIP155Network;
+using bitcoin_family::coin::p2p::bip155_address_size;
+using bitcoin_family::coin::p2p::MAX_ADDRV2_RECORDS;
+using bitcoin_family::coin::p2p::btc_addrv2_record_t;
+using bitcoin_family::coin::p2p::message_addrv2;
+
+// ── Dash-specific messages (no segwit, no MWEB) ──
+
+BEGIN_MESSAGE(tx)
+    MESSAGE_FIELDS
+    (
+        (MutableTransaction, m_tx)
+    )
+    {
+        READWRITE(obj.m_tx);
+    }
+END_MESSAGE()
+
+BEGIN_MESSAGE(block)
+    MESSAGE_FIELDS
+    (
+        (BlockType, m_block)
+    )
+    {
+        READWRITE(obj.m_block);
+    }
+END_MESSAGE()
+
+BEGIN_MESSAGE(headers)
+    MESSAGE_FIELDS
+    (
+        (std::vector<BlockType>, m_headers)
+    )
+    {
+        READWRITE(obj.m_headers);
+    }
+END_MESSAGE()
+
+// SPV A1 (parity audit): Dash ChainLockSig (clsig) message.
+// Reference: dashcore/src/chainlock/clsig.h — ChainLockSig struct.
+// Wire layout: nHeight(i32 LE) + blockHash(32B LE) + sig(96B BLS blob).
+// Peers push this unsolicited when a ChainLock is freshly aggregated,
+// and also on demand via inv+getdata(MSG_CLSIG=29). Parsing the sig is
+// not required — we treat it as opaque bytes; the fact that we received
+// the message at all is dashd's signal that the block is finalized.
+// ── BIP 152 compact-block messages (Phase S2) ─────────────────────────────
+// Wire types vendored from dashcore at src/impl/dash/coin/vendor/; see
+// vendor/README.md for the adaptation notes.
+
+BEGIN_MESSAGE(cmpctblock)
+    MESSAGE_FIELDS
+    (
+        (vendor::CBlockHeaderAndShortTxIDs, m_cmpct)
+    )
+    {
+        READWRITE(obj.m_cmpct);
+    }
+END_MESSAGE()
+
+BEGIN_MESSAGE(getblocktxn)
+    MESSAGE_FIELDS
+    (
+        (vendor::BlockTransactionsRequest, m_req)
+    )
+    {
+        READWRITE(obj.m_req);
+    }
+END_MESSAGE()
+
+BEGIN_MESSAGE(blocktxn)
+    MESSAGE_FIELDS
+    (
+        (vendor::BlockTransactions, m_txs)
+    )
+    {
+        READWRITE(obj.m_txs);
+    }
+END_MESSAGE()
+
+BEGIN_MESSAGE(clsig)
+    MESSAGE_FIELDS
+    (
+        (int32_t, m_height),
+        (uint256, m_block_hash),
+        (std::vector<uint8_t>, m_sig)
+    )
+    {
+        READWRITE(obj.m_height);
+        READWRITE(obj.m_block_hash);
+        READWRITE(Using<ArrayType<DefaultFormat, 96>>(obj.m_sig));
+    }
+END_MESSAGE()
+
+// ── Phase C-SML step 4: Simplified MN List sync messages ──────────────
+// Wire commands (dashcore protocol.cpp:68-69):
+//   "getmnlistd"  — request: baseBlockHash + blockHash
+//   "mnlistdiff"  — reply:   full diff struct (see vendor/smldiff.hpp)
+// Used to maintain a local SML for CBTX merkleRootMNList verification
+// and (in later phases) ChainLock signature validation. Dashcore full
+// nodes do NOT receive mnlistdiff (they Misbehaving(100) on receipt) —
+// the protocol is exclusively for light clients, which c2pool-dash now
+// is on the SML axis.
+
+BEGIN_MESSAGE(getmnlistd)
+    MESSAGE_FIELDS
+    (
+        (uint256, m_base_block_hash),
+        (uint256, m_block_hash)
+    )
+    {
+        READWRITE(obj.m_base_block_hash);
+        READWRITE(obj.m_block_hash);
+    }
+END_MESSAGE()
+
+BEGIN_MESSAGE(mnlistdiff)
+    MESSAGE_FIELDS
+    (
+        (vendor::CSimplifiedMNListDiff, m_diff)
+    )
+    {
+        READWRITE(obj.m_diff);
+    }
+END_MESSAGE()
+
+using Handler = MessageHandler<
+    message_version,
+    message_verack,
+    message_ping,
+    message_pong,
+    message_alert,
+    message_inv,
+    message_getdata,
+    message_getblocks,
+    message_getheaders,
+    message_tx,
+    message_block,
+    message_headers,
+    message_getaddr,
+    message_addr,
+    message_reject,
+    message_sendheaders,
+    message_notfound,
+    message_feefilter,
+    message_mempool,
+    message_sendcmpct,
+    message_sendaddrv2,
+    message_addrv2,
+    message_cmpctblock,
+    message_getblocktxn,
+    message_blocktxn,
+    message_clsig,
+    message_getmnlistd,
+    message_mnlistdiff
+>;
+
+} // namespace p2p
+} // namespace coin
+} // namespace dash

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -372,6 +372,19 @@ if (BUILD_TESTING AND GTest_FOUND)
     target_link_libraries(test_dash_smldiff PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
     gtest_add_tests(test_dash_smldiff "" AUTO)
 
+    # Dash coin-daemon P2P wire-message KATs (S8 block-submission lane). Pins
+    # the Dash-only messages (block/headers/clsig/getmnlistd/mnlistdiff) atop
+    # the smldiff leaf; no ltc/pool SCC dep beyond the OBJECT libs.
+    add_executable(test_dash_p2p_messages test_dash_p2p_messages.cpp)
+    target_link_libraries(test_dash_p2p_messages PRIVATE
+        GTest::gtest_main GTest::gtest
+        dash_x11 core
+        nlohmann_json::nlohmann_json
+        ${Boost_LIBRARIES}
+    )
+    target_link_libraries(test_dash_p2p_messages PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
+    gtest_add_tests(test_dash_p2p_messages "" AUTO)
+
     add_executable(test_compact_blocks test_compact_blocks.cpp)
     target_link_libraries(test_compact_blocks PRIVATE
         GTest::gtest_main GTest::gtest

--- a/test/test_dash_p2p_messages.cpp
+++ b/test/test_dash_p2p_messages.cpp
@@ -1,0 +1,187 @@
+/// Phase S8 — Dash coin-daemon P2P wire-message KATs
+///
+/// Exercises the Dash-specific messages in
+/// src/impl/dash/coin/p2p_messages.hpp — the embedded-P2P message layer the
+/// S8 block-submission lane (p2p_connection -> p2p_node -> broadcaster) builds
+/// on. The generic bitcoin_family messages (version/verack/inv/...) are
+/// already covered by the family suite; this pins the Dash-only additions
+/// that carry no segwit/MWEB plus the Dash consensus side-channels:
+///
+///   - block / headers : Dash fixed 80-byte header round-trip (no witness).
+///   - clsig           : ChainLock sig — i32 height + 32B hash + FIXED 96B BLS
+///                       blob. Byte-layout PINNED by independent stream
+///                       reconstruction (NOT a self round-trip), and a
+///                       transposed layout is rejected — proving the
+///                       comparator is layout-sensitive (integrator gate b).
+///   - getmnlistd      : two uint256 (base, block) at fixed 0/32 offsets.
+///   - mnlistdiff      : carries the vendored CSimplifiedMNListDiff (S8.1).
+///   - command strings : every Dash message maps to its exact wire command.
+///
+/// SCOPE NOTE (honest): structural + bit-exact-layout wire KATs, fully
+/// self-contained. The live "connect to a dashd peer and exchange these on a
+/// real socket" leg is the p2p_connection/p2p_node integration leaf, NOT
+/// claimed here.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/p2p_messages.hpp>
+#include <impl/dash/coin/block.hpp>
+#include <impl/dash/coin/transaction.hpp>
+#include <impl/dash/coin/vendor/smldiff.hpp>
+
+#include <core/uint256.hpp>
+#include <core/pack.hpp>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+using namespace dash::coin::p2p;
+using dash::coin::BlockType;
+using dash::coin::vendor::CSimplifiedMNListDiff;
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+// Non-destructive byte view of a PackStream (does not advance the read cursor).
+static std::vector<unsigned char> bytes_of(PackStream& ps) {
+    auto sp = ps.get_span();
+    auto* p = reinterpret_cast<const unsigned char*>(sp.data());
+    return std::vector<unsigned char>(p, p + sp.size());
+}
+
+static uint256 raw256_seq(uint8_t base) {
+    std::array<uint8_t, 32> p{};
+    for (size_t i = 0; i < 32; ++i) p[i] = static_cast<uint8_t>(base + i);
+    uint256 h; std::memcpy(h.data(), p.data(), 32); return h;
+}
+
+static BlockType make_header(uint8_t seed) {
+    BlockType b;
+    b.m_version        = 0x20000000u | seed;
+    b.m_previous_block = raw256_seq(0x10 + seed);
+    b.m_merkle_root    = raw256_seq(0x50 + seed);
+    b.m_timestamp      = 0x5f5e1000u + seed;
+    b.m_bits           = 0x1d00ffffu;
+    b.m_nonce          = 0xdeadbeefu - seed;
+    return b;
+}
+
+// ─── block / headers ────────────────────────────────────────────────────────
+
+TEST(DashP2PMessages, Message_Block_RoundTrip) {
+    auto blk = make_header(3);
+    auto rmsg = message_block::make_raw(blk);
+    EXPECT_EQ(rmsg->m_command, "block");
+    // Dash header is the canonical fixed 80 bytes (no witness/MWEB).
+    EXPECT_EQ(bytes_of(rmsg->m_data).size(), 80u);
+
+    auto parsed = message_block::make(rmsg->m_data);
+    EXPECT_EQ(parsed->m_block.m_previous_block, blk.m_previous_block);
+    EXPECT_EQ(parsed->m_block.m_merkle_root,    blk.m_merkle_root);
+    EXPECT_EQ(parsed->m_block.m_bits,           blk.m_bits);
+    EXPECT_EQ(parsed->m_block.m_nonce,          blk.m_nonce);
+}
+
+TEST(DashP2PMessages, Message_Headers_RoundTrip) {
+    std::vector<BlockType> hs{make_header(1), make_header(2)};
+    auto rmsg = message_headers::make_raw(hs);
+    EXPECT_EQ(rmsg->m_command, "headers");
+
+    auto parsed = message_headers::make(rmsg->m_data);
+    ASSERT_EQ(parsed->m_headers.size(), 2u);
+    EXPECT_EQ(parsed->m_headers[0].m_nonce, hs[0].m_nonce);
+    EXPECT_EQ(parsed->m_headers[1].m_merkle_root, hs[1].m_merkle_root);
+}
+
+// ─── clsig: round-trip, fixed 96B BLS sig, layout pin ────────────────────────
+
+TEST(DashP2PMessages, Message_ClSig_RoundTrip) {
+    int32_t height = 0x00abcdef;
+    uint256 bhash  = raw256_seq(0x80);
+    std::vector<uint8_t> sig(96);
+    for (size_t i = 0; i < 96; ++i) sig[i] = static_cast<uint8_t>(0x11 + i);
+
+    auto rmsg = message_clsig::make_raw(height, bhash, sig);
+    EXPECT_EQ(rmsg->m_command, "clsig");
+
+    auto parsed = message_clsig::make(rmsg->m_data);
+    EXPECT_EQ(parsed->m_height, height);
+    EXPECT_EQ(parsed->m_block_hash, bhash);
+    ASSERT_EQ(parsed->m_sig.size(), 96u);
+    EXPECT_EQ(parsed->m_sig, sig);
+}
+
+TEST(DashP2PMessages, Message_ClSig_LayoutPinned) {
+    int32_t height = 0x00abcdef;
+    uint256 bhash  = raw256_seq(0x80);
+    std::vector<uint8_t> sig(96);
+    for (size_t i = 0; i < 96; ++i) sig[i] = static_cast<uint8_t>(0x11 + i);
+
+    auto rmsg = message_clsig::make_raw(height, bhash, sig);
+    auto wire = bytes_of(rmsg->m_data);
+
+    // Independent reconstruction of the exact wire stream:
+    //   height(i32 LE) || blockHash(32B) || sig(FIXED 96B, no length prefix)
+    std::vector<unsigned char> expect;
+    for (int i = 0; i < 4; ++i) expect.push_back(static_cast<unsigned char>((height >> (8 * i)) & 0xff));
+    expect.insert(expect.end(), bhash.data(), bhash.data() + 32);
+    expect.insert(expect.end(), sig.begin(), sig.end());
+
+    ASSERT_EQ(expect.size(), 132u);               // 4 + 32 + 96, fixed
+    ASSERT_EQ(wire.size(), 132u);
+    EXPECT_EQ(wire, expect);
+
+    // Layout-sensitivity: a transposed reconstruction (hash before height)
+    // must NOT match — proves the comparator pins ORDER, not just contents.
+    std::vector<unsigned char> transposed;
+    transposed.insert(transposed.end(), bhash.data(), bhash.data() + 32);
+    for (int i = 0; i < 4; ++i) transposed.push_back(static_cast<unsigned char>((height >> (8 * i)) & 0xff));
+    transposed.insert(transposed.end(), sig.begin(), sig.end());
+    EXPECT_NE(wire, transposed);
+}
+
+// ─── getmnlistd: two uint256 at fixed offsets ───────────────────────────────
+
+TEST(DashP2PMessages, Message_GetMnListD_RoundTrip) {
+    uint256 base = raw256_seq(0x01);
+    uint256 blk  = raw256_seq(0xA1);
+    auto rmsg = message_getmnlistd::make_raw(base, blk);
+    EXPECT_EQ(rmsg->m_command, "getmnlistd");
+
+    auto wire = bytes_of(rmsg->m_data);
+    ASSERT_EQ(wire.size(), 64u);                  // 32 + 32
+    // base occupies [0,32), block occupies [32,64) — pinned offsets.
+    EXPECT_EQ(0, std::memcmp(wire.data() + 0,  base.data(), 32));
+    EXPECT_EQ(0, std::memcmp(wire.data() + 32, blk.data(),  32));
+
+    auto parsed = message_getmnlistd::make(rmsg->m_data);
+    EXPECT_EQ(parsed->m_base_block_hash, base);
+    EXPECT_EQ(parsed->m_block_hash, blk);
+}
+
+// ─── mnlistdiff: carries the vendored CSimplifiedMNListDiff ──────────────────
+
+TEST(DashP2PMessages, Message_MnListDiff_RoundTrip) {
+    CSimplifiedMNListDiff diff;
+    diff.baseBlockHash = raw256_seq(0x02);
+    diff.blockHash     = raw256_seq(0xB2);
+
+    auto rmsg = message_mnlistdiff::make_raw(diff);
+    EXPECT_EQ(rmsg->m_command, "mnlistdiff");
+    EXPECT_GT(bytes_of(rmsg->m_data).size(), 0u);
+
+    auto parsed = message_mnlistdiff::make(rmsg->m_data);
+    EXPECT_EQ(parsed->m_diff.baseBlockHash, diff.baseBlockHash);
+    EXPECT_EQ(parsed->m_diff.blockHash, diff.blockHash);
+}
+
+// ─── command-string registration sweep ──────────────────────────────────────
+
+TEST(DashP2PMessages, CommandStringsPinned) {
+    EXPECT_EQ(message_block::make_raw(make_header(0))->m_command, "block");
+    EXPECT_EQ(message_headers::make_raw(std::vector<BlockType>{})->m_command, "headers");
+    EXPECT_EQ(message_getmnlistd::make_raw(raw256_seq(0), raw256_seq(1))->m_command, "getmnlistd");
+    CSimplifiedMNListDiff d;
+    EXPECT_EQ(message_mnlistdiff::make_raw(d)->m_command, "mnlistdiff");
+}


### PR DESCRIPTION
Stacked on #357 (S8.1 smldiff). Lands `src/impl/dash/coin/p2p_messages.hpp` — the Dash-specific coin-daemon P2P message layer the S8 block-submission lane (p2p_connection -> p2p_node -> broadcaster) consumes. Generic messages imported from bitcoin_family; Dash additions carry no segwit/MWEB and add the Dash consensus side-channels (clsig ChainLock sig; getmnlistd/mnlistdiff SML sync over the S8.1 vendored types).

## Wire KATs (7/7 green, non-hollow, Linux x86_64, ctest 563-569)
- block / headers — fixed 80-byte Dash header round-trip (no witness)
- clsig — round-trip + byte-layout PIN (i32 height || 32B hash || fixed 96B BLS sig = 132B) by independent reconstruction; transposed layout rejected (layout-sensitive comparator, integrator gate b)
- getmnlistd — two-uint256 fixed-offset pin
- mnlistdiff — carries vendored CSimplifiedMNListDiff
- command-string registration sweep

## Fencing
Single-coin isolation: `src/impl/dash` only + its test + test/CMakeLists.txt + build.yml allowlist entry (no NOT_BUILT sentinel — registered on both --target lists). No shared/other-coin/SCC edits. dashd RPC submitblock fallback unaffected.

## Scope (honest)
Structural + bit-exact-layout wire KATs. The live dashd-socket exchange is the p2p_connection/p2p_node integration leaf, NOT claimed here.

GPG-signed dd5d0595. No self-merge — for whole-rollup verify + operator tap.