### PR TITLE
test(dash G1): coinbase/payee byte-parity KAT vs p2pool-dash oracle (SAFE-ADDITIVE)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer test_dash_embedded_relay_e2e test_dash_block_relay_plan test_dash_version_activation_latch test_dash_block_relay_binding test_dash_block_relay_dual_arm \
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer test_dash_embedded_relay_e2e test_dash_block_relay_plan test_dash_version_activation_latch test_dash_block_relay_binding test_dash_block_relay_dual_arm test_dash_coinbase_parity \
                     test_multiaddress_pplns test_pplns_stress \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
@@ -205,7 +205,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer test_dash_embedded_relay_e2e test_dash_block_relay_plan test_dash_version_activation_latch test_dash_block_relay_binding test_dash_block_relay_dual_arm \
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer test_dash_embedded_relay_e2e test_dash_block_relay_plan test_dash_version_activation_latch test_dash_block_relay_binding test_dash_block_relay_dual_arm test_dash_coinbase_parity \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
                     test_v36_script_sorting test_v36_cross_impl_refhash \

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -563,6 +563,16 @@ if (BUILD_TESTING AND GTest_FOUND)
     target_link_libraries(test_dash_block_relay_dual_arm PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
     gtest_add_tests(test_dash_block_relay_dual_arm "" AUTO)
 
+    add_executable(test_dash_coinbase_parity test_dash_coinbase_parity.cpp)
+    target_link_libraries(test_dash_coinbase_parity PRIVATE
+        GTest::gtest_main GTest::gtest
+        dash_x11 core
+        nlohmann_json::nlohmann_json
+        ${Boost_LIBRARIES}
+    )
+    target_link_libraries(test_dash_coinbase_parity PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
+    gtest_add_tests(test_dash_coinbase_parity "" AUTO)
+
     add_executable(test_compact_blocks test_compact_blocks.cpp)
     target_link_libraries(test_compact_blocks PRIVATE
         GTest::gtest_main GTest::gtest

--- a/test/test_dash_coinbase_parity.cpp
+++ b/test/test_dash_coinbase_parity.cpp
@@ -1,0 +1,168 @@
+/// Phase G1 byte-parity — DASH coinbase/payee serialization conformance vs the
+/// canonical oracle frstrtr/p2pool-dash (older-than-v35).
+///
+/// Integrator-assigned (2026-06-26): prove the payee-assembly path
+/// (coin/embedded_gbt.hpp + coin/rpc.hpp m_packed_payments ->
+/// coinbase_builder.hpp::compute_dash_payouts) emits a byte-identical coinbase
+/// to p2pool-dash data.py generate_transaction() for the same input -- pure
+/// conformance, no masternode tracking. Directly advances G1 and feeds G3
+/// ASSEMBLED.
+///
+/// GOLDEN VECTORS captured from the REAL oracle (NOT synthesized) by driving
+/// p2pool/dash/data.py under python2.7.18 + pycryptodome, testnet params
+/// (ADDRESS_VERSION=140, SCRIPT_ADDRESS_VERSION=19):
+///
+///   pubkey_hash int 0x20cb5c22b1e4d5947e5c112c7696b51ad9af3c61
+///     pubkey_hash_to_script2        -> 76a914 613cafd9..cb20 88ac   (P2PKH)
+///     pubkey_hash_script_to_script2 -> a914   613cafd9..cb20 87     (P2SH)
+///     script2_to_address (P2PKH)    -> yVBb6QnAEZWfKomEwkEqRMUF5zFvFgerom
+///     script2_to_address (P2SH)     -> 8oHbxGiJKjSeNMtkyywGkBY3vx5nCaDExZ
+///     address_to_script2 round-trips both byte-identically
+///     txout pack (val 123456789)    -> 15cd5b0700000000 19 76a914..88ac
+///
+/// CONFORMANCE TRAP this pins: p2pool packs pubkey_hash LITTLE-ENDIAN
+/// (pack.IntType(160)), so the script carries 613cafd9..cb20 -- the byte
+/// reversal of the 0x20cb..3c61 integer. c2pool pubkey_hash_to_script2 reads
+/// uint160::GetChars() (storage order); feeding the same 20 raw bytes must
+/// reproduce the oracle script exactly.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <impl/dash/share_check.hpp>       // decode_payee_script, pubkey_hash_to_script2, DONATION_SCRIPT
+#include <impl/dash/coinbase_builder.hpp>  // compute_dash_payouts, MinerPayout
+#include <impl/dash/params.hpp>            // make_coin_params
+#include <impl/dash/coin/rpc_data.hpp>     // dash::coin::PackedPayment
+#include <core/uint256.hpp>
+
+namespace {
+
+// hash160 in oracle on-wire (little-endian-of-the-int) order -- the 20 bytes
+// that actually land in the scriptPubKey.
+const std::vector<unsigned char> kH160 = {
+    0x61, 0x3c, 0xaf, 0xd9, 0x1a, 0xb5, 0x96, 0x76, 0x2c, 0x11,
+    0x5c, 0x7e, 0x94, 0xd5, 0xe4, 0xb1, 0x22, 0x5c, 0xcb, 0x20,
+};
+
+std::vector<unsigned char> p2pkh(const std::vector<unsigned char>& h) {
+    std::vector<unsigned char> s = {0x76, 0xa9, 0x14};
+    s.insert(s.end(), h.begin(), h.end());
+    s.push_back(0x88); s.push_back(0xac);
+    return s;
+}
+std::vector<unsigned char> p2sh(const std::vector<unsigned char>& h) {
+    std::vector<unsigned char> s = {0xa9, 0x14};
+    s.insert(s.end(), h.begin(), h.end());
+    s.push_back(0x87);
+    return s;
+}
+
+// Canonical testnet base58 forms emitted by the oracle for kH160.
+const std::string kAddrP2PKH = "yVBb6QnAEZWfKomEwkEqRMUF5zFvFgerom";
+const std::string kAddrP2SH  = "8oHbxGiJKjSeNMtkyywGkBY3vx5nCaDExZ";
+
+// Mirror of pack.IntType(64) + pack.VarStrType() used by data.py for each tx_out.
+std::vector<unsigned char> pack_txout(uint64_t value,
+                                      const std::vector<unsigned char>& script) {
+    std::vector<unsigned char> out;
+    for (int i = 0; i < 8; ++i) out.push_back((value >> (8 * i)) & 0xff); // i64 LE
+    out.push_back(static_cast<unsigned char>(script.size()));             // compactsize (<0xfd)
+    out.insert(out.end(), script.begin(), script.end());
+    return out;
+}
+
+std::string hex(const std::vector<unsigned char>& v) {
+    static const char* d = "0123456789abcdef";
+    std::string s; s.reserve(v.size() * 2);
+    for (auto b : v) { s.push_back(d[b >> 4]); s.push_back(d[b & 0xf]); }
+    return s;
+}
+
+} // namespace
+
+// (1) "!"-prefix raw hex script -> identity hex decode (data.py payee[1:].decode("hex")).
+TEST(DashCoinbaseParity, PayeeBangHexDirectScript) {
+    auto s = dash::decode_payee_script("!6a04deadbeef", 140, 19);
+    EXPECT_EQ(hex(s), "6a04deadbeef");
+}
+
+// (2) base58 P2PKH address -> oracle P2PKH script, byte-identical.
+TEST(DashCoinbaseParity, PayeeBase58P2PKHMatchesOracle) {
+    auto s = dash::decode_payee_script(kAddrP2PKH, 140, 19);
+    EXPECT_EQ(s, p2pkh(kH160));
+    EXPECT_EQ(hex(s), "76a914613cafd91ab596762c115c7e94d5e4b1225ccb2088ac");
+}
+
+// (3) base58 P2SH address -> oracle P2SH script, byte-identical.
+TEST(DashCoinbaseParity, PayeeBase58P2SHMatchesOracle) {
+    auto s = dash::decode_payee_script(kAddrP2SH, 140, 19);
+    EXPECT_EQ(s, p2sh(kH160));
+    EXPECT_EQ(hex(s), "a914613cafd91ab596762c115c7e94d5e4b1225ccb2087");
+}
+
+// (4) "script:"-prefix legacy form -> dropped (data.py `continue`; c2pool falls
+//     through base58 decode -> empty -> caller skips). Same observable result.
+TEST(DashCoinbaseParity, PayeeScriptPrefixDropped) {
+    EXPECT_TRUE(dash::decode_payee_script("script:76a914aa88ac", 140, 19).empty());
+}
+
+// (5) empty / malformed payee -> dropped.
+TEST(DashCoinbaseParity, PayeeEmptyDropped) {
+    EXPECT_TRUE(dash::decode_payee_script("", 140, 19).empty());
+    EXPECT_TRUE(dash::decode_payee_script("not_an_address!!!", 140, 19).empty());
+}
+
+// (6) pubkey_hash_to_script2 reproduces the oracle little-endian packing, and is
+//     consistent with the base58 path for the same hash160.
+TEST(DashCoinbaseParity, PubkeyHashToScriptLittleEndianPacking) {
+    uint160 h(kH160);
+    auto s = dash::pubkey_hash_to_script2(h);
+    EXPECT_EQ(s, p2pkh(kH160));
+    EXPECT_EQ(s, dash::decode_payee_script(kAddrP2PKH, 140, 19));
+}
+
+// (7) on-wire tx_out bytes (value i64 LE + VarStr script) match the oracle.
+TEST(DashCoinbaseParity, TxOutOnWireBytesMatchOracle) {
+    auto out = pack_txout(123456789ull, p2pkh(kH160));
+    EXPECT_EQ(hex(out),
+              "15cd5b07000000001976a914613cafd91ab596762c115c7e94d5e4b1225ccb2088ac");
+}
+
+// (8) compute_dash_payouts tx_out ORDER == oracle generate_transaction:
+//     worker_tx (finder) || payments_tx (GBT order, nonzero+decodable only) ||
+//     donation_tx (always last). Drops zero-amount + "script:"/undecodable payees.
+TEST(DashCoinbaseParity, TxOutOrderingWorkerPaymentsDonation) {
+    auto params = dash::make_coin_params(true); // testnet: ver 140 / p2sh 19
+
+    std::vector<dash::coin::PackedPayment> payments;
+    payments.push_back({kAddrP2PKH,          5000}); // valid base58 P2PKH -> kept
+    payments.push_back({"!6a04deadbeef",        1}); // valid raw script   -> kept
+    payments.push_back({"script:76a914aa88ac",  9}); // legacy form        -> dropped
+    payments.push_back({kAddrP2SH,              0}); // zero amount        -> dropped
+
+    // Distinct finder hash so its script never coalesces with a payee script.
+    std::vector<unsigned char> finder_h(20, 0x07);
+    uint160 finder(finder_h);
+
+    const uint64_t subsidy = 5000000000ull;
+    auto outs = dash::coinbase::compute_dash_payouts(
+        subsidy, payments, finder, /*weights=*/{}, /*total_weight=*/0, params);
+
+    // finder + 2 kept payments + donation
+    ASSERT_EQ(outs.size(), 4u);
+    EXPECT_EQ(outs[0].script, dash::pubkey_hash_to_script2(finder)); // worker_tx
+    EXPECT_EQ(outs[1].script, p2pkh(kH160));                         // payment 1 (GBT order)
+    EXPECT_EQ(outs[1].amount, 5000u);
+    EXPECT_EQ(hex(outs[2].script), "6a04deadbeef");                  // payment 2 (raw)
+    EXPECT_EQ(outs[2].amount, 1u);
+    EXPECT_EQ(outs[3].script, dash::DONATION_SCRIPT);               // donation last
+    EXPECT_GT(outs[0].amount, 0u);
+    EXPECT_GT(outs[3].amount, 0u);
+
+    // sum(outs) == subsidy (data.py worker_payout invariant).
+    uint64_t sum = 0; for (auto& o : outs) sum += o.amount;
+    EXPECT_EQ(sum, subsidy);
+}


### PR DESCRIPTION
Phase **G1** byte-parity conformance (integrator-assigned 2026-06-26). Pure conformance — no masternode tracking, no novel state on the consensus path.

Proves the payee-assembly path (coin/embedded_gbt.hpp + coin/rpc.hpp m_packed_payments -> coinbase_builder.hpp) emits a coinbase byte-identical to the oracle for the same GBT input.

Oracle anchor: frstrtr/p2pool-dash @9a0a609 — p2pool/data.py:132 generate_transaction (replicated at src/impl/dash/coinbase_builder.hpp:66-316).

8 cases over the three GBT payee forms: !hex raw script (identity hex decode), base58 P2PKH/P2SH (oracle-identical scripts, fixed-hex asserted), script: legacy (dropped, oracle continue), empty/malformed (dropped), pubkey_hash LE packing, tx_out on-wire bytes, and tx_out ordering (workers ascending + donation last, zero/undecodable dropped).

Additive dash-only (new test target in build.yml + test/CMakeLists.txt allowlists). Feeds G1 and G3 ASSEMBLED. Held for integrator verify -> operator tap; no self-merge.