### PR TITLE
ci(release): repoint macOS/Windows/checksums to self-hosted runners (finish #439)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,7 @@ jobs:
         arch: [arm64, x86_64]
         include:
           - arch: arm64
-            runner: macos-14
+            runner: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","macOS","ARM64","c2pool-mac-arm"]') || 'macos-14' }}
           - arch: x86_64
             runner: [self-hosted, macOS, X64, c2pool-mac-intel]
     steps:
@@ -308,7 +308,7 @@ jobs:
     name: ${{ matrix.coin }} package (macOS universal)
     needs: macos
     if: always()
-    runs-on: macos-14
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","macOS","ARM64","c2pool-mac-arm"]') || 'macos-14' }}
     strategy:
       fail-fast: false
       matrix:
@@ -412,7 +412,7 @@ jobs:
   # ════════════════════════════════════════════════════════════════════════════
   windows:
     name: ${{ matrix.coin }} package (Windows x86_64)
-    runs-on: windows-2022
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Windows","X64","c2pool-build"]') || 'windows-2022' }}
     strategy:
       fail-fast: false
       matrix:
@@ -556,7 +556,7 @@ jobs:
   # ════════════════════════════════════════════════════════════════════════════
   checksums:
     name: SHA256SUMS + draft release
-    runs-on: ubuntu-24.04
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
     needs: [linux, macos-universal, windows]
     if: always()
     permissions:


### PR DESCRIPTION
Finishes the #439 self-hosted migration for release.yml, which lagged build.yml (PR #617) because release.yml only fires on tags — the v0.2.1 tag exposed the gap.

Mirrors the exact fork-fallback guard build.yml already proved (`head.repo == repository ? self-hosted : github-hosted`):

| job | was | now (self-hosted, fork-fallback) |
|---|---|---|
| macos arm64 (per-arch) | macos-14 | c2pool-mac-arm (Alonso-227) / macos-14 |
| macos-universal (lipo merge) | macos-14 | c2pool-mac-arm / macos-14 |
| windows | windows-2022 | [self-hosted,Windows,X64,c2pool-build] (VM217) / windows-2022 |
| checksums / draft | ubuntu-24.04 | [self-hosted,Linux,X64,c2pool-build] / ubuntu-24.04 |

macos x86_64 (c2pool-mac-intel) and linux were already self-hosted. Pure config — no new infra; all runners live and used by build.yml daily.

Kept independent of the BCH __int128 fix (separate concern, unbundled per convention). integrator review + operator tap; no self-merge.