### PR TITLE
dash: wire live stratum stats into the dashboard /local_stats (display only)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -76,6 +76,7 @@
 #include <impl/dash/coinbase_builder.hpp>      // dash::coinbase::build / compute_dash_payouts (slice 5)
 #include <impl/dash/params.hpp>                // dash::make_coin_params (already via top include)
 #include <core/uint256.hpp>                    // uint160 payout pubkey hash
+#include <core/target_utils.hpp>              // chain::target_to_difficulty (dashboard net-diff)
 
 #include <core/stratum_server.hpp>             // core::StratumServer — miner-facing accept-loop (run-path caller)
 #include <impl/dash/stratum/work_source.hpp>   // dash::stratum::DASHWorkSource — concrete core::stratum::IWorkSource
@@ -558,6 +559,10 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         // hold the dashboard on the loading page forever. This seam exists in
         // core for exactly this caller (web_server.hpp:557).
         mi->set_dashboard_always_ready(true);
+        // Truthful /api/node_topology has_rpc: c2pool-dash reaches its daemon
+        // through the external dashd NodeRPC arm (armed above when creds
+        // resolved), not an ICoinNode, so tell the dashboard RPC is present.
+        mi->set_coin_rpc_available(static_cast<bool>(rpc));
 
         web_server->set_dashboard_dir(dashboard_dir);
         // Explicitly DISABLE the WebServer's own stratum acceptor. Its ctor
@@ -1119,7 +1124,42 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                         return {s.hashrate, s.effective_dt, s.total_datums,
                                 s.dead_datums};
                     });
