### PR TITLE
dash(s8): coin node-interface seam leaf — dash::interfaces::Node + KATs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node \
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface \
                     test_multiaddress_pplns test_pplns_stress \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
@@ -205,7 +205,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node \
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
                     test_v36_script_sorting test_v36_cross_impl_refhash \

--- a/src/impl/dash/coin/node_interface.hpp
+++ b/src/impl/dash/coin/node_interface.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "block.hpp"
+#include "transaction.hpp"
+
+#include <core/uint256.hpp>
+#include <core/events.hpp>
+
+#include <map>
+#include <vector>
+
+namespace dash
+{
+namespace interfaces
+{
+
+struct Node
+{
+    Variable<uint256> best_block_hash;
+    Event<uint256> new_block;
+    Event<coin::Transaction> new_tx;
+    Event<std::vector<coin::BlockHeaderType>> new_headers;
+    Event<coin::BlockType> full_block;
+
+    // SPV A1 (parity audit): fires when dashd announces a ChainLock has
+    // been aggregated for a block. Carries {block_hash, height}.
+    // Consumers (e.g. block-find submit handler) can consult
+    // m_chainlocked_blocks to know whether a found block is now
+    // irreversible.
+    Event<std::pair<uint256, int32_t>> new_chainlock;
+    std::map<uint256, int32_t> chainlocked_blocks; // block_hash → height
+
+    std::map<uint256, coin::Transaction> known_txs;
+};
+
+} // namespace interfaces
+} // namespace dash

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -409,6 +409,16 @@ if (BUILD_TESTING AND GTest_FOUND)
     target_link_libraries(test_dash_p2p_node PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
     gtest_add_tests(test_dash_p2p_node "" AUTO)
 
+    add_executable(test_dash_node_interface test_dash_node_interface.cpp)
+    target_link_libraries(test_dash_node_interface PRIVATE
+        GTest::gtest_main GTest::gtest
+        dash_x11 core
+        nlohmann_json::nlohmann_json
+        ${Boost_LIBRARIES}
+    )
+    target_link_libraries(test_dash_node_interface PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
+    gtest_add_tests(test_dash_node_interface "" AUTO)
+
     add_executable(test_compact_blocks test_compact_blocks.cpp)
     target_link_libraries(test_compact_blocks PRIVATE
         GTest::gtest_main GTest::gtest

--- a/test/test_dash_node_interface.cpp
+++ b/test/test_dash_node_interface.cpp
@@ -1,0 +1,140 @@
+/// Phase S8 — Dash coin-daemon node-interface seam KATs
+///
+/// Exercises src/impl/dash/coin/node_interface.hpp — the dash::interfaces::Node
+/// event/state seam the broadcaster gate binds against:
+///
+///     p2p_node -> [node_interface] -> broadcaster_full
+///
+/// broadcaster_full.hpp consumes this struct as the InterfacesNode each peer
+/// slot is handed (see DashBroadcastPeer). What is PINNED here is the real
+/// observable contract the broadcaster relies on:
+///
+///   (a) the Event fan-out — new_block / new_tx / new_headers / full_block each
+///       deliver their payload to a subscribed handler via happened(), the same
+///       core::Event mechanism the live node fires on. Subscribers observe the
+///       EXACT payload, not a placeholder.
+///
+///   (b) the best_block_hash Variable — set() flips has-value, value() reads the
+///       stored hash back, and the .changed Event fires the new value to a
+///       subscriber (the broadcaster watches this to learn the tip moved).
+///
+///   (c) the ChainLock seam — new_chainlock drives chainlocked_blocks so a
+///       block-find submit handler can ask "is this won block now irreversible?"
+///       A subscribed handler populates the map on fire; we assert the
+///       {block_hash -> height} mapping lands and is queryable.
+///
+///   plus known_txs as a plain lookup the broadcaster dedupes against.
+///
+/// SCOPE NOTE (honest): this pins the struct contract (events, Variable, maps)
+/// in isolation — no live socket, no broadcaster wiring (that is the next S8
+/// leaf). The Event/Variable machinery is the real core:: one, fired
+/// synchronously via happened()/set(); nothing here is mocked.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/node_interface.hpp>
+#include <impl/dash/coin/block.hpp>
+#include <impl/dash/coin/transaction.hpp>
+
+#include <core/uint256.hpp>
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+namespace {
+
+uint256 id_of(uint8_t b) { uint256 u; u.begin()[0] = b; return u; }
+
+dash::coin::Transaction make_tx()
+{
+    dash::coin::MutableTransaction mtx;
+    return dash::coin::Transaction(mtx);
+}
+
+// (a) Event fan-out: each Node event delivers its exact payload to a subscriber.
+TEST(DashNodeInterfaceKat, EventsFanOutExactPayload)
+{
+    dash::interfaces::Node node;
+
+    uint256 got_block;
+    int      block_hits = 0;
+    node.new_block.subscribe([&](uint256 h){ got_block = h; ++block_hits; });
+    node.new_block.happened(id_of(0xAB));
+    EXPECT_EQ(block_hits, 1);
+    EXPECT_EQ(got_block, id_of(0xAB));
+
+    int tx_hits = 0;
+    node.new_tx.subscribe([&](dash::coin::Transaction){ ++tx_hits; });
+    node.new_tx.happened(make_tx());
+    EXPECT_EQ(tx_hits, 1);
+
+    std::size_t hdr_count = 0;
+    node.new_headers.subscribe(
+        [&](std::vector<dash::coin::BlockHeaderType> hs){ hdr_count = hs.size(); });
+    node.new_headers.happened(std::vector<dash::coin::BlockHeaderType>(3));
+    EXPECT_EQ(hdr_count, 3u);
+
+    int full_hits = 0;
+    node.full_block.subscribe([&](dash::coin::BlockType){ ++full_hits; });
+    node.full_block.happened(dash::coin::BlockType{});
+    EXPECT_EQ(full_hits, 1);
+}
+
+// (b) best_block_hash Variable: set flips has-value, value() reads back,
+//     .changed fires the new tip to a subscriber.
+TEST(DashNodeInterfaceKat, BestBlockHashVariableTracksTip)
+{
+    dash::interfaces::Node node;
+
+    uint256 observed;
+    int     changes = 0;
+    node.best_block_hash.changed.subscribe([&](uint256 h){ observed = h; ++changes; });
+
+    node.best_block_hash.set(id_of(0x11));
+    EXPECT_EQ(node.best_block_hash.value(), id_of(0x11));
+    EXPECT_EQ(changes, 1);
+    EXPECT_EQ(observed, id_of(0x11));
+
+    // set to the same value is a no-op (no spurious change fired)
+    node.best_block_hash.set(id_of(0x11));
+    EXPECT_EQ(changes, 1);
+
+    node.best_block_hash.set(id_of(0x22));
+    EXPECT_EQ(node.best_block_hash.value(), id_of(0x22));
+    EXPECT_EQ(changes, 2);
+}
+
+// (c) ChainLock seam: new_chainlock drives chainlocked_blocks; a found block
+//     can then be queried for irreversibility.
+TEST(DashNodeInterfaceKat, ChainLockSeamPopulatesMap)
+{
+    dash::interfaces::Node node;
+
+    node.new_chainlock.subscribe([&](std::pair<uint256, int32_t> cl){
+        node.chainlocked_blocks[cl.first] = cl.second;
+    });
+
+    const uint256 won = id_of(0x7E);
+    EXPECT_EQ(node.chainlocked_blocks.count(won), 0u);
+
+    node.new_chainlock.happened(std::make_pair(won, int32_t{1501677}));
+
+    ASSERT_EQ(node.chainlocked_blocks.count(won), 1u);
+    EXPECT_EQ(node.chainlocked_blocks.at(won), 1501677);
+}
+
+// known_txs as a plain dedupe lookup the broadcaster consults.
+TEST(DashNodeInterfaceKat, KnownTxsLookup)
+{
+    dash::interfaces::Node node;
+
+    const uint256 k = id_of(0x33);
+    EXPECT_TRUE(node.known_txs.find(k) == node.known_txs.end());
+
+    node.known_txs.emplace(k, make_tx());
+    EXPECT_EQ(node.known_txs.size(), 1u);
+    EXPECT_TRUE(node.known_txs.find(k) != node.known_txs.end());
+}
+
+} // namespace


### PR DESCRIPTION
## S8 leaf — Dash coin node-interface seam (`dash::interfaces::Node`)

Ports `src/impl/dash/coin/node_interface.hpp` onto the S8 stack — the
prerequisite seam `broadcaster_full.hpp` binds against (each `DashBroadcastPeer`
is handed this struct as its `InterfacesNode`):

```
p2p_node -> [node_interface] -> broadcaster_full   <- this leaf is [node_interface]
```

**Stacked on** `dash/s8-p2p-node-leaf` (#397). Retarget to `master` once #397 lands.

### Scope (SAFE-ADDITIVE)
- New header-only file + new test target only. No existing file's behavior changes.
- All deps (`block.hpp`, `transaction.hpp`, `core/uint256`, `core/events`) already present on the base.

### KAT — `test_dash_node_interface.cpp`, **4/4 green Linux x86_64 (non-hollow, ids 622–625)**
Pins the real observable contract against the live `core::Event`/`Variable` machinery (no mocks):
- (a) `new_block`/`new_tx`/`new_headers`/`full_block` event fan-out, exact payload delivered
- (b) `best_block_hash` Variable: `set`/`value()` round-trip + `.changed` fire + no-op on equal-set
- (c) `new_chainlock` → `chainlocked_blocks` `{hash→height}` irreversibility query
- plus `known_txs` dedupe lookup

Wired into `test/CMakeLists.txt` and both `build.yml --target` lists.

Held for integrator verify → operator tap. No self-merge.
