### PR TITLE
deploy(d-miner): version-controlled user-systemd units for sampler + notify engine

### DIFF
--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -1,0 +1,39 @@
+# c2pool D-MINER user-systemd deployment
+
+Reproducible units for the per-miner presence + notification pipeline. They run
+as **user** services (no root) with lingering enabled, matching how the sampler
+is already deployed on the contabo prod node.
+
+Pipeline:
+- `c2pool-miner-sampler.service` — D-MINER.1 sampler, long-running; polls this
+  node `/local_stats` every `C2POOL_SAMPLE_INTERVAL`s into `miner_presence.db`.
+- `c2pool-miner-rollup.{service,timer}` — nightly (00:10) per-worker/day rollup.
+- `c2pool-miner-notify.{service,timer}` — D-MINER.5 engine `run`, every 5 min;
+  emits offline / back-online / hashrate-drop alerts (throttled, transport-agnostic).
+- `c2pool-miner-daily.{service,timer}` — daily-summary (08:00, after the rollup).
+
+Nothing is hardcoded: every path, URL, and transport setting lives in
+`~/.config/c2pool/miner.env` so each node stays per-node truthful.
+
+## Install (per node)
+
+    mkdir -p ~/.config/c2pool ~/.config/systemd/user ~/.local/share/c2pool
+    cp c2pool-miner.env.example ~/.config/c2pool/miner.env
+    $EDITOR ~/.config/c2pool/miner.env        # set scripts dir, DB, /local_stats URL, SMTP
+    cp c2pool-miner-*.service c2pool-miner-*.timer ~/.config/systemd/user/
+    loginctl enable-linger "$USER"            # survive logout / keep timers firing
+    systemctl --user daemon-reload
+    systemctl --user enable --now c2pool-miner-sampler.service
+    systemctl --user enable --now c2pool-miner-rollup.timer c2pool-miner-notify.timer c2pool-miner-daily.timer
+
+Seed a worker subscription before notify can route:
+
+    python3 \$C2POOL_MINER_SCRIPTS/miner_notify_engine.py subscribe \
+      --db \$C2POOL_MINER_DB --worker <addr.worker> --route <email> --channels email
+
+## Verify / dry-run
+
+    systemctl --user list-timers "c2pool-miner-*"
+    journalctl --user -u c2pool-miner-notify.service -n 50
+    # safe rehearsal (forces logonly transport, no mail sent):
+    python3 \$C2POOL_MINER_SCRIPTS/miner_notify_engine.py run --db \$C2POOL_MINER_DB --dry-run

--- a/deploy/systemd/c2pool-miner-daily.service
+++ b/deploy/systemd/c2pool-miner-daily.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=c2pool D-MINER.5 daily-summary emission (per-worker, from daily rollup)
+Documentation=https://github.com/frstrtr/c2pool/blob/master/docs/design/d-miner-5-notify-engine.md
+After=c2pool-miner-rollup.service
+
+[Service]
+Type=oneshot
+EnvironmentFile=%h/.config/c2pool/miner.env
+ExecStart=/usr/bin/env python3 ${C2POOL_MINER_SCRIPTS}/miner_notify_engine.py daily --db ${C2POOL_MINER_DB} --smtp-host ${SMTP_HOST} --smtp-port ${SMTP_PORT} --sender ${NOTIFY_SENDER}

--- a/deploy/systemd/c2pool-miner-daily.timer
+++ b/deploy/systemd/c2pool-miner-daily.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=c2pool D-MINER.5 daily-summary schedule
+
+[Timer]
+# After nightly rollup (00:10) has populated the daily table.
+OnCalendar=*-*-* 08:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/c2pool-miner-notify.service
+++ b/deploy/systemd/c2pool-miner-notify.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=c2pool D-MINER.5 notify engine run (offline/back-online/hashrate-drop, transport-agnostic)
+Documentation=https://github.com/frstrtr/c2pool/blob/master/docs/design/d-miner-5-notify-engine.md
+
+[Service]
+Type=oneshot
+EnvironmentFile=%h/.config/c2pool/miner.env
+ExecStart=/usr/bin/env python3 ${C2POOL_MINER_SCRIPTS}/miner_notify_engine.py run --db ${C2POOL_MINER_DB} --smtp-host ${SMTP_HOST} --smtp-port ${SMTP_PORT} --sender ${NOTIFY_SENDER}

