### PR TITLE
dash: vardiff hysteresis on power-of-two boundary (F-2)

### DIFF
--- a/src/c2pool/hashrate/tracker.cpp
+++ b/src/c2pool/hashrate/tracker.cpp
@@ -182,30 +182,58 @@ void HashrateTracker::set_difficulty_from_hashrate(double now) {
     if (ewma_share_count_ < static_cast<uint64_t>(vardiff_warmup_shares_)) return; // keep seed diff
     double h = get_recent_hashrate(now);
     if (h <= 0.0) return;
-    double d = h * target_time_per_mining_share_ / 4294967296.0;
-    d = std::max(min_difficulty_, std::min(max_difficulty_, d));
+    // Un-quantized ideal difficulty from the smoothed hashrate. The [min,max]
+    // clamp is part of the ideal (a rig outside the bounds should sit at the
+    // bound), so hysteresis below operates on this clamped-but-unquantized value.
+    double d_ideal = h * target_time_per_mining_share_ / 4294967296.0;
+    d_ideal = std::max(min_difficulty_, std::min(max_difficulty_, d_ideal));
     // Firmware-grid fix: many ASIC firmwares round the advertised pool difficulty
     // DOWN to a power-of-two grid, then mine that easier target and submit shares
     // the pool's exact (higher) required difficulty rejects. Advertise only
     // power-of-two difficulties so advertised == applied == required. Round DOWN so
     // accepted-share cadence never drops below target.
-    d = std::exp2(std::floor(std::log2(d)));
     // Quantize the floor too so a floor-pinned/warm-up advertise is still a
     // power of two. min_difficulty_ (e.g. 0.0005) is not itself on the grid, so
     // re-flooring at it would re-open the firmware reject gap at the floor.
     // Advertise at most one grid step below the configured floor (0.000488 vs
     // 0.0005), preserving the round-DOWN cadence invariant.
-    d = std::max(std::exp2(std::floor(std::log2(min_difficulty_))),
-                 std::exp2(std::floor(std::log2(d))));
+    double d_q = std::max(std::exp2(std::floor(std::log2(min_difficulty_))),
+                          std::exp2(std::floor(std::log2(d_ideal))));
+
+    // Hysteresis around the current power-of-two bucket. After the firmware-grid
+    // fix quantizes advertised diff to powers of two, both d_q and
+    // current_difficulty_ live on the 2^n grid, so a dead-band on the QUANTIZED
+    // ratio is inert (ratios are only 1, 2, 0.5). A rig whose un-quantized ideal
+    // D sits near a 2^n boundary would then flap its advertised bucket
+    // 2^n <-> 2^(n+1) on estimator noise (~+/-24% at tau=90s), doubling
+    // set_difficulty churn and jittering rig-side hashrate graphs.
+    //
+    // Fix: hold the current bucket [C, 2C) and only re-quantize when the
+    // UN-QUANTIZED ideal D leaves it DECISIVELY -- at/above 2C by the dead-band
+    // margin (step up) or below C by the dead-band margin (step down). Values in
+    // the band [C*(1-deadband), 2C*(1+deadband)) keep the current advertisement,
+    // so boundary noise no longer churns. This only widens the transition: it
+    // never advertises above ideal D by more than the margin, and never below the
+    // (quantized) floor. Round-DOWN cadence and warm-up/clamp are preserved.
     if (current_difficulty_ > 0.0) {
-        double ratio = d / current_difficulty_;
-        // Dead-band: absorb estimator noise, no needless set_difficulty churn.
-        if (ratio < 1.0 + vardiff_deadband_ && ratio > 1.0 / (1.0 + vardiff_deadband_))
-            return;
+        const double C = current_difficulty_;
+        // Only hold when the current advertisement is itself on the 2^n grid
+        // (a value we previously advertised). A non-grid seed/hint (e.g. the raw
+        // min_difficulty_ or an operator hint) must be corrected onto the grid
+        // immediately, not frozen in place by the hysteresis band.
+        const bool current_on_grid = (C == std::exp2(std::floor(std::log2(C))));
+        if (current_on_grid) {
+            const double up_threshold   = 2.0 * C * (1.0 + vardiff_deadband_);
+            const double down_threshold = C * (1.0 - vardiff_deadband_);
+            if (d_ideal >= down_threshold && d_ideal < up_threshold)
+                return;  // inside the hysteresis band -- keep the current bucket
+        }
     }
-    LOG_INFO << "[Stratum] VARDIFF(hashrate): " << current_difficulty_ << " -> " << d
+
+    if (d_q == current_difficulty_) return;  // decisive move re-adopts same grid step
+    LOG_INFO << "[Stratum] VARDIFF(hashrate): " << current_difficulty_ << " -> " << d_q
              << " (H_est=" << h << " H/s, target=" << target_time_per_mining_share_ << "s)";
-    current_difficulty_ = d;  // downstream notify + stratum 1% resend guard unchanged
+    current_difficulty_ = d_q;  // downstream notify + stratum 1% resend guard unchanged
 }
 
 void HashrateTracker::adjust_difficulty() {

--- a/test/test_dash_work_source.cpp
+++ b/test/test_dash_work_source.cpp
@@ -241,3 +241,98 @@ TEST(HashrateVardiffQuantize, QuantizationFormulaIsFloorLog2)
         EXPECT_GT(2.0 * q, D);
     }
 }
