### PR TITLE
dash: v36 share type (Phase A) — define + parse, dormant, byte-standardized

### DIFF
--- a/src/impl/dash/share.hpp
+++ b/src/impl/dash/share.hpp
@@ -70,4 +70,95 @@ struct DashShare : chain::BaseShare<uint256, 16>
     NetService peer_addr;
 };
 
+// ═══════════════════════════════════════════════════════════════════════════
+// DASH v36 share (wire-type 36) — PHASE A: DEFINED + PARSEABLE, DORMANT.
+//
+// Byte-standardized to the cross-coin v36 share shape (the v36-standardize-for-
+// v37 goal: uniform structs). The STANDARDIZED PREFIX (min_header .. message_data)
+// is byte-for-byte the NON-SEGWIT v36 layout — i.e. the BCH v36 MergedMiningShare
+// shape (src/impl/bch/share.hpp), which is the LTC/DGB v36 layout MINUS the
+// Optional(segwit_data) slot. BCH is the reference here (not LTC/DGB directly)
+// because DASH, like BCH, is non-segwit: BCH's SEGWIT_ACTIVATION_VERSION==0 makes
+// is_segwit_activated(36) false, so a non-segwit v36 coin OMITS segwit_data. This
+// is the ESTABLISHED cross-coin convention, NOT a DASH divergence.
+//
+// Field categories (operator 3-bucket / v36-standardize model):
+//   * SHARED / STANDARDIZED (Bucket-2, byte-identical cross-coin): min_header,
+//     prev_hash, coinbase, nonce, pubkey_hash + pubkey_type, subsidy(VarInt),
+//     donation, stale_info, desired_version(VarInt) [THE version-vote], the merged
+//     fields (merged_addresses / merged_coinbase_info / merged_payout_hash — held
+//     EMPTY/INERT since DASH is standalone X11 with no AuxPoW child, exactly as a
+//     non-merged ltc/dgb/bch coin populates them), far_share_hash, max_bits, bits,
+//     timestamp, absheight, abswork(AbsworkV36Format), ref_merkle_link,
+//     last_txout_nonce, hash_link(V36HashLinkType), merkle_link, message_data.
+//   * DASH-SPECIFIC SUFFIX (Bucket-3 / coin-specific, the FLAGGED divergence):
+//     coinbase_payload, payment_amount, packed_payments, coinbase_payload_outer.
+//     DASH masternode / DIP4-CbTx consensus data with NO cross-coin equivalent;
+//     required so Phase C can reconstruct+verify a real DASH coinbase from the
+//     share (a non-merged coin has no analogue). Appended AFTER the standardized
+//     message_data so the ENTIRE standardized prefix stays byte-identical to
+//     bch/ltc/dgb. See the design note + PR body for the review decision.
+//
+// The version-vote (m_desired_version) is what #774's AutoRatchet reads to
+// activate; Phase A only DEFINES this type (dormant, unminted). current_share_version
+// stays 16, so nothing mints a v36 share and the live 1700 accept path is
+// byte-unchanged (Phase C flips activation via the ratchet, NOT here).
+struct DashV36Share : chain::BaseShare<uint256, 36>
+{
+    // ── min_header (SmallBlockHeaderType — coin block header, standardized) ──
+    bitcoin_family::coin::SmallBlockHeaderType m_min_header;
+
+    // ── share_data (STANDARDIZED v36) ──
+    // NOTE: m_prev_hash is inherited from chain::BaseShare<uint256,36>.
+    BaseScript m_coinbase;          // coinbase scriptSig (VarStr)
+    uint32_t m_nonce{0};            // share nonce
+    uint160 m_pubkey_hash;          // v36 address (IntType(160))
+    uint8_t m_pubkey_type{0};       // v36: 0=P2PKH, 1=P2WPKH, 2=P2SH (DASH always 0/P2PKH)
+    uint64_t m_subsidy{0};          // v36: VarInt-encoded
+    uint16_t m_donation{0};         // donation (bps)
+    StaleInfo m_stale_info{StaleInfo::none};
+    uint64_t m_desired_version{36}; // THE version-vote (VarInt)
+
+    // v36 merged-mining address entries — EMPTY/INERT on DASH (no AuxPoW child).
+    std::vector<v36::MergedAddressEntry> m_merged_addresses;
+
+    // ── share_info (non-share_data, STANDARDIZED v36) ──
+    uint256 m_far_share_hash;
+    uint32_t m_max_bits{0};
+    uint32_t m_bits{0};
+    uint32_t m_timestamp{0};
+    uint32_t m_absheight{0};
+    uint128 m_abswork;              // v36: AbsworkV36Format (VarInt low64) on the wire
+
+    // v36 merged-mining coinbase verification — EMPTY/INERT on DASH.
+    std::vector<v36::MergedCoinbaseEntry> m_merged_coinbase_info;
+    uint256 m_merged_payout_hash;   // zero = none (INERT on DASH)
+
+    // ── remaining STANDARDIZED v36 share fields ──
+    v36::MerkleLink m_ref_merkle_link;
+    uint64_t m_last_txout_nonce{0};
+    v36::V36HashLinkType m_hash_link;   // v36: state + extra_data(VarStr) + length(VarInt)
+    v36::MerkleLink m_merkle_link;
+    BaseScript m_message_data;          // v36 messaging hook — EMPTY on DASH in Phase A (Phase B)
+
+    // ── DASH-SPECIFIC SUFFIX (FLAGGED divergence — see struct header) ──
+    BaseScript m_coinbase_payload;          // DIP3/DIP4 CBTX inner (PossiblyNone '', VarStr)
+    uint64_t m_payment_amount{0};           // total masternode payment amount
+    std::vector<PackedPayment> m_packed_payments; // masternode/superblock/platform
+    BaseScript m_coinbase_payload_outer;    // outer coinbase_payload_data (appended to hash_link)
+
+    // ── carried-but-UNSERIALIZED members (v36 wire omits tx_info; kept so a
+    //    future promotion into the live variant matches DashShare's field
+    //    surface for the shared generic-invoke call sites in node.cpp) ──
+    std::vector<uint256> m_new_transaction_hashes;
+    std::vector<uint64_t> m_transaction_hash_refs;
+
+    // Ingestion metadata — not on the wire (parity with DashShare::peer_addr).
+    NetService peer_addr;
+
+    DashV36Share() {}
+    DashV36Share(const uint256& hash, const uint256& prev_hash)
+        : chain::BaseShare<uint256, 36>(hash, prev_hash) {}
+};
+
 } // namespace dash

