### PR TITLE
stratum(all-coins): enable hashrate-based vardiff for LTC/DOGE/BTC/DGB/BCH (PRE-STAGED, hold for DASH)

### DIFF
--- a/src/c2pool/main_ltc.cpp
+++ b/src/c2pool/main_ltc.cpp
@@ -640,6 +640,9 @@ int main(int argc, char* argv[]) {
     // Stratum tuning (configurable via CLI or YAML)
     core::StratumConfig stratum_config;  // defaults: min=0.0005, max=65536, target=3.0s, vardiff=true
     stratum_config.coin_symbol = "LTC";  // runtime coin tag for coin-agnostic core log lines
+    // Stable-by-construction hashrate-based vardiff for LTC/DOGE (see DASH #766).
+    // Consensus-neutral (pseudoshare-only). PRE-STAGED — hold until DASH validates live.
+    stratum_config.use_hashrate_vardiff = true;
 
     // Operational tuning (configurable via CLI or YAML)
     std::string log_file;                        // empty = default "debug.log"

--- a/src/impl/bch/stratum/work_source.cpp
+++ b/src/impl/bch/stratum/work_source.cpp
@@ -103,6 +103,9 @@ BCHWorkSource::BCHWorkSource(bch::coin::HeaderChain&       chain,
     , submit_block_fn_(std::move(submit_fn))
     , config_(std::move(config))
 {
+    // Stable-by-construction hashrate-based vardiff (see DASH). Consensus-neutral
+    // (pseudoshare-only). PRE-STAGED — hold until DASH #766 validates live.
+    config_.use_hashrate_vardiff = true;
     LOG_INFO << "[BCH-STRATUM] BCHWorkSource constructed (testnet="
              << (is_testnet_ ? "1" : "0") << ")";
 }

--- a/src/impl/btc/stratum/work_source.cpp
+++ b/src/impl/btc/stratum/work_source.cpp
@@ -131,6 +131,9 @@ BTCWorkSource::BTCWorkSource(btc::coin::HeaderChain&       chain,
     // Runtime coin tag for coin-agnostic core log lines (#732).
     if (config_.coin_symbol.empty())
         config_.coin_symbol = "BTC";
+    // Stable-by-construction hashrate-based vardiff (see DASH). Consensus-neutral
+    // (pseudoshare-only). PRE-STAGED — hold until DASH #766 validates live.
+    config_.use_hashrate_vardiff = true;
 
     LOG_INFO << "[BTC-STRATUM] BTCWorkSource constructed"
              << " (testnet=" << is_testnet_

--- a/src/impl/dgb/stratum/work_source.cpp
+++ b/src/impl/dgb/stratum/work_source.cpp
@@ -119,6 +119,9 @@ DGBWorkSource::DGBWorkSource(c2pool::dgb::HeaderChain&     chain,
     // Runtime coin tag for coin-agnostic core log lines (#732).
     if (config_.coin_symbol.empty())
         config_.coin_symbol = "DGB";
+    // Stable-by-construction hashrate-based vardiff (see DASH). Consensus-neutral
+    // (pseudoshare-only). PRE-STAGED — hold until DASH #766 validates live.
+    config_.use_hashrate_vardiff = true;
     LOG_INFO << "[DGB-STRATUM] DGBWorkSource constructed"
              << " (testnet=" << is_testnet_
              << " min_diff=" << config_.min_difficulty


### PR DESCRIPTION
PRE-STAGED / DRAFT — do NOT merge until DASH #766 validates live on the hotel.

Stacks on #766 (the hashrate-vardiff engine). Flips use_hashrate_vardiff=true for the remaining coins — one line each at their stratum config point (BTC/DGB/BCH work-source ctors; LTC/DOGE via main_ltc StratumConfig). Reuses the same core engine; no new logic.

Consensus-neutral (pseudoshare difficulty only) — verified per the pre-v36 transition rule (empty diff-grep for share_bits/is_pool_share/etc). Before un-drafting each coin needs: (1) DASH proven live, (2) per-coin target_time field-tuning, (3) a soak against that coin's legacy p2pool sharechain (crossing safety). Revert = flip each flag back.

Order to un-hold: DASH live -> LTC/DOGE -> DGB -> BCH -> BTC.
