### PR TITLE
dgb(broadcaster): guard each dual-path leg vs silent won-block drop (NMC #468 mirror)

### DIFF
--- a/src/impl/dgb/coin/block_broadcast.hpp
+++ b/src/impl/dgb/coin/block_broadcast.hpp
@@ -31,6 +31,7 @@
 // ---------------------------------------------------------------------------
 
 #include <cstdint>
+#include <exception>
 #include <functional>
 #include <string>
 #include <vector>
@@ -61,8 +62,11 @@ struct BlockBroadcast
 // Fire a won block down BOTH broadcast paths. `block_bytes` is the pre-
 // serialized block blob the embedded P2P relay sends; `block_hex` is the same
 // block hex for the external submitblock fallback. `p2p_relay` may be empty
-// (no embedded sink yet); `seam` may be null or RPC-less -- each leg is guarded
-// so the dispatcher never throws or dereferences a null sink.
+// (no embedded sink yet); `seam` may be null or RPC-less -- each leg is wrapped
+// in try/catch so a throwing sink can NEVER propagate out of the dispatcher: a
+// throwing P2P leg falls through to the always-fire submitblock RPC fallback
+// (no silent won-block drop / lost subsidy), and a throwing RPC leg is a no-ack
+// that never masks a P2P win. The dispatcher also never dereferences a null sink.
 inline BlockBroadcast broadcast_won_block(const P2pRelaySink& p2p_relay,
                                           core::coin::ICoinNode* seam,
                                           const std::vector<unsigned char>& block_bytes,
@@ -70,13 +74,24 @@ inline BlockBroadcast broadcast_won_block(const P2pRelaySink& p2p_relay,
 {
     BlockBroadcast r;
 
-    // PRIMARY: embedded P2P relay (fastest propagation).
+    // PRIMARY: embedded P2P relay (fastest propagation). Guarded so a throwing
+    // relay sink can NEVER propagate out and skip the always-fire RPC fallback
+    // below -- a P2P-leg fault must degrade to the fallback, not silently drop a
+    // won block (lost subsidy).
     if (p2p_relay) {
-        p2p_relay(block_bytes);
-        r.p2p_sent = true;
-        r.landed_first = "p2p";
-        LOG_INFO << "[EMB-DGB] won-block P2P relay issued (" << block_bytes.size()
-                 << " bytes) -- primary path.";
+        try {
+            p2p_relay(block_bytes);
+            r.p2p_sent = true;
+            r.landed_first = "p2p";
+            LOG_INFO << "[EMB-DGB] won-block P2P relay issued (" << block_bytes.size()
+                     << " bytes) -- primary path.";
+        } catch (const std::exception& e) {
+            LOG_ERROR << "[EMB-DGB] won-block P2P relay threw (" << e.what()
+                      << ") -- falling through to submitblock RPC fallback.";
+        } catch (...) {
+            LOG_ERROR << "[EMB-DGB] won-block P2P relay threw (non-std) -- "
+                         "falling through to submitblock RPC fallback.";
+        }
     } else {
         LOG_WARNING << "[EMB-DGB] won-block: no embedded P2P sink; relying on RPC fallback.";
     }
@@ -85,10 +100,18 @@ inline BlockBroadcast broadcast_won_block(const P2pRelaySink& p2p_relay,
     // after a P2P accept is success, not failure -- ignore_failure=true so a
     // duplicate/already-have does not mask the P2P win.
     if (seam && seam->has_rpc()) {
-        r.rpc_ok = seam->submit_block_hex(block_hex, /*ignore_failure=*/true);
-        if (r.rpc_ok && !r.p2p_sent) r.landed_first = "rpc";
-        LOG_INFO << "[EMB-DGB] won-block submitblock RPC fallback "
-                 << (r.rpc_ok ? "ok/duplicate" : "no-ack") << ".";
+        try {
+            r.rpc_ok = seam->submit_block_hex(block_hex, /*ignore_failure=*/true);
+            if (r.rpc_ok && !r.p2p_sent) r.landed_first = "rpc";
+            LOG_INFO << "[EMB-DGB] won-block submitblock RPC fallback "
+                     << (r.rpc_ok ? "ok/duplicate" : "no-ack") << ".";
+        } catch (const std::exception& e) {
+            LOG_ERROR << "[EMB-DGB] won-block submitblock RPC fallback threw ("
+                      << e.what() << ") -- no-ack; not masking any P2P win.";
+        } catch (...) {
+            LOG_ERROR << "[EMB-DGB] won-block submitblock RPC fallback threw "
+                         "(non-std) -- no-ack; not masking any P2P win.";
+        }
     } else {
         LOG_WARNING << "[EMB-DGB] won-block: no external digibyted-RPC fallback sink wired.";
     }

--- a/src/impl/dgb/test/block_broadcast_test.cpp
+++ b/src/impl/dgb/test/block_broadcast_test.cpp
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -31,6 +32,7 @@ class FakeSeam : public core::coin::ICoinNode {
 public:
     bool rpc_present = true;
     bool submit_ack  = true;
+    bool throw_on_submit = false;
     int  submit_calls = 0;
     bool last_ignore_failure = false;
 
@@ -39,6 +41,7 @@ public:
     bool submit_block_hex(const std::string&, bool ignore_failure) override {
         ++submit_calls;
         last_ignore_failure = ignore_failure;
+        if (throw_on_submit) throw std::runtime_error("submitblock RPC boom");
         return submit_ack;
     }
 
@@ -121,4 +124,44 @@ TEST(DgbBlockBroadcast, FallbackNoAckDoesNotMaskP2p) {
     EXPECT_TRUE(r.any());
     EXPECT_STREQ(r.landed_first, "p2p");
     EXPECT_EQ(seam.submit_calls, 1);
+}
+
+
+// 6) GUARD (NMC #468 mirror -- throw->fallback-fires): the PRIMARY P2P relay
+//    sink THROWS. The dispatcher must NOT propagate; it falls through to the
+//    always-fire submitblock RPC fallback so a P2P-leg fault never silently
+//    drops a won block (lost subsidy) nor removes the external-daemon fallback.
+TEST(DgbBlockBroadcast, P2pThrowFallsThroughToRpcFallback) {
+    auto relay = [&](const std::vector<unsigned char>&) {
+        throw std::runtime_error("p2p relay boom");
+    };
+    FakeSeam seam; seam.rpc_present = true; seam.submit_ack = true;
+
+    dgb::coin::BlockBroadcast r;
+    ASSERT_NO_THROW({ r = dgb::coin::broadcast_won_block(relay, &seam, kBytes, kHex); });
+
+    EXPECT_FALSE(r.p2p_sent);            // a throwing relay did not actually send
+    EXPECT_TRUE(r.rpc_ok);              // fallback STILL fired despite the P2P fault
+    EXPECT_TRUE(r.any());
+    EXPECT_EQ(seam.submit_calls, 1);    // always-fire fallback preserved, not skipped
+    EXPECT_STREQ(r.landed_first, "rpc");
+}
+
+// 7) GUARD (NMC #468 mirror -- throw->p2p-win-preserved): the FALLBACK RPC leg
+//    THROWS. The dispatcher must NOT propagate and must never mask the P2P win:
+//    p2p_sent stays true, rpc_ok=false (a throw is a no-ack).
+TEST(DgbBlockBroadcast, RpcThrowDoesNotMaskP2pWin) {
+    bool relayed = false;
+    auto relay = [&](const std::vector<unsigned char>&) { relayed = true; };
+    FakeSeam seam; seam.rpc_present = true; seam.throw_on_submit = true;
+
+    dgb::coin::BlockBroadcast r;
+    ASSERT_NO_THROW({ r = dgb::coin::broadcast_won_block(relay, &seam, kBytes, kHex); });
+
+    EXPECT_TRUE(relayed);
+    EXPECT_TRUE(r.p2p_sent);            // P2P win preserved through the RPC fault
+    EXPECT_FALSE(r.rpc_ok);            // a throwing RPC leg = no-ack, not a mask
+    EXPECT_TRUE(r.any());
+    EXPECT_STREQ(r.landed_first, "p2p");
+    EXPECT_EQ(seam.submit_calls, 1);   // it was attempted (then threw)
 }


### PR DESCRIPTION
## What

`dgb/coin/block_broadcast.hpp`s doc-contract claimed "each leg is guarded so the dispatcher never throws," but **neither dual-path leg was actually wrapped**. A throwing embedded-P2P relay sink would propagate out **and** skip the always-fire submitblock RPC fallback — silently dropping a won block (lost subsidy) and runtime-removing the external-daemon fallback the broadcaster dual-path gate says must never be removed. This is the IDENTICAL latent defect btc-heap-opt fixed in NMC #468.

## Fix
- **PRIMARY P2P leg** wrapped in try/catch → a throw falls through to the always-fire submitblock RPC fallback (no silent drop); `p2p_sent` stays false.
- **FALLBACK RPC leg** wrapped in try/catch → a throw is a no-ack that never masks a P2P win; the dispatcher never propagates out of either leg.

## Tests (net-new, mirror NMC #468)
- `P2pThrowFallsThroughToRpcFallback` — throw→fallback-fires
- `RpcThrowDoesNotMaskP2pWin` — throw→p2p-win-preserved

`dgb_block_broadcast_test` **7/7** locally (5 prior + 2 net-new). Target already in both build.yml allowlists (lines 87 + 219) → no NOT_BUILT risk.

## Cross-check (task item 3)
RPC fallback is real, not a stub: `rpc.cpp:401 NodeRPC::submit_block_hex` (accepts/logs) ← `coin_node.cpp:37 CoinNode::submit_block_hex` delegates. The guard preserves a **live submitblock**, not just the no-op `!m_rpc` path.

## Scope
v36-native shared-structure standardization (bucket 2 toward v37). FENCED to `src/impl/dgb/` only. p2pool-merged-v36 surface: **NONE** (block dispatch only — no PoW hash, share format, coinbase commitment, or PPLNS math). GPG-signed, no attribution, **auto-merge OFF** — integrator tap-gates the merge.
