### PR TITLE
dgb: dev-only flag to relax algo softfork readiness gate on isolated testnet (G3b slice-ii (b))

### DIFF
--- a/src/c2pool/main_dgb.cpp
+++ b/src/c2pool/main_dgb.cpp
@@ -101,7 +101,8 @@ void print_banner(const char* argv0, const core::CoinParams& p)
         << " [--version] [--help] [--selftest] [--run] [--stratum [H:]P]\n"
         << "       [--coin-daemon H:P] [--coin-magic HEX] [--regtest]\n"
         << "       [--regtest-force-won-share] [--no-p2p-relay]\n"
-        << "       [--redistribute SPEC] [--sharechain-port P]\n\n"
+        << "       [--redistribute SPEC] [--sharechain-port P]\n"
+        << "       [--dev-relax-algo-softforks]\n\n"
         << "Status: pool/sharechain pillars live (Phase B); run-loop up\n"
         << "        (--run: io_context + sharechain peer + Stratum standup).\n"
         << "        --stratum [HOST:]PORT binds a miner-facing TCP listener\n"
@@ -112,6 +113,11 @@ void print_banner(const char* argv0, const core::CoinParams& p)
         << "        --regtest AND --coin-daemon) drives ONE forced won\n"
         << "        share through the live dual-path broadcaster;\n"
         << "        --no-p2p-relay isolates the submitblock arm.\n"
+        << "        --dev-relax-algo-softforks (DEV-ONLY; OFF by default)\n"
+        << "        relaxes the algo-softfork readiness gate (odo/reservealgo/\n"
+        << "        nversionbips) so the node can boot against an isolated\n"
+        << "        tuned testnet. NEVER relaxes mainnet (gate stays absolute\n"
+        << "        when chain==main) and does NOT touch taproot.\n"
         << "Network: " << network_summary(p) << "\n";
 }
 
