### PR TITLE
ci: fix job-level CONAN_HOME (runner.temp invalid at job-env → 0 jobs)

### DIFF
--- a/.github/workflows/bch-gate-g3a-regtest-block-production.yml
+++ b/.github/workflows/bch-gate-g3a-regtest-block-production.yml
@@ -33,6 +33,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Set per-job Conan home
+        run: echo "CONAN_HOME=$RUNNER_TEMP/conan2" >> "$GITHUB_ENV"
+
       - name: Check gate entrypoint presence
         id: presence
         run: |
@@ -65,18 +68,16 @@ jobs:
             conan --version   # pre-provisioned at /usr/local/bin on self-hosted
           fi
 
-      - name: Detect Conan profile
+      - name: Show committed Conan profile
         if: steps.presence.outputs.exists == '1'
-        run: |
-          conan profile detect --force
-          sed -i 's/compiler.cppstd=.*/compiler.cppstd=20/' "$(conan profile path default)"
+        run: conan profile show -pr:a=ci/conan/linux-gcc13.profile
 
       - name: Restore Conan cache
         if: steps.presence.outputs.exists == '1'
         uses: actions/cache@v5
         with:
-          path: ~/.conan2
-          key: conan2-ubuntu24-gcc13-bch-g3a-${{ hashFiles('conanfile.txt') }}
+          path: ${{ runner.temp }}/conan2
+          key: conan2-ubuntu24-gcc13-bch-g3a-${{ hashFiles('conanfile.txt', 'ci/conan/linux-gcc13.profile', 'conan.lock') }}
           restore-keys: |
             conan2-ubuntu24-gcc13-bch-g3a-
             conan2-ubuntu24-gcc13-

--- a/.github/workflows/bch-gate-g3b-genuine-activation.yml
+++ b/.github/workflows/bch-gate-g3b-genuine-activation.yml
@@ -30,6 +30,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Set per-job Conan home
+        run: echo "CONAN_HOME=$RUNNER_TEMP/conan2" >> "$GITHUB_ENV"
+
       - name: Check gate entrypoint presence
         id: presence
         run: |
@@ -62,18 +65,16 @@ jobs:
             conan --version   # pre-provisioned at /usr/local/bin on self-hosted
           fi
 
-      - name: Detect Conan profile
+      - name: Show committed Conan profile
         if: steps.presence.outputs.exists == '1'
-        run: |
-          conan profile detect --force
-          sed -i 's/compiler.cppstd=.*/compiler.cppstd=20/' "$(conan profile path default)"
+        run: conan profile show -pr:a=ci/conan/linux-gcc13.profile
 
       - name: Restore Conan cache
         if: steps.presence.outputs.exists == '1'
         uses: actions/cache@v5
         with:
-          path: ~/.conan2
-          key: conan2-ubuntu24-gcc13-bch-g3b-${{ hashFiles('conanfile.txt') }}
+          path: ${{ runner.temp }}/conan2
+          key: conan2-ubuntu24-gcc13-bch-g3b-${{ hashFiles('conanfile.txt', 'ci/conan/linux-gcc13.profile', 'conan.lock') }}
           restore-keys: |
             conan2-ubuntu24-gcc13-bch-g3b-
             conan2-ubuntu24-gcc13-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,13 +40,15 @@ jobs:
   linux:
     name: Linux x86_64
     runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
-    # Private per-job Conan home: each job builds Boost into an ISOLATED cache,
-    # so concurrent jobs can never tear each other's ~/.conan2 (root cause of the
-    # 1.90.0 torn-header flakes). See ci-boost-stream.md.
-    env:
-      CONAN_HOME: ${{ runner.temp }}/conan2
     steps:
       - uses: actions/checkout@v6
+
+      # Private per-job Conan home: each job builds Boost into an ISOLATED cache,
+      # so concurrent jobs can never tear each other's ~/.conan2 (root cause of the
+      # 1.90.0 torn-header flakes). RUNNER_TEMP is only valid at step scope, so
+      # export it via $GITHUB_ENV -- a job-level `env: runner.temp` fails to parse.
+      - name: Set per-job Conan home
+        run: echo "CONAN_HOME=$RUNNER_TEMP/conan2" >> "$GITHUB_ENV"
 
       - name: Install system dependencies
         if: runner.environment == 'github-hosted'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,6 +47,10 @@ jobs:
           build-mode: ${{ matrix.build-mode }}
           queries: security-and-quality
 
