### PR TITLE
config: align testnet P2P port to 19326

### DIFF
--- a/config/c2pool_testnet.yaml
+++ b/config/c2pool_testnet.yaml
@@ -1,11 +1,11 @@
 # C2Pool Litecoin Testnet Configuration
-# P2P: 19338, Stratum: 19327, HTTP: 8080
+# P2P: 19326, Stratum: 19327, HTTP: 8080
 #
 # All keys below are optional. CLI arguments always take priority over YAML values.
 # Unrecognized keys are silently ignored.
 
 # ─── Network ────────────────────────────────────────────────────────────────
-port: 19338                    # P2P p2pool sharechain port (testnet)
+port: 19326                    # P2P p2pool sharechain port (testnet)
 stratum_port: 19327            # Stratum mining port (testnet)
 http_port: 18080               # HTTP/JSON-RPC API port (testnet)
 http_host: "0.0.0.0"          # HTTP bind address

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -1383,7 +1383,7 @@ private:
     peer_info_fn_t m_peer_info_fn;
 
     // Port configuration
-    uint16_t m_p2p_port{9338};
+    uint16_t m_p2p_port{9326};
     uint16_t m_worker_port{9327};
     std::string m_external_ip;
     std::string m_pool_version{"c2pool/0.1.0-alpha"};


### PR DESCRIPTION
Small config cleanup split out from the contabo-gate hardening work.

The runtime P2P default is 9326 mainnet / 19326 testnet, but two stragglers still referenced the old 9338/19338:
- `config/c2pool_testnet.yaml` bound `port: 19338` (functional — testnet users binding from the YAML landed on the wrong P2P port)
- `src/core/web_server.hpp:1385` seeded `m_p2p_port{9338}` in the struct initializer (runtime-overridden, cosmetic — tidied for consistency)

No runtime-behaviour change on hosts that pass the port via CLI/override; fixes YAML-driven testnet binds. Kept separate from the underfill+DOA port per integrator.