### PR TITLE
docs(README): deep pass on release surface — v0.2.0, universal macOS, arm64, --net, binary name

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ cd build && ctest --output-on-failure -j$(nproc)
 
 | Area | Status |
 |---|---|
-| V36 share format (LTC parent chain) | Active development |
+| V36 share format (LTC parent chain) | Released (v0.2.0); prod cutover gated on crossing soak |
 | V36 share format (DGB Scrypt parent chain) | In development |
 | Merged mining (DOGE, PEP, BELLS, LKY, JKC, SHIC) | Working |
 | Embedded LTC SPV node | Working |

--- a/README.md
+++ b/README.md
@@ -31,20 +31,19 @@ c2pool is an independent C++ implementation of the P2Pool sharechain concept ori
 |----|---------|----------|-------|------|--------|
 | Ubuntu | 24.04.4 LTS | GCC 13.3 | 1.90 (Conan) | x86_64 | Working |
 | macOS | 26.3.1 (Tahoe) | Apple Clang 21.0 | 1.90 (Homebrew) | x86_64 Intel | Working |
-| macOS | — | Apple Clang | 1.90 (Homebrew) | arm64 (M-series) | Supported, untested |
+| macOS | 26.3.1 (Tahoe) | Apple Clang 21.0 | 1.90 (Homebrew) | arm64 (M-series) | Working |
 | Windows | 11 (26100) | MSVC 2022 | 1.90 (Conan) | x86_64 | Working |
 
 ---
 
 ## Download
 
