### PR TITLE
dash(embedded): SML + QuorumManager -> real CCbTx (TESTNET-PROVING, interim mainnet gate)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -845,10 +845,24 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     dash::coin::P2pRelaySink p2p_relay;
     if (coin_p2p && !no_p2p_relay) {
         p2p_relay =
-            [&ioc, &coin_p2p](const std::vector<unsigned char>& block_bytes) {
+            [&ioc, &coin_p2p](const std::vector<unsigned char>& block_bytes) -> bool {
+                // H1 honest reporting: submit_block_p2p_raw SILENTLY DROPS a won
+                // block when the coin-P2P peer is disconnected, and the io::post
+                // returns before the send even runs -- so only claim a P2P relay
+                // when the peer is actually connected+handshaked at dispatch time.
+                // If not, return false so broadcast_won_block relies on ARM B
+                // (submitblock RPC) and the NEVER-SILENT-DROP contract holds
+                // (loud dispatcher log if neither arm is reachable).
+                if (!coin_p2p || !coin_p2p->is_handshake_complete()) {
+                    std::cout << "[DASH-STRATUM-BLOCK] embedded P2P relay skipped: "
+                                 "coin-P2P peer not connected/handshaked -- relying "
+                                 "on submitblock-RPC backup\n";
+                    return false;
+                }
                 io::post(ioc, [&coin_p2p, bytes = block_bytes]() {
                     if (coin_p2p) coin_p2p->submit_block_p2p_raw(bytes);
                 });
+                return true;
             };
     } else if (no_p2p_relay) {
         std::cout << "[run] --no-p2p-relay: embedded P2P-relay arm SUPPRESSED; "
@@ -1292,6 +1306,33 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         coin_feed_subs.push_back(
             c2pool::dash::wire_mn_list_ingest(coin_state, *maintainer));
 
+        // Leg 5 (SML axis — DAEMONLESS CCbTx, v0.2.4 critical path): the raw
+        // mnlistdiff off the live coin-P2P feed advances the SML
+        // (merkleRootMNList) + QuorumManager (merkleRootQuorums) + seeds
+        // bestCL*/creditPool via CoinStateMaintainer::on_mnlistdiff. This is
+        // what makes the embedded coinbase's DIP-0004 type-5 payload
+        // MAINNET-VALID (review finding C1). Distinct from leg 4 (the RPC-seeded PAYEE
+        // axis). The getmnlistd request driver below primes it.
+        coin_feed_subs.push_back(
+            c2pool::dash::wire_mnlistdiff_ingest(coin_state, *maintainer));
+
+        // getmnlistd base tracker: the block hash the local SML is current at.
+        // Cold start = ZERO (full snapshot). Each accepted mnlistdiff advances
+        // it to diff.blockHash so the NEXT request is an incremental diff off
+        // the last synced point (avoids re-pulling the full ~450 kB list).
+        auto sml_base = std::make_shared<uint256>(uint256::ZERO);
+        coin_feed_subs.push_back(
+            coin_state.new_mnlistdiff.subscribe(
+                [sml_base](const dash::coin::vendor::CSimplifiedMNListDiff& d) {
+                    *sml_base = d.blockHash;
+                }));
+
+        // review finding H3: the embedded arm must NOT serve a template without a valid
+        // CCbTx (that block is consensus-invalid on mainnet). Gate embedded
+        // viability on an applied SML — until the first mnlistdiff lands, and
+        // after any reorg wipe, get_work stays on the retained dashd fallback.
+        node_coin_state.set_require_sml(true);
+
         // Bridge: new_headers -> HeaderChain::add_headers (X11 PoW + DGW
         // validated). The tip authority for the embedded template.
         coin_feed_subs.push_back(
@@ -1346,7 +1387,8 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         // stale work between job-push timer firings (event-driven notify).
         header_chain->set_on_tip_changed(
             [&coin_state, &stratum_server, hc = header_chain.get(),
-             addr_ver, p2sh_ver, ws = work_source.get()]
+             addr_ver, p2sh_ver, ws = work_source.get(),
+             cp = coin_p2p.get(), sml_base]
             (const uint256&, uint32_t, const uint256& new_tip, uint32_t new_height) {
                 auto ta = dash::coin::tip_advance_from_chain(
                     *hc, addr_ver, p2sh_ver);
@@ -1357,6 +1399,13 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                              << " bits=0x" << std::hex << ta->bits_for_next << std::dec
                              << " -> new_tip fired (maintainer arm)";
                 }
+                // SML axis: pull the mnlistdiff current AT the new tip. dashcore
+                // computes block (tip+1)'s CbTx merkleRootMNList/Quorums from the
+                // DMN/quorum list as-of `tip` (GetListForBlock(pindexPrev)), so
+                // targeting the diff at `new_tip` puts the local SML in exactly
+                // the state needed to build tip+1. Incremental off the last
+                // synced base; the new_mnlistdiff subscription advances sml_base.
+                if (cp) cp->send_getmnlistd(*sml_base, new_tip);
                 // #739: event-driven stale-work notify.
                 if (ws) ws->bump_work_generation();
                 if (stratum_server) stratum_server->notify_all();
@@ -1380,11 +1429,18 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         // Kick the initial sync once the version/verack handshake completes:
         // getheaders off our current locator + a mempool prime.
         coin_p2p->set_on_handshake_complete(
-            [cp = coin_p2p.get(), hc = header_chain.get()]() {
+            [cp = coin_p2p.get(), hc = header_chain.get(), sml_base]() {
                 LOG_INFO << "[EMB-DASH] handshake complete -> initial sync:"
-                            " getheaders + mempool";
+                            " getheaders + mempool + mnlistdiff(cold)";
                 cp->send_getheaders(70230, hc->get_locator(), uint256::ZERO);
                 cp->send_mempool();
+                // Cold-start SML sync: full snapshot (base=ZERO) up to our best
+                // known header tip. Steady-state incremental diffs then ride the
+                // tip-changed driver. If the header chain is still empty at
+                // handshake, target ZERO too — the first tip-change re-requests.
+                auto tip_entry = hc->tip();
+                const uint256 tip = tip_entry ? tip_entry->hash : uint256::ZERO;
+                cp->send_getmnlistd(*sml_base, tip);
             });
 
         std::cout << "[run] E2a live-feed wired: header-chain(" << hdr_db

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -1333,6 +1333,33 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         // after any reorg wipe, get_work stays on the retained dashd fallback.
         node_coin_state.set_require_sml(true);
 
+        // H-6: SML/quorum apply and bestCL adoption move ASYNCHRONOUSLY to the
+        // header tip. When they advance (catching the SML up to a moved tip, or
+        // adopting a fresher ChainLock) the served template changes but no tip
+        // signal fires — so drive the same re-issue path the tip-change uses.
+        // A reorg wipe also routes here so miners drop the orphaned-branch
+        // template immediately. (weak_ptr so a late event can't resurrect a
+        // torn-down work source during shutdown.)
+        {
+            std::weak_ptr<dash::stratum::DASHWorkSource> ws_dirty = work_source;
+            maintainer->set_on_state_dirty(
+                [ws_dirty, &stratum_server]() {
+                    if (auto ws = ws_dirty.lock()) ws->bump_work_generation();
+                    if (stratum_server) stratum_server->notify_all();
+                });
+        }
+
+        // Leg 6 (ChainLock sig): Node::new_chainlock_sig -> maintainer
+        // .on_new_chainlock. The clsig message carries the recovered 96-byte
+        // threshold sig (new_chainlock above drops it); the maintainer adopts
+        // the freshest observed ChainLock height+sig as the CCbTx bestCL*.
+        coin_feed_subs.push_back(
+            coin_state.new_chainlock_sig.subscribe(
+                [m = maintainer.get()]
+                (const dash::interfaces::Node::ChainLockSigEvent& c) {
+                    m->on_new_chainlock(c.height, c.sig);
+                }));
+
         // Bridge: new_headers -> HeaderChain::add_headers (X11 PoW + DGW
         // validated). The tip authority for the embedded template.
         coin_feed_subs.push_back(
@@ -1388,8 +1415,9 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         header_chain->set_on_tip_changed(
             [&coin_state, &stratum_server, hc = header_chain.get(),
              addr_ver, p2sh_ver, ws = work_source.get(),
-             cp = coin_p2p.get(), sml_base]
-            (const uint256&, uint32_t, const uint256& new_tip, uint32_t new_height) {
+             cp = coin_p2p.get(), sml_base, m = maintainer.get()]
+            (const uint256&, uint32_t, const uint256& new_tip, uint32_t new_height,
+             bool was_reorg) {
                 auto ta = dash::coin::tip_advance_from_chain(
                     *hc, addr_ver, p2sh_ver);
                 if (ta) {
@@ -1399,14 +1427,31 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                              << " bits=0x" << std::hex << ta->bits_for_next << std::dec
                              << " -> new_tip fired (maintainer arm)";
                 }
+                // C-2 reorg wiring: a branch switch invalidates the incremental
+                // SML (its applied diffs were relative to the orphaned branch).
+                // Wipe + drop have_sml so the embedded arm falls back to dashd,
+                // reset the sync base to ZERO, and re-request a FULL cold-start
+                // snapshot at the new tip (an incremental diff off the stale base
+                // would be rejected by the base-continuity guard anyway).
+                if (was_reorg && m) {
+                    LOG_WARNING << "[SML] reorg to h=" << new_height
+                                << " -> SML wipe + cold-resync";
+                    m->on_sml_reorg();
+                    *sml_base = uint256::ZERO;
+                }
                 // SML axis: pull the mnlistdiff current AT the new tip. dashcore
                 // computes block (tip+1)'s CbTx merkleRootMNList/Quorums from the
                 // DMN/quorum list as-of `tip` (GetListForBlock(pindexPrev)), so
                 // targeting the diff at `new_tip` puts the local SML in exactly
                 // the state needed to build tip+1. Incremental off the last
-                // synced base; the new_mnlistdiff subscription advances sml_base.
+                // synced base (ZERO after a reorg = full snapshot); the
+                // new_mnlistdiff subscription advances sml_base on acceptance.
                 if (cp) cp->send_getmnlistd(*sml_base, new_tip);
-                // #739: event-driven stale-work notify.
+                // #739: event-driven stale-work notify. NOTE: the freshness gate
+                // now holds the embedded arm on the dashd fallback until the
+                // getmnlistd above lands and re-notifies (maintainer state-dirty),
+                // so this notify serves the reward-safe fallback, not a stale-SML
+                // embedded template.
                 if (ws) ws->bump_work_generation();
                 if (stratum_server) stratum_server->notify_all();
             });

--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -40,6 +40,7 @@
 
 #include <array>
 #include <cstdint>
+#include <functional>
 #include <utility>
 #include <vector>
 
@@ -97,6 +98,23 @@ public:
     /// SML at exactly the state dashd commits for TIP+1 is the #1 item the live
     /// byte-parity KAT against a running dashd must confirm; do not assume.
     void on_mnlistdiff(const vendor::CSimplifiedMNListDiff& diff) {
+        // H-7 base-continuity: an INCREMENTAL diff is only valid when its
+        // baseBlockHash matches the block our SML is currently current at.
+        // Applying a diff whose base is some other block upserts/erases MN
+        // records relative to a state we are not in — silently corrupting the
+        // SML (ghost MNs, wrong merkleRootMNList). A ZERO base is a full
+        // snapshot and always safe (it replaces, not patches). Reject + keep the
+        // prior SML (the tip-change driver re-requests off the correct base).
+        const uint256 have_at = m_state.sml_current_hash();
+        if (!diff.baseBlockHash.IsNull() && !have_at.IsNull()
+            && diff.baseBlockHash != have_at) {
+            LOG_WARNING << "[SML] REJECT diff: base "
+                        << diff.baseBlockHash.GetHex().substr(0, 16)
+                        << " != SML-current " << have_at.GetHex().substr(0, 16)
+                        << " (base-continuity guard) — awaiting a diff off our base";
+            return;
+        }
+
         // 1) SML (merkleRootMNList). apply_diff erases deletedMNs, upserts
         //    diff.mnList, and re-sorts by proRegTxHash (memcmp order — the
         //    Bug-A-critical ordering, already pinned by test_dash_simplifiedmns).
@@ -130,7 +148,11 @@ public:
                         int32_t cb_h = observed.nHeight;
                         int32_t best_h = (cb_h - 1)
                             - static_cast<int32_t>(observed.bestCLHeightDiff);
-                        if (best_h > 0)
+                        // H-7 monotonic-bestCL: only adopt a ChainLock that does
+                        // NOT regress our best. A stale/replayed diff carrying an
+                        // older bestCL must not roll the committed bestCL* back
+                        // (that would desync the next template's CCbTx from dashd).
+                        if (best_h > 0 && best_h >= m_state.best_cl_height())
                             m_state.set_best_cl(best_h, observed.bestCLSignature);
                     }
                 }
@@ -139,6 +161,10 @@ public:
 
         m_have_mn_sml = m_state.sml().size() != 0;
         m_state.set_have_sml(m_have_mn_sml);
+        // Record the block the SML is now current at: the freshness gate
+        // (NodeCoinState::make_embedded_work_inputs) compares this to the tip
+        // we build on, and the next incremental diff's base must match it.
+        m_state.set_sml_current_hash(diff.blockHash);
         LOG_INFO << "[SML] applied diff: SML +" << sml_r.added_or_updated
                  << " -" << sml_r.deleted << " => " << m_state.sml().size()
                  << " MNs; quorums +" << q_added << " -" << q_deleted
@@ -148,6 +174,11 @@ public:
             demote();
         else
             republish();
+        // H-6: the SML just advanced (potentially catching up to a moved tip).
+        // Bump work-generation + re-notify so a fresh template is issued now
+        // that the freshness gate can pass — otherwise miners stay on the dashd
+        // fallback until the next unrelated work signal.
+        notify_state_dirty();
     }
 
     /// ChainLock reception: adopt the freshly-observed ChainLock as the best CL
@@ -155,8 +186,12 @@ public:
     /// block_hash, 96-byte recovered threshold sig}. Only advances forward.
     void on_new_chainlock(int32_t height,
                           const std::array<uint8_t, 96>& sig) {
-        if (height > m_state.best_cl_height())
+        if (height > m_state.best_cl_height()) {
             m_state.set_best_cl(height, sig);
+            // A fresher bestCL* changes the next template's committed CCbTx —
+            // re-issue work so the served template carries the new ChainLock.
+            notify_state_dirty();
+        }
     }
 
     /// Reorg (SML axis): a chain reorganisation can invalidate the incremental
@@ -171,7 +206,14 @@ public:
         m_state.qmgr().clear();
         m_have_mn_sml = false;
         m_state.set_have_sml(false);
+        // Drop the SML's current-at marker so (a) the freshness gate fails until
+        // a fresh cold-start diff lands, and (b) the next diff is accepted as a
+        // full snapshot (base-continuity guard treats ZERO current as cold).
+        m_state.set_sml_current_hash(uint256::ZERO);
         demote();
+        // Re-issue work so miners are moved off any embedded template that was
+        // built on the now-orphaned branch onto the dashd fallback immediately.
+        notify_state_dirty();
     }
 
     /// Reception path (mempool relay): fold a relayed tx into the local
@@ -246,10 +288,24 @@ public:
         demote();
     }
 
+    /// Wire a "state changed, re-issue work" sink (main_dash points this at
+    /// DASHWorkSource::bump_work_generation + stratum notify_all). Invoked when
+    /// the SML/quorum set advances, the bestCL* moves, or a reorg wipes the
+    /// bundle — the events that change (or invalidate) the next served template
+    /// but do NOT flow through the header tip-change notify. Optional: unset
+    /// (KAT posture) makes every notify_state_dirty() a no-op.
+    void set_on_state_dirty(std::function<void()> fn) {
+        m_on_state_dirty = std::move(fn);
+    }
+
     /// True iff both prerequisites are met AND the holder is currently live.
     bool live() const { return m_state.populated(); }
 
 private:
+    void notify_state_dirty() {
+        if (m_on_state_dirty) m_on_state_dirty();
+    }
+
     // Publish only when both prerequisites are present; otherwise leave the
     // holder in whatever (un)published state it is in -- callers reach demote()
     // explicitly for the invalidating transitions.
@@ -266,6 +322,7 @@ private:
     }
 
     NodeCoinState& m_state;
