### PR TITLE
dash(dashboard): v36 transition gauges + sharechain/PPLNS status — reuse c2pool LTC dashboard [DRAFT/do-not-merge]

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -92,6 +92,7 @@
 #include <impl/dash/mint_runloop.hpp>          // dash::mint — run-loop share minting (slice 3/3)
 #include <core/web_server.hpp>                 // core::WebServer — the EXISTING c2pool dashboard (same wiring main_ltc.cpp uses)
 #include <impl/dash/enhanced_node.hpp>         // dash::EnhancedDashNode — core::IMiningNode the WebServer ctor takes
+#include <impl/dash/share_messages.hpp>        // dash::unpack_share_messages — signed transitional-blob DISPLAY+VERIFY feed
 #include <core/log.hpp>
 
 #include <chrono>
@@ -654,19 +655,62 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             mi->mark_last_cache_tip_driven();
 
             // ── REAL sharechain stats ─────────────────────────────────────
-            // Straight off the live tracker / published snapshot. Only fields
-            // DASH actually computes are emitted — no LTC-shaped placeholders.
+            // Straight off the live tracker / published snapshot. Emits the same
+            // vote/sampling/propagation fields main_ltc.cpp's stats_fn does, so the
+            // SHARED core::rest_version_signaling() lights the v16→v36 transition
+            // gauges for DASH exactly as it does for LTC's v35→v36 crossing. All
+            // reads are display-only (no consensus mutation): the desired-version
+            // tally + work-weighted sampling mirror what apply_min_protocol_ratchet
+            // keys on (version_negotiation::get_desired_version_weights), so the
+            // dashboard shows the SAME numbers the ratchet decides on.
             mi->set_sharechain_stats_fn([node_ptr]() -> nlohmann::json {
+                // Last-good cache (mirrors main_ltc.cpp's stats_fn): think() holds the
+                // tracker lock frequently during normal operation, and returning a
+                // 4-field snapshot then would make the transition gauge (which reads
+                // shares_by_desired_version / sampling weights) flap to 0 every time.
+                // On a busy tick we return the last FULL result with volatile fields
+                // refreshed from the snapshot, so the crossing gauge stays steady.
+                static std::mutex s_cache_mutex;
+                static nlohmann::json s_last_good;
+
                 auto snap = node_ptr->get_tracker_snapshot();
                 nlohmann::json out;
-                out["chain_length"]   = static_cast<int>(dash::SharechainConfig::chain_length());
+                const int chain_len = static_cast<int>(dash::SharechainConfig::chain_length());
+                out["chain_length"]   = chain_len;
                 out["fork_count"]     = snap.fork_count;
                 out["verified_count"] = snap.verified_count;
                 out["orphan_shares"]  = snap.orphan_shares;
                 out["dead_shares"]    = snap.dead_shares;
+
+                // Protocol-floor gauge inputs (v16→v36 crossing). The live accept-floor
+                // is the ratchet output (1700 pre-crossing → 3600 once ≥95% v36-weighted);
+                // advertised is our v36-capability advert.
+                const int64_t live_floor = static_cast<int64_t>(node_ptr->runtime_min_protocol_version());
+                out["min_protocol_version"]     = live_floor;
+                out["cold_min_protocol_version"] = static_cast<int64_t>(dash::SharechainConfig::MINIMUM_PROTOCOL_VERSION);
+                out["new_min_protocol_version"] = static_cast<int64_t>(dash::SharechainConfig::NEW_MINIMUM_PROTOCOL_VERSION);
+                out["advertised_protocol_version"] = static_cast<int64_t>(dash::SharechainConfig::ADVERTISED_PROTOCOL_VERSION);
+                // DASH shares are wire-format v16 through the whole crossing (only the
+                // desired-version vote moves 16→36; there is no v36 share FORMAT for
+                // DASH), so the node's live share version is 16 until the floor latches.
+                out["live_share_version"] = (live_floor >= static_cast<int64_t>(dash::SharechainConfig::NEW_MINIMUM_PROTOCOL_VERSION)) ? 36 : 16;
+
                 auto guard = node_ptr->read_tracker();
                 if (!guard) {
-                    // Tracker busy — report the snapshot only, and say so.
+                    // Tracker busy — prefer the last FULL result (with the vote/sampling
+                    // fields) over a bare snapshot so the gauge doesn't flap.
+                    std::lock_guard<std::mutex> lock(s_cache_mutex);
+                    if (!s_last_good.is_null()) {
+                        nlohmann::json cached = s_last_good;
+                        // Refresh volatile fields + the live floor from this snapshot.
+                        cached["chain_height"]   = snap.chain_count;
+                        cached["total_shares"]   = snap.chain_count;
+                        cached["verified_count"] = snap.verified_count;
+                        cached["fork_count"]     = snap.fork_count;
+                        cached["min_protocol_version"]  = live_floor;
+                        cached["live_share_version"]    = out["live_share_version"];
+                        return cached;
+                    }
                     out["chain_height"] = snap.chain_count;
                     out["total_shares"] = snap.chain_count;
                     return out;
@@ -678,11 +722,151 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     auto h = chain.get_height(head_hash);
                     if (h > best_height) { best = head_hash; best_height = h; }
                 }
+                const int chain_ht = best.IsNull() ? 0 : chain.get_height(best);
                 out["chain_tip_hash"] = best.IsNull() ? "" : best.GetHex();
-                out["chain_height"]   = best.IsNull() ? 0 : chain.get_height(best);
-                out["total_shares"]   = static_cast<int>(chain.size());
+                out["chain_height"]   = chain_ht;
+                out["stored_shares"]  = static_cast<int>(chain.size());  // all shares in the DB (incl. forks)
+
+                // ── Single backward walk: desired-version votes, share-format
+                //    counts, per-miner tally, and V36 propagation depth ──────────
+                std::map<int, int> desired_counts;   // m_desired_version → count
+                std::map<std::string, int> miner_counts;
+                int format_v16 = 0;
+                int deepest_v36_pos = 0;
+                int v36_contiguous_from_tip = 0;
+                bool contiguous = true;
+                const int skip_count   = std::min(chain_ht, chain_len * 9 / 10);
+                const int sample_count = std::min(chain_ht - skip_count, chain_len / 10);
+                uint256 sampling_start;
+                const int full_walk = std::min(chain_ht, chain_len);
+                if (!best.IsNull() && full_walk > 0) {
+                    int i = 0;
+                    for (auto&& [hash, data] : chain.get_chain(best, static_cast<uint64_t>(full_walk))) {
+                        if (i == skip_count) sampling_start = hash;
+                        data.share.invoke([&](auto* s) {
+                            int dv = static_cast<int>(s->m_desired_version);
+                            desired_counts[dv] += 1;
+                            format_v16 += 1;  // DashShare is wire-format v16
+                            miner_counts[s->m_pubkey_hash.GetHex()] += 1;
+                            if (dv >= 36) {
+                                deepest_v36_pos = i + 1;
+                                if (contiguous) v36_contiguous_from_tip = i + 1;
+                            } else if (contiguous) {
+                                contiguous = false;
+                            }
+                        });
+                        ++i;
+                    }
+                }
+                if (sampling_start.IsNull() && skip_count == 0) sampling_start = best;
+
+                // total_shares == the active-chain window actually tallied (matches
+                // main_ltc.cpp, where total_shares is the windowed skiplist count), so
+                // the gauge's version percentages divide by the same denominator.
+                out["total_shares"] = format_v16;
+
+                nlohmann::json sbv = nlohmann::json::object();
+                if (format_v16 > 0) sbv["16"] = format_v16;
+                out["shares_by_version"] = sbv;
+
+                nlohmann::json sbdv = nlohmann::json::object();
+                for (auto& [ver, cnt] : desired_counts) sbdv[std::to_string(ver)] = cnt;
+                out["shares_by_desired_version"] = sbdv;
+                out["shares_by_miner"]        = miner_counts;
+                out["deepest_v36_position"]   = deepest_v36_pos;
+                out["v36_contiguous_from_tip"] = v36_contiguous_from_tip;
+
+                // ── Work-weighted sampling window: oldest CHAIN_LENGTH/10 shares.
+                //    Same weighting the v36 activation gate consumes, so the
+                //    dashboard's "% of hashpower-by-work on v36" matches the ratchet.
+                nlohmann::json sampling = nlohmann::json::object();
+                if (sample_count > 0 && !sampling_start.IsNull()) {
+                    auto weights = dash::version_negotiation::get_desired_version_weights(
+                        chain, sampling_start, static_cast<uint64_t>(sample_count));
+                    for (auto& [ver, w] : weights)
+                        sampling[std::to_string(ver)] = w.getdouble();
+                }
+                out["sampling_desired_version"] = sampling;
+
+                // Publish as last-good so busy ticks can serve the full gauge fields.
+                {
+                    std::lock_guard<std::mutex> lock(s_cache_mutex);
+                    s_last_good = out;
+                }
                 return out;
             });
