### PR TITLE
pool: hoist ban/whitelist subsystem into pool::SharechainNode (node.cpp reuse, slice 1)

### DIFF
--- a/src/impl/bch/node.cpp
+++ b/src/impl/bch/node.cpp
@@ -2175,155 +2175,18 @@ void NodeImpl::clean_tracker()
     }); // end of m_think_pool lambda
 }
 
-bool NodeImpl::is_whitelisted(const NetService& addr) const
-{
-    const std::string ip = addr.address();
-    if (m_whitelist_ips.contains(ip)) return true;
-    if (m_whitelist_hosts.contains(addr)) return true;
-    return false;
-}
 
-bool NodeImpl::is_banned(const NetService& addr) const
-{
-    // Whitelist bypass: permanent dial targets are immune to bans.
-    if (is_whitelisted(addr)) return false;
-
-    auto now = std::chrono::steady_clock::now();
-    auto it = m_ban_list.find(addr);
-    if (it != m_ban_list.end() && it->second > now) return true;
-
-    auto ip_it = m_ip_ban_list.find(addr.address());
-    if (ip_it != m_ip_ban_list.end() && ip_it->second > now) return true;
-
-    return false;
-}
 
 // ── Admin API implementation ──────────────────────────────────────────
 
-void NodeImpl::set_whitelist_path(const std::string& path)
-{
-    m_whitelist_path = path;
-    if (!path.empty()) load_whitelist_from_disk();
-}
 
-void NodeImpl::load_whitelist_from_disk()
-{
-    if (m_whitelist_path.empty()) return;
-    std::ifstream f(m_whitelist_path);
-    if (!f) return;
-    try {
-        nlohmann::json j;
-        f >> j;
-        if (!j.contains("entries") || !j["entries"].is_array()) return;
-        for (const auto& e : j["entries"]) {
-            if (!e.contains("host") || !e.contains("port")) continue;
-            std::string host = e["host"].get<std::string>();
-            uint16_t port = e["port"].get<uint16_t>();
-            m_whitelist_ips.insert(host);
-            m_whitelist_hosts.insert(NetService(host, port));
-        }
-        LOG_INFO << "[Pool] Loaded " << m_whitelist_hosts.size()
-                 << " whitelist entries from " << m_whitelist_path;
-    } catch (const std::exception& e) {
-        LOG_WARNING << "[Pool] Failed to parse whitelist " << m_whitelist_path
-                    << ": " << e.what();
-    }
-}
 
-void NodeImpl::save_whitelist_to_disk() const
-{
-    if (m_whitelist_path.empty()) return;
-    try {
-        nlohmann::json j;
-        j["version"] = 1;
-        auto arr = nlohmann::json::array();
-        auto now_unix = std::chrono::duration_cast<std::chrono::seconds>(
-            std::chrono::system_clock::now().time_since_epoch()).count();
-        for (const auto& host : m_whitelist_hosts) {
-            arr.push_back({
-                {"host", host.address()},
-                {"port", host.port()},
-                {"added_unix", now_unix}
-            });
-        }
-        j["entries"] = arr;
-        std::string tmp = m_whitelist_path + ".new";
-        {
-            std::ofstream f(tmp);
-            f << j.dump(2);
-        }
-        std::filesystem::rename(tmp, m_whitelist_path);
-    } catch (const std::exception& e) {
-        LOG_WARNING << "[Pool] Failed to persist whitelist: " << e.what();
-    }
-}
 
-static nlohmann::json build_bans_json(
-    const std::map<NetService, std::chrono::steady_clock::time_point>& peer_bans,
-    const std::map<std::string, std::chrono::steady_clock::time_point>& ip_bans)
-{
-    auto now = std::chrono::steady_clock::now();
-    auto arr = nlohmann::json::array();
-    for (const auto& [addr, expiry] : peer_bans) {
-        if (expiry <= now) continue;
-        auto secs = std::chrono::duration_cast<std::chrono::seconds>(expiry - now).count();
-        arr.push_back({{"host", addr.address()}, {"port", addr.port()},
-                       {"expires_in_sec", secs}, {"source", "auto"}});
-    }
-    for (const auto& [ip, expiry] : ip_bans) {
-        if (expiry <= now) continue;
-        auto secs = std::chrono::duration_cast<std::chrono::seconds>(expiry - now).count();
-        arr.push_back({{"host", ip}, {"port", 0},
-                       {"expires_in_sec", secs}, {"source", "admin"}});
-    }
-    return arr;
-}
 
-static nlohmann::json build_whitelist_json(const std::set<NetService>& hosts)
-{
-    auto arr = nlohmann::json::array();
-    for (const auto& h : hosts)
-        arr.push_back({{"host", h.address()}, {"port", h.port()}});
-    return arr;
-}
 
-nlohmann::json NodeImpl::admin_list_bans() const
-{
-    return {{"ok", true}, {"bans", build_bans_json(m_ban_list, m_ip_ban_list)}};
-}
 
-nlohmann::json NodeImpl::admin_ban_ip(const std::string& ip, int duration_sec)
-{
-    if (ip.empty())
-        return {{"ok", false}, {"error", "ip required"}};
-    int dur = duration_sec > 0 ? duration_sec : static_cast<int>(m_ban_duration.count());
-    auto expiry = std::chrono::steady_clock::now() + std::chrono::seconds(dur);
-    m_ip_ban_list[ip] = expiry;
-    LOG_INFO << "[Pool] Admin ban: " << ip << " for " << dur << "s";
-    return {{"ok", true}, {"action", "ban"}, {"target", ip},
-            {"duration_sec", dur},
-            {"bans", build_bans_json(m_ban_list, m_ip_ban_list)}};
-}
 
-nlohmann::json NodeImpl::admin_unban_ip(const std::string& ip)
-{
-    if (ip.empty())
-        return {{"ok", false}, {"error", "ip required"}};
-    size_t removed = m_ip_ban_list.erase(ip);
-    for (auto it = m_ban_list.begin(); it != m_ban_list.end(); ) {
-        if (it->first.address() == ip) { it = m_ban_list.erase(it); ++removed; }
-        else ++it;
-    }
-    LOG_INFO << "[Pool] Admin unban: " << ip << " (" << removed << " entries removed)";
-    return {{"ok", true}, {"action", "unban"}, {"target", ip},
-            {"removed", removed},
-            {"bans", build_bans_json(m_ban_list, m_ip_ban_list)}};
-}
 
-nlohmann::json NodeImpl::admin_list_whitelist() const
-{
-    return {{"ok", true}, {"whitelist", build_whitelist_json(m_whitelist_hosts)}};
-}
 
 nlohmann::json NodeImpl::admin_whitelist_add(const std::string& host, uint16_t port)
 {
@@ -2352,23 +2215,6 @@ nlohmann::json NodeImpl::admin_whitelist_add(const std::string& host, uint16_t p
             {"whitelist", build_whitelist_json(m_whitelist_hosts)}};
 }
 
-nlohmann::json NodeImpl::admin_whitelist_remove(const std::string& host, uint16_t port)
-{
-    if (host.empty() || port == 0)
-        return {{"ok", false}, {"error", "host and port required"}};
-    NetService addr(host, port);
-    size_t removed_h = m_whitelist_hosts.erase(addr);
-    // Only remove the IP from whitelist if no other host:port remains for it.
-    bool other_on_same_ip = std::any_of(
-        m_whitelist_hosts.begin(), m_whitelist_hosts.end(),
-        [&](const NetService& n) { return n.address() == host; });
-    if (!other_on_same_ip) m_whitelist_ips.erase(host);
-    if (removed_h) save_whitelist_to_disk();
-    LOG_INFO << "[Pool] De-whitelisted " << addr.to_string();
-    return {{"ok", true}, {"action", "whitelist_remove"},
-            {"target", addr.to_string()}, {"removed", removed_h},
-            {"whitelist", build_whitelist_json(m_whitelist_hosts)}};
-}
 
 nlohmann::json NodeImpl::admin_list_peers() const
 {

--- a/src/impl/bch/node.hpp
+++ b/src/impl/bch/node.hpp
@@ -28,6 +28,7 @@
 #include <core/version_gate.hpp>   // SSOT: core::version_gate::is_v36_active
 
 #include <pool/node.hpp>
+#include <pool/sharechain_node.hpp>
 #include <pool/protocol.hpp>
 #include <core/message.hpp>
 #include <core/reply_matcher.hpp>
@@ -53,8 +54,10 @@ struct ShareReplyData
     std::vector<chain::RawShare> m_raw_items;
 };
 
