### PR TITLE
web: getpeerinfo returns real share-peer list, not empty m_node stub

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -3049,10 +3049,21 @@ nlohmann::json MiningInterface::getmessageblob(const std::string& request_id)
 
 nlohmann::json MiningInterface::getpeerinfo(const std::string& request_id)
 {
+    // Prefer the live share-peer hook (real per-peer list from
+    // p2p_node->get_peer_info_json) over the empty m_node stub. On the
+    // embedded prod build m_node->get_connected_peers_count() returns 0 while
+    // the node is fully peered -- the same founding-charter lie that getinfo/
+    // getstats already route around. getpeerinfo must report the real peers.
+    if (m_peer_info_fn) {
+        auto pi = m_peer_info_fn();
+        if (pi.is_array())
+            return pi;
+    }
+
     nlohmann::json peers = nlohmann::json::array();
     if (m_node) {
         size_t count = m_node->get_connected_peers_count();
-        // Return minimal info — detailed peer data requires NodeImpl access
+        // Fallback only (API-only mode, no live hook): minimal aggregate count.
         peers.push_back({
             {"connected_peers", count}
         });


### PR DESCRIPTION
Charter de-stub, same vein as #462 (getstats stale) / #463 (getinfo poolshares/diff).

## Problem
`getpeerinfo` (registered JSON-RPC, web_server.cpp:960) returned `m_node->get_connected_peers_count()`. On the embedded prod build `m_node` is the unpopulated enhanced_node stub, so this reports ~0 peers while the node is fully share-peered -- the founding 0-stub lie, now in the bitcoind-style `getpeerinfo` surface.

## Fix
Prefer the live `m_peer_info_fn()` (`p2p_node->get_peer_info_json()`) -- the real per-peer list already used by getinfo/getstats -- and return it directly. The minimal `m_node` aggregate-count path is kept only as the API-only-mode fallback (no live hook wired).

## Scope
Web/JSON-API layer only, non-consensus. No consensus or wire change. Builds clean (c2pool target linked locally).

Web-on-prod => operator merge-tap awareness once CI is CLEAN.