### PR TITLE
dash: register DASH in unified launcher dispatch (first-local-share-mint slice 1)

### DIFF
--- a/src/c2pool/CMakeLists.txt
+++ b/src/c2pool/CMakeLists.txt
@@ -263,6 +263,30 @@ target_link_libraries(c2pool-bch
     ${Boost_LIBRARIES}
 )
 
+# c2pool-dash: DASH (X11 standalone parent, older-than-v35 -> V36) — EXE-WIRE
+# slice 2 (integrator 2026-06-23, stacked on launcher slice 1 #387). Closes the
+# "DASH is impl-files-only, not runnable" gap: slice 1 registered DASH in the
+# unified dispatch; this gives DASH its own executable driving the REAL header-
+# only consensus path (make_coin_params + X11 PoW + subsidy). Mirrors the
+# c2pool-bch --selftest tier: main_dash.cpp + the dash_x11 sph lib; params/
+# subsidy/utxo_adapter are header-only. Block submission (won-block dual-path
+# broadcaster: dashd-RPC submitblock + embedded P2P relay) is DEFERRED to the
+# next stacked slice and is an explicit, labelled --run stub (NOT silent). The
+# core OBJECT-lib link set matches c2pool-bch/the dash tests (core monolith SCC
+# direct-naming, #22/#39); per-coin isolation held: src/impl/dash only, no
+# shared-base/core SOURCE edit, dashd RPC fallback untouched.
+add_executable(c2pool-dash main_dash.cpp)
+target_compile_definitions(c2pool-dash PRIVATE C2POOL_VERSION="${C2POOL_GIT_VERSION}")
+target_link_libraries(c2pool-dash
+    core pool sharechain
+    c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage c2pool_difficulty
+    dash_x11   # DASH X11 PoW sph reference (BLAKE->...->ECHO), additive static lib
+    btclibs
+    yaml-cpp::yaml-cpp
+    nlohmann_json::nlohmann_json
+    ${Boost_LIBRARIES}
+)
+
 # Windows: Boost.Asio requires Winsock libraries; /bigobj for large translation units
 if(WIN32)
     target_link_libraries(c2pool ws2_32 mswsock bcrypt dbghelp)

--- a/src/c2pool/c2pool_refactored.cpp
+++ b/src/c2pool/c2pool_refactored.cpp
@@ -669,9 +669,10 @@ int main(int argc, char* argv[]) {
         if (blockchain_str == "xmr" || blockchain_str == "monero") return Blockchain::MONERO;
         if (blockchain_str == "zec" || blockchain_str == "zcash") return Blockchain::ZCASH;
         if (blockchain_str == "doge" || blockchain_str == "dogecoin") return Blockchain::DOGECOIN;
+        if (blockchain_str == "dash" || blockchain_str == "darkcoin") return Blockchain::DASH;
 
         LOG_ERROR << "Unknown blockchain: " << blockchain_str;
-        LOG_INFO << "Supported blockchains: ltc, dgb, btc, doge";
+        LOG_INFO << "Supported blockchains: ltc, dgb, btc, doge, dash";
         throw std::invalid_argument("Unknown blockchain type");
     };
 
@@ -682,6 +683,7 @@ int main(int argc, char* argv[]) {
         if (symbol == "NMC"   || symbol == "nmc")   return testnet ? 18334 : 8334;   // SSOT: src/impl/nmc/coin/chain_seeds.hpp (namecoind addrman)
         if (symbol == "BTC"   || symbol == "btc")   return testnet ? 18333 : 8333;
         if (symbol == "DGB"   || symbol == "dgb")   return testnet ? 12026 : 12024;
+        if (symbol == "DASH"  || symbol == "dash")  return testnet ? 19999 : 9999;   // SSOT: src/impl/dash/coin/chain_seeds.hpp (dashd addrman)
         if (symbol == "PEP"   || symbol == "pep")   return testnet ? 44874 : 33874;
         if (symbol == "BELLS" || symbol == "bells")  return testnet ? 29919 : 19919;
         if (symbol == "LKY"   || symbol == "lky")   return testnet ? 19917 : 9917;
@@ -696,6 +698,7 @@ int main(int argc, char* argv[]) {
             case Blockchain::DIGIBYTE: return "DGB";
             case Blockchain::BITCOIN:  return "BTC";
             case Blockchain::DOGECOIN: return "DOGE";
+            case Blockchain::DASH:     return "DASH";
             default: return "";
         }
     };
