### PR TITLE
bch(g2): won-block assembly/reconstruct SSOT + pre-broadcast merkle self-check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -485,6 +485,7 @@ jobs:
                     bch_asert_kat_test \
                     bch_muldiv_kat_test \
                     bch_g1_oracle_byte_parity_test bch_g1_share_serialization_parity_test bch_g0_canonical_pin_test bch_g2_ratchet_gate_kat_test test_bch_underfill_guard \
+                    bch_g2_block_assembly_roundtrip_test \
             -j8
 
       - name: Run BCH tests
@@ -617,6 +618,7 @@ jobs:
                     bch_asert_kat_test \
                     bch_muldiv_kat_test \
                     bch_g1_oracle_byte_parity_test bch_g1_share_serialization_parity_test bch_g0_canonical_pin_test bch_g2_ratchet_gate_kat_test test_bch_underfill_guard \
+                    bch_g2_block_assembly_roundtrip_test \
             -j8
 
       - name: Run BCH tests under sanitizers

--- a/src/impl/bch/coin/block_assembly.hpp
+++ b/src/impl/bch/coin/block_assembly.hpp
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+// ---------------------------------------------------------------------------
+// bch::coin -- won-block ASSEMBLY SSOT + pre-broadcast self-check.
+//
+// WHY THIS EXISTS (G2 zero-blocks root cause, 2026-07-23)
+// -------------------------------------------------------
+// The live pool accumulated ~774k accepted solutions and produced ZERO blocks.
+// The dispatcher was fine; every won block was REJECTED by the node with
+// `bad-txnmrklroot`. The relayed body measured 155 bytes:
+//
+//     80 (header) + 1 (tx-count varint) + 74 (generation transaction)
+//
+// and that 74-byte generation transaction decomposes as
+//
+//     62 (first coinbase segment) + 8 (extranonce) + 4 (locktime)
+//
+// The 62-byte first segment is
+//     4 version | 1 vin-count | 32 prevout-hash | 4 prevout-index
+//   | 1 scriptSig-len | 15 scriptSig | 4 sequence | 1 OUTPUT-COUNT = 0x00
+//
+// i.e. the first segment TERMINATES AT AN OUTPUT COUNT OF ZERO, and the miner's
+// 8 extranonce bytes are then spliced AFTER the (empty) output vector, in front
+// of the locktime. The bytes the miner hashed therefore do not deserialize as
+// the transaction anyone downstream reconstructs, so the recomputed root never
+// equals the header's root. Two independent defects produced it:
+//
+//   (a) the job builder emitted a generation transaction with zero outputs
+//       whenever the commitment output was suppressed (no reference hash) and
+//       the payout set was empty, and
+//   (b) the extranonce slot is only well-defined when it sits INSIDE a real
+//       commitment output; with no such output the splice point degenerates to
+//       "end of the output vector".
+//
+// (a)+(b) are fixed at the source in the stratum job builder (fail-closed: a
+// zero-output generation transaction is never published, and the extranonce
+// slot always lands inside a real commitment output). THIS file is the second,
+// independent line of defence: nothing is relayed until the assembled block has
+// been re-deserialized from its own wire bytes and its transaction root
+// recomputed and matched against the header the miner actually solved.
+//
+// Mirrors the shape nmc/dgb already ship (assemble_won_block +
+// reconstruct_won_block), with a BCH-native addition: verify_assembled_block()
+// is a hard gate, not advisory. A mismatch REFUSES the relay and names the
+// reason instead of shipping a body the node will reject.
+//
+// Per-coin isolation: src/impl/bch/ ONLY. Shared base (src/core,
+// bitcoin_family) untouched. p2pool-merged-v36 SURFACE: NONE -- this is parent
+// block framing, not share format / PPLNS / coinbase-commitment semantics.
+// ---------------------------------------------------------------------------
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <core/pack.hpp>
+#include <core/uint256.hpp>
+#include <btclibs/util/strencodings.h>
+
+#include "block.hpp"        // BlockType / BlockHeaderType / SmallBlockHeaderType
+#include "mempool.hpp"      // compute_txid
+#include "merkle.hpp"       // compute_merkle_root
+#include "transaction.hpp"  // MutableTransaction
+
+namespace bch
+{
+namespace coin
+{
+
+/// Verdict of the pre-broadcast self-check. `ok == false` means DO NOT RELAY.
+struct BlockSelfCheck
+{
+    bool        ok = false;
+    const char* reason = "unchecked";  ///< static reason string; "" when ok
+    size_t      tx_count = 0;
+    size_t      gentx_outputs = 0;
+    uint256     header_merkle_root{};    ///< as carried by the assembled header
+    uint256     computed_merkle_root{};  ///< recomputed from the decoded tx list
+
+    explicit operator bool() const { return ok; }
+};
+
+/// A fully assembled + self-checked won block.
+///   bytes : the blob the embedded P2P relay sends
+///   hex   : the SAME block for the external BCHN submitblock RPC fallback
+/// `check.ok` is the relay gate; assemble_and_verify_won_block() only ever
+/// hands back a value whose check passed.
+struct AssembledBlock
+{
+    std::vector<unsigned char> bytes;
+    std::string                hex;
+    BlockSelfCheck             check;
+};
+
+// ---------------------------------------------------------------------------
+// Framing
+// ---------------------------------------------------------------------------
+
+/// Serialize `header80 || CompactSize(1 + other_txs) || gentx_bytes || other_txs`.
+///
+/// The generation transaction is passed as the EXACT serialized buffer its txid
+/// was hashed from, so the relayed coinbase is byte-identical to the one
+/// consensus and the sharechain validated -- there is no second derivation path
+/// and therefore no divergence risk. `other_txs` is any range of pointers to a
+/// type the PackStream `<<` operator accepts (coin::Transaction on the pool
+/// reconstruct path, coin::MutableTransaction on the template path).
+template <class OtherTxPtrRange>
+inline std::vector<unsigned char>
+frame_won_block(std::span<const unsigned char> header80,
+                std::span<const unsigned char> gentx_bytes,
+                const OtherTxPtrRange& other_txs)
+{
+    PackStream block_stream;
+    block_stream.write(std::as_bytes(header80));
+
+    size_t n_other = 0;
+    for (auto it = other_txs.begin(); it != other_txs.end(); ++it) ++n_other;
+    WriteCompactSize(block_stream, static_cast<uint64_t>(1 + n_other));
+
+    block_stream.write(std::as_bytes(gentx_bytes));
+    for (const auto* tx : other_txs)
+        block_stream << *tx;
+
+    auto sp = block_stream.get_span();
+    return std::vector<unsigned char>(
+        reinterpret_cast<const unsigned char*>(sp.data()),
+        reinterpret_cast<const unsigned char*>(sp.data()) + sp.size());
+}
+
+/// Typed framing overload: `[gentx] ++ other_txs` through the proven BlockType
+/// codec (the same codec NodeRPC::submit_block and the P2P relay use), so the
+/// result is byte-identical to a daemon-built block. Mirrors the nmc/dgb SSOT.
+inline std::vector<unsigned char>
+frame_won_block(const BlockHeaderType& header,
+                const MutableTransaction& gentx,
+                const std::vector<MutableTransaction>& other_txs)
+{
+    BlockType block;
+    static_cast<BlockHeaderType&>(block) = header;
+    block.m_txs.reserve(1 + other_txs.size());
+    block.m_txs.push_back(gentx);
+    for (const auto& tx : other_txs)
+        block.m_txs.push_back(tx);
+
+    PackStream packed = pack<BlockType>(block);
+    auto sp = packed.get_span();
+    return std::vector<unsigned char>(
+        reinterpret_cast<const unsigned char*>(sp.data()),
+        reinterpret_cast<const unsigned char*>(sp.data()) + sp.size());
+}
+
+// ---------------------------------------------------------------------------
+// Pre-broadcast self-check -- the gate that would have caught the 155-byte body
+// ---------------------------------------------------------------------------
+
+/// Re-deserialize `block_bytes` FROM ITS OWN WIRE ENCODING and recompute the
+/// transaction merkle root over the decoded transaction list, then match it
+/// against the root carried by the decoded header.
+///
+/// This deliberately re-parses rather than reusing the in-memory objects: the
+/// G2 failure was precisely a body whose in-memory intent and wire encoding
+/// disagreed. Only a round trip through the wire form can see that.
+///
+/// Additional structural gates, each of which independently rejects the exact
+/// 155-byte body that lost 774k solutions:
+///   * at least one transaction (a headerless / txless body is not a block);
+///   * the generation transaction has exactly one input; and
+///   * the generation transaction has AT LEAST ONE OUTPUT -- a zero-output
+///     generation transaction is unspendable, pays nobody, and is the state in
+///     which the extranonce splice point degenerates.
+///   * no trailing bytes after the decoded block (a short-read would otherwise
+///     silently pass).
+inline BlockSelfCheck verify_assembled_block(std::span<const unsigned char> block_bytes)
+{
+    BlockSelfCheck r;
+
+    if (block_bytes.size() < 81) {   // 80-byte header + at least a tx count
+        r.reason = "block shorter than a header plus transaction count";
+        return r;
+    }
+
+    BlockType decoded;
+    try {
+        PackStream stream(std::vector<unsigned char>(block_bytes.begin(), block_bytes.end()));
+        stream >> decoded;
+        if (stream.cursor_size() != 0) {
+            r.reason = "trailing bytes after decoded block";
+            return r;
+        }
+    } catch (const std::exception&) {
+        r.reason = "assembled block does not re-deserialize";
+        return r;
+    } catch (...) {
+        r.reason = "assembled block does not re-deserialize";
+        return r;
+    }
+
+    r.tx_count = decoded.m_txs.size();
+    r.header_merkle_root = decoded.m_merkle_root;
+
+    if (decoded.m_txs.empty()) {
+        r.reason = "block carries no transactions";
+        return r;
+    }
+
+    const auto& gentx = decoded.m_txs.front();
+    r.gentx_outputs = gentx.vout.size();
+
+    if (gentx.vin.size() != 1) {
+        r.reason = "generation transaction does not have exactly one input";
+        return r;
+    }
+    if (gentx.vout.empty()) {
+        // The G2 signature: output count zero, extranonce spliced after the
+        // output vector. Refuse loudly rather than relay an unspendable body.
+        r.reason = "generation transaction has ZERO outputs";
+        return r;
+    }
+
+    std::vector<uint256> txids;
+    txids.reserve(decoded.m_txs.size());
+    for (const auto& tx : decoded.m_txs)
+        txids.push_back(compute_txid(tx));
+    r.computed_merkle_root = compute_merkle_root(std::move(txids));
+
+    if (r.computed_merkle_root != r.header_merkle_root) {
+        r.reason = "recomputed transaction root does not match the solved header";
+        return r;
+    }
+
+    r.ok = true;
+    r.reason = "";
+    return r;
+}
+
+// ---------------------------------------------------------------------------
+// Assemble + gate
+// ---------------------------------------------------------------------------
+
+/// Frame a won block and REFUSE to hand it back unless the self-check passes.
+/// `out_check` (optional) receives the verdict either way, so callers can log
+/// the named reason on refusal.
+template <class OtherTxPtrRange>
+inline std::optional<AssembledBlock>
+assemble_and_verify_won_block(std::span<const unsigned char> header80,
+                              std::span<const unsigned char> gentx_bytes,
+                              const OtherTxPtrRange& other_txs,
+                              BlockSelfCheck* out_check = nullptr)
+{
+    AssembledBlock out;
+    out.bytes = frame_won_block(header80, gentx_bytes, other_txs);
+    out.check = verify_assembled_block(out.bytes);
+    if (out_check) *out_check = out.check;
+    if (!out.check.ok)
+        return std::nullopt;
+
+    out.hex = HexStr(std::span<const unsigned char>(out.bytes.data(), out.bytes.size()));
+    return out;
+}
+
+/// Typed overload (BlockType codec path).
+inline std::optional<AssembledBlock>
+assemble_and_verify_won_block(const BlockHeaderType& header,
+                              const MutableTransaction& gentx,
+                              const std::vector<MutableTransaction>& other_txs,
+                              BlockSelfCheck* out_check = nullptr)
+{
+    AssembledBlock out;
+    out.bytes = frame_won_block(header, gentx, other_txs);
+    out.check = verify_assembled_block(out.bytes);
+    if (out_check) *out_check = out.check;
+    if (!out.check.ok)
+        return std::nullopt;
+
+    out.hex = HexStr(std::span<const unsigned char>(out.bytes.data(), out.bytes.size()));
+    return out;
+}
+
+} // namespace coin
+} // namespace bch

