### PR TITLE
ltc: Send() socket deadline + desync-safe teardown (parity with dash #781)

### DIFF
--- a/src/impl/ltc/coin/rpc.cpp
+++ b/src/impl/ltc/coin/rpc.cpp
@@ -6,6 +6,12 @@
 
 #include <core/log.hpp>
 #include <core/hash.hpp>
+
+#ifndef _WIN32
+#include <sys/socket.h>          // setsockopt SO_SND/RCVTIMEO (Send() deadline)
+#include <sys/time.h>            // struct timeval
+#endif
+
 namespace ltc
 {
 
@@ -67,6 +73,10 @@ void NodeRPC::connect(NetService address, std::string userpass)
                     {
                         try
                         {
+                            // Bound the synchronous Send() I/O BEFORE check()
+                            // runs its first RPC, so a wedged litecoind cannot
+                            // hang the caller (io thread or thread_pool worker).
+                            apply_socket_timeouts();
                             if (check())
                             {
                                 m_connected = true;
@@ -128,7 +138,49 @@ void NodeRPC::sync_reconnect()
 		LOG_WARNING << "CoindRPC sync_reconnect connect failed: " << ec.message();
 		return;
 	}
+	apply_socket_timeouts();   // re-arm the Send() deadline on the fresh socket
 	LOG_INFO << "CoindRPC reconnected (sync)";
+}
+
+void NodeRPC::close_stream()
+{
+	// Same teardown idiom as sync_reconnect()/the destructor. m_connected is
+	// cleared so the next Send() write-fails into a clean sync_reconnect().
+	beast::error_code ec;
+	m_stream.socket().shutdown(io::ip::tcp::socket::shutdown_both, ec);
+	m_stream.close();
+	m_connected = false;
+}
+
+void NodeRPC::apply_socket_timeouts()
+{
+	// Force the socket back to BLOCKING mode, then set kernel send/receive
+	// timeouts. async_connect (connect()) leaves asio's non_blocking flag set;
+	// under it a synchronous recv returns EAGAIN immediately and SO_RCVTIMEO is
+	// a no-op. In blocking mode the sync http::write/http::read inside Send() do
+	// true blocking send()/recv() which the kernel bounds by SO_SND/RCVTIMEO,
+	// returning an error after RPC_IO_TIMEOUT_SECONDS instead of hanging on a
+	// wedged litecoind/dogecoind. (beast tcp_stream::expires_after cannot be
+	// used: it only governs ASYNC ops -- the sync path calls socket.read_some()
+	// directly.) Per-operation inactivity timeout: a large-but-steadily-arriving
+	// GBT does NOT trip it; only a genuine stall does. POSIX (SO_*TIMEO takes a
+	// timeval); guarded off Windows (no <sys/time.h>/timeval, and Winsock
+	// SO_RCVTIMEO takes a DWORD) -- the deploy target is Linux, and macOS keeps
+	// the real deadline. On Windows this is a no-op (pre-parity behaviour).
+#ifndef _WIN32
+	if (!m_stream.socket().is_open())
+		return;
+	boost::system::error_code ec;
+	m_stream.socket().non_blocking(false, ec);   // guarantee SO_*TIMEO applies
+	if (ec)
+		LOG_WARNING << "CoindRPC: could not set blocking mode: " << ec.message();
+	struct timeval tv;
+	tv.tv_sec  = RPC_IO_TIMEOUT_SECONDS;
+	tv.tv_usec = 0;
+	const int fd = m_stream.socket().native_handle();
+	::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+	::setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+#endif
 }
 
 std::string NodeRPC::Send(const std::string &request)
@@ -151,6 +203,10 @@ std::string NodeRPC::Send(const std::string &request)
 				sync_reconnect();
 				continue;
 			}
+			// Deadline-desync guard (see the read-fail path below): tear the
+			// socket down before giving up so a partially-written request can
+			// never be answered into a LATER Send() on a reused connection.
+			close_stream();
 			return {};
 		}
 
@@ -169,6 +225,17 @@ std::string NodeRPC::Send(const std::string &request)
 				sync_reconnect();
 				continue;
 			}
+			// Deadline-desync guard (SO_RCVTIMEO deadline hazard): this final
+			// attempt has already WRITTEN the request into litecoind but its
+			// response is unread (read timed out). jsonrpccxx reuses the constant
+			// id "curltest" and never validates response ids, so reusing this
+			// open connection would make the NEXT Send() read THIS request's late
+			// response -> permanent off-by-one desync (a GBT would parse a
+			// getbestblockhash string -> zeroed work -> a stuck "honest set-gap"
+			// outage until the connection churns). Tear the socket down so the
+			// next Send() write-fails into a clean sync_reconnect(). Already
+			// under m_rpc_mutex.
+			close_stream();
 			return {};
 		}
 

--- a/src/impl/ltc/coin/rpc.hpp
+++ b/src/impl/ltc/coin/rpc.hpp
@@ -58,6 +58,29 @@ private:
     std::string Send(const std::string &request) override;
     nlohmann::json CallAPIMethod(const std::string& method, const jsonrpccxx::positional_parameter& params = {});
 
