### PR TITLE
web(found-blocks): per-coin block-confirmation timing (stop false orphans on slow chains)

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -4334,13 +4334,23 @@ void MiningInterface::schedule_block_verification(const std::string& block_hash)
             chain_name = m_found_blocks[idx].chain;
     }
 
+    // Per-coin block target (seconds). Confirmation checks below are spaced by
+    // this value, so it MUST track each chain's real block time. Previously only
+    // LTC/DOGE were known and every other coin fell through to 60s -- meaning a
+    // genuine found block on a slow chain (BTC/BCH ~10 min) exhausted all 6
+    // confirmation checks inside ~1 real block and was falsely marked orphaned.
+    // A dashboard must never lie that a real found block was lost.
+    std::string cn = chain_name;
+    if (cn.size() > 1 && cn[0] == 't')   // strip testnet prefix (tLTC, tBTC, ...)
+        cn = cn.substr(1);
     int block_time_sec;
-    if (chain_name == "LTC" || chain_name == "tLTC")
-        block_time_sec = 150;   // 2.5 minutes
-    else if (chain_name == "DOGE")
-        block_time_sec = 60;    // 1 minute
-    else
-        block_time_sec = 60;
+    if      (cn == "LTC")  block_time_sec = 150;   // 2.5 min
+    else if (cn == "DOGE") block_time_sec = 60;    // 1 min
+    else if (cn == "BTC")  block_time_sec = 600;   // 10 min
+    else if (cn == "BCH")  block_time_sec = 600;   // 10 min
+    else if (cn == "DASH") block_time_sec = 150;   // 2.5 min
+    else if (cn == "DGB")  block_time_sec = 15;    // ~15 s
+    else                   block_time_sec = 60;    // safe fallback
 
     // Check at: first_check, then every block_time for 6 blocks,
     // then one final check at 10 blocks


### PR DESCRIPTION
## What
`schedule_block_verification()` spaced its six found-block confirmation re-checks by a block-time table that only knew **LTC (150s)** and **DOGE (60s)** — every other coin fell through to a **60s default**.

## Why it matters (founding charter)
On a slow chain that default lies. A genuine found block on **BTC/BCH (~10 min/block)** exhausted all six confirmation checks within roughly **one real block**, then got marked **orphaned** on the dashboard while the block was actually accepted into the chain. A dashboard must never lie that a real found block was lost.

## Fix
Per-coin target keyed by chain symbol, with a leading testnet-prefix strip so `tLTC`/`tBTC`/… resolve to mainnet timing:

| coin | block time |
|------|-----------|
| LTC, DASH | 150s (2.5 min) |
| DOGE | 60s (1 min) |
| BTC, BCH | 600s (10 min) |
| DGB | 15s |
| fallback | 60s |

## Scope
Web layer only, **non-consensus**. Affects only the found-block verification *cadence* — no change to acceptance logic or recorded block data. Built clean locally (c2pool target links, exit 0). Serves charter #2 (per-node/per-coin truthfulness) for the 6-coin fleet.
