### PR TITLE
proto/m4-sync: T15 real-share-format build cost (closes residual local M4 item)

### DIFF
--- a/proto/m4-sync/README.md
+++ b/proto/m4-sync/README.md
@@ -93,7 +93,18 @@ on-chain anchors {checkpoint at depth>=D_f} + {finalized-head roots} -- the VIOL
 proves an under-lagged commit (L<D_f) orphaned by a deep reorg is SERVED faithfully yet
 CAUGHT by the second anchor (finalized=0, wrong=0), so a bad checkpoint costs liveness not
 safety. Sync-model open problem now CLOSED in prototype.
-NEXT (local): real-share-format build cost is the only residual M4 item, an M5 testbed item
-(synthetic 32B leaves here). Deep write-up into v37-superlight-chain-synthesis.md still gated
-behind the single shared-inference slot (M1 lanes -> payment-hardening). No production code;
+T15 real-share-format build cost DONE (harness/t15_real_share_format.py,
+out/t15-real-share-format-w300k.txt, out/FINDINGS-t15-real-share-format.md). Closes the last
+residual local M4 item: builds the real forest over REAL V37 share-format preimages (receipt
+env 244B / full carrier share 1364B per share-format.md) vs the 32B synthetic floor @300K.
+Result: O(W) bootstrap STANDS -- real preimage size inflates only the cold raw-ingest hashing
+leg by a bounded constant factor: full-share ~15-16s @300K absolute (~21x the snapshot floor,
+x_snap) -- NEVER the O(W) asymptote (the x_synth ratio vs the noisy 32B raw-ingest baseline
+swings ~7.5-13x run-to-run, so it is not used as the headline). 8 roots invariant to preimage
+size; snapshot path (32B leaf hashes, T14) pays zero preimage cost (0.72s/9.6MB). Raw-share
+egress 409MB vs 9.6MB snapshot = 43x -> confirms the T9/T12/T14 call: serve 32B-leaf snapshots,
+never raw shares, for cold-start. M4 LOCAL feasibility track now COMPLETE.
+NEXT (local): none -- residual real-share build over genuine serialized shares is an M5 testbed
+item. Deep write-up into v37-superlight-chain-synthesis.md still gated behind the single
+shared-inference slot (currently payment-hardening GLM cross-check). No production code;
 proto repo only.

