### PR TITLE
ci(bch): wire G3b genuine Upgrade9 activation gate into CI

### DIFF
--- a/.github/workflows/bch-gate-g3b-genuine-activation.yml
+++ b/.github/workflows/bch-gate-g3b-genuine-activation.yml
@@ -1,0 +1,93 @@
+name: BCH gate G3b — genuine Upgrade9 activation
+
+# ci-steward 2026-07-07. CI plumbing only — NO consensus knowledge here. The BCH
+# lane owns the harness, the CHECK-companions, and the gate script; this workflow
+# just runs the canonical entrypoint tests/gates/bch_g3b_genuine_activation.sh,
+# which self-configures (conan + cmake -DCOIN_BCH=ON, override via BUILD_DIR) and
+# runs two arms:
+#   * CI arm (network-free, always on): the pool-side activation semantics via the
+#     bch_g2_ratchet_gate_kat / bch_cashtokens_transparency / bch_coinbase_author_kat
+#     targets, with a false-green guard demanding the full expected test count ran.
+#   * Live regtest arm (opt-in): runs only when BCH_UPGRADE9_HEIGHT points at an
+#     isolated regtest BCHN started with -upgrade9activationheight=<N>. Left unset
+#     here — the network-free CI arm carries the gate until the BCH lane wires a
+#     regtest BCHN + secrets into the runner.
+#
+# Mirrors dash-gate-g3a-regtest-block-production.yml. Neutral-skip: on branches
+# predating the G3b entrypoint the job is a green no-op. Register as a required
+# check only after a confirmed non-hollow green rollup (operator-side ruleset).
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  g3b-genuine-activation:
+    name: BCH gate G3b — genuine Upgrade9 activation
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check gate entrypoint presence
+        id: presence
+        run: |
+          if [ -f "tests/gates/bch_g3b_genuine_activation.sh" ]; then
+            echo "exists=1" >> "$GITHUB_OUTPUT"
+            echo "::notice::G3b entrypoint present — running genuine Upgrade9 activation gate."
+          else
+            echo "exists=0" >> "$GITHUB_OUTPUT"
+            echo "::notice::tests/gates/bch_g3b_genuine_activation.sh not on this branch — neutral skip."
+          fi
+
+      - name: Install system dependencies
+        if: steps.presence.outputs.exists == '1' && runner.environment == 'github-hosted'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            g++ cmake make libleveldb-dev libsecp256k1-dev
+
+      - uses: actions/setup-python@v6
+        if: steps.presence.outputs.exists == '1' && runner.environment == 'github-hosted'
+        with: { python-version: '3.12' }
+
+      - name: Install Conan 2
+        if: steps.presence.outputs.exists == '1'
+        run: |
+          if [ "${{ runner.environment }}" = "github-hosted" ]; then
+            pip install "conan>=2.0,<3.0"
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          else
+            conan --version   # pre-provisioned at /usr/local/bin on self-hosted
+          fi
+
+      - name: Detect Conan profile
+        if: steps.presence.outputs.exists == '1'
+        run: |
+          conan profile detect --force
+          sed -i 's/compiler.cppstd=.*/compiler.cppstd=20/' "$(conan profile path default)"
+
+      - name: Restore Conan cache
+        if: steps.presence.outputs.exists == '1'
+        uses: actions/cache@v5
+        with:
+          path: ~/.conan2
+          key: conan2-ubuntu24-gcc13-bch-g3b-${{ hashFiles('conanfile.txt') }}
+          restore-keys: |
+            conan2-ubuntu24-gcc13-bch-g3b-
+            conan2-ubuntu24-gcc13-
+
+      - name: Clean stale build dir (self-hosted workspace is reused)
+        if: steps.presence.outputs.exists == '1' && runner.environment != 'github-hosted'
+        run: rm -rf build_bch_g3b
+
+      - name: Run G3b genuine-activation gate (bch-lane TEST_ENTRYPOINT)
+        if: steps.presence.outputs.exists == '1'
+        env:
+          BUILD_DIR: ${{ github.workspace }}/build_bch_g3b
+          # Live regtest arm stays opt-in: the script runs it only when this points
+          # at an isolated BCHN started with -upgrade9activationheight=<N>. Left
+          # unset — the network-free CI arm carries the gate.
+          BCH_UPGRADE9_HEIGHT: ${{ secrets.BCH_UPGRADE9_HEIGHT }}
+        run: bash tests/gates/bch_g3b_genuine_activation.sh


### PR DESCRIPTION
## What
The BCH G3b entrypoint `tests/gates/bch_g3b_genuine_activation.sh` and its CHECK-companions (bch_g2_ratchet_gate_kat / bch_cashtokens_transparency / bch_coinbase_author_kat) have been in master since the BCH lane landed, but **no workflow invoked them** — so the genuine-activation gate never actually ran. G3a has the same orphaned state; this PR closes the G3b half.

## How
New `.github/workflows/bch-gate-g3b-genuine-activation.yml`, a direct mirror of the proven `dash-gate-g3a-regtest-block-production.yml`:
- self-hosted runner with fork-PR github-hosted fallback (same RCE-safe ternary)
- entrypoint-presence **neutral-skip** (green no-op on branches predating the entrypoint)
- conan2 restore cache keyed `conan2-ubuntu24-gcc13-bch-g3b-`
- script self-configures `-DCOIN_BCH=ON`; `BUILD_DIR=build_bch_g3b`
- **live regtest arm left opt-in** (`BCH_UPGRADE9_HEIGHT` unset) — the network-free CI arm carries the gate; false-green guard demands the full expected test count ran

## Gate registration
CI plumbing only, no consensus surface. **Not** to be registered as a required check until a confirmed non-hollow green rollup — that ruleset entry is operator-side.

No merge requested; review gate.