### PR TITLE
dash(embedded): superblock governance-vote BLS verify — enable daemonless superblock serving (R3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,58 @@ if(GTest_FOUND OR GTEST_FOUND)
 else()
     message(STATUS "GTest not found - testing disabled")
 endif()
+# ── E1 Phase-L: optional dashbls (BLS12-381) backend for type-6 quorum-
+# commitment verification ────────────────────────────────────────────────────
+# dashpay/bls-signatures ("dashbls", relic-backed, Apache-2.0) — the SAME
+# library dashd wraps in src/bls/bls.h. OPT-IN and DASH-ONLY: only the DASH impl
+# (dash_bls_verify) + its KAT consume it, never the shared core the Windows
+# main_ltc launcher builds ([[reference_windows_ci_conan_flake]]: Windows CI
+# builds only the LTC launcher, so DASH-only BLS code cannot break it). When the
+# option is OFF (default) or the library is not found, dash_bls_verify compiles a
+# fail-closed stub and the DKG-window serve path keeps the pre-Phase-L
+# null-commitment posture exactly — no dashbls dependency enters any build.
+#
+# Build the library once for the CI factory with scripts/build_dashbls.sh (builds
+# dash's OWN src/dashbls subtree at the v23.1.7 tag — byte-identical to dashd);
+# point cmake at it with -DDASHBLS_ROOT=<prefix>.
+option(C2POOL_DASH_BLS "Link dashbls (BLS12-381) for E1 Phase-L real quorum-commitment verify" OFF)
+set(C2POOL_DASH_BLS_AVAILABLE OFF)
+if(C2POOL_DASH_BLS)
+    # Honour a DASHBLS_ROOT hint (the build-factory install prefix), else search
+    # the system paths. dashbls installs: include/dashbls/*.hpp,
+    # lib/libdashbls.a, lib/librelic_s.a, lib/mimalloc-2.0/libmimalloc-secure.a.
+    find_path(DASHBLS_INCLUDE_DIR dashbls/bls.hpp
+        HINTS ${DASHBLS_ROOT} ENV DASHBLS_ROOT PATH_SUFFIXES include)
+    find_library(DASHBLS_LIB       NAMES dashbls bls-dash
+        HINTS ${DASHBLS_ROOT} ENV DASHBLS_ROOT PATH_SUFFIXES lib)
+    find_library(DASHBLS_RELIC_LIB NAMES relic_s relic
+        HINTS ${DASHBLS_ROOT} ENV DASHBLS_ROOT PATH_SUFFIXES lib)
+    find_library(DASHBLS_MIMALLOC_LIB NAMES mimalloc-secure mimalloc
+        HINTS ${DASHBLS_ROOT} ENV DASHBLS_ROOT PATH_SUFFIXES lib lib/mimalloc-2.0 lib/mimalloc-2.1)
+    find_library(DASHBLS_GMP_LIB NAMES gmp)
+    # NOTE: the autotools install (scripts/build_dashbls.sh, the only build
+    # path dash's v23.1.7 src/dashbls subtree supports) folds relic + mimalloc
+    # INTO libdashbls.a — so the separate relic/mimalloc libs are OPTIONAL and
+    # only linked when present (the legacy standalone-CMake layout).
+    if(DASHBLS_INCLUDE_DIR AND DASHBLS_LIB AND DASHBLS_GMP_LIB)
+        set(C2POOL_DASH_BLS_AVAILABLE ON)
+        set(DASHBLS_LIBRARIES ${DASHBLS_LIB})
+        if(DASHBLS_RELIC_LIB)
+            list(APPEND DASHBLS_LIBRARIES ${DASHBLS_RELIC_LIB})
+        endif()
+        if(DASHBLS_MIMALLOC_LIB)
+            list(APPEND DASHBLS_LIBRARIES ${DASHBLS_MIMALLOC_LIB})
+        endif()
+        list(APPEND DASHBLS_LIBRARIES ${DASHBLS_GMP_LIB})
+        message(STATUS "dashbls found (E1 Phase-L BLS verify ENABLED): ${DASHBLS_LIB}")
+        message(STATUS "dashbls includes: ${DASHBLS_INCLUDE_DIR}")
+    else()
+        message(WARNING "C2POOL_DASH_BLS=ON but dashbls not found "
+            "(need dashbls + relic + gmp; run scripts/build_dashbls.sh and pass "
+            "-DDASHBLS_ROOT=<prefix>). Falling back to fail-closed null-serve.")
+    endif()
+endif()
+
 include_directories(include)
 include_directories(src)
 

--- a/src/c2pool/CMakeLists.txt
+++ b/src/c2pool/CMakeLists.txt
@@ -327,6 +327,8 @@ target_link_libraries(c2pool-dash
                        # CBlockHeaderAndShortTxIDs::FillShortTxIDSelector()
     dash_bls_verify    # E1 Phase-L: real type-6 quorum-commitment BLS verify
                        # (make_commitment_bls_verifier -> set_bls_verify_fn seam).
+                       # R3: also verify_govvote_operator_sig (governance-vote BLS
+                       # operator-key verify, daemonless superblock serving).
                        # Carries the C2POOL_DASH_BLS define + dashbls libs PUBLIC
                        # when the backend was found; fail-closed stub otherwise.
     btclibs

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -80,6 +80,7 @@
 #include <impl/dash/coin/mn_list_ingest.hpp>     // wire_mn_list_ingest (leg 4)
 #include <impl/dash/coin/govsync_ingest.hpp>     // wire_govobject_ingest / wire_govvote_ingest (E-SUPERBLOCK)
 #include <impl/dash/coin/superblock.hpp>         // get_superblock_payments / superblock_budget (E-SUPERBLOCK)
+#include <impl/dash/coin/vendor/bls_verify.hpp>  // R3: verify_govvote_operator_sig — governance-vote BLS operator-key verify
 #include <impl/dash/coin/mn_seed.hpp>            // E2c: RPC protx-list MN-set seed (parse_protx_list_seed)
 #include <impl/dash/coin/mn_checkpoint.hpp>      // E2d: pinned MN-set checkpoint format + fail-closed parser
 #include <impl/dash/coin/mn_checkpoint_lane.hpp> // E2d: checkpoint -> forward-replay bridge -> leg-4 publish
@@ -2756,25 +2757,27 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             // it OFF, set_require_superblock_provider(false) preserves the prior
             // reward-safe behaviour EXACTLY (every superblock height falls back).
             //
-            // FAIL-CLOSED BY CONSTRUCTION until vote-verify lands, TRIPLY:
-            //   1. the funding tally counts only votes the maintainer's
-            //      vote-verifier accepts — and that verifier is UNSET here.
-            //      (Follow-up contract: BLS by the voting MN's OPERATOR key
-            //      over govvote_signature_hash — dashcore verifies TRIGGER
-            //      funding votes against pubKeyOperator, NOT the
-            //      ECDSA/keyIDVoting path, which is proposal-only. See
-            //      CoinStateMaintainer::set_vote_verifier.)
-            //   2. the weighted tally needs the vote-weight/membership seam
-            //      (GovernanceStore::set_vote_weight_fn) — also UNSET here
-            //      (the DIP-4 SML lacks collateral outpoints; needs the full
-            //      DMN view).
+            // FAIL-CLOSED BY CONSTRUCTION, in three independent layers:
+            //   1. (R3, WIRED below) the funding tally counts only votes the
+            //      maintainer's vote-verifier accepts — now the real BLS verify
+            //      by the voting MN's OPERATOR key over govvote_signature_hash
+            //      (dashcore verifies TRIGGER funding votes against
+            //      pubKeyOperator, NOT the ECDSA/keyIDVoting path, which is
+            //      proposal-only). Unverified/forged votes never count; when the
+            //      BLS backend is absent the verifier fails closed (0 counted).
+            //   2. (R3, WIRED below) the weighted tally uses the vote-weight/
+            //      membership seam (GovernanceStore::set_vote_weight_fn) —
+            //      resolved from the full DMN view (collateral outpoint ->
+            //      operator key + type), EvoNode 4x, 0 for an MN no longer in
+            //      the valid set. The threshold itself reseeds from the weighted
+            //      SML count on every diff (reseed_funding_threshold).
             //   3. the R5 govsync-completeness gate
-            //      (set_superblock_sync_complete_fn) is NOT wired — the
+            //      (set_superblock_sync_complete_fn) is STILL NOT wired — the
             //      NodeCoinState guard refuses the serve path structurally,
-            //      so landing vote-verify alone can never open it.
+            //      so R3 landing here can never by itself open it.
             // The parse/selection/template-emit logic is proven by the KATs;
-            // flipping this fully live is gated on vote-verify + completeness
-            // + a funded-superblock soak.
+            // flipping this fully live is still gated on R5 completeness + the
+            // R6 desync latch + a funded-superblock soak.
             {
                 const int64_t budget_cycle = sb_cycle;
                 // Chain-strict trigger parsing + dashcore threshold inputs:
@@ -2822,21 +2825,97 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     [maint = maintainer.get()]() {
                         return maint->gov_sync_complete();
                     });
+
+                // R3 — governance-vote BLS verify + vote-weight seam. This is
+                // the piece that lets a funding tally count anything at all:
+                // both closures resolve the voting masternode by its COLLATERAL
+                // OUTPOINT in the node's live DMN view (node_coin_state
+                // .mnstates(), seeded from protx info — the DIP-4 SML alone
+                // carries neither collateral outpoints nor operator keys). Every
+                // step FAILS CLOSED: unknown MN, banned MN, unresolvable key,
+                // wrong sig size, stale/future time, or a failed BLS verify =>
+                // the vote is NOT tallied. The funding THRESHOLD is already
+                // (re)seeded from the weighted SML count on every accepted diff
+                // (reseed_funding_threshold); the R5 completeness gate wired
+                // ABOVE still evaluates FALSE in production (single peer / empty
+                // store), so landing vote-verify here can never by itself open
+                // the serve path.
+                {
+                    auto* ncs = &node_coin_state;
+
+                    // Vote-signature verifier — dashcore CGovernanceVote::
+                    // CheckSignature over the MN's OPERATOR key (TRIGGER funding
+                    // votes; the ECDSA voting-key path is PROPOSAL-only and NOT
+                    // used here). Plus the IsValid time bound (nTime <= now+1h).
+                    maintainer->set_vote_verifier(
+                        [ncs](const dash::coin::CoinStateMaintainer::GovVoteContext& v)
+                            -> bool {
+                            // dashcore IsValid: reject a vote timestamped more
+                            // than an hour into the future (clock-skew bound).
+                            if (v.time > static_cast<int64_t>(std::time(nullptr)) + 60 * 60)
+                                return false;
+                            // Resolve collateral outpoint -> DMN -> operator key.
+                            bitcoin_family::coin::TxPrevOut op;
+                            op.hash  = v.mn_outpoint_hash;
+                            op.index = v.mn_outpoint_index;
+                            auto pro = ncs->mnstates().find_by_collateral(op);
+                            if (!pro) return false;              // MN not in DMN set
+                            const auto& es = ncs->mnstates().entries();
+                            auto it = es.find(*pro);
+                            if (it == es.end()) return false;
+                            if (!it->second.isValid) return false;   // banned/invalid
+                            const bool legacy =
+                                (it->second.nVersion ==
+                                 dash::coin::vendor::ProTxVersion::LEGACY_BLS);
+                            return dash::coin::vendor::verify_govvote_operator_sig(
+                                it->second.pubKeyOperator, legacy,
+                                v.vote_hash, v.vch_sig);
+                        });
+
+                    // Vote-weight + membership-at-tally — dashcore
+                    // CountMatchingVotes: EvoNode 4x, Regular 1x, and 0
+                    // (vote dropped) when the MN is not in the valid DMN set at
+                    // tally time. Keyed by "<collateral-txid-hex>-<index>"
+                    // (GovOutPoint::to_key()); we reconstruct the outpoint and
+                    // resolve it against the SAME live DMN view.
+                    maintainer->gov_store().set_vote_weight_fn(
+                        [ncs](const std::string& key) -> int {
+                            const auto dashpos = key.rfind('-');
+                            if (dashpos == std::string::npos) return 0;
+                            bitcoin_family::coin::TxPrevOut op;
+                            op.hash.SetHex(key.substr(0, dashpos));
+                            try {
+                                op.index = static_cast<uint32_t>(
+                                    std::stoul(key.substr(dashpos + 1)));
+                            } catch (...) { return 0; }
+                            auto pro = ncs->mnstates().find_by_collateral(op);
+                            if (!pro) return 0;
+                            const auto& es = ncs->mnstates().entries();
+                            auto it = es.find(*pro);
+                            if (it == es.end() || !it->second.isValid) return 0;
+                            return (it->second.nType == dash::coin::vendor::MnType::EVO)
+                                       ? dash::coin::DASH_VOTE_WEIGHT_EVO
+                                       : dash::coin::DASH_VOTE_WEIGHT_REGULAR;
+                        });
+                }
+
+                // Reconciled log (R5 completeness gate + R3 vote-verify both wired).
                 if (embedded_superblock)
                     LOG_INFO << "[E-SUPERBLOCK] daemonless superblock arm ENABLED "
-                                "(--embedded-superblock); superblock heights served "
-                                "from govsync triggers ONLY when the governance "
-                                "view is trigger-confident AND provably complete "
-                                "(R5: >= "
+                                "(--embedded-superblock). BOTH gates WIRED: the R5 "
+                                "govsync-completeness gate (>= "
                              << dash::coin::DASH_GOVSYNC_MIN_PEERS_DEFAULT
-                             << " peers, quiesced), else fail closed to dashd. "
-                                "CO-REQUISITES still pending before this can serve "
-                                "live: multi-peer govsync + inv-driven getdata "
-                                "(the leg is inv-inert today) + BLS operator "
-                                "vote-verify + the vote-weight seam — until those "
-                                "land the completeness predicate evaluates FALSE "
-                                "(single peer / empty store) and the arm stays on "
-                                "the reward-safe fallback.";
+                             << " peers, settled, quiesced) that lets a "
+                                "trigger-confident superblock actually serve, AND the "
+                                "R3 governance-vote BLS operator verify + vote-weight "
+                                "seam ("
+                             << (dash::coin::vendor::bls_backend_available()
+                                     ? "BLS backend ON"
+                                     : "BLS backend ABSENT => votes never verify")
+                             << "). Serve stays CLOSED until the completeness "
+                                "predicate proves complete (single peer / empty store "
+                                "=> FALSE) and a funded soak clears -- R3 vote-verify "
+                                "landing here cannot by itself open it.";
             }
         }
 

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -2768,9 +2768,12 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             //   2. (R3, WIRED below) the weighted tally uses the vote-weight/
             //      membership seam (GovernanceStore::set_vote_weight_fn) —
             //      resolved from the full DMN view (collateral outpoint ->
