### PR TITLE
nmc(v37): classify always-fire dual-path as BUCKET-1 (do not converge to core SSOT)

### DIFF
--- a/src/impl/nmc/coin/block_broadcast.hpp
+++ b/src/impl/nmc/coin/block_broadcast.hpp
@@ -74,6 +74,20 @@ struct AuxBlockBroadcast
 // client yet) -- each leg is guarded so the dispatcher never throws or
 // dereferences an unset sink. Never silent-drops a won block: with NEITHER sink
 // present it logs an ERROR (lost-subsidy scream) and returns any()==false.
+// --- v37 BUCKET CLASSIFICATION (3-bucket rule) -------------------------------
+// BUCKET 1 (per-coin isolation invariant) -- KEEP, do NOT standardize/converge.
+// This dispatcher deliberately does NOT delegate to
+// core::broadcast_block_with_fallback() (src/core/block_broadcast.hpp). That
+// core SSOT SHORT-CIRCUITS on a P2P win (if p2p_ok return true) to avoid
+// a double-broadcast -- correct for a single-chain won block (BTC delegates to
+// it). NMC is merge-mined: the external namecoind submitauxblock RPC leg is
+// fired ALWAYS, even after a P2P win (a duplicate aux submission is a harmless
+// daemon rejection, never a silent drop). Converging NMC onto the core short-
+// circuit SSOT would DROP the always-fire aux leg -- a consensus-path
+// regression. The always-fire property is KAT-locked by
+// NmcAuxBlockBroadcast.DualPathAlwaysFiresFallback. v37 multichain migration
+// MUST preserve this per-coin aux contract, not collapse it onto the SSOT.
+// -----------------------------------------------------------------------------
 inline AuxBlockBroadcast broadcast_won_aux_block(const P2pRelaySink& p2p_relay,
                                                  const AuxRpcSink&   aux_rpc,
                                                  const std::vector<unsigned char>& block_bytes,


### PR DESCRIPTION
## What
Adds an in-file v37 3-bucket classification banner to `nmc::coin::broadcast_won_aux_block` marking its always-fire submitauxblock RPC leg as **BUCKET-1 (per-coin isolation invariant -- KEEP)**.

## Why
Post-#498, BTC delegates its won-block broadcast to `core::broadcast_block_with_fallback`, which **short-circuits on a P2P win** (`if (p2p_ok) return true;`) to avoid double-broadcast. NMC is merge-mined: the external namecoind `submitauxblock` RPC leg must fire **ALWAYS**, even after a P2P win (a duplicate aux submission is a harmless daemon rejection, never a silent drop). 

Naively converging NMC onto the core short-circuit SSOT during the v37 multichain migration would **drop the always-fire aux leg** -- a consensus-path regression. This banner makes the convergence verdict executable in-file so v37 tooling (or any agent doing cross-coin broadcast convergence) does not collapse NMC onto the SSOT.

## Safety
- Comment-only. No consensus-value, build, or runtime change.
- nmc-fenced (`src/impl/nmc/coin/block_broadcast.hpp` only); pulls no btc/dgb symbol.
- Behaviour already KAT-locked by `NmcAuxBlockBroadcast.DualPathAlwaysFiresFallback`; `nmc_block_broadcast_test` 7/7 green on this branch.

Held for integrator review + operator tap. I do not self-merge.