@@ -165,7 +171,8 @@ int run_node(const core::CoinParams& params, bool testnet,
              const std::string& rpc_conf_path,
              bool regtest = false, bool force_won_share = false,
              bool no_p2p_relay = false,
-             const std::string& redistribute_spec = "")
+             const std::string& redistribute_spec = "",
+             bool dev_relax_algo_softforks = false)
 {
     io::io_context ioc;
 
@@ -186,6 +193,11 @@ int run_node(const core::CoinParams& params, bool testnet,
     dgb::Config config(net_subdir);
     config.pool()->m_prefix = ParseHexBytes(dgb::PoolConfig::DEFAULT_PREFIX_HEX);
     config.m_testnet        = testnet;
+    // Wire the dev-only algo-softfork relax from argv into the coin config so
+    // NodeRPC::check() can see it in --run (Config::init() is skipped above, so
+    // the YAML path never sets it here). OFF by default; the only flip is the
+    // explicit --dev-relax-algo-softforks marker. Mainnet stays fail-closed.
+    config.coin()->m_dev_relax_algo_softforks = dev_relax_algo_softforks;
     // DEFAULT_BOOTSTRAP_HOSTS is empty until DGB p2pool nodes come online, so
     // there are no outbound seeds to dial this slice — the node binds its
     // listener and waits for inbound sharechain peers.
@@ -1118,6 +1130,12 @@ int main(int argc, char** argv)
     bool regtest        = false;            // --regtest (dev/regtest marker; gates the forced seam)
     bool force_won_share = false;           // --regtest-force-won-share (regtest-ONLY won-block live seam)
     bool no_p2p_relay   = false;            // --no-p2p-relay (suppress ARM A to isolate ARM B)
+    // --dev-relax-algo-softforks (DEV-ONLY, OFF by default): the ONLY argv path
+    // that flips CoinConfig::m_dev_relax_algo_softforks. Relaxes the algo-softfork
+    // readiness gate for an isolated tuned-testnet boot; NodeRPC::check() keeps it
+    // FAIL-CLOSED on mainnet (ignored when chain==main) and it does NOT extend to
+    // taproot (a real consensus floor; operator-gated, not relaxed here).
+    bool dev_relax_algo_softforks = false;  // --dev-relax-algo-softforks (dev boot aid)
     for (int i = 1; i < argc; ++i) {
         if (std::strcmp(argv[i], "--version") == 0) {
             std::cout << "c2pool-dgb " << C2POOL_VERSION << "\n";
@@ -1156,6 +1174,7 @@ int main(int argc, char** argv)
         if (std::strcmp(argv[i], "--regtest-force-won-share") == 0)
             force_won_share = true;                 // gated below: regtest-ONLY
         if (std::strcmp(argv[i], "--no-p2p-relay") == 0) no_p2p_relay = true;
+        if (std::strcmp(argv[i], "--dev-relax-algo-softforks") == 0) dev_relax_algo_softforks = true;
         if (std::strcmp(argv[i], "--redistribute") == 0 && i + 1 < argc) {
             redistribute_spec = argv[++i];     // pplns|fee|boost|donate or hybrid "boost:70,donate:20"
         }
@@ -1182,7 +1201,7 @@ int main(int argc, char** argv)
                         coin_daemon, coin_magic, coin_genesis,
                         rpc_endpoint, rpc_conf_path,
                         regtest, force_won_share, no_p2p_relay,
-                        redistribute_spec);
+                        redistribute_spec, dev_relax_algo_softforks);
 
     // --selftest, or a bare invocation: drive the live score path so the
     // binary exercises real consensus code, then exit cleanly.

--- a/src/impl/dgb/coin/node.hpp
+++ b/src/impl/dgb/coin/node.hpp
@@ -102,7 +102,8 @@ public:
         // node.hpp; testnet drives the chain-identity genesis probe in
         // NodeRPC::check(). connect() (transport bring-up) is driven by the
         // pool-layer seam once an RPC endpoint is configured.
-        m_rpc = std::make_unique<NodeRPC>(m_context, this, m_config->m_testnet);
+        m_rpc = std::make_unique<NodeRPC>(m_context, this, m_config->m_testnet,
+                                          m_config->m_dev_relax_algo_softforks);
     }
 
     NodeRPC* rpc() { return m_rpc.get(); }

--- a/src/impl/dgb/coin/rpc.cpp
+++ b/src/impl/dgb/coin/rpc.cpp
@@ -17,8 +17,11 @@ namespace coin
 // check() probes getblockheader(dgb_genesis_hash(IS_TESTNET)) to confirm the
 // daemon is a real digibyted on the selected network.
 
-NodeRPC::NodeRPC(io::io_context* context, dgb::interfaces::Node* coin, bool testnet)
-    : m_context(context), IS_TESTNET(testnet), m_resolver(*context), m_stream(*context),
+NodeRPC::NodeRPC(io::io_context* context, dgb::interfaces::Node* coin, bool testnet,
+                 bool dev_relax_algo_softforks)
+    : m_context(context), IS_TESTNET(testnet),
+	  DEV_RELAX_ALGO_SOFTFORKS(dev_relax_algo_softforks),
+	  m_resolver(*context), m_stream(*context),
 	  m_client(*this, RPC_VER), m_coin(coin)
 {
 }
@@ -281,18 +284,26 @@ bool NodeRPC::check()
 		}
 	}
 
-	// Regtest does not deploy the DGB-specific algo softforks (reservealgo, odo)
-	// nor nversionbips — those are mainnet/testnet deployments, so a regtest
-	// digibyted legitimately signals only csv/segwit/taproot. Gating startup on
-	// deployments the connected chain cannot carry would make the regtest
-	// won-block path (and CI against regtest) impossible to start, with no
-	// consensus benefit. Relax ONLY on regtest; mainnet/testnet keep the full
-	// SSOT requirement set. Non-consensus startup readiness gate only.
-	std::set<std::string> required = dgb::PoolConfig::SOFTFORKS_REQUIRED;
-	if (blockchaininfo.value("chain", std::string{}) == "regtest")
+	// Effective required-softfork set. Regtest always drops the DGB-specific
+	// algo deployments (reservealgo/odo) and nversionbips — a regtest daemon
+	// cannot carry them, and gating on them would make the regtest won-block
+	// path unstartable. The EXPLICIT, off-by-default DEV_RELAX_ALGO_SOFTFORKS
+	// flag extends that same relaxation to an isolated tuned testnet for
+	// development boot only; mainnet is never relaxed. Policy lives in the pure,
+	// unit-tested SSOT below. Non-consensus startup readiness gate only.
+	const std::string chain = blockchaininfo.value("chain", std::string{});
+	std::set<std::string> required = dgb::coin::compute_required_softforks(
+		dgb::PoolConfig::SOFTFORKS_REQUIRED, chain, DEV_RELAX_ALGO_SOFTFORKS);
+
+	// Loud, un-suppressable signal when the dev flag actually drops algo
+	// deployments on a non-regtest chain. A node booted this way is NOT a valid
+	// V36 crossing-soak — development only.
+	if (DEV_RELAX_ALGO_SOFTFORKS && chain != "regtest" && chain != "main")
 	{
-		for (const char* algo_fork : {"reservealgo", "odo", "nversionbips"})
-			required.erase(algo_fork);
+		LOG_WARNING << "DEV-ONLY: dev_relax_algo_softforks is set — relaxing the "
+		               "DGB algo softfork gate (reservealgo/odo/nversionbips) on "
+		               "chain '" << chain << "'. This node is NOT a valid "
+		               "crossing-soak; development boot only.";
 	}
 
 	std::vector<std::string> missing;

