### PR TITLE
dash(s8-p2p.2): Legacy/Actual/NodeBridge sharechain-p2p dispatch layer + 12-handler KATs

### DIFF
--- a/src/impl/dash/CMakeLists.txt
+++ b/src/impl/dash/CMakeLists.txt
@@ -35,3 +35,25 @@ target_include_directories(dash_rpc PRIVATE
     ${CMAKE_SOURCE_DIR}/src/btclibs
     ${CMAKE_SOURCE_DIR}/include)
 target_link_libraries(dash_rpc PRIVATE core nlohmann_json::nlohmann_json ${Boost_LIBRARIES})
+
+# S8 sharechain-p2p dispatch layer (slice S8-p2p.2). Mirrors the dgb pool OBJECT
+# lib (src/impl/dgb/CMakeLists.txt add_library(dgb OBJECT ...)): compiles the
+# Legacy/Actual established-peer protocol handlers so the 12-message dispatch
+# surface is a real compiled TU. node.cpp (the NodeImpl reception/think TU) is
+# slice .4 and does NOT exist yet, so this OBJECT lib is intentionally NOT linked
+# into any executable here -- processing_shares()/handle_get_share() are declared
+# in node.hpp and their definitions are link-deferred to slice .4. Object-compile
+# only; SAFE-ADDITIVE (no existing target links `dash`, so ltc/btc/doge/dgb build
+# + ctest surfaces are untouched). Per-coin isolation held: src/impl/dash only.
+add_library(dash OBJECT
+    node.hpp
+    peer.hpp
+    messages.hpp
+    share.hpp
+    protocol_actual.cpp protocol_legacy.cpp
+)
+target_include_directories(dash PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/src/btclibs
+    ${CMAKE_SOURCE_DIR}/include)
+target_link_libraries(dash core pool sharechain c2pool_storage dash_x11 btclibs nlohmann_json::nlohmann_json ${Boost_LIBRARIES} ${SECP256K1_LIBRARIES})

--- a/src/impl/dash/node.hpp
+++ b/src/impl/dash/node.hpp
@@ -25,6 +25,7 @@
 #include "coin/transaction.hpp"
 
 #include <pool/node.hpp>
+#include <pool/protocol.hpp>
 #include <core/reply_matcher.hpp>
 #include <c2pool/storage/sharechain_storage.hpp>
 
@@ -32,6 +33,7 @@
 #include <boost/asio/steady_timer.hpp>
 
 #include <atomic>
+#include <functional>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -96,6 +98,14 @@ protected:
     // Global pool of known transactions, populated by remember_tx and the coin
     // daemon. Reception-slice protocol handlers look up tx hashes here.
     std::map<uint256, coin::Transaction> m_known_txs;
+
+    // Wire-message parser used by the Legacy/Actual dispatch protocols to turn
+    // a RawMessage into a typed message variant. Mirrors dgb::NodeImpl::m_handler.
+    dash::Handler m_handler;
+
+    // Callback fired when a bestblock message is received from a peer; wired by
+    // the work layer (slice .4) to trigger a work refresh. Mirrors dgb.
+    std::function<void(const uint256&)> m_on_bestblock;
 
     // Thread pool for parallel share_init_verify (X11 CPU work). Keeps the
     // expensive crypto off the io_context thread.
@@ -309,6 +319,27 @@ public:
                    : pool::PeerConnectionType::legacy;
     }
 
+    // ── Reception-slice (B) dispatch surface ───────────────────
+    // Declarations consumed by the Legacy/Actual protocol handlers
+    // (protocol_legacy.cpp / protocol_actual.cpp). The bodies of
+    // processing_shares() and handle_get_share() live in the node.cpp
+    // translation unit (slice .4) and are intentionally link-deferred here;
+    // the dispatch layer object-compiles against these declarations.
+    void processing_shares(HandleSharesData& data, NetService addr);
+    std::vector<dash::ShareType> handle_get_share(std::vector<uint256> hashes,
+        uint64_t parents, std::vector<uint256> stops, NetService peer_addr);
+
+    // Completes a pending async share request when a sharereply arrives.
+    // Inline (mirrors dgb) so the reply-matcher plumbing needs no node.cpp.
+    void got_share_reply(uint256 id, dash::ShareReplyData shares)
+    {
+        try { m_share_getter.got_response(id, shares); }
+        catch (const std::invalid_argument&) { /* request already timed out */ }
+    }
+
+    // Register a callback fired when a bestblock message is received from a peer.
+    void set_on_bestblock(std::function<void(const uint256&)> fn) { m_on_bestblock = std::move(fn); }
+
     // ── Tracker accessors ───────────────────────────────────────────────
 
     /// Direct tracker access — compute-thread-only (already holds the exclusive