--- a/src/impl/bch/coin/embedded_daemon.hpp
+++ b/src/impl/bch/coin/embedded_daemon.hpp
@@ -513,8 +513,17 @@ public:
             (m_coin_node && m_coin_node->has_rpc()),
             [&] {
                 bool ok = m_coin_node->submit_block_hex(block_hex, /*ignore_failure=*/true);
-                LOG_INFO << "[EMB-BCH] won-block submitblock RPC fallback "
-                         << (ok ? "ok/duplicate" : "no-ack") << ".";
+                if (ok) {
+                    LOG_INFO << "[EMB-BCH] won-block submitblock RPC fallback ok/duplicate.";
+                } else {
+                    // A wired fallback channel that does not acknowledge a WON
+                    // BLOCK is a potential lost subsidy, not routine noise. It
+                    // is an error even though the P2P primary may have carried
+                    // the block -- the whole point of the dual path is that we
+                    // never have to assume that.
+                    LOG_ERROR << "[EMB-BCH] won-block submitblock RPC fallback NO-ACK -- the "
+                                 "external daemon did not confirm the block down this path.";
+                }
                 return ok;
             });
 

--- a/src/impl/bch/coin/reconstruct_won_block.hpp
+++ b/src/impl/bch/coin/reconstruct_won_block.hpp
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+// ---------------------------------------------------------------------------
+// bch::coin -- won-share -> parent-block RECONSTRUCTOR.
+//
+// The pool node holds a won share, not a block. Turning one into the other is
+// three steps, and BCH previously did all three inline in the pool node with no
+// gate between the last step and the wire:
+//
+//   1. rebuild the 80-byte header the miner actually solved. The share stores
+//      only a SmallBlockHeader (version | prev | time | bits | nonce) -- NO
+//      transaction root -- so the root is recomputed by walking the generation
+//      transaction's txid up the share's merkle link, exactly as the share's
+//      proof-of-work hash was computed at verification time;
+//   2. frame `header || CompactSize(1 + n) || gentx || other_txs`; and
+//   3. REFUSE to relay unless the framed bytes re-deserialize and their
+//      recomputed transaction root matches the header from step 1.
+//
+// Step 3 is the part that was missing. See block_assembly.hpp for the G2
+// zero-blocks post-mortem (155-byte body, `bad-txnmrklroot`, ~774k solutions,
+// zero blocks) that motivates it.
+//
+// The generation transaction is supplied as the EXACT serialized buffer its
+// txid was hashed from, so no second derivation path exists and the relayed
+// coinbase cannot drift from the one the sharechain validated.
+//
+// DEGRADED PATHS are first-class here, not afterthoughts:
+//   * reference hash absent  -> the header root cannot be trusted; the caller
+//     must not relay. The self-check catches it as a root mismatch and names it.
+//   * generation value zero / no outputs -> refused by name before it reaches
+//     the wire (this is the exact G2 signature).
+//
+// Per-coin isolation: src/impl/bch/ ONLY. p2pool-merged-v36 SURFACE: NONE.
+// ---------------------------------------------------------------------------
+
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <vector>
+
+#include <core/pack.hpp>
+#include <core/uint256.hpp>
+
+#include "block_assembly.hpp"
+
+namespace bch
+{
+namespace coin
+{
+
+/// Serialize the canonical 80-byte BCH block header. BCH did not change the
+/// header layout from Bitcoin: 4-byte version | 32 prev | 32 root | 4 time |
+/// 4 bits | 4 nonce. ASERT (Nov 2020) changes how `bits` is COMPUTED, not where
+/// it sits. Returns an empty vector if the encoding did not come out at exactly
+/// 80 bytes, which callers must treat as a hard refusal.
+inline std::vector<unsigned char>
+serialize_block_header80(uint32_t version,
+                         const uint256& previous_block,
+                         const uint256& merkle_root,
+                         uint32_t timestamp,
+                         uint32_t bits,
+                         uint32_t nonce)
+{
+    PackStream s;
+    s << version;
+    s << previous_block;
+    s << merkle_root;
+    s << timestamp;
+    s << bits;
+    s << nonce;
+
+    if (s.size() != 80)
+        return {};
+
+    auto sp = s.get_span();
+    return std::vector<unsigned char>(
+        reinterpret_cast<const unsigned char*>(sp.data()),
+        reinterpret_cast<const unsigned char*>(sp.data()) + sp.size());
+}
+
+/// Reconstruct + self-check a won parent block from its already-resolved parts.
+///
+///   header80   : the 80-byte header the miner solved (serialize_block_header80)
+///   gentx_bytes: the generation transaction, byte-identical to the buffer its
+///                txid was hashed from
+///   other_txs  : the non-coinbase transactions in block order (pointers; any
+///                type PackStream `<<` accepts). CTOR ordering is the caller's
+///                responsibility -- it is a property of the set, not of framing.
+///
+/// Returns nullopt when the block MUST NOT be relayed; `out_check.reason` names
+/// why. A returned value has already round-tripped through the wire form and
+/// matched its own transaction root against the solved header.
+template <class OtherTxPtrRange>
+inline std::optional<AssembledBlock>
+reconstruct_won_block_from_parts(std::span<const unsigned char> header80,
+                                 std::span<const unsigned char> gentx_bytes,
+                                 const OtherTxPtrRange& other_txs,
+                                 BlockSelfCheck* out_check = nullptr)
+{
+    BlockSelfCheck local;
+    BlockSelfCheck* check = out_check ? out_check : &local;
+
+    if (header80.size() != 80) {
+        check->ok = false;
+        check->reason = "header is not 80 bytes";
+        return std::nullopt;
+    }
+    if (gentx_bytes.empty()) {
+        check->ok = false;
+        check->reason = "generation transaction body is empty";
+        return std::nullopt;
+    }
+
+    return assemble_and_verify_won_block(header80, gentx_bytes, other_txs, check);
+}
+
+} // namespace coin
+} // namespace bch

