### PR TITLE
web: merged/aux chain symbol from real chain_info, never hardcoded DOGE

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -5446,9 +5446,9 @@ nlohmann::json MiningInterface::rest_best_share()
         result["round"] = round;
     }
 
-    // ── Merged chain (DOGE) best share stats ──
+    // ── Merged (aux) chain best share stats - symbol from the real aux chain, never hardcoded ──
     double merged_net_diff = 0.0;
-    std::string merged_symbol = "DOGE";
+    std::string merged_symbol;  // empty until sourced from the live aux chain
     if (m_mm_manager && m_mm_manager->has_chains()) {
         auto chain_infos = m_mm_manager->get_chain_infos();
         if (!chain_infos.empty()) {


### PR DESCRIPTION
## Charter #2 — per-node truthful dashboard

`rest_best_share()` initialized `merged_symbol = "DOGE"` and fell back to that literal whenever the aux chain reported no symbol, **or** when a historical best (`m_best_difficulty.merged_all_time > 0`) existed with no live aux chain. On a node whose merged-mined aux chain is not Dogecoin (or has no aux chain at all), `/best_share`s `merged.symbol` surfaced a fabricated **DOGE** — a per-node truthfulness violation (the in-tree principle: never a hardcoded coin shape).

### Fix
Default-construct `merged_symbol` (empty) and emit only what `m_mm_manager->get_chain_infos().front().symbol` actually reports. Empty-but-truthful beats fake-DOGE, consistent with the #361 truthful `default:` and #364/#370 per-coin slices.

- Read/web path only; pool aggregates and consensus untouched.
- web_server.cpp TU compiles clean locally.
- Found auditing the remaining charter-#2 mm_manager chain-iteration surface (the other paths — 4524/6647/6683 — are config-driven via get_chain_infos/get_discovered_blocks/callback and were re-confirmed clean).

Non-consensus web layer → normal merge + operator merge-tap.