### PR TITLE
dash(embedded): R5 govsync-completeness predicate — the superblock enable

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -2802,16 +2802,41 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                         return maint->superblock_schedule(next_height);
                     });
                 node_coin_state.set_require_superblock_provider(embedded_superblock);
-                // NOTE deliberately NOT set: set_superblock_sync_complete_fn
-                // (R5). Until a govsync-completeness proof exists, superblock
-                // heights refuse the embedded arm even with the flag on.
+                // R5 GOVSYNC-COMPLETENESS GATE (production wiring). Model:
+                // dashcore CMasternodeSync governance-phase completion — the
+                // view is COMPLETE only when the governance set was requested
+                // from >= min_peers distinct peers, a settle floor elapsed, and
+                // no new object/vote arrived for the quiescence window (the
+                // stream quiesced). Fed from the govobj/govobjvote reception
+                // path + note_govsync_requested at the send site (below). This
+                // is the gate that lets a VERIFIED-complete superblock actually
+                // serve; a PARTIAL view (missing the higher-yes competing
+                // trigger/votes) is the confidently-wrong-winner hazard, so the
+                // default (nothing synced / under-covered / not quiesced) is
+                // FALSE => reward-safe dashd fallback.
+                maintainer->set_gov_sync_params(
+                    dash::coin::DASH_GOVSYNC_MIN_PEERS_DEFAULT,
+                    dash::coin::DASH_GOVSYNC_SETTLE_SECS_DEFAULT,
+                    dash::coin::DASH_GOVSYNC_QUIESCE_SECS_DEFAULT);
+                node_coin_state.set_superblock_sync_complete_fn(
+                    [maint = maintainer.get()]() {
+                        return maint->gov_sync_complete();
+                    });
                 if (embedded_superblock)
                     LOG_INFO << "[E-SUPERBLOCK] daemonless superblock arm ENABLED "
                                 "(--embedded-superblock); superblock heights served "
-                                "from govsync triggers when trigger-confident, else "
-                                "fail closed to dashd. Vote-verify (BLS operator) + "
-                                "completeness gate pending => currently fails "
-                                "closed until pinned.";
+                                "from govsync triggers ONLY when the governance "
+                                "view is trigger-confident AND provably complete "
+                                "(R5: >= "
+                             << dash::coin::DASH_GOVSYNC_MIN_PEERS_DEFAULT
+                             << " peers, quiesced), else fail closed to dashd. "
+                                "CO-REQUISITES still pending before this can serve "
+                                "live: multi-peer govsync + inv-driven getdata "
+                                "(the leg is inv-inert today) + BLS operator "
+                                "vote-verify + the vote-weight seam — until those "
+                                "land the completeness predicate evaluates FALSE "
+                                "(single peer / empty store) and the arm stays on "
+                                "the reward-safe fallback.";
             }
         }
 
@@ -3217,7 +3242,7 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         // getheaders off our current locator + a mempool prime.
         coin_p2p->set_on_handshake_complete(
             [cp = coin_p2p.get(), hc = header_chain.get(), sml_base,
-             discover = coin_p2p_discover_eff]() {
+             discover = coin_p2p_discover_eff, maint = maintainer.get()]() {
                 LOG_INFO << "[EMB-DASH] handshake complete -> initial sync:"
                             " getheaders + mempool + mnlistdiff(cold)"
                          << (discover ? " + getaddr (peer crawl)" : "");
@@ -3246,6 +3271,12 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 // The inv-driven getdata + per-object vote sync + periodic
                 // re-prime co-land with vote-verify before any enable.
                 cp->send_govsync();
+                // R5: record govsync peer coverage + (re)arm the quiescence
+                // window for the completeness determination. With the current
+                // single-peer connection model this covers ONE peer, so the
+                // default min_peers floor (>=2) keeps the completeness predicate
+                // FALSE — reward-safe until multi-peer govsync lands.
+                maint->note_govsync_requested(cp->peer_key());
             });
 
         std::cout << "[run] E2a live-feed wired: header-chain(" << hdr_db

