### PR TITLE
dash(v36): wire the min-protocol AutoRatchet into the running node

### DIFF
--- a/src/impl/dash/config_pool.hpp
+++ b/src/impl/dash/config_pool.hpp
@@ -38,7 +38,31 @@ struct SharechainConfig
     static constexpr uint32_t REAL_CHAIN_LENGTH         = 4320;
     static constexpr uint32_t TARGET_LOOKBEHIND         = 100;
     static constexpr uint32_t SPREAD                    = 10;     // blocks
-    static constexpr uint32_t MINIMUM_PROTOCOL_VERSION  = 1700;   // protocol v1700 floor
+    static constexpr uint32_t MINIMUM_PROTOCOL_VERSION  = 1700;   // protocol v1700 floor (COLD accept-all; oracle dash.py:23)
+
+    // ── v36 crossing protocol versions (c2pool v36-native — NOT oracle-derived) ──
+    // The DASH oracle (frstrtr/p2pool-dash) has NO NEW_MINIMUM_PROTOCOL_VERSION and
+    // NO advertised-capability field; MINIMUM_PROTOCOL_VERSION is the static 1700 net
+    // constant. The two values below are c2pool v36-native choices made at the ratchet
+    // wire-up (dash/v36-ratchet-wireup) and are FLAGGED for integrator review:
+    //
+    //   NEW_MINIMUM_PROTOCOL_VERSION (3600): the RATCHET TARGET floor. It is the DASH
+    //     analog of ltc MINIMUM_PROTOCOL_VERSION=3301 / dgb SHARE_MINIMUM_PROTOCOL_VERSION
+    //     =3500 and matches the cross-coin v36 protocol lineage (ltc advertises 3600 for
+    //     v36 capability). The accept floor is NEVER set to this statically — that was the
+    //     v36 min-proto-3600 transition regression (a hard cut that blocked pre-v36 peers
+    //     from joining). It is reached ONLY by the work-weighted 95% AutoRatchet
+    //     (auto_ratchet.hpp), so a node still JOINS at the cold 1700 floor and ratchets UP.
+    //
+    //   ADVERTISED_PROTOCOL_VERSION (3600): the protocol version a v36-capable DASH node
+    //     puts on the wire in its version handshake. Required for ratchet COHERENCE: once
+    //     two nodes ratchet their accept floor to 3600 they must each advertise >= 3600 or
+    //     they would reject each other. Backward-compatible: legacy p2pool-dash peers accept
+    //     any version >= their own 1700 floor, so advertising 3600 pre-crossing rejects
+    //     nobody and does NOT prematurely negotiate the "actual" (v36) protocol path
+    //     (handle_version gates that on the accept floor being ratcheted, not on the advert).
+    static constexpr uint32_t NEW_MINIMUM_PROTOCOL_VERSION = 3600;  // AutoRatchet TARGET floor (v36-native)
+    static constexpr uint32_t ADVERTISED_PROTOCOL_VERSION  = 3600;  // v36-capability advert (>= target floor)
 
     // ---- testnet (networks/dash_testnet.py) ----
     static constexpr uint16_t TESTNET_P2P_PORT          = 18999;

--- a/src/impl/dash/node.cpp
+++ b/src/impl/dash/node.cpp
@@ -6,6 +6,7 @@
 #include <core/uint256.hpp>
 #include <core/common.hpp>
 #include <core/random.hpp>
+#include <core/version_gate.hpp>   // core::version_gate::V36_ACTIVATION_VERSION (ratchet v36 guard)
 
 #include <boost/asio/post.hpp>
 
@@ -382,6 +383,81 @@ void NodeImpl::shutdown_persistence()
     }
 }
 
