### PR TITLE
stratum(btc/ltc/dgb/bch): opt into keepalive-notify (25s) — protect idle clients [cross-coin reuse C2]

### DIFF
--- a/src/c2pool/main_ltc.cpp
+++ b/src/c2pool/main_ltc.cpp
@@ -656,6 +656,14 @@ int main(int argc, char* argv[]) {
     // Stratum tuning (configurable via CLI or YAML)
     core::StratumConfig stratum_config;  // defaults: min=0.0005, max=65536, target=3.0s, vardiff=true
     stratum_config.coin_symbol = "LTC";  // runtime coin tag for coin-agnostic core log lines
+    // Idle keepalive-notify (cross-coin reuse of DASH's D9 mitigation): many
+    // ASIC/proxy clients drop a pool connection that receives no mining.notify
+    // within ~60 s (LTC/DOGE ~2.5 min block cadence gives long idle gaps at high
+    // fixed diff). 25 s is safely under any reasonable client watchdog and kept
+    // identical to the other coins for consistency. Re-notify the CURRENT job
+    // (non-clean, so no ASIC work reset and NO work-generation bump); this is
+    // transport/liveness only -- ZERO wire-byte and consensus change.
+    stratum_config.keepalive_notify_sec = 25;
 
     // Operational tuning (configurable via CLI or YAML)
     std::string log_file;                        // empty = default "debug.log"

--- a/src/impl/bch/stratum/work_source.cpp
+++ b/src/impl/bch/stratum/work_source.cpp
@@ -103,6 +103,13 @@ BCHWorkSource::BCHWorkSource(bch::coin::HeaderChain&       chain,
     , submit_block_fn_(std::move(submit_fn))
     , config_(std::move(config))
 {
+    // Idle keepalive-notify (cross-coin reuse of DASH's D9 mitigation): many
+    // ASIC/proxy clients drop a pool connection that receives no mining.notify
+    // within ~60 s. Re-notify the CURRENT job (non-clean, so no ASIC work reset
+    // and NO work-generation bump) every 25 s -- comfortably under any
+    // reasonable client watchdog -- so idle BCH sessions stay stable backups.
+    // Transport/liveness only; ZERO wire-byte and consensus change.
+    config_.keepalive_notify_sec = 25;
     LOG_INFO << "[BCH-STRATUM] BCHWorkSource constructed (testnet="
              << (is_testnet_ ? "1" : "0") << ")";
 }

--- a/src/impl/btc/stratum/work_source.cpp
+++ b/src/impl/btc/stratum/work_source.cpp
@@ -155,6 +155,14 @@ BTCWorkSource::BTCWorkSource(btc::coin::HeaderChain&       chain,
     // validated; only genuinely dead / never-authorized sessions are reclaimed.
     config_.session_idle_timeout_sec   = 1800;
     config_.max_write_queue_depth      = 256;    // drop a stuck-write dead peer
+    // Idle keepalive-notify (cross-coin reuse of DASH's D9 mitigation): rigs on
+    // a high fixed-diff suffix can go multiple minutes between shares, and many
+    // ASIC/proxy clients drop a pool connection that receives no mining.notify
+    // within ~60 s (then retry). Re-notify the CURRENT job (non-clean, so no
+    // ASIC work reset and NO work-generation bump) every 25 s -- comfortably
+    // under any reasonable client watchdog -- so idle BTC sessions stay stable
+    // backups. Transport/liveness only; ZERO wire-byte and consensus change.
+    config_.keepalive_notify_sec       = 25;
 
     LOG_INFO << "[BTC-STRATUM] BTCWorkSource constructed"
              << " (testnet=" << is_testnet_

--- a/src/impl/dgb/stratum/work_source.cpp
+++ b/src/impl/dgb/stratum/work_source.cpp
@@ -119,6 +119,13 @@ DGBWorkSource::DGBWorkSource(c2pool::dgb::HeaderChain&     chain,
     // Runtime coin tag for coin-agnostic core log lines (#732).
     if (config_.coin_symbol.empty())
         config_.coin_symbol = "DGB";
+    // Idle keepalive-notify (cross-coin reuse of DASH's D9 mitigation): many
+    // ASIC/proxy clients drop a pool connection that receives no mining.notify
+    // within ~60 s. Re-notify the CURRENT job (non-clean, so no ASIC work reset
+    // and NO work-generation bump) every 25 s -- comfortably under any
+    // reasonable client watchdog -- so idle DGB sessions stay stable backups.
+    // Transport/liveness only; ZERO wire-byte and consensus change.
+    config_.keepalive_notify_sec = 25;
     LOG_INFO << "[DGB-STRATUM] DGBWorkSource constructed"
              << " (testnet=" << is_testnet_
              << " min_diff=" << config_.min_difficulty


### PR DESCRIPTION
## What

Opt btc, ltc, dgb and bch into the stratum **keepalive-notify** that DASH already ships, so idle stratum clients are no longer exposed to the client-side no-work watchdog drop.

The keepalive lives in shared `core::StratumServer`, gated by `StratumConfig::keepalive_notify_sec` (default `0` = off). DASH opts in at 25 s (`src/impl/dash/stratum/work_source.cpp`); the other four coins were all still `0` → no idle re-notify → the same watchdog drop DASH's D9 rigs hit (measured: a rig receiving no `mining.notify` for ~60 s drops the pool connection, then retries).

This is **cross-coin-reuse item C2** (cross-coin audit item).

## Change set (4 files, +1 opt-in line each)

| Coin | File | Line | Where |
|------|------|------|-------|
| BTC | `src/impl/btc/stratum/work_source.cpp` | 165 | `BTCWorkSource` ctor, alongside the live-session hygiene knobs |
| DGB | `src/impl/dgb/stratum/work_source.cpp` | 128 | `DGBWorkSource` ctor |
| BCH | `src/impl/bch/stratum/work_source.cpp` | 112 | `BCHWorkSource` ctor |
| LTC | `src/c2pool/main_ltc.cpp` | 666 | where LTC builds its `core::StratumConfig` |

All four set `keepalive_notify_sec = 25`.

### Why 25 s for all four
25 s is comfortably under any reasonable client watchdog and is kept **identical to DASH** for consistency. LTC/DOGE (~2.5 min blocks) and BTC (~10 min blocks) have even longer idle gaps at high fixed diff, so a sub-minute re-notify is, if anything, more conservative there — no coin-specific value warranted.

## Consensus-neutrality confirmation (pre-v36 transitional-leg house rule)

**Stratum transport/liveness only — no share/consensus behavior change.**

The keepalive path (`src/core/stratum_server.cpp`) fires **only when work generation is unchanged** (`current_gen == last_pushed_generation_`) and re-sends the **CURRENT** job via `send_notify_work(false)`:
- `clean_jobs = false` → the ASIC keeps its current work (no work reset)
- no new work is generated → **no work-generation bump**
- no share, target, difficulty, payout, or coinbase path is touched

Consensus/share diff-grep over the change set is **empty** — the only matches for `consensus|share|payout|target|difficulty|coinbase|…` are the explanatory comments (which contain the word "consensus"). No such code was added or modified.

## Tests

Mechanism + its KAT already exist and are unchanged: `test/test_stratum_hotel_interim.cpp` asserts the idle **non-clean** keepalive cadence, and includes a keepalive-**OFF** control run proving that coins at `keepalive_notify_sec == 0` emit no extra notifies (i.e. opting in is isolated per coin). No new per-coin test needed — the shared mechanism is already covered.

## Build

All four affected targets build clean from this branch (Release):
`c2pool-btc`, `c2pool-ltc`, `c2pool-dgb`, `c2pool-bch` — all link successfully.