+    std::function<void()> m_on_state_dirty;  // SML/bestCL/reorg -> re-issue work
 
     bool m_have_mn{false};
     bool m_have_tip{false};

--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -31,9 +31,14 @@
 #include <impl/dash/coin/mn_state_machine.hpp>   // MNState
 #include <impl/dash/coin/block.hpp>            // BlockType
 #include <impl/dash/coin/transaction.hpp>        // MutableTransaction
+#include <impl/dash/coin/vendor/smldiff.hpp>     // vendor::CSimplifiedMNListDiff + apply_diff
+#include <impl/dash/coin/vendor/quorum_tail.hpp> // vendor::parse_quorum_tail
+#include <impl/dash/coin/vendor/cbtx.hpp>        // vendor::parse_cbtx (bestCL*/creditPool seed)
 
 #include <core/uint256.hpp>
+#include <core/log.hpp>
 
+#include <array>
 #include <cstdint>
 #include <utility>
 #include <vector>
@@ -74,6 +79,99 @@ public:
             demote();
         else
             republish();
+    }
+
+    /// Reception path (mnlistdiff, SML axis — DAEMONLESS CCbTx source): apply a
+    /// raw deterministic-MN-list diff off the live coin-P2P feed. This is the
+    /// consensus-commitment counterpart to on_mn_list_update (which drives the
+    /// PAYEE MnStateMachine): it advances the NodeCoinState-held SML
+    /// (merkleRootMNList) and QuorumManager (merkleRootQuorums), and seeds the
+    /// version-appropriate bestCL*/creditPool from the diff's authoritative
+    /// embedded cbTx. All heavy lifting is the already-tested vendor code
+    /// (apply_diff / parse_quorum_tail / parse_cbtx) — this method is the wire.
+    ///
+    /// NOTE (consensus-timing, FLAGGED for byte-parity review): the diff
+    /// advances the SML/quorum set to `diff.blockHash`. dashd's GBT for the
+    /// NEXT block computes the CbTx roots over the DMN/quorum state AS OF that
+    /// next block's connect. Whether requesting mnlistdiff(base, TIP) leaves the
+    /// SML at exactly the state dashd commits for TIP+1 is the #1 item the live
+    /// byte-parity KAT against a running dashd must confirm; do not assume.
+    void on_mnlistdiff(const vendor::CSimplifiedMNListDiff& diff) {
+        // 1) SML (merkleRootMNList). apply_diff erases deletedMNs, upserts
+        //    diff.mnList, and re-sorts by proRegTxHash (memcmp order — the
+        //    Bug-A-critical ordering, already pinned by test_dash_simplifiedmns).
+        auto sml_r = vendor::apply_diff(m_state.sml(), diff);
+
+        // 2) Quorum set (merkleRootQuorums). The opaque tail parser fails SAFE:
+        //    a parse failure logs + skips quorum tracking for this diff without
+        //    aborting SML sync (the SML acceptance gate must not depend on it).
+        vendor::QuorumTail qt;
+        size_t q_added = 0, q_deleted = 0;
+        if (vendor::parse_quorum_tail(diff.quorum_tail, qt)) {
+            auto qr = m_state.qmgr().apply(qt);
+            q_added = qr.added_or_updated;
+            q_deleted = qr.deleted;
+        }
+
+        // 3) bestCL* + creditPool: the diff's embedded cbTx is the coinbase of
+        //    diff.blockHash and its extra_payload is the authoritative type-5
+        //    CCbTx for that height. Seed the fields the roots don't carry so the
+        //    next template's CCbTx matches dashd. Fails SAFE (leaves prior seed).
+        if (diff.cbTx.type == 5 && !diff.cbTx.extra_payload.empty()) {
+            vendor::CCbTx observed;
+            if (vendor::parse_cbtx(diff.cbTx.extra_payload, observed)) {
+                if (observed.nVersion >= vendor::CCbTx::VERSION_CLSIG_AND_BALANCE) {
+                    m_state.set_credit_pool(observed.creditPoolBalance);
+                    // bestCLHeightDiff is relative to (cbHeight-1); recover the
+                    // absolute best-CL height so the next template re-derives its
+                    // own diff against ITS height. Only adopt when the observed
+                    // sig is non-null (a real ChainLock for the window).
+                    if (observed.has_best_cl_signature()) {
+                        int32_t cb_h = observed.nHeight;
+                        int32_t best_h = (cb_h - 1)
+                            - static_cast<int32_t>(observed.bestCLHeightDiff);
+                        if (best_h > 0)
+                            m_state.set_best_cl(best_h, observed.bestCLSignature);
+                    }
+                }
+            }
+        }
+
+        m_have_mn_sml = m_state.sml().size() != 0;
+        m_state.set_have_sml(m_have_mn_sml);
+        LOG_INFO << "[SML] applied diff: SML +" << sml_r.added_or_updated
+                 << " -" << sml_r.deleted << " => " << m_state.sml().size()
+                 << " MNs; quorums +" << q_added << " -" << q_deleted
+                 << " => " << m_state.qmgr().active_count()
+                 << " active; have_sml=" << (m_have_mn_sml ? "yes" : "no");
+        if (!m_have_mn_sml)
+            demote();
+        else
+            republish();
+    }
+
+    /// ChainLock reception: adopt the freshly-observed ChainLock as the best CL
+    /// for the CCbTx bestCL* fields. The clsig message carries {height,
+    /// block_hash, 96-byte recovered threshold sig}. Only advances forward.
+    void on_new_chainlock(int32_t height,
+                          const std::array<uint8_t, 96>& sig) {
+        if (height > m_state.best_cl_height())
+            m_state.set_best_cl(height, sig);
+    }
+
+    /// Reorg (SML axis): a chain reorganisation can invalidate the incremental
+    /// SML/quorum state (the diffs we applied were relative to an orphaned
+    /// branch). Wipe the SML + quorum set and drop have_sml so the embedded arm
+    /// falls back to dashd until a fresh cold-start mnlistdiff(zero, new-tip)
+    /// rebuilds them. main_dash.cpp calls this from the header-chain reorg hook
+    /// and then re-requests a full diff. (Distinct from on_invalidate, which
+    /// only drops tip-readiness and deliberately KEEPS the MN payee list.)
+    void on_sml_reorg() {
+        m_state.sml().mnList.clear();
+        m_state.qmgr().clear();
+        m_have_mn_sml = false;
+        m_state.set_have_sml(false);
+        demote();
     }
 
     /// Reception path (mempool relay): fold a relayed tx into the local
@@ -171,6 +269,7 @@ private:
 
     bool m_have_mn{false};
     bool m_have_tip{false};
+    bool m_have_mn_sml{false};   // a non-empty SML has been applied (CCbTx source)
 
     // Height the last MN-set snapshot was current at (0 = none/unknown);
     // on_block_connected skips re-applying blocks at or below it.

