### PR TITLE
dash(stratum): dashd ZMQ hashblock INSTANT tip-notify on the fallback arm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,35 @@ find_package(Boost QUIET OPTIONAL_COMPONENTS system)
 find_package(nlohmann_json REQUIRED)
 find_package(yaml-cpp REQUIRED)  # hoisted to root so yaml-cpp::yaml-cpp is visible to src/c2pool OBJECT libs (sibling of src/core)
 
+# Optional dashd ZMQ `hashblock` INSTANT tip-notify (DASH fallback-arm hardening
+# on top of the #770 3 s poll). libzmq is an OPTIONAL dependency: when present
+# the c2pool-dash --coin-zmq-hashblock path is compiled (C2POOL_ZMQ define);
+# when absent c2pool-dash builds + runs exactly as the poll-only path. The conan
+# recipe (zeromq/4.3.5) exposes the CMake target `libzmq` via package `ZeroMQ`.
+option(C2POOL_WITH_ZMQ "Build dashd ZMQ hashblock instant tip-notify (optional; needs libzmq)" ON)
+set(C2POOL_ZMQ_AVAILABLE OFF)
+set(C2POOL_ZMQ_TARGET "")
+if(C2POOL_WITH_ZMQ)
+    find_package(ZeroMQ QUIET)
+    if(TARGET libzmq)
+        set(C2POOL_ZMQ_AVAILABLE ON)
+        set(C2POOL_ZMQ_TARGET libzmq)
+    elseif(TARGET libzmq-static)
+        set(C2POOL_ZMQ_AVAILABLE ON)
+        set(C2POOL_ZMQ_TARGET libzmq-static)
+    elseif(TARGET zmq)
+        set(C2POOL_ZMQ_AVAILABLE ON)
+        set(C2POOL_ZMQ_TARGET zmq)
+    endif()
+    if(C2POOL_ZMQ_AVAILABLE)
+        message(STATUS "dashd ZMQ hashblock tip-notify: ENABLED (libzmq via ${C2POOL_ZMQ_TARGET})")
+    else()
+        message(STATUS "dashd ZMQ hashblock tip-notify: DISABLED (libzmq not found; c2pool-dash builds poll-only)")
+    endif()
+else()
+    message(STATUS "dashd ZMQ hashblock tip-notify: DISABLED (C2POOL_WITH_ZMQ=OFF)")
+endif()
+
 # Threading (needed by LevelDB on some platforms)
 find_package(Threads REQUIRED)
 

