### PR TITLE
ci(build): do not cancel-in-progress on push runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,11 @@ on:
 # distinct PRs/branches never cancel each other.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Only cancel superseded PR runs; NEVER cancel a push (master/release/tag)
+  # run - back-to-back merges to master share this ref-group, so cancel-on-push
+  # would kill a merged SHA in-flight rollup before it verifies green (#626
+  # bit the #617 web-static lane exactly this way). PR churn still de-dupes.
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 
 jobs:


### PR DESCRIPTION
## Problem
The build.yml concurrency group is per-ref (`github.workflow-github.ref`). On master every merge is a push to the same ref, so back-to-back merges share one group and `cancel-in-progress: true` cancels the prior merge in-flight rollup before it verifies green.

Evidence: last completed master CI run 28692641464 (#626 merge) shows **Web-static verify = cancelled** while **Windows x86_64 = success** — the newer merge cancelled the older one mid-flight. This is #626 concurrency biting master, the watch-item flagged when #626 landed.

## Fix
Gate cancel-in-progress to non-push events:
```yaml
cancel-in-progress: ${{ github.event_name != 'push' }}
```
- PR churn (rapid re-pushes to a PR ref) still de-dupes and sheds the shared-pool OOM/oversubscription load #626 targeted.
- master / release / tag runs always run to completion, so a merged SHA is actually verified green.

Fenced to the concurrency block; no job or runner changes. Single-file, CI-infra.