--- a/src/impl/dash/coin/header_chain.hpp
+++ b/src/impl/dash/coin/header_chain.hpp
@@ -369,7 +369,7 @@ public:
             m_pending_tip_change.fired = false;
         }
         if (ptc.fired && m_on_tip_changed)
-            m_on_tip_changed(ptc.old_tip, ptc.old_height, ptc.new_tip, ptc.new_height);
+            m_on_tip_changed(ptc.old_tip, ptc.old_height, ptc.new_tip, ptc.new_height, ptc.was_reorg);
         return true;
     }
 
@@ -408,7 +408,7 @@ public:
             }
         }
         if (last_ptc.fired && m_on_tip_changed)
-            m_on_tip_changed(last_ptc.old_tip, last_ptc.old_height, last_ptc.new_tip, last_ptc.new_height);
+            m_on_tip_changed(last_ptc.old_tip, last_ptc.old_height, last_ptc.new_tip, last_ptc.new_height, last_ptc.was_reorg);
         return accepted;
     }
 
@@ -451,7 +451,9 @@ public:
 
     const DashChainParams& params() const { return m_params; }
 
-    using TipChangedCallback = std::function<void(const uint256&, uint32_t, const uint256&, uint32_t)>;
+    // (old_tip, old_height, new_tip, new_height, was_reorg). was_reorg lets the
+    // SML axis wipe + cold-resync when the tip jumped branches (see PendingTipChange).
+    using TipChangedCallback = std::function<void(const uint256&, uint32_t, const uint256&, uint32_t, bool)>;
     void set_on_tip_changed(TipChangedCallback cb) { m_on_tip_changed = std::move(cb); }
 
 private:
@@ -529,7 +531,10 @@ private:
             m_best_work = entry.chain_work;
             m_tip = bhash;
             m_tip_height = new_height;
-            if (new_height == old_height + 1 && entry.prev_hash == m_height_index[old_height]) {
+            bool linear_extension =
+                new_height == old_height + 1
+                && entry.prev_hash == m_height_index[old_height];
+            if (linear_extension) {
                 m_height_index[new_height] = bhash;
             } else {
                 rebuild_height_index(bhash);
@@ -554,6 +559,10 @@ private:
                 }
             }
             m_pending_tip_change.fired = true;
+            // A rebuilt height index with a pre-existing chain (old_height>0)
+            // means the new tip did not linearly extend the old one — a reorg
+            // the SML axis must react to.
+            m_pending_tip_change.was_reorg = !linear_extension && old_height > 0;
             m_pending_tip_change.old_tip = old_tip;
             m_pending_tip_change.old_height = old_height;
             m_pending_tip_change.new_tip = bhash;
@@ -734,6 +743,11 @@ private:
 
     struct PendingTipChange {
         bool fired{false};
+        // was_reorg: the tip advanced onto a branch that does NOT directly
+        // extend the previous tip (the height index had to be rebuilt). The
+        // SML axis consumes this to wipe + cold-resync the incremental SML,
+        // whose applied diffs were relative to the now-orphaned branch.
+        bool was_reorg{false};
         uint256 old_tip, new_tip;
         uint32_t old_height{0}, new_height{0};
     };

--- a/src/impl/dash/coin/mn_list_ingest.hpp
+++ b/src/impl/dash/coin/mn_list_ingest.hpp
@@ -62,4 +62,20 @@ wire_mn_list_ingest(::dash::interfaces::Node& node,
         });
 }
 
+// Subscribe maint to node.new_mnlistdiff: the SML axis (DAEMONLESS CCbTx). Each
+// parsed mnlistdiff off the live coin-P2P feed advances the SML
+// (merkleRootMNList) + QuorumManager (merkleRootQuorums) + seeds bestCL*/
+// creditPool via CoinStateMaintainer::on_mnlistdiff. Distinct from
+// wire_mn_list_ingest above (the PAYEE axis). Returns the subscription handle.
+inline std::shared_ptr<EventDisposable>
+wire_mnlistdiff_ingest(::dash::interfaces::Node& node,
+                       ::dash::coin::CoinStateMaintainer& maint)
+{
+    return node.new_mnlistdiff.subscribe(
+        [&maint](const ::dash::coin::vendor::CSimplifiedMNListDiff& diff)
+        {
+            maint.on_mnlistdiff(diff);
+        });
+}
+
 } // namespace c2pool::dash

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -23,9 +23,12 @@
 #include <impl/dash/coin/mn_state_machine.hpp>   // MnStateMachine
 #include <impl/dash/coin/mempool.hpp>            // Mempool
 #include <impl/dash/coin/rpc_data.hpp>           // DashWorkData
+#include <impl/dash/coin/quorum_manager.hpp>     // QuorumManager (merkleRootQuorums source)
+#include <impl/dash/coin/vendor/simplifiedmns.hpp> // vendor::CSimplifiedMNList (merkleRootMNList source)
 
 #include <core/uint256.hpp>
 
+#include <array>
 #include <cstdint>
 #include <functional>
 
@@ -47,6 +50,45 @@ public:
     // these from mnlistdiff + relayed mempool txs).
     MnStateMachine& mnstates() { return m_mnstates; }
     Mempool&        mempool()  { return m_mempool; }
+
+    // ── SML / quorum consensus-commitment state (daemonless CCbTx) ────────
+    // The deterministic MN list + LLMQ quorum set the CCbTx extra_payload
+    // commits to. Populated by CoinStateMaintainer::on_mnlistdiff (apply_diff
+    // + QuorumManager::apply) off the live coin-P2P mnlistdiff feed. These are
+    // the merkleRootMNList / merkleRootQuorums sources build_embedded_workdata
+    // needs to emit a MAINNET-VALID type-5 coinbase. In-memory only (no
+    // SMLDb/QuorumDb persistence yet — a restart re-requests a cold-start
+    // mnlistdiff(zero, tip), see main_dash.cpp handshake driver).
+    vendor::CSimplifiedMNList& sml() { return m_sml; }
+    QuorumManager&             qmgr() { return m_qmgr; }
+    const vendor::CSimplifiedMNList& sml() const { return m_sml; }
+    const QuorumManager&             qmgr() const { return m_qmgr; }
+
+    /// Mark whether a valid SML is present (set by the maintainer after the
+    /// first accepted mnlistdiff yields a non-empty list). When require_sml
+    /// is enabled (the mainnet / DIP-0004 posture), viability additionally
+    /// requires this — the embedded arm must NOT serve a template with an
+    /// empty/absent CCbTx (that block would be consensus-invalid).
+    void set_have_sml(bool v) { m_have_sml = v; }
+    bool have_sml() const { return m_have_sml; }
+
+    /// Seed the version-appropriate CCbTx fields the SML/quorum roots do not
+    /// carry: the best-ChainLock height+signature and the DIP-0027 credit-pool
+    /// balance. Sourced by the maintainer from the diff's embedded cbTx (the
+    /// authoritative wire form as-of blockHash) and from new_chainlock events.
+    void set_best_cl(int32_t height, const std::array<uint8_t, 96>& sig) {
+        m_best_cl_height = height;
+        m_best_cl_sig    = sig;
+    }
+    void set_credit_pool(int64_t balance) { m_credit_pool = balance; }
+    int32_t best_cl_height() const { return m_best_cl_height; }
+    int64_t credit_pool() const { return m_credit_pool; }
+
+    /// Enable the SML-required viability gate. main_dash.cpp turns this on for
+    /// the embedded coin-P2P arm so a template is only served once the CCbTx
+    /// commitment inputs are present (review finding H3: no mid-sync half-built block).
+    /// Default OFF preserves the pre-CCbTx KAT/testnet posture byte-for-byte.
+    void set_require_sml(bool v) { m_require_sml = v; }
 
     /// Record the header-tip parameters and mark the bundle live. Call after
     /// the tip advances AND the MN list + mempool are seeded; until then the
@@ -91,7 +133,8 @@ public:
     EmbeddedWorkInputs make_embedded_work_inputs() const {
         EmbeddedWorkInputs e;
         e.has_state            = m_populated
-                                 && (!m_utxo_ready_fn || m_utxo_ready_fn());
+                                 && (!m_utxo_ready_fn || m_utxo_ready_fn())
+                                 && (!m_require_sml || m_have_sml);
         e.prev_height          = m_prev_height;
         e.prev_hash            = m_prev_hash;
         e.mnstates             = &m_mnstates;
@@ -102,6 +145,19 @@ public:
         e.address_p2sh_version = m_address_p2sh_version;
         e.curtime              = m_curtime;
         e.version              = m_version;
+        // CCbTx seams: pass the SML + quorum set ONLY when present, so a
+        // legacy/testnet-without-SML bundle still builds the pre-CCbTx template
+        // (empty payload) byte-for-byte, while a live daemonless bundle emits
+        // the real type-5 coinbase. build_embedded_workdata folds these into
+        // build_embedded_cbtx (merkleRootMNList + merkleRootQuorums + bestCL* +
+        // creditPool) when both pointers are non-null.
+        if (m_have_sml) {
+            e.sml              = &m_sml;
+            e.qmgr             = &m_qmgr;
+            e.best_cl_height   = m_best_cl_height;
+            e.best_cl_sig      = m_best_cl_sig;
+            e.credit_pool      = m_credit_pool;
+        }
         return e;
     }
 
@@ -118,6 +174,13 @@ public:
 private:
     MnStateMachine m_mnstates;
     Mempool        m_mempool;
+    vendor::CSimplifiedMNList m_sml;         // merkleRootMNList source (mnlistdiff-fed)
+    QuorumManager  m_qmgr;                    // merkleRootQuorums source (quorum-tail-fed)
+    int32_t  m_best_cl_height{0};             // best observed ChainLock height
+    std::array<uint8_t, 96> m_best_cl_sig{};  // best observed ChainLock signature
+    int64_t  m_credit_pool{0};                // DIP-0027 credit-pool balance (seeded from cbTx)
+    bool     m_have_sml{false};               // a non-empty SML has been applied
+    bool     m_require_sml{false};            // gate viability on have_sml (embedded arm)
     std::function<bool()> m_utxo_ready_fn;   // optional UTXO maturity gate (E2b)
     uint32_t m_prev_height{0};
     uint256  m_prev_hash;

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -72,6 +72,16 @@ public:
     void set_have_sml(bool v) { m_have_sml = v; }
     bool have_sml() const { return m_have_sml; }
 
+    /// The block hash the applied SML is CURRENT AT (== the last accepted
+    /// mnlistdiff's blockHash; ZERO before the first diff / after a reorg wipe).
+    /// Under require_sml, template viability additionally requires this to equal
+    /// the tip we are building on (prev_hash) — so during the tip-change ->
+    /// getmnlistd round-trip, before the fresh diff lands, the embedded arm
+    /// serves nothing (H-6: no stale-SML template at a moved tip; fail to the
+    /// dashd fallback until the SML catches up to the new tip).
+    void set_sml_current_hash(const uint256& h) { m_sml_current_hash = h; }
+    const uint256& sml_current_hash() const { return m_sml_current_hash; }
+
     /// Seed the version-appropriate CCbTx fields the SML/quorum roots do not
     /// carry: the best-ChainLock height+signature and the DIP-0027 credit-pool
     /// balance. Sourced by the maintainer from the diff's embedded cbTx (the
@@ -134,7 +144,9 @@ public:
         EmbeddedWorkInputs e;
         e.has_state            = m_populated
                                  && (!m_utxo_ready_fn || m_utxo_ready_fn())
