### PR TITLE
dash: CI gate entrypoints — G1 byte-parity KAT + G3a populated block production

### DIFF
--- a/tests/gates/g1_byte_parity_kat.sh
+++ b/tests/gates/g1_byte_parity_kat.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# G1 — DASH X11 byte-parity known-answer test (CI required-gate entrypoint).
+# Wraps the real test_dash_x11_kat gtest suite (DashX11Kat.*): genesis + testnet3
+# real-node header vectors reproduce the X11 block hash byte-for-byte (#596 vectors).
+# Deterministic: exit 0 = every KAT vector reproduced; nonzero = failure / hollow run.
+# Network-free, CI-runner safe (~0.1s). Fenced: a tests/gates/ entrypoint over an
+# existing DASH test target — no consensus / shared-base / build.yml / CMake edits.
+set -euo pipefail
+
+GATE="G1 dash-x11-byte-parity-kat"
+TEST_REGEX='^DashX11Kat\.'
+TARGET=test_dash_x11_kat
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BUILD_DIR="${BUILD_DIR:-$REPO_ROOT/build}"
+
+# 1. Ensure the target exists (configure+build only if the CI cache is cold).
+if [ ! -f "$BUILD_DIR/CMakeCache.txt" ]; then
+  echo "[$GATE] no build dir at $BUILD_DIR — configuring (conan + cmake)"
+  conan install "$REPO_ROOT" --build=missing --output-folder="$BUILD_DIR" --settings=build_type=Release
+  cmake -S "$REPO_ROOT" -B "$BUILD_DIR" \
+    -DCMAKE_TOOLCHAIN_FILE="$BUILD_DIR/conan_toolchain.cmake" \
+    -DCMAKE_BUILD_TYPE=Release
+fi
+cmake --build "$BUILD_DIR" --target "$TARGET" -j"$(nproc)"
+
+# 2. Run from build/ and capture. Running ctest off the wrong CWD prints
+#    "No tests were found!!!" and EXITS 0 — the classic false-green trap.
+set +e
+OUT="$(cd "$BUILD_DIR" && ctest -R "$TEST_REGEX" --output-on-failure 2>&1)"
+RC=$?
+set -e
+echo "$OUT"
+
+# 3. False-green guard: demand a positive test count actually ran.
+if grep -q "No tests were found" <<<"$OUT"; then
+  echo "[$GATE] FAIL — hollow run: 0 tests matched $TEST_REGEX (wrong CWD/target?)" >&2
+  exit 1
+fi
+N="$(grep -oE 'out of [0-9]+' <<<"$OUT" | grep -oE '[0-9]+' | tail -1)"
+if [ -z "${N:-}" ] || [ "$N" -lt 1 ]; then
+  echo "[$GATE] FAIL — no positive test count parsed" >&2
+  exit 1
+fi
+if [ "$RC" -ne 0 ]; then
+  echo "[$GATE] FAIL — ctest exit $RC ($N tests)" >&2
+  exit "$RC"
+fi
+echo "[$GATE] PASS — $N DashX11Kat byte-parity vectors reproduced"

