### PR TITLE
dash(stratum): firmware-safe power-of-two vardiff quantization (v0.2.3.6) [stacks on #770]

### DIFF
--- a/src/c2pool/hashrate/tracker.cpp
+++ b/src/c2pool/hashrate/tracker.cpp
@@ -184,6 +184,13 @@ void HashrateTracker::set_difficulty_from_hashrate(double now) {
     if (h <= 0.0) return;
     double d = h * target_time_per_mining_share_ / 4294967296.0;
     d = std::max(min_difficulty_, std::min(max_difficulty_, d));
+    // Firmware-grid fix: many ASIC firmwares round the advertised pool difficulty
+    // DOWN to a power-of-two grid, then mine that easier target and submit shares
+    // the pool's exact (higher) required difficulty rejects. Advertise only
+    // power-of-two difficulties so advertised == applied == required. Round DOWN so
+    // accepted-share cadence never drops below target.
+    d = std::exp2(std::floor(std::log2(d)));
+    d = std::max(min_difficulty_, d);
     if (current_difficulty_ > 0.0) {
         double ratio = d / current_difficulty_;
         // Dead-band: absorb estimator noise, no needless set_difficulty churn.

--- a/src/c2pool/hashrate/tracker.cpp
+++ b/src/c2pool/hashrate/tracker.cpp
@@ -190,7 +190,13 @@ void HashrateTracker::set_difficulty_from_hashrate(double now) {
     // power-of-two difficulties so advertised == applied == required. Round DOWN so
     // accepted-share cadence never drops below target.
     d = std::exp2(std::floor(std::log2(d)));
-    d = std::max(min_difficulty_, d);
+    // Quantize the floor too so a floor-pinned/warm-up advertise is still a
+    // power of two. min_difficulty_ (e.g. 0.0005) is not itself on the grid, so
+    // re-flooring at it would re-open the firmware reject gap at the floor.
+    // Advertise at most one grid step below the configured floor (0.000488 vs
+    // 0.0005), preserving the round-DOWN cadence invariant.
+    d = std::max(std::exp2(std::floor(std::log2(min_difficulty_))),
+                 std::exp2(std::floor(std::log2(d))));
     if (current_difficulty_ > 0.0) {
         double ratio = d / current_difficulty_;
         // Dead-band: absorb estimator noise, no needless set_difficulty churn.

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -1481,6 +1481,65 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         }
     }
 
+    // ── Fallback-arm event-driven tip refresh ────────────────────────────
+    // On the dashd-fallback arm (no embedded coin-P2P tip source) the template
+    // cache only re-sources on the 30 s staleness TTL (work_source.cpp
+    // kStaleAfter) — there is NO tip-change signal like the embedded arm's
+    // header_chain->set_on_tip_changed callback. DASH blocks arrive ~every
+    // 150 s, so up to ~30 s of stale-tip mining can occur per block (accepted
+    // pseudoshares that can no longer win the current block). Poll dashd for
+    // its best-block hash every 3 s; on a change, drop the cached template +
+    // bump work-generation + notify every session (clean_jobs) — the SAME
+    // refresh pair the embedded arm fires. Gated on the fallback arm (coin_p2p
+    // null) AND an armed rpc AND a live stratum acceptor. getbestblockhash is a
+    // trivial RPC; failures are swallowed so a daemon hiccup never crashes the
+    // run-loop (retry next tick). Reuses the existing NodeRPC client — no new
+    // dependency, no dashd config change, no new notify mechanism.
+    if (!coin_p2p && rpc && stratum_server) {
+        auto tip_timer = std::make_shared<io::steady_timer>(ioc);
+        auto last_tip = std::make_shared<std::string>();
+        auto tip_tick = std::make_shared<
+            std::function<void(const boost::system::error_code&)>>();
+        *tip_tick = [rpc = rpc.get(), ws = work_source.get(),
+                     ss = stratum_server.get(), tip_timer, last_tip, tip_tick](
+                        const boost::system::error_code& ec) {
+            if (ec) return;   // cancelled at shutdown
+            try {
+                const std::string tip = rpc->getbestblockhash();
+                if (!tip.empty() && *last_tip != tip) {
+                    const bool first_seen = last_tip->empty();
+                    *last_tip = tip;
+                    // Skip the notify on the very first observation (baseline);
+                    // only a genuine tip CHANGE forces a refresh.
+                    if (!first_seen) {
+                        ws->invalidate_template_cache(
+                            "tip-poll: dashd best-block changed");
+                        ws->bump_work_generation();
+                        ss->notify_all();
+                        LOG_INFO << "[Stratum] tip-poll: new tip "
+                                 << tip.substr(0, 16)
+                                 << ", forcing template refresh + notify";
+                        std::cout << "[Stratum] tip-poll: new tip "
+                                  << tip.substr(0, 16)
+                                  << ", forcing template refresh + notify\n";
+                    }
+                }
+            } catch (const std::exception& e) {
+                LOG_WARNING << "[Stratum] tip-poll getbestblockhash failed "
+                               "(non-fatal, retry next tick): " << e.what();
+            } catch (...) {
+                // swallow — never crash the run-loop on a tip probe
+            }
+            tip_timer->expires_after(std::chrono::seconds(3));
+            tip_timer->async_wait(*tip_tick);
+        };
+        tip_timer->expires_after(std::chrono::seconds(3));
+        tip_timer->async_wait(*tip_tick);
+        std::cout << "[run] fallback-arm tip-poll ARMED (dashd getbestblockhash "
+                     "every 3 s -> event-driven template refresh + clean_jobs "
+                     "notify on tip change)\n";
+    }
+
     std::cout << "[run] run-loop up (Ctrl-C to stop); won blocks relay DUAL-PATH:\n"
                  "[run]   ARM A embedded coin-P2P relay (primary, daemonless) = "
               << (p2p_relay ? "ARMED" : (no_p2p_relay ? "SUPPRESSED (--no-p2p-relay)"

--- a/src/core/stratum_server.cpp
+++ b/src/core/stratum_server.cpp
@@ -1178,10 +1178,18 @@ nlohmann::json StratumSession::handle_submit(const nlohmann::json& params, const
 
     // ── Pseudoshare accepted — record in RateMonitor ──
     // p2pool: work = target_to_average_attempts(effective_target)
-    // For us: work = vardiff_difficulty × 2^32 (equivalent unit conversion)
+    // For us: work = credited_difficulty × 2^32 (equivalent unit conversion)
     ++accepted_shares_;
     static constexpr double TWO_32 = 4294967296.0;
-    double work = vardiff_difficulty * TWO_32;
+    // #766/#762: credit the hashrate estimate at the difficulty THIS job was
+    // actually issued/mined at, not the live vardiff. A vardiff retarget
+    // between job-issue and submit must not skew the EWMA/RateMonitor input —
+    // the share represents work at its own job's target. Falls back to the live
+    // vardiff when issued_difficulty is unset (0). Estimate/stats only; the
+    // acceptance gate above is unchanged.
+    double credited_difficulty =
+        (job.issued_difficulty > 0.0) ? job.issued_difficulty : vardiff_difficulty;
+    double work = credited_difficulty * TWO_32;
     bool is_dead = (job.stale_info != 0);
 
     // Record in global RateMonitor (for get_local_addr_rates)
@@ -1189,7 +1197,7 @@ nlohmann::json StratumSession::handle_submit(const nlohmann::json& params, const
         server_->record_pseudoshare(work, pubkey_hash_, username_, is_dead);
 
     // Record in per-connection tracker (for VARDIFF adjustment + per-session stats)
-    hashrate_tracker_.record_mining_share_submission(vardiff_difficulty, true);
+    hashrate_tracker_.record_mining_share_submission(credited_difficulty, true);
 
     // Check if VARDIFF changed → send new difficulty AND new work to miner.
     // p2pool (stratum.py:594-595): after adjusting target, calls _send_work()

--- a/src/core/stratum_server.cpp
+++ b/src/core/stratum_server.cpp
@@ -972,6 +972,17 @@ nlohmann::json StratumSession::handle_submit(const nlohmann::json& params, const
     if (params.size() < 5 || !params[1].is_string() || !params[2].is_string()
         || !params[3].is_string() || !params[4].is_string()) {
         ++rejected_shares_;
+        // Rate-limited (≤ once / REJECT_LOG_INTERVAL / session) malformed-params
+        // reject diagnostic — a misbehaving client sending garbage submits is
+        // otherwise silent. INFO + throttled so it cannot flood.
+        {
+            auto now_lg = std::chrono::steady_clock::now();
+            if (now_lg - last_badparams_log_ >= REJECT_LOG_INTERVAL) {
+                last_badparams_log_ = now_lg;
+                LOG_INFO << "[Stratum] REJECT bad-params user=" << username_
+                         << " nparams=" << params.size();
+            }
+        }
         nlohmann::json response;
         response["id"] = request_id;
         response["result"] = false;
@@ -1166,6 +1177,18 @@ nlohmann::json StratumSession::handle_submit(const nlohmann::json& params, const
     // Above pool target → also a P2P share (broadcast to network).
     if (share_difficulty < required_difficulty) {
         ++rejected_shares_;
+        // Rate-limited (≤ once / REJECT_LOG_INTERVAL / session) low-diff reject
+        // diagnostic: surfaces the exact diff triplet so a firmware-grid gap
+        // between advertised/issued and required is visible in the field.
+        {
+            auto now_lg = std::chrono::steady_clock::now();
+            if (now_lg - last_lowdiff_log_ >= REJECT_LOG_INTERVAL) {
+                last_lowdiff_log_ = now_lg;
+                LOG_INFO << "[Stratum] REJECT low-diff user=" << username_ << " job=" << job_id
+                         << " hash_diff=" << share_difficulty << " required=" << required_difficulty
+                         << " issued=" << job.issued_difficulty << " vardiff=" << vardiff_difficulty;
+            }
+        }
         // Record rejection for VARDIFF timing (p2pool only records accepted,
         // but we need the timing signal to avoid stalling VARDIFF).
         hashrate_tracker_.record_mining_share_submission(vardiff_difficulty, false);

--- a/src/core/stratum_server.hpp
+++ b/src/core/stratum_server.hpp
@@ -192,6 +192,13 @@ class StratumSession : public std::enable_shared_from_this<StratumSession>
     std::chrono::steady_clock::time_point connected_at_;
     std::string session_id_;
 
+    // Reject-reason diagnostics throttle: emit the low-diff (P5) and
+    // malformed-params (P1) reject lines at most once per REJECT_LOG_INTERVAL
+    // per session so a rig hammering rejects cannot flood the log. INFO level.
+    std::chrono::steady_clock::time_point last_lowdiff_log_{};
+    std::chrono::steady_clock::time_point last_badparams_log_{};
+    static constexpr std::chrono::seconds REJECT_LOG_INTERVAL{5};
+
     // Merged mining: per-chain payout addresses set by the miner.
     std::map<uint32_t, std::string> merged_addresses_;
 

--- a/src/impl/dash/coin/rpc.cpp
+++ b/src/impl/dash/coin/rpc.cpp
@@ -444,6 +444,18 @@ nlohmann::json NodeRPC::getmininginfo()
     return CallAPIMethod("getmininginfo");
 }
 
+// Trivial tip probe -- `getbestblockhash` returns the best-block hash as a bare
+// JSON string. Returns "" if the daemon result is null/absent (never throws on
+// a well-formed-but-empty result; transport errors still propagate to the
+// caller, which swallows them). No dashd config change is required.
+std::string NodeRPC::getbestblockhash()
+{
+    auto result = CallAPIMethod("getbestblockhash");
+    if (result.is_string())
+        return result.get<std::string>();
+    return {};
+}
+
 // verbose: true -- json result, false -- hex-encode result;
 nlohmann::json NodeRPC::getblockheader(uint256 header, bool verbose)
 {

--- a/src/impl/dash/coin/rpc.hpp
+++ b/src/impl/dash/coin/rpc.hpp
@@ -126,6 +126,11 @@ public:
     nlohmann::json getnetworkinfo();
     nlohmann::json getblockchaininfo();
     nlohmann::json getmininginfo();
+    // Trivial tip probe: the current best-block hash as a hex string. Used by
+    // the fallback-arm tip poller (main_dash.cpp) to drive event-driven
+    // template refresh without waiting on the 30 s staleness TTL. Empty string
+    // on a null/absent result.
+    std::string getbestblockhash();
     // verbose: true -- json result, false -- hex-encode result;
     nlohmann::json getblockheader(uint256 header, bool verbose = true);
     // verbosity: 0 for hex-encoded data, 1 for a json object, and 2 for json object with transaction data

--- a/test/test_dash_stratum_work_source.cpp
+++ b/test/test_dash_stratum_work_source.cpp
@@ -741,6 +741,56 @@ TEST(DashStratumWorkSource, InvalidateTemplateCacheForcesRefetchAndBumpsGenerati
     EXPECT_EQ(fallback_calls, 2);
 }
 
+// Fallback-arm event-driven tip refresh pin: on the dashd-fallback arm the
+// template cache only re-sources on the 30 s staleness TTL, so a new DASH block
+// can leave miners hashing a stale tip for up to ~30 s (accepted pseudoshares
+// that can no longer win the current block). The run-path tip poller
+// (main_dash.cpp) closes that window by firing the SAME refresh pair on a
+// dashd best-block change that the embedded arm fires from its header-chain
+// tip-changed callback: invalidate_template_cache() + bump_work_generation(),
+// then notify_all() pushes a clean_jobs mining.notify. This KAT pins the
+// work-source contract that pair relies on: on a tip change the served template
+// must SWAP to the new tip (no stale-tip mining) AND the work generation must
+// bump (the clean_jobs/notify signal every session re-pulls on). Fallback arm
+// only: an UNPOPULATED coin-state, so get_work routes to the dashd fallback.
+TEST(DashStratumWorkSource, FallbackArmTipChangeRefreshesTemplateAndBumpsGeneration)
+{
+    Fixture fx(true);                       // unpopulated coin-state -> fallback arm
+    ASSERT_FALSE(fx.coin_state.populated());
+    auto ws = fx.make();
+
+    // Baseline: the fallback serves the pre-tip-change template, cached at the
+    // old tip. This is what an idle miner would keep hashing until the TTL.
+    auto tmpl_before = ws->get_current_work_template();
+    ASSERT_FALSE(tmpl_before.empty());
+    EXPECT_EQ(tmpl_before.value("previousblockhash", ""), std::string(kPrevHashHex));
+    const uint64_t gen_before = ws->get_work_generation();
+
+    // A new DASH block arrives: dashd's best-block hash changes. The fallback
+    // now sources a new-tip template (rotated prev + rotated payee), exactly as
+    // getbestblockhash flips for the run-path poller.
+    fx.fallback_work = rotated_work();
+
+    // The poller's refresh action on an observed tip change (the SAME pair the
+    // embedded header-chain tip-changed callback fires).
+    ws->invalidate_template_cache("kat: fallback-arm dashd best-block changed");
+    ws->bump_work_generation();
+
+    // (a) clean_jobs/notify signal: work generation advanced, so notify_all()
+    //     will push a fresh mining.notify to every session.
+    EXPECT_GT(ws->get_work_generation(), gen_before);
+
+    // (b) no more stale-tip mining: the next served template is the NEW tip,
+    //     not the cached pre-change one.
+    auto tmpl_after = ws->get_current_work_template();
+    ASSERT_FALSE(tmpl_after.empty());
+    EXPECT_EQ(tmpl_after.value("previousblockhash", ""),
+              std::string(kRotatedPrevHashHex));
+    EXPECT_NE(tmpl_after.value("previousblockhash", ""),
+              tmpl_before.value("previousblockhash", ""));
+    EXPECT_EQ(tmpl_after.value("height", 0u), 424243u);
+}
+
 // Fix 3 pin (work-source side of the zero-hash pre-auth job_0 defect): a
 // template with a zeroed prev is NOT mineable work — honest set-gap, never a
 // zero-prev job.

--- a/test/test_dash_work_source.cpp
+++ b/test/test_dash_work_source.cpp
@@ -14,6 +14,9 @@
 ///   4. viable but null mempool  -> fallback (defensive null-guard).
 
 #include <impl/dash/coin/work_source.hpp>
+#include <c2pool/hashrate/tracker.hpp>
+
+#include <cmath>
 
 #include <gtest/gtest.h>
 
@@ -128,4 +131,67 @@ TEST(DashWorkSource, NullMempoolRoutesFallback)
     EXPECT_EQ(sel.source, WorkSource::DashdFallback);
     EXPECT_FALSE(emb_ran);
     EXPECT_TRUE(fb_ran);
+}
+
+// ─── Firmware-grid vardiff quantization KAT (retention fix) ──────────────────
+// HashrateTracker::set_difficulty_from_hashrate must advertise ONLY power-of-two
+// difficulties, rounded DOWN from the estimator's ideal D. Many ASIC firmwares
+// round the advertised pool difficulty down to a power-of-two grid, mine that
+// easier target, and submit shares the pool's exact (higher) required difficulty
+// silently rejects. Advertising the largest power of two <= D makes
+// advertised == applied == required, and rounding DOWN keeps the accepted-share
+// cadence at or above target. Driven purely through the public API.
+namespace {
+// Oracle mirroring the documented estimator (port of p2pool-dash work.py):
+//   D_ideal = ewma_work * target / norm,  norm = tau*(1 - exp(-2*target/tau))
+// with all accepted shares recorded in the same wall-second (decay ~ 1), so
+// ewma_work == N*share_diff and the bias-corrected age floors at 2*target.
+double ideal_D(int n, double share_diff, double target, double tau) {
+    const double norm = tau * (1.0 - std::exp(-2.0 * target / tau));
+    return static_cast<double>(n) * share_diff * target / norm;
+}
+bool is_power_of_two(double d) {
+    if (!(d > 0.0)) return false;
+    const double l = std::log2(d);
+    return std::abs(l - std::floor(l)) < 1e-9;
+}
+} // namespace
+
+TEST(HashrateVardiffQuantize, AdvertisesPowerOfTwoRoundedDown)
+{
+    constexpr double kTarget = 10.0;   // set_target_time_per_mining_share
+    constexpr double kTau    = 90.0;   // vardiff_ewma_tau_ (fixed default)
+    constexpr int    kShares = 15;     // > warmup (4)
+    constexpr double kDiff   = 12.0;   // per accepted-share issued difficulty
+
+    c2pool::hashrate::HashrateTracker t;
+    t.set_difficulty_bounds(0.0005, 1e9);   // wide: exercise quantization, not clamp
+    t.set_target_time_per_mining_share(kTarget);
+    t.set_hashrate_vardiff(true);
+    t.enable_vardiff(true);
+
+    for (int i = 0; i < kShares; ++i)
+        t.record_mining_share_submission(kDiff, /*accepted=*/true);
+
+    const double q = t.get_current_difficulty();
+    const double D = ideal_D(kShares, kDiff, kTarget, kTau);
+
+    // (1) Advertised value is an exact power of two (timing-independent).
+    EXPECT_TRUE(is_power_of_two(q)) << "advertised diff not power-of-two: " << q;
+    // (2) Rounds DOWN — never advertise more than the estimator's ideal D.
+    EXPECT_LE(q, D) << "advertised " << q << " exceeds ideal D " << D;
+    // (3) It is THE largest such power of two (down one step, not two): 2q > D.
+    EXPECT_GT(2.0 * q, D) << "advertised " << q << " rounded down too far vs D " << D;
+}
+
+TEST(HashrateVardiffQuantize, QuantizationFormulaIsFloorLog2)
+{
+    // Pure-math intent check: for any ideal D, the advertised value is the
+    // largest power of two not exceeding D  (floor on the log2 grid).
+    for (double D : {0.75, 1.0, 1.5, 3.0, 63.9, 64.0, 100.4, 65535.0}) {
+        const double q = std::exp2(std::floor(std::log2(D)));
+        EXPECT_TRUE(is_power_of_two(q));
+        EXPECT_LE(q, D);
+        EXPECT_GT(2.0 * q, D);
+    }
 }

--- a/test/test_dash_work_source.cpp
+++ b/test/test_dash_work_source.cpp
@@ -184,6 +184,52 @@ TEST(HashrateVardiffQuantize, AdvertisesPowerOfTwoRoundedDown)
     EXPECT_GT(2.0 * q, D) << "advertised " << q << " rounded down too far vs D " << D;
 }
 
+// Floor-pinned KAT (F-1 regression): when a rig slows so far that the estimator's
+// ideal D falls BELOW min_difficulty_, the [min,max] clamp pins the raw diff at the
+// floor. DASH's min_difficulty_ (0.0005) is NOT itself on the power-of-two grid, so
+// the pre-fix re-floor (max(min_difficulty_, d)) advertised the raw 0.0005 and
+// re-opened the firmware reject gap at the floor. Post-fix the advertised value must
+// STILL be an exact power of two: the largest grid step <= the floor (0.00048828125),
+// i.e. at most one step below the configured floor, preserving the round-DOWN cadence.
+// This assertion would FAIL pre-fix. A prior higher diff is seeded via the hint so the
+// small (~2.3%) floor correction is not swallowed by the vardiff dead-band — this is
+// the realistic path (a rig that had been faster and then slowed below the floor).
+TEST(HashrateVardiffQuantize, FloorPinnedAdvertiseIsPowerOfTwo)
+{
+    constexpr double kTarget = 10.0;
+    constexpr double kTau    = 90.0;
+    constexpr int    kShares = 15;      // > warmup (4)
+    constexpr double kFloor  = 0.0005;  // DASH min_difficulty_ (not a power of two)
+    constexpr double kDiff   = 1e-5;    // tiny issued diff => ideal D below the floor
+
+    c2pool::hashrate::HashrateTracker t;
+    t.set_difficulty_bounds(kFloor, 1e9);
+    t.set_target_time_per_mining_share(kTarget);
+    t.set_hashrate_vardiff(true);
+    t.enable_vardiff(true);
+    // Rig was previously running well above the floor; the slow-down below the floor
+    // is what the fix must quantize (also keeps the correction outside the dead-band).
+    t.set_difficulty_hint(0.01);
+
+    for (int i = 0; i < kShares; ++i)
+        t.record_mining_share_submission(kDiff, /*accepted=*/true);
+
+    const double q = t.get_current_difficulty();
+    const double D = ideal_D(kShares, kDiff, kTarget, kTau);
+
+    // Precondition: this really is the floor-pinned regime (ideal D below the floor).
+    ASSERT_LT(D, kFloor) << "test mis-scaled: ideal D " << D << " not below floor";
+
+    // (1) Advertised value is an exact power of two even when floor-pinned
+    //     (pre-fix advertised the raw 0.0005 here and FAILED this assertion).
+    EXPECT_TRUE(is_power_of_two(q)) << "floor-pinned advertise not power-of-two: " << q;
+    // (2) It is the largest power of two <= the configured floor: one grid step below
+    //     0.0005 (0.00048828125), never rounding down more than a single step.
+    EXPECT_EQ(q, std::exp2(std::floor(std::log2(kFloor))));
+    EXPECT_LE(q, kFloor);
+    EXPECT_GT(2.0 * q, kFloor) << "floor-pinned advertise " << q << " rounded down too far";
+}
+
 TEST(HashrateVardiffQuantize, QuantizationFormulaIsFloorLog2)
 {
     // Pure-math intent check: for any ideal D, the advertised value is the


### PR DESCRIPTION
## DASH firmware-safe power-of-two vardiff quantization (v0.2.3.6)

Resolves the retention-critical ~25% (23–30% observed) share-reject rate on the live DASH mining hotel.

**Stacks on #770** (dash/tip-notify-fallback-arm / v0.2.3.5 tip-poll). Base is `master`; review only the two commits on top of #770. Merge #770 first.

### Root cause
#766's hashrate-vardiff advertises arbitrary real difficulties. ASIC firmware rounds the advertised pool difficulty DOWN to a power-of-two grid, mines that easier target, then submits shares between the rig's rounded target and the pool's exact required difficulty. Every such share is silently rejected at the P5 gate (`share_difficulty < required_difficulty`, `src/core/stratum_server.cpp`). ~28% expected — matches the field. Rejects are cosmetic for block-finding (the block-check passes by orders of magnitude) but trigger miner-firmware failover to backup pools, bleeding the tenant's hashrate.

### F1 — retention fix
In `HashrateTracker::set_difficulty_from_hashrate`, right after the min/max clamp, snap the advertised difficulty to `exp2(floor(log2(d)))` — the largest power of two not exceeding the estimator's ideal D — then re-floor at `min_difficulty_`. Advertised == applied == required, closing the firmware-grid reject window. Rounding DOWN keeps accepted-share cadence at/above target. `issued_difficulty` (frozen at job creation from `get_current_difficulty()`) and the advertised `set_difficulty` carry the same quantized value by construction. Bounds / target_time / deadband unchanged. DASH-scoped by construction (only the `use_hashrate_vardiff` path).

`set_difficulty_hint` / suggest-difficulty is intentionally left untouched: it is the miner-requested fixed-diff path, shared across all coins, and quantizing it would take the change out of DASH scope.

### F2 — observability
Rate-limited (≤ 1 / 5 s / session) INFO diagnostics at the P5 low-diff reject (logs `hash_diff / required / issued / vardiff`) and the P1 malformed-params reject. INFO + throttled so it cannot flood.

### KAT
Extends the already-allowlisted `test_dash_work_source` target (in build.yml `--target` on both Linux legs) with `HashrateVardiffQuantize.*`: drives the tracker through its public API and asserts the advertised difficulty is an exact power of two and never exceeds the estimator's ideal D (rounds down). Plus a pure-math floor-on-log2-grid check.

### Consensus-neutrality (pre-v36 vardiff rule)
Per-connection vardiff/stratum path only. `git diff origin/master | grep -iE 'get_share_bits|share_bits|share_target|DGW|oracle|payout|pplns'` over this change's code lines is EMPTY — the only matches in the full range are comments (a pre-existing context line and the KAT's own doc comment). PASS.

### Build / test
- conan (cached) + cmake reconfigure + `cmake --build build_ci --target c2pool-dash test_dash_work_source` → exit 0.
- KAT: 6/6 pass (`HashrateVardiffQuantize.AdvertisesPowerOfTwoRoundedDown`, `...QuantizationFormulaIsFloorLog2`, plus the 4 pre-existing DashWorkSource routing tests).
- Release tarball `c2pool-dash-0.2.3.6-linux-x86_64.tar.gz`, bundle self-reports `0.2.3.6`.

Not deployed; systemd drop-in not staged — integrator handles staging/deploy.