--- a/src/impl/dash/share_chain.hpp
+++ b/src/impl/dash/share_chain.hpp
@@ -11,6 +11,7 @@
 #include <sharechain/share.hpp>
 #include <sharechain/sharechain.hpp>
 #include <core/target_utils.hpp>
+#include <core/version_gate.hpp>   // SSOT: core::version_gate::is_v36_active
 
 #include <chrono>
 
@@ -57,6 +58,17 @@ struct DashFormatter
     template <typename StreamType, typename ShareT>
     static void Read(StreamType& is, ShareT* share)
     {
+        // V36 shares (wire-type 36, dash::DashV36Share) use the standardized
+        // cross-coin v36 layout. Compile-time dispatch: the v16 body below is
+        // instantiated ONLY for DashShare (version 16), so it stays byte-
+        // unchanged; the v36 body is instantiated ONLY for DashV36Share.
+        if constexpr (core::version_gate::is_v36_active(ShareT::version))
+        {
+            ReadV36(is, share);
+            return;
+        }
+        else
+        {
         // ── min_header ──
         is >> share->m_min_header;
 
@@ -136,11 +148,19 @@ struct DashFormatter
 
         // ── coinbase_payload (outer) ──
         is >> share->m_coinbase_payload_outer;  // PossiblyNone('', VarStr)
+        } // else (v16)
     }
 
     template <typename StreamType, typename ShareT>
     static void Write(StreamType& os, const ShareT* share)
     {
+        if constexpr (core::version_gate::is_v36_active(ShareT::version))
+        {
+            WriteV36(os, share);
+            return;
+        }
+        else
+        {
         os << share->m_min_header;
         os << share->m_prev_hash;
         os << share->m_coinbase;
@@ -180,6 +200,124 @@ struct DashFormatter
         os << share->m_hash_link;
         os << share->m_merkle_link.m_branch;
         os << share->m_coinbase_payload_outer;
+        } // else (v16)
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // V36 (wire-type 36) read/write — STANDARDIZED cross-coin non-segwit v36
+    // layout (the bch/ltc/dgb MergedMiningShare shape MINUS segwit_data) plus
+    // the DASH-specific suffix. Field ORDER and ENCODINGS mirror the BCH v36
+    // Formatter (src/impl/bch/share.hpp) byte-for-byte for the standardized
+    // prefix; the suffix (coinbase_payload / payment_amount / packed_payments /
+    // coinbase_payload_outer) rides AFTER message_data. Pinned by the byte-
+    // parity + round-trip KATs in test/test_dash_v36_share.cpp.
+    // ═══════════════════════════════════════════════════════════════════════
+    template <typename StreamType, typename ShareT>
+    static void ReadV36(StreamType& is, ShareT* share)
+    {
+        // ── min_header ──
+        is >> share->m_min_header;
+
+        // ── share_data (standardized v36) ──
+        is >> share->m_prev_hash;           // PossiblyNone(0, IntType(256))
+        is >> share->m_coinbase;            // VarStr
+        is >> share->m_nonce;               // uint32
+        is >> share->m_pubkey_hash;         // v36 address: IntType(160)
+        is >> share->m_pubkey_type;         // v36: IntType(8)
+        { uint64_t sub; ::Unserialize(is, VarInt(sub)); share->m_subsidy = sub; } // v36: VarInt
+        is >> share->m_donation;            // uint16
+        { uint8_t si; is >> si; share->m_stale_info = static_cast<dash::StaleInfo>(si); }
+        { uint64_t dv; ::Unserialize(is, VarInt(dv)); share->m_desired_version = dv; } // version-vote
+
+        // NO segwit_data (non-segwit coin — BCH convention).
+
+        // v36 merged_addresses (empty/inert on DASH).
+        is >> share->m_merged_addresses;
+
+        // NO tx_info (only serialized for version < 34).
+
+        is >> share->m_far_share_hash;      // PossiblyNone(0, IntType(256))
+        is >> share->m_max_bits;            // uint32
+        is >> share->m_bits;                // uint32
+        is >> share->m_timestamp;           // uint32
+        is >> share->m_absheight;           // uint32
+        ::Unserialize(is, Using<v36::AbsworkV36Format>(share->m_abswork)); // v36: VarInt low64
+
+        // v36 merged_coinbase_info + merged_payout_hash (empty/zero-inert on DASH).
+        is >> share->m_merged_coinbase_info;
+        is >> share->m_merged_payout_hash;
+
+        // ref_merkle_link (MERKLE_LINK_SMALL — index omitted).
+        { ParamPackStream ps{v36::MERKLE_LINK_SMALL, is}; ::Unserialize(ps, share->m_ref_merkle_link); }
+
+        is >> share->m_last_txout_nonce;    // uint64
+        is >> share->m_hash_link;           // V36HashLinkType
+
+        { ParamPackStream ps{v36::MERKLE_LINK_SMALL, is}; ::Unserialize(ps, share->m_merkle_link); }
+
+        is >> share->m_message_data;        // v36 messaging hook (empty on DASH Phase A)
+
+        // ── DASH-specific suffix (FLAGGED divergence) ──
+        is >> share->m_coinbase_payload;    // PossiblyNone('', VarStr)
+        is >> share->m_payment_amount;      // uint64
+        {
+            uint64_t count;
+            ::Unserialize(is, VarInt(count));
+            if (count > MAX_PAYMENTS_PER_SHARE)
+                throw std::ios_base::failure("packed_payments count exceeds cap");
+            share->m_packed_payments.resize(count);
+            for (uint64_t i = 0; i < count; ++i) {
+                BaseScript payee_bs;
+                is >> payee_bs;
+                share->m_packed_payments[i].m_payee.assign(
+                    payee_bs.m_data.begin(), payee_bs.m_data.end());
+                is >> share->m_packed_payments[i].m_amount;
+            }
+        }
+        is >> share->m_coinbase_payload_outer; // PossiblyNone('', VarStr)
+    }
+
+    template <typename StreamType, typename ShareT>
+    static void WriteV36(StreamType& os, const ShareT* share)
+    {
+        os << share->m_min_header;
+        os << share->m_prev_hash;
+        os << share->m_coinbase;
+        os << share->m_nonce;
+        os << share->m_pubkey_hash;
+        os << share->m_pubkey_type;
+        ::Serialize(os, VarInt(share->m_subsidy));
+        os << share->m_donation;
+        { uint8_t si = static_cast<uint8_t>(share->m_stale_info); os << si; }
+        ::Serialize(os, VarInt(share->m_desired_version));
+        os << share->m_merged_addresses;
+        os << share->m_far_share_hash;
+        os << share->m_max_bits;
+        os << share->m_bits;
+        os << share->m_timestamp;
+        os << share->m_absheight;
+        ::Serialize(os, Using<v36::AbsworkV36Format>(share->m_abswork));
+        os << share->m_merged_coinbase_info;
+        os << share->m_merged_payout_hash;
+        { ParamPackStream ps{v36::MERKLE_LINK_SMALL, os}; ::Serialize(ps, share->m_ref_merkle_link); }
+        os << share->m_last_txout_nonce;
+        os << share->m_hash_link;
+        { ParamPackStream ps{v36::MERKLE_LINK_SMALL, os}; ::Serialize(ps, share->m_merkle_link); }
+        os << share->m_message_data;
+        // ── DASH-specific suffix (FLAGGED divergence) ──
+        os << share->m_coinbase_payload;
+        os << share->m_payment_amount;
+        {
+            uint64_t count = share->m_packed_payments.size();
+            ::Serialize(os, VarInt(count));
+            for (auto& pay : share->m_packed_payments) {
+                BaseScript bs;
+                bs.m_data.assign(pay.m_payee.begin(), pay.m_payee.end());
+                os << bs;
+                os << pay.m_amount;
+            }
+        }
+        os << share->m_coinbase_payload_outer;
     }
 };
 
