### PR TITLE
nmc: isolate P1f persist ctest datadirs to kill LevelDB LOCK flake

### DIFF
--- a/src/impl/nmc/test/auxpow_merkle_test.cpp
+++ b/src/impl/nmc/test/auxpow_merkle_test.cpp
@@ -27,6 +27,8 @@
 #include <stdexcept>
 #include <vector>
 #include <filesystem>
+#include <atomic>
+#include <unistd.h>
 
 #include <core/hash.hpp>
 #include <core/pack.hpp>
@@ -1249,9 +1251,21 @@ using nmc::coin::IndexEntry;
 using nmc::coin::IndexEntryDiskV1;
 
 // A fresh, empty on-disk path for one test (prior contents wiped).
+//
+// gtest_add_tests(... AUTO) registers each TEST as its own ctest entry, so the
+// persist KATs run as separate processes under `ctest -j`. A fixed per-test dir
+// name lets a sibling worker (or a not-yet-reaped retry) still hold the LevelDB
+// LOCK file when this call's remove_all + reopen races it, surfacing as
+// "LevelDB open failed ... LOCK: Resource temporarily unavailable". Make every
+// path globally unique to THIS process and call so no two opens can ever share
+// a datadir, regardless of ctest scheduling.
 static std::string fresh_db_dir(const std::string& name)
 {
-    std::filesystem::path p = std::filesystem::path(testing::TempDir()) / name;
+    static std::atomic<uint64_t> seq{0};
+    const std::string unique = name + "_pid" +
+        std::to_string(static_cast<long long>(::getpid())) + "_n" +
+        std::to_string(seq.fetch_add(1));
+    std::filesystem::path p = std::filesystem::path(testing::TempDir()) / unique;
     std::error_code ec;
     std::filesystem::remove_all(p, ec);
     return p.string();


### PR DESCRIPTION
## What

Per-call datadir isolation for the NMC P1f persist ctests
(`NmcP1fPersist.*` / `NmcP1fAcceptPersist.*`) to eliminate the LevelDB
`LOCK: Resource temporarily unavailable` flake that has intermittently
red-ed unrelated rollups (most recently BCH G0 #542's base `Linux x86_64`
leg, second occurrence).

## Root cause

`gtest_add_tests(... AUTO)` registers each persist `TEST` as its own
ctest entry, so they run as separate processes under `ctest -j`.
`fresh_db_dir()` used a fixed per-test name under `testing::TempDir()`.
A sibling worker (or a not-yet-reaped retry of the same test) can still
hold the LevelDB `LOCK` file when this call's `remove_all` + reopen races
it → intermittent open failure.

## Fix

`fresh_db_dir()` now appends `pid` + an atomic per-call counter, so every
datadir is globally unique and no two opens can ever share a path,
regardless of ctest scheduling. Strictly better than serializing with
`ctest -j1` — keeps parallelism.

- Test-only, **nmc-fenced**, no consensus / prod-path change.
- Verified: all 8 persist KATs pass under `ctest -j8` (all 8 start
  concurrently → all PASS), build exit 0.

Held for operator tap.
