### PR TITLE
core: won-block dual-path broadcast SSOT (BTC delegates) [Phase-1 convergence, DRAFT — review+operator-tap, no auto-merge]

### DIFF
--- a/src/core/block_broadcast.hpp
+++ b/src/core/block_broadcast.hpp
@@ -1,0 +1,71 @@
+#pragma once
+//
+// block_broadcast.hpp — Cross-coin WON-block broadcast fallback orchestration
+// (SINGLE SOURCE OF TRUTH).
+//
+// Every coin c2pool mines reaches the network the same way when it WINS a
+// block: P2P relay is PRIMARY, and the coin daemon submitblock RPC is the
+// FALLBACK that fires ONLY when P2P is unavailable or the relay did not
+// succeed. This orchestration carries no per-coin state — the sinks are passed
+// in as callables — so the policy (primary/fallback ordering + the throw
+// guards that stop a won block silently vanishing) belongs here in core/
+// rather than being re-spelled per coin dispatcher.
+//
+// SCOPE — what this SSOT owns and does NOT own:
+//   OWNS:   the broadcast POLICY — primary-then-fallback ordering, the
+//           "no unconditional double-broadcast", and the both-legs-guarded
+//           never-silent-drop invariant.
+//   NOT:    HOW a coin relays over P2P or HOW it shapes its submitblock RPC.
+//           Those are coin-specific and live behind the two callables.
+//
+// P2P relay is PRIMARY; the submitblock RPC is the FALLBACK and fires ONLY
+// when P2P is unavailable or the relay did not succeed. This is deliberately
+// NOT always-both / double-broadcast: a coin daemon dedupes a duplicate
+// submitblock harmlessly, but the fallback gives us robustness against a silent
+// P2P-unavailable / relay-failed hole without an unconditional double submit.
+//
+// `relay_p2p`  -> returns true on a successful P2P relay.
+// `submit_rpc` -> returns true when the coin daemon accepts the block.
+//
+// Returns true iff the block reached AT LEAST ONE sink. A false return means
+// the block reached NEITHER sink: the caller MUST treat that as a lost
+// subsidy and scream (never silent-drop a won block).
+//
+// BOTH legs are guarded so a throwing sink can never bypass the fallback or
+// escape this function: a THROWING relay_p2p() is a relay-FAILED mode, not a
+// reason to skip the fallback -- without the guard the exception would unwind
+// PAST this function, bypassing the submitblock fallback and silently dropping
+// the won block (the exact hole the fallback exists to close). A throwing
+// submit_rpc() (last-resort sink) collapses to a definite false return so the
+// caller's documented "reached neither sink, scream" path fires instead of an
+// exception escaping the won-block handler.
+//
+#include <functional>
+
+namespace core
+{
+
+inline bool broadcast_block_with_fallback(
+    const std::function<bool()>& relay_p2p,
+    const std::function<bool()>& submit_rpc)
+{
+    bool p2p_ok = false;
+    try {
+        p2p_ok = (relay_p2p && relay_p2p());
+    } catch (...) {
+        p2p_ok = false;              // relay threw -> treat as relay-failed
+    }
+    if (p2p_ok)
+        return true;                 // primary succeeded -> no double-broadcast
+
+    if (submit_rpc) {
+        try {
+            return submit_rpc();     // fallback path
+        } catch (...) {
+            return false;            // last-resort sink threw -> caller screams
+        }
+    }
+    return false;                    // reached neither sink
+}
+
+} // namespace core

--- a/src/core/test/CMakeLists.txt
+++ b/src/core/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (BUILD_TESTING AND (GTest_FOUND OR GTEST_FOUND))
-    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp)
+    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp)
     target_link_libraries(core_test PRIVATE GTest::gtest_main core c2pool_merged_mining GTest::gtest)
     target_link_libraries(core_test PRIVATE c2pool_payout c2pool_hashrate ltc_coin)  # OBJECT-lib SCC direct-naming (#22/#39)
 

