### PR TITLE
[DO-NOT-MERGE][hotel orphan fix] dash(mint): producer-job cache must invalidate on template tx-set/fee drift

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -907,12 +907,18 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     }
 
     // ARM B binding: EMPTY when no dashd creds are armed (daemonless deployment).
-    // ignore_failure=true so a duplicate/already-have after an ARM A accept is
-    // success, not failure, and never masks the primary win.
+    // ignore_failure=false: submitblock_result_accepted() ALREADY treats
+    // duplicate/inconclusive/already-have as success (so an ARM A accept is
+    // never re-reported as failure); what ignore_failure=true additionally
+    // suppressed was the ONLY record of a REAL dashd rejection reason. On the
+    // hotel mainnet orphans (h2508929/h2509044) the bad-cb-payee verdict was
+    // swallowed and the log showed just "no-ack", masking a consensus-invalid
+    // block as a mere broadcast hiccup. A won-block rejection reason is
+    // reward-critical diagnosis: log it loudly.
     dash::coin::RpcSubmitSink rpc_submit;
     if (rpc) {
         rpc_submit = [&rpc](const std::string& block_hex) -> bool {
-            return rpc->submit_block_hex(block_hex, /*ignore_failure=*/true);
+            return rpc->submit_block_hex(block_hex, /*ignore_failure=*/false);
         };
     }
 
@@ -1073,12 +1079,40 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 const ProducerJobKey key{prev_share_hash, payout_script};
 
                 // Cache hit: same sharechain tip, same coin template, fresh.
+                //
+                // "Same coin template" MUST mean the same TX SET, not merely the
+                // same tip+height: dashd re-sources GBT ~every 30 s at the SAME
+                // (tip, height) while the mempool moves, and the masternode
+                // payout amount inside the cached gentx is fee-dependent
+                // (MN share of subsidy+fees). Serving a cached gentx built over
+                // an older poll's fee total while build_connection_coinbase
+                // freezes the CURRENT wd's tx set around it yields a merkle-
+                // consistent but consensus-INVALID block: the coinbase underpays
+                // the MN payee by the fee delta's share and dashd rejects it
+                // with bad-cb-payee (hotel mainnet h2508929: paid the exact
+                // GBT@fees=1074 amount vs expected GBT@fees=1301 amount;
+                // h2509044: paid GBT@fees=85791 vs expected GBT@fees=88051 --
+                // both found blocks lost). desired_tx_hashes equality pins the
+                // cached coinbase to the exact tx set (and therefore the exact
+                // fee total) it was computed for; payment_amount equality is the
+                // cheap belt for any same-height payment-array drift.
                 if (auto it = job_cache->find(key); it != job_cache->end()) {
                     auto& e = it->second;
                     if (e.coin_tip == wd.m_previous_block && e.height == wd.m_height
+                        && e.build.frozen.payment_amount == wd.m_payment_amount
+                        && e.build.frozen.desired_tx_hashes == wd.m_tx_hashes
                         && now - e.at < std::chrono::seconds(30)) {
                         mint_registry->put(e.build.job.ref_hash, e.build.frozen);
                         return e.build.job;
+                    }
+                    if (e.coin_tip == wd.m_previous_block && e.height == wd.m_height
+                        && now - e.at < std::chrono::seconds(30)) {
+                        static int drift_log = 0;
+                        if (drift_log++ % 20 == 0)
+                            LOG_INFO << "[MINT] producer job cache invalidated: "
+                                        "template tx-set/fee drift at same tip "
+                                        "(h=" << wd.m_height << ") -- rebuilding "
+                                        "gentx over the current template";
                     }
                     job_cache->erase(it);
                 }


### PR DESCRIPTION
## DO NOT MERGE — for operator/integrator review (hotel reward-safety)

### Incident
The hotel DASH node lost 2 of its recent found blocks (h2508929, h2509044) — logged as "submitblock RPC backup no-ack" + p2p-relay-only, previously read as a block-propagation race. It was NOT a race: **both blocks were consensus-invalid (bad-cb-payee) and rejected by our own dashd**; the competing blocks arrived 119 s and 131 s later. Since `--coin-p2p-connect` points at the same local dashd (127.0.0.1:9999), both broadcast arms terminate at one node — a rejected block reaches nobody.

### Root cause
The per-(prev_share_hash, payout_script) producer-job cache in `main_dash.cpp` treated "same template" as (coin_tip, height, 30 s TTL). dashd re-sources GBT ~every 30 s at the SAME tip while mempool fees move, and the masternode payout inside the cached gentx is fee-dependent (MN share of subsidy+fees). A cache hit across a GBT refresh serves the OLD gentx while `build_connection_coinbase::freeze_snapshot` attaches the NEW template's tx set — merkle-consistent, PoW-valid, but the coinbase underpays the MN payee by the fee delta's share → `bad-cb-payee`.

### Field proof (hotel dashd debug.log, 2026-07-22, duff-exact)
| block | coinbase paid MN | == GBT poll | dashd expected | == GBT poll |
|---|---|---|---|---|
| h2509044 | 83,043,643 | 09:47:19Z (fees 85,791) | 83,045,338 | 09:47:49Z (fees 88,051; 36 tx = the block's exact tx set) |
| h2508929 | 82,980,105 | 04:40:11Z (fees 1,074) | 82,980,275 | 04:41:42Z (fees 1,301; 4 tx = the block's exact tx set) |

Both pairs are consecutive same-height/same-tip GBT polls 30 s apart — inside the cache TTL.

### Fix
1. Cache hit now also requires `frozen.desired_tx_hashes == wd.m_tx_hashes` (same tx set ⇒ same fee total ⇒ the frozen coinbase amounts are exact) and `frozen.payment_amount == wd.m_payment_amount` as a cheap belt. On drift the gentx is deterministically rebuilt over the current template — identical behavior to a tip/height change, with a rate-limited log line.
2. Won-block submitblock backup: `ignore_failure=false` so a REAL dashd rejection reason is logged loudly instead of collapsing into "no-ack". `submitblock_result_accepted()` already treats duplicate/inconclusive as success, so an ARM A accept is never re-reported as failure.

### Reward-safety argument
- Byte-identical job stream whenever the template did not drift (the common case); strictly fewer invalid blocks when it did.
- No PoW, share-format, PPLNS, or coinbase-serialization change; DASH-only (`src/c2pool/main_dash.cpp`); LTC/DOGE have no fee-dependent mandated-payee consensus check so they are unaffected.
- Syntax-checked against the real c2pool-dash build flags (front-end clean).

### Deploy note (operator)
Hotel runs 0.2.4.x; this lands on master and needs a cherry-pick onto the release line + a hotel redeploy (operator-gated; NOT done by this PR).