### PR TITLE
web(d-web): emit primary-coin tip in node_topology auto-detect fallback

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -5215,6 +5215,17 @@ nlohmann::json MiningInterface::rest_node_topology()
     // so a node never advertises a blank primary symbol.
     std::string primary = node_symbol();
 
+    // Primary coin's REAL current block height from the embedded daemon's cached
+    // template -- the same source rest_local_stats uses. Lets the auto-detect
+    // fallback emit "height" (tip) so the topology card shows the primary tip even
+    // when no per-coin StatsProvider hook is wired. (synced still needs the hook.)
+    uint64_t primary_height = 0;
+    {
+        std::lock_guard<std::mutex> lock(m_work_mutex);
+        if (!m_cached_template.is_null() && m_cached_template.contains("height"))
+            primary_height = m_cached_template["height"].get<uint64_t>();
+    }
+
     nlohmann::json coins = nlohmann::json::array();
     auto has_coin = [&](const std::string& sym) {
         for (const auto& c : coins)
@@ -5231,6 +5242,10 @@ nlohmann::json MiningInterface::rest_node_topology()
             // Real embedded/RPC flags for this node's own daemon.
             entry["embedded"] = (m_coin_node && m_coin_node->is_embedded());
             entry["has_rpc"]  = (m_coin_node && m_coin_node->has_rpc());
+            // Truthful tip from the embedded daemon's cached template (front-end
+            // renders it only when > 0, so omit a meaningless 0).
+            if (primary_height > 0)
+                entry["height"] = primary_height;
         }
         coins.push_back(std::move(entry));
     };


### PR DESCRIPTION
## What
The `/api/node_topology` **auto-detect fallback** (the path used when no per-coin StatsProvider hook is wired) emitted `coin/primary/peers/embedded/has_rpc` but never `height` — so the topology card front-end (PR #452) rendered the primary chain with peers but **no tip** on fallback nodes.

This fills the primary coin entry with the embedded daemon's REAL current block height from the cached template (`m_cached_template["height"]` under `m_work_mutex` — the same source `rest_local_stats` already uses), guarded `> 0` to match the front-end's render guard.

## Why (charter)
Charter #2: each node's dashboard must show *that node's* real topology, truthful and sourced from the same internal state debug.log uses. #452 surfaced synced/tip on the front-end, but the backend fallback never emitted tip — a node without the StatsProvider hook showed a less-truthful card than one with it. This closes that gap.

## Scope / safety
- **Web layer only.** No `ICoinNode` interface change → no per-coin / consensus ripple (deliberately avoided, per the BCH-enum-gap precedent).
- `synced` is **not** added here: `is_blockchain_synced()` is declared-but-unimplemented, so a truthful synced flag still requires the StatsProvider hook path. Left as-is rather than emit a fabricated value.
- Builds clean locally (c2pool target links).
