### PR TITLE
ci(web-static): stabilize flaky Web-static verify — reuse+retry Chrome provision

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -562,8 +562,23 @@ jobs:
               if [ -x "$bin" ]; then echo "CHROME_BIN=$bin" >> "$GITHUB_ENV"; break; fi
             done
           else
-            CHROME_BIN="$(npx --yes @puppeteer/browsers install chrome@stable | tail -1 | awk '{print $NF}')"
-            test -x "$CHROME_BIN" || { echo "puppeteer chrome install failed"; exit 1; }
+            # Self-hosted: REUSE a Chrome-for-Testing already unpacked under
+            # ~/.cache/puppeteer if present (VM905 persists it across jobs) so
+            # the warm path touches NO network. Only on a cold cache do we
+            # fetch from Google's CDN, and then with bounded retries — a
+            # single-attempt download false-reds the whole gate on a transient
+            # outbound blip (ENETUNREACH/ETIMEDOUT, run 29675949544), failing
+            # PRs that never touch web/.
+            CHROME_BIN="$(ls -1 "$HOME"/.cache/puppeteer/chrome/*/chrome-linux64/chrome 2>/dev/null | tail -1 || true)"
+            if [ ! -x "$CHROME_BIN" ]; then
+              for attempt in 1 2 3; do
+                CHROME_BIN="$(npx --yes @puppeteer/browsers install chrome@stable | tail -1 | awk '{print $NF}')" \
+                  && [ -x "$CHROME_BIN" ] && break
+                echo "chrome-for-testing fetch attempt $attempt failed; retrying in $((attempt*10))s"
+                sleep $((attempt*10))
+              done
+            fi
+            test -x "$CHROME_BIN" || { echo "puppeteer chrome install failed after retries"; exit 1; }
             echo "CHROME_BIN=$CHROME_BIN" >> "$GITHUB_ENV"
           fi
 


### PR DESCRIPTION
## Root cause
`Web-static verify` (build.yml) false-reds on PRs that do not touch web/ — confirmed on dash-fenced #746 and #747; master passes. The failing instance (run 29675949544, job 88163320181) shows the **self-hosted** `Install Chrome for pixel-regression harness` step failing at `puppeteer chrome install`: `@puppeteer/browsers install chrome@stable` does a **live download from Google's CDN every run**, and the runner hit `ENETUNREACH` (IPv6) / `ETIMEDOUT` (IPv4) reaching Google IPs. Pure infra/network flake — not a regression from the dash source fences.

## Fix
On the self-hosted branch:
- **Reuse** a Chrome-for-Testing already unpacked under `~/.cache/puppeteer` (VM905 persists it across jobs) → warm path touches **no network**, making the gate deterministic after first provision.
- Only on a **cold cache** do we fetch, now with **bounded retry** (3 attempts, 10/20s backoff) so a transient outbound blip no longer reds the gate.

GitHub-hosted branch (apt Chrome) unchanged. Gate stays required/blocking — this fixes the flake at its root rather than weakening coverage.

Unblocks the DASH release critical path (#746/#747).