@@ -714,6 +717,10 @@ int main(int argc, char* argv[]) {
         }
         if (symbol == "DGB" || symbol == "dgb") {
             return testnet ? ParseHexBytes("fdc8bddd") : ParseHexBytes("fac3b6da");
+        }
+        if (symbol == "DASH" || symbol == "dash") {
+            // Dash pchMessageStart: mainnet bf0c6bbd, testnet3 cee2caff (dashd net magic).
+            return testnet ? ParseHexBytes("cee2caff") : ParseHexBytes("bf0c6bbd");
         }
         if (symbol == "PEP" || symbol == "pep") {
             return testnet ? ParseHexBytes("fec1dbcc") : ParseHexBytes("c0a0f0e0");

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -1,0 +1,231 @@
+// c2pool-dash — DASH (X11 standalone parent, older-than-v35 -> V36) p2pool node
+// entry point.
+//
+// EXE-WIRE slice 2 (integrator 2026-06-23, stacked on launcher slice 1 #387):
+// closes the "DASH is impl-files-only, not runnable" gap. Slice 1 registered
+// DASH in the unified launcher dispatch (parse_blockchain / port / net-magic);
+// this slice gives DASH its own runnable executable that drives the REAL dash
+// consensus primitives, so `dash` is no longer a dispatch label with no body.
+//
+// PER-COIN ISOLATION: src/impl/dash headers only (params/crypto/subsidy); no
+// src/impl/<other-coin> edit, no shared-base/core source edit, dashd RPC
+// fallback untouched. Mirrors the c2pool-bch / c2pool-dgb add_executable shape,
+// pruned to the header-only consensus path (DASH carries no node.cpp run-loop
+// TU on master yet — that is the S7/S8 block-submission lane).
+//
+// ONE MODE TODAY:
+//   --selftest (default) : drive the LIVE dash consensus paths std-only, network
+//       free, exercising the exact code the sharechain depends on, then exit:
+//         (1) make_coin_params  — the oracle-sourced CoinParams factory wired,
+//             incl. the X11 pow_func reachable through the coin-params seam.
+//         (2) X11 PoW           — DASH mainnet genesis + a real-node testnet3
+//             block header reproduce their published hashes (CI-pinned KATs,
+//             test_dash_x11_kat.cpp).
+//         (3) subsidy           — post-V20 block reward + 3/4 MN payment match
+//             the live-validated mainnet value (test_dash_subsidy.cpp).
+//
+// BLOCK-SUBMISSION (--run) — EXPLICITLY DEFERRED, NOT a silent stub. A won DASH
+// block reaches the network by a dual-path broadcaster, BOTH arms of which live
+// in the unmerged dash-spv-embedded work and are NOT on master:
+//   - dashd-RPC submitblock fallback: needs a DASH NodeRPC TU (rpc.cpp/rpc.hpp/
+//     rpc_conf.hpp) — DASH has only coin/rpc_data.hpp (a data placeholder), no
+//     RPC client. Porting it (mirroring dgb/coin/rpc.cpp) is the NEXT slice.
+//   - embedded P2P relay arm: the broadcaster_full / reconstruct stack (S8).
+// The CoinParams *path* the RPC fallback consumes IS wired here (make_coin_params,
+// oracle-sourced via dash::PoolConfig SSOT); the block-submission SINKS are the
+// deferred piece. --run prints this status and exits cleanly so a smoke gate that
+// invokes it is never misled into thinking block relay is live.
+//
+// Conformance oracle: frstrtr/p2pool-dash (older-than-v35; transition 16 -> v36).
+// External dashd RPC stays as a fallback alongside the (future) embedded path.
+
+#include <impl/dash/params.hpp>
+#include <impl/dash/crypto/hash_x11.hpp>
+#include <impl/dash/coin/utxo_adapter.hpp>   // must precede subsidy.hpp (dash_txid in scope)
+#include <impl/dash/coin/subsidy.hpp>
+
+#include <core/coin_params.hpp>
+#include <core/uint256.hpp>
+
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <string>
+
+#ifndef C2POOL_VERSION
+#define C2POOL_VERSION "dev"
+#endif
+
+namespace {
+
+using dash::coin::compute_dash_block_reward_post_v20;
+using dash::coin::compute_dash_mn_payment_post_v20;
+
+void print_banner(const char* argv0)
+{
+    std::cout
+        << "c2pool-dash " << C2POOL_VERSION << " — DASH (X11, older-than-v35 -> V36)\n\n"
+        << "Usage: " << argv0 << " [--version] [--help] [--selftest]\n"
+        << "       " << argv0 << " --run   (block-submission DEFERRED — see status)\n\n"
+        << "Status: consensus layer live (X11 PoW, subsidy, oracle CoinParams).\n"
+        << "        Block submission (won-block dual-path broadcaster) is the\n"
+        << "        next stacked slice; external dashd RPC stays the fallback.\n"
+        << "Consensus: X11 PoW + block identity; 2.5 min spacing; 5 DASH post-V20\n"
+        << "        base, -1/14 per 210240; masternode payment 3/4 of block value.\n";
+}
+
+// Serialize an 80-byte DASH block header (LE; host is LE on the x86_64 target).
+void serialize_header(unsigned char out[80], uint32_t version, const char* prev_hex,
+                      const char* merkle_hex, uint32_t time, uint32_t bits, uint32_t nonce)
+{
+    uint256 prev_block;  prev_block.SetHex(prev_hex);
+    uint256 merkle_root; merkle_root.SetHex(merkle_hex);
+    size_t off = 0;
+    std::memcpy(out + off, &version, 4);             off += 4;
+    std::memcpy(out + off, prev_block.data(), 32);   off += 32;
+    std::memcpy(out + off, merkle_root.data(), 32);  off += 32;
+    std::memcpy(out + off, &time, 4);                off += 4;
+    std::memcpy(out + off, &bits, 4);                off += 4;
+    std::memcpy(out + off, &nonce, 4);               off += 4;
+}
+
+// (1) The oracle CoinParams factory is wired and self-consistent, AND the X11
+//     pow_func is reachable through the coin-params seam (the path the work
+//     source + block-identity checks consume).
+int check_coin_params()
+{
+    const core::CoinParams main = dash::make_coin_params(/*testnet=*/false);
+    const core::CoinParams test = dash::make_coin_params(/*testnet=*/true);
+
+    int fails = 0;
+    auto want = [&](bool ok, const char* what) {
+        std::cout << "[selftest]   coin_params: " << what << (ok ? " ok\n" : " FAIL\n");
+        if (!ok) ++fails;
+    };
+    want(main.symbol == "DASH",            "symbol == DASH");
+    // CoinParams.p2p_port is the SHARECHAIN/pool peer port (dash::PoolConfig SSOT),
+    // distinct from the DASH coin-daemon P2P port (9999/19999) wired in slice-1's
+    // get_coin_p2p_port. Assert the sharechain SSOT here.
+    want(main.p2p_port == 8999,            "mainnet sharechain p2p_port == 8999 (SSOT)");
+    want(test.p2p_port == 18999,           "testnet sharechain p2p_port == 18999 (SSOT)");
+    want(main.current_share_version == 16, "share_version == 16 (older-than-v35 baseline)");
+    want(main.address_version == 76,       "mainnet pubkey addr version == 76 (X...)");
+    want(static_cast<bool>(main.pow_func), "pow_func wired");
+
+    // Drive X11 THROUGH the CoinParams pow_func seam against the genesis header.
+    if (main.pow_func) {
+        unsigned char hdr[80];
+        serialize_header(hdr, 1, "0000000000000000000000000000000000000000000000000000000000000000",
+            "e0028eb9648db56b1ac77cf090b99048a8007e2bb64b68f092c03c7f56a662c7",
+            1390095618u, 0x1e0ffff0u, 28917698u);
+        const uint256 pow = main.pow_func(std::span<const unsigned char>(hdr, 80));
+        const bool ok = pow.GetHex() == "00000ffd590b1485b3caadc19b22e6379c733355108f107a430458cdf3407ab6";
+        want(ok, "pow_func(genesis) reproduces genesis hash");
+    }
+    return fails;
+}
+
+// (2) X11 PoW KATs: mainnet genesis + a real-node testnet3 block (CI-pinned,
+//     test_dash_x11_kat.cpp). Pins BLAKE->...->ECHO end to end via the direct
+//     dash::crypto::hash_x11 entry.
+int check_x11_kats()
+{
+    int fails = 0;
+    struct Vec { const char* name; uint32_t v; const char* prev; const char* merkle;
+                 uint32_t t; uint32_t bits; uint32_t nonce; const char* expect; };
+    const Vec vecs[] = {
+        { "mainnet-genesis", 1,
+          "0000000000000000000000000000000000000000000000000000000000000000",
+          "e0028eb9648db56b1ac77cf090b99048a8007e2bb64b68f092c03c7f56a662c7",
+          1390095618u, 0x1e0ffff0u, 28917698u,
+          "00000ffd590b1485b3caadc19b22e6379c733355108f107a430458cdf3407ab6" },
+        { "testnet3-#1497944", 536870912u,
+          "000000dbbc08ee519459b38b02bb7754b455dd00cd74069a1352f08f0dd986db",
+          "0464a4ac5f058a742f6aa42b2b3c7489abde7609b529612bcfa5da34b10bdb1b",
+          1781737170u, 0x1e00f256u, 721236u,
+          "000000b6a4e5ea1a0854ef83f0028dde5b96cdaacc604decd8b064d0cea38234" },
+    };
+    for (const auto& vc : vecs) {
+        unsigned char hdr[80];
+        serialize_header(hdr, vc.v, vc.prev, vc.merkle, vc.t, vc.bits, vc.nonce);
+        const uint256 pow = dash::crypto::hash_x11(hdr, sizeof(hdr));
+        const bool ok = pow.GetHex() == vc.expect;
+        std::cout << "[selftest]   x11 KAT " << vc.name << ": " << pow.GetHex()
+                  << (ok ? " ok\n" : " FAIL\n");
+        if (!ok) ++fails;
+    }
+    return fails;
+}
+
+// (3) Subsidy: post-V20 block reward + 3/4 MN payment (test_dash_subsidy.cpp,
+//     live-validated against dashd getblocktemplate at h=2459985).
+int check_subsidy()
+{
+    int fails = 0;
+    const int64_t reward = compute_dash_block_reward_post_v20(2459985);
+    const bool r_ok = reward == 177'022'505LL;
+    std::cout << "[selftest]   subsidy h=2459985 reward = " << reward
+              << (r_ok ? " ok\n" : " FAIL (want 177022505)\n");
+    if (!r_ok) ++fails;
+
+    const int64_t mn = compute_dash_mn_payment_post_v20(200'000'000LL);
+    const bool mn_ok = mn == 150'000'000LL;
+    std::cout << "[selftest]   masternode payment 3/4 of 2.0 DASH = " << mn
+              << (mn_ok ? " ok\n" : " FAIL (want 150000000)\n");
+    if (!mn_ok) ++fails;
+    return fails;
+}
+
+int run_selftest()
+{
+    std::cout << "[selftest] driving live DASH consensus (network-free)\n";
+    int fails = 0;
+    fails += check_coin_params();
+    fails += check_x11_kats();
+    fails += check_subsidy();
+    if (fails == 0) {
+        std::cout << "[selftest] OK — CoinParams + X11 PoW + subsidy all conform to oracle\n";
+        return 0;
+    }
+    std::cout << "[selftest] FAIL — " << fails << " consensus check(s) failed\n";
+    return 1;
+}
+
+// --run: block submission is DEFERRED. Print the exact deferral status so a smoke
+// gate is never misled, then exit cleanly (the consensus layer IS exercised by
+// --selftest; the run-loop standup lands with the broadcaster slice).
+int run_node_stub()
+{
+    std::cout
+        << "[run] DASH block submission is DEFERRED to the next stacked slice.\n"
+        << "[run]   - dashd-RPC submitblock fallback: needs a DASH NodeRPC TU\n"
+        << "[run]     (rpc.cpp/rpc.hpp/rpc_conf.hpp); only coin/rpc_data.hpp exists.\n"
+        << "[run]   - embedded P2P relay arm: S8 broadcaster/reconstruct stack.\n"
+        << "[run] The oracle CoinParams path the fallback consumes IS wired; run\n"
+        << "[run] --selftest to exercise the live consensus layer (X11 + subsidy).\n";
+    return 0;
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    bool want_help = false;
+    bool want_run  = false;
+    for (int i = 1; i < argc; ++i) {
+        if (std::strcmp(argv[i], "--version") == 0) {
+            std::cout << "c2pool-dash " << C2POOL_VERSION << "\n";
+            return 0;
+        }
+        if (std::strcmp(argv[i], "--help") == 0)     want_help = true;
+        if (std::strcmp(argv[i], "--run") == 0)      want_run  = true;
+        // --selftest is the default; accepted explicitly for symmetry.
+    }
+
+    print_banner(argv[0]);
+    if (want_help)
+        return 0;
+    if (want_run)
+        return run_node_stub();
+    return run_selftest();
+}


### PR DESCRIPTION
## What
Additive DASH registration in the unified c2pool launcher dispatch — slice 1 of the dashd-RPC-fallback launcher + standalone node-construction work (operator/integrator-approved option A, first-local-share-mint).

Touches **only** the dispatch lambdas in `src/c2pool/c2pool_refactored.cpp`:
- `parse_blockchain`: `dash|darkcoin` -> `Blockchain::DASH` (+ supported-list string)
- `get_coin_p2p_port`: DASH testnet 19999 / mainnet 9999 (SSOT: `src/impl/dash/coin/chain_seeds.hpp`)
- `blockchain_to_symbol`: `Blockchain::DASH` -> "DASH"
- `get_chain_p2p_prefix`: testnet `cee2caff` / mainnet `bf0c6bbd` (dashd net magic)

## Isolation / scope
Registration only — **no** edits to ltc/doge/dgb/btc launcher cases or any `src/impl/<coin>/` tree. `Blockchain::DASH` enum and the web_server DASH case already exist on master; this is pure wiring. dashd RPC fallback preserved (nothing removed/weakened).

## Out of scope (next slice)
The runnable node-construction path — new `src/c2pool/main_dash.cpp` (run_node over dashd-RPC fallback, local sharechain genesis) — lands in slice 2, with a clean seam for the S8 embedded-P2P path (#367/#359) to plug in.

## Verify
- Local: `ninja c2pool` GREEN on Linux x86_64 (workstation), c2pool binary links.
- Requested: integrator oracle diff + full CI rollup (all-coin smokes) before operator tap. No self-merge.