### PR TITLE
dash(embedded/E2a): wire live coin-P2P feed into maintainer -> populate NodeCoinState (daemonless templates)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -57,6 +57,13 @@
 #include <impl/dash/coin/p2p_client.hpp>   // dash::coin::p2p::CoinClient — OPT-IN coin-network dial (E1, --coin-p2p-connect)
 #include <impl/dash/coin/node_coin_state.hpp>  // dash::coin::NodeCoinState (embedded work bundle)
 #include <impl/dash/coin/utxo_lane.hpp>    // dash::coin::UtxoLane — embedded UTXO/fee lane (E2b, #738)
+#include <impl/dash/coin/header_chain.hpp>       // dash::coin::HeaderChain — SPV header/tip authority (E2a)
+#include <impl/dash/coin/coin_state_maintainer.hpp>  // dash::coin::CoinStateMaintainer — populate ordering gate (E2a)
+#include <impl/dash/coin/live_feed.hpp>          // E2a live-feed bridge (raw wire events -> derived ingest events)
+#include <impl/dash/coin/mempool_ingest.hpp>     // wire_mempool_ingest (leg 1)
+#include <impl/dash/coin/tip_ingest.hpp>         // wire_tip_ingest (leg 2)
+#include <impl/dash/coin/block_connect_ingest.hpp>   // wire_block_connect_ingest (leg 3)
+#include <impl/dash/coin/mn_list_ingest.hpp>     // wire_mn_list_ingest (leg 4)
 #include <impl/dash/node.hpp>          // dash::Node — sharechain pool-node (NodeBridge<NodeImpl,Legacy,Actual>)
 #include <impl/dash/config.hpp>        // dash::Config (PoolConfig/CoinConfig)
 #include <impl/dash/config_pool.hpp>   // dash::SharechainConfig — P2P_PORT / PREFIX / min-proto SSOT
@@ -891,6 +898,156 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     };
     think_timer->expires_after(std::chrono::seconds(15));
     think_timer->async_wait(*think_tick);
