### PR TITLE
dash(mint 3/3): run-loop share minting — ShareAccept -> tracker insert + broadcast + PPLNS weights

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -71,6 +71,13 @@
 
 #include <core/stratum_server.hpp>             // core::StratumServer — miner-facing accept-loop (run-path caller)
 #include <impl/dash/stratum/work_source.hpp>   // dash::stratum::DASHWorkSource — concrete core::stratum::IWorkSource
+#include <impl/dash/mint_runloop.hpp>          // dash::mint — run-loop share minting (slice 3/3)
+#include <core/log.hpp>
+
+#include <chrono>
+#include <ctime>
+#include <optional>
+#include <random>
 
 #include <boost/asio.hpp>
 
@@ -173,6 +180,8 @@ void print_banner(const char* argv0)
         << "           [--listen [HOST:]PORT] [--addnode HOST:PORT]... [--connect HOST:PORT]...\n"
         << "           [--stratum [HOST:]PORT] [--coin-p2p-connect HOST:PORT]...\n"
         << "           [--embedded-utxo]\n"
+        << "           [--give-author PCT] [-f|--fee PCT] [--node-owner-address ADDR]\n"
+        << "           [--redistribute pplns|fee|boost|donate]\n"
         << "       " << argv0 << " --mine-block [--coin-rpc H:P] [--coin-rpc-auth PATH]\n"
         << "           [--testnet] [--payout-pubkey-hash HEX] [--max-nonce N]\n\n"
         << "Status: consensus layer live (X11 PoW, subsidy, oracle CoinParams).\n"
@@ -335,12 +344,20 @@ int run_selftest()
 // repeated targets). E1 establishes + maintains the connection only; the
 // ingest legs that would populate NodeCoinState are later slices, so the
 // fallback arm still serves templates even WITH the flag.
+// Fee/donation flags (README design, LTC-path port — see the mint wiring):
+//   dev_donation        --give-author (donation_percentage), default 0.1%
+//   node_owner_fee      -f/--fee (node_owner_fee), default 0
+//   node_owner_address  --node-owner-address (fee destination, P2PKH)
+//   redistribute_mode   --redistribute (pplns/fee/boost/donate)
 int run_node(bool testnet, const std::string& rpc_endpoint,
              const std::string& rpc_conf_path, const std::string& submit_hex,
              const PeeringConfig& peer,
              const std::string& stratum_host, uint16_t stratum_port,
              const std::vector<NetService>& coin_p2p_targets,
-             bool embedded_utxo)
+             bool embedded_utxo,
+             double dev_donation, double node_owner_fee,
+             const std::string& node_owner_address,
+             const std::string& redistribute_mode)
 {
     namespace io = boost::asio;
 
@@ -424,6 +441,16 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     for (const auto& c : peer.connects)  config.pool()->m_bootstrap_addrs.push_back(c);
 
     dash::Node p2p_node(&ioc, &config);
+
+    // ── Mint slice 3/3: consensus params + sharechain persistence ────────
+    // The tracker's CoinParams carry the X11 pow_func + targets every
+    // reception/mint verify consumes — MUST be set before any share is
+    // processed (an empty pow_func fails every share_init_verify).
+    const core::CoinParams mint_params = dash::make_coin_params(testnet);
+    p2p_node.tracker().m_coin_params = mint_params;
+    // LevelDB sharechain store under the SAME per-net subdir as the rest of
+    // the node state (bucket-1 isolation), loading any persisted shares.
+    p2p_node.init_storage(net_subdir);
 
     // --connect (connect-only, no --listen) suppresses the inbound listener,
     // matching report_peering() above.
@@ -590,6 +617,228 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         node_coin_state, std::move(dashd_fallback), std::move(stratum_submit_fn),
         core::stratum::StratumConfig{}, testnet);
 
+    // ── Mint slice 3/3: run-loop share minting wiring ─────────────────────
+    // ShareAccept -> build_mint_share -> tracker insert -> peer broadcast.
+    // All callbacks below run on THIS ioc (StratumServer shares it), so the
+    // node's IO-thread invariants (try_to_lock tracker access) hold.
+    {
+        dash::Node* node_ptr = &p2p_node;
+        auto mint_registry = std::make_shared<dash::mint::FrozenJobRegistry>();
+
+        // ── Fee policy (README flags, LTC sharechain-lane port) ───────────
+        // --give-author -> the share's donation field (oracle dev-fee channel;
+        // the donation output itself is ALWAYS emitted by the gentx, even at
+        // 0% — the dust-marker semantic is preserved by construction).
+        // --fee/--node-owner-address -> probabilistic identity substitution
+        // (consensus-safe). --redistribute -> broken-credential policy.
+        dash::mint::MintFeePolicy fee_policy;
+        fee_policy.donation_u16       = dash::mint::donation_percent_to_u16(dev_donation);
+        fee_policy.node_owner_fee_pct = node_owner_fee;
+        fee_policy.redistribute =
+            dash::mint::MintFeePolicy::parse_redistribute(redistribute_mode);
+        if (!node_owner_address.empty()) {
+            auto owner_script = core::address_to_script(node_owner_address);
+            if (dash::stratum::pubkey_hash_from_p2pkh(owner_script)) {
+                fee_policy.node_owner_script = std::move(owner_script);
+            } else {
+                std::cout << "[run] --node-owner-address is not a P2PKH DASH "
+                             "address -- node-owner fee/redistribute-to-owner "
+                             "DISABLED (shares are pubkey_hash-keyed)\n";
+            }
+        }
+        if (fee_policy.node_owner_fee_pct > 0.0 && fee_policy.node_owner_script.empty())
+            std::cout << "[run] --fee " << node_owner_fee << " set but no usable "
+                         "--node-owner-address -- node-owner fee DISABLED\n";
+        std::cout << "[run] fee policy: give-author=" << dev_donation
+                  << "% (donation_u16=" << fee_policy.donation_u16
+                  << ") node-owner-fee=" << node_owner_fee
+                  << "% (owner=" << (fee_policy.node_owner_script.empty() ? "unset" : node_owner_address)
+                  << ") redistribute=" << redistribute_mode << "\n";
+
+        // Best-share election: prev_share_hash for new jobs = the live tip
+        // think() elected (verified-work-first; ZERO with peers-but-no-
+        // verified-chain so we never mint on an unverified foreign chain).
+        work_source->set_best_share_hash_fn(
+            [node_ptr]() -> uint256 { return node_ptr->best_share_hash(); });
+
+        // Producer job: the stratum coinbase IS the producer share gentx
+        // (byte-parity with the mint-time rebuild by construction). The
+        // frozen per-job context is registered under its ref_hash.
+        //
+        // Per-(prev, payout, template) CACHE: sessions re-notify every ~1 s;
+        // a fresh random share_nonce per notify would make every job's bytes
+        // unique — defeating the session's shared-payload reuse AND churning
+        // the frozen-job registry past its eviction window. Rebuilding is
+        // deterministic given the same inputs, so within a 30 s TTL (the
+        // template staleness window) the SAME job is served.
+        struct ProducerJobCacheEntry {
+            dash::mint::ProducerJobBuild build;
+            uint256 coin_tip;
+            uint32_t height{0};
+            std::chrono::steady_clock::time_point at;
+        };
+        using ProducerJobKey = std::pair<uint256, std::vector<unsigned char>>;
+        auto job_cache = std::make_shared<
+            std::map<ProducerJobKey, ProducerJobCacheEntry>>();
+
+        work_source->set_producer_job_fn(
+            [node_ptr, mint_params, mint_registry, job_cache, fee_policy](
+                const uint256& prev_share_hash,
+                const std::vector<unsigned char>& payout_script,
+                const dash::coin::DashWorkData& wd)
+                -> std::optional<dash::stratum::DASHWorkSource::ProducerJob>
+            {
+                const auto now = std::chrono::steady_clock::now();
+                const ProducerJobKey key{prev_share_hash, payout_script};
+
+                // Cache hit: same sharechain tip, same coin template, fresh.
+                if (auto it = job_cache->find(key); it != job_cache->end()) {
+                    auto& e = it->second;
+                    if (e.coin_tip == wd.m_previous_block && e.height == wd.m_height
+                        && now - e.at < std::chrono::seconds(30)) {
+                        mint_registry->put(e.build.job.ref_hash, e.build.frozen);
+                        return e.build.job;
+                    }
+                    job_cache->erase(it);
+                }
+                // Lazy TTL sweep keeps the cache bounded across miner churn.
+                if (job_cache->size() > 128) {
+                    for (auto it = job_cache->begin(); it != job_cache->end();) {
+                        if (now - it->second.at > std::chrono::seconds(60))
+                            it = job_cache->erase(it);
+                        else
+                            ++it;
+                    }
+                }
+
+                auto guard = node_ptr->read_tracker();
+                if (!guard)
+                    return std::nullopt;   // compute thread busy — degrade this job
+
+                static std::mt19937 nonce_rng{std::random_device{}()};
+                const uint32_t share_nonce = static_cast<uint32_t>(nonce_rng());
+
+                // Fee policy: one roll per job build (p2pool's per-get_work
+                // fee roll); resolve the share identity + donation.
+                const uint32_t roll_x100 = static_cast<uint32_t>(nonce_rng() % 10000u);
+                auto identity = dash::mint::resolve_mint_identity(
+                    fee_policy, payout_script, roll_x100);
+                if (!identity) {
+                    static int redist_log = 0;
+                    if (redist_log++ % 50 == 0)
+                        LOG_WARNING << "[MINT] no usable share identity for this "
+                                       "miner (non-P2PKH credentials; redistribute="
+                                    << "policy declined) -- job degrades to the "
+                                       "non-producer coinbase";
+                    return std::nullopt;
+                }
+                if (identity->substituted) {
+                    static int fee_log = 0;
+                    if (fee_log++ % 50 == 0)
+                        LOG_INFO << "[MINT] share identity substituted by fee/"
+                                    "redistribute policy (node-owner)";
+                }
+
+                auto built = dash::mint::build_producer_job(
+                    guard->chain, mint_params, prev_share_hash,
+                    identity->payout_script, wd,
+                    static_cast<uint32_t>(std::time(nullptr)), share_nonce,
+                    identity->donation_u16, /*pool_tag=*/"c2pool");
+                if (!built)
+                    return std::nullopt;
+
+                mint_registry->put(built->job.ref_hash, built->frozen);
+                // Template txs -> m_known_txs so share relay can serve
+                // remember_tx for the share's new_transaction_hashes.
+                node_ptr->register_template_txs(wd.m_txs, wd.m_tx_hashes);
+
+                auto job = built->job;
+                (*job_cache)[key] = ProducerJobCacheEntry{
+                    std::move(*built), wd.m_previous_block, wd.m_height, now};
+                return job;
+            });
+
+        // The mint itself: registry lookup by the coinbase's OP_RETURN
+        // commitment, deterministic producer rebuild (X11 identity gate +
+        // pow<=target ban-safety gate inside), tracker insert + broadcast.
+        work_source->set_mint_share_fn(
+            [node_ptr, mint_params, mint_registry](
+                const dash::stratum::DASHWorkSource::MintShareInputs& in) -> uint256
+            {
+                if (in.ref_hash.IsNull()) {
+                    LOG_WARNING << "[MINT] solve on a non-producer job (zero ref) — "
+                                   "no sharechain credit (fail-closed)";
+                    return uint256();
+                }
+                auto frozen = mint_registry->get(in.ref_hash);
+                if (!frozen) {
+                    LOG_WARNING << "[MINT] no frozen job for ref="
+                                << in.ref_hash.GetHex().substr(0, 16)
+                                << " (evicted/foreign) — declined";
+                    return uint256();
+                }
+
+                std::optional<dash::producer::BuiltShare> built;
+                {
+                    auto guard = node_ptr->read_tracker();
+                    if (!guard) {
+                        LOG_WARNING << "[MINT] tracker busy — solve declined "
+                                       "(retry on next share)";
+                        return uint256();
+                    }
+                    built = dash::mint::mint_from_inputs(
+                        guard->chain, mint_params, in, *frozen);
+                }
+                if (!built) {
+                    LOG_WARNING << "[MINT] producer rebuild declined the solve "
+                                   "(identity/target gate) — NOT minted";
+                    return uint256();
+                }
+
+                dash::ShareType share;
+                share = new dash::DashShare(std::move(built->share));
+                const uint256 minted = node_ptr->add_local_share(share);
+                if (minted.IsNull()) {
+                    // Not inserted (busy/duplicate) — reclaim the allocation.
+                    share.invoke([](auto* obj) { delete obj; });
+                    return uint256();
+                }
+                LOG_INFO << "[MINT] share " << minted.GetHex().substr(0, 16)
+                         << " minted onto the sharechain (prev="
+                         << in.prev_share_hash.GetHex().substr(0, 16) << ")";
+                return minted;
+            });
+
+        // PPLNS fallback-coinbase weights (non-producer path): oracle-window
+        // tracker walk so even a degraded job pays the live PPLNS window.
+        // block_bits from the prev share's own header (same difficulty epoch);
+        // ref stays ZERO — a solve on this path can never mint (fail-closed).
+        work_source->set_pplns_weights_fn(
+            [node_ptr, mint_params](const uint256& prev_share_hash)
+                -> std::optional<dash::stratum::DASHWorkSource::PplnsWeights>
+            {
+                auto guard = node_ptr->read_tracker();
+                if (!guard)
+                    return std::nullopt;
+                if (prev_share_hash.IsNull() || !guard->chain.contains(prev_share_hash))
+                    return std::nullopt;
+                uint32_t block_bits = 0;
+                guard->chain.get_share(prev_share_hash).invoke([&](auto* obj) {
+                    block_bits = obj->m_min_header.m_bits;
+                });
+                return dash::mint::pplns_weights_for(
+                    guard->chain, mint_params, prev_share_hash, block_bits);
+            });
+
+        // New best share -> stratum work refresh (sessions re-notify).
+        p2p_node.set_on_best_share_changed(
+            [ws = work_source.get()]() { ws->bump_work_generation(); });
+
+        std::cout << "[run] mint wiring LIVE: ShareAccept -> producer rebuild -> "
+                     "tracker insert + broadcast (legacy v16 shares; PPLNS window "
+                     "walk bound)\n";
+    }
+
     if (stratum_port != 0) {
         stratum_server = std::make_unique<core::StratumServer>(
             ioc, stratum_host, stratum_port, work_source);
@@ -609,6 +858,24 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         std::cout << "[run] stratum disabled (no --stratum flag)\n";
     }
 
+    // ── Think loop: initial election + 15 s keep-fresh tick ───────────────
+    // Share arrivals trigger run_think() themselves (add_verified_shares);
+    // the periodic tick covers quiet stretches (retries deferred broadcasts,
+    // re-elects after verify continuations). Serialized by m_think_running.
+    boost::asio::post(ioc, [&p2p_node]() { p2p_node.run_think(); });
+    auto think_timer = std::make_shared<io::steady_timer>(ioc);
+    auto think_tick =
+        std::make_shared<std::function<void(const boost::system::error_code&)>>();
+    *think_tick = [&p2p_node, think_timer, think_tick](
+                      const boost::system::error_code& ec) {
+        if (ec) return;   // cancelled at shutdown
+        p2p_node.run_think();
+        think_timer->expires_after(std::chrono::seconds(15));
+        think_timer->async_wait(*think_tick);
+    };
+    think_timer->expires_after(std::chrono::seconds(15));
+    think_timer->async_wait(*think_tick);
+
     std::cout << "[run] run-loop up (Ctrl-C to stop); won blocks relay via the\n"
                  "[run] dashd-RPC submitblock fallback + the embedded sharechain P2P leg.\n";
     ioc.run();
@@ -617,6 +884,9 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // it references are still alive -- explicit reset keeps destruction order safe
     // (stratum_server was declared before them, so it would otherwise outlive them).
     stratum_server.reset();
+
+    // Flush pending sharechain persistence buffers (verified marks + removals).
+    p2p_node.shutdown_persistence();
 
     std::cout << "[run] run-loop stopped cleanly\n";
     return 0;
@@ -777,6 +1047,10 @@ int main(int argc, char** argv)
     std::string stratum_host = "0.0.0.0";      // --stratum [HOST:]PORT bind interface (default all)
     uint16_t    stratum_port = 0;              // 0 disables the Stratum accept-loop; --stratum sets it
     bool embedded_utxo = false;                // --embedded-utxo: arm the E2b UTXO/fee lane (opt-in)
+    double dev_donation = 0.1;                 // --give-author (donation_percentage; README default 0.1%)
+    double node_owner_fee = 0.0;               // -f / --fee (node_owner_fee; default 0)
+    std::string node_owner_address;            // --node-owner-address (fee destination)
+    std::string redistribute_mode = "pplns";   // --redistribute pplns|fee|boost|donate
     for (int i = 1; i < argc; ++i) {
         if (std::strcmp(argv[i], "--version") == 0) {
             std::cout << "c2pool-dash " << C2POOL_VERSION << "\n";
@@ -810,6 +1084,16 @@ int main(int argc, char** argv)
             coin_p2p_raw.emplace_back(argv[++i]);
         else if (std::strcmp(argv[i], "--embedded-utxo") == 0)
             embedded_utxo = true;
+        else if ((std::strcmp(argv[i], "--give-author") == 0 ||
+                  std::strcmp(argv[i], "--dev-donation") == 0) && i + 1 < argc)
+            dev_donation = std::strtod(argv[++i], nullptr);
+        else if ((std::strcmp(argv[i], "-f") == 0 ||
+                  std::strcmp(argv[i], "--fee") == 0) && i + 1 < argc)
+            node_owner_fee = std::strtod(argv[++i], nullptr);
+        else if (std::strcmp(argv[i], "--node-owner-address") == 0 && i + 1 < argc)
+            node_owner_address = argv[++i];
+        else if (std::strcmp(argv[i], "--redistribute") == 0 && i + 1 < argc)
+            redistribute_mode = argv[++i];
         else if (std::strcmp(argv[i], "--stratum") == 0 && i + 1 < argc) {
             // --stratum [HOST:]PORT -- bind a Stratum TCP listener for miners.
             // Bare PORT keeps the default 0.0.0.0 bind host (parse_listen SSOT).
@@ -877,7 +1161,8 @@ int main(int argc, char** argv)
         }
         return run_node(testnet, rpc_endpoint, rpc_conf_path, submit_hex, peer,
                         stratum_host, stratum_port, coin_p2p_targets,
-                        embedded_utxo);
+                        embedded_utxo, dev_donation, node_owner_fee,
+                        node_owner_address, redistribute_mode);
     }
     return run_selftest();
 }

