### PR TITLE
dash(s8): WonBlockRelay <-> broadcaster binding — live-pool fan-out seam + KATs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer test_dash_embedded_relay_e2e test_dash_block_relay_plan test_dash_version_activation_latch \
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer test_dash_embedded_relay_e2e test_dash_block_relay_plan test_dash_version_activation_latch test_dash_block_relay_binding \
                     test_multiaddress_pplns test_pplns_stress \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
@@ -205,7 +205,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer test_dash_embedded_relay_e2e test_dash_block_relay_plan test_dash_version_activation_latch \
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer test_dash_embedded_relay_e2e test_dash_block_relay_plan test_dash_version_activation_latch test_dash_block_relay_binding \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
                     test_v36_script_sorting test_v36_cross_impl_refhash \

--- a/src/impl/dash/block_relay_binding.hpp
+++ b/src/impl/dash/block_relay_binding.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+// Phase S8 — WonBlockRelay <-> DashBroadcaster binding (LEAF).
+//
+// The last PURE rung before the operator-gated broadcaster_full keystone. The
+// planner (block_relay_plan.hpp) builds a won-block fan-out plan against a
+// caller-supplied list of live slot keys; the broadcaster (broadcaster.hpp)
+// owns the actual pool of live "host:port" slots. Neither references the other.
+// This leaf is the thin adapter that joins them:
+//
+//     [DashBroadcaster pool] --live_slot_keys()--> [binding] --> [planner] --> plan
+//
+//   * plan_announce(hash, block)
+//       reads the broadcaster's CURRENT live slot keys and asks the planner to
+//       record the won block and build its inv fan-out plan against THOSE keys
+//       (not a synthetic span). The block is recorded even at zero live slots.
+//   * plan_getdata_reply(slot, getdata_msg)
+//       pass-through to the planner: route ONE inbound getdata back to the slot
+//       that asked.
+//
+// SCOPE / NON-CONSENSUS: identical invariant to the framer/dispatcher/planner.
+// Slot keys are OPAQUE strings owned by the broadcaster pool; this binding opens
+// no socket, touches no io_context, recomputes no hash, and serves a block only
+// if it was announced. The plan is INERT data — the DECISION to walk it and
+// write the frames onto the live slots' sockets (and the dashd submitblock
+// fallback arm) stays in the operator-gated broadcaster_full keystone. The
+// binding only DECIDES recipients from the live pool; it does not transmit.
+// Header-only, single dash tree, socket-free — unit-testable with zero sockets
+// and zero live dashd, like its sibling leaves.
+
+#include "block_relay_plan.hpp"
+#include "broadcaster.hpp"
+
+#include <core/message.hpp>
+#include <core/uint256.hpp>
+
+#include <string>
+
+namespace dash
+{
+
+// Joins a DashBroadcaster's live slot pool to a WonBlockRelayPlanner. Holds both
+// by reference (the broadcaster owns the pool; the planner owns the relay book;
+// the binding is stateless). Pure: opens no socket, recomputes no hash.
+class WonBlockRelayBinding
+{
+public:
+    WonBlockRelayBinding(DashBroadcaster& pool, WonBlockRelayPlanner& planner)
+        : m_pool(pool), m_planner(planner) {}
+
+    // Record the won block and build its fan-out plan against the broadcaster's
+    // CURRENT live slots. Equivalent to pulling broadcaster.live_slot_keys() and
+    // handing it to the planner — so the inv is addressed to exactly the peers
+    // that are live at announce time. Pruned/dead slots are excluded (they fail
+    // the liveness predicate), and the block is still recorded when the pool is
+    // empty: recording is decoupled from fan-out, so the submitblock arm and a
+    // later-connecting peer still carry/serve it.
+    AnnouncePlan plan_announce(const uint256& hash, WonBlockRelay::BlockType block)
+    {
+        const std::vector<std::string> live = m_pool.live_slot_keys();
+        return m_planner.plan_announce(live, hash, std::move(block));
+    }
+
+    // Route an inbound getdata from `slot` back to that same slot. Pass-through
+    // to the planner; the slot key is whichever pool key the connection belongs
+    // to (the keystone supplies it from the receiving socket).
+    ReplyPlan plan_getdata_reply(const std::string& slot,
+                                 const RawMessage& getdata_msg) const
+    {
+        return m_planner.plan_getdata_reply(slot, getdata_msg);
+    }
+
+    // Convenience observer: how many live peers a won block would fan out to
+    // right now, without recording anything. Mirrors the broadcaster predicate.
+    size_t live_fanout() const { return m_pool.live_slot_keys().size(); }
+
+private:
+    DashBroadcaster&      m_pool;
+    WonBlockRelayPlanner& m_planner;
+};
+
+} // namespace dash