-Pre-built binaries are available on the [Releases page](https://github.com/frstrtr/c2pool/releases).
+Pre-built binaries are available on the [Releases page](https://github.com/frstrtr/c2pool/releases). The current release is **v0.2.0** (LTC + DOGE v36); packages are named `c2pool-ltc-<version>-<platform>`.
 
 | Platform | Package | Notes |
 |----------|---------|-------|
 | Linux x86_64 | `.tar.gz` | Extract and run `./start.sh` |
-| macOS Intel | `.zip` | Bundled dylibs, no Homebrew needed |
-| macOS Apple Silicon | `.zip` | Native arm64 binary |
+| macOS (universal) | `.dmg` or `.zip` | Single universal arm64 + x86_64 build (lipo-merged); bundled dylibs, no Homebrew needed |
 | Windows x86_64 | `.zip` or `setup.exe` | Installer bundles VC++ Runtime + firewall rules |
 
 ### Verify downloads
@@ -64,7 +63,7 @@ Get-FileHash c2pool-*-setup.exe -Algorithm SHA256
 
 All release binaries are built from the tagged git commit. To verify a binary matches the source:
 
-1. Check the git tag: `git log v0.14.0-v36-ltc-doge --oneline -1`
+1. Check the git tag: `git log v0.2.0 --oneline -1`
 2. Build from that tag following the platform-specific guide
 3. Compare the SHA256 of your binary with the release `SHA256SUMS`
 
@@ -104,7 +103,7 @@ cmake --build . --target c2pool -j$(sysctl -n hw.ncpu)
 
 **Windows (setup.exe or build from source)**
 
-Download `c2pool-VERSION-windows-x86_64-setup.exe` from [Releases](https://github.com/frstrtr/c2pool/releases) and run the installer. Or build from source — see [doc/build-windows.md](doc/build-windows.md).
+Download `c2pool-ltc-VERSION-windows-x86_64-setup.exe` from [Releases](https://github.com/frstrtr/c2pool/releases) and run the installer. Or build from source — see [doc/build-windows.md](doc/build-windows.md).
 
 That's it. No litecoind, no dogecoind, no config file. The node starts in
 **integrated P2P pool mode** with embedded LTC and DOGE SPV nodes, connects
@@ -317,7 +316,7 @@ complete examples with all options documented.
 | `--no-embedded-ltc` | | | Disable embedded LTC, use RPC daemon |
 | `--embedded-doge` | `embedded_doge` | **true** | Embedded DOGE SPV for merged mining |
 | `--no-embedded-doge` | | | Disable embedded DOGE |
-| `--net` | -- | litecoin | Blockchain: `litecoin`, `bitcoin`, `dogecoin` |
+| `--net` | -- | litecoin | Blockchain: `litecoin`, `digibyte`, `bitcoin`, `dogecoin` |
 | `--testnet` | `testnet` | false | Enable testnet mode |
 | `--config FILE` | -- | -- | YAML config file path |
 | `--address` | `solo_address` | -- | Node operator payout address (optional) |
@@ -392,7 +391,8 @@ complete examples with all options documented.
 | `/api/explorer/getblock` | Full block JSON by hash or height (loopback-only) |
 
 See [docs/DASHBOARD_INTEGRATION.md](docs/DASHBOARD_INTEGRATION.md) for the
-complete API reference.
+complete REST API reference and dashboard/explorer integration guide (and
+[docs/FAQ.md](docs/FAQ.md) for common questions).
 
 **Web dashboard** — served from `web-static/` by default:
 
@@ -484,7 +484,7 @@ See [above](#configuration-reference) for details.
 
 | Target | Description |
 |--------|-------------|
-| `c2pool` | Primary binary |
+| `c2pool-ltc` | Primary binary — release packages ship this per-coin name (`c2pool` is the dev-build alias) |
 | `test_hardening` | Softfork gate + reply-matcher regression tests |
 | `test_share_messages` | V36 authority message decrypt/verify tests |
 | `test_coin_broadcaster` | Coin peer-manager and broadcaster tests |

--- a/docs/DASHBOARD_INTEGRATION.md
+++ b/docs/DASHBOARD_INTEGRATION.md
@@ -1,0 +1,177 @@
+# Dashboard & REST API Integration
+
+c2pool serves a built-in web dashboard and a JSON REST API from the same HTTP
+port (default **8080**, `--web-port`). This document is the reference for
+integrating with that API — feeding an external block explorer, building a
+custom dashboard, or scraping pool metrics.
+
+> The authoritative source for exact response fields is
+> [`src/core/web_server.cpp`](../src/core/web_server.cpp) (the request router)
+> and the `rest_*` handlers behind it. Endpoint descriptions below are stable;
+> response shapes may gain fields over time.
+
+---
+
+## Serving basics
+
+- **Base URL:** `http://<host>:8080/` (change the port with `--web-port`, bind
+  address with `--http-host`, default `0.0.0.0`).
+- **Dashboard:** the HTML/JS UI is served from `web-static/` (override with
+  `--dashboard-dir`). Open `http://localhost:8080/` in a browser.
+- **Format:** read endpoints return `application/json` (the `/web/*` helpers
+  back the bundled dashboard and may return HTML/JSON as noted).
+- **Method:** the public stats/read API is `GET`-only. Mutating routes live
+  under `/control/*` and `/api/admin/*` and are access-gated (see below).
+- **CORS:** set `--cors-origin <origin>` (YAML `cors_origin`) to emit an
+  `Access-Control-Allow-Origin` header for cross-origin dashboards.
+- **Availability:** the dashboard + REST API are served in `integrated`,
+  `solo`, and `custodial` modes (not in `sharechain` relay-only mode).
+
+---
+
+## Node & pool statistics
+
+| Endpoint | Returns |
+|----------|---------|
+| `/local_stats` | Local node stats — peers, hashrates, share counts |
+| `/global_stats` | Pool-wide aggregate statistics |
+| `/p2pool_global_stats` | Sharechain-wide (p2pool-compatible) global stats |
+| `/node_info` | Node identity / build / mode info |
+| `/uptime` | Node uptime |
+| `/rate`, `/local_rate`, `/global_rate` | Hashrate (node / local miners / pool) |
+| `/difficulty`, `/network_difficulty` | Current share difficulty / parent-chain network difficulty |
+| `/fee` | Node operator fee configuration |
+| `/best_share` | Current best share (sharechain tip) summary |
+| `/version_signaling`, `/v36_status` | Share-version signalling tallies and V36 AutoRatchet state |
+
+## Payouts
+
+| Endpoint | Returns |
+|----------|---------|
+| `/current_payouts` | Current PPLNS payout distribution |
+| `/pplns/current` | PPLNS window snapshot |
+| `/pplns/miner/<address>` | PPLNS share/weight for one address |
+| `/miner_payouts/<address>` | Payout history/estimate for one address |
+| `/payout_addr`, `/payout_addrs` | Configured payout address(es) |
+
+## Miners & stratum
+
+| Endpoint | Returns |
+|----------|---------|
+| `/connected_miners` | Currently connected stratum workers |
+| `/stratum_stats` | Per-worker stratum stats (hashrate, difficulty, accepted/rejected) |
+| `/miner_stats/<address>` | Stats for one miner address |
+| `/miner_thresholds` | Minimum viable hashrate and dust range |
+| `/stratum_security` | Stratum connection/security posture |
+| `/users`, `/user_stales`, `/stale_rates` | Per-user list and stale-share rates |
+
+## Blocks & luck
+
+| Endpoint | Returns |
+|----------|---------|
+| `/recent_blocks` | Recently found blocks |
+| `/luck_stats` | Pool luck statistics |
+| `/checkpoint`, `/checkpoints` | SPV header checkpoint(s) in effect |
+
+## Sharechain
+
+| Endpoint | Returns |
+|----------|---------|
+| `/sharechain/stats` | Sharechain state summary |
+| `/sharechain/tip` | Current sharechain tip |
+| `/sharechain/window` | PPLNS window contents (cached, ETag/`304`, rate-limited) |
+| `/sharechain/delta` | Incremental sharechain updates |
+| `/sharechain/stream` | Streaming sharechain updates (for live visualizations) |
+| `/tracker_debug` | Share-tracker debug view |
+
+## Merged mining
+
+| Endpoint | Returns |
+|----------|---------|
+| `/merged_stats` | Merged-mining block statistics |
+| `/current_merged_payouts` | Current merged-mining payout distribution |
+| `/recent_merged_blocks` | Recently found merged (aux) blocks |
+| `/all_merged_blocks`, `/discovered_merged_blocks` | Full / discovered merged-block lists |
+| `/broadcaster_status`, `/merged_broadcaster_status` | Parent- and aux-chain block broadcaster status |
+
+## Peers & network
+
+| Endpoint | Returns |
+|----------|---------|
+| `/peer_list`, `/peer_addresses` | Connected sharechain peers |
+| `/peer_versions`, `/peer_txpool_sizes` | Peer protocol versions / mempool sizes |
+| `/pings` | Peer latency |
+| `/ban_stats` | P2P ban statistics |
+| `/api/coin_peers` | Parent-coin daemon peer info |
+| `/api/node_topology` | Sharechain topology graph |
+
+---
+
+## Explorer integration (loopback, opt-in)
+
+For feeding an **external block explorer**, c2pool exposes a Bitcoin-RPC-style
+subset under `/api/explorer/`. These are **loopback-only** (127.0.0.1) and
+require `explorer: true` in the config:
+
+| Endpoint | Returns |
+|----------|---------|
+| `/api/explorer/getblockchaininfo` | Parent-chain info |
+| `/api/explorer/getblockhash` | Block hash by height |
+| `/api/explorer/getblock` | Full block JSON by hash or height |
+
+Enable and point the bundled explorer at them:
+
+```yaml
+# config
+explorer: true
+explorer_url: "http://localhost:9090"
+explorer_depth_ltc: 288      # blocks to retain (LTC)
+explorer_depth_doge: 1440    # blocks to retain (DOGE)
+```
+
+```bash
+python3 explorer/explorer.py \
+  --ltc-c2pool http://127.0.0.1:8080/api/explorer \
+  --doge-c2pool http://127.0.0.1:8080/api/explorer \
+  --web-port 9090
+```
+
+Then browse `http://localhost:9090/`. The explorer shows block details, decoded
+coinbase scripts, and THE commitment proofs for c2pool-found blocks, and links
+out to a public explorer (default Blockchair) for anything outside the stored
+range.
+
+---
+
+## Dashboard customization
+
+Both the dashboard and the explorer are user-editable components:
+
+- **Dashboard:** edit HTML/JS/CSS in `web-static/` (or point `--dashboard-dir`
+  at your own directory). The bundled UI consumes the `/web/*` helper endpoints
+  (`/web/heads`, `/web/tails`, `/web/graph_data/…`, `/web/share/<hash>`,
+  `/web/best_share_hash`, `/web/sync_status`, `/web/currency_info`, …).
+- **Explorer:** modify `explorer/explorer.py`.
+- **External explorer links** default to Blockchair and can be overridden
+  per-node:
+
+```yaml
+address_explorer_prefix: "https://your-explorer.example.com/address/"
+block_explorer_prefix:   "https://your-explorer.example.com/block/"
+tx_explorer_prefix:      "https://your-explorer.example.com/tx/"
+```
+
+- **Analytics:** set `--analytics-id G-XXXXXXXXXX` (YAML `analytics_id`) to
+  inject a measurement snippet into the dashboard `</head>`.
+
+---
+
+## Control & admin endpoints
+
+Mutating and administrative routes exist under `/control/*` (e.g.
+`/control/mining/start`, `/stop`, `/restart`, `/ban`, `/unban`) and
+`/api/admin/*` (`/api/admin/pool/…`, `/api/admin/coin/…`). These change node
+state and are **not** part of the read-only integration surface — treat them as
+operator-only and keep them off any public binding. Consult
+`src/core/web_server.cpp` for their exact contracts before wiring automation to
+them.


### PR DESCRIPTION
## What
Second README fact-check pass, focused on the **release/download/platform surface** that the first (source-symbol) pass didn't cover. Docs-only.

## Corrections (evidence)
| README | Was | Now | Evidence |
|---|---|---|---|
| Download macOS | separate Intel + Apple-Silicon `.zip` rows | one **universal `.dmg`/`.zip`** (lipo arm64+x86_64) | `release.yml` macos-universal job; v0.2.0 assets `c2pool-ltc-0.2.0-macos-universal.{dmg,zip}` |
| Download intro | (none) | notes current release **v0.2.0** + `c2pool-ltc-<ver>-<platform>` naming | `gh release view v0.2.0` |
| Tested platforms | arm64 "Supported, untested" | "Working" | built natively on macos-14 in CI + shipped universal |
| Reproducible builds | `git log v0.14.0-v36-ltc-doge` (**tag doesn't exist**) | `git log v0.2.0` | `gh api tags`/`releases` |
| Windows quick-start pkg | `c2pool-VERSION-...` | `c2pool-ltc-VERSION-...` | per-coin release naming |
| `--net` values | litecoin, bitcoin, dogecoin | + **digibyte** | `main_ltc.cpp:376` |
| Build targets | `c2pool` | `c2pool-ltc` (per-coin ship name; `c2pool` = dev alias) | `release.yml:150/166`, `CMakeLists.txt:106/146` |
| API ref link | dead `docs/DASHBOARD_INTEGRATION.md` | `docs/FAQ.md` + endpoint table | file missing (#677) |

## Not in this PR (routed to ci-steward)
A **functional bug** surfaced during the sweep: the bundled **`start.sh` launches `./c2pool`** and **`start.bat` launches `c2pool.exe`**, but the v0.2.0 packages ship **`c2pool-ltc`** (`release.yml:166`) — so the README's documented "extract and run `./start.sh`" **fails on the real release**. Plus start.sh's banner is stale (`v0.1.1-alpha`). That's a packaging fix (owner's call: rename in packaging vs. fix launcher), filed separately.

## Verification
gh releases/tags, `.github/workflows/release.yml`, `src/c2pool/main_ltc.cpp`, `CMakeLists.txt`. Docs-only — no code paths touched.