### PR TITLE
core(version-gate): wire BTC accept seam to verify_version_transition SSOT (step 2, stacked on #597)

### DIFF
--- a/src/core/test/CMakeLists.txt
+++ b/src/core/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (BUILD_TESTING AND (GTest_FOUND OR GTEST_FOUND))
-    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp core_merkle_branches_test.cpp)
+    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp core_merkle_branches_test.cpp version_gate_test.cpp)
     target_link_libraries(core_test PRIVATE GTest::gtest_main core c2pool_merged_mining GTest::gtest)
     target_link_libraries(core_test PRIVATE c2pool_payout c2pool_hashrate ltc_coin)  # OBJECT-lib SCC direct-naming (#22/#39)
 

--- a/src/core/test/version_gate_test.cpp
+++ b/src/core/test/version_gate_test.cpp
@@ -1,0 +1,109 @@
+#include <gtest/gtest.h>
+
+#include <map>
+#include <string>
+#include <cstdint>
+#include <stdexcept>
+
+#include <core/version_gate.hpp>
+#include <core/uint256.hpp>
+
+using core::version_gate::verify_version_transition;
+
+// KAT for the cross-coin v36-native share-version-transition rule SSOT.
+// Weight type is uint288, matching get_desired_version_weights' tally type.
+
+namespace {
+
+// Build a weighted desired-version tally: { version -> weight }.
+std::map<uint64_t, uint288> tally(std::initializer_list<std::pair<uint64_t, uint64_t>> entries)
+{
+    std::map<uint64_t, uint288> m;
+    for (const auto& [ver, w] : entries)
+        m[ver] = uint288(w);
+    return m;
+}
+
+} // namespace
+
+TEST(VersionGateTransition, SameVersionAdmitted)
+{
+    // parent=36, share=36: never throws (correct when minted), with or w/o history.
+    auto w = tally({{36, 100}});
+    EXPECT_NO_THROW(verify_version_transition<uint288>(36, 36, w, /*have_history=*/true));
+    EXPECT_NO_THROW(verify_version_transition<uint288>(36, 36, w, /*have_history=*/false));
+}
+
+TEST(VersionGateTransition, UpgradeWithMajoritySupportAdmitted)
+{
+    // +1 upgrade, new version holds 70% of weighted support, history present -> ok.
+    auto w = tally({{36, 70}, {35, 30}});
+    EXPECT_NO_THROW(verify_version_transition<uint288>(35, 36, w, /*have_history=*/true));
+}
+
+TEST(VersionGateTransition, UpgradeWithoutMajoritySupportRejected)
+{
+    // +1 upgrade, new version only 50% of weighted support -> reject.
+    auto w = tally({{36, 50}, {35, 50}});
+    try
+    {
+        verify_version_transition<uint288>(35, 36, w, /*have_history=*/true);
+        FAIL() << "expected throw";
+    }
+    catch (const std::invalid_argument& e)
+    {
+        EXPECT_STREQ(e.what(), "switch without enough hash power upgraded");
+    }
+}
+
+TEST(VersionGateTransition, UpgradeWithoutHistoryRejected)
+{
+    // +1 upgrade, no CHAIN_LENGTH history -> reject with the history message.
+    auto w = tally({{36, 100}});
+    try
+    {
+        verify_version_transition<uint288>(35, 36, w, /*have_history=*/false);
+        FAIL() << "expected throw";
+    }
+    catch (const std::invalid_argument& e)
+    {
+        EXPECT_STREQ(e.what(), "switch without enough history");
+    }
+}
+
+TEST(VersionGateTransition, DowngradeByOneAdmitted)
+{
+    // -1 downgrade (parent=36, share=35: AutoRatchet deactivation) with history -> ok.
+    auto w = tally({{36, 100}});
+    EXPECT_NO_THROW(verify_version_transition<uint288>(36, 35, w, /*have_history=*/true));
+}
+
+TEST(VersionGateTransition, MultiVersionJumpWithHistoryRejected)
+{
+    // parent=34, share=36 (jump of 2) with history -> invalid version jump.
+    auto w = tally({{36, 100}});
+    try
+    {
+        verify_version_transition<uint288>(34, 36, w, /*have_history=*/true);
+        FAIL() << "expected throw";
+    }
+    catch (const std::invalid_argument& e)
+    {
+        EXPECT_STREQ(e.what(), "invalid version jump from 34 to 36");
+    }
+}
+
+TEST(VersionGateTransition, MultiVersionJumpWithoutHistoryAdmitted)
+{
+    // parent=34, share=36 with no history: only +1 upgrades are gated -> admitted.
+    auto w = tally({{36, 100}});
+    EXPECT_NO_THROW(verify_version_transition<uint288>(34, 36, w, /*have_history=*/false));
+}
+
+TEST(VersionGateTransition, ExactSixtyPercentBoundaryAdmitted)
+{
+    // new version == exactly 60% of total. Rule is `new*100 < total*60`:
+    // 60*100 == 100*60, NOT strictly less -> 60% PASSES (no throw).
+    auto w = tally({{36, 60}, {35, 40}});  // total 100, new=60 -> exactly 60%
+    EXPECT_NO_THROW(verify_version_transition<uint288>(35, 36, w, /*have_history=*/true));
+}

