### PR TITLE
[DASH] wire version-transition gate into accept-path step 2 (mint<->accept coupling)

### DIFF
--- a/src/impl/dash/share_check.hpp
+++ b/src/impl/dash/share_check.hpp
@@ -20,6 +20,7 @@
 
 #include "share.hpp"
 #include "share_types.hpp"
+#include "version_negotiation.hpp"   // dash::version_negotiation:: accept-path version gate
 
 #include <core/coin_params.hpp>
 #include <core/hash.hpp>
@@ -585,6 +586,79 @@ uint256 generate_share_transaction(const DashShare& share, TrackerT& tracker,
     auto tx_span = std::span<const unsigned char>(
         reinterpret_cast<const unsigned char*>(tx.data()), tx.size());
     return Hash(tx_span);
+}
+
+// === verify_version_transition (Dash accept-path step 2: mint<->accept coupling) ===
+// Gates which shares the accept path ADMITS at a share-VERSION boundary, closing
+// the gap where dash had the version_negotiation primitives KAT-proven in
+// isolation but ZERO accept-path consumers (btc/dgb carry this coupling live).
+// Composes the already-pinned primitives into the enforcement a node runs on
+// every incoming share, mirroring the cross-coin STANDARD shape in
+// src/impl/btc/auto_ratchet.hpp::validate_version_switch (60% successor guard)
+// and src/impl/btc/share_tracker.hpp::should_punish_version (95% obsolescence)
+// so the v37 unification is a clean migration, not a per-coin v36 dialect.
+//
+// Oracle: ref/p2pool-dash/p2pool/data.py Share.check() lines 384-393 (the
+// SUCCESSOR confirmed-state guard). DELIBERATE Bucket-2 standardization: that
+// older-oracle branch is DORMANT (Share.SUCCESSOR=None, data.py:71) and, where
+// it would fire, gated on 85%-WEIGHTED votes (data.py:392 sum*85//100 over the
+// WEIGHTED get_desired_version_counts, data.py:690-691). We standardize to the
+// v36/v37 shape -- 60% WEIGHTED successor guard + 95% WEIGHTED v36 activation --
+// identical to the btc/dgb live coupling and to the cross-coin standard the
+// fleet is converging on for v37. Throws std::invalid_argument on a disallowed
+// switch; returns normally when the share is admissible.
+template <typename ChainT>
+inline void verify_version_transition(const DashShare& share, ChainT& chain,
+                                      uint64_t chain_length)
+{
+    namespace vn = dash::version_negotiation;
+
+    const uint256 prev_hash = share.m_prev_hash;
+    if (prev_hash.IsNull() || !chain.contains(prev_hash))
+        return;  // genesis / unknown parent -- nothing to gate against
+
+    // Predecessor desired_version (single-share window reuse; no new chain API).
+    auto prev_counts = vn::get_desired_version_counts(chain, prev_hash, 1);
+    if (prev_counts.empty())
+        return;
+    const uint64_t prev_version = prev_counts.begin()->first;
+    const uint64_t this_version = share.m_desired_version;
+
+    // Not a boundary: a share matching its parent's version was valid when it was
+    // minted and is always admitted (data.py:382 type(self) is type(previous)).
+    if (this_version == prev_version)
+        return;
+
+    const bool have_history =
+        chain.get_height(prev_hash) >= static_cast<int64_t>(chain_length);
+
+    // (a) Obsolescence gate -- once v36 holds >= 95% of the WEIGHTED signaling in
+    // the CHAIN_LENGTH lookbehind, a pre-v36 share is stale and rejected. Mirrors
+    // btc should_punish_version; consumes the WEIGHTED tally (work.py v36_active).
+    if (this_version < 36 && have_history)
+    {
+        auto weights = vn::get_desired_version_weights(chain, prev_hash, chain_length);
+        if (vn::v36_active(weights))
+            throw std::invalid_argument(
+                "share version too old -- v36 has 95%+ weighted activation");
+    }
+
+    // (b) SUCCESSOR confirmed-state guard on an UPGRADE boundary: requires both
+    // CHAIN_LENGTH history and >= 60% WEIGHTED successor votes in the [9/10..10/10]
+    // tail window. data.py:385-393 (standardized 85%-weighted -> 60%-weighted, matching btc share_check.hpp:1781).
+    if (this_version > prev_version)
+    {
+        auto win = vn::negotiation_window(chain, prev_hash, chain_length);
+        if (!win)
+            throw std::invalid_argument("version switch without enough history");
+        auto weights =
+            vn::get_desired_version_weights(chain, win->start_hash, win->dist);
+        if (!vn::successor_switch_allowed(weights, this_version))
+            throw std::invalid_argument(
+                "version switch without enough hash power upgraded");
+    }
+    // Downgrade by AutoRatchet deactivation (this_version < prev_version, not v36-
+    // obsolete) is permitted, matching btc validate_version_switch. No gate.
 }
 
 } // namespace dash