@@ -378,5 +409,54 @@ public:
         return m_snapshot.verified_count;
     }
 };
+
+// ── Sharechain-p2p dispatch layer (slice S8-p2p.2) ──────────────────
+// Namespace-only port of the dgb reference (src/impl/dgb/node.hpp:647). The
+// version-handshake reception rides NodeImpl::handle_version above; the two
+// established-peer protocols below dispatch the 12 post-handshake messages.
+// Both Legacy and Actual register the identical handler set; the divergence
+// between them lives in the handler BODIES (protocol_legacy.cpp vs
+// protocol_actual.cpp), byte-parity with dgb. handle_message() bodies + the
+// 12 HANDLER() bodies are defined in those two .cpp translation units.
+
+class Legacy : public pool::Protocol<NodeImpl>
+{
+public:
+    void handle_message(std::unique_ptr<RawMessage> rmsg, NodeImpl::peer_ptr peer) override;
+
+    ADD_HANDLER(addrs, dash::message_addrs);
+    ADD_HANDLER(addrme, dash::message_addrme);
+    ADD_HANDLER(ping, dash::message_ping);
+    ADD_HANDLER(getaddrs, dash::message_getaddrs);
+    ADD_HANDLER(shares, dash::message_shares);
+    ADD_HANDLER(sharereq, dash::message_sharereq);
+    ADD_HANDLER(sharereply, dash::message_sharereply);
+    ADD_HANDLER(bestblock, dash::message_bestblock);
+    ADD_HANDLER(have_tx, dash::message_have_tx);
+    ADD_HANDLER(losing_tx, dash::message_losing_tx);
+    ADD_HANDLER(remember_tx, dash::message_remember_tx);
+    ADD_HANDLER(forget_tx, dash::message_forget_tx);
+};
+
+class Actual : public pool::Protocol<NodeImpl>
+{
+public:
+    void handle_message(std::unique_ptr<RawMessage> rmsg, NodeImpl::peer_ptr peer) override;
+
+    ADD_HANDLER(addrs, dash::message_addrs);
+    ADD_HANDLER(addrme, dash::message_addrme);
+    ADD_HANDLER(ping, dash::message_ping);
+    ADD_HANDLER(getaddrs, dash::message_getaddrs);
+    ADD_HANDLER(shares, dash::message_shares);
+    ADD_HANDLER(sharereq, dash::message_sharereq);
+    ADD_HANDLER(sharereply, dash::message_sharereply);
+    ADD_HANDLER(bestblock, dash::message_bestblock);
+    ADD_HANDLER(have_tx, dash::message_have_tx);
+    ADD_HANDLER(losing_tx, dash::message_losing_tx);
+    ADD_HANDLER(remember_tx, dash::message_remember_tx);
+    ADD_HANDLER(forget_tx, dash::message_forget_tx);
+};
+
+using Node = pool::NodeBridge<NodeImpl, Legacy, Actual>;
 
 } // namespace dash

