### PR TITLE
dgb: portable pi constant for MSVC Windows release lane (M_PI undeclared)

### DIFF
--- a/src/impl/dgb/coin/binomial_conf_interval.hpp
+++ b/src/impl/dgb/coin/binomial_conf_interval.hpp
@@ -28,6 +28,10 @@
 namespace dgb {
 namespace coin {
 
+// MSVC does not define M_PI (non-standard POSIX macro) without _USE_MATH_DEFINES;
+// use a portable constexpr to keep the Windows/MSVC release lane building.
+constexpr double kPi = 3.14159265358979323846;
+
 // Oracle erf -- Abramowitz & Stegun formula 7.1.26 (util/math.py:100).
 // erf(-x) = -erf(x) handled via sign capture, exactly as the oracle.
 inline double erf_as7126(double x)
@@ -57,7 +61,7 @@ inline double ierf(double z)
 {
     double guess = 0.0;
     for (int i = 0; i < 10; ++i) {
-        const double dy = 2.0 * std::exp(-guess * guess) / std::sqrt(M_PI);
+        const double dy = 2.0 * std::exp(-guess * guess) / std::sqrt(kPi);
         const double y_over_dy = (erf_as7126(guess) - z) / dy;
         const double prev = guess;
         guess = guess - y_over_dy;


### PR DESCRIPTION
## What
Replace `std::sqrt(M_PI)` in `dgb/coin/binomial_conf_interval.hpp:ierf()` with a namespace-scope `constexpr double kPi`.

## Why
MSVC does not define the non-standard POSIX `M_PI` macro unless `_USE_MATH_DEFINES` is set before `<cmath>`. The dgb **release** Windows lane (release.yml, self-hosted VM217/MSVC) fails at `Build c2pool-dgb` with:
```
binomial_conf_interval.hpp(60): error C2065: 'M_PI': undeclared identifier
binomial_conf_interval.hpp(60): error C2737: 'dy': const object must be initialized
```
Linux/macOS and build.yml pass because build.yml does not compile dgb's main executable target. Confirmed on release-dispatch run 29307660687 (Linux+macOS green, Windows package red at this exact error).

A `constexpr` avoids header-order-dependent `_USE_MATH_DEFINES` fragility. No numeric change on any platform.

## Verification
Release-dispatch off this branch to confirm Windows dgb Build/Package non-hollow green (attached next).

Depends on nothing; independent of #696 (release.yml pwsh/em-dash shell heal). Signed 285EFE76. No self-merge.