@@ -187,6 +325,22 @@ struct DashFormatter
 // For Dash, there's only one share version (v16).
 
 using ShareType = chain::ShareVariants<DashFormatter, DashShare>;
+
+// ── PHASE A: v36 share-type dispatch (DORMANT) ───────────────────────────────
+// The live `ShareType` above is DELIBERATELY left as {DashShare} only, so the
+// live accept / mint / store / send paths (node.cpp) stay byte-unchanged and
+// keep compiling — several consume the share via generic-invoke lambdas that
+// call DashShare-concrete helpers (e.g. share_init_verify(const DashShare&) at
+// node.cpp:64). Promoting DashV36Share into the live variant requires guarding
+// those call sites with `if constexpr (std::is_same_v<share_t, DashShare>)`, and
+// is the FIRST wiring step of Phase B/C — NOT Phase A.
+//
+// This SEPARATE variant proves the v36 wire type round-trips through the REAL
+// chain::ShareVariants dispatch machinery (load map keyed by version 36 ->
+// DashV36Share, DashFormatter::ReadV36/WriteV36). It is what the round-trip KAT
+// exercises. Nothing mints a v36 share (current_share_version stays 16), so the
+// type is parseable/mintable-in-principle yet dormant until Phase-C activation.
+using V36ShareType = chain::ShareVariants<DashFormatter, DashV36Share>;
 
 // ── Load share from wire format ──────────────────────────────────────────────
 
@@ -196,6 +350,16 @@ inline ShareType load_share(chain::RawShare& rshare, NetService peer_addr)
     auto share = ShareType::load(rshare.type, stream);
     // Propagate ingestion source to the share so the dashboard / audit
     // trail can show which peer gossiped it. Matches LTC share.hpp:260.
+    share.ACTION({ obj->peer_addr = peer_addr; });
+    return share;
+}
+
+// PHASE A v36 load helper (dispatch-by-version-36). Mirrors load_share but over
+// the dormant V36ShareType variant; used by the round-trip KAT.
+inline V36ShareType load_v36_share(chain::RawShare& rshare, NetService peer_addr)
+{
+    auto stream = rshare.contents.as_stream();
+    auto share = V36ShareType::load(rshare.type, stream);
     share.ACTION({ obj->peer_addr = peer_addr; });
     return share;
 }

--- a/src/impl/dash/share_types.hpp
+++ b/src/impl/dash/share_types.hpp
@@ -65,4 +65,152 @@ struct PackedPayment
     }
 };
 
