### PR TITLE
web: 404 unknown paths instead of leaking getinfo() JSON

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -827,8 +827,20 @@ void HttpSession::process_request()
                         send_response(std::move(response));
                         return;
                     }
+
+                    // Dashboard IS configured, the request matched no REST
+                    // endpoint above, and no such on-disk asset exists -> a real
+                    // 404. Previously this fell through to getinfo() below, so
+                    // unknown paths (explorer.html, blocks.html, typos, scanner
+                    // probes) leaked the node-info JSON instead of Not Found.
+                    response.result(http::status::not_found);
+                    response.set(http::field::content_type, "text/plain; charset=utf-8");
+                    response.body() = "404 Not Found";
+                    response.prepare_payload();
+                    send_response(std::move(response));
+                    return;
                 }
-                // Fallback to getinfo JSON
+                // Fallback to getinfo JSON (API-only mode: no --dashboard-dir set)
                 rest_result = mining_interface_->getinfo();
                 }  // end static file serving else
             }  // end explorer/static dispatch


### PR DESCRIPTION
## Context
Operator-facing breakage report from integrator (prod contabo :8080): top-nav Explorer link dead, and unknown paths (explorer.html / blocks.html) return the node-info JSON instead of a 404.

## What this PR fixes (BUG 2)
When a dashboard dir is configured, GET requests matching no REST endpoint and no on-disk asset fell through to `getinfo()` (web_server.cpp ~831), leaking the ~481-byte node-info JSON for explorer.html, blocks.html, typos and scanner probes. Now returns a real 404; the `getinfo()` fallback applies only in API-only mode (no --dashboard-dir).

## BUG 1 (Explorer nav literal) — already fixed in master, NO code change needed
Audited every page (index/dashboard/miners/graphs/stratum/share/miner). Current master has NO un-evaluated `' + currency_info.explorer_url + '` literal baked as static HTML:
- index.html:273 builds the link via valid JS concat inside a d3.json callback.
- All other pages inject via the correct DOM pattern `a.href = currency_info.explorer_url`.
- No nav links to explorer.html/blocks.html anywhere.
Prod is broken because contabo runs a 2-month-old binary (2026-04-20-686-ga5131ce1) that embeds the OLD buggy index.html. The fix already shipped in master; it reaches prod via redeploy.

## Deploy path
Current master serves the dashboard from an on-disk `--dashboard-dir` (web-static/), not embedded. Prod redeploy with this binary + web-static on disk makes ALL future web-asset fixes pure disk drop-ins (no rebuild). This 404 fix is C++, so it ships with the rebuild regardless.

## Scope
Read/web layer only; non-consensus. web_server TU compiles clean locally. Full CI on this PR.