### PR TITLE
test(d-miner.1): pin record_sample ingest-poll seam (live|dead union, JSON-null, empty payload)

### DIFF
--- a/scripts/miner_presence_sampler.py
+++ b/scripts/miner_presence_sampler.py
@@ -294,6 +294,38 @@ def _selftest():
     check("all-offline: samples still counted (worker not vanished)", cn == 2)
     check("all-offline: stale=100 when only dead work reported", abs(cst - 100.0) < 1e-9)
 
+    # 9) ingest seam (record_sample): the poll path that feeds every rollup.
+    #    KATs 2-8 add_raw() directly, bypassing record_sample; this pins its own
+    #    live|dead union + JSON-null resilience so a refactor cannot silently drop
+    #    workers or fabricate presence from dead-only work.
+    con = fresh()
+    # a rig emitting ONLY dead/DOA work is present in the dead map but absent
+    # from live -> must record OFFLINE, never phantom-online
+    record_sample(con, {"miner_hash_rates": {"X": 7000.0},
+                        "miner_dead_hash_rates": {"X": 500.0, "Y": 300.0},
+                        "shares": {"total": 10, "orphan": 1, "dead": 2}})
+    r = {w: (hr, dr, on) for w, hr, dr, on in
+         con.execute("SELECT worker,hashrate,dead_hashrate,online FROM samples")}
+    check("ingest: live>0 worker online with its dead carried", r.get("X") == (7000.0, 500.0, 1))
+    check("ingest: dead-only worker recorded OFFLINE (no phantom presence)", r.get("Y") == (0.0, 300.0, 0))
+    check("ingest: shares snapshot captured from payload",
+          con.execute("SELECT shares_total FROM pool_samples").fetchone()[0] == 10)
+
+    # the real API can emit JSON null (not merely omit a key); the `or {}` guard
+    # is honesty-critical -> must not crash and must not fabricate rows
+    con = fresh()
+    n = record_sample(con, {"miner_hash_rates": None, "miner_dead_hash_rates": None, "shares": None})
+    check("ingest: JSON-null maps -> zero worker rows (no crash)", n == 0)
+    check("ingest: JSON-null shares -> zeroed pool row (no crash)",
+          con.execute("SELECT shares_total,shares_orphan,shares_dead FROM pool_samples").fetchone() == (0, 0, 0))
+
+    # wholly empty payload -> no worker rows, pool row still written zeroed
+    con = fresh()
+    n = record_sample(con, {})
+    check("ingest: empty payload -> no worker rows", n == 0)
+    check("ingest: empty payload -> pool row still written zeroed",
+          con.execute("SELECT COUNT(*) FROM pool_samples").fetchone()[0] == 1)
+
     print("\nSELFTEST PASS" if not fails else "\nSELFTEST FAIL: " + ", ".join(fails))
     return 1 if fails else 0
 


### PR DESCRIPTION
## What

SAFE-ADDITIVE regression KAT pinning `record_sample` — the D-MINER.1 poll/ingest seam that feeds every rollup from `/local_stats`.

## Why

The existing selftest KATs (2-8) exercise the rollup accounting math via `add_raw()` direct inserts, which bypass `record_sample` entirely. But `record_sample` IS the poll path: it parses `miner_hash_rates` / `miner_dead_hash_rates` / `shares` off the live API and decides presence. That seam was unpinned. A refactor of its `set(live) | set(dead)` union, or the `or {}` null-guard, could silently:

- drop a dead-only worker (present in the dead map, absent from live),
- fabricate presence for a rig emitting only DOA work, or
- crash on a JSON-null payload (the real API can emit `null`, not just omit a key),

with no test to catch it. For a charter whose whole point is "the dashboard must never lie about prod health," the ingest edge is exactly where a silent regression would reintroduce a lie.

## KAT 9 (rig-free, in-memory)

- dead-only worker records **OFFLINE**, not phantom-online, dead hashrate still carried
- live>0 worker records online with its own dead hashrate
- JSON-null maps -> zero worker rows, no crash; null shares -> zeroed pool row
- wholly empty payload -> no worker rows, pool row still written zeroed

## Verification

`python3 scripts/miner_presence_sampler.py selftest` -> 29/29 green. Python-only, zero compiled TUs, no runtime behavior change.
