### PR TITLE
release: all-coin packaging fix (libsecp256k1 bundle + per-coin configs) for v0.2.3.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,13 +182,23 @@ jobs:
           mkdir -p "${PKG}/lib" "${PKG}/config" "${PKG}/web-static" "${PKG}/explorer"
           cp "build_${COIN}/src/c2pool/c2pool-${COIN}" "${PKG}/"
           strip "${PKG}/c2pool-${COIN}"
-          for lib in libleveldb.so.1 libsecp256k1.so.2 libsnappy.so.1; do
-            found=$(find /usr/lib -name "${lib}*" -type f 2>/dev/null | head -1)
-            [ -n "$found" ] && cp "$found" "${PKG}/lib/"
+          # Bundle the real runtime shared-library closure resolved from the freshly
+          # built binary via ldd (SONAME-agnostic). v0.2.3 shipped every Linux tarball
+          # DOA: this step hardcoded libsecp256k1.so.2 while the runner's
+          # libsecp256k1-dev provides .so.1 — find matched nothing and the binary's
+          # only dynamic non-glibc dependency went unbundled. Resolve, don't guess.
+          ldd "${PKG}/c2pool-${COIN}" | awk '/=> \//{print $3}' | while read -r so; do
+            case "$(basename "$so")" in
+              libc.so*|libm.so*|libdl.so*|librt.so*|libpthread.so*|ld-linux*|libstdc++.so*|libgcc_s.so*|libresolv.so*) continue ;;
+            esac
+            cp -Lv "$so" "${PKG}/lib/"
           done
           cp start.sh "${PKG}/" && chmod +x "${PKG}/start.sh"
