### PR TITLE
btc: arm submitblock RPC backup (ARM B) of the dual-path broadcaster (#744)

### DIFF
--- a/src/c2pool/main_btc.cpp
+++ b/src/c2pool/main_btc.cpp
@@ -31,6 +31,7 @@
 #include <impl/btc/coin/transaction.hpp>
 #include <impl/btc/config.hpp>
 #include <impl/btc/config_pool.hpp>
+#include <impl/btc/coin/rpc_conf.hpp>   // bitcoin.conf creds for the submitblock RPC backup (ARM B, #82/#744)
 #include <impl/btc/node.hpp>
 #include <impl/btc/auto_ratchet.hpp>     // AutoRatchet V35->V36 forward-version-voting
 #include <impl/btc/share_check.hpp>      // RefHashParams + compute_ref_hash_for_work
@@ -99,7 +100,13 @@ static void print_usage()
         "  --prefix HEX    c2pool sharechain PREFIX (hex, <=8 bytes), an\n"
         "                  INDEPENDENT per-network constant (no algebraic tie to\n"
         "                  IDENTIFIER). Supply with --network-id to join a custom\n"
-        "                  p2pool chain; omit to use the compiled default prefix.\n";
+        "                  p2pool chain; omit to use the compiled default prefix.\n"
+        "  --coin-rpc H:P  submitblock RPC backup (ARM B) endpoint override.\n"
+        "                  Endpoint only (no secret); creds come from bitcoin.conf.\n"
+        "  --coin-rpc-auth PATH  bitcoin.conf-style file with rpcuser/rpcpassword\n"
+        "                  for the submitblock backup (default ~/.bitcoin/\n"
+        "                  bitcoin.conf; keeps rpcpassword off the process table).\n"
+        "                  Omit both to run daemonless (embedded P2P relay only).\n";
 }
 
 /// BTC wire-protocol magic bytes per network (pchMessageStart).
@@ -130,6 +137,8 @@ int main(int argc, char* argv[])
     uint16_t    sharechain_port = 0;        // 0 = default P2P_PORT (9333); --sharechain-port overrides (opt-in isolation)
     std::string network_id_hex;             // --network-id: c2pool IDENTIFIER override (empty = public net)
     std::string prefix_hex;                 // --prefix: c2pool PREFIX override (empty = compiled default)