+
+    // ── E2a: wire the LIVE coin-P2P feed into the maintainer -> populate ──
+    // GUARANTEE: this whole block is gated on `coin_p2p` (i.e. --coin-p2p-connect
+    // was supplied). With NO flag, coin_p2p is null, none of the header chain /
+    // maintainer / ingest legs below are constructed, and run_node is byte-
+    // identical to the released dashd-fallback prod path. The subscriptions are
+    // REGISTERED here (before ioc.run()); no wire event can fire until the loop
+    // below pumps the socket I/O, so wiring after the E1 connect() is race-free.
+    //
+    // These locals are declared LAST in run_node's scope so they are destroyed
+    // FIRST at return (after ioc.run() has stopped and no further events fire):
+    // subscription handles -> maintainer -> header_chain, all torn down before
+    // node_coin_state / coin_state (declared earlier) they reference.
+    std::unique_ptr<dash::coin::HeaderChain> header_chain;
+    std::unique_ptr<dash::coin::CoinStateMaintainer> maintainer;
+    std::vector<std::shared_ptr<EventDisposable>> coin_feed_subs;
+    if (coin_p2p) {
+        const auto dash_params = testnet
+            ? dash::coin::make_dash_chain_params_testnet()
+            : dash::coin::make_dash_chain_params_mainnet();
+        const auto hdr_db = (core::filesystem::config_path()
+            / net_subdir / "dash_headers").string();
+        header_chain = std::make_unique<dash::coin::HeaderChain>(dash_params, hdr_db);
+        header_chain->init();
+
+        maintainer = std::make_unique<dash::coin::CoinStateMaintainer>(node_coin_state);
+
+        // Coin address versions for the embedded coinbase-payee encoding (the
+        // TipAdvance carries them so build_embedded_workdata can encode the MN
+        // payee); sourced from the oracle CoinParams, testnet/mainnet-aware.
+        const core::CoinParams coin_params = dash::make_coin_params(testnet);
+        const uint8_t addr_ver  = coin_params.address_version;
+        const uint8_t p2sh_ver  = coin_params.address_p2sh_version;
+
+        // Leg 1 (mempool relay): new_tx -> maintainer.on_mempool_tx. Optional
+        // for viability; enriches the assembled template.
+        coin_feed_subs.push_back(
+            c2pool::dash::wire_mempool_ingest(coin_state, *maintainer));
+        // Leg 2 (tip advance): Node::new_tip -> maintainer.on_new_tip. The
+        // new_tip event is FIRED by the tip-changed callback below (off the
+        // header chain), NOT the raw wire.
+        coin_feed_subs.push_back(
+            c2pool::dash::wire_tip_ingest(coin_state, *maintainer));
+        // Leg 3 (block connect): Node::block_connected -> maintainer
+        // .on_block_connected (MnStateMachine::apply_block, folds DIP3 special
+        // txs into the DMN set). block_connected is fired by the live-feed
+        // bridge (full_block -> height lookup). The E2b UTXO lane is ALSO
+        // subscribed to the same event (its connect_block + fee recompute).
+        coin_feed_subs.push_back(
+            c2pool::dash::wire_block_connect_ingest(coin_state, *maintainer));
+        // Leg 4 (mnlistdiff RESYNC): Node::mn_list_update -> maintainer
+        // .on_mn_list_update. Wired for completeness; a payee-complete DMN-set
+        // source over P2P is the known follow-on (see PR — Dash's Simplified MN
+        // List omits scriptPayout, so the authoritative payout-bearing set is
+        // built by leg 3's apply_block over connected block bodies).
+        coin_feed_subs.push_back(
+            c2pool::dash::wire_mn_list_ingest(coin_state, *maintainer));
+
+        // Bridge: new_headers -> HeaderChain::add_headers (X11 PoW + DGW
+        // validated). The tip authority for the embedded template.
+        coin_feed_subs.push_back(
+            dash::coin::wire_header_ingest(coin_state, *header_chain));
+        // Bridge: full_block -> (X11 hash -> header-chain height) ->
+        // Node::block_connected, driving leg 3 + the E2b UTXO lane.
+        coin_feed_subs.push_back(
+            dash::coin::wire_full_block_ingest(coin_state, *header_chain));
+
+        // new_block(inv hash) -> pull the full block from the peer (getdata).
+        // Closes the loop so live tip blocks arrive as full_block -> connect.
+        coin_feed_subs.push_back(
+            coin_state.new_block.subscribe(
+                [cp = coin_p2p.get()](const uint256& hash) {
+                    cp->request_block(hash);
+                }));
+
+        // new_chainlock -> record into the best-chainlock tracker (finalization
+        // signal the block-find submit path can consult).
+        coin_feed_subs.push_back(
+            coin_state.new_chainlock.subscribe(
+                [&coin_state](const std::pair<uint256, int32_t>& cl) {
+                    coin_state.chainlocked_blocks[cl.first] = cl.second;
+                }));
+
+        // Header self-propel: after each accepted headers batch, request the
+        // next batch off the updated locator so the chain catches up to tip.
+        // Registered AFTER wire_header_ingest so add_headers runs first and the
+        // locator reflects the new tip.
+        coin_feed_subs.push_back(
+            coin_state.new_headers.subscribe(
+                [cp = coin_p2p.get(), hc = header_chain.get()]
+                (const std::vector<dash::coin::BlockHeaderType>& batch) {
+                    if (batch.empty()) return;
+                    cp->send_getheaders(70230, hc->get_locator(), uint256::ZERO);
+                }));
+
+        // Tip-changed callback: (a) fire Node::new_tip (leg 2 arms tip-readiness
+        // -> the maintainer republishes once the MN list is ALSO seeded ->
+        // populated() flips), and (b) #739 idle-notify: bump work-generation +
+        // notify sessions on a real tip change so idle miners are not wedged on
+        // stale work between job-push timer firings (event-driven notify).
+        header_chain->set_on_tip_changed(
+            [&coin_state, &stratum_server, hc = header_chain.get(),
+             addr_ver, p2sh_ver, ws = work_source.get()]
+            (const uint256&, uint32_t, const uint256& new_tip, uint32_t new_height) {
+                auto ta = dash::coin::tip_advance_from_chain(
+                    *hc, addr_ver, p2sh_ver);
+                if (ta) {
+                    coin_state.new_tip.happened(*ta);
+                    LOG_INFO << "[EMB-DASH] tip advanced h=" << new_height
+                             << " " << new_tip.GetHex().substr(0, 16)
+                             << " bits=0x" << std::hex << ta->bits_for_next << std::dec
+                             << " -> new_tip fired (maintainer arm)";
+                }
+                // #739: event-driven stale-work notify.
+                if (ws) ws->bump_work_generation();
+                if (stratum_server) stratum_server->notify_all();
+            });
+
+        // E2b UTXO bootstrap window-refill seam: request historical block
+        // bodies BY HEIGHT (header-chain hash lookup) so the UTXO view + the
+        // MnStateMachine (apply_block) fill forward from the live feed.
+        if (embedded_utxo && utxo_lane.live()) {
+            utxo_lane.set_request_block_fn(
+                [cp = coin_p2p.get(), hc = header_chain.get()](uint32_t h) {
+                    auto e = hc->get_header_by_height(h);
+                    if (e) cp->request_block(e->hash);
+                });
+        }
+
+        // Peer's reported chain height -> header-chain sync-progress gauge.
+        coin_p2p->set_on_peer_height(
+            [hc = header_chain.get()](uint32_t h) { hc->set_peer_tip_height(h); });
+
+        // Kick the initial sync once the version/verack handshake completes:
+        // getheaders off our current locator + a mempool prime.
+        coin_p2p->set_on_handshake_complete(
+            [cp = coin_p2p.get(), hc = header_chain.get()]() {
+                LOG_INFO << "[EMB-DASH] handshake complete -> initial sync:"
+                            " getheaders + mempool";
+                cp->send_getheaders(70230, hc->get_locator(), uint256::ZERO);
+                cp->send_mempool();
+            });
+
+        std::cout << "[run] E2a live-feed wired: header-chain(" << hdr_db
+                  << ") + CoinStateMaintainer + 6 ingest subscriptions;"
+                     " populate flips get_work to the EMBEDDED arm once the tip"
+                     " (headers) AND the DMN set (block-connect apply_block) are"
+                     " present" << (embedded_utxo ? " + UTXO maturity>=106" : "")
+                  << "\n";
+    }
 
     std::cout << "[run] run-loop up (Ctrl-C to stop); won blocks relay via the\n"
                  "[run] dashd-RPC submitblock fallback + the embedded sharechain P2P leg.\n";

