### PR TITLE
bch: repoint daemon README off M2 stub to embedded body

### DIFF
--- a/src/impl/bch/daemon/README.txt
+++ b/src/impl/bch/daemon/README.txt
@@ -1,5 +1,11 @@
-Embedded BCHN daemon slice (M3). Forked from Bitcoin Cash Node, lowest
-divergence from Bitcoin Core (same root as c2pool-btc embedded daemon).
-Vendoring policy: NO in-tree vendor of BCHN; reference clone built siblingly,
-artifacts into worktree only (M1 §1.1). Scope: SPV + P2P + mempool + template
-builder. Confirm BCHN commit/tag at vendoring. Stub placeholder at M2.
+Embedded BCHN daemon slice. Forked from Bitcoin Cash Node, lowest divergence
+from Bitcoin Core (same root as c2pool-btc embedded daemon). Vendoring policy:
+NO in-tree vendor of BCHN; reference clone built siblingly, artifacts into
+worktree only (M1 §1.1). Scope: SPV + P2P + mempool + template builder.
+
+The embedded daemon body now lives under src/impl/bch/coin/. Owner entrypoint
+is EmbeddedDaemon<Config> (coin/embedded_daemon.hpp), which binds HeaderChain,
+Mempool, EmbeddedCoinNode, coin::Node and AblaRuntime in order and runs them.
+AblaRuntime (coin/abla_runtime.hpp) closes the ABLA loop full_block -> feed ->
+tracker -> getwork budget. EMBEDDED-PRIMARY / EXTERNAL-FALLBACK holds: the
+external BCHN RPC path (coin/rpc.*) is retained as fallback, never removed.


### PR DESCRIPTION
Doc-only, fenced to the BCH tree (src/impl/bch/daemon/README.txt only). No shared/other-coin files, zero build/consensus/behaviour change.

The daemon README still described the slice as an M2 stub placeholder. It now points at the landed embedded body under src/impl/bch/coin/: the EmbeddedDaemon<Config> entrypoint (coin/embedded_daemon.hpp) and the AblaRuntime ABLA loop (coin/abla_runtime.hpp), and records the retained EMBEDDED-PRIMARY / EXTERNAL-FALLBACK RPC path.

Surface-for-tap: hold merge for operator approval per standing rule.