### PR TITLE
bch(g3): testnet4 own LevelDB sharechain namespace (stacked on #615)

### DIFF
--- a/src/impl/bch/node.hpp
+++ b/src/impl/bch/node.hpp
@@ -15,7 +15,7 @@
 //   * NO merged-mining / AuxPoW — BCH is a SHA256d standalone-parent chain.
 //     The header carries no aux paths; nothing BTC-specific to omit.
 //   * verify_pool runs SHA256d share PoW verification (NOT scrypt).
-//   * LevelDB storage net name: "bitcoincash" / "bitcoincash_testnet".
+//   * LevelDB storage net name: "bitcoincash" / "bitcoincash_testnet" / "bitcoincash_testnet4".
 //
 // This is a header-only slice (declarations only); node.cpp body lands later.
 
@@ -359,7 +359,12 @@ public:
         m_chain = &m_tracker.chain;
 
         // Open LevelDB storage and load any persisted shares
-        std::string net_name = config->m_testnet ? "bitcoincash_testnet" : "bitcoincash";
+        // testnet4 gets its OWN LevelDB namespace so its sharechain never collides
+        // with testnet3 under the shared m_testnet flag (main_bch.cpp sets m_testnet
+        // true for testnet3|testnet4|regtest). Isolation-primitive: keep per-net.
+        std::string net_name = config->m_testnet4 ? "bitcoincash_testnet4"
+                             : config->m_testnet  ? "bitcoincash_testnet"
+                                                  : "bitcoincash";
         m_storage = std::make_unique<c2pool::storage::SharechainStorage>(net_name);
         load_persisted_shares();
 


### PR DESCRIPTION
Stacked on #615 (bch/testnet4-magic-path). Depends on the m_testnet4 selector it adds; GitHub will retarget to master once #615 merges.

Problem: main_bch.cpp sets m_testnet = testnet || testnet4 || regtest, so under --testnet4 the node.hpp net_name ternary picked "bitcoincash_testnet" -- the testnet3 label. testnet3 and testnet4 sharechains would share one LevelDB namespace and cross-contaminate on any host that ran both.

Fix (1 file, src/impl/bch/node.hpp): select "bitcoincash_testnet4" when m_testnet4, else fall through to the existing testnet3/mainnet labels. Isolation-primitive (3-bucket #1): keep per-net namespacing; do not unify.

Scope: BCH-isolated, non-consensus, header-only. No src/core, no bitcoin_family, no peer-coin hunks.

Verify: .198 build EXIT=0; ctest -R bch = 27/27 PASS (assembly/seam tests exercise the storage namespace). GPG-signed 285EFE76, zero attribution.

surface-for-tap -- NO self-merge (integrator merges on operator push approved).