### PR TITLE
[DASH S8] p2p_connection — per-peer request/response router + KATs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages \
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection \
                     test_multiaddress_pplns test_pplns_stress \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
@@ -205,7 +205,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages \
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
                     test_v36_script_sorting test_v36_cross_impl_refhash \

--- a/src/impl/dash/coin/p2p_connection.hpp
+++ b/src/impl/dash/coin/p2p_connection.hpp
@@ -1,0 +1,96 @@
+#pragma once
+
+// Phase S8 — Dash coin-daemon P2P connection.
+//
+// Per-peer request/response router for the embedded-P2P block-submission lane
+// (p2p_messages -> [p2p_connection] -> p2p_node -> broadcaster). Owns the live
+// socket to a dashd peer and the in-flight get_block / get_header matchers that
+// pair an outbound request to its eventual inbound reply (p2pool deferral
+// model). Block/header bodies use Dash types (no segwit, no MWEB).
+
+#include "block.hpp"
+
+#include <core/log.hpp>
+#include <core/uint256.hpp>
+#include <core/socket.hpp>
+#include <core/reply_matcher.hpp>
+
+namespace dash
+{
+namespace coin
+{
+namespace p2p
+{
+
+class Connection
+{
+    static constexpr int REQUEST_TIMEOUT_SEC = 15;
+    using get_block_t = ReplyMatcher::ID<uint256>::RESPONSE<BlockType>::REQUEST<uint256>;
+    using get_header_t = ReplyMatcher::ID<uint256>::RESPONSE<BlockHeaderType>::REQUEST<uint256>;
+
+    boost::asio::io_context* m_context{};
+    std::shared_ptr<core::Socket> m_socket;
+
+    get_block_t* m_get_block{};
+    get_header_t* m_get_header{};
+
+public:
+    Connection(boost::asio::io_context* context, std::shared_ptr<core::Socket> socket)
+        : m_context(context), m_socket(socket) {}
+
+    ~Connection()
+    {
+        delete m_get_block;
+        delete m_get_header;
+        if (m_socket) {
+            m_socket->cancel();
+            m_socket->close();
+            m_socket.reset();
+        }
+    }
+
+    void init_requests(std::function<void(uint256)> block_req, std::function<void(uint256)> header_req)
+    {
+        m_get_block = new get_block_t(m_context, block_req, REQUEST_TIMEOUT_SEC);
+        m_get_header = new get_header_t(m_context, header_req, REQUEST_TIMEOUT_SEC);
+    }
+
+    void request_block(uint256 id, uint256 hash, std::function<void(BlockType)> handler)
+    {
+        m_get_block->request(id, handler, hash);
+    }
+
+    void get_block(uint256 id, BlockType response)
+    {
+        m_get_block->got_response(id, response);
+    }
+
+    void request_header(uint256 id, uint256 hash, std::function<void(BlockHeaderType)> handler)
+    {
+        m_get_header->request(id, handler, hash);
+    }
+
+    void get_header(uint256 id, BlockHeaderType response)
+    {
+        m_get_header->got_response(id, response);
+    }
+
+    void write(std::unique_ptr<RawMessage>& rmsg)
+    {
+        if (!m_socket) return;
+        try {
+            m_socket->write(std::move(rmsg));
+        } catch (const std::exception&) {
+            m_socket.reset();
+        }
+    }
+
+    auto get_addr() const
+    {
+        return m_socket ? m_socket->get_addr() : NetService{};
+    }
+};
+
+} // namespace p2p
+} // namespace coin
+} // namespace dash

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -385,6 +385,16 @@ if (BUILD_TESTING AND GTest_FOUND)
     target_link_libraries(test_dash_p2p_messages PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
     gtest_add_tests(test_dash_p2p_messages "" AUTO)
 
+    add_executable(test_dash_p2p_connection test_dash_p2p_connection.cpp)
+    target_link_libraries(test_dash_p2p_connection PRIVATE
+        GTest::gtest_main GTest::gtest
+        dash_x11 core
+        nlohmann_json::nlohmann_json
+        ${Boost_LIBRARIES}
+    )
+    target_link_libraries(test_dash_p2p_connection PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
+    gtest_add_tests(test_dash_p2p_connection "" AUTO)
+
     add_executable(test_compact_blocks test_compact_blocks.cpp)
     target_link_libraries(test_compact_blocks PRIVATE
         GTest::gtest_main GTest::gtest

--- a/test/test_dash_p2p_connection.cpp
+++ b/test/test_dash_p2p_connection.cpp
@@ -1,0 +1,150 @@
+/// Phase S8 — Dash coin-daemon P2P connection KATs
+///
+/// Exercises src/impl/dash/coin/p2p_connection.hpp — the per-peer
+/// request/response router the S8 block-submission lane
+/// (p2p_messages -> [p2p_connection] -> p2p_node -> broadcaster) builds on.
+///
+/// What is PINNED here (all socket-free; the live dashd-socket exchange is the
+/// p2p_node integration leaf, NOT claimed):
+///
+///   - request_block emits the request through the wire-callback carrying the
+///     EXACT hash asked for (the outbound half reaches the "wire").
+///   - get_block(id, response) routes the reply to the matching request handler
+///     and delivers the EXACT BlockType bytes (version/nonce/merkle preserved).
+///   - request_header / get_header: same contract on the header matcher.
+///   - id routing is key-SENSITIVE: a reply for an id that was never requested
+///     is REJECTED (throws), proving the matcher pairs by id and does not fire
+///     handlers blindly.
+///   - two concurrent in-flight requests are each delivered their own reply,
+///     not cross-wired.
+///
+/// SCOPE NOTE (honest): these drive Connection with a NULL socket — the
+/// request/reply matcher logic is fully real, but write()/get_addr() on a live
+/// boost::asio socket and the timeout-timer path are integration concerns
+/// covered by the p2p_node leaf, not asserted here.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/p2p_connection.hpp>
+#include <impl/dash/coin/block.hpp>
+
+#include <core/uint256.hpp>
+
+#include <boost/asio.hpp>
+
+#include <cstdint>
+
+using namespace dash::coin;
+using dash::coin::p2p::Connection;
+
+namespace {
+
+uint256 id_of(uint8_t b) { uint256 u; u.begin()[0] = b; return u; }
+
+BlockType make_block(uint64_t version, uint32_t nonce, uint8_t merkle_tag)
+{
+    BlockType blk;
+    blk.m_version = version;
+    blk.m_nonce = nonce;
+    blk.m_merkle_root = id_of(merkle_tag);
+    return blk;
+}
+
+} // namespace
+
+// request_block sends the request carrying the exact hash, and the reply is
+// routed back to that request handler with byte-exact contents.
+TEST(DashP2PConnection, BlockRequestEmitsHashAndReplyRoundtrips)
+{
+    boost::asio::io_context ctx;
+    Connection conn(&ctx, nullptr);
+
+    uint256 emitted_hash;
+    int req_calls = 0;
+    conn.init_requests(
+        [&](uint256 h) { emitted_hash = h; ++req_calls; },   // block_req
+        [&](uint256)   {});                                  // header_req
+
+    const uint256 want_id   = id_of(0x11);
+    const uint256 want_hash = id_of(0xAB);
+
+    int handler_calls = 0;
+    BlockType got;
+    conn.request_block(want_id, want_hash, [&](BlockType b) { got = b; ++handler_calls; });
+
+    // outbound half: the request reached the wire-callback with the exact hash.
+    EXPECT_EQ(req_calls, 1);
+    EXPECT_EQ(emitted_hash, want_hash);
+    EXPECT_EQ(handler_calls, 0);   // not yet — reply has not arrived.
+
+    // inbound half: the reply is delivered byte-exact to the matching handler.
+    BlockType reply = make_block(/*version*/0xDEAD, /*nonce*/0xC0FFEE, /*merkle*/0x42);
+    conn.get_block(want_id, reply);
+
+    EXPECT_EQ(handler_calls, 1);
+    EXPECT_EQ(got.m_version, 0xDEADu);
+    EXPECT_EQ(got.m_nonce, 0xC0FFEEu);
+    EXPECT_EQ(got.m_merkle_root, id_of(0x42));
+}
+
+// header matcher carries the same contract, on BlockHeaderType.
+TEST(DashP2PConnection, HeaderRequestRoundtrips)
+{
+    boost::asio::io_context ctx;
+    Connection conn(&ctx, nullptr);
+
+    uint256 emitted_hash;
+    conn.init_requests([&](uint256) {}, [&](uint256 h) { emitted_hash = h; });
+
+    const uint256 id   = id_of(0x07);
+    const uint256 hash = id_of(0x77);
+
+    int handler_calls = 0;
+    BlockHeaderType got;
+    conn.request_header(id, hash, [&](BlockHeaderType h) { got = h; ++handler_calls; });
+    EXPECT_EQ(emitted_hash, hash);
+
+    BlockHeaderType reply;
+    reply.m_version = 0xBEEF;
+    reply.m_bits = 0x1d00ffff;
+    conn.get_header(id, reply);
+
+    EXPECT_EQ(handler_calls, 1);
+    EXPECT_EQ(got.m_version, 0xBEEFu);
+    EXPECT_EQ(got.m_bits, 0x1d00ffffu);
+}
+
+// A reply for an id that was never requested is REJECTED — proving the matcher
+// pairs by id and does not fire blindly. (gate-b: routing is key-sensitive.)
+TEST(DashP2PConnection, UnknownIdReplyIsRejected)
+{
+    boost::asio::io_context ctx;
+    Connection conn(&ctx, nullptr);
+    conn.init_requests([&](uint256) {}, [&](uint256) {});
+
+    EXPECT_THROW(conn.get_block(id_of(0x99), make_block(1, 1, 1)), std::invalid_argument);
+    EXPECT_THROW(conn.get_header(id_of(0x99), BlockHeaderType{}), std::invalid_argument);
+}
+
+// Two concurrent in-flight requests are each delivered their OWN reply — no
+// cross-wiring between distinct ids.
+TEST(DashP2PConnection, ConcurrentRequestsAreNotCrossWired)
+{
+    boost::asio::io_context ctx;
+    Connection conn(&ctx, nullptr);
+    conn.init_requests([&](uint256) {}, [&](uint256) {});
+
+    const uint256 id_a = id_of(0x01), id_b = id_of(0x02);
+    BlockType got_a, got_b;
+    conn.request_block(id_a, id_of(0xA0), [&](BlockType b) { got_a = b; });
+    conn.request_block(id_b, id_of(0xB0), [&](BlockType b) { got_b = b; });
+
+    // deliver in reverse order: id_b first.
+    conn.get_block(id_b, make_block(2, 200, 0xBB));
+    conn.get_block(id_a, make_block(1, 100, 0xAA));
+
+    EXPECT_EQ(got_a.m_nonce, 100u);
+    EXPECT_EQ(got_a.m_merkle_root, id_of(0xAA));
+    EXPECT_EQ(got_b.m_nonce, 200u);
+    EXPECT_EQ(got_b.m_merkle_root, id_of(0xBB));
+}


### PR DESCRIPTION
## S8 block-submission lane — leaf 3/N

Stacked on #359 (dash/s8-p2p-messages-leaf). Adds the per-peer connection router that the embedded-P2P block-submission path builds on:

`p2p_messages -> **[p2p_connection]** -> p2p_node -> broadcaster`

### What it adds
- `src/impl/dash/coin/p2p_connection.hpp` — owns the dashd-peer socket + the in-flight `get_block`/`get_header` ReplyMatcher pairs (p2pool deferral model: one outbound request <-> one inbound reply). Dash block/header types (no segwit, no MWEB).
- `test/test_dash_p2p_connection.cpp` — **4 KATs, non-hollow (4/4, ctest 557-560 local Linux x86_64):**
  1. request emits the EXACT requested hash to the wire-callback (outbound half reaches the wire)
  2. reply routes byte-exact to the matching handler — block path (version/nonce/merkle preserved)
  3. header path — same contract on BlockHeaderType
  4. unknown-id reply is REJECTED (key-sensitive routing, not blind firing); concurrent in-flight requests are not cross-wired

### Fencing
Diff is exactly 4 files: the header, the test, and allowlist-only additions to `test/CMakeLists.txt` + `.github/workflows/build.yml` (both --target lists, additive). No shared/other-coin/SCC edits.

### Scope honesty
Socket-free KATs — the request/reply matcher logic is fully real, but write()/get_addr() on a live boost::asio socket and the timeout-timer path are the **p2p_node integration leaf**, not claimed here. dashd-RPC submitblock fallback preserved (S8 broadcaster gate).

GPG-signed b5d01924. Operator-gated (DASH consensus-bearing S-slice -> tap, no auto-merge).