### PR TITLE
nmc(PF): source-anchor mainnet genesis seed + red-able merkleroot field-pin

### DIFF
--- a/src/impl/nmc/coin/header_chain.hpp
+++ b/src/impl/nmc/coin/header_chain.hpp
@@ -601,7 +601,9 @@ struct NMCChainParams {
 
     /// NMC mainnet params skeleton. pow_limit + genesis_hash PINNED from
     /// namecoin-core src/kernel/chainparams.cpp (CMainParams). The 80-byte
-    /// mainnet_genesis_header() seed (SHA256d cross-check) stays deferred.
+    /// mainnet_genesis_header() seed is now PINNED + SHA256d-cross-checked
+    /// (mainnet_genesis_header() below, KAT MainnetHeaderRederivesPinnedHash);
+    /// no longer deferred.
     static NMCChainParams mainnet() {
         NMCChainParams p;
         p.target_timespan = MAINNET_TARGET_TIMESPAN;
@@ -679,6 +681,10 @@ struct NMCChainParams {
     /// blocks=830010 IBD=false, 2026-06-20):
     ///   version=1  time=1303000001  bits=0x1c007fff  nonce=0xa21ea192
     ///   merkleroot=41c62dbd9068c89a449525e3cd5ac61b20ece28c3c38b3f35b2161f0e6d3cb0d
+    /// Source-anchored to namecoin-core@6697dba src/kernel/chainparams.cpp:200
+    ///   CreateGenesisBlock(1303000001, 0xa21ea192, 0x1c007fff, 1, 50 * COIN):
+    ///   version/time/bits/nonce match those literals, so the pin no longer
+    ///   rests solely on the ephemeral .140 daemon.
     /// SHA256d(header) == 000000000062b72c..c770 == mainnet genesis_hash
     /// (verified locally + by the MainnetHeaderRederivesPinnedHash KAT). This
     /// retires the deferred mainnet_genesis_header() seed; the expected hash is

--- a/src/impl/nmc/test/auxpow_wire_test.cpp
+++ b/src/impl/nmc/test/auxpow_wire_test.cpp
@@ -305,6 +305,14 @@ TEST(NmcP1Genesis, MainnetHeaderRederivesPinnedHash)
     EXPECT_EQ(g.m_bits, 0x1c007fffu);
     EXPECT_EQ(g.m_nonce, 0xa21ea192u);
 
+    // Merkle root SOURCE-pinned vs namecoin-core@6697dba chainparams.cpp:200
+    // CreateGenesisBlock(...): one coinbase tx, so root == that tx hash. An
+    // explicit field-pin reds HERE on merkleroot drift (the SHA256d check
+    // below would also red, but at the hash, not the offending field).
+    uint256 mroot;
+    mroot.SetHex("41c62dbd9068c89a449525e3cd5ac61b20ece28c3c38b3f35b2161f0e6d3cb0d");
+    EXPECT_EQ(g.m_merkle_root, mroot);
+
     uint256 expect;
     expect.SetHex("000000000062b72c5e2ceb45fbc8587e807c155b0da735e6483dfba2f0a9c770");
     EXPECT_EQ(nmc::coin::block_hash(g), expect);


### PR DESCRIPTION
## What
PF source-accuracy + conformance-lock for the NMC mainnet genesis seed. No consensus value changes.

- `header_chain.hpp`: retire the stale "mainnet_genesis_header() seed ... stays deferred" banner (the seed has been pinned + SHA256d-cross-checked since the MainnetHeaderRederivesPinnedHash KAT). Anchor the fields to namecoin-core@6697dba `src/kernel/chainparams.cpp:200` `CreateGenesisBlock(1303000001, 0xa21ea192, 0x1c007fff, 1, 50*COIN)` so the pin no longer rests solely on the ephemeral .140 daemon snapshot.
- `auxpow_wire_test.cpp`: add an explicit `m_merkle_root` field-pin to the KAT so a merkleroot drift reds AT the field (the SHA256d hash check would also red, but at the hash, not the offending field).

## Proof
- `NmcP1Genesis.*` 3/3 green.
- Flip->RED verified: mutating the merkleroot literal fails the new field-pin (Which is: 41c62d.. vs dead00..); restore->GREEN.

Held for operator tap — I do not self-merge.