### PR TITLE
web: /v36_status reports real V35->V36 state (de-stub)

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -5959,27 +5959,48 @@ nlohmann::json MiningInterface::rest_version_signaling(const nlohmann::json* cac
 nlohmann::json MiningInterface::rest_v36_status()
 {
     nlohmann::json result = nlohmann::json::object();
+
+    // Source the real ratchet state + share counts from rest_version_signaling()
+    // â the canonical, chain-derived V35âV36 computation â so /v36_status never
+    // lies about the cross. The old body returned a frozen "voting" / 0 v36
+    // shares regardless of reality (the founding-charter stub class). On
+    // non-transition coins version_signaling returns {}, leaving the truthful
+    // zeros below; on a too-short chain it early-returns before populating the
+    // overall_* fields, which .value() defaults handle.
+    nlohmann::json vs = rest_version_signaling();
+
+    std::string state = "voting";
+    if (vs.contains("auto_ratchet") && vs["auto_ratchet"].contains("state"))
+        state = vs["auto_ratchet"].value("state", std::string("voting"));
+
     result["auto_ratchet"] = {
-        {"state", "voting"},
-        {"persisted_state", ""},
+        {"state", state},
+        {"persisted_state", state},
         {"activated_at", nullptr},
         {"activated_height", nullptr},
         {"confirmed_at", nullptr}
     };
-    result["share_chain"] = {
-        {"height", 0},
-        {"sample_size", 0},
-        {"v35_shares", 0},
-        {"v36_shares", 0},
-        {"v36_percentage", 0.0}
-    };
+
+    int sample_size = vs.value("overall_total", 0);
+    int v36_shares  = vs.value("overall_v36_shares", 0);
+    int v35_shares  = std::max(0, sample_size - v36_shares);
+    double v36_pct  = vs.value("overall_v36_share_pct", 0.0);
+
+    int height = 0;
     if (m_sharechain_stats_fn) {
         auto sc = m_sharechain_stats_fn();
-        if (sc.contains("chain_height"))
-            result["share_chain"]["height"] = sc["chain_height"];
-        if (sc.contains("total_shares"))
-            result["share_chain"]["sample_size"] = sc["total_shares"];
+        height = sc.value("chain_height", 0);
+        if (sample_size == 0)
+            sample_size = sc.value("total_shares", 0);
     }
+
+    result["share_chain"] = {
+        {"height", height},
+        {"sample_size", sample_size},
+        {"v35_shares", v35_shares},
+        {"v36_shares", v36_shares},
+        {"v36_percentage", v36_pct}
+    };
     return result;
 }
 


### PR DESCRIPTION
## What
`rest_v36_status()` (route `/v36_status`) returned a **frozen stub**: `auto_ratchet.state="voting"`, `v35_shares=0`, `v36_shares=0`, `v36_percentage=0.0` regardless of real chain state — only `height`/`sample_size` were ever populated. On a node mid-cross this **lies about the V35->V36 transition** (the founding-charter stub class the dashboard exists to kill).

## Fix
The sibling `rest_version_signaling()` already derives the truthful ratchet state (voting/activated/confirmed) and v36 share counts/percentage from chain data. `/v36_status` now sources from it:
- `auto_ratchet.state` / `persisted_state` <- derived effective state
- `share_chain.{sample_size,v36_shares,v36_percentage}` <- `overall_total`/`overall_v36_shares`/`overall_v36_share_pct`
- `v35_shares` = `max(0, sample_size - v36_shares)`; `height` still from sharechain stats

Edge cases: non-transition coins (DASH etc.) get `rest_version_signaling()` empty `{}`, leaving truthful zeros; a too-short chain early-returns before the `overall_*` fields, handled by `.value()` defaults.

## Scope
Read/web (non-consensus) path only — pool aggregates and consensus logic untouched. Builds clean locally (c2pool target links; only pre-existing stdlib warnings). Serves the live LTC prod V35->V36 cross (#288) crossing-visibility charter (#3). GPG-signed.