--- a/src/impl/bch/coin/rpc.cpp
+++ b/src/impl/bch/coin/rpc.cpp
@@ -201,6 +201,12 @@ std::string NodeRPC::Send(const std::string &request)
 		}
 		return body;
 	}
+	// Both attempts exhausted: the channel is down and the request was NOT
+	// answered. Returning an empty body here is otherwise indistinguishable
+	// downstream from a legitimately null JSON-RPC result (submitblock's
+	// success shape), so say so loudly rather than let a drop read as an ack.
+	LOG_ERROR << "[BCH-RPC] request DROPPED after reconnect+retry -- no response "
+	             "from the daemon; caller must treat this as a failure, not a null result";
 	return {};
 }
 
@@ -419,13 +425,63 @@ void NodeRPC::submit_block(BlockType& block, bool ignore_failure)
 
 bool NodeRPC::submit_block_hex(const std::string& block_hex, bool ignore_failure)
 {
-	auto result = m_client.CallMethod<nlohmann::json>(ID, "submitblock", {block_hex});
-	bool success = result.is_null();
-	if (!success && !ignore_failure)
-		LOG_ERROR << "submit_block_hex result: " << result.dump();
-	else if (success)
-		LOG_INFO << "submit_block_hex accepted";
-	return success;
+	// The submitblock fallback is the LAST line of defence for a won block, so a
+	// dropped channel here is unrecoverable value loss. Two behaviours the old
+	// body got wrong, both of which contributed to the G2 zero-blocks window:
+	//
+	//   1. A TRANSPORT drop (connection reset / stale keep-alive after the
+	//      daemon restarted) surfaced as a swallowed no-ack and the request was
+	//      never re-issued. It is now LOUD (LOG_ERROR) and RE-ISSUED once after
+	//      a synchronous reconnect. `ignore_failure` suppresses the node's
+	//      CONSENSUS rejection reason only -- it never suppresses a drop.
+	//   2. `duplicate` was reported as failure. A duplicate means the block
+	//      already reached the node, normally via the P2P primary leg, which is
+	//      precisely the dual-path success case the broadcaster documents
+	//      ("rpc_ok = submitblock returned ok OR duplicate"). It is an ACK.
+	for (int attempt = 0; attempt < 2; ++attempt)
+	{
+		try
+		{
+			auto result = m_client.CallMethod<nlohmann::json>(ID, "submitblock", {block_hex});
+			if (result.is_null())
+			{
+				LOG_INFO << "submit_block_hex accepted";
+				return true;
+			}
+
+			const std::string reason = result.dump();
+			if (reason.find("duplicate") != std::string::npos)
+			{
+				LOG_INFO << "submit_block_hex duplicate (" << reason
+				         << ") -- the block already reached the node; counted as ack";
+				return true;
+			}
+
+			// A consensus rejection is a definitive answer; re-issuing the same
+			// bytes cannot change it, so do not retry -- but do say why.
+			if (ignore_failure)
+				LOG_WARNING << "submit_block_hex rejected: " << reason;
+			else
+				LOG_ERROR << "submit_block_hex rejected: " << reason;
+			return false;
+		}
+		catch (const std::exception& e)
+		{
+			LOG_ERROR << "[BCH-RPC] submitblock FALLBACK CHANNEL DROPPED mid-submit ("
+			          << e.what() << ")"
+			          << (attempt == 0
+			                  ? " -- reconnecting and RE-ISSUING the submit"
+			                  : " -- submit LOST after reconnect+retry; the won block did "
+			                    "NOT reach the network down this path");
+			if (attempt == 0)
+			{
+				sync_reconnect();
+				continue;
+			}
+			return false;
+		}
+	}
+	return false;
 }
 
 // RPC Methods