+
+            // ── Signed transitional-message feed (DISPLAY + VERIFY) ────────────
+            // Reuses the LTC crossing's exact signed-message component: read the
+            // best share's m_message_data blob, decrypt+verify the ECDSA signature
+            // against the pinned authority pubkeys (dash::unpack_share_messages →
+            // decrypt_message_data checks the 2 DONATION_AUTHORITY_PUBKEYS), and
+            // hand the SHARED core::rest_version_signaling() the same JSON shape
+            // main_ltc.cpp emits so the dashboard renders the signed v16→v36
+            // transition notice + pool announcements with a verified badge + signer.
+            //
+            // Phase A: DASH shares carry an EMPTY m_message_data (share.hpp:142), so
+            // this returns {decrypted:false, messages:[]} and the panel stays hidden
+            // until a signed blob is minted into shares (Phase B — see PR notes:
+            // the operator signs a MSG_TRANSITION_SIGNAL/0x20 payload with the
+            // authority privkey and the mint path embeds it in m_message_data).
+            // The DISPLAY+VERIFY path is fully wired now; only the emit side is Phase B.
+            mi->set_protocol_messages_fn([node_ptr]() -> nlohmann::json {
+                nlohmann::json result = {
+                    {"best_share_hash", ""},
+                    {"message_data_hex", ""},
+                    {"decrypted", false},
+                    {"authority_pubkey_hex", ""},
+                    {"messages", nlohmann::json::array()}
+                };
+
+                auto best = node_ptr->best_share_hash();
+                if (best.IsNull()) return result;
+                auto guard = node_ptr->read_tracker();
+                if (!guard) return result;
+                if (!guard->chain.contains(best)) return result;
+                result["best_share_hash"] = best.GetHex();
+
+                std::vector<unsigned char> blob;
+                guard->chain.get(best).share.invoke([&](auto* s) {
+                    if constexpr (requires { s->m_message_data; })
+                        blob = s->m_message_data.m_data;
+                });
+                if (blob.empty()) return result;
+
+                result["message_data_hex"] = HexStr(blob);
+                auto unpacked = dash::unpack_share_messages(blob.data(), blob.size());
+                result["decrypted"] = unpacked.decrypted;   // true ⇒ signature verified
+                if (!unpacked.decrypted || unpacked.authority_pubkey == nullptr)
+                    return result;
+
+                result["authority_pubkey_hex"] = HexStr(std::vector<unsigned char>(
+                    unpacked.authority_pubkey->begin(), unpacked.authority_pubkey->end()));
+                nlohmann::json msgs = nlohmann::json::array();
+                for (const auto& msg : unpacked.messages) {
+                    msgs.push_back({
+                        {"type", msg.msg_type},
+                        {"flags", msg.flags},
+                        {"timestamp", msg.timestamp},
+                        {"payload_hex", HexStr(msg.payload)},
+                        {"signature_hex", HexStr(msg.signature)},
+                        {"protocol_authority", (msg.wire_flags & dash::FLAG_PROTOCOL_AUTHORITY) != 0},
+                        {"is_transition_signal", msg.msg_type == dash::MSG_TRANSITION_SIGNAL}
+                    });
+                }
+                result["messages"] = msgs;
+                return result;
+            });
+
+            // Seed the cached "live share version" the /v36_status fallback reads
+            // when the chain is too short (<10 shares) for version_signaling to run.
+            // Core defaults this to 36 (LTC-family); DASH mines wire-format v16 until
+            // the accept-floor ratchets 1700→3600, so seed from the live floor to
+            // avoid a spurious "v36 active" on an empty/young DASH chain. Once the
+            // chain matures the stats fn's "live_share_version" drives it. Display-only.
+            mi->set_cached_share_version(
+                node_ptr->runtime_min_protocol_version()
+                    >= dash::SharechainConfig::NEW_MINIMUM_PROTOCOL_VERSION ? 36 : 16);
 
             // ── REAL pool hashrate (ported from main_ltc.cpp:2865) ────────
             // dash::ShareTracker::get_pool_attempts_per_second is the same

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -4945,18 +4945,23 @@ nlohmann::json MiningInterface::rest_version_signaling(const nlohmann::json* cac
 {
     // V35→V36 transition tracking applies to every v36-ratcheting coin
     // (LTC/DOGE/BTC/DGB, plus BCH which reaches this path as its embedded base
-    // coin). Only static-version coins (Dash = v16) have no pending transition,
-    // so for those return an empty object to keep the crossing banner hidden.
-    // A prior hardcoded {LTC,DOGE} allowlist suppressed the crossing banner on
-    // BTC/DGB/BCH nodes mid-cross — a charter #3 blind spot. Coins whose
-    // sharechain stats carry no vote data simply fall through to an empty result
-    // below, so the banner stays hidden until there is real crossing state.
-    if (m_blockchain == Blockchain::DASH)
-        return nlohmann::json::object();
+    // coin). DASH runs its OWN v16→v36 crossing (auto_ratchet.hpp lifts the accept
+    // floor 1700→3600 on ≥95% work-weighted v36 desire): its sharechain-stats fn
+    // (main_dash.cpp) emits the same shares_by_desired_version / sampling weight /
+    // propagation fields, so DASH flows through the identical gauge computation
+    // below — the crossing banner stays hidden until there is real vote data
+    // (overall_total<10 or no shares_by_* → empty result). A prior hardcoded early
+    // return suppressed the DASH crossing banner outright — a charter #3 blind
+    // spot now that DASH ratchets. Coins whose stats carry no vote data simply
+    // fall through to an empty result, so the banner stays hidden.
 
     // Matches p2pool's get_version_signaling() — all fields the dashboard JS expects.
     constexpr int TARGET_VERSION = 36;
+    // ETA cadence for the propagation countdown (display only): DASH mints one
+    // share every 20s, the LTC-family every 10s.
+    const int share_period_sec = (m_blockchain == Blockchain::DASH) ? 20 : 10;
     const std::map<int, std::string> share_type_names = {
+        {16, "DashShare"},
         {17, "Share"}, {32, "PreSegwitShare"}, {33, "NewShare"},
         {34, "SegwitMiningShare"}, {35, "PaddingBugfixShare"}, {36, "MergedMiningShare"}
     };
@@ -5101,7 +5106,7 @@ nlohmann::json MiningInterface::rest_version_signaling(const nlohmann::json* cac
         // V36 votes exist but haven't reached the sampling window yet
         status = "propagating";
         int shares_to = std::max(0, chain_length - deepest_v36_pos);
-        int eta_sec = shares_to * 10;  // SHARE_PERIOD = 10s for LTC
+        int eta_sec = shares_to * share_period_sec;  // per-coin share cadence
         int eta_min = eta_sec / 60;
         int eta_h = eta_min / 60;
         int eta_m = eta_min % 60;
@@ -5167,8 +5172,7 @@ nlohmann::json MiningInterface::rest_version_signaling(const nlohmann::json* cac
     double propagation_pct = propagation_target > 0
         ? std::min(deepest_v36_pos * 100.0 / propagation_target, 100.0) : 0;
     int shares_to_window = std::max(0, propagation_target - deepest_v36_pos);
-    constexpr int SHARE_PERIOD = 10;  // LTC: 10 seconds per share
-    double time_to_window_seconds = shares_to_window * SHARE_PERIOD;
+    double time_to_window_seconds = shares_to_window * share_period_sec;  // per-coin cadence
     result["propagation_pct"] = std::round(propagation_pct * 100) / 100.0;
     result["propagation_target"] = propagation_target;
     result["deepest_v36_position"] = deepest_v36_pos;
@@ -5188,6 +5192,10 @@ nlohmann::json MiningInterface::rest_version_signaling(const nlohmann::json* cac
             auto pm = m_protocol_messages_fn();
             if (pm.value("decrypted", false) && pm.contains("messages") && pm["messages"].is_array()) {
                 auto now = static_cast<uint32_t>(std::time(nullptr));
+                // Signer identity: the authority pubkey whose signature verified the
+                // blob (unpack returns it only on a good ECDSA check). Surfaced so the
+                // dashboard can show "✓ Verified — signed by <pubkey>" on the notice.
+                std::string signer = pm.value("authority_pubkey_hex", "");
                 nlohmann::json announcements = nlohmann::json::array();
                 for (auto& msg : pm["messages"]) {
                     int msg_type = msg.value("type", 0);
@@ -5200,7 +5208,7 @@ nlohmann::json MiningInterface::rest_version_signaling(const nlohmann::json* cac
                     try { payload_json = nlohmann::json::parse(payload_text); } catch (...) {}
 
                     if (msg_type == 0x20 && is_authority && result["transition_message"].is_null()) {
-                        nlohmann::json tmsg = {{"timestamp", ts}, {"verified", true}, {"authority", true}};
+                        nlohmann::json tmsg = {{"timestamp", ts}, {"verified", true}, {"authority", true}, {"signer", signer}};
                         if (payload_json.is_object()) {
                             tmsg["msg"] = payload_json.value("msg", "");
                             tmsg["url"] = payload_json.value("url", "");
@@ -5214,7 +5222,7 @@ nlohmann::json MiningInterface::rest_version_signaling(const nlohmann::json* cac
                             {"type", (msg_type == 0x10) ? "EMERGENCY" : "POOL_ANNOUNCE"},
                             {"type_id", msg_type}, {"timestamp", ts},
                             {"age", (now > ts) ? int(now - ts) : 0},
-                            {"verified", true}, {"authority", is_authority}
+                            {"verified", true}, {"authority", is_authority}, {"signer", signer}
                         };
                         if (payload_json.is_object()) {
                             ann["text"] = payload_json.value("msg", payload_json.value("text", ""));
@@ -5304,11 +5312,13 @@ nlohmann::json MiningInterface::rest_version_signaling(const nlohmann::json* cac
             effective_state = "voting";
         }
         // The chain-derived state above can momentarily disagree with what the
-        // node is ACTUALLY mining: m_cached_share_version is the live ratchet
-        // output (the version stamped on this node's new shares). Surface it as
-        // ground truth so a transient sampling dip cannot make the dashboard
-        // claim "voting" while the node has already latched to V36 (charter #3).
-        int64_t live_share_version = m_cached_share_version;
+        // node is ACTUALLY mining: the live ratchet output (the version stamped on
+        // this node's new shares) is ground truth so a transient sampling dip
+        // cannot make the dashboard claim "voting" while the node has already
+        // latched to V36 (charter #3). LTC-family sources it from m_cached_share_version;
+        // DASH (whose shares stay wire-format v16 across the whole crossing) hands
+        // the ratchet-derived version through the stats fn as "live_share_version".
+        int64_t live_share_version = sc.value("live_share_version", static_cast<int64_t>(m_cached_share_version));
         result["auto_ratchet"] = {
             {"state", effective_state},
             {"persisted_state", effective_state},
@@ -5318,6 +5328,15 @@ nlohmann::json MiningInterface::rest_version_signaling(const nlohmann::json* cac
             {"activated_height", nullptr},
             {"confirmed_at", nullptr}
         };
+
+        // Protocol-floor gauge pass-through (display only). DASH's stats fn emits
+        // the live accept-floor + advert; surface them so the dashboard can show
+        // "min-protocol floor 1700 → 3600" and "advertised vs current share version"
+        // alongside the vote gauge. Harmless for coins that don't emit these keys.
+        for (const char* k : {"min_protocol_version", "cold_min_protocol_version",
+                              "new_min_protocol_version", "advertised_protocol_version"}) {
+            if (sc.contains(k)) result[k] = sc[k];
+        }
     }
 
     return result;

--- a/src/impl/dash/node.hpp
+++ b/src/impl/dash/node.hpp
@@ -274,6 +274,14 @@ protected:
     std::set<NetService> m_whitelist_hosts;
 
 public:
+    // DISPLAY-ONLY read of the live P2P accept-floor (v36 ratchet output). Read
+    // atomically off any thread; the dashboard's /version_signaling surfaces this
+    // as the "min-protocol floor" gauge (1700 pre-crossing -> 3600 post-ratchet).
+    // Consensus-neutral: a plain atomic load, no side effects.
+    uint32_t runtime_min_protocol_version() const {
+        return m_runtime_min_protocol_version.load(std::memory_order_relaxed);
+    }
+
     // Default (rig-free) construction for tests/standalone: no io_context, the
     // share-getter requester is a no-op (there are no peers to write a
     // sharereq to; the ctx ctor below wires the real writer). Routes m_chain

--- a/test/test_web_honesty_regression.cpp
+++ b/test/test_web_honesty_regression.cpp
@@ -418,21 +418,65 @@ TEST(WebHonestyRegression, VersionSignalingSurfacesOnRatchetingDgb) {
     EXPECT_DOUBLE_EQ(r["overall_v36_vote_pct"].get<double>(), 100.0);
 }
 
-// DASH is non-ratcheting (static v16) -- the ONE coin #496 keeps excluded. Even
-// with full vote data wired, its crossing banner stays hidden: surfacing a
-// V35->V36 transition on a chain that has no such transition would be a lie.
-TEST(WebHonestyRegression, VersionSignalingSuppressedOnNonRatchetingDash) {
+// DASH now runs its OWN v16->v36 crossing: the accept-floor ratchet is armed
+// (apply_min_protocol_ratchet lifts 1700->3600 on >=95% work-weighted v36 desire).
+// The pre-#496 blanket suppression predated that armed ratchet; keeping it would
+// now be the LIE -- hiding a genuinely-armed transition. So DASH version_signaling
+// must surface the TRUTHFUL pre-crossing state: show_transition=true, status
+// "waiting", 0% v36 votes, floor 1700 (target 3600), v36 not yet active. Showing
+// "0% v36, waiting, floor 1700" is honest (a transition is real and armed); the
+// old empty {} is not. Mirrors what main_dash.cpp's stats fn emits pre-crossing.
+TEST(WebHonestyRegression, VersionSignalingTruthfulPreCrossingDash) {
     MiningInterface mi(/*testnet=*/true, /*node=*/nullptr, Blockchain::DASH);
+    // Real DASH pre-crossing shape: wire-format v16 shares, all still DESIRING v16
+    // (0% v36), a mature chain, and the armed accept-floor at its cold 1700 with the
+    // 3600 target advertised -- exactly the fields main_dash.cpp's stats fn emits.
     mi.set_sharechain_stats_fn([] {
         return json{
             {"total_shares", 100},
-            {"shares_by_version", {{"35", 100}}},
-            {"shares_by_desired_version", {{"36", 80}}},
+            {"chain_height", 4320},
+            {"chain_length", 4320},
+            {"shares_by_version", {{"16", 100}}},
+            {"shares_by_desired_version", {{"16", 100}}},
+            {"sampling_desired_version", {{"16", 1.0e15}}},
+            {"deepest_v36_position", 0},
+            {"v36_contiguous_from_tip", 0},
+            {"min_protocol_version", 1700},
+            {"cold_min_protocol_version", 1700},
+            {"new_min_protocol_version", 3600},
+            {"advertised_protocol_version", 3600},
+            {"live_share_version", 16},
         };
     });
-    EXPECT_TRUE(mi.rest_version_signaling().empty())
-        << "Dash is static v16 (non-ratcheting) -- no V35->V36 crossing exists, so "
-           "the banner must stay hidden regardless of wired vote data";
+
+    json r = mi.rest_version_signaling();
+    ASSERT_FALSE(r.empty())
+        << "DASH now ratchets v16->v36 -- the crossing gauge must surface the real "
+           "pre-crossing state, not the pre-armed-ratchet empty suppression";
+
+    // Truthful pre-crossing: a transition is armed but no v36 votes yet.
+    EXPECT_TRUE(r.value("show_transition", false))
+        << "an armed-but-unstarted crossing IS a transition to show (honestly at 0%)";
+    EXPECT_EQ(r.value("status", std::string{}), "waiting")
+        << "0 v36 votes on a ready chain -> waiting-for-upgrade, not a fabricated cross";
+    EXPECT_EQ(r["target_version"].get<int>(), 36);
+    EXPECT_EQ(r["current_share_type"].get<int>(), 16)
+        << "DASH mines wire-format v16 across the whole crossing";
+    EXPECT_DOUBLE_EQ(r["overall_v36_vote_pct"].get<double>(), 0.0)
+        << "no share desires v36 yet -- the gauge must read a truthful 0%";
+    EXPECT_DOUBLE_EQ(r["sampling_signaling"].get<double>(), 0.0);
+
+    // Protocol-floor gauge pass-through (the min-proto floor 1700 -> 3600 target).
+    EXPECT_EQ(r.value("min_protocol_version", 0), 1700);
+    EXPECT_EQ(r.value("new_min_protocol_version", 0), 3600);
+    EXPECT_EQ(r.value("advertised_protocol_version", 0), 3600);
+
+    // The ratchet has NOT latched: this node still mines v16, v36 not active.
+    ASSERT_TRUE(r.contains("auto_ratchet"));
+    EXPECT_EQ(r["auto_ratchet"].value("live_share_version", 0), 16);
+    EXPECT_FALSE(r["auto_ratchet"].value("v36_active", true))
+        << "floor is still 1700 -- v36 must NOT read active pre-crossing";
+    EXPECT_EQ(r["auto_ratchet"].value("state", std::string{}), "voting");
 }
 
 // Honest-empty: a ratcheting coin with too little chain (<10 shares) has no real

--- a/web-static/dashboard.html
+++ b/web-static/dashboard.html
@@ -3141,9 +3141,35 @@
                     }
                     
                     d3.select('#version-signaling').style('display', 'block');
-                    
+
                     // Update title
                     d3.select('.signaling-title').text('V' + vs.current_share_type + ' \u2192 V' + vs.target_version + ' Transition');
+
+                    // Protocol-floor gauge line: accept-floor (ratchet output), advert,
+                    // and the version this node stamps on new shares. Only rendered when
+                    // the node reports the floor (DASH v16\u2192v36 crossing surfaces these).
+                    (function() {
+                        var vsCard = d3.select('#version-signaling');
+                        vsCard.select('.protocol-floor-line').remove();
+                        if (vs.min_protocol_version == null) return;
+                        var floor = vs.min_protocol_version;
+                        var newFloor = vs.new_min_protocol_version;
+                        var adv = vs.advertised_protocol_version;
+                        var liveVer = (vs.auto_ratchet && vs.auto_ratchet.live_share_version) || vs.current_share_type;
+                        var ratcheted = (newFloor != null && floor >= newFloor);
+                        var line = vsCard.append('div')
+                            .attr('class', 'protocol-floor-line')
+                            .style('display', 'flex').style('flex-wrap', 'wrap')
+                            .style('gap', '14px').style('margin', '4px 0 10px 0')
+                            .style('font-size', '0.82em').style('color', '#9fb3c8');
+                        function chip(label, val, hot) {
+                            line.append('span').html(
+                                label + ': <b style="color:' + (hot ? '#22c55e' : '#e2e8f0') + '">' + val + '</b>');
+                        }
+                        chip('Accept-floor', floor + (ratcheted ? ' (ratcheted \u2713)' : ' \u2192 ' + (newFloor||'?')), ratcheted);
+                        chip('Advertised', adv != null ? adv : '\u2014', false);
+                        chip('This node mines', 'V' + liveVer, liveVer >= (vs.target_version||36));
+                    })();
                     
                     // Transition status message
                     var statusMsg = '';
@@ -3340,6 +3366,33 @@
                             d3.select('#transition-msg-url').attr('href', tmsg.url).text(tmsg.url + ' →');
                         } else {
                             d3.select('#transition-msg-url-row').style('display', 'none');
+                        }
+                        // Signature-verified badge + signer + timestamp. The backend sets
+                        // verified=true only after the ECDSA signature checks against a
+                        // pinned authority pubkey, so this is a real cryptographic trust
+                        // indicator — a miner can see the notice is from the legit operator.
+                        var tsec = d3.select('#transition-message-section');
+                        tsec.select('.tx-verified-line').remove();
+                        var vline = tsec.append('div')
+                            .attr('class', 'tx-verified-line')
+                            .style('margin-top', '8px').style('font-size', '0.8em')
+                            .style('display', 'flex').style('flex-wrap', 'wrap').style('gap', '10px');
+                        if (tmsg.verified) {
+                            vline.append('span').style('color', '#22c55e').style('font-weight', '600')
+                                .text('✓ Signature verified (authority-signed)');
+                            if (tmsg.signer) {
+                                var sg = String(tmsg.signer);
+                                vline.append('span').style('color', '#8fa3b8')
+                                    .html('signer: <code style="color:#cbd5e1">' +
+                                          (sg.length > 20 ? sg.slice(0, 10) + '…' + sg.slice(-8) : sg) + '</code>');
+                            }
+                        } else {
+                            vline.append('span').style('color', '#f59e0b').style('font-weight', '600')
+                                .text('⚠ Unverified signature');
+                        }
+                        if (tmsg.timestamp) {
+                            vline.append('span').style('color', '#8fa3b8')
+                                .text('signed: ' + new Date(tmsg.timestamp * 1000).toISOString().replace('T', ' ').slice(0, 19) + ' UTC');
                         }
                     } else {
                         d3.select('#transition-message-section').style('display', 'none');


### PR DESCRIPTION
**DRAFT — do-not-merge.** Integrator merges after dashboard-steward review. Consensus-neutral, display-only.

## What & why
Reuses the LTC v35→v36 crossing dashboard for DASH's **v16→v36** crossing so the operator (and any miner) can WATCH the crossing live on the dashboard **before** the hotel repoints onto the p2pool-dash sharechain and the ratchet is armed. DASH's ratchet is already merged (`apply_min_protocol_ratchet` keys on `get_desired_version_weights`); this shows the same numbers the ratchet decides on. **No consensus logic changes** — every read is display-only.

The shared `core::rest_version_signaling()` + `web-static/dashboard.html` already render the whole transition card for the LTC family; DASH was hard-short-circuited to `{}`. This wires DASH into the **same** path.

## LTC components reused (no reinvention)
| Gauge | Reused LTC component | DASH data source |
|---|---|---|
| Ratchet / crossing gauge | `rest_version_signaling` generic body (signaling bar, status phases, sampling %) | `sampling_desired_version` (work-weighted, `get_desired_version_weights`) + accept-floor 1700→3600 |
| Share-version distribution | `share_types` / `full_chain_versions` render | `shares_by_version` (v16 format) + `shares_by_desired_version` (16 vs 36 votes) |
| Sharechain status | existing peers / shares-in-chain / maturity cards | tracker snapshot + windowed walk |
| PPLNS distribution | `/current_payouts` card | existing DASH PPLNS outputs; `shares_by_miner` tally added (fixes Miners/Users card) |
| **Signed transitional message + verify** | `set_protocol_messages_fn` + `transition_message`/`authority_announcements` render | `dash::unpack_share_messages` (ECDSA verify vs pinned authority pubkeys) on best share's `m_message_data` |

## Signed transitional-message blob (operator requirement 1+2)
- **Display + verify wired**: `protocol_messages_fn` for DASH reads the best share's `m_message_data`, calls `dash::unpack_share_messages` → `decrypt_message_data` which **verifies the ECDSA signature against the two pinned authority pubkeys** (`DONATION_PUBKEY_FORRESTV` `03ffd0…`, `DONATION_PUBKEY_MAINTAINER` `02fe65…`). Frontend shows the notice text + **✓ Signature verified** badge + **signer** pubkey + **signed timestamp**, plus a pool-announcements feed. `verified=true` is only set after the signature checks — a real cryptographic trust indicator.

### ⚠️ Design point needing an operator decision (blob emit side is Phase B)
The **display + verify** path is fully wired now. The **emit** side is not: DASH v16 shares carry an **empty** `m_message_data` in Phase A (`share.hpp:142`), so pre-crossing the panel stays hidden (correct). To actually broadcast a signed v16→v36 transition notice, the operator must decide/confirm:
1. **Signing key** — which authority privkey signs (the two pinned pubkeys above are the current trust anchors; confirm the operator holds the matching privkey).
2. **Blob schema** — a `MSG_TRANSITION_SIGNAL` (0x20) message, `FLAG_PROTOCOL_AUTHORITY`, JSON payload `{msg,url,urg,from,to}` (same schema the LTC crossing used and this code parses).
3. **Emit path** — the DASH mint path must embed the signed blob into minted shares' `m_message_data` (Phase B) so it propagates on the sharechain.

## Files
- `core/web_server.cpp` — drop DASH short-circuit; v16 name; per-coin ETA cadence; live-share-version from stats; protocol-floor pass-through; `signer` on messages.
- `c2pool/main_dash.cpp` — stats fn version/sampling/propagation/floor + miner tally + last-good cache; `protocol_messages_fn`; seed cached share-version.
- `impl/dash/node.hpp` — `runtime_min_protocol_version()` display-only accessor.
- `web-static/dashboard.html` — protocol-floor line + signature-verified/signer/timestamp badge (additive; JS syntax-checked).

## Verification (built + served against a real pre-crossing mainnet DASH sharechain, 4320-window)
`/version_signaling`: `status=waiting`, `overall_v36_vote_pct=0.0`, `sampling_signaling=0.0`, `full_chain_versions={16:{count:4320,pct:100.0}}`, `show_transition=true`, `min_protocol_version=1700`, `new=3600`, `advertised=3600`, `auto_ratchet={state:voting, live_share_version:16, v36_active:false}`. `/users=3`. Stable across rapid polls (no flap). Endpoints show sensible **pre-crossing** values (0% v36, floor 1700), ready to watch climb during the crossing.

Known cosmetic: post-activation the "chain-fill %" confirmation bar keys on v36 share *format*, which DASH never has (v16 wire-format across the whole crossing) — the pre-crossing + signaling gauges (the watch target) are unaffected.