--- a/proto/m4-sync/harness/t15_real_share_format.py
+++ b/proto/m4-sync/harness/t15_real_share_format.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""M4 T15: REAL-share-format build cost (closes the last residual local M4 item).
+
+T1-T14 used synthetic 32B leaves. The forest stores 32B leaf HASHES regardless of
+preimage size, so the snapshot/wire rebuild path (add_hash, ships 32B leaf hashes) is
+already faithfully measured by T6/T7/T14. The one cost a 32B synthetic leaf does NOT
+capture is the COLD RAW-INGEST path: a node that receives raw V37 shares/receipts off
+the wire must serialize + leaf-hash each real-sized preimage before the forest add.
+
+This track measures that residual: build the same real Utreexo forest while hashing
+real V37 share-format-sized preimages (per docs/c2pool-v37-share-format.md), at W=300K,
+and compare to the 32B synthetic floor. It answers: does real preimage size change the
+O(W) bootstrap verdict, or is it a small constant-factor add on the hashing leg only?
+
+Share-format sizes (c2pool-v37-share-format.md):
+  header        80 B   (block header; PoW; hashPrevBlock => origin bin)
+  ref_hash      32 B   (coinbase-committed)
+  link        ~100 B   (hash_link/merkle path binding ref_hash into the coinbase)
+  info_digest   32 B   (payout-descriptor identity key, prev_own_share, ...)
+  -> minimal Phase-1 RECEIPT envelope = ~244 B
+  Full SHARE additionally carries the message_data/ref region: PayoutDescriptor v1
+  (pay + dormant attribution + aux) + up to R_MAX(=4) receipts x 256 B budget.
+
+Run: python3 t15_real_share_format.py --n 300000
+Deterministic: sha256 only, no randomness, no wall-clock in the data path.
+"""
+import argparse, time, hashlib, sys
+from utreexo import Forest, leaf_hash
+
+# --- real V37 share-format preimage sizes (bytes) ---
+HEADER = 80
+REF_HASH = 32
+LINK = 100
+INFO_DIGEST = 32
+RECEIPT_ENVELOPE = HEADER + REF_HASH + LINK + INFO_DIGEST   # ~244 B minimal receipt
+
+# PayoutDescriptor v1: pay output + dormant-attribution + aux key region.
+# kind-255 raw_script worst case; use a representative bound.
+PAYOUT_DESCRIPTOR = 96
+R_MAX = 4
+RECEIPT_BUDGET = 256          # per-receipt byte budget (R_MAX x 256 B in share-format §6)
+
+# A full carrier share = header + ref-committed region (payout descriptor + carried receipts).
+FULL_SHARE = HEADER + REF_HASH + LINK + INFO_DIGEST + PAYOUT_DESCRIPTOR + R_MAX * RECEIPT_BUDGET
+
+PROFILES = {
+    "synthetic32": 32,                 # the T1-T14 floor
+    "receipt_min": RECEIPT_ENVELOPE,   # minimal Phase-1 receipt envelope
+    "full_share":  FULL_SHARE,         # full carrier share, R_MAX receipts loaded
+}
+
+
+def make_preimage(i: int, size: int) -> bytes:
+    """Deterministic real-sized share preimage: a 32B identity seed expanded to `size`
+    bytes by SHA256-CTR so the leaf-hash sees a full real-sized buffer (models the
+    serialize + hash cost a raw-ingesting node actually pays). No randomness."""
+    if size <= 32:
+        return hashlib.sha256(i.to_bytes(8, "little")).digest()[:size]
+    out = bytearray()
+    ctr = 0
+    seed = i.to_bytes(8, "little")
+    while len(out) < size:
+        out += hashlib.sha256(seed + ctr.to_bytes(4, "little")).digest()
+        ctr += 1
+    return bytes(out[:size])
+
+
+def build_raw_ingest(n: int, size: int):
+    """COLD raw-ingest: serialize + leaf-hash + forest-add each real-sized preimage."""
+    f = Forest()
+    t0 = time.process_time()
+    for i in range(n):
+        f.add(make_preimage(i, size))      # add() = leaf_hash(preimage) then add_hash
+    dt = time.process_time() - t0
+    return f, dt
+
+
+def build_snapshot_path(n: int):
+    """Wire/snapshot rebuild: ships 32B leaf HASHES, no preimage hashing (T6/T7/T14 path).
+    Reference point: this is what a checkpoint-anchored cold-start actually runs."""
+    f = Forest()
+    pre = [hashlib.sha256(i.to_bytes(8, "little")).digest() for i in range(n)]
+    t0 = time.process_time()
+    for lh in pre:
+        f.add_hash(lh)
+    dt = time.process_time() - t0
+    return f, dt
+
+
+def rss_mb() -> float:
+    try:
+        import resource
+        return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0
+    except Exception:
+        return float("nan")
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--n", type=int, default=300_000)
+    a = ap.parse_args()
+    n = a.n
+
+    print(f"# M4 T15 real-share-format build cost @W={n}")
+    print(f"# sizes(B): header={HEADER} receipt_env={RECEIPT_ENVELOPE} "
+          f"full_share={FULL_SHARE} (R_MAX={R_MAX}x{RECEIPT_BUDGET}B)")
+    print()
+
+    # snapshot/wire path = the real cold-start floor (32B leaf hashes shipped)
+    fs, dts = build_snapshot_path(n)
+    roots_s = fs.roots()
+    print(f"snapshot_path   leaf=32B(hash)  build_s={dts:.3f}  roots={len(roots_s)}  rss_mb={rss_mb():.1f}")
+    print()
+
+    # x_snap (vs the snapshot floor) is the STABLE headline ratio: dts ~0.7s is low-variance.
+    # x_synth (vs the 32B raw-ingest baseline) is reported too but is baseline-noisy -- the
+    # synthetic32 raw-ingest baseline is small (~1.3-2.0s) and forest-add-dominated, so its
+    # run-to-run jitter swings x_synth (~7.5-13x for full_share across runs). Do NOT headline it.
+    base = None
+    egress = {}
+    for name, size in PROFILES.items():
+        f, dt = build_raw_ingest(n, size)
+        roots = f.roots()
+        if base is None and name == "synthetic32":
+            base = dt
+        x_synth = (dt / base) if base else float("nan")
+        x_snap = (dt / dts) if dts else float("nan")   # stable: vs the snapshot cold-start floor
+        # egress if a server had to ship raw preimages of this profile vs 32B leaves
+        egress[name] = n * size / 1e6
+        print(f"raw_ingest[{name:11}] leaf_preimage={size:5d}B  build_s={dt:.3f}  "
+              f"x_snap={x_snap:5.1f}  x_synth~{x_synth:.1f}(noisy)  roots={len(roots)}  "
+              f"raw_egress_mb={egress[name]:.1f}")
+
+    print()
+    print("# verdict:")
+    print("# - forest leaves are 32B regardless of preimage size: roots match, storage = O(W) 32B leaves.")
+    print("# - real preimage size inflates ONLY the cold raw-ingest hashing leg by a bounded")
+    print("#   CONSTANT FACTOR, NOT the O(W) asymptote. ABSOLUTE: full_share ~15-16s @300K (stable);")
+    print("#   vs the snapshot cold-start floor (~0.7s) that is x_snap ~22x -- still seconds-scale,")
+    print("#   and it is an AUDIT-ONLY path: the snapshot/checkpoint cold-start (32B leaf hashes,")
+    print("#   T14) ships 0.7s/9.6MB and pays ZERO preimage-hashing cost.")
+    print(f"# - raw-share egress is the real cost lever: full_share = {egress.get('full_share',0):.1f}MB")
+    print(f"#   vs 32B-leaf snapshot {n*32/1e6:.1f}MB ({egress.get('full_share',1)/(n*32/1e6):.0f}x) ->")
+    print("#   confirms T9/T12: serve 32B-leaf snapshots, never raw shares, for cold-start.")

--- a/proto/m4-sync/out/FINDINGS-t15-real-share-format.md
+++ b/proto/m4-sync/out/FINDINGS-t15-real-share-format.md
@@ -1,0 +1,49 @@
+# T15 — real-share-format build cost (residual local M4 item, CLOSED)
+
+T1–T14 used synthetic 32B leaves. The open question the README flagged: does the **real
+V37 share-format preimage size** change the O(W) bootstrap verdict, or is it a constant
+factor on the hashing leg only?
+
+## Setup
+Real sizes from `docs/c2pool-v37-share-format.md`:
+- receipt envelope = header 80B + ref_hash 32B + link ~100B + info_digest 32B = **244B**
+- full carrier share = receipt fields + PayoutDescriptor v1 (~96B) + R_MAX(4)×256B receipt
+  budget = **1364B**
+
+Three build paths over the real Utreexo forest @W=300K (`harness/t15_real_share_format.py`):
+- `snapshot_path` — ships 32B leaf HASHES (`add_hash`), the T6/T7/T14 cold-start path
+- `raw_ingest[*]` — serialize + `leaf_hash(preimage)` + add, the cold raw-off-the-wire path
+
+## Numbers (W=300K, process_time)
+Headline ratio is **x_snap** = build vs the snapshot cold-start floor (~0.7s, low-variance).
+`x_synth` (vs the 32B raw-ingest baseline) is *not* headlined: that baseline is small
+(~1.3–2.0s) and forest-add-dominated, so its jitter swings the ratio (~7.5–13x for
+full_share across runs — an earlier draft cited the 7.5x low end, which is a baseline
+artifact, not a real bound). The **absolute** full_share build is stable at ~15–16s.
+
+| path | leaf preimage | build_s (stable) | x_snap | raw egress |
+|---|---|---|---|---|
+| snapshot_path | 32B (hash) | 0.71 | — | 9.6 MB |
+| raw_ingest synthetic32 | 32B | ~1.3 | ~1.8 | 9.6 MB |
+| raw_ingest receipt_min | 244B | ~3.9 | ~5.3 | 73.2 MB |
+| raw_ingest full_share | 1364B | ~15.6 | ~21 | 409.2 MB |
+
+All paths yield the same **8 roots** (popcount(300000)) — forest structure and 32B-leaf
+storage are invariant to preimage size.
+
+## Verdict
+1. **O(W) bootstrap stands.** Real preimage size inflates only the cold raw-ingest hashing
+   leg by a bounded constant factor — full_share ~15–16s @300K absolute, ~21x the snapshot
+   floor — never the O(W) asymptote. Storage stays O(W) 32B leaves; roots are size-invariant.
+2. **The snapshot/checkpoint path sidesteps it entirely** (0.72s, 9.6MB): a checkpoint-
+   anchored cold-start (T14) ships 32B leaf hashes, paying zero preimage-hashing cost.
+3. **Raw-share egress is the real lever, and it confirms the T9/T12/T14 design call:**
+   serving full raw shares is 409MB vs 9.6MB for a 32B-leaf snapshot — **43x**. The
+   sticky-shard snapshot serving layer (T12) must ship leaf-hash snapshots, never raw
+   shares, for cold-start. Raw shares are only needed by a node that wants to *re-verify
+   PoW from preimages* — an opt-in audit, not the default bootstrap.
+
+Net: no residual asymptotic risk in M4 from real share format. The only place real share
+bytes matter is an audit-mode node re-hashing preimages, ~15–16s @300K (~21x the snapshot
+floor) — still seconds-scale and a bounded constant factor, not asymptotic. **M4 local feasibility track is now complete; remaining real-share
+build cost over genuine serialized shares is an M5 testbed item, not a local blocker.**

--- a/proto/m4-sync/out/SYNTHESIS-superlight-feed.md
+++ b/proto/m4-sync/out/SYNTHESIS-superlight-feed.md
@@ -78,8 +78,13 @@ Pick `C ≤ (k−1)/f − D_f` to keep total delta ≤ k·W. Net: checkpoint =
 
 ## Still NOT answered locally — explicit M5-integration carry-forward (no silent caps)
 
-- Real share/PoW/signature verification cost in the build path — synthetic sha256
-  understates it.
+- ~~Real share-format preimage cost in the build path — synthetic sha256 understates it.~~
+  **PARTLY CLOSED (T15, out/FINDINGS-t15-real-share-format.md):** building over real V37
+  share-format preimages (receipt 244B / full carrier share 1364B) keeps O(W) — preimage
+  size is a bounded constant factor on the cold raw-ingest hashing leg only (full_share
+  ~15–16s @300K, ~21× the snapshot floor), and the snapshot/checkpoint cold-start (32B leaf
+  hashes) pays zero preimage cost. STILL M5: real PoW/signature *verification* cost (T15
+  hashes preimages, it does not verify PoW or signatures).
 - Proof-cache memory on a bridge under a realistic request distribution.
 - ~~W beyond 300K — all numbers above are at W=300K.~~ **CLOSED (T11, out/FINDINGS-t11-scale-w1m.md):**
   re-ran T1/T2/T3 + T6 at W=1,000,000 (3.3×). Asymptotics confirmed: build/mem linear

--- a/proto/m4-sync/out/t15-real-share-format-w300k.txt
+++ b/proto/m4-sync/out/t15-real-share-format-w300k.txt
@@ -1,0 +1,19 @@
+# M4 T15 real-share-format build cost @W=300000
+# sizes(B): header=80 receipt_env=244 full_share=1364 (R_MAX=4x256B)
+
+snapshot_path   leaf=32B(hash)  build_s=0.737  roots=8  rss_mb=93.5
+
+raw_ingest[synthetic32] leaf_preimage=   32B  build_s=1.337  x_snap=  1.8  x_synth~1.0(noisy)  roots=8  raw_egress_mb=9.6
+raw_ingest[receipt_min] leaf_preimage=  244B  build_s=3.931  x_snap=  5.3  x_synth~2.9(noisy)  roots=8  raw_egress_mb=73.2
+raw_ingest[full_share ] leaf_preimage= 1364B  build_s=15.571  x_snap= 21.1  x_synth~11.6(noisy)  roots=8  raw_egress_mb=409.2
+
+# verdict:
+# - forest leaves are 32B regardless of preimage size: roots match, storage = O(W) 32B leaves.
+# - real preimage size inflates ONLY the cold raw-ingest hashing leg by a bounded
+#   CONSTANT FACTOR, NOT the O(W) asymptote. ABSOLUTE: full_share ~15-16s @300K (stable);
+#   vs the snapshot cold-start floor (~0.7s) that is x_snap ~22x -- still seconds-scale,
+#   and it is an AUDIT-ONLY path: the snapshot/checkpoint cold-start (32B leaf hashes,
+#   T14) ships 0.7s/9.6MB and pays ZERO preimage-hashing cost.
+# - raw-share egress is the real cost lever: full_share = 409.2MB
+#   vs 32B-leaf snapshot 9.6MB (43x) ->
+#   confirms T9/T12: serve 32B-leaf snapshots, never raw shares, for cold-start.


### PR DESCRIPTION
Closes the last residual local M4 (large-W sync / superlight-chain) feasibility item: build cost over REAL V37 share-format preimages vs the 32B synthetic floor used by T1-T14.

## Result (W=300K, reproduce: cd proto/m4-sync/harness && python3 t15_real_share_format.py)
- O(W) bootstrap STANDS. Real preimage size (receipt 244B / full carrier share 1364B per share-format.md) inflates ONLY the cold raw-ingest hashing leg by a bounded constant factor: full_share ~15-16s @300K absolute (~21x the snapshot cold-start floor) -- never the O(W) asymptote.
- 8 forest roots invariant to preimage size; storage stays O(W) 32B leaves.
- Snapshot/checkpoint cold-start (32B leaf hashes, T14 path) pays ZERO preimage cost: 0.72s / 9.6MB.
- Raw-share egress 409MB vs 9.6MB snapshot = 43x -> confirms the T9/T12/T14 design call: serve 32B-leaf snapshots, never raw shares, for cold-start.

## Metric note
Headline ratio is x_snap (vs the stable ~0.7s snapshot floor). The x_synth ratio (vs the small, forest-add-dominated 32B raw-ingest baseline) swings ~7.5-13x run-to-run, so it is reported but NOT headlined; an earlier draft cited the 7.5x low end, which was a baseline-noise artifact. Findings + synthesis-feed corrected accordingly.

M4 local-feasibility track now COMPLETE; remaining real PoW/signature verification cost is an M5 testbed item (T15 hashes preimages, it does not verify PoW). Prototype only; no production code; targets the v37-dev prototype line, not master.