### PR TITLE
dash(web): per-rig TCP latency column in workers-table

### DIFF
--- a/src/core/stratum_server.cpp
+++ b/src/core/stratum_server.cpp
@@ -15,6 +15,28 @@
 #include <cmath>
 #include <cstring>
 #include <boost/algorithm/string.hpp>
+#ifdef __linux__
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#endif
+
+namespace {
+// Sample kernel-measured TCP round-trip time for a connected socket, in ms.
+// Same value `ss -ti` prints (tcpi_rtt, microseconds). Linux-only; 0 elsewhere
+// or on any error (socket closed, not yet established).
+inline double sample_tcp_rtt_ms(int fd) {
+#ifdef __linux__
+    struct tcp_info ti;
+    socklen_t len = sizeof(ti);
+    if (fd >= 0 && ::getsockopt(fd, IPPROTO_TCP, TCP_INFO, &ti, &len) == 0)
+        return static_cast<double>(ti.tcpi_rtt) / 1000.0;
+#else
+    (void)fd;
+#endif
+    return 0.0;
+}
+}  // namespace
 
 namespace core {
 
@@ -722,6 +744,7 @@ nlohmann::json StratumSession::handle_authorize(const nlohmann::json& params, co
                 wi.remote_endpoint = socket_.remote_endpoint().address().to_string()
                     + ":" + std::to_string(socket_.remote_endpoint().port());
             } catch (...) {}
+            wi.rtt_ms = sample_tcp_rtt_ms(socket_.native_handle());
             mining_interface_->register_stratum_worker(session_id_, wi);
         }
         
@@ -1220,6 +1243,8 @@ nlohmann::json StratumSession::handle_submit(const nlohmann::json& params, const
             0.0,
             hashrate_tracker_.get_current_difficulty(),
             accepted_shares_, rejected_shares_, stale_shares_);
+        mining_interface_->update_stratum_worker_rtt(session_id_,
+            sample_tcp_rtt_ms(socket_.native_handle()));
     }
 
     nlohmann::json response;

--- a/src/core/stratum_types.hpp
+++ b/src/core/stratum_types.hpp
@@ -174,6 +174,7 @@ struct WorkerInfo {
     uint64_t stale{0};
     std::chrono::steady_clock::time_point connected_at;
     std::string remote_endpoint;  // "ip:port"
+    double rtt_ms{0.0};           // TCP round-trip latency in ms (Linux tcpi_rtt); 0 = unknown / non-Linux
 };
 
 }  // namespace core::stratum

--- a/src/core/stratum_work_source.hpp
+++ b/src/core/stratum_work_source.hpp
@@ -90,6 +90,12 @@ public:
                                        uint64_t accepted, uint64_t rejected,
                                        uint64_t stale) = 0;
 
+    // Optional: record per-session TCP round-trip latency (ms), sampled from the
+    // kernel socket by the stratum session. Default no-op so per-coin work sources
+    // need no override; MiningInterface stores it for dashboard display.
+    virtual void update_stratum_worker_rtt(const std::string& /*session_id*/,
+                                           double /*rtt_ms*/) {}
+
     // ── Work generation ──────────────────────────────────────────────────
     // Called per-job-issue (when sending mining.notify). Implementors
     // must produce a snapshot consistent with their template state at

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -3378,6 +3378,8 @@ nlohmann::json MiningInterface::rest_stratum_stats()
             workers_json[worker_key]["accepted"] = workers_json[worker_key]["accepted"].get<uint64_t>() + w.accepted;
             workers_json[worker_key]["rejected"] = workers_json[worker_key]["rejected"].get<uint64_t>() + w.rejected;
             workers_json[worker_key]["stale"] = workers_json[worker_key]["stale"].get<uint64_t>() + w.stale;
+            if (w.rtt_ms > workers_json[worker_key].value("rtt_ms", 0.0))
+                workers_json[worker_key]["rtt_ms"] = w.rtt_ms;
             workers_json[worker_key]["shares"] = workers_json[worker_key]["shares"].get<uint64_t>() + w.accepted + w.stale;
             // Keep earliest first_seen
             if (first_seen_ts < workers_json[worker_key]["first_seen"].get<uint64_t>())
@@ -3396,7 +3398,8 @@ nlohmann::json MiningInterface::rest_stratum_stats()
                 {"stale", w.stale},
                 {"shares", w.accepted + w.stale},
                 {"connected_seconds", elapsed},
