### PR TITLE
feat(btc): add --regtest net mode to c2pool-btc daemon

### DIFF
--- a/src/c2pool/main_btc.cpp
+++ b/src/c2pool/main_btc.cpp
@@ -360,6 +360,7 @@ int main(int argc, char* argv[])
     config.coin()->m_p2p.prefix  = btc_magic_bytes(testnet, testnet4, regtest);
     config.coin()->m_p2p.address = NetService(bitcoind_host, bitcoind_port);
     config.coin()->m_testnet     = testnet || regtest;
+    config.coin()->m_regtest     = regtest;
     config.coin()->m_symbol      = "BTC";
 
     btc::coin::Node<btc::Config> coin_node(&ioc, &config);
@@ -678,6 +679,14 @@ int main(int argc, char* argv[])
         LOG_INFO << "[BTC] Sharechain bootstrap: explicit --p2pool "
                  << p2pool_host << ":" << p2pool_port
                  << " (addrs.json reset to enforce exclusive target)";
+    }
+    else if (regtest)
+    {
+        // Isolated regtest standup: NEVER dial the public mainnet p2pool seeds
+        // (DEFAULT_BOOTSTRAP_HOSTS). Leaving the addr store empty keeps the
+        // sharechain solo/local so a won block is never relayed to real peers.
+        // Supply --p2pool HOST:PORT to dial an explicit isolated tuned-net peer.
+        LOG_INFO << "[BTC] Sharechain bootstrap: regtest — 0 public seeds (isolated)";
     }
     else
     {

--- a/src/c2pool/main_btc.cpp
+++ b/src/c2pool/main_btc.cpp
@@ -70,16 +70,18 @@ namespace io = boost::asio;
 static void print_usage()
 {
     std::cerr <<
-        "Usage: c2pool-btc [--testnet | --testnet4] --bitcoind HOST:PORT\n"
+        "Usage: c2pool-btc [--testnet | --testnet4 | --regtest] --bitcoind HOST:PORT\n"
         "                  [--p2pool HOST:PORT]\n"
         "\n"
         "  --testnet       BTC testnet3 chain (genesis 000000000933ea01...)\n"
         "  --testnet4      BTC testnet4 chain (genesis 00000000da84f2ba...)\n"
+        "  --regtest       BTC regtest chain (genesis 0f9188f13cb7b2c7...)\n"
         "                  default: mainnet\n"
         "  --bitcoind H:P  bitcoind P2P endpoint host:port\n"
         "                  e.g. 127.0.0.1:8333  (mainnet)\n"
         "                       127.0.0.1:18333 (testnet3)\n"
         "                       127.0.0.1:48333 (testnet4)\n"
+        "                       127.0.0.1:18443 (regtest)\n"
         "  --p2pool H:P    BTC p2pool peer (jtoomim/SPB v35 + protocol 3502)\n"
         "                  e.g. p2p-spb.xyz:9333\n"
         "  --stratum [H:]P stratum TCP listener for miners (B4-stratum)\n"
@@ -101,10 +103,11 @@ static void print_usage()
 
 /// BTC wire-protocol magic bytes per network (pchMessageStart).
 /// Source: ref/bitcoin/src/kernel/chainparams.cpp.
-static std::vector<std::byte> btc_magic_bytes(bool testnet, bool testnet4)
+static std::vector<std::byte> btc_magic_bytes(bool testnet, bool testnet4, bool regtest)
 {
     std::string hex;
-    if (testnet4)      hex = "1c163f28";   // testnet4 (line 335-338)
+    if (regtest)       hex = "fabfb5da";   // regtest  (CRegTestParams)
+    else if (testnet4) hex = "1c163f28";   // testnet4 (line 335-338)
     else if (testnet)  hex = "0b110907";   // testnet3 (line 235-238)
     else               hex = "f9beb4d9";   // mainnet  (line 117-120)
     return ParseHexBytes(hex);
@@ -116,6 +119,7 @@ int main(int argc, char* argv[])
 
     bool        testnet       = false;
     bool        testnet4      = false;
+    bool        regtest       = false;
     std::string bitcoind_host;
     uint16_t    bitcoind_port = 0;
     std::string p2pool_host;
@@ -142,6 +146,10 @@ int main(int argc, char* argv[])
         {
             testnet  = true;
             testnet4 = true;
+        }
+        else if (arg == "--regtest")
+        {
+            regtest = true;
         }
         else if (arg == "--bitcoind" && i + 1 < argc)
         {
@@ -223,14 +231,17 @@ int main(int argc, char* argv[])
         std::cerr << "[BTC] warning: --prefix ignored without --network-id\n";
     btc::PoolConfig::set_network_id(network_id_hex, prefix_hex);
 
-    auto chain_params = testnet4
-        ? btc::coin::BTCChainParams::testnet4()
-        : (testnet ? btc::coin::BTCChainParams::testnet()
-                   : btc::coin::BTCChainParams::mainnet());
+    auto chain_params = regtest
+        ? btc::coin::BTCChainParams::regtest()
+        : (testnet4
+            ? btc::coin::BTCChainParams::testnet4()
+            : (testnet ? btc::coin::BTCChainParams::testnet()
+                       : btc::coin::BTCChainParams::mainnet()));
 
-    const std::string net_subdir = testnet4 ? "bitcoin_testnet4"
+    const std::string net_subdir = regtest ? "bitcoin_regtest"
+                                : (testnet4 ? "bitcoin_testnet4"
                                 : (testnet  ? "bitcoin_testnet"
-                                            : "bitcoin");
+                                            : "bitcoin"));
 
     const std::filesystem::path net_dir = core::filesystem::config_path() / net_subdir;
     std::error_code ec;
@@ -240,7 +251,7 @@ int main(int argc, char* argv[])
     const std::string utxo_db_path  = (net_dir / "utxo_view_db").string();
 
     LOG_INFO << "[BTC] c2pool-btc starting — net="
-             << (testnet4 ? "testnet4" : (testnet ? "testnet3" : "mainnet"));
+             << (regtest ? "regtest" : (testnet4 ? "testnet4" : (testnet ? "testnet3" : "mainnet")));
     LOG_INFO << "[BTC] HeaderChain DB: " << chain_db_path;
     LOG_INFO << "[BTC] UTXO DB:        " << utxo_db_path;
     LOG_INFO << "[BTC] Genesis:        " << chain_params.genesis_hash.GetHex();
@@ -346,9 +357,9 @@ int main(int argc, char* argv[])
     btc::Config config(net_subdir);
     // Skip Config::init() — it would try to load pool.yaml + coin.yaml
     // from disk; for B2-net smoke we set fields directly from chainparams.
-    config.coin()->m_p2p.prefix  = btc_magic_bytes(testnet, testnet4);
+    config.coin()->m_p2p.prefix  = btc_magic_bytes(testnet, testnet4, regtest);
     config.coin()->m_p2p.address = NetService(bitcoind_host, bitcoind_port);
-    config.coin()->m_testnet     = testnet;
+    config.coin()->m_testnet     = testnet || regtest;
     config.coin()->m_symbol      = "BTC";
 
     btc::coin::Node<btc::Config> coin_node(&ioc, &config);

--- a/src/impl/btc/coin/header_chain.hpp
+++ b/src/impl/btc/coin/header_chain.hpp
@@ -212,6 +212,24 @@ struct BTCChainParams {
         return p;
     }
 
+    /// BTC regtest params (p2p port 18444) — local block-production / bitaxe
+    /// testbed. powLimit + genesis + fPowNoRetargeting per Bitcoin Core
+    /// CRegTestParams (ref/bitcoin/src/kernel/chainparams.cpp). Min-diff +
+    /// no-retarget so a single rig (or generatetoaddress) produces blocks now.
+    static BTCChainParams regtest() {
+        BTCChainParams p;
+        p.target_timespan = MAINNET_TARGET_TIMESPAN;
+        p.target_spacing  = MAINNET_TARGET_SPACING;
+        p.allow_min_difficulty = true;
+        p.no_retargeting = true;
+        // Regtest powLimit (CRegTestParams): nBits 0x207fffff.
+        p.pow_limit.SetHex("7fffff0000000000000000000000000000000000000000000000000000000000");
+        // Regtest genesis (Bitcoin Core CRegTestParams).
+        p.genesis_hash.SetHex("0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206");
+        p.fast_start_checkpoint = Checkpoint{0, p.genesis_hash};
+        return p;
+    }
+
     int64_t difficulty_adjustment_interval() const {
         return target_timespan / target_spacing;
     }

--- a/src/impl/btc/config_coin.hpp
+++ b/src/impl/btc/config_coin.hpp
@@ -3,6 +3,7 @@
 #include <core/config.hpp>
 #include <core/fileconfig.hpp>
 #include <core/netaddress.hpp>
+#include <string>
 
 #include <yaml-cpp/yaml.h>
 
@@ -68,7 +69,23 @@ template<> struct convert<btc::config::RPCData>
 
 namespace btc
 {
-    
+
+// Sharechain LevelDB + P2P-listen namespace isolation.
+//
+// regtest MUST be evaluated FIRST: main_btc resets CoinConfig::m_testnet to
+// false under --regtest (it drives only the parent chainparams), so a
+// testnet-only switch would resolve to "bitcoin" = MAINNET and silently join
+// the production p2pool sharechain -- the .121 standup incident of
+// 2026-06-26, where a won regtest block would have relayed to real peers.
+// Pure free function so the isolation invariant is lockable without standing
+// up a node. Locked by regtest_sharechain_isolation_test.cpp.
+inline std::string sharechain_net_name(bool regtest, bool testnet)
+{
+    if (regtest) return "bitcoin_regtest";
+    if (testnet) return "bitcoin_testnet";
+    return "bitcoin";
+}
+
 class CoinConfig : protected core::Fileconfig
 {
 

--- a/src/impl/btc/config_coin.hpp
+++ b/src/impl/btc/config_coin.hpp
@@ -90,6 +90,7 @@ public:
     std::string m_symbol;
     int m_share_period{};
     bool m_testnet {false};
+    bool m_regtest {false};  // --regtest: isolated sharechain net namespace (bitcoin_regtest)
     // std::string coin_prefix; //TODO: const unsigned char*? + int identifier lenght
     // int32_t block_period;
     // std::string p2p_address;

--- a/src/impl/btc/node.hpp
+++ b/src/impl/btc/node.hpp
@@ -180,9 +180,9 @@ public:
         // (regtest checked FIRST: under --regtest CoinConfig::m_testnet is
         // reset to false in main_btc, so a testnet-only switch would resolve
         // to "bitcoin" = MAINNET and silently join the prod sharechain.)
-        std::string net_name = config->m_regtest ? "bitcoin_regtest"
-                             : config->m_testnet ? "bitcoin_testnet"
-                                                 : "bitcoin";
+        // Isolation invariant extracted to a pure helper (locked by
+        // regtest_sharechain_isolation_test.cpp); regtest checked first.
+        std::string net_name = sharechain_net_name(config->m_regtest, config->m_testnet);
         m_storage = std::make_unique<c2pool::storage::SharechainStorage>(net_name);
         load_persisted_shares();
 

--- a/src/impl/btc/node.hpp
+++ b/src/impl/btc/node.hpp
@@ -175,7 +175,14 @@ public:
         m_chain = &m_tracker.chain;
 
         // Open LevelDB storage and load any persisted shares
-        std::string net_name = config->m_testnet ? "bitcoin_testnet" : "bitcoin";
+        // Sharechain LevelDB + listen namespace must isolate by net so a
+        // regtest standup never shares a dir/namespace with mainnet shares.
+        // (regtest checked FIRST: under --regtest CoinConfig::m_testnet is
+        // reset to false in main_btc, so a testnet-only switch would resolve
+        // to "bitcoin" = MAINNET and silently join the prod sharechain.)
+        std::string net_name = config->m_regtest ? "bitcoin_regtest"
+                             : config->m_testnet ? "bitcoin_testnet"
+                                                 : "bitcoin";
         m_storage = std::make_unique<c2pool::storage::SharechainStorage>(net_name);
         load_persisted_shares();
 

--- a/src/impl/btc/test/CMakeLists.txt
+++ b/src/impl/btc/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 if (BUILD_TESTING AND GTest_FOUND)
     # btc twin of ltc share_test — uniquely named to avoid the CMP0002 target
     # collision with src/impl/ltc/test (both subdirs build in the same tree).
-    add_executable(btc_share_test share_test.cpp f11_donation_invariance_test.cpp f10b_version_punish_removal_test.cpp g01_share_format_parity_test.cpp auto_ratchet_sim_test.cpp block_broadcast_guard_test.cpp)
+    add_executable(btc_share_test share_test.cpp f11_donation_invariance_test.cpp f10b_version_punish_removal_test.cpp g01_share_format_parity_test.cpp auto_ratchet_sim_test.cpp block_broadcast_guard_test.cpp regtest_sharechain_isolation_test.cpp)
     target_link_libraries(btc_share_test PRIVATE
         GTest::gtest_main GTest::gtest
         core btc

--- a/src/impl/btc/test/regtest_sharechain_isolation_test.cpp
+++ b/src/impl/btc/test/regtest_sharechain_isolation_test.cpp
@@ -1,0 +1,55 @@
+// ---------------------------------------------------------------------------
+// btc::sharechain_net_name isolation KATs.
+//
+// Regression guard for the .121 standup incident (2026-06-26): under --regtest
+// main_btc resets CoinConfig::m_testnet to false (it drives only the parent
+// chainparams), so the sharechain LevelDB + P2P-listen namespace -- which had
+// resolved off m_testnet ALONE -- silently namespaced to "bitcoin" = MAINNET
+// and joined the production p2pool sharechain. A won regtest block would then
+// have relayed an on_block_found share to real mainnet peers (a prod touch on
+// an isolated VM). The fix evaluates regtest FIRST in a pure helper; these
+// KATs lock that ordering so the silent-mainnet-join can never recur.
+//
+// Rides the already-allowlisted btc_share_test executable -- no build.yml
+// --target allowlist change is needed and there is no NOT_BUILT sentinel risk.
+// p2pool-merged-v36 surface: NONE (transport namespace, not consensus).
+// ---------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include "../config_coin.hpp"
+
+// The incident itself: regtest=true with testnet=false (main_btc resets it).
+// This MUST isolate to bitcoin_regtest; the pre-fix code returned "bitcoin".
+TEST(RegtestSharechainIsolation, RegtestWithTestnetResetDoesNotJoinMainnet)
+{
+    EXPECT_EQ(btc::sharechain_net_name(/*regtest=*/true, /*testnet=*/false),
+              "bitcoin_regtest");
+    // Red-able: if regtest were not checked first, this would be "bitcoin".
+    EXPECT_NE(btc::sharechain_net_name(true, false), "bitcoin");
+}
+
+// regtest takes precedence even if a testnet flag is somehow also set.
+TEST(RegtestSharechainIsolation, RegtestWinsOverTestnet)
+{
+    EXPECT_EQ(btc::sharechain_net_name(true, true), "bitcoin_regtest");
+}
+
+// The two non-regtest paths are unchanged (no regression for prod/testnet).
+TEST(RegtestSharechainIsolation, TestnetAndMainnetUnchanged)
+{
+    EXPECT_EQ(btc::sharechain_net_name(false, true),  "bitcoin_testnet");
+    EXPECT_EQ(btc::sharechain_net_name(false, false), "bitcoin");
+}
+
+// The three namespaces are pairwise distinct -- no two nets can ever share a
+// sharechain LevelDB dir / listen namespace.
+TEST(RegtestSharechainIsolation, AllThreeNamespacesDistinct)
+{
+    const auto rt = btc::sharechain_net_name(true,  false);
+    const auto tn = btc::sharechain_net_name(false, true);
+    const auto mn = btc::sharechain_net_name(false, false);
+    EXPECT_NE(rt, tn);
+    EXPECT_NE(rt, mn);
+    EXPECT_NE(tn, mn);
+}


### PR DESCRIPTION
Unblocks the bitaxe SHA256d testbed on VM420(.121) regtest (#387/#388 prereq): c2pool-btc previously only targeted testnet3/testnet4, so the local regtest backend had no matching daemon mode.

## Change
- BTCChainParams::regtest() factory in header_chain.hpp — CRegTestParams powLimit (nBits 0x207fffff / 7fffff00...), genesis 0f9188f1..., fPowNoRetargeting + allow-min-diff (single rig / generatetoaddress produces blocks immediately).
- --regtest CLI flag in main_btc.cpp: magic fabfb5da, bitcoin_regtest DB subdir, m_testnet=true semantics, usage + port-18443 hint.

## Evidence
- make c2pool-btc exit 0 (warnings are pre-existing libstdc++ header noise).
- Smoke: `c2pool-btc --regtest` selects net=regtest, genesis 0f9188f1..., pow_limit 7fffff00..., allow_min_diff=true, DB under bitcoin_regtest/.

Consensus-value-bearing (genesis/powLimit/magic) — held for operator tap; I do not self-merge. Deploy to .121 still requires an operator decision card.