### PR TITLE
ci(release): pin Windows Install Conan 2 to bash (fix pwsh ParserError)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -406,6 +406,7 @@ jobs:
 
       - name: Install Conan 2
         if: steps.presence.outputs.exists == '1'
+        shell: bash
         run: |
           if [ "${{ runner.environment }}" = "github-hosted" ]; then
             pip install "conan>=2.0,<3.0"


### PR DESCRIPTION
Windows packaging cells for btc/bch/dgb/dash failed at Install Conan 2 with a pwsh ParserError: the step set no shell, so github-hosted windows-2022 ran the bash if/then/fi under PowerShell. Pin the step to shell: bash. Detect Conan profile stays pwsh (uses $profile/Get-Content) intentionally.

Runner-infra companion: cleared corrupted apt cache on c2pool-build (srcpkgcache.bin rename EEXIST); apt-get update now exit 0.

Note: this greens the Windows conan step; btc/bch/dgb/dash may still red downstream as they are not v36-ready, and are not part of the v0.14.0-v36-ltc-doge release.