### PR TITLE
dgb: guard rpc_conf port parse against malformed conf (#744/#787 B2)

### DIFF
--- a/src/impl/dgb/coin/rpc_conf.hpp
+++ b/src/impl/dgb/coin/rpc_conf.hpp
@@ -55,6 +55,25 @@ inline std::string trim(const std::string& s)
     const auto e = s.find_last_not_of(ws);
     return s.substr(b, e - b + 1);
 }
+
+// Parse a TCP port from a conf value WITHOUT ever throwing. A raw std::stoi on
+// junk (e.g. rpcport=abc) throws std::invalid_argument / std::out_of_range which,
+// uncaught, ABORTS the node at startup -- and the default conf is read with no
+// flags, so a malformed digibyte.conf would crash operators who never opted in
+// (#744/#787 B2, first found in the BTC twin). On any non-numeric / out-of-range
+// / zero value, leave `out` untouched and return false so the caller degrades to
+// UNARMED, never crashes.
+inline bool parse_port(const std::string& val, uint16_t& out)
+{
+    if (val.empty()) return false;
+    for (char c : val) if (c < '0' || c > '9') return false;   // digits only
+    unsigned long n = 0;
+    try { n = std::stoul(val); }
+    catch (...) { return false; }
+    if (n == 0 || n > 65535) return false;
+    out = static_cast<uint16_t>(n);
+    return true;
+}
 } // namespace conf_detail
 
 // Parse rpcuser/rpcpassword/rpcport/rpcconnect from a digibyte.conf-style file
@@ -76,7 +95,7 @@ inline bool load_rpc_conf(const std::string& path, RpcConf& out)
         if (val.empty()) continue;
         if      (key == "rpcuser"     || key == "dgb_rpc_user")     out.user = val;
         else if (key == "rpcpassword" || key == "dgb_rpc_password") out.pass = val;
-        else if (key == "rpcport")    out.port = static_cast<uint16_t>(std::stoi(val));
+        else if (key == "rpcport")    conf_detail::parse_port(val, out.port);  // junk => leave 0 (caller fills default), never throw
         else if (key == "rpcconnect") out.host = val;
     }
     return !out.user.empty() && !out.pass.empty();
@@ -92,7 +111,9 @@ inline void apply_endpoint_override(const std::string& hostport, RpcConf& out)
     if (colon == std::string::npos) { out.host = hostport; return; }
     out.host = hostport.substr(0, colon);
     const std::string p = hostport.substr(colon + 1);
-    if (!p.empty()) out.port = static_cast<uint16_t>(std::stoi(p));
+    // Junk port (e.g. --coin-rpc host:notaport) is IGNORED, never a throw/abort:
+    // parse_port leaves out.port unchanged so the conf/default value stands.
+    conf_detail::parse_port(p, out.port);
 }
 
 } // namespace coin


### PR DESCRIPTION
Part of #744 / spun out of the #787 review.

## Bug
`dgb/coin/rpc_conf.hpp` parsed `rpcport` (and the `--coin-rpc` endpoint override) with **unguarded `std::stoi`**. A malformed value — e.g. `rpcport=abc` in `~/.digibyte/digibyte.conf` — throws `std::invalid_argument`/`std::out_of_range`, which is uncaught in `main_dgb`'s arming block and **aborts the node at startup**. The default conf path is read with no flags, so this crashes operators who never opted into the RPC arm.

Same defect the #787 review found in the BTC twin (B2); fixed there and here.

## Fix
Add `conf_detail::parse_port` (digits-only, range-checked 1..65535, never throws). Malformed/out-of-range/zero → leave port `0` (caller fills the per-net default) → the arm degrades to **UNARMED**, never a crash.

## Testing
Logic is byte-identical to the BTC twin's `parse_port`, which is KAT-locked (`MalformedPortNoThrowUnarmed` / `OutOfRangePortNoThrow` / `MalformedEndpointOverrideNoThrow` in #787). No new DGB test executable added, to avoid CI `--target` allowlist churn (the #137 NOT_BUILT sentinel risk). Builds clean (`c2pool-dgb`).

Header-only, DGB-fenced, consensus-neutral (conf parse only).

Draft — for review, not merge.