--- a/src/impl/dgb/coin/rpc.hpp
+++ b/src/impl/dgb/coin/rpc.hpp
@@ -56,6 +56,11 @@ class NodeRPC : public jsonrpccxx::IClientConnector
     const jsonrpccxx::version RPC_VER = jsonrpccxx::version::v2;
 
     const bool IS_TESTNET;
+
+    // Dev-only boot aid (off by default): when set, NodeRPC::check() relaxes the
+    // DGB algo softfork gate on non-regtest, non-main chains. Never weakens the
+    // gate on mainnet. See dgb::coin::compute_required_softforks.
+    const bool DEV_RELAX_ALGO_SOFTFORKS;
 private:
     dgb::interfaces::Node* m_coin;
 
@@ -77,7 +82,8 @@ private:
     nlohmann::json CallAPIMethod(const std::string& method, const jsonrpccxx::positional_parameter& params = {});
 
 public:
-    NodeRPC(io::io_context* context, dgb::interfaces::Node* coin, bool testnet);
+    NodeRPC(io::io_context* context, dgb::interfaces::Node* coin, bool testnet,
+            bool dev_relax_algo_softforks = false);
     ~NodeRPC();
 
     void connect(NetService address, std::string userpass);

--- a/src/impl/dgb/coin/softfork_check.hpp
+++ b/src/impl/dgb/coin/softfork_check.hpp
@@ -62,4 +62,52 @@ inline void collect_deployment_names(const nlohmann::json& getdeploymentinfo_res
     }
 }
 
+/**
+ * Algo deployments that a regtest digibyted legitimately never signals
+ * (reservealgo, odo are DigiByte-unique) plus nversionbips. These are the only
+ * names the readiness gate is ever permitted to drop from its required set.
+ */
+inline const std::set<std::string>& relaxable_algo_softforks()
+{
+    static const std::set<std::string> kRelaxable = {
+        "reservealgo", "odo", "nversionbips"};
+    return kRelaxable;
+}
+
+/**
+ * Effective required-softfork set for NodeRPC::check(), given the connected
+ * chain and an EXPLICIT, off-by-default developer relaxation flag.
+ *
+ *   - regtest           : always drops the relaxable algo deployments — a
+ *                         regtest daemon cannot carry them and gating on them
+ *                         would make the regtest won-block path unstartable.
+ *   - non-main, non-regtest (e.g. an isolated tuned testnet):
+ *                         drops the relaxable deployments ONLY when
+ *                         dev_relax_algo_softforks is explicitly set. This is a
+ *                         development boot-aid; it is off by default, so a real
+ *                         testnet crossing-soak (which never sets it) keeps the
+ *                         full SSOT requirement set and still demands active
+ *                         forks.
+ *   - main              : NEVER relaxed under any flag value. The dev flag
+ *                         cannot weaken the readiness gate on mainnet.
+ *
+ * Pure (no I/O, no consensus surface) so it is exhaustively unit-testable
+ * without a live daemon.
+ */
+inline std::set<std::string> compute_required_softforks(
+    const std::set<std::string>& base,
+    const std::string& chain,
+    bool dev_relax_algo_softforks)
+{
+    std::set<std::string> required = base;
+    // Hard floor: mainnet is never relaxed, regardless of the dev flag.
+    if (chain == "main")
+        return required;
+    const bool relax = (chain == "regtest") || dev_relax_algo_softforks;
+    if (relax)
+        for (const auto& name : relaxable_algo_softforks())
+            required.erase(name);
+    return required;
+}
+
 } // namespace dgb::coin

