### PR TITLE
ci: gate Conan 2 install by runner.environment (fix self-hosted exit 127)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,8 +42,12 @@ jobs:
 
       - name: Install Conan 2
         run: |
-          pip install "conan>=2.0,<3.0"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          if [ "${{ runner.environment }}" = "github-hosted" ]; then
+            pip install "conan>=2.0,<3.0"
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          else
+            conan --version   # pre-provisioned at /usr/local/bin on self-hosted
+          fi
 
       - name: Detect Conan profile
         run: |
@@ -171,8 +175,12 @@ jobs:
 
       - name: Install Conan 2
         run: |
-          pip install "conan>=2.0,<3.0"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          if [ "${{ runner.environment }}" = "github-hosted" ]; then
+            pip install "conan>=2.0,<3.0"
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          else
+            conan --version   # pre-provisioned at /usr/local/bin on self-hosted
+          fi
 
       - name: Detect Conan profile
         run: |
@@ -290,8 +298,12 @@ jobs:
 
       - name: Install Conan 2
         run: |
-          pip install "conan>=2.0,<3.0"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          if [ "${{ runner.environment }}" = "github-hosted" ]; then
+            pip install "conan>=2.0,<3.0"
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          else
+            conan --version   # pre-provisioned at /usr/local/bin on self-hosted
+          fi
 
       - name: Detect Conan profile
         run: |
@@ -373,8 +385,12 @@ jobs:
 
       - name: Install Conan 2
         run: |
-          pip install "conan>=2.0,<3.0"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          if [ "${{ runner.environment }}" = "github-hosted" ]; then
+            pip install "conan>=2.0,<3.0"
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          else
+            conan --version   # pre-provisioned at /usr/local/bin on self-hosted
+          fi
 
       - name: Detect Conan profile
         run: |
@@ -718,7 +734,12 @@ jobs:
         with: { python-version: '3.12' }
 
       - name: Install Conan 2
-        run: pip install "conan>=2.0,<3.0"
+        run: |
+          if [ "${{ runner.environment }}" = "github-hosted" ]; then
+            pip install "conan>=2.0,<3.0"
+          else
+            conan --version   # pre-provisioned at /usr/local/bin on self-hosted
+          fi
 
       - name: Detect Conan profile
         run: |
@@ -806,8 +827,12 @@ jobs:
 
       - name: Install Conan 2
         run: |
-          pip install "conan>=2.0,<3.0"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          if [ "${{ runner.environment }}" = "github-hosted" ]; then
+            pip install "conan>=2.0,<3.0"
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          else
+            conan --version   # pre-provisioned at /usr/local/bin on self-hosted
+          fi
 
       - name: Detect Conan profile
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -734,6 +734,7 @@ jobs:
         with: { python-version: '3.12' }
 
       - name: Install Conan 2
+        shell: bash
         run: |
           if [ "${{ runner.environment }}" = "github-hosted" ]; then
             pip install "conan>=2.0,<3.0"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -57,9 +57,13 @@ jobs:
       - if: matrix.build-mode == 'manual'
         name: Install Conan 2
         run: |
-          pip install "conan>=2.0,<3.0"
-          export PATH="$HOME/.local/bin:$PATH"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          if [ "${{ runner.environment }}" = "github-hosted" ]; then
+            pip install "conan>=2.0,<3.0"
+            export PATH="$HOME/.local/bin:$PATH"
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          else
+            conan --version   # pre-provisioned at /usr/local/bin on self-hosted
+          fi
           conan profile detect --force
           sed -i 's/compiler.cppstd=.*/compiler.cppstd=20/' \
             "$(conan profile path default)"

--- a/.github/workflows/coin-matrix.yml
+++ b/.github/workflows/coin-matrix.yml
@@ -53,8 +53,12 @@ jobs:
       - name: Install Conan 2
         if: steps.presence.outputs.exists == '1'
         run: |
-          pip install "conan>=2.0,<3.0"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          if [ "${{ runner.environment }}" = "github-hosted" ]; then
+            pip install "conan>=2.0,<3.0"
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          else
+            conan --version   # pre-provisioned at /usr/local/bin on self-hosted
+          fi
 
       - name: Detect Conan profile
         if: steps.presence.outputs.exists == '1'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,8 +88,12 @@ jobs:
       - name: Install Conan 2
         if: steps.presence.outputs.exists == '1'
         run: |
-          pip install "conan>=2.0,<3.0"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          if [ "${{ runner.environment }}" = "github-hosted" ]; then
+            pip install "conan>=2.0,<3.0"
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          else
+            conan --version   # pre-provisioned at /usr/local/bin on self-hosted
+          fi
 
       - name: Detect Conan profile
         if: steps.presence.outputs.exists == '1'
@@ -402,7 +406,12 @@ jobs:
 
       - name: Install Conan 2
         if: steps.presence.outputs.exists == '1'
-        run: pip install "conan>=2.0,<3.0"
+        run: |
+          if [ "${{ runner.environment }}" = "github-hosted" ]; then
+            pip install "conan>=2.0,<3.0"
+          else
+            conan --version   # pre-provisioned at /usr/local/bin on self-hosted
+          fi
 
       - name: Detect Conan profile
         if: steps.presence.outputs.exists == '1'


### PR DESCRIPTION
## Fleet-blocker: master CI red — `conan: command not found` (exit 127) on self-hosted

**Not a code regression.** The failing step is `Detect Conan profile`, right after `Install Conan 2`, on the **self-hosted** runner (VM905). On self-hosted, `setup-python` + `pip install conan` lands conan in a user-site path the next step's PATH does not see, shadowing the pre-provisioned `/usr/local/bin/conan`. github-hosted jobs are unaffected. A runner restart does NOT fix this — the runners are up and conan 2.29.1 is already installed.

### Fix
Mirror the existing `Install system dependencies` gate (`runner.environment`): on github-hosted, `pip install` as before; on self-hosted, use the pre-provisioned conan and just verify it. Applied to **all 10** `Install Conan 2` steps:
- `build.yml` (6)
- `coin-matrix.yml` (1)
- `codeql-analysis.yml` (1) — keeps the `export PATH` line in the github-hosted branch
- `release.yml` (2)

### Self-healing
This PR's own coin-matrix/CodeQL jobs run under the fix, so green CI here IS the validation.

No self-merge — flagging integrator for the merge tap once CI is green.