-class NodeImpl : public pool::BaseNode<bch::Config, bch::ShareChain, bch::Peer>
+class NodeImpl : public pool::SharechainNode<bch::Config, bch::ShareChain, bch::Peer>
 {
+
+    using base_t = pool::SharechainNode<bch::Config, bch::ShareChain, bch::Peer>;
     // Async share downloader:
     // ID = uint256 (matches sharereq id to sharereply id)
     // RESPONSE = parsed shares plus their original raw payloads
@@ -592,7 +595,6 @@ public:
     void set_max_peers(size_t count) { m_max_peers = count; }
 
     /// Set P2P ban duration (seconds).
-    void set_ban_duration(int seconds) { m_ban_duration = std::chrono::seconds(seconds); }
 
     /// Set cache size limits for memory control.
     void set_cache_limits(size_t max_shared, size_t max_known_txs, size_t max_raw) {
@@ -681,7 +683,6 @@ public:
     }
 
     /// Check whether a peer address is currently banned.
-    bool is_banned(const NetService& addr) const;
 
     /// ── Runtime admin API (pool peer bans + whitelist) ─────────────────
     /// All methods assumed to run on the io_context thread — callers
@@ -689,22 +690,15 @@ public:
     ///
     /// Returned JSON uses the shape:
     ///   {"ok": true|false, "error"?: "...", "bans": [...], "whitelist": [...]}
-    nlohmann::json admin_list_bans() const;
-    nlohmann::json admin_ban_ip(const std::string& ip, int duration_sec);
-    nlohmann::json admin_unban_ip(const std::string& ip);
-    nlohmann::json admin_list_whitelist() const;
     nlohmann::json admin_whitelist_add(const std::string& host, uint16_t port);
-    nlohmann::json admin_whitelist_remove(const std::string& host, uint16_t port);
     nlohmann::json admin_list_peers() const;
     nlohmann::json admin_drop_peer(const std::string& ip);
     nlohmann::json admin_dial_peer(const std::string& host, uint16_t port);
 
     /// Path to persisted whitelist file (~/.c2pool/pool_whitelist.json).
     /// Set by c2pool_refactored.cpp before start(); empty = no persistence.
-    void set_whitelist_path(const std::string& path);
 
     /// True if addr's IP matches a whitelist entry (IP or host:port).
-    bool is_whitelisted(const NetService& addr) const;
 
 protected:
     std::string m_software_version = "/c2pool:0.1/";  // overridden by set_software_version()
@@ -750,21 +744,13 @@ protected:
     std::set<NetService> m_outbound_addrs;     // successfully connected outbound peers
 
     // Peer banning: maps address → ban expiry time
-    std::map<NetService, std::chrono::steady_clock::time_point> m_ban_list;
-    std::chrono::seconds m_ban_duration{300}; // 5 minutes (configurable)
 
     // IP-only manual bans (admin endpoint). Keyed by IP string so the
     // operator can ban/unban without knowing the peer's source port.
-    std::map<std::string, std::chrono::steady_clock::time_point> m_ip_ban_list;
 
     // Whitelist: IPs that bypass is_banned() and host:port entries kept as
     // permanent dial targets. Persists across restart via m_whitelist_path.
-    std::set<std::string> m_whitelist_ips;
-    std::set<NetService> m_whitelist_hosts;
-    std::string m_whitelist_path;
 
-    void load_whitelist_from_disk();
-    void save_whitelist_to_disk() const;
 
     // Rate-limiting no longer needed: think() runs on a dedicated compute
     // thread (m_think_pool), serialized by m_think_running atomic flag.

--- a/src/impl/btc/node.cpp
+++ b/src/impl/btc/node.cpp
@@ -2172,155 +2172,18 @@ void NodeImpl::clean_tracker()
     }); // end of m_think_pool lambda
 }
 
-bool NodeImpl::is_whitelisted(const NetService& addr) const
-{
-    const std::string ip = addr.address();
-    if (m_whitelist_ips.contains(ip)) return true;
-    if (m_whitelist_hosts.contains(addr)) return true;
-    return false;
-}
 
-bool NodeImpl::is_banned(const NetService& addr) const
-{
-    // Whitelist bypass: permanent dial targets are immune to bans.
-    if (is_whitelisted(addr)) return false;
-
-    auto now = std::chrono::steady_clock::now();
-    auto it = m_ban_list.find(addr);
-    if (it != m_ban_list.end() && it->second > now) return true;
-
-    auto ip_it = m_ip_ban_list.find(addr.address());
-    if (ip_it != m_ip_ban_list.end() && ip_it->second > now) return true;
-
-    return false;
-}
 
 // ── Admin API implementation ──────────────────────────────────────────
 
-void NodeImpl::set_whitelist_path(const std::string& path)
-{
-    m_whitelist_path = path;
-    if (!path.empty()) load_whitelist_from_disk();
-}
 
-void NodeImpl::load_whitelist_from_disk()
-{
-    if (m_whitelist_path.empty()) return;
-    std::ifstream f(m_whitelist_path);
-    if (!f) return;
-    try {
-        nlohmann::json j;
-        f >> j;
-        if (!j.contains("entries") || !j["entries"].is_array()) return;
-        for (const auto& e : j["entries"]) {
-            if (!e.contains("host") || !e.contains("port")) continue;
-            std::string host = e["host"].get<std::string>();
-            uint16_t port = e["port"].get<uint16_t>();
-            m_whitelist_ips.insert(host);
-            m_whitelist_hosts.insert(NetService(host, port));
-        }
-        LOG_INFO << "[Pool] Loaded " << m_whitelist_hosts.size()
-                 << " whitelist entries from " << m_whitelist_path;
-    } catch (const std::exception& e) {
-        LOG_WARNING << "[Pool] Failed to parse whitelist " << m_whitelist_path
-                    << ": " << e.what();
-    }
-}
 
-void NodeImpl::save_whitelist_to_disk() const
-{
-    if (m_whitelist_path.empty()) return;
-    try {
-        nlohmann::json j;
-        j["version"] = 1;
-        auto arr = nlohmann::json::array();
-        auto now_unix = std::chrono::duration_cast<std::chrono::seconds>(
-            std::chrono::system_clock::now().time_since_epoch()).count();
-        for (const auto& host : m_whitelist_hosts) {
-            arr.push_back({
-                {"host", host.address()},
-                {"port", host.port()},
-                {"added_unix", now_unix}
-            });
-        }
-        j["entries"] = arr;
-        std::string tmp = m_whitelist_path + ".new";
-        {
-            std::ofstream f(tmp);
-            f << j.dump(2);
-        }
-        std::filesystem::rename(tmp, m_whitelist_path);
-    } catch (const std::exception& e) {
-        LOG_WARNING << "[Pool] Failed to persist whitelist: " << e.what();
-    }
-}
 
-static nlohmann::json build_bans_json(
-    const std::map<NetService, std::chrono::steady_clock::time_point>& peer_bans,
-    const std::map<std::string, std::chrono::steady_clock::time_point>& ip_bans)
-{
-    auto now = std::chrono::steady_clock::now();
-    auto arr = nlohmann::json::array();
-    for (const auto& [addr, expiry] : peer_bans) {
-        if (expiry <= now) continue;
-        auto secs = std::chrono::duration_cast<std::chrono::seconds>(expiry - now).count();
-        arr.push_back({{"host", addr.address()}, {"port", addr.port()},
-                       {"expires_in_sec", secs}, {"source", "auto"}});
-    }
-    for (const auto& [ip, expiry] : ip_bans) {
-        if (expiry <= now) continue;
-        auto secs = std::chrono::duration_cast<std::chrono::seconds>(expiry - now).count();
-        arr.push_back({{"host", ip}, {"port", 0},
-                       {"expires_in_sec", secs}, {"source", "admin"}});
-    }
-    return arr;
-}
 