--- a/test/test_dash_conformance.cpp
+++ b/test/test_dash_conformance.cpp
@@ -920,6 +920,101 @@ TEST(DashConformanceVersionNeg, SwitchClassifier5CaseKat) {
                                  successor_switch_allowed(clears, 36u)));
 }
 
+// === verify_version_transition: the WIRED accept-path gate (not the isolated
+// primitives above). Proves dash::verify_version_transition composes the
+// version_negotiation primitives into admit/reject enforcement at a version
+// boundary -- the mint<->accept coupling that was previously ZERO-consumer on
+// dash. CHAIN_LENGTH (CL) is small (20) so the [9/10..10/10] tail window is
+// reachable in a synthetic chain; the exact 60%/95% floors are pinned by the
+// isolation KATs above, so these lock the WIRING, not the thresholds.
+namespace {
+// Build a uniform run of `count` shares (all `version`/`bits`) on a fresh chain
+// and return the tip hash. The candidate is added separately by each test.
+uint256 build_uniform(SyntheticChain& sc, int count, uint64_t version,
+                      uint32_t bits, const uint160& pkh, uint8_t tag0 = 0x60) {
+    uint256 prev = uint256();
+    for (int i = 0; i < count; ++i)
+        prev = add_versioned(sc, static_cast<uint8_t>(tag0 + i), prev, version, bits, pkh);
+    return prev;
+}
+constexpr uint64_t CL = 20;  // synthetic CHAIN_LENGTH for the gate window
+}  // namespace
+
+// Same-version share is never a boundary -> always admitted (data.py:382).
+TEST(DashConformanceVersionWiring, SameVersionAdmitted) {
+    SyntheticChain sc;
+    const uint160 A = miner_h160(0x10);
+    uint256 tip = build_uniform(sc, 22, 36, BITS_DIFF1, A);
+    add_versioned(sc, 0x80, tip, 36, BITS_DIFF1, A);
+    EXPECT_NO_THROW(dash::verify_version_transition(*sc.pool.back(), sc.chain, CL));
+}
+
+// Upgrade boundary with fewer than CHAIN_LENGTH ancestors -> rejected
+// ("switch without enough history"). data.py:385-387.
+TEST(DashConformanceVersionWiring, UpgradeWithoutHistoryRejected) {
+    SyntheticChain sc;
+    const uint160 A = miner_h160(0x11);
+    uint256 tip = build_uniform(sc, 5, 16, BITS_DIFF1, A);  // < CL ancestors
+    add_versioned(sc, 0x81, tip, 36, BITS_DIFF1, A);        // v16 -> v36 upgrade
+    try {
+        dash::verify_version_transition(*sc.pool.back(), sc.chain, CL);
+        FAIL() << "expected throw on upgrade without enough history";
+    } catch (const std::invalid_argument& e) {
+        EXPECT_NE(std::string(e.what()).find("enough history"), std::string::npos);
+    }
+}
+
+// Upgrade boundary, history present, tail window already on the successor
+// version -> admitted (>=60% plain successor votes). data.py:388-393.
+TEST(DashConformanceVersionWiring, UpgradeWithSuccessorMajorityAdmitted) {
+    SyntheticChain sc;
+    const uint160 A = miner_h160(0x12);
+    uint256 tip = build_uniform(sc, 22, 36, BITS_DIFF1, A);   // tail window = v36
+    uint256 prev = add_versioned(sc, 0x82, tip, 16, BITS_DIFF1, A);  // a lone v16 prev
+    add_versioned(sc, 0x83, prev, 36, BITS_DIFF1, A);         // v16 -> v36 upgrade
+    EXPECT_NO_THROW(dash::verify_version_transition(*sc.pool.back(), sc.chain, CL));
+}
+
+// Upgrade boundary, history present, but the tail window has NO successor votes
+// -> rejected ("without enough hash power upgraded"). data.py:392.
+TEST(DashConformanceVersionWiring, UpgradeWithoutSuccessorVotesRejected) {
+    SyntheticChain sc;
+    const uint160 A = miner_h160(0x13);
+    uint256 tip = build_uniform(sc, 22, 16, BITS_DIFF1, A);   // tail window = all v16
+    add_versioned(sc, 0x84, tip, 36, BITS_DIFF1, A);          // v16 -> v36 upgrade
+    try {
+        dash::verify_version_transition(*sc.pool.back(), sc.chain, CL);
+        FAIL() << "expected throw on upgrade without successor votes";
+    } catch (const std::invalid_argument& e) {
+        EXPECT_NE(std::string(e.what()).find("hash power upgraded"),
+                  std::string::npos);
+    }
+}
+
+// Obsolescence gate: a pre-v36 share whose CHAIN_LENGTH lookbehind is already
+// >=95% WEIGHTED v36 -> rejected ("share version too old"). Mirrors btc
+// should_punish_version; consumes the WEIGHTED tally (work.py v36_active).
+TEST(DashConformanceVersionWiring, StalePreV36ShareRejected) {
+    SyntheticChain sc;
+    const uint160 A = miner_h160(0x14);
+    uint256 tip = build_uniform(sc, 22, 36, BITS_DIFF1, A);   // lookbehind = all v36
+    add_versioned(sc, 0x85, tip, 16, BITS_DIFF1, A);          // stale v16 on v36 tip
+    try {
+        dash::verify_version_transition(*sc.pool.back(), sc.chain, CL);
+        FAIL() << "expected throw on stale pre-v36 share";
+    } catch (const std::invalid_argument& e) {
+        EXPECT_NE(std::string(e.what()).find("too old"), std::string::npos);
+    }
+}
+
+// Genesis / no-parent share is admitted unconditionally (nothing to gate).
+TEST(DashConformanceVersionWiring, GenesisShareAdmitted) {
+    SyntheticChain sc;
+    const uint160 A = miner_h160(0x15);
+    add_versioned(sc, 0x86, uint256(), 36, BITS_DIFF1, A);    // null prev_hash
+    EXPECT_NO_THROW(dash::verify_version_transition(*sc.pool.back(), sc.chain, CL));
+}
+
 // ── DIP4 special-tx coinbase payload (CCbTx) wire-encoding conformance ──────
 // DASH coinbase transactions carry a DIP-0004 "special transaction" extra
 // payload: the CCbTx. Its merkleRootMNList / merkleRootQuorums fields are what


