### PR TITLE
btc: fix MSVC C2668 HexStr ambiguity breaking btc Windows release lane

### DIFF
--- a/src/impl/btc/coin/node.hpp
+++ b/src/impl/btc/coin/node.hpp
@@ -128,7 +128,7 @@ public:
     {
         if (!m_rpc)
             return false;
-        return m_rpc->submit_block_hex(HexStr(block_bytes), /*ignore_failure=*/true);
+        return m_rpc->submit_block_hex(HexStr(Span<const unsigned char>(block_bytes.data(), block_bytes.size())), /*ignore_failure=*/true);
     }
 
     /// Broadcast a WON block with FALLBACK semantics: P2P relay is primary,


### PR DESCRIPTION
**Problem.** v0.2.1 release run 29467003679 — `btc package (Windows x86_64)` failed with `node.hpp(131,40): error C2668: HexStr ambiguous call`. All 24 other lanes and the SHA256SUMS/draft step passed.

**Cause.** `submit_block_hex` passed a `std::vector<unsigned char>` directly to `HexStr`. There are three overloads (`Span<const uint8_t|char|std::byte>`); MSVC finds the vector->Span conversion ambiguous where GCC/Clang resolve to `uint8_t`.

**Fix.** Wrap in an explicit `Span<const unsigned char>(data, size)` — the idiom already used by every other coin lane (dgb/dash/ltc/bch). One line, btc-only, no behavior change.

Validate: btc Windows lane should now compile. Signed commit; no self-merge — integrator gate.