### PR TITLE
cmake: set /EHsc for MSVC — fixes boost::throw_exception LNK2019 (all Windows release builds)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,12 @@ endif()
 if(MSVC)
     # Suppress common MSVC warnings for POSIX names and unsafe CRT functions
     add_compile_definitions(_CRT_SECURE_NO_WARNINGS _WINSOCK_DEPRECATED_NO_WARNINGS)
+    # Enable C++ unwind semantics (/EHsc). Boost headers (asio, log, signals2)
+    # reference the inline boost::throw_exception, which links as an unresolved
+    # external (LNK2019) unless exceptions are enabled. The pinned Conan MSVC
+    # toolchain does not guarantee CMake's default /EHsc, so set it explicitly
+    # for every MSVC target — the coin binaries and the CI boost_sentinel alike.
+    add_compile_options(/EHsc)
 endif()
 
 # Handle CMake 3.30+ policy for FindBoost removal


### PR DESCRIPTION
## The bug
The v0.2.1 release build (tag `v0.2.1` @ `884a0aeb`) produced **all 5 coins on Linux + macOS-universal**, but **all 5 Windows x86_64 cells FAILED** — including LTC, which built fine before. Root cause (from the ltc Windows log):

```
warning C4530: C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc
boost_sentinel.obj : error LNK2019: unresolved external symbol "boost::throw_exception" ...
fatal error LNK1120: 2 unresolved externals
```

The pinned Conan `windows-msvc.profile` (#702) carries no exception flag, and Conan's toolchain doesn't guarantee CMake's default `/EHsc`. With exceptions disabled, Boost's inline `boost::throw_exception` (pulled in via asio/log/signals2) becomes an unresolved external. This killed the **`boost_sentinel` gate** first (it links `Boost::log`), so every coin's Windows cell died *before its own build even ran* — hence all 5 failing identically.

## The fix
Set `/EHsc` explicitly for **all** MSVC targets in the root CMakeLists (coin binaries + the CI `boost_sentinel`). One line, MSVC-only; Linux/macOS untouched.

## Verification path
Not workflow-scope — mergeable once green. After merge I'll re-tag `v0.2.1` to the fixed master and re-run the release build; expect the 5 Windows packages to join the already-green Linux + macOS set for the complete all-coin v0.2.1.