+      - if: matrix.build-mode == 'manual'
+        name: Set per-job Conan home
+        run: echo "CONAN_HOME=$RUNNER_TEMP/conan2" >> "$GITHUB_ENV"
+
       # ── C++ build (manual mode only) ─────────────────────────────────────
       - if: matrix.build-mode == 'manual' && runner.environment == 'github-hosted'
         name: Install system dependencies
@@ -73,17 +77,14 @@ jobs:
           else
             conan --version   # pre-provisioned at /usr/local/bin on self-hosted
           fi
-          conan profile detect --force
-          sed -i 's/compiler.cppstd=.*/compiler.cppstd=20/' \
-            "$(conan profile path default)"
 
       - if: matrix.build-mode == 'manual'
         name: Restore Conan package cache
         uses: actions/cache@v5
         with:
-          path: ~/.conan2
-          # Share cache with build.yml (same Release profile)
-          key: conan2-ubuntu24-gcc13-${{ hashFiles('conanfile.txt') }}
+          path: ${{ runner.temp }}/conan2
+          # Isolated per-job Conan home; keyed by profile + lockfile.
+          key: conan2-ubuntu24-gcc13-${{ hashFiles('conanfile.txt', 'ci/conan/linux-gcc13.profile', 'conan.lock') }}
           restore-keys: conan2-ubuntu24-gcc13-
 
       - if: matrix.build-mode == 'manual' && runner.environment != 'github-hosted'
@@ -94,6 +95,8 @@ jobs:
         name: Install Conan dependencies
         run: |
           conan install . \
+            -pr:a=ci/conan/linux-gcc13.profile \
+            --lockfile=conan.lock \
             --build=missing \
             --output-folder=build_codeql \
             --settings=build_type=Release

--- a/.github/workflows/coin-matrix.yml
+++ b/.github/workflows/coin-matrix.yml
@@ -37,6 +37,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Set per-job Conan home
+        run: echo "CONAN_HOME=$RUNNER_TEMP/conan2" >> "$GITHUB_ENV"
+
       - name: Check source presence
         id: presence
         run: |
@@ -69,18 +72,16 @@ jobs:
             conan --version   # pre-provisioned at /usr/local/bin on self-hosted
           fi
 
-      - name: Detect Conan profile
+      - name: Show committed Conan profile
         if: steps.presence.outputs.exists == '1'
-        run: |
-          conan profile detect --force
-          sed -i 's/compiler.cppstd=.*/compiler.cppstd=20/' "$(conan profile path default)"
+        run: conan profile show -pr:a=ci/conan/linux-gcc13.profile
 
       - name: Restore Conan cache
         if: steps.presence.outputs.exists == '1'
         uses: actions/cache@v5
         with:
-          path: ~/.conan2
-          key: conan2-ubuntu24-gcc13-${{ matrix.coin }}-${{ hashFiles('conanfile.txt') }}
+          path: ${{ runner.temp }}/conan2
+          key: conan2-ubuntu24-gcc13-${{ matrix.coin }}-${{ hashFiles('conanfile.txt', 'ci/conan/linux-gcc13.profile', 'conan.lock') }}
           restore-keys: |
             conan2-ubuntu24-gcc13-${{ matrix.coin }}-
             conan2-ubuntu24-gcc13-
@@ -102,6 +103,8 @@ jobs:
         if: steps.presence.outputs.exists == '1'
         run: |
           conan install . \
+            -pr:a=ci/conan/linux-gcc13.profile \
+            --lockfile=conan.lock \
             --build=missing \
             --output-folder=build_${{ matrix.coin }} \
             --settings=build_type=Release

--- a/.github/workflows/dash-gate-g1-byte-parity.yml
+++ b/.github/workflows/dash-gate-g1-byte-parity.yml
@@ -31,6 +31,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Set per-job Conan home
+        run: echo "CONAN_HOME=$RUNNER_TEMP/conan2" >> "$GITHUB_ENV"
+
       - name: Check gate entrypoint presence
         id: presence
         run: |
@@ -63,18 +66,16 @@ jobs:
             conan --version   # pre-provisioned at /usr/local/bin on self-hosted
           fi
 
-      - name: Detect Conan profile
+      - name: Show committed Conan profile
         if: steps.presence.outputs.exists == '1'
-        run: |
-          conan profile detect --force
-          sed -i 's/compiler.cppstd=.*/compiler.cppstd=20/' "$(conan profile path default)"
+        run: conan profile show -pr:a=ci/conan/linux-gcc13.profile
 
       - name: Restore Conan cache
         if: steps.presence.outputs.exists == '1'
         uses: actions/cache@v5
         with:
-          path: ~/.conan2
-          key: conan2-ubuntu24-gcc13-dash-g1-${{ hashFiles('conanfile.txt') }}
+          path: ${{ runner.temp }}/conan2
+          key: conan2-ubuntu24-gcc13-dash-g1-${{ hashFiles('conanfile.txt', 'ci/conan/linux-gcc13.profile', 'conan.lock') }}
           restore-keys: |
             conan2-ubuntu24-gcc13-dash-g1-
             conan2-ubuntu24-gcc13-

--- a/.github/workflows/dash-gate-g3a-regtest-block-production.yml
+++ b/.github/workflows/dash-gate-g3a-regtest-block-production.yml
@@ -34,6 +34,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Set per-job Conan home
+        run: echo "CONAN_HOME=$RUNNER_TEMP/conan2" >> "$GITHUB_ENV"
+
       - name: Check gate entrypoint presence
         id: presence
         run: |
@@ -66,18 +69,16 @@ jobs:
             conan --version   # pre-provisioned at /usr/local/bin on self-hosted
           fi
 
-      - name: Detect Conan profile
+      - name: Show committed Conan profile
         if: steps.presence.outputs.exists == '1'
-        run: |
-          conan profile detect --force
-          sed -i 's/compiler.cppstd=.*/compiler.cppstd=20/' "$(conan profile path default)"
+        run: conan profile show -pr:a=ci/conan/linux-gcc13.profile
 
       - name: Restore Conan cache
         if: steps.presence.outputs.exists == '1'
         uses: actions/cache@v5
         with:
-          path: ~/.conan2
-          key: conan2-ubuntu24-gcc13-dash-g3a-${{ hashFiles('conanfile.txt') }}
+          path: ${{ runner.temp }}/conan2
+          key: conan2-ubuntu24-gcc13-dash-g3a-${{ hashFiles('conanfile.txt', 'ci/conan/linux-gcc13.profile', 'conan.lock') }}
           restore-keys: |
             conan2-ubuntu24-gcc13-dash-g3a-
             conan2-ubuntu24-gcc13-

--- a/.github/workflows/dgb-phase-b-smoke.yml
+++ b/.github/workflows/dgb-phase-b-smoke.yml
@@ -26,6 +26,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Set per-job Conan home
+        run: echo "CONAN_HOME=$RUNNER_TEMP/conan2" >> "$GITHUB_ENV"
+
       - name: Check DGB Phase-B source presence
         id: presence
         run: |
@@ -57,18 +60,16 @@ jobs:
             conan --version   # pre-provisioned at /usr/local/bin on self-hosted
           fi
 
-      - name: Detect Conan profile
+      - name: Show committed Conan profile
         if: steps.presence.outputs.exists == '1'
-        run: |
-          conan profile detect --force
-          sed -i 's/compiler.cppstd=.*/compiler.cppstd=20/' "$(conan profile path default)"
+        run: conan profile show -pr:a=ci/conan/linux-gcc13.profile
 
       - name: Restore Conan cache
         if: steps.presence.outputs.exists == '1'
         uses: actions/cache@v5
         with:
-          path: ~/.conan2
-          key: conan2-ubuntu24-gcc13-dgb-smoke-${{ hashFiles('conanfile.txt') }}
+          path: ${{ runner.temp }}/conan2
+          key: conan2-ubuntu24-gcc13-dgb-smoke-${{ hashFiles('conanfile.txt', 'ci/conan/linux-gcc13.profile', 'conan.lock') }}
           restore-keys: |
             conan2-ubuntu24-gcc13-dgb-smoke-
             conan2-ubuntu24-gcc13-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,12 +56,6 @@ jobs:
   linux:
     name: ${{ matrix.coin }} package (Linux x86_64)
     runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
-    # Private per-job Conan home: each coin cell builds Boost into an ISOLATED
-    # cache, so the concurrent cells sharing the one c2pool-build self-hosted
-    # host can never tear each other's ~/.conan2 (root cause of the 1.90.0
-    # torn-header flakes). Mirrors build.yml. See ci-boost-stream.md.
-    env:
-      CONAN_HOME: ${{ runner.temp }}/conan2
     strategy:
       fail-fast: false
       matrix:
@@ -90,6 +84,11 @@ jobs:
             echo "exists=0" >> "$GITHUB_OUTPUT"
             echo "::warning::c2pool-${{ matrix.coin }} source not on this ref — no ${{ matrix.coin }} Linux package will be produced."
           fi
