### PR TITLE
dash(node): wire the 4 missing coin-agnostic node capabilities from btc parent — download/ban/outbound-dialer/clean-prune (+#755 load guard)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -458,7 +458,20 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     const uint16_t bind_port =
         peer.listen_port ? peer.listen_port : dash::SharechainConfig::p2p_port();
     if (!connect_only) {
-        p2p_node.core::Server::listen(bind_port);
+        // #755: an uncaught bind failure (EADDRINUSE from a lingering prior
+        // instance) here threw boost::system::system_error straight through
+        // main -> terminate -> Exit 134 core dump. The log made it LOOK like
+        // a share-load crash (the throw lands right after the "Loaded N
+        // persisted shares" lines). Fail CLEANLY with the actual reason.
+        try {
+            p2p_node.core::Server::listen(bind_port);
+        } catch (const std::exception& e) {
+            std::cerr << "[run] FATAL: cannot bind sharechain P2P port "
+                      << bind_port << ": " << e.what()
+                      << "\n[run] (another c2pool-dash instance running? "
+                         "stop it or pass a different --listen port)\n";
+            return 1;
+        }
         std::cout << "[run] sharechain peer LISTENING on " << peer.listen_host << ":"
                   << bind_port
                   << " — min-proto=" << dash::SharechainConfig::MINIMUM_PROTOCOL_VERSION
@@ -466,11 +479,17 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     } else {
         std::cout << "[run] --connect mode: inbound listener suppressed\n";
     }
-    // addnode/connect targets are registered in the addr store by the NodeImpl
-    // ctor, but ACTIVE outbound dialing rides the download/outbound slice
-    // (dash::NodeImpl carries no start_outbound_connections yet). Inbound
-    // reception — version handshake + the #646 min-proto gate — is live now
-    // via node.cpp (#656/#657).
+    // #754 download/outbound slice: ACTIVE outbound dialing from the addr
+    // store (--addnode/--connect seeds registered by the NodeImpl ctor) plus
+    // the share-download pumps (handshake best-share advert drain here;
+    // think()'s desired-set dispatch rides run_think). This is what lets an
+    // EMPTY node JOIN an established p2pool-dash chain instead of only
+    // serving inbound peers.
+    p2p_node.start_outbound_connections();
+    if (!config.pool()->m_bootstrap_addrs.empty())
+        std::cout << "[run] outbound dialing started ("
+                  << config.pool()->m_bootstrap_addrs.size()
+                  << " seed peer[s]); share-download leg ARMED\n";
 
     // ── E1: OPT-IN embedded coin-network P2P dial (--coin-p2p-connect) ────
     // GUARANTEE: with no --coin-p2p-connect on argv, coin_p2p stays null and
@@ -861,7 +880,11 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // ── Think loop: initial election + 15 s keep-fresh tick ───────────────
     // Share arrivals trigger run_think() themselves (add_verified_shares);
     // the periodic tick covers quiet stretches (retries deferred broadcasts,
-    // re-elects after verify continuations). Serialized by m_think_running.
+    // re-elects after verify continuations) and now runs clean_tracker()
+    // (btc/ltc parity: think + stale-head eat + drop-tails beyond
+    // 2*CHAIN_LENGTH+10 + LevelDB prune — without it the raw chain grows
+    // unbounded). clean_tracker runs think inline, so the tick still keeps
+    // the election fresh; it no-ops (defers) when a think is in flight.
     boost::asio::post(ioc, [&p2p_node]() { p2p_node.run_think(); });
     auto think_timer = std::make_shared<io::steady_timer>(ioc);
     auto think_tick =
@@ -869,7 +892,7 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     *think_tick = [&p2p_node, think_timer, think_tick](
                       const boost::system::error_code& ec) {
         if (ec) return;   // cancelled at shutdown
-        p2p_node.run_think();
+        p2p_node.clean_tracker();
         think_timer->expires_after(std::chrono::seconds(15));
         think_timer->async_wait(*think_tick);
     };
@@ -878,7 +901,26 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
 
     std::cout << "[run] run-loop up (Ctrl-C to stop); won blocks relay via the\n"
                  "[run] dashd-RPC submitblock fallback + the embedded sharechain P2P leg.\n";
-    ioc.run();
+    // #755 guard (btc main_btc.cpp:1309-1315 parity): an exception escaping an
+    // io handler must NOT terminate the node (Exit 134 core-dump — e.g. a
+    // chain-walk throw over unrooted persisted shares after a partial join).
+    // Log + resume; after an escaped exception the io_context is NOT stopped,
+    // so run() continues with the remaining handlers. Ctrl-C still exits via
+    // the signal handler's ioc.stop() → run() returns normally → break.
+    for (;;) {
+        try {
+            ioc.run();
+            break;
+        } catch (const std::exception& e) {
+            LOG_ERROR << "[run] io handler exception (non-fatal, #755 guard): "
+                      << e.what();
+            std::cout << "[run] io handler exception (non-fatal): " << e.what()
+                      << "\n";
+        } catch (...) {
+            LOG_ERROR << "[run] io handler exception (non-fatal, #755 guard): "
+                         "unknown error";
+        }
+    }
 
     // Tear the acceptor + sessions down while the work source and node_coin_state
     // it references are still alive -- explicit reset keeps destruction order safe

--- a/src/impl/dash/node.cpp
+++ b/src/impl/dash/node.cpp
@@ -5,6 +5,7 @@
 
 #include <core/uint256.hpp>
 #include <core/common.hpp>
+#include <core/random.hpp>
 
 #include <boost/asio/post.hpp>
 
@@ -447,23 +448,51 @@ void NodeImpl::run_think()
 
         boost::asio::post(*m_context, [this, result = std::move(result),
                                        best_changed, needs_continue]() {
-            // Peers that fed unverifiable shares: LOG ONLY for now — the DASH
-            // node carries no ban list yet (honest gap; the reception slice's
-            // error() close still applies to protocol violations).
-            for (const auto& bad_addr : result.bad_peer_addresses)
-                LOG_WARNING << "[think] peer provided unverifiable shares: "
-                            << bad_addr.to_string();
+          // #755 guard (ltc IO-phase parity, node.cpp:1580/1670): an exception
+          // escaping this handler would propagate out of ioc.run() and
+          // TERMINATE the node (Exit 134) — e.g. a chain-walk throw over a
+          // fragmented/unrooted restart chain. Catch, log, and keep serving.
+          try {
+            // Ban peers that provided invalid/unverifiable shares (btc
+            // node.cpp:1585-1603 port). Whitelisted bootstrap seeds are
+            // immune (is_banned bypass); port-0 entries are database-loaded
+            // addresses, not connectable peers.
+            {
+                const auto now = std::chrono::steady_clock::now();
+                for (const auto& bad_addr : result.bad_peer_addresses) {
+                    if (bad_addr.port() == 0)
+                        continue;
+                    LOG_WARNING << "run_think: banning peer " << bad_addr.to_string()
+                                << " for unverifiable shares";
+                    m_ban_list[bad_addr] = now + m_ban_duration;
+                }
+                // Expire old bans.
+                for (auto it = m_ban_list.begin(); it != m_ban_list.end(); ) {
+                    if (it->second <= now) it = m_ban_list.erase(it);
+                    else ++it;
+                }
+                for (auto it = m_ip_ban_list.begin(); it != m_ip_ban_list.end(); ) {
+                    if (it->second <= now) it = m_ip_ban_list.erase(it);
+                    else ++it;
+                }
+            }
 
-            // Desired-share download (p2pool node.py download loop) is NOT yet
-            // ported to the DASH node — log the gap loudly instead of silently
-            // dropping it. Reception can still serve peers (handle_get_share);
-            // filling OUR gaps from peers rides the download slice.
-            if (!result.desired.empty()) {
-                static int desired_log = 0;
-                if (desired_log++ % 20 == 0)
-                    LOG_WARNING << "[think] " << result.desired.size()
-                                << " desired share(s) not requested — the DASH "
-                                   "share-download leg is a later slice";
+            // #754 share-download leg (p2pool node.py download loop; ltc
+            // node.cpp:1600-1618 port): reset the per-cycle gate — p2pool
+            // re-adds desired hashes from scratch every cycle with sleep(1)
+            // backoff; permanent blacklisting stalls bootstrap — then request
+            // each desired missing parent from a RANDOM peer.
+            m_download_gate.new_cycle();
+            drain_peer_best_adverts();
+            if (!result.desired.empty() && !m_peers.empty()) {
+                for (const auto& [peer_addr, hash] : result.desired) {
+                    (void)peer_addr;  // oracle: random peer, not the reporter
+                    auto peer_it = m_peers.begin();
+                    if (m_peers.size() > 1)
+                        std::advance(peer_it,
+                            core::random::random_uint256().GetLow64() % m_peers.size());
+                    download_shares(peer_it->second, hash);
+                }
             }
 
             if (best_changed) {
@@ -481,6 +510,13 @@ void NodeImpl::run_think()
 
             if (needs_continue)
                 boost::asio::post(*m_context, [this]() { run_think(); });
+          } catch (const std::exception& e) {
+            LOG_ERROR << "run_think() IO phase failed: " << e.what();
+            m_think_running.store(false);
+          } catch (...) {
+            LOG_ERROR << "run_think() IO phase failed: unknown error";
+            m_think_running.store(false);
+          }
         });
     });
 }
