### PR TITLE
web: derive explorer/coin-admin default chain from node blockchain (no hardcoded ltc)

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -648,7 +648,7 @@ void HttpSession::process_request()
                     if (qpos != std::string::npos) ep = ep.substr(0, qpos);
 
                     std::string chain = getQueryParam("chain");
-                    if (chain.empty()) chain = "ltc";
+                    if (chain.empty()) chain = mining_interface_->primary_chain_key();
 
                     if (ep == "peers/list") {
                         rest_result = mining_interface_->call_admin_coin_list_peers(chain);
@@ -694,7 +694,7 @@ void HttpSession::process_request()
                     }
 
                     std::string chain = getQueryParam("chain");
-                    if (chain.empty()) chain = "ltc";
+                    if (chain.empty()) chain = mining_interface_->primary_chain_key();
 
                     std::string ep = target.substr(14);
 
@@ -1019,7 +1019,7 @@ void MiningInterface::setup_methods()
     // as if it were a standard Bitcoin/Litecoin daemon.
     Add("getblockchaininfo", jsonrpccxx::MethodHandle([this](const nlohmann::json& params) -> nlohmann::json {
         if (has_explorer_chaininfo_fn())
-            return call_explorer_chaininfo("ltc");
+            return call_explorer_chaininfo(primary_chain_key());
         return nlohmann::json{{"error", "explorer not enabled"}};
     }));
 
@@ -1027,26 +1027,26 @@ void MiningInterface::setup_methods()
         if (!has_explorer_blockhash_fn() || params.empty())
             return nullptr;
         uint32_t h = params[0].get<uint32_t>();
-        return call_explorer_blockhash(h, "ltc");
+        return call_explorer_blockhash(h, primary_chain_key());
     }));
 
     Add("getblock", jsonrpccxx::MethodHandle([this](const nlohmann::json& params) -> nlohmann::json {
         if (!has_explorer_getblock_fn() || params.empty())
             return nullptr;
         std::string hash = params[0].get<std::string>();
-        return call_explorer_getblock(hash, "ltc");
+        return call_explorer_getblock(hash, primary_chain_key());
     }));
 
     Add("getmempoolinfo", jsonrpccxx::MethodHandle([this](const nlohmann::json& params) -> nlohmann::json {
         if (has_explorer_mempoolinfo_fn())
-            return call_explorer_mempoolinfo("ltc");
+            return call_explorer_mempoolinfo(primary_chain_key());
         return nlohmann::json::object();
     }));
 
     Add("getrawmempool", jsonrpccxx::MethodHandle([this](const nlohmann::json& params) -> nlohmann::json {
         if (has_explorer_rawmempool_fn()) {
             bool verbose = (!params.empty() && params[0].get<bool>());
-            return call_explorer_rawmempool("ltc", verbose, 500);
+            return call_explorer_rawmempool(primary_chain_key(), verbose, 500);
         }
         return nlohmann::json::array();
     }));

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -1223,6 +1223,22 @@ public:
     bool is_explorer_enabled() const { return m_explorer_enabled; }
     void set_explorer_url(const std::string& url) { m_explorer_url = url; }
     const std::string& get_explorer_url() const { return m_explorer_url; }
+
+    // Primary chain key for THIS node, derived from its configured blockchain
+    // (lowercase symbol). Used as the default chain for explorer / coin-admin
+    // endpoints instead of a hardcoded "ltc": a DGB/DASH/BTC node must not
+    // silently serve Litecoin data. Empty for UNKNOWN so callers surface a
+    // truthful "chain not enabled" rather than a fabricated coin identity.
+    std::string primary_chain_key() const {
+        switch (m_blockchain) {
+            case Blockchain::LITECOIN: return "ltc";
+            case Blockchain::BITCOIN:  return "btc";
+            case Blockchain::DOGECOIN: return "doge";
+            case Blockchain::DASH:     return "dash";
+            case Blockchain::DIGIBYTE: return "dgb";
+            default:                   return "";
+        }
+    }
     void set_explorer_chaininfo_fn(explorer_chaininfo_fn_t fn) { m_explorer_chaininfo_fn = thread_safe_wrap(std::move(fn)); }
     void set_explorer_blockhash_fn(explorer_blockhash_fn_t fn) { m_explorer_blockhash_fn = thread_safe_wrap(std::move(fn)); }
     void set_explorer_getblock_fn(explorer_getblock_fn_t fn) { m_explorer_getblock_fn = thread_safe_wrap(std::move(fn)); }


### PR DESCRIPTION
## What

The `/api/explorer/*` and `/api/admin/coin/*` HTTP handlers, plus the explorer JSON-RPC adapter (`getblockchaininfo`, `getblockhash`, `getblock`, `getmempoolinfo`, `getrawmempool`), defaulted the chain to a **hardcoded `"ltc"`** when no `?chain=` was supplied. On a non-LTC-primary node (DGB/DASH/BTC) that silently served — or tried to serve — Litecoin data under the wrong coin identity.

Adds `MiningInterface::primary_chain_key()`, which maps the node-configured `m_blockchain` to a lowercase chain key (`ltc`/`btc`/`doge`/`dash`/`dgb`; empty for `UNKNOWN`), and uses it as the default everywhere instead of the literal. A node whose explorer does not support its primary chain now returns a truthful `chain not enabled` rather than fabricated LTC data.

## Scope

Web/read layer only (`core/web_server.{hpp,cpp}`). Pool aggregates and consensus paths untouched. Non-consensus → normal merge + operator merge-tap.

Charter #2: per-node truthful dashboard — *never a hardcoded LTC+DOGE shape*.