-                                 && (!m_require_sml || m_have_sml);
+                                 && (!m_require_sml
+                                     || (m_have_sml
+                                         && m_sml_current_hash == m_prev_hash));
         e.prev_height          = m_prev_height;
         e.prev_hash            = m_prev_hash;
         e.mnstates             = &m_mnstates;
@@ -180,6 +192,7 @@ private:
     std::array<uint8_t, 96> m_best_cl_sig{};  // best observed ChainLock signature
     int64_t  m_credit_pool{0};                // DIP-0027 credit-pool balance (seeded from cbTx)
     bool     m_have_sml{false};               // a non-empty SML has been applied
+    uint256  m_sml_current_hash;              // block hash the SML is current at (ZERO = cold/reorg)
     bool     m_require_sml{false};            // gate viability on have_sml (embedded arm)
     std::function<bool()> m_utxo_ready_fn;   // optional UTXO maturity gate (E2b)
     uint32_t m_prev_height{0};

--- a/src/impl/dash/coin/node_interface.hpp
+++ b/src/impl/dash/coin/node_interface.hpp
@@ -4,6 +4,7 @@
 #include "block.hpp"
 #include "transaction.hpp"
 #include "mn_state_machine.hpp"
+#include "vendor/smldiff.hpp"   // vendor::CSimplifiedMNListDiff (SML-axis reception feed)
 
 #include <core/uint256.hpp>
 #include <core/events.hpp>
@@ -106,6 +107,20 @@ struct Node
     // real feed (block_connected only folds per-block deltas between snapshots);
     // an empty snapshot demotes the bundle to the dashd fallback.
     Event<MnListUpdate> mn_list_update;
+
+    // Reception path (SML axis, daemonless): fires when the coin-P2P client
+    // parses a `mnlistdiff` message, carrying the RAW deterministic-MN-list
+    // diff (vendor::CSimplifiedMNListDiff) straight off the wire. Distinct from
+    // mn_list_update above, which is the PAYEE feed (MnStateMachine, MNState
+    // with scriptPayout + lastPaidHeight, seeded from dashd RPC `protx list`).
+    // The SML axis feeds the CONSENSUS-COMMITMENT machinery instead: the diff's
+    // mnList/deletedMNs advance the vendor::CSimplifiedMNList whose
+    // CalcMerkleRoot() is the CCbTx merkleRootMNList, and its opaque quorum
+    // tail advances the QuorumManager whose compute_merkle_root_quorums() is
+    // the CCbTx merkleRootQuorums. The diff's embedded cbTx also carries the
+    // authoritative bestCL* + creditPoolBalance as-of blockHash, which the
+    // maintainer seeds forward. CoinStateMaintainer::on_mnlistdiff subscribes.
+    Event<coin::vendor::CSimplifiedMNListDiff> new_mnlistdiff;
 
     // SPV A1 (parity audit): fires when dashd announces a ChainLock has
     // been aggregated for a block. Carries {block_hash, height}.

--- a/src/impl/dash/coin/node_interface.hpp
+++ b/src/impl/dash/coin/node_interface.hpp
@@ -9,6 +9,7 @@
 #include <core/uint256.hpp>
 #include <core/events.hpp>
 
+#include <array>
 #include <cstdint>
 #include <map>
 #include <utility>
@@ -129,6 +130,19 @@ struct Node
     // irreversible.
     Event<std::pair<uint256, int32_t>> new_chainlock;
     std::map<uint256, int32_t> chainlocked_blocks; // block_hash -> height
+
+    // ChainLock reception WITH the recovered 96-byte threshold signature. The
+    // clsig wire message carries {height, block_hash, sig(96B)}; new_chainlock
+    // above intentionally drops the sig (it only feeds the finalization map).
+    // The daemonless CCbTx path needs the sig itself: bestCLSignature is a
+    // committed field of the type-5 coinbase payload, so the maintainer adopts
+    // the freshest observed ChainLock's height + sig via on_new_chainlock.
+    struct ChainLockSigEvent {
+        int32_t                  height{0};
+        uint256                  block_hash;
+        std::array<uint8_t, 96>  sig{};
+    };
+    Event<ChainLockSigEvent> new_chainlock_sig;
 
     std::map<uint256, coin::Transaction> known_txs;
 };

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -45,6 +45,7 @@
 
 #include <impl/dash/crypto/hash_x11.hpp>   // block identity on Dash = X11(header)
 
+#include <algorithm>
 #include <memory>
 #include <string>
 #include <vector>
@@ -628,6 +629,17 @@ private:
         LOG_INFO << "[" << m_chain_label << "] chainlock: height=" << msg->m_height
                  << " block=" << msg->m_block_hash.GetHex().substr(0, 16) << "...";
         m_coin->new_chainlock.happened({msg->m_block_hash, msg->m_height});
+        // Daemonless CCbTx path: forward the recovered 96-byte threshold sig so
+        // the maintainer can adopt this ChainLock as the coinbase bestCLSignature.
+        // m_sig is decoded as a fixed 96-byte array (p2p_messages.hpp clsig);
+        // guard the copy defensively in case a peer sent a short blob.
+        if (msg->m_sig.size() == 96) {
+            ::dash::interfaces::Node::ChainLockSigEvent ev;
+            ev.height     = msg->m_height;
+            ev.block_hash = msg->m_block_hash;
+            std::copy(msg->m_sig.begin(), msg->m_sig.end(), ev.sig.begin());
+            m_coin->new_chainlock_sig.happened(ev);
+        }
     }
 
     ADD_P2P_HANDLER(mnlistdiff)

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -632,9 +632,22 @@ private:
 
     ADD_P2P_HANDLER(mnlistdiff)
     {
-        // SML snapshot — the CoinStateMaintainer::on_mn_list_update feed is a
-        // later slice; receipt is logged so the live wire is observable.
-        LOG_INFO << "[" << m_chain_label << "] mnlistdiff received (SML ingest is E2+)";
+        // SML/quorum snapshot. message_mnlistdiff already fully deserialized the
+        // wire form into msg->m_diff (a vendor::CSimplifiedMNListDiff, see
+        // p2p_messages.hpp) — apply_diff + the QuorumTail parser + the CCbTx
+        // seed all consume it downstream. Fire the reception event so the
+        // subscribed CoinStateMaintainer::on_mnlistdiff advances the local SML
+        // (merkleRootMNList), the QuorumManager (merkleRootQuorums), and seeds
+        // bestCL*/creditPool from the diff's embedded cbTx. With no subscriber
+        // (E1 posture / coin-P2P off) this is a no-op and the node keeps taking
+        // the retained dashd-RPC fallback — zero behavior change on that path.
+        LOG_INFO << "[" << m_chain_label << "] mnlistdiff: base="
+                 << msg->m_diff.baseBlockHash.GetHex().substr(0, 16)
+                 << " tip=" << msg->m_diff.blockHash.GetHex().substr(0, 16)
+                 << " +" << msg->m_diff.mnList.size() << "mn -"
+                 << msg->m_diff.deletedMNs.size() << "del qtail="
+                 << msg->m_diff.quorum_tail.size() << "B";
+        m_coin->new_mnlistdiff.happened(msg->m_diff);
     }
 
     // ── tolerated / ignored peer traffic ─────────────────────────────────

--- a/src/impl/dash/coin/rpc.cpp
+++ b/src/impl/dash/coin/rpc.cpp
@@ -412,11 +412,16 @@ void NodeRPC::submit_block(BlockType& block, bool ignore_failure)
 bool NodeRPC::submit_block_hex(const std::string& block_hex, bool ignore_failure)
 {
     auto result = m_client.CallMethod<nlohmann::json>(ID, "submitblock", {block_hex});
-    bool success = result.is_null();
+    // Dual-path contract (M1): a "duplicate"/"inconclusive"/already-have result
+    // means the OTHER broadcast arm already landed this block on the network —
+    // that is SUCCESS, not failure. See submitblock_result_accepted().
+    const bool success = dash::coin::submitblock_result_accepted(result);
     if (!success && !ignore_failure)
         LOG_ERROR << "submit_block_hex result: " << result.dump();
     else if (success)
-        LOG_INFO << "submit_block_hex accepted";
+        LOG_INFO << "submit_block_hex accepted"
+                 << (result.is_null() ? std::string{}
+                                      : " (already on network: " + result.dump() + ")");
     return success;
 }
 

--- a/src/impl/dash/coin/rpc_data.hpp
+++ b/src/impl/dash/coin/rpc_data.hpp
@@ -53,6 +53,27 @@ inline PackedPayment normalize_payment(const nlohmann::json& entry)
     return pp;
 }
 
