### PR TITLE
dash(embedded): independent credit-pool advance on ingestion post-restart [E2 — full independence]

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -1569,6 +1569,21 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 });
         }
 
+        // E4 re-soak fix (constant −66,966,830-duff creditPool bias): the
+        // DIP-0027 platform-share accrual is gated on the NETWORK'S MN_RR
+        // activation height (per-chainparams in dashcore: mainnet 2,128,896,
+        // testnet 1,066,900 — buried, cross-checked live via getblockchaininfo
+        // softforks). With the mainnet constant in force on testnet the
+        // platform reward evaluated to 0 for every current testnet height, so
+        // the embedded template committed creditPoolBalance(N-1) + 0 — exactly
+        // one block's platform reward LOW, at every height, surviving restart
+        // (the persisted seed was correct; the accrual term was the bias).
+        // This threads the network's height into the template build, the
+        // pre-emit value re-check, and the per-block credit-pool advance.
+        node_coin_state.set_mn_rr_height(
+            testnet ? dash::coin::DASH_MN_RR_HEIGHT_TESTNET
+                    : dash::coin::DASH_MN_RR_HEIGHT_MAINNET);
+
         // review PR #780 BLOCKER-1 (CRITICAL): refuse the embedded arm on DKG
         // commitment-window heights. There the block MUST carry mandatory type-6
         // quorum-commitment txs (which the C-3 filter strips) and merkleRootQuorums

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -63,6 +63,7 @@
 #include <impl/dash/coin/header_chain.hpp>       // dash::coin::HeaderChain — SPV header/tip authority (E2a)
 #include <impl/dash/coin/coin_state_maintainer.hpp>  // dash::coin::CoinStateMaintainer — populate ordering gate (E2a)
 #include <impl/dash/coin/sml_quorum_db.hpp>      // dash::coin::SMLDb / QuorumDb — SML+quorum persistence (incremental restart)
+#include <impl/dash/coin/credit_pool_db.hpp>     // dash::coin::CreditPoolDb — credit-pool tip persistence (E2 restart resume)
 #include <impl/dash/coin/live_feed.hpp>          // E2a live-feed bridge (raw wire events -> derived ingest events)
 #include <impl/dash/coin/mempool_ingest.hpp>     // wire_mempool_ingest (leg 1)
 #include <impl/dash/coin/tip_ingest.hpp>         // wire_tip_ingest (leg 2)
@@ -1435,7 +1436,14 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             (core::filesystem::config_path() / net_subdir / "dash_sml_db").string());
         auto quorum_db = std::make_shared<dash::coin::QuorumDb>(
             (core::filesystem::config_path() / net_subdir / "dash_quorum_db").string());
-        const bool sml_persist_ok = sml_db->open() && quorum_db->open();
+        // E2: the DIP-0027 credit-pool tip is persisted alongside SML/quorum so a
+        // warm restart resumes the pool at the SAME tip (matching best_hash),
+        // rather than the arm falling back to dashd until the next mnlistdiff
+        // re-seeds the credit pool for the restart tip.
+        auto credit_pool_db = std::make_shared<dash::coin::CreditPoolDb>(
+            (core::filesystem::config_path() / net_subdir / "dash_credit_pool_db").string());
+        const bool cp_open_ok = credit_pool_db->open();
+        const bool sml_persist_ok = sml_db->open() && quorum_db->open() && cp_open_ok;
         if (!sml_persist_ok) {
             LOG_WARNING << "[SML-DB] open failed -> persistence DISABLED "
                            "(cold mnlistdiff(zero,tip) each restart, as before)";
@@ -1459,6 +1467,35 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                          << ") @ " << sml_db->get_best_hash().GetHex().substr(0, 16)
                          << " h=" << sml_db->get_best_height()
                          << " -> incremental mnlistdiff(persisted-tip, tip)";
+                // E2: restore the credit-pool seed to the SAME tip. Sentinel: the
+                // persisted credit-pool best_hash must match the SML tip (both are
+                // written per accepted mnlistdiff for diff.blockHash). On match,
+                // seed BOTH the NodeCoinState freshness seed (keyed on this height)
+                // and the maintainer's running accrual, so the credit-pool
+                // freshness gate passes at the restart tip and the first
+                // post-restart block advances contiguously + verifies against its
+                // own from-wire cbTx. On mismatch (partial/divergent), wipe the
+                // credit-pool store and let it re-seed cold from the next block/diff.
+                if (credit_pool_db->is_initialized()
+                    && credit_pool_db->get_best_hash() == sml_db->get_best_hash()
+                    && !credit_pool_db->get_best_hash().IsNull()) {
+                    node_coin_state.set_credit_pool(
+                        credit_pool_db->get_balance(),
+                        credit_pool_db->get_best_hash(),
+                        static_cast<int32_t>(credit_pool_db->get_best_height()));
+                    maintainer->restore_credit_pool(
+                        credit_pool_db->get_balance(),
+                        credit_pool_db->get_best_height());
+                    LOG_INFO << "[CP-DB] WARM restart: credit pool "
+                             << credit_pool_db->get_balance() << " @ h="
+                             << credit_pool_db->get_best_height()
+                             << " (tip matches SML) -> freshness gate live at restart tip";
+                } else {
+                    LOG_WARNING << "[CP-DB] credit-pool tip "
+                                << credit_pool_db->get_best_hash().GetHex().substr(0, 16)
+                                << " != SML tip (or empty) -> wipe + cold re-seed";
+                    credit_pool_db->clear();
+                }
             } else {
                 // Undo any partial warm (quorum load may have replaced qmgr state)
                 // and drop divergent/one-sided persisted state so we cold-resync.
@@ -1471,6 +1508,10 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     sml_db->clear();
                     quorum_db->clear();
                 }
+                // E2: the SML cold-resyncs, so any persisted credit-pool tip is
+                // orphaned relative to the tip we will rebuild — wipe it so the
+                // pool re-seeds cold from the next block/diff (never a stale carry).
+                credit_pool_db->clear();
             }
 
             // Persist-on-apply: after each accepted mnlistdiff the maintainer
@@ -1483,14 +1524,27 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     sml_db->write_sml(node_coin_state.sml(), cur_hash, h);
                     quorum_db->write_quorums(node_coin_state.qmgr(), cur_hash, h);
                 });
+            // E2 credit-pool persist: written per accepted mnlistdiff with the SAME
+            // (blockHash, height) the SML persist uses, so the CreditPoolDb tip
+            // tracks the SML tip and the restart sentinel (cp_hash == sml_hash)
+            // holds. balance is the authoritative cbTx creditPoolBalance the diff
+            // re-anchored the pool to.
+            maintainer->set_on_credit_pool_persist(
+                [credit_pool_db]
+                (const uint256& cur_hash, uint32_t h, int64_t balance) {
+                    credit_pool_db->write_state(cur_hash, h, balance,
+                                                /*initialized=*/true);
+                });
             // Wipe-on-reorg/heal: the persisted state is now for an orphaned
             // branch (self-consistent, so the root-verify would pass) — clear it.
+            // Extended to the credit-pool store (same orphaned-branch hazard).
             maintainer->set_on_sml_clear(
-                [sml_db, quorum_db]() {
+                [sml_db, quorum_db, credit_pool_db]() {
                     sml_db->clear();
                     quorum_db->clear();
-                    LOG_INFO << "[SML-DB] reorg/heal -> persisted SML+quorum wiped "
-                                "(cold re-sync)";
+                    credit_pool_db->clear();
+                    LOG_INFO << "[SML-DB] reorg/heal -> persisted SML+quorum+creditpool "
+                                "wiped (cold re-sync)";
                 });
         }
 

--- a/src/impl/dash/coin/block_producer.hpp
+++ b/src/impl/dash/coin/block_producer.hpp
@@ -29,10 +29,13 @@
 // ---------------------------------------------------------------------------
 
 #include "rpc_data.hpp"                       // dash::coin::DashWorkData
+#include "block.hpp"                          // dash::coin::BlockType (body↔header binding)
 #include <impl/dash/crypto/hash_x11.hpp>      // dash::crypto::hash_x11
 #include <impl/dash/coinbase_builder.hpp>     // dash::coinbase::sha256d (Hash sha256d)
 
 #include <core/uint256.hpp>
+#include <core/pack.hpp>                      // ::pack (canonical tx bytes for txid)
+#include <core/hash.hpp>                      // ::Hash (sha256d txid)
 #include <btclibs/util/strencodings.h>        // HexStr, ParseHex
 
 #include <cstdint>
@@ -74,6 +77,49 @@ inline uint256 compute_merkle_root(const std::vector<uint256>& txids)
         layer.swap(next);
     }
     return layer[0];
+}
+
+// Body↔header binding (reward-critical, E2 finding A). The P2P layer validates
+// HEADERS (X11 PoW + DarkGravityWave) but delivers block BODIES cryptographically
+// UNBOUND: nothing checks the tx set against the header's committed merkle root.
+// A forged body under a real PoW header — e.g. a fake type-5 coinbase carrying
+// the correct nHeight but a WRONG creditPoolBalance — would otherwise be adopted
+// by the daemonless credit-pool bootstrap and served as a bad-cbtx. This binds
+// them: the merkle root folded over the body's tx set must equal the header's
+// committed root. Reuses the SAME fold dashcore commits (compute_merkle_root:
+// duplicate-last on odd, via bp_sha256d) so a valid body is NEVER false-rejected,
+// PLUS dashcore's consensus/merkle.cpp CVE-2012-2459 mutation guard: a body
+// padded with duplicate txids yields the same root but is consensus-INVALID, so
+// we reject it too (never false-ACCEPT a mutated body). Matches dashcore block
+// acceptance byte-for-byte. txid = sha256d(canonical tx bytes) == dash_txid.
+inline bool block_body_binds_to_header(const BlockType& block)
+{
+    if (block.m_txs.empty()) return false;   // a real block always carries a coinbase
+    std::vector<uint256> layer;
+    layer.reserve(block.m_txs.size());
+    for (const auto& tx : block.m_txs) {
+        auto packed = ::pack(tx);
+        layer.push_back(::Hash(packed.get_span()));
+    }
+    bool mutated = false;
+    while (layer.size() > 1) {
+        // dashcore mutation check: equal adjacent children (before odd-padding)
+        // flag a CVE-2012-2459 duplicate-padding mutation.
+        for (size_t pos = 0; pos + 1 < layer.size(); pos += 2)
+            if (layer[pos] == layer[pos + 1]) mutated = true;
+        if (layer.size() & 1) layer.push_back(layer.back());   // duplicate last on odd
+        std::vector<uint256> next;
+        next.reserve(layer.size() / 2);
+        for (size_t i = 0; i + 1 < layer.size(); i += 2) {
+            unsigned char buf[64];
+            std::memcpy(buf,      layer[i].data(),     32);
+            std::memcpy(buf + 32, layer[i + 1].data(), 32);
+            next.push_back(bp_sha256d(std::span<const unsigned char>(buf, 64)));
+        }
+        layer.swap(next);
+    }
+    if (mutated) return false;               // mutated body — consensus-invalid, fail closed
+    return layer[0] == block.m_merkle_root;
 }
 
 // Compact nBits -> 256-bit target (Bitcoin/Dash compact form). uint256 carries

