### PR TITLE
btc: disambiguate HexStr overload for MSVC (share_tracker.hpp:551) — last coin for all-5 Windows v0.2.1

### DIFF
--- a/src/impl/btc/share_tracker.hpp
+++ b/src/impl/btc/share_tracker.hpp
@@ -548,7 +548,9 @@ public:
                 if constexpr (requires { s->m_pubkey_hash; })
                     miner = s->m_pubkey_hash.GetHex();
                 else if constexpr (requires { s->m_address; })
-                    miner = HexStr(s->m_address.m_data);
+                    // MSVC: disambiguate HexStr overload (std::vector<unsigned char> is viable
+                    // for all span overloads). Feed the exact byte span the uint8_t overload wants.
+                    miner = HexStr(Span<const uint8_t>(s->m_address.m_data.data(), s->m_address.m_data.size()));
                 m_on_share_difficulty(diff, miner);
             });
         }


### PR DESCRIPTION
## Problem
BTC is the only coin missing from the v0.2.1 Windows set. c2pool-btc fails on MSVC:

```
src/impl/btc/share_tracker.hpp(551,29): error C2668: ambiguous call to overloaded function HexStr
```

`s->m_address` is a `BaseScript` whose `m_data` is `std::vector<unsigned char>`. MSVCs stricter overload resolution finds that vector viable for all three `HexStr` span overloads (`Span<const uint8_t>`, `Span<const char>`, `Span<const std::byte>`), so the bare `HexStr(s->m_address.m_data)` call is ambiguous. GCC/Clang resolve it, so Linux/macOS already build.

## Fix
Name the exact parameter type of the intended overload — `Span<const uint8_t>` built from the raw byte span:

```cpp
miner = HexStr(Span<const uint8_t>(s->m_address.m_data.data(), s->m_address.m_data.size()));
```

`Span` (btclibs/span.h) is already in scope via strencodings.h — no new include. This is MSVC-only disambiguation; no behavior change on any platform.

## Output verified byte-identical
Minimal TU under -std=c++20 exercising the exact expression on a fixture:
- `HexStr(Span<const uint8_t>(data, size))` == `HexStr(MakeUCharSpan(vec))` == `deadbeef`. rc=0.

Same bytes to the same uint8_t-span overload GCC/Clang were already selecting → the miner-id hex string is unchanged.

Mirrors the explicit-span idiom already green on the LTC Windows build (ltc/coin/template_builder.hpp).