+    std::string rpc_endpoint;               // --coin-rpc HOST:PORT: submitblock backup endpoint override (no secret)
+    std::string rpc_conf_path;              // --coin-rpc-auth PATH: bitcoin.conf creds (default ~/.bitcoin/bitcoin.conf)
 
     for (int i = 1; i < argc; ++i)
     {
@@ -207,6 +216,20 @@ int main(int argc, char* argv[])
         else if (arg == "--prefix" && i + 1 < argc)
         {
             prefix_hex = argv[++i];
+        }
+        else if (arg == "--coin-rpc" && i + 1 < argc)
+        {
+            // --coin-rpc HOST:PORT — endpoint override for the submitblock RPC
+            // backup (ARM B). Endpoint ONLY (no secret) so it is safe on argv;
+            // rpcuser/rpcpassword come from bitcoin.conf (--coin-rpc-auth).
+            rpc_endpoint = argv[++i];
+        }
+        else if (arg == "--coin-rpc-auth" && i + 1 < argc)
+        {
+            // --coin-rpc-auth PATH — bitcoin.conf-style file carrying
+            // rpcuser/rpcpassword for the submitblock RPC backup. Keeps the
+            // rpcpassword OFF the process table (default ~/.bitcoin/bitcoin.conf).
+            rpc_conf_path = argv[++i];
         }
         else
         {
@@ -365,6 +388,47 @@ int main(int argc, char* argv[])
     config.coin()->m_symbol      = "BTC";
 
     btc::coin::Node<btc::Config> coin_node(&ioc, &config);
+
+    // ── #82/#744 submitblock RPC BACKUP arm (ARM B of the dual-path
+    // broadcaster) ── The embedded coin-net P2P relay (submit_block_for_connect
+    // -> submit_block_p2p_raw) is the always-primary daemonless path; this arms
+    // the OPT-IN submitblock backup so a won block ALSO reaches a locally-run
+    // bitcoind if the operator provisions one. Creds come from bitcoin.conf
+    // (default ~/.bitcoin/bitcoin.conf, overridable with --coin-rpc-auth PATH)
+    // so the rpcpassword NEVER touches argv; --coin-rpc HOST:PORT overrides only
+    // the endpoint. No creds => arm stays UNARMED (has_rpc()==false) and
+    // submit_block_hex returns false LOUDLY -- byte-identical to the daemonless
+    // default. Mirrors main_dgb's NodeRPC arming (the #82 reference).
+    {
+        btc::coin::RpcConf rpc_conf;
+        std::string conf_path = rpc_conf_path;
+        if (conf_path.empty()) {
+            const char* home = std::getenv("HOME");
+            conf_path = std::string(home ? home : ".") + "/.bitcoin/bitcoin.conf";
+        }
+        if (btc::coin::load_rpc_conf(conf_path, rpc_conf)) {
+            if (rpc_conf.port == 0) {
+                // Bitcoin Core RPC defaults: mainnet 8332, testnet3 18332,
+                // testnet4 48332, regtest 18443.
+                rpc_conf.port = regtest ? 18443
+                              : (testnet4 ? 48332
+                                          : (testnet ? 18332 : 8332));
+            }
+            btc::coin::apply_endpoint_override(rpc_endpoint, rpc_conf);
+        } else {
+            // No conf creds; --coin-rpc alone still lets an operator point the
+            // endpoint, but without user/pass the arm cannot fire.
+            btc::coin::apply_endpoint_override(rpc_endpoint, rpc_conf);
+        }
+        if (rpc_conf.armed()) {
+            coin_node.arm_submit_rpc(NetService(rpc_conf.host, rpc_conf.port),
+                                     rpc_conf.userpass());
+        } else {
+            LOG_INFO << "[BTC] submitblock RPC backup UNARMED "
+                        "(no bitcoin.conf creds; embedded P2P relay is the only "
+                        "broadcast arm)";
+        }
+    }
 
     // Constants for getheaders driver: protocol version sent in the message
     // (matches what we advertised in version handshake — see B1 coin/p2p_node.hpp).

--- a/src/impl/btc/coin/block_broadcast.hpp
+++ b/src/impl/btc/coin/block_broadcast.hpp
@@ -52,8 +52,19 @@ inline bool broadcast_block_for_connect(
     const std::function<bool()>& relay_p2p,
     const std::function<bool()>& submit_rpc)
 {
-    bool relayed   = relay_p2p  ? relay_p2p()  : false;  // best-effort fast propagation
-    bool connected = submit_rpc ? submit_rpc() : false;  // ALWAYS - connect-authoritative
+    // BOTH legs guarded (mirrors core::broadcast_block_with_fallback): a throwing
+    // sink must NEVER unwind out of the won-block path and destroy the OTHER
+    // leg's result. In particular a throwing submit_rpc -- e.g. a daemon
+    // unreachable at submit time raises JsonRpcException out of submit_block_hex
+    // -- must NOT erase an already-succeeded P2P relay, else the caller falsely
+    // reports "reached NEITHER -- lost subsidy" for a block that WAS relayed to
+    // peers. This hole was newly reachable once ARM B (m_rpc) was armed (#744 M1).
+    bool relayed = false;
+    try { relayed = relay_p2p ? relay_p2p() : false; }      // best-effort fast propagation
+    catch (...) { relayed = false; }
+    bool connected = false;
+    try { connected = submit_rpc ? submit_rpc() : false; }  // ALWAYS - connect-authoritative
+    catch (...) { connected = false; }
     return relayed || connected;
 }
 

--- a/src/impl/btc/coin/genesis.hpp
+++ b/src/impl/btc/coin/genesis.hpp
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// ---------------------------------------------------------------------------
+// btc::coin genesis-hash SSOT for NodeRPC::check().
+//
+// check() probes getblockheader(<genesis>) to confirm the external daemon is a
+// real bitcoind on the SELECTED network (a wrong-coin / wrong-net daemon does
+// not answer for this hash). Historically check() hard-coded the *Litecoin*
+// genesis (copied verbatim from the LTC impl and never corrected), so on BTC
+// MAINNET the `is_main_chain && !has_block` gate always failed -> a permanent
+// 15s reconnect loop and a degraded ARM B on the one network where a lost block
+// is real money (#744/#787 B1, a #759-class cross-coin copy-paste drift).
+//
+// Per-net values sourced from bitcoin/src/kernel/chainparams.cpp and mirrored in
+// header_chain.hpp. Kept as a per-coin ISOLATION primitive (bucket-1): pinned
+// here so a standalone TU can guard against drift WITHOUT linking the beast
+// transport, exactly as dgb/coin/rpc_request.hpp does for DGB.
+// ---------------------------------------------------------------------------
+
+namespace btc
+{
+namespace coin
+{
+
+inline constexpr const char* BTC_GENESIS_MAIN =
+    "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f";
+// testnet3 genesis. NodeRPC carries a single testnet bool; the check() gate only
+// bites on `is_main_chain` (mainnet), so testnet3/testnet4/regtest all bypass it
+// regardless (is_main_chain==false) -- the testnet value is the correct probe
+// for a standard testnet3 daemon and harmless for the other test nets.
+inline constexpr const char* BTC_GENESIS_TEST =
+    "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943";
+
+// The genesis hash NodeRPC::check() probes for the selected network.
+inline const char* btc_genesis_hash(bool testnet)
+{
+    return testnet ? BTC_GENESIS_TEST : BTC_GENESIS_MAIN;
+}
+
+} // namespace coin
+} // namespace btc

--- a/src/impl/btc/coin/node.hpp
+++ b/src/impl/btc/coin/node.hpp
@@ -102,10 +102,12 @@ public:
     }
 
     /// Arm the submitblock RPC BACKUP leg (ARM B of the dual-path broadcaster)
-    /// WITHOUT the getwork side effect init_rpc() carries. connect() only
-    /// prepares the HTTP client + auth used by submit_block_hex; no getwork is
-    /// issued, so an external bitcoind that we drive purely for submitblock (or
-    /// one whose getwork we never call) arms cleanly. OPT-IN: main_btc calls
+    /// WITHOUT the getwork side effect init_rpc() carries. connect() runs the
+    /// read-only liveness/softfork probe check() (getblockheader + getblockchaininfo
+    /// + getnetworkinfo, results discarded by c2pool's own template path) but
+    /// never getwork, so an external bitcoind we drive purely for submitblock
+    /// arms cleanly and the embedded/daemonless template path is unperturbed.
+    /// OPT-IN: main_btc calls
     /// this only when bitcoin.conf creds resolve (rpcpassword stays off the
     /// process table); otherwise m_rpc stays null, has_rpc()==false, and
     /// submit_block_hex returns false LOUDLY -- byte-identical to the daemonless

--- a/src/impl/btc/coin/node.hpp
+++ b/src/impl/btc/coin/node.hpp
@@ -101,6 +101,27 @@ public:
             m_p2p->enable_mempool_request();
     }
 
