### PR TITLE
dgb(Phase-B): delegate get_donation_script version gate to core::version_gate SSOT

### DIFF
--- a/src/impl/dgb/config_pool.hpp
+++ b/src/impl/dgb/config_pool.hpp
@@ -3,6 +3,7 @@
 #include <core/config.hpp>
 #include <core/fileconfig.hpp>
 #include <core/netaddress.hpp>
+#include <core/version_gate.hpp>   // SSOT: core::version_gate::is_v36_active (V36 donation-transition boundary)
 
 #include <array>
 #include <cstdint>
@@ -108,7 +109,7 @@ public:
 
     static std::vector<unsigned char> get_donation_script(int64_t share_version)
     {
-        if (share_version >= 36)
+        if (core::version_gate::is_v36_active(share_version))
             return {COMBINED_DONATION_SCRIPT.begin(), COMBINED_DONATION_SCRIPT.end()};
         return {DONATION_SCRIPT.begin(), DONATION_SCRIPT.end()};
     }


### PR DESCRIPTION
## What
Replace the sole remaining bare `share_version >= 36` literal in `src/impl/dgb/config_pool.hpp` `get_donation_script()` with `core::version_gate::is_v36_active(share_version)`, plus the SSOT include.

## Why
Completes the operator-approved version_gate SSOT delegation sweep. Every other DGB call site (share.hpp, share_tracker.hpp, share_check.hpp, work_ref_hash.hpp) already delegates to `core::version_gate::is_v36_active`; this donation-script selector was the only site still open-coding the V36 share-format activation boundary.

## Correctness
Value byte-identical: `is_v36_active(v)` returns `v >= V36_ACTIVATION_VERSION` with `V36_ACTIVATION_VERSION == 36`, and the int64->uint64 argument convention matches every other DGB runtime call site. Consensus-neutral by construction.

## Scope / classification
- FENCED to `src/impl/dgb/`; no shared-base / cross-coin touch.
- 3-bucket rule: bucket-2 (v36-NATIVE shared structure — the V36 donation-transition boundary standardized toward the unified core gate). The donation script bytes and the per-coin PREFIX/IDENTIFIER isolation primitives are untouched.

## Verify
`cmake -S . -B build_dgb -DCOIN_DGB=ON` + build `c2pool-dgb` target: configure + link clean (exit 0).

No self-merge.