--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -29,6 +29,7 @@
 
 #include <impl/dash/coin/node_coin_state.hpp>    // NodeCoinState
 #include <impl/dash/coin/governance_store.hpp>   // GovernanceStore (daemonless superblock)
+#include <impl/dash/coin/govsync_status.hpp>     // GovSyncStatus (R5 completeness determination)
 #include <impl/dash/coin/governance_object.hpp>  // parse_superblock_trigger, govvote_signature_hash
 #include <impl/dash/coin/superblock.hpp>         // get_superblock_payments (R6 cross-check + provider)
 #include <impl/dash/coin/mn_state_machine.hpp>   // MNState
@@ -49,8 +50,10 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <ctime>
 #include <functional>
 #include <optional>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -118,6 +121,42 @@ public:
     /// R6 desync latch state (observability / tests).
     bool gov_desync_latched() const { return m_gov_desync_latched; }
 
+    // ── R5 govsync-completeness determination ────────────────────────────────
+    // Models dashcore CMasternodeSync's governance-phase completion (peer
+    // coverage + time-quiescence) — the "is governance synced" gate the
+    // NodeCoinState superblock guard consults via set_superblock_sync_complete_fn.
+    // Fed from the SAME reception path as the GovernanceStore (on_govobject /
+    // on_govvote re-arm quiescence) plus note_govsync_requested from the govsync
+    // send site. gov_sync_complete() is the production predicate main_dash wires.
+
+    /// Completeness tunables (main_dash sets these from the deployment; a
+    /// single-peer deployment leaves min_peers unmet => permanently INCOMPLETE
+    /// => reward-safe dashd fallback). See govsync_status.hpp for the model.
+    void set_gov_sync_params(size_t min_peers, int64_t settle_secs,
+                             int64_t quiesce_secs) {
+        m_gov_sync_status.set_params(min_peers, settle_secs, quiesce_secs);
+    }
+
+    /// Override the wall-clock source (default std::time). Tests inject a fake
+    /// clock so the settle/quiesce windows are deterministic.
+    void set_now_fn(std::function<int64_t()> fn) { m_now_fn = std::move(fn); }
+
+    /// The govsync send site (main_dash) calls this whenever it issues an
+    /// MNGOVERNANCESYNC to a peer — records peer coverage + (re)arms quiescence.
+    void note_govsync_requested(const std::string& peer_key) {
+        m_gov_sync_status.note_govsync_requested(peer_key, m_now_fn());
+    }
+
+    /// The production completeness predicate: TRUE only when the daemonless
+    /// governance view has provably caught up (peer coverage + settle + quiesce).
+    /// Default (nothing synced) => false => superblock heights fail closed.
+    bool gov_sync_complete() const {
+        return m_gov_sync_status.is_complete(m_now_fn());
+    }
+
+    /// Observability handle (logs / tests).
+    const GovSyncStatus& gov_sync_status() const { return m_gov_sync_status; }
+
     /// Vote verification seam — the contract the follow-up implementer MUST
     /// build to (WRONG-SCHEME WARNING: trigger funding votes are NOT
     /// ECDSA/keyIDVoting-signed; that path applies only to PROPOSAL funding
