### PR TITLE
dash(s8): WonBlockRelay live-slots reply path — per-slot send planner + KATs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer \
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer test_dash_block_relay_plan \
                     test_multiaddress_pplns test_pplns_stress \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
@@ -205,7 +205,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer \
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer test_dash_block_relay_plan \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
                     test_v36_script_sorting test_v36_cross_impl_refhash \

--- a/src/impl/dash/block_relay_plan.hpp
+++ b/src/impl/dash/block_relay_plan.hpp
@@ -1,0 +1,150 @@
+#pragma once
+
+// Phase S8 — WonBlockRelay live-slots reply path (LEAF).
+//
+// Binds the relay HANDSHAKE (block_relay.hpp framer + the inbound getdata
+// decode, inlined below) to the broadcaster's LIVE SLOTS, producing a per-slot SEND
+// PLAN. It is the last pure rung before the operator-gated keystone:
+//
+//     announce/dispatch frames ──▶ [block_relay_plan] ──▶ broadcaster_full
+//        (what to send)              (to WHICH slot)         (actual sockets)
+//
+// The framer/dispatcher answer "what frame" for ONE hash or ONE inbound getdata;
+// the DashBroadcaster (broadcaster.hpp) holds the pool of live "host:port" slot
+// keys. Neither knows the other. This leaf is the planner that joins them:
+//
+//   * plan_announce(live_slots, hash, block)
+//       records the won block (delegates to WonBlockRelay::announce) and returns
+//       the SINGLE `inv` frame plus the de-duped list of live slot keys it must
+//       fan out to. One frame, many slots — an inv broadcast, modelled honestly
+//       as one frame + a recipient list rather than N identical copies.
+//   * plan_getdata_reply(slot, getdata_msg)
+//       routes ONE inbound getdata (decoded inline against the relay) back to the
+//       SAME slot that asked: the ordered `block` replies + optional `notfound`,
+//       all tagged with the requesting slot key.
+//
+// SCOPE / NON-CONSENSUS: identical invariant to the framer/dispatcher. Slot keys
+// are OPAQUE strings (the broadcaster's pool keys) — no socket is opened, no
+// io_context touched, no block hash recomputed, and a block is served only if it
+// was announced. The plan is INERT data; the DECISION to walk it and write the
+// frames onto the live slots' sockets stays in the operator-gated
+// broadcaster_full keystone. A won block is recorded even when there are zero
+// live slots (the dashd submitblock arm still carries it, and a peer that
+// connects later can still getdata it) — recording is decoupled from fan-out.
+// Header-only, single dash tree, socket-free — unit-testable with zero sockets
+// and zero live dashd, like its sibling leaves.
+
+#include "block_relay.hpp"
+#include "coin/p2p_messages.hpp"
+
+#include <core/message.hpp>
+#include <core/pack.hpp>
+#include <core/uint256.hpp>
+
+#include <memory>
+#include <set>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace dash
+{
+
+// The fan-out plan for a won block: ONE inv frame + the live slot keys to send
+// it to. The inv is identical for every recipient (a broadcast), so it is held
+// once rather than copied per slot.
+struct AnnouncePlan
+{
+    std::vector<std::string>    slots;   // de-duped live slot keys to fan out to
+    std::unique_ptr<RawMessage> inv;     // the single `inv(MSG_BLOCK, hash)` frame
+
+    size_t fanout() const { return slots.size(); }
+};
+
+// The reply plan for ONE inbound getdata: the decoded block replies + optional
+// notfound, tagged with the slot that asked so broadcaster_full writes them back
+// to the right socket.
+struct ReplyPlan
+{
+    std::string                              slot;      // the slot that requested
+    std::vector<std::unique_ptr<RawMessage>> blocks;    // ordered `block` replies
+    std::unique_ptr<RawMessage>              notfound;  // misses, or nullptr
+
+    size_t served()     const { return blocks.size(); }
+    bool   has_misses() const { return notfound != nullptr; }
+};
+
+// Joins a WonBlockRelay to the broadcaster's live slot keys. Holds the relay by
+// reference (the relay owns the pending-block book; the planner is stateless).
+// Pure: opens no socket, recomputes no hash.
+class WonBlockRelayPlanner
+{
+public:
+    explicit WonBlockRelayPlanner(WonBlockRelay& relay) : m_relay(relay) {}
+
+    // Record the won block and build its fan-out plan: the single inv frame plus
+    // the live slot keys to send it to. Slot keys are de-duped and empties are
+    // skipped, so a slot is never announced to twice. The block is recorded even
+    // when `live_slots` is empty — fan-out is decoupled from recording.
+    AnnouncePlan plan_announce(std::span<const std::string> live_slots,
+                               const uint256& hash,
+                               WonBlockRelay::BlockType block)
+    {
+        AnnouncePlan plan;
+        plan.inv = m_relay.announce(hash, std::move(block));
+
+        std::set<std::string> seen;
+        for (const auto& key : live_slots)
+        {
+            if (key.empty() || !seen.insert(key).second)
+                continue;
+            plan.slots.push_back(key);
+        }
+        return plan;
+    }
+
+    // Route an inbound getdata from `slot` back to that same slot: decode the
+    // request against the relay's pending-block book, then tag the result with
+    // the requesting slot. `slot` is preserved even when nothing is served, so
+    // the caller always knows which connection the (possibly empty) reply
+    // belongs to.
+    ReplyPlan plan_getdata_reply(const std::string& slot,
+                                 const RawMessage& getdata_msg) const
+    {
+        using inventory_type = dash::coin::p2p::inventory_type;
+
+        ReplyPlan plan;
+        plan.slot = slot;
+
+        // Decode the inbound getdata against the relay's pending-block book and
+        // route each MSG_BLOCK request through it. (This pure routing previously
+        // lived in the block_relay_dispatch.hpp leaf; that getdata-decoder was
+        // folded on landing, so the same socket-free logic is inlined here.)
+        // make() consumes the stream, so parse a COPY - keeps getdata_msg const.
+        std::vector<inventory_type> misses;
+        PackStream stream = getdata_msg.m_data;
+        auto parsed = dash::coin::p2p::message_getdata::make(stream);
+        for (const auto& req : parsed->m_requests)
+        {
+            // Dash has no segwit, but a peer may tag MSG_WITNESS_BLOCK; match on
+            // the base type and serve the same canonical block either way.
+            if (req.base_type() != inventory_type::block)
+                continue;  // won-block relay serves blocks only
+
+            if (auto blk = m_relay.on_getdata_block(req.m_hash))
+                plan.blocks.push_back(std::move(blk));
+            else
+                misses.emplace_back(inventory_type::block, req.m_hash);
+        }
+
+        if (!misses.empty())
+            plan.notfound = dash::coin::p2p::message_notfound::make_raw(misses);
+
+        return plan;
+    }
+
+private:
+    WonBlockRelay& m_relay;
+};
+
+} // namespace dash

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -512,6 +512,15 @@ if (BUILD_TESTING AND GTest_FOUND)
     )
     target_link_libraries(test_dash_block_producer PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39): core stratum/web_server TUs
     gtest_add_tests(test_dash_block_producer "" AUTO)