+
+// Hysteresis KAT (F-2). After the F-1 fix quantizes advertised diff to powers of
+// two, the advertised value and current_difficulty_ both live on the 2^n grid, so
+// a dead-band on the QUANTIZED ratio is inert (ratios are only 1, 2, 0.5). A rig
+// whose un-quantized ideal D sits near a 2^n boundary then flaps its advertised
+// bucket 2^n <-> 2^(n+1) on estimator noise, doubling set_difficulty churn and
+// jittering rig-side hashrate graphs. The fix holds the current power-of-two
+// bucket [C, 2C) and only re-quantizes when the UN-QUANTIZED ideal D leaves it
+// DECISIVELY: at/above 2C by the dead-band margin (step up) or below C by the
+// margin (step down). These KATs would FAIL pre-fix (a bare round-DOWN quantize
+// steps the instant D crosses the plain 2^n edge). deadband = 0.10 (default).
+namespace {
+constexpr double kHystTarget = 10.0;   // set_target_time_per_mining_share
+constexpr double kHystTau    = 90.0;   // vardiff_ewma_tau_ (fixed default)
+constexpr double kDeadband   = 0.10;   // vardiff_deadband_ (default)
+
+// Configure a tracker seeded (via hint) at an on-grid power-of-two bucket C.
+// Passed by reference: HashrateTracker holds a std::mutex and is non-copyable.
+void setup_hyst_tracker(c2pool::hashrate::HashrateTracker& t, double seed_C) {
+    t.set_difficulty_bounds(0.0005, 1e9);   // wide: exercise hysteresis, not clamp
+    t.set_target_time_per_mining_share(kHystTarget);
+    t.set_hashrate_vardiff(true);
+    t.enable_vardiff(true);
+    t.set_difficulty_hint(seed_C);          // current bucket C (a power of two)
+}
+} // namespace
+
+// UP: an ideal D that rises PAST a 2^n boundary but stays within the hysteresis
+// band does NOT flap the advertised bucket; a decisive move past 2C*(1+deadband)
+// steps. Seeded bucket C = 8 (2^3); boundary of interest is the upper edge 16.
+TEST(HashrateVardiffHysteresis, BoundaryNoiseHeldButDecisiveMoveStepsUp)
+{
+    // per-share issued diff => ideal D grows ~2.06/share; at 8 shares D ~ 16.5,
+    // i.e. just above the 2^n edge (16) yet below 2C*(1+deadband) = 17.6.
+    constexpr double kDiff = 3.70;
+
+    c2pool::hashrate::HashrateTracker t;
+    setup_hyst_tracker(t, 8.0);
+    for (int i = 0; i < 8; ++i)
+        t.record_mining_share_submission(kDiff, /*accepted=*/true);
+
+    const double D8 = ideal_D(8, kDiff, kHystTarget, kHystTau);
+    // Precondition: D has crossed the plain 2^n edge (a pre-fix quantize would
+    // already advertise 16 here) but sits inside the upper hysteresis band.
+    ASSERT_GT(D8, 16.0)                          << "test mis-scaled: D8=" << D8;
+    ASSERT_LT(D8, 2.0 * 8.0 * (1.0 + kDeadband)) << "test mis-scaled: D8=" << D8;
+    // No-flap: advertised bucket held at C = 8 despite D having crossed 16.
+    EXPECT_EQ(t.get_current_difficulty(), 8.0)
+        << "boundary noise flapped the advertised bucket (D8=" << D8 << ")";
+
+    // Decisive move up: push D well past 2C*(1+deadband)=17.6.
+    for (int i = 8; i < 13; ++i)
+        t.record_mining_share_submission(kDiff, /*accepted=*/true);
+    const double D13 = ideal_D(13, kDiff, kHystTarget, kHystTau);
+    ASSERT_GE(D13, 2.0 * 8.0 * (1.0 + kDeadband)) << "test mis-scaled: D13=" << D13;
+    // Steps to the largest power of two <= D (round-DOWN preserved): 16.
+    EXPECT_EQ(t.get_current_difficulty(), 16.0)
+        << "decisive move did not step the advertised bucket (D13=" << D13 << ")";
+    EXPECT_LE(t.get_current_difficulty(), D13);   // never advertise above ideal D
+}
+
+// DOWN: an ideal D that dips BELOW the current bucket's lower edge but stays
+// within the margin holds; a decisive drop below C*(1-deadband) steps down.
+// Two trackers both seeded at C = 16 (2^4).
+TEST(HashrateVardiffHysteresis, LowerMarginHeldButDecisiveDropStepsDown)
+{
+    // Hold case: at warm-up completion (4 shares) D ~ 15.2 -- below the lower
+    // edge 16 yet at/above C*(1-deadband) = 14.4. Pre-fix would step down to 8.
+    {
+        constexpr double kDiff = 6.815;   // D(4) ~ 15.2
+        c2pool::hashrate::HashrateTracker t;
+        setup_hyst_tracker(t, 16.0);
+        for (int i = 0; i < 4; ++i)       // exactly warm-up: first adjust fires
+            t.record_mining_share_submission(kDiff, /*accepted=*/true);
+        const double D4 = ideal_D(4, kDiff, kHystTarget, kHystTau);
+        ASSERT_LT(D4, 16.0)                     << "test mis-scaled: D4=" << D4;
+        ASSERT_GE(D4, 16.0 * (1.0 - kDeadband)) << "test mis-scaled: D4=" << D4;
+        EXPECT_EQ(t.get_current_difficulty(), 16.0)
+            << "lower-margin noise flapped the advertised bucket down (D4=" << D4 << ")";
+    }
+    // Decisive case: D(4) ~ 11.0, clearly below C*(1-deadband)=14.4 -> step down.
+    {
+        constexpr double kDiff = 4.932;   // D(4) ~ 11.0
+        c2pool::hashrate::HashrateTracker t;
+        setup_hyst_tracker(t, 16.0);
+        for (int i = 0; i < 4; ++i)
+            t.record_mining_share_submission(kDiff, /*accepted=*/true);
+        const double D4 = ideal_D(4, kDiff, kHystTarget, kHystTau);
+        ASSERT_LT(D4, 16.0 * (1.0 - kDeadband)) << "test mis-scaled: D4=" << D4;
+        // Steps to the largest power of two <= D (round-DOWN preserved): 8.
+        EXPECT_EQ(t.get_current_difficulty(), 8.0)
+            << "decisive drop did not step the advertised bucket (D4=" << D4 << ")";
+        EXPECT_LE(t.get_current_difficulty(), D4);   // never advertise above ideal D
+    }
+}


