### PR TITLE
dash(embedded): projection-based MN payee attribution — fix soak-found intermittent bad-cb-payee [DO NOT MERGE: gate on re-soak]

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -1740,6 +1740,12 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         // NodeRPC::Send self-connects via the blocking sync_reconnect fallback
         // (the same property --submit-block relies on).
         if (rpc) {
+            // Reusable authoritative seed fetch: invoked once at startup AND
+            // re-invoked by the maintainer's payee-desync fail-closed path
+            // (set_on_mn_reseed below) after it wiped a desynced payee queue.
+            // Lifetime: rpc/coin_state are main()-scope and outlive ioc.run().
+            auto seed_mn_set_from_rpc = [rpc_ptr = rpc.get(), addr_ver,
+                                         p2sh_ver, &coin_state](const char* tag) {
             try {
                 // Height-stable fetch: the snapshot must carry the exact
                 // height it is current at (the maintainer fences off
@@ -1752,10 +1758,10 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 uint32_t as_of = 0;
                 for (int attempt = 0; attempt < 3; ++attempt) {
                     const uint32_t h_before = static_cast<uint32_t>(
-                        rpc->getblockchaininfo().value("blocks", 0));
-                    protx_list = rpc->protx_list_valid_detailed();
+                        rpc_ptr->getblockchaininfo().value("blocks", 0));
+                    protx_list = rpc_ptr->protx_list_valid_detailed();
                     const uint32_t h_after = static_cast<uint32_t>(
-                        rpc->getblockchaininfo().value("blocks", 0));
+                        rpc_ptr->getblockchaininfo().value("blocks", 0));
                     if (h_before == h_after && h_after != 0) {
                         as_of = h_after;
                         break;
@@ -1769,7 +1775,8 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     up.mnstates     = std::move(seed);
                     up.as_of_height = as_of;
                     coin_state.mn_list_update.happened(up);
-                    std::cout << "[run] E2c MN-set seed LOADED: "
+                    std::cout << "[run] E2c MN-set seed LOADED (" << tag
+                              << "): "
                               << seed_stats.seeded << "/" << seed_stats.total
                               << " valid MNs (" << seed_stats.evo << " Evo)"
                                  " as-of h=" << as_of << " from dashd `protx"
@@ -1777,13 +1784,15 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                  " ARMED; populated() flips once the header"
                                  " tip syncs\n";
                 } else if (as_of == 0) {
-                    std::cout << "[run] E2c MN-set seed SKIPPED (dashd tip"
+                    std::cout << "[run] E2c MN-set seed SKIPPED (" << tag
+                              << ": dashd tip"
                                  " moved during every fetch attempt / height"
                                  " unavailable) -- populated() waits for the"
                                  " special-tx replay path; dashd fallback"
                                  " keeps serving\n";
                 } else {
-                    std::cout << "[run] E2c MN-set seed EMPTY/ABORTED (total="
+                    std::cout << "[run] E2c MN-set seed EMPTY/ABORTED (" << tag
+                              << ": total="
                               << seed_stats.total << " decode_failed="
                               << seed_stats.payout_decode_failed
                               << " malformed=" << seed_stats.malformed
@@ -1791,11 +1800,22 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                  " replay path; dashd fallback keeps serving\n";
                 }
             } catch (const std::exception& e) {
-                std::cout << "[run] E2c MN-set seed FAILED (protx list RPC: "
+                std::cout << "[run] E2c MN-set seed FAILED (" << tag
+                          << ": protx list RPC: "
                           << e.what() << ") -- populated() waits for the"
                              " special-tx replay path; dashd fallback keeps"
                              " serving\n";
             }
+            };
+            seed_mn_set_from_rpc("startup");
+            // Payee-desync heal (soak-found bad-cb-payee class): after the
+            // maintainer wiped a desynced payee queue and demoted to the
+            // dashd fallback, re-arm the embedded payee half from the
+            // authoritative protx list. Until the re-seed lands, get_work
+            // keeps serving the reward-safe fallback.
+            maintainer->set_on_mn_reseed([seed_mn_set_from_rpc]() {
+                seed_mn_set_from_rpc("payee-desync re-seed");
+            });
         } else {
             // Pure daemonless: no dashd RPC to seed from. The DMN set must
             // come from a DIP3-height special-tx replay (sync block bodies

--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -75,6 +75,10 @@ public:
                            uint32_t as_of_height = 0) {
         m_have_mn = !mnstates.empty();
         m_mn_snapshot_height = as_of_height;
+        // An authoritative (non-empty) resync clears the payee-desync latch:
+        // the queue is trustworthy again from this snapshot forward.
+        if (m_have_mn)
+            m_mn_needs_reseed = false;
         m_state.mnstates().load(std::move(mnstates));
         if (!m_have_mn)
             demote();
@@ -309,7 +313,33 @@ public:
             return r;
         }
         auto r    = m_state.mnstates().apply_block(block, height);
-        m_have_mn = m_state.mnstates().size() != 0;
+        // PAYEE DESYNC (soak-found 2026-07-22, bad-cb-payee class): the
+        // connected block's coinbase does not pay the MN our queue projects.
+        // The payee set can no longer back a template — serving from it
+        // WOULD emit a coinbase dashd rejects with bad-cb-payee. Fail
+        // CLOSED: wipe the payee set (a desynced queue must not be trusted
+        // for later heights either), drop MN-readiness so get_work() routes
+        // to the dashd fallback, and ask main for an authoritative re-seed
+        // (protx list) when a coin RPC is configured. The wipe also resets
+        // the snapshot fence so the re-seed's as_of re-arms it.
+        if (r.payee_desync) {
+            LOG_WARNING << "[EMB-DASH] MN payee queue DESYNC at h=" << height
+                        << " — wiping payee set, demoting to dashd fallback,"
+                           " requesting authoritative re-seed";
+            m_state.mnstates().load({});
+            m_mn_snapshot_height = 0;
+            m_have_mn = false;
+            // Latch: only an authoritative on_mn_list_update resync may re-arm
+            // MN-readiness. Without this, a stray ProRegTx observed in a later
+            // block would register into the wiped set and republish a 1-MN
+            // "queue" — a guessed payee by another name.
+            m_mn_needs_reseed = true;
+            demote();
+            notify_state_dirty();
+            if (m_on_mn_reseed) m_on_mn_reseed();
+            return r;
+        }
+        m_have_mn = !m_mn_needs_reseed && m_state.mnstates().size() != 0;
         if (!m_have_mn)
             demote();
         else
@@ -336,6 +366,17 @@ public:
     /// (KAT posture) makes every notify_state_dirty() a no-op.
     void set_on_state_dirty(std::function<void()> fn) {
         m_on_state_dirty = std::move(fn);
+    }
+
+    /// Wire the authoritative MN re-seed sink (main_dash points this at the
+    /// E2c `protx list valid true` seed fetch when a coin RPC is configured).
+    /// Invoked from on_block_connected's payee-desync fail-closed path AFTER
+    /// the payee set is wiped and the bundle demoted — the arm stays on the
+    /// dashd fallback until the re-seed lands via on_mn_list_update. Optional:
+    /// unset (KAT posture / pure daemonless) leaves the arm failed closed,
+    /// which is the safe terminal state (never serve a guessed payee).
+    void set_on_mn_reseed(std::function<void()> fn) {
+        m_on_mn_reseed = std::move(fn);
     }
 
     /// Wire a "force a full mnlistdiff re-sync from ZERO" sink (main_dash resets
@@ -392,6 +433,7 @@ private:
 
     NodeCoinState& m_state;
     std::function<void()> m_on_state_dirty;  // SML/bestCL/reorg -> re-issue work