--- a/src/impl/bch/node.hpp
+++ b/src/impl/bch/node.hpp
@@ -26,6 +26,9 @@
 #include "peer.hpp"
 #include "messages.hpp"
 #include <core/version_gate.hpp>   // SSOT: core::version_gate::is_v36_active
+// Won-block assembly SSOT + the pre-broadcast self-check that refuses to relay
+// a body whose recomputed transaction root disagrees with the solved header.
+#include "coin/reconstruct_won_block.hpp"
 
 #include <pool/node.hpp>
 #include <pool/sharechain_node.hpp>
@@ -317,30 +320,48 @@ public:
             return std::nullopt;
         }
 
-        // --- serialize full block (Bitcoin wire) ---
-        // header || CompactSize(1 + other_txs) || coinbase_bytes || other txs.
-        PackStream block_stream;
-        block_stream.write(header_stream.get_span());
-        WriteCompactSize(block_stream,
-                         static_cast<uint64_t>(1 + other_txs.size()));
-        block_stream.write(std::as_bytes(std::span<const unsigned char>(
-            gentx_bytes.data(), gentx_bytes.size())));
-        for (const auto* tx : other_txs)
-            block_stream << *tx;
+        // --- frame + SELF-CHECK, then (only then) hand back for broadcast ---
+        // Framing goes through the coin::reconstruct_won_block_from_parts SSOT
+        // (header || CompactSize(1 + other_txs) || coinbase || other txs), which
+        // re-deserializes its own output and recomputes the transaction root
+        // against the header the miner solved before returning anything.
+        //
+        // This is the gate the G2 zero-blocks failure lacked: every won block
+        // was relayed as a 155-byte body whose generation transaction carried
+        // ZERO outputs (extranonce spliced after the empty output vector), and
+        // the node rejected all ~774k of them with bad-txnmrklroot. Now such a
+        // body is REFUSED here, by name, and never reaches either sink.
+        auto hdr_span = header_stream.get_span();
+        std::vector<unsigned char> header80(
+            reinterpret_cast<const unsigned char*>(hdr_span.data()),
+            reinterpret_cast<const unsigned char*>(hdr_span.data()) + hdr_span.size());
 
-        auto block_span = block_stream.get_span();
-        std::vector<unsigned char> block_bytes(
-            reinterpret_cast<const unsigned char*>(block_span.data()),
-            reinterpret_cast<const unsigned char*>(block_span.data())
-                + block_span.size());
-        std::string block_hex = HexStr(block_span);
+        coin::BlockSelfCheck check;
+        auto assembled = coin::reconstruct_won_block_from_parts(
+            std::span<const unsigned char>(header80.data(), header80.size()),
+            std::span<const unsigned char>(gentx_bytes.data(), gentx_bytes.size()),
+            other_txs, &check);
+
+        if (!assembled) {
+            LOG_ERROR << "[BCH-POOL] reconstruct: share "
+                      << share_hash.GetHex().substr(0, 16)
+                      << " REFUSED pre-broadcast self-check -- " << check.reason
+                      << " (txs=" << check.tx_count
+                      << " gentx_outputs=" << check.gentx_outputs
+                      << " header_root=" << check.header_merkle_root.GetHex().substr(0, 16)
+                      << " computed_root=" << check.computed_merkle_root.GetHex().substr(0, 16)
+                      << ") -- block NOT relayed down either path";
+            return std::nullopt;
+        }
 
         LOG_INFO << "[BCH-POOL] reconstruct: share "
                  << share_hash.GetHex().substr(0, 16)
-                 << " -> full block " << block_bytes.size() << " bytes, "
-                 << (1 + other_txs.size()) << " txs (1 coinbase + "
-                 << other_txs.size() << " other)";
-        return std::make_pair(std::move(block_bytes), std::move(block_hex));
+                 << " -> full block " << assembled->bytes.size() << " bytes, "
+                 << check.tx_count << " txs (1 coinbase with "
+                 << check.gentx_outputs << " outputs + "
+                 << other_txs.size() << " other); self-check PASSED (root "
+                 << check.computed_merkle_root.GetHex().substr(0, 16) << ")";
+        return std::make_pair(std::move(assembled->bytes), std::move(assembled->hex));
     }
 
     NodeImpl(boost::asio::io_context* ctx, config_t* config)

