### PR TITLE
release.yml: resilient Windows setup.exe step (skip when Inno Setup unavailable, always ship .zip)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -577,14 +577,28 @@ jobs:
           name: pkg-windows-${{ matrix.coin }}
           path: c2pool-*-windows-x86_64.zip
 
+      # Installer is a NICE-TO-HAVE: the portable .zip (uploaded above) is the
+      # must-have deliverable. If Inno Setup is unavailable on the runner (e.g.
+      # VM217 where choco cannot write C:\ProgramData\chocolatey\lib-bad), warn
+      # and skip so the job still succeeds and the .zip ships. Durable fix is a
+      # persistent Inno Setup 6 install on the runner (ISCC on PATH).
       - name: Build setup.exe installer (Inno Setup)
         if: steps.presence.outputs.exists == '1'
         shell: cmd
+        continue-on-error: true
         run: |
-          choco install innosetup -y --no-progress
+          set "ISCC=C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
+          if not exist "%ISCC%" (
+            echo Inno Setup not found; attempting install via chocolatey...
+            choco install innosetup -y --no-progress || echo WARNING: choco install innosetup failed
+          )
+          if not exist "%ISCC%" (
+            echo ::warning::Inno Setup unavailable on this runner; skipping setup.exe. Portable .zip already uploaded.
+            exit /b 0
+          )
           set "PKG=c2pool-${{ matrix.coin }}-${{ steps.ver.outputs.version }}-windows-x86_64"
           for /f "delims=" %%i in ('powershell -NoProfile -Command "(Get-ChildItem -Path 'C:\Program Files\Microsoft Visual Studio\2022' -Recurse -Filter vc_redist.x64.exe -ErrorAction SilentlyContinue | Select-Object -First 1).FullName"') do set "VCREDIST=%%i"
-          "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" installer\windows\c2pool-setup.iss ^
+          "%ISCC%" installer\windows\c2pool-setup.iss ^
             /DPACKAGE_DIR="%CD%\%PKG%" ^
             /DVCREDIST_PATH="%VCREDIST%" ^
             /DMyAppName=c2pool-${{ matrix.coin }} ^
@@ -599,6 +613,7 @@ jobs:
         with:
           name: pkg-windows-setup-${{ matrix.coin }}
           path: c2pool-*-windows-x86_64-setup.exe
+          if-no-files-found: ignore
 
   # ════════════════════════════════════════════════════════════════════════════
   # Aggregate: single SHA256SUMS over every produced package; on tags,


### PR DESCRIPTION
Fixes the last-step Windows failure on v0.2.1 (integrator report 2026-07-15).

## Problem
With the /EHsc fix (#707) the boost_sentinel passes and coin binaries build on Windows, but LTC/BCH/DGB/BTC cells now die at the final step "Build setup.exe installer (Inno Setup)":

    choco install innosetup ... Cannot create directory C:\ProgramData\chocolatey\lib-bad ... WinIOError

The step choco-installs Inno Setup at build time; chocolatey cannot write on VM217. The binary and portable .zip build fine but the job fails at the installer, so **nothing uploads**.

## Change (safety net — part 2 of integrator ask)
Guard the setup.exe step:
- Use `ISCC.exe` if already on the runner; else attempt `choco install` tolerantly; else emit `::warning::` and `exit /b 0`.
- `continue-on-error: true` on the build step and `if-no-files-found: ignore` on the upload, so the portable **.zip (must-have)** always ships even when the **.exe installer (nice-to-have)** cannot build.

macOS untouched. YAML validated.

## Durable fix (part 1 — separate fleet action, not this PR)
Persistent Inno Setup 6 install on VM217 (ISCC on PATH) so the step stops choco-installing at build time — coordinated with the VM217 owner per the no-unilateral-VM rule.

No self-merge — integrator review + operator tap.