### PR TITLE
ci: drop prune step from safe-cosmetic-automerge (job has no checkout)

### DIFF
--- a/.github/workflows/safe-cosmetic-automerge.yml
+++ b/.github/workflows/safe-cosmetic-automerge.yml
@@ -148,8 +148,8 @@ jobs:
             echo "::endgroup::"
           done
 
-      # Steady-state disk hygiene on the VM905 self-hosted runners: drop the
-      # checkout payload and _temp, keep _actions/_tool/_update. Always runs.
-      - name: Prune runner workspace
-        if: always()
-        uses: ./.github/actions/prune-runner-workspace
+      # NOTE: deliberately NO prune-runner-workspace step here. This job never
+      # runs actions/checkout, so `uses: ./.github/actions/...` cannot resolve
+      # (the local action path does not exist in the workspace) and the step
+      # hard-fails the job. There is also nothing to prune: with no checkout the
+      # workspace holds no build tree. Do not re-add it without a checkout.


### PR DESCRIPTION
## Root cause

PR #808 (`de4b3c7f`, merged 2026-07-23T00:21Z) added the post-job `prune-runner-workspace` step to every self-hosted workflow. `safe-cosmetic-automerge.yml` was the only one whose job runs **zero** `actions/checkout` steps, so the local composite-action path cannot resolve:

```
##[error]Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under
'/home/ubuntu/actions-runner-8/_work/c2pool/c2pool/.github/actions/prune-runner-workspace'.
Did you forget to run actions/checkout before running your local action?
```

- run 30019228813 (PR #818, 15:12Z) — https://github.com/frstrtr/c2pool/actions/runs/30019228813
- run 29993973504 (master check_suite, 09:07Z) — https://github.com/frstrtr/c2pool/actions/runs/29993973504

Every `evaluate` run since 02:08Z on 2026-07-23 fails this way. The checkout hypothesis is **confirmed**, with the specific form being a local-action path resolution failure, not a missing source tree for the gate logic.

## Fix

Remove the step. The job never checks out, so there is nothing to prune (no build tree in the workspace), and a comment now records why it must not be re-added without a checkout. Verified this is the only workflow with the prune step and no `actions/checkout`.

## Safety

The prune step is the **last** step in the job and the gate logic runs to completion before it. The failure is strictly post-decision: the label/base/draft/required-context checks and the head-SHA-bound HMAC gate all evaluated normally, and no merge path was bypassed. Logs from the failing runs show the gate correctly skipping (`PR is draft — skip.`, `No SAFE-COSMETIC label — skip.`) and then dying at the prune step. Nothing was silently auto-merged that should not have been.