### PR TITLE
build: Boost.Asio handler-invoke compat shim (conan 1.90 vs legacy system Boost 1.83)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,12 @@ endif()
 include_directories(include)
 include_directories(src)
 
+# Boost.Asio build compat (build-only, no behaviour change): force-include the
+# handler_invoke_helpers shim ahead of every C++ TU so a legacy system Boost
+# leaking boost/asio/impl/system_executor.hpp cannot break the conan-pinned
+# build on any coin, regardless of ccache eviction. See core/boost_asio_compat.hpp.
+add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-include;core/boost_asio_compat.hpp>")
+
 # Make secp256k1 headers available globally (needed by btclibs, impl/)
 if(SECP256K1_INCLUDE_DIRS)
     include_directories(${SECP256K1_INCLUDE_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,12 @@ include_directories(src)
 # handler_invoke_helpers shim ahead of every C++ TU so a legacy system Boost
 # leaking boost/asio/impl/system_executor.hpp cannot break the conan-pinned
 # build on any coin, regardless of ccache eviction. See core/boost_asio_compat.hpp.
-add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-include;core/boost_asio_compat.hpp>")
+# MSVC/Windows carries no legacy *system* Boost under /usr/include, so it has
+# nothing to leak and does not need (or resolve) this force-include. Gating to
+# non-MSVC avoids C1083 on the MSVC path while keeping the Linux/macOS fix.
+if(NOT MSVC)
+  add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-include;core/boost_asio_compat.hpp>")
+endif()
 
 # Make secp256k1 headers available globally (needed by btclibs, impl/)
 if(SECP256K1_INCLUDE_DIRS)

--- a/src/core/boost_asio_compat.hpp
+++ b/src/core/boost_asio_compat.hpp
@@ -1,0 +1,57 @@
+#pragma once
+//
+// core/boost_asio_compat.hpp
+//
+// Build-only compatibility shim for Boost.Asio's removed
+// boost_asio_handler_invoke_helpers namespace. This is NOT a behaviour change.
+//
+// c2pool pins Boost via conan (currently 1.90), which deleted
+// boost/asio/detail/handler_invoke_helpers.hpp together with the
+// boost_asio_handler_invoke_helpers namespace (the asio_handler_invoke hooks
+// were deprecated in Boost 1.79 and dropped thereafter). On build hosts that
+// also carry a legacy *system* Boost (e.g. libboost-dev 1.83 under
+// /usr/include), that older tree's boost/asio/impl/system_executor.hpp can
+// leak onto the include path and still calls
+//     boost_asio_handler_invoke_helpers::invoke(f, f);
+// yielding "'boost_asio_handler_invoke_helpers' has not been declared" when
+// the conan (>= 1.90) headers no longer provide it.
+//
+// This header supplies that namespace's historical *default* (hook-free)
+// invoke so the leaked impl resolves. The body mirrors Boost's own
+// BOOST_ASIO_HAS_HANDLER_HOOKS-disabled path (copy the function, then call
+// it), which is identical to how Boost >= 1.90 dispatches internally. c2pool
+// defines no asio_handler_invoke overloads, so behaviour is unchanged.
+//
+// It is force-included ahead of every C++ translation unit (see the top-level
+// CMakeLists.txt) so all five coins keep building regardless of ccache
+// eviction. Guarded so it stays inert on any Boost that still ships the
+// namespace itself.
+//
+#include <boost/version.hpp>
+
+#if BOOST_VERSION >= 108400
+// Claim Boost's own include guard so that, if the real (legacy) header is
+// reached later in the same TU, it becomes a no-op instead of a redefinition.
+#ifndef BOOST_ASIO_DETAIL_HANDLER_INVOKE_HELPERS_HPP
+#define BOOST_ASIO_DETAIL_HANDLER_INVOKE_HELPERS_HPP
+
+namespace boost_asio_handler_invoke_helpers {
+
+template <typename Function, typename Context>
+inline void invoke(Function& function, Context& /*context*/)
+{
+  Function tmp(function);
+  tmp();
+}
+
+template <typename Function, typename Context>
+inline void invoke(const Function& function, Context& /*context*/)
+{
+  Function tmp(function);
+  tmp();
+}
+
+} // namespace boost_asio_handler_invoke_helpers
+
+#endif // BOOST_ASIO_DETAIL_HANDLER_INVOKE_HELPERS_HPP
+#endif // BOOST_VERSION >= 108400


### PR DESCRIPTION
## What / why

Master is RED: every coin's `core` fails building `addr_store.cpp` on the self-hosted runner (VM905) with:

```
/usr/include/boost/asio/impl/system_executor.hpp:58:5:
error: 'boost_asio_handler_invoke_helpers' has not been declared
```

Root cause is a **mixed-Boost include collision**, not a code regression:

- conan pins **Boost 1.90** (`BOOST_VERSION 109000`), which removed `boost/asio/detail/handler_invoke_helpers.hpp` and the `boost_asio_handler_invoke_helpers` namespace (the `asio_handler_invoke` hooks were deprecated in 1.79, dropped since).
- VM905 also carries a **system Boost 1.83** under `/usr/include`. Its `boost/asio/impl/system_executor.hpp` leaks onto the include path and still calls `boost_asio_handler_invoke_helpers::invoke(...)`, which the conan (>= 1.90) tree no longer declares.

The include chain from the failing TU: conan `boost/asio/system_executor.hpp:714` -> system `/usr/include/boost/asio/impl/system_executor.hpp`. Any `core` TU that pulls asio hits it, so it is latent across all five coins and re-fires on every ccache eviction.

## Fix

`core/boost_asio_compat.hpp` supplies the namespace's historical **default hook-free `invoke`** (copy the function, call it) — identical to how Boost >= 1.90 dispatches internally. It is **force-included** ahead of every C++ TU via a `COMPILE_LANGUAGE:CXX`-gated `add_compile_options` in the top-level `CMakeLists.txt`, so all coins survive cache eviction. Guarded on `BOOST_VERSION >= 108400` and claims Boost's own include guard, so it is inert on any Boost that still ships the namespace.

**Build compat only — no behaviour change.** c2pool defines no `asio_handler_invoke` overloads (verified), so the hook-free default is behaviourally equivalent.

## Durable follow-up (infra, not this PR)

The lasting cleanup is removing the stray system `libboost-dev` 1.83 from VM905 so the conan pin is the only Boost the build sees. This shim is the cache-eviction-proof safety net requested regardless.

Signed, attribution-clean. Merge-gated — holding for push-approval per Rule 12.
