### PR TITLE
fix(dgb): read softfork state from getdeploymentinfo on Core-26 daemons (G3b slice-ii (c))

### DIFF
--- a/src/impl/dgb/coin/rpc.cpp
+++ b/src/impl/dgb/coin/rpc.cpp
@@ -241,6 +241,23 @@ bool NodeRPC::check()
 	if (blockchaininfo.contains("bip9_softforks"))
 		dgb::coin::collect_softfork_names(blockchaininfo["bip9_softforks"], softforks_supported);
 
+	// DigiByte Core 8.26.2 (Bitcoin Core 26 base) no longer reports softfork
+	// status under getblockchaininfo["softforks"]; it moved to the dedicated
+	// getdeploymentinfo RPC. Read it when the legacy fields are absent so the
+	// readiness gate sees the real deployment set on Core-26 daemons (whose
+	// young chains otherwise expose only csv/segwit via GBT rules).
+	if (softforks_supported.empty())
+	{
+		try
+		{
+			dgb::coin::collect_deployment_names(getdeploymentinfo(), softforks_supported);
+		}
+		catch (const std::exception&)
+		{
+			// Older daemons lack getdeploymentinfo; fall through to GBT rules.
+		}
+	}
+
 	// Fallback for daemons that don't populate getblockchaininfo softfork fields.
 	if (softforks_supported.empty())
 	{
@@ -425,6 +442,11 @@ nlohmann::json NodeRPC::getnetworkinfo()
 nlohmann::json NodeRPC::getblockchaininfo()
 {
 	return CallAPIMethod("getblockchaininfo");
+}
+
+nlohmann::json NodeRPC::getdeploymentinfo()
+{
+	return CallAPIMethod("getdeploymentinfo");
 }
 
 nlohmann::json NodeRPC::getmininginfo()

--- a/src/impl/dgb/coin/rpc.hpp
+++ b/src/impl/dgb/coin/rpc.hpp
@@ -97,6 +97,7 @@ public:
     nlohmann::json getblocktemplate(std::vector<std::string> rules);
     nlohmann::json getnetworkinfo();
 	nlohmann::json getblockchaininfo();
+	nlohmann::json getdeploymentinfo();
 	nlohmann::json getmininginfo();
 	// verbose: true -- json result, false -- hex-encode result;
 	nlohmann::json getblockheader(uint256 header, bool verbose = true);

--- a/src/impl/dgb/coin/softfork_check.hpp
+++ b/src/impl/dgb/coin/softfork_check.hpp
@@ -36,4 +36,30 @@ inline void collect_softfork_names(const nlohmann::json& value,
     }
 }
 
+/**
+ * Populate `out` with deployment names from a getdeploymentinfo RPC result.
+ *
+ * DigiByte Core 8.26.2 (Bitcoin Core 26 base) no longer reports softfork
+ * status under getblockchaininfo["softforks"]; that data moved to the
+ * dedicated getdeploymentinfo RPC, whose "deployments" field is an object
+ * keyed by deployment name, e.g.:
+ *   {"deployments":{"csv":{...},"segwit":{...},"reservealgo":{...}, ...}}
+ *
+ * This reuses the object-keyed branch of collect_softfork_names so the
+ * readiness gate observes identical name semantics across the Core-22 ->
+ * Core-26 RPC drift (a name present here means the daemon knows that
+ * deployment, exactly as a key under the legacy "softforks" object did).
+ * No-op if the result lacks a "deployments" object (older daemons, or an
+ * error result), so it is always safe to call as a fallback.
+ */
+inline void collect_deployment_names(const nlohmann::json& getdeploymentinfo_result,
+                                     std::set<std::string>& out)
+{
+    if (getdeploymentinfo_result.is_object()
+        && getdeploymentinfo_result.contains("deployments"))
+    {
+        collect_softfork_names(getdeploymentinfo_result["deployments"], out);
+    }
+}
+
 } // namespace dgb::coin

--- a/src/impl/dgb/test/softfork_check_test.cpp
+++ b/src/impl/dgb/test/softfork_check_test.cpp
@@ -11,6 +11,11 @@
 //   2. array of strings:  ["segwit","taproot", ...]    (compact form)
 //   3. object with keys:  {"segwit":{...}, ...}         (BIP9 style)
 //
+// It also pins collect_deployment_names(), which reads the getdeploymentinfo
+// RPC ("deployments" object) used as the readiness-gate source on DigiByte
+// Core 8.26.2 (Bitcoin Core 26 base), where getblockchaininfo no longer
+// carries the "softforks" field.
+//
 // Header-only + nlohmann + gtest -- no boost::beast/jsonrpccxx transport, so it
 // builds standalone without entering the dgb OBJECT lib (same gate-safe shape
 // as rpc_request_test.cpp).
@@ -24,6 +29,7 @@
 #include <string>
 
 using dgb::coin::collect_softfork_names;
+using dgb::coin::collect_deployment_names;
 using json = nlohmann::json;
 
 // --- Format 1: array of objects (modern digibyted) --------------------------
@@ -105,4 +111,77 @@ TEST(DgbSoftforkCheck, ScalarValueIsNoOp)
     collect_softfork_names(json(7), out);
     collect_softfork_names(json("segwit"), out);  // bare scalar, not a container
     EXPECT_TRUE(out.empty());
