### PR TITLE
dash(dashboard): Best Share + peers + found-blocks parity with LTC dashboard (v0.2.4)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -674,6 +674,16 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             // ── REAL best-share hash ──────────────────────────────────────
             web_server->set_best_share_hash_fn(
                 [node_ptr]() { return node_ptr->best_share_hash(); });
+
+            // ── REAL pool-peer info (node-status card) ────────────────────
+            // /local_stats {peers:{incoming,outgoing}} + the peer table read
+            // this. Without it the node-status card reported 0 peers on DASH
+            // (the m_node fallback in rest_local_stats never sees the pool
+            // p2p peers). Same shape main_ltc.cpp:2830 uses. Display only.
+            mi->set_peer_info_fn(
+                [&p2p_node]() -> nlohmann::json {
+                    return p2p_node.get_peer_info_json();
+                });
         }
 
         // ── REAL per-share difficulty feed (main_ltc.cpp:4213) ────────────
@@ -939,6 +949,48 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         // verified-chain so we never mint on an unverified foreign chain).
         work_source->set_best_share_hash_fn(
             [node_ptr]() -> uint256 { return node_ptr->best_share_hash(); });
+
+        // ── REAL best-share feed for the dashboard "Best Share" card ──────
+        // Every ACCEPTED stratum submit reports the actual PoW difficulty of
+        // the found hash (target_to_difficulty(pow_hash)) + miner + pow-hash.
+        // record_share_difficulty tracks the pool-wide/session/round max WITH
+        // the hash + timestamp; /best_share + /local_stats render it. This is
+        // the PRIMARY best-share feed on the DASH solo path — the tracker's
+        // verified-share m_on_share_difficulty hook (wired above) almost never
+        // fires here because solo shares seldom mint onto the sharechain, so
+        // without this the 🎯 Best Share card sat empty. Display only; the
+        // callback touches no share/target/payout logic (consensus-neutral).
+        if (web_server) {
+            core::WebServer* ws = web_server.get();
+            work_source->set_on_share_difficulty_fn(
+                [ws](double diff, const std::string& miner, const uint256& pow_hash) {
+                    ws->get_mining_interface()->record_share_difficulty(
+                        diff, miner, pow_hash.GetHex());
+                });
+
+            // ── Recent-blocks feed: DASH block wins into the history card ──
+            // Every dispatched block solution records to /recent_blocks with
+            // the height, X11 block hash (== pow_hash for DASH), miner, and the
+            // net difficulty at find time. Without this DASH block wins never
+            // appeared on the recent-blocks card (main_ltc.cpp:2970 parity).
+            // Display only; the callback runs after dispatch, never gates it.
+            work_source->set_on_found_block_fn(
+                [ws](uint32_t height, const uint256& block_hash,
+                     const std::string& miner, bool reached_network) {
+                    auto* mi = ws->get_mining_interface();
+                    mi->record_found_block(
+                        height, block_hash,
+                        static_cast<uint64_t>(std::time(nullptr)),
+                        "DASH", miner, block_hash.GetHex(),
+                        mi->get_network_difficulty(),
+                        /*share_difficulty=*/0.0,
+                        /*pool_hashrate=*/0.0,
+                        /*subsidy=*/0);
+                    if (!reached_network)
+                        LOG_WARNING << "[DASH] recorded found block height="
+                                    << height << " that reached NO network sink";
+                });
+        }
 
         // Producer job: the stratum coinbase IS the producer share gentx
         // (byte-parity with the mint-time rebuild by construction). The