--- a/src/impl/dash/broadcaster.hpp
+++ b/src/impl/dash/broadcaster.hpp
@@ -263,6 +263,20 @@ public:
         return n;
     }
 
+    // Opaque "host:port" keys of the LIVE slots, in deterministic (std::map,
+    // sorted) order. The won-block planner fans an inv out to exactly these
+    // keys; this is the read seam that lets the relay binding pull the live
+    // pool WITHOUT touching a socket. Pure: same liveness predicate as
+    // live_count(), no dial, no I/O. broadcaster_full still owns writing the
+    // frames onto the live slot sockets.
+    std::vector<std::string> live_slot_keys() const
+    {
+        std::vector<std::string> keys;
+        for (const auto& [key, slot] : m_slots)
+            if (slot && m_is_live && m_is_live(*slot)) keys.push_back(key);
+        return keys;
+    }
+
     size_t slot_count() const { return m_slots.size(); }
 
     bool has_slot(const std::string& key) const { return m_slots.count(key) != 0; }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -543,6 +543,15 @@ if (BUILD_TESTING AND GTest_FOUND)
     )
     target_link_libraries(test_dash_block_relay_plan PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
     gtest_add_tests(test_dash_block_relay_plan "" AUTO)
+    add_executable(test_dash_block_relay_binding test_dash_block_relay_binding.cpp)
+    target_link_libraries(test_dash_block_relay_binding PRIVATE
+        GTest::gtest_main GTest::gtest
+        dash_x11 core
+        nlohmann_json::nlohmann_json
+        ${Boost_LIBRARIES}
+    )
+    target_link_libraries(test_dash_block_relay_binding PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
+    gtest_add_tests(test_dash_block_relay_binding "" AUTO)
 
     add_executable(test_compact_blocks test_compact_blocks.cpp)
     target_link_libraries(test_compact_blocks PRIVATE

--- a/test/test_dash_block_relay_binding.cpp
+++ b/test/test_dash_block_relay_binding.cpp
@@ -1,0 +1,257 @@
+/// Phase S8 — WonBlockRelay <-> DashBroadcaster binding KATs.
+///
+/// Exercises src/impl/dash/block_relay_binding.hpp — the adapter that pulls the
+/// broadcaster's LIVE slot keys and feeds them to the won-block planner, with NO
+/// socket and NO live dashd:
+///
+///   (a) bind_fanout      — announce against a pool of N discovered+live slots
+///                          fans the inv out to exactly those N pool keys, in
+///                          deterministic (sorted) order; the block records.
+///   (b) excludes_dead    — when the liveness predicate flips every slot dead,
+///                          the live view (and thus the fan-out) drops to zero
+///                          even though the slots still occupy the pool.
+///   (c) empty_pool_record— with an empty pool the block is STILL recorded
+///                          (relay.knows == true, pending == 1, fanout == 0):
+///                          recording is decoupled from fan-out.
+///   (d) reply_passthru   — plan_getdata_reply routes a getdata back to its slot
+///                          and serves the announced block.
+///   (e) live_fanout_obs  — live_fanout() reports the recipient count WITHOUT
+///                          recording anything (relay.pending stays 0).
+///
+/// SCOPE NOTE (honest): pure adapter over opaque "host:port" slot keys driven by
+/// the injected liveness predicate. No socket opened, no io_context driven, no
+/// hash recomputed; a block is served only if announced. The live plan -> socket
+/// write + dashd submitblock arm is the operator-gated broadcaster_full concern
+/// and is not claimed here.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/block_relay_binding.hpp>
+#include <impl/dash/block_relay_plan.hpp>
+#include <impl/dash/block_relay.hpp>
+#include <impl/dash/broadcaster.hpp>
+#include <impl/dash/config.hpp>
+#include <impl/dash/coin/p2p_messages.hpp>
+
+#include <core/netaddress.hpp>
+#include <core/uint256.hpp>
+#include <core/pack.hpp>
+
+#include <boost/asio.hpp>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace dash;
+using nlohmann::json;
+using dash::coin::BlockType;
+using dash::coin::p2p::message_getdata;
+using dash::coin::p2p::inventory_type;
+
+namespace {
+
+constexpr uint16_t kCanonicalPort = 19999;
+constexpr char     kPrimaryHost[] = "10.9.9.9";
+
+std::unique_ptr<Config> make_config()
+{
+    auto cfg = std::make_unique<Config>("dash-s8-binding-kat");
+    cfg->coin()->m_p2p.address =
+        NetService{std::string{"127.0.0.1"}, std::to_string(kCanonicalPort)};
+    return cfg;
+}
+
+// Bare-NodeP2P factory (no socket); liveness governed by the injected predicate.
+struct StubFactory {
+    boost::asio::io_context* ioc;
+    DashBroadcaster::Slot operator()(const NetService& /*addr*/)
+    {
+        return std::make_unique<dash::coin::p2p::NodeP2P>(ioc);
+    }
+};
+
+DashBroadcaster make_bcast(boost::asio::io_context& ioc, Config* cfg,
+                           bool* all_live, size_t max_peers)
+{
+    DashBroadcaster b{&ioc, cfg, NetService{std::string{kPrimaryHost},
+                                            std::to_string(kCanonicalPort)},
+                      max_peers};
+    b.set_slot_factory(StubFactory{&ioc});
+    b.set_live_predicate(
+        [all_live](const dash::coin::p2p::NodeP2P&) { return *all_live; });
+    return b;
+}
+
+json peer(const std::string& addr)
+{
+    json p = json::object(); p["addr"] = addr; return p;
+}
+
+uint256 hash_seq(uint8_t base)
+{
+    std::array<uint8_t, 32> p{};
+    for (size_t i = 0; i < 32; ++i) p[i] = static_cast<uint8_t>(base + i);
+    uint256 h; std::memcpy(h.data(), p.data(), 32); return h;
+}
+
+BlockType make_block(uint8_t seed)
+{
+    BlockType b;
+    b.m_version        = 0x20000000u | seed;
+    b.m_previous_block = hash_seq(0x10 + seed);
+    b.m_merkle_root    = hash_seq(0x50 + seed);
+    b.m_timestamp      = 0x5f5e1000u + seed;
+    b.m_bits           = 0x1d00ffffu;
+    b.m_nonce          = 0xdeadbeefu - seed;
+    return b;
+}
+
+inventory_type inv_block(const uint256& h)
+{
+    return inventory_type(inventory_type::block, h);
+}
+
+std::unique_ptr<RawMessage> make_getdata(std::vector<inventory_type> reqs)
+{
+    return message_getdata::make_raw(std::move(reqs));
+}
+
+} // namespace
+
+// (a) bind_fanout: announce reaches every live discovered slot, in pool order ──
+TEST(DashRelayBinding, AnnounceFansOutToLivePool)
+{
+    boost::asio::io_context ioc;
+    auto cfg = make_config();
+    bool all_live = true;
+    DashBroadcaster pool = make_bcast(ioc, cfg.get(), &all_live, /*max_peers*/8);
+
+    json peers = json::array();
+    peers.push_back(peer("1.1.1.1:19999"));
+    peers.push_back(peer("2.2.2.2:19999"));
+    peers.push_back(peer("3.3.3.3:19999"));
+    ASSERT_EQ(pool.discover(peers), 3u);
+    ASSERT_EQ(pool.live_slot_keys().size(), 3u);
+
+    WonBlockRelay relay;
+    WonBlockRelayPlanner planner(relay);
+    WonBlockRelayBinding binding(pool, planner);
+
+    const uint256 h = hash_seq(0x20);
+    AnnouncePlan plan = binding.plan_announce(h, make_block(4));
+
+    EXPECT_TRUE(relay.knows(h));
+    ASSERT_NE(plan.inv, nullptr);
+    EXPECT_EQ(plan.inv->m_command, "inv");
+    ASSERT_EQ(plan.fanout(), 3u);
+    // std::map ordering of the pool keys is deterministic.
+    EXPECT_EQ(plan.slots[0], "1.1.1.1:19999");
+    EXPECT_EQ(plan.slots[1], "2.2.2.2:19999");
+    EXPECT_EQ(plan.slots[2], "3.3.3.3:19999");
+}
+
+// (b) excludes_dead: liveness predicate gates the fan-out, not slot occupancy ──
+TEST(DashRelayBinding, DeadSlotsDropOutOfFanout)
+{
+    boost::asio::io_context ioc;
+    auto cfg = make_config();
+    bool all_live = true;
+    DashBroadcaster pool = make_bcast(ioc, cfg.get(), &all_live, /*max_peers*/8);
+
+    json peers = json::array();
+    peers.push_back(peer("1.1.1.1:19999"));
+    peers.push_back(peer("2.2.2.2:19999"));
+    ASSERT_EQ(pool.discover(peers), 2u);
+    ASSERT_EQ(pool.live_slot_keys().size(), 2u);
+
+    // Connections collapse: every slot now fails the liveness predicate.
+    all_live = false;
+    EXPECT_EQ(pool.live_slot_keys().size(), 0u);
+    EXPECT_EQ(pool.slot_count(), 2u);  // still occupy the pool until pruned
+
+    WonBlockRelay relay;
+    WonBlockRelayPlanner planner(relay);
+    WonBlockRelayBinding binding(pool, planner);
+
+    AnnouncePlan plan = binding.plan_announce(hash_seq(0x30), make_block(1));
+    EXPECT_TRUE(relay.knows(hash_seq(0x30)));  // recorded regardless
+    EXPECT_EQ(plan.fanout(), 0u);              // but nobody live to fan out to
+}
+
+// (c) empty_pool_record: empty pool still records the won block ────────────────
+TEST(DashRelayBinding, EmptyPoolStillRecords)
+{
+    boost::asio::io_context ioc;
+    auto cfg = make_config();
+    bool all_live = true;
+    DashBroadcaster pool = make_bcast(ioc, cfg.get(), &all_live, /*max_peers*/4);
+
+    WonBlockRelay relay;
+    WonBlockRelayPlanner planner(relay);
+    WonBlockRelayBinding binding(pool, planner);
+
+    const uint256 h = hash_seq(0x40);
+    AnnouncePlan plan = binding.plan_announce(h, make_block(2));
+
+    EXPECT_EQ(plan.fanout(), 0u);
+    EXPECT_TRUE(relay.knows(h));
+    EXPECT_EQ(relay.pending(), 1u);
+    ASSERT_NE(plan.inv, nullptr);  // the inv frame exists even with no recipients
+}
+
+// (d) reply_passthru: getdata routed back to its slot, serves announced block ──
+TEST(DashRelayBinding, GetDataReplyRoutesToSlot)
+{
+    boost::asio::io_context ioc;
+    auto cfg = make_config();
+    bool all_live = true;
+    DashBroadcaster pool = make_bcast(ioc, cfg.get(), &all_live, /*max_peers*/4);
+    json peers = json::array();
+    peers.push_back(peer("7.7.7.7:19999"));
+    ASSERT_EQ(pool.discover(peers), 1u);
+
+    WonBlockRelay relay;
+    WonBlockRelayPlanner planner(relay);
+    WonBlockRelayBinding binding(pool, planner);
+
+    const uint256 h = hash_seq(0x55);
+    binding.plan_announce(h, make_block(3));   // record it first
+
+    auto gd = make_getdata({inv_block(h)});
+    ReplyPlan reply = binding.plan_getdata_reply("7.7.7.7:19999", *gd);
+
+    EXPECT_EQ(reply.slot, "7.7.7.7:19999");
+    EXPECT_EQ(reply.served(), 1u);
+    EXPECT_FALSE(reply.has_misses());
+
+    // an unknown hash from the same slot serves nothing and notfounds.
+    ReplyPlan miss = binding.plan_getdata_reply("7.7.7.7:19999",
+                                                *make_getdata({inv_block(hash_seq(0x99))}));
+    EXPECT_EQ(miss.slot, "7.7.7.7:19999");
+    EXPECT_EQ(miss.served(), 0u);
+    EXPECT_TRUE(miss.has_misses());
+}
+
+// (e) live_fanout_obs: observer reports recipients without recording ──────────
+TEST(DashRelayBinding, LiveFanoutObserverDoesNotRecord)
+{
+    boost::asio::io_context ioc;
+    auto cfg = make_config();
+    bool all_live = true;
+    DashBroadcaster pool = make_bcast(ioc, cfg.get(), &all_live, /*max_peers*/4);
+    json peers = json::array();
+    peers.push_back(peer("8.8.8.8:19999"));
+    peers.push_back(peer("9.9.9.9:19999"));
+    ASSERT_EQ(pool.discover(peers), 2u);
+
+    WonBlockRelay relay;
+    WonBlockRelayPlanner planner(relay);
+    WonBlockRelayBinding binding(pool, planner);
+
+    EXPECT_EQ(binding.live_fanout(), 2u);
+    EXPECT_EQ(relay.pending(), 0u);  // nothing recorded by the observer
+}


### PR DESCRIPTION
## S8 — WonBlockRelay ↔ DashBroadcaster binding (LEAF)

The last **pure** rung before the operator-gated `broadcaster_full` keystone. Joins the broadcaster's live slot pool to the won-block planner so the inv fan-out is addressed to the **actual live peers**, not a caller-supplied span.

```
[DashBroadcaster pool] --live_slot_keys()--> [binding] --> [planner] --> plan
```

### Changes
- **`broadcaster.hpp`** — additive `live_slot_keys()` observer: opaque `"host:port"` keys of the LIVE slots, same liveness predicate as `live_count()`. Pure read seam; **no behaviour change** to existing paths.
- **`block_relay_binding.hpp`** (new) — `WonBlockRelayBinding`:
  - `plan_announce(hash, block)` — reads the live pool, records the won block, builds the inv fan-out against those keys. Records even at **zero live slots** (decoupled from fan-out; the dashd submitblock arm still carries it).
  - `plan_getdata_reply(slot, getdata)` — pass-through to the planner.
  - `live_fanout()` — recipient-count observer (records nothing).

### Scope / non-consensus
Socket-free, single dash tree (`src/impl/dash/` + build allowlists only). Opens no socket, drives no `io_context`, recomputes no hash, serves a block only if announced. The live plan→socket write + dashd submitblock fallback stay in the operator-gated `broadcaster_full` keystone.

### Evidence
- `test_dash_block_relay_binding` **5/5 green** — real count, non-hollow (discovery logs show genuine slot creation); run from `build/`.
- Existing `test_dash_broadcaster` **8/8** unaffected by the additive accessor.
- Commit `56c958e7` GPG-good.

Stacked on `dash/s8-relay-plan` (#443). Attribution-gate-only rollup expected while stacked; full matrix auto-fires on retarget once the base chain lands. Held for integrator verify → operator tap — no self-merge.
