### PR TITLE
nmc(broadcast): guard dual-path legs — throwing sink never drops a won aux block

### DIFF
--- a/src/impl/nmc/coin/block_broadcast.hpp
+++ b/src/impl/nmc/coin/block_broadcast.hpp
@@ -33,6 +33,7 @@
 // ---------------------------------------------------------------------------
 
 #include <cstdint>
+#include <exception>
 #include <functional>
 #include <string>
 #include <vector>
@@ -81,13 +82,24 @@ inline AuxBlockBroadcast broadcast_won_aux_block(const P2pRelaySink& p2p_relay,
 {
     AuxBlockBroadcast r;
 
-    // PRIMARY: embedded P2P relay (fastest propagation).
+    // PRIMARY: embedded P2P relay (fastest propagation). GUARDED: a throwing
+    // relay sink must NOT prevent the always-fire submitauxblock fallback below
+    // -- otherwise a P2P-leg fault silently drops a won block AND skips its
+    // safety net. p2p_sent is only set after the sink returns cleanly.
     if (p2p_relay) {
-        p2p_relay(block_bytes);
-        r.p2p_sent = true;
-        r.landed_first = "p2p";
-        LOG_INFO << "[EMB-NMC] won-aux-block P2P relay issued (" << block_bytes.size()
-                 << " bytes) -- primary path.";
+        try {
+            p2p_relay(block_bytes);
+            r.p2p_sent = true;
+            r.landed_first = "p2p";
+            LOG_INFO << "[EMB-NMC] won-aux-block P2P relay issued (" << block_bytes.size()
+                     << " bytes) -- primary path.";
+        } catch (const std::exception& e) {
+            LOG_ERROR << "[EMB-NMC] won-aux-block P2P relay threw (" << e.what()
+                      << ") -- falling through to submitauxblock RPC fallback.";
+        } catch (...) {
+            LOG_ERROR << "[EMB-NMC] won-aux-block P2P relay threw (non-std) -- "
+                         "falling through to submitauxblock RPC fallback.";
+        }
     } else {
         LOG_WARNING << "[EMB-NMC] won-aux-block: no embedded P2P sink; relying on submitauxblock RPC fallback.";
     }
@@ -96,10 +108,17 @@ inline AuxBlockBroadcast broadcast_won_aux_block(const P2pRelaySink& p2p_relay,
     // after a P2P accept is success, not failure -- the sink uses ignore-failure
     // semantics so a duplicate/already-have never masks the P2P win.
     if (aux_rpc) {
-        r.rpc_ok = aux_rpc(block_hash_hex, auxpow_hex);
-        if (r.rpc_ok && !r.p2p_sent) r.landed_first = "rpc";
-        LOG_INFO << "[EMB-NMC] won-aux-block submitauxblock RPC fallback "
-                 << (r.rpc_ok ? "accept/duplicate" : "no-ack") << ".";
+        try {
+            r.rpc_ok = aux_rpc(block_hash_hex, auxpow_hex);
+            if (r.rpc_ok && !r.p2p_sent) r.landed_first = "rpc";
+            LOG_INFO << "[EMB-NMC] won-aux-block submitauxblock RPC fallback "
+                     << (r.rpc_ok ? "accept/duplicate" : "no-ack") << ".";
+        } catch (const std::exception& e) {
+            LOG_ERROR << "[EMB-NMC] won-aux-block submitauxblock RPC fallback threw ("
+                      << e.what() << ") -- treated as no-ack, P2P win (if any) preserved.";
+        } catch (...) {
+            LOG_ERROR << "[EMB-NMC] won-aux-block submitauxblock RPC fallback threw (non-std) -- treated as no-ack.";
+        }
     } else {
         LOG_WARNING << "[EMB-NMC] won-aux-block: no external namecoind submitauxblock fallback sink wired.";
     }

--- a/src/impl/nmc/test/nmc_block_broadcast_test.cpp
+++ b/src/impl/nmc/test/nmc_block_broadcast_test.cpp
@@ -18,6 +18,8 @@
 
 #include <gtest/gtest.h>
 
+#include <stdexcept>
+
 #include <string>
 #include <vector>
 
@@ -110,4 +112,48 @@ TEST(NmcAuxBlockBroadcast, FallbackNoAckDoesNotMaskP2p) {
     EXPECT_TRUE(r.any());
     EXPECT_STREQ(r.landed_first, "p2p");
     EXPECT_EQ(calls, 1);
+}
+
+
+// 6) PRIMARY-LEG GUARD: a throwing embedded P2P relay sink must NOT prevent the
+//    ALWAYS-fire submitauxblock RPC fallback -- the won aux block still reaches
+//    namecoind via the safety net, p2p_sent stays false (the relay never
+//    actually sent), any()=true (NOT silent-dropped), and the dispatcher does
+//    not propagate the throw. Locks the doc-comment "each leg is guarded so the
+//    dispatcher never throws" contract that the un-guarded impl violated.
+TEST(NmcAuxBlockBroadcast, ThrowingP2pStillFiresRpcFallback) {
+    auto relay = [&](const std::vector<unsigned char>&) {
+        throw std::runtime_error("p2p relay down mid-teardown");
+    };
+    int  calls = 0;
+    auto aux_rpc = [&](const std::string&, const std::string&) { ++calls; return true; };
+
+    nmc::coin::AuxBlockBroadcast r;
+    EXPECT_NO_THROW(r = nmc::coin::broadcast_won_aux_block(relay, aux_rpc,
+                                                           kBytes, kHashHex, kAuxpowHex));
+    EXPECT_FALSE(r.p2p_sent);             // relay threw -> never marked sent
+    EXPECT_TRUE(r.rpc_ok);                // always-fire fallback STILL fired
+    EXPECT_EQ(calls, 1);
+    EXPECT_TRUE(r.any());                 // won block was NOT silent-dropped
+    EXPECT_STREQ(r.landed_first, "rpc");  // fallback carried it
+}
+
+// 7) FALLBACK-LEG GUARD: a throwing submitauxblock RPC sink must not propagate
+//    and must not mask a P2P win already recorded -- rpc_ok=false, the P2P win
+//    still stands (landed_first="p2p", any()=true).
+TEST(NmcAuxBlockBroadcast, ThrowingRpcDoesNotMaskP2pWin) {
+    bool relayed = false;
+    auto relay = [&](const std::vector<unsigned char>&) { relayed = true; };
+    auto aux_rpc = [&](const std::string&, const std::string&) -> bool {
+        throw std::runtime_error("submitauxblock client socket reset");
+    };
+
+    nmc::coin::AuxBlockBroadcast r;
+    EXPECT_NO_THROW(r = nmc::coin::broadcast_won_aux_block(relay, aux_rpc,
+                                                           kBytes, kHashHex, kAuxpowHex));
+    EXPECT_TRUE(relayed);
+    EXPECT_TRUE(r.p2p_sent);
+    EXPECT_FALSE(r.rpc_ok);
+    EXPECT_TRUE(r.any());
+    EXPECT_STREQ(r.landed_first, "p2p");
 }


### PR DESCRIPTION
## What
`broadcast_won_aux_block`'s doc-comment promised "each leg is guarded so the dispatcher never throws," but the impl wrapped neither leg. A throwing embedded **P2P relay** sink propagated out **and** skipped the **always-fire `submitauxblock` RPC fallback** — a P2P-leg fault would silently drop a won aux block (lost subsidy) and runtime-remove the external-namecoind safety net that must never be removed.

## Fix
Wrap each leg in try/catch:
- throwing **P2P relay** → logs ERROR, falls through to the always-fire RPC fallback; `p2p_sent` only set after the sink returns cleanly.
- throwing **RPC** sink → treated as no-ack, never masks a recorded P2P win.

## Tests
+2 guard KATs (`nmc_block_broadcast_test` 5→7), both PASS locally; target already in build.yml allowlist (Linux + ASan) — no NOT_BUILT sentinel.
- `ThrowingP2pStillFiresRpcFallback`: relay throws → fallback fires, landed_first=rpc, any()=true.
- `ThrowingRpcDoesNotMaskP2pWin`: rpc throws → p2p win stands, no propagation.

## Scope
`nmc/`-fenced; consumes core/log only; no PoW/share/commitment/PPLNS surface. DGB/BCH carry the same un-guarded claim — flagged to their stewards as a v36-native dual-path **standardization**, not edited here (per-coin isolation).

Auto-merge OFF — operator/integrator tap.