### PR TITLE
nmc: source-pin AuxPow chain_id (nAuxpowChainId=0x0001) + KAT

### DIFF
--- a/src/impl/nmc/coin/aux_id.hpp
+++ b/src/impl/nmc/coin/aux_id.hpp
@@ -9,8 +9,11 @@
 // need NOT pull the full embedded header_chain.hpp (leveldb/block/transaction)
 // just to read a chain id. NMCChainParams::aux_chain_id defaults to this.
 //
-// Namecoin nAuxpowChainId = 0x0001 on both mainnet and testnet
-// (Namecoin src/chainparams.cpp). NOT DOGE's 0x0062.
+// Namecoin nAuxpowChainId = 0x0001 across ALL nets. PINNED from canonical
+// Namecoin Core @ 6697dba480 (branch auxpow), src/kernel/chainparams.cpp:
+//   :179 CMainParams  :345 CTestNetParams  :620 CTestNet4Params
+//   :725 CRegTestParams  -> consensus.nAuxpowChainId = 0x0001 (all four).
+// Live cross-check vs .140 namecoind deferred to PE item4 soak. NOT DOGE's 0x0062.
 namespace nmc {
 namespace coin {
 

--- a/src/impl/nmc/coin/header_chain.hpp
+++ b/src/impl/nmc/coin/header_chain.hpp
@@ -294,12 +294,13 @@ inline std::vector<unsigned char> build_mm_commitment(uint256 chain_merkle_root,
 /// keyed by (chain_id, merkle size, nonce). For NMC under a BTC parent the
 /// list is normally length 1, but the type models the general case.
 struct AuxChain {
-    // TO-CONFIRM: Namecoin mainnet chain id. Namecoin historically uses
-    // chain_id = 1 for mainnet merge-mining, but this MUST be pinned against
-    // Namecoin chainparams (CChainParams::nAuxpowChainId) + namecoind before
-    // it is treated as consensus. Sentinel below is a placeholder, NOT a
-    // committed constant.
-    int32_t  chain_id{-1};        // TO-CONFIRM: sentinel (-1 = unpinned)
+    // chain_id: PINNED from canonical Namecoin Core @ 6697dba480 (branch
+    // auxpow), src/kernel/chainparams.cpp:179/345/620/725 -> nAuxpowChainId =
+    // 0x0001 across all four nets (main/testnet/testnet4/regtest). Defaults to
+    // the aux_id.hpp SSOT so this slot-modeling struct never disagrees with the
+    // consensus-bearing NMCChainParams::aux_chain_id. Live cross-check vs .140
+    // namecoind deferred to PE item4 soak.
+    int32_t  chain_id{static_cast<int32_t>(NMC_AUXPOW_CHAIN_ID)};  // = 0x0001 (pinned)
     uint256  aux_block_hash;      // the aux (NMC) block hash being committed
     uint32_t merkle_index{0};     // slot index within the chain merkle tree
 };
@@ -582,8 +583,9 @@ struct NMCChainParams {
     // hand-built Params never claims merge-mining is active off a placeholder.
     int32_t auxpow_activation_height{-1};   // -1 = unpinned default; pinned per-net in factory
     // aux_chain_id: the chain id this NMC instance claims in the parent's
-    //   merged-mining tree. -1 = unpinned sentinel.
-    int32_t aux_chain_id{static_cast<int32_t>(NMC_AUXPOW_CHAIN_ID)};                // Namecoin nAuxpowChainId = 0x0001 (both nets); see chainparams.cpp
+    //   merged-mining tree. PINNED via the aux_id.hpp SSOT (no longer a -1
+    //   sentinel); live cross-check vs .140 namecoind deferred to PE item4 soak.
+    int32_t aux_chain_id{static_cast<int32_t>(NMC_AUXPOW_CHAIN_ID)};                // = 0x0001; namecoin-core@6697dba src/kernel/chainparams.cpp:179/345/620/725
 
     int64_t difficulty_adjustment_interval() const {
         return target_timespan / target_spacing;

--- a/src/impl/nmc/test/auxpow_merkle_test.cpp
+++ b/src/impl/nmc/test/auxpow_merkle_test.cpp
@@ -1803,3 +1803,79 @@ TEST(NmcPdGoldenFixture, MarkerFieldOffsetsAreThePinnedLayout)
 }
 
 } // namespace
+
+// ---------------------------------------------------------------------------
+// NMC chain-id source-pin KAT.
+//
+// Pins consensus.nAuxpowChainId = 0x0001, sourced from canonical Namecoin Core
+// @ 6697dba480 (branch auxpow), src/kernel/chainparams.cpp:179 (CMainParams),
+// :345 (CTestNetParams), :620 (CTestNet4Params), :725 (CRegTestParams) -- the
+// value is 0x0001 across all four nets. The live cross-check vs .140 namecoind
+// is DEFERRED to the PE item4 soak (the gate stays visible; it is not retired).
+//
+// Three bindings prove the pin is load-bearing, not decorative:
+//   1. the aux_id.hpp SSOT constant, the slot-modeling AuxChain default and the
+//      consensus-bearing NMCChainParams::aux_chain_id all read 0x0001 -- drift on
+//      any one reds (the -1 placeholder cannot creep back);
+//   2. an AuxPow round-trip carrying the PINNED chain_id reaches the same staged
+//      state a correct proof does (INCOMPLETE -- step 4 parent-PoW still unbuilt --
+//      and never spuriously VALID);
+//   3. presenting the SAME proof under a DIFFERENT expected chain id moves the
+//      demanded slot (aux_expected_index folds chain_id in), so the marker no
+//      longer occupies the required slot and the proof is no longer staged --
+//      chain_id genuinely participates in the consensus slot binding.
+// Per-coin isolation (P0 fence #4): src/impl/nmc/ test target only; rides the
+// already-allowlisted nmc_auxpow_merkle_test exe; no build.yml change.
+// ---------------------------------------------------------------------------
+
+TEST(NmcChainIdPin, PinnedValueIsAuxpowChainId0x0001)
+{
+    EXPECT_EQ(nmc::coin::NMC_AUXPOW_CHAIN_ID, 0x0001u);
+    // slot-modeling struct default is the SSOT, no longer the -1 sentinel:
+    EXPECT_EQ(nmc::coin::AuxChain{}.chain_id, 0x0001);
+    // consensus-bearing params field agrees with the SSOT:
+    EXPECT_EQ(nmc::coin::NMCChainParams::mainnet().aux_chain_id, 0x0001);
+}
+
+TEST(NmcChainIdPin, RoundTripUnderPinnedChainIdIsStagedNotInvalid)
+{
+    const int32_t cid = static_cast<int32_t>(nmc::coin::NMC_AUXPOW_CHAIN_ID); // 0x0001
+    uint256 aux = leaf_of(0x01), sib = leaf_of(0x55);
+    uint256 root = combine(aux, sib);                 // index bit0=0 => leaf left
+    const unsigned h = 1; const uint32_t nonce = 1;
+    const uint32_t slot = aux_expected_index(nonce, cid, h);   // (1,1,1) => 0
+    ASSERT_EQ(slot, 0u);
+    auto script = mm_script(root_reversed(root), 1u << h, nonce);
+
+    AuxPow ap;
+    ap.parent_coinbase = coinbase_with_script(script);
+    ap.chain_merkle_branch = {sib};
+    ap.chain_merkle_index = slot;
+    // pinned chain id: marker scans, slot binds, proof staged (step 4 unbuilt).
+    EXPECT_EQ(ap.check_proof(aux, cid), AuxPow::CheckResult::INCOMPLETE);
+    EXPECT_NE(ap.check_proof(aux, cid), AuxPow::CheckResult::VALID);
+}
+
+TEST(NmcChainIdPin, WrongExpectedChainIdBreaksSlotBinding)
+{
+    const int32_t cid   = static_cast<int32_t>(nmc::coin::NMC_AUXPOW_CHAIN_ID); // 1
+    const int32_t wrong = cid + 1;                                              // 2
+    const unsigned h = 1; const uint32_t nonce = 1;
+    // chain_id folds into the deterministic slot: the demanded slot moves.
+    EXPECT_NE(aux_expected_index(nonce, cid, h),
+              aux_expected_index(nonce, wrong, h));        // 0 vs 1
+
+    uint256 aux = leaf_of(0x01), sib = leaf_of(0x55);
+    uint256 root = combine(aux, sib);
+    const uint32_t slot = aux_expected_index(nonce, cid, h);   // marker laid at slot 0
+    auto script = mm_script(root_reversed(root), 1u << h, nonce);
+
+    AuxPow ap;
+    ap.parent_coinbase = coinbase_with_script(script);
+    ap.chain_merkle_branch = {sib};
+    ap.chain_merkle_index = slot;
+    // Same proof, WRONG expected chain id -> verifier demands a different slot,
+    // so the staged MATCH is lost; never INCOMPLETE, never VALID.
+    EXPECT_NE(ap.check_proof(aux, wrong), AuxPow::CheckResult::INCOMPLETE);
+    EXPECT_NE(ap.check_proof(aux, wrong), AuxPow::CheckResult::VALID);
+}


### PR DESCRIPTION
## Summary
Retires the `-1 / TO-CONFIRM` AuxPow chain_id sentinel and source-pins it to the canonical value, with a load-bearing KAT.

**Pin source (cited from my own checkout, not the wire/memory):** canonical Namecoin Core @ `6697dba480` (branch `auxpow`), `src/kernel/chainparams.cpp`:
- :179 `CMainParams`      -> `consensus.nAuxpowChainId = 0x0001`
- :345 `CTestNetParams`   -> `0x0001`
- :620 `CTestNet4Params`  -> `0x0001`
- :725 `CRegTestParams`   -> `0x0001`

Value is `0x0001` across all four nets — unambiguous.

## What changed
- `aux_id.hpp` SSOT comment: exact file:line citation.
- `header_chain.hpp`: `AuxChain.chain_id` default `-1` -> `NMC_AUXPOW_CHAIN_ID` (the consensus-bearing `NMCChainParams::aux_chain_id` already defaulted to the SSOT; this aligns the slot-modeling struct so it can never disagree). Citations upgraded.
- **Live check NOT retired:** comments now read `PINNED from Namecoin Core 6697dba; live cross-check vs .140 namecoind deferred to PE item4 soak.` The soak gate stays visible.

## KAT (`nmc_auxpow_merkle_test` 84 -> 87, all green)
1. `PinnedValueIsAuxpowChainId0x0001` — SSOT / struct default / params field all read `0x0001` (drift reds; -1 cannot creep back).
2. `RoundTripUnderPinnedChainIdIsStagedNotInvalid` — AuxPow round-trip carrying the pinned chain_id reaches the staged `INCOMPLETE` state (step-4 parent PoW unbuilt), never spuriously VALID.
3. `WrongExpectedChainIdBreaksSlotBinding` — a different expected chain_id moves the deterministic slot (`aux_expected_index` folds chain_id in), breaking the proof — chain_id genuinely participates in the consensus slot binding.

## Scope / gate
- Fenced to `src/impl/nmc/` only — no `bitcoin_family/` or `src/core/` touch; no `build.yml` change (rides the already-allowlisted exe).
- Signed, no third-party attribution.
- **Carries a consensus VALUE -> NO auto-merge.** Reporting green for operator tap.