-            //      operator key + type), EvoNode 4x, 0 for an MN no longer in
-            //      the valid set. The threshold itself reseeds from the weighted
-            //      SML count on every diff (reseed_funding_threshold).
+            //      operator key + type), EvoNode 4x, 0 only for an MN no
+            //      longer in the DMN list at all (dashcore's UNFILTERED
+            //      GetMNByCollateral — PoSe-banned MNs still count). The
+            //      threshold itself reseeds from the weighted VALID SML count
+            //      on every diff (reseed_funding_threshold — dashcore's own
+            //      tally/denominator asymmetry).
             //   3. the R5 govsync-completeness gate
             //      (set_superblock_sync_complete_fn) is STILL NOT wired — the
             //      NodeCoinState guard refuses the serve path structurally,
@@ -2831,15 +2834,20 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 // both closures resolve the voting masternode by its COLLATERAL
                 // OUTPOINT in the node's live DMN view (node_coin_state
                 // .mnstates(), seeded from protx info — the DIP-4 SML alone
-                // carries neither collateral outpoints nor operator keys). Every
-                // step FAILS CLOSED: unknown MN, banned MN, unresolvable key,
-                // wrong sig size, stale/future time, or a failed BLS verify =>
-                // the vote is NOT tallied. The funding THRESHOLD is already
-                // (re)seeded from the weighted SML count on every accepted diff
-                // (reseed_funding_threshold); the R5 completeness gate wired
-                // ABOVE still evaluates FALSE in production (single peer / empty
-                // store), so landing vote-verify here can never by itself open
-                // the serve path.
+                // carries neither collateral outpoints nor operator keys), via
+                // the shared gov_mn_by_collateral / gov_vote_weight_for_key
+                // parity helpers. Every step FAILS CLOSED: unknown MN,
+                // unresolvable key, wrong sig size, stale/future time, or a
+                // failed BLS verify => the vote is NOT tallied. NOTE dashcore
+                // parity (v23.1.7): the resolve is UNFILTERED
+                // (GetMNByCollateral) — a PoSe-BANNED MN's vote still verifies
+                // and still counts at full weight, in BOTH paths; only the
+                // funding THRESHOLD denominator is valid-weighted
+                // (reseed_funding_threshold, reseeded from the weighted SML
+                // count on every accepted diff — dashcore's own asymmetry).
+                // The R5 completeness gate wired ABOVE still evaluates FALSE
+                // in production (single peer / empty store), so landing
+                // vote-verify here can never by itself open the serve path.
                 {
                     auto* ncs = &node_coin_state;
 
@@ -2852,50 +2860,48 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                             -> bool {
                             // dashcore IsValid: reject a vote timestamped more
                             // than an hour into the future (clock-skew bound).
+                            // KNOWN NIT (documented, not fixed): dashcore uses
+                            // GetAdjustedTime() (network-adjusted); c2pool has
+                            // no peer time-offset plumbing here, so this is the
+                            // LOCAL clock. Divergence is bounded by our own
+                            // clock skew and only matters for votes inside that
+                            // skew of the +1h edge; NTP-disciplined hosts make
+                            // it negligible. Revisit if soak shows drift.
                             if (v.time > static_cast<int64_t>(std::time(nullptr)) + 60 * 60)
                                 return false;
-                            // Resolve collateral outpoint -> DMN -> operator key.
+                            // Resolve collateral outpoint -> DMN -> operator
+                            // key. UNFILTERED (no PoSe-ban check) — dashcore
+                            // CGovernanceVote::IsValid resolves via
+                            // GetMNByCollateral, so a banned MN's vote still
+                            // verifies in dashd and must here too (dropping a
+                            // banned MN's NO inflates our yes−no vs dashd).
                             bitcoin_family::coin::TxPrevOut op;
                             op.hash  = v.mn_outpoint_hash;
                             op.index = v.mn_outpoint_index;
-                            auto pro = ncs->mnstates().find_by_collateral(op);
-                            if (!pro) return false;              // MN not in DMN set
-                            const auto& es = ncs->mnstates().entries();
-                            auto it = es.find(*pro);
-                            if (it == es.end()) return false;
-                            if (!it->second.isValid) return false;   // banned/invalid
+                            const dash::coin::MNState* mn =
+                                dash::coin::gov_mn_by_collateral(
+                                    ncs->mnstates(), op);
+                            if (!mn) return false;           // MN not in DMN list
                             const bool legacy =
-                                (it->second.nVersion ==
+                                (mn->nVersion ==
                                  dash::coin::vendor::ProTxVersion::LEGACY_BLS);
                             return dash::coin::vendor::verify_govvote_operator_sig(
-                                it->second.pubKeyOperator, legacy,
+                                mn->pubKeyOperator, legacy,
                                 v.vote_hash, v.vch_sig);
                         });
 
                     // Vote-weight + membership-at-tally — dashcore
-                    // CountMatchingVotes: EvoNode 4x, Regular 1x, and 0
-                    // (vote dropped) when the MN is not in the valid DMN set at
-                    // tally time. Keyed by "<collateral-txid-hex>-<index>"
-                    // (GovOutPoint::to_key()); we reconstruct the outpoint and
-                    // resolve it against the SAME live DMN view.
+                    // CountMatchingVotes: EvoNode 4x, Regular 1x, and 0 (vote
+                    // dropped) ONLY when the outpoint is not in the DMN list
+                    // at tally time (unfiltered GetMNByCollateral — banned MNs
+                    // still count). Keyed by "<collateral-txid-hex>-<index>"
+                    // (GovOutPoint::to_key()); gov_vote_weight_for_key
+                    // reconstructs the outpoint and resolves it against the
+                    // SAME live DMN view.
                     maintainer->gov_store().set_vote_weight_fn(
                         [ncs](const std::string& key) -> int {
-                            const auto dashpos = key.rfind('-');
-                            if (dashpos == std::string::npos) return 0;
-                            bitcoin_family::coin::TxPrevOut op;
-                            op.hash.SetHex(key.substr(0, dashpos));
-                            try {
-                                op.index = static_cast<uint32_t>(
-                                    std::stoul(key.substr(dashpos + 1)));
-                            } catch (...) { return 0; }
-                            auto pro = ncs->mnstates().find_by_collateral(op);
-                            if (!pro) return 0;
-                            const auto& es = ncs->mnstates().entries();
-                            auto it = es.find(*pro);
-                            if (it == es.end() || !it->second.isValid) return 0;
-                            return (it->second.nType == dash::coin::vendor::MnType::EVO)
-                                       ? dash::coin::DASH_VOTE_WEIGHT_EVO
-                                       : dash::coin::DASH_VOTE_WEIGHT_REGULAR;
+                            return dash::coin::gov_vote_weight_for_key(
+                                ncs->mnstates(), key);
                         });
                 }
 

