### PR TITLE
ci(dgb): Phase-B per-coin smoke — pillar gtests

### DIFF
--- a/.github/workflows/dgb-phase-b-smoke.yml
+++ b/.github/workflows/dgb-phase-b-smoke.yml
@@ -1,0 +1,84 @@
+name: DGB Phase-B smoke — per-coin pillar gtests
+
+# ci-steward 2026-07-06. Per-coin smoke for the DGB (DigiByte) lane: assert the
+# DGB Phase-B pillars (block assembly, witness commitment, mempool ingest,
+# won-block reconstruction, header ingest/sample-build, share) build and their
+# gtest suites run green. CI plumbing only — NO consensus knowledge here; the
+# dgb lane owns the targets and the gate script (tests/gates/dgb_phase_b_smoke.sh).
+#
+# Network-free CI arm only: ctest -R the pillar suites BY NAME with an empty-suite
+# guard demanding a positive test count (false-green trap caught in the script).
+#
+# Neutral-skip: on branches/coins without the DGB Phase-B sources the job is a
+# green no-op. Register as a required check only after a confirmed non-hollow
+# green rollup on the runner.
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  dgb-phase-b-smoke:
+    name: DGB Phase-B smoke — per-coin pillar gtests
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check DGB Phase-B source presence
+        id: presence
+        run: |
+          if [ -f "src/impl/dgb/test/block_assembly_test.cpp" ] && [ -f "tests/gates/dgb_phase_b_smoke.sh" ]; then
+            echo "exists=1" >> "$GITHUB_OUTPUT"
+            echo "::notice::DGB Phase-B sources present — running per-coin smoke."
+          else
+            echo "exists=0" >> "$GITHUB_OUTPUT"
+            echo "::notice::DGB Phase-B sources absent on this branch — neutral skip."
+          fi
+
+      - name: Install system dependencies
+        if: steps.presence.outputs.exists == '1' && runner.environment == 'github-hosted'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends g++ cmake make libleveldb-dev libsecp256k1-dev
+
+      - uses: actions/setup-python@v6
+        if: steps.presence.outputs.exists == '1' && runner.environment == 'github-hosted'
+        with: { python-version: '3.12' }
+
+      - name: Install Conan 2
+        if: steps.presence.outputs.exists == '1'
+        run: |
+          if [ "${{ runner.environment }}" = "github-hosted" ]; then
+            pip install "conan>=2.0,<3.0"
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          else
+            conan --version   # pre-provisioned at /usr/local/bin on self-hosted
+          fi
+
+      - name: Detect Conan profile
+        if: steps.presence.outputs.exists == '1'
+        run: |
+          conan profile detect --force
+          sed -i 's/compiler.cppstd=.*/compiler.cppstd=20/' "$(conan profile path default)"
+
+      - name: Restore Conan cache
+        if: steps.presence.outputs.exists == '1'
+        uses: actions/cache@v5
+        with:
+          path: ~/.conan2
+          key: conan2-ubuntu24-gcc13-dgb-smoke-${{ hashFiles('conanfile.txt') }}
+          restore-keys: |
+            conan2-ubuntu24-gcc13-dgb-smoke-
+            conan2-ubuntu24-gcc13-
+
+      - name: Clean stale build dir (self-hosted workspace is reused)
+        if: steps.presence.outputs.exists == '1' && runner.environment != 'github-hosted'
+        run: rm -rf build_dgb_smoke
+
+      - name: Run DGB Phase-B smoke (dgb-lane entrypoint)
+        if: steps.presence.outputs.exists == '1'
+        env:
+          BUILD_DIR: ${{ github.workspace }}/build_dgb_smoke
+        run: bash tests/gates/dgb_phase_b_smoke.sh