+// Classify a dashd `submitblock` RPC result under the dual-path won-block
+// contract (M1). submitblock returns null on accept; a non-null string is a
+// reject reason. A "duplicate" / "inconclusive" / "already-have" result means
+// the block is ALREADY on the network — the OTHER broadcast arm (embedded P2P
+// relay, or a peer) landed it first — which is SUCCESS (the block reached the
+// network), NOT a failure. "duplicate-invalid" is the one exception: the block
+// was rejected as invalid, a genuine failure. Pure over the JSON so the KAT can
+// pin it without a live RPC client.
+inline bool submitblock_result_accepted(const nlohmann::json& result)
+{
+    if (result.is_null()) return true;
+    if (!result.is_string()) return false;
+    std::string code = result.get<std::string>();
+    for (char& c : code)
+        if (c >= 'A' && c <= 'Z') c = static_cast<char>(c - 'A' + 'a');
+    const bool already_have = code == "duplicate"
+                           || code.find("inconclusive") != std::string::npos
+                           || code.find("already") != std::string::npos;
+    return already_have && code.find("invalid") == std::string::npos;
+}
+
 struct DashWorkData {
     // Raw getblocktemplate JSON response (kept for fallback access to fields
     // we haven't promoted to members yet).

--- a/src/impl/dash/coin/won_block_dispatch.hpp
+++ b/src/impl/dash/coin/won_block_dispatch.hpp
@@ -52,7 +52,14 @@ namespace coin
 // Embedded P2P relay sink (ARM A, primary): the run-loop binds this to the E1
 // CoinClient's submit_block_p2p_raw. EMPTY == no embedded P2P sink present
 // (no --coin-p2p-connect peer, or --no-p2p-relay suppression).
-using P2pRelaySink = std::function<void(const std::vector<unsigned char>&)>;
+//
+// RETURNS true iff the block was actually relayed onto a CONNECTED coin-P2P
+// peer (H1 honest-reporting contract). submit_block_p2p_raw SILENTLY DROPS a
+// won block when the peer is disconnected, so the sink MUST report false in
+// that case — otherwise the dispatcher would claim landed_first=p2p while the
+// block was dropped, falsely relying on a dead arm instead of the submitblock
+// RPC backup.
+using P2pRelaySink = std::function<bool(const std::vector<unsigned char>&)>;
 
 // submitblock RPC sink (ARM B, backup): the run-loop binds this to
 // NodeRPC::submit_block_hex. Returns true iff dashd accepted (or duplicate).
@@ -64,7 +71,7 @@ using RpcSubmitSink = std::function<bool(const std::string&)>;
 // which path was engaged first for the record.
 struct BlockBroadcast
 {
-    bool        p2p_sent     = false;   // embedded P2P relay issued (sink present)
+    bool        p2p_sent     = false;   // embedded P2P relay issued to a CONNECTED peer
     bool        rpc_ok       = false;   // submitblock returned ok OR duplicate
     const char* landed_first = "none";  // "p2p" | "rpc" | "none"
 
@@ -92,11 +99,22 @@ inline BlockBroadcast broadcast_won_block(const P2pRelaySink& p2p_relay,
     // block (lost subsidy).
     if (p2p_relay) {
         try {
-            p2p_relay(block_bytes);
-            r.p2p_sent = true;
-            r.landed_first = "p2p";
-            LOG_INFO << "[EMB-DASH] won-block embedded P2P relay issued ("
-                     << block_bytes.size() << " bytes) -- primary path.";
+            // H1 honest reporting: only claim p2p_sent when the sink confirms the
+            // block was relayed onto a CONNECTED peer. A disconnected coin-P2P
+            // peer means submit_block_p2p_raw would silently drop the block, so
+            // the sink returns false and we rely on ARM B instead of masking the
+            // loss with a false landed_first=p2p.
+            const bool relayed = p2p_relay(block_bytes);
+            if (relayed) {
+                r.p2p_sent = true;
+                r.landed_first = "p2p";
+                LOG_INFO << "[EMB-DASH] won-block embedded P2P relay issued ("
+                         << block_bytes.size() << " bytes) -- primary path.";
+            } else {
+                LOG_WARNING << "[EMB-DASH] won-block embedded P2P relay NOT sent "
+                               "(coin-P2P peer not connected/handshaked) -- "
+                               "relying on submitblock RPC backup.";
+            }
         } catch (const std::exception& e) {
             LOG_ERROR << "[EMB-DASH] won-block embedded P2P relay threw (" << e.what()
                       << ") -- falling through to submitblock RPC backup.";

--- a/src/impl/dash/coin/work_source.hpp
+++ b/src/impl/dash/coin/work_source.hpp
@@ -25,6 +25,7 @@
 
 #include <core/uint256.hpp>
 
+#include <array>
 #include <ctime>
 #include <cstdint>
 #include <functional>
@@ -51,6 +52,17 @@ struct EmbeddedWorkInputs {
     // defaults (std::time(nullptr) / 0x20000000 BIP9 baseline).
     uint32_t              curtime{0};
     uint32_t              version{0};
+
+    // CCbTx (DIP-0004 type-5 extra_payload) seams. When sml AND qmgr are both
+    // non-null, build_embedded_workdata folds the real type-5 payload
+    // (merkleRootMNList + merkleRootQuorums + version-appropriate bestCL* +
+    // creditPool) so the assembled coinbase is MAINNET-VALID. Left null by
+    // legacy callers => empty payload (pre-CCbTx behavior, byte-unchanged).
+    const vendor::CSimplifiedMNList* sml{nullptr};
+    const QuorumManager*             qmgr{nullptr};
+    int32_t                          best_cl_height{0};
+    std::array<uint8_t, 96>          best_cl_sig{};
+    int64_t                          credit_pool{0};
 
     bool viable() const {
         return has_state && mnstates != nullptr && mempool != nullptr;
@@ -93,7 +105,14 @@ inline WorkSelection select_dash_work(
                 emb.address_version, emb.address_p2sh_version,
                 emb.curtime ? emb.curtime
                             : static_cast<uint32_t>(std::time(nullptr)),
-                emb.version ? emb.version : 0x20000000u);
+                emb.version ? emb.version : 0x20000000u,
+                // underfill-observation seam left default (nullptr); the CCbTx
+                // seams thread the SML/quorum/bestCL/creditPool through so the
+                // LIVE embedded arm emits the real type-5 payload (empty when
+                // sml/qmgr null — legacy callers unchanged).
+                /*underfill_tripped=*/nullptr,
+                emb.sml, emb.qmgr,
+                emb.best_cl_height, emb.best_cl_sig, emb.credit_pool);
         },
         dashd_fallback);
 }

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -50,6 +50,7 @@
 #include <cstdio>
 #include <cstring>
 #include <ctime>
+#include <mutex>
 #include <span>
 #include <utility>
 
@@ -168,6 +169,17 @@ DASHWorkSource::~DASHWorkSource() = default;
 // ─────────────────────────────────────────────────────────────────────────────
 GetWork DASHWorkSource::get_work(const WorkJobTargetInputs& job_in) const
 {
+    // C1 mainnet gate (see cached_work): the embedded arm emits an EMPTY CCbTx
+    // extra_payload (consensus-invalid on a DIP4-active mainnet) until the
+    // SML/QuorumManager wiring lands post-v0.2.4. On mainnet never source the
+    // embedded template — use ONLY the reward-safe dashd-RPC fallback. is_testnet_
+    // defaults false, so an unconfigured node fails closed to the fallback.
+    if (!is_testnet_) {
+        coin::DashWorkData w =
+            dashd_fallback_ ? dashd_fallback_() : coin::DashWorkData{};
+        return GetWork{ coin::WorkSource::DashdFallback, std::move(w),
+                        assemble_work_job_targets(job_in) };
+    }
     // Qualify the free function explicitly: unqualified `get_work` in this
     // member body resolves to THIS member (class scope shadows the namespace),
     // so name the capstone by its namespace to avoid a self-call.
@@ -281,13 +293,44 @@ std::shared_ptr<const coin::DashWorkData> DASHWorkSource::cached_work() const
             return nullptr;
     }
 
+    // ── C1 mainnet gate (v0.2.4 tag-blocker) ────────────────────────────────
+    // The embedded template arm's only prod caller does not pass the E2d
+    // SML/QuorumManager seams, so build_embedded_workdata() clears the CCbTx
+    // extra_payload and the coinbase is a plain v1 tx with NO DIP-0004 type-5
+    // payload. On a DIP4-active DASH MAINNET that block is consensus-INVALID
+    // (bad-cbtx) and the won subsidy is lost. Populating the payload needs the
+    // SML/QuorumManager wiring that is post-v0.2.4. Until then the embedded arm
+    // is FAIL-CLOSED off mainnet: we never take the populated() embedded flip on
+    // mainnet — the template comes ONLY from the reward-safe dashd-RPC fallback
+    // (the never-removed [GBT-XCHECK] safety path). Testnet/regtest keep the
+    // embedded arm (E5 proving ground). is_testnet_ defaults false, so an
+    // unconfigured node is treated as mainnet — fail-closed by default.
+    const bool embedded_arm_enabled = is_testnet_;
+    if (!embedded_arm_enabled && coin_state_.populated()) {
+        static std::once_flag mainnet_gate_logged;
+        std::call_once(mainnet_gate_logged, [] {
+            LOG_WARNING << "[DASH-STRATUM-GBT] embedded template arm disabled on "
+                           "mainnet: CCbTx payload not yet buildable — using "
+                           "dashd-RPC fallback";
+        });
+    }
+
     // Re-source OUTSIDE the lock (the fallback arm is a blocking dashd RPC).
-    // Embedded arm when the node-held bundle is populated, retained dashd GBT
-    // fallback otherwise (the never-removed [GBT-XCHECK] safety path).
+    // Embedded arm ONLY when enabled (testnet/regtest) AND the node-held bundle
+    // is populated; otherwise the retained dashd GBT fallback.
     coin::DashWorkData work;
-    if (coin_state_.populated() || dashd_fallback_) {
+    const bool try_embedded = embedded_arm_enabled && coin_state_.populated();
+    if (try_embedded || dashd_fallback_) {
         try {
-            coin::WorkSelection sel = coin_state_.select_work(dashd_fallback_);
+            // On mainnet (embedded gated) select_work is bypassed entirely and
+            // we source directly from the reward-safe dashd fallback; on
+            // testnet/regtest select_work picks embedded-when-viable, dashd
+            // otherwise (unchanged behaviour).
+            coin::WorkSelection sel = try_embedded
+                ? coin_state_.select_work(dashd_fallback_)
+                : coin::WorkSelection{
+                      dashd_fallback_ ? dashd_fallback_() : coin::DashWorkData{},
+                      coin::WorkSource::DashdFallback };
             // E2c observability: WHICH arm served this template + the MN payee
             // it carries (the payee-correctness axis of the embedded arm). One
             // line per re-source (cache-TTL cadence), INFO -- the field-

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -169,9 +169,11 @@ DASHWorkSource::~DASHWorkSource() = default;
 // ─────────────────────────────────────────────────────────────────────────────
 GetWork DASHWorkSource::get_work(const WorkJobTargetInputs& job_in) const
 {
-    // C1 mainnet gate (see cached_work): the embedded arm emits an EMPTY CCbTx
-    // extra_payload (consensus-invalid on a DIP4-active mainnet) until the
-    // SML/QuorumManager wiring lands post-v0.2.4. On mainnet never source the
+    // INTERIM mainnet gate (see cached_work): the SML/QuorumManager wiring that
+    // assembles the real type-5 CCbTx IS landed and TESTNET-PROVING, but its
+    // byte-parity against a real dashd getblocktemplate is not yet proven, so
+    // the embedded arm is not yet trusted to be consensus-valid on a DIP4-active
+    // MAINNET. Until that proof lifts the gate, on mainnet never source the
     // embedded template — use ONLY the reward-safe dashd-RPC fallback. is_testnet_
     // defaults false, so an unconfigured node fails closed to the fallback.
     if (!is_testnet_) {
@@ -293,25 +295,27 @@ std::shared_ptr<const coin::DashWorkData> DASHWorkSource::cached_work() const
             return nullptr;
     }
 
-    // ── C1 mainnet gate (v0.2.4 tag-blocker) ────────────────────────────────
-    // The embedded template arm's only prod caller does not pass the E2d
-    // SML/QuorumManager seams, so build_embedded_workdata() clears the CCbTx
-    // extra_payload and the coinbase is a plain v1 tx with NO DIP-0004 type-5
-    // payload. On a DIP4-active DASH MAINNET that block is consensus-INVALID
-    // (bad-cbtx) and the won subsidy is lost. Populating the payload needs the
-    // SML/QuorumManager wiring that is post-v0.2.4. Until then the embedded arm
-    // is FAIL-CLOSED off mainnet: we never take the populated() embedded flip on
-    // mainnet — the template comes ONLY from the reward-safe dashd-RPC fallback
-    // (the never-removed [GBT-XCHECK] safety path). Testnet/regtest keep the
-    // embedded arm (E5 proving ground). is_testnet_ defaults false, so an
-    // unconfigured node is treated as mainnet — fail-closed by default.
+    // ── INTERIM mainnet gate (v0.2.4 tag-blocker) ───────────────────────────
+    // The SML/QuorumManager wiring IS landed: on the coin-P2P (testnet-proving)
+    // arm the maintainer feeds the SML/quorum/bestCL/creditPool seams and
+    // build_embedded_workdata() emits a real DIP-0004 type-5 CCbTx payload. What
+    // is NOT yet proven is byte-parity of that payload against a real dashd
+    // getblocktemplate — until that proof lands (the dash/embedded-mainnet-
+    // validity follow-up: real-dashd byte-parity fixture + special-tx filter +
+    // creditPool accrual), an assembled coinbase could still diverge from
+    // consensus on a DIP4-active DASH MAINNET (bad-cbtx, lost subsidy). So the
+    // embedded arm stays FAIL-CLOSED off mainnet: we never take the populated()
+    // embedded flip on mainnet — the template comes ONLY from the reward-safe
+    // dashd-RPC fallback (the never-removed [GBT-XCHECK] safety path).
+    // Testnet/regtest keep the embedded arm (the proving ground). is_testnet_
+    // defaults false, so an unconfigured node is treated as mainnet — fail-closed.
     const bool embedded_arm_enabled = is_testnet_;
     if (!embedded_arm_enabled && coin_state_.populated()) {
         static std::once_flag mainnet_gate_logged;
         std::call_once(mainnet_gate_logged, [] {
-            LOG_WARNING << "[DASH-STRATUM-GBT] embedded template arm disabled on "
-                           "mainnet: CCbTx payload not yet buildable — using "
-                           "dashd-RPC fallback";
+            LOG_WARNING << "[DASH-STRATUM-GBT] embedded template arm held behind "
+                           "interim mainnet gate: CCbTx byte-parity not yet proven "
+                           "— using dashd-RPC fallback";
         });
     }
 

--- a/test/test_dash_cb_payee.cpp
+++ b/test/test_dash_cb_payee.cpp
@@ -88,3 +88,39 @@ TEST(DashCbPayee, NonObjectEntryYieldsEmptyPayment) {
     EXPECT_TRUE(pp.payee.empty());
     EXPECT_EQ(pp.amount, 0u);
 }
+
+// ── M1: submitblock dual-path result classification ─────────────────────────
+// submitblock returns null on accept; a "duplicate"/"inconclusive"/already-have
+// string means the OTHER dual-path arm already landed the block on the network
+// = SUCCESS under the dual-path contract, NOT failure. "duplicate-invalid" is
+// the exception (rejected as invalid = genuine failure).
+using dash::coin::submitblock_result_accepted;
+
+TEST(DashSubmitblockResult, NullResultIsAccept) {
+    EXPECT_TRUE(submitblock_result_accepted(json(nullptr)));
+}
+
+TEST(DashSubmitblockResult, DuplicateCountsAsSuccess) {
+    // The block already reached the network via the other arm.
+    EXPECT_TRUE(submitblock_result_accepted(json("duplicate")));
+    EXPECT_TRUE(submitblock_result_accepted(json("DUPLICATE")));   // case-insensitive
+}
+
+TEST(DashSubmitblockResult, InconclusiveAndAlreadyHaveCountAsSuccess) {
+    EXPECT_TRUE(submitblock_result_accepted(json("inconclusive")));
+    EXPECT_TRUE(submitblock_result_accepted(json("inconclusive-already-have")));
+    EXPECT_TRUE(submitblock_result_accepted(json("duplicate-inconclusive")));
+}
+
+TEST(DashSubmitblockResult, DuplicateInvalidIsGenuineFailure) {
+    // Already have it, but it is INVALID — must NOT be counted as landed.
+    EXPECT_FALSE(submitblock_result_accepted(json("duplicate-invalid")));
+}
+
+TEST(DashSubmitblockResult, RealRejectReasonsAreFailure) {
+    EXPECT_FALSE(submitblock_result_accepted(json("bad-cb-payee")));
+    EXPECT_FALSE(submitblock_result_accepted(json("high-hash")));
+    EXPECT_FALSE(submitblock_result_accepted(json("rejected")));
+    // Non-string, non-null (defensive): not an accept.
+    EXPECT_FALSE(submitblock_result_accepted(json::object()));
+}

--- a/test/test_dash_coin_state_maintainer.cpp
+++ b/test/test_dash_coin_state_maintainer.cpp
@@ -29,6 +29,8 @@
 #include <impl/dash/coin/utxo_adapter.hpp>
 #include <impl/dash/coin/rpc_data.hpp>
 #include <impl/dash/coin/transaction.hpp>
+#include <impl/dash/coin/vendor/smldiff.hpp>
+#include <impl/dash/coin/vendor/simplifiedmns.hpp>
 
 #include <core/uint256.hpp>
 
@@ -289,4 +291,100 @@ TEST(DashCoinStateMaintainer, BlockConnectCollateralSpendDropsToFallback) {
     WorkSelection sel = st.select_work([&]() { fb = true; return DashWorkData{}; });
     EXPECT_EQ(sel.source, WorkSource::DashdFallback);
     EXPECT_TRUE(fb) << "empty DMN set must route get_work to the dashd RPC fallback";
+}
+
+// ========================================================================
+// SML-axis reception behaviours (C-2 / H-6 / H-7).
+// ========================================================================
+using dash::coin::vendor::CSimplifiedMNListDiff;
+using dash::coin::vendor::CSimplifiedMNListEntry;
+
+static CSimplifiedMNListEntry sml_entry(uint8_t seed) {
+    CSimplifiedMNListEntry e;
+    e.proRegTxHash  = raw256(seed);
+    e.confirmedHash = raw256(seed + 1);
+    e.isValid = true;
+    return e;
+}
+
+// H-7 base-continuity: once the SML is current at block A, an INCREMENTAL diff
+// whose base is NOT A is rejected — the SML and its current-at marker are left
+// untouched (no ghost-MN corruption from applying a diff off the wrong base).
+TEST(DashCoinStateMaintainer, MnlistdiffBaseContinuityRejectsMismatchedBase) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+
+    // Cold-start full snapshot (base ZERO) -> SML current at A.
+    CSimplifiedMNListDiff d1;
+    d1.baseBlockHash = uint256::ZERO;
+    d1.blockHash     = raw256(0xA0);
+    d1.mnList = {sml_entry(0x40), sml_entry(0x60)};
+    m.on_mnlistdiff(d1);
+    ASSERT_TRUE(st.have_sml());
+    ASSERT_EQ(st.sml().size(), 2u);
+    ASSERT_EQ(st.sml_current_hash(), raw256(0xA0));
+
+    // A diff based on some OTHER block B (!= A) must be rejected.
+    CSimplifiedMNListDiff bad;
+    bad.baseBlockHash = raw256(0xB0);
+    bad.blockHash     = raw256(0xC0);
+    bad.mnList = {sml_entry(0x80)};
+    m.on_mnlistdiff(bad);
+    EXPECT_EQ(st.sml().size(), 2u) << "mismatched-base diff must not mutate the SML";
+    EXPECT_EQ(st.sml_current_hash(), raw256(0xA0)) << "current-at marker must not advance";
+
+    // A correctly-based incremental diff (base == A) IS accepted.
+    CSimplifiedMNListDiff d2;
+    d2.baseBlockHash = raw256(0xA0);
+    d2.blockHash     = raw256(0xD0);
+    d2.mnList = {sml_entry(0x80)};
+    m.on_mnlistdiff(d2);
+    EXPECT_EQ(st.sml_current_hash(), raw256(0xD0));
+    EXPECT_EQ(st.sml().size(), 3u);
+}
+
+// C-2 chainlock: on_new_chainlock adopts a fresher ChainLock as the CCbTx
+// bestCL* and fires the state-dirty sink; a non-advancing height is ignored.
+TEST(DashCoinStateMaintainer, OnNewChainlockAdoptsForwardOnlyAndFiresDirty) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    int dirty = 0;
+    m.set_on_state_dirty([&] { ++dirty; });
+
+    std::array<uint8_t, 96> sig{}; sig[0] = 0x11;
+    m.on_new_chainlock(1500000, sig);
+    EXPECT_EQ(st.best_cl_height(), 1500000);
+    EXPECT_EQ(dirty, 1) << "a fresher ChainLock must re-issue work";
+
+    // A stale (<=) height is ignored — no adoption, no re-issue.
+    std::array<uint8_t, 96> older{}; older[0] = 0x22;
+    m.on_new_chainlock(1499999, older);
+    EXPECT_EQ(st.best_cl_height(), 1500000);
+    EXPECT_EQ(dirty, 1);
+
+    // A forward ChainLock advances + re-issues again.
+    m.on_new_chainlock(1500005, sig);
+    EXPECT_EQ(st.best_cl_height(), 1500005);
+    EXPECT_EQ(dirty, 2);
+}
+
+// H-6 state-dirty: applying an mnlistdiff (SML advance) fires the re-issue sink,
+// and a reorg wipe fires it too (miners move off the orphaned-branch template).
+TEST(DashCoinStateMaintainer, SmlApplyAndReorgFireStateDirty) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    int dirty = 0;
+    m.set_on_state_dirty([&] { ++dirty; });
+
+    CSimplifiedMNListDiff d1;
+    d1.baseBlockHash = uint256::ZERO;
+    d1.blockHash     = raw256(0xA0);
+    d1.mnList = {sml_entry(0x40)};
+    m.on_mnlistdiff(d1);
+    EXPECT_EQ(dirty, 1) << "SML advance must re-issue work (freshness gate can now pass)";
+
+    m.on_sml_reorg();
+    EXPECT_FALSE(st.have_sml());
+    EXPECT_EQ(st.sml_current_hash(), uint256::ZERO);
+    EXPECT_EQ(dirty, 2) << "reorg wipe must re-issue work (drop orphaned-branch template)";
 }

--- a/test/test_dash_node_coin_state.cpp
+++ b/test/test_dash_node_coin_state.cpp
@@ -27,6 +27,12 @@
 #include <impl/dash/coin/utxo_adapter.hpp>
 #include <impl/dash/coin/rpc_data.hpp>
 #include <impl/dash/coin/transaction.hpp>
+#include <impl/dash/coin/coin_state_maintainer.hpp>
+#include <impl/dash/coin/vendor/simplifiedmns.hpp>
+#include <impl/dash/coin/vendor/smldiff.hpp>
+#include <impl/dash/coin/vendor/cbtx.hpp>
+#include <impl/dash/coin/quorum_manager.hpp>
+#include <impl/dash/coin/quorum_root.hpp>
 
 #include <core/uint256.hpp>
 #include <core/pack.hpp>
@@ -46,6 +52,12 @@ using dash::coin::MnStateMachine;
 using dash::coin::Mempool;
 using dash::coin::MutableTransaction;
 using dash::coin::build_embedded_workdata;
+using dash::coin::CoinStateMaintainer;
+using dash::coin::QuorumManager;
+using dash::coin::vendor::CSimplifiedMNList;
+using dash::coin::vendor::CSimplifiedMNListEntry;
+using dash::coin::vendor::CSimplifiedMNListDiff;
+using dash::coin::vendor::CCbTx;
 using ::core::coin::UTXOViewCache;
 using ::core::coin::Outpoint;
 using ::core::coin::Coin;
@@ -192,4 +204,174 @@ TEST(DashNodeCoinState, InvalidateRevertsToFallback) {
     WorkSelection sel = st.select_work([&]() { fallback_called = true; return DashWorkData{}; });
     EXPECT_EQ(sel.source, WorkSource::DashdFallback);
     EXPECT_TRUE(fallback_called);
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// CCbTx WIRING (v0.2.4 daemonless critical path).
+//
+// Proves the end-to-end seam: a NodeCoinState carrying an applied SML +
+// QuorumManager routes the Embedded arm AND emits the real DIP-0004 type-5
+// CCbTx extra_payload (non-empty m_coinbase_payload), byte-identical to a
+// direct build_embedded_workdata() call passing the same SML/quorum seams.
+// The pre-wiring bundle (no SML) emits an EMPTY payload — the C1 gap.
+// ════════════════════════════════════════════════════════════════════════
+
+static CSimplifiedMNListEntry sml_entry(uint8_t seed) {
+    CSimplifiedMNListEntry e;
+    e.proRegTxHash = raw256(seed);
+    e.confirmedHash = raw256(seed + 1);
+    e.isValid = true;
+    return e;
+}
+
+// Seed the NodeCoinState SML/quorum stores directly (as the maintainer would
+// after an accepted mnlistdiff) and mark have_sml.
+static void seed_sml(NodeCoinState& st) {
+    st.sml().mnList = {sml_entry(0x40), sml_entry(0x60)};
+    st.sml().sort();
+    st.set_have_sml(true);
+}
+
+TEST(DashNodeCoinState, SmlPresentEmitsRealCcbtxPayloadByteEqualToDirectBuild) {
+    UTXOViewCache utxo(nullptr);
+    uint256 prev = raw256(0x77);
+    utxo.add_coin(Outpoint(prev, 0), Coin(100'000, {}, 1, false));
+
+    auto payout = p2pkh_script(0x30);
+    const uint256 prev_hash = raw256(0xAB);
+    const uint32_t bits = 0x1b104be3u, mtp = 1'700'000'000u;
+    const uint32_t curtime = 1'700'000'123u, version = 0x20000000u;
+
+    NodeCoinState st;
+    seed_single_mn(st, payout);
+    seed_sml(st);
+    st.mempool().set_utxo(&utxo);
+    ASSERT_TRUE(st.mempool().add_tx(make_spend(prev, 0, 90'000, 1)));
+    st.set_tip(H - 1, prev_hash, bits, mtp, DASH_PUBKEY_VER, DASH_P2SH_VER, curtime, version);
+
+    ASSERT_TRUE(st.make_embedded_work_inputs().viable());
+
+    // Independent reference: direct build with the SAME SML/quorum seams.
+    CSimplifiedMNList ref_sml = st.sml();
+    QuorumManager ref_qmgr;   // empty active set == st.qmgr() here
+    DashWorkData reference = build_embedded_workdata(
+        H - 1, prev_hash, st.mnstates(), st.mempool(),
+        bits, mtp, DASH_PUBKEY_VER, DASH_P2SH_VER, curtime, version,
+        /*underfill=*/nullptr, &ref_sml, &ref_qmgr,
+        /*best_cl_height=*/0, dash::coin::k_zero_cl_sig, /*credit_pool=*/0);
+
+    bool fallback_called = false;
+    WorkSelection sel = st.select_work([&]() { fallback_called = true; return DashWorkData{}; });
+
+    EXPECT_EQ(sel.source, WorkSource::Embedded);
+    EXPECT_FALSE(fallback_called);
+    // THE CORE ASSERTION: a real, non-empty type-5 payload, byte-equal to ref.
+    EXPECT_FALSE(sel.work.m_coinbase_payload.empty())
+        << "SML-backed bundle must emit a non-empty CCbTx extra_payload";
+    EXPECT_EQ(sel.work.m_coinbase_payload, reference.m_coinbase_payload);
+
+    // And it decodes as a v3 CCbTx whose merkleRootMNList is our SML root.
+    CCbTx decoded;
+    ASSERT_TRUE(dash::coin::vendor::parse_cbtx(sel.work.m_coinbase_payload, decoded));
+    EXPECT_EQ(decoded.nVersion, CCbTx::VERSION_CLSIG_AND_BALANCE);
+    EXPECT_EQ(decoded.nHeight, static_cast<int32_t>(H));
+    EXPECT_EQ(decoded.merkleRootMNList, ref_sml.CalcMerkleRoot());
+    EXPECT_EQ(decoded.merkleRootQuorums,
+              dash::coin::compute_merkle_root_quorums(ref_qmgr));
+}
+
+// Without an SML the bundle still routes Embedded but emits an EMPTY payload —
+// the exact C1 gap (invalid on mainnet). This pins the pre/post contrast.
+TEST(DashNodeCoinState, NoSmlEmitsEmptyPayloadC1Gap) {
+    UTXOViewCache utxo(nullptr);
+    uint256 prev = raw256(0x77);
+    utxo.add_coin(Outpoint(prev, 0), Coin(100'000, {}, 1, false));
+    NodeCoinState st;
+    seed_single_mn(st, p2pkh_script(0x30));
+    st.mempool().set_utxo(&utxo);
+    ASSERT_TRUE(st.mempool().add_tx(make_spend(prev, 0, 90'000, 1)));
+    st.set_tip(H - 1, raw256(0xAB), 0x1b104be3u, 1'700'000'000u,
+               DASH_PUBKEY_VER, DASH_P2SH_VER);
+    WorkSelection sel = st.select_work([&]() { return DashWorkData{}; });
+    EXPECT_EQ(sel.source, WorkSource::Embedded);
+    EXPECT_TRUE(sel.work.m_coinbase_payload.empty());
+}
+
+// require_sml gate (review finding H3): the embedded arm must NOT serve a template with
+// no CCbTx. With the gate on, a bundle lacking an SML falls back to dashd;
+// applying an SML flips it to Embedded.
+TEST(DashNodeCoinState, RequireSmlGateFallsBackUntilSmlApplied) {
+    UTXOViewCache utxo(nullptr);
+    uint256 prev = raw256(0x77);
+    utxo.add_coin(Outpoint(prev, 0), Coin(100'000, {}, 1, false));
+    NodeCoinState st;
+    st.set_require_sml(true);
+    seed_single_mn(st, p2pkh_script(0x30));
+    st.mempool().set_utxo(&utxo);
+    ASSERT_TRUE(st.mempool().add_tx(make_spend(prev, 0, 90'000, 1)));
+    st.set_tip(H - 1, raw256(0xAB), 0x1b104be3u, 1'700'000'000u,
+               DASH_PUBKEY_VER, DASH_P2SH_VER);
+
+    EXPECT_FALSE(st.make_embedded_work_inputs().viable())
+        << "require_sml + no SML must gate the embedded arm off";
+    bool fb = false;
+    EXPECT_EQ(st.select_work([&]{ fb = true; return DashWorkData{}; }).source,
+              WorkSource::DashdFallback);
+    EXPECT_TRUE(fb);
+
+    seed_sml(st);
+    EXPECT_TRUE(st.make_embedded_work_inputs().viable());
+    EXPECT_EQ(st.select_work([&]{ return DashWorkData{}; }).source,
+              WorkSource::Embedded);
+}
+
+// Maintainer wiring: on_mnlistdiff applies the vendored apply_diff into the
+// node-held SML and flips have_sml, so a subsequent select_work emits the
+// real payload — the full reception path minus the socket.
+TEST(DashNodeCoinState, MaintainerOnMnlistdiffPopulatesSmlAndEmitsPayload) {
+    UTXOViewCache utxo(nullptr);
+    uint256 prev = raw256(0x77);
+    utxo.add_coin(Outpoint(prev, 0), Coin(100'000, {}, 1, false));
+
+    NodeCoinState st;
+    st.set_require_sml(true);
+    CoinStateMaintainer maint(st);
+
+    // Reception order mirrors the live node: MN payee set THROUGH the
+    // maintainer (leg 4 — arms the maintainer's own have_mn gate), mempool
+    // (leg 1), then the SML diff (new leg), then the tip (leg 2).
+    MNState pm; pm.isValid = true; pm.nRegisteredHeight = 2'300'000;
+    pm.nLastPaidHeight = 0; pm.scriptPayout.m_data = p2pkh_script(0x30);
+    maint.on_mn_list_update(
+        std::vector<std::pair<uint256, MNState>>{{raw256(0x01), pm}}, 0);
+    st.mempool().set_utxo(&utxo);
+    ASSERT_TRUE(st.mempool().add_tx(make_spend(prev, 0, 90'000, 1)));
+
+    // Build a minimal mnlistdiff: two fresh MNs, no deletes, empty quorum tail,
+    // default (type-0) cbTx so the credit-pool seed is skipped.
+    CSimplifiedMNListDiff diff;
+    diff.baseBlockHash = uint256::ZERO;
+    diff.blockHash = raw256(0xAB);
+    diff.mnList = {sml_entry(0x40), sml_entry(0x60)};
+
+    EXPECT_FALSE(st.have_sml());
+    maint.on_mnlistdiff(diff);
+    EXPECT_TRUE(st.have_sml());
+    EXPECT_EQ(st.sml().size(), 2u);
+
+    // Arm the tip AFTER the SML so republish sees both halves.
+    maint.on_new_tip(H - 1, raw256(0xAB), 0x1b104be3u, 1'700'000'000u,
+                     DASH_PUBKEY_VER, DASH_P2SH_VER, 1'700'000'123u, 0x20000000u);
+    ASSERT_TRUE(st.populated());
+    ASSERT_TRUE(st.make_embedded_work_inputs().viable());
+
+    WorkSelection sel = st.select_work([&]() { return DashWorkData{}; });
+    EXPECT_EQ(sel.source, WorkSource::Embedded);
+    EXPECT_FALSE(sel.work.m_coinbase_payload.empty());
+
+    // A reorg wipe drops the SML and gates the arm back to fallback.
+    maint.on_sml_reorg();
+    EXPECT_FALSE(st.have_sml());
+    EXPECT_EQ(st.sml().size(), 0u);
+    EXPECT_FALSE(st.make_embedded_work_inputs().viable());
 }

--- a/test/test_dash_node_coin_state.cpp
+++ b/test/test_dash_node_coin_state.cpp
@@ -320,9 +320,35 @@ TEST(DashNodeCoinState, RequireSmlGateFallsBackUntilSmlApplied) {
     EXPECT_TRUE(fb);
 
     seed_sml(st);
+    // Freshness gate (H-6): require_sml also requires the SML to be current AT
+    // the tip we build on. seed_sml() bypasses the maintainer, so set the
+    // current-at hash to the tip prev_hash explicitly (the maintainer does this
+    // from diff.blockHash on the live path).
+    st.set_sml_current_hash(raw256(0xAB));
     EXPECT_TRUE(st.make_embedded_work_inputs().viable());
     EXPECT_EQ(st.select_work([&]{ return DashWorkData{}; }).source,
               WorkSource::Embedded);
+}
+
+// Freshness gate (H-6): with require_sml + an applied SML, a tip that moves
+// AHEAD of the SML (sml_current_hash != prev_hash) must gate the embedded arm
+// OFF until a fresh mnlistdiff re-aligns the SML to the new tip — no stale-SML
+// template served at a moved tip.
+TEST(DashNodeCoinState, RequireSmlFreshnessGateHoldsWhenSmlStaleAtTip) {
+    NodeCoinState st;
+    st.set_require_sml(true);
+    seed_single_mn(st, p2pkh_script(0x30));
+    seed_sml(st);
+    // SML is current at block A, but the tip advanced to build on block B.
+    st.set_sml_current_hash(raw256(0xAB));
+    st.set_tip(H - 1, raw256(0xCD), 0x1b104be3u, 1'700'000'000u,
+               DASH_PUBKEY_VER, DASH_P2SH_VER);
+    EXPECT_FALSE(st.make_embedded_work_inputs().viable())
+        << "stale SML at a moved tip must gate the embedded arm off";
+
+    // The fresh diff for block B lands: SML now current at the tip -> viable.
+    st.set_sml_current_hash(raw256(0xCD));
+    EXPECT_TRUE(st.make_embedded_work_inputs().viable());
 }
 
 // Maintainer wiring: on_mnlistdiff applies the vendored apply_diff into the

--- a/test/test_dash_stratum_work_source.cpp
+++ b/test/test_dash_stratum_work_source.cpp
@@ -983,6 +983,112 @@ TEST(DashDashboardWiring, LocalStatsSumsStratumWorkerHashrate)
         EXPECT_EQ(w.get<std::string>().find("pool is idle"), std::string::npos);
 }
 
+// ═════════════════════════════════════════════════════════════════════════════
+// C1 mainnet gate (v0.2.4 tag-blocker). The embedded template arm's only prod
+// caller does not pass the E2d SML/QuorumManager seams, so build_embedded_
+// workdata() emits an EMPTY CCbTx extra_payload — a coinbase that is consensus-
+// INVALID (bad-cbtx) on a DIP4-active DASH MAINNET. Until the payload is
+// buildable (post-v0.2.4) the embedded arm MUST be fail-closed off mainnet: a
+// populated NodeCoinState must NOT serve its embedded template on mainnet (it
+// routes to the reward-safe dashd-RPC fallback), while testnet/regtest keep the
+// embedded arm (E5 proving ground). is_testnet_ defaults false, so an
+// unconfigured node is treated as mainnet — fail-closed by default.
+// ═════════════════════════════════════════════════════════════════════════════
+
+namespace {
+// A populated coin-state whose embedded template is DISTINGUISHABLE from the
+// dashd-fallback fixture (different prev/height), so the served template's
+// prevhash proves which arm ran. Empty MN/mempool is fine: the embedded build
+// still yields a valid, mineable template (non-null prev, non-zero bits).
+const char* const kEmbeddedPrevHashHex =
+    "0000000000000000abcdef0123456789abcdef0123456789abcdef0123456789";
+constexpr uint32_t kEmbeddedPrevHeight = 500000u;   // embedded template -> +1
+void seed_populated(dash::coin::NodeCoinState& cs)
+{
+    uint256 emb_prev;
+    emb_prev.SetHex(kEmbeddedPrevHashHex);
+    cs.set_tip(kEmbeddedPrevHeight, emb_prev, /*bits_for_next=*/0x1e0ffff0u,
+               /*mtp_at_tip=*/1'700'000'000u, /*addr_ver=*/76, /*p2sh_ver=*/16,
+               /*curtime=*/kCurtime, /*version=*/static_cast<uint32_t>(kVersion));
+}
+}  // namespace
+
+// MAINNET: a populated coin-state must NOT flip to the embedded arm — the served
+// template is the reward-safe dashd fallback (prev/height of rich_work), never
+// the embedded template (which would carry the empty-CCbTx coinbase).
+TEST(DashStratumC1MainnetGate, MainnetPopulatedCoinStateRoutesToDashdFallback)
+{
+    dash::coin::NodeCoinState cs;
+    seed_populated(cs);
+    ASSERT_TRUE(cs.populated());
+    ASSERT_TRUE(cs.make_embedded_work_inputs().viable());
+
+    auto fallback = []() -> dash::coin::DashWorkData { return rich_work(); };
+    auto submit   = [](const std::vector<unsigned char>&, uint32_t) { return true; };
+
+    // is_testnet=false => mainnet => embedded arm GATED off.
+    dash::stratum::DASHWorkSource ws(cs, fallback, submit,
+                                     core::stratum::StratumConfig{},
+                                     /*is_testnet=*/false);
+
+    auto tmpl = ws.get_current_work_template();
+    ASSERT_FALSE(tmpl.empty());
+    // The fallback's tip/height — NOT the embedded prev/height. Embedded was
+    // suppressed on mainnet.
+    EXPECT_EQ(tmpl.value("previousblockhash", ""), std::string(kPrevHashHex));
+    EXPECT_EQ(tmpl.value("height", 0u), 424242u);
+
+    // The fused adapter path is gated too: source is the retained dashd arm.
+    dash::stratum::WorkJobTargetInputs job_in;
+    job_in.sane_target_min.SetHex(
+        "0000000000000000000000000000000000000000000000000000000000000001");
+    job_in.sane_target_max.SetHex(
+        "00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    job_in.share_info_bits_target.SetHex(
+        "0000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    auto gw = ws.get_work(job_in);
+    EXPECT_EQ(gw.source, dash::coin::WorkSource::DashdFallback);
+    EXPECT_EQ(gw.work.m_height, 424242u);
+}
+
+// TESTNET/REGTEST: the SAME populated coin-state DOES serve its embedded
+// template (E5 lives here) — proving the gate is mainnet-only, not a blanket
+// disable.
+TEST(DashStratumC1MainnetGate, TestnetPopulatedCoinStateServesEmbedded)
+{
+    dash::coin::NodeCoinState cs;
+    seed_populated(cs);
+    ASSERT_TRUE(cs.populated());
+
+    auto fallback = []() -> dash::coin::DashWorkData { return rich_work(); };
+    auto submit   = [](const std::vector<unsigned char>&, uint32_t) { return true; };
+
+    // is_testnet=true => testnet/regtest => embedded arm ENABLED.
+    dash::stratum::DASHWorkSource ws(cs, fallback, submit,
+                                     core::stratum::StratumConfig{},
+                                     /*is_testnet=*/true);
+
+    uint256 emb_prev;
+    emb_prev.SetHex(kEmbeddedPrevHashHex);
+
+    auto tmpl = ws.get_current_work_template();
+    ASSERT_FALSE(tmpl.empty());
+    // The embedded tip/height (prev_height + 1) — the embedded arm ran.
+    EXPECT_EQ(tmpl.value("previousblockhash", ""), emb_prev.GetHex());
+    EXPECT_EQ(tmpl.value("height", 0u), kEmbeddedPrevHeight + 1u);
+
+    dash::stratum::WorkJobTargetInputs job_in;
+    job_in.sane_target_min.SetHex(
+        "0000000000000000000000000000000000000000000000000000000000000001");
+    job_in.sane_target_max.SetHex(
+        "00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    job_in.share_info_bits_target.SetHex(
+        "0000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    auto gw = ws.get_work(job_in);
+    EXPECT_EQ(gw.source, dash::coin::WorkSource::Embedded);
+    EXPECT_EQ(gw.work.m_height, kEmbeddedPrevHeight + 1u);
+}
+
 TEST(DashDashboardWiring, LocalStatsIdleWarningWhenNoWorkers)
 {
     // No provider wired and an empty local registry -> the honest idle warning

--- a/test/test_dash_won_block_dualpath.cpp
+++ b/test/test_dash_won_block_dualpath.cpp
@@ -71,7 +71,9 @@ TEST(DashWonBlockDualPath, BothArmsCarryIdenticalBlock)
 
     std::vector<unsigned char> relayed;
     bool did_relay = false;
-    P2pRelaySink p2p = [&](const std::vector<unsigned char>& b) { did_relay = true; relayed = b; };
+    P2pRelaySink p2p = [&](const std::vector<unsigned char>& b) -> bool {
+        did_relay = true; relayed = b; return true;   // connected peer -> relayed
+    };
 
     std::string submitted_hex;
     int submit_calls = 0;
@@ -107,7 +109,9 @@ TEST(DashWonBlockDualPath, DaemonlessP2pOnlyReachesNetwork)
     const std::string block_hex = to_hex(block);
 
     std::vector<unsigned char> relayed;
-    P2pRelaySink p2p = [&](const std::vector<unsigned char>& b) { relayed = b; };
+    P2pRelaySink p2p = [&](const std::vector<unsigned char>& b) -> bool {
+        relayed = b; return true;   // connected peer -> relayed
+    };
 
     const auto r = broadcast_won_block(p2p, /*rpc=*/{}, block, block_hex);
 
@@ -164,7 +168,7 @@ TEST(DashWonBlockDualPath, ThrowingPrimaryFallsThroughToBackup)
     const auto block = make_block_bytes();
     const std::string block_hex = to_hex(block);
 
-    P2pRelaySink p2p = [&](const std::vector<unsigned char>&) {
+    P2pRelaySink p2p = [&](const std::vector<unsigned char>&) -> bool {
         throw std::runtime_error("relay socket down");
     };
     std::string submitted_hex;
@@ -179,4 +183,55 @@ TEST(DashWonBlockDualPath, ThrowingPrimaryFallsThroughToBackup)
     EXPECT_EQ(submitted_hex, block_hex);
     EXPECT_TRUE(r.any());              // block still reached the network
     EXPECT_STREQ(r.landed_first, "rpc");
+}
+
+// 6) H1 HONEST REPORTING: a DISCONNECTED coin-P2P peer makes submit_block_p2p_raw
+//    silently drop the block, so the relay sink reports false. The dispatcher must
+//    NOT claim p2p_sent -- it relies on the submitblock RPC backup, and
+//    landed_first is "rpc", never a false "p2p". (Before the fix the sink returned
+//    void and p2p_sent was set true unconditionally: a lost subsidy logged as a win.)
+TEST(DashWonBlockDualPath, DisconnectedP2pNotClaimedRelaysViaBackup)
+{
+    const auto block = make_block_bytes();
+    const std::string block_hex = to_hex(block);
+
+    // The sink reports the peer is not connected -> NOT relayed.
+    bool relay_attempted = false;
+    P2pRelaySink p2p = [&](const std::vector<unsigned char>&) -> bool {
+        relay_attempted = true;
+        return false;   // coin-P2P peer disconnected: silent-drop territory
+    };
+    std::string submitted_hex;
+    RpcSubmitSink rpc = [&](const std::string& hex) -> bool {
+        submitted_hex = hex; return true;
+    };
+
+    const auto r = broadcast_won_block(p2p, rpc, block, block_hex);
+
+    EXPECT_TRUE(relay_attempted);
+    EXPECT_FALSE(r.p2p_sent);           // honest: the disconnected arm did NOT send
+    EXPECT_TRUE(r.rpc_ok);              // backup carried it
+    EXPECT_EQ(submitted_hex, block_hex);
+    EXPECT_STREQ(r.landed_first, "rpc");   // NOT a false "p2p"
+    EXPECT_TRUE(r.any());
+}
+
+// 7) H1 fail-loud: a disconnected P2P arm AND no RPC backup => the block reached
+//    NEITHER sink. any()==false and p2p_sent must be honest (false), so the caller
+//    takes the LOUD "block NOT relayed" path instead of a silent lost subsidy.
+TEST(DashWonBlockDualPath, DisconnectedP2pWithNoBackupReachesNeither)
+{
+    const auto block = make_block_bytes();
+    const std::string block_hex = to_hex(block);
+
+    P2pRelaySink p2p = [&](const std::vector<unsigned char>&) -> bool {
+        return false;   // disconnected
+    };
+
+    const auto r = broadcast_won_block(p2p, /*rpc=*/{}, block, block_hex);
+
+    EXPECT_FALSE(r.p2p_sent);
+    EXPECT_FALSE(r.rpc_ok);
+    EXPECT_FALSE(r.any());              // LOUD "block NOT relayed", never a silent win
+    EXPECT_STREQ(r.landed_first, "none");
 }


### PR DESCRIPTION
Wires the vendored SML/QuorumManager/CCbTx machinery (vendor/simplifiedmns, quorum_manager, vendor/cbtx) into the live embedded template path so the daemonless arm assembles a real DIP-0004 type-5 CCbTx.

**Status: TESTNET-PROVING under the interim mainnet safety-gate. This is NOT mainnet completion.** On mainnet the embedded arm stays fail-closed on the reward-safe dashd-RPC fallback; only testnet/regtest exercise the embedded CCbTx. The gate lifts only when a real-dashd byte-parity proof lands (separate follow-up: `dash/embedded-mainnet-validity`).

What this PR does (consensus-neutral hardening of the proving path):
- **C-2** reorg + chainlock callers, previously unwired, are now wired: a header-chain reorg wipes + cold-resyncs the SML (no stale `have_sml=true`); the clsig 96-byte signature is plumbed through so the maintainer adopts the ChainLock as the CCbTx `bestCL*`.
- **H-6** stale-SML-at-tip race: SML/quorum apply bumps work-generation, and template serving is gated on SML freshness for the tip (holds on the dashd fallback during the tip-change -> getmnlistd RTT).
- **H-7** mnlistdiff integrity: base-continuity + monotonic-bestCL guards reject diffs that would corrupt the SML.
- Corrected the comments that implied the wiring was "post-v0.2.4"/that reorg was already wired.

Confirmed gaps that the follow-up must close before the mainnet gate can lift (tracked in `dash/embedded-mainnet-validity`):
- **H-5** real-dashd `getblocktemplate` byte-parity fixture (the current KAT was self-referential).
- **C-3** special-tx filter in embedded tx-selection.
- **H-4** creditPoolBalance accrual correctness.
- superblock-height guard.

Draft — updates #779; the mainnet-gate lift is a small follow-up once byte-parity holds.