### PR TITLE
release.yml: pass --repo to gh release create (fixes draft-release job)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -521,6 +521,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release create "${GITHUB_REF_NAME}" \
+            --repo "${{ github.repository }}" \
             --draft \
             --title "c2pool ${GITHUB_REF_NAME}" \
             --notes "Draft assembled by release.yml — operator reviews and publishes manually." \


### PR DESCRIPTION
One-line fix. The `SHA256SUMS + draft release` aggregate job (release.yml:492) runs on a bare ubuntu-24.04 with no actions/checkout, so `gh release create` cannot infer the repo (`fatal: not a git repository`) and the draft is never created — even though every green package (all 5 coins Linux, macOS-universal, LTC Windows) uploads fine and SHA256SUMS is generated over the green set.

Fix: pass `--repo ${{ github.repository }}` so the artifact-only job resolves the repo without a checkout.

Root cause diagnosed by ltc-doge-production-steward from run 29142617968. Unblocks the v0.14.0-v36-ltc-doge draft: re-run release.yml on the tag after merge → draft assembles → operator publishes manually (CI creates a DRAFT only, release.yml:28-29). Does not touch the matrix; the red btc/dash/bch/dgb Windows cells remain decoupled (fail-fast:false + if:always()) and are off the LTC/DOGE critical path.