### PR DESCRIPTION
## What
Composes the dash `version_negotiation` primitives (`successor_switch_allowed` + `v36_active`) into `dash::verify_version_transition` — the share-VERSION boundary gate the accept path runs on every incoming share. Closes the gap where dash carried the primitives **KAT-proven in isolation but with ZERO accept-path consumers**, while btc/dgb carry the same mint<->accept coupling live.

## Gap evidence (as approved by integrator)
- Primitives spec+KAT in `test_dash_conformance.cpp` (isolation KATs), but the prior `m_desired_version` refs in `share_check.hpp` (194/547) were **serialization, not enforcement** — no composing consumer.
- btc live coupling: `src/impl/btc/share_check.hpp:1731` `share_check()` step 2; weighted 60% gate at `:1781` (`get_desired_version_weights`).

## Oracle conformance
- `ref/p2pool-dash/p2pool/data.py` `Share.check()` lines 384-393 (SUCCESSOR confirmed-state guard).
- Bucket-2 standardization toward the cross-coin v36-native shape: **60% WEIGHTED successor guard + 95% WEIGHTED v36 activation**, identical to btc/dgb (`share_check.hpp:1781`). The older oracle branch is dormant (`Share.SUCCESSOR=None`, data.py:71) and where it fired was 85%-weighted (data.py:392) — standardized to the v37 shape, not a per-coin dialect.

## Scope / fencing
- Diff is **STRICTLY inside `src/impl/dash/`** + the existing dash conformance test. Zero touches to `bitcoin_family` or `src/core`. Per-coin isolation invariant holds.
- `verify_version_transition` is the standalone **step-2 gate** the accept path calls. dash has no `node.cpp`/`share_check()` orchestrator on master yet (that accept orchestrator is a future S8 deliverable), so the live caller is a one-line hook landing with S8 — exactly like the other dash header-only scaffolding. This slice closes the gap at the layer that exists on master (composes the primitives + proves the wired path) so S8 calls the gate rather than re-deriving it.

## Tests (non-hollow, Linux x86_64, from build/)
`100% tests passed, 0 failed out of 45`. 6 NEW wired-path KATs (`DashConformanceVersionWiring`): SameVersionAdmitted, UpgradeWithoutHistoryRejected, UpgradeWithSuccessorMajorityAdmitted, UpgradeWithoutSuccessorVotesRejected, StalePreV36ShareRejected, GenesisShareAdmitted — distinct from the isolated-primitive KATs.

## Consensus-bearing — NOT auto-merge
Changes which shares the accept path admits. PR -> integrator re-verify (oracle + independent re-check of the zero-consumer claim + full CI rollup) -> operator tap. No self-merge.