--- a/src/impl/bch/stratum/coinbase_slot_guard.hpp
+++ b/src/impl/bch/stratum/coinbase_slot_guard.hpp
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+// ---------------------------------------------------------------------------
+// bch::stratum -- structural guard on the coinb1 / extranonce seam.
+//
+// A Stratum job hands the miner (coinb1, coinb2) and the miner builds
+//
+//     coinbase = coinb1 || extranonce1 || extranonce2 || coinb2
+//
+// so the extranonce is spliced at whatever byte offset coinb1 happens to end
+// at. That is only a valid transaction if the seam lands INSIDE a script that
+// has room for it. On BCH the extranonce rides the tail of the last output's
+// OP_RETURN commitment: a 42-byte script `OP_RETURN PUSH_40 <32-byte reference
+// hash> <8-byte nonce>` whose final 8 bytes are exactly the extranonce, so
+// coinb1 stops 8 bytes short of the script's declared length and the miner
+// completes it.
+//
+// If the commitment output is ever suppressed, coinb1 instead terminates right
+// after the output-count varint and the extranonce lands between the output
+// vector and the locktime. The result is a transaction the miner hashed but
+// nobody can decode -- the recomputed transaction root never matches the solved
+// header, and every won block is rejected `bad-txnmrklroot`. That is the G2
+// zero-blocks failure (62-byte coinb1 ending in an output count of zero; ~774k
+// accepted solutions, no blocks).
+//
+// coinb1_ends_in_commitment_slot() is the machine-checkable statement of the
+// invariant. It fully parses coinb1 as a truncated BCH generation transaction
+// and returns true only when the seam is the 8-byte tail of a real OP_RETURN
+// commitment output.
+//
+// Per-coin isolation: src/impl/bch/ ONLY. p2pool-merged-v36 SURFACE: NONE --
+// this inspects the job wire split, not the share format or the coinbase's
+// consensus meaning.
+// ---------------------------------------------------------------------------
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace bch
+{
+namespace stratum
+{
+
+/// Byte layout of the BCH commitment output that carries the extranonce.
+inline constexpr uint8_t  kCommitmentScriptLen  = 0x2a;  ///< 42 bytes
+inline constexpr uint8_t  kOpReturn             = 0x6a;
+inline constexpr uint8_t  kPush40               = 0x28;
+inline constexpr size_t   kExtranonceBytes      = 8;     ///< en1 (4) + en2 (4)
+/// What must still be present in coinb1 for the final output: 8-byte value +
+/// 1-byte script length + (42 - 8) bytes of the script.
+inline constexpr size_t   kCommitmentTailBytes  =
+    8 + 1 + (static_cast<size_t>(kCommitmentScriptLen) - kExtranonceBytes);
+
+namespace detail
+{
+
+/// Minimal CompactSize reader. Returns false on truncation or a value that
+/// cannot be a sane count/length for a coinbase.
+inline bool read_varint(const std::vector<uint8_t>& b, size_t& pos, uint64_t& out)
+{
+    if (pos >= b.size()) return false;
+    const uint8_t first = b[pos++];
+    if (first < 0xfd) { out = first; return true; }
+    size_t n = (first == 0xfd) ? 2 : (first == 0xfe) ? 4 : 8;
+    if (pos + n > b.size()) return false;
+    uint64_t v = 0;
+    for (size_t i = 0; i < n; ++i) v |= static_cast<uint64_t>(b[pos + i]) << (8 * i);
+    pos += n;
+    out = v;
+    return true;
+}
+
+} // namespace detail
+
+/// True iff `coinb1` is a generation transaction truncated EXACTLY at the
+/// 8-byte extranonce slot inside a final OP_RETURN commitment output.
+///
+/// Checks, in order:
+///   * 4-byte version, exactly one input, 32-byte null prevout hash;
+///   * a scriptSig whose declared length is present in full;
+///   * 4-byte sequence;
+///   * an output count of AT LEAST ONE (a zero-output generation transaction is
+///     the G2 failure shape and is rejected here);
+///   * every output but the last fully present; and
+///   * the last output present up to -- and only up to -- its extranonce slot:
+///     value, script length 0x2a, then `OP_RETURN PUSH_40` and 32 bytes, with
+///     the trailing 8 bytes absent because the miner supplies them.
+inline bool coinb1_ends_in_commitment_slot(const std::vector<uint8_t>& coinb1)
+{
+    size_t pos = 0;
+
+    if (coinb1.size() < 4) return false;
+    pos += 4;                                     // tx version
+
+    uint64_t vin_count = 0;
+    if (!detail::read_varint(coinb1, pos, vin_count)) return false;
+    if (vin_count != 1) return false;             // coinbase: exactly one input
+
+    if (pos + 36 > coinb1.size()) return false;
+    for (size_t i = 0; i < 32; ++i)
+        if (coinb1[pos + i] != 0x00) return false; // null prevout hash
+    pos += 36;                                     // prevout hash + index
+
+    uint64_t sslen = 0;
+    if (!detail::read_varint(coinb1, pos, sslen)) return false;
+    if (sslen > 100) return false;                 // consensus scriptSig cap
+    if (pos + sslen + 4 > coinb1.size()) return false;
+    pos += static_cast<size_t>(sslen) + 4;         // scriptSig + sequence
+
+    uint64_t out_count = 0;
+    if (!detail::read_varint(coinb1, pos, out_count)) return false;
+    if (out_count == 0) return false;              // <-- the G2 signature
+
+    // All outputs except the last must be complete.
+    for (uint64_t i = 0; i + 1 < out_count; ++i) {
+        if (pos + 8 > coinb1.size()) return false;
+        pos += 8;                                  // value
+        uint64_t slen = 0;
+        if (!detail::read_varint(coinb1, pos, slen)) return false;
+        if (pos + slen > coinb1.size()) return false;
+        pos += static_cast<size_t>(slen);
+    }
+
+    // The last output must be the commitment, truncated at the extranonce slot.
+    if (coinb1.size() - pos != kCommitmentTailBytes) return false;
+    pos += 8;                                      // value (0 sats)
+    if (coinb1[pos++] != kCommitmentScriptLen) return false;
+    if (coinb1[pos++] != kOpReturn) return false;
+    if (coinb1[pos++] != kPush40) return false;
+
+    // Remaining bytes are the 32-byte reference hash; the 8-byte nonce slot is
+    // deliberately absent -- that is the seam the extranonce fills.
+    return (coinb1.size() - pos) == 32;
+}
+
+} // namespace stratum
+} // namespace bch

--- a/src/impl/bch/stratum/work_source.cpp
+++ b/src/impl/bch/stratum/work_source.cpp
@@ -27,6 +27,7 @@
 #include <impl/bch/stratum/work_source.hpp>
 
 #include <impl/bch/stratum/coinbase_outputs.hpp>  // assemble_v36_coinbase_outputs
+#include <impl/bch/stratum/coinbase_slot_guard.hpp> // coinb1_ends_in_commitment_slot
 
 #include <impl/bch/coin/header_chain.hpp>
 #include <impl/bch/coin/mempool.hpp>
@@ -506,11 +507,41 @@ core::stratum::CoinbaseResult BCHWorkSource::build_connection_coinbase(
     }
     const uint256&  ref_hash       = rh_result.ref_hash;
     const uint64_t  ref_nonce      = rh_result.last_txout_nonce;
-    const bool      emit_op_return = ref_hash_fn && !ref_hash.IsNull();
+
+    // ── G2 HARDENING (2026-07-23): the commitment output is STRUCTURAL ──────
+    // The extranonce (en1||en2, 8 bytes) is spliced at the coinb1/coinb2 seam.
+    // That seam is only well-defined when it falls INSIDE a real output's
+    // script; if the commitment output is suppressed, the seam degenerates to
+    // "end of the output vector" and the miner's 8 extranonce bytes land
+    // between the output vector and the locktime. The published job then hashes
+    // a byte string that does not deserialize as the transaction anyone
+    // reconstructs, and every solved block is rejected `bad-txnmrklroot`.
+    //
+    // That is exactly what happened on the live pool: coinb1 terminated at an
+    // output count of 0x00 after 62 bytes, and ~774k accepted solutions yielded
+    // ZERO blocks. So the OP_RETURN commitment output is now emitted
+    // UNCONDITIONALLY -- it is the extranonce's container, not an optional
+    // decoration -- which also makes a zero-output generation transaction
+    // structurally unreachable (output_count >= 1 always).
+    //
+    // A null reference hash is still a real problem (the resulting share cannot
+    // link to the sharechain), but it is a LOUD, LOCAL one: it is logged here
+    // and caught at share verification, instead of silently producing
+    // merkle-invalid blocks for the rest of the pool's life.
+    if (!ref_hash_fn) {
+        LOG_ERROR << "[BCH-STRATUM] no ref_hash callback wired -- emitting the "
+                     "commitment output with a null reference hash so the "
+                     "extranonce still sits inside a real output; shares from "
+                     "this job will NOT link to the sharechain";
+    } else if (ref_hash.IsNull()) {
+        LOG_WARNING << "[BCH-STRATUM] reference hash is null -- commitment "
+                       "output still emitted (extranonce container); the share "
+                       "authored from this job will not link";
+    }
 
     // Assemble coinb1: full tx up to (and including) ref_hash. NO SegWit
-    // output -> output_count is PPLNS outputs + optional OP_RETURN only.
-    const size_t output_count = outputs.size() + (emit_op_return ? 1 : 0);
+    // output -> output_count is PPLNS outputs + the always-present commitment.
+    const size_t output_count = outputs.size() + 1;
 
     std::vector<uint8_t> coinb1;
     push_u32_le(coinb1, 1);                  // tx version
@@ -527,13 +558,27 @@ core::stratum::CoinbaseResult BCHWorkSource::build_connection_coinbase(
         push_varint(coinb1, script.size());
         coinb1.insert(coinb1.end(), script.begin(), script.end());
     }
