### PR TITLE
security: clear CodeQL findings (gmtime thread-safety + path-injection hardening)

### DIFF
--- a/src/c2pool/merged/coin_peer_manager.hpp
+++ b/src/c2pool/merged/coin_peer_manager.hpp
@@ -17,6 +17,7 @@
 #include <cmath>
 #include <random>
 #include <algorithm>
+#include <cctype>
 #include <array>
 #include <sstream>
 
@@ -698,7 +699,20 @@ private:
         else
             dir = m_data_dir;
         std::filesystem::create_directories(dir);
-        return (dir / ("peers_" + m_symbol + ".json")).string();
+        // Defense-in-depth (CodeQL cpp/path-injection): m_symbol is a hardcoded
+        // ticker literal at every production ctor site, but never let it become a
+        // path component. Reject anything non-alphanumeric so no '/','\\','.' or
+        // NUL can survive into the filename.
+        std::string sym = m_symbol;
+        const bool clean = !sym.empty() && sym.size() <= 16 &&
+            std::all_of(sym.begin(), sym.end(),
+                        [](unsigned char c) { return std::isalnum(c) != 0; });
+        if (!clean) {
+            LOG_WARNING << "[PeerManager] non-alphanumeric coin symbol '"
+                        << m_symbol << "' -> using peers_unknown.json";
+            sym = "unknown";
+        }
+        return (dir / ("peers_" + sym + ".json")).string();
     }
 
     void save_peers()

--- a/src/core/filesystem.hpp
+++ b/src/core/filesystem.hpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <filesystem>
+#include <cstdlib>
 
 namespace core
 {
@@ -11,10 +12,15 @@ namespace filesystem
 
 inline std::filesystem::path config_path()
 {
+    // getenv may return nullptr if the var is unset; std::filesystem::path(nullptr)
+    // is UB. Fall back to the current directory so an unset HOME/APPDATA degrades
+    // gracefully instead of crashing.
     #ifdef _WIN32
-        return std::filesystem::path(std::getenv("APPDATA")) / "c2pool";
+        const char* base = std::getenv("APPDATA");
+        return std::filesystem::path(base ? base : ".") / "c2pool";
     #else  // Linux + macOS
-        return std::filesystem::path(std::getenv("HOME")) / ".c2pool";
+        const char* base = std::getenv("HOME");
+        return std::filesystem::path(base ? base : ".") / ".c2pool";
     #endif
 }
 

--- a/src/core/log.cpp
+++ b/src/core/log.cpp
@@ -160,7 +160,16 @@ void Logger::init(const std::string& log_file_name, int rotation_size_mb, int ma
         if (!fec && sz > static_cast<uintmax_t>(rotation_size_mb) * 1024 * 1024) {
             std::time_t t = std::time(nullptr);
             char ts[32];
-            std::strftime(ts, sizeof(ts), "%Y%m%d-%H%M%S", std::gmtime(&t));
+            // Thread-safe gmtime: std::gmtime returns a pointer into a shared
+            // static tm and is not reentrant (CodeQL cpp/potentially-dangerous-
+            // function). Use the reentrant per-platform variant into a local tm.
+            std::tm tmv{};
+#ifdef _WIN32
+            gmtime_s(&tmv, &t);   // MSVC secure-CRT: (tm*, time_t*)
+#else
+            gmtime_r(&t, &tmv);   // POSIX GCC/Clang: (time_t*, tm*)
+#endif
+            std::strftime(ts, sizeof(ts), "%Y%m%d-%H%M%S", &tmv);
             std::filesystem::path rotated =
                 rotated_dir / (debug_log.filename().string() + std::string(".") + ts);
             std::filesystem::rename(debug_log, rotated, fec);


### PR DESCRIPTION
Clears the **8 genuine CodeQL security alerts** on the repo. The other ~92 open code-scanning alerts are code-quality notes (`cpp/loop-variable-changed` from the intentional `argv[++i]` arg-parsing, unused-var, etc.), not security — handled separately by dismiss/query-suite tuning. **Dependabot = 0, secret-scanning = 0** (no dependency or secret vulns).

Every finding was triaged, then **independently re-reviewed** (adversarial second pass) — both passes agree.

## Fixed in this PR (3 findings)
| # | Sev | Site | Fix |
|---|-----|------|-----|
| #490 | **CRITICAL** | `src/core/log.cpp:163` | `std::gmtime` -> `gmtime_r`/`gmtime_s` into a local `tm` (reentrant). Only gmtime/localtime call in `src/`. |
| #503 | HIGH | `coin_peer_manager.hpp` `db_path()` | alnum-only guard on `m_symbol` before it enters the filename |
| #502 | HIGH | `coin_peer_manager.hpp` `db_path()` | (same guard closes both) |

**Rider (latent UB):** `core::filesystem::config_path()` dereferenced `getenv()` with no null check -> `path(nullptr)` is UB if `HOME`/`APPDATA` is unset. Now falls back to `.`.

## Dismiss as false-positive (5 findings)
`#507` node.cpp:2199, `#506/#505/#504` payout_manager.cpp:224/261/284, `#501` auto_ratchet.hpp:309 - all build a path from `config_path()` (getenv `HOME`/`APPDATA`) + a **hardcoded basename literal**, never from network/peer/miner input. Canonical CodeQL getenv-as-source FP; an attacker who controls `$HOME` already owns the process environment. Dismissed via the code-scanning API with that justification once this lands.

## Verification notes
- `m_symbol` traced through **every** ctor caller: both production `CoinBroadcaster` sites pass either a `blockchain_to_symbol()` enum-switch literal or a `--merged` spec gated behind an exact-match `get_chain_p2p_prefix` whitelist -> no `../` can reach `db_path()`. The guard is pure defense-in-depth for future callers.
- Legitimate tickers (LTC/DOGE/DGB/DASH/BTC/NMC/PEP/BELLS/...) are all alphanumeric -> **no on-disk peers-file rename**, no DASH/DGB/DOGE/NMC breakage.
- HTTP admin `chain` param, dash `broadcaster_full` port, and peer-address crawl data all independently ruled out as filename sources.