+    /// Arm the submitblock RPC BACKUP leg (ARM B of the dual-path broadcaster)
+    /// WITHOUT the getwork side effect init_rpc() carries. connect() only
+    /// prepares the HTTP client + auth used by submit_block_hex; no getwork is
+    /// issued, so an external bitcoind that we drive purely for submitblock (or
+    /// one whose getwork we never call) arms cleanly. OPT-IN: main_btc calls
+    /// this only when bitcoin.conf creds resolve (rpcpassword stays off the
+    /// process table); otherwise m_rpc stays null, has_rpc()==false, and
+    /// submit_block_hex returns false LOUDLY -- byte-identical to the daemonless
+    /// default. Mirrors main_dgb's NodeRPC arming (the #82 reference). The
+    /// embedded P2P relay (ARM A) remains the always-primary daemonless path.
+    void arm_submit_rpc(const NetService& addr, const std::string& userpass)
+    {
+        m_rpc = std::make_unique<NodeRPC>(m_context, this, m_config->coin()->m_testnet);
+        m_rpc->connect(addr, userpass);
+        LOG_INFO << "[BTC] submitblock RPC backup ARMED: NodeRPC -> "
+                 << addr.to_string() << " (creds from bitcoin.conf)";
+    }
+
+    /// True once arm_submit_rpc has bound the submitblock backup leg.
+    bool has_rpc() const { return m_rpc != nullptr; }
+
     /// Submit a block via P2P directly (faster propagation than RPC).
     void submit_block_p2p(BlockType& block)
     {

--- a/src/impl/btc/coin/rpc.cpp
+++ b/src/impl/btc/coin/rpc.cpp
@@ -1,8 +1,14 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 #include "rpc.hpp"
 
+#ifndef _WIN32
+#include <sys/socket.h>          // setsockopt SO_SND/RCVTIMEO (Send() deadline, #744/#787 M2)
+#include <sys/time.h>            // struct timeval
+#endif
+
 #include <impl/btc/config_pool.hpp>
 #include <impl/btc/coin/softfork_check.hpp>
+#include <impl/btc/coin/genesis.hpp>       // btc_genesis_hash — per-net check() probe (#744/#787 B1)
 
 #include <core/log.hpp>
 #include <core/hash.hpp>
@@ -65,6 +71,11 @@ void NodeRPC::connect(NetService address, std::string userpass)
                         LOG_ERROR << "CoindRPC error when try connect: [" << ec.message() << "].";
                     } else
                     {
+                        // #744/#787 M2: arm the Send() socket deadline on the
+                        // freshly-connected socket BEFORE check() issues any
+                        // blocking RPC, so a daemon that connects but never
+                        // responds cannot wedge the ioc here either.
+                        apply_socket_timeouts();
                         try
                         {
                             if (check())
@@ -128,7 +139,36 @@ void NodeRPC::sync_reconnect()
 		LOG_WARNING << "CoindRPC sync_reconnect connect failed: " << ec.message();
 		return;
 	}
+	apply_socket_timeouts();   // #744/#787 M2: re-arm the Send() deadline on the fresh socket
 	LOG_INFO << "CoindRPC reconnected (sync)";
+}
+
+void NodeRPC::apply_socket_timeouts()
+{
+	// Force the socket back to BLOCKING mode, then set kernel send/receive
+	// timeouts. async_connect leaves asio's non_blocking flag set; under it a
+	// synchronous recv returns EAGAIN immediately and SO_RCVTIMEO is a no-op. In
+	// blocking mode the sync http::write/http::read inside Send() do true
+	// blocking send()/recv() which the kernel bounds by SO_SND/RCVTIMEO, so a
+	// wedged bitcoind returns an error after RPC_IO_TIMEOUT_SECONDS instead of
+	// hanging the whole ioc. (beast tcp_stream::expires_after governs only ASYNC
+	// ops; Send() drives the sync path, so the socket-option deadline is the
+	// correct lever -- same reasoning as the DASH #781 impl.) POSIX-only; on
+	// Windows this is a no-op (pre-PR behaviour: no deadline). #744/#787 M2.
+#ifndef _WIN32
+	if (!m_stream.socket().is_open())
+		return;
+	boost::system::error_code ec;
+	m_stream.socket().non_blocking(false, ec);   // guarantee SO_*TIMEO applies
+	if (ec)
+		LOG_WARNING << "CoindRPC: could not set blocking mode: " << ec.message();
+	struct timeval tv;
+	tv.tv_sec  = RPC_IO_TIMEOUT_SECONDS;
+	tv.tv_usec = 0;
+	const int fd = m_stream.socket().native_handle();
+	::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+	::setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+#endif
 }
 
 std::string NodeRPC::Send(const std::string &request)
