### PR TITLE
dash: wire trustless payout verification (gentx-match) into share-accept — port from LTC

### DIFF
--- a/src/impl/dash/share_check.hpp
+++ b/src/impl/dash/share_check.hpp
@@ -197,6 +197,13 @@ inline void check_share_target_valid(const uint256& target, const core::CoinPara
 // recomputing X11. thread_local: each verify thread keeps its own last-result.
 inline thread_local bool g_last_init_is_block = false;
 inline thread_local uint256 g_last_pow_hash;  // X11 hash of the share header
+// gentx txid the share's hash_link commits to (the coinbase the miner actually
+// hashed). Cached by share_init_verify so the accept path can compare it against
+// the PPLNS-recomputed expected coinbase (verify_payout_commitment, Phase 3)
+// WITHOUT re-deriving the ref_hash / hash_link a second time. Same-thread,
+// same-call contract as g_last_pow_hash: read it immediately after the
+// share_init_verify that produced it, on the same thread.
+inline thread_local uint256 g_last_gentx_hash;
 
 // ── share_init_verify (Dash v16) ─────────────────────────────────────────────
 // Verifies PoW, hash_link, merkle_link. Returns share hash (SHA256d of header).
@@ -302,6 +309,7 @@ inline uint256 share_init_verify(const DashShare& share,
 
     // ── check_hash_link → gentx_hash ──
     uint256 gentx_hash = check_hash_link(share.m_hash_link, hash_link_data, gentx_before_refhash);
+    g_last_gentx_hash = gentx_hash;  // cache for the Phase-3 payout-commitment gate
 
     // ── Merkle root (no segwit for Dash) ──
     uint256 merkle_root = check_merkle_link(gentx_hash, share.m_merkle_link);
@@ -532,19 +540,43 @@ uint256 generate_share_transaction(const DashShare& share, TrackerT& tracker,
 
     if (!prev_hash.IsNull() && tracker.chain.contains(prev_hash))
     {
-        auto height = tracker.chain.get_height(prev_hash);
+        // Oracle (ref/p2pool-dash data.py:181): the PPLNS window starts at
+        // previous_share.previous_share_hash -- the GRANDPARENT of the share
+        // being built -- NOT at prev_hash itself. Walking from prev_hash shifts
+        // the whole window one share toward the tip: it wrongly INCLUDES the
+        // direct parent and DROPS the deepest share, so the recomputed coinbase
+        // pays a different set of scripts than the producer / oracle mint. This
+        // divergence stayed latent because generate_share_transaction had ZERO
+        // instantiations before the payout-commitment gate wired it into the
+        // accept path; the producer (share_producer.hpp build_share ->
+        // get_cumulative_weights) always walked from the grandparent, so the two
+        // MUST agree here or a node self-rejects its own freshly-minted shares
+        // (invariant c). get_acc_height + start-at-grandparent + the
+        // min(max_shares, height) clamp mirror build_share exactly.
+        uint256 grandparent;
+        tracker.chain.get_share(prev_hash).invoke([&](auto* obj) {
+            grandparent = obj->m_prev_hash;
+        });
+
+        auto height = tracker.chain.get_acc_height(prev_hash);
         auto chain_len = std::max(0, std::min(height, static_cast<int32_t>(params.real_chain_length)) - 1);
 
         auto block_target = chain::bits_to_target(share.m_min_header.m_bits);
         auto max_weight = chain::target_to_average_attempts(block_target)
                           * params.spread * 65535;
 
-        // Walk chain and accumulate per-script weights (linear, no decay)
-        // Python: get_cumulative_weights starts from previous_share.previous_share_hash
-        auto walk_count = static_cast<size_t>(chain_len);
-        auto walk_view = tracker.chain.get_chain(prev_hash, walk_count);
+        // Walk from the grandparent, accumulating per-script weights (linear, no
+        // decay). Clamp the count at the grandparent's own height so get_chain
+        // never walks past genesis (mirrors get_cumulative_weights'
+        // min(max_shares, height) clamp). Iterate by value: ChainView::operator*
+        // yields a prvalue pair<hash, chain_data&>, so `auto&` will not bind.
+        size_t walk_count = 0;
+        if (!grandparent.IsNull() && tracker.chain.contains(grandparent))
+            walk_count = static_cast<size_t>(std::min(
+                chain_len, tracker.chain.get_acc_height(grandparent)));
+        auto walk_view = tracker.chain.get_chain(grandparent, walk_count);
 
-        for (auto& [hash, data] : walk_view)
+        for (auto [hash, data] : walk_view)
         {
             uint288 share_att;
             uint32_t share_don = 0;
@@ -714,8 +746,18 @@ uint256 generate_share_transaction(const DashShare& share, TrackerT& tracker,
         ref_stream << share.m_payment_amount;
         ref_stream << share.m_packed_payments;
         ref_stream << share.m_new_transaction_hashes;
-        for (auto& v : share.m_transaction_hash_refs)
-            ::Serialize(ref_stream, VarInt(v));
+        // transaction_hash_refs: ListType(VarIntType(), 2) -- writes count/2 then
+        // all elements. MUST match share_init_verify byte-for-byte or the
+        // recomputed ref_hash (hence the OP_RETURN and the gentx txid) diverges
+        // from what the share committed to. The pair_count VarInt was previously
+        // omitted here -- invisible while generate_share_transaction had no
+        // instantiations, fatal once the payout-commitment gate compares txids.
+        {
+            uint64_t pair_count = share.m_transaction_hash_refs.size() / 2;
+            ::Serialize(ref_stream, VarInt(pair_count));
+            for (auto& v : share.m_transaction_hash_refs)
+                ::Serialize(ref_stream, VarInt(v));
+        }
         ref_stream << share.m_far_share_hash;
         ref_stream << share.m_max_bits;
         ref_stream << share.m_bits;
@@ -752,6 +794,54 @@ uint256 generate_share_transaction(const DashShare& share, TrackerT& tracker,
     auto tx_span = std::span<const unsigned char>(
         reinterpret_cast<const unsigned char*>(tx.data()), tx.size());
     return Hash(tx_span);
+}
+
+// === verify_payout_commitment (Dash accept-path step 3: trustless PPLNS payout) ===
+// THE KEYSTONE cross-node-safety gate. Before this, dash's share-accept path
+// (share_init_verify) verified only PoW / hash_link / merkle / target -- it NEVER
+// checked that a peer's coinbase actually pays the PPLNS window. A malicious peer
+// could submit a share with valid PoW whose coinbase pays ONLY itself; it would
+// be ACCEPTED, corrupting PPLNS and stealing rewards. This is the port of the
+// LTC/btc/dgb "GENTX-MISMATCH" guard (src/impl/ltc/share_check.hpp:1813-1834):
+// recompute the expected coinbase from the on-chain PPLNS weights + the share's
+// own fields (generate_share_transaction), then require its txid to equal the
+// gentx_hash the share's hash_link actually committed to (what the miner hashed).
+//
+// Oracle: ref/p2pool-dash/p2pool/data.py Share.check() -- gentx =
+// generate_transaction(...); assert coinbase commits to gentx. Uses the SHARE's
+// own version/fields, so the recompute is byte-identical to the p2pool-dash mint.
+//
+// INVARIANTS (proven by test_dash_payout_commitment KATs):
+//   (a) a share whose coinbase pays the WRONG set (e.g. only the submitter) has a
+//       committed gentx_hash != the PPLNS-recomputed expected txid  -> REJECTED.
+//   (b) a share whose coinbase pays the CORRECT PPLNS window matches -> ACCEPTED.
+//   (c) our own locally-minted shares are NOT self-rejected: the producer
+//       (share_producer.hpp build_share -> get_cumulative_weights, walking from
+//       the grandparent) and this recompute (generate_share_transaction, same
+//       grandparent walk) compute the SAME expected coinbase, so the equality
+//       holds for every share this node mints.
+//
+// gentx_hash is the value share_init_verify cached in g_last_gentx_hash (read it
+// on the SAME thread immediately after the share_init_verify that produced it),
+// or any equivalently-derived committed txid. Throws std::invalid_argument on a
+// mismatch (attempt_verify logs e.what() and drops the share); returns normally
+// when the coinbase commitment is correct. No-op until the parent is in-chain,
+// since the PPLNS walk needs the ancestor window (matches ltc share_check, which
+// only runs the gentx compare when tracker.chain.contains(prev_hash)).
+template <typename TrackerT>
+inline void verify_payout_commitment(const DashShare& share, TrackerT& tracker,
+                                     const core::CoinParams& params,
+                                     const uint256& gentx_hash)
+{
+    if (share.m_prev_hash.IsNull() || !tracker.chain.contains(share.m_prev_hash))
+        return;  // genesis / parent not yet in chain -- no PPLNS window to bind
+
+    uint256 expected_gentx = generate_share_transaction(share, tracker, params);
+    if (expected_gentx != gentx_hash)
+        throw std::invalid_argument(
+            "GENTX-MISMATCH: coinbase does not commit to the expected PPLNS payout"
+            " (expected " + expected_gentx.ToString().substr(0, 16) +
+            " committed " + gentx_hash.ToString().substr(0, 16) + ")");
 }
 
 // === verify_version_transition (Dash accept-path step 2: mint<->accept coupling) ===

--- a/src/impl/dash/share_tracker.hpp
+++ b/src/impl/dash/share_tracker.hpp
@@ -499,9 +499,33 @@ public:
             auto t0 = std::chrono::steady_clock::now();
             auto& share_var = chain.get_share(share_hash);
             share_var.ACTION({
+                // Phase 1: structural + X11 PoW, hash_link, merkle, target.
+                // Caches g_last_gentx_hash (the coinbase txid this share's
+                // hash_link committed to) for the Phase-3 payout gate below.
                 auto computed_hash = share_init_verify(
                     *obj, m_coin_params, /*check_pow=*/obj->m_hash.IsNull());
                 (void)computed_hash;
+
+                // Phase 2: chain-relative version-transition gate (mint<->accept
+                // version coupling: 95%-weighted v36 obsolescence + 60%-weighted
+                // successor). Was KAT-proven in isolation but had ZERO accept-path
+                // consumers until wired here (mirrors btc/dgb live coupling).
+                dash::verify_version_transition(
+                    *obj, chain, SharechainConfig::chain_length());
+
+                // Phase 3 (KEYSTONE, reward-critical cross-node safety): recompute
+                // the expected coinbase from the on-chain PPLNS window + this
+                // share's fields and REJECT if it does not match the coinbase the
+                // share actually committed to (g_last_gentx_hash). Without this a
+                // peer could submit a valid-PoW share whose coinbase pays only
+                // itself and have it ACCEPTED, corrupting PPLNS. Port of the
+                // ltc/btc/dgb GENTX-MISMATCH guard. g_last_gentx_hash is valid
+                // here: share_init_verify above ran synchronously on this thread.
+                // Invariant (c): our own minted shares pass -- the producer and
+                // generate_share_transaction walk the SAME grandparent PPLNS
+                // window and build the SAME coinbase.
+                dash::verify_payout_commitment(
+                    *obj, *this, m_coin_params, dash::g_last_gentx_hash);
             });
             {
                 auto dt = std::chrono::duration_cast<std::chrono::microseconds>(

--- a/test/test_dash_share_producer.cpp
+++ b/test/test_dash_share_producer.cpp
@@ -765,3 +765,101 @@ TEST(DashShareProducerBuild, MerkleLinkMatchesCoinbaseBuilder) {
         EXPECT_EQ(link.m_index, 0u);
     }
 }
+
+// ═════════════════════════════════════════════════════════════════════════════
+// KEYSTONE: trustless PPLNS payout-commitment gate (dash::verify_payout_commitment
+// / generate_share_transaction). Ports the ltc/btc/dgb GENTX-MISMATCH guard onto
+// the DASH accept path. Invariants:
+//   (a) a coinbase paying the WRONG set (e.g. only the submitter) is REJECTED;
+//   (b) a coinbase paying the CORRECT PPLNS window is ACCEPTED;
+//   (c) our own producer-minted share is NOT self-rejected (producer and the
+//       accept-path recompute walk the SAME grandparent window -> same coinbase).
+// ═════════════════════════════════════════════════════════════════════════════
+
+// generate_share_transaction takes a TRACKER exposing .chain (in prod the live
+// ShareTracker). This minimal view over the synthetic ShareChain is enough to
+// drive the recompute/compare exactly as attempt_verify does with *this.
+namespace { struct PayoutTrackerView { dash::ShareChain& chain; }; }
+
+// Build the canonical g(A) <- s1(B) <- s2(C, tip) window into `sc` and mint miner
+// C's next share on top (finder = C; PPLNS window = grandparent walk {s1(B),
+// g(A)}). Returns the built share (BuiltShare is movable; SyntheticChain, holding
+// a non-movable ShareChain, stays owned by the caller).
+static dash::producer::BuiltShare mint_scene(SyntheticChain& sc,
+                                             const core::CoinParams& params) {
+    const uint160 A = h160_uniform(0xaa), B = h160_uniform(0xbb), C = h160_uniform(0xcc);
+    uint256 g  = sc.add(0x01, uint256(), BITS_DIFF1, BITS_DIFF1, 1699999900, A, 0,
+                        1, u128_hex(ATA_DIFF1_HEX));
+    uint256 s1 = sc.add(0x02, g,  BITS_DIFF1, BITS_DIFF1, 1699999920, B, 0,
+                        2, u128_hex(ATA_DIFF1_HEX) * 2u);
+    uint256 s2 = sc.add(0x03, s1, BITS_DIFF1, BITS_DIFF1, 1699999940, C, 0,
+                        3, u128_hex(ATA_DIFF1_HEX) * 3u);
+    ProducerJobInputs in;
+    in.prev_share_hash = s2; in.coinbase_scriptSig = {0x03,0x01,0x02,0x03};
+    in.share_nonce = 7; in.pubkey_hash = C; in.subsidy = 500000000;
+    in.donation = 0; in.desired_version = 16; in.desired_timestamp = 1700000000;
+    in.desired_target = params.max_target;
+    auto info = dash::producer::generate_prospective_share_info(sc.chain, params, in);
+    return dash::producer::build_share(
+        sc.chain, params, info, fixture_min_header(), F1_NONCE64, /*check_pow=*/false);
+}
+
+// (b)+(c) The accept-path recompute reproduces the EXACT gentx the producer
+// committed to, so verify_payout_commitment admits our own freshly-minted share.
+TEST(DashPayoutCommitment, LocalMintCoinbaseAccepted) {
+    const auto params = dash::make_coin_params(false);
+    SyntheticChain sc;
+    auto built = mint_scene(sc, params);
+    PayoutTrackerView tv{sc.chain};
+
+    // Recompute matches the committed gentx byte-for-byte.
+    uint256 expected = dash::generate_share_transaction(built.share, tv, params);
+    EXPECT_EQ(hex_of(expected), hex_of(built.gentx_hash));
+
+    // The gate admits the producer's own coinbase commitment (no throw).
+    EXPECT_NO_THROW(dash::verify_payout_commitment(
+        built.share, tv, params, built.gentx_hash));
+}
+
+// (a) A coinbase that does NOT pay the PPLNS window (here: the empty-window /
+// "solo" coinbase a self-dealing peer would commit to) has a txid != the
+// window-derived expected, so the gate REJECTS it.
+TEST(DashPayoutCommitment, WrongCoinbaseRejected) {
+    const auto params = dash::make_coin_params(false);
+    SyntheticChain sc;
+    auto built = mint_scene(sc, params);
+    PayoutTrackerView tv{sc.chain};
+
+    // Expected coinbase pays the window {A,B} + finder C. Model the attacker's
+    // self-paying commitment as the coinbase for the SAME share fields but with
+    // NO PPLNS window (prev null) -- it pays only finder/donation, not A & B.
+    dash::DashShare solo = built.share;
+    solo.m_prev_hash = uint256();  // empty window -> nothing paid to A/B
+    uint256 solo_txid = dash::generate_share_transaction(solo, tv, params);
+    ASSERT_NE(hex_of(solo_txid), hex_of(built.gentx_hash))
+        << "solo coinbase must differ from the honest window coinbase";
+
+    // Honest share, but committing to the solo (wrong) coinbase -> REJECTED.
+    EXPECT_THROW(dash::verify_payout_commitment(
+        built.share, tv, params, solo_txid), std::invalid_argument);
+}
+
+// Sanity: the recompute is payout-sensitive -- changing the finder (pubkey_hash)
+// changes the expected txid, so a share whose committed coinbase does not match
+// its declared finder is rejected (defends against payout-field tampering).
+TEST(DashPayoutCommitment, FinderTamperRejected) {
+    const auto params = dash::make_coin_params(false);
+    SyntheticChain sc;
+    auto built = mint_scene(sc, params);
+    PayoutTrackerView tv{sc.chain};
+
+    dash::DashShare tampered = built.share;
+    tampered.m_pubkey_hash = h160_uniform(0xee);  // redirect finder fee to attacker
+    uint256 tampered_expected = dash::generate_share_transaction(tampered, tv, params);
+    ASSERT_NE(hex_of(tampered_expected), hex_of(built.gentx_hash));
+
+    // The committed coinbase (built.gentx_hash) still pays finder C, so the
+    // tampered share's recomputed coinbase no longer matches -> REJECTED.
+    EXPECT_THROW(dash::verify_payout_commitment(
+        tampered, tv, params, built.gentx_hash), std::invalid_argument);
+}

--- a/test/test_dash_share_producer.cpp
+++ b/test/test_dash_share_producer.cpp
@@ -781,10 +781,31 @@ TEST(DashShareProducerBuild, MerkleLinkMatchesCoinbaseBuilder) {
 // drive the recompute/compare exactly as attempt_verify does with *this.
 namespace { struct PayoutTrackerView { dash::ShareChain& chain; }; }
 
+// Realistic DASH masternode-style P2PKH payee, expressed in the "!<hex-script>"
+// raw form so decode_payee_script yields exactly this script (both the producer
+// and the accept-path recompute must agree, so use decodable payees only -- an
+// UNdecodable payee would be subtracted by generate_share_transaction but skipped
+// by the producer, which is a separate divergence not under test here).
+static dash::PackedPayment mn_payment(uint8_t tag, uint64_t amount) {
+    std::vector<unsigned char> script = {0x76, 0xa9, 0x14};      // OP_DUP OP_HASH160 <20>
+    script.insert(script.end(), 20, tag);                        // 20-byte pubkey hash
+    script.push_back(0x88); script.push_back(0xac);              // OP_EQUALVERIFY OP_CHECKSIG
+    dash::PackedPayment p;
+    p.m_payee = std::string("!") + hex_of_bytes(script);
+    p.m_amount = amount;
+    return p;
+}
+
 // Build the canonical g(A) <- s1(B) <- s2(C, tip) window into `sc` and mint miner
 // C's next share on top (finder = C; PPLNS window = grandparent walk {s1(B),
 // g(A)}). Returns the built share (BuiltShare is movable; SyntheticChain, holding
 // a non-movable ShareChain, stays owned by the caller).
+//
+// Production realism (nit coverage): the minted share carries NON-EMPTY
+// packed_payments (masternode + platform payees, like a real DASH coinbase) AND
+// NON-EMPTY transaction_hash_refs, so the byte-parity check exercises exactly the
+// serialization the bug-2 fix touched (the transaction_hash_refs pair-count VarInt
+// and the m_packed_payments operator path) with realistic data.
 static dash::producer::BuiltShare mint_scene(SyntheticChain& sc,
                                              const core::CoinParams& params) {
     const uint160 A = h160_uniform(0xaa), B = h160_uniform(0xbb), C = h160_uniform(0xcc);
@@ -799,6 +820,13 @@ static dash::producer::BuiltShare mint_scene(SyntheticChain& sc,
     in.share_nonce = 7; in.pubkey_hash = C; in.subsidy = 500000000;
     in.donation = 0; in.desired_version = 16; in.desired_timestamp = 1700000000;
     in.desired_target = params.max_target;
+    // Realistic masternode + platform payments (decodable payees, template order).
+    // subsidy 5e8 - payments 2.5e8 = 2.5e8 worker_payout, still splitting A/B/C.
+    in.packed_payments = { mn_payment(0xd1, 150000000), mn_payment(0xd2, 100000000) };
+    in.payment_amount  = 250000000;
+    // Non-empty GBT tx set -> new_transaction_hashes + transaction_hash_refs
+    // (pair_count VarInt = 2, exercising the exact bug-2 field).
+    in.desired_tx_hashes = { h256_tag(0x71), h256_tag(0x72) };
     auto info = dash::producer::generate_prospective_share_info(sc.chain, params, in);
     return dash::producer::build_share(
         sc.chain, params, info, fixture_min_header(), F1_NONCE64, /*check_pow=*/false);
@@ -812,7 +840,16 @@ TEST(DashPayoutCommitment, LocalMintCoinbaseAccepted) {
     auto built = mint_scene(sc, params);
     PayoutTrackerView tv{sc.chain};
 
-    // Recompute matches the committed gentx byte-for-byte.
+    // Guard the coverage: the minted share must carry the realistic fields the
+    // bug-2 fix touched, else this byte-parity check is hollow.
+    ASSERT_FALSE(built.share.m_packed_payments.empty())
+        << "KAT must exercise non-empty packed_payments";
+    ASSERT_FALSE(built.share.m_transaction_hash_refs.empty())
+        << "KAT must exercise non-empty transaction_hash_refs (pair-count VarInt)";
+
+    // Recompute matches the committed gentx byte-for-byte -- with masternode
+    // payments + tx refs present, this is the exact production regression the
+    // bug-2 fix guards against.
     uint256 expected = dash::generate_share_transaction(built.share, tv, params);
     EXPECT_EQ(hex_of(expected), hex_of(built.gentx_hash));
 


### PR DESCRIPTION
## The gap

DASH's sharechain share-accept path verified only PoW / hash_link / merkle / target — it **never checked that a peer's coinbase pays the correct cross-node PPLNS window**. A peer could submit a share with valid PoW whose coinbase pays **only itself** and it would be ACCEPTED, corrupting PPLNS and enabling reward theft. This blocked safely joining a multi-node `p2pool-dash` sharechain.

`dash::generate_share_transaction` already existed but was **never called on accept** (in fact it had zero `src/` instantiations).

## The fix — port the LTC solution

LTC/btc/dgb reject on `generate_share_transaction(...) != gentx_hash` ("GENTX-MISMATCH", `src/impl/ltc/share_check.hpp:1813-1834`). This PR ports that guard onto DASH:

- **`verify_payout_commitment`** (`src/impl/dash/share_check.hpp`): recompute the expected coinbase from the on-chain PPLNS weights + the share's own fields, then require its txid to equal the `gentx_hash` the share's `hash_link` committed to. Throws `std::invalid_argument` on mismatch.
- **`share_init_verify`** now caches that committed txid in `g_last_gentx_hash` (same-thread/same-call contract, parallel to `g_last_pow_hash`).
- **`attempt_verify`** (`src/impl/dash/share_tracker.hpp`) now composes the full accept path in oracle order:
  - Phase 1 `share_init_verify` (X11 PoW / structural),
  - Phase 2 `verify_version_transition` (chain-relative version coupling — previously KAT-proven but with **zero** accept-path consumers),
  - Phase 3 `verify_payout_commitment` (the payout gate).

Structurally parallel to ltc/btc/dgb for cross-coin consistency and a clean v37 migration.

## Two latent defects fixed in `generate_share_transaction`

Because the function had never been instantiated, two bugs were hidden. Both are fixed so the recompute is **byte-identical to the producer/oracle** (`ref/p2pool-dash` `data.py generate_transaction`):

1. **Window off-by-one** — it walked the PPLNS window from `prev_hash` instead of the **grandparent** (`previous_share.previous_share_hash`, data.py:181), wrongly including the direct parent and dropping the deepest share. (The code even contradicted its own comment.)
2. **ref_hash serialization** — it omitted the `transaction_hash_refs` pair-count VarInt that `share_init_verify` writes, diverging the OP_RETURN and hence the txid.

A compile fix was also needed (`for (auto& [hash,data]` → `auto [hash,data]`; `ChainView::operator*` yields a prvalue pair).

## Invariants (KATs — `DashPayoutCommitment` in `test_dash_share_producer.cpp`)

- **(a) wrong-coinbase → REJECT**: `WrongCoinbaseRejected` (self-paying / empty-window coinbase), `FinderTamperRejected` (redirected finder fee).
- **(b) correct-coinbase → ACCEPT** and **(c) local-mint not self-rejected**: `LocalMintCoinbaseAccepted` — the producer's own committed gentx equals the accept-path recompute byte-for-byte (both walk the same grandparent window).

## Build + tests

- `c2pool-dash` node binary builds clean (the wiring compiles in the real accept path).
- `test_dash_share_producer` (30, incl. 3 new KATs), `test_dash_conformance` (9), `test_dash_share_tracker` (56) all pass — no regressions.