### PR TITLE
dash(embedded/E1): opt-in coin-network P2P client + outbound dial in run_node

### DIFF
--- a/src/c2pool/CMakeLists.txt
+++ b/src/c2pool/CMakeLists.txt
@@ -316,6 +316,9 @@ target_link_libraries(c2pool-dash
     dash_x11   # DASH X11 PoW sph reference (BLAKE->...->ECHO), additive static lib
     dash_rpc   # launcher slice-3: external-dashd-RPC client (submitblock fallback)
     dash_stratum  # S8: DASHWorkSource IWorkSource bodies (stratum accept-loop caller)
+    dash_block_replay  # E1: coin/vendor/blockencodings.cpp — the coin-network P2P Handler
+                       # (cmpctblock codec) the opt-in CoinClient instantiates ODR-uses
+                       # CBlockHeaderAndShortTxIDs::FillShortTxIDSelector()
     btclibs
     yaml-cpp::yaml-cpp
     nlohmann_json::nlohmann_json

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -54,6 +54,7 @@
 #include <impl/dash/coin/work_source.hpp>   // dash::coin::select_dash_work -- embedded-gbt live-wire + dashd fallback (S8 capstone)
 #include <impl/dash/coin/rpc_conf.hpp>     // dash.conf creds resolution (rpcpassword off argv)
 #include <impl/dash/coin/node_interface.hpp>
+#include <impl/dash/coin/p2p_client.hpp>   // dash::coin::p2p::CoinClient — OPT-IN coin-network dial (E1, --coin-p2p-connect)
 #include <impl/dash/node.hpp>          // dash::Node — sharechain pool-node (NodeBridge<NodeImpl,Legacy,Actual>)
 #include <impl/dash/config.hpp>        // dash::Config (PoolConfig/CoinConfig)
 #include <impl/dash/config_pool.hpp>   // dash::SharechainConfig — P2P_PORT / PREFIX / min-proto SSOT
@@ -168,7 +169,7 @@ void print_banner(const char* argv0)
         << "       " << argv0 << " --run [--coin-rpc H:P] [--coin-rpc-auth PATH]\n"
         << "           [--testnet] [--submit-block HEX | --submit-block-file PATH]\n"
         << "           [--listen [HOST:]PORT] [--addnode HOST:PORT]... [--connect HOST:PORT]...\n"
-        << "           [--stratum [HOST:]PORT]\n"
+        << "           [--stratum [HOST:]PORT] [--coin-p2p-connect HOST:PORT]...\n"
         << "       " << argv0 << " --mine-block [--coin-rpc H:P] [--coin-rpc-auth PATH]\n"
         << "           [--testnet] [--payout-pubkey-hash HEX] [--max-nonce N]\n\n"
         << "Status: consensus layer live (X11 PoW, subsidy, oracle CoinParams).\n"
@@ -180,6 +181,9 @@ void print_banner(const char* argv0)
         << "        dispatch via the retained dashd-RPC submitblock arm.\n"
         << "        --submit-block[-file] drives ONE real submitblock then exits\n"
         << "        (the won-block-reaches-network leg); embedded P2P relay = S8.\n"
+        << "        --coin-p2p-connect HOST:PORT (repeatable) OPT-IN dials the DASH\n"
+        << "        coin network directly (version/verack + keep-alive + reconnect);\n"
+        << "        absent => no coin P2P client, dashd-RPC fallback path unchanged.\n"
         << "Consensus: X11 PoW + block identity; 2.5 min spacing; 5 DASH post-V20\n"
         << "        base, -1/14 per 210240; masternode payment 3/4 of block value.\n";
 }
@@ -318,10 +322,21 @@ int run_selftest()
 // blocking sync_reconnect fallback, so the submit self-connects -- no async race.
 // A synthetic-only pass does NOT earn block-viable; the live dashd-reached run is
 // the gate.