@@ -164,6 +203,10 @@ public:
     /// bytes). The parse is CHAIN-STRICT per set_gov_params.
     void on_govobject(const uint256& object_hash, int32_t object_type,
                       const std::vector<uint8_t>& vch_data) {
+        // R5: ANY object arrival (trigger, proposal, or malformed) proves the
+        // peer is still streaming its set — re-arm the quiescence window BEFORE
+        // the type filter, so a stream of proposals still keeps us "mid-sync".
+        m_gov_sync_status.note_object_arrival(m_now_fn());
         if (object_type != GOVERNANCE_OBJECT_TRIGGER) return;   // only superblock triggers
         std::string plain(vch_data.begin(), vch_data.end());
         auto trig = parse_superblock_trigger(plain, object_hash, m_gov_testnet);
@@ -187,6 +230,9 @@ public:
     /// by the MN's OPERATOR key (see set_vote_verifier — default UNSET =>
     /// never counted => fail closed).
     void on_govvote(const GovVoteContext& v, const std::string& mn_outpoint_key) {
+        // R5: ANY vote arrival re-arms the quiescence window (mid-sync signal),
+        // BEFORE the signal/outcome/known-trigger filters below.
+        m_gov_sync_status.note_vote_arrival(m_now_fn());
         if (v.signal != VOTE_SIGNAL_FUNDING) return;            // only the superblock tally axis
         if (v.outcome != VOTE_OUTCOME_YES && v.outcome != VOTE_OUTCOME_NO &&
             v.outcome != VOTE_OUTCOME_ABSTAIN)
@@ -905,6 +951,8 @@ private:
                                "(superblock heights fail to dashd until "
                                "restart); re-issuing work.";
                 m_gov_store.clear();
+                m_gov_sync_status.reset();   // R5: a proven-wrong view is no
+                                             // longer "complete"; force re-sync
                 m_gov_desync_latched = true;
                 // Transient invalidate + re-issue so any currently-published
                 // template is rebuilt. The MN axis is a separate axis — if it
@@ -938,6 +986,12 @@ private:
 
     NodeCoinState& m_state;
     GovernanceStore m_gov_store;             // E-SUPERBLOCK: govsync object/vote store
+    GovSyncStatus   m_gov_sync_status;       // R5: govsync-completeness determination
+    // Wall-clock source for the completeness settle/quiesce windows (default
+    // std::time; tests inject a fake clock).
+    std::function<int64_t()> m_now_fn{[]() {
+        return static_cast<int64_t>(std::time(nullptr));
+    }};
     // Vote-verify seam (unset = fail closed). Contract: BLS by the MN's
     // OPERATOR key for trigger funding votes — see set_vote_verifier docs.
     std::function<bool(const GovVoteContext&)> m_vote_verifier;

--- a/src/impl/dash/coin/govsync_status.hpp
+++ b/src/impl/dash/coin/govsync_status.hpp
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// GOVSYNC-COMPLETENESS DETERMINATION (E-SUPERBLOCK R5). The reward-critical
+/// question the superblock serve path asks before it trusts the daemonless
+/// GovernanceStore's winning trigger: has our governance view provably CAUGHT
+/// UP to the network's, or are we still mid-sync?
+///
+/// The dangerous failure mode is a PARTIAL view: a store missing the higher-yes
+/// competing trigger (or its votes) yields a CONFIDENT wrong winner — dashd
+/// validates the block against ITS best trigger and rejects it (bad-cb-payee).
+/// A per-trigger funding threshold cannot see what it never received, so
+/// trigger-confidence alone is NOT sufficient to serve; the view must first be
+/// COMPLETE.
+///
+/// REUSE — this models dashcore's own governance-sync-status logic, CMasternodeSync
+/// (masternode/sync.cpp): the MASTERNODE_SYNC_GOVERNANCE asset requests objects
+/// + votes from peers and declares governance SYNCED (IsSynced(), after which
+/// dashd trusts its governance view for superblock validation) when
+///   (a) it has requested the governance set from enough peers, AND
+///   (b) no NEW governance object/vote has arrived for MASTERNODE_SYNC_TIMEOUT
+///       seconds (the stream has quiesced — nTimeLastBumped stopped advancing).
+/// There is no explicit "done" message on the wire; completeness IS the
+/// peer-coverage + time-quiescence determination. We reproduce exactly that:
+/// peer coverage (redundancy against a single withholding/partial peer) plus a
+/// quiescence window since the last arrival, plus a settle floor since the
+/// first request so an empty store cannot be declared "complete" before objects
+/// have had time to arrive.
+///
+/// FAIL-CLOSED BY CONSTRUCTION: default state (no request issued) is INCOMPLETE.
+/// Every uncertain / under-covered / not-yet-quiesced view returns false, so the
+/// NodeCoinState superblock guard routes to the reward-safe dashd fallback.
+/// This is a NECESSARY (not sufficient) gate: the serve path additionally
+/// requires a trigger-confident winner (GovernanceStore::get_best_superblock)
+/// and the R6 desync latch to be clear — defence in depth.
+
+#include <cstdint>
+#include <set>
+#include <string>
+
+namespace dash {
+namespace coin {
+
+/// dashcore masternode/sync.h MASTERNODE_SYNC_TIMEOUT_SECONDS (the no-new-data
+/// window after which a sync asset is considered complete). Used as the default
+/// quiescence window.
+inline constexpr int64_t DASH_GOVSYNC_QUIESCE_SECS_DEFAULT = 30;
+
+/// Settle floor since the first govsync request before completeness can be
+/// asserted at all — guards against declaring an empty store "complete" in the
+/// instant between issuing the request and the first objects arriving. dashcore
+/// gets this implicitly from its multi-tick asset progression; we make it
+/// explicit.
+inline constexpr int64_t DASH_GOVSYNC_SETTLE_SECS_DEFAULT = 60;
+
+/// Peer-coverage floor: the number of DISTINCT peers we must have requested the
+/// governance set from before a quiesced view counts as complete. Redundancy is
+/// the only defence against a single peer that withholds the winning trigger
+/// (or its votes) — a one-peer "quiesced" view is exactly the partial-view
+/// hazard. dashcore syncs governance from multiple peers for the same reason.
+/// DEFAULT 2 (fail-closed leaning): a single-peer deployment can NEVER assert
+/// completeness, so it stays on the reward-safe dashd fallback until the
+/// multi-peer govsync leg lands.
+inline constexpr size_t DASH_GOVSYNC_MIN_PEERS_DEFAULT = 2;
+
+/// Tracks daemonless governance-sync progress and answers is_complete(now).
+/// Pure/clock-injected (the caller passes wall-seconds), so it is deterministic
+/// under test. Not thread-safe by itself — the maintainer owns the single
+/// instance and drives it from the same reception path as the GovernanceStore.
+class GovSyncStatus {
+public:
+    /// Tunables (main_dash wires these from chain/deployment; the KAT drives
+    /// them directly). All three must be crossed for completeness.
+    void set_params(size_t min_peers, int64_t settle_secs, int64_t quiesce_secs) {
+        m_min_peers    = min_peers;
+        m_settle_secs  = settle_secs;
+        m_quiesce_secs = quiesce_secs;
+    }
+
+    /// A govsync (MNGOVERNANCESYNC) request was issued to `peer_key` at `now`.
+    /// Records peer coverage and (re-)arms quiescence: a fresh request means we
+    /// expect a stream, so the view is not yet quiesced. The first request also
+    /// starts the settle clock.
+    void note_govsync_requested(const std::string& peer_key, int64_t now) {
+        if (m_first_request_time == 0) m_first_request_time = now;
+        m_requested_peers.insert(peer_key);
+        // A new request re-arms the quiescence window (dashcore bumps
+        // nTimeLastBumped when it (re)asks a peer): we must not call a view
+        // "quiesced" the instant after asking a fresh peer.
+        if (now > m_last_activity_time) m_last_activity_time = now;
+    }
+
+    /// A governance OBJECT (govobj) arrived at `now` — the stream is still
+    /// delivering, so re-arm quiescence. Stamped on ANY object arrival (trigger,
+    /// proposal, or malformed), because activity of any kind proves the peer is
+    /// still streaming its set (matching dashcore's per-message bump).
+    void note_object_arrival(int64_t now) {
+        ++m_objects;
+        if (now > m_last_activity_time) m_last_activity_time = now;
+    }
+
+    /// A governance VOTE (govobjvote) arrived at `now` — re-arm quiescence.
+    void note_vote_arrival(int64_t now) {
+        ++m_votes;
+        if (now > m_last_activity_time) m_last_activity_time = now;
+    }
+
+    /// Wipe sync progress (store reset / reorg / desync clear). Forces the view
+    /// back to INCOMPLETE until a fresh govsync round re-covers the peers and
+    /// re-quiesces — a re-proof obligation, never trust a torn view.
+    void reset() {
+        m_requested_peers.clear();
+        m_first_request_time = 0;
+        m_last_activity_time = 0;
+        m_objects = 0;
+        m_votes = 0;
+    }
+
+    /// The completeness determination. TRUE only when ALL hold:
+    ///   1. at least one govsync was requested (m_first_request_time set), AND
+    ///   2. the governance set was requested from >= min_peers DISTINCT peers, AND
+    ///   3. the settle floor has elapsed since the first request, AND
+    ///   4. no new object/vote has arrived for >= quiesce window (quiesced).
+    /// Anything else (default, mid-sync, under-covered, not-yet-quiesced) is
+    /// FALSE => the superblock arm fails closed to dashd.
+    ///
+    /// NOTE it deliberately does NOT require objects>0: a genuinely unfunded
+    /// cycle has no trigger, and the winner-selection gate
+    /// (get_best_superblock => nullopt) already refuses that height. Requiring
+    /// objects here would wrongly serve nothing on a complete-but-unfunded view
+    /// AND could not distinguish "no trigger this cycle" from "peer withheld it"
+    /// — the peer-coverage floor is what defends the latter.
+    bool is_complete(int64_t now) const {
+        if (m_first_request_time == 0) return false;               // never asked
+        if (m_requested_peers.size() < m_min_peers) return false;  // under-covered
+        if (now - m_first_request_time < m_settle_secs) return false;   // not settled
+        if (now - m_last_activity_time < m_quiesce_secs) return false;  // not quiesced
+        return true;
+    }
+
+    // ── observability (logs / tests) ────────────────────────────────────────
+    size_t   requested_peer_count() const { return m_requested_peers.size(); }
+    uint64_t object_count() const { return m_objects; }
+    uint64_t vote_count() const { return m_votes; }
+    int64_t  first_request_time() const { return m_first_request_time; }
+    int64_t  last_activity_time() const { return m_last_activity_time; }
+
+private:
+    std::set<std::string> m_requested_peers;
+    int64_t m_first_request_time{0};
+    int64_t m_last_activity_time{0};
+    uint64_t m_objects{0};
+    uint64_t m_votes{0};
+    size_t  m_min_peers{DASH_GOVSYNC_MIN_PEERS_DEFAULT};
+    int64_t m_settle_secs{DASH_GOVSYNC_SETTLE_SECS_DEFAULT};
+    int64_t m_quiesce_secs{DASH_GOVSYNC_QUIESCE_SECS_DEFAULT};
+};
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -367,6 +367,12 @@ public:
     uint64_t peer_services() const { return m_peer_services; }
     uint32_t peer_version() const { return m_peer_version; }
     const std::string& peer_subver() const { return m_peer_subver; }
+    /// Stable identity of the currently-connected peer (addr:port) — the R5
+    /// govsync-completeness tracker keys peer coverage on this. Empty when no
+    /// peer is connected.
+    std::string peer_key() const {
+        return m_peer ? m_peer->get_addr().to_string() : std::string();
+    }
     uint32_t peer_start_height() const { return m_peer_start_height; }
     const std::string& chain_label() const { return m_chain_label; }
     int64_t peer_uptime_sec() const {

--- a/test/test_dash_superblock.cpp
+++ b/test/test_dash_superblock.cpp
@@ -48,6 +48,7 @@
 #include <impl/dash/coin/utxo_adapter.hpp>          // dash_txid (subsidy.hpp template dep)
 #include <impl/dash/coin/governance_object.hpp>
 #include <impl/dash/coin/governance_store.hpp>
+#include <impl/dash/coin/govsync_status.hpp>        // R5 completeness determination
 #include <impl/dash/coin/superblock.hpp>
 #include <impl/dash/coin/embedded_gbt.hpp>
 #include <impl/dash/coin/mn_state_machine.hpp>
@@ -775,6 +776,103 @@ TEST(DashSuperblock, CompletenessGateIsRequiredToServe) {
     ASSERT_EQ(e.superblock_payments.size(), 1u);
     EXPECT_EQ(e.superblock_payments[0].script, kScriptYeRZ);
     EXPECT_EQ(e.superblock_payments[0].amount, 500'000'000LL);
+}
+
+// ── 8a. R5: the GovSyncStatus completeness DETERMINATION (production logic) ──
+// Unit-drive the real predicate (dashcore CMasternodeSync governance-phase
+// model): completeness requires peer coverage + a settle floor + quiescence.
+// Every under-covered / not-settled / not-quiesced view is INCOMPLETE.
+TEST(DashSuperblock, GovSyncStatusCompletenessDetermination) {
+    GovSyncStatus s;
+    // min_peers=2, settle=60s, quiesce=30s (the mainnet-ish defaults).
+    s.set_params(/*min_peers=*/2, /*settle=*/60, /*quiesce=*/30);
+
+    const int64_t t0 = 1'700'000'000;
+    // Default (nothing requested) => INCOMPLETE.
+    EXPECT_FALSE(s.is_complete(t0));
+
+    // One peer requested; even long after, one peer can never be complete
+    // (partial-view hazard: a single peer may withhold the winning trigger).
+    s.note_govsync_requested("peerA", t0);
+    EXPECT_FALSE(s.is_complete(t0 + 10'000)) << "single-peer view is never complete";
+
+    // Second distinct peer covered, but the settle floor has not elapsed.
+    s.note_govsync_requested("peerB", t0 + 5);
+    EXPECT_FALSE(s.is_complete(t0 + 30)) << "not settled (60s floor since first req)";
+
+    // Settled, but an object just arrived => not quiesced.
+    s.note_object_arrival(t0 + 61);
+    EXPECT_FALSE(s.is_complete(t0 + 70)) << "recent object arrival re-arms quiescence";
+
+    // Settled AND quiesced (>=30s since last activity) AND >=2 peers => COMPLETE.
+    EXPECT_TRUE(s.is_complete(t0 + 61 + 30));
+
+    // A fresh vote arrival re-opens the sync (mid-stream again) => INCOMPLETE.
+    s.note_vote_arrival(t0 + 200);
+    EXPECT_FALSE(s.is_complete(t0 + 210));
+    EXPECT_TRUE(s.is_complete(t0 + 200 + 30)) << "quiesces again after the vote";
+
+    // reset() (desync / reorg) forces the view back to INCOMPLETE.
+    s.reset();
+    EXPECT_FALSE(s.is_complete(t0 + 100'000));
+    EXPECT_EQ(s.requested_peer_count(), 0u);
+}
+
+// ── 8b. R5: the maintainer's PRODUCTION predicate drives the serve path ──────
+// End-to-end: wire NodeCoinState::set_superblock_sync_complete_fn to the REAL
+// maintainer->gov_sync_complete() (as main_dash does), with an injected clock.
+// A mid-sync governance view REFUSES; only a peer-covered + settled + quiesced
+// view lets the trigger-confident superblock serve.
+TEST(DashSuperblock, MaintainerGovSyncCompleteGatesServe) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+
+    // Injected clock so settle/quiesce windows are deterministic.
+    int64_t now = 1'700'000'000;
+    m.set_now_fn([&now]() { return now; });
+    m.set_gov_sync_params(/*min_peers=*/2, /*settle=*/60, /*quiesce=*/30);
+
+    m.on_mn_list_update(single_mn(p2pkh_script(0x30)));
+    m.on_new_tip(SBH - 1, raw256(0xAB), 0x1e0ffff0u, 1'700'000'000u,
+                 /*addr_ver*/140, /*addr_p2sh*/19, 1'700'000'100u, 0x20000000u);
+    ASSERT_TRUE(m.live());
+
+    // Trigger-confident view + provider + flag, and the PRODUCTION completeness
+    // predicate (not a fake toggle).
+    arm_trigger_confident(m);
+    st.set_is_superblock_fn([](uint32_t h) { return h == SBH; });
+    st.set_superblock_provider([&m](uint32_t h) { return m.superblock_schedule(h); });
+    st.set_require_superblock_provider(true);
+    st.set_superblock_sync_complete_fn([&m]() { return m.gov_sync_complete(); });
+
+    // Nothing synced yet => INCOMPLETE => refuse.
+    EXPECT_FALSE(st.make_embedded_work_inputs().viable())
+        << "no govsync => incomplete => must refuse";
+
+    // One peer only => still incomplete (under-covered).
+    m.note_govsync_requested("peerA");
+    now += 10'000;
+    EXPECT_FALSE(st.make_embedded_work_inputs().viable())
+        << "single-peer govsync is never complete";
+
+    // Second peer, but not yet settled/quiesced.
+    m.note_govsync_requested("peerB");
+    now += 5;
+    EXPECT_FALSE(st.make_embedded_work_inputs().viable())
+        << "two peers but not settled/quiesced => refuse";
+
+    // Settle + quiesce elapse with no new arrivals => COMPLETE => serve.
+    now += 100;
+    auto e = st.make_embedded_work_inputs();
+    ASSERT_TRUE(e.viable()) << "peer-covered + settled + quiesced => serve";
+    ASSERT_EQ(e.superblock_payments.size(), 1u);
+    EXPECT_EQ(e.superblock_payments[0].script, kScriptYeRZ);
+
+    // A late govobject arrival re-opens the sync => refuse again (proves the
+    // reception path re-arms the production predicate).
+    m.on_govobject(hash_of(99), GOVERNANCE_OBJECT_TRIGGER, {});
+    EXPECT_FALSE(st.make_embedded_work_inputs().viable())
+        << "a fresh govobject re-arms quiescence => mid-sync => refuse";
 }
 
 // ── 9. R6: superblock desync cross-check ────────────────────────────────────


### PR DESCRIPTION
## R5: wire the govsync-completeness predicate (superblock enable)

**Draft — do not merge.** Stacks on `dash/embedded-superblock-govsync` (#810 superblock sourcing + R1-R6 rework).

### Problem
`set_superblock_sync_complete_fn` had **no production caller**, so `resolve_superblock` (which requires the completeness predicate PRESENT and TRUE) always refused → every superblock height fell back to dashd. Landing vote-verify alone could never open the serve path.

### What this does
Adds `GovSyncStatus` (`govsync_status.hpp`) — the govsync-completeness determination, modelled on **dashcore `CMasternodeSync`'s governance-phase completion**. A view is COMPLETE only when:
1. the governance set was requested from **>= min_peers distinct peers** (redundancy vs. a single peer withholding the winning trigger), AND
2. a **settle floor** elapsed since the first request, AND
3. **no new object/vote arrived for the quiescence window** (the stream quiesced).

There is no explicit "done" on the wire; completeness IS the peer-coverage + time-quiescence determination dashd itself uses before trusting its governance view for superblock validation. Default (nothing synced / under-covered / not quiesced) = **FALSE → reward-safe dashd fallback**.

Wired through `CoinStateMaintainer::gov_sync_complete()` (fed from the govobj/govobjvote reception path + `note_govsync_requested` at the send site; injectable clock for tests; R6 desync clear resets it). `main_dash` now sets `set_superblock_sync_complete_fn` → `maintainer->gov_sync_complete()`. `p2p_client` gains `peer_key()`.

### Reward-safety
NECESSARY (not sufficient) gate — the serve path also requires a trigger-confident winner + clear desync latch. A wrong "complete" → serve a superblock with a missing/wrong trigger (bad-cb-payee), so absent/uncertain always refuses.

### Co-requisites still pending before superblocks serve LIVE
(documented in the main_dash log): **multi-peer govsync** (single-peer model never meets the >=2-peer floor), **inv-driven getdata** (the govsync leg is inv-inert today → store stays empty), **BLS operator vote-verify**, and the **vote-weight seam**. Under all of these the predicate correctly evaluates FALSE.

### KATs (`test_dash_superblock`)
- `GovSyncStatusCompletenessDetermination` — default/under-covered/not-settled/not-quiesced ⇒ incomplete; peer-covered + settled + quiesced ⇒ complete; fresh arrival re-arms; reset reopens.
- `MaintainerGovSyncCompleteGatesServe` — end-to-end via the REAL `gov_sync_complete()` with injected clock: mid-sync refuses, only a complete view serves, a late govobject re-arms ⇒ refuse.
- existing `CompletenessGateIsRequiredToServe` (structural) still passes.

All 26 `DashSuperblock` tests pass; `main_dash.cpp` compiles. (Pre-existing, unrelated: `DashCoinStateMaintainer.PayeeDesyncWipesDemotesAndFiresReseed` fails on the base branch too — not touched here.)