--- a/src/core/version_gate.hpp
+++ b/src/core/version_gate.hpp
@@ -32,6 +32,9 @@
 //
 
 #include <cstdint>
+#include <map>
+#include <stdexcept>
+#include <string>
 
 namespace core::version_gate
 {
@@ -45,6 +48,75 @@ inline constexpr uint64_t V36_ACTIVATION_VERSION = 36;
 constexpr bool is_v36_active(uint64_t version)
 {
     return version >= V36_ACTIVATION_VERSION;
+}
+
+
+// Canonical v36-native share-version-transition rule (cross-coin SSOT).
+// Applies the boundary admit/reject decision to an ALREADY-EXTRACTED
+// (parent_version, share_version) pair using a PRECOMPUTED PPLNS-WEIGHTED
+// desired-version tally for the [CHAIN_LENGTH*9/10, CHAIN_LENGTH] window behind
+// the parent, plus a flag for whether CHAIN_LENGTH history exists behind the
+// parent. Throws std::invalid_argument on a disallowed switch; returns on an
+// admissible one.
+//
+// Rule (p2pool data.py check()): same-version always valid; +1 upgrade needs
+// >= 60% PPLNS-WEIGHTED desired-version support for the new version in the
+// window AND CHAIN_LENGTH history; -1 (AutoRatchet deactivation) valid; any
+// other jump throws when history exists. With insufficient history only a +1
+// upgrade is rejected ("switch without enough history") and other shapes pass,
+// matching the BTC inline gate exactly.
+//
+// `floor` is the per-coin v36 activation version (e.g. BTC 35->36, DASH 16->36).
+// It is bucket-3 transition-compat carried as a PARAMETER (never hardcoded) so a
+// coin whose seam also runs an obsolescence branch (DASH) can thread its own
+// floor when it migrates onto this SSOT; the canonical boundary rule itself does
+// not reference it. Defaulted to V36_ACTIVATION_VERSION.
+template <typename WeightT>
+inline void verify_version_transition(
+    int64_t parent_version,
+    int64_t share_version,
+    const std::map<uint64_t, WeightT>& window_weights,
+    bool have_history,
+    uint64_t floor = V36_ACTIVATION_VERSION)
+{
+    (void)floor;
+    // same version — always valid (it was correct when minted), regardless of history.
+    if (share_version == parent_version)
+        return;
+
+    if (have_history)
+    {
+        if (share_version == parent_version + 1)
+        {
+            // Upgrade by one: needs >= 60% weighted support for the new version.
+            WeightT new_ver_weight{};
+            WeightT total_weight{};
+            for (const auto& [ver, w] : window_weights)
+            {
+                total_weight = total_weight + w;
+                if (static_cast<int64_t>(ver) == share_version)
+                    new_ver_weight = new_ver_weight + w;
+            }
+            // canonical: counts.get(VERSION,0) < sum(counts)*60//100
+            if (new_ver_weight * uint32_t(100) < total_weight * uint32_t(60))
+                throw std::invalid_argument("switch without enough hash power upgraded");
+        }
+        else if (parent_version == share_version + 1)
+        {
+            // downgrade by one (AutoRatchet deactivation: V35 may follow V36)
+        }
+        else
+        {
+            throw std::invalid_argument("invalid version jump from "
+                + std::to_string(parent_version) + " to " + std::to_string(share_version));
+        }
+    }
+    else if (share_version == parent_version + 1)
+    {
+        // Not enough history for an upgrade boundary.
+        throw std::invalid_argument("switch without enough history");
+    }
+    // else (downgrade / multi-jump with insufficient history): admitted, matching BTC.
 }
 
 } // namespace core::version_gate