--- a/src/impl/dash/coin/block.hpp
+++ b/src/impl/dash/coin/block.hpp
@@ -7,12 +7,17 @@
 // NOTE: the `m_txs` block-body member below was ADVANCED FROM S5 (block-replay)
 // into the S4-pre foundation (branch dash/pr0-foundation-s4) to close
 // credit_pool.apply_block(), which walks block.m_txs for asset-lock/unlock
-// accounting. This is the SINGLE canonical declaration of the member: S5 builds
-// on it (adding the transaction-aware (de)serialization of m_txs) rather than
-// re-authoring it, to avoid a double-add collision on this struct.
+// accounting. This is the SINGLE canonical declaration of the member.
 //
-// S3/S4-pre serialization stays HEADER-ONLY here; transaction-aware
-// (de)serialization of m_txs remains deferred to S5 along with the wire format.
+// E2a (#738) closes the S5 deferral: BlockType now (de)serializes m_txs as the
+// standard Bitcoin block body (CompactSize tx-count + txs), mirroring the DGB
+// sibling (src/impl/dgb/coin/block.hpp) minus witness (Dash is non-segwit, non-
+// MWEB). This is what a live dashd `block` message body needs to deserialize
+// into the tx set the embedded ingest legs consume, and it makes the multi-entry
+// `headers` message round-trip too: on the wire each `headers` entry is an 80-
+// byte header followed by a CompactSize(0) tx-count, which now deserializes as a
+// header + empty m_txs. The E1 coin-P2P client explicitly deferred this parser
+// to E2a.
 
 #include <impl/bitcoin_family/coin/base_block.hpp>
 #include <impl/dash/coin/transaction.hpp>  // complete MutableTransaction for m_txs member
