### PR TITLE
dash(embedded/E2c): RPC protx-list MN-set seed -> populated() flips, embedded serves correct-payee templates

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -64,6 +64,7 @@
 #include <impl/dash/coin/tip_ingest.hpp>         // wire_tip_ingest (leg 2)
 #include <impl/dash/coin/block_connect_ingest.hpp>   // wire_block_connect_ingest (leg 3)
 #include <impl/dash/coin/mn_list_ingest.hpp>     // wire_mn_list_ingest (leg 4)
+#include <impl/dash/coin/mn_seed.hpp>            // E2c: RPC protx-list MN-set seed (parse_protx_list_seed)
 #include <impl/dash/node.hpp>          // dash::Node — sharechain pool-node (NodeBridge<NodeImpl,Legacy,Actual>)
 #include <impl/dash/config.hpp>        // dash::Config (PoolConfig/CoinConfig)
 #include <impl/dash/config_pool.hpp>   // dash::SharechainConfig — P2P_PORT / PREFIX / min-proto SSOT
@@ -971,11 +972,10 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         // subscribed to the same event (its connect_block + fee recompute).
         coin_feed_subs.push_back(
             c2pool::dash::wire_block_connect_ingest(coin_state, *maintainer));
-        // Leg 4 (mnlistdiff RESYNC): Node::mn_list_update -> maintainer
-        // .on_mn_list_update. Wired for completeness; a payee-complete DMN-set
-        // source over P2P is the known follow-on (see PR — Dash's Simplified MN
-        // List omits scriptPayout, so the authoritative payout-bearing set is
-        // built by leg 3's apply_block over connected block bodies).
+        // Leg 4 (MN-set RESYNC): Node::mn_list_update -> maintainer
+        // .on_mn_list_update. Dash's P2P Simplified MN List omits scriptPayout,
+        // so the payout-bearing feed for this leg is the E2c RPC seed below
+        // (startup baseline) + leg 3's apply_block folding special txs on top.
         coin_feed_subs.push_back(
             c2pool::dash::wire_mn_list_ingest(coin_state, *maintainer));
 
@@ -1070,6 +1070,65 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                      " (headers) AND the DMN set (block-connect apply_block) are"
                      " present" << (embedded_utxo ? " + UTXO maturity>=106" : "")
                   << "\n";
+
+        // ── E2c (#738): RPC MN-set SEED — flip the DMN half of populated() ──
+        // E2a proved the TIP half populates live, but populated() ALSO needs a
+        // payout-bearing DMN set, and no live leg can cold-start one: the P2P
+        // Simplified MN List (leg 4's wire form) omits scriptPayout +
+        // nLastPaidHeight, and leg 3's apply_block only folds special txs from
+        // blocks we actually connect (a full DIP3-height replay = E2d). So when
+        // the dashd-RPC arm is ARMED, fetch the full valid DMN set ONCE via
+        // `protx list valid true` (payoutAddress + lastPaidHeight — everything
+        // GetMNPayee ordering needs) and publish it through the EXISTING leg-4
+        // event, so the maintainer takes it exactly like any other resync. The
+        // parse FAILS CLOSED (mn_seed.hpp): any undecodable payoutAddress
+        // aborts the whole seed rather than minting a wrong payee (the
+        // bad-cb-payee class #746 fixed). Synchronous-before-ioc.run() is safe:
+        // NodeRPC::Send self-connects via the blocking sync_reconnect fallback
+        // (the same property --submit-block relies on).
+        if (rpc) {
+            try {
+                dash::coin::MnSeedStats seed_stats;
+                auto seed = dash::coin::parse_protx_list_seed(
+                    rpc->protx_list_valid_detailed(), addr_ver, p2sh_ver,
+                    &seed_stats);
+                if (!seed.empty()) {
+                    dash::interfaces::MnListUpdate up;
+                    up.mnstates = std::move(seed);
+                    coin_state.mn_list_update.happened(up);
+                    std::cout << "[run] E2c MN-set seed LOADED: "
+                              << seed_stats.seeded << "/" << seed_stats.total
+                              << " valid MNs (" << seed_stats.evo << " Evo) from"
+                                 " dashd `protx list valid true` -> maintainer"
+                                 " DMN half ARMED; populated() flips once the"
+                                 " header tip syncs\n";
+                } else {
+                    std::cout << "[run] E2c MN-set seed EMPTY/ABORTED (total="
+                              << seed_stats.total << " decode_failed="
+                              << seed_stats.payout_decode_failed
+                              << " malformed=" << seed_stats.malformed
+                              << ") -- populated() waits for the special-tx"
+                                 " replay path; dashd fallback keeps serving\n";
+                }
+            } catch (const std::exception& e) {
+                std::cout << "[run] E2c MN-set seed FAILED (protx list RPC: "
+                          << e.what() << ") -- populated() waits for the"
+                             " special-tx replay path; dashd fallback keeps"
+                             " serving\n";
+            }
+        } else {
+            // Pure daemonless: no dashd RPC to seed from. The DMN set must
+            // come from a DIP3-height special-tx replay (sync block bodies
+            // from DIP3 activation, replay ProRegTx/ProUpRegTx/... through
+            // MnStateMachine::apply_block) — the flagged E2d follow-up slice.
+            // Flag loudly, don't fail: the run-loop stands up, the tip half
+            // still syncs, and get_work stays on the (unarmed) fallback.
+            std::cout << "[run] E2c MN-set seed UNAVAILABLE (embedded arm"
+                         " enabled but NO coin-RPC configured): populated()"
+                         " will wait for the DIP3 special-tx replay path"
+                         " (E2d follow-up) -- templates keep routing to the"
+                         " fallback arm\n";
+        }
     }
 
     std::cout << "[run] run-loop up (Ctrl-C to stop); won blocks relay via the\n"

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -988,11 +988,21 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         coin_feed_subs.push_back(
             dash::coin::wire_full_block_ingest(coin_state, *header_chain));
 
