### PR TITLE
dash(S8): arm --stratum dashd-RPC fallback via NodeRPC::getwork()

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -440,11 +440,22 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     dash::coin::NodeCoinState node_coin_state;
 
     // REQUIRED always-reachable dashd-RPC fallback arm -- the safety +
-    // [GBT-XCHECK] cross-check path, NEVER removed (operator standing rule). For
-    // this skeleton standup it returns the documented set-gap default; wiring it
-    // from NodeRPC getblocktemplate -> DashWorkData is a deferred sub-slice.
+    // [GBT-XCHECK] cross-check path, NEVER removed (operator standing rule).
+    // Wired to NodeRPC::getwork() (dashd getblocktemplate -> rich DashWorkData,
+    // the same seam run_mine_block uses). When the RPC arm is UNARMED (no
+    // dash.conf creds) it returns the documented empty set-gap default and logs
+    // loudly -- never a silent drop. &rpc is lifetime-safe: rpc is declared
+    // above work_source in this scope, so work_source (which owns this lambda)
+    // is destroyed BEFORE rpc at scope exit.
     std::function<dash::coin::DashWorkData()> dashd_fallback =
-        []() -> dash::coin::DashWorkData { return dash::coin::DashWorkData{}; };
+        [&rpc]() -> dash::coin::DashWorkData {
+            if (!rpc) {
+                std::cout << "[DASH-STRATUM-GBT] fallback arm UNARMED (no dashd "
+                             "RPC creds) -- serving empty set-gap template\n";
+                return dash::coin::DashWorkData{};
+            }
+            return rpc->getwork();
+        };
 
     // Won-block dispatch: mirrors the DGB stratum_submit_fn. On a won X11 block,
     // HexStr the bytes, log a [DASH-STRATUM-BLOCK] line, and dispatch via the


### PR DESCRIPTION
## What
Wires the run_node --stratum **dashd-RPC fallback arm** from a stub (empty `DashWorkData` set-gap default) to the EXISTING `NodeRPC::getwork()` seam — the same rich getblocktemplate -> DashWorkData path `run_mine_block` already uses.

## Why
The S8 stratum standup shipped the run-path caller (main_dash --stratum -> DASHWorkSource -> StratumServer) with the dashd fallback arm stubbed. This closes that gap so the stratum path serves real dashd work when the embedded-GBT arm is not the source.

## Safety
- dashd-RPC fallback **RETAINED** (never removed) — operator standing rule.
- UNARMED path (no dash.conf creds) keeps the empty set-gap default and logs `[DASH-STRATUM-GBT]` loudly — never a silent drop.
- Lifetime-safe: `rpc` (unique_ptr, declared above `work_source`) outlives the lambda-owning `work_source`; destroyed BEFORE `rpc` at scope exit.
- Embedded-P2P relay leg stays S8-gated. No shared-base / other-coin edit — per-coin isolation held.
- Conforms vs oracle frstrtr/p2pool-dash (getwork seam unchanged; this is caller-side wiring only).

## Verify
Local Linux x86_64 c2pool-dash link-verify in flight; will post CI + `--run --stratum 127.0.0.1:13333` acceptor-standup result before undrafting. 1 file, +15/-4.