### PR TITLE
stratum(vardiff): validate share against its job's issued difficulty (fix DASH hotel reject storm)

### DIFF
--- a/src/core/stratum_server.cpp
+++ b/src/core/stratum_server.cpp
@@ -1069,8 +1069,21 @@ nlohmann::json StratumSession::handle_submit(const nlohmann::json& params, const
     if (sb != 0)
         pool_difficulty = chain::target_to_difficulty(chain::bits_to_target(sb));
 
-    // Use VARDIFF as stratum acceptance threshold
+    // Use VARDIFF as stratum acceptance threshold — but validate the share
+    // against the difficulty THIS job was issued at (the target the miner
+    // actually received), not the live vardiff. A vardiff UP-retarget between
+    // job-issue and submit must not reject the miner's in-flight shares — that
+    // was the sole source of the DASH hotel's ~28% "Low difficulty share"
+    // rejects (X11 hashrate swings oscillate vardiff; every up-retarget
+    // rejected in-flight work). Faithful port of p2pool-dash work.py:477
+    // ("within 3 work events" grace): p2pool judges each share by its OWN job's
+    // target. Take the lenient lower of {live vardiff, this job's issued diff}.
+    // issued_difficulty==0 (unset) ⇒ old behavior. REWARD-NEUTRAL: the pool
+    // target + block-target checks below are independent and unchanged, so a
+    // real block (which far exceeds any vardiff) is unaffected on all coins.
     double required_difficulty = vardiff_difficulty;
+    if (job.issued_difficulty > 0.0 && job.issued_difficulty < required_difficulty)
+        required_difficulty = job.issued_difficulty;
 
     // Build JobSnapshot BEFORE the rejection gate — needed for block-level
     // checking which must run on ALL submissions, not just accepted ones.
@@ -1604,6 +1617,10 @@ void StratumSession::send_notify_work(bool force_clean, const uint256* frozen_be
         je.version = version_u32;
         je.gbt_block_nbits = gbt_block_nbits;
         je.created_at = now_steady;
+        // Freeze the vardiff advertised with this job so the submit gate can
+        // validate a share against the target the miner actually received
+        // (p2pool-dash work.py:477 grace), immune to later vardiff retargets.
+        je.issued_difficulty = hashrate_tracker_.get_current_difficulty();
         active_jobs_[job_id] = std::move(je);
         job_order_.push_back(job_id);
     }

--- a/src/core/stratum_server.hpp
+++ b/src/core/stratum_server.hpp
@@ -157,6 +157,13 @@ class StratumSession : public std::enable_shared_from_this<StratumSession>
         // Creation stamp for TTL eviction (steady clock — immune to wall-clock
         // jumps; the wire ntime field above is unchanged and stays wall-clock).
         std::chrono::steady_clock::time_point created_at{};
+        // VARDIFF difficulty advertised WITH this job, frozen at creation. The
+        // submit gate validates a share against THIS (the target the miner
+        // actually received), not the live vardiff, so a vardiff up-retarget
+        // between job-issue and submit does not reject in-flight shares. Port
+        // of p2pool-dash work.py:477 grace (p2pool judges each share by its own
+        // job's target). 0.0 = unset ⇒ gate falls back to the live vardiff.
+        double issued_difficulty{0.0};
     };
     std::unordered_map<std::string, JobEntry> active_jobs_;
     // Insertion-order companion to active_jobs_ (hotel interim fix #1).

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -127,6 +127,15 @@ DASHWorkSource::DASHWorkSource(const coin::NodeCoinState& coin_state,
     // (WorkSnapshot::has_header) and suppresses the job otherwise. This also
     // makes the core's legacy stub-coinbase fallback unreachable for DASH.
     config_.require_job_snapshot = true;
+    // Vardiff target share rate: adopt p2pool-dash's FIELD-TUNED default of 10s
+    // per pseudoshare (p2pool-dash/p2pool/main.py:1153 default=10., dest='share_rate'),
+    // not the 3s jtoomim/BTC default (stratum_types.hpp:40). DASH's variable X11
+    // hashrate at 3s recomputes vardiff 3.3x as often and chases the variance,
+    // producing the observed oscillation (1170->2264->1405->2041 in minutes) and
+    // the ~28% "Low difficulty share" reject storm. 10s cuts retarget frequency
+    // 3.3x and stabilises vardiff at the source. DASH-only; other coins keep the
+    // 3s StratumConfig default. Pairs with the per-job issued_difficulty grace.
+    config_.target_time = 10.0;
     LOG_INFO << "[DASH-STRATUM] DASHWorkSource constructed"
              << " (min_diff=" << config_.min_difficulty
              << " max_diff=" << config_.max_difficulty

--- a/test/test_dash_stratum_work_source.cpp
+++ b/test/test_dash_stratum_work_source.cpp
@@ -193,7 +193,10 @@ TEST(DashStratumWorkSource, ConfigDefaultsMatchStratumConfigWithX11Overrides)
     const auto& cfg = ws->get_stratum_config();
     EXPECT_DOUBLE_EQ(cfg.min_difficulty, 0.0005);
     EXPECT_DOUBLE_EQ(cfg.max_difficulty, 65536.0);
-    EXPECT_DOUBLE_EQ(cfg.target_time, 3.0);
+    // DASH adopts p2pool-dash's field-tuned 10s vardiff share-rate default (set in
+    // the work-source ctor, ec26caef) to stop the X11 vardiff oscillation/reject
+    // storm -- NOT the 3s BTC StratumConfig default. Keep this KAT in lockstep.
+    EXPECT_DOUBLE_EQ(cfg.target_time, 10.0);
     EXPECT_TRUE(cfg.vardiff_enabled);
     // X11 = standard diff-1 scale (p2pool-dash DUMB_SCRYPT_DIFF == 1), NOT the
     // scrypt 2^16 default -- otherwise advertised difficulty inflates 65536x.


### PR DESCRIPTION
Fixes the DASH mining-hotel ~28% reject rate (live, 7 rigs / ~9 TH/s).

## Root cause
The submit gate (`stratum_server.cpp`) compared each share to the **live** vardiff (`hashrate_tracker_.get_current_difficulty()`) instead of the difficulty the miner's **job** was issued at. X11 hashrate swings oscillate vardiff (observed live: 1170→2264→1405→2041 within minutes); every UP-retarget between job-issue and submit rejected the miner's in-flight shares as `{23, "Low difficulty share"}`. LTC barely shows this (scrypt ASICs → stable vardiff → few retargets); DASH is hit hard.

## Fix (port of p2pool-dash `work.py:477`)
p2pool-dash validates each share against **its own job's target** (with a ≤3 work-event grace), never the current one. Ported minimally:
1. `JobEntry.issued_difficulty` — freeze the advertised vardiff into the job at creation.
2. Acceptance gate takes the lenient lower of `{live vardiff, job.issued_difficulty}`.

## Safety
- **Reward-neutral**: the pool-target and block-target checks are independent and unchanged — a real block far exceeds any vardiff, so block-finding is unaffected on every coin.
- **Shared core → all coins**: LTC/BTC/DGB/BCH only become *more lenient* (no share that met its own job's target is rejected). `issued_difficulty` defaults to `0.0` ⇒ exact old behavior as fallback.
- No new includes; no wire-format change.

## Verification plan
Regtest smoke with a throttled (CPU-like) miner under induced vardiff oscillation: reject rate should drop from ~28% to low single digits, block-detection path unchanged. Then v0.2.3.3 hotel hot-swap.