-static nlohmann::json build_whitelist_json(const std::set<NetService>& hosts)
-{
-    auto arr = nlohmann::json::array();
-    for (const auto& h : hosts)
-        arr.push_back({{"host", h.address()}, {"port", h.port()}});
-    return arr;
-}
 
-nlohmann::json NodeImpl::admin_list_bans() const
-{
-    return {{"ok", true}, {"bans", build_bans_json(m_ban_list, m_ip_ban_list)}};
-}
 
-nlohmann::json NodeImpl::admin_ban_ip(const std::string& ip, int duration_sec)
-{
-    if (ip.empty())
-        return {{"ok", false}, {"error", "ip required"}};
-    int dur = duration_sec > 0 ? duration_sec : static_cast<int>(m_ban_duration.count());
-    auto expiry = std::chrono::steady_clock::now() + std::chrono::seconds(dur);
-    m_ip_ban_list[ip] = expiry;
-    LOG_INFO << "[Pool] Admin ban: " << ip << " for " << dur << "s";
-    return {{"ok", true}, {"action", "ban"}, {"target", ip},
-            {"duration_sec", dur},
-            {"bans", build_bans_json(m_ban_list, m_ip_ban_list)}};
-}
 
-nlohmann::json NodeImpl::admin_unban_ip(const std::string& ip)
-{
-    if (ip.empty())
-        return {{"ok", false}, {"error", "ip required"}};
-    size_t removed = m_ip_ban_list.erase(ip);
-    for (auto it = m_ban_list.begin(); it != m_ban_list.end(); ) {
-        if (it->first.address() == ip) { it = m_ban_list.erase(it); ++removed; }
-        else ++it;
-    }
-    LOG_INFO << "[Pool] Admin unban: " << ip << " (" << removed << " entries removed)";
-    return {{"ok", true}, {"action", "unban"}, {"target", ip},
-            {"removed", removed},
-            {"bans", build_bans_json(m_ban_list, m_ip_ban_list)}};
-}
 
-nlohmann::json NodeImpl::admin_list_whitelist() const
-{
-    return {{"ok", true}, {"whitelist", build_whitelist_json(m_whitelist_hosts)}};
-}
 
 nlohmann::json NodeImpl::admin_whitelist_add(const std::string& host, uint16_t port)
 {
@@ -2349,23 +2212,6 @@ nlohmann::json NodeImpl::admin_whitelist_add(const std::string& host, uint16_t p
             {"whitelist", build_whitelist_json(m_whitelist_hosts)}};
 }
 
-nlohmann::json NodeImpl::admin_whitelist_remove(const std::string& host, uint16_t port)
-{
-    if (host.empty() || port == 0)
-        return {{"ok", false}, {"error", "host and port required"}};
-    NetService addr(host, port);
-    size_t removed_h = m_whitelist_hosts.erase(addr);
-    // Only remove the IP from whitelist if no other host:port remains for it.
-    bool other_on_same_ip = std::any_of(
-        m_whitelist_hosts.begin(), m_whitelist_hosts.end(),
-        [&](const NetService& n) { return n.address() == host; });
-    if (!other_on_same_ip) m_whitelist_ips.erase(host);
-    if (removed_h) save_whitelist_to_disk();
-    LOG_INFO << "[Pool] De-whitelisted " << addr.to_string();
-    return {{"ok", true}, {"action", "whitelist_remove"},
-            {"target", addr.to_string()}, {"removed", removed_h},
-            {"whitelist", build_whitelist_json(m_whitelist_hosts)}};
-}
 
 nlohmann::json NodeImpl::admin_list_peers() const
 {

--- a/src/impl/btc/node.hpp
+++ b/src/impl/btc/node.hpp
@@ -8,6 +8,7 @@
 #include "messages.hpp"
 
 #include <pool/node.hpp>
+#include <pool/sharechain_node.hpp>
 #include <pool/protocol.hpp>
 #include <core/message.hpp>
 #include <core/reply_matcher.hpp>
@@ -32,8 +33,10 @@ struct ShareReplyData
     std::vector<chain::RawShare> m_raw_items;
 };
 
-class NodeImpl : public pool::BaseNode<btc::Config, btc::ShareChain, btc::Peer>
+class NodeImpl : public pool::SharechainNode<btc::Config, btc::ShareChain, btc::Peer>
 {
+
+    using base_t = pool::SharechainNode<btc::Config, btc::ShareChain, btc::Peer>;
     // Async share downloader:
     // ID = uint256 (matches sharereq id to sharereply id)
     // RESPONSE = parsed shares plus their original raw payloads
@@ -372,7 +375,6 @@ public:
     void set_max_peers(size_t count) { m_max_peers = count; }
 
     /// Set P2P ban duration (seconds).
-    void set_ban_duration(int seconds) { m_ban_duration = std::chrono::seconds(seconds); }
 
     /// Set cache size limits for memory control.
     void set_cache_limits(size_t max_shared, size_t max_known_txs, size_t max_raw) {
@@ -461,7 +463,6 @@ public:
     }
 
     /// Check whether a peer address is currently banned.
-    bool is_banned(const NetService& addr) const;
 
     /// ── Runtime admin API (pool peer bans + whitelist) ─────────────────
     /// All methods assumed to run on the io_context thread — callers
@@ -469,22 +470,15 @@ public:
     ///
     /// Returned JSON uses the shape:
     ///   {"ok": true|false, "error"?: "...", "bans": [...], "whitelist": [...]}
-    nlohmann::json admin_list_bans() const;
-    nlohmann::json admin_ban_ip(const std::string& ip, int duration_sec);
-    nlohmann::json admin_unban_ip(const std::string& ip);
-    nlohmann::json admin_list_whitelist() const;
     nlohmann::json admin_whitelist_add(const std::string& host, uint16_t port);
-    nlohmann::json admin_whitelist_remove(const std::string& host, uint16_t port);
     nlohmann::json admin_list_peers() const;
     nlohmann::json admin_drop_peer(const std::string& ip);
     nlohmann::json admin_dial_peer(const std::string& host, uint16_t port);
 
     /// Path to persisted whitelist file (~/.c2pool/pool_whitelist.json).
     /// Set by c2pool_refactored.cpp before start(); empty = no persistence.
-    void set_whitelist_path(const std::string& path);
 
     /// True if addr's IP matches a whitelist entry (IP or host:port).
-    bool is_whitelisted(const NetService& addr) const;
 
 protected:
     std::string m_software_version = "/c2pool:0.1/";  // overridden by set_software_version()
@@ -530,21 +524,13 @@ protected:
     std::set<NetService> m_outbound_addrs;     // successfully connected outbound peers
 
     // Peer banning: maps address → ban expiry time
-    std::map<NetService, std::chrono::steady_clock::time_point> m_ban_list;
-    std::chrono::seconds m_ban_duration{300}; // 5 minutes (configurable)
 
     // IP-only manual bans (admin endpoint). Keyed by IP string so the
     // operator can ban/unban without knowing the peer's source port.
-    std::map<std::string, std::chrono::steady_clock::time_point> m_ip_ban_list;
 
     // Whitelist: IPs that bypass is_banned() and host:port entries kept as
     // permanent dial targets. Persists across restart via m_whitelist_path.
-    std::set<std::string> m_whitelist_ips;
-    std::set<NetService> m_whitelist_hosts;
-    std::string m_whitelist_path;
 
-    void load_whitelist_from_disk();
-    void save_whitelist_to_disk() const;
 
     // Rate-limiting no longer needed: think() runs on a dedicated compute
     // thread (m_think_pool), serialized by m_think_running atomic flag.

--- a/src/impl/dgb/node.cpp
+++ b/src/impl/dgb/node.cpp
@@ -2153,155 +2153,18 @@ void NodeImpl::clean_tracker()
     }); // end of m_think_pool lambda
 }
 
