### PR TITLE
web: add DASH case to blockchain_short_symbol (no UNKNOWN coin label)

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -6256,6 +6256,7 @@ const char* blockchain_short_symbol(Blockchain b)
         case Blockchain::LITECOIN: return "LTC";
         case Blockchain::BITCOIN:  return "BTC";
         case Blockchain::DOGECOIN: return "DOGE";
+        case Blockchain::DASH:     return "DASH";
         case Blockchain::DIGIBYTE: return "DGB";
         case Blockchain::ETHEREUM: return "ETH";
         case Blockchain::MONERO:   return "XMR";


### PR DESCRIPTION
## Charter #2 — per-node truthful dashboard

`blockchain_short_symbol()` (src/core/web_server.cpp ~6253) had cases for LTC/BTC/DOGE/DGB/ETH/XMR/ZEC but **no Blockchain::DASH case** — though the enum value exists in address_validator.hpp. A Dash node therefore returned `"UNKNOWN"` for `out["coin"]`, mislabeling its own coin on the dashboard.

Fix: one-line `case Blockchain::DASH: return "DASH";`. Read/web-stats path only; pool aggregates and consensus untouched. Non-consensus web layer → normal merge + operator merge-tap.

Flagged earlier while shipping #363.