### PR TITLE
dash: payee-guard verifies payee SCRIPTS by set-membership, not (script,amount) vs current template — stops false-rejecting valid won blocks

### DIFF
--- a/src/impl/dash/stratum/submit_payee_guard.hpp
+++ b/src/impl/dash/stratum/submit_payee_guard.hpp
@@ -10,27 +10,50 @@
 // bad-cb-payee — the block reward is lost. This was hex-confirmed live on
 // testnet (.52) at h1517420: the reassembled stratum coinbase was byte-correct
 // against the GBT at job-BUILD time, yet rejected at SUBMIT time because the
-// payee had rotated in between (same staleness class as the h1517187
-// bad-chainlock sibling).
+// payee had rotated in between.
 //
+// ── CRITICAL INVARIANT (reward safety) ──────────────────────────────────────
+// The guard must NEVER refuse a block that dashd would ACCEPT — a false refusal
+// forfeits a full block reward (~0.44 DASH per event, empirically observed).
+// It must still refuse a block dashd would deterministically reject for
+// bad-cb-payee (a genuinely WRONG payee script, or a WRONG height). When in
+// doubt, SUBMIT: a truly bad block is rejected by dashd for free, whereas a
+// false refusal is a guaranteed, irreversible loss.
+//
+// ── Why an AMOUNT comparison is WRONG (the false-refusal this fix removes) ───
+// The masternode/operator payment amount is subsidy + BLOCK FEES. Fees drift
+// every time the template is re-pulled at the same height (the mempool moves),
+// so a job's FROZEN coinbase amount routinely differs from the amount in a
+// LATER-fetched "current" template — even though both pay the SAME, correct,
+// height-deterministic payee script. dashd validates the masternode amount
+// against the BLOCK'S OWN fees (self-consistent by GBT construction), NOT
+// against some newer template. Comparing the frozen amount to the current
+// template's amount therefore false-flags perfectly valid winning blocks as
+// "stale payee" and refuses to submit them. Two mainnet blocks (heights
+// 2508655, 2508696) were lost this way in a single day: correct payee, correct
+// height/parent, multi-minute head start over the eventual network winner,
+// rejected purely on fee-driven amount drift.
+//
+// ── What the guard actually checks ──────────────────────────────────────────
 // check_submit_payee() is the last line of defense, called by
 // DASHWorkSource::mining_submit() on the won-block path BEFORE dispatching to
-// the network: it compares the job's reassembled coinbase outputs against the
-// GBT-mandated payments of the CURRENT template.
+// the network. The payee SCRIPT is height-deterministic; the amount is not. So
+// the guard verifies payee SCRIPTS by SET MEMBERSHIP and never compares amounts:
 //
-//   - TipMoved:      the job's prev != current template prev. The block is
-//                    internally consistent for ITS OWN height (its payee
-//                    matches its own prev), so it is still submitted — it is
-//                    an orphan-race candidate, not a doomed bad-cb-payee.
-//   - StalePayee:    prev matches (same height) but a GBT-mandated payment
-//                    (masternode / superblock / platform burn) is MISSING or
-//                    amount-mismatched in the coinbase → dashd WILL reject
-//                    bad-cb-payee. The caller must NOT submit (reject-loud —
-//                    the steward-ruled posture; never silently submit a
-//                    doomed block).
-//   - Unverifiable:  the coinbase failed to deserialize. Never block a
-//                    submission on a guard-side parse failure — submit, log.
-//   - Ok:            every current GBT-mandated payment is present exactly.
+//   - WrongHeight:  the job's prev != the current chain tip. The job was built
+//                   on a parent that is no longer the tip → the block is for the
+//                   wrong height and dashd would reject it. DO NOT submit.
+//   - PayeeMissing: prev matches (same height) but a GBT-mandated payee SCRIPT
+//                   (masternode / operator / superblock / platform burn) is
+//                   ABSENT from the coinbase outputs → a genuine bad-cb-payee.
+//                   DO NOT submit. (This is the real stale/wrong-payee case;
+//                   a mere amount difference is NOT this — see above.)
+//   - Unverifiable: the coinbase failed to deserialize. Never block a
+//                   submission on a guard-side parse failure — submit, log.
+//   - Ok:           every GBT-mandated payee SCRIPT is present in the coinbase
+//                   at the current height. Amounts may differ from the current
+//                   template (fee drift) — that is fine; dashd validates the
+//                   amount against the block's own fees. SUBMIT.
 //
 // Pure + fenced: no sockets, no RPC, no locks — direct KAT surface
 // (test_dash_stratum_work_source.cpp). The payee→script decode reuses the