+// ═══════════════════════════════════════════════════════════════════════════
+// V36 SHARED (Bucket-2 / category-2) serialization types.
+//
+// These are BYTE-FOR-BYTE COPIES of the cross-coin v36 share-format types that
+// already live, duplicated per-coin, in src/impl/{ltc,dgb,bch,btc}/share_types.hpp
+// (V36HashLinkType, MergedAddressEntry, MergedCoinbaseEntry, AbsworkV36Format,
+// the param-based MerkleLink + MERKLE_LINK_SMALL). The v36 share revision has NO
+// single shared header — every coin carries its own byte-identical copy and the
+// ONLY shared symbol is core::version_gate::is_v36_active. DASH conforms to that
+// established pattern here: the copies below MUST stay identical to the other
+// coins (this is the whole v36-standardize-for-v37 goal — uniform structs). Any
+// drift from the ltc/dgb/bch shape is a cross-coin consensus divergence.
+//
+// Kept in a nested `dash::v36` namespace so the param-based v36 MerkleLink does
+// NOT collide with the pre-existing branch-only `dash::MerkleLink` used by the
+// live v16 DashShare (which stays byte-unchanged). The two MerkleLink encodings
+// are byte-equivalent for the share-level links (both emit just the branch
+// vector: dash::MerkleLink never serializes index; dash::v36::MerkleLink under
+// MERKLE_LINK_SMALL has allow_index=false, so index is likewise omitted).
+//
+// DASH is standalone X11 with NO AuxPoW child, so the MERGED-mining types
+// (MergedAddressEntry / MergedCoinbaseEntry) are carried for STRUCTURAL
+// uniformity only and are always populated EMPTY on a DASH v36 share — exactly
+// how a non-merged ltc/dgb/bch coin populates them (empty vector => VarInt(0)).
+namespace v36
+{
+
+struct MerkleLinkParams
+{
+    const bool allow_index;
+
+    SER_PARAMS_OPFUNC
+};
+
+constexpr static MerkleLinkParams MERKLE_LINK_SMALL {.allow_index = false};
+constexpr static MerkleLinkParams MERKLE_LINK_FULL  {.allow_index = true};
+
+// Param-based MerkleLink (ltc/dgb/bch v36 shape). Under MERKLE_LINK_SMALL the
+// index is NOT serialized (allow_index=false) — byte-identical to the branch-
+// only encoding the live v16 dash::MerkleLink uses for the share-level links.
+struct MerkleLink
+{
+    std::vector<uint256> m_branch;
+    uint32_t m_index{0};
+
+    MerkleLink() { }
+
+    template<typename StreamType>
+    void UnserializeMerkleLink(StreamType& s, const MerkleLinkParams& params)
+    {
+        s >> m_branch;
+        if (params.allow_index)
+            s >> m_index;
+    }
+
+    template<typename StreamType>
+    void SerializeMerkleLink(StreamType& s, const MerkleLinkParams& params) const
+    {
+        s << m_branch;
+        if (params.allow_index)
+            s << m_index;
+    }
+
+    template <typename StreamType>
+    inline void Serialize(StreamType& os) const
+    {
+        SerializeMerkleLink(os, os.GetParams());
+    }
+
+    template <typename StreamType>
+    inline void Unserialize(StreamType& is)
+    {
+        UnserializeMerkleLink(is, is.GetParams());
+    }
+};
+
+// V36 hash link — extra_data becomes VarStr (was FixedStr(0) pre-V36).
+struct V36HashLinkType
+{
+    FixedStrType<32> m_state;
+    BaseScript m_extra_data;     // VarStr in V36
+    uint64_t m_length;
+
+    C2POOL_SERIALIZE_METHODS(V36HashLinkType) { READWRITE(obj.m_state, obj.m_extra_data, VarInt(obj.m_length)); }
+};
+
+// V36 merged mining: per-chain address entry.
+struct MergedAddressEntry
+{
+    uint32_t m_chain_id;
+    BaseScript m_script;
+
+    C2POOL_SERIALIZE_METHODS(MergedAddressEntry) { READWRITE(obj.m_chain_id, obj.m_script); }
+};
+
+// V36 merged mining: per-chain coinbase verification entry.
+struct MergedCoinbaseEntry
+{
+    uint32_t m_chain_id;
+    uint64_t m_coinbase_value;
+    uint32_t m_block_height;
+    FixedStrType<80> m_block_header;
+    MerkleLink m_coinbase_merkle_link;
+    BaseScript m_coinbase_script;  // V36: actual scriptSig (allows custom tags + THE state_root)
+
+    template <typename StreamType>
+    void Serialize(StreamType& os) const
+    {
+        ::Serialize(os, m_chain_id);
+        ::Serialize(os, Using<CompactFormat>(m_coinbase_value));
+        ::Serialize(os, Using<CompactFormat>(m_block_height));
+        ::Serialize(os, m_block_header);
+        ParamPackStream pstream{MERKLE_LINK_SMALL, os};
+        ::Serialize(pstream, m_coinbase_merkle_link);
+        ::Serialize(os, m_coinbase_script);
+    }
+
+    template <typename StreamType>
+    void Unserialize(StreamType& is)
+    {
+        ::Unserialize(is, m_chain_id);
+        ::Unserialize(is, Using<CompactFormat>(m_coinbase_value));
+        ::Unserialize(is, Using<CompactFormat>(m_block_height));
+        ::Unserialize(is, m_block_header);
+        ParamPackStream pstream{MERKLE_LINK_SMALL, is};
+        ::Unserialize(pstream, m_coinbase_merkle_link);
+        ::Unserialize(is, m_coinbase_script);
+    }
+};
+
+// V36: abswork is VarInt-encoded on the wire but stored as uint128.
+struct AbsworkV36Format
+{
+    template <typename StreamType>
+    static void Write(StreamType& os, const uint128& value)
+    {
+        WriteCompactSize(os, value.GetLow64());
+    }
+
+    template <typename StreamType>
+    static void Read(StreamType& is, uint128& value)
+    {
+        value = uint128(ReadCompactSize(is, false));
+    }
+};
+
+} // namespace v36
+
 } // namespace dash

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -391,12 +391,18 @@ if (BUILD_TESTING AND GTest_FOUND)
     # sharereply's shares (RawShare round-trip, child->parent order) insert +
     # verify and ROOT a previously-unrooted live-pushed tip. Same allowlisted
     # target (proven pattern), no build.yml change.
