### PR TITLE
test(web): honesty-regression KAT pinning getinfo un-stub (SAFE-ADDITIVE)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
                     test_v36_script_sorting test_v36_cross_impl_refhash \
                     test_phase4_embedded \
                     test_mweb_builder \
-                    test_address_resolution test_compute_share_target \
+                    test_address_resolution test_compute_share_target test_web_honesty_regression \
                     test_utxo test_dgb_subsidy test_dgb_coinbase_value dgb_share_test dgb_redistribute_test dgb_block_assembly_test dgb_witness_commitment_test dgb_header_sample_build_test dgb_header_ingest_test dgb_mempool_ingest_test \
                     dgb_gentx_coinbase_test dgb_connection_coinbase_test dgb_pplns_payout_split_test nmc_auxpow_merkle_test nmc_template_builder_test nmc_auxpow_wire_test nmc_reconstruct_won_block_test nmc_mempool_name_test nmc_block_broadcast_test nmc_host_dualpath_test nmc_fallback_path_conformance_test dgb_gentx_share_path_test dgb_conn_pplns_producer_test dgb_other_tx_resolver_test \
                     dgb_other_tx_assembler_test dgb_reconstruct_won_block_test dgb_reconstruct_closure_test dgb_gentx_unpack_test dgb_work_source_test dgb_template_builder_test dgb_embedded_coin_node_test dgb_embedded_tx_select_test dgb_template_other_txs_test dgb_coinbase_value_parity_test dgb_submit_classify_test dgb_aux_parent_coinbase_parity_test dgb_template_capture_test dgb_aux_doge_db_commitment_bind_test dgb_aux_doge_mm_commitment_test dgb_aux_doge_dc_proof_test dgb_aux_doge_bind_parsers_test dgb_compact_blocks_bip152_parity_test dgb_aux_dual_target_select_test dgb_aux_broadcast_path_election_test \
@@ -211,7 +211,7 @@ jobs:
                     test_v36_script_sorting test_v36_cross_impl_refhash \
                     test_phase4_embedded \
                     test_mweb_builder \
-                    test_address_resolution test_compute_share_target \
+                    test_address_resolution test_compute_share_target test_web_honesty_regression \
                     test_utxo test_dgb_subsidy test_dgb_coinbase_value dgb_share_test dgb_redistribute_test dgb_block_assembly_test dgb_witness_commitment_test dgb_header_sample_build_test dgb_header_ingest_test dgb_mempool_ingest_test \
                     dgb_gentx_coinbase_test dgb_connection_coinbase_test dgb_pplns_payout_split_test nmc_auxpow_merkle_test nmc_template_builder_test nmc_auxpow_wire_test nmc_reconstruct_won_block_test nmc_mempool_name_test nmc_block_broadcast_test nmc_host_dualpath_test nmc_fallback_path_conformance_test dgb_gentx_share_path_test dgb_conn_pplns_producer_test dgb_other_tx_resolver_test \
                     dgb_other_tx_assembler_test dgb_reconstruct_won_block_test dgb_reconstruct_closure_test dgb_gentx_unpack_test dgb_work_source_test dgb_template_builder_test dgb_embedded_coin_node_test dgb_embedded_tx_select_test dgb_template_other_txs_test dgb_coinbase_value_parity_test dgb_submit_classify_test dgb_aux_parent_coinbase_parity_test dgb_template_capture_test dgb_aux_doge_db_commitment_bind_test dgb_aux_doge_mm_commitment_test dgb_aux_doge_dc_proof_test dgb_aux_doge_bind_parsers_test dgb_compact_blocks_bip152_parity_test dgb_aux_dual_target_select_test dgb_aux_broadcast_path_election_test \

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -709,4 +709,15 @@ if (BUILD_TESTING AND GTest_FOUND)
     )
     target_link_libraries(test_compute_share_target PRIVATE c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage ltc_coin pool)  # OBJECT-lib SCC direct-naming (#22/#39)
     gtest_add_tests(test_compute_share_target "" AUTO)
+    add_executable(test_web_honesty_regression test_web_honesty_regression.cpp)
+    target_link_libraries(test_web_honesty_regression PRIVATE
+        GTest::gtest_main GTest::gtest
+        core ltc
+        nlohmann_json::nlohmann_json
+        ${Boost_LIBRARIES}
+    )
+    target_link_libraries(test_web_honesty_regression PRIVATE c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage ltc_coin pool)  # OBJECT-lib SCC direct-naming (#22/#39)
+    gtest_add_tests(test_web_honesty_regression "" AUTO)
+
 endif()
+