--- a/src/core/stratum_server.cpp
+++ b/src/core/stratum_server.cpp
@@ -1286,6 +1286,20 @@ nlohmann::json StratumSession::handle_submit(const nlohmann::json& params, const
     // Record in per-connection tracker (for VARDIFF adjustment + per-session stats)
     hashrate_tracker_.record_mining_share_submission(credited_difficulty, true);
 
+    // Best-share dashboard feed: every ACCEPTED pseudoshare's real (X11/scrypt)
+    // difficulty is a candidate for the "Best Share" card (highest-difficulty
+    // share seen — how close a miner got to a block). Default no-op; a work
+    // source whose dashboard is a separate object (c2pool-dash) overrides this
+    // to forward into the dashboard's best-share tracker. share_difficulty is
+    // the true per-hash difficulty computed above; pass the raw submit fields so
+    // the implementor can recover the exact pow-hash. Display only.
+    mining_interface_->record_best_pseudoshare(
+        share_difficulty, username_,
+        job.payload->coinb1, job.payload->coinb2,
+        extranonce1_, extranonce2, ntime, nonce,
+        effective_version, job.gbt_prevhash, job.nbits,
+        job.payload->merkle_branches);
+
     // Check if VARDIFF changed → send new difficulty AND new work to miner.
     // p2pool (stratum.py:594-595): after adjusting target, calls _send_work()
     // which sends both set_difficulty and mining.notify. Without new work,

--- a/src/core/stratum_work_source.hpp
+++ b/src/core/stratum_work_source.hpp
@@ -183,6 +183,25 @@ public:
         uint32_t version, const std::string& prevhash_hex,
         const std::string& nbits_hex,
         const std::vector<std::string>& merkle_branches) const = 0;
+
+    /// Record an ACCEPTED pseudoshare for the dashboard "Best Share" card
+    /// (the highest-difficulty share seen — how close a miner got to a block).
+    /// The stratum session invokes this for EVERY accepted pseudoshare (the
+    /// vardiff-gate acceptance path), passing the already-computed X11/scrypt
+    /// share difficulty plus the raw submit fields so an implementor that wants
+    /// the exact pow-hash can recompute it. Default no-op — only work sources
+    /// whose dashboard is a separate object (c2pool-dash: the DASHWorkSource
+    /// drives its own stratum acceptor, distinct from the WebServer's
+    /// MiningInterface) override this to forward to the dashboard's best-share
+    /// tracker. Display only — never affects acceptance, target, or payout.
+    virtual void record_best_pseudoshare(
+        double /*share_difficulty*/, const std::string& /*miner*/,
+        const std::string& /*coinb1*/, const std::string& /*coinb2*/,
+        const std::string& /*extranonce1*/, const std::string& /*extranonce2*/,
+        const std::string& /*ntime*/, const std::string& /*nonce*/,
+        uint32_t /*version*/, const std::string& /*prevhash_hex*/,
+        const std::string& /*nbits_hex*/,
+        const std::vector<std::string>& /*merkle_branches*/) {}
 };
 
 }  // namespace core::stratum

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -4667,6 +4667,29 @@ nlohmann::json MiningInterface::rest_local_stats()
     }
     result["miner_last_difficulties"] = miner_diffs;
 
+    // Best-share summary (highest-difficulty pseudoshare seen). Mirrors the
+    // dedicated /best_share endpoint so /local_stats consumers get the "how
+    // close did the best share get to a block" metric inline. Display only.
+    {
+        std::lock_guard<std::mutex> lock(m_best_diff_mutex);
+        auto pct = [&](double d) { return net_diff > 0 ? d / net_diff * 100.0 : 0.0; };
+        auto bs_entry = [&](double diff, const std::string& miner,
+                            const std::string& hash, uint64_t ts) {
+            return nlohmann::json{
+                {"difficulty", diff}, {"pct_of_block", pct(diff)},
+                {"miner", miner}, {"hash", hash}, {"timestamp", ts}};
+        };
+        result["best_share"] = {
+            {"network_difficulty", net_diff},
+            {"round", bs_entry(m_best_difficulty.round, m_best_difficulty.miner,
+                               m_best_difficulty.hash, m_best_difficulty.timestamp)},
+            {"session", bs_entry(m_best_difficulty.session, m_best_difficulty.session_miner,
+                                 m_best_difficulty.session_hash, m_best_difficulty.session_ts)},
+            {"all_time", bs_entry(m_best_difficulty.all_time, m_best_difficulty.all_time_miner,
+                                  m_best_difficulty.all_time_hash, m_best_difficulty.all_time_ts)}
+        };
+    }
+
     // p2pool-compat: version and protocol_version
     result["version"] = m_pool_version;
     result["protocol_version"] = m_protocol_version.load(std::memory_order_relaxed);
@@ -5610,23 +5633,28 @@ nlohmann::json MiningInterface::rest_best_share()
             best_round = avg;
         }
 
