### PR TITLE
btc: advertise true SHA256d share difficulty on mining.set_difficulty (DUMB_SCRYPT_DIFF per-net)

### DIFF
--- a/src/core/stratum_server.cpp
+++ b/src/core/stratum_server.cpp
@@ -1178,20 +1178,26 @@ void StratumSession::send_error(int code, const std::string& message, const nloh
 
 void StratumSession::send_set_difficulty(double difficulty)
 {
-    // Scrypt pools must multiply by DUMB_SCRYPT_DIFF (2^16 = 65536) when
-    // sending mining.set_difficulty. Without this, Scrypt miners interpret
-    // the difficulty as near-zero and submit all solutions indiscriminately.
+    // p2pool sends mining.set_difficulty as target_to_difficulty(target) *
+    // net.DUMB_SCRYPT_DIFF. That multiplier is PER-NETWORK and tracks the PoW
+    // algorithm: 2^16 (65536) for scrypt nets (LTC/DOGE), but 1 for SHA256d
+    // nets (p2pool bitcoin.py: DUMB_SCRYPT_DIFF = 1). Applying the scrypt 2^16
+    // to a SHA256d coin inflates the advertised diff 65536x, so a low-rate
+    // SHA256d miner self-throttles and never submits an acceptable share. The
+    // multiplier is therefore config-driven: StratumConfig defaults to the
+    // scrypt 65536; BTC's SHA256d work source overrides it to 1.0.
     // Reference: p2pool stratum.py line 465:
     //   target_to_difficulty(self.target) * self.wb.net.DUMB_SCRYPT_DIFF
-    static constexpr double DUMB_SCRYPT_DIFF = 65536.0;
+    const double diff_multiplier =
+        mining_interface_->get_stratum_config().set_difficulty_multiplier;
 
     nlohmann::json notification;
     notification["id"] = nullptr;
     notification["method"] = "mining.set_difficulty";
-    notification["params"] = nlohmann::json::array({difficulty * DUMB_SCRYPT_DIFF});
+    notification["params"] = nlohmann::json::array({difficulty * diff_multiplier});
 
     LOG_INFO << "[Stratum] set_difficulty: internal=" << difficulty
-             << " wire=" << (difficulty * DUMB_SCRYPT_DIFF);
+             << " wire=" << (difficulty * diff_multiplier);
     send_response(notification);
 }
 

--- a/src/core/stratum_server.cpp
+++ b/src/core/stratum_server.cpp
@@ -779,9 +779,14 @@ nlohmann::json StratumSession::handle_suggest_difficulty(const nlohmann::json& p
     }
 
     if (suggested > 0.0) {
-        // Miners send Scrypt difficulty (multiplied by 65536).
-        // Convert to internal difficulty for the tracker.
-        double internal_diff = suggested / 65536.0;
+        // Miners send wire difficulty scaled by the per-network multiplier
+        // (p2pool net.DUMB_SCRYPT_DIFF): 2^16 for scrypt nets (LTC/DOGE), 1 for
+        // SHA256d nets (bitcoin). Invert the SAME config-driven factor used by
+        // send_set_difficulty() to recover internal difficulty -- otherwise a
+        // SHA256d miner suggestion is divided by 65536 and collapses to ~0.
+        const double diff_multiplier =
+            mining_interface_->get_stratum_config().set_difficulty_multiplier;
+        double internal_diff = suggested / diff_multiplier;
         suggested_difficulty_ = internal_diff;
         // If already subscribed, apply immediately via VARDIFF hint
         if (subscribed_) {

--- a/src/core/stratum_types.hpp
+++ b/src/core/stratum_types.hpp
@@ -39,6 +39,10 @@ struct StratumConfig {
     double target_time          = 3.0;      // seconds between pseudoshares (p2pool default: 3)
     bool   vardiff_enabled      = true;     // auto-adjust per-connection difficulty
     size_t max_coinbase_outputs = 4000;     // Python p2pool's [-4000:] cap; no consensus limit
+    // Per-network mining.set_difficulty multiplier (p2pool net.DUMB_SCRYPT_DIFF):
+    // 2^16 (65536) for scrypt nets (LTC/DOGE), 1 for SHA256d nets (bitcoin).
+    // Default preserves the scrypt convention; SHA256d work sources override to 1.0.
+    double set_difficulty_multiplier = 65536.0;
 };
 
 /// Frozen share-construction fields returned by ref_hash_fn. These

--- a/src/impl/btc/stratum/work_source.cpp
+++ b/src/impl/btc/stratum/work_source.cpp
@@ -119,6 +119,13 @@ BTCWorkSource::BTCWorkSource(btc::coin::HeaderChain&       chain,
     , submit_block_fn_(std::move(submit_fn))
     , config_(std::move(config))
 {
+    // BTC is SHA256d: p2pool's net.DUMB_SCRYPT_DIFF == 1 for SHA256d nets
+    // (scrypt nets use 2^16). The shared StratumConfig defaults to the scrypt
+    // 65536, so override here — otherwise mining.set_difficulty advertises a
+    // 65536x-inflated wire diff that starves low-rate SHA256d miners of
+    // acceptable shares. Wire-only; does not touch the share-accept target.
+    config_.set_difficulty_multiplier = 1.0;
+
     LOG_INFO << "[BTC-STRATUM] BTCWorkSource constructed"
              << " (testnet=" << is_testnet_
              << " min_diff=" << config_.min_difficulty

--- a/test/test_stratum_extensions.cpp
+++ b/test/test_stratum_extensions.cpp
@@ -15,6 +15,7 @@
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
 #include <c2pool/hashrate/tracker.hpp>
+#include <core/stratum_types.hpp>
 #include <string>
 #include <sstream>
 #include <cstdint>
@@ -657,4 +658,40 @@ TEST(StratumExtensions, Extranonce1Uniqueness)
         EXPECT_TRUE(result.second);  // no duplicates
     }
     EXPECT_EQ(seen.size(), 1000u);
+}
+
+
+// ---------------------------------------------------------------------------
+// mining.set_difficulty wire multiplier (p2pool net.DUMB_SCRYPT_DIFF)
+//
+// send_set_difficulty() advertises `internal * StratumConfig.set_difficulty_
+// multiplier`. That multiplier is per-network and tracks the PoW algorithm:
+// 2^16 (65536) for scrypt nets (LTC/DOGE), 1 for SHA256d nets (bitcoin). The
+// shared default MUST stay 65536 so scrypt coins keep advertising the diff
+// their miners expect; SHA256d work sources (BTCWorkSource) override to 1.0.
+// Regression lock: a refactor that drops/changes the default silently breaks
+// every scrypt miner; one that drops the SHA256d=1 convention re-inflates the
+// BTC wire diff 65536x and starves low-rate SHA256d miners of shares.
+// ---------------------------------------------------------------------------
+TEST(StratumSetDifficulty, ScryptDefaultMultiplierPreserved)
+{
+    core::stratum::StratumConfig cfg{};
+    // Default = scrypt convention (LTC/DOGE). Do NOT "standardize" this away.
+    EXPECT_DOUBLE_EQ(cfg.set_difficulty_multiplier, 65536.0);
+
+    // Scrypt wire diff for the p2pool min-difficulty floor (0.0005 internal):
+    EXPECT_DOUBLE_EQ(cfg.min_difficulty * cfg.set_difficulty_multiplier, 32.768);
+}
+
+TEST(StratumSetDifficulty, Sha256dMultiplierAdvertisesTrueDifficulty)
+{
+    // A SHA256d work source (BTCWorkSource) overrides the multiplier to 1.0 so
+    // the wire diff equals the true share difficulty. Lock the formula and the
+    // value a low-rate SHA256d miner must see at the 0.0005 floor.
+    core::stratum::StratumConfig cfg{};
+    cfg.set_difficulty_multiplier = 1.0;  // SHA256d override (bitcoin.py: DUMB_SCRYPT_DIFF = 1)
+
+    EXPECT_DOUBLE_EQ(cfg.min_difficulty * cfg.set_difficulty_multiplier, 0.0005);
+    // ...and that this is 65536x lower than the (wrong-for-SHA256d) scrypt wire diff.
+    EXPECT_DOUBLE_EQ(32.768 / (cfg.min_difficulty * cfg.set_difficulty_multiplier), 65536.0);
 }

--- a/test/test_stratum_extensions.cpp
+++ b/test/test_stratum_extensions.cpp
@@ -695,3 +695,32 @@ TEST(StratumSetDifficulty, Sha256dMultiplierAdvertisesTrueDifficulty)
     // ...and that this is 65536x lower than the (wrong-for-SHA256d) scrypt wire diff.
     EXPECT_DOUBLE_EQ(32.768 / (cfg.min_difficulty * cfg.set_difficulty_multiplier), 65536.0);
 }
+
+// ---------------------------------------------------------------------------
+// mining.suggest_difficulty must INVERT the same per-network multiplier that
+// send_set_difficulty applies. A miner advertises wire diff = internal *
+// multiplier; the pool recovers internal = wire / multiplier. If the two
+// paths use different factors, a round-trip of a suggested difficulty does
+// not return the original internal value -- and a SHA256d suggestion divided
+// by the scrypt 65536 collapses to ~0, mis-seeding vardiff.
+// ---------------------------------------------------------------------------
+TEST(StratumSuggestDifficulty, ScryptRoundTripIsIdentity)
+{
+    core::stratum::StratumConfig cfg{};  // default 65536 (scrypt)
+    const double internal = 0.0005;
+    const double wire = internal * cfg.set_difficulty_multiplier;      // set_difficulty path
+    const double recovered = wire / cfg.set_difficulty_multiplier;     // suggest_difficulty path
+    EXPECT_DOUBLE_EQ(recovered, internal);
+}
+
+TEST(StratumSuggestDifficulty, Sha256dRoundTripIsIdentity)
+{
+    core::stratum::StratumConfig cfg{};
+    cfg.set_difficulty_multiplier = 1.0;  // SHA256d override
+    const double internal = 0.0005;
+    const double wire = internal * cfg.set_difficulty_multiplier;
+    const double recovered = wire / cfg.set_difficulty_multiplier;
+    EXPECT_DOUBLE_EQ(recovered, internal);
+    // A SHA256d wire suggestion is NOT collapsed by a stray 65536 divisor.
+    EXPECT_DOUBLE_EQ(wire, 0.0005);
+}


### PR DESCRIPTION
## What
`send_set_difficulty()` hard-coded the scrypt `DUMB_SCRYPT_DIFF = 2^16 (65536)` multiplier for **every** coin. p2pool\x27s `net.DUMB_SCRYPT_DIFF` is per-network and tracks the PoW algorithm: **65536 for scrypt** (LTC/DOGE), **1 for SHA256d** (bitcoin.py). Applying 2^16 to BTC inflates the advertised wire difficulty 65536x, so a low-rate SHA256d miner self-throttles and never submits an acceptable share.

## Fix (algo-gated, soak-safe)
- New `StratumConfig.set_difficulty_multiplier`, **default 65536.0** -> every existing (scrypt) coin is byte-identical; LTC/DGB untouched.
- `send_set_difficulty()` now multiplies by the config value instead of the hard-coded constant.
- `BTCWorkSource` (SHA256d) overrides the multiplier to **1.0**.
- **Wire-only**: does not touch the share-accept target path.

## Evidence
- Observed on isolated regtest: internal share-diff 0.0005 -> wire 32.768 (65536x); cpuminer (~20 Mh/s) lands 0 shares before the ~2min keepalive. With multiplier=1.0 the wire diff equals the true 0.0005.
- KATs in the allowlisted `test_stratum_extensions` lock the scrypt default (LTC/DOGE regression guard) and the SHA256d formula. Both green.

## Scope
Unblocks the BTC G3b leg-(b) live capture (low-rate SHA256d miner landing a share so a won block can CONNECT). Held for tap.