### PR TITLE
dash: runnable c2pool-dash launcher + external-dashd submitblock-fallback RPC (clean lane)

### DIFF
--- a/src/c2pool/CMakeLists.txt
+++ b/src/c2pool/CMakeLists.txt
@@ -281,6 +281,7 @@ target_link_libraries(c2pool-dash
     core pool sharechain
     c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage c2pool_difficulty
     dash_x11   # DASH X11 PoW sph reference (BLAKE->...->ECHO), additive static lib
+    dash_rpc   # launcher slice-3: external-dashd-RPC client (submitblock fallback)
     btclibs
     yaml-cpp::yaml-cpp
     nlohmann_json::nlohmann_json

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -46,10 +46,25 @@
 
 #include <core/coin_params.hpp>
 #include <core/uint256.hpp>
+#include <core/netaddress.hpp>             // NetService (dashd RPC endpoint)
+
+#include <impl/dash/coin/rpc.hpp>          // dash::coin::NodeRPC — external-dashd submitblock arm (slice 3)
+#include <impl/dash/coin/rpc_conf.hpp>     // dash.conf creds resolution (rpcpassword off argv)
+#include <impl/dash/coin/node_interface.hpp>
+#include <impl/dash/coin/block_producer.hpp>  // dash::coin::mine_block / serialize_full_block_hex (slice 5)
+#include <impl/dash/coinbase_builder.hpp>      // dash::coinbase::build / compute_dash_payouts (slice 5)
+#include <impl/dash/params.hpp>                // dash::make_coin_params (already via top include)
+#include <core/uint256.hpp>                    // uint160 payout pubkey hash
+
+#include <boost/asio.hpp>
 
 #include <cstdint>
+#include <cstdlib>      // std::getenv
 #include <cstring>
+#include <fstream>
 #include <iostream>
+#include <map>
+#include <memory>
 #include <string>
 
 #ifndef C2POOL_VERSION
@@ -66,10 +81,15 @@ void print_banner(const char* argv0)
     std::cout
         << "c2pool-dash " << C2POOL_VERSION << " — DASH (X11, older-than-v35 -> V36)\n\n"
         << "Usage: " << argv0 << " [--version] [--help] [--selftest]\n"
-        << "       " << argv0 << " --run   (block-submission DEFERRED — see status)\n\n"
+        << "       " << argv0 << " --run [--coin-rpc H:P] [--coin-rpc-auth PATH]\n"
+        << "           [--testnet] [--submit-block HEX | --submit-block-file PATH]\n"
+        << "       " << argv0 << " --mine-block [--coin-rpc H:P] [--coin-rpc-auth PATH]\n"
+        << "           [--testnet] [--payout-pubkey-hash HEX] [--max-nonce N]\n\n"
         << "Status: consensus layer live (X11 PoW, subsidy, oracle CoinParams).\n"
-        << "        Block submission (won-block dual-path broadcaster) is the\n"
-        << "        next stacked slice; external dashd RPC stays the fallback.\n"
+        << "        --run stands up the run-loop and ARMS the external-dashd\n"
+        << "        submitblock fallback (creds from dash.conf, never on argv).\n"
+        << "        --submit-block[-file] drives ONE real submitblock then exits\n"
+        << "        (the won-block-reaches-network leg); embedded P2P relay = S8.\n"
         << "Consensus: X11 PoW + block identity; 2.5 min spacing; 5 DASH post-V20\n"
         << "        base, -1/14 per 210240; masternode payment 3/4 of block value.\n";
 }
@@ -191,19 +211,182 @@ int run_selftest()
     return 1;
 }
 