+    # test_dash_v36_share.cpp (Phase A DASH v36 share-type): byte-parity of the
+    # standardized cross-coin v36 prefix vs the non-segwit (BCH) v36 shape,
+    # round-trip through the version-36 ShareVariants dispatch, merged-fields-
+    # inert convention, and v16 backward-compat. Same allowlisted target (proven
+    # pattern), no build.yml change (avoids the #769 new-target/allowlist trap).
     add_executable(test_dash_share_hash_link
         test_dash_share_hash_link.cpp
         test_dash_share_producer.cpp
         test_dash_share_producer_bind.cpp
         test_dash_mint_runloop.cpp
-        test_dash_share_download.cpp)
+        test_dash_share_download.cpp
+        test_dash_v36_share.cpp)
     target_link_libraries(test_dash_share_hash_link PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core

--- a/test/test_dash_v36_share.cpp
+++ b/test/test_dash_v36_share.cpp
@@ -1,0 +1,343 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// DASH v36 share-type KATs (Phase A: DEFINE + PARSE, dormant).
+//
+// CONSENSUS-BEARING. This pins the DASH v36 share wire format (dash::DashV36Share,
+// wire-type 36). Four guarantees:
+//
+//   1. BYTE-PARITY of the STANDARDIZED prefix (min_header .. message_data) vs the
+//      cross-coin non-segwit v36 share shape. The reference is the BCH v36
+//      MergedMiningShare Formatter (src/impl/bch/share.hpp:152-252), i.e. the
+//      LTC/DGB v36 layout MINUS the Optional(segwit_data) slot — BCH, like DASH,
+//      is non-segwit (SEGWIT_ACTIVATION_VERSION==0 => is_segwit_activated(36)
+//      false), so the segwit_data field is omitted. The expected prefix is
+//      rebuilt field-by-field in the BCH order using the SAME core pack
+//      primitives, then frozen as a golden hex regression sentinel — a field-
+//      order or encoding drift (missing pubkey_type, fixed-uint64 subsidy instead
+//      of VarInt, fixed-uint128 abswork instead of AbsworkV36Format, segwit slot
+//      leaking in, etc.) fails the test.
+//
+//   2. ROUND-TRIP through the REAL chain::ShareVariants dispatch: pack -> RawShare
+//      (type 36) -> dash::load_v36_share -> field equality -> re-pack byte-
+//      identical. Proves version-36 dispatch (LoadMethods[36] -> DashV36Share,
+//      DashFormatter::ReadV36/WriteV36) round-trips.
+//
+//   3. MERGED fields are INERT and follow the non-merged cross-coin convention:
+//      empty merged_addresses / merged_coinbase_info => a single VarInt(0) byte;
+//      zero merged_payout_hash => 32 zero bytes; empty message_data => VarInt(0).
+//      Identical to how a standalone (non-merged) ltc/dgb/bch coin populates them.
+//
+//   4. BACKWARD-COMPAT: the pre-existing v16 DashShare wire format is byte-
+//      UNCHANGED by the DashFormatter version-branch refactor (v16 round-trips
+//      through the live ShareType::load(16); v16 vs v36 of the same logical
+//      inputs are DISTINCT and keep the v16-specific ordering).
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/share_chain.hpp>   // DashFormatter, ShareType, V36ShareType, load_share, load_v36_share
+#include <impl/dash/share.hpp>         // dash::DashShare, dash::DashV36Share
+#include <impl/dash/share_types.hpp>   // dash::v36::* shared types, dash::PackedPayment
+
+#include <sharechain/share.hpp>        // chain::RawShare
+#include <core/netaddress.hpp>
+#include <core/pack.hpp>
+#include <core/pack_types.hpp>
+#include <core/uint256.hpp>
+
+#include <cstdio>
+#include <cstdint>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::string to_hex(const std::span<const unsigned char> bytes)
+{
+    static const char* h = "0123456789abcdef";
+    std::string out;
+    out.reserve(bytes.size() * 2);
+    for (unsigned char b : bytes) { out.push_back(h[b >> 4]); out.push_back(h[b & 0xf]); }
+    return out;
+}
+
+std::string pack_hex(const PackStream& ps)
+{
+    auto& m = const_cast<PackStream&>(ps);
+    return to_hex(std::span<const unsigned char>(
+        reinterpret_cast<const unsigned char*>(m.data()), m.size()));
+}
+
+// A canonical, fully-populated DASH v36 share. Distinctive scalar values so a
+// misordered/misencoded field is visible; merged fields left EMPTY (DASH is
+// standalone X11 — no AuxPoW child), DASH suffix populated.
+dash::DashV36Share make_canonical_v36()
+{
+    dash::DashV36Share s;
+    s.m_min_header.m_version = 2;
+    s.m_min_header.m_previous_block.SetHex(
+        "00000000000000000000000000000000000000000000000000000000000000aa");
+    s.m_min_header.m_timestamp = 0x11223344;
+    s.m_min_header.m_bits = 0x1e0ffff0;
+    s.m_min_header.m_nonce = 0x55667788;
+
+    s.m_prev_hash.SetHex(
+        "0000000000000000000000000000000000000000000000000000000000000001");
+    s.m_coinbase = BaseScript(std::vector<unsigned char>{0xab, 0xcd});
+    s.m_nonce = 0x0a0b0c0d;
+    s.m_pubkey_hash.SetHex("00000000000000000000000000000000deadbeef");
+    s.m_pubkey_type = 0;                 // DASH always P2PKH
+    s.m_subsidy = 5000000000ULL;         // > 2^32 => 9-byte VarInt
+    s.m_donation = 0x1234;
+    s.m_stale_info = dash::StaleInfo::none;
+    s.m_desired_version = 36;            // the version-vote
+
+    // merged_addresses: EMPTY (inert)
+    s.m_far_share_hash.SetHex(
+        "0000000000000000000000000000000000000000000000000000000000000002");
+    s.m_max_bits = 0x1e0fffff;
+    s.m_bits = 0x1d00ffff;
+    s.m_timestamp = 0x99aabbcc;
+    s.m_absheight = 0x00010203;
+    s.m_abswork = uint128(0x0102030405060708ULL);
+
+    // merged_coinbase_info: EMPTY (inert); merged_payout_hash: zero (inert)
+    s.m_last_txout_nonce = 0xdeadbeefcafef00dULL;
+    s.m_hash_link.m_state.m_data.assign(32, 0x00);
+    for (int i = 0; i < 32; ++i) s.m_hash_link.m_state.m_data[i] = static_cast<unsigned char>(i);
+    s.m_hash_link.m_extra_data = BaseScript(std::vector<unsigned char>{0xaa, 0xbb, 0xcc});
+    s.m_hash_link.m_length = 128;
+    // ref_merkle_link / merkle_link: empty branches
+    // message_data: EMPTY (Phase A — messaging is Phase B)
+
+    // ── DASH suffix ──
+    s.m_coinbase_payload = BaseScript(std::vector<unsigned char>{0x01, 0x02});
+    s.m_payment_amount = 0x00000000abcdef01ULL;
+    s.m_packed_payments.push_back(dash::PackedPayment{"!6a0401020304", 12345});
+    s.m_coinbase_payload_outer = BaseScript(std::vector<unsigned char>{0x02, 0x01, 0x02});
+    return s;
+}
+
+// Independently rebuild the STANDARDIZED prefix (min_header .. message_data) in
+// the BCH v36 Formatter field order, using the same core primitives. This is the
+// byte-parity reference: if DashFormatter::WriteV36 drifts from the standardized
+// order/encoding this reconstruction diverges.
+PackStream expected_standardized_prefix(const dash::DashV36Share& s)
+{
+    PackStream os;
+    os << s.m_min_header;                                     // bch:154
+    os << s.m_prev_hash << s.m_coinbase << s.m_nonce;         // bch:156-160
+    os << s.m_pubkey_hash;                                    // bch:165 (v36 address)
+    os << s.m_pubkey_type;                                    // bch:166 (v36)
+    ::Serialize(os, VarInt(s.m_subsidy));                     // bch:180 (v36 VarInt)
+    os << s.m_donation;                                       // bch:188
+    { uint8_t si = static_cast<uint8_t>(s.m_stale_info); os << si; } // bch:189 EnumType<IntType<8>>
+    ::Serialize(os, VarInt(s.m_desired_version));             // bch:190 (version-vote)
+    // NO segwit_data (non-segwit — bch:194 is_segwit_activated(36)==false)
+    os << s.m_merged_addresses;                               // bch:202 (v36)
+    // NO tx_info (version >= 34)
+    os << s.m_far_share_hash << s.m_max_bits << s.m_bits
+       << s.m_timestamp << s.m_absheight;                     // bch:210-215
+    ::Serialize(os, Using<dash::v36::AbsworkV36Format>(s.m_abswork)); // bch:221 (v36)
+    os << s.m_merged_coinbase_info;                           // bch:231 (v36)
+    os << s.m_merged_payout_hash;                             // bch:232 (v36)
+    { ParamPackStream ps{dash::v36::MERKLE_LINK_SMALL, os}; ::Serialize(ps, s.m_ref_merkle_link); } // bch:237
+    os << s.m_last_txout_nonce;                               // bch:239
+    os << s.m_hash_link;                                      // bch:241 (V36HashLinkType)
+    { ParamPackStream ps{dash::v36::MERKLE_LINK_SMALL, os}; ::Serialize(ps, s.m_merkle_link); } // bch:244
+    os << s.m_message_data;                                   // bch:250 (v36)
+    return os;
+}
+
+// Serialize the DASH suffix alone (everything WriteV36 emits after message_data).
+PackStream expected_dash_suffix(const dash::DashV36Share& s)
+{
+    PackStream os;
+    os << s.m_coinbase_payload;
+    os << s.m_payment_amount;
+    {
+        uint64_t count = s.m_packed_payments.size();
+        ::Serialize(os, VarInt(count));
+        for (auto& pay : s.m_packed_payments) {
+            BaseScript bs; bs.m_data.assign(pay.m_payee.begin(), pay.m_payee.end());
+            os << bs; os << pay.m_amount;
+        }
+    }
+    os << s.m_coinbase_payload_outer;
+    return os;
+}
+
+// Full v36 wire bytes via the production formatter.
+PackStream pack_v36(const dash::DashV36Share& s)
+{
+    PackStream os;
+    dash::DashFormatter::Write(os, &s);   // version-branch -> WriteV36
+    return os;
+}
+
+} // namespace
+
+// ── 1. BYTE-PARITY: standardized prefix matches the BCH v36 field order ──────
+TEST(DashV36ShareByteParity, StandardizedPrefixMatchesCrossCoinV36Shape)
+{
+    auto s = make_canonical_v36();
+
+    PackStream full = pack_v36(s);
+    PackStream expect_prefix = expected_standardized_prefix(s);
+    PackStream expect_suffix = expected_dash_suffix(s);
+
+    const std::string full_hex   = pack_hex(full);
+    const std::string prefix_hex = pack_hex(expect_prefix);
+    const std::string suffix_hex = pack_hex(expect_suffix);
+
+    // The production wire = standardized prefix ++ DASH suffix, in that order.
+    ASSERT_EQ(full_hex, prefix_hex + suffix_hex)
+        << "DashFormatter::WriteV36 must emit the standardized cross-coin v36 "
+           "prefix (bch/ltc/dgb non-segwit shape) followed by the DASH suffix";
+
+    // The standardized prefix is the consensus-critical cross-coin part.
+    EXPECT_EQ(full_hex.substr(0, prefix_hex.size()), prefix_hex)
+        << "standardized v36 prefix byte-parity";
+}
+
+// FROZEN GOLDEN regression sentinel for the standardized prefix + full wire.
+// Captured from DashFormatter::WriteV36 on make_canonical_v36(); any change to
+// the v36 wire layout must update these deliberately (a consensus boundary).
+TEST(DashV36ShareByteParity, FrozenGoldenWire)
+{
+    auto s = make_canonical_v36();
+    const std::string prefix_hex = pack_hex(expected_standardized_prefix(s));
+    const std::string full_hex   = pack_hex(pack_v36(s));
+
+    EXPECT_EQ(prefix_hex, std::string(
+        "02aa0000000000000000000000000000000000000000000000000000000000000044332211f0ff0f1e88776655010000000000000000000000000000000000000000000000000000000000000002abcd0d0c0b0aefbeadde0000000000000000000000000000000000ff00f2052a0100000034120024000200000000000000000000000000000000000000000000000000000000000000ffff0f1effff001dccbbaa9903020100ff0807060504030201000000000000000000000000000000000000000000000000000000000000000000000df0fecaefbeadde000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f03aabbcc800000"))
+        << "standardized v36 prefix golden drift";
+    EXPECT_EQ(full_hex, std::string(
+        "02aa0000000000000000000000000000000000000000000000000000000000000044332211f0ff0f1e88776655010000000000000000000000000000000000000000000000000000000000000002abcd0d0c0b0aefbeadde0000000000000000000000000000000000ff00f2052a0100000034120024000200000000000000000000000000000000000000000000000000000000000000ffff0f1effff001dccbbaa9903020100ff0807060504030201000000000000000000000000000000000000000000000000000000000000000000000df0fecaefbeadde000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f03aabbcc80000002010201efcdab00000000010d21366130343031303230333034393000000000000003020102"))
+        << "full v36 wire golden drift";
+}
+
+// ── 2. ROUND-TRIP through real version-36 dispatch ───────────────────────────
+TEST(DashV36ShareRoundTrip, ThroughVersion36Dispatch)
+{
+    auto s = make_canonical_v36();
+    PackStream wire = pack_v36(s);
+
+    // Wrap as a RawShare(type=36) and load via the real ShareVariants dispatch.
+    chain::RawShare rshare(uint64_t{36}, wire);
+    ASSERT_EQ(rshare.type, 36u);
+    auto loaded = dash::load_v36_share(rshare, NetService{"test", 0});
+
+    loaded.invoke([&](auto* obj) {
+        using T = std::remove_pointer_t<decltype(obj)>;
+        static_assert(std::is_same_v<T, dash::DashV36Share>,
+                      "type-36 wire must dispatch to DashV36Share");
+        EXPECT_EQ(obj->m_min_header.m_version, s.m_min_header.m_version);
+        EXPECT_EQ(obj->m_min_header.m_bits, s.m_min_header.m_bits);
+        EXPECT_EQ(obj->m_prev_hash, s.m_prev_hash);
+        EXPECT_EQ(obj->m_coinbase.m_data, s.m_coinbase.m_data);
+        EXPECT_EQ(obj->m_nonce, s.m_nonce);
+        EXPECT_EQ(obj->m_pubkey_hash, s.m_pubkey_hash);
+        EXPECT_EQ(obj->m_pubkey_type, s.m_pubkey_type);
+        EXPECT_EQ(obj->m_subsidy, s.m_subsidy);
+        EXPECT_EQ(obj->m_donation, s.m_donation);
+        EXPECT_EQ(obj->m_desired_version, s.m_desired_version);
+        EXPECT_EQ(obj->m_far_share_hash, s.m_far_share_hash);
+        EXPECT_EQ(obj->m_max_bits, s.m_max_bits);
+        EXPECT_EQ(obj->m_bits, s.m_bits);
+        EXPECT_EQ(obj->m_timestamp, s.m_timestamp);
+        EXPECT_EQ(obj->m_absheight, s.m_absheight);
+        EXPECT_EQ(obj->m_abswork.GetLow64(), s.m_abswork.GetLow64());
+        EXPECT_TRUE(obj->m_merged_addresses.empty());
+        EXPECT_TRUE(obj->m_merged_coinbase_info.empty());
+        EXPECT_EQ(obj->m_merged_payout_hash, s.m_merged_payout_hash);
+        EXPECT_EQ(obj->m_last_txout_nonce, s.m_last_txout_nonce);
+        EXPECT_EQ(obj->m_hash_link.m_state.m_data, s.m_hash_link.m_state.m_data);
+        EXPECT_EQ(obj->m_hash_link.m_extra_data.m_data, s.m_hash_link.m_extra_data.m_data);
+        EXPECT_EQ(obj->m_hash_link.m_length, s.m_hash_link.m_length);
+        // DASH suffix
+        EXPECT_EQ(obj->m_coinbase_payload.m_data, s.m_coinbase_payload.m_data);
+        EXPECT_EQ(obj->m_payment_amount, s.m_payment_amount);
+        ASSERT_EQ(obj->m_packed_payments.size(), s.m_packed_payments.size());
+        EXPECT_EQ(obj->m_packed_payments[0].m_payee, s.m_packed_payments[0].m_payee);
+        EXPECT_EQ(obj->m_packed_payments[0].m_amount, s.m_packed_payments[0].m_amount);
+        EXPECT_EQ(obj->m_coinbase_payload_outer.m_data, s.m_coinbase_payload_outer.m_data);
+    });
+
+    // Re-serialize the loaded share: must be byte-identical to the original wire.
+    PackStream re;
+    loaded.Serialize(re);
+    EXPECT_EQ(pack_hex(re), pack_hex(wire)) << "v36 re-serialization must round-trip";
+
+    // Dispatch reports version 36.
+    EXPECT_EQ(loaded.version(), 36);
+}
+
+// ── 3. MERGED fields inert => non-merged cross-coin convention ───────────────
+TEST(DashV36ShareMergedInert, EmptyMergedFieldsFollowNonMergedConvention)
+{
+    auto s = make_canonical_v36();
+    ASSERT_TRUE(s.m_merged_addresses.empty());
+    ASSERT_TRUE(s.m_merged_coinbase_info.empty());
+    ASSERT_TRUE(s.m_merged_payout_hash.IsNull());
+
+    // An empty vector serializes as a single VarInt(0) == 0x00 byte; a zero
+    // uint256 payout hash as 32 zero bytes. Same as a standalone ltc/dgb/bch coin.
+    PackStream a; a << s.m_merged_addresses;
+    EXPECT_EQ(pack_hex(a), "00");
+    PackStream c; c << s.m_merged_coinbase_info;
+    EXPECT_EQ(pack_hex(c), "00");
+    PackStream p; p << s.m_merged_payout_hash;
+    EXPECT_EQ(pack_hex(p), std::string(64, '0'));
+    PackStream m; m << s.m_message_data;
+    EXPECT_EQ(pack_hex(m), "00") << "empty message_data (Phase A) == VarInt(0)";
+}
+
+// ── 4. version-vote (desired_version) is a VarInt the ratchet can read ────────
+TEST(DashV36ShareVersionVote, DesiredVersionRidesAsVarInt)
+{
+    auto s = make_canonical_v36();
+    s.m_desired_version = 36;
+    PackStream a; ::Serialize(a, VarInt(s.m_desired_version));
+    EXPECT_EQ(pack_hex(a), "24");   // 36 == 0x24, single-byte CompactSize
+
+    s.m_desired_version = 300;      // multi-byte CompactSize boundary
+    PackStream b; ::Serialize(b, VarInt(s.m_desired_version));
+    EXPECT_EQ(pack_hex(b), "fd2c01");
+}
+
+// ── 5. BACKWARD-COMPAT: v16 DashShare wire is UNCHANGED and DISTINCT ─────────
+TEST(DashV16BackwardCompat, V16RoundTripsAndIsDistinctFromV36)
+{
+    // Minimal v16 share.
+    dash::DashShare v16;
+    v16.m_min_header.m_version = 2;
+    v16.m_min_header.m_bits = 0x1e0ffff0;
+    v16.m_prev_hash.SetHex(
+        "0000000000000000000000000000000000000000000000000000000000000001");
+    v16.m_coinbase = BaseScript(std::vector<unsigned char>{0xab, 0xcd});
+    v16.m_nonce = 0x0a0b0c0d;
+    v16.m_pubkey_hash.SetHex("00000000000000000000000000000000deadbeef");
+    v16.m_subsidy = 5000000000ULL;
+    v16.m_donation = 0x1234;
+    v16.m_desired_version = 16;
+    v16.m_bits = 0x1d00ffff;
+    v16.m_hash_link.m_state.m_data.assign(32, 0x00);
+    v16.m_hash_link.m_length = 0;
+
+    // v16 packs via the live ShareType formatter (else-branch) and round-trips
+    // through the live LoadMethods[16] dispatch — byte-unchanged by the refactor.
+    PackStream w16; dash::DashFormatter::Write(w16, &v16);
+    chain::RawShare r16(uint64_t{16}, w16);
+    auto loaded16 = dash::load_share(r16, NetService{"test", 0});
+    EXPECT_EQ(loaded16.version(), 16);
+    PackStream re16; loaded16.Serialize(re16);
+    EXPECT_EQ(pack_hex(re16), pack_hex(w16)) << "v16 wire must round-trip unchanged";
+
+    // v16-specific ordering pin: coinbase_payload is serialized IMMEDIATELY after
+    // coinbase (v16 share_data), a slot the v36 layout does NOT have there. Prove
+    // the two layouts are distinct for the same logical inputs.
+    auto v36 = make_canonical_v36();
+    PackStream w36; dash::DashFormatter::Write(w36, &v36);
+    EXPECT_NE(pack_hex(w16), pack_hex(w36))
+        << "v16 and v36 wire layouts must differ (distinct share formats)";
+}


