### PR TITLE
btc: adopt oracle FLOOR for v36 version-gate tail accept (SSOT step-2, + green KAT)

### DIFF
--- a/src/impl/btc/auto_ratchet.hpp
+++ b/src/impl/btc/auto_ratchet.hpp
@@ -166,8 +166,16 @@ public:
                     if (static_cast<int64_t>(ver) >= target_version_)
                         tail_target = tail_target + w;
                 }
-                // Canonical: counts.get(VERSION,0) < sum(counts)*60//100
-                bool tail_ok = !(tail_target * uint32_t(100) < tail_total * uint32_t(SWITCH_THRESHOLD));
+                // Canonical FLOOR (p2pool data.py share-acceptance):
+                //   valid iff target >= floor(total * SWITCH_THRESHOLD / 100)
+                //   i.e. counts.get(VERSION,0) >= sum(counts)*60//100.
+                // The prior cross-multiplied form (target*100 >= total*60) is the
+                // algebraic CEIL: at a non-integral boundary (total*60 % 100 != 0)
+                // it latched up to one work-unit LATER than the network oracle.
+                // Adopting FLOOR removes that c2pool-only late-latch divergence so
+                // our accept gate is byte-identical to every p2pool peer's.
+                bool tail_ok = !(tail_target <
+                                 (tail_total * uint32_t(SWITCH_THRESHOLD)) / uint32_t(100));
 
                 if (!tail_ok) {
                     static int tail_log = 0;

--- a/src/impl/btc/test/auto_ratchet_sim_test.cpp
+++ b/src/impl/btc/test/auto_ratchet_sim_test.cpp
@@ -34,14 +34,15 @@ using btc::RatchetState;
 namespace {
 
 // Verbatim replica of the LIVE inline tail-guard in
-// AutoRatchet::get_share_version:  tail_ok = !(target*100 < total*SWITCH).
+// AutoRatchet::get_share_version:  tail_ok = !(target < total*SWITCH/100).
 // Localises the 60%-by-WORK accept gate so C3 pins it WITHOUT driving the
-// consensus path or importing a lifted SSOT.
+// consensus path or importing a lifted SSOT. FLOOR form, tracking the SSOT
+// step-2 adoption (was the algebraic CEIL target*100 < total*SWITCH).
 bool inline_tail_ok(const uint288& target, const uint288& total,
                     int thr = AutoRatchet::SWITCH_THRESHOLD)
 {
-    return !((target * static_cast<uint32_t>(100)) <
-             (total  * static_cast<uint32_t>(thr)));
+    return !(target < (total * static_cast<uint32_t>(thr))
+                       / static_cast<uint32_t>(100));
 }
 
 // 95%-by-COUNT activation predicate (flat head-count), mirroring the VOTING ->
@@ -199,19 +200,20 @@ TEST(BTC_AutoRatchetSim, C4_StatePersistsAcrossRestart)
 //
 // p2pool oracle (data.py share-acceptance) valid threshold is the FLOOR form:
 //     counts.get(VERSION,0) >= sum(counts)*60//100            # floor
-// The BTC inline tail-guard (auto_ratchet.hpp:169, replicated as
-// inline_tail_ok above) is the algebraic CEIL form at the boundary:
-//     target*100 >= total*60   <=>   target >= ceil(total*60/100).
-// When (total*60) % 100 != 0, floor < ceil, so the ORACLE latches up to one
-// share EARLIER than our form. This KAT PINS that divergence at a non-integral
-// boundary (total=101 => total*60 = 6060, 6060 % 100 = 60 != 0):
-//     floor(6060/100) = 60   (oracle: target=60 PASSES)
-//     ceil (6060/100) = 61   (inline: target=60 HOLDS)
-// The EXPECT_FALSE on the inline form is the STANDARDIZATION SEAM: it flips to
-// PASS only when the core-SSOT floor adoption lands (EXCEPTIONAL/operator-tap
-// gated). Until then it locks the gap as PROVEN, not asserted. The integral
-// control (total=100) shows the two forms AGREE when the boundary is exact, so
-// the divergence is the %100 remainder alone. Consensus surface UNCHANGED.
+// The BTC inline tail-guard (auto_ratchet.hpp, replicated as inline_tail_ok
+// above) has ADOPTED that FLOOR form. Previously it was the algebraic CEIL
+//     target*100 >= total*60   <=>   target >= ceil(total*60/100),
+// which at a non-integral boundary (total*60 % 100 != 0) latched up to one
+// share LATER than the oracle. This KAT now PINS the CONVERGED state: at the
+// same non-integral boundary (total=101 => total*60 = 6060, 6060 % 100 != 0)
+//     floor(6060/100) = 60   (oracle  : target=60 PASSES)
+//     inline (FLOOR)  = 60   (adopted : target=60 PASSES)  <-- seam CLOSED
+// Pre-adoption this line read EXPECT_FALSE on the inline form (CEIL held until
+// 61); the SSOT floor adoption (operator-tap gated) flips it to EXPECT_TRUE.
+// The integral control (total=100) still shows both forms AGREE on the exact
+// boundary, so the only behavioural change is the %100 remainder share, now
+// accepted one unit earlier in lock-step with the network. Consensus surface
+// equals the p2pool oracle EXACTLY.
 // ---------------------------------------------------------------------------
 TEST(BTC_AutoRatchetSim, SSOT2_OracleFloorVsInlineCeilBoundary)
 {
@@ -227,8 +229,8 @@ TEST(BTC_AutoRatchetSim, SSOT2_OracleFloorVsInlineCeilBoundary)
 
     const uint288 total(101);                            // 101*60 = 6060, %100 = 60
     EXPECT_TRUE (oracle_floor_ok(uint288(60), total));   // oracle: latches at 60
-    EXPECT_FALSE(inline_tail_ok (uint288(60), total));   // inline: holds until 61
-    // One share later the two forms re-converge.
+    EXPECT_TRUE (inline_tail_ok (uint288(60), total));   // inline FLOOR: latches at 60 too
+    // Forms are now identical at every point (boundary and beyond).
     EXPECT_TRUE (oracle_floor_ok(uint288(61), total));
     EXPECT_TRUE (inline_tail_ok (uint288(61), total));
 }

--- a/src/impl/btc/test/auto_ratchet_sim_test.cpp
+++ b/src/impl/btc/test/auto_ratchet_sim_test.cpp
@@ -193,3 +193,42 @@ TEST(BTC_AutoRatchetSim, C4_StatePersistsAcrossRestart)
     EXPECT_EQ(vote, 36);
     std::remove(path.c_str());
 }
+
+// ---------------------------------------------------------------------------
+// SSOT step-2 / #1 standardization target — ORACLE FLOOR vs INLINE CEIL.
+//
+// p2pool oracle (data.py share-acceptance) valid threshold is the FLOOR form:
+//     counts.get(VERSION,0) >= sum(counts)*60//100            # floor
+// The BTC inline tail-guard (auto_ratchet.hpp:169, replicated as
+// inline_tail_ok above) is the algebraic CEIL form at the boundary:
+//     target*100 >= total*60   <=>   target >= ceil(total*60/100).
+// When (total*60) % 100 != 0, floor < ceil, so the ORACLE latches up to one
+// share EARLIER than our form. This KAT PINS that divergence at a non-integral
+// boundary (total=101 => total*60 = 6060, 6060 % 100 = 60 != 0):
+//     floor(6060/100) = 60   (oracle: target=60 PASSES)
+//     ceil (6060/100) = 61   (inline: target=60 HOLDS)
+// The EXPECT_FALSE on the inline form is the STANDARDIZATION SEAM: it flips to
+// PASS only when the core-SSOT floor adoption lands (EXCEPTIONAL/operator-tap
+// gated). Until then it locks the gap as PROVEN, not asserted. The integral
+// control (total=100) shows the two forms AGREE when the boundary is exact, so
+// the divergence is the %100 remainder alone. Consensus surface UNCHANGED.
+// ---------------------------------------------------------------------------
+TEST(BTC_AutoRatchetSim, SSOT2_OracleFloorVsInlineCeilBoundary)
+{
+    // Oracle floor predicate: target >= floor(total*60/100).
+    auto oracle_floor_ok = [](const uint288& target, const uint288& total) {
+        return !(target < ((total * static_cast<uint32_t>(60))
+                           / static_cast<uint32_t>(100)));
+    };
+
+    // Integral-boundary control (total=100): floor==ceil==60, forms AGREE.
+    EXPECT_EQ(oracle_floor_ok(uint288(60), uint288(100)),
+              inline_tail_ok (uint288(60), uint288(100)));
+
+    const uint288 total(101);                            // 101*60 = 6060, %100 = 60
+    EXPECT_TRUE (oracle_floor_ok(uint288(60), total));   // oracle: latches at 60
+    EXPECT_FALSE(inline_tail_ok (uint288(60), total));   // inline: holds until 61
+    // One share later the two forms re-converge.
+    EXPECT_TRUE (oracle_floor_ok(uint288(61), total));
+    EXPECT_TRUE (inline_tail_ok (uint288(61), total));
+}


### PR DESCRIPTION
## v36 version_gate SSOT — adopt oracle FLOOR for the tail accept gate

Operator-approved standardization: drop the c2pool-only late-latch CEIL and adopt
the p2pool oracle FLOOR form for the v36 version-gate 60%-by-work tail accept gate.
Fenced to the version_gate path; two files, no behavioural change on any realizable
work-weighted tally (see safety proof below).

### Change
- **PROD** `src/impl/btc/auto_ratchet.hpp` `AutoRatchet::get_share_version` tail
  guard: CEIL `tail_target*100 < tail_total*60` -> FLOOR
  `tail_target < (tail_total*60)/100` (p2pool `data.py` form). Only behavioural
  delta: at a non-integral boundary the gate latches one work-unit earlier, in
  lock-step with the oracle every deployed peer enforces.
- **TEST** `auto_ratchet_sim_test.cpp`: `inline_tail_ok` replica updated to the same
  FLOOR form, and `SSOT2_OracleFloorVsInlineCeilBoundary` flips
  `EXPECT_FALSE -> EXPECT_TRUE` at the total=101 boundary — the seam is now CLOSED,
  pinning the CONVERGED state. The KAT was proven flip-RED before this change, so it
  is load-bearing.

Verified locally: 7/7 AutoRatchet KATs + full `btc_share_test` 39/39 green. Sibling
accept-gate / mint-cannot-outrun-accept / monotonic cases unaffected (integral or
far-from-boundary).

### Consensus-safety (paired evidence)
The FLOOR vs CEIL forms differ on exactly one integer value of `target_work` — a
1-work-unit band. The gate reads the work-weighted tally
(`get_desired_version_weights`, weight = `ShareIndex::work`), not a flat count. The
minimum single-share work quantum `W_min` is bounded below by the scrypt pow_limit
at >= 2^20 (~1.05e6) work-units, so every share moves `target_work` by >= ~1e6 >>
the 1-unit band. Oracle-FLOOR and inline-CEIL therefore latch on the identical share
for any realizable tally — the early latch is unreachable by construction, not merely
improbable. Direction of risk: FLOOR removes a latent c2pool-only late-latch
divergence and introduces no early activation.

Full exhaustive proof: evidence doc `1579dc4` (frstrtr/the#12,
`docs/v36-version-gate-ssot-step2-prod-vote-safety.md`).

### Notes
- Stacked on #543 (crossing-drive standup); base will retarget to master once #543
  lands. The version_gate commits touch disjoint files from #543.
- Consensus-bearing version-gate change: held for operator tap, no self-merge.