--- a/src/impl/dash/mint_runloop.hpp
+++ b/src/impl/dash/mint_runloop.hpp
@@ -1,0 +1,509 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// ============================================================================
+// mint_runloop.hpp — DASH run-loop share minting (mint campaign slice 3/3).
+//
+// The wiring layer between the producer machinery (share_producer.hpp, slice 1;
+// share_producer_bind.hpp, slice 2) and the live --run pool: everything the
+// main_dash run-loop closures need to
+//   (a) serve a stratum coinbase whose bytes ARE the producer share gentx
+//       (build_producer_job -> DASHWorkSource::ProducerJob), so a solved header
+//       reproduces the exact bytes build_mint_share rebuilds at mint time —
+//       byte-parity by construction, not by parallel-implementation parity;
+//   (b) freeze the per-job producer context keyed by the ref_hash committed in
+//       the coinbase OP_RETURN (FrozenJobRegistry) and look it up at mint time
+//       (MintShareInputs.ref_hash, recovered from the coinb1 tail);
+//   (c) mint fail-closed: build_mint_share (slice 2, X11 identity gate) PLUS
+//       the explicit pow<=share-target guard (mint_from_inputs) so a share
+//       whose PoW does not meet its own committed m_bits target can NEVER be
+//       inserted/broadcast — the ban-safety line;
+//   (d) elect the best share (elect_best_share — the btc::NodeImpl policy,
+//       verified-work-first, ported as a pure function so it is KAT-able);
+//   (e) walk the tracker for the PPLNS fallback-coinbase weights
+//       (pplns_weights_for — ORACLE window: grandparent start, data.py:181).
+//
+// ORACLE: github.com/frstrtr/p2pool-dash (pre-v35 v16 lineage, min-proto 1700).
+// Everything minted here is the LEGACY v16 DashShare the live network speaks —
+// the v36 crossing is a SEPARATE later step and is deliberately absent.
+//
+// Header-only, fenced to src/impl/dash/. Nothing in src/core is touched; the
+// dashd-RPC fallback path is untouched.
+// ============================================================================
+
+#include "share_producer.hpp"
+#include "share_producer_bind.hpp"     // FrozenMintJob, build_mint_share
+#include "coinbase_builder.hpp"        // push_bip34_height (BIP34 scriptSig SSOT)
+#include "coin/rpc_data.hpp"           // dash::coin::DashWorkData
+#include "stratum/work_source.hpp"     // DASHWorkSource::{MintShareInputs, ProducerJob, PplnsWeights}
+
+#include <core/coin_params.hpp>
+#include <core/target_utils.hpp>
+#include <core/uint256.hpp>
+
+#include <cstring>
+#include <deque>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace dash::mint {
+
+// ── build_producer_job ───────────────────────────────────────────────────────
+//
+// Job-time producer pass: assemble the prospective share_info off the live
+// chain, compute its ref_hash, and serialize the FULL share gentx (nonce64
+// slot zeroed — the stratum extranonce1||extranonce2 slot). The returned
+// bytes/offset are what build_connection_coinbase splits into coinb1/coinb2,
+// so the coinbase a miner hashes is byte-identical to the gentx the mint-time
+// build_mint_share reproduces (same chain anchors, same frozen inputs — all
+// producer walks are backward from prev_share_hash and therefore deterministic
+// even if the chain has since grown).
+//
+// desired_target policy: params.max_target. The oracle clips desired into
+// [pre_target3/30, pre_target3] (data.py:141-145), so max_target clips to
+// pre_target3 — the pool's ACTUAL current share target. Per-miner pseudoshare
+// difficulty stays a session/vardiff concern; the share target the mint gate
+// enforces is the network one.
+struct ProducerJobBuild
+{
+    dash::stratum::DASHWorkSource::ProducerJob job;   // gentx bytes + split point + ref_hash + bits
+    dash::stratum::FrozenMintJob               frozen; // per-job mint context (registry payload)
+};
+
+template <typename ChainT>
+inline std::optional<ProducerJobBuild> build_producer_job(
+    ChainT& chain,
+    const core::CoinParams& params,
+    const uint256& prev_share_hash,
+    const std::vector<unsigned char>& payout_script,
+    const dash::coin::DashWorkData& wd,
+    uint32_t desired_timestamp,
+    uint32_t share_nonce,
+    uint16_t donation,
+    const std::string& pool_tag)
+{
+    // Miner identity: DASH sharechain payouts are P2PKH-keyed (share_data
+    // pubkey_hash). Non-P2PKH -> no producer job (the caller's non-producer
+    // coinbase path still serves work; it just cannot mint).
+    auto pubkey_hash = dash::stratum::pubkey_hash_from_p2pkh(payout_script);
+    if (!pubkey_hash)
+        return std::nullopt;
+    if (wd.m_bits == 0 || wd.m_height == 0)
+        return std::nullopt;   // no real template -> nothing to commit to
+
+    // share_data['coinbase'] — BIP34 height push + pool tag, capped at the
+    // verifier's 100-byte scriptSig bound (oracle work.py packs height+flags
+    // and slices [:100]). push_bip34_height is the same SSOT coinbase::build
+    // uses, so the share-gentx scriptSig matches dashd's bad-cb-height check.
+    std::vector<unsigned char> script_sig = dash::coinbase::push_bip34_height(wd.m_height);
+    for (char c : pool_tag) {
+        if (script_sig.size() >= 100) break;
+        script_sig.push_back(static_cast<unsigned char>(c));
+    }
+    if (script_sig.size() < 2 || script_sig.size() > 100)
+        return std::nullopt;   // verifier bound (share_check) — fail-closed
+
+    dash::producer::ProducerJobInputs pin;
+    pin.prev_share_hash    = prev_share_hash;
+    pin.coinbase_scriptSig = script_sig;
+    pin.coinbase_payload.assign(wd.m_coinbase_payload.begin(), wd.m_coinbase_payload.end());
+    pin.share_nonce        = share_nonce;
+    pin.pubkey_hash        = *pubkey_hash;
+    pin.subsidy            = wd.m_coinbase_value;
+    pin.donation           = donation;
+    pin.stale_info         = dash::StaleInfo::none;
+    pin.desired_version    = 16;                     // LEGACY v16 — the live lineage
+    pin.payment_amount     = wd.m_payment_amount;
+    for (const auto& p : wd.m_packed_payments) {
+        dash::PackedPayment pp;
+        pp.m_payee  = p.payee;
+        pp.m_amount = p.amount;
+        pin.packed_payments.push_back(std::move(pp));
+    }
+    pin.desired_tx_hashes  = wd.m_tx_hashes;
+    pin.desired_timestamp  = desired_timestamp;
+    pin.desired_target     = params.max_target;
+
+    auto info = dash::producer::generate_prospective_share_info(chain, params, pin);
+
+    // Cumulative PPLNS weights — the EXACT interior of producer::build_share
+    // (oracle window: start at the grandparent, max(0, min(height, RCL)-1)
+    // shares, capped at 65535*SPREAD*ata(block_target); data.py:181-184).
+    // build_mint_share re-runs this identically at mint time.
+    dash::producer::CumulativeWeights weights;
+    if (!info.prev_hash.IsNull() && chain.contains(info.prev_hash))
+    {
+        uint256 grandparent;
+        chain.get_share(info.prev_hash).invoke([&](auto* obj) {
+            grandparent = obj->m_prev_hash;
+        });
+        const int32_t height = chain.get_acc_height(info.prev_hash);
+        const int32_t max_shares = std::max<int32_t>(
+            0, std::min<int32_t>(height, static_cast<int32_t>(params.real_chain_length)) - 1);
+        const uint256 block_target = chain::bits_to_target(wd.m_bits);
+        const uint288 desired_weight =
+            chain::target_to_average_attempts(block_target) * params.spread * 65535u;
+        weights = dash::producer::get_cumulative_weights(
+            chain, grandparent, max_shares, desired_weight);
+    }
+
+    const uint256 ref_hash = dash::producer::compute_ref_hash(params, info);
+    dash::producer::GentxResult gentx =
+        dash::producer::build_gentx(info, weights, ref_hash, /*last_txout_nonce=*/0, params);
+
+    // nonce64 slot: the OP_RETURN tail is [0x6a 0x28 ref(32) nonce(8)] followed
+    // by locktime(4) + optional payload VarStr; build_gentx's prefix_len cuts
+    // exactly before the ref_hash, so the nonce slot is prefix_len + 32.
+    const size_t nonce_off = gentx.prefix_len + 32;
+    if (nonce_off + 8 > gentx.bytes.size())
+        return std::nullopt;                             // producer invariant broke
+    if (std::memcmp(gentx.bytes.data() + gentx.prefix_len, ref_hash.data(), 32) != 0)
+        return std::nullopt;                             // ref not where expected
+    for (size_t i = 0; i < 8; ++i)
+        if (gentx.bytes[nonce_off + i] != 0x00)
+            return std::nullopt;                         // slot must be zeroed
+
+    ProducerJobBuild out;
+    out.job.gentx_bytes    = std::move(gentx.bytes);
+    out.job.nonce64_offset = nonce_off;
+    out.job.ref_hash       = ref_hash;
+    out.job.share_bits     = info.bits;
+    out.job.share_max_bits = info.max_bits;
+
+    out.frozen.coinbase_scriptSig = std::move(script_sig);
+    out.frozen.coinbase_payload   = pin.coinbase_payload;
+    out.frozen.share_nonce        = share_nonce;
+    out.frozen.donation           = donation;
+    out.frozen.desired_version    = 16;
+    out.frozen.payment_amount     = pin.payment_amount;
+    out.frozen.packed_payments    = pin.packed_payments;
+    out.frozen.desired_tx_hashes  = pin.desired_tx_hashes;
+    out.frozen.desired_timestamp  = desired_timestamp;
+    out.frozen.desired_target     = pin.desired_target;
+    out.frozen.last_txout_nonce   = 0;                   // filled at mint from en1||en2
+    out.frozen.stale_info         = dash::StaleInfo::none;
+    // Freeze the job's share identity: the mint-time rebuild MUST use the
+    // exact identity this gentx committed to (see FrozenMintJob note) — with
+    // --fee substitution the submit-time username script differs from it.
+    out.frozen.payout_script_override = payout_script;
+    return out;
+}
+
+// ── Node-owner fee + dev fee + redistribute (README flag port) ───────────────
+//
+// Port of the LTC sharechain-lane semantics (main_ltc.cpp / web_server
+// set_node_fee_from_address):
+//   --give-author PCT  -> share_data['donation'] = round(65535*PCT/100) — the
+//       ORACLE dev-fee channel (p2pool work.py math.perfect_round). PPLNS
+//       weights already decay by it (att*(65535-donation)); the donation
+//       output is ALWAYS emitted by build_gentx (even at 0 — the dust
+//       marker), so --give-author 0 keeps the output present at the
+//       remainder-only value. NOTHING here changes the gentx layout.
+//   --fee PCT + --node-owner-address -> V36-compatible PROBABILISTIC identity
+//       substitution at share-creation: ~PCT% of minted shares carry the node
+//       owner's pubkey_hash instead of the miner's, so the owner accumulates
+//       PPLNS weight while every peer still computes identical coinbase
+//       outputs (consensus-safe — no new output, no format change).
+//   --redistribute MODE -> policy for miners whose stratum credentials do not
+//       decode to a P2PKH script (DASH shares are pubkey_hash-keyed):
+//       fee    -> mint under the node owner's identity;
+//       donate -> mint under the node owner's identity with donation=65535
+//                 (100% of the share's PPLNS weight decays to the donation
+//                 script — the DASH-conform expression of "100% to donation",
+//                 since a v16 share MUST carry some pubkey_hash);
+//       pplns/boost -> the LTC weighted-redistribution engine is NOT yet
+//                 ported to DASH; these decline the producer job (the
+//                 pre-existing fail-closed behavior, loudly logged).
+struct MintFeePolicy
+{
+    enum class Redistribute { PPLNS, FEE, BOOST, DONATE };
+
+    uint16_t donation_u16{66};                     // --give-author (default 0.1% -> 66)
+    double   node_owner_fee_pct{0.0};              // --fee (0 = off)
+    std::vector<unsigned char> node_owner_script;  // --node-owner-address (P2PKH), may be empty
+    Redistribute redistribute{Redistribute::PPLNS};
+
+    static Redistribute parse_redistribute(const std::string& s)
+    {
+        if (s == "fee")    return Redistribute::FEE;
+        if (s == "boost")  return Redistribute::BOOST;
+        if (s == "donate") return Redistribute::DONATE;
+        return Redistribute::PPLNS;
+    }
+};
+
+// round(65535 * pct / 100), clamped to the u16 field — the oracle's
+// math.perfect_round(65535*donation_percentage/100) (p2pool work.py).
+inline uint16_t donation_percent_to_u16(double pct)
+{
+    if (pct <= 0.0)   return 0;
+    if (pct >= 100.0) return 65535;
+    const double v = 65535.0 * pct / 100.0;
+    const uint64_t r = static_cast<uint64_t>(v + 0.5);
+    return r > 65535 ? 65535 : static_cast<uint16_t>(r);
+}
+
+// The share identity + donation a producer job freezes, after fee policy.
+struct ResolvedIdentity
+{
+    std::vector<unsigned char> payout_script;  // P2PKH the share is keyed on
+    uint16_t donation_u16{0};
+    bool substituted{false};                   // true when NOT the miner's own
+};
+
+// Deterministic core (KAT-able): the caller supplies the fee roll as
+// roll_x100 in [0, 10000) — one roll per job build, matching p2pool's
+// per-get_work fee roll. Substitution triggers when roll_x100 <
+// node_owner_fee_pct*100. Returns nullopt when no P2PKH identity is
+// available for this job (mint declines fail-closed).
+inline std::optional<ResolvedIdentity> resolve_mint_identity(
+    const MintFeePolicy& policy,
+    const std::vector<unsigned char>& miner_script,
+    uint32_t roll_x100)
+{
+    const bool miner_ok =
+        dash::stratum::pubkey_hash_from_p2pkh(miner_script).has_value();
+    const bool owner_ok =
+        dash::stratum::pubkey_hash_from_p2pkh(policy.node_owner_script).has_value();
+
+    if (miner_ok) {
+        if (policy.node_owner_fee_pct > 0.0 && owner_ok &&
+            static_cast<double>(roll_x100) < policy.node_owner_fee_pct * 100.0)
+            return ResolvedIdentity{policy.node_owner_script, policy.donation_u16, true};
+        return ResolvedIdentity{miner_script, policy.donation_u16, false};
+    }
+
+    // Broken/undecodable miner credentials -> redistribute policy.
+    switch (policy.redistribute) {
+    case MintFeePolicy::Redistribute::FEE:
+        if (owner_ok)
+            return ResolvedIdentity{policy.node_owner_script, policy.donation_u16, true};
+        return std::nullopt;
+    case MintFeePolicy::Redistribute::DONATE:
+        // 100%-donation share: weight fully decays to the donation script.
+        if (owner_ok)
+            return ResolvedIdentity{policy.node_owner_script, 65535, true};
+        return std::nullopt;
+    case MintFeePolicy::Redistribute::PPLNS:
+    case MintFeePolicy::Redistribute::BOOST:
+    default:
+        return std::nullopt;   // weighted redistribution engine: later port
+    }
+}
+
+// ── FrozenJobRegistry ────────────────────────────────────────────────────────
+//
+// Bounded ref_hash -> FrozenMintJob store. The ref_hash commits to the ENTIRE
+// prospective share_info (miner pubkey_hash included), so it uniquely names
+// the job context a solved coinbase belongs to. FIFO-evicted at `capacity`
+// (default 512 — comfortably above MAX_ACTIVE_JOBS * sessions on one node);
+// a miss at mint time is a fail-closed decline, never a guess.
+class FrozenJobRegistry
+{
+public:
+    explicit FrozenJobRegistry(size_t capacity = 512) : m_capacity(capacity) {}
+
+    void put(const uint256& ref_hash, dash::stratum::FrozenMintJob job)
+    {
+        std::lock_guard<std::mutex> lk(m_mutex);
+        auto it = m_jobs.find(ref_hash);
+        if (it != m_jobs.end()) {
+            it->second = std::move(job);   // same ref = same context; refresh
+            return;
+        }
+        m_jobs[ref_hash] = std::move(job);
+        m_order.push_back(ref_hash);
+        while (m_order.size() > m_capacity) {
+            m_jobs.erase(m_order.front());
+            m_order.pop_front();
+        }
+    }
+
+    std::optional<dash::stratum::FrozenMintJob> get(const uint256& ref_hash) const
+    {
+        std::lock_guard<std::mutex> lk(m_mutex);
+        auto it = m_jobs.find(ref_hash);
+        if (it == m_jobs.end())
+            return std::nullopt;
+        return it->second;
+    }
+
+    size_t size() const
+    {
+        std::lock_guard<std::mutex> lk(m_mutex);
+        return m_jobs.size();
+    }
+
+private:
+    mutable std::mutex m_mutex;
+    size_t m_capacity;
+    std::map<uint256, dash::stratum::FrozenMintJob> m_jobs;
+    std::deque<uint256> m_order;
+};
+
+// ── mint_from_inputs ─────────────────────────────────────────────────────────
+//
+// The mint-time transform: MintShareInputs + the registry-frozen job (with the
+// live extranonce nonce64 filled in) -> a fully-built, self-verified BuiltShare.
+// TWO fail-closed gates on top of slice 2's X11 identity gate:
+//   * build_mint_share declines unless the rebuilt share's m_hash reproduces
+//     the miner-solved header PoW exactly (byte-identity);
+//   * the pow<=target guard declines a share whose PoW does not meet its OWN
+//     committed m_bits target. Without it, a stratum share-bits race (job
+//     classified against a stale/easier share target) could mint a share that
+//     verifies structurally but fails the oracle's PoW check on peers — a
+//     PeerMisbehavingError BAN. This guard is the ban-safety line.
+template <typename ChainT>
+inline std::optional<dash::producer::BuiltShare> mint_from_inputs(
+    ChainT& chain,
+    const core::CoinParams& params,
+    const dash::stratum::DASHWorkSource::MintShareInputs& in,
+    dash::stratum::FrozenMintJob job)
+{
+    job.last_txout_nonce = in.last_txout_nonce;
+    auto built = dash::stratum::build_mint_share(chain, params, in, job);
+    if (!built)
+        return std::nullopt;
+
+    // Ban-safety: m_hash (== in.pow_hash, X11 of the solved header) must meet
+    // the share's own committed target.
+    const uint256 share_target = chain::bits_to_target(built->share.m_bits);
+    if (share_target.IsNull() || built->share.m_hash > share_target)
+        return std::nullopt;
+
+    return built;
+}
+
+// ── elect_best_share ─────────────────────────────────────────────────────────
+//
+// Best-share election policy — the btc::NodeImpl::best_share_hash() body
+// (src/impl/btc/node.cpp) ported as a pure function over the tracker so the
+// policy is KAT-able and the dash node method is a thin delegate. Mirrors
+// p2pool: think()'s best is authoritative WHEN it sits on the verified chain;
+// otherwise the heaviest verified head; with peers but no verified chain the
+// answer is ZERO (never build work on an unverifiable head — p2pool's
+// best_share_var None); a true genesis node (no peers) bootstraps from the
+// tallest raw head.
+template <typename TrackerT>
+inline uint256 elect_best_share(TrackerT& tracker,
+                                const uint256& think_best,
+                                bool has_peers)
+{
+    if (!think_best.IsNull() && tracker.verified.contains(think_best))
+        return think_best;
+
+    // Heaviest verified head by ACCUMULATED work (tracker view get_work =
+    // p2pool get_delta_to_last().work — cumulative from the chain tail; the
+    // per-share index.work would mis-elect a short heavy fork).
+    if (tracker.verified.size() > 0) {
+        uint256 best;
+        uint288 best_work;
+        bool first = true;
+        for (const auto& [head_hash, tail_hash] : tracker.verified.get_heads()) {
+            if (!tracker.verified.contains(head_hash))
+                continue;
+            const uint288 w = tracker.verified.get_work(head_hash);
+            if (first || w > best_work) {
+                best = head_hash;
+                best_work = w;
+                first = false;
+            }
+        }
+        if (!best.IsNull())
+            return best;
+    }
+
+    // Verified chain empty. With peers: refuse (ZERO) — never mint on an
+    // unverified foreign chain. Without peers: genesis bootstrap off the
+    // tallest raw head.
+    if (has_peers)
+        return uint256::ZERO;
+
+    if (tracker.chain.size() == 0)
+        return uint256::ZERO;
+
+    uint256 best;
+    int32_t best_height = -1;
+    for (const auto& [head_hash, tail_hash] : tracker.chain.get_heads()) {
+        auto h = tracker.chain.get_height(head_hash);
+        if (static_cast<int32_t>(h) > best_height) {
+            best = head_hash;
+            best_height = static_cast<int32_t>(h);
+        }
+    }
+    return best;
+}
+
+// ── pplns_weights_for ────────────────────────────────────────────────────────
+//
+// Tracker walk for the DASHWorkSource PplnsWeights seam — the NON-producer
+// (fallback) coinbase path, so a template built while the producer seam is
+// busy still pays the live PPLNS window. ORACLE window semantics
+// (data.py:181-184): the walk starts at prev's GRANDPARENT with
+// max(0, min(height, REAL_CHAIN_LENGTH)-1) shares, capped at
+// 65535*SPREAD*ata(block_target).
+//
+// The seam's weights are uint64; the oracle's are unbounded. A uniform
+// right-shift normalizes everything into range when the 288-bit totals exceed
+// 63 bits — proportions (and therefore payouts, which divide by total) are
+// preserved to within the shift truncation.
+//
+// ref_hash is ZERO by contract here: the fallback coinbase carries no
+// producer commitment, so a solve on it can never look up a frozen job and
+// the mint declines — fail-closed by construction (payouts stay correct; only
+// the sharechain credit needs the producer path).
+template <typename ChainT>
+inline std::optional<dash::stratum::DASHWorkSource::PplnsWeights>
+pplns_weights_for(ChainT& chain,
+                  const core::CoinParams& params,
+                  const uint256& prev_share_hash,
+                  uint32_t block_bits)
+{
+    if (prev_share_hash.IsNull() || !chain.contains(prev_share_hash) || block_bits == 0)
+        return std::nullopt;
+
+    uint256 grandparent;
+    chain.get_share(prev_share_hash).invoke([&](auto* obj) {
+        grandparent = obj->m_prev_hash;
+    });
+    const int32_t height = chain.get_acc_height(prev_share_hash);
+    const int32_t max_shares = std::max<int32_t>(
+        0, std::min<int32_t>(height, static_cast<int32_t>(params.real_chain_length)) - 1);
+    const uint256 block_target = chain::bits_to_target(block_bits);
+    const uint288 desired_weight =
+        chain::target_to_average_attempts(block_target) * params.spread * 65535u;
+
+    auto w = dash::producer::get_cumulative_weights(
+        chain, grandparent, max_shares, desired_weight);
+    if (w.total_weight.IsNull())
+        return std::nullopt;
+
+    // Normalize 288-bit weights into the seam's uint64 space: uniform shift
+    // until the grand total fits in 63 bits.
+    unsigned shift = 0;
+    {
+        uint288 t = w.total_weight;
+        uint288 limit;
+        limit.SetHex("7fffffffffffffff");   // 2^63 - 1
+        while (t > limit) { t = t >> 1; ++shift; }
+    }
+
+    dash::stratum::DASHWorkSource::PplnsWeights out;
+    out.total_weight = (w.total_weight >> shift).GetLow64();
+    if (out.total_weight == 0)
+        return std::nullopt;
+    for (const auto& [script, weight] : w.weights) {
+        const uint64_t v = (weight >> shift).GetLow64();
+        if (v > 0)
+            out.weights[script] = v;
+    }
+    out.ref_hash = uint256::ZERO;   // fallback path: no producer commitment
+    if (out.weights.empty())
+        return std::nullopt;
+    return out;
+}
+
+} // namespace dash::mint

