### PR TITLE
test(web): extend honesty-regression KAT to getstats + getpeerinfo (SAFE-ADDITIVE)

### DIFF
--- a/test/test_web_honesty_regression.cpp
+++ b/test/test_web_honesty_regression.cpp
@@ -72,3 +72,91 @@ TEST(WebHonestyRegression, GetInfoWellFormedWithoutHooks) {
     EXPECT_TRUE(r.contains("poolshares"));
     EXPECT_TRUE(r.contains("difficulty"));
 }
+
+// --- getstats: same founding-bug surface as getinfo --------------------------
+// getstats() reported connected_peers=0 / pool_hashrate=0 and zeroed orphan/DOA/
+// stale share counts whenever m_node was the empty embedded-prod stub, while
+// /stale_rates (the same m_sharechain_stats_fn hook) showed the truth. Pin the
+// un-stub: with node==nullptr and live hooks wired, pool_statistics must report
+// real peers / hashrate / orphan / DOA / stale.
+TEST(WebHonestyRegression, GetStatsSourcesLiveHooksNotZeroStubs) {
+    MiningInterface mi(/*testnet=*/true, /*node=*/nullptr);
+
+    mi.set_peer_info_fn([] {
+        json peers = json::array();
+        for (int i = 0; i < 7; ++i)
+            peers.push_back(json{{"addr", "10.0.0." + std::to_string(i)}});
+        return peers;
+    });
+    mi.set_pool_hashrate_fn([] { return 62.2e9; });
+    // 1000 total shares, 30 orphan + 10 dead -> 40 stale, 4% stale_prop.
+    mi.set_sharechain_stats_fn([] {
+        return json{{"total_shares", 1000}, {"orphan_shares", 30}, {"dead_shares", 10}};
+    });
+
+    json r = mi.getstats("kat");
+    ASSERT_TRUE(r.contains("pool_statistics"));
+    const json& ps = r["pool_statistics"];
+
+    EXPECT_EQ(ps["connected_peers"].get<int>(), 7)
+        << "connected_peers must come from m_peer_info_fn, not the 0-stub";
+    EXPECT_DOUBLE_EQ(ps["pool_hashrate"].get<double>(), 62.2e9)
+        << "pool_hashrate must come from m_pool_hashrate_fn, not the 0-stub";
+    EXPECT_EQ(ps["orphan_shares"].get<uint64_t>(), 30u)
+        << "orphan_shares must come from the live sharechain stats hook";
+    EXPECT_EQ(ps["doa_shares"].get<uint64_t>(), 10u)
+        << "doa_shares must come from the live sharechain stats hook";
+    EXPECT_EQ(ps["stale_shares"].get<uint64_t>(), 40u)
+        << "stale_shares = orphan + dead from the live hook";
+    EXPECT_DOUBLE_EQ(ps["stale_prop"].get<double>(), 0.04)
+        << "stale_prop = (orphan+dead)/total from the live hook";
+}
+
+// Belt-and-braces: nodeless interface with NO hooks still returns a well-formed
+// getstats whose un-stub keys are structurally present (honest 0 = "not
+// instrumented", distinct from the founding lie of 0-while-live-data-exists).
+TEST(WebHonestyRegression, GetStatsWellFormedWithoutHooks) {
+    MiningInterface mi(/*testnet=*/true, /*node=*/nullptr);
+
+    json r = mi.getstats("kat");
+    ASSERT_TRUE(r.contains("pool_statistics"));
+    const json& ps = r["pool_statistics"];
+    EXPECT_TRUE(ps.contains("connected_peers"));
+    EXPECT_TRUE(ps.contains("pool_hashrate"));
+    EXPECT_TRUE(ps.contains("orphan_shares"));
+    EXPECT_TRUE(ps.contains("doa_shares"));
+    EXPECT_TRUE(ps.contains("stale_shares"));
+}
+
+// --- getpeerinfo: the real per-peer list, not the 0-count fallback -----------
+// On the embedded-prod build m_node->get_connected_peers_count() returns 0 while
+// the node is fully peered. getpeerinfo() must return the real per-peer list
+// from m_peer_info_fn -- not the single {connected_peers:0} aggregate fallback.
+TEST(WebHonestyRegression, GetPeerInfoReturnsLivePeerListNotZeroStub) {
+    MiningInterface mi(/*testnet=*/true, /*node=*/nullptr);
+
+    mi.set_peer_info_fn([] {
+        json peers = json::array();
+        for (int i = 0; i < 7; ++i)
+            peers.push_back(json{{"addr", "10.0.0." + std::to_string(i)}});
+        return peers;
+    });
+
+    json r = mi.getpeerinfo("kat");
+    ASSERT_TRUE(r.is_array());
+    EXPECT_EQ(r.size(), 7u)
+        << "getpeerinfo must return the real per-peer list from m_peer_info_fn";
+    EXPECT_EQ(r[0]["addr"].get<std::string>(), "10.0.0.0");
+}
+
+// Without a live hook and without a node, getpeerinfo returns an empty array --
+// honest absence (no peers reported because none are observable), never a
+// fabricated count.
+TEST(WebHonestyRegression, GetPeerInfoEmptyWithoutHooksIsHonest) {
+    MiningInterface mi(/*testnet=*/true, /*node=*/nullptr);
+
+    json r = mi.getpeerinfo("kat");
+    ASSERT_TRUE(r.is_array());
+    EXPECT_TRUE(r.empty())
+        << "no node + no hook -> empty list (honest absence), not a fake count";
+}


### PR DESCRIPTION
Follow-up to #510. Extends the web honesty-regression KAT from getinfo to its two sibling endpoints that carried the **identical founding-bug 0-stub risk** (2026-06-22, contabo prod lied about peers/hashrate while fully mining):

- **getstats** — `pool_statistics{connected_peers, pool_hashrate, orphan_shares, doa_shares, stale_shares, stale_prop}` must source from `m_peer_info_fn` / `m_pool_hashrate_fn` / `m_sharechain_stats_fn`, not the empty embedded-prod `m_node` (the un-stub landed in #462).
- **getpeerinfo** — must return the real per-peer list from `m_peer_info_fn`, not the single `{connected_peers:0}` aggregate fallback (un-stub landed in #464).

Each also gets a *well-formed-without-hooks* case proving a structural 0 / empty array (honest absence) is preserved — distinct from the founding lie of reporting 0 while live data exists.

Pure test addition; no production code touched. Built + ran locally: **6/6 green**. Reintroducing the `m_node`-only path now fails CI on these endpoints too.