### PR TITLE
dash(s8-p2p.3): bind real sharechain P2P listener in --run

### DIFF
--- a/src/c2pool/CMakeLists.txt
+++ b/src/c2pool/CMakeLists.txt
@@ -288,6 +288,7 @@ add_executable(c2pool-dash main_dash.cpp)
 target_compile_definitions(c2pool-dash PRIVATE C2POOL_VERSION="${C2POOL_GIT_VERSION}")
 target_link_libraries(c2pool-dash
     core pool sharechain
+    dash       # S8-p2p: sharechain pool-node OBJECT lib (NodeImpl + Legacy/Actual dispatch, node.cpp)
     c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage c2pool_difficulty
     dash_x11   # DASH X11 PoW sph reference (BLAKE->...->ECHO), additive static lib
     dash_rpc   # launcher slice-3: external-dashd-RPC client (submitblock fallback)

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -51,6 +51,13 @@
 #include <impl/dash/coin/rpc.hpp>          // dash::coin::NodeRPC — external-dashd submitblock arm (slice 3)
 #include <impl/dash/coin/rpc_conf.hpp>     // dash.conf creds resolution (rpcpassword off argv)
 #include <impl/dash/coin/node_interface.hpp>
+#include <impl/dash/node.hpp>          // dash::Node — sharechain pool-node (NodeBridge<NodeImpl,Legacy,Actual>)
+#include <impl/dash/config.hpp>        // dash::Config (PoolConfig/CoinConfig)
+#include <impl/dash/config_pool.hpp>   // dash::SharechainConfig — P2P_PORT / PREFIX / min-proto SSOT
+#include <core/filesystem.hpp>         // core::filesystem::config_path()
+#include <btclibs/util/strencodings.h> // ParseHexBytes (prefix isolation primitive)
+#include <filesystem>
+#include <system_error>
 #include <impl/dash/coin/block_producer.hpp>  // dash::coin::mine_block / serialize_full_block_hex (slice 5)
 #include <impl/dash/coinbase_builder.hpp>      // dash::coinbase::build / compute_dash_payouts (slice 5)
 #include <impl/dash/params.hpp>                // dash::make_coin_params (already via top include)
@@ -139,9 +146,9 @@ void report_peering(const PeeringConfig& peer, bool testnet)
         std::cout << "[run]   addnode (persistent outbound) -> " << a.to_string() << "\n";
     for (const auto& c : peer.connects)
         std::cout << "[run]   connect (connect-only)        -> " << c.to_string() << "\n";
-    std::cout << "[run] NOTE: peering argv contract + validation are LIVE; the bind/dial\n"
-                 "[run]       wires when the DASH sharechain pool Node (node.hpp/peer/\n"
-                 "[run]       messages/share_tracker, mirror btc::Node) lands -- next S8 leaf.\n";
+    std::cout << "[run] peering argv contract is LIVE and the sharechain pool Node\n"
+                 "[run]       (node.hpp: NodeBridge<NodeImpl,Legacy,Actual>) binds the listener\n"
+                 "[run]       below (S8-p2p.3); reception rides #656/#657.\n";
 }
 
 using dash::coin::compute_dash_block_reward_post_v20;
@@ -352,8 +359,53 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     }
 
     report_peering(peer, testnet);
+
+    // ── S8-p2p.3: bind the REAL sharechain P2P listener ───────────────────
+    // node.cpp reception bodies landed (#656/#657), so dash::Node is now fully
+    // linkable and --run opens an actual socket instead of only echoing the
+    // topology. Mirrors the dgb::Node bring-up (src/c2pool/main_dgb.cpp).
+    dash::SharechainConfig::is_testnet = testnet;
+
+    // Bucket-1 ISOLATION PRIMITIVE: DASH keeps its own net subdir + PREFIX,
+    // per-coin AND per-pool-instance, in v36 and v37 — never standardised.
+    const std::string net_subdir = testnet ? "dash_testnet" : "dash";
+    std::error_code mkdir_ec;
+    std::filesystem::create_directories(
+        core::filesystem::config_path() / net_subdir, mkdir_ec);  // best effort
+
+    dash::Config config(net_subdir);
+    // PREFIX sourced from the frstrtr/p2pool-dash oracle constants (SharechainConfig).
+    config.pool()->m_prefix = ParseHexBytes(dash::SharechainConfig::prefix_hex());
+    config.m_testnet        = testnet;
+    // --addnode (persistent outbound) + --connect (connect-only) both seed the
+    // bootstrap addr store the NodeImpl ctor dials via start_outbound_connections().
+    for (const auto& a : peer.addnodes)  config.pool()->m_bootstrap_addrs.push_back(a);
+    for (const auto& c : peer.connects)  config.pool()->m_bootstrap_addrs.push_back(c);
+
+    dash::Node p2p_node(&ioc, &config);
+
+    // --connect (connect-only, no --listen) suppresses the inbound listener,
+    // matching report_peering() above.
+    const bool connect_only = !peer.connects.empty() && !peer.listen_set;
+    const uint16_t bind_port =
+        peer.listen_port ? peer.listen_port : dash::SharechainConfig::p2p_port();
+    if (!connect_only) {
+        p2p_node.core::Server::listen(bind_port);
+        std::cout << "[run] sharechain peer LISTENING on " << peer.listen_host << ":"
+                  << bind_port
+                  << " — min-proto=" << dash::SharechainConfig::MINIMUM_PROTOCOL_VERSION
+                  << " prefix=" << dash::SharechainConfig::prefix_hex() << "\n";
+    } else {
+        std::cout << "[run] --connect mode: inbound listener suppressed\n";
+    }
+    // addnode/connect targets are registered in the addr store by the NodeImpl
+    // ctor, but ACTIVE outbound dialing rides the download/outbound slice
+    // (dash::NodeImpl carries no start_outbound_connections yet). Inbound
+    // reception — version handshake + the #646 min-proto gate — is live now
+    // via node.cpp (#656/#657).
+
     std::cout << "[run] run-loop up (Ctrl-C to stop); won blocks relay via the\n"