-        // new_block(inv hash) -> pull the full block from the peer (getdata).
-        // Closes the loop so live tip blocks arrive as full_block -> connect.
+        // new_block(inv hash) -> pull the headers THEN the full block from the
+        // peer. The getheaders-first ordering is the steady-state tip-follow
+        // fix (E2c): dashd announces new blocks via inv (we never negotiate
+        // sendheaders), so without an explicit getheaders here the header
+        // chain stalls at the initial-sync tip forever and EVERY live block
+        // hits wire_full_block_ingest's not-in-header-chain deferral — no
+        // block_connected, no apply_block, no UTXO bootstrap trigger. Same
+        // single ordered TCP stream to the same peer, so the headers response
+        // (tip advance, header now known) lands BEFORE the block does and the
+        // connect proceeds. Mirrors the PROVEN LTC new-block handler
+        // (main_ltc.cpp ~2133: request_headers off the locator + block pull).
         coin_feed_subs.push_back(
             coin_state.new_block.subscribe(
-                [cp = coin_p2p.get()](const uint256& hash) {
+                [cp = coin_p2p.get(), hc = header_chain.get()](const uint256& hash) {
+                    cp->send_getheaders(70230, hc->get_locator(), uint256::ZERO);
                     cp->request_block(hash);
                 }));
 
@@ -1088,20 +1098,47 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         // (the same property --submit-block relies on).
         if (rpc) {
             try {
+                // Height-stable fetch: the snapshot must carry the exact
+                // height it is current at (the maintainer fences off
+                // re-application of blocks <= that height -- see
+                // MnListUpdate::as_of_height). protx list is evaluated at
+                // dashd's live tip, so bracket it with getblockcount and
+                // refetch on a mid-flight tip move (bounded; a testnet block
+                // race is rare, mainnet 2.5 min spacing makes it rarer).
+                nlohmann::json protx_list;
+                uint32_t as_of = 0;
+                for (int attempt = 0; attempt < 3; ++attempt) {
+                    const uint32_t h_before = static_cast<uint32_t>(
+                        rpc->getblockchaininfo().value("blocks", 0));
+                    protx_list = rpc->protx_list_valid_detailed();
+                    const uint32_t h_after = static_cast<uint32_t>(
+                        rpc->getblockchaininfo().value("blocks", 0));
+                    if (h_before == h_after && h_after != 0) {
+                        as_of = h_after;
+                        break;
+                    }
+                }
                 dash::coin::MnSeedStats seed_stats;
                 auto seed = dash::coin::parse_protx_list_seed(
-                    rpc->protx_list_valid_detailed(), addr_ver, p2sh_ver,
-                    &seed_stats);
-                if (!seed.empty()) {
+                    protx_list, addr_ver, p2sh_ver, &seed_stats);
+                if (!seed.empty() && as_of != 0) {
                     dash::interfaces::MnListUpdate up;
-                    up.mnstates = std::move(seed);
+                    up.mnstates     = std::move(seed);
+                    up.as_of_height = as_of;
                     coin_state.mn_list_update.happened(up);
                     std::cout << "[run] E2c MN-set seed LOADED: "
                               << seed_stats.seeded << "/" << seed_stats.total
-                              << " valid MNs (" << seed_stats.evo << " Evo) from"
-                                 " dashd `protx list valid true` -> maintainer"
-                                 " DMN half ARMED; populated() flips once the"
-                                 " header tip syncs\n";
+                              << " valid MNs (" << seed_stats.evo << " Evo)"
+                                 " as-of h=" << as_of << " from dashd `protx"
+                                 " list valid true` -> maintainer DMN half"
+                                 " ARMED; populated() flips once the header"
+                                 " tip syncs\n";
+                } else if (as_of == 0) {
+                    std::cout << "[run] E2c MN-set seed SKIPPED (dashd tip"
+                                 " moved during every fetch attempt / height"
+                                 " unavailable) -- populated() waits for the"
+                                 " special-tx replay path; dashd fallback"
+                                 " keeps serving\n";
                 } else {
                     std::cout << "[run] E2c MN-set seed EMPTY/ABORTED (total="
                               << seed_stats.total << " decode_failed="

--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -56,8 +56,19 @@ public:
     /// coinbase pays. An EMPTY list is treated as a gap -- it cannot back a
     /// valid payee, so it clears MN-readiness and drops the bundle to fallback
     /// rather than publishing a template with no masternode payment.
-    void on_mn_list_update(std::vector<std::pair<uint256, MNState>> mnstates) {
+    ///
+    /// as_of_height (E2c): the chain height the snapshot is CURRENT AT
+    /// (0 = unknown). Recorded so on_block_connected() can skip re-applying
+    /// blocks the snapshot already reflects -- replaying a historical coinbase
+    /// payment on top of an already-current lastPaidHeight set falsely
+    /// re-bumps the front of the GetMNPayee queue when several MNs share one
+    /// payoutAddress (live-observed: E2b's 288-block UTXO bootstrap replay
+    /// scrambled the seeded queue and the embedded template projected the
+    /// wrong payee).
+    void on_mn_list_update(std::vector<std::pair<uint256, MNState>> mnstates,
+                           uint32_t as_of_height = 0) {
         m_have_mn = !mnstates.empty();
+        m_mn_snapshot_height = as_of_height;
         m_state.mnstates().load(std::move(mnstates));
         if (!m_have_mn)
             demote();
@@ -105,6 +116,18 @@ public:
     /// template with a phantom payee. Returns apply_block's ApplyResult.
     MnStateMachine::ApplyResult
     on_block_connected(const dash::coin::BlockType& block, uint32_t height) {
+        // E2c snapshot fence: blocks the payout-bearing snapshot already
+        // reflects (height <= its as-of height) must NOT be re-folded -- the
+        // snapshot's registrations/spends/lastPaid ARE those blocks' effects,
+        // and re-attributing their coinbase payments corrupts the shared-
+        // payoutAddress payee queue (see on_mn_list_update). The E2b UTXO
+        // lane's own subscription to the same event is unaffected (it needs
+        // every block for the UTXO view; it holds no MN state).
+        if (m_mn_snapshot_height != 0 && height <= m_mn_snapshot_height) {
+            MnStateMachine::ApplyResult r;
+            r.total_after = m_state.mnstates().size();
+            return r;
+        }
         auto r    = m_state.mnstates().apply_block(block, height);
         m_have_mn = m_state.mnstates().size() != 0;
         if (!m_have_mn)
@@ -148,6 +171,10 @@ private:
 
     bool m_have_mn{false};
     bool m_have_tip{false};
+
+    // Height the last MN-set snapshot was current at (0 = none/unknown);
+    // on_block_connected skips re-applying blocks at or below it.
+    uint32_t m_mn_snapshot_height{0};
 
     // Last observed tip params, applied on republish().
     uint32_t m_prev_height{0};

--- a/src/impl/dash/coin/mn_list_ingest.hpp
+++ b/src/impl/dash/coin/mn_list_ingest.hpp
@@ -56,7 +56,9 @@ wire_mn_list_ingest(::dash::interfaces::Node& node,
     return node.mn_list_update.subscribe(
         [&maint](const ::dash::interfaces::MnListUpdate& u)
         {
-            maint.on_mn_list_update(u.mnstates);
+            // as_of_height rides along (E2c): the maintainer uses it to fence
+            // off re-application of blocks the snapshot already reflects.
+            maint.on_mn_list_update(u.mnstates, u.as_of_height);
         });
 }
 

--- a/src/impl/dash/coin/mn_seed.hpp
+++ b/src/impl/dash/coin/mn_seed.hpp
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// E2c (#738): RPC MN-set seed — dashd `protx list valid true` JSON ->
+/// the payout-bearing DMN baseline CoinStateMaintainer::on_mn_list_update()
+/// loads at cold start.
+///
+/// THE GAP THIS CLOSES (proven by E2a): NodeCoinState::populated() needs BOTH
+/// a header tip AND a payout-bearing masternode set. The live coin-P2P legs
+/// deliver the tip half fast, but the P2P Simplified MN List (mnlistdiff)
+/// OMITS scriptPayout + nLastPaidHeight — so leg 4 alone can never assemble a
+/// payee-complete set, and building one from block bodies alone needs a full
+/// DIP3-height special-tx replay (the heavier E2d follow-up). Until a seed
+/// exists, populated() stays false forever on a cold start and get_work()
+/// routes to the dashd-RPC fallback arm.
+///
+/// THE SEED: when a coin-RPC is configured (the mining-hotel posture — dashd
+/// present), fetch the full valid deterministic-MN set ONCE at startup via
+/// `protx list valid true` and convert it here into the exact
+/// vector<pair<proTxHash, MNState>> the maintainer's resync leg takes. That
+/// JSON carries everything payee selection needs that the SML does not:
+///   - state.payoutAddress   -> MNState.scriptPayout      (the payee itself)
+///   - state.lastPaidHeight  -> MNState.nLastPaidHeight   (GetMNPayee order)
+///   - state.registeredHeight / PoSeRevivedHeight / PoSeBanHeight
+///                           -> CompareByLastPaid_GetHeight inputs
+/// `protx diff` (even extended) was rejected as the seed source: it carries
+/// payoutAddress but NOT lastPaidHeight/registeredHeight, so a diff-seeded set
+/// would rank every MN equal and project the WRONG payee — exactly the
+/// bad-cb-payee class the coinbase fix (#746) closed. Never mint payees from
+/// payout-incomplete data.
+///
+/// ADDRESS -> SCRIPT round trip: dashd consensus (CheckService on ProRegTx /
+/// ProUpRegTx) only admits P2PKH / P2SH payout scripts, and payoutAddress is
+/// EncodeDestination(scriptPayout). Decoding it back through base58check +
+/// hash160_to_merged_script reproduces the script BYTE-EXACTLY, and
+/// embedded_gbt's script_to_address() re-encodes the identical address dashd's
+/// getblocktemplate reports — the byte-faithful payee equality the E2c gate
+/// asserts.
+///
+/// FAIL-CLOSED: if ANY entry's payoutAddress cannot be decoded against the
+/// coin's version bytes, the WHOLE seed is aborted (empty return). A partial
+/// set could rank a skipped MN's payment slot onto the wrong payee; an empty
+/// set is a set-gap that keeps populated() false and get_work() on the dashd
+/// fallback — safe by construction.
+///
+/// STRICTLY single-coin: src/impl/dash/coin/ only. Pure function over
+/// nlohmann::json — network-free, KAT-pinned (test_dash_mn_seed.cpp).
+
+#include <impl/dash/coin/mn_state_db.hpp>        // MNState
+#include <impl/dash/coin/vendor/providertx.hpp>  // MnType / ProTxVersion / BLS_PUBKEY_SIZE
+
+#include <core/address_utils.hpp>  // base58check_to_hash160 / is_address_for_chain / hash160_to_merged_script
+#include <core/log.hpp>
+#include <core/uint256.hpp>
+
+#include <nlohmann/json.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace dash {
+namespace coin {
+
+/// Observability counters for the seed parse (logged at the call site and
+/// pinned by the KAT).
+struct MnSeedStats {
+    size_t total{0};           // JSON entries walked
+    size_t seeded{0};          // entries converted into the returned vector
+    size_t evo{0};             // of which Evo (platform) MNs
+    size_t payout_decode_failed{0};  // payoutAddress undecodable -> seed ABORTED
+    size_t malformed{0};       // entry missing proTxHash/state -> seed ABORTED
+};
+
+namespace detail {
+
+// dashd's detailed protx JSON uses -1 as the "never" sentinel for
+// lastPaidHeight / PoSeRevivedHeight / PoSeBanHeight. Internally we store 0
+// for "never" (see mn_state_machine.hpp find_expected_payee's SENTINEL note —
+// storing the raw uint32 wrap of -1 is the exact bug class that produced a
+// constant expected-payee and 100% [PAY] MISMATCH). Clamp negatives to 0.
+inline uint32_t sane_height_json(const nlohmann::json& j, const char* key)
+{
+    if (!j.contains(key) || !j[key].is_number()) return 0;
+    const int64_t v = j[key].get<int64_t>();
+    return v > 0 ? static_cast<uint32_t>(v) : 0u;
+}
+
+// Decode a base58check P2PKH/P2SH address into its scriptPubKey using the
+// coin's version bytes. Empty return == undecodable (caller fail-closes).
+inline std::vector<unsigned char> payout_address_to_script(
+    const std::string& addr, uint8_t address_version, uint8_t address_p2sh_version)
+{
+    if (addr.empty()) return {};
+    const char* type = nullptr;
+    if (::core::is_address_for_chain(addr, {}, {address_version}))
+        type = "p2pkh";
+    else if (::core::is_address_for_chain(addr, {}, {address_p2sh_version}))
+        type = "p2sh";
+    else
+        return {};
+    const std::string h160 = ::core::base58check_to_hash160(addr);
+    if (h160.size() != 40) return {};  // bad checksum / malformed
+    return ::core::hash160_to_merged_script(h160, type);
+}
+
+// base58check hash160 payload -> uint160 (internal byte order: the payload
+// bytes ARE dashcore's CKeyID raw bytes, so build from the byte vector
+// directly — SetHex would byte-reverse them).
+inline uint160 hash160_hex_to_uint160(const std::string& h160_hex)
+{
+    if (h160_hex.size() != 40) return uint160();
+    std::vector<unsigned char> bytes;
+    bytes.reserve(20);
+    for (size_t i = 0; i < 40; i += 2)
+        bytes.push_back(static_cast<unsigned char>(
+            std::stoul(h160_hex.substr(i, 2), nullptr, 16)));
+    return uint160(bytes);
+}
+
+inline std::array<uint8_t, vendor::BLS_PUBKEY_SIZE>
+parse_bls_pubkey_hex(const std::string& hex)
+{
+    std::array<uint8_t, vendor::BLS_PUBKEY_SIZE> out{};
+    if (hex.size() != vendor::BLS_PUBKEY_SIZE * 2) return out;
+    for (size_t i = 0; i < vendor::BLS_PUBKEY_SIZE; ++i)
+        out[i] = static_cast<uint8_t>(
+            std::stoul(hex.substr(i * 2, 2), nullptr, 16));
+    return out;
+}
+
+} // namespace detail
+
+/// Convert a dashd `protx list valid true` (detailed) JSON array into the
+/// (proTxHash -> MNState) vector CoinStateMaintainer::on_mn_list_update()
+/// takes. Returns EMPTY on any malformed entry or undecodable payoutAddress
+/// (fail-closed: a partial set could project the wrong payee; an empty set is
+/// a safe set-gap that keeps the dashd fallback serving).
+inline std::vector<std::pair<uint256, MNState>> parse_protx_list_seed(
+    const nlohmann::json& list,
+    uint8_t address_version,
+    uint8_t address_p2sh_version,
+    MnSeedStats* stats = nullptr)
+{
+    MnSeedStats st;
+    std::vector<std::pair<uint256, MNState>> out;
+    if (!list.is_array()) {
+        LOG_WARNING << "[MN-SEED] protx list result is not an array -- seed aborted";
+        if (stats) *stats = st;
+        return {};
+    }
+    out.reserve(list.size());
+
+    for (const auto& e : list) {
+        ++st.total;
+        if (!e.is_object() || !e.contains("proTxHash")
+            || !e.contains("state") || !e["state"].is_object()) {
+            ++st.malformed;
+            LOG_WARNING << "[MN-SEED] malformed protx entry (#" << st.total
+                        << ": no proTxHash/state) -- seed aborted";
+            if (stats) *stats = st;
+            return {};
+        }
+        const auto& s = e["state"];
+
+        MNState mn;
+
+        // Identity / registration facets.
+        const uint256 proTxHash = uint256S(e["proTxHash"].get<std::string>());
+        if (e.contains("collateralHash"))
+            mn.collateralOutpoint.hash =
+                uint256S(e["collateralHash"].get<std::string>());
+        if (e.contains("collateralIndex") && e["collateralIndex"].is_number())
+            mn.collateralOutpoint.index = e["collateralIndex"].get<uint32_t>();
+        // JSON reports operatorReward as a percentage double (dashd ToJson:
+        // nOperatorReward / 100.0); recover the internal 0..10000 fixed-point.
+        if (e.contains("operatorReward") && e["operatorReward"].is_number())
+            mn.nOperatorReward = static_cast<uint16_t>(
+                std::llround(e["operatorReward"].get<double>() * 100.0));
+        const std::string type_str = e.value("type", "Regular");
+        mn.nType = (type_str == "Evo" || type_str == "HighPerformance")
+                       ? vendor::MnType::EVO
+                       : vendor::MnType::REGULAR;
+        if (mn.nType == vendor::MnType::EVO) ++st.evo;
+
+        // Per-block state-machine facets (the GetMNPayee ordering inputs the
+        // SML can never provide — the reason protx diff was rejected).
+        if (s.contains("version") && s["version"].is_number())
+            mn.nVersion = s["version"].get<uint16_t>();
+        mn.nRegisteredHeight    = detail::sane_height_json(s, "registeredHeight");
+        mn.nLastPaidHeight      = detail::sane_height_json(s, "lastPaidHeight");
+        mn.nPoSeRevivedHeight   = detail::sane_height_json(s, "PoSeRevivedHeight");
+        mn.nPoSeBanHeight       = detail::sane_height_json(s, "PoSeBanHeight");
+        mn.nConsecutivePayments =
+            detail::sane_height_json(s, "consecutivePayments");
+        if (s.contains("revocationReason") && s["revocationReason"].is_number())
+            mn.nRevocationReason = s["revocationReason"].get<uint16_t>();
+        // `protx list valid` already filters to non-banned MNs; keep the
+        // defensive ban-height projection anyway.
+        mn.isValid = (mn.nPoSeBanHeight == 0);
+
+        // THE payee keystone: payoutAddress -> scriptPayout, byte-exact.
+        mn.scriptPayout.m_data = detail::payout_address_to_script(
+            s.value("payoutAddress", ""), address_version, address_p2sh_version);
+        if (mn.scriptPayout.m_data.empty()) {
+            ++st.payout_decode_failed;
+            LOG_WARNING << "[MN-SEED] undecodable payoutAddress '"
+                        << s.value("payoutAddress", "") << "' for proTx "
+                        << proTxHash.GetHex().substr(0, 16)
+                        << " -- seed aborted (fail-closed: partial sets mint"
+                           " wrong payees)";
+            if (stats) *stats = st;
+            return {};
+        }
+        // Operator payout (optional, best-effort — not payee-critical today;
+        // operator-payout coinbase matching is a documented non-goal of the
+        // state machine).
+        const std::string op_addr = s.value("operatorPayoutAddress", "");
+        if (!op_addr.empty())
+            mn.scriptOperatorPayout.m_data = detail::payout_address_to_script(
+                op_addr, address_version, address_p2sh_version);
+
+        // Governance keys (best-effort; not consumed by payee projection).
+        mn.keyIDOwner  = detail::hash160_hex_to_uint160(
+            ::core::base58check_to_hash160(s.value("ownerAddress", "")));
+        mn.keyIDVoting = detail::hash160_hex_to_uint160(
+            ::core::base58check_to_hash160(s.value("votingAddress", "")));
+        mn.pubKeyOperator =
+            detail::parse_bls_pubkey_hex(s.value("pubKeyOperator", ""));
+
+        out.emplace_back(proTxHash, std::move(mn));
+        ++st.seeded;
+    }
+
+    if (stats) *stats = st;
+    return out;
+}
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/mn_seed.hpp
+++ b/src/impl/dash/coin/mn_seed.hpp
@@ -57,6 +57,7 @@
 
 #include <cmath>
 #include <cstdint>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -131,6 +132,20 @@ parse_bls_pubkey_hex(const std::string& hex)
     return out;
 }
 
+// Strict 64-lowercase/uppercase-hex check for RPC hash strings. uint256S is
+// TOLERANT of short/garbage input (parses what it can), which would key a
+// seeded MN under a wrong/zero hash that later apply_block updates never
+// match — a silent drift instead of the contracted fail-closed abort.
+inline bool is_hex256(const std::string& s)
+{
+    if (s.size() != 64) return false;
+    for (char c : s)
+        if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')
+              || (c >= 'A' && c <= 'F')))
+            return false;
+    return true;
+}
+
 } // namespace detail
 
 /// Convert a dashd `protx list valid true` (detailed) JSON array into the
@@ -153,13 +168,27 @@ inline std::vector<std::pair<uint256, MNState>> parse_protx_list_seed(
     }
     out.reserve(list.size());
 
+    // Duplicate-collateral guard: MnStateMachine::load() keys a collateral
+    // index by outpoint, so two seeded MNs sharing one would silently shadow
+    // each other there. Real dashd output cannot contain duplicates (DIP3
+    // consensus enforces unique collaterals); seeing one means the input is
+    // not a real protx list — fail closed.
+    std::set<std::pair<uint256, uint32_t>> seen_collateral;
+
     for (const auto& e : list) {
         ++st.total;
+        bool entry_malformed = false;
+        try {
         if (!e.is_object() || !e.contains("proTxHash")
+            || !e["proTxHash"].is_string()
+            || !detail::is_hex256(e["proTxHash"].get<std::string>())
             || !e.contains("state") || !e["state"].is_object()) {
+            entry_malformed = true;
+        }
+        if (entry_malformed) {
             ++st.malformed;
             LOG_WARNING << "[MN-SEED] malformed protx entry (#" << st.total
-                        << ": no proTxHash/state) -- seed aborted";
+                        << ": bad proTxHash/state) -- seed aborted";
             if (stats) *stats = st;
             return {};
         }
@@ -169,11 +198,21 @@ inline std::vector<std::pair<uint256, MNState>> parse_protx_list_seed(
 
         // Identity / registration facets.
         const uint256 proTxHash = uint256S(e["proTxHash"].get<std::string>());
-        if (e.contains("collateralHash"))
+        if (e.contains("collateralHash") && e["collateralHash"].is_string()
+            && detail::is_hex256(e["collateralHash"].get<std::string>()))
             mn.collateralOutpoint.hash =
                 uint256S(e["collateralHash"].get<std::string>());
         if (e.contains("collateralIndex") && e["collateralIndex"].is_number())
             mn.collateralOutpoint.index = e["collateralIndex"].get<uint32_t>();
+        if (!seen_collateral.emplace(mn.collateralOutpoint.hash,
+                                     mn.collateralOutpoint.index).second) {
+            ++st.malformed;
+            LOG_WARNING << "[MN-SEED] duplicate collateral outpoint in protx"
+                           " list (proTx " << proTxHash.GetHex().substr(0, 16)
+                        << ") -- seed aborted (not a real DIP3 set)";
+            if (stats) *stats = st;
+            return {};
+        }
         // JSON reports operatorReward as a percentage double (dashd ToJson:
         // nOperatorReward / 100.0); recover the internal 0..10000 fixed-point.
         if (e.contains("operatorReward") && e["operatorReward"].is_number())
@@ -232,6 +271,17 @@ inline std::vector<std::pair<uint256, MNState>> parse_protx_list_seed(
 
         out.emplace_back(proTxHash, std::move(mn));
         ++st.seeded;
+        } catch (const nlohmann::json::exception& ex) {
+            // Type mismatch anywhere in the entry (numeric proTxHash,
+            // non-numeric height, ...): the parser's contract is a FAIL-CLOSED
+            // empty return, never an escaping throw.
+            ++st.malformed;
+            LOG_WARNING << "[MN-SEED] protx entry #" << st.total
+                        << " JSON type error (" << ex.what()
+                        << ") -- seed aborted";
+            if (stats) *stats = st;
+            return {};
+        }
     }
 
     if (stats) *stats = st;

--- a/src/impl/dash/coin/node_interface.hpp
+++ b/src/impl/dash/coin/node_interface.hpp
@@ -65,6 +65,16 @@ struct BlockConnected
 struct MnListUpdate
 {
     std::vector<std::pair<uint256, coin::MNState>> mnstates;
+
+    // E2c: the chain height this snapshot is CURRENT AT (0 = unknown). A
+    // payout-bearing snapshot (e.g. the RPC protx-list seed) already reflects
+    // every registration/spend/payment up to this height, so the maintainer
+    // must NOT re-fold blocks at height <= as_of_height into it: replaying a
+    // historical coinbase payment on top of an already-current lastPaidHeight
+    // set falsely re-bumps the front of the GetMNPayee queue (live-observed
+    // on testnet where dozens of MNs share one payoutAddress) and projects
+    // the WRONG payee. 0 preserves the pre-E2c behavior (no skip).
+    uint32_t as_of_height{0};
 };
 
 struct Node

--- a/src/impl/dash/coin/rpc.cpp
+++ b/src/impl/dash/coin/rpc.cpp
@@ -456,6 +456,18 @@ nlohmann::json NodeRPC::getblock(uint256 blockhash, int verbosity)
     return CallAPIMethod("getblock", {blockhash, verbosity});
 }
 
+// E2c (#738): the MN-set seed fetch. `protx list valid true` returns every
+// registered, non-PoSe-banned masternode at the current tip with the detailed
+// per-MN state (payoutAddress, lastPaidHeight, registeredHeight, PoSe
+// heights, pubKeyOperator, ...). Chosen over `protx diff`: the diff (even
+// extended) carries payoutAddress but NOT lastPaidHeight/registeredHeight, so
+// a diff-seeded set would rank every MN equal in GetMNPayee ordering and
+// project the WRONG payee (the bad-cb-payee class #746 fixed).
+nlohmann::json NodeRPC::protx_list_valid_detailed()
+{
+    return CallAPIMethod("protx", {"list", "valid", true});
+}
+
 } // namespace coin
 
 } // namespace dash

--- a/src/impl/dash/coin/rpc.hpp
+++ b/src/impl/dash/coin/rpc.hpp
@@ -130,6 +130,13 @@ public:
     nlohmann::json getblockheader(uint256 header, bool verbose = true);
     // verbosity: 0 for hex-encoded data, 1 for a json object, and 2 for json object with transaction data
     nlohmann::json getblock(uint256 blockhash, int verbosity = 1);
+    // E2c (#738): `protx list valid true` -- the full valid deterministic-MN
+    // set at the current tip in the DETAILED shape (state.payoutAddress +
+    // lastPaidHeight + registeredHeight + PoSe heights). This is the
+    // payout-bearing MN-set SEED source for the embedded arm; the P2P
+    // Simplified MN List omits scriptPayout/lastPaidHeight so it can never
+    // back this. See coin/mn_seed.hpp (parse_protx_list_seed).
+    nlohmann::json protx_list_valid_detailed();
 };
 
 struct RPCAuthData

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -259,7 +259,21 @@ std::shared_ptr<const coin::DashWorkData> DASHWorkSource::cached_work() const
     coin::DashWorkData work;
     if (coin_state_.populated() || dashd_fallback_) {
         try {
-            work = coin_state_.select_work(dashd_fallback_).work;
+            coin::WorkSelection sel = coin_state_.select_work(dashd_fallback_);
+            // E2c observability: WHICH arm served this template + the MN payee
+            // it carries (the payee-correctness axis of the embedded arm). One
+            // line per re-source (cache-TTL cadence), INFO -- the field-
+            // checkable "embedded arm is live and paying the right MN" signal
+            // the E2c smoke gate and prod diagnosis both read.
+            std::string mn_payee = "(none)";
+            for (const auto& pp : sel.work.m_packed_payments)
+                if (pp.payee != "!6a") { mn_payee = pp.payee; break; }
+            LOG_INFO << "[DASH-STRATUM-GBT] template sourced: arm="
+                     << (sel.source == coin::WorkSource::Embedded
+                             ? "EMBEDDED" : "dashd-fallback")
+                     << " h=" << sel.work.m_height
+                     << " mn_payee=" << mn_payee;
+            work = std::move(sel.work);
         } catch (const std::exception& e) {
             LOG_WARNING << "[DASH-STRATUM] template sourcing threw: " << e.what();
             work = coin::DashWorkData{};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -688,8 +688,14 @@ if (BUILD_TESTING AND GTest_FOUND)
     # (live_feed.hpp) translating raw coin-P2P wire events into the derived
     # ingest events (new_headers->HeaderChain, full_block->block_connected) + the
     # pure tip_advance_from_chain gate. Same target/link set; no new allowlist.
+    # Third TU (E2c): test_dash_mn_seed.cpp — the RPC protx-list MN-set seed
+    # (mn_seed.hpp): payoutAddress->scriptPayout byte-exact round trip,
+    # fail-closed abort on undecodable payees, and the seed->leg-4-event->
+    # populated()-flips->embedded-template-pays-the-correct-MN capstone. Same
+    # target/link set (core already carries address_utils); no new allowlist.
     add_executable(test_dash_node_reception_wire test_dash_node_reception_wire.cpp
-                   test_dash_live_feed_bridge.cpp)
+                   test_dash_live_feed_bridge.cpp
+                   test_dash_mn_seed.cpp)
     target_link_libraries(test_dash_node_reception_wire PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core

--- a/test/test_dash_mn_seed.cpp
+++ b/test/test_dash_mn_seed.cpp
@@ -30,6 +30,7 @@
 #include <impl/dash/coin/node_interface.hpp>       // dash::interfaces::Node
 #include <impl/dash/coin/mn_list_ingest.hpp>       // wire_mn_list_ingest (leg 4)
 #include <impl/dash/coin/tip_ingest.hpp>           // wire_tip_ingest (leg 2)
+#include <impl/dash/coin/block_connect_ingest.hpp> // wire_block_connect_ingest (leg 3)
 #include <impl/dash/coin/coin_state_maintainer.hpp>
 #include <impl/dash/coin/node_coin_state.hpp>
 #include <impl/dash/coin/rpc_data.hpp>
@@ -78,7 +79,10 @@ static json protx_entry(uint8_t idbyte, const std::string& payout_addr,
                         const std::string& type = "Regular") {
     std::string protx(64, '0');
     protx[0] = static_cast<char>('0' + (idbyte % 10));
+    // Unique per-entry collateral: DIP3 consensus enforces unique collateral
+    // outpoints, and the parser fail-closes on duplicates.
     std::string coll(64, 'a');
+    coll[0] = static_cast<char>('0' + (idbyte % 10));
     return json{
         {"type", type},
         {"proTxHash", protx},
@@ -177,6 +181,63 @@ TEST(DashMnSeed, EmptyOrNonArrayYieldsEmptySeed)
                                       DASH_P2SH_VER, &st).empty());
 }
 
+// ── malformed entries fail closed, never throw ─────────────────────────────
+TEST(DashMnSeed, MalformedEntriesFailClosedWithoutThrowing)
+{
+    const std::string good_addr = addr_of(p2pkh_script(0x11));
+
+    // Numeric proTxHash (type mismatch) -> empty, no escaping throw.
+    auto bad_type = protx_entry(1, good_addr, 1, 1);
+    bad_type["proTxHash"] = 12345;
+    MnSeedStats st1;
+    EXPECT_TRUE(parse_protx_list_seed(json::array({bad_type}),
+                                      DASH_PUBKEY_VER, DASH_P2SH_VER,
+                                      &st1).empty());
+    EXPECT_EQ(st1.malformed, 1u);
+
+    // Short/garbage proTxHash hex (uint256S would tolerate it and key the MN
+    // under a wrong hash) -> empty.
+    auto bad_hex = protx_entry(1, good_addr, 1, 1);
+    bad_hex["proTxHash"] = "deadbeef";
+    MnSeedStats st2;
+    EXPECT_TRUE(parse_protx_list_seed(json::array({bad_hex}),
+                                      DASH_PUBKEY_VER, DASH_P2SH_VER,
+                                      &st2).empty());
+    EXPECT_EQ(st2.malformed, 1u);
+
+    // Type-guarded numeric fields degrade gracefully (no throw, no abort):
+    // a string lastPaidHeight parses as 0 via the is_number guard.
+    auto odd_height = protx_entry(1, good_addr, 1, 1);
+    odd_height["state"]["lastPaidHeight"] = "not-a-number";
+    MnSeedStats st3;
+    auto seed3 = parse_protx_list_seed(json::array({odd_height}),
+                                       DASH_PUBKEY_VER, DASH_P2SH_VER, &st3);
+    ASSERT_EQ(seed3.size(), 1u);
+    EXPECT_EQ(seed3[0].second.nLastPaidHeight, 0u);
+
+    // A json type error on an unguarded .value() path (non-string "type")
+    // is caught INSIDE the parser -> fail-closed empty, no escaping throw.
+    auto bad_type_field = protx_entry(1, good_addr, 1, 1);
+    bad_type_field["type"] = 5;
+    MnSeedStats st5;
+    EXPECT_TRUE(parse_protx_list_seed(json::array({bad_type_field}),
+                                      DASH_PUBKEY_VER, DASH_P2SH_VER,
+                                      &st5).empty());
+    EXPECT_EQ(st5.malformed, 1u);
+
+    // Duplicate collateral outpoint (impossible in a real DIP3 set; would
+    // silently shadow in MnStateMachine::load's collateral index) -> empty.
+    auto a = protx_entry(1, good_addr, 1, 1);
+    auto b = protx_entry(2, addr_of(p2pkh_script(0x22)), 2, 2);
+    b["collateralHash"]  = a["collateralHash"];
+    b["collateralIndex"] = a["collateralIndex"];
+    MnSeedStats st4;
+    EXPECT_TRUE(parse_protx_list_seed(json::array({a, b}),
+                                      DASH_PUBKEY_VER, DASH_P2SH_VER,
+                                      &st4).empty());
+    EXPECT_EQ(st4.malformed, 1u);
+}
+
 // ── end-to-end: seed -> leg-4 event -> populated() flips -> EMBEDDED
 //    template pays the CORRECT (lowest-lastPaid) seeded MN ──────────────────
 TEST(DashMnSeed, SeedFlipsPopulatedAndEmbeddedTemplatePaysSeededPayee)
@@ -242,4 +303,60 @@ TEST(DashMnSeed, SeedFlipsPopulatedAndEmbeddedTemplatePaysSeededPayee)
     // An EMPTY resync (set-gap) demotes back to the fallback.
     node.mn_list_update.happened(dash::interfaces::MnListUpdate{});
     EXPECT_FALSE(state.populated());
+}
+
+// ── snapshot as-of fence: blocks the seed already reflects must NOT
+//    re-attribute their coinbase payments (the shared-payoutAddress queue
+//    scramble observed live with the E2b 288-block bootstrap replay) ───────
+TEST(DashMnSeed, SnapshotHeightFencesReplayedBlocks)
+{
+    dash::interfaces::Node node;
+    NodeCoinState state;
+    CoinStateMaintainer maint(state);
+    auto sub_mn  = c2pool::dash::wire_mn_list_ingest(node, maint);
+    auto sub_blk = c2pool::dash::wire_block_connect_ingest(node, maint);
+
+    // Two MNs SHARING one payout script (the testnet reality that exposed
+    // the bug), lastPaid current at the snapshot height 2'399'901.
+    const auto shared = p2pkh_script(0x44);
+    const std::string shared_addr = addr_of(shared);
+    json list = json::array({
+        protx_entry(1, shared_addr, 2'399'900, 2'300'000),
+        protx_entry(2, shared_addr, 2'399'901, 2'300'100),
+    });
+    auto seed = parse_protx_list_seed(list, DASH_PUBKEY_VER, DASH_P2SH_VER);
+    ASSERT_EQ(seed.size(), 2u);
+    const uint256 mn_a = seed[0].first;   // lastPaid 2'399'900 (queue front)
+
+    dash::interfaces::MnListUpdate up;
+    up.mnstates     = std::move(seed);
+    up.as_of_height = 2'399'901;
+    node.mn_list_update.happened(up);
+
+    // A REPLAYED block at height <= as_of (its payment is already reflected
+    // in the seed's lastPaid values) must not re-bump the queue front.
+    auto paying_block = [&](uint32_t /*h*/) {
+        dash::interfaces::BlockConnected bc;
+        dash::coin::MutableTransaction cb;
+        cb.version = 1; cb.type = 0;
+        bitcoin_family::coin::TxOut o;
+        o.value = 100'000'000;
+        o.scriptPubKey.m_data = shared;
+        cb.vout.push_back(o);
+        bc.block.m_txs.push_back(cb);
+        return bc;
+    };
+    auto bc_old = paying_block(2'399'901);
+    bc_old.height = 2'399'901;
+    node.block_connected.happened(bc_old);
+    EXPECT_EQ(state.mnstates().entries().at(mn_a).nLastPaidHeight, 2'399'900u)
+        << "replayed (<= as_of) block must not re-attribute its payment";
+
+    // A NEW block above the snapshot height applies normally: the queue-front
+    // MN (lowest lastPaid) is attributed the payment.
+    auto bc_new = paying_block(2'399'902);
+    bc_new.height = 2'399'902;
+    node.block_connected.happened(bc_new);
+    EXPECT_EQ(state.mnstates().entries().at(mn_a).nLastPaidHeight, 2'399'902u)
+        << "post-snapshot block must fold normally";
 }

--- a/test/test_dash_mn_seed.cpp
+++ b/test/test_dash_mn_seed.cpp
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/// E2c (#738) -- RPC protx-list MN-set seed KAT.
+///
+/// E2a proved the TIP half of NodeCoinState::populated() flips off the live
+/// coin-P2P feed, but the DMN half had NO cold-start source: the P2P
+/// Simplified MN List omits scriptPayout + nLastPaidHeight, and apply_block
+/// only folds special txs from blocks we connect. mn_seed.hpp closes that gap
+/// by converting dashd's `protx list valid true` JSON (payoutAddress +
+/// lastPaidHeight -- everything GetMNPayee ordering needs) into the
+/// (proTxHash -> MNState) vector the maintainer's leg-4 resync takes.
+///
+/// This suite pins, network-free:
+///   * parse: payoutAddress -> scriptPayout is BYTE-EXACT (round-trip through
+///     the same script_to_address encoding embedded_gbt emits), ordering
+///     fields (lastPaid/registered/PoSe) land, dashd's -1 "never" sentinels
+///     normalize to 0 (the UINT32_MAX wrap bug class), Evo typing, stats;
+///   * fail-closed: ONE undecodable payoutAddress aborts the WHOLE seed
+///     (empty return) -- a partial set could mint a wrong payee (the
+///     bad-cb-payee class #746 fixed), an empty set is a safe set-gap;
+///   * end-to-end: publishing the parsed seed through the REAL leg-4 event
+///     (mn_list_update -> wire_mn_list_ingest -> on_mn_list_update) + a live
+///     tip (new_tip -> wire_tip_ingest) flips populated() TRUE, select_work()
+///     takes the EMBEDDED arm without touching the fallback, and the
+///     template's MN payee is the seeded MN dashd's GetMNPayee ordering picks
+///     (lowest lastPaid) -- the payee-correctness the E2c gate asserts.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/mn_seed.hpp>              // parse_protx_list_seed (DUT)
+#include <impl/dash/coin/node_interface.hpp>       // dash::interfaces::Node
+#include <impl/dash/coin/mn_list_ingest.hpp>       // wire_mn_list_ingest (leg 4)
+#include <impl/dash/coin/tip_ingest.hpp>           // wire_tip_ingest (leg 2)
+#include <impl/dash/coin/coin_state_maintainer.hpp>
+#include <impl/dash/coin/node_coin_state.hpp>
+#include <impl/dash/coin/rpc_data.hpp>
+
+#include <core/address_utils.hpp>
+#include <core/uint256.hpp>
+
+#include <nlohmann/json.hpp>
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+using dash::coin::CoinStateMaintainer;
+using dash::coin::MNState;
+using dash::coin::MnSeedStats;
+using dash::coin::NodeCoinState;
+using dash::coin::parse_protx_list_seed;
+using dash::coin::WorkSource;
+using nlohmann::json;
+
+static constexpr uint8_t  DASH_PUBKEY_VER = 76;   // mainnet 'X...'
+static constexpr uint8_t  DASH_P2SH_VER   = 16;   // mainnet '7...'
+static constexpr uint32_t H = 2'400'000;          // past MN_RR
+
+// A deterministic 25-byte P2PKH scriptPubKey.
+static std::vector<unsigned char> p2pkh_script(uint8_t hashseed) {
+    std::vector<unsigned char> s{0x76, 0xa9, 0x14};
+    for (int i = 0; i < 20; ++i) s.push_back(static_cast<unsigned char>(hashseed + i));
+    s.push_back(0x88); s.push_back(0xac);
+    return s;
+}
+
+// The base58 address dashd's EncodeDestination would report for that script --
+// produced by the SAME script_to_address the embedded template payee encoding
+// uses, so the KAT pins the full round trip address -> script -> address.
+static std::string addr_of(const std::vector<unsigned char>& script) {
+    return ::core::script_to_address(script, /*bech32_hrp=*/"",
+                                     DASH_PUBKEY_VER, DASH_P2SH_VER);
+}
+
+// One detailed `protx list valid true` entry, dashd JSON shape.
+static json protx_entry(uint8_t idbyte, const std::string& payout_addr,
+                        int64_t last_paid, int64_t registered,
+                        const std::string& type = "Regular") {
+    std::string protx(64, '0');
+    protx[0] = static_cast<char>('0' + (idbyte % 10));
+    std::string coll(64, 'a');
+    return json{
+        {"type", type},
+        {"proTxHash", protx},
+        {"collateralHash", coll},
+        {"collateralIndex", 1},
+        {"operatorReward", 0.0},
+        {"state", {
+            {"version", 2},
+            {"service", "203.0.113.7:9999"},
+            {"registeredHeight", registered},
+            {"lastPaidHeight", last_paid},
+            {"consecutivePayments", 0},
+            {"PoSePenalty", 0},
+            {"PoSeRevivedHeight", -1},   // dashd "never" sentinel
+            {"PoSeBanHeight", -1},       // dashd "never" sentinel
+            {"revocationReason", 0},
+            {"ownerAddress", payout_addr},
+            {"votingAddress", payout_addr},
+            {"payoutAddress", payout_addr},
+            {"pubKeyOperator", std::string(96, '0')}
+        }}
+    };
+}
+
+// ── parse: payout script byte-exact + ordering fields + sentinels ──────────
+TEST(DashMnSeed, ParsesPayoutBearingSet)
+{
+    const auto script_a = p2pkh_script(0x11);
+    const auto script_b = p2pkh_script(0x22);
+    json list = json::array({
+        protx_entry(1, addr_of(script_a), 2'350'000, 2'300'000),
+        protx_entry(2, addr_of(script_b), 2'351'000, 2'300'100, "Evo"),
+    });
+
+    MnSeedStats st;
+    auto seed = parse_protx_list_seed(list, DASH_PUBKEY_VER, DASH_P2SH_VER, &st);
+    ASSERT_EQ(seed.size(), 2u);
+    EXPECT_EQ(st.total, 2u);
+    EXPECT_EQ(st.seeded, 2u);
+    EXPECT_EQ(st.evo, 1u);
+    EXPECT_EQ(st.payout_decode_failed, 0u);
+
+    // THE keystone: scriptPayout reproduced byte-exactly from the address.
+    EXPECT_EQ(seed[0].second.scriptPayout.m_data, script_a);
+    EXPECT_EQ(seed[1].second.scriptPayout.m_data, script_b);
+
+    // GetMNPayee ordering inputs (what the P2P SML can never provide).
+    EXPECT_EQ(seed[0].second.nLastPaidHeight,   2'350'000u);
+    EXPECT_EQ(seed[0].second.nRegisteredHeight, 2'300'000u);
+    EXPECT_EQ(seed[1].second.nLastPaidHeight,   2'351'000u);
+
+    // dashd -1 sentinels normalize to 0 -- NOT the UINT32_MAX wrap that made
+    // one never-paid MN win find_expected_payee forever (mn_state_machine
+    // SENTINEL note).
+    EXPECT_EQ(seed[0].second.nPoSeRevivedHeight, 0u);
+    EXPECT_EQ(seed[0].second.nPoSeBanHeight,     0u);
+    EXPECT_TRUE(seed[0].second.isValid);
+
+    // Evo typing.
+    EXPECT_EQ(seed[1].second.nType, dash::coin::vendor::MnType::EVO);
+    EXPECT_EQ(seed[0].second.nType, dash::coin::vendor::MnType::REGULAR);
+}
+
+// ── fail-closed: one bad payoutAddress aborts the WHOLE seed ───────────────
+TEST(DashMnSeed, FailsClosedOnUndecodablePayoutAddress)
+{
+    json list = json::array({
+        protx_entry(1, addr_of(p2pkh_script(0x11)), 2'350'000, 2'300'000),
+        protx_entry(2, "not-a-dash-address", 2'351'000, 2'300'100),
+    });
+    MnSeedStats st;
+    auto seed = parse_protx_list_seed(list, DASH_PUBKEY_VER, DASH_P2SH_VER, &st);
+    EXPECT_TRUE(seed.empty());
+    EXPECT_EQ(st.payout_decode_failed, 1u);
+
+    // Wrong-chain version byte (a TESTNET address against mainnet versions)
+    // must equally fail closed -- never seed a cross-net payee.
+    const std::string testnet_addr = ::core::script_to_address(
+        p2pkh_script(0x33), "", /*testnet p2pkh=*/140, /*testnet p2sh=*/19);
+    json list2 = json::array({
+        protx_entry(1, testnet_addr, 2'350'000, 2'300'000),
+    });
+    MnSeedStats st2;
+    auto seed2 = parse_protx_list_seed(list2, DASH_PUBKEY_VER, DASH_P2SH_VER, &st2);
+    EXPECT_TRUE(seed2.empty());
+    EXPECT_EQ(st2.payout_decode_failed, 1u);
+}
+
+// ── non-array / empty results are safe set-gaps ────────────────────────────
+TEST(DashMnSeed, EmptyOrNonArrayYieldsEmptySeed)
+{
+    MnSeedStats st;
+    EXPECT_TRUE(parse_protx_list_seed(json::object(), DASH_PUBKEY_VER,
+                                      DASH_P2SH_VER, &st).empty());
+    EXPECT_TRUE(parse_protx_list_seed(json::array(), DASH_PUBKEY_VER,
+                                      DASH_P2SH_VER, &st).empty());
+}
+
+// ── end-to-end: seed -> leg-4 event -> populated() flips -> EMBEDDED
+//    template pays the CORRECT (lowest-lastPaid) seeded MN ──────────────────
+TEST(DashMnSeed, SeedFlipsPopulatedAndEmbeddedTemplatePaysSeededPayee)
+{
+    dash::interfaces::Node node;
+    NodeCoinState state;
+    CoinStateMaintainer maint(state);
+    auto sub_mn  = c2pool::dash::wire_mn_list_ingest(node, maint);
+    auto sub_tip = c2pool::dash::wire_tip_ingest(node, maint);
+
+    // Two seeded MNs; MN A (lower lastPaid) is what dashd's GetMNPayee
+    // ordering pays next -- the embedded template must agree.
+    const auto script_a = p2pkh_script(0x11);
+    const auto script_b = p2pkh_script(0x22);
+    const std::string addr_a = addr_of(script_a);
+    json list = json::array({
+        protx_entry(1, addr_a, 2'350'000, 2'300'000),
+        protx_entry(2, addr_of(script_b), 2'351'000, 2'300'100),
+    });
+    auto seed = parse_protx_list_seed(list, DASH_PUBKEY_VER, DASH_P2SH_VER);
+    ASSERT_EQ(seed.size(), 2u);
+
+    // Publish through the REAL leg-4 event -- no direct maintainer poke.
+    dash::interfaces::MnListUpdate up;
+    up.mnstates = std::move(seed);
+    node.mn_list_update.happened(up);
+    EXPECT_FALSE(state.populated());   // DMN half armed; tip half missing
+
+    // Tip arrives (leg 2, real event): populated() flips.
+    dash::interfaces::TipAdvance ta;
+    ta.prev_height          = H - 1;
+    ta.prev_hash            = uint256S("00000000000000000000000000000000"
+                                       "000000000000000000000000000000aa");
+    ta.bits_for_next        = 0x1a012345u;
+    ta.mtp_at_tip           = 1'750'000'000u;
+    ta.address_version      = DASH_PUBKEY_VER;
+    ta.address_p2sh_version = DASH_P2SH_VER;
+    node.new_tip.happened(ta);
+    ASSERT_TRUE(state.populated());
+
+    // get_work now takes the EMBEDDED arm; the fallback must NOT be touched.
+    bool fallback_called = false;
+    auto sel = state.select_work([&fallback_called]() {
+        fallback_called = true;
+        return dash::coin::DashWorkData{};
+    });
+    EXPECT_FALSE(fallback_called);
+    ASSERT_EQ(sel.source, WorkSource::Embedded);
+    EXPECT_EQ(sel.work.m_height, H);
+
+    // The MN payee in the packed payments is the seeded lowest-lastPaid MN's
+    // address -- the same base58 wire form dashd's GBT "masternode" reports.
+    bool found_payee = false;
+    for (const auto& pp : sel.work.m_packed_payments) {
+        if (pp.payee == addr_a) {
+            found_payee = true;
+            EXPECT_GT(pp.amount, 0u);
+        }
+        EXPECT_NE(pp.payee, addr_of(script_b));  // wrong MN must not be paid
+    }
+    EXPECT_TRUE(found_payee);
+
+    // An EMPTY resync (set-gap) demotes back to the fallback.
+    node.mn_list_update.happened(dash::interfaces::MnListUpdate{});
+    EXPECT_FALSE(state.populated());
+}


### PR DESCRIPTION
SLICE E2c of the DASH embedded-daemon campaign (#738). E2a (#747) proved the TIP half of `NodeCoinState::populated()` flips off the live coin-P2P feed; this slice closes the DMN half, so the embedded arm actually serves templates with the CORRECT masternode payee.

**Base note:** stacked on `feat/dash-embedded-populate` (E2a, #747) — the maintainer/live-feed seam this seeds is not on master yet. Retarget/rebase onto master once #747 merges.

## The gap

`populated()` needs a header tip AND a payout-bearing DMN set. No live leg can cold-start the DMN half:

- the P2P Simplified MN List (`mnlistdiff`) **omits `scriptPayout` + `nLastPaidHeight`** — leg 4 alone can never assemble a payee-complete set, and converting the payout-incomplete SML into a DMN set would mint WRONG payees (`bad-cb-payee`, the exact class #746 fixed);
- leg 3's `apply_block` only folds special txs from blocks we actually connect — a payee-complete set from block bodies needs a full DIP3-height replay.

So cold start needs an explicit MN-set seed.

## The seed (this slice)

When the embedded arm is enabled (`--coin-p2p-connect`) AND the dashd-RPC arm is armed, fetch the full valid DMN set once at startup via **`protx list valid true`** (detailed) and publish it through the EXISTING leg-4 event (`mn_list_update` → `wire_mn_list_ingest` → `on_mn_list_update`) — the maintainer takes it exactly like any other resync, and the live legs (apply_block + SML validity sync) keep it current on top.

**Why not `protx diff` (the obvious candidate):** even the extended diff carries `payoutAddress` but NOT `lastPaidHeight`/`registeredHeight`. A diff-seeded set would rank every MN equal in GetMNPayee ordering and project the wrong payee. `protx list valid true` carries the full ordering triple (lastPaid / registered / PoSe heights) plus `payoutAddress` in one call.

- `coin/mn_seed.hpp` — `parse_protx_list_seed()`: pure JSON → `(proTxHash, MNState)` converter.
  - `payoutAddress` → `scriptPayout` **byte-exact**: dashd consensus only admits P2PKH/P2SH payout scripts and `payoutAddress` is `EncodeDestination(scriptPayout)`, so the base58 round trip is lossless; `embedded_gbt`'s `script_to_address()` re-encodes the identical address dashd's GBT reports.
  - dashd `-1` "never" sentinels normalize to 0 — not the UINT32_MAX wrap that once pinned `find_expected_payee`.
  - **Fails closed**: any undecodable `payoutAddress` (incl. cross-net version bytes) aborts the WHOLE seed — a partial set could rank a skipped MN's slot onto the wrong payee; an empty set is a safe set-gap on the retained fallback.
- `coin/rpc.{hpp,cpp}` — `NodeRPC::protx_list_valid_detailed()`.
- `main_dash.cpp` — E2c seed block after the E2a legs (inside the `coin_p2p` gate): RPC armed → fetch/parse/publish; parse or RPC failure → log + stay on fallback; **no RPC → flag, don't fail** (see E2d below).
- `stratum/work_source.cpp` — `[DASH-STRATUM-GBT] template sourced: arm=EMBEDDED|dashd-fallback h=... mn_payee=...` at cache re-source cadence — the field-checkable payee-correctness signal this gate (and prod diagnosis) reads.

The dashd-RPC fallback arm is untouched and never removed; the no-`--coin-p2p-connect` run path is byte-identical.

## Verification

- **KATs** (`test_dash_mn_seed.cpp`, third TU of the allowlisted `test_dash_node_reception_wire` target — no new allowlist): parse byte-exactness + sentinels + Evo typing; fail-closed aborts (bad address, cross-net address, non-array); capstone: seed → real leg-4 event → `populated()` flips once tip arrives → `select_work` takes EMBEDDED without touching the fallback → template pays the lowest-lastPaid seeded MN (dashd's GetMNPayee ordering); empty resync demotes back. 19/19 green in the target.
- `--selftest` green; no-flag path unchanged.
- **Live smoke** (.52 testnet dashd, `--run --coin-p2p-connect .52:19999 --coin-rpc .52:19998 --embedded-utxo --testnet --stratum`): `E2c MN-set seed LOADED: 85/85 valid MNs (30 Evo)`; populated() flip + embedded-arm serving + byte-faithful MN-payee match vs `dashd getblocktemplate` at the same tip: **see the smoke transcript in the PR comment below.**

## Flagged follow-up — E2d: pure-daemonless MN seed (NOT built here)

A node with NO dashd at all cannot use this seed. Its DMN set must come from a DIP3-height special-tx replay: sync block bodies from DIP3 activation and replay ProRegTx/ProUpRegTx/ProUpServTx/ProUpRevTx through `MnStateMachine::apply_block` (the specialtxman equivalent already vendored). That is a heavier slice (historical block-body sync + checkpointing). The RPC seed covers the mining hotel (which runs dashd) and every RPC-configured deployment now; the startup log flags the daemonless wait explicitly.

Known cosmetic: the synchronous seed self-connects via `Send`'s `sync_reconnect` before the async `connect()` callback lands, so one benign `CoindRPC error when try connect: [Transport endpoint is already connected]` line appears before `...CoindRPC connected!`. Same pattern `--submit-block` already relies on.
