### PR TITLE
dash: restore share-target validity guard (target>MAX_TARGET) — conform vs p2pool-dash oracle

### DIFF
--- a/src/impl/dash/share_check.hpp
+++ b/src/impl/dash/share_check.hpp
@@ -158,6 +158,23 @@ inline std::vector<unsigned char> compute_gentx_before_refhash()
     return result;
 }
 
+// ── check_share_target_valid (Dash v16) ─────────────────────────────
+// Conformance with p2pool-dash oracle data.py Share.__init__:
+//     if self.target > net.MAX_TARGET: raise PeerMisbehavingError('share target invalid')
+// The claimed share target must be no easier than the network share-diff floor
+// (params.max_target == net.MAX_TARGET); a zero target is likewise invalid. This is
+// a structural validity guard on share_info['bits'], independent of the PoW check.
+// v36 3-bucket: the GUARD is v36-native SHARED validation (Bucket 2 — cross-coin
+// identical); only the per-coin max_target constant differs (a consensus param, not
+// an isolation primitive).
+inline void check_share_target_valid(const uint256& target, const core::CoinParams& params)
+{
+    if (target.IsNull())
+        throw std::invalid_argument("share target is zero");
+    if (target > params.max_target)
+        throw std::invalid_argument("share target invalid");
+}
+
 // ── share_init_verify (Dash v16) ─────────────────────────────────────────────
 // Verifies PoW, hash_link, merkle_link. Returns share hash (SHA256d of header).
 inline uint256 share_init_verify(const DashShare& share,
@@ -166,6 +183,10 @@ inline uint256 share_init_verify(const DashShare& share,
 {
     if (share.m_coinbase.m_data.size() < 2 || share.m_coinbase.m_data.size() > 100)
         throw std::invalid_argument("bad coinbase size");
+
+    // ── Share target validity (oracle: target > MAX_TARGET → "share target invalid") ──
+    // Unconditional — NOT gated by check_pow, matching p2pool-dash Share.__init__.
+    check_share_target_valid(chain::bits_to_target(share.m_bits), params);
 
     // ── Compute ref_hash ──
     PackStream ref_stream;
@@ -269,9 +290,6 @@ inline uint256 share_init_verify(const DashShare& share,
     if (check_pow)
     {
         uint256 target = chain::bits_to_target(share.m_bits);
-        if (target.IsNull())
-            throw std::invalid_argument("share target is zero");
-
         if (share_hash > target)
             throw std::invalid_argument("share PoW hash does not meet target");
     }

--- a/test/test_dash_conformance.cpp
+++ b/test/test_dash_conformance.cpp
@@ -367,6 +367,33 @@ TEST(DashConformanceDifficulty, BitsToDifficultyMatchesP2poolDash) {
     }
 }
 
+// ── Pillar-3 conformance: share-target validity guard vs p2pool-dash oracle ──
+// Oracle data.py Share.__init__ rejects `self.target > net.MAX_TARGET`
+// ("share target invalid") AND a zero target. c2pool share_init_verify previously
+// enforced only the zero case — no share-diff-floor upper bound. This pins the
+// restored guard against the mainnet floor (params.max_target == 0xFFFF*2**208).
+TEST(DashConformanceShareTarget, RejectsTargetEasierThanFloorAndZero) {
+    core::CoinParams params;
+    params.max_target = dash::PoolConfig::max_target();   // 00000000ffff00..00
+
+    const uint256 floor = params.max_target;
+
+    // exactly at the floor -> accepted (boundary, not "> floor")
+    EXPECT_NO_THROW(dash::check_share_target_valid(floor, params));
+
+    // strictly harder (numerically smaller target) -> accepted
+    uint256 harder; harder.SetHex("000000000000ffff000000000000000000000000000000000000000000000000");
+    EXPECT_NO_THROW(dash::check_share_target_valid(harder, params));
+
+    // strictly easier than the floor (numerically larger) -> rejected
+    uint256 easier; easier.SetHex("00000001ffff0000000000000000000000000000000000000000000000000000");
+    EXPECT_THROW(dash::check_share_target_valid(easier, params), std::invalid_argument);
+
+    // zero target -> rejected
+    uint256 zero;
+    EXPECT_THROW(dash::check_share_target_valid(zero, params), std::invalid_argument);
+}
+
 // ── PPLNS payout-SET equality conformance (S6 slice 6) ───────────────────────
 // The miner-facing output of the whole sharechain is the PPLNS payout SET:
 // the {scriptPubKey -> amount} map a coinbase pays. For DASH to be value-


### PR DESCRIPTION
Pillar-3 of the integrator-directed DASH conformance sweep (share-hash/ref-hash construction + PoW target/work accounting) vs oracle frstrtr/p2pool-dash @9a0a609.

## Finding
ref_hash / hash_link / merkle / gentx_before_refhash construction audited byte-conformant. ONE divergence in PoW target accounting: the oracle Share.__init__ rejects `self.target > net.MAX_TARGET` ("share target invalid") — the share-diff floor — but c2pool `dash::share_init_verify` enforced only the zero-target case. No upper-bound (floor) guard existed anywhere in the dash accept path (share_check.hpp / share_chain.hpp).

## Fix (SAFE-ADDITIVE, consensus-bearing → verify+tap gated)
- Add `check_share_target_valid(target, params)`: rejects zero AND `target > params.max_target`.
- Wire it **unconditionally** (not gated by check_pow), matching the oracle. The per-coin `max_target` constant is unchanged; only the previously-missing guard is restored.
- New KAT `DashConformanceShareTarget`: floor + harder accepted; easier + zero rejected.

## v36 3-bucket classification
The **guard** is Bucket-2 (v36-native SHARED validation — cross-coin identical; standardize toward a shared check). The **max_target constant** stays per-coin (a consensus param, NOT an isolation primitive). IDENTIFIER/PREFIX untouched (Bucket-1).

## Evidence
- IDENTIFIER exact match: mainnet `7242ef345e1bed6b`, testnet `b6deb1e543fe2427` (= oracle networks/dash{,_testnet}.py).
- Linux x86_64 `ctest test_dash_conformance`: 46/46 green, non-hollow (13 suites).
- GPG-signed b06c1968. base=master @c2815b7c. 2 files, +48/-3, no build.yml/CMake change.

No self-merge — held for integrator verify (oracle + full CI) then operator tap.