### PR TITLE
dash(stratum): submit height-race won-blocks instead of dropping them (payee-guard false-refusal fix)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -1184,14 +1184,20 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
 
     dash::stratum::DASHWorkSource::SubmitBlockFn stratum_submit_fn =
         [p2p_relay, rpc_submit](const std::vector<unsigned char>& block_bytes,
-                                uint32_t height) -> bool {
+                                uint32_t height,
+                                bool height_race) -> bool {
             const std::string block_hex = HexStr(block_bytes);
             std::cout << "[DASH-STRATUM-BLOCK] won block height=" << height
                       << " bytes=" << block_bytes.size()
+                      << (height_race
+                              ? " (HEIGHT RACE -- RPC-first: dashd validates before"
+                                " any coin-P2P relay)"
+                              : "")
                       << " -- dispatching dual-path (embedded P2P primary + "
                          "submitblock-RPC backup)\n";
             const auto bcast = dash::coin::broadcast_won_block(
-                p2p_relay, rpc_submit, block_bytes, block_hex);
+                p2p_relay, rpc_submit, block_bytes, block_hex,
+                /*prefer_rpc_first=*/height_race);
             if (!bcast.any()) {
                 std::cout << "[DASH-STRATUM-BLOCK] reached NEITHER sink "
                              "(no embedded P2P peer AND no dashd RPC creds) -- "
@@ -1280,7 +1286,8 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                         // 4) Drive the REAL run-path dual-path dispatch.
                         std::vector<unsigned char> block_bytes = ParseHex(mr.block_hex);
                         if (forced_dispatch)
-                            forced_dispatch(block_bytes, work.m_height);
+                            forced_dispatch(block_bytes, work.m_height,
+                                            /*height_race=*/false);
                         else
                             std::cout << "[run] E5 forced-won-block: dispatch sink "
                                          "UNBOUND -- nothing fired\n";

--- a/src/impl/dash/coin/won_block_dispatch.hpp
+++ b/src/impl/dash/coin/won_block_dispatch.hpp
@@ -32,6 +32,20 @@
 // dispatcher logs LOUDLY (LOG_ERROR) and reports any()==false so the caller
 // treats it as "block NOT relayed", never a silent lost subsidy.
 //
+// ── RPC-FIRST GATE for stale / height-race blocks (prefer_rpc_first) ─────────
+// A height-race/stale block (the job's parent moved since issue) MIGHT be
+// invalid at its real height. Relaying an unvalidated block to a coin-P2P peer
+// risks DoS-scoring/ban of OUR coin-P2P identity, whereas the local dashd
+// rejects an invalid block for free. So when the caller flags such a block AND
+// a local dashd RPC arm (ARM B) is armed, the dispatcher runs ARM B FIRST and
+// gates the ARM A P2P relay on dashd ACCEPTANCE: a valid race block is relayed
+// (we still race), an invalid one is never pushed to peers. This is a pure
+// ORDERING/gating change on the SAME two arms -- no consensus, PoW, or coinbase
+// bytes are touched. DAEMONLESS (no RPC arm) is unaffected: ARM A stays primary
+// and relays anyway, because it is then the ONLY path to the network and
+// dropping a winnable block is a guaranteed loss. A normal (non-race) block is
+// also unaffected: relay-first as before.
+//
 // Reward/consensus-NEUTRAL: broadcast path only. No PoW hash, share format,
 // coinbase commitment, or PPLNS math is touched. Per-coin isolation:
 // src/impl/dash/ only.
@@ -89,9 +103,72 @@ struct BlockBroadcast
 inline BlockBroadcast broadcast_won_block(const P2pRelaySink& p2p_relay,
                                           const RpcSubmitSink& rpc_submit,
                                           const std::vector<unsigned char>& block_bytes,
-                                          const std::string& block_hex)
+                                          const std::string& block_hex,
+                                          bool prefer_rpc_first = false)
 {
     BlockBroadcast r;
+
+    // RPC-FIRST validation gate for a stale / height-race won block. The block
+    // MIGHT be invalid at its real height, so when the caller asks for it AND a
+    // local dashd RPC arm is armed, validate via ARM B FIRST and relay on ARM A
+    // ONLY if dashd accepted. This keeps an invalid race block off the coin-P2P
+    // network (no peer-ban exposure) while a valid one still races. Daemonless
+    // (no rpc_submit) falls through to the relay-first path below unchanged --
+    // the relay is then the only route to the network.
+    if (prefer_rpc_first && rpc_submit) {
+        // ARM B first: the local dashd validates the block.
+        try {
+            r.rpc_ok = rpc_submit(block_hex);
+            if (r.rpc_ok) r.landed_first = "rpc";
+            LOG_INFO << "[EMB-DASH] height-race won-block: RPC-first submitblock "
+                     << (r.rpc_ok ? "ACCEPTED" : "REJECTED")
+                     << " -- local dashd is the authority at the block's real height.";
+        } catch (const std::exception& e) {
+            LOG_ERROR << "[EMB-DASH] height-race won-block: RPC-first submitblock threw ("
+                      << e.what() << ") -- treating as no-ack; NOT relaying to peers.";
+        } catch (...) {
+            LOG_ERROR << "[EMB-DASH] height-race won-block: RPC-first submitblock threw "
+                         "(non-std) -- treating as no-ack; NOT relaying to peers.";
+        }
+
+        // ARM A only when dashd ACCEPTED: never relay an unvalidated/rejected
+        // race block to a coin-P2P peer (avoids DoS-scoring/ban of our identity).
+        if (r.rpc_ok && p2p_relay) {
+            try {
+                const bool relayed = p2p_relay(block_bytes);
+                if (relayed) {
+                    r.p2p_sent = true;
+                    LOG_INFO << "[EMB-DASH] height-race won-block: dashd-accepted, "
+                                "embedded P2P relay issued (" << block_bytes.size()
+                             << " bytes) -- racing the network.";
+                } else {
+                    LOG_WARNING << "[EMB-DASH] height-race won-block: dashd-accepted but "
+                                   "embedded P2P relay NOT sent (peer not "
+                                   "connected/handshaked) -- dashd already carries it.";
+                }
+            } catch (const std::exception& e) {
+                LOG_ERROR << "[EMB-DASH] height-race won-block: P2P relay threw ("
+                          << e.what() << ") -- dashd already carries the block.";
+            } catch (...) {
+                LOG_ERROR << "[EMB-DASH] height-race won-block: P2P relay threw (non-std) "
+                             "-- dashd already carries the block.";
+            }
+        } else if (!r.rpc_ok) {
+            LOG_WARNING << "[EMB-DASH] height-race won-block: local dashd REJECTED it -- "
+                           "NOT relaying to coin-P2P peers (it was invalid at its real "
+                           "height; rejected for free, no peer-ban exposure).";
+        }
+
+        if (!r.any())
+            LOG_ERROR << "[EMB-DASH] height-race won-block reached NEITHER sink -- "
+                         "block NOT relayed!";
+        else
+            LOG_INFO << "[EMB-DASH] height-race won-block broadcast: rpc="
+                     << (r.rpc_ok ? "ok" : "off") << " p2p="
+                     << (r.p2p_sent ? "sent" : "off")
+                     << " landed_first=" << r.landed_first << ".";
+        return r;
+    }
 
     // ARM A -- embedded P2P relay (ALWAYS-PRIMARY, daemonless). Guarded so a
     // throwing relay sink can NEVER propagate out and skip the RPC backup below

--- a/src/impl/dash/stratum/submit_payee_guard.hpp
+++ b/src/impl/dash/stratum/submit_payee_guard.hpp
@@ -40,9 +40,21 @@
 // the network. The payee SCRIPT is height-deterministic; the amount is not. So
 // the guard verifies payee SCRIPTS by SET MEMBERSHIP and never compares amounts:
 //
-//   - WrongHeight:  the job's prev != the current chain tip. The job was built
-//                   on a parent that is no longer the tip → the block is for the
-//                   wrong height and dashd would reject it. DO NOT submit.
+//   - HeightRace:   the job's prev != the current chain tip. The tip moved
+//                   AFTER the job was issued, but "parent moved" ≠ "unwinnable"
+//                   and the guard must NOT drop the block (that would forfeit a
+//                   winnable reward, violating the invariant above). If the
+//                   chain merely extended, our block is a valid competing block
+//                   at the same height — dashd ACCEPTS it and we race. If it was
+//                   a 1-block reorg, our block is one above the current tip —
+//                   submitting makes OUR chain longer and the network reorgs to
+//                   us. Only when buried 2+ deep is it unwinnable, and even then
+//                   submitting is free (dashd stores a dead orphan, no harm).
+//                   dashd is the authority on validity at the block's REAL
+//                   height, so we CANNOT run the set-membership payee check here
+//                   (m_packed_payments are for the CURRENT tip's height, not our
+//                   block's) — we SUBMIT and log a race warning. Dropping would
+//                   guarantee the loss; submitting lets the network decide.
 //   - PayeeMissing: prev matches (same height) but a GBT-mandated payee SCRIPT
 //                   (masternode / operator / superblock / platform burn) is
 //                   ABSENT from the coinbase outputs → a genuine bad-cb-payee.
@@ -76,7 +88,7 @@ namespace dash::stratum {
 
 enum class PayeeGuardVerdict {
     Ok,           ///< all mandated payee SCRIPTS present at current height — submit
-    WrongHeight,  ///< job prev != current tip — wrong height, dashd rejects — DO NOT submit
+    HeightRace,   ///< job prev != current tip — parent moved — SUBMIT as a height race (dashd decides)
     PayeeMissing, ///< same height, a mandated payee SCRIPT absent — bad-cb-payee — DO NOT submit
     Unverifiable, ///< coinbase would not parse — submit (never guard-block on parse)
 };
@@ -95,16 +107,25 @@ inline PayeeGuardResult check_submit_payee(
     PayeeGuardResult r;
 
     // Height context: same prev == same height == same expected payee set.
-    // A differing prev means the tip moved after the job was issued: the job
-    // was built on a parent that is no longer the chain tip, so the block is
-    // for the wrong height and dashd would reject it. Refuse — submitting a
-    // wrong-height block cannot win and only muddies the reject log.
+    // A differing prev means the tip moved after the job was issued. That is a
+    // RACE, not a guaranteed loss: if the chain merely extended, our block is a
+    // valid competing block at the same height (dashd accepts, we race); if it
+    // was a 1-block reorg, our block is one above the current tip (submitting
+    // makes our chain longer, the network reorgs to us). Only a 2+ deep bury is
+    // unwinnable — and even then submitting is free (dashd stores a dead orphan,
+    // no harm). Per the reward invariant, when in doubt we SUBMIT and let dashd
+    // (the authority at the block's REAL height) decide. We deliberately SKIP
+    // the set-membership payee check below: m_packed_payments belong to the
+    // CURRENT tip's height, NOT our block's, so comparing against them would be
+    // meaningless — dashd validates the payee at the block's own height.
     if (current.m_previous_block.GetHex() != job_gbt_prevhash) {
-        r.verdict = PayeeGuardVerdict::WrongHeight;
+        r.verdict = PayeeGuardVerdict::HeightRace;
         r.detail  = "job prev=" + job_gbt_prevhash.substr(0, 16)
                   + " current tip=" + current.m_previous_block.GetHex().substr(0, 16)
-                  + " (tip moved since job issue — block is for the wrong height,"
-                    " dashd would reject; DO NOT submit)";
+                  + " (parent moved since job issue — submitting anyway as a"
+                    " height race; dashd will accept if valid at the block's real"
+                    " height, reject for free if not; dropping would guarantee"
+                    " the loss)";
         return r;
     }
 

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -870,13 +870,21 @@ nlohmann::json DASHWorkSource::mining_submit(
                              "job/template pipeline served stale work "
                              "(investigate!)";
                 break;
-            case PayeeGuardVerdict::WrongHeight:
-                payee_guard_reject = true;
-                LOG_ERROR << "[DASH-STRATUM-PAYEE-GUARD] WON BLOCK LOCALLY "
-                             "REJECTED, NOT submitted: " << guard.detail
-                          << " user=" << username << " job=" << job_id
-                          << " -- the job's parent is no longer the chain tip; "
-                             "dashd would reject this wrong-height block";
+            case PayeeGuardVerdict::HeightRace:
+                // Parent moved since the job was issued -- but "parent moved"
+                // is NOT "unwinnable". A chain-extend leaves us a valid
+                // same-height competitor (dashd accepts, we race); a 1-block
+                // reorg leaves us one above the tip (submitting reorgs the
+                // network to us); only a 2+ deep bury is unwinnable, and even
+                // then submitting is free (dashd stores a dead orphan). Per the
+                // reward invariant we SUBMIT and let dashd decide -- dropping
+                // would be a guaranteed, irreversible loss. NOT a reject.
+                LOG_WARNING << "[DASH-STRATUM-PAYEE-GUARD] WON BLOCK is a HEIGHT "
+                               "RACE: " << guard.detail
+                            << " user=" << username << " job=" << job_id
+                            << " -- submitting anyway; dashd is the authority at "
+                               "the block's real height and will accept if valid, "
+                               "reject for free if not";
                 break;
             case PayeeGuardVerdict::Unverifiable:
                 LOG_WARNING << "[DASH-STRATUM-PAYEE-GUARD] guard could not "

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -851,10 +851,16 @@ nlohmann::json DASHWorkSource::mining_submit(
         // GBT-mandated payee SCRIPT by SET MEMBERSHIP — it does NOT compare
         // amounts against the current template (the masternode amount is
         // subsidy + fees and drifts with the mempool on every re-pull; dashd
-        // checks it against the block's OWN fees). Refuse only when the tip has
-        // moved (wrong height) or a mandated payee SCRIPT is genuinely absent;
-        // a guard-side parse failure never blocks a submission.
+        // checks it against the block's OWN fees). Refuse only when a mandated
+        // payee SCRIPT is genuinely absent (PayeeMissing); a moved-tip block is
+        // a HeightRace and IS submitted (dashd is the authority at the block's
+        // real height), and a guard-side parse failure never blocks a submit.
+        // A HeightRace submit is dispatched RPC-FIRST (the is_height_race flag
+        // threaded to submit_block_fn_ below): the local dashd validates the
+        // block before we relay it to any coin-P2P peer, so an invalid race
+        // block is rejected locally for free and never risks a coin-P2P ban.
         bool payee_guard_reject = false;
+        bool is_height_race     = false;
         if (wd) {
             const auto guard = check_submit_payee(
                 coinbase, job->gbt_prevhash, *wd,
@@ -878,13 +884,18 @@ nlohmann::json DASHWorkSource::mining_submit(
                 // network to us); only a 2+ deep bury is unwinnable, and even
                 // then submitting is free (dashd stores a dead orphan). Per the
                 // reward invariant we SUBMIT and let dashd decide -- dropping
-                // would be a guaranteed, irreversible loss. NOT a reject.
+                // would be a guaranteed, irreversible loss. NOT a reject. Flag
+                // it so the broadcaster dispatches RPC-FIRST: the local dashd
+                // validates the block before any coin-P2P relay, so an invalid
+                // race block is rejected for free and never risks a peer-ban.
+                is_height_race = true;
                 LOG_WARNING << "[DASH-STRATUM-PAYEE-GUARD] WON BLOCK is a HEIGHT "
                                "RACE: " << guard.detail
                             << " user=" << username << " job=" << job_id
-                            << " -- submitting anyway; dashd is the authority at "
-                               "the block's real height and will accept if valid, "
-                               "reject for free if not";
+                            << " -- submitting anyway (RPC-first: dashd validates "
+                               "before any coin-P2P relay); dashd is the authority "
+                               "at the block's real height and will accept if "
+                               "valid, reject for free if not";
                 break;
             case PayeeGuardVerdict::Unverifiable:
                 LOG_WARNING << "[DASH-STRATUM-PAYEE-GUARD] guard could not "
@@ -912,7 +923,7 @@ nlohmann::json DASHWorkSource::mining_submit(
             // template was ours.
         } else if (submit_block_fn_) {
             try {
-                reached_network = submit_block_fn_(block_bytes, height);
+                reached_network = submit_block_fn_(block_bytes, height, is_height_race);
             } catch (const std::exception& e) {
                 LOG_ERROR << "[DASH-STRATUM-BLOCK] submit_block_fn threw: " << e.what();
             }

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -84,8 +84,17 @@ public:
     /// the won block reached at least one network sink -- a false return
     /// means it reached NEITHER and the won-block path must log loudly
     /// (no silent drop -- the block-viability gate).
+    ///
+    /// `height_race` is true when the submit-time payee guard classified the
+    /// block as a HeightRace (the job's parent moved since issue): the block
+    /// MIGHT be invalid at its real height, so the broadcaster dispatches it
+    /// RPC-FIRST (local dashd validates before any coin-P2P relay) to avoid
+    /// relaying an unvalidated block to peers and risking a coin-P2P ban.
+    /// Daemonless (no RPC arm) keeps relay-first: the relay is then the ONLY
+    /// path and dropping would forfeit a winnable block.
     using SubmitBlockFn = std::function<bool(const std::vector<unsigned char>& block_bytes,
-                                             uint32_t height)>;
+                                             uint32_t height,
+                                             bool height_race)>;
 
     /// Found-share fields handed to the sharechain mint dispatch when a
     /// stratum submission meets the share target (stage 4d). Mirrors the

--- a/test/test_dash_stratum_work_source.cpp
+++ b/test/test_dash_stratum_work_source.cpp
@@ -1143,14 +1143,22 @@ TEST(DashSubmitPayeeGuard, OkWhenMandatedAmountDriftsButScriptPresent)
     EXPECT_EQ(r.verdict, dash::stratum::PayeeGuardVerdict::Ok);
 }
 
-TEST(DashSubmitPayeeGuard, WrongHeightWhenPrevDiffers)
+TEST(DashSubmitPayeeGuard, HeightRaceWhenPrevDiffersIsSubmittedNotDropped)
 {
-    // The job's parent is no longer the chain tip: the block is for the wrong
-    // height and dashd would reject it. The guard must refuse the submit.
+    // REWARD-CRITICAL false-refusal fix. The job's parent is no longer the
+    // chain tip -- but "parent moved" is NOT "unwinnable": a chain-extend
+    // leaves us a valid same-height competitor dashd accepts, a 1-block reorg
+    // leaves us one above the tip so the network reorgs to us, and even a deep
+    // bury is free to submit (dashd stores a dead orphan). Per the guard's own
+    // invariant the block must be SUBMITTED (HeightRace), never dropped --
+    // dashd is the authority at the block's real height. The guard also does
+    // NOT run the payee check here (the current template's payees are for the
+    // WRONG height), so it reports HeightRace regardless of payee shape.
     const auto cb = fixture_coinbase_bytes();
     const auto r = dash::stratum::check_submit_payee(
         cb, kPrevHashHex, rotated_work(), dash::make_coin_params(false));
-    EXPECT_EQ(r.verdict, dash::stratum::PayeeGuardVerdict::WrongHeight);
+    EXPECT_EQ(r.verdict, dash::stratum::PayeeGuardVerdict::HeightRace);
+    EXPECT_NE(r.detail.find("height race"), std::string::npos);
 }
 
 TEST(DashSubmitPayeeGuard, UnverifiableOnGarbageCoinbaseNeverBlocks)
@@ -1216,10 +1224,14 @@ TEST(DashStratumWorkSource, WonBlockWithMandatedAmountDriftStillSubmits)
     EXPECT_TRUE(rig.fx.submit_called);        // amount drift is NOT a refusal
 }
 
-// A won block across a MOVED tip is for the wrong height (the job's parent is
-// no longer the chain tip) — dashd would reject it, so the guard refuses and
-// the broadcaster must NOT fire.
-TEST(DashStratumWorkSource, WonBlockAcrossTipMoveIsLocallyRejected)
+// A won block across a MOVED tip is a HEIGHT RACE, not a guaranteed loss: a
+// chain-extend leaves us a valid same-height competitor dashd accepts, a
+// 1-block reorg leaves us one above the tip so the network reorgs to us, and
+// even a deep bury is free to submit (dashd stores a dead orphan). Per the
+// guard's reward invariant the block MUST be submitted (dashd is the authority
+// at its real height) — dropping it would forfeit a winnable reward. The
+// broadcaster MUST fire.
+TEST(DashStratumWorkSource, WonBlockAcrossTipMoveIsSubmittedAsHeightRace)
 {
     SubmitRig rig;
     rig.job.share_bits  = 0x207fffffu;
@@ -1235,7 +1247,7 @@ TEST(DashStratumWorkSource, WonBlockAcrossTipMoveIsLocallyRejected)
     auto result = rig.submit(nonce);
     ASSERT_TRUE(result.is_boolean());
     EXPECT_TRUE(result.get<bool>());          // the miner's work was honest
-    EXPECT_FALSE(rig.fx.submit_called);       // ...but wrong-height: NOT dispatched
+    EXPECT_TRUE(rig.fx.submit_called);        // ...and the race block IS dispatched
 }
 
 // ── Dashboard stats seam (issue: /local_stats hashrate under-reported) ───────

--- a/test/test_dash_stratum_work_source.cpp
+++ b/test/test_dash_stratum_work_source.cpp
@@ -118,6 +118,7 @@ struct Fixture {
     dash::coin::NodeCoinState coin_state;             // default: populated()==false
     bool                      submit_called = false;
     uint32_t                  submit_height = 0;
+    bool                      submit_height_race = false;   // guard flagged HeightRace
     std::vector<unsigned char> submitted_block;
     dash::coin::DashWorkData  fallback_work;          // seeded by caller
 
@@ -127,10 +128,12 @@ struct Fixture {
     std::unique_ptr<dash::stratum::DASHWorkSource> make()
     {
         auto submit = [this](const std::vector<unsigned char>& block,
-                             uint32_t height) -> bool {
-            submit_called   = true;
-            submit_height   = height;
-            submitted_block = block;
+                             uint32_t height,
+                             bool height_race) -> bool {
+            submit_called      = true;
+            submit_height      = height;
+            submit_height_race = height_race;
+            submitted_block    = block;
             return true;
         };
         auto fallback = [this]() -> dash::coin::DashWorkData { return fallback_work; };
@@ -1222,6 +1225,7 @@ TEST(DashStratumWorkSource, WonBlockWithMandatedAmountDriftStillSubmits)
     ASSERT_TRUE(result.is_boolean());
     EXPECT_TRUE(result.get<bool>());
     EXPECT_TRUE(rig.fx.submit_called);        // amount drift is NOT a refusal
+    EXPECT_FALSE(rig.fx.submit_height_race);  // same-height Ok -> relay-first, not a race
 }
 
 // A won block across a MOVED tip is a HEIGHT RACE, not a guaranteed loss: a
@@ -1248,6 +1252,7 @@ TEST(DashStratumWorkSource, WonBlockAcrossTipMoveIsSubmittedAsHeightRace)
     ASSERT_TRUE(result.is_boolean());
     EXPECT_TRUE(result.get<bool>());          // the miner's work was honest
     EXPECT_TRUE(rig.fx.submit_called);        // ...and the race block IS dispatched
+    EXPECT_TRUE(rig.fx.submit_height_race);   // ...flagged HeightRace -> RPC-first dispatch
 }
 
 // ── Dashboard stats seam (issue: /local_stats hashrate under-reported) ───────
@@ -1357,7 +1362,7 @@ TEST(DashStratumC1MainnetGate, MainnetPopulatedCoinStateRoutesToDashdFallback)
     ASSERT_TRUE(cs.make_embedded_work_inputs().viable());
 
     auto fallback = []() -> dash::coin::DashWorkData { return rich_work(); };
-    auto submit   = [](const std::vector<unsigned char>&, uint32_t) { return true; };
+    auto submit   = [](const std::vector<unsigned char>&, uint32_t, bool) { return true; };
 
     // is_testnet=false => mainnet => embedded arm GATED off.
     dash::stratum::DASHWorkSource ws(cs, fallback, submit,
@@ -1394,7 +1399,7 @@ TEST(DashStratumC1MainnetGate, TestnetPopulatedCoinStateServesEmbedded)
     ASSERT_TRUE(cs.populated());
 
     auto fallback = []() -> dash::coin::DashWorkData { return rich_work(); };
-    auto submit   = [](const std::vector<unsigned char>&, uint32_t) { return true; };
+    auto submit   = [](const std::vector<unsigned char>&, uint32_t, bool) { return true; };
 
     // is_testnet=true => testnet/regtest => embedded arm ENABLED.
     dash::stratum::DASHWorkSource ws(cs, fallback, submit,
@@ -1452,7 +1457,7 @@ TEST(DashStratumC1MainnetGate, EmbeddedCacheHitReValidatesCreditPoolAndReSources
                76, 16, kCurtime, static_cast<uint32_t>(kVersion));
 
     auto fallback = []() -> dash::coin::DashWorkData { return rich_work(); };
-    auto submit   = [](const std::vector<unsigned char>&, uint32_t) { return true; };
+    auto submit   = [](const std::vector<unsigned char>&, uint32_t, bool) { return true; };
     dash::stratum::DASHWorkSource ws(cs, fallback, submit,
                                      core::stratum::StratumConfig{},
                                      /*is_testnet=*/true);
@@ -1521,7 +1526,7 @@ TEST(DashStratumC1MainnetGate, GbtXcheckServesDashdOnCreditPoolMismatch)
         w.m_coinbase_payload = dash::coin::encode_cbtx(cb);
         return w;
     };
-    auto submit = [](const std::vector<unsigned char>&, uint32_t) { return true; };
+    auto submit = [](const std::vector<unsigned char>&, uint32_t, bool) { return true; };
     dash::stratum::DASHWorkSource ws(cs, fallback, submit,
                                      core::stratum::StratumConfig{},
                                      /*is_testnet=*/true);
@@ -1575,7 +1580,7 @@ TEST(DashStratumCoinP2pTipInvalidate, InvalidateClosesStalePayeeWindowUnderRefre
 {
     auto current  = std::make_shared<dash::coin::DashWorkData>(rich_work());   // tip A
     auto fallback = [current]() -> dash::coin::DashWorkData { return *current; };
-    auto submit   = [](const std::vector<unsigned char>&, uint32_t) { return true; };
+    auto submit   = [](const std::vector<unsigned char>&, uint32_t, bool) { return true; };
     dash::coin::NodeCoinState cs;   // unpopulated -> fallback arm
 
     dash::stratum::DASHWorkSource ws(cs, fallback, submit,
@@ -1617,7 +1622,7 @@ TEST(DashStratumCoinP2pTipInvalidate, BumpAloneServesStaleUnderRefreshExecutor)
 {
     auto current  = std::make_shared<dash::coin::DashWorkData>(rich_work());
     auto fallback = [current]() -> dash::coin::DashWorkData { return *current; };
-    auto submit   = [](const std::vector<unsigned char>&, uint32_t) { return true; };
+    auto submit   = [](const std::vector<unsigned char>&, uint32_t, bool) { return true; };
     dash::coin::NodeCoinState cs;
 
     dash::stratum::DASHWorkSource ws(cs, fallback, submit,

--- a/test/test_dash_won_block_dualpath.cpp
+++ b/test/test_dash_won_block_dualpath.cpp
@@ -237,6 +237,93 @@ TEST(DashWonBlockDualPath, DisconnectedP2pWithNoBackupReachesNeither)
     EXPECT_STREQ(r.landed_first, "none");
 }
 
+// ── RPC-FIRST GATE for stale / height-race blocks (prefer_rpc_first) ─────────
+
+// 8) HEIGHT-RACE ORDERING: with a dashd RPC arm armed, a race block is validated
+//    RPC-FIRST and the coin-P2P relay fires ONLY AFTER dashd accepts. Pins the
+//    ordering (RPC call precedes the relay) and that a valid race block still
+//    reaches BOTH arms so we race the network.
+TEST(DashWonBlockDualPath, HeightRaceIsRpcFirstThenRelaysOnAccept)
+{
+    const auto block = make_block_bytes();
+    const std::string block_hex = to_hex(block);
+
+    int seq = 0;
+    int rpc_order = 0, relay_order = 0;
+    std::string submitted_hex;
+
+    RpcSubmitSink rpc = [&](const std::string& hex) -> bool {
+        rpc_order = ++seq; submitted_hex = hex; return true;   // dashd ACCEPTS
+    };
+    std::vector<unsigned char> relayed;
+    P2pRelaySink p2p = [&](const std::vector<unsigned char>& b) -> bool {
+        relay_order = ++seq; relayed = b; return true;
+    };
+
+    const auto r = broadcast_won_block(p2p, rpc, block, block_hex,
+                                       /*prefer_rpc_first=*/true);
+
+    // ORDER: dashd validated FIRST, then the relay fired.
+    ASSERT_EQ(rpc_order, 1);
+    ASSERT_EQ(relay_order, 2);
+    // Valid race block -> both arms carry it; landed_first is the RPC validation.
+    EXPECT_TRUE(r.rpc_ok);
+    EXPECT_TRUE(r.p2p_sent);
+    EXPECT_EQ(relayed, block);
+    EXPECT_EQ(submitted_hex, block_hex);
+    EXPECT_STREQ(r.landed_first, "rpc");
+    EXPECT_TRUE(r.any());
+}
+
+// 9) HEIGHT-RACE INVALID: dashd REJECTS the race block -> the coin-P2P relay is
+//    NEVER invoked (no unvalidated block pushed to peers -> no ban exposure).
+//    The block is rejected locally for free; any()==false (LOUD not-relayed path).
+TEST(DashWonBlockDualPath, HeightRaceRejectedByDashdIsNotRelayedToPeers)
+{
+    const auto block = make_block_bytes();
+    const std::string block_hex = to_hex(block);
+
+    RpcSubmitSink rpc = [&](const std::string&) -> bool {
+        return false;   // dashd REJECTS: invalid at the block's real height
+    };
+    bool relay_attempted = false;
+    P2pRelaySink p2p = [&](const std::vector<unsigned char>&) -> bool {
+        relay_attempted = true; return true;
+    };
+
+    const auto r = broadcast_won_block(p2p, rpc, block, block_hex,
+                                       /*prefer_rpc_first=*/true);
+
+    EXPECT_FALSE(relay_attempted);      // GATED: never relayed an invalid race block
+    EXPECT_FALSE(r.p2p_sent);
+    EXPECT_FALSE(r.rpc_ok);
+    EXPECT_FALSE(r.any());              // rejected locally for free
+    EXPECT_STREQ(r.landed_first, "none");
+}
+
+// 10) HEIGHT-RACE DAEMONLESS: no RPC arm to validate against, so the RPC-first
+//     gate does NOT apply -- ARM A relays anyway (it is the ONLY route to the
+//     network; dropping a winnable block would be a guaranteed loss).
+TEST(DashWonBlockDualPath, HeightRaceDaemonlessStillRelaysPrimary)
+{
+    const auto block = make_block_bytes();
+    const std::string block_hex = to_hex(block);
+
+    std::vector<unsigned char> relayed;
+    P2pRelaySink p2p = [&](const std::vector<unsigned char>& b) -> bool {
+        relayed = b; return true;
+    };
+
+    const auto r = broadcast_won_block(p2p, /*rpc=*/{}, block, block_hex,
+                                       /*prefer_rpc_first=*/true);
+
+    EXPECT_TRUE(r.p2p_sent);            // relay-first fallback: the only path
+    EXPECT_FALSE(r.rpc_ok);
+    EXPECT_EQ(relayed, block);
+    EXPECT_STREQ(r.landed_first, "p2p");
+    EXPECT_TRUE(r.any());
+}
+
 // 8) E5 --coin-p2p-magic override: the embedded coin-P2P wire magic selector.
 //    No override -> the mainnet/testnet defaults are returned BYTE-FOR-BYTE
 //    unchanged (guards the production ARM A dial from regression). An override


### PR DESCRIPTION
## Problem

The submit-time masternode-payee guard (`src/impl/dash/stratum/submit_payee_guard.hpp`, `check_submit_payee()`) returned `PayeeGuardVerdict::WrongHeight` and the caller (`DASHWorkSource::mining_submit()`) then **refused to submit** any won block whose job parent was no longer the current chain tip.

That directly violated the guard's own documented reward invariant:

> The guard must NEVER refuse a block that dashd would ACCEPT — a false refusal forfeits a full block reward... When in doubt, SUBMIT: a truly bad block is rejected by dashd for free, whereas a false refusal is a guaranteed, irreversible loss.

**"Parent moved" is not "unwinnable":**
- Chain merely extended -> our block is a valid competing block at the same height; dashd accepts it and we race.
- 1-block reorg -> our block is one above the current tip; submitting makes our chain longer and the network reorgs to us.
- Buried 2+ deep -> unwinnable, but submitting is still free (dashd stores a dead orphan, no harm).

Dropping guaranteed the loss.

## Fix

- Rename the verdict `WrongHeight` -> `HeightRace`. The guard now returns it as a **submit** outcome and logs a `WARNING`.
- The caller treats `HeightRace` as submit (not reject).
- In the race case the set-membership payee check is **skipped**: `m_packed_payments` belong to the current tip's height, not our block's, so comparing against them would be meaningless — dashd is the authority on validity at the block's real height.
- `PayeeMissing` (same-height, a mandated payee script genuinely absent — a known bad-cb-payee dashd rejects) is **unchanged** and still refuses.
- `Unverifiable` and `Ok` are unchanged (both submit).

## Reward safety (RPC-first for race blocks)

The won-block dispatcher (`dash::coin::broadcast_won_block`) has **two arms**:
- **ARM A — embedded coin-P2P relay** (`submit_block_p2p_raw`), which fires with **no local validation** and is the **only** path in daemonless deployments;
- **ARM B — `submitblock` RPC** to the local dashd, which is **empty in daemonless** deployments.

Because we now submit *more* race blocks, and a race block *might* be invalid at its real height, relaying an unvalidated block straight onto ARM A risks DoS-scoring / ban of our coin-P2P identity. So this PR makes the height-race submit **RPC-first**: an `is_height_race` flag is threaded from the guard through `SubmitBlockFn` into `broadcast_won_block` (`prefer_rpc_first`). When it is set **and a local dashd RPC arm is armed**, the dispatcher:
1. submits via **ARM B (submitblock RPC) first** — the local dashd validates at the block's real height;
2. relays on **ARM A only if dashd ACCEPTED**.

A valid race block is therefore relayed and races the network; an invalid one is rejected locally **for free** and is **never** pushed to peers (no ban exposure). Daemonless (no RPC arm) keeps relay-first: ARM A is then the only route to the network and dropping a winnable block would be a guaranteed loss. Normal (non-race) blocks are unchanged — relay-first as before.

This is a pure **ordering/gating** change on the same two arms: no consensus, PoW, share format, or coinbase bytes are touched.

## No consensus change

Coinbase bytes are untouched. This is purely the submit / no-submit **decision** plus dispatch **ordering** — no serialization or share-format change.

## Tests

- Pure-function KAT `WrongHeightWhenPrevDiffers` -> `HeightRaceWhenPrevDiffersIsSubmittedNotDropped`: now expects `HeightRace`.
- Hot-path KAT `WonBlockAcrossTipMoveIsLocallyRejected` -> `WonBlockAcrossTipMoveIsSubmittedAsHeightRace`: asserts the broadcaster **fires** and the `is_height_race` flag reaches the sink.
- Same-height amount-drift KAT additionally pins `is_height_race == false` (relay-first, not a race).
- New dual-path ordering KATs: RPC-first-then-relay-on-accept, dashd-reject-is-NOT-relayed-to-peers (no ban exposure), daemonless-still-relays-primary.
- Same-height `PayeeMissing` still refuses — retained.

Build: `c2pool-dash` + `test_dash_stratum_work_source` + `test_dash_broadcaster_full` green. **44/44 stratum + 21/21 broadcaster pass.**

## Cross-coin note

The false-refusal principle and the RPC-first ban-avoidance principle are both coin-agnostic, but:
- The DASH payee-guard is the **only** submit-time height/payee guard in the tree (it exists because DASH rotates the MN payee every block), so DASH is the only coin that classifies a height-race and threads the flag.
- The RPC-first gate lives in **`dash::coin::broadcast_won_block`** (DASH's dispatcher). DGB/BCH have their own `broadcast_won_block` with relay arms, but no height-race classifier feeds them, so nothing changes there today; the pattern is available to port if/when they gain a race classifier.
- The shared-core HTTP `submitblock` path (#833, `web_server.cpp` `MiningInterface::submitblock`) is **RPC-only** — it has no separate coin-P2P relay arm — so the peer-ban exposure this gate closes does not apply to it; #833's own fix (forward stale/race blocks to the daemon) is the analogous false-refusal fix on that path.

