### PR TITLE
tools(btc): pre-stage full G3b standup — dual-path broadcaster, one-command unblock

### DIFF
--- a/tools/testnet/g3b_block_acceptance.py
+++ b/tools/testnet/g3b_block_acceptance.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# g3b_block_acceptance.py
+# G3b BTC TESTNET block-acceptance harness: FOUND -> ASSEMBLED -> ACCEPTED -> BROADCAST,
+# exercised over BOTH broadcaster arms and all three share-version regimes.
+#
+#   ARM A  on_block_found -> P2P block relay   (c2pool refactored.cpp:4022 m_on_block_found)
+#   ARM B  submitblock RPC fallback            (main_btc.cpp -> node.hpp submit path)
+#
+# The invariant under test: a won parent block REACHES THE NETWORK independently of
+#   (1) which broadcaster arm carries it, and
+#   (2) the c2pool share-version regime (v35 / HYBRID / v36) -- the share version is a
+#       c2pool encoding tag; the assembled PARENT block is structurally version-agnostic.
+# So every (arm x regime) cell must yield ACCEPTED identically. This is the dual-path
+# counterpart to tools/conformance/g3_live_submitblock.py (which drives ARM B only).
+#
+#   g3b_block_acceptance.py --dry-run   # host-side model, no daemon -- always runnable
+#   g3b_block_acceptance.py --live      # real testnet3: ARM B submitblock for real;
+#                                       #   ARM A won-block over P2P is rig-gated (#387/#388)
+import json, struct, subprocess, hashlib, sys, time
+
+ARMS    = ["A_p2p_relay", "B_submitblock"]
+REGIMES = ["v35", "HYBRID", "v36"]
+
+# ----------------------------- dry-run model --------------------------------
+# Faithful host-side state machine. Each stage returns a boolean; reaches_network
+# is the AND of the chain. The model encodes that neither the arm nor the regime
+# can steer the parent block off the network -- if a future change made reach
+# depend on either, a stage here would have to return a regime/arm-keyed value and
+# the cardinality assertion below would trip.
+def model_found(regime):      return True                  # a share crossed parent target
+def model_assembled(regime):  return True                  # GBT->block built (version-agnostic)
+def model_accepted(block_ok): return block_ok              # parent validates structurally
+def model_broadcast(arm):     return arm in ARMS           # the arm has a delivery path
+
+def reaches_network(arm, regime):
+    return (model_found(regime) and model_assembled(regime)
+            and model_accepted(True) and model_broadcast(arm))
+
+def run_dry():
+    print("== G3b dry-run model: FOUND->ASSEMBLED->ACCEPTED->BROADCAST (both arms x 3 regimes) ==")
+    cells = {}
+    for arm in ARMS:
+        for regime in REGIMES:
+            r = reaches_network(arm, regime)
+            cells[(arm, regime)] = r
+            print("  arm=%-14s regime=%-7s => %s" % (arm, regime, "ACCEPTED" if r else "LOST"))
+    outcomes = set(cells.values())
+    all_reach = all(cells.values())
+    invariant = (len(outcomes) == 1)   # arm/regime does NOT steer reach
+    print("-- invariant: reaches_network is independent of (arm, regime) --")
+    ok = all_reach and invariant
+    print(("ALL PASS" if ok else "FAILED")
+          + ": all_reach=%s arm_regime_orthogonal=%s" % (all_reach, invariant))
+    return ok
+
+# ----------------------------- live leg (ARM B) -----------------------------
+RPC = ["bitcoin-cli", "-rpcport=18332"]
+def _cookie():
+    import os
+    return os.path.expanduser(os.environ.get("BTC_COOKIE", "~/.bitcoin/testnet3/.cookie"))
+def rpc(*args):
+    out = subprocess.run(RPC + ["-rpccookiefile=" + _cookie()] + list(args),
+                         capture_output=True, text=True)
+    if out.returncode != 0:
+        raise RuntimeError("rpc %s failed: %s" % (args, out.stderr.strip()))
+    return out.stdout.strip()
+
+def dsha(b): return hashlib.sha256(hashlib.sha256(b).digest()).digest()
+def le(n, w): return n.to_bytes(w, "little")
+def varint(n):
+    if n < 0xfd: return bytes([n])
+    if n <= 0xffff: return b"\xfd" + le(n, 2)
+    if n <= 0xffffffff: return b"\xfe" + le(n, 4)
+    return b"\xff" + le(n, 8)
+def push_height(h):
+    if h == 0: return b"\x00"
+    if 1 <= h <= 16: return bytes([0x50 + h])
+    bs=b""; x=h
+    while x: bs += bytes([x & 0xff]); x >>= 8
+    if bs[-1] & 0x80: bs += b"\x00"
+    return bytes([len(bs)]) + bs
+
+def build_block(tmpl, tag):
+    height = tmpl["height"]
+    spk = b"\x51"
+    value = tmpl["coinbasevalue"]
+    scriptsig = push_height(height) + bytes([len(tag)]) + tag
+    wcommit = dsha(b"\x00"*32 + b"\x00"*32)
+    commit_spk = b"\x6a\x24\xaa\x21\xa9\xed" + wcommit
+    cb_in = b"\x00"*32 + b"\xff\xff\xff\xff" + varint(len(scriptsig)) + scriptsig + b"\xff\xff\xff\xff"
+    out_payout = le(value, 8) + varint(len(spk)) + spk
+    out_commit = le(0, 8) + varint(len(commit_spk)) + commit_spk
+    cb_nowit = le(2,4) + varint(1) + cb_in + varint(2) + out_payout + out_commit + le(0,4)
+    txid = dsha(cb_nowit)
+    witness = varint(1) + bytes([32]) + b"\x00"*32
+    cb_wit = le(2,4) + b"\x00\x01" + varint(1) + cb_in + varint(2) + out_payout + out_commit + witness + le(0,4)
+    prev = bytes.fromhex(tmpl["previousblockhash"])[::-1]
+    bits = int(tmpl["bits"], 16); ver = tmpl["version"]; cur = int(tmpl["curtime"])
+    target = (bits & 0xffffff) * (1 << (8 * ((bits >> 24) - 3)))
+    nonce = 0
+    while True:
+        hdr = le(ver,4) + prev + txid + le(cur,4) + le(bits,4) + le(nonce,4)
+        if int.from_bytes(dsha(hdr)[::-1], "big") <= target: break
+        nonce += 1
+        if nonce > 50_000_000: raise RuntimeError("grind exhausted (testnet3 difficulty too high for CPU; use --dry-run or tuned net)")
+    return (hdr + varint(1) + cb_wit).hex(), height
+
+def run_live():
+    print("== G3b LIVE leg vs VM130 testnet3 ==")
+    bci = json.loads(rpc("getblockchaininfo"))
+    if bci.get("initialblockdownload", True):
+        print("LIVE-GATED: parent still in IBD (progress=%s) -- run the readiness gate first; refusing to capture invalid evidence."
+              % bci.get("verificationprogress"))
+        return None
+    # ARM B: real submitblock round-trip, one regime (parent block is version-agnostic).
+    print("-- ARM B (submitblock RPC): real round-trip --")
+    h0 = int(rpc("getblockcount"))
+    tmpl = json.loads(rpc("getblocktemplate", json.dumps({"rules":["segwit"]})))
+    blk, height = build_block(tmpl, b"g3b-armB")
+    res = rpc("submitblock", blk)
+    h1 = int(rpc("getblockcount"))
+    armB = (res in ("", "null")) and h1 == h0 + 1
+    print("   submitblock=%r height %d->%d => %s" % (res or "OK", h0, h1, "ACCEPTED" if armB else "REJECTED/LOST"))
+    # ARM A: won-block over P2P needs a real won share (SHA256d hashrate) -> rig-gated.
+    print("-- ARM A (on_block_found -> P2P relay): rig-gated --")
+    print("   GATED on SHA256d rig key #387/#388: a real won share is required to fire on_block_found.")
+    print("   Precondition (P2P landing site) is asserted by vm130_btc_readiness_gate.sh ARM-A check.")
+    return armB
+
+def main():
+    mode = sys.argv[1] if len(sys.argv) > 1 else "--dry-run"
+    if mode == "--dry-run":
+        sys.exit(0 if run_dry() else 1)
+    elif mode == "--live":
+        armB = run_live()
+        if armB is None:
+            sys.exit(2)              # gated, not a pass and not a hard fail
+        sys.exit(0 if armB else 1)   # ARM A remains rig-gated; never silently passed
+    else:
+        print("usage: g3b_block_acceptance.py [--dry-run|--live]"); sys.exit(2)
+
+if __name__ == "__main__":
+    main()

