### PR TITLE
dashboard(D0.4): per-coin StatsProvider seam for /api/node_topology synced/tip

### DIFF
--- a/src/c2pool/c2pool_refactored.cpp
+++ b/src/c2pool/c2pool_refactored.cpp
@@ -3511,6 +3511,23 @@ int main(int argc, char* argv[]) {
             // coin_peer_sources is declared in outer scope. Add LTC broadcaster.
             if (embedded_broadcaster)
                 coin_peer_sources->push_back(embedded_broadcaster.get());
+            // D0.4 per-coin StatsProvider: LTC plugs its REAL synced/tip from the
+            // same embedded handles debug.log reads (migrated off the former
+            // /api/node_topology LTC special-case). Lifetime mirrors the
+            // topology lambda below, which captures the same handles by ref.
+            if (embedded_broadcaster) {
+                embedded_broadcaster->set_sync_state_fn(
+                    [&ltc_utxo_cache, &embedded_chain]() -> nlohmann::json {
+                        nlohmann::json r = nlohmann::json::object();
+                        int connected = ltc_utxo_cache
+                            ? static_cast<int>(ltc_utxo_cache->blocks_connected()) : 0;
+                        r["synced"] = connected >=
+                            static_cast<int>(core::coin::LTC_MINING_GATE_DEPTH);
+                        if (embedded_chain)
+                            r["height"] = static_cast<int>(embedded_chain->height());
+                        return r;
+                    });
+            }
             web_server.get_mining_interface()->set_coin_peers_fn(
                 [coin_peer_sources]() {
                 nlohmann::json r;
@@ -3568,19 +3585,19 @@ int main(int argc, char* argv[]) {
                     e["primary"]  = (sym == primary);
                     e["embedded"] = true;
                     e["peers"]    = static_cast<int>(bc->connected_count());
-                    // Real synced/tip from the live embedded handles (same reads
-                    // as set_spv_progress_fn) -- never fabricated for a coin we
-                    // hold no handle for.
-                    if (sym == "LTC") {
-                        int connected = ltc_utxo_cache
-                            ? static_cast<int>(ltc_utxo_cache->blocks_connected()) : 0;
-                        e["synced"] = connected >= static_cast<int>(core::coin::LTC_MINING_GATE_DEPTH);
-                        if (embedded_chain)
-                            e["height"] = static_cast<int>(embedded_chain->height());
-                    } else if (sym == "DOGE") {
-                        int connected = doge_utxo_ptr
-                            ? static_cast<int>(doge_utxo_ptr->blocks_connected()) : 0;
-                        e["synced"] = connected >= static_cast<int>(core::coin::DOGE_MINING_GATE_DEPTH);
+                    // D0.4: synced/tip come uniformly from the per-coin
+                    // StatsProvider seam (set_sync_state_fn). Each coin's init
+                    // wires the hook from the SAME live embedded handles
+                    // debug.log uses; a coin with no hook contributes no
+                    // synced/tip key (omitted, never fabricated). This drops the
+                    // former LTC/DOGE-only special-case so every coin plugs in
+                    // the same way.
+                    nlohmann::json ss = bc->sync_state();
+                    if (ss.is_object()) {
+                        if (ss.contains("synced"))
+                            e["synced"] = ss["synced"];
+                        if (ss.contains("height") && ss["height"].is_number())
+                            e["height"] = ss["height"];
                     }
                     coins.push_back(std::move(e));
                 }
@@ -5857,6 +5874,30 @@ int main(int argc, char* argv[]) {
                                      << " → " << local_daemon_str;
                             // Register for /api/coin_peers endpoint
                             coin_peer_sources->push_back(broadcaster.get());
+                            // D0.4 per-coin StatsProvider: DOGE plugs its REAL
+                            // synced flag from its embedded UTXO handle (migrated
+                            // off the topology special-case). DOGE exposes no
+                            // separate tip handle here, so height is omitted --
+                            // never fabricated. Guarded to DOGE since this loop is
+                            // generic over merged coins.
+                            {
+                                std::string msym = cfg.symbol;
+                                for (auto& ch : msym)
+                                    if (ch >= 'a' && ch <= 'z')
+                                        ch = static_cast<char>(ch - 32);
+                                if (msym == "DOGE") {
+                                    broadcaster->set_sync_state_fn(
+                                        [&doge_utxo_ptr]() -> nlohmann::json {
+                                            nlohmann::json r = nlohmann::json::object();
+                                            int connected = doge_utxo_ptr
+                                                ? static_cast<int>(doge_utxo_ptr->blocks_connected())
+                                                : 0;
+                                            r["synced"] = connected >=
+                                                static_cast<int>(core::coin::DOGE_MINING_GATE_DEPTH);
+                                            return r;
+                                        });
+                                }
+                            }
                             merged_broadcasters[cfg.chain_id] = std::move(broadcaster);
                         } else {
                             LOG_WARNING << "Unknown P2P prefix for " << cfg.symbol

--- a/src/c2pool/merged/coin_broadcaster.hpp
+++ b/src/c2pool/merged/coin_broadcaster.hpp
@@ -329,6 +329,21 @@ public:
 
     const std::string& symbol() const { return m_symbol; }
 
+    /// D0.4 per-coin StatsProvider seam. Each coin's init wires this hook so
+    /// the dashboard /api/node_topology can surface the embedded daemon's REAL
+    /// synced flag + tip height for THAT coin -- read from the same handles
+    /// debug.log uses. Unset = unknown: callers omit synced/tip rather than
+    /// fabricate them. Generalizes the prior LTC/DOGE-only special-case so the
+    /// per-coin stewards (BTC/DGB/DASH/BCH) light up their own coin by
+    /// implementing this hook, not by editing the web wiring. Returns a JSON
+    /// object {synced:bool, height:int} (either key optional), or null.
+    using SyncStateFn = std::function<nlohmann::json()>;
+    void set_sync_state_fn(SyncStateFn fn) { m_sync_state_fn = std::move(fn); }
+    nlohmann::json sync_state() const
+    {
+        return m_sync_state_fn ? m_sync_state_fn() : nlohmann::json(nullptr);
+    }
+
     /// Request a full block (MSG_MWEB_BLOCK) from all peers via getdata.
     /// Used after a chain reorg to re-fetch MWEB state for the new tip.
     void request_full_block(const uint256& block_hash)
@@ -567,6 +582,7 @@ private:
 
     boost::asio::io_context& m_ioc;
     std::string m_symbol;
+    SyncStateFn m_sync_state_fn;  // D0.4 per-coin stats seam (optional)
     std::vector<std::byte> m_prefix;
     std::optional<PeerEndpoint> m_local_daemon;  // nullopt = seed-only mode
     CoinPeerManager m_peer_manager;


### PR DESCRIPTION
## What

`/api/node_topology` special-cased `synced`/`tip` for **LTC and DOGE only** (`if sym==LTC ... else if sym==DOGE`). BTC/DGB/DASH/BCH got peer counts + the embedded flag but **never a synced flag or tip** — charter-#2 (per-node truthful dashboard) stalled at two coins.

## Change (web/diagnostic layer only — non-consensus)

- New uniform **per-coin StatsProvider seam** on `CoinBroadcaster`: `set_sync_state_fn()` / `sync_state()` returning `{synced, height}` (either key optional) or null.
- The topology wiring now reads `bc->sync_state()` **uniformly**, dropping the LTC/DOGE special-case branch.
- **Honesty preserved:** unset hook = unknown → the coin contributes no `synced`/`tip` key (omitted, never fabricated) — same charter rule as the rest of the truthful sweep.
- **LTC + DOGE migrated** onto the seam with zero behaviour change: identical `blocks_connected() >= *_MINING_GATE_DEPTH` reads and LTC tip height, from the same live embedded handles debug.log uses. DOGE hook is symbol-guarded (the merged-broadcaster loop is generic).

## Why it matters

Per-coin stewards (BTC/DGB/DASH/BCH) now light up their own coin by calling `set_sync_state_fn()` at their broadcaster init — **no web edit needed**. This is the contract half of the per-coin StatsProvider milestone: web owns the seam, per-coin stewards implement.

## Verification

- Builds clean (`cmake --build . --target c2pool`, exit 0; only pre-existing system-header warnings).
- LTC/DOGE topology output unchanged by construction (same reads, relocated).