--- a/test/test_web_honesty_regression.cpp
+++ b/test/test_web_honesty_regression.cpp
@@ -1,0 +1,74 @@
+// Web honesty-regression KAT (SAFE-ADDITIVE characterization test).
+//
+// Charter: "A dashboard must never lie about prod health." (founding bug
+// 2026-06-22 -- the getinfo / local_stats surface reported connections=0 and
+// poolhashps=0 while the node was fully peered + mining, because the embedded
+// prod build runs MiningInterface with an UNPOPULATED m_node (the enhanced_node
+// stub whose peer/hashrate/share accessors all return 0). It lied to the
+// operator TWICE in one night about contabo LTC+DOGE prod health.)
+//
+// This test pins the un-stub fix in place: it constructs MiningInterface with
+// node == nullptr -- the exact embedded-prod topology that produced the false
+// zeros -- and verifies getinfo() sources connections / poolhashps / poolshares
+// / difficulty from the live MiningInterface hooks instead of collapsing to the
+// historical 0-stubs. If anyone re-introduces the m_node-only path, these
+// expectations fail loudly.
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+#include <core/web_server.hpp>
+
+using namespace core;
+using nlohmann::json;
+
+// With an empty m_node but live hooks wired, getinfo must report TRUTH, not the
+// historical zeros.
+TEST(WebHonestyRegression, GetInfoSourcesLiveHooksNotZeroStubs) {
+    // node == nullptr: the embedded-prod topology where every m_node accessor
+    // returns 0 -- the founding-bug scenario.
+    MiningInterface mi(/*testnet=*/true, /*node=*/nullptr);
+
+    // 7 real c2pool share-peers (the prod node ran 6-7 V36 share peers on the
+    // night of the founding bug while the dashboard said "0").
+    mi.set_peer_info_fn([] {
+        json peers = json::array();
+        for (int i = 0; i < 7; ++i)
+            peers.push_back(json{{"addr", "10.0.0." + std::to_string(i)}});
+        return peers;
+    });
+    // Real pool hashrate -- 62.2 GH/s was the verified contabo prod truth once
+    // the stub was fixed (see founding-charter-verified-prod).
+    mi.set_pool_hashrate_fn([] { return 62.2e9; });
+    // Live sharechain stats (same truthful source #462 used for stale/DOA).
+    mi.set_sharechain_stats_fn([] {
+        return json{{"total_shares", 12345}, {"average_difficulty", 1024.0}};
+    });
+
+    json r = mi.getinfo("kat");
+
+    // The four metrics that the founding bug zeroed out:
+    EXPECT_EQ(r["connections"].get<int>(), 7)
+        << "share-peer count must come from m_peer_info_fn, not the 0-stub";
+    EXPECT_GT(r["poolhashps"].get<double>(), 0.0)
+        << "pool hashrate must come from m_pool_hashrate_fn, not the 0-stub";
+    EXPECT_DOUBLE_EQ(r["poolhashps"].get<double>(), 62.2e9);
+    EXPECT_EQ(r["poolshares"].get<uint64_t>(), 12345u)
+        << "poolshares must come from the live sharechain stats hook";
+    EXPECT_GT(r["difficulty"].get<double>(), 0.0)
+        << "difficulty must come from the live sharechain stats hook";
+}
+
+// Belt-and-braces: a nodeless interface with NO hooks still returns a
+// well-formed object whose un-stub keys are STRUCTURALLY present (value 0).
+// Absent telemetry reporting a structural 0 ("not instrumented") is honest --
+// distinct from the founding lie of reporting 0 while live data exists.
+TEST(WebHonestyRegression, GetInfoWellFormedWithoutHooks) {
+    MiningInterface mi(/*testnet=*/true, /*node=*/nullptr);
+
+    json r = mi.getinfo("kat");
+    ASSERT_TRUE(r.is_object());
+    EXPECT_TRUE(r.contains("connections"));
+    EXPECT_TRUE(r.contains("poolhashps"));
+    EXPECT_TRUE(r.contains("poolshares"));
+    EXPECT_TRUE(r.contains("difficulty"));
+}


### PR DESCRIPTION
SAFE-ADDITIVE characterization KAT pinning the founding-charter un-stub fix.

**Charter:** a dashboard must never lie about prod health. On 2026-06-22 the getinfo/local_stats surface reported connections=0 and poolhashps=0 while the contabo LTC+DOGE node was fully peered + mining (~129 GH/s), because the embedded prod build runs MiningInterface with an unpopulated m_node stub whose peer/hashrate/share accessors return 0.

**What this locks in:** the test constructs MiningInterface with node==nullptr (the exact embedded-prod topology) and asserts getinfo() sources connections / poolhashps / poolshares / difficulty from the live MiningInterface hooks (m_peer_info_fn, m_pool_hashrate_fn, m_sharechain_stats_fn) instead of the 0-stubs. A second case documents that a nodeless, hookless interface still emits those keys structurally (an honest "not instrumented" 0).

**Scope:** pure test addition (test/ only); no production code changed. Web layer / non-consensus.

Built clean and both cases pass locally.