@@ -52,9 +75,9 @@
 namespace dash::stratum {
 
 enum class PayeeGuardVerdict {
-    Ok,           ///< all current GBT-mandated payments present — submit
-    TipMoved,     ///< job prev != current prev — orphan race, still submit
-    StalePayee,   ///< same prev, payee missing/mismatched — DO NOT submit
+    Ok,           ///< all mandated payee SCRIPTS present at current height — submit
+    WrongHeight,  ///< job prev != current tip — wrong height, dashd rejects — DO NOT submit
+    PayeeMissing, ///< same height, a mandated payee SCRIPT absent — bad-cb-payee — DO NOT submit
     Unverifiable, ///< coinbase would not parse — submit (never guard-block on parse)
 };
 
@@ -72,13 +95,16 @@ inline PayeeGuardResult check_submit_payee(
     PayeeGuardResult r;
 
     // Height context: same prev == same height == same expected payee set.
-    // A differing prev means the tip moved after the job was issued; the
-    // block is self-consistent for its own height (orphan-race candidate).
+    // A differing prev means the tip moved after the job was issued: the job
+    // was built on a parent that is no longer the chain tip, so the block is
+    // for the wrong height and dashd would reject it. Refuse — submitting a
+    // wrong-height block cannot win and only muddies the reject log.
     if (current.m_previous_block.GetHex() != job_gbt_prevhash) {
-        r.verdict = PayeeGuardVerdict::TipMoved;
+        r.verdict = PayeeGuardVerdict::WrongHeight;
         r.detail  = "job prev=" + job_gbt_prevhash.substr(0, 16)
-                  + " current prev=" + current.m_previous_block.GetHex().substr(0, 16)
-                  + " (tip moved since job issue — orphan-race submit)";
+                  + " current tip=" + current.m_previous_block.GetHex().substr(0, 16)
+                  + " (tip moved since job issue — block is for the wrong height,"
+                    " dashd would reject; DO NOT submit)";
         return r;
     }
 
@@ -94,31 +120,37 @@ inline PayeeGuardResult check_submit_payee(
         return r;
     }
 
-    // Every GBT-mandated payment (masternode / superblock / platform burn) of
-    // the CURRENT template must appear as an exact (script, amount) output.
+    // SET-MEMBERSHIP payee-script check (NOT an amount comparison). Every
+    // GBT-mandated payee SCRIPT of the current height must appear as SOME
+    // coinbase output's scriptPubKey. The payee script is height-deterministic,
+    // so the current template's mandated scripts equal the job's mandated
+    // scripts whenever the prev matches (verified above). We deliberately do
+    // NOT compare out.value against pay.amount: the mandated amount is
+    // subsidy + fees and drifts with the mempool between template re-pulls at
+    // the same height; dashd checks it against the block's OWN fees, so an
+    // amount difference here is NOT a reject and must NOT block the submit.
     for (const auto& pay : current.m_packed_payments) {
         if (pay.amount == 0)
-            continue;
+            continue;   // no-op payment — builder emits no output for it
         const auto want_script = dash::decode_payee_script(
             pay.payee, params.address_version, params.address_p2sh_version);
         if (want_script.empty())
             continue;   // undecodable payee — builder drops these too
         bool found = false;
         for (const auto& out : cb.vout) {
-            if (out.value == static_cast<int64_t>(pay.amount)
-                && out.scriptPubKey.m_data == want_script) {
+            if (out.scriptPubKey.m_data == want_script) {   // script only, ANY amount
                 found = true;
                 break;
             }
         }
         if (!found) {
             std::ostringstream ss;
-            ss << "GBT-mandated payment MISSING from coinbase: payee="
-               << pay.payee << " amount=" << pay.amount
+            ss << "GBT-mandated payee SCRIPT MISSING from coinbase: payee="
+               << pay.payee
                << " (height " << current.m_height
-               << " payee set != job's frozen payee set — dashd would reject"
-                  " bad-cb-payee)";
-            r.verdict = PayeeGuardVerdict::StalePayee;
+               << " — the coinbase does not pay this mandated payee at all;"
+                  " dashd would reject bad-cb-payee)";
+            r.verdict = PayeeGuardVerdict::PayeeMissing;
             r.detail  = ss.str();
             return r;
         }
@@ -126,7 +158,8 @@ inline PayeeGuardResult check_submit_payee(
 
     r.verdict = PayeeGuardVerdict::Ok;
     r.detail  = "all " + std::to_string(current.m_packed_payments.size())
-              + " GBT-mandated payments present at current height";
+              + " GBT-mandated payee scripts present at current height"
+                " (amounts validated by dashd against the block's own fees)";
     return r;
 }
 

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -843,33 +843,40 @@ nlohmann::json DASHWorkSource::mining_submit(
             block_bytes.insert(block_bytes.end(), tx_bytes.begin(), tx_bytes.end());
         }
 
-        // ── SUBMIT-TIME PAYEE GUARD (stale-payee fix, defect 4) ──────────
-        // Last line of defense: validate the job's frozen coinbase against
-        // the CURRENT template's GBT-mandated payments before dispatch. A
-        // same-height payee mismatch is a deterministic dashd bad-cb-payee
-        // reject (the hex-confirmed h1517420 class) — reject LOUDLY here
-        // instead of submitting a doomed block (steward-ruled posture). A
-        // moved tip is an orphan-race candidate and still submits; a guard-
-        // side parse failure never blocks a submission.
+        // ── SUBMIT-TIME PAYEE GUARD (payee-script set-membership) ────────
+        // Last line of defense before dispatch. REWARD INVARIANT: never refuse
+        // a block dashd would ACCEPT (a false refusal forfeits ~0.44 DASH),
+        // while still refusing one dashd would deterministically reject for
+        // bad-cb-payee. The guard verifies the job's frozen coinbase pays every
+        // GBT-mandated payee SCRIPT by SET MEMBERSHIP — it does NOT compare
+        // amounts against the current template (the masternode amount is
+        // subsidy + fees and drifts with the mempool on every re-pull; dashd
+        // checks it against the block's OWN fees). Refuse only when the tip has
+        // moved (wrong height) or a mandated payee SCRIPT is genuinely absent;
+        // a guard-side parse failure never blocks a submission.
         bool payee_guard_reject = false;
         if (wd) {
             const auto guard = check_submit_payee(
                 coinbase, job->gbt_prevhash, *wd,
                 dash::make_coin_params(is_testnet_));
             switch (guard.verdict) {
-            case PayeeGuardVerdict::StalePayee:
+            case PayeeGuardVerdict::PayeeMissing:
                 payee_guard_reject = true;
                 LOG_ERROR << "[DASH-STRATUM-PAYEE-GUARD] WON BLOCK LOCALLY "
                              "REJECTED, NOT submitted: " << guard.detail
                           << " user=" << username << " job=" << job_id
-                          << " -- a stale-payee coinbase is a guaranteed "
-                             "bad-cb-payee network reject; the job/template "
-                             "pipeline served stale work (investigate!)";
+                          << " -- a coinbase that omits a mandated payee script "
+                             "is a guaranteed bad-cb-payee network reject; the "
+                             "job/template pipeline served stale work "
+                             "(investigate!)";
                 break;
-            case PayeeGuardVerdict::TipMoved:
-                LOG_WARNING << "[DASH-STRATUM-PAYEE-GUARD] " << guard.detail
-                            << " -- submitting anyway (block is self-"
-                               "consistent for its own height)";
+            case PayeeGuardVerdict::WrongHeight:
+                payee_guard_reject = true;
+                LOG_ERROR << "[DASH-STRATUM-PAYEE-GUARD] WON BLOCK LOCALLY "
+                             "REJECTED, NOT submitted: " << guard.detail
+                          << " user=" << username << " job=" << job_id
+                          << " -- the job's parent is no longer the chain tip; "
+                             "dashd would reject this wrong-height block";
                 break;
             case PayeeGuardVerdict::Unverifiable:
                 LOG_WARNING << "[DASH-STRATUM-PAYEE-GUARD] guard could not "
@@ -877,9 +884,11 @@ nlohmann::json DASHWorkSource::mining_submit(
                             << ") -- submitting unblocked";
                 break;
             case PayeeGuardVerdict::Ok:
-                LOG_INFO << "[DASH-STRATUM-PAYEE-GUARD] coinbase payee set "
-                            "verified against current template ("
-                         << guard.detail << ")";
+                LOG_INFO << "[DASH-STRATUM-PAYEE-GUARD] coinbase pays all "
+                            "mandated payee scripts at the current height ("
+                         << guard.detail
+                         << ") -- amount drift (if any) is validated by dashd "
+                            "against the block's own fees; submitting";
                 break;
             }
         }

--- a/test/test_dash_stratum_work_source.cpp
+++ b/test/test_dash_stratum_work_source.cpp
@@ -1112,38 +1112,45 @@ TEST(DashSubmitPayeeGuard, OkWhenAllMandatedPaymentsPresent)
     EXPECT_EQ(r.verdict, dash::stratum::PayeeGuardVerdict::Ok);
 }
 
-TEST(DashSubmitPayeeGuard, StalePayeeWhenPayeeRotatedAtSameHeight)
+TEST(DashSubmitPayeeGuard, PayeeMissingWhenPayeeScriptRotatedAtSameHeight)
 {
     // Same prev (same height context) but the current template now mandates a
-    // ROTATED masternode payee the frozen coinbase does not pay: the exact
-    // hex-confirmed bad-cb-payee class. The guard must forbid the submit.
+    // ROTATED masternode payee SCRIPT the frozen coinbase does not pay at all:
+    // the genuine bad-cb-payee class (wrong PAYEE, not a mere amount drift).
+    // The guard must forbid the submit.
     const auto cb = fixture_coinbase_bytes();
     dash::coin::DashWorkData current = rotated_work();
-    current.m_previous_block.SetHex(kPrevHashHex);   // same height, new payee
+    current.m_previous_block.SetHex(kPrevHashHex);   // same height, new payee script
     const auto r = dash::stratum::check_submit_payee(
         cb, kPrevHashHex, current, dash::make_coin_params(false));
-    EXPECT_EQ(r.verdict, dash::stratum::PayeeGuardVerdict::StalePayee);
+    EXPECT_EQ(r.verdict, dash::stratum::PayeeGuardVerdict::PayeeMissing);
     EXPECT_NE(r.detail.find("bad-cb-payee"), std::string::npos);
 }
 
-TEST(DashSubmitPayeeGuard, StalePayeeWhenMandatedAmountChanged)
+TEST(DashSubmitPayeeGuard, OkWhenMandatedAmountDriftsButScriptPresent)
 {
+    // THE reward-critical false-refusal fix. Same prev, same payee SCRIPT, but
+    // the current template's mandated amount differs from the job's frozen one
+    // (fees moved on a template re-pull at the same height). dashd validates
+    // the masternode amount against the block's OWN fees, so this is a valid
+    // winning block — the guard must PASS it (set-membership on scripts, no
+    // amount comparison). This exact drift lost mainnet blocks 2508655/2508696.
     const auto cb = fixture_coinbase_bytes();
     dash::coin::DashWorkData current = rich_work();
-    current.m_packed_payments[0].amount += 1;   // same script, wrong amount
+    current.m_packed_payments[0].amount += 54321;   // same script, drifted amount
     const auto r = dash::stratum::check_submit_payee(
         cb, kPrevHashHex, current, dash::make_coin_params(false));
-    EXPECT_EQ(r.verdict, dash::stratum::PayeeGuardVerdict::StalePayee);
+    EXPECT_EQ(r.verdict, dash::stratum::PayeeGuardVerdict::Ok);
 }
 
-TEST(DashSubmitPayeeGuard, TipMovedWhenPrevDiffers)
+TEST(DashSubmitPayeeGuard, WrongHeightWhenPrevDiffers)
 {
-    // A moved tip is an orphan-race candidate, NOT a doomed bad-cb-payee: the
-    // block stays self-consistent for its own height and must still submit.
+    // The job's parent is no longer the chain tip: the block is for the wrong
+    // height and dashd would reject it. The guard must refuse the submit.
     const auto cb = fixture_coinbase_bytes();
     const auto r = dash::stratum::check_submit_payee(
         cb, kPrevHashHex, rotated_work(), dash::make_coin_params(false));
-    EXPECT_EQ(r.verdict, dash::stratum::PayeeGuardVerdict::TipMoved);
+    EXPECT_EQ(r.verdict, dash::stratum::PayeeGuardVerdict::WrongHeight);
 }
 
 TEST(DashSubmitPayeeGuard, UnverifiableOnGarbageCoinbaseNeverBlocks)
@@ -1156,9 +1163,9 @@ TEST(DashSubmitPayeeGuard, UnverifiableOnGarbageCoinbaseNeverBlocks)
 
 // ── Fix 4 wired into the hot path: mining_submit ────────────────────────────
 
-// A won block whose payee rotated at the SAME height between job issue and
-// submit is locally rejected LOUDLY — the broadcaster must NOT fire (never
-// submit a doomed bad-cb-payee block; steward-ruled posture).
+// A won block whose payee SCRIPT rotated at the SAME height between job issue
+// and submit is locally rejected LOUDLY — the broadcaster must NOT fire (never
+// submit a doomed bad-cb-payee block; a genuinely omitted mandated payee).
 TEST(DashStratumWorkSource, WonBlockWithStalePayeeIsLocallyRejectedNotSubmitted)
 {
     SubmitRig rig;
@@ -1169,9 +1176,9 @@ TEST(DashStratumWorkSource, WonBlockWithStalePayeeIsLocallyRejectedNotSubmitted)
         return pow <= block_target;
     });
 
-    // Between job issue and submit: the payee ROTATES at the same height
+    // Between job issue and submit: the payee SCRIPT ROTATES at the same height
     // (the churn/staleness window). The re-sourced current template now
-    // mandates a payee the frozen job coinbase does not pay.
+    // mandates a payee SCRIPT the frozen job coinbase does not pay at all.
     rig.fx.fallback_work = rotated_work();
     rig.fx.fallback_work.m_previous_block.SetHex(kPrevHashHex);  // same prev
     rig.ws->bump_work_generation();   // submit-side cached_work re-sources
@@ -1182,9 +1189,37 @@ TEST(DashStratumWorkSource, WonBlockWithStalePayeeIsLocallyRejectedNotSubmitted)
     EXPECT_FALSE(rig.fx.submit_called);       // ...but NOTHING was dispatched
 }
 
-// A won block across a MOVED tip is an orphan-race candidate and still
-// dispatches (self-consistent for its own height — never guard-blocked).
-TEST(DashStratumWorkSource, WonBlockAcrossTipMoveStillSubmits)
+// THE reward-critical false-refusal fix, end-to-end on the hot path. A won
+// block whose mandated masternode AMOUNT drifted (fees moved on a same-height
+// template re-pull) but whose payee SCRIPT is unchanged is a VALID winning
+// block — dashd validates the amount against the block's own fees. The guard
+// must PASS it and the broadcaster MUST fire. This drift lost mainnet blocks
+// 2508655/2508696 before the set-membership fix.
+TEST(DashStratumWorkSource, WonBlockWithMandatedAmountDriftStillSubmits)
+{
+    SubmitRig rig;
+    rig.job.share_bits  = 0x207fffffu;
+    rig.job.block_nbits = "207fffff";
+    const uint256 block_target = dash::coin::target_from_nbits(0x207fffffu);
+    const uint32_t nonce = rig.find_nonce([&](const uint256& pow) {
+        return pow <= block_target;
+    });
+
+    // Same prev, same payee SCRIPT, only the mandated amount drifts (fee churn).
+    rig.fx.fallback_work = rich_work();
+    rig.fx.fallback_work.m_packed_payments[0].amount += 98765;
+    rig.ws->bump_work_generation();
+
+    auto result = rig.submit(nonce);
+    ASSERT_TRUE(result.is_boolean());
+    EXPECT_TRUE(result.get<bool>());
+    EXPECT_TRUE(rig.fx.submit_called);        // amount drift is NOT a refusal
+}
+
+// A won block across a MOVED tip is for the wrong height (the job's parent is
+// no longer the chain tip) — dashd would reject it, so the guard refuses and
+// the broadcaster must NOT fire.
+TEST(DashStratumWorkSource, WonBlockAcrossTipMoveIsLocallyRejected)
 {
     SubmitRig rig;
     rig.job.share_bits  = 0x207fffffu;
@@ -1199,8 +1234,8 @@ TEST(DashStratumWorkSource, WonBlockAcrossTipMoveStillSubmits)
 
     auto result = rig.submit(nonce);
     ASSERT_TRUE(result.is_boolean());
-    EXPECT_TRUE(result.get<bool>());
-    EXPECT_TRUE(rig.fx.submit_called);        // orphan race: still dispatched
+    EXPECT_TRUE(result.get<bool>());          // the miner's work was honest
+    EXPECT_FALSE(rig.fx.submit_called);       // ...but wrong-height: NOT dispatched
 }
 
 // ── Dashboard stats seam (issue: /local_stats hashrate under-reported) ───────


### PR DESCRIPTION
## The bug (reward-critical false rejection)

The DASH stratum submit-time payee guard (`[DASH-STRATUM-PAYEE-GUARD] WON BLOCK LOCALLY REJECTED, NOT submitted`) refused to submit a won block when a GBT-mandated masternode payment looked "missing" from the frozen coinbase.

It matched each mandated payment as an exact `(payee_script, AMOUNT)` pair against the **current** template. But the masternode/operator payment amount is **subsidy + block fees**, so it drifts every time the template is re-pulled at the same height (the mempool moves). When a winning share's job predates the last template re-pull, the frozen amount no longer equals the current template's amount → the guard falsely reported the mandated payee "missing" and **refused to submit a perfectly valid winning block**.

Two mainnet blocks were lost this way in a single day:

- heights **2508655** and **2508696**
- correct payee address, correct height/parent
- multi-minute head start over the eventual network winner
- rejected purely on fee-driven amount drift

dashd validates the masternode amount against the block's **own** fees (self-consistent by GBT construction), so an amount-equality check against a newer template is invalid by construction.

## The fix

The guard now verifies the coinbase pays every GBT-mandated payee **SCRIPT** by **set membership** and never compares amounts:

- **prev matches (same height) + all mandated payee scripts present → SUBMIT.** Amounts may differ from the current template (fee drift); dashd checks them against the block's own fees.
- **a mandated payee SCRIPT genuinely absent from the coinbase → REFUSE** (a real `bad-cb-payee`; the reward-safety property is preserved).
- **job prev != current chain tip → REFUSE** (wrong height; dashd would reject).
- coinbase fails to deserialize → submit (never guard-block on a parse failure).

The payee script is height-deterministic, so when the prev matches, the current template's mandated scripts equal the job's mandated scripts — the set-membership check is sound. Only the amount-drift / current-template false positive is removed; a genuinely omitted or wrong payee is still refused.

### Invariant (stated in a comment in the guard)

Never refuse a block dashd would **accept** — a false refusal forfeits a full block reward (~0.44 DASH per event, observed) — while still refusing one dashd would deterministically reject for `bad-cb-payee` (wrong payee script, or wrong height). When uncertain, **submit**: a truly bad block is rejected by dashd for free; a false refusal is a guaranteed, irreversible loss.

## Tests

Extended the existing payee-guard KATs (unit + hot path):

- amount drifts but payee **script** present → **PASS / submitted** (unit `OkWhenMandatedAmountDriftsButScriptPresent` + hot-path `WonBlockWithMandatedAmountDriftStillSubmits`) — the exact class that lost 2508655/2508696.
- payee **script** omitted at same height → **refused** (`PayeeMissingWhenPayeeScriptRotatedAtSameHeight`, hot-path unchanged).
- job prev != current tip → **refused** (`WrongHeightWhenPrevDiffers`, hot-path `WonBlockAcrossTipMoveIsLocallyRejected`).

`c2pool-dash` builds clean; full `test_dash_stratum_work_source` suite green (44/44).