### PR TITLE
ci: unconditional post-job workspace prune on VM905 self-hosted runners

### DIFF
--- a/.github/actions/prune-runner-workspace/action.yml
+++ b/.github/actions/prune-runner-workspace/action.yml
@@ -1,0 +1,68 @@
+name: Prune runner workspace
+description: >
+  Post-job disk hygiene for the VM905 self-hosted Linux runners. Removes the
+  per-repo checkout payload (<_work>/c2pool/**, keeping .git so the checkout
+  post-step still works) and the contents of <_work>/_temp. Deliberately never
+  touches _actions/, _tool/, _update/, _update.sh or ~/.cache -- _actions and
+  _tool are reuse caches whose removal re-downloads on every job, and runner -2
+  is mid-update with _update/ live in its _work.
+
+  No-ops on github-hosted runners, which are ephemeral already.
+
+runs:
+  using: composite
+  steps:
+    - name: Prune workspace
+      if: runner.environment == 'self-hosted' && runner.os == 'Linux'
+      shell: bash
+      run: |
+        set -uo pipefail
+        work_root="$(dirname "$RUNNER_WORKSPACE")"
+
+        echo "::group::disk before prune"
+        df -h "$work_root"
+        du -sh "$RUNNER_WORKSPACE" 2>/dev/null
+        echo "::endgroup::"
+
+        # Refuse on any layout that is not the expected <_work>/<repo>. This is
+        # the guard that keeps a bad env from turning `rm -rf` loose on $HOME.
+        case "$GITHUB_WORKSPACE" in "$RUNNER_WORKSPACE"/*) ;; *) bad=1 ;; esac
+        if [ "$(basename "$work_root")" != "_work" ] || [ ! -d "$RUNNER_WORKSPACE" ] || [ -n "${bad:-}" ]; then
+          echo "unexpected layout (work_root=$work_root workspace=$RUNNER_WORKSPACE) -- not pruning"
+          exit 0
+        fi
+
+        cd /
+
+        # Everything under the workspace except the checkout's .git. Keeping .git
+        # (~230 MiB) lets actions/checkout's post-step unset its auth header
+        # instead of erroring, and lets the next job fetch incrementally. The
+        # build trees, which are the actual ~5 GiB, all go.
+        find "$RUNNER_WORKSPACE" -mindepth 1 -maxdepth 1 ! -path "$GITHUB_WORKSPACE" -exec rm -rf -- {} +
+        find "$GITHUB_WORKSPACE" -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf -- {} +
+
+        # _temp: empty it, keep the directory itself -- the runner holds it open
+        # for the remainder of the job. conan2/ is exempt: release.yml's linux
+        # packaging job and build.yml's linux-package job restore actions/cache
+        # at ${{ runner.temp }}/conan2 WITHOUT a github-hosted guard, and that
+        # action's post-step saves from the path after this step has run. On
+        # self-hosted CONAN_HOME lives in ~/.conan2-ci/$RUNNER_NAME anyway, so
+        # the exemption costs ~nothing (_temp measures ~100 KiB on VM905).
+        if [ -d "$work_root/_temp" ]; then
+          find "$work_root/_temp" -mindepth 1 -maxdepth 1 ! -name conan2 -exec rm -rf -- {} +
+        fi
+
+        echo "::group::preserved caches"
+        for keep in _actions _tool _update _update.sh; do
+          if [ -e "$work_root/$keep" ]; then
+            echo "PRESENT  $work_root/$keep"
+          else
+            echo "absent   $work_root/$keep"
+          fi
+        done
+        echo "::endgroup::"
+
+        echo "::group::disk after prune"
+        df -h "$work_root"
+        du -sh "$RUNNER_WORKSPACE" 2>/dev/null
+        echo "::endgroup::"

--- a/.github/workflows/attribution-gate.yml
+++ b/.github/workflows/attribution-gate.yml
@@ -62,3 +62,9 @@ jobs:
             exit 1
           fi
           echo "attribution-gate: clean"
+
+      # Steady-state disk hygiene on the VM905 self-hosted runners: drop the
+      # checkout payload and _temp, keep _actions/_tool/_update. Always runs.
+      - name: Prune runner workspace
+        if: always()
+        uses: ./.github/actions/prune-runner-workspace

--- a/.github/workflows/bch-gate-g3a-regtest-block-production.yml
+++ b/.github/workflows/bch-gate-g3a-regtest-block-production.yml
@@ -110,3 +110,9 @@ jobs:
           BCH_RPC_PASS: ${{ secrets.BCH_RPC_PASS }}
           BCH_RPC_AUTH: ${{ secrets.BCH_RPC_AUTH }}
         run: bash tests/gates/bch_g3a_regtest_block_production.sh
+
+      # Steady-state disk hygiene on the VM905 self-hosted runners: drop the
+      # checkout payload and _temp, keep _actions/_tool/_update. Always runs.
+      - name: Prune runner workspace
+        if: always()
+        uses: ./.github/actions/prune-runner-workspace

--- a/.github/workflows/bch-gate-g3b-genuine-activation.yml
+++ b/.github/workflows/bch-gate-g3b-genuine-activation.yml
@@ -106,3 +106,9 @@ jobs:
           # unset — the network-free CI arm carries the gate.
           BCH_UPGRADE9_HEIGHT: ${{ secrets.BCH_UPGRADE9_HEIGHT }}
         run: bash tests/gates/bch_g3b_genuine_activation.sh
+
+      # Steady-state disk hygiene on the VM905 self-hosted runners: drop the
+      # checkout payload and _temp, keep _actions/_tool/_update. Always runs.
+      - name: Prune runner workspace
+        if: always()
+        uses: ./.github/actions/prune-runner-workspace

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check coin test targets vs build.yml --target allowlist
         run: python3 tools/ci/check_test_target_allowlist.py
+
+      # Steady-state disk hygiene on the VM905 self-hosted runners: drop the
+      # checkout payload and _temp, keep _actions/_tool/_update. Always runs.
+      - name: Prune runner workspace
+        if: always()
+        uses: ./.github/actions/prune-runner-workspace
   # ════════════════════════════════════════════════════════════════════════════
   # Linux (Ubuntu 24.04, GCC 13, Conan)
   # ════════════════════════════════════════════════════════════════════════════
@@ -188,6 +194,12 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v7
         with: { name: test-results-linux, path: build_ci/Testing/, retention-days: 7 }
+
+      # Steady-state disk hygiene on the VM905 self-hosted runners: drop the
+      # checkout payload and _temp, keep _actions/_tool/_update. Always runs.
+      - name: Prune runner workspace
+        if: always()
+        uses: ./.github/actions/prune-runner-workspace
 
   # ════════════════════════════════════════════════════════════════════════════
   # Linux AddressSanitizer + UBSan (informational, not gating yet)
@@ -347,6 +359,12 @@ jobs:
         uses: actions/upload-artifact@v7
         with: { name: test-results-linux-asan, path: build_asan/Testing/, retention-days: 7 }
 
+      # Steady-state disk hygiene on the VM905 self-hosted runners: drop the
+      # checkout payload and _temp, keep _actions/_tool/_update. Always runs.
+      - name: Prune runner workspace
+        if: always()
+        uses: ./.github/actions/prune-runner-workspace
+
   # ════════════════════════════════════════════════════════════════════════════
   # COIN_BCH leg — Bitcoin Cash (SHA256d standalone parent, V36)
   #
@@ -478,6 +496,12 @@ jobs:
         uses: actions/upload-artifact@v7
         with: { name: test-results-coin-bch, path: build_bch/Testing/, retention-days: 7 }
 
+      # Steady-state disk hygiene on the VM905 self-hosted runners: drop the
+      # checkout payload and _temp, keep _actions/_tool/_update. Always runs.
+      - name: Prune runner workspace
+        if: always()
+        uses: ./.github/actions/prune-runner-workspace
+
   # ════════════════════════════════════════════════════════════════════════════
   # COIN_BCH AddressSanitizer + UBSan (informational, mirrors linux-asan posture)
   # ════════════════════════════════════════════════════════════════════════════
@@ -607,6 +631,12 @@ jobs:
         uses: actions/upload-artifact@v7
         with: { name: test-results-coin-bch-asan, path: build_bch_asan/Testing/, retention-days: 7 }
 
+      # Steady-state disk hygiene on the VM905 self-hosted runners: drop the
+      # checkout payload and _temp, keep _actions/_tool/_update. Always runs.
+      - name: Prune runner workspace
+        if: always()
+        uses: ./.github/actions/prune-runner-workspace
+
   # ════════════════════════════════════════════════════════════════════════════
   # Web-static JS verify (typecheck + build + tests + bundle-size gate)
   # Covers web-static/sharechain-explorer/: the Explorer + PPLNS View
@@ -688,6 +718,12 @@ jobs:
           name: visual-diff-out
           path: web-static/sharechain-explorer/tests/visual/out/
           retention-days: 7
+
+      # Steady-state disk hygiene on the VM905 self-hosted runners: drop the
+      # checkout payload and _temp, keep _actions/_tool/_update. Always runs.
+      - name: Prune runner workspace
+        if: always()
+        uses: ./.github/actions/prune-runner-workspace
 
   # ════════════════════════════════════════════════════════════════════════════
   # c2pool-qt leak-regression harness (Qt hybrid step 14, delta v1 §E.2)
@@ -774,6 +810,12 @@ jobs:
         run: |
           xvfb-run -a --server-args="-screen 0 1280x800x24 +extension GLX +render -noreset" \
             timeout 180 ./build-qt/c2pool-qt_test_embedded_leak
+
+      # Steady-state disk hygiene on the VM905 self-hosted runners: drop the
+      # checkout payload and _temp, keep _actions/_tool/_update. Always runs.
+      - name: Prune runner workspace
+        if: always()
+        uses: ./.github/actions/prune-runner-workspace
 
   # ════════════════════════════════════════════════════════════════════════════
   # BTC embedded smoke — RETIRED 2026-06-17 (ci-steward/retire-btc-linux).
@@ -1093,6 +1135,12 @@ jobs:
             build_dgb_auxdoge/CMakeFiles/CMakeError.log
           retention-days: 7
           if-no-files-found: ignore
+
+      # Steady-state disk hygiene on the VM905 self-hosted runners: drop the
+      # checkout payload and _temp, keep _actions/_tool/_update. Always runs.
+      - name: Prune runner workspace
+        if: always()
+        uses: ./.github/actions/prune-runner-workspace
 
   # Releases are built and published manually (not via CI).
   # See installer/ for packaging scripts (DMG, ZIP, Inno Setup).

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -153,3 +153,9 @@ jobs:
           # auto-default, kept for github-hosted (fork) runs.
           threads: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && '12' || '0' }}
           ram: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && '20000' || '0' }}
+
+      # Steady-state disk hygiene on the VM905 self-hosted runners: drop the
+      # checkout payload and _temp, keep _actions/_tool/_update. Always runs.
+      - name: Prune runner workspace
+        if: always()
+        uses: ./.github/actions/prune-runner-workspace

--- a/.github/workflows/coin-matrix.yml
+++ b/.github/workflows/coin-matrix.yml
@@ -161,3 +161,9 @@ jobs:
             build_${{ matrix.coin }}/CMakeFiles/CMakeError.log
           retention-days: 7
           if-no-files-found: ignore
+
+      # Steady-state disk hygiene on the VM905 self-hosted runners: drop the
+      # checkout payload and _temp, keep _actions/_tool/_update. Always runs.
+      - name: Prune runner workspace
+        if: always()
+        uses: ./.github/actions/prune-runner-workspace

--- a/.github/workflows/dash-gate-g1-byte-parity.yml
+++ b/.github/workflows/dash-gate-g1-byte-parity.yml
@@ -103,3 +103,9 @@ jobs:
         env:
           BUILD_DIR: ${{ github.workspace }}/build_g1
         run: bash tests/gates/g1_byte_parity_kat.sh
+
+      # Steady-state disk hygiene on the VM905 self-hosted runners: drop the
+      # checkout payload and _temp, keep _actions/_tool/_update. Always runs.
+      - name: Prune runner workspace
+        if: always()
+        uses: ./.github/actions/prune-runner-workspace

--- a/.github/workflows/dash-gate-g3a-regtest-block-production.yml
+++ b/.github/workflows/dash-gate-g3a-regtest-block-production.yml
@@ -111,3 +111,9 @@ jobs:
           DASH_RPC_PASS: ${{ secrets.DASH_RPC_PASS }}
           DASH_RPC_AUTH: ${{ secrets.DASH_RPC_AUTH }}
         run: bash tests/gates/g3a_regtest_block_production.sh
+
+      # Steady-state disk hygiene on the VM905 self-hosted runners: drop the
+      # checkout payload and _temp, keep _actions/_tool/_update. Always runs.
+      - name: Prune runner workspace
+        if: always()
+        uses: ./.github/actions/prune-runner-workspace

--- a/.github/workflows/dgb-phase-b-smoke.yml
+++ b/.github/workflows/dgb-phase-b-smoke.yml
@@ -97,3 +97,9 @@ jobs:
         env:
           BUILD_DIR: ${{ github.workspace }}/build_dgb_smoke
         run: bash tests/gates/dgb_phase_b_smoke.sh
+
+      # Steady-state disk hygiene on the VM905 self-hosted runners: drop the
+      # checkout payload and _temp, keep _actions/_tool/_update. Always runs.
+      - name: Prune runner workspace
+        if: always()
+        uses: ./.github/actions/prune-runner-workspace

--- a/.github/workflows/pplns-parse-seedpin.yml
+++ b/.github/workflows/pplns-parse-seedpin.yml
@@ -46,3 +46,9 @@ jobs:
         run: |
           node --import tsx --import ./.ci-seed-pin.mjs \
             --test "tests/unit/pplns-parse-properties.test.ts"
+
+      # Steady-state disk hygiene on the VM905 self-hosted runners: drop the
+      # checkout payload and _temp, keep _actions/_tool/_update. Always runs.
+      - name: Prune runner workspace
+        if: always()
+        uses: ./.github/actions/prune-runner-workspace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,6 +210,12 @@ jobs:
           name: pkg-linux-${{ matrix.coin }}
           path: c2pool-*-linux-x86_64.tar.gz
 
+      # Steady-state disk hygiene on the VM905 self-hosted runners: drop the
+      # checkout payload and _temp, keep _actions/_tool/_update. Always runs.
+      - name: Prune runner workspace
+        if: always()
+        uses: ./.github/actions/prune-runner-workspace
+
   # ════════════════════════════════════════════════════════════════════════════
   # macOS universal (arm64 + x86_64) — operator decision 2026-06-11.
   # Each arch builds natively on its own runner (macos-14 = Apple Silicon ->
@@ -698,3 +704,9 @@ jobs:
               --notes "Draft assembled by release.yml -- operator reviews and publishes manually." \
               dist/*
           fi
+
+      # Steady-state disk hygiene on the VM905 self-hosted runners: drop the
+      # checkout payload and _temp, keep _actions/_tool/_update. Always runs.
+      - name: Prune runner workspace
+        if: always()
+        uses: ./.github/actions/prune-runner-workspace

--- a/.github/workflows/safe-cosmetic-automerge.yml
+++ b/.github/workflows/safe-cosmetic-automerge.yml
@@ -147,3 +147,9 @@ jobs:
             gh pr merge "$PR" --repo "$REPO" --merge --delete-branch=false
             echo "::endgroup::"
           done
+
+      # Steady-state disk hygiene on the VM905 self-hosted runners: drop the
+      # checkout payload and _temp, keep _actions/_tool/_update. Always runs.
+      - name: Prune runner workspace
+        if: always()
+        uses: ./.github/actions/prune-runner-workspace


### PR DESCRIPTION
Steady-state disk hygiene for the eight `actions.runner.frstrtr-c2pool.c2pool-linux-905*` services on VM905, per the attached spec. Framed as hygiene, not an incident fix — the ENOSPC event was closed by the scsi0 200G→400G online resize on 2026-07-22 (/ is now 387G, 242G free, 35% used as measured just now).

## What lands

New composite action `.github/actions/prune-runner-workspace`, wired as the **final step of all 20 self-hosted Linux jobs** with `if: always()`, across 12 workflows. Nothing runs out of band; the prune only ever executes inside the job that owns the workspace, so the forbidden cross-runner idle sweep is structurally impossible here.

## What it deletes

- everything under `<_work>/c2pool/` **except the checkout's `.git`**
- the contents of `<_work>/_temp/` (the directory itself stays; the runner holds it open)

Measured on runner 1: the checkout is 5,295,572 KiB of which `.git` is 234,376 KiB, so ~5.0 GiB per runner comes back, ~40 GiB across the eight. `.git` is kept on purpose — it lets `actions/checkout`'s post-step unset its auth header instead of erroring into a red job, and lets the next job fetch incrementally rather than clone cold.

## What it never touches

`_actions/`, `_tool/`, `_update/`, `_update.sh`, `~/.cache`. Runner -2 is mid-update on bin.2.335.1 with `_update/` live in its `_work`; `_actions` and `_tool` are reuse caches (`_tool` alone is 5.7 GiB and would re-download every job). The step logs a PRESENT/absent line for each of the four after pruning, so the acceptance check is readable straight off the run log rather than needing a separate disk inspection.

One carve-out worth your eye: **`_temp/conan2` is exempt.** `release.yml` linux-package and `build.yml` linux-package restore `actions/cache` at `${{ runner.temp }}/conan2` with no `github-hosted` guard, unlike the other 11 cache sites. That action saves from the path in a post-step, which runs *after* this step — emptying `_temp` wholesale would break those two saves. On self-hosted `CONAN_HOME` is `~/.conan2-ci/$RUNNER_NAME` anyway and `_temp` measures ~100 KiB, so the exemption costs essentially nothing.

## Guards

- `runner.environment == 'self-hosted' && runner.os == 'Linux'` — github-hosted forks are untouched.
- A layout check bails out with a message unless the tree really is `<_work>/<repo>` with `GITHUB_WORKSPACE` beneath `RUNNER_WORKSPACE`. That is what keeps a mangled env from pointing `rm -rf` at `$HOME`.
- `df -h` and `du -sh` are logged before and after.

## Acceptance status

- [x] Post-job step present with `if: always()` on every workflow using these runners (20 jobs / 12 workflows).
- [x] All 13 touched files re-validated through a YAML parse; the embedded script through `bash -n`.
- [ ] One green run per affected workflow showing the step executed and freed space — **the PR-triggered run does this for itself; I will collect the per-workflow evidence and post it here.**
- [ ] Post-pass confirmation that `_actions/`, `_tool/` and -2's `_update/` survive — read directly from the preserved-caches group in each run log, plus a direct `ls` on VM905 after the pass.

Not merging this myself; it is yours to review. Commit `4f2e8496`, GPG-signed.

One alternative I considered and rejected: the runner's own `ACTIONS_RUNNER_HOOK_JOB_COMPLETED` hook would cover cancelled and infrastructure-failed jobs too, which `if: always()` misses, and it is eight one-line `.env` edits instead of 20 workflow insertions. I did not take it because it is not a reviewable repo change and your spec was explicit about the in-job step. Worth a follow-up decision if cancelled-job leakage turns out to matter.
