### PR TITLE
dash: route v36 COMBINED_DONATION_SCRIPT onto cross-coin core::donation SSOT (Bucket-2 dedup)

### DIFF
--- a/src/impl/dash/share_check.hpp
+++ b/src/impl/dash/share_check.hpp
@@ -23,6 +23,7 @@
 #include "version_negotiation.hpp"   // dash::version_negotiation:: accept-path version gate
 
 #include <core/coin_params.hpp>
+#include <core/donation.hpp>          // cross-coin COMBINED_DONATION_SCRIPT SSOT (Bucket-2)
 #include <core/hash.hpp>
 #include <core/pack.hpp>
 #include <core/pack_types.hpp>
@@ -117,18 +118,17 @@ static const std::vector<unsigned char> DONATION_SCRIPT = {
 
 // ── v36 unified cross-coin donation P2SH (Bucket-2 standardization, operator
 //    FLAG6 2026-06-17) ─────────────────────────────────────────────────────
-// Byte-identical to btc/bch/dgb/ltc COMBINED_DONATION_SCRIPT: P2SH wrapping the
-// 1-of-2 (forrestv + c2pool dev key) redeem script. Selected for v36+ shares;
-// pre-v36 shares keep the DASH-specific P2PKH DONATION_SCRIPT above (Bucket-3,
-// per-coin keep-for-soak). This is the cross-coin v36-native shape, NOT a
-// DASH isolation primitive — must match the other coins byte-for-byte.
-static const std::vector<unsigned char> COMBINED_DONATION_SCRIPT = {
-    0xa9, 0x14,
-    0x8c, 0x62, 0x72, 0x62, 0x1d, 0x89, 0xe8, 0xfa,
-    0x52, 0x6d, 0xd8, 0x6a, 0xcf, 0xf6, 0x0c, 0x71,
-    0x36, 0xbe, 0x8e, 0x85,
-    0x87
-};
+// Sourced from the cross-coin SSOT core::donation::COMBINED_DONATION_SCRIPT so
+// DASH cannot drift from btc/bch/dgb/ltc — this is the v36-native SHARED shape
+// (Bucket-2), NOT a DASH isolation primitive, so it must stay byte-identical to
+// the other coins. Was a hand-copied local literal; this rewire is value-
+// invariant (proven by DashConformanceCombinedDonation.MatchesCrossCoinSSOT).
+// P2SH wrapping the 1-of-2 (forrestv + c2pool dev key) redeem script; selected
+// for v36+ shares, while pre-v36 shares keep the DASH-specific P2PKH
+// DONATION_SCRIPT above (Bucket-3, per-coin keep-for-soak).
+static const std::vector<unsigned char> COMBINED_DONATION_SCRIPT(
+    core::donation::COMBINED_DONATION_SCRIPT.begin(),
+    core::donation::COMBINED_DONATION_SCRIPT.end());
 
 // ── compute_gentx_before_refhash (Dash v16) ──────────────────────────────────
 inline std::vector<unsigned char> compute_gentx_before_refhash()

--- a/test/test_dash_conformance.cpp
+++ b/test/test_dash_conformance.cpp
@@ -38,6 +38,7 @@
 
 #include <core/hash.hpp>                     // Hash (sha256d)
 #include <core/uint256.hpp>
+#include <core/donation.hpp>                 // cross-coin COMBINED_DONATION_SCRIPT SSOT
 
 #include <cstdint>
 #include <map>
@@ -196,6 +197,30 @@ TEST(DashConformancePayoutScript, MatchesOutOfBandKat) {
 TEST(DashConformancePayoutScript, DonationScriptIsP2PKHOverDonationHash) {
     EXPECT_EQ(dash::pubkey_hash_to_script2(h160(DONATION_H160)),
               dash::DONATION_SCRIPT);
+}
+
+// ── v36 unified P2SH (Bucket-2) cross-coin SSOT lock ─────────────────────────
+// Pillar-4 of the v36-migration-std sweep: DASH's v36+ donation P2SH must be the
+// cross-coin SHARED shape, not a per-coin dialect. Proves (1) DASH's
+// COMBINED_DONATION_SCRIPT is the SSOT core::donation::COMBINED_DONATION_SCRIPT
+// byte-for-byte (so the literal can never drift from btc/bch/dgb/ltc), and
+// (2) it is exactly the 23-byte P2SH a914<8c627262..8e85>87. Pre-v36 donation
+// stays the DASH-specific P2PKH (Bucket-3) and is covered by the tests above.
+TEST(DashConformanceCombinedDonation, MatchesCrossCoinSSOT) {
+    const std::vector<unsigned char> ssot(
+        core::donation::COMBINED_DONATION_SCRIPT.begin(),
+        core::donation::COMBINED_DONATION_SCRIPT.end());
+    EXPECT_EQ(dash::COMBINED_DONATION_SCRIPT, ssot);
+
+    const std::vector<unsigned char> expected = {
+        0xa9, 0x14,
+        0x8c, 0x62, 0x72, 0x62, 0x1d, 0x89, 0xe8, 0xfa,
+        0x52, 0x6d, 0xd8, 0x6a, 0xcf, 0xf6, 0x0c, 0x71,
+        0x36, 0xbe, 0x8e, 0x85,
+        0x87
+    };
+    EXPECT_EQ(dash::COMBINED_DONATION_SCRIPT, expected);
+    EXPECT_EQ(dash::COMBINED_DONATION_SCRIPT.size(), 23u);
 }
 
 // ── Masternode-payment-packing conformance (S6 slice 3) ──────────────────────


### PR DESCRIPTION
**Pillar-4 of the v36-migration-std sweep — donation P2SH.**

DASH kept a **hand-copied local literal** of the unified v36 P2SH in `src/impl/dash/share_check.hpp` instead of consuming the cross-coin single-source `core::donation::COMBINED_DONATION_SCRIPT` that btc already references. The bytes were identical, but a per-coin literal copy is exactly the v36 dialect-drift the operator 3-bucket rule flags as a **Bucket-2 standardization target**: the v36 donation script is a SHARED v36-native shape, *not* a DASH isolation primitive, so it must stay byte-identical to btc/bch/dgb/ltc and should derive from the SSOT (clean v37 migration).

### Change (value-invariant)
- `COMBINED_DONATION_SCRIPT` now initializes from `core::donation::COMBINED_DONATION_SCRIPT` instead of a literal byte array — proven byte-identical to the prior literal *and* to `a914<8c627262..8e85>87`.
- Pre-v36 DASH-specific P2PKH `DONATION_SCRIPT` (Bucket-3, oracle-conformant per frstrtr/p2pool-dash data.py:66, kept for the soak) is **untouched**.
- `current_share_version` stays 16 → no live share changes shape.

### Conformance verdict (pillar-4)
- pre-v36 P2PKH = **byte-identical to oracle** (`76a91420cb5c22..88ac`, XdgF55w…) — CONFORMANT (Bucket-3).
- v36 P2SH = the cross-coin SSOT value — CONFORMANT standardization (Bucket-2, FLAG6).
- **No consensus slice owed** — this is the dedup that removes the only remaining per-coin copy.

### Tests
Adds `DashConformanceCombinedDonation.MatchesCrossCoinSSOT` (locks dash == core SSOT == expected 23-byte P2SH). Full dash conformance **47/47 green** on Linux x86_64.

Scope: 2 files, DASH-isolated (dash impl + dash test); consumes the existing core SSOT, does not modify `core/`. No build.yml allowlist change (test_dash_conformance already targeted). Held for integrator verify → operator tap; no self-merge.