### PR TITLE
dash: stratum idle keepalive-notify (fixes D9 60s backup-watchdog flap) + CoindRPC idle-reconnect no longer re-pulls template unless tip changed

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -1221,6 +1221,12 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // mining (and later submitting) a payee from before the churn. weak_ptr:
     // rpc outlives work_source in this scope (declared earlier), so the
     // callback must not extend or assume the work source's lifetime.
+    //
+    // This is the conservative DEFAULT (covers the embedded arm, and the
+    // fallback arm before its tip poll is armed): every reconnect invalidates
+    // unconditionally. On the fallback arm the tip-poll block below OVERRIDES
+    // this with a tip-aware version that skips the invalidate when the tip is
+    // provably unchanged (#751 idle-reconnect churn fix) -- see there.
     if (rpc) {
         std::weak_ptr<dash::stratum::DASHWorkSource> ws_weak = work_source;
         rpc->set_on_reconnect([ws_weak]() {
@@ -1776,13 +1782,17 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         // The refresh trio, shared by both paths. Runs on the io_context thread
         // ONLY (the poll follow-up is posted back to ioc; the ZMQ callback posts
         // onto ioc), so ws/ss/dedup are never touched concurrently. `verb`
-        // differentiates the instant (ZMQ) vs polled log line.
-        std::function<void(const std::string&, const char*, const char*)>
+        // differentiates the instant (ZMQ) vs polled log line. Returns true iff
+        // the refresh trio actually fired (a NEW tip vs the shared dedup); false
+        // when the tip was unchanged and the call coalesced to a no-op -- the
+        // reconnect observer below uses that to tell a real tip change apart from
+        // a benign idle-timeout reconnect.
+        std::function<bool(const std::string&, const char*, const char*)>
             fire_refresh = [ws = work_source.get(), ss = stratum_server.get(),
                             tip_dedup](const std::string& tip,
                                        const char* source, const char* verb) {
                 if (!tip_dedup->is_new_tip(tip))
-                    return;   // dedup: coalesce a poll+ZMQ double-fire on one tip
+                    return false; // dedup: coalesce a poll+ZMQ double-fire on one tip
                 ws->invalidate_template_cache(
                     "tip-notify: dashd best-block changed");
                 ws->bump_work_generation();
@@ -1791,7 +1801,73 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                          << " -> " << verb;
                 std::cout << "[Stratum] " << source << ": " << tip.substr(0, 16)
                           << " -> " << verb << "\n";
+                return true;
             };
+
+        // #751 churn fix: refine the CoindRPC reconnect-churn observer on the
+        // fallback arm. dashd closes an idle keep-alive connection on its
+        // rpcservertimeout (default 30 s), so on an otherwise-idle pool c2pool
+        // reconnects every ~30-90 s. The unconditional invalidate wired on the
+        // main path (see "reconnect-churn observer" above) then fires clean_jobs
+        // to every stratum session on EVERY such reconnect -> the endpoint flaps
+        // and rigs waste work even though NOTHING changed on-chain. Here we
+        // OVERRIDE that observer (this assignment runs after the main-path one,
+        // still before the io loop starts) with a tip-aware version: on a
+        // reconnect, probe dashd's best-block hash and invalidate ONLY if the tip
+        // actually moved while we were disconnected.
+        //
+        //   INVARIANT (must NOT regress the stale-masternode-payee lost-block
+        //   class): a tip change during the disconnect window MUST still
+        //   invalidate -- a new tip means a new masternode payee, so any template
+        //   cached from before the churn is stale and unsafe to serve or submit.
+        //   We skip the invalidate ONLY when the tip is PROVABLY unchanged (probe
+        //   succeeded AND equals the last-seen tip). If the probe itself fails
+        //   (RPC not ready on the fresh socket) we FALL BACK to invalidating --
+        //   never serve stale-payee work on an unproven tip.
+        //
+        // Deadlock note: m_on_reconnect fires from inside NodeRPC::sync_reconnect(),
+        // which runs UNDER m_rpc_mutex from within Send(). A synchronous
+        // getbestblockhash() here would re-enter Send() and self-deadlock on that
+        // non-recursive mutex, so the probe is POSTED to rpc_pool (the RPC thread)
+        // and runs after the triggering Send() releases the lock. The tip compare
+        // + refresh trio then post BACK onto ioc, where fire_refresh / tip_dedup
+        // are io-thread-confined -- identical threading to the 3 s tip poll below.
+        rpc->set_on_reconnect(
+            [rpc = rpc.get(), rpc_pool, fire_refresh, ws = work_source.get(),
+             &ioc]() {
+                boost::asio::post(*rpc_pool, [rpc, fire_refresh, ws, &ioc]() {
+                    std::string tip;
+                    bool ok = false;
+                    try {
+                        tip = rpc->getbestblockhash(); // BLOCKING -- background thread
+                        ok = true;
+                    } catch (...) {
+                        // swallow -- treated as a probe failure (fail-safe below)
+                    }
+                    boost::asio::post(ioc,
+                        [ok, tip = std::move(tip), fire_refresh, ws]() {
+                            if (!ok || tip.empty()) {
+                                // FAIL-SAFE: tip unproven -> conservatively drop
+                                // the cache (the pre-#751 unconditional behaviour).
+                                ws->invalidate_template_cache(
+                                    "CoindRPC reconnect: tip probe failed "
+                                    "(fail-safe invalidate)");
+                                return;
+                            }
+                            // fire_refresh invalidates + bumps + notifies IFF the
+                            // tip is NEW vs the shared last-seen dedup; an unchanged
+                            // tip is a benign idle-timeout reconnect -> cache kept.
+                            if (!fire_refresh(tip, "reconnect",
+                                              "tip changed during disconnect -> "
+                                              "refresh + notify")) {
+                                LOG_INFO << "[Stratum] reconnect: benign idle-"
+                                            "timeout, tip unchanged ("
+                                         << tip.substr(0, 16)
+                                         << ") -- template cache retained";
+                            }
+                        });
+                });
+            });
 
         // BACKSTOP: 3 s getbestblockhash poll (#770), io-decoupled (#781).
         auto tip_timer = std::make_shared<io::steady_timer>(ioc);

--- a/src/core/stratum_server.cpp
+++ b/src/core/stratum_server.cpp
@@ -446,6 +446,7 @@ StratumSession::StratumSession(tcp::socket socket, std::shared_ptr<IWorkSource> 
     , server_(server)
     , connected_at_(std::chrono::steady_clock::now())
     , last_activity_(connected_at_)
+    , last_notify_at_(connected_at_)
     , work_push_timer_(socket_.get_executor())
     , handshake_timer_(socket_.get_executor())
 {
@@ -555,6 +556,16 @@ void StratumSession::process_message(std::size_t bytes_read)
                 : hashrate_tracker_.get_current_difficulty();
             send_set_difficulty(initial_diff);
             send_notify_work();
+            // Idle keepalive only: arm the periodic work-push / keepalive timer
+            // as soon as the session is subscribed -- a backup pool connection
+            // commonly subscribes and then sits idle without ever submitting, and
+            // it must still be fed keepalive notifies (D9 60 s watchdog).
+            // Idempotent: the authorize path re-calls start_periodic_work_push()
+            // and it no-ops. Gated on keepalive being enabled so coins with it
+            // OFF (LTC/BTC/DGB) keep the legacy authorize-only arming.
+            if (mining_interface_
+                && mining_interface_->get_stratum_config().keepalive_notify_sec > 0)
+                start_periodic_work_push();
         }
         
     } catch (const std::exception& e) {
@@ -1828,6 +1839,13 @@ void StratumSession::send_notify_work(bool force_clean, const uint256* frozen_be
     // Track generation so safety timer doesn't re-push unchanged work
     last_pushed_generation_ = mining_interface_->get_work_generation();
 
+    // Idle keepalive-notify bookkeeping: record when we last put a mining.notify
+    // on the wire so the periodic push can tell an idle session (no notify for
+    // keepalive_notify_sec) from a recently-fed one. Covers EVERY notify path
+    // (event-driven, VARDIFF, safety, keepalive) so a real notify resets the
+    // idle clock and the keepalive never piggybacks right after one.
+    last_notify_at_ = std::chrono::steady_clock::now();
+
     send_response(notification);
 }
 
@@ -1835,9 +1853,19 @@ void StratumSession::start_periodic_work_push()
 {
     // Safety-net timer: push work only if the template changed since last push.
     // p2pool has no periodic push — work is pushed purely by events (new block,
-    // new best_share, VARDIFF). This 30-second fallback catches edge cases where
-    // an event-driven notify_all() might miss a session.
-    work_push_timer_.expires_after(std::chrono::seconds(5));
+    // new best_share, VARDIFF). This fallback catches edge cases where an
+    // event-driven notify_all() might miss a session. When idle keepalive-notify
+    // is enabled (StratumConfig::keepalive_notify_sec) the SAME timer also feeds
+    // an idle-but-live session a non-clean refresh so a client-side no-notify
+    // watchdog never drops it (see schedule_work_push_timer). First tick soon;
+    // never later than the keepalive interval so an idle session is fed promptly.
+    if (periodic_push_started_) return;   // arm exactly once (subscribe/authorize)
+    periodic_push_started_ = true;
+    const auto& cfg = mining_interface_->get_stratum_config();
+    uint32_t first = 5;
+    if (cfg.keepalive_notify_sec > 0)
+        first = std::min<uint32_t>(first, cfg.keepalive_notify_sec);
+    work_push_timer_.expires_after(std::chrono::seconds(first));
     schedule_work_push_timer();
 }
 
@@ -1849,13 +1877,34 @@ void StratumSession::schedule_work_push_timer()
     // Matches p2pool Twisted: transport owns timers, connectionLost is teardown.
     work_push_timer_.async_wait([self = shared_from_this()](boost::system::error_code ec) {
         if (ec || !self->is_connected()) return;
-        self->work_push_timer_.expires_after(std::chrono::seconds(30));
+        const auto& cfg = self->mining_interface_->get_stratum_config();
+        // Re-arm at the keepalive interval when enabled (so the idle check runs
+        // often enough to stay under the client watchdog), else the legacy 30 s
+        // safety cadence -- LTC/BTC/DGB (keepalive_notify_sec == 0) unchanged.
+        const uint32_t interval =
+            cfg.keepalive_notify_sec > 0 ? cfg.keepalive_notify_sec : 30;
+        self->work_push_timer_.expires_after(std::chrono::seconds(interval));
         self->schedule_work_push_timer();
         try {
             auto current_gen = self->mining_interface_->get_work_generation();
             if (current_gen != self->last_pushed_generation_) {
+                // Work actually changed -> event-style push (may be clean_jobs).
                 self->send_notify_work();
                 self->last_pushed_generation_ = current_gen;
+            } else if (cfg.keepalive_notify_sec > 0
+                       && self->is_subscribed()
+                       && self->seconds_since_last_notify() * 2
+                              >= static_cast<double>(cfg.keepalive_notify_sec)) {
+                // Idle keepalive: nothing changed and this session has had no
+                // notify for >= half the interval. Re-send the CURRENT job as a
+                // non-clean (force_clean=false) mining.notify to feed a client-
+                // side no-notify watchdog (measured D9: 60 s) so an otherwise-
+                // idle BACKUP connection never flaps. clean_jobs stays false, so
+                // the ASIC keeps its current work -- this is a liveness ping, not
+                // a work reset. The half-interval guard bounds the worst-case gap
+                // between notifies to ~1.5x the interval (well under the watchdog)
+                // while never piggybacking right after an event notify.
+                self->send_notify_work(false);
             }
         } catch (const std::exception& e) {
             LOG_WARNING << "[STRATUM] Work push error: " << e.what();

--- a/src/core/stratum_server.hpp
+++ b/src/core/stratum_server.hpp
@@ -194,6 +194,12 @@ class StratumSession : public std::enable_shared_from_this<StratumSession>
     // session_idle_timeout_sec). Updated on every received stratum line; a
     // half-open NAT-dead peer never advances it. Init to connected_at_.
     std::chrono::steady_clock::time_point last_activity_;
+    // Last OUTBOUND mining.notify timestamp (idle keepalive-notify, StratumConfig::
+    // keepalive_notify_sec). Distinct from last_activity_ (inbound): the keepalive
+    // must fire on an idle-but-live session that is receiving nothing AND sending
+    // nothing. Updated whenever send_notify_work() actually emits a notify; init
+    // to connected_at_.
+    std::chrono::steady_clock::time_point last_notify_at_;
     std::string session_id_;
 
     // Reject-reason diagnostics throttle: emit the low-diff (P5) and
@@ -221,6 +227,12 @@ class StratumSession : public std::enable_shared_from_this<StratumSession>
     // the timer outlives all its callbacks.  Matches p2pool Twisted semantics
     // where the transport/protocol object owns its timers.
     boost::asio::steady_timer work_push_timer_;
+    // One-shot guard so the periodic work-push / idle-keepalive timer is armed
+    // exactly once. It is armed at subscribe (so a subscribe-only backup session
+    // is kept alive by the keepalive) and again after authorize (payout-aware
+    // resend); this flag makes the second call a no-op so the timer chain never
+    // forks into a double-notify cadence.
+    bool periodic_push_started_ = false;
 
     // Handshake deadline (zombie-session fix, StratumConfig::handshake_timeout_
     // sec): armed at start(), disarmed once authorize completes. A session that
@@ -239,6 +251,11 @@ public:
     double seconds_since_activity() const {
         return std::chrono::duration<double>(
                    std::chrono::steady_clock::now() - last_activity_).count();
+    }
+    // Seconds since the last OUTBOUND mining.notify (idle keepalive-notify).
+    double seconds_since_last_notify() const {
+        return std::chrono::duration<double>(
+                   std::chrono::steady_clock::now() - last_notify_at_).count();
     }
     // Reap a stale/zombie session: cancel timers + close the socket. The pending
     // async_read then fails and runs the normal disconnect path. Idempotent.

--- a/src/core/stratum_types.hpp
+++ b/src/core/stratum_types.hpp
@@ -97,6 +97,19 @@ struct StratumConfig {
     //     exceeds this many frames (a dead peer whose kernel send buffer filled
     //     accumulates unbounded). 0=unlimited (legacy).
     size_t   max_write_queue_depth      = 0;
+    // (e) Idle keepalive-notify: re-send a mining.notify (a normal, non-
+    //     clean_jobs refresh of the CURRENT job) to a connected+subscribed
+    //     session that has received NO notify for ~this many seconds, driven by
+    //     the per-session periodic work-push timer -- regardless of tip/work
+    //     changes and regardless of whether the session is submitting. This
+    //     feeds a CLIENT-SIDE no-notify watchdog (measured Antminer D9: drops a
+    //     pool after 60.0 s without a notify) so an otherwise-idle BACKUP pool
+    //     connection stays alive independent of slot/path/RPC-timeout settings.
+    //     Set comfortably under the client watchdog (DASH: 25 s vs the 60 s D9
+    //     watchdog). clean_jobs is NEVER forced on this refresh, so ASIC work is
+    //     not reset. 0 = off (LTC/BTC/DGB unchanged: periodic push stays purely
+    //     work-generation-gated).
+    uint32_t keepalive_notify_sec       = 0;
 };
 
 /// Frozen share-construction fields returned by ref_hash_fn. These

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -163,6 +163,16 @@ DASHWorkSource::DASHWorkSource(const coin::NodeCoinState& coin_state,
     // genuinely dead / never-authorized sessions are reclaimed.
     config_.session_idle_timeout_sec = 1800;
     config_.max_write_queue_depth    = 256;     // drop a stuck-write dead peer
+    // Idle keepalive-notify (coupled with the #751 idle-reconnect churn fix):
+    // measured Antminer D9 rigs DROP a pool connection that receives no
+    // mining.notify for 60.0 s (then retry after 30 s). Until the #751 fix, the
+    // CoindRPC idle-reconnect churn re-broadcast work every ~30 s and was the
+    // ONLY thing keeping idle BACKUP pool connections alive; reducing that churn
+    // without feeding idle sessions would make every idle backup flap every
+    // ~90 s. Re-notify the CURRENT job (non-clean, so no ASIC work reset) every
+    // 25 s -- comfortably under the 60 s watchdog -- so any node is a stable
+    // backup regardless of slot/path/RPC-timeout settings.
+    config_.keepalive_notify_sec     = 25;
     LOG_INFO << "[DASH-STRATUM] DASHWorkSource constructed"
              << " (min_diff=" << config_.min_difficulty
              << " max_diff=" << config_.max_difficulty

--- a/test/test_dash_stratum_work_source.cpp
+++ b/test/test_dash_stratum_work_source.cpp
@@ -799,6 +799,100 @@ TEST(DashStratumWorkSource, FallbackArmTipChangeRefreshesTemplateAndBumpsGenerat
     EXPECT_EQ(tmpl_after.value("height", 0u), 424243u);
 }
 
+// ── #751 idle-reconnect churn fix KAT ───────────────────────────────────────
+// dashd closes an idle keep-alive connection on its rpcservertimeout (default
+// 30 s), so on an otherwise-idle pool c2pool reconnects every ~30-90 s. The old
+// behaviour invalidated the template cache (and fired clean_jobs) on EVERY such
+// reconnect, flapping the endpoint and wasting rig work even though nothing
+// changed on-chain. The fix makes the fallback-arm reconnect observer tip-aware:
+// on a reconnect it probes dashd's best-block hash and invalidates ONLY if the
+// tip actually moved during the disconnect.
+//
+// This KAT models that observer (mirroring main_dash.cpp's reconnect handler the
+// same way the ZMQ KAT models fire_refresh) and pins all three cases:
+//   (1) reconnect with the tip UNCHANGED -> NO invalidate (cache retained, no
+//       clean_jobs) -- the churn fix;
+//   (2) reconnect with the tip CHANGED during the disconnect -> DOES invalidate
+//       + bump (the stale-masternode-payee INVARIANT is preserved -- a moved tip
+//       must still re-source fresh-payee work);
+//   (3) reconnect where the best-block probe FAILS -> FAIL-SAFE invalidate
+//       (never serve stale-payee work on an unproven tip).
+TEST(DashStratumWorkSource, ReconnectInvalidatesOnlyWhenTipChanged)
+{
+    Fixture fx(true);                       // unpopulated coin-state -> fallback arm
+    ASSERT_FALSE(fx.coin_state.populated());
+    auto ws = fx.make();
+
+    // Shared last-seen-tip dedup + the tip-aware reconnect observer, mirroring
+    // main_dash.cpp: fire_refresh invalidates+bumps IFF the tip is new; the
+    // reconnect handler adds the fail-safe invalidate on a probe failure.
+    dash::coin::TipHashDedup dedup;
+    int notify_count = 0;
+    auto fire_refresh = [&](const std::string& tip) -> bool {
+        if (!dedup.is_new_tip(tip)) return false;   // unchanged tip -> no-op
+        ws->invalidate_template_cache("kat: tip changed during disconnect");
+        ws->bump_work_generation();
+        ++notify_count;                              // stands in for notify_all()
+        return true;
+    };
+    auto on_reconnect = [&](bool probe_ok, const std::string& probed_tip) {
+        if (!probe_ok || probed_tip.empty()) {
+            // FAIL-SAFE: unproven tip -> conservatively invalidate.
+            ws->invalidate_template_cache("kat: reconnect probe failed");
+            ++notify_count;
+            return;
+        }
+        // Benign idle-timeout reconnect (tip unchanged) coalesces to a no-op;
+        // a real tip change fires the refresh trio.
+        fire_refresh(probed_tip);
+    };
+
+    // Startup baseline: seed the dedup with the tip we are already mining (as the
+    // poll does at startup, WITHOUT notifying).
+    const std::string tip_old(64, 'a');
+    dedup.set_last(tip_old);
+    auto tmpl_before = ws->get_current_work_template();
+    ASSERT_FALSE(tmpl_before.empty());
+    EXPECT_EQ(tmpl_before.value("previousblockhash", ""), std::string(kPrevHashHex));
+    const uint64_t gen_baseline = ws->get_work_generation();
+
+    // (1) Idle-timeout reconnect, tip UNCHANGED -> NO invalidate, NO clean_jobs.
+    //     The endpoint does not flap; the cached template stays put.
+    on_reconnect(true, tip_old);
+    EXPECT_EQ(notify_count, 0);
+    EXPECT_EQ(ws->get_work_generation(), gen_baseline);   // no work-gen bump
+    auto tmpl_still = ws->get_current_work_template();
+    ASSERT_FALSE(tmpl_still.empty());
+    EXPECT_EQ(tmpl_still.value("previousblockhash", ""), std::string(kPrevHashHex));
+
+    // (2) A real tip change during the disconnect window -> MUST invalidate + bump
+    //     (stale-masternode-payee invariant preserved). The fallback now sources
+    //     the rotated-tip/rotated-payee template.
+    fx.fallback_work = rotated_work();
+    const std::string tip_new(64, 'b');
+    ASSERT_NE(tip_new, tip_old);
+    on_reconnect(true, tip_new);
+    EXPECT_EQ(notify_count, 1);                            // trio fired
+    EXPECT_GT(ws->get_work_generation(), gen_baseline);   // clean_jobs/notify signal
+    auto tmpl_after = ws->get_current_work_template();
+    ASSERT_FALSE(tmpl_after.empty());
+    EXPECT_EQ(tmpl_after.value("previousblockhash", ""),   // no stale-tip mining
+              std::string(kRotatedPrevHashHex));
+    EXPECT_EQ(tmpl_after.value("height", 0u), 424243u);
+
+    // (2b) An immediate follow-up reconnect on the SAME (now current) tip is again
+    //      benign -> deduped no-op (proves case (1) still holds after a change).
+    const uint64_t gen_after_change = ws->get_work_generation();
+    on_reconnect(true, tip_new);
+    EXPECT_EQ(notify_count, 1);
+    EXPECT_EQ(ws->get_work_generation(), gen_after_change);
+
+    // (3) FAIL-SAFE: the best-block probe fails on reconnect (RPC not ready) ->
+    //     invalidate conservatively rather than risk serving stale-payee work.
+    on_reconnect(false, "");
+    EXPECT_EQ(notify_count, 2);                            // fail-safe invalidate fired
+}
+
 // ── io-thread-decouple KAT (mining-hotel stratum-stall fix, v0.2.3.8) ────────
 // The stall fix: the stratum io_context thread must NEVER block on the dashd
 // fallback getblocktemplate. cached_work() re-sources through a background

--- a/test/test_stratum_hotel_interim.cpp
+++ b/test/test_stratum_hotel_interim.cpp
@@ -332,6 +332,7 @@ public:
     }
 
     std::vector<std::string> jobs;         // job ids, in notify order
+    std::vector<bool> clean_flags;         // clean_jobs (params[8]) per notify, in order
     std::string last_ntime = "65a812c0";   // overwritten by record_notify
 
 private:
@@ -341,6 +342,7 @@ private:
             && j.contains("params") && j["params"].is_array()
             && j["params"].size() >= 9) {
             jobs.push_back(j["params"][0].get<std::string>());
+            clean_flags.push_back(j["params"][8].get<bool>());
             last_ntime = j["params"][7].get<std::string>();
         }
     }
@@ -492,4 +494,72 @@ TEST(StratumHotelInterim, FlatRssSharedPayloadIdentity)
     // one copy per job. This is the de-duped "memory bomb" assertion.
     EXPECT_EQ(distinct, kSessions)
         << "expected 1 shared payload per session (jobs=" << total << ")";
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// KAT 4 — IDLE KEEPALIVE-NOTIFY (D9 60 s backup-watchdog flap fix,
+// StratumConfig::keepalive_notify_sec). An idle, subscribe-only, NON-submitting
+// session must keep receiving mining.notify at the keepalive cadence even though
+// the work generation NEVER changes and no share is ever submitted — this is
+// what keeps an idle BACKUP pool connection alive under a client-side no-notify
+// watchdog (measured Antminer D9: drops a pool after 60 s without a notify). The
+// keepalive refresh must be NON-clean (clean_jobs=false) so the ASIC's current
+// work is not reset. A control run with keepalive OFF must NOT emit those extra
+// notifies (proving the notifies are the keepalive, not some other path, and
+// that other coins with keepalive_notify_sec==0 are unaffected).
+//
+// Uses a 1 s keepalive interval so the KAT runs in a few seconds of wall-clock
+// while exercising the real per-session steady-timer path end-to-end.
+TEST(StratumHotelInterim, IdleKeepaliveNotifyFeedsSubscribeOnlySession)
+{
+    ServerHarness h;
+    h.ws->cfg.keepalive_notify_sec = 1;   // 1 s cadence for a fast KAT
+    ASSERT_TRUE(h.start());
+
+    Client c;
+    ASSERT_TRUE(c.connect(h.port));
+    ASSERT_TRUE(c.subscribe());           // subscribe-only: never authorize, never submit
+
+    // The generation is pinned (FakeWorkSource::generation stays 1) and we drive
+    // NO notify_storm, so every notify beyond the initial subscribe push is a
+    // pure idle keepalive. Collect over ~4.5 s: at a 1 s cadence an idle session
+    // must receive several. Without the keepalive this would time out at 1.
+    const bool got = c.collect_notifies(4, 4500ms);
+    EXPECT_TRUE(got) << "idle subscribe-only session received only "
+                     << c.jobs.size() << " notify(ies) — keepalive not firing";
+    EXPECT_GE(c.jobs.size(), 4u);
+
+    // Every keepalive refresh after the first (subscribe) notify must be
+    // NON-clean: clean_jobs=false, so the ASIC keeps hashing its current work.
+    ASSERT_FALSE(c.clean_flags.empty());
+    for (size_t i = 1; i < c.clean_flags.size(); ++i)
+        EXPECT_FALSE(c.clean_flags[i])
+            << "keepalive notify #" << i << " forced clean_jobs (would reset ASIC work)";
+
+    // Generation never moved: the notifies came purely from the keepalive path,
+    // not from a work-generation change.
+    EXPECT_EQ(h.ws->generation.load(), 1u);
+}
+
+// KAT 4b — CONTROL: with keepalive OFF (keepalive_notify_sec==0, the default and
+// the LTC/BTC/DGB setting), an idle subscribe-only session receives NO periodic
+// notify — the periodic push stays purely work-generation-gated. This pins that
+// the extra notifies in KAT 4 are the keepalive and that the feature is opt-in.
+TEST(StratumHotelInterim, KeepaliveOffLeavesIdleSessionUnfed)
+{
+    ServerHarness h;
+    h.ws->cfg.keepalive_notify_sec = 0;   // default / other-coins behaviour
+    ASSERT_TRUE(h.start());
+
+    Client c;
+    ASSERT_TRUE(c.connect(h.port));
+    ASSERT_TRUE(c.subscribe());
+    const size_t after_subscribe = c.jobs.size();
+
+    // No generation change, no storm, keepalive off: no further notify should
+    // arrive. collect_notifies must TIME OUT (return false) here.
+    const bool got_more = c.collect_notifies(after_subscribe + 2, 3500ms);
+    EXPECT_FALSE(got_more)
+        << "idle session got unexpected notifies with keepalive OFF (jobs="
+        << c.jobs.size() << ")";
 }


### PR DESCRIPTION
## Problem

On the DASH stratum **fallback arm**, two coupled effects hurt idle backup pools:

1. **CoindRPC idle-reconnect churn (#751).** The c2pool->dashd JSON-RPC keep-alive connection idles out (dashd default `rpcservertimeout=30s` closes it) and c2pool reconnects. The reconnect-churn observer invalidated the template cache on **every** reconnect, firing `clean_jobs` to every session. On an idle node this recurs every ~30-90s -> the endpoint flaps and rigs waste work even though nothing changed on-chain.

2. **Client-side no-notify watchdog.** Measured Antminer D9 rigs **drop** a pool connection that receives no `mining.notify` for **60.0s** (then retry after 30s). The churn above was *accidentally* re-broadcasting work every ~30s (each `invalidate_template_cache` bumps the work generation, and the per-session periodic push notifies on a generation change) -- which was the **only** thing keeping idle BACKUP pool connections alive.

These are **coupled**: reducing the churn (fix 1) without also feeding idle sessions would make every idle backup pool flap every ~90s (deterministic). This PR ships both as a safe-to-merge unit.

## Fix

### A. Idle keepalive-notify (primary)
A per-session keepalive driven by the existing periodic work-push steady timer:
- New `StratumConfig::keepalive_notify_sec` (**default 0 = off**, so LTC/BTC/DGB are byte-unchanged). DASH sets **25s** (comfortably under the 60s D9 watchdog).
- When enabled and the work generation has **not** changed, a connected+subscribed session that has had no notify for >= half the interval is re-sent the **current** job as a **non-clean** (`clean_jobs=false`) `mining.notify`. It is a liveness ping, **not** a work reset -- the ASIC keeps its work. The half-interval guard bounds the worst-case notify gap to ~1.5x the interval (well under the watchdog) and never piggybacks right after an event notify.
- The timer re-arms at the keepalive interval when enabled (else the legacy 30s safety cadence), and is now armed at **subscribe** (idempotent one-shot guard) when keepalive is on, so a subscribe-only backup session that never submits is still fed. Coins with keepalive off keep the legacy authorize-only arming.
- `last_notify_at_` tracks the last outbound notify across all paths (event/VARDIFF/safety/keepalive) so the idle clock is accurate.

This makes any node a stable backup independent of slot, path, or dashd `rpcservertimeout`.

### B. Tip-aware CoindRPC reconnect (#751 churn reduction)
On a reconnect the fallback-arm observer probes dashd `getbestblockhash` and invalidates the template cache **only if** the best-block hash actually moved during the disconnect:
- tip **CHANGED** -> invalidate + bump work generation + `notify_all` (unchanged behaviour: a new tip means a new masternode payee);
- tip **UNCHANGED** -> keep the cache, log a benign idle-timeout reconnect;
- probe **FAILS/times out** -> **fail-safe** invalidate (never serve stale-payee work on an unproven tip).

The probe is posted to the RPC-dedicated thread and the compare/refresh posts back onto the `io_context`, because the observer fires from inside `NodeRPC::sync_reconnect()` while holding the RPC mutex within `Send()` -- a synchronous `getbestblockhash()` there would self-deadlock. The main-path observer (embedded arm) keeps the conservative unconditional invalidate.

## Preserved invariant

The stale-masternode-payee lost-block class does **not** regress: a tip change during the disconnect window still invalidates; the invalidate is skipped only when the tip is provably unchanged. Stated in a code comment.

## Safety as a unit

With the keepalive present, reducing the churn no longer causes flap: idle sessions are fed a non-clean notify every ~25s regardless of tip changes or RPC-timeout settings.

## Tests

- `StratumHotelInterim.IdleKeepaliveNotifyFeedsSubscribeOnlySession` -- an idle subscribe-only, non-submitting session receives `mining.notify` at cadence with a pinned generation; all keepalive notifies are non-clean (`clean_jobs=false`).
- `StratumHotelInterim.KeepaliveOffLeavesIdleSessionUnfed` -- control: with keepalive off, an idle session receives none.
- `DashStratumWorkSource.ReconnectInvalidatesOnlyWhenTipChanged` -- unchanged tip -> no invalidate; changed tip -> invalidate + bump; probe failure -> fail-safe invalidate.

Full suites pass: `test_stratum_hotel_interim` 5/5, `test_dash_stratum_work_source` 43/43, `test_dash_stratum_notify_roundtrip` 7/7, `test_dash_job_notify_roundtrip` 6/6. `c2pool-dash` builds clean; LTC/BTC/DGB behaviour byte-unchanged (keepalive default off).
