### PR TITLE
bch: correct 2 stale broadcaster comments -- reconstruction has landed (#744)

### DIFF
--- a/src/impl/bch/node.hpp
+++ b/src/impl/bch/node.hpp
@@ -197,10 +197,11 @@ public:
     // other_txs from m_known_txs via the share transaction_hash_refs over
     // parent shares (data.py get_other_tx_hashes / _get_other_txs); returns
     // nullopt when not all parent txs are present (== as_block None).
-    // NOTE: coinbase (gentx) full-body reconstruction (GenerateShareTransaction,
-    // share_check.hpp:472) is the remaining dependency before this emits a
-    // complete block; until it lands this returns nullopt -- no partial/
-    // invalid block is ever broadcast. The other_tx gather seam is here.
+    // Coinbase (gentx) full-body reconstruction is IMPLEMENTED below via
+    // generate_share_transaction (the same fn the verify path uses), so this
+    // emits a COMPLETE wire block on success. nullopt is returned ONLY when not
+    // all parent txs are present (== as_block None) or the gentx/header build
+    // fails -- never a partial/invalid block. The other_tx gather seam is here.
     std::optional<std::pair<std::vector<unsigned char>, std::string>>
         reconstruct_won_block(const uint256& share_hash)
     {

--- a/src/impl/bch/pool_standup.hpp
+++ b/src/impl/bch/pool_standup.hpp
@@ -14,10 +14,13 @@
 // run-loop; idempotent (set_block_broadcaster replaces).
 //
 // The sink being live is NECESSARY but NOT SUFFICIENT to close the gate to
-// verified: reconstruct_won_block() still returns nullopt until gentx (coinbase)
-// full-body reconstruction lands (share_check.hpp:472) and leg C is exercised
-// against VM300 (192.168.86.110:8333). Until then the lambda has a live sink yet
-// emits nothing -- the gate stays honestly GAP and no partial block is relayed.
+// verified: reconstruct_won_block() now fully reconstructs the block (gentx +
+// header + full wire serialization), so on a won share the lambda emits a
+// complete block down BOTH broadcast arms. What remains before the gate flips to
+// verified is a run-path dual-path soak -- leg C (submitblock RPC) exercised
+// against a live BCHN (e.g. VM300, 192.168.86.110:8333) alongside the P2P relay
+// arm. Until that soak lands the gate stays honestly GAP on VERIFICATION, not on
+// missing code; no partial block is ever relayed (nullopt on incomplete txs).
 //
 // PER-COIN ISOLATION: src/impl/bch only. Zero p2pool-merged-v36 surface -- block
 // dispatch, NOT share/PPLNS/coinbase bytes. BCH = SHA256d standalone parent.


### PR DESCRIPTION
Part of #744 (fleet dual-path broadcaster gate audit) — the "2 stale misleading BCH comments" cleanup.

## What
Both comments asserted `reconstruct_won_block()` still returns `nullopt` because gentx (coinbase) full-body reconstruction had not landed (citing a stale `share_check.hpp:472` line). That is **no longer true**: `reconstruct_won_block` (`src/impl/bch/node.hpp`) calls `generate_share_transaction` — the same coinbase builder the verify path uses — then builds the 80-byte header and serializes the full wire block, returning a complete block on success. `nullopt` now means only incomplete parent txs (`== as_block None`) or a build failure.

Corrected:
- `src/impl/bch/node.hpp` — the `reconstruct_won_block` doc note.
- `src/impl/bch/pool_standup.hpp` — the sink-liveness note; the residual gate to "verified" is a run-path dual-path **soak** (leg C submitblock RPC against a live BCHN + the P2P relay arm), not missing reconstruction code.

## Safety
Comment-only — zero code/behavior change, zero p2pool-merged-v36 surface.

## Context
Re-audit finding: contrary to the 2026-07-19 note, both BCH arms ARE wired into the `--pool` run path (`standup_pool_run` → `broadcast_won_block`, P2P leg + submitblock leg, with a sink-liveness assert). The only real remaining gap is a run-path dual-path soak (shared with LTC/DOGE).

Draft — for review, not merge.
