### PR TITLE
dash(s8): WonBlock dual-arm delivery plan + reached-network verdict

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer test_dash_embedded_relay_e2e test_dash_block_relay_plan test_dash_version_activation_latch test_dash_block_relay_binding \
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer test_dash_embedded_relay_e2e test_dash_block_relay_plan test_dash_version_activation_latch test_dash_block_relay_binding test_dash_block_relay_dual_arm \
                     test_multiaddress_pplns test_pplns_stress \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
@@ -205,7 +205,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer test_dash_embedded_relay_e2e test_dash_block_relay_plan test_dash_version_activation_latch test_dash_block_relay_binding \
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer test_dash_embedded_relay_e2e test_dash_block_relay_plan test_dash_version_activation_latch test_dash_block_relay_binding test_dash_block_relay_dual_arm \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
                     test_v36_script_sorting test_v36_cross_impl_refhash \

--- a/src/impl/dash/block_relay_dual_arm.hpp
+++ b/src/impl/dash/block_relay_dual_arm.hpp
@@ -1,0 +1,117 @@
+#pragma once
+
+// Phase S8 — WonBlock dual-arm delivery plan + reached-network verdict (LEAF).
+//
+// THE last PURE rung before the operator-gated broadcaster_full keystone. The
+// binding (block_relay_binding.hpp) joins the live broadcaster pool to the
+// planner and yields an AnnouncePlan (one inv frame + the live slot keys). A won
+// block must reach the network by EITHER of two independent arms:
+//
+//     [won block] --+-- embedded-P2P arm  -- inv fan-out to live pool slots
+//                   +-- dashd submitblock  -- raw-block RPC fallback
+//
+// This leaf decides, as INERT data, WHICH arms a given won block is armed on,
+// and (separately) evaluates whether the block actually REACHED the network once
+// the keystone has executed both arms and reported their results. It performs no
+// I/O: it opens no socket, drives no io_context, issues no RPC, recomputes no
+// hash. The keystone walks the plan, writes the inv frames onto the live slots'
+// sockets, calls dashd submitblock with the raw bytes, collects the per-arm
+// results, and hands them back to evaluate() for the won-block-reaches-network
+// verdict. That transmit + RPC is the keystone's operator-gated concern; the
+// DECISION of arms and the verdict LOGIC are pure and unit-testable here, with
+// zero sockets and zero live dashd, like every sibling leaf.
+//
+// SCOPE / NON-CONSENSUS: single dash tree, header-only, socket-free. The raw
+// block bytes are an OPAQUE, caller-supplied blob (the won block as captured for
+// submission, the same span the broadcaster's submit_block_raw_all / FanOutHook
+// already consume) -- they are carried verbatim, NOT re-serialized here, and no
+// consensus value is computed or altered.
+
+#include "block_relay_binding.hpp"
+#include "block_relay_plan.hpp"
+
+#include <core/uint256.hpp>
+
+#include <cstddef>
+#include <span>
+#include <utility>
+#include <vector>
+
+namespace dash
+{
+
+// The dual-arm delivery plan for ONE won block: the embedded-P2P fan-out plan
+// plus the raw block bytes for the dashd submitblock fallback, each tagged with
+// whether that arm is armed. The submitblock arm is armed whenever raw bytes are
+// present, INDEPENDENT of live-slot count -- so a won block with zero live peers
+// still ships via dashd. The P2P arm is armed only when the live pool is
+// non-empty. Both arms are INERT: nothing is transmitted until the keystone
+// walks this plan.
+struct DualArmPlan
+{
+    AnnouncePlan               p2p;                 // inv frame + live slot keys
+    std::vector<unsigned char> submitblock_bytes;   // raw won block (opaque)
+    bool                       p2p_armed{false};     // live pool non-empty
+    bool                       submitblock_armed{false}; // raw bytes present
+
+    // True if the block is armed on at least one arm -- i.e. there is some path
+    // to the network. A won block recorded with no live peers and no raw bytes is
+    // a dead end (caller error); both arms then report false.
+    bool any_armed() const { return p2p_armed || submitblock_armed; }
+};
+
+// The post-execution verdict: did the won block actually reach the network? The
+// keystone fills this in AFTER it has driven both arms, from the real results:
+//   * p2p_acks       -- how many live slots accepted the inv fan-out (>=1 relayed)
+//   * submitblock_ok -- dashd accepted the raw block via the RPC fallback
+// reached_network is the OR of the two arms: a single successful arm suffices.
+struct DeliveryVerdict
+{
+    std::size_t p2p_acks{0};
+    bool        submitblock_ok{false};
+
+    bool reached_network() const { return p2p_acks > 0 || submitblock_ok; }
+};
+
+// Builds dual-arm delivery plans over a binding (which owns the live-pool view
+// and the relay book). Stateless and pure: opens no socket, recomputes no hash.
+class DualArmPlanner
+{
+public:
+    explicit DualArmPlanner(WonBlockRelayBinding& binding) : m_binding(binding) {}
+
+    // Record the won block (via the binding -> planner -> relay) and build its
+    // dual-arm plan against the broadcaster's CURRENT live slots. The raw bytes
+    // are carried verbatim for the dashd submitblock arm and copied into the
+    // plan so it outlives the caller's buffer. The P2P arm is armed iff the live
+    // fan-out is non-empty; the submitblock arm is armed iff raw bytes were
+    // supplied. The block records even when BOTH would be disarmed (recording is
+    // decoupled from delivery), so a peer connecting later can still getdata it.
+    DualArmPlan plan(const uint256& hash,
+                     WonBlockRelay::BlockType block,
+                     std::span<const unsigned char> raw_block_bytes)
+    {
+        DualArmPlan out;
+        out.p2p = m_binding.plan_announce(hash, std::move(block));
+        out.submitblock_bytes.assign(raw_block_bytes.begin(), raw_block_bytes.end());
+        out.p2p_armed         = out.p2p.fanout() > 0;
+        out.submitblock_armed = !out.submitblock_bytes.empty();
+        return out;
+    }
+
+    // Pure verdict evaluator: given the per-arm results the keystone observed,
+    // decide whether the won block reached the network. Static -- it depends only
+    // on the reported results, not on any pool state.
+    static DeliveryVerdict evaluate(std::size_t p2p_acks, bool submitblock_ok)
+    {
+        DeliveryVerdict v;
+        v.p2p_acks       = p2p_acks;
+        v.submitblock_ok = submitblock_ok;
+        return v;
+    }
+
+private:
+    WonBlockRelayBinding& m_binding;
+};
+
+} // namespace dash

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -553,6 +553,16 @@ if (BUILD_TESTING AND GTest_FOUND)
     target_link_libraries(test_dash_block_relay_binding PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
     gtest_add_tests(test_dash_block_relay_binding "" AUTO)
 
+    add_executable(test_dash_block_relay_dual_arm test_dash_block_relay_dual_arm.cpp)
+    target_link_libraries(test_dash_block_relay_dual_arm PRIVATE
+        GTest::gtest_main GTest::gtest
+        dash_x11 core
+        nlohmann_json::nlohmann_json
+        ${Boost_LIBRARIES}
+    )
+    target_link_libraries(test_dash_block_relay_dual_arm PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
+    gtest_add_tests(test_dash_block_relay_dual_arm "" AUTO)
+
     add_executable(test_compact_blocks test_compact_blocks.cpp)
     target_link_libraries(test_compact_blocks PRIVATE
         GTest::gtest_main GTest::gtest

--- a/test/test_dash_block_relay_dual_arm.cpp
+++ b/test/test_dash_block_relay_dual_arm.cpp
@@ -1,0 +1,264 @@
+/// Phase S8 — WonBlock dual-arm delivery plan + reached-network verdict KATs.
+///
+/// Exercises src/impl/dash/block_relay_dual_arm.hpp — the pure planner that
+/// decides which of the two delivery arms (embedded-P2P inv fan-out, dashd
+/// submitblock fallback) a won block is armed on, and the static verdict
+/// evaluator that decides whether the block reached the network once the
+/// keystone has driven both arms. NO socket, NO live dashd:
+///
+///   (a) both_arms        — live pool + raw bytes -> P2P arm armed (fans out to
+///                          the live slots) AND submitblock arm armed; bytes are
+///                          carried verbatim; the block records.
+///   (b) submitblock_only — empty pool but raw bytes present -> P2P arm DISARMED
+///                          (fanout 0) while the submitblock arm STILL carries
+///                          it; the block still records.
+///   (c) p2p_only         — live pool but no raw bytes -> P2P arm armed, submit-
+///                          block arm disarmed.
+///   (d) dead_end_records — neither arm armed -> any_armed()==false, yet the
+///                          block is STILL recorded (recording is decoupled from
+///                          delivery, so a later peer can getdata it).
+///   (e) verdict_logic    — evaluate(): reached via P2P acks alone, via submit-
+///                          block alone, and NOT reached when both arms fail.
+///
+/// SCOPE NOTE (honest): pure decision over an opaque caller-supplied raw-block
+/// blob and the broadcaster's live-slot view. No socket opened, no io_context
+/// driven, no RPC issued, no hash recomputed. The live plan -> socket write, the
+/// dashd submitblock RPC, and collecting the real per-arm results are the
+/// operator-gated broadcaster_full concern and are not claimed here.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/block_relay_dual_arm.hpp>
+#include <impl/dash/block_relay_binding.hpp>
+#include <impl/dash/block_relay_plan.hpp>
+#include <impl/dash/block_relay.hpp>
+#include <impl/dash/broadcaster.hpp>
+#include <impl/dash/config.hpp>
+#include <impl/dash/coin/p2p_messages.hpp>
+
+#include <core/netaddress.hpp>
+#include <core/uint256.hpp>
+
+#include <boost/asio.hpp>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <span>
+#include <string>
+#include <vector>
+
+using namespace dash;
+using nlohmann::json;
+using dash::coin::BlockType;
+
+namespace {
+
+constexpr uint16_t kCanonicalPort = 19999;
+constexpr char     kPrimaryHost[] = "10.9.9.9";
+
+std::unique_ptr<Config> make_config()
+{
+    auto cfg = std::make_unique<Config>("dash-s8-dualarm-kat");
+    cfg->coin()->m_p2p.address =
+        NetService{std::string{"127.0.0.1"}, std::to_string(kCanonicalPort)};
+    return cfg;
+}
+
+struct StubFactory {
+    boost::asio::io_context* ioc;
+    DashBroadcaster::Slot operator()(const NetService& /*addr*/)
+    {
+        return std::make_unique<dash::coin::p2p::NodeP2P>(ioc);
+    }
+};
+
+DashBroadcaster make_bcast(boost::asio::io_context& ioc, Config* cfg,
+                           bool* all_live, size_t max_peers)
+{
+    DashBroadcaster b{&ioc, cfg, NetService{std::string{kPrimaryHost},
+                                            std::to_string(kCanonicalPort)},
+                      max_peers};
+    b.set_slot_factory(StubFactory{&ioc});
+    b.set_live_predicate(
+        [all_live](const dash::coin::p2p::NodeP2P&) { return *all_live; });
+    return b;
+}
+
+json peer(const std::string& addr)
+{
+    json p = json::object(); p["addr"] = addr; return p;
+}
+
+uint256 hash_seq(uint8_t base)
+{
+    std::array<uint8_t, 32> p{};
+    for (size_t i = 0; i < 32; ++i) p[i] = static_cast<uint8_t>(base + i);
+    uint256 h; std::memcpy(h.data(), p.data(), 32); return h;
+}
+
+BlockType make_block(uint8_t seed)
+{
+    BlockType b;
+    b.m_version        = 0x20000000u | seed;
+    b.m_previous_block = hash_seq(0x10 + seed);
+    b.m_merkle_root    = hash_seq(0x50 + seed);
+    b.m_timestamp      = 0x5f5e1000u + seed;
+    b.m_bits           = 0x1d00ffffu;
+    b.m_nonce          = 0xdeadbeefu - seed;
+    return b;
+}
+
+// A stand-in for the won block's raw serialized bytes captured for submission.
+std::vector<unsigned char> raw_bytes(uint8_t seed, size_t n = 80)
+{
+    std::vector<unsigned char> v(n);
+    for (size_t i = 0; i < n; ++i)
+        v[i] = static_cast<unsigned char>(seed + i);
+    return v;
+}
+
+} // namespace
+
+// (a) both_arms ────────────────────────────────────────────────────────────────
+TEST(DashDualArm, BothArmsArmedWithLivePoolAndBytes)
+{
+    boost::asio::io_context ioc;
+    auto cfg = make_config();
+    bool all_live = true;
+    DashBroadcaster pool = make_bcast(ioc, cfg.get(), &all_live, /*max_peers*/8);
+
+    json peers = json::array();
+    peers.push_back(peer("1.1.1.1:19999"));
+    peers.push_back(peer("2.2.2.2:19999"));
+    peers.push_back(peer("3.3.3.3:19999"));
+    ASSERT_EQ(pool.discover(peers), 3u);
+
+    WonBlockRelay relay;
+    WonBlockRelayPlanner planner(relay);
+    WonBlockRelayBinding binding(pool, planner);
+    DualArmPlanner dual(binding);
+
+    const uint256 h = hash_seq(0x20);
+    const std::vector<unsigned char> bytes = raw_bytes(0xA0);
+    DualArmPlan plan = dual.plan(h, make_block(4),
+                                 std::span<const unsigned char>(bytes));
+
+    EXPECT_TRUE(relay.knows(h));
+    EXPECT_TRUE(plan.p2p_armed);
+    EXPECT_TRUE(plan.submitblock_armed);
+    EXPECT_TRUE(plan.any_armed());
+    EXPECT_EQ(plan.p2p.fanout(), 3u);
+    ASSERT_NE(plan.p2p.inv, nullptr);
+    // Raw bytes carried verbatim into the submitblock arm.
+    ASSERT_EQ(plan.submitblock_bytes.size(), bytes.size());
+    EXPECT_EQ(plan.submitblock_bytes, bytes);
+}
+
+// (b) submitblock_only ─────────────────────────────────────────────────────────
+TEST(DashDualArm, SubmitblockOnlyAtZeroLiveSlots)
+{
+    boost::asio::io_context ioc;
+    auto cfg = make_config();
+    bool all_live = true;
+    DashBroadcaster pool = make_bcast(ioc, cfg.get(), &all_live, /*max_peers*/4);
+    // No discover() -> empty live pool.
+
+    WonBlockRelay relay;
+    WonBlockRelayPlanner planner(relay);
+    WonBlockRelayBinding binding(pool, planner);
+    DualArmPlanner dual(binding);
+
+    const uint256 h = hash_seq(0x40);
+    const std::vector<unsigned char> bytes = raw_bytes(0xB0);
+    DualArmPlan plan = dual.plan(h, make_block(2),
+                                 std::span<const unsigned char>(bytes));
+
+    EXPECT_FALSE(plan.p2p_armed);          // nobody live to fan out to
+    EXPECT_EQ(plan.p2p.fanout(), 0u);
+    EXPECT_TRUE(plan.submitblock_armed);   // dashd arm still carries it
+    EXPECT_TRUE(plan.any_armed());
+    EXPECT_TRUE(relay.knows(h));           // recorded regardless
+    EXPECT_EQ(relay.pending(), 1u);
+}
+
+// (c) p2p_only ─────────────────────────────────────────────────────────────────
+TEST(DashDualArm, P2POnlyWhenNoRawBytes)
+{
+    boost::asio::io_context ioc;
+    auto cfg = make_config();
+    bool all_live = true;
+    DashBroadcaster pool = make_bcast(ioc, cfg.get(), &all_live, /*max_peers*/4);
+    json peers = json::array();
+    peers.push_back(peer("5.5.5.5:19999"));
+    ASSERT_EQ(pool.discover(peers), 1u);
+
+    WonBlockRelay relay;
+    WonBlockRelayPlanner planner(relay);
+    WonBlockRelayBinding binding(pool, planner);
+    DualArmPlanner dual(binding);
+
+    const uint256 h = hash_seq(0x60);
+    DualArmPlan plan = dual.plan(h, make_block(5),
+                                 std::span<const unsigned char>());  // no bytes
+
+    EXPECT_TRUE(plan.p2p_armed);
+    EXPECT_EQ(plan.p2p.fanout(), 1u);
+    EXPECT_FALSE(plan.submitblock_armed);
+    EXPECT_TRUE(plan.submitblock_bytes.empty());
+    EXPECT_TRUE(plan.any_armed());
+}
+
+// (d) dead_end_records ─────────────────────────────────────────────────────────
+TEST(DashDualArm, DeadEndStillRecords)
+{
+    boost::asio::io_context ioc;
+    auto cfg = make_config();
+    bool all_live = true;
+    DashBroadcaster pool = make_bcast(ioc, cfg.get(), &all_live, /*max_peers*/4);
+    // empty pool + no bytes.
+
+    WonBlockRelay relay;
+    WonBlockRelayPlanner planner(relay);
+    WonBlockRelayBinding binding(pool, planner);
+    DualArmPlanner dual(binding);
+
+    const uint256 h = hash_seq(0x70);
+    DualArmPlan plan = dual.plan(h, make_block(6),
+                                 std::span<const unsigned char>());
+
+    EXPECT_FALSE(plan.p2p_armed);
+    EXPECT_FALSE(plan.submitblock_armed);
+    EXPECT_FALSE(plan.any_armed());        // dead end: no path to network...
+    EXPECT_TRUE(relay.knows(h));           // ...but the block is still recorded
+    EXPECT_EQ(relay.pending(), 1u);
+}
+
+// (e) verdict_logic ────────────────────────────────────────────────────────────
+TEST(DashDualArm, VerdictReachedViaEitherArm)
+{
+    // P2P alone suffices.
+    DeliveryVerdict v1 = DualArmPlanner::evaluate(/*p2p_acks*/2, /*sb_ok*/false);
+    EXPECT_TRUE(v1.reached_network());
+    EXPECT_EQ(v1.p2p_acks, 2u);
+    EXPECT_FALSE(v1.submitblock_ok);
+
+    // submitblock alone suffices (zero live peers).
+    DeliveryVerdict v2 = DualArmPlanner::evaluate(0, true);
+    EXPECT_TRUE(v2.reached_network());
+    EXPECT_EQ(v2.p2p_acks, 0u);
+    EXPECT_TRUE(v2.submitblock_ok);
+
+    // both arms suceeding still reaches.
+    DeliveryVerdict v3 = DualArmPlanner::evaluate(3, true);
+    EXPECT_TRUE(v3.reached_network());
+}
+
+TEST(DashDualArm, VerdictNotReachedWhenBothFail)
+{
+    DeliveryVerdict v = DualArmPlanner::evaluate(/*p2p_acks*/0, /*sb_ok*/false);
+    EXPECT_FALSE(v.reached_network());
+    EXPECT_EQ(v.p2p_acks, 0u);
+    EXPECT_FALSE(v.submitblock_ok);
+}


### PR DESCRIPTION
S8 leaf, stacked on #444 (dash/s8-relay-binding @56c958e7). THE last pure rung before the operator-gated broadcaster_full keystone.

WHAT: src/impl/dash/block_relay_dual_arm.hpp — DualArmPlanner over the relay binding.
- plan(hash, block, raw_bytes) -> DualArmPlan { AnnouncePlan p2p; vector<uchar> submitblock_bytes; bool p2p_armed; bool submitblock_armed }. P2P arm armed iff live pool non-empty; submitblock arm armed iff raw bytes present (so a won block with zero live peers still ships via dashd). Block records even when both arms disarmed (recording decoupled from delivery).
- static evaluate(p2p_acks, submitblock_ok) -> DeliveryVerdict { reached_network() = acks>0 || submitblock_ok }. Operationalizes the won-block-reaches-network gate as pure logic.

SCOPE / NON-CONSENSUS: single dash tree, header-only, socket-free. Raw block bytes are an OPAQUE caller-supplied blob (same span broadcaster.submit_block_raw_all / FanOutHook already consume) — carried verbatim, NOT re-serialized; no consensus value computed or altered. No socket, no io_context, no RPC, no hash recompute. The live plan->socket write + dashd submitblock RPC + collecting real per-arm results stay in the operator-gated broadcaster_full keystone.

TEST: test/test_dash_block_relay_dual_arm.cpp — 6/6 ctest green non-hollow on Linux x86_64 (both-arms / submitblock-only-at-zero-slots / p2p-only / dead-end-still-records / verdict-reached-via-either / verdict-not-reached). Existing test_dash_block_relay_binding 5/5 unaffected.

Stacked: attribution-gate-only rollup expected; full matrix auto-fires on retarget once #444 base lands. Held for integrator verify -> operator tap. No self-merge.