@@ -29,18 +34,22 @@ using bitcoin_family::coin::BlockHeaderType;
 
 struct BlockType : BlockHeaderType
 {
-    // Advanced from S5 to close credit_pool.apply_block(). Transaction-aware
-    // (de)serialization of this member lands in S5; not serialized here.
+    // Block body. E2a: transaction-aware (de)serialization below. Dash is
+    // non-segwit / non-MWEB, so the tx vector is the plain CompactSize-prefixed
+    // MutableTransaction sequence (MutableTransaction carries its own Dash
+    // version|type<<16 + extra_payload codec) — no TX_WITH_WITNESS wrapper.
     std::vector<MutableTransaction> m_txs;
 
     template <typename Stream>
     void Serialize(Stream& s) const {
         BlockHeaderType::Serialize(s);
+        ::Serialize(s, m_txs);
     }
 
     template <typename Stream>
     void Unserialize(Stream& s) {
         BlockHeaderType::Unserialize(s);
+        ::Unserialize(s, m_txs);
     }
 
     BlockType() : BlockHeaderType() { }

--- a/src/impl/dash/coin/header_chain.hpp
+++ b/src/impl/dash/coin/header_chain.hpp
@@ -15,6 +15,7 @@
 #include <core/pack.hpp>
 #include <core/hash.hpp>
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <functional>
@@ -315,6 +316,31 @@ public:
     size_t size() const {
         std::lock_guard<std::mutex> lock(m_mutex);
         return m_headers.size();
+    }
+
+    // Median-time-past of the tip: median of the last 11 block timestamps
+    // (dashcore GetMedianTimePast / BIP113). build_embedded_workdata() uses
+    // mtp_at_tip+1 as the template mintime, so the embedded arm needs a real
+    // MTP off the header chain to match dashd's GBT. Falls back to the tip
+    // timestamp when fewer than 11 headers are indexed (cold start).
+    uint32_t median_time_past() const {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (m_tip.IsNull()) return 0;
+        static constexpr int MEDIAN_SPAN = 11;
+        std::vector<uint32_t> times;
+        times.reserve(MEDIAN_SPAN);
+        int64_t h = static_cast<int64_t>(m_tip_height);
+        for (int i = 0; i < MEDIAN_SPAN && h >= 0; ++i, --h) {
+            auto e = get_header_by_height_internal(static_cast<uint32_t>(h));
+            if (!e) break;
+            times.push_back(e->header.m_timestamp);
+        }
+        if (times.empty()) {
+            auto it = m_headers.find(m_tip);
+            return it != m_headers.end() ? it->second.header.m_timestamp : 0;
+        }
+        std::sort(times.begin(), times.end());
+        return times[times.size() / 2];
     }
 
     bool has_header(const uint256& hash) const {

--- a/src/impl/dash/coin/live_feed.hpp
+++ b/src/impl/dash/coin/live_feed.hpp
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+// ===========================================================================
+// DASH embedded live-feed bridge (E2a, #738).
+//
+// E1 (p2p_client.hpp) landed a coin-network P2P client that dials a dashd peer
+// and FIRES the RAW dash::interfaces::Node events off the wire:
+//   new_block(hash)  new_tx(Transaction)  full_block(BlockType)
+//   new_headers(vector<BlockHeaderType>)  new_chainlock({hash,height})
+// but with NO subscribers those events are no-ops and NodeCoinState never
+// populates. The four ingest legs (mempool_ingest / tip_ingest /
+// block_connect_ingest / mn_list_ingest) subscribe DERIVED events the raw wire
+// does not fire directly:
+//   * tip_ingest        <- Node::new_tip        (TipAdvance: height/hash/bits/mtp/addr)
+//   * block_connect_ingest <- Node::block_connected (BlockConnected: block + height)
+//   * mn_list_ingest    <- Node::mn_list_update  (MnListUpdate: full DMN set)
+//   * mempool_ingest    <- Node::new_tx          (direct — already matches)
+//
+// This bridge is the E2a translation layer that turns the raw wire events into
+// the derived ingest events, using a HeaderChain as the tip/height authority:
+//
+//   new_headers ──> HeaderChain::add_headers ──(tip advances)──> Node::new_tip
+//   full_block  ──(X11 hash -> HeaderChain height)──────────────> Node::block_connected
+//   new_block(hash inv) ──> request the full block from the peer (getdata)
+//
+// The tip-advance params (bits-for-next via DarkGravityWave, median-time-past,
+// coin address versions) are exactly build_embedded_workdata()'s inputs — they
+// come off the HeaderChain, NOT a dashd poll, keeping the embedded arm
+// daemonless.
+//
+// FENCED: src/impl/dash/coin only, dash interface only. Header-only, pulls the
+// full dash codec (block/transaction/header_chain), so include ONLY from a TU
+// that already links the dash codec (main_dash + this bridge's KAT), never a
+// guard-weight TU — identical contract to the ingest legs.
+// ===========================================================================
+#include <memory>
+#include <vector>
+
+#include <core/events.hpp>
+#include <core/uint256.hpp>
+#include <core/log.hpp>
+#include <core/pack.hpp>
+
+#include "node_interface.hpp"   // dash::interfaces::Node + TipAdvance/BlockConnected
+#include "block.hpp"            // BlockType / BlockHeaderType
+#include "header_chain.hpp"     // HeaderChain, x11_hash, IndexEntry
+
+#include <impl/dash/crypto/hash_x11.hpp>
+
+namespace dash {
+namespace coin {
+
+// Build the TipAdvance the embedded template consumes from a HeaderChain's
+// current tip: prev_height/hash = the tip to build ON, bits_for_next =
+// DarkGravityWave next-work over the tip window, mtp_at_tip = median-time-past
+// (BIP113), plus the coin address versions for coinbase-payee encoding. Returns
+// nullopt when the chain has no usable tip / cannot retarget yet (caller keeps
+// the dashd fallback).
+inline std::optional<::dash::interfaces::TipAdvance>
+tip_advance_from_chain(const HeaderChain& chain,
+                       uint8_t address_version,
+                       uint8_t address_p2sh_version)
+{
+    auto tip = chain.tip();
+    if (!tip) return std::nullopt;
+    uint32_t bits_for_next = chain.next_work_required();
+    if (bits_for_next == 0) return std::nullopt;   // not enough headers to retarget
+    ::dash::interfaces::TipAdvance t;
+    t.prev_height          = tip->height;
+    t.prev_hash            = tip->hash;
+    t.bits_for_next        = bits_for_next;
+    t.mtp_at_tip           = chain.median_time_past();
+    t.address_version      = address_version;
+    t.address_p2sh_version = address_p2sh_version;
+    // curtime/version left 0 => build_embedded_workdata()'s SAFE-ADDITIVE defaults.
+    return t;
+}
+
+// Subscribe the HeaderChain to Node::new_headers: every batch of headers off
+// the wire is fed to add_headers (X11 PoW + DarkGravityWave validated). Returns
+// the subscription handle so the caller controls teardown. The tip-advance
+// republish is driven by HeaderChain::set_on_tip_changed (wired by the caller,
+// so it can also fold the #739 idle-notify) — NOT here, so a batch that does
+// not move the tip costs nothing downstream.
+inline std::shared_ptr<EventDisposable>
+wire_header_ingest(::dash::interfaces::Node& node, HeaderChain& chain)
+{
+    return node.new_headers.subscribe(
+        [&chain](const std::vector<BlockHeaderType>& headers)
+        {
+            if (headers.empty()) return;
+            chain.add_headers(headers);
+        });
+}
+
+// Subscribe Node::full_block -> derive height off the HeaderChain -> fire
+// Node::block_connected({block, height}). block_connected then drives BOTH the
+// maintainer's incremental MnStateMachine::apply_block (leg 3) AND the E2b UTXO
+// lane connect_block, from a single fired event. A block whose header is not yet
+// in the chain (raced ahead of headers sync) is skipped — apply_block/UTXO need
+// the chain-position height, and a subsequent headers batch + re-request closes
+// the gap. Returns the subscription handle.
+inline std::shared_ptr<EventDisposable>
+wire_full_block_ingest(::dash::interfaces::Node& node, HeaderChain& chain)
+{
+    return node.full_block.subscribe(
+        [&node, &chain](const BlockType& block)
+        {
+            auto packed_hdr = ::pack(
+                static_cast<const BlockHeaderType&>(block));
+            const uint256 hash =
+                ::dash::crypto::hash_x11(packed_hdr.get_span());
+            auto entry = chain.get_header(hash);
+            if (!entry) {
+                LOG_DEBUG_COIND << "[EMB-DASH] full_block " << hash.GetHex().substr(0, 16)
+                                << " not in header chain yet — deferring connect";
+                return;
+            }
+            node.block_connected.happened(
+                ::dash::interfaces::BlockConnected{block, entry->height});
+        });
+}
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -327,6 +327,19 @@ public:
         m_peer->write(msg);
     }
 
+    /// Request the peer's mempool inventory (E2a initial-sync seam). The peer
+    /// replies with inv(MSG_TX,...) announcements; our inv handler currently
+    /// only pulls block invs (tx pull is relay-driven), so this primes the
+    /// relay feed — mempool contents are OPTIONAL for embedded-template
+    /// viability (an empty mempool still yields a valid coinbase-only template),
+    /// so this never gates populate; it only enriches the assembled template.
+    void send_mempool()
+    {
+        if (!m_peer) return;
+        auto msg = message_mempool::make_raw();
+        m_peer->write(msg);
+    }
+
     /// Request a full block via plain MSG_BLOCK getdata (E2 pull seam).
     void request_block(const uint256& block_hash)
     {
@@ -556,9 +569,11 @@ private:
 
     ADD_P2P_HANDLER(block)
     {
-        // NOTE: dash BlockType wire-deserialization is header-only today
-        // (block.hpp S5 note) — msg->m_block carries the header; body ingest
-        // needs the raw-payload parser (E2).
+        // E2a: BlockType now deserializes the full body (header + tx set), so
+        // msg->m_block carries the transactions the ingest legs consume
+        // (MnStateMachine::apply_block special txs, UTXO connect_block). The
+        // full_block event below feeds the E2a live-feed bridge, which derives
+        // the block height off the header chain and fires block_connected.
         auto header = static_cast<BlockHeaderType>(msg->m_block);
         auto packed_header = pack(header);
         auto blockhash = dash::crypto::hash_x11(packed_header.get_span());
@@ -571,10 +586,11 @@ private:
 
     ADD_P2P_HANDLER(headers)
     {
-        // E1 receives unsolicited single-entry announcements at most (we do
-        // not send sendheaders/getheaders). Multi-entry batches need the
-        // raw-payload parser (dash BlockType is header-only on the wire) —
-        // that is the E2 sync slice.
+        // E2a: BlockType now round-trips the wire `headers` layout (each entry
+        // is an 80-byte header + CompactSize(0) tx-count), so multi-entry
+        // getheaders-driven batches deserialize correctly. The new_headers event
+        // feeds the E2a live-feed bridge -> HeaderChain::add_headers, which is
+        // the tip authority driving the embedded template's next-work/MTP.
         std::vector<BlockHeaderType> vheaders;
         for (auto& block : msg->m_headers)
         {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -677,7 +677,12 @@ if (BUILD_TESTING AND GTest_FOUND)
     # real Events (no direct poke), honour dispose(), and reach the embedded
     # template. Same header-only link set as the maintainer suite (no NodeImpl
     # -> no pool/storage dep).
-    add_executable(test_dash_node_reception_wire test_dash_node_reception_wire.cpp)
+    # Second TU (E2a): test_dash_live_feed_bridge.cpp — the live-feed bridge
+    # (live_feed.hpp) translating raw coin-P2P wire events into the derived
+    # ingest events (new_headers->HeaderChain, full_block->block_connected) + the
+    # pure tip_advance_from_chain gate. Same target/link set; no new allowlist.
+    add_executable(test_dash_node_reception_wire test_dash_node_reception_wire.cpp
+                   test_dash_live_feed_bridge.cpp)
     target_link_libraries(test_dash_node_reception_wire PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core

--- a/test/test_dash_live_feed_bridge.cpp
+++ b/test/test_dash_live_feed_bridge.cpp
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/// DASH embedded live-feed bridge (E2a, #738) — translation-layer KATs.
+///
+/// live_feed.hpp turns the RAW dash::interfaces::Node wire events the E1 coin-
+/// P2P client fires into the DERIVED events the ingest legs consume, using a
+/// HeaderChain as the tip/height authority:
+///   * tip_advance_from_chain()   — pure: builds the TipAdvance the embedded
+///     template needs (prev height/hash, DGW next-work bits, MTP, addr versions)
+///     off the header-chain tip; nullopt when the chain has no tip / can't
+///     retarget yet, so the caller keeps the dashd fallback.
+///   * wire_full_block_ingest()   — full_block -> (X11 hash -> header-chain
+///     height) -> Node::block_connected, driving leg 3 (apply_block) + E2b UTXO.
+///   * wire_header_ingest()       — new_headers -> HeaderChain::add_headers.
+///
+/// The header->tip->maintainer arm at scale is proven by the live smoke against
+/// a testnet dashd (see PR); these KATs pin the pure/lookup translation logic
+/// without a fully PoW-synced chain (set_dynamic_checkpoint registers a
+/// hash->height entry the full_block lookup resolves against).
+///
+/// Compiles into the allowlisted test_dash_node_reception_wire target (second
+/// TU; no new target, no workflow edit).
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/live_feed.hpp>
+#include <impl/dash/coin/header_chain.hpp>
+#include <impl/dash/coin/node_interface.hpp>
+#include <impl/dash/coin/block.hpp>
+
+#include <core/pack.hpp>
+#include <core/uint256.hpp>
+
+#include <impl/dash/crypto/hash_x11.hpp>
+
+#include <vector>
+
+using dash::coin::HeaderChain;
+using dash::coin::BlockType;
+using dash::coin::BlockHeaderType;
+using dash::coin::make_dash_chain_params_testnet;
+using dash::coin::tip_advance_from_chain;
+using dash::coin::wire_full_block_ingest;
+using dash::coin::wire_header_ingest;
+
+namespace {
+
+// Dash testnet address versions (params.hpp) — the payee-encoding bytes the
+// TipAdvance carries.
+constexpr uint8_t DASH_TESTNET_PUBKEY_VER = 140;
+constexpr uint8_t DASH_TESTNET_P2SH_VER   = 19;
+
+BlockType make_block(uint8_t seed) {
+    BlockType b;
+    b.m_version        = 0x20000000u | seed;
+    b.m_previous_block.SetHex("00");
+    b.m_merkle_root.SetHex("00");
+    b.m_timestamp      = 1'700'000'000u + seed;
+    b.m_bits           = 0x1e0ffff0u;
+    b.m_nonce          = 0x12340000u + seed;
+    return b;
+}
+
+uint256 x11_of(const BlockType& b) {
+    auto packed = ::pack(static_cast<const BlockHeaderType&>(b));
+    return ::dash::crypto::hash_x11(packed.get_span());
+}
+
+// ── tip_advance_from_chain: nullopt gates ─────────────────────────────────
+
+TEST(DashLiveFeedBridge, TipAdvanceNulloptOnEmptyChain) {
+    HeaderChain chain(make_dash_chain_params_testnet());
+    chain.init();
+    // Only the genesis stub is seeded (height 0) — next_work_required needs
+    // >= 24 headers, so it returns 0 and tip_advance_from_chain declines,
+    // keeping the caller on the dashd fallback.
+    auto ta = tip_advance_from_chain(chain, DASH_TESTNET_PUBKEY_VER,
+                                     DASH_TESTNET_P2SH_VER);
+    EXPECT_FALSE(ta.has_value());
+}
+
+// ── wire_full_block_ingest: header present -> block_connected(block, height) ─
+
+TEST(DashLiveFeedBridge, FullBlockFiresBlockConnectedWithChainHeight) {
+    HeaderChain chain(make_dash_chain_params_testnet());
+    chain.init();
+
+    auto block = make_block(7);
+    const uint256 hash = x11_of(block);
+    // Register the block's identity at a known height WITHOUT PoW (the bridge
+    // only needs the height lookup; a real chain gets it from add_headers).
+    chain.set_dynamic_checkpoint(1000, hash);
+
+    ::dash::interfaces::Node node;
+
+    int fired = 0;
+    uint32_t got_height = 0;
+    uint256  got_prev;
+    auto sub_probe = node.block_connected.subscribe(
+        [&](const ::dash::interfaces::BlockConnected& bc) {
+            ++fired;
+            got_height = bc.height;
+            got_prev   = bc.block.m_previous_block;
+        });
+
+    auto sub_bridge = wire_full_block_ingest(node, chain);
+
+    node.full_block.happened(block);
+
+    EXPECT_EQ(fired, 1);
+    EXPECT_EQ(got_height, 1000u);
+    EXPECT_EQ(got_prev, block.m_previous_block);
+}
+
+// ── wire_full_block_ingest: header ABSENT -> no block_connected (deferred) ───
+
+TEST(DashLiveFeedBridge, FullBlockUnknownHeaderIsDeferred) {
+    HeaderChain chain(make_dash_chain_params_testnet());
+    chain.init();
+
+    auto block = make_block(9);   // never registered in the chain
+
+    ::dash::interfaces::Node node;
+    int fired = 0;
+    auto sub_probe = node.block_connected.subscribe(
+        [&](const ::dash::interfaces::BlockConnected&) { ++fired; });
+    auto sub_bridge = wire_full_block_ingest(node, chain);
+
+    node.full_block.happened(block);
+
+    // A block whose header is not yet in the chain is skipped — apply_block /
+    // UTXO need the chain-position height; a later headers batch closes the gap.
+    EXPECT_EQ(fired, 0);
+}
+
+// ── wire_header_ingest: empty batch is a no-op (never touches the chain) ─────
+
+TEST(DashLiveFeedBridge, HeaderIngestEmptyBatchNoOp) {
+    HeaderChain chain(make_dash_chain_params_testnet());
+    chain.init();
+    const uint32_t h0 = chain.height();
+
+    ::dash::interfaces::Node node;
+    auto sub = wire_header_ingest(node, chain);
+
+    node.new_headers.happened(std::vector<BlockHeaderType>{});
+    EXPECT_EQ(chain.height(), h0);
+}
+
+} // namespace

--- a/test/test_dash_p2p_messages.cpp
+++ b/test/test_dash_p2p_messages.cpp
@@ -74,14 +74,55 @@ TEST(DashP2PMessages, Message_Block_RoundTrip) {
     auto blk = make_header(3);
     auto rmsg = message_block::make_raw(blk);
     EXPECT_EQ(rmsg->m_command, "block");
-    // Dash header is the canonical fixed 80 bytes (no witness/MWEB).
-    EXPECT_EQ(bytes_of(rmsg->m_data).size(), 80u);
+    // E2a: BlockType now serializes the standard Bitcoin block body — the
+    // 80-byte header PLUS a CompactSize tx-count. An empty-body block is
+    // 80 + 1 = 81 bytes (CompactSize(0) == 0x00), matching what a real dashd
+    // `block` message with no transactions would carry. (Pre-E2a this was a
+    // header-only 80 bytes — the deferred-parser regression E2a closes.)
+    EXPECT_EQ(bytes_of(rmsg->m_data).size(), 81u);
 
     auto parsed = message_block::make(rmsg->m_data);
     EXPECT_EQ(parsed->m_block.m_previous_block, blk.m_previous_block);
     EXPECT_EQ(parsed->m_block.m_merkle_root,    blk.m_merkle_root);
     EXPECT_EQ(parsed->m_block.m_bits,           blk.m_bits);
     EXPECT_EQ(parsed->m_block.m_nonce,          blk.m_nonce);
+    EXPECT_TRUE(parsed->m_block.m_txs.empty());
+}
+
+// E2a: a full `block` message body with transactions must deserialize into the
+// exact tx set the ingest legs (MnStateMachine::apply_block, UTXO connect_block)
+// consume. Pre-E2a the body was dropped (header-only) and m_txs stayed empty.
+TEST(DashP2PMessages, Message_Block_Body_TxSet_RoundTrip) {
+    using dash::coin::MutableTransaction;
+    using bitcoin_family::coin::TxIn;
+    using bitcoin_family::coin::TxOut;
+
+    auto blk = make_header(7);
+    // Coinbase-like tx0 (type 0) + a special tx (type 5 with extra_payload) to
+    // exercise the Dash version|type<<16 + extra_payload codec through the body.
+    MutableTransaction cb;
+    cb.version = 1; cb.type = 0;
+    cb.vin.push_back(TxIn{}); cb.vout.push_back(TxOut{});
+    cb.vout.back().value = 500000000;
+    MutableTransaction special;
+    special.version = 3; special.type = 5;
+    special.vin.push_back(TxIn{}); special.vout.push_back(TxOut{});
+    special.extra_payload = {0xde, 0xad, 0xbe, 0xef, 0x01, 0x02};
+    blk.m_txs = {cb, special};
+
+    auto rmsg = message_block::make_raw(blk);
+    auto parsed = message_block::make(rmsg->m_data);
+    ASSERT_EQ(parsed->m_block.m_txs.size(), 2u);
+    EXPECT_EQ(parsed->m_block.m_txs[0].type, 0);
+    EXPECT_EQ(parsed->m_block.m_txs[0].vout.size(), 1u);
+    EXPECT_EQ(parsed->m_block.m_txs[0].vout[0].value, 500000000);
+    EXPECT_EQ(parsed->m_block.m_txs[1].version, 3);
+    EXPECT_EQ(parsed->m_block.m_txs[1].type, 5);
+    EXPECT_EQ(parsed->m_block.m_txs[1].extra_payload,
+              (std::vector<unsigned char>{0xde, 0xad, 0xbe, 0xef, 0x01, 0x02}));
+    // Header still intact after the body.
+    EXPECT_EQ(parsed->m_block.m_nonce, blk.m_nonce);
+    EXPECT_EQ(parsed->m_block.m_merkle_root, blk.m_merkle_root);
 }
 
 TEST(DashP2PMessages, Message_Headers_RoundTrip) {


### PR DESCRIPTION
## E2a — wire the live coin-P2P feed into the maintainer → populate NodeCoinState (daemonless templates)

E1 (#743) landed the coin-network P2P client that dials a dashd peer and fires the raw `dash::interfaces::Node` wire events, with **no subscribers** → `NodeCoinState` stayed unpopulated → `get_work` always took the dashd-RPC fallback. E2b (#745) landed the UTXO/fee lane. **E2a joins them into a live populate loop**, entirely behind the opt-in flags.

### What got wired (`src/impl/dash/coin/live_feed.hpp` + `main_dash.cpp`)
The raw wire events don't match the ingest legs' derived events; E2a is the translation layer, using a `HeaderChain` as the tip/height authority:

| Raw wire event | Bridge | Ingest leg |
|---|---|---|
| `new_headers` | `HeaderChain::add_headers` (X11 + DarkGravityWave) → `set_on_tip_changed` derives `TipAdvance` → fires `Node::new_tip` | leg 2 → `maintainer.on_new_tip` (tip readiness) |
| `new_tx` | direct | leg 1 → `maintainer.on_mempool_tx` |
| `full_block` | X11(header) → header-chain height → fires `Node::block_connected{block,height}` | leg 3 → `maintainer.on_block_connected` (`apply_block`) **and** E2b UTXO `connect_block` + fee recompute (one fired event drives both) |
| `new_block`(inv) | → `request_block` (getdata pull) | — |
| `new_chainlock` | → best-CL tracker (`chainlocked_blocks`) | — |
| `mn_list_update` | wired for completeness | leg 4 → `maintainer.on_mn_list_update` |

`set_on_handshake_complete` kicks initial sync (`getheaders` off the locator + `mempool`); a header self-propel requests the next batch off the updated locator; the UTXO bootstrap's request-by-height seam is bound to the coin-P2P full-block pull.

### BlockType parser (the E1-deferred fix)
`src/impl/dash/coin/block.hpp` closes the S5 header-only deferral: `BlockType` now (de)serializes the standard Bitcoin block **body** (`CompactSize` tx-count + txs), mirroring the DGB sibling minus witness (Dash is non-segwit/non-MWEB). This lets a live dashd `block` body deserialize into the tx set the ingest legs consume (`apply_block` special txs, UTXO `connect_block`), and makes the multi-entry `headers` message round-trip (each wire entry is an 80-byte header + `CompactSize(0)` tx-count → header + empty `m_txs`). `HeaderChain` gains `median_time_past()` (BIP113) for the template mintime.

### #739 folded in
On a **real** tip change the header-chain callback bumps `work_generation_` + `notify_all()` sessions — event-driven stale-work notify, closing the idle-session stale-work deadlock. (A few lines in the tip-changed callback, so folded in.)

### no-flag guarantee
The entire E2a block is gated on `coin_p2p` (i.e. `--coin-p2p-connect`). Verified: a `--run` with no coin-P2P flag reaches the run-loop with **zero** E2a runtime wiring (no header chain, no maintainer, no subscriptions) — the mining-hotel dashd-fallback prod path is byte-unchanged.

### Verification
- **KATs**: block-body tx-set round-trip + 81-byte empty-body pin (`test_dash_p2p_messages`); live-feed bridge translation — `tip_advance_from_chain` nullopt gates, `full_block`→`block_connected` height derivation, unknown-header defer (`test_dash_live_feed_bridge`, folded into the allowlisted `test_dash_node_reception_wire` target).
- **All affected dash targets green** (120 tests): p2p_messages, block_relay, block_replay, embedded_relay_e2e, p2p_node, node_reception_wire, embedded_gbt, node_embedded_wire, mn_state, get_work, stratum_work_source, node_interface.
- **`--selftest` green**.
- **LIVE SMOKE** vs testnet dashd `192.168.86.52:19999` (Dash Core 22.1.3, height 1,517,453): connect + version/verack handshake ✓; initial sync kicked ✓; `new_headers → HeaderChain → tip advance → Node::new_tip fired → maintainer arm` proven at scale (740k+ headers synced, ~370 tip-advance events, **0 PoW failures**), self-propel streaming 2000-header batches.

### Populate flip — status and the known gap
The **tip half** of `populated()` is proven live (maintainer receives `on_new_tip` every advance). The **MN-set half** was NOT reached in-smoke, for a real reason worth flagging:

- `on_block_connected`/`apply_block` builds the payout-bearing DMN set from block **bodies**, which only start flowing after header sync reaches tip AND a live-block inv triggers the 288-block bootstrap — beyond the smoke window (genesis-sync latency; the test env also reaps long background runs).
- The P2P `mnlistdiff` **Simplified MN List deliberately omits `scriptPayout`** (and `nLastPaidHeight`), so leg 4 alone cannot supply a payout-complete DMN set for the coinbase payee.

**Consequently the embedded arm was not observed serving a template in this smoke** — `populated()` correctly stays `false` (→ dashd fallback) until the DMN set is present, which is the intended safety behavior. Guaranteed cold-start populate needs an **MN-set seed**: either an RPC `protx diff` snapshot at startup (hybrid; the RPC arm already persists) or a DIP3-height special-tx replay bootstrap. That is a follow-on slice, not event-wiring — surfaced here for the integrator to schedule. The embedded-arm **selection** itself (populated → `build_embedded_workdata`) is already KAT-proven (`test_dash_node_embedded_wire`, `test_dash_get_work`); E2a proves the feed that drives it.

Do **not** self-merge.