-        auto make_entry = [&](double diff, const std::string& miner, uint64_t ts) {
+        auto make_entry = [&](double diff, const std::string& miner, uint64_t ts,
+                              const std::string& hash) {
             nlohmann::json e;
             e["difficulty"] = diff;
             e["pct_of_block"] = (net_diff > 0) ? (diff / net_diff * 100.0) : 0.0;
             e["miner"] = miner;
             e["timestamp"] = ts;
+            e["hash"] = hash;   // pow-hash of the record share (empty until wired)
             return e;
         };
 
         result["all_time"] = make_entry(best_all,
-            m_best_difficulty.all_time_miner, m_best_difficulty.all_time_ts);
+            m_best_difficulty.all_time_miner, m_best_difficulty.all_time_ts,
+            m_best_difficulty.all_time_hash);
         auto session = make_entry(best_sess,
-            m_best_difficulty.session_miner, m_best_difficulty.session_ts);
+            m_best_difficulty.session_miner, m_best_difficulty.session_ts,
+            m_best_difficulty.session_hash);
         session["started"] = m_start_time.time_since_epoch().count() / 1000000000ULL;
         result["session"] = session;
         auto round = make_entry(best_round,
-            m_best_difficulty.miner, m_best_difficulty.timestamp);
+            m_best_difficulty.miner, m_best_difficulty.timestamp,
+            m_best_difficulty.hash);
         round["started"] = m_best_difficulty.round_start;
         result["round"] = round;
     }
