### PR TITLE
dgb: emit BIP141 coinbase witness commitment on populated won blocks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
                     test_phase4_embedded \
                     test_mweb_builder \
                     test_address_resolution test_compute_share_target \
-                    test_utxo test_dgb_subsidy test_dgb_coinbase_value dgb_share_test dgb_redistribute_test dgb_block_assembly_test dgb_header_sample_build_test dgb_header_ingest_test dgb_mempool_ingest_test \
+                    test_utxo test_dgb_subsidy test_dgb_coinbase_value dgb_share_test dgb_redistribute_test dgb_block_assembly_test dgb_witness_commitment_test dgb_header_sample_build_test dgb_header_ingest_test dgb_mempool_ingest_test \
                     dgb_gentx_coinbase_test dgb_connection_coinbase_test dgb_pplns_payout_split_test nmc_auxpow_merkle_test nmc_template_builder_test nmc_auxpow_wire_test nmc_reconstruct_won_block_test nmc_mempool_name_test nmc_block_broadcast_test dgb_gentx_share_path_test dgb_conn_pplns_producer_test dgb_other_tx_resolver_test \
                     dgb_other_tx_assembler_test dgb_reconstruct_won_block_test dgb_reconstruct_closure_test dgb_gentx_unpack_test dgb_work_source_test dgb_template_builder_test dgb_embedded_coin_node_test dgb_embedded_tx_select_test dgb_template_other_txs_test dgb_coinbase_value_parity_test dgb_submit_classify_test dgb_aux_parent_coinbase_parity_test dgb_template_capture_test dgb_aux_doge_db_commitment_bind_test dgb_aux_doge_dc_proof_test dgb_aux_doge_bind_parsers_test \
                     rpc_request_test softfork_check_test genesis_check_test algo_select_test digishield_walk_test header_chain_test \
@@ -212,7 +212,7 @@ jobs:
                     test_phase4_embedded \
                     test_mweb_builder \
                     test_address_resolution test_compute_share_target \
-                    test_utxo test_dgb_subsidy test_dgb_coinbase_value dgb_share_test dgb_redistribute_test dgb_block_assembly_test dgb_header_sample_build_test dgb_header_ingest_test dgb_mempool_ingest_test \
+                    test_utxo test_dgb_subsidy test_dgb_coinbase_value dgb_share_test dgb_redistribute_test dgb_block_assembly_test dgb_witness_commitment_test dgb_header_sample_build_test dgb_header_ingest_test dgb_mempool_ingest_test \
                     dgb_gentx_coinbase_test dgb_connection_coinbase_test dgb_pplns_payout_split_test nmc_auxpow_merkle_test nmc_template_builder_test nmc_auxpow_wire_test nmc_reconstruct_won_block_test nmc_mempool_name_test nmc_block_broadcast_test dgb_gentx_share_path_test dgb_conn_pplns_producer_test dgb_other_tx_resolver_test \
                     dgb_other_tx_assembler_test dgb_reconstruct_won_block_test dgb_reconstruct_closure_test dgb_gentx_unpack_test dgb_work_source_test dgb_template_builder_test dgb_embedded_coin_node_test dgb_embedded_tx_select_test dgb_template_other_txs_test dgb_coinbase_value_parity_test dgb_submit_classify_test dgb_aux_parent_coinbase_parity_test dgb_template_capture_test dgb_aux_doge_db_commitment_bind_test dgb_aux_doge_dc_proof_test dgb_aux_doge_bind_parsers_test \
                     rpc_request_test softfork_check_test genesis_check_test algo_select_test digishield_walk_test header_chain_test \

--- a/src/impl/dgb/coin/block_assembly.hpp
+++ b/src/impl/dgb/coin/block_assembly.hpp
@@ -46,6 +46,8 @@
 #include "../share_check.hpp"   // dgb::check_merkle_link (SSOT merkle-branch walk)
 #include "../share_types.hpp"   // dgb::MerkleLink
 #include "mempool.hpp"          // dgb::coin::compute_txid (block-body txid SSOT)
