### PR TITLE
dgb: SSOT think() Phase-1 desired-emit decision + non-circular KAT (Phase-B pool/share)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
                     dgb_gentx_coinbase_test dgb_connection_coinbase_test dgb_pplns_payout_split_test nmc_auxpow_merkle_test nmc_template_builder_test nmc_auxpow_wire_test nmc_reconstruct_won_block_test dgb_gentx_share_path_test dgb_conn_pplns_producer_test dgb_other_tx_resolver_test \
                     dgb_other_tx_assembler_test dgb_reconstruct_won_block_test dgb_reconstruct_closure_test dgb_gentx_unpack_test dgb_work_source_test dgb_template_builder_test dgb_embedded_coin_node_test dgb_embedded_tx_select_test dgb_template_other_txs_test dgb_coinbase_value_parity_test dgb_submit_classify_test dgb_aux_parent_coinbase_parity_test dgb_template_capture_test dgb_aux_doge_db_commitment_bind_test \
                     rpc_request_test softfork_check_test genesis_check_test algo_select_test digishield_walk_test header_chain_test \
-                    dgb_coin_node_seam_test dgb_block_broadcast_test dgb_won_block_dispatch_test dgb_forced_won_share_dualpath_test dgb_scrypt_pow_test dgb_nonce_grinder_test dgb_regrind_block_test dgb_won_block_finalize_test dgb_share_target_genesis_test dgb_pool_msg_wire_test dgb_get_shares_walk_test dgb_download_stops_test dgb_think_p1_walk_bounds_test v37_test \
+                    dgb_coin_node_seam_test dgb_block_broadcast_test dgb_won_block_dispatch_test dgb_forced_won_share_dualpath_test dgb_scrypt_pow_test dgb_nonce_grinder_test dgb_regrind_block_test dgb_won_block_finalize_test dgb_share_target_genesis_test dgb_pool_msg_wire_test dgb_get_shares_walk_test dgb_download_stops_test dgb_think_p1_walk_bounds_test dgb_think_p1_desired_emit_test v37_test \
             -j$(nproc)
 
       - name: Run tests
@@ -216,7 +216,7 @@ jobs:
                     dgb_gentx_coinbase_test dgb_connection_coinbase_test dgb_pplns_payout_split_test nmc_auxpow_merkle_test nmc_template_builder_test nmc_auxpow_wire_test nmc_reconstruct_won_block_test dgb_gentx_share_path_test dgb_conn_pplns_producer_test dgb_other_tx_resolver_test \
                     dgb_other_tx_assembler_test dgb_reconstruct_won_block_test dgb_reconstruct_closure_test dgb_gentx_unpack_test dgb_work_source_test dgb_template_builder_test dgb_embedded_coin_node_test dgb_embedded_tx_select_test dgb_template_other_txs_test dgb_coinbase_value_parity_test dgb_submit_classify_test dgb_aux_parent_coinbase_parity_test dgb_template_capture_test dgb_aux_doge_db_commitment_bind_test \
                     rpc_request_test softfork_check_test genesis_check_test algo_select_test digishield_walk_test header_chain_test \
-                    dgb_coin_node_seam_test dgb_block_broadcast_test dgb_won_block_dispatch_test dgb_forced_won_share_dualpath_test dgb_scrypt_pow_test dgb_nonce_grinder_test dgb_regrind_block_test dgb_won_block_finalize_test dgb_share_target_genesis_test dgb_pool_msg_wire_test dgb_get_shares_walk_test dgb_download_stops_test dgb_think_p1_walk_bounds_test test_coin_broadcaster test_multiaddress_pplns test_pplns_stress \
+                    dgb_coin_node_seam_test dgb_block_broadcast_test dgb_won_block_dispatch_test dgb_forced_won_share_dualpath_test dgb_scrypt_pow_test dgb_nonce_grinder_test dgb_regrind_block_test dgb_won_block_finalize_test dgb_share_target_genesis_test dgb_pool_msg_wire_test dgb_get_shares_walk_test dgb_download_stops_test dgb_think_p1_walk_bounds_test dgb_think_p1_desired_emit_test test_coin_broadcaster test_multiaddress_pplns test_pplns_stress \
                     v37_test \
             -j$(nproc)
 

--- a/src/impl/dgb/test/CMakeLists.txt
+++ b/src/impl/dgb/test/CMakeLists.txt
@@ -618,4 +618,18 @@ if (BUILD_TESTING AND GTest_FOUND)
         dgb_coin pool sharechain)
     gtest_add_tests(dgb_think_p1_walk_bounds_test "" AUTO)
 
