### PR TITLE
ci(web-static): raise visual-capture nav+render timeouts for loaded self-hosted runner

### DIFF
--- a/web-static/sharechain-explorer/tests/visual/capture.mjs
+++ b/web-static/sharechain-explorer/tests/visual/capture.mjs
@@ -65,8 +65,8 @@ async function capture(mode, outfile) {
     // leaves a non-essential subresource (favicon/image) pending and
     // never fires the load event within the timeout; `networkidle0`
     // never settles because bundled mode opens a persistent SSE conn.
-    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 15000 });
-    await page.waitForSelector('#defrag-canvas', { timeout: 8000 });
+    await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 45000 });
+    await page.waitForSelector('#defrag-canvas', { timeout: 20000 });
     // Generous fixed delay lets both paths complete their initial
     // fetch + render. Deterministic against the mock server (no live
     // data, no SSE pushes).


### PR DESCRIPTION
**Problem.** Web-static verify (`npm run visual`) is flaking RED across multiple in-flight PRs (#628, #625) on self-hosted `actions-runner-5`:
```
TimeoutError: Navigation timeout of 15000 ms exceeded
    at CdpPage.goto (.../puppeteer-core/.../api/Page.js:570)
```
The mock server is **local** (127.0.0.1:18082), so the 15s ceiling is pure CPU starvation on a VM905-saturated runner — not a code regression. Green on an idle runner (#607 migration), TimeoutError under load.

**Fix.** Flake-hardening only, fenced to the visual-capture harness:
- `page.goto(domcontentloaded)` 15000 -> 45000 ms
- `waitForSelector(#defrag-canvas)` 8000 -> 20000 ms

No consensus/product code touched. Restores deterministic web-static green under runner load.

Merge-gated — awaiting operator push-approval.