@@ -7266,7 +7294,8 @@ nlohmann::json MiningInterface::rest_web_graph_data(const std::string& source, c
 
 // ──────────── Difficulty tracking and stat log helpers ────────────────────
 
-void MiningInterface::record_share_difficulty(double difficulty, const std::string& miner)
+void MiningInterface::record_share_difficulty(double difficulty, const std::string& miner,
+                                              const std::string& share_hash)
 {
     // Feed the rolling-hashrate ring. Independent of the best-diff
     // tracking below; the ring has its own internal lock.
@@ -7278,16 +7307,19 @@ void MiningInterface::record_share_difficulty(double difficulty, const std::stri
     if (difficulty > m_best_difficulty.all_time) {
         m_best_difficulty.all_time = difficulty;
         m_best_difficulty.all_time_miner = miner;
+        m_best_difficulty.all_time_hash = share_hash;
         m_best_difficulty.all_time_ts = now_ts;
     }
     if (difficulty > m_best_difficulty.session) {
         m_best_difficulty.session = difficulty;
         m_best_difficulty.session_miner = miner;
+        m_best_difficulty.session_hash = share_hash;
         m_best_difficulty.session_ts = now_ts;
     }
     if (difficulty > m_best_difficulty.round) {
         m_best_difficulty.round = difficulty;
         m_best_difficulty.miner = miner;
+        m_best_difficulty.hash = share_hash;
         m_best_difficulty.timestamp = now_ts;
     }
 }

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -1364,7 +1364,11 @@ public:
     void auto_detect_external_info();
 
     // Best share difficulty tracking (for /best_share, /miner_stats)
-    void record_share_difficulty(double difficulty, const std::string& miner);
+    // share_hash: optional pow-hash of the record-setting share (display only;
+    // DASH stratum submit path supplies it so the Best Share card can show the
+    // exact hash that got closest to net difficulty).
+    void record_share_difficulty(double difficulty, const std::string& miner,
+                                 const std::string& share_hash = "");
     void record_merged_share_difficulty(double difficulty, const std::string& miner);
 
     // Stat log entry (appended every 5 minutes, rolling 24h window for /web/log JSON)
@@ -1426,12 +1430,15 @@ private:
     struct BestDifficulty {
         double all_time{0.0};
         std::string all_time_miner;
+        std::string all_time_hash;   // pow-hash of the record share (display only)
         uint64_t all_time_ts{0};
         double session{0.0};
         std::string session_miner;
+        std::string session_hash;
         uint64_t session_ts{0};
         double round{0.0};
         std::string miner;       // round-level miner (backward compat)
+        std::string hash;        // round-level pow-hash (display only)
         uint64_t timestamp{0};   // round-level timestamp (backward compat)
         uint64_t round_start{0};
         // Merged chain (DOGE) best share tracking

--- a/src/impl/dash/node.hpp
+++ b/src/impl/dash/node.hpp
@@ -620,6 +620,30 @@ public:
     /// above, next to send_version.)
     uint256 best_share_hash();
 
+    /// Pool-peer info for the dashboard node-status card (ltc node.hpp:302
+    /// parity). Display only — MiningInterface::set_peer_info_fn feeds
+    /// /local_stats {peers:{incoming,outgoing}} and the peer table. Read-only
+    /// over the live m_peers map; touches no share/target/payout state.
+    nlohmann::json get_peer_info_json() const {
+        nlohmann::json arr = nlohmann::json::array();
+        for (const auto& [nonce, peer] : m_peers) {
+            if (!peer) continue;
+            auto addr = peer->addr();
+            bool incoming = (m_outbound_addrs.find(addr) == m_outbound_addrs.end());
+            auto uptime_sec = std::chrono::duration_cast<std::chrono::seconds>(
+                std::chrono::steady_clock::now() - peer->m_connected_at).count();
+            arr.push_back({
+                {"address", addr.to_string()},
+                {"version", peer->m_other_subversion},
+                {"incoming", incoming},
+                {"uptime", uptime_sec},
+                {"downtime", 0},
+                {"web_port", 0}
+            });
+        }
+        return arr;
+    }
+
     /// Relay a share (and up to 4 un-broadcast ancestors) to all peers via
     /// the message_shares wire codec (+ remember_tx/forget_tx for txs the
     /// peer lacks). try_to_lock; deferred if the compute thread is busy.

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -710,6 +710,12 @@ nlohmann::json DASHWorkSource::mining_submit(
         }
     };
 
+    // NOTE: the dashboard "Best Share" feed is NOT recorded here — mining_submit
+    // only runs for pool-quality shares / block solutions (the stratum session
+    // gates it), so it would miss ordinary pseudoshares. Every accepted
+    // pseudoshare is instead recorded via record_best_pseudoshare(), which the
+    // core stratum session calls on the vardiff-accept path.
+
     // 6. Classify (tighten-first: block target before share target).
     if (pow_hash <= block_target) {
         // A full network block. NEVER drop it.
@@ -803,6 +809,19 @@ nlohmann::json DASHWorkSource::mining_submit(
                          "BLOCK height=" << height << " not broadcast -- lost subsidy!";
         }
 
+        // Recent-blocks dashboard record: a genuine block solution we
+        // dispatched to the network. A local payee-guard reject was never sent
+        // (not a won block) so it is skipped. Display only; fired after the
+        // dispatch decision, never gates it.
+        if (!payee_guard_reject) {
+            FoundBlockFn fb_fn;
+            {
+                std::lock_guard<std::mutex> lk(found_block_mutex_);
+                fb_fn = on_found_block_fn_;
+            }
+            if (fb_fn) fb_fn(height, pow_hash, username, reached_network);
+        }
+
         bump(true);
         return nlohmann::json(true);
     }
@@ -874,23 +893,23 @@ nlohmann::json DASHWorkSource::mining_submit(
     return reject(23, "Low difficulty share");
 }
 
-double DASHWorkSource::compute_share_difficulty(
+// Shared header reconstruction → X11 pow-hash. Used by BOTH the vardiff-gate
+// difficulty (compute_share_difficulty) and the best-share dashboard feed
+// (record_best_pseudoshare) so the two never diverge. Returns a null uint256
+// on any malformed input.
+static uint256 dash_reconstruct_pow_hash(
     const std::string& coinb1, const std::string& coinb2,
     const std::string& extranonce1, const std::string& extranonce2,
     const std::string& ntime, const std::string& nonce,
     uint32_t version, const std::string& prevhash_hex,
     const std::string& nbits_hex,
-    const std::vector<std::string>& merkle_branches) const
+    const std::vector<std::string>& merkle_branches)
 {
-    // Per-coin PoW difficulty for the vardiff gate: the SAME header
-    // reconstruction as mining_submit, ending in diff1 / x11(header). 0.0 on
-    // any malformed input (the documented parse-error sentinel the vardiff
-    // gate treats as a hard reject).
     auto coinb1_bytes = ParseHex(coinb1);
     auto en1_bytes    = ParseHex(extranonce1);
     auto en2_bytes    = ParseHex(extranonce2);
     auto coinb2_bytes = ParseHex(coinb2);
-    if (coinb1_bytes.empty() || coinb2_bytes.empty()) return 0.0;
+    if (coinb1_bytes.empty() || coinb2_bytes.empty()) return uint256();
 
     std::vector<unsigned char> coinbase;
     coinbase.reserve(coinb1_bytes.size() + en1_bytes.size()
@@ -908,9 +927,8 @@ double DASHWorkSource::compute_share_difficulty(
         merkle_root = merkle_pair(merkle_root, b);
     }
 
-    // prevhash arrives BE-display; 64 hex chars or it's malformed.
     auto prevhash_be = ParseHex(prevhash_hex);
-    if (prevhash_be.size() != 32) return 0.0;
+    if (prevhash_be.size() != 32) return uint256();
     uint256 prev_block;
     prev_block.SetHex(prevhash_hex.c_str());
 
@@ -920,9 +938,53 @@ double DASHWorkSource::compute_share_difficulty(
         parse_be_hex_u32(ntime), parse_be_hex_u32(nbits_hex),
         parse_be_hex_u32(nonce));
 
-    const uint256 pow_hash = dash::crypto::hash_x11(header, sizeof(header));
+    return dash::crypto::hash_x11(header, sizeof(header));
+}
+
+double DASHWorkSource::compute_share_difficulty(
+    const std::string& coinb1, const std::string& coinb2,
+    const std::string& extranonce1, const std::string& extranonce2,
+    const std::string& ntime, const std::string& nonce,
+    uint32_t version, const std::string& prevhash_hex,
+    const std::string& nbits_hex,
+    const std::vector<std::string>& merkle_branches) const
+{
+    // Per-coin PoW difficulty for the vardiff gate: the SAME header
+    // reconstruction as mining_submit, ending in diff1 / x11(header). 0.0 on
+    // any malformed input (the documented parse-error sentinel the vardiff
+    // gate treats as a hard reject).
+    const uint256 pow_hash = dash_reconstruct_pow_hash(
+        coinb1, coinb2, extranonce1, extranonce2, ntime, nonce,
+        version, prevhash_hex, nbits_hex, merkle_branches);
     if (pow_hash.IsNull()) return 0.0;
     return chain::target_to_difficulty(pow_hash);
+}
+
+void DASHWorkSource::record_best_pseudoshare(
+    double share_difficulty, const std::string& miner,
+    const std::string& coinb1, const std::string& coinb2,
+    const std::string& extranonce1, const std::string& extranonce2,
+    const std::string& ntime, const std::string& nonce,
+    uint32_t version, const std::string& prevhash_hex,
+    const std::string& nbits_hex,
+    const std::vector<std::string>& merkle_branches)
+{
+    ShareDifficultyFn fn;
+    {
+        std::lock_guard<std::mutex> lk(share_difficulty_mutex_);
+        fn = on_share_difficulty_fn_;
+    }
+    if (!fn) return;
+    const uint256 pow_hash = dash_reconstruct_pow_hash(
+        coinb1, coinb2, extranonce1, extranonce2, ntime, nonce,
+        version, prevhash_hex, nbits_hex, merkle_branches);
+    // Prefer the difficulty the stratum session already computed; fall back to
+    // the reconstructed hash if the caller passed 0.
+    double diff = share_difficulty > 0.0
+                      ? share_difficulty
+                      : (pow_hash.IsNull() ? 0.0 : chain::target_to_difficulty(pow_hash));
+    if (diff > 0.0)
+        fn(diff, miner, pow_hash);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -933,6 +995,18 @@ void DASHWorkSource::set_best_share_hash_fn(std::function<uint256()> fn)
 {
     std::lock_guard<std::mutex> lk(best_share_mutex_);
     best_share_hash_fn_ = std::move(fn);
+}
+
+void DASHWorkSource::set_on_share_difficulty_fn(ShareDifficultyFn fn)
+{
+    std::lock_guard<std::mutex> lk(share_difficulty_mutex_);
+    on_share_difficulty_fn_ = std::move(fn);
+}
+
+void DASHWorkSource::set_on_found_block_fn(FoundBlockFn fn)
+{
+    std::lock_guard<std::mutex> lk(found_block_mutex_);
+    on_found_block_fn_ = std::move(fn);
 }
 
 void DASHWorkSource::set_mint_share_fn(MintShareFn fn)

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -241,6 +241,20 @@ public:
         const std::string& nbits_hex,
         const std::vector<std::string>& merkle_branches) const override;
 
+    /// IWorkSource best-share feed: recompute the exact X11 pow-hash for this
+    /// accepted pseudoshare and forward (difficulty, miner, pow_hash) to the
+    /// dashboard best-share tracker via on_share_difficulty_fn_. Every accepted
+    /// pseudoshare flows here (the stratum vardiff-accept path), so the "Best
+    /// Share" card populates on the DASH solo path where shares seldom mint.
+    void record_best_pseudoshare(
+        double share_difficulty, const std::string& miner,
+        const std::string& coinb1, const std::string& coinb2,
+        const std::string& extranonce1, const std::string& extranonce2,
+        const std::string& ntime, const std::string& nonce,
+        uint32_t version, const std::string& prevhash_hex,
+        const std::string& nbits_hex,
+        const std::vector<std::string>& merkle_branches) override;
+
     // ── IWorkSource: atomic state ────────────────────────────────────────
     uint32_t get_share_bits() const override     { return share_bits_.load(); }
     uint32_t get_share_max_bits() const override { return share_max_bits_.load(); }
@@ -265,6 +279,32 @@ public:
     /// hash. Called once at startup from main_dash.cpp after the DASH
     /// ShareTracker is constructed.
     void set_best_share_hash_fn(std::function<uint256()> fn);
+
+    /// Best-share (highest-difficulty pseudoshare) reporter. Fired from
+    /// mining_submit for EVERY accepted submission with the actual PoW
+    /// difficulty of the found hash (target_to_difficulty(pow_hash)), the
+    /// submitting miner (stratum username), and the pow-hash hex. main_dash.cpp
+    /// binds this to MiningInterface::record_share_difficulty so the dashboard
+    /// "Best Share" card shows how close DASH solo shares got to net difficulty
+    /// even when no share ever mints onto the sharechain. Display only — never
+    /// touches share/target/payout logic. While unbound this is a no-op.
+    using ShareDifficultyFn =
+        std::function<void(double difficulty, const std::string& miner,
+                           const uint256& pow_hash)>;
+    void set_on_share_difficulty_fn(ShareDifficultyFn fn);
+
+    /// Found-block reporter for the dashboard "Recent Blocks" card. Fired from
+    /// mining_submit the moment a submission meets the full network block
+    /// target AND is dispatched to the network (NOT on a local payee-guard
+    /// reject). Carries the block height, the X11 block hash (== pow_hash for
+    /// DASH), the submitting miner, and whether at least one network sink was
+    /// reached. main_dash.cpp binds this to MiningInterface::record_found_block
+    /// so DASH block wins appear in the found-block history. Display only —
+    /// never gates the won-block dispatch. While unbound this is a no-op.
+    using FoundBlockFn =
+        std::function<void(uint32_t height, const uint256& block_hash,
+                           const std::string& miner, bool reached_network)>;
+    void set_on_found_block_fn(FoundBlockFn fn);
 
     /// Wire the sharechain mint dispatch (stage 4d follow-up). While unbound,
     /// share-target submissions are accepted for vardiff + loudly logged.
@@ -348,6 +388,14 @@ private:
     // Best-share callback (from ShareTracker). Empty until wired.
     mutable std::mutex          best_share_mutex_;
     std::function<uint256()>    best_share_hash_fn_;
+
+    // Best-share (highest-difficulty pseudoshare) reporter. Empty until wired.
+    mutable std::mutex          share_difficulty_mutex_;
+    ShareDifficultyFn           on_share_difficulty_fn_;
+
+    // Found-block reporter (dashboard recent-blocks card). Empty until wired.
+    mutable std::mutex          found_block_mutex_;
+    FoundBlockFn                on_found_block_fn_;
 
     // Sharechain mint dispatch (stage 4d). Empty until wired.
     mutable std::mutex          mint_share_mutex_;

--- a/web-static/dashboard.html
+++ b/web-static/dashboard.html
@@ -1841,6 +1841,7 @@
                         <div class="stat-value" style="display: flex; align-items: baseline; justify-content: flex-start; gap: 4px;"><span id="best_share_round_pct_fancy" style="color: var(--primary);">-</span><span id="best_share_merged_round_part" style="display: none;"> / <span id="best_share_merged_pct_fancy" style="color: #c3a634;">-</span></span></div>
                         <div class="stat-sub" style="font-size: 0.85em;"><span id="best_share_round_diff" style="color: var(--primary);">-</span> / <span id="best_share_net_diff" style="opacity: 0.55;">-</span><span id="best_share_merged_diff_part" style="display: none;"> &nbsp;·&nbsp; <span id="best_share_merged_round_diff" style="color: #c3a634;">-</span> / <span id="best_share_merged_net_diff" style="opacity: 0.55;">-</span></span></div>
                         <div class="stat-detail">🏆 <span style="color: var(--primary);"><span id="best_share_alltime_pct_fancy">-</span></span><span id="best_share_merged_record_part" style="display: none;"> / <span style="color: #c3a634;"><span id="best_share_merged_alltime_pct_fancy">-</span></span></span><span id="best_share_median_part" style="display: none;"> &nbsp;· x̃ <span style="color: var(--primary);"><span id="best_share_median_pct_fancy">-</span></span><span id="best_share_merged_median_part" style="display: none;"> / <span style="color: #c3a634;"><span id="best_share_merged_median_pct_fancy">-</span></span></span></span></div>
+                        <div class="stat-detail" style="font-size: 0.75em; opacity: 0.7; font-family: monospace; display: none;" id="best_share_hash_line" title=""></div>
                     </div>
                 </div>
                 
@@ -2992,6 +2993,20 @@
             d3.select('#best_share_round_diff').text(format_difficulty(bs.round.difficulty));
             d3.select('#best_share_net_diff').text(format_difficulty(bs.network_difficulty));
             d3.select('#best_share_alltime_pct_fancy').html(format_pct_fancy(bs.all_time.pct_of_block));
+            // Record-share hash (the exact hash that got closest to a block).
+            var recHash = (bs.round && bs.round.hash) ? bs.round.hash
+                        : ((bs.all_time && bs.all_time.hash) ? bs.all_time.hash : '');
+            var recMiner = (bs.round && bs.round.miner) ? bs.round.miner
+                        : ((bs.all_time && bs.all_time.miner) ? bs.all_time.miner : '');
+            var hl = d3.select('#best_share_hash_line');
+            if (recHash) {
+                hl.style('display', 'block')
+                  .attr('title', recHash + (recMiner ? '  —  ' + recMiner : ''))
+                  .text('⛏ ' + recHash.substr(0, 12) + '…' + recHash.substr(-8)
+                        + (recMiner ? '  ·  ' + recMiner.substr(0, 10) : ''));
+            } else {
+                hl.style('display', 'none');
+            }
             if (bs.merged) {
                 d3.select('#best_share_merged_round_part').style('display', 'inline');
                 d3.select('#best_share_merged_pct_fancy').html(format_pct_fancy(bs.merged.round.pct_of_block));


### PR DESCRIPTION
## DASH dashboard → LTC parity (ships with v0.2.4)

Wires the DASH c2pool dashboard cards that were broken/unpopulated to the **real DASH work-source / tracker / coin-state**, reusing `main_ltc`'s `WebServer` / `MiningInterface` wiring rather than forking a parallel dashboard. All changes are **display-only** — no share/target/payout/consensus logic is touched (confirmed below).

Base: fresh `master` @ `9ac8b3dd` (#781).

### PRIORITY-1 — Best Share card (end-to-end, populated)

The operator wants to *see how close DASH solo shares got to net difficulty* — solo shares rarely cross net-diff, and on the DASH path they seldom even mint onto the sharechain, so the tracker's verified-share `m_on_share_difficulty` hook (the only best-share feed) never fired → the 🎯 **Best Share** card sat empty.

Root fix — record best-share on the **stratum vardiff-accept path**, where every accepted pseudoshare is seen:

- New `IWorkSource::record_best_pseudoshare(...)` (default **no-op** → LTC/BTC/DGB unchanged). The core `StratumSession::handle_submit` calls it for **every accepted pseudoshare**, passing the already-computed X11 difficulty + miner + the raw submit fields.
- `DASHWorkSource` overrides it: recomputes the exact X11 pow-hash (shared `dash_reconstruct_pow_hash` helper, byte-identical to `mining_submit`/`compute_share_difficulty`) and forwards `(difficulty, miner, pow_hash)` to the dashboard via a callback `main_dash` binds to `MiningInterface::record_share_difficulty`.
- `record_share_difficulty` / `BestDifficulty` / `/best_share` now also carry the **share hash + timestamp**; a compact `best_share` block is added to `/local_stats`; the dashboard card renders the record-hash line.

**Verified live against a testnet dashd** (`ubuntu@192.168.86.52`, isolated instance, testbed only) — a pseudoshare miner submitted and `/best_share` populated:

```json
{
  "network_difficulty": 0.008288110320964296,
  "round": {
    "difficulty": 0.0007045984339726283,
    "pct_of_block": 8.501315820934325,
    "miner": "yiXsatJHYQD2u2vFVR1yeWQEUn3vDh7Ley",
    "hash": "0000058b39f949586e72742e3798efb456ba44d8f93686f2add980a9a271e78f",
    "timestamp": 1784597678
  },
  "session": { "difficulty": 0.0007045984, "pct_of_block": 8.50, "hash": "0000058b39f9...", ... },
  "all_time": { "difficulty": 0.0007045984, "pct_of_block": 8.50, "hash": "0000058b39f9...", ... }
}
```

i.e. **the best share got to 8.5% of net difficulty**, with the exact hash and the miner that found it — precisely the metric requested.

### Other cards wired (audit vs LTC dashboard)

| Card | Before (DASH) | After |
|---|---|---|
| **Best Share** 🎯 | empty ("-") — no stratum feed; tracker hook never fires solo | round/session/all-time difficulty + **pct_of_block** + **hash** + miner, populated from every accepted pseudoshare |
| **Peers / node-status** | `peers {incoming:0, outgoing:0}` always — `dash::Node` had no `get_peer_info_json`, `set_peer_info_fn` unwired | real pool p2p peers (added `dash::Node::get_peer_info_json`, ltc parity; wired `set_peer_info_fn`) |
| **Recent blocks / found-block history** | DASH block wins never recorded to the dashboard | `DASHWorkSource` fires a found-block hook after dual-path dispatch; `main_dash` records via `record_found_block` |

Already correct on master and confirmed populated in the same run (reused LTC data path, no change needed): pool/network hashrate, network difficulty, miner count + per-miner rows (`miner_hash_rates`), shares/efficiency, **block value + payout split** (`block_value` 2.381 / `block_value_miner` 0.595 via `coin_work_fn`), attempts-to-block, uptime, sharechain tip/stats.

Not in this PR (documented follow-ups; higher-touch, coin-embedded specific): node-topology per-coin panel (`set_node_topology_fn` is tied to embedded `coin_peer_sources`) and the PPLNS current-payouts panel. DASH masternode-payee / DIP4 coinbase display has no analogous LTC slot to reuse.

### Consensus-neutrality

Dashboard is read-only. The two touches on sensitive paths are strictly additive display feeds:
- `stratum_server.cpp`: one `record_best_pseudoshare(...)` call inserted between existing statements on the already-accepted path — no control-flow, acceptance, target, or payout change.
- `work_source.cpp`: the found-block hook fires **after** the existing dual-path dispatch decision (`!payee_guard_reject`) and only reads a callback.

No model/tool authorship attribution anywhere (branch/commit/PR/comments/HTML).

### Build / test
- `c2pool-dash` builds clean (0 errors).
- Live testbed run against testnet dashd: web dashboard LIVE, `/best_share` + `/local_stats` populated as above. No production deploy (hotel deploy is an operator tap).

**DRAFT** — no merge, no deploy.

