### PR TITLE
fix(dash): VarStr-pack outer coinbase_payload in gentx hash_link (oracle conform)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster \
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_share_hash_link \
                     test_multiaddress_pplns test_pplns_stress \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
@@ -205,7 +205,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster \
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_share_hash_link \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
                     test_v36_script_sorting test_v36_cross_impl_refhash \

--- a/src/impl/dash/share_check.hpp
+++ b/src/impl/dash/share_check.hpp
@@ -231,12 +231,24 @@ inline uint256 share_init_verify(const DashShare& share,
         auto* p = reinterpret_cast<const unsigned char*>(&zero);
         hash_link_data.insert(hash_link_data.end(), p, p + 4);
     }
-    // Append outer coinbase_payload (coinbase_payload_data in Python)
-    // Reference: data.py line 342-348
+    // Append outer coinbase_payload (coinbase_payload_data in Python).
+    // Oracle data.py:278,346-348: coinbase_payload_data = pack.VarStrType().pack(payload)
+    // = [compactsize(len)][payload]; check_hash_link appends THAT (or b"" when None).
+    // BaseScript C2POOL_SERIALIZE_METHODS does READWRITE(m_data) over a byte vector,
+    // which strips one VarStr layer on read (so m_data holds the RAW payload) and
+    // re-adds the compactsize prefix on write. Serialize via the stream rather than
+    // appending m_data raw — the raw append dropped the prefix, diverging gentx_hash
+    // from the oracle on any non-empty (DIP4 CbTx) payload. PRESERVE the empty branch:
+    // the oracle appends nothing (b"") when the payload is None/empty, NOT a 0x00.
     {
         auto& cpd = share.m_coinbase_payload_outer.m_data;
         if (!cpd.empty())
-            hash_link_data.insert(hash_link_data.end(), cpd.begin(), cpd.end());
+        {
+            PackStream cpd_stream;
+            cpd_stream << share.m_coinbase_payload_outer;   // VarStr-pack: [compactsize][payload]
+            auto* cp = reinterpret_cast<const unsigned char*>(cpd_stream.data());
+            hash_link_data.insert(hash_link_data.end(), cp, cp + cpd_stream.size());
+        }
     }
 
     auto gentx_before_refhash = compute_gentx_before_refhash();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -254,6 +254,19 @@ if (BUILD_TESTING AND GTest_FOUND)
     target_link_libraries(test_dash_conformance PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39): core stratum/web_server TUs
     gtest_add_tests(test_dash_conformance "" AUTO)
 
+    # share_init_verify gentx hash_link byte-parity vs oracle (coinbase_payload
+    # VarStr prefix). Header-only over the dash_x11 + core link set; mirrors the
+    # test_dash_conformance link set.
+    add_executable(test_dash_share_hash_link test_dash_share_hash_link.cpp)
+    target_link_libraries(test_dash_share_hash_link PRIVATE
+        GTest::gtest_main GTest::gtest
+        dash_x11 core
+        nlohmann_json::nlohmann_json
+        ${Boost_LIBRARIES}
+    )
+    target_link_libraries(test_dash_share_hash_link PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39): core stratum/web_server TUs
+    gtest_add_tests(test_dash_share_hash_link "" AUTO)
+
     # DASH block-subsidy + UTXO adapter (S7 foundation slice): GetBlockSubsidy /
     # masternode + platform reward split (subsidy.hpp) consumed through the
     # header-only utxo_adapter view shim. Both are header-only over