-bool NodeImpl::is_whitelisted(const NetService& addr) const
-{
-    const std::string ip = addr.address();
-    if (m_whitelist_ips.contains(ip)) return true;
-    if (m_whitelist_hosts.contains(addr)) return true;
-    return false;
-}
 
-bool NodeImpl::is_banned(const NetService& addr) const
-{
-    // Whitelist bypass: permanent dial targets are immune to bans.
-    if (is_whitelisted(addr)) return false;
-
-    auto now = std::chrono::steady_clock::now();
-    auto it = m_ban_list.find(addr);
-    if (it != m_ban_list.end() && it->second > now) return true;
-
-    auto ip_it = m_ip_ban_list.find(addr.address());
-    if (ip_it != m_ip_ban_list.end() && ip_it->second > now) return true;
-
-    return false;
-}
 
 // ── Admin API implementation ──────────────────────────────────────────
 
-void NodeImpl::set_whitelist_path(const std::string& path)
-{
-    m_whitelist_path = path;
-    if (!path.empty()) load_whitelist_from_disk();
-}
 
-void NodeImpl::load_whitelist_from_disk()
-{
-    if (m_whitelist_path.empty()) return;
-    std::ifstream f(m_whitelist_path);
-    if (!f) return;
-    try {
-        nlohmann::json j;
-        f >> j;
-        if (!j.contains("entries") || !j["entries"].is_array()) return;
-        for (const auto& e : j["entries"]) {
-            if (!e.contains("host") || !e.contains("port")) continue;
-            std::string host = e["host"].get<std::string>();
-            uint16_t port = e["port"].get<uint16_t>();
-            m_whitelist_ips.insert(host);
-            m_whitelist_hosts.insert(NetService(host, port));
-        }
-        LOG_INFO << "[Pool] Loaded " << m_whitelist_hosts.size()
-                 << " whitelist entries from " << m_whitelist_path;
-    } catch (const std::exception& e) {
-        LOG_WARNING << "[Pool] Failed to parse whitelist " << m_whitelist_path
-                    << ": " << e.what();
-    }
-}
 
-void NodeImpl::save_whitelist_to_disk() const
-{
-    if (m_whitelist_path.empty()) return;
-    try {
-        nlohmann::json j;
-        j["version"] = 1;
-        auto arr = nlohmann::json::array();
-        auto now_unix = std::chrono::duration_cast<std::chrono::seconds>(
-            std::chrono::system_clock::now().time_since_epoch()).count();
-        for (const auto& host : m_whitelist_hosts) {
-            arr.push_back({
-                {"host", host.address()},
-                {"port", host.port()},
-                {"added_unix", now_unix}
-            });
-        }
-        j["entries"] = arr;
-        std::string tmp = m_whitelist_path + ".new";
-        {
-            std::ofstream f(tmp);
-            f << j.dump(2);
-        }
-        std::filesystem::rename(tmp, m_whitelist_path);
-    } catch (const std::exception& e) {
-        LOG_WARNING << "[Pool] Failed to persist whitelist: " << e.what();
-    }
-}
 
-static nlohmann::json build_bans_json(
-    const std::map<NetService, std::chrono::steady_clock::time_point>& peer_bans,
-    const std::map<std::string, std::chrono::steady_clock::time_point>& ip_bans)
-{
-    auto now = std::chrono::steady_clock::now();
-    auto arr = nlohmann::json::array();
-    for (const auto& [addr, expiry] : peer_bans) {
-        if (expiry <= now) continue;
-        auto secs = std::chrono::duration_cast<std::chrono::seconds>(expiry - now).count();
-        arr.push_back({{"host", addr.address()}, {"port", addr.port()},
-                       {"expires_in_sec", secs}, {"source", "auto"}});
-    }
-    for (const auto& [ip, expiry] : ip_bans) {
-        if (expiry <= now) continue;
-        auto secs = std::chrono::duration_cast<std::chrono::seconds>(expiry - now).count();
-        arr.push_back({{"host", ip}, {"port", 0},
-                       {"expires_in_sec", secs}, {"source", "admin"}});
-    }
-    return arr;
-}
 
-static nlohmann::json build_whitelist_json(const std::set<NetService>& hosts)
-{
-    auto arr = nlohmann::json::array();
-    for (const auto& h : hosts)
-        arr.push_back({{"host", h.address()}, {"port", h.port()}});
-    return arr;
-}
 
-nlohmann::json NodeImpl::admin_list_bans() const
-{
-    return {{"ok", true}, {"bans", build_bans_json(m_ban_list, m_ip_ban_list)}};
-}
 
-nlohmann::json NodeImpl::admin_ban_ip(const std::string& ip, int duration_sec)
-{
-    if (ip.empty())
-        return {{"ok", false}, {"error", "ip required"}};
-    int dur = duration_sec > 0 ? duration_sec : static_cast<int>(m_ban_duration.count());
-    auto expiry = std::chrono::steady_clock::now() + std::chrono::seconds(dur);
-    m_ip_ban_list[ip] = expiry;
-    LOG_INFO << "[Pool] Admin ban: " << ip << " for " << dur << "s";
-    return {{"ok", true}, {"action", "ban"}, {"target", ip},
-            {"duration_sec", dur},
-            {"bans", build_bans_json(m_ban_list, m_ip_ban_list)}};
-}
 
-nlohmann::json NodeImpl::admin_unban_ip(const std::string& ip)
-{
-    if (ip.empty())
-        return {{"ok", false}, {"error", "ip required"}};
-    size_t removed = m_ip_ban_list.erase(ip);
-    for (auto it = m_ban_list.begin(); it != m_ban_list.end(); ) {
-        if (it->first.address() == ip) { it = m_ban_list.erase(it); ++removed; }
-        else ++it;
-    }
-    LOG_INFO << "[Pool] Admin unban: " << ip << " (" << removed << " entries removed)";
-    return {{"ok", true}, {"action", "unban"}, {"target", ip},
-            {"removed", removed},
-            {"bans", build_bans_json(m_ban_list, m_ip_ban_list)}};
-}
 
-nlohmann::json NodeImpl::admin_list_whitelist() const
-{
-    return {{"ok", true}, {"whitelist", build_whitelist_json(m_whitelist_hosts)}};
-}
 
 nlohmann::json NodeImpl::admin_whitelist_add(const std::string& host, uint16_t port)
 {
@@ -2330,23 +2193,6 @@ nlohmann::json NodeImpl::admin_whitelist_add(const std::string& host, uint16_t p
             {"whitelist", build_whitelist_json(m_whitelist_hosts)}};
 }
 
-nlohmann::json NodeImpl::admin_whitelist_remove(const std::string& host, uint16_t port)
-{
-    if (host.empty() || port == 0)
-        return {{"ok", false}, {"error", "host and port required"}};
-    NetService addr(host, port);
-    size_t removed_h = m_whitelist_hosts.erase(addr);
-    // Only remove the IP from whitelist if no other host:port remains for it.
-    bool other_on_same_ip = std::any_of(
-        m_whitelist_hosts.begin(), m_whitelist_hosts.end(),
-        [&](const NetService& n) { return n.address() == host; });
-    if (!other_on_same_ip) m_whitelist_ips.erase(host);
-    if (removed_h) save_whitelist_to_disk();
-    LOG_INFO << "[Pool] De-whitelisted " << addr.to_string();
-    return {{"ok", true}, {"action", "whitelist_remove"},
-            {"target", addr.to_string()}, {"removed", removed_h},
-            {"whitelist", build_whitelist_json(m_whitelist_hosts)}};
-}
 
 nlohmann::json NodeImpl::admin_list_peers() const
 {

--- a/src/impl/dgb/node.hpp
+++ b/src/impl/dgb/node.hpp
@@ -15,6 +15,7 @@
 
 #include <core/coin_params.hpp>
 #include <pool/node.hpp>
+#include <pool/sharechain_node.hpp>
 #include <pool/protocol.hpp>
 #include <core/message.hpp>
 #include <core/reply_matcher.hpp>
@@ -43,8 +44,10 @@ struct ShareReplyData
     std::vector<chain::RawShare> m_raw_items;
 };
 
