### PR TITLE
web: remove dead LitecoinRpcClient mock from web_server

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -911,7 +911,6 @@ void HttpSession::handle_error(beast::error_code ec, char const* what)
 /// MiningInterface Implementation
 MiningInterface::MiningInterface(bool testnet, std::shared_ptr<IMiningNode> node, Blockchain blockchain)
     : m_work_id_counter(1)
-    , m_rpc_client(std::make_unique<LitecoinRpcClient>(testnet))
     , m_testnet(testnet)
     , m_blockchain(blockchain)
     , m_node(node)
@@ -8570,35 +8569,6 @@ bool WebServer::is_stratum_running() const
 uint16_t WebServer::get_stratum_port() const
 {
     return stratum_port_;
-}
-
-/// LitecoinRpcClient Implementation
-LitecoinRpcClient::LitecoinRpcClient(bool testnet)
-    : testnet_(testnet)
-{
-}
-
-LitecoinRpcClient::SyncStatus LitecoinRpcClient::get_sync_status()
-{
-    SyncStatus status;
-    status.is_synced = true;  // Assume synced for now
-    status.progress = 1.0;
-    status.current_blocks = 3945867;  // Mock value for testing
-    status.total_headers = 3945867;
-    status.initial_block_download = false;
-    status.error_message = "";
-    
-    return status;
-}
-
-bool LitecoinRpcClient::is_connected()
-{
-    return true;  // Assume connected for now
-}
-
-std::string LitecoinRpcClient::execute_cli_command(const std::string& command)
-{
-    return "OK";  // Mock response for testing
 }
 
 

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -54,30 +54,6 @@ using tcp = net::ip::tcp;
 // Forward declarations
 class MiningInterface;
 class StratumServer;
-class LitecoinRpcClient;
-
-/// Litecoin Core RPC client for blockchain sync status
-class LitecoinRpcClient
-{
-public:
-    LitecoinRpcClient(bool testnet = true);
-    
-    struct SyncStatus {
-        bool is_synced;
-        double progress;
-        uint64_t current_blocks;
-        uint64_t total_headers;
-        bool initial_block_download;
-        std::string error_message;
-    };
-    
-    SyncStatus get_sync_status();
-    bool is_connected();
-    std::string execute_cli_command(const std::string& command);
-    
-private:
-    bool testnet_;
-};
 
 /// HTTP Session handler for incoming connections
 class HttpSession : public std::enable_shared_from_this<HttpSession>
@@ -956,7 +932,6 @@ private:
     // Internal state
     uint64_t m_work_id_counter;
     std::map<std::string, nlohmann::json> m_active_work;
-    std::unique_ptr<LitecoinRpcClient> m_rpc_client;
     bool m_testnet;  // Store testnet flag
     Blockchain m_blockchain;  // Store blockchain type
     std::shared_ptr<IMiningNode> m_node;  // Connection to c2pool node for difficulty tracking


### PR DESCRIPTION
Removes the dead `LitecoinRpcClient` mock from the web/API layer.

## What it was
A mock RPC client whose methods returned hardcoded fiction:
- `get_sync_status()` → always `is_synced=true`, `current_blocks=3945867` (commented "Mock value for testing"), `initial_block_download=false`
- `is_connected()` → always `true`
- `execute_cli_command()` → always `"OK"`

`MiningInterface` constructed `m_rpc_client` but **never called any of its methods** — verified zero call sites repo-wide (`grep m_rpc_client / LitecoinRpcClient` → only decl/ctor). So none of the mock data reaches any endpoint today.

## Why remove rather than wire
This is a charter-class hazard: a sync-status source that always reports synced with a frozen block height is exactly the kind of stub a dashboard must never surface about prod health. Real per-coin embedded-daemon synced/peer state already comes from live node state (`currency_info` `coins[]`, `coin_peers`). Leaving a fabricating mock in the tree only invites an accidental future wiring of fake data.

## Scope
Pure dead-code excision, no behavior change: forward decl + class definition + `SyncStatus` struct + `m_rpc_client` member + ctor initializer + full impl block. web_server TU compiles and the `c2pool` binary links clean locally. Non-consensus web layer.
