### PR TITLE
ci(coin-matrix): clear orphaned conan download tempfiles on self-hosted

### DIFF
--- a/.github/workflows/coin-matrix.yml
+++ b/.github/workflows/coin-matrix.yml
@@ -89,6 +89,15 @@ jobs:
         if: steps.presence.outputs.exists == '1' && runner.environment != 'github-hosted'
         run: rm -rf build_${{ matrix.coin }}
 
+      - name: Clear orphaned Conan download tempfiles (self-hosted cache is reused)
+        if: steps.presence.outputs.exists == '1' && runner.environment != 'github-hosted'
+        # An interrupted or racing conan download can leave a partial conan_package.tgz
+        # in ~/.conan2 that makes the next `conan install` abort with
+        # "the file to download already exists". Delete these staging archives so a
+        # missing binary package can be re-fetched cleanly; extracted packages are untouched.
+        run: |
+          find ~/.conan2/p -type f \( -name 'conan_package.tgz' -o -name 'conan_sources.tgz' \) -delete 2>/dev/null || true
+
       - name: Conan install
         if: steps.presence.outputs.exists == '1'
         run: |


### PR DESCRIPTION
## What
Adds a self-hosted-gated pre-`conan install` step in coin-matrix.yml that deletes orphaned `conan_package.tgz`/`conan_sources.tgz` staging archives from the reused `~/.conan2` cache.

## Why
Master tip `465ded92` **bch smoke** went RED with:
```
boost/1.90.0: Main binary package ... missing
ERROR: the file to download already exists: /home/ubuntu/.conan2/p/boost.../d/conan_package.tgz
```
An interrupted/racing conan download leaves a partial staging tgz behind; the next `conan install` refuses to overwrite it and aborts. This is a self-hosted **environment** race, not a code regression — but re-running alone cannot clear it, since the tempfile persists on the runner across jobs. Recurrence warrants hardening rather than perpetual re-runs.

## Scope
- Single file, additive-only; gated `runner.environment != github-hosted` (mirrors the existing "Clean stale build dir" step).
- Deletes only download *staging* archives; extracted binary packages and recipes are untouched, so a present package is not re-downloaded.

Merge-gated: awaiting operator push-approval.