### PR DESCRIPTION
## Phase A of the DASH 1700 → v36 transition — the v36 SHARE TYPE

**DRAFT for the integrator's merge-tap.** Consensus-bearing (defines a share format). Do not merge without review of the flagged divergence in §2.

Decided context (operator, 2026-07-20): DASH does the full 1700→v36 transition, phased. v36 protocol version = 3600. #774 wired the AutoRatchet (dormant); DASH had ONLY a permanent type-16 `DashShare` and no v36 share type, so the ratchet could not activate. **This PR creates that v36 share type.** Scope is Phase A ONLY — messaging is Phase B, activation (the ratchet flip) is Phase C; neither is done here.

### 1. Standardized shape — byte-parity reference is BCH v36 (the non-segwit precedent)
The v36 formatter emits `Optional(segwit_data)` only `if constexpr (is_segwit_activated(version))`. That is true for LTC/DGB/BTC (they carry a segwit slot) but **false for BCH** (`SEGWIT_ACTIVATION_VERSION == 0`). **DASH is non-segwit (X11), like BCH**, so the correct byte-parity reference is the **BCH v36 `MergedMiningShare` shape = the ltc/dgb/btc v36 layout MINUS segwit_data**. Omitting segwit_data is the established non-segwit convention, **not** a divergence.

