### PR TITLE
test(core): pin compute_merkle_branches pure-tx producer/consumer contract

### DIFF
--- a/src/core/test/CMakeLists.txt
+++ b/src/core/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (BUILD_TESTING AND (GTest_FOUND OR GTEST_FOUND))
-    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp)
+    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp core_merkle_branches_test.cpp)
     target_link_libraries(core_test PRIVATE GTest::gtest_main core c2pool_merged_mining GTest::gtest)
     target_link_libraries(core_test PRIVATE c2pool_payout c2pool_hashrate ltc_coin)  # OBJECT-lib SCC direct-naming (#22/#39)
 

--- a/src/core/test/core_merkle_branches_test.cpp
+++ b/src/core/test/core_merkle_branches_test.cpp
@@ -1,0 +1,69 @@
+// ---------------------------------------------------------------------------
+// core_merkle_branches_test.cpp
+//
+// PRODUCER/CONSUMER CONTRACT PIN for core::MiningInterface::compute_merkle_branches
+// (the LTC/core stratum consumer of WorkData::m_hashes).
+//
+// Sibling guard to PR #570 (BTC stratum merkle leaf-0 fix) + #574 (BIP141
+// witness leaf-0). #570 established the SSOT producer contract: WorkData
+// m_hashes is the PURE non-coinbase tx list [tx1..txN] with NO coinbase slot;
+// the coinbase is leaf 0 and is prepended by each CONSUMER, never by the
+// producer. The BTC consumer (get_stratum_merkle_branches) was fixed to prepend
+// uint256::ZERO locally. This core consumer already honours the pure-tx
+// contract -- it folds input[0] as the FIRST branch sibling (tx1), not a
+// coinbase placeholder -- but had ZERO test coverage (the exact "untested
+// merkle-branch contract" class the #570 bug arose from).
+//
+// This locks branches[0] == tx1 for a pure-tx input. If anyone later mistakenly
+// "generalises" #570 by prepending a coinbase placeholder at the PRODUCER, this
+// core/LTC path would silently drop tx1 and branches[0] would become all-zeros
+// -- and these EXPECTs go RED. SAFE-ADDITIVE: pins present behaviour, adds no
+// new logic.
+// ---------------------------------------------------------------------------
+#include <gtest/gtest.h>
+
+#include <span>
+#include <string>
+#include <vector>
+
+#include <core/uint256.hpp>
+#include <core/web_server.hpp>
+#include <btclibs/util/strencodings.h>  // HexStr
+
+namespace {
+
+// HexStr of the INTERNAL (LE) bytes of a uint256 parsed from display hex --
+// matches the wire encoding compute_merkle_branches emits per branch.
+std::string internal_hex(const std::string& display_hex) {
+    uint256 u; u.SetHex(display_hex);
+    return HexStr(std::span<const unsigned char>(u.data(), 32));
+}
+
+const std::string TX1 = "1111111111111111111111111111111111111111111111111111111111111111";
+const std::string TX2 = "2222222222222222222222222222222222222222222222222222222222222222";
+const std::string TX3 = "3333333333333333333333333333333333333333333333333333333333333333";
+
+} // namespace
+
+// Leaf-0 contract: for a PURE non-coinbase tx list, the first stratum branch is
+// tx1 itself (the coinbase's right-sibling at level 0), NOT a coinbase slot.
+TEST(CoreMerkleBranches, PureTxListLeafZeroIsTx1NotCoinbasePlaceholder) {
+    auto branches = core::MiningInterface::compute_merkle_branches({TX1, TX2, TX3});
+    ASSERT_EQ(branches.size(), 2u);  // 3 tx -> {tx1, hash(tx2,tx3)}
+    EXPECT_EQ(branches[0], internal_hex(TX1));
+
+    // flip-RED tripwire: a producer-side ZERO coinbase placeholder would push
+    // tx1 to branches[1] and make branches[0] the all-zero leaf.
+    const std::string zero_hex =
+        HexStr(std::span<const unsigned char>(uint256::ZERO.data(), 32));
+    EXPECT_NE(branches[0], zero_hex);
+}
+
+// Degenerate sizes: empty -> {}, single tx -> single branch == that tx.
+TEST(CoreMerkleBranches, EmptyAndSingleTxContract) {
+    EXPECT_TRUE(core::MiningInterface::compute_merkle_branches({}).empty());
+
+    auto one = core::MiningInterface::compute_merkle_branches({TX1});
+    ASSERT_EQ(one.size(), 1u);
+    EXPECT_EQ(one[0], internal_hex(TX1));
+}

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -905,11 +905,13 @@ private:
         const std::string& ref_hash_hex = {},
         const uint256& the_state_root = uint256(),
         const std::string& coinbase_text = {});
+    public:  // pure, stateless stratum-merkle utilities (contract-pinned in core_merkle_branches_test)
     // Compute Stratum merkle branches from a list of tx hashes (excl. coinbase)
     static std::vector<std::string> compute_merkle_branches(std::vector<std::string> tx_hashes);
     // Reconstruct merkle root from coinbase hex + Stratum merkle branches
     static uint256 reconstruct_merkle_root(const std::string& coinbase_hex,
                                            const std::vector<std::string>& merkle_branches);
+    private:
     // Build full block hex from Stratum submit parameters.
     // When job is provided, uses its frozen template data instead of the live m_cached_template.
     std::string build_block_from_stratum(const std::string& extranonce1,


### PR DESCRIPTION
## What
Flip-RED KAT pinning the **LTC/core** consumer of `WorkData::m_hashes` — `core::MiningInterface::compute_merkle_branches` — which had **zero** test coverage (the same untested merkle-branch-contract class PR #570 arose from). Sibling guard to #570 (BTC stratum leaf-0) and #574 (BIP141 witness leaf-0).

## Why (audit finding — de-risks the #570 tap)
Confirmed #570 prepends its ZERO coinbase placeholder **locally** in the BTC-fenced consumer (`get_stratum_merkle_branches` / new `btc::coin::stratum_merkle_siblings`), leaving the **producer** contract unchanged: `m_hashes` = pure `[tx1..txN]`, no coinbase slot. This core consumer already honours that contract (folds `input[0]` as tx1). **No cross-coin regression from #570.** This pins it so a future mistaken *producer-side* prepend goes RED on the LTC path.

## Changes
- new `core_merkle_branches_test.cpp`: leaf-0 == tx1 (not a coinbase placeholder) + flip-RED ZERO-prepend tripwire + empty/single degenerate sizes.
- promote static pure helpers `compute_merkle_branches`/`reconstruct_merkle_root` private→public (test-accessible; stateless, no behaviour change).

## Evidence
- `core_test` 46 → **48 green**; flip-RED **proven** (injected ZERO-prepend → leaf-0 assertion FAILED, reverted → green).

## Scope / routing
Touches **shared core** (`web_server.hpp` visibility + `core/test`) — test-only + a visibility widen, no behaviour change. Routing-flagged for integrator review. SAFE-ADDITIVE, BTC-lane-authored. Held for operator tap — I don't self-merge.