--- a/src/core/test/block_broadcast_test.cpp
+++ b/src/core/test/block_broadcast_test.cpp
@@ -1,0 +1,85 @@
+#include <gtest/gtest.h>
+
+#include <core/block_broadcast.hpp>
+
+// SSOT guard/policy KATs for core::broadcast_block_with_fallback.
+//
+// These lock the cross-coin won-block broadcast invariant at the core symbol
+// (the BTC entry point is a thin delegate to this): primary-then-fallback
+// ordering, no unconditional double-broadcast, both legs guarded against a
+// throwing sink, and a never-silent-drop false return when neither sink takes
+// the block.
+
+namespace {
+
+// 1. Primary P2P relay succeeds -> return true and DO NOT invoke the RPC
+//    fallback (no unconditional double-broadcast).
+TEST(CoreBlockBroadcast, PrimarySucceeds_NoDoubleBroadcast)
+{
+    bool rpc_called = false;
+    bool ok = core::broadcast_block_with_fallback(
+        [] { return true; },
+        [&] { rpc_called = true; return true; });
+    EXPECT_TRUE(ok);
+    EXPECT_FALSE(rpc_called) << "RPC fallback must not fire after a successful P2P relay";
+}
+
+// 2. P2P relay returns false -> fall back to the RPC, which accepts.
+TEST(CoreBlockBroadcast, PrimaryFails_FallbackAccepts)
+{
+    bool rpc_called = false;
+    bool ok = core::broadcast_block_with_fallback(
+        [] { return false; },
+        [&] { rpc_called = true; return true; });
+    EXPECT_TRUE(ok);
+    EXPECT_TRUE(rpc_called) << "RPC fallback must fire when P2P relay did not succeed";
+}
+
+// 3. A THROWING P2P relay is a relay-FAILED mode, NOT a reason to skip the
+//    fallback: the exception must be swallowed and the RPC must still fire.
+TEST(CoreBlockBroadcast, PrimaryThrows_FallbackStillFires)
+{
+    bool rpc_called = false;
+    bool ok = core::broadcast_block_with_fallback(
+        [] () -> bool { throw std::runtime_error("relay blew up"); },
+        [&] { rpc_called = true; return true; });
+    EXPECT_TRUE(ok);
+    EXPECT_TRUE(rpc_called) << "throwing P2P relay must not bypass the RPC fallback";
+}
+
+// 4. The last-resort RPC sink throwing collapses to a definite false return so
+//    the caller's "reached neither sink, scream" path fires (not an escaping
+//    exception).
+TEST(CoreBlockBroadcast, FallbackThrows_ReturnsFalseNotException)
+{
+    bool ok = true;
+    EXPECT_NO_THROW({
+        ok = core::broadcast_block_with_fallback(
+            [] { return false; },
+            [] () -> bool { throw std::runtime_error("submitblock blew up"); });
+    });
+    EXPECT_FALSE(ok) << "a throwing RPC sink must collapse to false, never escape";
+}
+
+// 5. Both sinks decline -> false (won block reached NEITHER sink: caller screams).
+TEST(CoreBlockBroadcast, NeitherSink_ReturnsFalse)
+{
+    bool ok = core::broadcast_block_with_fallback(
+        [] { return false; },
+        [] { return false; });
+    EXPECT_FALSE(ok);
+}
+
+// 6. Null callables are tolerated and treated as unavailable sinks: a null P2P
+//    leg falls through to the RPC; both null -> false (never a crash).
+TEST(CoreBlockBroadcast, NullSinks_NoCrash)
+{
+    std::function<bool()> none;
+    bool ok_rpc = core::broadcast_block_with_fallback(none, [] { return true; });
+    EXPECT_TRUE(ok_rpc) << "null P2P leg must fall through to the RPC fallback";
+
+    bool ok_neither = core::broadcast_block_with_fallback(none, none);
+    EXPECT_FALSE(ok_neither) << "both sinks unavailable -> false, no crash";
+}
+
+} // namespace

--- a/src/impl/btc/coin/block_broadcast.hpp
+++ b/src/impl/btc/coin/block_broadcast.hpp
@@ -1,56 +1,35 @@
 #pragma once
 
+// FALLBACK broadcast orchestration for a WON block.
+//
+// The canonical implementation now lives in the cross-coin SSOT
+// core::broadcast_block_with_fallback (<core/block_broadcast.hpp>): the
+// primary-then-fallback policy and the both-legs-guarded never-silent-drop
+// invariant are IDENTICAL for every coin, so they are owned once in core/
+// rather than re-spelled per coin. This btc::coin entry point is retained as a
+// thin, signature-stable delegate so existing BTC call sites (and the other
+// coin trees that cross-include this header) keep resolving the same symbol.
+//
+// P2P relay is PRIMARY; the submitblock RPC is the FALLBACK and fires ONLY
+// when P2P is unavailable or the relay did not succeed (NOT always-both /
+// double-broadcast). Returns true iff the block reached AT LEAST ONE sink; a
+// false return means it reached NEITHER and the caller MUST treat it as a lost
+// subsidy and scream. See the core header for the full guard rationale.
+
 #include <functional>