+void NodeImpl::apply_min_protocol_ratchet()
+{
+    // Runtime wiring of the v36 accept-floor ratchet (auto_ratchet.hpp pure fns).
+    // Structural mirror of dgb::NodeImpl::apply_min_protocol_ratchet (src/impl/dgb/
+    // node.cpp:815), called at the same best-share-advance sites. Lifts the inbound
+    // P2P accept-floor 1700 -> 3600 once the best share's DESIRED version holds
+    // >= 95% of the work-weighted desired-version tally over the [9/10..10/10] window
+    // behind the best share's parent — the SAME window the 60% successor gate reads
+    // (version_negotiation.hpp). MUST run under the exclusive m_tracker_mutex.
+    const uint32_t target  = SharechainConfig::NEW_MINIMUM_PROTOCOL_VERSION;  // 3600
+    const uint32_t current =
+        m_runtime_min_protocol_version.load(std::memory_order_relaxed);
+    if (current >= target)                    // already ratcheted -> latched, no-op
+        return;
+    if (m_best_share_hash.IsNull() || !m_tracker.chain.contains(m_best_share_hash))
+        return;
+
+    // DASH DIVERGENCE FROM dgb (flagged for integrator): dgb keys the ratchet on the
+    // best share's static TYPE version (35 -> 36 after the format switch). DASH has
+    // NO v36 share TYPE — DashShare is permanently wire-type 16 — so "the best share
+    // is v36" is expressed by its m_desired_version VOTE reaching 36, and that vote is
+    // what the work-weighted tally is keyed by. Using the static type here would check
+    // weights[16] (always ~100% pre-crossing) and FALSELY lift the floor; using the
+    // vote checks weights[36], which is ~0 until the crossing actually happens.
+    int64_t best_desired = 0;
+    uint256 prev_hash;
+    m_tracker.chain.get_share(m_best_share_hash).invoke([&](auto* obj) {
+        best_desired = static_cast<int64_t>(obj->m_desired_version);
+        prev_hash    = obj->m_prev_hash;
+    });
+
+    // SAFETY GUARD (DASH-specific): only a best share that itself desires v36 can lift
+    // the floor. Without this, a fully-agreed pre-crossing chain (everyone desires 16)
+    // would satisfy weights[best_desired=16] >= 95% and spuriously ratchet to 3600,
+    // partitioning the pool from every legacy 1700 peer. dgb gets this for free because
+    // its target floor is reachable only once the best share TYPE is already 36.
+    if (best_desired < static_cast<int64_t>(
+            core::version_gate::V36_ACTIVATION_VERSION))               // < 36
+        return;
+
+    if (prev_hash.IsNull() || !m_tracker.chain.contains(prev_hash))
+        return;
+
+    const int32_t CL = static_cast<int32_t>(SharechainConfig::chain_length());
+    const int32_t parent_height = m_tracker.chain.get_height(prev_hash);
+
+    // Sample the SAME window the 60% switch gate reads (version_negotiation.hpp
+    // negotiation_window): anchor = nth_parent(parent, CHAIN_LENGTH*9/10),
+    // size = CHAIN_LENGTH/10.
+    const uint32_t window_start = (static_cast<uint32_t>(CL) * 9) / 10;
+    const uint32_t window_size  =  static_cast<uint32_t>(CL) / 10;
+    const uint256 anchor = m_tracker.chain.get_nth_parent_key(
+        prev_hash, static_cast<int32_t>(window_start));
+    auto weights = dash::version_negotiation::get_desired_version_weights(
+        m_tracker.chain, anchor, window_size);
+
+    // apply_min_protocol_ratchet_decision applies the full-window guard (parent_height
+    // >= CHAIN_LENGTH) the pure ratchet omits, then delegates to the floor-divided 95%
+    // work-weighted gate.
+    const uint32_t lifted = dash::apply_min_protocol_ratchet_decision(
+        parent_height, CL, weights, best_desired, current, target);
+    if (lifted != current) {
+        // Publish via the ATOMIC only. The IO-thread handshake (handle_version)
+        // reads m_runtime_min_protocol_version.load() and composes it with the
+        // operator knob (m_min_protocol_gate) via max(), so the ratcheted floor is
+        // enforced immediately with NO data race on the plain-uint32 gate member
+        // (which stays IO-thread-owned / operator-set).
+        m_runtime_min_protocol_version.store(lifted, std::memory_order_relaxed);
+        LOG_INFO << "[min-proto-ratchet] MINIMUM_PROTOCOL_VERSION " << current
+                 << " -> " << lifted << " (>=95% window work desires v"
+                 << best_desired << ", best="
+                 << m_best_share_hash.GetHex().substr(0, 16) << ")";
+    }
+}
+
 void NodeImpl::run_think()
 {
     // Serialize: only one think() in flight (compute pool has 1 thread).
@@ -426,6 +502,7 @@ void NodeImpl::run_think()
             if (!result.best.IsNull()) {
                 best_changed = (m_best_share_hash != result.best);
                 m_best_share_hash = result.best;
+                apply_min_protocol_ratchet();  // v36 accept-floor ratchet (dgb node.cpp:1526 parallel)
             }
             publish_snapshot();
 
@@ -773,8 +850,10 @@ void NodeImpl::clean_tracker()
                                           /*previous_block=*/uint256(),
                                           /*bits=*/0, bootstrap);
             m_last_top5_heads = std::move(result.top5_heads);
