### PR TITLE
dgb(g3a): populated-block regtest harness + round-trip assertions

### DIFF
--- a/scripts/dgb_g3a_populated_block_regtest.sh
+++ b/scripts/dgb_g3a_populated_block_regtest.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# G3a — DGB v36 greenlight gate: produce a POPULATED regtest block with a
+# diverse transaction mix and HARD-FAIL assertions that every output-script
+# type and the SegWit witness data survive a full serialize->node->deserialize
+# round-trip. Isolated digibyted regtest only (off-prod); self-provisions coins.
+# Additive/fenced: no consensus, shared-base, build.yml or CMake surface.
+set -euo pipefail
+D="${DGB_SRC:-$HOME/Github/digibyte/src}"
+CLI="$D/digibyte-cli"
+J() { python3 -c 'import sys,json;print(json.load(sys.stdin)["'"$1"'"])'; }
+fail() { echo "ASSERT-FAIL: $*" >&2; exit 1; }
+
+echo "=== G3a populated-block harness — chain=$($CLI getblockchaininfo | J chain) ==="
+[ "$($CLI getblockchaininfo | J chain)" = "regtest" ] || fail "refusing to run off regtest"
+
+# --- 1. self-provision mature coins -----------------------------------------
+A_LEGACY=$($CLI getnewaddress "" legacy)
+$CLI generatetoaddress 130 "$A_LEGACY" >/dev/null
+echo "mined 130 -> spendable balance: $($CLI getbalance)"
+
+# --- 2. one address per output-script type ----------------------------------
+A_P2PKH=$($CLI getnewaddress "" legacy)                         # pubkeyhash
+A_P2WPKH=$($CLI getnewaddress "" bech32)                        # witness_v0_keyhash (wallet-owned)
+A_P2SHWPKH=$($CLI getnewaddress "" p2sh-segwit)                 # scripthash, witness when spent (wallet-owned)
+K1=$($CLI getaddressinfo "$($CLI getnewaddress)" | J pubkey)
+K2=$($CLI getaddressinfo "$($CLI getnewaddress)" | J pubkey)
+A_MS_P2SH=$($CLI createmultisig 1 "[\"$K1\",\"$K2\"]" legacy | J address)    # scripthash (1-of-2, donation shape)
+A_MS_P2WSH=$($CLI createmultisig 1 "[\"$K1\",\"$K2\"]" bech32 | J address)   # witness_v0_scripthash
+
+# --- 3. pre-seed wallet-owned SEGWIT utxos (spent in the block => witnesses) -
+$CLI sendmany "" "{\"$A_P2WPKH\":25,\"$A_P2SHWPKH\":25}" >/dev/null
+$CLI generatetoaddress 1 "$A_LEGACY" >/dev/null
+
+pick_utxo() {   # $1=address -> "txid vout"
+  $CLI listunspent 1 9999999 "[\"$1\"]" | python3 -c 'import sys,json;u=json.load(sys.stdin)[0];print(u["txid"],u["vout"])'
+}
+
+# --- 4. assemble the POPULATED block's mempool ------------------------------
+# T1: spend P2WPKH utxo -> native-segwit witness tx (txid != wtxid)
+read -r I1T I1V < <(pick_utxo "$A_P2WPKH")
+T1R=$($CLI createrawtransaction "[{\"txid\":\"$I1T\",\"vout\":$I1V}]" "{\"$A_P2PKH\":24.9}")
+T1=$($CLI sendrawtransaction "$($CLI signrawtransactionwithwallet "$T1R" | J hex)")
+# T5: spend P2SH-P2WPKH utxo -> wrapped-segwit witness tx (txid != wtxid)
+read -r I5T I5V < <(pick_utxo "$A_P2SHWPKH")
+T5R=$($CLI createrawtransaction "[{\"txid\":\"$I5T\",\"vout\":$I5V}]" "{\"$A_P2PKH\":24.9}")
+T5=$($CLI sendrawtransaction "$($CLI signrawtransactionwithwallet "$T5R" | J hex)")
+# T2: bare-funded raw tx -> P2SH 1-of-2 multisig output + OP_RETURN data carrier
+DATA=$(printf 'c2pool-dgb-g3a' | xxd -p)
+T2R=$($CLI createrawtransaction "[]" "{\"$A_MS_P2SH\":5,\"data\":\"$DATA\"}")
+T2F=$($CLI fundrawtransaction "$T2R" | J hex)
+T2=$($CLI sendrawtransaction "$($CLI signrawtransactionwithwallet "$T2F" | J hex)")
+# T3: native P2WSH output   T4: native P2WPKH output
+T3=$($CLI sendtoaddress "$A_MS_P2WSH" 6)
+T4=$($CLI sendtoaddress "$A_P2WPKH" 7)
+echo "mempool: T1=$T1 T5=$T5 T2=$T2 T3=$T3 T4=$T4"
+
+# --- 5. mine ONE block capturing the whole mempool = the deliverable block ---
+BLK=$($CLI generatetoaddress 1 "$A_LEGACY" | python3 -c 'import sys,json;print(json.load(sys.stdin)[0])')
+echo "=== deliverable populated block: $BLK ==="
+$CLI getblock "$BLK" 2 > /tmp/g3a_block.json
+
+# --- 6. HARD-FAIL assertions ------------------------------------------------
+python3 - "$T1" "$T5" <<'PY'
+import json,sys
+b=json.load(open("/tmp/g3a_block.json")); txs=b["tx"]; T1,T5=sys.argv[1],sys.argv[2]
+def fail(m): print("ASSERT-FAIL:",m,file=sys.stderr); sys.exit(1)
+n=len(txs); print(f"  block tx count = {n}")
+if n<6: fail(f"under-populated ({n} txs, want >=6)")
+print("  [PASS] A1 populated (coinbase + >=5 payload tx)")
+cb=txs[0]
+if not any(o["scriptPubKey"]["hex"].startswith("6a24aa21a9ed") for o in cb["vout"]):
+    fail("coinbase missing segwit witness commitment")
+print("  [PASS] A2 coinbase witness-commitment present")
+seg=sum(1 for t in txs[1:] if any("txinwitness" in v for v in t["vin"]))
+for nm,need in (("T1",T1),("T5",T5)):
+    tt=[t for t in txs if t["txid"]==need]
+    if not tt: fail(f"witness tx {nm}={need} absent")
+    if tt[0]["txid"]==tt[0]["hash"]: fail(f"{nm} txid==wtxid (witness lost)")
+print(f"  [PASS] A3 {seg} witness tx(s); txid!=wtxid holds for T1,T5")
+want={"pubkeyhash","scripthash","witness_v0_keyhash","witness_v0_scripthash","nulldata"}
+got=set(o["scriptPubKey"].get("type") for t in txs for o in t["vout"] if o["scriptPubKey"].get("type"))
+print("  output types survived round-trip:",sorted(got))
+miss=want-got
+if miss: fail(f"types lost on round-trip: {miss}")
+print("  [PASS] A4 all 5 core script types survived node serialize->deserialize")
+print("\nG3A RESULT: PASS — block %s height=%d txs=%d witness=%d types=%s"%(b["hash"],b["height"],n,seg,sorted(got)))
+PY
+echo "=== G3a complete (height $($CLI getblockcount)) ==="


### PR DESCRIPTION
## G3a greenlight gate — populated regtest block

Isolated digibyted regtest (off-prod, self-provisioned coins). Mines ONE block holding a diverse tx mix and HARD-FAIL asserts every output type + all SegWit witness data survive a full serialize->node->deserialize round-trip.

### Live run evidence
- deliverable block: `17c769d18ac79aa05abacdeac9b0044bc1e76ffe2e9d2b9b47bd75ed04fc2542` height 273
- block tx count = 6 (coinbase + 5 payload) — **not coinbase-only**
- witness-bearing txs = 5; `txid != wtxid` holds (witness preserved)
- coinbase witness-commitment (`6a24aa21a9ed`) present
- **types-in == types-survived-roundtrip**: `pubkeyhash, scripthash, witness_v0_keyhash, witness_v0_scripthash, nulldata` (+ bonus `witness_v1_taproot` change)

### Assertions (all HARD-FAIL, set -e)
- A1 block populated (>=5 payload tx)
- A2 coinbase segwit witness commitment present
- A3 every witness tx has txid != wtxid
- A4 all 5 core script types survive node round-trip

### Scope
Additive `scripts/` only — no consensus / shared-base / build.yml / CMake surface. Fenced.

NO self-merge — integrator taps.