+    std::function<void()> m_on_mn_reseed;    // payee desync -> authoritative protx re-seed
     std::function<void()> m_on_full_resync;  // H-1 heal -> reset sml_base + full re-sync
     std::function<void(const uint256&)> m_on_sml_persist;  // accepted diff -> SMLDb/QuorumDb write
     std::function<void()> m_on_sml_clear;    // reorg/heal -> SMLDb/QuorumDb wipe
@@ -403,6 +445,11 @@ private:
     // Height the last MN-set snapshot was current at (0 = none/unknown);
     // on_block_connected skips re-applying blocks at or below it.
     uint32_t m_mn_snapshot_height{0};
+
+    // Payee-desync latch: set when on_block_connected wiped a desynced payee
+    // queue; only a non-empty on_mn_list_update resync clears it. While set,
+    // MN-readiness must not re-arm off incidental per-block registrations.
+    bool m_mn_needs_reseed{false};
 
     // Last observed tip params, applied on republish().
     uint32_t m_prev_height{0};

--- a/src/impl/dash/coin/mn_state_machine.hpp
+++ b/src/impl/dash/coin/mn_state_machine.hpp
@@ -30,16 +30,32 @@
 ///     block can have its collateral spent in a later tx of the same
 ///     block (rare but consensus-correct). We mirror.
 ///
-///   Pass 3 — payee resolution (coinbase outputs):
-///     dashcore computes expected payee from PREV-block list before
-///     applying any tx; we OBSERVE actual coinbase outputs and find
-///     matches in our current list. Functionally equivalent for nodes
-///     processing accepted blocks (every accepted coinbase pays the
-///     dashcore-expected MN by definition).
-///     For each output that matches an MN's scriptPayout: set
-///     nLastPaidHeight = height; for Evo MNs, increment
-///     nConsecutivePayments if last payment was at height-1, else reset
-///     to 1.
+///   Pass 3 — payee resolution (PROJECTION attribution, dashd-exact):
+///     Mirrors dashcore evo/deterministicmns.cpp BuildNewListFromBlock:
+///     the payee is COMPUTED from the pre-block list (GetMNPayee on
+///     pindexPrev == find_expected_payee() before pass 1) and — if still
+///     present after passes 1/2 (newList.HasMN) — marked
+///     nLastPaidHeight = height. The coinbase is only used as a
+///     CROSS-CHECK: if it does not pay the projected MN's scriptPayout,
+///     this state has desynced from the network's payment schedule and
+///     the apply reports payee_desync (caller fails closed + re-seeds)
+///     instead of guessing an attribution.
+///
+///     HISTORY (soak-found 2026-07-22, e4-e1e2b, 13x bad-cb-payee):
+///     the previous OBSERVATION attribution (scan coinbase outputs,
+///     pick_paid_mn per matching output) was not idempotent: any
+///     duplicated/replayed attribution of one block re-picked within a
+///     shared-payoutAddress group (53 testnet MNs share one address) and
+///     marked the NEXT MN of the group, silently shifting the group's
+///     payment cursor one slot ahead FOREVER. The embedded arm then
+///     emitted the wrong coinbase payee at every height where the
+///     one-ahead group cursor changed the projected address (~10% of
+///     serves; dashd rejected each with bad-cb-payee). Projection
+///     attribution + the whole-apply monotonic-height guard remove the
+///     divergence class structurally; the desync flag turns any residual
+///     mismatch into an immediate fail-closed instead of silent wrongness.
+///     For Evo MNs, nConsecutivePayments increments if last payment was
+///     at height-1, else resets to 1 (unchanged).
 ///
 /// Things we DELIBERATELY don't model (with consequence notes):
 ///   - Confirmation pass (dashcore: nMasternodeMinimumConfirmations →
@@ -111,19 +127,37 @@ public:
         size_t updated{0};
         size_t revoked{0};
         size_t spent{0};       // collateral spent → MN removed
-        size_t paid{0};        // matched a coinbase output
+        size_t paid{0};        // projected payee marked paid this block
         size_t total_after{0};
+        // Duplicate / out-of-order delivery: height <= last applied height.
+        // The WHOLE apply was skipped (no state mutation). A re-run of the
+        // old observation-attribution over an already-applied block marked
+        // the NEXT MN of a shared-payoutAddress group — the soak-found
+        // bad-cb-payee corruption this guard closes.
+        bool skipped_out_of_order{false};
+        // The coinbase does NOT pay the MN this machine projects as the
+        // deterministic payee: this state desynced from the network's DMN
+        // payment schedule (missed block / corrupted seed / replay). The
+        // payment was NOT attributed — never guess. Caller must fail
+        // closed (stop backing templates with this payee set) + re-seed.
+        bool payee_desync{false};
     };
 
     void load(std::vector<std::pair<uint256, MNState>> entries)
     {
         m_entries.clear();
         m_collateral_index.clear();
+        m_last_applied_height = 0;
         for (auto& [h, st] : entries) {
             m_collateral_index[st.collateralOutpoint] = h;
             m_entries.emplace(h, std::move(st));
         }
     }
+
+    // Height of the last block folded by apply_block (0 = none since load).
+    // apply_block is FORWARD-ONLY: any call at height <= this is skipped
+    // whole (see ApplyResult::skipped_out_of_order).
+    uint32_t last_applied_height() const { return m_last_applied_height; }
 
     size_t size() const { return m_entries.size(); }
 
@@ -461,6 +495,25 @@ public:
     {
         ApplyResult r;
 
+        // ── Pass 0: forward-only guard + payee projection ──────────
+        // dashcore connects blocks strictly forward; mirror that here so a
+        // duplicated or out-of-order delivery can NEVER mutate this state.
+        // (Soak-found 2026-07-22: one extra attribution pass over an
+        // already-applied block shifted a shared-payoutAddress group's
+        // payment cursor one slot ahead permanently -> intermittent
+        // bad-cb-payee on the embedded serve arm.)
+        if (m_last_applied_height != 0 && height <= m_last_applied_height) {
+            r.skipped_out_of_order = true;
+            r.total_after = m_entries.size();
+            return r;
+        }
+
+        // dashcore BuildNewListFromBlock computes the payee from the
+        // PRE-block list (oldList.GetMNPayee(pindexPrev)) BEFORE folding
+        // this block's special txs; the mark lands after passes 1/2 (and
+        // only if the MN survived them — newList.HasMN). Mirror exactly.
+        const std::optional<uint256> projected = find_expected_payee();
+
         // ── Pass 1: special-tx records ─────────────────────────────
         // Walk all non-coinbase txs (i=1+). The order of types within
         // a block is whatever the miner included; dashcore handles
@@ -598,48 +651,59 @@ public:
             }
         }
 