-                 "[run] dashd-RPC submitblock fallback. Embedded P2P relay = S8.\n";
+                 "[run] dashd-RPC submitblock fallback + the embedded sharechain P2P leg.\n";
     ioc.run();
     std::cout << "[run] run-loop stopped cleanly\n";
     return 0;

--- a/src/impl/dash/CMakeLists.txt
+++ b/src/impl/dash/CMakeLists.txt
@@ -39,12 +39,12 @@ target_link_libraries(dash_rpc PRIVATE core nlohmann_json::nlohmann_json ${Boost
 # S8 sharechain-p2p dispatch layer (slice S8-p2p.2). Mirrors the dgb pool OBJECT
 # lib (src/impl/dgb/CMakeLists.txt add_library(dgb OBJECT ...)): compiles the
 # Legacy/Actual established-peer protocol handlers so the 12-message dispatch
-# surface is a real compiled TU. node.cpp (the NodeImpl reception/think TU) is
-# slice .4 and does NOT exist yet, so this OBJECT lib is intentionally NOT linked
-# into any executable here -- processing_shares()/handle_get_share() are declared
-# in node.hpp and their definitions are link-deferred to slice .4. Object-compile
-# only; SAFE-ADDITIVE (no existing target links `dash`, so ltc/btc/doge/dgb build
-# + ctest surfaces are untouched). Per-coin isolation held: src/impl/dash only.
+# surface is a real compiled TU. node.cpp (the NodeImpl reception/think TU) landed
+# with slice .4 (#656/#657: processing_shares()/handle_get_share() bodies), so this
+# OBJECT lib is now fully linkable and slice .3 LINKS it into c2pool-dash to bind a
+# real sharechain P2P listener (src/c2pool/main_dash.cpp run_node). SAFE-ADDITIVE:
+# the ONLY executable linking `dash` is c2pool-dash, so ltc/btc/doge/dgb build +
+# ctest surfaces are untouched. Per-coin isolation held: src/impl/dash only.
 add_library(dash OBJECT
     node.hpp
     peer.hpp


### PR DESCRIPTION
## S8-p2p.3 — listener bind

node.cpp reception bodies landed (#656/#657), so `dash::Node` (`NodeBridge<NodeImpl,Legacy,Actual>`) is now fully linkable. This slice makes `c2pool-dash --run` open a **real** sharechain P2P socket instead of only echoing the topology.

### What changed
- **CMake**: link the `dash` OBJECT lib (protocol_actual/legacy + node.cpp) into `c2pool-dash`; refresh the stale comment that claimed node.cpp does not exist.
- **main_dash.cpp `run_node`**: replace the NOTE-only `report_peering` stub with a real bind — construct `dash::Config` + `dash::Node`, call `core::Server::listen(port)`. Default port 8999 (testnet 18999), `--listen [HOST:]PORT` override, `--connect` suppresses inbound.

### Scope / honesty
- **Inbound reception is live** (version handshake + #646 min-proto gate via node.cpp).
- **Outbound dialing is deferred**: `dash::NodeImpl` has no `start_outbound_connections` yet (rides the download/outbound slice). `--addnode`/`--connect` targets are registered in the addr store but not actively dialed. Labelled in code + logs — not a silent stub.
- **PREFIX** kept as a per-coin isolation primitive (oracle constants). dashd-RPC submitblock fallback untouched.
- SAFE-ADDITIVE: the only executable linking `dash` is `c2pool-dash`; ltc/btc/doge/dgb build+ctest surfaces untouched.

### Verification (Linux x86_64)
- `cmake --build . --target dash` — object lib builds clean.
- `cmake --build . --target c2pool-dash` — links clean.
- `./c2pool-dash --run --testnet --listen 29777` → `ss` shows `LISTEN 0.0.0.0:29777` held by c2pool-dash; log: `Factory started for port: 29777`.

Stacks on master @fa4eef43. Requesting integrator diff + full-CI verify (oracle + Linux ctest, no false-green).