### PR TITLE
dash(stratum): event-driven tip refresh on dashd-fallback arm + issued-diff hashrate credit

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -1481,6 +1481,65 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         }
     }
 
+    // ── Fallback-arm event-driven tip refresh ────────────────────────────
+    // On the dashd-fallback arm (no embedded coin-P2P tip source) the template
+    // cache only re-sources on the 30 s staleness TTL (work_source.cpp
+    // kStaleAfter) — there is NO tip-change signal like the embedded arm's
+    // header_chain->set_on_tip_changed callback. DASH blocks arrive ~every
+    // 150 s, so up to ~30 s of stale-tip mining can occur per block (accepted
+    // pseudoshares that can no longer win the current block). Poll dashd for
+    // its best-block hash every 3 s; on a change, drop the cached template +
+    // bump work-generation + notify every session (clean_jobs) — the SAME
+    // refresh pair the embedded arm fires. Gated on the fallback arm (coin_p2p
+    // null) AND an armed rpc AND a live stratum acceptor. getbestblockhash is a
+    // trivial RPC; failures are swallowed so a daemon hiccup never crashes the
+    // run-loop (retry next tick). Reuses the existing NodeRPC client — no new
+    // dependency, no dashd config change, no new notify mechanism.
+    if (!coin_p2p && rpc && stratum_server) {
+        auto tip_timer = std::make_shared<io::steady_timer>(ioc);
+        auto last_tip = std::make_shared<std::string>();
+        auto tip_tick = std::make_shared<
+            std::function<void(const boost::system::error_code&)>>();
+        *tip_tick = [rpc = rpc.get(), ws = work_source.get(),
+                     ss = stratum_server.get(), tip_timer, last_tip, tip_tick](
+                        const boost::system::error_code& ec) {
+            if (ec) return;   // cancelled at shutdown
+            try {
+                const std::string tip = rpc->getbestblockhash();
+                if (!tip.empty() && *last_tip != tip) {
+                    const bool first_seen = last_tip->empty();
+                    *last_tip = tip;
+                    // Skip the notify on the very first observation (baseline);
+                    // only a genuine tip CHANGE forces a refresh.
+                    if (!first_seen) {
+                        ws->invalidate_template_cache(
+                            "tip-poll: dashd best-block changed");
+                        ws->bump_work_generation();
+                        ss->notify_all();
+                        LOG_INFO << "[Stratum] tip-poll: new tip "
+                                 << tip.substr(0, 16)
+                                 << ", forcing template refresh + notify";
+                        std::cout << "[Stratum] tip-poll: new tip "
+                                  << tip.substr(0, 16)
+                                  << ", forcing template refresh + notify\n";
+                    }
+                }
+            } catch (const std::exception& e) {
+                LOG_WARNING << "[Stratum] tip-poll getbestblockhash failed "
+                               "(non-fatal, retry next tick): " << e.what();
+            } catch (...) {
+                // swallow — never crash the run-loop on a tip probe
+            }
+            tip_timer->expires_after(std::chrono::seconds(3));
+            tip_timer->async_wait(*tip_tick);
+        };
+        tip_timer->expires_after(std::chrono::seconds(3));
+        tip_timer->async_wait(*tip_tick);
+        std::cout << "[run] fallback-arm tip-poll ARMED (dashd getbestblockhash "
+                     "every 3 s -> event-driven template refresh + clean_jobs "
+                     "notify on tip change)\n";
+    }
+
     std::cout << "[run] run-loop up (Ctrl-C to stop); won blocks relay DUAL-PATH:\n"
                  "[run]   ARM A embedded coin-P2P relay (primary, daemonless) = "
               << (p2p_relay ? "ARMED" : (no_p2p_relay ? "SUPPRESSED (--no-p2p-relay)"

--- a/src/core/stratum_server.cpp
+++ b/src/core/stratum_server.cpp
@@ -1178,10 +1178,18 @@ nlohmann::json StratumSession::handle_submit(const nlohmann::json& params, const
 
     // ── Pseudoshare accepted — record in RateMonitor ──
     // p2pool: work = target_to_average_attempts(effective_target)
-    // For us: work = vardiff_difficulty × 2^32 (equivalent unit conversion)
+    // For us: work = credited_difficulty × 2^32 (equivalent unit conversion)
     ++accepted_shares_;
     static constexpr double TWO_32 = 4294967296.0;
-    double work = vardiff_difficulty * TWO_32;
+    // #766/#762: credit the hashrate estimate at the difficulty THIS job was
+    // actually issued/mined at, not the live vardiff. A vardiff retarget
+    // between job-issue and submit must not skew the EWMA/RateMonitor input —
+    // the share represents work at its own job's target. Falls back to the live
+    // vardiff when issued_difficulty is unset (0). Estimate/stats only; the
+    // acceptance gate above is unchanged.
+    double credited_difficulty =
+        (job.issued_difficulty > 0.0) ? job.issued_difficulty : vardiff_difficulty;
+    double work = credited_difficulty * TWO_32;
     bool is_dead = (job.stale_info != 0);
 
     // Record in global RateMonitor (for get_local_addr_rates)
@@ -1189,7 +1197,7 @@ nlohmann::json StratumSession::handle_submit(const nlohmann::json& params, const
         server_->record_pseudoshare(work, pubkey_hash_, username_, is_dead);
 
     // Record in per-connection tracker (for VARDIFF adjustment + per-session stats)
-    hashrate_tracker_.record_mining_share_submission(vardiff_difficulty, true);
+    hashrate_tracker_.record_mining_share_submission(credited_difficulty, true);
 
     // Check if VARDIFF changed → send new difficulty AND new work to miner.
     // p2pool (stratum.py:594-595): after adjusting target, calls _send_work()

--- a/src/impl/dash/coin/rpc.cpp
+++ b/src/impl/dash/coin/rpc.cpp
@@ -444,6 +444,18 @@ nlohmann::json NodeRPC::getmininginfo()
     return CallAPIMethod("getmininginfo");
 }
 
+// Trivial tip probe -- `getbestblockhash` returns the best-block hash as a bare
+// JSON string. Returns "" if the daemon result is null/absent (never throws on
+// a well-formed-but-empty result; transport errors still propagate to the
+// caller, which swallows them). No dashd config change is required.
+std::string NodeRPC::getbestblockhash()
+{
+    auto result = CallAPIMethod("getbestblockhash");
+    if (result.is_string())
+        return result.get<std::string>();
+    return {};
+}
+
 // verbose: true -- json result, false -- hex-encode result;
 nlohmann::json NodeRPC::getblockheader(uint256 header, bool verbose)
 {

--- a/src/impl/dash/coin/rpc.hpp
+++ b/src/impl/dash/coin/rpc.hpp
@@ -126,6 +126,11 @@ public:
     nlohmann::json getnetworkinfo();
     nlohmann::json getblockchaininfo();
     nlohmann::json getmininginfo();
+    // Trivial tip probe: the current best-block hash as a hex string. Used by
+    // the fallback-arm tip poller (main_dash.cpp) to drive event-driven
+    // template refresh without waiting on the 30 s staleness TTL. Empty string
+    // on a null/absent result.
+    std::string getbestblockhash();
     // verbose: true -- json result, false -- hex-encode result;
     nlohmann::json getblockheader(uint256 header, bool verbose = true);
     // verbosity: 0 for hex-encoded data, 1 for a json object, and 2 for json object with transaction data

--- a/test/test_dash_stratum_work_source.cpp
+++ b/test/test_dash_stratum_work_source.cpp
@@ -741,6 +741,56 @@ TEST(DashStratumWorkSource, InvalidateTemplateCacheForcesRefetchAndBumpsGenerati
     EXPECT_EQ(fallback_calls, 2);
 }
 
+// Fallback-arm event-driven tip refresh pin: on the dashd-fallback arm the
+// template cache only re-sources on the 30 s staleness TTL, so a new DASH block
+// can leave miners hashing a stale tip for up to ~30 s (accepted pseudoshares
+// that can no longer win the current block). The run-path tip poller
+// (main_dash.cpp) closes that window by firing the SAME refresh pair on a
+// dashd best-block change that the embedded arm fires from its header-chain
+// tip-changed callback: invalidate_template_cache() + bump_work_generation(),
+// then notify_all() pushes a clean_jobs mining.notify. This KAT pins the
+// work-source contract that pair relies on: on a tip change the served template
+// must SWAP to the new tip (no stale-tip mining) AND the work generation must
+// bump (the clean_jobs/notify signal every session re-pulls on). Fallback arm
+// only: an UNPOPULATED coin-state, so get_work routes to the dashd fallback.
+TEST(DashStratumWorkSource, FallbackArmTipChangeRefreshesTemplateAndBumpsGeneration)
+{
+    Fixture fx(true);                       // unpopulated coin-state -> fallback arm
+    ASSERT_FALSE(fx.coin_state.populated());
+    auto ws = fx.make();
+
+    // Baseline: the fallback serves the pre-tip-change template, cached at the
+    // old tip. This is what an idle miner would keep hashing until the TTL.
+    auto tmpl_before = ws->get_current_work_template();
+    ASSERT_FALSE(tmpl_before.empty());
+    EXPECT_EQ(tmpl_before.value("previousblockhash", ""), std::string(kPrevHashHex));
+    const uint64_t gen_before = ws->get_work_generation();
+
+    // A new DASH block arrives: dashd's best-block hash changes. The fallback
+    // now sources a new-tip template (rotated prev + rotated payee), exactly as
+    // getbestblockhash flips for the run-path poller.
+    fx.fallback_work = rotated_work();
+
+    // The poller's refresh action on an observed tip change (the SAME pair the
+    // embedded header-chain tip-changed callback fires).
+    ws->invalidate_template_cache("kat: fallback-arm dashd best-block changed");
+    ws->bump_work_generation();
+
+    // (a) clean_jobs/notify signal: work generation advanced, so notify_all()
+    //     will push a fresh mining.notify to every session.
+    EXPECT_GT(ws->get_work_generation(), gen_before);
+
+    // (b) no more stale-tip mining: the next served template is the NEW tip,
+    //     not the cached pre-change one.
+    auto tmpl_after = ws->get_current_work_template();
+    ASSERT_FALSE(tmpl_after.empty());
+    EXPECT_EQ(tmpl_after.value("previousblockhash", ""),
+              std::string(kRotatedPrevHashHex));
+    EXPECT_NE(tmpl_after.value("previousblockhash", ""),
+              tmpl_before.value("previousblockhash", ""));
+    EXPECT_EQ(tmpl_after.value("height", 0u), 424243u);
+}
+
 // Fix 3 pin (work-source side of the zero-hash pre-auth job_0 defect): a
 // template with a zeroed prev is NOT mineable work — honest set-gap, never a
 // zero-prev job.


### PR DESCRIPTION
## Summary

Two consensus-neutral stratum fixes for the live mining-hotel DASH node, targeting the confirmed dashd-fallback template arm (`template sourced: arm=dashd-fallback`, no tip-change events). Both touch only the per-connection vardiff/pseudoshare path and the template-refresh/notify path.

### FIX 1 (high impact) — event-driven tip refresh on the dashd-fallback arm
The fallback arm has no tip-change signal like the embedded arm's `header_chain->set_on_tip_changed` callback; the template cache only re-sources on a 30 s staleness TTL (`work_source.cpp kStaleAfter`). DASH blocks arrive ~every 150 s, so up to ~30 s of stale-tip mining per block was silent waste (accepted pseudoshares that can no longer win the current block).

Added a lightweight run-path poller (`main_dash.cpp`) that reads dashd `getbestblockhash` every 3 s. On a tip change it fires the SAME refresh pair the embedded arm uses: `invalidate_template_cache()` + `bump_work_generation()` + `stratum_server->notify_all()` (clean_jobs push). It:
- is gated on the fallback arm only (`coin_p2p` null) AND an armed `rpc` AND a live stratum acceptor;
- reuses the existing `NodeRPC` client via a new trivial `getbestblockhash()` method — no new dependency, no dashd config change, no new notify mechanism;
- swallows RPC failures (retry next tick — never crashes the run-loop);
- skips the notify on the first observation (baseline), only a genuine tip change refreshes;
- logs `[Stratum] tip-poll: new tip <hash>, forcing template refresh + notify`.

### FIX 2 (low priority, design conformance) — EWMA credit at issued difficulty
In `stratum_server.cpp` `handle_submit`, the accepted pseudoshare was credited to the hashrate EWMA + RateMonitor at the live `vardiff_difficulty`. Per #766/#762 it is now credited at `credited_difficulty = (job.issued_difficulty > 0.0) ? job.issued_difficulty : vardiff_difficulty` — the diff the job was actually mined at, so a vardiff retarget between job-issue and submit no longer skews the estimate. Estimate/stats only; the acceptance gate is unchanged.

## Consensus-neutrality
`git diff origin/master | grep -iE 'get_share_bits|share_bits|share_target|DGW|oracle'` → **empty** (no matches, comments included). `get_share_bits()`/pool `share_bits`, the DGW retarget, the sharechain share target, and block-acceptance are untouched.

## Tests
Extended `test_dash_stratum_work_source` (already in both `build.yml --target` allowlists) with `FallbackArmTipChangeRefreshesTemplateAndBumpsGeneration`, pinning the fallback-arm tip-change refresh contract: on a tip change the served template swaps to the new tip AND work-generation bumps (the clean_jobs/notify signal). Local run: **31/31 passed** (was 30, +1 new KAT). Full `c2pool-dash` builds clean.

### build.yml note
The KAT extends the existing `test_dash_stratum_work_source` target, which is **already present in BOTH `build.yml --target` lists** (lines 141 and 323), so no `build.yml` edit is required and the target-allowlist CI check stays green. This was a deliberate choice to keep the change surgical and avoid a new CI target. For the record, the active gh token scope is `gist, read:org, repo` (no `workflow` scope), so a `build.yml` edit could not have been pushed anyway — but none is needed here.

## Release artifact
Built `c2pool-dash-0.2.3.5-linux-x86_64.tar.gz` via the `release.yml` Linux recipe (strip + ldd-resolved lib closure + config/web-static/explorer). Binary self-reports `c2pool-dash 0.2.3.5`. Deploy is the integrator + operator's job (not staged here).

## Deploy posture
Live-tenant surgical + reversible. No refactors. Draft PR — two-party merge is the integrator's.
