### PR TITLE
ci: route remaining heavy workflows to self-hosted (Phase 2, fork-gated)

### DIFF
--- a/.github/workflows/attribution-gate.yml
+++ b/.github/workflows/attribution-gate.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   attribution-gate:
     name: attribution-gate
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-latest' }}
     steps:
       - name: Checkout full history
         uses: actions/checkout@v4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: ubuntu-24.04
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
     permissions:
       security-events: write
       packages: read
@@ -39,7 +39,7 @@ jobs:
           queries: security-and-quality
 
       # ── C++ build (manual mode only) ─────────────────────────────────────
-      - if: matrix.build-mode == 'manual'
+      - if: matrix.build-mode == 'manual' && runner.environment == 'github-hosted'
         name: Install system dependencies
         run: |
           sudo apt-get update -qq
@@ -70,6 +70,10 @@ jobs:
           # Share cache with build.yml (same Release profile)
           key: conan2-ubuntu24-gcc13-${{ hashFiles('conanfile.txt') }}
           restore-keys: conan2-ubuntu24-gcc13-
+
+      - if: matrix.build-mode == 'manual' && runner.environment != 'github-hosted'
+        name: Clean stale build dir (self-hosted workspace is reused)
+        run: rm -rf build_codeql
 
       - if: matrix.build-mode == 'manual'
         name: Install Conan dependencies

--- a/.github/workflows/coin-matrix.yml
+++ b/.github/workflows/coin-matrix.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   coin:
     name: ${{ matrix.coin }} smoke (Linux x86_64)
-    runs-on: ubuntu-24.04
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
     strategy:
       fail-fast: false
       matrix:
@@ -40,7 +40,7 @@ jobs:
           fi
 
       - name: Install system dependencies
-        if: steps.presence.outputs.exists == '1'
+        if: steps.presence.outputs.exists == '1' && runner.environment == 'github-hosted'
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
@@ -69,6 +69,10 @@ jobs:
           restore-keys: |
             conan2-ubuntu24-gcc13-${{ matrix.coin }}-
             conan2-ubuntu24-gcc13-
+
+      - name: Clean stale build dir (self-hosted workspace is reused)
+        if: steps.presence.outputs.exists == '1' && runner.environment != 'github-hosted'
+        run: rm -rf build_${{ matrix.coin }}
 
       - name: Conan install
         if: steps.presence.outputs.exists == '1'

--- a/.github/workflows/safe-cosmetic-automerge.yml
+++ b/.github/workflows/safe-cosmetic-automerge.yml
@@ -51,7 +51,7 @@ concurrency:
 
 jobs:
   evaluate:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
     steps:
       - name: Evaluate gate and merge if green and authorized
         env:


### PR DESCRIPTION
## Phase 2 — route remaining heavy workflows to self-hosted (fork-gated)

Follow-on to #439 (build.yml self-hosted switch). Reclaims more of the
~95.6% machine-hours still on GitHub-hosted by routing the remaining
heavy workflows onto the self-hosted fleet, using the **same fork-gated
pattern as #439**: self-hosted for push / internal-branch PRs,
GitHub-hosted fallback for fork PRs.

### Runners verified online before routing
`gh api repos/frstrtr/c2pool/actions/runners` — all online:
Linux-905 (×4), Windows-217, Mac-mini-Alonso-227, macpro-intel-204.

### Migrated (runs-on -> fork-gated self-hosted Linux)
- `coin-matrix.yml` — coin smoke matrix (ltc/doge/dash/btc/dgb/bch)
- `codeql-analysis.yml` — Analyze legs (c-cpp + python)
- `attribution-gate.yml`
- `safe-cosmetic-automerge.yml` — evaluate

### Build-env parity (the two building jobs only)
Mirrors build.yml on coin-matrix + codeql c-cpp manual:
- clean stale reused build dir on self-hosted (`rm -rf build_<coin>` /
  `build_codeql`) — avoids the stale `gtest_discover` exit-8 seen in #439
- skip apt system-deps on self-hosted (preinstalled on c2pool-build)

### Guardrails
- Per-coin source-presence guards (PR #47) **untouched**.
- CI plumbing only — no consensus / coin-tree changes (fenced lane).

Merge-gated: surfacing for a tap once the full rollup is CLEAN green.