-            if (!result.best.IsNull())
+            if (!result.best.IsNull()) {
                 m_best_share_hash = result.best;
+                apply_min_protocol_ratchet();  // v36 accept-floor ratchet (dgb node.cpp:1905 parallel)
+            }
             flush_verified_to_leveldb();
         }
 
@@ -893,6 +972,7 @@ void NodeImpl::clean_tracker()
             if (!result.best.IsNull()) {
                 clean_best_changed = (m_best_share_hash != result.best);
                 m_best_share_hash = result.best;
+                apply_min_protocol_ratchet();  // v36 accept-floor ratchet (dgb node.cpp:2077 parallel)
             }
             publish_snapshot();
             flush_verified_to_leveldb();

--- a/src/impl/dash/node.hpp
+++ b/src/impl/dash/node.hpp
@@ -22,6 +22,8 @@
 #include "share_tracker.hpp"
 #include "peer.hpp"
 #include "min_protocol_gate.hpp"
+#include "auto_ratchet.hpp"          // dash::apply_min_protocol_ratchet_decision (v36 accept-floor ratchet)
+#include "version_negotiation.hpp"   // dash::version_negotiation::get_desired_version_weights (ratchet window)
 #include "messages.hpp"
 #include "coin/transaction.hpp"
 #include "coin/node_coin_state.hpp"       // dash::coin::NodeCoinState (node-held embedded bundle)
@@ -36,6 +38,7 @@
 #include <boost/asio/thread_pool.hpp>
 #include <boost/asio/steady_timer.hpp>
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <functional>
@@ -207,6 +210,17 @@ protected:
     // Best-share election result — published by run_think() on the compute
     // thread under m_tracker_mutex (mirrors btc::NodeImpl::m_best_share_hash).
     uint256 m_best_share_hash;
+
+    // ── v36 min-protocol accept-floor ratchet (#643/#646, mirrors dgb) ──────────
+    // Runtime P2P accept-floor, seeded from the COLD config floor (1700, accept-all)
+    // and lifted to NEW_MINIMUM_PROTOCOL_VERSION (3600) by apply_min_protocol_ratchet()
+    // once the work-weighted desired-version tally over the [9/10..10/10] window behind
+    // the best share holds >= 95% for v36. Mutated ONLY on the compute thread under the
+    // exclusive m_tracker_mutex (same sites as m_best_share_hash); it drives the LIVE
+    // m_min_protocol_gate.min_version so the handshake reception reflects the ratchet.
+    std::atomic<uint32_t> m_runtime_min_protocol_version{
+        SharechainConfig::MINIMUM_PROTOCOL_VERSION};
+
     // De-dup set for broadcast_share (hashes already relayed to peers).
     std::set<uint256> m_shared_share_hashes;
     // Hashes of the CURRENT template's txs registered in m_known_txs by