@@ -195,7 +235,9 @@ nlohmann::json NodeRPC::CallAPIMethod(const std::string& method, const jsonrpccx
 
 bool NodeRPC::check()
 {
-	bool has_block = check_blockheader(uint256S("12a765e31ffd4059bada1e25190f6e98c99d9714d334efa41a195a7e7e04bfe2"));
+	// #744/#787 B1: probe the per-net BTC genesis (was the LITECOIN genesis,
+	// copied from the LTC impl -- broke the mainnet handshake gate below).
+	bool has_block = check_blockheader(uint256S(btc_genesis_hash(IS_TESTNET)));
 	bool is_main_chain = getblockchaininfo()["chain"].get<std::string>() == "main";
 	nlohmann::json blockchaininfo;
 

--- a/src/impl/btc/coin/rpc.hpp
+++ b/src/impl/btc/coin/rpc.hpp
@@ -49,6 +49,15 @@ private:
     bool m_connected = false;
     std::unique_ptr<core::Timer> m_reconnect_timer;
 
+    // #744/#787 M2: a hung bitcoind (accepts TCP, never responds) must not freeze
+    // the whole single-threaded ioc (stratum + sharechain P2P + header sync all
+    // run on it) mid-won-block. apply_socket_timeouts() forces the socket to
+    // blocking mode and sets kernel SO_SND/RCVTIMEO so Send()'s sync write/read
+    // return an error after RPC_IO_TIMEOUT_SECONDS instead of hanging forever.
+    // Mirrors the DASH #781 pattern. Called after each (re)connect.
+    static constexpr int RPC_IO_TIMEOUT_SECONDS = 30;
+    void apply_socket_timeouts();
+
     std::string Send(const std::string &request) override;
     nlohmann::json CallAPIMethod(const std::string& method, const jsonrpccxx::positional_parameter& params = {});
 

--- a/src/impl/btc/coin/rpc_conf.hpp
+++ b/src/impl/btc/coin/rpc_conf.hpp
@@ -53,6 +53,24 @@ inline std::string trim(const std::string& s)
     const auto e = s.find_last_not_of(ws);
     return s.substr(b, e - b + 1);
 }
+
+// Parse a TCP port from a conf value WITHOUT ever throwing. A raw std::stoi on
+// junk (e.g. rpcport=abc) throws std::invalid_argument / std::out_of_range which,
+// uncaught, ABORTS the node at startup -- and the default conf is read with no
+// flags, so a malformed conf would crash operators who never opted in (#744/#787
+// B2). On any non-numeric / out-of-range / zero value, leave `out` untouched and
+// return false so the caller degrades to UNARMED, never crashes.
+inline bool parse_port(const std::string& val, uint16_t& out)
+{
+    if (val.empty()) return false;
+    for (char c : val) if (c < '0' || c > '9') return false;   // digits only
+    unsigned long n = 0;
+    try { n = std::stoul(val); }
+    catch (...) { return false; }
+    if (n == 0 || n > 65535) return false;
+    out = static_cast<uint16_t>(n);
+    return true;
+}
 } // namespace conf_detail
 
 // Parse rpcuser/rpcpassword/rpcport/rpcconnect from a bitcoin.conf-style file
@@ -74,7 +92,7 @@ inline bool load_rpc_conf(const std::string& path, RpcConf& out)
         if (val.empty()) continue;
         if      (key == "rpcuser"     || key == "btc_rpc_user")     out.user = val;
         else if (key == "rpcpassword" || key == "btc_rpc_password") out.pass = val;
-        else if (key == "rpcport")    out.port = static_cast<uint16_t>(std::stoi(val));
+        else if (key == "rpcport")    conf_detail::parse_port(val, out.port);  // junk => leave 0 (caller fills default), never throw
         else if (key == "rpcconnect") out.host = val;
     }
     return !out.user.empty() && !out.pass.empty();
@@ -90,7 +108,9 @@ inline void apply_endpoint_override(const std::string& hostport, RpcConf& out)
     if (colon == std::string::npos) { out.host = hostport; return; }
     out.host = hostport.substr(0, colon);
     const std::string p = hostport.substr(colon + 1);
-    if (!p.empty()) out.port = static_cast<uint16_t>(std::stoi(p));
+    // Junk port (e.g. --coin-rpc host:notaport) is IGNORED, never a throw/abort:
+    // parse_port leaves out.port unchanged so the conf/default value stands.
+    conf_detail::parse_port(p, out.port);
 }
 
 } // namespace coin

