### PR TITLE
fix(btc): gate regtest AddrStore load — polluted addrs.json never feeds the dialer (#506 follow-up)

### DIFF
--- a/src/core/addr_store.hpp
+++ b/src/core/addr_store.hpp
@@ -89,6 +89,13 @@ public:
     // for bootstrap
     void load(const std::vector<NetService>& addrs);
 
+    // Drop all in-memory addrs WITHOUT touching the persisted file on disk.
+    // Used to start an isolated net (e.g. --regtest) from the bootstrap list
+    // only, so a public-polluted persisted addrs.json never feeds the dialer.
+    // (#506 follow-up: pollution accumulates *within* the regtest namespace via
+    //  addr-exchange, so net-id path namespacing alone cannot prevent it.)
+    void clear() { m_data.clear(); }
+
     std::vector<AddrStorePair> get_all() const
     {
         std::vector<AddrStorePair> all;

--- a/src/core/test/CMakeLists.txt
+++ b/src/core/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (BUILD_TESTING AND (GTest_FOUND OR GTEST_FOUND))
-    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp)
+    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp addr_store_isolation_test.cpp)
     target_link_libraries(core_test PRIVATE GTest::gtest_main core c2pool_merged_mining GTest::gtest)
     target_link_libraries(core_test PRIVATE c2pool_payout c2pool_hashrate ltc_coin)  # OBJECT-lib SCC direct-naming (#22/#39)
 

--- a/src/core/test/addr_store_isolation_test.cpp
+++ b/src/core/test/addr_store_isolation_test.cpp
@@ -1,0 +1,72 @@
+// Regression lock for the #506 follow-up: a persisted addrs.json must never
+// re-feed the dialer of an isolated net (--regtest) after the regtest gate runs.
+//
+// Root cause (proven on the live regtest standup): the AddrStore constructor
+// reloads config_path()/<net>/addrs.json at startup. A prior regtest run
+// accumulates PUBLIC peers in that file via addr-exchange, so on restart they
+// are reloaded into the outbound dial set even though the store path is already
+// net-namespaced ("bitcoin_regtest"). The fix btc::Node applies under --regtest
+// is AddrStore::clear() before seeding bootstrap -> dial set starts empty.
+//
+// This KAT exercises the REAL persistence path (add()->save()->reconstruct->
+// from_json) and the REAL gate primitive (clear()) that the btc node ctor calls.
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <core/addr_store.hpp>
+#include <core/filesystem.hpp>
+#include <core/netaddress.hpp>
+
+using namespace core;
+
+namespace {
+// Unique coin/net name so the KAT never collides with a real config dir.
+const std::string kTestNet = "btc_regtest_addrstore_isolation_kat";
+
+std::filesystem::path test_dir()
+{
+    return core::filesystem::config_path() / kTestNet;
+}
+
+void wipe()
+{
+    std::error_code ec;
+    std::filesystem::remove_all(test_dir(), ec);
+}
+} // namespace
+
+// A persisted store reloads its public peers on reconstruct (the leak vector),
+// the regtest gate (clear()) empties the dial set, and the on-disk file SURVIVES
+// the clear (no user-data loss; the mainnet/testnet path is never gated).
+TEST(AddrStoreRegtestIsolation, PollutedFileNeverFeedsDialerAfterGate)
+{
+    std::filesystem::create_directories(test_dir());
+    wipe();
+    std::filesystem::create_directories(test_dir());
+
+    // Populate + persist three PUBLIC peers (simulates addr-exchange pollution).
+    {
+        AddrStore seeded(kTestNet);
+        seeded.add(NetService("8.8.8.8", uint16_t(9333)), {0, 1, 1});
+        seeded.add(NetService("1.1.1.1", uint16_t(9333)), {0, 1, 1});
+        seeded.add(NetService("9.9.9.9", uint16_t(9333)), {0, 1, 1});
+        ASSERT_EQ(seeded.len(), 3u);
+    }
+
+    // Fresh construct reloads the persisted public peers -> THIS is the leak the
+    // dialer would consume at startup if left ungated.
+    AddrStore reloaded(kTestNet);
+    EXPECT_EQ(reloaded.len(), 3u) << "persisted addrs.json must round-trip (leak vector)";
+
+    // The regtest gate (exactly what btc::Node calls under --regtest) empties the
+    // in-memory dial set -> bootstrap-only -> zero outbound dials.
+    reloaded.clear();
+    EXPECT_EQ(reloaded.len(), 0u) << "regtest gate must yield an empty dial set";
+
+    // The gate must NOT destroy the persisted file: a non-gated (mainnet/testnet)
+    // construct still reloads it intact. Proves clear() is dial-set-only.
+    AddrStore mainnet_view(kTestNet);
+    EXPECT_EQ(mainnet_view.len(), 3u) << "clear() must not touch the on-disk file";
+
+    wipe();
+}

