### PR TITLE
btc: coinbase subsidy honors per-network halving interval (G3b leg-b fix)

### DIFF
--- a/src/impl/btc/coin/header_chain.hpp
+++ b/src/impl/btc/coin/header_chain.hpp
@@ -156,6 +156,13 @@ struct BTCChainParams {
     uint256 pow_limit;
     uint256 genesis_hash;      // SHA256d genesis block hash (for identification)
 
+    // Subsidy halving interval (Bitcoin Core consensus.nSubsidyHalvingInterval).
+    // Mainnet/testnet = 210,000; regtest = 150 (CRegTestParams). The embedded
+    // TemplateBuilder MUST emit coinbasevalue using THIS per-network interval,
+    // else a won block past a regtest halving is rejected bad-cb-amount
+    // (c2pool claims the genesis 50 BTC subsidy the network no longer allows).
+    uint32_t subsidy_halving_interval{210'000u};
+
     // Fast-start checkpoint: skip syncing from genesis, start from a recent height.
     // The header chain seeds this checkpoint as if it were the genesis block.
     // All headers before this height are implicitly trusted.

--- a/src/impl/btc/coin/template_builder.hpp
+++ b/src/impl/btc/coin/template_builder.hpp
@@ -6,7 +6,7 @@
 /// removing the getblocktemplate RPC dependency for LTC.
 ///
 /// Provides:
-///   get_block_subsidy()   — BTC halving schedule (50 BTC, halving every 210,000 blocks)
+///   get_block_subsidy()   — BTC halving schedule (50 BTC, per-network halving interval)
 ///   compute_merkle_root() — SHA256d-based Merkle tree (Bitcoin/Litecoin compatible)
 ///   TemplateBuilder       — static build_template() → WorkData
 ///   CoinNodeInterface     — abstract interface (getwork / submit_block / getblockchaininfo)
@@ -43,15 +43,18 @@ namespace coin {
 
 /// BTC block subsidy (miner reward) in satoshis at a given block height.
 /// Initial subsidy: 50 BTC = 5,000,000,000 satoshis.
-/// Halving: every 210,000 blocks (BTC original halving schedule).
+/// Halving: every halving_interval blocks (210,000 mainnet/testnet, 150 regtest).
 /// Subsidy drops to 0 after 64 halvings (never in practice — block ~13.4 M).
 /// Reference: ref/bitcoin/src/validation.cpp GetBlockSubsidy().
-inline uint64_t get_block_subsidy(uint32_t height) {
+inline uint64_t get_block_subsidy(uint32_t height,
+                                  uint32_t halving_interval = 210'000u) {
     static constexpr uint64_t COIN            = 100'000'000ULL;   // satoshis per BTC
     static constexpr uint64_t INITIAL_SUBSIDY = 50ULL * COIN;     // 50 BTC
-    static constexpr uint32_t HALVING_INTERVAL = 210'000u;
+    // halving_interval is per-network (Bitcoin Core consensus.nSubsidyHalvingInterval):
+    // mainnet/testnet 210,000, regtest 150. Default keeps single-arg callers on mainnet.
+    if (halving_interval == 0) return INITIAL_SUBSIDY;  // guard div-by-zero
 
-    int halvings = static_cast<int>(height / HALVING_INTERVAL);
+    int halvings = static_cast<int>(height / halving_interval);
     if (halvings >= 64) return 0;
     return INITIAL_SUBSIDY >> halvings;
 }
@@ -199,7 +202,7 @@ public:
             block_version = BIP9_BASE_VERSION;
 
         // ── Subsidy ────────────────────────────────────────────────────────
-        uint64_t subsidy = get_block_subsidy(next_h);
+        uint64_t subsidy = get_block_subsidy(next_h, chain.params().subsidy_halving_interval);
 
         // ── Transactions from mempool (fee-sorted when UTXO available) ────
         auto [selected_txs, total_fees] =

--- a/src/impl/btc/test/share_test.cpp
+++ b/src/impl/btc/test/share_test.cpp
@@ -6,6 +6,8 @@
 #include <core/uint256.hpp>
 #include <sharechain/sharechain.hpp>
 #include <impl/btc/share.hpp>
+#include <impl/btc/coin/template_builder.hpp>
+#include <impl/btc/coin/header_chain.hpp>
 
 // struct FakeBlock
 // {
@@ -67,4 +69,53 @@ TEST(BTC_version_gate, SegwitNotFoldedIntoV36Gate)
     static_assert(33u < core::version_gate::V36_ACTIVATION_VERSION,
                   "BTC segwit version must remain below the v36 gate");
     EXPECT_FALSE(core::version_gate::is_v36_active(33));
+}
+
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Coinbase subsidy MUST honor the per-network halving interval.
+//
+// Regression for the G3b won-block "bad-cb-amount" reject: the embedded
+// TemplateBuilder computes coinbasevalue from get_block_subsidy(height) and
+// previously hardcoded the 210,000-block mainnet halving interval. On regtest
+// (CRegTestParams nSubsidyHalvingInterval = 150) a won block at height 275 is
+// one halving past 150, so consensus allows only 25 BTC — but c2pool emitted
+// the genesis 50 BTC and bitcoind rejected the block on ConnectBlock, silently
+// losing the won subsidy. get_block_subsidy must scale by the passed interval.
+// ─────────────────────────────────────────────────────────────────────────────
+TEST(BTC_subsidy, RegtestHalvingIntervalHonored)
+{
+    using btc::coin::get_block_subsidy;
+    constexpr uint64_t COIN = 100'000'000ULL;
+
+    // Regtest interval = 150. This is the exact won-block scenario.
+    EXPECT_EQ(get_block_subsidy(0,   150u), 50 * COIN);   // genesis epoch
+    EXPECT_EQ(get_block_subsidy(149, 150u), 50 * COIN);   // last of epoch 0
+    EXPECT_EQ(get_block_subsidy(150, 150u), 25 * COIN);   // first halving
+    EXPECT_EQ(get_block_subsidy(274, 150u), 25 * COIN);   // still epoch 1
+    EXPECT_EQ(get_block_subsidy(275, 150u), 25 * COIN);   // the rejected height: 25, NOT 50
+    EXPECT_EQ(get_block_subsidy(299, 150u), 25 * COIN);   // last of epoch 1
+    EXPECT_EQ(get_block_subsidy(300, 150u), 1'250'000'000ULL); // 12.5 BTC, epoch 2
+
+    // The pre-fix bug would have returned 50 BTC at h=275 (275 < 210000).
+    EXPECT_NE(get_block_subsidy(275, 150u), 50 * COIN);
+}
+
+// Mainnet/testnet remain consensus-neutral after parameterization: the
+// chainparams field defaults to 210,000 and the single-arg default path is
+// unchanged.
+TEST(BTC_subsidy, MainnetIntervalUnchanged)
+{
+    using btc::coin::get_block_subsidy;
+    using btc::coin::BTCChainParams;
+    constexpr uint64_t COIN = 100'000'000ULL;
+
+    EXPECT_EQ(BTCChainParams::mainnet().subsidy_halving_interval, 210'000u);
+    EXPECT_EQ(BTCChainParams::testnet().subsidy_halving_interval, 210'000u);
+    EXPECT_EQ(BTCChainParams::testnet4().subsidy_halving_interval, 210'000u);
+
+    // Default-arg (single-arg) call still yields mainnet halving values.
+    EXPECT_EQ(get_block_subsidy(209'999),       50 * COIN);
+    EXPECT_EQ(get_block_subsidy(210'000),       25 * COIN);
+    EXPECT_EQ(get_block_subsidy(210'000, 210'000u), 25 * COIN);
 }


### PR DESCRIPTION
## Defect (G3b leg-(b) — won block rejected bad-cb-amount)

The embedded `TemplateBuilder` computes `coinbasevalue` from `get_block_subsidy(height)`, which **hardcoded the 210,000-block mainnet halving interval**. On regtest (`CRegTestParams nSubsidyHalvingInterval = 150`), a won block one halving past height 150 (the live capture hit **h275**) is allowed only **25 BTC**, but c2pool emitted the genesis **50 BTC** subsidy. bitcoind rejected it on `ConnectBlock` with `bad-cb-amount`, `InvalidChainFound`, and the won block was **silently lost** (tip stuck). Latent on mainnet only because the pool had never connected a won block before.

This is the gating defect after the #516 P2P body-serve leg cleared the silent-loss (block now *reaches* ConnectBlock instead of timing out).

## Fix (consensus-neutral on master)
- `get_block_subsidy(height, halving_interval = 210'000u)` — parameterized; single-arg default preserves mainnet behavior for all existing callers.
- `BTCChainParams::subsidy_halving_interval{210'000u}` — new field; **defaults to 210,000**, so mainnet/testnet/testnet4 factories are byte-for-byte consensus-neutral.
- Builder passes `chain.params().subsidy_halving_interval`.

## Stacked dependency
The live regtest fix also needs `BTCChainParams::regtest()` to set `subsidy_halving_interval = 150`. `regtest()` lives in the open **#506** branch; that one-liner rides #506 (noted for the integrator). This PR ships the mechanism + KAT independently on master.

## Tests (CI-fired, btc_share_test → 27→29)
- `BTC_subsidy.RegtestHalvingIntervalHonored` — reproduces the h275=25-BTC scenario; **flip-proven RED** under the old hardcoded interval (h275→50 BTC).
- `BTC_subsidy.MainnetIntervalUnchanged` — locks the 210,000 default + single-arg path + all three factory fields.

`cmake --build ... --target btc_share_test` → rc=0; `btc_share_test` 29/29 green. Signed, no third-party attribution. Held for operator tap — I don't self-merge.