--- a/tests/gates/dgb_phase_b_smoke.sh
+++ b/tests/gates/dgb_phase_b_smoke.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# DGB Phase-B per-coin smoke (CI entrypoint). ci-steward 2026-07-06.
+# Fenced: workflow + this entrypoint over EXISTING dgb Phase-B gtest targets —
+# no consensus knowledge, no coin-matrix.yml / build.yml / CMake edits (PR #47
+# source guard stays untouched). Mirrors the dash-gate-g3a template.
+#
+# Default arm (network-free, always on): build the dgb Phase-B pillar targets
+# and run their gtest suites BY NAME via ctest -R, with a false-green guard
+# demanding a parsed positive test count (wrong-CWD ctest prints
+# "No tests were found!!!" and EXITS 0 — that trap is caught here).
+# Deterministic: exit 0 = pass; nonzero = failure / hollow run.
+set -euo pipefail
+
+GATE="DGB Phase-B smoke"
+# Phase-B pillars: block assembly, witness commitment, mempool ingest, won-block
+# reconstruction, header ingest/sample-build, and the share pillar.
+TEST_REGEX="^(DgbBlockAssembly|DgbWitnessCommitment|MempoolIngest|DgbReconstructWonBlock|HeaderIngest|CompactToTarget|MakeHeaderSample|DGB_share_test|WorkRefHashAssembler)\."
+TARGETS=(dgb_share_test dgb_block_assembly_test dgb_witness_commitment_test dgb_mempool_ingest_test dgb_reconstruct_won_block_test dgb_header_ingest_test dgb_header_sample_build_test)
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BUILD_DIR="${BUILD_DIR:-$REPO_ROOT/build}"
+
+# 1. Configure (conan + cmake) only if the CI cache is cold.
+if [ ! -f "$BUILD_DIR/CMakeCache.txt" ]; then
+  echo "[$GATE] no build dir at $BUILD_DIR — configuring (conan + cmake)"
+  conan install "$REPO_ROOT" --build=missing --output-folder="$BUILD_DIR" --settings=build_type=Release
+  cmake -S "$REPO_ROOT" -B "$BUILD_DIR" \
+    -DCMAKE_TOOLCHAIN_FILE="$BUILD_DIR/conan_toolchain.cmake" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_TESTING=ON
+fi
+cmake --build "$BUILD_DIR" --target "${TARGETS[@]}" -j"$(nproc)"
+
+# 2. Run from build/ (false-green trap: wrong CWD prints "No tests were found!!!"
+#    and EXITS 0).
+set +e
+OUT="$(cd "$BUILD_DIR" && ctest -R "$TEST_REGEX" --output-on-failure 2>&1)"
+RC=$?
+set -e
+echo "$OUT"
+
+# 3. Empty-suite guard: demand a positive test count actually ran.
+if grep -q "No tests were found" <<<"$OUT"; then
+  echo "[$GATE] FAIL — hollow run: 0 tests matched $TEST_REGEX" >&2
+  exit 1
+fi
+N="$(grep -oE "out of [0-9]+" <<<"$OUT" | grep -oE "[0-9]+" | tail -1)"
+if [ -z "${N:-}" ] || [ "$N" -lt 1 ]; then
+  echo "[$GATE] FAIL — no positive test count parsed" >&2
+  exit 1
+fi
+if [ "$RC" -ne 0 ]; then
+  echo "[$GATE] FAIL — ctest exit $RC ($N tests)" >&2
+  exit "$RC"
+fi
+echo "[$GATE] PASS — $N dgb Phase-B pillar assertions green"

--- a/tests/gates/dgb_phase_b_smoke.sh
+++ b/tests/gates/dgb_phase_b_smoke.sh
@@ -27,7 +27,8 @@ if [ ! -f "$BUILD_DIR/CMakeCache.txt" ]; then
   cmake -S "$REPO_ROOT" -B "$BUILD_DIR" \
     -DCMAKE_TOOLCHAIN_FILE="$BUILD_DIR/conan_toolchain.cmake" \
     -DCMAKE_BUILD_TYPE=Release \
-    -DBUILD_TESTING=ON
+    -DBUILD_TESTING=ON \
+    -DCOIN_DGB=ON
 fi
 cmake --build "$BUILD_DIR" --target "${TARGETS[@]}" -j"$(nproc)"
 


### PR DESCRIPTION
Per-coin smoke for the DGB lane: builds the Phase-B pillar targets (block assembly, witness commitment, mempool ingest, won-block reconstruction, header ingest/sample-build, share) and runs their gtest suites by name via ctest -R with a false-green empty-suite guard. Network-free CI arm only.

Fenced: workflow + tests/gates/dgb_phase_b_smoke.sh entrypoint over EXISTING dgb targets — no coin-matrix.yml / build.yml / CMake edits; PR #47 source guard untouched. Presence-gated on the DGB sources -> neutral-skip on branches/coins lacking them.

Review-gated: no self-merge. Awaiting a confirmed non-hollow green rollup on the self-hosted runner, then operator push-approval.