-class NodeImpl : public pool::BaseNode<dgb::Config, dgb::ShareChain, dgb::Peer>
+class NodeImpl : public pool::SharechainNode<dgb::Config, dgb::ShareChain, dgb::Peer>
 {
+
+    using base_t = pool::SharechainNode<dgb::Config, dgb::ShareChain, dgb::Peer>;
     // Async share downloader:
     // ID = uint256 (matches sharereq id to sharereply id)
     // RESPONSE = parsed shares plus their original raw payloads
@@ -407,7 +410,6 @@ public:
     void set_max_peers(size_t count) { m_max_peers = count; }
 
     /// Set P2P ban duration (seconds).
-    void set_ban_duration(int seconds) { m_ban_duration = std::chrono::seconds(seconds); }
 
     /// Set cache size limits for memory control.
     void set_cache_limits(size_t max_shared, size_t max_known_txs, size_t max_raw) {
@@ -496,7 +498,6 @@ public:
     }
 
     /// Check whether a peer address is currently banned.
-    bool is_banned(const NetService& addr) const;
 
     /// ── Runtime admin API (pool peer bans + whitelist) ─────────────────
     /// All methods assumed to run on the io_context thread — callers
@@ -504,22 +505,15 @@ public:
     ///
     /// Returned JSON uses the shape:
     ///   {"ok": true|false, "error"?: "...", "bans": [...], "whitelist": [...]}
-    nlohmann::json admin_list_bans() const;
-    nlohmann::json admin_ban_ip(const std::string& ip, int duration_sec);
-    nlohmann::json admin_unban_ip(const std::string& ip);
-    nlohmann::json admin_list_whitelist() const;
     nlohmann::json admin_whitelist_add(const std::string& host, uint16_t port);
-    nlohmann::json admin_whitelist_remove(const std::string& host, uint16_t port);
     nlohmann::json admin_list_peers() const;
     nlohmann::json admin_drop_peer(const std::string& ip);
     nlohmann::json admin_dial_peer(const std::string& host, uint16_t port);
 
     /// Path to persisted whitelist file (~/.c2pool/pool_whitelist.json).
     /// Set by c2pool_refactored.cpp before start(); empty = no persistence.
-    void set_whitelist_path(const std::string& path);
 
     /// True if addr's IP matches a whitelist entry (IP or host:port).
-    bool is_whitelisted(const NetService& addr) const;
 
 protected:
     std::string m_software_version = "/c2pool:0.1/";  // overridden by set_software_version()
@@ -565,21 +559,13 @@ protected:
     std::set<NetService> m_outbound_addrs;     // successfully connected outbound peers
 
     // Peer banning: maps address → ban expiry time
-    std::map<NetService, std::chrono::steady_clock::time_point> m_ban_list;
-    std::chrono::seconds m_ban_duration{300}; // 5 minutes (configurable)
 
     // IP-only manual bans (admin endpoint). Keyed by IP string so the
     // operator can ban/unban without knowing the peer's source port.
-    std::map<std::string, std::chrono::steady_clock::time_point> m_ip_ban_list;
 
     // Whitelist: IPs that bypass is_banned() and host:port entries kept as
     // permanent dial targets. Persists across restart via m_whitelist_path.
-    std::set<std::string> m_whitelist_ips;
-    std::set<NetService> m_whitelist_hosts;
-    std::string m_whitelist_path;
 
-    void load_whitelist_from_disk();
-    void save_whitelist_to_disk() const;
 
     // Rate-limiting no longer needed: think() runs on a dedicated compute
     // thread (m_think_pool), serialized by m_think_running atomic flag.

--- a/src/impl/ltc/node.cpp
+++ b/src/impl/ltc/node.cpp
@@ -2162,155 +2162,18 @@ void NodeImpl::clean_tracker()
     }); // end of m_think_pool lambda
 }
 
-bool NodeImpl::is_whitelisted(const NetService& addr) const
-{
-    const std::string ip = addr.address();
-    if (m_whitelist_ips.contains(ip)) return true;
-    if (m_whitelist_hosts.contains(addr)) return true;
-    return false;
-}
 
-bool NodeImpl::is_banned(const NetService& addr) const
-{
-    // Whitelist bypass: permanent dial targets are immune to bans.
-    if (is_whitelisted(addr)) return false;
-
-    auto now = std::chrono::steady_clock::now();
-    auto it = m_ban_list.find(addr);
-    if (it != m_ban_list.end() && it->second > now) return true;
-
-    auto ip_it = m_ip_ban_list.find(addr.address());
-    if (ip_it != m_ip_ban_list.end() && ip_it->second > now) return true;
-
-    return false;
-}
 
 // ── Admin API implementation ──────────────────────────────────────────
 
-void NodeImpl::set_whitelist_path(const std::string& path)
-{
-    m_whitelist_path = path;
-    if (!path.empty()) load_whitelist_from_disk();
-}
 
-void NodeImpl::load_whitelist_from_disk()
-{
-    if (m_whitelist_path.empty()) return;
-    std::ifstream f(m_whitelist_path);
-    if (!f) return;
-    try {
-        nlohmann::json j;
-        f >> j;
-        if (!j.contains("entries") || !j["entries"].is_array()) return;
-        for (const auto& e : j["entries"]) {
-            if (!e.contains("host") || !e.contains("port")) continue;
-            std::string host = e["host"].get<std::string>();
-            uint16_t port = e["port"].get<uint16_t>();
-            m_whitelist_ips.insert(host);
-            m_whitelist_hosts.insert(NetService(host, port));
-        }
-        LOG_INFO << "[Pool] Loaded " << m_whitelist_hosts.size()
-                 << " whitelist entries from " << m_whitelist_path;
-    } catch (const std::exception& e) {
-        LOG_WARNING << "[Pool] Failed to parse whitelist " << m_whitelist_path
-                    << ": " << e.what();
-    }
-}
 
-void NodeImpl::save_whitelist_to_disk() const
-{
-    if (m_whitelist_path.empty()) return;
-    try {
-        nlohmann::json j;
-        j["version"] = 1;
-        auto arr = nlohmann::json::array();
-        auto now_unix = std::chrono::duration_cast<std::chrono::seconds>(
-            std::chrono::system_clock::now().time_since_epoch()).count();
-        for (const auto& host : m_whitelist_hosts) {
-            arr.push_back({
-                {"host", host.address()},
-                {"port", host.port()},
-                {"added_unix", now_unix}
-            });
-        }
-        j["entries"] = arr;
-        std::string tmp = m_whitelist_path + ".new";
-        {
-            std::ofstream f(tmp);
-            f << j.dump(2);
-        }
-        std::filesystem::rename(tmp, m_whitelist_path);
-    } catch (const std::exception& e) {
-        LOG_WARNING << "[Pool] Failed to persist whitelist: " << e.what();
-    }
-}
 
-static nlohmann::json build_bans_json(
-    const std::map<NetService, std::chrono::steady_clock::time_point>& peer_bans,
-    const std::map<std::string, std::chrono::steady_clock::time_point>& ip_bans)
-{
-    auto now = std::chrono::steady_clock::now();
-    auto arr = nlohmann::json::array();
-    for (const auto& [addr, expiry] : peer_bans) {
-        if (expiry <= now) continue;
-        auto secs = std::chrono::duration_cast<std::chrono::seconds>(expiry - now).count();
-        arr.push_back({{"host", addr.address()}, {"port", addr.port()},
-                       {"expires_in_sec", secs}, {"source", "auto"}});
-    }
-    for (const auto& [ip, expiry] : ip_bans) {
-        if (expiry <= now) continue;
-        auto secs = std::chrono::duration_cast<std::chrono::seconds>(expiry - now).count();
-        arr.push_back({{"host", ip}, {"port", 0},
-                       {"expires_in_sec", secs}, {"source", "admin"}});
-    }
-    return arr;
-}
 
