### PR TITLE
dash(embedded): integrate bls-signatures + E1 Phase-L real quorum-commitment verify

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,50 @@ else()
     set(SECP256K1_INCLUDE_DIRS "")
 endif()
 
+# ── E1 Phase-L: optional dashbls (BLS12-381) backend for type-6 quorum-
+# commitment verification ────────────────────────────────────────────────────
+# dashpay/bls-signatures ("dashbls", relic-backed, Apache-2.0) — the SAME
+# library dashd wraps in src/bls/bls.h. OPT-IN and DASH-ONLY: only the DASH impl
+# (dash_bls_verify) + its KAT consume it, never the shared core the Windows
+# main_ltc launcher builds ([[reference_windows_ci_conan_flake]]: Windows CI
+# builds only the LTC launcher, so DASH-only BLS code cannot break it). When the
+# option is OFF (default) or the library is not found, dash_bls_verify compiles a
+# fail-closed stub and the DKG-window serve path keeps the pre-Phase-L
+# null-commitment posture exactly — no dashbls dependency enters any build.
+#
+# Build the library once for the CI factory with scripts/build_dashbls.sh (pins
+# the exact upstream commit); point cmake at it with -DDASHBLS_ROOT=<prefix>.
+option(C2POOL_DASH_BLS "Link dashbls (BLS12-381) for E1 Phase-L real quorum-commitment verify" OFF)
+set(C2POOL_DASH_BLS_AVAILABLE OFF)
+if(C2POOL_DASH_BLS)
+    # Honour a DASHBLS_ROOT hint (the build-factory install prefix), else search
+    # the system paths. dashbls installs: include/dashbls/*.hpp,
+    # lib/libdashbls.a, lib/librelic_s.a, lib/mimalloc-2.0/libmimalloc-secure.a.
+    find_path(DASHBLS_INCLUDE_DIR dashbls/bls.hpp
+        HINTS ${DASHBLS_ROOT} ENV DASHBLS_ROOT PATH_SUFFIXES include)
+    find_library(DASHBLS_LIB       NAMES dashbls bls-dash
+        HINTS ${DASHBLS_ROOT} ENV DASHBLS_ROOT PATH_SUFFIXES lib)
+    find_library(DASHBLS_RELIC_LIB NAMES relic_s relic
+        HINTS ${DASHBLS_ROOT} ENV DASHBLS_ROOT PATH_SUFFIXES lib)
+    find_library(DASHBLS_MIMALLOC_LIB NAMES mimalloc-secure mimalloc
+        HINTS ${DASHBLS_ROOT} ENV DASHBLS_ROOT PATH_SUFFIXES lib lib/mimalloc-2.0 lib/mimalloc-2.1)
+    find_library(DASHBLS_GMP_LIB NAMES gmp)
+    if(DASHBLS_INCLUDE_DIR AND DASHBLS_LIB AND DASHBLS_RELIC_LIB AND DASHBLS_GMP_LIB)
+        set(C2POOL_DASH_BLS_AVAILABLE ON)
+        set(DASHBLS_LIBRARIES ${DASHBLS_LIB} ${DASHBLS_RELIC_LIB})
+        if(DASHBLS_MIMALLOC_LIB)
+            list(APPEND DASHBLS_LIBRARIES ${DASHBLS_MIMALLOC_LIB})
+        endif()
+        list(APPEND DASHBLS_LIBRARIES ${DASHBLS_GMP_LIB})
+        message(STATUS "dashbls found (E1 Phase-L BLS verify ENABLED): ${DASHBLS_LIB}")
+        message(STATUS "dashbls includes: ${DASHBLS_INCLUDE_DIR}")
+    else()
+        message(WARNING "C2POOL_DASH_BLS=ON but dashbls not found "
+            "(need dashbls + relic + gmp; run scripts/build_dashbls.sh and pass "
+            "-DDASHBLS_ROOT=<prefix>). Falling back to fail-closed null-serve.")
+    endif()
+endif()
+
 # Enable testing only if GTest is found
 if(GTest_FOUND OR GTEST_FOUND)
     enable_testing()

--- a/scripts/build_dashbls.sh
+++ b/scripts/build_dashbls.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Build + install dashpay/bls-signatures ("dashbls") for the c2pool E1 Phase-L
+# BLS quorum-commitment verifier. This is the SAME library dashd wraps in
+# src/bls/bls.h (libdashbls 2.0, relic-backed, Apache-2.0). It is NOT on
+# ConanCenter, so — like secp256k1 — c2pool consumes it as a prebuilt system
+# library (find_library in the root CMakeLists, gated by -DC2POOL_DASH_BLS=ON).
+# Run this once on the CI build factory / dev host, then configure c2pool with:
+#
+#     cmake -DC2POOL_DASH_BLS=ON -DDASHBLS_ROOT=<PREFIX> ...
+#
+# Requires: cmake, a C++17 compiler, and libgmp-dev (relic ARITH=gmp backend).
+#
+# Pinned to the exact upstream commit dash v23.1.x vendors as src/dashbls
+# (libdashbls 2.0 / relic 0.5.0). RE-PIN in lockstep with the vendored-dashcore
+# bump that moves vendor/llmq_commitment.hpp (same discipline as dkg_window.hpp).
+set -euo pipefail
+
+DASHBLS_REPO="${DASHBLS_REPO:-https://github.com/dashpay/bls-signatures.git}"
+# libdashbls 2.0 (dash v23.1.x src/dashbls subtree; relic backend, basic+legacy
+# BLS schemes). Pin by commit for a reproducible, offline-cacheable build.
+DASHBLS_COMMIT="${DASHBLS_COMMIT:-dd683653c6eaba7235bc9c600f46bafbb8210291}"
+PREFIX="${1:-${DASHBLS_ROOT:-/opt/dashbls}}"
+BUILD_DIR="${BUILD_DIR:-/tmp/dashbls-build}"
+JOBS="${JOBS:-$(nproc 2>/dev/null || echo 4)}"
+
+echo "[build_dashbls] repo=$DASHBLS_REPO commit=$DASHBLS_COMMIT prefix=$PREFIX"
+
+rm -rf "$BUILD_DIR"
+git clone "$DASHBLS_REPO" "$BUILD_DIR/src"
+git -C "$BUILD_DIR/src" checkout --quiet "$DASHBLS_COMMIT"
+
+cmake -S "$BUILD_DIR/src" -B "$BUILD_DIR/build" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+    -DBUILD_BLS_TESTS=0 \
+    -DBUILD_BLS_BENCHMARKS=0 \
+    -DBUILD_BLS_PYTHON_BINDINGS=0 \
+    -DBUILD_BLS_JS_BINDINGS=0
+
+cmake --build "$BUILD_DIR/build" -j "$JOBS"
+cmake --install "$BUILD_DIR/build"
+
+echo "[build_dashbls] installed:"
+find "$PREFIX" -name 'libdashbls*' -o -name 'librelic*' -o -name 'bls.hpp' | sed 's/^/  /'
+echo "[build_dashbls] done — configure c2pool with -DC2POOL_DASH_BLS=ON -DDASHBLS_ROOT=$PREFIX"