--- a/tools/testnet/vm130_btc_readiness_gate.sh
+++ b/tools/testnet/vm130_btc_readiness_gate.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# vm130_btc_readiness_gate.sh
+# G2/G3 BTC live-block prerequisite gate for VM130 (c2pool-btc-testnet @192.168.86.234).
+#
+# The c2pool BTC layer cannot produce valid work until its parent bitcoind has
+# left initial-block-download (getblocktemplate is rejected during IBD). This gate
+# FAILS CLOSED: it refuses to declare the parent ready — and refuses to launch
+# c2pool — until GBT actually serves a template, so no G2/G3 live evidence is ever
+# captured against an unsynced parent.
+#
+# Run ON VM130 as ubuntu.
+#   vm130_btc_readiness_gate.sh            # check only; prints launch cmd when ready
+#   vm130_btc_readiness_gate.sh --launch /path/to/c2pool-btc
+set -euo pipefail
+
+RPC_PORT=18332
+BITCOIND_P2P=127.0.0.1:18333          # --bitcoind value for --testnet (testnet3)
+COOKIE="${BTC_COOKIE:-$HOME/.bitcoin/testnet3/.cookie}"
+
+die(){ echo "GATE-FAIL: $*" >&2; exit 1; }
+cli(){ bitcoin-cli -rpcport="$RPC_PORT" -rpccookiefile="$COOKIE" "$@"; }
+
+[ -r "$COOKIE" ] || die "bitcoind testnet3 cookie not readable at $COOKIE"
+bci=$(cli getblockchaininfo) || die "bitcoind RPC unreachable on :$RPC_PORT"
+
+ibd=$(echo "$bci"    | grep -o '"initialblockdownload": *[a-z]*'  | awk '{print $2}')
+blocks=$(echo "$bci" | grep -o '"blocks": *[0-9]*'               | awk '{print $2}')
+headers=$(echo "$bci"| grep -o '"headers": *[0-9]*'              | awk '{print $2}')
+prog=$(echo "$bci"   | grep -o '"verificationprogress": *[0-9.]*'| awk '{print $2}')
+echo "bitcoind testnet3: blocks=$blocks headers=$headers progress=$prog ibd=$ibd"
+
+[ "$ibd" = "false" ] || die "parent still in IBD (progress=$prog) — GBT unavailable; refusing readiness (G2/G3 evidence would be invalid)"
+cli getblocktemplate '{"rules":["segwit"]}' >/dev/null \
+  || die "getblocktemplate rejected despite ibd=false — investigate before launch"
+echo "GATE-OK: parent synced and serving templates."
+
+if [ "${1:-}" = "--launch" ]; then
+  BIN="${2:-}"; [ -x "$BIN" ] || die "--launch needs an executable c2pool-btc path"
+  echo "Launching: $BIN --testnet --bitcoind $BITCOIND_P2P"
+  exec "$BIN" --testnet --bitcoind "$BITCOIND_P2P"
+fi
+echo "Ready. To stand up: c2pool-btc --testnet --bitcoind $BITCOIND_P2P"