--- a/test/test_dash_share_hash_link.cpp
+++ b/test/test_dash_share_hash_link.cpp
@@ -1,0 +1,190 @@
+// DASH share hash_link / gentx_hash byte-parity vs oracle (frstrtr/p2pool-dash).
+//
+// Pins the coinbase_payload encoding inside the gentx hash_link_data assembly.
+// Oracle data.py:278,346-348: the outer coinbase_payload is appended to the
+// check_hash_link data as pack.VarStrType().pack(payload) == [compactsize(len)]
+// [payload] when non-empty, and as b"" (nothing) when None/empty. A prior
+// c2pool defect appended the RAW payload bytes with NO compactsize prefix, so
+// for any non-empty (DIP4 CbTx) payload the gentx_hash — and therefore share
+// accept/reject — diverged from the oracle. This is net-new coverage: DASH had
+// no caller of share_init_verify under test.
+//
+// Two complementary anchors:
+//   1. OracleCheckHashLinkVarStrPayload — a non-circular pin. With a length-0
+//      hash_link seeded by the SHA-256 IV, dash::check_hash_link degenerates to
+//      plain SHA256d(data), so the expected digest is computed OUT-OF-BAND with
+//      CPython hashlib over a fully-known byte vector (ref || nonce || 0 ||
+//      VarStr(payload)). Also asserts the buggy raw-append form yields a
+//      DIFFERENT, separately-pinned digest, proving the prefix is load-bearing.
+//   2. ShareInitVerifyAppendsVarStrPayload — exercises the production
+//      share_init_verify() end-to-end on a DashShare with a non-empty outer
+//      payload. With empty merkle/ref links the block merkle_root equals the
+//      gentx_hash, so X11(reconstructed header) is a faithful proxy for the
+//      gentx_hash. The expected value is rebuilt with the oracle VarStr form;
+//      the raw-append form is asserted to differ, so the test is discriminating.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/share_check.hpp>   // share_init_verify, check_hash_link, check_merkle_link, compute_gentx_before_refhash
+#include <impl/dash/share.hpp>         // dash::DashShare
+#include <impl/dash/share_types.hpp>   // dash::HashLinkType, dash::MerkleLink
+#include <impl/dash/params.hpp>        // dash::make_coin_params
+
+#include <core/coin_params.hpp>
+#include <core/hash.hpp>               // Hash (sha256d)
+#include <core/pack.hpp>
+#include <core/pack_types.hpp>
+#include <core/target_utils.hpp>       // chain::bits_to_target
+#include <core/uint256.hpp>
+
+#include <array>
+#include <cstdint>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace {
+
+// SHA-256 initial hash values (big-endian). Seeding a length-0 hash_link with
+// these makes check_hash_link == SHA256d(data) — see header note (1).
+constexpr std::array<unsigned char, 32> SHA256_IV = {
+    0x6a,0x09,0xe6,0x67, 0xbb,0x67,0xae,0x85, 0x3c,0x6e,0xf3,0x72, 0xa5,0x4f,0xf5,0x3a,
+    0x51,0x0e,0x52,0x7f, 0x9b,0x05,0x68,0x8c, 0x1f,0x83,0xd9,0xab, 0x5b,0xe0,0xcd,0x19,
+};
+
+// Raw-digest / uint256-internal order (matches test_dash_conformance idiom).
+std::string hex_of(const uint256& h) {
+    auto c = h.GetChars();
+    return HexStr(std::span<const unsigned char>(c.data(), c.size()));
+}
+
+dash::HashLinkType iv_hash_link() {
+    dash::HashLinkType hl;
+    hl.m_state.m_data.assign(SHA256_IV.begin(), SHA256_IV.end());
+    hl.m_extra_data.m_data.clear();
+    hl.m_length = 0;  // length % 64 == 0 -> no const_ending consumed; CSHA256 starts fresh
+    return hl;
+}
+
+void put_le(std::vector<unsigned char>& v, uint64_t x, int n) {
+    for (int i = 0; i < n; ++i) v.push_back(static_cast<unsigned char>((x >> (8 * i)) & 0xff));
+}
+
+const std::vector<unsigned char> kPayload = {0xde, 0xad, 0xbe, 0xef};
+
+} // namespace
+
+// (1) Non-circular oracle anchor: SHA256d over a fully-known byte vector.
+TEST(DashShareHashLink, OracleCheckHashLinkVarStrPayload) {
+    auto hl = iv_hash_link();
+    const auto ce = dash::compute_gentx_before_refhash();  // unused at length%64==0
+
+    std::vector<unsigned char> data;
+    for (int i = 0; i < 32; ++i) data.push_back(static_cast<unsigned char>(i));  // ref_hash
+    put_le(data, 0, 8);   // last_txout_nonce
+    put_le(data, 0, 4);   // IntType(32).pack(0)
+    data.push_back(static_cast<unsigned char>(kPayload.size()));                 // compactsize
+    data.insert(data.end(), kPayload.begin(), kPayload.end());                   // VarStr(payload)
+
+    uint256 g = dash::check_hash_link(hl, data, ce);
+    // CPython: sha256d(bytes(range(32)) + 0*8 + 0*4 + b"\x04\xde\xad\xbe\xef")
+    EXPECT_EQ(hex_of(g), "2d21628941d5bd07d5fe90349bb113ed0fad495a0d33bf4f5c270697c40e8843");
+
+    // Buggy raw-append (no compactsize) -> different, separately-pinned digest.
+    std::vector<unsigned char> raw;
+    for (int i = 0; i < 32; ++i) raw.push_back(static_cast<unsigned char>(i));
+    put_le(raw, 0, 8);
+    put_le(raw, 0, 4);
+    raw.insert(raw.end(), kPayload.begin(), kPayload.end());
+    uint256 gr = dash::check_hash_link(hl, raw, ce);
+    EXPECT_EQ(hex_of(gr), "75e4562b843ac74b7c78db29dc40ce10d6659c578159c5952638b3340f877fb2");
+    EXPECT_NE(hex_of(g), hex_of(gr)) << "compactsize prefix must change gentx_hash";
+}
+
+// (2) End-to-end through the production share_init_verify().
+TEST(DashShareHashLink, ShareInitVerifyAppendsVarStrPayload) {
+    const core::CoinParams params = dash::make_coin_params(/*testnet=*/false);
+
+    dash::DashShare share;
+    share.m_coinbase = BaseScript(std::vector<unsigned char>{0x00, 0x00});  // 2 bytes (valid 2..100)
+    share.m_coinbase_payload_outer.m_data = kPayload;                       // NON-empty (under test)
+    share.m_desired_version = 16;
+    share.m_bits = 0x1d00ffffu;       // bits_to_target == mainnet max_target (passes validity guard)
+    share.m_max_bits = 0x1d00ffffu;
+    share.m_hash_link = iv_hash_link();
+    // empty m_ref_merkle_link / m_merkle_link -> ref_hash == hash_ref, merkle_root == gentx_hash
+
+    // ---- mirror share_init_verify ref_hash assembly (to feed expected gentx) ----
+    PackStream ref_stream;
+    {
+        auto hex = params.active_identifier_hex();
+        for (size_t i = 0; i + 1 < hex.size(); i += 2) {
+            unsigned char b = static_cast<unsigned char>(std::stoul(hex.substr(i, 2), nullptr, 16));
+            ref_stream.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(&b), 1));
+        }
+    }
+    ref_stream << share.m_prev_hash;
+    ref_stream << share.m_coinbase;
+    ref_stream << share.m_coinbase_payload;
+    ref_stream << share.m_nonce;
+    ref_stream << share.m_pubkey_hash;
+    ref_stream << share.m_subsidy;
+    ref_stream << share.m_donation;
+    { uint8_t si = static_cast<uint8_t>(share.m_stale_info); ref_stream << si; }
+    ::Serialize(ref_stream, VarInt(share.m_desired_version));
+    ref_stream << share.m_payment_amount;
+    ref_stream << share.m_packed_payments;
+    ref_stream << share.m_new_transaction_hashes;
+    {
+        uint64_t pair_count = share.m_transaction_hash_refs.size() / 2;
+        ::Serialize(ref_stream, VarInt(pair_count));
+        for (auto& v : share.m_transaction_hash_refs) ::Serialize(ref_stream, VarInt(v));
+    }
+    ref_stream << share.m_far_share_hash;
+    ref_stream << share.m_max_bits;
+    ref_stream << share.m_bits;
+    ref_stream << share.m_timestamp;
+    ref_stream << share.m_absheight;
+    ref_stream << share.m_abswork;
+    auto ref_span = std::span<const unsigned char>(
+        reinterpret_cast<const unsigned char*>(ref_stream.data()), ref_stream.size());
+    uint256 ref_hash = dash::check_merkle_link(Hash(ref_span), share.m_ref_merkle_link);
+
+    // expected gentx with the ORACLE (VarStr) payload form
+    auto build_gentx = [&](bool varstr) {
+        std::vector<unsigned char> hd(ref_hash.data(), ref_hash.data() + 32);
+        put_le(hd, share.m_last_txout_nonce, 8);
+        put_le(hd, 0, 4);
+        if (varstr) {
+            PackStream ps; ps << share.m_coinbase_payload_outer;
+            auto* cp = reinterpret_cast<const unsigned char*>(ps.data());
+            hd.insert(hd.end(), cp, cp + ps.size());
+        } else {
+            hd.insert(hd.end(), kPayload.begin(), kPayload.end());
+        }
+        return dash::check_hash_link(share.m_hash_link, hd, dash::compute_gentx_before_refhash());
+    };
+
+    auto share_hash_for = [&](const uint256& gentx) {
+        uint256 merkle_root = dash::check_merkle_link(gentx, share.m_merkle_link);  // empty -> gentx
+        PackStream hs;
+        uint32_t v = static_cast<uint32_t>(share.m_min_header.m_version); hs << v;
+        hs << share.m_min_header.m_previous_block;
+        hs << merkle_root;
+        hs << share.m_min_header.m_timestamp;
+        hs << share.m_min_header.m_bits;
+        hs << share.m_min_header.m_nonce;
+        auto hsp = std::span<const unsigned char>(
+            reinterpret_cast<const unsigned char*>(hs.data()), hs.size());
+        return params.pow_func(hsp);
+    };
+
+    uint256 expected = share_hash_for(build_gentx(/*varstr=*/true));
+    uint256 buggy    = share_hash_for(build_gentx(/*varstr=*/false));
+    ASSERT_NE(hex_of(expected), hex_of(buggy)) << "test must discriminate the two encodings";
+
+    uint256 actual = dash::share_init_verify(share, params, /*check_pow=*/false);
+    EXPECT_EQ(hex_of(actual), hex_of(expected))
+        << "share_init_verify must append VarStr(coinbase_payload), not raw bytes";
+    EXPECT_NE(hex_of(actual), hex_of(buggy));
+}


