### PR TITLE
dash(embedded/E2b): wire the UTXO/fee lane — live UTXOViewCache + connect_block + type-9 fee (fixes fee_known empty-template)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -55,6 +55,8 @@
 #include <impl/dash/coin/rpc_conf.hpp>     // dash.conf creds resolution (rpcpassword off argv)
 #include <impl/dash/coin/node_interface.hpp>
 #include <impl/dash/coin/p2p_client.hpp>   // dash::coin::p2p::CoinClient — OPT-IN coin-network dial (E1, --coin-p2p-connect)
+#include <impl/dash/coin/node_coin_state.hpp>  // dash::coin::NodeCoinState (embedded work bundle)
+#include <impl/dash/coin/utxo_lane.hpp>    // dash::coin::UtxoLane — embedded UTXO/fee lane (E2b, #738)
 #include <impl/dash/node.hpp>          // dash::Node — sharechain pool-node (NodeBridge<NodeImpl,Legacy,Actual>)
 #include <impl/dash/config.hpp>        // dash::Config (PoolConfig/CoinConfig)
 #include <impl/dash/config_pool.hpp>   // dash::SharechainConfig — P2P_PORT / PREFIX / min-proto SSOT
@@ -170,6 +172,7 @@ void print_banner(const char* argv0)
         << "           [--testnet] [--submit-block HEX | --submit-block-file PATH]\n"
         << "           [--listen [HOST:]PORT] [--addnode HOST:PORT]... [--connect HOST:PORT]...\n"
         << "           [--stratum [HOST:]PORT] [--coin-p2p-connect HOST:PORT]...\n"
+        << "           [--embedded-utxo]\n"
         << "       " << argv0 << " --mine-block [--coin-rpc H:P] [--coin-rpc-auth PATH]\n"
         << "           [--testnet] [--payout-pubkey-hash HEX] [--max-nonce N]\n\n"
         << "Status: consensus layer live (X11 PoW, subsidy, oracle CoinParams).\n"
@@ -336,7 +339,8 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              const std::string& rpc_conf_path, const std::string& submit_hex,
              const PeeringConfig& peer,
              const std::string& stratum_host, uint16_t stratum_port,
-             const std::vector<NetService>& coin_p2p_targets)
+             const std::vector<NetService>& coin_p2p_targets,
+             bool embedded_utxo)
 {
     namespace io = boost::asio;
 
@@ -484,7 +488,58 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // ioc.run() tears the acceptor down while node_coin_state is still alive.
     // Default (unpopulated) bundle: populated()==false, so get_work() takes the
     // retained dashd-fallback arm -- correct + documented for the 4a standup.
+    //
+    // E2b (#738) UTXO/fee lane: utxo_lane is declared BEFORE node_coin_state
+    // deliberately -- attach() hands the lane's UTXOViewCache pointer to the
+    // bundle's Mempool (set_utxo), so the lane must outlive the mempool that
+    // references it (reverse destruction order at scope exit).
+    dash::coin::UtxoLane utxo_lane;
     dash::coin::NodeCoinState node_coin_state;
+
+    // ── E2b (#738): the embedded UTXO/fee lane -- OPT-IN via --embedded-utxo.
+    // Transliterated from the PROVEN LTC wiring (main_ltc.cpp ~1750-1801 con-
+    // struction + set_utxo + maturity gate; ~2385-2433 block-connect leg; see
+    // utxo_lane.hpp). This is the root-cause fix for the fee_known=false ->
+    // empty-template defect: Mempool::set_utxo previously had zero dash-arm
+    // callers, so every relayed tx stayed unknown-fee and the conservative
+    // selection guard (unknown fees EXCLUDED so coinbasevalue never overstates
+    // vs dashd's GBT -- guard untouched) returned an empty selection forever.
+    //
+    // Default (flag absent): NOTHING here is constructed or subscribed -- the
+    // dashd-RPC fallback path (mining-hotel prod) is byte-unchanged. With the
+    // flag: the lane opens its LevelDB, arms the mempool's fee machinery, and
+    // subscribes the coin-state block_connected seam (leg 3, the same event
+    // block_connect_ingest.hpp routes to CoinStateMaintainer). The LIVE block
+    // feed that FIRES that event is the E1/E2a coin-P2P leg; until it lands
+    // the lane sits armed-but-dormant and get_work still routes to the
+    // retained dashd fallback (populated()==false).
+    std::shared_ptr<EventDisposable> utxo_block_sub;
+    if (embedded_utxo) {
+        const auto utxo_path = (core::filesystem::config_path()
+            / net_subdir / "utxo_leveldb").string();
+        if (utxo_lane.open(utxo_path)) {
+            utxo_lane.attach(node_coin_state.mempool());
+            // Mining gate: coinbase_maturity + reorg buffer = 100 + 6 = 106
+            // (DASH_MINING_GATE_DEPTH, utxo_adapter.hpp; mirrors the LTC
+            // set_utxo_ready_fn gate) -- embedded templates stay off until
+            // the UTXO view is deep enough to exclude immature coinbase
+            // spends. The dashd fallback is unaffected.
+            node_coin_state.set_utxo_ready_fn(
+                [&utxo_lane]() { return utxo_lane.mining_utxo_ready(); });
+            utxo_block_sub = coin_state.block_connected.subscribe(
+                [&utxo_lane](const dash::interfaces::BlockConnected& bc) {
+                    utxo_lane.on_block_connected(bc.block, bc.height);
+                });
+            std::cout << "[run] embedded UTXO/fee lane ARMED: db=" << utxo_path
+                      << " best_height=" << utxo_lane.cache()->get_best_height()
+                      << " (mempool fee pricing live; block feed = E1/E2a leg;"
+                         " maturity gate " << dash::coin::DASH_MINING_GATE_DEPTH
+                      << " blocks)\n";
+        } else {
+            std::cout << "[run] embedded UTXO/fee lane FAILED to open " << utxo_path
+                      << " -- fees stay unknown; dashd-RPC fallback unaffected\n";
+        }
+    }
 
     // REQUIRED always-reachable dashd-RPC fallback arm -- the safety +
     // [GBT-XCHECK] cross-check path, NEVER removed (operator standing rule).
@@ -721,6 +776,7 @@ int main(int argc, char** argv)
     std::vector<std::string> coin_p2p_raw;     // --coin-p2p-connect HOST:PORT (repeatable; E1 opt-in coin-network dial)
     std::string stratum_host = "0.0.0.0";      // --stratum [HOST:]PORT bind interface (default all)
     uint16_t    stratum_port = 0;              // 0 disables the Stratum accept-loop; --stratum sets it
+    bool embedded_utxo = false;                // --embedded-utxo: arm the E2b UTXO/fee lane (opt-in)
     for (int i = 1; i < argc; ++i) {
         if (std::strcmp(argv[i], "--version") == 0) {
             std::cout << "c2pool-dash " << C2POOL_VERSION << "\n";
@@ -752,6 +808,8 @@ int main(int argc, char** argv)
             connect_raw.emplace_back(argv[++i]);
         else if (std::strcmp(argv[i], "--coin-p2p-connect") == 0 && i + 1 < argc)
             coin_p2p_raw.emplace_back(argv[++i]);
+        else if (std::strcmp(argv[i], "--embedded-utxo") == 0)
+            embedded_utxo = true;
         else if (std::strcmp(argv[i], "--stratum") == 0 && i + 1 < argc) {
             // --stratum [HOST:]PORT -- bind a Stratum TCP listener for miners.
             // Bare PORT keeps the default 0.0.0.0 bind host (parse_listen SSOT).
@@ -818,7 +876,8 @@ int main(int argc, char** argv)
             coin_p2p_targets.push_back(ns);
         }
         return run_node(testnet, rpc_endpoint, rpc_conf_path, submit_hex, peer,
-                        stratum_host, stratum_port, coin_p2p_targets);
+                        stratum_host, stratum_port, coin_p2p_targets,
+                        embedded_utxo);
     }
     return run_selftest();
 }

