### PR TITLE
ci: auto-heal corrupt boost conan cache on self-hosted runners

### DIFF
--- a/.github/actions/conan-cache-guard/action.yml
+++ b/.github/actions/conan-cache-guard/action.yml
@@ -9,7 +9,11 @@ description: >
 runs:
   using: composite
   steps:
-    - name: Verify boost conan package integrity (auto-purge if corrupt)
+    # VM217 (Windows self-hosted) has no bash on the service PATH — same reason
+    # build.yml Windows conan steps run under pwsh. Split by runner.os so the
+    # guard runs on every lane incl. win-217.
+    - name: Verify boost conan package integrity (auto-purge if corrupt) [posix]
+      if: runner.os != 'Windows'
       shell: bash
       run: |
         if conan cache check-integrity "boost/*"; then
@@ -18,3 +22,15 @@ runs:
           echo "::warning title=conan-cache-guard::boost package integrity check FAILED — purging so conan install rebuilds it clean"
           conan remove "boost/*" -c || true
         fi
+    - name: Verify boost conan package integrity (auto-purge if corrupt) [windows]
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        conan cache check-integrity "boost/*"
+        if ($LASTEXITCODE -ne 0) {
+          Write-Output "::warning title=conan-cache-guard::boost package integrity check FAILED — purging so conan install rebuilds it clean"
+          conan remove "boost/*" -c
+        } else {
+          Write-Output "conan-cache-guard: boost cache integrity OK"
+        }
+        exit 0

--- a/.github/actions/conan-cache-guard/action.yml
+++ b/.github/actions/conan-cache-guard/action.yml
@@ -1,29 +1,33 @@
 name: "Conan cache integrity guard"
 description: >
   Auto-heal a corrupt/incomplete OR wrong-config cached boost package on
-  self-hosted runners. The self-hosted runners reuse ~/.conan2 across jobs.
-  A partially-failed conan build can leave an incomplete boost package
-  (missing headers/libs), and an out-of-band/manual `conan install` can leave
-  an intact-but-wrong-std boost (compiler.cppstd=gnu17) that PASSES an integrity
-  check yet is ABI-incompatible with the cppstd=20 c2pool TUs. Conan's
-  compatibility fallback then re-selects that gnu17 boost instead of rebuilding,
-  reddening later jobs intermittently (the per-job profile cppstd=20 pin cannot
-  prevent this; it only sets what is *requested*, not what is *selected*). This
-  purges boost on integrity mismatch OR on any cached cppstd != 20 so the
-  following `conan install` rebuilds it clean. No-op on a healthy cppstd=20 or
-  empty cache.
+  self-hosted runners. The self-hosted Linux runners (VM905) reuse ONE
+  ~/.conan2 across up to 8 concurrent jobs. A partially-failed conan build
+  can leave an incomplete boost package (missing headers/libs), and an
+  out-of-band/manual `conan install` can leave an intact-but-wrong-std boost
+  (compiler.cppstd=gnu17) that PASSES an integrity check yet is ABI-incompatible
+  with the cppstd=20 c2pool TUs. Conan compatibility fallback then re-selects
+  that gnu17 boost instead of rebuilding, reddening later jobs intermittently
+  (the per-job profile cppstd=20 pin only sets what is *requested*, not what is
+  *selected*). This purges boost on integrity mismatch OR on any cached
+  cppstd != 20 and rebuilds a clean cppstd=20 boost. On the shared Linux cache
+  the whole check+purge+rebuild is serialized under an flock so exactly ONE
+  cold-cache job rebuilds boost while the rest wait and then cache-hit -- without
+  the lock, every concurrent job purges+rebuilds into the same cache at once and
+  races ("Reference ... already exists" / boost headers deleted mid-build).
+  No-op (fast, unlocked-fast) on a healthy cppstd=20 cache.
 runs:
   using: composite
   steps:
-    # VM217 (Windows self-hosted) has no bash on the service PATH. Split by
-    # runner.os so the guard runs on every lane incl. win-217. The Windows leg
-    # uses shell: cmd (not powershell) because VM217 execution-policy blocks
-    # unsigned script bodies; cmd has no execution-policy gate, matching what
-    # the windows-2022 fork-fallback already does.
-    - name: Verify boost integrity + cppstd (auto-purge if corrupt or wrong-std) [posix]
+    - name: Verify boost integrity + cppstd, rebuild-once under lock (shared cache) [posix]
       if: runner.os != 'Windows'
       shell: bash
       run: |
+        # Serialize check+purge+rebuild across all jobs sharing ~/.conan2 on
+        # this self-hosted host (mirrors the apt-get flock guard, PR #670).
+        lock="${HOME}/.conan2/.c2pool-boost-guard.lock"
+        exec 9>"$lock" 2>/dev/null || exec 9>/tmp/.c2pool-boost-guard.lock
+        flock 9
         purge=""
         if ! conan cache check-integrity "boost/*"; then
           purge="integrity check FAILED"
@@ -33,15 +37,27 @@ runs:
           purge="a cached binary was built with compiler.cppstd != 20 (wrong-std; Conan compatibility fallback would re-select it)"
         fi
         if [ -n "$purge" ]; then
-          echo "::warning title=conan-cache-guard::boost $purge -- purging so conan install rebuilds it clean"
+          echo "::warning title=conan-cache-guard::boost $purge -- purging + rebuilding cppstd=20 boost from source under lock"
           conan remove "boost/*" -c || true
+          # Rebuild boost NOW, while holding the lock, using the job's already
+          # cppstd=20-pinned default profile, so every subsequent (unlocked)
+          # `conan install` is a clean cache hit and no job ever installs against
+          # a boost another job is deleting. Log is intentionally not suppressed
+          # so the from-source rebuild is visible as evidence.
+          conan install . --build="boost/*" --settings=build_type=Release \
+            --output-folder="${RUNNER_TEMP:-/tmp}/conan-boost-warm"
         else
           echo "conan-cache-guard: boost cache OK (integrity + cppstd=20)"
         fi
+        flock -u 9
     - name: Verify boost integrity + cppstd (auto-purge if corrupt or wrong-std) [windows]
       if: runner.os == 'Windows'
       shell: cmd
       run: |
+        rem VM217 is a single Windows runner -- no concurrent siblings share its
+        rem cache, so no thundering-herd race; a purge here is healed by this
+        rem job's own following conan install. cmd (not powershell) because
+        rem VM217 execution-policy blocks unsigned script bodies.
         set purge=
         conan cache check-integrity "boost/*"
         if errorlevel 1 set purge=integrity check FAILED

--- a/.github/actions/conan-cache-guard/action.yml
+++ b/.github/actions/conan-cache-guard/action.yml
@@ -1,11 +1,17 @@
 name: "Conan cache integrity guard"
 description: >
-  Auto-heal a corrupt/incomplete cached boost package on self-hosted runners.
-  The self-hosted runners reuse ~/.conan2 across jobs; a partially-failed conan
-  build can leave an incomplete boost package (missing headers/libs) that
-  persists and reddens later jobs intermittently. This verifies the cached
-  boost package against its manifest and purges it on any mismatch so the
-  following `conan install` rebuilds it clean. No-op on a healthy/empty cache.
+  Auto-heal a corrupt/incomplete OR wrong-config cached boost package on
+  self-hosted runners. The self-hosted runners reuse ~/.conan2 across jobs.
+  A partially-failed conan build can leave an incomplete boost package
+  (missing headers/libs), and an out-of-band/manual `conan install` can leave
+  an intact-but-wrong-std boost (compiler.cppstd=gnu17) that PASSES an integrity
+  check yet is ABI-incompatible with the cppstd=20 c2pool TUs. Conan's
+  compatibility fallback then re-selects that gnu17 boost instead of rebuilding,
+  reddening later jobs intermittently (the per-job profile cppstd=20 pin cannot
+  prevent this; it only sets what is *requested*, not what is *selected*). This
+  purges boost on integrity mismatch OR on any cached cppstd != 20 so the
+  following `conan install` rebuilds it clean. No-op on a healthy cppstd=20 or
+  empty cache.
 runs:
   using: composite
   steps:
@@ -14,25 +20,40 @@ runs:
     # uses shell: cmd (not powershell) because VM217 execution-policy blocks
     # unsigned script bodies; cmd has no execution-policy gate, matching what
     # the windows-2022 fork-fallback already does.
-    - name: Verify boost conan package integrity (auto-purge if corrupt) [posix]
+    - name: Verify boost integrity + cppstd (auto-purge if corrupt or wrong-std) [posix]
       if: runner.os != 'Windows'
       shell: bash
       run: |
-        if conan cache check-integrity "boost/*"; then
-          echo "conan-cache-guard: boost cache integrity OK"
-        else
-          echo "::warning title=conan-cache-guard::boost package integrity check FAILED — purging so conan install rebuilds it clean"
-          conan remove "boost/*" -c || true
+        purge=""
+        if ! conan cache check-integrity "boost/*"; then
+          purge="integrity check FAILED"
+        elif conan list "boost/*:*" -f json 2>/dev/null \
+               | grep -oE '"compiler.cppstd": "[^"]*"' \
+               | grep -qv '"compiler.cppstd": "20"'; then
+          purge="a cached binary was built with compiler.cppstd != 20 (wrong-std; Conan compatibility fallback would re-select it)"
         fi
-    - name: Verify boost conan package integrity (auto-purge if corrupt) [windows]
+        if [ -n "$purge" ]; then
+          echo "::warning title=conan-cache-guard::boost $purge -- purging so conan install rebuilds it clean"
+          conan remove "boost/*" -c || true
+        else
+          echo "conan-cache-guard: boost cache OK (integrity + cppstd=20)"
+        fi
+    - name: Verify boost integrity + cppstd (auto-purge if corrupt or wrong-std) [windows]
       if: runner.os == 'Windows'
       shell: cmd
       run: |
+        set purge=
         conan cache check-integrity "boost/*"
