### PR TITLE
ci(release): apply #700 boost torn-cache pattern to release.yml (before v0.2.1 re-tag)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,12 @@ jobs:
   linux:
     name: ${{ matrix.coin }} package (Linux x86_64)
     runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
+    # Private per-job Conan home: each coin cell builds Boost into an ISOLATED
+    # cache, so the concurrent cells sharing the one c2pool-build self-hosted
+    # host can never tear each other's ~/.conan2 (root cause of the 1.90.0
+    # torn-header flakes). Mirrors build.yml. See ci-boost-stream.md.
+    env:
+      CONAN_HOME: ${{ runner.temp }}/conan2
     strategy:
       fail-fast: false
       matrix:
@@ -114,18 +120,16 @@ jobs:
             conan --version   # pre-provisioned at /usr/local/bin on self-hosted
           fi
 
-      - name: Detect Conan profile
+      - name: Show committed Conan profile
         if: steps.presence.outputs.exists == '1'
-        run: |
-          conan profile detect --force
-          sed -i 's/compiler.cppstd=.*/compiler.cppstd=20/' "$(conan profile path default)"
+        run: conan profile show -pr:a=ci/conan/linux-gcc13.profile
 
       - name: Restore Conan cache
         if: steps.presence.outputs.exists == '1'
         uses: actions/cache@v5
         with:
-          path: ~/.conan2
-          key: conan2-ubuntu24-gcc13-${{ matrix.coin }}-${{ hashFiles('conanfile.txt') }}
+          path: ${{ runner.temp }}/conan2
+          key: conan2-ubuntu24-gcc13-${{ matrix.coin }}-${{ hashFiles('conanfile.txt', 'ci/conan/linux-gcc13.profile', 'conan.lock') }}
           restore-keys: |
             conan2-ubuntu24-gcc13-${{ matrix.coin }}-
             conan2-ubuntu24-gcc13-
@@ -134,9 +138,10 @@ jobs:
         if: steps.presence.outputs.exists == '1'
         run: |
           conan install . \
+            -pr:a=ci/conan/linux-gcc13.profile \
+            --lockfile=conan.lock \
             --build=missing \
-            --output-folder=build_${{ matrix.coin }} \
-            --settings=build_type=Release
+            --output-folder=build_${{ matrix.coin }}
 
       - name: Configure
         if: steps.presence.outputs.exists == '1'
@@ -148,6 +153,15 @@ jobs:
             -DCMAKE_TOOLCHAIN_FILE=build_${{ matrix.coin }}/conan_toolchain.cmake \
             -DCMAKE_BUILD_TYPE=Release \
             ${{ matrix.coin == 'dgb' && '-DAUX_DOGE=ON' || '' }}
+
+      # Boost header-integrity + version gate: a torn/mixed Boost tree or an
+      # apt-Boost fallback fails HERE (fast, one TU), not deep in the coin
+      # packaging build. Same gate build.yml runs. See ci-boost-stream.md.
+      - name: Boost sentinel
+        if: steps.presence.outputs.exists == '1'
+        run: |
+          cmake --build build_${{ matrix.coin }} --target boost_sentinel -j$(nproc)
+          ctest --test-dir build_${{ matrix.coin }} -R '^boost_sentinel$' --output-on-failure
 
       - name: Build c2pool-${{ matrix.coin }}
         if: steps.presence.outputs.exists == '1'
@@ -418,6 +432,9 @@ jobs:
   windows:
     name: ${{ matrix.coin }} package (Windows x86_64)
     runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Windows","X64","c2pool-build"]') || 'windows-2022' }}
+    # Private per-job Conan home (isolated per coin cell) — see the Linux lane.
+    env:
+      CONAN_HOME: ${{ runner.temp }}/conan2
     defaults:
       run:
         # VM217 Windows PowerShell runs at ExecutionPolicy=Restricted and has no
@@ -484,23 +501,20 @@ jobs:
           Add-Content -Path $env:GITHUB_PATH -Value $userScripts
           conan --version
 
-      - name: Detect Conan profile
+      - name: Show committed Conan profile
         if: steps.presence.outputs.exists == '1'
-        run: |
-          conan profile detect --force
-          $profile = conan profile path default
-          (Get-Content $profile) -replace 'compiler.cppstd=14','compiler.cppstd=20' | Set-Content $profile
+        run: conan profile show -pr:a=ci/conan/windows-msvc.profile
 
       - name: Restore Conan cache
         if: steps.presence.outputs.exists == '1'
         uses: actions/cache@v5
         with:
-          path: ~/.conan2
-          key: conan2-windows-msvc194-${{ hashFiles('conanfile.txt') }}
+          path: ${{ runner.temp }}/conan2
+          key: conan2-windows-msvc194-${{ hashFiles('conanfile.txt', 'ci/conan/windows-msvc.profile', 'conan.lock') }}
 
       - name: Conan install
         if: steps.presence.outputs.exists == '1'
-        run: conan install . --build=missing --output-folder=build_ci
+        run: conan install . -pr:a=ci/conan/windows-msvc.profile --lockfile=conan.lock --build=missing --output-folder=build_ci
 
       - name: Build secp256k1
         if: steps.presence.outputs.exists == '1'
@@ -515,6 +529,15 @@ jobs:
         shell: cmd
         # DGB: -DAUX_DOGE=ON -> DGB parent + embedded DOGE (mirrors c2pool-ltc). Inert for other coins.
         run: cmake -S . -B build_ci -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=build_ci/conan_toolchain.cmake -DCMAKE_PREFIX_PATH="%GITHUB_WORKSPACE%/secp256k1" -DCMAKE_CXX_FLAGS="/D_WIN32_WINNT=0x0A00" ${{ matrix.coin == 'dgb' && '-DAUX_DOGE=ON' || '' }}
