### PR TITLE
ci(build): per-job CONAN_HOME for the 5 remaining conan-building jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,6 +189,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Per-job Conan home under $RUNNER_TEMP so concurrent jobs on the shared
+      # self-hosted host never tear each other's cache (root of the boost
+      # torn-cache reds). Export via $GITHUB_ENV -- a job-level `env: runner.temp`
+      # fails to parse.
+      - name: Set per-job Conan home
+        run: echo "CONAN_HOME=$RUNNER_TEMP/conan2" >> "$GITHUB_ENV"
+
       - name: Install system dependencies
         if: runner.environment == 'github-hosted'
         run: |
@@ -216,8 +223,8 @@ jobs:
       - name: Restore Conan cache
         uses: actions/cache@v5
         with:
-          path: ~/.conan2
-          key: conan2-ubuntu24-gcc13-${{ hashFiles('conanfile.txt') }}
+          path: ${{ runner.temp }}/conan2
+          key: conan2-ubuntu24-gcc13-asan-${{ hashFiles('conanfile.txt') }}
 
       # Self-hosted runners reuse the workspace across runs; a stale build_asan/
       # leaves gtest_discover_tests POST_BUILD artifacts that ctest then
@@ -312,6 +319,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Per-job Conan home under $RUNNER_TEMP so concurrent jobs on the shared
+      # self-hosted host never tear each other's cache (root of the boost
+      # torn-cache reds). Export via $GITHUB_ENV -- a job-level `env: runner.temp`
+      # fails to parse.
+      - name: Set per-job Conan home
+        run: echo "CONAN_HOME=$RUNNER_TEMP/conan2" >> "$GITHUB_ENV"
+
       - name: Install system dependencies
         if: runner.environment == 'github-hosted'
         run: |
@@ -339,7 +353,7 @@ jobs:
       - name: Restore Conan cache
         uses: actions/cache@v5
         with:
-          path: ~/.conan2
+          path: ${{ runner.temp }}/conan2
           key: conan2-ubuntu24-gcc13-bch-${{ hashFiles('conanfile.txt') }}
 
       # Self-hosted runners reuse the workspace across runs; a stale build_bch/
@@ -401,6 +415,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Per-job Conan home under $RUNNER_TEMP so concurrent jobs on the shared
+      # self-hosted host never tear each other's cache (root of the boost
+      # torn-cache reds). Export via $GITHUB_ENV -- a job-level `env: runner.temp`
+      # fails to parse.
+      - name: Set per-job Conan home
+        run: echo "CONAN_HOME=$RUNNER_TEMP/conan2" >> "$GITHUB_ENV"
+
       - name: Install system dependencies
         if: runner.environment == 'github-hosted'
         run: |
@@ -428,8 +449,8 @@ jobs:
       - name: Restore Conan cache
         uses: actions/cache@v5
         with:
-          path: ~/.conan2
-          key: conan2-ubuntu24-gcc13-bch-${{ hashFiles('conanfile.txt') }}
+          path: ${{ runner.temp }}/conan2
+          key: conan2-ubuntu24-gcc13-bch-asan-${{ hashFiles('conanfile.txt') }}
 
       # Self-hosted runners reuse the workspace across runs; a stale build_bch_asan/
       # leaves gtest_discover_tests POST_BUILD artifacts that ctest then
@@ -765,6 +786,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Per-job Conan home under $RUNNER_TEMP so concurrent jobs never tear each
+      # other's cache. Export via $GITHUB_ENV (job-level env fails to parse).
+      # PowerShell form (inherits the job's ExecutionPolicy-Bypass shell).
+      - name: Set per-job Conan home
+        run: echo "CONAN_HOME=$env:RUNNER_TEMP/conan2" | Out-File -FilePath $env:GITHUB_ENV -Append
+
       - uses: actions/setup-python@v6
         if: ${{ runner.environment == 'github-hosted' }}
         with: { python-version: '3.12' }
@@ -811,7 +838,7 @@ jobs:
       - name: Restore Conan cache
         uses: actions/cache@v5
         with:
-          path: ~/.conan2
+          path: ${{ runner.temp }}/conan2
           key: conan2-windows-msvc194-${{ hashFiles('conanfile.txt') }}
 
       - name: Conan install
@@ -876,6 +903,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Per-job Conan home under $RUNNER_TEMP so concurrent jobs on the shared
+      # self-hosted host never tear each other's cache (root of the boost
+      # torn-cache reds). Export via $GITHUB_ENV -- a job-level `env: runner.temp`
+      # fails to parse.
+      - name: Set per-job Conan home
+        run: echo "CONAN_HOME=$RUNNER_TEMP/conan2" >> "$GITHUB_ENV"
+
       - name: Install system dependencies
         if: runner.environment == 'github-hosted'
         run: |
@@ -903,7 +937,7 @@ jobs:
       - name: Restore Conan cache
         uses: actions/cache@v5
         with:
-          path: ~/.conan2
+          path: ${{ runner.temp }}/conan2
           key: conan2-ubuntu24-gcc13-dgb-auxdoge-${{ hashFiles('conanfile.txt') }}
 
       # Self-hosted runners reuse the workspace across runs; a stale build_dgb_auxdoge/


### PR DESCRIPTION
Finishes the #704 durability pass. Five conan-building jobs in build.yml still cached the shared `~/.conan2` on the self-hosted c2pool-linux-905 host, so concurrent jobs kept tearing each other's b2/boost cache — the intermittent `b2/5.5.1 ... file to download already exists` reds the operator flagged on AsAN/BCH/DGB (#706/#708/#709).

Applies the `linux`-job pattern (from #704) to all five:
- **linux-asan, coin-bch, coin-bch-asan, coin-dgb-auxdoge** — post-checkout `Set per-job Conan home` step exporting `CONAN_HOME=\$RUNNER_TEMP/conan2` via `\$GITHUB_ENV` (not job-level env — that is the runner.temp parse break patched in #704).
- **windows** — same, PowerShell `Out-File` form, inheriting the job's ExecutionPolicy-Bypass shell.
- cache `path: ~/.conan2` -> `\${{ runner.temp }}/conan2` on all five.
- scoped the two colliding keys: linux-asan -> `-asan`, coin-bch-asan -> `-bch-asan` (coin-bch/windows/dgb keys were already distinct).

Verified: `yaml.safe_load` parses; 6/6 conan cache paths now per-job runner.temp; all 6 keys unique. Diff is build.yml only (+41/-7). Needs a PR run where linux-asan/coin-bch/coin-dgb-auxdoge go green without a retry. No self-merge — integrator review + operator workflow-scope tap.