### PR TITLE
ci(release): route Linux package job to self-hosted c2pool-build pool

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
   # ════════════════════════════════════════════════════════════════════════════
   linux:
     name: ${{ matrix.coin }} package (Linux x86_64)
-    runs-on: ubuntu-24.04
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Routes the last GitHub-hosted Linux lane living in a separate (non-build.yml) workflow file onto the self-hosted `c2pool-build` pool.

- `release.yml` `linux` job was hardcoded `runs-on: ubuntu-24.04`; its steps were already self-hosted-prepped (conan pre-provisioned on the runner) but the `runs-on` was never flipped.
- Applies the same trusted-event conditional already used across build.yml and every other workflow: self-hosted `c2pool-build` for trusted events, `ubuntu-24.04` fallback for fork PRs (never run untrusted fork code self-hosted).
- Reclaims GitHub-hosted machine-hours on tagged release builds (local-CI-utilization vector, #439/#617 line).

Fenced: 1 file, 1 line. macOS/Windows release lanes stay GitHub-hosted (hardware-gated, separate track — VM217 line). Off master, not stacked on #617/#616.