### PR TITLE
btc: connect-authoritative won-block submit (always-fire submitblock RPC) — G3b leg-(b) connect fix

### DIFF
--- a/src/c2pool/main_btc.cpp
+++ b/src/c2pool/main_btc.cpp
@@ -807,8 +807,12 @@ int main(int argc, char* argv[])
         }
         LOG_INFO << "[BTC-SUBMIT] sending block " << block_hash.GetHex().substr(0, 16)
                  << " height=" << height << " (via stratum)";
-        // FALLBACK: P2P relay primary, submitblock RPC if P2P unavailable/failed.
-        return coin_node.submit_block_with_fallback(block_bytes);
+        // CONNECT-AUTHORITATIVE: P2P relay (fast propagation) + submitblock RPC
+        // fired UNCONDITIONALLY so the won block actually connects. A P2P
+        // cmpctblock announce-success alone does NOT connect the tip (daemon
+        // requests the body via getblocktxn, which we do not serve) - the
+        // silent-loss this path closes. BTC-fenced; cross-coin fallback intact.
+        return coin_node.submit_block_for_connect(block_bytes);
     };
 
     // Construct the work source. Holds non-owning refs to chain + mempool;

--- a/src/impl/btc/coin/block_broadcast.hpp
+++ b/src/impl/btc/coin/block_broadcast.hpp
@@ -32,5 +32,29 @@ inline bool broadcast_block_with_fallback(
     return core::broadcast_block_with_fallback(relay_p2p, submit_rpc);
 }
 
+// CONNECT-AUTHORITATIVE broadcast (BTC lane ONLY). Distinct policy from the
+// cross-coin FALLBACK orchestration above: a P2P relay "success" only means
+// the block was ANNOUNCED to a peer (a cmpctblock header). Under compact-block
+// relay the daemon then requests the body via getblocktxn, which the c2pool
+// broadcaster does NOT serve, so the daemon never ConnectBlock()s the block and
+// the full subsidy is silently lost even though relay_p2p() returned true. The
+// submitblock RPC, by contrast, delivers the FULL block and is therefore
+// connect-authoritative. So the connect path ALWAYS fires the RPC leg, in
+// ADDITION to the P2P relay (kept for best-effort fast propagation). Returns
+// true iff the block reached at least one sink.
+//
+// This is BTC-lane-fenced and deliberately does NOT alter the cross-coin
+// core::broadcast_block_with_fallback contract: the give-submitblock-primacy /
+// always-fire convergence is the v37 broadcaster-convergence shape held on HOLD
+// (#500/#498). Only the BTC won-block connect path opts into it here.
+inline bool broadcast_block_for_connect(
+    const std::function<bool()>& relay_p2p,
+    const std::function<bool()>& submit_rpc)
+{
+    bool relayed   = relay_p2p  ? relay_p2p()  : false;  // best-effort fast propagation
+    bool connected = submit_rpc ? submit_rpc() : false;  // ALWAYS - connect-authoritative
+    return relayed || connected;
+}
+
 } // namespace coin
 } // namespace btc

--- a/src/impl/btc/coin/node.hpp
+++ b/src/impl/btc/coin/node.hpp
@@ -125,6 +125,21 @@ public:
             [&]{ return submit_block_hex(block_bytes); });
     }
 
+    /// Broadcast a WON block for ACTUAL CONNECT (BTC lane). Unlike
+    /// submit_block_with_fallback (P2P-primary, RPC only on relay-fail), the
+    /// connect path fires the submitblock RPC UNCONDITIONALLY because a P2P
+    /// cmpctblock announce-success does NOT guarantee the daemon connects the
+    /// block (it requests the body via getblocktxn, which we do not serve).
+    /// submitblock is connect-authoritative; P2P relay still fires for fast
+    /// propagation. BTC-fenced - does not change the cross-coin fallback
+    /// contract. Returns true iff the block reached at least one sink.
+    bool submit_block_for_connect(const std::vector<unsigned char>& block_bytes)
+    {
+        return broadcast_block_for_connect(
+            [&]{ return submit_block_p2p_raw(block_bytes); },
+            [&]{ return submit_block_hex(block_bytes); });
+    }
+
     bool has_p2p() const { return m_p2p != nullptr; }
 
     /// Send getheaders to drive header sync (BIP 31).

