### PR TITLE
web(currency_info): report LIVE ratchet share_version, not static 36

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -4813,13 +4813,19 @@ nlohmann::json MiningInterface::rest_web_currency_info()
 
     // p2pool share version for the current coin — consumed by the
     // bundled @c2pool/sharechain-explorer to classify share cells.
-    // Dash = v16, LTC/DOGE/BTC = v36.
+    // For the V35/V36-ratcheting coins this MUST be the node's LIVE
+    // ratchet-selected version (m_cached_share_version, fed from the
+    // AutoRatchet), never a static 36: during the V35->V36 cross a node that
+    // is still VOTING is actually producing V35 shares, and reporting 36 would
+    // make the explorer misclassify live V35 share cells as V36 — a lie about
+    // the crossing state. DASH (v16, non-ratcheting on this path) keeps its
+    // protocol version since the LTC AutoRatchet does not drive its cache.
     switch (m_blockchain) {
     case Blockchain::DASH:     result["share_version"] = 16; break;
     case Blockchain::LITECOIN:
     case Blockchain::BITCOIN:
     case Blockchain::DOGECOIN:
-    default:                   result["share_version"] = 36; break;
+    default:                   result["share_version"] = m_cached_share_version; break;
     }
 
     // ─── Per-coin explorer map (operator 2026-06-23: each coin = a distinct


### PR DESCRIPTION
## Problem
`rest_web_currency_info` set `share_version` from a static coin switch — LTC/DOGE/BTC always `36`, DASH `16`. The bundled `@c2pool/sharechain-explorer` consumes this field to classify share cells.

During the live V35→V36 cross (LTC prod #288), a node that is still **VOTING** is actually producing **V35** shares — but `/currency_info` would report `36`, so the explorer misclassifies live V35 cells as V36. That is a dashboard lie about the crossing state — exactly the class of bug this lane exists to kill (charter #3: operators must see the ratchet truthfully).

## Fix
Source `share_version` from the node-live `m_cached_share_version`, which is fed from the `AutoRatchet` (`set_cached_share_version`, updated on every PPLNS work refresh) — the same internal state the share-selection path uses. DASH keeps its static `16`: it is non-ratcheting on this path (separate activation latch, #466) and the LTC AutoRatchet does not drive its cache, so the live value would default-lie there.

## Scope
Web/diagnostic layer only (`core/web_server.cpp`, one switch arm). No consensus path touched. Built clean locally.
