### PR TITLE
btc(nmc PR-1): link nmc_coin into c2pool-btc target

### DIFF
--- a/src/c2pool/CMakeLists.txt
+++ b/src/c2pool/CMakeLists.txt
@@ -175,6 +175,7 @@ target_link_libraries(c2pool-btc
     ltc_coin  # ltc OBJECT lib pulls in protocol handlers needing ltc::coin::{Mutable,}Transaction ctors
     btc
     btc_stratum
+    nmc_coin   # NMC coin-layer: embedded merged-mining (2b-ii) — supplies nmc::coin Transaction/MutableTransaction ctors for the aux commitment path wired into main_btc
     nlohmann_json::nlohmann_json
     ${Boost_LIBRARIES}
 )


### PR DESCRIPTION
PR-1 of 3 wiring embedded Namecoin merged-mining into the **packaged** c2pool-btc binary (the per-coin release.yml artifact, main_btc.cpp), so a shipped BTC v0.2.x package can carry NMC embedded MM. Today NMC host activation lives only in main_ltc.cpp (the multi-net binary), which release.yml does not package as the BTC artifact.

## This slice (link-only, no behavior change)
Adds `nmc_coin` to the c2pool-btc `target_link_libraries` block in `src/c2pool/CMakeLists.txt` (1 line). Supplies the nmc::coin out-of-line Transaction/MutableTransaction ctors that the aux-commitment path will call. No call sites yet, so the linker drops the unreferenced objects — the value here is proving nmc_coin is link-compatible with c2pool-btc's toolchain/flags (no ODR/symbol conflict).

## Verify
Clean from-scratch build on workstation: `[100%] Built target c2pool-btc`, exit 0, no errors. Binary 8.1 MB.

## Follows (separate slices, each off master)
- **PR-2** (substantive): host activation in main_btc — instantiate MM manager + NMC HeaderChain/Mempool/params + feed aux commitment into the coinbase build (replaces empty merged_addrs), mirroring main_ltc + the doge/coin pattern.
- **PR-3**: aux-submit broadcaster (submitauxblock + fallback) mirroring the BTC won-block dual-path submit seam.
- **CI**: NMC gate for the BTC package (link-presence + headless startup smoke).

Base off master per slice rule. No self-merge — for integrator review + operator tap.