### PR TITLE
dash(embedded): daemonless type-6 quorum + superblock sourcing at DKG/superblock heights [E1 — full independence]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,50 @@ else()
     set(SECP256K1_INCLUDE_DIRS "")
 endif()
 
+# ── E1 Phase-L: optional dashbls (BLS12-381) backend for type-6 quorum-
+# commitment verification ────────────────────────────────────────────────────
+# dashpay/bls-signatures ("dashbls", relic-backed, Apache-2.0) — the SAME
+# library dashd wraps in src/bls/bls.h. OPT-IN and DASH-ONLY: only the DASH impl
+# (dash_bls_verify) + its KAT consume it, never the shared core the Windows
+# main_ltc launcher builds ([[reference_windows_ci_conan_flake]]: Windows CI
+# builds only the LTC launcher, so DASH-only BLS code cannot break it). When the
+# option is OFF (default) or the library is not found, dash_bls_verify compiles a
+# fail-closed stub and the DKG-window serve path keeps the pre-Phase-L
+# null-commitment posture exactly — no dashbls dependency enters any build.
+#
+# Build the library once for the CI factory with scripts/build_dashbls.sh (pins
+# the exact upstream commit); point cmake at it with -DDASHBLS_ROOT=<prefix>.
+option(C2POOL_DASH_BLS "Link dashbls (BLS12-381) for E1 Phase-L real quorum-commitment verify" OFF)
+set(C2POOL_DASH_BLS_AVAILABLE OFF)
+if(C2POOL_DASH_BLS)
+    # Honour a DASHBLS_ROOT hint (the build-factory install prefix), else search
+    # the system paths. dashbls installs: include/dashbls/*.hpp,
+    # lib/libdashbls.a, lib/librelic_s.a, lib/mimalloc-2.0/libmimalloc-secure.a.
+    find_path(DASHBLS_INCLUDE_DIR dashbls/bls.hpp
+        HINTS ${DASHBLS_ROOT} ENV DASHBLS_ROOT PATH_SUFFIXES include)
+    find_library(DASHBLS_LIB       NAMES dashbls bls-dash
+        HINTS ${DASHBLS_ROOT} ENV DASHBLS_ROOT PATH_SUFFIXES lib)
+    find_library(DASHBLS_RELIC_LIB NAMES relic_s relic
+        HINTS ${DASHBLS_ROOT} ENV DASHBLS_ROOT PATH_SUFFIXES lib)
+    find_library(DASHBLS_MIMALLOC_LIB NAMES mimalloc-secure mimalloc
+        HINTS ${DASHBLS_ROOT} ENV DASHBLS_ROOT PATH_SUFFIXES lib lib/mimalloc-2.0 lib/mimalloc-2.1)
+    find_library(DASHBLS_GMP_LIB NAMES gmp)
+    if(DASHBLS_INCLUDE_DIR AND DASHBLS_LIB AND DASHBLS_RELIC_LIB AND DASHBLS_GMP_LIB)
+        set(C2POOL_DASH_BLS_AVAILABLE ON)
+        set(DASHBLS_LIBRARIES ${DASHBLS_LIB} ${DASHBLS_RELIC_LIB})
+        if(DASHBLS_MIMALLOC_LIB)
+            list(APPEND DASHBLS_LIBRARIES ${DASHBLS_MIMALLOC_LIB})
+        endif()
+        list(APPEND DASHBLS_LIBRARIES ${DASHBLS_GMP_LIB})
+        message(STATUS "dashbls found (E1 Phase-L BLS verify ENABLED): ${DASHBLS_LIB}")
+        message(STATUS "dashbls includes: ${DASHBLS_INCLUDE_DIR}")
+    else()
+        message(WARNING "C2POOL_DASH_BLS=ON but dashbls not found "
+            "(need dashbls + relic + gmp; run scripts/build_dashbls.sh and pass "
+            "-DDASHBLS_ROOT=<prefix>). Falling back to fail-closed null-serve.")
+    endif()
+endif()
+
 # Enable testing only if GTest is found
 if(GTest_FOUND OR GTEST_FOUND)
     enable_testing()

--- a/scripts/build_dashbls.sh
+++ b/scripts/build_dashbls.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Build + install dashpay/bls-signatures ("dashbls") for the c2pool E1 Phase-L
+# BLS quorum-commitment verifier. This is the SAME library dashd wraps in
+# src/bls/bls.h (libdashbls 2.0, relic-backed, Apache-2.0). It is NOT on
+# ConanCenter, so — like secp256k1 — c2pool consumes it as a prebuilt system
+# library (find_library in the root CMakeLists, gated by -DC2POOL_DASH_BLS=ON).
+# Run this once on the CI build factory / dev host, then configure c2pool with:
+#
+#     cmake -DC2POOL_DASH_BLS=ON -DDASHBLS_ROOT=<PREFIX> ...
+#
+# Requires: cmake, a C++17 compiler, and libgmp-dev (relic ARITH=gmp backend).
+#
+# Pinned to the exact upstream commit dash v23.1.x vendors as src/dashbls
+# (libdashbls 2.0 / relic 0.5.0). RE-PIN in lockstep with the vendored-dashcore
+# bump that moves vendor/llmq_commitment.hpp (same discipline as dkg_window.hpp).
+set -euo pipefail
+
+DASHBLS_REPO="${DASHBLS_REPO:-https://github.com/dashpay/bls-signatures.git}"
+# libdashbls 2.0 (dash v23.1.x src/dashbls subtree; relic backend, basic+legacy
+# BLS schemes). Pin by commit for a reproducible, offline-cacheable build.
+DASHBLS_COMMIT="${DASHBLS_COMMIT:-dd683653c6eaba7235bc9c600f46bafbb8210291}"
+PREFIX="${1:-${DASHBLS_ROOT:-/opt/dashbls}}"
+BUILD_DIR="${BUILD_DIR:-/tmp/dashbls-build}"
+JOBS="${JOBS:-$(nproc 2>/dev/null || echo 4)}"
+
+echo "[build_dashbls] repo=$DASHBLS_REPO commit=$DASHBLS_COMMIT prefix=$PREFIX"
+
+rm -rf "$BUILD_DIR"
+git clone "$DASHBLS_REPO" "$BUILD_DIR/src"
+git -C "$BUILD_DIR/src" checkout --quiet "$DASHBLS_COMMIT"
+
+cmake -S "$BUILD_DIR/src" -B "$BUILD_DIR/build" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+    -DBUILD_BLS_TESTS=0 \
+    -DBUILD_BLS_BENCHMARKS=0 \
+    -DBUILD_BLS_PYTHON_BINDINGS=0 \
+    -DBUILD_BLS_JS_BINDINGS=0
+
+cmake --build "$BUILD_DIR/build" -j "$JOBS"
+cmake --install "$BUILD_DIR/build"
+
+echo "[build_dashbls] installed:"
+find "$PREFIX" -name 'libdashbls*' -o -name 'librelic*' -o -name 'bls.hpp' | sed 's/^/  /'
+echo "[build_dashbls] done — configure c2pool with -DC2POOL_DASH_BLS=ON -DDASHBLS_ROOT=$PREFIX"

