### PR TITLE
bch: gate work-source donation script on v36 (P2SH) — close recompute/GENTX residual

### DIFF
--- a/src/impl/bch/pool_entrypoint.hpp
+++ b/src/impl/bch/pool_entrypoint.hpp
@@ -164,10 +164,16 @@ inline void standup_pool_run(boost::asio::io_context& ioc,
     work_source->set_best_share_hash_fn(
         [&node]() -> uint256 { return node.best_share_hash(); });
 
-    // Initial donation matches the cold-start create version (35 -> P2PK). A
-    // ratchet-driven refresh to the COMBINED P2SH on v36 activation is the same
-    // follow-up slice as pplns_fn/ref_hash_fn.
-    work_source->set_donation_script(PoolConfig::get_donation_script(35));
+    // Work-source donation MUST match the authored share version. Shares are
+    // authored v36-native (result.share_version = 36 above, verify-preimage
+    // fix), and generate_share_transaction rebuilds the coinbase donation with
+    // get_donation_script(36) -> COMBINED P2SH. Serving the v35 P2PK here made
+    // the miner-hashed template coinbase carry a 67-byte P2PK donation while
+    // verify rebuilt a 23-byte P2SH donation -> the donation output diverged at
+    // byte offset 104 on every non-genesis share -> 100% recompute/GENTX
+    // mismatch. Gate on 36 to match. (Dynamic ratchet-tracking generalises this
+    // once the staged v35+v36 dual-pool migration lands.)
+    work_source->set_donation_script(PoolConfig::get_donation_script(36));
 
     // -- ref_hash_fn: peer-verifiable share commitment (G2 conform) --------
     // Without this the local-author coinbase carries NO p2pool OP_RETURN


### PR DESCRIPTION
Stacks on #652 (bch/v36-author-verify-preimage). Fences to src/impl/bch/pool_entrypoint.hpp only.

## Root (byte-diff)
Shares author v36-native (result.share_version=36), and generate_share_transaction rebuilds the coinbase donation with get_donation_script(36) -> 23-byte COMBINED P2SH. The work source still served get_donation_script(35) -> 67-byte forrestv P2PK. The miner-hashed template coinbase and the verify-side rebuild therefore diverged at the donation output:

- First diverging byte offset 104 (donation scriptPubKey length byte)
- author/miner cb: 0x43 -> P2PK 4104..ac (67B, forrestv legacy)
- verify rebuild: 0x17 -> P2SH a9148c6272..87 (23B, v36 COMBINED)

=> 100 percent recompute/GENTX mismatch on every non-genesis share (genesis is 100-percent-donation single-output, structurally different).

## Fix
One line: work_source->set_donation_script(get_donation_script(36)) to match authored version.

## Evidence (regtest grind, demo floors 207fffff/1d00ffff)
- 12/12 accepted, 0 rejected
- GENTX-MISMATCH 10 -> 0
- HASHLINK-CMP 11 YES / 1 NO (the NO is genesis, expected)
- chain==verified 12/12 (1:1)
- author [ACTUAL-CB] now byte-matches verify [COINBASE-HEX] (both P2SH donation)

Attribution-clean, GPG-signed 285EFE76. NOT self-merged — operator merge-tap.