--- a/src/impl/dash/node.cpp
+++ b/src/impl/dash/node.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 #include "node.hpp"
 #include "share.hpp"
+#include "mint_runloop.hpp"   // dash::mint::elect_best_share (election policy SSOT)
 
 #include <core/uint256.hpp>
 #include <core/common.hpp>
@@ -8,6 +9,8 @@
 #include <boost/asio/post.hpp>
 
 #include <atomic>
+#include <chrono>
+#include <cstring>
 #include <memory>
 #include <vector>
 
@@ -114,6 +117,7 @@ void NodeImpl::add_verified_shares(HandleSharesData& data, NetService addr)
 
         int32_t new_count = 0;
         int32_t dup_count = 0;
+        std::vector<c2pool::storage::SharechainStorage::ShareBatchEntry> db_batch;
         for (auto& share : data.m_items)
         {
             // Skip shares that failed phase-1 verification (hash still null).
@@ -128,7 +132,16 @@ void NodeImpl::add_verified_shares(HandleSharesData& data, NetService addr)
 
             m_tracker.add(share);
             ++new_count;
+
+            // Collect for the atomic LevelDB batch persist (btc parity:
+            // 8-byte version prefix + packed contents; committed after loop).
+            if (m_storage && m_storage->is_available())
+                collect_share_batch_entry(share, db_batch);
         }
+
+        // Commit all shares atomically (one WriteBatch — crash-safe).
+        if (!db_batch.empty() && m_storage && m_storage->is_available())
+            m_storage->store_shares_batch(db_batch);
 
         if (new_count > 0)
         {
@@ -138,9 +151,48 @@ void NodeImpl::add_verified_shares(HandleSharesData& data, NetService addr)
                      << "... (dup=" << dup_count
                      << " chain=" << m_tracker.chain.size() << ")";
         }
+
+        // Lock released at scope exit; think() trigger below runs lock-free.
+        if (new_count == 0)
+            return;
     }
-    // Scoring / best-share selection / persist / relay ride the think() and
-    // broadcast slices; slice .4 stops at tracker insertion.
+
+    // p2pool: set_best_share() after EVERY batch with new shares — think()
+    // verifies, scores heads, and elects m_best_share_hash so minted shares
+    // build on the live tip.
+    run_think();
+}
+
+// Serialize one share into a LevelDB batch entry (btc node.cpp parity:
+// [8B version LE][packed contents]; height slot carries absheight so the
+// load path's height-ordered scan replays parents before children).
+void NodeImpl::collect_share_batch_entry(
+    ShareType& share,
+    std::vector<c2pool::storage::SharechainStorage::ShareBatchEntry>& out)
+{
+    PackStream ps = pack(share);
+    auto span = ps.get_span();
+    uint64_t ver = share.version();
+    std::vector<uint8_t> versioned;
+    versioned.resize(8 + span.size());
+    std::memcpy(versioned.data(), &ver, 8);
+    std::memcpy(versioned.data() + 8,
+                reinterpret_cast<const uint8_t*>(span.data()), span.size());
+
+    share.invoke([&](auto* obj) {
+        uint256 target = chain::bits_to_target(obj->m_bits);
+        uint256 abswork_256;
+        std::copy(obj->m_abswork.begin(), obj->m_abswork.end(), abswork_256.begin());
+        c2pool::storage::SharechainStorage::ShareBatchEntry entry;
+        entry.hash = obj->m_hash;
+        entry.serialized_data = std::move(versioned);
+        entry.prev_hash = obj->m_prev_hash;
+        entry.height = obj->m_absheight;
+        entry.timestamp = obj->m_timestamp;
+        entry.work = abswork_256;
+        entry.target = target;
+        out.push_back(std::move(entry));
+    });
 }
 
 std::vector<dash::ShareType>
@@ -191,6 +243,427 @@ NodeImpl::handle_get_share(std::vector<uint256> hashes, uint64_t parents,
         LOG_INFO << "[Pool] Sending " << shares.size() << " shares to " << peer_addr.to_string();
 
     return shares;
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Run-loop mint slice (3/3) bodies — ports of the btc::NodeImpl prod
+// reference (src/impl/btc/node.cpp), reconciled to the DASH pool-node.
+// ════════════════════════════════════════════════════════════════════════════
+
+void NodeImpl::init_storage(const std::string& net_name)
+{
+    if (m_storage)
+        return;   // idempotent — run-loop calls once
+
+    m_storage = std::make_unique<c2pool::storage::SharechainStorage>(net_name);
+
+    // p2pool known_verified pattern: newly verified hashes buffer, flushed in
+    // batches (and at shutdown).
+    m_tracker.m_on_share_verified = [this](const uint256& hash) {
+        m_verified_flush_buf.push_back(hash);
+        if (m_verified_flush_buf.size() >= 50)
+            flush_verified_to_leveldb();
+    };
+
+    // Pruned shares → batched LevelDB deletion (flushed at shutdown; unflushed
+    // leftovers get pruned by the next startup's load_persisted_shares).
+    m_tracker.chain.on_removed([this](const uint256& hash) {
+        m_removal_flush_buf.push_back(hash);
+        if (m_removal_flush_buf.size() >= 200 && m_storage && m_storage->is_available()) {
+            m_storage->remove_shares_batch(m_removal_flush_buf);
+            m_removal_flush_buf.clear();
+        }
+    });
+
+    load_persisted_shares();
+}
+
+void NodeImpl::load_persisted_shares()
+{
+    if (!m_storage || !m_storage->is_available())
+        return;
+
+    auto all_hashes = m_storage->get_shares_by_height_range(0, UINT64_MAX);
+    if (all_hashes.empty()) {
+        LOG_INFO << "[Pool] No persisted DASH shares found in LevelDB";
+        return;
+    }
+
+    // Only the newest window is loaded (LevelDB accumulates forever).
+    const size_t keep = static_cast<size_t>(SharechainConfig::chain_length()) * 2 + 10;
+    const size_t total_in_db = all_hashes.size();
+    size_t skip = (total_in_db > keep) ? (total_in_db - keep) : 0;
+
+    int loaded = 0, skipped = 0;
+    std::vector<uint256> verified_hashes;
+    for (size_t i = skip; i < total_in_db; ++i)
+    {
+        const auto& hash = all_hashes[i];
+        std::vector<uint8_t> data;
+        core::ShareMetadata meta;
+        if (!m_storage->load_share(hash, data, meta) || data.size() < 8) {
+            ++skipped;
+            continue;
+        }
+        try {
+            uint64_t ver;
+            std::memcpy(&ver, data.data(), 8);
+            chain::RawShare rshare(ver, PackStream(
+                std::vector<unsigned char>(data.begin() + 8, data.end())));
+            auto share = dash::load_share(rshare, NetService{"database", 0});
+            // m_hash is not serialized — restore from the LevelDB key.
+            share.ACTION({ obj->m_hash = hash; });
+            if (m_chain->contains(share.hash())) {
+                ++skipped;
+                continue;
+            }
+            m_tracker.add(share);
+            ++loaded;
+            // Restore the cached X11 pow_hash (attempt_verify recomputes and
+            // re-caches when missing).
+            if (auto* idx = m_tracker.chain.get_index(hash); idx && !meta.pow_hash.IsNull())
+                idx->pow_hash = meta.pow_hash;
+            if (meta.is_verified)
+                verified_hashes.push_back(hash);
+        } catch (const std::exception& e) {
+            LOG_WARNING << "[Pool] failed to load persisted share "
+                        << hash.GetHex().substr(0, 16) << ": " << e.what();
+        }
+    }
+
+    // Pre-populate the verified subset (p2pool node.py known_verified); the
+    // height-ordered scan guarantees parent-before-child.
+    int pre_verified = 0;
+    for (const auto& vh : verified_hashes) {
+        if (m_tracker.chain.contains(vh) && !m_tracker.verified.contains(vh)) {
+            try {
+                m_tracker.verified.add(m_tracker.chain.get_share(vh));
+                ++pre_verified;
+            } catch (...) {}
+        }
+    }
+
+    LOG_INFO << "[Pool] Loaded " << loaded << " persisted DASH shares from LevelDB"
+             << " (db_total=" << total_in_db << " window=" << keep
+             << " pre_verified=" << pre_verified << " skipped=" << skipped << ")";
+
+    // Prune everything older than the loaded window.
+    if (skip > 0) {
+        std::vector<uint256> prune(all_hashes.begin(),
+                                   all_hashes.begin() + static_cast<long>(skip));
+        m_storage->remove_shares_batch(prune);
+        LOG_INFO << "[Pool] Pruned " << prune.size() << " old shares from LevelDB";
+    }
+}
+
+void NodeImpl::flush_verified_to_leveldb()
+{
+    if (m_verified_flush_buf.empty() || !m_storage || !m_storage->is_available())
+        return;
+    std::vector<std::pair<uint256, uint256>> hash_pow_pairs;
+    hash_pow_pairs.reserve(m_verified_flush_buf.size());
+    for (const auto& hash : m_verified_flush_buf) {
+        uint256 pow;
+        if (auto* idx = m_tracker.chain.get_index(hash))
+            pow = idx->pow_hash;
+        hash_pow_pairs.emplace_back(hash, pow);
+    }
+    m_storage->mark_shares_verified_with_pow(hash_pow_pairs);
+    m_verified_flush_buf.clear();
+}
+
+void NodeImpl::shutdown_persistence()
+{
+    flush_verified_to_leveldb();
+    if (!m_removal_flush_buf.empty() && m_storage && m_storage->is_available()) {
+        m_storage->remove_shares_batch(m_removal_flush_buf);
+        m_removal_flush_buf.clear();
+    }
+}
+
+void NodeImpl::run_think()
+{
+    // Serialize: only one think() in flight (compute pool has 1 thread).
+    if (m_think_running.exchange(true)) {
+        static int skip_log = 0;
+        if (skip_log++ % 20 == 0)
+            LOG_INFO << "[ASYNC-THINK] skipped — compute thread busy";
+        return;
+    }
+    if (!m_context) {
+        // Rig-free (KAT/standalone) node: no IO context to hop back to.
+        m_think_running.store(false);
+        return;
+    }
+
+    auto block_rel_height = m_block_rel_height_fn
+        ? m_block_rel_height_fn
+        : std::function<int32_t(uint256)>([](uint256) -> int32_t { return 0; });
+
+    boost::asio::post(m_think_pool, [this, block_rel_height]() {
+        m_compute_thread_id.store(std::this_thread::get_id(), std::memory_order_relaxed);
+
+        TrackerThinkResult result;
+        bool best_changed = false;
+        bool needs_continue = false;
+        int64_t think_ms = 0;
+
+        try {
+            std::unique_lock lock(m_tracker_mutex);   // exclusive — IO defers
+
+            // Bootstrap: no verified chain yet → verify everything in one
+            // pass (p2pool think() runs synchronously during initial sync).
+            const bool bootstrap = m_tracker.verified.size() == 0;
+            auto t0 = std::chrono::steady_clock::now();
+            result = m_tracker.think(block_rel_height,
+                                     /*previous_block=*/uint256(),
+                                     /*bits=*/0, bootstrap);
+            think_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - t0).count();
+
+            m_last_top5_heads = std::move(result.top5_heads);
+            if (!result.best.IsNull()) {
+                best_changed = (m_best_share_hash != result.best);
+                m_best_share_hash = result.best;
+            }
+            publish_snapshot();
+
+            needs_continue = m_tracker.m_think_needs_continue
+                          || m_tracker.m_think_walk_needs_continue;
+
+            flush_verified_to_leveldb();
+        } catch (const std::exception& e) {
+            LOG_ERROR << "run_think() failed on compute thread: " << e.what();
+        } catch (...) {
+            LOG_ERROR << "run_think() failed on compute thread: unknown error";
+        }
+        // ── exclusive lock released ──
+
+        LOG_INFO << "[ASYNC-THINK] compute done in " << think_ms << "ms"
+                 << " best_changed=" << best_changed
+                 << " needs_continue=" << needs_continue
+                 << " bads=" << result.bad_peer_addresses.size()
+                 << " desired=" << result.desired.size();
+
+        boost::asio::post(*m_context, [this, result = std::move(result),
+                                       best_changed, needs_continue]() {
+            // Peers that fed unverifiable shares: LOG ONLY for now — the DASH
+            // node carries no ban list yet (honest gap; the reception slice's
+            // error() close still applies to protocol violations).
+            for (const auto& bad_addr : result.bad_peer_addresses)
+                LOG_WARNING << "[think] peer provided unverifiable shares: "
+                            << bad_addr.to_string();
+
+            // Desired-share download (p2pool node.py download loop) is NOT yet
+            // ported to the DASH node — log the gap loudly instead of silently
+            // dropping it. Reception can still serve peers (handle_get_share);
+            // filling OUR gaps from peers rides the download slice.
+            if (!result.desired.empty()) {
+                static int desired_log = 0;
+                if (desired_log++ % 20 == 0)
+                    LOG_WARNING << "[think] " << result.desired.size()
+                                << " desired share(s) not requested — the DASH "
+                                   "share-download leg is a later slice";
+            }
+
+            if (best_changed) {
+                LOG_INFO << "[ASYNC-THINK] best=" << m_best_share_hash.GetHex().substr(0, 16)
+                         << " — refreshing work + re-advertising";
+                if (m_on_best_share_changed)
+                    m_on_best_share_changed();
+                // Re-announce our head so peers pull it (btc ROOT-2 parity).
+                broadcast_share(m_best_share_hash);
+            }
+
+            drain_pending_adds();
+
+            m_think_running.store(false);
+
+            if (needs_continue)
+                boost::asio::post(*m_context, [this]() { run_think(); });
+        });
+    });
+}
+
+void NodeImpl::drain_pending_adds()
+{
+    if (m_pending_adds.empty())
+        return;
+    auto pending = std::move(m_pending_adds);
+    m_pending_adds.clear();
+    LOG_INFO << "[ASYNC-THINK] draining " << pending.size() << " deferred share batch(es)";
+    for (auto& batch : pending)
+        add_verified_shares(*batch.data, batch.addr);
+}
+
+uint256 NodeImpl::best_share_hash()
+{
+    return dash::mint::elect_best_share(m_tracker, m_best_share_hash, !m_peers.empty());
+}
+
+void NodeImpl::broadcast_share(const uint256& share_hash)
+{
+    if (share_hash.IsNull())
+        return;
+    // try_to_lock: never block the IO thread on the compute thread's exclusive
+    // lock — a deferred broadcast is picked up by the next think cycle.
+    std::shared_lock<std::shared_mutex> lock(m_tracker_mutex, std::try_to_lock);
+    if (!lock.owns_lock()) {
+        static int defer_log = 0;
+        if (defer_log++ % 50 == 0)
+            LOG_INFO << "[broadcast_share] tracker busy — deferring "
+                     << share_hash.GetHex().substr(0, 16);
+        return;
+    }
+
+    if (!m_chain->contains(share_hash))
+        return;
+
+    // Walk back up to 5 shares, collecting the not-yet-broadcast ones.
+    std::vector<uint256> to_send;
+    int32_t height = m_chain->get_height(share_hash);
+    int32_t walk = std::min(height, 5);
+    for (auto [hash, data] : m_chain->get_chain(share_hash, walk)) {
+        if (m_shared_share_hashes.count(hash))
+            break;
+        m_shared_share_hashes.insert(hash);
+        to_send.push_back(hash);
+    }
+    if (to_send.empty())
+        return;
+
+    for (auto& [nonce, peer] : m_peers)
+        send_shares(peer, to_send);
+}
+
+void NodeImpl::send_shares(peer_ptr peer, const std::vector<uint256>& share_hashes)
+{
+    // Caller (broadcast_share) already holds a shared tracker lock; this
+    // method only READS chain + m_known_txs and writes to the peer socket.
+    std::vector<ShareType> shares;
+    for (const auto& hash : share_hashes) {
+        if (!m_chain->contains(hash))
+            continue;
+        for (auto [h, data] : m_chain->get_chain(hash, 1)) {
+            shares.push_back(data.share);
+            break;
+        }
+    }
+    if (shares.empty())
+        return;
+
+    // Forward the txs the peer needs BEFORE the shares (p2pool remember_tx
+    // protocol) — a share referencing unknown txs makes the receiving oracle
+    // node drop the connection.
+    std::set<uint256> needed_txs;
+    for (auto& share : shares) {
+        share.invoke([&](auto* obj) {
+            for (const auto& th : obj->m_new_transaction_hashes) {
+                if (!peer->m_remote_txs.count(th) && !peer->m_remembered_txs.count(th))
+                    needed_txs.insert(th);
+            }
+        });
+    }
+    if (!needed_txs.empty()) {
+        std::vector<uint256> known_hashes;
+        std::vector<coin::MutableTransaction> full_txs;
+        size_t missing = 0;
+        for (const auto& th : needed_txs) {
+            if (peer->m_remote_txs.count(th)) {
+                known_hashes.push_back(th);
+            } else if (auto it = m_known_txs.find(th); it != m_known_txs.end()) {
+                full_txs.emplace_back(it->second);
+            } else {
+                ++missing;
+            }
+        }
+        if (missing > 0)
+            LOG_WARNING << "[send_shares] " << missing << " referenced tx(s) not in "
+                           "m_known_txs — peer may drop these shares "
+                           "(register_template_txs gap?)";
+        if (!known_hashes.empty() || !full_txs.empty()) {
+            auto rtx_msg = message_remember_tx::make_raw(known_hashes, full_txs);
+            peer->write(std::move(rtx_msg));
+        }
+    }
+
+    // Pack and send via the message_shares wire codec (round-trip pinned by
+    // the mint-runloop KATs, so a re-serialized share is byte-identical).
+    std::vector<chain::RawShare> rshares;
+    rshares.reserve(shares.size());
+    for (auto& share : shares)
+        rshares.emplace_back(share.version(), pack(share));
+    auto shares_msg = message_shares::make_raw(rshares);
+    peer->write(std::move(shares_msg));
+
+    if (!needed_txs.empty()) {
+        std::vector<uint256> forget_vec(needed_txs.begin(), needed_txs.end());
+        auto ftx_msg = message_forget_tx::make_raw(forget_vec);
+        peer->write(std::move(ftx_msg));
+    }
+
+    LOG_INFO << "[Pool] Sent " << shares.size() << " share(s) (+"
+             << needed_txs.size() << " tx refs) to " << peer->addr().to_string();
+}
+
+uint256 NodeImpl::add_local_share(ShareType share)
+{
+    const uint256 hash = share.hash();
+    if (hash.IsNull())
+        return uint256::ZERO;
+
+    {
+        // Exclusive tracker lock, non-blocking (architectural rule): if the
+        // compute thread is mid-think, DECLINE the mint (fail-closed) — the
+        // miner keeps the pseudoshare credit, the next solve mints.
+        std::unique_lock lock(m_tracker_mutex, std::try_to_lock);
+        if (!lock.owns_lock()) {
+            LOG_WARNING << "[MINT] tracker busy — local share "
+                        << hash.GetHex().substr(0, 16) << " declined (retry on next solve)";
+            return uint256::ZERO;
+        }
+        if (m_chain->contains(hash)) {
+            LOG_WARNING << "[MINT] duplicate local share " << hash.GetHex().substr(0, 16);
+            return uint256::ZERO;
+        }
+
+        m_tracker.add(share);
+        // Local share: verify inline (p2pool: set_best_share → think verifies;
+        // the inline attempt keeps the just-mint tip usable immediately).
+        m_tracker.attempt_verify(hash);
+
+        if (m_storage && m_storage->is_available()) {
+            std::vector<c2pool::storage::SharechainStorage::ShareBatchEntry> db_batch;
+            collect_share_batch_entry(share, db_batch);
+            m_storage->store_shares_batch(db_batch);
+        }
+    }
+
+    // Lock released — relay + rescore (both take their own locks / post).
+    broadcast_share(hash);
+    run_think();
+    return hash;
+}
+
+void NodeImpl::register_template_txs(const std::vector<coin::Transaction>& txs,
+                                     const std::vector<uint256>& hashes)
+{
+    if (txs.size() != hashes.size()) {
+        LOG_WARNING << "[register_template_txs] size mismatch txs=" << txs.size()
+                    << " hashes=" << hashes.size() << " — skipped";
+        return;
+    }
+    // Drop the PREVIOUS template's leftovers that the new template no longer
+    // carries, then insert the new set — m_known_txs stays bounded by one
+    // template (plus reception-protocol remembered txs, which are peer-scoped).
+    std::set<uint256> new_set(hashes.begin(), hashes.end());
+    for (const auto& old_hash : m_template_tx_hashes) {
+        if (!new_set.count(old_hash))
+            m_known_txs.erase(old_hash);
+    }
+    for (size_t i = 0; i < txs.size(); ++i)
+        m_known_txs.insert_or_assign(hashes[i], txs[i]);
+    m_template_tx_hashes = std::move(new_set);
 }
 
 } // namespace dash

