### PR TITLE
web(d-web): surface embedded-daemon synced state + tip on topology card

### DIFF
--- a/web-static/dashboard.html
+++ b/web-static/dashboard.html
@@ -2953,8 +2953,20 @@
                 if (c.has_rpc) tags.push('rpc');
                 var tagStr = tags.length ? ' <span style="opacity:0.6;">[' + tags.join(', ') + ']</span>' : '';
                 var peers = (c.peers != null ? c.peers : 0);
+                // Surface the embedded daemon REAL sync state + tip height when the
+                // backend reports them (StatsProvider path emits synced/height per
+                // coin). Only rendered when present -- a coin we hold no handle for
+                // stays silent rather than claim a sync state it cannot read.
+                var sync = '';
+                if (typeof c.synced === 'boolean')
+                    sync = c.synced
+                        ? ' &nbsp;&middot;&nbsp; <span style="color:#3c3;">synced</span>'
+                        : ' &nbsp;&middot;&nbsp; <span style="color:#e90;">syncing</span>';
+                var tip = (c.height != null && c.height > 0)
+                    ? ' &nbsp;&middot;&nbsp; tip ' + c.height : '';
                 return '<div><strong>' + c.coin + '</strong>' + tagStr +
-                       ' &nbsp;&middot;&nbsp; ' + peers + ' peer' + (peers === 1 ? '' : 's') + '</div>';
+                       ' &nbsp;&middot;&nbsp; ' + peers + ' peer' + (peers === 1 ? '' : 's') +
+                       sync + tip + '</div>';
             }).join('');
             document.getElementById('node_topology_coins').innerHTML = rows;
             d3.select('#node_topology_symbol').text(t.node_symbol ? '(' + t.node_symbol + ')' : '');


### PR DESCRIPTION
## What

The node-topology StatsProvider hook (#415) already computes each embedded coin's **real synced flag** and **tip height** from the live handles (LTC `blocks_connected` vs `LTC_MINING_GATE_DEPTH`, DOGE likewise, `embedded_chain->height()`). But the front-end `renderNodeTopology` dropped both fields — the card rendered peers + embedded/rpc tags only.

So the binary knew whether embedded LTC :9333 was synced and at what tip, yet the dashboard never showed it: **real data computed, silently discarded.** That is the founding charter gap (the dashboard must not omit known prod truth — the 2026-06-22 bug was exactly a sync/peer lie).

## Change

Front-end only. Render per coin:
- `synced` → green **synced** / amber **syncing**
- `height` → **tip <n>**

Both gated on the field actually being present — a coin we hold no handle for stays silent rather than claim a state it cannot read (no fabrication).

## Risk / deploy

- Non-consensus web layer. **Static drop-in** (`web-static/dashboard.html`) — deployable via static-swap like #422/#442/#446, no restart.
- No backend or wire change; consumes fields the StatsProvider path already emits.

Serves the LTC per-coin dashboard milestone (embedded LTC :9333 peers/synced/tip).