### PR TITLE
btc(rpc): always log daemon reject verdict on submitblock

### DIFF
--- a/src/impl/btc/coin/rpc.cpp
+++ b/src/impl/btc/coin/rpc.cpp
@@ -393,12 +393,19 @@ void NodeRPC::submit_block(BlockType& block, bool ignore_failure)
 
 bool NodeRPC::submit_block_hex(const std::string& block_hex, bool ignore_failure)
 {
+	(void)ignore_failure;
 	auto result = m_client.CallMethod<nlohmann::json>(ID, "submitblock", {block_hex});
 	bool success = result.is_null();
-	if (!success && !ignore_failure)
-		LOG_ERROR << "submit_block_hex result: " << result.dump();
-	else if (success)
+	if (success)
 		LOG_INFO << "submit_block_hex accepted";
+	else
+		// A won block rejection reason is load-bearing diagnostic data: the
+		// daemon returns a verdict string ("bad-witness-merkle-match",
+		// "high-hash", "Superfluous witness record", ...). Surface it ALWAYS.
+		// ignore_failure governs fatality (never throw out of the won-block
+		// path), NOT log visibility -- a swallowed reason blinds block-prod
+		// debugging (G3b submits went pending -> rejected with no cause).
+		LOG_ERROR << "submit_block_hex REJECTED by daemon: " << result.dump();
 	return success;
 }
 


### PR DESCRIPTION
## What
`submit_block_hex` (the submitblock RPC sink for won blocks) is always called with `ignore_failure=true` so a daemon rejection never throws out of the found-block handler. But the reject-reason log line was gated on `!ignore_failure`, so bitcoind's verdict string was silently swallowed on **every** rejection.

## Why it matters
A won block's reject reason is load-bearing diagnostic data. On the `.121` g3btuned0 regtest, c2pool finds blocks at height 131 but every submit stalls `pending -> rejected` with **no observable cause** — bitcoind stuck at 130 for ~17h. The verdict string (`bad-witness-merkle-match` / `high-hash` / `Superfluous witness record` / ...) is exactly the discriminator between the two open G3b block-prod hypotheses (witness-commitment vs coinbase-only serialization).

## Change
`ignore_failure` now governs fatality only (never throw); log visibility is unconditional. Rejections log `LOG_ERROR << "submit_block_hex REJECTED by daemon: " << result.dump()`. Param retained + `(void)`-cast to avoid a signature ripple / unused-param `-Werror`. Logging-only; no behavioral change to accept/return semantics.

Cut off `origin/master`. Unblocks the G3b diagnosis on the next rig cycle.
