### PR TITLE
dash(stratum): explicit template-cache invalidate on coin-P2P tip event — close stale-payee window under future io-decouple

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -1575,12 +1575,21 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 // synced base (ZERO after a reorg = full snapshot); the
                 // new_mnlistdiff subscription advances sml_base on acceptance.
                 if (cp) cp->send_getmnlistd(*sml_base, new_tip);
-                // #739: event-driven stale-work notify. NOTE: the freshness gate
-                // now holds the embedded arm on the dashd fallback until the
-                // getmnlistd above lands and re-notifies (maintainer state-dirty),
-                // so this notify serves the reward-safe fallback, not a stale-SML
-                // embedded template.
-                if (ws) ws->bump_work_generation();
+                // #739 + stale-payee window close: event-driven stale-work
+                // notify. INVALIDATE the template cache FIRST (mirrors the
+                // #770/#772 fire_refresh trio: invalidate + bump + notify) so the
+                // next served job is ALWAYS re-sourced with the fresh-tip payee,
+                // regardless of refresh_executor_ state. Without the explicit
+                // invalidate the window only stays closed IMPLICITLY (the coin-P2P
+                // arm has no refresh_executor_, so cached_work() re-sources inline);
+                // if io-decouple is ever extended to this arm, cached_work() would
+                // serve the STALE cached template while refreshing async and a
+                // stale-payee job would go out. Make it robust, not implicit.
+                if (ws) {
+                    ws->invalidate_template_cache(
+                        "coin-P2P tip changed: fresh-payee re-source");
+                    ws->bump_work_generation();
+                }
                 if (stratum_server) stratum_server->notify_all();
             });
 

--- a/test/test_dash_stratum_work_source.cpp
+++ b/test/test_dash_stratum_work_source.cpp
@@ -1411,4 +1411,93 @@ TEST(DashDashboardWiring, LocalStatsIdleWarningWhenNoWorkers)
     EXPECT_TRUE(idle);
 }
 
+// ═════════════════════════════════════════════════════════════════════════════
+// coin-P2P tip event closes the stale-payee window EXPLICITLY (robust under a
+// future io-decouple-extended config where refresh_executor_ is SET).
+// ═════════════════════════════════════════════════════════════════════════════
+
+namespace {
+// A DEFERRED refresh executor (models the rpc_pool background thread): jobs are
+// queued, not run inline, so cached_work() takes the serve-stale-while-refreshing
+// path — exactly the config where a bump-only tip event would REOPEN the window.
+struct DeferredExecutor {
+    std::vector<std::function<void()>> jobs;
+    void operator()(std::function<void()> j) { jobs.push_back(std::move(j)); }
+    void run() { auto q = std::move(jobs); jobs.clear(); for (auto& j : q) j(); }
+};
+}  // namespace
+
+// THE FIX: invalidate_template_cache() on the coin-P2P tip event guarantees the
+// next served job is re-sourced (fresh payee), never the stale cached one — even
+// with a background refresh_executor_ set.
+TEST(DashStratumCoinP2pTipInvalidate, InvalidateClosesStalePayeeWindowUnderRefreshExecutor)
+{
+    auto current  = std::make_shared<dash::coin::DashWorkData>(rich_work());   // tip A
+    auto fallback = [current]() -> dash::coin::DashWorkData { return *current; };
+    auto submit   = [](const std::vector<unsigned char>&, uint32_t) { return true; };
+    dash::coin::NodeCoinState cs;   // unpopulated -> fallback arm
+
+    dash::stratum::DASHWorkSource ws(cs, fallback, submit,
+                                     core::stratum::StratumConfig{}, /*is_testnet=*/false);
+    auto exec = std::make_shared<DeferredExecutor>();
+    ws.set_refresh_executor([exec](std::function<void()> j) { (*exec)(std::move(j)); });
+
+    // Prime the cache with tip A (dispatch the bg refresh, then run it).
+    ws.get_current_work_template();   // dispatches; returns set-gap
+    exec->run();                      // bg refresh sources tip A -> cache = A
+    ASSERT_EQ(ws.get_current_work_template().value("previousblockhash", ""),
+              std::string(kPrevHashHex));
+
+    // The coin-P2P feed advances to tip B (a DIFFERENT masternode payee).
+    *current = rotated_work();
+
+    // The coin-P2P on_tip_changed handler fires: invalidate + bump (+ notify).
+    ws.invalidate_template_cache("coin-P2P tip changed: fresh-payee re-source");
+    ws.bump_work_generation();
+
+    // Under refresh_executor_ the served job must NEVER be the stale tip-A
+    // template: the invalidate dropped the cache -> honest set-gap until the bg
+    // refresh lands tip B.
+    auto served = ws.get_current_work_template();
+    if (!served.empty())
+        EXPECT_NE(served.value("previousblockhash", ""), std::string(kPrevHashHex))
+            << "stale tip-A template must not be served after a coin-P2P tip event";
+    exec->run();   // the deferred bg refresh completes
+    auto fresh = ws.get_current_work_template();
+    ASSERT_FALSE(fresh.empty());
+    EXPECT_EQ(fresh.value("previousblockhash", ""), std::string(kRotatedPrevHashHex))
+        << "the served job must carry the FRESH-tip (B) template/payee";
+}
+
+// CONTRAST (the window this fix closes): bump_work_generation() ALONE, under a
+// refresh_executor_, serves the STALE cached tip-A template while refreshing
+// async — the implicit-only path that reopens the stale-payee window.
+TEST(DashStratumCoinP2pTipInvalidate, BumpAloneServesStaleUnderRefreshExecutor)
+{
+    auto current  = std::make_shared<dash::coin::DashWorkData>(rich_work());
+    auto fallback = [current]() -> dash::coin::DashWorkData { return *current; };
+    auto submit   = [](const std::vector<unsigned char>&, uint32_t) { return true; };
+    dash::coin::NodeCoinState cs;
+
+    dash::stratum::DASHWorkSource ws(cs, fallback, submit,
+                                     core::stratum::StratumConfig{}, /*is_testnet=*/false);
+    auto exec = std::make_shared<DeferredExecutor>();
+    ws.set_refresh_executor([exec](std::function<void()> j) { (*exec)(std::move(j)); });
+
+    ws.get_current_work_template();
+    exec->run();
+    ASSERT_EQ(ws.get_current_work_template().value("previousblockhash", ""),
+              std::string(kPrevHashHex));
+
+    *current = rotated_work();
+    ws.bump_work_generation();   // NO invalidate — the pre-fix implicit path
+
+    // Serves the STALE tip-A template (cache still held; async refresh not landed).
+    auto served = ws.get_current_work_template();
+    ASSERT_FALSE(served.empty());
+    EXPECT_EQ(served.value("previousblockhash", ""), std::string(kPrevHashHex))
+        << "bump-only under refresh_executor_ serves the STALE tip-A payee — the "
+           "window invalidate_template_cache() closes";
+}
+
 }  // namespace