--- a/src/impl/dash/node.hpp
+++ b/src/impl/dash/node.hpp
@@ -41,6 +41,7 @@
 #include <memory>
 #include <mutex>
 #include <random>
+#include <set>
 #include <shared_mutex>
 #include <thread>
 #include <vector>
@@ -199,6 +200,22 @@ protected:
     // Buffer of pruned share hashes, batch-deleted from LevelDB after clean.
     std::vector<uint256> m_removal_flush_buf;
 
+    // ── Run-loop mint slice (3/3) state ─────────────────────────────────
+    // Best-share election result — published by run_think() on the compute
+    // thread under m_tracker_mutex (mirrors btc::NodeImpl::m_best_share_hash).
+    uint256 m_best_share_hash;
+    // De-dup set for broadcast_share (hashes already relayed to peers).
+    std::set<uint256> m_shared_share_hashes;
+    // Hashes of the CURRENT template's txs registered in m_known_txs by
+    // register_template_txs — replaced wholesale each registration so the
+    // known-tx pool stays bounded by one template.
+    std::set<uint256> m_template_tx_hashes;
+    // Fired on the IO thread when run_think() elects a new best share
+    // (p2pool: new_work_event) — main_dash binds the stratum work refresh.
+    std::function<void()> m_on_best_share_changed;
+    // Chain-relative block height for think() scoring; unbound -> zero fn.
+    std::function<int32_t(uint256)> m_block_rel_height_fn;
+
 public:
     // Default (rig-free) construction for tests/standalone: no io_context, the
     // share-getter requester is a no-op (reception slice supplies the real
@@ -276,10 +293,65 @@ public:
         // slice; post-handshake messages are dropped for now.
     }
 
-    // BaseNode pure-virtuals. Slice A provides minimal stubs so NodeImpl is a
-    // concrete, instantiable type for the KAT; the reception/handshake slice (B)
-    // replaces these with the real ping + version handshake.
-    void send_ping(peer_ptr /*peer*/) override { }
+    // Keep-alive ping (reception's ping handler is live; the sender keeps the
+    // peer's timeout timer from firing on the remote side).
+    void send_ping(peer_ptr peer) override
+    {
+        auto rmsg = dash::message_ping::make_raw();
+        peer->write(std::move(rmsg));
+    }
+
+    // Run-loop mint slice (3/3): SEND our version on every new connection —
+    // without it a p2pool-dash peer times out waiting for our handshake and
+    // drops the link (reception alone cannot hold a session). Advertises
+    // advertised_best_share() so peers pull our chain (btc ROOT-2 parity).
+    // INLINE (not node.cpp): connected() is virtual, so its body must be
+    // visible to every TU that emits the NodeImpl vtable — the link-deferred
+    // KAT targets instantiate NodeImpl without the node.cpp TU.
+    void connected(std::shared_ptr<core::Socket> socket) override
+    {
+        // BaseNode creates the peer + timeout timer; then OPEN the handshake.
+        // p2pool sends version from both sides on connectionMade — a silent
+        // side gets dropped by the remote's handshake timeout.
+        base_t::connected(socket);
+        auto it = m_connections.find(socket->get_addr());
+        if (it != m_connections.end())
+            send_version(it->second);
+    }
+
+    void send_version(peer_ptr peer)
+    {
+        auto rmsg = dash::message_version::make_raw(
+            SharechainConfig::MINIMUM_PROTOCOL_VERSION,  // oracle p2p VERSION (1700 lineage)
+            1,                                           // services
+            addr_t{1, peer->addr()},                     // addr_to (the remote)
+            addr_t{1, NetService{"0.0.0.0", SharechainConfig::p2p_port()}},  // addr_from
+            m_nonce,
+            std::string("c2pool"),
+            1,                                           // mode (always 1, legacy compat)
+            advertised_best_share());                    // head advert (raw pre-sync)
+        peer->write(std::move(rmsg));
+    }
+
+    /// Head advertised to peers: think()'s best when known, else the tallest
+    /// RAW chain head (btc ROOT-2: a pre-sync/genesis node must still let a
+    /// connecting peer learn it HAS a chain and pull it). Inline — reachable
+    /// from send_version() above.
+    uint256 advertised_best_share()
+    {
+        if (!m_best_share_hash.IsNull())
+            return m_best_share_hash;
+        uint256 best;
+        int32_t best_height = -1;
+        for (const auto& [head_hash, tail_hash] : m_tracker.chain.get_heads()) {
+            const auto h = static_cast<int32_t>(m_tracker.chain.get_height(head_hash));
+            if (h > best_height) {
+                best = head_hash;
+                best_height = h;
+            }
+        }
+        return best;
+    }
 
     // #646 min-protocol ratchet gate -- LIVE per-instance floor. Default-
     // constructed it holds the oracle accept-all floor (1700), so at the default
@@ -348,6 +420,59 @@ public:
     // verified batch (non-blocking lock; defers to m_pending_adds if the
     // compute thread holds the exclusive lock). Body in node.cpp.
     void add_verified_shares(HandleSharesData& data, NetService addr);
+
+    // ── Run-loop mint slice (3/3) surface — bodies in node.cpp ──────────
+    // Ports of the btc::NodeImpl prod reference (src/impl/btc/node.cpp),
+    // reconciled to the DASH pool-node. These make --run actually MINT:
+    // stratum ShareAccept -> add_local_share -> broadcast_share, with think()
+    // electing the best share the next job builds on.
+
+    /// Open the LevelDB sharechain store for `net_name`, wire the verified-
+    /// hash persistence + removal hooks, and load persisted shares into the
+    /// tracker. Call ONCE from the run-loop before serving work.
+    void init_storage(const std::string& net_name);
+    void load_persisted_shares();
+    /// Serialize one share into a LevelDB batch entry ([8B ver][contents]).
+    void collect_share_batch_entry(ShareType& share,
+        std::vector<c2pool::storage::SharechainStorage::ShareBatchEntry>& out);
+    void flush_verified_to_leveldb();
+    /// Flush pending persistence buffers (call at shutdown).
+    void shutdown_persistence();
+
+    /// Async best-chain selection: post tracker.think() to the compute
+    /// thread (exclusive lock), publish m_best_share_hash + snapshot, then
+    /// IO-phase: drain deferred share batches, fire on_best_share_changed,
+    /// re-broadcast the new head. Serialized via m_think_running.
+    void run_think();
+    void drain_pending_adds();
+
+    /// Verified-work-first best share (mint_runloop.hpp elect_best_share
+    /// policy — btc parity). ZERO with peers but no verified chain (never
+    /// mint on an unverified foreign chain); raw-head bootstrap on genesis.
+    /// (advertised_best_share — the peer-facing raw-head variant — is inline
+    /// above, next to send_version.)
+    uint256 best_share_hash();
+
+    /// Relay a share (and up to 4 un-broadcast ancestors) to all peers via
+    /// the message_shares wire codec (+ remember_tx/forget_tx for txs the
+    /// peer lacks). try_to_lock; deferred if the compute thread is busy.
+    void broadcast_share(const uint256& share_hash);
+    void send_shares(peer_ptr peer, const std::vector<uint256>& share_hashes);
+
+    /// Insert a locally-minted, ALREADY self-verified share into the tracker
+    /// (+ LevelDB persist + attempt_verify), then broadcast + run_think.
+    /// Returns the share hash, or ZERO when the tracker lock is busy or the
+    /// share is a duplicate (fail-closed: caller declines the mint).
+    uint256 add_local_share(ShareType share);
+
+    /// Register the current template's txs in m_known_txs so send_shares can
+    /// serve remember_tx for a minted share's new_transaction_hashes. The
+    /// previous template's leftovers are dropped (bounded by one template).
+    void register_template_txs(const std::vector<coin::Transaction>& txs,
+                               const std::vector<uint256>& hashes);
+
+    void set_on_best_share_changed(std::function<void()> fn) { m_on_best_share_changed = std::move(fn); }
+    void set_block_rel_height_fn(std::function<int32_t(uint256)> fn) { m_block_rel_height_fn = std::move(fn); }
 
     // Completes a pending async share request when a sharereply arrives.
     // Inline (mirrors dgb) so the reply-matcher plumbing needs no node.cpp.

--- a/src/impl/dash/share_producer_bind.hpp
+++ b/src/impl/dash/share_producer_bind.hpp
@@ -1,0 +1,49 @@
+// share_producer_bind.hpp -- slice 2/3 of the DASH mint campaign.
+//
+// Adapter that binds the producer-side share construction in
+// share_producer.hpp (build_share) to the node work-source found-share
+// seam DASHWorkSource::MintShareFn (work_source.hpp). This is the wire-in
+// half of the campaign: it turns a stratum-found solution (MintShareInputs)
+// into a fully-built, self-verified DashShare and returns its X11 share
+// hash for the run-loop to add to the ShareTracker + broadcast.
+//
+// SCOPE / SAFETY (mirrors #734 skeleton posture, integrator-approved):
+//   - header-only, lives entirely inside src/impl/dash/ (single-coin smoke
+//     gate preserved -- touches nothing shared);
+//   - KAT-gated: exercised only by test/impl/dash (see
+//     share_producer_bind_kat.cpp); NOT wired into --run here. The run-loop
+//     set_mint_share_fn(...) call is slice 3/3 (main_dash);
+//   - dashd RPC fallback path is untouched and stays.
+//
+// Mapping MintShareInputs -> ProducerJobInputs (build order):
+//   header_bytes(80)   -> SmallBlockHeaderType min_header   [deserialize]
+//   coinbase_bytes     -> coinbase_scriptSig + DIP4 payload [parse; reuse
+//                         the CbTx decode already in share_check.hpp]
+//   payout_script      -> pubkey_hash (uint160)             [extract P2PKH]
+//   subsidy            -> subsidy
+//   prev_share_hash    -> prev_share_hash
+//   pow_hash           -> cross-check vs build_share self-verify (X11)
+//   (payments/desired_tx set + desired_target come from the frozen job
+//    context the run-loop threads in slice 3/3; here they arrive via the
+//    ProducerJobInputs the KAT constructs.)
+//
+// STATUS: WIP skeleton -- signature + mapping doc landed; parse helpers +
+// build_share call + KAT are the next commit (build-verified before push).
+
+#pragma once
+
+#include <impl/dash/share_producer.hpp>
+#include <impl/dash/stratum/work_source.hpp>
+
+namespace dash::stratum {
+
+// TODO(slice 2/3): implement -- deserialize min_header, parse coinbase into
+// scriptSig+payload, derive pubkey_hash from payout_script, assemble
+// ProducerJobInputs, call dash::coin::build_share, cross-check pow_hash, and
+// return BuiltShare.share.m_hash. Bound via set_mint_share_fn in slice 3/3.
+//
+// template <typename ChainT>
+// DASHWorkSource::MintShareFn make_producer_mint_fn(
+//     ChainT& chain, const core::CoinParams& params);
+
+}  // namespace dash::stratum

--- a/src/impl/dash/share_producer_bind.hpp
+++ b/src/impl/dash/share_producer_bind.hpp
@@ -108,6 +108,14 @@ struct FrozenMintJob
     uint256  desired_target;                         // vardiff target (pre-clip)
     uint64_t last_txout_nonce{0};                    // per-connection coinbase nonce
     dash::StaleInfo stale_info{dash::StaleInfo::none};
+    // Share identity frozen at job time (slice 3/3 node-fee port). When
+    // non-empty this P2PKH script REPLACES MintShareInputs.payout_script in
+    // the rebuild -- the mechanism behind the consensus-safe --fee
+    // (probabilistic node-owner substitution) and --redistribute: the job's
+    // coinbase was built with THIS identity, so the mint must rebuild with
+    // the same one or the X11 identity gate would decline every
+    // fee-substituted solve. Empty -> identity from the submit's username.
+    std::vector<unsigned char> payout_script_override;
 };
 
 // -- build_mint_share --------------------------------------------------------