+    # dgb_think_p1_desired_emit_test: FENCED, additive KAT pinning the think()
+    # Phase-1 desired-emit decision in think_p1_desired_emit.hpp vs the p2pool
+    # data.py think() oracle (no-parent -> prune-zone(2*CL+10 inclusive) ->
+    # dedup -> emit ladder), plus a non-circular delegation anchor vs the verbatim
+    # pre-delegation inline ladder. Pure arithmetic/bools -> links only core. MUST
+    # also be in the build.yml --target allowlist (#143 NOT_BUILT trap).
+    add_executable(dgb_think_p1_desired_emit_test think_p1_desired_emit_test.cpp)
+    target_link_libraries(dgb_think_p1_desired_emit_test PRIVATE
+        GTest::gtest_main GTest::gtest
+        core dgb
+        c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage
+        dgb_coin pool sharechain)
+    gtest_add_tests(dgb_think_p1_desired_emit_test "" AUTO)
+
 endif()

--- a/src/impl/dgb/test/think_p1_desired_emit_test.cpp
+++ b/src/impl/dgb/test/think_p1_desired_emit_test.cpp
@@ -1,0 +1,123 @@
+// dgb think() Phase-1 DESIRED-EMIT decision conformance KAT.
+//
+// FENCED, additive (no production code touched this slice). Pins
+// src/impl/dgb/think_p1_desired_emit.hpp against the p2pool data.py think()
+// Phase-1 oracle for the requester-side desired-emit decision per unverified
+// head whose verify walk found nothing:
+//
+//   if last is null            -> SkipNoParent     (no parent hash to request)
+//   else if head_h >= 2*CL+10  -> SkipPruningZone  (parent re-pruned at once)
+//   else if already_desired    -> SkipDuplicate    (desired = set() dedup)
+//   else                       -> EmitRequest
+//
+// Two layers of evidence:
+//   1. Truth-table cases HAND-DERIVED from the oracle ladder (NOT read back from
+//      the subject — a KAT that asks its subject for the answer passes
+//      vacuously), incl. the inclusive 2*CL+10 prune boundary and the
+//      check-ORDER precedence (no-parent before prune-zone before dedup).
+//   2. A NON-CIRCULAR delegation anchor: a verbatim re-implementation of the
+//      pre-delegation inline ladder from share_tracker.hpp think() Phase 1,
+//      asserted EQUAL to the SSOT across an exhaustive input matrix. This is the
+//      guarantee the future share_tracker rewire preserves byte-identical
+//      behaviour — proven WITHOUT the SSOT appearing on both sides.
+//
+// Pure arithmetic/bools: links only core (no chain standup). MUST appear in BOTH
+// this dir's CMakeLists.txt AND the build.yml --target allowlist, or it becomes
+// a #143 NOT_BUILT sentinel (compiled-out, silently "passing").
+
+#include <impl/dgb/think_p1_desired_emit.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+namespace {
+
+using dgb::ThinkP1DesiredEmit;
+using dgb::think_p1_desired_emit;
+
+// ---- SkipNoParent: a null parent short-circuits BEFORE every other check,
+//      regardless of height / prune-zone / dedup state.
+TEST(ThinkP1DesiredEmit, NullParentSkipsFirst)
+{
+    constexpr int32_t CL = 10;
+    EXPECT_EQ(think_p1_desired_emit(true, 0,    CL, false), ThinkP1DesiredEmit::SkipNoParent);
+    EXPECT_EQ(think_p1_desired_emit(true, 5,    CL, false), ThinkP1DesiredEmit::SkipNoParent);
+    // even in the prune zone and already-desired, null parent still wins.
+    EXPECT_EQ(think_p1_desired_emit(true, 1000, CL, true),  ThinkP1DesiredEmit::SkipNoParent);
+}
+
+// ---- SkipPruningZone: non-null parent, head at/over the inclusive 2*CL+10
+//      threshold. Precedence: prune-zone check is BEFORE the dedup check.
+TEST(ThinkP1DesiredEmit, PruningZoneInclusiveAndBeforeDedup)
+{
+    constexpr int32_t CL = 10;            // threshold = 2*10 + 10 = 30
+    EXPECT_EQ(think_p1_desired_emit(false, 29, CL, false), ThinkP1DesiredEmit::EmitRequest);
+    EXPECT_EQ(think_p1_desired_emit(false, 30, CL, false), ThinkP1DesiredEmit::SkipPruningZone); // inclusive
+    EXPECT_EQ(think_p1_desired_emit(false, 31, CL, false), ThinkP1DesiredEmit::SkipPruningZone);
+    // prune-zone outranks dedup: already_desired=true must NOT change the verdict.
+    EXPECT_EQ(think_p1_desired_emit(false, 30, CL, true),  ThinkP1DesiredEmit::SkipPruningZone);
+
+    constexpr int32_t CL2 = 24;           // threshold = 2*24 + 10 = 58
+    EXPECT_EQ(think_p1_desired_emit(false, 57, CL2, false), ThinkP1DesiredEmit::EmitRequest);
+    EXPECT_EQ(think_p1_desired_emit(false, 58, CL2, false), ThinkP1DesiredEmit::SkipPruningZone);
+}
+
+// ---- SkipDuplicate vs EmitRequest: non-null parent, below prune zone, gated
+//      only by whether the parent hash is already in the desired set.
+TEST(ThinkP1DesiredEmit, DedupGatesEmissionBelowPruneZone)
+{
+    constexpr int32_t CL = 10;
+    EXPECT_EQ(think_p1_desired_emit(false, 0,  CL, false), ThinkP1DesiredEmit::EmitRequest);
+    EXPECT_EQ(think_p1_desired_emit(false, 0,  CL, true),  ThinkP1DesiredEmit::SkipDuplicate);
+    EXPECT_EQ(think_p1_desired_emit(false, 15, CL, false), ThinkP1DesiredEmit::EmitRequest);
+    EXPECT_EQ(think_p1_desired_emit(false, 15, CL, true),  ThinkP1DesiredEmit::SkipDuplicate);
+}
+
+// ---- NON-CIRCULAR delegation anchor.
+// Verbatim transcription of the pre-delegation inline ladder as it stands in
+// share_tracker.hpp think() Phase 1 (walk0 + for/else branches, identical):
+//
+//     if (!last.IsNull()) {
+//         if (head_height >= 2 * CL_prune + 10) { /* skip: pruning zone */ }
+//         else if (!desired_hashes.count(last)) { /* emit */ }
+//         /* else: implicit skip — duplicate */
+//     }
+//     /* else: implicit skip — no parent */
+//
+// Reproduced WITHOUT calling the SSOT, then asserted equal to it.
+ThinkP1DesiredEmit inline_reference(bool last_is_null, int32_t head_height,
+                                    int32_t CL, bool already_desired)
+{
+    if (!last_is_null) {
+        if (head_height >= 2 * CL + 10) {
+            return ThinkP1DesiredEmit::SkipPruningZone;
+        } else if (!already_desired) {
+            return ThinkP1DesiredEmit::EmitRequest;
+        } else {
+            return ThinkP1DesiredEmit::SkipDuplicate;
+        }
+    }
+    return ThinkP1DesiredEmit::SkipNoParent;
+}
+
+TEST(ThinkP1DesiredEmit, DelegationMatchesPreDelegationInlineLadder)
+{
+    // Exhaustive matrix across both CHAIN_LENGTH values, heights straddling the
+    // prune boundary, and both dedup/null states.
+    for (int32_t CL : {1, 10, 24, 50}) {
+        for (int32_t h = 0; h <= 2 * CL + 12; ++h) {
+            for (bool last_is_null : {false, true}) {
+                for (bool dup : {false, true}) {
+                    EXPECT_EQ(
+                        think_p1_desired_emit(last_is_null, h, CL, dup),
+                        inline_reference(last_is_null, h, CL, dup))
+                        << " CL=" << CL << " h=" << h
+                        << " null=" << last_is_null << " dup=" << dup;
+                }
+            }
+        }
+    }
+}
+
+} // namespace

