### PR TITLE
web(topology): config-driven coin label fallback for chains absent from Blockchain enum

### DIFF
--- a/src/c2pool/c2pool_refactored.cpp
+++ b/src/c2pool/c2pool_refactored.cpp
@@ -578,6 +578,7 @@ int main(int argc, char* argv[]) {
     std::string doge_p2p_address;            // --doge-p2p-address HOST
     int doge_p2p_port = 0;                   // --doge-p2p-port PORT
     Blockchain blockchain = Blockchain::LITECOIN;  // Default to Litecoin
+    std::string blockchain_label = "ltc";  // Raw coin string -> web layer node_symbol() fallback (config-driven labeling)
 
     // Coin daemon P2P connection (for fast block relay alongside RPC)
     std::string coind_p2p_address;   // defaults to rpc_host (same machine as RPC)
@@ -765,7 +766,8 @@ int main(int argc, char* argv[]) {
         else if (arg == "--loglevel-critical") { cli_log_level = "fatal"; cli_explicit.insert("log_level"); }
         // Network / blockchain selection (p2pool: --net)
         else if ((arg == "--net" || arg == "--blockchain") && i + 1 < argc) {
-            blockchain = parse_blockchain(argv[++i]);
+            blockchain_label = argv[++i];
+            blockchain = parse_blockchain(blockchain_label);
             cli_explicit.insert("blockchain");
         }
         // P2Pool P2P sharechain port (p2pool: --p2pool-port)
@@ -1142,8 +1144,10 @@ int main(int argc, char* argv[]) {
                 else if (m == "wait") startup_mode = StartupMode::WAIT;
                 else startup_mode = StartupMode::AUTO;
             }
-            if (!cli_explicit.count("blockchain") && cfg["blockchain"])
-                blockchain = parse_blockchain(cfg["blockchain"].as<std::string>());
+            if (!cli_explicit.count("blockchain") && cfg["blockchain"]) {
+                blockchain_label = cfg["blockchain"].as<std::string>();
+                blockchain = parse_blockchain(blockchain_label);
+            }
 
             // Ports
             if (!cli_explicit.count("p2p_port") && cfg["port"])
@@ -1568,6 +1572,7 @@ int main(int argc, char* argv[]) {
             if (!external_ip.empty())
                 web_server.get_mining_interface()->set_external_ip(external_ip);
 #ifdef C2POOL_VERSION
+            web_server.get_mining_interface()->set_coin_label(blockchain_label);
             web_server.get_mining_interface()->set_pool_version(
                 "c2pool/" C2POOL_VERSION);
 #endif

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -5210,16 +5210,10 @@ nlohmann::json MiningInterface::rest_node_topology()
         return str;
     };
 
-    // This node's own chain.
-    std::string primary;
-    switch (m_blockchain) {
-    case Blockchain::LITECOIN: primary = "LTC";  break;
-    case Blockchain::BITCOIN:  primary = "BTC";  break;
-    case Blockchain::DOGECOIN: primary = "DOGE"; break;
-    case Blockchain::DASH:     primary = "DASH"; break;
-    case Blockchain::DIGIBYTE: primary = "DGB";  break;
-    default: break;
-    }
+    // This node's own chain. node_symbol() falls back to the config-driven
+    // coin label for chains with no Blockchain enum entry (BCH / NMC-aux),
+    // so a node never advertises a blank primary symbol.
+    std::string primary = node_symbol();
 
     nlohmann::json coins = nlohmann::json::array();
     auto has_coin = [&](const std::string& sym) {
@@ -5294,6 +5288,17 @@ nlohmann::json MiningInterface::rest_node_info()
         result["symbol"] = "DGB";
         break;
     default: break;
+    }
+    // Config-driven fallback for chains absent from the Blockchain enum
+    // (BCH / NMC-aux): label from the configured coin string rather than
+    // leaving symbol/network blank.
+    if (!result.contains("symbol")) {
+        std::string sym = node_symbol();
+        if (!sym.empty()) result["symbol"] = sym;
+    }
+    if (!result.contains("network")) {
+        std::string ck = primary_chain_key();
+        if (!ck.empty()) result["network"] = m_testnet ? (ck + "_testnet") : ck;
     }
     return result;
 }

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -934,6 +934,7 @@ private:
     std::map<std::string, nlohmann::json> m_active_work;
     bool m_testnet;  // Store testnet flag
     Blockchain m_blockchain;  // Store blockchain type
+    std::string m_coin_label; // Raw configured coin string; fallback label for chains absent from the Blockchain enum
     std::shared_ptr<IMiningNode> m_node;  // Connection to c2pool node for difficulty tracking
     BlockchainAddressValidator m_address_validator;  // New address validator
     std::unique_ptr<c2pool::payout::PayoutManager> m_payout_manager;  // Payout management
@@ -1199,6 +1200,23 @@ public:
     void set_explorer_url(const std::string& url) { m_explorer_url = url; }
     const std::string& get_explorer_url() const { return m_explorer_url; }
 
+    // Uppercase coin symbol for THIS node. Enum-derived for the consensus-
+    // supported coins; falls back to the config-driven m_coin_label when the
+    // chain has no Blockchain enum entry (BCH / NMC-aux), so topology and
+    // node_info never emit a blank symbol. "" only when truly unconfigured.
+    std::string node_symbol() const {
+        switch (m_blockchain) {
+            case Blockchain::LITECOIN: return "LTC";
+            case Blockchain::BITCOIN:  return "BTC";
+            case Blockchain::DOGECOIN: return "DOGE";
+            case Blockchain::DASH:     return "DASH";
+            case Blockchain::DIGIBYTE: return "DGB";
+            default:                   break;
+        }
+        std::string s = m_coin_label;
+        for (auto& ch : s) if (ch >= 'a' && ch <= 'z') ch = static_cast<char>(ch - 32);
+        return s;
+    }
     // Primary chain key for THIS node, derived from its configured blockchain
     // (lowercase symbol). Used as the default chain for explorer / coin-admin
     // endpoints instead of a hardcoded "ltc": a DGB/DASH/BTC node must not
@@ -1211,8 +1229,11 @@ public:
             case Blockchain::DOGECOIN: return "doge";
             case Blockchain::DASH:     return "dash";
             case Blockchain::DIGIBYTE: return "dgb";
-            default:                   return "";
+            default:                   break;
         }