@@ -494,6 +530,408 @@ void NodeImpl::drain_pending_adds()
     LOG_INFO << "[ASYNC-THINK] draining " << pending.size() << " deferred share batch(es)";
     for (auto& batch : pending)
         add_verified_shares(*batch.data, batch.addr);
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// #754 share-download leg — faithful port of the PROVEN ltc downloader
+// (src/impl/ltc/node.cpp:968-1105 download_shares, :1289-1327
+// start_outbound_connections), coin-agnostic planning/gating shared via
+// pool/share_download.hpp. This is what lets an EMPTY c2pool-dash node JOIN an
+// established p2pool-dash sharechain: request the missing ancestors, insert
+// them through the SAME processing_shares pipeline reception uses, and let
+// think() root + verify the previously-orphaned live-pushed shares.
+// ════════════════════════════════════════════════════════════════════════════
+
+void NodeImpl::download_shares(peer_ptr peer, const uint256& target_hash)
+{
+    // C++ implementation of the p2pool share-download loop (ltc parity):
+    //   1. de-dup + per-cycle fail gate (no re-request while in flight);
+    //   2. RANDOM parent count 0..499 (oracle: random.randrange(500));
+    //   3. STOPS list: known heads + their 10th parents (bounds the reply);
+    //   4. on reply: feed processing_shares, then continue from the oldest
+    //      received share's parent until the chain roots.
+    if (target_hash.IsNull())
+        return;
+    if (!m_download_gate.try_begin(target_hash))
+        return;  // already in flight, or failed out this think() cycle
+
+    // p2pool: if len(self.peers) == 0: sleep(1); continue
+    if (m_peers.empty()) {
+        m_download_gate.abort(target_hash);
+        return;
+    }
+
+    // Ask the supplied peer when it is still connected (the handshake-advert
+    // path asks the ADVERTISING peer, oracle p2p.py handle_version →
+    // handle_share_hashes); fall back to a random peer (oracle download loop:
+    // peer = random.choice(self.peers.values()); ltc:1002-1007).
+    if (!peer || !m_connections.contains(peer->addr())) {
+        auto peer_it = m_peers.begin();
+        if (m_peers.size() > 1)
+            std::advance(peer_it,
+                core::random::random_uint256().GetLow64() % m_peers.size());
+        peer = peer_it->second;
+    }
+
+    // p2pool: parents=random.randrange(500)
+    const uint64_t parents =
+        core::random::random_uint256().GetLow64() % pool::download::PARENTS_RANGE;
+
+    // stops need a tracker read — try_to_lock per the architectural rule (the
+    // IO thread NEVER blocks on m_tracker_mutex). If think() holds it, skip;
+    // the next think() cycle re-derives desired and retries.
+    std::vector<uint256> stops;
+    {
+        std::shared_lock<std::shared_mutex> lock(m_tracker_mutex, std::try_to_lock);
+        if (!lock.owns_lock()) {
+            m_download_gate.abort(target_hash);
+            return;
+        }
+        stops = pool::download::build_stops(m_tracker.chain);
+    }
+
+    const uint256 req_id = core::random::random_uint256();
+    std::vector<uint256> hashes = { target_hash };
+
+    // Track req_id → peer for selective cancellation on disconnect.
+    m_pending_share_reqs[req_id] = peer->addr();
+
+    LOG_INFO << "[Pool] Requesting parent share "
+             << target_hash.ToString().substr(0, 16)
+             << " from " << peer->addr().to_string()
+             << " (parents=" << parents << " stops=" << stops.size() << ")";
+
+    // weak_ptr prevents use-after-free if the peer disconnects before reply.
+    std::weak_ptr<peer_t> weak_peer = peer;
+    const auto peer_addr_for_log = peer->addr();
+
+    request_shares(req_id, peer, hashes, parents, stops,
+        [this, weak_peer, target_hash, peer_addr_for_log, req_id]
+        (dash::ShareReplyData reply)
+        {
+            m_pending_share_reqs.erase(req_id);
+
+            if (reply.m_items.empty())
+            {
+                // Empty reply = timeout, cancel, or peer had no match.
+                const int fails = m_download_gate.on_empty(target_hash);
+                LOG_INFO << "[Pool] Share request empty for "
+                         << target_hash.ToString().substr(0, 16)
+                         << " from " << peer_addr_for_log.to_string()
+                         << " (fail " << fails << "/"
+                         << pool::download::MAX_EMPTY_RETRIES << ")";
+                return;
+            }
+
+            m_download_gate.on_success(target_hash);
+            LOG_INFO << "[Pool] Received " << reply.m_items.size()
+                     << " share(s) for download request "
+                     << target_hash.ToString().substr(0, 16);
+
+            // Feed the SAME reception pipeline live pushes ride: parallel
+            // X11 verify → tracker insert → run_think (verify/root + next
+            // desired set).
+            HandleSharesData data;
+            for (size_t idx = 0; idx < reply.m_items.size(); ++idx)
+            {
+                if (idx < reply.m_raw_items.size())
+                    data.add(reply.m_items[idx], {}, reply.m_raw_items[idx]);
+                else
+                    data.add(reply.m_items[idx], {});
+            }
+            processing_shares(data, peer_addr_for_log);
+
+            // Backfill continuation: oldest received share's parent still
+            // unknown → keep pulling (ltc:1093-1102). This drives the full
+            // history download without waiting one think() cycle per chunk.
+            const uint256 next = pool::download::oldest_parent(reply.m_items);
+            if (!next.IsNull() && !m_chain->contains(next))
+            {
+                if (auto locked = weak_peer.lock())
+                    download_shares(locked, next);
+            }
+        });
+}
+
+void NodeImpl::drain_peer_best_adverts()
+{
+    if (m_peer_best_adverts.empty())
+        return;
+    auto adverts = std::move(m_peer_best_adverts);
+    m_peer_best_adverts.clear();
+    for (auto& [weak_peer, best] : adverts)
+    {
+        auto peer = weak_peer.lock();
+        if (!peer)
+            continue;
+        if (m_chain->contains(best))
+        {
+            // Known share: re-run think() to re-evaluate the best chain with
+            // the peer's perspective (ltc node.cpp:328-334 — critical after
+            // restart, when LevelDB-loaded shares carry a stale election).
+            run_think();
+            continue;
+        }
+        download_shares(peer, best);
+    }
+}
+
+void NodeImpl::start_outbound_connections()
+{
+    if (!m_context)
+        return;  // rig-free (KAT/standalone) node
+
+    // Advert-drain pump: handle_version (inline, link-free for the KAT
+    // targets) only QUEUES a peer's advertised best share; this timer is the
+    // node.cpp-side consumer that turns the queue into sharereq dispatches.
+    // 2s bounds the join latency; the check is O(1) when the queue is empty.
+    m_advert_timer = std::make_unique<core::Timer>(m_context, true);
+    m_advert_timer->start(2, [this]() { drain_peer_best_adverts(); });
+
+    if (m_target_outbound_peers == 0)
+    {
+        LOG_INFO << "[Pool] Outbound peer dialing disabled (target=0)";
+        return;
+    }
+
+    // btc/ltc node.cpp:1289-1327 port.
+    auto try_connect_peers = [this]()
+    {
+        const size_t outbound = m_outbound_addrs.size();
+        if (outbound >= m_target_outbound_peers || m_connections.size() >= m_max_peers)
+            return;
+
+        size_t needed = m_target_outbound_peers - outbound;
+        // Ask for a few extra in case some are already connected.
+        for (auto& ap : get_good_peers(needed + 4))
+        {
+            if (needed == 0)
+                break;
+            // Skip if already connected, already dialing, or banned.
+            if (m_connections.contains(ap.addr) || m_pending_outbound.contains(ap.addr)
+                || is_banned(ap.addr))
+                continue;
+            LOG_INFO << "[Pool] Dialing outbound peer " << ap.addr.to_string();
+            m_pending_outbound.insert(ap.addr);
+            core::Client::connect(ap.addr);
+            --needed;
+        }
+    };
+
+    try_connect_peers();  // initial burst (--addnode/--connect seeds)
+
+    // Periodic maintenance — top up outbound peers every 30 seconds.
+    m_connect_timer = std::make_unique<core::Timer>(m_context, true);
+    m_connect_timer->start(30, try_connect_peers);
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// clean_tracker — btc node.cpp:1878-2173 port (p2pool node.py:355-402:
+// stale-head eating + tail dropping). Runs think + prune on the compute
+// thread under the exclusive lock — chain modifications MUST NOT happen
+// concurrently with think() or IO-thread reads. Scheduled by the run loop's
+// periodic tick; without it the raw chain grows unbounded past
+// 2*CHAIN_LENGTH+10.
+// ════════════════════════════════════════════════════════════════════════════
+
+void NodeImpl::clean_tracker()
+{
+    // Prevent concurrent clean_tracker (timer re-entry safety).
+    if (m_clean_running.exchange(true))
+        return;
+
+    // Skip if think() is already in flight — the periodic timer will retry.
+    if (m_think_running.load()) {
+        m_clean_running.store(false);
+        return;
+    }
+    if (!m_context) {
+        m_clean_running.store(false);
+        return;   // rig-free (KAT/standalone) node
+    }
+
+    // Post the entire body to the compute thread: chain modifications happen
+    // under the exclusive lock, never concurrent with think() or IO reads.
+    m_think_running.store(true);  // block think() re-entry during clean
+
+    boost::asio::post(m_think_pool, [this]() {
+      m_compute_thread_id.store(std::this_thread::get_id(), std::memory_order_relaxed);
+
+      bool clean_best_changed = false;
+      bool bootstrap = false;
+      try {
+        std::unique_lock lock(m_tracker_mutex);  // exclusive
+
+        auto block_rel_height = m_block_rel_height_fn
+            ? m_block_rel_height_fn
+            : std::function<int32_t(uint256)>([](uint256) -> int32_t { return 0; });
+
+        // Step 1: run think() inline (already holds the lock).
+        {
+            bootstrap = m_tracker.verified.size() == 0;
+            auto result = m_tracker.think(block_rel_height,
+                                          /*previous_block=*/uint256(),
+                                          /*bits=*/0, bootstrap);
+            m_last_top5_heads = std::move(result.top5_heads);
+            if (!result.best.IsNull())
+                m_best_share_hash = result.best;
+            flush_verified_to_leveldb();
+        }
+
+        const auto now_sec = static_cast<int64_t>(std::time(nullptr));
+        const auto CL = static_cast<int32_t>(SharechainConfig::chain_length());
+
+        // Step 2: eat stale heads (p2pool node.py:358-378). Three guards
+        // protect useful heads: top-5 scored, seen <300s ago, unverified
+        // heads whose tail has recent (<120s) child activity.
+        if (!m_last_top5_heads.empty())  // p2pool node.py:359: if decorated_heads:
+        {
+            std::set<uint256> top5_set(m_last_top5_heads.begin(), m_last_top5_heads.end());
+
+            for (int iter = 0; iter < 1000; ++iter)
+            {
+                std::vector<uint256> to_remove;
+                auto heads_copy = m_tracker.chain.get_heads();
+                for (auto& [head_hash, tail_hash] : heads_copy)
+                {
+                    if (!m_tracker.chain.contains(head_hash)) continue;
+                    if (top5_set.count(head_hash)) continue;             // guard 1
+                    auto* idx = m_tracker.chain.get_index(head_hash);
+                    if (!idx || idx->time_seen > now_sec - 300) continue; // guard 2
+                    if (!m_tracker.verified.contains(head_hash))          // guard 3
+                    {
+                        auto& rev = m_tracker.chain.get_reverse();
+                        auto rev_it = rev.find(tail_hash);
+                        if (rev_it != rev.end() && !rev_it->second.empty())
+                        {
+                            int64_t max_child_ts = 0;
+                            for (const auto& child : rev_it->second)
+                            {
+                                auto* cidx = m_tracker.chain.get_index(child);
+                                if (cidx && cidx->time_seen > max_child_ts)
+                                    max_child_ts = cidx->time_seen;
+                            }
+                            if (max_child_ts > now_sec - 120) continue;
+                        }
+                    }
+                    to_remove.push_back(head_hash);
+                }
+
+                if (to_remove.empty()) break;
+
+                for (const auto& h : to_remove)
+                {
+                    try {
+                        if (m_tracker.verified.contains(h))
+                            m_tracker.verified.remove(h, /*owns_data=*/false);
+                        if (m_tracker.chain.contains(h))
+                            m_tracker.chain.remove(h);
+                    } catch (...) {}
+                }
+            }
+        }
+
+        // Step 3: drop tails — remove ALL children of tails whose every head
+        // is at least 2*CHAIN_LENGTH+10 high (p2pool node.py:382-398; only
+        // shares far beyond the PPLNS window are removed).
+        {
+            int total_dropped = 0;
+            for (int iter = 0; iter < 1000; ++iter)
+            {
+                std::vector<uint256> to_remove;
+                auto tails_copy = m_tracker.chain.get_tails();
+                for (auto& [tail_hash, head_hashes] : tails_copy)
+                {
+                    int32_t min_height = 0;  // 0 → skip if no valid heads
+                    for (auto& hh : head_hashes) {
+                        if (!m_tracker.chain.contains(hh)) continue;
+                        auto h = m_tracker.chain.get_height(hh);
+                        if (min_height == 0 || h < min_height)
+                            min_height = h;
+                    }
+                    if (min_height < 2 * CL + 10) continue;
+
+                    // p2pool node.py:386: to_remove.update(reverse.get(tail))
+                    auto& rev = m_tracker.chain.get_reverse();
+                    auto rev_it = rev.find(tail_hash);
+                    if (rev_it != rev.end()) {
+                        for (const auto& child : rev_it->second)
+                            to_remove.push_back(child);
+                    }
+                }
+
+                if (to_remove.empty()) break;
+
+                for (const auto& aftertail : to_remove)
+                {
+                    try {
+                        if (!m_tracker.chain.contains(aftertail)) continue;
+                        // p2pool node.py:393: previous_hash must still be a tail.
+                        auto* idx = m_tracker.chain.get_index(aftertail);
+                        if (!idx) continue;
+                        if (!m_tracker.chain.get_tails().count(idx->tail))
+                            continue;
+                        if (m_tracker.verified.contains(aftertail))
+                            m_tracker.verified.remove(aftertail, /*owns_data=*/false);
+                        m_tracker.chain.remove(aftertail);
+                        ++total_dropped;
+                    } catch (...) {}
+                }
+            }
+            if (total_dropped > 0)
+                LOG_INFO << "[clean-drop-tails] dropped " << total_dropped << " shares"
+                         << " chain_size=" << m_tracker.chain.size()
+                         << " heads=" << m_tracker.chain.get_heads().size();
+        }
+
+        // Step 4: re-score after pruning (inline, still holding the lock).
+        {
+            auto result = m_tracker.think(block_rel_height,
+                                          /*previous_block=*/uint256(),
+                                          /*bits=*/0, bootstrap);
+            m_last_top5_heads = std::move(result.top5_heads);
+            if (!result.best.IsNull()) {
+                clean_best_changed = (m_best_share_hash != result.best);
+                m_best_share_hash = result.best;
+            }
+            publish_snapshot();
+            flush_verified_to_leveldb();
+        }
+
+        // Step 5: flush pruned shares from LevelDB (p2pool main.py:269-270).
+        if (!m_removal_flush_buf.empty() && m_storage && m_storage->is_available())
+        {
+            auto count = m_removal_flush_buf.size();
+            if (m_storage->remove_shares_batch(m_removal_flush_buf))
+                LOG_INFO << "[clean-leveldb] removed " << count << " pruned shares from LevelDB";
+            else
+                LOG_WARNING << "[clean-leveldb] batch remove failed, count=" << count;
+            m_removal_flush_buf.clear();
+        }
+      } catch (const std::exception& e) {
+        LOG_ERROR << "[CLEAN] failed on compute thread: " << e.what();
+      } catch (...) {
+        LOG_ERROR << "[CLEAN] failed on compute thread: unknown error";
+      }
+      // Lock released — IO-phase: work refresh + drain, no lock held.
+      boost::asio::post(*m_context, [this, clean_best_changed]() {
+        try {
+            if (clean_best_changed) {
+                LOG_INFO << "[CLEAN] IO-phase: work refresh (best changed)";
+                if (m_on_best_share_changed)
+                    m_on_best_share_changed();
+                broadcast_share(m_best_share_hash);  // re-announce new head
+            }
+            drain_pending_adds();
+        } catch (const std::exception& e) {
+            LOG_ERROR << "[CLEAN] IO phase failed: " << e.what();
+        } catch (...) {
+            LOG_ERROR << "[CLEAN] IO phase failed: unknown error";
+        }
+        m_think_running.store(false);
+        m_clean_running.store(false);
+      });
+    });
 }
 
 uint256 NodeImpl::best_share_hash()

--- a/src/impl/dash/node.hpp
+++ b/src/impl/dash/node.hpp
@@ -29,6 +29,7 @@
 
 #include <pool/node.hpp>
 #include <pool/protocol.hpp>
+#include <pool/share_download.hpp>  // shared downloader helpers (#754)
 #include <core/reply_matcher.hpp>
 #include <c2pool/storage/sharechain_storage.hpp>
 
@@ -36,6 +37,7 @@
 #include <boost/asio/steady_timer.hpp>
 
 #include <atomic>
+#include <chrono>
 #include <functional>
 #include <map>
 #include <memory>
@@ -43,6 +45,7 @@
 #include <random>
 #include <set>
 #include <shared_mutex>
+#include <string>
 #include <thread>
 #include <vector>
 
@@ -216,11 +219,52 @@ protected:
     // Chain-relative block height for think() scoring; unbound -> zero fn.
     std::function<int32_t(uint256)> m_block_rel_height_fn;
 
+    // ── Share-download leg (#754) state — IO-thread only ────────────────
+    // De-dup + per-cycle retry gate for in-flight sharereq targets (shared
+    // pool/share_download.hpp; ltc m_downloading_shares/m_download_fail_count).
+    pool::download::DownloadGate m_download_gate;
+    // req_id → peer addr for selective cancellation on disconnect. p2pool has
+    // per-peer get_shares deferrers (connectionLost → respond_all on just that
+    // peer); c2pool's m_share_getter is shared, so the ownership is tracked
+    // here (ltc node.hpp:511 parity).
+    std::map<uint256, NetService> m_pending_share_reqs;
+    // Best-share adverts learned in handle_version, awaiting download. The
+    // inline (vtable) handle_version body must stay link-free for the
+    // rig-free KAT targets (they build NodeImpl WITHOUT the node.cpp TU), so
+    // it QUEUES here; run_think()'s IO phase + the advert timer started by
+    // start_outbound_connections() (both node.cpp) drain the queue into
+    // download_shares — the oracle p2p.py handle_version →
+    // node.handle_share_hashes join trigger, one hop later.
+    std::vector<std::pair<std::weak_ptr<peer_t>, uint256>> m_peer_best_adverts;
+
+    // ── Outbound dialing (btc/ltc start_outbound_connections port) ──────
+    static constexpr size_t DEFAULT_TARGET_OUTBOUND_PEERS = 8;
+    size_t m_max_peers = 30;
+    size_t m_target_outbound_peers = DEFAULT_TARGET_OUTBOUND_PEERS;
+    std::unique_ptr<core::Timer> m_connect_timer;   // 30s dial maintenance
+    std::unique_ptr<core::Timer> m_advert_timer;    // 2s best-advert drain
+    std::set<NetService> m_pending_outbound;  // addresses currently being dialed
+    std::set<NetService> m_outbound_addrs;    // established outbound peers
+
+    // ── P2P ban list (btc node.hpp:533-545 port) ────────────────────────
+    // Peers that fed unverifiable shares (think()'s bad_peer_addresses) are
+    // banned for m_ban_duration; expired entries are swept each think cycle.
+    std::map<NetService, std::chrono::steady_clock::time_point> m_ban_list;
+    std::chrono::seconds m_ban_duration{300};   // 5 minutes (configurable)
+    std::map<std::string, std::chrono::steady_clock::time_point> m_ip_ban_list;
+    // Whitelist: permanent dial targets (--addnode/--connect bootstrap seeds)
+    // are immune to bans — banning the only seed of a small mesh would lock
+    // the node out of its own pool (btc is_banned whitelist-bypass parity;
+    // populated from the config bootstrap list in the ctor).
+    std::set<std::string> m_whitelist_ips;
+    std::set<NetService> m_whitelist_hosts;
+
 public:
     // Default (rig-free) construction for tests/standalone: no io_context, the
-    // share-getter requester is a no-op (reception slice supplies the real
-    // sharereq writer). Routes m_chain at the tracker's main chain so any
-    // BaseNode path that reads m_chain is valid.
+    // share-getter requester is a no-op (there are no peers to write a
+    // sharereq to; the ctx ctor below wires the real writer). Routes m_chain
+    // at the tracker's main chain so any BaseNode path that reads m_chain is
+    // valid.
     NodeImpl()
         : m_share_getter(nullptr,
             [](uint256, peer_ptr, std::vector<uint256>, uint64_t, std::vector<uint256>){})
@@ -232,14 +276,28 @@ public:
 
     NodeImpl(boost::asio::io_context* ctx, config_t* config)
         : base_t(ctx, config),
-          // Slice A keeps the share-getter wired with a no-op requester; the
-          // reception slice (B) replaces this with the real sharereq writer.
+          // #754 share-download leg: the REAL sharereq writer (ltc
+          // node.hpp:162-170 parity) — packs the request through the
+          // message_sharereq wire codec and writes it to the chosen peer.
           m_share_getter(ctx,
-            [](uint256, peer_ptr, std::vector<uint256>, uint64_t, std::vector<uint256>){},
+            [](uint256 req_id, peer_ptr to_peer,
+               std::vector<uint256> hashes, uint64_t parents,
+               std::vector<uint256> stops)
+            {
+                auto rmsg = dash::message_sharereq::make_raw(
+                    req_id, hashes, parents, stops);
+                to_peer->write(std::move(rmsg));
+            },
             15)  // p2pool p2p.py:80 — 15s timeout for share requests
     {
         // Seed addr store with hardcoded bootstrap peers.
         m_addrs.load(config->pool()->m_bootstrap_addrs);
+        // Bootstrap seeds are whitelisted: permanent dial targets are immune
+        // to bans (btc is_banned whitelist-bypass parity).
+        for (const auto& seed : config->pool()->m_bootstrap_addrs) {
+            m_whitelist_ips.insert(seed.address());
+            m_whitelist_hosts.insert(seed);
+        }
         // Randomise our nonce so we detect self-connections.
         std::mt19937_64 rng(std::random_device{}());
         m_nonce = rng();
@@ -308,15 +366,100 @@ public:
     // INLINE (not node.cpp): connected() is virtual, so its body must be
     // visible to every TU that emits the NodeImpl vtable — the link-deferred
     // KAT targets instantiate NodeImpl without the node.cpp TU.
+    // ── P2P ban check (btc node.cpp:2183-2196 port, inline for the vtable-
+    // complete KAT targets). Whitelisted permanent dial targets bypass bans.
+    bool is_whitelisted(const NetService& addr) const
+    {
+        return m_whitelist_ips.contains(addr.address())
+            || m_whitelist_hosts.contains(addr);
+    }
+    bool is_banned(const NetService& addr) const
+    {
+        if (is_whitelisted(addr)) return false;
+        const auto now = std::chrono::steady_clock::now();
+        auto it = m_ban_list.find(addr);
+        if (it != m_ban_list.end() && it->second > now) return true;
+        auto ip_it = m_ip_ban_list.find(addr.address());
+        if (ip_it != m_ip_ban_list.end() && ip_it->second > now) return true;
+        return false;
+    }
+    void set_ban_duration(int seconds) { m_ban_duration = std::chrono::seconds(seconds); }
+
     void connected(std::shared_ptr<core::Socket> socket) override
     {
+        // Reject banned peers (btc node.cpp:133-139).
+        if (is_banned(socket->get_addr()))
+        {
+            LOG_INFO << "[Pool] Rejecting connection from banned peer "
+                     << socket->get_addr().to_string();
+            socket->close();
+            return;
+        }
+
+        // Outbound lifecycle tracking (#754, ltc node.cpp:128-149): a dial we
+        // initiated graduates from pending to established.
+        const bool is_outbound = m_pending_outbound.erase(socket->get_addr()) > 0;
+
         // BaseNode creates the peer + timeout timer; then OPEN the handshake.
         // p2pool sends version from both sides on connectionMade — a silent
         // side gets dropped by the remote's handshake timeout.
         base_t::connected(socket);
         auto it = m_connections.find(socket->get_addr());
         if (it != m_connections.end())
+        {
+            if (is_outbound)
+                m_outbound_addrs.insert(socket->get_addr());
             send_version(it->second);
+        }
+    }
+
+    // ── Disconnect cleanup (#754, ltc node.cpp:151-241 reduced) ─────────
+    // Cancel this peer's pending share requests (invokes their callbacks with
+    // an empty reply so the download gate releases the hashes immediately
+    // instead of waiting out the 15s ReplyMatcher timeout — p2pool p2p.py:595
+    // get_shares.respond_all on connectionLost), drop its stale nonce entry
+    // from m_peers (without this, reconnects are rejected as false
+    // duplicates), and clear the outbound tracking. INLINE (vtable bodies must
+    // stay link-free for the rig-free KAT targets).
+    using base_t::error;   // keep the error_code overload visible
+    void error(const message_error_type& err, const NetService& service,
+               const std::source_location where =
+                   std::source_location::current()) override
+    {
+        cancel_peer_share_requests(service);
+        for (auto it = m_peers.begin(); it != m_peers.end(); )
+        {
+            if (it->second && it->second->addr() == service)
+                it = m_peers.erase(it);
+            else
+                ++it;
+        }
+        m_pending_outbound.erase(service);
+        m_outbound_addrs.erase(service);
+        base_t::error(err, service, where);
+    }
+
+    void close_connection(const NetService& service) override
+    {
+        cancel_peer_share_requests(service);
+        m_pending_outbound.erase(service);
+        m_outbound_addrs.erase(service);
+        base_t::close_connection(service);
+    }
+
+    void cancel_peer_share_requests(const NetService& service)
+    {
+        std::vector<uint256> to_cancel;
+        for (const auto& [req_id, peer_addr] : m_pending_share_reqs)
+        {
+            if (peer_addr == service)
+                to_cancel.push_back(req_id);
+        }
+        for (const auto& req_id : to_cancel)
+        {
+            m_pending_share_reqs.erase(req_id);
+            m_share_getter.cancel(req_id);  // fires callback with empty reply
+        }
     }
 
     void send_version(peer_ptr peer)
@@ -395,6 +538,23 @@ public:
         peer->m_nonce = msg->m_nonce;
         m_peers[peer->m_nonce] = peer;
 
+        // #754 join trigger (oracle p2p.py handle_version → node.py
+        // handle_share_hashes): a peer advertising a best share we don't have
+        // is THE download entry point for an empty node joining an
+        // established chain. QUEUED, not called directly — download_shares
+        // lives in node.cpp and this inline vtable body must stay link-free
+        // for the rig-free KAT targets; run_think()'s IO phase and the
+        // 2s advert timer (start_outbound_connections) drain the queue.
+        if (!msg->m_best_share.IsNull())
+        {
+            LOG_INFO << "[Pool] Peer " << peer->addr().to_string()
+                     << " advertises best share "
+                     << msg->m_best_share.ToString().substr(0, 16)
+                     << (m_chain->contains(msg->m_best_share)
+                             ? " (known)" : " (unknown — queued for download)");
+            m_peer_best_adverts.emplace_back(peer, msg->m_best_share);
+        }
+
         // Legacy/actual split for the G2 dual-pool: only once the operator has
         // ratcheted the floor above the oracle baseline do at-or-above-floor
         // peers negotiate the actual (v36) protocol; otherwise legacy (parity
@@ -446,6 +606,13 @@ public:
     void run_think();
     void drain_pending_adds();
 
+    /// Periodic maintenance (btc node.cpp:1878-2173 / p2pool node.py:355-402
+    /// clean_tracker port): think + eat stale heads + drop tails beyond
+    /// 2*CHAIN_LENGTH+10 + LevelDB prune flush, all on the compute thread
+    /// under the exclusive lock. Body in node.cpp; scheduled by the run
+    /// loop's periodic tick. Without it the raw chain grows unbounded.
+    void clean_tracker();
+
     /// Verified-work-first best share (mint_runloop.hpp elect_best_share
     /// policy — btc parity). ZERO with peers but no verified chain (never
     /// mint on an unverified foreign chain); raw-head bootstrap on genesis.
@@ -473,6 +640,37 @@ public:
 
     void set_on_best_share_changed(std::function<void()> fn) { m_on_best_share_changed = std::move(fn); }
     void set_block_rel_height_fn(std::function<int32_t(uint256)> fn) { m_block_rel_height_fn = std::move(fn); }
+
+    // ── #754 share-download leg surface ─────────────────────────────────
+
+    /// Async share download: register the reply callback + dispatch the
+    /// sharereq through the ctor's writer (ltc node.hpp:275-281 parity).
+    void request_shares(uint256 id, peer_ptr peer,
+                        std::vector<uint256> hashes, uint64_t parents,
+                        std::vector<uint256> stops,
+                        std::function<void(dash::ShareReplyData)> callback)
+    {
+        m_share_getter.request(id, callback, id, peer, hashes, parents, stops);
+    }
+
+    /// Request `target_hash` (+ a random 0..499-parent chunk, stops-bounded)
+    /// from a peer; on reply, feed the shares into processing_shares and
+    /// continue backfilling from the oldest parent. Body in node.cpp (ltc
+    /// node.cpp:968-1105 port).
+    void download_shares(peer_ptr peer, const uint256& target_hash);
+
+    /// Drain the handle_version best-share advert queue into
+    /// download_shares (unknown) / run_think (known). Body in node.cpp.
+    void drain_peer_best_adverts();
+
+    /// Dial outbound peers from the AddrStore (--addnode/--connect seeds) and
+    /// start the 30s dial-maintenance + 2s advert-drain timers. Call once
+    /// from the run loop after listen(). Body in node.cpp (ltc
+    /// node.cpp:1289-1327 port).
+    void start_outbound_connections();
+
+    void set_target_outbound_peers(size_t count) { m_target_outbound_peers = count; }
+    void set_max_peers(size_t count) { m_max_peers = count; }
 
     // Completes a pending async share request when a sharereply arrives.
     // Inline (mirrors dgb) so the reply-matcher plumbing needs no node.cpp.

--- a/src/pool/share_download.hpp
+++ b/src/pool/share_download.hpp
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// Shared sharechain-download helpers (#754) — the coin-agnostic half of the
+// p2pool share-download loop, extracted from the PROVEN ltc reference
+// (src/impl/ltc/node.cpp:968-1105 download_shares + :1600-1618 think()-desired
+// dispatch), which itself mirrors the python p2pool oracle (node.py
+// Node.download_shares + p2p.py Protocol.get_shares).
+//
+// ONE downloader, reused per coin (operator direction): every coin node
+// (ltc/btc/dgb/dash/bch) runs the same request-planning + retry-gating logic;
+// only the per-coin seams (message codec instance, ShareType, tracker,
+// processing pipeline) stay in each NodeImpl. This header is ADDITIVE shared
+// core: nothing existing links it until a coin opts in (dash first — #754);
+// migrating the ltc/btc/dgb inline copies onto it is a mechanical follow-up.
+//
+// Header-only on purpose: the dash pool-node KAT targets are link-deferred
+// (they instantiate NodeImpl without the node.cpp TU), and the download-leg
+// KAT (test/test_dash_share_download.cpp) must drive the same code the node
+// runs without sockets.
+
+#include <core/uint256.hpp>
+
+#include <algorithm>
+#include <map>
+#include <set>
+#include <vector>
+
+namespace pool::download
+{
+
+// oracle node.py download loop: parents=random.randrange(500) — a RANDOM chunk
+// size per request, NOT a fixed 500 (mirrors ltc node.cpp:1010).
+inline constexpr uint64_t PARENTS_RANGE = 500;
+
+// oracle: stops list truncated [:100] (node.py download loop; ltc:1035-1039).
+inline constexpr std::size_t STOPS_CAP = 100;
+
+// Empty-reply cap per hash per think() cycle (ltc node.hpp:504). p2pool has no
+// permanent blacklist — it re-adds desired from scratch every loop iteration
+// with sleep(1) backoff; the cap is reset each think() cycle to match
+// (permanent blacklisting stalls bootstrap: ltc node.cpp:1603-1608).
+inline constexpr int MAX_EMPTY_RETRIES = 3;
+
+// De-dup + retry gate for in-flight share downloads. IO-thread only (all
+// mutation happens on the io_context thread: think()'s IO phase, the
+// sharereply callbacks, and the ReplyMatcher timeout timers).
+struct DownloadGate
+{
+    std::set<uint256> in_flight;          // hashes with a pending sharereq
+    std::map<uint256, int> fail_count;    // consecutive empty replies per hash
+
+    // True if `h` may be requested now (not already in flight, not failed
+    // out this cycle); marks it in flight. Mirrors ltc node.cpp:978-994.
+    bool try_begin(const uint256& h)
+    {
+        if (in_flight.count(h))
+            return false;
+        auto it = fail_count.find(h);
+        if (it != fail_count.end() && it->second >= MAX_EMPTY_RETRIES)
+            return false;
+        in_flight.insert(h);
+        return true;
+    }
+
+    // The request was not actually dispatched (no peers / tracker busy).
+    void abort(const uint256& h) { in_flight.erase(h); }
+
+    // Empty reply or ReplyMatcher timeout: release + count the failure.
+    // Returns the new failure count (for logging against MAX_EMPTY_RETRIES).
+    int on_empty(const uint256& h)
+    {
+        in_flight.erase(h);
+        return ++fail_count[h];
+    }
+
+    // Non-empty reply: release + clear the failure history for the hash.
+    void on_success(const uint256& h)
+    {
+        in_flight.erase(h);
+        fail_count.erase(h);
+    }
+
+    // think()-cycle reset (ltc node.cpp:1600-1608): clear the stale download
+    // set and the fail counts so desired hashes are retried from scratch.
+    void new_cycle()
+    {
+        in_flight.clear();
+        fail_count.clear();
+    }
+};
+
+// stops = known heads + their min(max(0, height-1), 10)-th parents, capped at
+// STOPS_CAP (oracle node.py download loop stops=...[:100]; ltc:1022-1040
+// port). Bounds each reply to the actual info-gap between our chain and the
+// peer's — without stops the peer dumps up to `parents` shares along one
+// lineage per request, which can cross 2*CHAIN_LENGTH+10 during bootstrap and
+// get drop-tailed. Caller must hold (or be safe without) the tracker lock.
+template <typename ChainT>
+std::vector<uint256> build_stops(ChainT& chain)
+{
+    std::set<uint256> stop_set;
+    for (const auto& [head_hash, tail_hash] : chain.get_heads())
+    {
+        stop_set.insert(head_hash);
+        const int h = chain.get_acc_height(head_hash);
+        const int nth = std::min(std::max(0, h - 1), 10);
+        if (nth > 0)
+        {
+            auto parent = chain.get_nth_parent_via_skip(head_hash, nth);
+            if (!parent.IsNull())
+                stop_set.insert(parent);
+        }
+    }
+    std::vector<uint256> stops;
+    for (const auto& s : stop_set)
+    {
+        if (stops.size() >= STOPS_CAP)
+            break;
+        stops.push_back(s);
+    }
+    return stops;
+}
+
+// Backfill continuation rule (ltc node.cpp:1093-1102): a sharereply carries
+// shares child→parent (handle_get_share's get_chain walk order), so the LAST
+// item is the oldest; its prev_hash is the next download target when still
+// unknown. Returns ZERO for an empty batch (nothing to continue from) or when
+// the oldest share is the chain genesis (prev == ZERO → fully rooted).
+// ShareVecT = std::vector<coin ShareType> (the coin's share variant exposes
+// invoke() over the concrete share object).
+template <typename ShareVecT>
+uint256 oldest_parent(ShareVecT& items)
+{
+    if (items.empty())
+        return uint256::ZERO;
+    uint256 prev;
+    items.back().invoke([&](auto* obj) { prev = obj->m_prev_hash; });
+    return prev;
+}
+
+} // namespace pool::download

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -385,11 +385,18 @@ if (BUILD_TESTING AND GTest_FOUND)
     # mint_from_inputs -> tracker insert -> wire round-trip -> best-share
     # election -> PPLNS oracle-window pin. Same allowlisted target (proven
     # pattern), no build.yml change.
+    # test_dash_share_download.cpp (#754 share-download leg): sharereq wire
+    # byte-parity vs the python oracle layout, DownloadGate de-dup/retry/
+    # cycle-reset, build_stops, and the download-gate proof -- a mocked
+    # sharereply's shares (RawShare round-trip, child->parent order) insert +
+    # verify and ROOT a previously-unrooted live-pushed tip. Same allowlisted
+    # target (proven pattern), no build.yml change.
     add_executable(test_dash_share_hash_link
         test_dash_share_hash_link.cpp
         test_dash_share_producer.cpp
         test_dash_share_producer_bind.cpp
-        test_dash_mint_runloop.cpp)
+        test_dash_mint_runloop.cpp
+        test_dash_share_download.cpp)
     target_link_libraries(test_dash_share_hash_link PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core

--- a/test/test_dash_share_download.cpp
+++ b/test/test_dash_share_download.cpp
@@ -1,0 +1,362 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// DASH share-download leg KATs (#754 — the outbound sharereq/backfill slice).
+//
+// The download leg is what lets an EMPTY c2pool-dash node JOIN an established
+// p2pool-dash sharechain: think() computes the `desired` missing-parent set,
+// download_shares (node.cpp) dispatches a sharereq via the ReplyMatcher, the
+// sharereply's shares ride the SAME reception pipeline live pushes use, and
+// the downloaded ancestors ROOT the previously-unverifiable pushed shares.
+//
+// Rig-free coverage (no sockets, no io_context — the link-deferred KAT
+// pattern; the shared planning/gating logic lives in pool/share_download.hpp
+// exactly so this KAT drives the code the node runs):
+//   (1) sharereq WIRE BYTE-PARITY: the message payload matches the python
+//       p2pool oracle layout (p2p.py 'sharereq' ComposedType: 32B LE id,
+//       CompactSize-prefixed hash list, VarInt parents, CompactSize-prefixed
+//       stops list) — a malformed request gets the node BANNED, so the bytes
+//       are pinned by hand, not by round-trip alone.
+//   (2) DownloadGate: in-flight de-dup, empty-reply retry cap, per-think-cycle
+//       reset (p2pool re-adds desired from scratch each cycle).
+//   (3) build_stops: heads + capped nth-parents from a real minted chain.
+//   (4) THE DOWNLOAD GATE PROOF: a live-pushed share with missing ancestors
+//       stays UNROOTED (verified=0); a mocked sharereply carrying the
+//       ancestors (RawShare wire round-trip, child→parent order exactly as
+//       handle_get_share serves them) is inserted through load_share +
+//       tracker.add + attempt_verify — verified climbs 0→N and the previously
+//       unrooted tip ROOTS. oldest_parent() drives the continuation until the
+//       genesis share (prev=ZERO) ends the backfill.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/mint_runloop.hpp>
+#include <impl/dash/share_tracker.hpp>
+#include <impl/dash/share_chain.hpp>
+#include <impl/dash/share_check.hpp>       // pubkey_hash_to_script2
+#include <impl/dash/params.hpp>
+#include <impl/dash/messages.hpp>
+#include <impl/dash/crypto/hash_x11.hpp>
+#include <impl/dash/coinbase_builder.hpp>  // merkle_branches_raw / sha256d
+#include <impl/bitcoin_family/coin/base_block.hpp>
+
+#include <pool/share_download.hpp>
+
+#include <core/coin_params.hpp>
+#include <core/pack_types.hpp>
+#include <core/target_utils.hpp>
+#include <core/uint256.hpp>
+
+#include <cstring>
+#include <vector>
+
+namespace {
+
+using dash::mint::build_producer_job;
+using dash::mint::mint_from_inputs;
+using MintShareInputs = dash::stratum::DASHWorkSource::MintShareInputs;
+
+uint256 h256_tag(uint8_t tag)
+{
+    std::vector<unsigned char> v(32, 0x00);
+    v[0] = tag; v[31] = 0x5a;
+    return uint256(v);
+}
+
+uint160 h160_uniform(uint8_t tag)
+{
+    return uint160(std::vector<unsigned char>(20, tag));
+}
+
+// Easy-PoW params (mint-runloop KAT pattern): mainnet DASH params except
+// max_target, so the nonce search solves in a few thousand X11 hashes.
+core::CoinParams easy_params()
+{
+    core::CoinParams p = dash::make_coin_params(false);
+    p.max_target.SetHex("00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    return p;
+}
+
+dash::coin::DashWorkData make_workdata(uint8_t prev_tag = 0x77)
+{
+    dash::coin::DashWorkData wd;
+    wd.m_version        = 536870912;
+    wd.m_previous_block = h256_tag(prev_tag);
+    wd.m_height         = 1000;
+    wd.m_coinbase_value = 500000000;
+    wd.m_bits           = 0x1b00ffffu;
+    wd.m_curtime        = 1700000005;
+    return wd;
+}
+
+// Full miner-side solve of one producer job (trimmed copy of the
+// test_dash_mint_runloop.cpp scaffold — same target, separate TU).
+struct SolvedShare
+{
+    dash::ShareType share;
+    uint256 hash;
+    bool ok{false};
+};
+
+SolvedShare solve_share(dash::ShareChain& chain, const core::CoinParams& params,
+                        const uint256& prev, const uint160& miner_pkh,
+                        uint32_t share_nonce)
+{
+    SolvedShare out;
+    const auto payout_script = dash::pubkey_hash_to_script2(miner_pkh);
+    const auto wd = make_workdata();
+
+    auto built = build_producer_job(chain, params, prev, payout_script, wd,
+                                    /*desired_timestamp=*/wd.m_curtime,
+                                    share_nonce, /*donation=*/0, "c2pool");
+    if (!built)
+        return out;
+    const auto& job = built->job;
+
+    std::vector<unsigned char> coinb1(job.gentx_bytes.begin(),
+                                      job.gentx_bytes.begin() + job.nonce64_offset);
+    std::vector<unsigned char> coinb2(job.gentx_bytes.begin() + job.nonce64_offset + 8,
+                                      job.gentx_bytes.end());
+    const std::vector<unsigned char> en1 = {0x01, 0x02, 0x03, 0x04};
+    const std::vector<unsigned char> en2 = {0x05, 0x06, 0x07, 0x08};
+
+    std::vector<unsigned char> coinbase;
+    coinbase.insert(coinbase.end(), coinb1.begin(), coinb1.end());
+    coinbase.insert(coinbase.end(), en1.begin(), en1.end());
+    coinbase.insert(coinbase.end(), en2.begin(), en2.end());
+    coinbase.insert(coinbase.end(), coinb2.begin(), coinb2.end());
+
+    uint256 merkle_root = dash::coinbase::sha256d(
+        std::span<const unsigned char>(coinbase.data(), coinbase.size()));
+
+    const uint256 share_target = chain::bits_to_target(job.share_bits);
+    bitcoin_family::coin::BlockHeaderType hdr;
+    hdr.m_version        = wd.m_version;
+    hdr.m_previous_block = wd.m_previous_block;
+    hdr.m_merkle_root    = merkle_root;
+    hdr.m_timestamp      = wd.m_curtime;
+    hdr.m_bits           = wd.m_bits;
+
+    uint256 pow_hash;
+    std::vector<unsigned char> header_bytes;
+    bool solved = false;
+    for (uint32_t nonce = 0; nonce < 2000000; ++nonce) {
+        hdr.m_nonce = nonce;
+        PackStream ps;
+        ps << hdr;
+        header_bytes.assign(
+            reinterpret_cast<const unsigned char*>(ps.data()),
+            reinterpret_cast<const unsigned char*>(ps.data()) + ps.size());
+        pow_hash = dash::crypto::hash_x11(header_bytes.data(), header_bytes.size());
+        if (pow_hash <= share_target) { solved = true; break; }
+    }
+    if (!solved)
+        return out;
+
+    MintShareInputs in;
+    in.header_bytes    = header_bytes;
+    in.coinbase_bytes  = coinbase;
+    in.subsidy         = wd.m_coinbase_value;
+    in.prev_share_hash = prev;
+    in.merkle_branches = {};
+    in.payout_script   = payout_script;
+    in.pow_hash        = pow_hash;
+    std::memcpy(in.ref_hash.begin(), coinb1.data() + coinb1.size() - 32, 32);
+    uint64_t n64 = 0;
+    {
+        unsigned char cat[8];
+        std::memcpy(cat, en1.data(), 4);
+        std::memcpy(cat + 4, en2.data(), 4);
+        for (int i = 7; i >= 0; --i) n64 = (n64 << 8) | cat[i];
+    }
+    in.last_txout_nonce = n64;
+
+    auto minted = mint_from_inputs(chain, params, in, built->frozen);
+    if (!minted)
+        return out;
+    out.hash  = minted->share.m_hash;
+    out.share = new dash::DashShare(minted->share);
+    out.ok    = true;
+    return out;
+}
+
+// Wire round-trip: pack the share into the RawShare form a sharereply
+// carries, then load it back exactly as HANDLER(sharereply) does.
+chain::RawShare to_raw(dash::ShareType& share)
+{
+    return chain::RawShare(share.version(), pack(share));
+}
+
+void append_u256(std::vector<unsigned char>& out, const uint256& v)
+{
+    out.insert(out.end(), v.data(), v.data() + 32);
+}
+
+}  // namespace
+
+// (1) sharereq wire byte-parity vs the python oracle layout (p2p.py
+//     'sharereq': IntType(256) id, ListType(IntType(256)) hashes,
+//     VarIntType() parents, ListType(IntType(256)) stops). IntType(256) is
+//     32 raw LE bytes; ListType/VarIntType are bitcoin CompactSize. A
+//     divergent request (wrong field order, fixed-width parents, missing
+//     prefix) would get c2pool disconnected/banned by every oracle peer.
+TEST(DashShareDownload, ShareReqWireBytesOracleParity)
+{
+    const uint256 id = h256_tag(0xA1);
+    const uint256 h1 = h256_tag(0xB2);
+    const uint256 h2 = h256_tag(0xC3);
+    const uint256 s1 = h256_tag(0xD4);
+    const uint64_t parents = 37;
+
+    auto rmsg = dash::message_sharereq::make_raw(id, {h1, h2}, parents, {s1});
+    ASSERT_EQ(rmsg->m_command, "sharereq");
+
+    std::vector<unsigned char> expected;
+    append_u256(expected, id);          // id: 32 raw LE bytes
+    expected.push_back(0x02);           // hashes: CompactSize(2)
+    append_u256(expected, h1);
+    append_u256(expected, h2);
+    expected.push_back(0x25);           // parents: VarInt/CompactSize(37)
+    expected.push_back(0x01);           // stops: CompactSize(1)
+    append_u256(expected, s1);
+
+    const auto* raw = reinterpret_cast<const unsigned char*>(rmsg->m_data.data());
+    std::vector<unsigned char> got(raw, raw + rmsg->m_data.size());
+    EXPECT_EQ(got, expected);
+
+    // And the parse side (what the oracle's reply/serve path exercises).
+    auto parsed = dash::message_sharereq::make(rmsg->m_data);
+    EXPECT_EQ(parsed->m_id, id);
+    ASSERT_EQ(parsed->m_hashes.size(), 2u);
+    EXPECT_EQ(parsed->m_hashes[0], h1);
+    EXPECT_EQ(parsed->m_hashes[1], h2);
+    EXPECT_EQ(parsed->m_parents, parents);
+    ASSERT_EQ(parsed->m_stops.size(), 1u);
+    EXPECT_EQ(parsed->m_stops[0], s1);
+}
+
+// (2) DownloadGate: de-dup while in flight, empty-reply cap, cycle reset.
+TEST(DashShareDownload, DownloadGateDedupRetryCapAndCycleReset)
+{
+    pool::download::DownloadGate gate;
+    const uint256 h = h256_tag(0x11);
+
+    EXPECT_TRUE(gate.try_begin(h));    // first request goes out
+    EXPECT_FALSE(gate.try_begin(h));   // in flight — de-duped
+
+    // Empty replies release the hash but count failures.
+    for (int i = 1; i <= pool::download::MAX_EMPTY_RETRIES; ++i) {
+        EXPECT_EQ(gate.on_empty(h), i);
+        if (i < pool::download::MAX_EMPTY_RETRIES)
+            EXPECT_TRUE(gate.try_begin(h));   // retried below the cap
+    }
+    EXPECT_FALSE(gate.try_begin(h));   // failed out this cycle
+
+    // think()-cycle reset: p2pool re-adds desired from scratch each cycle.
+    gate.new_cycle();
+    EXPECT_TRUE(gate.try_begin(h));
+
+    // A success clears the failure history.
+    gate.on_empty(h);
+    EXPECT_TRUE(gate.try_begin(h));
+    gate.on_success(h);
+    EXPECT_TRUE(gate.fail_count.empty());
+    EXPECT_TRUE(gate.in_flight.empty());
+}
+
+// (3)+(4) THE DOWNLOAD GATE PROOF on real minted shares.
+TEST(DashShareDownload, MockedShareReplyRootsUnrootedLiveShares)
+{
+    const auto params = easy_params();
+
+    // "Peer" side: an established chain g <- m <- t (genesis, middle, tip).
+    dash::ShareTracker peer_tracker;
+    peer_tracker.m_coin_params = params;
+    auto g = solve_share(peer_tracker.chain, params, uint256(), h160_uniform(0x21), 1);
+    ASSERT_TRUE(g.ok);
+    peer_tracker.add(g.share);
+    auto m = solve_share(peer_tracker.chain, params, g.hash, h160_uniform(0x21), 2);
+    ASSERT_TRUE(m.ok);
+    peer_tracker.add(m.share);
+    auto t = solve_share(peer_tracker.chain, params, m.hash, h160_uniform(0x21), 3);
+    ASSERT_TRUE(t.ok);
+    peer_tracker.add(t.share);
+
+    // Empty joining node receives the TIP via live push — parents missing.
+    dash::ShareTracker node;
+    node.m_coin_params = params;
+    {
+        auto raw = to_raw(t.share);
+        auto pushed = dash::load_share(raw, NetService{"kat", 0});
+        pushed.ACTION({
+            obj->m_hash = dash::share_init_verify(*obj, node.m_coin_params, true);
+        });
+        ASSERT_EQ(pushed.hash(), t.hash);
+        node.add(pushed);
+    }
+    // Unrooted: attempt_verify must NOT verify it (its ancestry is unknown),
+    // and must not throw — this is the #754 pre-download steady state.
+    EXPECT_FALSE(node.attempt_verify(t.hash));
+    EXPECT_EQ(node.verified.size(), 0u);
+
+    // think()'s desired set would name the missing parent; the download leg
+    // requests it. Mock the ORACLE's sharereply: handle_get_share serves the
+    // chain child→parent, so the reply for hashes=[m.hash] with parents is
+    // [m, g] (RawShare wire form — byte round-trip like the real handler).
+    std::vector<dash::ShareType> reply_items;
+    for (auto* s : {&m, &g}) {
+        auto raw = to_raw(s->share);
+        auto loaded = dash::load_share(raw, NetService{"kat", 0});
+        loaded.ACTION({
+            obj->m_hash = dash::share_init_verify(*obj, node.m_coin_params, true);
+        });
+        reply_items.push_back(loaded);
+    }
+    ASSERT_EQ(reply_items[0].hash(), m.hash);
+    ASSERT_EQ(reply_items[1].hash(), g.hash);
+
+    // Backfill continuation rule: the oldest received share is the genesis
+    // (prev=ZERO) → oldest_parent ends the pull.
+    EXPECT_EQ(pool::download::oldest_parent(reply_items), uint256::ZERO);
+
+    // Insert through the same seam the node's reception path uses
+    // (tracker.add), then verify as think()'s bootstrap pass does.
+    for (auto& s : reply_items)
+        node.add(s);
+    EXPECT_TRUE(node.attempt_verify(g.hash));
+    EXPECT_TRUE(node.attempt_verify(m.hash));
+    // THE POINT: the previously-unrooted live-pushed tip now verifies.
+    EXPECT_TRUE(node.attempt_verify(t.hash));
+    EXPECT_EQ(node.verified.size(), 3u);
+    EXPECT_TRUE(node.verified.contains(t.hash));
+
+    // (3) build_stops over the joined chain: contains the head, capped size.
+    auto stops = pool::download::build_stops(node.chain);
+    ASSERT_FALSE(stops.empty());
+    EXPECT_LE(stops.size(), pool::download::STOPS_CAP);
+    bool head_in_stops = false;
+    for (const auto& s : stops) head_in_stops |= (s == t.hash);
+    EXPECT_TRUE(head_in_stops);
+}
+
+// oldest_parent: mid-chain reply continues from the deepest received share's
+// parent (the next sharereq target), empty batch returns ZERO.
+TEST(DashShareDownload, OldestParentContinuationTarget)
+{
+    const auto params = easy_params();
+    dash::ShareTracker tr;
+    tr.m_coin_params = params;
+    auto a = solve_share(tr.chain, params, uint256(), h160_uniform(0x31), 7);
+    ASSERT_TRUE(a.ok);
+    tr.add(a.share);
+    auto b = solve_share(tr.chain, params, a.hash, h160_uniform(0x31), 8);
+    ASSERT_TRUE(b.ok);
+    tr.add(b.share);
+    auto c = solve_share(tr.chain, params, b.hash, h160_uniform(0x31), 9);
+    ASSERT_TRUE(c.ok);
+
+    // Reply chunk [c, b] (child→parent): continuation target is b's parent a.
+    std::vector<dash::ShareType> chunk = {c.share, b.share};
+    EXPECT_EQ(pool::download::oldest_parent(chunk), a.hash);
+
+    std::vector<dash::ShareType> empty;
+    EXPECT_TRUE(pool::download::oldest_parent(empty).IsNull());
+}


### PR DESCRIPTION
## The gap (#754, re-verified on master e01dece6)

The DASH pool-node was ported from the btc parent but stopped before the OUTBOUND half:

- `src/impl/dash/node.cpp` think() computed the `desired` missing-parent set and dropped it — log-only: *"desired share(s) not requested — the DASH share-download leg is a later slice"*.
- `m_share_getter` (ReplyMatcher) only ever `.got_response()`, never `.request()`; the ctor's sharereq writer was a no-op lambda.
- The node never dialed out (`start_outbound_connections` absent — main_dash carried the TODO comment), had no ban list (log-only bad-peer handling), and no clean/prune (unbounded raw-chain growth).

Consequence: an EMPTY c2pool-dash could not JOIN an established p2pool-dash sharechain — live pushes arrived but could never root (`verified=0` forever). Only genesis-present operation worked. This gated the p2pool-dash co-run / Phase-2 crossing.

## The port (faithful copy from the proven parents; dash types only)

1. **Share download / backfill (#754)** — ltc/btc `download_shares` port: handshake best-share advert triggers the join (oracle `p2p.py handle_version → handle_share_hashes`); think()'s desired set dispatches per-cycle; `sharereq` rides the existing ReplyMatcher (15s timeout, random `parents=randrange(500)`, stops = heads + 10th parents capped 100); replies feed the SAME `processing_shares` pipeline reception uses; backfill continues from the oldest received share's parent until rooted. Per-peer pending-request cancellation on disconnect (`get_shares.respond_all` parity).
   - The coin-agnostic planning/gating (stops builder, retry gate, continuation rule, constants) is extracted to a NEW **additive** shared header `src/pool/share_download.hpp` (`pool::download`) — dash consumes it now; migrating the btc/ltc/dgb inline copies onto it is a mechanical follow-up toward the one-shared-downloader goal. No existing file in src/pool touched.
2. **Ban list** — btc port: `m_ban_list`/`m_ip_ban_list` + `is_banned` + think-cycle ban of unverifiable-share feeders + expiry sweep + rejection in `connected()` and the dialer. Bootstrap seeds (--addnode/--connect) are whitelisted (permanent dial targets immune — btc semantics).
3. **Outbound dialer** — btc/ltc `start_outbound_connections` port: initial burst + 30s top-up from the AddrStore, outbound lifecycle tracking, stale `m_peers` nonce cleanup on disconnect (reconnects no longer falsely rejected as duplicates).
4. **Clean/prune** — btc `clean_tracker` port (p2pool node.py:355-402): think + stale-head eating (top-5/300s/120s guards) + drop-tails beyond `2*CHAIN_LENGTH+10` + LevelDB prune flush, on the compute thread under the exclusive lock; the run-loop 15s tick now drives it (ltc scheduling parity). (`prune_shares` in the parents is an uncalled legacy body; the live prune is clean_tracker steps 2-3 — not copied.)

## #755 — root cause found + guarded

Reproduced live: the "startup core-dump with unrooted shares" signature is an **uncaught `boost::system::system_error` from the sharechain `listen()` bind (EADDRINUSE from a lingering prior instance)** landing right after the `Loaded N persisted shares` log lines — share-content-independent (datadir wipes appeared to fix it only because the port freed in the meantime). Fixes:
- `listen()` failure now exits cleanly with the real reason (proven live: exit 1 + `[run] FATAL: cannot bind sharechain P2P port 18997: Address already in use`, previously Exit 134 core dump).
- The run loop catches io-handler exceptions non-fatally (btc main parity), and the think/clean IO phases carry the ltc-parity try/catch DASH had omitted — neither a bind race nor a chain-walk throw over a fragmented restart chain can terminate the node.
- Restart on a persisted datadir proven live: `Loaded 82 persisted DASH shares (pre_verified=82)` → best re-elected → node serving.

## Byte-parity

- The `sharereq`/`sharereply` codec is the shared p2pool-family wire shape (identical field layout to ltc's proven codec; matches oracle `p2p.py` ComposedType: 32B LE id, CompactSize hash list, VarInt parents, CompactSize stops).
- KAT pins the REQUEST bytes by hand (not round-trip alone) — a malformed request gets banned by every oracle peer.
- Live proof: the python p2pool-dash oracle answered c2pool's sharereq with 115 shares parsed 100% (0 load failures), and later accepted + built on a c2pool-minted share.

## KATs (test/test_dash_share_download.cpp — existing allowlisted target, no build.yml change)

- `ShareReqWireBytesOracleParity` — hand-assembled oracle byte layout == `message_sharereq::make_raw` payload.
- `DownloadGateDedupRetryCapAndCycleReset` — in-flight de-dup, 3-empty-reply cap, per-think-cycle reset.
- `MockedShareReplyRootsUnrootedLiveShares` — THE download-gate proof: real minted X11 chain, live-pushed tip stays unrooted (verified=0, no throw); a mocked sharereply (RawShare wire round-trip, child→parent order) inserts + verifies and ROOTS the tip (verified 0→3); stops built over the joined chain.
- `OldestParentContinuationTarget` — backfill continuation targets the deepest received share's parent.

All 44 tests in the target pass; `test_dash_node` 8/8; `--selftest` green. Non-dash surfaces untouched (new pool header is additive and only dash includes it).

## Live smoke (.145 testbed, python p2pool-dash `--net dash --testnet`, established chain)

Empty c2pool-dash (fresh datadir) `--addnode 127.0.0.1:19990`:

1. `Dialing outbound peer 127.0.0.1:19990` → connected → `Peer advertises best share 0000024fa05a809b (unknown — queued for download)`
2. `Requesting parent share 0000024fa05a809b (parents=68 stops=0)` → **`Received 69 share(s)`** → recursive continuation `Requesting parent share 0000046f7892847c` → +10 → … to genesis
3. **verified 0 → 81** (chain=81, all rooted+verified)
4. **Tip converge, exact match**: c2pool best `0000039768002606` == python `/web/best_share_hash` `00000397680026063c5be1979963bfc0…`
5. **Mint on top**: cpuminer share → `[MINT] share 0000018ca8183539 minted onto the sharechain (prev=0000039768002606)` — prev IS the downloaded python tip
6. **Cross-accept**: the python node's next best share `00000218b167fe6b…` has `parent: 0000018ca8183539e4c427fbe962bb88…` — the oracle mined ON TOP of the c2pool share; both nodes converged on it. No reorg, no bans, no disconnects.

(An earlier smoke run against a second python instance also joined + tip-matched `000006f1eac0a327…`; that instance later started resetting ALL fresh localhost connections after an unrelated crash-loop had flapped it — python-side in-memory state, reproduced with a raw probe, not a c2pool wire issue.)

## Notes for review

- `new_cycle()` clears the in-flight gate every think cycle (ltc/p2pool parity), so a still-pending request can be re-issued once per cycle — the serve side de-dups and the tracker drops dup inserts; same behavior as ltc.
- The handshake advert is QUEUED (not called inline): the download bodies live in node.cpp and the inline vtable bodies must stay link-free for the link-deferred KAT targets; run_think()'s IO phase + a 2s drain timer consume the queue.
- A follow-up hoist of the whole downloader into a shared `pool::` node base (all coins) reconciles with `pool/share_download.hpp` already carrying the coin-agnostic half.

Closes #754. Closes #755.