-// --run: block submission is DEFERRED. Print the exact deferral status so a smoke
-// gate is never misled, then exit cleanly (the consensus layer IS exercised by
-// --selftest; the run-loop standup lands with the broadcaster slice).
-int run_node_stub()
+// --run: stand up a real run-loop and ARM the external-dashd submitblock fallback
+// arm (rpc.cpp submit_block_hex -- the RPC leg of the won-block dual-path
+// broadcaster). The embedded-P2P relay leg is still S8-deferred; this slice lights
+// the dashd-RPC sink so a won DASH block CAN reach the network today.
+//
+// Creds posture (operator self-provision, 2026-06-19): the rpcpassword NEVER
+// reaches the process table. --coin-rpc HOST:PORT carries only the endpoint;
+// rpcuser/rpcpassword come from dash.conf (default ~/.dashcore/dash.conf, override
+// --coin-rpc-auth PATH). No creds (or no port) => the arm stays UNARMED and
+// submit_block_hex is never reached -- the run-loop still stands up cleanly.
+//
+// --submit-block HEX drives ONE real submitblock against the configured dashd and
+// reports accept/reject, then exits: the G2 "won-block-reaches-network" evidence
+// lever (point it at the VM200/201 dashd). NodeRPC::Send is synchronous with a
+// blocking sync_reconnect fallback, so the submit self-connects -- no async race.
+// A synthetic-only pass does NOT earn block-viable; the live dashd-reached run is
+// the gate.
+int run_node(bool testnet, const std::string& rpc_endpoint,
+             const std::string& rpc_conf_path, const std::string& submit_hex)
 {
-    std::cout
-        << "[run] DASH block submission is DEFERRED to the next stacked slice.\n"
-        << "[run]   - dashd-RPC submitblock fallback: needs a DASH NodeRPC TU\n"
-        << "[run]     (rpc.cpp/rpc.hpp/rpc_conf.hpp); only coin/rpc_data.hpp exists.\n"
-        << "[run]   - embedded P2P relay arm: S8 broadcaster/reconstruct stack.\n"
-        << "[run] The oracle CoinParams path the fallback consumes IS wired; run\n"
-        << "[run] --selftest to exercise the live consensus layer (X11 + subsidy).\n";
+    namespace io = boost::asio;
+
+    dash::coin::RpcConf conf;
+    std::string conf_path = rpc_conf_path;
+    if (conf_path.empty()) {
+        const char* home = std::getenv("HOME");
+        conf_path = std::string(home ? home : ".") + "/.dashcore/dash.conf";
+    }
+    dash::coin::load_rpc_conf(conf_path, conf);
+    dash::coin::apply_endpoint_override(rpc_endpoint, conf);
+    if (conf.port == 0)
+        conf.port = testnet ? 19998 : 9998;   // dashd default RPC ports
+
+    io::io_context ioc;
+    io::signal_set signals(ioc, SIGINT, SIGTERM);
+    signals.async_wait([&ioc](const boost::system::error_code&, int) {
+        std::cout << "[run] shutdown signal -- stopping run-loop\n";
+        ioc.stop();
+    });
+
+    dash::interfaces::Node coin_state;
+    std::unique_ptr<dash::coin::NodeRPC> rpc;
+    if (conf.armed()) {
+        rpc = std::make_unique<dash::coin::NodeRPC>(&ioc, &coin_state, testnet);
+        rpc->connect(NetService(conf.host, conf.port), conf.userpass());
+        std::cout << "[run] external-daemon submit arm ARMED: NodeRPC -> "
+                  << conf.host << ":" << conf.port << " (creds from dash.conf)\n";
+    } else {
+        std::cout << "[run] external-daemon submit arm UNARMED "
+                     "(no dash.conf creds / no port); embedded P2P relay leg is S8.\n";
+    }
+
+    // One-shot submit: the G2 won-block-reaches-network evidence path.
+    if (!submit_hex.empty()) {
+        if (!rpc) {
+            std::cout << "[run] --submit-block given but submit arm UNARMED; supply "
+                         "dashd creds via dash.conf or --coin-rpc-auth PATH\n";
+            return 2;
+        }
+        std::cout << "[run] submitting block (" << submit_hex.size() / 2
+                  << " bytes) to dashd " << conf.host << ":" << conf.port << "...\n";
+        const bool accepted = rpc->submit_block_hex(submit_hex, /*ignore_failure=*/false);
+        std::cout << "[run] submitblock " << (accepted ? "ACCEPTED" : "REJECTED")
+                  << " by dashd\n";
+        return accepted ? 0 : 1;
+    }
+
+    std::cout << "[run] run-loop up (Ctrl-C to stop); won blocks relay via the\n"
+                 "[run] dashd-RPC submitblock fallback. Embedded P2P relay = S8.\n";
+    ioc.run();
+    std::cout << "[run] run-loop stopped cleanly\n";
     return 0;
+}
+
+// --mine-block: the slice-5 PRODUCER one-shot. Pull a block template (dashd
+// getblocktemplate via NodeRPC::getwork), build the coinbase, X11-mine the
+// 80-byte header over the nonce until it meets the compact-bits target,
+// serialize the FULL block to hex, and feed it into the EXISTING submit arm
+// (NodeRPC::submit_block_hex). This is the "c2pool-dash builds and wins the
+// block itself" lever -- slice-4 only re-submitted a pre-built hex.
+//
+// Creds posture is IDENTICAL to --submit-block: endpoint via --coin-rpc, creds
+// from dash.conf (never argv). The optional --payout-pubkey-hash HEX (40 hex =
+// 20 bytes) names the block-finder P2PKH payout; default all-zero placeholder
+// (genesis-style: empty PPLNS weights, total_weight 0). max_nonce is bounded;
+// regtest bits (0x207fffff) make the target trivial so a winner is found fast.
+int run_mine_block(bool testnet, const std::string& rpc_endpoint,
+                   const std::string& rpc_conf_path,
+                   const std::string& payout_pkh_hex,
+                   uint64_t max_nonce)
+{
+    namespace io = boost::asio;
+
+    dash::coin::RpcConf conf;
+    std::string conf_path = rpc_conf_path;
+    if (conf_path.empty()) {
+        const char* home = std::getenv("HOME");
+        conf_path = std::string(home ? home : ".") + "/.dashcore/dash.conf";
+    }
+    dash::coin::load_rpc_conf(conf_path, conf);
+    dash::coin::apply_endpoint_override(rpc_endpoint, conf);
+    if (conf.port == 0)
+        conf.port = testnet ? 19998 : 9998;
+
+    if (!conf.armed()) {
+        std::cout << "[mine] submit arm UNARMED (no dash.conf creds / no port); "
+                     "supply dashd creds via dash.conf or --coin-rpc-auth PATH\n";
+        return 2;
+    }
+
+    io::io_context ioc;
+    dash::interfaces::Node coin_state;
+    dash::coin::NodeRPC rpc(&ioc, &coin_state, testnet);
+    rpc.connect(NetService(conf.host, conf.port), conf.userpass());
+    std::cout << "[mine] producer ARMED: NodeRPC -> " << conf.host << ":"
+              << conf.port << " (creds from dash.conf)\n";
+
+    // 1) Pull the template.
+    std::cout << "[mine] fetching block template (getblocktemplate)...\n";
+    dash::coin::DashWorkData work = rpc.getwork();
+    std::cout << "[mine] template: height=" << work.m_height
+              << " bits=0x" << std::hex << work.m_bits << std::dec
+              << " prev=" << work.m_previous_block.GetHex().substr(0, 16) << "..."
+              << " ntx(gbt)=" << work.m_tx_data_hex.size()
+              << " coinbase_value=" << work.m_coinbase_value << "\n";
+
+    // 2) Build the coinbase. Genesis-style payout (no prior shares): empty
+    //    weights, total_weight 0 -> all of worker_payout goes to the finder
+    //    (this_script, 2% rule) + donation remainder.
+    uint160 payout_pkh;   // default all-zero
+    if (!payout_pkh_hex.empty()) {
+        if (payout_pkh_hex.size() != 40) {
+            std::cout << "[mine] --payout-pubkey-hash must be 40 hex chars (20 bytes)\n";
+            return 2;
+        }
+        payout_pkh.SetHex(payout_pkh_hex);
+    }
+    const core::CoinParams params = dash::make_coin_params(testnet);
+    std::map<std::vector<unsigned char>, uint64_t> empty_weights;
+    auto tx_outs = dash::coinbase::compute_dash_payouts(
+        work.m_coinbase_value, work.m_packed_payments, payout_pkh,
+        empty_weights, /*total_weight=*/0, params);
+    // ref_hash is the PPLNS commitment; for a standalone producer block we use
+    // zero (no sharechain commitment) -- consensus-irrelevant to dashd validity.
+    auto layout = dash::coinbase::build(work, tx_outs, /*pool_tag=*/"c2pool",
+                                        params, /*ref_hash=*/uint256::ZERO);
+    std::cout << "[mine] coinbase built: " << layout.bytes.size()
+              << " bytes, " << tx_outs.size() << " outputs\n";
+
+    // 3) X11-mine.
+    std::cout << "[mine] X11-mining header (max_nonce=" << max_nonce << ")...\n";
+    dash::coin::MineResult mr =
+        dash::coin::mine_block(work, layout.bytes, max_nonce);
+    if (!mr.found) {
+        std::cout << "[mine] NO winning nonce in [0, " << max_nonce
+                  << "] -- raise --max-nonce or check bits\n";
+        return 1;
+    }
+    std::cout << "[mine] WON: nonce=" << mr.nonce
+              << " powhash=" << mr.block_hash.GetHex()
+              << " block=" << (mr.block_hex.size() / 2) << " bytes\n";
+
+    // 4) Submit via the EXISTING arm.
+    const int64_t before = static_cast<int64_t>(
+        rpc.getblockchaininfo().value("blocks", -1));
+    std::cout << "[mine] getblockcount(before)=" << before << "\n";
+    std::cout << "[mine] submitting mined block to dashd "
+              << conf.host << ":" << conf.port << "...\n";
+    const bool accepted = rpc.submit_block_hex(mr.block_hex, /*ignore_failure=*/false);
+    const int64_t after = static_cast<int64_t>(
+        rpc.getblockchaininfo().value("blocks", -1));
+    std::cout << "[mine] submitblock " << (accepted ? "ACCEPTED" : "REJECTED")
+              << " by dashd; block_hash=" << mr.block_hash.GetHex()
+              << " getblockcount(after)=" << after
+              << (after > before ? " (+1, tip advanced)\n" : "\n");
+    return accepted ? 0 : 1;
 }
 
 } // namespace
@@ -212,20 +395,60 @@ int main(int argc, char** argv)
 {
     bool want_help = false;
     bool want_run  = false;
+    bool want_mine = false;
+    bool testnet   = false;
+    std::string payout_pkh_hex;   // --payout-pubkey-hash HEX (20-byte P2PKH finder)
+    uint64_t    max_nonce = 0xffffffffull;  // --max-nonce N (producer search bound)
+    std::string rpc_endpoint;     // --coin-rpc / --coin-daemon HOST:PORT (endpoint only)
+    std::string rpc_conf_path;    // --coin-rpc-auth PATH (creds; default ~/.dashcore/dash.conf)
+    std::string submit_hex;       // --submit-block HEX (one-shot won-block submit)
+    std::string submit_file;      // --submit-block-file PATH
     for (int i = 1; i < argc; ++i) {
         if (std::strcmp(argv[i], "--version") == 0) {
             std::cout << "c2pool-dash " << C2POOL_VERSION << "\n";
             return 0;
         }
-        if (std::strcmp(argv[i], "--help") == 0)     want_help = true;
-        if (std::strcmp(argv[i], "--run") == 0)      want_run  = true;
+        else if (std::strcmp(argv[i], "--help") == 0)    want_help = true;
+        else if (std::strcmp(argv[i], "--run") == 0)     want_run  = true;
+        else if (std::strcmp(argv[i], "--mine-block") == 0) want_mine = true;
+        else if (std::strcmp(argv[i], "--payout-pubkey-hash") == 0 && i + 1 < argc)
+            payout_pkh_hex = argv[++i];
+        else if (std::strcmp(argv[i], "--max-nonce") == 0 && i + 1 < argc)
+            max_nonce = std::strtoull(argv[++i], nullptr, 0);
+        else if (std::strcmp(argv[i], "--testnet") == 0 ||
+                 std::strcmp(argv[i], "--regtest") == 0)  testnet = true;
+        else if ((std::strcmp(argv[i], "--coin-rpc") == 0 ||
+                  std::strcmp(argv[i], "--coin-daemon") == 0) && i + 1 < argc)
+            rpc_endpoint = argv[++i];
+        else if (std::strcmp(argv[i], "--coin-rpc-auth") == 0 && i + 1 < argc)
+            rpc_conf_path = argv[++i];
+        else if (std::strcmp(argv[i], "--submit-block") == 0 && i + 1 < argc)
+            submit_hex = argv[++i];
+        else if (std::strcmp(argv[i], "--submit-block-file") == 0 && i + 1 < argc)
+            submit_file = argv[++i];
         // --selftest is the default; accepted explicitly for symmetry.
     }
 
     print_banner(argv[0]);
     if (want_help)
         return 0;
-    if (want_run)
-        return run_node_stub();
+    if (want_mine)
+        return run_mine_block(testnet, rpc_endpoint, rpc_conf_path,
+                              payout_pkh_hex, max_nonce);
+    if (want_run) {
+        if (!submit_file.empty() && submit_hex.empty()) {
+            std::ifstream bf(submit_file);
+            if (!bf) {
+                std::cout << "[run] cannot open --submit-block-file " << submit_file << "\n";
+                return 2;
+            }
+            std::getline(bf, submit_hex, '\0');   // whole-file slurp
+            while (!submit_hex.empty() &&
+                   (submit_hex.back() == '\n' || submit_hex.back() == '\r' ||
+                    submit_hex.back() == ' '  || submit_hex.back() == '\t'))
+                submit_hex.pop_back();
+        }
+        return run_node(testnet, rpc_endpoint, rpc_conf_path, submit_hex);
+    }
     return run_selftest();
 }

