### PR TITLE
dash(v36-migration): Component A persisted activation latch (VOTING/ACTIVATED/CONFIRMED)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer test_dash_embedded_relay_e2e test_dash_block_relay_plan \
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer test_dash_embedded_relay_e2e test_dash_block_relay_plan test_dash_version_activation_latch \
                     test_multiaddress_pplns test_pplns_stress \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
@@ -205,7 +205,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer test_dash_embedded_relay_e2e test_dash_block_relay_plan \
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer test_dash_embedded_relay_e2e test_dash_block_relay_plan test_dash_version_activation_latch \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
                     test_v36_script_sorting test_v36_cross_impl_refhash \

--- a/src/impl/dash/version_activation_latch.hpp
+++ b/src/impl/dash/version_activation_latch.hpp
@@ -1,0 +1,127 @@
+#pragma once
+
+// Dash v36 activation LATCH — the persisted VOTING -> ACTIVATED -> CONFIRMED
+// state machine that Component A of the v36-migration-mechanism-standard
+// requires and that DASH previously lacked.
+//
+// version_negotiation.hpp computes the v36-active verdict LIVE from chain
+// ancestry every call (v36_active(weights) -- the 95% weighted gate). That is
+// correct for a continuously-running supervised node, but an UNSUPERVISED node
+// that restarts recomputes the verdict from whatever window it currently holds
+// and can therefore FLAP: a transient dip below 95% (reorg, partial sync) would
+// read as "not active" even though the chain had already crossed and confirmed.
+//
+// The latch fixes that by recording the crossing as durable state:
+//
+//   VOTING     v36 has not yet held the 95% weighted gate.
+//   ACTIVATED  v36_active first observed true; activation height recorded. The
+//              chain has crossed but the crossing is not yet irreversible — if
+//              signaling falls back below 95% before it is sustained, the latch
+//              reverts to VOTING (the activation was not real / was reorged out).
+//   CONFIRMED  v36_active held continuously for 2 * CHAIN_LENGTH ancestors after
+//              activation. IRREVERSIBLE: once confirmed the latch never reverts,
+//              even if a later window dips below 95%. This is the value that is
+//              persisted so a restart reloads "confirmed" instead of recomputing.
+//
+// 3-bucket classification (operator 2026-06-17): this is a v36-NATIVE SHARED
+// STRUCTURE (Bucket 2) — the activation-latch shape is identical across coins
+// and standardizes toward the v37 unified multichain datastructure. It carries
+// NO per-coin isolation primitive (no PREFIX/IDENTIFIER) and is NOT pre-v36
+// transition compat. Pure + scaffolding-only: it owns no chain handle and has no
+// live share_check caller yet (the caller feeds it the already-computed
+// v36_active boolean), so it is socket-free testable and zero consensus risk.
+
+#include "config_pool.hpp"   // dash::PoolConfig::CHAIN_LENGTH
+
+#include <nlohmann/json.hpp>
+
+#include <cstdint>
+#include <string>
+
+namespace dash::version_activation_latch
+{
+
+enum class LatchState : uint8_t {
+    Voting    = 0,  // 95% weighted gate not yet held
+    Activated = 1,  // gate first held; crossing not yet irreversible
+    Confirmed = 2,  // gate held for 2*CHAIN_LENGTH after activation -- latched
+};
+
+inline const char* to_string(LatchState s)
+{
+    switch (s) {
+        case LatchState::Voting:    return "VOTING";
+        case LatchState::Activated: return "ACTIVATED";
+        case LatchState::Confirmed: return "CONFIRMED";
+    }
+    return "VOTING";
+}
+
+inline LatchState state_from_string(const std::string& s)
+{
+    if (s == "CONFIRMED") return LatchState::Confirmed;
+    if (s == "ACTIVATED") return LatchState::Activated;
+    return LatchState::Voting;
+}
+
+// The persisted latch. `confirm_span` defaults to 2 * CHAIN_LENGTH per the
+// migration standard; it is a field (not a hard constant) so it round-trips
+// through JSON and so a test can drive a short span without a 4320-deep chain.
+struct ActivationLatch
+{
+    LatchState state          = LatchState::Voting;
+    uint64_t   version        = 36;     // the version this latch tracks activation of
+    uint64_t   activated_height = 0;    // height at which v36_active first held (valid iff != Voting)
+    uint64_t   confirm_span   = 2ull * PoolConfig::CHAIN_LENGTH;  // 2*CHAIN_LENGTH ancestors
+
+    bool is_confirmed() const { return state == LatchState::Confirmed; }
+
+    // Feed one observation: `active` = version_negotiation::v36_active over the
+    // window ending at `height`. Advances the latch deterministically. CONFIRMED
+    // is a sink (never reverts); a pre-confirmation dip reverts ACTIVATED->VOTING.
+    void observe(bool active, uint64_t height)
+    {
+        if (state == LatchState::Confirmed) return;  // irreversible sink
+
+        if (active) {
+            if (state == LatchState::Voting) {
+                state            = LatchState::Activated;
+                activated_height = height;
+            } else if (state == LatchState::Activated) {
+                // confirm once the crossing has been sustained for the full span
+                if (height >= activated_height &&
+                    height - activated_height >= confirm_span) {
+                    state = LatchState::Confirmed;
+                }
+            }
+        } else {
+            // signaling fell back below 95% before the crossing was irreversible
+            if (state == LatchState::Activated) {
+                state            = LatchState::Voting;
+                activated_height = 0;
+            }
+        }
+    }
+
+    nlohmann::json to_json() const
+    {
+        return nlohmann::json{
+            {"state", to_string(state)},
+            {"version", version},
+            {"activated_height", activated_height},
+            {"confirm_span", confirm_span},
+        };
+    }
+
+    static ActivationLatch from_json(const nlohmann::json& j)
+    {
+        ActivationLatch l;
+        l.state            = state_from_string(j.at("state").get<std::string>());
+        l.version          = j.at("version").get<uint64_t>();
+        l.activated_height = j.at("activated_height").get<uint64_t>();
+        l.confirm_span     = j.at("confirm_span").get<uint64_t>();
+        return l;
+    }
+};
+
+} // namespace dash::version_activation_latch

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -456,6 +456,18 @@ if (BUILD_TESTING AND GTest_FOUND)
     target_link_libraries(test_dash_config PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
     gtest_add_tests(test_dash_config "" AUTO)
 
+    # additive: pure persisted activation-latch (header-only version_activation_latch.hpp);
+    # mirrors the test_dash_config link set (nlohmann_json + core), no ltc/pool SCC dependency.
+    add_executable(test_dash_version_activation_latch test_dash_version_activation_latch.cpp)
+    target_link_libraries(test_dash_version_activation_latch PRIVATE
+        GTest::gtest_main GTest::gtest
+        dash_x11 core
+        nlohmann_json::nlohmann_json
+        ${Boost_LIBRARIES}
+    )
+    target_link_libraries(test_dash_version_activation_latch PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
+    gtest_add_tests(test_dash_version_activation_latch "" AUTO)
+
     add_executable(test_dash_broadcaster test_dash_broadcaster.cpp)
     target_link_libraries(test_dash_broadcaster PRIVATE
         GTest::gtest_main GTest::gtest

--- a/test/test_dash_version_activation_latch.cpp
+++ b/test/test_dash_version_activation_latch.cpp
@@ -1,0 +1,117 @@
+/// Phase v36-migration-std — DASH Component A persisted activation LATCH KATs.
+///
+/// Exercises src/impl/dash/version_activation_latch.hpp — the persisted
+/// VOTING -> ACTIVATED -> CONFIRMED state machine the migration standard
+/// requires and that DASH lacked (version_negotiation.hpp computed the
+/// v36-active verdict LIVE every call, so an unsupervised restart could flap).
+///
+/// The latch is fed the already-computed v36_active boolean (decoupled from the
+/// chain) so these KATs are pure + socket-free. They prove:
+///
+///   (1) StartsVoting              — fresh latch is VOTING, not confirmed.
+///   (2) ActivatesOnFirstActive    — first active=true -> ACTIVATED + height.
+///   (3) ConfirmsAfterFullSpan     — active sustained for 2*CHAIN_LENGTH -> CONFIRMED.
+///   (4) DoesNotConfirmEarly       — active for < span stays ACTIVATED.
+///   (5) RevertsWhenActivationLost — active drops before confirm -> back to VOTING.
+///   (6) ConfirmedIsIrreversible   — once CONFIRMED, active=false never reverts.
+///   (7) JsonRoundTrips            — to_json()/from_json() identity across states.
+///   (8) DefaultSpanIsTwoChainLen  — default confirm_span == 2*CHAIN_LENGTH.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/version_activation_latch.hpp>
+#include <impl/dash/config_pool.hpp>
+
+using dash::version_activation_latch::ActivationLatch;
+using dash::version_activation_latch::LatchState;
+
+namespace {
+
+// short span so a KAT need not walk a 4320-deep chain; the span is a field.
+ActivationLatch make_short(uint64_t span)
+{
+    ActivationLatch l;
+    l.confirm_span = span;
+    return l;
+}
+
+} // namespace
+
+TEST(DashVersionActivationLatch, StartsVoting)
+{
+    ActivationLatch l;
+    EXPECT_EQ(l.state, LatchState::Voting);
+    EXPECT_FALSE(l.is_confirmed());
+}
+
+TEST(DashVersionActivationLatch, ActivatesOnFirstActive)
+{
+    auto l = make_short(100);
+    l.observe(true, 1000);
+    EXPECT_EQ(l.state, LatchState::Activated);
+    EXPECT_EQ(l.activated_height, 1000u);
+    EXPECT_FALSE(l.is_confirmed());
+}
+
+TEST(DashVersionActivationLatch, ConfirmsAfterFullSpan)
+{
+    auto l = make_short(100);
+    l.observe(true, 1000);            // ACTIVATED at 1000
+    l.observe(true, 1099);            // span-1 -> still ACTIVATED
+    EXPECT_EQ(l.state, LatchState::Activated);
+    l.observe(true, 1100);            // exactly span -> CONFIRMED
+    EXPECT_EQ(l.state, LatchState::Confirmed);
+    EXPECT_TRUE(l.is_confirmed());
+}
+
+TEST(DashVersionActivationLatch, DoesNotConfirmEarly)
+{
+    auto l = make_short(100);
+    l.observe(true, 1000);
+    l.observe(true, 1050);            // halfway
+    EXPECT_EQ(l.state, LatchState::Activated);
+    EXPECT_FALSE(l.is_confirmed());
+}
+
+TEST(DashVersionActivationLatch, RevertsWhenActivationLost)
+{
+    auto l = make_short(100);
+    l.observe(true, 1000);            // ACTIVATED
+    l.observe(false, 1040);           // dip below 95% before confirm -> revert
+    EXPECT_EQ(l.state, LatchState::Voting);
+    EXPECT_EQ(l.activated_height, 0u);
+}
+
+TEST(DashVersionActivationLatch, ConfirmedIsIrreversible)
+{
+    auto l = make_short(100);
+    l.observe(true, 1000);
+    l.observe(true, 1100);            // CONFIRMED
+    ASSERT_TRUE(l.is_confirmed());
+    l.observe(false, 1200);           // a later dip must NOT un-confirm
+    l.observe(false, 5000);
+    EXPECT_EQ(l.state, LatchState::Confirmed);
+    EXPECT_TRUE(l.is_confirmed());
+}
+
+TEST(DashVersionActivationLatch, JsonRoundTrips)
+{
+    for (LatchState st : {LatchState::Voting, LatchState::Activated, LatchState::Confirmed}) {
+        ActivationLatch l;
+        l.state = st;
+        l.version = 36;
+        l.activated_height = (st == LatchState::Voting) ? 0u : 4242u;
+        l.confirm_span = 777u;
+        ActivationLatch r = ActivationLatch::from_json(l.to_json());
+        EXPECT_EQ(r.state, l.state);
+        EXPECT_EQ(r.version, l.version);
+        EXPECT_EQ(r.activated_height, l.activated_height);
+        EXPECT_EQ(r.confirm_span, l.confirm_span);
+    }
+}
+
+TEST(DashVersionActivationLatch, DefaultSpanIsTwoChainLen)
+{
+    ActivationLatch l;
+    EXPECT_EQ(l.confirm_span, 2ull * dash::PoolConfig::CHAIN_LENGTH);
+}


### PR DESCRIPTION
Closes the Component A gap of the v36-migration-mechanism-standard for DASH.

**Why:** `version_negotiation.hpp` computes the v36-active verdict LIVE every call (95% weighted gate over the current window). An UNSUPERVISED node that restarts recomputes from whatever window it then holds and can FLAP on a transient sub-95% dip (reorg / partial sync) — reading "not active" after the chain had already crossed. Non-blocking for the supervised/coordinated crossing; blocking for unsupervised.

**What:** new additive header `src/impl/dash/version_activation_latch.hpp` — persisted state machine:
- VOTING -> ACTIVATED (v36_active first held; activation height recorded)
- ACTIVATED -> CONFIRMED (held continuously for 2*CHAIN_LENGTH after activation; **irreversible sink**)
- pre-confirmation dip reverts ACTIVATED -> VOTING
- `nlohmann` `to_json`/`from_json` persist the latch across restarts

**Isolation / risk:** pure + scaffolding-only — caller feeds the already-computed `v36_active` boolean, owns no chain handle, no live `share_check` caller, socket-free testable. **Zero edits** to the consensus-bearing `version_negotiation.hpp`. Fence = exactly 4 dash-lane files (header + KAT + test/CMakeLists.txt + build.yml allowlist line). 3-bucket: **Bucket-2 v36-native shared structure** (identical shape cross-coin, standardizes toward v37); carries no per-coin isolation primitive.

**Tests:** `test_dash_version_activation_latch` — 8 KATs, 8/8 green Linux x86_64 (StartsVoting, ActivatesOnFirstActive, ConfirmsAfterFullSpan, DoesNotConfirmEarly, RevertsWhenActivationLost, ConfirmedIsIrreversible, JsonRoundTrips, DefaultSpanIsTwoChainLen). dashd-RPC fallback untouched.

Held for integrator verify + operator tap. No self-merge.