--- a/src/impl/dash/coin/mempool.hpp
+++ b/src/impl/dash/coin/mempool.hpp
@@ -39,6 +39,7 @@
 #include "block.hpp"
 #include "transaction.hpp"
 #include "utxo_adapter.hpp"
+#include "vendor/assetlock.hpp"   // DIP-0027 CAssetUnlockPayload (type-9 fee source)
 
 #include <core/uint256.hpp>
 #include <core/pack.hpp>
@@ -466,6 +467,34 @@ private:
     bool compute_fee_locked(MempoolEntry& entry,
                             ::core::coin::UTXOViewCache* utxo)
     {
+        // DIP-0027 asset-UNLOCK special case (type 9, E2b/#738). An
+        // asset-unlock tx mints UTXO from the credit pool and carries NO
+        // regular inputs, so the generic in-minus-out path below yields
+        // in_sum(0) < out_sum -> permanently fee_known=false, and the
+        // conservative selection guard would exclude it forever. Its miner
+        // fee is EXPLICIT in the payload (CAssetUnlockPayload.fee — the
+        // amount deducted from the unlock total for the miner's coinbase;
+        // vendor/assetlock.hpp), exactly what dashd's GBT reports for it.
+        // Pricing from the payload needs no UTXO view, so this branch sits
+        // ahead of the null-utxo bail-out. TARGETED: only an input-free
+        // type-9 body with a well-formed payload qualifies; anything else
+        // (including a malformed type-9) falls through to / stays on the
+        // conservative unknown-fee path. The general unknown-fee exclusion
+        // for every other tx class is untouched.
+        if (entry.tx.type == vendor::CAssetUnlockPayload::SPECIALTX_TYPE
+            && entry.tx.vin.empty()) {
+            vendor::CAssetUnlockPayload payload;
+            if (vendor::parse_assetunlock_payload(entry.tx.extra_payload,
+                                                  payload)) {
+                entry.fee = payload.fee;
+                entry.fee_known = true;
+                return true;
+            }
+            entry.fee_known = false;
+            entry.fee = 0;
+            return false;
+        }
+
         if (!utxo) {
             entry.fee_known = false;
             return false;

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -73,12 +73,25 @@ public:
 
     bool populated() const { return m_populated; }
 
-    /// Assemble the selector input. has_state is populated(); the two required
-    /// pointers are always non-null (members), so viable() reduces to
-    /// populated() -- exactly the semantics work_source.hpp documents.
+    /// Coinbase-maturity mining gate (E2b/#738) — the dash analog of the LTC
+    /// EmbeddedCoinNode::set_utxo_ready_fn (main_ltc.cpp ~1785-1801). When
+    /// set, embedded-template viability additionally requires the predicate
+    /// (UtxoLane::mining_utxo_ready: blocks_connected >= 106) so templates
+    /// cannot include txs spending immature coinbase outputs; until then
+    /// has_state stays false and get_work routes to the retained dashd
+    /// fallback. Unset (default) preserves the pre-E2b behaviour exactly.
+    void set_utxo_ready_fn(std::function<bool()> fn) {
+        m_utxo_ready_fn = std::move(fn);
+    }
+
+    /// Assemble the selector input. has_state is populated() gated by the
+    /// optional UTXO-maturity predicate; the two required pointers are always
+    /// non-null (members), so viable() reduces to that gate -- exactly the
+    /// semantics work_source.hpp documents.
     EmbeddedWorkInputs make_embedded_work_inputs() const {
         EmbeddedWorkInputs e;
-        e.has_state            = m_populated;
+        e.has_state            = m_populated
+                                 && (!m_utxo_ready_fn || m_utxo_ready_fn());
         e.prev_height          = m_prev_height;
         e.prev_hash            = m_prev_hash;
         e.mnstates             = &m_mnstates;
@@ -105,6 +118,7 @@ public:
 private:
     MnStateMachine m_mnstates;
     Mempool        m_mempool;
+    std::function<bool()> m_utxo_ready_fn;   // optional UTXO maturity gate (E2b)
     uint32_t m_prev_height{0};
     uint256  m_prev_hash;
     uint32_t m_bits_for_next{0};

--- a/src/impl/dash/coin/utxo_adapter.hpp
+++ b/src/impl/dash/coin/utxo_adapter.hpp
@@ -6,9 +6,10 @@
 /// Plumbs `dash::coin::BlockType` and `dash::coin::MutableTransaction` into
 /// the chain-agnostic `core::coin::UTXOViewCache` / `UTXOViewDB` machinery
 /// (already used by LTC and DOGE). This file is the **type-compatibility
-/// shim only** — no live UTXOViewCache instance is constructed yet; that
-/// wiring lands in later Phase U steps (connect_block on new-tip arrival,
-/// LevelDB persistence, block-bootstrapper cold-start).
+/// shim**; the live UTXOViewCache wiring (connect_block on block-connect
+/// arrival, LevelDB persistence, block-bootstrapper cold-start) lives in
+/// utxo_lane.hpp (Phase U capstone, E2b/#738) and is constructed by the
+/// opt-in embedded path in main_dash.cpp.
 ///
 /// Why adapter-only first: lets us ship the Dash-side types + constants +
 /// txid helper in a standalone commit so the larger Phase U integration

--- a/src/impl/dash/coin/utxo_lane.hpp
+++ b/src/impl/dash/coin/utxo_lane.hpp
@@ -1,0 +1,343 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// Phase U capstone (E2b, #738): the LIVE Dash UTXO/fee lane.
+///
+/// utxo_adapter.hpp shipped the type-compatibility shim (DASH_LIMITS /
+/// DASH_MIN_BLOCKS_TO_KEEP / DASH_MINING_GATE_DEPTH / dash_txid) with the
+/// explicit note "no live UTXOViewCache instance is constructed yet". That
+/// gap is the root cause of the #738 differential's fee_known=false ->
+/// empty-template defect: Mempool::set_utxo had ZERO callers in the dash
+/// arm, so m_utxo stayed nullptr, every entry stayed fee_known=false, and
+/// the conservative selection guard (unknown-fee txs EXCLUDED so
+/// coinbasevalue can never overstate vs dashd's GBT) correctly returned an
+/// empty selection forever.
+///
+/// This header is a TRANSLITERATION of the PROVEN, LIVE Litecoin wiring in
+/// src/c2pool/main_ltc.cpp:
+///   - UTXOViewDB + UTXOViewCache construction with open-retry
+///     (main_ltc.cpp ~1750-1780) -> UtxoLane::open()
+///   - pool->set_utxo(cache)              (~1770)  -> UtxoLane::attach()
+///   - coinbase-maturity mining gate      (~1785-1801) -> mining_utxo_ready()
+///   - block-connect leg: connect_block + put_block_undo + flush +
+///     prune_undo + mempool remove_for_block + recompute_unknown_fees
+///     (~2385-2433) -> on_block_connected() / connect_one()
+///   - cold-start ordered-download pipeline over the N-block window
+///     (core/coin/block_bootstrapper.hpp, main_ltc.cpp ~2160-2379)
+///     -> the BlockBootstrapState<BlockType> branch, window = 288
+///        (DASH_MIN_BLOCKS_TO_KEEP, dashcore validation.h MIN_BLOCKS_TO_KEEP)
+///
+/// Differences from the LTC reference (each deliberate, none behavioral):
+///   - Dash's block_connected seam (node_interface.hpp BlockConnected)
+///     already pairs (block, height), so the header-chain height lookup the
+///     LTC handler performs is unnecessary; the block hash is recomputed
+///     here (X11(header) = Dash block identity, header_chain.hpp).
+///   - No MWEB tracker / HogEx handling (Dash has no MWEB; the shared
+///     connect_block template sees MutableTransaction::m_hogEx == false).
+///   - The LIVE block feed + full-block request plumbing is E1/E2a's leg
+///     (the coin P2P transport). This lane exposes exactly two seams for
+///     it: on_block_connected() (subscribe to Node::block_connected) and
+///     set_request_block_fn() (bootstrap window refill / stall re-request,
+///     the analog of broadcaster->request_full_block by height). Until E2a
+///     connects them the lane is dormant and byte-inert.
+///
+/// FENCED: src/impl/dash only. Constructed exclusively by the opt-in
+/// embedded path in main_dash.cpp; the dashd-RPC fallback (mining-hotel
+/// prod) never touches this file.
+
+#include "block.hpp"
+#include "mempool.hpp"
+#include "utxo_adapter.hpp"
+
+#include <impl/dash/crypto/hash_x11.hpp>
+
+#include <core/coin/block_bootstrapper.hpp>
+#include <core/leveldb_store.hpp>
+#include <core/log.hpp>
+#include <core/pack.hpp>
+#include <core/uint256.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <thread>
+#include <utility>
+
+namespace dash {
+namespace coin {
+
+class UtxoLane {
+public:
+    /// Bootstrap window-refill / stall re-request seam. E1/E2a wires this to
+    /// the coin P2P transport's request-full-block-by-height path (the analog
+    /// of the LTC broadcaster->request_full_block(header_by_height(h).hash)).
+    using RequestBlockFn = std::function<void(uint32_t height)>;
+
+    UtxoLane() = default;
+    UtxoLane(const UtxoLane&) = delete;
+    UtxoLane& operator=(const UtxoLane&) = delete;
+
+    /// Open the LevelDB-backed UTXO store and build the write-back cache.
+    /// Mirrors main_ltc.cpp ~1750-1780: 32 MB block cache / 8 MB write
+    /// buffer, 5 open attempts 2 s apart. Returns live() on success.
+    ///
+    /// An EMPTY db_path builds an ephemeral cache-only view (no LevelDB
+    /// base) — the synthetic-block KAT mode; persistence calls are skipped.
+    bool open(const std::string& db_path)
+    {
+        if (db_path.empty()) {
+            m_cache = std::make_unique<UtxoViewCache>(nullptr);
+            LOG_INFO << "[EMB-DASH] UTXO lane: ephemeral (no LevelDB base)";
+            return true;
+        }
+        ::core::LevelDBOptions utxo_opts;
+        utxo_opts.block_cache_size  = 32 * 1024 * 1024;  // 32 MB cache
+        utxo_opts.write_buffer_size =  8 * 1024 * 1024;  // 8 MB
+        bool utxo_ok = false;
+        for (int attempt = 1; attempt <= 5; ++attempt) {
+            m_db = std::make_unique<UtxoViewDB>(db_path, utxo_opts);
+            if (m_db->open()) { utxo_ok = true; break; }
+            LOG_WARNING << "[EMB-DASH] UTXO DB open failed (attempt "
+                        << attempt << "/5) — retrying in 2s...";
+            std::this_thread::sleep_for(std::chrono::seconds(2));
+        }
+        if (!utxo_ok) {
+            LOG_WARNING << "[EMB-DASH] UTXO DB failed to open after 5 attempts"
+                           " — fees will be unknown";
+            m_db.reset();
+            return false;
+        }
+        m_cache = std::make_unique<UtxoViewCache>(m_db.get());
+        LOG_INFO << "[EMB-DASH] UTXO set opened: best_height="
+                 << m_db->get_best_height() << " best_block="
+                 << m_db->get_best_block().GetHex().substr(0, 16);
+        return true;
+    }
+
+    bool live() const { return static_cast<bool>(m_cache); }
+    UtxoViewCache* cache() { return m_cache.get(); }
+    UtxoViewDB*    db()    { return m_db.get(); }
+
+    /// The set_utxo call the dash arm never made (main_ltc.cpp:1770).
+    /// After this, Mempool::add_tx prices via UTXO+CPFP and
+    /// recompute_unknown_fees can resolve backlog entries.
+    void attach(Mempool& pool)
+    {
+        m_pool = &pool;
+        if (m_cache) pool.set_utxo(m_cache.get());
+    }
+
+    void set_request_block_fn(RequestBlockFn fn) { m_request_fn = std::move(fn); }
+
+    /// Coinbase-maturity mining gate (main_ltc.cpp ~1785-1801): embedded
+    /// templates must not be built until the UTXO view is at least
+    /// coinbase_maturity + reorg-buffer deep, or they may spend immature
+    /// coinbase outputs. DASH_MINING_GATE_DEPTH = 100 + 6 = 106
+    /// (utxo_adapter.hpp; dashcore consensus.h COINBASE_MATURITY).
+    bool mining_utxo_ready() const
+    {
+        if (!m_cache) return false;
+        const auto connected = m_cache->blocks_connected();
+        const bool ready = connected >= DASH_MINING_GATE_DEPTH;
+        if (!ready) {
+            static int s_log_ctr = 0;
+            if (s_log_ctr++ % 20 == 0)
+                LOG_INFO << "[EMB-DASH] UTXO maturity gate: blocks_connected="
+                         << connected << " need>=" << DASH_MINING_GATE_DEPTH;
+        }
+        return ready;
+    }
+
+    /// The E2a seam — subscribe to dash::interfaces::Node::block_connected
+    /// (the leg-3 event of block_connect_ingest.hpp; it pairs block+height,
+    /// so no header-chain lookup is needed here). Transliterates the LTC
+    /// full-block handler (main_ltc.cpp ~2199-2433): bootstrap trigger ->
+    /// ordered drain -> window refill, else normal single-block connect;
+    /// mempool cleanup + fee recompute in both modes.
+    void on_block_connected(const BlockType& block, uint32_t height)
+    {
+        if (!m_cache) return;
+
+        // Dash block identity = X11(header) (header_chain.hpp).
+        auto packed_hdr = ::pack(
+            static_cast<const ::dash::coin::BlockHeaderType&>(block));
+        const uint256 block_hash =
+            ::dash::crypto::hash_x11(packed_hdr.get_span());
+
+        constexpr uint32_t DASH_KEEP = DASH_MIN_BLOCKS_TO_KEEP;  // 288
+
+        // ═══ BOOTSTRAP PIPELINE (cold start) ══════════════════════════════
+        // 1. Trigger — fires BEFORE connecting the first block so
+        //    best_height isn't set prematurely (else every bootstrap block
+        //    below the tip silently fails the height > best_height guard).
+        if (!m_bootstrap_done && !m_bs.active && height > DASH_KEEP) {
+            m_bootstrap_done = true;
+            const uint32_t utxo_best = m_cache->get_best_height();
+            const uint32_t start_from =
+                (utxo_best > 0 && utxo_best >= height - DASH_KEEP)
+                ? utxo_best + 1 : height - DASH_KEEP;
+
+            if (start_from < height) {
+                m_bs.active       = true;
+                m_bs.next_height  = start_from;
+                m_bs.end_height   = height;
+                m_bs.next_request = start_from;
+                m_bs.total        = height - start_from + 1;
+                m_bs.buffer[height] = {block, block_hash};
+                m_bs.last_drain_time = std::chrono::steady_clock::now();
+
+                int requested = 0;
+                while (m_bs.next_request <= m_bs.end_height &&
+                       (m_bs.next_request - m_bs.next_height)
+                           < m_bs.WINDOW_SIZE) {
+                    if (!m_bs.buffer.count(m_bs.next_request)) {
+                        request_block(m_bs.next_request);
+                        ++requested;
+                    }
+                    ++m_bs.next_request;
+                }
+                LOG_INFO << "[EMB-DASH] Bootstrap pipeline: " << m_bs.total
+                         << " blocks [" << start_from << ".." << height << "]"
+                         << " window=" << m_bs.WINDOW_SIZE
+                         << " requests=" << requested;
+                return;
+            }
+            LOG_INFO << "[EMB-DASH] UTXO warm restart: best=" << utxo_best
+                     << " — no bootstrap needed";
+        }
+
+        // 2. Bootstrap active: buffer -> drain in height order -> refill.
+        if (m_bs.active) {
+            if (height >= m_bs.next_height && height <= m_bs.end_height) {
+                m_bs.buffer.try_emplace(height,
+                                        std::make_pair(block, block_hash));
+            } else if (height > m_bs.end_height) {
+                // New block mined during bootstrap — extend range.
+                m_bs.end_height = height;
+                m_bs.total = m_bs.processed
+                    + (m_bs.end_height - m_bs.next_height + 1);
+                m_bs.buffer.try_emplace(height,
+                                        std::make_pair(block, block_hash));
+            }
+
+            // Stall detection: re-request the missing block if stuck.
+            const auto now = std::chrono::steady_clock::now();
+            const auto stall = std::chrono::duration_cast<std::chrono::seconds>(
+                now - m_bs.last_drain_time).count();
+            if (stall >= m_bs.STALL_TIMEOUT_SEC) {
+                LOG_WARNING << "[EMB-DASH] Bootstrap stall h="
+                            << m_bs.next_height << " (" << stall
+                            << "s) — re-request fallback";
+                request_block(m_bs.next_height);
+                m_bs.last_drain_time = now;
+            }
+
+            // Drain consecutive blocks in height order.
+            bool drained_any = false;
+            while (m_bs.buffer.count(m_bs.next_height)) {
+                auto node = m_bs.buffer.extract(m_bs.next_height);
+                auto& [b, bh] = node.mapped();
+                connect_one(b, m_bs.next_height, bh);
+                drained_any = true;
+                ++m_bs.next_height;
+                ++m_bs.processed;
+                m_bs.last_drain_time = std::chrono::steady_clock::now();
+            }
+
+            static int bs_log = 0;
+            if (++bs_log % 20 == 0 || m_bs.next_height > m_bs.end_height) {
+                LOG_INFO << "[EMB-DASH] Bootstrap: " << m_bs.processed << "/"
+                         << m_bs.total << " buf=" << m_bs.buffer.size();
+            }
+
+            // Refill sliding window.
+            while (m_bs.next_request <= m_bs.end_height
+                   && (m_bs.next_request - m_bs.next_height)
+                       < m_bs.WINDOW_SIZE) {
+                if (!m_bs.buffer.count(m_bs.next_request))
+                    request_block(m_bs.next_request);
+                ++m_bs.next_request;
+            }
+
+            if (m_bs.next_height > m_bs.end_height) {
+                m_bs.active = false;
+                m_bs.stop_stall_timer();
+                LOG_INFO << "[EMB-DASH] Bootstrap complete: "
+                         << m_bs.processed << " blocks";
+            }
+
+            if (drained_any) recompute_fees();
+            return;
+        }
+
+        // 3. Normal processing (after bootstrap or warm restart) —
+        //    main_ltc.cpp ~2385-2433.
+        if (height > m_cache->get_best_height()) {
+            connect_one(block, height, block_hash);
+
+            static int utxo_log = 0;
+            if (utxo_log++ % 10 == 0) {
+                LOG_INFO << "[EMB-DASH] UTXO: block " << height << " hash="
+                         << block_hash.GetHex().substr(0, 16)
+                         << " txs=" << block.m_txs.size()
+                         << " cache=" << m_cache->cache_size();
+            }
+        } else if (m_pool) {
+            // UTXO already past this height (duplicate / raced delivery):
+            // still clear confirmed txs from the mempool, as the LTC handler
+            // does outside its height guard.
+            m_pool->remove_for_block(block);
+        }
+        recompute_fees();
+    }
+
+private:
+    /// Single-block connect: UTXO spend/add + undo persist + flush + prune
+    /// + mempool confirm-eviction. Mirrors the per-block body of both the
+    /// LTC drain loop (~2303-2311) and normal leg (~2387-2391).
+    void connect_one(const BlockType& block, uint32_t height,
+                     const uint256& block_hash)
+    {
+        auto undo = m_cache->connect_block(
+            block, height,
+            [](const MutableTransaction& tx) { return dash_txid(tx); });
+        if (m_db) m_db->put_block_undo(height, undo);
+        m_cache->flush(block_hash, height);
+        m_cache->prune_undo(height, DASH_MIN_BLOCKS_TO_KEEP);
+        if (m_pool) m_pool->remove_for_block(block);
+    }
+
+    /// Post-connect fee revalidation (main_ltc.cpp:2428): the block's
+    /// outputs are now in UTXO and may resolve previously-unknown inputs,
+    /// flipping entries fee_known and into the feerate-sorted selection.
+    void recompute_fees()
+    {
+        if (m_pool && m_cache)
+            m_pool->recompute_unknown_fees(m_cache.get());
+    }
+
+    void request_block(uint32_t height)
+    {
+        if (m_request_fn) { m_request_fn(height); return; }
+        static bool warned = false;
+        if (!warned) {
+            warned = true;
+            LOG_WARNING << "[EMB-DASH] UTXO bootstrap wants block h=" << height
+                        << " but no request seam is wired"
+                           " (set_request_block_fn — the E1/E2a live-feed leg);"
+                           " relying on inbound delivery only";
+        }
+    }
+
+    std::unique_ptr<UtxoViewDB>    m_db;
+    std::unique_ptr<UtxoViewCache> m_cache;
+    Mempool*                       m_pool{nullptr};
+    RequestBlockFn                 m_request_fn;
+    ::core::coin::BlockBootstrapState<BlockType> m_bs;
+    bool                           m_bootstrap_done{false};
+};
+
+} // namespace coin
+} // namespace dash

--- a/test/test_dash_mempool.cpp
+++ b/test/test_dash_mempool.cpp
@@ -402,3 +402,302 @@ TEST(DashMempool, FeerateCompareIsDivisionFreeCrossMultiplyNotPreDividedDouble)
     EXPECT_TRUE(hi < lo) << "higher feerate must precede regardless of txid";
     EXPECT_FALSE(lo < hi);
 }
+// ═══ E2b (#738) — the live UTXO/fee lane KATs ════════════════════════════════
+//
+// utxo_lane.hpp is the Phase U capstone: the transliterated LTC wiring
+// (main_ltc.cpp UTXOViewDB/UTXOViewCache construction + set_utxo + block-
+// connect leg + 288-window cold-start) that finally gives the dash mempool a
+// live UTXO view. These KATs feed SYNTHETIC blocks through the exact seam the
+// E1/E2a live feed will fire (on_block_connected == Node::block_connected)
+// and pin:
+//   (a) connect_block resolves fee_known and makes txs selectable
+//   (b) coinbasevalue = subsidy + summed REAL fees (hand oracle; never over)
+//   (c) a DIP-0027 type-9 asset-unlock is priced from payload.fee
+//   (d) an unknown-fee ordinary tx stays EXCLUDED (guard untouched)
+//   (e) recompute_unknown_fees after a block-connect flips unknown -> known
+// plus the 288-window bootstrap request plan and the 106-deep maturity gate.
+
+#include <impl/dash/coin/utxo_lane.hpp>
+#include <impl/dash/coin/vendor/assetlock.hpp>
+#include <impl/dash/coin/subsidy.hpp>
+
+using dash::coin::UtxoLane;
+using dash::coin::DASH_MIN_BLOCKS_TO_KEEP;
+using dash::coin::DASH_MINING_GATE_DEPTH;
+
+// Synthetic coinbase: no inputs, the given output values, salt-distinct txid.
+static MutableTransaction make_coinbase(std::vector<int64_t> values,
+                                        uint32_t salt) {
+    MutableTransaction tx;
+    tx.version = 1;
+    tx.type = 0;
+    tx.locktime = 0x0cb00000u ^ salt;
+    for (int64_t v : values) tx.vout.push_back(make_output(v));
+    return tx;
+}
+
+// Synthetic block: header salted for a distinct block hash, txs[0] = coinbase.
+static dash::coin::BlockType make_block(
+    std::vector<MutableTransaction> txs, uint32_t salt) {
+    dash::coin::BlockType b;
+    b.m_nonce = salt;
+    b.m_previous_block = mint_hash(0xb10c0000u ^ salt);
+    b.m_txs = std::move(txs);
+    return b;
+}
+
+// Wire-serialize a CAssetUnlockPayload into extra_payload bytes.
+static std::vector<unsigned char> pack_unlock_payload(
+    const dash::coin::vendor::CAssetUnlockPayload& pl) {
+    auto ps = ::pack(pl);
+    auto span = ps.get_span();
+    return std::vector<unsigned char>(
+        reinterpret_cast<const unsigned char*>(span.data()),
+        reinterpret_cast<const unsigned char*>(span.data()) + span.size());
+}
+
+// Type-9 asset-unlock: NO inputs; outputs mint from the credit pool; the
+// miner fee lives ONLY in the payload.
+static MutableTransaction make_asset_unlock(int64_t out_value, uint32_t fee,
+                                            uint32_t salt) {
+    dash::coin::vendor::CAssetUnlockPayload pl;
+    pl.index = salt;
+    pl.fee = fee;
+    pl.requestedHeight = 1000 + salt;
+    MutableTransaction tx;
+    tx.version = 1;
+    tx.type = dash::coin::vendor::CAssetUnlockPayload::SPECIALTX_TYPE;  // 9
+    tx.locktime = 0;
+    tx.vout.push_back(make_output(out_value));
+    tx.extra_payload = pack_unlock_payload(pl);
+    return tx;
+}
+
+// (a) A UTXOViewCache fed a known UTXO set (via a connected block) resolves
+//     fee_known=true and the tx becomes selectable.
+TEST(DashUtxoLane, ConnectBlockResolvesFeeAndMakesSelectable)
+{
+    UtxoLane lane;
+    ASSERT_TRUE(lane.open(""));   // ephemeral cache-only (synthetic-block mode)
+    Mempool mp;
+    lane.attach(mp);              // the set_utxo call the dash arm never made
+
+    auto cb = make_coinbase({100'000, 60'000}, /*salt=*/1);
+    lane.on_block_connected(make_block({cb}, /*salt=*/1), /*height=*/1);
+    EXPECT_EQ(lane.cache()->blocks_connected(), 1u);
+
+    // Spend the coinbase output: 100000 in - 90000 out = 10000 fee, priced
+    // IMMEDIATELY at add_tx because the mempool now holds a live UTXO view.
+    auto spend = make_spend(dash_txid(cb), 0, 90'000, /*salt=*/11);
+    EXPECT_TRUE(mp.add_tx(spend));
+    auto entry = mp.get_entry(dash_txid(spend));
+    ASSERT_TRUE(entry.has_value());
+    EXPECT_TRUE(entry->fee_known)
+        << "with the lane attached, add_tx must price from UTXO";
+    EXPECT_EQ(entry->fee, 10'000u);
+
+    auto [sel, fees] = mp.get_sorted_txs_with_fees(1'000'000);
+    ASSERT_EQ(sel.size(), 1u) << "the priced tx must be selectable";
+    EXPECT_EQ(fees, 10'000u);
+    EXPECT_EQ(dash_txid(sel[0].tx), dash_txid(spend));
+}
+
+// (c) A type-9 asset-unlock tx is priced from payload.fee and selected —
+//     no UTXO view needed (the fee is explicit in the payload, exactly what
+//     dashd's GBT reports). Malformed payloads and input-carrying type-9
+//     bodies stay on the conservative unknown-fee path.
+TEST(DashMempool, AssetUnlockType9PricedFromPayloadFee)
+{
+    Mempool mp;                    // deliberately NO set_utxo
+    auto t9 = make_asset_unlock(500'000, /*fee=*/7'000, /*salt=*/1);
+    EXPECT_TRUE(mp.add_tx(t9));
+    auto entry = mp.get_entry(dash_txid(t9));
+    ASSERT_TRUE(entry.has_value());
+    EXPECT_TRUE(entry->fee_known)
+        << "type-9 fee comes from payload.fee, independent of UTXO";
+    EXPECT_EQ(entry->fee, 7'000u);
+
+    auto [sel, fees] = mp.get_sorted_txs_with_fees(1'000'000);
+    ASSERT_EQ(sel.size(), 1u) << "the asset-unlock must be selectable";
+    EXPECT_EQ(fees, 7'000u);
+
+    // Malformed payload: conservative — stays unknown, stays excluded.
+    MutableTransaction bad;
+    bad.version = 1;
+    bad.type = 9;
+    bad.vout.push_back(make_output(1'000));
+    bad.extra_payload = {0x01};   // truncated
+    EXPECT_TRUE(mp.add_tx(bad));
+    EXPECT_FALSE(mp.get_entry(dash_txid(bad))->fee_known);
+
+    // Type-9 WITH inputs is not an asset-unlock shape: generic path
+    // (which, with no UTXO view here, stays conservatively unknown).
+    auto odd = make_asset_unlock(2'000, 500, /*salt=*/2);
+    odd.vin.push_back(make_input(mint_hash(40), 0));
+    EXPECT_TRUE(mp.add_tx(odd));
+    EXPECT_FALSE(mp.get_entry(dash_txid(odd))->fee_known);
+
+    auto [sel2, fees2] = mp.get_sorted_txs_with_fees(1'000'000);
+    EXPECT_EQ(sel2.size(), 1u);
+    EXPECT_EQ(fees2, 7'000u) << "only the well-formed unlock is priced";
+}
+
+// (b)+(d) coinbasevalue = subsidy + summed real fees, matching a hand-
+//     computed oracle; unknown-fee ordinary txs contribute NOTHING, so the
+//     value can never overstate what dashd's GBT would report.
+TEST(DashUtxoLane, CoinbasevalueConservativeOracle)
+{
+    UtxoLane lane;
+    ASSERT_TRUE(lane.open(""));
+    Mempool mp;
+    lane.attach(mp);
+
+    auto cb = make_coinbase({100'000, 60'000}, /*salt=*/2);
+    lane.on_block_connected(make_block({cb}, /*salt=*/2), /*height=*/1);
+
+    // Priced ordinary spend: fee 10000.
+    auto spend = make_spend(dash_txid(cb), 0, 90'000, /*salt=*/21);
+    EXPECT_TRUE(mp.add_tx(spend));
+    // Priced type-9 unlock: fee 7000 from payload.
+    auto t9 = make_asset_unlock(400'000, 7'000, /*salt=*/22);
+    EXPECT_TRUE(mp.add_tx(t9));
+    // (d) Unknown-fee ordinary tx (input never in UTXO): must stay excluded.
+    auto unknown = make_spend(mint_hash(50), 0, 30'000, /*salt=*/23);
+    EXPECT_TRUE(mp.add_tx(unknown));
+    ASSERT_FALSE(mp.get_entry(dash_txid(unknown))->fee_known);
+
+    auto [sel, fees] = mp.get_sorted_txs_with_fees(1'000'000);
+    ASSERT_EQ(sel.size(), 2u)
+        << "exactly the two priced txs — the unknown-fee tx is EXCLUDED";
+    EXPECT_EQ(fees, 17'000u) << "hand oracle: 10000 + 7000";
+    for (const auto& s : sel)
+        EXPECT_NE(dash_txid(s.tx), dash_txid(unknown));
+
+    // coinbasevalue oracle at the live-validated subsidy pin (h=2459985,
+    // test_dash_subsidy.cpp): 177022505 sat subsidy + 17000 sat real fees.
+    const int64_t subsidy =
+        dash::coin::compute_dash_block_reward_post_v20(2459985);
+    ASSERT_EQ(subsidy, 177'022'505LL);
+    EXPECT_EQ(subsidy + static_cast<int64_t>(fees), 177'039'505LL)
+        << "coinbasevalue = subsidy + summed REAL fees, never inflated by "
+           "unknown-fee entries";
+}
+
+// (e) recompute_unknown_fees after a block-connect flips previously-unknown
+//     fees to known — the lane drives it automatically on the connect leg.
+TEST(DashUtxoLane, BlockConnectFlipsPreviouslyUnknownFees)
+{
+    UtxoLane lane;
+    ASSERT_TRUE(lane.open(""));
+    Mempool mp;
+    lane.attach(mp);
+
+    auto cb1 = make_coinbase({100'000}, /*salt=*/3);
+    lane.on_block_connected(make_block({cb1}, /*salt=*/3), /*height=*/1);
+
+    // Funding tx F confirms in block 2 (it is never in the mempool);
+    // spender S rides the mempool and references F's output.
+    auto funding = make_spend(dash_txid(cb1), 0, 95'000, /*salt=*/31);
+    auto spender = make_spend(dash_txid(funding), 0, 90'000, /*salt=*/32);
+    EXPECT_TRUE(mp.add_tx(spender));
+    ASSERT_FALSE(mp.get_entry(dash_txid(spender))->fee_known)
+        << "F is neither in UTXO nor in the mempool yet";
+    EXPECT_EQ(mp.get_sorted_txs_with_fees(1'000'000).first.size(), 0u)
+        << "unknown-fee tx must not be selectable";
+
+    auto cb2 = make_coinbase({50'000}, /*salt=*/4);
+    lane.on_block_connected(make_block({cb2, funding}, /*salt=*/4),
+                            /*height=*/2);
+
+    auto entry = mp.get_entry(dash_txid(spender));
+    ASSERT_TRUE(entry.has_value()) << "S must survive remove_for_block";
+    EXPECT_TRUE(entry->fee_known)
+        << "the connect leg must run recompute_unknown_fees";
+    EXPECT_EQ(entry->fee, 5'000u);  // 95000 - 90000
+    auto [sel, fees] = mp.get_sorted_txs_with_fees(1'000'000);
+    ASSERT_EQ(sel.size(), 1u);
+    EXPECT_EQ(fees, 5'000u);
+}
+
+// Confirmed txs leave the mempool on the connect leg (remove_for_block).
+TEST(DashUtxoLane, ConnectLegEvictsConfirmedTxs)
+{
+    UtxoLane lane;
+    ASSERT_TRUE(lane.open(""));
+    Mempool mp;
+    lane.attach(mp);
+
+    auto cb = make_coinbase({100'000}, /*salt=*/5);
+    lane.on_block_connected(make_block({cb}, /*salt=*/5), /*height=*/1);
+
+    auto spend = make_spend(dash_txid(cb), 0, 90'000, /*salt=*/51);
+    EXPECT_TRUE(mp.add_tx(spend));
+    ASSERT_EQ(mp.size(), 1u);
+
+    auto cb2 = make_coinbase({50'000}, /*salt=*/6);
+    lane.on_block_connected(make_block({cb2, spend}, /*salt=*/6),
+                            /*height=*/2);
+    EXPECT_EQ(mp.size(), 0u) << "confirmed tx must be evicted";
+}
+
+// Cold start: the first connected block above the 288 window triggers the
+// ordered-download bootstrap (block_bootstrapper.hpp) instead of connecting
+// the tip out of order, and requests exactly the 16-wide sliding window from
+// tip-288 upward through the E1/E2a request seam.
+TEST(DashUtxoLane, ColdStartBootstrapWindowPlan)
+{
+    UtxoLane lane;
+    ASSERT_TRUE(lane.open(""));
+    Mempool mp;
+    lane.attach(mp);
+
+    std::vector<uint32_t> requested;
+    lane.set_request_block_fn(
+        [&requested](uint32_t h) { requested.push_back(h); });
+
+    const uint32_t tip = 500;
+    auto cbt = make_coinbase({100'000}, /*salt=*/7);
+    lane.on_block_connected(make_block({cbt}, /*salt=*/7), tip);
+
+    // 500 > 288 => bootstrap: start = 500 - 288 = 212, window 212..227.
+    const uint32_t start = tip - DASH_MIN_BLOCKS_TO_KEEP;
+    ASSERT_EQ(start, 212u);
+    ASSERT_EQ(requested.size(), 16u) << "initial sliding window = 16";
+    for (uint32_t i = 0; i < 16; ++i)
+        EXPECT_EQ(requested[i], start + i);
+    EXPECT_EQ(lane.cache()->blocks_connected(), 0u)
+        << "the tip must NOT connect out of order";
+
+    // Drain in strict height order: 212 connects, the window refills.
+    auto cb212 = make_coinbase({70'000}, /*salt=*/8);
+    lane.on_block_connected(make_block({cb212}, /*salt=*/8), start);
+    EXPECT_EQ(lane.cache()->blocks_connected(), 1u);
+    ASSERT_GT(requested.size(), 16u) << "window must refill after a drain";
+    EXPECT_EQ(requested.back(), start + 16);
+
+    // Out-of-order arrival buffers without connecting.
+    auto cb214 = make_coinbase({70'000}, /*salt=*/9);
+    lane.on_block_connected(make_block({cb214}, /*salt=*/9), start + 2);
+    EXPECT_EQ(lane.cache()->blocks_connected(), 1u)
+        << "height-order drain must stall on the missing block";
+}
+
+// The 106-deep coinbase-maturity mining gate (100 + 6, utxo_adapter.hpp).
+TEST(DashUtxoLane, MiningMaturityGateAt106)
+{
+    ASSERT_EQ(DASH_MINING_GATE_DEPTH, 106u);
+    UtxoLane lane;
+    ASSERT_TRUE(lane.open(""));
+    EXPECT_FALSE(lane.mining_utxo_ready());
+
+    for (uint32_t h = 1; h <= DASH_MINING_GATE_DEPTH; ++h) {
+        auto cb = make_coinbase({10'000}, /*salt=*/1000 + h);
+        lane.on_block_connected(make_block({cb}, /*salt=*/1000 + h), h);
+        if (h < DASH_MINING_GATE_DEPTH)
+            EXPECT_FALSE(lane.mining_utxo_ready())
+                << "gate must hold below " << DASH_MINING_GATE_DEPTH
+                << " (h=" << h << ")";
+    }
+    EXPECT_TRUE(lane.mining_utxo_ready())
+        << "gate must open at exactly " << DASH_MINING_GATE_DEPTH;
+}


### PR DESCRIPTION
SLICE E2b of the DASH embedded-daemon campaign (#738): complete the dormant UTXO/fee lane so the embedded mempool can price transactions and build populated templates. Root-cause fix for the `fee_known=false` -> empty-template defect the #738 differential found.

## Root cause (re-verified against source)

The dash mempool already carried the full fee machinery — `compute_fee_locked` (UTXO + CPFP parent fallback), `recompute_unknown_fees`, the dashcore-conformant feerate index, and the conservative guard that EXCLUDES unknown-fee txs so coinbasevalue can never overstate vs dashd's GBT. What was missing was one live `UTXOViewCache`: `utxo_adapter.hpp` was explicitly the "type-compatibility shim only — no live UTXOViewCache constructed yet", and `Mempool::set_utxo` had **zero** callers in the dash arm. `m_utxo == nullptr` -> `fee_known=false` forever -> selection (correctly) empty forever.

## What was transliterated from the LIVE Litecoin wiring

Mirror of `main_ltc.cpp`, deliberately not invented:

| LTC reference | Dash landing |
|---|---|
| UTXOViewDB + UTXOViewCache construction, open-retry, 32 MB/8 MB LevelDB opts (~1750-1780) | `UtxoLane::open()` at `<datadir>/dash[_testnet]/utxo_leveldb` |
| `embedded_pool->set_utxo(cache)` (1770) | `UtxoLane::attach(node_coin_state.mempool())` — the missing call |
| maturity gate `set_utxo_ready_fn` (1785-1801) | `NodeCoinState::set_utxo_ready_fn` + `UtxoLane::mining_utxo_ready()` (106 = `DASH_MINING_GATE_DEPTH`) |
| block-connect leg: `connect_block` + `put_block_undo` + `flush` + `prune_undo` + `remove_for_block` + `recompute_unknown_fees` (2303/2387-2433) | `UtxoLane::on_block_connected()` / `connect_one()`, txid via `dash_txid` |
| 288-window ordered cold-start (`block_bootstrapper.hpp`, 2160-2379) | same pipeline, window = `DASH_MIN_BLOCKS_TO_KEEP` (288), refill/stall re-request through a request seam |

The pre-staged constants in `utxo_adapter.hpp` (`DASH_LIMITS`, `288`, `106`) are consumed as-is.

Deviations from the LTC reference (each deliberate): the dash `block_connected` event already pairs (block, height), so no header-chain height lookup; block hash is X11(header) (dash block identity); no MWEB/HogEx handling (Dash has none); the maturity gate lands on `NodeCoinState` because dash has no `EmbeddedCoinNode` analog yet.

## DASH-only special case: DIP-0027 type-9 asset-unlock fee

An asset-unlock tx (special type 9) mints UTXO from the credit pool and has NO regular inputs, so the generic in-minus-out path yields `in_sum(0) < out_sum` -> permanently `fee_known=false`. Its miner fee is EXPLICIT in the payload (`CAssetUnlockPayload.fee`, `vendor/assetlock.hpp`) — exactly what dashd's GBT credits to the coinbase. `compute_fee_locked` now prices an **input-free, well-formed** type-9 from `payload.fee`. Malformed payloads and input-carrying type-9 bodies stay on the conservative unknown-fee path. **The general unknown-fee exclusion for every other tx class is untouched, and NO floor-ordered fallback inclusion of unknown-fee txs was added** — the invariant that coinbasevalue never desyncs above dashd's GBT holds.

## No-fallback-path-disturbance guarantee

The lane is OPT-IN via `--run --embedded-utxo`. Flag absent (default, mining-hotel prod): nothing is constructed, no LevelDB is opened, no event is subscribed, `set_utxo_ready_fn` is never set — verified by a live `--run` bring-up with and without the flag (no UTXO artifacts on disk, identical `[run]` output). The dashd-RPC GBT/submitblock fallback arm is untouched and remains the always-reachable safety + [GBT-XCHECK] path.

## KAT results (compiled into the existing allowlisted `test_dash_mempool` target, #729 pattern)

All synthetic-block, network-free, driving the exact `on_block_connected` seam:

- (a) `DashUtxoLane.ConnectBlockResolvesFeeAndMakesSelectable` — UTXO fed via a connected block; spend priced at `add_tx` (fee 10000), selectable. PASS
- (b) `DashUtxoLane.CoinbasevalueConservativeOracle` — selection fees = 17000 (hand oracle 10000+7000); coinbasevalue = 177022505 (live-validated subsidy pin) + 17000 = 177039505; the unknown-fee tx contributes nothing, so the value can never exceed dashd's. PASS
- (c) `DashMempool.AssetUnlockType9PricedFromPayloadFee` — type-9 priced from `payload.fee` (7000) and selected; malformed / input-carrying variants stay unknown. PASS
- (d) unknown-fee ordinary tx stays EXCLUDED (asserted inside (b)). PASS
- (e) `DashUtxoLane.BlockConnectFlipsPreviouslyUnknownFees` — recompute after block-connect flips unknown -> known (fee 5000). PASS
- plus `ConnectLegEvictsConfirmedTxs`, `ColdStartBootstrapWindowPlan` (288-window, 16-wide sliding requests, strict height-order drain), `MiningMaturityGateAt106`.

`test_dash_mempool`: 18/18 PASS. All 44 dash test binaries in the tree: PASS (no regression from the mempool / node_coin_state edits). `c2pool-dash --selftest`: green. `c2pool-dash` + tests built locally `-j4`.

## What E2a must connect (the LIVE feed)

E2b validates with synthetic blocks; the lane is armed but dormant until E1/E2a supplies real blocks:

1. **Fire `dash::interfaces::Node::block_connected`** with real `(block, height)` pairs from the coin P2P transport (the same leg-3 event `block_connect_ingest.hpp` routes to `CoinStateMaintainer`). main_dash already subscribes the lane to it under `--embedded-utxo`.
2. **Wire `UtxoLane::set_request_block_fn`** to the transport's request-full-block-by-height path (header-chain lookup + getdata), so the 288-block bootstrap window can refill and stall re-requests work. Until then the lane logs once and relies on inbound delivery only.
3. Once the maintainer populates `NodeCoinState` (`set_tip` + MN list), the 106-deep maturity gate automatically holds embedded templates back until the UTXO view is deep enough; no further E2a action needed there.
