### PR TITLE
dash(v36): port LTC v36 share features + activate AutoRatchet (v16→v36 crossing)

### DIFF
--- a/src/impl/dash/params.hpp
+++ b/src/impl/dash/params.hpp
@@ -105,7 +105,18 @@ inline core::CoinParams make_coin_params(bool testnet, const PoolOverrides& over
 
     p.target_lookbehind        = SharechainConfig::TARGET_LOOKBEHIND;
     p.spread                   = SharechainConfig::SPREAD;
-    p.minimum_protocol_version = SharechainConfig::MINIMUM_PROTOCOL_VERSION;
+    // v16->v36 crossing: the COLD reject-floor stays at MINIMUM_PROTOCOL_VERSION
+    // (1700) so v16 AND v36 peers COEXIST during the window; the runtime accept-
+    // floor AutoRatchet (node.cpp apply_min_protocol_ratchet) lifts the reject
+    // floor to NEW_MINIMUM_PROTOCOL_VERSION (3600) only once >=95% of the window
+    // work desires v36. advertised_protocol_version (3600) is what we ADVERTISE
+    // (v36 capability, mirrors ltc/dgb params) — NOT the accept-floor; handle_version
+    // keeps minimum_protocol_version as the reject floor. Advertising 3600 is
+    // backward-compatible (legacy 1700-floor peers accept any >=1700) and is
+    // REQUIRED for ratchet coherence: once two nodes ratchet their floor to 3600
+    // they must each advertise >=3600 or they would reject each other.
+    p.minimum_protocol_version    = SharechainConfig::MINIMUM_PROTOCOL_VERSION;
+    p.advertised_protocol_version = SharechainConfig::ADVERTISED_PROTOCOL_VERSION;
     p.block_max_size           = 0;  // DASH: no segwit weight accounting
     p.block_max_weight         = 0;
 

--- a/test/test_dash_conformance.cpp
+++ b/test/test_dash_conformance.cpp
@@ -1356,6 +1356,11 @@ TEST(DashConformanceFactory, PoolFieldsSourcedFromSSOT) {
         EXPECT_EQ(p.target_lookbehind,        dash::SharechainConfig::TARGET_LOOKBEHIND);
         EXPECT_EQ(p.spread,                   dash::SharechainConfig::SPREAD);
         EXPECT_EQ(p.minimum_protocol_version, dash::SharechainConfig::MINIMUM_PROTOCOL_VERSION);
+        // v16->v36 crossing: the COLD accept-floor stays at MINIMUM (1700) so v16 and
+        // v36 peers coexist; we ADVERTISE v36 capability (3600) — the AutoRatchet, not
+        // this field, lifts the accept-floor. Mirrors ltc/dgb params advertised wiring.
+        EXPECT_EQ(p.advertised_protocol_version,
+                  dash::SharechainConfig::ADVERTISED_PROTOCOL_VERSION);
         EXPECT_EQ(p.identifier_hex,           dash::SharechainConfig::IDENTIFIER_HEX);
         EXPECT_EQ(p.prefix_hex,               dash::SharechainConfig::PREFIX_HEX);
         EXPECT_EQ(p.testnet_identifier_hex,   dash::SharechainConfig::TESTNET_IDENTIFIER_HEX);


### PR DESCRIPTION
**DRAFT — do-not-merge (integrator reviews + merges).**

## TL;DR — the substantive port is ALREADY MERGED on master

A full audit against the LTC v36 template found the DASH v16→v36 port + AutoRatchet activation **already landed on master**. This PR carries the **one residual gap** that audit surfaced, plus a conformance assertion, and documents the true state so the operator can drive the live crossing with confidence.

### Already merged (verified against master `a56d1382`)

| Task deliverable | Status | Where |
|---|---|---|
| v36 share TYPE (`DashV36Share`: `V36HashLinkType`, `pubkey_hash`+`pubkey_type`, P2SH-1of2 combined donation, merged fields inert) — parseable, DORMANT | ✅ merged | Phase-A `share.hpp` / `share_chain.hpp` (`V36ShareType`, `load_v36_share`) |
| AutoRatchet pure decision fns (95% work-weighted, floor-div, full-window guard) | ✅ merged | #774 `auto_ratchet.hpp` |
| **AutoRatchet call-site wired into running node** (body + 3 best-share-advance sites) | ✅ merged | `12b4a257` `node.cpp:386` (`apply_min_protocol_ratchet`) |
| Ratchet **TARGET = v36 / 3600** (`NEW_MINIMUM_PROTOCOL_VERSION`) | ✅ merged | `config_pool.hpp:64`, `node.cpp:395` |
| **Anti-false-activation** (07-14 incident: absence≠vote) | ✅ merged | full-window guard (`parent_height ≥ CHAIN_LENGTH`) + DASH-specific `best_desired ≥ 36` guard (`node.cpp:417-424`) — a pre-crossing all-v16 chain can NEVER lift the floor |
| Crossing-window coexistence (cold floor 1700 accepts v16 **and** v36; ratchet → 3600 kicks legacy) | ✅ merged | `handle_version` effective-floor = `max(operator-knob, atomic ratchet)` |
| Advertise v36 (3600) on the wire | ✅ merged | `node.hpp` `send_version` → `ADVERTISED_PROTOCOL_VERSION` |
| KATs: crossing accept, post-crossing reject, false-lift guard, latch, 60%-by-work successor gate | ✅ merged | +7 `DashRatchetCrossing` in `test_dash_auto_ratchet.cpp`, plus `test_dash_version_activation_latch`, `test_dash_min_protocol_gate`, `test_dash_v36_share` round-trip/backward-compat |

### This PR (the residual)

The running-node wire-up never populated `core::CoinParams::advertised_protocol_version` in the `make_coin_params` factory, so the field defaulted to **0** for DASH while **ltc** (`params.hpp:66`) and **dgb** (`params.hpp:102`) both set it. DASH's own node reads `SharechainConfig::ADVERTISED_PROTOCOL_VERSION` directly, so this is functionally inert today — but any CoinParams-layer consumer (shared pool/stats/future unified v37 path) reads 0, a latent cross-layer inconsistency and a break of the ltc/dgb precedent.

- `params.hpp`: `p.advertised_protocol_version = SharechainConfig::ADVERTISED_PROTOCOL_VERSION` (3600). Cold reject-floor stays 1700; advertising 3600 is backward-compatible and required for ratchet coherence.
- `test_dash_conformance.cpp`: assert the field equals the SSOT (**fail-before**: 0 ≠ 3600; **pass-after**: 3600).

### Dormancy / safety

`current_share_version` stays **16** — v36 is DORMANT-by-default; nothing mints v36 and the accept-floor never lifts until ≥95% of window WORK desires v36. **No change to the live v16 join** (T1c byte-parity preserved). The live network crossing is a separate operator-gated action (hotel ≈89% hashpower), not this PR.

### Follow-up (not this PR): python p2pool-dash fork

The DASH oracle `frstrtr/p2pool-dash` is older-than-v35 and has **no** `NEW_MINIMUM_PROTOCOL_VERSION` / no accept-floor ratchet (`MINIMUM_PROTOCOL_VERSION` is the static 1700 net constant). For a legacy python peer to participate in the ratchet (advertise ≥3600, lift its own floor), the fork needs `NEW_MINIMUM_PROTOCOL_VERSION` + `update_min_protocol_version` added — a separate `frstrtr/p2pool-dash` change. Until then c2pool ratchets its own accept-floor autonomously and legacy python peers are simply dropped once the floor passes their advertised 1700.

### Verification
- `test_dash_auto_ratchet`: **21/21 pass** (incl. 7 `DashRatchetCrossing`).
- `test_dash_conformance` `DashConformanceFactory`: **7/7 pass** (incl. new advertised assertion).