### PR TITLE
core(web): forward stale/race won-blocks to the daemon instead of dropping them

### DIFF
--- a/src/core/coin/submitblock_result.hpp
+++ b/src/core/coin/submitblock_result.hpp
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// ---------------------------------------------------------------------------
+// core::coin::submitblock_result_accepted -- shared classifier for a coin
+// daemon's `submitblock` RPC result under the dual-path won-block contract.
+//
+// submitblock returns JSON null on ACCEPT; a non-null string is the reject
+// reason. A "duplicate" / "inconclusive" / "already-have" result means the
+// block is ALREADY on the network — the OTHER broadcast arm (our own P2P relay,
+// or a peer that won the very race we are submitting into) landed it first.
+// That is SUCCESS (the block reached the network), NOT a failure. The lone
+// exception is a "duplicate-invalid" reason: the block was rejected as invalid,
+// a genuine failure.
+//
+// Historically LTC/BTC/DGB NodeRPC::submit_block_hex classified with a bare
+// `result.is_null()`, so a daemon "duplicate" (the common dual-path / race
+// outcome) surfaced as FALSE and a WON block was reported as a reject through
+// the shared web_server submit seam. This predicate lifts them onto the same
+// contract BCH and DASH already implement. Pure over the JSON so a KAT can pin
+// it without a live RPC client.
+// ---------------------------------------------------------------------------
+
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+namespace core::coin {
+
+inline bool submitblock_result_accepted(const nlohmann::json& result)
+{
+    if (result.is_null()) return true;      // canonical accept
+    if (!result.is_string()) return false;  // unexpected shape — treat as reject
+    std::string code = result.get<std::string>();
+    for (char& c : code)
+        if (c >= 'A' && c <= 'Z') c = static_cast<char>(c - 'A' + 'a');
+    const bool already_have = code == "duplicate"
+                           || code.find("inconclusive") != std::string::npos
+                           || code.find("already") != std::string::npos;
+    return already_have && code.find("invalid") == std::string::npos;
+}
+
+} // namespace core::coin

--- a/src/core/test/CMakeLists.txt
+++ b/src/core/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (BUILD_TESTING AND (GTest_FOUND OR GTEST_FOUND))
-    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp core_merkle_branches_test.cpp version_gate_test.cpp filesystem_test.cpp)
+    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp core_merkle_branches_test.cpp version_gate_test.cpp filesystem_test.cpp web_server_submitblock_test.cpp)
     target_link_libraries(core_test PRIVATE GTest::gtest_main core c2pool_merged_mining GTest::gtest)
     target_link_libraries(core_test PRIVATE c2pool_payout c2pool_hashrate ltc_coin)  # OBJECT-lib SCC direct-naming (#22/#39)
 

--- a/src/core/test/web_server_submitblock_test.cpp
+++ b/src/core/test/web_server_submitblock_test.cpp
@@ -13,6 +13,7 @@
 #include <core/uint256.hpp>
 #include <core/coin/node_iface.hpp>
 #include <core/coin/work_view.hpp>
+#include <core/coin/submitblock_result.hpp>
 
 // ---------------------------------------------------------------------------
 // KATs for core::MiningInterface::submitblock — the SHARED-CORE HTTP won-block
@@ -22,7 +23,11 @@
 // The handler must FORWARD such a block to the coin daemon (never drop it) and
 // return the DAEMON's verdict — accept => success, reject => error. It must NOT
 // synthesize a "stale" error and drop the block before the daemon ever sees it.