--- a/src/c2pool/CMakeLists.txt
+++ b/src/c2pool/CMakeLists.txt
@@ -322,6 +322,10 @@ target_link_libraries(c2pool-dash
     dash_block_replay  # E1: coin/vendor/blockencodings.cpp — the coin-network P2P Handler
                        # (cmpctblock codec) the opt-in CoinClient instantiates ODR-uses
                        # CBlockHeaderAndShortTxIDs::FillShortTxIDSelector()
+    dash_bls_verify    # E1 Phase-L: real type-6 quorum-commitment BLS verify
+                       # (make_commitment_bls_verifier -> set_bls_verify_fn seam).
+                       # Carries the C2POOL_DASH_BLS define + dashbls libs PUBLIC
+                       # when the backend was found; fail-closed stub otherwise.
     btclibs
     yaml-cpp::yaml-cpp
     nlohmann_json::nlohmann_json

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -59,6 +59,7 @@
 #include <impl/dash/coin/zmq_tip_notify.hpp> // dash::coin::TipHashDedup / ZmqHashblockSubscriber — dashd ZMQ hashblock INSTANT tip-notify (opt-in, hardening on the #770 poll)
 #include <impl/dash/coin/node_coin_state.hpp>  // dash::coin::NodeCoinState (embedded work bundle)
 #include <impl/dash/coin/dkg_window.hpp>       // dash::coin::is_dkg_commitment_window (BLOCKER-1 guard)
+#include <impl/dash/coin/dkg_commitments.hpp>  // E1: build_daemonless_qc_plan (serve DKG windows daemonlessly)
 #include <impl/dash/coin/utxo_lane.hpp>    // dash::coin::UtxoLane — embedded UTXO/fee lane (E2b, #738)
 #include <impl/dash/coin/header_chain.hpp>       // dash::coin::HeaderChain — SPV header/tip authority (E2a)
 #include <impl/dash/coin/coin_state_maintainer.hpp>  // dash::coin::CoinStateMaintainer — populate ordering gate (E2a)
@@ -1521,10 +1522,74 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         // must include them (which the mnlistdiff-fed set omits) — the embedded
         // arm would produce a bad-qc-missing / wrong-root block. Fail closed to
         // the reward-safe dashd fallback at those heights (it builds the qc block).
+        // With the E1 qc plan below installed this fn is the DORMANT fallback
+        // posture (the plan supersedes it); it stays authoritative whenever the
+        // plan is not installed.
         node_coin_state.set_commitment_window_fn(
             [](uint32_t next_height) {
                 return dash::coin::is_dkg_commitment_window(next_height);
             });
+
+        // E1 — daemonless DKG-window serving (dkg_commitments.hpp). Where the
+        // embedded arm is enabled (testnet, or mainnet behind the explicit
+        // --embedded-mainnet gate-lift; default OFF), DKG mining-window heights
+        // are SERVED instead of refused: the mandatory type-6 commitment set is
+        // derived from local state only — params-table math + quorum base
+        // hashes off the embedded header chain + the mnlistdiff-fed
+        // QuorumManager as dashd's HasMinedCommitment — and filled with the
+        // consensus-valid NULL commitments dashd's own miner mines when it
+        // holds no verified DKG result (real relayed commitments are Phase L,
+        // behind a BLS verifier). merkleRootQuorums stays the PROVEN
+        // active-set root (null commitments never fold in). Any height where
+        // the set cannot be derived (header gap, below the per-network V19
+        // serve floor — which also covers --regtest chains riding the testnet
+        // flag) yields nullopt and the arm fails closed to the dashd fallback,
+        // exactly the old refusal. The emit gate re-derives this same plan and
+        // hard-rejects any template whose type-6 set drifts from it.
+        if (testnet || embedded_mainnet) {
+            const auto qc_net = testnet ? dash::coin::LlmqNetwork::Testnet
+                                        : dash::coin::LlmqNetwork::Mainnet;
+            // Phase-L sourcing leg: collect REAL relayed DKG commitments off
+            // the coin-P2P qfcommit stream (structural admission only). The
+            // cache serves NOTHING into templates until a BLS12-381 verifier
+            // is installed (MineableCommitmentCache::set_bls_verify_fn — the
+            // exact Phase-L follow-up); until then every required slot mines
+            // the consensus-valid null commitment, same as dashd without a
+            // DKG result. [QC-MINEABLE] is the field-checkable signal that
+            // the sourcing leg is live.
+            auto qc_cache =
+                std::make_shared<dash::coin::MineableCommitmentCache>();
+            coin_feed_subs.push_back(
+                coin_state.new_qfcommit.subscribe(
+                    [qc_cache, qc_net]
+                    (const dash::coin::vendor::CFinalCommitment& c) {
+                        if (qc_cache->ingest(qc_net, c)) {
+                            LOG_INFO << "[QC-MINEABLE] cached commitment type="
+                                     << static_cast<int>(c.llmqType)
+                                     << " quorum="
+                                     << c.quorumHash.GetHex().substr(0, 16)
+                                     << "... signers=" << c.CountSigners()
+                                     << " cache=" << qc_cache->size()
+                                     << " (inclusion pending Phase-L BLS)";
+                        }
+                    }));
+            node_coin_state.set_qc_plan_fn(
+                [&node_coin_state, hc = header_chain.get(), qc_net, qc_cache]
+                (uint32_t next_h) -> std::optional<dash::coin::QcBlockPlan> {
+                    return dash::coin::build_daemonless_qc_plan(
+                        qc_net, next_h, node_coin_state.qmgr(),
+                        [hc](uint32_t h) -> std::optional<uint256> {
+                            if (auto e = hc->get_header_by_height(h))
+                                return e->hash;
+                            return std::nullopt;
+                        },
+                        [hc](const uint256& qh) -> std::optional<uint32_t> {
+                            if (auto e = hc->get_header(qh)) return e->height;
+                            return std::nullopt;
+                        },
+                        qc_cache.get());
+                });
+        }
 
         // review PR #780 BLOCKER-2 (HIGH): refuse the embedded arm on a stale or
         // absent bestCL (dashcore CheckCbTxBestChainlock rejects null/older CL).

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -60,6 +60,7 @@
 #include <impl/dash/coin/node_coin_state.hpp>  // dash::coin::NodeCoinState (embedded work bundle)
 #include <impl/dash/coin/dkg_window.hpp>       // dash::coin::is_dkg_commitment_window (BLOCKER-1 guard)
 #include <impl/dash/coin/dkg_commitments.hpp>  // E1: build_daemonless_qc_plan (serve DKG windows daemonlessly)
+#include <impl/dash/coin/vendor/bls_verify.hpp>  // E1 Phase-L: make_commitment_bls_verifier (real qc verify seam)
 #include <impl/dash/coin/utxo_lane.hpp>    // dash::coin::UtxoLane — embedded UTXO/fee lane (E2b, #738)
 #include <impl/dash/coin/header_chain.hpp>       // dash::coin::HeaderChain — SPV header/tip authority (E2a)
 #include <impl/dash/coin/coin_state_maintainer.hpp>  // dash::coin::CoinStateMaintainer — populate ordering gate (E2a)
@@ -1559,6 +1560,41 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             // the sourcing leg is live.
             auto qc_cache =
                 std::make_shared<dash::coin::MineableCommitmentCache>();
+
+            // Phase-L VERIFY leg: install the dashbls-backed verifier on the
+            // cache. verified_for() will only yield a REAL commitment once this
+            // passes dashcore's CFinalCommitment::Verify (membersSig aggregate
+            // over the signers' operator keys + quorumSig against
+            // quorumPublicKey, both over BuildCommitmentHash). The verifier
+            // sources the ordered member operator key set via the provider
+            // below; anything it cannot establish with certainty fails CLOSED
+            // (verified_for -> nullopt -> the slot mines the consensus-valid
+            // null commitment, exactly the pre-Phase-L posture — reward-safe).
+            //
+            // MEMBER-SET RESIDUAL: the deterministic quorum member selection
+            // (dashcore llmq/utils.cpp ComputeQuorumMembers: score = hash over
+            // proRegTxHash/confirmedHash with the per-quorum modifier, taken
+            // over the SML AS OF the quorum base block) needs the HISTORICAL
+            // SML at cycleStart+quorumIndex — sourced over coin-P2P qrinfo
+            // (getqrinfo), not yet wired. Until that lands the provider returns
+            // nullopt and Phase-L stays fail-closed to null-serve; the BLS
+            // crypto path is complete + KAT-locked and needs no further change
+            // when the member set arrives. The SML nVersion (VER_LEGACY_BLS/
+            // VER_BASIC_BLS) MUST populate MemberOperatorKey::legacy_scheme so a
+            // mixed-scheme quorum verifies (a bare key hex is scheme-ambiguous).
+            dash::coin::vendor::MemberKeysProvider qc_member_keys =
+                [](uint8_t /*llmqType*/, const uint256& /*quorumHash*/)
+                    -> std::optional<std::vector<dash::coin::vendor::MemberOperatorKey>> {
+                    return std::nullopt;   // historical-SML member selection: qrinfo TODO
+                };
+            qc_cache->set_bls_verify_fn(
+                dash::coin::vendor::make_commitment_bls_verifier(
+                    std::move(qc_member_keys)));
+            if (dash::coin::vendor::bls_backend_available()) {
+                LOG_INFO << "[QC-PHASE-L] dashbls verifier installed "
+                            "(real qc inclusion gated on member-set sourcing)";
+            }
+
             coin_feed_subs.push_back(
                 coin_state.new_qfcommit.subscribe(
                     [qc_cache, qc_net]

--- a/src/impl/dash/CMakeLists.txt
+++ b/src/impl/dash/CMakeLists.txt
@@ -34,6 +34,26 @@ target_link_libraries(dash_block_replay PRIVATE core nlohmann_json::nlohmann_jso
 # links it is c2pool-dash (this slice), so the ltc/btc/doge/dgb build + ctest
 # surfaces are untouched. Per-coin isolation held: src/impl/dash only, no
 # shared-base/core SOURCE edit, dashd RPC fallback preserved.
+# E1 Phase-L: type-6 quorum-commitment BLS verify (coin/vendor/bls_verify.cpp).
+# Compiled UNCONDITIONALLY so the seam symbols (make_commitment_bls_verifier,
+# verify_final_commitment, build_commitment_hash) always resolve; the dashbls
+# backend is linked + the C2POOL_DASH_BLS define is set (PUBLIC, so the sole
+# consumer c2pool-dash inherits it) ONLY when the library was found. Without it
+# the verify functions are fail-closed stubs and NO dashbls dependency enters
+# the build — keeping the Windows main_ltc launcher (shared core only) clean.
+# SAFE-ADDITIVE: the only executable linking dash_bls_verify is c2pool-dash.
+add_library(dash_bls_verify STATIC coin/vendor/bls_verify.cpp)
+target_include_directories(dash_bls_verify PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/src/btclibs
+    ${CMAKE_SOURCE_DIR}/include)
+target_link_libraries(dash_bls_verify PRIVATE core ${Boost_LIBRARIES})
+if(C2POOL_DASH_BLS_AVAILABLE)
+    target_compile_definitions(dash_bls_verify PUBLIC C2POOL_DASH_BLS)
+    target_include_directories(dash_bls_verify PUBLIC ${DASHBLS_INCLUDE_DIR})
+    target_link_libraries(dash_bls_verify PUBLIC ${DASHBLS_LIBRARIES})
+endif()
+
 add_library(dash_rpc STATIC coin/rpc.cpp coin/zmq_tip_notify.cpp)
 target_include_directories(dash_rpc PRIVATE
     ${CMAKE_SOURCE_DIR}/src

--- a/src/impl/dash/coin/dkg_commitments.hpp
+++ b/src/impl/dash/coin/dkg_commitments.hpp
@@ -1,0 +1,517 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// E1 — daemonless type-6 (LLMQ quorum-commitment) sourcing at DKG
+/// mining-window heights. The follow-through that turns dkg_window.hpp's
+/// PHASE-1 "refuse the embedded arm" posture into "serve daemonlessly".
+///
+/// CONSENSUS MODEL (dashcore llmq/blockprocessor.cpp @ develop cfad414,
+/// the same pin as vendor/llmq_commitment.hpp):
+///
+///   * ProcessBlock requires, PER enabled llmqType, that the number of
+///     type-6 special txs in block N EQUALS GetNumCommitmentsRequired
+///     (numRequired > inBlock => bad-qc-missing; < => bad-qc-not-allowed).
+///   * GetNumCommitmentsRequired(params, N): 0 unless N is inside the
+///     type's DKG mining window ([cycleStart+dkgMiningWindowStart,
+///     cycleStart+dkgMiningWindowEnd], cycleStart = N - N%dkgInterval).
+///     Inside it, one commitment is required for every quorumIndex in
+///     [0, rotation ? signingActiveQuorumCount : 1) whose quorum base
+///     block hash (block at cycleStart+quorumIndex) exists and whose
+///     commitment has NOT already been mined earlier in the window.
+///   * A required commitment may be NULL (llmq/commitment.cpp
+///     CheckLLMQCommitment / ProcessCommitment: IsNull => VerifyNull,
+///     which checks only llmqType validity + all-null fields + bitset
+///     sizes == params.size). dashd's OWN miner mines a null commitment
+///     whenever it has no verified mineable commitment
+///     (GetMineableCommitments: "null commitment required" arm). A null
+///     commitment never enters the active quorum set and is SKIPPED by
+///     CalcCbTxMerkleRootQuorums ("having null commitments is ok but we
+///     don't use them here").
+///
+/// DAEMONLESS DERIVABILITY (why no dashd and no BLS lib are needed for a
+/// consensus-valid block at these heights):
+///
+///   * "which commitments are mandatory": pure params-table math over the
+///     next height + the quorum base block hashes, which the embedded
+///     header chain already carries (HeaderChain::get_header_by_height).
+///   * "already mined this cycle?": the mnlistdiff-fed QuorumManager IS
+///     dashd's GetMinedAndActiveCommitmentsUntilBlock(tip) set
+///     (evo/smldiff.cpp BuildQuorumsDiff builds the diff from exactly
+///     that call, inclusive of commitments mined AT the diff's tip), and
+///     embedded viability already requires the SML/quorum state to be
+///     CURRENT AT the tip we build on. A quorum mined earlier in the
+///     current window is guaranteed still active (active spans
+///     signingActiveQuorumCount cycles >= 4), so
+///     has_mined == qmgr.find(type, quorumBaseHash).has_value().
+///   * "content": NULL commitments (the same ones dashd's miner builds
+///     from thin air) are fully synthesizable locally: version =
+///     CFinalCommitment::GetVersion(rotation, basic_bls=true), llmqType,
+///     quorumHash = base block hash, quorumIndex, size-sized all-false
+///     bitsets, zero key/vvec/sigs.
+///   * merkleRootQuorums: unchanged by null commitments — the PROVEN
+///     compute_merkle_root_quorums(qmgr) (byte-identical to dashd from
+///     the wire, test_dash_mnlistdiff_root_parity) stays the root.
+///
+/// PHASE-L LINE (real, non-null commitments — the only remaining piece),
+/// stated REUSE-FIRST per the operator mandate (vendor Dash Core's own
+/// code, do not hand-roll):
+///
+/// dashd's own template carries the REAL finalized commitment when its
+/// DKG succeeded and the qfcommit was relayed. Sourcing that content
+/// daemonlessly already works off the coin-P2P `qfcommit` relay
+/// (MSG_QUORUM_FINAL_COMMITMENT inv 21 + "qfcommit" message — the same
+/// CFinalCommitment wire struct vendored here); MineableCommitmentCache
+/// below ingests + structurally validates them (VerifySizes + threshold
+/// counts + version + non-null crypto fields — every check dashcore's
+/// CFinalCommitment::Verify performs EXCEPT the BLS math). What remains
+/// before an unverified relayed commitment may be MINED is dashcore's
+/// cryptographic verification, and the plan is to VENDOR it, not
+/// re-derive it:
+///
+///   (1) LIFT (same vendor/ pattern as llmq_commitment.hpp, pin cfad414):
+///       * llmq/commitment.cpp — CFinalCommitment::Verify(checkSigs) +
+///         BuildCommitmentHash (the signed preimage);
+///       * llmq/utils.cpp — GetAllQuorumMembers/ComputeQuorumMembers
+///         (deterministic member selection: score = hash(proTxHash,
+///         confirmedHash, modifier) over the MN list at the quorum base
+///         block — the SML we already sync carries proRegTxHash +
+///         confirmedHash + pubKeyOperator, i.e. every input);
+///       * llmq/snapshot.{h,cpp} — CQuorumRotationInfo/CQuorumSnapshot
+///         (the `qrinfo`/`getqrinfo` light-client protocol) for ROTATED
+///         member computation (ComputeQuorumMembersByQuarterRotation) —
+///         qrinfo also carries the mnlistdiffs at the cycle base blocks,
+///         which is exactly the historical-SML input member selection
+///         needs (the seam: feed it from the SAME coin-P2P client that
+///         already speaks getmnlistd/mnlistdiff).
+///   (2) LINK dash Core's BLS backend rather than any substitute:
+///       dashpay/bls-signatures ("bls-dash", the Chia-BLS fork dashd
+///       itself links via src/bls/bls.h CBLSPublicKey/CBLSSignature) —
+///       relic-backed, CMake, Apache-2.0 (license-compatible with the
+///       Apache engine). NO BLS lib is currently vendored or in
+///       conanfile.txt (verified) — this is the ONE new third-party
+///       dependency Phase L introduces; dashcore's src/bls/bls.h wrapper
+///       is then vendored thinly so Verify() runs verbatim: quorumSig =
+///       threshold sig by quorumPublicKey and membersSig = aggregate over
+///       the signers' pubKeyOperator, both over BuildCommitmentHash(...),
+///       basic scheme post-V19.
+///   (3) SEAM: MineableCommitmentCache::set_bls_verify_fn — Phase L
+///       installs the vendored verifier there; nothing else changes.
+///   (4) RESIDUAL after that: none for producing/validating block-N's
+///       mandatory commitments — c2pool never PARTICIPATES in DKG (that
+///       genuinely requires operator keys and is not a miner concern);
+///       it only needs to verify-and-include, which (1)+(2) cover.
+///
+/// Until then an unverified relayed commitment MUST NOT be mined (a
+/// malicious peer could hand us a bad-qc-invalid block), so the provider
+/// falls back to the always-consensus-valid NULL commitment for that
+/// slot — exactly what dashd mines when IT has no verified commitment.
+///
+/// MAINTENANCE: the params table + enabled sets + V19 floors below are
+/// copied VERBATIM from dashcore llmq/params.h + chainparams.cpp @
+/// cfad414. RE-DIFF on every vendored-dashcore pin bump (same rule as
+/// dkg_window.hpp) — a params change silently mis-shapes the mandatory
+/// set at window heights.
+
+#include <impl/dash/coin/quorum_manager.hpp>
+#include <impl/dash/coin/quorum_root.hpp>
+#include <impl/dash/coin/transaction.hpp>
+#include <impl/dash/coin/vendor/llmq_commitment.hpp>
+
+#include <core/uint256.hpp>
+#include <core/pack.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <map>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace dash {
+namespace coin {
+
+// ── LLMQ params (dashcore llmq/params.h @ cfad414, verbatim values) ────────
+
+enum class LlmqNetwork : uint8_t { Mainnet, Testnet };
+
+struct LlmqParamsView {
+    uint8_t  type;
+    uint16_t size;
+    uint16_t threshold;
+    uint32_t dkg_interval;
+    uint32_t mining_window_start;   // offset from cycle start
+    uint32_t mining_window_end;     // offset from cycle start, inclusive
+    uint16_t signing_active_quorum_count;
+    bool     use_rotation;
+};
+
+// llmq/params.h rows for the production types (LLMQ_25_67 is
+// .useRotation=false at this pin — do NOT confuse with the DIP-24 types).
+inline constexpr LlmqParamsView kLlmq50_60  {1, 50,  30,  24,  10, 18, 24, false};
+inline constexpr LlmqParamsView kLlmq60_75  {5, 60,  45,  288, 42, 50, 32, true };
+inline constexpr LlmqParamsView kLlmq400_60 {2, 400, 240, 288, 20, 28, 4,  false};
+inline constexpr LlmqParamsView kLlmq400_85 {3, 400, 340, 576, 20, 48, 4,  false};
+inline constexpr LlmqParamsView kLlmq100_67 {4, 100, 67,  24,  10, 18, 24, false};
+inline constexpr LlmqParamsView kLlmq25_67  {6, 25,  17,  24,  10, 18, 24, false};
+
+/// Enabled LLMQ types per network, IN dashd's AddLLMQ ORDER (chainparams.cpp:
+/// mainnet 269-273, testnet 459-464). The order matters for byte parity: the
+/// miner emits qc txs in GetEnabledQuorumParams enumeration order
+/// (node/miner.cpp CreateNewBlock), which is AddLLMQ insertion order.
+inline const std::vector<LlmqParamsView>& enabled_llmqs(LlmqNetwork net)
+{
+    static const std::vector<LlmqParamsView> kMainnet{
+        kLlmq50_60, kLlmq60_75, kLlmq400_60, kLlmq400_85, kLlmq100_67};
+    static const std::vector<LlmqParamsView> kTestnet{
+        kLlmq50_60, kLlmq60_75, kLlmq400_60, kLlmq400_85, kLlmq100_67,
+        kLlmq25_67};
+    return net == LlmqNetwork::Mainnet ? kMainnet : kTestnet;
+}
+
+/// Daemonless-qc serve floor = V19Height (chainparams.cpp: mainnet 1899072,
+/// testnet 850100). Below it the basic-BLS commitment versions this module
+/// hardcodes are wrong AND (far below, pre-DIP0003) a qc tx is
+/// bad-qc-premature — both true of the c2pool "--regtest folds into
+/// testnet=true" harness chains. Below the floor the provider preserves the
+/// PHASE-1 posture exactly: refuse the embedded arm inside any window.
+inline constexpr uint32_t kQcServeFloorMainnet = 1'899'072u;
+inline constexpr uint32_t kQcServeFloorTestnet = 850'100u;
+
+inline uint32_t qc_serve_floor(LlmqNetwork net)
+{
+    return net == LlmqNetwork::Mainnet ? kQcServeFloorMainnet
+                                       : kQcServeFloorTestnet;
+}
+
+/// dashcore llmq/blockprocessor.cpp IsMiningPhase, verbatim semantics.
+inline bool is_mining_phase(const LlmqParamsView& p, uint32_t height)
+{
+    const uint32_t phase = height % p.dkg_interval;
+    return phase >= p.mining_window_start && phase <= p.mining_window_end;
+}
+
+// ── Mandatory-slot computation ─────────────────────────────────────────────
+
+struct RequiredQcSlot {
+    LlmqParamsView params;
+    int16_t        quorum_index{0};
+    uint256        quorum_hash;      // base block hash at cycleStart+index
+};
+
+/// dashcore GetNumCommitmentsRequired, computed daemonlessly.
+///
+///   hash_at_height : header-chain lookup (height -> block hash);
+///                    std::nullopt when the header is not held locally.
+///   has_mined      : HasMinedCommitment proxy — true iff (type, quorumHash)
+///                    is in the mnlistdiff-fed active set (see header note).
+///
+/// Returns std::nullopt when the mandatory set CANNOT be derived safely
+/// (below the serve floor inside a window, or a needed quorum base header is
+/// missing) — the caller must FAIL CLOSED to the dashd fallback. Otherwise
+/// the exact ordered slot list (possibly empty: non-window height, or every
+/// window commitment already mined).
+inline std::optional<std::vector<RequiredQcSlot>> compute_required_qc_slots(
+    LlmqNetwork net, uint32_t next_height,
+    const std::function<std::optional<uint256>(uint32_t)>& hash_at_height,
+    const std::function<bool(uint8_t, const uint256&)>& has_mined)
+{
+    std::vector<RequiredQcSlot> slots;
+    const bool below_floor = next_height < qc_serve_floor(net);
+    for (const auto& p : enabled_llmqs(net)) {
+        if (!is_mining_phase(p, next_height)) continue;
+        if (below_floor) return std::nullopt;   // PHASE-1 refusal preserved
+        const uint32_t cycle_start =
+            next_height - (next_height % p.dkg_interval);
+        const uint32_t n = p.use_rotation ? p.signing_active_quorum_count : 1;
+        for (uint32_t qi = 0; qi < n; ++qi) {
+            const uint32_t base_h = cycle_start + qi;
+            if (base_h >= next_height) return std::nullopt;  // hash unknowable
+            auto qh = hash_at_height(base_h);
+            if (!qh || qh->IsNull()) return std::nullopt;    // header gap
+            if (has_mined(p.type, *qh)) continue;            // already mined
+            slots.push_back(RequiredQcSlot{p, static_cast<int16_t>(qi), *qh});
+        }
+    }
+    return slots;
+}
+
+// ── Null-commitment + qc-tx construction ───────────────────────────────────
+
+/// dashcore CFinalCommitment(params, quorumHash) + the GetMineableCommitments
+/// "null commitment required" arm: size-sized all-false bitsets, zero
+/// pubkey/vvec/sigs, nVersion = GetVersion(rotation, basic_bls=true) (the
+/// serve floor guarantees post-V19 basic scheme): 3 non-rotated, 4 rotated.
+inline vendor::CFinalCommitment build_null_commitment(
+    const LlmqParamsView& p, const uint256& quorum_hash, int16_t quorum_index)
+{
+    vendor::CFinalCommitment c;
+    c.nVersion = p.use_rotation
+        ? vendor::CFinalCommitment::BASIC_BLS_INDEXED_QUORUM_VERSION
+        : vendor::CFinalCommitment::BASIC_BLS_NON_INDEXED_QUORUM_VERSION;
+    c.llmqType    = p.type;
+    c.quorumHash  = quorum_hash;
+    c.quorumIndex = quorum_index;   // serialized only by the indexed versions
+    c.signers.assign(p.size, false);
+    c.validMembers.assign(p.size, false);
+    // quorumPublicKey / quorumVvecHash / quorumSig / membersSig stay zero.
+    return c;
+}
+
+/// dashcore GetMineableCommitmentsTx: nVersion=3, nType=6, empty vin/vout,
+/// extra_payload = CFinalCommitmentTxPayload{version 1, nHeight, commitment}.
+inline MutableTransaction build_qc_tx(uint32_t height,
+                                      const vendor::CFinalCommitment& c)
+{
+    vendor::CFinalCommitmentTxPayload payload;
+    payload.nVersion = vendor::CFinalCommitmentTxPayload::CURRENT_VERSION;
+    payload.nHeight  = height;
+    payload.commitment = c;
+    auto stream = ::pack(payload);
+    auto sp = stream.get_span();
+
+    MutableTransaction tx;
+    tx.version = 3;
+    tx.type    = vendor::CFinalCommitmentTxPayload::SPECIALTX_TYPE;  // 6
+    tx.locktime = 0;
+    tx.extra_payload.assign(
+        reinterpret_cast<const unsigned char*>(sp.data()),
+        reinterpret_cast<const unsigned char*>(sp.data()) + sp.size());
+    return tx;
+}
+
+// ── Mineable-commitment cache (Phase-L seam) ───────────────────────────────
+
+/// Collects REAL finalized commitments off the coin-P2P `qfcommit` relay —
+/// the exact stream dashd's own miner sources from. Admission is structural
+/// (sizes, thresholds, non-null crypto fields, expected version); commitments
+/// are only SERVED for mining once a BLS verifier is installed AND passes
+/// (Phase L). Without one, verified_for() always returns nullopt and the
+/// provider mines the consensus-valid null commitment instead. Mirrors
+/// dashd's minableCommitments keep-best-by-CountSigners policy.
+class MineableCommitmentCache {
+public:
+    using BlsVerifyFn = std::function<bool(const vendor::CFinalCommitment&)>;
+
+    void set_bls_verify_fn(BlsVerifyFn fn) { m_bls_verify = std::move(fn); }
+    bool has_bls_verifier() const { return static_cast<bool>(m_bls_verify); }
+
+    /// Structural admission of a relayed commitment. Returns true when the
+    /// commitment was cached (new, or better than the cached one).
+    bool ingest(LlmqNetwork net, const vendor::CFinalCommitment& c)
+    {
+        const LlmqParamsView* p = nullptr;
+        for (const auto& e : enabled_llmqs(net))
+            if (e.type == c.llmqType) { p = &e; break; }
+        if (p == nullptr) return false;
+        // Version must be the post-V19 basic-scheme variant for the type's
+        // rotation flag (dashcore CFinalCommitment::Verify version check).
+        const uint16_t expected = p->use_rotation
+            ? vendor::CFinalCommitment::BASIC_BLS_INDEXED_QUORUM_VERSION
+            : vendor::CFinalCommitment::BASIC_BLS_NON_INDEXED_QUORUM_VERSION;
+        if (c.nVersion != expected) return false;
+        // VerifySizes.
+        if (c.signers.size() != p->size || c.validMembers.size() != p->size)
+            return false;
+        // A REAL commitment: thresholds met, crypto fields non-null
+        // (dashcore Verify's CountValidMembers/CountSigners >= threshold and
+        // non-null key/sig checks — everything except the BLS math).
+        if (c.CountValidMembers() < p->threshold) return false;
+        if (c.CountSigners() < p->threshold) return false;
+        auto all_zero = [](const auto& arr) {
+            for (auto b : arr) if (b != 0) return false;
+            return true;
+        };
+        if (all_zero(c.quorumPublicKey) || c.quorumVvecHash.IsNull()
+            || all_zero(c.quorumSig) || all_zero(c.membersSig))
+            return false;
+
+        const Key k{c.llmqType, c.quorumHash};
+        auto it = m_cache.find(k);
+        if (it != m_cache.end()
+            && it->second.CountSigners() >= c.CountSigners())
+            return false;   // already hold an equal-or-better one
+        m_cache[k] = c;
+        return true;
+    }
+
+    /// The mineable commitment for a slot — ONLY once BLS-verified. The
+    /// Phase-L blocker line: without a verifier this is always nullopt.
+    std::optional<vendor::CFinalCommitment>
+    verified_for(uint8_t llmq_type, const uint256& quorum_hash) const
+    {
+        if (!m_bls_verify) return std::nullopt;
+        auto it = m_cache.find(Key{llmq_type, quorum_hash});
+        if (it == m_cache.end()) return std::nullopt;
+        if (!m_bls_verify(it->second)) return std::nullopt;
+        return it->second;
+    }
+
+    size_t size() const { return m_cache.size(); }
+    void   clear() { m_cache.clear(); }
+
+private:
+    struct Key {
+        uint8_t llmqType;
+        uint256 quorumHash;
+        bool operator<(const Key& r) const
+        {
+            if (llmqType != r.llmqType) return llmqType < r.llmqType;
+            return std::memcmp(quorumHash.data(), r.quorumHash.data(), 32) < 0;
+        }
+    };
+    std::map<Key, vendor::CFinalCommitment> m_cache;
+    BlsVerifyFn m_bls_verify;   // unset until Phase L lands a BLS12-381 lib
+};
+
+// ── Daemonless provider (the piece main_dash wires in) ─────────────────────
+
+/// The full mandatory type-6 set for block `next_height`, sourced without
+/// dashd: real BLS-verified commitments from `cache` when available (Phase
+/// L), the consensus-valid null commitment otherwise. std::nullopt => the
+/// set cannot be derived safely; the embedded arm must fail closed.
+inline std::optional<std::vector<vendor::CFinalCommitment>>
+daemonless_qc_commitments(
+    LlmqNetwork net, uint32_t next_height,
+    const std::function<std::optional<uint256>(uint32_t)>& hash_at_height,
+    const std::function<bool(uint8_t, const uint256&)>& has_mined,
+    const MineableCommitmentCache* cache = nullptr)
+{
+    auto slots = compute_required_qc_slots(net, next_height,
+                                           hash_at_height, has_mined);
+    if (!slots) return std::nullopt;
+    std::vector<vendor::CFinalCommitment> out;
+    out.reserve(slots->size());
+    for (const auto& s : *slots) {
+        if (cache != nullptr) {
+            if (auto real = cache->verified_for(s.params.type, s.quorum_hash)) {
+                out.push_back(std::move(*real));
+                continue;
+            }
+        }
+        out.push_back(build_null_commitment(s.params, s.quorum_hash,
+                                            s.quorum_index));
+    }
+    return out;
+}
+
+// ── merkleRootQuorums with block-local commitments ─────────────────────────
+
+/// dashcore evo/cbtx.cpp CalcCbTxMerkleRootQuorums INCLUDING the candidate
+/// block's own type-6 commitments (the piece compute_merkle_root_quorums —
+/// proven at non-window heights — does not model):
+///   * null commitments are SKIPPED (upstream: "having null commitments is
+///     ok but we don't use them here") — so an all-null block reproduces
+///     compute_merkle_root_quorums(qmgr) exactly;
+///   * rotated types: the new leaf REPLACES the active leaf with the same
+///     (llmqType, quorumIndex);
+///   * non-rotated types: when the type is at signingActiveQuorumCount
+///     capacity, the OLDEST-mined active leaf is evicted first. Mined order
+///     within one type is monotone in the quorum base height (a cycle's
+///     mining window closes before the next cycle starts), so "oldest
+///     mined" == lowest base-block height, resolved via `height_of_hash`
+///     (the header chain). std::nullopt when an eviction is needed but a
+///     base height cannot be resolved — the caller must fail closed.
+inline std::optional<uint256> compute_merkle_root_quorums_with_block(
+    LlmqNetwork net,
+    const QuorumManager& qmgr,
+    const std::vector<vendor::CFinalCommitment>& block_qcs,
+    const std::function<std::optional<uint32_t>(const uint256&)>& height_of_hash)
+{
+    struct Leaf {
+        uint256 hash;         // SerializeHash(commitment)
+        uint256 quorum_hash;  // for eviction ordering
+        int16_t quorum_index; // for rotated replacement
+    };
+    std::map<uint8_t, std::vector<Leaf>> per_type;
+    for (const auto& e : qmgr.active_entries()) {
+        per_type[e.key.llmqType].push_back(
+            Leaf{hash_commitment(e.commitment), e.key.quorumHash,
+                 e.commitment.quorumIndex});
+    }
+
+    auto params_of = [&](uint8_t t) -> const LlmqParamsView* {
+        for (const auto& p : enabled_llmqs(net))
+            if (p.type == t) return &p;
+        return nullptr;
+    };
+
+    for (const auto& qc : block_qcs) {
+        // IsNull per dashcore: no signers/valid members and null crypto.
+        if (qc.CountSigners() == 0 && qc.CountValidMembers() == 0)
+            continue;   // null commitment — not folded into the root
+        const LlmqParamsView* p = params_of(qc.llmqType);
+        if (p == nullptr) return std::nullopt;
+        auto& leaves = per_type[qc.llmqType];
+        const Leaf nl{hash_commitment(qc), qc.quorumHash, qc.quorumIndex};
+        if (p->use_rotation) {
+            auto it = std::find_if(leaves.begin(), leaves.end(),
+                [&](const Leaf& l) { return l.quorum_index == qc.quorumIndex; });
+            if (it != leaves.end()) *it = nl; else leaves.push_back(nl);
+        } else {
+            if (leaves.size() >= p->signing_active_quorum_count) {
+                // Evict the oldest-mined == lowest quorum-base-height leaf.
+                size_t oldest = 0;
+                std::optional<uint32_t> oldest_h;
+                for (size_t i = 0; i < leaves.size(); ++i) {
+                    auto h = height_of_hash(leaves[i].quorum_hash);
+                    if (!h) return std::nullopt;   // cannot order — fail closed
+                    if (!oldest_h || *h < *oldest_h) { oldest_h = *h; oldest = i; }
+                }
+                leaves.erase(leaves.begin() + static_cast<long>(oldest));
+            }
+            leaves.push_back(nl);
+        }
+        if (leaves.size() > p->signing_active_quorum_count)
+            return std::nullopt;   // excess-quorums — fail closed
+    }
+
+    std::vector<uint256> vec_hashes_final;
+    for (const auto& [t, leaves] : per_type)
+        for (const auto& l : leaves) vec_hashes_final.push_back(l.hash);
+    std::sort(vec_hashes_final.begin(), vec_hashes_final.end(),
+        [](const uint256& a, const uint256& b) {
+            return std::memcmp(a.data(), b.data(), 32) < 0;
+        });
+    return compute_merkle_root_local(std::move(vec_hashes_final));
+}
+
+// ── The per-height plan NodeCoinState consumes ─────────────────────────────
+
+/// Everything the embedded template needs at one height: the ordered
+/// mandatory type-6 commitment set (empty off-window / all-mined) plus the
+/// merkleRootQuorums INCLUDING those commitments. While the set is all-null
+/// (the pre-Phase-L posture) the root equals the PROVEN
+/// compute_merkle_root_quorums(qmgr) by construction.
+struct QcBlockPlan {
+    std::vector<vendor::CFinalCommitment> commitments;
+    uint256 merkle_root_quorums;
+};
+
+/// Compose the full daemonless plan. std::nullopt => cannot be derived
+/// safely at this height; the embedded arm must fail closed to the dashd
+/// fallback (exactly the PHASE-1 refusal, but now only when genuinely
+/// unable rather than for the whole window).
+inline std::optional<QcBlockPlan> build_daemonless_qc_plan(
+    LlmqNetwork net, uint32_t next_height,
+    const QuorumManager& qmgr,
+    const std::function<std::optional<uint256>(uint32_t)>& hash_at_height,
+    const std::function<std::optional<uint32_t>(const uint256&)>& height_of_hash,
+    const MineableCommitmentCache* cache = nullptr)
+{
+    auto has_mined = [&qmgr](uint8_t t, const uint256& qh) {
+        return qmgr.find(t, qh).has_value();
+    };
+    auto commitments = daemonless_qc_commitments(
+        net, next_height, hash_at_height, has_mined, cache);
+    if (!commitments) return std::nullopt;
+    auto root = compute_merkle_root_quorums_with_block(
+        net, qmgr, *commitments, height_of_hash);
+    if (!root) return std::nullopt;
+    return QcBlockPlan{std::move(*commitments), *root};
+}
+
+} // namespace coin
+} // namespace dash
+

--- a/src/impl/dash/coin/embedded_gbt.hpp
+++ b/src/impl/dash/coin/embedded_gbt.hpp
@@ -35,8 +35,11 @@
 #include <impl/dash/coin/rpc_data.hpp>
 #include <impl/dash/coin/quorum_root.hpp>
 #include <impl/dash/coin/quorum_manager.hpp>
+#include <impl/dash/coin/dkg_commitments.hpp>   // E1: build_qc_tx (mandatory type-6 txs)
 #include <impl/dash/coin/vendor/cbtx.hpp>
 #include <impl/dash/coin/vendor/simplifiedmns.hpp>
+
+#include <btclibs/util/strencodings.h>          // HexStr (m_tx_data_hex fill)
 
 #include <core/uint256.hpp>
 #include <core/pack.hpp>
@@ -89,7 +92,8 @@ inline bool underfill_guard_trips(uint64_t selected_bytes,
 // CCbTx extra_payload into the embedded template via these.
 inline vendor::CCbTx build_embedded_cbtx(
     uint32_t, const vendor::CSimplifiedMNList&, const QuorumManager&,
-    int32_t, const std::array<uint8_t, 96>&, int64_t);
+    int32_t, const std::array<uint8_t, 96>&, int64_t,
+    const uint256* quorum_root_override);
 inline std::vector<unsigned char> encode_cbtx(const vendor::CCbTx&);
 // Zero CLSIG default for the E2d best_cl_sig seam (no temporary-bound ref).
 inline const std::array<uint8_t, 96> k_zero_cl_sig{};
@@ -127,7 +131,14 @@ inline DashWorkData build_embedded_workdata(
     const QuorumManager* qmgr = nullptr,
     int32_t best_cl_height = 0,
     const std::array<uint8_t, 96>& best_cl_sig = k_zero_cl_sig,
-    int64_t last_observed_credit_pool = 0)
+    int64_t last_observed_credit_pool = 0,
+    // E1 seams: the mandatory type-6 quorum-commitment set for THIS height
+    // (dkg_commitments.hpp daemonless plan) and the with-block
+    // merkleRootQuorums the CbTx must commit. Default nullptr => every
+    // existing caller is byte-for-byte unchanged (SAFE-ADDITIVE): no qc txs,
+    // plain compute_merkle_root_quorums root.
+    const std::vector<vendor::CFinalCommitment>* qc_commitments = nullptr,
+    const uint256* quorum_root_override = nullptr)
 {
     DashWorkData w;
     w.m_height          = prev_height + 1;
@@ -160,15 +171,43 @@ inline DashWorkData build_embedded_workdata(
 
     // Selected txs — populate the wire-form fields the existing
     // coinbase_builder.hpp expects.
-    w.m_txs.reserve(selected.size());
-    w.m_tx_hashes.reserve(selected.size());
-    w.m_tx_fees.reserve(selected.size());
+    w.m_txs.reserve(selected.size()
+                    + (qc_commitments ? qc_commitments->size() : 0));
+    w.m_tx_hashes.reserve(w.m_txs.capacity());
+    w.m_tx_fees.reserve(w.m_txs.capacity());
+    w.m_tx_data_hex.reserve(w.m_txs.capacity());
+    // Wire-form hex of one tx (the submit-time block body source). The
+    // embedded arm previously left m_tx_data_hex EMPTY (only the dashd-GBT
+    // parser filled it), so a won embedded block's body could omit txs whose
+    // ids were already folded into the job merkle — fill it here for every
+    // template tx (E1; additive, the dashd fallback path is untouched).
+    auto tx_hex = [](const MutableTransaction& mtx) {
+        auto stream = ::pack(mtx);
+        auto sp = stream.get_span();
+        return HexStr(std::span<const unsigned char>(
+            reinterpret_cast<const unsigned char*>(sp.data()), sp.size()));
+    };
+    // E1: mandatory type-6 quorum-commitment txs FIRST — dashd's miner
+    // places them immediately after the coinbase, before mempool txs
+    // (node/miner.cpp CreateNewBlock), and the daemonless template mirrors
+    // that for byte parity. Zero fee, zero in/out; consensus-checked via
+    // the NodeCoinState emit gate against the same deterministic plan.
+    if (qc_commitments != nullptr) {
+        for (const auto& c : *qc_commitments) {
+            MutableTransaction qtx = build_qc_tx(w.m_height, c);
+            w.m_txs.emplace_back(qtx);
+            w.m_tx_hashes.push_back(dash::coin::dash_txid(qtx));
+            w.m_tx_fees.push_back(0);
+            w.m_tx_data_hex.push_back(tx_hex(qtx));
+        }
+    }
     uint64_t selected_bytes = 0;  // wire bytes packed into this template (underfill guard)
     for (auto& s : selected) {
         selected_bytes += s.base_size;
         w.m_txs.emplace_back(s.tx);
         w.m_tx_hashes.push_back(dash::coin::dash_txid(s.tx));
         w.m_tx_fees.push_back(s.fee);
+        w.m_tx_data_hex.push_back(tx_hex(s.tx));
     }
 
     // ── Underfill guard ─────────────────────────────────────────────
@@ -266,7 +305,7 @@ inline DashWorkData build_embedded_workdata(
             last_observed_credit_pool + platform_reward;
         vendor::CCbTx cb = build_embedded_cbtx(
             prev_height, *sml, *qmgr, best_cl_height, best_cl_sig,
-            accrued_credit_pool);
+            accrued_credit_pool, quorum_root_override);
         w.m_coinbase_payload = encode_cbtx(cb);
     } else {
         w.m_coinbase_payload.clear();
@@ -372,7 +411,12 @@ inline vendor::CCbTx build_embedded_cbtx(
     const QuorumManager& qmgr,
     int32_t  best_cl_height,
     const std::array<uint8_t, 96>& best_cl_sig,
-    int64_t  last_observed_credit_pool)
+    int64_t  last_observed_credit_pool,
+    // E1: the with-block merkleRootQuorums (fold of the template's own
+    // type-6 commitments over the active set). nullptr (default) => the
+    // plain PROVEN active-set root — byte-identical for every pre-E1 caller
+    // AND for all-null commitment sets.
+    const uint256* quorum_root_override = nullptr)
 {
     vendor::CCbTx c;
     c.nVersion           = vendor::CCbTx::VERSION_CLSIG_AND_BALANCE;
@@ -383,7 +427,9 @@ inline vendor::CCbTx build_embedded_cbtx(
     // budget for log-only validation.
     auto sml_mut = sml;
     c.merkleRootMNList   = sml_mut.CalcMerkleRoot();
-    c.merkleRootQuorums  = compute_merkle_root_quorums(qmgr);
+    c.merkleRootQuorums  = quorum_root_override
+        ? *quorum_root_override
+        : compute_merkle_root_quorums(qmgr);
 
     // bestCL fields: only set when we have an actual best.
     // dashcore's formula is heightDiff = (cb_height - 1) - bestCLHeight.

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -25,6 +25,7 @@
 #include <impl/dash/coin/rpc_data.hpp>           // DashWorkData
 #include <impl/dash/coin/quorum_manager.hpp>     // QuorumManager (merkleRootQuorums source)
 #include <impl/dash/coin/quorum_root.hpp>        // compute_merkle_root_quorums (pre-emit recompute)
+#include <impl/dash/coin/dkg_commitments.hpp>    // QcBlockPlan (E1 daemonless DKG-window serving)
 #include <impl/dash/coin/vendor/simplifiedmns.hpp> // vendor::CSimplifiedMNList (merkleRootMNList source)
 #include <impl/dash/coin/vendor/cbtx.hpp>        // vendor::parse_cbtx (pre-emit CbTx self-check)
 #include <impl/dash/coin/subsidy.hpp>            // compute_dash_platform_reward_post_v20_mn_rr (creditPool re-check)
@@ -191,6 +192,19 @@ public:
         m_commitment_window_fn = std::move(fn);
     }
 
+    /// E1 — daemonless DKG-window serving. When set, this SUPERSEDES the
+    /// commitment-window refusal: at every height the plan fn derives the
+    /// mandatory type-6 commitment set + the with-block merkleRootQuorums
+    /// from local state only (header chain + mnlistdiff-fed QuorumManager,
+    /// see dkg_commitments.hpp). nullopt => the set cannot be derived
+    /// safely and viability fails closed to the dashd fallback — the same
+    /// reward-safe outcome as the PHASE-1 refusal, but now only when
+    /// genuinely unable instead of for the whole 9-block window. Unset
+    /// (default) preserves the refusal posture exactly.
+    void set_qc_plan_fn(std::function<std::optional<QcBlockPlan>(uint32_t)> fn) {
+        m_qc_plan_fn = std::move(fn);
+    }
+
     /// bestCL freshness guard (review PR #780 BLOCKER-2, HIGH). dashcore
     /// CheckCbTxBestChainlock rejects a block whose committed bestCLSignature is
     /// null or older than the previous block's committed ChainLock
@@ -233,7 +247,29 @@ public:
         if (!m_quorum_healthy) return false;
         const uint32_t next_h = m_prev_height + 1;
         if (m_is_superblock_fn && m_is_superblock_fn(next_h)) return false;
-        if (m_commitment_window_fn && m_commitment_window_fn(next_h)) return false;
+        // E1: with a qc plan installed the DKG-window heights are SERVED, not
+        // refused — re-derive the mandatory type-6 set here and require the
+        // BUILT template to carry exactly it (count + payload bytes, in
+        // order). Any drift (missing/extra/reordered commitment) is a
+        // bad-qc-missing / bad-qc-not-allowed block => discard for the
+        // reward-safe fallback. Without a plan fn the PHASE-1 refusal stays.
+        std::optional<QcBlockPlan> qc_plan;
+        if (m_qc_plan_fn) {
+            qc_plan = m_qc_plan_fn(next_h);
+            if (!qc_plan) return false;   // underivable — fail closed
+            // Collect the type-6 payloads actually in the template.
+            std::vector<std::vector<unsigned char>> got;
+            for (const auto& tx : w.m_txs)
+                if (tx.type == vendor::CFinalCommitmentTxPayload::SPECIALTX_TYPE)
+                    got.push_back(tx.extra_payload);
+            if (got.size() != qc_plan->commitments.size()) return false;
+            for (size_t i = 0; i < got.size(); ++i) {
+                auto expect = build_qc_tx(next_h, qc_plan->commitments[i]);
+                if (got[i] != expect.extra_payload) return false;
+            }
+        } else if (m_commitment_window_fn && m_commitment_window_fn(next_h)) {
+            return false;
+        }
         if (m_require_fresh_bestcl
             && m_best_cl_height < static_cast<int32_t>(m_prev_height) - 1)
             return false;
@@ -249,7 +285,14 @@ public:
         if (cb.nHeight != static_cast<int32_t>(next_h)) return false;
         auto sml_copy = m_sml;
         if (cb.merkleRootMNList != sml_copy.CalcMerkleRoot()) return false;
-        if (cb.merkleRootQuorums != compute_merkle_root_quorums(m_qmgr)) return false;
+        // E1: under a qc plan the committed root must be the WITH-BLOCK root
+        // (fold of the plan's commitments over the active set — equal to the
+        // plain root while the plan is all-null, diverging only once Phase L
+        // serves real commitments). Without a plan, the plain PROVEN root.
+        const uint256 expected_quorum_root = qc_plan
+            ? qc_plan->merkle_root_quorums
+            : compute_merkle_root_quorums(m_qmgr);
+        if (cb.merkleRootQuorums != expected_quorum_root) return false;
         if (m_require_fresh_bestcl && !cb.has_best_cl_signature()) return false;
         // SOAK RE-FIX (build-vs-serve skew): re-derive the expected creditPool
         // from the CURRENT seed at emit/serve time and require the BUILT CbTx to
@@ -275,12 +318,26 @@ public:
     /// semantics work_source.hpp documents.
     EmbeddedWorkInputs make_embedded_work_inputs() const {
         EmbeddedWorkInputs e;
+        // E1: with a qc plan fn installed, DKG-window heights are SERVED
+        // daemonlessly — the plan carries the mandatory type-6 set + the
+        // with-block merkleRootQuorums. A nullopt plan (header gap / below
+        // serve floor) refuses exactly like the PHASE-1 posture. Without a
+        // plan fn the BLOCKER-1 window refusal below stays authoritative.
+        std::optional<QcBlockPlan> qc_plan;
+        bool qc_ok = true;
+        if (m_qc_plan_fn && m_populated) {
+            qc_plan = m_qc_plan_fn(m_prev_height + 1);
+            qc_ok = qc_plan.has_value();
+        }
         e.has_state            = m_populated
+                                 && qc_ok
                                  && (!m_utxo_ready_fn || m_utxo_ready_fn())
                                  && (!m_is_superblock_fn
                                      || !m_is_superblock_fn(m_prev_height + 1))
-                                 // BLOCKER-1: refuse DKG commitment-window heights.
-                                 && (!m_commitment_window_fn
+                                 // BLOCKER-1: refuse DKG commitment-window
+                                 // heights — unless the E1 qc plan serves them.
+                                 && (m_qc_plan_fn
+                                     || !m_commitment_window_fn
                                      || !m_commitment_window_fn(m_prev_height + 1))
                                  // BLOCKER-2: refuse a stale/absent bestCL.
                                  && (!m_require_fresh_bestcl
@@ -321,6 +378,14 @@ public:
             e.best_cl_sig      = m_best_cl_sig;
             e.credit_pool      = m_credit_pool;
         }
+        // E1: hand the daemonless qc plan to the template builder — the
+        // mandatory type-6 txs to place after the coinbase and the
+        // with-block merkleRootQuorums the CbTx must commit.
+        if (qc_plan) {
+            e.qc_commitments       = std::move(qc_plan->commitments);
+            e.has_quorum_root_override = true;
+            e.quorum_root_override = qc_plan->merkle_root_quorums;
+        }
         return e;
     }
 
@@ -348,6 +413,7 @@ private:
     std::function<bool()> m_utxo_ready_fn;   // optional UTXO maturity gate (E2b)
     std::function<bool(uint32_t)> m_is_superblock_fn;  // refuse embedded on superblock heights
     std::function<bool(uint32_t)> m_commitment_window_fn;  // refuse embedded on DKG commitment heights
+    std::function<std::optional<QcBlockPlan>(uint32_t)> m_qc_plan_fn;  // E1: serve DKG windows daemonlessly
     bool     m_require_fresh_bestcl{false};  // refuse embedded on a stale/absent bestCL
     bool     m_require_fresh_credit_pool{false}; // refuse embedded on a lagged credit-pool seed
     uint256  m_credit_pool_current_hash;     // block hash the credit-pool seed is current at

--- a/src/impl/dash/coin/node_interface.hpp
+++ b/src/impl/dash/coin/node_interface.hpp
@@ -5,6 +5,7 @@
 #include "transaction.hpp"
 #include "mn_state_machine.hpp"
 #include "vendor/smldiff.hpp"   // vendor::CSimplifiedMNListDiff (SML-axis reception feed)
+#include "vendor/llmq_commitment.hpp"  // vendor::CFinalCommitment (qfcommit sourcing leg)
 
 #include <core/uint256.hpp>
 #include <core/events.hpp>
@@ -143,6 +144,14 @@ struct Node
         std::array<uint8_t, 96>  sig{};
     };
     Event<ChainLockSigEvent> new_chainlock_sig;
+
+    // E1 Phase-L sourcing leg: a peer-relayed DKG final commitment off the
+    // coin-P2P `qfcommit` stream (inv MSG_QUORUM_FINAL_COMMITMENT = 21) —
+    // the exact stream dashd's own miner sources block-N's mandatory type-6
+    // txs from. main_dash subscribes the MineableCommitmentCache
+    // (dkg_commitments.hpp): structural admission now, BLS verification
+    // (Phase L) before any template inclusion.
+    Event<coin::vendor::CFinalCommitment> new_qfcommit;
 
     std::map<uint256, coin::Transaction> known_txs;
 };

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -554,6 +554,18 @@ private:
         // NO getdata pulls yet — the ingest legs are later slices.
         for (auto& inv : msg->m_invs)
         {
+            // E1 Phase-L sourcing leg: pull relayed DKG final commitments
+            // (MSG_QUORUM_FINAL_COMMITMENT = 21, dashcore protocol.h). The
+            // qfcommit handler below feeds the MineableCommitmentCache.
+            if (static_cast<uint32_t>(inv.m_type) == 21u)
+            {
+                auto getdata_msg = message_getdata::make_raw(
+                    {inventory_type(
+                        static_cast<inventory_type::inv_type>(21u),
+                        inv.m_hash)});
+                m_peer->write(getdata_msg);
+                continue;
+            }
             if (inv.base_type() == inventory_type::block)
             {
                 LOG_INFO << "[" << m_chain_label << "] block inv "
@@ -640,6 +652,20 @@ private:
             std::copy(msg->m_sig.begin(), msg->m_sig.end(), ev.sig.begin());
             m_coin->new_chainlock_sig.happened(ev);
         }
+    }
+
+    ADD_P2P_HANDLER(qfcommit)
+    {
+        // E1 Phase-L sourcing leg: a peer-relayed DKG final commitment — the
+        // same stream dashd's own miner mines type-6 txs from. Fire the event
+        // seam; main_dash feeds the MineableCommitmentCache (structural
+        // admission there; BLS verification is the Phase-L gate before any
+        // template inclusion). No subscriber => no-op, zero behavior change.
+        LOG_INFO << "[" << m_chain_label << "] qfcommit: type="
+                 << static_cast<int>(msg->m_commitment.llmqType)
+                 << " quorum=" << msg->m_commitment.quorumHash.GetHex().substr(0, 16)
+                 << "... signers=" << msg->m_commitment.CountSigners();
+        m_coin->new_qfcommit.happened(msg->m_commitment);
     }
 
     ADD_P2P_HANDLER(mnlistdiff)

--- a/src/impl/dash/coin/p2p_messages.hpp
+++ b/src/impl/dash/coin/p2p_messages.hpp
@@ -9,6 +9,7 @@
 #include "block.hpp"
 #include "vendor/blockencodings.hpp"
 #include "vendor/smldiff.hpp"
+#include "vendor/llmq_commitment.hpp"
 
 #include <impl/bitcoin_family/coin/base_p2p_messages.hpp>
 
@@ -150,6 +151,25 @@ END_MESSAGE()
 // the protocol is exclusively for light clients, which c2pool-dash now
 // is on the SML axis.
 
+// ── E1 Phase-L sourcing leg: mineable quorum commitments ──────────────
+// dashcore relays every VERIFIED DKG final commitment to all peers as
+// inv MSG_QUORUM_FINAL_COMMITMENT (21) + "qfcommit" (llmq/blockprocessor
+// .cpp ProcessMessage / AddMineableCommitment) — the exact stream its
+// OWN miner sources block-N's mandatory type-6 txs from. The payload is
+// a bare CFinalCommitment (already vendored). We pull the inv and feed
+// the MineableCommitmentCache (dkg_commitments.hpp); template INCLUSION
+// stays behind the Phase-L BLS verifier — until then the daemonless arm
+// mines the consensus-valid null commitment.
+BEGIN_MESSAGE(qfcommit)
+    MESSAGE_FIELDS
+    (
+        (vendor::CFinalCommitment, m_commitment)
+    )
+    {
+        READWRITE(obj.m_commitment);
+    }
+END_MESSAGE()
+
 BEGIN_MESSAGE(getmnlistd)
     MESSAGE_FIELDS
     (
@@ -199,6 +219,7 @@ using Handler = MessageHandler<
     message_getblocktxn,
     message_blocktxn,
     message_clsig,
+    message_qfcommit,
     message_getmnlistd,
     message_mnlistdiff
 >;

--- a/src/impl/dash/coin/vendor/bls_verify.cpp
+++ b/src/impl/dash/coin/vendor/bls_verify.cpp
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// E1 Phase-L BLS verification of type-6 quorum commitments. See bls_verify.hpp.
+//
+// This TU is compiled UNCONDITIONALLY (so the seam symbols always resolve), but
+// the BLS backend is linked + used only when C2POOL_DASH_BLS is defined. Without
+// it, verify_final_commitment() / the produced verifier are fail-closed stubs
+// (always false) and the serve path keeps the pre-Phase-L null-commitment
+// posture — no dashbls dependency leaks into a build (e.g. the Windows main_ltc
+// launcher, which never defines C2POOL_DASH_BLS).
+
+#include <impl/dash/coin/vendor/bls_verify.hpp>
+
+#include <core/pack.hpp>       // PackStream, WriteCompactSize
+#include <core/hash.hpp>       // CHash256
+
+#include <cstring>
+#include <span>
+
+#ifdef C2POOL_DASH_BLS
+// dashpay/bls-signatures ("dashbls") — the exact library dashd wraps in
+// src/bls/bls.h. bls.hpp pulls in the relic-backed G1/G2 element + scheme API.
+#include <dashbls/bls.hpp>
+#include <dashbls/schemes.hpp>
+#include <dashbls/elements.hpp>
+#endif
+
+namespace dash {
+namespace coin {
+namespace vendor {
+
+// ── BuildCommitmentHash (dashcore llmq/commitment.cpp, byte-exact) ──────────
+
+uint256 build_commitment_hash(
+    uint8_t llmq_type, const uint256& quorum_hash,
+    const std::vector<bool>& valid_members,
+    const std::array<uint8_t, CFinalCommitment::BLS_PUBKEY_SIZE>& quorum_public_key,
+    const uint256& quorum_vvec_hash)
+{
+    // CHashWriter(SER_GETHASH, 0) << llmqType << blockHash
+    //   << DYNBITSET(validMembers) << pubKey << vvecHash
+    // then GetHash() == SHA256d. We build the identical preimage with a
+    // PackStream (little-endian integrals; uint256 raw 32 LE bytes; the
+    // vendored DynBitSetFormat is wire-identical to dashcore's
+    // DynamicBitSetFormatter; the BLS pubkey is the opaque 48 wire bytes) and
+    // hash it with core CHash256 — the same primitive quorum_root.hpp uses.
+    ::PackStream s;
+    s << llmq_type;                                   // 1 byte
+    s << quorum_hash;                                 // 32 bytes (uint256, LE)
+    DynBitSetFormat::Write(s, valid_members);         // CompactSize + ceil(n/8)
+    s.write(std::as_bytes(std::span{quorum_public_key}));  // 48 raw wire bytes
+    s << quorum_vvec_hash;                            // 32 bytes (uint256, LE)
+
+    auto sp = s.get_span();
+    uint256 h;
+    CHash256()
+        .Write(std::span<const unsigned char>(
+            reinterpret_cast<const unsigned char*>(sp.data()), sp.size()))
+        .Finalize(std::span<unsigned char>(h.data(), 32));
+    return h;
+}
+
+// ── BLS backend ─────────────────────────────────────────────────────────────
+
+bool bls_backend_available()
+{
+#ifdef C2POOL_DASH_BLS
+    return true;
+#else
+    return false;
+#endif
+}
+
+#ifdef C2POOL_DASH_BLS
+namespace {
+
+// Robust G1 (public-key) deserialization mirroring dashcore CBLSWrapper::
+// SetBytes: try the entry's declared scheme, and if the point is invalid fall
+// back to the other scheme (a pre-V19 key relayed after the fork, or an SML
+// nVersion mismatch). Returns false when neither yields a valid point.
+bool deser_g1(const std::array<uint8_t, CFinalCommitment::BLS_PUBKEY_SIZE>& bytes,
+              bool prefer_legacy, bls::G1Element& out)
+{
+    const bls::Bytes b(bytes.data(), bytes.size());
+    for (bool legacy : {prefer_legacy, !prefer_legacy}) {
+        try {
+            bls::G1Element e = bls::G1Element::FromBytes(b, legacy);
+            if (e.IsValid()) { out = e; return true; }
+        } catch (...) { /* try the other scheme */ }
+    }
+    return false;
+}
+
+// Post-V19 signatures are BASIC scheme (fLegacy = false) — the serve floor in
+// dkg_commitments.hpp guarantees post-V19, and the commitment we admit is the
+// basic-scheme wire object.
+bool deser_g2_basic(const std::array<uint8_t, CFinalCommitment::BLS_SIG_SIZE>& bytes,
+                    bls::G2Element& out)
+{
+    try {
+        out = bls::G2Element::FromBytes(bls::Bytes(bytes.data(), bytes.size()),
+                                        /*fLegacy=*/false);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+} // namespace
+#endif // C2POOL_DASH_BLS
+
+bool verify_final_commitment(const CFinalCommitment& c,
+                             const std::vector<MemberOperatorKey>& members)
+{
+#ifndef C2POOL_DASH_BLS
+    (void)c;
+    (void)members;
+    return false;   // no BLS backend → fail closed (serve null / dashd)
+#else
+    // ── structural guards (dashcore CFinalCommitment::Verify prelude) ───────
+    if (members.empty()) return false;
+    if (c.signers.size() != members.size()) return false;
+    if (c.validMembers.size() != members.size()) return false;
+
+    const uint256 commitment_hash = build_commitment_hash(
+        c.llmqType, c.quorumHash, c.validMembers, c.quorumPublicKey,
+        c.quorumVvecHash);
+    const bls::Bytes msg(commitment_hash.data(), 32);
+    bls::BasicSchemeMPL scheme;   // post-V19
+
+    try {
+        // ── membersSig: aggregate over the SIGNERS' operator keys ───────────
+        bls::G2Element members_sig;
+        if (!deser_g2_basic(c.membersSig, members_sig)) return false;
+
+        std::vector<bls::G1Element> signer_pubkeys;
+        signer_pubkeys.reserve(members.size());
+        for (size_t i = 0; i < members.size(); ++i) {
+            if (!c.signers[i]) continue;
+            bls::G1Element pk;
+            if (!deser_g1(members[i].pubKeyOperator,
+                          members[i].legacy_scheme, pk))
+                return false;   // a signer key we cannot decode → fail closed
+            signer_pubkeys.push_back(pk);
+        }
+        if (signer_pubkeys.empty()) return false;
+
+        if (signer_pubkeys.size() == 1) {
+            // dashcore is_single_member() path: plain VerifyInsecure.
+            if (!scheme.Verify(signer_pubkeys[0], msg, members_sig))
+                return false;
+        } else {
+            if (!scheme.VerifySecure(signer_pubkeys, members_sig, msg))
+                return false;
+        }
+
+        // ── quorumSig: threshold sig against quorumPublicKey ────────────────
+        bls::G1Element quorum_pubkey =
+            bls::G1Element::FromBytes(
+                bls::Bytes(c.quorumPublicKey.data(), c.quorumPublicKey.size()),
+                /*fLegacy=*/false);
+        if (!quorum_pubkey.IsValid()) return false;
+        bls::G2Element quorum_sig;
+        if (!deser_g2_basic(c.quorumSig, quorum_sig)) return false;
+        if (!scheme.Verify(quorum_pubkey, msg, quorum_sig)) return false;
+    } catch (...) {
+        return false;   // any relic/dashbls throw → fail closed
+    }
+    return true;
+#endif // C2POOL_DASH_BLS
+}
+
+// ── seam factory ────────────────────────────────────────────────────────────
+
+std::function<bool(const CFinalCommitment&)>
+make_commitment_bls_verifier(MemberKeysProvider provider)
+{
+    if (!bls_backend_available() || !provider) {
+        // Fail-closed: verified_for() will never yield a real commitment; the
+        // provider mines the null commitment (or dashd fallback) exactly as
+        // pre-Phase-L.
+        return [](const CFinalCommitment&) { return false; };
+    }
+    return [provider = std::move(provider)](const CFinalCommitment& c) -> bool {
+        auto members = provider(c.llmqType, c.quorumHash);
+        if (!members) return false;   // member set uncertain → fail closed
+        return verify_final_commitment(c, *members);
+    };
+}
+
+} // namespace vendor
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/vendor/bls_verify.hpp
+++ b/src/impl/dash/coin/vendor/bls_verify.hpp
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// E1 Phase-L — cryptographic verification of REAL (non-null) type-6 quorum
+/// commitments, reusing Dash Core's own verify logic + BLS backend.
+///
+/// This is the piece the MineableCommitmentCache::set_bls_verify_fn seam
+/// (dkg_commitments.hpp) was cut for. Without it every DKG-window slot mines
+/// the consensus-valid NULL commitment (dashd's own behaviour when it holds no
+/// verified DKG result); with it, a peer-relayed commitment that PASSES
+/// dashcore's CFinalCommitment::Verify may be INCLUDED in the template, so a
+/// mainnet DKG-window block carries the same REAL commitment dashd's block
+/// carries (null-serve would diverge → bad-qc reject on a successful DKG).
+///
+/// REUSE-FIRST (operator mandate — vendor Dash Core, do not hand-roll):
+///
+///   * build_commitment_hash  == dashcore llmq/commitment.cpp BuildCommitmentHash
+///     (the signed preimage; byte-exact, locked by a from-wire KAT).
+///   * verify_final_commitment == dashcore CFinalCommitment::VerifySignatureAsync
+///     (checkSigs path): membersSig = VerifySecureAggregated over the signers'
+///     pubKeyOperator, quorumSig = VerifyInsecure against quorumPublicKey, both
+///     over the commitment hash. Post-V19 BASIC scheme (the serve floor in
+///     dkg_commitments.hpp guarantees post-V19).
+///   * The BLS math is dashpay/bls-signatures ("dashbls", relic-backed,
+///     Apache-2.0 — the SAME library dashd wraps in src/bls/bls.h) — linked
+///     only when C2POOL_DASH_BLS is defined (see src/impl/dash/CMakeLists.txt).
+///
+/// FAIL-CLOSED (reward-critical embedded consensus): when the BLS backend is
+/// not compiled in, OR the member operator key set cannot be sourced, OR any
+/// size is wrong, OR the BLS verify FAILS, every entry point returns false and
+/// the caller (MineableCommitmentCache::verified_for) yields nullopt → the
+/// provider mines the always-valid NULL commitment (or falls back to dashd).
+/// An unverified/forged relayed commitment is NEVER served.
+///
+/// WHY membersSig IS MANDATORY (not quorumSig alone): the commitment hash binds
+/// quorumPublicKey, and quorumSig is a self-signature by that key — a malicious
+/// peer can mint its own (sk, pk) and produce a valid quorumSig. Only membersSig
+/// (an aggregate over the ACTUAL quorum members' operator keys, which the peer
+/// does not control) proves authenticity. So Phase-L REQUIRES the real member
+/// operator key set; without it we fail closed.
+
+#include <impl/dash/coin/vendor/llmq_commitment.hpp>
+
+#include <core/uint256.hpp>
+
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <vector>
+
+namespace dash {
+namespace coin {
+namespace vendor {
+
+/// One quorum member's BLS operator public key, carrying the wire scheme the
+/// key was serialized under. The SML (E3, CSimplifiedMNListEntry) records this
+/// per entry via nVersion (VER_LEGACY_BLS == 1 → legacy, VER_BASIC_BLS == 2 →
+/// basic), so production sourcing is UNAMBIGUOUS — unlike a bare RPC hex string
+/// (a mixed quorum has keys valid under BOTH encodings; only the SML nVersion
+/// disambiguates). legacy_scheme MUST reflect that flag.
+struct MemberOperatorKey {
+    std::array<uint8_t, CFinalCommitment::BLS_PUBKEY_SIZE> pubKeyOperator{};
+    bool legacy_scheme{false};
+};
+
+/// dashcore llmq/commitment.cpp BuildCommitmentHash (@ v23.1.x, verbatim
+/// preimage): CHashWriter(SER_GETHASH) << llmqType << quorumHash
+/// << DYNBITSET(validMembers) << quorumPublicKey << quorumVvecHash, then
+/// SHA256d. No BLS dependency — usable + testable regardless of C2POOL_DASH_BLS.
+uint256 build_commitment_hash(uint8_t llmq_type, const uint256& quorum_hash,
+                              const std::vector<bool>& valid_members,
+                              const std::array<uint8_t, CFinalCommitment::BLS_PUBKEY_SIZE>& quorum_public_key,
+                              const uint256& quorum_vvec_hash);
+
+/// True iff the dashbls backend is compiled in (C2POOL_DASH_BLS). When false,
+/// verify_final_commitment / the produced verifier fn always return false and
+/// the serve path fails closed — a build without BLS keeps the pre-Phase-L
+/// null-serve posture exactly.
+bool bls_backend_available();
+
+/// Verify one commitment's crypto EXACTLY as dashcore CFinalCommitment::Verify
+/// (checkSigs) does, post-V19 basic scheme. `members` MUST be the full ordered
+/// quorum member set (index-aligned with c.signers; members.size() ==
+/// c.signers.size() == params.size). Returns true only when BOTH the aggregate
+/// membersSig and the quorumSig verify. Fail-closed (false) on: backend absent,
+/// size mismatch, empty signer set, or any BLS verify failure. Never throws.
+bool verify_final_commitment(const CFinalCommitment& c,
+                             const std::vector<MemberOperatorKey>& members);
+
+/// Sources the ordered member operator key set for a (llmqType, quorumHash).
+/// Returns std::nullopt when the set cannot be established with certainty
+/// (member selection not resolvable, SML gap, historical base list unavailable)
+/// — in which case the verifier fails closed. The keys MUST be index-aligned
+/// with the commitment's signers/validMembers bitsets.
+using MemberKeysProvider =
+    std::function<std::optional<std::vector<MemberOperatorKey>>(
+        uint8_t llmq_type, const uint256& quorum_hash)>;
+
+/// Build the MineableCommitmentCache::BlsVerifyFn (std::function<bool(const
+/// CFinalCommitment&)>) main_dash installs via set_bls_verify_fn. It sources
+/// the member set via `provider`, then runs verify_final_commitment. When the
+/// BLS backend is absent OR the provider yields nullopt, the returned fn is
+/// fail-closed (always false). `provider` may be null (always fail closed).
+std::function<bool(const CFinalCommitment&)>
+make_commitment_bls_verifier(MemberKeysProvider provider);
+
+} // namespace vendor
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/work_source.hpp
+++ b/src/impl/dash/coin/work_source.hpp
@@ -30,6 +30,7 @@
 #include <cstdint>
 #include <functional>
 #include <utility>
+#include <vector>
 
 namespace dash {
 namespace coin {
@@ -63,6 +64,16 @@ struct EmbeddedWorkInputs {
     int32_t                          best_cl_height{0};
     std::array<uint8_t, 96>          best_cl_sig{};
     int64_t                          credit_pool{0};
+
+    // E1 daemonless DKG-window seams (dkg_commitments.hpp QcBlockPlan,
+    // populated by NodeCoinState::make_embedded_work_inputs when a qc plan fn
+    // is installed): the mandatory type-6 commitment set for this height
+    // (empty off-window / all-mined) and the with-block merkleRootQuorums the
+    // CbTx must commit. Absent (default) => pre-E1 behavior byte-for-byte
+    // (no qc txs, plain compute_merkle_root_quorums root).
+    std::vector<vendor::CFinalCommitment> qc_commitments;
+    bool                             has_quorum_root_override{false};
+    uint256                          quorum_root_override;
 
     bool viable() const {
         return has_state && mnstates != nullptr && mempool != nullptr;
@@ -112,7 +123,11 @@ inline WorkSelection select_dash_work(
                 // sml/qmgr null — legacy callers unchanged).
                 /*underfill_tripped=*/nullptr,
                 emb.sml, emb.qmgr,
-                emb.best_cl_height, emb.best_cl_sig, emb.credit_pool);
+                emb.best_cl_height, emb.best_cl_sig, emb.credit_pool,
+                // E1: mandatory type-6 set + with-block quorum root.
+                emb.qc_commitments.empty() ? nullptr : &emb.qc_commitments,
+                emb.has_quorum_root_override ? &emb.quorum_root_override
+                                             : nullptr);
         },
         dashd_fallback);
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -495,6 +495,21 @@ if (BUILD_TESTING AND GTest_FOUND)
     target_link_libraries(test_dash_quorum_root PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
     gtest_add_tests(test_dash_quorum_root "" AUTO)
 
+    # E1 Phase-L: type-6 quorum-commitment BLS verify KAT. Links dash_bls_verify
+    # (which carries the C2POOL_DASH_BLS define + dashbls include/libs PUBLIC when
+    # the backend was found; a fail-closed stub otherwise). The BuildCommitmentHash
+    # byte-exactness + fail-closed KATs run in EVERY build; the BLS crypto KATs are
+    # #ifdef C2POOL_DASH_BLS-gated in the source and only exercise when linked.
+    add_executable(test_dash_bls_verify test_dash_bls_verify.cpp)
+    target_link_libraries(test_dash_bls_verify PRIVATE
+        GTest::gtest_main GTest::gtest
+        dash_bls_verify core
+        nlohmann_json::nlohmann_json
+        ${Boost_LIBRARIES}
+    )
+    target_link_libraries(test_dash_bls_verify PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
+    gtest_add_tests(test_dash_bls_verify "" AUTO)
+
     # DASH masternode state-machine (S7 leaf): vendored ProTx wire
     # (providertx.hpp) + MNState persistence (mn_state_db.hpp) +
     # apply_block RebuildListFromBlock + find_expected_payee / pick_paid_mn

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -533,6 +533,7 @@ if (BUILD_TESTING AND GTest_FOUND)
         test_dash_embedded_gbt.cpp
         test_dash_embedded_cbtx_byte_parity.cpp
         test_dash_mnlistdiff_root_parity.cpp
+        test_dash_dkg_commitments.cpp
         test_dash_sml_quorum_db.cpp)
     target_compile_definitions(test_dash_embedded_gbt PRIVATE
         DASH_FIXTURE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/fixtures")

--- a/test/test_dash_bls_verify.cpp
+++ b/test/test_dash_bls_verify.cpp
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// E1 Phase-L KATs: BLS12-381 verification of type-6 quorum commitments.
+//
+// Two independent anchors:
+//
+//   1. BuildCommitmentHash byte-exactness (ALWAYS runs, no BLS backend needed):
+//      the signed preimage of a REAL from-wire testnet commitment hashes to the
+//      value dashd itself signed. This is the hardest-to-get-right piece and is
+//      locked regardless of whether dashbls is linked.
+//
+//   2. BLS crypto (gated on C2POOL_DASH_BLS): the real from-wire quorumSig
+//      verifies against the real quorumPublicKey over that hash (ACCEPT), and
+//      tampering REJECTS; plus a fully synthetic round-trip that exercises the
+//      complete verify_final_commitment() path (membersSig aggregate + quorumSig)
+//      deterministically, and the fail-closed guards.
+//
+// The real vector was captured read-only from the testnet dashd (block 1519931,
+// llmq_50_60 quorum 0000001badbdd0…5c928798) — a successful DKG whose canonical
+// block carries the REAL (non-null) commitment, the exact mainnet case null-serve
+// would diverge on.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/vendor/bls_verify.hpp>
+#include <impl/dash/coin/vendor/llmq_commitment.hpp>
+#include <core/uint256.hpp>
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#ifdef C2POOL_DASH_BLS
+#include <dashbls/bls.hpp>
+#include <dashbls/schemes.hpp>
+#include <dashbls/elements.hpp>
+#endif
+
+using namespace dash::coin::vendor;
+
+namespace {
+
+std::vector<uint8_t> unhex(const std::string& s)
+{
+    std::vector<uint8_t> o;
+    o.reserve(s.size() / 2);
+    for (size_t i = 0; i + 1 < s.size(); i += 2)
+        o.push_back(static_cast<uint8_t>(std::stoul(s.substr(i, 2), nullptr, 16)));
+    return o;
+}
+
+template <size_t N>
+std::array<uint8_t, N> to_array(const std::vector<uint8_t>& v)
+{
+    std::array<uint8_t, N> a{};
+    EXPECT_EQ(v.size(), N);
+    for (size_t i = 0; i < N && i < v.size(); ++i) a[i] = v[i];
+    return a;
+}
+
+// uint256 from raw little-endian wire bytes (as they appear on the wire).
+uint256 u256_le(const std::string& le_hex)
+{
+    return uint256(unhex(le_hex));
+}
+
+// ── real from-wire testnet vector (llmq_50_60 @ block 1519931) ──────────────
+constexpr uint8_t kLlmqType = 1;
+const char* kQuorumHashLe =
+    "9887925c4fe116e798cb79d54f3614baf73349e85c0bf66ce9d0bdad1b000000";
+const char* kQuorumPubKey =
+    "a51db3577089e74a6aa0b3ed0e8b8697e56f43b330be3c34e88fe7d4d1e3889e"
+    "781fea3c5aa385edcbca6540ddd49fa1";
+const char* kQuorumVvecHash =
+    "77a703f2ee5498e7b79df11f8fbbd40ab5c26e660c0a8fe67443dc083e3e4524";
+const char* kQuorumSig =
+    "93a37bd57ef329e8953deb448a0348124cafa52df0e5b7ca1076fc57e9a801ae"
+    "fd445c259b1a65e43472959a3b16e3f901aa42b7e830706b5525841e3c7b388b"
+    "94be4a72da1776f52b1f90e73d8dff21831fc90332634c88311b7f7ac6aa166b";
+// SHA256d of the BuildCommitmentHash preimage, as computed against dashd's
+// signed value (independently derived from the wire, matches the quorumSig).
+const char* kExpectedCommitmentHash =
+    "fda5e2b76b8d83aa328b694b0f827b0d589babb656d81fb8b92f3b193ed86594";
+
+} // namespace
+
+// ── anchor 1: BuildCommitmentHash byte-exactness (no backend needed) ────────
+TEST(DashBlsVerify, BuildCommitmentHashRealVector)
+{
+    std::vector<bool> valid_members(50, true);   // all 50 valid on this quorum
+    uint256 h = build_commitment_hash(
+        kLlmqType, u256_le(kQuorumHashLe), valid_members,
+        to_array<48>(unhex(kQuorumPubKey)), u256_le(kQuorumVvecHash));
+
+    // h is SHA256d output stored LE; compare against the LE-hex we captured.
+    std::vector<uint8_t> got(h.data(), h.data() + 32);
+    std::vector<uint8_t> want = unhex(kExpectedCommitmentHash);
+    EXPECT_EQ(got, want)
+        << "BuildCommitmentHash preimage drifted from dashd (bad-qc risk)";
+}
+
+// ── fail-closed without a backend / provider (always meaningful) ────────────
+TEST(DashBlsVerify, FailClosedNoMembers)
+{
+    CFinalCommitment c;
+    c.llmqType = kLlmqType;
+    c.signers.assign(50, true);
+    c.validMembers.assign(50, true);
+    // Empty member set → cannot verify membersSig → false, regardless of backend.
+    EXPECT_FALSE(verify_final_commitment(c, {}));
+    // Size-mismatched member set → false.
+    std::vector<MemberOperatorKey> two(2);
+    EXPECT_FALSE(verify_final_commitment(c, two));
+}
+
+TEST(DashBlsVerify, MakeVerifierNullProviderFailsClosed)
+{
+    auto fn = make_commitment_bls_verifier(nullptr);
+    ASSERT_TRUE(static_cast<bool>(fn));
+    CFinalCommitment c;
+    c.llmqType = kLlmqType;
+    c.signers.assign(50, true);
+    c.validMembers.assign(50, true);
+    EXPECT_FALSE(fn(c));   // null provider → never serves a real commitment
+}
+
+#ifdef C2POOL_DASH_BLS
+
+// ── anchor 2a: real quorumSig verifies over the real commitment hash ────────
+TEST(DashBlsVerify, RealQuorumSigAcceptsAndTamperRejects)
+{
+    ASSERT_TRUE(bls_backend_available());
+    std::vector<bool> valid_members(50, true);
+    uint256 h = build_commitment_hash(
+        kLlmqType, u256_le(kQuorumHashLe), valid_members,
+        to_array<48>(unhex(kQuorumPubKey)), u256_le(kQuorumVvecHash));
+
+    auto pk = unhex(kQuorumPubKey);
+    auto sig = unhex(kQuorumSig);
+    bls::G1Element qpk =
+        bls::G1Element::FromBytes(bls::Bytes(pk.data(), pk.size()), false);
+    bls::G2Element qs =
+        bls::G2Element::FromBytes(bls::Bytes(sig.data(), sig.size()), false);
+    bls::BasicSchemeMPL scheme;
+
+    // real quorumSig over the real commitment hash → ACCEPT.
+    EXPECT_TRUE(scheme.Verify(qpk, bls::Bytes(h.data(), 32), qs));
+
+    // flip one bit of the hash → REJECT.
+    std::vector<uint8_t> bad(h.data(), h.data() + 32);
+    bad[7] ^= 0x01;
+    EXPECT_FALSE(scheme.Verify(qpk, bls::Bytes(bad.data(), bad.size()), qs));
+
+    // flip one byte of the signature → REJECT (or fails to deserialize).
+    auto badsig = sig;
+    badsig[20] ^= 0x01;
+    bool ok_badsig = false;
+    try {
+        bls::G2Element qsb = bls::G2Element::FromBytes(
+            bls::Bytes(badsig.data(), badsig.size()), false);
+        ok_badsig = scheme.Verify(qpk, bls::Bytes(h.data(), 32), qsb);
+    } catch (...) { ok_badsig = false; }
+    EXPECT_FALSE(ok_badsig);
+}
+
+// ── BLS smoke KAT: a self-generated keypair round-trips ─────────────────────
+TEST(DashBlsVerify, BlsSmokeSignVerify)
+{
+    bls::BasicSchemeMPL scheme;
+    std::vector<uint8_t> seed(32, 0x11);
+    bls::PrivateKey sk = scheme.KeyGen(seed);
+    bls::G1Element pk = sk.GetG1Element();
+    std::vector<uint8_t> msg = {'c', '2', 'p', 'o', 'o', 'l'};
+    bls::G2Element sig = scheme.Sign(sk, msg);
+    EXPECT_TRUE(scheme.Verify(pk, bls::Bytes(msg.data(), msg.size()), sig));
+    std::vector<uint8_t> other = {'x'};
+    EXPECT_FALSE(scheme.Verify(pk, bls::Bytes(other.data(), other.size()), sig));
+}
+
+// ── anchor 2b: full verify_final_commitment round-trip (synthetic) ──────────
+//
+// Deterministically construct a VALID commitment (real member + quorum BLS
+// keys we generate here), then assert verify_final_commitment ACCEPTS it and
+// every single-byte tamper REJECTS — exercising the complete production path
+// (BuildCommitmentHash + membersSig VerifySecure + quorumSig Verify) without the
+// scheme-ambiguity of RPC-sourced member keys.
+TEST(DashBlsVerify, VerifyFinalCommitmentSyntheticRoundTrip)
+{
+    const size_t kSize = 5;
+    bls::BasicSchemeMPL scheme;
+
+    CFinalCommitment c;
+    c.nVersion = CFinalCommitment::BASIC_BLS_NON_INDEXED_QUORUM_VERSION;
+    c.llmqType = kLlmqType;
+    c.quorumHash = u256_le(kQuorumHashLe);
+    c.quorumVvecHash = u256_le(kQuorumVvecHash);
+    c.signers.assign(kSize, true);
+    c.validMembers.assign(kSize, true);
+
+    // member operator keys
+    std::vector<MemberOperatorKey> members(kSize);
+    std::vector<bls::PrivateKey> member_sks;
+    std::vector<bls::G1Element> member_pks;
+    for (size_t i = 0; i < kSize; ++i) {
+        std::vector<uint8_t> seed(32, static_cast<uint8_t>(0x40 + i));
+        bls::PrivateKey sk = scheme.KeyGen(seed);
+        bls::G1Element pk = sk.GetG1Element();
+        member_sks.push_back(sk);
+        member_pks.push_back(pk);
+        auto raw = pk.Serialize(false);   // basic scheme wire bytes
+        for (size_t j = 0; j < 48; ++j) members[i].pubKeyOperator[j] = raw[j];
+        members[i].legacy_scheme = false;
+    }
+    // quorum threshold key
+    std::vector<uint8_t> qseed(32, 0xAB);
+    bls::PrivateKey qsk = scheme.KeyGen(qseed);
+    bls::G1Element qpk = qsk.GetG1Element();
+    {
+        auto raw = qpk.Serialize(false);
+        for (size_t j = 0; j < 48; ++j) c.quorumPublicKey[j] = raw[j];
+    }
+
+    // the commitment hash the signatures must cover
+    uint256 h = build_commitment_hash(
+        c.llmqType, c.quorumHash, c.validMembers, c.quorumPublicKey,
+        c.quorumVvecHash);
+    bls::Bytes msg(h.data(), 32);
+
+    // membersSig = secure aggregate of each member's signature over h
+    std::vector<bls::G2Element> member_sigs;
+    for (auto& sk : member_sks) member_sigs.push_back(scheme.Sign(sk, msg));
+    bls::G2Element members_sig = scheme.AggregateSecure(member_pks, member_sigs, msg);
+    {
+        auto raw = members_sig.Serialize(false);
+        for (size_t j = 0; j < 96; ++j) c.membersSig[j] = raw[j];
+    }
+    // quorumSig = the threshold key's signature over h
+    bls::G2Element quorum_sig = scheme.Sign(qsk, msg);
+    {
+        auto raw = quorum_sig.Serialize(false);
+        for (size_t j = 0; j < 96; ++j) c.quorumSig[j] = raw[j];
+    }
+
+    // ACCEPT.
+    EXPECT_TRUE(verify_final_commitment(c, members));
+
+    // tamper membersSig → REJECT.
+    {
+        CFinalCommitment t = c;
+        t.membersSig[10] ^= 0x01;
+        EXPECT_FALSE(verify_final_commitment(t, members));
+    }
+    // tamper quorumSig → REJECT.
+    {
+        CFinalCommitment t = c;
+        t.quorumSig[10] ^= 0x01;
+        EXPECT_FALSE(verify_final_commitment(t, members));
+    }
+    // tamper quorumPublicKey → REJECT (changes the hash AND the key).
+    {
+        CFinalCommitment t = c;
+        t.quorumPublicKey[10] ^= 0x01;
+        EXPECT_FALSE(verify_final_commitment(t, members));
+    }
+    // drop a signer's key (wrong member set) → REJECT.
+    {
+        auto bad_members = members;
+        bad_members[0].pubKeyOperator[5] ^= 0x01;
+        EXPECT_FALSE(verify_final_commitment(c, bad_members));
+    }
+}
+
+#endif // C2POOL_DASH_BLS

--- a/test/test_dash_dkg_commitments.cpp
+++ b/test/test_dash_dkg_commitments.cpp
@@ -1,0 +1,515 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/// E1 — daemonless type-6 quorum-commitment sourcing at DKG-window heights
+/// (dkg_commitments.hpp). Compiled into the CI-allowlisted
+/// test_dash_embedded_gbt executable.
+///
+/// Axes:
+///   * mandatory-slot math (dashcore GetNumCommitmentsRequired parity:
+///     windows, rotation fan-out, already-mined suppression, AddLLMQ order);
+///   * fail-closed surfaces (header gap, below-V19-floor => PHASE-1 refusal);
+///   * null-commitment + qc-tx byte KATs (dashcore CFinalCommitment(params,
+///     quorumHash) / GetMineableCommitmentsTx shapes);
+///   * FROM-WIRE window-height byte parity: the captured testnet mnlistdiff
+///     (block 1518412) -> QuorumManager -> daemonless plan at the WINDOW
+///     height 1518420 -> merkleRootQuorums == the root a real dashd
+///     committed (all-null plan folds nothing, so the with-block root must
+///     equal the PROVEN active-set root byte-for-byte);
+///   * with-block root fold for REAL commitments (Phase-L path): non-rotated
+///     oldest-eviction at capacity + rotated per-index replacement;
+///   * MineableCommitmentCache structural admission + the BLS-verifier gate
+///     (verified_for is nullopt until Phase L installs a verifier);
+///   * build_embedded_workdata integration: qc txs first, zero-fee, hex body
+///     filled, CbTx commits the override root.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/dkg_commitments.hpp>
+#include <impl/dash/coin/dkg_window.hpp>
+#include <impl/dash/coin/quorum_manager.hpp>
+#include <impl/dash/coin/quorum_root.hpp>
+#include <impl/dash/coin/vendor/llmq_commitment.hpp>
+#include <impl/dash/coin/vendor/quorum_tail.hpp>
+#include <impl/dash/coin/vendor/smldiff.hpp>
+
+#include <core/pack.hpp>
+#include <core/uint256.hpp>
+
+#include <algorithm>
+#include <cstring>
+#include <fstream>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+using namespace dash::coin;
+using dash::coin::vendor::CFinalCommitment;
+using dash::coin::vendor::CFinalCommitmentTxPayload;
+
+namespace {
+
+uint256 h256(uint8_t fill)
+{
+    uint256 u;
+    std::memset(u.data(), fill, 32);
+    return u;
+}
+
+// hash_at_height stub: deterministic per-height pseudo hash.
+std::optional<uint256> fake_hash_at(uint32_t h)
+{
+    uint256 u;
+    std::memset(u.data(), 0xAB, 32);
+    std::memcpy(u.data(), &h, 4);
+    return u;
+}
+
+bool never_mined(uint8_t, const uint256&) { return false; }
+
+} // namespace
+
+// ── mandatory-slot math ────────────────────────────────────────────────────
+
+TEST(DashDkgCommitments, MainnetInterval24WindowYieldsOneSlotPerType)
+{
+    // 1900800 % 24 == 0 and >= the mainnet V19 serve floor (1899072).
+    const uint32_t h = 1'900'800u + 12;   // phase 12 in [10,18]
+    auto slots = compute_required_qc_slots(
+        LlmqNetwork::Mainnet, h, fake_hash_at, never_mined);
+    ASSERT_TRUE(slots.has_value());
+    // Interval-24 mainnet types in AddLLMQ order: LLMQ_50_60 (1), LLMQ_100_67
+    // (4). 288/576-interval types are at phase 12, outside their windows.
+    ASSERT_EQ(slots->size(), 2u);
+    EXPECT_EQ((*slots)[0].params.type, 1);
+    EXPECT_EQ((*slots)[1].params.type, 4);
+    for (const auto& s : *slots) {
+        EXPECT_EQ(s.quorum_index, 0);
+        EXPECT_EQ(s.quorum_hash, *fake_hash_at(1'900'800u));
+    }
+}
+
+TEST(DashDkgCommitments, RotatedWindowFansOutPerQuorumIndexInAddLlmqOrder)
+{
+    // 1900800 is 0 mod 24/288/576, so at phase 42: LLMQ_60_75's window start
+    // ([42,50], 32 rotated slots), LLMQ_400_85's window ([20,48], 1 slot),
+    // AND the last interval-24 window height (42 % 24 == 18) — the slot list
+    // interleaves per AddLLMQ order: [50_60, 60_75 x32, 400_85, 100_67].
+    const uint32_t h = 1'900'800u + 42;
+    auto slots = compute_required_qc_slots(
+        LlmqNetwork::Mainnet, h, fake_hash_at, never_mined);
+    ASSERT_TRUE(slots.has_value());
+    ASSERT_EQ(slots->size(), 1u + 32u + 1u + 1u);
+    EXPECT_EQ((*slots)[0].params.type, 1);
+    for (int i = 0; i < 32; ++i) {
+        const auto& s = (*slots)[1 + static_cast<size_t>(i)];
+        EXPECT_EQ(s.params.type, 5);
+        EXPECT_EQ(s.quorum_index, i);
+        // Rotated base blocks: cycleStart + quorumIndex — DISTINCT hashes.
+        EXPECT_EQ(s.quorum_hash, *fake_hash_at(1'900'800u + static_cast<uint32_t>(i)));
+    }
+    EXPECT_EQ((*slots)[33].params.type, 3);
+    EXPECT_EQ(slots->back().params.type, 4);
+}
+
+TEST(DashDkgCommitments, AlreadyMinedCommitmentSuppressesItsSlot)
+{
+    const uint32_t h = 1'900'800u + 12;
+    auto mined_type1 = [](uint8_t t, const uint256&) { return t == 1; };
+    auto slots = compute_required_qc_slots(
+        LlmqNetwork::Mainnet, h, fake_hash_at, mined_type1);
+    ASSERT_TRUE(slots.has_value());
+    ASSERT_EQ(slots->size(), 1u);
+    EXPECT_EQ((*slots)[0].params.type, 4);
+}
+
+TEST(DashDkgCommitments, NonWindowHeightYieldsEmptySet)
+{
+    const uint32_t h = 1'900'800u + 4;    // phase 4 — outside every window
+    auto slots = compute_required_qc_slots(
+        LlmqNetwork::Mainnet, h, fake_hash_at, never_mined);
+    ASSERT_TRUE(slots.has_value());
+    EXPECT_TRUE(slots->empty());
+}
+
+TEST(DashDkgCommitments, HeaderGapFailsClosed)
+{
+    const uint32_t h = 1'900'800u + 12;
+    auto no_headers = [](uint32_t) -> std::optional<uint256> {
+        return std::nullopt;
+    };
+    EXPECT_FALSE(compute_required_qc_slots(
+        LlmqNetwork::Mainnet, h, no_headers, never_mined).has_value());
+}
+
+TEST(DashDkgCommitments, BelowServeFloorPreservesPhase1RefusalExactly)
+{
+    // Below the V19 floor: refuse (nullopt) INSIDE any window, serve-empty
+    // outside — i.e. byte-identical routing to the dkg_window.hpp guard.
+    for (uint32_t h = 100'000; h < 100'000 + 600; ++h) {
+        auto slots = compute_required_qc_slots(
+            LlmqNetwork::Mainnet, h, fake_hash_at, never_mined);
+        if (is_dkg_commitment_window(h)) {
+            EXPECT_FALSE(slots.has_value()) << "h=" << h;
+        } else {
+            ASSERT_TRUE(slots.has_value()) << "h=" << h;
+            EXPECT_TRUE(slots->empty()) << "h=" << h;
+        }
+    }
+}
+
+TEST(DashDkgCommitments, EverySlotHeightIsInsideTheCoarseWindowUnion)
+{
+    // The served set is a REFINEMENT of the coarse dkg_window union: any
+    // height with a non-empty mandatory set must be flagged by the old guard
+    // (the reverse is not true — that over-refusal is what E1 removes).
+    for (uint32_t h = 1'900'800u; h < 1'900'800u + 1152; ++h) {
+        auto slots = compute_required_qc_slots(
+            LlmqNetwork::Mainnet, h, fake_hash_at, never_mined);
+        ASSERT_TRUE(slots.has_value());
+        if (!slots->empty())
+            EXPECT_TRUE(is_dkg_commitment_window(h)) << "h=" << h;
+    }
+}
+
+// ── null commitment + qc tx byte KATs ──────────────────────────────────────
+
+TEST(DashDkgCommitments, NullCommitmentByteShape)
+{
+    const uint256 qh = h256(0x42);
+    auto c = build_null_commitment(kLlmq50_60, qh, 0);
+    EXPECT_EQ(c.nVersion, CFinalCommitment::BASIC_BLS_NON_INDEXED_QUORUM_VERSION);
+    EXPECT_EQ(c.llmqType, 1);
+    EXPECT_EQ(c.CountSigners(), 0);
+    EXPECT_EQ(c.CountValidMembers(), 0);
+    EXPECT_EQ(c.signers.size(), 50u);
+    EXPECT_EQ(c.validMembers.size(), 50u);
+    // Wire: u16 ver + u8 type + 32B hash + 2 x (CompactSize(50) + 7B bitset)
+    //       + 48B pk + 32B vvec + 96B qsig + 96B msig = 323 bytes.
+    auto bytes = ::pack(c);
+    EXPECT_EQ(bytes.get_span().size(), 323u);
+
+    // Rotated (indexed) variant: +2B quorumIndex, 60-bit bitsets (8B each).
+    auto cr = build_null_commitment(kLlmq60_75, qh, 7);
+    EXPECT_EQ(cr.nVersion, CFinalCommitment::BASIC_BLS_INDEXED_QUORUM_VERSION);
+    EXPECT_EQ(cr.quorumIndex, 7);
+    auto rbytes = ::pack(cr);
+    EXPECT_EQ(rbytes.get_span().size(), 2u + 1 + 32 + 2 + 2 * (1 + 8) + 48 + 32 + 96 + 96);
+}
+
+TEST(DashDkgCommitments, QcTxShapeAndPayloadRoundTrip)
+{
+    const uint32_t height = 1'900'812u;
+    const uint256 qh = h256(0x42);
+    auto c = build_null_commitment(kLlmq50_60, qh, 0);
+    auto tx = build_qc_tx(height, c);
+    EXPECT_EQ(tx.version, 3);
+    EXPECT_EQ(tx.type, 6);
+    EXPECT_TRUE(tx.vin.empty());
+    EXPECT_TRUE(tx.vout.empty());
+    EXPECT_EQ(tx.locktime, 0u);
+    // Payload: u16 ver(1) + u32 height + commitment(323) = 329 bytes,
+    // parseable by the vendored strict-tail parser and field-faithful.
+    ASSERT_EQ(tx.extra_payload.size(), 329u);
+    CFinalCommitmentTxPayload back;
+    ASSERT_TRUE(vendor::parse_qfcommit_payload(tx.extra_payload, back));
+    EXPECT_EQ(back.nVersion, 1);
+    EXPECT_EQ(back.nHeight, height);
+    EXPECT_EQ(back.commitment.quorumHash, qh);
+    EXPECT_EQ(::pack(back.commitment).get_span().size(),
+              ::pack(c).get_span().size());
+    // Full tx wire: 4B version|type + 1B vin cnt + 1B vout cnt + 4B locktime
+    //               + CompactSize(329)=3B + 329B payload = 342 bytes.
+    auto wire = ::pack(tx);
+    ASSERT_EQ(wire.get_span().size(), 342u);
+    // version|type dword: 3 | (6 << 16) => LE bytes 03 00 06 00.
+    auto sp = wire.get_span();
+    const auto* b = reinterpret_cast<const unsigned char*>(sp.data());
+    EXPECT_EQ(b[0], 0x03); EXPECT_EQ(b[1], 0x00);
+    EXPECT_EQ(b[2], 0x06); EXPECT_EQ(b[3], 0x00);
+}
+
+// ── FROM-WIRE window-height byte parity ────────────────────────────────────
+
+namespace {
+
+std::vector<unsigned char> read_mnlistdiff_fixture()
+{
+    const std::string path =
+        std::string(DASH_FIXTURE_DIR) + "/dash_testnet_mnlistdiff_1518412.bin";
+    std::ifstream f(path, std::ios::binary);
+    EXPECT_TRUE(f.good()) << "cannot open fixture: " << path;
+    return std::vector<unsigned char>(std::istreambuf_iterator<char>(f),
+                                      std::istreambuf_iterator<char>());
+}
+
+// dashd's committed merkleRootQuorums for block 1518413 (same anchor as
+// test_dash_mnlistdiff_root_parity.cpp).
+const char* kExpQuorumRoot =
+    "1901c17202846e585a92ee7b858f5716a5a3c33d0afae06f245ae07e7bff1dfb";
+
+} // namespace
+
+TEST(DashDkgCommitments, FromWireWindowHeightPlanMatchesDashdQuorumRoot)
+{
+    // Wire -> QuorumManager (the same path the live maintainer runs).
+    auto bytes = read_mnlistdiff_fixture();
+    ::PackStream in(bytes);
+    vendor::CSimplifiedMNListDiff diff;
+    in >> diff;
+    ASSERT_EQ(in.cursor_size(), 0u);
+    vendor::QuorumTail tail;
+    ASSERT_TRUE(vendor::parse_quorum_tail(diff.quorum_tail, tail));
+    QuorumManager qmgr;
+    qmgr.apply(tail);
+    ASSERT_GT(qmgr.active_count(), 0u);
+
+    // 1518420 is a DKG mining-window height on testnet (phase 12 of the
+    // 24-block cycle => LLMQ_50_60 / LLMQ_100_67 / LLMQ_25_67 windows; the
+    // 288/576-cycle types are at phase 84, off-window). Cycle start 1518408.
+    const uint32_t next_h = 1'518'420u;
+    ASSERT_TRUE(is_dkg_commitment_window(next_h));  // PHASE-1 refused here
+
+    auto height_of = [](const uint256&) -> std::optional<uint32_t> {
+        ADD_FAILURE() << "eviction ordering must not be needed for an "
+                         "all-null plan";
+        return std::nullopt;
+    };
+    auto plan = build_daemonless_qc_plan(
+        LlmqNetwork::Testnet, next_h, qmgr, fake_hash_at, height_of);
+    ASSERT_TRUE(plan.has_value());
+
+    // The current cycle's quorums cannot be in the (older) fixture set, so
+    // all three interval-24 testnet types need a commitment — served as the
+    // consensus-valid nulls dashd itself mines without a DKG result.
+    ASSERT_EQ(plan->commitments.size(), 3u);
+    EXPECT_EQ(plan->commitments[0].llmqType, 1);
+    EXPECT_EQ(plan->commitments[1].llmqType, 4);
+    EXPECT_EQ(plan->commitments[2].llmqType, 6);
+    for (const auto& c : plan->commitments) {
+        EXPECT_EQ(c.CountSigners(), 0);
+        EXPECT_EQ(c.CountValidMembers(), 0);
+        EXPECT_EQ(c.quorumHash, *fake_hash_at(1'518'408u));
+    }
+
+    // BYTE PARITY: null commitments fold nothing, so the with-block root the
+    // CbTx commits at this WINDOW height must equal the root a real dashd
+    // committed over the same wire-fed active set.
+    EXPECT_EQ(plan->merkle_root_quorums.GetHex(), kExpQuorumRoot);
+    EXPECT_EQ(plan->merkle_root_quorums, compute_merkle_root_quorums(qmgr));
+}
+
+// ── with-block fold: real commitments (Phase-L path) ───────────────────────
+
+namespace {
+
+CFinalCommitment real_commitment(const LlmqParamsView& p, const uint256& qh,
+                                 int16_t qi, uint8_t seed)
+{
+    CFinalCommitment c;
+    c.nVersion = p.use_rotation
+        ? CFinalCommitment::BASIC_BLS_INDEXED_QUORUM_VERSION
+        : CFinalCommitment::BASIC_BLS_NON_INDEXED_QUORUM_VERSION;
+    c.llmqType    = p.type;
+    c.quorumHash  = qh;
+    c.quorumIndex = qi;
+    c.signers.assign(p.size, true);
+    c.validMembers.assign(p.size, true);
+    c.quorumPublicKey.fill(seed);
+    c.quorumVvecHash = h256(seed);
+    c.quorumSig.fill(seed);
+    c.membersSig.fill(seed);
+    return c;
+}
+
+} // namespace
+
+TEST(DashDkgCommitments, WithBlockFoldEvictsOldestNonRotatedAtCapacity)
+{
+    // LLMQ_400_60 (type 2): signingActiveQuorumCount = 4. Fill to capacity,
+    // fold one real commitment: the LOWEST-base-height leaf must drop.
+    QuorumManager qmgr;
+    vendor::QuorumTail tail;
+    std::vector<uint256> hashes;
+    for (uint8_t i = 0; i < 4; ++i) {
+        const uint256 qh = h256(static_cast<uint8_t>(0x10 + i));
+        hashes.push_back(qh);
+        tail.newQuorums.push_back(real_commitment(kLlmq400_60, qh, 0,
+                                                  static_cast<uint8_t>(i + 1)));
+    }
+    qmgr.apply(tail);
+    ASSERT_EQ(qmgr.active_count(), 4u);
+    auto height_of = [&](const uint256& qh) -> std::optional<uint32_t> {
+        for (size_t i = 0; i < hashes.size(); ++i)
+            if (hashes[i] == qh) return 1000u + 288u * static_cast<uint32_t>(i);
+        return std::nullopt;
+    };
+    auto newc = real_commitment(kLlmq400_60, h256(0x99), 0, 0x77);
+    auto root = compute_merkle_root_quorums_with_block(
+        LlmqNetwork::Mainnet, qmgr, {newc}, height_of);
+    ASSERT_TRUE(root.has_value());
+
+    // Expected: leaves of entries 1..3 (entry 0 = lowest height, evicted)
+    // + the new commitment, sorted, merkled — via the PROVEN primitives.
+    std::vector<uint256> leaves;
+    for (size_t i = 1; i < 4; ++i)
+        leaves.push_back(hash_commitment(*qmgr.find(2, hashes[i])));
+    leaves.push_back(hash_commitment(newc));
+    std::sort(leaves.begin(), leaves.end(),
+        [](const uint256& a, const uint256& b) {
+            return std::memcmp(a.data(), b.data(), 32) < 0;
+        });
+    EXPECT_EQ(*root, compute_merkle_root_local(leaves));
+
+    // And an unknown base height while eviction is needed => fail closed.
+    auto unknown = [](const uint256&) -> std::optional<uint32_t> {
+        return std::nullopt;
+    };
+    EXPECT_FALSE(compute_merkle_root_quorums_with_block(
+        LlmqNetwork::Mainnet, qmgr, {newc}, unknown).has_value());
+}
+
+TEST(DashDkgCommitments, WithBlockFoldReplacesRotatedSameIndexAndSkipsNulls)
+{
+    QuorumManager qmgr;
+    vendor::QuorumTail tail;
+    tail.newQuorums.push_back(real_commitment(kLlmq60_75, h256(0x20), 0, 0x01));
+    tail.newQuorums.push_back(real_commitment(kLlmq60_75, h256(0x21), 1, 0x02));
+    qmgr.apply(tail);
+    ASSERT_EQ(qmgr.active_count(), 2u);
+    auto no_heights = [](const uint256&) -> std::optional<uint32_t> {
+        return std::nullopt;   // must never be needed for rotated replacement
+    };
+
+    // Replace index 1; also carry a NULL commitment — folded root must skip it.
+    auto repl = real_commitment(kLlmq60_75, h256(0x31), 1, 0x03);
+    auto nullc = build_null_commitment(kLlmq50_60, h256(0x40), 0);
+    auto root = compute_merkle_root_quorums_with_block(
+        LlmqNetwork::Mainnet, qmgr, {repl, nullc}, no_heights);
+    ASSERT_TRUE(root.has_value());
+
+    std::vector<uint256> leaves{
+        hash_commitment(*qmgr.find(5, h256(0x20))),
+        hash_commitment(repl)};
+    std::sort(leaves.begin(), leaves.end(),
+        [](const uint256& a, const uint256& b) {
+            return std::memcmp(a.data(), b.data(), 32) < 0;
+        });
+    EXPECT_EQ(*root, compute_merkle_root_local(leaves));
+
+    // All-null fold == the plain PROVEN root (the E1 steady-state identity).
+    auto null_only = compute_merkle_root_quorums_with_block(
+        LlmqNetwork::Mainnet, qmgr, {nullc}, no_heights);
+    ASSERT_TRUE(null_only.has_value());
+    EXPECT_EQ(*null_only, compute_merkle_root_quorums(qmgr));
+}
+
+// ── MineableCommitmentCache: the Phase-L line ──────────────────────────────
+
+TEST(DashDkgCommitments, MineableCacheStructuralAdmissionAndBlsGate)
+{
+    MineableCommitmentCache cache;
+    const uint256 qh = h256(0x55);
+    auto good = real_commitment(kLlmq50_60, qh, 0, 0x11);
+
+    // Structural rejects: wrong version / short bitsets / below threshold /
+    // null crypto fields.
+    {
+        auto bad = good; bad.nVersion = CFinalCommitment::LEGACY_BLS_NON_INDEXED_QUORUM_VERSION;
+        EXPECT_FALSE(cache.ingest(LlmqNetwork::Mainnet, bad));
+    }
+    {
+        auto bad = good; bad.signers.assign(10, true);
+        EXPECT_FALSE(cache.ingest(LlmqNetwork::Mainnet, bad));
+    }
+    {
+        auto bad = good;
+        bad.signers.assign(50, false);
+        for (int i = 0; i < 29; ++i) bad.signers[static_cast<size_t>(i)] = true;  // threshold is 30
+        EXPECT_FALSE(cache.ingest(LlmqNetwork::Mainnet, bad));
+    }
+    {
+        auto bad = good; bad.quorumSig.fill(0);
+        EXPECT_FALSE(cache.ingest(LlmqNetwork::Mainnet, bad));
+    }
+    EXPECT_EQ(cache.size(), 0u);
+
+    ASSERT_TRUE(cache.ingest(LlmqNetwork::Mainnet, good));
+    EXPECT_EQ(cache.size(), 1u);
+
+    // THE Phase-L line: without a BLS verifier the cache NEVER serves — the
+    // provider must mine the consensus-valid null commitment instead.
+    EXPECT_FALSE(cache.has_bls_verifier());
+    EXPECT_FALSE(cache.verified_for(1, qh).has_value());
+    auto plan_commitments = daemonless_qc_commitments(
+        LlmqNetwork::Mainnet, 1'900'812u, fake_hash_at, never_mined, &cache);
+    ASSERT_TRUE(plan_commitments.has_value());
+    for (const auto& c : *plan_commitments)
+        EXPECT_EQ(c.CountSigners(), 0) << "unverified commitment served";
+
+    // With a (stub) verifier installed the cached commitment is served.
+    cache.set_bls_verify_fn([](const CFinalCommitment&) { return true; });
+    auto served = cache.verified_for(1, qh);
+    ASSERT_TRUE(served.has_value());
+    EXPECT_EQ(::pack(*served).get_span().size(), ::pack(good).get_span().size());
+    // And a failing verifier withholds it again.
+    cache.set_bls_verify_fn([](const CFinalCommitment&) { return false; });
+    EXPECT_FALSE(cache.verified_for(1, qh).has_value());
+}
+
+// ── template integration ───────────────────────────────────────────────────
+
+#include <impl/dash/coin/embedded_gbt.hpp>
+#include <impl/dash/coin/mn_state_machine.hpp>
+#include <impl/dash/coin/mempool.hpp>
+
+TEST(DashDkgCommitments, EmbeddedWorkdataCarriesQcTxsFirstAndOverrideRoot)
+{
+    MnStateMachine mnstates;
+    Mempool mempool;
+    vendor::CSimplifiedMNList sml;   // empty — root ZERO, irrelevant here
+    QuorumManager qmgr;
+
+    const uint32_t prev_h = 1'900'811u;
+    std::vector<CFinalCommitment> qcs{
+        build_null_commitment(kLlmq50_60, h256(0x42), 0),
+        build_null_commitment(kLlmq100_67, h256(0x42), 0)};
+    const uint256 override_root = h256(0x66);
+
+    auto w = build_embedded_workdata(
+        prev_h, h256(0x01), mnstates, mempool,
+        /*bits*/ 0x1a012345u, /*mtp*/ 1000u, /*addr_ver*/ 76, /*p2sh*/ 16,
+        /*curtime*/ 1234u, /*version*/ 0x20000000u,
+        /*underfill*/ nullptr, &sml, &qmgr,
+        /*best_cl_height*/ 0, k_zero_cl_sig, /*credit_pool*/ 0,
+        &qcs, &override_root);
+
+    // qc txs first, zero-fee, body hex filled for submit-time assembly.
+    ASSERT_EQ(w.m_txs.size(), 2u);
+    ASSERT_EQ(w.m_tx_hashes.size(), 2u);
+    ASSERT_EQ(w.m_tx_fees.size(), 2u);
+    ASSERT_EQ(w.m_tx_data_hex.size(), 2u);
+    for (size_t i = 0; i < 2; ++i) {
+        EXPECT_EQ(w.m_txs[i].type, 6);
+        EXPECT_EQ(w.m_tx_fees[i], 0u);
+        MutableTransaction expect = build_qc_tx(prev_h + 1, qcs[i]);
+        EXPECT_EQ(w.m_txs[i].extra_payload, expect.extra_payload);
+        EXPECT_EQ(w.m_tx_hashes[i], dash_txid(expect));
+        EXPECT_FALSE(w.m_tx_data_hex[i].empty());
+    }
+
+    // The CbTx commits the override (with-block) quorum root.
+    vendor::CCbTx cb;
+    ASSERT_TRUE(vendor::parse_cbtx(w.m_coinbase_payload, cb));
+    EXPECT_EQ(cb.merkleRootQuorums, override_root);
+
+    // Without the qc seams the very same call is byte-identical to pre-E1:
+    // no txs, plain (empty-set => ZERO) root.
+    auto w0 = build_embedded_workdata(
+        prev_h, h256(0x01), mnstates, mempool,
+        0x1a012345u, 1000u, 76, 16, 1234u, 0x20000000u,
+        nullptr, &sml, &qmgr, 0, k_zero_cl_sig, 0);
+    EXPECT_TRUE(w0.m_txs.empty());
+    vendor::CCbTx cb0;
+    ASSERT_TRUE(vendor::parse_cbtx(w0.m_coinbase_payload, cb0));
+    EXPECT_EQ(cb0.merkleRootQuorums, uint256::ZERO);
+}

--- a/test/test_dash_node_coin_state.cpp
+++ b/test/test_dash_node_coin_state.cpp
@@ -419,6 +419,84 @@ TEST(DashNodeCoinState, DkgCommitmentHeightRefusesEmbedded) {
     EXPECT_TRUE(st.make_embedded_work_inputs().viable());
 }
 
+// E1 — daemonless DKG-window serving: with a qc plan installed the SAME
+// window height that BLOCKER-1 refused is SERVED, the template carries the
+// mandatory type-6 txs (dkg_commitments.hpp plan, testnet types 1/4/6 at an
+// interval-24 window height), and the pre-emit gate both accepts the honest
+// template and discards a tampered one (missing commitment => the block
+// dashd would reject as bad-qc-missing never leaves the node).
+TEST(DashNodeCoinState, QcPlanServesDkgWindowHeightAndEmitGateEnforcesIt) {
+    NodeCoinState st;
+    seed_single_mn(st, p2pkh_script(0x30));
+    seed_sml(st);
+    st.set_require_sml(true);
+    st.set_commitment_window_fn(
+        [](uint32_t next_h) { return dash::coin::is_dkg_commitment_window(next_h); });
+    // The same closure shape main_dash installs: the daemonless plan over
+    // the node's own QuorumManager + a header-chain hash-at-height lookup.
+    st.set_qc_plan_fn([&st](uint32_t next_h) {
+        return dash::coin::build_daemonless_qc_plan(
+            dash::coin::LlmqNetwork::Testnet, next_h, st.qmgr(),
+            [](uint32_t h) -> std::optional<uint256> {
+                uint256 u;
+                std::memset(u.data(), 0xCD, 32);
+                std::memcpy(u.data(), &h, 4);
+                return u;
+            },
+            [](const uint256&) -> std::optional<uint32_t> {
+                return std::nullopt;   // never needed for an all-null plan
+            });
+    });
+
+    // Tip 1518417 => next block 1518418 (phase 10: the exact height the
+    // BLOCKER-1 test above proves REFUSED without a plan).
+    st.set_sml_current_hash(raw256(0xAB));
+    st.set_tip(1518417, raw256(0xAB), 0x1b104be3u, 1'700'000'000u,
+               DASH_PUBKEY_VER, DASH_P2SH_VER, 1'700'000'123u, 0x20000000u);
+
+    auto e = st.make_embedded_work_inputs();
+    ASSERT_TRUE(e.viable())
+        << "E1: a DKG window height must now be SERVED daemonlessly";
+    // Testnet interval-24 types LLMQ_50_60 / LLMQ_100_67 / LLMQ_25_67, all
+    // unmined in the (empty) quorum set => 3 mandatory null commitments.
+    ASSERT_EQ(e.qc_commitments.size(), 3u);
+    ASSERT_TRUE(e.has_quorum_root_override);
+
+    bool fallback_called = false;
+    WorkSelection sel = st.select_work([&]() {
+        fallback_called = true;
+        return DashWorkData{};
+    });
+    EXPECT_EQ(sel.source, WorkSource::Embedded);
+    EXPECT_FALSE(fallback_called);
+    ASSERT_EQ(sel.work.m_txs.size(), 3u);
+    for (size_t i = 0; i < 3; ++i)
+        EXPECT_EQ(sel.work.m_txs[i].type, 6) << "qc txs must lead the tx set";
+    EXPECT_TRUE(st.embedded_template_emit_ok(sel.work))
+        << "the honest daemonless qc template must pass the pre-emit gate";
+
+    // Tampered: drop one mandatory commitment => the emit gate must discard
+    // (that block is dashd bad-qc-missing).
+    DashWorkData tampered = sel.work;
+    tampered.m_txs.pop_back();
+    EXPECT_FALSE(st.embedded_template_emit_ok(tampered));
+
+    // Tampered: wrong committed quorum root => discard (wrong-root block).
+    DashWorkData wrong_root = sel.work;
+    {
+        dash::coin::vendor::CCbTx cb;
+        ASSERT_TRUE(dash::coin::vendor::parse_cbtx(wrong_root.m_coinbase_payload, cb));
+        cb.merkleRootQuorums = raw256(0x5A);
+        wrong_root.m_coinbase_payload = dash::coin::encode_cbtx(cb);
+    }
+    EXPECT_FALSE(st.embedded_template_emit_ok(wrong_root));
+
+    // And a plan fn that cannot derive the set (header gap) fails closed —
+    // the PHASE-1 reward-safe routing, not a wrong block.
+    st.set_qc_plan_fn([](uint32_t) { return std::nullopt; });
+    EXPECT_FALSE(st.make_embedded_work_inputs().viable());
+}
+
 // BLOCKER-2 viability: a stale/absent bestCL fails closed; a fresh one serves.
 TEST(DashNodeCoinState, StaleBestClRefusesEmbedded) {
     NodeCoinState st;


### PR DESCRIPTION
## What this closes (E1)

The embedded DASH template arm FAILED CLOSED to the dashd fallback at every DKG-commitment-window height — the `(24,[10,18])` window alone is 37.5% of all heights, the full union ~44% — because it could not produce block-N's OWN mandatory type-6 LLMQ quorum commitments (`bad-qc-missing` + wrong `merkleRootQuorums`). This PR serves those heights daemonlessly. Superblock heights (1 in 16616) keep the reward-safe refusal (see "Superblocks" below).

## The daemonless design (reuse-first: every rule is dashcore's own, at the vendored pin cfad414)

`src/impl/dash/coin/dkg_commitments.hpp` (new) ports, without re-derivation:

1. **Which commitments are mandatory** — `llmq/blockprocessor.cpp GetNumCommitmentsRequired/IsMiningPhase`: per enabled llmqType, inside `[cycleStart+windowStart, cycleStart+windowEnd]`, one commitment per quorumIndex (`rotation ? signingActiveQuorumCount : 1`) whose quorum base block (`cycleStart+index`) exists and whose commitment is not yet mined. Params table + per-network enabled sets (AddLLMQ order — also the miner's qc-tx emission order) copied verbatim from `llmq/params.h` + `chainparams.cpp`, with the same re-diff-on-pin-bump maintenance rule as `dkg_window.hpp`.
2. **`HasMinedCommitment` without dashd** — the mnlistdiff-fed `QuorumManager` IS `GetMinedAndActiveCommitmentsUntilBlock(tip)` (that is exactly what `evo/smldiff.cpp BuildQuorumsDiff` serializes, inclusive of commitments mined AT the tip), and embedded viability already requires the SML/quorum state current at the tip we build on. A commitment mined earlier in the current window is necessarily still active, so `has_mined == qmgr.find(type, baseHash)`.
3. **Content** — the consensus-valid **NULL commitment**, i.e. dashcore's own `GetMineableCommitments` "null commitment required" arm (`CFinalCommitment(params, quorumHash)`, version `GetVersion(rotation, basic_bls)`): exactly what dashd itself mines when it holds no verified DKG result. `ProcessBlock` requires `numInBlock == numRequired` and accepts nulls via `VerifyNull`; `CalcCbTxMerkleRootQuorums` **skips** nulls.
4. **`merkleRootQuorums`** — unchanged by an all-null set, so the committed root is the PROVEN from-wire `compute_merkle_root_quorums` (#780). The full `evo/cbtx.cpp` **with-block fold** (non-rotated oldest-eviction at `signingActiveQuorumCount` capacity — ordered by quorum-base height off the header chain, which equals mined order per type; rotated per-`quorumIndex` replacement; null skip) is implemented and KAT'd now, so Phase-L real commitments only flip a verifier.
5. **Placement** — qc txs immediately after the coinbase, before mempool txs (`node/miner.cpp CreateNewBlock` position), zero-fee. Also fills `m_tx_data_hex` on the embedded arm (previously only the dashd-GBT parser filled it — the submit-time block body source).

**Gating**: the plan installs only where the embedded arm is enabled (testnet, or mainnet behind the existing `--embedded-mainnet` opt-in, default OFF — graduation stays soak-gated). Below a per-network **V19 serve floor** (mainnet 1899072 / testnet 850100 — also covers `--regtest` chains riding the testnet flag, where a qc tx would be `bad-qc-premature`) the PHASE-1 refusal is preserved exactly. Any underivable height (header gap at a quorum base, unorderable eviction) => `nullopt` => fail closed to the dashd fallback — never a wrong block.

**Invariant enforcement**: the pre-emit HARD GATE (`NodeCoinState::embedded_template_emit_ok`) re-derives the same deterministic plan and discards any template whose type-6 payload set (count, bytes, order) or committed quorum root drifts — a `bad-qc-missing`/`bad-qc-not-allowed`/wrong-root block cannot leave the node. The GBT-xcheck backstop and the dashd fallback arm are untouched.

## BLS / Phase-L determination (reuse-first, with evidence)

**Question**: can we vendor/reuse Dash Core's own quorum-commitment sourcing + verification and its BLS backend inside the embedded arm, rather than hand-rolling?

**Answer: YES — and E1 needs none of it to be consensus-valid at window heights.** The null-commitment path above is itself reused dashd miner behavior and requires no BLS. For REAL (non-null) commitments — matching dashd's template byte-for-byte when a DKG succeeded — the concrete reuse plan, all seams landed in this PR:

1. **Sourcing (landed here)**: dashd relays every VERIFIED final commitment to all peers as inv `MSG_QUORUM_FINAL_COMMITMENT` (21) + `qfcommit` (`llmq/blockprocessor.cpp ProcessMessage/AddMineableCommitment`) — the exact stream its own miner mines from. This PR pulls the inv, parses the (already-vendored) `CFinalCommitment`, and feeds `MineableCommitmentCache` with full structural validation (`VerifySizes`, thresholds, version, non-null crypto fields — every `CFinalCommitment::Verify` check except the BLS math). `[QC-MINEABLE]` is the live observability signal.
2. **Verification (the exact remaining piece — scoped, not vague)**: vendor, at the same pin and in the same `vendor/` pattern as `llmq_commitment.hpp`:
   - `llmq/commitment.cpp` — `CFinalCommitment::Verify(checkSigs=true)` + `BuildCommitmentHash` (the signed preimage);
   - `llmq/utils.cpp` — `ComputeQuorumMembers`/`CalculateQuorum` (deterministic member selection: score = hash(proTxHash, confirmedHash, modifier); the SML we already sync carries proRegTxHash + confirmedHash + pubKeyOperator — every input, for non-rotated types);
   - `llmq/snapshot.{h,cpp}` — `CQuorumRotationInfo`/`CQuorumSnapshot` + `ComputeQuorumMembersByQuarterRotation` for ROTATED types, fed from the `qrinfo`/`getqrinfo` light-client protocol on the SAME coin-P2P client that already speaks `getmnlistd`/`mnlistdiff` (qrinfo carries the cycle-base mnlistdiffs = the historical-SML input member selection needs);
   - **BLS backend**: link `dashpay/bls-signatures` ("bls-dash", the Chia-BLS fork dashd itself wraps via `src/bls/bls.h`), relic-backed, CMake, Apache-2.0 (engine-license compatible). **Verified absent today**: no BLS lib in `conanfile.txt` (boost/nlohmann/yaml-cpp/gtest/leveldb/zeromq only) or `vendor/`; `vendor/llmq_commitment.hpp` adaptation note 3 explicitly defers point decompression/verification to Phase L.
3. **Seam (landed here)**: `MineableCommitmentCache::set_bls_verify_fn` — Phase L installs the vendored verifier there; nothing else changes (`verified_for` returns nothing until then, so unverified relayed commitments are never mined — a malicious peer cannot hand us a `bad-qc-invalid` block).
4. **Residual after that**: none for the miner role. c2pool never PARTICIPATES in DKG (that requires masternode operator keys and is not a miner concern); it only verifies-and-includes, which the vendored `Verify` + member computation + bls-dash cover.

Consequence of the interim null-only posture: on the rare block where we win a window height AND a real commitment existed, that quorum activates a few blocks later via another miner (dashd accepts our null block as valid; windows are 9 blocks). Phase L removes even that.

## Superblocks (analogous gap, separately scoped)

Still refused (reward-safe fallback). The daemonless piece is NOT BLS: it is governance-trigger sourcing — vendor `governance/classes.cpp CSuperblock::GetPayeeData`/`CSuperblockManager::GetSuperblockPayments` and sync the trigger gobjects + votes over coin-P2P (`govsync`/`govobj`/`govobjvote`, ECDSA-signed votes tallied against the DMN set we already hold). Follow-up scope, unchanged behavior here.

## What's daemonless NOW vs still-fallback

| Height class | Before | After |
|---|---|---|
| Plain heights | embedded | embedded (unchanged) |
| DKG windows, all cycle commitments already mined | REFUSED | embedded (plain template, zero qc txs) |
| DKG windows, commitments pending | REFUSED | embedded with mandatory null qc txs |
| DKG windows, underivable (header gap / below V19 floor / --regtest) | REFUSED | refused (unchanged fail-closed) |
| Superblock heights | REFUSED | refused (scoped follow-up above) |

## Byte-parity KAT (folded into CI-allowlisted `test_dash_embedded_gbt`)

`test/test_dash_dkg_commitments.cpp` (14 tests): the captured testnet `mnlistdiff` @1518412 -> `QuorumManager` -> daemonless plan at **window height 1518420** -> 3 mandatory commitments (types 1/4/6, correct order/hashes) -> `merkleRootQuorums` **byte-equal to the root a real dashd committed** (`1901c172…`); dashcore-parity slot math incl. the 35-slot rotated fan-out at phase 42 (50_60 + 60_75 x32 + 400_85 + 100_67); null-commitment/qc-tx wire-shape KATs (323/342-byte vectors, version|type dword); below-floor refusal proven byte-identical to the PHASE-1 guard over 600 consecutive heights; with-block fold eviction/replacement vs hand-built leaf sets; cache admission + BLS gate. Plus an end-to-end `NodeCoinState` test: the exact height the BLOCKER-1 test proves refused without a plan is now served, the emit gate passes the honest template and discards a tampered one (dropped commitment, wrong root).

## Verification

- `test_dash_embedded_gbt` 37/37 (incl. all prior byte-parity suites), `test_dash_node_coin_state` 16/16 (new end-to-end), plus green: work_source (9), stratum_work_source (44), get_work (4), p2p_messages (8), p2p_node (16), node_reception_wire (21), node_embedded_wire (3), embedded_relay_e2e (4), coin_state_maintainer (11), block_producer (9), quorum_root (11), quorum, p2p_connection (4).
- `c2pool-dash` builds clean; smoke-run OK.
- Default-path safety: no qc plan fn installed => every touched surface is byte-for-byte pre-E1 (KAT'd); the dashd fallback + GBT-xcheck safety net stays throughout maturation.

Do NOT merge — integrator review + soak gate (v37-dev steward) before merge.