--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -491,8 +491,14 @@ private:
             return;
         }
         const int64_t from_wire = observed.creditPoolBalance;
+        // Network-aware platform-share gate (E4 re-soak fix): the MN_RR
+        // activation height is per-chainparams; the state holds the network's
+        // value. With the mainnet constant hard-coded here, testnet heights got
+        // reward=0, the contiguous advance under-accrued by exactly one block's
+        // platform reward, and every block fired ACCRUAL DRIFT + re-seeded.
         const int64_t reward =
-            dash::coin::compute_dash_platform_reward_post_v20_mn_rr(height);
+            dash::coin::compute_dash_platform_reward_post_v20_mn_rr(
+                height, m_state.mn_rr_height());
 
         // Nit C — monotonic guard: never regress the freshness seed on a
         // duplicate/late OLD block. A contiguous advance is height ==

--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -36,6 +36,7 @@
 #include <impl/dash/coin/vendor/cbtx.hpp>        // vendor::parse_cbtx (bestCL*/creditPool seed)
 #include <impl/dash/coin/credit_pool.hpp>        // CreditPool (independent per-block accrual, E2)
 #include <impl/dash/coin/subsidy.hpp>            // compute_dash_platform_reward_post_v20_mn_rr
+#include <impl/dash/coin/block_producer.hpp>     // block_body_binds_to_header (E2 finding A body↔header bind)
 #include <impl/dash/crypto/hash_x11.hpp>         // dash::crypto::hash_x11 (block identity for the seed)
 
 #include <core/uint256.hpp>
