### PR TITLE
ltc: saturate emergency-decay target shift to prevent uint256 wrap

### DIFF
--- a/src/impl/ltc/share_tracker.hpp
+++ b/src/impl/ltc/share_tracker.hpp
@@ -1367,6 +1367,27 @@ public:
         return attempts / uint288(time_span);
     }
 
+    // Saturating left-shift of a share target, used by the death-spiral
+    // emergency decay (Step 3 of compute_share_target).
+    //
+    // BUG GUARDED: a bare `prev << shift` overflows the 256-bit target and
+    // WRAPS to a tiny value (= HARDER difficulty), which accelerates the very
+    // death spiral the emergency decay exists to arrest. The old `halvings <
+    // 256` guard only bounded the shift width, not whether the shifted value
+    // stayed <= max_target (MAX_TARGET is 2^236-1 on mainnet, so even modest
+    // halvings overflow). We saturate to max_target whenever the shift would
+    // exceed it; otherwise the result is provably <= max_target < 2^256.
+    static uint256 emergency_decay_shl(const uint256& prev, unsigned int shift,
+                                       const uint256& max_target)
+    {
+        // prev << shift > max_target  <=>  prev > (max_target >> shift)
+        if (shift >= 256 || prev > (max_target >> shift))
+            return max_target;
+        uint256 r = prev;
+        r <<= shift;            // result <= max_target < 2^256: no overflow
+        return r;
+    }
+
     // -- Share target computation --
     // Computes max_bits and bits for a new share, matching p2pool-v36
     // BaseShare.generate_transaction():
@@ -1539,11 +1560,10 @@ public:
                 auto halvings = excess / half_life;
                 auto remainder = excess % half_life;
                 // 2^halvings with linear interpolation for fractional part
-                uint256 eased = prev_max_target;
-                if (halvings < 256)
-                    eased <<= halvings;
-                else
-                    eased = MAX_TARGET;
+                // Saturating shift: guards against uint256 overflow that
+                // would otherwise wrap the eased target to a tiny value.
+                uint256 eased = emergency_decay_shl(
+                    prev_max_target, static_cast<unsigned int>(halvings), MAX_TARGET);
                 // Linear interpolation: eased = eased * (half_life + remainder) / half_life
                 uint288 eased_288;
                 eased_288.SetHex(eased.GetHex());

