### PR TITLE
docs(README): fact-check against source — fix stale defaults, checkpoints, DGB status, test count

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/frstrtr/c2pool/actions/workflows/build.yml/badge.svg)](https://github.com/frstrtr/c2pool/actions/workflows/build.yml)
 
-C++ reimplementation of [forrestv/p2pool](https://github.com/p2pool/p2pool) targeting the **V36 share format** with Litecoin + multi-chain merged mining (DOGE, PEP, BELLS, LKY, JKC, SHIC). DigiByte Scrypt support planned as an additional parent chain.
+C++ reimplementation of [forrestv/p2pool](https://github.com/p2pool/p2pool) targeting the **V36 share format** with Litecoin + multi-chain merged mining (DOGE, PEP, BELLS, LKY, JKC, SHIC). DigiByte Scrypt support in development as an additional parent chain.
 
 Bitcoin wiki: <https://en.bitcoin.it/wiki/P2Pool>
 Original forum thread: <https://bitcointalk.org/index.php?topic=18313>
@@ -209,8 +209,8 @@ Running `c2pool` with no arguments is equivalent to:
 
 ```
 --integrated --embedded-ltc --embedded-doge --wait-for-peers
---header-checkpoint 3079000:862daf...
---doge-header-checkpoint 6140000:743b7e...
+--header-checkpoint 3088000:4a7fc8d4...
+--doge-header-checkpoint 6160000:51efd04d...
 ```
 
 | Setting | Default | Override |
@@ -218,8 +218,8 @@ Running `c2pool` with no arguments is equivalent to:
 | Operating mode | Integrated P2P pool | `--solo`, `--custodial`, `--sharechain`, `--standalone` |
 | LTC backend | Embedded SPV (DNS seeds) | `--no-embedded-ltc` (requires RPC daemon) |
 | DOGE backend | Embedded SPV | `--no-embedded-doge` (disables merged mining) |
-| LTC bootstrap | Block 3,079,000 | `--header-checkpoint HEIGHT:HASH` |
-| DOGE bootstrap | Block 6,140,000 | `--doge-header-checkpoint HEIGHT:HASH` |
+| LTC bootstrap | Block 3,088,000 | `--header-checkpoint HEIGHT:HASH` |
+| DOGE bootstrap | Block 6,160,000 | `--doge-header-checkpoint HEIGHT:HASH` |
 | Startup mode | Wait for peers (persist=true) | `--genesis` or `--startup-mode auto` |
 | Coin daemon | Not required | `--coind-address` / `--coind-rpc-port` |
 | `--address` | Optional (miners use stratum username) | Required only for `--custodial` |
@@ -346,7 +346,7 @@ complete examples with all options documented.
 | `--no-vardiff` | `vardiff_enabled` | true | Disable auto-difficulty |
 | `--max-coinbase-outputs` | `max_coinbase_outputs` | 4000 | Max coinbase outputs |
 | `--network-id` | `network_id` | 0 | Private chain identifier (hex) |
-| `--log-level` | `log_level` | INFO | trace/debug/info/warning/error |
+| `--log-level` | `log_level` | trace | trace/debug/info/warning/error |
 | `--log-file` | `log_file` | debug.log | Log filename |
 | `--log-rotation-mb` | `log_rotation_size_mb` | 100 | Log rotation threshold (MB) |
 | `--log-max-mb` | `log_max_total_mb` | 1000 | Total size cap across all rotated log files (MB) |
@@ -367,7 +367,7 @@ complete examples with all options documented.
 | -- | `explorer_depth_doge` | 1440 | DOGE blocks to keep in explorer store |
 | `--coinbase-text` | `coinbase_text` | /c2pool/ | Custom coinbase scriptSig text |
 | `--message-blob-hex` | -- | -- | V36 authority message blob |
-| `--doge-testnet4alpha` | -- | false | Use DOGE testnet4alpha |
+| `--doge-testnet4alpha` | `doge_testnet4alpha` | false | Use DOGE testnet4alpha |
 
 ---
 
@@ -500,7 +500,7 @@ cd build && ctest --output-on-failure -j$(nproc)
 | Area | Status |
 |---|---|
 | V36 share format (LTC parent chain) | Active development |
-| V36 share format (DGB Scrypt parent chain) | Planned |
+| V36 share format (DGB Scrypt parent chain) | In development |
 | Merged mining (DOGE, PEP, BELLS, LKY, JKC, SHIC) | Working |
 | Embedded LTC SPV node | Working |
 | Embedded DOGE SPV node | Working |
@@ -510,7 +510,7 @@ cd build && ctest --output-on-failure -j$(nproc)
 | Payout / PPLNS | Working |
 | Authority message blobs (V36) | Working |
 | Solo / Custodial modes | Working |
-| Test suite | 501 tests passing |
+| Test suite | 1,875 test cases across 194 suites |
 
 > **Need a pool running today?**
 > [frstrtr/p2pool-merged-v36](https://github.com/frstrtr/p2pool-merged-v36) — production Python V36 pool (LTC + DGB + DOGE, Docker, dashboard).


### PR DESCRIPTION
## What

Line-by-line fact-check of `README.md` against the current source (master `945e1b3a`). Verified every factual claim; corrected the 9 that had drifted. Docs-only.

## Corrections (each backed by source)

| README | Was | Now | Evidence |
|---|---|---|---|
| log_level default | `INFO` | `trace` | `main_ltc.cpp:470` help "(default: trace)", `:623` empty=trace, `log.cpp:82` fallback |
| LTC header-checkpoint | `3079000:862daf…` | `3088000:4a7fc8d4…` | `main_ltc.cpp:582` |
| DOGE header-checkpoint | `6140000:743b7e…` | `6160000:51efd04d…` | `main_ltc.cpp:583` |
| Defaults: LTC/DOGE bootstrap | 3,079,000 / 6,140,000 | 3,088,000 / 6,160,000 | same as above |
| `--doge-testnet4alpha` YAML key | `--` (none) | `doge_testnet4alpha` | `main_ltc.cpp:1145` |
| DGB Scrypt parent (intro + status) | "planned" / "Planned" | "in development" | `c2pool-dgb` target (`CMakeLists.txt:221`), 1211-line `main_dgb.cpp`, dgb-phase-b-smoke CI |
| Test suite count | "501 tests passing" | "1,875 test cases across 194 suites" | actual gtest count (0 DISABLED); 501 appears nowhere in test code |

## Verified accurate (unchanged)

The rest of the README checked out against source and was left alone: the full ~53-row config reference table (CLI flags, YAML keys, defaults), all 15 API-endpoint routes (`web_server.cpp`), ports (9326/9327/8080, testnet 19326/19327), the four operating modes + flags, merged-coin registry + chain_ids (DOGE 98, PEP 63, BELLS 16, LKY 8211, JKC 8224, SHIC 74), bootstrap host list (ml.toom.im, usa.p2p-spb.xyz + 9 IPs), coinbase byte layout, build targets, authority-blob util args, platform/Boost/compiler versions, and license.

## Method

Five parallel verification passes over the source, each required to cite a contradicting `file:line` before flagging a claim (no guessing); the two headline changes (log default, test count) were independently re-verified. Docs-only — no code paths touched.