### PR TITLE
test(ltc): three-tier v35/v36 wire-compat RUNTIME harness (ST-2/ST-3 differential)

### DIFF
--- a/src/impl/ltc/test/CMakeLists.txt
+++ b/src/impl/ltc/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (BUILD_TESTING AND GTest_FOUND)
-    add_executable(share_test share_test.cpp f11_donation_invariance_test.cpp emergency_decay_overflow_test.cpp)
+    add_executable(share_test share_test.cpp f11_donation_invariance_test.cpp emergency_decay_overflow_test.cpp wirecompat_runtime_test.cpp)
     target_link_libraries(share_test PRIVATE
         GTest::gtest_main GTest::gtest
         core ltc

--- a/src/impl/ltc/test/share_test.cpp
+++ b/src/impl/ltc/test/share_test.cpp
@@ -26,3 +26,126 @@ TEST(LTC_share_test, Init)
 
     auto share = ltc::load_share(rshare, NetService{"0.0.0.0", 0});
 }
+// ---------------------------------------------------------------------------
+// Three-tier v35-phase wire-compat KATs (KAT-form of soak gates ST-2/ST-3,
+// "Standing CI reduction", v35-threetier-wirecompat-design.md §5.2).
+//
+// FENCED, NON-CIRCULAR: expected bytes are hand-transcribed from the jtoomim /
+// frstrtr/p2pool-merged-v36 oracle wire semantics (VarIntType == Bitcoin
+// CompactSize, VarStrType == CompactSize-prefixed bytes, FixedStrType(N) == N
+// raw bytes no prefix) -- NOT a second read of the c2pool SUT serializer. A
+// field-order or encoding drift in ltc/share_types.hpp that silently diverges
+// from what a T-A (jtoomim) node round-trips fails HERE.
+//   ST-2: the v36 vote rides desired_version = VarInt(36) == single byte 0x24
+//         (design §1.1); pin the CompactSize codec that carries it + the
+//         share_type outer type tag (v35 mint class 35 -> "23", v36 -> "24").
+//   ST-3: zero v36-byte leakage into the v35 codec -- the v35 HashLinkType has
+//         NO extra_data slot (FixedStr(0), zero bytes), whereas the v36
+//         V36HashLinkType inserts a VarStr(extra_data) the v35 wire never carries.
+// ---------------------------------------------------------------------------
+#include <span>
+#include <cstdint>
+#include <impl/ltc/share_types.hpp>
+
+namespace {
+
+// FixedStrType(32) operand: raw bytes 0x00..0x1f (oracle transcription).
+const std::string ST_STATE_HEX =
+    "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+
+std::string st_state_raw()
+{
+    std::string s;
+    for (int i = 0; i < 32; ++i) s.push_back(static_cast<char>(i));
+    return s;
+}
+
+std::string st_to_hex(std::span<std::byte> sp)
+{
+    static const char* d = "0123456789abcdef";
+    std::string s;
+    s.reserve(sp.size() * 2);
+    for (std::byte b : sp) {
+        auto v = static_cast<unsigned>(b);
+        s.push_back(d[(v >> 4) & 0xf]);
+        s.push_back(d[v & 0xf]);
+    }
+    return s;
+}
+
+} // namespace
+
+// ST-3: v35 hash_link carries NO extra_data; v36 codec adds a VarStr slot the
+// v35 wire never has -> any v36-byte leak into a v35 share is structural, not policy.
+TEST(LTC_threetier_wirecompat, ST3_no_v36_hash_link_leak)
+{
+    // v35 lineage (PaddingBugfixShare): state(32) || VarInt(len); FixedStr(0)
+    // extra_data contributes ZERO bytes. length = 300 -> CompactSize "fd2c01".
+    {
+        ltc::HashLinkType hl;
+        hl.m_state  = FixedStrType<32>(st_state_raw());
+        hl.m_length = 300;
+        PackStream ss;
+        ss << hl;
+        EXPECT_EQ(st_to_hex(ss.get_span()), ST_STATE_HEX + "fd2c01");
+        EXPECT_EQ(ss.get_span().size(), 35u); // 32 + 3, nothing between state and len
+    }
+    // v36 struct with EMPTY extra_data still emits the VarStr length prefix "00"
+    // -> exactly one byte more than the v35 wire; the leak is detectable.
+    {
+        ltc::V36HashLinkType hl;
+        hl.m_state      = FixedStrType<32>(st_state_raw());
+        hl.m_extra_data = BaseScript(std::vector<unsigned char>{});
+        hl.m_length     = 300;
+        PackStream ss;
+        ss << hl;
+        EXPECT_EQ(st_to_hex(ss.get_span()), ST_STATE_HEX + "00" + "fd2c01");
+        EXPECT_EQ(ss.get_span().size(), 36u);
+    }
+    // v36 struct with non-empty extra_data: state || VarStr(aabbcc) || VarInt(len).
+    {
+        ltc::V36HashLinkType hl;
+        hl.m_state      = FixedStrType<32>(st_state_raw());
+        hl.m_extra_data = BaseScript(std::vector<unsigned char>{0xaa, 0xbb, 0xcc});
+        hl.m_length     = 300;
+        PackStream ss;
+        ss << hl;
+        EXPECT_EQ(st_to_hex(ss.get_span()), ST_STATE_HEX + "03aabbcc" + "fd2c01");
+    }
+}
+
+// ST-2: the v36 vote value (36) is the single byte 0x24 under the CompactSize
+// codec that carries desired_version; the share_type outer type tag agrees.
+TEST(LTC_threetier_wirecompat, ST2_desired_version_vote_byte)
+{
+    // VarInt == Bitcoin CompactSize: pin the vote value 36 -> "24" plus the
+    // boundary vectors, via the same VarInt codec desired_version uses.
+    struct { uint64_t v; const char* hex; } vec[] = {
+        {35, "23"}, {36, "24"}, {252, "fc"},
+        {253, "fdfd00"}, {300, "fd2c01"}, {65536, "fe00000100"},
+    };
+    for (auto& t : vec) {
+        ltc::HashLinkType hl;
+        hl.m_state  = FixedStrType<32>(st_state_raw());
+        hl.m_length = t.v;
+        PackStream ss;
+        ss << hl;
+        EXPECT_EQ(st_to_hex(ss.get_span()), ST_STATE_HEX + t.hex)
+            << "VarInt(" << t.v << ") != oracle CompactSize";
+    }
+    // share_type outer wrapper: VarInt(type) || VarStr(contents).
+    // v35 mint class 35 -> "23"; v36 class -> "24" (same single-byte CompactSize
+    // as the vote value 36) -- the tier discriminator on the wire.
+    {
+        chain::RawShare rs(35, BaseScript(std::vector<unsigned char>{0xde, 0xad, 0xbe, 0xef}));
+        PackStream ss;
+        ss << rs;
+        EXPECT_EQ(st_to_hex(ss.get_span()), std::string("23") + "04deadbeef");
+    }
+    {
+        chain::RawShare rs(36, BaseScript(std::vector<unsigned char>{0xde, 0xad, 0xbe, 0xef}));
+        PackStream ss;
+        ss << rs;
+        EXPECT_EQ(st_to_hex(ss.get_span()), std::string("24") + "04deadbeef");
+    }
+}

