### PR TITLE
test(dash): bind merkle root in PayeeDesync KAT — fix master-red test-1647

### DIFF
--- a/test/test_dash_coin_state_maintainer.cpp
+++ b/test/test_dash_coin_state_maintainer.cpp
@@ -308,6 +308,7 @@ TEST(DashCoinStateMaintainer, PayeeDesyncWipesDemotesAndFiresReseed) {
     BlockType blk;
     blk.m_txs.push_back(make_spend(raw256(0x90), 0, 500000000, 1));
     blk.m_txs[0].vout[0].scriptPubKey.m_data = p2pkh_script(0x77);  // NOT the MN
+    bind_block(blk);
     auto r = m.on_block_connected(blk, H);
 
     EXPECT_TRUE(r.payee_desync);


### PR DESCRIPTION
Forward-fix for the red `DashCoinStateMaintainer.PayeeDesyncWipesDemotesAndFiresReseed` on master.

## Root cause
`test/test_dash_coin_state_maintainer.cpp:310` builds a `BlockType` by hand and calls `on_block_connected()` **without** `bind_block(blk)`, so the block carries a zero merkle root. Every sibling KAT in the file (lines 279, 341) binds it.

PR #802 (`7ffb14dc`, E2 finding A) added a trust-boundary guard at the top of `CoinStateMaintainer::on_block_connected` that refuses any body not folding to the header commitment. The unbound KAT block trips that guard and returns early, so the desync path never executes and the assertions fail.

## Fix
One line: `bind_block(blk);` before `on_block_connected`, matching the sibling cases.

## Scope
- **test/-only.** 1 file, +1/-0. No product file touched.
- SAFE-COSMETIC does not apply — this is a test correctness fix, not a relabel.
- dash smoke suffices per integrator routing; not EXCEPTIONAL.

Signed commit `f548126f`.