+
+      # Per-coin-cell Conan home; RUNNER_TEMP is step-scope only, so export via
+      # $GITHUB_ENV (job-level `env: runner.temp` fails to parse). See build.yml.
+      - name: Set per-job Conan home
+        run: echo "CONAN_HOME=$RUNNER_TEMP/conan2" >> "$GITHUB_ENV"
 
       - name: Install system dependencies
         if: steps.presence.outputs.exists == '1'
@@ -432,9 +431,6 @@ jobs:
   windows:
     name: ${{ matrix.coin }} package (Windows x86_64)
     runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Windows","X64","c2pool-build"]') || 'windows-2022' }}
-    # Private per-job Conan home (isolated per coin cell) — see the Linux lane.
-    env:
-      CONAN_HOME: ${{ runner.temp }}/conan2
     defaults:
       run:
         # VM217 Windows PowerShell runs at ExecutionPolicy=Restricted and has no
@@ -448,6 +444,11 @@ jobs:
         coin: ${{ fromJSON(github.event.inputs.coins || '["btc","ltc","dgb","dash","bch"]') }}
     steps:
       - uses: actions/checkout@v6
+
+      # Per-coin-cell Conan home; RUNNER_TEMP is step-scope only, so export via
+      # $GITHUB_ENV (job-level `env: runner.temp` fails to parse). PowerShell form.
+      - name: Set per-job Conan home
+        run: echo "CONAN_HOME=$env:RUNNER_TEMP/conan2" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Resolve version
         id: ver

--- a/tests/gates/bch_g3a_regtest_block_production.sh
+++ b/tests/gates/bch_g3a_regtest_block_production.sh
@@ -36,7 +36,7 @@ BUILD_DIR="${BUILD_DIR:-$REPO_ROOT/build_bch}"
 # 1. Ensure the targets exist (configure+build only if the CI cache is cold).
 if [ ! -f "$BUILD_DIR/CMakeCache.txt" ]; then
   echo "[$GATE] no build dir at $BUILD_DIR — configuring (conan + cmake -DCOIN_BCH=ON)"
-  conan install "$REPO_ROOT" --build=missing --output-folder="$BUILD_DIR" --settings=build_type=Release
+  conan install "$REPO_ROOT" -pr:a="$REPO_ROOT/ci/conan/linux-gcc13.profile" --lockfile="$REPO_ROOT/conan.lock" --build=missing --output-folder="$BUILD_DIR" --settings=build_type=Release
   cmake -S "$REPO_ROOT" -B "$BUILD_DIR" \
     -DCMAKE_TOOLCHAIN_FILE="$BUILD_DIR/conan_toolchain.cmake" \
     -DCMAKE_BUILD_TYPE=Release \

--- a/tests/gates/bch_g3b_genuine_activation.sh
+++ b/tests/gates/bch_g3b_genuine_activation.sh
@@ -46,7 +46,7 @@ BUILD_DIR="${BUILD_DIR:-$REPO_ROOT/build_bch}"
 # 1. Ensure the targets exist (configure+build only if the CI cache is cold).
 if [ ! -f "$BUILD_DIR/CMakeCache.txt" ]; then
   echo "[$GATE] no build dir at $BUILD_DIR — configuring (conan + cmake -DCOIN_BCH=ON)"
-  conan install "$REPO_ROOT" --build=missing --output-folder="$BUILD_DIR" --settings=build_type=Release
+  conan install "$REPO_ROOT" -pr:a="$REPO_ROOT/ci/conan/linux-gcc13.profile" --lockfile="$REPO_ROOT/conan.lock" --build=missing --output-folder="$BUILD_DIR" --settings=build_type=Release
   cmake -S "$REPO_ROOT" -B "$BUILD_DIR" \
     -DCMAKE_TOOLCHAIN_FILE="$BUILD_DIR/conan_toolchain.cmake" \
     -DCMAKE_BUILD_TYPE=Release \

--- a/tests/gates/dgb_phase_b_smoke.sh
+++ b/tests/gates/dgb_phase_b_smoke.sh
@@ -23,7 +23,7 @@ BUILD_DIR="${BUILD_DIR:-$REPO_ROOT/build}"
 # 1. Configure (conan + cmake) only if the CI cache is cold.
 if [ ! -f "$BUILD_DIR/CMakeCache.txt" ]; then
   echo "[$GATE] no build dir at $BUILD_DIR — configuring (conan + cmake)"