--- a/src/impl/dgb/think_p1_desired_emit.hpp
+++ b/src/impl/dgb/think_p1_desired_emit.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+// SSOT for the think() Phase-1 DESIRED-EMIT decision — the requester-side rule
+// that decides, per unverified sharechain head whose verification walk found
+// nothing, WHETHER to emit a parent (desired) download request for that head's
+// resolved parent hash `last`, and if not, WHY it is suppressed.
+//
+// This decision is currently OPEN-CODED 2x inline in share_tracker.hpp think()
+// Phase 1: once in the walk0 branch (walk_count <= 0) and once in the for/else
+// branch (verification walk completed without verifying). Both copies run the
+// identical ladder:
+//
+//     if (!last.IsNull()) {                       // there IS a parent to request
+//         if (head_height >= 2*CL + 10)  -> skip  // pruning-zone (re-pruned anyway)
+//         else if (desired_hashes.count(last)) -> skip   // already desired (dedup)
+//         else -> desired_hashes.insert(last); desired.push_back({peer,last,ts})
+//     }
+//
+// A silent drift between the two copies — or against the p2pool oracle — would
+// change which parents a c2pool-dgb node requests during sync (or double-request
+// a hash, or keep requesting a prune-zone parent that clean_tracker immediately
+// drops) with NO compile error. Lifting the decision to a single header-only
+// SSOT lets a KAT pin the exact ladder, including the check ORDER (no-parent →
+// pruning-zone → duplicate → emit) and the inclusive 2*CL+10 prune boundary.
+//
+// Oracle: p2pool data.py:2095-2108 OkayTracker.think(), the `desired.add(...)`
+// emission inside the per-head verify loop; combined with c2pool-dgb's
+// node-local prune-zone guard (a head at/over 2*CHAIN_LENGTH+10 has parents that
+// clean_tracker would immediately re-prune, so no parent request is emitted) and
+// the desired-set dedup-by-hash (p2pool `desired = set()`).
+//
+// Composes with think_p1_in_pruning_zone() from think_p1_walk_bounds.hpp so the
+// prune boundary stays defined in exactly one place.
+//
+// Per-coin isolation: dgb/ only. Header-only, additive; this slice does NOT yet
+// rewire share_tracker.hpp (that is the byte-identity-fenced delegation
+// follow-on, mirroring the walk-bounds #353->#354 split) — it pins the decision
+// as a pure free function so the KAT exercises it with no ShareTracker/NodeImpl
+// standup. Consensus-neutral: the function only CLASSIFIES; the caller still
+// performs the desired-set insert + push on Emit. No value semantics changed.
+
+#include <impl/dgb/think_p1_walk_bounds.hpp>
+
+#include <cstdint>
+
+namespace dgb {
+
+// Outcome of the think() Phase-1 desired-emit decision for one unverified head.
+// Order matches the inline ladder's short-circuit precedence.
+enum class ThinkP1DesiredEmit {
+    SkipNoParent,     // last.IsNull(): head has no resolved parent to request
+    SkipPruningZone,  // head_height >= 2*CL+10: parent would be re-pruned at once
+    SkipDuplicate,    // parent hash already present in the desired set (dedup)
+    EmitRequest,      // emit a desired (parent download) request for `last`
+};
+
+// Decide whether think() Phase-1 should emit a desired parent-download request.
+//   last_is_null   : true if the head's resolved parent (`last`) is null.
+//   head_height    : accumulated height of the head.
+//   chain_length   : PoolConfig::chain_length() (CHAIN_LENGTH).
+//   already_desired: true if `last` is already in the running desired-hash set.
+// The caller performs the desired_hashes.insert(last) + desired.push_back(...)
+// side effects ONLY when this returns EmitRequest.
+inline ThinkP1DesiredEmit think_p1_desired_emit(bool last_is_null,
+                                                int32_t head_height,
+                                                int32_t chain_length,
+                                                bool already_desired)
+{
+    if (last_is_null)
+        return ThinkP1DesiredEmit::SkipNoParent;
+    if (think_p1_in_pruning_zone(head_height, chain_length))
+        return ThinkP1DesiredEmit::SkipPruningZone;
+    if (already_desired)
+        return ThinkP1DesiredEmit::SkipDuplicate;
+    return ThinkP1DesiredEmit::EmitRequest;
+}
+
+} // namespace dgb


