### PR TITLE
dgb: advertise oracle p2p.py VERSION (3501) in outbound handshake, not accept-floor

### DIFF
--- a/src/impl/dgb/config_pool.hpp
+++ b/src/impl/dgb/config_pool.hpp
@@ -34,7 +34,7 @@ public:
     static constexpr uint32_t SPREAD                    = 24;
     static constexpr uint32_t TARGET_LOOKBEHIND         = 100;
     static constexpr uint32_t MINIMUM_PROTOCOL_VERSION    = 1700;  // floor (p2pool-dgb-scrypt digibyte.py NEW_MIN)
-    static constexpr uint32_t ADVERTISED_PROTOCOL_VERSION = 3301;  // advertised capability (p2pool-dgb-scrypt p2p.py VERSION)
+    static constexpr uint32_t ADVERTISED_PROTOCOL_VERSION = 3501;  // advertised P2P protocol capability == oracle frstrtr/p2pool-dgb-scrypt p2p.py:28 Protocol.VERSION
     static constexpr uint32_t SEGWIT_ACTIVATION_VERSION = 35;     // canonical oracle p2pool-dgb-scrypt digibyte.py:27 (merged-v36 farsider350=17 WAIVED for DGB per operator 2026-06-17)
     static constexpr uint32_t BLOCK_MAX_SIZE            = 32000000;
     static constexpr uint32_t BLOCK_MAX_WEIGHT          = 128000000;

