### PR TITLE
web: emit real networkhashps in getinfo() instead of hardcoded 0

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -2859,6 +2859,13 @@ nlohmann::json MiningInterface::getinfo(const std::string& request_id)
         if (!m_cached_template.is_null() && m_cached_template.contains("height"))
             block_height = m_cached_template["height"].get<uint64_t>();
     }
+    // Real network hashrate -- same source as /global_rate (net_difficulty
+    // * 2^32 / block_period, template fallback). Previously left at 0.0,
+    // which made the dashboard graphs/stats tabs report networkhashps:0
+    // while the chain was live. rest_global_rate() locks m_work_mutex
+    // itself, so it MUST be called after the block above releases it.
+    if (auto gr = rest_global_rate(); gr.is_number())
+        network_hashps = gr.get<double>();
     
     nlohmann::json protocol_messages = nlohmann::json::array();
     if (m_protocol_messages_fn) {


### PR DESCRIPTION
## What
getinfo() — backing /api/stats and the dashboard graphs/stats/blockchain tabs — declared `network_hashps = 0.0` and never populated it. The networkhashps field was therefore always 0 while the chain was live, the same false-zero class as the original connections/poolhashps stubs (now real).

## Fix
Reuse `rest_global_rate()` (net_difficulty * 2^32 / block_period, with cached-template fallback) — the same source `/global_rate` already serves — so getinfo and /global_rate agree on network hashrate. Called after the m_work_mutex block releases, since rest_global_rate() takes that lock itself.

## Scope / caveat
Non-consensus web layer. block_period in rest_global_rate() is currently LTC-tuned (150s); making it per-coin is a separate charter-#2 slice and out of scope here — this PR only stops getinfo lying with a hardcoded 0.

## Test
Full CI (coin matrix + web-static verify). Charter: a dashboard must never lie about prod health.