+
+#include <core/block_broadcast.hpp>
 
 namespace btc
 {
 namespace coin
 {
 
-// FALLBACK broadcast orchestration for a WON block.
-//
-// P2P relay is PRIMARY; the submitblock RPC is the FALLBACK and fires ONLY
-// when P2P is unavailable or the relay did not succeed. This is deliberately
-// NOT always-both / double-broadcast: bitcoind dedupes a duplicate submitblock
-// harmlessly, but the fallback gives us robustness against a silent
-// P2P-unavailable / relay-failed hole without an unconditional double submit.
-//
-// `relay_p2p`  -> returns true on a successful P2P relay.
-// `submit_rpc` -> returns true when bitcoind accepts the block.
-//
-// Returns true iff the block reached AT LEAST ONE sink. A false return means
-// the block reached NEITHER sink: the caller MUST treat that as a lost
-// subsidy and scream (never silent-drop a won block).
-//
-// BOTH legs are guarded so a throwing sink can never bypass the fallback or
-// escape this function: a THROWING relay_p2p() is a relay-FAILED mode, not a
-// reason to skip the fallback -- without the guard the exception would unwind
-// PAST this function, bypassing the submitblock fallback and silently dropping
-// the won block (the exact hole the fallback exists to close). A throwing
-// submit_rpc() (last-resort sink) collapses to a definite false return so the
-// caller's documented "reached neither sink, scream" path fires instead of an
-// exception escaping the won-block handler.
 inline bool broadcast_block_with_fallback(
     const std::function<bool()>& relay_p2p,
     const std::function<bool()>& submit_rpc)
 {
-    bool p2p_ok = false;
-    try {
-        p2p_ok = (relay_p2p && relay_p2p());
-    } catch (...) {
-        p2p_ok = false;              // relay threw -> treat as relay-failed
-    }
-    if (p2p_ok)
-        return true;                 // primary succeeded -> no double-broadcast
-
-    if (submit_rpc) {
-        try {
-            return submit_rpc();     // fallback path
-        } catch (...) {
-            return false;            // last-resort sink threw -> caller screams
-        }
-    }
-    return false;                    // reached neither sink
+    return core::broadcast_block_with_fallback(relay_p2p, submit_rpc);
 }
 
 } // namespace coin


### PR DESCRIPTION
## What
Phase-1 of the v36-native broadcaster-guard **convergence** (bucket-2 standardization). Lifts the canonical won-block dual-path broadcast policy into a cross-coin SSOT and makes BTC a thin delegate.

- NEW `core::broadcast_block_with_fallback` in `src/core/block_broadcast.hpp` — the canonical primary-then-fallback policy (P2P relay primary, submitblock RPC fallback) + both-legs-guarded never-silent-drop invariant.
- `src/impl/btc/coin/block_broadcast.hpp` reduced to a thin, **signature-stable** delegate forwarding to the core SSOT. Every existing includer (btc `node.hpp`, and the nmc/dgb trees that cross-include this header) keeps resolving the same symbol with **zero behavior change**.
- NEW `CoreBlockBroadcast` KATs on the core symbol directly (rides allowlisted `core_test`).

## Scope discipline (EXCEPTIONAL shared-core change)
- **Only `core/` and `btc/` touched.** nmc/dgb/bch trees are NOT modified.
- Per-coin dispatcher delegation to the new core SSOT is a **separate, per-coin, steward-owned slice**, sequenced AFTER this core SSOT + the design doc land and the operator greenlights the convergence direction (integrator to surface as a `[decision-needed]` tap).
- Per-coin PREFIX/IDENTIFIER **isolation primitives are untouched** — this converges only the v36-native *shared* broadcast structure (bucket 2), not the isolation boundary (bucket 1).

## Verification
- `core_test --gtest_filter=CoreBlockBroadcast.*` → **6/6**
- `btc` target build → **exit 0**
- `test_coin_broadcaster` (BTC broadcaster) → **65/65** through the delegate
- `nmc_block_broadcast_test` (cross-coin includer) → **7/7**, compiles+passes unchanged

## Merge policy
Shared-core is EXCEPTIONAL under per-coin isolation: **DO NOT auto-merge**. Needs integrator review + operator tap. Draft until then. Companion convergence DESIGN doc held in `the/docs` pending operator approval to push.