### PR TITLE
ci: put pip --user conan on PATH for self-hosted Linux runners (fix exit127)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,9 @@ jobs:
         with: { python-version: '3.12' }
 
       - name: Install Conan 2
-        run: pip install "conan>=2.0,<3.0"
+        run: |
+          pip install "conan>=2.0,<3.0"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Detect Conan profile
         run: |
@@ -168,7 +170,9 @@ jobs:
         with: { python-version: '3.12' }
 
       - name: Install Conan 2
-        run: pip install "conan>=2.0,<3.0"
+        run: |
+          pip install "conan>=2.0,<3.0"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Detect Conan profile
         run: |
@@ -285,7 +289,9 @@ jobs:
         with: { python-version: 3.12 }
 
       - name: Install Conan 2
-        run: pip install "conan>=2.0,<3.0"
+        run: |
+          pip install "conan>=2.0,<3.0"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Detect Conan profile
         run: |
@@ -366,7 +372,9 @@ jobs:
         with: { python-version: 3.12 }
 
       - name: Install Conan 2
-        run: pip install "conan>=2.0,<3.0"
+        run: |
+          pip install "conan>=2.0,<3.0"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Detect Conan profile
         run: |
@@ -797,7 +805,9 @@ jobs:
         with: { python-version: 3.12 }
 
       - name: Install Conan 2
-        run: pip install "conan>=2.0,<3.0"
+        run: |
+          pip install "conan>=2.0,<3.0"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Detect Conan profile
         run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -58,6 +58,8 @@ jobs:
         name: Install Conan 2
         run: |
           pip install "conan>=2.0,<3.0"
+          export PATH="$HOME/.local/bin:$PATH"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           conan profile detect --force
           sed -i 's/compiler.cppstd=.*/compiler.cppstd=20/' \
             "$(conan profile path default)"

--- a/.github/workflows/coin-matrix.yml
+++ b/.github/workflows/coin-matrix.yml
@@ -52,7 +52,9 @@ jobs:
 
       - name: Install Conan 2
         if: steps.presence.outputs.exists == '1'
-        run: pip install "conan>=2.0,<3.0"
+        run: |
+          pip install "conan>=2.0,<3.0"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Detect Conan profile
         if: steps.presence.outputs.exists == '1'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,9 @@ jobs:
 
       - name: Install Conan 2
         if: steps.presence.outputs.exists == '1'
-        run: pip install "conan>=2.0,<3.0"
+        run: |
+          pip install "conan>=2.0,<3.0"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Detect Conan profile
         if: steps.presence.outputs.exists == '1'


### PR DESCRIPTION
Fixes the conan: command not found / exit 127 failures on the self-hosted Linux runners (VM905, c2pool-linux-905-*), seen on DGB #589 @3a3a2ab47 and reported by dgb-scrypt-steward.

Root cause: the Install Conan step runs pip install "conan>=2.0,<3.0". On Ubuntu 24.04 (PEP 668) that lands the conan entry point in ~/.local/bin, which is NOT on the self-hosted runner service non-interactive PATH, so the next step (conan profile detect) gets command-not-found. GitHub-hosted runners pre-path ~/.local/bin, which is why only self-hosted Linux legs failed while Windows/macOS (other runners) passed.

Fix: append $HOME/.local/bin to $GITHUB_PATH right after install so conan resolves in every later step regardless of runner login PATH. This is baked into the workflow, so it survives runner restarts/reprovisioning (addresses the harden ask). Same idiom already used for Homebrew on macpro-intel-204.

Scope: Linux legs only across build.yml (linux, linux-asan, coin-bch, coin-bch-asan, coin-dgb-auxdoge), coin-matrix.yml, release.yml, codeql-analysis.yml. Windows (windows-2022) and macOS conan steps deliberately untouched. codeql installs+detects in one step so it also exports PATH inline.

Merge-gated: awaiting push-approval. Note: re-running #589 will need it rebased onto merged master, since a re-run reuses the PR own workflow version.