### PR TITLE
dgb: correct stale SEGWIT_ACTIVATION_VERSION oracle comment (17->35)

### DIFF
--- a/src/impl/dgb/share_types.hpp
+++ b/src/impl/dgb/share_types.hpp
@@ -8,7 +8,7 @@
 namespace dgb
 {
 
-// SSOT delegation (oracle = 17). Serialization/consensus gate sources from
+// SSOT delegation (oracle digibyte.py:26 = 35). Serialization/consensus gate sources from
 // PoolConfig; no local literal. Symbol kept for share_check.hpp consumers.
 inline constexpr uint32_t SEGWIT_ACTIVATION_VERSION = PoolConfig::SEGWIT_ACTIVATION_VERSION;
 


### PR DESCRIPTION
SAFE-COSMETIC, comment-only, own coin tree (src/impl/dgb/share_types.hpp).

The SSOT-delegation comment on dgb::SEGWIT_ACTIVATION_VERSION cited a stale oracle value (oracle = 17). The actual value, sourced via PoolConfig from frstrtr/p2pool-dgb-scrypt digibyte.py:26, is 35. The symbol already delegates to PoolConfig::SEGWIT_ACTIVATION_VERSION (== 35) — no value or behavior change. Comment text only.

Per integrator UID3095: split out from the consensus floor change (#590, operator-tap-gated) since this is a different file, pure cosmetic, over an already-correct value. Lands standalone so the lane keeps moving.

GPG-signed (Good).