### PR DESCRIPTION
## Pillar-3 conformance defect (DASH sweep)

**Divergence (REAL, consensus-bearing):** `share_init_verify` appended the RAW outer `coinbase_payload` bytes into the `check_hash_link` data, dropping the compactsize length prefix. Oracle `frstrtr/p2pool-dash` `data.py:278,346-348` packs it as `VarStrType == [compactsize(len)][payload]` (appends `b""` when None/empty). For any non-empty DIP4 CbTx payload this diverged `gentx_hash` -> share accept/reject from the oracle.

**Fix:** serialize `m_coinbase_payload_outer` through the PackStream (VarStr-pack). Empty branch preserved (append nothing, not `0x00`).

**Net-new coverage** (`test_dash_share_hash_link`): DASH had no caller of `share_init_verify` under test.
1. `OracleCheckHashLinkVarStrPayload` — non-circular pin: length-0 IV hash_link degenerates check_hash_link to SHA256d, expected digest computed out-of-band with CPython over the fully-known byte vector; buggy raw-append form asserted to differ (separately pinned).
2. `ShareInitVerifyAppendsVarStrPayload` — end-to-end production path with a non-empty (DIP4 CbTx) payload; also closes the pillar-4 transitive caveat (exercises a non-empty special-tx payload empirically, not by inheritance).

Target wired into BOTH `build.yml --target` lists (A1-incident: CI-built, not just CMake-defined).

**Local (Linux x86_64, non-hollow):** test_dash_share_hash_link 2/2; test_dash_conformance + factory 55/55; no regression.

Per-coin isolation: DASH consensus code, conforms vs its own oracle. Consensus-bearing — NOT green-auto-merge; held for integrator verify -> operator tap.