@@ -465,7 +479,7 @@ public:
     void send_version(peer_ptr peer)
     {
         auto rmsg = dash::message_version::make_raw(
-            SharechainConfig::MINIMUM_PROTOCOL_VERSION,  // oracle p2p VERSION (1700 lineage)
+            SharechainConfig::ADVERTISED_PROTOCOL_VERSION,  // advertise v36 capability (3600); >= ratchet target so ratcheted peers accept us. Legacy peers (floor 1700) accept any >=1700, so backward-compatible.
             1,                                           // services
             addr_t{1, peer->addr()},                     // addr_to (the remote)
             addr_t{1, NetService{"0.0.0.0", SharechainConfig::p2p_port()}},  // addr_from
@@ -530,9 +544,16 @@ public:
             return std::nullopt;
 
         // #646 min-protocol ratchet -- LIVE discrimination. Throwing here makes
-        // the NodeBridge close the connection (pool/node.hpp handle()). At the
-        // default floor (1700) every real DASH peer is admitted (accept-all).
-        if (m_min_protocol_gate.rejects(msg->m_version))
+        // the NodeBridge close the connection (pool/node.hpp handle()). The
+        // effective floor is the MAX of the operator knob (m_min_protocol_gate,
+        // IO-thread-owned) and the auto-ratchet floor (m_runtime_min_protocol_version,
+        // lifted 1700 -> 3600 on the compute thread by apply_min_protocol_ratchet).
+        // Reading the atomic here is race-free; at the cold default (both 1700) every
+        // real DASH peer is admitted (accept-all).
+        const uint32_t effective_floor = std::max(
+            m_min_protocol_gate.min_version,
+            m_runtime_min_protocol_version.load(std::memory_order_relaxed));
+        if (msg->m_version < effective_floor)
             throw std::runtime_error("peer protocol below min-protocol floor");
 
         peer->m_nonce = msg->m_nonce;
@@ -560,8 +581,8 @@ public:
         // peers negotiate the actual (v36) protocol; otherwise legacy (parity
         // with the ltc reference, which returns legacy unconditionally).
         const bool ratcheted =
-            m_min_protocol_gate.min_version > SharechainConfig::MINIMUM_PROTOCOL_VERSION;
-        return (ratcheted && msg->m_version >= m_min_protocol_gate.min_version)
+            effective_floor > SharechainConfig::MINIMUM_PROTOCOL_VERSION;
+        return (ratcheted && msg->m_version >= effective_floor)
                    ? pool::PeerConnectionType::actual
                    : pool::PeerConnectionType::legacy;
     }
@@ -605,6 +626,18 @@ public:
     /// re-broadcast the new head. Serialized via m_think_running.
     void run_think();
     void drain_pending_adds();
+
+    /// v36 accept-floor AutoRatchet — runtime wiring of the pure decision in
+    /// auto_ratchet.hpp (mirrors dgb::NodeImpl::apply_min_protocol_ratchet, the
+    /// three best-share-advance call sites in src/impl/dgb/node.cpp). Over the
+    /// [CHAIN_LENGTH*9/10 .. CHAIN_LENGTH] window behind the best share's parent
+    /// — the SAME window the 60% successor gate reads — lift the P2P accept floor
+    /// 1700 -> 3600 once >= 95% of the work-weighted desired-version tally desires
+    /// v36. Latched (never lowers), full-window-guarded (never lifts on a partial
+    /// window), and DASH-specific keyed on the best share's m_desired_version (DASH
+    /// has no v36 share TYPE — the vote carries v36-ness). MUST be called under the
+    /// exclusive m_tracker_mutex. Body in node.cpp.
+    void apply_min_protocol_ratchet();
 
     /// Periodic maintenance (btc node.cpp:1878-2173 / p2pool node.py:355-402
     /// clean_tracker port): think + eat stale heads + drop tails beyond

--- a/test/test_dash_auto_ratchet.cpp
+++ b/test/test_dash_auto_ratchet.cpp
@@ -29,9 +29,14 @@
 // becomes a NOT_BUILT sentinel that silently passes.
 
 #include <impl/dash/auto_ratchet.hpp>
+#include <impl/dash/config_pool.hpp>            // COLD 1700 / NEW_MINIMUM 3600 crossing constants
+#include <impl/dash/min_protocol_gate.hpp>      // MinProtocolGate — LIVE handshake accept gate
+#include <impl/dash/version_activation_latch.hpp> // VOTING->ACTIVATED->CONFIRMED state machine
+#include <impl/dash/version_negotiation.hpp>    // 60% weighted successor gate
 
 #include <core/uint256.hpp>  // uint288
 
+#include <algorithm>
 #include <gtest/gtest.h>
 
 namespace {
@@ -176,4 +181,132 @@ TEST(DashAutoRatchetWiring, AlreadyAtTargetShortCircuits) {
     auto w = std::map<uint64_t, uint288>{{36, u(100)}};
     EXPECT_EQ(dash::apply_min_protocol_ratchet_decision(CL, CL, w, 36, TARGET, TARGET), TARGET);
     EXPECT_EQ(dash::apply_min_protocol_ratchet_decision(0,  CL, w, 36, TARGET, TARGET), TARGET);
+}
+
+// ============================================================================
+// RUNTIME WIRE-UP KATs (branch dash/v36-ratchet-wireup). The pure decision above
+// is proven; these pin the node.cpp consumer's COMPOSED behavior:
+//   * the crossing constants are the DASH-native 1700 -> 3600 pair,
+//   * the LIVE handshake gate (MinProtocolGate + the atomic-runtime max() the node
+//     composes in handle_version) enforces the crossing floor AND stays backward-
+//     compatible pre-crossing,
+//   * the node's DASH-specific best_desired>=36 SAFETY GUARD is necessary (the raw
+//     decision would false-lift on a fully-agreed pre-crossing chain),
+//   * the VOTING->ACTIVATED->CONFIRMED latch is driven by the SAME 95% verdict,
+//   * the 60% weighted successor gate (the mint<->accept coupling the crossing rides).
+// ============================================================================
+
+// The wire-up constants ARE the DASH-native crossing pair (config_pool.hpp SSOT).
+TEST(DashRatchetCrossing, ConstantsAreDashNativeCrossingPair) {
+    EXPECT_EQ(dash::SharechainConfig::MINIMUM_PROTOCOL_VERSION,     COLD);    // 1700 cold
+    EXPECT_EQ(dash::SharechainConfig::NEW_MINIMUM_PROTOCOL_VERSION, TARGET);  // 3600 ratchet target
+    EXPECT_EQ(dash::SharechainConfig::ADVERTISED_PROTOCOL_VERSION,  TARGET);  // 3600 v36 advert >= target
+}
+
+// The effective floor the node's handle_version composes: max(operator knob,
+// atomic auto-ratchet floor). Mirrors src/impl/dash/node.hpp handle_version.
+static uint32_t effective_floor(uint32_t operator_knob, uint32_t runtime_ratchet) {
+    return std::max(operator_knob, runtime_ratchet);
+}
+
+// BACKWARD-COMPAT (item 6d): PRE-crossing, both the operator knob and the runtime
+// ratchet sit at the cold 1700 floor, so a legacy DASH peer advertising 1700 — and a
+// v36-capable peer advertising 3600 — are BOTH admitted. The node must still JOIN at
+// the current protocol; the crossing is opt-in via the ratchet, never a hard cut.
+TEST(DashRatchetCrossing, PreCrossingAdmitsLegacyAndV36Peers) {
+    dash::MinProtocolGate gate;  // default operator knob = 1700
+    const uint32_t runtime = COLD;  // m_runtime_min_protocol_version seed (pre-ratchet)
+    const uint32_t floor = effective_floor(gate.min_version, runtime);
+    EXPECT_EQ(floor, COLD);
+    EXPECT_GE(1700u, floor);            // legacy peer advertising 1700 admitted
+    EXPECT_TRUE(1700u >= floor);
+    EXPECT_TRUE(3600u >= floor);        // v36-advertising peer admitted too
+    EXPECT_FALSE(1699u >= floor);       // genuinely below-floor peer still rejected
+}
+
+// CROSSING-FLOOR ENFORCEMENT (item 6c): once apply_min_protocol_ratchet lifts the
+// atomic runtime floor to 3600, the composed effective floor rejects legacy 1700
+// peers and admits only >= 3600 (v36) peers — the crossing has partitioned legacy off.
+TEST(DashRatchetCrossing, PostCrossingRejectsLegacyAdmitsV36) {
+    dash::MinProtocolGate gate;  // operator knob still cold 1700 (auto-ratchet drives it)
+    const uint32_t runtime = TARGET;  // ratchet has lifted the atomic to 3600
+    const uint32_t floor = effective_floor(gate.min_version, runtime);
+    EXPECT_EQ(floor, TARGET);
+    EXPECT_FALSE(1700u >= floor);       // legacy 1700 peer now REJECTED
+    EXPECT_FALSE(3599u >= floor);       // just-below-target rejected
+    EXPECT_TRUE(3600u >= floor);        // v36 peer admitted
+}
+
+// SAFETY GUARD RATIONALE (DASH divergence from dgb): DASH has no v36 share TYPE, so
+// the node keys the ratchet on the best share's m_desired_version VOTE and guards
+// best_desired >= 36. This test proves the guard is NECESSARY: on a fully-agreed
+// PRE-crossing chain everybody desires v16, and the raw decision keyed on 16 WOULD
+// lift the floor to 3600 (partitioning the pool). The node's >=36 guard is what
+// prevents that; keyed on 36 (the crossing vote) with a 100%-v16 window stays COLD.
+TEST(DashRatchetCrossing, GuardPreventsPreCrossingFalseLift) {
+    auto all_v16 = std::map<uint64_t, uint288>{{16, u(100)}};  // unanimous pre-crossing
+    // Raw decision keyed on the CURRENT vote (16): weights[16]=100% -> WOULD lift.
+    EXPECT_EQ(dash::apply_min_protocol_ratchet_decision(CL, CL, all_v16, 16, COLD, TARGET),
+              TARGET);  // <-- the danger the node's best_desired>=36 guard blocks
+    // Keyed on the crossing vote (36): weights[36]=0 -> stays COLD (correct).
+    EXPECT_EQ(dash::apply_min_protocol_ratchet_decision(CL, CL, all_v16, 36, COLD, TARGET),
+              COLD);
+}
+
+// STATE MACHINE (item 6a): the VOTING->ACTIVATED->CONFIRMED latch is driven by the
+// SAME 95% work-weighted verdict the accept-floor ratchet uses. We synthesize a
+// window that has crossed (v36 holds >=95% by work), feed the ratchet's own verdict
+// into the latch, and assert the progression + the pre-confirmation revert.
+TEST(DashRatchetCrossing, LatchDrivenByRatchetVerdict) {
+    namespace val = dash::version_activation_latch;
+    // Crossed window: v36 heavy (work 96), v16 light (work 4) -> 96 >= 100*95//100=95.
+    auto crossed = std::map<uint64_t, uint288>{{36, u(96)}, {16, u(4)}};
+    const bool crossed_active =
+        dash::apply_min_protocol_ratchet_decision(CL, CL, crossed, 36, COLD, TARGET) == TARGET;
+    EXPECT_TRUE(crossed_active);  // the ratchet fires -> the latch's "active" input
+
+    val::ActivationLatch latch;
+    latch.confirm_span = 10;  // short span so the KAT need not walk 2*CHAIN_LENGTH
+    EXPECT_EQ(latch.state, val::LatchState::Voting);
+
+    latch.observe(crossed_active, /*height=*/100);
+    EXPECT_EQ(latch.state, val::LatchState::Activated);
+    EXPECT_EQ(latch.activated_height, 100u);
+
+    // Sustained past the span -> CONFIRMED (irreversible).
+    latch.observe(crossed_active, /*height=*/111);  // 111-100=11 >= span 10
+    EXPECT_EQ(latch.state, val::LatchState::Confirmed);
+    latch.observe(false, /*height=*/200);  // a later dip cannot un-confirm
+    EXPECT_EQ(latch.state, val::LatchState::Confirmed);
+
+    // A pre-confirmation dip reverts ACTIVATED -> VOTING (crossing was not real).
+    val::ActivationLatch latch2;
+    latch2.confirm_span = 10;
+    latch2.observe(true, 100);
+    EXPECT_EQ(latch2.state, val::LatchState::Activated);
+    latch2.observe(false, 105);  // dip before the span elapsed
+    EXPECT_EQ(latch2.state, val::LatchState::Voting);
+}
+
+// 60% WEIGHTED SUCCESSOR GATE (item 6b): the mint<->accept coupling the crossing
+// rides. successor_switch_allowed consumes the WORK-WEIGHTED tally (not a flat count)
+// and clears at exactly 60% by work. This is the gate a 36-desiring share must pass.
+TEST(DashRatchetCrossing, SuccessorGateIsSixtyPercentByWork) {
+    namespace vn = dash::version_negotiation;
+    // Exactly 60% by work -> allowed (have*100 >= total*60, 60*100 >= 100*60).
+    EXPECT_TRUE(vn::successor_switch_allowed({{16, u(40)}, {36, u(60)}}, 36));
+    // Just below 60% -> rejected.
+    EXPECT_FALSE(vn::successor_switch_allowed({{16, u(41)}, {36, u(59)}}, 36));
+    // Empty tally -> rejected (no support window).
+    EXPECT_FALSE(vn::successor_switch_allowed({}, 36));
+}
+
+// The successor gate is WORK-weighted, not flat-count: one heavy v36 share outvotes
+// many tiny v16 shares. Guards the same F10 divergence the accept-floor ratchet does.
+TEST(DashRatchetCrossing, SuccessorGateIsWeightedNotFlatCount) {
+    namespace vn = dash::version_negotiation;
+    // 1 heavy v36 (work 70) vs 9 tiny v16 (work 1 each = 9). By WORK: 70/79 = 88% -> pass.
+    // By flat COUNT it would be 1/10 = 10% -> fail. Proves the weighting.
+    auto weights = std::map<uint64_t, uint288>{{36, u(70)}, {16, u(9)}};
+    EXPECT_TRUE(vn::successor_switch_allowed(weights, 36));
 }


### PR DESCRIPTION
## Summary — CONSENSUS-BEARING, do-not-merge (integrator review)

Wires the PRESENT-BUT-INERT DASH v36 min-protocol AutoRatchet
(`src/impl/dash/auto_ratchet.hpp` — pure fns with ZERO node consumer) into the
running node, mirroring the LIVE DGB reference
`dgb::NodeImpl::apply_min_protocol_ratchet()` (src/impl/dgb/node.cpp:815) and its
three best-share-advance call sites (dgb node.cpp:1526 / 1905 / 2077).

The ratchet becomes **wired but gated**: it has a live node consumer driving the
live handshake gate, but stays DORMANT (no false lift) until DASH shares desire v36.

## Files / functions wired (with DGB parallels)

| DASH | DGB parallel |
|---|---|
| `node.cpp apply_min_protocol_ratchet()` | `dgb/node.cpp:815` |
| call site 1 — `run_think()` compute phase | `dgb/node.cpp:1526` |
| call site 2 — periodic-clean step-1 think | `dgb/node.cpp:1905` |
| call site 3 — re-score-after-prune think | `dgb/node.cpp:2077` |
| `node.hpp` atomic `m_runtime_min_protocol_version{1700}` | `dgb/node.hpp:76` |
| `config_pool.hpp NEW_MINIMUM_PROTOCOL_VERSION` | `dgb SHARE_MINIMUM_PROTOCOL_VERSION` |

`handle_version()` now enforces the effective floor `max(operator-knob
m_min_protocol_gate, atomic runtime ratchet)` (race-free: compute thread writes the
atomic, IO thread reads it). `send_version()` advertises `ADVERTISED_PROTOCOL_VERSION`.

## Chosen crossing values (FLAGGED — no DASH oracle source)

- **Target floor / advert = 3600.** DASH oracle has NO `NEW_MINIMUM_PROTOCOL_VERSION`;
  3600 is a c2pool v36-native choice — DASH analog of ltc 3301 / dgb 3500, matching the
  cross-coin v36 lineage (ltc advertises 3600). Already the established stand-in in the
  pre-existing `test_dash_auto_ratchet` KAT (COLD=1700 / TARGET=3600).
- Cold accept floor **stays 1700**. The floor is NEVER set to 3600 statically (that was
  the v36 min-proto-3600 transition regression / hard cut). It is reached ONLY by the
  work-weighted 95% ratchet → node JOINS at 1700 and ratchets UP. **No hard cut.**

## DASH divergence from the DGB shape (REVIEW)

DGB keys on the best share's static TYPE version. **DASH has no v36 share TYPE**
(`DashShare` is permanently wire-type 16; v36-ness lives in the `m_desired_version`
VOTE). So this wire-up keys `best_version` on `m_desired_version` **and** adds a
`best_desired >= 36` SAFETY GUARD. Without the guard, a fully-agreed pre-crossing chain
(everyone desires v16) satisfies `weights[16] >= 95%` and would FALSELY ratchet to 3600,
partitioning the pool. KAT `GuardPreventsPreCrossingFalseLift` pins this.

## COMBINED donation — NOT reachable by the ratchet alone (IMPORTANT)

Task item 4 asked to confirm the COMBINED P2SH donation activates. Honest finding: it
**does not**, and not because of the ratchet. `params.donation_script_func` (v36 →
COMBINED) has **zero consumers** — both DASH coinbase paths
(`coinbase_builder.hpp compute_dash_payouts`, `share_check.hpp` write_txout) HARDCODE the
pre-v36 P2PKH `dash::DONATION_SCRIPT`. DGB instead calls
`params.donation_script_func(share_version)` (dgb share_check.hpp:241/1100). The SSOT
COMBINED script itself IS correct (share_check.hpp:130 → `core::donation::COMBINED_DONATION_SCRIPT`,
the 1-of-2 forrestv+dev P2SH, verified by `DashConformanceCombinedDonation.MatchesCrossCoinSSOT`);
only the SELECTION is missing. Rewiring it changes coinbase output bytes → separate
consensus-bearing follow-on, flagged not silently done.

## Other remaining crossing gaps (flagged, out of scope)

- `desired_version` mint flip to 36 is blocked by a bootstrap paradox: the 60% weighted
  successor gate (`verify_version_transition`, live via verify_share) rejects the first
  36-desiring share for lack of 60% support → window never fills. Needs a coordinated
  activation design.
- `current_share_version` left at 16 — bumping it hard-cuts the v36 payout arm for ALL
  shares (coinbase_builder.hpp:126). Must not flip.

## Tests

Extended the already-allowlisted `test_dash_auto_ratchet` (no build.yml change → avoids
the #769 new-target trap). Proves: crossing-floor enforcement, pre-crossing backward-compat,
the best_desired>=36 guard, VOTING→ACTIVATED→CONFIRMED latch driven by the ratchet verdict,
and the 60% work-weighted successor gate (weighted ≠ flat-count).

- `test_dash_auto_ratchet` 21/21 (9 pure + 5 wiring + 7 new)
- Regression: `test_dash_min_protocol_gate` 3/3, `test_dash_version_activation_latch` 8/8,
  `test_dash_conformance` 56/56, `test_dash_node_reception_wire` 21/21,
  `test_dash_p2p_node` 16/16, `test_dash_node` 8/8
- `c2pool-dash` binary builds + links (conan + cmake, Release)

Design writeup staged to frstrtr/the `docs/c2pool-dash-v36-ratchet-wireup.md`
(not pushed, per preservation rule).