-  conan install "$REPO_ROOT" --build=missing --output-folder="$BUILD_DIR" --settings=build_type=Release
+  conan install "$REPO_ROOT" -pr:a="$REPO_ROOT/ci/conan/linux-gcc13.profile" --lockfile="$REPO_ROOT/conan.lock" --build=missing --output-folder="$BUILD_DIR" --settings=build_type=Release
   cmake -S "$REPO_ROOT" -B "$BUILD_DIR" \
     -DCMAKE_TOOLCHAIN_FILE="$BUILD_DIR/conan_toolchain.cmake" \
     -DCMAKE_BUILD_TYPE=Release \

--- a/tests/gates/g1_byte_parity_kat.sh
+++ b/tests/gates/g1_byte_parity_kat.sh
@@ -17,7 +17,7 @@ BUILD_DIR="${BUILD_DIR:-$REPO_ROOT/build}"
 # 1. Ensure the target exists (configure+build only if the CI cache is cold).
 if [ ! -f "$BUILD_DIR/CMakeCache.txt" ]; then
   echo "[$GATE] no build dir at $BUILD_DIR — configuring (conan + cmake)"
-  conan install "$REPO_ROOT" --build=missing --output-folder="$BUILD_DIR" --settings=build_type=Release
+  conan install "$REPO_ROOT" -pr:a="$REPO_ROOT/ci/conan/linux-gcc13.profile" --lockfile="$REPO_ROOT/conan.lock" --build=missing --output-folder="$BUILD_DIR" --settings=build_type=Release
   cmake -S "$REPO_ROOT" -B "$BUILD_DIR" \
     -DCMAKE_TOOLCHAIN_FILE="$BUILD_DIR/conan_toolchain.cmake" \
     -DCMAKE_BUILD_TYPE=Release

--- a/tests/gates/g3a_regtest_block_production.sh
+++ b/tests/gates/g3a_regtest_block_production.sh
@@ -21,7 +21,7 @@ BUILD_DIR="${BUILD_DIR:-$REPO_ROOT/build}"
 # 1. Ensure the targets exist (configure+build only if the CI cache is cold).
 if [ ! -f "$BUILD_DIR/CMakeCache.txt" ]; then
   echo "[$GATE] no build dir at $BUILD_DIR — configuring (conan + cmake)"
-  conan install "$REPO_ROOT" --build=missing --output-folder="$BUILD_DIR" --settings=build_type=Release
+  conan install "$REPO_ROOT" -pr:a="$REPO_ROOT/ci/conan/linux-gcc13.profile" --lockfile="$REPO_ROOT/conan.lock" --build=missing --output-folder="$BUILD_DIR" --settings=build_type=Release
   cmake -S "$REPO_ROOT" -B "$BUILD_DIR" \
     -DCMAKE_TOOLCHAIN_FILE="$BUILD_DIR/conan_toolchain.cmake" \
     -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
**Regression fix — CI + release have been dark since #700/#702 merged.**

## Root cause
#700 (build.yml) and #702 (release.yml) set `CONAN_HOME: ${{ runner.temp }}/conan2` at **job-level `env:`**. The `runner` context does not exist at job-env parse time (step scope only), so GitHub rejects the workflow: *Unrecognized named-value: runner*. Effect (confirmed live):
- `workflow_dispatch` on release.yml → HTTP 422 "failed to parse workflow".
- push runs of build.yml + release.yml materialize **zero jobs**, marked failure at 0s (runs 29358330561 / 29358331142).
- The v0.2.1 re-tag produced no release run because the workflow cannot parse.

## Fix
Drop the job-level `env: CONAN_HOME` in all 3 affected jobs (build.yml linux, release.yml linux + windows) and export it in an early step via `$GITHUB_ENV` where `RUNNER_TEMP` is valid (PowerShell `Out-File` on Windows). Per-job/per-cell Boost cache isolation is preserved; the exported path matches the existing step-level cache `path:`.

## Verified
- both files parse (python `yaml.safe_load`).
- no job-level `runner.temp` remains (only comments + step-level cache `path:`, both valid at step scope).
- 3 `$GITHUB_ENV` exports present (build-linux bash, release-linux bash, release-windows pwsh).

Follow-up (non-blocking, per integrator): release macos/macos-universal/checksums and build.yml other coin jobs use shared ~/.conan2 and are still flake-exposed — add the same isolation step-set separately.

Signed b4ba9792. No self-merge — integrator review + operator tap.