+
+      # Boost header-integrity + version gate (VS multi-config -> --config/-C Release).
+      # A torn/mixed Boost tree fails HERE, before the coin packaging build.
+      - name: Boost sentinel
+        if: steps.presence.outputs.exists == '1'
+        shell: cmd
+        run: |
+          cmake --build build_ci --target boost_sentinel --config Release -j %NUMBER_OF_PROCESSORS%
+          ctest --test-dir build_ci -R "^boost_sentinel$" -C Release --output-on-failure
 
       - name: Build c2pool-${{ matrix.coin }}
         if: steps.presence.outputs.exists == '1'

--- a/ci/conan/macos-clang.profile
+++ b/ci/conan/macos-clang.profile
@@ -1,0 +1,13 @@
+# Committed Conan profile — macOS / apple-clang lane (cppstd=20), per the Boost
+# root-fix plan (§B). NOTE: release.yml's macOS lanes currently build against
+# Homebrew deps, NOT Conan, so this profile is not yet wired into release.yml.
+# It is committed for provenance and for a future macOS->Conan migration; arch
+# is per-runner (armv8 on Apple Silicon, x86_64 on Intel), override with -s arch=.
+[settings]
+os=Macos
+arch=armv8
+build_type=Release
+compiler=apple-clang
+compiler.version=16
+compiler.cppstd=20
+compiler.libcxx=libc++

--- a/ci/conan/windows-msvc.profile
+++ b/ci/conan/windows-msvc.profile
@@ -1,0 +1,14 @@
+# Committed Conan profile — Windows / MSVC 2022 lane. Replaces the runtime
+# `conan profile detect --force` + `cppstd 14->20` sed on the release Windows
+# lane: pins EXACT settings so every lane resolves the SAME package_id and can
+# never silently fall back to a wrong-config prebuilt Boost (root cause of the
+# 1.90.0 torn-header flakes). See ci-boost-stream.md §B.
+[settings]
+os=Windows
+arch=x86_64
+build_type=Release
+compiler=msvc
+compiler.version=194
+compiler.cppstd=20
+compiler.runtime=dynamic
+compiler.runtime_type=Release

--- a/conan.lock
+++ b/conan.lock
@@ -1,0 +1,20 @@
+{
+    "version": "0.5",
+    "requires": [
+        "zlib/1.3.2#1cb806da49011867778ffb6ac7190fcb%1777558780.503",
+        "yaml-cpp/0.8.0#1aa371213f0307605d88ad5445581aff%1773246038.815",
+        "snappy/1.1.10#9cff2aa2cf616aa98532b1872ef44dcf%1743607712.928",
+        "nlohmann_json/3.12.0#2d634ab0ec8d9f56353e5ccef6d6612c%1744735883.94",
+        "libbacktrace/cci.20210118#a7691bfccd8caaf66309df196790a5a1%1722218217.276",
+        "leveldb/1.23#4e79f90a895472fbdf61064efa0ad95b%1707750968.355",
+        "gtest/1.14.0#f8f0757a574a8dd747d16af62d6eb1b7%1743410807.169",
+        "crc32c/1.1.2#e12fa67962640dc0412ffb28f47d206f%1759090994.248",
+        "bzip2/1.0.8#c470882369c2d95c5c77e970c0c7e321%1762886692.465",
+        "boost/1.90.0#cd8d6667856c182d561afc841f1a8252%1783338727.082"
+    ],
+    "build_requires": [
+        "b2/5.5.1#64d533c0c55f96a91011f77fd2900b45%1783557339.429"
+    ],
+    "python_requires": [],
+    "config_requires": []
+}


### PR DESCRIPTION
Follow-up to #700 (which landed build.yml-only). master release.yml still had the flaky pattern (`conan profile detect --force` at Linux ~L120 / Windows ~L490, shared ~/.conan2, no lockfile), so the v0.2.1 all-coin re-tag would re-hit the boost 1.90.0 torn-header flake. This extends the #700 pattern to release.yml.

## Linux + Windows package lanes (the two Conan-using lanes)
- **per-job `CONAN_HOME=${{ runner.temp }}/conan2`** — each concurrent coin cell on the shared c2pool-build host builds Boost into an isolated cache; this is the root-cause fix for the torn ~/.conan2.
- **committed profiles** — replace `conan profile detect --force` + cppstd sed with `-pr:a=ci/conan/linux-gcc13.profile` (already committed) and new `ci/conan/windows-msvc.profile` (msvc 194, cppstd=20). Stable package_id, no wrong-config prebuilt fallback.
- **conan.lock** — committed (boost/1.90.0 pinned) and passed via `--lockfile=conan.lock` on every install; cache keys now also hash the profile + lockfile.
- **Boost sentinel** — header-integrity gate runs before the coin build (fast fail on a torn/apt-fallback Boost), same gate as build.yml.
- VM217 Windows shell port (07-14) preserved.

## Not changed (by design)
- **macOS lanes** build against Homebrew deps, not Conan — they cannot hit the torn-cache flake. `ci/conan/macos-clang.profile` is committed for provenance / a future macOS→Conan migration only; the macOS lane is untouched.
- **checksums** job does no Conan build.

## Scope note
build.yml is already green with the #700 pattern; I deliberately did **not** re-touch it here to keep this PR release-scoped. Wiring build.yml to also consume conan.lock is a clean follow-up if you want lockfile enforcement fleet-wide.

Workflow-scope → your review + operator tap before merge. No self-merge.