### PR TITLE
dgb: feed --dev-relax-algo-softforks into the submit-arm NodeRPC readiness gate (G3b slice-iii, follow-on to #514)

### DIFF
--- a/src/c2pool/main_dgb.cpp
+++ b/src/c2pool/main_dgb.cpp
@@ -305,7 +305,8 @@ int run_node(const core::CoinParams& params, bool testnet,
     }
     std::unique_ptr<dgb::coin::NodeRPC> rpc;
     if (rpc_conf.armed()) {
-        rpc = std::make_unique<dgb::coin::NodeRPC>(&ioc, /*coin=*/nullptr, testnet);
+        rpc = std::make_unique<dgb::coin::NodeRPC>(&ioc, /*coin=*/nullptr, testnet,
+                                                  /*dev_relax_algo_softforks=*/dev_relax_algo_softforks);
         rpc->connect(NetService(rpc_conf.host, rpc_conf.port), rpc_conf.userpass());
         std::cout << "[DGB] external-daemon submit arm ARMED: NodeRPC -> "
                   << rpc_conf.host << ":" << rpc_conf.port


### PR DESCRIPTION
## Slice-iii: complete the --dev-relax-algo-softforks wire (follow-on to #514)

**Stacked on #514** (`dgb/dev-relax-algo-softforks-flag`). Diff is the single line below once #514 lands; rebases to master cleanly after.

### Gap #514 left
#514 wired `--dev-relax-algo-softforks` into `config.coin()->m_dev_relax_algo_softforks` and into `dgb::Node`'s internal `m_rpc`, but the **standalone submit-arm `NodeRPC`** built in `run_node` (`main_dgb.cpp`) — the one whose `check()` actually gates `--run` startup — was constructed as `NodeRPC(&ioc, nullptr, testnet)`, omitting the 4th arg, so it defaulted to `false`. The flag was reachable but **inert**: the node still printed `missing required softfork features: nversionbips, odo, reservealgo` / `Refusing to start` against an isolated tuned testnet even with the flag on.

### Fix
Pass `dev_relax_algo_softforks` as the 4th arg to that `make_unique<NodeRPC>`. OFF by default. Mainnet stays fail-closed: `compute_required_softforks` hard-floors `chain=="main"` regardless of the flag, and the **daemon's** `chain` field drives the relax decision (not c2pool's `testnet` bool). SSOT relax logic (`softfork_check.hpp`) is unchanged and already unit-tested (#514 KAT 15/15).

### Proof (empirical, .42 tuned testnet4, chain=test, daemon @h123)
- BEFORE (this branch's parent, flag on): `missing required softfork features: nversionbips, odo, reservealgo` → `Refusing to start`.
- AFTER: `DEV-ONLY: dev_relax_algo_softforks is set — relaxing the DGB algo softfork gate (reservealgo/odo/nversionbips) on chain 'test'`; **0** `Refusing to start`; `run-loop up`; `StratumServer started`. Node ran steadily to the soak timeout, clean SIGTERM exit.
- Note: pre-existing embedded coin-P2P `prefix doesn't match` (RPC-fallback submit arm dials the RPC port) is unrelated and unchanged by this PR.

Also confirms the taproot floor cleared on this rebased line via #512's getdeploymentinfo parse (taproot dropped from the gate's missing set before this fix).

FENCED to `src/c2pool/main_dgb.cpp` (dgb run path). No consensus surface; non-consensus startup readiness gate only.
