### PR TITLE
dash(version-gate): route 60%/95% gate literals to named v36-native thresholds (Bucket-2 SSOT dedup)

### DIFF
--- a/src/impl/dash/version_negotiation.hpp
+++ b/src/impl/dash/version_negotiation.hpp
@@ -36,6 +36,18 @@
 namespace dash::version_negotiation
 {
 
+// -- v36-native consensus thresholds (NAMED, single-sourced within DASH) ------
+// The successor-switch and v36-activation percentages are v36-native SHARED
+// shapes (Bucket-2): semantically identical across btc/dgb/dash. Naming them
+// here lets the gates below read ONE definition instead of re-spelling bare
+// 60 / 95 literals at each call site -- the same dialect-drift #533 removed for
+// the donation script. Hoisting these into core::version_gate as the cross-coin
+// SSOT is a coordinated follow-up (touches btc/dgb call sites); this keeps DASH
+// internally single-sourced now. Values byte-unchanged: 60/95/85 as before.
+inline constexpr unsigned UNIFIED_SUCCESSOR_PCT        = 60; // v36-native successor gate
+inline constexpr unsigned V36_SIGNAL_ACTIVATION_PCT    = 95; // v36 weighted-signal activation
+inline constexpr unsigned CROSSING_SUCCESSOR_FLOOR_PCT = 85; // legacy p2pool-dash crossing floor (Bucket-3)
+
 // PLAIN desired-version tally over the `dist` shares ending at `start_hash`
 // (inclusive, walking back via prev_hash). One vote per share. Mirrors the
 // older p2pool-dash get_desired_version_counts as used by the SUCCESSOR
@@ -104,7 +116,7 @@ successor_switch_allowed(const std::map<uint64_t, uint288>& weights,
     if (total == uint288(0)) return false;
     auto it = weights.find(successor_version);
     const uint288 have = (it == weights.end()) ? uint288(0) : it->second;
-    return have * uint288(100) >= total * uint288(60);
+    return have * uint288(100) >= total * uint288(UNIFIED_SUCCESSOR_PCT);
 }
 
 // -- Bucket-3 crossing FLOOR (PRE-V36 transition-compat; dash-only; REVERSIBLE) --
@@ -119,8 +131,8 @@ successor_switch_allowed(const std::map<uint64_t, uint288>& weights,
 // COMPAT -- per-coin, temporary, dropped after the soak; NOT a standardization
 // target. The unified 60% end state is the 2-arg successor_switch_allowed() above
 // and stays byte-unchanged. integrator ruling (B), 2026-06-26.
-inline constexpr unsigned CROSSING_SUCCESSOR_FLOOR_PCT = 85; // legacy p2pool-dash
-inline constexpr unsigned UNIFIED_SUCCESSOR_PCT        = 60; // v36-native end state
+// (UNIFIED_SUCCESSOR_PCT / CROSSING_SUCCESSOR_FLOOR_PCT are defined once at the
+// top of this namespace -- see the named-threshold block above.)
 
 // Additive overload. When `crossing_active` the successor must hold >= 85% of the
 // weighted tally (lockstep with legacy peers); otherwise it delegates to the
@@ -153,7 +165,7 @@ v36_active(const std::map<uint64_t, uint288>& weights, uint64_t v36_version = 36
     if (total == uint288(0)) return false;
     auto it = weights.find(v36_version);
     uint288 w36 = (it == weights.end()) ? uint288(0) : it->second;
-    return w36 * uint288(100) >= total * uint288(95);
+    return w36 * uint288(100) >= total * uint288(V36_SIGNAL_ACTIVATION_PCT);
 }
 
 // Window helper mirroring Share.check: negotiation looks at the [9/10 .. 10/10]

--- a/test/test_dash_conformance.cpp
+++ b/test/test_dash_conformance.cpp
@@ -1347,3 +1347,30 @@ TEST(DashConformanceFactory, OverridesNeverTouchConsensusOrIsolation) {
     for (int64_t v : {0, 16, 35, 36})
         EXPECT_EQ(p.donation_script_func(v), ssot.donation_script_func(v));
 }
+
+// ── Threshold-SSOT dedup (dash/version-gate-threshold-ssot) ──────────────────
+// version_negotiation now reads the 60% successor gate and 95% v36-activation
+// signal from NAMED constants instead of bare literals (the #533 dialect-drift
+// fix applied to the version gate). This KAT pins the named constants to their
+// canonical v36-native values so a future edit cannot silently fork the gate,
+// and re-confirms the gates behave byte-identically through the named path.
+TEST(DashVersionGateThresholdSSOT, NamedConstantsArePinned) {
+    using namespace dash::version_negotiation;
+    EXPECT_EQ(UNIFIED_SUCCESSOR_PCT,        60u);  // v36-native successor gate
+    EXPECT_EQ(V36_SIGNAL_ACTIVATION_PCT,    95u);  // v36 weighted-signal activation
+    EXPECT_EQ(CROSSING_SUCCESSOR_FLOOR_PCT, 85u);  // Bucket-3 legacy crossing floor
+}
+
+TEST(DashVersionGateThresholdSSOT, GatesUnchangedThroughNamedPath) {
+    using dash::version_negotiation::successor_switch_allowed;
+    using dash::version_negotiation::v36_active;
+    // 60% successor gate — exact boundary unchanged (uint288 exact-rational).
+    EXPECT_TRUE (successor_switch_allowed({{36u, uint288(60u)}, {16u, uint288(40u)}}, 36u)); // 60/100
+    EXPECT_FALSE(successor_switch_allowed({{36u, uint288(59u)}, {16u, uint288(41u)}}, 36u)); // 59/100
+    // 95% v36 activation signal — exact boundary unchanged.
+    EXPECT_TRUE (v36_active({{36u, uint288(95u)}, {16u, uint288(5u)}}, 36u));  // 95/100
+    EXPECT_FALSE(v36_active({{36u, uint288(94u)}, {16u, uint288(6u)}}, 36u));  // 94/100
+    // 85% crossing floor (3-arg) — unchanged: 84% fails, 85% passes when active.
+    EXPECT_FALSE(successor_switch_allowed({{36u, uint288(84u)}, {16u, uint288(16u)}}, 36u, /*crossing_active=*/true));
+    EXPECT_TRUE (successor_switch_allowed({{36u, uint288(85u)}, {16u, uint288(15u)}}, 36u, /*crossing_active=*/true));
+}


### PR DESCRIPTION
## What

v36-migration-std sweep, pillar-5 (share-version-weighting / desired_version gate). `version_negotiation.hpp` re-spelled the v36-native **successor-switch (60%)** and **v36-activation-signal (95%)** percentages as bare `uint288` literals at the gate call sites — even though `UNIFIED_SUCCESSOR_PCT = 60` was already declared lower in the same file (used only by the 3-arg crossing overload). This is the same per-coin dialect-drift #533 removed for the donation script, now for the version gate.

This slice hoists the three threshold constants to the top of the namespace and routes both gates through them:
- 2-arg `successor_switch_allowed` → `UNIFIED_SUCCESSOR_PCT` (60)
- `v36_active` → `V36_SIGNAL_ACTIVATION_PCT` (95, newly named)
- `CROSSING_SUCCESSOR_FLOOR_PCT` (85) hoisted alongside (Bucket-3, unchanged)

## Why it is safe
- **Value-invariant**: 60/95/85 unchanged; uint288 exact-rational arithmetic untouched.
- **DASH-isolated**: 2 files, zero `core/` edit, no `build.yml` allowlist change (`test_dash_conformance` already listed).
- New KAT `DashVersionGateThresholdSSOT` pins the named constants to canonical values (so a future edit cannot silently fork the gate) and re-confirms the 60/95/85 boundaries are byte-identical through the named path.
- **49/49 `test_dash_conformance` green on Linux x86_64** (+2 new, non-hollow).

## Classification (3-bucket)
- The 60%/95% percentages are **Bucket-2 v36-native SHARED shapes** (identical across btc/dgb/dash). This slice single-sources them *within DASH*; a cross-coin hoist into `core::version_gate` (which today owns only the `=36` boundary, not the percentages — btc/dgb also re-spell 60/95 as bare literals) is a **coordinated follow-up flagged to decisions@**, deliberately not done here to avoid colliding with the BTC/DGB lanes.
- `CROSSING_SUCCESSOR_FLOOR_PCT` stays Bucket-3 (per-coin, temporary, dropped post-soak).

Oracle-conformant (frstrtr/p2pool-dash); held for integrator verify → operator tap. No self-merge.