Standardized prefix (`min_header .. message_data`) is byte-identical to BCH v36: VarInt version; v36 address (`pubkey_hash` + `pubkey_type`); VarInt `subsidy`; `donation`; `stale_info`; **`desired_version` VarInt = the version-vote the ratchet reads**; `merged_addresses` (empty/inert); far/max_bits/bits/timestamp/absheight; `AbsworkV36Format` abswork; `merged_coinbase_info` + `merged_payout_hash` (empty/zero inert); ref_merkle_link; last_txout_nonce; `V36HashLinkType` hash_link; merkle_link; `message_data` (empty, Phase A). Merged-mining fields are carried for structural uniformity but always **EMPTY/INERT** (DASH is standalone X11, no AuxPoW child) — exactly as a non-merged coin populates them. "DensePPLNS weights" are derived by the tracker from `bits`/`donation`/`pubkey_hash`, not a wire field.

The v36 shared types are added as byte-identical copies in a new `dash::v36` namespace (the established per-coin duplication pattern — the only shared symbol is `core::version_gate::is_v36_active`).

### 2. ⚠️ FLAGGED DIVERGENCE — the DASH suffix (integrator/operator review)
DASH must pay masternodes/superblocks/platform and carry a DIP4 CbTx payload — consensus data with **no cross-coin equivalent**. It rides as a DASH-specific **suffix after `message_data`**, keeping the entire standardized prefix byte-identical: `coinbase_payload`, `payment_amount`, `packed_payments`, `coinbase_payload_outer`. Folding it into the shared `merged_*` fields was rejected (invents a DASH-only encoding, breaks parity). **Please confirm this suffix approach** vs. a pure no-suffix shape (which would break p2p verifiability for peers without dashd state). Baked now (dormant + reversible) so the wire format is frozen once rather than changed again at Phase C.

