### PR TITLE
web(d-web): getinfo poolshares+difficulty from live sharechain, not empty m_node stub

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -2862,6 +2862,21 @@ nlohmann::json MiningInterface::getinfo(const std::string& request_id)
     if (double real_hs = get_pool_hashrate(); real_hs > 0.0)
         pool_hashrate = real_hs;
 
+    // poolshares + difficulty previously came ONLY from the empty m_node stub
+    // (get_total_mining_shares()/get_difficulty_stats() return 0 on the
+    // embedded prod build) -- the same false-zero source as the founding
+    // connections/poolhashps bug. Source them from the live sharechain stats
+    // hook (the truthful source #462 used for stale/DOA): total_shares =
+    // current sharechain length, average_difficulty = PPLNS-window share diff.
+    if (m_sharechain_stats_fn) {
+        auto ss = m_sharechain_stats_fn();
+        if (ss.contains("total_shares") && ss["total_shares"].is_number())
+            total_shares = ss["total_shares"].get<uint64_t>();
+        if (ss.contains("average_difficulty") && ss["average_difficulty"].is_number()
+            && ss["average_difficulty"].get<double>() > 0.0)
+            current_difficulty = ss["average_difficulty"].get<double>();
+    }
+
     // Read block height from cached template
     uint64_t block_height = 0;
     double network_hashps = 0.0;


### PR DESCRIPTION
Charter: a dashboard must never lie about prod health.

## Problem
getinfo overrides connections (share peers) and poolhashps (real attempts/s) from live hooks, but poolshares (total_shares) and difficulty were left reading ONLY the embedded-prod m_node stub (get_total_mining_shares()/get_difficulty_stats()), which returns 0/empty on the unpopulated enhanced_node -- so /api dashboards report poolshares:0 and difficulty:1 while the sharechain is live. Same false-zero class as the founding connections/poolhashps bug.

## Fix
Source both from the live sharechain stats hook (same truthful source the stale/DOA path uses):
- poolshares  <- total_shares (current sharechain length)
- difficulty  <- average_difficulty (PPLNS-window share difficulty)

Guarded by is_number()/>0 so a cold-start empty snapshot never regresses the prior value. Web layer only, non-consensus -> normal merge after CI, surfaced to operator for the web merge-tap.

## Scope
getinfo only. The getstats twin (mining_shares/difficulty) has the same gap but overlaps in-flight #462 (getstats stale/DOA); it stacks on #462 after merge to keep this slice conflict-free.

## Test
Local Debug build links clean; full CI on this PR.