### PR TITLE
bch(g3): --testnet4 net-params path -- magic e2b7daaf + own-genesis selector

### DIFF
--- a/src/c2pool/main_bch.cpp
+++ b/src/c2pool/main_bch.cpp
@@ -74,7 +74,7 @@ void print_banner(const char* argv0)
         << "       " << argv0 << " --with-peer-verify [--testnet] [--peer HOST:PORT] [--max-seconds N]\n"
         << "       " << argv0 << " --leg-c-capture [--rpc-conf PATH]\n"
         << "       " << argv0 << " --leg-c-capture-p2p [--rpc-conf PATH] [--p2p-port N]\n"
-        << "       " << argv0 << " --pool [--testnet|--regtest] [--stratum [HOST:]PORT] [--peer HOST:PORT] [--anchor N] [--rpc-conf PATH]\n\n"
+        << "       " << argv0 << " --pool [--testnet|--testnet4|--regtest] [--stratum [HOST:]PORT] [--peer HOST:PORT] [--anchor N] [--rpc-conf PATH]\n\n"
         << "Status: M5 pool/sharechain + embedded-daemon assembly live.\n"
         << "        The embedded daemon (coin/embedded_daemon.hpp) is the primary\n"
         << "        work source; external BCHN-RPC stays as the fallback.\n"
@@ -603,8 +603,21 @@ int run_leg_c_capture_p2p(const std::string& conf_path, uint16_t p2p_port)
 //
 // p2pool-merged-v36 surface: NONE -- run-loop bring-up + block dispatch, not
 // share/PPLNS/coinbase/PoW bytes. PER-COIN ISOLATION: src/impl/bch only.
