### PR TITLE
ci(boost): per-job Conan home + committed profile + Boost sentinel (root-fix, NOT a downgrade)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,11 @@ jobs:
   linux:
     name: Linux x86_64
     runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
+    # Private per-job Conan home: each job builds Boost into an ISOLATED cache,
+    # so concurrent jobs can never tear each other's ~/.conan2 (root cause of the
+    # 1.90.0 torn-header flakes). See ci-boost-stream.md.
+    env:
+      CONAN_HOME: ${{ runner.temp }}/conan2
     steps:
       - uses: actions/checkout@v6
 
@@ -64,16 +69,14 @@ jobs:
             conan --version   # pre-provisioned at /usr/local/bin on self-hosted
           fi
 
-      - name: Detect Conan profile
-        run: |
-          conan profile detect --force
-          sed -i 's/compiler.cppstd=.*/compiler.cppstd=20/' "$(conan profile path default)"
+      - name: Show committed Conan profile
+        run: conan profile show -pr:a=ci/conan/linux-gcc13.profile
 
       - name: Restore Conan cache
         uses: actions/cache@v5
         with:
-          path: ~/.conan2
-          key: conan2-ubuntu24-gcc13-${{ hashFiles('conanfile.txt') }}
+          path: ${{ runner.temp }}/conan2
+          key: conan2-ubuntu24-gcc13-${{ hashFiles('conanfile.txt', 'ci/conan/linux-gcc13.profile') }}
 
       # Self-hosted runners reuse the workspace across runs; a stale build_ci/
       # leaves gtest_discover_tests POST_BUILD artifacts that ctest then
@@ -85,10 +88,17 @@ jobs:
         run: rm -rf build_ci
 
       - name: Conan install
-        run: conan install . --build=missing --output-folder=build_ci --settings=build_type=Release
+        run: conan install . -pr:a=ci/conan/linux-gcc13.profile --build=missing --output-folder=build_ci
 
       - name: Configure
         run: cmake -S . -B build_ci -DCMAKE_TOOLCHAIN_FILE=build_ci/conan_toolchain.cmake -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCOIN_DGB=ON
+
+      # Boost header-integrity + version gate: a torn/mixed Boost tree or apt-Boost
+      # fallback fails HERE (fast, one TU), not deep in the coin build.
+      - name: Boost sentinel
+        run: |
+          cmake --build build_ci --target boost_sentinel -j8
+          ctest --test-dir build_ci -R '^boost_sentinel$' --output-on-failure
 
       - name: Build
         run: cmake --build build_ci --target c2pool -j8

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,5 +99,9 @@ endif()
 
 add_subdirectory(src)
 add_subdirectory(test)
+# Boost header-integrity + version sentinel (CI compile-gate; testing-only).
+if(GTest_FOUND OR GTEST_FOUND)
+    add_subdirectory(ci/sentinel)
+endif()
 # add_subdirectory(benchmark)
 # add_subdirectory(temp)

--- a/ci/conan/linux-gcc13.profile
+++ b/ci/conan/linux-gcc13.profile
@@ -1,0 +1,16 @@
+# Committed Conan profile — the Linux/GCC-13 lane that must hold.
+# Pins EXACT settings so every lane resolves the SAME package_id and can never
+# silently fall back to a wrong-config prebuilt (root-cause of the Boost 1.90.0
+# torn-header flakes). See ci-boost-stream.md §B.
+[settings]
+os=Linux
+arch=x86_64
+build_type=Release
+compiler=gcc
+compiler.version=13
+compiler.cppstd=20
+compiler.libcxx=libstdc++11
+
+[buildenv]
+CC=gcc-13
+CXX=g++-13

--- a/ci/sentinel/CMakeLists.txt
+++ b/ci/sentinel/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Boost header-integrity + version sentinel. Gated into every CI lane right
+# after conan install + configure, before the main build: a torn/mixed Boost
+# tree or an apt-Boost fallback fails HERE (fast, one TU) instead of deep in
+# the coin build. Boost::log / Boost::log_setup are found at the root scope.
+add_executable(boost_sentinel boost_sentinel.cpp)
+target_compile_features(boost_sentinel PRIVATE cxx_std_20)
+target_link_libraries(boost_sentinel PRIVATE Boost::log Boost::log_setup)
+add_test(NAME boost_sentinel COMMAND boost_sentinel)

