### PR TITLE
btc: wire regtest subsidy_halving_interval=150 (G3b leg-b bad-cb-amount)

### DIFF
--- a/src/impl/btc/coin/header_chain.hpp
+++ b/src/impl/btc/coin/header_chain.hpp
@@ -234,6 +234,11 @@ struct BTCChainParams {
         // Regtest genesis (Bitcoin Core CRegTestParams).
         p.genesis_hash.SetHex("0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206");
         p.fast_start_checkpoint = Checkpoint{0, p.genesis_hash};
+        // CRegTestParams nSubsidyHalvingInterval = 150 (Bitcoin Core consensus).
+        // Without this the field inherits the 210,000 mainnet default, so the
+        // embedded TemplateBuilder emits the un-halved 50 BTC at h>=150 and a
+        // won block is rejected bad-cb-amount on ConnectBlock (G3b leg-b).
+        p.subsidy_halving_interval = 150u;
         return p;
     }
 

--- a/src/impl/btc/test/share_test.cpp
+++ b/src/impl/btc/test/share_test.cpp
@@ -99,6 +99,16 @@ TEST(BTC_subsidy, RegtestHalvingIntervalHonored)
 
     // The pre-fix bug would have returned 50 BTC at h=275 (275 < 210000).
     EXPECT_NE(get_block_subsidy(275, 150u), 50 * COIN);
+
+    // INTEGRATION SEAM (the actual G3b leg-b defect): proving the resolver
+    // honors a 150 interval is not enough — the regtest chainparams must
+    // actually CARRY 150 so the embedded TemplateBuilder passes it through.
+    // Pre-fix regtest() inherited the 210,000 default, so the won-block
+    // coinbase at h275 paid the un-halved 50 BTC. These flip RED on the bug.
+    using btc::coin::BTCChainParams;
+    EXPECT_EQ(BTCChainParams::regtest().subsidy_halving_interval, 150u);
+    EXPECT_EQ(get_block_subsidy(275, BTCChainParams::regtest().subsidy_halving_interval),
+              25 * COIN);
 }
 
 // Mainnet/testnet remain consensus-neutral after parameterization: the


### PR DESCRIPTION
## G3b leg-b root cause: regtest halving interval never wired

`BTCChainParams::regtest()` never set `subsidy_halving_interval`, so it inherited the **210,000-block mainnet default**. The embedded TemplateBuilder therefore computed `get_block_subsidy(275, 210000)` = **50 BTC (5000000000)** at every regtest height. Past the regtest first halving (interval 150), consensus allows only **25 BTC (2500000000)** from h150 onward, so bitcoind rejected each won block `bad-cb-amount` on ConnectBlock and `getblockcount` stayed 274→274.

This explains the integrator capture: dual-broadcast (#530) fired both legs correctly; the block was simply un-connectable because the coinbase over-claimed.

## Acceptance criteria
1. **Per-net halving applied to won-block value path** — regtest now carries interval 150; h≥150 pays 25 BTC, with subsequent halvings at the right multiples. ✅
2. **Single resolver, reconciled** — there is one coinbase-value source: the won-block/found path (`work_source.cpp`) reads `coinbasevalue` from the **same cached embedded template** the stratum path uses, built by `TemplateBuilder` via `get_block_subsidy(h, chain.params().subsidy_halving_interval)`. Wiring the regtest field fixes both paths; no second resolver exists. ✅
3. **mainnet/testnet unchanged** — only `regtest()` sets 150; mainnet/testnet/testnet4 keep the 210,000 default. Per-net interval bug, not a flat-value change. ✅

## Why #520 missed it
#520 added the parameterized resolver and the `subsidy_halving_interval` field, but never set it on `regtest()`. Its KATs exercised `get_block_subsidy(275, 150u)` in isolation and the chainparams assertions covered mainnet/testnet/testnet4 but **omitted regtest()** — the integration seam.

## Test
- New flip-RED assertions in `BTC_subsidy.RegtestHalvingIntervalHonored` pin `regtest().subsidy_halving_interval == 150` and `get_block_subsidy(275, regtest interval) == 25 BTC`.
- **Proven RED pre-fix** (reverting only the header line: `Which is: 2500000000` → FAILED).
- Full `btc_share_test`: 38/38 PASS with fix.

Signed, no third-party attribution. Held for operator tap — I do not self-merge.