-          cp config/c2pool_mainnet.yaml "${PKG}/config/c2pool_mainnet.yaml.example" || true
-          cp config/c2pool_testnet.yaml "${PKG}/config/" || true
+          cp "config/${COIN}/c2pool_mainnet.yaml" "${PKG}/config/c2pool_mainnet.yaml.example"
+          cp "config/${COIN}/c2pool_testnet.yaml" "${PKG}/config/c2pool_testnet.yaml"
+          # Fail-fast packaging tripwires (BUG A / BUG B regression guards):
+          ls "${PKG}/lib/" | grep -q '^libsecp256k1\.so' || { echo "PKG-ASSERT FAIL: libsecp256k1 not bundled in ${PKG}/lib"; exit 1; }
+          head -1 "${PKG}/config/c2pool_mainnet.yaml.example" | grep -qi "${COIN}" || { echo "PKG-ASSERT FAIL: ${PKG} config header does not identify ${COIN}"; exit 1; }
           cp -r web-static/* "${PKG}/web-static/"
           cp explorer/explorer.py "${PKG}/explorer/"
           tar czf "${PKG}.tar.gz" "${PKG}/"
@@ -304,7 +314,8 @@ jobs:
             install_name_tool -id "@executable_path/lib/$(basename $lib)" "$lib"
           done
           cp start.sh "${PKG}/" && chmod +x "${PKG}/start.sh"
-          cp config/c2pool_mainnet.yaml "${PKG}/config/c2pool_mainnet.yaml.example" || true
+          cp "config/${COIN}/c2pool_mainnet.yaml" "${PKG}/config/c2pool_mainnet.yaml.example"
+          cp "config/${COIN}/c2pool_testnet.yaml" "${PKG}/config/c2pool_testnet.yaml"
           cp -r web-static/* "${PKG}/web-static/"
           cp explorer/explorer.py "${PKG}/explorer/"
 
@@ -577,8 +588,8 @@ jobs:
           Copy-Item start.bat "${PKG}/"
           Copy-Item -Recurse web-static/* "${PKG}/web-static/"
           Copy-Item explorer/explorer.py "${PKG}/explorer/"
-          Copy-Item config/c2pool_mainnet.yaml "${PKG}/config/c2pool_mainnet.yaml.example"
-          Copy-Item config/c2pool_testnet.yaml "${PKG}/config/" -ErrorAction SilentlyContinue
+          Copy-Item "config/${COIN}/c2pool_mainnet.yaml" "${PKG}/config/c2pool_mainnet.yaml.example"
+          Copy-Item "config/${COIN}/c2pool_testnet.yaml" "${PKG}/config/c2pool_testnet.yaml"
           Compress-Archive -Path "${PKG}" -DestinationPath "${PKG}.zip"
 
       - name: Upload package

--- a/config/bch/c2pool_mainnet.yaml
+++ b/config/bch/c2pool_mainnet.yaml
@@ -1,0 +1,31 @@
+# C2Pool Bitcoin Cash [BCH] Mainnet Configuration
+#
+# Zero-config startup: run ./start.sh (Linux/macOS) or start.bat (Windows).
+# Miners set their payout address as the stratum username (p2pool-style).
+# CLI arguments always override values set here.
+
+# --- Network -----------------------------------------------------------------
+port: 9349                    # p2pool sharechain P2P port (BCH mainnet default)
+# stratum_port:                # Stratum is opt-in for this coin: enable with --stratum [HOST:]PORT
+web_port: 8080                 # Web dashboard / JSON-RPC API port
+http_host: "0.0.0.0"           # HTTP bind address
+# external_ip: ""              # Public IP/domain for stratum URL display
+#
+# Port forwarding (if behind NAT/firewall):
+#   9349 TCP  — P2P sharechain (REQUIRED for full p2pool participation)
+#   8333 TCP  — BCH coin P2P (recommended for faster daemon sync)
+
+# --- Operating mode ----------------------------------------------------------
+# Deployment: EXTERNAL BCHN (bitcoind-cash) RPC for block templates.
+# Run a full BCHN node and set the bch_rpc_* fields below.
+
+# --- Bootstrap header checkpoint (optional) ----------------------------------
+# Skip old headers on first sync.  Format: HEIGHT:BLOCK_HASH
+# header_checkpoint: "HEIGHT:BLOCK_HASH"   # set for faster first sync
+
+# --- Coin daemon RPC (for non-embedded / daemon mode) ------------------------
+# bch_rpc_host: 127.0.0.1
+# bch_rpc_port:                # your BCH daemon's RPC port
+# bch_rpc_user: user
+# bch_rpc_password: pass
+

--- a/config/bch/c2pool_testnet.yaml
+++ b/config/bch/c2pool_testnet.yaml
@@ -1,0 +1,27 @@
+# C2Pool Bitcoin Cash [BCH] Testnet Configuration
+#
+# Zero-config startup: run ./start.sh (Linux/macOS) or start.bat (Windows).
+# Miners set their payout address as the stratum username (p2pool-style).
+# CLI arguments always override values set here.
+
+# --- Network -----------------------------------------------------------------
+# port:                        # BCH testnet sharechain port — binary default applies; set to override
+# stratum_port:                # Stratum is opt-in for this coin: enable with --stratum [HOST:]PORT
+web_port: 8080                 # Web dashboard / JSON-RPC API port
+http_host: "0.0.0.0"           # HTTP bind address
+# external_ip: ""              # Public IP/domain for stratum URL display
+
+# --- Operating mode ----------------------------------------------------------
+# Deployment: EXTERNAL BCHN (bitcoind-cash) RPC for block templates.
+# Run a full BCHN node and set the bch_rpc_* fields below.
+
+# --- Bootstrap header checkpoint (optional) ----------------------------------
+# Skip old headers on first sync.  Format: HEIGHT:BLOCK_HASH
+# header_checkpoint: "HEIGHT:BLOCK_HASH"   # set for faster first sync
+
+# --- Coin daemon RPC (for non-embedded / daemon mode) ------------------------
+# bch_rpc_host: 127.0.0.1
+# bch_rpc_port:                # your BCH daemon's RPC port
+# bch_rpc_user: user
+# bch_rpc_password: pass
+

--- a/config/btc/c2pool_mainnet.yaml
+++ b/config/btc/c2pool_mainnet.yaml
@@ -1,0 +1,31 @@
+# C2Pool Bitcoin [BTC] Mainnet Configuration
+#
+# Zero-config startup: run ./start.sh (Linux/macOS) or start.bat (Windows).
+# Miners set their payout address as the stratum username (p2pool-style).
+# CLI arguments always override values set here.
+
+# --- Network -----------------------------------------------------------------
+port: 9333                    # p2pool sharechain P2P port (BTC mainnet default)
+# stratum_port:                # Stratum is opt-in for this coin: enable with --stratum [HOST:]PORT
+web_port: 8080                 # Web dashboard / JSON-RPC API port
+http_host: "0.0.0.0"           # HTTP bind address
+# external_ip: ""              # Public IP/domain for stratum URL display
+#
+# Port forwarding (if behind NAT/firewall):
+#   9333 TCP  — P2P sharechain (REQUIRED for full p2pool participation)
+#   8333 TCP  — BTC coin P2P (recommended for faster daemon sync)
+
+# --- Operating mode ----------------------------------------------------------
+# Deployment: EXTERNAL bitcoind RPC for block templates (getblocktemplate).
+# Run a full bitcoind and set the btc_rpc_* fields below.
+
+# --- Bootstrap header checkpoint (optional) ----------------------------------
+# Skip old headers on first sync.  Format: HEIGHT:BLOCK_HASH
+# header_checkpoint: "HEIGHT:BLOCK_HASH"   # set for faster first sync
+
+# --- Coin daemon RPC (for non-embedded / daemon mode) ------------------------
+# btc_rpc_host: 127.0.0.1
+# btc_rpc_port:                # your BTC daemon's RPC port
+# btc_rpc_user: user
+# btc_rpc_password: pass
+

--- a/config/btc/c2pool_testnet.yaml
+++ b/config/btc/c2pool_testnet.yaml
@@ -1,0 +1,27 @@
+# C2Pool Bitcoin [BTC] Testnet Configuration
+#
+# Zero-config startup: run ./start.sh (Linux/macOS) or start.bat (Windows).
+# Miners set their payout address as the stratum username (p2pool-style).
+# CLI arguments always override values set here.
+
+# --- Network -----------------------------------------------------------------
+# port:                        # BTC testnet sharechain port — binary default applies; set to override
+# stratum_port:                # Stratum is opt-in for this coin: enable with --stratum [HOST:]PORT
+web_port: 8080                 # Web dashboard / JSON-RPC API port
+http_host: "0.0.0.0"           # HTTP bind address
+# external_ip: ""              # Public IP/domain for stratum URL display
+
+# --- Operating mode ----------------------------------------------------------
+# Deployment: EXTERNAL bitcoind RPC for block templates (getblocktemplate).
+# Run a full bitcoind and set the btc_rpc_* fields below.
+
+# --- Bootstrap header checkpoint (optional) ----------------------------------
+# Skip old headers on first sync.  Format: HEIGHT:BLOCK_HASH
+# header_checkpoint: "HEIGHT:BLOCK_HASH"   # set for faster first sync
+
+# --- Coin daemon RPC (for non-embedded / daemon mode) ------------------------
+# btc_rpc_host: 127.0.0.1
+# btc_rpc_port:                # your BTC daemon's RPC port
+# btc_rpc_user: user
+# btc_rpc_password: pass
+

--- a/config/dash/c2pool_mainnet.yaml
+++ b/config/dash/c2pool_mainnet.yaml
@@ -1,0 +1,34 @@
+# C2Pool Dash [DASH] Mainnet Configuration
+#
+# Zero-config startup: run ./start.sh (Linux/macOS) or start.bat (Windows).
+# Miners set their payout address as the stratum username (p2pool-style).
+# CLI arguments always override values set here.
+
+# --- Network -----------------------------------------------------------------
+port: 8999                    # p2pool sharechain P2P port (DASH mainnet default)
+stratum_port: 7903            # Stratum mining port
+web_port: 8080                 # Web dashboard / JSON-RPC API port
+http_host: "0.0.0.0"           # HTTP bind address
+# external_ip: ""              # Public IP/domain for stratum URL display
+#
+# Port forwarding (if behind NAT/firewall):
+#   8999 TCP  — P2P sharechain (REQUIRED for full p2pool participation)
+#   7903 TCP  — Stratum mining (REQUIRED for miners to connect)
+#   9999 TCP  — DASH coin P2P (recommended for faster daemon sync)
+
+# --- Operating mode ----------------------------------------------------------
+# Deployment: EXTERNAL dashd RPC fallback. Embedded Dash SPV is NOT wired
+# on this release (tracked in #738) — do not rely on embedded mode. Point
+# the dash_rpc_* fields below at a running dashd for block templates.
+# embedded_dash: false         # (unavailable this release)
+
+# --- Bootstrap header checkpoint (optional) ----------------------------------
+# Skip old headers on first sync.  Format: HEIGHT:BLOCK_HASH
+# header_checkpoint: "HEIGHT:BLOCK_HASH"   # set for faster first sync
+
+# --- Coin daemon RPC (for non-embedded / daemon mode) ------------------------
+# dash_rpc_host: 127.0.0.1
+# dash_rpc_port:                # your DASH daemon's RPC port
+# dash_rpc_user: user
+# dash_rpc_password: pass
+

--- a/config/dash/c2pool_testnet.yaml
+++ b/config/dash/c2pool_testnet.yaml
@@ -1,0 +1,34 @@
+# C2Pool Dash [DASH] Testnet Configuration
+#
+# Zero-config startup: run ./start.sh (Linux/macOS) or start.bat (Windows).
+# Miners set their payout address as the stratum username (p2pool-style).
+# CLI arguments always override values set here.
+
+# --- Network -----------------------------------------------------------------
+port: 18999                   # p2pool sharechain P2P port (DASH testnet default)
+stratum_port: 17903           # Stratum mining port
+web_port: 8080                 # Web dashboard / JSON-RPC API port
+http_host: "0.0.0.0"           # HTTP bind address
+# external_ip: ""              # Public IP/domain for stratum URL display
+#
+# Port forwarding (if behind NAT/firewall):
+#   18999 TCP  — P2P sharechain (REQUIRED for full p2pool participation)
+#   17903 TCP  — Stratum mining (REQUIRED for miners to connect)
+#   9999 TCP  — DASH coin P2P (recommended for faster daemon sync)
+
+# --- Operating mode ----------------------------------------------------------
+# Deployment: EXTERNAL dashd RPC fallback. Embedded Dash SPV is NOT wired
+# on this release (tracked in #738) — do not rely on embedded mode. Point
+# the dash_rpc_* fields below at a running dashd for block templates.
+# embedded_dash: false         # (unavailable this release)
+
+# --- Bootstrap header checkpoint (optional) ----------------------------------
+# Skip old headers on first sync.  Format: HEIGHT:BLOCK_HASH
+# header_checkpoint: "HEIGHT:BLOCK_HASH"   # set for faster first sync
+
+# --- Coin daemon RPC (for non-embedded / daemon mode) ------------------------
+# dash_rpc_host: 127.0.0.1
+# dash_rpc_port:                # your DASH daemon's RPC port
+# dash_rpc_user: user
+# dash_rpc_password: pass
+

--- a/config/dgb/c2pool_mainnet.yaml
+++ b/config/dgb/c2pool_mainnet.yaml
@@ -1,0 +1,32 @@
+# C2Pool DigiByte [DGB] Mainnet Configuration
+#
+# Zero-config startup: run ./start.sh (Linux/macOS) or start.bat (Windows).
+# Miners set their payout address as the stratum username (p2pool-style).
+# CLI arguments always override values set here.
+
+# --- Network -----------------------------------------------------------------
+port: 5024                    # p2pool sharechain P2P port (DGB mainnet default)
+stratum_port: 5025            # Stratum mining port
+web_port: 8080                 # Web dashboard / JSON-RPC API port
+http_host: "0.0.0.0"           # HTTP bind address
+# external_ip: ""              # Public IP/domain for stratum URL display
+#
+# Port forwarding (if behind NAT/firewall):
+#   5024 TCP  — P2P sharechain (REQUIRED for full p2pool participation)
+#   5025 TCP  — Stratum mining (REQUIRED for miners to connect)
+#   12024 TCP  — DGB coin P2P (recommended for faster daemon sync)
+
+# --- Operating mode ----------------------------------------------------------
+# Deployment: DigiByte daemon RPC. Run digibyted and set the dgb_rpc_*
+# fields below. See `./c2pool-dgb --help` for algo/mode options.
+
+# --- Bootstrap header checkpoint (optional) ----------------------------------
+# Skip old headers on first sync.  Format: HEIGHT:BLOCK_HASH
+# header_checkpoint: "HEIGHT:BLOCK_HASH"   # set for faster first sync
+
+# --- Coin daemon RPC (for non-embedded / daemon mode) ------------------------
+# dgb_rpc_host: 127.0.0.1
+# dgb_rpc_port:                # your DGB daemon's RPC port
+# dgb_rpc_user: user
+# dgb_rpc_password: pass
+

--- a/config/dgb/c2pool_testnet.yaml
+++ b/config/dgb/c2pool_testnet.yaml
@@ -1,0 +1,27 @@
+# C2Pool DigiByte [DGB] Testnet Configuration
+#
+# Zero-config startup: run ./start.sh (Linux/macOS) or start.bat (Windows).
+# Miners set their payout address as the stratum username (p2pool-style).
+# CLI arguments always override values set here.
+
+# --- Network -----------------------------------------------------------------
+# port:                        # DGB testnet sharechain port — binary default applies; set to override
+# stratum_port:                # Stratum is opt-in for this coin: enable with --stratum [HOST:]PORT
+web_port: 8080                 # Web dashboard / JSON-RPC API port
+http_host: "0.0.0.0"           # HTTP bind address
+# external_ip: ""              # Public IP/domain for stratum URL display
+
+# --- Operating mode ----------------------------------------------------------
+# Deployment: DigiByte daemon RPC. Run digibyted and set the dgb_rpc_*
+# fields below. See `./c2pool-dgb --help` for algo/mode options.
+
+# --- Bootstrap header checkpoint (optional) ----------------------------------
+# Skip old headers on first sync.  Format: HEIGHT:BLOCK_HASH
+# header_checkpoint: "HEIGHT:BLOCK_HASH"   # set for faster first sync
+
+# --- Coin daemon RPC (for non-embedded / daemon mode) ------------------------
+# dgb_rpc_host: 127.0.0.1
+# dgb_rpc_port:                # your DGB daemon's RPC port
+# dgb_rpc_user: user
+# dgb_rpc_password: pass
+

--- a/config/ltc/c2pool_mainnet.yaml
+++ b/config/ltc/c2pool_mainnet.yaml
@@ -1,0 +1,35 @@
+# C2Pool Litecoin [LTC] Mainnet Configuration
+#
+# Zero-config startup: run ./start.sh (Linux/macOS) or start.bat (Windows).
+# Miners set their payout address as the stratum username (p2pool-style).
+# CLI arguments always override values set here.
+
+# --- Network -----------------------------------------------------------------
+port: 9326                    # p2pool sharechain P2P port (LTC mainnet default)
+stratum_port: 9327            # Stratum mining port
+web_port: 8080                 # Web dashboard / JSON-RPC API port
+http_host: "0.0.0.0"           # HTTP bind address
+# external_ip: ""              # Public IP/domain for stratum URL display
+#
+# Port forwarding (if behind NAT/firewall):
+#   9326 TCP  — P2P sharechain (REQUIRED for full p2pool participation)
+#   9327 TCP  — Stratum mining (REQUIRED for miners to connect)
+#   9333 TCP  — LTC coin P2P (recommended for faster daemon sync)
+
+# --- Operating mode ----------------------------------------------------------
+# Default: integrated P2P pool with EMBEDDED LTC + DOGE SPV nodes.
+# Zero-config — no litecoind/dogecoind daemon required.
+embedded_ltc: true             # Embedded LTC SPV (default)
+embedded_doge: true            # Embedded DOGE SPV for merged mining (default)
+
+# --- Bootstrap header checkpoint (optional) ----------------------------------
+# Skip old headers on first sync.  Format: HEIGHT:BLOCK_HASH
+header_checkpoint: "3088000:4a7fc8d4668c69db4f40fcdeb99ad3dbd85545b742b48e1529ebbec641e547d1"
+doge_header_checkpoint: "6160000:51efd04daebddba43ae403662098524d99abf3edad3bddc3ea7b2938c6799939"
+
+# --- Coin daemon RPC (for non-embedded / daemon mode) ------------------------
+# ltc_rpc_host: 127.0.0.1
+# ltc_rpc_port:                # your LTC daemon's RPC port
+# ltc_rpc_user: user
+# ltc_rpc_password: pass
+

--- a/config/ltc/c2pool_testnet.yaml
+++ b/config/ltc/c2pool_testnet.yaml
@@ -1,0 +1,34 @@
+# C2Pool Litecoin [LTC] Testnet Configuration
+#
+# Zero-config startup: run ./start.sh (Linux/macOS) or start.bat (Windows).
+# Miners set their payout address as the stratum username (p2pool-style).
+# CLI arguments always override values set here.
+
+# --- Network -----------------------------------------------------------------
+port: 19326                   # p2pool sharechain P2P port (LTC testnet default)
+stratum_port: 19327           # Stratum mining port
+web_port: 8080                 # Web dashboard / JSON-RPC API port
+http_host: "0.0.0.0"           # HTTP bind address
+# external_ip: ""              # Public IP/domain for stratum URL display
+#
+# Port forwarding (if behind NAT/firewall):
+#   19326 TCP  — P2P sharechain (REQUIRED for full p2pool participation)
+#   19327 TCP  — Stratum mining (REQUIRED for miners to connect)
+#   9333 TCP  — LTC coin P2P (recommended for faster daemon sync)
+
+# --- Operating mode ----------------------------------------------------------
+# Default: integrated P2P pool with EMBEDDED LTC + DOGE SPV nodes.
+# Zero-config — no litecoind/dogecoind daemon required.
+embedded_ltc: true             # Embedded LTC SPV (default)
+embedded_doge: true            # Embedded DOGE SPV for merged mining (default)
+
+# --- Bootstrap header checkpoint (optional) ----------------------------------
+# Skip old headers on first sync.  Format: HEIGHT:BLOCK_HASH
+# header_checkpoint: "HEIGHT:BLOCK_HASH"   # set for faster first sync
+
+# --- Coin daemon RPC (for non-embedded / daemon mode) ------------------------
+# ltc_rpc_host: 127.0.0.1
+# ltc_rpc_port:                # your LTC daemon's RPC port
+# ltc_rpc_user: user
+# ltc_rpc_password: pass
+

--- a/start.bat
+++ b/start.bat
@@ -16,6 +16,19 @@ if "!BIN!"=="" (
 )
 for %%f in ("!BIN!") do set BINNAME=%%~nxf
 
+:: Coin-guard: refuse a binary/config coin mismatch (see start.sh).
+for /f "tokens=2 delims=-." %%c in ("!BINNAME!") do set BINCOIN=%%c
+if exist "%CONFIG%" (
+    set /p CFGHDR=<"%CONFIG%"
+    echo !CFGHDR! | findstr /I "!BINCOIN!" >nul
+    if errorlevel 1 (
+        echo ERROR: config/coin mismatch - binary is c2pool-!BINCOIN! but config header reads:
+        echo          !CFGHDR!
+        echo Launch with the coin-correct config, e.g.: %~nx0 config\c2pool_mainnet.yaml
+        exit /b 1
+    )
+)
+
 echo === !BINNAME! ===
 echo Config:   %CONFIG%
 echo Web:      http://0.0.0.0:8080

--- a/start.sh
+++ b/start.sh
@@ -23,6 +23,20 @@ if [ -f "$CONFIG" ]; then
     [ -n "$WP" ] && WEB_PORT="$WP"
 fi
 
+# --- Coin-guard --------------------------------------------------------------
+# v0.2.3 shipped the Litecoin config in every coin tarball, so a DASH pool
+# silently bound LTC ports and logged LTC. Refuse to launch a binary against a
+# config whose coin header does not match the binary's coin.
+BIN_COIN=$(basename "$BIN" | sed -n "s/^c2pool-\([a-z][a-z]*\).*/\1/p")
+if [ -n "$BIN_COIN" ] && [ -f "$CONFIG" ]; then
+    if ! head -1 "$CONFIG" | grep -qi "$BIN_COIN"; then
+        echo "ERROR: config/coin mismatch — binary is c2pool-$BIN_COIN but config header reads:" >&2
+        echo "         $(head -1 "$CONFIG")" >&2
+        echo "       Launch with the coin-correct config, e.g.:  $0 $DIR/config/c2pool_mainnet.yaml" >&2
+        exit 1
+    fi
+fi
+
 echo "=== $(basename "$BIN") ==="
 echo "Config:   $CONFIG"
 echo "Web:      http://0.0.0.0:${WEB_PORT}"