--- a/conan.lock
+++ b/conan.lock
@@ -2,6 +2,7 @@
     "version": "0.5",
     "requires": [
         "zlib/1.3.2#1cb806da49011867778ffb6ac7190fcb%1777558780.503",
+        "zeromq/4.3.5",
         "yaml-cpp/0.8.0#1aa371213f0307605d88ad5445581aff%1773246038.815",
         "snappy/1.1.10#9cff2aa2cf616aa98532b1872ef44dcf%1743607712.928",
         "nlohmann_json/3.12.0#2d634ab0ec8d9f56353e5ccef6d6612c%1744735883.94",

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -4,10 +4,14 @@ nlohmann_json/3.12.0
 yaml-cpp/0.8.0
 gtest/1.14.0
 leveldb/1.23
+zeromq/4.3.5
 
 [options]
 boost/*:without_exception=False
 boost/*:without_cobalt=True
+# dashd `hashblock` is a plain unauthenticated SUB socket: no CURVE/encryption
+# needed, so drop the libsodium transitive dep and keep the build lean.
+zeromq/*:encryption=False
 
 [generators]
 CMakeDeps

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -56,6 +56,7 @@
 #include <impl/dash/coin/node_interface.hpp>
 #include <impl/dash/coin/p2p_client.hpp>   // dash::coin::p2p::CoinClient — OPT-IN coin-network dial (E1, --coin-p2p-connect)
 #include <impl/dash/coin/won_block_dispatch.hpp> // dash::coin::broadcast_won_block — S8 dual-path won-block dispatcher (embedded P2P primary + submitblock RPC backup)
+#include <impl/dash/coin/zmq_tip_notify.hpp> // dash::coin::TipHashDedup / ZmqHashblockSubscriber — dashd ZMQ hashblock INSTANT tip-notify (opt-in, hardening on the #770 poll)
 #include <impl/dash/coin/node_coin_state.hpp>  // dash::coin::NodeCoinState (embedded work bundle)
 #include <impl/dash/coin/dkg_window.hpp>       // dash::coin::is_dkg_commitment_window (BLOCKER-1 guard)
 #include <impl/dash/coin/utxo_lane.hpp>    // dash::coin::UtxoLane — embedded UTXO/fee lane (E2b, #738)
@@ -198,6 +199,7 @@ void print_banner(const char* argv0)
         << "           [--embedded-utxo]\n"
         << "           [--give-author PCT] [-f|--fee PCT] [--node-owner-address ADDR]\n"
         << "           [--redistribute pplns|fee|boost|donate]\n"
+        << "           [--coin-zmq-hashblock tcp://HOST:PORT]\n"
         << "       " << argv0 << " --mine-block [--coin-rpc H:P] [--coin-rpc-auth PATH]\n"
         << "           [--testnet] [--payout-pubkey-hash HEX] [--max-nonce N]\n\n"
         << "Status: consensus layer live (X11 PoW, subsidy, oracle CoinParams).\n"
@@ -212,6 +214,11 @@ void print_banner(const char* argv0)
         << "        --coin-p2p-connect HOST:PORT (repeatable) OPT-IN dials the DASH\n"
         << "        coin network directly (version/verack + keep-alive + reconnect);\n"
         << "        absent => no coin P2P client, dashd-RPC fallback path unchanged.\n"
+        << "        --coin-zmq-hashblock tcp://HOST:PORT (opt-in) subscribes to dashd's\n"
+        << "        ZMQ `hashblock` topic for INSTANT (~0 s) new-tip template refresh +\n"
+        << "        clean_jobs notify on the fallback arm; absent/unreachable => the 3 s\n"
+        << "        getbestblockhash poll is the active path (requires dashd\n"
+        << "        zmqpubhashblock=tcp://HOST:PORT). No consensus effect.\n"
         << "        --web-port PORT (alias --http-port, default 8080) serves the FULL\n"
         << "        c2pool web dashboard + JSON API on --web-host (default 0.0.0.0)\n"
         << "        from --dashboard-dir (default web-static); --web-port 0 disables.\n"
@@ -384,7 +391,8 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              const std::string& node_owner_address,
              const std::string& redistribute_mode,
              bool no_p2p_relay,
-             bool embedded_mainnet)
+             bool embedded_mainnet,
+             const std::string& coin_zmq_hashblock)
 {
     namespace io = boost::asio;
 
@@ -1708,14 +1716,19 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // kStaleAfter) — there is NO tip-change signal like the embedded arm's
     // header_chain->set_on_tip_changed callback. DASH blocks arrive ~every
     // 150 s, so up to ~30 s of stale-tip mining can occur per block (accepted
-    // pseudoshares that can no longer win the current block). Poll dashd for
-    // its best-block hash every 3 s; on a change, drop the cached template +
-    // bump work-generation + notify every session (clean_jobs) — the SAME
-    // refresh pair the embedded arm fires. Gated on the fallback arm (coin_p2p
-    // null) AND an armed rpc AND a live stratum acceptor. getbestblockhash is a
-    // trivial RPC; failures are swallowed so a daemon hiccup never crashes the
-    // run-loop (retry next tick). Reuses the existing NodeRPC client — no new
-    // dependency, no dashd config change, no new notify mechanism.
+    // pseudoshares that can no longer win the current block).
+    //
+    // TWO tip-notify paths, sharing ONE last-seen-tip dedup so a poll+ZMQ
+    // double-fire on the same block coalesces to a single refresh:
+    //   • BACKSTOP (always, #770): a 3 s getbestblockhash poll. When ZMQ is
+    //     unconfigured/unreachable this is the sole active path.
+    //   • PRIMARY (opt-in, --coin-zmq-hashblock): a dashd ZMQ `hashblock` SUB
+    //     subscriber fires the INSTANT (~0 s) the daemon connects a new block.
+    // On a genuine tip CHANGE either path drops the cached template + bumps
+    // work-generation + notifies every session (clean_jobs) — the SAME refresh
+    // pair the embedded arm fires. Gated on the fallback arm (coin_p2p null) AND
+    // an armed rpc AND a live stratum acceptor. getbestblockhash is a trivial
+    // RPC; failures are swallowed so a daemon hiccup never crashes the run-loop.
     // io-thread-decouple: dedicated single-thread pool for the fallback arm's
     // BLOCKING dashd RPC (getbestblockhash tip probe + the background template
     // re-source). Mirrors main_ltc.cpp hdr_pool ("keeps scrypt off io_context"):
@@ -1726,6 +1739,12 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // loop -- and its destructor -- happen BEFORE those objects unwind: no
     // background probe is ever mid-flight against freed state. Only created on
     // the fallback arm; null on the embedded arm (legacy inline path unchanged).
+    // The opt-in ZMQ subscriber (declared here for the same teardown ordering)
+    // only posts onto ioc; when unconfigured/uncompiled the poll is the whole
+    // mechanism -- byte-identical to the poll-only #770/#781 behavior.
+#ifdef C2POOL_ZMQ
+    std::unique_ptr<dash::coin::ZmqHashblockSubscriber> zmq_sub;
+#endif
     std::shared_ptr<boost::asio::thread_pool> rpc_pool;
     if (!coin_p2p && rpc && stratum_server) {
         rpc_pool = std::make_shared<boost::asio::thread_pool>(1);
@@ -1740,25 +1759,49 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 boost::asio::post(*rpc_pool, std::move(job));
             });
 
+        // Shared last-seen-tip dedup — the poll AND the ZMQ subscriber consult
+        // it, so if both observe the same new block only the first fires the
+        // refresh trio (the second is_new_tip() returns false → no-op).
+        auto tip_dedup = std::make_shared<dash::coin::TipHashDedup>();
+
+        // The refresh trio, shared by both paths. Runs on the io_context thread
+        // ONLY (the poll follow-up is posted back to ioc; the ZMQ callback posts
+        // onto ioc), so ws/ss/dedup are never touched concurrently. `verb`
+        // differentiates the instant (ZMQ) vs polled log line.
+        std::function<void(const std::string&, const char*, const char*)>
+            fire_refresh = [ws = work_source.get(), ss = stratum_server.get(),
+                            tip_dedup](const std::string& tip,
+                                       const char* source, const char* verb) {
+                if (!tip_dedup->is_new_tip(tip))
+                    return;   // dedup: coalesce a poll+ZMQ double-fire on one tip
+                ws->invalidate_template_cache(
+                    "tip-notify: dashd best-block changed");
+                ws->bump_work_generation();
+                ss->notify_all();
+                LOG_INFO << "[Stratum] " << source << ": " << tip.substr(0, 16)
+                         << " -> " << verb;
+                std::cout << "[Stratum] " << source << ": " << tip.substr(0, 16)
+                          << " -> " << verb << "\n";
+            };
+
+        // BACKSTOP: 3 s getbestblockhash poll (#770), io-decoupled (#781).
         auto tip_timer = std::make_shared<io::steady_timer>(ioc);
-        auto last_tip = std::make_shared<std::string>();
         auto tip_tick = std::make_shared<
             std::function<void(const boost::system::error_code&)>>();
         // tip_tick runs ON ioc when the 3 s timer fires. It does NOT call the
         // blocking RPC itself: it hands getbestblockhash to rpc_pool and posts
-        // the tip-change follow-up (invalidate + bump + notify) + the timer
-        // re-arm BACK onto ioc (ws/ss/tip_timer are io-thread-confined), exactly
-        // like main_ltc.cpp's post-to-pool -> post-back-to-ioc pattern. The
-        // timer is re-armed only AFTER the RPC completes, so a slow dashd cannot
-        // pile up overlapping polls. Lost-block-prevention is preserved: a real
-        // tip change still fires invalidate + notify -- only WHERE the probe runs
-        // has moved off the stratum io thread.
-        *tip_tick = [rpc = rpc.get(), ws = work_source.get(),
-                     ss = stratum_server.get(), tip_timer, last_tip, tip_tick,
-                     rpc_pool, &ioc](const boost::system::error_code& ec) {
+        // the tip-change follow-up + the timer re-arm BACK onto ioc (fire_refresh
+        // / tip_timer are io-thread-confined), exactly like main_ltc.cpp's
+        // post-to-pool -> post-back-to-ioc pattern. The timer is re-armed only
+        // AFTER the RPC completes, so a slow dashd cannot pile up overlapping
+        // polls. Lost-block-prevention is preserved: a real tip change still
+        // fires the refresh trio -- only WHERE the probe runs has moved off the
+        // stratum io thread.
+        *tip_tick = [rpc = rpc.get(), tip_dedup, fire_refresh, tip_timer,
+                     tip_tick, rpc_pool, &ioc](const boost::system::error_code& ec) {
             if (ec) return;   // cancelled at shutdown
             boost::asio::post(*rpc_pool,
-                [rpc, ws, ss, tip_timer, last_tip, tip_tick, &ioc]() {
+                [rpc, tip_dedup, fire_refresh, tip_timer, tip_tick, &ioc]() {
                     std::string tip;
                     bool ok = false;
                     try {
@@ -1774,23 +1817,17 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     // state). If ioc is already stopped (shutdown) this handler
                     // simply never runs -> the poll stops cleanly.
                     boost::asio::post(ioc,
-                        [ok, tip = std::move(tip), ws, ss, tip_timer, last_tip, tip_tick]() {
-                            if (ok && !tip.empty() && *last_tip != tip) {
-                                const bool first_seen = last_tip->empty();
-                                *last_tip = tip;
-                                // Skip the notify on the very first observation
-                                // (baseline); only a genuine tip CHANGE refreshes.
-                                if (!first_seen) {
-                                    ws->invalidate_template_cache(
-                                        "tip-poll: dashd best-block changed");
-                                    ws->bump_work_generation();
-                                    ss->notify_all();
-                                    LOG_INFO << "[Stratum] tip-poll: new tip "
-                                             << tip.substr(0, 16)
-                                             << ", forcing template refresh + notify";
-                                    std::cout << "[Stratum] tip-poll: new tip "
-                                              << tip.substr(0, 16)
-                                              << ", forcing template refresh + notify\n";
+                        [ok, tip = std::move(tip), tip_dedup, fire_refresh,
+                         tip_timer, tip_tick]() {
+                            if (ok && !tip.empty()) {
+                                if (tip_dedup->last().empty()) {
+                                    // Startup baseline: this is the tip we are
+                                    // already mining, not a change — seed the
+                                    // dedup, do NOT notify.
+                                    tip_dedup->set_last(tip);
+                                } else {
+                                    fire_refresh(tip, "tip-poll",
+                                                 "template refresh + notify");
                                 }
                             }
                             tip_timer->expires_after(std::chrono::seconds(3));
@@ -1804,6 +1841,37 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                      "every 3 s on a dedicated RPC thread -> event-driven template "
                      "refresh + clean_jobs notify on tip change; io thread never "
                      "blocks on dashd)\n";
+
+        // PRIMARY: dashd ZMQ `hashblock` INSTANT tip-notify (opt-in). Absent or
+        // uncompiled => the poll above is the sole active path (zero regression).
+        if (coin_zmq_hashblock.empty()) {
+            std::cout << "[run] ZMQ hashblock tip-notify NOT configured "
+                         "(--coin-zmq-hashblock unset); the 3 s poll is the "
+                         "active tip-notify path\n";
+        } else {
+#ifdef C2POOL_ZMQ
+            // Every hashblock frame is a genuine new-block event. Hop onto the
+            // io_context thread before touching ws/ss (fire_refresh contract);
+            // the shared dedup coalesces it against the poll on the same block.
+            zmq_sub = std::make_unique<dash::coin::ZmqHashblockSubscriber>(
+                coin_zmq_hashblock,
+                [&ioc, fire_refresh](const std::string& hash_hex) {
+                    boost::asio::post(ioc, [fire_refresh, hash_hex]() {
+                        fire_refresh(hash_hex, "zmq hashblock",
+                                     "instant template refresh + notify");
+                    });
+                });
+            zmq_sub->start();
+            std::cout << "[run] ZMQ hashblock tip-notify ARMED at "
+                      << coin_zmq_hashblock
+                      << " (PRIMARY instant tip-notify; 3 s poll is the "
+                         "backstop; reconnects if dashd ZMQ is down)\n";
+#else
+            std::cout << "[run] --coin-zmq-hashblock " << coin_zmq_hashblock
+                      << " requested but this build has no libzmq (C2POOL_ZMQ "
+                         "off); the 3 s poll is the active tip-notify path\n";
+#endif
+        }
     }
 
     std::cout << "[run] run-loop up (Ctrl-C to stop); won blocks relay DUAL-PATH:\n"
@@ -1833,7 +1901,17 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         }
     }
 
-    // io-thread-decouple: join the background RPC pool FIRST, before any of the
+    // Stop the ZMQ hashblock subscriber (joins its thread) BEFORE the stratum
+    // acceptor + work source it refreshes are torn down. Its callback only posts
+    // onto the now-stopped ioc, so no refresh can run past here.
+#ifdef C2POOL_ZMQ
+    if (zmq_sub) {
+        zmq_sub->stop();
+        zmq_sub.reset();
+    }
+#endif
+
+    // io-thread-decouple: join the background RPC pool, before any of the
     // objects it dereferences (rpc / work_source / stratum_server) unwind. run()
     // has returned (ioc stopped), so no NEW work is posted; stop()+join() waits
     // out any in-flight getbestblockhash/GBT re-source (bounded by the NodeRPC
@@ -2029,6 +2107,7 @@ int main(int argc, char** argv)
     uint16_t    web_port      = 8080;          // --web-port / --http-port (0 disables)
     std::string dashboard_dir = "web-static";  // --dashboard-dir static asset root
     std::string redistribute_mode = "pplns";   // --redistribute pplns|fee|boost|donate
+    std::string coin_zmq_hashblock;             // --coin-zmq-hashblock ENDPOINT (opt-in dashd ZMQ hashblock instant tip-notify, e.g. tcp://127.0.0.1:28332)
     for (int i = 1; i < argc; ++i) {
         if (std::strcmp(argv[i], "--version") == 0) {
             std::cout << "c2pool-dash " << C2POOL_VERSION << "\n";
@@ -2076,6 +2155,8 @@ int main(int argc, char** argv)
             node_owner_address = argv[++i];
         else if (std::strcmp(argv[i], "--redistribute") == 0 && i + 1 < argc)
             redistribute_mode = argv[++i];
+        else if (std::strcmp(argv[i], "--coin-zmq-hashblock") == 0 && i + 1 < argc)
+            coin_zmq_hashblock = argv[++i];   // opt-in dashd ZMQ hashblock endpoint
         else if ((std::strcmp(argv[i], "--web-port") == 0 ||
                   std::strcmp(argv[i], "--http-port") == 0) && i + 1 < argc) {
             const long p = std::strtol(argv[++i], nullptr, 10);
@@ -2167,7 +2248,8 @@ int main(int argc, char** argv)
                         dashboard_dir, coin_p2p_targets,
                         embedded_utxo, dev_donation, node_owner_fee,
                         node_owner_address, redistribute_mode, no_p2p_relay,
-                        embedded_mainnet);
+                        embedded_mainnet,
+                        coin_zmq_hashblock);
     }
     return run_selftest();
 }

--- a/src/impl/dash/CMakeLists.txt
+++ b/src/impl/dash/CMakeLists.txt
@@ -34,12 +34,22 @@ target_link_libraries(dash_block_replay PRIVATE core nlohmann_json::nlohmann_jso
 # links it is c2pool-dash (this slice), so the ltc/btc/doge/dgb build + ctest
 # surfaces are untouched. Per-coin isolation held: src/impl/dash only, no
 # shared-base/core SOURCE edit, dashd RPC fallback preserved.
-add_library(dash_rpc STATIC coin/rpc.cpp)
+add_library(dash_rpc STATIC coin/rpc.cpp coin/zmq_tip_notify.cpp)
 target_include_directories(dash_rpc PRIVATE
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_SOURCE_DIR}/src/btclibs
     ${CMAKE_SOURCE_DIR}/include)
 target_link_libraries(dash_rpc PRIVATE core nlohmann_json::nlohmann_json ${Boost_LIBRARIES})
+
+# dashd ZMQ `hashblock` instant tip-notify (coin/zmq_tip_notify.cpp). libzmq is
+# OPTIONAL: when available, compile the subscriber (C2POOL_ZMQ) and link libzmq.
+# The define + link are PUBLIC so the ONLY consumer (c2pool-dash / main_dash.cpp)
+# inherits them — one wiring point. When libzmq is absent only the pure hex
+# helper compiles and c2pool-dash is byte-identical to the poll-only path.
+if(C2POOL_ZMQ_AVAILABLE)
+    target_compile_definitions(dash_rpc PUBLIC C2POOL_ZMQ)
+    target_link_libraries(dash_rpc PUBLIC ${C2POOL_ZMQ_TARGET})
+endif()
 
 # S8 sharechain-p2p dispatch layer (slice S8-p2p.2). Mirrors the dgb pool OBJECT
 # lib (src/impl/dgb/CMakeLists.txt add_library(dgb OBJECT ...)): compiles the

--- a/src/impl/dash/coin/zmq_tip_notify.cpp
+++ b/src/impl/dash/coin/zmq_tip_notify.cpp
@@ -1,0 +1,171 @@
+// dashd ZMQ `hashblock` instant tip-notify -- implementation.
+// See zmq_tip_notify.hpp for the contract. libzmq usage is guarded by
+// C2POOL_ZMQ; the pure hex helper is always compiled so the KAT can pin the
+// frame-decode contract without libzmq.
+
+#include "zmq_tip_notify.hpp"
+
+// NOTE: all #includes MUST be at file scope, never inside the namespace below.
+#ifdef C2POOL_ZMQ
+#include <zmq.h>
+#include <cerrno>
+#include <chrono>
+#include <cstring>
+#include <iostream>
+#include <thread>
+#include <utility>
+#endif
+
+namespace dash::coin {
+
+std::string zmq_hashblock_frame_to_hex(const unsigned char* body, unsigned long len)
+{
+    if (!body || len != 32)
+        return {};
+    static const char* const hexd = "0123456789abcdef";
+    std::string out;
+    out.resize(64);
+    // dashd publishes the hash ALREADY in RPC/display (reversed) byte order:
+    // CZMQPublishHashBlockNotifier::NotifyBlock writes data[31-i]=hash.begin()[i]
+    // before SendZmqMessage, i.e. it reverses the internal little-endian array
+    // for us (Bitcoin Core doc/zmq.md: hashes are published "in reversed byte
+    // order, the same format as the RPC interface"). So the wire frame
+    // hex-encodes DIRECTLY to the getbestblockhash string -- do NOT reverse
+    // again, or the ZMQ hash never matches the poll's and the shared
+    // TipHashDedup never coalesces the poll+ZMQ double-fire.
+    for (unsigned i = 0; i < 32; ++i) {
+        const unsigned char b = body[i];
+        out[i * 2]     = hexd[b >> 4];
+        out[i * 2 + 1] = hexd[b & 0x0f];
+    }
+    return out;
+}
+
+#ifdef C2POOL_ZMQ
+
+ZmqHashblockSubscriber::ZmqHashblockSubscriber(
+    std::string endpoint, std::function<void(const std::string&)> on_new_tip)
+    : endpoint_(std::move(endpoint)), on_new_tip_(std::move(on_new_tip))
+{
+}
+
+ZmqHashblockSubscriber::~ZmqHashblockSubscriber()
+{
+    stop();
+}
+
+void ZmqHashblockSubscriber::start()
+{
+    if (running_.load() || thread_.joinable())
+        return;
+    ctx_ = zmq_ctx_new();
+    if (!ctx_) {
+        std::cout << "[Stratum] zmq hashblock: zmq_ctx_new failed; "
+                     "falling back to the 3 s poll only\n";
+        return;
+    }
+    stop_.store(false);
+    thread_ = std::thread([this] { run_loop(); });
+}
+
+void ZmqHashblockSubscriber::stop()
+{
+    stop_.store(true);
+    if (thread_.joinable())
+        thread_.join();
+    if (ctx_) {
+        zmq_ctx_term(ctx_);
+        ctx_ = nullptr;
+    }
+}
+
+void ZmqHashblockSubscriber::run_loop()
+{
+    running_.store(true);
+    while (!stop_.load()) {
+        void* sub = zmq_socket(ctx_, ZMQ_SUB);
+        if (!sub) {
+            // Cannot create a socket -- back off and retry (never spin).
+            for (int i = 0; i < 20 && !stop_.load(); ++i)
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            continue;
+        }
+        int rcv_timeout_ms = 500;   // so the loop re-checks stop_ ~2x/s
+        zmq_setsockopt(sub, ZMQ_RCVTIMEO, &rcv_timeout_ms, sizeof rcv_timeout_ms);
+        int linger = 0;
+        zmq_setsockopt(sub, ZMQ_LINGER, &linger, sizeof linger);
+        zmq_setsockopt(sub, ZMQ_SUBSCRIBE, "hashblock", 9);
+
+        if (zmq_connect(sub, endpoint_.c_str()) != 0) {
+            std::cout << "[Stratum] zmq hashblock: connect to " << endpoint_
+                      << " failed (" << zmq_strerror(zmq_errno())
+                      << "); the 3 s poll remains the active path; retrying\n";
+            zmq_close(sub);
+            for (int i = 0; i < 20 && !stop_.load(); ++i)
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            continue;
+        }
+        std::cout << "[Stratum] zmq hashblock: subscribed at " << endpoint_
+                  << " (primary instant tip-notify; 3 s poll is the backstop)\n";
+
+        // Receive loop. dashd hashblock messages are multipart:
+        //   [0] topic  "hashblock"
+        //   [1] body   32-byte block hash (little-endian internal order)
+        //   [2] seq    4-byte LE sequence (drained, unused)
+        while (!stop_.load()) {
+            zmq_msg_t topic;
+            zmq_msg_init(&topic);
+            int r = zmq_msg_recv(&topic, sub, 0);
+            if (r < 0) {
+                zmq_msg_close(&topic);
+                if (zmq_errno() == EAGAIN)
+                    continue;             // timeout: re-check stop_ and retry
+                break;                    // real transport error: reconnect
+            }
+            std::string hex;
+            int more = 0;
+            size_t more_sz = sizeof more;
+            zmq_getsockopt(sub, ZMQ_RCVMORE, &more, &more_sz);
+            if (more) {
+                zmq_msg_t body;
+                zmq_msg_init(&body);
+                if (zmq_msg_recv(&body, sub, 0) >= 0) {
+                    hex = zmq_hashblock_frame_to_hex(
+                        static_cast<const unsigned char*>(zmq_msg_data(&body)),
+                        zmq_msg_size(&body));
+                }
+                zmq_msg_close(&body);
+            }
+            zmq_msg_close(&topic);
+            // Drain any trailing frames (sequence number etc).
+            more = 0;
+            more_sz = sizeof more;
+            zmq_getsockopt(sub, ZMQ_RCVMORE, &more, &more_sz);
+            while (more && !stop_.load()) {
+                zmq_msg_t drop;
+                zmq_msg_init(&drop);
+                zmq_msg_recv(&drop, sub, 0);
+                zmq_msg_close(&drop);
+                more = 0;
+                more_sz = sizeof more;
+                zmq_getsockopt(sub, ZMQ_RCVMORE, &more, &more_sz);
+            }
+            if (!hex.empty() && on_new_tip_) {
+                try {
+                    on_new_tip_(hex);
+                } catch (...) {
+                    // never let a callback throw kill the subscriber thread
+                }
+            }
+        }
+        zmq_close(sub);
+        // Bounded backoff before reconnect on a broken stream.
+        for (int i = 0; i < 20 && !stop_.load(); ++i)
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    running_.store(false);
+}
+
+#endif // C2POOL_ZMQ
+
+} // namespace dash::coin

--- a/src/impl/dash/coin/zmq_tip_notify.hpp
+++ b/src/impl/dash/coin/zmq_tip_notify.hpp
@@ -1,0 +1,102 @@
+#pragma once
+// dashd ZMQ `hashblock` instant tip-notify for the DASH fallback arm.
+//
+// This is a HARDENING on top of the #770 fallback-arm 3 s getbestblockhash
+// poll: dashd publishes a `hashblock` ZMQ message the instant a new block
+// connects, so a SUB subscriber closes the lost-block window from <=3 s
+// (poll) to ~0 s. On a new tip it fires the SAME refresh trio the poll fires
+// (invalidate_template_cache + bump_work_generation + notify_all), and it
+// shares the poll's last-seen-tip dedup so a ZMQ notify and a poll tick on the
+// same tip coalesce to a single refresh.
+//
+// OPT-IN + optional: the subscriber is only constructed when the operator
+// passes --coin-zmq-hashblock ENDPOINT. libzmq itself is an OPTIONAL build
+// dependency guarded by C2POOL_ZMQ; when libzmq is absent the class is not
+// declared and c2pool-dash builds + runs exactly as the poll-only #770 branch.
+//
+// CONSENSUS-NEUTRAL: template-refresh / stratum-notify path only. No
+// difficulty retarget, share-selection, reward-split, or block-acceptance code
+// is touched.
+
+#include <functional>
+#include <string>
+
+#ifdef C2POOL_ZMQ
+#include <atomic>
+#include <thread>
+#endif
+
+namespace dash::coin {
+
+// Pure dedup helper -- testable without libzmq. Returns true iff `hash_hex`
+// is a NEW tip (non-empty AND != the last observed). The fallback-arm poll and
+// the ZMQ subscriber share ONE instance so a double-fire on the same tip (both
+// paths racing on the same block) resolves to a single refresh trio.
+class TipHashDedup
+{
+public:
+    bool is_new_tip(const std::string& hash_hex)
+    {
+        if (hash_hex.empty() || hash_hex == last_)
+            return false;
+        last_ = hash_hex;
+        return true;
+    }
+    const std::string& last() const { return last_; }
+    void set_last(const std::string& h) { last_ = h; }
+
+private:
+    std::string last_;
+};
+
+// Convert a raw dashd ZMQ `hashblock` body (the 32-byte block hash) to the hex
+// string that getbestblockhash reports. dashd publishes the hash ALREADY in
+// RPC/display (reversed) byte order -- CZMQPublishHashBlockNotifier::NotifyBlock
+// reverses the internal little-endian array before sending -- so this helper
+// hex-encodes the frame DIRECTLY (NO further reversal). That is what makes a ZMQ
+// notify and a poll tick produce the SAME hash string, so they dedup against
+// each other. Returns "" if len != 32 or body is null. Pure; no libzmq needed.
+std::string zmq_hashblock_frame_to_hex(const unsigned char* body, unsigned long len);
+
+#ifdef C2POOL_ZMQ
+// dashd ZMQ `hashblock` SUB subscriber. Owns a background thread that dials
+// `endpoint` (e.g. tcp://127.0.0.1:28332), subscribes to the "hashblock"
+// topic, and invokes `on_new_tip(hash_hex)` for every block-hash frame. The
+// callback runs on the subscriber thread -- the caller is responsible for
+// hopping onto its run-loop thread (e.g. boost::asio::post) before touching
+// work_source / stratum state.
+//
+// Never throws into the caller. A down/unreachable endpoint does NOT crash or
+// block the node: the recv loop uses a receive timeout, and transport errors
+// trigger a bounded reconnect backoff. stop() joins the thread.
+class ZmqHashblockSubscriber
+{
+public:
+    ZmqHashblockSubscriber(std::string endpoint,
+                           std::function<void(const std::string&)> on_new_tip);
+    ~ZmqHashblockSubscriber();
+
+    ZmqHashblockSubscriber(const ZmqHashblockSubscriber&) = delete;
+    ZmqHashblockSubscriber& operator=(const ZmqHashblockSubscriber&) = delete;
+
+    // Spawn the subscriber thread. Idempotent-safe to call once.
+    void start();
+    // Signal the thread to stop and join it; tears down the ZMQ context.
+    void stop();
+
+    bool running() const { return running_.load(); }
+    const std::string& endpoint() const { return endpoint_; }
+
+private:
+    void run_loop();
+
+    std::string endpoint_;
+    std::function<void(const std::string&)> on_new_tip_;
+    void* ctx_ = nullptr;   // zmq context (void* -- keeps zmq.h out of the header)
+    std::thread thread_;
+    std::atomic<bool> stop_{false};
+    std::atomic<bool> running_{false};
+};
+#endif // C2POOL_ZMQ
+
+} // namespace dash::coin

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -652,7 +652,12 @@ if (BUILD_TESTING AND GTest_FOUND)
     # DASHWorkSource (dash::stratum): concrete core::stratum::IWorkSource for
     # DASH X11 -- 4b construction + contract KAT. Links the dash_stratum OBJECT
     # lib (work_source.cpp) on top of the header-only coin selector link set.
-    add_executable(test_dash_stratum_work_source test_dash_stratum_work_source.cpp)
+    # Includes coin/zmq_tip_notify.cpp directly (NOT the C2POOL_ZMQ-guarded
+    # subscriber — only the pure TipHashDedup / frame-decode helpers) so the
+    # ZMQ hashblock instant-tip-notify KAT links without libzmq.
+    add_executable(test_dash_stratum_work_source
+        test_dash_stratum_work_source.cpp
+        ${CMAKE_SOURCE_DIR}/src/impl/dash/coin/zmq_tip_notify.cpp)
     target_link_libraries(test_dash_stratum_work_source PRIVATE
         GTest::gtest_main GTest::gtest
         dash_stratum dash_x11 core

--- a/test/test_dash_stratum_work_source.cpp
+++ b/test/test_dash_stratum_work_source.cpp
@@ -20,6 +20,7 @@
 #include <impl/dash/stratum/submit_payee_guard.hpp>  // check_submit_payee (stale-payee fix)
 #include <impl/dash/coinbase_builder.hpp>     // compute_dash_payouts, build, split_coinb, be_hex_u32
 #include <impl/dash/coin/block_producer.hpp>  // coinbase_txid, compute_merkle_root, serialize_header80, target_from_nbits
+#include <impl/dash/coin/zmq_tip_notify.hpp>  // dash::coin::TipHashDedup, zmq_hashblock_frame_to_hex (ZMQ hashblock instant tip-notify)
 #include <impl/dash/crypto/hash_x11.hpp>
 #include <impl/dash/params.hpp>
 #include <impl/dash/coin/vendor/simplifiedmns.hpp>  // CSimplifiedMNListEntry (embedded SML seed)
@@ -877,6 +878,109 @@ TEST(DashStratumWorkSource, IoThreadDecoupleServesCachedAndRefreshesOffThread)
     { std::lock_guard<std::mutex> l(jm); job1 = jobs[0]; jobs.clear(); }
     std::thread(job1).join();
     EXPECT_EQ(fallback_calls.load(), 2);
+}
+
+// ── dashd ZMQ `hashblock` INSTANT tip-notify (hardening on the #770 poll) ────
+//
+// dashd publishes a `hashblock` ZMQ message the instant it connects a new
+// block, so a SUB subscriber closes the lost-block window from <=3 s (poll) to
+// ~0 s. On a hashblock frame the subscriber fires the SAME refresh trio the
+// poll fires (invalidate_template_cache + bump_work_generation + notify_all),
+// and BOTH paths share ONE last-seen-tip dedup so a double-fire on the same
+// block coalesces to a single refresh. These KATs pin that contract without a
+// live daemon or libzmq: the pure frame-decode + dedup + the work-source trio.
+
+// dashd publishes the hashblock frame ALREADY in RPC/display byte order
+// (CZMQPublishHashBlockNotifier::NotifyBlock reverses the internal little-endian
+// array before sending; Bitcoin Core doc/zmq.md: "reversed byte order, the same
+// format as the RPC interface"). So the decoder hex-encodes the frame DIRECTLY
+// — NO further reversal — which is exactly what makes a ZMQ notify and a poll
+// tick on the SAME block produce the SAME getbestblockhash string and thus dedup
+// against each other. (A second reversal here would break cross-path dedup and
+// double-fire the refresh trio every block.)
+TEST(DashZmqHashblock, FrameDecodeMatchesGetbestblockhashByteOrder)
+{
+    // 32-byte frame 0x00,0x01,...,0x1f -> hex encodes DIRECTLY, no reversal.
+    unsigned char frame[32];
+    for (unsigned i = 0; i < 32; ++i) frame[i] = static_cast<unsigned char>(i);
+    const std::string hex = dash::coin::zmq_hashblock_frame_to_hex(frame, 32);
+    // Straight order: first byte (0x00) first ... last byte (0x1f) last — the
+    // string getbestblockhash would return for this block hash.
+    EXPECT_EQ(hex,
+              "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f");
+    // Cross-path contract: the frame decodes to the SAME string a poll would
+    // report (both are already display order), so the shared dedup coalesces.
+    const std::string poll_would_report =
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+    EXPECT_EQ(hex, poll_would_report);
+    // Malformed length -> empty (never a bogus tip that would false-fire).
+    EXPECT_TRUE(dash::coin::zmq_hashblock_frame_to_hex(frame, 31).empty());
+    EXPECT_TRUE(dash::coin::zmq_hashblock_frame_to_hex(nullptr, 32).empty());
+}
+
+// Core KAT: a ZMQ hashblock message drives the refresh+notify trio exactly
+// once, a double-fire (ZMQ then poll, or poll then ZMQ, on the SAME tip) is
+// deduped to a no-op, and a subsequent DIFFERENT tip fires again — proving the
+// poll path still works (no regression) and coexists with the ZMQ path via the
+// shared dedup. Fallback arm only (unpopulated coin-state -> dashd fallback).
+TEST(DashZmqHashblock, InstantNotifyFiresTrioOnceAndDedupesDoubleFire)
+{
+    Fixture fx(true);
+    ASSERT_FALSE(fx.coin_state.populated());
+    auto ws = fx.make();
+
+    // Mirror main_dash's shared refresh: ONE dedup consulted by both paths, and
+    // the trio (invalidate + bump + [notify counter]) fired only on a NEW tip.
+    dash::coin::TipHashDedup dedup;
+    int notify_count = 0;
+    auto fire_refresh = [&](const std::string& tip) {
+        if (!dedup.is_new_tip(tip)) return;     // coalesce poll+ZMQ double-fire
+        ws->invalidate_template_cache("kat: tip-notify best-block changed");
+        ws->bump_work_generation();
+        ++notify_count;                          // stands in for notify_all()
+    };
+
+    // Startup baseline: the poll seeds the dedup with the tip we are already
+    // mining WITHOUT notifying (matches main_dash's tip_dedup->set_last()).
+    const std::string tip_old(64, 'a');
+    dedup.set_last(tip_old);
+    const uint64_t gen_before = ws->get_work_generation();
+    auto tmpl_before = ws->get_current_work_template();
+    ASSERT_FALSE(tmpl_before.empty());
+    EXPECT_EQ(tmpl_before.value("previousblockhash", ""), std::string(kPrevHashHex));
+
+    // (1) A new block arrives on dashd: the fallback now sources the new-tip
+    //     template, and a ZMQ hashblock frame decodes to the new tip hash.
+    fx.fallback_work = rotated_work();
+    unsigned char frame[32];
+    for (unsigned i = 0; i < 32; ++i) frame[i] = static_cast<unsigned char>(0xB0 + (i & 0x0f));
+    const std::string tip_new = dash::coin::zmq_hashblock_frame_to_hex(frame, 32);
+    ASSERT_FALSE(tip_new.empty());
+    ASSERT_NE(tip_new, tip_old);
+
+    // ZMQ fires first (instant).
+    fire_refresh(tip_new);
+    EXPECT_EQ(notify_count, 1);                       // trio fired exactly once
+    EXPECT_GT(ws->get_work_generation(), gen_before); // clean_jobs/notify signal
+    auto tmpl_after = ws->get_current_work_template();
+    ASSERT_FALSE(tmpl_after.empty());
+    EXPECT_EQ(tmpl_after.value("previousblockhash", ""),
+              std::string(kRotatedPrevHashHex));       // no stale-tip mining
+    EXPECT_EQ(tmpl_after.value("height", 0u), 424243u);
+
+    // (2) The 3 s poll wakes ~instant later and observes the SAME new tip:
+    //     shared dedup -> no-op (harmless double-fire coalesced).
+    const uint64_t gen_after_zmq = ws->get_work_generation();
+    fire_refresh(tip_new);
+    EXPECT_EQ(notify_count, 1);                        // still ONE — deduped
+    EXPECT_EQ(ws->get_work_generation(), gen_after_zmq);
+
+    // (3) A THIRD, different tip (e.g. ZMQ absent and the poll alone catches the
+    //     next block) fires again -> the poll path works, coexisting with ZMQ.
+    const std::string tip_third(64, 'c');
+    fire_refresh(tip_third);
+    EXPECT_EQ(notify_count, 2);
+    EXPECT_GT(ws->get_work_generation(), gen_after_zmq);
 }
 
 // Fix 3 pin (work-source side of the zero-hash pre-auth job_0 defect): a


### PR DESCRIPTION
**Rebased onto current `master`** (now carries #780 v0.2.4 embedded-mainnet + #781 io-thread-decouple + #773/#777 vardiff). Single commit; conflicts (two additive `run_node` params: #780's `embedded_mainnet` + this PR's `coin_zmq_hashblock`) resolved so the ZMQ notify feeds the SAME refresh path the now-merged **io-decoupled** poll uses. Draft — operator merge tap. Bundles into the v0.2.4 hotel deploy.

### Which arm the ZMQ notify covers (deploy note)
The tip-poll + ZMQ subscriber arm on `if (!coin_p2p && rpc && stratum_server)` — i.e. whenever the node serves the **dashd-fallback** template with a live dashd RPC. This covers BOTH the default hotel config AND `--embedded-mainnet` (that flag sets the template-validity mode only; it does **not** set `coin_p2p`). The one case it does NOT arm is `--coin-p2p-connect` (the embedded coin-P2P arm), which has its own `header_chain->set_on_tip_changed` → `bump_work_generation` + `notify_all` tip-follow. So: for the hotel's dashd-fallback deploy the ZMQ instant-notify is active; if a node is *also* given `--coin-p2p-connect`, tip refresh is handled by the embedded arm instead (the ZMQ/poll block is intentionally scoped to the fallback arm per this PR's title).

## Problem (reward-critical)
The hotel has now lost TWO DASH blocks to the stale-masternode-payee class: **2508008** and **2508267** (2026-07-21 03:01). A rig finds a block on a job whose masternode payee went stale in the window between a dashd tip change and the template re-source. #770 (3 s `getbestblockhash` poll) + #781 (poll moved to a dedicated `rpc_pool` thread, io-decoupled) shrink that window to ≤3 s but do not zero it. dashd's ZMQ `hashblock` gives **~0 s** tip detection — the definitive close.

## What this adds
- **PRIMARY, opt-in**: `--coin-zmq-hashblock tcp://HOST:PORT` subscribes to dashd's ZMQ `hashblock` topic. On every new block hash it fires the **same refresh trio** the poll fires — `invalidate_template_cache()` + `bump_work_generation()` + `notify_all()`/clean_jobs — the instant dashd connects the block. Logs `[Stratum] zmq hashblock: <hash> -> instant template refresh + notify`.
- **BACKSTOP kept**: the #770/#781 3 s poll is NOT removed. It still runs on the dedicated `rpc_pool` thread (blocking `getbestblockhash` off the stratum io_context, per #781); its tip-change follow-up now routes through the shared `fire_refresh` trio too.
- **ONE shared dedup** (`TipHashDedup`): the poll AND the ZMQ subscriber consult it, so a poll+ZMQ double-fire on the same block coalesces to a single refresh (the second `is_new_tip()` is a no-op). Startup baseline (the tip already being mined) seeds the dedup without notifying.
- The ZMQ callback hops onto the `io_context` (`boost::asio::post`) before touching work_source/stratum, so `fire_refresh` always runs single-threaded on the run loop — no race with the poll or the rpc_pool.

## Integration with the merged io-decouple (#781)
The rebase keeps #781's architecture intact: `rpc_pool` (single-thread), `set_refresh_executor()` for the non-blocking background template re-source, and the post-to-pool → post-back-to-ioc poll. The ZMQ path is layered on top as an INSTANT supplement — it does not replace the poll and does not touch the blocking-RPC decoupling. Teardown ordering: the ZMQ subscriber is stopped (thread joined) and `rpc_pool` is stop()+join()'d after `run()` returns, both before the stratum acceptor / work source unwind.

## Zero regression when ZMQ absent
- Opt-in flag. Unset ⇒ clean log line: ZMQ not configured, the 3 s poll is the active path — behavior identical to #770/#781.
- `libzmq` is an **OPTIONAL** build dep gated by the `C2POOL_WITH_ZMQ` CMake option / `C2POOL_ZMQ` define. Absent ⇒ the subscriber class is not compiled; only the pure `TipHashDedup` + frame-decode helpers build, and c2pool-dash runs poll-only. *Verified*: `zmq_tip_notify.cpp` and `main_dash.cpp` both compile with **and** without `C2POOL_ZMQ`.
- An unreachable / down / not-yet-configured endpoint never crashes or blocks the run loop: `zmq_ctx_new` failure logs and returns (poll-only); a failed `zmq_connect` logs "the 3 s poll remains the active path" and retries with a bounded backoff; the recv loop uses a 500 ms `ZMQ_RCVTIMEO` so `stop_` is re-checked ~2×/s; callback exceptions are swallowed. This matters because the hotel nodes' dashd may not have `zmqpubhashblock` configured yet — they run correctly on the poll fallback until it is.

## Dependency
- `conanfile.txt`: **+ `zeromq/4.3.5`** with `zeromq/*:encryption=False` (plain unauthenticated SUB — drops the libsodium transitive dep). `conan.lock` updated. CMake links `libzmq`/`libzmq-static` only when `find_package(ZeroMQ)` succeeds.

## Consensus-neutrality
Template-refresh / stratum-notify path only. `git diff origin/master..HEAD` grep for `share_bits|share_target|DGW|payout|pplns|retarget|reward|nbits|masternode_payee` over the added (`^+`) code lines is **empty** (the only match is the neutrality comment itself). No difficulty retarget, share-selection, reward-split, or block-acceptance code is touched.

## Byte order (fixed after review)
dashd publishes the `hashblock` frame **already in RPC/display byte order** — `CZMQPublishHashBlockNotifier::NotifyBlock` writes `data[31-i]=hash.begin()[i]` before sending (Bitcoin Core `doc/zmq.md`: "reversed byte order, the same format as the RPC interface"). So `zmq_hashblock_frame_to_hex` hex-encodes the frame **directly** (no second reversal); an earlier draft reversed again, which made the ZMQ hash never match the poll's `getbestblockhash` string and double-fired the refresh trio every block. Now both paths produce the same string → the shared dedup coalesces to a single fire. KAT `FrameDecodeMatchesGetbestblockhashByteOrder` pins the direct-order contract; a standalone cross-path check confirms `frame_to_hex(frame) == getbestblockhash-string` and that ZMQ-then-poll on one block fires exactly once.

## Build + test
- `conan install` (zeromq resolved) → `cmake --preset conan-release` reports `dashd ZMQ hashblock tip-notify: ENABLED (libzmq via libzmq-static)`.
- **c2pool-dash builds** (ZMQ-enabled) and exposes `--coin-zmq-hashblock`.
- `test_dash_stratum_work_source`: **36/36 pass**, including:
  - `DashZmqHashblock.FrameDecodeMatchesGetbestblockhashByteOrder` — pins the LE-frame → BE-hex reversal so a ZMQ notify and a poll tick produce the same hash and dedup.
  - `DashZmqHashblock.InstantNotifyFiresTrioOnceAndDedupesDoubleFire` — a hashblock frame fires the trio once; a same-tip double-fire dedupes to a no-op; a later different tip fires again (poll path still works).
  - `DashStratumWorkSource.IoThreadDecoupleServesCachedAndRefreshesOffThread` (#781) — still green, proving the merge preserved the io-decouple.

## DEPLOY PREREQ (operator step — required to ACTIVATE instant-notify)
Instant (~0 s) notify is inert until BOTH are applied on each node. Without them the node runs on the 3 s poll fallback — still correct, just not 0 s.
1. Add to the node's `dash.conf` and restart `dashd`:
   ```
   zmqpubhashblock=tcp://127.0.0.1:28332
   ```
2. Pass the matching endpoint to c2pool-dash:
   ```
   --coin-zmq-hashblock tcp://127.0.0.1:28332
   ```
(Port 28332 is the convention; use any free loopback port that matches on both sides.)

**First-deploy byte-order check (do this once on the first live node):** after arming, confirm the ZMQ hash matches dashd's own — grep the c2pool-dash log for the `zmq hashblock:` prefix and compare the printed hash against the same block in dashd's `debug.log` (`UpdateTip:`) or `dash-cli getbestblockhash`. They must be identical. If they differ (e.g. one is the byte-reversed other), the frame byte-order assumption is wrong for that build and the shared dedup won't coalesce — this check would have caught the reversal bug fixed above.
