### PR TITLE
impl(all-coins): snapshot get_peer_info_json to close the peer-map read race (back-port of #828)

### DIFF
--- a/src/impl/bch/node.cpp
+++ b/src/impl/bch/node.cpp
@@ -186,6 +186,7 @@ void NodeImpl::error(const message_error_type& err, const NetService& service, c
     // Clean outbound tracking before base removes the peer
     m_pending_outbound.erase(service);
     m_outbound_addrs.erase(service);
+    publish_peer_info_snapshot();   // IO thread: refresh after peer removal
 
     // p2pool p2p.py:595: self.get_shares.respond_all(reason)
     // Cancel pending share requests for this peer — invokes callbacks with
@@ -239,6 +240,7 @@ void NodeImpl::close_connection(const NetService& service)
     }
 
     base_t::close_connection(service);
+    publish_peer_info_snapshot();   // IO thread: refresh after close
 }
 
 NodeImpl::TrackerSnapshot NodeImpl::get_tracker_snapshot() const {
@@ -301,6 +303,7 @@ std::optional<pool::PeerConnectionType> NodeImpl::handle_version(std::unique_ptr
 
         peer->m_nonce = msg->m_nonce;
         m_peers[peer->m_nonce] = peer;
+        publish_peer_info_snapshot();   // IO thread: refresh the display snapshot
 
         // Request peers from the newly established connection
         {
@@ -1667,6 +1670,7 @@ void NodeImpl::run_think()
             LOG_INFO << "[ASYNC-THINK] IO-phase: draining " << m_pending_adds.size()
                      << " pending batches, peers=" << m_peers.size();
             drain_pending_adds();
+            publish_peer_info_snapshot();   // IO thread: keep uptime fresh
 
             // Cycle completed normally — disarm the watchdog first so it
             // cannot fire on this (now-finished) generation.

--- a/src/impl/bch/node.hpp
+++ b/src/impl/bch/node.hpp
@@ -141,6 +141,19 @@ protected:
     mutable std::mutex m_snapshot_mutex;
     TrackerSnapshot m_snapshot;
 
+    // ── Lock-free peer-info snapshot (display-only) ──────────────────────
+    // m_peers / m_outbound_addrs are IO-thread-owned with NO lock; the
+    // dashboard peer panel (set_peer_info_fn -> /peer_list, /peer_versions, …)
+    // is served from the WebServer. Iterating those std::maps off the IO
+    // thread while handle_version inserts / error()+close_connection erase
+    // rebalances the tree under the reader's iterator -> freed-memory GP-fault
+    // (back-port of the DASH #828 fix). So the JSON is BUILT on the IO thread
+    // (publish_peer_info_snapshot, at every peer add/remove + the think
+    // IO-phase for uptime freshness) and get_peer_info_json returns this copy
+    // lock-free — it NEVER touches the live maps. Guarded by the existing
+    // m_snapshot_mutex (held only for the swap; never nested with the tracker).
+    nlohmann::json m_peer_info_snapshot = nlohmann::json::array();
+
     // Identity of the compute thread (m_think_pool's single thread).
     // Used by TrackerReadGuard to skip shared_lock when the caller is
     // already on the compute thread (which holds exclusive lock).
@@ -542,10 +555,14 @@ public:
             peer->write(message_bestblock::make_raw(header));
     }
 
-    /// Return a JSON array of connected peer info for the /peer_list endpoint.
-    nlohmann::json get_peer_info_json() const {
+    /// Rebuild the lock-free peer-info snapshot. IO-THREAD ONLY (reads the
+    /// IO-owned m_peers / m_outbound_addrs). Called at every peer add/remove
+    /// and on the think IO-phase. Publishes under m_snapshot_mutex so the
+    /// dashboard reader (get_peer_info_json) never touches the live maps.
+    void publish_peer_info_snapshot() {
         nlohmann::json arr = nlohmann::json::array();
         for (const auto& [nonce, peer] : m_peers) {
+            if (!peer) continue;
             auto addr = peer->addr();
             bool incoming = (m_outbound_addrs.find(addr) == m_outbound_addrs.end());
             auto uptime_sec = std::chrono::duration_cast<std::chrono::seconds>(
@@ -559,7 +576,17 @@ public:
                 {"web_port", 0}
             });
         }
-        return arr;
+        std::lock_guard<std::mutex> lock(m_snapshot_mutex);
+        m_peer_info_snapshot = std::move(arr);
+    }
+
+    /// Return a JSON array of connected peer info for the /peer_list endpoint.
+    /// Returns the IO-thread-published snapshot lock-free — it must NEVER
+    /// iterate the live m_peers map (that races the IO thread's insert/erase
+    /// -> freed-memory GP-fault; back-port of DASH #828).
+    nlohmann::json get_peer_info_json() const {
+        std::lock_guard<std::mutex> lock(m_snapshot_mutex);
+        return m_peer_info_snapshot;
     }
 
     /// Register a callback invoked whenever a bestblock message is received

--- a/src/impl/btc/node.cpp
+++ b/src/impl/btc/node.cpp
@@ -186,6 +186,7 @@ void NodeImpl::error(const message_error_type& err, const NetService& service, c
     // Clean outbound tracking before base removes the peer
     m_pending_outbound.erase(service);
     m_outbound_addrs.erase(service);
+    publish_peer_info_snapshot();   // IO thread: refresh after peer removal
 
     // p2pool p2p.py:595: self.get_shares.respond_all(reason)
     // Cancel pending share requests for this peer — invokes callbacks with
@@ -239,6 +240,7 @@ void NodeImpl::close_connection(const NetService& service)
     }
 
     base_t::close_connection(service);
+    publish_peer_info_snapshot();   // IO thread: refresh after close
 }
 
 NodeImpl::TrackerSnapshot NodeImpl::get_tracker_snapshot() const {
@@ -301,6 +303,7 @@ std::optional<pool::PeerConnectionType> NodeImpl::handle_version(std::unique_ptr
 
         peer->m_nonce = msg->m_nonce;
         m_peers[peer->m_nonce] = peer;
+        publish_peer_info_snapshot();   // IO thread: refresh the display snapshot
 
         // Request peers from the newly established connection
         {
@@ -1664,6 +1667,7 @@ void NodeImpl::run_think()
             LOG_INFO << "[ASYNC-THINK] IO-phase: draining " << m_pending_adds.size()
                      << " pending batches, peers=" << m_peers.size();
             drain_pending_adds();
+            publish_peer_info_snapshot();   // IO thread: keep uptime fresh
 
             // Cycle completed normally — disarm the watchdog first so it
             // cannot fire on this (now-finished) generation.

--- a/src/impl/btc/node.hpp
+++ b/src/impl/btc/node.hpp
@@ -105,6 +105,19 @@ protected:
     mutable std::mutex m_snapshot_mutex;
     TrackerSnapshot m_snapshot;
 
+    // ── Lock-free peer-info snapshot (display-only) ──────────────────────
+    // m_peers / m_outbound_addrs are IO-thread-owned with NO lock; the
+    // dashboard peer panel (set_peer_info_fn -> /peer_list, /peer_versions, …)
+    // is served from the WebServer. Iterating those std::maps off the IO
+    // thread while handle_version inserts / error()+close_connection erase
+    // rebalances the tree under the reader's iterator -> freed-memory GP-fault
+    // (back-port of the DASH #828 fix). So the JSON is BUILT on the IO thread
+    // (publish_peer_info_snapshot, at every peer add/remove + the think
+    // IO-phase for uptime freshness) and get_peer_info_json returns this copy
+    // lock-free — it NEVER touches the live maps. Guarded by the existing
+    // m_snapshot_mutex (held only for the swap; never nested with the tracker).
+    nlohmann::json m_peer_info_snapshot = nlohmann::json::array();
+
     // Identity of the compute thread (m_think_pool's single thread).
     // Used by TrackerReadGuard to skip shared_lock when the caller is
     // already on the compute thread (which holds exclusive lock).
@@ -300,10 +313,14 @@ public:
             peer->write(message_bestblock::make_raw(header));
     }
 
-    /// Return a JSON array of connected peer info for the /peer_list endpoint.
-    nlohmann::json get_peer_info_json() const {
+    /// Rebuild the lock-free peer-info snapshot. IO-THREAD ONLY (reads the
+    /// IO-owned m_peers / m_outbound_addrs). Called at every peer add/remove
+    /// and on the think IO-phase. Publishes under m_snapshot_mutex so the
+    /// dashboard reader (get_peer_info_json) never touches the live maps.
+    void publish_peer_info_snapshot() {
         nlohmann::json arr = nlohmann::json::array();
         for (const auto& [nonce, peer] : m_peers) {
+            if (!peer) continue;
             auto addr = peer->addr();
             bool incoming = (m_outbound_addrs.find(addr) == m_outbound_addrs.end());
             auto uptime_sec = std::chrono::duration_cast<std::chrono::seconds>(
@@ -317,7 +334,17 @@ public:
                 {"web_port", 0}
             });
         }
-        return arr;
+        std::lock_guard<std::mutex> lock(m_snapshot_mutex);
+        m_peer_info_snapshot = std::move(arr);
+    }
+
+    /// Return a JSON array of connected peer info for the /peer_list endpoint.
+    /// Returns the IO-thread-published snapshot lock-free — it must NEVER
+    /// iterate the live m_peers map (that races the IO thread's insert/erase
+    /// -> freed-memory GP-fault; back-port of DASH #828).
+    nlohmann::json get_peer_info_json() const {
+        std::lock_guard<std::mutex> lock(m_snapshot_mutex);
+        return m_peer_info_snapshot;
     }
 
     /// Register a callback invoked whenever a bestblock message is received

--- a/src/impl/dgb/node.cpp
+++ b/src/impl/dgb/node.cpp
@@ -188,6 +188,7 @@ void NodeImpl::error(const message_error_type& err, const NetService& service, c
     // Clean outbound tracking before base removes the peer
     m_pending_outbound.erase(service);
     m_outbound_addrs.erase(service);
+    publish_peer_info_snapshot();   // IO thread: refresh after peer removal
 
     // p2pool p2p.py:595: self.get_shares.respond_all(reason)
     // Cancel pending share requests for this peer — invokes callbacks with
@@ -241,6 +242,7 @@ void NodeImpl::close_connection(const NetService& service)
     }
 
     base_t::close_connection(service);
+    publish_peer_info_snapshot();   // IO thread: refresh after close
 }
 
 NodeImpl::TrackerSnapshot NodeImpl::get_tracker_snapshot() const {
@@ -303,6 +305,7 @@ std::optional<pool::PeerConnectionType> NodeImpl::handle_version(std::unique_ptr
 
         peer->m_nonce = msg->m_nonce;
         m_peers[peer->m_nonce] = peer;
+        publish_peer_info_snapshot();   // IO thread: refresh the display snapshot
 
         // Request peers from the newly established connection
         {
@@ -1651,6 +1654,7 @@ void NodeImpl::run_think()
             LOG_INFO << "[ASYNC-THINK] IO-phase: draining " << m_pending_adds.size()
                      << " pending batches, peers=" << m_peers.size();
             drain_pending_adds();
+            publish_peer_info_snapshot();   // IO thread: keep uptime fresh
 
             // Clear flag AFTER drain — prevents new think() from starting
             // while deferred shares are still being added to the tracker.

--- a/src/impl/dgb/node.hpp
+++ b/src/impl/dgb/node.hpp
@@ -144,6 +144,19 @@ protected:
     mutable std::mutex m_snapshot_mutex;
     TrackerSnapshot m_snapshot;
 
+    // ── Lock-free peer-info snapshot (display-only) ──────────────────────
+    // m_peers / m_outbound_addrs are IO-thread-owned with NO lock; the
+    // dashboard peer panel (set_peer_info_fn -> /peer_list, /peer_versions, …)
+    // is served from the WebServer. Iterating those std::maps off the IO
+    // thread while handle_version inserts / error()+close_connection erase
+    // rebalances the tree under the reader's iterator -> freed-memory GP-fault
+    // (back-port of the DASH #828 fix). So the JSON is BUILT on the IO thread
+    // (publish_peer_info_snapshot, at every peer add/remove + the think
+    // IO-phase for uptime freshness) and get_peer_info_json returns this copy
+    // lock-free — it NEVER touches the live maps. Guarded by the existing
+    // m_snapshot_mutex (held only for the swap; never nested with the tracker).
+    nlohmann::json m_peer_info_snapshot = nlohmann::json::array();
+
     // Identity of the compute thread (m_think_pool's single thread).
     // Used by TrackerReadGuard to skip shared_lock when the caller is
     // already on the compute thread (which holds exclusive lock).
@@ -319,10 +332,14 @@ public:
             peer->write(message_bestblock::make_raw(header));
     }
 
-    /// Return a JSON array of connected peer info for the /peer_list endpoint.
-    nlohmann::json get_peer_info_json() const {
+    /// Rebuild the lock-free peer-info snapshot. IO-THREAD ONLY (reads the
+    /// IO-owned m_peers / m_outbound_addrs). Called at every peer add/remove
+    /// and on the think IO-phase. Publishes under m_snapshot_mutex so the
+    /// dashboard reader (get_peer_info_json) never touches the live maps.
+    void publish_peer_info_snapshot() {
         nlohmann::json arr = nlohmann::json::array();
         for (const auto& [nonce, peer] : m_peers) {
+            if (!peer) continue;
             auto addr = peer->addr();
             bool incoming = (m_outbound_addrs.find(addr) == m_outbound_addrs.end());
             auto uptime_sec = std::chrono::duration_cast<std::chrono::seconds>(
@@ -336,7 +353,17 @@ public:
                 {"web_port", 0}
             });
         }
-        return arr;
+        std::lock_guard<std::mutex> lock(m_snapshot_mutex);
+        m_peer_info_snapshot = std::move(arr);
+    }
+
+    /// Return a JSON array of connected peer info for the /peer_list endpoint.
+    /// Returns the IO-thread-published snapshot lock-free — it must NEVER
+    /// iterate the live m_peers map (that races the IO thread's insert/erase
+    /// -> freed-memory GP-fault; back-port of DASH #828).
+    nlohmann::json get_peer_info_json() const {
+        std::lock_guard<std::mutex> lock(m_snapshot_mutex);
+        return m_peer_info_snapshot;
     }
 
     /// Register a callback invoked whenever a bestblock message is received

--- a/src/impl/ltc/node.cpp
+++ b/src/impl/ltc/node.cpp
@@ -185,6 +185,7 @@ void NodeImpl::error(const message_error_type& err, const NetService& service, c
     // Clean outbound tracking before base removes the peer
     m_pending_outbound.erase(service);
     m_outbound_addrs.erase(service);
+    publish_peer_info_snapshot();   // IO thread: refresh after peer removal
 
     // p2pool p2p.py:595: self.get_shares.respond_all(reason)
     // Cancel pending share requests for this peer — invokes callbacks with
@@ -238,6 +239,7 @@ void NodeImpl::close_connection(const NetService& service)
     }
 
     base_t::close_connection(service);
+    publish_peer_info_snapshot();   // IO thread: refresh after close
 }
 
 NodeImpl::TrackerSnapshot NodeImpl::get_tracker_snapshot() const {
@@ -300,6 +302,7 @@ std::optional<pool::PeerConnectionType> NodeImpl::handle_version(std::unique_ptr
 
         peer->m_nonce = msg->m_nonce;
         m_peers[peer->m_nonce] = peer;
+        publish_peer_info_snapshot();   // IO thread: refresh the display snapshot
 
         // Request peers from the newly established connection
         {
@@ -1682,6 +1685,7 @@ void NodeImpl::run_think()
             LOG_INFO << "[ASYNC-THINK] IO-phase: draining " << m_pending_adds.size()
                      << " pending batches, peers=" << m_peers.size();
             drain_pending_adds();
+            publish_peer_info_snapshot();   // IO thread: keep uptime fresh
 
             // Clear flag AFTER drain — prevents new think() from starting
             // while deferred shares are still being added to the tracker.

--- a/src/impl/ltc/node.hpp
+++ b/src/impl/ltc/node.hpp
@@ -131,6 +131,19 @@ protected:
     mutable std::mutex m_snapshot_mutex;
     TrackerSnapshot m_snapshot;
 
+    // ── Lock-free peer-info snapshot (display-only) ──────────────────────
+    // m_peers / m_outbound_addrs are IO-thread-owned with NO lock; the
+    // dashboard peer panel (set_peer_info_fn -> /peer_list, /peer_versions, …)
+    // is served from the WebServer. Iterating those std::maps off the IO
+    // thread while handle_version inserts / error()+close_connection erase
+    // rebalances the tree under the reader's iterator -> freed-memory GP-fault
+    // (back-port of the DASH #828 fix). So the JSON is BUILT on the IO thread
+    // (publish_peer_info_snapshot, at every peer add/remove + the think
+    // IO-phase for uptime freshness) and get_peer_info_json returns this copy
+    // lock-free — it NEVER touches the live maps. Guarded by the existing
+    // m_snapshot_mutex (held only for the swap; never nested with the tracker).
+    nlohmann::json m_peer_info_snapshot = nlohmann::json::array();
+
     // Identity of the compute thread (m_think_pool's single thread).
     // Used by TrackerReadGuard to skip shared_lock when the caller is
     // already on the compute thread (which holds exclusive lock).
@@ -303,10 +316,14 @@ public:
             peer->write(message_bestblock::make_raw(header));
     }
 
-    /// Return a JSON array of connected peer info for the /peer_list endpoint.
-    nlohmann::json get_peer_info_json() const {
+    /// Rebuild the lock-free peer-info snapshot. IO-THREAD ONLY (reads the
+    /// IO-owned m_peers / m_outbound_addrs). Called at every peer add/remove
+    /// and on the think IO-phase. Publishes under m_snapshot_mutex so the
+    /// dashboard reader (get_peer_info_json) never touches the live maps.
+    void publish_peer_info_snapshot() {
         nlohmann::json arr = nlohmann::json::array();
         for (const auto& [nonce, peer] : m_peers) {
+            if (!peer) continue;
             auto addr = peer->addr();
             bool incoming = (m_outbound_addrs.find(addr) == m_outbound_addrs.end());
             auto uptime_sec = std::chrono::duration_cast<std::chrono::seconds>(
@@ -320,7 +337,17 @@ public:
                 {"web_port", 0}
             });
         }
-        return arr;
+        std::lock_guard<std::mutex> lock(m_snapshot_mutex);
+        m_peer_info_snapshot = std::move(arr);
+    }
+
+    /// Return a JSON array of connected peer info for the /peer_list endpoint.
+    /// Returns the IO-thread-published snapshot lock-free — it must NEVER
+    /// iterate the live m_peers map (that races the IO thread's insert/erase
+    /// -> freed-memory GP-fault; back-port of DASH #828).
+    nlohmann::json get_peer_info_json() const {
+        std::lock_guard<std::mutex> lock(m_snapshot_mutex);
+        return m_peer_info_snapshot;
     }
 
     /// Register a callback invoked whenever a bestblock message is received


### PR DESCRIPTION
## Summary

Back-port of the DASH `get_peer_info_json` snapshot fix (#828) to the other four coins. `get_peer_info_json()` iterated the IO-thread-owned `m_peers` + `m_outbound_addrs` maps directly and returned that to the WebServer's `set_peer_info_fn` (dashboard peer panel: `/peer_list`, `/peer_versions`, `/peer_txpool_sizes`, `/pings`). If that iteration runs off the IO thread while `handle_version` inserts / `error()`+`close_connection` erase `m_peers`, the `std::map` rebalance under the reader's iterator is a freed-memory GP-fault — the same crash class closed for DASH in #828.

## Per-coin status (verified, not assumed — each function body read directly)

| Coin | `get_peer_info_json` before | `set_peer_info_fn` wired? | Action |
|------|------------------------------|---------------------------|--------|
| **LTC** | UNLOCKED — bare `for (const auto& [nonce,peer] : m_peers)` + `m_outbound_addrs`, const, no lock (node.hpp:307–324) | **Yes — live on prod** (main_ltc.cpp:2861) | Fixed |
| **DGB** | UNLOCKED — identical copy (node.hpp:323–340) | No (latent) | Fixed |
| **BCH** | UNLOCKED — identical copy (node.hpp:546–563) | No (latent) | Fixed |
| **BTC** | UNLOCKED — identical copy (node.hpp:304–321) | No (latent) | Fixed |

All four were the identical unlocked copy. DGB/BCH/BTC don't currently wire `set_peer_info_fn` (latent) — fixed anyway so their peer panel is safe when it lands.

## Fix (identical to #828, per coin, reusing each coin's existing `m_snapshot_mutex`)

- `publish_peer_info_snapshot()` BUILDS the peer JSON on the IO thread and stores it in `m_peer_info_snapshot` under the existing `m_snapshot_mutex`; refreshed at every peer **add** (`handle_version` insert), **remove** (`error()` erase, `close_connection`), and the **think IO-phase** (uptime freshness).
- `get_peer_info_json()` returns that copy lock-free — never touches the live maps.
- Adds the null-peer guard (`if (!peer) continue;`) DASH carries. No other change to the peer-panel payload.

Sites fixed (file:line on this branch's base):
- LTC `src/impl/ltc/node.hpp` get_peer_info_json split; `node.cpp` handle_version insert (~302), error erase (~187), close_connection (~240), think IO-phase drain (~1684).
- DGB `src/impl/dgb/node.{hpp,cpp}` — insert ~305, error ~190, close ~228, think ~1653.
- BCH `src/impl/bch/node.{hpp,cpp}` — insert ~303, error ~188, close ~226, think ~1669.
- BTC `src/impl/btc/node.{hpp,cpp}` — insert ~303, error ~188, close ~226, think ~1666.

## The other 5 tracker-read sites (confirmed)

Each coin carries 22–24 `try_to_lock`/`shared_lock` hits — the download/think/broadcast reader sites already hold the discipline. One item to flag for a decision (NOT changed here): each coin's `best_share_hash()` does an unlocked `m_tracker.verified.contains(...)`/`get_heads()` walk, and it IS reachable from the web layer (`set_pool_hashrate_fn`, `set_best_share_hash_fn`). It does **not** race in these coins today because their mains call `set_io_context(&ioc)` + run a 2s HTTP cache-refresh timer on the io_context, so the RCU-wrapped web fns compute on the io_context thread (serialized with peer/tracker mutation) and the HTTP thread only reads the pre-built cache. DASH raced precisely because `main_dash` omitted that routing (`m_context` null → the wrapped fn computed on the HTTP thread). See the note below.

## Exposure nuance (important for severity)

Because `set_peer_info_fn` is RCU-wrapped (`thread_safe_wrap`) and LTC's main calls `set_io_context` + a 2s cache-refresh timer on the io_context, LTC's `get_peer_info_json` currently executes on the **io_context thread** during cache refresh (serialized with peer add/remove), and the HTTP thread only reads the cached copy — so it is **not actively GP-faulting today**. This fix makes `get_peer_info_json` intrinsically thread-safe regardless of that wiring, removing the latent class and any dependence on the RCU/`set_io_context`/cache-timer chain staying correct (which DASH's main did not have).

## Build

`c2pool-ltc`, `c2pool-dgb`, `c2pool-bch`, `c2pool-btc` — all four built green (Debug, exit 0, zero errors), run, and contain the new symbol.

Draft — do not merge. code review + cross-coin CI gate.