+}
+
+// --- getdeploymentinfo path (DigiByte Core 8.26.2 / Bitcoin Core 26) --------
+//
+// On Core-26 daemons getblockchaininfo drops "softforks"/"bip9_softforks";
+// the readiness gate must instead read getdeploymentinfo["deployments"], an
+// object keyed by deployment name. collect_deployment_names() bridges that
+// result into the same name set the gate already consumes.
+
+TEST(DgbDeploymentInfo, Core26DeploymentsObjectCollectsAllNames)
+{
+    // Shape mirrors DigiByte 8.26.2 getdeploymentinfo: each deployment is an
+    // object (buried or bip9), keyed by name. The DGB-specific algo forks
+    // (reservealgo, odo) and nversionbips appear here even before activation.
+    auto v = json::parse(R"({
+        "hash": "00ff",
+        "height": 123,
+        "deployments": {
+            "csv": {"type":"buried","active":true,"height":1},
+            "segwit": {"type":"buried","active":true,"height":1},
+            "taproot": {"type":"bip9","bip9":{"status":"defined","bit":2},"active":false},
+            "nversionbips": {"type":"bip9","bip9":{"status":"started","bit":1},"active":false},
+            "reservealgo": {"type":"bip9","bip9":{"status":"defined","bit":3},"active":false},
+            "odo": {"type":"bip9","bip9":{"status":"defined","bit":4},"active":false}
+        }
+    })");
+    std::set<std::string> out;
+    collect_deployment_names(v, out);
+    EXPECT_EQ(out, (std::set<std::string>{
+        "csv", "segwit", "taproot", "nversionbips", "reservealgo", "odo"}));
+}
+
+TEST(DgbDeploymentInfo, RegressionGateForksDetectableFromDeployments)
+{
+    // The exact set the readiness gate was reporting "missing" on testnet4 when
+    // it could only read getblockchaininfo/GBT-rules (csv/segwit). All four
+    // required forks must be recoverable from the getdeploymentinfo result.
+    auto v = json::parse(R"({"deployments":{
+        "csv":{"active":true},"segwit":{"active":true},
+        "taproot":{"active":false},"nversionbips":{"active":false},
+        "reservealgo":{"active":false},"odo":{"active":false}}})");
+    std::set<std::string> out;
+    collect_deployment_names(v, out);
+    for (const char* req : {"taproot", "nversionbips", "reservealgo", "odo"})
+        EXPECT_TRUE(out.count(req)) << "required fork not detected: " << req;
+}
+
+TEST(DgbDeploymentInfo, MissingDeploymentsKeyIsNoOp)
+{
+    // A result lacking "deployments" (older daemon, or a non-conforming
+    // response) must be a safe no-op so the caller can fall through to GBT.
+    std::set<std::string> out{"segwit"};
+    collect_deployment_names(json::parse(R"({"hash":"00","height":1})"), out);
+    EXPECT_EQ(out, (std::set<std::string>{"segwit"}));
+}
+
+TEST(DgbDeploymentInfo, NonObjectResultIsNoOp)
+{
+    // null / scalar / array results (e.g. a swallowed RPC error) are no-ops.
+    std::set<std::string> out;
+    collect_deployment_names(json(nullptr), out);
+    collect_deployment_names(json(7), out);
+    collect_deployment_names(json::parse("[]"), out);
+    EXPECT_TRUE(out.empty());
+}
+
+TEST(DgbDeploymentInfo, AccumulatesIntoExistingSet)
+{
+    // Like collect_softfork_names, must append (never clear) so the gate can
+    // merge multiple sources.
+    std::set<std::string> out{"preexisting"};
+    collect_deployment_names(json::parse(R"({"deployments":{"segwit":{}}})"), out);
+    EXPECT_EQ(out, (std::set<std::string>{"preexisting", "segwit"}));
 }


### PR DESCRIPTION
## (c) of integrator's G3b slice-(ii) ruling — Core-26 softfork-gate API drift

Closes the `NodeRPC::check()` readiness-gate blocker that refused to boot
`c2pool-dgb` against the tuned testnet4 daemon (DigiByte 8.26.2 / Bitcoin
Core 26 base): the gate aborted with `missing softfork:
reservealgo/odo/nversionbips/taproot` even though the daemon supports them.

**Root cause:** Core-26 removed the top-level `getblockchaininfo["softforks"]`
/ `["bip9_softforks"]` objects; deployment status moved to the dedicated
`getdeploymentinfo` RPC (`deployments` object, keyed by deployment name). The
gate saw an empty softfork set and could only recover `csv`/`segwit` from GBT
rules on a young chain.

**Fix:**
- `NodeRPC::getdeploymentinfo()` RPC method (rpc.cpp/rpc.hpp).
- `dgb::coin::collect_deployment_names()` SSOT helper that reuses the
  object-keyed branch of `collect_softfork_names` — identical name semantics
  across the Core-22 -> Core-26 drift (a name present == daemon knows the
  deployment, exactly as a legacy `softforks`-object key did).
- `check()` reads `getdeploymentinfo()` as a fallback when the legacy fields
  are absent, *before* the GBT-rules fallback. Older daemons lacking the RPC
  fall through unchanged.

**Scope / safety:** Non-consensus startup readiness gate only. Single-coin,
fully fenced to `src/impl/dgb/`. No consensus-value change.

**Evidence:**
- `softfork_check_test` 13/13 (8 existing + 5 new `DgbDeploymentInfo` cases,
  including the exact testnet4 regression set `taproot/nversionbips/
  reservealgo/odo`).
- `dgb_coin` object lib (`rpc.cpp`) builds clean with the new call.

GPG-signed (G). Per ruling, the **(b)** dev-only-flag slice lands separately
and the actual slice-(ii) vote-tally read runs on the booted node next. This
PR does **not** assert a G3b PASS — that proof bar is the operator's open
ruling. NO self-merge; integrator merges on operator tap.
