### PR TITLE
release.yml: idempotent draft assembly (no more duplicate v0.2.1 drafts) + surface missing setup.exe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -613,7 +613,10 @@ jobs:
         with:
           name: pkg-windows-setup-${{ matrix.coin }}
           path: c2pool-*-windows-x86_64-setup.exe
-          if-no-files-found: ignore
+          # warn (not ignore): if ISCC ran but produced no .exe, surface it as a
+          # run annotation instead of silently shipping a draft with no installer.
+          # Still non-fatal — the portable .zip remains the must-have deliverable.
+          if-no-files-found: warn
 
   # ════════════════════════════════════════════════════════════════════════════
   # Aggregate: single SHA256SUMS over every produced package; on tags,
@@ -649,14 +652,27 @@ jobs:
           name: SHA256SUMS
           path: dist/SHA256SUMS
 
-      - name: Create draft release
+      # Idempotent draft assembly: a v-tag draft may already exist from a prior
+      # re-run of this job. gh release create is NOT idempotent -- it spawns a
+      # SECOND draft with the same tag_name, so repeated runs pile up duplicate
+      # "vX.Y.Z" drafts. Refresh ONE canonical draft instead: upload --clobber
+      # if the release exists, else create it fresh.
+      - name: Assemble draft release (idempotent)
         if: startsWith(github.ref, 'refs/tags/v')
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "${GITHUB_REF_NAME}" \
-            --repo "${{ github.repository }}" \
-            --draft \
-            --title "c2pool ${GITHUB_REF_NAME}" \
-            --notes "Draft assembled by release.yml — operator reviews and publishes manually." \
-            dist/*
+          TAG="${GITHUB_REF_NAME}"
+          REPO="${{ github.repository }}"
+          if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+            echo "Draft $TAG already exists -- refreshing assets in place (--clobber)."
+            gh release upload "$TAG" dist/* --clobber --repo "$REPO"
+          else
+            echo "No release for $TAG -- creating fresh draft."
+            gh release create "$TAG" \
+              --repo "$REPO" \
+              --draft \
+              --title "c2pool $TAG" \
+              --notes "Draft assembled by release.yml -- operator reviews and publishes manually." \
+              dist/*
+          fi


### PR DESCRIPTION
Fixes two release.yml/checksums-job issues surfaced completing v0.2.1 (integrator, 2026-07-15).

## 1. Duplicate drafts (the actual workflow bug)
The final step ran `gh release create "$TAG" --draft ... dist/*` unconditionally. `gh release create` is NOT idempotent against a tag that already has a draft — it spawns ANOTHER draft with the same tag_name. Re-running the checksums job for v0.2.1 produced four duplicate drafts (352940274/354059858/354194644/354303682); `gh release view v0.2.1` returns the stale one, so the tag looked incomplete.

Fix: refresh ONE canonical draft — `gh release view` ? `gh release upload --clobber` : `gh release create`. Re-runs now update the single draft in place.

## 2. setup.exe visibility
Investigated the plumbing: setup.exe is uploaded as a **separate** `pkg-windows-setup-<coin>` artifact (not bundled in pkg-windows-<coin>), and the checksums job already pulls it into the draft via its `pattern: pkg-*` download. So routing is correct — the .exe was absent because that draft-producing run predated a working ISCC on VM217 (the Inno step hit its choco-fail exit-0 skip path). With persistent ISCC on VM217, a fresh run now produces + ships them.

To keep this from silently recurring, flipped the setup.exe upload from `if-no-files-found: ignore` to `warn`: a run where ISCC yields no installer is now an annotation instead of a silent .zip-only draft. Still non-fatal — the portable .zip stays the must-have deliverable.

## Validation
- YAML parses (yaml.safe_load).
- Commit GPG-signed (key 50AB1379285EFE76).
- No functional change to the .zip/package path; only the draft-assembly step and one upload guard.

After merge: one clean re-dispatch off the tag yields the canonical v0.2.1 draft (both .zip AND setup.exe per coin); the four duplicate drafts can then be deleted, keeping the newest canonical one.

Workflow-scope — needs your review + operator workflow-scope tap. No self-merge.