### PR DESCRIPTION
Supersedes the #740-only task. Field audit of v0.2.3 confirmed two all-coin packaging bugs; both fixed here. Retag as v0.2.3.1 (tag-build path, same source) on merge.

## Audit matrix (needs vs bundles, v0.2.3 live assets)
| platform | needs (dynamic) | bundled | config | verdict |
|---|---|---|---|---|
| Linux x86_64 (all 5) | libsecp256k1.so.1 | leveldb+snappy only (secp MISSING) | LTC header | BROKEN / DOA |
| macOS universal (all 5) | secp+boost+leveldb+yaml-cpp | all present, rpath-ed | LTC header | closure OK / config wrong |
| Windows x86_64 (all 5) | libsecp256k1-6.dll | present (exe + lib/) | LTC header | closure OK / config wrong |

leveldb/snappy/boost/gmp/event are statically linked on Linux — libsecp256k1.so.1 is the ONLY dynamic non-glibc dep, and it was the one omitted. No other unbundled deps on any platform.

## BUG A — libsecp256k1 missing (Linux only, all 5 coins)
Root cause: Linux packaging hardcoded libsecp256k1.so.2; the runner libsecp256k1-dev provides .so.1, so find matched nothing and it was never copied. Fixed by resolving the real runtime closure via ldd of the built binary (SONAME-agnostic; survives the next SONAME bump). macOS/Windows already bundle secp256k1 correctly.

## BUG B — wrong-coin config (all 15 packages)
Every tarball shipped the Litecoin config, so a DASH pool logged LTC and bound LTC ports. Added config/<coin>/c2pool_{mainnet,testnet}.yaml with coin-correct headers and authoritative sharechain ports (btc 9333, ltc 9326/9327, dgb 5024/5025, dash 8999/7903, bch 9349); release.yml selects config/${COIN}/ on all three platforms. DASH config documents the external dashd-RPC fallback (embedded SPV unwired per #738). Checkpoints/RPC left as commented guidance rather than fabricated values.

## Guards
- release.yml packaging tripwires: assert each Linux package bundles libsecp256k1 and its config header names the coin (fails the build otherwise).
- start.sh / start.bat refuse to launch a binary against a mismatched-coin config.

Closes #740, closes #741. No self-merge — on approval I take the tag-build path to v0.2.3.1.
