### PR TITLE
ci(release): cap btc/dgb Windows compile to -j 8 (VM217 pagefile-wall fix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -543,7 +543,13 @@ jobs:
       - name: Build c2pool-${{ matrix.coin }}
         if: steps.presence.outputs.exists == '1'
         shell: cmd
-        run: cmake --build build_ci --target c2pool-${{ matrix.coin }} --config Release -j %NUMBER_OF_PROCESSORS%
+        # VM217 has a fixed 2GB pagefile; a 16-way MSVC parallel build of the
+        # heavy btc+NMC (and dgb+DOGE) TU set drives commit charge past the
+        # 32GB+2GB wall. The failure surfaces as an orphaned MSBuild with NO
+        # C####/LNK diagnostic. Cap MSBuild /maxcpucount (cmake -j -> /maxcpucount
+        # on the VS generator) to bound concurrent cl.exe and keep committed
+        # memory under the wall. Conservative 8; tune up only if headroom allows.
+        run: cmake --build build_ci --target c2pool-${{ matrix.coin }} --config Release -j 8
 
       - name: Smoke test (--help)
         if: steps.presence.outputs.exists == '1'


### PR DESCRIPTION
Root cause (vm-fleet-steward): VM217 has a fixed 2GB pagefile. A 16-way MSVC parallel build of the heavy btc+NMC (and dgb+DOGE) TU set drives commit charge past the 32GB+2GB wall. The allocation failure surfaces as an orphaned MSBuild with no C####/LNK diagnostic -- the walled, no-compiler-error signature behind the 3 btc-Windows v0.2.1 failures.

Fix: cap the heavy Windows compile step to cmake -j 8 (maps to MSBuild /maxcpucount:8 on the VS generator; CMake does not add /MP, so this bounds concurrent cl.exe across projects and keeps committed memory under the wall). Conservative 8; tune up only if headroom allows. No reboot required -- this is the CI-lane half of the fix.

Scope: only the Build c2pool-<coin> Windows step. boost_sentinel (single small TU) and every per-coin source-presence guard left intact. No matrix / guard relaxation.

Validation: fresh release.yml dispatch coins=[btc] off this branch pending runner clearance (VM217 orphan being cleared by vm-fleet-steward).