+//
+// --coin-p2p-connect HOST:PORT (repeatable) — E1 OPT-IN embedded coin-network
+// dial. ABSENT (the released/prod path): no coin P2P client is instantiated,
+// NodeCoinState stays default-unpopulated, and get_work() keeps taking the
+// retained dashd-RPC fallback — byte-identical run_node behavior. PRESENT:
+// a dash::coin::p2p::CoinClient dials the given dashd P2P endpoint(s)
+// (version/verack handshake, ping keep-alive, 30s reconnect rotating over
+// repeated targets). E1 establishes + maintains the connection only; the
+// ingest legs that would populate NodeCoinState are later slices, so the
+// fallback arm still serves templates even WITH the flag.
 int run_node(bool testnet, const std::string& rpc_endpoint,
              const std::string& rpc_conf_path, const std::string& submit_hex,
              const PeeringConfig& peer,
-             const std::string& stratum_host, uint16_t stratum_port)
+             const std::string& stratum_host, uint16_t stratum_port,
+             const std::vector<NetService>& coin_p2p_targets)
 {
     namespace io = boost::asio;
 
@@ -425,6 +440,38 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // (dash::NodeImpl carries no start_outbound_connections yet). Inbound
     // reception — version handshake + the #646 min-proto gate — is live now
     // via node.cpp (#656/#657).
+
+    // ── E1: OPT-IN embedded coin-network P2P dial (--coin-p2p-connect) ────
+    // GUARANTEE: with no --coin-p2p-connect on argv, coin_p2p stays null and
+    // this block is a no-op — the run path is unchanged and the mining-hotel
+    // prod posture (NodeCoinState unpopulated -> dashd-RPC fallback) is
+    // untouched. The coin-network wire MAGIC (dashd pchMessageStart: mainnet
+    // bf0c6bbd / testnet cee2caff, same constants as the slice-1 launcher
+    // dispatch) is DISTINCT from the sharechain PREFIX set above — different
+    // layers, never conflated. The client rides the SAME ioc as the
+    // sharechain node and stratum; declared after config/coin_state (both of
+    // which it borrows), so it is destroyed before them at scope exit.
+    std::unique_ptr<dash::coin::p2p::CoinClient<dash::Config>> coin_p2p;
+    if (!coin_p2p_targets.empty()) {
+        config.coin()->m_testnet = testnet;
+        config.coin()->m_p2p.prefix =
+            ParseHexBytes(testnet ? "cee2caff" : "bf0c6bbd");
+        config.coin()->m_p2p.address = coin_p2p_targets.front();
+
+        coin_p2p = std::make_unique<dash::coin::p2p::CoinClient<dash::Config>>(
+            &ioc, &coin_state, &config, "COIN-P2P");
+        coin_p2p->connect(coin_p2p_targets);
+        std::cout << "[run] coin-network P2P client dialing "
+                  << coin_p2p_targets.front().to_string()
+                  << (coin_p2p_targets.size() > 1
+                          ? " (+" + std::to_string(coin_p2p_targets.size() - 1)
+                                + " alternate[s], reconnect rotates)"
+                          : "")
+                  << " magic=" << (testnet ? "cee2caff" : "bf0c6bbd")
+                  << " proto=70230 (E1: dial+handshake+keep-alive only;\n"
+                     "[run]       ingest legs are later slices — templates still source from\n"
+                     "[run]       the dashd-RPC fallback until NodeCoinState is fed)\n";
+    }
 
     // ── S8 miner-facing Stratum accept-loop standup (run-path caller) ─────
     // This is the production caller the DASHWorkSource 4a/4b skeleton (#706)
@@ -671,6 +718,7 @@ int main(int argc, char** argv)
     std::string listen_raw;                    // --listen [HOST:]PORT (sharechain bind)
     std::vector<std::string> addnode_raw;      // --addnode HOST:PORT (persistent outbound)
     std::vector<std::string> connect_raw;      // --connect HOST:PORT (connect-only)
+    std::vector<std::string> coin_p2p_raw;     // --coin-p2p-connect HOST:PORT (repeatable; E1 opt-in coin-network dial)
     std::string stratum_host = "0.0.0.0";      // --stratum [HOST:]PORT bind interface (default all)
     uint16_t    stratum_port = 0;              // 0 disables the Stratum accept-loop; --stratum sets it
     for (int i = 1; i < argc; ++i) {
@@ -702,6 +750,8 @@ int main(int argc, char** argv)
             addnode_raw.emplace_back(argv[++i]);
         else if (std::strcmp(argv[i], "--connect") == 0 && i + 1 < argc)
             connect_raw.emplace_back(argv[++i]);
+        else if (std::strcmp(argv[i], "--coin-p2p-connect") == 0 && i + 1 < argc)
+            coin_p2p_raw.emplace_back(argv[++i]);
         else if (std::strcmp(argv[i], "--stratum") == 0 && i + 1 < argc) {
             // --stratum [HOST:]PORT -- bind a Stratum TCP listener for miners.
             // Bare PORT keeps the default 0.0.0.0 bind host (parse_listen SSOT).
@@ -757,8 +807,18 @@ int main(int argc, char** argv)
             }
             peer.listen_set = true;
         }
+        std::vector<NetService> coin_p2p_targets;
+        for (const auto& raw : coin_p2p_raw) {
+            NetService ns;
+            if (!parse_hostport(raw, ns)) {
+                std::cout << "[run] --coin-p2p-connect malformed (want HOST:PORT): "
+                          << raw << "\n";
+                return 2;
+            }
+            coin_p2p_targets.push_back(ns);
+        }
         return run_node(testnet, rpc_endpoint, rpc_conf_path, submit_hex, peer,
-                        stratum_host, stratum_port);
+                        stratum_host, stratum_port, coin_p2p_targets);
     }
     return run_selftest();
 }

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -1,0 +1,682 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// DASH embedded coin-network P2P client (E1: instantiate + outbound dial).
+//
+// Live-dial counterpart of the S8 socket-node skeleton (p2p_node.hpp). Where
+// NodeP2P owns only the request/reply lifecycle over an already-attached
+// socket, CoinClient owns the WHOLE outbound connection to a dashd peer:
+//
+//   * dial: core::Factory<core::Client> resolve/connect to a HOST:PORT target
+//     (repeatable targets rotate round-robin on reconnect — DialPlan below);
+//   * handshake: version/verack (HandshakeTracker below — the KAT'd state
+//     machine), advertising protocol 70230, the SAME version the vendored
+//     SML/clsig codecs assume (vendor/smldiff.hpp, vendor/quorum_tail.hpp);
+//   * keep-alive: 30s ping cadence + idle/handshake timeout teardown;
+//   * reconnect: 30s retry while disconnected, rotating the dial plan.
+//
+// Ported 1:1 from the PROVEN per-coin clients (src/impl/dgb/coin/p2p_node.hpp
+// mirror lineage btc <- ltc), trimmed to the E1 scope: NO ingest legs. The
+// tx/block/headers/inv/clsig/mnlistdiff handlers parse and FIRE the
+// dash::interfaces::Node events (new_block / new_tx / full_block / new_headers
+// / new_chainlock) — that event surface is the seam later slices (E2+) attach
+// CoinStateMaintainer / HeaderChain / Mempool ingest to. With no subscribers
+// (the E1 run_node wiring), every event is a no-op and NodeCoinState stays
+// default-unpopulated, so get_work() keeps taking the retained dashd-RPC
+// fallback — zero behavior change on the mining path.
+//
+// EXPLICITLY NOT HERE (later slices): getheaders sync driving (E2 — dash
+// BlockType serialization is header-only, so multi-entry `headers` batches
+// need a raw-payload parser first), getdata pulls, compact-block
+// reconstruction, mnlistdiff-driven SML maintenance, fee pricing.
+//
+// Wire magic (pchMessageStart): mainnet bf0c6bbd / testnet cee2caff — supplied
+// by run_node via config.coin()->m_p2p.prefix, never hard-coded here. The
+// coin-network magic is DISTINCT from the sharechain PREFIX (pool peer
+// isolation primitive): different layers, never conflated.
+//
+// Header-only to match the sibling dash coin leaves.
+
+#include "p2p_messages.hpp"
+#include "p2p_connection.hpp"
+#include "node_interface.hpp"
+#include "block.hpp"
+#include "transaction.hpp"
+
+#include <impl/dash/crypto/hash_x11.hpp>   // block identity on Dash = X11(header)
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <boost/asio.hpp>
+
+#include <core/config.hpp>
+#include <core/log.hpp>
+#include <core/random.hpp>
+#include <core/factory.hpp>
+#include <core/timer.hpp>
+
+namespace dash
+{
+namespace coin
+{
+namespace p2p
+{
+
+namespace io = boost::asio;
+
+inline std::string parse_net_error(const boost::system::error_code& ec)
+{
+    switch (ec.value())
+    {
+    case boost::asio::error::eof:
+        return "EOF, socket disconnected";
+    default:
+        return ec.message();
+    }
+}
+
+// ── Handshake state machine (pure, KAT-able) ─────────────────────────────
+//
+// version/verack progress tracker, extracted from the client so the
+// transition rules are unit-testable without sockets:
+//
+//   Idle --on_connected()--> Connected        (socket up, our version sent)
+//   Connected --on_version()--> VersionReceived (peer version seen, verack sent)
+//   VersionReceived --on_verack()--> Complete   (peer verack seen)
+//
+// verack-before-version is tolerated (Connected --on_verack()--> Complete;
+// some implementations ack eagerly). Events received while Idle are ignored
+// (a stray message must not fabricate a session). reset() returns to Idle on
+// any disconnect/error.
+class HandshakeTracker
+{
+public:
+    enum class State { Idle, Connected, VersionReceived, Complete };
+
+private:
+    State m_state{State::Idle};
+
+public:
+    State state() const { return m_state; }
+    bool complete() const { return m_state == State::Complete; }
+
+    void on_connected() { m_state = State::Connected; }
+
+    // Returns true if this version message is the handshake-advancing one
+    // (i.e. we should reply verack); duplicates / pre-connect strays => false.
+    bool on_version()
+    {
+        if (m_state != State::Connected)
+            return false;
+        m_state = State::VersionReceived;
+        return true;
+    }
+
+    // Returns true if the handshake just completed.
+    bool on_verack()
+    {
+        if (m_state != State::Connected && m_state != State::VersionReceived)
+            return false;
+        m_state = State::Complete;
+        return true;
+    }
+
+    void reset() { m_state = State::Idle; }
+};
+
+// ── Dial plan (pure, KAT-able) ───────────────────────────────────────────
+//
+// Ordered outbound targets for --coin-p2p-connect (repeatable). current() is
+// the target being dialed; advance() rotates round-robin so a dead first
+// target does not wedge reconnection when alternates were supplied.
+class DialPlan
+{
+    std::vector<NetService> m_targets;
+    std::size_t m_index{0};
+
+public:
+    void set_targets(std::vector<NetService> targets)
+    {
+        m_targets = std::move(targets);
+        m_index = 0;
+    }
+
+    bool empty() const { return m_targets.empty(); }
+    std::size_t size() const { return m_targets.size(); }
+
+    const NetService& current() const { return m_targets.at(m_index); }
+
+    // Rotate to the next target (single-target plans stay put) and return it.
+    const NetService& advance()
+    {
+        if (!m_targets.empty())
+            m_index = (m_index + 1) % m_targets.size();
+        return current();
+    }
+};
+
+#define ADD_P2P_HANDLER(name)\
+    void handle(std::unique_ptr<dash::coin::p2p::message_##name> msg)
+
+// Outbound coin-network client: dial, handshake, keep-alive, reconnect.
+// Concrete on dash::Config (per-coin isolation — no cross-coin template reuse).
+template <typename ConfigType>
+class CoinClient : public core::ICommunicator, public core::INetwork, public core::Factory<core::Client>
+{
+    using config_t = ConfigType;
+
+private:
+    static constexpr time_t CONNECT_TIMEOUT_SEC = 10;
+    static constexpr time_t IDLE_TIMEOUT_SEC = 100;
+    static constexpr time_t PING_INTERVAL_SEC = 30;
+    static constexpr time_t RECONNECT_INTERVAL_SEC = 30;
+
+    // Dash Core PROTOCOL_VERSION we advertise. MUST stay >= 70230: the
+    // vendored mnlistdiff/clsig wire codecs (vendor/smldiff.hpp,
+    // vendor/quorum_tail.hpp) parse the >=70230 layout.
+    static constexpr uint32_t PROTOCOL_VERSION = 70230;
+    static constexpr uint64_t NODE_NETWORK = 1;   // no segwit/witness on Dash
+    static constexpr uint16_t MAINNET_P2P_PORT = 9999;
+
+    dash::interfaces::Node* m_coin;
+    io::io_context* m_context;
+    config_t* m_config;
+    p2p::Handler m_handler;
+
+    std::unique_ptr<Connection> m_peer;
+    std::unique_ptr<core::Timer> m_reconnect_timer;
+    std::unique_ptr<core::Timer> m_ping_timer;
+    std::unique_ptr<core::Timer> m_timeout_timer;
+    DialPlan m_dial_plan;
+    bool m_reconnect_enabled = false;
+    HandshakeTracker m_handshake;
+    std::string m_chain_label = "COIN-P2P";
+
+    // Peer metadata from the version message
+    uint64_t m_peer_services{0};
+    uint32_t m_peer_version{0};
+    std::string m_peer_subver;
+    uint32_t m_peer_start_height{0};
+    std::chrono::steady_clock::time_point m_connected_at{std::chrono::steady_clock::now()};
+
+    // E2+ seams (callbacks, all optional)
+    using AddrCallback = std::function<void(const std::vector<NetService>&)>;
+    AddrCallback m_addr_callback;
+    using PeerHeightCallback = std::function<void(uint32_t)>;
+    PeerHeightCallback m_on_peer_height;
+    using HandshakeCallback = std::function<void()>;
+    HandshakeCallback m_on_handshake_complete;
+
+public:
+    CoinClient(io::io_context* context, dash::interfaces::Node* coin, config_t* config,
+               const std::string& chain_label = "COIN-P2P")
+        : core::Factory<core::Client>(context, this, chain_label)
+        , m_coin(coin), m_context(context), m_config(config)
+        , m_chain_label(chain_label)
+    {
+    }
+
+    ~CoinClient()
+    {
+        m_reconnect_enabled = false;
+        if (m_reconnect_timer) m_reconnect_timer->stop();
+        stop_ping_timer();
+        stop_timeout_timer();
+    }
+
+    /// Dial the given targets with automatic reconnection (30s interval,
+    /// round-robin over the target list on each retry).
+    void connect(std::vector<NetService> targets)
+    {
+        if (targets.empty()) return;
+        m_dial_plan.set_targets(std::move(targets));
+        m_reconnect_enabled = true;
+        LOG_INFO << "[" << m_chain_label << "] dialing "
+                 << m_dial_plan.current().to_string()
+                 << " (" << m_dial_plan.size() << " target[s] in plan)";
+        core::Factory<core::Client>::connect(m_dial_plan.current());
+
+        m_reconnect_timer = std::make_unique<core::Timer>(m_context, /*repeat=*/true);
+        m_reconnect_timer->start(RECONNECT_INTERVAL_SEC, [this]() {
+            if (!m_peer && m_reconnect_enabled) {
+                const auto& target = m_dial_plan.advance();
+                LOG_INFO << "[" << m_chain_label << "] reconnecting to "
+                         << target.to_string() << "...";
+                core::Factory<core::Client>::connect(target);
+            }
+        });
+    }
+
+    // INetwork
+    void connected(std::shared_ptr<core::Socket> socket) override
+    {
+        m_peer = std::make_unique<Connection>(m_context, socket);
+        m_handshake.reset();
+        m_handshake.on_connected();
+        m_connected_at = std::chrono::steady_clock::now();
+        LOG_INFO << "[" << m_chain_label << "] connected to "
+                 << m_peer->get_addr().to_string() << " — sending version (proto "
+                 << PROTOCOL_VERSION << ")";
+
+        // Require version/verack progress soon after connect.
+        ensure_timeout_timer();
+        m_timeout_timer->start(CONNECT_TIMEOUT_SEC, [this]() {
+            timeout("handshake timeout");
+        });
+
+        auto msg_version = message_version::make_raw(
+            PROTOCOL_VERSION,
+            NODE_NETWORK,
+            core::timestamp(),
+            addr_t{NODE_NETWORK, m_peer->get_addr()},
+            addr_t{NODE_NETWORK, NetService{"0.0.0.0", MAINNET_P2P_PORT}},
+            core::random::random_nonce(),
+            "c2pool-dash",
+            0
+        );
+        m_peer->write(msg_version);
+    }
+
+    void disconnect() override
+    {
+        stop_ping_timer();
+        stop_timeout_timer();
+        m_handshake.reset();
+        m_peer.reset();
+    }
+
+    /// Whether the version/verack handshake with the peer is complete.
+    bool is_handshake_complete() const { return m_handshake.complete(); }
+    bool is_connected() const { return m_peer != nullptr; }
+
+    /// Peer metadata accessors (populated after the peer's version message).
+    uint64_t peer_services() const { return m_peer_services; }
+    uint32_t peer_version() const { return m_peer_version; }
+    const std::string& peer_subver() const { return m_peer_subver; }
+    uint32_t peer_start_height() const { return m_peer_start_height; }
+    const std::string& chain_label() const { return m_chain_label; }
+    int64_t peer_uptime_sec() const {
+        return std::chrono::duration_cast<std::chrono::seconds>(
+            std::chrono::steady_clock::now() - m_connected_at).count();
+    }
+
+    // ── E2+ seams ────────────────────────────────────────────────────────
+    /// addr-message peer discovery feed.
+    void set_addr_callback(AddrCallback cb) { m_addr_callback = std::move(cb); }
+    /// Peer's reported chain height (from its version message).
+    void set_on_peer_height(PeerHeightCallback cb) { m_on_peer_height = std::move(cb); }
+    /// Fired once per session when the version/verack handshake completes —
+    /// the hook E2 uses to kick the initial getheaders/mnlistdiff sync.
+    void set_on_handshake_complete(HandshakeCallback cb) { m_on_handshake_complete = std::move(cb); }
+
+    /// Send a getheaders request (E2 sync driver seam; unused by E1 run_node).
+    void send_getheaders(uint32_t version, const std::vector<uint256>& locator, const uint256& stop)
+    {
+        if (!m_peer) return;
+        auto msg = message_getheaders::make_raw(version, locator, stop);
+        m_peer->write(msg);
+    }
+
+    /// Send getaddr to request peer addresses (feeds set_addr_callback).
+    void send_getaddr()
+    {
+        if (!m_peer) return;
+        auto msg = message_getaddr::make_raw();
+        m_peer->write(msg);
+    }
+
+    /// Request a full block via plain MSG_BLOCK getdata (E2 pull seam).
+    void request_block(const uint256& block_hash)
+    {
+        if (!m_peer) return;
+        auto msg = message_getdata::make_raw(
+            {inventory_type(inventory_type::block, block_hash)});
+        m_peer->write(msg);
+    }
+
+    /// Send a getmnlistd (SML diff request) — E2/E3 masternode-list sync seam.
+    void send_getmnlistd(const uint256& base_block_hash, const uint256& block_hash)
+    {
+        if (!m_peer) return;
+        auto msg = message_getmnlistd::make_raw(base_block_hash, block_hash);
+        m_peer->write(msg);
+    }
+
+    /// Relay a pre-serialized won block as a `block` P2P message (the embedded
+    /// P2P-relay arm of the dual-path broadcaster — dispatch wiring is a later
+    /// slice; the method is here so the relay leg binds without a client edit).
+    void submit_block_p2p_raw(const std::vector<unsigned char>& raw_block)
+    {
+        if (!m_peer)
+        {
+            LOG_ERROR << "[" << m_chain_label << "] no coin-network connection; "
+                         "cannot relay won block over embedded P2P";
+            return;
+        }
+        auto rmsg = std::make_unique<RawMessage>("block", PackStream(raw_block));
+        m_peer->write(rmsg);
+        LOG_INFO << "[" << m_chain_label << "] won-block relayed over embedded P2P ("
+                 << raw_block.size() << " bytes)";
+    }
+
+    // ICommunicator
+    void error(const message_error_type& err, const NetService& service, const std::source_location where = std::source_location::current()) override
+    {
+        // Copy — the NetService reference may dangle once the socket is freed.
+        NetService svc_copy = service;
+        LOG_WARNING << "[" << m_chain_label << "] peer " << svc_copy.to_string()
+                    << " disconnected: " << err
+                    << (m_reconnect_enabled ? " (reconnect armed)" : "");
+        if (m_peer)
+            m_peer.reset();
+        // else: already disconnected (double-fire race) — safe to ignore
+
+        stop_ping_timer();
+        stop_timeout_timer();
+        m_handshake.reset();
+    }
+
+    void error(const boost::system::error_code& ec, const NetService& service, const std::source_location where = std::source_location::current()) override
+    {
+        error(parse_net_error(ec), service, where);
+    }
+
+    void handle(std::unique_ptr<RawMessage> rmsg, const NetService& service) override
+    {
+        on_activity();
+
+        p2p::Handler::result_t result;
+        try
+        {
+            result = m_handler.parse(rmsg);
+        } catch (const std::runtime_error& ec)
+        {
+            LOG_ERROR << "[" << m_chain_label << "] handle(" << rmsg->m_command
+                      << ", " << rmsg->m_data.size() << " bytes): " << ec.what();
+            return;
+        } catch (const std::out_of_range&)
+        {
+            // Command outside our Handler set — dashd peers push spork/
+            // governance/quorum traffic (spork, senddsq, qsendrecsigs, ...)
+            // unsolicited; ignoring them is protocol-legal for a light client.
+            LOG_DEBUG_COIND << "[" << m_chain_label << "] ignoring unhandled command '"
+                            << rmsg->m_command << "' (" << rmsg->m_data.size() << " bytes)";
+            return;
+        }
+
+        std::visit([&](auto& msg){ handle(std::move(msg)); }, result);
+    }
+
+    const std::vector<std::byte>& get_prefix() const override
+    {
+        return m_config->coin()->m_p2p.prefix;
+    }
+
+private:
+    void ensure_timeout_timer()
+    {
+        if (!m_timeout_timer)
+            m_timeout_timer = std::make_unique<core::Timer>(m_context, false);
+    }
+
+    void ensure_ping_timer()
+    {
+        if (!m_ping_timer)
+            m_ping_timer = std::make_unique<core::Timer>(m_context, true);
+    }
+
+    void stop_timeout_timer()
+    {
+        if (m_timeout_timer)
+            m_timeout_timer->stop();
+    }
+
+    void stop_ping_timer()
+    {
+        if (m_ping_timer)
+            m_ping_timer->stop();
+    }
+
+    void on_activity()
+    {
+        if (!m_peer)
+            return;
+        ensure_timeout_timer();
+        auto timeout = m_handshake.complete() ? IDLE_TIMEOUT_SEC : CONNECT_TIMEOUT_SEC;
+        m_timeout_timer->restart(timeout);
+    }
+
+    void timeout(const char* reason)
+    {
+        auto endpoint = m_peer ? m_peer->get_addr()
+                               : (m_dial_plan.empty() ? NetService{} : m_dial_plan.current());
+        error(std::string("peer timeout: ") + reason, endpoint);
+    }
+
+    void send_ping()
+    {
+        if (!m_peer || !m_handshake.complete())
+            return;
+        auto msg_ping = message_ping::make_raw(core::random::random_nonce());
+        m_peer->write(msg_ping);
+    }
+
+    // ── handshake ────────────────────────────────────────────────────────
+
+    ADD_P2P_HANDLER(version)
+    {
+        m_peer_services = msg->m_services;
+        m_peer_version = msg->m_version;
+        m_peer_subver = msg->m_subversion;
+        m_peer_start_height = msg->m_start_height;
+        LOG_INFO << "[" << m_chain_label << "] peer version: proto=" << msg->m_version
+                 << " start_height=" << msg->m_start_height
+                 << " services=0x" << std::hex << msg->m_services << std::dec
+                 << " subver=" << msg->m_subversion;
+        if (m_on_peer_height && msg->m_start_height > 0)
+            m_on_peer_height(msg->m_start_height);
+        if (!m_handshake.on_version())
+            return;   // duplicate / stray version — do not re-ack
+        auto verack_msg = message_verack::make_raw();
+        m_peer->write(verack_msg);
+    }
+
+    ADD_P2P_HANDLER(verack)
+    {
+        if (!m_handshake.on_verack())
+            return;   // stray verack outside a session
+
+        // Arm the Connection request matchers (the E2 pull legs ride these).
+        m_peer->init_requests(
+            [&](uint256 hash)
+            {
+                auto getdata_msg = message_getdata::make_raw({inventory_type(inventory_type::block, hash)});
+                m_peer->write(getdata_msg);
+            },
+            [&](uint256 hash)
+            {
+                auto getheaders_msg = message_getheaders::make_raw(1, {}, hash);
+                m_peer->write(getheaders_msg);
+            }
+        );
+
+        LOG_INFO << "[" << m_chain_label << "] handshake complete with "
+                 << m_peer->get_addr().to_string()
+                 << " (peer proto=" << m_peer_version
+                 << " height=" << m_peer_start_height << ")";
+
+        ensure_timeout_timer();
+        m_timeout_timer->restart(IDLE_TIMEOUT_SEC);
+
+        ensure_ping_timer();
+        m_ping_timer->start(PING_INTERVAL_SEC, [this]() {
+            send_ping();
+        });
+
+        if (m_on_handshake_complete)
+            m_on_handshake_complete();
+    }
+
+    // ── keep-alive ───────────────────────────────────────────────────────
+
+    ADD_P2P_HANDLER(ping)
+    {
+        auto msg_pong = message_pong::make_raw(msg->m_nonce);
+        m_peer->write(msg_pong);
+    }
+
+    ADD_P2P_HANDLER(pong)
+    {
+        // liveness already refreshed by on_activity()
+    }
+
+    // ── E1 seam handlers: parse + fire interfaces::Node events, NO ingest ─
+
+    ADD_P2P_HANDLER(inv)
+    {
+        // E1: announce-only. Block invs fire new_block (the E2 ingest seam);
+        // NO getdata pulls yet — the ingest legs are later slices.
+        for (auto& inv : msg->m_invs)
+        {
+            if (inv.base_type() == inventory_type::block)
+            {
+                LOG_INFO << "[" << m_chain_label << "] block inv "
+                         << inv.m_hash.GetHex().substr(0, 16) << "...";
+                m_coin->new_block.happened(inv.m_hash);
+            }
+        }
+    }
+
+    ADD_P2P_HANDLER(tx)
+    {
+        m_coin->new_tx.happened(Transaction(msg->m_tx));
+    }
+
+    ADD_P2P_HANDLER(block)
+    {
+        // NOTE: dash BlockType wire-deserialization is header-only today
+        // (block.hpp S5 note) — msg->m_block carries the header; body ingest
+        // needs the raw-payload parser (E2).
+        auto header = static_cast<BlockHeaderType>(msg->m_block);
+        auto packed_header = pack(header);
+        auto blockhash = dash::crypto::hash_x11(packed_header.get_span());
+        try { m_peer->get_block(blockhash, msg->m_block); } catch (...) {}
+        try { m_peer->get_header(blockhash, header); } catch (...) {}
+        LOG_INFO << "[" << m_chain_label << "] block received: "
+                 << blockhash.GetHex().substr(0, 16) << "...";
+        m_coin->full_block.happened(msg->m_block);
+    }
+
+    ADD_P2P_HANDLER(headers)
+    {
+        // E1 receives unsolicited single-entry announcements at most (we do
+        // not send sendheaders/getheaders). Multi-entry batches need the
+        // raw-payload parser (dash BlockType is header-only on the wire) —
+        // that is the E2 sync slice.
+        std::vector<BlockHeaderType> vheaders;
+        for (auto& block : msg->m_headers)
+        {
+            auto header = static_cast<BlockHeaderType>(block);
+            auto packed_header = pack(header);
+            auto blockhash = dash::crypto::hash_x11(packed_header.get_span());
+            try { m_peer->get_header(blockhash, header); } catch (...) {}
+            vheaders.push_back(header);
+        }
+        if (!vheaders.empty())
+            m_coin->new_headers.happened(vheaders);
+    }
+
+    ADD_P2P_HANDLER(addr)
+    {
+        if (m_addr_callback && !msg->m_addrs.empty()) {
+            std::vector<NetService> addrs;
+            addrs.reserve(msg->m_addrs.size());
+            for (auto& rec : msg->m_addrs)
+                addrs.push_back(rec.m_endpoint);
+            m_addr_callback(addrs);
+        }
+    }
+
+    ADD_P2P_HANDLER(addrv2)
+    {
+        LOG_DEBUG_COIND << "[" << m_chain_label << "] addrv2: "
+                        << msg->m_addrs.size() << " record(s) (discovery seam is E2)";
+    }
+
+    ADD_P2P_HANDLER(clsig)
+    {
+        // ChainLock announcement — finalization signal. Fire the event seam;
+        // recording into chainlocked_blocks is state population (E2+).
+        LOG_INFO << "[" << m_chain_label << "] chainlock: height=" << msg->m_height
+                 << " block=" << msg->m_block_hash.GetHex().substr(0, 16) << "...";
+        m_coin->new_chainlock.happened({msg->m_block_hash, msg->m_height});
+    }
+
+    ADD_P2P_HANDLER(mnlistdiff)
+    {
+        // SML snapshot — the CoinStateMaintainer::on_mn_list_update feed is a
+        // later slice; receipt is logged so the live wire is observable.
+        LOG_INFO << "[" << m_chain_label << "] mnlistdiff received (SML ingest is E2+)";
+    }
+
+    // ── tolerated / ignored peer traffic ─────────────────────────────────
+
+    ADD_P2P_HANDLER(alert)
+    {
+        LOG_WARNING << "[" << m_chain_label << "] alert: " << msg->m_signature;
+    }
+
+    ADD_P2P_HANDLER(reject)
+    {
+        LOG_WARNING << "[" << m_chain_label << "] peer rejected " << msg->m_message
+                    << " (code=" << static_cast<int>(msg->m_ccode)
+                    << "): " << msg->m_reason
+                    << " hash=" << msg->m_data.GetHex();
+    }
+
+    ADD_P2P_HANDLER(notfound)
+    {
+        for (auto& inv : msg->m_invs)
+        {
+            if (inv.base_type() == inventory_type::block)
+            {
+                // Complete the ReplyMatcher with an empty response so pending
+                // requests don't wait out the 15s deferral timeout.
+                try { m_peer->get_block(inv.m_hash, BlockType{}); } catch (...) {}
+                try { m_peer->get_header(inv.m_hash, BlockHeaderType{}); } catch (...) {}
+            }
+        }
+    }
+
+    ADD_P2P_HANDLER(sendcmpct)
+    {
+        LOG_DEBUG_COIND << "[" << m_chain_label << "] peer sendcmpct v"
+                        << msg->m_version << " (compact-block lane is a later slice)";
+    }
+
+    ADD_P2P_HANDLER(feefilter)
+    {
+        LOG_DEBUG_COIND << "[" << m_chain_label << "] peer feefilter: "
+                        << msg->m_feerate << " duff/kB (fee pricing is a later slice)";
+    }
+
+    ADD_P2P_HANDLER(sendheaders)   { /* peer preference noted; we don't announce */ }
+    ADD_P2P_HANDLER(sendaddrv2)    { /* acknowledged */ }
+    ADD_P2P_HANDLER(mempool)       { /* we don't serve mempool */ }
+    ADD_P2P_HANDLER(getaddr)       { /* we don't serve addresses */ }
+    ADD_P2P_HANDLER(getdata)       { /* we don't serve blocks/txs */ }
+    ADD_P2P_HANDLER(getblocks)     { /* we don't serve blocks */ }
+    ADD_P2P_HANDLER(getheaders)    { /* we don't serve headers */ }
+    ADD_P2P_HANDLER(getmnlistd)    { /* we don't serve SML diffs */ }
+    ADD_P2P_HANDLER(cmpctblock)    { LOG_DEBUG_COIND << "[" << m_chain_label << "] cmpctblock ignored (E1)"; }
+    ADD_P2P_HANDLER(getblocktxn)   { /* we never announce compact blocks */ }
+    ADD_P2P_HANDLER(blocktxn)      { /* no pending compact block in E1 */ }
+
+    #undef ADD_P2P_HANDLER
+};
+
+} // namespace p2p
+} // namespace coin
+} // namespace dash

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -730,9 +730,16 @@ if (BUILD_TESTING AND GTest_FOUND)
     # lifecycle (attach/teardown), the outbound-request->inbound-reply exchange
     # through Connection, and the real-timer idle-timeout path. Header-only over
     # the dash_x11 + core link set; same set as the p2p_connection leaf.
-    add_executable(test_dash_p2p_node test_dash_p2p_node.cpp)
+    # Second TU (E1): test_dash_coin_p2p_client.cpp — the OPT-IN outbound-dial
+    # client (p2p_client.hpp): handshake state machine, dial-plan rotation, and
+    # the byte-exact version/verack handshake drive. Same target, no new
+    # allowlist entry needed.
+    add_executable(test_dash_p2p_node test_dash_p2p_node.cpp test_dash_coin_p2p_client.cpp)
     target_link_libraries(test_dash_p2p_node PRIVATE
         GTest::gtest_main GTest::gtest
+        dash_block_replay   # E1: coin/vendor/blockencodings.cpp — the full p2p Handler
+                            # (cmpctblock codec) the CoinClient instantiates ODR-uses
+                            # CBlockHeaderAndShortTxIDs::FillShortTxIDSelector().
         dash_x11 core
         nlohmann_json::nlohmann_json
         ${Boost_LIBRARIES}

--- a/test/test_dash_coin_p2p_client.cpp
+++ b/test/test_dash_coin_p2p_client.cpp
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/// DASH embedded coin-network P2P client (E1) — connection-management KATs
+///
+/// Exercises src/impl/dash/coin/p2p_client.hpp — the OPT-IN outbound dial
+/// layer (--coin-p2p-connect) the embedded arm uses to reach a live dashd:
+///
+///   (a) HandshakeTracker — the extracted version/verack state machine:
+///       legal progression, verack-before-version tolerance, stray/duplicate
+///       rejection, reset-on-disconnect.
+///
+///   (b) DialPlan — round-robin rotation over repeatable --coin-p2p-connect
+///       targets: single-target plans stay put; multi-target plans rotate on
+///       each reconnect attempt so a dead first target cannot wedge redial.
+///
+///   (c) CoinClient handshake drive — the REAL client class fed byte-exact
+///       wire messages (message_version / message_verack round-tripped
+///       through make_raw -> Handler::parse, the same path live socket bytes
+///       take): peer metadata capture, handshake completion, the
+///       on_handshake_complete seam, unknown-command tolerance (dashd spork/
+///       governance traffic), and teardown-on-error resetting the session.
+///
+/// SCOPE NOTE (honest): the wire transport here is direct handle() delivery,
+/// not a live TCP socket — the live-socket leg is the E1 smoke gate run
+/// against a controlled testnet dashd (see PR). Everything above the socket
+/// (parse -> dispatch -> state machine -> timers armed) is the real code.
+///
+/// This TU compiles into the EXISTING allowlisted test_dash_p2p_node target
+/// (second source; no new test target, no workflow edit).
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/p2p_client.hpp>
+#include <impl/dash/config.hpp>
+
+#include <core/netaddress.hpp>
+#include <core/uint256.hpp>
+#include <btclibs/util/strencodings.h>   // ParseHexBytes (wire-magic bytes)
+
+#include <boost/asio.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+using dash::coin::p2p::CoinClient;
+using dash::coin::p2p::DialPlan;
+using dash::coin::p2p::HandshakeTracker;
+
+namespace {
+
+using State = HandshakeTracker::State;
+
+// ── (a) HandshakeTracker ──────────────────────────────────────────────────
+
+TEST(DashCoinP2PClient, handshake_tracker_legal_progression)
+{
+    HandshakeTracker t;
+    EXPECT_EQ(t.state(), State::Idle);
+    EXPECT_FALSE(t.complete());
+
+    t.on_connected();
+    EXPECT_EQ(t.state(), State::Connected);
+
+    EXPECT_TRUE(t.on_version());          // peer version -> we verack
+    EXPECT_EQ(t.state(), State::VersionReceived);
+    EXPECT_FALSE(t.complete());
+
+    EXPECT_TRUE(t.on_verack());           // peer verack -> session up
+    EXPECT_EQ(t.state(), State::Complete);
+    EXPECT_TRUE(t.complete());
+}
+
+TEST(DashCoinP2PClient, handshake_tracker_verack_before_version_tolerated)
+{
+    HandshakeTracker t;
+    t.on_connected();
+    EXPECT_TRUE(t.on_verack());           // eager ack — session still completes
+    EXPECT_TRUE(t.complete());
+}
+
+TEST(DashCoinP2PClient, handshake_tracker_strays_ignored_while_idle)
+{
+    HandshakeTracker t;
+    EXPECT_FALSE(t.on_version());         // no session — must not fabricate one
+    EXPECT_FALSE(t.on_verack());
+    EXPECT_EQ(t.state(), State::Idle);
+    EXPECT_FALSE(t.complete());
+}
+
+TEST(DashCoinP2PClient, handshake_tracker_duplicate_version_not_reacked)
+{
+    HandshakeTracker t;
+    t.on_connected();
+    EXPECT_TRUE(t.on_version());
+    EXPECT_FALSE(t.on_version());         // duplicate — caller must not re-verack
+    EXPECT_TRUE(t.on_verack());
+    EXPECT_FALSE(t.on_version());         // post-complete version — ignored
+    EXPECT_TRUE(t.complete());
+}
+
+TEST(DashCoinP2PClient, handshake_tracker_reset_returns_to_idle)
+{
+    HandshakeTracker t;
+    t.on_connected();
+    t.on_version();
+    t.on_verack();
+    ASSERT_TRUE(t.complete());
+
+    t.reset();                            // disconnect / error path
+    EXPECT_EQ(t.state(), State::Idle);
+    EXPECT_FALSE(t.complete());
+    EXPECT_FALSE(t.on_verack());          // and strays stay ignored again
+}
+
+// ── (b) DialPlan ──────────────────────────────────────────────────────────
+
+TEST(DashCoinP2PClient, dial_plan_single_target_stays_put)
+{
+    DialPlan p;
+    p.set_targets({NetService("192.168.86.52", 19999)});
+    ASSERT_EQ(p.size(), 1u);
+    EXPECT_EQ(p.current().to_string(), "192.168.86.52:19999");
+    EXPECT_EQ(p.advance().to_string(), "192.168.86.52:19999");   // rotation is a no-op
+    EXPECT_EQ(p.advance().to_string(), "192.168.86.52:19999");
+}
+
+TEST(DashCoinP2PClient, dial_plan_multi_target_rotates_round_robin)
+{
+    DialPlan p;
+    p.set_targets({NetService("10.0.0.1", 9999),
+                   NetService("10.0.0.2", 9999),
+                   NetService("10.0.0.3", 9999)});
+    EXPECT_EQ(p.current().to_string(), "10.0.0.1:9999");
+    EXPECT_EQ(p.advance().to_string(), "10.0.0.2:9999");
+    EXPECT_EQ(p.advance().to_string(), "10.0.0.3:9999");
+    EXPECT_EQ(p.advance().to_string(), "10.0.0.1:9999");   // wraps
+}
+
+// ── (c) CoinClient handshake drive ────────────────────────────────────────
+
+struct ClientRig
+{
+    boost::asio::io_context ioc;
+    dash::interfaces::Node coin_state;
+    dash::Config config;
+    CoinClient<dash::Config> client;
+
+    ClientRig()
+        : config("dash-coin-p2p-client-kat")
+        , client(&ioc, &coin_state, &config, "COIN-P2P-KAT")
+    {
+        config.coin()->m_p2p.prefix = ParseHexBytes("cee2caff");   // testnet magic
+    }
+
+    // Stand the session up the way Factory does on a live connect. A null
+    // socket is legal for the Connection leaf (write() no-ops, get_addr()
+    // yields the empty NetService) — everything ABOVE the socket is real.
+    void wire_connected() { client.connected(nullptr); }
+
+    void deliver(std::unique_ptr<RawMessage> rmsg)
+    {
+        client.handle(std::move(rmsg), NetService{});
+    }
+
+    std::unique_ptr<RawMessage> peer_version(uint32_t proto, uint64_t services,
+                                             uint32_t height, const std::string& subver)
+    {
+        return dash::coin::p2p::message_version::make_raw(
+            proto, services, /*timestamp=*/1234567890ull,
+            addr_t{services, NetService{"127.0.0.1", 19999}},
+            addr_t{services, NetService{"127.0.0.1", 19999}},
+            /*nonce=*/0x1122334455667788ull, subver, height);
+    }
+};
+
+TEST(DashCoinP2PClient, client_completes_handshake_and_captures_peer_metadata)
+{
+    ClientRig rig;
+    EXPECT_FALSE(rig.client.is_connected());
+    EXPECT_FALSE(rig.client.is_handshake_complete());
+
+    bool handshake_fired = false;
+    rig.client.set_on_handshake_complete([&]{ handshake_fired = true; });
+
+    uint32_t seen_height = 0;
+    rig.client.set_on_peer_height([&](uint32_t h){ seen_height = h; });
+
+    rig.wire_connected();
+    EXPECT_TRUE(rig.client.is_connected());
+    EXPECT_FALSE(rig.client.is_handshake_complete());
+
+    rig.deliver(rig.peer_version(70230, /*services=*/5, /*height=*/1497944,
+                                 "/Dash Core:21.1.0/"));
+    EXPECT_FALSE(rig.client.is_handshake_complete());   // verack still pending
+    EXPECT_EQ(rig.client.peer_version(), 70230u);
+    EXPECT_EQ(rig.client.peer_services(), 5u);
+    EXPECT_EQ(rig.client.peer_start_height(), 1497944u);
+    EXPECT_EQ(rig.client.peer_subver(), "/Dash Core:21.1.0/");
+    EXPECT_EQ(seen_height, 1497944u);
+
+    rig.deliver(dash::coin::p2p::message_verack::make_raw());
+    EXPECT_TRUE(rig.client.is_handshake_complete());
+    EXPECT_TRUE(handshake_fired);
+}
+
+TEST(DashCoinP2PClient, client_ignores_stray_verack_without_session)
+{
+    ClientRig rig;
+    rig.deliver(dash::coin::p2p::message_verack::make_raw());
+    EXPECT_FALSE(rig.client.is_handshake_complete());
+    EXPECT_FALSE(rig.client.is_connected());
+}
+
+TEST(DashCoinP2PClient, client_tolerates_unknown_commands)
+{
+    // dashd pushes spork/governance/quorum commands outside our Handler set;
+    // the client must ignore them without tearing the session down.
+    ClientRig rig;
+    rig.wire_connected();
+    rig.deliver(rig.peer_version(70230, 1, 100, "/Dash Core:21.1.0/"));
+    rig.deliver(dash::coin::p2p::message_verack::make_raw());
+    ASSERT_TRUE(rig.client.is_handshake_complete());
+
+    auto spork = std::make_unique<RawMessage>("spork", PackStream{});
+    rig.deliver(std::move(spork));                       // must not throw
+    EXPECT_TRUE(rig.client.is_handshake_complete());     // session survives
+    EXPECT_TRUE(rig.client.is_connected());
+}
+
+TEST(DashCoinP2PClient, client_error_tears_session_down_for_redial)
+{
+    ClientRig rig;
+    rig.wire_connected();
+    rig.deliver(rig.peer_version(70230, 1, 100, "/Dash Core:21.1.0/"));
+    rig.deliver(dash::coin::p2p::message_verack::make_raw());
+    ASSERT_TRUE(rig.client.is_handshake_complete());
+
+    rig.client.error(std::string("KAT-induced disconnect"), NetService{});
+    EXPECT_FALSE(rig.client.is_connected());             // peer dropped
+    EXPECT_FALSE(rig.client.is_handshake_complete());    // session reset
+
+    // A fresh connect must renegotiate from scratch (no stale completion).
+    rig.wire_connected();
+    EXPECT_TRUE(rig.client.is_connected());
+    EXPECT_FALSE(rig.client.is_handshake_complete());
+}
+
+} // namespace


### PR DESCRIPTION
## SLICE E1 — DASH embedded coin-network dial (issue #738)

First slice of the DASH embedded (daemonless) wiring campaign: make the embedded arm establish a **live outbound connection to the Dash coin network** so later slices can populate `NodeCoinState` and build templates without a local dashd. **E1 scope = instantiate the coin P2P client + dial + maintain the connection.** Ingest / state population / mempool pull / fee pricing are later slices.

## Opt-in flag design (hard safety constraint)

A mining hotel runs the **retained dashd-RPC fallback path in production right now** (`NodeCoinState` default-unpopulated → `get_work()` takes the fallback). This change is strictly **opt-in**:

- New repeatable flag: `--coin-p2p-connect HOST:PORT`
- **ABSENT** (released/prod path): no coin P2P client is instantiated, `run_node` behavior is byte-identical to today, fallback arm untouched.
- **PRESENT**: a `dash::coin::p2p::CoinClient` dials the given endpoint(s) on the **same `ioc`** as the sharechain node, handshakes, keep-alives, and reconnects.

Even **with** the flag, `NodeCoinState` stays unpopulated in E1 (no ingest legs yet), so the fallback still serves templates — **no mining-path regression in either mode.**

## What's wired

- **`src/impl/dash/coin/p2p_client.hpp`** — `CoinClient<Config>`: the outbound-dial counterpart of the S8 socket-node skeleton (`p2p_node.hpp`). Ported 1:1 from the proven per-coin clients (`dgb <- btc <- ltc`), trimmed to E1: dial (via `core::Factory<core::Client>`), version/verack handshake (proto **70230**, the version the vendored SML/clsig codecs assume), 30s ping keep-alive, idle/handshake-timeout teardown, 30s reconnect rotating the dial plan. Two pure helpers extracted for KATs: `HandshakeTracker` (version/verack state machine) and `DialPlan` (round-robin over repeated targets).
- **`main_dash.cpp` `run_node`** — flag parse/validation + gated client standup. Coin-network wire magic (`bf0c6bbd` main / `cee2caff` testnet) sourced into `config.coin()->m_p2p.prefix`, kept **distinct** from the sharechain PREFIX. Client declared after `config`/`coin_state` so it tears down before them at scope exit.

## No-flag-unchanged guarantee

Live-verified: `--run --testnet` with no `--coin-p2p-connect` emits **zero** coin-network client lines; run-loop stands up, fallback arm `UNARMED`, sharechain listener + stratum exactly as before.

## Live-smoke result (E1 gate) — PASS

Against a controlled testnet dashd (`192.168.86.52:19999`):

```
[COIN-P2P] dialing 192.168.86.52:19999 (1 target[s] in plan)
[COIN-P2P] connected to 192.168.86.52:19999 — sending version (proto 70230)
[COIN-P2P] peer version: proto=70237 start_height=1517161 services=0x1c05 subver=/Dash Core:22.1.3/
[COIN-P2P] handshake complete with 192.168.86.52:19999 (peer proto=70237 height=1517161)
```

- Outbound connection **ESTABLISHED**, handshake **completed** against real Dash Core 22.1.3.
- Connection stayed up **65s** with **no disconnect** (testnet advanced a block mid-run, height 1517161→1517162, confirming a live peer).
- Reconnect: against a closed port, retry fires at **exactly 30s** (`dialing` 00:50:30 → `reconnecting` 00:51:00).

## Tests

- **11 new KATs** (`test/test_dash_coin_p2p_client.cpp`): handshake state machine (legal progression, verack-before-version tolerance, stray/duplicate rejection, reset), dial-plan rotation, and byte-exact `version`/`verack` drive through the real `Handler::parse` path (peer metadata capture, handshake completion, `on_handshake_complete` seam, unknown-command tolerance, error-teardown-for-redial).
- Compiled into the **existing allowlisted** `test_dash_p2p_node` target (second TU) — no `build.yml`/workflow edit. **16/16 pass** (5 original skeleton + 11 new).
- `--selftest` green; `test_dash_p2p_messages` (7) and `test_dash_p2p_connection` (4) green.

## E2 seam exposed

The client parses inbound `tx`/`block`/`headers`/`inv`/`clsig`/`mnlistdiff` and **fires the existing `dash::interfaces::Node` events** (`new_block` / `new_tx` / `full_block` / `new_headers` / `new_chainlock`), plus a `set_on_handshake_complete(cb)` hook to kick initial sync. **In E1 there are no subscribers, so every event is a no-op** and `NodeCoinState` stays unpopulated. **E2 attaches its ingest legs (`CoinStateMaintainer` / `HeaderChain` / `Mempool`) to exactly that event surface + the handshake hook** — zero change to the client to light it up.

## Isolation

Dash-fenced: `src/impl/dash` + `src/c2pool/main_dash.cpp` only; **no `src/core` edit**. Links the additive `dash_block_replay` static lib (`coin/vendor/blockencodings.cpp`) into `c2pool-dash` and `test_dash_p2p_node` — the full coin-network `Handler` the client instantiates ODR-uses `CBlockHeaderAndShortTxIDs::FillShortTxIDSelector()`.