+    // Socket deadline (parity with dash #781, impl/dash/coin/rpc.{hpp,cpp}): a
+    // REAL bound on the synchronous Send() I/O so a wedged-but-connected
+    // litecoind/dogecoind (socket open, no bytes) cannot hang the caller forever
+    // -- today that permanently wedges the RPC path (refresh-wedge) AND blocks
+    // join() at shutdown (SIGINT-hang). beast's SYNCHRONOUS read_some/write_some
+    // call socket.read_some() directly and do NOT honour tcp_stream::
+    // expires_after (that timer only fires for ASYNC ops), so the robust bound is
+    // a kernel SO_RCV/SNDTIMEO on the socket forced back to BLOCKING mode
+    // (async_connect leaves asio's non_blocking flag set, under which SO_*TIMEO
+    // is a no-op). apply_socket_timeouts() does both; called after every
+    // successful (re)connect. Linux release target; no-op on Windows (pre-parity
+    // behaviour: no deadline).
+    static constexpr int RPC_IO_TIMEOUT_SECONDS = 12;
+    void apply_socket_timeouts();
+    // Tear down m_stream (sync_reconnect idiom). Called on a FINAL-attempt Send()
+    // failure so a half-written / unread request can never be answered into a
+    // later Send() on a reused connection -- the deadline-desync guard. The
+    // constant "curltest" id (ID above) + jsonrpccxx not validating response ids
+    // make any reused-connection off-by-one a permanent set-gap outage (a GBT
+    // would parse a getbestblockhash string -> zeroed work). Caller holds
+    // m_rpc_mutex.
+    void close_stream();
+
 public:
     NodeRPC(io::io_context* context, ltc::interfaces::Node* coin, bool testnet);
     ~NodeRPC();


### PR DESCRIPTION
## P1 — live LTC-DOGE prod reference: RPC socket deadline

Propagates the DASH #781 (`9ac8b3dd`) socket-deadline class to LTC, the P1 lane
in the cross-coin io/RPC reconciliation audit. LTC already has the class-A
`thread_pool` decouple and the class-B `m_rpc_mutex`; the remaining gap is the
class-C deadline.

### Problem
`ltc::coin::NodeRPC::Send()` has **no deadline** — a wedged-but-connected
litecoind/dogecoind (socket open, no bytes) hangs the blocking `http::read`
forever → permanent refresh-wedge + SIGINT-hang on join, on the live merged-
mining node.

### Change — port DASH's mechanism verbatim
- **`apply_socket_timeouts()`** — forces the socket back to BLOCKING mode
  (`async_connect` leaves asio's non_blocking flag set, under which `SO_*TIMEO`
  is a no-op) then sets kernel `SO_RCVTIMEO`/`SO_SNDTIMEO` =
  `RPC_IO_TIMEOUT_SECONDS` (12). Called after every successful (re)connect (the
  `async_connect` handler before `check()`, and `sync_reconnect()`). beast's
  synchronous `read_some`/`write_some` do **not** honour
  `tcp_stream::expires_after` (async-only), so the kernel timeout is the robust
  bound. `#ifndef _WIN32` guarded (Linux release target; Windows keeps the
  pre-parity no-deadline behaviour).
- **`close_stream()`** — desync-safe teardown on the **final-attempt** `Send()`
  exits (both write-fail and read-fail). **This is the critical half** — the
  deadline alone reintroduces #781's item-2b off-by-one desync.

### Why the desync applies to LTC (verified, not assumed)
LTC's `NodeRPC` shares DASH's shape: `const std::string ID = "curltest"` (a
constant request id) driving `jsonrpccxx::JsonRpcClient`, which never validates
response ids. A timed-out-but-still-open stream (request written, response
unread) reused by the next `Send()` would read **this** request's late response
→ permanent off-by-one: a GBT parses a `getbestblockhash` hash-string → zeroed
work → a stuck "honest set-gap" outage until the connection churns.
`close_stream()` tears the socket down so the next `Send()` write-fails into a
clean `sync_reconnect()`. LTC already had `m_rpc_mutex` (class B) — no mutex
work needed.

### Consensus-neutral
Transport/liveness only — **zero wire-byte change**; strict added-code diff-grep
for share/target/payout/vardiff/reward/coinbase/merkle/nbits/difficulty is
empty. Satisfies the pre-v36 transition rule.

### Scope note — LTC class-D (WebServer) is a separate follow-on
LTC's miner-facing server is `core::WebServer`, **not** `core::StratumServer`,
so the #781 core reap knobs do NOT reach LTC. Its zombie-session class needs a
WebServer-level keepalive + idle-reap fix — queued, out of scope for this PR
(class-C deadline only).

### Build/test
`c2pool-ltc` builds clean with the change compiled in; LTC-lane regression
(`test_template_builder` 35/35, `test_doge_chain` 37/37) green. `NodeRPC` is not
unit-testable without a live daemon socket.

**Draft** — not for merge/deploy; LTC-DOGE prod is an operator tap. Gets an
LTC-parity review first.