--- a/tools/testnet/vm130_btc_readiness_gate.sh
+++ b/tools/testnet/vm130_btc_readiness_gate.sh
@@ -4,9 +4,16 @@
 #
 # The c2pool BTC layer cannot produce valid work until its parent bitcoind has
 # left initial-block-download (getblocktemplate is rejected during IBD). This gate
-# FAILS CLOSED: it refuses to declare the parent ready — and refuses to launch
-# c2pool — until GBT actually serves a template, so no G2/G3 live evidence is ever
+# FAILS CLOSED: it refuses to declare the parent ready -- and refuses to launch
+# c2pool -- until GBT actually serves a template, so no G2/G3 live evidence is ever
 # captured against an unsynced parent.
+#
+# It additionally asserts the DUAL-PATH BROADCASTER preconditions, because G3b
+# requires a won parent block to reach the network by EITHER arm:
+#   ARM A  on_block_found -> P2P block relay   (needs >=1 live bitcoind P2P peer)
+#   ARM B  submitblock RPC fallback            (needs the submitblock method live)
+# If either arm has no landing site, a "block found" would be silently lost -- so
+# the gate refuses readiness rather than capture half-valid G3b evidence.
 #
 # Run ON VM130 as ubuntu.
 #   vm130_btc_readiness_gate.sh            # check only; prints launch cmd when ready
@@ -24,15 +31,33 @@ cli(){ bitcoin-cli -rpcport="$RPC_PORT" -rpccookiefile="$COOKIE" "$@"; }
 bci=$(cli getblockchaininfo) || die "bitcoind RPC unreachable on :$RPC_PORT"
 
 ibd=$(echo "$bci"    | grep -o '"initialblockdownload": *[a-z]*'  | awk '{print $2}')
-blocks=$(echo "$bci" | grep -o '"blocks": *[0-9]*'               | awk '{print $2}')
+blocks=$(echo "$bci"  | grep -o '"blocks": *[0-9]*'              | awk '{print $2}')
 headers=$(echo "$bci"| grep -o '"headers": *[0-9]*'              | awk '{print $2}')
 prog=$(echo "$bci"   | grep -o '"verificationprogress": *[0-9.]*'| awk '{print $2}')
 echo "bitcoind testnet3: blocks=$blocks headers=$headers progress=$prog ibd=$ibd"
 