+    add_executable(test_dash_block_relay_plan test_dash_block_relay_plan.cpp)
+    target_link_libraries(test_dash_block_relay_plan PRIVATE
+        GTest::gtest_main GTest::gtest
+        dash_x11 core
+        nlohmann_json::nlohmann_json
+        ${Boost_LIBRARIES}
+    )
+    target_link_libraries(test_dash_block_relay_plan PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
+    gtest_add_tests(test_dash_block_relay_plan "" AUTO)
 
     add_executable(test_compact_blocks test_compact_blocks.cpp)
     target_link_libraries(test_compact_blocks PRIVATE

--- a/test/test_dash_block_relay_plan.cpp
+++ b/test/test_dash_block_relay_plan.cpp
@@ -1,0 +1,219 @@
+/// Phase S8 — WonBlockRelay live-slots reply-path KATs.
+///
+/// Exercises src/impl/dash/block_relay_plan.hpp — the planner that binds the
+/// relay handshake (framer + getdata dispatcher) to the broadcaster's LIVE SLOT
+/// keys, producing a per-slot SEND PLAN, WITHOUT any socket or live dashd:
+///
+///   (a) announce fan-out  — a won block records in the relay AND yields one inv
+///                           frame addressed to every live slot, in order.
+///   (b) dedupe/skip-empty  — duplicate and empty slot keys collapse so a slot
+///                           is never announced to twice.
+///   (c) zero-slots record  — with no live peers the block is STILL recorded
+///                           (fan-out empty, relay.knows == true): recording is
+///                           decoupled from fan-out (the submitblock arm carries
+///                           it and a late peer can still getdata it).
+///   (d) inv frame parity   — the announce inv reparses to exactly one MSG_BLOCK
+///                           inventory carrying the announced hash.
+///   (e) reply served       — a getdata from slot "peerA" for a known block is
+///                           routed back tagged to "peerA"; the block reparses.
+///   (f) reply notfound     — an unknown hash yields a notfound tagged to the
+///                           same slot; nothing served.
+///   (g) reply empty/tagged — a tx-only getdata serves nothing and emits no
+///                           notfound, yet the slot tag is preserved.
+///   (h) end-to-end         — announce to slots, then that peer's getdata for the
+///                           announced hash returns the block (the round-trip the
+///                           keystone executes against real sockets).
+///
+/// SCOPE NOTE (honest): pure planner over opaque string slot keys. No socket is
+/// opened, no io_context touched, no hash recomputed; a block is served only if
+/// announced. The live plan -> socket write path is the operator-gated
+/// broadcaster_full concern and is not claimed here.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/block_relay_plan.hpp>
+#include <impl/dash/block_relay.hpp>
+#include <impl/dash/coin/p2p_messages.hpp>
+
+#include <core/uint256.hpp>
+#include <core/pack.hpp>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+using dash::WonBlockRelay;
+using dash::WonBlockRelayPlanner;
+using dash::AnnouncePlan;
+using dash::ReplyPlan;
+using dash::coin::BlockType;
+using dash::coin::p2p::message_getdata;
+using dash::coin::p2p::message_block;
+using dash::coin::p2p::message_notfound;
+using dash::coin::p2p::message_inv;
+using dash::coin::p2p::inventory_type;
+
+namespace {
+
+uint256 hash_seq(uint8_t base) {
+    std::array<uint8_t, 32> p{};
+    for (size_t i = 0; i < 32; ++i) p[i] = static_cast<uint8_t>(base + i);
+    uint256 h; std::memcpy(h.data(), p.data(), 32); return h;
+}
+
+BlockType make_block(uint8_t seed) {
+    BlockType b;
+    b.m_version        = 0x20000000u | seed;
+    b.m_previous_block = hash_seq(0x10 + seed);
+    b.m_merkle_root    = hash_seq(0x50 + seed);
+    b.m_timestamp      = 0x5f5e1000u + seed;
+    b.m_bits           = 0x1d00ffffu;
+    b.m_nonce          = 0xdeadbeefu - seed;
+    return b;
+}
+
+std::unique_ptr<RawMessage> make_getdata(std::vector<inventory_type> reqs) {
+    return message_getdata::make_raw(std::move(reqs));
+}
+
+inventory_type inv_block(const uint256& h) {
+    return inventory_type(inventory_type::block, h);
+}
+
+} // namespace
+
+// (a) announce fan-out: block recorded + one inv addressed to every slot ──────
+TEST(DashRelayPlan, Announce_RecordsAndFansOutToEverySlot) {
+    WonBlockRelay relay;
+    WonBlockRelayPlanner planner(relay);
+
+    const uint256 h = hash_seq(0x20);
+    const std::vector<std::string> slots{"10.0.0.1:9999", "10.0.0.2:9999", "10.0.0.3:9999"};
+
+    AnnouncePlan plan = planner.plan_announce(slots, h, make_block(4));
+
+    EXPECT_TRUE(relay.knows(h));
+    ASSERT_NE(plan.inv, nullptr);
+    EXPECT_EQ(plan.inv->m_command, "inv");
+    ASSERT_EQ(plan.fanout(), 3u);
+    EXPECT_EQ(plan.slots[0], "10.0.0.1:9999");
+    EXPECT_EQ(plan.slots[1], "10.0.0.2:9999");
+    EXPECT_EQ(plan.slots[2], "10.0.0.3:9999");
+}
+
+// (b) duplicate + empty slot keys collapse ────────────────────────────────────
+TEST(DashRelayPlan, Announce_DedupesAndSkipsEmptySlots) {
+    WonBlockRelay relay;
+    WonBlockRelayPlanner planner(relay);
+
+    const std::vector<std::string> slots{"a:1", "", "b:2", "a:1", "", "b:2", "c:3"};
+    AnnouncePlan plan = planner.plan_announce(slots, hash_seq(0x30), make_block(1));
+
+    ASSERT_EQ(plan.fanout(), 3u);
+    // first-seen order preserved (set is only for dedupe membership)
+    EXPECT_EQ(plan.slots[0], "a:1");
+    EXPECT_EQ(plan.slots[1], "b:2");
+    EXPECT_EQ(plan.slots[2], "c:3");
+}
+
+// (c) zero live slots: block STILL recorded, fan-out empty ────────────────────
+TEST(DashRelayPlan, Announce_ZeroSlots_StillRecords) {
+    WonBlockRelay relay;
+    WonBlockRelayPlanner planner(relay);
+
+    const uint256 h = hash_seq(0x40);
+    AnnouncePlan plan = planner.plan_announce(std::vector<std::string>{}, h, make_block(2));
+
+    EXPECT_EQ(plan.fanout(), 0u);
+    EXPECT_NE(plan.inv, nullptr);       // frame built even with no recipients
+    EXPECT_TRUE(relay.knows(h));        // recording decoupled from fan-out
+    EXPECT_EQ(relay.pending(), 1u);
+}
+
+// (d) the inv frame reparses to one MSG_BLOCK inventory of the announced hash ──
+TEST(DashRelayPlan, Announce_InvFrameReparsesToBlockHash) {
+    WonBlockRelay relay;
+    WonBlockRelayPlanner planner(relay);
+
+    const uint256 h = hash_seq(0x55);
+    AnnouncePlan plan = planner.plan_announce(std::vector<std::string>{"p:1"}, h, make_block(3));
+
+    auto inv = message_inv::make(plan.inv->m_data);
+    ASSERT_EQ(inv->m_invs.size(), 1u);
+    EXPECT_EQ(inv->m_invs[0].m_hash, h);
+    EXPECT_EQ(static_cast<uint32_t>(inv->m_invs[0].m_type),
+              static_cast<uint32_t>(inventory_type::block));
+}
+
+// (e) reply path: known block routed back tagged to the requesting slot ───────
+TEST(DashRelayPlan, Reply_KnownBlock_TaggedToSlot) {
+    WonBlockRelay relay;
+    WonBlockRelayPlanner planner(relay);
+
+    const uint256 h = hash_seq(0x33);
+    const BlockType blk = make_block(7);
+    planner.plan_announce(std::vector<std::string>{"peerA"}, h, blk);
+
+    ReplyPlan rp = planner.plan_getdata_reply("peerA", *make_getdata({inv_block(h)}));
+
+    EXPECT_EQ(rp.slot, "peerA");
+    ASSERT_EQ(rp.served(), 1u);
+    EXPECT_FALSE(rp.has_misses());
+    auto parsed = message_block::make(rp.blocks[0]->m_data);
+    EXPECT_EQ(parsed->m_block.m_nonce, blk.m_nonce);
+    EXPECT_EQ(parsed->m_block.m_merkle_root, blk.m_merkle_root);
+}
+
+// (f) reply path: unknown hash -> notfound tagged to the same slot ────────────
+TEST(DashRelayPlan, Reply_UnknownBlock_NotfoundTaggedToSlot) {
+    WonBlockRelay relay;
+    WonBlockRelayPlanner planner(relay);
+    planner.plan_announce(std::vector<std::string>{"peerB"}, hash_seq(0x10), make_block(1));
+
+    const uint256 unknown = hash_seq(0x90);
+    ReplyPlan rp = planner.plan_getdata_reply("peerB", *make_getdata({inv_block(unknown)}));
+
+    EXPECT_EQ(rp.slot, "peerB");
+    EXPECT_EQ(rp.served(), 0u);
+    ASSERT_TRUE(rp.has_misses());
+    auto nf = message_notfound::make(rp.notfound->m_data);
+    ASSERT_EQ(nf->m_invs.size(), 1u);
+    EXPECT_EQ(nf->m_invs[0].m_hash, unknown);
+}
+
+// (g) reply path: tx-only serves nothing, no notfound, slot tag preserved ─────
+TEST(DashRelayPlan, Reply_TxOnly_EmptyButTagged) {
+    WonBlockRelay relay;
+    WonBlockRelayPlanner planner(relay);
+    planner.plan_announce(std::vector<std::string>{"peerC"}, hash_seq(0x20), make_block(4));
+
+    ReplyPlan rp = planner.plan_getdata_reply("peerC", *make_getdata({
+        inventory_type(inventory_type::tx, hash_seq(0x66)),
+    }));
+
+    EXPECT_EQ(rp.slot, "peerC");
+    EXPECT_EQ(rp.served(), 0u);
+    EXPECT_FALSE(rp.has_misses());
+}
+
+// (h) end-to-end: announce then the peer's getdata returns the block ──────────
+TEST(DashRelayPlan, EndToEnd_AnnounceThenGetdataReturnsBlock) {
+    WonBlockRelay relay;
+    WonBlockRelayPlanner planner(relay);
+
+    const uint256 h = hash_seq(0x44);
+    const BlockType blk = make_block(5);
+    AnnouncePlan ap = planner.plan_announce(std::vector<std::string>{"miner-peer"}, h, blk);
+    ASSERT_EQ(ap.fanout(), 1u);
+
+    // the peer answers our inv with getdata for the same hash
+    ReplyPlan rp = planner.plan_getdata_reply("miner-peer", *make_getdata({inv_block(h)}));
+    ASSERT_EQ(rp.served(), 1u);
+    EXPECT_EQ(rp.slot, "miner-peer");
+    auto parsed = message_block::make(rp.blocks[0]->m_data);
+    EXPECT_EQ(parsed->m_block.m_version,        blk.m_version);
+    EXPECT_EQ(parsed->m_block.m_previous_block, blk.m_previous_block);
+    EXPECT_EQ(parsed->m_block.m_nonce,          blk.m_nonce);
+}


### PR DESCRIPTION
Phase S8 leaf, stacked on #441 (base dash/s8-getdata-dispatch @735fec80).

## What
The last pure rung before the operator-gated broadcaster_full keystone. Binds the relay handshake to the broadcaster live-slot keys, producing a per-slot **send plan**:

- `plan_announce(live_slots, hash, block)` — records the won block (delegates to WonBlockRelay::announce) and returns the single `inv` frame + the de-duped live slot keys to fan it to. One frame, many slots, modelled as frame + recipient list (not N copies).
- `plan_getdata_reply(slot, getdata_msg)` — routes one inbound getdata (delegates to dispatch_getdata) back to the **same** slot: ordered `block` replies + optional `notfound`, tagged with the requesting slot key.

## Scope / non-consensus
Same invariant as the framer (#432) and dispatcher (#441): slot keys are opaque strings, no socket opened, no io_context touched, no block hash recomputed, a block served only if announced. A won block is **recorded even with zero live slots** (the dashd submitblock arm still carries it; a late peer can still getdata it) — recording is decoupled from fan-out. The live plan->socket write path stays in the operator-gated **broadcaster_full** keystone. Header-only, single dash tree, socket-free.

## Evidence
- New `test_dash_block_relay_plan`: **8/8 ctest, Linux x86_64**, real count (run from build/, not CWD-hollow): fan-out + dedupe/skip-empty + zero-slot recording + inv-frame reparse + reply served/notfound/empty-but-tagged + end-to-end announce->getdata->block.
- build.yml allowlist updated on both target lists; CMakeLists target mirrors the dispatch leaf (SCC direct-naming).
- Commit GPG-signed.

Stacked-base: the attribution-gate-only rollup is expected; the full matrix auto-fires on retarget to master once #441 lands. Held for integrator verify -> operator tap. No self-merge.