### PR TITLE
nmc(PE): production dual-target coinbase caller, equiv-locked to cross-coin SSOT

### DIFF
--- a/src/impl/nmc/coin/header_chain.hpp
+++ b/src/impl/nmc/coin/header_chain.hpp
@@ -284,6 +284,33 @@ inline std::vector<unsigned char> build_mm_commitment(uint256 chain_merkle_root,
                                                    nonce);
 }
 
+/// PRODUCTION PD dual-target caller (integrator 2026-06-24 decision (b):
+/// equiv-lock the production coinbase caller to the cross-coin manager; do NOT
+/// fork an NMC-local commitment builder). Given the parent (BTC) coinbase
+/// scriptSig prefix the parent work-source already assembles (BIP34 height push
+/// + pool tag), APPEND this aux chain's merged-mining commitment marker followed
+/// by the trailing extranonce -- yielding the dual-target parent coinbase
+/// scriptSig the miner solves against. The marker bytes are produced ONLY by
+/// build_mm_commitment(), which delegates to the cross-coin SSOT
+/// c2pool::merged::build_auxpow_commitment: there is NO NMC-local re-derivation
+/// of the commitment byte layout. The parent (btc) tree SUPPLIES scriptsig_prefix
+/// and CALLS this; it never copies the commitment math (per-coin isolation +
+/// v36-native shared structure standardized cross-coin). The byte-identity of
+/// the embedded marker to the size==1 SSOT output is pinned, fail-build, by the
+/// NmcPDProdCaller KATs in test/auxpow_merkle_test.cpp.
+inline std::vector<unsigned char> build_dual_target_coinbase_scriptsig(
+        const std::vector<unsigned char>& scriptsig_prefix,
+        uint256 chain_merkle_root,
+        unsigned chain_height,
+        uint32_t nonce,
+        const std::vector<unsigned char>& extranonce = {}) {
+    std::vector<unsigned char> sig(scriptsig_prefix);
+    const auto marker = build_mm_commitment(chain_merkle_root, chain_height, nonce);
+    sig.insert(sig.end(), marker.begin(), marker.end());
+    sig.insert(sig.end(), extranonce.begin(), extranonce.end());
+    return sig;
+}
+
 // ─── AuxPow (merge-mining proof) ─────────────────────────────────────────────
 
 /// One aux-chain slot inside a parent coinbase's merged-mining merkle tree.

--- a/src/impl/nmc/test/auxpow_merkle_test.cpp
+++ b/src/impl/nmc/test/auxpow_merkle_test.cpp
@@ -724,6 +724,83 @@ TEST(NmcPDEquivLock, Size1FramedTruncationGuardFires)
 }
 
 
