### PR TITLE
btc: BIP 35 mempool pull on connect -> POPULATED G3b templates

### DIFF
--- a/src/c2pool/main_btc.cpp
+++ b/src/c2pool/main_btc.cpp
@@ -533,6 +533,15 @@ int main(int argc, char* argv[])
     LOG_INFO << "[BTC] Connecting to bitcoind...";
     coin_node.start_p2p(NetService(bitcoind_host, bitcoind_port));
 
+    // Phase 10c: pull the peer mempool on connect (BIP 35) so TemplateBuilder
+    // produces POPULATED blocks. Without this the new_tx subscription above only
+    // sees txs announced via inv AFTER connect; txs already resident in the
+    // bitcoind mempool at connect time (e.g. a seeded regtest mempool) are never
+    // requested, leaving coinbase-only templates. Mirrors main_dgb. Peer must
+    // advertise NODE_BLOOM (regtest: -peerbloomfilters=1) or the request is
+    // skipped (logged) to avoid a disconnect; normal inv relay still applies.
+    coin_node.enable_mempool_request();
+
     // Drive initial header sync. Per BTC protocol, NodeP2P's verack handler
     // sends sendheaders/sendcmpct/feefilter but NOT getheaders — header sync
     // is the consumer's responsibility (LTC drives this from the broadcaster).

--- a/src/impl/btc/coin/node.hpp
+++ b/src/impl/btc/coin/node.hpp
@@ -29,6 +29,7 @@ class Node : public btc::interfaces::Node
 
     std::unique_ptr<NodeRPC> m_rpc;
     std::unique_ptr<NodeP2P<config_t>> m_p2p;
+    bool m_request_mempool_on_connect{false};  // BIP 35 pull on (re)connect
 
     void init_p2p()
     {
@@ -79,8 +80,24 @@ public:
     void start_p2p(const NetService& addr)
     {
         m_p2p = std::make_unique<NodeP2P<config_t>>(m_context, this, m_config);
+        if (m_request_mempool_on_connect)
+            m_p2p->enable_mempool_request();
         m_p2p->connect(addr);
         LOG_INFO << "Coin P2P broadcaster connecting to " << addr.to_string();
+    }
+
+    /// Opt into the BIP 35 `mempool` request on (re)connect. Without this the
+    /// embedded mempool only learns txs announced via `inv` AFTER we connect,
+    /// so any tx already resident in the peer mempool at connect time is never
+    /// pulled -> coinbase-only templates. Mirrors main_dgb. Idempotent; applies
+    /// to the current peer immediately and to any peer start_p2p creates later.
+    /// NOTE: the peer must advertise NODE_BLOOM (regtest: -peerbloomfilters=1)
+    /// or NodeP2P skips the request to avoid a disconnect.
+    void enable_mempool_request()
+    {
+        m_request_mempool_on_connect = true;
+        if (m_p2p)
+            m_p2p->enable_mempool_request();
     }
 
     /// Submit a block via P2P directly (faster propagation than RPC).


### PR DESCRIPTION
## What
Embedded BTC TemplateBuilder produced **coinbase-only (nTx=1)** won blocks — the G3b POPULATED residual. The `new_tx -> mempool.add_tx` subscription in `main_btc` only sees txs announced via `inv` **after** connect; txs already resident in the bitcoind mempool at connect time (e.g. a seeded regtest mempool) were never requested.

## Fix
- Expose `btc::coin::Node::enable_mempool_request()` — forwards to `NodeP2P` (applied at `start_p2p` and on any later reconnect).
- Call it from `main_btc` after `start_p2p`, so the BIP 35 `mempool` request fires on connect and the existing `new_tx` subscription ingests the pulled txs.
- Mirrors the established `main_dgb.cpp` pattern. BTC-fenced; no cross-coin contract change.

## Prereq for live proof
Peer must advertise NODE_BLOOM or NodeP2P skips the request (logged) to avoid a disconnect. Regtest re-drive must launch bitcoind with `-peerbloomfilters=1`. Normal inv relay is unchanged.

## Verification
- `cmake --build build --target c2pool-btc` clean.
- Live proof = G3b re-drive on .121 showing a won block with nTx>1 (next step, deploy-gated).

Held for operator tap — I do not self-merge.