--- a/src/impl/btc/node.hpp
+++ b/src/impl/btc/node.hpp
@@ -166,6 +166,15 @@ public:
             },
             15)  // p2pool p2p.py:80: timeout=15 for share requests
     {
+        // #506 follow-up: a persisted addrs.json from a prior regtest run
+        // accumulates public peers via addr-exchange; reloading them at startup
+        // re-feeds the outbound dialer (root-caused on the live standup: moving
+        // addrs.json aside -> 0 dials). The store path is already net-namespaced
+        // (config->m_name == "bitcoin_regtest"), but the pollution lives *inside*
+        // that namespace, so namespacing alone cannot prevent it. Under --regtest,
+        // start the dial set from bootstrap ONLY (zeroed) -> zero outbound dials.
+        if (config->m_regtest)
+            m_addrs.clear();
         // Seed addr store with hardcoded bootstrap peers
         m_addrs.load(config->pool()->m_bootstrap_addrs);
         // Randomise our nonce so we detect self-connections


### PR DESCRIPTION
Stacked follow-up to #506 (base = btc/regtest-mode). DRAFT — lands only AFTER #506 taps. I do not self-merge.

## Root cause (proven on the live regtest standup)
#506 isolates the regtest sharechain namespace + zeroes the compiled bootstrap list, but the standup still saw outbound dials to PUBLIC peers. Root cause: the AddrStore ctor reloads `config_path()/<net>/addrs.json` at startup, and a prior regtest run accumulates public peers in that file via addr-exchange. The store path is **already** net-namespaced (`config->m_name == bitcoin_regtest`), but the pollution lives *inside* that namespace, so namespacing alone cannot prevent it. Operationally confirmed: moving addrs.json aside -> 0 dials.

## Fix
Under `--regtest`, `btc::Node` clears the in-memory dial set before seeding the (zeroed) bootstrap list -> zero outbound dials. `AddrStore::clear()` is dial-set-only and never touches the on-disk file -> no user-data loss; the mainnet/testnet dial path is byte-identical (gate is `m_regtest`-only).

## EXCEPTIONAL — shared-layer touch (integrator req #1)
- `src/core/addr_store.hpp`: **pure-additive** `clear()` method. No behavior change to any existing path; no-op unless called. Only call site is the btc regtest gate.
- `src/impl/btc/node.hpp`: regtest-fenced (`if (config->m_regtest)`) — prod path untouched.
- Considered per-net-id path namespacing (integrator suggestion); rejected because the path is already namespaced and the pollution is in-namespace, so namespacing does not address this root cause. Documented inline.

## KAT (regression lock, req #2) — core_test (allowlisted)
`src/core/test/addr_store_isolation_test.cpp`: polluted addrs.json round-trips on reconstruct (proves the leak vector is real), `clear()` yields an empty dial set (the regtest gate -> zero dials), and the on-disk file survives the clear (mainnet path intact).

## Verification
- core_test 39/39 green (new KAT included); `make btc` exit 0.
- Signed, no third-party attribution.