-                std::cout << "[run] dashboard local-hashrate bound to the DASH "
+                // ── REAL per-worker registry into the dashboard ────────────
+                // The DASH stratum acceptor's StratumSessions register/update
+                // their per-connection hashrate + share/difficulty state into
+                // DASHWorkSource (NOT the dashboard's own MiningInterface,
+                // whose acceptor is disabled). Feed that live registry so
+                // /local_stats + /stratum_stats report the true per-miner
+                // hashrates, non-empty miner maps, and a correct connected-
+                // miner count (no false "pool is idle"). Display only.
+                mi->set_stratum_workers_fn(
+                    [wsrc = work_source.get()]()
+                        -> std::map<std::string, core::MiningInterface::WorkerInfo> {
+                        return wsrc->get_stratum_workers();
+                    });
+                // ── REAL block value + network difficulty into the dashboard ─
+                // c2pool-dash drives its own work pipeline, so WebServer's
+                // m_cached_template stays empty. Expose the last-sourced dashd
+                // GBT template so block_value / masternode payment split /
+                // attempts_to_block read the live values. Non-fetching peek;
+                // display only, never drives coinbase or consensus.
+                mi->set_coin_work_fn(
+                    [wsrc = work_source.get()]()
+                        -> core::MiningInterface::CoinWorkInfo {
+                        core::MiningInterface::CoinWorkInfo info;
+                        auto t = wsrc->peek_template();
+                        if (!t) return info;
+                        info.valid              = true;
+                        info.coinbase_value_sat = t->m_coinbase_value;
+                        info.payment_amount_sat = t->m_payment_amount;
+                        info.height             = t->m_height;
+                        if (t->m_bits != 0)
+                            info.network_difficulty = chain::target_to_difficulty(
+                                dash::coin::target_from_nbits(t->m_bits));
+                        return info;
+                    });
+                std::cout << "[run] dashboard local-hashrate + per-worker "
+                             "registry + block-value/net-diff bound to the DASH "
                              "stratum acceptor\n";
             }
         } else {

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -3314,7 +3314,7 @@ nlohmann::json MiningInterface::rest_uptime()
 nlohmann::json MiningInterface::rest_connected_miners()
 {
     // p2pool returns a simple array of unique miner addresses
-    auto workers = get_stratum_workers();
+    auto workers = effective_stratum_workers();
     std::set<std::string> unique_addrs;
     for (const auto& [sid, w] : workers) {
         // Strip worker suffix: "addr.worker" → "addr"
@@ -3334,7 +3334,7 @@ nlohmann::json MiningInterface::rest_stratum_stats()
     // p2pool format: { pool: {...}, workers: {...} }
     // stratum.html reads data.pool.* and data.workers.*
     nlohmann::json result = nlohmann::json::object();
-    auto workers = get_stratum_workers();
+    auto workers = effective_stratum_workers();
     auto now = std::time(nullptr);
     auto now_steady = std::chrono::steady_clock::now();
 
@@ -4408,7 +4408,7 @@ nlohmann::json MiningInterface::rest_local_stats()
     nlohmann::json miner_rates = nlohmann::json::object();
     nlohmann::json miner_dead  = nlohmann::json::object();
     {
-        auto workers = get_stratum_workers();
+        auto workers = effective_stratum_workers();
         for (const auto& [sid, w] : workers) {
             // Key by the FULL stratum username (ADDRESS.worker) so each D9/worker
             // gets its own bucket; fall back to the bare address when no worker
@@ -4454,6 +4454,16 @@ nlohmann::json MiningInterface::rest_local_stats()
 
     result["uptime"] = rest_uptime();
 
+    // Live coin-template summary for coin targets (c2pool-dash) that drive
+    // their own work pipeline and leave WebServer's m_cached_template empty.
+    // Display only; NEVER drives coinbase or consensus. Also refreshes the
+    // network-difficulty cache so /global_stats + attempts_to_block read the
+    // real value on the DASH path (where refresh_work() never runs).
+    CoinWorkInfo coin_work;
+    if (m_coin_work_fn) coin_work = m_coin_work_fn();
+    if (coin_work.valid && coin_work.network_difficulty > 0.0)
+        m_network_difficulty.store(coin_work.network_difficulty, std::memory_order_relaxed);
+
     // block_value in coins (not satoshis)
     double block_value = 0.0;
     double payment_amount = 0.0;
@@ -4465,6 +4475,11 @@ nlohmann::json MiningInterface::rest_local_stats()
             // These are deducted from miner payout before PPLNS distribution
             payment_amount = m_cached_template.value("payment_amount", uint64_t(0)) / 1e8;
         }
+    }
+    // Fall back to the coin target's live template when WebServer has none.
+    if (block_value == 0.0 && coin_work.valid) {
+        block_value    = static_cast<double>(coin_work.coinbase_value_sat) / 1e8;
+        payment_amount = static_cast<double>(coin_work.payment_amount_sat) / 1e8;
     }
     result["block_value"] = block_value;
     // Miner portion: subsidy minus protocol payments (masternode/superblock) minus node fee
@@ -4558,7 +4573,7 @@ nlohmann::json MiningInterface::rest_local_stats()
         }
 
         // 5. No miners connected
-        if (get_stratum_workers().empty() && !m_solo_mode)
+        if (effective_stratum_workers().empty() && !m_solo_mode)
             warnings.push_back("No miners connected — pool is idle");
 
         // 6. Version signaling: majority voting for unsupported version
@@ -4605,7 +4620,7 @@ nlohmann::json MiningInterface::rest_local_stats()
     // p2pool-compat: my_hash_rates_in_last_hour — aggregate from all local workers
     double total_hr = 0, total_dead = 0;
     {
-        auto workers = get_stratum_workers();
+        auto workers = effective_stratum_workers();
         for (const auto& [sid, w] : workers) {
             total_hr += w.hashrate;
             total_dead += w.dead_hashrate;
@@ -4644,7 +4659,7 @@ nlohmann::json MiningInterface::rest_local_stats()
     // p2pool-compat: miner_last_difficulties — from stratum workers
     nlohmann::json miner_diffs = nlohmann::json::object();
     {
-        auto workers = get_stratum_workers();
+        auto workers = effective_stratum_workers();
         for (const auto& [sid, w] : workers) {
             std::string key = w.username;
             miner_diffs[key] = w.difficulty;
@@ -4811,9 +4826,12 @@ nlohmann::json MiningInterface::rest_web_currency_info()
     if (m_explorer_enabled && !m_explorer_url.empty())
         result["explorer_url"] = m_explorer_url;
 
-    // Mode indicators for conditional UI
+    // Mode indicators for conditional UI. Coin targets whose daemon RPC is an
+    // external NodeRPC arm (c2pool-dash dashd) rather than an ICoinNode set the
+    // m_coin_rpc_available flag so has_rpc is truthful.
     result["embedded"] = (m_coin_node && m_coin_node->is_embedded());
-    result["has_rpc"]  = (m_coin_node && m_coin_node->has_rpc());
+    result["has_rpc"]  = (m_coin_node && m_coin_node->has_rpc())
+                         || m_coin_rpc_available.load(std::memory_order_relaxed);
 
     // p2pool share version for the current coin — consumed by the
     // bundled @c2pool/sharechain-explorer to classify share cells.
@@ -5291,6 +5309,12 @@ nlohmann::json MiningInterface::rest_node_topology()
         if (!m_cached_template.is_null() && m_cached_template.contains("height"))
             primary_height = m_cached_template["height"].get<uint64_t>();
     }
+    // Coin targets (c2pool-dash) leave m_cached_template empty; use the live
+    // template summary's height instead.
+    if (primary_height == 0 && m_coin_work_fn) {
+        auto cw = m_coin_work_fn();
+        if (cw.valid) primary_height = cw.height;
+    }
 
     nlohmann::json coins = nlohmann::json::array();
     auto has_coin = [&](const std::string& sym) {
@@ -5305,9 +5329,11 @@ nlohmann::json MiningInterface::rest_node_topology()
         entry["primary"] = is_primary;
         entry["peers"]   = peers;
         if (is_primary) {
-            // Real embedded/RPC flags for this node's own daemon.
+            // Real embedded/RPC flags for this node's own daemon. Coin targets
+            // with an external NodeRPC arm (c2pool-dash) set m_coin_rpc_available.
             entry["embedded"] = (m_coin_node && m_coin_node->is_embedded());
-            entry["has_rpc"]  = (m_coin_node && m_coin_node->has_rpc());
+            entry["has_rpc"]  = (m_coin_node && m_coin_node->has_rpc())
+                                || m_coin_rpc_available.load(std::memory_order_relaxed);
             // Truthful tip from the embedded daemon's cached template (front-end
             // renders it only when > 0, so omit a meaningless 0).
             if (primary_height > 0)
@@ -5460,7 +5486,7 @@ nlohmann::json MiningInterface::rest_miner_stats(const std::string& address)
     uint64_t accepted = 0, rejected = 0, stale = 0;
     bool found = false;
     {
-        auto workers = get_stratum_workers();
+        auto workers = effective_stratum_workers();
         for (const auto& [sid, w] : workers) {
             // Match base address (strip worker suffix)
             std::string base = w.username;
@@ -7012,6 +7038,20 @@ std::map<std::string, MiningInterface::WorkerInfo> MiningInterface::get_stratum_
     return m_stratum_workers;
 }
 
+std::map<std::string, MiningInterface::WorkerInfo> MiningInterface::effective_stratum_workers() const
+{
+    {
+        std::lock_guard<std::mutex> lock(m_stratum_workers_mutex);
+        if (!m_stratum_workers.empty())
+            return m_stratum_workers;   // LTC path: dashboard-owned acceptor
+    }
+    // Coin targets (c2pool-dash) run their stratum acceptor against a separate
+    // IWorkSource; its per-connection registry is the ground truth.
+    if (m_stratum_workers_fn)
+        return m_stratum_workers_fn();
+    return {};
+}
+
 // ──────────── /web/ sub-endpoints (share chain inspection) ───────────────
 
 nlohmann::json MiningInterface::rest_web_heads()
@@ -7300,7 +7340,7 @@ void MiningInterface::update_stat_log()
     entry.local_hash_rates = nlohmann::json::object();
     entry.local_dead_hash_rates = nlohmann::json::object();
     {
-        auto workers = get_stratum_workers();
+        auto workers = effective_stratum_workers();
         entry.connected_count = static_cast<int>(workers.size());  // raw TCP connections
         std::set<std::string> worker_combos;
         for (const auto& [sid, w] : workers) {

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -577,6 +577,40 @@ public:
     void set_stratum_rate_stats_fn(std::function<RateStats()> fn) { m_stratum_rate_stats_fn = thread_safe_wrap(std::move(fn)); }
     RateStats get_stratum_rate_stats() const { return m_stratum_rate_stats_fn ? m_stratum_rate_stats_fn() : RateStats{}; }
 
+    // Per-worker stratum registry provider (display only). On the LTC path the
+    // dashboard's OWN core::StratumServer registers workers straight into
+    // m_stratum_workers (register_stratum_worker). Coin targets that run their
+    // own stratum acceptor bound to a separate IWorkSource (c2pool-dash ->
+    // DASHWorkSource) leave m_stratum_workers empty; they wire THIS provider so
+    // /local_stats + /stratum_stats read the live per-connection registry from
+    // that acceptor. effective_stratum_workers() prefers the local registry and
+    // falls back to this provider, so LTC behavior is byte-unchanged.
+    void set_stratum_workers_fn(std::function<std::map<std::string, core::stratum::WorkerInfo>()> fn) {
+        m_stratum_workers_fn = thread_safe_wrap(std::move(fn));
+    }
+
+    // Live coin-template summary provider (display only; NEVER drives coinbase
+    // or consensus). Coin targets that drive their own work pipeline
+    // (c2pool-dash -> DASHWorkSource) leave WebServer's internal
+    // refresh_work()/m_cached_template unpopulated, so block_value / masternode
+    // payment split / network difficulty read 0 on /local_stats. They wire this
+    // to expose the last-sourced template's coinbase value, payment split,
+    // height and network difficulty. Unset on the LTC path (m_cached_template
+    // is populated there), so LTC behavior is byte-unchanged.
+    struct CoinWorkInfo {
+        bool     valid = false;
+        double   network_difficulty = 0.0;   // from template nbits
+        uint64_t coinbase_value_sat = 0;      // "coinbasevalue"
+        uint64_t payment_amount_sat = 0;      // masternode+treasury share
+        uint64_t height = 0;                  // template height
+    };
+    void set_coin_work_fn(std::function<CoinWorkInfo()> fn) { m_coin_work_fn = thread_safe_wrap(std::move(fn)); }
+
+    // Truthful RPC availability for coin targets whose daemon RPC is not
+    // exposed through m_coin_node (c2pool-dash uses an external dashd NodeRPC
+    // arm, not an ICoinNode). OR'd into the /api/node_topology has_rpc flag.
+    void set_coin_rpc_available(bool v) { m_coin_rpc_available.store(v, std::memory_order_relaxed); }
+
     // Current PPLNS outputs for payout display
     // Coin targets (c2pool-dash) that compute PPLNS outside the
     // refresh_work() path can push the current distribution here so
@@ -1473,8 +1507,16 @@ public:
     std::map<std::string, WorkerInfo> get_stratum_workers() const;
 
 private:
+    // Effective per-worker registry for the stats/display path: the locally
+    // registered workers (LTC dashboard-owned acceptor) when present, else the
+    // external provider (coin-target acceptor bound to its own IWorkSource).
+    std::map<std::string, WorkerInfo> effective_stratum_workers() const;
+
     std::map<std::string, WorkerInfo> m_stratum_workers;
     mutable std::mutex m_stratum_workers_mutex;
+    std::function<std::map<std::string, WorkerInfo>()> m_stratum_workers_fn;  // external provider (coin targets)
+    std::function<CoinWorkInfo()> m_coin_work_fn;                             // live template summary (coin targets)
+    std::atomic<bool> m_coin_rpc_available{false};                           // external daemon RPC present
     std::chrono::steady_clock::time_point m_stratum_start_time{std::chrono::steady_clock::now()};
 };
 

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -249,6 +249,19 @@ void DASHWorkSource::update_stratum_worker(const std::string& session_id,
     it->second.stale         = stale;
 }
 
+std::map<std::string, core::stratum::WorkerInfo>
+DASHWorkSource::get_stratum_workers() const
+{
+    std::lock_guard<std::mutex> lk(workers_mutex_);
+    return workers_;   // copy under lock -- dashboard stats seam
+}
+
+std::shared_ptr<const coin::DashWorkData> DASHWorkSource::peek_template() const
+{
+    std::lock_guard<std::mutex> lk(template_mutex_);
+    return template_cache_;   // last-sourced snapshot; no refresh triggered
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // IWorkSource: work generation -- Stage 4c (the template trio).
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -200,6 +200,16 @@ public:
                                double hashrate, double dead_hashrate, double difficulty,
                                uint64_t accepted, uint64_t rejected, uint64_t stale) override;
 
+    /// Thread-safe snapshot of the per-connection worker registry
+    /// (session_id -> WorkerInfo). The DASH stratum acceptor is a standalone
+    /// core::StratumServer bound to THIS work source (main_dash.cpp), so its
+    /// StratumSessions register/update HERE -- not into the dashboard
+    /// WebServer's own MiningInterface registry (that acceptor is disabled).
+    /// main_dash.cpp feeds this snapshot to
+    /// MiningInterface::set_stratum_workers_fn so /local_stats reports the
+    /// real per-worker hashrates + share/difficulty state (display only).
+    std::map<std::string, core::stratum::WorkerInfo> get_stratum_workers() const;
+
     // ── IWorkSource: work generation ─────────────────────────────────────
     nlohmann::json                      get_current_work_template() const override;
     std::vector<std::string>            get_stratum_merkle_branches() const override;
@@ -276,6 +286,15 @@ public:
     /// further job may be served from it. The generation bump makes every
     /// stratum session re-pull a FRESH template on its next heartbeat.
     void invalidate_template_cache(const char* reason = "reconnect");
+
+    /// Non-fetching read of the last DashWorkData sourced through the
+    /// embedded/dashd selector. Returns the cached snapshot (or nullptr when
+    /// none has been sourced yet) WITHOUT triggering a refresh -- safe to call
+    /// from the dashboard HTTP thread. main_dash.cpp feeds it to
+    /// MiningInterface::set_coin_work_fn so /local_stats can report the real
+    /// block_value / masternode payment split / network difficulty from the
+    /// live template (display only; never drives coinbase or consensus).
+    std::shared_ptr<const coin::DashWorkData> peek_template() const;
 
 private:
     /// Template cache resolve: return the cached DashWorkData snapshot when it

--- a/test/test_dash_stratum_work_source.cpp
+++ b/test/test_dash_stratum_work_source.cpp
@@ -26,6 +26,7 @@
 #include <core/stratum_work_source.hpp>
 #include <core/target_utils.hpp>
 #include <core/uint256.hpp>
+#include <core/web_server.hpp>                // core::MiningInterface (dashboard stats seam)
 
 #include <btclibs/util/strencodings.h>        // ParseHex, HexStr
 
@@ -864,6 +865,88 @@ TEST(DashStratumWorkSource, WonBlockAcrossTipMoveStillSubmits)
     ASSERT_TRUE(result.is_boolean());
     EXPECT_TRUE(result.get<bool>());
     EXPECT_TRUE(rig.fx.submit_called);        // orphan race: still dispatched
+}
+
+// ── Dashboard stats seam (issue: /local_stats hashrate under-reported) ───────
+//
+// The DASH stratum acceptor is a standalone core::StratumServer bound to a
+// DASHWorkSource; its StratumSessions register/update per-connection hashrate +
+// share/difficulty state into the work source's OWN registry, NOT into the
+// dashboard WebServer's MiningInterface (whose acceptor is disabled). Before the
+// fix, MiningInterface::rest_local_stats read only its own empty registry, so a
+// busy pool reported miner_hash_rates {} / my_hash_rates_in_last_hour.actual 0
+// and a false "No miners connected — pool is idle" warning. main_dash wires
+// set_stratum_workers_fn -> DASHWorkSource::get_stratum_workers to close the
+// gap. This KAT pins that end-to-end: N workers of known hashrate -> summed
+// aggregate, non-empty per-worker maps, no idle warning.
+
+TEST(DashDashboardWiring, LocalStatsSumsStratumWorkerHashrate)
+{
+    Fixture fx(true);
+    auto ws = fx.make();
+
+    struct W { std::string sid, user, worker; double hr, dead, diff; uint64_t acc; };
+    // 3 X11 rigs across 2 payout addresses; hashrates in the field's TH/s range.
+    const std::vector<W> rigs = {
+        {"sess-1", "Xpayout1", "rig0", 1.20e13, 0.0,    4096.0, 100},
+        {"sess-2", "Xpayout1", "rig1", 8.00e12, 0.0,    2048.0,  80},
+        {"sess-3", "Xpayout2", "rig0", 2.50e13, 1.0e12, 8192.0, 200},
+    };
+    double expected_total = 0.0, expected_dead = 0.0;
+    for (const auto& r : rigs) {
+        core::stratum::WorkerInfo wi;
+        wi.username    = r.user;
+        wi.worker_name = r.worker;
+        wi.difficulty  = r.diff;
+        ws->register_stratum_worker(r.sid, wi);
+        ws->update_stratum_worker(r.sid, r.hr, r.dead, r.diff, r.acc, 0, 0);
+        expected_total += r.hr;
+        expected_dead  += r.dead;
+    }
+    ASSERT_EQ(ws->get_stratum_workers().size(), rigs.size());
+
+    // Wire the live registry into a DASH dashboard exactly as main_dash.cpp does.
+    core::MiningInterface mi(false, nullptr, c2pool::address::Blockchain::DASH);
+    mi.set_stratum_workers_fn([wsrc = ws.get()]() {
+        return wsrc->get_stratum_workers();
+    });
+
+    auto stats = mi.rest_local_stats();
+
+    // Aggregate hashrate == SUM of connected workers (was 0 before the fix).
+    ASSERT_TRUE(stats.contains("my_hash_rates_in_last_hour"));
+    const auto& hr = stats["my_hash_rates_in_last_hour"];
+    EXPECT_NEAR(hr["actual"].get<double>(),   expected_total,                 1.0);
+    EXPECT_NEAR(hr["nonstale"].get<double>(), expected_total - expected_dead, 1.0);
+    EXPECT_NEAR(hr["rewarded"].get<double>(), expected_total - expected_dead, 1.0);
+
+    // Per-worker maps are non-empty and keyed per "address.worker".
+    ASSERT_TRUE(stats.contains("miner_hash_rates"));
+    EXPECT_EQ(stats["miner_hash_rates"].size(), rigs.size());
+    EXPECT_FALSE(stats["miner_dead_hash_rates"].empty());
+    EXPECT_FALSE(stats["miner_last_difficulties"].empty());
+    EXPECT_NEAR(stats["miner_hash_rates"]["Xpayout1.rig0"].get<double>(), 1.20e13, 1.0);
+
+    // No false "pool is idle" warning while miners ARE connected.
+    ASSERT_TRUE(stats.contains("warnings"));
+    for (const auto& w : stats["warnings"])
+        EXPECT_EQ(w.get<std::string>().find("pool is idle"), std::string::npos);
+}
+
+TEST(DashDashboardWiring, LocalStatsIdleWarningWhenNoWorkers)
+{
+    // No provider wired and an empty local registry -> the honest idle warning
+    // fires and the per-worker map stays empty (the pre-fix state was correct
+    // ONLY when the pool truly had no miners).
+    core::MiningInterface mi(false, nullptr, c2pool::address::Blockchain::DASH);
+    auto stats = mi.rest_local_stats();
+
+    EXPECT_TRUE(stats["miner_hash_rates"].empty());
+    EXPECT_DOUBLE_EQ(stats["my_hash_rates_in_last_hour"]["actual"].get<double>(), 0.0);
+    bool idle = false;
+    for (const auto& w : stats["warnings"])
+        if (w.get<std::string>().find("pool is idle") != std::string::npos) idle = true;
+    EXPECT_TRUE(idle);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

The DASH dashboard under-reported local hashrate (~7-9x low), showed empty
per-worker tables, warned **"No miners connected — pool is idle"** on a busy
pool, and zeroed block-value / attempts-to-block / `has_rpc`. This is a
LTC→DASH dashboard-port wiring gap (introduced when the WebServer /
`/local_stats` generator was reused into `main_dash` while c2pool-dash runs its
own stratum/work pipeline) — **not** a hashrate problem. Fix is display/stats
path only.

## Root cause (file:line)

- The dashboard `WebServer`'s own stratum acceptor is deliberately disabled on
  the DASH path — `web_server->set_stratum_port(0)` at
  `src/c2pool/main_dash.cpp:572` — because c2pool-dash binds its **own**
  `core::StratumServer` to a separate `DASHWorkSource`
  (`src/c2pool/main_dash.cpp:1096`).
- The generic `StratumSession` registers/updates per-connection hashrate +
  share/difficulty into whatever work source it was constructed with:
  `register_stratum_worker` at `src/core/stratum_server.cpp:748`,
  `update_stratum_worker` at `src/core/stratum_server.cpp:1241`. On the DASH
  path that is `DASHWorkSource` (`src/impl/dash/stratum/work_source.cpp:210/235`,
  stored in `workers_`), **not** `MiningInterface::m_stratum_workers`.
- But `MiningInterface::rest_local_stats` reads only its own registry via
  `get_stratum_workers()` — `src/core/web_server.cpp:4411` (miner_hash_rates),
  `:4608` (my_hash_rates_in_last_hour), `:4647` (miner_last_difficulties),
  `:4561` (idle warning). That registry is permanently empty on DASH →
  every per-worker field is `{}` and `my_hash_rates_in_last_hour.actual == 0`.
- `block_value*` reads `m_cached_template` (`:4462`), which never populates on
  DASH (`refresh_work()` is bypassed by `set_dashboard_always_ready(true)`,
  `main_dash.cpp:560`). `attempts_to_block` / network hashrate read
  `m_network_difficulty` (`:4591`), only written by `refresh_work` (disabled).
  `/api/node_topology` `has_rpc` reads `m_coin_node->has_rpc()`
  (`src/core/web_server.cpp:4831/5328`), but DASH reaches dashd through an
  external `NodeRPC` arm, not an `ICoinNode`, so `m_coin_node` is null → false.

The dashboard's local-hashrate widget is literally
`d3.sum(values(local_stats.miner_hash_rates))` (`web-static/dashboard.html:3047`)
— empty map → 0/partial. `#pool_rate` is the separate sharechain estimator
`global_stats.pool_hash_rate` (the ~5.77 TH/s number), which is a different
metric and was already wired.

## Fix (reuse the existing callback-wiring pattern; LTC path byte-unchanged)

- `DASHWorkSource::get_stratum_workers()` — thread-safe snapshot of the live
  registry. `MiningInterface::set_stratum_workers_fn` + a new
  `effective_stratum_workers()` helper prefer the local registry and fall back
  to this provider, so LTC (dashboard-owned acceptor) is unchanged. Feeds
  `miner_hash_rates`, `miner_dead_hash_rates`, `miner_last_difficulties`,
  `my_hash_rates_in_last_hour`, the connected-miner count / idle warning, the
  workers table (`/stratum_stats`, `/connected_miners`) and the local-hashrate
  graph snapshot.
- `DASHWorkSource::peek_template()` — non-fetching read of the last dashd GBT
  template. `MiningInterface::set_coin_work_fn` (`CoinWorkInfo`) exposes
  coinbase value, masternode/treasury payment split, height and network
  difficulty (from nbits) → `block_value` / `block_value_miner` /
  `block_value_payments`, `attempts_to_block`, network hashrate, topology height.
- `set_coin_rpc_available(bool)` — OR'd into `/api/node_topology has_rpc` so a
  node reaching dashd via the external NodeRPC arm reports RPC true.
- Wired in `main_dash.cpp` alongside the existing `set_stratum_hashrate_fn` /
  `set_pool_hashrate_fn` callbacks.

## Field inventory (DASH `/local_stats` + endpoints, before → after)

| Field | Before | After | Source |
|---|---|---|---|
| `miner_hash_rates` | EMPTY-MAP | LIVE | DASHWorkSource registry |
| `miner_dead_hash_rates` | EMPTY-MAP | LIVE | DASHWorkSource registry |
| `miner_last_difficulties` | EMPTY-MAP | LIVE | DASHWorkSource registry |
| `my_hash_rates_in_last_hour.{actual,nonstale,rewarded}` | STUBBED-ZERO | LIVE | DASHWorkSource registry (true ~40.9 TH/s) |
| `warnings` idle | WRONG | LIVE | real connected-worker count |
| `attempts_to_block` | STUBBED-ZERO | LIVE | template nbits → net-diff |
| network hashrate (`/global_stats`) | STUBBED-ZERO | LIVE | template nbits → net-diff |
| `block_value` | STUBBED-ZERO | LIVE | template coinbasevalue |
| `block_value_miner` | STUBBED-ZERO | LIVE | subsidy − payments − fee |
| `block_value_payments` | STUBBED-ZERO | LIVE | template masternode/treasury |
| `/api/node_topology has_rpc` | WRONG (false) | LIVE (true when armed) | external NodeRPC arm |
| `/api/node_topology height` | omitted | LIVE | template height |
| `node_fee_dash` | 0 (local_hr=0) | LIVE | now computes (local_hr non-zero) |
| `attempts_to_merged_block` | 0 | CORRECT (0) | DASH is standalone X11, no merged mining |
| `fee` / `donation_proportion` | config | CONFIRMED config-driven | `m_pool_fee_percent` via `set_node_fee`; 0 is correct for a no-fee/solo node |
| `efficiency` / `efficiency_if_miner_perfect` / stale proportions | LIVE | CONFIRMED LIVE | sharechain stats fn (already wired) |
| `shares.total` / `my_share_counts_in_last_hour` | LIVE | CONFIRMED LIVE | sharechain (minted) share count — p2pool semantic |
| `pool_hash_rate` / `pool_nonstale_hash_rate` | LIVE | unchanged | sharechain PPLNS-window estimator |

**Note on the 663-vs-~6200 observation:** `/local_stats` `shares` count is the
p2pool-semantic **sharechain** (minted) share count, at share difficulty — not
the raw stratum pseudoshare count. The tenant-facing local hashrate is
`my_hash_rates_in_last_hour` / `sum(miner_hash_rates)`, which this PR sources
from the stratum HashrateTracker H_est (`ΣvardiffH_est`) and now equals the true
~40.9 TH/s. `pool_hash_rate` (the ~5.77 number) is a separate sharechain-window
estimator and is intentionally a different metric.

## Consensus-neutrality

`git diff origin/master | grep -iE 'get_share_bits|share_bits|share_target|DGW|oracle|payout|pplns'`
→ matches are comments and test-fixture identifiers only (e.g. include comments,
"payout display", test addresses `Xpayout1/2`). No `get_share_bits()`,
share-target, DGW, oracle, block-acceptance, or PPLNS payout **logic** is
touched. Stats/display path only.

## Tests / verification

- New KATs in `test_dash_stratum_work_source` (already on the build.yml
  `--target` allowlist in both legs — **no build.yml edit needed**):
  - `DashDashboardWiring.LocalStatsSumsStratumWorkerHashrate` — 3 workers of
    known hashrate → `my_hash_rates_in_last_hour.actual == Σhashrate`, 3
    non-empty `miner_hash_rates` keys, non-empty dead/difficulty maps, no idle
    warning.
  - `DashDashboardWiring.LocalStatsIdleWarningWhenNoWorkers` — empty registry →
    idle warning present, empty maps, actual == 0.
  - `test_dash_stratum_work_source`: **32/32 pass** (30 pre-existing + 2 new).
- `c2pool-dash` builds clean (conan + cmake, gcc-13, Release).
- Live boot smoke (`--run --web-port ... --stratum ...`):
  - Wiring log line fires: *"dashboard local-hashrate + per-worker registry +
    block-value/net-diff bound to the DASH stratum acceptor"*.
  - No miners / no RPC → honest empty maps + idle warning + `has_rpc:false`
    (proves real-state reads, not hardcoded).
  - With dashd creds armed (`--coin-rpc --coin-rpc-auth`): `/api/node_topology`
    `has_rpc: true`.

Draft — two-party review before merge. Not deployed; no release tarball built.
