### PR TITLE
dgb: delegate naughty-propagation onto coin SSOT (byte-identity rewire)

### DIFF
--- a/src/impl/dgb/share_tracker.hpp
+++ b/src/impl/dgb/share_tracker.hpp
@@ -25,6 +25,7 @@ inline uint64_t mul128_shift(uint64_t a, uint64_t b, unsigned shift) {
 #include <impl/nmc/coin/aux_id.hpp>          // nmc::coin::NMC_AUXPOW_CHAIN_ID (v37 bucket-2)
 #include "share_check.hpp"
 #include "think_p1_walk_bounds.hpp"  // SSOT: think_p1_walk_count / think_p1_in_pruning_zone
+#include "coin/naughty_propagation.hpp"  // SSOT: propagate_naughty_from_parent (data.py:543-549)
 #include "config_pool.hpp"
 
 #include <core/target_utils.hpp>
@@ -565,11 +566,13 @@ public:
             share_var.invoke([&](auto* obj) { prev_hash = obj->m_prev_hash; });
             if (!prev_hash.IsNull() && chain.contains(prev_hash)) {
                 auto* parent_idx = chain.get_index(prev_hash);
-                if (parent_idx && parent_idx->naughty > 0) {
-                    auto* my_idx = chain.get_index(share_hash);
-                    if (my_idx) {
-                        my_idx->naughty = parent_idx->naughty + 1;
-                        if (my_idx->naughty > 6) my_idx->naughty = 0; // reset after 6 generations
+                if (parent_idx) {
+                    // Delegate the +1/clamp-at-6 generation arithmetic AND the
+                    // "parent is naughty" guard to the SSOT. nullopt == oracle's
+                    // non-naughty-parent case: leave the child's naughty as-is.
+                    if (auto child = dgb::propagate_naughty_from_parent(parent_idx->naughty)) {
+                        auto* my_idx = chain.get_index(share_hash);
+                        if (my_idx) my_idx->naughty = *child;
                     }
                 }
             }


### PR DESCRIPTION
## What

Byte-identity delegation follow-on to #445. Rewires the inline naughty-propagation ancestor-punishment body in `share_tracker.hpp` onto `dgb::propagate_naughty_from_parent()` (the SSOT landed in #445).

## Why this is value-identical

The SSOT encodes both the generation arithmetic and the oracle `parent is naughty` guard (`p2pool-dgb-scrypt data.py:543-549`):

- engaged `<=>` `parent_idx->naughty > 0` (prior inline guard)
- value `= 1 + parent_naughty`, reset to `0` when `> 6`
- `nullopt` for a non-naughty parent => child counter left **untouched** (never zeroed), exactly the prior `if (... naughty > 0)` branch

No consensus value changes vs the pre-delegation inline path. This is the behavioral-rewire follow-on integrator flagged for separate diffing.

## Scope / isolation

`src/impl/dgb/share_tracker.hpp` only (+1 include, body delegated). `dgb/` per-coin isolation holds; no shared/bitcoin_family or other-coin tree touched.

## Stacking

Base = `dgb/naughty-propagation-ssot` (#445), where the SSOT header lives. Retarget -> master after #445 lands.

## Proof

- `dgb_share_test` 33/33
- `dgb_naughty_propagation_test` 4/4