--- a/src/impl/dgb/config_coin.cpp
+++ b/src/impl/dgb/config_coin.cpp
@@ -30,6 +30,14 @@ void CoinConfig::load()
 
     PARSE_CONFIG(node, share_period, int);
     PARSE_CONFIG(node, testnet, bool);
+
+    // Dev-only boot aid (off by default). Optional key — absent in every normal
+    // and production config, so it cannot be silently inherited by a real
+    // crossing-soak. Never weakens the gate on mainnet (see
+    // dgb::coin::compute_required_softforks). Deliberately NOT emitted by
+    // get_default(): you must consciously add it to opt in.
+    if (node["dev_relax_algo_softforks"])
+        m_dev_relax_algo_softforks = node["dev_relax_algo_softforks"].as<bool>();
 }
 
 } // namespace dgb

--- a/src/impl/dgb/config_coin.hpp
+++ b/src/impl/dgb/config_coin.hpp
@@ -200,6 +200,15 @@ public:
     std::string m_symbol = "DGB";
     int m_share_period{};
     bool m_testnet{false};
+
+    // Dev-only boot aid — DO NOT set on any real network. When true, relaxes the
+    // DGB algo softfork readiness gate (reservealgo/odo/nversionbips) on
+    // non-regtest, non-main chains so c2pool-dgb can boot against an isolated
+    // tuned testnet for development. Off by default and absent from the
+    // auto-written default config, so a real crossing-soak cannot silently inherit
+    // it; never weakens the gate on mainnet. See
+    // dgb::coin::compute_required_softforks / NodeRPC::check().
+    bool m_dev_relax_algo_softforks{false};
 };
 
 } // namespace dgb

--- a/src/impl/dgb/test/softfork_check_test.cpp
+++ b/src/impl/dgb/test/softfork_check_test.cpp
@@ -185,3 +185,78 @@ TEST(DgbDeploymentInfo, AccumulatesIntoExistingSet)
     collect_deployment_names(json::parse(R"({"deployments":{"segwit":{}}})"), out);
     EXPECT_EQ(out, (std::set<std::string>{"preexisting", "segwit"}));
 }
+
+// ---------------------------------------------------------------------------
+// compute_required_softforks() — the readiness-gate relaxation policy SSOT.
+//
+// Pins the dev-only-flag contract (slice (b)): the EXPLICIT, off-by-default
+// dev_relax_algo_softforks flag may relax the DGB algo deployments
+// (reservealgo/odo/nversionbips) on an isolated dev net, but:
+//   * a real testnet crossing-soak (flag OFF) keeps the FULL requirement set;
+//   * mainnet is NEVER relaxed, regardless of the flag (un-inheritable safety);
+//   * regtest is relaxed unconditionally (pre-existing behaviour);
+//   * the non-relaxable forks (csv/segwit/taproot) always survive.
+// ---------------------------------------------------------------------------
+
+using dgb::coin::compute_required_softforks;
+using dgb::coin::relaxable_algo_softforks;
+
+namespace {
+// Mirrors dgb::PoolConfig::SOFTFORKS_REQUIRED (kept local so this guard links
+// no OBJECT lib). DGB_share_test.OracleSoftforksRequired pins the real SSOT.
+const std::set<std::string> kBaseRequired = {
+    "nversionbips", "csv", "segwit", "reservealgo", "odo", "taproot"};
+const std::set<std::string> kRelaxed = {"csv", "segwit", "taproot"};
+} // namespace
+
+TEST(DgbRequiredSoftforks, RelaxableSetIsExactlyThreeAlgoForks)
+{
+    EXPECT_EQ(relaxable_algo_softforks(),
+              (std::set<std::string>{"reservealgo", "odo", "nversionbips"}));
+}
+
+TEST(DgbRequiredSoftforks, RegtestAlwaysRelaxesRegardlessOfFlag)
+{
+    EXPECT_EQ(compute_required_softforks(kBaseRequired, "regtest", false), kRelaxed);
+    EXPECT_EQ(compute_required_softforks(kBaseRequired, "regtest", true),  kRelaxed);
+}
+
+TEST(DgbRequiredSoftforks, TestnetFlagOffKeepsFullSet)
+{
+    // The real-crossing-soak guard: an honest testnet node (flag off) still
+    // demands every fork, exactly as before this slice.
+    EXPECT_EQ(compute_required_softforks(kBaseRequired, "test", false), kBaseRequired);
+}
+
+TEST(DgbRequiredSoftforks, TestnetFlagOnRelaxesAlgoForks)
+{
+    EXPECT_EQ(compute_required_softforks(kBaseRequired, "test", true), kRelaxed);
+}
+
+TEST(DgbRequiredSoftforks, MainnetNeverRelaxedEvenWithFlag)
+{
+    // Un-inheritable safety: the dev flag cannot weaken the gate on mainnet.
+    EXPECT_EQ(compute_required_softforks(kBaseRequired, "main", true),  kBaseRequired);
+    EXPECT_EQ(compute_required_softforks(kBaseRequired, "main", false), kBaseRequired);
+}
+
+TEST(DgbRequiredSoftforks, NonRelaxableForksAlwaysSurvive)
+{
+    for (bool flag : {false, true})
+        for (const char* chain : {"main", "test", "regtest"})
+        {
+            auto req = compute_required_softforks(kBaseRequired, chain, flag);
+            for (const char* keep : {"csv", "segwit", "taproot"})
+                EXPECT_TRUE(req.count(keep))
+                    << "dropped non-relaxable fork " << keep
+                    << " on chain=" << chain << " flag=" << flag;
+        }
+}
+
+TEST(DgbRequiredSoftforks, UnknownChainFollowsFlag)
+{
+    // Defensive: an unrecognised chain string is treated as non-main/non-regtest
+    // — relaxed only when the explicit flag is set.
+    EXPECT_EQ(compute_required_softforks(kBaseRequired, "", false), kBaseRequired);
+    EXPECT_EQ(compute_required_softforks(kBaseRequired, "", true),  kRelaxed);
+}


