### PR TITLE
bch: add pool-node body TUs to embedded body-test link set

### DIFF
--- a/src/impl/bch/test/CMakeLists.txt
+++ b/src/impl/bch/test/CMakeLists.txt
@@ -194,7 +194,18 @@ if(BUILD_TESTING)
             ${CMAKE_SOURCE_DIR}/src/impl/bch/coin/coin_node.cpp
             ${CMAKE_SOURCE_DIR}/src/impl/bch/coin/p2p_connection.cpp
             ${CMAKE_SOURCE_DIR}/src/impl/bch/coin/p2p_node.cpp
-            ${CMAKE_SOURCE_DIR}/src/impl/bch/coin/rpc.cpp)
+            ${CMAKE_SOURCE_DIR}/src/impl/bch/coin/rpc.cpp
+            # M5 pool-node body TUs: NodeImpl out-of-line methods (node.cpp) +
+            # the two p2pool p2p protocol dispatchers (Legacy/Actual
+            # handle_message_* family) + the stratum work source. These define
+            # the NodeImpl::/protocol/BCHWorkSource symbols an embedded body test
+            # references when it constructs the real pool node graph. Mirrors the
+            # shipping c2pool-bch target (src/c2pool/CMakeLists.txt) so the link
+            # set stays consistent; additive, src/impl/bch only, isolation holds.
+            ${CMAKE_SOURCE_DIR}/src/impl/bch/node.cpp
+            ${CMAKE_SOURCE_DIR}/src/impl/bch/protocol_actual.cpp
+            ${CMAKE_SOURCE_DIR}/src/impl/bch/protocol_legacy.cpp
+            ${CMAKE_SOURCE_DIR}/src/impl/bch/stratum/work_source.cpp)
         target_include_directories(bch_${t} PRIVATE ${CMAKE_SOURCE_DIR}/src)
         target_link_libraries(bch_${t} PRIVATE
             core pool sharechain


### PR DESCRIPTION
Fenced, additive, build-only fix for the BCH embedded body-test link set.

## What
The `BCH_EMBEDDED_BODY_TESTS` foreach in `src/impl/bch/test/CMakeLists.txt` compiled only the coin-side TUs (transaction / coin_node / p2p_connection / p2p_node / rpc). It omitted the four pool-node body TUs that define the `NodeImpl` out-of-line methods (`node.cpp`), the Legacy/Actual p2p protocol dispatchers (`protocol_legacy.cpp` / `protocol_actual.cpp`), and the stratum `BCHWorkSource` ctor (`stratum/work_source.cpp`).

Any embedded body test that constructs the real pool-node graph hits undefined vtable/method symbols at link (the classic SOURCES-omission linker signature). This mirrors the four TUs already present in the shipping `c2pool-bch` target (`src/c2pool/CMakeLists.txt`) so the two link sets stay consistent.

## Scope / isolation
Touches only `src/impl/bch/test/CMakeLists.txt`. Additive build-only, single-coin BCH, no shared base / bitcoin_family / src/core, no other-coin tree, no consensus value. Per-coin isolation holds.

## Evidence
COIN_BCH Debug build: all four embedded body test binaries (`bch_embedded_getwork_test`, `bch_embedded_seam_workview_test`, `bch_embedded_block_broadcast_test`, `bch_coin_node_seam_test`) link green; 4/4 ctest pass.

No self-merge — for ci-steward matrix re-run + integrator full-rollup tap.