-// The normal (matching prev-hash) submit path must be unchanged.
+//
+// REWARD-ACCOUNTING invariant (B1): the found-block callback fires EXACTLY ONCE
+// per block, with the correct stale_info code, AFTER the daemon verdict — an
+// accepted stale/race block must fire 0 (WON), NOT be left recorded only as an
+// eager 253 (ORPHAN/pending), or the dashboard under-credits a real paid win.
 // ---------------------------------------------------------------------------
 
 namespace {
@@ -72,15 +77,15 @@ std::string make_header_hex(const std::vector<uint8_t>& prev32) {
 }
 
 // A MiningInterface primed with a live template whose previousblockhash is a
-// known value; returns the 32 internal prev bytes so tests can build matching
-// or mismatching headers.
+// known value; also captures every found-block callback fire (stale_info code)
+// so tests can assert EXACTLY ONE fire per path with the right code.
 struct Fixture {
     core::MiningInterface mi{/*testnet=*/true};
     MockCoinNode          node;
     std::vector<uint8_t>  template_prev32;
+    std::vector<int>      fires;   // stale_info codes captured, in order
 
     Fixture() {
-        // Pick a clearly non-zero template prev-hash.
         const std::string prev_hex =
             "00000000000000000000000000000000000000000000000000000000000000ab";
         uint256 pe;
@@ -96,82 +101,136 @@ struct Fixture {
             {"rules", nlohmann::json::array()},
         };
         mi.set_coin_node(&node);
+        mi.set_on_block_submitted(
+            [this](const std::string&, int stale_info) { fires.push_back(stale_info); });
         mi.refresh_work();  // populates m_cached_template from work_data
     }
+
+    std::string stale_header()  const { return make_header_hex(std::vector<uint8_t>(32, 0x00)); }
+    std::string normal_header() const { return make_header_hex(template_prev32); }
 };
 
 bool is_error(const nlohmann::json& r) {
     return r.is_object() && r.contains("error");
 }
 
-// 1. STALE/RACE block, daemon ACCEPTS -> forwarded, handler returns success.
-TEST(WebServerSubmitBlock, StaleRaceForwardedAndAccepted)
+// ------------------------------ B1 / M3: fire accounting ------------------
+
+// stale + accept => forwarded, single 0-fire (WON — the B1 regression case).
+TEST(WebServerSubmitBlock, StaleAccept_SingleWonFire)
 {
     Fixture f;
     f.node.accept = true;
 
-    // prev-hash that does NOT match the template (all zeros) => "stale"/race.
-    std::string hex = make_header_hex(std::vector<uint8_t>(32, 0x00));
-    int calls_before = f.node.submit_calls;
+    auto r = f.mi.submitblock(f.stale_header());
 
-    auto r = f.mi.submitblock(hex);
-
-    EXPECT_EQ(f.node.submit_calls, calls_before + 1)
-        << "race block MUST be forwarded to the daemon, not dropped";
-    EXPECT_EQ(f.node.last_submitted_hex, hex);
-    EXPECT_FALSE(is_error(r))
-        << "daemon accepted => handler must return success, got: " << r.dump();
+    EXPECT_EQ(f.node.submit_calls, 1) << "race block MUST be forwarded, not dropped";
+    EXPECT_FALSE(is_error(r)) << "accepted => success, got: " << r.dump();
+    ASSERT_EQ(f.fires.size(), 1u) << "exactly ONE found-block callback must fire";
+    EXPECT_EQ(f.fires[0], 0)
+        << "an accepted stale/race block is a WON block (0), not ORPHAN (253)";
 }
 
-// 2. STALE/RACE block, daemon REJECTS -> forwarded, handler returns the reject.
-TEST(WebServerSubmitBlock, StaleRaceForwardedAndRejectReturned)
+// stale + reject => forwarded, single 253 (ORPHAN) fire, reject returned.
+TEST(WebServerSubmitBlock, StaleReject_SingleOrphanFire)
 {
     Fixture f;
-    f.node.accept = false;  // daemon says invalid
+    f.node.accept = false;
 
-    std::string hex = make_header_hex(std::vector<uint8_t>(32, 0x00));
-    int calls_before = f.node.submit_calls;
+    auto r = f.mi.submitblock(f.stale_header());
 
-    auto r = f.mi.submitblock(hex);
-
-    EXPECT_EQ(f.node.submit_calls, calls_before + 1)
-        << "race block MUST reach the daemon before any reject decision";
-    EXPECT_TRUE(is_error(r))
-        << "daemon rejected => handler must return the daemon's reject verdict";
-    // And it must NOT be the old synthetic pre-daemon "stale" drop error.
+    EXPECT_EQ(f.node.submit_calls, 1) << "race block MUST reach the daemon first";
+    EXPECT_TRUE(is_error(r)) << "daemon rejected => handler returns the reject";
     EXPECT_EQ(r["error"].get<std::string>().find("stale"), std::string::npos)
         << "reject must reflect the daemon verdict, not a synthetic stale drop";
+    ASSERT_EQ(f.fires.size(), 1u) << "exactly ONE found-block callback must fire";
+    EXPECT_EQ(f.fires[0], 253) << "a rejected stale/race block records as ORPHAN (253)";
 }
 
-// 3. NORMAL (matching prev-hash) block, daemon ACCEPTS -> forwarded, success.
-//    Guards the byte-identical normal path.
-TEST(WebServerSubmitBlock, NormalMatchingPrevForwardedAndAccepted)
+// normal + accept => forwarded, single 0 (WON) fire, success.
+TEST(WebServerSubmitBlock, NormalAccept_SingleWonFire)
 {
     Fixture f;
     f.node.accept = true;
 
-    std::string hex = make_header_hex(f.template_prev32);  // matches template
-    int calls_before = f.node.submit_calls;
+    auto r = f.mi.submitblock(f.normal_header());
 
-    auto r = f.mi.submitblock(hex);
-
-    EXPECT_EQ(f.node.submit_calls, calls_before + 1)
-        << "normal block must be forwarded to the daemon";
-    EXPECT_FALSE(is_error(r))
-        << "normal accepted block must return success, got: " << r.dump();
+    EXPECT_EQ(f.node.submit_calls, 1);
+    EXPECT_FALSE(is_error(r)) << "normal accepted block must succeed, got: " << r.dump();
+    ASSERT_EQ(f.fires.size(), 1u);
+    EXPECT_EQ(f.fires[0], 0);
 }
 
-// 4. Guard: a too-short payload is still rejected locally (never forwarded).
+// normal + reject => forwarded, error returned, NO won-fire (matches prior
+// telemetry: plain reject recorded nothing; a "false" may be daemon-duplicate).
+TEST(WebServerSubmitBlock, NormalReject_ErrorAndNoFire)
+{
+    Fixture f;
+    f.node.accept = false;
+
+    auto r = f.mi.submitblock(f.normal_header());
+
+    EXPECT_EQ(f.node.submit_calls, 1);
+    EXPECT_TRUE(is_error(r));
+    EXPECT_EQ(f.fires.size(), 0u)
+        << "a non-stale reject must not fire a found-block callback (no DOA mis-count)";
+}
+
+// RPC throw (transport failure) => single DOA fire: 254 non-stale, 253 stale.
+TEST(WebServerSubmitBlock, RpcThrowNonStale_SingleDoaFire)
+{
+    Fixture f;
+    f.node.throw_on_submit = true;
+
+    auto r = f.mi.submitblock(f.normal_header());
+
+    EXPECT_EQ(f.node.submit_calls, 1);
+    EXPECT_TRUE(is_error(r));
+    ASSERT_EQ(f.fires.size(), 1u);
+    EXPECT_EQ(f.fires[0], 254) << "non-stale RPC throw records as DOA (254)";
+}
+
+TEST(WebServerSubmitBlock, RpcThrowStale_SingleOrphanFire)
+{
+    Fixture f;
+    f.node.throw_on_submit = true;
+
+    auto r = f.mi.submitblock(f.stale_header());
+
+    EXPECT_EQ(f.node.submit_calls, 1);
+    EXPECT_TRUE(is_error(r));
+    ASSERT_EQ(f.fires.size(), 1u);
+    EXPECT_EQ(f.fires[0], 253) << "stale RPC throw records as ORPHAN (253)";
+}
+
+// Guard: a too-short payload is rejected locally, never forwarded, never fires.
 TEST(WebServerSubmitBlock, TooShortRejectedLocally)
 {
     Fixture f;
-    int calls_before = f.node.submit_calls;
-
-    auto r = f.mi.submitblock(std::string("00", 2));  // 1 byte, well under 80
-
-    EXPECT_EQ(f.node.submit_calls, calls_before)
-        << "malformed short payload must never reach the daemon";
+    auto r = f.mi.submitblock(std::string("00", 2));
+    EXPECT_EQ(f.node.submit_calls, 0) << "malformed short payload must never reach the daemon";
     EXPECT_TRUE(is_error(r));
+    EXPECT_EQ(f.fires.size(), 0u);
+}
+
+// ------------------------------ M2: duplicate = ACK -----------------------
+
+// The shared classifier used by LTC/BTC/DGB NodeRPC::submit_block_hex: a daemon
+// "duplicate"/"inconclusive"/already-have (the dual-path / race outcome) is an
+// ACK, so a won block never surfaces as a reject through the web_server seam.
+TEST(SubmitblockResult, DuplicateAndInconclusiveAreAck)
+{
+    using core::coin::submitblock_result_accepted;
+    EXPECT_TRUE(submitblock_result_accepted(nlohmann::json()));            // null = accept
+    EXPECT_TRUE(submitblock_result_accepted("duplicate"));
+    EXPECT_TRUE(submitblock_result_accepted("DUPLICATE"));
+    EXPECT_TRUE(submitblock_result_accepted("inconclusive"));
+    EXPECT_TRUE(submitblock_result_accepted("duplicate-inconclusive"));
+    EXPECT_TRUE(submitblock_result_accepted("already have block"));
+    // Genuine rejects stay rejects.
+    EXPECT_FALSE(submitblock_result_accepted("duplicate-invalid"));
+    EXPECT_FALSE(submitblock_result_accepted("high-hash"));
+    EXPECT_FALSE(submitblock_result_accepted("bad-txnmrklroot"));
 }
 
 } // namespace