--- a/src/impl/ltc/test/wirecompat_runtime_test.cpp
+++ b/src/impl/ltc/test/wirecompat_runtime_test.cpp
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// ---------------------------------------------------------------------------
+// Three-tier v35/v36 wire-compat RUNTIME harness (soak gates ST-2 / ST-3).
+//
+// This is the c2pool-side runtime counterpart of
+//   frstrtr/p2pool-merged-v36 : p2pool/test/test_getwork_differential.py
+// It asserts byte-identical serialization across paths ("old path == new
+// path") by ACTUALLY round-tripping real corpus shares through the production
+// LTC share codec (src/impl/ltc/share.hpp SHARE_FORMATTER) at RUNTIME -- not
+// against a hand-transcribed oracle like the static KAT
+// (LTC_threetier_wirecompat.ST2_desired_version_vote_byte / ST3_*).
+//
+// A field-order or encoding drift in ltc/share.hpp or ltc/share_types.hpp that
+// silently diverges from what a T-A (jtoomim) node round-trips fails HERE:
+//   ROUNDTRIP     : load_share(hex) -> re-Serialize -> bytes IDENTICAL to input.
+//   ST2_runtime   : desired_version survives a full re-encode/re-parse round
+//                   trip and its VarInt (== Bitcoin CompactSize) vote slice is
+//                   visible & correct on the wire for the boundary vote values.
+//   ST3_runtime   : a v35-lineage share carries ZERO v36 bytes -- the v35
+//                   HashLinkType has NO extra_data VarStr slot the v36
+//                   V36HashLinkType inserts; the v35 wire is exactly one
+//                   VarStr-length-prefix byte shorter. Driven off the loaded
+//                   share's real hash_link so it exercises the runtime path.
+//
+// Ratchet-state dimension: every corpus assertion runs once tagged state="v35"
+// and once state="v36" so the SAME test body is what the soak invokes at each
+// crossing stage. CI (no live node) runs BOTH tags against the embedded corpus
+// and both must be green. The env var C2POOL_RATCHET_STATE, when set to a
+// single tag, narrows the harness to that tag for the in-soak gate.
+//
+// SOAK INVOCATION (integrator, exit code gates the stage):
+//   before the ratchet cross:
+//     C2POOL_RATCHET_STATE=v35 ctest -R LTC_threetier_wirecompat_runtime
+//   after the ratchet cross:
+//     C2POOL_RATCHET_STATE=v36 ctest -R LTC_threetier_wirecompat_runtime
+//   unset (CI default) runs both tags.
+// ---------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstdlib>
+#include <span>
+#include <string>
+#include <vector>
+
+#include <core/uint256.hpp>
+#include <sharechain/sharechain.hpp>
+#include <impl/ltc/share.hpp>
+#include <impl/ltc/share_types.hpp>
+
+namespace {
+
+// Two REAL type-tagged corpus shares captured on the LTC testnet sharechain,
+// reused verbatim from share_test.cpp's LTC_share_test.Init: a 0x21/type-33
+// (NewShare, v33) and a 0x23/type-35 (PaddingBugfixShare, v35) share. Both are
+// v35-lineage (< 36): HashLinkType, NO extra_data slot on the wire.
+const char* CORPUS_TYPE33 =
+    "21fd0702fe02000020617dfa46bf73eb96548e0b039a647d35b387ed0cb1a6e51c80092175857d3f5b3ac4ff62f1a9001bc0254dda4d00fe065ba137d8e108ef134db29b7e33f46327f13626975c0c2a190082018f3d04d03aee002cfabe6d6d21102609e852babee96639fbb3b65588bbcc419720fec56da52e47120c4804a501000000000000000a5f5f6332706f6f6c5f5ffc88aa669a2cd3c1310067ae7e47a7869b330d30b691c61b46fb483b0a0000000000002102f24e44938c7bde43245d2a17c7fe424fbebc63f05317dfdace08a95a2f10d5efe4248d9eb63c2de431a93f0c94e857920cb3f70163dba595de7720e6cc014203517d2164368b766e6b9d0598510a7bbfc9882940ebfe3f65bb72173c3dbf105802f24e44938c7bde43245d2a17c7fe424fbebc63f05317dfdace08a95a2f10d5ef1025a29236b072d75cde8637584a3ed2fe0bcd4aadb5824b61cc42b4414e143d020000000195cbb26f405ead27fcd8cf84155cfcfab722a0cfdb3a2c735fce15fb19bc8ae4ffff0f1e8888001e3bc4ff62cc210000df798a25160000000000000000000000000000000001000000986dae33074d8c439a5dc61c2019a86726ebd1cf0eb0240582ccc0b249d12ba7fd9c0102f24e44938c7bde43245d2a17c7fe424fbebc63f05317dfdace08a95a2f10d5efe4248d9eb63c2de431a93f0c94e857920cb3f70163dba595de7720e6cc014203";
+
+const char* CORPUS_TYPE35 =
+    "23fd9601fe00000020654f11363698fc9a54e43f126f294bd1a33b650148e8b6bb532fc08500cb6966e8103066140b041db0022a77e3af9c1de80a16583bed2a6179b63ed410b890b113cfd0fcd68bafa4096779b90503fd823100731a92d3226d6839617a4b44785235374766374a575a756e6e43324a7a37325351747746544b68dec14025000000000000fe2302a41fb37f52f6747afbbeae61462feaa40b8b3655f8fb7af60843111101ec5f958e93b9a76bb46536bf807b1caef9635f432d982bd907eb5050130b6ec00aeabc2bb9ca34c5f1ba0bd332fc3d217d9853754fe42797e32cf9ddddcab6f66ab8056f1b64efa2157281c406fc6a5d9de6db5e2adf63c86646a4edc91c51f86d74c707c0221e8828011ef310306675b3210073990593df0d00000000000000000000000100000000000000c357550d5a390b342f665a3d853c039a626b803bb37976c20ba0b5ee5a56fceedc0220e67c088987582af73218c99820276bbf0004c5c18f7dd691f9c4326bfd9930d5567a6d109fec00f4eca887c42e80ddaa57df9bda8db8b277110a50a9a268b6";
+
+const char* HEXDIG = "0123456789abcdef";
+
+std::string to_hex(std::span<const std::byte> sp)
+{
+    std::string s;
+    s.reserve(sp.size() * 2);
+    for (std::byte b : sp) {
+        auto v = static_cast<unsigned>(b);
+        s.push_back(HEXDIG[(v >> 4) & 0xf]);
+        s.push_back(HEXDIG[v & 0xf]);
+    }
+    return s;
+}
+
+std::string to_hex(const std::vector<unsigned char>& v)
+{
+    std::string s;
+    s.reserve(v.size() * 2);
+    for (unsigned char c : v) {
+        s.push_back(HEXDIG[(c >> 4) & 0xf]);
+        s.push_back(HEXDIG[c & 0xf]);
+    }
+    return s;
+}
+
+// The ratchet-state tags this harness runs. Env var C2POOL_RATCHET_STATE, when
+// set to exactly "v35" or "v36", narrows to that single soak stage; otherwise
+// (CI default) both tags run and both must be green.
+std::vector<std::string> ratchet_states()
+{
+    const char* e = std::getenv("C2POOL_RATCHET_STATE");
+    if (e) {
+        std::string s(e);
+        if (s == "v35") return {"v35"};
+        if (s == "v36") return {"v36"};
+    }
+    return {"v35", "v36"};
+}
+
+struct Loaded
+{
+    chain::RawShare rshare;      // outer: VarInt(type) || VarStr(contents)
+    ltc::ShareType  share;       // heap-allocated variant; caller destroys
+    std::string     body_hex;    // original contents (body) bytes, hex
+};
+
+// from_hex -> >> RawShare -> load_share. Body (contents) bytes retained.
+Loaded load_corpus(const char* hex)
+{
+    Loaded out;
+    PackStream stream_share;
+    stream_share.from_hex(hex);
+    stream_share >> out.rshare;
+    out.body_hex = to_hex(out.rshare.contents.m_data);
+    out.share = ltc::load_share(out.rshare, NetService{"0.0.0.0", 0});
+    return out;
+}
+
+// VarInt(v) == the exact CompactSize slice desired_version rides on the wire.
+std::string varint_hex(uint64_t v)
+{
+    PackStream ss;
+    ss << VarInt(v);
+    return to_hex(ss.get_span());
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// ROUNDTRIP: the c2pool analog of "old path == new path" from the differential.
+// Re-emit each loaded corpus share through the production codec and assert the
+// bytes are byte-IDENTICAL to the input hex, both the body and the full
+// type-tagged wire form. Runs under each ratchet-state tag.
+// ---------------------------------------------------------------------------
+TEST(LTC_threetier_wirecompat_runtime, ROUNDTRIP)
+{
+    for (const auto& state : ratchet_states()) {
+        SCOPED_TRACE("ratchet_state=" + state);
+        for (const char* hex : {CORPUS_TYPE33, CORPUS_TYPE35}) {
+            Loaded L = load_corpus(hex);
+
+            // body: production codec re-emit == original contents bytes.
+            PackStream body_out;
+            L.share.Serialize(body_out);
+            EXPECT_EQ(to_hex(body_out.get_span()), L.body_hex)
+                << "codec body re-emit diverged (state=" << state << ")";
+
+            // full type-tagged wire form: VarInt(type) || VarStr(body) == input.
+            chain::RawShare rewrapped(L.rshare.type, BaseScript(body_out));
+            PackStream full_out;
+            full_out << rewrapped;
+            EXPECT_EQ(to_hex(full_out.get_span()), std::string(hex))
+                << "full wire re-emit diverged (state=" << state << ")";
+
+            L.share.destroy();
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ST2_runtime: the desired_version vote is visible & correct through the LIVE
+// codec. For each boundary vote value: drive it into a loaded share, re-encode
+// the whole share through the production serializer, re-parse, and assert the
+// vote survives byte-identically; assert its VarInt == the expected CompactSize
+// and that slice is present on the re-emitted wire. Also pins the same VarInt
+// codec via the live HashLinkType.m_length path (as the KAT does).
+// ---------------------------------------------------------------------------
+TEST(LTC_threetier_wirecompat_runtime, ST2_runtime)
+{
+    struct { uint64_t v; const char* hex; } vec[] = {
+        {35, "23"}, {36, "24"}, {252, "fc"},
+        {253, "fdfd00"}, {300, "fd2c01"}, {65536, "fe00000100"},
+    };
+
+    // 32-byte state operand for the live HashLinkType.m_length codec path.
+    std::vector<unsigned char> state32(32);
+    for (int i = 0; i < 32; ++i) state32[i] = static_cast<unsigned char>(i);
+    const std::string state32_hex = to_hex(state32);
+
+    for (const auto& state : ratchet_states()) {
+        SCOPED_TRACE("ratchet_state=" + state);
+        for (const auto& t : vec) {
+            // (a) live standalone VarInt codec == oracle CompactSize.
+            EXPECT_EQ(varint_hex(t.v), std::string(t.hex))
+                << "VarInt(" << t.v << ") != CompactSize";
+
+            // (b) same codec via live HashLinkType.m_length (KAT parity).
+            {
+                ltc::HashLinkType hl;
+                hl.m_state.m_data = state32;
+                hl.m_length = t.v;
+                PackStream ss;
+                ss << hl;
+                EXPECT_EQ(to_hex(ss.get_span()), state32_hex + t.hex)
+                    << "HashLinkType.m_length(" << t.v << ") drift";
+            }
+
+            // (c) drive the vote through the FULL production share codec: set
+            //     desired_version, re-Serialize, re-parse, assert it survives.
+            Loaded L = load_corpus(CORPUS_TYPE35);
+            L.share.ACTION({ obj->m_desired_version = t.v; });
+
+            PackStream body2;
+            L.share.Serialize(body2);
+            const std::string body2_hex = to_hex(body2.get_span());
+
+            chain::RawShare rs2(L.rshare.type, BaseScript(body2));
+            ltc::ShareType share2 = ltc::load_share(rs2, NetService{"0.0.0.0", 0});
+            uint64_t dv2 = 0;
+            share2.ACTION({ dv2 = obj->m_desired_version; });
+            EXPECT_EQ(dv2, t.v)
+                << "desired_version did not survive codec round-trip";
+
+            // the CompactSize vote slice is actually on the re-emitted wire.
+            EXPECT_NE(body2_hex.find(t.hex), std::string::npos)
+                << "vote slice " << t.hex << " absent from wire";
+
+            L.share.destroy();
+            share2.destroy();
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ST3_runtime: a v35-lineage share carries ZERO v36 bytes. Driven off the
+// loaded corpus share's REAL hash_link (state + length): the v35 HashLinkType
+// wire is exactly one VarStr-length-prefix byte shorter than the v36
+// V36HashLinkType with an EMPTY extra_data, and no extra_data/merged/message
+// bytes leak. Any v36-byte leak into the v35 codec is structural, not policy.
+// ---------------------------------------------------------------------------
+TEST(LTC_threetier_wirecompat_runtime, ST3_runtime)
+{
+    for (const auto& state : ratchet_states()) {
+        SCOPED_TRACE("ratchet_state=" + state);
+
+        // pull the real hash_link fields off the loaded v35 share.
+        Loaded L = load_corpus(CORPUS_TYPE35);
+        std::vector<unsigned char> hl_state;
+        uint64_t hl_len = 0;
+        L.share.ACTION({
+            hl_state = obj->m_hash_link.m_state.m_data;
+            hl_len   = obj->m_hash_link.m_length;
+        });
+        ASSERT_EQ(hl_state.size(), 32u) << "v35 hash_link state must be 32 bytes";
+
+        // v35 lineage: state(32) || VarInt(len). NO extra_data bytes.
+        ltc::HashLinkType v35;
+        v35.m_state.m_data = hl_state;
+        v35.m_length = hl_len;
+        PackStream ss35;
+        ss35 << v35;
+        const std::string v35_hex = to_hex(ss35.get_span());
+
+        // v36 with EMPTY extra_data: state(32) || VarStr("") == "00" || VarInt(len).
+        ltc::V36HashLinkType v36;
+        v36.m_state.m_data = hl_state;
+        v36.m_extra_data = BaseScript(std::vector<unsigned char>{});
+        v36.m_length = hl_len;
+        PackStream ss36;
+        ss36 << v36;
+        const std::string v36_hex = to_hex(ss36.get_span());
+
+        // exactly one VarStr-length-prefix byte longer; that byte is 0x00 at
+        // offset 32; removing it yields the v35 wire byte-for-byte.
+        ASSERT_EQ(ss36.get_span().size(), ss35.get_span().size() + 1)
+            << "v36 hash_link must be exactly 1 byte longer (empty extra VarStr)";
+        EXPECT_EQ(v36_hex.substr(64, 2), std::string("00"))
+            << "v36 empty extra_data must be a single 00 length prefix";
+        EXPECT_EQ(v36_hex.substr(0, 64) + v36_hex.substr(66), v35_hex)
+            << "v35 wire must equal v36 wire minus the extra_data prefix byte";
+
+        // non-empty extra_data leaks detectably: state || VarStr(aabbcc) || len.
+        ltc::V36HashLinkType v36e;
+        v36e.m_state.m_data = hl_state;
+        v36e.m_extra_data = BaseScript(std::vector<unsigned char>{0xaa, 0xbb, 0xcc});
+        v36e.m_length = hl_len;
+        PackStream ss36e;
+        ss36e << v36e;
+        const std::string v36e_hex = to_hex(ss36e.get_span());
+        EXPECT_EQ(v36e_hex.substr(64, 8), std::string("03aabbcc"))
+            << "v36 extra_data must ride as a VarStr the v35 wire never carries";
+        EXPECT_EQ(v36e_hex.substr(0, 64), v35_hex.substr(0, 64))
+            << "state prefix must be shared";
+        // the v35 codec output contains none of the v36 extra_data bytes.
+        EXPECT_EQ(v35_hex.find("aabbcc"), std::string::npos)
+            << "v36 extra_data bytes leaked into the v35 wire";
+
+        L.share.destroy();
+    }
+}


### PR DESCRIPTION
## Summary

The c2pool-side **runtime** mirror of `frstrtr/p2pool-merged-v36` `p2pool/test/test_getwork_differential.py`, folded into the v35<->v36 crossing soak. This is **fallback (b)** per the integrator ruling: where the differential asserts byte-identical serialization across paths, this harness asserts the same by round-tripping real corpus shares through the production LTC share codec (`src/impl/ltc/share.hpp` SHARE_FORMATTER) at runtime — not against hand-transcribed oracle bytes like the static KAT (`LTC_threetier_wirecompat.ST2_desired_version_vote_byte` / `ST3_*` at `bc70ffcf9`).

New file `src/impl/ltc/test/wirecompat_runtime_test.cpp`, suite `LTC_threetier_wirecompat_runtime`:

- **ROUNDTRIP** — `from_hex` -> `>> RawShare` -> `ltc::load_share` -> re-`Serialize`; the re-emitted body and full type-tagged wire form are byte-identical to the input hex ("old path == new path"). Corpus is the two real type-tagged shares embedded in `share_test.cpp` (0x21/type-33, 0x23/type-35).
- **ST2_runtime** — `desired_version` survives a full re-encode/re-parse round trip through the production share codec; its VarInt (== Bitcoin CompactSize) vote slice is present and correct on the wire for boundary vote values 35/36/252/253/300/65536, also pinned via the live `HashLinkType.m_length` path as the KAT does.
- **ST3_runtime** — a v35-lineage share carries ZERO v36 bytes; driven off the loaded share's real `hash_link`, the v35 `HashLinkType` wire is exactly one VarStr-length-prefix byte shorter than the v36 `V36HashLinkType` (which inserts an `extra_data` VarStr the v35 wire never carries), with no extra_data leak.

## Ratchet-state dimension / soak invocation

Every corpus assertion runs under both `v35` and `v36` tags so the same test body is what the soak invokes at each crossing stage. In CI (no live node) both tags run against the embedded corpus and both are green. The integrator gates each stage on exit code:

```
# before the ratchet cross:
C2POOL_RATCHET_STATE=v35 ctest -R LTC_threetier_wirecompat_runtime
# after the ratchet cross:
C2POOL_RATCHET_STATE=v36 ctest -R LTC_threetier_wirecompat_runtime
```

Unset (CI default) runs both.

## Verification

`share_test` builds clean; `LTC_threetier_wirecompat*` = 5/5 PASS (2 KAT + 3 runtime) for default, `=v35`, and `=v36`. Non-hollowness confirmed: a deliberate one-byte CompactSize oracle perturbation fails ST2_runtime; reverting restores green.

Wired into `src/impl/ltc/test/CMakeLists.txt` `share_test` target.
