### PR TITLE
docs(readme): add First DASH Block milestone (block 2507753, reward-safe)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Development is supported by Anthropic's [Claude for Open Source](https://claude.
 > **Recent Bitcoin Block Mined by P2pool** (2026-06-27 05:34:44 UTC) BTC [#955609](https://blockchair.com/bitcoin/block/955609)
 > 
 > **Recent Bitcoin Block Mined by P2pool** (2025-03-07 06:08:22 UTC) BTC [#886688](https://blockchair.com/bitcoin/block/886688)
+>
+> **First DASH Block Mined by c2pool** (2026-07-20 01:15:15 UTC) DASH [#2507753](https://blockchair.com/dash/block/2507753) — solo X11 block, DIP4 coinbase reward-safe with the correct masternode payee, accepted by dashd
 
 ---
 


### PR DESCRIPTION
Adds the DASH first-block milestone to the README block-milestones list, matching the existing BTC-block style.

**First DASH Block Mined by c2pool** (2026-07-20 01:15:15 UTC) DASH [#2507753](https://blockchair.com/dash/block/2507753) — solo X11 block, DIP4 coinbase reward-safe with the correct masternode payee, accepted by dashd.

On-chain / public data only (block height + Blockchair link). No addresses, IPs, operator, or any personal data. One-line addition; no code.