### PR TITLE
dash(s8): p2p_node socket-node leaf — lifecycle + request/reply + real-timer idle-timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection \
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node \
                     test_multiaddress_pplns test_pplns_stress \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
@@ -205,7 +205,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection \
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
                     test_v36_script_sorting test_v36_cross_impl_refhash \

--- a/src/impl/dash/coin/p2p_node.hpp
+++ b/src/impl/dash/coin/p2p_node.hpp
@@ -1,0 +1,192 @@
+#pragma once
+
+// Phase S8 — Dash coin-daemon P2P node (socket-node skeleton LEAF).
+//
+// Minimal node lifecycle layer that sits one rung above the per-peer
+// request/response router:
+//
+//     p2p_messages -> p2p_connection -> [p2p_node] -> broadcaster
+//
+// This leaf owns ONLY the socket-node skeleton:
+//
+//   * lifecycle: construct -> attach a live peer (Connection over a socket)
+//     -> teardown. attach()/teardown() are idempotent and timer-safe.
+//   * the outbound-request -> inbound-reply exchange, driven entirely through
+//     the already-landed Connection matcher (request_block/header out,
+//     deliver_block/header in). The node arms the matchers on attach and
+//     forwards exchange calls to the live peer; with no peer the calls are
+//     dropped (no throw — a torn-down node must not crash the caller).
+//   * the timeout path: a single idle/liveness Timer. Every inbound reply or
+//     explicit note_activity() restarts it; if it ever fires we run
+//     on_timeout(reason) -> teardown and notify an optional observer. This is
+//     the p2pool "no peer activity within N seconds => drop" liveness guard,
+//     decoupled from the per-request deferral timeout that Connection already
+//     owns (reply_matcher.hpp).
+//
+// EXPLICITLY OUT OF SCOPE for this leaf (later S8 slices): the dashd handshake
+// (version/verack), GBT fetch, block-submit / submit_block_raw, quorum and
+// mnlistdiff sync, reconnect/ping cadence, and the INetwork/Factory<Client>
+// socket-acceptor wiring. None of that surface is pulled in here.
+//
+// Header-only to match the sibling leaves (p2p_connection.hpp, p2p_messages.hpp).
+
+#include "p2p_connection.hpp"
+#include "block.hpp"
+
+#include <functional>
+#include <memory>
+#include <string>
+
+#include <boost/asio.hpp>
+
+#include <core/log.hpp>
+#include <core/uint256.hpp>
+#include <core/socket.hpp>
+#include <core/timer.hpp>
+
+namespace dash
+{
+namespace coin
+{
+namespace p2p
+{
+
+// Socket-node skeleton over Connection. Concrete (not yet templated on
+// coin/config — that threading arrives with the broadcaster slice), so the
+// type stays trivially constructible and testable.
+class NodeP2P
+{
+public:
+    // Seconds of peer silence tolerated before the liveness timer fires and the
+    // node tears the peer down. Distinct from Connection's per-request deferral
+    // timeout (reply_matcher.hpp) — that bounds a single in-flight request; this
+    // bounds the whole peer's idleness.
+    static constexpr time_t IDLE_TIMEOUT_SEC = 100;
+
+    using TimeoutObserver = std::function<void(const std::string& /*reason*/)>;
+
+private:
+    boost::asio::io_context* m_context{};
+    std::unique_ptr<Connection> m_peer;
+    std::unique_ptr<core::Timer> m_idle_timer;
+    TimeoutObserver m_on_timeout;
+    // Liveness deadline actually used by arm_idle_timer(); defaults to
+    // IDLE_TIMEOUT_SEC. Overridable (set_idle_timeout_sec) so tests can
+    // drive a real, short timer-fire of the timeout path.
+    time_t m_idle_timeout_sec{IDLE_TIMEOUT_SEC};
+
+    void ensure_idle_timer()
+    {
+        if (!m_idle_timer)
+            m_idle_timer = std::make_unique<core::Timer>(m_context, /*repeat*/false);
+    }
+
+public:
+    explicit NodeP2P(boost::asio::io_context* context)
+        : m_context(context) {}
+
+    ~NodeP2P() { teardown(); }
+
+    NodeP2P(const NodeP2P&) = delete;
+    NodeP2P& operator=(const NodeP2P&) = delete;
+
+    // Observer fired when the liveness timer expires (peer went silent). The
+    // node has already torn the peer down by the time this runs.
+    void set_on_timeout(TimeoutObserver cb) { m_on_timeout = std::move(cb); }
+
+    // Override the liveness deadline (seconds) before attach(). The default
+    // is IDLE_TIMEOUT_SEC; production never changes it.
+    void set_idle_timeout_sec(time_t s) { m_idle_timeout_sec = s; }
+
+    // ── lifecycle ────────────────────────────────────────────────────────
+
+    // Attach a freshly-connected peer socket. Builds the Connection, arms its
+    // request matchers with the supplied outbound-wire callbacks, and starts
+    // the liveness timer. Replaces any existing peer (idempotent re-attach).
+    void attach(std::shared_ptr<core::Socket> socket,
+                std::function<void(uint256)> block_req,
+                std::function<void(uint256)> header_req)
+    {
+        teardown();
+        m_peer = std::make_unique<Connection>(m_context, socket);
+        m_peer->init_requests(std::move(block_req), std::move(header_req));
+        arm_idle_timer();
+    }
+
+    // Drop the peer and stop the liveness timer. Safe to call when not attached
+    // and safe to call from inside a timer callback.
+    void teardown()
+    {
+        if (m_idle_timer)
+            m_idle_timer->stop();
+        m_peer.reset();
+    }
+
+    bool is_attached() const { return m_peer != nullptr; }
+
+    auto peer_addr() const { return m_peer ? m_peer->get_addr() : NetService{}; }
+
+    // ── liveness / timeout path ──────────────────────────────────────────
+
+    // (Re)start the idle countdown. Called on attach and whenever fresh peer
+    // activity is observed.
+    void arm_idle_timer()
+    {
+        if (!m_peer) return;
+        ensure_idle_timer();
+        m_idle_timer->start(m_idle_timeout_sec, [this]() { on_timeout("idle timeout"); });
+    }
+
+    // Note inbound peer activity — pushes the idle deadline forward.
+    void note_activity()
+    {
+        if (m_peer && m_idle_timer)
+            m_idle_timer->restart(m_idle_timeout_sec);
+    }
+
+    // Invoked by the liveness timer (or directly, for the deterministic test
+    // path). Tears the peer down, then notifies the observer.
+    void on_timeout(const std::string& reason)
+    {
+        LOG_WARNING << "[DashP2P] peer timeout: " << reason;
+        teardown();
+        if (m_on_timeout)
+            m_on_timeout(reason);
+    }
+
+    // ── outbound-request -> inbound-reply exchange (through Connection) ───
+
+    // Outbound: emit a get-block request keyed by `id` for `hash`. The reply is
+    // delivered later via deliver_block(id, ...). Dropped silently if no peer.
+    void request_block(uint256 id, uint256 hash, std::function<void(BlockType)> handler)
+    {
+        if (!m_peer) return;
+        m_peer->request_block(id, hash, std::move(handler));
+    }
+
+    // Inbound: route a block reply to its pending request handler and refresh
+    // liveness. Dropped silently if no peer.
+    void deliver_block(uint256 id, BlockType response)
+    {
+        if (!m_peer) return;
+        note_activity();
+        m_peer->get_block(id, response);
+    }
+
+    void request_header(uint256 id, uint256 hash, std::function<void(BlockHeaderType)> handler)
+    {
+        if (!m_peer) return;
+        m_peer->request_header(id, hash, std::move(handler));
+    }
+
+    void deliver_header(uint256 id, BlockHeaderType response)
+    {
+        if (!m_peer) return;
+        note_activity();
+        m_peer->get_header(id, response);
+    }
+};
+
+} // namespace p2p
+} // namespace coin
+} // namespace dash

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -395,6 +395,20 @@ if (BUILD_TESTING AND GTest_FOUND)
     target_link_libraries(test_dash_p2p_connection PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
     gtest_add_tests(test_dash_p2p_connection "" AUTO)
 
+    # Dash coin-daemon P2P node (S8 socket-node skeleton leaf). Pins the node
+    # lifecycle (attach/teardown), the outbound-request->inbound-reply exchange
+    # through Connection, and the real-timer idle-timeout path. Header-only over
+    # the dash_x11 + core link set; same set as the p2p_connection leaf.
+    add_executable(test_dash_p2p_node test_dash_p2p_node.cpp)
+    target_link_libraries(test_dash_p2p_node PRIVATE
+        GTest::gtest_main GTest::gtest
+        dash_x11 core
+        nlohmann_json::nlohmann_json
+        ${Boost_LIBRARIES}
+    )
+    target_link_libraries(test_dash_p2p_node PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
+    gtest_add_tests(test_dash_p2p_node "" AUTO)
+
     add_executable(test_compact_blocks test_compact_blocks.cpp)
     target_link_libraries(test_compact_blocks PRIVATE
         GTest::gtest_main GTest::gtest

--- a/test/test_dash_p2p_node.cpp
+++ b/test/test_dash_p2p_node.cpp
@@ -1,0 +1,212 @@
+/// Phase S8 — Dash coin-daemon P2P node (socket-node skeleton) KATs
+///
+/// Exercises src/impl/dash/coin/p2p_node.hpp — the socket-node lifecycle layer
+/// the S8 block-submission lane builds on:
+///
+///     p2p_messages -> p2p_connection -> [p2p_node] -> broadcaster
+///
+/// What is PINNED here:
+///
+///   (a) the outbound-request -> inbound-reply exchange, driven END-TO-END
+///       through the node lifecycle: attach() arms the Connection matcher,
+///       request_block() emits through the wire-callback carrying the EXACT
+///       hash, and deliver_block() routes the byte-exact reply back to the
+///       matching handler. A loopback wire-callback closes the round-trip the
+///       way a live socket would, so the full attach -> request -> wire ->
+///       reply -> handler path is real (the matcher logic is the same one the
+///       Connection leaf pins; here it runs through the node, not in isolation).
+///
+///   (b) the TIMEOUT path, driven by a REAL core::Timer firing through
+///       io_context.run(): a short idle deadline elapses with no activity, the
+///       liveness timer fires, the node tears the peer down and notifies the
+///       observer. This is the genuine async timer fire — not a synchronous
+///       poke — and asserts post-fire state (detached) and the reason.
+///
+///   plus lifecycle invariants: teardown is idempotent, a torn-down node drops
+///   exchange calls instead of throwing, and note_activity() pushing the
+///   deadline forward keeps the peer alive past the original deadline.
+///
+/// SCOPE NOTE (honest): the wire transport is a loopback std::function, not a
+/// live boost::asio::ip::tcp socket — constructing a real core::Socket requires
+/// the INetwork/Factory acceptor wiring that is a LATER S8 slice, explicitly
+/// out of scope for this leaf. The request/reply matcher logic, the lifecycle,
+/// and the timer-driven timeout are all real and asserted.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/p2p_node.hpp>
+#include <impl/dash/coin/block.hpp>
+
+#include <core/uint256.hpp>
+
+#include <boost/asio.hpp>
+
+#include <cstdint>
+#include <string>
+
+using namespace dash::coin;
+using dash::coin::p2p::NodeP2P;
+
+namespace {
+
+uint256 id_of(uint8_t b) { uint256 u; u.begin()[0] = b; return u; }
+
+BlockType make_block(uint64_t version, uint32_t nonce, uint8_t merkle_tag)
+{
+    BlockType blk;
+    blk.m_version = version;
+    blk.m_nonce = nonce;
+    blk.m_merkle_root = id_of(merkle_tag);
+    return blk;
+}
+
+} // namespace
+
+// (a) Live socket-style exchange: a block request emitted through the node
+// reaches the wire-callback with the exact hash; a loopback feeds the reply
+// straight back via deliver_block; the byte-exact block lands on the handler.
+TEST(DashP2PNode, RequestReplyExchangeRoundtripsThroughNode)
+{
+    boost::asio::io_context ctx;
+    NodeP2P node(&ctx);
+
+    const uint256 want_id   = id_of(0x11);
+    const uint256 want_hash = id_of(0xAB);
+    const BlockType reply    = make_block(0xDEAD, 0xC0FFEE, 0x42);
+
+    uint256 emitted_hash;
+    int wire_calls = 0;
+
+    // Loopback "wire": on the outbound block request, immediately deliver the
+    // matching reply back into the node — the round-trip a live socket makes.
+    node.attach(
+        /*socket*/ nullptr,
+        /*block_req*/ [&](uint256 h) {
+            emitted_hash = h;
+            ++wire_calls;
+            node.deliver_block(want_id, reply);
+        },
+        /*header_req*/ [&](uint256) {});
+
+    ASSERT_TRUE(node.is_attached());
+
+    int handler_calls = 0;
+    BlockType got;
+    node.request_block(want_id, want_hash, [&](BlockType b) { got = b; ++handler_calls; });
+
+    // outbound half reached the wire with the exact hash.
+    EXPECT_EQ(wire_calls, 1);
+    EXPECT_EQ(emitted_hash, want_hash);
+
+    // inbound half routed the byte-exact reply to the matching handler.
+    EXPECT_EQ(handler_calls, 1);
+    EXPECT_EQ(got.m_version, 0xDEADu);
+    EXPECT_EQ(got.m_nonce, 0xC0FFEEu);
+    EXPECT_EQ(got.m_merkle_root, id_of(0x42));
+}
+
+// Header exchange carries the same contract through the node.
+TEST(DashP2PNode, HeaderExchangeRoundtripsThroughNode)
+{
+    boost::asio::io_context ctx;
+    NodeP2P node(&ctx);
+
+    const uint256 id   = id_of(0x07);
+    const uint256 hash = id_of(0x77);
+    BlockHeaderType reply;
+    reply.m_version = 0xBEEF;
+    reply.m_bits = 0x1d00ffff;
+
+    uint256 emitted_hash;
+    node.attach(nullptr, [&](uint256) {},
+        [&](uint256 h) { emitted_hash = h; node.deliver_header(id, reply); });
+
+    int handler_calls = 0;
+    BlockHeaderType got;
+    node.request_header(id, hash, [&](BlockHeaderType h) { got = h; ++handler_calls; });
+
+    EXPECT_EQ(emitted_hash, hash);
+    EXPECT_EQ(handler_calls, 1);
+    EXPECT_EQ(got.m_version, 0xBEEFu);
+    EXPECT_EQ(got.m_bits, 0x1d00ffffu);
+}
+
+// (b) Timeout path, driven by a REAL timer firing through io_context.run():
+// with a 1s idle deadline and no activity, the liveness timer fires, the node
+// tears the peer down, and the observer is notified with the reason.
+TEST(DashP2PNode, IdleTimeoutFiresViaRealTimerAndTearsDown)
+{
+    boost::asio::io_context ctx;
+    NodeP2P node(&ctx);
+
+    node.set_idle_timeout_sec(1);     // short, real countdown
+
+    std::string fired_reason;
+    int fire_count = 0;
+    node.set_on_timeout([&](const std::string& r) { fired_reason = r; ++fire_count; });
+
+    node.attach(nullptr, [&](uint256) {}, [&](uint256) {});
+    ASSERT_TRUE(node.is_attached());
+
+    // Drive the io_context until the timer actually fires (real async wait).
+    ctx.run();
+
+    EXPECT_EQ(fire_count, 1);
+    EXPECT_EQ(fired_reason, "idle timeout");
+    EXPECT_FALSE(node.is_attached());   // peer torn down on timeout
+}
+
+// note_activity() pushes the deadline forward: an activity poke before the
+// original deadline keeps the peer alive. Here we verify the node does NOT
+// time out within a window when activity keeps arriving — the timer is rearmed.
+TEST(DashP2PNode, ActivityRearmsLivenessTimer)
+{
+    boost::asio::io_context ctx;
+    NodeP2P node(&ctx);
+
+    node.set_idle_timeout_sec(2);
+    int fire_count = 0;
+    node.set_on_timeout([&](const std::string&) { ++fire_count; });
+
+    node.attach(nullptr, [&](uint256) {}, [&](uint256) {});
+
+    // Schedule an activity poke at ~1s (before the 2s deadline) that rearms the
+    // 2s countdown, then stop the io_context shortly after so run() returns
+    // before the rearmed deadline. The timeout must NOT have fired.
+    boost::asio::steady_timer poke(ctx, std::chrono::milliseconds(1000));
+    poke.async_wait([&](const boost::system::error_code&) { node.note_activity(); });
+
+    boost::asio::steady_timer stop(ctx, std::chrono::milliseconds(1500));
+    stop.async_wait([&](const boost::system::error_code&) { node.teardown(); });
+
+    ctx.run();
+
+    EXPECT_EQ(fire_count, 0);            // rearmed deadline never reached
+    EXPECT_FALSE(node.is_attached());   // teardown() detached it
+}
+
+// Lifecycle: teardown is idempotent and a torn-down node drops exchange calls
+// rather than throwing (a dead node must not crash the caller).
+TEST(DashP2PNode, TornDownNodeDropsExchangeCallsAndTeardownIsIdempotent)
+{
+    boost::asio::io_context ctx;
+    NodeP2P node(&ctx);
+
+    node.attach(nullptr, [&](uint256) {}, [&](uint256) {});
+    EXPECT_TRUE(node.is_attached());
+
+    node.teardown();
+    EXPECT_FALSE(node.is_attached());
+    node.teardown();                    // idempotent — no crash
+    EXPECT_FALSE(node.is_attached());
+
+    int handler_calls = 0;
+    // Dropped silently — no peer, no matcher; must NOT throw.
+    EXPECT_NO_THROW(node.request_block(id_of(1), id_of(2),
+        [&](BlockType) { ++handler_calls; }));
+    EXPECT_NO_THROW(node.deliver_block(id_of(1), make_block(1, 1, 1)));
+    EXPECT_NO_THROW(node.request_header(id_of(1), id_of(2),
+        [&](BlockHeaderType) { ++handler_calls; }));
+    EXPECT_NO_THROW(node.deliver_header(id_of(1), BlockHeaderType{}));
+    EXPECT_EQ(handler_calls, 0);
+}


### PR DESCRIPTION
S8 block-submission lane leaf toward the broadcaster gate. Adds the Dash coin-daemon P2P **node** layer on top of the merged p2p_connection/p2p_messages leaves (#357/#359/#367).

## Scope (DASH-fenced, 4 files / +420 −2)
- src/impl/dash/coin/p2p_node.hpp — socket-node skeleton: attach/teardown lifecycle, outbound-request -> inbound-reply exchange through Connection, real-timer idle-timeout + liveness re-arm.
- test/test_dash_p2p_node.cpp — 5 KATs (non-hollow).
- test/CMakeLists.txt — target + gtest_add_tests AUTO registration (same idiom as p2p_connection leaf).
- .github/workflows/build.yml — test_dash_p2p_node appended to BOTH target lists (avoids the NOT_BUILT allowlist sentinel).

## Evidence (Linux x86_64)
`ctest -R DashP2PNode` -> **100% tests passed, 0 failed out of 5** (tests #611-615, real registration — not a hollow target):
- RequestReplyExchangeRoundtripsThroughNode
- HeaderExchangeRoundtripsThroughNode
- IdleTimeoutFiresViaRealTimerAndTearsDown (real 1s timer)
- ActivityRearmsLivenessTimer
- TornDownNodeDropsExchangeCallsAndTeardownIsIdempotent

Base = master @3b4a5669 (rebased clean, GPG-good). Keeps dashd-RPC fallback path. No self-merge — held for integrator verify + operator tap.