--- a/src/impl/btc/share_check.hpp
+++ b/src/impl/btc/share_check.hpp
@@ -1765,49 +1765,30 @@ bool share_check(const ShareT& share,
             int64_t share_ver = share.version;
 
             auto prev_height = tracker.chain.get_height(share.m_prev_hash);
-            if (prev_height >= chain_length)
-            {
-                if (share_ver == parent_version)
-                {
-                    // same version — always valid (correct when created)
-                }
-                else if (share_ver == parent_version + 1)
-                {
-                    // Upgrade by one version: requires >= 60% weighted support in
-                    // window [CHAIN_LENGTH*9/10, CHAIN_LENGTH] behind the parent.
-                    uint32_t window_start = (static_cast<uint32_t>(chain_length) * 9) / 10;
-                    uint32_t window_size  = static_cast<uint32_t>(chain_length) / 10;
-                    auto ancestor = tracker.chain.get_nth_parent_key(share.m_prev_hash, window_start);
-                    auto weights = tracker.get_desired_version_weights(
-                        ancestor, static_cast<int32_t>(window_size));
+            const bool have_history = (prev_height >= chain_length);
 
-                    uint288 new_ver_weight;   // weight of shares desiring exactly share_ver
-                    uint288 total_weight;
-                    for (auto& [ver, w] : weights)
-                    {
-                        total_weight = total_weight + w;
-                        if (static_cast<int64_t>(ver) == share_ver)
-                            new_ver_weight = new_ver_weight + w;
-                    }
-                    // Canonical: counts.get(self.VERSION,0) < sum(counts)*60//100
-                    if (new_ver_weight * uint32_t(100) < total_weight * uint32_t(60))
-                        throw std::invalid_argument("switch without enough hash power upgraded");
-                }
-                else if (parent_version == share_ver + 1)
-                {
-                    // Downgrade by one (AutoRatchet deactivation: V35 may follow V36)
-                }
-                else
-                {
-                    throw std::invalid_argument("invalid version jump from "
-                        + std::to_string(parent_version) + " to " + std::to_string(share_ver));
-                }
-            }
-            else if (share_ver == parent_version + 1)
+            // Only a +1 upgrade boundary WITH history consults the PPLNS-weighted
+            // desired-version window; compute it lazily there (preserving the prior
+            // fetch behavior — no get_desired_version_weights call on other shapes)
+            // and pass empty otherwise. The SSOT reads window_weights only in that
+            // branch, so accept/reject is byte-for-byte identical to the prior inline.
+            std::map<uint64_t, uint288> window_weights;
+            if (have_history && share_ver == parent_version + 1)
             {
-                // Not enough history for an upgrade boundary
-                throw std::invalid_argument("switch without enough history");
+                uint32_t window_start = (static_cast<uint32_t>(chain_length) * 9) / 10;
+                uint32_t window_size  = static_cast<uint32_t>(chain_length) / 10;
+                auto ancestor = tracker.chain.get_nth_parent_key(share.m_prev_hash, window_start);
+                window_weights = tracker.get_desired_version_weights(
+                    ancestor, static_cast<int32_t>(window_size));
             }
+
+            // SSOT (PR #597): core::version_gate::verify_version_transition holds the
+            // canonical p2pool data.py check() boundary rule (same-version ok; +1 needs
+            // >=60% weighted support AND history; -1 AutoRatchet deactivation ok; other
+            // jumps throw; insufficient-history rejects only +1). floor defaults to
+            // V36_ACTIVATION_VERSION — BTC threads the default (no obsolescence branch).
+            core::version_gate::verify_version_transition<uint288>(
+                parent_version, share_ver, window_weights, have_history);
         }
     }
 


### PR DESCRIPTION
Step 2 of the integrator-approved 3-step Axis-3 standardization (step 1 = #597).

Replaces the inline 60%-weighted version-transition boundary in `src/impl/btc/share_check.hpp` with a call to the core SSOT `core::version_gate::verify_version_transition` added in #597.

**Byte-for-byte / behavior-preserving** — verified across all six transition shapes (same-version, +1, -1, multi-jump x history/no-history); every accept/reject outcome and every error string is unchanged. The PPLNS-weighted desired-version window is still fetched lazily only on the +1-with-history boundary; other shapes pass an empty map the SSOT never reads. Floor defaults to `V36_ACTIVATION_VERSION` (BTC has no obsolescence branch).

**HELD behind #597.** Stacked on #597 head 59b0825 because the call site needs the SSOT to compile — cannot be based off master until #597 lands. Do NOT merge before #597; expects rebase onto fresh master once #597 lands. No self-merge. Gate = four coin smokes + btc ASan green.

Sequencing: step 3 (DASH obsolescence branch onto the defaulted floor param) stays staged/unstarted until this seam is proven.