### PR TITLE
ci: per-ref concurrency (cancel-in-progress) on build, CodeQL, coin-matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,15 @@ on:
   pull_request:
     branches: [master, btc-embedded, dash-spv-embedded, dgb/**]
 
+# Concurrency: a newer run on the same ref cancels the stale in-progress
+# one, cutting concurrent load on the shared self-hosted pool (the OOM/
+# oversubscription root cause, not just queue depth). Per-ref group so
+# distinct PRs/branches never cancel each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+
 jobs:
   # ════════════════════════════════════════════════════════════════════════════
   # Test-allowlist drift-guard (fast, no build): every per-coin test executable

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,6 +8,15 @@ on:
   schedule:
     - cron: '30 1 * * 1'   # Weekly on Monday 01:30 UTC
 
+# Concurrency: a newer run on the same ref cancels the stale in-progress
+# one, cutting concurrent load on the shared self-hosted pool (the OOM/
+# oversubscription root cause, not just queue depth). Per-ref group so
+# distinct PRs/branches never cancel each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/coin-matrix.yml
+++ b/.github/workflows/coin-matrix.yml
@@ -17,6 +17,15 @@ on:
   pull_request:
     branches: [master, btc-embedded, dash-spv-embedded, dgb/slice4-skeleton, dgb/pool-pillars-port]
 
+# Concurrency: a newer run on the same ref cancels the stale in-progress
+# one, cutting concurrent load on the shared self-hosted pool (the OOM/
+# oversubscription root cause, not just queue depth). Per-ref group so
+# distinct PRs/branches never cancel each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+
 jobs:
   coin:
     name: ${{ matrix.coin }} smoke (Linux x86_64)


### PR DESCRIPTION
Adds a per-ref concurrency block (cancel-in-progress: true) to the three heavy self-hosted workflows: build.yml (CI), codeql-analysis.yml, coin-matrix.yml.

Why: the shared c2pool-build pool is memory-oversubscribed — a CodeQL job peaked at 24.3G and OOM-killed a runner slot, and a killed job re-queues from zero. Cancelling stale in-progress runs on the same ref when a newer push arrives cuts concurrent load at that root cause, not just queue depth.

Scope: workflow YAML only, 3 files, +27 lines. Per-ref group keys so distinct PRs/branches never cancel each other; only a superseding push to the same ref cancels its own prior run. release.yml and safe-cosmetic-automerge.yml already carry concurrency; attribution-gate and pplns are fast greps, left untouched.

Approved to open by integrator (S8-drain thread). Merge-gated: needs operator merge tap.