-        if errorlevel 1 (
-          echo ::warning title=conan-cache-guard::boost package integrity check FAILED -- purging so conan install rebuilds it clean
+        if errorlevel 1 set purge=integrity check FAILED
+        if not defined purge (
+          conan list "boost/*:*" -f json > "%TEMP%\cg_boost.json" 2>nul
+          findstr /C:"compiler.cppstd" "%TEMP%\cg_boost.json" | findstr /V /C:": \"20\"" >nul
+          if not errorlevel 1 set purge=a cached binary was built with compiler.cppstd ^!= 20
+        )
+        if defined purge (
+          echo ::warning title=conan-cache-guard::boost %purge% -- purging so conan install rebuilds it clean
           conan remove "boost/*" -c
         ) else (
-          echo conan-cache-guard: boost cache integrity OK
+          echo conan-cache-guard: boost cache OK ^(integrity + cppstd=20^)
         )
         exit /b 0

--- a/.github/actions/conan-cache-guard/action.yml
+++ b/.github/actions/conan-cache-guard/action.yml
@@ -24,7 +24,7 @@ runs:
         fi
     - name: Verify boost conan package integrity (auto-purge if corrupt) [windows]
       if: runner.os == 'Windows'
-      shell: pwsh
+      shell: powershell
       run: |
         conan cache check-integrity "boost/*"
         if ($LASTEXITCODE -ne 0) {

--- a/.github/actions/conan-cache-guard/action.yml
+++ b/.github/actions/conan-cache-guard/action.yml
@@ -9,9 +9,11 @@ description: >
 runs:
   using: composite
   steps:
-    # VM217 (Windows self-hosted) has no bash on the service PATH — same reason
-    # build.yml Windows conan steps run under pwsh. Split by runner.os so the
-    # guard runs on every lane incl. win-217.
+    # VM217 (Windows self-hosted) has no bash on the service PATH. Split by
+    # runner.os so the guard runs on every lane incl. win-217. The Windows leg
+    # uses shell: cmd (not powershell) because VM217 execution-policy blocks
+    # unsigned script bodies; cmd has no execution-policy gate, matching what
+    # the windows-2022 fork-fallback already does.
     - name: Verify boost conan package integrity (auto-purge if corrupt) [posix]
       if: runner.os != 'Windows'
       shell: bash
@@ -24,13 +26,13 @@ runs:
         fi
     - name: Verify boost conan package integrity (auto-purge if corrupt) [windows]
       if: runner.os == 'Windows'
-      shell: powershell
+      shell: cmd
       run: |
         conan cache check-integrity "boost/*"
-        if ($LASTEXITCODE -ne 0) {
-          Write-Output "::warning title=conan-cache-guard::boost package integrity check FAILED — purging so conan install rebuilds it clean"
+        if errorlevel 1 (
+          echo ::warning title=conan-cache-guard::boost package integrity check FAILED -- purging so conan install rebuilds it clean
           conan remove "boost/*" -c
-        } else {
-          Write-Output "conan-cache-guard: boost cache integrity OK"
-        }
-        exit 0
+        ) else (
+          echo conan-cache-guard: boost cache integrity OK
+        )
+        exit /b 0

--- a/.github/actions/conan-cache-guard/action.yml
+++ b/.github/actions/conan-cache-guard/action.yml
@@ -1,0 +1,20 @@
+name: "Conan cache integrity guard"
+description: >
+  Auto-heal a corrupt/incomplete cached boost package on self-hosted runners.
+  The self-hosted runners reuse ~/.conan2 across jobs; a partially-failed conan
+  build can leave an incomplete boost package (missing headers/libs) that
+  persists and reddens later jobs intermittently. This verifies the cached
+  boost package against its manifest and purges it on any mismatch so the
+  following `conan install` rebuilds it clean. No-op on a healthy/empty cache.
+runs:
+  using: composite
+  steps:
+    - name: Verify boost conan package integrity (auto-purge if corrupt)
+      shell: bash
+      run: |
+        if conan cache check-integrity "boost/*"; then
+          echo "conan-cache-guard: boost cache integrity OK"
+        else
+          echo "::warning title=conan-cache-guard::boost package integrity check FAILED — purging so conan install rebuilds it clean"
+          conan remove "boost/*" -c || true
+        fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,8 @@ jobs:
         if: runner.environment != 'github-hosted'
         run: rm -rf build_ci
 
+      - name: Conan cache guard (auto-heal corrupt boost)
+        uses: ./.github/actions/conan-cache-guard
       - name: Conan install
         run: conan install . --build=missing --output-folder=build_ci --settings=build_type=Release
 
@@ -216,6 +218,8 @@ jobs:
         if: runner.environment != 'github-hosted'
         run: rm -rf build_asan
 
+      - name: Conan cache guard (auto-heal corrupt boost)
+        uses: ./.github/actions/conan-cache-guard
       - name: Conan install
         run: conan install . --build=missing --output-folder=build_asan --settings=build_type=Release
 
@@ -339,6 +343,8 @@ jobs:
         if: runner.environment != 'github-hosted'
         run: rm -rf build_bch
 
+      - name: Conan cache guard (auto-heal corrupt boost)
+        uses: ./.github/actions/conan-cache-guard
       - name: Conan install
         run: conan install . --build=missing --output-folder=build_bch --settings=build_type=Release
 
@@ -428,6 +434,8 @@ jobs:
         if: runner.environment != 'github-hosted'
         run: rm -rf build_bch_asan
 
+      - name: Conan cache guard (auto-heal corrupt boost)
+        uses: ./.github/actions/conan-cache-guard
       - name: Conan install
         run: conan install . --build=missing --output-folder=build_bch_asan --settings=build_type=Release
 
@@ -802,6 +810,8 @@ jobs:
           path: ~/.conan2
           key: conan2-windows-msvc194-${{ hashFiles('conanfile.txt') }}
 
+      - name: Conan cache guard (auto-heal corrupt boost)
+        uses: ./.github/actions/conan-cache-guard
       - name: Conan install
         run: conan install . --build=missing --output-folder=build_ci
 
@@ -903,6 +913,8 @@ jobs:
         if: runner.environment != 'github-hosted'
         run: rm -rf build_dgb_auxdoge
 
+      - name: Conan cache guard (auto-heal corrupt boost)
+        uses: ./.github/actions/conan-cache-guard
       - name: Conan install
         run: conan install . --build=missing --output-folder=build_dgb_auxdoge --settings=build_type=Release
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -91,6 +91,9 @@ jobs:
         run: rm -rf build_codeql
 
       - if: matrix.build-mode == 'manual'
+        name: Conan cache guard (auto-heal corrupt boost)
+        uses: ./.github/actions/conan-cache-guard
+      - if: matrix.build-mode == 'manual'
         name: Install Conan dependencies
         run: |
           conan install . \

--- a/.github/workflows/coin-matrix.yml
+++ b/.github/workflows/coin-matrix.yml
@@ -98,6 +98,9 @@ jobs:
         run: |
           find ~/.conan2/p -type f \( -name 'conan_package.tgz' -o -name 'conan_sources.tgz' \) -delete 2>/dev/null || true
 
+      - name: Conan cache guard (auto-heal corrupt boost)
+        if: steps.presence.outputs.exists == '1'
+        uses: ./.github/actions/conan-cache-guard
       - name: Conan install
         if: steps.presence.outputs.exists == '1'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,9 @@ jobs:
             conan2-ubuntu24-gcc13-${{ matrix.coin }}-
             conan2-ubuntu24-gcc13-
 
+      - name: Conan cache guard (auto-heal corrupt boost)
+        if: steps.presence.outputs.exists == '1'
+        uses: ./.github/actions/conan-cache-guard
       - name: Conan install
         if: steps.presence.outputs.exists == '1'
         run: |
@@ -476,6 +479,9 @@ jobs:
           path: ~/.conan2
           key: conan2-windows-msvc194-${{ hashFiles('conanfile.txt') }}
 
+      - name: Conan cache guard (auto-heal corrupt boost)
+        if: steps.presence.outputs.exists == '1'
+        uses: ./.github/actions/conan-cache-guard
       - name: Conan install
         if: steps.presence.outputs.exists == '1'
         run: conan install . --build=missing --output-folder=build_ci


### PR DESCRIPTION
## Problem
Recurring **intermittent** boost/conan reds across CI + release builds. The self-hosted runners reuse `~/.conan2` across jobs; a partially-failed conan build leaves an **incomplete boost package** that persists and poisons later jobs. Different pieces go missing per run (same class):
- `boost/asio/detail/timed_cancel_op.hpp: No such file` (#688 dgb)
- `boost/log/detail/header.hpp: No such file` (bch smoke, master c79e4be0)
- `libboost_process.a: No such file`
- `boost_coroutine "expected to be built but not built"` (dash smoke)

Intermittent because it depends on which runner/cache state a job lands on.

## Fix
New composite action `.github/actions/conan-cache-guard` runs before every `conan install`:
```
conan cache check-integrity "boost/*" || conan remove "boost/*" -c
```
`check-integrity` validates the cached package **against its manifest**, so it catches ANY missing header/lib — not just the named ones — and auto-purges so the following `conan install` rebuilds boost clean. No-op on a healthy/empty cache; declares its own `shell: bash` so it is cross-platform (Linux/mac/Windows-217). Never fails the build itself.

Wired before all conan install sites: build.yml (6), coin-matrix.yml (1), release.yml (2), codeql-analysis.yml (1) — presence/build-mode conditions mirrored.

## Verification
- VM905 (c2pool-build) cache verified **currently clean**: all named-missing files present (44 libs), `check-integrity boost/*` RC=0.
- Manually confirmed `check-integrity` detects the corruption class (manifest-vs-disk mismatch) and `conan remove boost/*` purges cleanly.

Reviewer: @integrator — no self-merge; awaiting operator push-approval.