--- a/src/core/test/web_server_submitblock_test.cpp
+++ b/src/core/test/web_server_submitblock_test.cpp
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include <core/web_server.hpp>
+#include <core/uint256.hpp>
+#include <core/coin/node_iface.hpp>
+#include <core/coin/work_view.hpp>
+
+// ---------------------------------------------------------------------------
+// KATs for core::MiningInterface::submitblock — the SHARED-CORE HTTP won-block
+// submit path (LTC's + NMC's PRIMARY block-submit path; also DASH/BTC/DGB/BCH).
+//
+// Invariant under test: a prev-hash MISMATCH ("stale") is a RACE, not a loss.
+// The handler must FORWARD such a block to the coin daemon (never drop it) and
+// return the DAEMON's verdict — accept => success, reject => error. It must NOT
+// synthesize a "stale" error and drop the block before the daemon ever sees it.
+// The normal (matching prev-hash) submit path must be unchanged.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// Minimal ICoinNode test double: records whether the block reached the daemon
+// and lets each test choose the daemon's verdict (accept / reject / RPC throw).
+struct MockCoinNode : public core::coin::ICoinNode {
+    nlohmann::json work_data;
+    bool           accept          = true;   // submit_block_hex return value
+    bool           throw_on_submit = false;  // model an RPC transport failure
+    int            submit_calls    = 0;
+    std::string    last_submitted_hex;
+
+    core::coin::WorkView get_work_view() override {
+        core::coin::WorkView v;
+        v.m_data = work_data;
+        return v;
+    }
+    bool submit_block_hex(const std::string& block_hex, bool /*ignore_failure*/) override {
+        ++submit_calls;
+        last_submitted_hex = block_hex;
+        if (throw_on_submit) throw std::runtime_error("coin RPC unreachable");
+        return accept;
+    }
+    bool is_embedded() const override { return false; }
+    bool has_rpc()     const override { return true; }
+};
+
+std::string to_hex(const std::vector<uint8_t>& bytes) {
+    static const char* H = "0123456789abcdef";
+    std::string s;
+    s.reserve(bytes.size() * 2);
+    for (uint8_t b : bytes) { s += H[b >> 4]; s += H[b & 0x0f]; }
+    return s;
+}
+
+// Build an 80-byte block header (160 hex chars) whose prev-hash field (bytes
+// 4..35, internal byte order) is exactly `prev32`. Other fields are arbitrary.
+std::string make_header_hex(const std::vector<uint8_t>& prev32) {
+    std::vector<uint8_t> hdr(80, 0);
+    hdr[0] = 0x20;                         // version (LE) — arbitrary non-zero
+    std::memcpy(hdr.data() + 4, prev32.data(), 32);
+    for (int i = 36; i < 68; ++i) hdr[i] = static_cast<uint8_t>(i);  // merkle
+    hdr[72] = 0xff; hdr[73] = 0x00; hdr[74] = 0x00; hdr[75] = 0x1d;  // nbits
+    hdr[76] = 0x01;                        // nonce
+    return to_hex(hdr);
+}
+
+// A MiningInterface primed with a live template whose previousblockhash is a
+// known value; returns the 32 internal prev bytes so tests can build matching
+// or mismatching headers.
+struct Fixture {
+    core::MiningInterface mi{/*testnet=*/true};
+    MockCoinNode          node;
+    std::vector<uint8_t>  template_prev32;
+
+    Fixture() {
+        // Pick a clearly non-zero template prev-hash.
+        const std::string prev_hex =
+            "00000000000000000000000000000000000000000000000000000000000000ab";
+        uint256 pe;
+        pe.SetHex(prev_hex);
+        template_prev32.assign(pe.data(), pe.data() + 32);
+
+        node.work_data = {
+            {"previousblockhash", prev_hex},
+            {"height", 100},
+            {"bits", "1d00ffff"},
+            {"coinbasevalue", 5000000000LL},
+            {"transactions", nlohmann::json::array()},
+            {"rules", nlohmann::json::array()},
+        };
+        mi.set_coin_node(&node);
+        mi.refresh_work();  // populates m_cached_template from work_data
+    }
+};
+
+bool is_error(const nlohmann::json& r) {
+    return r.is_object() && r.contains("error");
+}
+
+// 1. STALE/RACE block, daemon ACCEPTS -> forwarded, handler returns success.
+TEST(WebServerSubmitBlock, StaleRaceForwardedAndAccepted)
+{
+    Fixture f;
+    f.node.accept = true;
+
+    // prev-hash that does NOT match the template (all zeros) => "stale"/race.
+    std::string hex = make_header_hex(std::vector<uint8_t>(32, 0x00));
+    int calls_before = f.node.submit_calls;
+
+    auto r = f.mi.submitblock(hex);
+
+    EXPECT_EQ(f.node.submit_calls, calls_before + 1)
+        << "race block MUST be forwarded to the daemon, not dropped";
+    EXPECT_EQ(f.node.last_submitted_hex, hex);
+    EXPECT_FALSE(is_error(r))
+        << "daemon accepted => handler must return success, got: " << r.dump();
+}
+
+// 2. STALE/RACE block, daemon REJECTS -> forwarded, handler returns the reject.
+TEST(WebServerSubmitBlock, StaleRaceForwardedAndRejectReturned)
+{
+    Fixture f;
+    f.node.accept = false;  // daemon says invalid
+
+    std::string hex = make_header_hex(std::vector<uint8_t>(32, 0x00));
+    int calls_before = f.node.submit_calls;
+
+    auto r = f.mi.submitblock(hex);
+
+    EXPECT_EQ(f.node.submit_calls, calls_before + 1)
+        << "race block MUST reach the daemon before any reject decision";
+    EXPECT_TRUE(is_error(r))
+        << "daemon rejected => handler must return the daemon's reject verdict";
+    // And it must NOT be the old synthetic pre-daemon "stale" drop error.
+    EXPECT_EQ(r["error"].get<std::string>().find("stale"), std::string::npos)
+        << "reject must reflect the daemon verdict, not a synthetic stale drop";
+}
+
+// 3. NORMAL (matching prev-hash) block, daemon ACCEPTS -> forwarded, success.
+//    Guards the byte-identical normal path.
+TEST(WebServerSubmitBlock, NormalMatchingPrevForwardedAndAccepted)
+{
+    Fixture f;
+    f.node.accept = true;
+
+    std::string hex = make_header_hex(f.template_prev32);  // matches template
+    int calls_before = f.node.submit_calls;
+
+    auto r = f.mi.submitblock(hex);
+
+    EXPECT_EQ(f.node.submit_calls, calls_before + 1)
+        << "normal block must be forwarded to the daemon";
+    EXPECT_FALSE(is_error(r))
+        << "normal accepted block must return success, got: " << r.dump();
+}
+
+// 4. Guard: a too-short payload is still rejected locally (never forwarded).
+TEST(WebServerSubmitBlock, TooShortRejectedLocally)
+{
+    Fixture f;
+    int calls_before = f.node.submit_calls;
+
+    auto r = f.mi.submitblock(std::string("00", 2));  // 1 byte, well under 80
+
+    EXPECT_EQ(f.node.submit_calls, calls_before)
+        << "malformed short payload must never reach the daemon";
+    EXPECT_TRUE(is_error(r));
+}
+
+} // namespace

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -1869,14 +1869,13 @@ nlohmann::json MiningInterface::submitblock(const std::string& hex_data, const s
                 LOG_TRACE << "[LTC] submitblock: merkle_root=" << submitted_merkle_root.GetHex();
             }
         }