-                {"remote_endpoint", w.remote_endpoint}
+                {"remote_endpoint", w.remote_endpoint},
+                {"rtt_ms", w.rtt_ms}
             };
         }
     }
@@ -6993,6 +6996,14 @@ void MiningInterface::update_stratum_worker(const std::string& session_id,
         it->second.rejected = rejected;
         it->second.stale = stale;
     }
+}
+
+void MiningInterface::update_stratum_worker_rtt(const std::string& session_id, double rtt_ms)
+{
+    std::lock_guard<std::mutex> lock(m_stratum_workers_mutex);
+    auto it = m_stratum_workers.find(session_id);
+    if (it != m_stratum_workers.end())
+        it->second.rtt_ms = rtt_ms;
 }
 
 std::map<std::string, MiningInterface::WorkerInfo> MiningInterface::get_stratum_workers() const

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -1469,6 +1469,7 @@ public:
     void update_stratum_worker(const std::string& session_id,
                                double hashrate, double dead_hashrate, double difficulty,
                                uint64_t accepted, uint64_t rejected, uint64_t stale) override;
+    void update_stratum_worker_rtt(const std::string& session_id, double rtt_ms) override;
     std::map<std::string, WorkerInfo> get_stratum_workers() const;
 
 private:

--- a/web-static/stratum.html
+++ b/web-static/stratum.html
@@ -628,6 +628,7 @@
                     <tr>
                         <th>Worker</th>
                         <th>Hash Rate</th>
+                        <th title="Kernel TCP round-trip latency (ss -ti tcpi_rtt)">Latency (ms)</th>
                         <th>Shares</th>
                         <th>Accepted</th>
                         <th>Rejected</th>
@@ -985,6 +986,11 @@
                         .text(w.name.length > 25 ? w.name.substr(0, 12) + '...' + w.name.substr(-8) : w.name)
                         .attr('title', w.name);
                     tr.append('td').attr('class', 'hash-rate').text(format_hashrate(s.hash_rate || 0));
+                    var rtt = s.rtt_ms || 0;
+                    var rttClass = rtt <= 0 ? '' : (rtt < 20 ? 'good' : (rtt > 100 ? 'bad' : ''));
+                    tr.append('td').attr('class', rttClass)
+                        .attr('title', rtt <= 0 ? 'unknown (non-Linux node or socket closed)' : '')
+                        .text(rtt > 0 ? d3.format('.1f')(rtt) : '-');
                     tr.append('td').text(d3.format(',')(s.shares || 0));
                     tr.append('td').attr('class', 'good').text(d3.format(',')(s.accepted || 0));
                     tr.append('td').attr('class', wRejectPct > 5 ? 'bad' : '')
@@ -995,7 +1001,7 @@
                 
                 if (workerList.length === 0) {
                     tbody.append('tr')
-                        .append('td').attr('colspan', '7')
+                        .append('td').attr('colspan', '8')
                         .style('text-align', 'center')
                         .style('color', 'var(--text-muted)')
                         .text('No workers connected');


### PR DESCRIPTION
Completes the per-rig **Latency (ms)** column folded into the #764 DASH dashboard-wiring scope — #764 merged as pure WebServer wiring, so this lands the latency piece as its own small additive PR.

## What
- `core::stratum::WorkerInfo` gains `rtt_ms`, sampled from `getsockopt(fd, IPPROTO_TCP, TCP_INFO).tcpi_rtt / 1000` (the same value `ss -ti` prints) — populated at connect and refreshed on each periodic worker-stats update.
- New **non-pure** virtual `update_stratum_worker_rtt` (default no-op) so the five per-coin work sources (LTC/DOGE/DGB/DASH/BTC/BCH) need **no override** — only core `MiningInterface` stores it. Zero cross-coin ripple.
- `getminerstats` JSON exposes `rtt_ms` per worker (worst/max across a worker s aggregated connections).
- `web-static/stratum.html` workers-table: new **Latency (ms)** column — green <20ms, red >100ms, `-` when unmeasurable.

## Honesty invariant
Linux-only (`#ifdef __linux__`); non-Linux nodes or closed sockets render `-`, never a fake `0`.

## Verification
Builds green locally (`c2pool-dash` target, exit 0). Non-consensus web layer → normal merge; awaiting CI CLEAN before merge-tap.