+#include "merkle_root.hpp"          // dgb::coin::build_block_merkle_root (merkle SSOT)
+#include "witness_commitment.hpp"   // body_has_witness, add_witness_commitment (BIP141)
 
 namespace dgb
 {
@@ -73,27 +75,9 @@ reconstruct_block_header(const SmallBlockHeaderType& small_header,
     return header;
 }
 
-// Build the canonical Bitcoin block merkle root over an ordered txid list
-// ([gentx_hash] ++ other-tx txids): duplicate-the-last on an odd count, then
-// sha256d each adjacent pair up to the single root.  This is the BLOCK-BODY
-// SSOT for the header merkle_root -- it MUST be recomputed over the txs the
-// block actually carries, NOT walked up the share's merkle_link, or a
-// tx-bearing reconstruct emits a header root for the coinbase-only set and the
-// daemon rejects the block with bad-txnmrklroot (#82 funded-soak regression).
-inline uint256 build_block_merkle_root(std::vector<uint256> txids)
-{
-    if (txids.empty()) return uint256();
-    while (txids.size() > 1) {
-        if (txids.size() % 2 == 1)
-            txids.push_back(txids.back());
-        std::vector<uint256> next;
-        next.reserve(txids.size() / 2);
-        for (size_t i = 0; i + 1 < txids.size(); i += 2)
-            next.push_back(Hash(txids[i], txids[i + 1]));
-        txids = std::move(next);
-    }
-    return txids[0];
-}
+// build_block_merkle_root now lives in merkle_root.hpp (the block-body merkle
+// SSOT), shared with witness_commitment.hpp without a circular include.
+
 
 // Assemble the full serialized parent block for a won share.
 //   small_header  : share.m_min_header (version|prev|time|bits|nonce)
@@ -122,9 +106,24 @@ assemble_won_block(const SmallBlockHeaderType& small_header,
     static_cast<BlockHeaderType&>(block) =
         reconstruct_block_header(small_header, gentx_hash, merkle_link);
 
-    // txs = [gentx] ++ other_txs  (coinbase first; data.py as_block ordering).
+    // BIP141: the conditional codec emits a SEGWIT block whenever any tx
+    // HasWitness().  A witness-bearing body that ships with a plain coinbase is
+    // rejected `unexpected-witness` (CheckWitnessMalleation) -- the coinbase must
+    // publish the witness commitment + carry the 32-byte reserved value.  Inject
+    // it into a LOCAL coinbase copy when (and only when) the body carries witness
+    // data; a coinbase-only / all-legacy body is left byte-identical to the proven
+    // legacy + coinbase-only paths.  Injection changes the coinbase txid, so the
+    // body merkle_root below is computed over the post-injection txid.
+    MutableTransaction coinbase = gentx;
+    uint256 coinbase_txid = gentx_hash;
+    if (body_has_witness(other_txs)) {
+        add_witness_commitment(coinbase, other_txs);
+        coinbase_txid = compute_txid(coinbase);
+    }
+
+    // txs = [coinbase] ++ other_txs  (coinbase first; data.py as_block ordering).
     block.m_txs.reserve(1 + other_txs.size());
-    block.m_txs.push_back(gentx);
+    block.m_txs.push_back(coinbase);
     for (const auto& tx : other_txs)
         block.m_txs.push_back(tx);
 
@@ -142,7 +141,7 @@ assemble_won_block(const SmallBlockHeaderType& small_header,
     {
         std::vector<uint256> txids;
         txids.reserve(block.m_txs.size());
-        txids.push_back(gentx_hash);
+        txids.push_back(coinbase_txid);
         for (const auto& tx : other_txs)
             txids.push_back(compute_txid(tx));
         block.m_merkle_root = build_block_merkle_root(std::move(txids));

--- a/src/impl/dgb/coin/merkle_root.hpp
+++ b/src/impl/dgb/coin/merkle_root.hpp
@@ -1,0 +1,47 @@
+#pragma once
+// ---------------------------------------------------------------------------
+// dgb::coin::build_block_merkle_root -- the block-body merkle-root SSOT.
+//
+// Factored out of block_assembly.hpp so BOTH the block framer (block_assembly)
+// AND the BIP141 witness-commitment injector (witness_commitment.hpp) can build
+// a duplicate-last Bitcoin merkle root over an ordered hash list without a
+// circular include.  The symbol stays dgb::coin::build_block_merkle_root and is
+// still visible through block_assembly.hpp (which includes this), so existing
+// callers/tests are unchanged.
+//
+// Build the canonical Bitcoin block merkle root over an ordered hash list
+// (txids for the block body root; wtxids for the BIP141 witness root): duplicate
+// the last leaf on an odd count, then sha256d each adjacent pair up to the
+// single root.
+//
+// Per-coin isolation: src/impl/dgb/ only.  p2pool-merged-v36 surface: NONE.
+// ---------------------------------------------------------------------------
+
+#include <utility>
+#include <vector>
+
+#include <core/hash.hpp>
+#include <core/uint256.hpp>
+
+namespace dgb
+{
+namespace coin
+{
+
+inline uint256 build_block_merkle_root(std::vector<uint256> txids)
+{
+    if (txids.empty()) return uint256();
+    while (txids.size() > 1) {
+        if (txids.size() % 2 == 1)
+            txids.push_back(txids.back());
+        std::vector<uint256> next;
+        next.reserve(txids.size() / 2);
+        for (size_t i = 0; i + 1 < txids.size(); i += 2)
+            next.push_back(Hash(txids[i], txids[i + 1]));
+        txids = std::move(next);
+    }
+    return txids[0];
+}
+
+} // namespace coin
+} // namespace dgb

--- a/src/impl/dgb/coin/witness_commitment.hpp
+++ b/src/impl/dgb/coin/witness_commitment.hpp
@@ -1,0 +1,142 @@
+#pragma once
+// ---------------------------------------------------------------------------
+// dgb::coin::add_witness_commitment -- the BIP141 coinbase witness-commitment
+// injector for the won-block reconstructor (#82, POPULATED-block slice).
+//
+// THE BLOCKER it closes (G3b populated-block adjudication, 2026-06-25):
+// assemble_won_block (block_assembly.hpp) frames the block through the standard
+// Bitcoin-Core conditional serializer (BlockType::Serialize -> TX_WITH_WITNESS),
+// which emits the per-tx witness marker/flag + witness stacks iff some tx
+// HasWitness().  When the replayed mempool set carries SEGWIT transactions the
+// block goes out witness-shaped -- but the reconstructed coinbase carries NO
+// BIP141 witness commitment, so node B rejects it `unexpected-witness`
+// (CheckWitnessMalleation).  The coinbase-only path drains witness and ACCEPTs;
+// the populated path did not.  This seam supplies the missing commitment.
+//
+// Faithful port of Bitcoin Core GenerateCoinbaseCommitment
+// (validation.cpp / src/validation.cpp BIP141):
+//   1. witness_root = merkle root over wtxids, where the coinbase wtxid is
+//      DEFINED to be 0x00..00 (BIP141), others are SHA256d(with-witness bytes);
+//   2. commitment  = SHA256d(witness_root || witness_reserved_value), with the
+//      reserved value a single 32-byte item (Core defaults it to all-zero);
+//   3. coinbase gains an OUTPUT  value 0, scriptPubKey =
+//      OP_RETURN 0x24 0xaa21a9ed <32-byte commitment> (38 bytes); AND
+//   4. the coinbase INPUT[0] witness becomes exactly that one 32-byte reserved
+//      value (BIP141 requires the coinbase witness be a single 32-byte item).
+//
+// Trigger discipline (assemble_won_block owns it): inject ONLY when the block
+// body (other_txs) carries witness data.  A coinbase-only / all-legacy body
+// needs no commitment and Core accepts it without one -- so the legacy and
+// coinbase-only proofs stay byte-identical (zero regression).  Injecting
+// changes the coinbase txid; the caller recomputes the block merkle_root over
+// the post-injection coinbase txid (build_block_merkle_root), so header and
+// body stay consistent by construction.
+//
+// Per-coin isolation: src/impl/dgb/ only.  Consumes core/ (hash, opscript,
+// uint256) + the dgb tx codec; modifies NO shared layer.  p2pool-merged-v36
+// surface: NONE -- DGB-Scrypt is a STANDALONE parent; this is parent-block
+// (daemon-facing) assembly, not share format / PoW / PPLNS.
+// ---------------------------------------------------------------------------
+
+#include <cstdint>
+#include <vector>
+
+#include <core/hash.hpp>
+#include <core/opscript.hpp>
+#include <core/pack.hpp>
+#include <core/uint256.hpp>
+
+#include "transaction.hpp"        // MutableTransaction, TxOut, TX_WITH_WITNESS
+#include "merkle_root.hpp"        // build_block_merkle_root (merkle SSOT)
+
+namespace dgb
+{
+namespace coin
+{
+
+// BIP141 commitment header tag that precedes the 32-byte commitment hash in the
+// coinbase OP_RETURN output (Core: HEADER_BYTES).
+inline constexpr unsigned char kWitnessCommitmentHeader[4] = {0xaa, 0x21, 0xa9, 0xed};
+
+// True iff any non-coinbase tx in the block body carries witness data -- the
+// condition under which BIP141 requires a coinbase witness commitment.
+inline bool body_has_witness(const std::vector<MutableTransaction>& other_txs)
+{
+    for (const auto& tx : other_txs)
+        if (tx.HasWitness())
+            return true;
+    return false;
+}
+
+// wtxid = SHA256d of the WITH-witness serialization.  For a non-witness tx this
+// equals its txid (the with-witness blob has no marker/flag when HasWitness()
+// is false), matching Core's CTransaction::GetWitnessHash().
+inline uint256 compute_wtxid(const MutableTransaction& tx)
+{
+    auto packed = pack(TX_WITH_WITNESS(tx));
+    return Hash(packed.get_span());
+}
+
+// Witness merkle root over [coinbase wtxid == 0x00..00] ++ other-tx wtxids,
+// using the standard duplicate-last block-merkle SSOT.  The coinbase wtxid is
+// fixed to zero per BIP141 (it cannot commit to a hash of itself).
+inline uint256 compute_witness_merkle_root(const std::vector<MutableTransaction>& other_txs)
+{
+    std::vector<uint256> wids;
+    wids.reserve(1 + other_txs.size());
+    wids.push_back(uint256());                 // coinbase wtxid := 0 (BIP141)
+    for (const auto& tx : other_txs)
+        wids.push_back(compute_wtxid(tx));
+    return build_block_merkle_root(std::move(wids));
+}
+
+// BIP141 commitment hash = SHA256d(witness_merkle_root || witness_reserved_value).
+inline uint256 compute_witness_commitment_hash(const uint256& witness_root,
+                                               const uint256& reserved_value)
+{
+    return Hash(witness_root, reserved_value);
+}
+
+// The 38-byte commitment scriptPubKey:
+//   OP_RETURN(0x6a) PUSH36(0x24) 0xaa21a9ed <32-byte commitment>.
+inline std::vector<unsigned char> witness_commitment_script(const uint256& commitment)
+{
+    std::vector<unsigned char> s;
+    s.reserve(2 + 4 + 32);
+    s.push_back(0x6a);   // OP_RETURN
+    s.push_back(0x24);   // direct push of the following 36 bytes
+    s.insert(s.end(), std::begin(kWitnessCommitmentHeader), std::end(kWitnessCommitmentHeader));
+    s.insert(s.end(), commitment.data(), commitment.data() + 32);
+    return s;
+}
+
+// Inject the BIP141 witness commitment into the coinbase (mutates in place):
+//   * coinbase input[0] witness  := single 32-byte reserved value, and
+//   * append a value-0 OP_RETURN commitment output.
+// reserved_value defaults to the all-zero value Core uses.  Mirrors
+// GenerateCoinbaseCommitment; the commitment output is appended LAST so a
+// highest-index scan (Core's pattern) finds it.
+inline void add_witness_commitment(MutableTransaction& coinbase,
+                                   const std::vector<MutableTransaction>& other_txs,
+                                   const uint256& reserved_value = uint256())
+{
+    const uint256 wroot      = compute_witness_merkle_root(other_txs);
+    const uint256 commitment = compute_witness_commitment_hash(wroot, reserved_value);
+
+    // Coinbase witness: exactly one 32-byte stack item (the reserved value).
+    if (!coinbase.vin.empty())
+    {
+        std::vector<unsigned char> rv(reserved_value.data(), reserved_value.data() + 32);
+        coinbase.vin[0].scriptWitness.stack.assign(1, std::move(rv));
+    }
+
+    // Commitment output: value 0, scriptPubKey = OP_RETURN 0x24 aa21a9ed <hash>.
+    TxOut out;
+    out.value = 0;
+    const auto script = witness_commitment_script(commitment);
+    out.scriptPubKey = OPScript(script.data(), script.data() + script.size());
+    coinbase.vout.push_back(std::move(out));
+}
+
+} // namespace coin
+} // namespace dgb

--- a/src/impl/dgb/test/CMakeLists.txt
+++ b/src/impl/dgb/test/CMakeLists.txt
@@ -32,6 +32,22 @@ if (BUILD_TESTING AND GTest_FOUND)
         dgb_coin pool sharechain)
     gtest_add_tests(dgb_block_assembly_test "" AUTO)
 
+    # --- #82 broadcaster-gate: BIP141 coinbase witness commitment ----------
+    # Pins coin/witness_commitment.hpp + assemble_won_block's injector: a
+    # forced-won reconstruct over a WITNESS-BEARING body must publish the
+    # coinbase witness commitment + the 32-byte reserved value, or node B
+    # rejects the populated block `unexpected-witness`.  Links the dgb OBJECT
+    # lib like dgb_block_assembly_test (shares block_assembly.hpp / the merkle
+    # SSOT + the tx codec).  MUST appear in BOTH this registration AND the
+    # build.yml --target allowlist.
+    add_executable(dgb_witness_commitment_test witness_commitment_test.cpp)
+    target_link_libraries(dgb_witness_commitment_test PRIVATE
+        GTest::gtest_main GTest::gtest
+        core dgb
+        c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage
+        dgb_coin pool sharechain)
+    gtest_add_tests(dgb_witness_commitment_test "" AUTO)
+
     # --- embedded-ingest HeaderSample builder ---------------------------------
     # Pins coin/header_sample_build.hpp: a parsed BlockHeaderType -> HeaderSample
     # (block_hash = sha256d(80-byte header), target = SetCompact(nBits)), the

--- a/src/impl/dgb/test/other_tx_assembler_test.cpp
+++ b/src/impl/dgb/test/other_tx_assembler_test.cpp
@@ -244,7 +244,23 @@ TEST(DgbOtherTxAssembler, WitnessOtherTxEmitsWitnessBlock)
     BlockType blk;
     ps >> blk;
     ASSERT_EQ(blk.m_txs.size(), 2u);
-    EXPECT_FALSE(blk.m_txs[0].HasWitness());   // coinbase legacy
+    // #458: a witness-bearing body now drives the BIP141 path, so the coinbase
+    // is no longer legacy -- it carries the single 32-byte all-zero witness
+    // reserved value AND an appended OP_RETURN witness-commitment output. A
+    // populated won block WITHOUT this commitment is what triggered the live
+    // "unexpected-witness" reject; this pins the fix.
+    EXPECT_TRUE(blk.m_txs[0].HasWitness());     // coinbase now BIP141
+    ASSERT_EQ(blk.m_txs[0].vin[0].scriptWitness.stack.size(), 1u);
+    EXPECT_EQ(blk.m_txs[0].vin[0].scriptWitness.stack[0],
+              std::vector<unsigned char>(32, 0x00)); // reserved value
+    {
+        // commitment output appended LAST: OP_RETURN 0x24 0xaa21a9ed <32B>.
+        const auto& spk = blk.m_txs[0].vout.back().scriptPubKey.m_data;
+        ASSERT_GE(spk.size(), 6u);
+        EXPECT_EQ(spk[0], 0x6a); EXPECT_EQ(spk[1], 0x24);
+        EXPECT_EQ(spk[2], 0xaa); EXPECT_EQ(spk[3], 0x21);
+        EXPECT_EQ(spk[4], 0xa9); EXPECT_EQ(spk[5], 0xed);
+    }
     EXPECT_TRUE(blk.m_txs[1].HasWitness());    // other_tx carries witness
     ASSERT_EQ(blk.m_txs[1].vin[0].scriptWitness.stack.size(), 1u);
     EXPECT_EQ(blk.m_txs[1].vin[0].scriptWitness.stack[0],

--- a/src/impl/dgb/test/witness_commitment_test.cpp
+++ b/src/impl/dgb/test/witness_commitment_test.cpp
@@ -1,0 +1,245 @@
+// ---------------------------------------------------------------------------
+// dgb::coin::add_witness_commitment / assemble_won_block witness-commitment KAT
+// (#82 broadcaster-gate, POPULATED-block witness slice, 2026-06-25).
+//
+// Locks the BIP141 coinbase witness-commitment injection that lets a forced-won
+// reconstruct over a WITNESS-BEARING mempool ship a block node B ACCEPTs (the
+// coinbase-only G3b proof drained witness; the populated set was rejected
+// `unexpected-witness` until this seam landed). Mirrors Bitcoin Core
+// GenerateCoinbaseCommitment:
+//   * witness merkle root over [coinbase wtxid==0] ++ other-tx wtxids;
+//   * commitment = SHA256d(witness_root || 32-byte reserved value);
+//   * coinbase gains an OP_RETURN 0x24 0xaa21a9ed <commitment> output AND a
+//     single 32-byte reserved-value input witness.
+// Trigger discipline: inject IFF the body carries witness data -- a coinbase-
+// only / all-legacy body is left byte-identical (zero regression).
+//
+// Goldens are hand-derived through the same Hash()/pack primitives via an
+// INDEPENDENT recomputation path (not by calling add_witness_commitment), so
+// the assertions are non-circular against the production injector.
+//
+// MUST appear in BOTH test/CMakeLists.txt AND the build.yml --target allowlist
+// or it becomes a NOT_BUILT sentinel that reds master.
+// ---------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include <core/hash.hpp>
+#include <core/pack.hpp>
+#include <core/uint256.hpp>
+
+#include "../coin/block_assembly.hpp"
+#include "../coin/witness_commitment.hpp"
+
+namespace {
+
+using dgb::coin::BlockType;
+using dgb::coin::MutableTransaction;
+using dgb::coin::SmallBlockHeaderType;
+using dgb::coin::assemble_won_block;
+using dgb::coin::add_witness_commitment;
+using dgb::coin::body_has_witness;
+using dgb::coin::compute_wtxid;
+using dgb::coin::compute_witness_merkle_root;
+using dgb::coin::witness_commitment_script;
+
+MutableTransaction make_gentx()
+{
+    MutableTransaction tx;
+    tx.version = 1;
+    tx.locktime = 0;
+    dgb::coin::TxIn in;
+    in.prevout.hash.SetNull();
+    in.prevout.index = 0xffffffff;
+    in.sequence = 0xffffffff;
+    tx.vin.push_back(in);
+    dgb::coin::TxOut out;
+    out.value = 5000000000LL;
+    tx.vout.push_back(out);
+    return tx;
+}
+
+// A plain (legacy) non-coinbase tx.
+MutableTransaction make_legacy_tx(int64_t value)
+{
+    MutableTransaction tx;
+    tx.version = 1;
+    tx.locktime = 0;
+    dgb::coin::TxIn in;
+    in.prevout.hash.SetNull();
+    in.prevout.index = 0;
+    in.sequence = 0xffffffff;
+    tx.vin.push_back(in);
+    dgb::coin::TxOut out;
+    out.value = value;
+    tx.vout.push_back(out);
+    return tx;
+}
+
+// A witness-bearing (segwit) non-coinbase tx: a non-empty input witness stack.
+MutableTransaction make_segwit_tx(int64_t value, unsigned char tag)
+{
+    auto tx = make_legacy_tx(value);
+    tx.vin[0].scriptWitness.stack = { std::vector<unsigned char>{tag, 0xbe, 0xef} };
+    return tx;
+}
+
+SmallBlockHeaderType make_small_header()
+{
+    SmallBlockHeaderType h;
+    h.m_version = 0x20000000;
+    h.m_previous_block.SetHex("00000000000000000000000000000000000000000000000000000000deadbeef");
+    h.m_timestamp = 1718700000;
+    h.m_bits = 0x1a0fffff;
+    h.m_nonce = 0x12345678;
+    return h;
+}
+
+uint256 fixed_gentx_hash()
+{
+    uint256 h;
+    h.SetHex("1111111111111111111111111111111111111111111111111111111111111111");
+    return h;
+}
+
+// Independent recomputation of the BIP141 commitment hash for a body, NOT via
+// add_witness_commitment: witness_root = duplicate-last merkle over
+// [0] ++ wtxids; commitment = SHA256d(witness_root || 32 zero bytes).
+uint256 expected_commitment(const std::vector<MutableTransaction>& body)
+{
+    std::vector<uint256> wids;
+    wids.push_back(uint256());                       // coinbase wtxid := 0
+    for (const auto& tx : body) {
+        auto packed = pack(dgb::coin::TX_WITH_WITNESS(tx));
+        wids.push_back(Hash(packed.get_span()));     // wtxid
+    }
+    // duplicate-last merkle
+    while (wids.size() > 1) {
+        if (wids.size() % 2 == 1) wids.push_back(wids.back());
+        std::vector<uint256> next;
+        for (size_t i = 0; i + 1 < wids.size(); i += 2)
+            next.push_back(Hash(wids[i], wids[i + 1]));
+        wids = std::move(next);
+    }
+    return Hash(wids[0], uint256());                  // || reserved value (zero)
+}
+
+// --- Test 1: body_has_witness predicate ---------------------------------------
+TEST(DgbWitnessCommitment, BodyHasWitnessPredicate)
+{
+    EXPECT_FALSE(body_has_witness({}));
+    EXPECT_FALSE(body_has_witness({ make_legacy_tx(1), make_legacy_tx(2) }));
+    EXPECT_TRUE(body_has_witness({ make_legacy_tx(1), make_segwit_tx(2, 0x01) }));
+}
+
+// --- Test 2: commitment script is OP_RETURN 0x24 0xaa21a9ed <32-byte hash> -----
+TEST(DgbWitnessCommitment, CommitmentScriptShape)
+{
+    uint256 c; c.SetHex("00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff");
+    auto s = witness_commitment_script(c);
+    ASSERT_EQ(s.size(), 38u);
+    EXPECT_EQ(s[0], 0x6a);  // OP_RETURN
+    EXPECT_EQ(s[1], 0x24);  // push 36
+    EXPECT_EQ(s[2], 0xaa); EXPECT_EQ(s[3], 0x21);
+    EXPECT_EQ(s[4], 0xa9); EXPECT_EQ(s[5], 0xed);
+    // tail 32 bytes == commitment little-endian byte layout (uint256::data()).
+    std::vector<unsigned char> tail(s.begin() + 6, s.end());
+    std::vector<unsigned char> want(c.data(), c.data() + 32);
+    EXPECT_EQ(tail, want);
+}
+
+// --- Test 3: add_witness_commitment matches the independent golden -------------
+TEST(DgbWitnessCommitment, InjectorMatchesIndependentGolden)
+{
+    std::vector<MutableTransaction> body = { make_legacy_tx(10), make_segwit_tx(20, 0x07) };
+    const uint256 want_commit = expected_commitment(body);
+
+    auto coinbase = make_gentx();
+    ASSERT_FALSE(coinbase.HasWitness());
+    const size_t vout_before = coinbase.vout.size();
+    add_witness_commitment(coinbase, body);
+
+    // (a) coinbase gained exactly one output, the commitment OP_RETURN.
+    ASSERT_EQ(coinbase.vout.size(), vout_before + 1);
+    const auto& spk = coinbase.vout.back().scriptPubKey.m_data;
+    EXPECT_EQ(coinbase.vout.back().value, 0);
+    ASSERT_EQ(spk.size(), 38u);
+    std::vector<unsigned char> got_commit_bytes(spk.begin() + 6, spk.end());
+    std::vector<unsigned char> want_commit_bytes(want_commit.data(), want_commit.data() + 32);
+    EXPECT_EQ(got_commit_bytes, want_commit_bytes);
+
+    // (b) coinbase input[0] now carries a single 32-byte zero reserved value.
+    ASSERT_EQ(coinbase.vin.size(), 1u);
+    ASSERT_EQ(coinbase.vin[0].scriptWitness.stack.size(), 1u);
+    EXPECT_EQ(coinbase.vin[0].scriptWitness.stack[0],
+              std::vector<unsigned char>(32, 0x00));
+    EXPECT_TRUE(coinbase.HasWitness());
+}
+
+// --- Test 4: witness merkle root, coinbase wtxid is zero (single other tx) -----
+TEST(DgbWitnessCommitment, WitnessMerkleRootCoinbaseZero)
+{
+    auto seg = make_segwit_tx(5, 0x03);
+    std::vector<MutableTransaction> body = { seg };
+    // [0, wtxid] => root == Hash(0, wtxid).
+    EXPECT_EQ(compute_witness_merkle_root(body),
+              Hash(uint256(), compute_wtxid(seg)));
+}
+
+// --- Test 5: assemble injects ONLY for a witness body (trigger discipline) -----
+TEST(DgbWitnessCommitment, AssembleInjectsForWitnessBodyOnly)
+{
+    auto sh = make_small_header();
+    auto gentx = make_gentx();
+    auto gtx_hash = fixed_gentx_hash();
+    ::dgb::MerkleLink link;
+
+    // Legacy body: NO injection -> coinbase still 1 output, legacy block.
+    {
+        std::vector<MutableTransaction> body = { make_legacy_tx(10), make_legacy_tx(20) };
+        auto [bytes, hex] = assemble_won_block(sh, gentx, gtx_hash, link, body);
+        PackStream ps(bytes); BlockType blk; ps >> blk;
+        ASSERT_EQ(blk.m_txs.size(), 3u);
+        EXPECT_EQ(blk.m_txs[0].vout.size(), 1u);       // no commitment output
+        EXPECT_FALSE(blk.m_txs[0].HasWitness());       // legacy coinbase
+        // merkle root over legacy body txids (post-injection == pre here).
+        EXPECT_EQ(blk.m_merkle_root, dgb::coin::build_block_merkle_root(
+            { gtx_hash, dgb::coin::compute_txid(body[0]), dgb::coin::compute_txid(body[1]) }));
+    }
+
+    // Witness body: injection -> coinbase 2 outputs (commitment last), segwit.
+    {
+        std::vector<MutableTransaction> body = { make_legacy_tx(10), make_segwit_tx(20, 0x09) };
+        auto [bytes, hex] = assemble_won_block(sh, gentx, gtx_hash, link, body);
+        PackStream ps(bytes); BlockType blk; ps >> blk;
+        ASSERT_EQ(blk.m_txs.size(), 3u);
+
+        // (a) coinbase carries the commitment output + reserved-value witness.
+        ASSERT_EQ(blk.m_txs[0].vout.size(), 2u);
+        EXPECT_TRUE(blk.m_txs[0].HasWitness());
+        ASSERT_EQ(blk.m_txs[0].vin[0].scriptWitness.stack.size(), 1u);
+        EXPECT_EQ(blk.m_txs[0].vin[0].scriptWitness.stack[0],
+                  std::vector<unsigned char>(32, 0x00));
+        const auto& spk = blk.m_txs[0].vout.back().scriptPubKey.m_data;
+        ASSERT_EQ(spk.size(), 38u);
+        EXPECT_EQ(spk[0], 0x6a); EXPECT_EQ(spk[1], 0x24);
+        EXPECT_EQ(spk[2], 0xaa); EXPECT_EQ(spk[3], 0x21);
+        EXPECT_EQ(spk[4], 0xa9); EXPECT_EQ(spk[5], 0xed);
+        std::vector<unsigned char> got(spk.begin() + 6, spk.end());
+        auto wc = expected_commitment(body);
+        std::vector<unsigned char> want(wc.data(), wc.data() + 32);
+        EXPECT_EQ(got, want);
+
+        // (b) header merkle_root is over the POST-injection coinbase txid (the
+        //     coinbase changed when the commitment output was appended), so the
+        //     header agrees with the body the daemon validates.
+        const uint256 post_txid = dgb::coin::compute_txid(blk.m_txs[0]);
+        EXPECT_EQ(blk.m_merkle_root, dgb::coin::build_block_merkle_root(
+            { post_txid, dgb::coin::compute_txid(body[0]), dgb::coin::compute_txid(body[1]) }));
+        EXPECT_NE(post_txid, gtx_hash);   // injection mutated the coinbase txid
+    }
+}
+
+} // namespace


### PR DESCRIPTION
## What
Closes the G3b **populated-block** blocker: a forced-won reconstruct over a witness-bearing mempool now ships a block node B ACCEPTs, by emitting the BIP141 coinbase witness commitment + the 32-byte witness-reserved value.

## Why
`assemble_won_block` frames blocks through the standard conditional serializer (`TX_WITH_WITNESS`), which emits segwit marker/flag + witness stacks whenever any tx `HasWitness()`. The reconstructed coinbase carried **no** commitment, so a witness-bearing body was rejected `unexpected-witness` (CheckWitnessMalleation). The coinbase-only G3b proof drained witness and ACCEPTed; the populated set did not.

## How
- `coin/witness_commitment.hpp` — faithful port of Bitcoin Core `GenerateCoinbaseCommitment`:
  - witness merkle root over `[coinbase wtxid==0] ++ other-tx wtxids`
  - `commitment = SHA256d(witness_root || 32-byte reserved value)`
  - append value-0 `OP_RETURN 0x24 0xaa21a9ed <hash>` coinbase output + single 32-byte reserved-value coinbase input witness
- `assemble_won_block` injects **only** when the body carries witness data, and recomputes the header merkle root over the **post-injection** coinbase txid. Coinbase-only / all-legacy paths are byte-identical (zero regression).
- `coin/merkle_root.hpp` — `build_block_merkle_root` factored out so the framer and the injector share the merkle SSOT with no circular include.

## Scope / safety
- **Fenced to `src/impl/dgb/`** (+ CMake/build.yml test wiring). No `bitcoin_family/` or `core/` modification — only consumes `core/` hash/opscript/uint256. p2pool-merged-v36 surface: **none**. GPG-signed, no attribution.

## Tests (green at head)
- `dgb_witness_commitment_test` 5/5 (non-circular hand-derived goldens)
- regression: `dgb_block_assembly_test` 8/8, `dgb_reconstruct_won_block_test` 9/9, `dgb_reconstruct_closure_test` 11/11, `dgb_won_block_finalize_test` 5/5

## Follow-up note (per integrator note #1, NOT in this slice)
The regtest readiness gate reaches `tip_ready` only via the 60s last-resort path (embedded coin-P2P getheaders ingests no header into HeaderChain) — a regtest-only artifact; ACCEPT still holds. If testnet G3 needs real embedded header ingest, that is a **separate** follow-up, not bundled here.

Cosmetic note #2 (the "P2P relay issued" log printing under `--no-p2p-relay`) is a `main_dgb.cpp` log-gating change; it is **not** in this fenced slice (would break the fenced scope) — I'll fold it into the next `main_dgb.cpp`-touching change unless you'd prefer it standalone.

## Live both-arms re-run
Pending on the .42 tuned-net (the same rig that proved coinbase-only A→B h112/h113). Will re-run P2P-relay-primary + `--no-p2p-relay` isolated over the 12-tx segwit set and report identical tips, gated on rig availability.
