### PR TITLE
dgb: silence GCC13 -Wstringop-overread false-positive in finalize_won_block_pow (-Werror build fix)

### DIFF
--- a/src/impl/dgb/coin/won_block_finalize.hpp
+++ b/src/impl/dgb/coin/won_block_finalize.hpp
@@ -100,7 +100,21 @@ finalize_won_block_pow(std::vector<unsigned char> block_bytes, const u256& targe
         return std::nullopt;   // too short to frame a header -> fail closed
 
     std::array<unsigned char, 80> header{};
+    // The size>=80 guard above proves this 80-byte read is in-bounds. GCC 13's
+    // -Wstringop-overread mis-tracks the vector extent through inlining when a
+    // caller passes a compile-time-known short (<80) vector by value (e.g. the
+    // FailsClosedOnShortInput KAT's 79-byte buffer): it false-positives here
+    // ("reading 80 bytes from a region of size 79") even though that path early-
+    // returns std::nullopt above. Suppress narrowly; the runtime guard is the
+    // real (and only) safety net. No behavior change.
+#if defined(__GNUC__) && !defined(__clang__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wstringop-overread"
+#endif
     std::copy(block_bytes.begin(), block_bytes.begin() + 80, header.begin());
+#if defined(__GNUC__) && !defined(__clang__)
+#  pragma GCC diagnostic pop
+#endif
 
     auto out = grind_won_nonce(header, target, start_nonce, max_iters);
     if (!out.has_value())


### PR DESCRIPTION
## What

Narrowly suppresses a GCC 13 `-Wstringop-overread` **false positive** in `dgb::coin::finalize_won_block_pow` (`src/impl/dgb/coin/won_block_finalize.hpp`), which `-Werror` was turning into a hard build failure.

## Why

The function fail-closes on short input before copying the 80-byte header:

```cpp
if (block_bytes.size() < 80)
    return std::nullopt;            // too short -> fail closed
std::array<unsigned char, 80> header{};
std::copy(block_bytes.begin(), block_bytes.begin() + 80, header.begin());
```

The `size() >= 80` guard proves the copy is in-bounds. But because the function takes `block_bytes` **by value** and gets fully inlined into the `FailsClosedOnShortInput` KAT — which passes a compile-time-known **79-byte** vector — GCC 13 propagates the 79-byte allocation extent to the copy **without folding the early-return**, then false-positives: *"reading 80 bytes from a region of size 79"*.

This is inlining-context sensitive: PR#369 compiled the identical file clean, while PR#362's rebased translation unit perturbed inlining enough to trip it. Surfaced as the Linux x86_64 / ASan build failure on PR#362.

## Fix

`#pragma GCC diagnostic push/ignored("-Wstringop-overread")/pop` around the single guarded copy, gated on `__GNUC__ && !__clang__`, with a comment explaining the runtime guard is the real safety net.

- **No behavior change** — pure diagnostic suppression at one call site.
- **Consensus-neutral**, fenced to `src/impl/dgb/`.
- Local verify: `dgb_won_block_finalize_test` builds clean under `-Werror` (no overread/stringop warnings) and **5/5 KAT pass** incl. `FailsClosedOnShortInput`.

Unblocks PR#362 (stacking onto this).
