### PR TITLE
nmc(PD): route build_mm_commitment through cross-coin SSOT + drift-guard KAT

### DIFF
--- a/src/impl/nmc/coin/header_chain.hpp
+++ b/src/impl/nmc/coin/header_chain.hpp
@@ -61,6 +61,20 @@
 #include <stdexcept>
 #include <vector>
 
+// PD SSOT wire-in: build_mm_commitment() below delegates the merged-mining
+// commitment byte layout to the cross-coin canonical builder rather than
+// re-emitting it NMC-locally. Forward-declared here (instead of #include
+// <c2pool/merged/merged_mining.hpp>) so this foundational coin header stays
+// clear of that header boost/asio + jsonrpccxx include graph. The signature
+// MUST track c2pool::merged::build_auxpow_commitment in merged_mining.hpp; the
+// drift-guard KAT in test/auxpow_merkle_test.cpp fails closed if the layouts
+// ever diverge. Definition lives in c2pool_merged_mining (linked by the test).
+namespace c2pool { namespace merged {
+std::vector<std::uint8_t> build_auxpow_commitment(const uint256& mm_root,
+                                                  std::uint32_t tree_size,
+                                                  std::uint32_t nonce);
+} }  // namespace c2pool::merged
+
 namespace nmc {
 namespace coin {
 
@@ -251,32 +265,23 @@ inline MMScan scan_mm_commitment(const std::vector<unsigned char>& script,
 /// occupies slot aux_expected_index(nonce, chain_id, chain_height). The root is
 /// stored reversed (big-endian display order) to match auxpow.cpp. This emits
 /// ONLY the MM marker payload; the caller (PD dual-target build path) prepends
-/// any coinbase scriptSig framing (height push, extranonce). Kept NMC-LOCAL per
-/// the coin fence (only std + core types). chain_merkle_root is taken by value
+/// any coinbase scriptSig framing (height push, extranonce). Delegates the byte layout to the cross-coin
+/// SSOT c2pool::merged::build_auxpow_commitment (see body). chain_merkle_root is taken by value
 /// because base_uint::begin() is non-const (same as scan_mm_commitment).
 inline std::vector<unsigned char> build_mm_commitment(uint256 chain_merkle_root,
                                                       unsigned chain_height,
                                                       uint32_t nonce) {
-    std::vector<unsigned char> out;
-    out.reserve(4 + uint256::BYTES + 8);
-    out.insert(out.end(), MM_HEADER_MAGIC, MM_HEADER_MAGIC + 4);
-
-    // Chain-merkle root committed reversed (big-endian display order).
-    const unsigned char* rb =
-        reinterpret_cast<const unsigned char*>(chain_merkle_root.begin());
-    std::vector<unsigned char> root_be(rb, rb + uint256::BYTES);
-    std::reverse(root_be.begin(), root_be.end());
-    out.insert(out.end(), root_be.begin(), root_be.end());
-
-    auto put_le32 = [&out](uint32_t x) {
-        out.push_back(static_cast<unsigned char>( x        & 0xff));
-        out.push_back(static_cast<unsigned char>((x >> 8)  & 0xff));
-        out.push_back(static_cast<unsigned char>((x >> 16) & 0xff));
-        out.push_back(static_cast<unsigned char>((x >> 24) & 0xff));
-    };
-    put_le32(1u << chain_height);   // tree size = 2^chain_height
-    put_le32(nonce);
-    return out;
+    // SSOT adapter (bucket-2: v36-NATIVE SHARED STRUCTURE). The merged-mining
+    // commitment byte layout is IDENTICAL across every merge-mined coin, so this
+    // emits no parallel NMC-local path: it delegates to the cross-coin canonical
+    // builder c2pool::merged::build_auxpow_commitment and contributes ONLY the
+    // NMC-typed height->size mapping (chain-merkle tree size = 2^chain_height).
+    // A single-NMC-under-BTC slot has chain_height == 0 -> size == 1. The byte
+    // output (magic | root BE(32) | size LE32 | nonce LE32) is pinned identical
+    // to the SSOT by the drift-guard KAT in test/auxpow_merkle_test.cpp.
+    return c2pool::merged::build_auxpow_commitment(chain_merkle_root,
+                                                   1u << chain_height,
+                                                   nonce);
 }
 
 // ─── AuxPow (merge-mining proof) ─────────────────────────────────────────────

--- a/src/impl/nmc/test/auxpow_merkle_test.cpp
+++ b/src/impl/nmc/test/auxpow_merkle_test.cpp
@@ -35,6 +35,7 @@
 
 #include "../coin/header_chain.hpp"
 #include "../coin/mempool.hpp"
+#include <c2pool/merged/merged_mining.hpp>  // PD SSOT drift-guard: build_auxpow_commitment
 
 namespace {
 
@@ -489,6 +490,28 @@ TEST(NmcBuildMMCommitment, ByteLayoutIsMagicReversedRootSizeNonce)
 
     EXPECT_EQ(got, want);
     EXPECT_EQ(got.size(), static_cast<size_t>(4 + 32 + 4 + 4));
+}
+
+TEST(NmcBuildMMCommitment, DelegatesByteForByteToCrossCoinSSOT)
+{
+    // PD SSOT drift-guard. build_mm_commitment is a thin NMC-typed ADAPTER over
+    // the cross-coin canonical builder c2pool::merged::build_auxpow_commitment;
+    // its only added semantics is the height->size map (tree size = 2^height).
+    // Pin byte-for-byte equality so the adapter can never silently fork a
+    // parallel NMC-local commitment layout -- the bucket-2 v37-convergence trap.
+    struct Case { uint256 root; unsigned h; uint32_t nonce; };
+    const std::vector<Case> cases = {
+        { leaf_of(0x01), 0, 0u },                              // single NMC under BTC: size == 1
+        { leaf_of(0xAB), 1, 1u },
+        { combine(leaf_of(0x02), leaf_of(0x77)), 3, 0x04030201u },
+        { leaf_of(0xFF), 5, 0xDEADBEEFu },
+    };
+    for (const auto& c : cases) {
+        auto adapter = build_mm_commitment(c.root, c.h, c.nonce);
+        auto ssot    = c2pool::merged::build_auxpow_commitment(c.root, 1u << c.h, c.nonce);
+        EXPECT_EQ(adapter, ssot)
+            << "MM commitment adapter diverged from cross-coin SSOT at h=" << c.h;
+    }
 }
 
 TEST(NmcBuildMMCommitment, TamperedRootOrSlotFailsScan)


### PR DESCRIPTION
PD SSOT wire-in. Refactors `nmc::coin::build_mm_commitment` from a parallel NMC-local byte path into a thin typed **adapter** that delegates to the cross-coin canonical builder `c2pool::merged::build_auxpow_commitment`. The adapter contributes ONLY the NMC-typed height->size mapping (chain-merkle tree size = `1 << chain_height`; single-NMC-under-BTC -> size 1). Byte layout (`fabe6d6d | root BE(32) | size LE32 | nonce LE32`) is now emitted by one builder for all merge-mined coins.

**Bucket-2 (v36-NATIVE SHARED STRUCTURE).** Standardizing to one commitment builder is what keeps v37's unified multichain datastructure a clean migration, not a reconciliation of divergent per-coin layouts. Byte output is identical => structure/SSOT change, not a consensus-VALUE change.

**Include hygiene.** `build_auxpow_commitment` is forward-declared in `header_chain.hpp` (not `#include`d) so this foundational coin header stays clear of `merged_mining.hpp`'s boost/asio + jsonrpccxx include graph. Symbol resolves from `c2pool_merged_mining`, already linked by `nmc_auxpow_merkle_test` -> **no CMake / build.yml allowlist change needed.**

**Drift-guard KAT.** `NmcBuildMMCommitment.DelegatesByteForByteToCrossCoinSSOT` asserts `build_mm_commitment(root,h,n) == build_auxpow_commitment(root,1<<h,n)` byte-for-byte across h=0..5, failing closed if layouts diverge. The 3 pre-existing layout KATs are unchanged and still pass (refactor is byte-preserving). `nmc_auxpow_merkle_test` **84/84 green** locally.

**Fence:** `src/impl/nmc/` + its test only; no DOGE/LTC parent-coinbase edits.

Integrator asks: (1) confirmed — the adapter is the ONLY NMC build-side commitment emitter; zero non-test callers of `build_mm_commitment` and zero hand-rolled `fabe6d6d`/MM layouts anywhere under `src/impl/nmc/` outside the test, so the SSOT claim is not hollow. (2) fence held. Auto-merge OFF — for integrator CI-rollup verification + operator tap.
