### PR TITLE
web: add DOGECOIN case to payout-address encoding (no BTC fallback)

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -7145,6 +7145,12 @@ void MiningInterface::update_stat_log()
             case Blockchain::DASH:
                 return m_testnet ? std::make_tuple<uint8_t, uint8_t, std::string>(140, 19, "")
                                  : std::make_tuple<uint8_t, uint8_t, std::string>(76, 16, "");
+            case Blockchain::DOGECOIN:
+                // Dogecoin mainnet version bytes (address_validator.cpp:163):
+                // D addresses p2pkh=30, 9/A p2sh=22, no bech32 HRP. Without
+                // this a primary-DOGE node fell to the Bitcoin default and
+                // surfaced payout addresses with the wrong (BTC) version bytes.
+                return std::make_tuple<uint8_t, uint8_t, std::string>(30, 22, "");
             case Blockchain::BITCOIN:
             default:
                 return m_testnet ? std::make_tuple<uint8_t, uint8_t, std::string>(0x6f, 0xc4, "tb")


### PR DESCRIPTION
## What
`rest_local_stats()` current_payouts encodes payout addresses per the node primary blockchain (web_server.cpp ~7138). The switch had cases for LITECOIN/DASH/BITCOIN+default only.

## Why
A primary-DOGE node fell through to the Bitcoin `default` and surfaced payout addresses with BTC version bytes (0x00/0x05) instead of Dogecoin. Dashboard would show wrong/garbage addresses for a real prod coin.

## Fix
Add a `Blockchain::DOGECOIN` case: p2pkh=30, p2sh=22, no bech32 HRP — sourced from address_validator.cpp:163-164. Read/web path only; pool aggregates untouched.

Charter #2 (per-node truthful dashboard). Non-consensus web layer -> normal merge + operator merge-tap.