### PR TITLE
btc(msvc): disambiguate second HexStr C2668 at coin/node.hpp:131

### DIFF
--- a/src/impl/btc/coin/node.hpp
+++ b/src/impl/btc/coin/node.hpp
@@ -128,7 +128,11 @@ public:
     {
         if (!m_rpc)
             return false;
-        return m_rpc->submit_block_hex(HexStr(block_bytes), /*ignore_failure=*/true);
+        // MSVC: disambiguate HexStr overload (std::vector<unsigned char> is viable
+        // for all span overloads). Feed the exact byte span the uint8_t overload wants.
+        return m_rpc->submit_block_hex(
+            HexStr(Span<const uint8_t>(block_bytes.data(), block_bytes.size())),
+            /*ignore_failure=*/true);
     }
 
     /// Broadcast a WON block with FALLBACK semantics: P2P relay is primary,


### PR DESCRIPTION
Fixes the sole remaining v0.2.1 Windows build failure (run 29467003679): `node.hpp(131,40): C2668 ambiguous HexStr`.

Same MSVC ambiguity #711 fixed in share_tracker.hpp, at a second call site (block-submit RPC fallback). `std::vector<unsigned char>` is viable for all three Span overloads; feed the exact `Span<const uint8_t>` — byte-identical to the #711 pattern.

Swept every HexStr site reachable from the MSVC btc build: the only other bare-container sites (config_coin `prefix`, config_pool `m_prefix`) are `std::vector<std::byte>`, which match a single overload and are already unambiguous. No third site remains.