--- a/tests/gates/g3a_regtest_block_production.sh
+++ b/tests/gates/g3a_regtest_block_production.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# G3a — DASH populated block production (CI required-gate entrypoint).
+# Default arm (CI-runner, network-free): the DashG3Assembled.* + DashBlockProducer.*
+# gtest suites — c2pool-dash assembles a POPULATED block (coinbase DIP masternode
+# split + >=3 diverse non-witness payload txs), X11-mines a winning nonce, serializes
+# it, and the won block reaches the network on BOTH paths (embedded P2P + submitblock).
+# Optional live arm (opt-in when DASH_RPC_PASS + DASH_RPC_AUTH are set): additionally
+# drives scripts/dash_g3a_populated_block_regtest.sh against an isolated regtest dashd
+# for a real end-to-end populated block via the submitblock RPC arm.
+# Deterministic: exit 0 = pass; nonzero = failure / hollow run. Fenced: tests/gates/
+# entrypoint over existing DASH targets — no consensus / shared-base / build.yml / CMake.
+set -euo pipefail
+
+GATE="G3a dash-populated-block-production"
+TEST_REGEX='^(DashG3Assembled|DashBlockProducer)\.'
+TARGETS=(test_dash_g3_assembled test_dash_block_producer)
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BUILD_DIR="${BUILD_DIR:-$REPO_ROOT/build}"
+
+# 1. Ensure the targets exist (configure+build only if the CI cache is cold).
+if [ ! -f "$BUILD_DIR/CMakeCache.txt" ]; then
+  echo "[$GATE] no build dir at $BUILD_DIR — configuring (conan + cmake)"
+  conan install "$REPO_ROOT" --build=missing --output-folder="$BUILD_DIR" --settings=build_type=Release
+  cmake -S "$REPO_ROOT" -B "$BUILD_DIR" \
+    -DCMAKE_TOOLCHAIN_FILE="$BUILD_DIR/conan_toolchain.cmake" \
+    -DCMAKE_BUILD_TYPE=Release
+fi
+cmake --build "$BUILD_DIR" --target "${TARGETS[@]}" -j"$(nproc)"
+
+# 2. Run from build/ and capture (false-green trap: wrong CWD prints
+#    "No tests were found!!!" and EXITS 0).
+set +e
+OUT="$(cd "$BUILD_DIR" && ctest -R "$TEST_REGEX" --output-on-failure 2>&1)"
+RC=$?
+set -e
+echo "$OUT"
+
+# 3. False-green guard: demand a positive test count actually ran.
+if grep -q "No tests were found" <<<"$OUT"; then
+  echo "[$GATE] FAIL — hollow run: 0 tests matched $TEST_REGEX" >&2
+  exit 1
+fi
+N="$(grep -oE 'out of [0-9]+' <<<"$OUT" | grep -oE '[0-9]+' | tail -1)"
+if [ -z "${N:-}" ] || [ "$N" -lt 1 ]; then
+  echo "[$GATE] FAIL — no positive test count parsed" >&2
+  exit 1
+fi
+if [ "$RC" -ne 0 ]; then
+  echo "[$GATE] FAIL — ctest exit $RC ($N tests)" >&2
+  exit "$RC"
+fi
+echo "[$GATE] PASS (CI arm) — $N assembled-block / producer assertions green"
+
+# 4. Optional live regtest arm — only when an isolated dashd is wired in via env.
+if [ -n "${DASH_RPC_PASS:-}" ] && [ -n "${DASH_RPC_AUTH:-}" ]; then
+  echo "[$GATE] live arm: driving scripts/dash_g3a_populated_block_regtest.sh"
+  "$REPO_ROOT/scripts/dash_g3a_populated_block_regtest.sh"
+  echo "[$GATE] PASS (live arm) — populated regtest block proven via c2pool-dash submitblock"
+else
+  echo "[$GATE] live regtest arm SKIPPED (set DASH_RPC_PASS + DASH_RPC_AUTH to enable)"
+fi


### PR DESCRIPTION
Lands the two DASH required-gate entrypoints ci-steward PR #619 wires TEST_ENTRYPOINT at.

## Files (fenced to tests/gates/)
- tests/gates/g1_byte_parity_kat.sh -> test_dash_x11_kat (DashX11Kat.*): 4 X11 byte-parity KAT vectors
- tests/gates/g3a_regtest_block_production.sh -> test_dash_g3_assembled + test_dash_block_producer (DashG3Assembled.* / DashBlockProducer.*): 18 populated-block assemble + X11-mine + dual-path reach-network assertions

## Contract
- Deterministic exit codes: 0 = pass, nonzero = fail.
- Self-configure a cold build (conan + cmake), build only the target(s), run ctest from build/.
- False-green guard: hard-fail on the empty-suite trap (No tests were found -> ctest exit 0).
- G3a optional live arm: when DASH_RPC_PASS + DASH_RPC_AUTH set, additionally drives scripts/dash_g3a_populated_block_regtest.sh (isolated regtest dashd, submitblock arm).

## Verification (Linux x86_64, rebased on master 2530888a)
- G1: 4/4 pass, exit 0, non-hollow.
- G3a CI arm: 18/18 pass, exit 0, non-hollow; live arm correctly SKIPPED without creds.

SAFE-ADDITIVE. No consensus / shared-base / build.yml / CMake edits (ci-steward owns the .yml). Per-coin isolation preserved.