@@ -126,7 +134,10 @@ build_mint_share(ChainT& chain,
     if (!min_header)
         return std::nullopt;  // malformed 80-byte header
 
-    auto pubkey_hash = pubkey_hash_from_p2pkh(in.payout_script);
+    const std::vector<unsigned char>& identity_script =
+        job.payout_script_override.empty() ? in.payout_script
+                                           : job.payout_script_override;
+    auto pubkey_hash = pubkey_hash_from_p2pkh(identity_script);
     if (!pubkey_hash)
         return std::nullopt;  // non-canonical payout script
 

--- a/src/impl/dash/share_producer_bind.hpp
+++ b/src/impl/dash/share_producer_bind.hpp
@@ -1,49 +1,189 @@
 // share_producer_bind.hpp -- slice 2/3 of the DASH mint campaign.
 //
 // Adapter that binds the producer-side share construction in
-// share_producer.hpp (build_share) to the node work-source found-share
-// seam DASHWorkSource::MintShareFn (work_source.hpp). This is the wire-in
-// half of the campaign: it turns a stratum-found solution (MintShareInputs)
-// into a fully-built, self-verified DashShare and returns its X11 share
-// hash for the run-loop to add to the ShareTracker + broadcast.
+// share_producer.hpp (generate_prospective_share_info + build_share) to the
+// node work-source found-share seam DASHWorkSource::MintShareFn
+// (stratum/work_source.hpp). This is the wire-in half of the campaign: it
+// turns a stratum-found solution (MintShareInputs) plus the per-job context
+// frozen at getblocktemplate/notify time (FrozenMintJob) into a fully-built,
+// self-verified DashShare and returns its X11 share hash for the run-loop to
+// add to the ShareTracker + broadcast.
 //
-// SCOPE / SAFETY (mirrors #734 skeleton posture, integrator-approved):
+// SCOPE / SAFETY (mirrors #734 posture, integrator-approved slice-2 shape):
 //   - header-only, lives entirely inside src/impl/dash/ (single-coin smoke
-//     gate preserved -- touches nothing shared);
-//   - KAT-gated: exercised only by test/impl/dash (see
-//     share_producer_bind_kat.cpp); NOT wired into --run here. The run-loop
-//     set_mint_share_fn(...) call is slice 3/3 (main_dash);
+//     gate preserved -- touches nothing shared / nothing in src/core);
+//   - KAT-gated: exercised only by test/test_dash_share_producer_bind.cpp;
+//     NOT wired into --run here. The run-loop set_mint_share_fn(...) call is
+//     slice 3/3 (main_dash);
 //   - dashd RPC fallback path is untouched and stays.
 //
-// Mapping MintShareInputs -> ProducerJobInputs (build order):
-//   header_bytes(80)   -> SmallBlockHeaderType min_header   [deserialize]
-//   coinbase_bytes     -> coinbase_scriptSig + DIP4 payload [parse; reuse
-//                         the CbTx decode already in share_check.hpp]
-//   payout_script      -> pubkey_hash (uint160)             [extract P2PKH]
-//   subsidy            -> subsidy
-//   prev_share_hash    -> prev_share_hash
-//   pow_hash           -> cross-check vs build_share self-verify (X11)
-//   (payments/desired_tx set + desired_target come from the frozen job
-//    context the run-loop threads in slice 3/3; here they arrive via the
-//    ProducerJobInputs the KAT constructs.)
+// WHY the frozen job carries the coinbase pieces (not a reverse-parse):
+//   At mint time the producer already knows the canonical share_data
+//   ['coinbase'] scriptSig + DIP4 payload it handed to the miner at job
+//   assembly -- it does NOT reverse-parse the solved coinbase. MintShareInputs
+//   .coinbase_bytes is the reassembled coinbase (for the miner merkle/PoW);
+//   the canonical scriptSig/payload + payment/tx set + desired_target arrive
+//   via FrozenMintJob, which slice 3/3 threads from the live DASHWorkSource
+//   job and the KAT constructs directly.
 //
-// STATUS: WIP skeleton -- signature + mapping doc landed; parse helpers +
-// build_share call + KAT are the next commit (build-verified before push).
+// Mapping MintShareInputs (in) + FrozenMintJob (job) -> ProducerJobInputs:
+//   in.header_bytes(80) -> min_header            [parse_min_header_80, slice]
+//   in.prev_share_hash  -> prev_share_hash
+//   in.subsidy          -> subsidy
+//   in.payout_script    -> pubkey_hash           [P2PKH extract, fail-closed]
+//   job.coinbase_scriptSig / coinbase_payload / share_nonce / donation /
+//     desired_version / payment_amount / packed_payments / desired_tx_hashes /
+//     desired_timestamp / desired_target / stale_info -> carried through
+//   in.pow_hash         -> cross-check vs built.share.m_hash (X11), decline
+//                          the mint (null) on mismatch -> fail-closed.
 
 #pragma once
 
-#include <impl/dash/share_producer.hpp>
-#include <impl/dash/stratum/work_source.hpp>
+#include <functional>
+#include <optional>
+#include <vector>
+
+#include <core/pack_types.hpp>                     // PackStream
+#include <core/uint256.hpp>                        // uint160/uint256
+#include <impl/bitcoin_family/coin/base_block.hpp> // BlockHeaderType / SmallBlockHeaderType
+#include <impl/dash/share_producer.hpp>            // dash::producer::*
+#include <impl/dash/stratum/work_source.hpp>       // dash::stratum::DASHWorkSource
 
 namespace dash::stratum {
 
-// TODO(slice 2/3): implement -- deserialize min_header, parse coinbase into
-// scriptSig+payload, derive pubkey_hash from payout_script, assemble
-// ProducerJobInputs, call dash::coin::build_share, cross-check pow_hash, and
-// return BuiltShare.share.m_hash. Bound via set_mint_share_fn in slice 3/3.
+// -- parse_min_header_80 -----------------------------------------------------
+// Parse a canonical 80-byte block header (fixed 4-byte version + merkle_root)
+// into the SmallBlockHeaderType (version|prev|time|bits|nonce) the producer
+// consumes. Slices off m_merkle_root. Returns nullopt on a short/malformed
+// buffer (fail-closed). Pure.
+inline std::optional<bitcoin_family::coin::SmallBlockHeaderType>
+parse_min_header_80(const std::vector<unsigned char>& header_bytes)
+{
+    if (header_bytes.size() < 80)
+        return std::nullopt;
+    try {
+        PackStream ps(header_bytes);
+        bitcoin_family::coin::BlockHeaderType full;
+        ps >> full;
+        // SmallBlockHeaderType is the base subobject of BlockHeaderType; slicing
+        // off m_merkle_root yields exactly the small-header fields.
+        return static_cast<bitcoin_family::coin::SmallBlockHeaderType&>(full);
+    } catch (const std::exception&) {
+        return std::nullopt;  // truncated / unserialize failure -> fail-closed
+    }
+}
+
+// -- pubkey_hash_from_p2pkh --------------------------------------------------
+// Extract the 20-byte hash160 from a standard Dash P2PKH script
+// (76 a9 14 <20> 88 ac). Exact inverse of share_check.hpp::pubkey_hash_to_script2.
+// Returns nullopt on any non-canonical script (fail-closed: the mint declines
+// rather than credit a malformed / non-P2PKH payout). Pure.
+inline std::optional<uint160>
+pubkey_hash_from_p2pkh(const std::vector<unsigned char>& script)
+{
+    if (script.size() != 25)
+        return std::nullopt;
+    if (script[0] != 0x76 || script[1] != 0xa9 || script[2] != 0x14 ||
+        script[23] != 0x88 || script[24] != 0xac)
+        return std::nullopt;
+    return uint160(std::vector<unsigned char>(script.begin() + 3, script.begin() + 23));
+}
+
+// -- FrozenMintJob -----------------------------------------------------------
+// The per-job context frozen at getblocktemplate/notify time and threaded into
+// the mint. Carries the ProducerJobInputs fields the found-solution
+// MintShareInputs does NOT itself carry. Slice 3/3 binds this from the live
+// DASHWorkSource job; the KAT constructs it directly.
+struct FrozenMintJob
+{
+    std::vector<unsigned char> coinbase_scriptSig;   // share_data['coinbase'], 2..100 bytes
+    std::vector<unsigned char> coinbase_payload;     // RAW DIP4 CbTx extra payload ('' -> none)
+    uint32_t share_nonce{0};                         // share_data['nonce']
+    uint16_t donation{0};                            // share_data['donation'] (--give-author)
+    uint64_t desired_version{16};                    // pre-v36 baseline
+    uint64_t payment_amount{0};                      // GBT masternode/superblock total
+    std::vector<dash::PackedPayment> packed_payments;  // GBT payment list (template order)
+    std::vector<uint256> desired_tx_hashes;          // GBT tx set (template order)
+    uint32_t desired_timestamp{0};                   // job time
+    uint256  desired_target;                         // vardiff target (pre-clip)
+    uint64_t last_txout_nonce{0};                    // per-connection coinbase nonce
+    dash::StaleInfo stale_info{dash::StaleInfo::none};
+};
+
+// -- build_mint_share --------------------------------------------------------
+// Pure transform: MintShareInputs + FrozenMintJob -> BuiltShare, or nullopt if
+// the header is malformed, the payout script is non-P2PKH, or the rebuilt share
+// X11 hash does not reproduce the solved header PoW hash (all fail-closed).
+// Deterministic; KAT-exercised.
+template <typename ChainT>
+inline std::optional<dash::producer::BuiltShare>
+build_mint_share(ChainT& chain,
+                 const core::CoinParams& params,
+                 const DASHWorkSource::MintShareInputs& in,
+                 const FrozenMintJob& job)
+{
+    auto min_header = parse_min_header_80(in.header_bytes);
+    if (!min_header)
+        return std::nullopt;  // malformed 80-byte header
+
+    auto pubkey_hash = pubkey_hash_from_p2pkh(in.payout_script);
+    if (!pubkey_hash)
+        return std::nullopt;  // non-canonical payout script
+
+    dash::producer::ProducerJobInputs pin;
+    pin.prev_share_hash    = in.prev_share_hash;
+    pin.coinbase_scriptSig = job.coinbase_scriptSig;
+    pin.coinbase_payload   = job.coinbase_payload;
+    pin.share_nonce        = job.share_nonce;
+    pin.pubkey_hash        = *pubkey_hash;
+    pin.subsidy            = in.subsidy;
+    pin.donation           = job.donation;
+    pin.stale_info         = job.stale_info;
+    pin.desired_version    = job.desired_version;
+    pin.payment_amount     = job.payment_amount;
+    pin.packed_payments    = job.packed_payments;
+    pin.desired_tx_hashes  = job.desired_tx_hashes;
+    pin.desired_timestamp  = job.desired_timestamp;
+    pin.desired_target     = job.desired_target;
+
+    auto info = dash::producer::generate_prospective_share_info(chain, params, pin);
+    // check_pow=false: the stratum already vardiff-validated the solution; we do
+    // our own exact X11 identity cross-check below instead of a target compare.
+    auto built = dash::producer::build_share(
+        chain, params, info, *min_header, job.last_txout_nonce, /*check_pow=*/false);
+
+    // Integrity gate: the rebuilt share must reproduce the miner-solved header.
+    // If the reassembled coinbase/merkle diverged, m_hash != pow_hash -> decline
+    // rather than mint a share that would not verify on peers.
+    if (built.share.m_hash != in.pow_hash)
+        return std::nullopt;
+
+    return built;
+}
+
+// -- make_producer_mint_fn ---------------------------------------------------
+// Bind build_mint_share into a DASHWorkSource::MintShareFn. The job-context
+// provider yields the FrozenMintJob for the template the solution belongs to
+// (slice 3/3 supplies it from the live work source; the KAT supplies a fixed
+// closure). Returns the minted share hash, or NULL uint256 when the mint is
+// declined (fail-closed branch; slice 3/3 logs the reason).
 //
-// template <typename ChainT>
-// DASHWorkSource::MintShareFn make_producer_mint_fn(
-//     ChainT& chain, const core::CoinParams& params);
+// NOTE: minting into the ShareTracker + peer broadcast is the run-loop job
+// (slice 3/3); this adapter only produces the verified share + its hash.
+template <typename ChainT>
+inline DASHWorkSource::MintShareFn make_producer_mint_fn(
+    ChainT& chain,
+    const core::CoinParams& params,
+    std::function<FrozenMintJob(const DASHWorkSource::MintShareInputs&)> job_provider)
+{
+    return [&chain, &params, job_provider = std::move(job_provider)](
+               const DASHWorkSource::MintShareInputs& in) -> uint256 {
+        FrozenMintJob job = job_provider(in);
+        auto built = build_mint_share(chain, params, in, job);
+        if (!built)
+            return uint256();  // declined / deferred -- null share hash
+        return built->share.m_hash;
+    };
+}
 
 }  // namespace dash::stratum

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -348,6 +348,80 @@ core::stratum::CoinbaseResult DASHWorkSource::build_connection_coinbase(
     auto wd = cached_work();
     if (!wd) return {};   // no template -> no job (session retries)
 
+    // Shared frozen-snapshot tail: branches + tx set from the SAME wd the
+    // coinbase was built over, so the session's job merkle always matches the
+    // block body assembled at submit time. Used by BOTH coinbase paths below.
+    auto freeze_snapshot = [&](core::stratum::CoinbaseResult& out,
+                               const uint256& ref_hash) {
+        out.snapshot.subsidy             = wd->m_coinbase_value;
+        out.snapshot.frozen_ref.ref_hash = ref_hash;
+        if (!wd->m_tx_hashes.empty()) {
+            std::vector<uint256> leaves;
+            leaves.reserve(1 + wd->m_tx_hashes.size());
+            leaves.push_back(uint256::ZERO);
+            leaves.insert(leaves.end(), wd->m_tx_hashes.begin(), wd->m_tx_hashes.end());
+            auto raw = dash::coinbase::merkle_branches_raw(leaves);
+            out.snapshot.frozen_ref.frozen_merkle_branches = raw;
+            out.snapshot.merkle_branches = dash::coinbase::merkle_branches_hex(raw);
+        }
+        out.snapshot.tx_data = std::make_shared<const std::vector<std::string>>(
+            wd->m_tx_data_hex);
+    };
+
+    // ── Producer path (slice 3/3, run-loop mint) ─────────────────────────
+    // When bound, the stratum coinbase IS the producer share gentx: split
+    // verbatim around the zeroed nonce64 slot. Byte-parity with the mint-time
+    // rebuild holds by construction — there is exactly ONE gentx serializer
+    // on this path (producer::build_gentx). On nullopt/throw the non-producer
+    // path below serves a block-valid coinbase (mint declines fail-closed).
+    {
+        ProducerJobFn pfn;
+        {
+            std::lock_guard<std::mutex> lk(producer_job_mutex_);
+            pfn = producer_job_fn_;
+        }
+        if (pfn) {
+            try {
+                if (auto pj = pfn(prev_share_hash, payout_script, *wd)) {
+                    if (pj->nonce64_offset + 8 <= pj->gentx_bytes.size()) {
+                        core::stratum::CoinbaseResult out;
+                        std::span<const unsigned char> b1(
+                            pj->gentx_bytes.data(), pj->nonce64_offset);
+                        std::span<const unsigned char> b2(
+                            pj->gentx_bytes.data() + pj->nonce64_offset + 8,
+                            pj->gentx_bytes.size() - pj->nonce64_offset - 8);
+                        out.coinb1 = HexStr(b1);
+                        out.coinb2 = HexStr(b2);
+                        freeze_snapshot(out, pj->ref_hash);
+                        // Publish the share_info-committed target so the
+                        // mining_submit share gate matches the minted share's
+                        // own m_bits (the ban-safety alignment).
+                        // set_share_target only stores atomics; const_cast is
+                        // safe here (build_connection_coinbase is const by
+                        // interface contract, the target publish is a relaxed
+                        // atomic store).
+                        if (pj->share_bits != 0)
+                            const_cast<DASHWorkSource*>(this)->set_share_target(
+                                pj->share_bits, pj->share_max_bits);
+                        return out;
+                    }
+                    LOG_ERROR << "[DASH-STRATUM] producer job nonce64 offset out of "
+                                 "range -- falling back to non-producer coinbase";
+                } else {
+                    static int degrade_log = 0;
+                    if (degrade_log++ % 50 == 0)
+                        LOG_INFO << "[DASH-STRATUM] producer job unavailable "
+                                    "(tracker busy / non-P2PKH payout / no template) "
+                                    "-- serving non-producer coinbase (mint disabled "
+                                    "for this job)";
+                }
+            } catch (const std::exception& e) {
+                LOG_WARNING << "[DASH-STRATUM] producer job threw: " << e.what()
+                            << " -- serving non-producer coinbase";
+            }
+        }
+    }
+
     try {
         const core::CoinParams params = dash::make_coin_params(is_testnet_);
 
@@ -399,22 +473,8 @@ core::stratum::CoinbaseResult DASHWorkSource::build_connection_coinbase(
         out.coinb1 = std::move(split.coinb1_hex);
         out.coinb2 = std::move(split.coinb2_hex);
 
-        // Freeze the snapshot ATOMICALLY with the coinbase: branches + tx set
-        // come from the SAME wd the coinbase was built over, so the session's
-        // job merkle always matches the block body assembled at submit time.
-        out.snapshot.subsidy             = wd->m_coinbase_value;
-        out.snapshot.frozen_ref.ref_hash = ref_hash;
-        if (!wd->m_tx_hashes.empty()) {
-            std::vector<uint256> leaves;
-            leaves.reserve(1 + wd->m_tx_hashes.size());
-            leaves.push_back(uint256::ZERO);
-            leaves.insert(leaves.end(), wd->m_tx_hashes.begin(), wd->m_tx_hashes.end());
-            auto raw = dash::coinbase::merkle_branches_raw(leaves);
-            out.snapshot.frozen_ref.frozen_merkle_branches = raw;
-            out.snapshot.merkle_branches = dash::coinbase::merkle_branches_hex(raw);
-        }
-        out.snapshot.tx_data = std::make_shared<const std::vector<std::string>>(
-            wd->m_tx_data_hex);
+        // Freeze the snapshot ATOMICALLY with the coinbase (shared helper).
+        freeze_snapshot(out, ref_hash);
         return out;
     } catch (const std::exception& e) {
         // Builder invariant tripped (logged): serve no job rather than a
@@ -587,12 +647,29 @@ nlohmann::json DASHWorkSource::mining_submit(
         if (mint_fn) {
             MintShareInputs in;
             in.header_bytes.assign(header, header + 80);
-            in.coinbase_bytes  = std::move(coinbase);
             in.subsidy         = job->subsidy;
             in.prev_share_hash = job->prev_share_hash;
             in.merkle_branches = std::move(branch_hashes);
             in.payout_script   = core::address_to_script(username);
             in.pow_hash        = pow_hash;
+            // ref_hash: the coinb1/coinb2 split sits immediately after the
+            // 32-byte OP_RETURN ref_hash (before the 8B nonce64 slot), so the
+            // commitment is the coinb1 tail. Raw LE-internal bytes — embedded
+            // via ref_hash.data() at build time, recovered the same way.
+            if (coinb1_bytes.size() >= 32)
+                std::memcpy(in.ref_hash.begin(),
+                            coinb1_bytes.data() + coinb1_bytes.size() - 32, 32);
+            // nonce64 = LE u64 of extranonce1 || extranonce2 (4+4 bytes).
+            if (en1_bytes.size() + en2_bytes.size() == 8) {
+                unsigned char n64[8];
+                std::memcpy(n64, en1_bytes.data(), en1_bytes.size());
+                std::memcpy(n64 + en1_bytes.size(), en2_bytes.data(), en2_bytes.size());
+                uint64_t v = 0;
+                for (int i = 7; i >= 0; --i) v = (v << 8) | n64[i];
+                in.last_txout_nonce = v;
+            }
+            in.tx_data         = job->tx_data;
+            in.coinbase_bytes  = std::move(coinbase);
             try {
                 share_hash = mint_fn(in);
             } catch (const std::exception& e) {
@@ -693,6 +770,12 @@ void DASHWorkSource::set_pplns_weights_fn(PplnsWeightsFn fn)
 {
     std::lock_guard<std::mutex> lk(pplns_mutex_);
     pplns_weights_fn_ = std::move(fn);
+}
+
+void DASHWorkSource::set_producer_job_fn(ProducerJobFn fn)
+{
+    std::lock_guard<std::mutex> lk(producer_job_mutex_);
+    producer_job_fn_ = std::move(fn);
 }
 
 }  // namespace dash::stratum

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -102,6 +102,19 @@ public:
         std::vector<uint256>       merkle_branches; ///< parsed LE-internal branch hashes
         std::vector<unsigned char> payout_script;   ///< miner payout script (from username)
         uint256                    pow_hash;        ///< X11 PoW hash of header_bytes
+        // ── slice 3/3 (run-loop mint) additions ──────────────────────────
+        /// The PPLNS OP_RETURN commitment of the job's coinbase — recovered
+        /// from the coinb1 tail (the coinb1/coinb2 split sits immediately
+        /// after the 32-byte ref_hash, before the 8-byte nonce64 slot). The
+        /// run-loop keys its frozen-job registry on this; ZERO (non-producer
+        /// coinbase) can never match a frozen job -> mint declines fail-closed.
+        uint256                    ref_hash;
+        /// nonce64 the miner filled into the OP_RETURN slot: LE u64 of
+        /// extranonce1 || extranonce2 (4+4 bytes).
+        uint64_t                   last_txout_nonce{0};
+        /// Template tx hex frozen with the job (shared, may be null) — the
+        /// run-loop registers these for share relay (remember_tx serving).
+        std::shared_ptr<const std::vector<std::string>> tx_data;
     };
     /// Returns the minted share hash, or null-uint256 when the mint was
     /// declined/deferred (reason logged by the callee).
@@ -122,6 +135,30 @@ public:
     };
     using PplnsWeightsFn =
         std::function<std::optional<PplnsWeights>(const uint256& prev_share_hash)>;
+
+    /// Producer-built share gentx for a connection's job (slice 3/3). When the
+    /// run-loop binds set_producer_job_fn, build_connection_coinbase serves the
+    /// producer share gentx VERBATIM as the stratum coinbase (split around the
+    /// 8-byte nonce64 slot), so the bytes a miner hashes are byte-identical to
+    /// what the mint-time rebuild (build_mint_share) reproduces — the mint's
+    /// X11 identity gate then passes by construction. share_bits/max_bits are
+    /// the oracle-retargeted share target committed in the share_info; the
+    /// work source publishes them via set_share_target so the mining_submit
+    /// classification gate matches the share's own target.
+    struct ProducerJob {
+        std::vector<unsigned char> gentx_bytes;    ///< full share gentx, nonce64 slot zeroed
+        size_t                     nonce64_offset{0}; ///< first byte of the 8B nonce64 slot
+        uint256                    ref_hash;       ///< PPLNS OP_RETURN commitment (registry key)
+        uint32_t                   share_bits{0};  ///< share_info.bits (oracle retarget)
+        uint32_t                   share_max_bits{0}; ///< share_info.max_bits
+    };
+    /// Returns nullopt when no producer job can be built right now (tracker
+    /// busy, non-P2PKH payout, no template) — the coinbase then degrades to
+    /// the non-producer path (block-valid, mint declines fail-closed).
+    using ProducerJobFn = std::function<std::optional<ProducerJob>(
+        const uint256& prev_share_hash,
+        const std::vector<unsigned char>& payout_script,
+        const coin::DashWorkData& wd)>;
 
     /// Construct the DASH work source. Holds a NON-OWNING reference to the
     /// node-held coin-state (the embedded arm) and captures the REQUIRED dashd
@@ -227,6 +264,11 @@ public:
     /// While unbound, the coinbase uses the genesis single-miner split.
     void set_pplns_weights_fn(PplnsWeightsFn fn);
 
+    /// Wire the run-loop producer-job builder (slice 3/3). While unbound the
+    /// coinbase path is byte-unchanged (compute_dash_payouts + coinbase::build)
+    /// and share-target submissions cannot mint (loud fail-closed decline).
+    void set_producer_job_fn(ProducerJobFn fn);
+
 private:
     /// Template cache resolve: return the cached DashWorkData snapshot when it
     /// is still fresh (same work_generation AND younger than the staleness
@@ -270,6 +312,10 @@ private:
     // PPLNS weight walk (stage 4c multi-output path). Empty until wired.
     mutable std::mutex          pplns_mutex_;
     PplnsWeightsFn              pplns_weights_fn_;
+
+    // Producer-job builder (slice 3/3 run-loop mint). Empty until wired.
+    mutable std::mutex          producer_job_mutex_;
+    ProducerJobFn               producer_job_fn_;
 
     // Template cache (stage 4c): the last DashWorkData sourced through the
     // embedded/fallback selector, keyed on work_generation_ + a staleness TTL

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -380,10 +380,16 @@ if (BUILD_TESTING AND GTest_FOUND)
     # prospective share_info assembly, ref_hash/hash_link producers, oracle
     # retarget + gentx byte goldens. Compiled into this EXISTING allowlisted
     # target so the CI build.yml allowlist stays untouched (proven pattern).
+    # test_dash_mint_runloop.cpp (mint campaign slice 3): the run-loop mint
+    # pipeline -- producer job -> coinb1/coinb2 split -> real X11 solve ->
+    # mint_from_inputs -> tracker insert -> wire round-trip -> best-share
+    # election -> PPLNS oracle-window pin. Same allowlisted target (proven
+    # pattern), no build.yml change.
     add_executable(test_dash_share_hash_link
         test_dash_share_hash_link.cpp
         test_dash_share_producer.cpp
-        test_dash_share_producer_bind.cpp)
+        test_dash_share_producer_bind.cpp
+        test_dash_mint_runloop.cpp)
     target_link_libraries(test_dash_share_hash_link PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -382,7 +382,8 @@ if (BUILD_TESTING AND GTest_FOUND)
     # target so the CI build.yml allowlist stays untouched (proven pattern).
     add_executable(test_dash_share_hash_link
         test_dash_share_hash_link.cpp
-        test_dash_share_producer.cpp)
+        test_dash_share_producer.cpp
+        test_dash_share_producer_bind.cpp)
     target_link_libraries(test_dash_share_hash_link PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core

--- a/test/test_dash_mint_runloop.cpp
+++ b/test/test_dash_mint_runloop.cpp
@@ -1,0 +1,661 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// DASH run-loop mint KATs (mint campaign slice 3/3 — mint_runloop.hpp).
+//
+// Drives the FULL ShareAccept pipeline the --run wiring executes, KAT-style
+// (no sockets, no io_context):
+//   build_producer_job  -> coinb1/coinb2 split -> miner-side coinbase
+//   reassembly (extranonce1||extranonce2 fills the nonce64 slot) -> stratum
+//   merkle ascent -> 80-byte header -> REAL X11 solve (nonce search) ->
+//   MintShareInputs (ref_hash recovered from the coinb1 tail, exactly as
+//   mining_submit does) -> mint_from_inputs -> tracker insert -> get_shares
+//   walk -> message_shares codec round-trip -> best-share election -> PPLNS
+//   oracle-window pin.
+//
+// Coverage contract (task KATs):
+//   (1) a ShareAccept mints a DashShare that PASSES the in-tree verifier
+//       (build_share's mandatory self-verify) and whose m_hash IS the solved
+//       header's X11 PoW;
+//   (2) the minted share round-trips the message_shares payload codec
+//       byte-identically;
+//   (3) the minted share inserts into the tracker and appears in the
+//       get_shares chain walk;
+//   (4) best-share election picks the heaviest verified head (and refuses to
+//       elect with peers-but-no-verified-chain);
+//   (5) the PPLNS weights walk matches the ORACLE window (grandparent start,
+//       data.py:181) — pinned against a hand-computed window;
+//   (6) ban-safety: a solve whose PoW does not meet the share's own committed
+//       target is DECLINED by mint_from_inputs (never minted / broadcast);
+//   (7) the frozen-job registry declines unknown/evicted refs (fail-closed).
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/mint_runloop.hpp>
+#include <impl/dash/share_tracker.hpp>
+#include <impl/dash/share_chain.hpp>
+#include <impl/dash/share_check.hpp>       // pubkey_hash_to_script2
+#include <impl/dash/params.hpp>
+#include <impl/dash/crypto/hash_x11.hpp>
+#include <impl/dash/coinbase_builder.hpp>  // merkle_branches_raw / sha256d
+#include <impl/bitcoin_family/coin/base_block.hpp>
+
+#include <core/coin_params.hpp>
+#include <core/pack_types.hpp>
+#include <core/target_utils.hpp>
+#include <core/uint256.hpp>
+
+#include <cstring>
+#include <optional>
+#include <vector>
+
+namespace {
+
+using dash::mint::build_producer_job;
+using dash::mint::mint_from_inputs;
+using dash::mint::elect_best_share;
+using dash::mint::pplns_weights_for;
+using dash::mint::FrozenJobRegistry;
+using MintShareInputs = dash::stratum::DASHWorkSource::MintShareInputs;
+
+uint256 h256_tag(uint8_t tag)
+{
+    std::vector<unsigned char> v(32, 0x00);
+    v[0] = tag; v[31] = 0x5a;
+    return uint256(v);
+}
+
+uint160 h160_uniform(uint8_t tag)
+{
+    return uint160(std::vector<unsigned char>(20, tag));
+}
+
+// Easy-PoW params: identical to mainnet DASH params except max_target, so a
+// nonce search finds a REAL X11 solve in a few thousand hashes. The retarget
+// path (genesis: pre_target3 = max_target) then commits share bits derived
+// from this target — the exact code path a fresh pool runs.
+core::CoinParams easy_params()
+{
+    core::CoinParams p = dash::make_coin_params(false);
+    p.max_target.SetHex("00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    return p;
+}
+
+dash::coin::DashWorkData make_workdata(uint8_t prev_tag = 0x77)
+{
+    dash::coin::DashWorkData wd;
+    wd.m_version        = 536870912;
+    wd.m_previous_block = h256_tag(prev_tag);
+    wd.m_height         = 1000;
+    wd.m_coinbase_value = 500000000;         // 5 DASH
+    wd.m_bits           = 0x1b00ffffu;       // block target (much harder than shares)
+    wd.m_curtime        = 1700000005;
+    return wd;
+}
+
+// One merkle ascent step (LE-internal bytes), same fold as the work source.
+uint256 merkle_pair(const uint256& left, const uint256& right)
+{
+    unsigned char buf[64];
+    std::memcpy(buf,      left.data(),  32);
+    std::memcpy(buf + 32, right.data(), 32);
+    return dash::coinbase::sha256d(std::span<const unsigned char>(buf, 64));
+}
+
+// The full miner+mining_submit side of the pipeline for one job build:
+// reassemble the coinbase, ascend the branches, serialize the header, search
+// a REAL X11 solve against the job's committed share target, and produce the
+// MintShareInputs exactly as mining_submit does.
+struct SolvedJob
+{
+    MintShareInputs in;
+    dash::stratum::FrozenMintJob frozen;
+    bool solved{false};
+};
+
+SolvedJob solve_job(dash::ShareTracker& tracker,
+                    const core::CoinParams& params,
+                    const uint256& prev_share_hash,
+                    const uint160& miner_pkh,
+                    const dash::coin::DashWorkData& wd,
+                    uint32_t share_nonce,
+                    uint16_t donation = 0)
+{
+    SolvedJob out;
+    const auto payout_script = dash::pubkey_hash_to_script2(miner_pkh);
+
+    auto built = build_producer_job(tracker.chain, params, prev_share_hash,
+                                    payout_script, wd,
+                                    /*desired_timestamp=*/wd.m_curtime,
+                                    share_nonce, donation, "c2pool");
+    if (!built)
+        return out;
+    out.frozen = built->frozen;
+    const auto& job = built->job;
+
+    // coinb1/coinb2 split around the zeroed nonce64 slot (work source path).
+    std::vector<unsigned char> coinb1(job.gentx_bytes.begin(),
+                                      job.gentx_bytes.begin() + job.nonce64_offset);
+    std::vector<unsigned char> coinb2(job.gentx_bytes.begin() + job.nonce64_offset + 8,
+                                      job.gentx_bytes.end());
+    const std::vector<unsigned char> en1 = {0x01, 0x02, 0x03, 0x04};
+    const std::vector<unsigned char> en2 = {0x05, 0x06, 0x07, 0x08};
+
+    // Miner-side coinbase reassembly.
+    std::vector<unsigned char> coinbase;
+    coinbase.insert(coinbase.end(), coinb1.begin(), coinb1.end());
+    coinbase.insert(coinbase.end(), en1.begin(), en1.end());
+    coinbase.insert(coinbase.end(), en2.begin(), en2.end());
+    coinbase.insert(coinbase.end(), coinb2.begin(), coinb2.end());
+
+    // Stratum merkle ascent from the coinbase txid.
+    std::vector<uint256> branches;
+    if (!wd.m_tx_hashes.empty()) {
+        std::vector<uint256> leaves;
+        leaves.push_back(uint256::ZERO);
+        leaves.insert(leaves.end(), wd.m_tx_hashes.begin(), wd.m_tx_hashes.end());
+        branches = dash::coinbase::merkle_branches_raw(leaves);
+    }
+    uint256 merkle_root = dash::coinbase::sha256d(
+        std::span<const unsigned char>(coinbase.data(), coinbase.size()));
+    for (const auto& b : branches)
+        merkle_root = merkle_pair(merkle_root, b);
+
+    // 80-byte header + REAL X11 nonce search against the committed share target.
+    const uint256 share_target = chain::bits_to_target(job.share_bits);
+    bitcoin_family::coin::BlockHeaderType hdr;
+    hdr.m_version        = wd.m_version;
+    hdr.m_previous_block = wd.m_previous_block;
+    hdr.m_merkle_root    = merkle_root;
+    hdr.m_timestamp      = wd.m_curtime;
+    hdr.m_bits           = wd.m_bits;
+
+    uint256 pow_hash;
+    std::vector<unsigned char> header_bytes;
+    for (uint32_t nonce = 0; nonce < 2000000; ++nonce) {
+        hdr.m_nonce = nonce;
+        PackStream ps;
+        ps << hdr;
+        header_bytes.assign(
+            reinterpret_cast<const unsigned char*>(ps.data()),
+            reinterpret_cast<const unsigned char*>(ps.data()) + ps.size());
+        pow_hash = dash::crypto::hash_x11(header_bytes.data(), header_bytes.size());
+        if (pow_hash <= share_target) {
+            out.solved = true;
+            break;
+        }
+    }
+    if (!out.solved)
+        return out;
+
+    // MintShareInputs exactly as mining_submit populates them.
+    out.in.header_bytes    = header_bytes;
+    out.in.coinbase_bytes  = coinbase;
+    out.in.subsidy         = wd.m_coinbase_value;
+    out.in.prev_share_hash = prev_share_hash;
+    out.in.merkle_branches = branches;
+    out.in.payout_script   = payout_script;
+    out.in.pow_hash        = pow_hash;
+    std::memcpy(out.in.ref_hash.begin(), coinb1.data() + coinb1.size() - 32, 32);
+    uint64_t n64 = 0;
+    {
+        unsigned char cat[8];
+        std::memcpy(cat, en1.data(), 4);
+        std::memcpy(cat + 4, en2.data(), 4);
+        for (int i = 7; i >= 0; --i) n64 = (n64 << 8) | cat[i];
+    }
+    out.in.last_txout_nonce = n64;
+    return out;
+}
+
+// Mint one share onto the tracker (build + insert + verified.add), returning
+// its hash. Fails the calling test on any decline.
+uint256 mint_onto(dash::ShareTracker& tracker, const core::CoinParams& params,
+                  const uint256& prev, const uint160& miner, uint32_t share_nonce,
+                  uint8_t wd_prev_tag = 0x77)
+{
+    auto wd = make_workdata(wd_prev_tag);
+    auto solved = solve_job(tracker, params, prev, miner, wd, share_nonce);
+    EXPECT_TRUE(solved.solved);
+    if (!solved.solved) return uint256();
+    auto built = mint_from_inputs(tracker.chain, params, solved.in, solved.frozen);
+    EXPECT_TRUE(built.has_value());
+    if (!built) return uint256();
+    const uint256 hash = built->share.m_hash;
+    dash::ShareType st;
+    st = new dash::DashShare(built->share);
+    tracker.add(st);
+    EXPECT_TRUE(tracker.chain.contains(hash));
+    // Pre-populate verified (the load-path pattern) so election is exercised
+    // independently of attempt_verify's depth heuristics.
+    tracker.verified.add(tracker.chain.get_share(hash));
+    return hash;
+}
+
+}  // namespace
+
+// (1) The full ShareAccept pipeline mints a self-verified share whose m_hash
+//     IS the solved header's X11 PoW, and (3) it lands in the tracker +
+//     get_shares chain walk.
+TEST(DashMintRunloop, ShareAcceptMintsVerifiedShareIntoTracker)
+{
+    const auto params = easy_params();
+    dash::ShareTracker tracker;
+    tracker.m_coin_params = params;
+
+    auto wd = make_workdata();
+    auto solved = solve_job(tracker, params, uint256(), h160_uniform(0x22), wd, 7);
+    ASSERT_TRUE(solved.solved);
+
+    // Register the frozen job the way the run-loop does, then look it up by
+    // the ref recovered from the coinb1 tail — they must agree.
+    FrozenJobRegistry registry;
+    // (build_producer_job committed the ref into the gentx; the recovered
+    //  in.ref_hash is the registry key.)
+    registry.put(solved.in.ref_hash, solved.frozen);
+    auto frozen = registry.get(solved.in.ref_hash);
+    ASSERT_TRUE(frozen.has_value());
+
+    auto built = mint_from_inputs(tracker.chain, params, solved.in, *frozen);
+    ASSERT_TRUE(built.has_value());
+
+    // The share hash IS the solved header PoW (X11 identity), and the share
+    // passed build_share's MANDATORY in-tree self-verify to get here.
+    EXPECT_EQ(built->share.m_hash, solved.in.pow_hash);
+    EXPECT_EQ(built->ref_hash, solved.in.ref_hash);
+    EXPECT_EQ(built->share.m_last_txout_nonce, solved.in.last_txout_nonce);
+    EXPECT_EQ(built->share.m_bits != 0, true);
+    // Committed target honored (the ban-safety gate passed for the right reason).
+    EXPECT_TRUE(built->share.m_hash <= chain::bits_to_target(built->share.m_bits));
+
+    // Tracker insert + the get_shares walk (handle_get_share's exact read).
+    const uint256 hash = built->share.m_hash;
+    dash::ShareType st;
+    st = new dash::DashShare(built->share);
+    tracker.add(st);
+    ASSERT_TRUE(tracker.chain.contains(hash));
+    int seen = 0;
+    for (auto [h, data] : tracker.chain.get_chain(hash, 1)) {
+        EXPECT_EQ(h, hash);
+        EXPECT_EQ(data.share.hash(), hash);
+        ++seen;
+    }
+    EXPECT_EQ(seen, 1);
+}
+
+// (2) The minted share round-trips the message_shares payload codec
+//     (vector<chain::RawShare>) byte-identically.
+TEST(DashMintRunloop, MintedShareWireRoundTripByteIdentical)
+{
+    const auto params = easy_params();
+    dash::ShareTracker tracker;
+    tracker.m_coin_params = params;
+
+    auto wd = make_workdata();
+    auto solved = solve_job(tracker, params, uint256(), h160_uniform(0x33), wd, 9);
+    ASSERT_TRUE(solved.solved);
+    auto built = mint_from_inputs(tracker.chain, params, solved.in, solved.frozen);
+    ASSERT_TRUE(built.has_value());
+
+    dash::ShareType st;
+    st = new dash::DashShare(built->share);
+
+    // Serialize exactly as send_shares does.
+    PackStream contents = pack(st);
+    std::vector<unsigned char> original(
+        reinterpret_cast<const unsigned char*>(contents.data()),
+        reinterpret_cast<const unsigned char*>(contents.data()) + contents.size());
+    chain::RawShare rshare(st.version(), PackStream(original));
+
+    // Wire envelope: the message_shares payload is vector<RawShare>.
+    PackStream wire;
+    std::vector<chain::RawShare> shares_out{rshare};
+    wire << shares_out;
+
+    std::vector<chain::RawShare> shares_in;
+    wire >> shares_in;
+    ASSERT_EQ(shares_in.size(), 1u);
+    EXPECT_EQ(shares_in[0].type, 16u);
+
+    // Parse back through the reception loader and re-serialize: byte-identical.
+    auto reloaded = dash::load_share(shares_in[0], NetService{"kat", 0});
+    PackStream contents2 = pack(reloaded);
+    std::vector<unsigned char> reserialized(
+        reinterpret_cast<const unsigned char*>(contents2.data()),
+        reinterpret_cast<const unsigned char*>(contents2.data()) + contents2.size());
+    EXPECT_EQ(original, reserialized);
+
+    // And the reloaded share re-verifies to the SAME X11 share hash through
+    // the in-tree verifier (the exact check a receiving peer runs).
+    uint256 reverified;
+    reloaded.invoke([&](auto* obj) {
+        reverified = dash::share_init_verify(*obj, params, /*check_pow=*/false);
+    });
+    EXPECT_EQ(reverified, built->share.m_hash);
+}
+
+// (4) Best-share election: heaviest verified head wins; peers-but-no-verified
+//     chain refuses (ZERO); genesis (no peers) bootstraps from the raw head.
+TEST(DashMintRunloop, BestShareElectionPicksHeaviestVerifiedHead)
+{
+    const auto params = easy_params();
+    dash::ShareTracker tracker;
+    tracker.m_coin_params = params;
+
+    // Empty tracker: nothing to elect.
+    EXPECT_TRUE(elect_best_share(tracker, uint256(), false).IsNull());
+    // With peers and no verified chain: REFUSE (never mint on unverified).
+    EXPECT_EQ(elect_best_share(tracker, uint256(), true), uint256::ZERO);
+
+    // Fork A: two chained shares. Fork B: one share (different miner/nonce).
+    const uint256 a1 = mint_onto(tracker, params, uint256(),      h160_uniform(0x11), 1);
+    ASSERT_FALSE(a1.IsNull());
+    const uint256 a2 = mint_onto(tracker, params, a1,             h160_uniform(0x11), 2);
+    ASSERT_FALSE(a2.IsNull());
+    const uint256 b1 = mint_onto(tracker, params, uint256(),      h160_uniform(0x44), 3);
+    ASSERT_FALSE(b1.IsNull());
+    ASSERT_NE(a1, b1);
+
+    // Heaviest verified head = A2 (two shares of accumulated work vs one).
+    EXPECT_EQ(elect_best_share(tracker, uint256(), true), a2);
+    // A think-elected best that IS on the verified chain is authoritative.
+    EXPECT_EQ(elect_best_share(tracker, b1, true), b1);
+    // A think-elected best NOT on the verified chain falls back to heaviest.
+    EXPECT_EQ(elect_best_share(tracker, h256_tag(0xEE), true), a2);
+}
+
+// (5) PPLNS weights walk — ORACLE window pin: the walk starts at the
+//     GRANDPARENT of the share being built (data.py:181), so the direct
+//     parent's own weight is EXCLUDED and earlier shares' included.
+TEST(DashMintRunloop, PplnsWeightsMatchOracleWindow)
+{
+    const auto params = easy_params();
+    dash::ShareTracker tracker;
+    tracker.m_coin_params = params;
+
+    // Chain: g1 (miner A) <- g2 (miner B) <- g3 (miner C: the tip we build on).
+    const uint160 miner_a = h160_uniform(0xa1);
+    const uint160 miner_b = h160_uniform(0xb2);
+    const uint160 miner_c = h160_uniform(0xc3);
+    const uint256 g1 = mint_onto(tracker, params, uint256(), miner_a, 11);
+    ASSERT_FALSE(g1.IsNull());
+    const uint256 g2 = mint_onto(tracker, params, g1, miner_b, 12);
+    ASSERT_FALSE(g2.IsNull());
+    const uint256 g3 = mint_onto(tracker, params, g2, miner_c, 13);
+    ASSERT_FALSE(g3.IsNull());
+
+    uint32_t block_bits = 0;
+    tracker.chain.get_share(g3).invoke([&](auto* obj) {
+        block_bits = obj->m_min_header.m_bits;
+    });
+    auto w = pplns_weights_for(tracker.chain, params, g3, block_bits);
+    ASSERT_TRUE(w.has_value());
+
+    // Oracle window: start at g3's GRANDPARENT (g2's parent walk start = g2's
+    // prev == g1's child... i.e. prev(g3)=g2 -> grandparent walk starts at g2's
+    // prev = g1? NO — grandparent of the share BEING BUILT (child of g3) is g2.
+    // pplns_weights_for(prev=g3) starts the walk at g3's prev_hash = g2, per
+    // data.py:181 (previous_share.previous_share_hash with previous_share=g3).
+    const auto script_a = dash::pubkey_hash_to_script2(miner_a);
+    const auto script_b = dash::pubkey_hash_to_script2(miner_b);
+    const auto script_c = dash::pubkey_hash_to_script2(miner_c);
+
+    // g3 (the tip itself) is EXCLUDED — its miner has no weight yet.
+    EXPECT_EQ(w->weights.count(script_c), 0u);
+    // g2 and g1 are in the window.
+    ASSERT_EQ(w->weights.count(script_b), 1u);
+    ASSERT_EQ(w->weights.count(script_a), 1u);
+
+    // Hand-computed pin (donation 0): weight(share) = ata(target(bits))*65535,
+    // total = sum. All three shares carry the same bits here (same retarget
+    // inputs), so A and B carry EQUAL weight and total = 2 * each.
+    EXPECT_EQ(w->weights[script_a], w->weights[script_b]);
+    EXPECT_EQ(w->total_weight, w->weights[script_a] + w->weights[script_b]);
+    EXPECT_GT(w->total_weight, 0u);
+    // Fallback-path contract: no producer commitment.
+    EXPECT_TRUE(w->ref_hash.IsNull());
+}
+
+// (6) Ban-safety: a structurally-consistent solve whose PoW does NOT meet the
+//     share's own committed target is DECLINED (this is what keeps a stratum
+//     share-bits race from minting a peer-bannable share).
+TEST(DashMintRunloop, DeclinesSolveBelowCommittedTarget)
+{
+    // REAL mainnet params: the committed share target is astronomically hard,
+    // so an arbitrary-nonce header cannot meet it — but the byte identity
+    // still holds, isolating the decline to the pow<=target gate.
+    const core::CoinParams params = dash::make_coin_params(false);
+    dash::ShareTracker tracker;
+    tracker.m_coin_params = params;
+
+    auto wd = make_workdata();
+    const uint160 miner = h160_uniform(0x55);
+    const auto payout_script = dash::pubkey_hash_to_script2(miner);
+    auto built_job = build_producer_job(tracker.chain, params, uint256(),
+                                        payout_script, wd, wd.m_curtime,
+                                        21, 0, "c2pool");
+    ASSERT_TRUE(built_job.has_value());
+    const auto& job = built_job->job;
+
+    std::vector<unsigned char> coinb1(job.gentx_bytes.begin(),
+                                      job.gentx_bytes.begin() + job.nonce64_offset);
+    std::vector<unsigned char> coinb2(job.gentx_bytes.begin() + job.nonce64_offset + 8,
+                                      job.gentx_bytes.end());
+    std::vector<unsigned char> coinbase;
+    coinbase.insert(coinbase.end(), coinb1.begin(), coinb1.end());
+    for (unsigned char c : {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08})
+        coinbase.push_back(c);
+    coinbase.insert(coinbase.end(), coinb2.begin(), coinb2.end());
+
+    bitcoin_family::coin::BlockHeaderType hdr;
+    hdr.m_version        = wd.m_version;
+    hdr.m_previous_block = wd.m_previous_block;
+    hdr.m_merkle_root    = dash::coinbase::sha256d(
+        std::span<const unsigned char>(coinbase.data(), coinbase.size()));
+    hdr.m_timestamp      = wd.m_curtime;
+    hdr.m_bits           = wd.m_bits;
+    hdr.m_nonce          = 0x12345678u;   // arbitrary — will not meet the target
+
+    PackStream ps;
+    ps << hdr;
+
+    MintShareInputs in;
+    in.header_bytes.assign(
+        reinterpret_cast<const unsigned char*>(ps.data()),
+        reinterpret_cast<const unsigned char*>(ps.data()) + ps.size());
+    in.coinbase_bytes  = coinbase;
+    in.subsidy         = wd.m_coinbase_value;
+    in.prev_share_hash = uint256();
+    in.payout_script   = payout_script;
+    in.pow_hash        = dash::crypto::hash_x11(in.header_bytes.data(),
+                                                in.header_bytes.size());
+    std::memcpy(in.ref_hash.begin(), coinb1.data() + coinb1.size() - 32, 32);
+    in.last_txout_nonce = 0x0807060504030201ull;
+
+    // Structural identity holds (the exact bytes were rebuilt), so the ONLY
+    // discriminator left is the pow<=target ban-safety gate — it must decline.
+    const uint256 committed_target = chain::bits_to_target(job.share_bits);
+    ASSERT_TRUE(in.pow_hash > committed_target);   // astronomically certain
+    EXPECT_FALSE(mint_from_inputs(tracker.chain, params, in, built_job->frozen)
+                     .has_value());
+}
+
+// (7) Frozen-job registry: fail-closed on unknown refs, FIFO-bounded.
+TEST(DashMintRunloop, FrozenJobRegistryFailClosedAndBounded)
+{
+    FrozenJobRegistry registry(/*capacity=*/4);
+    EXPECT_FALSE(registry.get(h256_tag(0x01)).has_value());
+
+    for (uint8_t i = 1; i <= 6; ++i) {
+        dash::stratum::FrozenMintJob job;
+        job.share_nonce = i;
+        registry.put(h256_tag(i), job);
+    }
+    EXPECT_EQ(registry.size(), 4u);
+    // Oldest two evicted; newest four present.
+    EXPECT_FALSE(registry.get(h256_tag(1)).has_value());
+    EXPECT_FALSE(registry.get(h256_tag(2)).has_value());
+    for (uint8_t i = 3; i <= 6; ++i) {
+        auto j = registry.get(h256_tag(i));
+        ASSERT_TRUE(j.has_value());
+        EXPECT_EQ(j->share_nonce, i);
+    }
+}
+
+// (8) --give-author mapping: donation percentage -> the oracle u16 field
+//     (math.perfect_round(65535*pct/100)).
+TEST(DashMintRunloop, DonationPercentToU16Mapping)
+{
+    using dash::mint::donation_percent_to_u16;
+    EXPECT_EQ(donation_percent_to_u16(0.0), 0);
+    EXPECT_EQ(donation_percent_to_u16(0.1), 66);     // README default 0.1%
+    EXPECT_EQ(donation_percent_to_u16(0.5), 328);    // p2pool default 0.5%
+    EXPECT_EQ(donation_percent_to_u16(2.5), 1638);
+    EXPECT_EQ(donation_percent_to_u16(100.0), 65535);
+    EXPECT_EQ(donation_percent_to_u16(250.0), 65535);  // clamped
+    EXPECT_EQ(donation_percent_to_u16(-3.0), 0);       // clamped
+}
+
+// (9) --fee / --node-owner-address / --redistribute identity resolution
+//     (deterministic core; the run-loop supplies the roll).
+TEST(DashMintRunloop, ResolveMintIdentityFeeAndRedistribute)
+{
+    using dash::mint::MintFeePolicy;
+    using dash::mint::resolve_mint_identity;
+
+    const auto miner_script = dash::pubkey_hash_to_script2(h160_uniform(0x22));
+    const auto owner_script = dash::pubkey_hash_to_script2(h160_uniform(0x99));
+    const std::vector<unsigned char> broken_script = {0x00, 0x14};  // not P2PKH
+
+    MintFeePolicy p;
+    p.donation_u16 = 66;
+    p.node_owner_fee_pct = 1.0;          // --fee 1
+    p.node_owner_script = owner_script;
+
+    // roll < fee*100 -> substituted to the owner; donation unchanged.
+    auto sub = resolve_mint_identity(p, miner_script, /*roll_x100=*/99);
+    ASSERT_TRUE(sub.has_value());
+    EXPECT_TRUE(sub->substituted);
+    EXPECT_EQ(sub->payout_script, owner_script);
+    EXPECT_EQ(sub->donation_u16, 66);
+    // roll >= fee*100 -> the miner keeps the share.
+    auto keep = resolve_mint_identity(p, miner_script, /*roll_x100=*/100);
+    ASSERT_TRUE(keep.has_value());
+    EXPECT_FALSE(keep->substituted);
+    EXPECT_EQ(keep->payout_script, miner_script);
+
+    // --fee 0: never substituted regardless of roll.
+    MintFeePolicy p0 = p;
+    p0.node_owner_fee_pct = 0.0;
+    auto never = resolve_mint_identity(p0, miner_script, 0);
+    ASSERT_TRUE(never.has_value());
+    EXPECT_FALSE(never->substituted);
+
+    // Broken credentials: redistribute policy decides.
+    p.redistribute = MintFeePolicy::Redistribute::FEE;
+    auto rfee = resolve_mint_identity(p, broken_script, 5000);
+    ASSERT_TRUE(rfee.has_value());
+    EXPECT_EQ(rfee->payout_script, owner_script);
+    EXPECT_EQ(rfee->donation_u16, 66);
+
+    p.redistribute = MintFeePolicy::Redistribute::DONATE;
+    auto rdon = resolve_mint_identity(p, broken_script, 5000);
+    ASSERT_TRUE(rdon.has_value());
+    EXPECT_EQ(rdon->payout_script, owner_script);
+    EXPECT_EQ(rdon->donation_u16, 65535);   // 100% weight decays to donation
+
+    p.redistribute = MintFeePolicy::Redistribute::PPLNS;
+    EXPECT_FALSE(resolve_mint_identity(p, broken_script, 5000).has_value());
+
+    // fee/donate without a usable owner address: fail-closed.
+    MintFeePolicy no_owner = p;
+    no_owner.node_owner_script.clear();
+    no_owner.redistribute = MintFeePolicy::Redistribute::FEE;
+    EXPECT_FALSE(resolve_mint_identity(no_owner, broken_script, 0).has_value());
+}
+
+// (10) Combined-split pin: --fee 1 --give-author 0 with the fee roll hitting.
+//      The minted share carries the NODE OWNER identity (1%-of-shares fee
+//      channel), donation field 0 (0% dev), and the coinbase STILL emits the
+//      donation output (the always-present dust-marker semantic). Also the
+//      override regression: the submit's username script is the MINER's, yet
+//      the mint succeeds because FrozenMintJob.payout_script_override pins
+//      the substituted identity.
+TEST(DashMintRunloop, CombinedFeeSplitOwnerSubstitutionWithZeroDevFee)
+{
+    const auto params = easy_params();
+    dash::ShareTracker tracker;
+    tracker.m_coin_params = params;
+
+    const uint160 miner_pkh = h160_uniform(0x22);
+    const uint160 owner_pkh = h160_uniform(0x99);
+    const auto miner_script = dash::pubkey_hash_to_script2(miner_pkh);
+
+    dash::mint::MintFeePolicy policy;
+    policy.donation_u16 = dash::mint::donation_percent_to_u16(0.0);  // --give-author 0
+    policy.node_owner_fee_pct = 1.0;                                 // --fee 1
+    policy.node_owner_script = dash::pubkey_hash_to_script2(owner_pkh);
+
+    // Fee roll hits (roll 0 < 100): the job is built under the OWNER identity.
+    auto identity = dash::mint::resolve_mint_identity(policy, miner_script, 0);
+    ASSERT_TRUE(identity.has_value());
+    ASSERT_TRUE(identity->substituted);
+    EXPECT_EQ(identity->donation_u16, 0);
+
+    auto wd = make_workdata();
+    auto solved = solve_job(tracker, params, uint256(), owner_pkh, wd, 31,
+                            identity->donation_u16);
+    ASSERT_TRUE(solved.solved);
+
+    // mining_submit hands the MINER's username script; the frozen override
+    // must carry the substitution through the rebuild.
+    solved.in.payout_script = miner_script;
+    ASSERT_EQ(solved.frozen.payout_script_override,
+              dash::pubkey_hash_to_script2(owner_pkh));
+
+    auto built = mint_from_inputs(tracker.chain, params, solved.in, solved.frozen);
+    ASSERT_TRUE(built.has_value());
+    EXPECT_EQ(built->share.m_pubkey_hash, owner_pkh);   // 1% owner fee channel
+    EXPECT_EQ(built->share.m_donation, 0);              // 0% dev fee
+
+    // Donation output PRESENT even at --give-author 0 (dust marker): the
+    // DONATION_SCRIPT bytes appear as an output of the solved coinbase.
+    const std::vector<unsigned char> donation_script(
+        dash::DONATION_SCRIPT.begin(), dash::DONATION_SCRIPT.end());
+    auto itd = std::search(solved.in.coinbase_bytes.begin(),
+                           solved.in.coinbase_bytes.end(),
+                           donation_script.begin(), donation_script.end());
+    EXPECT_NE(itd, solved.in.coinbase_bytes.end());
+}
+
+// (11) --give-author decays the share's PPLNS weight toward the donation
+//      script by the oracle formula: weight = att*(65535-donation).
+TEST(DashMintRunloop, DonationFieldDecaysPplnsWeight)
+{
+    const auto params = easy_params();
+    dash::ShareTracker tracker;
+    tracker.m_coin_params = params;
+
+    const uint160 miner = h160_uniform(0x37);
+    const uint16_t donation = 1638;   // --give-author 2.5
+    auto wd = make_workdata();
+    auto solved = solve_job(tracker, params, uint256(), miner, wd, 41, donation);
+    ASSERT_TRUE(solved.solved);
+    auto built = mint_from_inputs(tracker.chain, params, solved.in, solved.frozen);
+    ASSERT_TRUE(built.has_value());
+    EXPECT_EQ(built->share.m_donation, donation);
+
+    dash::ShareType st;
+    st = new dash::DashShare(built->share);
+    tracker.add(st);
+
+    const uint288 att = chain::target_to_average_attempts(
+        chain::bits_to_target(built->share.m_bits));
+    uint288 big;
+    big.SetHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    auto w = dash::producer::get_cumulative_weights(
+        tracker.chain, built->share.m_hash, 1, big);
+    const auto script = dash::pubkey_hash_to_script2(miner);
+    ASSERT_EQ(w.weights.count(script), 1u);
+    EXPECT_EQ(w.weights[script], att * static_cast<uint32_t>(65535 - donation));
+    EXPECT_EQ(w.donation_weight, att * static_cast<uint32_t>(donation));
+    EXPECT_EQ(w.total_weight, att * 65535u);
+}

--- a/test/test_dash_share_producer_bind.cpp
+++ b/test/test_dash_share_producer_bind.cpp
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// DASH share-producer BIND KATs (mint campaign slice 2/3).
+//
+// Exercises share_producer_bind.hpp -- the adapter that turns a stratum-found
+// solution (DASHWorkSource::MintShareInputs) plus the per-job context frozen at
+// job assembly (FrozenMintJob) into a fully-built, self-verified DashShare and
+// returns its X11 share hash. This is the wire-in half of the mint campaign;
+// nothing here touches src/core or wires into --run (that is slice 3/3).
+//
+// Coverage:
+//   (a) parse_min_header_80: 80-byte canonical header -> SmallBlockHeaderType
+//       (merkle_root sliced off); short buffer -> nullopt (fail-closed).
+//   (b) pubkey_hash_from_p2pkh: exact inverse of pubkey_hash_to_script2;
+//       non-canonical script -> nullopt (fail-closed).
+//   (c) build_mint_share: genesis mint reproduces the DIRECT
+//       generate_prospective_share_info + build_share path byte-for-byte
+//       (share hash, ref_hash, gentx_hash), proving the MintShareInputs +
+//       FrozenMintJob -> ProducerJobInputs mapping is faithful.
+//   (d) the X11 integrity gate: a solution whose pow_hash does not match the
+//       rebuilt share hash is DECLINED (nullopt / null hash), never minted.
+//   (e) make_producer_mint_fn: binds the transform into a MintShareFn and
+//       returns the minted hash on success / null on decline.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/share_producer_bind.hpp>
+#include <impl/dash/share_producer.hpp>
+#include <impl/dash/share_chain.hpp>
+#include <impl/dash/share_check.hpp>       // dash::pubkey_hash_to_script2
+#include <impl/dash/share_types.hpp>       // dash::StaleInfo, dash::PackedPayment
+#include <impl/dash/params.hpp>            // dash::make_coin_params
+#include <impl/dash/stratum/work_source.hpp>
+#include <impl/bitcoin_family/coin/base_block.hpp>
+
+#include <core/coin_params.hpp>
+#include <core/pack_types.hpp>
+#include <core/uint256.hpp>
+
+#include <optional>
+#include <vector>
+
+namespace {
+
+using dash::stratum::parse_min_header_80;
+using dash::stratum::pubkey_hash_from_p2pkh;
+using dash::stratum::FrozenMintJob;
+using dash::stratum::build_mint_share;
+using dash::stratum::make_producer_mint_fn;
+using MintShareInputs = dash::stratum::DASHWorkSource::MintShareInputs;
+
+uint256 h256_tag(uint8_t tag) {
+    std::vector<unsigned char> v(32, 0x00);
+    v[0] = tag; v[31] = 0xa5;
+    return uint256(v);
+}
+
+uint160 h160_uniform(uint8_t tag) {
+    return uint160(std::vector<unsigned char>(20, tag));
+}
+
+bitcoin_family::coin::BlockHeaderType make_full_header() {
+    bitcoin_family::coin::BlockHeaderType h;
+    h.m_version = 536870912;                 // BIP9 base version (fixed 4 bytes on the wire)
+    h.m_previous_block = h256_tag(0x77);
+    h.m_merkle_root = h256_tag(0x99);        // sliced off by the small header
+    h.m_timestamp = 1700000005;
+    h.m_bits = 0x1b00ffffu;
+    h.m_nonce = 0xdeadbeefu;
+    return h;
+}
+
+std::vector<unsigned char> serialize80(const bitcoin_family::coin::BlockHeaderType& h) {
+    PackStream s;
+    s << h;
+    return std::vector<unsigned char>(
+        reinterpret_cast<const unsigned char*>(s.data()),
+        reinterpret_cast<const unsigned char*>(s.data()) + s.size());
+}
+
+// Shared genesis fixture: chosen job context + solved header, and the DIRECT
+// (non-adapter) build of the same inputs to compare against.
+struct GenesisFixture {
+    core::CoinParams params = dash::make_coin_params(false);
+    dash::ShareChain chain;
+    FrozenMintJob job;
+    uint160 pubkey_hash = h160_uniform(0x22);
+    uint64_t subsidy = 500000000;
+    std::vector<unsigned char> header_bytes;
+    dash::producer::BuiltShare expected;
+
+    GenesisFixture() {
+        job.coinbase_scriptSig = {0x51, 0x52};
+        job.share_nonce = 0;
+        job.donation = 0;
+        job.desired_version = 16;
+        job.desired_timestamp = 1700000005;
+        job.desired_target = params.max_target;
+        job.last_txout_nonce = 0x0102030405060708ull;
+
+        auto full = make_full_header();
+        header_bytes = serialize80(full);
+
+        dash::producer::ProducerJobInputs pin;
+        pin.prev_share_hash    = uint256();
+        pin.coinbase_scriptSig = job.coinbase_scriptSig;
+        pin.share_nonce        = job.share_nonce;
+        pin.pubkey_hash        = pubkey_hash;
+        pin.subsidy            = subsidy;
+        pin.donation           = job.donation;
+        pin.desired_version    = job.desired_version;
+        pin.desired_timestamp  = job.desired_timestamp;
+        pin.desired_target     = job.desired_target;
+        auto info = dash::producer::generate_prospective_share_info(chain, params, pin);
+        auto small = static_cast<bitcoin_family::coin::SmallBlockHeaderType&>(full);
+        expected = dash::producer::build_share(
+            chain, params, info, small, job.last_txout_nonce, /*check_pow=*/false);
+    }
+
+    MintShareInputs good_inputs() const {
+        MintShareInputs in;
+        in.header_bytes    = header_bytes;
+        in.subsidy         = subsidy;
+        in.prev_share_hash = uint256();
+        in.payout_script   = dash::pubkey_hash_to_script2(pubkey_hash);
+        in.pow_hash        = expected.share.m_hash;
+        return in;
+    }
+};
+
+}  // namespace
+
+// (a) parse_min_header_80 -----------------------------------------------------
+TEST(DashShareProducerBind, ParseMinHeader80SlicesMerkleRoot) {
+    auto full = make_full_header();
+    auto bytes = serialize80(full);
+    ASSERT_EQ(bytes.size(), 80u);
+
+    auto parsed = parse_min_header_80(bytes);
+    ASSERT_TRUE(parsed.has_value());
+    EXPECT_EQ(parsed->m_version, full.m_version);
+    EXPECT_EQ(parsed->m_previous_block, full.m_previous_block);
+    EXPECT_EQ(parsed->m_timestamp, full.m_timestamp);
+    EXPECT_EQ(parsed->m_bits, full.m_bits);
+    EXPECT_EQ(parsed->m_nonce, full.m_nonce);
+
+    // Short buffer -> fail-closed.
+    bytes.resize(40);
+    EXPECT_FALSE(parse_min_header_80(bytes).has_value());
+    EXPECT_FALSE(parse_min_header_80({}).has_value());
+}
+
+// (b) pubkey_hash_from_p2pkh --------------------------------------------------
+TEST(DashShareProducerBind, PubkeyHashP2PKHRoundTrip) {
+    const uint160 h = h160_uniform(0x3c);
+    auto script = dash::pubkey_hash_to_script2(h);
+    ASSERT_EQ(script.size(), 25u);
+
+    auto back = pubkey_hash_from_p2pkh(script);
+    ASSERT_TRUE(back.has_value());
+    EXPECT_EQ(*back, h);
+
+    // Non-canonical scripts -> fail-closed.
+    EXPECT_FALSE(pubkey_hash_from_p2pkh({}).has_value());
+    EXPECT_FALSE(pubkey_hash_from_p2pkh(std::vector<unsigned char>(25, 0x00)).has_value());
+    auto wrong_len = script; wrong_len.pop_back();
+    EXPECT_FALSE(pubkey_hash_from_p2pkh(wrong_len).has_value());
+    auto wrong_tail = script; wrong_tail[24] = 0x00;  // not OP_CHECKSIG
+    EXPECT_FALSE(pubkey_hash_from_p2pkh(wrong_tail).has_value());
+}
+
+// (c) build_mint_share reproduces the direct producer path --------------------
+TEST(DashShareProducerBind, GenesisMintMatchesDirectBuild) {
+    GenesisFixture fx;
+    ASSERT_FALSE(fx.expected.share.m_hash.IsNull());
+
+    auto got = build_mint_share(fx.chain, fx.params, fx.good_inputs(), fx.job);
+    ASSERT_TRUE(got.has_value());
+    EXPECT_EQ(got->share.m_hash, fx.expected.share.m_hash);
+    EXPECT_EQ(got->ref_hash, fx.expected.ref_hash);
+    EXPECT_EQ(got->gentx_hash, fx.expected.gentx_hash);
+}
+
+// (d) the X11 integrity gate + fail-closed inputs -----------------------------
+TEST(DashShareProducerBind, DeclinesOnPowMismatchAndMalformedInputs) {
+    GenesisFixture fx;
+
+    // pow_hash does not reproduce the rebuilt share -> DECLINE.
+    auto in = fx.good_inputs();
+    in.pow_hash = h256_tag(0xEE);
+    EXPECT_FALSE(build_mint_share(fx.chain, fx.params, in, fx.job).has_value());
+
+    // Non-P2PKH payout script -> DECLINE.
+    in = fx.good_inputs();
+    in.payout_script = {0x00, 0x14};
+    EXPECT_FALSE(build_mint_share(fx.chain, fx.params, in, fx.job).has_value());
+
+    // Truncated header -> DECLINE.
+    in = fx.good_inputs();
+    in.header_bytes.resize(40);
+    EXPECT_FALSE(build_mint_share(fx.chain, fx.params, in, fx.job).has_value());
+}
+
+// (e) make_producer_mint_fn ---------------------------------------------------
+TEST(DashShareProducerBind, MintFnBindsAndReturnsHashOrNull) {
+    GenesisFixture fx;
+    auto fn = make_producer_mint_fn(
+        fx.chain, fx.params,
+        [&fx](const MintShareInputs&) { return fx.job; });
+
+    EXPECT_EQ(fn(fx.good_inputs()), fx.expected.share.m_hash);
+
+    auto bad = fx.good_inputs();
+    bad.pow_hash = h256_tag(0xEE);
+    EXPECT_TRUE(fn(bad).IsNull());
+}


### PR DESCRIPTION
Slice 3/3 of the DASH sharechain-MINT campaign: the run-loop wiring that makes `c2pool-dash --run` actually MINT legacy v16 shares onto the p2pool-dash sharechain — ShareAccept -> producer rebuild -> tracker insert -> peer broadcast, with best-share election and the PPLNS window bound into the coinbase. Enables PPLNS payouts and is the prerequisite for joining the live p2pool-dash network.

## Re-verified gap delta (vs the earlier assessment)

- **Slice 2 was NOT on master.** `share_producer_bind.hpp` (+ its 5 KATs) sat unmerged on `dash/s8-share-producer-mint-bind` with no PR. The two commits are included here (cherry-picked, unchanged) — this PR stacks on them.
- **(b) think(): the tracker half already existed** — `ShareTracker::think()` (P1 verify walk / P2 budgeted verify / scoring) is fully implemented on master. What was missing was the NODE-side driver: `run_think()`, `m_best_share_hash` publication, the pending-adds drain, and any caller. All added.
- **(a) mint seam, (c) broadcast/forward leg, (d) storage construction, (e) PPLNS weights binding** — all still missing on master; all built here.
- **Two additional blocking gaps found during re-verification, both fixed:**
  - the DASH node NEVER SENT its own `version` message (no `connected()` override / `send_version`) — a p2pool-dash peer drops the link on handshake timeout, so reception alone could not hold a session; `send_ping` was also a stub;
  - nothing set `tracker.m_coin_params` (X11 pow_func) — reception verify would run with an empty pow function and reject every share.

## What was built

**Byte-parity architecture (the ban-safety keystone):** when the producer seam is bound, the stratum coinbase served to miners IS the producer share gentx (`producer::build_gentx`), split verbatim around the zeroed nonce64 slot. The mint-time rebuild (`build_mint_share`, slice 2) re-runs the identical deterministic producer walks (all anchored backward from the frozen `prev_share_hash`), so the rebuilt share reproduces the solved header bytes exactly — ONE gentx serializer, byte-parity by construction rather than by parallel-implementation parity. Fail-closed gates stack: frozen-job registry miss (ref_hash recovered from the coinb1 tail), the slice-2 X11 identity gate, and a new explicit `pow <= committed m_bits target` guard so a stratum share-bits race can never mint a share peers would ban over.

- `src/impl/dash/mint_runloop.hpp` — build_producer_job, FrozenJobRegistry, mint_from_inputs (ban-safety gate), elect_best_share (verified-accumulated-work-first; KAT-able pure function), pplns_weights_for (ORACLE window: grandparent start, data.py:181), fee policy (below).
- `src/impl/dash/node.{hpp,cpp}` — run_think + election + snapshot publication; broadcast_share/send_shares (message_shares codec + remember_tx/forget_tx tx forwarding); connected()/send_version (+ real ping); SharechainStorage construction + reload + verified-mark/removal persistence + batch share persist; add_local_share; register_template_txs.
- `src/impl/dash/stratum/work_source.{hpp,cpp}` — ProducerJobFn seam (byte-unchanged fallback path when unbound); MintShareInputs extended with ref_hash / last_txout_nonce / tx_data.
- `src/c2pool/main_dash.cpp` — full --run wiring: coin-params + storage init, best-share fn, producer-job fn (per-job cache to keep notify bytes stable + the registry within its window), mint fn, PPLNS weights fn, work-refresh on best change, initial + 15 s think tick, shutdown flush.

**Fee flags (README design, LTC sharechain-lane port):** `--give-author` (default 0.1%) -> the share's `donation` u16 (oracle dev-fee channel; PPLNS weights decay by `att*(65535-donation)`; the donation output is ALWAYS emitted by the gentx — `--give-author 0` keeps the dust-marker output present). `-f/--fee` + `--node-owner-address` -> the consensus-safe probabilistic identity substitution (~fee% of minted shares carry the owner's pubkey_hash; identical coinbases on every peer). `--redistribute fee|donate` for non-P2PKH miner credentials (donate = `donation=65535`, the pubkey-hash-keyed DASH form of 100%-to-donation); the LTC weighted `pplns|boost` redistribution engine is NOT yet ported — those decline fail-closed (the pre-existing behavior), reported as a follow-up. The pre-v36 donation script stays `dash::DONATION_SCRIPT` (what the live v16 network verifies); the v36 COMBINED-script migration surface (`compute_dash_payouts` version gate) is untouched — when the crossing slice lands, `producer::build_gentx` needs the same share-version gate (flagged, not silently wrong: this slice mints v16 only by construction).

## STOPPED on (honest gaps, loudly logged — not half-wired)

- **Desired-share DOWNLOAD leg** (p2pool node.py download loop): think()'s `desired` set is logged, not requested. Reception can serve peers (`handle_get_share`), but filling OUR gaps beyond what peers push rides a later slice — required for a cold-start sync against the live network.
- **Peer ban list + rejected-share tracking** (btc `m_ban_list`/`m_rejected_share_hashes`): bad-share peers are logged, not banned.
- **pplns/boost redistribute engine** — LTC's weighted redistribution not yet ported (declines fail-closed).
- **clean_tracker/prune driver** on the DASH node (tracker-side machinery exists; the periodic prune caller is a later slice — bounded exposure while chains are short).

## KATs (11 new, in the existing allowlisted `test_dash_share_hash_link` target; 40/40 green)

Full pipeline with REAL X11 nonce searches: ShareAccept mints a share that passes the in-tree verifier and whose hash IS the solved header PoW; message_shares codec round-trip byte-identical + peer-side re-verify to the same hash; tracker insert + get_shares walk; heaviest-verified-head election (+ refusal with peers-but-no-verified-chain); PPLNS oracle-window pin (grandparent start, tip's miner excluded, hand-computed weights); ban-safety decline of an above-target solve (isolated to the target gate via mainnet params); registry fail-closed + FIFO bound; donation u16 mapping; fee-roll/redistribute identity resolution; the combined `--fee 1 --give-author 0` split (owner identity + donation 0 + donation output PRESENT); oracle weight decay `att*(65535-donation)`.

## Verification

- test_dash_share_hash_link 40/40 (slice-1 + slice-2 + slice-3 KATs); all 17 affected dash test targets rebuilt + green (node, tracker, work_source x4, stratum x4, p2p_node, peer, messages x2, reception wire, auto_ratchet, min_protocol_gate, conformance 56/56).
- `c2pool-dash --selftest` OK; 20 s `--run --testnet` smoke: listener + stratum up, think tick live, clean shutdown with persistence flush.
- Fenced to `src/impl/dash/` + `main_dash.cpp` + dash test files; no core/other-coin source edits; dashd-RPC fallback untouched.

## Byte-parity confidence vs the oracle

The producer core (slice 1) is hand-traced from frstrtr/p2pool-dash with oracle-pinned KATs; slice 3 adds no second serializer — the mint reuses the producer end-to-end and self-verifies through the in-tree verifier plus the X11 identity + target gates, so a diverging share CANNOT reach the tracker or the wire (it declines instead). What KATs cannot prove is live-oracle ACCEPTANCE semantics (e.g. tx-forwarding expectations of a real peer, timestamp/donation edge tolerances) — the next step is a controlled soak against a p2pool-dash testnet peer (available on request) BEFORE pointing at mainnet: connect, mint on the live tip, and confirm the oracle keeps the session + tracks our share.

## Remaining gap to a live p2pool-dash JOIN

1. Controlled-peer soak (above) — the acceptance evidence gate.
2. The desired-share download leg (cold-start sync).
3. Outbound dial machinery exists via bootstrap addrs; addnode/connect reach the addr store and inbound handshakes now complete both ways — verify a sustained outbound session against the controlled peer.
4. Ban list + clean_tracker driver (robustness under long uptime).
