### PR TITLE
web(merged): per-coin aux-payout address version bytes (stop hardcoded DOGE)

### DIFF
--- a/src/c2pool/merged/merged_mining.cpp
+++ b/src/c2pool/merged/merged_mining.cpp
@@ -1711,6 +1711,8 @@ std::vector<MergedMiningManager::ChainInfo> MergedMiningManager::get_chain_infos
         info.current_height = c.current_work.height;
         info.current_tip    = c.last_tip;
         info.coinbase_value = c.current_work.coinbase_value;
+        info.address_version = c.config.address_version;
+        info.p2sh_version    = c.config.p2sh_version;
         info.target         = c.current_work.target;
         info.block_hash     = c.current_work.block_hash.GetHex();
         // Compute difficulty from target: diff = 2^256 / (target+1)

--- a/src/c2pool/merged/merged_mining.hpp
+++ b/src/c2pool/merged/merged_mining.hpp
@@ -266,6 +266,8 @@ public:
         int         current_height{0};
         std::string current_tip;
         uint64_t    coinbase_value{0};  // satoshis
+        uint8_t     address_version{0}; // P2PKH version byte (from aux chain config)
+        uint8_t     p2sh_version{0};    // P2SH version byte (from aux chain config)
         double      difficulty{0.0};    // from target
         uint256     target;             // current aux chain target (for peer block detection)
         std::string block_hash;         // current aux block hash hex

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -6250,10 +6250,13 @@ nlohmann::json MiningInterface::compute_current_merged_payouts()
             auto merged_payouts = m_mm_manager->get_payouts(ci.chain_id, ci.coinbase_value);
             if (merged_payouts.empty()) continue;
 
-            // DOGE address version bytes (mainnet P2PKH=0x1e, P2SH=0x16)
-            uint8_t merged_p2pkh_ver = 0x1e;
-            uint8_t merged_p2sh_ver = 0x16;
-            // TODO: testnet detection for DOGE address versions
+            // Per-coin aux-payout address version bytes from the merged
+            // chain's own config -- never a hardcoded DOGE assumption, so a
+            // node merging NMC/other into its primary renders truthful aux
+            // payout addresses. Falls back to DOGE mainnet bytes (0x1e/0x16)
+            // only when the chain config leaves them unset (legacy DOGE).
+            uint8_t merged_p2pkh_ver = ci.address_version ? ci.address_version : 0x1e;
+            uint8_t merged_p2sh_ver  = ci.p2sh_version    ? ci.p2sh_version    : 0x16;
 
             for (auto& [script, amount] : merged_payouts) {
                 // Determine source label (p2pool: auto-convert, donation, explicit)


### PR DESCRIPTION
## What
The merged-payout renderer hardcoded **DOGE mainnet** address-version bytes (P2PKH `0x1e` / P2SH `0x16`) for **every** merged chain. Any node merging a non-DOGE aux chain (e.g. NMC into BTC) therefore rendered structurally-wrong aux payout addresses on the dashboard + JSON API.

## Why it was wrong
`AuxChainConfig` already carries the real per-coin `address_version` / `p2sh_version`, but `ChainInfo` (the web-facing snapshot returned by `get_chain_infos()`) dropped them, so `web_server.cpp` had nothing to read and fell back to a baked-in DOGE assumption.

## Fix
- Add `address_version` / `p2sh_version` passthrough to `ChainInfo`, populated from `c.config` in `get_chain_infos()`.
- Consume them per merged chain in the payout renderer; fall back to DOGE mainnet bytes only when a chain config leaves them unset (preserves legacy DOGE behaviour exactly).

Web / diagnostic layer only — no consensus path touched. Additive read-only surfacing of already-configured values.

## Charter
Per-node truth: the dashboard reflects THIS node real merged topology, never a baked-in LTC+DOGE shape.

## Test
Incremental build clean (`merged_mining.cpp`, `web_server.cpp`, `c2pool` link). DOGE behaviour byte-identical (fallback path). Full CI to confirm.
