### PR TITLE
btc(nmc PR-2a): wire BTCWorkSource.has_merged_chain to MergedMiningManager

### DIFF
--- a/src/c2pool/merged/merged_mining.cpp
+++ b/src/c2pool/merged/merged_mining.cpp
@@ -574,6 +574,16 @@ IAuxChainBackend* MergedMiningManager::get_chain_rpc(uint32_t chain_id)
     return nullptr;
 }
 
+bool MergedMiningManager::has_chain(uint32_t chain_id) const
+{
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
+    for (const auto& chain : m_chains) {
+        if (chain.config.chain_id == chain_id)
+            return true;
+    }
+    return false;
+}
+
 void MergedMiningManager::start()
 {
     if (m_running) return;

--- a/src/c2pool/merged/merged_mining.hpp
+++ b/src/c2pool/merged/merged_mining.hpp
@@ -242,6 +242,11 @@ public:
     // Number of registered chains
     size_t chain_count() const { return m_chains.size(); }
 
+    // True if a chain with this chain_id is registered (embedded OR rpc).
+    // NOTE: distinct from get_chain_rpc(), which returns only the RPC
+    // fallback backend (null for embedded-primary chains with no fallback).
+    bool has_chain(uint32_t chain_id) const;
+
     // Get RPC client for a chain (for wiring broadcaster getpeerinfo)
     IAuxChainBackend* get_chain_rpc(uint32_t chain_id);
 

--- a/src/impl/btc/stratum/work_source.cpp
+++ b/src/impl/btc/stratum/work_source.cpp
@@ -19,6 +19,7 @@
 #include <impl/btc/coin/mempool.hpp>
 #include <impl/btc/coin/template_builder.hpp>  // build_template + merkle_hash_pair
 #include <impl/btc/coin/transaction.hpp>
+#include <c2pool/merged/merged_mining.hpp>   // MergedMiningManager::has_chain (PR-2a)
 
 #include <core/address_utils.hpp>               // address_to_script (for share write path)
 #include <core/hash.hpp>
@@ -170,10 +171,11 @@ uint64_t BTCWorkSource::get_work_generation() const
     return work_generation_.load(std::memory_order_relaxed);
 }
 
-bool BTCWorkSource::has_merged_chain(uint32_t /*chain_id*/) const
+bool BTCWorkSource::has_merged_chain(uint32_t chain_id) const
 {
-    // BTC MVP: no merged mining (the LTC MM rig is DOGE — none for BTC currently).
-    return false;
+    // Wired in PR-2a: consult the merged-mining manager if main_btc set one
+    // (--merged NMC:...). No manager or unknown chain_id => false.
+    return mm_manager_ != nullptr && mm_manager_->has_chain(chain_id);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/impl/btc/stratum/work_source.hpp
+++ b/src/impl/btc/stratum/work_source.hpp
@@ -52,6 +52,9 @@ class Mempool;
 namespace rpc { struct WorkData; }
 }  // namespace btc::coin
 
+// Merged-mining manager (embedded NMC etc.) — heavy header lives in the .cpp.
+namespace c2pool { namespace merged { class MergedMiningManager; } }
+
 namespace btc::stratum {
 
 class BTCWorkSource : public core::stratum::IWorkSource
@@ -227,6 +230,11 @@ public:
     /// a stratum proxy without sharechain participation.
     void set_create_share_fn(CreateShareFn fn);
 
+    /// Wire the merged-mining manager (embedded NMC etc.). Called once at
+    /// startup from main_btc.cpp when --merged is passed. null => no
+    /// merged chains, has_merged_chain() returns false.
+    void set_merged_mining_manager(c2pool::merged::MergedMiningManager* mm) { mm_manager_ = mm; }
+
     /// Set the donation script (bytes of the c2pool donation
     /// scriptPubKey — typically a P2PKH or P2WPKH for the c2pool donation
     /// address). Used by build_connection_coinbase as the residual
@@ -267,6 +275,10 @@ private:
     RefHashFn                   ref_hash_fn_;
     CreateShareFn               create_share_fn_;
     std::vector<unsigned char>  donation_script_;
+
+    // Merged-mining manager (embedded NMC etc.); non-owning, set by
+    // main_btc.cpp. null => no merged chains configured.
+    c2pool::merged::MergedMiningManager* mm_manager_ = nullptr;
 
     // Template cache (filled lazily; invalidated when work_generation_ bumps)
     // Stage 4c populates these.


### PR DESCRIPTION
PR-2a of the NMC-into-c2pool-btc arc. Minimal, compile-safe seam.

## What
Wires BTCWorkSource.has_merged_chain() to the MergedMiningManager instead of the hardcoded `false` stub, so embedded merged-mining (NMC under BTC) can report through the BTC work source.

- `MergedMiningManager::has_chain(chain_id)` — true when a chain is registered (embedded OR rpc). Distinct from `get_chain_rpc()`, which returns only the RPC-fallback backend (null for embedded-primary chains).
- `BTCWorkSource` gains a non-owning `mm_manager_` pointer + `set_merged_mining_manager()` setter (manager forward-declared; heavy header confined to the .cpp).
- `has_merged_chain()` consults the manager; null manager => false.

## Scope
Seam only (+32/-3, 4 files). Host construction in main_btc.cpp (`--merged NMC:...`) is the follow-up. Behaviour is unchanged until a manager is wired, so this is a no-op on the shipped c2pool-btc path. Base master.