### PR DESCRIPTION
## Phase-B pool/share — think() Phase-1 requester desired-emit SSOT

Follow-on to #353/#354 (think() Phase-1 walk-bounds). Lifts the **desired-emit decision** — the requester-side rule that decides whether an unverified head emits a parent (desired) download request — to a header-only SSOT.

### Problem
The ladder is open-coded **2x** inline in `share_tracker.hpp` think() Phase 1 (walk0 branch + for/else branch), identical in both:
```
no-parent (last null)        -> skip
head_h >= 2*CL+10 (inclusive) -> skip  (pruning-zone; clean_tracker re-prunes)
already in desired set        -> skip  (dedup; p2pool desired = set())
else                          -> emit
```
Silent drift between the two copies — or vs the p2pool data.py oracle — would change which parents a node requests during sync, double-request a hash, or keep requesting a prune-zone parent, with **no compile error**.

### This slice
- New `src/impl/dgb/think_p1_desired_emit.hpp`: pure `think_p1_desired_emit()` returning a 4-way `ThinkP1DesiredEmit` enum, **composing** `think_p1_in_pruning_zone()` from #353 so the prune boundary stays defined once. Classifies only — caller keeps the desired-set insert+push side effects on `EmitRequest`.
- **FENCED, additive**: `share_tracker.hpp` is **NOT** rewired this slice (byte-identity delegation is the follow-on, mirroring the #353->#354 split).
- KAT 4/4 (`dgb_think_p1_desired_emit_test`):
  1. Hand-derived truth-table — inclusive 2*CL+10 boundary + check-**ORDER** precedence (no-parent before prune-zone before dedup), expectations derived from the oracle not read back from the subject.
  2. Non-circular `DelegationMatchesPreDelegationInlineLadder` anchor — verbatim re-impl of the pre-delegation inline ladder asserted EQUAL to the SSOT across an exhaustive CL/height/null/dup matrix.

### Fence
dgb-tree-local; pure arithmetic, consensus-neutral; new target in `test/CMakeLists.txt` + **both** `build.yml` allowlists (#143 NOT_BUILT trap). No shared/other-coin/CMake-core/allowlist-cross changes. Attribution clean, GPG-signed.

No self-merge — surfacing for operator tap.