+// ---------------------------------------------------------------------------
+// PE production dual-target caller equiv-lock (integrator 2026-06-24 (b)).
+//
+// The KATs above pin the bare marker (build_mm_commitment) and the test-local
+// frame helper. These pin the PRODUCTION caller itself --
+// nmc::coin::build_dual_target_coinbase_scriptsig() -- the function the live
+// parent (BTC) work-source will CALL to splice this aux chain's commitment into
+// the dual-target coinbase scriptSig. The lock is byte-level and fail-build (a
+// gtest in the CI-allowlisted nmc_auxpow_merkle_test): the marker the production
+// caller embeds MUST be byte-identical to the size==1 cross-coin SSOT output
+// c2pool::merged::build_auxpow_commitment(root, 1, nonce). If the caller ever
+// re-derives the commitment NMC-locally and drifts, this turns CI red -- it does
+// not warn. Per-coin isolation: src/impl/nmc/ only; SSOT consumed READ-ONLY.
+// ---------------------------------------------------------------------------
+
+namespace {
+// The leading parent-coinbase scriptSig framing the BTC work-source builds and
+// hands to the production caller as scriptsig_prefix (BIP34 height push + pool
+// tag) -- the SAME bytes frame_parent_coinbase_script() prepends, minus the
+// marker/extranonce the production caller is responsible for appending.
+std::vector<unsigned char> btc_scriptsig_prefix(int parent_height)
+{
+    return frame_parent_coinbase_script(parent_height, /*marker=*/{}, /*extranonce=*/{});
+}
+}  // namespace
+
+TEST(NmcPDProdCaller, EmbeddedMarkerIsByteIdenticalToCrossCoinSSOT)
+{
+    // Single NMC chain under BTC: chain_height == 0 -> tree size == 1.
+    uint256 root = combine(leaf_of(0x21), leaf_of(0x22));
+    const unsigned chain_height = 0; const uint32_t nonce = 0xdeadbeef;
+    const std::vector<unsigned char> extranonce = {0xa1, 0xb2, 0xc3, 0xd4};
+
+    // What the PRODUCTION caller actually emits as the full coinbase scriptSig.
+    auto sig = nmc::coin::build_dual_target_coinbase_scriptsig(
+        btc_scriptsig_prefix(123456), root, chain_height, nonce, extranonce);
+
+    // The cross-coin canonical SSOT for the size==1 single-chain case -- the
+    // ONLY source the caller is allowed to derive the commitment from.
+    const auto ssot = c2pool::merged::build_auxpow_commitment(root, /*size=*/1u, nonce);
+
+    // FAIL-BUILD equiv-lock: the marker the production caller spliced into the
+    // coinbase scriptSig is byte-for-byte the SSOT output, NOT merely present.
+    EXPECT_EQ(extract_mm_marker(sig), ssot);
+}
+
+TEST(NmcPDProdCaller, EmbeddedMarkerResolvesAtSlotZeroUnderProductionFraming)
+{
+    uint256 root = combine(leaf_of(0x23), leaf_of(0x24));
+    const unsigned chain_height = 0; const int32_t cid = 1; const uint32_t nonce = 7;
+
+    const uint32_t slot = aux_expected_index(nonce, cid, chain_height);
+    ASSERT_EQ(slot, 0u);
+
+    auto sig = nmc::coin::build_dual_target_coinbase_scriptsig(
+        btc_scriptsig_prefix(700000), root, chain_height, nonce, {0x09, 0x0a});
+    EXPECT_EQ(scan_mm_commitment(sig, root, chain_height, cid, slot), MMScan::MATCH);
+}
+
+TEST(NmcPDProdCaller, SecondSmuggledMarkerInProducedScriptIsRejected)
+{
+    uint256 root = combine(leaf_of(0x25), leaf_of(0x26));
+    const unsigned chain_height = 0; const int32_t cid = 1; const uint32_t nonce = 1;
+
+    // A prefix that already carries a (replayed) marker -- the production caller
+    // appends its own, yielding two. scan_mm_commitment must reject the dup.
+    auto smuggled = build_mm_commitment(root, chain_height, nonce);
+    auto prefix = btc_scriptsig_prefix(900);
+    prefix.insert(prefix.end(), smuggled.begin(), smuggled.end());
+
+    auto sig = nmc::coin::build_dual_target_coinbase_scriptsig(
+        prefix, root, chain_height, nonce, {0x07, 0x08});
+
+    const uint32_t slot = aux_expected_index(nonce, cid, chain_height);
+    EXPECT_EQ(scan_mm_commitment(sig, root, chain_height, cid, slot), MMScan::MISMATCH);
+}
+
 
 // ---------------------------------------------------------------------------
 // P1c-step4: AuxPow::check_proof parent proof-of-work leg (step 4).


### PR DESCRIPTION
Per integrator 2026-06-24 decision **(b)**: equiv-lock the production coinbase caller to the cross-coin manager `build_auxpow_commitment`; do NOT fork an NMC-local builder.

## What
- `nmc::coin::build_dual_target_coinbase_scriptsig()` — the production entry the parent (BTC) work-source CALLS to splice this aux chain's merged-mining commitment into the dual-target coinbase scriptSig. Layout: caller-supplied BIP34+tag prefix -> marker from `build_mm_commitment()` (delegates to SSOT `c2pool::merged::build_auxpow_commitment`) -> extranonce. No NMC-local commitment math; the btc tree gains a caller, not a copy.
- 3 KATs (`NmcPDProdCaller.*`), 92->95 in CI-allowlisted `nmc_auxpow_merkle_test`.

## Equiv-lock guard (integrator ask: real, not nominal)
Byte-level + **fail-build**: `EmbeddedMarkerIsByteIdenticalToCrossCoinSSOT` asserts the embedded marker == `build_auxpow_commitment(root, size=1, nonce)` byte-for-byte. Verified the lock bites — perturbing the size derivation to `2u<<h` turns the KAT (and thus CI) **red**, restored clean. Plus: resolves at slot 0 under production framing; smuggled-second-marker rejected.

## Scope / safety
- Fenced `src/impl/nmc/` only; SSOT consumed READ-ONLY (merged_mining.hpp untouched); no build.yml/CMake change (test already allowlisted).
- **No consensus-bearing value change** — composition + delegation only.
- Signed, no third-party attribution. Stacked on #421; retarget to master after #418/#421 land.

I do not self-merge.