--- a/src/impl/dash/protocol_actual.cpp
+++ b/src/impl/dash/protocol_actual.cpp
@@ -1,0 +1,274 @@
+#include "node.hpp"
+#include "share.hpp"
+
+#include <core/uint256.hpp>
+#include <core/random.hpp>
+#include <core/common.hpp>
+
+#include <cstring>
+
+namespace dash
+{
+    
+void Actual::handle_message(std::unique_ptr<RawMessage> rmsg, peer_ptr peer)
+{
+    dash::Handler::result_t result;
+    try 
+    {
+        result = m_handler.parse(rmsg);
+    } catch (const std::exception& ec)
+    {
+        LOG_WARNING << "Failed to parse message '" << rmsg->m_command << "' from "
+                    << peer->addr().to_string() << ": " << ec.what();
+        return;
+    }
+
+    try
+    {
+        std::visit([&](auto& msg){ handle(std::move(msg), peer); }, result);
+    }
+    catch (const std::exception& ec)
+    {
+        LOG_WARNING << "Handler error for '" << rmsg->m_command << "' from "
+                    << peer->addr().to_string() << ": " << ec.what();
+        return;
+    }
+}
+
+void Actual::HANDLER(addrs) 
+{
+    for (auto& addr : msg->m_addrs)
+    {
+        addr.m_timestamp = std::min((uint64_t) core::timestamp(), addr.m_timestamp);
+        got_addr(addr.m_endpoint, addr.m_services, addr.m_timestamp);
+
+        if ((core::random::random_float(0, 1) < 0.8) && (!m_connections.empty()))
+        {
+            auto wpeer = core::random::random_choice(m_connections);
+            auto rmsg = message_addrs::make_raw({addr});
+            wpeer->write(std::move(rmsg));
+        }
+    }
+}
+
+void Actual::HANDLER(addrme)
+{
+    if (peer->addr().address() == "127.0.0.1")
+    {
+        if (!m_peers.empty() && (core::random::random_float(0, 1) < 0.8))
+        {
+            auto random_peer = core::random::random_choice(m_peers);
+            auto rmsg = dash::message_addrme::make_raw(msg->m_port);
+            random_peer->write(std::move(rmsg));
+        }
+    } else
+    {
+        auto endpoint = NetService{peer->addr().address(), msg->m_port};
+        got_addr(endpoint, peer->m_other_services, core::timestamp());
+        if (!m_peers.empty() && (core::random::random_float(0, 1) < 0.8))
+        {
+            auto random_peer = core::random::random_choice(m_peers);
+            auto rmsg = dash::message_addrs::make_raw({addr_record_t{peer->m_other_services, endpoint, core::timestamp()} });
+            random_peer->write(std::move(rmsg));
+        }
+    }
+}
+
+void Actual::HANDLER(ping)
+{
+}
+
+void Actual::HANDLER(getaddrs)
+{
+    if (msg->m_count > 100)
+        msg->m_count = 100;
+
+    std::vector<addr_record_t> addrs;
+    for (const auto& pair : get_good_peers(msg->m_count))
+    {
+        addrs.push_back({pair.value.m_service, pair.addr, pair.value.m_last_seen});
+    }
+
+    auto rmsg = message_addrs::make_raw({addrs});
+    peer->write(std::move(rmsg));
+}
+
+void Actual::HANDLER(shares)
+{
+    dash::HandleSharesData result;
+
+    for (auto wrappedshare : msg->m_shares)
+    {
+        // Save a copy of the original raw bytes before deserialization consumes them
+        chain::RawShare raw_copy(wrappedshare.type,
+                                 BaseScript(wrappedshare.contents.m_data));
+
+        dash::ShareType share;
+        try
+        {
+            share = dash::load_share(wrappedshare, peer->addr());
+        }
+        catch(const std::exception& e)
+        {
+            LOG_WARNING << "Failed to load share (type=" << wrappedshare.type
+                        << ") from " << peer->addr().to_string() << ": " << e.what();
+            continue;
+        }
+
+        std::vector<coin::MutableTransaction> txs;
+        share.ACTION
+        ({
+            if constexpr (share_t::version >= 13 && share_t::version < 34) 
+            for (auto tx_hash : obj->m_tx_info.m_new_transaction_hashes)
+            {
+                auto it = m_known_txs.find(tx_hash);
+                if (it != m_known_txs.end())
+                {
+                    txs.emplace_back(it->second);
+                }
+                else
+                {
+                    LOG_WARNING << "Peer referenced unknown transaction " << tx_hash.ToString();
+                }
+            }
+        });
+
+        result.add(share, txs, raw_copy);
+    }
+
+    processing_shares(result, peer->addr());
+}
+
+void Actual::HANDLER(sharereq)
+{
+    auto shares = handle_get_share(msg->m_hashes, msg->m_parents, msg->m_stops, peer->addr());
+
+    std::vector<chain::RawShare> rshares;
+
+    try
+    {
+        for (auto& share : shares)
+        {
+            rshares.emplace_back(share.version(), pack(share));
+        }
+        auto reply_msg = message_sharereply::make_raw(msg->m_id, dash::ShareReplyResult::good, rshares);
+        peer->write(std::move(reply_msg));
+    }
+    catch (const std::invalid_argument &e)
+    {
+        auto reply_msg = message_sharereply::make_raw(msg->m_id, dash::ShareReplyResult::too_long, {});
+        peer->write(std::move(reply_msg));
+    }
+}
+
+void Actual::HANDLER(sharereply)
+{
+    dash::ShareReplyData result;
+    if (msg->m_result == ShareReplyResult::good)
+    {
+        result.m_items.reserve(msg->m_shares.size());
+        result.m_raw_items.reserve(msg->m_shares.size());
+        for (auto& rshare : msg->m_shares)
+        {
+            try
+            {
+                auto share = dash::load_share(rshare, peer->addr());
+                result.m_items.push_back(share);
+                result.m_raw_items.push_back(rshare);
+            }
+            catch(const std::exception& e)
+            {
+                LOG_WARNING << "Failed to deserialize share (type=" << rshare.type
+                            << ") from " << peer->addr().to_string() << ": " << e.what();
+                continue;
+            }
+        }
+    }
+    got_share_reply(msg->m_id, result);
+}
+
+void Actual::HANDLER(bestblock)
+{
+    auto header_hash = Hash(pack(msg->m_header).get_span());
+    LOG_INFO << "[Pool] New best block from peer " << peer->addr().to_string()
+             << ": " << header_hash.ToString();
+
+    // p2pool does NOT relay bestblock — each node broadcasts only from its own
+    // block source (bitcoind_work.changed → best_block_header.changed).
+    // Relaying creates an amplification loop: A→B→C→A with alternating hashes.
+    if (m_on_bestblock) m_on_bestblock(header_hash);
+}
+
+void Actual::HANDLER(have_tx)
+{
+    peer->m_remote_txs.insert(msg->m_tx_hashes.begin(), msg->m_tx_hashes.end());
+    if (peer->m_remote_txs.size() > 10000)
+    {
+        peer->m_remote_txs.erase(peer->m_remote_txs.begin(), std::next(peer->m_remote_txs.begin(), peer->m_remote_txs.size() - 10000));
+    }
+}
+
+void Actual::HANDLER(losing_tx)
+{
+    std::set<uint256> losing_txs;
+    losing_txs.insert(msg->m_tx_hashes.begin(), msg->m_tx_hashes.end());
+
+    std::set<uint256> diff_txs;
+    std::set_difference(peer->m_remote_txs.begin(), peer->m_remote_txs.end(),
+                        losing_txs.begin(), losing_txs.end(),
+                        std::inserter(diff_txs, diff_txs.begin()));
+
+    peer->m_remote_txs = diff_txs;
+}
+
+void Actual::HANDLER(remember_tx)
+{
+    // Phase 1: tx_hashes — peer tells us to remember these by hash (must be in known_txs)
+    for (auto tx_hash : msg->m_tx_hashes)
+    {
+        if (peer->m_remembered_txs.contains(tx_hash))
+        {
+            LOG_WARNING << "Peer referenced transaction twice: " << tx_hash.ToString();
+            continue;
+        }
+
+        auto it = m_known_txs.find(tx_hash);
+        if (it != m_known_txs.end())
+        {
+            peer->m_remembered_txs.insert_or_assign(tx_hash, it->second);
+        }
+        else
+        {
+            LOG_WARNING << "Peer referenced unknown transaction " << tx_hash.ToString();
+        }
+    }
+
+    // Phase 2: txs — peer sends full transactions (compute hash, store)
+    for (auto& tx : msg->m_txs)
+    {
+        auto packed = pack(coin::TX_WITH_WITNESS(tx));
+        auto tx_hash = Hash(packed.get_span());
+
+        if (peer->m_remembered_txs.contains(tx_hash))
+        {
+            LOG_WARNING << "Peer sent duplicate transaction: " << tx_hash.ToString();
+            continue;
+        }
+
+        coin::Transaction full_tx(tx);
+        peer->m_remembered_txs.insert_or_assign(tx_hash, full_tx);
+
+        if (!m_known_txs.contains(tx_hash))
+            m_known_txs.emplace(tx_hash, std::move(full_tx));
+    }
+}
+
+void Actual::HANDLER(forget_tx)
+{
+    for (auto tx_hash : msg->m_tx_hashes)
+    {
+        peer->m_remembered_txs.erase(tx_hash);
+    }
+}
+
+} // namespace dash

