### PR TITLE
stratum(dash): hashrate-based vardiff (stable-by-construction) — reject endgame

### DIFF
--- a/src/c2pool/hashrate/tracker.cpp
+++ b/src/c2pool/hashrate/tracker.cpp
@@ -29,6 +29,10 @@ void HashrateTracker::record_mining_share_submission(double difficulty, bool acc
         // think the miner is 10-100x faster → difficulty spikes.
         auto tp = clock::now();
         recent_share_times_.push_back(tp);
+        // Feed the hashrate-based vardiff estimator with the issued difficulty
+        // of this accepted share (only when that path is active).
+        if (use_hashrate_vardiff_)
+            record_share_for_hashrate(difficulty, static_cast<double>(now));
     }
 
     adjust_difficulty();
@@ -141,9 +145,66 @@ void HashrateTracker::set_difficulty_hint(double hint) {
 // 2 back-to-back shares at the correct difficulty level.
 // No cooldown — p2pool doesn't use one; the window reset after each
 // adjustment means VARDIFF_TRIGGER shares must accumulate again.
+// --- Hashrate-based vardiff (stable-by-construction). Port of p2pool-dash
+// work.py:369-376: set pseudoshare difficulty directly from the smoothed
+// hashrate so the miner emits ~1 share per target_time. D = H_est*target/2^32
+// has no dependence on current_difficulty_, so there is no loop to oscillate. ---
+static inline double ewma_decay(double dt, double tau) {
+    return dt <= 0.0 ? 1.0 : std::exp(-dt / tau);
+}
+
+// Called (shares_mutex_ held) when an accepted share is recorded, with the
+// share's issued difficulty — consistent with the #762 grace, so counted work
+// matches hashes actually done.
+void HashrateTracker::record_share_for_hashrate(double issued_difficulty, double now) {
+    if (ewma_share_count_ == 0) {
+        ewma_first_share_time_ = now;
+        ewma_last_decay_time_  = now;
+    }
+    ewma_work_ = ewma_work_ * ewma_decay(now - ewma_last_decay_time_, vardiff_ewma_tau_)
+               + issued_difficulty;
+    ewma_last_decay_time_ = now;
+    ++ewma_share_count_;
+}
+
+double HashrateTracker::get_recent_hashrate(double now) const {
+    if (ewma_share_count_ == 0) return 0.0;
+    double work = ewma_work_ * ewma_decay(now - ewma_last_decay_time_, vardiff_ewma_tau_);
+    // Bias-corrected normalizer (unbiased during warm-up); floor the age so a
+    // fresh connection cannot divide by ~0.
+    double age  = std::max(now - ewma_first_share_time_, 2.0 * target_time_per_mining_share_);
+    double norm = vardiff_ewma_tau_ * (1.0 - std::exp(-age / vardiff_ewma_tau_));
+    if (norm <= 0.0) return 0.0;
+    return work * 4294967296.0 / norm;   // H/s (2^32 attempts per difficulty-1 share)
+}
+
+void HashrateTracker::set_difficulty_from_hashrate(double now) {
+    if (ewma_share_count_ < static_cast<uint64_t>(vardiff_warmup_shares_)) return; // keep seed diff
+    double h = get_recent_hashrate(now);
+    if (h <= 0.0) return;
+    double d = h * target_time_per_mining_share_ / 4294967296.0;
+    d = std::max(min_difficulty_, std::min(max_difficulty_, d));
+    if (current_difficulty_ > 0.0) {
+        double ratio = d / current_difficulty_;
+        // Dead-band: absorb estimator noise, no needless set_difficulty churn.
+        if (ratio < 1.0 + vardiff_deadband_ && ratio > 1.0 / (1.0 + vardiff_deadband_))
+            return;
+    }
+    LOG_INFO << "[Stratum] VARDIFF(hashrate): " << current_difficulty_ << " -> " << d
+             << " (H_est=" << h << " H/s, target=" << target_time_per_mining_share_ << "s)";
+    current_difficulty_ = d;  // downstream notify + stratum 1% resend guard unchanged
+}
+
 void HashrateTracker::adjust_difficulty() {
     if (!vardiff_enabled_)
         return;
+
+    // Stable-by-construction path (DASH): derive difficulty from smoothed
+    // hashrate, no ratio feedback → no oscillation. Legacy path below unchanged.
+    if (use_hashrate_vardiff_) {
+        set_difficulty_from_hashrate(static_cast<double>(std::time(nullptr)));
+        return;
+    }
 
     size_t num_shares = recent_share_times_.size();
     if (num_shares == 0)

--- a/src/c2pool/hashrate/tracker.hpp
+++ b/src/c2pool/hashrate/tracker.hpp
@@ -52,6 +52,21 @@ private:
     // Whether vardiff auto-adjustment is active (only for stratum per-connection trackers)
     bool vardiff_enabled_ = false;
 
+    // --- Hashrate-based vardiff (stable-by-construction; opt-in per tracker) ---
+    // Sets difficulty directly from a smoothed hashrate estimate
+    // (D = H_est * target_time / 2^32) instead of the ratio feedback loop, which
+    // oscillates because new_diff = current_diff / ratio(current_diff). Off by
+    // default; DASH opts in via set_hashrate_vardiff(true). Port of p2pool-dash
+    // work.py:369-376 target modulation. The legacy ratio path stays byte-identical.
+    bool     use_hashrate_vardiff_   = false;
+    double   vardiff_ewma_tau_       = 90.0;  // s; hashrate estimator time constant (60-120)
+    double   vardiff_deadband_       = 0.10;  // only move diff when change > 10%
+    int      vardiff_warmup_shares_  = 4;     // keep seed/initial diff until warm
+    double   ewma_work_              = 0.0;   // exp-decayed sum of accepted-share difficulty
+    double   ewma_last_decay_time_   = 0.0;   // epoch s
+    double   ewma_first_share_time_  = 0.0;   // epoch s
+    uint64_t ewma_share_count_       = 0;
+
     // Statistics
     uint64_t total_mining_shares_submitted_ = 0;
     uint64_t total_mining_shares_accepted_ = 0;
@@ -71,6 +86,8 @@ public:
     void set_difficulty_bounds(double min_difficulty, double max_difficulty);
     void set_target_time_per_mining_share(double target_seconds);
     void enable_vardiff(bool enabled = true);
+    // Enable the stable-by-construction hashrate-based vardiff (DASH). Off = legacy ratio feedback.
+    void set_hashrate_vardiff(bool on) { use_hashrate_vardiff_ = on; }
 
     // Backward compatibility
     void record_share_submission(double difficulty, bool accepted) {
@@ -93,6 +110,10 @@ public:
 
 private:
     void adjust_difficulty();
+    // Hashrate-based vardiff helpers (all take epoch-seconds 'now'; caller holds shares_mutex_).
+    void   record_share_for_hashrate(double issued_difficulty, double now);
+    double get_recent_hashrate(double now) const;   // EWMA H/s (600s get_current_hashrate() untouched)
+    void   set_difficulty_from_hashrate(double now);
 };
 
 } // namespace hashrate

--- a/src/core/stratum_server.cpp
+++ b/src/core/stratum_server.cpp
@@ -378,6 +378,7 @@ StratumSession::StratumSession(tcp::socket socket, std::shared_ptr<IWorkSource> 
     const auto& cfg = mining_interface_->get_stratum_config();
     hashrate_tracker_.set_difficulty_bounds(cfg.min_difficulty, cfg.max_difficulty);
     hashrate_tracker_.set_target_time_per_mining_share(cfg.target_time);
+    hashrate_tracker_.set_hashrate_vardiff(cfg.use_hashrate_vardiff);
     if (cfg.vardiff_enabled)
         hashrate_tracker_.enable_vardiff();
 }

--- a/src/core/stratum_types.hpp
+++ b/src/core/stratum_types.hpp
@@ -39,6 +39,7 @@ struct StratumConfig {
     double max_difficulty       = 65536.0;  // ceiling for per-connection vardiff
     double target_time          = 3.0;      // seconds between pseudoshares (p2pool default: 3)
     bool   vardiff_enabled      = true;     // auto-adjust per-connection difficulty
+    bool   use_hashrate_vardiff = false;    // stable-by-construction hashrate-based vardiff (DASH); off = legacy ratio feedback
     size_t max_coinbase_outputs = 4000;     // Python p2pool's [-4000:] cap; no consensus limit
     // Per-network mining.set_difficulty multiplier (p2pool net.DUMB_SCRYPT_DIFF):
     // 2^16 (65536) for scrypt nets (LTC/DOGE), 1 for SHA256d nets (bitcoin).

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -136,6 +136,12 @@ DASHWorkSource::DASHWorkSource(const coin::NodeCoinState& coin_state,
     // 3.3x and stabilises vardiff at the source. DASH-only; other coins keep the
     // 3s StratumConfig default. Pairs with the per-job issued_difficulty grace.
     config_.target_time = 10.0;
+    // Use the stable-by-construction hashrate-based vardiff (D = H_est*target/2^32)
+    // instead of the ratio-feedback loop, which still limit-cycles ~2-3x even at
+    // 10s for variable X11 hashrate — the residual "Low difficulty share" rejects.
+    // Derived directly from a smoothed hashrate, so it cannot oscillate. DASH-only;
+    // other coins keep the legacy ratio path (use_hashrate_vardiff=false).
+    config_.use_hashrate_vardiff = true;
     LOG_INFO << "[DASH-STRATUM] DASHWorkSource constructed"
              << " (min_diff=" << config_.min_difficulty
              << " max_diff=" << config_.max_difficulty


### PR DESCRIPTION
Finishes the DASH reject fix. v0.2.3.3 (#762 grace + 10s) cut the live hotel rejects ~30% → ~20%, but the **ratio-feedback vardiff still limit-cycles ~2–3×** (2747–9016 observed), leaving a stable ~20% "Low difficulty share" floor.

## Root cause
`new_diff = current_diff / ratio`, where `ratio` depends on `current_diff` via share arrival rate → it multiplies its own output → limit cycle. The oscillation also **desyncs advertised vs job-captured difficulty** (set_difficulty fires on change events, `issued_difficulty` snapshots at job creation), so compliant miners land below the job’s captured diff and the #762 grace still rejects them.

## Fix (port of p2pool-dash `work.py:369-376`)
Set difficulty **directly from a smoothed hashrate estimate**: `D = H_est × target_time / 2³²`. No dependence on `current_difficulty_` → **no loop → cannot oscillate**. EWMA work estimator (tau=90s) + 10% dead-band + 4-share warmup.

## Safety
- **Flag-gated** `StratumConfig.use_hashrate_vardiff` — DASHWorkSource sets it true; **all other coins keep the legacy ratio path byte-identical**.
- **Reward-neutral** (pseudoshare difficulty only); preserves the #762 per-job grace, min/max clamps, and the `+N` fixed-diff seed (warmup gate).
- **Revert = flip the flag** (single commit).
- Graceful hashrate-loss decay (read-time EWMA) instead of the old `/10` cliff.

## Validation
- CI: compile + all-coin regression (legacy path unchanged) + DASH G1/G3a gates.
- Live: this becomes the next hotel hot-swap (bundled with the #764 dashboard, both on master) — the reject delta is measured on the real 7-rig workload with instant revert, same as v0.2.3.3.
- Follow-up test suite (stability / step-response anti-oscillation / single-digit reject sim) to be added to `test/vardiff_test.py`.

No payout-path code touched.