### PR TITLE
release.yml: ship c2pool-dgb as the -DAUX_DOGE=ON DGB+DOGE merged build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,9 +141,13 @@ jobs:
       - name: Configure
         if: steps.presence.outputs.exists == '1'
         run: |
+          # DGB ships the -DAUX_DOGE=ON build: DGB parent + embedded DOGE aux as ONE
+          # binary, the direct parallel to c2pool-ltc carrying DOGE. Gated to the dgb
+          # cell; inert for the other coins. Merged-mining path per #603/#614/#589/#395.
           cmake -S . -B build_${{ matrix.coin }} \
             -DCMAKE_TOOLCHAIN_FILE=build_${{ matrix.coin }}/conan_toolchain.cmake \
-            -DCMAKE_BUILD_TYPE=Release
+            -DCMAKE_BUILD_TYPE=Release \
+            ${{ matrix.coin == 'dgb' && '-DAUX_DOGE=ON' || '' }}
 
       - name: Build c2pool-${{ matrix.coin }}
         if: steps.presence.outputs.exists == '1'
@@ -249,7 +253,8 @@ jobs:
 
       - name: Configure
         if: steps.presence.outputs.exists == '1'
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+        # DGB: -DAUX_DOGE=ON -> DGB parent + embedded DOGE (mirrors c2pool-ltc). Inert for other coins.
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release ${{ matrix.coin == 'dgb' && '-DAUX_DOGE=ON' || '' }}
 
       - name: Build c2pool-${{ matrix.coin }}
         if: steps.presence.outputs.exists == '1'
@@ -486,7 +491,8 @@ jobs:
       - name: Configure
         if: steps.presence.outputs.exists == '1'
         shell: cmd
-        run: cmake -S . -B build_ci -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=build_ci/conan_toolchain.cmake -DCMAKE_PREFIX_PATH="%GITHUB_WORKSPACE%/secp256k1" -DCMAKE_CXX_FLAGS="/D_WIN32_WINNT=0x0A00"
+        # DGB: -DAUX_DOGE=ON -> DGB parent + embedded DOGE (mirrors c2pool-ltc). Inert for other coins.
+        run: cmake -S . -B build_ci -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=build_ci/conan_toolchain.cmake -DCMAKE_PREFIX_PATH="%GITHUB_WORKSPACE%/secp256k1" -DCMAKE_CXX_FLAGS="/D_WIN32_WINNT=0x0A00" ${{ matrix.coin == 'dgb' && '-DAUX_DOGE=ON' || '' }}
 
       - name: Build c2pool-${{ matrix.coin }}
         if: steps.presence.outputs.exists == '1'


### PR DESCRIPTION
## What
Wires the DGB+DOGE Scrypt merged-mining variant into release packaging. Makes the shipped `c2pool-dgb` the `-DAUX_DOGE=ON` build (DGB parent + embedded DOGE aux as ONE binary) — the direct parallel to how `c2pool-ltc` carries DOGE (**Option A** from the task).

## Mechanism
`-DAUX_DOGE=ON` is the existing global CMake option (`src/impl/dgb/CMakeLists.txt:29`). Passed per-cell, gated to `matrix.coin==dgb`, in all three platform Configure steps (Linux / macOS / Windows). Inert for btc/ltc/dash/bch.

- **No new matrix cell, no package rename.** Target stays `c2pool-dgb`; package stays `c2pool-dgb-<ver>-<platform>`. The merged binary is a superset — runs DGB standalone OR DGB+DOGE merged, exactly like `c2pool-ltc` runs LTC-only or LTC+DOGE.
- `fail-fast:false` per-coin decouple unchanged; inherits #684 launcher auto-detect (`c2pool-*` glob).

## Why Option A over B
Direct parallel to the LTC+DOGE ship model — one binary, no standalone/merged split to maintain. If dgb-scrypt-steward confirms standalone-DGB must ALSO ship as a separate package, that is a fast follow-up (add a distinct `c2pool-dgb-doge` cell = Option B).

## Provenance
Merged-mining path already merged + green: #603 live-wire, #614 dual-target seam, #589 isolation guard, #395 AuxPoW byte-parity KAT.

## Validation
Fired `release.yml` `workflow_dispatch` dry-run from this branch (coins=["dgb"], artifacts-only, non-tag): run 29225995267. Confirming non-hollow green (real DGB merged binary links + `--help` smoke on all 3 platforms) before merge.

## Gate
integrator review + operator tap. **No self-merge.** Packaging lands independent of DGB G2 real-rig crossing (same as LTC shipped v0.2.0 with its crossing pending).