--- a/src/c2pool/CMakeLists.txt
+++ b/src/c2pool/CMakeLists.txt
@@ -322,6 +322,10 @@ target_link_libraries(c2pool-dash
     dash_block_replay  # E1: coin/vendor/blockencodings.cpp — the coin-network P2P Handler
                        # (cmpctblock codec) the opt-in CoinClient instantiates ODR-uses
                        # CBlockHeaderAndShortTxIDs::FillShortTxIDSelector()
+    dash_bls_verify    # E1 Phase-L: real type-6 quorum-commitment BLS verify
+                       # (make_commitment_bls_verifier -> set_bls_verify_fn seam).
+                       # Carries the C2POOL_DASH_BLS define + dashbls libs PUBLIC
+                       # when the backend was found; fail-closed stub otherwise.
     btclibs
     yaml-cpp::yaml-cpp
     nlohmann_json::nlohmann_json

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -60,6 +60,7 @@
 #include <impl/dash/coin/node_coin_state.hpp>  // dash::coin::NodeCoinState (embedded work bundle)
 #include <impl/dash/coin/dkg_window.hpp>       // dash::coin::is_dkg_commitment_window (BLOCKER-1 guard)
 #include <impl/dash/coin/dkg_commitments.hpp>  // E1: build_daemonless_qc_plan (serve DKG windows daemonlessly)
+#include <impl/dash/coin/vendor/bls_verify.hpp>  // E1 Phase-L: make_commitment_bls_verifier (real qc verify seam)
 #include <impl/dash/coin/utxo_lane.hpp>    // dash::coin::UtxoLane — embedded UTXO/fee lane (E2b, #738)
 #include <impl/dash/coin/header_chain.hpp>       // dash::coin::HeaderChain — SPV header/tip authority (E2a)
 #include <impl/dash/coin/coin_state_maintainer.hpp>  // dash::coin::CoinStateMaintainer — populate ordering gate (E2a)
@@ -1559,6 +1560,41 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             // the sourcing leg is live.
             auto qc_cache =
                 std::make_shared<dash::coin::MineableCommitmentCache>();
+
+            // Phase-L VERIFY leg: install the dashbls-backed verifier on the
+            // cache. verified_for() will only yield a REAL commitment once this
+            // passes dashcore's CFinalCommitment::Verify (membersSig aggregate
+            // over the signers' operator keys + quorumSig against
+            // quorumPublicKey, both over BuildCommitmentHash). The verifier
+            // sources the ordered member operator key set via the provider
+            // below; anything it cannot establish with certainty fails CLOSED
+            // (verified_for -> nullopt -> the slot mines the consensus-valid
+            // null commitment, exactly the pre-Phase-L posture — reward-safe).
+            //
+            // MEMBER-SET RESIDUAL: the deterministic quorum member selection
+            // (dashcore llmq/utils.cpp ComputeQuorumMembers: score = hash over
+            // proRegTxHash/confirmedHash with the per-quorum modifier, taken
+            // over the SML AS OF the quorum base block) needs the HISTORICAL
+            // SML at cycleStart+quorumIndex — sourced over coin-P2P qrinfo
+            // (getqrinfo), not yet wired. Until that lands the provider returns
+            // nullopt and Phase-L stays fail-closed to null-serve; the BLS
+            // crypto path is complete + KAT-locked and needs no further change
+            // when the member set arrives. The SML nVersion (VER_LEGACY_BLS/
+            // VER_BASIC_BLS) MUST populate MemberOperatorKey::legacy_scheme so a
+            // mixed-scheme quorum verifies (a bare key hex is scheme-ambiguous).
+            dash::coin::vendor::MemberKeysProvider qc_member_keys =
+                [](uint8_t /*llmqType*/, const uint256& /*quorumHash*/)
+                    -> std::optional<std::vector<dash::coin::vendor::MemberOperatorKey>> {
+                    return std::nullopt;   // historical-SML member selection: qrinfo TODO
+                };
+            qc_cache->set_bls_verify_fn(
+                dash::coin::vendor::make_commitment_bls_verifier(
+                    std::move(qc_member_keys)));
+            if (dash::coin::vendor::bls_backend_available()) {
+                LOG_INFO << "[QC-PHASE-L] dashbls verifier installed "
+                            "(real qc inclusion gated on member-set sourcing)";
+            }
+
             coin_feed_subs.push_back(
                 coin_state.new_qfcommit.subscribe(
                     [qc_cache, qc_net]

--- a/src/impl/dash/CMakeLists.txt
+++ b/src/impl/dash/CMakeLists.txt
@@ -34,6 +34,26 @@ target_link_libraries(dash_block_replay PRIVATE core nlohmann_json::nlohmann_jso
 # links it is c2pool-dash (this slice), so the ltc/btc/doge/dgb build + ctest
 # surfaces are untouched. Per-coin isolation held: src/impl/dash only, no
 # shared-base/core SOURCE edit, dashd RPC fallback preserved.
+# E1 Phase-L: type-6 quorum-commitment BLS verify (coin/vendor/bls_verify.cpp).
+# Compiled UNCONDITIONALLY so the seam symbols (make_commitment_bls_verifier,
+# verify_final_commitment, build_commitment_hash) always resolve; the dashbls
+# backend is linked + the C2POOL_DASH_BLS define is set (PUBLIC, so the sole
+# consumer c2pool-dash inherits it) ONLY when the library was found. Without it
+# the verify functions are fail-closed stubs and NO dashbls dependency enters
+# the build — keeping the Windows main_ltc launcher (shared core only) clean.
+# SAFE-ADDITIVE: the only executable linking dash_bls_verify is c2pool-dash.
+add_library(dash_bls_verify STATIC coin/vendor/bls_verify.cpp)
+target_include_directories(dash_bls_verify PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/src/btclibs
+    ${CMAKE_SOURCE_DIR}/include)
+target_link_libraries(dash_bls_verify PRIVATE core ${Boost_LIBRARIES})
+if(C2POOL_DASH_BLS_AVAILABLE)
+    target_compile_definitions(dash_bls_verify PUBLIC C2POOL_DASH_BLS)
+    target_include_directories(dash_bls_verify PUBLIC ${DASHBLS_INCLUDE_DIR})
+    target_link_libraries(dash_bls_verify PUBLIC ${DASHBLS_LIBRARIES})
+endif()
+
 add_library(dash_rpc STATIC coin/rpc.cpp coin/zmq_tip_notify.cpp)
 target_include_directories(dash_rpc PRIVATE
     ${CMAKE_SOURCE_DIR}/src

--- a/src/impl/dash/coin/vendor/bls_verify.cpp
+++ b/src/impl/dash/coin/vendor/bls_verify.cpp
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// E1 Phase-L BLS verification of type-6 quorum commitments. See bls_verify.hpp.
+//
+// This TU is compiled UNCONDITIONALLY (so the seam symbols always resolve), but
+// the BLS backend is linked + used only when C2POOL_DASH_BLS is defined. Without
+// it, verify_final_commitment() / the produced verifier are fail-closed stubs
+// (always false) and the serve path keeps the pre-Phase-L null-commitment
+// posture — no dashbls dependency leaks into a build (e.g. the Windows main_ltc
+// launcher, which never defines C2POOL_DASH_BLS).
+
+#include <impl/dash/coin/vendor/bls_verify.hpp>
+
+#include <core/pack.hpp>       // PackStream, WriteCompactSize
+#include <core/hash.hpp>       // CHash256
+
+#include <cstring>
+#include <span>
+
+#ifdef C2POOL_DASH_BLS
+// dashpay/bls-signatures ("dashbls") — the exact library dashd wraps in
+// src/bls/bls.h. bls.hpp pulls in the relic-backed G1/G2 element + scheme API.
+#include <dashbls/bls.hpp>
+#include <dashbls/schemes.hpp>
+#include <dashbls/elements.hpp>
+#endif
+
+namespace dash {
+namespace coin {
+namespace vendor {
+
+// ── BuildCommitmentHash (dashcore llmq/commitment.cpp, byte-exact) ──────────
+
+uint256 build_commitment_hash(
+    uint8_t llmq_type, const uint256& quorum_hash,
+    const std::vector<bool>& valid_members,
+    const std::array<uint8_t, CFinalCommitment::BLS_PUBKEY_SIZE>& quorum_public_key,
+    const uint256& quorum_vvec_hash)
+{
+    // CHashWriter(SER_GETHASH, 0) << llmqType << blockHash
+    //   << DYNBITSET(validMembers) << pubKey << vvecHash
+    // then GetHash() == SHA256d. We build the identical preimage with a
+    // PackStream (little-endian integrals; uint256 raw 32 LE bytes; the
+    // vendored DynBitSetFormat is wire-identical to dashcore's
+    // DynamicBitSetFormatter; the BLS pubkey is the opaque 48 wire bytes) and
+    // hash it with core CHash256 — the same primitive quorum_root.hpp uses.
+    ::PackStream s;
+    s << llmq_type;                                   // 1 byte
+    s << quorum_hash;                                 // 32 bytes (uint256, LE)
+    DynBitSetFormat::Write(s, valid_members);         // CompactSize + ceil(n/8)
+    s.write(std::as_bytes(std::span{quorum_public_key}));  // 48 raw wire bytes
+    s << quorum_vvec_hash;                            // 32 bytes (uint256, LE)
+
+    auto sp = s.get_span();
+    uint256 h;
+    CHash256()
+        .Write(std::span<const unsigned char>(
+            reinterpret_cast<const unsigned char*>(sp.data()), sp.size()))
+        .Finalize(std::span<unsigned char>(h.data(), 32));
+    return h;
+}
+
+// ── BLS backend ─────────────────────────────────────────────────────────────
+
+bool bls_backend_available()
+{
+#ifdef C2POOL_DASH_BLS
+    return true;
+#else
+    return false;
+#endif
+}
+
+#ifdef C2POOL_DASH_BLS
+namespace {
+
+// Robust G1 (public-key) deserialization mirroring dashcore CBLSWrapper::
+// SetBytes: try the entry's declared scheme, and if the point is invalid fall
+// back to the other scheme (a pre-V19 key relayed after the fork, or an SML
+// nVersion mismatch). Returns false when neither yields a valid point.
+bool deser_g1(const std::array<uint8_t, CFinalCommitment::BLS_PUBKEY_SIZE>& bytes,
+              bool prefer_legacy, bls::G1Element& out)
+{
+    const bls::Bytes b(bytes.data(), bytes.size());
+    for (bool legacy : {prefer_legacy, !prefer_legacy}) {
+        try {
+            bls::G1Element e = bls::G1Element::FromBytes(b, legacy);
+            if (e.IsValid()) { out = e; return true; }
+        } catch (...) { /* try the other scheme */ }
+    }
+    return false;
+}
+
+// Post-V19 signatures are BASIC scheme (fLegacy = false) — the serve floor in
+// dkg_commitments.hpp guarantees post-V19, and the commitment we admit is the
+// basic-scheme wire object.
+bool deser_g2_basic(const std::array<uint8_t, CFinalCommitment::BLS_SIG_SIZE>& bytes,
+                    bls::G2Element& out)
+{
+    try {
+        out = bls::G2Element::FromBytes(bls::Bytes(bytes.data(), bytes.size()),
+                                        /*fLegacy=*/false);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+} // namespace
+#endif // C2POOL_DASH_BLS
+
+bool verify_final_commitment(const CFinalCommitment& c,
+                             const std::vector<MemberOperatorKey>& members)
+{
+#ifndef C2POOL_DASH_BLS
+    (void)c;
+    (void)members;
+    return false;   // no BLS backend → fail closed (serve null / dashd)
+#else
+    // ── structural guards (dashcore CFinalCommitment::Verify prelude) ───────
+    if (members.empty()) return false;
+    if (c.signers.size() != members.size()) return false;
+    if (c.validMembers.size() != members.size()) return false;
+
+    const uint256 commitment_hash = build_commitment_hash(
+        c.llmqType, c.quorumHash, c.validMembers, c.quorumPublicKey,
+        c.quorumVvecHash);
+    const bls::Bytes msg(commitment_hash.data(), 32);
+    bls::BasicSchemeMPL scheme;   // post-V19
+
+    try {
+        // ── membersSig: aggregate over the SIGNERS' operator keys ───────────
+        bls::G2Element members_sig;
+        if (!deser_g2_basic(c.membersSig, members_sig)) return false;
+
+        std::vector<bls::G1Element> signer_pubkeys;
+        signer_pubkeys.reserve(members.size());
+        for (size_t i = 0; i < members.size(); ++i) {
+            if (!c.signers[i]) continue;
+            bls::G1Element pk;
+            if (!deser_g1(members[i].pubKeyOperator,
+                          members[i].legacy_scheme, pk))
+                return false;   // a signer key we cannot decode → fail closed
+            signer_pubkeys.push_back(pk);
+        }
+        if (signer_pubkeys.empty()) return false;
+
+        if (signer_pubkeys.size() == 1) {
+            // dashcore is_single_member() path: plain VerifyInsecure.
+            if (!scheme.Verify(signer_pubkeys[0], msg, members_sig))
+                return false;
+        } else {
+            if (!scheme.VerifySecure(signer_pubkeys, members_sig, msg))
+                return false;
+        }
+
+        // ── quorumSig: threshold sig against quorumPublicKey ────────────────
+        bls::G1Element quorum_pubkey =
+            bls::G1Element::FromBytes(
+                bls::Bytes(c.quorumPublicKey.data(), c.quorumPublicKey.size()),
+                /*fLegacy=*/false);
+        if (!quorum_pubkey.IsValid()) return false;
+        bls::G2Element quorum_sig;
+        if (!deser_g2_basic(c.quorumSig, quorum_sig)) return false;
+        if (!scheme.Verify(quorum_pubkey, msg, quorum_sig)) return false;
+    } catch (...) {
+        return false;   // any relic/dashbls throw → fail closed
+    }
+    return true;
+#endif // C2POOL_DASH_BLS
+}
+
+// ── seam factory ────────────────────────────────────────────────────────────
+
+std::function<bool(const CFinalCommitment&)>
+make_commitment_bls_verifier(MemberKeysProvider provider)
+{
+    if (!bls_backend_available() || !provider) {
+        // Fail-closed: verified_for() will never yield a real commitment; the
+        // provider mines the null commitment (or dashd fallback) exactly as
+        // pre-Phase-L.
+        return [](const CFinalCommitment&) { return false; };
+    }
+    return [provider = std::move(provider)](const CFinalCommitment& c) -> bool {
+        auto members = provider(c.llmqType, c.quorumHash);
+        if (!members) return false;   // member set uncertain → fail closed
+        return verify_final_commitment(c, *members);
+    };
+}
+
+} // namespace vendor
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/vendor/bls_verify.hpp
+++ b/src/impl/dash/coin/vendor/bls_verify.hpp
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// E1 Phase-L — cryptographic verification of REAL (non-null) type-6 quorum
+/// commitments, reusing Dash Core's own verify logic + BLS backend.
+///
+/// This is the piece the MineableCommitmentCache::set_bls_verify_fn seam
+/// (dkg_commitments.hpp) was cut for. Without it every DKG-window slot mines
+/// the consensus-valid NULL commitment (dashd's own behaviour when it holds no
+/// verified DKG result); with it, a peer-relayed commitment that PASSES
+/// dashcore's CFinalCommitment::Verify may be INCLUDED in the template, so a
+/// mainnet DKG-window block carries the same REAL commitment dashd's block
+/// carries (null-serve would diverge → bad-qc reject on a successful DKG).
+///
+/// REUSE-FIRST (operator mandate — vendor Dash Core, do not hand-roll):
+///
+///   * build_commitment_hash  == dashcore llmq/commitment.cpp BuildCommitmentHash
+///     (the signed preimage; byte-exact, locked by a from-wire KAT).
+///   * verify_final_commitment == dashcore CFinalCommitment::VerifySignatureAsync
+///     (checkSigs path): membersSig = VerifySecureAggregated over the signers'
+///     pubKeyOperator, quorumSig = VerifyInsecure against quorumPublicKey, both
+///     over the commitment hash. Post-V19 BASIC scheme (the serve floor in
+///     dkg_commitments.hpp guarantees post-V19).
+///   * The BLS math is dashpay/bls-signatures ("dashbls", relic-backed,
+///     Apache-2.0 — the SAME library dashd wraps in src/bls/bls.h) — linked
+///     only when C2POOL_DASH_BLS is defined (see src/impl/dash/CMakeLists.txt).
+///
+/// FAIL-CLOSED (reward-critical embedded consensus): when the BLS backend is
+/// not compiled in, OR the member operator key set cannot be sourced, OR any
+/// size is wrong, OR the BLS verify FAILS, every entry point returns false and
+/// the caller (MineableCommitmentCache::verified_for) yields nullopt → the
+/// provider mines the always-valid NULL commitment (or falls back to dashd).
+/// An unverified/forged relayed commitment is NEVER served.
+///
+/// WHY membersSig IS MANDATORY (not quorumSig alone): the commitment hash binds
+/// quorumPublicKey, and quorumSig is a self-signature by that key — a malicious
+/// peer can mint its own (sk, pk) and produce a valid quorumSig. Only membersSig
+/// (an aggregate over the ACTUAL quorum members' operator keys, which the peer
+/// does not control) proves authenticity. So Phase-L REQUIRES the real member
+/// operator key set; without it we fail closed.
+
+#include <impl/dash/coin/vendor/llmq_commitment.hpp>
+
+#include <core/uint256.hpp>
+
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <vector>
+
+namespace dash {
+namespace coin {
+namespace vendor {
+
+/// One quorum member's BLS operator public key, carrying the wire scheme the
+/// key was serialized under. The SML (E3, CSimplifiedMNListEntry) records this
+/// per entry via nVersion (VER_LEGACY_BLS == 1 → legacy, VER_BASIC_BLS == 2 →
+/// basic), so production sourcing is UNAMBIGUOUS — unlike a bare RPC hex string
+/// (a mixed quorum has keys valid under BOTH encodings; only the SML nVersion
+/// disambiguates). legacy_scheme MUST reflect that flag.
+struct MemberOperatorKey {
+    std::array<uint8_t, CFinalCommitment::BLS_PUBKEY_SIZE> pubKeyOperator{};
+    bool legacy_scheme{false};
+};
+
+/// dashcore llmq/commitment.cpp BuildCommitmentHash (@ v23.1.x, verbatim
+/// preimage): CHashWriter(SER_GETHASH) << llmqType << quorumHash
+/// << DYNBITSET(validMembers) << quorumPublicKey << quorumVvecHash, then
+/// SHA256d. No BLS dependency — usable + testable regardless of C2POOL_DASH_BLS.
+uint256 build_commitment_hash(uint8_t llmq_type, const uint256& quorum_hash,
+                              const std::vector<bool>& valid_members,
+                              const std::array<uint8_t, CFinalCommitment::BLS_PUBKEY_SIZE>& quorum_public_key,
+                              const uint256& quorum_vvec_hash);
+
+/// True iff the dashbls backend is compiled in (C2POOL_DASH_BLS). When false,
+/// verify_final_commitment / the produced verifier fn always return false and
+/// the serve path fails closed — a build without BLS keeps the pre-Phase-L
+/// null-serve posture exactly.
+bool bls_backend_available();
+
+/// Verify one commitment's crypto EXACTLY as dashcore CFinalCommitment::Verify
+/// (checkSigs) does, post-V19 basic scheme. `members` MUST be the full ordered
+/// quorum member set (index-aligned with c.signers; members.size() ==
+/// c.signers.size() == params.size). Returns true only when BOTH the aggregate
+/// membersSig and the quorumSig verify. Fail-closed (false) on: backend absent,
+/// size mismatch, empty signer set, or any BLS verify failure. Never throws.
+bool verify_final_commitment(const CFinalCommitment& c,
+                             const std::vector<MemberOperatorKey>& members);
+
+/// Sources the ordered member operator key set for a (llmqType, quorumHash).
+/// Returns std::nullopt when the set cannot be established with certainty
+/// (member selection not resolvable, SML gap, historical base list unavailable)
+/// — in which case the verifier fails closed. The keys MUST be index-aligned
+/// with the commitment's signers/validMembers bitsets.
+using MemberKeysProvider =
+    std::function<std::optional<std::vector<MemberOperatorKey>>(
+        uint8_t llmq_type, const uint256& quorum_hash)>;
+
+/// Build the MineableCommitmentCache::BlsVerifyFn (std::function<bool(const
+/// CFinalCommitment&)>) main_dash installs via set_bls_verify_fn. It sources
+/// the member set via `provider`, then runs verify_final_commitment. When the
+/// BLS backend is absent OR the provider yields nullopt, the returned fn is
+/// fail-closed (always false). `provider` may be null (always fail closed).
+std::function<bool(const CFinalCommitment&)>
+make_commitment_bls_verifier(MemberKeysProvider provider);
+
+} // namespace vendor
+} // namespace coin
+} // namespace dash

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -495,6 +495,21 @@ if (BUILD_TESTING AND GTest_FOUND)
     target_link_libraries(test_dash_quorum_root PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
     gtest_add_tests(test_dash_quorum_root "" AUTO)
 
+    # E1 Phase-L: type-6 quorum-commitment BLS verify KAT. Links dash_bls_verify
+    # (which carries the C2POOL_DASH_BLS define + dashbls include/libs PUBLIC when
+    # the backend was found; a fail-closed stub otherwise). The BuildCommitmentHash
+    # byte-exactness + fail-closed KATs run in EVERY build; the BLS crypto KATs are
+    # #ifdef C2POOL_DASH_BLS-gated in the source and only exercise when linked.
+    add_executable(test_dash_bls_verify test_dash_bls_verify.cpp)
+    target_link_libraries(test_dash_bls_verify PRIVATE
+        GTest::gtest_main GTest::gtest
+        dash_bls_verify core
+        nlohmann_json::nlohmann_json
+        ${Boost_LIBRARIES}
+    )
+    target_link_libraries(test_dash_bls_verify PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
+    gtest_add_tests(test_dash_bls_verify "" AUTO)
+
     # DASH masternode state-machine (S7 leaf): vendored ProTx wire
     # (providertx.hpp) + MNState persistence (mn_state_db.hpp) +
     # apply_block RebuildListFromBlock + find_expected_payee / pick_paid_mn

--- a/test/test_dash_bls_verify.cpp
+++ b/test/test_dash_bls_verify.cpp
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// E1 Phase-L KATs: BLS12-381 verification of type-6 quorum commitments.
+//
+// Two independent anchors:
+//
+//   1. BuildCommitmentHash byte-exactness (ALWAYS runs, no BLS backend needed):
+//      the signed preimage of a REAL from-wire testnet commitment hashes to the
+//      value dashd itself signed. This is the hardest-to-get-right piece and is
+//      locked regardless of whether dashbls is linked.
+//
+//   2. BLS crypto (gated on C2POOL_DASH_BLS): the real from-wire quorumSig
+//      verifies against the real quorumPublicKey over that hash (ACCEPT), and
+//      tampering REJECTS; plus a fully synthetic round-trip that exercises the
+//      complete verify_final_commitment() path (membersSig aggregate + quorumSig)
+//      deterministically, and the fail-closed guards.
+//
+// The real vector was captured read-only from the testnet dashd (block 1519931,
+// llmq_50_60 quorum 0000001badbdd0…5c928798) — a successful DKG whose canonical
+// block carries the REAL (non-null) commitment, the exact mainnet case null-serve
+// would diverge on.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/vendor/bls_verify.hpp>
+#include <impl/dash/coin/vendor/llmq_commitment.hpp>
+#include <core/uint256.hpp>
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#ifdef C2POOL_DASH_BLS
+#include <dashbls/bls.hpp>
+#include <dashbls/schemes.hpp>
+#include <dashbls/elements.hpp>
+#endif
+
+using namespace dash::coin::vendor;
+
+namespace {
+
+std::vector<uint8_t> unhex(const std::string& s)
+{
+    std::vector<uint8_t> o;
+    o.reserve(s.size() / 2);
+    for (size_t i = 0; i + 1 < s.size(); i += 2)
+        o.push_back(static_cast<uint8_t>(std::stoul(s.substr(i, 2), nullptr, 16)));
+    return o;
+}
+
+template <size_t N>
+std::array<uint8_t, N> to_array(const std::vector<uint8_t>& v)
+{
+    std::array<uint8_t, N> a{};
+    EXPECT_EQ(v.size(), N);
+    for (size_t i = 0; i < N && i < v.size(); ++i) a[i] = v[i];
+    return a;
+}
+
+// uint256 from raw little-endian wire bytes (as they appear on the wire).
+uint256 u256_le(const std::string& le_hex)
+{
+    return uint256(unhex(le_hex));
+}
+
+// ── real from-wire testnet vector (llmq_50_60 @ block 1519931) ──────────────
+constexpr uint8_t kLlmqType = 1;
+const char* kQuorumHashLe =
+    "9887925c4fe116e798cb79d54f3614baf73349e85c0bf66ce9d0bdad1b000000";
+const char* kQuorumPubKey =
+    "a51db3577089e74a6aa0b3ed0e8b8697e56f43b330be3c34e88fe7d4d1e3889e"
+    "781fea3c5aa385edcbca6540ddd49fa1";
+const char* kQuorumVvecHash =
+    "77a703f2ee5498e7b79df11f8fbbd40ab5c26e660c0a8fe67443dc083e3e4524";
+const char* kQuorumSig =
+    "93a37bd57ef329e8953deb448a0348124cafa52df0e5b7ca1076fc57e9a801ae"
+    "fd445c259b1a65e43472959a3b16e3f901aa42b7e830706b5525841e3c7b388b"
+    "94be4a72da1776f52b1f90e73d8dff21831fc90332634c88311b7f7ac6aa166b";
+// SHA256d of the BuildCommitmentHash preimage, as computed against dashd's
+// signed value (independently derived from the wire, matches the quorumSig).
+const char* kExpectedCommitmentHash =
+    "fda5e2b76b8d83aa328b694b0f827b0d589babb656d81fb8b92f3b193ed86594";
+
+} // namespace
+
+// ── anchor 1: BuildCommitmentHash byte-exactness (no backend needed) ────────
+TEST(DashBlsVerify, BuildCommitmentHashRealVector)
+{
+    std::vector<bool> valid_members(50, true);   // all 50 valid on this quorum
+    uint256 h = build_commitment_hash(
+        kLlmqType, u256_le(kQuorumHashLe), valid_members,
+        to_array<48>(unhex(kQuorumPubKey)), u256_le(kQuorumVvecHash));
+
+    // h is SHA256d output stored LE; compare against the LE-hex we captured.
+    std::vector<uint8_t> got(h.data(), h.data() + 32);
+    std::vector<uint8_t> want = unhex(kExpectedCommitmentHash);
+    EXPECT_EQ(got, want)
+        << "BuildCommitmentHash preimage drifted from dashd (bad-qc risk)";
+}
+
+// ── fail-closed without a backend / provider (always meaningful) ────────────
+TEST(DashBlsVerify, FailClosedNoMembers)
+{
+    CFinalCommitment c;
+    c.llmqType = kLlmqType;
+    c.signers.assign(50, true);
+    c.validMembers.assign(50, true);
+    // Empty member set → cannot verify membersSig → false, regardless of backend.
+    EXPECT_FALSE(verify_final_commitment(c, {}));
+    // Size-mismatched member set → false.
+    std::vector<MemberOperatorKey> two(2);
+    EXPECT_FALSE(verify_final_commitment(c, two));
+}
+
+TEST(DashBlsVerify, MakeVerifierNullProviderFailsClosed)
+{
+    auto fn = make_commitment_bls_verifier(nullptr);
+    ASSERT_TRUE(static_cast<bool>(fn));
+    CFinalCommitment c;
+    c.llmqType = kLlmqType;
+    c.signers.assign(50, true);
+    c.validMembers.assign(50, true);
+    EXPECT_FALSE(fn(c));   // null provider → never serves a real commitment
+}
+
+#ifdef C2POOL_DASH_BLS
+
+// ── anchor 2a: real quorumSig verifies over the real commitment hash ────────
+TEST(DashBlsVerify, RealQuorumSigAcceptsAndTamperRejects)
+{
+    ASSERT_TRUE(bls_backend_available());
+    std::vector<bool> valid_members(50, true);
+    uint256 h = build_commitment_hash(
+        kLlmqType, u256_le(kQuorumHashLe), valid_members,
+        to_array<48>(unhex(kQuorumPubKey)), u256_le(kQuorumVvecHash));
+
+    auto pk = unhex(kQuorumPubKey);
+    auto sig = unhex(kQuorumSig);
+    bls::G1Element qpk =
+        bls::G1Element::FromBytes(bls::Bytes(pk.data(), pk.size()), false);
+    bls::G2Element qs =
+        bls::G2Element::FromBytes(bls::Bytes(sig.data(), sig.size()), false);
+    bls::BasicSchemeMPL scheme;
+
+    // real quorumSig over the real commitment hash → ACCEPT.
+    EXPECT_TRUE(scheme.Verify(qpk, bls::Bytes(h.data(), 32), qs));
+
+    // flip one bit of the hash → REJECT.
+    std::vector<uint8_t> bad(h.data(), h.data() + 32);
+    bad[7] ^= 0x01;
+    EXPECT_FALSE(scheme.Verify(qpk, bls::Bytes(bad.data(), bad.size()), qs));
+
+    // flip one byte of the signature → REJECT (or fails to deserialize).
+    auto badsig = sig;
+    badsig[20] ^= 0x01;
+    bool ok_badsig = false;
+    try {
+        bls::G2Element qsb = bls::G2Element::FromBytes(
+            bls::Bytes(badsig.data(), badsig.size()), false);
+        ok_badsig = scheme.Verify(qpk, bls::Bytes(h.data(), 32), qsb);
+    } catch (...) { ok_badsig = false; }
+    EXPECT_FALSE(ok_badsig);
+}
+
+// ── BLS smoke KAT: a self-generated keypair round-trips ─────────────────────
+TEST(DashBlsVerify, BlsSmokeSignVerify)
+{
+    bls::BasicSchemeMPL scheme;
+    std::vector<uint8_t> seed(32, 0x11);
+    bls::PrivateKey sk = scheme.KeyGen(seed);
+    bls::G1Element pk = sk.GetG1Element();
+    std::vector<uint8_t> msg = {'c', '2', 'p', 'o', 'o', 'l'};
+    bls::G2Element sig = scheme.Sign(sk, msg);
+    EXPECT_TRUE(scheme.Verify(pk, bls::Bytes(msg.data(), msg.size()), sig));
+    std::vector<uint8_t> other = {'x'};
+    EXPECT_FALSE(scheme.Verify(pk, bls::Bytes(other.data(), other.size()), sig));
+}
+
+// ── anchor 2b: full verify_final_commitment round-trip (synthetic) ──────────
+//
+// Deterministically construct a VALID commitment (real member + quorum BLS
+// keys we generate here), then assert verify_final_commitment ACCEPTS it and
+// every single-byte tamper REJECTS — exercising the complete production path
+// (BuildCommitmentHash + membersSig VerifySecure + quorumSig Verify) without the
+// scheme-ambiguity of RPC-sourced member keys.
+TEST(DashBlsVerify, VerifyFinalCommitmentSyntheticRoundTrip)
+{
+    const size_t kSize = 5;
+    bls::BasicSchemeMPL scheme;
+
+    CFinalCommitment c;
+    c.nVersion = CFinalCommitment::BASIC_BLS_NON_INDEXED_QUORUM_VERSION;
+    c.llmqType = kLlmqType;
+    c.quorumHash = u256_le(kQuorumHashLe);
+    c.quorumVvecHash = u256_le(kQuorumVvecHash);
+    c.signers.assign(kSize, true);
+    c.validMembers.assign(kSize, true);
+
+    // member operator keys
+    std::vector<MemberOperatorKey> members(kSize);
+    std::vector<bls::PrivateKey> member_sks;
+    std::vector<bls::G1Element> member_pks;
+    for (size_t i = 0; i < kSize; ++i) {
+        std::vector<uint8_t> seed(32, static_cast<uint8_t>(0x40 + i));
+        bls::PrivateKey sk = scheme.KeyGen(seed);
+        bls::G1Element pk = sk.GetG1Element();
+        member_sks.push_back(sk);
+        member_pks.push_back(pk);
+        auto raw = pk.Serialize(false);   // basic scheme wire bytes
+        for (size_t j = 0; j < 48; ++j) members[i].pubKeyOperator[j] = raw[j];
+        members[i].legacy_scheme = false;
+    }
+    // quorum threshold key
+    std::vector<uint8_t> qseed(32, 0xAB);
+    bls::PrivateKey qsk = scheme.KeyGen(qseed);
+    bls::G1Element qpk = qsk.GetG1Element();
+    {
+        auto raw = qpk.Serialize(false);
+        for (size_t j = 0; j < 48; ++j) c.quorumPublicKey[j] = raw[j];
+    }
+
+    // the commitment hash the signatures must cover
+    uint256 h = build_commitment_hash(
+        c.llmqType, c.quorumHash, c.validMembers, c.quorumPublicKey,
+        c.quorumVvecHash);
+    bls::Bytes msg(h.data(), 32);
+
+    // membersSig = secure aggregate of each member's signature over h
+    std::vector<bls::G2Element> member_sigs;
+    for (auto& sk : member_sks) member_sigs.push_back(scheme.Sign(sk, msg));
+    bls::G2Element members_sig = scheme.AggregateSecure(member_pks, member_sigs, msg);
+    {
+        auto raw = members_sig.Serialize(false);
+        for (size_t j = 0; j < 96; ++j) c.membersSig[j] = raw[j];
+    }
+    // quorumSig = the threshold key's signature over h
+    bls::G2Element quorum_sig = scheme.Sign(qsk, msg);
+    {
+        auto raw = quorum_sig.Serialize(false);
+        for (size_t j = 0; j < 96; ++j) c.quorumSig[j] = raw[j];
+    }
+
+    // ACCEPT.
+    EXPECT_TRUE(verify_final_commitment(c, members));
+
+    // tamper membersSig → REJECT.
+    {
+        CFinalCommitment t = c;
+        t.membersSig[10] ^= 0x01;
+        EXPECT_FALSE(verify_final_commitment(t, members));
+    }
+    // tamper quorumSig → REJECT.
+    {
+        CFinalCommitment t = c;
+        t.quorumSig[10] ^= 0x01;
+        EXPECT_FALSE(verify_final_commitment(t, members));
+    }
+    // tamper quorumPublicKey → REJECT (changes the hash AND the key).
+    {
+        CFinalCommitment t = c;
+        t.quorumPublicKey[10] ^= 0x01;
+        EXPECT_FALSE(verify_final_commitment(t, members));
+    }
+    // drop a signer's key (wrong member set) → REJECT.
+    {
+        auto bad_members = members;
+        bad_members[0].pubKeyOperator[5] ^= 0x01;
+        EXPECT_FALSE(verify_final_commitment(c, bad_members));
+    }
+}
+
+#endif // C2POOL_DASH_BLS


### PR DESCRIPTION
**DO NOT MERGE** — draft; integrator merges after review + soak. Stacked on #803 (E1); base = `dash/e1-daemonless-dkg-window`.

## What
The BLS backend + the cryptographic verify that E1 (#803) cut its `MineableCommitmentCache::set_bls_verify_fn` seam for. E1 today serves the consensus-valid **null** type-6 commitment at DKG-window heights. On **mainnet** a DKG usually **succeeds**, so the canonical block carries the **real** (non-null) commitment and null-serve would diverge → `bad-qc` reject (the GLM minority-report concern). Phase-L sources the real commitment (E1 already relays `qfcommit` over coin-P2P), **verifies it with BLS reusing Dash Core's own logic**, and makes it includable — true daemonless at DKG windows.

## Part A — BLS library integration
- **dashpay/bls-signatures ("dashbls", relic-backed, Apache-2.0)** — the exact library dashd wraps in `src/bls/bls.h` (libdashbls 2.0 = the dash v23.1.x `src/dashbls` subtree). Not on ConanCenter, so consumed as a **prebuilt system library like secp256k1**: `scripts/build_dashbls.sh` pins the upstream commit; the root `CMakeLists.txt` `find_library`s it behind `-DC2POOL_DASH_BLS=ON` (`-DDASHBLS_ROOT=<prefix>`).
- **DASH-only + Windows-safe:** only `dash_bls_verify` (linked solely by `c2pool-dash`) and its KAT consume it. Option **OFF by default**; when off or the lib isn't found, `dash_bls_verify` compiles a **fail-closed stub** and **no dashbls dependency enters any build** — verified: the default configure reports no dashbls and the stub object carries zero dashbls/relic symbols, so the Windows `main_ltc` launcher (shared core only) is untouched.
- **BLS smoke KAT** proves the lib links + signs + verifies.

## Part B — E1 Phase-L verify (reuse-first; vendored from Dash Core v23.1.x)
- `build_commitment_hash` == `llmq/commitment.cpp` **BuildCommitmentHash** (the signed preimage), **byte-exact** — locked by a from-wire testnet KAT.
- `verify_final_commitment` == **CFinalCommitment::Verify** (checkSigs): `membersSig` `VerifySecureAggregated` over the signers' operator keys **+** `quorumSig` `VerifyInsecure` against `quorumPublicKey`, both over the commitment hash, post-V19 basic scheme.
- `membersSig` is **mandatory** — `quorumSig` alone is a self-signature a peer can forge (it controls `quorumPublicKey`); only the actual members' operator keys prove authenticity.
- Verifier installed via `set_bls_verify_fn` in `main_dash`.
- **Fail-closed throughout** (reward-critical embedded consensus): backend absent, member set uncertain, size mismatch, or any BLS verify failure → `verified_for()` yields `nullopt` → the slot mines the null commitment (or dashd fallback). An unverified/forged relayed commitment is **never** served.

## KATs — `test_dash_bls_verify` (6/6 passing)
Captured **read-only** from the testnet dashd (`192.168.86.52`), block 1519931, llmq_50_60 quorum `0000001b…5c928798` (a **successful** DKG — the mainnet case null-serve diverges on):
- `BuildCommitmentHashRealVector` — preimage of the real commitment hashes to dashd's signed value (runs **with or without** the backend).
- `RealQuorumSigAcceptsAndTamperRejects` — real from-wire `quorumSig` **ACCEPT**; flip a hash/sig byte → **REJECT**.
- `VerifyFinalCommitmentSyntheticRoundTrip` — full `verify_final_commitment` (both legs) on a synthetic valid commitment **ACCEPT**; per-field tamper (`membersSig`/`quorumSig`/`quorumPublicKey`/member key) → **REJECT**.
- `BlsSmokeSignVerify`, `FailClosedNoMembers`, `MakeVerifierNullProviderFailsClosed`.

## Residual (fail-closed until it lands)
The deterministic quorum **member selection** (`llmq/utils.cpp` `ComputeQuorumMembers` over the SML **as of the quorum base block**) needs the historical SML sourced over coin-P2P `qrinfo` — not yet wired. Until then the member-keys provider returns `nullopt` and Phase-L stays at null-serve. The **BLS crypto path is complete + KAT-locked** and needs no change when the member set arrives. The SML `nVersion` (`VER_LEGACY_BLS`/`VER_BASIC_BLS`) disambiguates each member key's scheme (a bare RPC hex is scheme-ambiguous — a mixed quorum has keys valid under both encodings).

## Build / safety
- `c2pool-dash` builds green with `-DC2POOL_DASH_BLS=ON` (verifier symbols linked).
- Default (OFF) configure + `dash_bls_verify` stub build green, **no dashbls symbols** — Windows/`main_ltc` unaffected.
- Running v0.2.4 soaks untouched (all captures read-only on their dashd).