-        // ── Pass 3: payee resolution ──────────────────────────────
-        // BUG FIX 2026-04-25: multiple MNs can share the same payoutAddress
-        // (operators running multiple MNs to one wallet). The original
-        // find_by_payout_script returned the FIRST map-iteration match,
-        // which deterministically attributed ALL payments to whichever
-        // MN had the lowest proRegTxHash bytes. Net effect: for each
-        // shared-script payment dashd correctly attributed to one MN,
-        // we'd attribute it to the OTHER one — leaving the actual paid
-        // MN's nLastPaidHeight stale forever. Live-observed: MN
-        // 7173b6a9... and 06a9ee24... both pay address
-        // XjbaGWaGnvEtuQAUoBgDxJWe8ZNv45upG2; we kept giving 06a9ee24
-        // every payment, so 7173b6a9 stayed at lastPaid=2458528 → kept
-        // winning find_expected_payee → 100% [PAY] MISMATCH against
-        // dashd which correctly rotated the two.
-        //
-        // Fix: when multiple MNs share a script, use pick_paid_mn (defined
-        // above) which mirrors dashd's CompareByLastPaid_GetHeight ordering.
-        if (!block.m_txs.empty()) {
-            const auto& cb = block.m_txs[0];
-            for (const auto& vout : cb.vout) {
-                auto matched = pick_paid_mn(vout.scriptPubKey.m_data);
-                if (!matched) continue;
-                auto it = m_entries.find(*matched);
-                if (it == m_entries.end()) continue;
-                // Idempotency safety net: never roll lastPaidHeight backwards.
-                // Defense-in-depth against any future caller bypassing the
-                // outer OOO guard (main_dash.cpp's `already_in_state` check).
-                // Without this, an out-of-order h<current re-apply would have
-                // bumped lastPaid backwards — the original 03fa0aa1 bug class.
-                if (height <= it->second.nLastPaidHeight) continue;
-                bool was_consecutive = (it->second.nLastPaidHeight == height - 1);
-                it->second.nLastPaidHeight = height;
-                if (it->second.nType == vendor::MnType::EVO) {
-                    it->second.nConsecutivePayments =
-                        was_consecutive ? it->second.nConsecutivePayments + 1 : 1;
-                } else {
-                    it->second.nConsecutivePayments = 0;
+        // ── Pass 3: payee resolution (PROJECTION, dashd-exact) ─────
+        // dashcore evo/deterministicmns.cpp BuildNewListFromBlock: mark the
+        // PROJECTED payee (computed pass 0 from the pre-block list), not an
+        // MN inferred from scanning coinbase outputs. Observation-based
+        // attribution (the pre-2026-07 code) re-derived the paid MN with
+        // pick_paid_mn per matching output; that inference is not
+        // idempotent under duplicated/replayed applies within a
+        // shared-payoutAddress group and once wrong stayed wrong forever
+        // (self-perpetuating one-slot-ahead group cursor; soak-found
+        // bad-cb-payee at ~10% of embedded serves). The coinbase is now
+        // only the CROSS-CHECK: an accepted block by definition pays
+        // dashd's projected MN, so if it does not pay OURS, our queue has
+        // desynced — report payee_desync, attribute nothing, and let the
+        // caller fail closed + re-seed (never guess).
+        if (projected && !block.m_txs.empty()) {
+            auto it = m_entries.find(*projected);
+            // Mirrors dashcore's newList.HasMN(payee->proRegTxHash): a
+            // payee whose MN was removed by THIS block's passes 1/2 is
+            // silently skipped (no mark, no desync).
+            if (it != m_entries.end()) {
+                const auto& script = it->second.scriptPayout.m_data;
+                bool paid_in_cb = false;
+                if (!script.empty()) {
+                    for (const auto& vout : block.m_txs[0].vout) {
+                        if (vout.scriptPubKey.m_data == script) {
+                            paid_in_cb = true;
+                            break;
+                        }
+                    }
                 }
-                ++r.paid;
+                if (paid_in_cb) {
+                    bool was_consecutive =
+                        (it->second.nLastPaidHeight == height - 1);
+                    it->second.nLastPaidHeight = height;
+                    if (it->second.nType == vendor::MnType::EVO) {
+                        it->second.nConsecutivePayments =
+                            was_consecutive
+                                ? it->second.nConsecutivePayments + 1 : 1;
+                    } else {
+                        it->second.nConsecutivePayments = 0;
+                    }
+                    ++r.paid;
+                } else {
+                    r.payee_desync = true;
+                    LOG_WARNING << "[MNS-SM] PAYEE DESYNC h=" << height
+                                << ": coinbase does not pay projected MN "
+                                << projected->GetHex().substr(0, 16)
+                                << " — attribution withheld (fail closed)";
+                }
             }
         }
 
+        m_last_applied_height = height;
         r.total_after = m_entries.size();
         return r;
     }
@@ -647,6 +711,10 @@ public:
 private:
     std::map<uint256, MNState>                                          m_entries;
     std::map<bitcoin_family::coin::TxPrevOut, uint256, TxPrevOutLess>   m_collateral_index;
+
+    // Forward-only apply cursor: height of the last block folded by
+    // apply_block (0 = none since load). See ApplyResult::skipped_out_of_order.
+    uint32_t m_last_applied_height{0};
 
     // Compute a tx's identifying hash. Mirrors dashcore's
     // CTransaction::GetHash() which is SHA256d(serialized_tx).

--- a/test/test_dash_coin_state_maintainer.cpp
+++ b/test/test_dash_coin_state_maintainer.cpp
@@ -257,14 +257,57 @@ TEST(DashCoinStateMaintainer, BlockConnectNoSpecialTxPreservesReadiness) {
     m.on_new_tip(H - 1, PREV_HASH, BITS, MTP, DASH_PUBKEY_VER, DASH_P2SH_VER, CURTIME, VERSION);
     ASSERT_TRUE(m.live());
 
+    // Post projection-attribution: a connected block's coinbase pays the
+    // PROJECTED payee (every dashd-accepted block does) — that is the
+    // readiness-preserving "normal" block. A coinbase that does NOT pay the
+    // projected MN is a payee DESYNC (own KAT below), not a no-op.
     BlockType blk;
-    blk.m_txs.push_back(make_spend(raw256(0x90), 0, 500000000, 1));  // cb (idx 0, skipped)
+    blk.m_txs.push_back(make_spend(raw256(0x90), 0, 500000000, 1));  // cb (idx 0)
+    blk.m_txs[0].vout[0].scriptPubKey.m_data = p2pkh_script(0x30);   // pays projected MN
     blk.m_txs.push_back(make_spend(raw256(0x91), 0, 400000000, 2));  // plain spend, no collateral match
     auto r = m.on_block_connected(blk, H);
 
     EXPECT_EQ(r.registered, 0u);
+    EXPECT_EQ(r.paid, 1u) << "projected payee must be marked paid";
+    EXPECT_FALSE(r.payee_desync);
     EXPECT_EQ(st.mnstates().size(), 1u);
     EXPECT_TRUE(m.live()) << "no-op block must not drop the live bundle";
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Soak-found 2026-07-22 (E4 re-soak, 13x bad-cb-payee): the payee queue can
+// desync from the network's DIP-3 payment schedule (duplicated attribution,
+// missed block, corrupted seed). A connected block whose coinbase does NOT
+// pay the MN we project is that desync made visible. The maintainer must
+// fail CLOSED: wipe the untrustworthy payee set, demote to the dashd
+// fallback, and fire the authoritative re-seed hook — never keep serving a
+// guessed payee (dashd rejects it with bad-cb-payee).
+// ════════════════════════════════════════════════════════════════════════
+TEST(DashCoinStateMaintainer, PayeeDesyncWipesDemotesAndFiresReseed) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    bool reseed_fired = false;
+    m.set_on_mn_reseed([&]() { reseed_fired = true; });
+    m.on_mn_list_update(single_mn(p2pkh_script(0x30)));
+    m.on_new_tip(H - 1, PREV_HASH, BITS, MTP, DASH_PUBKEY_VER, DASH_P2SH_VER, CURTIME, VERSION);
+    ASSERT_TRUE(m.live());
+
+    // Coinbase pays a DIFFERENT script than the projected MN's payout.
+    BlockType blk;
+    blk.m_txs.push_back(make_spend(raw256(0x90), 0, 500000000, 1));
+    blk.m_txs[0].vout[0].scriptPubKey.m_data = p2pkh_script(0x77);  // NOT the MN
+    auto r = m.on_block_connected(blk, H);
+
+    EXPECT_TRUE(r.payee_desync);
+    EXPECT_EQ(r.paid, 0u) << "a desynced payment must NOT be guessed onto some MN";
+    EXPECT_EQ(st.mnstates().size(), 0u) << "desynced payee set must be wiped";
+    EXPECT_FALSE(m.live()) << "desync must demote the bundle to the dashd fallback";
+    EXPECT_TRUE(reseed_fired) << "desync must request an authoritative re-seed";
+
+    bool fb = false;
+    WorkSelection sel = st.select_work([&]() { fb = true; return DashWorkData{}; });
+    EXPECT_EQ(sel.source, WorkSource::DashdFallback);
+    EXPECT_TRUE(fb) << "after a payee desync, get_work must serve the dashd fallback";
 }
 
 // A block whose non-coinbase tx spends the sole MN's collateral removes it

--- a/test/test_dash_mn_seed.cpp
+++ b/test/test_dash_mn_seed.cpp
@@ -360,3 +360,251 @@ TEST(DashMnSeed, SnapshotHeightFencesReplayedBlocks)
     EXPECT_EQ(state.mnstates().entries().at(mn_a).nLastPaidHeight, 2'399'902u)
         << "post-snapshot block must fold normally";
 }
+
+// ════════════════════════════════════════════════════════════════════════
+// FROM-WIRE regression vector (soak e4-e1e2b, bad-cb-payee class,
+// captured 2026-07-23 from the REAL Dash testnet node @192.168.86.52):
+//
+//   - seed: the FRONT SIX of dashd's deterministic payment queue at height
+//     1519543 (`protx list valid true 1519543`), verbatim JSON. Two of them
+//     are Evo MNs; two payout-address GROUPS are shared (3x yVXDAM73…,
+//     2x yeRZBWYf…) — the exact shared-address shape the soak corruption
+//     exploited.
+//   - blocks: the REAL testnet blocks 1519544/1519545/1519546 (getblock
+//     verbosity 0), whose coinbases dashd accepted.
+//
+// dashd's authoritative attributions (protx list @h vs @h-1):
+//   1519544 -> dc2e02ac… (yVXDAM73…)   1519545 -> 9b653e76… (Evo, yeRZBWYf…)
+//   1519546 -> 91bbce94… (Evo, yeRZBWYf…)   next payee @1519547 -> 72ee70fa…
+//
+// The KAT asserts the embedded machine reproduces that schedule EXACTLY,
+// and that a duplicated delivery of block 1519546 cannot advance the
+// yeRZBWYf… group cursor (the soak failure mode: post-duplicate the machine
+// projected the wrong payee at ~10%% of heights and dashd rejected the
+// embedded block with bad-cb-payee).
+// ════════════════════════════════════════════════════════════════════════
+
+namespace {
+
+// Dash TESTNET address version bytes (yeRZ…/yVXD… are testnet addresses).
+constexpr uint8_t TESTNET_PUBKEY_VER = 140;
+constexpr uint8_t TESTNET_P2SH_VER   = 19;
+
+const char* kProtxFront6At1519543 =
+        "[{\"type\":\"Regular\",\"proTxHash\":\"dc2e02ac95ce4ccc9843c38de7bdaf32f2a1d5966c054127a3f4ca4f4bbd5991\",\"c"
+        "ollateralHash\":\"4ee3ff5074723d995f4cb957a954587c6c637a42655ada8f4054037b28d1e7a8\",\"collateralIndex\":"
+        "34,\"collateralAddress\":\"yRXyymKDuWytHMJE9odBkUJjaayqk3giCq\",\"operatorReward\":0,\"state\":{\"version\":1,"
+        "\"service\":\"68.67.122.64:19999\",\"registeredHeight\":838365,\"lastPaidHeight\":1519459,\"consecutivePaymen"
+        "ts\":0,\"PoSePenalty\":0,\"PoSeRevivedHeight\":1367840,\"PoSeBanHeight\":-1,\"revocationReason\":0,\"ownerAddr"
+        "ess\":\"yQxgY6sdiHRWmi8STNftizktwqy4zhndfS\",\"votingAddress\":\"yQxgY6sdiHRWmi8STNftizktwqy4zhndfS\",\"payo"
+        "utAddress\":\"yVXDAM73Tg6A44Bm3qduXsMCYxzuqBCT48\",\"pubKeyOperator\":\"0db85a27cd589d225beff9977aa0ac3255"
+        "1d15bd906a899bc1ef33458d7c979118f92bf1de4ddb55144acc2f7cf6d854\"},\"confirmations\":681326,\"wallet\":{\"h"
+        "asOwnerKey\":false,\"hasOperatorKey\":false,\"hasVotingKey\":false,\"ownsCollateral\":false,\"ownsPayeeScrip"
+        "t\":false,\"ownsOperatorRewardScript\":false},\"metaInfo\":{\"lastDSQ\":578542,\"mixingTxCount\":0,\"outboundA"
+        "ttemptCount\":0,\"lastOutboundAttempt\":0,\"lastOutboundAttemptElapsed\":1784749234,\"lastOutboundSuccess\""
+        ":1783259090,\"lastOutboundSuccessElapsed\":1490144}},{\"type\":\"Evo\",\"proTxHash\":\"9b653e767b978c10346d93"
+        "8c08dc8c5acd03c495f9d913e6fc652bfcae11a348\",\"collateralHash\":\"75fe9d8d90619576ef11deb8550d023366bf9d"
+        "85e686dc6d5afba0aca8827e21\",\"collateralIndex\":2,\"collateralAddress\":\"yaBTTTgGBro5U3MHAMXDC4GbHj6Rnc8"
+        "prr\",\"operatorReward\":0,\"state\":{\"version\":2,\"service\":\"68.67.122.4:19999\",\"registeredHeight\":142762"
+        "3,\"lastPaidHeight\":1519460,\"consecutivePayments\":0,\"PoSePenalty\":0,\"PoSeRevivedHeight\":1446613,\"PoSe"
+        "BanHeight\":-1,\"revocationReason\":0,\"ownerAddress\":\"ygDPwRAi4XVcgNjTTR71kayENznYRwinhy\",\"votingAddres"
+        "s\":\"ygDPwRAi4XVcgNjTTR71kayENznYRwinhy\",\"platformNodeID\":\"0785881ea118c05df7bb9dd2195a78f10cdde0bb\","
+        "\"platformP2PPort\":36656,\"platformHTTPPort\":1443,\"payoutAddress\":\"yeRZBWYfeNE4yVUHV4ZLs83Ppn9aMRH57A\""
+        ",\"pubKeyOperator\":\"80ab2701950ef7a1e068b97d02a2ed1e64a8d38dd2d0e5a0d9de5432b3e1ad2c318109d89326d48ab"
+        "6e285d6ac0bb22e\"},\"confirmations\":92096,\"wallet\":{\"hasOwnerKey\":false,\"hasOperatorKey\":false,\"hasVot"
+        "ingKey\":false,\"ownsCollateral\":false,\"ownsPayeeScript\":false,\"ownsOperatorRewardScript\":false},\"meta"
+        "Info\":{\"lastDSQ\":578522,\"mixingTxCount\":0,\"outboundAttemptCount\":0,\"lastOutboundAttempt\":0,\"lastOutb"
+        "oundAttemptElapsed\":1784749234,\"lastOutboundSuccess\":1783455154,\"lastOutboundSuccessElapsed\":1294080"
+        "}},{\"type\":\"Evo\",\"proTxHash\":\"91bbce94c34ebde0d099c0a2cb7635c0c31425ebabcec644f4f1a0854bfa605d\",\"col"
+        "lateralHash\":\"6ce8545e25d4f03aba1527062d9583ae01827c65b234bd979aca5954c6ae3a59\",\"collateralIndex\":30"
+        ",\"collateralAddress\":\"yhgAPgRNVEdK6eDG3ngvTDc4eUKdRM2woR\",\"operatorReward\":0,\"state\":{\"version\":2,\"s"
+        "ervice\":\"68.67.122.15:19999\",\"registeredHeight\":850334,\"lastPaidHeight\":1519461,\"consecutivePayments"
+        "\":0,\"PoSePenalty\":0,\"PoSeRevivedHeight\":1368973,\"PoSeBanHeight\":-1,\"revocationReason\":0,\"ownerAddres"
+        "s\":\"yfEfxRYgc2LMY7LjunL9vHWfb5FPnHgowZ\",\"votingAddress\":\"yfEfxRYgc2LMY7LjunL9vHWfb5FPnHgowZ\",\"platfo"
+        "rmNodeID\":\"02aa69f8ef6666e7cad6d9323755a0ef3c1b6bd9\",\"platformP2PPort\":36656,\"platformHTTPPort\":1443"
+        ",\"payoutAddress\":\"yeRZBWYfeNE4yVUHV4ZLs83Ppn9aMRH57A\",\"pubKeyOperator\":\"81ad0f9be5a88ae62ff54fe938df"
+        "ceea71be03bd4c6a7aebf75896e8d495d310acc4146aa4820bc0e5f5b06579dedea5\"},\"confirmations\":669357,\"walle"
+        "t\":{\"hasOwnerKey\":false,\"hasOperatorKey\":false,\"hasVotingKey\":false,\"ownsCollateral\":false,\"ownsPaye"
+        "eScript\":false,\"ownsOperatorRewardScript\":false},\"metaInfo\":{\"lastDSQ\":578540,\"mixingTxCount\":0,\"out"
+        "boundAttemptCount\":0,\"lastOutboundAttempt\":0,\"lastOutboundAttemptElapsed\":1784749234,\"lastOutboundSu"
+        "ccess\":1784208362,\"lastOutboundSuccessElapsed\":540872}},{\"type\":\"Regular\",\"proTxHash\":\"72ee70fa75262"
+        "781a17d1eb69a6c3e97328208be98b59d5530164f31e481d3aa\",\"collateralHash\":\"4ee3ff5074723d995f4cb957a9545"
+        "87c6c637a42655ada8f4054037b28d1e7a8\",\"collateralIndex\":96,\"collateralAddress\":\"yfbqanJdStcfLwYDxGNVV"
+        "HZiT6qUbvcDdQ\",\"operatorReward\":0,\"state\":{\"version\":1,\"service\":\"68.67.122.67:19999\",\"registeredHei"
+        "ght\":838365,\"lastPaidHeight\":1519462,\"consecutivePayments\":0,\"PoSePenalty\":0,\"PoSeRevivedHeight\":136"
+        "7330,\"PoSeBanHeight\":-1,\"revocationReason\":0,\"ownerAddress\":\"yYmpgYanZZNmYprdTLhSvscUqzGMHCD5F7\",\"vo"
+        "tingAddress\":\"yYmpgYanZZNmYprdTLhSvscUqzGMHCD5F7\",\"payoutAddress\":\"yVXDAM73Tg6A44Bm3qduXsMCYxzuqBCT4"
+        "8\",\"pubKeyOperator\":\"91f9052f62561db112ddca7df3d914d546866b130124eccb2ae1e8419563e51f239b2efec3d1b3f"
+        "d388072610939d694\"},\"confirmations\":681326,\"wallet\":{\"hasOwnerKey\":false,\"hasOperatorKey\":false,\"has"
+        "VotingKey\":false,\"ownsCollateral\":false,\"ownsPayeeScript\":false,\"ownsOperatorRewardScript\":false},\"m"
+        "etaInfo\":{\"lastDSQ\":578487,\"mixingTxCount\":0,\"outboundAttemptCount\":0,\"lastOutboundAttempt\":0,\"lastO"
+        "utboundAttemptElapsed\":1784749234,\"lastOutboundSuccess\":1783435021,\"lastOutboundSuccessElapsed\":1314"
+        "213}},{\"type\":\"Regular\",\"proTxHash\":\"c87218fb9d031f4926c22430c69b4edf1f0fb80c331c1a79e3b1b3873407c0a"
+        "c\",\"collateralHash\":\"4ee3ff5074723d995f4cb957a954587c6c637a42655ada8f4054037b28d1e7a8\",\"collateralIn"
+        "dex\":62,\"collateralAddress\":\"yWausFtKkqUgPXsBen7H84fJ2vhqwXoA6K\",\"operatorReward\":0,\"state\":{\"versio"
+        "n\":1,\"service\":\"68.67.122.56:19999\",\"registeredHeight\":838365,\"lastPaidHeight\":1519463,\"consecutiveP"
+        "ayments\":0,\"PoSePenalty\":0,\"PoSeRevivedHeight\":1367840,\"PoSeBanHeight\":-1,\"revocationReason\":0,\"owne"
+        "rAddress\":\"yUi9YLkmErtbsrkbyCBFkwN4ic31GbCtB3\",\"votingAddress\":\"yUi9YLkmErtbsrkbyCBFkwN4ic31GbCtB3\","
+        "\"payoutAddress\":\"yVXDAM73Tg6A44Bm3qduXsMCYxzuqBCT48\",\"pubKeyOperator\":\"842c53c3aa11ae4b985a52ae6a317"
+        "0bdb58f88ec04c62013f9322bd5fda4417939836b6f41741dd864c348103a1155d3\"},\"confirmations\":681326,\"wallet"
+        "\":{\"hasOwnerKey\":false,\"hasOperatorKey\":false,\"hasVotingKey\":false,\"ownsCollateral\":false,\"ownsPayee"
+        "Script\":false,\"ownsOperatorRewardScript\":false},\"metaInfo\":{\"lastDSQ\":578525,\"mixingTxCount\":0,\"outb"
+        "oundAttemptCount\":0,\"lastOutboundAttempt\":0,\"lastOutboundAttemptElapsed\":1784749234,\"lastOutboundSuc"
+        "cess\":1777357130,\"lastOutboundSuccessElapsed\":7392104}},{\"type\":\"Regular\",\"proTxHash\":\"ecebeb952f56a"
+        "61abaccd7bda7f4df5eccbd5f87a91bc4a8969535df1058158e\",\"collateralHash\":\"f329c4c9d194159e81597e50144ce"
+        "41a40e2b40860c7813a85eabb0454700a3d\",\"collateralIndex\":1,\"collateralAddress\":\"yMaRbUBSrfEqSGjJUPiC2N"
+        "icdVQB4m4zuQ\",\"operatorReward\":0,\"state\":{\"version\":2,\"service\":\"78.17.70.175:19999\",\"registeredHeig"
+        "ht\":1491043,\"lastPaidHeight\":1519464,\"consecutivePayments\":0,\"PoSePenalty\":0,\"PoSeRevivedHeight\":150"
+        "7780,\"PoSeBanHeight\":-1,\"revocationReason\":0,\"ownerAddress\":\"yfZjU5gZQhzh85VBo2sxoH1Ut8Y5Ro6Ncr\",\"vo"
+        "tingAddress\":\"yfVwUDTsuvbphbaR671SskWmek6SMsHbc6\",\"payoutAddress\":\"yjTpMw9buZfv4jNkf87AHpDj95YSAFuDi"
+        "X\",\"pubKeyOperator\":\"93b72005436c6e4dbd6b59cf5818fd9679a4a2c51548fb9205c88852b4bb5f05d1bfc72a54035b6"
+        "85fceaaae2115d43f\"},\"confirmations\":28647,\"wallet\":{\"hasOwnerKey\":false,\"hasOperatorKey\":false,\"hasV"
+        "otingKey\":false,\"ownsCollateral\":false,\"ownsPayeeScript\":false,\"ownsOperatorRewardScript\":false},\"me"
+        "taInfo\":{\"lastDSQ\":578533,\"mixingTxCount\":0,\"outboundAttemptCount\":0,\"lastOutboundAttempt\":0,\"lastOu"
+        "tboundAttemptElapsed\":1784749234,\"lastOutboundSuccess\":1784716675,\"lastOutboundSuccessElapsed\":32559"
+        "}}]";
+
+const char* kBlockHex1519544 =
+        "000000201b543a9bb905794129b5b965a55176e1d6169de90d22d464d37f41ba4800000095d95cbd42771d55f34c46009d29"
+        "27f0684b22ca85667a2c0cb1626b0952138dfcc9606a4518511d0002780e0103000500010000000000000000000000000000"
+        "000000000000000000000000000000000000ffffffff1303b82f170e2f5032506f6f6c2d74444153482fffffffff05056583"
+        "03000000001976a9142629e1bbb4960da4c86226c876019e55c7c0346288ac2ed5fd0300000000016af80da7060000000019"
+        "76a91464f2b2b84f62d68a2cd7f7f5fb2b5aa75ef716d788acb3e60800000000001976a91420cb5c22b1e4d5947e5c112c76"
+        "96b51ad9af3c6188ac00000000000000002a6a282ad8f902c1ae2fece365590e4009eda31825336f273077a41697c43a54c0"
+        "835f000000000000000000000000af0300b82f17007edd5fec21fd07f7b9d44b5029884ebc71d2e2812fd3029a76690045ce"
+        "5c1647eb3ef20c2f89e9b8525f21e7064a47305b867ed642db1166faa9e0461fa0ee1d01b1a377ba4ad754bcc9bc00da609a"
+        "d3482ad7acc7847039a0424300c35a2e99c4ea6f3659e987f86eb9559fb88a020bf404d9fe2c33e097e13647f55fbe0d6941"
+        "e306f7bf206728634bff7e52a49d9e4b1b969017abd30c32ebc08d0c623cd98bb460a399f41e0000";
+
+const char* kBlockHex1519545 =
+        "0000002013912532ebf7d4e655abf829f99d670de25fdb46d2cbcc6d567b6f294200000070151825df25a1f90162dfc2d978"
+        "8b7dfdc8a690f9a61f0f8dd3f93e43bb5a2234ca606ac3fd4c1d00358c470103000500010000000000000000000000000000"
+        "000000000000000000000000000000000000ffffffff1303b92f170e2f5032506f6f6c2d74444153482fffffffff050c6583"
+        "03000000001976a9142629e1bbb4960da4c86226c876019e55c7c0346288ac2ed5fd0300000000016af80da7060000000019"
+        "76a914c69a0bda7daaae481be8def95e5f347a1d00a4b488acace60800000000001976a91420cb5c22b1e4d5947e5c112c76"
+        "96b51ad9af3c6188ac00000000000000002a6a2863ff5a8eb9b8e769435056d98f1831c46eaee642b6d17d0e9148d9b8385e"
+        "434a000000000000000000000000af0300b92f17007edd5fec21fd07f7b9d44b5029884ebc71d2e2812fd3029a76690045ce"
+        "5c1647eb3ef20c2f89e9b8525f21e7064a47305b867ed642db1166faa9e0461fa0ee1d0191d1a83a98f0b7b8cfb7f7ffca11"
+        "6dd416960ec91ef8a0052ca0ac2ff7f0fcddf0c38f6894765f7ba11c6fa25385ca9d1498cd5d5581b9ca2603fd2d35a16dfe"
+        "24cfd3dd49326da6d0d371cf3f97921c471ab5ad2eba487f680ced98063b26a9e235a19df41e0000";
+
+const char* kBlockHex1519546 =
+        "00000020c9497b889ffb56364da48fd35c7673dc51df02c382bc2a3876b91e5138000000a2de65097455b4ae92412e868d9a"
+        "c9d71c6f79322c1c10ddcab218e0bf004ff4e2ca606a76b04b1d000441980403000500010000000000000000000000000000"
+        "000000000000000000000000000000000000ffffffff1303ba2f170e2f5032506f6f6c2d74444153482fffffffff05e16483"
+        "03000000001976a9142629e1bbb4960da4c86226c876019e55c7c0346288ac2ed5fd0300000000016af80da7060000000019"
+        "76a914c69a0bda7daaae481be8def95e5f347a1d00a4b488acd7e60800000000001976a91420cb5c22b1e4d5947e5c112c76"
+        "96b51ad9af3c6188ac00000000000000002a6a2867e657696ff842bd354401663fb597a5edb52be7d029fdbdc710894c9776"
+        "3512000000000000000000000000af0300ba2f17007edd5fec21fd07f7b9d44b5029884ebc71d2e2812fd3029a76690045ce"
+        "5c1647eb3ef20c2f89e9b8525f21e7064a47305b867ed642db1166faa9e0461fa0ee1d01b836c031e91cc8b43129c7b1a93b"
+        "2bf2e5ce31803a848318680d8144ba28379a8d769a313882306a5e3f4a10814466a511415c388a2ab98201c312e7ec291194"
+        "31693053caad6df9d98a187588145cea3eb42b741eb3959abdf9138167fe993a100b9fa1f41e000003000600000000000000"
+        "fd49010100ba2f170003000148f97725a2106d1fa6c4dc099de8acdc72b5b6b601751e65201adf9512000000320000000000"
+        "0000320000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        "000000000000000000000000000000000000000000000000000000000000000003000600000000000000fd55010100ba2f17"
+        "0003000448f97725a2106d1fa6c4dc099de8acdc72b5b6b601751e65201adf95120000006400000000000000000000000000"
+        "6400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        "00000000000000000000000000000000000000000000000000000000000000000000000003000600000000000000fd430101"
+        "00ba2f170003000648f97725a2106d1fa6c4dc099de8acdc72b5b6b601751e65201adf951200000019000000001900000000"
+        "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        "00000000000000000000000000000000000000000000";
+
+dash::coin::BlockType block_from_hex(const char* hex) {
+    std::string h(hex);
+    std::vector<unsigned char> raw;
+    raw.reserve(h.size() / 2);
+    for (size_t i = 0; i + 1 < h.size(); i += 2)
+        raw.push_back(static_cast<unsigned char>(
+            std::stoul(h.substr(i, 2), nullptr, 16)));
+    ::PackStream ps(raw);
+    dash::coin::BlockType blk;
+    ps >> blk;
+    return blk;
+}
+
+} // namespace
+
+TEST(DashMnSeed, RealTestnetVectorProjectionTracksDashdSchedule) {
+    MnSeedStats st;
+    auto seed = parse_protx_list_seed(json::parse(kProtxFront6At1519543),
+                                      TESTNET_PUBKEY_VER, TESTNET_P2SH_VER, &st);
+    ASSERT_EQ(seed.size(), 6u) << "all six from-wire entries must seed";
+    EXPECT_EQ(st.evo, 2u);
+
+    dash::coin::MnStateMachine m;
+    m.load(std::move(seed));
+
+    const uint256 mn_1519544 = uint256S(
+        "dc2e02ac95ce4ccc9843c38de7bdaf32f2a1d5966c054127a3f4ca4f4bbd5991");
+    const uint256 mn_1519545 = uint256S(
+        "9b653e767b978c10346d938c08dc8c5acd03c495f9d913e6fc652bfcae11a348");
+    const uint256 mn_1519546 = uint256S(
+        "91bbce94c34ebde0d099c0a2cb7635c0c31425ebabcec644f4f1a0854bfa605d");
+    const uint256 mn_1519547 = uint256S(
+        "72ee70fa75262781a17d1eb69a6c3e97328208be98b59d5530164f31e481d3aa");
+
+    // Projection at 1519544 (list @1519543) == dashd's payee.
+    auto exp = m.find_expected_payee();
+    ASSERT_TRUE(exp.has_value());
+    EXPECT_EQ(*exp, mn_1519544);
+
+    // Apply the real accepted blocks; each attribution must land on exactly
+    // the MN dashd credited.
+    auto b44 = block_from_hex(kBlockHex1519544);
+    auto b45 = block_from_hex(kBlockHex1519545);
+    auto b46 = block_from_hex(kBlockHex1519546);
+    ASSERT_FALSE(b44.m_txs.empty());
+    ASSERT_FALSE(b45.m_txs.empty());
+    ASSERT_FALSE(b46.m_txs.empty());
+
+    auto r44 = m.apply_block(b44, 1519544);
+    EXPECT_EQ(r44.paid, 1u);
+    EXPECT_FALSE(r44.payee_desync);
+    EXPECT_EQ(m.entries().at(mn_1519544).nLastPaidHeight, 1519544u);
+
+    exp = m.find_expected_payee();
+    ASSERT_TRUE(exp.has_value());
+    EXPECT_EQ(*exp, mn_1519545) << "next payee after 1519544 must be the Evo MN 9b653e76";
+
+    auto r45 = m.apply_block(b45, 1519545);
+    EXPECT_EQ(r45.paid, 1u);
+    EXPECT_EQ(m.entries().at(mn_1519545).nLastPaidHeight, 1519545u);
+
+    exp = m.find_expected_payee();
+    ASSERT_TRUE(exp.has_value());
+    EXPECT_EQ(*exp, mn_1519546);
+
+    auto r46 = m.apply_block(b46, 1519546);
+    EXPECT_EQ(r46.paid, 1u);
+    EXPECT_EQ(m.entries().at(mn_1519546).nLastPaidHeight, 1519546u);
+
+    exp = m.find_expected_payee();
+    ASSERT_TRUE(exp.has_value());
+    EXPECT_EQ(*exp, mn_1519547) << "projection after the three real blocks";
+
+    // THE soak failure mode: a duplicated delivery of block 1519546. Pre-fix
+    // the observation attribution re-picked inside the shared yeRZBWYf… group
+    // and marked 9b653e76 a second time — shifting the group cursor one slot
+    // ahead of dashd forever. Post-fix the duplicate is skipped whole.
+    auto rdup = m.apply_block(b46, 1519546);
+    EXPECT_TRUE(rdup.skipped_out_of_order);
+    EXPECT_EQ(rdup.paid, 0u);
+    EXPECT_EQ(m.entries().at(mn_1519545).nLastPaidHeight, 1519545u)
+        << "duplicate apply must not advance the shared-address group cursor";
+    exp = m.find_expected_payee();
+    ASSERT_TRUE(exp.has_value());
+    EXPECT_EQ(*exp, mn_1519547)
+        << "projection must be unchanged by a duplicated block delivery";
+}

--- a/test/test_dash_mn_state.cpp
+++ b/test/test_dash_mn_state.cpp
@@ -661,6 +661,123 @@ TEST(DashMnState, FindExpectedPayeeSkipsInvalid) {
     EXPECT_EQ(*exp, raw256_byte(0, 0x05));
 }
 
+// ─── projection attribution (soak-found bad-cb-payee class, 2026-07-22) ────
+//
+// E4 re-soak evidence (run/e4-e1e2b, binary 0b6cd2bb): 13/124 embedded serves
+// REJECTED by dashd with bad-cb-payee. Root cause: the old OBSERVATION
+// attribution (scan coinbase outputs -> pick_paid_mn per match) is not
+// idempotent — ONE duplicated attribution pass over an already-applied block
+// re-picks inside a shared-payoutAddress group (53 testnet MNs share one
+// address) and marks the NEXT MN of the group. The group's payment cursor
+// then runs one slot ahead of dashd's DIP-3 schedule FOREVER, emitting the
+// wrong coinbase payee at every height where the shifted cursor changes the
+// projected address (~10% of serves). Exhaustive replay of the soak's 129
+// embedded emissions reproduced ALL of them (129/129, incl. all 13 fails)
+// from exactly two such duplicated attributions.
+//
+// Fix under test: dashd-exact PROJECTION attribution
+// (evo/deterministicmns.cpp BuildNewListFromBlock: mark
+// GetMNPayee(pindexPrev), never an output-scan inference) + whole-apply
+// forward-only guard + payee-desync fail-closed.
+
+// THE regression KAT (fails on the pre-fix machine, passes post-fix): a
+// duplicated apply of one block must NOT advance a shared-payoutAddress
+// group's payment cursor. Uses only the pre-fix API surface so it compiles
+// against both implementations.
+TEST(DashMnState, SharedPayoutGroupCursorSurvivesDuplicateApply) {
+    MnStateMachine m;
+    auto shared = script_bytes(0x42, 25);   // A and B share this payout
+    auto other  = script_bytes(0x43, 25);   // C pays elsewhere
+
+    MNState a; a.isValid = true; a.scriptPayout.m_data = shared;
+    a.nRegisteredHeight = 1'000'000; a.nLastPaidHeight = 1'519'100;
+    MNState b = a; b.nLastPaidHeight = 1'519'200;
+    MNState c = a; c.scriptPayout.m_data = other; c.nLastPaidHeight = 1'519'300;
+    // Distinct collaterals (load() keys a collateral index).
+    a.collateralOutpoint.hash = raw256_byte(0, 0xA1);
+    b.collateralOutpoint.hash = raw256_byte(0, 0xB1);
+    c.collateralOutpoint.hash = raw256_byte(0, 0xC1);
+
+    uint256 hA = raw256_byte(0, 0x01);
+    uint256 hB = raw256_byte(0, 0x02);
+    uint256 hC = raw256_byte(0, 0x03);
+    m.load(std::vector<std::pair<uint256, MNState>>{{hA, a}, {hB, b}, {hC, c}});
+
+    // dashd schedule: A (oldest) is the payee at H; the block pays `shared`.
+    BlockType blk;
+    blk.m_txs.push_back(coinbase_tx(std::vector<std::vector<unsigned char>>{shared}));
+    auto r1 = m.apply_block(blk, 1'520'000);
+    EXPECT_EQ(r1.paid, 1u);
+    EXPECT_EQ(m.entries().at(hA).nLastPaidHeight, 1'520'000u);
+
+    // DUPLICATE delivery of the same block. Pre-fix: pick_paid_mn skips the
+    // just-marked A and spuriously marks B (the soak corruption). Post-fix:
+    // the whole apply is skipped (forward-only) — no mutation.
+    m.apply_block(blk, 1'520'000);
+    EXPECT_EQ(m.entries().at(hB).nLastPaidHeight, 1'519'200u)
+        << "duplicate apply must not mark the next MN of the shared group";
+
+    // The projected next payee must still be B (dashd's schedule), not C.
+    auto exp = m.find_expected_payee();
+    ASSERT_TRUE(exp.has_value());
+    EXPECT_EQ(*exp, hB)
+        << "group cursor ran one slot ahead after a duplicate apply";
+}
+
+// Projection attribution marks exactly the projected MN and reports it —
+// and an out-of-order (height <=) delivery is skipped whole.
+TEST(DashMnState, ApplyBlockIsForwardOnlyAndReportsSkip) {
+    MnStateMachine m;
+    auto shared = script_bytes(0x44, 25);
+    MNState a; a.isValid = true; a.scriptPayout.m_data = shared;
+    a.nRegisteredHeight = 1'000'000; a.nLastPaidHeight = 1'519'100;
+    a.collateralOutpoint.hash = raw256_byte(0, 0xA2);
+    uint256 hA = raw256_byte(0, 0x01);
+    m.load(std::vector<std::pair<uint256, MNState>>{{hA, a}});
+    EXPECT_EQ(m.last_applied_height(), 0u);
+
+    BlockType blk;
+    blk.m_txs.push_back(coinbase_tx(std::vector<std::vector<unsigned char>>{shared}));
+    auto r1 = m.apply_block(blk, 1'520'000);
+    EXPECT_FALSE(r1.skipped_out_of_order);
+    EXPECT_EQ(r1.paid, 1u);
+    EXPECT_EQ(m.last_applied_height(), 1'520'000u);
+
+    auto r2 = m.apply_block(blk, 1'520'000);     // duplicate
+    EXPECT_TRUE(r2.skipped_out_of_order);
+    EXPECT_EQ(r2.paid, 0u);
+    auto r3 = m.apply_block(blk, 1'519'999);     // out-of-order
+    EXPECT_TRUE(r3.skipped_out_of_order);
+    EXPECT_EQ(m.last_applied_height(), 1'520'000u);
+}
+
+// A coinbase that does NOT pay the projected MN is a payee DESYNC: nothing is
+// attributed (never guess) and the apply reports payee_desync so the caller
+// fails closed. The old code silently marked whatever MN matched any output.
+TEST(DashMnState, CoinbaseNotPayingProjectedMnReportsDesyncNoGuess) {
+    MnStateMachine m;
+    auto sA = script_bytes(0x45, 25);
+    auto sB = script_bytes(0x46, 25);
+    MNState a; a.isValid = true; a.scriptPayout.m_data = sA;
+    a.nRegisteredHeight = 1'000'000; a.nLastPaidHeight = 1'519'100;  // projected
+    MNState b = a; b.scriptPayout.m_data = sB; b.nLastPaidHeight = 1'519'200;
+    a.collateralOutpoint.hash = raw256_byte(0, 0xA3);
+    b.collateralOutpoint.hash = raw256_byte(0, 0xB3);
+    uint256 hA = raw256_byte(0, 0x01);
+    uint256 hB = raw256_byte(0, 0x02);
+    m.load(std::vector<std::pair<uint256, MNState>>{{hA, a}, {hB, b}});
+
+    // Block pays B's script while the projection says A -> desync, no mark.
+    BlockType blk;
+    blk.m_txs.push_back(coinbase_tx(std::vector<std::vector<unsigned char>>{sB}));
+    auto r = m.apply_block(blk, 1'520'000);
+    EXPECT_TRUE(r.payee_desync);
+    EXPECT_EQ(r.paid, 0u);
+    EXPECT_EQ(m.entries().at(hA).nLastPaidHeight, 1'519'100u);
+    EXPECT_EQ(m.entries().at(hB).nLastPaidHeight, 1'519'200u)
+        << "desync must not attribute the payment to the observed-match MN";
+}
+
 // ─── sync_validity_from_sml (Bug 12/14 triple-field reconciliation) ─────────
 
 TEST(DashMnState, SyncValidityFromSmlBansAndRevives) {

--- a/test/test_dash_node_reception_wire.cpp
+++ b/test/test_dash_node_reception_wire.cpp
@@ -342,7 +342,11 @@ TEST(DashReceptionWire, BlockConnectRelayNoSpecialTxPreservesReadiness) {
 
     dash::interfaces::BlockConnected bc;
     bc.height = H;
-    bc.block.m_txs.push_back(make_spend(raw256(0x90), 0, 500'000'000, 1));  // cb (idx 0, skipped)
+    bc.block.m_txs.push_back(make_spend(raw256(0x90), 0, 500'000'000, 1));  // cb (idx 0)
+    // Projection attribution: a readiness-preserving block pays the PROJECTED
+    // payee (every dashd-accepted block does); a non-paying coinbase is a
+    // payee desync and deliberately demotes (maintainer KAT covers it).
+    bc.block.m_txs[0].vout[0].scriptPubKey.m_data = p2pkh_script(0x30);
     bc.block.m_txs.push_back(make_spend(raw256(0x91), 0, 400'000'000, 2));  // plain spend, no collateral
     node.block_connected.happened(bc);
 


### PR DESCRIPTION
## DO NOT MERGE — gate on the next embedded soak crossing

Fixes the 5th embedded-soak-refuted issue class: **intermittent `bad-cb-payee` (13/124 embedded serves, ~10%) on the E4 re-soak** (`run/e4-e1e2b`, binary 0b6cd2bb, real Dash testnet dashd @ .52). Roots (merkleRootQuorums / creditPool) were correct on all 13 — the failure is purely the coinbase masternode PAYMENT payee.

### Root cause (proven, class B: wrong masternode, not amount)
- At every failing height the embedded arm emitted a **different payee ADDRESS** than dashd's deterministic DIP-3 schedule — and always **exactly the address of dashd's payee at H+1** (one payment-queue slot ahead).
- The selection comparator (`CompareByLastPaid_GetHeight` + memcmp `proTxHash` tiebreak) is **exact**: reconstructed against dashd's historical `protx list <h>` it reproduces dashd's actual payee sequence **246/246 heights**.
- The defect is the **attribution**: `apply_block` pass 3 attributed payments by **observing coinbase outputs** (`pick_paid_mn` per matching output). Dash Core instead attributes **projectively** (`BuildNewListFromBlock` marks `GetMNPayee(pindexPrev)`). Observation attribution is **not idempotent**: one duplicated/replayed attribution pass re-picks inside a shared-payoutAddress group (53 testnet MNs share one payout address, 28 another) and marks the NEXT MN of the group — permanently shifting that group's payment cursor one slot ahead.
- Exhaustive replay against dashd's per-height authoritative attributions reproduces **ALL 129 of the soak's embedded payee emissions (129/129, incl. all 13 rejects)** from exactly **two** such duplicated attributions (origin windows 1519527–1519543 and 1519648–1519661). No collateral spends, no MN set changes, no SML validity flips in those windows — the extra attribution pass is the only mechanism consistent with all the data.

### Fix (mostly-reuse: mirrors Dash Core `evo/deterministicmns.cpp` exactly)
1. **Projection attribution**: pass 3 marks `find_expected_payee()` computed from the pre-block list (== `GetMNPayee(pindexPrev)`), only if it survived passes 1/2 (== `newList.HasMN`).
2. **Coinbase as cross-check only**: if the coinbase does not pay the projected MN's `scriptPayout`, the apply reports `payee_desync` and attributes **nothing** (never guess).
3. **Forward-only whole-apply guard**: duplicate / out-of-order deliveries are skipped whole (`skipped_out_of_order`) — the corruption mechanism is structurally impossible now.
4. **Fail-closed + self-heal**: `CoinStateMaintainer` on desync wipes the payee set, latches `needs-reseed` (no re-arm off incidental ProRegTx), demotes to the dashd fallback, and fires the new `set_on_mn_reseed` hook; `main_dash` wires that to the (now reusable) E2c `protx list valid true` seed.

### KATs (fails-before / passes-after)
- `DashMnState.SharedPayoutGroupCursorSurvivesDuplicateApply` — **FAILS on the pre-fix machine** (duplicate apply marks the next shared-address MN; projected payee runs one slot ahead), passes with the fix. Verified by building the same test against unmodified master.
- `DashMnSeed.RealTestnetVectorProjectionTracksDashdSchedule` — **from-wire vector captured from the real testnet node**: front six of dashd's payment queue at 1519543 (`protx list valid true 1519543`, verbatim JSON, incl. 2 Evo MNs + both shared-address groups) + real accepted blocks 1519544–1519546. Asserts dashd's exact per-height attributions and next-payee projection, plus duplicate-delivery immunity.
- `DashMnState.ApplyBlockIsForwardOnlyAndReportsSkip`, `DashMnState.CoinbaseNotPayingProjectedMnReportsDesyncNoGuess`, `DashCoinStateMaintainer.PayeeDesyncWipesDemotesAndFiresReseed`.
- Test results: `test_dash_mn_state` 26/26, `test_dash_coin_state_maintainer` 12/12, `test_dash_node_reception_wire` (incl. mn_seed TU) 22/22.

### Scope decision
The defect lives in `mn_state_machine.hpp` **on master** (identical bytes on master and the soak merge) — it is NOT part of #803's E1 DKG/serve wiring, so this is a follow-up branch off master, not an E1 amendment. #802/#803 remain gated; the next combined re-soak should include this branch (expected: 0 bad-cb-payee).

Cross-checked against the hotel's #806 (`bad-cb-payee` via stale-coinbase fee drift on the dashd-backed producer path): different class — that one paid the right address with a wrong amount; this one paid the wrong masternode. Both are now covered separately.