### 3. Dormancy / backward-compat (1700 byte-unchanged)
The live `dash::ShareType = ShareVariants<DashFormatter, DashShare>` is **unchanged** — its concrete consumers (`share_init_verify(const DashShare&)`, node.cpp:64) would not compile against a second variant member; that guarding is Phase B/C. A separate dormant `dash::V36ShareType` proves version-36 dispatch. `DashFormatter::Read/Write` branch on `ShareT::version`, so the v16 body is instantiated only for `DashShare` (byte-unchanged). `current_share_version` stays 16 — nothing mints a v36 share, and the #774 hard-cut warning is respected.

### 4. KATs — MANDATORY (bundled into the already-allowlisted `test_dash_share_hash_link`, no build.yml change → avoids the #769 new-target trap)
- **Byte-parity**: standardized prefix == BCH v36 field order/encoding + frozen golden hex sentinel (prefix + full wire).
- **Round-trip**: pack → `RawShare(type 36)` → `load_v36_share` → field equality → re-pack byte-identical (real dispatch).
- **Merged-inert**: empty merged vectors → `0x00`; zero payout hash → 32 zero bytes; empty message_data → `0x00`.
- **Version-vote**: `desired_version` rides as CompactSize VarInt.
- **Backward-compat**: v16 round-trips through the live `ShareType::load(16)` unchanged; v16 vs v36 distinct.

Results: `test_dash_share_hash_link` **50/50** pass; `c2pool-dash` builds; `test_dash_conformance` (56), `test_dash_share_tracker` (9), `test_dash_share_messages` (9) unchanged.

### 5. Phase B / C build on this
- **B (messaging)**: populate/consume `message_data`; extend `version_negotiation` tallies to count `DashV36Share.m_desired_version` (currently guarded to `DashShare` only — correct while dormant).
- **C (activation)**: promote `DashV36Share` into the live variant + guard the DashShare-concrete consumers; add a v36 accept path (X11 PoW + hash_link + merkle + the suffix coinbase reconstruction); feed `apply_min_protocol_ratchet_decision` with `target_floor = 3600`; only then consider `current_share_version → 36` behind the 95% weighted activation.

Design note staged to `frstrtr/the` `docs/dash-v36-share-type-phaseA.md` (not pushed).