--- a/ci/sentinel/boost_sentinel.cpp
+++ b/ci/sentinel/boost_sentinel.cpp
@@ -1,0 +1,67 @@
+// Boost header-integrity + version gate.
+//
+// Compiles ONE TU that exercises the four exact subsystems whose torn-header
+// signatures surfaced the Boost 1.90.0 / GCC-13 CI flakes, and static_asserts
+// the resolved Boost is 1.90.0 (catches a stray apt Boost 1.83 filling holes
+// via include-path fallback). Green here == intact single-version tree, right
+// version resolved, compiled archives link. See ci-boost-stream.md ss.D.
+#include <boost/version.hpp>
+static_assert(BOOST_VERSION == 109000, "wrong Boost tree resolved: expected 1.90.0");
+
+#include <boost/asio/cancel_after.hpp>   // pulls detail/timed_cancel_op.hpp (stage-1 casualty)
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/steady_timer.hpp>
+
+#include <boost/log/sources/record_ostream.hpp>
+#include <boost/log/sources/severity_logger.hpp>  // A.1 site (BOOST_PP expansion)
+#include <boost/log/trivial.hpp>
+#include <boost/log/utility/setup/console.hpp>
+
+#include <boost/signals2/signal.hpp>               // A.2 site (slot_template.hpp)
+
+#include <boost/fusion/adapted/std_pair.hpp>
+#include <boost/spirit/home/x3.hpp>                // A.3 site (operator/detail/sequence.hpp)
+
+#include <chrono>
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <utility>
+
+int main()
+{
+    // asio: timed cancellation machinery
+    boost::asio::io_context io;
+    boost::asio::steady_timer timer(io, std::chrono::milliseconds(100));
+    bool aborted = false;
+    timer.async_wait(boost::asio::cancel_after(
+        std::chrono::milliseconds(10),
+        [&](boost::system::error_code ec) { aborted = (ec == boost::asio::error::operation_aborted); }));
+    io.run();
+    if (!aborted) { std::puts("FAIL asio"); return 1; }
+
+    // log: severity_logger (header) + libboost_log / log_setup (link check)
+    boost::log::add_console_log();
+    boost::log::sources::severity_logger<boost::log::trivial::severity_level> lg;
+    BOOST_LOG_SEV(lg, boost::log::trivial::info) << "sentinel: log ok";
+
+    // signals2: std::shared_ptr tracking -> the exact foreign_void_weak_ptr push_back path
+    using sig_t = boost::signals2::signal<int(int)>;
+    sig_t sig;
+    auto tracked = std::make_shared<int>(1);
+    sig.connect(sig_t::slot_type([&](int x) { return x + *tracked; }).track_foreign(tracked));
+    if (sig(41).value_or(0) != 42) { std::puts("FAIL signals2"); return 1; }
+
+    // spirit.x3: sequence operator -> partition_attribute static_asserts
+    namespace x3 = boost::spirit::x3;
+    std::pair<int, int> out{};
+    std::string const in = "12,34";
+    auto it = in.begin();
+    if (!x3::parse(it, in.end(), x3::int_ >> ',' >> x3::int_, out)
+        || it != in.end() || out.first != 12 || out.second != 34) {
+        std::puts("FAIL spirit.x3"); return 1;
+    }
+
+    std::puts("boost_sentinel: asio+log+signals2+spirit.x3 OK");
+    return 0;
+}


### PR DESCRIPTION
Root-fix for the recurring Boost 1.90.0 / GCC-13 CI flakes per ci-boost-stream.md. **Keeps Boost 1.90.0** — the three compile errors were the mechanical signature of a torn/interleaved header set from a shared ~/.conan2 cache race + apt-Boost fallback, not a real 1.90.0<->GCC-13 incompatibility.

This PR is the **first slice** proving the mechanism on the highest-value lane (self-hosted Linux, where the poisoning occurred) and running the doc §A.5 falsification test.

What it does (build.yml linux lane + new artifacts):
- `ci/conan/linux-gcc13.profile` — committed, exact-pinned settings (cppstd=20 strict, libcxx=libstdc++11) so the lane always resolves the same package_id and cannot fall back to a wrong-config prebuilt.
- Private per-job `CONAN_HOME=${{ runner.temp }}/conan2` — each job builds Boost into an ISOLATED cache, so concurrent jobs can never tear each other's cache (the actual race fix). Install resolves via the committed profile.
- `ci/sentinel/boost_sentinel.cpp` — one TU that `static_assert`s BOOST_VERSION==1.90.0 (catches apt fallback) and exercises the four failing paths (asio cancel_after, severity_logger, signals2 track_foreign, spirit.x3 sequence). Gated right after configure, before the main build.

Falsification (§A.5): green sentinel from a pristine per-job home ⇒ version-agnostic, fix holds. If spirit.x3 STILL fires here, that is the only genuine-1.90.0-regression signal → then (and only then) flip `[requires]` to boost/1.88.0.

Follow-up slices (tracked, not in this PR): macOS/Windows profiles + sentinel wiring; committed conan.lock (recipe-revision pin); unskip the github-hosted `conan install` in coin-matrix/gate/codeql/release workflows; per-runner decontamination (purge poisoned boost + drop apt libboost-dev).

No self-merge — awaiting review + operator push-approval.