### PR DESCRIPTION
Fast-follow reward-safety hardening (v0.2.4.1). **NOT blocking** the current review-approved v0.2.4 hotel deploy — the stale-payee window closes correctly today; this makes it explicit + future-proof.

## The latent gap (found in the ZMQ-rebase adversarial delta)
With `--coin-p2p-connect` (the hotel config), the coin-P2P arm's `on_tip_changed` handler (`main_dash.cpp`) does only `bump_work_generation()` + `notify_all()`. The fresh-payee GBT re-source happens **only implicitly**: the coin-P2P arm has no `refresh_executor_`, so `cached_work()` takes the legacy inline-blocking re-source path.

If #781's io-decouple is ever extended to the coin-P2P arm, `refresh_executor_` becomes set → `cached_work()` serves the **STALE cached template** (frozen masternode payee) while refreshing async → a stale-payee job goes out → the window **reopens** → lost blocks on a rotated payee.

## Fix
The coin-P2P `on_tip_changed` handler now calls `ws->invalidate_template_cache()` alongside `bump_work_generation()` + `notify_all()` — mirroring the #770/#772 `fire_refresh` trio (invalidate + bump + notify). The invalidate **drops the cache**, so the next served job is re-sourced with the fresh-tip payee regardless of `refresh_executor_` state; a set-gap (honest null) is served until the fresh template lands — never a stale-payee job.

## KATs (folded into the allowlisted `test_dash_stratum_work_source` — no `build.yml` change)
With a **deferred** `refresh_executor_` (models the rpc_pool background thread) and the fallback rotated to a NEW tip/payee after the cache is primed:
- `InvalidateClosesStalePayeeWindowUnderRefreshExecutor` — after invalidate+bump the served job is **never** the stale tip-A template (set-gap, then fresh tip-B). **The window stays closed with `refresh_executor_` set.**
- `BumpAloneServesStaleUnderRefreshExecutor` — the contrast: bump-only serves the STALE tip-A payee, proving the invalidate is what closes it.

**Consensus-neutral** — notify/refresh timing only; no share/payout/target/payee-value change. `stratum_work_source` 40 → 42 green; `c2pool-dash` builds+links.

Draft — for a v0.2.4.1 hotel binary; the staged v0.2.4 deploys meanwhile.