### PR TITLE
dgb: correct won_share_inputs header drift -- m_on_block_found bound, not a nullopt stub

### DIFF
--- a/src/impl/dgb/coin/won_share_inputs.hpp
+++ b/src/impl/dgb/coin/won_share_inputs.hpp
@@ -2,8 +2,9 @@
 // ---------------------------------------------------------------------------
 // dgb::coin::won_share_inputs -- the SHARE-SIDE half of the #82 faithful
 // won-block reconstruct closure (the closure the run-loop installs as
-// ShareTracker::m_on_block_found, today an interim nullopt stub in
-// main_dgb.cpp). reconstruct_won_block_from_template (reconstruct_won_block.hpp)
+// ShareTracker::m_on_block_found, now bound in main_dgb.cpp via
+// dgb::coin::make_on_block_found -- the #82 dual-path broadcaster, no longer
+// a nullopt stub). reconstruct_won_block_from_template (reconstruct_won_block.hpp)
 // needs five inputs to frame a broadcastable block:
 //
 //     { small_header, merkle_link, gentx, gentx_hash, template_other_txs }


### PR DESCRIPTION
## What

Comment-only correction to `src/impl/dgb/coin/won_share_inputs.hpp`. The banner described `ShareTracker::m_on_block_found` as "today an interim nullopt stub in main_dgb.cpp". That is stale.

`main_dgb.cpp` now binds `m_on_block_found = dgb::coin::make_on_block_found(...)` -- the #82 dual-path broadcaster (P2P-relay arm + external-digibyted `submitblock` fallback), proven end-to-end on regtest (both arms accept a tx-bearing won block).

## Scope

- Comment-only. Zero code/behavior delta.
- No consensus, share-format, PPLNS, or p2pool-merged-v36-surface change.
- Per-coin isolation preserved: `src/impl/dgb/` only.
- The adjacent "remaining three inputs" paragraph is left intact -- it accurately describes this seam pulling only the two share-carried fields (`small_header`, `merkle_link`); the other three are supplied template-side in `reconstruct_closure.hpp`.

Fenced/additive doc fix. No self-merge.
