### PR TITLE
dash(s8): broadcaster peer-pool leaf — DashBroadcaster discovery/fan-out scaffold + KATs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config \
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster \
                     test_multiaddress_pplns test_pplns_stress \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
@@ -205,7 +205,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config \
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
                     test_v36_script_sorting test_v36_cross_impl_refhash \

--- a/src/impl/dash/broadcaster.hpp
+++ b/src/impl/dash/broadcaster.hpp
@@ -1,0 +1,338 @@
+#pragma once
+
+// Phase S8 — DashBroadcaster: dashd P2P peer-pool + discovery scaffold (LEAF).
+//
+// One rung above the socket-node, this is the pool that holds many parent-chain
+// (dashd) P2P connections so a found block can be fanned out in parallel,
+// cutting propagation latency below what a single-dashd submit can reach:
+//
+//     p2p_connection -> p2p_node -> [broadcaster] -> broadcaster_full
+//
+// Mirrors the INTENT of p2pool-dash/p2pool/dash/broadcaster.py
+// (DashNetworkBroadcaster, max_peers=20) and c2pool-ltc's CoinBroadcaster, but
+// this LEAF is strictly the PURE peer-pool + discovery + fan-out SCAFFOLD:
+//
+//   * a slot pool keyed "host:port", slot = unique_ptr<dash::coin::p2p::NodeP2P>
+//     (the concrete current node type). Slot creation (the DIAL) is injected via
+//     a std::function factory so the selection/discovery logic is unit-testable
+//     WITHOUT opening a socket. The default factory just constructs a NodeP2P.
+//   * the deterministic discovery pipeline driven from a getpeerinfo-shaped
+//     nlohmann::json array: parse "addr" -> port-filter to the canonical p2p
+//     port -> exclude the primary host -> dedupe vs existing slots -> respect a
+//     per-key backoff map -> cap at max_peers.
+//   * prune-dead: drop slots whose liveness predicate is false and arm a
+//     backoff so we don't thrash-dial a dead address.
+//   * live_count + peer_info aggregation (primary array + per-slot arrays).
+//
+// EXPLICITLY OUT OF SCOPE for this LEAF (lands in the SEPARATE keystone
+// broadcaster_full.hpp, which routes the won block through the operator):
+//   * real block submission / submit_block_raw / the won-block path. Here the
+//     fan-out only iterates the LIVE slots invoking an injectable per-slot hook
+//     (a no-op by default) — NO consensus, NO submitblock, NO RPC.
+//   * the dashd handshake (version/verack), GBT fetch, quorum/mnlistdiff sync,
+//     reconnect/ping cadence, peer scoring / Wilson-score reputation,
+//     exponential backoff growth, /16 group caps, persisted anchor peers, and
+//     the actual getpeerinfo RPC call (discover() takes the json directly so the
+//     selection logic is driven deterministically; wiring the live RPC tick is
+//     a broadcaster_full concern).
+//
+// Header-only to match the sibling leaves (config.hpp, p2p_node.hpp,
+// p2p_connection.hpp, p2p_messages.hpp). No consensus value, single dash tree.
+
+#include "coin/p2p_node.hpp"
+#include "config.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <functional>
+#include <map>
+#include <memory>
+#include <span>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include <core/log.hpp>
+#include <core/netaddress.hpp>
+
+namespace dash
+{
+
+// Pool of dashd P2P node slots + discovery/fan-out scaffold. Non-consensus.
+class DashBroadcaster
+{
+public:
+    using Slot = std::unique_ptr<dash::coin::p2p::NodeP2P>;
+
+    // Injectable DIAL/slot factory. Default constructs a bare NodeP2P bound to
+    // the io_context (no socket attached yet — attach()/handshake is a
+    // broadcaster_full concern). Tests inject a stub factory so the selection
+    // pipeline runs with no socket opened.
+    using SlotFactory = std::function<Slot(const NetService& /*addr*/)>;
+
+    // Injectable per-slot liveness predicate. Defaults to NodeP2P::is_attached.
+    // Decoupled so tests can drive prune/live_count deterministically without a
+    // live peer; production uses the real attached() predicate.
+    using LivePredicate = std::function<bool(const dash::coin::p2p::NodeP2P&)>;
+
+    // Injectable per-slot fan-out hook. THIS LEAF leaves it a no-op; the real
+    // block-submit fan-out lands in broadcaster_full.hpp. submit_block_raw_all
+    // only iterates the LIVE slots invoking this hook.
+    using FanOutHook = std::function<void(dash::coin::p2p::NodeP2P& /*slot*/,
+                                          std::span<const unsigned char> /*block_bytes*/)>;
+
+    DashBroadcaster(boost::asio::io_context* ioc,
+                    dash::Config* config,
+                    const NetService& primary_addr,
+                    size_t max_peers)
+        : m_ioc(ioc)
+        , m_config(config)
+        , m_primary_addr(primary_addr)
+        , m_max_peers(max_peers)
+        , m_factory(default_factory(ioc))
+        , m_is_live([](const dash::coin::p2p::NodeP2P& n) { return n.is_attached(); })
+        , m_fan_out([](dash::coin::p2p::NodeP2P&, std::span<const unsigned char>) {})
+    {}
+
+    // ── injection seams (tests / broadcaster_full) ───────────────────────
+
+    void set_slot_factory(SlotFactory f) { m_factory = std::move(f); }
+    void set_live_predicate(LivePredicate p) { m_is_live = std::move(p); }
+    void set_fan_out_hook(FanOutHook h) { m_fan_out = std::move(h); }
+
+    // ── pure deterministic endpoint parse ────────────────────────────────
+
+    struct ParsedEndpoint { std::string host; int port{0}; bool valid{false}; };
+
+    // Parse a getpeerinfo "addr" entry: "host:port" or bracketed "[host]:port".
+    // Strips an "::ffff:" IPv4-mapped prefix off the host. Rejects empties,
+    // missing/bad ports, and out-of-range ports.
+    static ParsedEndpoint parse_host_port(const std::string& s)
+    {
+        ParsedEndpoint out;
+        if (s.empty()) return out;
+        std::string host;
+        std::string port_str;
+        if (s.front() == '[') {
+            auto close = s.find(']');
+            if (close == std::string::npos) return out;
+            host = s.substr(1, close - 1);
+            if (close + 1 >= s.size() || s[close + 1] != ':') return out;
+            port_str = s.substr(close + 2);
+        } else {
+            auto colon = s.rfind(':');
+            if (colon == std::string::npos) return out;
+            host = s.substr(0, colon);
+            port_str = s.substr(colon + 1);
+        }
+        const std::string v4map = "::ffff:";
+        if (host.rfind(v4map, 0) == 0) host = host.substr(v4map.size());
+        if (host.empty()) return out;
+        try { out.port = std::stoi(port_str); }
+        catch (...) { return out; }
+        if (out.port <= 0 || out.port > 65535) return out;
+        out.host = std::move(host);
+        out.valid = true;
+        return out;
+    }
+
+    // ── pure deterministic candidate selection ───────────────────────────
+
+    // From a getpeerinfo-shaped json array, select the endpoints we should dial:
+    //   * parse the "addr" field; skip malformed
+    //   * port-filter to the canonical p2p port
+    //   * exclude the primary host (already connected via main_dash)
+    //   * dedupe vs existing slots AND within this batch
+    //   * respect the per-key backoff map (skip if still backed off)
+    //   * cap so live_count + selected does not exceed max_peers
+    // Returns the chosen NetService dial targets in input order. PURE w.r.t. the
+    // pool: it reads the slot keys / backoff but does NOT create slots.
+    std::vector<NetService> select_candidates(const nlohmann::json& peers) const
+    {
+        std::vector<NetService> chosen;
+        if (!peers.is_array()) return chosen;
+
+        const int port = canonical_port();
+        const std::string primary = primary_host();
+        const auto now = std::chrono::steady_clock::now();
+        const size_t live = live_count();
+
+        std::map<std::string, bool> seen_this_batch;
+
+        for (const auto& p : peers) {
+            if (live + chosen.size() >= m_max_peers) break;
+            if (!p.is_object()) continue;
+            if (!p.contains("addr")) continue;
+
+            auto ep = parse_host_port(p.value("addr", std::string{}));
+            if (!ep.valid) continue;
+            if (ep.port != port) continue;          // canonical-port only
+            if (ep.host == primary) continue;        // exclude primary
+
+            std::string key = ep.host + ":" + std::to_string(ep.port);
+            if (m_slots.count(key)) continue;        // dedupe vs existing slots
+            if (seen_this_batch.count(key)) continue; // dedupe within batch
+
+            auto bo = m_backoff.find(key);
+            if (bo != m_backoff.end() && now < bo->second) continue; // backoff
+
+            seen_this_batch[key] = true;
+            chosen.emplace_back(ep.host, static_cast<uint16_t>(ep.port));
+        }
+        return chosen;
+    }
+
+    // ── pool mutation ────────────────────────────────────────────────────
+
+    // Run one discovery pass over a getpeerinfo-shaped json array: select
+    // candidates, then create a slot for each via the injected factory. Returns
+    // the number of new slots created. prune_dead() is run first so freed
+    // capacity is reused. No socket is opened by this method itself — that is
+    // entirely the factory's business (default factory only constructs).
+    size_t discover(const nlohmann::json& peers)
+    {
+        prune_dead();
+        auto cands = select_candidates(peers);
+        size_t dialed = 0;
+        for (const auto& addr : cands) {
+            std::string key = slot_key(addr);
+            if (m_slots.count(key)) continue;
+            auto slot = m_factory ? m_factory(addr) : Slot{};
+            if (!slot) {
+                // Factory declined (dial failed) — short backoff, try again soon.
+                m_backoff[key] = std::chrono::steady_clock::now()
+                                 + std::chrono::minutes(1);
+                continue;
+            }
+            m_slots[key] = std::move(slot);
+            ++dialed;
+        }
+        if (dialed > 0)
+            LOG_INFO << "[DashBroadcast] discovery: dialed=" << dialed
+                     << " live=" << live_count() << "/" << m_max_peers;
+        return dialed;
+    }
+
+    // Remove slots whose liveness predicate is false (connection collapsed /
+    // never handshook) and arm a backoff so the same dead address is not
+    // thrash-dialed by the next discovery pass. Returns count pruned.
+    size_t prune_dead()
+    {
+        const auto now = std::chrono::steady_clock::now();
+        size_t pruned = 0;
+        for (auto it = m_slots.begin(); it != m_slots.end(); ) {
+            const bool live = it->second && m_is_live && m_is_live(*it->second);
+            if (!live) {
+                LOG_INFO << "[DashBroadcast] pruning dead slot " << it->first;
+                m_backoff[it->first] = now + std::chrono::minutes(5);
+                it = m_slots.erase(it);
+                ++pruned;
+            } else {
+                ++it;
+            }
+        }
+        return pruned;
+    }
+
+    // ── fan-out (SCAFFOLD — NO real block submit in this leaf) ────────────
+
+    // Iterate the LIVE slots invoking the injected fan-out hook. In this leaf
+    // the hook is a no-op by default; the REAL block-submit fan-out lands in
+    // broadcaster_full.hpp (which routes the won block through the operator).
+    // Returns the number of live slots the hook was invoked on.
+    size_t submit_block_raw_all(std::span<const unsigned char> block_bytes)
+    {
+        size_t sent = 0;
+        for (auto& [key, slot] : m_slots) {
+            if (slot && m_is_live && m_is_live(*slot)) {
+                m_fan_out(*slot, block_bytes);
+                ++sent;
+            }
+        }
+        return sent;
+    }
+
+    // ── observers ────────────────────────────────────────────────────────
+
+    size_t live_count() const
+    {
+        size_t n = 0;
+        for (const auto& [key, slot] : m_slots)
+            if (slot && m_is_live && m_is_live(*slot)) ++n;
+        return n;
+    }
+
+    size_t slot_count() const { return m_slots.size(); }
+
+    bool has_slot(const std::string& key) const { return m_slots.count(key) != 0; }
+
+    bool is_backed_off(const std::string& key) const
+    {
+        auto bo = m_backoff.find(key);
+        return bo != m_backoff.end()
+               && std::chrono::steady_clock::now() < bo->second;
+    }
+
+    // Dashboard panel feed: combine the primary peer array with each slot's
+    // own peer_info array into a single flat array. Slots contribute via the
+    // injected per-slot json provider; absent one, only the primary passes
+    // through (a per-slot json source is a broadcaster_full concern).
+    nlohmann::json peer_info_json_all(
+        const nlohmann::json& primary,
+        const std::function<nlohmann::json(const dash::coin::p2p::NodeP2P&)>& slot_json
+            = {}) const
+    {
+        nlohmann::json arr = nlohmann::json::array();
+        if (primary.is_array())
+            for (const auto& p : primary) arr.push_back(p);
+        if (slot_json) {
+            for (const auto& [key, slot] : m_slots) {
+                if (!slot) continue;
+                auto entry = slot_json(*slot);
+                if (entry.is_array())
+                    for (auto& p : entry) arr.push_back(std::move(p));
+                else if (!entry.is_null())
+                    arr.push_back(std::move(entry));
+            }
+        }
+        return arr;
+    }
+
+private:
+    static SlotFactory default_factory(boost::asio::io_context* ioc)
+    {
+        return [ioc](const NetService&) -> Slot {
+            // Bare node bound to the io_context. The actual socket dial /
+            // attach / handshake is deferred to broadcaster_full.hpp.
+            return std::make_unique<dash::coin::p2p::NodeP2P>(ioc);
+        };
+    }
+
+    int canonical_port() const
+    {
+        return m_config ? static_cast<int>(m_config->coin()->m_p2p.address.port())
+                        : 0;
+    }
+
+    std::string primary_host() const { return m_primary_addr.address(); }
+
+    static std::string slot_key(const NetService& addr)
+    {
+        return addr.address() + ":" + std::to_string(addr.port());
+    }
+
+    boost::asio::io_context* m_ioc{};
+    dash::Config*            m_config{};
+    NetService               m_primary_addr;
+    size_t                   m_max_peers{};
+
+    SlotFactory   m_factory;
+    LivePredicate m_is_live;
+    FanOutHook    m_fan_out;
+
+    std::map<std::string, Slot>                                    m_slots;
+    std::map<std::string, std::chrono::steady_clock::time_point>   m_backoff;
+};
+
+} // namespace dash

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -429,6 +429,16 @@ if (BUILD_TESTING AND GTest_FOUND)
     target_link_libraries(test_dash_config PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
     gtest_add_tests(test_dash_config "" AUTO)
 
+    add_executable(test_dash_broadcaster test_dash_broadcaster.cpp)
+    target_link_libraries(test_dash_broadcaster PRIVATE
+        GTest::gtest_main GTest::gtest
+        dash_x11 core
+        nlohmann_json::nlohmann_json
+        ${Boost_LIBRARIES}
+    )
+    target_link_libraries(test_dash_broadcaster PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
+    gtest_add_tests(test_dash_broadcaster "" AUTO)
+
     add_executable(test_compact_blocks test_compact_blocks.cpp)
     target_link_libraries(test_compact_blocks PRIVATE
         GTest::gtest_main GTest::gtest

--- a/test/test_dash_broadcaster.cpp
+++ b/test/test_dash_broadcaster.cpp
@@ -1,0 +1,325 @@
+/// Phase S8 — DashBroadcaster peer-pool + discovery scaffold KATs.
+///
+/// Exercises src/impl/dash/broadcaster.hpp — the PURE peer-pool + discovery +
+/// fan-out scaffold one rung above the socket-node:
+///
+///     p2p_connection -> p2p_node -> [broadcaster] -> broadcaster_full
+///
+/// What is PINNED here is the real, deterministic, socket-free contract the
+/// broadcaster_full keystone builds on. Every test injects the slot factory and
+/// the liveness predicate so NO socket is opened and NO live node is required:
+///
+///   (a) parse_host_port — plain "host:port", bracketed "[v6]:port",
+///       "::ffff:" v4-mapped stripping, and rejection of malformed/bad-port.
+///   (b) select_candidates — canonical-port filter, primary-host exclude,
+///       dedupe vs existing slots, dedupe within batch, backoff skip, and the
+///       max_peers cap (live + selected <= max).
+///   (c) discover — creates a slot per candidate via the injected factory and
+///       reuses freed capacity after prune.
+///   (d) prune_dead — removes non-live slots and arms a backoff for each.
+///   (e) live_count — counts only slots the injected predicate marks live.
+///   (f) peer_info_json_all — merges the primary array with per-slot arrays.
+///   (g) submit_block_raw_all — fan-out scaffold invokes the injected per-slot
+///       hook on LIVE slots only (NO real block submit in this leaf).
+///
+/// SCOPE NOTE (honest): the slot factory produces bare NodeP2P objects (no
+/// socket attached) and liveness is driven through the injected predicate, so
+/// these KATs pin the selection/pool/fan-out logic in isolation against the
+/// real dash::Config / NetService / NodeP2P types. The live dashd handshake,
+/// getpeerinfo RPC tick, and the real block-submit fan-out are broadcaster_full
+/// concerns and are intentionally not exercised here.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/broadcaster.hpp>
+#include <impl/dash/config.hpp>
+#include <core/netaddress.hpp>
+
+#include <boost/asio.hpp>
+
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+using namespace dash;
+using nlohmann::json;
+
+namespace {
+
+// Canonical p2p port the broadcaster filters to (testnet3, 19999 is mainnet).
+constexpr uint16_t kCanonicalPort = 19999;
+constexpr char     kPrimaryHost[] = "10.9.9.9";
+
+// Build a config whose coin p2p address carries the canonical port the
+// candidate selection filters against.
+std::unique_ptr<Config> make_config()
+{
+    auto cfg = std::make_unique<Config>("dash-s8-broadcaster-kat");
+    cfg->coin()->m_p2p.address =
+        NetService{std::string{"127.0.0.1"}, std::to_string(kCanonicalPort)};
+    return cfg;
+}
+
+// A factory that records every address it was asked to dial and produces a bare
+// NodeP2P (no socket). Liveness of produced slots is governed entirely by the
+// injected predicate below, so nothing touches a socket.
+struct StubFactory {
+    boost::asio::io_context* ioc;
+    std::vector<std::string>* dialed;
+    DashBroadcaster::Slot operator()(const NetService& addr)
+    {
+        dialed->push_back(addr.address() + ":" + std::to_string(addr.port()));
+        return std::make_unique<dash::coin::p2p::NodeP2P>(ioc);
+    }
+};
+
+// Helper to wire a broadcaster with the stub factory + a controllable liveness
+// predicate (default: everything created is "live").
+DashBroadcaster make_bcast(boost::asio::io_context& ioc,
+                           Config* cfg,
+                           std::vector<std::string>& dialed,
+                           bool* all_live,
+                           size_t max_peers)
+{
+    DashBroadcaster b{&ioc, cfg, NetService{std::string{kPrimaryHost},
+                                            std::to_string(kCanonicalPort)},
+                      max_peers};
+    b.set_slot_factory(StubFactory{&ioc, &dialed});
+    b.set_live_predicate(
+        [all_live](const dash::coin::p2p::NodeP2P&) { return *all_live; });
+    return b;
+}
+
+json peer(const std::string& addr)
+{
+    json p = json::object();
+    p["addr"] = addr;
+    return p;
+}
+
+} // namespace
+
+// (a) parse_host_port — all variants.
+TEST(DashBroadcaster, ParseHostPortVariants)
+{
+    // plain host:port
+    auto a = DashBroadcaster::parse_host_port("1.2.3.4:19999");
+    ASSERT_TRUE(a.valid);
+    EXPECT_EQ(a.host, "1.2.3.4");
+    EXPECT_EQ(a.port, 19999);
+
+    // bracketed IPv6
+    auto b = DashBroadcaster::parse_host_port("[2001:db8::1]:19999");
+    ASSERT_TRUE(b.valid);
+    EXPECT_EQ(b.host, "2001:db8::1");
+    EXPECT_EQ(b.port, 19999);
+
+    // v4-mapped prefix stripped (bracketed form, as dashd emits)
+    auto c = DashBroadcaster::parse_host_port("[::ffff:5.6.7.8]:19999");
+    ASSERT_TRUE(c.valid);
+    EXPECT_EQ(c.host, "5.6.7.8");
+    EXPECT_EQ(c.port, 19999);
+
+    // rejections
+    EXPECT_FALSE(DashBroadcaster::parse_host_port("").valid);
+    EXPECT_FALSE(DashBroadcaster::parse_host_port("nohostport").valid);
+    EXPECT_FALSE(DashBroadcaster::parse_host_port("1.2.3.4:abc").valid);
+    EXPECT_FALSE(DashBroadcaster::parse_host_port("1.2.3.4:0").valid);
+    EXPECT_FALSE(DashBroadcaster::parse_host_port("1.2.3.4:70000").valid);
+    EXPECT_FALSE(DashBroadcaster::parse_host_port("[2001:db8::1]").valid);   // no port
+    EXPECT_FALSE(DashBroadcaster::parse_host_port("[2001:db8::1]9999").valid); // missing colon
+}
+
+// (b) select_candidates — port filter, primary exclude, dedupe, cap.
+TEST(DashBroadcaster, SelectCandidatesFilterAndCap)
+{
+    boost::asio::io_context ioc;
+    auto cfg = make_config();
+    std::vector<std::string> dialed;
+    bool all_live = true;
+    auto b = make_bcast(ioc, cfg.get(), dialed, &all_live, /*max_peers*/2);
+
+    json peers = json::array();
+    peers.push_back(peer("1.1.1.1:19999"));                 // good
+    peers.push_back(peer("2.2.2.2:8888"));                  // wrong port -> skip
+    peers.push_back(std::string{kPrimaryHost} + ":19999");  // not an object form below
+    peers.push_back(peer(std::string{kPrimaryHost} + ":19999")); // primary -> skip
+    peers.push_back(peer("[::ffff:3.3.3.3]:19999"));        // good (v4-mapped)
+    peers.push_back(peer("4.4.4.4:19999"));                 // good but over cap=2
+    peers.push_back(peer("1.1.1.1:19999"));                 // dup of first -> skip
+    peers.push_back(peer("garbage"));                       // malformed -> skip
+    peers.push_back(7);                                     // non-object -> skip
+
+    auto cands = b.select_candidates(peers);
+    ASSERT_EQ(cands.size(), 2u);  // capped at max_peers
+    EXPECT_EQ(cands[0].address(), "1.1.1.1");
+    EXPECT_EQ(cands[1].address(), "3.3.3.3");  // v4-mapped stripped
+}
+
+// (b cont) backoff skip is respected by selection.
+TEST(DashBroadcaster, SelectCandidatesBackoffSkip)
+{
+    boost::asio::io_context ioc;
+    auto cfg = make_config();
+    std::vector<std::string> dialed;
+    bool all_live = false;  // produced slots considered dead -> pruned -> backoff
+    auto b = make_bcast(ioc, cfg.get(), dialed, &all_live, /*max_peers*/8);
+
+    // First discover dials these; since predicate says dead, prune arms backoff.
+    json peers = json::array();
+    peers.push_back(peer("5.5.5.5:19999"));
+    peers.push_back(peer("6.6.6.6:19999"));
+
+    EXPECT_EQ(b.discover(peers), 2u);   // both dialed (factory always yields)
+    EXPECT_EQ(b.prune_dead(), 2u);      // both dead -> pruned + backoff armed
+    EXPECT_TRUE(b.is_backed_off("5.5.5.5:19999"));
+    EXPECT_TRUE(b.is_backed_off("6.6.6.6:19999"));
+
+    // Now selection must skip both (still backed off).
+    auto cands = b.select_candidates(peers);
+    EXPECT_TRUE(cands.empty());
+}
+
+// (c) discover creates slots via the injected factory.
+TEST(DashBroadcaster, DiscoverCreatesSlots)
+{
+    boost::asio::io_context ioc;
+    auto cfg = make_config();
+    std::vector<std::string> dialed;
+    bool all_live = true;
+    auto b = make_bcast(ioc, cfg.get(), dialed, &all_live, /*max_peers*/8);
+
+    json peers = json::array();
+    peers.push_back(peer("7.7.7.7:19999"));
+    peers.push_back(peer("8.8.8.8:19999"));
+
+    EXPECT_EQ(b.discover(peers), 2u);
+    EXPECT_EQ(b.slot_count(), 2u);
+    EXPECT_TRUE(b.has_slot("7.7.7.7:19999"));
+    EXPECT_TRUE(b.has_slot("8.8.8.8:19999"));
+    ASSERT_EQ(dialed.size(), 2u);
+
+    // Re-discover with the same peers -> dedupe vs existing slots, no new dials.
+    EXPECT_EQ(b.discover(peers), 0u);
+    EXPECT_EQ(b.slot_count(), 2u);
+    EXPECT_EQ(dialed.size(), 2u);
+}
+
+// (d) prune_dead removes non-live slots and arms backoff; (e) live_count.
+TEST(DashBroadcaster, PruneDeadAndLiveCount)
+{
+    boost::asio::io_context ioc;
+    auto cfg = make_config();
+    std::vector<std::string> dialed;
+    bool all_live = true;
+    auto b = make_bcast(ioc, cfg.get(), dialed, &all_live, /*max_peers*/8);
+
+    json peers = json::array();
+    peers.push_back(peer("9.9.9.1:19999"));
+    peers.push_back(peer("9.9.9.2:19999"));
+    EXPECT_EQ(b.discover(peers), 2u);
+    EXPECT_EQ(b.live_count(), 2u);  // predicate says live
+
+    // Flip predicate to dead -> live_count drops, prune removes both.
+    all_live = false;
+    EXPECT_EQ(b.live_count(), 0u);
+    EXPECT_EQ(b.prune_dead(), 2u);
+    EXPECT_EQ(b.slot_count(), 0u);
+    EXPECT_TRUE(b.is_backed_off("9.9.9.1:19999"));
+    EXPECT_TRUE(b.is_backed_off("9.9.9.2:19999"));
+}
+
+// (e cont) capacity cap accounts for existing live slots.
+TEST(DashBroadcaster, MaxPeersAccountsForLiveSlots)
+{
+    boost::asio::io_context ioc;
+    auto cfg = make_config();
+    std::vector<std::string> dialed;
+    bool all_live = true;
+    auto b = make_bcast(ioc, cfg.get(), dialed, &all_live, /*max_peers*/3);
+
+    json first = json::array();
+    first.push_back(peer("1.0.0.1:19999"));
+    first.push_back(peer("1.0.0.2:19999"));
+    EXPECT_EQ(b.discover(first), 2u);
+    EXPECT_EQ(b.live_count(), 2u);
+
+    // Now offer 3 more; only 1 fits (2 live + 1 = max 3).
+    json more = json::array();
+    more.push_back(peer("1.0.0.3:19999"));
+    more.push_back(peer("1.0.0.4:19999"));
+    more.push_back(peer("1.0.0.5:19999"));
+    EXPECT_EQ(b.discover(more), 1u);
+    EXPECT_EQ(b.slot_count(), 3u);
+}
+
+// (f) peer_info_json_all merges primary + per-slot arrays.
+TEST(DashBroadcaster, PeerInfoAggregation)
+{
+    boost::asio::io_context ioc;
+    auto cfg = make_config();
+    std::vector<std::string> dialed;
+    bool all_live = true;
+    auto b = make_bcast(ioc, cfg.get(), dialed, &all_live, /*max_peers*/8);
+
+    json peers = json::array();
+    peers.push_back(peer("2.0.0.1:19999"));
+    peers.push_back(peer("2.0.0.2:19999"));
+    EXPECT_EQ(b.discover(peers), 2u);
+
+    json primary = json::array();
+    primary.push_back(json{{"addr", "primary-A"}});
+    primary.push_back(json{{"addr", "primary-B"}});
+
+    // Per-slot json source: each slot contributes a single-element array.
+    int counter = 0;
+    auto slot_json = [&counter](const dash::coin::p2p::NodeP2P&) {
+        json a = json::array();
+        a.push_back(json{{"slot", counter++}});
+        return a;
+    };
+
+    auto all = b.peer_info_json_all(primary, slot_json);
+    ASSERT_TRUE(all.is_array());
+    EXPECT_EQ(all.size(), 4u);  // 2 primary + 2 slot
+
+    // Without a slot-json source, only the primary array passes through.
+    auto primary_only = b.peer_info_json_all(primary);
+    EXPECT_EQ(primary_only.size(), 2u);
+}
+
+// (g) submit_block_raw_all fan-out scaffold — hook fires on LIVE slots only.
+TEST(DashBroadcaster, FanOutHookOnLiveSlotsOnly)
+{
+    boost::asio::io_context ioc;
+    auto cfg = make_config();
+    std::vector<std::string> dialed;
+    bool all_live = true;
+    auto b = make_bcast(ioc, cfg.get(), dialed, &all_live, /*max_peers*/8);
+
+    json peers = json::array();
+    peers.push_back(peer("3.0.0.1:19999"));
+    peers.push_back(peer("3.0.0.2:19999"));
+    EXPECT_EQ(b.discover(peers), 2u);
+
+    int hook_calls = 0;
+    std::vector<unsigned char> observed;
+    b.set_fan_out_hook(
+        [&](dash::coin::p2p::NodeP2P&, std::span<const unsigned char> bytes) {
+            ++hook_calls;
+            observed.assign(bytes.begin(), bytes.end());
+        });
+
+    std::vector<unsigned char> block = {0xde, 0xad, 0xbe, 0xef};
+    EXPECT_EQ(b.submit_block_raw_all(block), 2u);  // 2 live slots
+    EXPECT_EQ(hook_calls, 2);
+    ASSERT_EQ(observed.size(), 4u);
+    EXPECT_EQ(observed[0], 0xde);
+
+    // Mark all dead -> no live slots -> hook not invoked.
+    all_live = false;
+    hook_calls = 0;
+    EXPECT_EQ(b.submit_block_raw_all(block), 0u);
+    EXPECT_EQ(hook_calls, 0);
+}


### PR DESCRIPTION
## DASH S8 — broadcaster peer-pool LEAF (Phase 1: discovery/fan-out scaffold)

Adds `src/impl/dash/broadcaster.hpp` — the PURE dashd P2P peer-pool + discovery + fan-out **scaffold** one rung above the socket-node, the next `broadcaster_full.hpp` prerequisite:

```
p2p_connection -> p2p_node -> [broadcaster] -> broadcaster_full
```

### Scope (strictly non-consensus)
- Slot pool keyed `"host:port"`, slot = `std::unique_ptr<dash::coin::p2p::NodeP2P>` (the concrete current node type).
- The DIAL/slot-creation is **injectable** via a `std::function` factory (default constructs a bare `NodeP2P`; tests inject a stub) so the discovery/selection logic is unit-testable with **no live socket**. Liveness uses `NodeP2P::is_attached()` through an injectable predicate so prune/live_count are deterministic in tests.
- Deterministic discovery pipeline over a getpeerinfo-shaped `nlohmann::json` array: `parse_host_port` (plain `host:port`, bracketed `[v6]:port`, `::ffff:` v4-mapped stripping, reject malformed/bad-port) → canonical-port filter → exclude primary host → dedupe vs existing slots + within batch → per-key backoff skip → cap at `max_peers`.
- `prune_dead` removes non-live slots and arms a backoff; `live_count`; `peer_info_json_all` merges the primary array with per-slot arrays.

### Explicitly OUT OF SCOPE (separate keystone `broadcaster_full.hpp`, which routes the won block through the operator)
Real block submission / `submit_block_raw` / the won-block path, the dashd handshake, GBT/quorum/mnlistdiff sync, the live getpeerinfo RPC tick, peer scoring. Here the fan-out only iterates LIVE slots invoking an injectable per-slot hook (no-op by default) — **no consensus, no submitblock, no RPC**. The reference broadcaster's `coin/node.hpp` + `coin/rpc.hpp` deps (absent on this tree) are intentionally not pulled in; this builds against the current `p2p_node` + `config` seams only.

### Safety
**SAFE-ADDITIVE**: header-only new file + new ctest target only. No existing file behavior changes, single dash tree, no `shared` / `bitcoin_family` / `src/core` touch, no consensus value.

### Tests
`test_dash_broadcaster.cpp` — socket-free KATs against the live `dash::Config` / `NetService` / `NodeP2P` types: parse_host_port variants + rejections; candidate selection (port-filter / primary-exclude / dedupe-vs-existing / dedupe-in-batch / backoff-skip / max_peers cap accounting for live slots); discover slot creation + re-run dedupe; prune_dead + backoff; live_count; peer_info aggregation; fan-out hook on LIVE slots only. **8/8 ctest green on Linux x86_64 (non-hollow, ids 630-637).** Wired into `test/CMakeLists.txt` and **both** `build.yml --target` lists.

Stacked on #404 (`dash/s8-config-leaf`). Held for integrator verify — **NO self-merge**.
