### PR TITLE
d-miner5(fix): gate back_online on a reported outage (no false recovery on sub-threshold blip)

### DIFF
--- a/scripts/miner_notify_engine.py
+++ b/scripts/miner_notify_engine.py
@@ -130,8 +130,10 @@ def evaluate(con, sub_for, at=None):
         peak = prev[6] if prev else 0.0
 
         if online:
-            # back-online edge: was known-offline, now producing
-            if p_online == 0:
+            # back-online edge: only after we actually reported the outage.
+            # A sub-threshold blip never fires OFFLINE -> reporting a recovery
+            # from an outage the miner was never told about is a false alert.
+            if p_online == 0 and offline_fired:
                 events.append({"worker": worker, "kind": BACK_ONLINE, "ts": ts,
                                "detail": f"hashrate {hr:.3g} (was offline)"})
             offline_since, offline_fired = None, 0
@@ -386,6 +388,19 @@ def selftest(_args=None):
     e = evaluate(con, sub_for, at=t0 + 41 * 60)
     check([x["kind"] for x in e] == [HASHRATE_DROP], f"expected drop, got {e}")
 
+    # 6b) sub-threshold blip (dark < offline_min so OFFLINE never fired) then
+    #     recovery must stay silent: no false back_online for an unreported outage
+    put(t0 + 50 * 60, "w3", 90.0)
+    evaluate(con, sub_for, at=t0 + 50 * 60)             # w3 first-online: silent
+    put(t0 + 51 * 60, "w3", 0.0)
+    e = evaluate(con, sub_for, at=t0 + 51 * 60)         # 1m dark < 15m threshold
+    check([x for x in e if x["worker"] == "w3"] == [],
+          f"sub-threshold blip should be silent, got {e}")
+    put(t0 + 52 * 60, "w3", 90.0)
+    e = evaluate(con, sub_for, at=t0 + 52 * 60)         # recovered, never alerted
+    check([x for x in e if x["worker"] == "w3"] == [],
+          f"recovery without a prior offline alert must be silent, got {e}")
+
     # 7) quiet-hours suppresses info (back_online) but NOT warn (offline)
     check(in_quiet_hours("22-07", t0) is not None, "quiet parse")
     info_ev = {"worker": "w1", "kind": BACK_ONLINE, "ts": t0, "detail": "d"}
@@ -415,7 +430,7 @@ def selftest(_args=None):
         for f in fails:
             print("  -", f)
         return 1
-    print("SELFTEST OK (9/9)")
+    print("SELFTEST OK (10/10)")
     return 0
 
 


### PR DESCRIPTION
## What

`evaluate()` in the D-MINER.5 notify engine emitted a `back_online` event whenever the prior sample was offline (`p_online == 0`), regardless of whether an `OFFLINE` alert had ever fired.

A sub-threshold blip — a worker dark for less than `offline_min` — never fires `OFFLINE`. But on the next online sample the old code still emitted `back_online`, telling the miner they had recovered from an outage:

- they were never notified about, and
- that never met the alert threshold in the first place.

That is a false-positive notification: the engine reporting a recovery from an outage it never reported. Same charter as the dashboard — the notify path must never tell a miner something untrue.

## Fix

Gate the `back_online` edge on `offline_fired`, so a recovery is only reported when the outage itself was reported.

## Test

Adds KAT scenario 6b: a worker blips dark for 1m (< 15m threshold) then recovers — must stay silent (no `OFFLINE`, no false `back_online`). Verified the KAT fails before the fix and passes after. `selftest` 10/10.

Web/notify-engine layer only; non-consensus.
