### PR TITLE
web(d-web4): narrow-phone (<=480px) hardening for embedded dashboard header

### DIFF
--- a/web-static/dashboard.html
+++ b/web-static/dashboard.html
@@ -1248,7 +1248,26 @@
                 max-width: 100%;
             }
         }
-        
+
+        /* Narrow phones (<=480px): the header info boxes carry INLINE
+           min-width (280px / 220px) which the wider breakpoints cannot
+           override, and the monospace config lines (stratum URL, the
+           <ADDR>,<DOGE_ADDR>.WORKER username) are unbreakable tokens.
+           Together they force horizontal overflow that clips the view on
+           a phone. Neutralize the inline mins and let long tokens wrap.
+           Static drop-in; serves the operator-flagged D-WEB.4 mobile clip. */
+        @media (max-width: 480px) {
+            #miner-info, #network-info {
+                min-width: 0 !important;
+                flex: 1 1 100% !important;
+            }
+            .miner-info [style*="monospace"],
+            .miner-info [style*="monospace"] span {
+                overflow-wrap: anywhere;
+                word-break: break-word;
+            }
+        }
+
         /* Two-column layout for sections */
         .two-col {
             display: grid;


### PR DESCRIPTION
## What
Adds a `@media (max-width: 480px)` block to `web-static/dashboard.html`:
- forces `#miner-info` / `#network-info` to full-width, min-width:0 (their **inline** min-width of 280px/220px is unreachable by the existing 768px/900px breakpoints, so on a phone the two boxes sum to ~500px and overflow horizontally → clipped view)
- adds `overflow-wrap/word-break` to the monospace config lines (stratum URL, the `<ADDR>,<DOGE_ADDR>.WORKER` username) which are unbreakable tokens that push past the viewport

## Why
Closes the residual half of the operator-flagged D-WEB.4 mobile-clip on the **embedded** :8080 dashboard. PR #422 covered the legacy index/graphs static pages; this covers `dashboard.html` (the root `/` page served from `--dashboard-dir`).

## Risk / deploy
Pure CSS, additive, scoped to <=480px only — no change at desktop/tablet widths. **Static drop-in**: served on-disk from `--dashboard-dir`, deploys via static-swap (no rebuild, no restart). Web/non-consensus → normal merge after CI green + operator merge-tap awareness.