--- a/deploy/systemd/c2pool-miner-notify.timer
+++ b/deploy/systemd/c2pool-miner-notify.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=c2pool D-MINER.5 notify engine evaluation cadence
+
+[Timer]
+# Evaluate every 5 min; offline-min default 15 + hourly throttle make this safe.
+OnCalendar=*:0/5
+Persistent=false
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/c2pool-miner-rollup.service
+++ b/deploy/systemd/c2pool-miner-rollup.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=c2pool D-MINER.1 nightly rollup (per-worker/day hours_online,avg_hashrate,shares,stale%%)
+Documentation=https://github.com/frstrtr/c2pool/blob/master/docs/design/d-miner-5-notify-engine.md
+
+[Service]
+Type=oneshot
+EnvironmentFile=%h/.config/c2pool/miner.env
+ExecStart=/usr/bin/env python3 ${C2POOL_MINER_SCRIPTS}/miner_presence_sampler.py rollup --db ${C2POOL_MINER_DB}

--- a/deploy/systemd/c2pool-miner-rollup.timer
+++ b/deploy/systemd/c2pool-miner-rollup.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=c2pool D-MINER.1 nightly presence rollup
+
+[Timer]
+OnCalendar=*-*-* 00:10:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/c2pool-miner-sampler.service
+++ b/deploy/systemd/c2pool-miner-sampler.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=c2pool D-MINER.1 presence sampler (poll /local_stats -> miner_presence.db)
+Documentation=https://github.com/frstrtr/c2pool/blob/master/docs/design/d-miner-5-notify-engine.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=%h/.config/c2pool/miner.env
+ExecStart=/usr/bin/env python3 ${C2POOL_MINER_SCRIPTS}/miner_presence_sampler.py sample --db ${C2POOL_MINER_DB} --url ${C2POOL_LOCAL_STATS_URL} --interval ${C2POOL_SAMPLE_INTERVAL}
+Restart=on-failure
+RestartSec=30
+
+[Install]
+WantedBy=default.target

--- a/deploy/systemd/c2pool-miner.env.example
+++ b/deploy/systemd/c2pool-miner.env.example
@@ -1,0 +1,16 @@
+# c2pool D-MINER deployment config (D-MINER.1 sampler + D-MINER.5 notify engine).
+# Copy to ~/.config/c2pool/miner.env and edit for THIS node. Nothing here is
+# baked into the units: each node points at its own dashboard + DB + relay, so
+# the deployment stays per-node truthful (charter) rather than hardcoded.
+#
+# Absolute path to the c2pool scripts/ dir on this node:
+C2POOL_MINER_SCRIPTS=%h/c2pool/scripts
+# Presence DB (sampler writes, engine reads). Raw 90d, daily forever:
+C2POOL_MINER_DB=%h/.local/share/c2pool/miner_presence.db
+# This node dashboard /local_stats endpoint the sampler polls:
+C2POOL_LOCAL_STATS_URL=http://127.0.0.1:8080/local_stats
+C2POOL_SAMPLE_INTERVAL=60
+# Notify transport (email spine; V36 P2P relay + Telegram plug in later):
+SMTP_HOST=127.0.0.1
+SMTP_PORT=25
+NOTIFY_SENDER=dashboard-steward@morisguide.com


### PR DESCRIPTION
## What

Version-controlled **user-systemd** units for the D-MINER pipeline. The
D-MINER.1 presence sampler and D-MINER.5 notify engine are built and KAT-locked,
but had no reproducible deployment path — the sampler was hand-deployed on the
contabo prod node and the notify engine had none. This makes the pipeline
turn-on-able from the repo and keeps it per-node truthful.

`deploy/systemd/`:
- `c2pool-miner-sampler.service` — long-running D-MINER.1 sampler
- `c2pool-miner-rollup.{service,timer}` — nightly per-worker/day rollup (00:10)
- `c2pool-miner-notify.{service,timer}` — D-MINER.5 engine `run`, every 5 min
- `c2pool-miner-daily.{service,timer}` — daily-summary (08:00, after rollup)
- `c2pool-miner.env.example` + `README.md` — per-node config + install steps

## Why per-node honest

Every path, /local_stats URL, and SMTP/transport setting lives in
`~/.config/c2pool/miner.env`; nothing is baked into the units, so each node
points at its own dashboard + DB + relay (charter: per-node truthful, config-
driven not hardcoded).

## Safety

Additive only — no script or consensus code touched. Units validate clean with
`systemd-analyze verify`; engine selftest still 15/15. The notify timer runs
`run` every 5 min, safe against the 15-min offline-min default + hourly throttle.

## Notes

- Email-spine transport; V36 P2P relay (D-MINER.6) and Telegram plug into the
  engine adapter later with no unit change.
- Web/ops layer, non-consensus → normal merge; surfaced for operator awareness.