+// BCH wire-protocol magic bytes per network (pchMessageStart).
+// Source: BCHN chainparams.cpp, verified vs staged bchn29 bitcoind rodata:
+// mainnet e3e1f3e8, testnet3 f4e5f3f4, testnet4 e2b7daaf, regtest dab5bffa.
+static std::vector<std::byte> bch_magic_bytes(bool testnet, bool testnet4, bool regtest)
+{
+    std::string hex;
+    if      (regtest)  hex = "dab5bffa";   // CRegTestParams
+    else if (testnet4) hex = "e2b7daaf";   // CTestNet4Params
+    else if (testnet)  hex = "f4e5f3f4";   // CTestNetParams (testnet3)
+    else               hex = "e3e1f3e8";   // CMainParams
+    return ParseHexBytes(hex);
+}
+
 int run_pool(const std::string& peer_host, uint16_t peer_port, bool testnet,
-             bool regtest, uint32_t anchor_height,
+             bool testnet4, bool regtest, uint32_t anchor_height,
              const std::string& stratum_addr, uint16_t stratum_port,
              const std::string& rpc_conf)
 {
@@ -615,17 +628,14 @@ int run_pool(const std::string& peer_host, uint16_t peer_port, bool testnet,
     bch::Config config("bch");
     // Skip Config::init() (no on-disk pool.yaml/coin.yaml); set only the fields
     // the run-loop touches, from BCH chainparams.
-    config.coin()->m_testnet = testnet || regtest;
+    config.coin()->m_testnet = testnet || testnet4 || regtest;
+    config.coin()->m_testnet4 = testnet4;            // -> BCHChainParams::testnet4() (own genesis 000000001dd4.., magic e2b7daaf)
     config.coin()->m_symbol  = "BCH";
     config.coin()->m_p2p.address = NetService(peer_host, peer_port);
     // BCH P2P network magic (pchMessageStart, BCHN chainparams.cpp): mainnet
     // e3e1f3e8, testnet3 f4e5f3f4, regtest dab5bffa. Wrong magic == BCHN drops
     // the peer with EOF right after connect.
-    config.coin()->m_p2p.prefix = regtest
-        ? std::vector<std::byte>{ std::byte{0xda}, std::byte{0xb5}, std::byte{0xbf}, std::byte{0xfa} }
-        : (testnet
-            ? std::vector<std::byte>{ std::byte{0xf4}, std::byte{0xe5}, std::byte{0xf3}, std::byte{0xf4} }
-            : std::vector<std::byte>{ std::byte{0xe3}, std::byte{0xe1}, std::byte{0xf3}, std::byte{0xe8} });
+    config.coin()->m_p2p.prefix = bch_magic_bytes(testnet, testnet4, regtest);
     // Sharechain identity: BCH p2pool PREFIX namespaces the sharechain P2P
     // framing. standup_pool_run's Node reads pool()->m_prefix.
     config.pool()->m_prefix = ParseHexBytes(bch::PoolConfig::prefix_hex());
@@ -651,7 +661,7 @@ int run_pool(const std::string& peer_host, uint16_t peer_port, bool testnet,
 
     std::cout
         << "[pool] c2pool-bch pool run-loop"
-        << (regtest ? " (regtest)" : (testnet ? " (testnet)" : " (mainnet)"))
+        << (regtest ? " (regtest)" : (testnet4 ? " (testnet4)" : (testnet ? " (testnet)" : " (mainnet)")))
         << " -- BCHN peer " << peer_host << ":" << peer_port
         << ", cold-start anchor=" << anchor_height;
     if (stratum_port)
@@ -662,7 +672,7 @@ int run_pool(const std::string& peer_host, uint16_t peer_port, bool testnet,
 
     try {
         bch::standup_pool_run(ioc, config, anchor_height,
-                              stratum_addr, stratum_port, testnet || regtest, regtest);
+                              stratum_addr, stratum_port, testnet || testnet4 || regtest, regtest);
     } catch (const std::exception& e) {
         std::cout << "[pool] FATAL: " << e.what() << "\n";
         return 1;
@@ -687,6 +697,7 @@ int main(int argc, char** argv)
     uint16_t leg_c_p2p_port = 18444;  // BCHN regtest P2P default
     std::string rpc_conf;
     bool testnet = false;
+    bool testnet4 = false;
     bool near_tip = false;
     bool auto_kick = false;
     std::string host = "192.168.86.110";   // VM300 bchn-bch
@@ -721,6 +732,7 @@ int main(int argc, char** argv)
             leg_c_p2p_port = static_cast<uint16_t>(std::stoul(argv[++i]));
         if (std::strcmp(argv[i], "--rpc-conf") == 0 && i + 1 < argc) rpc_conf = argv[++i];
         if (std::strcmp(argv[i], "--testnet") == 0) { testnet = true; port = 18333; }
+        if (std::strcmp(argv[i], "--testnet4") == 0) { testnet4 = true; port = 28333; }
         if (std::strcmp(argv[i], "--near-tip") == 0) near_tip = true;
         if (std::strcmp(argv[i], "--auto-kick") == 0) auto_kick = true;
         if (std::strcmp(argv[i], "--peer") == 0 && i + 1 < argc) {
@@ -758,7 +770,7 @@ int main(int argc, char** argv)
     }
 
     if (want_pool)
-        return run_pool(host, port, testnet, regtest, anchor_height, stratum_addr, stratum_port, rpc_conf);
+        return run_pool(host, port, testnet, testnet4, regtest, anchor_height, stratum_addr, stratum_port, rpc_conf);
 
     if (want_with_peer_verify)
         return run_with_peer_verify(host, port, testnet, max_seconds);

--- a/src/impl/bch/coin/embedded_daemon.hpp
+++ b/src/impl/bch/coin/embedded_daemon.hpp
@@ -85,8 +85,9 @@ public:
                    bool is_regtest = false)
         : m_config(config),
           m_chain(is_regtest ? BCHChainParams::regtest()
-                             : (config->m_testnet ? BCHChainParams::testnet()
-                                                  : BCHChainParams::mainnet())),
+                             : (config->m_testnet4 ? BCHChainParams::testnet4()
+                                : (config->m_testnet ? BCHChainParams::testnet()
+                                                     : BCHChainParams::mainnet()))),
           m_pool(),
           m_embedded(m_chain, m_pool, config->m_testnet),
           m_node(context, config),

--- a/src/impl/bch/config_coin.hpp
+++ b/src/impl/bch/config_coin.hpp
@@ -106,6 +106,7 @@ public:
     std::string m_symbol;
     int m_share_period{};
     bool m_testnet {false};
+    bool m_testnet4 {false};  // BCH testnet4: OWN genesis (000000001dd4..) + magic e2b7daaf; testnet-class for ABLA/ASERT
 };
 
 } // namespace bch