-    if (emit_op_return) {
+    {
+        // Commitment output -- ALWAYS emitted; carries the 8-byte extranonce
+        // slot at its tail, which is where coinb1 ends and en1||en2 is spliced.
         push_u64_le(coinb1, 0);   // 0 sats
         coinb1.push_back(0x2a);   // script_len = 42
         coinb1.push_back(0x6a);   // OP_RETURN
         coinb1.push_back(0x28);   // PUSH_40
         coinb1.insert(coinb1.end(), ref_hash.data(), ref_hash.data() + 32);
         // [8B nonce slot -- coinb1 ends here; en1+en2 fills it]
+    }
+
+    // Fail-closed post-condition. The invariants above make both branches
+    // unreachable; if a future edit breaks one, REFUSE to publish the job
+    // rather than hand miners a template whose solutions can never be relayed.
+    // (Caller treats an empty coinb1 as "no per-connection coinbase".)
+    if (output_count == 0 || !bch::stratum::coinb1_ends_in_commitment_slot(coinb1)) {
+        LOG_ERROR << "[BCH-STRATUM] REFUSING to publish generation transaction: "
+                     "output_count=" << output_count
+                  << " and the extranonce slot is not inside a commitment "
+                     "output -- this is the G2 bad-txnmrklroot shape";
+        return core::stratum::CoinbaseResult{};
     }
 
     std::vector<uint8_t> coinb2;

--- a/src/impl/bch/test/CMakeLists.txt
+++ b/src/impl/bch/test/CMakeLists.txt
@@ -204,4 +204,20 @@ if(BUILD_TESTING)
             btclibs)
         add_test(NAME bch_${t} COMMAND bch_${t})
     endforeach()
