### PR TITLE
web(merged): stop fabricating DOGE label on symbol-less merged entries

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -3795,7 +3795,7 @@ void MiningInterface::start_pplns_precompute()
                                 template_addr_ltc = merged_template[addr]["amount"].get<double>();
                             double scale = (template_addr_ltc > 0) ? (ltc_amt / template_addr_ltc) : 1.0;
                             entry["merged"].push_back({
-                                {"symbol", m.value("symbol", "DOGE")},
+                                {"symbol", m.value("symbol", "")},  // honesty: never fabricate a coin label
                                 {"address", m.value("address", "")},
                                 {"amount", template_doge * scale}
                             });
@@ -6539,11 +6539,18 @@ nlohmann::json MiningInterface::rest_pplns_current()
                 for (const auto& mm : entry["merged"]) {
                     double mm_amount = mm.value("amount", 0.0);
                     if (!(mm_amount > 0)) continue;
-                    std::string sym = mm.value("symbol", std::string("DOGE"));
+                    // Charter honesty: a merged entry must carry its real
+                    // aux-chain symbol (producers set it from ci.symbol). If it
+                    // is somehow absent we must NOT fabricate a specific coin --
+                    // the old "DOGE" default lied on non-DOGE aux nodes and
+                    // folded the amount into a bogus DOGE merged_total. Leave it
+                    // unlabelled (== unknown) so it never masquerades as DOGE.
+                    std::string sym = mm.value("symbol", std::string(""));
                     std::string mm_addr = mm.value("address", std::string(""));
                     if (mm_addr.empty() && mm.contains("addr"))
                         mm_addr = mm.value("addr", std::string(""));
-                    merged_totals[sym] += mm_amount;
+                    if (!sym.empty())
+                        merged_totals[sym] += mm_amount;
                     nlohmann::json me;
                     me["symbol"]  = sym;
                     me["address"] = mm_addr;


### PR DESCRIPTION
## What
Stop fabricating a `DOGE` symbol on merged-payout entries that arrive without a `symbol` key.

Two sites in `web_server.cpp` defaulted a merged entry's symbol to `"DOGE"`:
- `rest_pplns_current()` (live cross-coin renderer)
- the PPLNS cache-upgrade builder in `start_pplns_precompute()`

## Why (charter)
On a non-DOGE aux node (e.g. BTC+NMC) a symbol-less entry was labelled as a coin the operator is **not** mining, and its amount was folded into a bogus `merged_totals["DOGE"]` aggregate. Worse, it was internally inconsistent: the pct fill-in loop already defaults the symbol to `""`, so the fabricated `DOGE` row computed its percentage against an empty bucket (== 0). A fabricated coin label on the dashboard is exactly the failure mode this layer exists to prevent.

## Change
- Default the symbol to `""` (unknown) in both sites.
- Do not fold an unlabelled amount into any coin total.

Producers set the real `ci.symbol`, so correctly-formed entries are unchanged; only the malformed/legacy case stops masquerading as DOGE. Web/diagnostic layer only — no consensus impact.

## Test
- `web_server.cpp` compiles clean (incremental object build).
- No behavioural change for entries that carry a real symbol (the common path).