--- a/src/impl/btc/test/CMakeLists.txt
+++ b/src/impl/btc/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 if (BUILD_TESTING AND GTest_FOUND)
     # btc twin of ltc share_test — uniquely named to avoid the CMP0002 target
     # collision with src/impl/ltc/test (both subdirs build in the same tree).
-    add_executable(btc_share_test share_test.cpp f11_donation_invariance_test.cpp f10b_version_punish_removal_test.cpp g01_share_format_parity_test.cpp auto_ratchet_sim_test.cpp block_broadcast_guard_test.cpp regtest_sharechain_isolation_test.cpp)
+    add_executable(btc_share_test share_test.cpp f11_donation_invariance_test.cpp f10b_version_punish_removal_test.cpp g01_share_format_parity_test.cpp auto_ratchet_sim_test.cpp block_broadcast_guard_test.cpp block_broadcast_connect_test.cpp regtest_sharechain_isolation_test.cpp)
     target_link_libraries(btc_share_test PRIVATE
         GTest::gtest_main GTest::gtest
         core btc

--- a/src/impl/btc/test/block_broadcast_connect_test.cpp
+++ b/src/impl/btc/test/block_broadcast_connect_test.cpp
@@ -1,0 +1,82 @@
+// ---------------------------------------------------------------------------
+// btc::coin::broadcast_block_for_connect CONNECT-AUTHORITATIVE KATs.
+//
+// The won-block connect path differs from the cross-coin FALLBACK policy
+// (broadcast_block_with_fallback): a P2P relay "success" only means the block
+// was ANNOUNCED to a peer (a cmpctblock header). Under compact-block relay the
+// daemon then requests the body via getblocktxn, which the c2pool broadcaster
+// does not serve, so the daemon never ConnectBlock()s the block and the subsidy
+// is SILENTLY LOST even though relay_p2p() returned true. submitblock delivers
+// the full block and is connect-authoritative, so this path fires the RPC leg
+// UNCONDITIONALLY -- the exact invariant these KATs lock.
+//
+// This is BTC-lane-fenced and does NOT alter the cross-coin
+// core::broadcast_block_with_fallback contract (the always-fire convergence is
+// the v37 broadcaster-convergence shape held on HOLD, #500/#498). The guard
+// twin block_broadcast_guard_test.cpp still locks the unchanged fallback policy.
+//
+// Rides the already-allowlisted btc_share_test executable, so no build.yml
+// --target allowlist change is needed and there is no #137-style NOT_BUILT
+// sentinel risk. p2pool-merged-v36 surface: NONE.
+// ---------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+
+#include "../coin/block_broadcast.hpp"
+
+// 1) THE FIX: P2P relay succeeds (cmpctblock announce-success) -> the
+//    submitblock RPC STILL fires. This is the connect-authoritative invariant:
+//    an announce alone does not connect the tip, so the RPC leg must not be
+//    short-circuited the way the FALLBACK policy short-circuits it.
+TEST(BtcBlockBroadcastConnect, P2pSuccessStillFiresSubmitblock) {
+    bool rpc_called = false;
+    auto relay  = [] { return true; };            // announced to peer
+    auto submit = [&] { rpc_called = true; return true; };
+
+    EXPECT_TRUE(btc::coin::broadcast_block_for_connect(relay, submit));
+    EXPECT_TRUE(rpc_called);  // ALWAYS fires -- block actually connects via RPC
+}
+
+// 1b) Contrast lock: the unchanged FALLBACK policy DOES short-circuit on the
+//     same inputs. Pinning both side-by-side documents that the connect path is
+//     a deliberately distinct policy, not a change to the shared contract.
+TEST(BtcBlockBroadcastConnect, FallbackPolicyStillShortCircuits) {
+    bool rpc_called = false;
+    auto relay  = [] { return true; };
+    auto submit = [&] { rpc_called = true; return true; };
+
+    EXPECT_TRUE(btc::coin::broadcast_block_with_fallback(relay, submit));
+    EXPECT_FALSE(rpc_called);  // fallback: no double-broadcast (UNCHANGED)
+}
+
+// 2) P2P relay fails -> RPC still delivers the block (reaches the network).
+TEST(BtcBlockBroadcastConnect, P2pFailRpcStillConnects) {
+    int rpc_calls = 0;
+    auto relay  = [] { return false; };
+    auto submit = [&] { ++rpc_calls; return true; };
+
+    EXPECT_TRUE(btc::coin::broadcast_block_for_connect(relay, submit));
+    EXPECT_EQ(rpc_calls, 1);
+}
+
+// 3) Both sinks fail -> reaches NEITHER -> false, so the won-block path screams
+//    (never a silent success).
+TEST(BtcBlockBroadcastConnect, BothFailReachesNeither) {
+    auto relay  = [] { return false; };
+    auto submit = [] { return false; };
+
+    EXPECT_FALSE(btc::coin::broadcast_block_for_connect(relay, submit));
+}
+
+// 4) RPC accepts even when P2P is an empty (null) sink -> connect path engages
+//    the connect-authoritative leg regardless of P2P availability.
+TEST(BtcBlockBroadcastConnect, NullP2pRpcConnects) {
+    std::function<bool()> no_p2p;   // empty: models m_p2p == nullptr
+    int rpc_calls = 0;
+    auto submit = [&] { ++rpc_calls; return true; };
+
+    EXPECT_TRUE(btc::coin::broadcast_block_for_connect(no_p2p, submit));
+    EXPECT_EQ(rpc_calls, 1);
+}


### PR DESCRIPTION
## What

Fixes the G3b leg-(b) connect blocker: a won block was relayed but never connected the tip, silently losing the subsidy.

The stratum won-block path called `submit_block_with_fallback`, whose P2P-primary policy treats a P2P relay success as "reached the network" and short-circuits the `submitblock` RPC. But a P2P relay success only means the block was **announced** (a cmpctblock header). Under compact-block relay the daemon then requests the body via `getblocktxn`, which the c2pool broadcaster does not serve, so the daemon never `ConnectBlock()`s and the block is silently lost despite `relay_p2p()` returning true.

## Change (BTC-lane-fenced)

- Add `btc::coin::broadcast_block_for_connect` + `Node::submit_block_for_connect`: fires the `submitblock` RPC **unconditionally** (connect-authoritative -- submitblock delivers the full block, so it always connects), keeping the P2P relay for best-effort fast propagation.
- Wire the stratum won-block path (`main_btc.cpp`) to the connect-authoritative call.
- New `block_broadcast_connect_test.cpp` (rides the allowlisted `btc_share_test`, no NOT_BUILT risk) -- 5 KATs pin always-fire, P2P-fail-still-connects, both-fail-reaches-neither, null-P2P, plus a **side-by-side contrast lock** that the fallback policy still short-circuits.

## What is NOT changed

The cross-coin SSOT `core::broadcast_block_with_fallback` contract is **untouched**. The "give submitblock primacy / always-fire" convergence is the v37 broadcaster-convergence shape held on HOLD (#500 / #498); only the BTC won-block connect path opts into it locally here. The existing `block_broadcast_guard_test` (6 KATs) still passes unchanged, proving the fallback policy is intact.

## Verify

`btc_share_test` builds clean; `BtcBlockBroadcastConnect.*` (5) + `BtcBlockBroadcastGuard.*` (6) = 11/11 PASS.

Held for operator tap -- I do not self-merge.