-static nlohmann::json build_whitelist_json(const std::set<NetService>& hosts)
-{
-    auto arr = nlohmann::json::array();
-    for (const auto& h : hosts)
-        arr.push_back({{"host", h.address()}, {"port", h.port()}});
-    return arr;
-}
 
-nlohmann::json NodeImpl::admin_list_bans() const
-{
-    return {{"ok", true}, {"bans", build_bans_json(m_ban_list, m_ip_ban_list)}};
-}
 
-nlohmann::json NodeImpl::admin_ban_ip(const std::string& ip, int duration_sec)
-{
-    if (ip.empty())
-        return {{"ok", false}, {"error", "ip required"}};
-    int dur = duration_sec > 0 ? duration_sec : static_cast<int>(m_ban_duration.count());
-    auto expiry = std::chrono::steady_clock::now() + std::chrono::seconds(dur);
-    m_ip_ban_list[ip] = expiry;
-    LOG_INFO << "[Pool] Admin ban: " << ip << " for " << dur << "s";
-    return {{"ok", true}, {"action", "ban"}, {"target", ip},
-            {"duration_sec", dur},
-            {"bans", build_bans_json(m_ban_list, m_ip_ban_list)}};
-}
 
-nlohmann::json NodeImpl::admin_unban_ip(const std::string& ip)
-{
-    if (ip.empty())
-        return {{"ok", false}, {"error", "ip required"}};
-    size_t removed = m_ip_ban_list.erase(ip);
-    for (auto it = m_ban_list.begin(); it != m_ban_list.end(); ) {
-        if (it->first.address() == ip) { it = m_ban_list.erase(it); ++removed; }
-        else ++it;
-    }
-    LOG_INFO << "[Pool] Admin unban: " << ip << " (" << removed << " entries removed)";
-    return {{"ok", true}, {"action", "unban"}, {"target", ip},
-            {"removed", removed},
-            {"bans", build_bans_json(m_ban_list, m_ip_ban_list)}};
-}
 
-nlohmann::json NodeImpl::admin_list_whitelist() const
-{
-    return {{"ok", true}, {"whitelist", build_whitelist_json(m_whitelist_hosts)}};
-}
 
 nlohmann::json NodeImpl::admin_whitelist_add(const std::string& host, uint16_t port)
 {
@@ -2339,23 +2202,6 @@ nlohmann::json NodeImpl::admin_whitelist_add(const std::string& host, uint16_t p
             {"whitelist", build_whitelist_json(m_whitelist_hosts)}};
 }
 
-nlohmann::json NodeImpl::admin_whitelist_remove(const std::string& host, uint16_t port)
-{
-    if (host.empty() || port == 0)
-        return {{"ok", false}, {"error", "host and port required"}};
-    NetService addr(host, port);
-    size_t removed_h = m_whitelist_hosts.erase(addr);
-    // Only remove the IP from whitelist if no other host:port remains for it.
-    bool other_on_same_ip = std::any_of(
-        m_whitelist_hosts.begin(), m_whitelist_hosts.end(),
-        [&](const NetService& n) { return n.address() == host; });
-    if (!other_on_same_ip) m_whitelist_ips.erase(host);
-    if (removed_h) save_whitelist_to_disk();
-    LOG_INFO << "[Pool] De-whitelisted " << addr.to_string();
-    return {{"ok", true}, {"action", "whitelist_remove"},
-            {"target", addr.to_string()}, {"removed", removed_h},
-            {"whitelist", build_whitelist_json(m_whitelist_hosts)}};
-}
 
 nlohmann::json NodeImpl::admin_list_peers() const
 {

--- a/src/impl/ltc/node.hpp
+++ b/src/impl/ltc/node.hpp
@@ -10,6 +10,7 @@
 
 #include <core/coin_params.hpp>
 #include <pool/node.hpp>
+#include <pool/sharechain_node.hpp>
 #include <pool/protocol.hpp>
 #include <core/message.hpp>
 #include <core/reply_matcher.hpp>
@@ -32,8 +33,10 @@ struct ShareReplyData
     std::vector<chain::RawShare> m_raw_items;
 };
 
