### PR TITLE
feat(core/stratum): per-session doa_shares_ DOA counter (split from #665)

### DIFF
--- a/src/core/stratum_server.cpp
+++ b/src/core/stratum_server.cpp
@@ -936,6 +936,7 @@ nlohmann::json StratumSession::handle_submit(const nlohmann::json& params, const
                      << ": block template changed (job=" << job_id
                      << " job_prev=" << job_it->second.gbt_prevhash.substr(0, 16)
                      << " current_prev=" << current_prevhash.substr(0, 16) << ")";
+            ++doa_shares_;
             // DON'T set job.stale_info here — it would break ref_hash.
             // The share is still created and broadcast (matches p2pool behavior).
             // DOA tracking is for statistics/dashboard only.

--- a/src/core/stratum_server.hpp
+++ b/src/core/stratum_server.hpp
@@ -154,6 +154,7 @@ class StratumSession : public std::enable_shared_from_this<StratumSession>
     uint64_t accepted_shares_ = 0;
     uint64_t rejected_shares_ = 0;
     uint64_t stale_shares_    = 0;
+    uint64_t doa_shares_      = 0;  // block-template changed at submit (live-vs-frozen prevhash mismatch); accounting only, share still broadcasts
     std::chrono::steady_clock::time_point connected_at_;
     std::string session_id_;
 


### PR DESCRIPTION
Split out of #665 per the integrator scope ruling (test-harness PR must not carry a shared-`src/core` prod change).

## What
Increments a new per-session `doa_shares_` counter in `StratumSession::handle_submit` on the block-template-changed path (live-vs-frozen prevhash mismatch at submit).

- Accounting only — the share is still created and broadcast (matches p2pool). No PPLNS/consensus path touched.
- Sits alongside the existing `accepted_/rejected_/stale_shares_` session stat members.

## Scope justification (src/core = shared exceptional-only lane)
Per-session DOA visibility for the crossing-soak dashboards. Isolated to `StratumSession` stat members; no coin-specific consensus, no isolation-primitive (prefix/id) touched.

## Honest caveats for the reviewer
- **Write-only today**: the counter is incremented but not yet read by any dashboard/stats endpoint. If you would rather this land together with its consumer, hold it and I will fold it into the dashboard-emit change instead. Flagging rather than hiding.
- Gate: needs all four coin smokes green before merge (shared-lane rule).

## Not in this diff
The SPDX AGPL headers and the no-trailing-newline state on both files are already on `master` from relicense #658 — they are **not** introduced here. `git diff github/master...03e3a6eb -- src/core/stratum_server.*` shows only the two `doa_shares_` lines.

GPG: signed, key 50AB1379285EFE76.
