### PR TITLE
fix(core): null-io_context-safe Server construction (SAFE-ADDITIVE)

### DIFF
--- a/src/core/factory.hpp
+++ b/src/core/factory.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <boost/asio.hpp>
+#include <optional>
 
 #include <core/log.hpp>
 #include <core/socket.hpp>
@@ -19,7 +20,7 @@ class Server
 {
 private:
 	INetwork* m_node;
-	io::ip::tcp::acceptor m_acceptor;
+	std::optional<io::ip::tcp::acceptor> m_acceptor;
 
 protected:
 	void accept()
@@ -30,7 +31,7 @@ protected:
         // fall back to raw m_node (preserves prior behavior).
         auto weak_node = m_node->weak_from_this();
         bool was_managed = weak_node.lock() != nullptr;
-        m_acceptor.async_accept(
+        m_acceptor->async_accept(
 			[this, weak_node, was_managed](boost::system::error_code ec, io::ip::tcp::socket io_socket)
 			{
 				if (ec)
@@ -57,24 +58,35 @@ protected:
 
 public:
 	Server(io::io_context* context, INetwork* node, const std::string& /*label*/ = "")
-		: m_acceptor(*context), m_node(node)
+		: m_node(node)
 	{
+		// Rig-free / test construction (context == nullptr, e.g. a default-
+		// constructed BaseNode used for share-admit unit tests) leaves the
+		// acceptor unengaged so no null io_context is dereferenced. listen()
+		// is only valid once a real io_context has been wired in.
+		if (context)
+			m_acceptor.emplace(*context);
 	}
 
 	void listen(auto listen_port)
     {
+        if (!m_acceptor)
+        {
+            LOG_ERROR << "listen() called on a context-less Server";
+            return;
+        }
         io::ip::tcp::endpoint listen_ep(io::ip::tcp::v4(), listen_port);
 
-        m_acceptor.open(listen_ep.protocol());
-		m_acceptor.set_option(io::socket_base::reuse_address(true));
-		m_acceptor.bind(listen_ep);
-		m_acceptor.listen();
+        m_acceptor->open(listen_ep.protocol());
+		m_acceptor->set_option(io::socket_base::reuse_address(true));
+		m_acceptor->bind(listen_ep);
+		m_acceptor->listen();
 		accept();
 
 		LOG_INFO << "Factory started for port: " << listen_ep.port();
     }
 
-	uint16_t listen_port() const { return m_acceptor.local_endpoint().port(); }
+	uint16_t listen_port() const { return m_acceptor->local_endpoint().port(); }
 };
 
 class Client
@@ -82,7 +94,7 @@ class Client
 private:
 	INetwork* m_node;
 	io::io_context* m_context;
-    io::ip::tcp::resolver m_resolver;
+    std::optional<io::ip::tcp::resolver> m_resolver;
     std::string m_label = "Net";  // chain/protocol label for log messages
 
 	void connect_socket(boost::asio::ip::tcp::resolver::results_type endpoints)
@@ -136,7 +148,12 @@ private:
 		// only enforce the alive check when there WAS a shared owner to
 		// begin with.
 		bool was_managed = weak_node.lock() != nullptr;
-		m_resolver.async_resolve(addr.address(), addr.port_str(),
+		if (!m_resolver)
+		{
+			LOG_ERROR << "resolve() called on a context-less Client";
+			return;
+		}
+		m_resolver->async_resolve(addr.address(), addr.port_str(),
 			[this, weak_node, was_managed, addr = addr](const auto& ec, auto endpoints)
 			{
 				if (ec)
@@ -160,8 +177,13 @@ private:
 
 public:
 	Client(io::io_context* context, INetwork* node, const std::string& label = "Net")
-		: m_context(context), m_resolver(*context), m_node(node), m_label(label)
+		: m_node(node), m_context(context), m_label(label)
 	{
+		// Rig-free / test construction (context == nullptr) defers the resolver
+		// so no null io_context is dereferenced; resolve()/connect() are only
+		// valid once a real io_context has been wired in.
+		if (context)
+			m_resolver.emplace(*context);
 	}
 
 	void connect(NetService addr)


### PR DESCRIPTION
## fix(core): null-io_context-safe Server construction — SAFE-ADDITIVE

Extracted from #586 per integrator routing (shared/core change does not belong buried in a coin-fenced PR).

### What
`Server::Server` dereferenced `*context` unconditionally, so a context-less `BaseNode` (default / test construction, `context==nullptr`) segfaulted before any test body ran. This makes `m_acceptor` a `std::optional`, emplaces the acceptor only when a real `io_context` is supplied, and guards `listen()` when unengaged.

### Why SAFE-ADDITIVE
- Real callers (`c2pool_refactored` `enhanced_node->listen`, `ltc_pool_test`, all production node construction) pass a valid `io_context` -> the emplace path runs, behaviour is **byte-identical** to before.
- The **only** new path is the formerly-crashing context-less one, which now no-ops instead of dereferencing null.
- No API removed, no signature changed. Additive guard only.

### Validation
- Full local rollup on workstation: **1170/1170 ctest** with this change in tree (the #586 verify that caught & corrected the earlier case-sensitive `ctest -R dash` false-green). All four coin suites (ltc / doge / dgb / dash) exercised — dash 326/326.
- Un-REDs the context-less path used by DASH S8 leaf tests **and** the equivalent context-less btc/dgb node tests -> benefits three coins, which is exactly why it is core, not dash.
- Full-matrix CI gate: holding for CLEAN full rollup; will ping `[s=ci-green]` on the clean rollup, not Linux-only.

### Review + ordering
- **@ltc-doge-production-steward**: requesting LTC + DOGE preservation review — mandatory for any `src/core` change.
- **Ordering dependency**: this core PR must land FIRST. #586 will then be rebased to carry only the `dash::PoolConfig -> SharechainConfig` rename (`442c46ef`) on top of this, since it un-REDs the context-less path the S8 leaf tests exercise.
- Shared-layer change -> flagged for operator tap before merge (not auto-merge eligible).