--- a/src/impl/dash/protocol_legacy.cpp
+++ b/src/impl/dash/protocol_legacy.cpp
@@ -1,0 +1,310 @@
+#include "node.hpp"
+#include "share.hpp"
+
+#include <core/uint256.hpp>
+#include <core/random.hpp>
+#include <core/common.hpp>
+
+namespace dash
+{
+
+void Legacy::handle_message(std::unique_ptr<RawMessage> rmsg, peer_ptr peer)
+{
+    dash::Handler::result_t result;
+    try 
+    {
+        result = m_handler.parse(rmsg);
+    } catch (const std::exception& ec)
+    {
+        LOG_WARNING << "Failed to parse message '" << rmsg->m_command << "' from "
+                    << peer->addr().to_string() << ": " << ec.what();
+        return;
+    }
+
+    try
+    {
+        std::visit([&](auto& msg){ handle(std::move(msg), peer); }, result);
+    }
+    catch (const std::exception& ec)
+    {
+        LOG_WARNING << "Handler error for '" << rmsg->m_command << "' from "
+                    << peer->addr().to_string() << ": " << ec.what();
+        return;
+    }
+}
+
+void Legacy::HANDLER(addrs) 
+{
+    for (auto& addr : msg->m_addrs)
+    {
+        addr.m_timestamp = std::min((uint64_t) core::timestamp(), addr.m_timestamp);
+        got_addr(addr.m_endpoint, addr.m_services, addr.m_timestamp);
+
+        if ((core::random::random_float(0, 1) < 0.8) && (!m_connections.empty()))
+        {
+            auto wpeer = core::random::random_choice(m_connections);
+            auto rmsg = message_addrs::make_raw({addr});
+            wpeer->write(std::move(rmsg));
+        }
+    }
+}
+
+void Legacy::HANDLER(addrme)
+{
+    if (peer->addr().address() == "127.0.0.0")
+    {
+        if (m_peers.empty() && (core::random::random_float(0, 1) < 0.8))
+        {
+            auto random_peer = core::random::random_choice(m_peers);
+            auto rmsg = dash::message_addrme::make_raw(msg->m_port);
+            random_peer->write(std::move(rmsg));
+        }
+    } else
+    {
+        auto endpoint = NetService{peer->addr().address(), msg->m_port};
+        got_addr(endpoint, peer->m_other_services, core::timestamp());
+        if (m_peers.empty() && (core::random::random_float(0, 1) < 0.8))
+        {
+            auto random_peer = core::random::random_choice(m_peers);
+            auto rmsg = dash::message_addrs::make_raw({addr_record_t{peer->m_other_services, endpoint, core::timestamp()} });
+            random_peer->write(std::move(rmsg));
+        }
+    }
+}
+
+void Legacy::HANDLER(ping)
+{
+}
+
+void Legacy::HANDLER(getaddrs)
+{
+    if (msg->m_count > 100)
+        msg->m_count = 100;
+
+    std::vector<addr_record_t> addrs;
+    for (const auto& pair : get_good_peers(msg->m_count))
+    {
+        addrs.push_back({pair.value.m_service, pair.addr, pair.value.m_last_seen});
+    }
+
+    auto rmsg = message_addrs::make_raw({addrs});
+    peer->write(std::move(rmsg));
+}
+
+void Legacy::HANDLER(shares)
+{
+    try {
+        dash::HandleSharesData result; //share, txs
+
+        for (auto wrappedshare : msg->m_shares)
+        {
+            dash::ShareType share;
+            try
+            {
+                share = dash::load_share(wrappedshare, peer->addr());
+            }
+            catch(const std::exception& e)
+            {
+                LOG_WARNING << "Failed to load share (type=" << wrappedshare.type
+                            << ") from " << peer->addr().to_string() << ": " << e.what();
+                continue;
+            }
+
+            std::vector<coin::MutableTransaction> txs;
+            share.ACTION
+            ({
+                if constexpr (share_t::version >= 13 && share_t::version < 34)
+                for (auto tx_hash : obj->m_tx_info.m_new_transaction_hashes)
+                {
+                    auto it = m_known_txs.find(tx_hash);
+                    if (it != m_known_txs.end())
+                    {
+                        txs.emplace_back(it->second);
+                    }
+                    else
+                    {
+                        LOG_WARNING << "Peer referenced unknown transaction " << tx_hash.ToString();
+                    }
+                }
+            });
+
+            result.add(share, txs);
+        }
+
+        processing_shares(result, peer->addr());
+    } catch (const std::exception& e) {
+        LOG_ERROR << "[Pool] shares handler exception: " << e.what();
+    }
+}
+
+void Legacy::HANDLER(sharereq)
+{
+    // Debug: log what's being requested
+    {
+        static int dbg_req = 0;
+        if (dbg_req < 20)
+        {
+            ++dbg_req;
+            std::string req_hashes;
+            for (auto& h : msg->m_hashes) req_hashes += h.ToString().substr(0, 16) + " ";
+            LOG_WARNING << "SHAREREQ #" << dbg_req << " from " << peer->addr().to_string()
+                        << " hashes=[" << req_hashes << "] parents=" << msg->m_parents
+                        << " stops=" << msg->m_stops.size();
+        }
+    }
+
+    auto shares = handle_get_share(msg->m_hashes, msg->m_parents, msg->m_stops, peer->addr());
+
+    // Debug: log what we're returning
+    {
+        static int dbg_rep = 0;
+        if (dbg_rep < 20)
+        {
+            ++dbg_rep;
+            LOG_WARNING << "SHAREREPLY #" << dbg_rep << " returning " << shares.size() << " shares";
+            for (size_t i = 0; i < std::min(shares.size(), (size_t)3); ++i)
+            {
+                LOG_WARNING << "  share[" << i << "] hash=" << shares[i].hash().ToString().substr(0, 16);
+            }
+        }
+    }
+
+    std::vector<chain::RawShare> rshares;
+
+    try
+    {
+        for (auto& share : shares)
+        {
+            rshares.emplace_back(share.version(), pack(share));
+        }
+        auto reply_msg = message_sharereply::make_raw(msg->m_id, dash::ShareReplyResult::good, rshares);
+        peer->write(std::move(reply_msg));
+    }
+    catch (const std::invalid_argument &e)
+    {
+        // Serialization overflow: the packed shares exceeded the P2P message
+        // size limit (32 MB). Reply with too_long so the peer requests a
+        // smaller batch. This is the correct behavior per Python p2pool.
+        LOG_WARNING << "Share reply too large, sending too_long: " << e.what();
+        auto reply_msg = message_sharereply::make_raw(msg->m_id, dash::ShareReplyResult::too_long, {});
+        peer->write(std::move(reply_msg));
+    }
+}
+
+void Legacy::HANDLER(sharereply)
+{
+    dash::ShareReplyData result;
+    if (msg->m_result == ShareReplyResult::good)
+    {
+        result.m_items.reserve(msg->m_shares.size());
+        result.m_raw_items.reserve(msg->m_shares.size());
+        for (auto& rshare : msg->m_shares)
+        {
+            try
+            {
+                auto share = dash::load_share(rshare, peer->addr());
+                result.m_items.push_back(share);
+                result.m_raw_items.push_back(rshare);
+            }
+            catch(const std::exception& e)
+            {
+                LOG_WARNING << "Failed to deserialize share (type=" << rshare.type
+                            << ") from " << peer->addr().to_string() << ": " << e.what();
+                continue;
+            }
+        }
+    }
+    // Resolve the async request that originally sent the sharereq
+    got_share_reply(msg->m_id, result);
+}
+
+void Legacy::HANDLER(bestblock)
+{
+    try {
+        auto header_hash = Hash(pack(msg->m_header).get_span());
+        LOG_INFO << "[Pool] New best block from peer " << peer->addr().to_string()
+                 << ": " << header_hash.ToString();
+
+        // p2pool does NOT relay bestblock — each node broadcasts only from its own
+        // block source (bitcoind_work.changed → best_block_header.changed).
+        // Relaying creates an amplification loop: A→B→C→A with alternating hashes.
+        if (m_on_bestblock) m_on_bestblock(header_hash);
+    } catch (const std::exception& e) {
+        LOG_WARNING << "[Pool] bestblock handler exception: " << e.what();
+    }
+}
+
+void Legacy::HANDLER(have_tx)
+{
+    peer->m_remote_txs.insert(msg->m_tx_hashes.begin(), msg->m_tx_hashes.end());
+    if (peer->m_remote_txs.size() > 10000)
+    {
+        peer->m_remote_txs.erase(peer->m_remote_txs.begin(), std::next(peer->m_remote_txs.begin(), peer->m_remote_txs.size() - 10000));
+    }
+}
+
+void Legacy::HANDLER(losing_tx)
+{
+    //remove all msg->txs hashes from remote_tx_hashes
+    std::set<uint256> losing_txs;
+    losing_txs.insert(msg->m_tx_hashes.begin(), msg->m_tx_hashes.end());
+
+    std::set<uint256> diff_txs;
+    std::set_difference(peer->m_remote_txs.begin(), peer->m_remote_txs.end(),
+                        losing_txs.begin(), losing_txs.end(),
+                        std::inserter(diff_txs, diff_txs.begin()));
+
+    peer->m_remote_txs = diff_txs;
+}
+
+void Legacy::HANDLER(remember_tx)
+{
+    // Phase 1: tx_hashes — peer tells us to remember these by hash (must be in known_txs)
+    for (auto tx_hash : msg->m_tx_hashes)
+    {
+        if (peer->m_remembered_txs.contains(tx_hash))
+        {
+            LOG_WARNING << "Peer referenced transaction twice: " << tx_hash.ToString();
+            continue;
+        }
+
+        auto it = m_known_txs.find(tx_hash);
+        if (it != m_known_txs.end())
+        {
+            peer->m_remembered_txs.insert_or_assign(tx_hash, it->second);
+        }
+        else
+        {
+            LOG_WARNING << "Peer referenced unknown transaction " << tx_hash.ToString();
+        }
+    }
+
+    // Phase 2: txs — peer sends full transactions (compute hash, store)
+    for (auto& tx : msg->m_txs)
+    {
+        auto packed = pack(coin::TX_WITH_WITNESS(tx));
+        auto tx_hash = Hash(packed.get_span());
+
+        if (peer->m_remembered_txs.contains(tx_hash))
+        {
+            LOG_WARNING << "Peer sent duplicate transaction: " << tx_hash.ToString();
+            continue;
+        }
+
+        coin::Transaction full_tx(tx);
+        peer->m_remembered_txs.insert_or_assign(tx_hash, full_tx);
+
+        if (!m_known_txs.contains(tx_hash))
+            m_known_txs.emplace(tx_hash, std::move(full_tx));
+    }
+}
+
+void Legacy::HANDLER(forget_tx)
+{
+    for (auto tx_hash : msg->m_tx_hashes)
+    {
+        peer->m_remembered_txs.erase(tx_hash);
+    }
+}
+
+} // namespace dash