--- a/src/impl/btc/coin/rpc_conf.hpp
+++ b/src/impl/btc/coin/rpc_conf.hpp
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// ---------------------------------------------------------------------------
+// btc::coin::rpc_conf -- bitcoin.conf credential resolution for the submitblock
+// RPC BACKUP leg (ARM B of the dual-path broadcaster).
+//
+// Direct mirror of dgb::coin::rpc_conf (src/impl/dgb/coin/rpc_conf.hpp), the
+// #82 reference. Credential rule (operator self-provision posture): the
+// rpcpassword NEVER reaches the process table. --coin-rpc carries only
+// HOST:PORT; --coin-rpc-auth carries a FILE PATH to the conf (default
+// ~/.bitcoin/bitcoin.conf); rpcuser/rpcpassword are read from that file and are
+// never echoed. When no creds resolve the arm stays UNARMED and
+// submit_block_hex returns false LOUDLY -- byte-identical to the daemonless
+// default build (the embedded P2P relay, ARM A, is the always-primary path).
+//
+// Header-only and dependency-light by design (no config pull): the net-default
+// RPC port is supplied by the caller, so the parser can be unit-exercised
+// without dragging the coin config in.
+// ---------------------------------------------------------------------------
+
+#include <cstdint>
+#include <fstream>
+#include <string>
+
+namespace btc
+{
+namespace coin
+{
+
+// Resolved external-daemon RPC endpoint + credentials. `armed()` is the single
+// gate main_btc consults before calling Node::arm_submit_rpc: no creds (or no
+// port) => the submit backup stays UNARMED and submit_block_hex returns false
+// LOUDLY, identical to the daemonless default build.
+struct RpcConf
+{
+    std::string host = "127.0.0.1";
+    uint16_t    port = 0;   // 0 => caller fills the per-net default
+    std::string user;
+    std::string pass;
+
+    bool armed() const { return !user.empty() && !pass.empty() && port != 0; }
+    std::string userpass() const { return user + ":" + pass; }
+};
+
+namespace conf_detail
+{
+inline std::string trim(const std::string& s)
+{
+    const char* ws = " \t\r\n";
+    const auto b = s.find_first_not_of(ws);
+    if (b == std::string::npos) return {};
+    const auto e = s.find_last_not_of(ws);
+    return s.substr(b, e - b + 1);
+}
+} // namespace conf_detail
+
+// Parse rpcuser/rpcpassword/rpcport/rpcconnect from a bitcoin.conf-style file
+// (also accepts the c2pool btc_rpc_user/btc_rpc_password aliases). '#' begins a
+// comment. Returns true ONLY when BOTH user and password were found; the
+// password stays in-file and is never logged.
+inline bool load_rpc_conf(const std::string& path, RpcConf& out)
+{
+    std::ifstream f(path);
+    if (!f) return false;
+    std::string line;
+    while (std::getline(f, line)) {
+        const auto h = line.find('#');
+        if (h != std::string::npos) line = line.substr(0, h);
+        const auto eq = line.find('=');
+        if (eq == std::string::npos) continue;
+        const std::string key = conf_detail::trim(line.substr(0, eq));
+        const std::string val = conf_detail::trim(line.substr(eq + 1));
+        if (val.empty()) continue;
+        if      (key == "rpcuser"     || key == "btc_rpc_user")     out.user = val;
+        else if (key == "rpcpassword" || key == "btc_rpc_password") out.pass = val;
+        else if (key == "rpcport")    out.port = static_cast<uint16_t>(std::stoi(val));
+        else if (key == "rpcconnect") out.host = val;
+    }
+    return !out.user.empty() && !out.pass.empty();
+}
+
+// Apply a "--coin-rpc HOST:PORT" endpoint override. Endpoint only -- carries no
+// secret, so it is safe on the process table. A bare "HOST" leaves the port at
+// whatever the conf/default supplied; an empty argument is a no-op.
+inline void apply_endpoint_override(const std::string& hostport, RpcConf& out)
+{
+    if (hostport.empty()) return;
+    const auto colon = hostport.rfind(':');
+    if (colon == std::string::npos) { out.host = hostport; return; }
+    out.host = hostport.substr(0, colon);
+    const std::string p = hostport.substr(colon + 1);
+    if (!p.empty()) out.port = static_cast<uint16_t>(std::stoi(p));
+}
+
+} // namespace coin
+} // namespace btc

--- a/src/impl/btc/test/CMakeLists.txt
+++ b/src/impl/btc/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 if (BUILD_TESTING AND GTest_FOUND)
     # btc twin of ltc share_test — uniquely named to avoid the CMP0002 target
     # collision with src/impl/ltc/test (both subdirs build in the same tree).
