### PR TITLE
web: rest_web_currency_info handles DigiByte + truthful default

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -4703,6 +4703,30 @@ nlohmann::json MiningInterface::rest_web_currency_info()
             result["tx_explorer_url_prefix"]      = "https://blockchair.com/dash/transaction/";
         }
         break;
+    case Blockchain::DIGIBYTE:
+        result["symbol"] = "DGB";
+        result["name"] = "DigiByte";
+        result["block_period"] = 15;   // ~15 s average (multi-algo)
+        if (!m_custom_address_explorer.empty()) {
+            result["address_explorer_url_prefix"] = m_custom_address_explorer;
+            result["block_explorer_url_prefix"]   = m_custom_block_explorer;
+            result["tx_explorer_url_prefix"]      = m_custom_tx_explorer;
+        } else {
+            result["address_explorer_url_prefix"] = "https://blockchair.com/digibyte/address/";
+            result["block_explorer_url_prefix"]   = "https://blockchair.com/digibyte/block/";
+            result["tx_explorer_url_prefix"]      = "https://blockchair.com/digibyte/transaction/";
+        }
+        break;
+    default:
+        // Per-node truthfulness: never fabricate a coin identity we do not know.
+        // Honor an operator-configured custom explorer if present; otherwise leave
+        // symbol/name unset so the dashboard shows unknown rather than a wrong coin.
+        if (!m_custom_address_explorer.empty()) {
+            result["address_explorer_url_prefix"] = m_custom_address_explorer;
+            result["block_explorer_url_prefix"]   = m_custom_block_explorer;
+            result["tx_explorer_url_prefix"]      = m_custom_tx_explorer;
+        }
+        break;
     }
 
     // Expose explorer state so dashboard JS can link to internal explorer


### PR DESCRIPTION
Charter #2 (per-node truthful dashboard). rest_web_currency_info() switch had cases only for LTC/BTC/DOGE/DASH, so a DigiByte node returned currency_info with no symbol/name/block_period/explorer, and any other enum fell through silently with no default. Adds a DIGIBYTE case (DGB, 15s blocks, blockchair explorer, custom-override honored) and a truthful default that never fabricates an unknown coin identity (honors configured custom explorer, leaves symbol/name unset). Switch is now enum-exhaustive. Non-consensus web layer, per-node read path only; pool aggregates untouched.