--- a/src/impl/bch/test/embedded_block_broadcast_test.cpp
+++ b/src/impl/bch/test/embedded_block_broadcast_test.cpp
@@ -41,6 +41,7 @@ int failures = 0;
 
 struct TestConfig {
     bool m_testnet = false;
+    bool m_testnet4 = false;  // mirror config_coin.hpp: BCH testnet4 selector
     struct P2P { std::vector<std::byte> prefix; };
     struct Coin { P2P m_p2p; };
     Coin m_coin;

--- a/src/impl/bch/test/embedded_daemon_assembly_test.cpp
+++ b/src/impl/bch/test/embedded_daemon_assembly_test.cpp
@@ -53,6 +53,7 @@ int failures = 0;
 // Node::run()/init_rpc(), which this offline test never calls.
 struct TestConfig {
     bool m_testnet = false;
+    bool m_testnet4 = false;  // mirror config_coin.hpp: BCH testnet4 selector
     // Duck-typed coin()->m_p2p.prefix: NodeP2P<Config>::get_prefix() is a virtual
     // override (eagerly instantiated via the vtable) and reads it. Empty here --
     // assemble() never sends a P2P message, so the value is inert.

--- a/src/impl/bch/test/embedded_seam_workview_test.cpp
+++ b/src/impl/bch/test/embedded_seam_workview_test.cpp
@@ -66,6 +66,7 @@ int failures = 0;
 // which this offline test never calls.
 struct TestConfig {
     bool m_testnet = false;
+    bool m_testnet4 = false;  // mirror config_coin.hpp: BCH testnet4 selector
     struct P2P { std::vector<std::byte> prefix; };
     struct Coin { P2P m_p2p; };
     Coin m_coin;


### PR DESCRIPTION
## What
Wire BCH **testnet4** into the `c2pool-bch --pool` entrypoint so the embedded daemon selects testnet4 consensus params instead of falling back to testnet3.

**Root cause (prior):** `run_pool` had no testnet4 branch -> emitted testnet3 magic `f4e5f3f4` + testnet3 genesis -> BCHN EOF-dropped the peer right after connect -> HeaderChain stuck at h0.

## Hunks (3 files)
- `src/impl/bch/config_coin.hpp` — `m_testnet4` flag (testnet-class for ABLA/ASERT).
- `src/impl/bch/coin/embedded_daemon.hpp` — select `BCHChainParams::testnet4()` (own genesis `000000001dd4..`, ASERT anchor 16844) when `m_testnet4`.
- `src/c2pool/main_bch.cpp` — `--testnet4` arg (port 28333); `bch_magic_bytes()` emits `e2b7daaf` (CTestNet4Params, verified vs bchn29 rodata); `run_pool` threads testnet4 through magic / params / banner.

`testnet4()` + `asert_testnet4()` consensus constants already live in master — this is **CLI + selector wiring only**.

## Proof
Build GREEN (link EXIT=0). Behavioural: `--pool --testnet4` vs a testnet4 BCHN substrate handshakes off h0 (start_height=312925, BCHN 29.0.0), EOF-drop gone, HeaderChain advances past h0 (2000->4000/312925 climbing).

## Isolation / compat
- Per-coin isolation intact: only `src/impl/bch/` + the **c2pool-bch-exclusive** `main_bch.cpp` entrypoint. No `src/core` / `bitcoin_family` / peer-coin hunks.
- No p2pool-merged-v36 surface change (subsidy / payout / version-gate untouched) -> **surface-for-tap, not auto-merge**.

## Follow-up (tracked, non-consensus)
Cosmetic leveldb path + BCHWorkSource still label `bitcoincash_testnet` for testnet4; magic/genesis/P2P path proven correct by sync off the real testnet4 chain. Separate label-harmonization slice.

Do NOT self-merge — integrator merges on operator tap.