-class NodeImpl : public pool::BaseNode<ltc::Config, ltc::ShareChain, ltc::Peer>
+class NodeImpl : public pool::SharechainNode<ltc::Config, ltc::ShareChain, ltc::Peer>
 {
+
+    using base_t = pool::SharechainNode<ltc::Config, ltc::ShareChain, ltc::Peer>;
     // Async share downloader:
     // ID = uint256 (matches sharereq id to sharereply id)
     // RESPONSE = parsed shares plus their original raw payloads
@@ -370,7 +373,6 @@ public:
     void set_max_peers(size_t count) { m_max_peers = count; }
 
     /// Set P2P ban duration (seconds).
-    void set_ban_duration(int seconds) { m_ban_duration = std::chrono::seconds(seconds); }
 
     /// Set cache size limits for memory control.
     void set_cache_limits(size_t max_shared, size_t max_known_txs, size_t max_raw) {
@@ -459,7 +461,6 @@ public:
     }
 
     /// Check whether a peer address is currently banned.
-    bool is_banned(const NetService& addr) const;
 
     /// ── Runtime admin API (pool peer bans + whitelist) ─────────────────
     /// All methods assumed to run on the io_context thread — callers
@@ -467,22 +468,15 @@ public:
     ///
     /// Returned JSON uses the shape:
     ///   {"ok": true|false, "error"?: "...", "bans": [...], "whitelist": [...]}
-    nlohmann::json admin_list_bans() const;
-    nlohmann::json admin_ban_ip(const std::string& ip, int duration_sec);
-    nlohmann::json admin_unban_ip(const std::string& ip);
-    nlohmann::json admin_list_whitelist() const;
     nlohmann::json admin_whitelist_add(const std::string& host, uint16_t port);
-    nlohmann::json admin_whitelist_remove(const std::string& host, uint16_t port);
     nlohmann::json admin_list_peers() const;
     nlohmann::json admin_drop_peer(const std::string& ip);
     nlohmann::json admin_dial_peer(const std::string& host, uint16_t port);
 
     /// Path to persisted whitelist file (~/.c2pool/pool_whitelist.json).
     /// Set by c2pool_refactored.cpp before start(); empty = no persistence.
-    void set_whitelist_path(const std::string& path);
 
     /// True if addr's IP matches a whitelist entry (IP or host:port).
-    bool is_whitelisted(const NetService& addr) const;
 
 protected:
     std::string m_software_version = "/c2pool:0.1/";  // overridden by set_software_version()
@@ -528,21 +522,13 @@ protected:
     std::set<NetService> m_outbound_addrs;     // successfully connected outbound peers
 
     // Peer banning: maps address → ban expiry time
-    std::map<NetService, std::chrono::steady_clock::time_point> m_ban_list;
-    std::chrono::seconds m_ban_duration{300}; // 5 minutes (configurable)
 
     // IP-only manual bans (admin endpoint). Keyed by IP string so the
     // operator can ban/unban without knowing the peer's source port.
-    std::map<std::string, std::chrono::steady_clock::time_point> m_ip_ban_list;
 
     // Whitelist: IPs that bypass is_banned() and host:port entries kept as
     // permanent dial targets. Persists across restart via m_whitelist_path.
-    std::set<std::string> m_whitelist_ips;
-    std::set<NetService> m_whitelist_hosts;
-    std::string m_whitelist_path;
 
-    void load_whitelist_from_disk();
-    void save_whitelist_to_disk() const;
 
     // Rate-limiting no longer needed: think() runs on a dedicated compute
     // thread (m_think_pool), serialized by m_think_running atomic flag.

--- a/src/pool/sharechain_node.hpp
+++ b/src/pool/sharechain_node.hpp
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// pool::SharechainNode
+// ────────────────────
+// Intermediate layer between pool::BaseNode and each coin's NodeImpl that owns
+// the coin-agnostic, non-consensus P2P *policy* machinery shared verbatim by
+// every coin. This first slice hoists the peer ban-list + whitelist subsystem,
+// which was byte-identical across ltc/btc/bch/dgb node.cpp (only the coin
+// namespace differed). The bodies are relocated unchanged — behaviour is
+// identical, this is pure de-duplication.
+//
+// Only the self-contained ban/whitelist surface lives here: every method below
+// touches ONLY members declared in this class, so no dependent-base (BaseNode)
+// qualification is needed and no consensus/sharechain state is involved. The
+// peer/outbound-connection admin endpoints (admin_list_peers/drop/dial,
+// admin_whitelist_add) stay in NodeImpl for now because they reach into
+// BaseNode's connection maps and the outbound-dial members; they can be hoisted
+// in a follow-up once those members move here too.
+
+#include <pool/node.hpp>
+
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <set>
+#include <string>
+
+namespace pool
+{
+
+template <typename ConfigType, typename ShareChainType, typename PeerData>
+class SharechainNode : public BaseNode<ConfigType, ShareChainType, PeerData>
+{
+public:
+    using base_t = BaseNode<ConfigType, ShareChainType, PeerData>;
+
+    SharechainNode() : base_t() {}
+    SharechainNode(boost::asio::io_context* context, typename base_t::config_t* config)
+        : base_t(context, config) {}
+
+    // ── Ban policy ────────────────────────────────────────────────────────
+    /// Set P2P ban duration (seconds).
+    void set_ban_duration(int seconds) { m_ban_duration = std::chrono::seconds(seconds); }
+
+    /// Check whether a peer address is currently banned.
+    bool is_banned(const NetService& addr) const
+    {
+        // Whitelist bypass: permanent dial targets are immune to bans.
+        if (is_whitelisted(addr)) return false;
+
+        auto now = std::chrono::steady_clock::now();
+        auto it = m_ban_list.find(addr);
+        if (it != m_ban_list.end() && it->second > now) return true;
+
+        auto ip_it = m_ip_ban_list.find(addr.address());
+        if (ip_it != m_ip_ban_list.end() && ip_it->second > now) return true;
+
+        return false;
+    }
+
+    // ── Whitelist ─────────────────────────────────────────────────────────
+    /// True if addr's IP matches a whitelist entry (IP or host:port).
+    bool is_whitelisted(const NetService& addr) const
+    {
+        const std::string ip = addr.address();
+        if (m_whitelist_ips.contains(ip)) return true;
+        if (m_whitelist_hosts.contains(addr)) return true;
+        return false;
+    }
+
+    /// Path to persisted whitelist file (~/.c2pool/pool_whitelist.json).
+    /// Set by c2pool_refactored.cpp before start(); empty = no persistence.
+    void set_whitelist_path(const std::string& path)
+    {
+        m_whitelist_path = path;
+        if (!path.empty()) load_whitelist_from_disk();
+    }
+
+    // ── Runtime admin API (ban/whitelist subset) ───────────────────────────
+    /// All methods assumed to run on the io_context thread — callers
+    /// (web_server HTTP handlers) dispatch via thread_safe_wrap().
+    ///
+    /// Returned JSON uses the shape:
+    ///   {"ok": true|false, "error"?: "...", "bans": [...], "whitelist": [...]}
+    nlohmann::json admin_list_bans() const
+    {
+        return {{"ok", true}, {"bans", build_bans_json(m_ban_list, m_ip_ban_list)}};
+    }
+
+    nlohmann::json admin_ban_ip(const std::string& ip, int duration_sec)
+    {
+        if (ip.empty())
+            return {{"ok", false}, {"error", "ip required"}};
+        int dur = duration_sec > 0 ? duration_sec : static_cast<int>(m_ban_duration.count());
+        auto expiry = std::chrono::steady_clock::now() + std::chrono::seconds(dur);
+        m_ip_ban_list[ip] = expiry;
+        LOG_INFO << "[Pool] Admin ban: " << ip << " for " << dur << "s";
+        return {{"ok", true}, {"action", "ban"}, {"target", ip},
+                {"duration_sec", dur},
+                {"bans", build_bans_json(m_ban_list, m_ip_ban_list)}};
+    }
+
+    nlohmann::json admin_unban_ip(const std::string& ip)
+    {
+        if (ip.empty())
+            return {{"ok", false}, {"error", "ip required"}};
+        size_t removed = m_ip_ban_list.erase(ip);
+        for (auto it = m_ban_list.begin(); it != m_ban_list.end(); ) {
+            if (it->first.address() == ip) { it = m_ban_list.erase(it); ++removed; }
+            else ++it;
+        }
+        LOG_INFO << "[Pool] Admin unban: " << ip << " (" << removed << " entries removed)";
+        return {{"ok", true}, {"action", "unban"}, {"target", ip},
+                {"removed", removed},
+                {"bans", build_bans_json(m_ban_list, m_ip_ban_list)}};
+    }
+
+    nlohmann::json admin_list_whitelist() const
+    {
+        return {{"ok", true}, {"whitelist", build_whitelist_json(m_whitelist_hosts)}};
+    }
+
+    nlohmann::json admin_whitelist_remove(const std::string& host, uint16_t port)
+    {
+        if (host.empty() || port == 0)
+            return {{"ok", false}, {"error", "host and port required"}};
+        NetService addr(host, port);
+        size_t removed_h = m_whitelist_hosts.erase(addr);
+        // Only remove the IP from whitelist if no other host:port remains for it.
+        bool other_on_same_ip = std::any_of(
+            m_whitelist_hosts.begin(), m_whitelist_hosts.end(),
+            [&](const NetService& n) { return n.address() == host; });
+        if (!other_on_same_ip) m_whitelist_ips.erase(host);
+        if (removed_h) save_whitelist_to_disk();
+        LOG_INFO << "[Pool] De-whitelisted " << addr.to_string();
+        return {{"ok", true}, {"action", "whitelist_remove"},
+                {"target", addr.to_string()}, {"removed", removed_h},
+                {"whitelist", build_whitelist_json(m_whitelist_hosts)}};
+    }
+
+protected:
+    void load_whitelist_from_disk()
+    {
+        if (m_whitelist_path.empty()) return;
+        std::ifstream f(m_whitelist_path);
+        if (!f) return;
+        try {
+            nlohmann::json j;
+            f >> j;
+            if (!j.contains("entries") || !j["entries"].is_array()) return;
+            for (const auto& e : j["entries"]) {
+                if (!e.contains("host") || !e.contains("port")) continue;
+                std::string host = e["host"].get<std::string>();
+                uint16_t port = e["port"].get<uint16_t>();
+                m_whitelist_ips.insert(host);
+                m_whitelist_hosts.insert(NetService(host, port));
+            }
+            LOG_INFO << "[Pool] Loaded " << m_whitelist_hosts.size()
+                     << " whitelist entries from " << m_whitelist_path;
+        } catch (const std::exception& e) {
+            LOG_WARNING << "[Pool] Failed to parse whitelist " << m_whitelist_path
+                        << ": " << e.what();
+        }
+    }
+
+    void save_whitelist_to_disk() const
+    {
+        if (m_whitelist_path.empty()) return;
+        try {
+            nlohmann::json j;
+            j["version"] = 1;
+            auto arr = nlohmann::json::array();
+            auto now_unix = std::chrono::duration_cast<std::chrono::seconds>(
+                std::chrono::system_clock::now().time_since_epoch()).count();
+            for (const auto& host : m_whitelist_hosts) {
+                arr.push_back({
+                    {"host", host.address()},
+                    {"port", host.port()},
+                    {"added_unix", now_unix}
+                });
+            }
+            j["entries"] = arr;
+            std::string tmp = m_whitelist_path + ".new";
+            {
+                std::ofstream f(tmp);
+                f << j.dump(2);
+            }
+            std::filesystem::rename(tmp, m_whitelist_path);
+        } catch (const std::exception& e) {
+            LOG_WARNING << "[Pool] Failed to persist whitelist: " << e.what();
+        }
+    }
+
+    static nlohmann::json build_bans_json(
+        const std::map<NetService, std::chrono::steady_clock::time_point>& peer_bans,
+        const std::map<std::string, std::chrono::steady_clock::time_point>& ip_bans)
+    {
+        auto now = std::chrono::steady_clock::now();
+        auto arr = nlohmann::json::array();
+        for (const auto& [addr, expiry] : peer_bans) {
+            if (expiry <= now) continue;
+            auto secs = std::chrono::duration_cast<std::chrono::seconds>(expiry - now).count();
+            arr.push_back({{"host", addr.address()}, {"port", addr.port()},
+                           {"expires_in_sec", secs}, {"source", "auto"}});
+        }
+        for (const auto& [ip, expiry] : ip_bans) {
+            if (expiry <= now) continue;
+            auto secs = std::chrono::duration_cast<std::chrono::seconds>(expiry - now).count();
+            arr.push_back({{"host", ip}, {"port", 0},
+                           {"expires_in_sec", secs}, {"source", "admin"}});
+        }
+        return arr;
+    }
+
+    static nlohmann::json build_whitelist_json(const std::set<NetService>& hosts)
+    {
+        auto arr = nlohmann::json::array();
+        for (const auto& h : hosts)
+            arr.push_back({{"host", h.address()}, {"port", h.port()}});
+        return arr;
+    }
+
+    // Peer banning: maps address → ban expiry time
+    std::map<NetService, std::chrono::steady_clock::time_point> m_ban_list;
+    std::chrono::seconds m_ban_duration{300}; // 5 minutes (configurable)
+
+    // IP-only manual bans (admin endpoint). Keyed by IP string so the
+    // operator can ban/unban without knowing the peer's source port.
+    std::map<std::string, std::chrono::steady_clock::time_point> m_ip_ban_list;
+
+    // Whitelist: IPs that bypass is_banned() and host:port entries kept as
+    // permanent dial targets. Persists across restart via m_whitelist_path.
+    std::set<std::string> m_whitelist_ips;
+    std::set<NetService> m_whitelist_hosts;
+    std::string m_whitelist_path;
+};
+
+} // namespace pool


### PR DESCRIPTION
## Summary

`node.cpp` is copy-pasted across the five coins. This PR lands the **first, safe slice** of the reuse hoist: a new intermediate layer **`pool::SharechainNode<Config,ShareChain,Peer>`** between `pool::BaseNode` and each coin's `NodeImpl`, holding the byte-identical, coin-agnostic, **non-consensus** peer **ban-list + whitelist** subsystem. All four complete coins now inherit it instead of carrying their own copy.

**Net: −688 lines across the four coins, +243-line shared header** (one source of truth for four copies; −176 lines per coin).

## What hoisted (verified byte-identical across ltc/btc/bch/dgb, coin namespace aside)

`is_banned`, `is_whitelisted`, `set_ban_duration`, `set_whitelist_path`, `load_whitelist_from_disk`, `save_whitelist_to_disk`, `admin_list_bans`, `admin_ban_ip`, `admin_unban_ip`, `admin_list_whitelist`, `admin_whitelist_remove`, the `build_bans_json`/`build_whitelist_json` helpers, and the members `m_ban_list`, `m_ip_ban_list`, `m_ban_duration`, `m_whitelist_ips`, `m_whitelist_hosts`, `m_whitelist_path`.

Every hoisted method touches **only** members that move with it — no dependent-base qualification, no consensus/sharechain-timing state. Bodies relocated unchanged: **pure de-duplication, behaviour identical.**

The connection-coupled endpoints (`admin_whitelist_add`, `admin_list_peers`, `admin_drop_peer`, `admin_dial_peer`) stay in `NodeImpl` for now — they reach into `BaseNode`'s connection maps and the outbound-dial members, so they belong to the next slice that also hoists the outbound-connection manager.

## Per-coin no-regression evidence (system Boost 1.83 / leveldb, `-j4`)

| Check | Result |
|---|---|
| `c2pool-ltc` / `-btc` / `-bch` / `-dgb` / `-dash` build | all green |
| `test_ltc_node` | PASS (exit 0) |
| `core_test` | 56/56 PASS (incl. `VersionGateTransition` suite) |
| `sharechain_test` | green (0 cases) |
| `ltc_pool_test` harness | constructs node through the new base + enters run loop, no crash |

`ltc_coin_test` aborts on `CoindRPC connection refused` — it requires a live litecoind daemon (environmental, not present in this sandbox); unrelated to this non-consensus change.

## ⚠️ Important finding — the audit premise does NOT hold for the consensus core

The directive assumed the five node.cpp copies are "~90% byte-identical" so a hoist is "same code relocated, behaviour UNCHANGED." A function-by-function identity check across the four complete coins (coin-name-normalized, brace-matched) shows that is true only for **26 of 43** functions. The other **17 — precisely the consensus-adjacent core — have drifted into 2–4 distinct implementations**:

- **BTC + BCH** are a tight pair (13 lines apart). **LTC** and **DGB** each diverge from them and from each other (242 / 313 / 499 / 510-line normalized diffs).
- `run_think`, `clean_tracker`, `processing_shares`, `processing_shares_phase2`, `handle_version`, `send_version`, `heartbeat_log` (all four differ), `download_shares`, `handle_get_share`, `load_persisted_shares`, `advertised_best_share`, `notify_local_share`, `prune_shares` — all drifted.
- `readvertise_best` (BTC/BCH: `broadcast_share`) vs `readvertise_best_share` (LTC/DGB: full tip-walk re-push) — different name **and** different body.
- `arm_think_watchdog` / `disarm_think_watchdog` differ between LTC and BTC/BCH and are **entirely missing in DGB**; DGB additionally carries a unique `apply_min_protocol_ratchet`.
- The async-defer lock discipline (kr1z1s SIGSEGV region) differs: LTC releases the tracker lock early; BTC/BCH hold it across the mutation and add a `MAX_PENDING_ADDS` backpressure cap.
- The "config-constant accessor" drift is **not cosmetic**: LTC reads `minimum_protocol_version = 3301` from coin_params, BTC reads `MINIMUM_PROTOCOL_VERSION = 3500` from a `PoolConfig` constant — different values from different sources, entangled with the per-coin protocol-version map.

**Consequence:** a single shared implementation of any of those 17 functions cannot be produced by mechanical relocation — it forces one coin's behaviour onto the others in exactly the node/sharechain-timing + protocol-version areas with prior prod-incident history. Those are therefore **NOT hoisted here**; they require a reconciliation-first path (pick the canonical impl per function, back-port to all coins, soak-validate per coin) before any shared layer can absorb them.

## DASH coordination

DASH is still the 668-line skeleton with no ban/whitelist block, so it is **untouched** and keeps deriving from `pool::BaseNode` directly. Once the DASH node quick-wire lands and gives it the same block, DASH switches its base to `pool::SharechainNode` and inherits this layer for free — same as the other four.

## Follow-up (separate PRs, not this one)

1. Slice 2 — hoist the outbound-connection manager + the connection-coupled admin endpoints + `connected/error/close_connection` (also byte-identical all-4) with the small `this->`/`Base::` qualification they need.
2. Reconciliation track (prerequisite for any consensus hoist) — converge the 17 drifted functions to one canonical implementation per function, back-port + soak per coin, THEN hoist. This is the risky, per-coin-validated work; it is intentionally deferred, not half-done here.
