### PR TITLE
ci(codeql): cap Analyze (c-cpp) footprint on self-hosted 905 (fix co-OOM with ASan)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -95,10 +95,24 @@ jobs:
           cmake -S . -B build_codeql \
             -DCMAKE_TOOLCHAIN_FILE=build_codeql/conan_toolchain.cmake \
             -DCMAKE_BUILD_TYPE=Release
-          cmake --build build_codeql --target c2pool -j$(nproc)
+          # Cap build parallelism on the shared self-hosted 905 box so the
+          # CodeQL build does not co-OOM with a concurrent ASan job.
+          # github-hosted (fork) runs keep full parallelism.
+          if [ "${{ runner.environment }}" = "github-hosted" ]; then
+            JOBS=$(nproc)
+          else
+            JOBS=8
+          fi
+          cmake --build build_codeql --target c2pool -j"$JOBS"
 
       # ── Analysis ──────────────────────────────────────────────────────────
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"
+          # Cap the run-queries footprint on the shared self-hosted 905 box so
+          # CodeQL does not co-OOM with a concurrent ASan job (was auto-sizing
+          # to --ram=60466 --threads=32, nearly the whole box). 0 = action
+          # auto-default, kept for github-hosted (fork) runs.
+          threads: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && '12' || '0' }}
+          ram: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && '20000' || '0' }}


### PR DESCRIPTION
Runner-side fix, not a code finding — do NOT change PR-author code.

## Problem
The only red on DASH PRs #583/#571/#586 is CodeQL `Analyze (c-cpp)`. The identical code compiles green under 4+ other toolchains (x86_64, ASan+UBSan, all COIN_* matrices, Windows, macOS, coin smokes). Root cause is the shared self-hosted 905 box, not the code:

- `Build for CodeQL analysis` used `-j$(nproc)` (32-way).
- `Perform CodeQL Analysis` auto-sized run-queries to `--ram=60466 --threads=32` — nearly the whole box.

When CodeQL ran concurrently with an ASan job on 905 both co-OOMed (07-02 exit-137; #583 job 84734661452 step 10/11 conclusion=null kill).

## Fix
Cap **self-hosted only**, leaving headroom for a concurrent ASan job:
- build `-j8`
- analyze `threads: 12`, `ram: 20000` MB

github-hosted (fork) runs keep auto defaults (`threads/ram: 0`, `-j$(nproc)`) via the same fork-gate expression as PR #439. Single file, no author-code change.

Overlaps #439 self-hosted-CI oversubscription work — this is the same 905-box root cause folded into the CodeQL lane.