### PR TITLE
ci(asan): build boost_sentinel so it runs (fixes linux-asan Not Run -> exit 8)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -264,6 +264,7 @@ jobs:
         run: |
           cmake --build build_asan \
             --target c2pool \
+                    boost_sentinel \
                     test_hardening test_share_messages \
                     test_redistribute_address test_redistribute test_auto_ratchet \
                     test_stratum_extensions \


### PR DESCRIPTION
## Problem
`Linux x86_64 (AsAN+UBSan)` fails with:
```
The following tests FAILED:
  1913 - boost_sentinel (Not Run)
Errors while running CTest ... exit code 8
```
Every real test passes; only `boost_sentinel` shows **Not Run**, tripping ctest exit 8. Reported on #713 (web-only) and #706 (DASH S8).

## Root cause (deterministic, not a flake)
- Root CMake registers the test globally: `add_subdirectory(ci/sentinel)` under `GTest_FOUND` -> `add_test(NAME boost_sentinel ...)`.
- The linux-asan job `Build c2pool + tests` `--target` allowlist never built the `boost_sentinel` binary.
- `ctest --exclude-regex "LiveTest\."` includes the registered test but the executable is absent -> **Not Run** -> exit 8.
- Introduced by #700 (9e4ba869), which wired the sentinel build only into the `linux` lane (its dedicated Boost sentinel step). The ASan lane is informational/non-gating (build.yml L169), so master stayed green while the lane was silently red on every ASan run since.

## Fix
Add `boost_sentinel` to the linux-asan build target list so the binary exists and the sentinel runs under ASan/UBSan (bonus: sanitized coverage of the boost integrity gate). One-line diff; mirrors the linux lane intent.

## Unblock path for #713 / #706
This fix lives in build.yml on master. After merge (operator push-approval), rebase #713 and #706 onto new master to pick it up; their ASan lanes then go green. I can alternatively cherry-pick this one-liner onto each branch for a faster unblock.

No self-merge.