--- a/src/impl/dgb/node.cpp
+++ b/src/impl/dgb/node.cpp
@@ -249,7 +249,7 @@ int NodeImpl::get_verified_count() const { return get_tracker_snapshot().verifie
 void NodeImpl::send_version(peer_ptr peer)
 {
     auto rmsg = dgb::message_version::make_raw(
-        m_tracker.m_params->minimum_protocol_version,
+        m_tracker.m_params->advertised_protocol_version,  // advertise our capability (oracle p2p.py VERSION 3501), NOT the accept-floor (handle_version keeps minimum_protocol_version as the reject floor)
         1,                                    // services
         addr_t{1, peer->addr()},              // addr_to (the remote)
         addr_t{1, NetService{"0.0.0.0", m_tracker.m_params->p2p_port}}, // addr_from (us)

--- a/src/impl/dgb/params.hpp
+++ b/src/impl/dgb/params.hpp
@@ -85,7 +85,8 @@ inline core::CoinParams make_coin_params(bool testnet)
 
     p.target_lookbehind        = PoolConfig::TARGET_LOOKBEHIND;          // 100
     p.spread                   = PoolConfig::SPREAD;                     // 24
-    p.minimum_protocol_version = PoolConfig::MINIMUM_PROTOCOL_VERSION;   // 1700 floor
+    p.minimum_protocol_version = PoolConfig::MINIMUM_PROTOCOL_VERSION;   // 1700 floor (digibyte.py NEW_MIN; accept-floor only)
+    p.advertised_protocol_version = PoolConfig::ADVERTISED_PROTOCOL_VERSION; // 3501 (oracle p2p.py VERSION) -- what we ADVERTISE, not the accept-floor
     p.block_max_size           = PoolConfig::BLOCK_MAX_SIZE;
     p.block_max_weight         = PoolConfig::BLOCK_MAX_WEIGHT;
 

--- a/src/impl/dgb/test/share_test.cpp
+++ b/src/impl/dgb/test/share_test.cpp
@@ -48,9 +48,34 @@ TEST(DGB_share_test, OracleConsensusParams)
     EXPECT_EQ(dgb::PoolConfig::P2P_PORT,                   5024u);
     EXPECT_EQ(dgb::PoolConfig::SEGWIT_ACTIVATION_VERSION,  35u);
     EXPECT_EQ(dgb::PoolConfig::MINIMUM_PROTOCOL_VERSION,   1700u);
-    EXPECT_EQ(dgb::PoolConfig::ADVERTISED_PROTOCOL_VERSION, 3301u);
+    EXPECT_EQ(dgb::PoolConfig::ADVERTISED_PROTOCOL_VERSION, 3501u);  // oracle p2p.py:28 Protocol.VERSION (was wrongly 3301)
     EXPECT_EQ(dgb::PoolConfig::SHARE_PERIOD,               15u);
     EXPECT_EQ(dgb::PoolConfig::CHAIN_LENGTH,               2880u);
+}
+
+// G1 version-semantics guard: the OUTBOUND version handshake must ADVERTISE our
+// capability (oracle frstrtr/p2pool-dgb-scrypt p2p.py:28 Protocol.VERSION = 3501),
+// NOT the accept-floor. The accept-floor (digibyte.py NEW_MIN = 1700) stays the
+// inbound reject threshold (node.cpp handle_version). These are two distinct
+// fields per p2pool: send_version(version=self.VERSION); reject if version<NEW_MIN.
+// Regression caught: send_version previously fed minimum_protocol_version (1700)
+// into the version field, so a mature oracle network (MINIMUM_PROTOCOL_VERSION
+// ratcheted to 3500) would reject us as "peer too old".
+TEST(DGB_share_test, OracleAdvertisedVsAcceptFloorProtocolVersion)
+{
+    const core::CoinParams main = dgb::make_coin_params(/*testnet=*/false);
+    EXPECT_EQ(main.advertised_protocol_version, 3501u);  // oracle p2p.py VERSION (what we SEND)
+    EXPECT_EQ(main.minimum_protocol_version,    1700u);  // digibyte.py NEW_MIN (inbound accept-floor)
+    // We must advertise ABOVE the floor so a mature oracle net (floor->3500) accepts us.
+    EXPECT_GT(main.advertised_protocol_version, main.minimum_protocol_version);
+    EXPECT_GE(main.advertised_protocol_version, 3500u);
+
+    // NOTE: testnet coverage is asserted via the net-independent PoolConfig
+    // constant below rather than make_coin_params(true) -- the testnet builder
+    // leaks a global max_target that corrupts later mainnet-expecting tests if
+    // it runs mid-suite (harmless in prod: one net is built per process).
+    EXPECT_EQ(dgb::PoolConfig::ADVERTISED_PROTOCOL_VERSION, 3501u);
+    EXPECT_EQ(dgb::PoolConfig::MINIMUM_PROTOCOL_VERSION,    1700u);
 }
 
 // Pool/share layer timing + bound params — audited CONFORM to the DGB oracle


### PR DESCRIPTION
## What
DGB outbound `send_version` advertised `minimum_protocol_version` (1700 = the inbound accept-floor / digibyte.py NEW_MIN) in the handshake version field. Against a mature oracle network (frstrtr/p2pool-dgb-scrypt) whose accept-floor has ratcheted toward `p2p.py` Protocol.VERSION (3501), that under-advertisement = rejected as a too-old peer.

## Change (fenced, DGB-tree-local)
- New `PoolConfig::ADVERTISED_PROTOCOL_VERSION = 3501` (oracle p2p.py:28; fixes prior wrong 3301).
- Wire existing `core::CoinParams.advertised_protocol_version` (already on master) in params.hpp.
- `send_version` now sends advertised version, NOT the accept-floor. Accept-floor (1700) stays the inbound reject threshold in `handle_version` — matches p2pool: `send_version(version=self.VERSION)`; reject if `version < NEW_MIN`.

## Conformance
Two distinct fields per p2pool oracle; no shared-base touch (core field pre-exists). v36 bucket: per-coin consensus/handshake (NOT an isolation primitive, NOT cross-coin-standardize).

## Test
`dgb_share_test` 9/9 green incl new `OracleAdvertisedVsAcceptFloorProtocolVersion` (pins advertised>floor, >=3500, ==3501 vs oracle). No allowlist change (existing test file).

No self-merge — integrator taps on operator approval.