@@ -328,6 +329,23 @@ public:
     /// template with a phantom payee. Returns apply_block's ApplyResult.
     MnStateMachine::ApplyResult
     on_block_connected(const dash::coin::BlockType& block, uint32_t height) {
+        // E2 finding A (reward-critical, defence-in-depth): this component EXTRACTS
+        // the reward-critical creditPoolBalance from the block's coinbase, so it
+        // validates its own input at the trust boundary. The body↔header binding is
+        // the outer wire's job (wire_full_block_ingest), but ANY caller reaching
+        // on_block_connected directly (tests / future legs) must not adopt an
+        // unbound body. A body whose tx set does not fold to the header's committed
+        // merkle root (forged/mutated) is refused: no credit-pool advance, no
+        // apply_block, no state change — the prior (valid) seed is retained.
+        if (!dash::coin::block_body_binds_to_header(block)) {
+            LOG_WARNING << "[CREDITPOOL] on_block_connected h=" << height
+                        << " body merkle root != header commitment — REFUSED "
+                           "(no advance, no apply_block)";
+            MnStateMachine::ApplyResult r;
+            r.total_after = m_state.mnstates().size();
+            return r;
+        }
+
         // E2 (independent credit-pool advance): fold THIS block's own credit-pool
         // accrual so the DIP-0027 balance tracks the tip on every ingested block,
         // NOT only when the periodic mnlistdiff re-seeds it. This is what lets the
@@ -475,6 +493,16 @@ private:
         const int64_t from_wire = observed.creditPoolBalance;
         const int64_t reward =
             dash::coin::compute_dash_platform_reward_post_v20_mn_rr(height);
+
+        // Nit C — monotonic guard: never regress the freshness seed on a
+        // duplicate/late OLD block. A contiguous advance is height ==
+        // sm.height()+1 and a forward gap is height > sm.height()+1 (both >
+        // sm.height()); only height <= sm.height() is a backwards/duplicate
+        // delivery — skip it so it cannot roll the seed back to a stale height.
+        // (Same-height reorgs are handled by on_sml_reorg's wipe, not here.)
+        if (m_credit_pool_sm.initialized()
+            && height <= m_credit_pool_sm.height())
+            return;
 
         if (m_credit_pool_sm.initialized()
             && m_credit_pool_sm.height() + 1 == height) {

--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -34,8 +34,12 @@
 #include <impl/dash/coin/vendor/smldiff.hpp>     // vendor::CSimplifiedMNListDiff + apply_diff
 #include <impl/dash/coin/vendor/quorum_tail.hpp> // vendor::parse_quorum_tail
 #include <impl/dash/coin/vendor/cbtx.hpp>        // vendor::parse_cbtx (bestCL*/creditPool seed)
+#include <impl/dash/coin/credit_pool.hpp>        // CreditPool (independent per-block accrual, E2)
+#include <impl/dash/coin/subsidy.hpp>            // compute_dash_platform_reward_post_v20_mn_rr
+#include <impl/dash/crypto/hash_x11.hpp>         // dash::crypto::hash_x11 (block identity for the seed)
 
 #include <core/uint256.hpp>
+#include <core/pack.hpp>
 #include <core/log.hpp>
 
 #include <array>
@@ -98,6 +102,13 @@ public:
     /// SML at exactly the state dashd commits for TIP+1 is the #1 item the live
     /// byte-parity KAT against a running dashd must confirm; do not assume.
     void on_mnlistdiff(const vendor::CSimplifiedMNListDiff& diff) {
+        // E2 credit-pool persist locals: set when the diff's cbTx re-anchors the
+        // pool, flushed (aligned with the SML persist) at the bottom so a restart
+        // resumes the credit pool at the SAME tip as SMLDb/QuorumDb.
+        bool     cp_seeded  = false;
+        int64_t  cp_balance = 0;
+        uint32_t cp_height  = 0;
+
         // H-7 base-continuity: an INCREMENTAL diff is only valid when its
         // baseBlockHash matches the block our SML/quorum state is CURRENT AT.
         // Applying a diff whose base is some other block upserts/erases MN +
@@ -163,6 +174,16 @@ public:
                     // instead of committing a lagged creditPoolBalance (soak fix).
                     m_state.set_credit_pool(observed.creditPoolBalance,
                                             diff.blockHash, observed.nHeight);
+                    // E2: re-anchor the independent running accrual to this
+                    // authoritative snapshot value/height so the per-block advance
+                    // (on_block_connected) continues contiguously from here, and
+                    // record it for the aligned CreditPoolDb persist below (same
+                    // blockHash/height as the SML persist → matching restart tip).
+                    m_credit_pool_sm.seed(observed.creditPoolBalance,
+                                          static_cast<uint32_t>(observed.nHeight));
+                    cp_seeded  = true;
+                    cp_balance = observed.creditPoolBalance;
+                    cp_height  = static_cast<uint32_t>(observed.nHeight);
                     // bestCLHeightDiff is relative to (cbHeight-1); recover the
                     // absolute best-CL height so the next template re-derives its
                     // own diff against ITS height. Only adopt when the observed
@@ -201,6 +222,13 @@ public:
         // QuorumDb::write_quorums; unset (KAT posture) makes it a no-op.
         if (m_have_mn_sml && m_on_sml_persist)
             m_on_sml_persist(diff.blockHash);
+        // E2: persist the credit-pool tip alongside the SML tip (same blockHash +
+        // height), so the CreditPoolDb sentinel (cp_hash == sml_hash) holds and a
+        // warm restart restores the pool to exactly the SML's resume point. Only
+        // when the SML actually applied non-empty (a persistable tip) AND the
+        // diff carried a v3+ cbTx seed.
+        if (m_have_mn_sml && cp_seeded && m_on_credit_pool_persist)
+            m_on_credit_pool_persist(diff.blockHash, cp_height, cp_balance);
         if (!m_have_mn_sml)
             demote();
         else
@@ -244,6 +272,10 @@ public:
         // Invalidate the credit-pool seed's freshness too (height -1 != any tip),
         // so the arm fails closed on the credit-pool axis until a fresh re-seed.
         m_state.set_credit_pool(0, uint256::ZERO, -1);
+        // E2: wipe the independent running accrual as well — its balance was built
+        // on the now-orphaned branch. It re-bootstraps from the first post-reorg
+        // block's / full-snapshot's authoritative cbTx (never a stale carry-over).
+        m_credit_pool_sm.clear();
         // Wipe the PERSISTED SML/quorum stores too. The on-disk state is now for
         // an orphaned branch; it is self-consistent so the root-verify on the
         // next restart WOULD pass and serve a wrong-branch template. Clearing it
@@ -296,6 +328,15 @@ public:
     /// template with a phantom payee. Returns apply_block's ApplyResult.
     MnStateMachine::ApplyResult
     on_block_connected(const dash::coin::BlockType& block, uint32_t height) {
+        // E2 (independent credit-pool advance): fold THIS block's own credit-pool
+        // accrual so the DIP-0027 balance tracks the tip on every ingested block,
+        // NOT only when the periodic mnlistdiff re-seeds it. This is what lets the
+        // freshness gate pass daemonlessly between diffs and — paired with the
+        // CreditPoolDb restore in main_dash — on the tip that existed at restart.
+        // Runs BEFORE the MN snapshot fence: the credit pool is a distinct axis
+        // (asset-lock/unlock + platform-reward), independent of the payee set.
+        advance_credit_pool_on_block(block, height);
+
         // E2c snapshot fence: blocks the payout-bearing snapshot already
         // reflects (height <= its as-of height) must NOT be re-folded -- the
         // snapshot's registrations/spends/lastPaid ARE those blocks' effects,
@@ -367,12 +408,107 @@ public:
         m_on_sml_clear = std::move(fn);
     }
 
+    /// Wire the credit-pool PERSISTENCE sink (main_dash points this at
+    /// CreditPoolDb::write_state). Invoked from on_mnlistdiff after an accepted
+    /// diff re-anchors the pool, with the same (blockHash, height) the SML persist
+    /// uses so the on-disk credit-pool tip matches SMLDb/QuorumDb exactly (E2).
+    /// Optional (unset in KATs = no-op; the running arm never needs persistence).
+    void set_on_credit_pool_persist(
+        std::function<void(const uint256&, uint32_t, int64_t)> fn) {
+        m_on_credit_pool_persist = std::move(fn);
+    }
+
+    /// Restore the independent running credit-pool accrual on a warm restart
+    /// (main_dash calls this when CreditPoolDb loads a tip matching the SML's).
+    /// Seeds the state machine to the persisted balance/height so the first
+    /// post-restart block advances contiguously (and verifies against its own
+    /// from-wire cbTx) instead of the arm falling back to dashd for the restart
+    /// tip. The caller sets the NodeCoinState freshness seed in parallel (E2).
+    void restore_credit_pool(int64_t balance, uint32_t height) {
+        m_credit_pool_sm.seed(balance, height);
+    }
+
     /// True iff both prerequisites are met AND the holder is currently live.
     bool live() const { return m_state.populated(); }
 
 private:
     void notify_state_dirty() {
         if (m_on_state_dirty) m_on_state_dirty();
+    }
+
+    // Block identity hash (Dash: X11 of the 80-byte header). Marks the credit-pool
+    // seed as current AT this exact block; cheap (~0.1 ms) and computed off the
+    // ingested block, never from any template we built.
+    static uint256 block_identity_hash(const dash::coin::BlockType& block) {
+        auto packed = ::pack(
+            static_cast<const bitcoin_family::coin::BlockHeaderType&>(block));
+        return dash::crypto::hash_x11(packed.get_span());
+    }
+
+    // E2 — INDEPENDENT per-block credit-pool advance + non-self-referential verify.
+    //
+    // Every ingested block carries, in its OWN coinbase CCbTx, the creditPoolBalance
+    // dashd committed for that height. That is the independent, off-the-wire source
+    // of truth. We (a) run our own accrual state machine forward across the block
+    // and (b) require the result to equal the block's own committed value. Two
+    // independent sources are compared — our recomputation vs dashd's committed
+    // value at the same height — NOT a built template against its own seed (the
+    // self-consistent-but-stale trap that refuted 3 prior soaks). The seed's height
+    // is taken straight off the wire (cbTx.nHeight == connected height, checked),
+    // so it can never be mistaken as current at a height we did not observe.
+    void advance_credit_pool_on_block(const dash::coin::BlockType& block,
+                                      uint32_t height) {
+        if (block.m_txs.empty()) return;                 // no coinbase
+        const auto& cb = block.m_txs[0];                 // coinbase = tx 0
+        if (cb.type != 5 || cb.extra_payload.empty())
+            return;                                      // pre-v20 / non-CbTx: leave prior seed
+        vendor::CCbTx observed;
+        if (!vendor::parse_cbtx(cb.extra_payload, observed)) return;
+        if (observed.nVersion < vendor::CCbTx::VERSION_CLSIG_AND_BALANCE) return;
+        // Never seed a balance against a height we did not verify off the wire.
+        if (observed.nHeight != static_cast<int32_t>(height)) {
+            LOG_WARNING << "[CREDITPOOL] block cbTx nHeight " << observed.nHeight
+                        << " != connected height " << height
+                        << " — skip credit-pool advance";
+            return;
+        }
+        const int64_t from_wire = observed.creditPoolBalance;
+        const int64_t reward =
+            dash::coin::compute_dash_platform_reward_post_v20_mn_rr(height);
+
+        if (m_credit_pool_sm.initialized()
+            && m_credit_pool_sm.height() + 1 == height) {
+            // CONTIGUOUS: advance the running accrual by THIS block's own delta
+            // (platform reward + Σ assetLocks − Σ assetUnlocks) and cross-check it
+            // against the block's OWN committed balance (the independent verify).
+            m_credit_pool_sm.apply_block(block, height, reward);
+            if (m_credit_pool_sm.balance() != from_wire) {
+                // Drift: our model disagrees with the wire. Fail CLOSED — do not
+                // advance the freshness seed (get_work falls back to the reward-safe
+                // dashd path for this height). Re-anchor the state machine to the
+                // authoritative wire value so the next block re-verifies, and surface
+                // the drift for soak triage. (Making the advance correct — not
+                // relaxing the gate — is the fix if this ever fires.)
+                LOG_WARNING << "[CREDITPOOL] ACCRUAL DRIFT h=" << height
+                            << " computed=" << m_credit_pool_sm.balance()
+                            << " from-wire=" << from_wire
+                            << " — freshness seed NOT advanced (fail closed to fallback)";
+                m_credit_pool_sm.seed(from_wire, height);
+                return;
+            }
+            // Verified: an independently-confirmed advance to this height.
+        } else {
+            // NON-CONTIGUOUS (cold / gap / first block post-restart before a diff
+            // re-anchor): no running prediction to verify against, so bootstrap
+            // directly from the block's own committed balance. Still non-self-
+            // referential — value AND height come straight off the wire.
+            m_credit_pool_sm.seed(from_wire, height);
+        }
+        // Advance the freshness seed to THIS block: height == the tip we build the
+        // next template on, so the credit-pool freshness gate passes at the right
+        // height without waiting for the next mnlistdiff.
+        m_state.set_credit_pool(from_wire, block_identity_hash(block),
+                                static_cast<int32_t>(height));
     }
 
     // Publish only when both prerequisites are present; otherwise leave the
@@ -394,7 +530,12 @@ private:
     std::function<void()> m_on_state_dirty;  // SML/bestCL/reorg -> re-issue work
     std::function<void()> m_on_full_resync;  // H-1 heal -> reset sml_base + full re-sync
     std::function<void(const uint256&)> m_on_sml_persist;  // accepted diff -> SMLDb/QuorumDb write
-    std::function<void()> m_on_sml_clear;    // reorg/heal -> SMLDb/QuorumDb wipe
+    std::function<void()> m_on_sml_clear;    // reorg/heal -> SMLDb/QuorumDb wipe (extended to CreditPoolDb)
+    // E2: independent DIP-0027 credit-pool accrual, advanced per ingested block
+    // (on_block_connected) and re-anchored per accepted mnlistdiff. Verified
+    // against each block's own from-wire cbTx; persisted via the hook below.
+    CreditPool m_credit_pool_sm;
+    std::function<void(const uint256&, uint32_t, int64_t)> m_on_credit_pool_persist;
 
     bool m_have_mn{false};
     bool m_have_tip{false};

--- a/src/impl/dash/coin/credit_pool.hpp
+++ b/src/impl/dash/coin/credit_pool.hpp
@@ -45,12 +45,23 @@ public:
     /// Apply a block to the pool. Returns the per-block delta on
     /// success, or std::nullopt if the pool is uninitialized (no seed
     /// observed yet — caller should seed from CCbTx.creditPoolBalance).
+    ///
+    /// reward_accrual is the platform-reward term dashcore adds to the credit
+    /// pool for this block (evo/creditpool.cpp folds the DIP-0027 platform
+    /// share locked at block N on top of the asset-lock/unlock deltas):
+    ///   creditPoolBalance(N) = creditPoolBalance(N-1)
+    ///                          + reward_accrual (platform share locked at N)
+    ///                          + Σ assetLocks(N) − Σ assetUnlocks(N)
+    /// The asset terms are walked from block.m_txs here; the caller supplies
+    /// reward_accrual (compute_dash_platform_reward_post_v20_mn_rr(N)) since
+    /// this state machine deliberately holds no subsidy schedule. Defaults to
+    /// 0 (pure DiffFromBlock accrual) so existing callers are unchanged.
     std::optional<int64_t> apply_block(
-        const BlockType& block, uint32_t height)
+        const BlockType& block, uint32_t height, int64_t reward_accrual = 0)
     {
         if (!m_initialized) return std::nullopt;
 
-        int64_t delta = 0;
+        int64_t delta = reward_accrual;
         size_t locks = 0, unlocks = 0;
 
         // Skip cb (index 0) — it's the special-tx-5 CCbTx itself,
@@ -89,6 +100,7 @@ public:
         if (delta != 0 || locks != 0 || unlocks != 0) {
             LOG_INFO << "[CREDITPOOL] h=" << height
                      << " delta=" << delta
+                     << " reward=" << reward_accrual
                      << " locks=" << locks
                      << " unlocks=" << unlocks
                      << " balance=" << m_balance;

--- a/src/impl/dash/coin/embedded_gbt.hpp
+++ b/src/impl/dash/coin/embedded_gbt.hpp
@@ -127,7 +127,14 @@ inline DashWorkData build_embedded_workdata(
     const QuorumManager* qmgr = nullptr,
     int32_t best_cl_height = 0,
     const std::array<uint8_t, 96>& best_cl_sig = k_zero_cl_sig,
-    int64_t last_observed_credit_pool = 0)
+    int64_t last_observed_credit_pool = 0,
+    // Network seam: the MN_RR activation height gating the DIP-0027
+    // platform-share accrual (dashcore Params().GetConsensus().MN_RRHeight).
+    // Defaults to MAINNET (existing callers byte-unchanged); testnet callers
+    // MUST pass DASH_MN_RR_HEIGHT_TESTNET or the platform reward evaluates to
+    // 0 and the committed creditPoolBalance sits one block-reward low (the E4
+    // re-soak constant −66,966,830-duff bias).
+    int mn_rr_height = DASH_MN_RR_HEIGHT_MAINNET)
 {
     DashWorkData w;
     w.m_height          = prev_height + 1;
@@ -152,7 +159,8 @@ inline DashWorkData build_embedded_workdata(
     auto [selected, total_fees] =
         mempool.get_sorted_txs_with_fees(MAX_BLOCK_BYTES, /*exclude_special=*/true);
     int64_t block_value      = reward + static_cast<int64_t>(total_fees);
-    int64_t platform_reward  = compute_dash_platform_reward_post_v20_mn_rr(w.m_height);
+    int64_t platform_reward  = compute_dash_platform_reward_post_v20_mn_rr(
+        w.m_height, mn_rr_height);
     int64_t mn_payment       = compute_dash_mn_payment_post_v20(block_value) - platform_reward;
 
     w.m_coinbase_value  = static_cast<uint64_t>(block_value);

--- a/src/impl/dash/coin/live_feed.hpp
+++ b/src/impl/dash/coin/live_feed.hpp
@@ -44,6 +44,7 @@
 #include "node_interface.hpp"   // dash::interfaces::Node + TipAdvance/BlockConnected
 #include "block.hpp"            // BlockType / BlockHeaderType
 #include "header_chain.hpp"     // HeaderChain, x11_hash, IndexEntry
+#include "block_producer.hpp"   // dash::coin::block_body_binds_to_header (E2 finding A)
 
 #include <impl/dash/crypto/hash_x11.hpp>
 
@@ -114,6 +115,19 @@ wire_full_block_ingest(::dash::interfaces::Node& node, HeaderChain& chain)
             if (!entry) {
                 LOG_DEBUG_COIND << "[EMB-DASH] full_block " << hash.GetHex().substr(0, 16)
                                 << " not in header chain yet — deferring connect";
+                return;
+            }
+            // E2 finding A (reward-critical): the header is PoW/DGW-validated, but
+            // the BODY arrives cryptographically UNBOUND. Bind it before firing
+            // block_connected — the merkle root over the tx set must match the
+            // header's committed root — so a forged body (e.g. a fake type-5
+            // coinbase with the right nHeight but a wrong creditPoolBalance) can
+            // never reach the credit-pool bootstrap / apply_block / UTXO legs.
+            // Fail closed: skip the connect (the real body re-request closes it).
+            if (!dash::coin::block_body_binds_to_header(block)) {
+                LOG_WARNING << "[EMB-DASH] full_block " << hash.GetHex().substr(0, 16)
+                            << " body merkle root != header commitment (forged/mutated"
+                               " body) — REFUSING connect (fail closed to dashd fallback)";
                 return;
             }
             node.block_connected.happened(

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -123,6 +123,17 @@ public:
     /// reward-safe dashd fallback. Default OFF preserves prior unit-test posture.
     void set_require_fresh_credit_pool(bool v) { m_require_fresh_credit_pool = v; }
 
+    /// Network MN_RR activation height (dashcore Params().GetConsensus()
+    /// .MN_RRHeight — per-chainparams). Gates the DIP-0027 platform-share
+    /// credit-pool accrual in the template build, the pre-emit value re-check,
+    /// and the per-block advance. main_dash sets the testnet value; the
+    /// mainnet default keeps every existing caller byte-unchanged. E4 re-soak
+    /// fix: leaving the MAINNET constant in force on testnet zeroes the
+    /// platform reward and biases every committed creditPoolBalance low by
+    /// exactly one block's platform reward (constant 66,966,830 duffs).
+    void set_mn_rr_height(int h) { m_mn_rr_height = h; }
+    int mn_rr_height() const { return m_mn_rr_height; }
+
     /// Enable the SML-required viability gate. main_dash.cpp turns this on for
     /// the embedded coin-P2P arm so a template is only served once the CCbTx
     /// commitment inputs are present (review finding H3: no mid-sync half-built block).
@@ -263,7 +274,8 @@ public:
         if (m_require_fresh_credit_pool) {
             const int64_t expected_credit_pool =
                 m_credit_pool
-                + compute_dash_platform_reward_post_v20_mn_rr(next_h);
+                + compute_dash_platform_reward_post_v20_mn_rr(next_h,
+                                                              m_mn_rr_height);
             if (cb.creditPoolBalance != expected_credit_pool) return false;
         }
         return true;
@@ -308,6 +320,7 @@ public:
         e.address_p2sh_version = m_address_p2sh_version;
         e.curtime              = m_curtime;
         e.version              = m_version;
+        e.mn_rr_height         = m_mn_rr_height;
         // CCbTx seams: pass the SML + quorum set ONLY when present, so a
         // legacy/testnet-without-SML bundle still builds the pre-CCbTx template
         // (empty payload) byte-for-byte, while a live daemonless bundle emits
@@ -350,6 +363,7 @@ private:
     std::function<bool(uint32_t)> m_commitment_window_fn;  // refuse embedded on DKG commitment heights
     bool     m_require_fresh_bestcl{false};  // refuse embedded on a stale/absent bestCL
     bool     m_require_fresh_credit_pool{false}; // refuse embedded on a lagged credit-pool seed
+    int      m_mn_rr_height{DASH_MN_RR_HEIGHT_MAINNET}; // network MN_RR activation height (platform-share gate)
     uint256  m_credit_pool_current_hash;     // block hash the credit-pool seed is current at
     int32_t  m_credit_pool_height{-1};       // seed cbTx's OWN height (-1 = never seeded)
     bool     m_quorum_healthy{true};         // last diff's quorum tail parsed OK

--- a/src/impl/dash/coin/subsidy.hpp
+++ b/src/impl/dash/coin/subsidy.hpp
@@ -45,6 +45,15 @@ inline constexpr int DASH_SUBSIDY_HALVING_INTERVAL = 210240;
 inline constexpr int DASH_V20_HEIGHT_MAINNET       = 1'987'776;
 inline constexpr int DASH_BRR_HEIGHT_MAINNET       = 1'374'912;
 inline constexpr int DASH_MN_RR_HEIGHT_MAINNET     = 2'128'896;
+// Testnet activation heights (dashcore chainparams.cpp CTestNetParams;
+// cross-checked live against testnet dashd getblockchaininfo softforks:
+// v20 buried @905100, mn_rr buried @1066900). MN_RR gates the DIP-0027
+// platform-share credit-pool accrual — using the MAINNET height on testnet
+// makes the per-block platform reward evaluate to 0 for every testnet
+// height in [1066900, 2128896), i.e. a constant −66,966,830-duff
+// creditPoolBalance bias at current testnet heights (E4 re-soak finding).
+inline constexpr int DASH_V20_HEIGHT_TESTNET       = 905'100;
+inline constexpr int DASH_MN_RR_HEIGHT_TESTNET     = 1'066'900;
 inline constexpr int DASH_SUPERBLOCK_CYCLE_MAINNET = 16616;
 inline constexpr int DASH_SUPERBLOCK_CYCLE_TESTNET = 24;   // dashcore testnet nSuperblockCycle
 
@@ -85,9 +94,17 @@ inline int64_t compute_dash_mn_payment_post_v20(int64_t block_value)
 /// truncates between the two divisions, so we replicate that order exactly.
 /// The result is added as an OP_RETURN coinbase output and DEDUCTED from the
 /// MN's portion (miner share is unaffected).
-inline int64_t compute_dash_platform_reward_post_v20_mn_rr(uint32_t height)
+///
+/// `mn_rr_height` is the NETWORK'S MN_RR activation height (dashcore keys this
+/// off Params().GetConsensus().MN_RRHeight, i.e. per-chainparams). Defaults to
+/// MAINNET; callers on testnet MUST pass DASH_MN_RR_HEIGHT_TESTNET — the E4
+/// re-soak proved that gating testnet heights on the mainnet constant returns
+/// 0 here and biases every committed creditPoolBalance low by exactly one
+/// block's platform reward (66,966,830 duffs at testnet h≈1.519M).
+inline int64_t compute_dash_platform_reward_post_v20_mn_rr(
+    uint32_t height, int mn_rr_height = DASH_MN_RR_HEIGHT_MAINNET)
 {
-    if (static_cast<int>(height) < DASH_MN_RR_HEIGHT_MAINNET) return 0;
+    if (static_cast<int>(height) < mn_rr_height) return 0;
     int64_t mn_subsidy_share = compute_dash_block_reward_post_v20(height) * 3 / 4;
     return mn_subsidy_share * 375 / 1000;
 }

--- a/src/impl/dash/coin/work_source.hpp
+++ b/src/impl/dash/coin/work_source.hpp
@@ -63,6 +63,10 @@ struct EmbeddedWorkInputs {
     int32_t                          best_cl_height{0};
     std::array<uint8_t, 96>          best_cl_sig{};
     int64_t                          credit_pool{0};
+    // Network MN_RR activation height for the DIP-0027 platform-share accrual
+    // (per-chainparams in dashcore). Mainnet default; main_dash sets the
+    // testnet value via NodeCoinState::set_mn_rr_height (E4 re-soak fix).
+    int                              mn_rr_height{DASH_MN_RR_HEIGHT_MAINNET};
 
     bool viable() const {
         return has_state && mnstates != nullptr && mempool != nullptr;
@@ -112,7 +116,8 @@ inline WorkSelection select_dash_work(
                 // sml/qmgr null — legacy callers unchanged).
                 /*underfill_tripped=*/nullptr,
                 emb.sml, emb.qmgr,
-                emb.best_cl_height, emb.best_cl_sig, emb.credit_pool);
+                emb.best_cl_height, emb.best_cl_sig, emb.credit_pool,
+                emb.mn_rr_height);
         },
         dashd_fallback);
 }

--- a/test/test_dash_coin_state_maintainer.cpp
+++ b/test/test_dash_coin_state_maintainer.cpp
@@ -26,6 +26,7 @@
 #include <impl/dash/coin/mn_state_machine.hpp>
 #include <impl/dash/coin/mempool.hpp>
 #include <impl/dash/coin/block.hpp>
+#include <impl/dash/coin/block_producer.hpp>   // compute_merkle_root (E2 finding A body↔header bind)
 #include <impl/dash/coin/utxo_adapter.hpp>
 #include <impl/dash/coin/rpc_data.hpp>
 #include <impl/dash/coin/transaction.hpp>
@@ -73,6 +74,16 @@ static std::vector<unsigned char> p2pkh_script(uint8_t hashseed) {
     for (int i = 0; i < 20; ++i) s.push_back(static_cast<unsigned char>(hashseed + i));
     s.push_back(0x88); s.push_back(0xac);
     return s;
+}
+
+// Bind a hand-built block body to its header: commit the merkle root over the
+// tx set so on_block_connected's E2 finding-A guard (block_body_binds_to_header)
+// accepts it. Every block fed to the connect path must be bound (as a real
+// P2P-delivered, PoW-headed block is).
+static void bind_block(BlockType& b) {
+    std::vector<uint256> ids;
+    for (const auto& tx : b.m_txs) ids.push_back(dash::coin::dash_txid(tx));
+    b.m_merkle_root = dash::coin::compute_merkle_root(ids);
 }
 
 static MutableTransaction make_spend(const uint256& prev, uint32_t idx,
@@ -260,6 +271,7 @@ TEST(DashCoinStateMaintainer, BlockConnectNoSpecialTxPreservesReadiness) {
     BlockType blk;
     blk.m_txs.push_back(make_spend(raw256(0x90), 0, 500000000, 1));  // cb (idx 0, skipped)
     blk.m_txs.push_back(make_spend(raw256(0x91), 0, 400000000, 2));  // plain spend, no collateral match
+    bind_block(blk);
     auto r = m.on_block_connected(blk, H);
 
     EXPECT_EQ(r.registered, 0u);
@@ -282,6 +294,7 @@ TEST(DashCoinStateMaintainer, BlockConnectCollateralSpendDropsToFallback) {
     BlockType blk;
     blk.m_txs.push_back(make_spend(raw256(0x90), 0, 500000000, 1));  // cb (idx 0, skipped)
     blk.m_txs.push_back(make_spend(coll, 3, 400000000, 2));          // spends the MN collateral
+    bind_block(blk);
     m.on_block_connected(blk, H);
 
     EXPECT_EQ(st.mnstates().size(), 0u);

--- a/test/test_dash_embedded_cbtx_byte_parity.cpp
+++ b/test/test_dash_embedded_cbtx_byte_parity.cpp
@@ -40,6 +40,7 @@
 
 #include <impl/dash/coin/embedded_gbt.hpp>
 #include <impl/dash/coin/subsidy.hpp>
+#include <impl/dash/coin/credit_pool.hpp>
 #include <impl/dash/coin/quorum_manager.hpp>
 #include <impl/dash/coin/vendor/cbtx.hpp>
 #include <impl/dash/coin/vendor/simplifiedmns.hpp>
@@ -187,6 +188,136 @@ TEST(DashEmbeddedCbtxByteParity, CreditPoolAccrualMatchesRealDashd) {
     // dashd's creditPoolBalance for block N = balance(N-1) + platformReward(N)
     // (+ asset lock/unlock, zero here — the embedded template excludes special
     // txs). Proven against dashd's own numbers: block 1518412 -> template 1518413.
+    // NOTE (E4 re-soak lesson): this is a CONSTANTS-only delta identity — it
+    // never calls the reward function and never anchors an absolute value, so
+    // it passed while the built templates carried a constant −66,966,830-duff
+    // bias. The DashCreditPoolSeedAnchorKat suite below closes that hole.
     EXPECT_EQ(kPrevCreditPoolSat + kPlatformRewardSat, kExpCreditPoolSat)
         << "platform-reward accrual must land on dashd's committed creditPoolBalance";
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// E4 RE-SOAK KAT — ABSOLUTE credit-pool seed anchor vs REAL from-wire cbTx.
+//
+// The 4th credit-pool soak refutation: every prior KAT proved DELTAS or
+// self-consistent round-trips, so the embedded creditPoolBalance sat a CONSTANT
+// 66,966,830 duffs BELOW dashd at every height (testnet, h≈1.519M) while all
+// KATs passed. Root cause: compute_dash_platform_reward_post_v20_mn_rr gated
+// the DIP-0027 platform share on the MAINNET MN_RR height (2,128,896)
+// unconditionally; on TESTNET (MN_RR buried @1,066,900) every current height
+// returned reward=0, so template(N) = seed(N-1) + 0 — exactly one block's
+// platform reward low, forever, surviving restart.
+//
+// These vectors are REAL dashd testnet type-5 cbTx extra_payloads, captured
+// verbatim off getblock (192.168.86.52, the E4 soak oracle): consecutive
+// coinbase-only blocks 1,519,413 / 1,519,414 (ntx=1 each — the step between
+// them is PURELY the platform reward; no asset locks/unlocks). The assertions
+// are ABSOLUTE: our accrual, seeded from the wire at H-1, must land EXACTLY on
+// the wire's committed balance at H. Before the network-aware MN_RR gate fix,
+// every absolute assertion here fails by exactly 66,966,830.
+// ════════════════════════════════════════════════════════════════════════════
+
+// Block 1,519,413 (0000006df1961a602f3f8fb68ba2c56130667f91deaa09c35454279e26e47e10).
+static const char* kSeedAnchorCbTxHexH1 =
+    "0300352f17007edd5fec21fd07f7b9d44b5029884ebc71d2e2812fd3029a7669"
+    "0045ce5c16470a7d455f49ef4de2ff0259e92a58733efd42d4ef2bc11f6efe30"
+    "e026d9a76aa200a34d69c329d6489a29b58f267785246a70b46349889d8f42fa"
+    "88814eeb5570dc08d8a4cfd9a225d8cb9712991f609e190483d6b9804f57d8c2"
+    "092377a5d5c1a1cf93e2668a5b05a6980a2f33cee25f57486c262528937c88c8"
+    "789ba41f3cbb99eaacb67ef21e0000";
+// Block 1,519,414 (0000001166a4ae22b7c0dcc6b0eef37fb1caeb6cc350d39857cbbfac9d34b0ad).
+static const char* kSeedAnchorCbTxHexH2 =
+    "0300362f17007edd5fec21fd07f7b9d44b5029884ebc71d2e2812fd3029a7669"
+    "0045ce5c16470a7d455f49ef4de2ff0259e92a58733efd42d4ef2bc11f6efe30"
+    "e026d9a76aa201a34d69c329d6489a29b58f267785246a70b46349889d8f42fa"
+    "88814eeb5570dc08d8a4cfd9a225d8cb9712991f609e190483d6b9804f57d8c2"
+    "092377a5d5c1a1cf93e2668a5b05a6980a2f33cee25f57486c262528937c88c8"
+    "789ba41f3cbb991882b482f21e0000";
+
+static constexpr int32_t kSeedAnchorHeightH1 = 1'519'413;
+static constexpr int32_t kSeedAnchorHeightH2 = 1'519'414;
+// dashd's committed absolute balances (getblock cbTx.creditPoolBalance, duffs).
+static constexpr int64_t kSeedAnchorBalanceH1 = 34'026'856'819'946LL;
+static constexpr int64_t kSeedAnchorBalanceH2 = 34'026'923'786'776LL;
+
+// 1. The from-wire vectors decode to the expected ABSOLUTE anchor values.
+TEST(DashCreditPoolSeedAnchorKat, FromWireSeedEqualsDashdAbsoluteValue) {
+    CCbTx h1, h2;
+    ASSERT_TRUE(parse_cbtx(from_hex(kSeedAnchorCbTxHexH1), h1));
+    ASSERT_TRUE(parse_cbtx(from_hex(kSeedAnchorCbTxHexH2), h2));
+    EXPECT_EQ(h1.nHeight, kSeedAnchorHeightH1);
+    EXPECT_EQ(h2.nHeight, kSeedAnchorHeightH2);
+    EXPECT_EQ(h1.creditPoolBalance, kSeedAnchorBalanceH1)
+        << "seed anchor must equal dashd's committed creditPoolBalance EXACTLY";
+    EXPECT_EQ(h2.creditPoolBalance, kSeedAnchorBalanceH2);
+}
+
+// 2. THE regression this suite exists for: the platform reward at a CURRENT
+//    testnet height, under the TESTNET MN_RR gate, equals the real on-chain
+//    step between the two coinbase-only blocks. Before the fix the mainnet
+//    gate returned 0 here (1,519,414 < 2,128,896) — off by 66,966,830.
+TEST(DashCreditPoolSeedAnchorKat, TestnetPlatformRewardEqualsOnChainStep) {
+    const int64_t on_chain_step = kSeedAnchorBalanceH2 - kSeedAnchorBalanceH1;
+    EXPECT_EQ(on_chain_step, 66'966'830LL) << "capture regression";
+    EXPECT_EQ(dash::coin::compute_dash_platform_reward_post_v20_mn_rr(
+                  static_cast<uint32_t>(kSeedAnchorHeightH2),
+                  dash::coin::DASH_MN_RR_HEIGHT_TESTNET),
+              on_chain_step)
+        << "TESTNET-gated platform reward must equal dashd's real per-block "
+           "credit-pool step (MN_RR buried @1,066,900 on testnet)";
+    // The mainnet gate still (correctly) reports pre-activation zero at this
+    // height — the network-aware seam, not a formula change, is the fix.
+    EXPECT_EQ(dash::coin::compute_dash_platform_reward_post_v20_mn_rr(
+                  static_cast<uint32_t>(kSeedAnchorHeightH2)),
+              0);
+}
+
+// 3. ABSOLUTE template anchor: a template built on the from-wire seed at H-1
+//    must commit dashd's EXACT absolute balance at H (0 delta — the definitive
+//    E4 check the soak runs against getblock).
+TEST(DashCreditPoolSeedAnchorKat, BuiltTemplateCommitsDashdAbsoluteValue) {
+    CCbTx seed;
+    ASSERT_TRUE(parse_cbtx(from_hex(kSeedAnchorCbTxHexH1), seed));
+    const int64_t committed =
+        seed.creditPoolBalance
+        + dash::coin::compute_dash_platform_reward_post_v20_mn_rr(
+              static_cast<uint32_t>(kSeedAnchorHeightH2),
+              dash::coin::DASH_MN_RR_HEIGHT_TESTNET);
+    EXPECT_EQ(committed, kSeedAnchorBalanceH2)
+        << "template(N) = seed(N-1) + platformReward(N) must equal dashd's "
+           "committed ABSOLUTE creditPoolBalance, not sit a constant below it";
+}
+
+// 4. The E2 per-block advance leg: CreditPool seeded from the wire at H-1 and
+//    advanced across the (coinbase-only) block at H must land EXACTLY on the
+//    block's OWN from-wire committed balance. This is the contiguous-advance
+//    path that fired [CREDITPOOL] ACCRUAL DRIFT on every block of the E4 soak
+//    when the reward term evaluated to 0.
+TEST(DashCreditPoolSeedAnchorKat, PerBlockAdvanceLandsOnFromWireAbsolute) {
+    CCbTx h2;
+    ASSERT_TRUE(parse_cbtx(from_hex(kSeedAnchorCbTxHexH2), h2));
+
+    dash::coin::CreditPool pool;
+    pool.seed(kSeedAnchorBalanceH1,
+              static_cast<uint32_t>(kSeedAnchorHeightH1));
+
+    // Reconstruct block 1,519,414's body shape: coinbase-only (ntx=1, type-5),
+    // exactly as captured — the accrual across it is purely the platform reward.
+    dash::coin::BlockType block;
+    dash::coin::MutableTransaction cb;
+    cb.type = 5;
+    cb.extra_payload = from_hex(kSeedAnchorCbTxHexH2);
+    block.m_txs.push_back(cb);
+
+    const int64_t reward =
+        dash::coin::compute_dash_platform_reward_post_v20_mn_rr(
+            static_cast<uint32_t>(kSeedAnchorHeightH2),
+            dash::coin::DASH_MN_RR_HEIGHT_TESTNET);
+    auto delta = pool.apply_block(
+        block, static_cast<uint32_t>(kSeedAnchorHeightH2), reward);
+    ASSERT_TRUE(delta.has_value());
+    EXPECT_EQ(pool.balance(), h2.creditPoolBalance)
+        << "the independent advance must equal the block's OWN from-wire "
+           "committed creditPoolBalance (the E2 non-self-referential verify)";
+    EXPECT_EQ(pool.balance(), kSeedAnchorBalanceH2);
 }

--- a/test/test_dash_embedded_gbt.cpp
+++ b/test/test_dash_embedded_gbt.cpp
@@ -61,6 +61,7 @@
 #include <impl/dash/coin/coin_state_maintainer.hpp>    // E2: CoinStateMaintainer (independent advance)
 #include <impl/dash/coin/credit_pool.hpp>              // E2: CreditPool (running accrual)
 #include <impl/dash/coin/block.hpp>                    // E2: BlockType (ingested block)
+#include <impl/dash/coin/block_producer.hpp>           // E2 finding A: compute_merkle_root / block_body_binds_to_header
 
 #include <core/uint256.hpp>
 #include <core/pack.hpp>
@@ -663,7 +664,23 @@ static BlockType e2_block_with_cbtx(int32_t cb_height, int64_t credit_pool) {
     TxIn cin; cin.prevout.hash = uint256::ZERO; cin.prevout.index = 0xffffffffu;
     coinbase.vin.push_back(cin);
     blk.m_txs.push_back(std::move(coinbase));
+    // Bind the body to the header: commit the merkle root over the actual tx set,
+    // so the E2 finding-A guard (block_body_binds_to_header) accepts this block.
+    std::vector<uint256> txids;
+    for (const auto& tx : blk.m_txs) txids.push_back(dash::coin::dash_txid(tx));
+    blk.m_merkle_root = dash::coin::compute_merkle_root(txids);
     return blk;
+}
+
+// A FORGED body: the header commits the real coinbase's merkle root, but the
+// delivered body swaps in a coinbase with a WRONG creditPoolBalance (same
+// nHeight). The merkle root is left committing the real coinbase, so the body no
+// longer binds to the header — a real-PoW-header + forged-body attack.
+static BlockType e2_forged_block(int32_t cb_height, int64_t real_cp,
+                                 int64_t forged_cp) {
+    BlockType blk = e2_block_with_cbtx(cb_height, real_cp);   // root commits real cbTx
+    blk.m_txs[0].extra_payload = e2_cbtx_payload(cb_height, forged_cp);  // swap in forgery
+    return blk;                                              // m_merkle_root NOT updated
 }
 
 static CSimplifiedMNListEntry e2_sml_entry(uint8_t seed) {
@@ -853,4 +870,53 @@ TEST(DashEmbeddedGbt, E2CreditPoolDriftFailsClosedNotSelfReferential) {
     m_ok.on_block_connected(good, H);
     EXPECT_EQ(st_ok.credit_pool_height(), static_cast<int32_t>(H));
     EXPECT_EQ(st_ok.credit_pool(), CP1_correct);
+}
+
+// E2 finding A — a FORGED block body (real PoW header, fake type-5 coinbase with
+// the CORRECT nHeight but a WRONG creditPoolBalance and an unbound merkle root)
+// must be REFUSED at ingestion and must NOT advance the freshness seed. Without
+// the body↔header binding this forgery would ride the non-contiguous bootstrap,
+// advance the gate, and be SERVED as a bad-cbtx — E2 widened this trust surface,
+// so the binding closes it. The verify is discriminating: a well-BOUND block
+// (correct root committing its own coinbase) still advances.
+TEST(DashEmbeddedGbt, E2ForgedBlockBodyRefusedDoesNotAdvanceSeed) {
+    const uint32_t P      = H - 1;
+    const uint256  HASH_P = raw256(0x54);
+    const int64_t  CP0    = 111'000'000'000LL;
+    const int64_t  reward = e2_platform_reward_oracle(H);
+    const int64_t  CP1_real   = CP0 + reward;
+    const int64_t  CP1_forged = CP1_real + 777;   // attacker's fabricated balance
+
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    st.set_credit_pool(CP0, HASH_P, static_cast<int32_t>(P));
+    m.restore_credit_pool(CP0, P);
+
+    // Forged body: right nHeight (H), wrong creditPoolBalance, header still commits
+    // the REAL coinbase → the delivered body does not fold to the committed root.
+    BlockType forged = e2_forged_block(static_cast<int32_t>(H), CP1_real, CP1_forged);
+    ASSERT_FALSE(dash::coin::block_body_binds_to_header(forged))
+        << "the forged body must fail the merkle body↔header binding";
+    // Re-parse confirms the forgery carries the right height but the fake balance.
+    {
+        CCbTx fake;
+        ASSERT_TRUE(parse_cbtx(forged.m_txs[0].extra_payload, fake));
+        ASSERT_EQ(fake.nHeight, static_cast<int32_t>(H));
+        ASSERT_EQ(fake.creditPoolBalance, CP1_forged);
+    }
+    m.on_block_connected(forged, H);
+
+    // Refused: the seed stayed at P — the fabricated balance was never adopted.
+    EXPECT_EQ(st.credit_pool_height(), static_cast<int32_t>(P))
+        << "a forged/unbound body must NOT advance the freshness seed";
+    EXPECT_EQ(st.credit_pool(), CP0);
+    EXPECT_NE(st.credit_pool(), CP1_forged);
+
+    // Discriminating: a well-bound block at H (root commits its own coinbase) IS
+    // accepted and advances — the guard rejects only unbound bodies, not valid ones.
+    BlockType good = e2_block_with_cbtx(static_cast<int32_t>(H), CP1_real);
+    ASSERT_TRUE(dash::coin::block_body_binds_to_header(good));
+    m.on_block_connected(good, H);
+    EXPECT_EQ(st.credit_pool_height(), static_cast<int32_t>(H));
+    EXPECT_EQ(st.credit_pool(), CP1_real);
 }

--- a/test/test_dash_embedded_gbt.cpp
+++ b/test/test_dash_embedded_gbt.cpp
@@ -56,6 +56,11 @@
 #include <impl/dash/coin/transaction.hpp>
 #include <impl/dash/coin/vendor/cbtx.hpp>
 #include <impl/dash/coin/vendor/simplifiedmns.hpp>
+#include <impl/dash/coin/vendor/smldiff.hpp>           // E2: CSimplifiedMNListDiff (restart-seed KAT)
+#include <impl/dash/coin/node_coin_state.hpp>          // E2: NodeCoinState freshness gate
+#include <impl/dash/coin/coin_state_maintainer.hpp>    // E2: CoinStateMaintainer (independent advance)
+#include <impl/dash/coin/credit_pool.hpp>              // E2: CreditPool (running accrual)
+#include <impl/dash/coin/block.hpp>                    // E2: BlockType (ingested block)
 
 #include <core/uint256.hpp>
 #include <core/pack.hpp>
@@ -86,7 +91,12 @@ using dash::coin::compute_merkle_root_quorums;
 using dash::coin::vendor::CCbTx;
 using dash::coin::vendor::CSimplifiedMNList;
 using dash::coin::vendor::CSimplifiedMNListEntry;
+using dash::coin::vendor::CSimplifiedMNListDiff;
 using dash::coin::vendor::parse_cbtx;
+using dash::coin::NodeCoinState;
+using dash::coin::CoinStateMaintainer;
+using dash::coin::BlockType;
+using dash::coin::compute_dash_block_reward_post_v20;
 using ::core::coin::UTXOViewCache;
 using ::core::coin::Outpoint;
 using ::core::coin::Coin;
@@ -603,4 +613,244 @@ TEST(DashEmbeddedGbt, G1GoldenVersionSeamEchoesInjectedVersion) {
     EXPECT_EQ(injected.m_mintime,        baseline.m_mintime);
     EXPECT_EQ(injected.m_coinbase_value, baseline.m_coinbase_value);
     EXPECT_EQ(injected.m_payment_amount, baseline.m_payment_amount);
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// E2 — independent credit-pool advance on ingestion, POST-RESTART.
+//
+// The gap: m_credit_pool is seeded only by the periodic mnlistdiff cbTx, and is
+// NOT persisted. After a warm restart the SML resumes from its persisted tip
+// (#800), but the credit pool re-seeds to nothing until the NEXT mnlistdiff —
+// so for the tip that existed AT restart the credit-pool freshness gate fails
+// closed and the daemonless arm falls back to dashd.
+//
+// The fix (verified here):
+//   (1) persist the credit-pool tip alongside the SML (same blockHash/height)
+//       and RESTORE it on warm restart, so the gate is live at the restart tip;
+//   (2) ADVANCE the pool INDEPENDENTLY on every ingested block, verified against
+//       that block's OWN from-wire cbTx creditPoolBalance at nHeight == height —
+//       NOT against a template we built from the seed (the self-consistent-but-
+//       stale trap that refuted 3 prior soaks).
+//
+// Oracle discipline: the block's committed creditPoolBalance is built from the
+// raw dashcore platform-share formula (subsidy*3/4*375/1000, recomputed here),
+// and we assert the maintainer's independent accrual reproduces exactly that
+// from-wire value — two independent derivations meeting, never a self-check.
+// ════════════════════════════════════════════════════════════════════════
+
+// v3 CCbTx extra_payload at a given height carrying a given creditPoolBalance.
+static std::vector<unsigned char> e2_cbtx_payload(int32_t cb_height,
+                                                  int64_t credit_pool) {
+    CCbTx cb;
+    cb.nVersion          = CCbTx::VERSION_CLSIG_AND_BALANCE;
+    cb.nHeight           = cb_height;
+    cb.creditPoolBalance = credit_pool;
+    return dash::coin::encode_cbtx(cb);
+}
+
+// A block whose coinbase (tx 0) is a type-5 CbTx committing creditPoolBalance at
+// cb_height. No special asset-lock/unlock txs, so the per-block accrual reduces
+// to the platform-reward term (the mainnet steady state at H).
+static BlockType e2_block_with_cbtx(int32_t cb_height, int64_t credit_pool) {
+    BlockType blk;
+    blk.m_bits = 0x1b104be3u;                 // non-null header (identity hashable)
+    MutableTransaction coinbase;
+    coinbase.version       = 3;
+    coinbase.type          = 5;               // CbTx
+    coinbase.extra_payload = e2_cbtx_payload(cb_height, credit_pool);
+    // A coinbase input (prevout null) — not inspected by the credit-pool walk
+    // (it skips tx 0), present only so the block looks well-formed.
+    TxIn cin; cin.prevout.hash = uint256::ZERO; cin.prevout.index = 0xffffffffu;
+    coinbase.vin.push_back(cin);
+    blk.m_txs.push_back(std::move(coinbase));
+    return blk;
+}
+
+static CSimplifiedMNListEntry e2_sml_entry(uint8_t seed) {
+    CSimplifiedMNListEntry e;
+    e.proRegTxHash  = raw256(seed);
+    e.confirmedHash = raw256(seed + 1);
+    e.isValid = true;
+    return e;
+}
+
+// mnlistdiff carrying a type-5 cbTx seed (credit pool @ cb_height).
+static CSimplifiedMNListDiff e2_diff_with_seed(const uint256& base,
+                                               const uint256& block,
+                                               int32_t cb_height,
+                                               int64_t credit_pool) {
+    CSimplifiedMNListDiff d;
+    d.baseBlockHash = base;
+    d.blockHash     = block;
+    d.mnList = {e2_sml_entry(0x40)};
+    d.cbTx.version       = 3;
+    d.cbTx.type          = 5;
+    d.cbTx.extra_payload = e2_cbtx_payload(cb_height, credit_pool);
+    return d;
+}
+
+static std::vector<std::pair<uint256, MNState>>
+e2_mn_pairs(const std::vector<unsigned char>& payout) {
+    MNState s;
+    s.isValid = true;
+    s.nRegisteredHeight = 2'300'000;
+    s.nLastPaidHeight = 0;
+    s.scriptPayout.m_data = payout;
+    return std::vector<std::pair<uint256, MNState>>{{raw256(0x01), s}};
+}
+
+// The independent platform-reward oracle at a height (raw dashcore formula,
+// truncation order preserved), NOT compute_dash_platform_reward_post_v20_mn_rr.
+static int64_t e2_platform_reward_oracle(uint32_t height) {
+    int64_t mn_share = compute_dash_block_reward_post_v20(height) * 3 / 4;
+    return mn_share * 375 / 1000;
+}
+
+TEST(DashEmbeddedGbt, E2CreditPoolIndependentAdvancePostRestart) {
+    // Snapshot tip at P = H-1; the first post-restart block is at H.
+    const uint32_t P       = H - 1;
+    const uint256  HASH_P  = raw256(0x54);
+    const int64_t  CP0     = 111'000'000'000LL;             // snapshot balance @ P
+    const int64_t  reward  = e2_platform_reward_oracle(H);  // locked at block H
+    ASSERT_GT(reward, 0) << "H must be past MN_RR so the platform burn is active";
+    const int64_t  CP1     = CP0 + reward;                  // committed balance @ H
+
+    // ── Pre-restart: a cold snapshot seeds + PERSISTS the credit pool @ P. ──
+    uint256 persist_hash; uint32_t persist_h = 0; int64_t persist_bal = 0; bool persisted = false;
+    {
+        NodeCoinState st;
+        CoinStateMaintainer m(st);
+        m.set_on_credit_pool_persist(
+            [&](const uint256& h, uint32_t ht, int64_t bal) {
+                persist_hash = h; persist_h = ht; persist_bal = bal; persisted = true;
+            });
+        m.on_mnlistdiff(e2_diff_with_seed(uint256::ZERO, HASH_P,
+                                          static_cast<int32_t>(P), CP0));
+        ASSERT_EQ(st.credit_pool(), CP0);
+        ASSERT_EQ(st.credit_pool_height(), static_cast<int32_t>(P));
+        ASSERT_TRUE(persisted) << "an accepted diff with a v3 cbTx must persist the pool tip";
+        EXPECT_EQ(persist_hash, HASH_P);
+        EXPECT_EQ(persist_h, P);
+        EXPECT_EQ(persist_bal, CP0);
+    }
+
+    // Helper: simulate a warm SML restore (loaded from SMLDb directly, NOT via a
+    // diff), so the credit pool is the ONLY axis under test.
+    auto warm_restore_sml = [&](NodeCoinState& st) {
+        st.sml() = CSimplifiedMNList(std::vector<CSimplifiedMNListEntry>{e2_sml_entry(0x40)});
+        st.set_have_sml(true);
+        st.set_sml_current_hash(HASH_P);
+    };
+    auto arm_full_bundle = [&](NodeCoinState& st, CoinStateMaintainer& m) {
+        st.set_require_sml(true);
+        st.set_require_fresh_credit_pool(true);
+        m.on_mn_list_update(e2_mn_pairs(p2pkh_script(0x30)));
+        m.on_new_tip(P, HASH_P, 0x1b104be3u, 1'700'000'000u, DASH_PUBKEY_VER, DASH_P2SH_VER);
+    };
+
+    // ── Restart WITHOUT the credit-pool restore (the bug): SML resumes @ P but
+    //    the pool is unseeded (height -1) → the freshness gate fails closed. ──
+    {
+        NodeCoinState st;
+        CoinStateMaintainer m(st);
+        warm_restore_sml(st);
+        arm_full_bundle(st, m);
+        EXPECT_EQ(st.credit_pool_height(), -1)
+            << "without persistence the pool is unseeded at the restart tip";
+        EXPECT_FALSE(st.make_embedded_work_inputs().viable())
+            << "unseeded credit pool at the restart tip must fail closed to dashd fallback";
+    }
+
+    // ── Restart WITH the credit-pool restore (the fix): pool resumes @ P, the
+    //    gate is live at the restart tip, and the first ingested block advances
+    //    the pool INDEPENDENTLY, VERIFIED against its own from-wire cbTx. ──
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    warm_restore_sml(st);
+    // Restore both the freshness seed (NodeCoinState) and the running accrual.
+    st.set_credit_pool(persist_bal, persist_hash, static_cast<int32_t>(persist_h));
+    m.restore_credit_pool(persist_bal, persist_h);
+    arm_full_bundle(st, m);
+    EXPECT_EQ(st.credit_pool_height(), static_cast<int32_t>(P));
+    EXPECT_EQ(st.credit_pool(), CP0);
+    EXPECT_TRUE(st.make_embedded_work_inputs().viable())
+        << "restored credit pool current at the restart tip must serve daemonlessly";
+
+    // First incremental block @ H carrying the from-wire committed balance CP1.
+    BlockType blk = e2_block_with_cbtx(static_cast<int32_t>(H), CP1);
+    // Sanity: the block's OWN coinbase commits CP1 at nHeight H (the independent
+    // source of truth the advance is verified against — re-parsed here).
+    {
+        CCbTx from_wire;
+        ASSERT_TRUE(parse_cbtx(blk.m_txs[0].extra_payload, from_wire));
+        ASSERT_EQ(from_wire.nHeight, static_cast<int32_t>(H));
+        ASSERT_EQ(from_wire.creditPoolBalance, CP1);
+    }
+    m.on_block_connected(blk, H);
+    // The pool advanced to the tip, matching the block's OWN committed value.
+    EXPECT_EQ(st.credit_pool_height(), static_cast<int32_t>(H))
+        << "the pool must advance to the ingested block's height independently";
+    EXPECT_EQ(st.credit_pool(), CP1)
+        << "advance must equal the block's from-wire committed creditPoolBalance";
+    // Non-self-referential: the advanced value equals CP0 + the INDEPENDENTLY
+    // derived platform reward, i.e. the seed plus this block's own accrual —
+    // reproduced from the raw formula, not read back off a template we built.
+    EXPECT_EQ(st.credit_pool(), CP0 + e2_platform_reward_oracle(H));
+
+    // The advanced pool is fresh at the new tip → still serves at H.
+    m.on_new_tip(H, raw256(0x55), 0x1b104be3u, 1'700'000'000u, DASH_PUBKEY_VER, DASH_P2SH_VER);
+    // (sml_current_hash must also be at the new tip for full viability; the
+    // credit-pool axis specifically is proven fresh below regardless.)
+    EXPECT_EQ(st.credit_pool_height(), static_cast<int32_t>(H));
+}
+
+// E2 — the independent verify is REAL: a block whose coinbase commits a WRONG
+// creditPoolBalance (inconsistent with the accrual) is REJECTED — the freshness
+// seed is NOT advanced, so the arm fails closed rather than serving a bad-cbtx
+// balance. A self-referential built==seed+reward check could not catch this
+// (it would happily rebuild the wrong value); comparing our independent accrual
+// to the block's own committed value does.
+TEST(DashEmbeddedGbt, E2CreditPoolDriftFailsClosedNotSelfReferential) {
+    const uint32_t P      = H - 1;
+    const uint256  HASH_P = raw256(0x54);
+    const int64_t  CP0    = 111'000'000'000LL;
+    const int64_t  reward = e2_platform_reward_oracle(H);
+    const int64_t  CP1_correct = CP0 + reward;
+    const int64_t  CP1_wrong   = CP1_correct + 1;   // off-by-one bad-cbtx
+
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    // Warm-restore the pool @ P (contiguous predecessor of block H).
+    st.sml() = CSimplifiedMNList(std::vector<CSimplifiedMNListEntry>{e2_sml_entry(0x40)});
+    st.set_have_sml(true);
+    st.set_sml_current_hash(HASH_P);
+    st.set_credit_pool(CP0, HASH_P, static_cast<int32_t>(P));
+    m.restore_credit_pool(CP0, P);
+
+    // A block @ H whose committed balance disagrees with the accrual by 1 duff.
+    BlockType bad = e2_block_with_cbtx(static_cast<int32_t>(H), CP1_wrong);
+    m.on_block_connected(bad, H);
+
+    // Fail closed: the freshness seed stayed at P (did NOT advance to H), so with
+    // the tip at H the credit-pool gate refuses the arm — the invariant "never
+    // serve a wrong creditPoolBalance" holds by failing to fallback, not by
+    // adopting the bad value.
+    EXPECT_EQ(st.credit_pool_height(), static_cast<int32_t>(P))
+        << "a drifted (bad-cbtx) balance must NOT advance the freshness seed";
+    EXPECT_NE(st.credit_pool(), CP1_wrong)
+        << "the wrong committed balance must never be adopted as the seed";
+    EXPECT_EQ(st.credit_pool(), CP0)
+        << "the seed must remain the last independently-confirmed value";
+
+    // Contrast — the SAME block with the CORRECT committed balance DOES verify
+    // (contiguous advance from the restored P) and advances the seed to H. This
+    // is what proves the check is discriminating, not merely always-refusing.
+    NodeCoinState st_ok;
+    CoinStateMaintainer m_ok(st_ok);
+    st_ok.set_credit_pool(CP0, HASH_P, static_cast<int32_t>(P));
+    m_ok.restore_credit_pool(CP0, P);
+    BlockType good = e2_block_with_cbtx(static_cast<int32_t>(H), CP1_correct);
+    m_ok.on_block_connected(good, H);
+    EXPECT_EQ(st_ok.credit_pool_height(), static_cast<int32_t>(H));
+    EXPECT_EQ(st_ok.credit_pool(), CP1_correct);
 }

--- a/test/test_dash_live_feed_bridge.cpp
+++ b/test/test_dash_live_feed_bridge.cpp
@@ -26,6 +26,8 @@
 #include <impl/dash/coin/header_chain.hpp>
 #include <impl/dash/coin/node_interface.hpp>
 #include <impl/dash/coin/block.hpp>
+#include <impl/dash/coin/block_producer.hpp>   // compute_merkle_root (E2 finding A body↔header bind)
+#include <impl/dash/coin/utxo_adapter.hpp>     // dash_txid
 
 #include <core/pack.hpp>
 #include <core/uint256.hpp>
@@ -53,10 +55,22 @@ BlockType make_block(uint8_t seed) {
     BlockType b;
     b.m_version        = 0x20000000u | seed;
     b.m_previous_block.SetHex("00");
-    b.m_merkle_root.SetHex("00");
     b.m_timestamp      = 1'700'000'000u + seed;
     b.m_bits           = 0x1e0ffff0u;
     b.m_nonce          = 0x12340000u + seed;
+    // A minimal coinbase so the body binds to the header (E2 finding A: the
+    // bridge now verifies the tx set folds to the committed merkle root before
+    // firing block_connected). A real P2P block always carries a coinbase.
+    dash::coin::MutableTransaction cb;
+    cb.version = 1; cb.type = 0; cb.locktime = seed;
+    ::bitcoin_family::coin::TxIn in;
+    in.prevout.hash = uint256::ZERO; in.prevout.index = 0xffffffffu;
+    in.sequence = 0xffffffffu;
+    cb.vin.push_back(in);
+    b.m_txs.push_back(cb);
+    std::vector<uint256> ids;
+    for (const auto& tx : b.m_txs) ids.push_back(dash::coin::dash_txid(tx));
+    b.m_merkle_root = dash::coin::compute_merkle_root(ids);
     return b;
 }
 

--- a/test/test_dash_mn_seed.cpp
+++ b/test/test_dash_mn_seed.cpp
@@ -31,6 +31,8 @@
 #include <impl/dash/coin/mn_list_ingest.hpp>       // wire_mn_list_ingest (leg 4)
 #include <impl/dash/coin/tip_ingest.hpp>           // wire_tip_ingest (leg 2)
 #include <impl/dash/coin/block_connect_ingest.hpp> // wire_block_connect_ingest (leg 3)
+#include <impl/dash/coin/block_producer.hpp>        // compute_merkle_root (E2 finding A body↔header bind)
+#include <impl/dash/coin/utxo_adapter.hpp>          // dash_txid
 #include <impl/dash/coin/coin_state_maintainer.hpp>
 #include <impl/dash/coin/node_coin_state.hpp>
 #include <impl/dash/coin/rpc_data.hpp>
@@ -344,6 +346,10 @@ TEST(DashMnSeed, SnapshotHeightFencesReplayedBlocks)
         o.scriptPubKey.m_data = shared;
         cb.vout.push_back(o);
         bc.block.m_txs.push_back(cb);
+        // Bind the body to the header (E2 finding A) so on_block_connected accepts it.
+        std::vector<uint256> ids;
+        for (const auto& tx : bc.block.m_txs) ids.push_back(dash::coin::dash_txid(tx));
+        bc.block.m_merkle_root = dash::coin::compute_merkle_root(ids);
         return bc;
     };
     auto bc_old = paying_block(2'399'901);

--- a/test/test_dash_node_reception_wire.cpp
+++ b/test/test_dash_node_reception_wire.cpp
@@ -40,6 +40,7 @@
 #include <impl/dash/coin/block.hpp>
 #include <impl/dash/coin/mempool.hpp>
 #include <impl/dash/coin/utxo_adapter.hpp>
+#include <impl/dash/coin/block_producer.hpp>   // compute_merkle_root (E2 finding A body↔header bind)
 #include <impl/dash/coin/rpc_data.hpp>
 #include <impl/dash/coin/transaction.hpp>
 
@@ -100,6 +101,15 @@ static MutableTransaction make_spend(const uint256& prev, uint32_t idx,
     TxOut o; o.value = out_value;
     tx.vout.push_back(o);
     return tx;
+}
+
+// Bind a hand-built block to its header so the E2 finding-A body↔header guard
+// (block_body_binds_to_header, enforced in on_block_connected) accepts it — as a
+// real PoW-headed, P2P-delivered block is bound.
+static void bind_block(dash::coin::BlockType& b) {
+    std::vector<uint256> ids;
+    for (const auto& tx : b.m_txs) ids.push_back(dash::coin::dash_txid(tx));
+    b.m_merkle_root = dash::coin::compute_merkle_root(ids);
 }
 
 static std::vector<std::pair<uint256, MNState>> single_mn(const std::vector<unsigned char>& payout) {
@@ -312,6 +322,7 @@ TEST(DashReceptionWire, BlockConnectRelayDrivesApplyBlockThenDemotes) {
     bc.height = H;
     bc.block.m_txs.push_back(make_spend(raw256(0x90), 0, 500'000'000, 1));  // cb (idx 0, skipped)
     bc.block.m_txs.push_back(make_spend(coll, 3, 400'000'000, 2));          // spends MN collateral
+    bind_block(bc.block);
     node.block_connected.happened(bc);
 
     EXPECT_EQ(st.mnstates().size(), 0u) << "apply_block (via wire) must remove the MN";
@@ -344,6 +355,7 @@ TEST(DashReceptionWire, BlockConnectRelayNoSpecialTxPreservesReadiness) {
     bc.height = H;
     bc.block.m_txs.push_back(make_spend(raw256(0x90), 0, 500'000'000, 1));  // cb (idx 0, skipped)
     bc.block.m_txs.push_back(make_spend(raw256(0x91), 0, 400'000'000, 2));  // plain spend, no collateral
+    bind_block(bc.block);
     node.block_connected.happened(bc);
 
     EXPECT_EQ(st.mnstates().size(), 1u) << "no-special-tx block must not touch the DMN set";
@@ -374,6 +386,7 @@ TEST(DashReceptionWire, DisposeStopsBlockConnectIngest) {
     bc.height = H;
     bc.block.m_txs.push_back(make_spend(raw256(0x90), 0, 500'000'000, 1));  // cb (idx 0, skipped)
     bc.block.m_txs.push_back(make_spend(coll, 3, 400'000'000, 2));          // would spend MN collateral
+    bind_block(bc.block);
     node.block_connected.happened(bc);
 
     EXPECT_EQ(st.mnstates().size(), 1u) << "after dispose, a connected block must not be applied";


### PR DESCRIPTION
## E2 — full daemonless independence for the DIP-0027 credit pool

### The gap
`m_credit_pool` advanced **only** when the periodic `mnlistdiff` re-seeded it from the diff's cbTx, and was **never persisted**. After a warm restart the SML resumes from its persisted tip (#800 / `SMLDb`+`QuorumDb`), but the credit pool re-seeds to nothing until the *next* `mnlistdiff` — so for the tip that existed **at restart** the credit-pool freshness gate fails closed and the daemonless arm falls back to `dashd` (the restart-seed case). `CreditPool` (`credit_pool.hpp`) and `CreditPoolDb` (`credit_pool_db.hpp`) existed but were entirely unwired.

### Mechanism (two independent legs)
- **Per-block advance** — `CoinStateMaintainer::on_block_connected` now folds *this block's own* credit-pool accrual (platform-reward + Σ assetLocks − Σ assetUnlocks) through a running `CreditPool` state machine, so the balance tracks the tip on **every ingested block**, not only at `mnlistdiff` cadence. Wired ahead of the MN-snapshot fence (distinct axis). `CreditPool::apply_block` gains the platform-reward accrual term.
- **Restart persistence** — `CreditPoolDb` is written per accepted `mnlistdiff` with the **same `(blockHash, height)`** the SML persist uses, so its tip tracks `SMLDb`. On warm restart, when the persisted credit-pool tip matches the SML tip (sentinel), both the `NodeCoinState` freshness seed **and** the running accrual are restored — the gate is live at the restart tip and the first ingested block advances contiguously. Reorg/heal wipes the accrual + the persisted store alongside SML/quorum.

### The INDEPENDENT (non-self-referential) verify
The 3 prior soaks were refuted because a self-referential check (`built == seed + reward`) proves the template is internally consistent — **not** that the seed is correct — so a stale seed sailed through.

Here, every ingested block commits, **in its own coinbase CCbTx**, dashd's `creditPoolBalance` for that height. The running accrual is advanced across the block and **required to equal that from-wire committed value at `nHeight == connected height`**. That compares two genuinely independent derivations — our recomputation vs the network's committed value at the same height — never a template against its own seed. The seed height is taken straight off the wire, so it can never be mistaken as current at an unobserved height (the exact stale-seed trap).

**Invariant preserved:** on drift the freshness seed is **not** advanced (fail closed to the reward-safe `dashd` fallback) and the accrual re-anchors to the wire value. The fix makes the advance *correct*, it does **not** relax the gate. The pre-emit GBT-xcheck + fail-closed-to-fallback remain as the maturation safety net.

### Restart KAT (folded into `test_dash_embedded_gbt`)
`E2CreditPoolIndependentAdvancePostRestart` models the sequence:
1. cold snapshot seeds + **persists** the pool @ P;
2. warm restart **without** restore → gate fails closed at the restart tip (the bug reproduced);
3. warm restart **with** restore → serves at the restart tip;
4. first incremental block @ P+1 advances the pool to its from-wire committed value — cross-checked against an **independently re-derived** platform reward (raw dashcore `subsidy*3/4*375/1000`), not self-referentially.

`E2CreditPoolDriftFailsClosedNotSelfReferential` proves the verify is discriminating: an off-by-one **bad-cbtx** block fails closed (seed stays at P), while the correct block verifies and advances to H.

### Build + tests
- `c2pool-dash` builds + links clean.
- `test_dash_embedded_gbt`: **25/25** pass (incl. 2 new E2 KATs).
- `test_dash_coin_state_maintainer`: **11/11** pass (no regression on the existing SML/credit-pool suites).

### Files
- `src/impl/dash/coin/credit_pool.hpp` — `apply_block` platform-reward accrual term.
- `src/impl/dash/coin/coin_state_maintainer.hpp` — per-block advance + independent verify, mnlistdiff re-anchor + aligned persist, restore + persist hooks, reorg wipe.
- `src/c2pool/main_dash.cpp` — `CreditPoolDb` open / warm-restore (sentinel vs SML tip) / persist / clear wiring.
- `test/test_dash_embedded_gbt.cpp` — restart + drift KATs.

**Do NOT merge** — integrator review + soak gate (this area is soak-sensitive; empirical soak is authoritative over review here).
