### PR TITLE
dash(version-neg): additive 85% crossing FLOOR for successor gate (Bucket-3 transition-compat)

### DIFF
--- a/src/impl/dash/version_negotiation.hpp
+++ b/src/impl/dash/version_negotiation.hpp
@@ -107,6 +107,41 @@ successor_switch_allowed(const std::map<uint64_t, uint288>& weights,
     return have * uint288(100) >= total * uint288(60);
 }
 
+// -- Bucket-3 crossing FLOOR (PRE-V36 transition-compat; dash-only; REVERSIBLE) --
+// The unified v36-native successor gate above is 60%. During the live G2
+// crossing-soak the pool may admit LEGACY canonical p2pool-dash peers that still
+// gate the successor switch at the older 85% threshold. Flipping c2pool to 60%
+// while a legacy peer holds 85% opens a sharechain fork across the 60-85%
+// weighted-support band. To stay in lockstep we retain 85% as a TEMPORARY,
+// conditional crossing FLOOR and flip to the unified 60% only post-crossing.
+//
+// 3-bucket rule (operator 2026-06-17): this is Bucket-3 PRE-V36 TRANSITION
+// COMPAT -- per-coin, temporary, dropped after the soak; NOT a standardization
+// target. The unified 60% end state is the 2-arg successor_switch_allowed() above
+// and stays byte-unchanged. integrator ruling (B), 2026-06-26.
+inline constexpr unsigned CROSSING_SUCCESSOR_FLOOR_PCT = 85; // legacy p2pool-dash
+inline constexpr unsigned UNIFIED_SUCCESSOR_PCT        = 60; // v36-native end state
+
+// Additive overload. When `crossing_active` the successor must hold >= 85% of the
+// weighted tally (lockstep with legacy peers); otherwise it delegates to the
+// unified 60% gate. Default-gated to the crossing floor so the soak is fork-safe;
+// the post-crossing flip is a single `crossing_active = false`. Same exact-rational
+// uint288 arithmetic (have*100 >= total*pct) -- no IEEE-double, no floor.
+inline bool
+successor_switch_allowed(const std::map<uint64_t, uint288>& weights,
+                         uint64_t successor_version,
+                         bool crossing_active)
+{
+    if (!crossing_active)
+        return successor_switch_allowed(weights, successor_version);
+    uint288 total(0);
+    for (const auto& [v, w] : weights) total += w;
+    if (total == uint288(0)) return false;
+    auto it = weights.find(successor_version);
+    const uint288 have = (it == weights.end()) ? uint288(0) : it->second;
+    return have * uint288(100) >= total * uint288(CROSSING_SUCCESSOR_FLOOR_PCT);
+}
+
 // v36 activation gate (p2pool-merged-v36 work.py): v36 is active once its
 // WEIGHTED signaling reaches >= 95% of total work. Evaluated as the exact
 // rational w36*100 >= total*95 — integer uint288, no IEEE-double fragility.

--- a/test/test_dash_conformance.cpp
+++ b/test/test_dash_conformance.cpp
@@ -864,6 +864,50 @@ TEST(DashConformanceVersionNeg, SuccessorGuard60PercentWeightedKat) {
     EXPECT_FALSE(successor_switch_allowed({}, 36u));                                          // empty
 }
 