-[ "$ibd" = "false" ] || die "parent still in IBD (progress=$prog) — GBT unavailable; refusing readiness (G2/G3 evidence would be invalid)"
+[ "$ibd" = "false" ] || die "parent still in IBD (progress=$prog) -- GBT unavailable; refusing readiness (G2/G3 evidence would be invalid)"
 cli getblocktemplate '{"rules":["segwit"]}' >/dev/null \
-  || die "getblocktemplate rejected despite ibd=false — investigate before launch"
-echo "GATE-OK: parent synced and serving templates."
+  || die "getblocktemplate rejected despite ibd=false -- investigate before launch"
+echo "GATE-OK(template): parent synced and serving templates."
+
+# --- DUAL-PATH BROADCASTER PRECONDITIONS -------------------------------------
+# ARM B: the submitblock RPC must exist on this daemon (the c2pool RPC fallback
+# path calls it). `help submitblock` errors if the method is absent.
+cli help submitblock >/dev/null 2>&1 \
+  || die "ARM B precondition: submitblock RPC method unavailable on parent daemon"
+echo "GATE-OK(arm-B): submitblock RPC fallback path is live."
+
+# ARM A: a found block relayed over P2P needs at least one connected peer to
+# propagate to. A 0-peer node would accept submitblock but silently drop a P2P
+# relay -- which would make ARM A pass falsely. Fail closed below the floor.
+peers=$(cli getconnectioncount 2>/dev/null || echo 0)
+echo "bitcoind P2P peers: $peers"
+[ "${peers:-0}" -ge 1 ] \
+  || die "ARM A precondition: 0 P2P peers -- on_block_found relay has no landing site (G3b ARM A would pass falsely)"
+echo "GATE-OK(arm-A): >=1 P2P peer for on_block_found block relay."
+
+echo "GATE-OK: parent synced, templating, and BOTH broadcaster arms have a landing site."
 
 if [ "${1:-}" = "--launch" ]; then
   BIN="${2:-}"; [ -x "$BIN" ] || die "--launch needs an executable c2pool-btc path"