--- a/src/impl/dash/CMakeLists.txt
+++ b/src/impl/dash/CMakeLists.txt
@@ -18,3 +18,20 @@ add_subdirectory(crypto)
 add_library(dash_block_replay STATIC coin/vendor/blockencodings.cpp)
 target_include_directories(dash_block_replay PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries(dash_block_replay PRIVATE core nlohmann_json::nlohmann_json ${Boost_LIBRARIES})
+
+# Launcher slice-3 external-dashd-RPC client (won-block dual-path broadcaster,
+# RPC leg). coin/rpc.cpp is a real boost::beast + jsonrpccxx HTTP JSON-RPC
+# client to an external dashd, mirroring src/impl/dgb/coin/rpc.cpp conformed to
+# DASH (X11, no segwit -> plain getblocktemplate body, NO algo param; rich
+# DashWorkData getwork(); DASH genesis identity probe; submit_block_hex dashd
+# submitblock fallback). The embedded-P2P relay leg of the broadcaster is still
+# DEFERRED. SAFE-ADDITIVE: additive static lib; the ONLY existing target that
+# links it is c2pool-dash (this slice), so the ltc/btc/doge/dgb build + ctest
+# surfaces are untouched. Per-coin isolation held: src/impl/dash only, no
+# shared-base/core SOURCE edit, dashd RPC fallback preserved.
+add_library(dash_rpc STATIC coin/rpc.cpp)
+target_include_directories(dash_rpc PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/src/btclibs
+    ${CMAKE_SOURCE_DIR}/include)
+target_link_libraries(dash_rpc PRIVATE core nlohmann_json::nlohmann_json ${Boost_LIBRARIES})

--- a/src/impl/dash/coin/block_producer.hpp
+++ b/src/impl/dash/coin/block_producer.hpp
@@ -1,0 +1,241 @@
+#pragma once
+
+// ---------------------------------------------------------------------------
+// dash::coin block PRODUCER (launcher slice 5).
+//
+// The "c2pool-dash builds and wins the block itself" lever. Slice 3/4 only
+// re-SUBMITTED a pre-built block hex via NodeRPC::submit_block_hex. This header
+// closes the producer gap: given a DashWorkData (from dashd getblocktemplate via
+// NodeRPC::getwork(), or the embedded build_embedded_workdata path) plus an
+// already-assembled coinbase tx (dash::coinbase::build -> CoinbaseLayout.bytes),
+// it:
+//   - folds the block merkle root over [coinbase_txid] + work.m_tx_hashes,
+//   - serializes the 80-byte X11 header,
+//   - X11-mines the nonce until hash_x11(header) meets the compact-bits target,
+//   - serializes the FULL block (header || CompactSize(ntx) || coinbase || txs),
+//   - and hands the hex to the EXISTING submit arm.
+//
+// PER-COIN ISOLATION: header-only, src/impl/dash only. Reuses the dash merkle
+// fold idiom (sha256d, duplicate-last on odd), the dash X11 PoW entry, and the
+// DASH tx-data hex already parsed by NodeRPC::getwork(). No src/core edit, no
+// other coin touched, dashd-RPC fallback untouched.
+//
+// Byte order: all header/CompactSize fields are little-endian on the wire; the
+// x86_64 CI target is LE so memcpy of host integers is the wire form (this
+// mirrors main_dash.cpp::serialize_header). uint256::data() is the internal LE
+// byte order, which is the on-wire order for prev_block / merkle_root (the same
+// order hash_x11 already consumes in the X11 KATs).
+// ---------------------------------------------------------------------------
+
+#include "rpc_data.hpp"                       // dash::coin::DashWorkData
+#include <impl/dash/crypto/hash_x11.hpp>      // dash::crypto::hash_x11
+#include <impl/dash/coinbase_builder.hpp>     // dash::coinbase::sha256d (Hash sha256d)
+
+#include <core/uint256.hpp>
+#include <btclibs/util/strencodings.h>        // HexStr, ParseHex
+
+#include <cstdint>
+#include <cstring>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace dash {
+namespace coin {
+
+// sha256d over a byte span (reuse the coinbase_builder helper, which is just
+// core::Hash). Kept local so callers of block_producer don't need to reach
+// into the coinbase namespace.
+inline uint256 bp_sha256d(std::span<const unsigned char> a)
+{
+    return dash::coinbase::sha256d(a);
+}
+
+// Standard Bitcoin/Dash merkle root fold. txids[0] is the coinbase txid.
+// Duplicate the last element on odd-sized layers. Empty -> ZERO; single ->
+// that element. Hashes are in internal (LE) byte order throughout; the result
+// is the merkle_root in the same order the 80-byte header carries.
+inline uint256 compute_merkle_root(const std::vector<uint256>& txids)
+{
+    if (txids.empty()) return uint256::ZERO;
+    std::vector<uint256> layer = txids;
+    while (layer.size() > 1) {
+        if (layer.size() % 2 == 1)
+            layer.push_back(layer.back());          // duplicate last on odd
+        std::vector<uint256> next;
+        next.reserve(layer.size() / 2);
+        for (size_t i = 0; i + 1 < layer.size(); i += 2) {
+            unsigned char buf[64];
+            std::memcpy(buf,      layer[i].data(),     32);
+            std::memcpy(buf + 32, layer[i + 1].data(), 32);
+            next.push_back(bp_sha256d(std::span<const unsigned char>(buf, 64)));
+        }
+        layer.swap(next);
+    }
+    return layer[0];
+}
+
+// Compact nBits -> 256-bit target (Bitcoin/Dash compact form). uint256 carries
+// SetCompact directly.
+inline uint256 target_from_nbits(uint32_t nbits)
+{
+    uint256 target;
+    target.SetCompact(nbits);
+    return target;
+}
+
+// A PoW hash (internal LE order, as returned by hash_x11) meets the target iff
+// powhash <= target_from_nbits(nbits). uint256 comparison is value comparison.
+inline bool meets_target(const uint256& powhash, uint32_t nbits)
+{
+    return powhash <= target_from_nbits(nbits);
+}
+
+// Serialize the 80-byte DASH block header into out[80] (LE host == wire on the
+// x86_64 target). merkle_root and prev_block are passed in internal LE order.
+inline void serialize_header80(unsigned char out[80],
+                               int32_t version,
+                               const uint256& prev_block,
+                               const uint256& merkle_root,
+                               uint32_t time,
+                               uint32_t bits,
+                               uint32_t nonce)
+{
+    size_t off = 0;
+    std::memcpy(out + off, &version, 4);             off += 4;
+    std::memcpy(out + off, prev_block.data(), 32);   off += 32;
+    std::memcpy(out + off, merkle_root.data(), 32);  off += 32;
+    std::memcpy(out + off, &time, 4);                off += 4;
+    std::memcpy(out + off, &bits, 4);                off += 4;
+    std::memcpy(out + off, &nonce, 4);               off += 4;
+}
+
+// CompactSize (Bitcoin "varint") encoder.
+inline void append_compact_size(std::vector<unsigned char>& out, uint64_t n)
+{
+    if (n < 0xfd) {
+        out.push_back(static_cast<unsigned char>(n));
+    } else if (n <= 0xffff) {
+        out.push_back(0xfd);
+        out.push_back(static_cast<unsigned char>(n & 0xff));
+        out.push_back(static_cast<unsigned char>((n >> 8) & 0xff));
+    } else if (n <= 0xffffffffULL) {
+        out.push_back(0xfe);
+        for (int i = 0; i < 4; ++i)
+            out.push_back(static_cast<unsigned char>((n >> (8 * i)) & 0xff));
+    } else {
+        out.push_back(0xff);
+        for (int i = 0; i < 8; ++i)
+            out.push_back(static_cast<unsigned char>((n >> (8 * i)) & 0xff));
+    }
+}
+
+// Coinbase txid: sha256d of the raw coinbase bytes (DASH non-witness canonical
+// serialization == the txid preimage; matches NodeRPC::getwork()'s recompute).
+inline uint256 coinbase_txid(const std::vector<unsigned char>& coinbase_bytes)
+{
+    return bp_sha256d(std::span<const unsigned char>(
+        coinbase_bytes.data(), coinbase_bytes.size()));
+}
+
+// Assemble the FULL block as raw bytes:
+//   80-byte header
+//   CompactSize(1 + work.m_txs.size())
+//   coinbase_bytes
+//   each tx (decoded from work.m_tx_data_hex)
+// The merkle root is folded over [coinbase_txid] + work.m_tx_hashes.
+inline std::vector<unsigned char> serialize_full_block(
+    const DashWorkData& work,
+    const std::vector<unsigned char>& coinbase_bytes,
+    uint32_t nonce,
+    uint32_t time)
+{
+    std::vector<uint256> txids;
+    txids.reserve(1 + work.m_tx_hashes.size());
+    txids.push_back(coinbase_txid(coinbase_bytes));
+    for (const auto& h : work.m_tx_hashes) txids.push_back(h);
+    const uint256 merkle_root = compute_merkle_root(txids);
+
+    std::vector<unsigned char> block;
+    block.reserve(80 + 9 + coinbase_bytes.size() + work.m_tx_data_hex.size() * 256);
+
+    unsigned char hdr[80];
+    serialize_header80(hdr, work.m_version, work.m_previous_block, merkle_root,
+                       time, work.m_bits, nonce);
+    block.insert(block.end(), hdr, hdr + 80);
+
+    // tx count = coinbase + GBT txs. Use m_tx_data_hex as the canonical tx
+    // count/source (the raw hex we will emit verbatim).
+    const uint64_t ntx = 1 + work.m_tx_data_hex.size();
+    append_compact_size(block, ntx);
+
+    block.insert(block.end(), coinbase_bytes.begin(), coinbase_bytes.end());
+    for (const auto& tx_hex : work.m_tx_data_hex) {
+        auto raw = ParseHex(tx_hex);
+        block.insert(block.end(), raw.begin(), raw.end());
+    }
+    return block;
+}
+
+// Hex-encode the full serialized block (the form NodeRPC::submit_block_hex eats).
+inline std::string serialize_full_block_hex(
+    const DashWorkData& work,
+    const std::vector<unsigned char>& coinbase_bytes,
+    uint32_t nonce,
+    uint32_t time)
+{
+    auto block = serialize_full_block(work, coinbase_bytes, nonce, time);
+    return HexStr(std::span<const unsigned char>(block.data(), block.size()));
+}
+
+struct MineResult {
+    bool        found{false};
+    uint32_t    nonce{0};
+    uint32_t    time{0};
+    std::string block_hex;
+    uint256     block_hash;     // X11 PoW hash (internal LE order) of the winning header
+};
+
+// X11-mine the header over the nonce range [0, max_nonce] until the PoW hash
+// meets the compact-bits target. Returns the first winning nonce. On regtest
+// bits (e.g. 0x207fffff) the target is trivial -> found almost immediately.
+//
+// The time used is work.m_curtime (the GBT curtime). The merkle root is folded
+// once (it does not depend on the nonce) and the header's nonce field is the
+// only mutated word across the loop.
+inline MineResult mine_block(const DashWorkData& work,
+                             const std::vector<unsigned char>& coinbase_bytes,
+                             uint64_t max_nonce)
+{
+    MineResult r;
+    r.time = work.m_curtime;
+
+    std::vector<uint256> txids;
+    txids.reserve(1 + work.m_tx_hashes.size());
+    txids.push_back(coinbase_txid(coinbase_bytes));
+    for (const auto& h : work.m_tx_hashes) txids.push_back(h);
+    const uint256 merkle_root = compute_merkle_root(txids);
+
+    unsigned char hdr[80];
+    serialize_header80(hdr, work.m_version, work.m_previous_block, merkle_root,
+                       work.m_curtime, work.m_bits, 0);
+
+    for (uint64_t n = 0; n <= max_nonce; ++n) {
+        const uint32_t nonce = static_cast<uint32_t>(n);
+        std::memcpy(hdr + 76, &nonce, 4);            // overwrite nonce word only
+        const uint256 pow = dash::crypto::hash_x11(hdr, 80);
+        if (meets_target(pow, work.m_bits)) {
+            r.found      = true;
+            r.nonce      = nonce;
+            r.block_hash = pow;
+            r.block_hex  = serialize_full_block_hex(work, coinbase_bytes,
+                                                    nonce, work.m_curtime);
+            return r;
+        }
+        if (nonce == 0xffffffffu) break;             // guard against u32 wrap
+    }
+    return r;
+}
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/rpc.cpp
+++ b/src/impl/dash/coin/rpc.cpp
@@ -1,0 +1,456 @@
+#include "rpc.hpp"
+
+#include <impl/dash/coin/rpc_request.hpp>
+
+#include <core/log.hpp>
+#include <core/hash.hpp>
+#include <core/core_util.hpp>    // core::timestamp() (getwork latency)
+
+#include <util/strencodings.h>   // ParseHex / HexStr
+
+namespace dash
+{
+
+namespace coin
+{
+
+// DASH chain-identity genesis hashes, DASH_MIN_DAEMON_VERSION and
+// make_gbt_request: see impl/dash/coin/rpc_request.hpp (oracle/identity SSOT).
+// check() probes getblockheader(dash_genesis_hash(IS_TESTNET)) to confirm the
+// daemon is a real dashd on the selected network.
+
+NodeRPC::NodeRPC(io::io_context* context, dash::interfaces::Node* coin, bool testnet)
+    : IS_TESTNET(testnet), m_coin(coin), m_context(context), m_stream(*context),
+      m_resolver(*context), m_client(*this, RPC_VER)
+{
+}
+
+void NodeRPC::connect(NetService address, std::string userpass)
+{
+    m_address = address;
+    m_userpass = userpass;
+
+    m_auth = std::make_unique<RPCAuthData>();
+    m_http_request = {http::verb::post, "/", 11};
+
+    m_auth->host = address.to_string();
+    m_http_request.set(http::field::host, m_auth->host);
+
+    m_http_request.set(http::field::user_agent, BOOST_BEAST_VERSION_STRING);
+    m_http_request.set(http::field::content_type, "application/json");
+    m_http_request.set(http::field::connection, "keep-alive");
+
+    std::string encoded_login2;
+    encoded_login2.resize(boost::beast::detail::base64::encoded_size(userpass.size()));
+    const auto result = boost::beast::detail::base64::encode(&encoded_login2[0], userpass.data(), userpass.size());
+    encoded_login2.resize(result);
+    m_auth->authorization = "Basic " + encoded_login2;
+
+    m_http_request.set(http::field::authorization, m_auth->authorization);
+
+    // Async DNS resolve — must NOT use the blocking m_resolver.resolve() overload
+    // as that stalls the entire io_context thread for the DNS round-trip.
+    m_resolver.async_resolve(address.address(), address.port_str(),
+        [this](boost::system::error_code ec, boost::asio::ip::tcp::resolver::results_type results)
+        {
+            if (ec)
+            {
+                LOG_ERROR << "CoindRPC DNS resolve failed: " << ec.message() << ", retrying in 15s";
+                m_reconnect_timer = std::make_unique<core::Timer>(m_context, false);
+                m_reconnect_timer->start(15, [this]() { connect(m_address, m_userpass); });
+                return;
+            }
+            boost::asio::ip::tcp::endpoint endpoint = *results.begin();
+            m_stream.async_connect(endpoint,
+                [this](boost::system::error_code ec)
+                {
+                    if (ec)
+                    {
+                        if (ec == boost::system::errc::operation_canceled)
+                            return;
+
+                        LOG_ERROR << "CoindRPC error when try connect: [" << ec.message() << "].";
+                    } else
+                    {
+                        try
+                        {
+                            if (check())
+                            {
+                                m_connected = true;
+                                LOG_INFO << "...CoindRPC connected!";
+                                return;
+                            }
+                        }
+                        catch(const std::runtime_error& ec)
+                        {
+                            LOG_ERROR << "Error when try check CoindRPC: " << ec.what();
+                        }
+                    }
+
+                    LOG_INFO << "Retry after 15 seconds...";
+                    m_connected = false;
+                    m_stream.close();
+                    m_reconnect_timer = std::make_unique<core::Timer>(m_context, false);
+                    m_reconnect_timer->start(15, [this]() { connect(m_address, m_userpass); });
+                }
+            );
+        });
+}
+
+NodeRPC::~NodeRPC()
+{
+    beast::error_code ec;
+    m_stream.socket().shutdown(io::ip::tcp::socket::shutdown_both, ec);
+    if (ec)
+    {
+        // shutdown errors on close are typically benign; ignore
+    }
+}
+
+void NodeRPC::reconnect()
+{
+    if (!m_connected)
+        return;  // already reconnecting or never connected
+    m_connected = false;
+    LOG_WARNING << "RPC connection lost — reconnecting in 15 seconds...";
+    m_stream.close();
+    m_reconnect_timer = std::make_unique<core::Timer>(m_context, false);
+    m_reconnect_timer->start(15, [this]() { connect(m_address, m_userpass); });
+}
+
+void NodeRPC::sync_reconnect()
+{
+    beast::error_code ec;
+    m_stream.socket().shutdown(io::ip::tcp::socket::shutdown_both, ec);
+    m_stream.close();
+
+    // Blocking resolve + connect for immediate retry
+    auto results = m_resolver.resolve(m_address.address(), m_address.port_str(), ec);
+    if (ec) {
+        LOG_WARNING << "CoindRPC sync_reconnect resolve failed: " << ec.message();
+        return;
+    }
+    m_stream.connect(*results.begin(), ec);
+    if (ec) {
+        LOG_WARNING << "CoindRPC sync_reconnect connect failed: " << ec.message();
+        return;
+    }
+    LOG_INFO << "CoindRPC reconnected (sync)";
+}
+
+std::string NodeRPC::Send(const std::string &request)
+{
+    // Retry once after synchronous reconnect on write/read failure
+    for (int attempt = 0; attempt < 2; ++attempt)
+    {
+        m_http_request.body() = request;
+        m_http_request.prepare_payload();
+        try
+        {
+            http::write(m_stream, m_http_request);
+        }
+        catch(const std::exception& e)
+        {
+            LOG_WARNING << "CoindRPC write failed: " << e.what()
+                        << (attempt == 0 ? " — reconnecting..." : "");
+            if (attempt == 0) {
+                sync_reconnect();
+                continue;
+            }
+            return {};
+        }
+
+        beast::flat_buffer buffer;
+        boost::beast::http::response<boost::beast::http::dynamic_body> response;
+
+        try
+        {
+            boost::beast::http::read(m_stream, buffer, response);
+        }
+        catch (const std::exception& ex)
+        {
+            LOG_WARNING << "CoindRPC read failed: " << ex.what()
+                        << (attempt == 0 ? " — reconnecting..." : "");
+            if (attempt == 0) {
+                sync_reconnect();
+                continue;
+            }
+            return {};
+        }
+
+        auto body = boost::beast::buffers_to_string(response.body().data());
+        if (body.empty()) {
+            static int _empty_count = 0;
+            if (_empty_count++ < 5)
+                LOG_WARNING << "CoindRPC empty response: HTTP " << response.result_int()
+                            << " content-length=" << response[http::field::content_length]
+                            << " connection=" << response[http::field::connection];
+            if (attempt == 0 && response.result_int() != 200) {
+                sync_reconnect();
+                continue;
+            }
+        }
+        return body;
+    }
+    return {};
+}
+
+nlohmann::json NodeRPC::CallAPIMethod(const std::string& method, const jsonrpccxx::positional_parameter& params)
+{
+    return m_client.CallMethod<nlohmann::json>(ID, method, params);
+}
+
+bool NodeRPC::check()
+{
+    uint256 genesis = uint256S(dash_genesis_hash(IS_TESTNET));
+    bool has_block = check_blockheader(genesis);
+    bool is_main_chain = getblockchaininfo()["chain"].get<std::string>() == "main";
+
+    if (is_main_chain && !has_block)
+    {
+        LOG_ERROR << "Check failed! Make sure that you're connected to the right dashd with --dash-rpc-port, and that it has finished syncing!" << std::endl;
+        return false;
+    }
+
+    try
+    {
+        auto networkinfo = getnetworkinfo();
+        bool version_check_result = daemon_version_acceptable(networkinfo["version"].get<int>());
+        if (!version_check_result)
+        {
+            LOG_ERROR << "Dash daemon too old! Upgrade!";
+            return false;
+        }
+    } catch (const jsonrpccxx::JsonRpcException& ex)
+    {
+        LOG_WARNING << "NodeRPC::check() exception: " << ex.what();
+        return false;
+    }
+
+    // DASH older-than-v35 baseline has NO segwit and no required-softfork gate
+    // (params.hpp: softforks_required == {}). Unlike DGB (reservealgo/odo/
+    // nversionbips), DASH carries no startup-readiness softfork requirement set,
+    // so the genesis-identity + version-floor probe above is the full check.
+    return true;
+}
+
+bool NodeRPC::check_blockheader(uint256 header)
+{
+    try
+    {
+        getblockheader(header);
+        return true;
+    } catch (const jsonrpccxx::JsonRpcException& ex)
+    {
+        return false;
+    }
+}
+
+DashWorkData NodeRPC::getwork()
+{
+    auto start = core::timestamp();
+    // DASH: X11, no segwit -> plain rules (no "algo", no injected "segwit").
+    auto work = getblocktemplate({});
+    auto end = core::timestamp();
+
+    DashWorkData w;
+    w.m_raw = work;
+
+    // ----- Standard Bitcoin-family fields -----
+    if (work.contains("version"))        w.m_version        = work["version"].get<int32_t>();
+    if (work.contains("previousblockhash"))
+        w.m_previous_block = uint256S(work["previousblockhash"].get<std::string>());
+    if (work.contains("coinbasevalue"))  w.m_coinbase_value = work["coinbasevalue"].get<uint64_t>();
+    if (work.contains("curtime"))        w.m_curtime        = work["curtime"].get<uint32_t>();
+    if (work.contains("mintime"))        w.m_mintime        = work["mintime"].get<uint32_t>();
+    if (work.contains("coinbaseaux") && work["coinbaseaux"].contains("flags"))
+        w.m_coinbase_flags_hex = work["coinbaseaux"]["flags"].get<std::string>();
+    if (work.contains("bits"))
+    {
+        // GBT "bits" is a hex string (compact nBits).
+        w.m_bits = static_cast<uint32_t>(std::stoul(work["bits"].get<std::string>(), nullptr, 16));
+    }
+
+    // Height: prefer GBT's, else previous block + 1.
+    if (work.contains("height"))
+        w.m_height = work["height"].get<uint32_t>();
+    else if (work.contains("previousblockhash"))
+        w.m_height = getblock(w.m_previous_block)["height"].get<uint32_t>() + 1;
+
+    // ----- Transactions (full parse + raw hex + txid + fees) -----
+    if (work.contains("transactions"))
+    {
+        for (auto& packed_tx : work["transactions"])
+        {
+            std::string data_hex;
+            if (packed_tx.is_object() && packed_tx.contains("data"))
+                data_hex = packed_tx["data"].get<std::string>();
+            else if (packed_tx.is_string())
+                data_hex = packed_tx.get<std::string>();
+            if (data_hex.empty())
+                continue;
+
+            w.m_tx_data_hex.push_back(data_hex);
+
+            // Deserialize into a full MutableTransaction (DASH tx codec handles
+            // the version|(type<<16) field + DIP3/DIP4 special-tx payload).
+            MutableTransaction mtx;
+            try
+            {
+                PackStream ps_tx(ParseHex(data_hex));
+                ps_tx >> mtx;
+            }
+            catch (const std::exception& ex)
+            {
+                LOG_WARNING << "getwork: tx deserialize failed: " << ex.what();
+            }
+            w.m_txs.emplace_back(mtx);   // Transaction(MutableTransaction) is explicit
+
+            // txid: prefer GBT's "txid" field, else recompute (DASH non-witness
+            // canonical serialization == dash_txid).
+            uint256 txid;
+            if (packed_tx.is_object() && packed_tx.contains("txid"))
+                txid = uint256S(packed_tx["txid"].get<std::string>());
+            else
+            {
+                PackStream ps_id(ParseHex(data_hex));
+                txid = Hash(ps_id.get_span());
+            }
+            w.m_tx_hashes.push_back(txid);
+
+            uint64_t fee = 0;
+            if (packed_tx.is_object() && packed_tx.contains("fee"))
+                fee = packed_tx["fee"].get<uint64_t>();
+            w.m_tx_fees.push_back(fee);
+        }
+    }
+
+    // ----- DASH masternode + superblock + platform payments -----
+    // Normalize into m_packed_payments in the EXACT coinbase-output order, using
+    // the same "!hex" raw-script / base58-address payee convention that
+    // coin/embedded_gbt.hpp::gbt_xcheck compares the embedded build against.
+    //
+    // dashd GBT carries these as either:
+    //   - the v0.13+ "masternode" array (objects {payee, script, amount}) and
+    //     "superblock" array (same shape), and/or
+    //   - the legacy single-object "masternode"/"payee"+"payee_amount" fields.
+    // We accept both shapes. Platform credit-pool OP_RETURN burns surface as a
+    // payee with an empty/"6a" script -> normalized to "!6a".
+    auto push_payment = [&w](const nlohmann::json& entry) {
+        PackedPayment pp;
+        if (entry.is_object())
+        {
+            if (entry.contains("payee") && entry["payee"].is_string())
+                pp.payee = entry["payee"].get<std::string>();
+            else if (entry.contains("script") && entry["script"].is_string())
+                pp.payee = "!" + entry["script"].get<std::string>();
+            if (entry.contains("amount"))
+                pp.amount = entry["amount"].get<uint64_t>();
+        }
+        if (pp.amount == 0)
+            return;
+        w.m_packed_payments.push_back(std::move(pp));
+        w.m_payment_amount += w.m_packed_payments.back().amount;
+    };
+
+    // Platform credit-pool OP_RETURN burn FIRST (dashcore GetBlockTxOuts order).
+    if (work.contains("coinbase_payload_burn"))
+    {
+        PackedPayment burn;
+        burn.payee  = "!6a";
+        burn.amount = work["coinbase_payload_burn"].get<uint64_t>();
+        if (burn.amount > 0)
+        {
+            w.m_packed_payments.push_back(std::move(burn));
+            w.m_payment_amount += w.m_packed_payments.back().amount;
+        }
+    }
+
+    if (work.contains("masternode"))
+    {
+        if (work["masternode"].is_array())
+            for (auto& e : work["masternode"]) push_payment(e);
+        else if (work["masternode"].is_object())
+            push_payment(work["masternode"]);
+    }
+    if (work.contains("superblock") && work["superblock"].is_array())
+        for (auto& e : work["superblock"]) push_payment(e);
+
+    // ----- DIP3/DIP4 coinbase extra payload -----
+    if (work.contains("coinbase_payload") && work["coinbase_payload"].is_string())
+    {
+        auto payload = ParseHex(work["coinbase_payload"].get<std::string>());
+        w.m_coinbase_payload.assign(payload.begin(), payload.end());
+    }
+
+    w.m_latency = end - start;
+    return w;
+}
+
+void NodeRPC::submit_block(BlockType& block, bool ignore_failure)
+{
+    // DASH is non-segwit, non-MWEB: full-block packing is the plain block codec.
+    // NOTE: BlockType transaction-aware (de)serialization of m_txs is the S5
+    // deferral (coin/block.hpp); until that lands, the hex submit arm
+    // (submit_block_hex) carrying a fully-assembled block is the live won-block
+    // RPC path. This typed overload packs the header form.
+    PackStream packed_block = pack<dash::coin::BlockType>(block);
+    auto result = m_client.CallMethod<nlohmann::json>(ID, "submitblock", {HexStr(packed_block.get_span())});
+    bool success = result.is_null();
+
+    auto success_expected = true;
+
+    if ((!success && success_expected && !ignore_failure) || (success && !success_expected))
+        LOG_ERROR << "Block submittal result: " << success << "(" << result.dump() << ") Expected: " << success_expected;
+}
+
+bool NodeRPC::submit_block_hex(const std::string& block_hex, bool ignore_failure)
+{
+    auto result = m_client.CallMethod<nlohmann::json>(ID, "submitblock", {block_hex});
+    bool success = result.is_null();
+    if (!success && !ignore_failure)
+        LOG_ERROR << "submit_block_hex result: " << result.dump();
+    else if (success)
+        LOG_INFO << "submit_block_hex accepted";
+    return success;
+}
+
+// RPC Methods
+
+nlohmann::json NodeRPC::getblocktemplate(std::vector<std::string> rules)
+{
+    // Body shape (plain rules, NO algo, NO injected segwit) is the
+    // rpc_request.hpp SSOT -- the key DASH<->DGB divergence.
+    return CallAPIMethod("getblocktemplate", {make_gbt_request(rules)});
+}
+
+nlohmann::json NodeRPC::getnetworkinfo()
+{
+    return CallAPIMethod("getnetworkinfo");
+}
+
+nlohmann::json NodeRPC::getblockchaininfo()
+{
+    return CallAPIMethod("getblockchaininfo");
+}
+
+nlohmann::json NodeRPC::getmininginfo()
+{
+    return CallAPIMethod("getmininginfo");
+}
+
+// verbose: true -- json result, false -- hex-encode result;
+nlohmann::json NodeRPC::getblockheader(uint256 header, bool verbose)
+{
+    return CallAPIMethod("getblockheader", {header, verbose});
+}
+
+// verbosity: 0 for hex-encoded data, 1 for a json object, and 2 for json object with transaction data
+nlohmann::json NodeRPC::getblock(uint256 blockhash, int verbosity)
+{
+    return CallAPIMethod("getblock", {blockhash, verbosity});
+}
+
+} // namespace coin
+
+} // namespace dash

--- a/src/impl/dash/coin/rpc.hpp
+++ b/src/impl/dash/coin/rpc.hpp
@@ -1,0 +1,131 @@
+#pragma once
+
+// ---------------------------------------------------------------------------
+// dash::coin::NodeRPC -- external dashd-RPC client (launcher slice 3).
+//
+// Real boost::beast + jsonrpccxx HTTP JSON-RPC client to an external dashd,
+// mirroring src/impl/dgb/coin/rpc.{hpp,cpp} (itself mirrored from
+// src/impl/btc/coin/rpc.{hpp,cpp}). This is the EXTERNAL-DAEMON FALLBACK path
+// that V36 mandates persist alongside the embedded daemon (v36 external_fallback:
+// "embedded primary, external fallback persists -- do NOT remove external-daemon
+// code paths"). Closes the launcher-campaign gap: before this slice DASH had
+// ONLY coin/rpc_data.hpp (the DashWorkData placeholder) and NO RPC client.
+//
+// DASH divergences from DGB/BTC (conformed at port time):
+//   - getblocktemplate(): DASH is X11 and has NO segwit, so -- unlike DGB --
+//     the GBT body carries NO {"algo":"scrypt"} param and injects NO "segwit"
+//     rule. It is the plain {"rules": <caller rules>} dashd expects (default
+//     {}). See coin/rpc_request.hpp (request-shape SSOT).
+//   - getwork() returns the RICH dash::coin::DashWorkData (NOT the trimmed
+//     rpc::WorkData family-1 seam DGB uses). It parses the dashd GBT JSON into:
+//       * standard fields (version/prev/height/coinbasevalue/bits/curtime/...)
+//       * the full transaction set (m_txs + m_tx_data_hex + m_tx_hashes + fees)
+//       * the DASH masternode + superblock + platform payments
+//         (m_packed_payments, normalized to the "!hex"/base58 payee convention
+//         coin/embedded_gbt.hpp::gbt_xcheck compares against), with
+//         m_payment_amount = sum of those amounts (the masternode+treasury
+//         share miners do NOT receive)
+//       * the DIP3/DIP4 coinbase extra payload (m_coinbase_payload, hex-decoded)
+//   - check(): chain-identity probe uses the DASH genesis hash (mainnet vs
+//     testnet3 by IS_TESTNET) from coin/rpc_request.hpp, not DGB's.
+//
+// submit_block_hex(block_hex, ignore_failure) is THE key deliverable: the dashd
+// `submitblock` fallback arm. The embedded-P2P relay leg of the won-block
+// dual-path broadcaster is still DEFERRED (lands with coin/p2p_node); this slice
+// ships the RPC submit fallback only. NEVER remove the external-daemon path.
+// ---------------------------------------------------------------------------
+
+#include "block.hpp"
+#include "rpc_data.hpp"
+#include "node_interface.hpp"
+
+#include <iostream>
+
+#include <core/uint256.hpp>
+#include <core/timer.hpp>
+#include <core/netaddress.hpp>   // NetService m_address / connect() endpoint
+
+#include <boost/asio.hpp>
+#include <boost/beast.hpp>
+#include <nlohmann/json.hpp>
+#include <jsonrpccxx/client.hpp>
+
+namespace io = boost::asio;
+namespace beast = boost::beast;
+namespace http = beast::http;
+
+namespace dash
+{
+
+namespace coin
+{
+
+struct RPCAuthData;
+class NodeRPC : public jsonrpccxx::IClientConnector
+{
+    const std::string ID = "curltest";
+    const jsonrpccxx::version RPC_VER = jsonrpccxx::version::v2;
+
+    const bool IS_TESTNET;
+private:
+    dash::interfaces::Node* m_coin;
+
+    io::io_context* m_context;
+    beast::tcp_stream m_stream;
+    boost::asio::ip::tcp::resolver m_resolver;
+    http::request<http::string_body> m_http_request;
+
+    std::unique_ptr<RPCAuthData> m_auth;
+    jsonrpccxx::JsonRpcClient m_client;
+
+    // Reconnection state
+    NetService m_address;
+    std::string m_userpass;
+    bool m_connected = false;
+    std::unique_ptr<core::Timer> m_reconnect_timer;
+
+    std::string Send(const std::string &request) override;
+    nlohmann::json CallAPIMethod(const std::string& method, const jsonrpccxx::positional_parameter& params = {});
+
+public:
+    NodeRPC(io::io_context* context, dash::interfaces::Node* coin, bool testnet);
+    ~NodeRPC();
+
+    void connect(NetService address, std::string userpass);
+    void reconnect();
+    void sync_reconnect();
+    bool check();
+    bool check_blockheader(uint256 header);
+
+    // Parse a dashd getblocktemplate response into the rich DashWorkData (txs +
+    // masternode/superblock payments + DIP3/DIP4 coinbase payload).
+    DashWorkData getwork();
+
+    void submit_block(BlockType& block, bool ignore_failure);
+    // Submit a pre-serialised block passed in as a hex string (avoids re-packing)
+    // -- THE dashd submitblock fallback arm. Returns true iff the daemon
+    // accepted the block (result is null), false otherwise.
+    bool submit_block_hex(const std::string& block_hex, bool ignore_failure);
+
+    // RPC Methods
+    // DASH: X11, no segwit -> rules are passed through plainly; no separate algo
+    // param (the DGB Scrypt divergence does NOT apply). See rpc_request.hpp.
+    nlohmann::json getblocktemplate(std::vector<std::string> rules = {});
+    nlohmann::json getnetworkinfo();
+    nlohmann::json getblockchaininfo();
+    nlohmann::json getmininginfo();
+    // verbose: true -- json result, false -- hex-encode result;
+    nlohmann::json getblockheader(uint256 header, bool verbose = true);
+    // verbosity: 0 for hex-encoded data, 1 for a json object, and 2 for json object with transaction data
+    nlohmann::json getblock(uint256 blockhash, int verbosity = 1);
+};
+
+struct RPCAuthData
+{
+    std::string authorization;
+    std::string host;
+};
+
+} // namespace coin
+
+} // namespace dash

--- a/src/impl/dash/coin/rpc_conf.hpp
+++ b/src/impl/dash/coin/rpc_conf.hpp
@@ -1,0 +1,97 @@
+#pragma once
+
+// ---------------------------------------------------------------------------
+// dash::coin::rpc_conf -- dash.conf credential resolution for the launcher
+// slice-3 external-daemon submitblock arm (the RPC leg of the won-block
+// dual-path broadcaster; the embedded-P2P relay leg is still DEFERRED).
+//
+// Credential rule (operator self-provision posture, STANDING RULE 2026-06-18):
+// the rpcpassword NEVER reaches the process table. --coin-rpc carries only
+// HOST:PORT; --coin-rpc-auth carries a FILE PATH to the conf (default
+// ~/.dashcore/dash.conf); rpcuser/rpcpassword are read from that file and are
+// never echoed. 1:1 mirror of src/impl/dgb/coin/rpc_conf.hpp, conformed to
+// DASH (dash.conf default path + dash_rpc_* aliases), fenced in src/impl/dash/
+// only -- zero shared/core touch, per-coin isolation held.
+//
+// Header-only and dependency-light by design (no config_pool.hpp pull): the
+// net-default RPC port is supplied by the caller, so a standalone conf-parse
+// guard can exercise the parser without dragging the coin config in.
+// ---------------------------------------------------------------------------
+
+#include <cstdint>
+#include <fstream>
+#include <string>
+
+namespace dash
+{
+namespace coin
+{
+
+// Resolved external-daemon RPC endpoint + credentials. `armed()` is the single
+// gate the launcher consults before constructing a NodeRPC: no creds (or no
+// port) => the submit arm stays UNARMED and submit_block_hex returns false
+// LOUDLY, identical to the daemon-less default build. NEVER remove the
+// external-daemon RPC fallback (V36 external_fallback mandate).
+struct RpcConf
+{
+    std::string host = "127.0.0.1";
+    uint16_t    port = 0;   // 0 => caller fills the per-net default
+    std::string user;
+    std::string pass;
+
+    bool armed() const { return !user.empty() && !pass.empty() && port != 0; }
+    std::string userpass() const { return user + ":" + pass; }
+};
+
+namespace conf_detail
+{
+inline std::string trim(const std::string& s)
+{
+    const char* ws = " \t\r\n";
+    const auto b = s.find_first_not_of(ws);
+    if (b == std::string::npos) return {};
+    const auto e = s.find_last_not_of(ws);
+    return s.substr(b, e - b + 1);
+}
+} // namespace conf_detail
+
+// Parse rpcuser/rpcpassword/rpcport/rpcconnect from a dash.conf-style file
+// (also accepts the c2pool dash_rpc_user/dash_rpc_password aliases). '#' begins
+// a comment. Returns true ONLY when BOTH user and password were found; the
+// password stays in-file and is never logged.
+inline bool load_rpc_conf(const std::string& path, RpcConf& out)
+{
+    std::ifstream f(path);
+    if (!f) return false;
+    std::string line;
+    while (std::getline(f, line)) {
+        const auto h = line.find('#');
+        if (h != std::string::npos) line = line.substr(0, h);
+        const auto eq = line.find('=');
+        if (eq == std::string::npos) continue;
+        const std::string key = conf_detail::trim(line.substr(0, eq));
+        const std::string val = conf_detail::trim(line.substr(eq + 1));
+        if (val.empty()) continue;
+        if      (key == "rpcuser"     || key == "dash_rpc_user")     out.user = val;
+        else if (key == "rpcpassword" || key == "dash_rpc_password") out.pass = val;
+        else if (key == "rpcport")    out.port = static_cast<uint16_t>(std::stoi(val));
+        else if (key == "rpcconnect") out.host = val;
+    }
+    return !out.user.empty() && !out.pass.empty();
+}
+
+// Apply a "--coin-rpc HOST:PORT" endpoint override. Endpoint only -- carries no
+// secret, so it is safe on the process table. A bare "HOST" leaves the port at
+// whatever the conf/default supplied; an empty argument is a no-op.
+inline void apply_endpoint_override(const std::string& hostport, RpcConf& out)
+{
+    if (hostport.empty()) return;
+    const auto colon = hostport.rfind(':');
+    if (colon == std::string::npos) { out.host = hostport; return; }
+    out.host = hostport.substr(0, colon);
+    const std::string p = hostport.substr(colon + 1);
+    if (!p.empty()) out.port = static_cast<uint16_t>(std::stoi(p));
+}
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/rpc_request.hpp
+++ b/src/impl/dash/coin/rpc_request.hpp
@@ -1,0 +1,89 @@
+#pragma once
+
+// ---------------------------------------------------------------------------
+// dash::coin -- launcher-slice-3 RPC request-shape SSOT (pure, dependency-light).
+//
+// Single source of truth for the oracle-pinned external-RPC contract values
+// that NodeRPC::check()/getwork() depend on, factored out of rpc.cpp so a
+// standalone test TU can guard them WITHOUT linking the boost::beast /
+// jsonrpccxx transport (i.e. without building the dash coin transport TU):
+//
+//   1. DASH_MIN_DAEMON_VERSION -- the getnetworkinfo["version"] accept floor,
+//      conformed to the DASH oracle frstrtr/p2pool-dash (older-than-v35
+//      baseline -> dashd v0.17 line, protocol/version family). DASH p2pool
+//      runs against Dash Core's DIP3/DIP4-capable daemons; the floor pins the
+//      minimum that returns the masternode/superblock/coinbase_payload GBT
+//      fields getwork() consumes.
+//   2. make_gbt_request() -- DASH getblocktemplate body. THIS IS THE KEY
+//      DASH<->DGB DIVERGENCE: DASH is X11 and has NO segwit, so the body does
+//      NOT carry DGB's {"algo":"scrypt"} param and does NOT inject a "segwit"
+//      rule. dashd getblocktemplate is called with the plain rules array the
+//      caller supplies (default {} -> base template carrying the masternode +
+//      superblock payment fields and the DIP3/DIP4 coinbasevalue/payload).
+//      Conforms to dashd getblocktemplate semantics + the p2pool-dash oracle
+//      getwork() (older-than-v35), NOT a Bitcoin/DGB segwit template.
+//   3. DASH chain-identity genesis hashes -- so check() can probe a real dashd
+//      on the selected network. Pinned here (and mirrored from
+//      coin/header_chain.hpp) as a bucket-1 ISOLATION PRIMITIVE: per-coin AND
+//      per-net, never standardized cross-coin.
+//
+// Header-only + nlohmann-only: includes nothing from the transport stack, so
+// the guard test is a clean standalone link.
+// ---------------------------------------------------------------------------
+
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+namespace dash
+{
+
+namespace coin
+{
+
+// Minimum acceptable dashd getnetworkinfo["version"] int. DASH p2pool conforms
+// to its OWN older-than-v35 oracle (operator 2026-06-17 per-coin re-scope); the
+// floor is Dash Core 0.17 (the first line returning the DIP3/DIP4 masternode +
+// coinbase_payload GBT fields getwork() parses). 170000 == Dash Core 0.17.0.0.
+inline constexpr int DASH_MIN_DAEMON_VERSION = 170000;
+
+// True iff a daemon advertising getnetworkinfo["version"]==v clears the floor.
+inline bool daemon_version_acceptable(int version)
+{
+    return DASH_MIN_DAEMON_VERSION <= version;
+}
+
+// Build the DASH getblocktemplate request body. DASH is X11 with NO segwit, so
+// -- unlike DGB -- the body carries NO "algo" param and injects NO "segwit"
+// rule: it is the plain {"rules": <caller rules>} dashd expects. The default
+// (empty rules) yields dashd's base template, which already carries the
+// masternode/superblock payment arrays and the DIP3/DIP4 coinbasevalue +
+// coinbase_payload fields DashWorkData consumes. Conforms to dashd
+// getblocktemplate + the p2pool-dash oracle getwork() (older-than-v35).
+inline nlohmann::json make_gbt_request(const std::vector<std::string>& rules = {})
+{
+    return nlohmann::json::object({{"rules", rules}});
+}
+
+// DASH chain-identity genesis hashes (Dash Core chainparams.cpp; mirrored from
+// src/impl/dash/coin/header_chain.hpp seed). NodeRPC::check() probes
+// getblockheader(genesis) to confirm it is talking to a real dashd on the
+// selected network (a wrong-coin daemon does not answer). Bucket-1 ISOLATION
+// PRIMITIVE -- KEEP per-coin in v36 AND v37, never standardize; pinned in this
+// SSOT only so a standalone TU can guard against accidental drift WITHOUT
+// linking the boost::beast transport.
+inline constexpr const char* DASH_GENESIS_MAIN =
+    "00000ffd590b1485b3caadc19b22e6379c733355108f107a430458cdf3407ab6";
+inline constexpr const char* DASH_GENESIS_TEST =
+    "00000bafbc94add76cb75e2ec92894837288a481e5c005f6563d91623bf8bc2c";
+
+// The genesis hash NodeRPC::check() probes for the selected network.
+inline const char* dash_genesis_hash(bool testnet)
+{
+    return testnet ? DASH_GENESIS_TEST : DASH_GENESIS_MAIN;
+}
+
+} // namespace coin
+
+} // namespace dash


### PR DESCRIPTION
Clean, lane-fenced re-land of the DASH launcher on fresh master per integrator request. Brings ONLY the working VM200 launcher tree (the one that won + submitted regtest block 7), self-contained and compiling.

## Lane (git diff --name-only origin/master..HEAD)
```
src/c2pool/CMakeLists.txt
src/c2pool/main_dash.cpp
src/impl/dash/CMakeLists.txt
src/impl/dash/coin/block_producer.hpp
src/impl/dash/coin/rpc.cpp
src/impl/dash/coin/rpc.hpp
src/impl/dash/coin/rpc_conf.hpp
src/impl/dash/coin/rpc_request.hpp
```
8 files, +1273/-18. Strictly src/c2pool/ (launcher dispatch) + src/impl/dash/ (dash coin glue).

## NOT touched (master keeps its own)
build.yml, test/CMakeLists.txt, src/impl/dgb/*, web-static/*, other coins' dispatch lines.

## Deviation from the listed lane (the two-dir / over-strip gap)
- c2pool_refactored.cpp + node_interface.hpp: already IDENTICAL on master (earlier slices landed) -> no diff, omitted.
- ADDED beyond the list, because main_dash.cpp / rpc.cpp include them and the launcher will not compile without them (header-only, dash-only, additive): src/impl/dash/CMakeLists.txt (defines the dash_rpc lib c2pool-dash links), rpc_conf.hpp, rpc_request.hpp, block_producer.hpp.
- NOT brought: the coinbase_builder.hpp BIP34 OP_N regtest-height fixup. It is consensus-bearing and only bites at heights <=16 (regtest); mainnet heights are unchanged. Per your rule it stays master's; I will surface it as a separate tiny consensus slice (needed for the regtest crossing proof, not for this launcher build).

## Verified (Linux x86_64)
- c2pool-dash links clean off master 549f4f62.
- --selftest 11/11 non-hollow (X11 PoW KATs, subsidy, oracle CoinParams).

SAFE-ADDITIVE: dash_rpc linked ONLY by c2pool-dash; no shared-base/core source edit; external-dashd RPC fallback preserved. GPG-signed 1f503a4a, attribution-clean. No self-merge — held for your verify + operator tap.