+// Bucket-3 crossing FLOOR (PRE-V36 transition-compat). During the G2 crossing-soak
+// the successor gate holds the legacy 85% floor (lockstep with canonical
+// p2pool-dash peers); it flips to the unified 60% only post-crossing
+// (crossing_active=false). The 60-85% weighted-support band is exactly where a
+// 60%-vs-85% split would fork the sharechain -- the floor closes it. Additive +
+// reversible: the 2-arg unified gate is byte-unchanged and the flip is one bool.
+TEST(DashConformanceVersionNeg, CrossingSuccessorFloor85Kat) {
+    using dash::version_negotiation::successor_switch_allowed;
+    EXPECT_EQ(dash::version_negotiation::CROSSING_SUCCESSOR_FLOOR_PCT, 85u);
+    EXPECT_EQ(dash::version_negotiation::UNIFIED_SUCCESSOR_PCT,        60u);
+
+    const std::map<uint64_t, uint288> w70 = {{36u, uint288(70u)}, {16u, uint288(30u)}}; // 70%
+    const std::map<uint64_t, uint288> w85 = {{36u, uint288(85u)}, {16u, uint288(15u)}}; // 85%
+    const std::map<uint64_t, uint288> w84 = {{36u, uint288(84u)}, {16u, uint288(16u)}}; // 84%
+    const std::map<uint64_t, uint288> w90 = {{36u, uint288(90u)}, {16u, uint288(10u)}}; // 90%
+    const std::map<uint64_t, uint288> w50 = {{36u, uint288(50u)}, {16u, uint288(50u)}}; // 50%
+
+    // In the 60-85% fork band the crossing floor DENIES where the unified gate clears.
+    EXPECT_TRUE (successor_switch_allowed(w70, 36u));        // unified 60%: clears
+    EXPECT_TRUE (successor_switch_allowed(w70, 36u, false)); // post-crossing: clears (delegates)
+    EXPECT_FALSE(successor_switch_allowed(w70, 36u, true));  // crossing: 70 < 85 -> DENY (fork-safe)
+
+    // 85% boundary: exact rational, floor cleared at exactly 85%.
+    EXPECT_TRUE (successor_switch_allowed(w85, 36u, true));  // 8500 >= 8500
+    EXPECT_FALSE(successor_switch_allowed(w84, 36u, true));  // 8400 <  8500 -> deny
+
+    // Above the floor: both gates agree.
+    EXPECT_TRUE (successor_switch_allowed(w90, 36u, true));
+    EXPECT_TRUE (successor_switch_allowed(w90, 36u, false));
+
+    // Below the unified 60%: both paths deny.
+    EXPECT_FALSE(successor_switch_allowed(w50, 36u, true));
+    EXPECT_FALSE(successor_switch_allowed(w50, 36u, false));
+
+    // Empty tally denies on every path.
+    EXPECT_FALSE(successor_switch_allowed({}, 36u, true));
+    EXPECT_FALSE(successor_switch_allowed({}, 36u, false));
+
+    // Delegation identity: crossing_active=false is byte-identical to the 2-arg gate.
+    for (const auto* w : {&w50, &w70, &w85, &w90})
+        EXPECT_EQ(successor_switch_allowed(*w, 36u, false),
+                  successor_switch_allowed(*w, 36u));
+}
+
 // v36 activation gate, exact-rational 95% on the work-weighted tally. KAT
 // booleans from CPython w36*100 >= total*95.
 TEST(DashConformanceVersionNeg, V36GateWeighted95PercentKat) {


### PR DESCRIPTION
Slice (B) per integrator ruling 2026-06-26 (crossing-floor A-vs-B). Retains the legacy canonical p2pool-dash **85% successor-switch** threshold as a TEMPORARY, conditional, dash-only crossing FLOOR during the G2 crossing-soak, flipping to the unified v36-native **60%** gate only post-crossing.

**Why:** flipping c2pool to 60% while a legacy peer still gates at 85% opens a sharechain fork across the 60-85% weighted-support band. The floor keeps c2pool in lockstep through that band, closing the fork window. No-op if no legacy peer joins.

**Shape:** additive + reversible. New 3-arg `successor_switch_allowed(weights, ver, crossing_active)` overload; the 2-arg unified 60% gate is **byte-unchanged** (+79/-0, zero deletions). Post-crossing flip is a single bool. Same exact-rational uint288 arithmetic (have*100 >= total*pct), no IEEE-double, no floor.

**3-bucket:** Bucket-3 PRE-V36 TRANSITION COMPAT — per-coin, temporary, dropped after the soak; NOT a standardization target. The unified 60% end state is the Bucket-2 standardized gate already on master.

**Test:** `DashConformanceVersionNeg.CrossingSuccessorFloor85Kat` — floor denies at 70/84% (where the unified 60% gate clears), clears at 85/90%, both deny <60%, empty denies all paths, delegation identity for crossing_active=false. **6/6 DashConformanceVersionNeg green on Linux x86_64.**

Held for integrator verify -> operator tap. No self-merge. The crossing-floor mechanism + the get_desired_version_counts weighted-comment correction will be folded into the coordinated-migration doc (item a) per the same ruling.