+        std::string s = m_coin_label;
+        for (auto& ch : s) if (ch >= 'A' && ch <= 'Z') ch = static_cast<char>(ch + 32);
+        return s;  // "" only when truly unconfigured -> callers surface "not enabled"
     }
     void set_explorer_chaininfo_fn(explorer_chaininfo_fn_t fn) { m_explorer_chaininfo_fn = thread_safe_wrap(std::move(fn)); }
     void set_explorer_blockhash_fn(explorer_blockhash_fn_t fn) { m_explorer_blockhash_fn = thread_safe_wrap(std::move(fn)); }
@@ -1296,6 +1317,12 @@ public:
     void set_worker_port(uint16_t port) { m_worker_port = port; }
     void set_external_ip(const std::string& ip) { m_external_ip = ip; }
     void set_pool_version(const std::string& ver) { m_pool_version = ver; }
+    // Config-driven coin label (raw --blockchain/cfg string). Only consulted
+    // by node_symbol()/primary_chain_key() when the consensus Blockchain enum
+    // has no entry for this chain (e.g. embedded BCH / NMC-aux), so the
+    // dashboard labels every node truthfully instead of going blank. Web-layer
+    // only -- never feeds consensus/address-validation.
+    void set_coin_label(const std::string& sym) { m_coin_label = sym; }
     const std::string& get_pool_version() const { return m_pool_version; }
 
     /// Auto-detect public IP and version from external services.


### PR DESCRIPTION
## What
Dashboard topology / node_info / primary_chain_key derive the node coin symbol by `switch` over the consensus `Blockchain` enum, which has **no entry for BCH or the NMC-aux sub-state**. Such a node was surfaced with an **empty** symbol/network/chain-key — the dashboard going blank rather than truthful, against the per-node-topology charter (the founding anti-lie charter).

## How
- New web-layer `m_coin_label`, captured from the raw `--blockchain`/cfg string, wired via `set_coin_label()`.
- `node_symbol()` helper + `primary_chain_key()` fall back to it (upper/lower-cased) **only** when the enum has no entry.
- `rest_node_topology()` and `rest_node_info()` use the fallback.

## Why config-driven, not an enum add
`address_validator` / `payout_manager` / `developer_payout` all `switch` on `Blockchain` — adding BCH/NMC there ripples into **consensus + address validation**. This keeps the fix in the web layer only; it never feeds consensus or address validation. Enum-supported coins are byte-unchanged; an empty label still yields `""` so callers surface an honest "chain not enabled".

## Scope / dependency
This is the dashboard-side seam. Actually *running* a BCH node also needs the consensus-lane `parse_blockchain`/coin enablement (separate steward lane) — this PR ensures the dashboard labels truthfully the moment that lands.

## Test
`-fsyntax-only` clean on both changed TUs; awaiting full CI.