### PR DESCRIPTION
## F-2 vardiff hysteresis (DASH hashrate-vardiff)

Low-priority polish identified in the #773 review. **Cosmetic + consensus-neutral** — smooths rig-side hashrate graphs and cuts `set_difficulty` churn; no effect on shares, targets, or payout.

### Problem
After #773 (F-1) quantizes advertised vardiff to powers of two (`d = exp2(floor(log2(d)))`), the 10% dead-band (`vardiff_deadband_`) is **inert** — it compares already-quantized values, so ratios are only 1, 2, 0.5. A rig whose EWMA-estimated ideal `D` sits near a `2^n` boundary flaps its advertised difficulty `2^n <-> 2^(n+1)` on estimator noise (~±24% at `tau=90s`), roughly doubling `set_difficulty` events and jittering rig hashrate graphs. No rejects (the P5 gate uses `min(live, issued)`, both PoT), just churn.

### Fix
Apply hysteresis on the **un-quantized** ideal `D`. Hold the current power-of-two bucket `[C, 2C)` and only re-quantize when `D` leaves it decisively:
- **step up** when `D >= 2C * (1 + deadband)`
- **step down** when `D <  C  * (1 - deadband)`
- values in `[C*(1-deadband), 2C*(1+deadband))` keep the current advertisement.

Only the current advertisement being **on the 2^n grid** triggers the hold (a non-grid seed/hint is corrected onto the grid immediately). Preserved: round-DOWN cadence, warm-up, min/max clamp, and the quantized floor (F-1). DASH `use_hashrate_vardiff_` path only.

### Tests
Extends the allowlisted `test_dash_work_source` (where the `HashrateVardiffQuantize` KATs live) with `HashrateVardiffHysteresis`:
- `BoundaryNoiseHeldButDecisiveMoveStepsUp` — ideal `D` rises past the `2^n` edge but within the band → bucket **held**; a decisive move past `2C*(1+deadband)` → **steps** (round-DOWN preserved).
- `LowerMarginHeldButDecisiveDropStepsDown` — `D` dips below the lower edge but within margin → **held**; a decisive drop below `C*(1-deadband)` → **steps down**.

Both would FAIL pre-fix (a bare round-DOWN quantize steps the instant `D` crosses the plain edge). All 9 tests in the binary pass; the 3 existing quantize KATs are unaffected.

### Consensus-neutrality
`git diff origin/master | grep -iE 'get_share_bits|share_bits|share_target|DGW|oracle|payout|pplns'` → **empty**. Diff touches only `tracker.cpp` (vardiff advertisement) and the test.

Draft — for merge-tap review, not for merge/deploy.
