### PR TITLE
dgb: plumb optional GBT bits field into embedded work template

### DIFF
--- a/src/impl/dgb/coin/template_builder.hpp
+++ b/src/impl/dgb/coin/template_builder.hpp
@@ -77,11 +77,14 @@ public:
 // absence, never a fabricated tx; the fee total is folded into coinbasevalue
 // UPSTREAM via resolve_coinbase_value, not here), previousblockhash
 // is emitted ONLY when the caller supplies a real tip hash (truthful absence,
-// never a fabricated id), and `bits` is held back entirely -- DGB Core's live
-// next-target is MultiShield V4 (a global 5-algo window == V37), so a
-// Scrypt-only walk would emit a known-wrong difficulty (the same fabrication
-// the empty transactions[] deliberately avoids). bits becomes a GBT
-// pass-through once the external-daemon path is plumbed in.
+// never a fabricated id), and `bits` is likewise a caller-supplied conditional
+// pass-through: emitted ONLY when the caller hands in the authoritative
+// external-daemon GBT bits. The embedded Scrypt-only path supplies none -- DGB
+// Core's live next-target is MultiShield V4 (a global 5-algo window == V37), so
+// a Scrypt-only walk would emit a known-wrong difficulty (the same fabrication
+// the empty transactions[] deliberately avoids); it leaves bits unset and the
+// field is held back for that caller, never fabricated. The G1 replay harness
+// and any future daemon-GBT caller set in.bits from the oracle value.
 struct WorkTemplateInputs {
     // Absolute height of the NEXT block (#209 next_block_height()).
     uint32_t next_height = 0;
@@ -108,6 +111,13 @@ struct WorkTemplateInputs {
     // coinbasevalue UPSTREAM via resolve_coinbase_value(total_fees) (#207 SSOT);
     // the builder never derives the reward, so this field is display-only shape.
     nlohmann::json transactions = nlohmann::json::array();
+    // GBT nBits (compact difficulty) as the daemon emits it -- the authoritative
+    // external-daemon GBT value, supplied by the caller. nullopt -> bits omitted
+    // from the template (truthful absence: the embedded Scrypt-only path can only
+    // reconstruct MultiShield V4 with a full 5-algo window (== V37), so it never
+    // fabricates a Scrypt-only value and leaves this unset). The identical
+    // conditional-emit discipline as previousblockhash.
+    std::optional<std::string> bits;
 };
 
 inline nlohmann::json build_work_template(const WorkTemplateInputs& in)
@@ -139,6 +149,11 @@ inline nlohmann::json build_work_template(const WorkTemplateInputs& in)
     // previousblockhash: truthful conditional emit (see struct notes).
     if (in.previousblockhash)
         tmpl["previousblockhash"] = *in.previousblockhash;
+
+    // bits: truthful conditional emit -- present only when the caller supplies
+    // the authoritative external-daemon GBT value (see struct notes).
+    if (in.bits)
+        tmpl["bits"] = *in.bits;
 
     return tmpl;
 }

--- a/src/impl/dgb/stratum/work_source.cpp
+++ b/src/impl/dgb/stratum/work_source.cpp
@@ -297,9 +297,13 @@ nlohmann::json DGBWorkSource::get_current_work_template() const
     //                  a digishield_next_target()-derived bits would be a
     //                  KNOWN-WRONG value -- the same fabrication the empty
     //                  transactions[] and total_fees=0 avoid. The authoritative
-    //                  bits is the external-daemon GBT value, which is not
-    //                  plumbed into this embedded template path yet; bits stays
-    //                  absent until then. [decision-needed] surfaced to integrator.
+    //                  bits is the external-daemon GBT value. WorkTemplateInputs
+    //                  now carries an optional bits field (template_builder.hpp),
+    //                  so the plumb EXISTS: a daemon-GBT caller or the G1 replay
+    //                  harness sets in.bits and the builder emits it. This
+    //                  embedded Scrypt-only path still supplies none -- truthful
+    //                  absence, identical to previousblockhash -- so bits stays
+    //                  absent here until a daemon source is wired into this path.
     // and the per-connection coinbase (gentx + ShareTracker ref_hash + PPLNS
     // payout map) assembles in build_connection_coinbase() — that output is
     // consensus-bearing and surfaces for an operator tap, not in this field wire.


### PR DESCRIPTION
## What

Adds an optional `bits` field to `WorkTemplateInputs` and emits it from `build_work_template()` via the same truthful-absence conditional already used for `previousblockhash`: **present only when the caller supplies the authoritative external-daemon GBT bits**, omitted otherwise.

The embedded Scrypt-only stratum path (`DGBWorkSource::get_current_work_template`) still supplies **none** — a Scrypt-only header walk cannot reconstruct DGB MultiShield V4 (a global 5-algo window == V37), so it leaves `bits` unset rather than fabricate a known-wrong difficulty. This resolves the `[decision-needed]` annotation that was pinned in that comment block; integrator resolved it in-thread as a mechanical plumb (no operator scope tap).

## Scope / fence

- Fenced to the dgb embedded template path only: `src/impl/dgb/coin/template_builder.hpp` + `src/impl/dgb/stratum/work_source.cpp` (comment-only there). No shared/core, no consensus value change.
- **Non-consensus, shape-only**: no value is derived or altered; `bits` is a caller-supplied pass-through. Mirrors the existing `previousblockhash` field + emit exactly.
- `src/impl/dash` has no embedded template builder yet, so the plumb lands in the canonical dgb mirror; dash inherits the pattern when its work source lands.

## Why

Unblocks the G1 getwork-replay harness to drive the **WITH-bits** differential from the p2pool-oracle daemon-GBT value (harness sets `in.bits` from the golden input). The bits-scoped-OUT G1 replay (2a) remains gated on p2pool substrate route restore, tracked separately.

Merge-gated: awaiting operator push-approval. Not self-merging.