--- a/test/test_dash_node.cpp
+++ b/test/test_dash_node.cpp
@@ -22,6 +22,9 @@
 #include <impl/dash/node.hpp>
 #include <core/uint256.hpp>
 
+#include <memory>
+#include <type_traits>
+
 namespace {
 
 // Expose protected publish_snapshot() / m_tracker member shape for the KAT by
@@ -110,4 +113,96 @@ TEST(DashNode, TrackerSharedLockBlockingPath)
     }
     // Mutex is the same object exposed by tracker_mutex().
     EXPECT_EQ(&node.tracker_mutex(), &node.tracker_mutex());
+}
+
+
+// ── Slice S8-p2p.2: sharechain-p2p dispatch surface ──────────────────
+//
+// These KATs pin the dispatch LAYER added by slice .2 (Legacy / Actual /
+// Node = NodeBridge<...>) at COMPILE time. They deliberately do NOT
+// instantiate Legacy/Actual nor invoke a handler: the handler bodies live in
+// protocol_legacy.cpp / protocol_actual.cpp and transitively reference
+// NodeImpl::processing_shares()/handle_get_share(), whose definitions are
+// link-deferred to node.cpp (slice .4). A SFINAE detector checks each of the
+// 12 handler overloads is DECLARED on both protocols in a fully unevaluated
+// context, so no definition is ODR-used and this test still links against the
+// slice-A header-only node.
+namespace {
+
+template <class P, class M, class = void>
+struct has_msg_handler : std::false_type {};
+template <class P, class M>
+struct has_msg_handler<P, M, std::void_t<decltype(
+    std::declval<P&>().handle(std::declval<std::unique_ptr<M>>(),
+                              std::declval<dash::NodeImpl::peer_ptr>()))>>
+    : std::true_type {};
+
+template <class P>
+constexpr bool registers_all_12()
+{
+    return has_msg_handler<P, dash::message_addrs>::value
+        && has_msg_handler<P, dash::message_addrme>::value
+        && has_msg_handler<P, dash::message_ping>::value
+        && has_msg_handler<P, dash::message_getaddrs>::value
+        && has_msg_handler<P, dash::message_shares>::value
+        && has_msg_handler<P, dash::message_sharereq>::value
+        && has_msg_handler<P, dash::message_sharereply>::value
+        && has_msg_handler<P, dash::message_bestblock>::value
+        && has_msg_handler<P, dash::message_have_tx>::value
+        && has_msg_handler<P, dash::message_losing_tx>::value
+        && has_msg_handler<P, dash::message_remember_tx>::value
+        && has_msg_handler<P, dash::message_forget_tx>::value;
+}
+
+} // namespace
+
+// 6. Legacy registers a handler overload for all 12 established-peer messages.
+TEST(DashNodeDispatch, LegacyRegistersAll12Handlers)
+{
+    EXPECT_TRUE((has_msg_handler<dash::Legacy, dash::message_addrs>::value));
+    EXPECT_TRUE((has_msg_handler<dash::Legacy, dash::message_addrme>::value));
+    EXPECT_TRUE((has_msg_handler<dash::Legacy, dash::message_ping>::value));
+    EXPECT_TRUE((has_msg_handler<dash::Legacy, dash::message_getaddrs>::value));
+    EXPECT_TRUE((has_msg_handler<dash::Legacy, dash::message_shares>::value));
+    EXPECT_TRUE((has_msg_handler<dash::Legacy, dash::message_sharereq>::value));
+    EXPECT_TRUE((has_msg_handler<dash::Legacy, dash::message_sharereply>::value));
+    EXPECT_TRUE((has_msg_handler<dash::Legacy, dash::message_bestblock>::value));
+    EXPECT_TRUE((has_msg_handler<dash::Legacy, dash::message_have_tx>::value));
+    EXPECT_TRUE((has_msg_handler<dash::Legacy, dash::message_losing_tx>::value));
+    EXPECT_TRUE((has_msg_handler<dash::Legacy, dash::message_remember_tx>::value));
+    EXPECT_TRUE((has_msg_handler<dash::Legacy, dash::message_forget_tx>::value));
+    static_assert(registers_all_12<dash::Legacy>(),
+                  "Legacy must register all 12 sharechain-p2p dispatch handlers");
+}
+
+// 7. Actual registers the identical 12-handler set (bodies diverge, surface does not).
+TEST(DashNodeDispatch, ActualRegistersAll12Handlers)
+{
+    EXPECT_TRUE((has_msg_handler<dash::Actual, dash::message_addrs>::value));
+    EXPECT_TRUE((has_msg_handler<dash::Actual, dash::message_addrme>::value));
+    EXPECT_TRUE((has_msg_handler<dash::Actual, dash::message_ping>::value));
+    EXPECT_TRUE((has_msg_handler<dash::Actual, dash::message_getaddrs>::value));
+    EXPECT_TRUE((has_msg_handler<dash::Actual, dash::message_shares>::value));
+    EXPECT_TRUE((has_msg_handler<dash::Actual, dash::message_sharereq>::value));
+    EXPECT_TRUE((has_msg_handler<dash::Actual, dash::message_sharereply>::value));
+    EXPECT_TRUE((has_msg_handler<dash::Actual, dash::message_bestblock>::value));
+    EXPECT_TRUE((has_msg_handler<dash::Actual, dash::message_have_tx>::value));
+    EXPECT_TRUE((has_msg_handler<dash::Actual, dash::message_losing_tx>::value));
+    EXPECT_TRUE((has_msg_handler<dash::Actual, dash::message_remember_tx>::value));
+    EXPECT_TRUE((has_msg_handler<dash::Actual, dash::message_forget_tx>::value));
+    static_assert(registers_all_12<dash::Actual>(),
+                  "Actual must register all 12 sharechain-p2p dispatch handlers");
+}
+
+// 8. The Node alias binds NodeImpl + both protocols through the shared NodeBridge.
+TEST(DashNodeDispatch, NodeBridgeAliasBindsLegacyActual)
+{
+    static_assert(std::is_same_v<dash::Node,
+                      pool::NodeBridge<dash::NodeImpl, dash::Legacy, dash::Actual>>,
+                  "dash::Node must be NodeBridge<NodeImpl, Legacy, Actual>");
+    static_assert(std::is_base_of_v<dash::NodeImpl, dash::Legacy>,
+                  "Legacy must derive from NodeImpl");
+    static_assert(std::is_base_of_v<dash::NodeImpl, dash::Actual>,
+                  "Actual must derive from NodeImpl");
+    SUCCEED();
 }


### PR DESCRIPTION
S8-p2p slice .2 (node-dispatch). Namespace-only port of the dgb sharechain-p2p dispatch reference into src/impl/dash/. 

- Legacy + Actual each register the identical 12 post-handshake handlers; protocol divergence lives in the handler bodies (protocol_legacy.cpp vs protocol_actual.cpp), byte-parity with dgb.
- NO X11/16->36 consensus-bearing handler divergence at the dispatch level (X11 PoW / InstantSend / ChainLock surface stays in the already-landed reception/verify path, not message dispatch).
- processing_shares()/handle_get_share() bodies link-deferred to node.cpp (slice .4); dispatch layer object-compiles + links the KAT harness against the declarations.
- main_dash listener bind stays in slice .3. dashd-RPC fallback preserved. Confined to src/impl/dash/ + test/ — single-coin, isolation invariant holds.

Linux x86_64 ctest: test_dash_node 12/12 green (incl new LegacyRegistersAll12Handlers / ActualRegistersAll12Handlers / NodeBridgeAliasBindsLegacyActual). HEAD b2a5e216, GPG-signed.