### PR TITLE
packaging: auto-detect per-coin binary in bundled launchers

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -1,16 +1,28 @@
 @echo off
-setlocal
+setlocal enabledelayedexpansion
 set DIR=%~dp0
 set CONFIG=%1
 if "%CONFIG%"=="" set CONFIG=%DIR%config\c2pool_mainnet.yaml
 
-echo === c2pool ===
+:: Locate the packaged coin binary. release.yml packages it per-coin as
+:: c2pool-<coin>.exe, so resolve by glob rather than a hard-coded name;
+:: fall back to a plain c2pool.exe for source builds.
+set BIN=
+for %%f in ("%DIR%c2pool-*.exe") do set BIN=%%f
+if "!BIN!"=="" if exist "%DIR%c2pool.exe" set BIN=%DIR%c2pool.exe
+if "!BIN!"=="" (
+    echo ERROR: no c2pool binary found in %DIR%
+    exit /b 1
+)
+for %%f in ("!BIN!") do set BINNAME=%%~nxf
+
+echo === !BINNAME! ===
 echo Config:   %CONFIG%
 echo Web:      http://0.0.0.0:8080
 echo Explorer: http://0.0.0.0:9090
 
 :: Start c2pool
-start /B "" "%DIR%c2pool.exe" --config "%CONFIG%" --dashboard-dir "%DIR%web-static"
+start /B "" "!BIN!" --config "%CONFIG%" --dashboard-dir "%DIR%web-static"
 
 :: Wait for API
 :wait_loop

--- a/start.sh
+++ b/start.sh
@@ -7,13 +7,23 @@ CONFIG="${1:-$DIR/config/c2pool_mainnet.yaml}"
 EXPLORER_PORT=9090
 WEB_PORT=8080
 
+# Locate the packaged coin binary. release.yml packages it per-coin as
+# c2pool-<coin> (c2pool-ltc, c2pool-btc, ...), so resolve by glob rather
+# than a hard-coded name; fall back to a plain c2pool for source builds.
+BIN=$(find "$DIR" -maxdepth 1 -type f -name "c2pool-*" -perm -u+x 2>/dev/null | head -1)
+[ -z "$BIN" ] && [ -x "$DIR/c2pool" ] && BIN="$DIR/c2pool"
+if [ -z "$BIN" ]; then
+    echo "ERROR: no c2pool binary found in $DIR" >&2
+    exit 1
+fi
+
 # Parse web_port from config if present
 if [ -f "$CONFIG" ]; then
-    WP=$(grep -E "^web_port:" "$CONFIG" 2>/dev/null | awk '{print $2}')
+    WP=$(grep -E "^web_port:" "$CONFIG" 2>/dev/null | awk "{print \$2}")
     [ -n "$WP" ] && WEB_PORT="$WP"
 fi
 
-echo "=== c2pool v0.1.1-alpha ==="
+echo "=== $(basename "$BIN") ==="
 echo "Config:   $CONFIG"
 echo "Web:      http://0.0.0.0:${WEB_PORT}"
 echo "Explorer: http://0.0.0.0:${EXPLORER_PORT}"
@@ -21,14 +31,14 @@ echo ""
 
 # Start c2pool with bundled libs
 export LD_LIBRARY_PATH="$DIR/lib:${LD_LIBRARY_PATH:-}"
-"$DIR/c2pool" --config "$CONFIG" --dashboard-dir "$DIR/web-static" &
+"$BIN" --config "$CONFIG" --dashboard-dir "$DIR/web-static" &
 C2POOL_PID=$!
 
 # Wait for the explorer API to be ready (callbacks wired after full init)
 echo "Waiting for c2pool to initialize..."
 for i in $(seq 1 120); do
     RESP=$(curl -s "http://127.0.0.1:${WEB_PORT}/api/explorer/getblockchaininfo" 2>/dev/null || true)
-    if echo "$RESP" | grep -q '"blocks"'; then
+    if echo "$RESP" | grep -q "\"blocks\""; then
         echo "c2pool explorer API ready."
         break
     fi


### PR DESCRIPTION
## Problem
release.yml packages the node per-coin as `c2pool-<coin>` (`c2pool-ltc`, `c2pool-btc`, ...), but the bundled launchers hard-coded a binary that is not in the tarball:
- `start.sh` launched `./c2pool` -> No such file
- `start.bat` launched `%DIR%c2pool.exe` -> same on Windows
- `start.sh` banner was stale (`v0.1.1-alpha`, release is `v0.2.0`)

Since README says "extract and run ./start.sh", a fresh v0.2.0 user hit this immediately.

## Fix — auto-detect (issue option 3)
The **same** `start.sh`/`start.bat` is copied into every coin package by the shared matrix step, so hard-coding any single coin name would only fix one of five packages. This resolves the binary by `c2pool-*` glob (each package contains exactly one), with a plain-`c2pool` fallback for source builds:
- `start.sh`: `find "$DIR" -maxdepth 1 -type f -name "c2pool-*" -perm -u+x`
- `start.bat`: `for %%f in ("%DIR%c2pool-*.exe") do set BIN=%%f`
- Banner now derived from the binary basename, so it cannot go stale again.

No release.yml change needed — the per-coin rename stays. Docs reconciliation is integrator PR #682 (docs-only).

Not self-merging — awaiting operator push-approval per standing rule.