-        // Fire the race/stale telemetry OUTSIDE the lock (avoid deadlock) so the
-        // race stays visible in metrics — then continue into the submit path
-        // below. stale_info 253 = ORPHAN (stale prev). NOTE: we fire this ONCE
-        // here for the race marker; the accepted/rejected branches below are
-        // guarded on !is_stale so a stale block is never double-recorded.
-        if (is_stale && m_on_block_submitted && hex_data.size() >= 160) {
-            m_on_block_submitted(hex_data.substr(0, 160), 253);
-        }
+        // The race/stale telemetry is NOT fired eagerly here. When the daemon is
+        // RPC-armed, a stale/race block can still be ACCEPTED (we win the race),
+        // and must then be credited as a WON block (stale_info 0) so the consumer
+        // runs broadcast_bestblock + schedule_block_verification and the found
+        // block is NOT left pending/ORPHAN. So we fire EXACTLY ONE callback per
+        // block: AFTER the daemon verdict (RPC arm below), or synchronously in the
+        // embedded / no-verdict arms.
     }
 
     if (m_coin_node && m_coin_node->has_rpc()) {
@@ -1885,10 +1884,12 @@ nlohmann::json MiningInterface::submitblock(const std::string& hex_data, const s
             LOG_INFO << "Block forwarded to coin daemon"
                      << (is_stale ? " (stale/race — daemon is authority on validity)" : "");
             if (accepted) {
-                // Notify P2P layer with stale_info=0 (none — accepted). Suppressed
-                // for a stale/race block, which already fired 253 above (no
-                // double-record); the block is still relayed below.
-                if (!is_stale && m_on_block_submitted && hex_data.size() >= 160) {
+                // WON. Fire the single found-block callback with stale_info 0 EVEN
+                // for a stale/race block: an accepted race is a real, paid win and
+                // must be credited (broadcast_bestblock + schedule_block_verification).
+                // record_found_block dedups by block hash, so firing at verdict time
+                // is double-record-safe.
+                if (m_on_block_submitted && hex_data.size() >= 160) {
                     m_on_block_submitted(hex_data.substr(0, 160), 0);
                 }
                 // Relay full block via P2P for fast propagation
@@ -1896,23 +1897,25 @@ nlohmann::json MiningInterface::submitblock(const std::string& hex_data, const s
                     m_on_block_relay(hex_data);
                 }
             } else {
-                // Daemon REJECTED the block: return its verdict to the caller
-                // (submit_block_hex maps daemon null=accept to true; any non-null
-                // reject/duplicate string to false — the reject reason is logged
-                // by submit_block_hex itself). Do NOT synthesize a "stale" error.
-                // We do NOT fire a found-block callback here (preserving the prior
-                // telemetry, which only recorded on the exception path): a "false"
-                // return can also mean daemon-duplicate (block already accepted via
-                // P2P), and recording that as DOA would mis-count a won block.
+                // Daemon REJECTED (or already had) the block: return its verdict to
+                // the caller instead of a synthetic "stale" error. Fire the single
+                // callback ONLY for a stale/race block, recording it as ORPHAN (253)
+                // so the race stays visible. For a NON-stale block fire nothing —
+                // matching the prior telemetry (which only recorded on the exception
+                // path) — and because a "false" return can also mean daemon-duplicate
+                // (block already accepted via P2P), which must not be mis-counted.
                 LOG_WARNING << "submitblock: coin daemon rejected the block (or already had it)";
+                if (is_stale && m_on_block_submitted && hex_data.size() >= 160) {
+                    m_on_block_submitted(hex_data.substr(0, 160), 253);
+                }
                 return {{"error", "block rejected by coin daemon"}};
             }
         } catch (const std::exception& e) {
             LOG_ERROR << "submitblock failed: " << e.what();
-            // Fire callback with doa stale info (254). Suppressed for a stale/race
-            // block (already fired 253 above — no double-record).
-            if (!is_stale && m_on_block_submitted && hex_data.size() >= 160) {
-                m_on_block_submitted(hex_data.substr(0, 160), 254);
+            // DOA (RPC transport failure — no verdict). Fire the single callback:
+            // 253 for a stale/race block, else 254.
+            if (m_on_block_submitted && hex_data.size() >= 160) {
+                m_on_block_submitted(hex_data.substr(0, 160), is_stale ? 253 : 254);
             }
             return {{"error", std::string(e.what())}};
         }
@@ -1958,11 +1961,12 @@ nlohmann::json MiningInterface::submitblock(const std::string& hex_data, const s
             }
         }
 
-        // Fire block-found callback immediately (synchronous — updates stats).
-        // Suppressed for a stale/race block, which already fired 253 above (no
-        // double-record); the block is still relayed via P2P below regardless.
-        if (!is_stale && m_on_block_submitted && hex_data.size() >= 160)
-            m_on_block_submitted(hex_data.substr(0, 160), 0);
+        // Fire the single found-block callback synchronously (embedded has no
+        // synchronous daemon verdict — it relays via P2P and does async RPC
+        // feedback below). A stale/race block is recorded as ORPHAN (253); a fresh
+        // block as WON (0). The block is still relayed via P2P regardless.
+        if (m_on_block_submitted && hex_data.size() >= 160)
+            m_on_block_submitted(hex_data.substr(0, 160), is_stale ? 253 : 0);
 
         // Thread the slow parts (P2P relay + RPC) so stratum isn't blocked.
         // P2P relay runs FIRST — fast propagation is critical for block acceptance.
@@ -1994,6 +1998,10 @@ nlohmann::json MiningInterface::submitblock(const std::string& hex_data, const s
         }).detach();
     } else {
         LOG_WARNING << "[LTC] submitblock: no coin RPC or embedded node connected, block discarded";
+        // No verdict and no forward path: a stale/race block is genuinely lost
+        // here, so record it as ORPHAN (253) to keep the race visible in metrics.
+        if (is_stale && m_on_block_submitted && hex_data.size() >= 160)
+            m_on_block_submitted(hex_data.substr(0, 160), 253);
     }
 
     return nullptr; // null = accepted in getblocktemplate spec

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -1834,9 +1834,20 @@ nlohmann::json MiningInterface::submitblock(const std::string& hex_data, const s
     uint256 submitted_merkle_root;
     std::memcpy(submitted_merkle_root.data(), header_bytes.data() + 36, 32);
 
-    // Validate prev_block_hash matches our cached template
+    // Compare prev_block_hash against our cached template. A MISMATCH is a RACE,
+    // NOT a guaranteed loss: a chain-extended block is a valid same-height
+    // competitor, a 1-block reorg block leads by one, and only a block buried 2+
+    // deep is unwinnable — and forwarding even that is free (the daemon stores a
+    // dead orphan). GUIDING INVARIANT: never REFUSE a block the daemon might
+    // accept — a false refusal is a guaranteed irreversible loss, whereas a
+    // truly-dead block is rejected by the daemon for free. So "stale" is ADVISORY
+    // telemetry only: we log it, mark it in metrics, then FALL THROUGH to the
+    // normal submit path and let the daemon be the authority on validity at the
+    // block's real height. (Previously this path early-returned a synthetic
+    // "stale" error and DROPPED the block, forfeiting winnable race blocks —
+    // this is LTC's + NMC's primary won-block submit path.)
+    bool is_stale = false;
     {
-        bool is_stale = false;
         {
             std::lock_guard<std::mutex> lock(m_work_mutex);
             if (m_work_valid && !m_cached_template.is_null()
@@ -1845,9 +1856,10 @@ nlohmann::json MiningInterface::submitblock(const std::string& hex_data, const s
                 uint256 expected_prev;
                 expected_prev.SetHex(m_cached_template["previousblockhash"].get<std::string>());
                 if (submitted_prev_hash != expected_prev) {
-                    LOG_WARNING << "[LTC] submitblock: stale block — prev_hash mismatch"
+                    LOG_WARNING << "[LTC] submitblock: stale/race block — prev_hash mismatch"
                                 << " submitted=" << submitted_prev_hash.GetHex()
-                                << " expected=" << expected_prev.GetHex();
+                                << " expected=" << expected_prev.GetHex()
+                                << " — forwarding to daemon anyway (daemon is authority)";
                     is_stale = true;
                 }
             }
@@ -1857,33 +1869,49 @@ nlohmann::json MiningInterface::submitblock(const std::string& hex_data, const s
                 LOG_TRACE << "[LTC] submitblock: merkle_root=" << submitted_merkle_root.GetHex();
             }
         }
-        // Fire stale callback OUTSIDE the lock to avoid deadlock
-        if (is_stale) {
-            if (m_on_block_submitted && hex_data.size() >= 160) {
-                m_on_block_submitted(hex_data.substr(0, 160), 253);
-            }
-            return {{"error", "stale block: previous block hash mismatch"}};
+        // Fire the race/stale telemetry OUTSIDE the lock (avoid deadlock) so the
+        // race stays visible in metrics — then continue into the submit path
+        // below. stale_info 253 = ORPHAN (stale prev). NOTE: we fire this ONCE
+        // here for the race marker; the accepted/rejected branches below are
+        // guarded on !is_stale so a stale block is never double-recorded.
+        if (is_stale && m_on_block_submitted && hex_data.size() >= 160) {
+            m_on_block_submitted(hex_data.substr(0, 160), 253);
         }
     }
 
     if (m_coin_node && m_coin_node->has_rpc()) {
         try {
             bool accepted = m_coin_node->submit_block_hex(hex_data, false);
-            LOG_INFO << "Block forwarded to coin daemon";
+            LOG_INFO << "Block forwarded to coin daemon"
+                     << (is_stale ? " (stale/race — daemon is authority on validity)" : "");
             if (accepted) {
-                // Notify P2P layer with stale_info=0 (none — accepted)
-                if (m_on_block_submitted && hex_data.size() >= 160) {
+                // Notify P2P layer with stale_info=0 (none — accepted). Suppressed
+                // for a stale/race block, which already fired 253 above (no
+                // double-record); the block is still relayed below.
+                if (!is_stale && m_on_block_submitted && hex_data.size() >= 160) {
                     m_on_block_submitted(hex_data.substr(0, 160), 0);
                 }
                 // Relay full block via P2P for fast propagation
                 if (m_on_block_relay) {
                     m_on_block_relay(hex_data);
                 }
+            } else {
+                // Daemon REJECTED the block: return its verdict to the caller
+                // (submit_block_hex maps daemon null=accept to true; any non-null
+                // reject/duplicate string to false — the reject reason is logged
+                // by submit_block_hex itself). Do NOT synthesize a "stale" error.
+                // We do NOT fire a found-block callback here (preserving the prior
+                // telemetry, which only recorded on the exception path): a "false"
+                // return can also mean daemon-duplicate (block already accepted via
+                // P2P), and recording that as DOA would mis-count a won block.
+                LOG_WARNING << "submitblock: coin daemon rejected the block (or already had it)";
+                return {{"error", "block rejected by coin daemon"}};
             }
         } catch (const std::exception& e) {
             LOG_ERROR << "submitblock failed: " << e.what();
-            // Fire callback with doa stale info (254)
-            if (m_on_block_submitted && hex_data.size() >= 160) {
+            // Fire callback with doa stale info (254). Suppressed for a stale/race
+            // block (already fired 253 above — no double-record).
+            if (!is_stale && m_on_block_submitted && hex_data.size() >= 160) {
                 m_on_block_submitted(hex_data.substr(0, 160), 254);
             }
             return {{"error", std::string(e.what())}};
@@ -1930,8 +1958,10 @@ nlohmann::json MiningInterface::submitblock(const std::string& hex_data, const s
             }
         }
 
-        // Fire block-found callback immediately (synchronous — updates stats)
-        if (m_on_block_submitted && hex_data.size() >= 160)
+        // Fire block-found callback immediately (synchronous — updates stats).
+        // Suppressed for a stale/race block, which already fired 253 above (no
+        // double-record); the block is still relayed via P2P below regardless.
+        if (!is_stale && m_on_block_submitted && hex_data.size() >= 160)
             m_on_block_submitted(hex_data.substr(0, 160), 0);
 
         // Thread the slow parts (P2P relay + RPC) so stratum isn't blocked.

--- a/src/impl/btc/coin/rpc.cpp
+++ b/src/impl/btc/coin/rpc.cpp
@@ -12,6 +12,7 @@
 
 #include <core/log.hpp>
 #include <core/hash.hpp>
+#include <core/coin/submitblock_result.hpp>
 namespace btc
 {
 
@@ -437,9 +438,13 @@ bool NodeRPC::submit_block_hex(const std::string& block_hex, bool ignore_failure
 {
 	(void)ignore_failure;
 	auto result = m_client.CallMethod<nlohmann::json>(ID, "submitblock", {block_hex});
-	bool success = result.is_null();
+	// Dual-path contract: a "duplicate"/"inconclusive"/already-have result means
+	// the block already reached the network (our P2P relay, or a peer won the
+	// race) — that is SUCCESS, not failure. See core::coin::submitblock_result_accepted.
+	const bool success = core::coin::submitblock_result_accepted(result);
 	if (success)
-		LOG_INFO << "submit_block_hex accepted";
+		LOG_INFO << "submit_block_hex accepted"
+		         << (result.is_null() ? std::string{} : " (" + result.dump() + ")");
 	else
 		// A won block rejection reason is load-bearing diagnostic data: the
 		// daemon returns a verdict string ("bad-witness-merkle-match",

--- a/src/impl/dgb/coin/rpc.cpp
+++ b/src/impl/dgb/coin/rpc.cpp
@@ -7,6 +7,7 @@
 
 #include <core/log.hpp>
 #include <core/hash.hpp>
+#include <core/coin/submitblock_result.hpp>
 namespace dgb
 {
 
@@ -430,11 +431,15 @@ void NodeRPC::submit_block(BlockType& block, bool ignore_failure)
 bool NodeRPC::submit_block_hex(const std::string& block_hex, bool ignore_failure)
 {
 	auto result = m_client.CallMethod<nlohmann::json>(ID, "submitblock", {block_hex});
-	bool success = result.is_null();
+	// Dual-path contract: a "duplicate"/"inconclusive"/already-have result means
+	// the block already reached the network (our P2P relay, or a peer won the
+	// race) — that is SUCCESS, not failure. See core::coin::submitblock_result_accepted.
+	const bool success = core::coin::submitblock_result_accepted(result);
 	if (!success && !ignore_failure)
 		LOG_ERROR << "submit_block_hex result: " << result.dump();
 	else if (success)
-		LOG_INFO << "submit_block_hex accepted";
+		LOG_INFO << "submit_block_hex accepted"
+		         << (result.is_null() ? std::string{} : " (" + result.dump() + ")");
 	return success;
 }
 

--- a/src/impl/ltc/coin/rpc.cpp
+++ b/src/impl/ltc/coin/rpc.cpp
@@ -6,6 +6,7 @@
 
 #include <core/log.hpp>
 #include <core/hash.hpp>
+#include <core/coin/submitblock_result.hpp>
 
 #ifndef _WIN32
 #include <sys/socket.h>          // setsockopt SO_SND/RCVTIMEO (Send() deadline)
@@ -472,11 +473,15 @@ void NodeRPC::submit_block(BlockType& block, std::string mweb, bool ignore_failu
 bool NodeRPC::submit_block_hex(const std::string& block_hex, const std::string& mweb, bool ignore_failure)
 {
 	auto result = m_client.CallMethod<nlohmann::json>(ID, "submitblock", {block_hex + mweb});
-	bool success = result.is_null();
+	// Dual-path contract: a "duplicate"/"inconclusive"/already-have result means
+	// the block already reached the network (our P2P relay, or a peer won the
+	// race) — that is SUCCESS, not failure. See core::coin::submitblock_result_accepted.
+	const bool success = core::coin::submitblock_result_accepted(result);
 	if (!success && !ignore_failure)
 		LOG_ERROR << "submit_block_hex result: " << result.dump();
 	else if (success)
-		LOG_INFO << "submit_block_hex accepted";
+		LOG_INFO << "submit_block_hex accepted"
+		         << (result.is_null() ? std::string{} : " (" + result.dump() + ")");
 	return success;
 }
 


### PR DESCRIPTION
## Problem

The shared-core HTTP `submitblock` handler (`MiningInterface::submitblock`, `src/core/web_server.cpp`) compared the submitted header's prev-hash against the cached template and, on a mismatch, logged `stale block`, fired the 253 (orphan) telemetry, and **early-returned a synthetic `stale block: previous block hash mismatch` error without ever calling `submit_block_hex()`**. The block never reached the daemon and a winnable race block was forfeited.

This is the **primary won-block submit path for LTC and NMC**, and is shared by DASH / BTC / DGB / BCH (it is `src/core`, so one change fixes all coins).

## Why it's a bug

A prev-hash mismatch is a **RACE, not a guaranteed loss**:
- chain-extended = our block is a valid same-height competitor (daemon accepts, we can win the race);
- 1-block reorg = our block leads by one (network reorgs to us → we win);
- only when buried 2+ deep is it unwinnable — and forwarding even that is free (the daemon stores a dead orphan).

Guiding invariant: **never refuse a block the daemon might accept.** A false local refusal is a guaranteed irreversible loss; a truly-dead block is rejected by the daemon for free.

## Fix

- Make `stale` **advisory**: keep the log + the 253 race-telemetry (fired once, up front), then **fall through** to the existing `submit_block_hex(hex, false)` path and let the daemon be the authority on validity at the block's real height.
- Return the **daemon's actual verdict** to the caller (accept ⇒ success, reject ⇒ the reject) instead of a synthetic stale error.
- Guard the accepted / rejected / embedded found-block callbacks so a stale block is **never double-recorded**. The reject branch does **not** fire a found-block callback — a `false` return from `submit_block_hex` can also mean daemon-**duplicate** (block already accepted, e.g. via P2P), which must not be mis-counted as DOA.
- The **normal matching-prev-hash accepted path is unchanged** (byte-identical): valid block → `accepted == true` → fire(0) + relay → success.

No consensus / coinbase / serialization change — purely the submit/no-submit **decision** in the RPC handler.

## Reward safety

Forwarding a stale/race block is safe: the daemon validates it. An invalid block is rejected locally by the daemon and never propagates beyond it. The only case that changes behavior for a *valid* block is winning a race that was previously dropped.

## Cross-coin

Because the change is in `src/core`, it fixes DASH, BTC, DGB, BCH, LTC and NMC at once. No per-coin copies of this HTTP-handler stale-drop exist (the `stale block: previous block hash mismatch` string was unique to `web_server.cpp`; the per-coin `template_builder`/`rpc` files reference `previousblockhash` only for template *building*, not submit-drops).

## Tests

New `src/core/test/web_server_submitblock_test.cpp` KATs (mock `ICoinNode`):
- prev-mismatch (race) block **is forwarded** to the daemon and the daemon's verdict is returned — accept ⇒ success, reject ⇒ error (and the error is **not** the old synthetic stale drop);
- normal matching-prev block still forwards and succeeds;
- malformed short payload is still rejected locally (never forwarded).

Build + test: `core_test` green (64/64, incl. the 4 new KATs). `c2pool-ltc` and `c2pool-dash` both compile + link (cross-coin core-lib compile confirmed).