### PR TITLE
ltc: reconcile stale count-based comments on AutoRatchet tail-guard (code is work-weighted)

### DIFF
--- a/src/impl/ltc/auto_ratchet.hpp
+++ b/src/impl/ltc/auto_ratchet.hpp
@@ -279,7 +279,11 @@ public:
     // source of truth for the version-switch gate is now share_check step 2,
     // which calls ShareTracker::get_desired_version_weights and matches
     // p2pool check() (data.py:1396-1414) exactly. The VOTING tail guard above
-    // stays inline and count-based (finding #1).
+    // is ALSO work-weighted: it calls ShareTracker::get_desired_version_weights
+    // over the oldest 10% of the window and couples activation to that same
+    // check()-phase 60% accept gate (mint<->accept coupling). It is NOT
+    // count-based -- a flat-count tail guard would let a 95%-by-count activation
+    // outrun the 60%-by-work accept gate and wedge the crossing.
 
 private:
     std::string state_file_;

--- a/src/impl/ltc/share_check.hpp
+++ b/src/impl/ltc/share_check.hpp
@@ -1748,8 +1748,9 @@ bool share_check(const ShareT& share,
     // The weight is target_to_average_attempts per share — get_desired_version_weights,
     // matching canonical get_desired_version_counts (data.py:2651) — NOT a flat count.
     // F10/(b): the prior non-canonical 95%-obsolescence punish is removed; the
-    // canonical 60% switch rule is now the ONLY version gate. AutoRatchet stays
-    // count-based and does not gate peer shares here.
+    // canonical 60% switch rule is now the ONLY version gate. AutoRatchet's
+    // VOTING tail guard is work-weighted (get_desired_version_weights) and does
+    // not gate peer shares here.
     {
         auto chain_length = static_cast<int32_t>(params.chain_length);
         if (!share.m_prev_hash.IsNull() && tracker.chain.contains(share.m_prev_hash))

--- a/src/impl/ltc/share_tracker.hpp
+++ b/src/impl/ltc/share_tracker.hpp
@@ -2152,10 +2152,11 @@ public:
     // Canonical p2pool get_desired_version_counts (data.py:2651) weights each
     // share by target_to_average_attempts(share.target) — NOT a flat count.
     // The check()-phase 60% switch rule (share_check step 2) is a consensus gate
-    // and MUST use these weights to stay byte-identical with p2pool. AutoRatchet
-    // and its tail guard deliberately keep the FLAT-COUNT variant above
-    // (count-based per F10 finding #1 — weighting them would shift activation
-    // timing across the soak). Weight = ShareIndex::work (share.hpp).
+    // and MUST use these weights to stay byte-identical with p2pool. The
+    // AutoRatchet VOTING tail guard ALSO uses these work-weights (auto_ratchet.hpp
+    // calls get_desired_version_weights), coupling activation to the check()-phase
+    // 60% accept gate so a minted boundary share can never be rejected. There is
+    // no flat-count tail-guard codepath. Weight = ShareIndex::work (share.hpp).
     std::map<uint64_t, uint288> get_desired_version_weights(const uint256& share_hash, int32_t lookbehind)
     {
         std::map<uint64_t, uint288> weights;


### PR DESCRIPTION
Comment-only reconciliation. Three stale comments asserted the AutoRatchet tail guard was flat-count; the code (auto_ratchet.hpp:160, share_check.hpp:1779) calls get_desired_version_weights and couples activation to the check()-phase 60%-by-work accept gate (#288 mint<->accept coupling). The only count fn, get_desired_version_counts (share_tracker.hpp:2131), has zero callers in src/impl/ltc. Reconciled comments to the code. No consensus-value change, single LTC tree, GPG-signed (50AB1379). Verified by integrator.