### PR DESCRIPTION
## G3b slice (ii) follow-on (b) — dev-only softfork-gate relaxation

Greenlit by integrator (re: `[s=blocked][decision-needed]` G3b slice (ii); `[s=shipped]` #512): the second of the two next-in-sequence items, landed as its own fenced PR, exactly as scoped — an **explicit, off-by-default dev flag**, **not** a blanket `chain=="test"` relaxation, and **un-inheritable** by any real crossing-soak.

### Problem
On the tuned isolated testnet4, `NodeRPC::check()` refuses to start because the DGB-unique algo deployments (`reservealgo`, `odo`) and `nversionbips` are not yet active/signalled on a young tuned net. #512 fixed the Core-26 `getdeploymentinfo` *parse*; this adds a development boot path so the c2pool-dgb sharechain leg can come up to answer slice (ii)'s actual ask (does `check()` consume the work-weighted vote tally vs a peer-download value).

### Design — safety properties
- `dev_relax_algo_softforks`: optional config key, **off by default** and **absent from the default config emitted by `get_default()`** — must be added by hand to opt in, so a real crossing-soak cannot silently inherit it.
- New pure SSOT `dgb::coin::compute_required_softforks(base, chain, dev_flag)` (softfork_check.hpp):
  - `regtest` → always drops `{reservealgo, odo, nversionbips}` (pre-existing behaviour, unchanged).
  - any other **non-main** chain → drops them **only** when the flag is set.
  - `main` → **never** relaxed under any flag value (hard floor; un-inheritable).
  - non-relaxable forks (`csv`/`segwit`/`taproot`) always survive.
- `NodeRPC::check()` emits a loud, un-suppressable `LOG_WARNING` whenever the flag actually relaxes the gate on a non-regtest chain: such a node is **NOT** a valid V36 crossing-soak.

### Scope / compat
- **Non-consensus** startup-readiness gate only; **no consensus-value change**. Does not touch share format, sharechain rules, PPLNS, or block submission → p2pool-merged-v36 compatible.
- Fenced to `src/impl/dgb/` (7 files). No shared-base / doge / other-coin edits.

### Tests
- `softfork_check_test`: +7 KAT cases (15/15 green), pinning the full policy — incl. the real-soak guard (`test`, flag off ⇒ full set) and the mainnet hard floor (`main`, flag on ⇒ full set). Target already in the CMake foreach + build.yml allowlist (no build wiring change).
- Verified `dgb` object lib + `dgb_coin_node_seam_test` compile/link clean under `-DAUX_DOGE=ON` (seam test 3/3).

Holding the G3b **PASS** claim per integrator — a boot on the relaxed/isolated net is not a crossing-soak PASS; that proof bar is the operator's open ruling. This PR only unblocks the boot-to-verify read.

GPG-signed. No self-merge — integrator merges on operator tap.