-    add_executable(btc_share_test share_test.cpp f11_donation_invariance_test.cpp f10b_version_punish_removal_test.cpp g01_share_format_parity_test.cpp auto_ratchet_sim_test.cpp block_broadcast_guard_test.cpp block_broadcast_connect_test.cpp regtest_sharechain_isolation_test.cpp stratum_merkle_branch_test.cpp witness_commitment_merkle_test.cpp finder_fee_integer_exact_test.cpp)
+    add_executable(btc_share_test share_test.cpp f11_donation_invariance_test.cpp f10b_version_punish_removal_test.cpp g01_share_format_parity_test.cpp auto_ratchet_sim_test.cpp block_broadcast_guard_test.cpp block_broadcast_connect_test.cpp regtest_sharechain_isolation_test.cpp stratum_merkle_branch_test.cpp witness_commitment_merkle_test.cpp finder_fee_integer_exact_test.cpp rpc_conf_test.cpp)
     target_link_libraries(btc_share_test PRIVATE
         GTest::gtest_main GTest::gtest
         core btc

--- a/src/impl/btc/test/CMakeLists.txt
+++ b/src/impl/btc/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 if (BUILD_TESTING AND GTest_FOUND)
     # btc twin of ltc share_test — uniquely named to avoid the CMP0002 target
     # collision with src/impl/ltc/test (both subdirs build in the same tree).
-    add_executable(btc_share_test share_test.cpp f11_donation_invariance_test.cpp f10b_version_punish_removal_test.cpp g01_share_format_parity_test.cpp auto_ratchet_sim_test.cpp block_broadcast_guard_test.cpp block_broadcast_connect_test.cpp regtest_sharechain_isolation_test.cpp stratum_merkle_branch_test.cpp witness_commitment_merkle_test.cpp finder_fee_integer_exact_test.cpp rpc_conf_test.cpp)
+    add_executable(btc_share_test share_test.cpp f11_donation_invariance_test.cpp f10b_version_punish_removal_test.cpp g01_share_format_parity_test.cpp auto_ratchet_sim_test.cpp block_broadcast_guard_test.cpp block_broadcast_connect_test.cpp regtest_sharechain_isolation_test.cpp stratum_merkle_branch_test.cpp witness_commitment_merkle_test.cpp finder_fee_integer_exact_test.cpp rpc_conf_test.cpp genesis_check_test.cpp)
     target_link_libraries(btc_share_test PRIVATE
         GTest::gtest_main GTest::gtest
         core btc

--- a/src/impl/btc/test/block_broadcast_connect_test.cpp
+++ b/src/impl/btc/test/block_broadcast_connect_test.cpp
@@ -81,3 +81,44 @@ TEST(BtcBlockBroadcastConnect, NullP2pRpcConnects) {
     EXPECT_TRUE(btc::coin::broadcast_block_for_connect(no_p2p, submit));
     EXPECT_EQ(rpc_calls, 1);
 }
+// ── #744/#787 M1: a THROWING RPC leg must never destroy an ARM A relay win ──
+// Once ARM B (m_rpc) is armed, a daemon unreachable at submit time raises a
+// JsonRpcException out of submit_block_hex. Both legs of
+// broadcast_block_for_connect are now guarded so that throw cannot unwind out
+// and turn an already-succeeded P2P relay into a false "reached NEITHER -- lost
+// subsidy" alarm.
+
+// 5) RPC leg THROWS but P2P relayed -> block still counts as reaching the
+//    network (true), and no exception escapes.
+TEST(BtcBlockBroadcastConnect, RpcThrowsButP2pRelayed) {
+    auto relay  = [] { return true; };
+    auto submit = []() -> bool { throw std::runtime_error("daemon unreachable"); };
+
+    bool result = false;
+    EXPECT_NO_THROW({ result = btc::coin::broadcast_block_for_connect(relay, submit); });
+    EXPECT_TRUE(result);   // ARM A's relay win stands despite the throwing RPC leg
+}
+
+// 6) RPC leg THROWS and P2P did NOT relay -> reaches neither -> false (scream),
+//    but still no exception escapes the won-block path.
+TEST(BtcBlockBroadcastConnect, RpcThrowsAndP2pFailedReachesNeither) {
+    auto relay  = [] { return false; };
+    auto submit = []() -> bool { throw std::runtime_error("daemon unreachable"); };
+
+    bool result = true;
+    EXPECT_NO_THROW({ result = btc::coin::broadcast_block_for_connect(relay, submit); });
+    EXPECT_FALSE(result);
+}
+
+// 7) A THROWING P2P relay leg must not skip the connect-authoritative RPC leg
+//    (the RPC still delivers the block).
+TEST(BtcBlockBroadcastConnect, P2pThrowsRpcStillConnects) {
+    auto relay  = []() -> bool { throw std::runtime_error("relay sink threw"); };
+    int rpc_calls = 0;
+    auto submit = [&] { ++rpc_calls; return true; };
+
+    bool result = false;
+    EXPECT_NO_THROW({ result = btc::coin::broadcast_block_for_connect(relay, submit); });
+    EXPECT_TRUE(result);
+    EXPECT_EQ(rpc_calls, 1);   // RPC leg reached despite the throwing relay
+}

--- a/src/impl/btc/test/genesis_check_test.cpp
+++ b/src/impl/btc/test/genesis_check_test.cpp
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// ---------------------------------------------------------------------------
+// btc::coin::btc_genesis_hash KATs (#744/#787 B1).
+//
+// NodeRPC::check() probes getblockheader(btc_genesis_hash(IS_TESTNET)) to
+// confirm the external daemon is a real bitcoind on the selected network. The
+// pre-fix code hard-coded the LITECOIN genesis, so the mainnet
+// `is_main_chain && !has_block` gate always failed -> a permanent 15s reconnect
+// loop and a degraded ARM B on mainnet. These KATs pin the correct per-net BTC
+// genesis so a future copy-paste drift is caught at build time WITHOUT linking
+// the beast transport (mirrors dgb/test/genesis_check_test.cpp).
+// ---------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "../coin/genesis.hpp"
+
+// The historical wrong value: the Litecoin genesis that check() used to probe.
+static constexpr const char* LTC_GENESIS =
+    "12a765e31ffd4059bada1e25190f6e98c99d9714d334efa41a195a7e7e04bfe2";
+
+TEST(BtcGenesisCheck, MainnetIsBitcoinGenesis) {
+    EXPECT_STREQ(btc::coin::btc_genesis_hash(false),
+                 "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f");
+}
+
+TEST(BtcGenesisCheck, TestnetIsBitcoinTestnet3Genesis) {
+    EXPECT_STREQ(btc::coin::btc_genesis_hash(true),
+                 "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943");
+}
+
+TEST(BtcGenesisCheck, MainAndTestDiffer) {
+    EXPECT_STRNE(btc::coin::btc_genesis_hash(false), btc::coin::btc_genesis_hash(true));
+}
+
+// The regression guard: neither per-net probe may be the Litecoin genesis again.
+TEST(BtcGenesisCheck, NotTheLitecoinGenesis) {
+    EXPECT_STRNE(btc::coin::btc_genesis_hash(false), LTC_GENESIS);
+    EXPECT_STRNE(btc::coin::btc_genesis_hash(true),  LTC_GENESIS);
+}

--- a/src/impl/btc/test/rpc_conf_test.cpp
+++ b/src/impl/btc/test/rpc_conf_test.cpp
@@ -115,3 +115,42 @@ TEST(BtcRpcConf, EndpointOverride)
     EXPECT_EQ(c.host, "10.1.2.3");
     EXPECT_EQ(c.port, 18332);
 }
+
+// ── #744/#787 B2: a malformed conf must degrade to UNARMED, never abort ──
+// The default ~/.bitcoin/bitcoin.conf is read with NO flags, so a junk rpcport
+// must not throw std::invalid_argument/out_of_range out of the parser and abort
+// the node at startup for an operator who never opted in.
+
+// 6) rpcport=abc (non-numeric): no throw; port stays 0 => UNARMED.
+TEST(BtcRpcConf, MalformedPortNoThrowUnarmed) {
+    const std::string path = write_temp_conf("badport",
+        "rpcuser=alice\n"
+        "rpcpassword=s3cr3t\n"
+        "rpcport=abc\n");
+    btc::coin::RpcConf c;
+    EXPECT_NO_THROW({ btc::coin::load_rpc_conf(path, c); });
+    EXPECT_EQ(c.port, 0);          // junk ignored, default left for caller
+    EXPECT_FALSE(c.armed());       // no port => not armed
+    EXPECT_EQ(c.user, "alice");    // creds still parsed
+    std::remove(path.c_str());
+}
+
+// 7) rpcport out of uint16 range: no throw; port stays 0.
+TEST(BtcRpcConf, OutOfRangePortNoThrow) {
+    const std::string path = write_temp_conf("bigport",
+        "rpcuser=u\nrpcpassword=p\nrpcport=99999\n");
+    btc::coin::RpcConf c;
+    EXPECT_NO_THROW({ btc::coin::load_rpc_conf(path, c); });
+    EXPECT_EQ(c.port, 0);          // 99999 > 65535 rejected (no silent truncation)
+    EXPECT_FALSE(c.armed());
+    std::remove(path.c_str());
+}
+
+// 8) --coin-rpc host:notaport endpoint override: no throw; host applied, port kept.
+TEST(BtcRpcConf, MalformedEndpointOverrideNoThrow) {
+    btc::coin::RpcConf c;
+    c.user = "u"; c.pass = "p"; c.port = 8332;
+    EXPECT_NO_THROW({ btc::coin::apply_endpoint_override("10.0.0.9:notaport", c); });
+    EXPECT_EQ(c.host, "10.0.0.9");  // host applied
+    EXPECT_EQ(c.port, 8332);        // junk port ignored, prior value stands
+}

--- a/src/impl/btc/test/rpc_conf_test.cpp
+++ b/src/impl/btc/test/rpc_conf_test.cpp
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// ---------------------------------------------------------------------------
+// btc::coin::rpc_conf KATs -- bitcoin.conf credential resolution for the
+// submitblock RPC BACKUP arm (ARM B of the dual-path broadcaster, #82/#744).
+//
+// Locks the gate main_btc consults before arming the submitblock backup:
+//   - armed() is true ONLY with user + pass + a non-zero port,
+//   - the parser reads rpcuser/rpcpassword/rpcport/rpcconnect (and the c2pool
+//     btc_rpc_user/btc_rpc_password aliases), honours '#' comments,
+//   - a --coin-rpc HOST:PORT endpoint override carries no secret.
+// No creds => UNARMED => submit_block_hex returns false LOUDLY (daemonless
+// default). Direct twin of the dgb rpc_conf helper (the #82 reference).
+//
+// Rides the already-allowlisted btc_share_test executable (no build.yml target
+// allowlist change; no #137 NOT_BUILT sentinel risk). p2pool-merged-v36
+// surface: NONE -- broadcast-config parse only; no PoW/share/PPLNS math.
+// ---------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <fstream>
+#include <string>
+
+#include "../coin/rpc_conf.hpp"
+
+namespace
+{
+// Write `body` to a unique temp path under gtest's temp dir and return it.
+std::string write_temp_conf(const std::string& tag, const std::string& body)
+{
+    static int counter = 0;
+    std::string path = ::testing::TempDir() + "btc_rpc_conf_" + tag + "_"
+                     + std::to_string(counter++) + ".conf";
+    std::ofstream f(path);
+    f << body;
+    f.close();
+    return path;
+}
+} // namespace
+
+// 1) A well-formed bitcoin.conf arms the backup: user+pass+port all resolved.
+TEST(BtcRpcConf, WellFormedConfArms)
+{
+    const std::string path = write_temp_conf("wellformed",
+        "rpcuser=alice\n"
+        "rpcpassword=s3cr3t\n"
+        "rpcport=8332\n"
+        "rpcconnect=10.0.0.5\n");
+    btc::coin::RpcConf c;
+    ASSERT_TRUE(btc::coin::load_rpc_conf(path, c));
+    EXPECT_TRUE(c.armed());
+    EXPECT_EQ(c.user, "alice");
+    EXPECT_EQ(c.pass, "s3cr3t");
+    EXPECT_EQ(c.port, 8332);
+    EXPECT_EQ(c.host, "10.0.0.5");
+    EXPECT_EQ(c.userpass(), "alice:s3cr3t");
+    std::remove(path.c_str());
+}
+
+// 2) No creds => NOT armed (daemonless default; submit backup stays dark).
+TEST(BtcRpcConf, MissingCredsUnarmed)
+{
+    const std::string path = write_temp_conf("nocreds",
+        "# only an endpoint, no secret\n"
+        "rpcport=8332\n"
+        "rpcconnect=127.0.0.1\n");
+    btc::coin::RpcConf c;
+    EXPECT_FALSE(btc::coin::load_rpc_conf(path, c));  // false: no user/pass
+    EXPECT_FALSE(c.armed());
+    std::remove(path.c_str());
+}
+
+// 3) A missing file is a clean UNARMED, never a throw.
+TEST(BtcRpcConf, MissingFileUnarmed)
+{
+    btc::coin::RpcConf c;
+    EXPECT_FALSE(btc::coin::load_rpc_conf("/nonexistent/path/bitcoin.conf", c));
+    EXPECT_FALSE(c.armed());
+}
+
+// 4) c2pool aliases + '#' comments are honoured; port still required to arm.
+TEST(BtcRpcConf, AliasesAndCommentsNoPortStillUnarmed)
+{
+    const std::string path = write_temp_conf("aliases",
+        "btc_rpc_user=bob    # inline comment stripped\n"
+        "btc_rpc_password=hunter2\n");
+    btc::coin::RpcConf c;
+    ASSERT_TRUE(btc::coin::load_rpc_conf(path, c));  // user+pass found
+    EXPECT_EQ(c.user, "bob");
+    EXPECT_EQ(c.pass, "hunter2");
+    EXPECT_FALSE(c.armed());  // port==0 => not armed until caller fills default
+    std::remove(path.c_str());
+}
+
+// 5) --coin-rpc HOST:PORT endpoint override (no secret) overrides endpoint only.
+TEST(BtcRpcConf, EndpointOverride)
+{
+    btc::coin::RpcConf c;
+    c.user = "u"; c.pass = "p"; c.host = "127.0.0.1"; c.port = 8332;
+    btc::coin::apply_endpoint_override("192.168.1.9:18332", c);
+    EXPECT_EQ(c.host, "192.168.1.9");
+    EXPECT_EQ(c.port, 18332);
+    EXPECT_EQ(c.user, "u");   // creds untouched by the endpoint override
+    EXPECT_EQ(c.pass, "p");
+    EXPECT_TRUE(c.armed());
+
+    // Bare HOST leaves the port at whatever the conf/default supplied.
+    btc::coin::apply_endpoint_override("10.1.2.3", c);
+    EXPECT_EQ(c.host, "10.1.2.3");
+    EXPECT_EQ(c.port, 18332);
+
+    // Empty override is a no-op.
+    btc::coin::apply_endpoint_override("", c);
+    EXPECT_EQ(c.host, "10.1.2.3");
+    EXPECT_EQ(c.port, 18332);
+}


### PR DESCRIPTION
Part of #744. DGB is the reference; DASH is now GREEN.

## Gap
BTC's dual-path broadcaster had ARM A (embedded P2P relay, `submit_block_for_connect` → `submit_block_p2p_raw`) live-wired, but ARM B (submitblock RPC backup) was code-present-but-unarmed: `m_rpc` was never constructed in the run path. A won block could not reach a locally-run bitcoind.

## Commit 1 — arm ARM B (mirrors DGB #82)
- `btc/coin/rpc_conf.hpp` — header-only `bitcoin.conf` credential parser (twin of `dgb/coin/rpc_conf.hpp`); rpcpassword stays off the process table.
- `Node::arm_submit_rpc()` — constructs+connects `NodeRPC` for submitblock (no getwork), plus `has_rpc()`.
- `main_btc` — loads creds (default `~/.bitcoin/bitcoin.conf`), arms when `armed()`, else UNARMED. `--coin-rpc` / `--coin-rpc-auth` flags.

## Commit 2 — harden the newly-live reward path (review fixes)
Arming ARM B made four previously-dead defects live. All fixed:
- **B1 (blocker)** — `NodeRPC::check()` probed the **Litecoin** genesis (copied from the LTC impl, a #759-class cross-coin drift) → BTC-mainnet handshake gate always failed → permanent 15s reconnect loop, ARM B degraded on mainnet. New `btc/coin/genesis.hpp` + `btc_genesis_hash(IS_TESTNET)`; per-net BTC genesis (mirrors DGB). `genesis_check_test.cpp` pins it.
- **B2 (blocker)** — unguarded `std::stoi` aborted the node at startup on a malformed `rpcport` in the **default** conf (read with no flags). New `parse_port` (digits-only, range-checked, never throws) → junk degrades to UNARMED. 3 KATs.
- **M1 (major)** — a daemon unreachable at submit raised `JsonRpcException` out of `submit_block_hex`; `broadcast_block_for_connect` had no throw guards → the exception destroyed ARM A's already-succeeded relay → false "reached NEITHER — lost subsidy" alarm. Both legs now guarded. 3 throwing-leg KATs.
- **M2 (major)** — no socket deadline on the beast stream shared with stratum on one single-threaded ioc → a hung bitcoind froze the whole node mid-won-block. Added `apply_socket_timeouts()` (SO_SND/RCVTIMEO, mirrors DASH #781), armed after each (re)connect.

## Safety
Broadcast/RPC-transport path only — no PoW hash, share format, coinbase commitment, or PPLNS math touched (consensus-neutral). BTC-fenced. Builds clean (`c2pool-btc` + `btc_share_test`); **20 KATs pass** (8 conf + 4 genesis + 8 connect incl. 3 new throwing-leg).

## Follow-ons
- Run-path dual-path soak against a live regtest (both arms fire + accept) — gates the un-draft; shared with LTC/BCH.
- **The B2 `std::stoi` bug exists verbatim in the DGB twin** (`dgb/coin/rpc_conf.hpp`) — fixed separately (see the DGB PR) to keep per-coin fencing.

Draft — for re-review, not merge.