--- a/src/impl/ltc/test/CMakeLists.txt
+++ b/src/impl/ltc/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (BUILD_TESTING AND GTest_FOUND)
-    add_executable(share_test share_test.cpp f11_donation_invariance_test.cpp)
+    add_executable(share_test share_test.cpp f11_donation_invariance_test.cpp emergency_decay_overflow_test.cpp)
     target_link_libraries(share_test PRIVATE
         GTest::gtest_main GTest::gtest
         core ltc

--- a/src/impl/ltc/test/emergency_decay_overflow_test.cpp
+++ b/src/impl/ltc/test/emergency_decay_overflow_test.cpp
@@ -1,0 +1,95 @@
+// Conformance KAT — death-spiral emergency-decay uint256 overflow.
+//
+// Guards ltc::ShareTracker::emergency_decay_shl (Step 3 of
+// compute_share_target, src/impl/ltc/share_tracker.hpp).
+//
+// REGRESSION: the emergency time-based decay used a bare `prev << halvings`
+// on a 256-bit target. With a large prev (MAX_TARGET is 2^236-1 on mainnet)
+// and a multi-window share gap, the shift overflows 256 bits and WRAPS to a
+// tiny value — i.e. a HARDER target — which accelerates the very death
+// spiral the decay exists to arrest. The old `halvings < 256` guard only
+// bounded the shift width, never the magnitude. The fix saturates to
+// max_target on overflow.
+//
+// CORE INVARIANT: emergency decay only ever EASES (target non-decreasing).
+// A wrapped result would be strictly LESS than prev — that is exactly what
+// each ASSERT_GE below catches.
+//
+// Standardized fix shape — DGB and BTC carry the identical helper and an
+// equivalent KAT (per-coin fenced PRs, same arithmetic).
+
+#include <gtest/gtest.h>
+
+#include <impl/ltc/config_pool.hpp>
+#include <impl/ltc/share_tracker.hpp>
+
+using ltc::ShareTracker;
+
+namespace {
+
+uint256 hex(const char* h) { uint256 v; v.SetHex(h); return v; }
+
+// mainnet share-difficulty floor: 2^236 - 1  (59 hex 'f's)
+const uint256 MAX_T = hex("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+
+} // namespace
+
+TEST(EmergencyDecayOverflow, ShiftZeroIsIdentity)
+{
+    uint256 prev = hex("1000000000000000000000000000000000000000000000000000000000");
+    EXPECT_EQ(ShareTracker::emergency_decay_shl(prev, 0, MAX_T), prev);
+}
+
+TEST(EmergencyDecayOverflow, SmallShiftWithinHeadroomIsExact)
+{
+    uint256 prev = uint256(1);
+    uint256 r = ShareTracker::emergency_decay_shl(prev, 8, MAX_T);
+    EXPECT_EQ(r, uint256(256));   // 1 << 8
+    EXPECT_TRUE(r <= MAX_T);
+    EXPECT_TRUE(r >= prev);
+}
+
+// The regression: a large prev shifted past the 256-bit boundary must
+// saturate to MAX_T, NOT wrap to a small value.
+TEST(EmergencyDecayOverflow, LargeShiftSaturatesNoWrap)
+{
+    uint256 prev = MAX_T;                 // already at the ceiling
+    for (unsigned int shift : {1u, 8u, 32u, 64u, 200u, 255u, 256u, 1000u})
+    {
+        uint256 r = ShareTracker::emergency_decay_shl(prev, shift, MAX_T);
+        EXPECT_EQ(r, MAX_T) << "shift=" << shift << " did not saturate";
+        EXPECT_TRUE(r >= prev) << "shift=" << shift << " eased target SHRANK (wrap)";
+    }
+}
+
+// prev just below the ceiling: any shift >= 1 overflows and must saturate.
+TEST(EmergencyDecayOverflow, NearCeilingSaturates)
+{
+    uint256 prev = hex("0fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // ~2^232
+    uint256 r1 = ShareTracker::emergency_decay_shl(prev, 4, MAX_T);   // 2^236-ish -> over
+    EXPECT_EQ(r1, MAX_T);
+    EXPECT_TRUE(r1 >= prev);
+    // shift of 3 still fits under 2^236 -> exact, no saturation
+    uint256 r2 = ShareTracker::emergency_decay_shl(prev, 3, MAX_T);
+    EXPECT_TRUE(r2 <= MAX_T);
+    EXPECT_TRUE(r2 >= prev);
+}
+
+// General monotonicity sweep: for prev <= max, decay never produces a
+// smaller target at any shift.
+TEST(EmergencyDecayOverflow, NeverDecreasesTarget)
+{
+    const uint256 prevs[] = {
+        uint256(1),
+        hex("100000000000000000000000000000"),
+        hex("1000000000000000000000000000000000000000000000000000000000"),
+        MAX_T,
+    };
+    for (const auto& prev : prevs)
+        for (unsigned int shift = 0; shift <= 260; ++shift)
+        {
+            uint256 r = ShareTracker::emergency_decay_shl(prev, shift, MAX_T);
+            ASSERT_TRUE(r >= prev)  << "prev=" << prev.GetHex() << " shift=" << shift;
+            ASSERT_TRUE(r <= MAX_T) << "prev=" << prev.GetHex() << " shift=" << shift;
+        }
+}


### PR DESCRIPTION
Replaces the bare `prev << halvings` in compute_share_target Step 3 with a saturating `emergency_decay_shl()` helper that clamps to max_target on 256-bit overflow. A large prev across a multi-window share gap could previously wrap to a tiny (harder) target and accelerate a death spiral; this makes the emergency-decay path easing-only.

Scope: src/impl/ltc/ only (single-coin, LTC lane). DOGE rides the same site; BTC carries its own copy of the helper separately in its lane (no cross-coin bundling).

Tests: new 5-case conformance KAT (easing-only invariant) green; full ltc share_test 11/11 green; clean rebuild.

Head: da75622a4. Held for integrator merge tap (consensus-bearing path).