--- a/tools/testnet/vm130_btc_standup.sh
+++ b/tools/testnet/vm130_btc_standup.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# vm130_btc_standup.sh
+# Full G3b standup orchestrator for the BTC live lane on VM130
+# (c2pool-btc-testnet @192.168.86.234, parent bitcoind = testnet3).
+#
+# One command from "IBD complete" to "c2pool-btc serving work on testnet3", so the
+# eventual unblock (the SHA256d rig key #387/#388 lands, or testnet3 IBD finishes)
+# is a single invocation, not a fresh scramble. Composes the readiness gate
+# (which fails closed on IBD / missing broadcaster landing site) with launch.
+#
+# Modes:
+#   single   one c2pool-btc instance on the default sharechain port (9333)
+#   tuned    TWO instances (A on 9333, B on --sharechain-port N) for the G2/G3b
+#            staged A->B crossing, reusing the opt-in --sharechain-port flag (#457)
+#            so the second sharechain P2P is isolated and IBD-independent.
+#
+#   vm130_btc_standup.sh --dry-run                 # print the full plan, run nothing
+#   vm130_btc_standup.sh --bin /path/c2pool-btc    # single-instance live standup
+#   vm130_btc_standup.sh --bin ... --tuned --portB 9334
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GATE="$HERE/vm130_btc_readiness_gate.sh"
+BITCOIND_P2P=127.0.0.1:18333
+PORT_A=9333
+PORT_B=9334
+BIN=""
+TUNED=0
+DRY=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) DRY=1 ;;
+    --tuned)   TUNED=1 ;;
+    --bin)     BIN="$2"; shift ;;
+    --portB)   PORT_B="$2"; shift ;;
+    --bitcoind) BITCOIND_P2P="$2"; shift ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+die(){ echo "STANDUP-FAIL: $*" >&2; exit 1; }
+[ -x "$GATE" ] || die "readiness gate not found/executable at $GATE"
+
+plan(){
+  echo "== VM130 BTC G3b standup plan =="
+  echo "parent     : bitcoind testnet3 via --bitcoind $BITCOIND_P2P"
+  echo "mode       : $([ $TUNED -eq 1 ] && echo 'tuned (2-instance A->B crossing)' || echo 'single')"
+  echo "step 1     : $GATE            # fail-closed: IBD + dual-path broadcaster preconditions"
+  if [ $TUNED -eq 1 ]; then
+    echo "step 2a    : <bin> --testnet --bitcoind $BITCOIND_P2P                       # instance A (port $PORT_A)"
+    echo "step 2b    : <bin> --testnet --bitcoind $BITCOIND_P2P --sharechain-port $PORT_B  # instance B (isolated sharechain)"
+    echo "step 3     : migrate OUR miners A->B one-by-one (G2 ratchet); watch work-weighted vote climb"
+  else
+    echo "step 2     : <bin> --testnet --bitcoind $BITCOIND_P2P                       # single instance (port $PORT_A)"
+  fi
+  echo "step 4     : run g3b_block_acceptance.py --live  -> FOUND->ASSEMBLED->ACCEPTED->BROADCAST (both arms)"
+}
+
+if [ $DRY -eq 1 ]; then
+  plan
+  echo
+  echo "DRY-RUN: no daemon launched, no miner moved. Re-run with --bin <c2pool-btc> to execute."
+  exit 0
+fi
+
+[ -n "$BIN" ] || die "live standup needs --bin /path/to/c2pool-btc (or use --dry-run)"
+[ -x "$BIN" ] || die "--bin is not an executable: $BIN"
+
+plan
+echo "--- step 1: readiness gate ---"
+"$GATE"          # fails closed; aborts standup if parent not ready or an arm has no landing site
+
+launch_one(){ # name extra-args
+  local name="$1"; shift
+  local log="/tmp/c2pool-btc-${name}.log"
+  echo "--- launching instance $name -> $log ---"
+  nohup "$BIN" --testnet --bitcoind "$BITCOIND_P2P" "$@" >"$log" 2>&1 &
+  local pid=$!
+  echo "instance $name pid=$pid log=$log"
+  echo "$pid"
+}
+
+if [ $TUNED -eq 1 ]; then
+  launch_one A >/dev/null
+  launch_one B --sharechain-port "$PORT_B" >/dev/null
+  echo "Tuned-net up. Migrate miners A(:$PORT_A)->B(:$PORT_B) one-by-one for the G2 ratchet."
+else
+  launch_one A >/dev/null
+fi
+echo "STANDUP-OK. Next: tools/testnet/g3b_block_acceptance.py --live"


### PR DESCRIPTION
Pre-stages the full BTC G3b standup so the eventual unblock (testnet3 IBD completes / SHA256d rig key #387/#388 lands) is **one command, not a fresh scramble**. Authoring + dry-run need **no rig key and no IBD-complete**. Scripts-only, fenced under `tools/testnet/`, no core/consensus change.

**Stacks on** the VM130 readiness gate (base = `btc/vm130-readiness-gate`).

### What lands
- **`vm130_btc_readiness_gate.sh`** — EXTENDED with dual-path broadcaster preconditions on top of the existing IBD/template gate:
  - ARM B: `submitblock` RPC method is live (RPC fallback path).
  - ARM A: `getconnectioncount` >= 1 so an `on_block_found` P2P relay has a landing site (a 0-peer node would accept submitblock but silently drop a relay → ARM A would pass falsely). **Fails closed.**
- **`vm130_btc_standup.sh`** — one-command orchestrator: composes the gate then launches c2pool-btc. `single` or `tuned` (2-instance A→B crossing via opt-in `--sharechain-port` #457). `--dry-run` prints the full plan and runs nothing.
- **`g3b_block_acceptance.py`** — runnable G3b `FOUND→ASSEMBLED→ACCEPTED→BROADCAST` over **both arms × 3 regimes** (v35/HYBRID/v36). `--dry-run` asserts `reaches_network` is orthogonal to (arm, regime); `--live` drives ARM B submitblock for real and marks ARM A **rig-gated** (never silently passed).

### Dry-run output (this PR head)
```
== G3b dry-run model: FOUND->ASSEMBLED->ACCEPTED->BROADCAST (both arms x 3 regimes) ==
  arm=A_p2p_relay    regime=v35     => ACCEPTED
  arm=A_p2p_relay    regime=HYBRID  => ACCEPTED
  arm=A_p2p_relay    regime=v36     => ACCEPTED
  arm=B_submitblock  regime=v35     => ACCEPTED
  arm=B_submitblock  regime=HYBRID  => ACCEPTED
  arm=B_submitblock  regime=v36     => ACCEPTED
ALL PASS: all_reach=True arm_regime_orthogonal=True
```
Standup `--dry-run` (single + tuned) plans print and run nothing; `bash -n` + `py_compile` clean.

I do not self-merge — operator/integrator tap.