+
+    # g2_block_assembly_roundtrip_test: the won-block assembly + pre-broadcast
+    # self-check gate that closes the G2 zero-blocks failure (155-byte body,
+    # zero-output generation transaction, bad-txnmrklroot on ~774k solutions).
+    # Needs coin/transaction.cpp for the MutableTransaction ctors, same as
+    # block_connector_test; link set and header-only-over-coin/*.hpp posture are
+    # otherwise identical, so per-coin isolation stays clean.
+    add_executable(bch_g2_block_assembly_roundtrip_test
+        g2_block_assembly_roundtrip_test.cpp
+        ${CMAKE_SOURCE_DIR}/src/impl/bch/coin/transaction.cpp)
+    target_include_directories(bch_g2_block_assembly_roundtrip_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
+    target_link_libraries(bch_g2_block_assembly_roundtrip_test PRIVATE
+        core pool sharechain
+        c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage c2pool_difficulty
+        btclibs)
+    add_test(NAME bch_g2_block_assembly_roundtrip_test COMMAND bch_g2_block_assembly_roundtrip_test)
 endif()

--- a/src/impl/bch/test/g2_block_assembly_roundtrip_test.cpp
+++ b/src/impl/bch/test/g2_block_assembly_roundtrip_test.cpp
@@ -1,0 +1,368 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// ---------------------------------------------------------------------------
+// G2 won-block assembly round-trip test.
+//
+// Pins the gate that closes the G2 zero-blocks failure: the live pool accepted
+// ~774k solutions and produced ZERO blocks because every relayed body was a
+// 155-byte
+//
+//     80 header + 1 tx-count + 74 generation transaction
+//
+// whose generation transaction was
+//
+//     62 first-coinbase-segment + 8 extranonce + 4 locktime
+//
+// with the 62-byte segment terminating at an OUTPUT COUNT OF ZERO -- so the
+// miner's extranonce was spliced AFTER the (empty) output vector rather than
+// inside a commitment output. Nothing downstream could decode what the miner
+// hashed, the recomputed transaction root never matched the header, and the
+// node rejected every block `bad-txnmrklroot`.
+//
+// What this test pins:
+//   1. ROUND TRIP -- a well-formed won block frames, re-deserializes from its
+//      own wire bytes, and its recomputed transaction root matches the header.
+//      Holds for the coinbase-only case and with other transactions present.
+//   2. G2 REGRESSION -- the exact historical 155-byte shape is REFUSED, by
+//      name, before it can reach either broadcast sink.
+//   3. DEGRADED: REFERENCE HASH ABSENT -- a header built without a usable
+//      reference hash carries a root that cannot match the transactions; the
+//      self-check catches it as a mismatch instead of relaying.
+//   4. DEGRADED: GENERATION VALUE ZERO -- a coinbase paying zero satoshis is
+//      still STRUCTURALLY valid (it has an output), so it must round-trip and
+//      pass. Zero value is an economics question; zero OUTPUTS is a framing
+//      defect. The test pins that the gate distinguishes them.
+//   5. JOB-BUILDER INVARIANT -- coinb1_ends_in_commitment_slot() accepts a
+//      hardened job's coinb1 and rejects the G2 62-byte segment, so the
+//      extranonce slot provably sits inside a real commitment output.
+//   6. TRUNCATION / TRAILING BYTES -- a short read or extra tail is refused
+//      rather than silently accepted.
+//
+// Build posture matches the other bch seam tests: header-only over coin/*.hpp
+// plus coin/transaction.cpp for the MutableTransaction ctors; impl_bch is NOT
+// linked, so per-coin isolation stays clean. p2pool-merged-v36 surface: NONE.
+// ---------------------------------------------------------------------------
+
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "../coin/block.hpp"
+#include "../coin/block_assembly.hpp"
+#include "../coin/mempool.hpp"
+#include "../coin/merkle.hpp"
+#include "../coin/reconstruct_won_block.hpp"
+#include "../coin/transaction.hpp"
+#include "../stratum/coinbase_slot_guard.hpp"
+
+namespace {
+
+int failures = 0;
+#define CHECK(cond) do { if (!(cond)) { \
+    std::cerr << "FAIL: " #cond " @ line " << __LINE__ << "\n"; ++failures; } } while (0)
+
+using bch::coin::MutableTransaction;
+using bch::coin::TxIn;
+using bch::coin::TxOut;
+
+// ---------------------------------------------------------------------------
+// Byte-level builders. These deliberately emit RAW BYTES rather than reusing
+// the struct serializers, because the whole point of the G2 failure was that
+// the bytes on the wire and the objects in memory disagreed.
+// ---------------------------------------------------------------------------
+
+void push_u32_le(std::vector<uint8_t>& v, uint32_t x) {
+    v.push_back(uint8_t(x)); v.push_back(uint8_t(x >> 8));
+    v.push_back(uint8_t(x >> 16)); v.push_back(uint8_t(x >> 24));
+}
+void push_u64_le(std::vector<uint8_t>& v, uint64_t x) {
+    for (int i = 0; i < 8; ++i) v.push_back(uint8_t(x >> (8 * i)));
+}
+
+/// The first coinbase segment a Stratum job hands out, up to the extranonce
+/// seam. `n_payout_outputs` payout outputs, then -- when `commitment` is set --
+/// the OP_RETURN commitment output truncated at its 8-byte extranonce slot.
+/// With `commitment == false` and no payouts this reproduces the G2 shape
+/// exactly: 62 bytes ending in an output count of 0x00.
+std::vector<uint8_t> build_coinb1(size_t n_payout_outputs, bool commitment,
+                                  int64_t payout_value = 625000000,
+                                  const uint8_t* ref_hash32 = nullptr)
+{
+    static const uint8_t kScriptSig[15] = {
+        0x03, 0x40, 0x0d, 0x0e, 0x08, 0x2f, 0x63, 0x32,
+        0x70, 0x6f, 0x6f, 0x6c, 0x2d, 0x62, 0x63 };
+    static const uint8_t kZeroRef[32] = {0};
+    if (!ref_hash32) ref_hash32 = kZeroRef;
+
+    std::vector<uint8_t> c;
+    push_u32_le(c, 1);                      // tx version
+    c.push_back(0x01);                      // vin count = 1
+    c.insert(c.end(), 32, 0x00);            // null prevout hash
+    push_u32_le(c, 0xFFFFFFFFu);            // prevout index
+    c.push_back(uint8_t(sizeof(kScriptSig)));
+    c.insert(c.end(), kScriptSig, kScriptSig + sizeof(kScriptSig));
+    push_u32_le(c, 0xFFFFFFFFu);            // sequence
+    c.push_back(uint8_t(n_payout_outputs + (commitment ? 1 : 0)));  // output count
+
+    for (size_t i = 0; i < n_payout_outputs; ++i) {
+        push_u64_le(c, uint64_t(payout_value));
+        c.push_back(0x19);                  // P2PKH script length (25)
+        const uint8_t p2pkh[25] = {0x76, 0xa9, 0x14,
+            0x11,0x22,0x33,0x44,0x55,0x66,0x77,0x88,0x99,0xaa,
+            0xbb,0xcc,0xdd,0xee,0xff,0x00,0x11,0x22,0x33,0x44,
+            0x88, 0xac};
+        c.insert(c.end(), p2pkh, p2pkh + 25);
+    }
+    if (commitment) {
+        push_u64_le(c, 0);                  // 0 sats
+        c.push_back(0x2a);                  // script length 42
+        c.push_back(0x6a);                  // OP_RETURN
+        c.push_back(0x28);                  // PUSH_40
+        c.insert(c.end(), ref_hash32, ref_hash32 + 32);
+        // stops here: the 8-byte extranonce slot is what the miner supplies
+    }
+    return c;
+}
+
+/// coinb1 || en1 || en2 || coinb2 -- exactly what a miner submits back.
+std::vector<uint8_t> splice_coinbase(const std::vector<uint8_t>& coinb1)
+{
+    std::vector<uint8_t> tx = coinb1;
+    const uint8_t extranonce[8] = {0xde,0xad,0xbe,0xef, 0x01,0x02,0x03,0x04};
+    tx.insert(tx.end(), extranonce, extranonce + 8);
+    push_u32_le(tx, 0);                     // coinb2 == locktime
+    return tx;
+}
+
+uint256 txid_of_bytes(const std::vector<uint8_t>& tx_bytes)
+{
+    return Hash(std::span<const uint8_t>(tx_bytes.data(), tx_bytes.size()));
+}
+
+/// The 80-byte header the miner solves, over an explicit transaction root.
+std::vector<unsigned char> header_over(const uint256& root)
+{
+    uint256 prev;
+    prev.SetHex("000000000000000001dfb1f2a4c0e0ecb0f7a1c2d3e4f5061728394a5b6c7d8e");
+    return bch::coin::serialize_block_header80(
+        /*version=*/0x20000000, prev, root,
+        /*timestamp=*/1753200000u, /*bits=*/0x1a0ffff0u, /*nonce=*/0x0badf00du);
+}
+
+MutableTransaction make_other_tx(const char* prev_hex, uint32_t idx, int64_t value)
+{
+    MutableTransaction tx;
+    tx.version = 2;
+    tx.locktime = 0;
+    TxIn in;
+    in.prevout.hash.SetHex(prev_hex);
+    in.prevout.index = idx;
+    in.sequence = 0xffffffff;
+    tx.vin.push_back(in);
+    TxOut out;
+    out.value = value;
+    static const unsigned char op_true[1] = {0x51};  // OP_TRUE
+    out.scriptPubKey = OPScript(op_true, op_true + 1);
+    tx.vout.push_back(out);
+    return tx;
+}
+
+// ---------------------------------------------------------------------------
+
+/// 1 + 4: a well-formed won block round-trips; coinbase-only and populated.
+void test_roundtrip_ok()
+{
+    for (int64_t payout_value : {int64_t(625000000), int64_t(0)}) {
+        // Coinbase-only: root == the coinbase txid.
+        auto gentx = splice_coinbase(build_coinb1(1, /*commitment=*/true, payout_value));
+        const uint256 gentx_hash = txid_of_bytes(gentx);
+        auto hdr = header_over(gentx_hash);
+        CHECK(hdr.size() == 80);
+
+        std::vector<const MutableTransaction*> none;
+        bch::coin::BlockSelfCheck check;
+        auto blk = bch::coin::reconstruct_won_block_from_parts(
+            std::span<const unsigned char>(hdr.data(), hdr.size()),
+            std::span<const unsigned char>(gentx.data(), gentx.size()),
+            none, &check);
+
+        CHECK(blk.has_value());
+        CHECK(check.ok);
+        CHECK(std::string(check.reason).empty());
+        CHECK(check.tx_count == 1);
+        CHECK(check.gentx_outputs == 2);   // payout + commitment
+        CHECK(check.computed_merkle_root == check.header_merkle_root);
+        if (blk) {
+            CHECK(blk->bytes.size() == 80 + 1 + gentx.size());
+            CHECK(blk->hex.size() == blk->bytes.size() * 2);
+        }
+    }
+
+    // Populated: root over [coinbase, tx1, tx2].
+    auto gentx = splice_coinbase(build_coinb1(2, /*commitment=*/true));
+    const uint256 gentx_hash = txid_of_bytes(gentx);
+    auto t1 = make_other_tx("11" "00000000000000000000000000000000000000000000000000000000000000", 0, 1000);
+    auto t2 = make_other_tx("22" "00000000000000000000000000000000000000000000000000000000000000", 1, 2000);
+
+    std::vector<uint256> ids{gentx_hash,
+                             bch::coin::compute_txid(t1),
+                             bch::coin::compute_txid(t2)};
+    auto hdr = header_over(bch::coin::compute_merkle_root(ids));
+
+    std::vector<const MutableTransaction*> others{&t1, &t2};
+    bch::coin::BlockSelfCheck check;
+    auto blk = bch::coin::reconstruct_won_block_from_parts(
+        std::span<const unsigned char>(hdr.data(), hdr.size()),
+        std::span<const unsigned char>(gentx.data(), gentx.size()),
+        others, &check);
+
+    CHECK(blk.has_value());
+    CHECK(check.ok);
+    CHECK(check.tx_count == 3);
+    CHECK(check.gentx_outputs == 3);
+    CHECK(check.computed_merkle_root == check.header_merkle_root);
+}
+
+/// 2: the historical G2 body is refused, by name, and its size is the one that
+/// was observed on the wire.
+void test_g2_zero_output_body_refused()
+{
+    auto coinb1 = build_coinb1(0, /*commitment=*/false);
+    CHECK(coinb1.size() == 62);                      // the observed first segment
+
+    auto gentx = splice_coinbase(coinb1);
+    CHECK(gentx.size() == 74);                       // 62 + 8 extranonce + 4 locktime
+
+    // The miner hashes these bytes, so the header's root is "consistent" with
+    // them -- which is exactly why a root check alone against the miner's own
+    // buffer would NOT have caught this. Only re-deserializing does.
+    auto hdr = header_over(txid_of_bytes(gentx));
+
+    std::vector<const MutableTransaction*> none;
+    bch::coin::BlockSelfCheck check;
+    auto blk = bch::coin::reconstruct_won_block_from_parts(
+        std::span<const unsigned char>(hdr.data(), hdr.size()),
+        std::span<const unsigned char>(gentx.data(), gentx.size()),
+        none, &check);
+
+    CHECK(!blk.has_value());                          // REFUSED -- not relayed
+    CHECK(!check.ok);
+
+    // Pin the total: 80 + 1 + 74 == 155, the body seen on the live pool.
+    auto framed = bch::coin::frame_won_block(
+        std::span<const unsigned char>(hdr.data(), hdr.size()),
+        std::span<const unsigned char>(gentx.data(), gentx.size()),
+        none);
+    CHECK(framed.size() == 155);
+    auto verdict = bch::coin::verify_assembled_block(
+        std::span<const unsigned char>(framed.data(), framed.size()));
+    CHECK(!verdict.ok);
+    // Either the decoder chokes on the extranonce sitting where the locktime
+    // should be, or it decodes a zero-output coinbase. Both are refusals; the
+    // gate must never let this body through.
+    CHECK(std::string(verdict.reason).find("ZERO outputs") != std::string::npos ||
+          std::string(verdict.reason).find("re-deserialize") != std::string::npos ||
+          std::string(verdict.reason).find("trailing bytes") != std::string::npos);
+    std::cerr << "note: G2 155-byte body refused -- " << verdict.reason << "\n";
+}
+
+/// 3: reference hash absent -> the header cannot describe the transactions.
+void test_degraded_reference_hash_absent()
+{
+    // Commitment output present but its reference hash is all zeros: the job
+    // was published without a usable reference, so the header the pool rebuilds
+    // (from the share's merkle link over a DIFFERENT coinbase) will not match.
+    auto gentx_published = splice_coinbase(build_coinb1(1, /*commitment=*/true));
+    auto gentx_rebuilt   = splice_coinbase(build_coinb1(2, /*commitment=*/true));
+
+    // Header over the published coinbase; body carries the rebuilt one.
+    auto hdr = header_over(txid_of_bytes(gentx_published));
+
+    std::vector<const MutableTransaction*> none;
+    bch::coin::BlockSelfCheck check;
+    auto blk = bch::coin::reconstruct_won_block_from_parts(
+        std::span<const unsigned char>(hdr.data(), hdr.size()),
+        std::span<const unsigned char>(gentx_rebuilt.data(), gentx_rebuilt.size()),
+        none, &check);
+
+    CHECK(!blk.has_value());
+    CHECK(!check.ok);
+    CHECK(std::string(check.reason).find("does not match") != std::string::npos);
+    CHECK(check.computed_merkle_root != check.header_merkle_root);
+}
+
+/// 5: the job-builder invariant is machine-checkable.
+void test_job_builder_commitment_slot_invariant()
+{
+    // Hardened job: commitment output present, coinb1 stops at the slot.
+    CHECK(bch::stratum::coinb1_ends_in_commitment_slot(build_coinb1(1, true)));
+    CHECK(bch::stratum::coinb1_ends_in_commitment_slot(build_coinb1(4, true)));
+    // A payout-free job STILL has the commitment output after hardening.
+    CHECK(bch::stratum::coinb1_ends_in_commitment_slot(build_coinb1(0, true)));
+
+    // The G2 shape: no commitment output, coinb1 ends at the output count.
+    CHECK(!bch::stratum::coinb1_ends_in_commitment_slot(build_coinb1(0, false)));
+    // Payout outputs but no commitment: the seam still falls outside a script.
+    CHECK(!bch::stratum::coinb1_ends_in_commitment_slot(build_coinb1(2, false)));
+
+    // A coinb1 that already includes the extranonce leaves no slot to fill.
+    CHECK(!bch::stratum::coinb1_ends_in_commitment_slot(splice_coinbase(build_coinb1(1, true))));
+    // Truncated garbage.
+    CHECK(!bch::stratum::coinb1_ends_in_commitment_slot({}));
+    CHECK(!bch::stratum::coinb1_ends_in_commitment_slot({0x01, 0x00, 0x00}));
+}
+
+/// 6: truncation and trailing bytes are refusals, not silent passes.
+void test_truncation_and_trailing_bytes()
+{
+    auto gentx = splice_coinbase(build_coinb1(1, true));
+    auto hdr = header_over(txid_of_bytes(gentx));
+    std::vector<const MutableTransaction*> none;
+
+    auto good = bch::coin::frame_won_block(
+        std::span<const unsigned char>(hdr.data(), hdr.size()),
+        std::span<const unsigned char>(gentx.data(), gentx.size()),
+        none);
+    CHECK(bch::coin::verify_assembled_block(
+        std::span<const unsigned char>(good.data(), good.size())).ok);
+
+    auto truncated = good;
+    truncated.resize(truncated.size() - 5);
+    CHECK(!bch::coin::verify_assembled_block(
+        std::span<const unsigned char>(truncated.data(), truncated.size())).ok);
+
+    auto trailing = good;
+    trailing.push_back(0xff);
+    auto v = bch::coin::verify_assembled_block(
+        std::span<const unsigned char>(trailing.data(), trailing.size()));
+    CHECK(!v.ok);
+    CHECK(std::string(v.reason).find("trailing bytes") != std::string::npos);
+
+    // Header-only body (no transactions at all).
+    std::vector<unsigned char> headerless(hdr.begin(), hdr.end());
+    headerless.push_back(0x00);   // tx count = 0
+    auto hv = bch::coin::verify_assembled_block(
+        std::span<const unsigned char>(headerless.data(), headerless.size()));
+    CHECK(!hv.ok);
+    CHECK(std::string(hv.reason).find("no transactions") != std::string::npos);
+}
+
+} // namespace
+
+int main()
+{
+    test_roundtrip_ok();
+    test_g2_zero_output_body_refused();
+    test_degraded_reference_hash_absent();
+    test_job_builder_commitment_slot_invariant();
+    test_truncation_and_trailing_bytes();
+
+    if (failures) {
+        std::cerr << failures << " CHECK(s) failed\n";
+        return 1;
+    }
+    std::cout << "g2_block_assembly_roundtrip_test: all checks passed\n";
+    return 0;
+}


### PR DESCRIPTION
## What

Fixes BCH won-block production: every block found by the pool was being rejected by
the node with `bad-txnmrklroot`. Dispatch was fine — the relayed body was header plus a
stripped generation transaction, not a block whose merkle root matched the header.

BCH lacked the assemble/reconstruct single-source-of-truth that the NMC and DGB modules
already have. This adds it.

- `src/impl/bch/coin/block_assembly.hpp` — canonical block assembly (CTOR-ordered),
  single source of truth for the serialized block bytes.
- `src/impl/bch/coin/reconstruct_won_block.hpp` — rebuilds the full won block from the
  share's coinbase + the work-source transaction set, then re-derives the merkle root.
- Pre-broadcast self-check: if the recomputed merkle root does not match the header the
  block is **refused** rather than broadcast. A won block never leaves the process in a
  state the node will reject.
- The coinbase commitment output is now emitted unconditionally, so the zero-output
  generation transaction that produced the stripped body is unreachable by construction.
- `rpc.cpp`: a dropped `submitblock` is now loud and the request is re-issued instead of
  being swallowed by `ignore_failure` under a stale keep-alive connection.
- `g2_block_assembly_roundtrip_test.cpp` — found → assembled → reconstructed → merkle-root
  round-trip, registered in **both** COIN_BCH CI target lists in `build.yml`.

## Scope

`src/impl/bch/` only, plus two COIN_BCH target lines in `.github/workflows/build.yml`.
Shared base untouched — per-coin isolation invariant holds.

## Verification

`c2pool-bch` builds green; 30/30 tests pass, including the new round-trip test.

## Residual (out of lane — do not fix here)

`src/core/stratum_server.cpp:1614` still has a shared-base fallback that publishes a
placeholder `coinb1` after a per-coin work builder has deliberately refused to produce
work. That defeats the refusal for every coin, not just BCH. Flagged rather than touched:
it is a cross-coin item tracked separately and is deliberately outside this PR's boundary.
