### PR TITLE
dash(v0.2.4): fail-closed mainnet gate for embedded template arm + M1/H1 dual-path honesty [DRAFT]

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -845,10 +845,24 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     dash::coin::P2pRelaySink p2p_relay;
     if (coin_p2p && !no_p2p_relay) {
         p2p_relay =
-            [&ioc, &coin_p2p](const std::vector<unsigned char>& block_bytes) {
+            [&ioc, &coin_p2p](const std::vector<unsigned char>& block_bytes) -> bool {
+                // H1 honest reporting: submit_block_p2p_raw SILENTLY DROPS a won
+                // block when the coin-P2P peer is disconnected, and the io::post
+                // returns before the send even runs -- so only claim a P2P relay
+                // when the peer is actually connected+handshaked at dispatch time.
+                // If not, return false so broadcast_won_block relies on ARM B
+                // (submitblock RPC) and the NEVER-SILENT-DROP contract holds
+                // (loud dispatcher log if neither arm is reachable).
+                if (!coin_p2p || !coin_p2p->is_handshake_complete()) {
+                    std::cout << "[DASH-STRATUM-BLOCK] embedded P2P relay skipped: "
+                                 "coin-P2P peer not connected/handshaked -- relying "
+                                 "on submitblock-RPC backup\n";
+                    return false;
+                }
                 io::post(ioc, [&coin_p2p, bytes = block_bytes]() {
                     if (coin_p2p) coin_p2p->submit_block_p2p_raw(bytes);
                 });
+                return true;
             };
     } else if (no_p2p_relay) {
         std::cout << "[run] --no-p2p-relay: embedded P2P-relay arm SUPPRESSED; "

--- a/src/impl/dash/coin/rpc.cpp
+++ b/src/impl/dash/coin/rpc.cpp
@@ -412,11 +412,16 @@ void NodeRPC::submit_block(BlockType& block, bool ignore_failure)
 bool NodeRPC::submit_block_hex(const std::string& block_hex, bool ignore_failure)
 {
     auto result = m_client.CallMethod<nlohmann::json>(ID, "submitblock", {block_hex});
-    bool success = result.is_null();
+    // Dual-path contract (M1): a "duplicate"/"inconclusive"/already-have result
+    // means the OTHER broadcast arm already landed this block on the network —
+    // that is SUCCESS, not failure. See submitblock_result_accepted().
+    const bool success = dash::coin::submitblock_result_accepted(result);
     if (!success && !ignore_failure)
         LOG_ERROR << "submit_block_hex result: " << result.dump();
     else if (success)
-        LOG_INFO << "submit_block_hex accepted";
+        LOG_INFO << "submit_block_hex accepted"
+                 << (result.is_null() ? std::string{}
+                                      : " (already on network: " + result.dump() + ")");
     return success;
 }
 

--- a/src/impl/dash/coin/rpc_data.hpp
+++ b/src/impl/dash/coin/rpc_data.hpp
@@ -53,6 +53,27 @@ inline PackedPayment normalize_payment(const nlohmann::json& entry)
     return pp;
 }
 
+// Classify a dashd `submitblock` RPC result under the dual-path won-block
+// contract (M1). submitblock returns null on accept; a non-null string is a
+// reject reason. A "duplicate" / "inconclusive" / "already-have" result means
+// the block is ALREADY on the network — the OTHER broadcast arm (embedded P2P
+// relay, or a peer) landed it first — which is SUCCESS (the block reached the
+// network), NOT a failure. "duplicate-invalid" is the one exception: the block
+// was rejected as invalid, a genuine failure. Pure over the JSON so the KAT can
+// pin it without a live RPC client.
+inline bool submitblock_result_accepted(const nlohmann::json& result)
+{
+    if (result.is_null()) return true;
+    if (!result.is_string()) return false;
+    std::string code = result.get<std::string>();
+    for (char& c : code)
+        if (c >= 'A' && c <= 'Z') c = static_cast<char>(c - 'A' + 'a');
+    const bool already_have = code == "duplicate"
+                           || code.find("inconclusive") != std::string::npos
+                           || code.find("already") != std::string::npos;
+    return already_have && code.find("invalid") == std::string::npos;
+}
+
 struct DashWorkData {
     // Raw getblocktemplate JSON response (kept for fallback access to fields
     // we haven't promoted to members yet).

--- a/src/impl/dash/coin/won_block_dispatch.hpp
+++ b/src/impl/dash/coin/won_block_dispatch.hpp
@@ -52,7 +52,14 @@ namespace coin
 // Embedded P2P relay sink (ARM A, primary): the run-loop binds this to the E1
 // CoinClient's submit_block_p2p_raw. EMPTY == no embedded P2P sink present
 // (no --coin-p2p-connect peer, or --no-p2p-relay suppression).
-using P2pRelaySink = std::function<void(const std::vector<unsigned char>&)>;
+//
+// RETURNS true iff the block was actually relayed onto a CONNECTED coin-P2P
+// peer (H1 honest-reporting contract). submit_block_p2p_raw SILENTLY DROPS a
+// won block when the peer is disconnected, so the sink MUST report false in
+// that case — otherwise the dispatcher would claim landed_first=p2p while the
+// block was dropped, falsely relying on a dead arm instead of the submitblock
+// RPC backup.
+using P2pRelaySink = std::function<bool(const std::vector<unsigned char>&)>;
 
 // submitblock RPC sink (ARM B, backup): the run-loop binds this to
 // NodeRPC::submit_block_hex. Returns true iff dashd accepted (or duplicate).
@@ -64,7 +71,7 @@ using RpcSubmitSink = std::function<bool(const std::string&)>;
 // which path was engaged first for the record.
 struct BlockBroadcast
 {
-    bool        p2p_sent     = false;   // embedded P2P relay issued (sink present)
+    bool        p2p_sent     = false;   // embedded P2P relay issued to a CONNECTED peer
     bool        rpc_ok       = false;   // submitblock returned ok OR duplicate
     const char* landed_first = "none";  // "p2p" | "rpc" | "none"
 
@@ -92,11 +99,22 @@ inline BlockBroadcast broadcast_won_block(const P2pRelaySink& p2p_relay,
     // block (lost subsidy).
     if (p2p_relay) {
         try {
-            p2p_relay(block_bytes);
-            r.p2p_sent = true;
-            r.landed_first = "p2p";
-            LOG_INFO << "[EMB-DASH] won-block embedded P2P relay issued ("
-                     << block_bytes.size() << " bytes) -- primary path.";
+            // H1 honest reporting: only claim p2p_sent when the sink confirms the
+            // block was relayed onto a CONNECTED peer. A disconnected coin-P2P
+            // peer means submit_block_p2p_raw would silently drop the block, so
+            // the sink returns false and we rely on ARM B instead of masking the
+            // loss with a false landed_first=p2p.
+            const bool relayed = p2p_relay(block_bytes);
+            if (relayed) {
+                r.p2p_sent = true;
+                r.landed_first = "p2p";
+                LOG_INFO << "[EMB-DASH] won-block embedded P2P relay issued ("
+                         << block_bytes.size() << " bytes) -- primary path.";
+            } else {
+                LOG_WARNING << "[EMB-DASH] won-block embedded P2P relay NOT sent "
+                               "(coin-P2P peer not connected/handshaked) -- "
+                               "relying on submitblock RPC backup.";
+            }
         } catch (const std::exception& e) {
             LOG_ERROR << "[EMB-DASH] won-block embedded P2P relay threw (" << e.what()
                       << ") -- falling through to submitblock RPC backup.";

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -50,6 +50,7 @@
 #include <cstdio>
 #include <cstring>
 #include <ctime>
+#include <mutex>
 #include <span>
 #include <utility>
 
@@ -168,6 +169,17 @@ DASHWorkSource::~DASHWorkSource() = default;
 // ─────────────────────────────────────────────────────────────────────────────
 GetWork DASHWorkSource::get_work(const WorkJobTargetInputs& job_in) const
 {
+    // C1 mainnet gate (see cached_work): the embedded arm emits an EMPTY CCbTx
+    // extra_payload (consensus-invalid on a DIP4-active mainnet) until the
+    // SML/QuorumManager wiring lands post-v0.2.4. On mainnet never source the
+    // embedded template — use ONLY the reward-safe dashd-RPC fallback. is_testnet_
+    // defaults false, so an unconfigured node fails closed to the fallback.
+    if (!is_testnet_) {
+        coin::DashWorkData w =
+            dashd_fallback_ ? dashd_fallback_() : coin::DashWorkData{};
+        return GetWork{ coin::WorkSource::DashdFallback, std::move(w),
+                        assemble_work_job_targets(job_in) };
+    }
     // Qualify the free function explicitly: unqualified `get_work` in this
     // member body resolves to THIS member (class scope shadows the namespace),
     // so name the capstone by its namespace to avoid a self-call.
@@ -281,13 +293,44 @@ std::shared_ptr<const coin::DashWorkData> DASHWorkSource::cached_work() const
             return nullptr;
     }
 
+    // ── C1 mainnet gate (v0.2.4 tag-blocker) ────────────────────────────────
+    // The embedded template arm's only prod caller does not pass the E2d
+    // SML/QuorumManager seams, so build_embedded_workdata() clears the CCbTx
+    // extra_payload and the coinbase is a plain v1 tx with NO DIP-0004 type-5
+    // payload. On a DIP4-active DASH MAINNET that block is consensus-INVALID
+    // (bad-cbtx) and the won subsidy is lost. Populating the payload needs the
+    // SML/QuorumManager wiring that is post-v0.2.4. Until then the embedded arm
+    // is FAIL-CLOSED off mainnet: we never take the populated() embedded flip on
+    // mainnet — the template comes ONLY from the reward-safe dashd-RPC fallback
+    // (the never-removed [GBT-XCHECK] safety path). Testnet/regtest keep the
+    // embedded arm (E5 proving ground). is_testnet_ defaults false, so an
+    // unconfigured node is treated as mainnet — fail-closed by default.
+    const bool embedded_arm_enabled = is_testnet_;
+    if (!embedded_arm_enabled && coin_state_.populated()) {
+        static std::once_flag mainnet_gate_logged;
+        std::call_once(mainnet_gate_logged, [] {
+            LOG_WARNING << "[DASH-STRATUM-GBT] embedded template arm disabled on "
+                           "mainnet: CCbTx payload not yet buildable — using "
+                           "dashd-RPC fallback";
+        });
+    }
+
     // Re-source OUTSIDE the lock (the fallback arm is a blocking dashd RPC).
-    // Embedded arm when the node-held bundle is populated, retained dashd GBT
-    // fallback otherwise (the never-removed [GBT-XCHECK] safety path).
+    // Embedded arm ONLY when enabled (testnet/regtest) AND the node-held bundle
+    // is populated; otherwise the retained dashd GBT fallback.
     coin::DashWorkData work;
-    if (coin_state_.populated() || dashd_fallback_) {
+    const bool try_embedded = embedded_arm_enabled && coin_state_.populated();
+    if (try_embedded || dashd_fallback_) {
         try {
-            coin::WorkSelection sel = coin_state_.select_work(dashd_fallback_);
+            // On mainnet (embedded gated) select_work is bypassed entirely and
+            // we source directly from the reward-safe dashd fallback; on
+            // testnet/regtest select_work picks embedded-when-viable, dashd
+            // otherwise (unchanged behaviour).
+            coin::WorkSelection sel = try_embedded
+                ? coin_state_.select_work(dashd_fallback_)
+                : coin::WorkSelection{
+                      dashd_fallback_ ? dashd_fallback_() : coin::DashWorkData{},
+                      coin::WorkSource::DashdFallback };
             // E2c observability: WHICH arm served this template + the MN payee
             // it carries (the payee-correctness axis of the embedded arm). One
             // line per re-source (cache-TTL cadence), INFO -- the field-

--- a/test/test_dash_cb_payee.cpp
+++ b/test/test_dash_cb_payee.cpp
@@ -88,3 +88,39 @@ TEST(DashCbPayee, NonObjectEntryYieldsEmptyPayment) {
     EXPECT_TRUE(pp.payee.empty());
     EXPECT_EQ(pp.amount, 0u);
 }
+
+// ── M1: submitblock dual-path result classification ─────────────────────────
+// submitblock returns null on accept; a "duplicate"/"inconclusive"/already-have
+// string means the OTHER dual-path arm already landed the block on the network
+// = SUCCESS under the dual-path contract, NOT failure. "duplicate-invalid" is
+// the exception (rejected as invalid = genuine failure).
+using dash::coin::submitblock_result_accepted;
+
+TEST(DashSubmitblockResult, NullResultIsAccept) {
+    EXPECT_TRUE(submitblock_result_accepted(json(nullptr)));
+}
+
+TEST(DashSubmitblockResult, DuplicateCountsAsSuccess) {
+    // The block already reached the network via the other arm.
+    EXPECT_TRUE(submitblock_result_accepted(json("duplicate")));
+    EXPECT_TRUE(submitblock_result_accepted(json("DUPLICATE")));   // case-insensitive
+}
+
+TEST(DashSubmitblockResult, InconclusiveAndAlreadyHaveCountAsSuccess) {
+    EXPECT_TRUE(submitblock_result_accepted(json("inconclusive")));
+    EXPECT_TRUE(submitblock_result_accepted(json("inconclusive-already-have")));
+    EXPECT_TRUE(submitblock_result_accepted(json("duplicate-inconclusive")));
+}
+
+TEST(DashSubmitblockResult, DuplicateInvalidIsGenuineFailure) {
+    // Already have it, but it is INVALID — must NOT be counted as landed.
+    EXPECT_FALSE(submitblock_result_accepted(json("duplicate-invalid")));
+}
+
+TEST(DashSubmitblockResult, RealRejectReasonsAreFailure) {
+    EXPECT_FALSE(submitblock_result_accepted(json("bad-cb-payee")));
+    EXPECT_FALSE(submitblock_result_accepted(json("high-hash")));
+    EXPECT_FALSE(submitblock_result_accepted(json("rejected")));
+    // Non-string, non-null (defensive): not an accept.
+    EXPECT_FALSE(submitblock_result_accepted(json::object()));
+}

--- a/test/test_dash_stratum_work_source.cpp
+++ b/test/test_dash_stratum_work_source.cpp
@@ -983,6 +983,112 @@ TEST(DashDashboardWiring, LocalStatsSumsStratumWorkerHashrate)
         EXPECT_EQ(w.get<std::string>().find("pool is idle"), std::string::npos);
 }
 
+// ═════════════════════════════════════════════════════════════════════════════
+// C1 mainnet gate (v0.2.4 tag-blocker). The embedded template arm's only prod
+// caller does not pass the E2d SML/QuorumManager seams, so build_embedded_
+// workdata() emits an EMPTY CCbTx extra_payload — a coinbase that is consensus-
+// INVALID (bad-cbtx) on a DIP4-active DASH MAINNET. Until the payload is
+// buildable (post-v0.2.4) the embedded arm MUST be fail-closed off mainnet: a
+// populated NodeCoinState must NOT serve its embedded template on mainnet (it
+// routes to the reward-safe dashd-RPC fallback), while testnet/regtest keep the
+// embedded arm (E5 proving ground). is_testnet_ defaults false, so an
+// unconfigured node is treated as mainnet — fail-closed by default.
+// ═════════════════════════════════════════════════════════════════════════════
+
+namespace {
+// A populated coin-state whose embedded template is DISTINGUISHABLE from the
+// dashd-fallback fixture (different prev/height), so the served template's
+// prevhash proves which arm ran. Empty MN/mempool is fine: the embedded build
+// still yields a valid, mineable template (non-null prev, non-zero bits).
+const char* const kEmbeddedPrevHashHex =
+    "0000000000000000abcdef0123456789abcdef0123456789abcdef0123456789";
+constexpr uint32_t kEmbeddedPrevHeight = 500000u;   // embedded template -> +1
+void seed_populated(dash::coin::NodeCoinState& cs)
+{
+    uint256 emb_prev;
+    emb_prev.SetHex(kEmbeddedPrevHashHex);
+    cs.set_tip(kEmbeddedPrevHeight, emb_prev, /*bits_for_next=*/0x1e0ffff0u,
+               /*mtp_at_tip=*/1'700'000'000u, /*addr_ver=*/76, /*p2sh_ver=*/16,
+               /*curtime=*/kCurtime, /*version=*/static_cast<uint32_t>(kVersion));
+}
+}  // namespace
+
+// MAINNET: a populated coin-state must NOT flip to the embedded arm — the served
+// template is the reward-safe dashd fallback (prev/height of rich_work), never
+// the embedded template (which would carry the empty-CCbTx coinbase).
+TEST(DashStratumC1MainnetGate, MainnetPopulatedCoinStateRoutesToDashdFallback)
+{
+    dash::coin::NodeCoinState cs;
+    seed_populated(cs);
+    ASSERT_TRUE(cs.populated());
+    ASSERT_TRUE(cs.make_embedded_work_inputs().viable());
+
+    auto fallback = []() -> dash::coin::DashWorkData { return rich_work(); };
+    auto submit   = [](const std::vector<unsigned char>&, uint32_t) { return true; };
+
+    // is_testnet=false => mainnet => embedded arm GATED off.
+    dash::stratum::DASHWorkSource ws(cs, fallback, submit,
+                                     core::stratum::StratumConfig{},
+                                     /*is_testnet=*/false);
+
+    auto tmpl = ws.get_current_work_template();
+    ASSERT_FALSE(tmpl.empty());
+    // The fallback's tip/height — NOT the embedded prev/height. Embedded was
+    // suppressed on mainnet.
+    EXPECT_EQ(tmpl.value("previousblockhash", ""), std::string(kPrevHashHex));
+    EXPECT_EQ(tmpl.value("height", 0u), 424242u);
+
+    // The fused adapter path is gated too: source is the retained dashd arm.
+    dash::stratum::WorkJobTargetInputs job_in;
+    job_in.sane_target_min.SetHex(
+        "0000000000000000000000000000000000000000000000000000000000000001");
+    job_in.sane_target_max.SetHex(
+        "00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    job_in.share_info_bits_target.SetHex(
+        "0000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    auto gw = ws.get_work(job_in);
+    EXPECT_EQ(gw.source, dash::coin::WorkSource::DashdFallback);
+    EXPECT_EQ(gw.work.m_height, 424242u);
+}
+
+// TESTNET/REGTEST: the SAME populated coin-state DOES serve its embedded
+// template (E5 lives here) — proving the gate is mainnet-only, not a blanket
+// disable.
+TEST(DashStratumC1MainnetGate, TestnetPopulatedCoinStateServesEmbedded)
+{
+    dash::coin::NodeCoinState cs;
+    seed_populated(cs);
+    ASSERT_TRUE(cs.populated());
+
+    auto fallback = []() -> dash::coin::DashWorkData { return rich_work(); };
+    auto submit   = [](const std::vector<unsigned char>&, uint32_t) { return true; };
+
+    // is_testnet=true => testnet/regtest => embedded arm ENABLED.
+    dash::stratum::DASHWorkSource ws(cs, fallback, submit,
+                                     core::stratum::StratumConfig{},
+                                     /*is_testnet=*/true);
+
+    uint256 emb_prev;
+    emb_prev.SetHex(kEmbeddedPrevHashHex);
+
+    auto tmpl = ws.get_current_work_template();
+    ASSERT_FALSE(tmpl.empty());
+    // The embedded tip/height (prev_height + 1) — the embedded arm ran.
+    EXPECT_EQ(tmpl.value("previousblockhash", ""), emb_prev.GetHex());
+    EXPECT_EQ(tmpl.value("height", 0u), kEmbeddedPrevHeight + 1u);
+
+    dash::stratum::WorkJobTargetInputs job_in;
+    job_in.sane_target_min.SetHex(
+        "0000000000000000000000000000000000000000000000000000000000000001");
+    job_in.sane_target_max.SetHex(
+        "00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    job_in.share_info_bits_target.SetHex(
+        "0000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    auto gw = ws.get_work(job_in);
+    EXPECT_EQ(gw.source, dash::coin::WorkSource::Embedded);
+    EXPECT_EQ(gw.work.m_height, kEmbeddedPrevHeight + 1u);
+}
+
 TEST(DashDashboardWiring, LocalStatsIdleWarningWhenNoWorkers)
 {
     // No provider wired and an empty local registry -> the honest idle warning

--- a/test/test_dash_won_block_dualpath.cpp
+++ b/test/test_dash_won_block_dualpath.cpp
@@ -71,7 +71,9 @@ TEST(DashWonBlockDualPath, BothArmsCarryIdenticalBlock)
 
     std::vector<unsigned char> relayed;
     bool did_relay = false;
-    P2pRelaySink p2p = [&](const std::vector<unsigned char>& b) { did_relay = true; relayed = b; };
+    P2pRelaySink p2p = [&](const std::vector<unsigned char>& b) -> bool {
+        did_relay = true; relayed = b; return true;   // connected peer -> relayed
+    };
 
     std::string submitted_hex;
     int submit_calls = 0;
@@ -107,7 +109,9 @@ TEST(DashWonBlockDualPath, DaemonlessP2pOnlyReachesNetwork)
     const std::string block_hex = to_hex(block);
 
     std::vector<unsigned char> relayed;
-    P2pRelaySink p2p = [&](const std::vector<unsigned char>& b) { relayed = b; };
+    P2pRelaySink p2p = [&](const std::vector<unsigned char>& b) -> bool {
+        relayed = b; return true;   // connected peer -> relayed
+    };
 
     const auto r = broadcast_won_block(p2p, /*rpc=*/{}, block, block_hex);
 
@@ -164,7 +168,7 @@ TEST(DashWonBlockDualPath, ThrowingPrimaryFallsThroughToBackup)
     const auto block = make_block_bytes();
     const std::string block_hex = to_hex(block);
 
-    P2pRelaySink p2p = [&](const std::vector<unsigned char>&) {
+    P2pRelaySink p2p = [&](const std::vector<unsigned char>&) -> bool {
         throw std::runtime_error("relay socket down");
     };
     std::string submitted_hex;
@@ -179,4 +183,55 @@ TEST(DashWonBlockDualPath, ThrowingPrimaryFallsThroughToBackup)
     EXPECT_EQ(submitted_hex, block_hex);
     EXPECT_TRUE(r.any());              // block still reached the network
     EXPECT_STREQ(r.landed_first, "rpc");
+}
+
+// 6) H1 HONEST REPORTING: a DISCONNECTED coin-P2P peer makes submit_block_p2p_raw
+//    silently drop the block, so the relay sink reports false. The dispatcher must
+//    NOT claim p2p_sent -- it relies on the submitblock RPC backup, and
+//    landed_first is "rpc", never a false "p2p". (Before the fix the sink returned
+//    void and p2p_sent was set true unconditionally: a lost subsidy logged as a win.)
+TEST(DashWonBlockDualPath, DisconnectedP2pNotClaimedRelaysViaBackup)
+{
+    const auto block = make_block_bytes();
+    const std::string block_hex = to_hex(block);
+
+    // The sink reports the peer is not connected -> NOT relayed.
+    bool relay_attempted = false;
+    P2pRelaySink p2p = [&](const std::vector<unsigned char>&) -> bool {
+        relay_attempted = true;
+        return false;   // coin-P2P peer disconnected: silent-drop territory
+    };
+    std::string submitted_hex;
+    RpcSubmitSink rpc = [&](const std::string& hex) -> bool {
+        submitted_hex = hex; return true;
+    };
+
+    const auto r = broadcast_won_block(p2p, rpc, block, block_hex);
+
+    EXPECT_TRUE(relay_attempted);
+    EXPECT_FALSE(r.p2p_sent);           // honest: the disconnected arm did NOT send
+    EXPECT_TRUE(r.rpc_ok);              // backup carried it
+    EXPECT_EQ(submitted_hex, block_hex);
+    EXPECT_STREQ(r.landed_first, "rpc");   // NOT a false "p2p"
+    EXPECT_TRUE(r.any());
+}
+
+// 7) H1 fail-loud: a disconnected P2P arm AND no RPC backup => the block reached
+//    NEITHER sink. any()==false and p2p_sent must be honest (false), so the caller
+//    takes the LOUD "block NOT relayed" path instead of a silent lost subsidy.
+TEST(DashWonBlockDualPath, DisconnectedP2pWithNoBackupReachesNeither)
+{
+    const auto block = make_block_bytes();
+    const std::string block_hex = to_hex(block);
+
+    P2pRelaySink p2p = [&](const std::vector<unsigned char>&) -> bool {
+        return false;   // disconnected
+    };
+
+    const auto r = broadcast_won_block(p2p, /*rpc=*/{}, block, block_hex);
+
+    EXPECT_FALSE(r.p2p_sent);
+    EXPECT_FALSE(r.rpc_ok);
+    EXPECT_FALSE(r.any());              // LOUD "block NOT relayed", never a silent win
+    EXPECT_STREQ(r.landed_first, "none");
 }


### PR DESCRIPTION
**v0.2.4 pre-tag safety bundle (E-series review).** DRAFT for merge-tap review — do NOT merge. The HOTEL runs the dashd-RPC fallback arm and is unaffected/reward-safe; this makes the *release* safe so no one arms the incomplete embedded arm on mainnet and loses blocks. Consensus-critical; KATs mandatory.

### C1 — TAG-BLOCKER: embedded arm fail-closed off mainnet
The embedded template arm's only prod caller does not pass the SML/QuorumManager seams, so `build_embedded_workdata()` emits an **EMPTY CCbTx extra_payload** → a plain v1 coinbase that is **consensus-INVALID (bad-cbtx)** on a DIP4-active DASH mainnet (won subsidy lost). The payload is structurally unbuildable today (no in-process SML/QuorumManager; mnlistdiff handler is a log-only stub) — building it is post-v0.2.4.

**Gate mechanism (option a):** `DASHWorkSource` refuses the `populated()` embedded flip on mainnet. Both prod template paths funnel through it:
- `cached_work()` (stratum session path): on mainnet, `select_work()` is bypassed and the template is sourced only from the reward-safe dashd-RPC fallback.
- `get_work()` (fused adapter): on mainnet, returns `WorkSource::DashdFallback` directly.

Keyed on `is_testnet_`, which **defaults `false` (mainnet) → fail-closed by default**. A one-time loud log fires: `embedded template arm disabled on mainnet: CCbTx payload not yet buildable — using dashd-RPC fallback`. Testnet/regtest keep the embedded arm (E5). **No CCbTx builder added** (deferred).

**KAT proof** (`test_dash_stratum_work_source`, allowlisted): with a populated `NodeCoinState`, `is_testnet=false` serves the *fallback* tip/height (embedded suppressed); `is_testnet=true` serves the *embedded* tip/height — pinned on both `get_current_work_template()` and `get_work()`.

### M1 — submitblock duplicate = success
`submit_block_hex` counted `duplicate`/`inconclusive`/already-have as failure, contradicting the dual-path contract (a duplicate means the other arm already landed the block = reached network = success). Now classified via a pure, KAT-pinned `submitblock_result_accepted()` helper; `duplicate-invalid` stays a genuine failure. KAT in `test_dash_cb_payee`.

### H1 — honest p2p_sent reporting
The dispatcher claimed `p2p_sent=true` at `io::post` time, but `submit_block_p2p_raw` silently drops when the coin-P2P peer is disconnected → a won block lost while logging `landed_first=p2p`. The relay sink now checks `is_handshake_complete()` at dispatch and reports whether the block was actually relayed; `broadcast_won_block` only claims `p2p_sent` on a real relay, so ARM B (submitblock RPC) is honestly relied on. NEVER-SILENT-DROP preserved (loud log if neither arm reachable). KATs in `test_dash_won_block_dualpath`.

### Verification
- `conan build c2pool-dash` — binary builds clean.
- KATs (allowlisted targets only; no new-target/build.yml trap): **C1 3/3, M1 5/5, H1 7/7**; full suites green — `test_dash_stratum_work_source` 35/35, `test_dash_cb_payee` 12/12, `test_dash_broadcaster_full` 16/16.
- Consensus grep `get_share_bits|share_bits|share_target|DGW|oracle|payout|pplns` over the diff: **empty** — fallback-arm reward-safe logic and share/payout math untouched.

M2 (E5 comment-magic fix) rides the #776 branch separately.