--- a/src/impl/dash/CMakeLists.txt
+++ b/src/impl/dash/CMakeLists.txt
@@ -34,14 +34,16 @@ target_link_libraries(dash_block_replay PRIVATE core nlohmann_json::nlohmann_jso
 # links it is c2pool-dash (this slice), so the ltc/btc/doge/dgb build + ctest
 # surfaces are untouched. Per-coin isolation held: src/impl/dash only, no
 # shared-base/core SOURCE edit, dashd RPC fallback preserved.
-# E1 Phase-L: type-6 quorum-commitment BLS verify (coin/vendor/bls_verify.cpp).
-# Compiled UNCONDITIONALLY so the seam symbols (make_commitment_bls_verifier,
-# verify_final_commitment, build_commitment_hash) always resolve; the dashbls
-# backend is linked + the C2POOL_DASH_BLS define is set (PUBLIC, so the sole
-# consumer c2pool-dash inherits it) ONLY when the library was found. Without it
-# the verify functions are fail-closed stubs and NO dashbls dependency enters
-# the build — keeping the Windows main_ltc launcher (shared core only) clean.
-# SAFE-ADDITIVE: the only executable linking dash_bls_verify is c2pool-dash.
+# E1 Phase-L / E-SUPERBLOCK: BLS verify (coin/vendor/bls_verify.cpp). Provides
+# BOTH the type-6 quorum-commitment aggregate verify (Phase-L) AND the single-
+# signature governance-vote operator-key verify (R3 daemonless superblock
+# serving — verify_govvote_operator_sig). Compiled UNCONDITIONALLY so the seam
+# symbols always resolve; the dashbls backend is linked + the C2POOL_DASH_BLS
+# define is set (PUBLIC, so the sole consumer c2pool-dash inherits it) ONLY when
+# the library was found. Without it the verify functions are fail-closed stubs
+# and NO dashbls dependency enters the build — keeping the Windows main_ltc
+# launcher (shared core only) clean. SAFE-ADDITIVE: the only executable linking
+# dash_bls_verify is c2pool-dash (plus its KAT test_dash_govvote_bls).
 add_library(dash_bls_verify STATIC coin/vendor/bls_verify.cpp)
 target_include_directories(dash_bls_verify PRIVATE
     ${CMAKE_SOURCE_DIR}/src

--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -60,6 +60,58 @@
 namespace dash {
 namespace coin {
 
+// ── R3 governance-tally MN resolution (dashcore v23.1.7 parity) ─────────────
+//
+// Both the vote-VERIFY path (CGovernanceVote::IsValid) and the vote-COUNT path
+// (CGovernanceObject::CountMatchingVotes) in dashcore resolve the voting
+// masternode with CDeterministicMNList::GetMNByCollateral — the UNFILTERED
+// lookup (evo/deterministicmns.h keeps GetValidMNByCollateral as a SEPARATE
+// accessor, and governance uses the unfiltered one in both places). So a
+// PoSe-BANNED MN's vote still VERIFIES and still COUNTS at its full voting
+// weight in dashd. Filtering banned MNs out of the tally here would diverge:
+// dropping a banned MN's NO vote inflates (yes − no) in c2pool vs dashd, and
+// natural PoSe-ban churn triggers that with no attacker (wrong trigger wins =>
+// wrong superblock payees => lost block).
+//
+// THE ASYMMETRY TO PRESERVE: dashcore's funding THRESHOLD denominator
+// (UpdateSentinelVariables: nAbsVoteReq = max(nGovernanceMinQuorum,
+// nWeightedMnCount / 10)) uses GetCounts().m_valid_weighted — the VALID set.
+// So: per-vote tally UNFILTERED, threshold denominator valid-only. That is
+// dashcore's own asymmetry; reseed_funding_threshold() below keeps the
+// valid-only denominator and these helpers keep the unfiltered tally.
+
+/// dashcore GetMNByCollateral over the node's live DMN view: UNFILTERED —
+/// resolves PoSe-banned entries too. nullptr only when the collateral outpoint
+/// is not in the DMN list at all (dashcore then rejects the vote / counts 0).
+inline const MNState* gov_mn_by_collateral(
+    const MnStateMachine& mns, const bitcoin_family::coin::TxPrevOut& outpoint)
+{
+    auto pro = mns.find_by_collateral(outpoint);
+    if (!pro) return nullptr;
+    auto it = mns.entries().find(*pro);
+    return it == mns.entries().end() ? nullptr : &it->second;
+}
+
+/// dashcore CountMatchingVotes per-vote weight for a stored vote key
+/// ("<collateral-txid-hex>-<index>", GovOutPoint::to_key()): EvoNode 4x,
+/// Regular 1x, 0 ONLY for an outpoint not in the DMN list (unknown MN). A
+/// PoSe-banned MN still weighs in at full weight — see the parity note above.
+inline int gov_vote_weight_for_key(const MnStateMachine& mns,
+                                   const std::string& key)
+{
+    const auto dashpos = key.rfind('-');
+    if (dashpos == std::string::npos) return 0;
+    bitcoin_family::coin::TxPrevOut op;
+    op.hash.SetHex(key.substr(0, dashpos));
+    try {
+        op.index = static_cast<uint32_t>(std::stoul(key.substr(dashpos + 1)));
+    } catch (...) { return 0; }
+    const MNState* mn = gov_mn_by_collateral(mns, op);
+    if (!mn) return 0;
+    return (mn->nType == vendor::MnType::EVO) ? DASH_VOTE_WEIGHT_EVO
+                                              : DASH_VOTE_WEIGHT_REGULAR;
+}
+
 /// Drives a node-owned NodeCoinState from the async update events the running
 /// node observes. Non-copyable (holds a reference to the node's holder). The
 /// node constructs exactly one, wired to its NodeCoinState member; the
@@ -162,8 +214,10 @@ public:
     /// ECDSA/keyIDVoting-signed; that path applies only to PROPOSAL funding
     /// votes — dashcore governance/object.cpp: onlyVotingKeyAllowed =
     /// (type == PROPOSAL && signal == FUNDING)):
-    ///   1. Look the voting MN up by its COLLATERAL OUTPOINT in the valid
-    ///      deterministic MN set at verify time (unknown MN => reject). Note
+    ///   1. Look the voting MN up by its COLLATERAL OUTPOINT in the
+    ///      deterministic MN list at verify time (unknown MN => reject) —
+    ///      UNFILTERED, dashcore GetMNByCollateral: a PoSe-banned MN's vote
+    ///      still verifies (and counts), see gov_mn_by_collateral above. Note
     ///      the DIP-4 SML does not carry collateral outpoints — this needs the
     ///      full DMN view (protx info), see GovernanceStore::set_vote_weight_fn.
     ///   2. BLS-verify vch_sig with the MN's OPERATOR key (pubKeyOperator from
@@ -234,9 +288,14 @@ public:
         // BEFORE the signal/outcome/known-trigger filters below.
         m_gov_sync_status.note_vote_arrival(m_now_fn());
         if (v.signal != VOTE_SIGNAL_FUNDING) return;            // only the superblock tally axis
-        if (v.outcome != VOTE_OUTCOME_YES && v.outcome != VOTE_OUTCOME_NO &&
-            v.outcome != VOTE_OUTCOME_ABSTAIN)
-            return;                                             // dashcore IsValid outcome range
+        // dashcore CGovernanceVote::IsValid outcome range: NONE..ABSTAIN
+        // (nVoteOutcome < VOTE_OUTCOME_NONE || >= VOTE_OUTCOME_UNKNOWN =>
+        // reject). NONE is a VALID, STORED outcome — a newer NONE vote
+        // REPLACES a stored YES in dashd's per-(MN,signal) record, dropping
+        // the yes-count. Dropping NONE here would leave a stale YES tallied
+        // in c2pool after the voter withdrew it (tally inflation vs dashd).
+        if (v.outcome < VOTE_OUTCOME_NONE || v.outcome > VOTE_OUTCOME_ABSTAIN)
+            return;
         if (!m_gov_store.has_trigger(v.parent_hash)) return;    // vote for a non-trigger → ignore
         if (!m_vote_verifier || !m_vote_verifier(v)) {
             // Unverified (default) or failed verify: DO NOT count. Fail closed.
@@ -946,6 +1005,12 @@ private:
     // weight (Regular 1, EvoNode 4 — evo/dmn_types.h). Empty list or unset
     // min-quorum (set_gov_params not called) => 0 => fail closed. Called on
     // every accepted mnlistdiff, on SML reorg wipes, and from set_gov_params.
+    //
+    // NOTE the deliberate ASYMMETRY (dashcore's own, DO NOT "fix"): this
+    // DENOMINATOR is computed over the VALID set only (GetCounts()
+    // .m_valid_weighted — the `isValid` filter below stays), while the
+    // per-vote TALLY resolves voters UNFILTERED (GetMNByCollateral — a
+    // PoSe-banned MN's vote still counts; see gov_vote_weight_for_key).
     void reseed_funding_threshold() {
         int weighted = 0;
         for (const auto& e : m_state.sml().mnList) {

--- a/src/impl/dash/coin/governance_store.hpp
+++ b/src/impl/dash/coin/governance_store.hpp
@@ -19,11 +19,12 @@
 /// superblock template when its WEIGHTED funding-signal absolute-yes tally
 /// reaches the network funding threshold AND every counted vote was
 /// cryptographically verified (BLS operator-key — see the vote-verifier
-/// contract in coin_state_maintainer.hpp) AND the voting MN is still in the
-/// valid set at tally time (weight seam below). An incomplete / unverified /
-/// sub-threshold view yields NO winning trigger, so the arm refuses and routes
-/// to the reward-safe dashd fallback — the mandate: NEVER guess superblock
-/// payees.
+/// contract in coin_state_maintainer.hpp) AND the voting MN still resolves by
+/// collateral in the DMN list at tally time (weight seam below — UNFILTERED
+/// by PoSe-ban, dashcore GetMNByCollateral; only the threshold DENOMINATOR is
+/// valid-weighted). An incomplete / unverified / sub-threshold view yields NO
+/// winning trigger, so the arm refuses and routes to the reward-safe dashd
+/// fallback — the mandate: NEVER guess superblock payees.
 
 #include <impl/dash/coin/governance_object.hpp>
 
@@ -69,7 +70,10 @@ inline int governance_funding_threshold(int weighted_mn_count, int min_quorum)
 /// Keyed by the voting masternode's collateral outpoint so a re-vote replaces
 /// the prior (dashcore keeps only the latest vote per (MN, signal) pair).
 struct GovFundingVote {
-    int32_t outcome{VOTE_OUTCOME_NONE};  // YES / NO / ABSTAIN
+    int32_t outcome{VOTE_OUTCOME_NONE};  // NONE / YES / NO / ABSTAIN — NONE is
+                                         // a STORED outcome (dashcore parity:
+                                         // a newer NONE replaces a stored YES,
+                                         // dropping the yes-count)
     int64_t timestamp{0};                // newer replaces older
 };
 
@@ -93,9 +97,14 @@ public:
     /// Vote-weight + membership-at-tally seam (dashcore CountMatchingVotes):
     /// given a voting MN's collateral-outpoint key ("<txid>-<index>"), return
     /// its CURRENT voting weight — DASH_VOTE_WEIGHT_REGULAR (1) for a regular
-    /// MN, DASH_VOTE_WEIGHT_EVO (4) for an EvoNode, and 0 when the outpoint is
-    /// NOT in the valid MN set at tally time (dashcore drops such votes from
-    /// the count: GetMNByCollateral == nullptr => not counted).
+    /// MN, DASH_VOTE_WEIGHT_EVO (4) for an EvoNode, and 0 ONLY when the
+    /// outpoint is not in the DMN list at all at tally time (dashcore drops
+    /// exactly those votes: GetMNByCollateral == nullptr => not counted).
+    /// GetMNByCollateral is the UNFILTERED lookup — a PoSe-BANNED MN still
+    /// resolves and its vote still counts at FULL weight in dashd; do NOT
+    /// filter by ban status here (see gov_vote_weight_for_key in
+    /// coin_state_maintainer.hpp — the threshold DENOMINATOR alone is
+    /// valid-weighted, dashcore's own asymmetry).
     ///
     /// UNSET (default) => every vote weighs 0 => no tally can reach any
     /// positive threshold => FAIL CLOSED. NOTE for the follow-up implementer:
@@ -135,16 +144,37 @@ public:
                                    int32_t outcome, int64_t timestamp) {
         auto& per_obj = m_funding_votes[parent_hash];
         auto it = per_obj.find(mn_outpoint_key);
-        if (it != per_obj.end() && it->second.timestamp >= timestamp)
-            return; // keep the newer vote (dashcore latest-wins per MN)
+        if (it != per_obj.end()) {
+            // dashcore v23.1.7 CGovernanceObject::ProcessVote replacement rule
+            // (governance/object.cpp), matched EXACTLY:
+            //   new nTime <  stored  => "Obsolete vote"            => reject
+            //   new nTime == stored  => reject ONLY when the new OUTCOME <
+            //                           the stored outcome (upstream's
+            //                           explicit "arbitrary comparison ... to
+            //                           pick the winning vote" tie-break);
+            //                           otherwise accept (replace)
+            //   new nTime >  stored  => accept (replace) — ANY valid outcome,
+            //                           including NONE (a newer NONE drops a
+            //                           stored YES from the tally)
+            // A diverging rule here means c2pool and dashd keep DIFFERENT
+            // latest-votes for the same MN => tally divergence => the wrong
+            // trigger can win locally => wrong superblock payees.
+            if (timestamp < it->second.timestamp) return;
+            if (timestamp == it->second.timestamp &&
+                outcome < it->second.outcome)
+                return;
+        }
         per_obj[mn_outpoint_key] = GovFundingVote{outcome, timestamp};
     }
 
     /// dashcore CGovernanceObject::GetAbsoluteYesCount(VOTE_SIGNAL_FUNDING) ==
     /// GetYesCount - GetNoCount, where CountMatchingVotes weighs every vote by
-    /// the voting MN's CURRENT weight (EvoNodes 4x) and counts nothing for an
-    /// MN no longer in the valid set (membership-at-tally). With the weight
-    /// seam unset every vote weighs 0 (fail closed).
+    /// the voting MN's CURRENT weight (EvoNodes 4x) and counts nothing ONLY
+    /// for an MN no longer in the DMN list at all (membership-at-tally via the
+    /// unfiltered GetMNByCollateral — PoSe-banned MNs still count). A stored
+    /// NONE/ABSTAIN outcome contributes to neither side (but a NONE that
+    /// REPLACED a YES has already removed that yes — dashcore parity). With
+    /// the weight seam unset every vote weighs 0 (fail closed).
     int absolute_yes_count(const uint256& object_hash) const {
         auto it = m_funding_votes.find(object_hash);
         if (it == m_funding_votes.end()) return 0;

--- a/src/impl/dash/coin/vendor/bls_verify.cpp
+++ b/src/impl/dash/coin/vendor/bls_verify.cpp
@@ -191,41 +191,55 @@ bool verify_govvote_operator_sig(
     const bls::Bytes msg(digest.data(), 32);   // GetSignatureHash() digest bytes
 
     try {
-        // The SIGNING scheme (signature wire-encoding + verify DST) and the
-        // OPERATOR KEY's wire-encoding are INDEPENDENT, and dashcore treats them
-        // so: a masternode registered under LEGACY_BLS (nVersion 1) keeps a
-        // legacy-encoded pubKeyOperator forever, yet post-V19 it signs its
-        // governance votes under the CURRENT (BASIC) scheme — a basic-encoded
-        // signature verified with the basic DST. (Pinned against the real
-        // from-wire testnet vote: legacy-encoded pubkey + basic-encoded sig +
-        // basic DST verifies; every other combination fails.) So we vary the
-        // two axes independently: the network signing scheme (BASIC first,
-        // post-V19) drives sig-encoding + DST together; the key's declared
-        // scheme drives the pubkey encoding, other as fallback. A forged/
-        // tampered sig or wrong key verifies under NO combination — this only
-        // widens which LEGITIMATE encodings are accepted, never what is
-        // cryptographically valid.
-        for (bool net_legacy : {false, true}) {   // BASIC (post-V19) first
-            bls::G2Element sig;
+        // ── SIGNATURE axis: HARD-PINNED to the BASIC scheme ─────────────────
+        // dashcore v23.1.7 governance/vote.cpp CGovernanceVote::CheckSignature
+        // (const CBLSPublicKey&):
+        //     CBLSSignature sig;
+        //     sig.SetBytes(vchSig, false);                       // BASIC decode
+        //     sig.VerifyInsecure(pubKey, GetSignatureHash(), false);  // BASIC DST
+        // Both the sig wire-decode AND the verify DST are hard-pinned false
+        // (basic). SetBytes has NO legacy retry — the CheckMalleable/legacy
+        // fallback exists only in the stream Unserialize path, which this
+        // verify never takes. So post-V19 dashd REJECTS a legacy-scheme-signed
+        // governance vote outright, and so must we: a legacy-sig fallback here
+        // would accept votes dashd neither tallies nor relays — a hostile
+        // registered MN could legacy-sign a YES on a near-threshold trigger
+        // and feed it ONLY to c2pool, inflating our tally vs the network's
+        // (wrong trigger wins => wrong superblock payees => lost block).
+        // Pre-V19 heights would be legacy-scheme, but this tally only ever
+        // runs post-V19 (triggers are cycle-ephemeral and the serve floor is
+        // post-V19); if that ever changes, gate the scheme on the V19 fork
+        // height exactly as dashcore does — never fall back per-vote.
+        bls::G2Element sig;
+        try {
+            sig = bls::G2Element::FromBytes(
+                bls::Bytes(vch_sig.data(), vch_sig.size()), /*fLegacy=*/false);
+        } catch (...) {
+            return false;   // not a basic-encoded G2 point => dashd rejects too
+        }
+
+        // ── PUBKEY-encoding axis: declared scheme first, other as fallback ──
+        // Independent of the signature axis, and the fallback here is KEPT: a
+        // masternode registered under LEGACY_BLS (ProRegTx nVersion 1) keeps a
+        // legacy-ENCODED pubKeyOperator forever, and dashcore's
+        // CBLSLazyPublicKey ingest decodes it per that registration version
+        // BEFORE CheckSignature ever sees it (pubKeyOperator.Get() hands over
+        // the decoded element — the key's encoding never reaches the verify).
+        // We decode from the raw wire bytes ourselves, so we mirror that
+        // ingest: the key's declared scheme first, the other encoding as
+        // fallback. (Pinned against the real from-wire testnet vote:
+        // legacy-encoded pubkey + basic-encoded sig + basic DST verifies; a
+        // forged/tampered sig or wrong key verifies under NO pubkey encoding.)
+        for (bool pk_legacy : {key_legacy_scheme, !key_legacy_scheme}) {
+            bls::G1Element pk;
             try {
-                sig = bls::G2Element::FromBytes(
-                    bls::Bytes(vch_sig.data(), vch_sig.size()), net_legacy);
+                pk = bls::G1Element::FromBytes(
+                    bls::Bytes(pubkey_operator.data(), pubkey_operator.size()),
+                    pk_legacy);
             } catch (...) { continue; }
+            if (!pk.IsValid()) continue;
 
-            for (bool pk_legacy : {key_legacy_scheme, !key_legacy_scheme}) {
-                bls::G1Element pk;
-                try {
-                    pk = bls::G1Element::FromBytes(
-                        bls::Bytes(pubkey_operator.data(), pubkey_operator.size()),
-                        pk_legacy);
-                } catch (...) { continue; }
-                if (!pk.IsValid()) continue;
-
-                const bool ok = net_legacy
-                    ? bls::LegacySchemeMPL().Verify(pk, msg, sig)
-                    : bls::BasicSchemeMPL().Verify(pk, msg, sig);
-                if (ok) return true;
-            }
+            if (bls::BasicSchemeMPL().Verify(pk, msg, sig)) return true;
         }
         return false;
     } catch (...) {

--- a/src/impl/dash/coin/vendor/bls_verify.cpp
+++ b/src/impl/dash/coin/vendor/bls_verify.cpp
@@ -171,6 +171,69 @@ bool verify_final_commitment(const CFinalCommitment& c,
 #endif // C2POOL_DASH_BLS
 }
 
+// ── R3: governance-vote operator-key single-sig verify ──────────────────────
+
+bool verify_govvote_operator_sig(
+    const std::array<uint8_t, CFinalCommitment::BLS_PUBKEY_SIZE>& pubkey_operator,
+    bool key_legacy_scheme, const uint256& digest,
+    const std::vector<uint8_t>& vch_sig)
+{
+#ifndef C2POOL_DASH_BLS
+    (void)pubkey_operator;
+    (void)key_legacy_scheme;
+    (void)digest;
+    (void)vch_sig;
+    return false;   // no BLS backend → fail closed (vote never tallied → dashd)
+#else
+    // dashcore CGovernanceVote::CheckSignature: a BLS signature is 96 bytes.
+    if (vch_sig.size() != CFinalCommitment::BLS_SIG_SIZE) return false;
+
+    const bls::Bytes msg(digest.data(), 32);   // GetSignatureHash() digest bytes
+
+    try {
+        // The SIGNING scheme (signature wire-encoding + verify DST) and the
+        // OPERATOR KEY's wire-encoding are INDEPENDENT, and dashcore treats them
+        // so: a masternode registered under LEGACY_BLS (nVersion 1) keeps a
+        // legacy-encoded pubKeyOperator forever, yet post-V19 it signs its
+        // governance votes under the CURRENT (BASIC) scheme — a basic-encoded
+        // signature verified with the basic DST. (Pinned against the real
+        // from-wire testnet vote: legacy-encoded pubkey + basic-encoded sig +
+        // basic DST verifies; every other combination fails.) So we vary the
+        // two axes independently: the network signing scheme (BASIC first,
+        // post-V19) drives sig-encoding + DST together; the key's declared
+        // scheme drives the pubkey encoding, other as fallback. A forged/
+        // tampered sig or wrong key verifies under NO combination — this only
+        // widens which LEGITIMATE encodings are accepted, never what is
+        // cryptographically valid.
+        for (bool net_legacy : {false, true}) {   // BASIC (post-V19) first
+            bls::G2Element sig;
+            try {
+                sig = bls::G2Element::FromBytes(
+                    bls::Bytes(vch_sig.data(), vch_sig.size()), net_legacy);
+            } catch (...) { continue; }
+
+            for (bool pk_legacy : {key_legacy_scheme, !key_legacy_scheme}) {
+                bls::G1Element pk;
+                try {
+                    pk = bls::G1Element::FromBytes(
+                        bls::Bytes(pubkey_operator.data(), pubkey_operator.size()),
+                        pk_legacy);
+                } catch (...) { continue; }
+                if (!pk.IsValid()) continue;
+
+                const bool ok = net_legacy
+                    ? bls::LegacySchemeMPL().Verify(pk, msg, sig)
+                    : bls::BasicSchemeMPL().Verify(pk, msg, sig);
+                if (ok) return true;
+            }
+        }
+        return false;
+    } catch (...) {
+        return false;   // any relic/dashbls throw → fail closed
+    }
+#endif // C2POOL_DASH_BLS
+}
+
 // ── seam factory ────────────────────────────────────────────────────────────
 
 std::function<bool(const CFinalCommitment&)>

--- a/src/impl/dash/coin/vendor/bls_verify.hpp
+++ b/src/impl/dash/coin/vendor/bls_verify.hpp
@@ -105,6 +105,42 @@ using MemberKeysProvider =
 std::function<bool(const CFinalCommitment&)>
 make_commitment_bls_verifier(MemberKeysProvider provider);
 
+// ── R3: governance-vote operator-key signature verify ───────────────────────
+//
+// Daemonless superblock serving (E-SUPERBLOCK) needs to VERIFY that a relayed
+// TRIGGER funding vote was really signed by the voting masternode — else the
+// GovernanceStore tally counts nothing (fail closed) and every superblock
+// height falls back to dashd. This is the SINGLE-signature analogue of the
+// aggregate quorum-commitment verify above: one sig, one operator key, no
+// aggregation.
+//
+// Contract (dashcore CGovernanceVote::CheckSignature(const CBLSPublicKey&)):
+//   CBLSSignature sig; sig.SetByteVector(vchSig, legacy);
+//   sig.VerifyInsecure(pubKeyOperator, GetSignatureHash(), legacy);
+// i.e. VerifyInsecure == scheme.Verify(pubKeyOperator_G1, digest_bytes,
+// vchSig_G2). TRIGGER funding votes are signed by the MN's OPERATOR key (NOT
+// the ECDSA voting key — that path is PROPOSAL-funding-only). `digest` is the
+// govvote_signature_hash preimage (governance_object.hpp), i.e. dashcore
+// GetSignatureHash(). `key_legacy_scheme` reflects the operator key's declared
+// wire scheme (MNState nVersion: LEGACY_BLS => true, BASIC_BLS => false).
+// IMPORTANT (pinned against a real from-wire testnet vote): the key's
+// wire-encoding and the SIGNING scheme are INDEPENDENT — a LEGACY_BLS-registered
+// MN keeps a legacy-encoded pubkey but post-V19 signs under the BASIC scheme
+// (basic-encoded sig + basic DST). The implementation therefore varies the two
+// axes independently (network sig-scheme BASIC-first for sig-encoding+DST; the
+// key's declared scheme first for the pubkey encoding). A forged/tampered sig or
+// wrong key verifies under NO combination — this only broadens which LEGITIMATE
+// encodings are accepted, never what is cryptographically valid.
+//
+// FAIL-CLOSED (reward-critical): returns false when the BLS backend is absent,
+// vch_sig is not 96 bytes, either point fails to deserialize, or the BLS verify
+// fails — so an unverified vote is NEVER tallied. Never throws.
+bool verify_govvote_operator_sig(
+    const std::array<uint8_t, CFinalCommitment::BLS_PUBKEY_SIZE>& pubkey_operator,
+    bool key_legacy_scheme,
+    const uint256& digest,
+    const std::vector<uint8_t>& vch_sig);
+
 } // namespace vendor
 } // namespace coin
 } // namespace dash

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -482,6 +482,21 @@ if (BUILD_TESTING AND GTest_FOUND)
     target_link_libraries(test_dash_superblock PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39): core stratum/web_server TUs
     gtest_add_tests(test_dash_superblock "" AUTO)
 
+    # R3 — governance-vote BLS operator-key verify KAT. Links dash_bls_verify
+    # (the ONLY test that does): the real from-wire DELETE-signal vote verifies
+    # against the real MN operator key; tamper/wrong-key/wrong-digest/wrong-size
+    # reject; the synthetic end-to-end pins the fail-closed threshold ladder.
+    add_executable(test_dash_govvote_bls test_dash_govvote_bls.cpp)
+    target_link_libraries(test_dash_govvote_bls PRIVATE
+        GTest::gtest_main GTest::gtest
+        dash_bls_verify
+        dash_x11 core
+        nlohmann_json::nlohmann_json
+        ${Boost_LIBRARIES}
+    )
+    target_link_libraries(test_dash_govvote_bls PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)
+    gtest_add_tests(test_dash_govvote_bls "" AUTO)
+
     # DASH external-dashd RPC creds-resolution KAT (launcher slice 4): dash.conf
     # rpcuser/rpcpassword/rpcport parse + --coin-rpc endpoint override + armed()
     # gating that main_dash --run consults before ARMing the submitblock fallback.

--- a/test/test_dash_govvote_bls.cpp
+++ b/test/test_dash_govvote_bls.cpp
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/// R3 — governance-vote BLS operator-key signature verification KATs.
+///
+/// This is the piece that ENABLES daemonless superblock serving: #810's govsync
+/// store tallies a funding vote ONLY when the maintainer's vote-verifier accepts
+/// its signature. R3 makes that verifier real — dashcore CGovernanceVote::
+/// CheckSignature(const CBLSPublicKey&): a TRIGGER funding vote is BLS-signed by
+/// the voting masternode's OPERATOR key (NOT the ECDSA voting key — that path is
+/// PROPOSAL-funding-only) over govvote_signature_hash().
+///
+/// ───────────────────────── REAL vs SYNTHETIC ─────────────────────────
+/// REAL (from-wire) vector — captured read-only from testnet dashd
+/// @192.168.86.52 (P2P 19999 govobjvote + RPC 19998 protx/gobject):
+///
+///   * Governance object 4fe428f7…140f ("infraclaw-delete-test-20260716",
+///     ObjectType 1 = proposal).
+///   * A DELETE-signal vote on it (gobject getcurrentvotes vote-hash
+///     3760895388…c43f). DELETE (signal 3) votes — like TRIGGER FUNDING votes —
+///     are BLS-signed by the MN OPERATOR key, so they exercise the EXACT crypto
+///     path R3 adds. Captured govobjvote: 96-byte vchSig (BLS, not the 65-byte
+///     ECDSA a proposal-FUNDING vote carries — that contrast is pinned below).
+///   * The voting MN (collateral 4ee3ff50…e7a8-95, proTxHash bc77a5a2…b121)
+///     operator key from `protx list registered true`: pubKeyOperator
+///     174de566…4a8f, registration version 1 (LEGACY_BLS), type Regular,
+///     PoSeBanHeight -1 (valid).
+///
+/// A FUNDED superblock TRIGGER with real trigger-funding votes does NOT exist on
+/// testnet (top proposal is under the funding threshold — governance never
+/// promoted a trigger), so the end-to-end THRESHOLD → winner → payee selection
+/// is exercised SYNTHETICALLY on the real GovernanceStore/maintainer code with a
+/// verifier stub, while the SIGNATURE-VERIFY primitive itself (the only new
+/// crypto R3 introduces) is pinned against the REAL from-wire operator-key vote
+/// above. A tampered sig / wrong key / wrong digest / wrong size all REJECT.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/utxo_adapter.hpp>          // dash_txid (subsidy template dep)
+#include <impl/dash/coin/governance_object.hpp>     // govvote_signature_hash
+#include <impl/dash/coin/governance_store.hpp>      // GovernanceStore, weights
+#include <impl/dash/coin/node_coin_state.hpp>
+#include <impl/dash/coin/coin_state_maintainer.hpp> // on_govvote / set_vote_verifier
+#include <impl/dash/coin/vendor/bls_verify.hpp>     // verify_govvote_operator_sig
+
+#include <core/uint256.hpp>
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace {
+
+using dash::coin::vendor::verify_govvote_operator_sig;
+using dash::coin::vendor::bls_backend_available;
+using dash::coin::VOTE_OUTCOME_YES;
+using dash::coin::VOTE_OUTCOME_NO;
+using dash::coin::VOTE_SIGNAL_FUNDING;
+
+// hex (big-endian, as printed) -> raw bytes, no reversal (opaque BLS wire bytes).
+std::vector<uint8_t> hx(const std::string& s) {
+    std::vector<uint8_t> out;
+    out.reserve(s.size() / 2);
+    for (size_t i = 0; i + 1 < s.size(); i += 2)
+        out.push_back(static_cast<uint8_t>(std::stoul(s.substr(i, 2), nullptr, 16)));
+    return out;
+}
+std::array<uint8_t, 48> pubkey48(const std::string& s) {
+    auto v = hx(s);
+    std::array<uint8_t, 48> a{};
+    for (size_t i = 0; i < 48 && i < v.size(); ++i) a[i] = v[i];
+    return a;
+}
+
+// ── REAL from-wire vector (testnet dashd, DELETE-signal operator-key vote) ────
+// Collateral outpoint hash is passed in DISPLAY order to uint256S (SetHex
+// reverses to the wire/internal bytes govvote_signature_hash serializes).
+const char* kMnCollateralDisplay =
+    "4ee3ff5074723d995f4cb957a954587c6c637a42655ada8f4054037b28d1e7a8";
+const uint32_t kMnCollateralIndex = 95;
+const char* kParentDisplay =
+    "4fe428f7b538ce0b3c08caf187894afcd7c867877495d0b28872c9f9e7e4140f";
+const int32_t kOutcome = 1;   // yes
+const int32_t kSignal  = 3;   // DELETE (operator-key path, same as trigger-FUNDING)
+const int64_t kTime    = 1784232979;
+const char* kVchSigHex =
+    "8918e91decb5ca31bf75d6120f1cf36c5df3249f0b7b6e4329d4b7229180da4e"
+    "c8644af2ceabd2b9666d23bd53294867068a5bd5b7d9433b310f12171d923a4c"
+    "5f961aaa7883d5af33c1a16aca56f4f650692f28ad095a0e32605cbb19608d7b";
+const char* kPubKeyOperatorHex =
+    "174de56654f2bb6417e15ff06361ea0becc00bd72a3eba0f83b60feac8605707"
+    "69fbf28482a706f10906a1e96dae4a8f";
+const bool kKeyLegacyScheme = true;   // protx state.version == 1 => LEGACY_BLS
+
+uint256 real_vote_digest() {
+    return dash::coin::govvote_signature_hash(
+        uint256S(kMnCollateralDisplay), kMnCollateralIndex,
+        uint256S(kParentDisplay), kOutcome, kSignal, kTime);
+}
+
+// ── 1. REAL vote sig VERIFIES against the real operator key ──────────────────
+// Simultaneously pins: (a) the govvote_signature_hash preimage (a wrong digest
+// would not verify), (b) the BLS operator-key verify, (c) the scheme handling.
+TEST(DashGovVoteBLS, RealDeleteVoteVerifiesAgainstOperatorKey) {
+    if (!bls_backend_available())
+        GTEST_SKIP() << "built without C2POOL_DASH_BLS — verifier is a fail-closed stub";
+    EXPECT_TRUE(verify_govvote_operator_sig(
+        pubkey48(kPubKeyOperatorHex), kKeyLegacyScheme,
+        real_vote_digest(), hx(kVchSigHex)));
+}
+
+// ── 2. TAMPERED sig REJECTS ──────────────────────────────────────────────────
+TEST(DashGovVoteBLS, TamperedSignatureRejects) {
+    if (!bls_backend_available()) GTEST_SKIP();
+    auto sig = hx(kVchSigHex);
+    sig[0] ^= 0x01;                                   // flip one bit
+    EXPECT_FALSE(verify_govvote_operator_sig(
+        pubkey48(kPubKeyOperatorHex), kKeyLegacyScheme,
+        real_vote_digest(), sig));
+    auto sig2 = hx(kVchSigHex);
+    sig2[sig2.size() - 1] ^= 0x80;                    // flip a trailing bit
+    EXPECT_FALSE(verify_govvote_operator_sig(
+        pubkey48(kPubKeyOperatorHex), kKeyLegacyScheme,
+        real_vote_digest(), sig2));
+}
+
+// ── 3. WRONG operator key REJECTS ────────────────────────────────────────────
+TEST(DashGovVoteBLS, WrongOperatorKeyRejects) {
+    if (!bls_backend_available()) GTEST_SKIP();
+    auto pk = pubkey48(kPubKeyOperatorHex);
+    pk[0] ^= 0x01;                                    // a different (still-valid-form) key
+    EXPECT_FALSE(verify_govvote_operator_sig(
+        pk, kKeyLegacyScheme, real_vote_digest(), hx(kVchSigHex)));
+}
+
+// ── 4. WRONG digest (any signed field mutated) REJECTS ───────────────────────
+TEST(DashGovVoteBLS, WrongDigestRejects) {
+    if (!bls_backend_available()) GTEST_SKIP();
+    // time+1 → a different GetSignatureHash → the real sig no longer matches.
+    uint256 bad = dash::coin::govvote_signature_hash(
+        uint256S(kMnCollateralDisplay), kMnCollateralIndex,
+        uint256S(kParentDisplay), kOutcome, kSignal, kTime + 1);
+    EXPECT_FALSE(verify_govvote_operator_sig(
+        pubkey48(kPubKeyOperatorHex), kKeyLegacyScheme, bad, hx(kVchSigHex)));
+    // outcome flipped (yes→no) → different digest → reject.
+    uint256 bad2 = dash::coin::govvote_signature_hash(
+        uint256S(kMnCollateralDisplay), kMnCollateralIndex,
+        uint256S(kParentDisplay), 2 /*no*/, kSignal, kTime);
+    EXPECT_FALSE(verify_govvote_operator_sig(
+        pubkey48(kPubKeyOperatorHex), kKeyLegacyScheme, bad2, hx(kVchSigHex)));
+}
+
+// ── 5. WRONG-SIZE sig REJECTS (a 65-byte ECDSA proposal-FUNDING vote) ─────────
+// Real from-wire contrast: proposal FUNDING votes carry a 65-byte ECDSA
+// voting-key sig, NOT a BLS operator-key sig — the size guard fails them closed,
+// which is correct: the superblock tally consults only BLS trigger-funding votes.
+TEST(DashGovVoteBLS, EcdsaSizedSigRejects) {
+    if (!bls_backend_available()) GTEST_SKIP();
+    std::vector<uint8_t> ecdsa_sized(65, 0x20);       // 65 bytes, not 96
+    EXPECT_FALSE(verify_govvote_operator_sig(
+        pubkey48(kPubKeyOperatorHex), kKeyLegacyScheme,
+        real_vote_digest(), ecdsa_sized));
+    EXPECT_FALSE(verify_govvote_operator_sig(
+        pubkey48(kPubKeyOperatorHex), kKeyLegacyScheme,
+        real_vote_digest(), {}));                     // empty
+}
+
+// ── 6. END-TO-END fail-closed chain (synthetic trigger + tally) ──────────────
+// No REAL funded trigger exists on testnet, so the winner-selection ladder is
+// exercised on the real GovernanceStore code with synthetic triggers/votes. The
+// point: a superblock is served ONLY with enough VERIFIED funding votes past the
+// weighted threshold. Enabling the verifier must NOT open a serve path for an
+// under-verified or under-threshold trigger.
+namespace {
+uint256 h(uint8_t b) { uint256 x; x.data()[0] = b; return x; }   // distinct object hashes
+dash::coin::GovernanceTrigger mk_trigger(const uint256& oh, int32_t height) {
+    dash::coin::GovernanceTrigger t;
+    t.object_hash = oh;
+    t.event_block_height = height;
+    // one well-formed payee so the trigger is a valid schedule (amount is not
+    // consulted by the tally/selection under test here).
+    dash::coin::SuperblockPayment p;
+    p.script = {0x76, 0xa9, 0x14};   // opaque; selection doesn't parse it
+    p.amount = 1000;
+    t.payments.push_back(p);
+    return t;
+}
+} // namespace
+
+TEST(DashGovVoteBLS, TallyServesOnlyWithEnoughVerifiedVotes) {
+    dash::coin::GovernanceStore store;
+    const int32_t H = 1519824;
+    auto oh = h(0xAA);
+    store.add_trigger(mk_trigger(oh, H));
+
+    // Weight seam: 3 known regular MNs (weight 1 each), everything else 0.
+    store.set_vote_weight_fn([](const std::string& key) -> int {
+        if (key == "mn-1" || key == "mn-2" || key == "mn-3") return 1;
+        return 0;   // unknown MN / not in valid set → dropped
+    });
+    store.set_funding_threshold(3);   // need weighted-yes >= 3
+
+    // Two VERIFIED yes votes: 2 < 3 → NOT triggered (fail closed).
+    store.add_verified_funding_vote(oh, "mn-1", VOTE_OUTCOME_YES, 100);
+    store.add_verified_funding_vote(oh, "mn-2", VOTE_OUTCOME_YES, 100);
+    EXPECT_FALSE(store.is_superblock_triggered(H));
+    EXPECT_FALSE(store.get_best_superblock(H).has_value());
+
+    // Third verified yes → 3 >= 3 → triggered, winner is our trigger.
+    store.add_verified_funding_vote(oh, "mn-3", VOTE_OUTCOME_YES, 100);
+    EXPECT_TRUE(store.is_superblock_triggered(H));
+    auto best = store.get_best_superblock(H);
+    ASSERT_TRUE(best.has_value());
+    EXPECT_EQ(best->object_hash, oh);
+
+    // An unknown-MN vote adds 0 weight (membership-at-tally) — cannot push a
+    // sub-threshold trigger over on its own.
+    dash::coin::GovernanceStore store2;
+    store2.add_trigger(mk_trigger(oh, H));
+    store2.set_vote_weight_fn([](const std::string& k) -> int {
+        return (k == "mn-1") ? 1 : 0; });
+    store2.set_funding_threshold(3);
+    store2.add_verified_funding_vote(oh, "mn-1", VOTE_OUTCOME_YES, 100);
+    store2.add_verified_funding_vote(oh, "ghost-mn", VOTE_OUTCOME_YES, 100);
+    EXPECT_FALSE(store2.get_best_superblock(H).has_value());   // 1 weighted < 3
+
+    // Unknown/unset threshold fails closed even with votes past any count.
+    dash::coin::GovernanceStore store3;
+    store3.add_trigger(mk_trigger(oh, H));
+    store3.set_vote_weight_fn([](const std::string&) { return 1; });
+    // threshold left 0 (unset) → governance_funding_threshold semantics: closed.
+    store3.add_verified_funding_vote(oh, "a", VOTE_OUTCOME_YES, 100);
+    store3.add_verified_funding_vote(oh, "b", VOTE_OUTCOME_YES, 100);
+    EXPECT_FALSE(store3.get_best_superblock(H).has_value());
+}
+
+// ── 7. maintainer on_govvote gate: UNVERIFIED votes are never tallied ────────
+// The verifier seam is what makes the tally count anything. With it UNSET
+// (default) or REJECTING, a funding vote never reaches the store → fail closed.
+// With it ACCEPTING (the R3 wiring, modelled here by a stub that stands in for
+// the real BLS verify), verified votes tally and a funded trigger can win.
+TEST(DashGovVoteBLS, MaintainerCountsOnlyVerifiedVotes) {
+    using Ctx = dash::coin::CoinStateMaintainer::GovVoteContext;
+    const int32_t H = 1519824;
+    auto oh = h(0xBB);
+
+    auto build_ctx = [&](const std::string& key) {
+        Ctx v;
+        v.parent_hash = oh;
+        v.outcome = VOTE_OUTCOME_YES;
+        v.signal  = VOTE_SIGNAL_FUNDING;
+        v.time    = 100;
+        // vote_hash/vch_sig unused by the stub verifiers below.
+        return v;
+    };
+
+    // (a) verifier UNSET → default fail closed: nothing tallies.
+    {
+        dash::coin::NodeCoinState ncs;
+        dash::coin::CoinStateMaintainer m(ncs);
+        m.set_gov_params(/*testnet=*/true, /*min_quorum=*/1);
+        m.gov_store().add_trigger(mk_trigger(oh, H));
+        m.gov_store().set_vote_weight_fn([](const std::string&) { return 1; });
+        m.gov_store().set_funding_threshold(2);
+        m.on_govvote(build_ctx("mn-1"), "mn-1");
+        m.on_govvote(build_ctx("mn-2"), "mn-2");
+        EXPECT_FALSE(m.gov_store().get_best_superblock(H).has_value());
+    }
+    // (b) verifier REJECTS every vote → still fail closed.
+    {
+        dash::coin::NodeCoinState ncs;
+        dash::coin::CoinStateMaintainer m(ncs);
+        m.set_gov_params(true, 1);
+        m.gov_store().add_trigger(mk_trigger(oh, H));
+        m.gov_store().set_vote_weight_fn([](const std::string&) { return 1; });
+        m.gov_store().set_funding_threshold(2);
+        m.set_vote_verifier([](const Ctx&) { return false; });
+        m.on_govvote(build_ctx("mn-1"), "mn-1");
+        m.on_govvote(build_ctx("mn-2"), "mn-2");
+        EXPECT_FALSE(m.gov_store().get_best_superblock(H).has_value());
+    }
+    // (c) verifier ACCEPTS (stands in for the wired BLS verify) → verified votes
+    //     tally and, past threshold, the trigger wins.
+    {
+        dash::coin::NodeCoinState ncs;
+        dash::coin::CoinStateMaintainer m(ncs);
+        m.set_gov_params(true, 1);
+        m.gov_store().add_trigger(mk_trigger(oh, H));
+        m.gov_store().set_vote_weight_fn([](const std::string&) { return 1; });
+        m.gov_store().set_funding_threshold(2);
+        m.set_vote_verifier([](const Ctx&) { return true; });
+        m.on_govvote(build_ctx("mn-1"), "mn-1");
+        EXPECT_FALSE(m.gov_store().get_best_superblock(H).has_value());  // 1 < 2
+        m.on_govvote(build_ctx("mn-2"), "mn-2");
+        auto best = m.gov_store().get_best_superblock(H);
+        ASSERT_TRUE(best.has_value());
+        EXPECT_EQ(best->object_hash, oh);
+    }
+}
+
+} // namespace

--- a/test/test_dash_govvote_bls.cpp
+++ b/test/test_dash_govvote_bls.cpp
@@ -41,6 +41,15 @@
 #include <impl/dash/coin/coin_state_maintainer.hpp> // on_govvote / set_vote_verifier
 #include <impl/dash/coin/vendor/bls_verify.hpp>     // verify_govvote_operator_sig
 
+#ifdef C2POOL_DASH_BLS
+// Synthetic operator keypair for the legacy-scheme-signed-vote KAT (a
+// legacy-SIGNED vote cannot be captured from the wire — post-V19 dashd
+// rejects and never relays one; that is exactly the parity under test).
+#include <dashbls/bls.hpp>
+#include <dashbls/schemes.hpp>
+#include <dashbls/elements.hpp>
+#endif
+
 #include <core/uint256.hpp>
 
 #include <array>
@@ -52,6 +61,7 @@ namespace {
 
 using dash::coin::vendor::verify_govvote_operator_sig;
 using dash::coin::vendor::bls_backend_available;
+using dash::coin::VOTE_OUTCOME_NONE;
 using dash::coin::VOTE_OUTCOME_YES;
 using dash::coin::VOTE_OUTCOME_NO;
 using dash::coin::VOTE_SIGNAL_FUNDING;
@@ -295,6 +305,229 @@ TEST(DashGovVoteBLS, MaintainerCountsOnlyVerifiedVotes) {
         ASSERT_TRUE(best.has_value());
         EXPECT_EQ(best->object_hash, oh);
     }
+}
+
+// ═══════════ #818 review must-fix KATs — governance-tally dashcore parity ═══
+// All three are the SAME hazard class: c2pool tallying votes dashd does NOT
+// (or not counting ones it does) => tally divergence => wrong trigger wins =>
+// wrong superblock payees => lost block. Parity target: dashcore v23.1.7
+// governance/vote.cpp + governance/object.cpp.
+
+// ── 8. must-fix 1: a LEGACY-SCHEME-SIGNED vote REJECTS ───────────────────────
+// dashcore CGovernanceVote::CheckSignature(const CBLSPublicKey&) does
+// sig.SetBytes(vchSig, false) + sig.VerifyInsecure(pubKey, hash, false) — the
+// SIGNATURE axis is hard-pinned BASIC (SetBytes has no legacy/CheckMalleable
+// retry; that exists only in stream Unserialize). Post-V19 dashd therefore
+// REJECTS a legacy-scheme-signed governance vote. The pre-fix legacy-sig
+// fallback ACCEPTED it — a hostile registered MN could legacy-sign a YES on a
+// near-threshold trigger and feed it only to c2pool (dashd would not relay
+// it), inflating the local tally. FAILS on the pre-fix code / PASSES after.
+#ifdef C2POOL_DASH_BLS
+TEST(DashGovVoteBLS, LegacySchemeSignedVoteRejects) {
+    if (!bls_backend_available()) GTEST_SKIP();
+    std::vector<uint8_t> seed(32, 0x5a);
+    bls::PrivateKey sk = bls::BasicSchemeMPL().KeyGen(seed);
+    const uint256 digest = real_vote_digest();   // real vote structure/preimage
+    const bls::Bytes msg(digest.data(), 32);
+
+    // The hostile MN legacy-SIGNS the (otherwise well-formed) vote digest and
+    // may hand us the sig in either wire encoding, claiming either key
+    // registration — dashd rejects EVERY combination, and so must we.
+    bls::G2Element legacy_sig = bls::LegacySchemeMPL().Sign(sk, msg);
+    for (bool sig_enc_legacy : {true, false}) {
+        const std::vector<uint8_t> sig_bytes = legacy_sig.Serialize(sig_enc_legacy);
+        for (bool key_enc_legacy : {true, false}) {
+            const std::array<uint8_t, 48> pk48 =
+                sk.GetG1Element().SerializeToArray(key_enc_legacy);
+            EXPECT_FALSE(verify_govvote_operator_sig(
+                pk48, /*key_legacy_scheme=*/key_enc_legacy, digest, sig_bytes))
+                << "legacy-SIGNED vote accepted (sig_enc_legacy="
+                << sig_enc_legacy << ", key_enc_legacy=" << key_enc_legacy
+                << ") — dashd rejects it; tally-inflation hazard";
+        }
+    }
+
+    // Positive control: the SAME key BASIC-signs (the post-V19 network
+    // scheme) => ACCEPT — under BOTH pubkey wire-encodings and BOTH declared
+    // registration flags. This pins that must-fix 1 removed ONLY the
+    // signature-axis fallback and KEPT the pubkey-ENCODING fallback (dashcore
+    // CBLSLazyPublicKey ingest decodes the operator key per its registration
+    // version before CheckSignature ever sees it).
+    bls::G2Element basic_sig = bls::BasicSchemeMPL().Sign(sk, msg);
+    const std::vector<uint8_t> basic_sig_bytes = basic_sig.Serialize(false);
+    for (bool key_enc_legacy : {false, true}) {
+        const std::array<uint8_t, 48> pk48 =
+            sk.GetG1Element().SerializeToArray(key_enc_legacy);
+        for (bool declared_legacy : {false, true}) {
+            EXPECT_TRUE(verify_govvote_operator_sig(
+                pk48, declared_legacy, digest, basic_sig_bytes))
+                << "basic-signed vote must verify (key_enc_legacy="
+                << key_enc_legacy << ", declared_legacy=" << declared_legacy
+                << ") — pubkey-encoding fallback must be preserved";
+        }
+    }
+}
+#endif // C2POOL_DASH_BLS
+
+// ── 9. must-fix 2: banned-MN votes COUNT; threshold denominator is VALID-only ─
+// dashcore resolves the voting MN with the UNFILTERED GetMNByCollateral in
+// BOTH CGovernanceVote::IsValid and CGovernanceObject::CountMatchingVotes — a
+// PoSe-BANNED MN's vote verifies and counts at FULL weight. Only the funding
+// THRESHOLD denominator (UpdateSentinelVariables: max(minQuorum,
+// m_valid_weighted/10)) is computed over the VALID set. Pre-fix c2pool
+// filtered banned MNs out of both closures: natural PoSe-ban churn (no
+// attacker needed) then dropped e.g. a banned MN's NO and inflated yes−no vs
+// dashd. FAILS on the pre-fix semantics / PASSES after.
+TEST(DashGovVoteBLS, BannedMnVoteCountsAtWeightThresholdUsesValidSet) {
+    using dash::coin::gov_mn_by_collateral;
+    using dash::coin::gov_vote_weight_for_key;
+
+    dash::coin::NodeCoinState ncs;
+    dash::coin::CoinStateMaintainer m(ncs);
+
+    // SML: 30 valid + 20 PoSe-banned regular MNs. The DENOMINATOR half of the
+    // asymmetry: valid-weighted = 30 => threshold = max(1, 30/10) = 3 — the
+    // banned 20 are EXCLUDED here (dashcore m_valid_weighted), even though
+    // their votes still count below.
+    for (int i = 0; i < 50; ++i) {
+        dash::coin::vendor::CSimplifiedMNListEntry e;
+        e.isValid = (i < 30);
+        e.nType   = dash::coin::vendor::CSimplifiedMNListEntry::TYPE_REGULAR;
+        ncs.sml().mnList.push_back(e);
+    }
+    m.set_gov_params(/*testnet=*/true, /*min_quorum=*/1);   // reseeds threshold
+    EXPECT_EQ(m.gov_store().funding_threshold(), 3)
+        << "threshold denominator must be the VALID-weighted count only";
+
+    // DMN view: one valid regular MN, one PoSe-BANNED EvoNode.
+    dash::coin::MNState valid_mn;
+    valid_mn.collateralOutpoint.hash  = h(0x01);
+    valid_mn.collateralOutpoint.index = 1;
+    valid_mn.isValid = true;
+    valid_mn.nType   = dash::coin::vendor::MnType::REGULAR;
+
+    dash::coin::MNState banned_evo;
+    banned_evo.collateralOutpoint.hash  = h(0x02);
+    banned_evo.collateralOutpoint.index = 2;
+    banned_evo.isValid = false;                             // PoSe-banned
+    banned_evo.nType   = dash::coin::vendor::MnType::EVO;
+
+    ncs.mnstates().load({{h(0x11), valid_mn}, {h(0x12), banned_evo}});
+
+    const std::string valid_key =
+        valid_mn.collateralOutpoint.hash.GetHex() + "-1";
+    const std::string banned_key =
+        banned_evo.collateralOutpoint.hash.GetHex() + "-2";
+
+    // VERIFY path (CGovernanceVote::IsValid): the banned MN still RESOLVES —
+    // its vote reaches the BLS verify (unfiltered GetMNByCollateral).
+    EXPECT_NE(gov_mn_by_collateral(ncs.mnstates(),
+                                   banned_evo.collateralOutpoint),
+              nullptr)
+        << "banned MN must resolve on the verify path (dashd verifies its vote)";
+
+    // TALLY path (CountMatchingVotes): banned EvoNode counts at FULL weight 4;
+    // an unknown collateral is the ONLY membership drop dashcore performs.
+    EXPECT_EQ(gov_vote_weight_for_key(ncs.mnstates(), valid_key), 1);
+    EXPECT_EQ(gov_vote_weight_for_key(ncs.mnstates(), banned_key), 4)
+        << "banned MN's vote must count at full weight (dashcore unfiltered)";
+    EXPECT_EQ(gov_vote_weight_for_key(ncs.mnstates(),
+                                      h(0x03).GetHex() + "-0"), 0);
+
+    // End-to-end through the store with the wired weight fn: the banned
+    // EvoNode's verified YES (weight 4) alone reaches the valid-only
+    // threshold 3; its later NO pulls the tally NEGATIVE — exactly the swing
+    // the pre-fix isValid filter would have hidden.
+    const int32_t H = 1519824;
+    auto oh = h(0xCC);
+    auto& store = m.gov_store();
+    store.add_trigger(mk_trigger(oh, H));
+    store.set_vote_weight_fn([&ncs](const std::string& k) {
+        return dash::coin::gov_vote_weight_for_key(ncs.mnstates(), k);
+    });
+    store.add_verified_funding_vote(oh, banned_key, VOTE_OUTCOME_YES, 100);
+    EXPECT_EQ(store.absolute_yes_count(oh), 4);
+    EXPECT_TRUE(store.is_superblock_triggered(H));
+    store.add_verified_funding_vote(oh, banned_key, VOTE_OUTCOME_NO, 101);
+    EXPECT_EQ(store.absolute_yes_count(oh), -4)
+        << "a banned MN's NO must count (dropping it inflates yes-no vs dashd)";
+    EXPECT_FALSE(store.is_superblock_triggered(H));
+}
+
+// ── 10. must-fix 3: NONE replaces a stored YES; exact replacement tie-break ──
+// dashcore CGovernanceObject::ProcessVote STORES outcome NONE (IsValid's
+// outcome range starts AT VOTE_OUTCOME_NONE) — a newer NONE replaces a stored
+// YES and the yes-count drops. Replacement rule, matched exactly: reject when
+// new nTime < stored ("Obsolete vote"); on EQUAL nTime reject ONLY when the
+// new outcome < the stored outcome (upstream's explicit tie-break); otherwise
+// replace. Pre-fix c2pool dropped NONE (stale YES lingered after the voter
+// withdrew it) and rejected ALL equal-nTime re-votes. FAILS pre-fix / PASSES
+// after.
+TEST(DashGovVoteBLS, NoneVoteReplacesYesAndEqualTimeTieBreakMatchesDashcore) {
+    dash::coin::GovernanceStore store;
+    const int32_t H = 1519824;
+    auto oh = h(0xDD);
+    store.add_trigger(mk_trigger(oh, H));
+    store.set_vote_weight_fn([](const std::string&) { return 1; });
+    store.set_funding_threshold(1);
+
+    store.add_verified_funding_vote(oh, "mn-1", VOTE_OUTCOME_YES, 100);
+    EXPECT_EQ(store.absolute_yes_count(oh), 1);
+    EXPECT_TRUE(store.is_superblock_triggered(H));
+
+    // Newer NONE REPLACES the stored YES → yes-count drops, trigger unfunds.
+    store.add_verified_funding_vote(oh, "mn-1", VOTE_OUTCOME_NONE, 101);
+    EXPECT_EQ(store.absolute_yes_count(oh), 0)
+        << "a newer NONE must remove the stored YES from the tally";
+    EXPECT_FALSE(store.is_superblock_triggered(H));
+
+    // Obsolete (older nTime) => rejected.
+    store.add_verified_funding_vote(oh, "mn-1", VOTE_OUTCOME_YES, 50);
+    EXPECT_EQ(store.absolute_yes_count(oh), 0);
+
+    // Equal-nTime tie-break — reject ONLY new outcome < stored:
+    // stored NONE(0)@101, new YES(1)@101: 1 >= 0 => ACCEPTED (replaces).
+    store.add_verified_funding_vote(oh, "mn-1", VOTE_OUTCOME_YES, 101);
+    EXPECT_EQ(store.absolute_yes_count(oh), 1);
+    // stored YES(1)@101, new NONE(0)@101: 0 < 1 => REJECTED.
+    store.add_verified_funding_vote(oh, "mn-1", VOTE_OUTCOME_NONE, 101);
+    EXPECT_EQ(store.absolute_yes_count(oh), 1);
+    // stored YES(1)@101, new NO(2)@101: 2 >= 1 => ACCEPTED (yes -> no).
+    store.add_verified_funding_vote(oh, "mn-1", VOTE_OUTCOME_NO, 101);
+    EXPECT_EQ(store.absolute_yes_count(oh), -1);
+}
+
+// ── 11. must-fix 3 (ingest leg): on_govvote must NOT drop outcome NONE ───────
+TEST(DashGovVoteBLS, MaintainerIngestsNoneVote) {
+    using Ctx = dash::coin::CoinStateMaintainer::GovVoteContext;
+    const int32_t H = 1519824;
+    auto oh = h(0xEE);
+
+    dash::coin::NodeCoinState ncs;
+    dash::coin::CoinStateMaintainer m(ncs);
+    m.set_gov_params(true, 1);
+    m.gov_store().add_trigger(mk_trigger(oh, H));
+    m.gov_store().set_vote_weight_fn([](const std::string&) { return 1; });
+    m.gov_store().set_funding_threshold(1);
+    m.set_vote_verifier([](const Ctx&) { return true; });
+
+    Ctx yes;
+    yes.parent_hash = oh;
+    yes.outcome = VOTE_OUTCOME_YES;
+    yes.signal  = VOTE_SIGNAL_FUNDING;
+    yes.time    = 100;
+    m.on_govvote(yes, "mn-1");
+    EXPECT_TRUE(m.gov_store().is_superblock_triggered(H));
+
+    // The voter withdraws: a newer NONE vote. Pre-fix on_govvote dropped it
+    // at the outcome filter and the stale YES kept the trigger funded here
+    // while dashd's tally had already dropped it.
+    Ctx none = yes;
+    none.outcome = VOTE_OUTCOME_NONE;
+    none.time    = 101;
+    m.on_govvote(none, "mn-1");
+    EXPECT_FALSE(m.gov_store().is_superblock_triggered(H))
+        << "on_govvote must ingest NONE — the withdrawn YES must leave the tally";
 }
 
 } // namespace


### PR DESCRIPTION
## R3 — governance-vote BLS operator-key verification (enables daemonless superblock serving)

**DO-NOT-MERGE draft.** Base: `dash/embedded-superblock-govsync` (#810). Depends on #810 (govsync superblock sourcing) + the dashbls BLS lib from the #814/#812 stack (brought in here).

### Problem
#810's daemonless superblock arm is **fail-closed-inert**: its vote-verifier seam (`CoinStateMaintainer::set_vote_verifier`) is UNSET, so no funding vote is counted → no trigger reaches threshold → every superblock height falls back to dashd. R3 makes that verifier real.

### What R3 adds
- **`verify_govvote_operator_sig`** (`vendor/bls_verify.cpp`): single-signature verify of a governance vote's `vch_sig` against the voting MN's **operator** BLS key over `govvote_signature_hash()` — dashcore `CGovernanceVote::CheckSignature(const CBLSPublicKey&)`. TRIGGER funding votes are operator-key-signed (NOT the ECDSA voting key — that's proposal-funding-only, the #810 R3 finding). Sits alongside the aggregate quorum-commitment verify already in this TU. The key's wire-encoding (`LEGACY_BLS` registration) and the signing scheme (post-V19 `BASIC`) are **independent** and varied separately — pinned against a real from-wire vote.
- **Wiring** (`main_dash.cpp`, `--embedded-superblock`): `set_vote_verifier` resolves the voting MN by **collateral outpoint** in the live DMN view (`mnstates().find_by_collateral` → `pubKeyOperator` + `nVersion` scheme + `isValid`), enforces the `IsValid` time bound (`nTime <= now+1h`), then BLS-verifies. Companion `set_vote_weight_fn` (EvoNode 4x, Regular 1x, 0 when not in the valid set) wired from the same DMN view.
- **BLS lib**: root `CMakeLists` `C2POOL_DASH_BLS` option + `scripts/build_dashbls.sh` + `dash_bls_verify` static lib, from the #814 stack (Dash Core v23.1.7 `src/dashbls` subtree — the same lib dashd wraps). Default **OFF** → fail-closed stub, no dashbls dependency in any build (Windows `main_ltc` clean).

### Fail-closed chain HOLDS
Unverified votes never tally; a trigger wins only past the R4 weighted threshold (`max(minQuorum, weighted/10)`); **R5 completeness (`set_superblock_sync_complete_fn`) + the R6 desync latch remain UNWIRED**, so R3 alone can never open the serve path. Landing R3 keeps every superblock height fail-closed to dashd until R5 + a funded soak.

### KATs (`test_dash_govvote_bls`, links `dash_bls_verify`)
- **REAL from-wire** (testnet dashd @192.168.86.52, read-only): a DELETE-signal operator-key vote (96-byte BLS `vchSig`, object `4fe428f7…`, MN collateral `4ee3ff50…-95`, proTxHash `bc77a5a2…`, operator key `174de566…`) **verifies** against the real operator key. This simultaneously pins the `govvote_signature_hash` preimage, the BLS verify, and the scheme handling.
- **Tamper / wrong-key / wrong-digest / wrong-size REJECT** — incl. a 65-byte ECDSA proposal-FUNDING vote (real from-wire contrast: proposal-funding = ECDSA voting-key, delete/trigger = BLS operator-key).
- **Synthetic end-to-end**: no funded superblock trigger exists on testnet, so the threshold → winner → payee ladder + the maintainer's verified-only tally gate are pinned synthetically on the real `GovernanceStore`/maintainer code. Real-vector vs synthetic documented in the test header.

### Build / verify
`cmake … -DC2POOL_DASH_BLS=ON -DDASHBLS_ROOT=/home/ubuntu/dashbls`; `c2pool-dash` links dashbls; `test_dash_govvote_bls` 7/7 PASS, `test_dash_superblock` 24/24 PASS (no regression).


---

### Review must-fixes landed (015c9e72) — governance-tally dashcore-v23.1.7 parity
All three CHANGES-REQUIRED items were one hazard class: c2pool tallying votes dashd does NOT (or dropping ones dashd counts) → tally divergence → wrong trigger wins → wrong superblock payees → lost block. The crypto core is unchanged.

1. **Signature axis hard-pinned BASIC** (`vendor/bls_verify.cpp`): dashcore `CheckSignature` does `SetBytes(vchSig, false)` + `VerifyInsecure(…, false)` — no legacy-sig retry (that fallback exists only in stream `Unserialize`). The legacy-sig verify fallback (a superset of dashcore — tally-inflation vector via a hostile MN legacy-signing a YES that dashd rejects and never relays) is removed; the **pubkey-ENCODING** fallback is kept (mirrors `CBLSLazyPublicKey` ingest of `LEGACY_BLS`-registered keys). Pre-V19 note documented in-code: this tally only runs post-V19; if that ever changes, gate on the V19 fork height.
2. **PoSe-ban (`isValid`) filters removed** from BOTH the verify and the weight closures: dashcore resolves the voter with the **unfiltered** `GetMNByCollateral` in both `CGovernanceVote::IsValid` and `CGovernanceObject::CountMatchingVotes` — a banned MN's vote verifies and counts at full weight (dropping its NO inflates yes−no under natural ban churn). **Preserved asymmetry** (dashcore's own): the threshold denominator (`reseed_funding_threshold` = `max(minQuorum, valid_weighted/10)`, dashcore `m_valid_weighted`) stays VALID-only; only the per-vote tally is unfiltered. Both closures now share `gov_mn_by_collateral` / `gov_vote_weight_for_key` (`coin_state_maintainer.hpp`).
3. **Replacement semantics matched exactly** (`governance_store.hpp` + `on_govvote`): outcome **NONE is stored** (a newer NONE replaces a stored YES → yes-count drops); replacement per `ProcessVote`: reject `nTime <` stored ("Obsolete vote"); on EQUAL `nTime` reject ONLY new outcome `<` stored (upstream's explicit tie-break); otherwise replace.

**KATs** (fail-before/pass-after verified against the pre-fix tree: 3 FAILED before → **11/11 PASS** after; the 5 real-from-wire crypto KATs pass unchanged on both): legacy-scheme-signed vote rejects under every encoding combination while the same key basic-signed accepts under both pubkey encodings (fallback preserved); banned-MN vote resolves + counts at full weight while the threshold reseeds valid-only (asymmetry asserted both directions); NONE-replaces-YES + obsolete-reject + exact equal-nTime tie-break, at both the store and the `on_govvote` ingest legs. `test_dash_superblock` 24/24 PASS, `c2pool-dash` builds.

**Review nits**: the `IsValid` time bound uses the **local clock** where dashcore uses `GetAdjustedTime()` — documented at the bound (no peer time-offset plumbing here; NTP-disciplined hosts make the divergence negligible; revisit if soak shows drift). **No orphan pool for early votes**: a vote arriving before its trigger object is dropped, where dashd would post-process it once the object lands — an AVAILABILITY-only risk (we under-count vs dashd → tally short of threshold → fail closed to dashd; never the unsafe direction). To be confirmed during the funded-superblock soak — if govsync's object-before-votes ordering doesn't hold in practice, an orphan buffer becomes a follow-up.

Fail-closed chain unchanged: **R5 (`set_superblock_sync_complete_fn`) remains unwired** — no production caller sets it, `resolve_superblock` still refuses the serve path — so R3 + these fixes still cannot open embedded superblock serving by themselves.