### PR TITLE
release.yml: flock apt-get to serialize concurrent coin package jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,15 @@ jobs:
 
       - name: Install system dependencies
         if: steps.presence.outputs.exists == '1'
+        # Serialize apt across the concurrent coin package jobs sharing the one
+        # c2pool-build self-hosted host. Without this, the 5 Linux matrix cells
+        # race on /var/lib/apt/lists/lock (and corrupt srcpkgcache.bin), and the
+        # loser fails before the build starts (e.g. LTC on v0.2.0, run
+        # 29148852306). flock on a host-wide lock makes apt atomic; on
+        # github-hosted runners the lock is per-VM and uncontended, so no-op.
         run: |
+          exec {lockfd}>/tmp/c2pool-apt.lock
+          flock "$lockfd"
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
             g++ cmake make libleveldb-dev libsecp256k1-dev


### PR DESCRIPTION
Root-fix for the recurring self-hosted Linux apt-lock contention that flaked the LTC Linux package on v0.2.0 (run 29148852306).

## Problem
The five Linux coin package cells (btc/ltc/dgb/dash/bch) run concurrently on the single \`c2pool-build\` self-hosted host and race on \`/var/lib/apt/lists/lock\`. The loser fails at *Install system dependencies* before its build starts; the same concurrency also produces the sibling \`srcpkgcache.bin\` corruption.

## Fix
Wrap the two \`apt-get\` calls in a host-wide \`flock /tmp/c2pool-apt.lock\`, making the install atomic across concurrent jobs. Chosen over containerize / prebake-image because it is the smallest durable change and kills the whole class (lock race + srcpkgcache corruption) with no image-maintenance or drift cost. No-op on github-hosted runners (lock is per-VM, uncontended).

## Follow-up (not this PR)
Other workflows that apt-install on the same host (build.yml smoke, gate workflows) can adopt the same \`/tmp/c2pool-apt.lock\` path to extend serialization cross-workflow. Scoped out to keep this change to the reported release flake.

Merge-gated — awaiting operator push-approval.