### PR TITLE
web: surface DGB node identity in node_topology + node_info

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -5217,6 +5217,8 @@ nlohmann::json MiningInterface::rest_node_topology()
     case Blockchain::BITCOIN:  primary = "BTC";  break;
     case Blockchain::DOGECOIN: primary = "DOGE"; break;
     case Blockchain::DASH:     primary = "DASH"; break;
+    case Blockchain::DIGIBYTE: primary = "DGB";  break;
+    default: break;
     }
 
     nlohmann::json coins = nlohmann::json::array();
@@ -5287,6 +5289,11 @@ nlohmann::json MiningInterface::rest_node_info()
         result["network"] = m_testnet ? "dash_testnet" : "dash";
         result["symbol"] = "DASH";
         break;
+    case Blockchain::DIGIBYTE:
+        result["network"] = m_testnet ? "digibyte_testnet" : "digibyte";
+        result["symbol"] = "DGB";
+        break;
+    default: break;
     }
     return result;
 }


### PR DESCRIPTION
## What

`rest_node_topology()` and `rest_node_info()` switched on `m_blockchain` but only covered LTC/BTC/DOGE/DASH. A **DigiByte node fell through both switches**, leaving `node_symbol`/`primary` and `symbol`/`network` **empty** — the dashboard surfaced *no identity* for a DGB node. That is precisely the node-level lie the web layer exists to prevent.

## Fix
- Add `Blockchain::DIGIBYTE` cases to both switches (DGB / digibyte).
- Add `default: break;` so any future enum value fails safe to an empty-but-truthful "not enabled" state instead of relying on fall-through.

The header helper `primary_chain_key()` already handled DIGIBYTE; this just brings the two `.cpp` switches into line — pure consistency fix.

## Scope
Non-consensus **web layer** only → normal merge, flagged for operator merge-tap awareness (web on prod).

## Known follow-up (not this PR)
BCH and NMC remain unsurfaced because they are **absent from the `Blockchain` enum** (address_validator.hpp). Adding them is a cross-cutting coordination item with the consensus/per-coin stewards, tracked separately.

Charter: per-node truthful dashboard (each node shows its own real topology).