### PR TITLE
web: collapse triplicated share_version switch in rest_web_currency_info

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -4772,28 +4772,6 @@ nlohmann::json MiningInterface::rest_web_currency_info()
     default:                   result["share_version"] = 36; break;
     }
 
-    // p2pool share version for the current coin — consumed by the
-    // bundled @c2pool/sharechain-explorer to classify share cells.
-    // Dash = v16, LTC/DOGE/BTC = v36.
-    switch (m_blockchain) {
-    case Blockchain::DASH:     result["share_version"] = 16; break;
-    case Blockchain::LITECOIN:
-    case Blockchain::BITCOIN:
-    case Blockchain::DOGECOIN:
-    default:                   result["share_version"] = 36; break;
-    }
-
-    // p2pool share version for the current coin — consumed by the
-    // bundled @c2pool/sharechain-explorer to classify share cells.
-    // Dash = v16, LTC/DOGE/BTC = v36.
-    switch (m_blockchain) {
-    case Blockchain::DASH:     result["share_version"] = 16; break;
-    case Blockchain::LITECOIN:
-    case Blockchain::BITCOIN:
-    case Blockchain::DOGECOIN:
-    default:                   result["share_version"] = 36; break;
-    }
-
     // ─── Per-coin explorer map (operator 2026-06-23: each coin = a distinct
     // blockchain). On merged-mining nodes (e.g. LTC primary + DOGE aux) the
     // dashboard switcher must link each coin's blocks/txs/addresses to the


### PR DESCRIPTION
## What

`rest_web_currency_info()` set `result["share_version"]` via **three byte-for-byte identical** `switch (m_blockchain)` blocks in a row (lines ~4764-4795) — a merge artifact. The 2nd and 3rd blocks are pure dead code: each re-assigns the same key to the same value the prior block already set.

## Change

Collapse to a single block. **No behavior change** — the emitted `/web/currency_info` JSON is byte-identical; this only removes 22 lines of redundant code.

## Scope

Web/API layer only (`core/web_server.cpp`), non-consensus, normal merge. Surfacing to operator for web-on-prod awareness. Follow-on cleanup after the per-coin explorer map (#385) landed.
