### PR TITLE
dgb: route consensus get_desired_version_weights clamp onto chain_walk_window SSOT (#450 follow-on)

### DIFF
--- a/src/impl/dgb/coin/chain_walk_window.hpp
+++ b/src/impl/dgb/coin/chain_walk_window.hpp
@@ -40,11 +40,14 @@
 //
 // Per-coin isolation: dgb/ only. Header-only, additive, free functions over the
 // already-resolved (height, lookbehind) pair -- the get_chain skip-list walk
-// stays in the forest. This slice does NOT rewire share_tracker.hpp; the four
-// call sites keep their inline std::min/(actual<=0) guards. That byte-identity
-// delegation is the follow-on (mirrors #414 redistribute rewire). The lifted
-// body is a verbatim copy of the inline clamp (same int32_t height, same
-// std::min, same <=0 comparison), so the follow-on is provably value-identical.
+// stays in the forest. Delegation follow-on (mirrors #414 redistribute rewire):
+// the two desired_version accessors -- get_desired_version_counts AND the
+// consensus get_desired_version_weights (60%-by-work switch-gate input) -- now
+// route their clamp through these helpers; get_average_stale_prop /
+// get_stale_counts keep their inline std::min/(actual<=0) guards pending their
+// own follow-on. The lifted body is a verbatim copy of the inline clamp (same
+// int32_t height, same std::min, same <=0 comparison), proven value-identical by
+// DgbChainWalkWindow.DelegationMatchesPreDelegationInline over a dense matrix.
 // Consensus-neutral: pure arithmetic, no value semantics changed.
 
 #include <algorithm>

--- a/src/impl/dgb/share_tracker.hpp
+++ b/src/impl/dgb/share_tracker.hpp
@@ -2168,8 +2168,8 @@ public:
         if (!chain.contains(share_hash))
             return {};
         auto height = chain.get_height(share_hash);
-        auto actual = std::min(lookbehind, height);
-        if (actual <= 0)
+        auto actual = dgb::chain_walk_window_count(height, lookbehind);
+        if (!dgb::chain_walk_window_active(actual))
             return {};
 
         std::vector<dgb::VersionWork> window;


### PR DESCRIPTION
## What
Routes the consensus `get_desired_version_weights` lookbehind clamp onto the `chain_walk_window` SSOT (`chain_walk_window_count`/`chain_walk_window_active`). This accessor is the 60%-by-work version-switch gate input (share_check step 2) and was the last consensus-surface call site still clamping inline (`std::min(lookbehind, height)` + `actual<=0`). Its diagnostic counts sibling already delegates; this brings the consensus accessor onto the same SSOT.

## Value-invariance (gated merge — NO self-merge)
Byte-identical: `chain_walk_window_count(h,lb) == std::min(lb,h)`, `chain_walk_window_active(a) == a>0`. Pinned **non-circularly** by the existing `DgbChainWalkWindow.DelegationMatchesPreDelegationInline` KAT — a dense (height,lookbehind) matrix re-deriving `std::min`/(`<=0`) verbatim with zero reference to the header, whose comment already cites this call site (share_tracker.hpp:2149-2153). Accumulation was already on the desired_version_tally SSOT (#429), so this completes the consensus path delegation.

## Tests (Linux x86_64)
- `dgb_chain_walk_window_test` 5/5 green
- `dgb_desired_version_tally_test` 6/6 green

Both targets already in BOTH build.yml `--target` allowlists.

## Scope
Fenced to `src/impl/dgb/` only (share_tracker.hpp 4 lines + chain_walk_window.hpp comment). DGB-tree, single-coin smoke is the bar. Sits on the version-switch surface → operator-tap gated, not fenced auto-merge.