### PR TITLE
dash: v36 PPLNS full-weight payout split (drop finder, a60f7f7f donation floor)

### DIFF
--- a/src/impl/dash/coinbase_builder.hpp
+++ b/src/impl/dash/coinbase_builder.hpp
@@ -47,6 +47,7 @@
 
 #include <core/pack.hpp>
 #include <core/uint256.hpp>
+#include <core/version_gate.hpp>   // SSOT: core::version_gate::is_v36_active (DASH 16->36)
 #include <core/hash.hpp>
 #include <core/coin_params.hpp>
 #include <core/log.hpp>
@@ -107,31 +108,64 @@ inline std::vector<MinerPayout> compute_dash_payouts(
     // 2. worker_payout = subsidy - Σpayment_amounts
     uint64_t worker_payout = (subsidy > total_payments) ? (subsidy - total_payments) : 0;
 
-    // 3. amounts[script] = worker_payout * 49 * weight / (50 * total_weight)
-    //    (skipped for genesis where total_weight==0; populated for
-    //    non-genesis shares via walk_cumulative_weights).
+    // 3-4. PPLNS split. Two consensus arms, gated on the minted share version
+    //      (core::version_gate SSOT; DASH transition 16 -> 36):
+    //
+    //   pre-v36 (bucket-3 per-coin compat, UNCHANGED p2pool-dash shape):
+    //       amounts[script]      = worker_payout * 49 * weight / (50 * total_weight)
+    //       amounts[this_script] += worker_payout / 50            (2% block-finder)
+    //
+    //   v36 (bucket-2 standardize-toward-merged-v36; mirrors DGB
+    //        share_tracker::get_expected_payouts):
+    //       amounts[script] = worker_payout * weight / total_weight  (FULL weight)
+    //       NO block-finder fee.
+    //   total_weight is the GRAND total (includes donation_weight), so the
+    //   donation absorbs its decayed-weight share via the step-5 remainder.
+    const bool v36 =
+        core::version_gate::is_v36_active(params.current_share_version);
     std::map<Script, uint64_t> amounts;
     if (total_weight > 0) {
-        // uint128-ish: worker_payout < 2^50, 49 < 2^6, weight < ~2^80 for a few
-        // shares; use explicit 128-bit to avoid silent overflow.
-        __uint128_t den = static_cast<__uint128_t>(total_weight) * 50;
+        // weights/total_weight fit uint64 at the DASH layer; __uint128_t covers
+        // the products (worker_payout < 2^50, 49 < 2^6, weight < 2^64).
+        __uint128_t den = v36
+            ? static_cast<__uint128_t>(total_weight)
+            : static_cast<__uint128_t>(total_weight) * 50;
         for (const auto& [script, w] : weights) {
             __uint128_t num = static_cast<__uint128_t>(w)
-                            * static_cast<__uint128_t>(worker_payout)
-                            * 49;
+                            * static_cast<__uint128_t>(worker_payout);
+            if (!v36) num *= 49;
             amounts[script] = static_cast<uint64_t>(num / den);
         }
     }
 
-    // 4. amounts[this_script] += worker_payout // 50  (2 % block-finder).
+    // 4. (pre-v36 only) 2% block-finder fee to the share creator.
     auto this_script = dash::pubkey_hash_to_script2(miner_pubkey_hash);
-    amounts[this_script] = amounts[this_script] + (worker_payout / 50);
+    if (!v36)
+        amounts[this_script] = amounts[this_script] + (worker_payout / 50);
 
     // 5. amounts[DONATION] += worker_payout - Σamounts  (remainder incl. rounding).
     uint64_t current_sum = 0;
     for (const auto& [s, a] : amounts) current_sum += a;
     uint64_t donation_remainder = (worker_payout > current_sum)
         ? (worker_payout - current_sum) : 0;
+
+    // v36 consensus (a60f7f7f): the donation output MUST carry >= 1 satoshi.
+    // If the remainder rounds to 0, deduct 1 sat from the largest miner
+    // (deterministic tiebreak: (amount, script)); the sum invariant holds.
+    if (v36 && donation_remainder < 1 && worker_payout > 0 && !amounts.empty()) {
+        auto largest = std::max_element(amounts.begin(), amounts.end(),
+            [&](const auto& a, const auto& b) {
+                if (a.first == donation_script) return true;   // never pick donation
+                if (b.first == donation_script) return false;
+                if (a.second != b.second) return a.second < b.second;
+                return a.first < b.first;
+            });
+        if (largest != amounts.end() && largest->first != donation_script
+            && largest->second >= 1) {
+            largest->second -= 1;
+            donation_remainder += 1;
+        }
+    }
     amounts[donation_script] = amounts[donation_script] + donation_remainder;
 
     // Sanity: Σ(amounts) == worker_payout (matches p2pool-dash assertion).

--- a/test/test_dash_coinbase_parity.cpp
+++ b/test/test_dash_coinbase_parity.cpp
@@ -166,3 +166,80 @@ TEST(DashCoinbaseParity, TxOutOrderingWorkerPaymentsDonation) {
     uint64_t sum = 0; for (auto& o : outs) sum += o.amount;
     EXPECT_EQ(sum, subsidy);
 }
+
+// (9) v36 ARM: full-weight split, NO 2% block-finder fee, donation = remainder.
+//     Gated on params.current_share_version >= 36 (core::version_gate SSOT).
+//     Mirrors DGB share_tracker::get_expected_payouts; total_weight is the
+//     GRAND total (incl. donation_weight) so the donation absorbs its slice
+//     via the step-5 remainder.
+TEST(DashCoinbaseParity, V36FullWeightNoFinder) {
+    auto params = dash::make_coin_params(true);
+    params.current_share_version = 36;  // activate v36 arm
+
+    // Two distinct weighted miners. total_weight=50 > sum(miner weights)=40,
+    // i.e. donation_weight=10 -> donation gets 10/50 of worker_payout.
+    std::vector<unsigned char> hA(20, 0x11), hB(20, 0x22);
+    auto scriptA = dash::pubkey_hash_to_script2(uint160(hA));
+    auto scriptB = dash::pubkey_hash_to_script2(uint160(hB));
+    std::map<std::vector<unsigned char>, uint64_t> weights;
+    weights[scriptA] = 30;
+    weights[scriptB] = 10;
+
+    // Finder hash NOT in the weight set -> in v36 it must produce NO output.
+    std::vector<unsigned char> finder_h(20, 0x07);
+    uint160 finder(finder_h);
+
+    const uint64_t subsidy = 5000000000ull;  // no payments -> worker_payout=subsidy
+    auto outs = dash::coinbase::compute_dash_payouts(
+        subsidy, /*payments=*/{}, finder, weights, /*total_weight=*/50, params);
+
+    std::map<std::vector<unsigned char>, uint64_t> got;
+    for (auto& o : outs) got[o.script] += o.amount;
+
+    EXPECT_EQ(got[scriptA], 3000000000ull);           // 5e9 * 30/50  (FULL weight)
+    EXPECT_EQ(got[scriptB], 1000000000ull);           // 5e9 * 10/50
+    EXPECT_EQ(got[std::vector<unsigned char>(
+                  dash::DONATION_SCRIPT.begin(), dash::DONATION_SCRIPT.end())],
+              1000000000ull);                          // remainder = 5e9 - 4e9
+    // finder dropped entirely in v36 (no 2% fee).
+    EXPECT_EQ(got.count(dash::pubkey_hash_to_script2(finder)), 0u);
+
+    uint64_t sum = 0; for (auto& o : outs) sum += o.amount;
+    EXPECT_EQ(sum, subsidy);
+}
+
+// (10) v36 a60f7f7f floor: when the donation remainder rounds to 0, exactly
+//      1 satoshi is deducted from the largest miner (tiebreak: (amount,script)).
+TEST(DashCoinbaseParity, V36DonationFloorOneSat) {
+    auto params = dash::make_coin_params(true);
+    params.current_share_version = 36;
+
+    std::vector<unsigned char> hA(20, 0x11), hB(20, 0x22);
+    auto scriptA = dash::pubkey_hash_to_script2(uint160(hA));
+    auto scriptB = dash::pubkey_hash_to_script2(uint160(hB));
+    std::map<std::vector<unsigned char>, uint64_t> weights;
+    weights[scriptA] = 1;
+    weights[scriptB] = 1;  // total_weight=2 -> donation_weight=0, remainder rounds to 0
+
+    std::vector<unsigned char> finder_h(20, 0x07);
+    uint160 finder(finder_h);
+
+    const uint64_t subsidy = 1000ull;  // worker_payout=1000 -> A=500,B=500, donation 0
+    auto outs = dash::coinbase::compute_dash_payouts(
+        subsidy, /*payments=*/{}, finder, weights, /*total_weight=*/2, params);
+
+    std::map<std::vector<unsigned char>, uint64_t> got;
+    for (auto& o : outs) got[o.script] += o.amount;
+
+    auto don = std::vector<unsigned char>(
+        dash::DONATION_SCRIPT.begin(), dash::DONATION_SCRIPT.end());
+    EXPECT_EQ(got[don], 1u);                           // floor forced donation >= 1
+    // Tiebreak (amount,script): equal 500/500 -> larger script bytes loses 1 sat.
+    auto& loser  = (scriptA < scriptB) ? scriptB : scriptA;
+    auto& other  = (scriptA < scriptB) ? scriptA : scriptB;
+    EXPECT_EQ(got[loser], 499u);
+    EXPECT_EQ(got[other], 500u);
+
+    uint64_t sum = 0; for (auto& o : outs) sum += o.amount;
+    EXPECT_EQ(sum, subsidy);                            // invariant preserved
+}


### PR DESCRIPTION
STACKED on #586 (leaf-4 share_tracker). The PPLNS donation-weight slice from the 06-28 scan — adds the missing version-gated v36 payout arm to compute_dash_payouts.

## What
core::version_gate SSOT (DASH 16->36) selects the arm off params.current_share_version:
- pre-v36 (bucket-3 per-coin compat, UNCHANGED): worker_payout*49*weight/(50*total_weight) + worker_payout/50 block-finder + remainder donation. Byte-exact p2pool-dash.
- v36 (bucket-2 standardize-toward-merged-v36, mirrors DGB share_tracker::get_expected_payouts): worker_payout*weight/total_weight FULL weight, NO finder fee, donation = remainder against the GRAND total_weight (incl. donation_weight), then a60f7f7f >=1-sat donation floor (deduct 1 from largest miner, (amount,script) tiebreak).

Denominator stays grand_total (integrator catch, oracle data.py:258) — NOT collapsed to miner-only.

## Verify (Linux x86_64, from build/)
test_dash_coinbase_parity 10/10:
- 8 pre-v36 cases byte-exact -> no regression (gate transparent at ver=16)
- V36FullWeightNoFinder (full weight, finder dropped, remainder donation, sum==subsidy)
- V36DonationFloorOneSat (donation forced >=1, 1 sat off largest, invariant held)

## Conformance
3-bucket: 49/50 vs full-weight = bucket-3 per-coin (KEEP pre-v36 arm). v36 full-weight + floor = bucket-2 standardize. dashd RPC fallback unaffected.

Requesting integrator verify (oracle KAT both arms + full gh rollup, not Linux-only) -> operator tap. NO self-merge.