### PR TITLE
dash(g1): real testnet3 X11 byte-parity KATs from live node (Dash Core 22.1.3)

### DIFF
--- a/test/test_dash_x11_kat.cpp
+++ b/test/test_dash_x11_kat.cpp
@@ -15,6 +15,9 @@
 
 #include <cstdint>
 #include <cstring>
+#include <cstdio>
+
+#include <array>
 
 namespace {
 
@@ -88,4 +91,61 @@ TEST(DashX11Kat, Testnet3Block1497944ReproducesBlockHash) {
 
     uint256 pow = dash::crypto::hash_x11(header, sizeof(header));
     EXPECT_EQ(pow.GetHex(), expected);
+}
+
+
+// -- Real-node byte-parity KATs: DASH testnet3 raw on-wire headers -----------
+// Captured 2026-06-26 from a fully-synced testnet3 dashd (Dash Core 22.1.3;
+// blocks==headers==1503386, initialblockdownload=false) on the testbed node
+// (VMID 200) via:  dash-cli getblockheader <hash> false  -- the raw 80-byte
+// serialized header hex exactly as it crosses the wire. Hashing each header with
+// X11 must reproduce the block hash the node reports. Unlike the field-
+// reconstructed vector above, these pin the pipeline against the precise
+// consensus bytes the node relays (no host-side serialization assumptions).
+namespace {
+
+std::array<unsigned char, 80> header_from_hex(const char* hex) {
+    std::array<unsigned char, 80> out{};
+    for (size_t i = 0; i < out.size(); ++i) {
+        unsigned int byte = 0;
+        std::sscanf(hex + 2 * i, "%2x", &byte);
+        out[i] = static_cast<unsigned char>(byte);
+    }
+    return out;
+}
+
+struct RealHeaderVector {
+    int         height;
+    const char* raw_header_hex;   // 160 hex chars == 80 serialized header bytes
+    const char* expected_hash;    // node-reported block hash (display order)
+};
+
+// Dash Core 22.1.3, testnet3, captured 2026-06-26 @ tip 1503386.
+constexpr RealHeaderVector kRealVectors[] = {
+    {1503380,
+     "00000020ed80a6115db295cfce0267973b57c99559ef153c8ee6d637230708b262000000"
+     "d57690645314f8e6c928b0bb009e26b250599ec71049926aa6811e237e5a4aed818c3e6a"
+     "f4c3001e38a10000",
+     "000000b30a96f693930510ea6e0fde107ebe25816ad8caf2b4eb78593e193225"},
+    {1502000,
+     "00000020e2f154277cac71c02d220aac3a8270f79fb948c9c46b2311c13693888b000000"
+     "69941a5ab8c7b4fea50ea0d7f9cf998a57a31ef3b6ea164eb226091364a72c6392913b6a"
+     "9926011e95e70c00",
+     "0000005a8905c97234e4fef4fc42b70bf0bdb9ccf80d1c00ade9269af39b82a6"},
+    {1500000,
+     "00000020f0f499182b0f199a5ed575408449f3da1daa5d05d8694a68f56da86f37000000"
+     "45293808cc9d4b6be7de310c88ac5cd40fe1bbaee4425fce5459d68e1df1d07a9096376a"
+     "28ca001ec60b0700",
+     "000000b625f73fab6cb338c31cb656680ccfb3b574b9225022c8e90e293a0c12"},
+};
+
+} // namespace
+
+TEST(DashX11Kat, Testnet3RawHeadersReproduceBlockHash) {
+    for (const auto& v : kRealVectors) {
+        const auto header = header_from_hex(v.raw_header_hex);
+        const uint256 pow = dash::crypto::hash_x11(header.data(), header.size());
+        EXPECT_EQ(pow.GetHex(), v.expected_hash)
+            << "X11 byte-parity mismatch at testnet3 height " << v.height;
+    }
 }


### PR DESCRIPTION
## What
Hardens the G-series X11 byte-parity fixtures with REAL on-wire vectors captured from a live testnet3 dashd, replacing reliance on synthetic/single-block coverage.

Adds `DashX11Kat.Testnet3RawHeadersReproduceBlockHash`: three raw 80-byte serialized headers captured from a fully-synced testnet3 node, asserting `X11(header) == node-reported block hash` for each.

## Node provenance
- Node: **Dash Core 22.1.3**, chain=test (testnet3), VMID 200 testbed (never prod, no tiny rig)
- State at capture (2026-06-26): blocks==headers==**1503386**, initialblockdownload=false
- Source RPC: `dash-cli getblockheader <hash> false` (raw on-wire 80-byte header hex)
- Vectors: heights **1500000 / 1502000 / 1503380**

Using the raw serialized hex rather than reconstructing from decoded fields pins the BLAKE->BMW->...->ECHO pipeline against the precise consensus bytes the node relays (no host-side serialization assumptions).

## Non-hollow proof
- Local: 4/4 `test_dash_x11_kat` green (genesis + 1497944 + 3 new real vectors).
- Tamper check: flipping a single header byte turns the new test RED with `X11 byte-parity mismatch at testnet3 height 1503380`; revert -> green. The assertion exercises the real X11 pipeline, not a stub.

## Fencing
- Single file: `test/test_dash_x11_kat.cpp` (+60). dash-fenced, additive, no shared/other-coin/src-core touch -> single-coin DASH smoke suffices.
- GPG-signed, attribution-clean.

Held for integrator verify + operator tap (no self-merge).