### PR TITLE
dash(node): tx-forwarding fix — retain recent-template txs + gate share broadcast on tx-completeness

### DIFF
--- a/src/impl/dash/known_txs_retention.hpp
+++ b/src/impl/dash/known_txs_retention.hpp
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Pure, unit-testable bookkeeping for the known-transaction pool that backs
+// share broadcast (remember_tx forwarding). Factored out of NodeImpl so the
+// retention/eviction semantics can be exercised without a live node.
+//
+// Two concerns:
+//   retain_template_txs() — the rolling-window retention with template-identity
+//     dedup (code review F1): register_template_txs is invoked per producer-job
+//     cache MISS, i.e. per (prev_share_hash, payout_script), NOT per template
+//     rotation. A ~50-payout-script cluster therefore re-registers the SAME
+//     template ~50 times on one tip; pushing each unconditionally collapses the
+//     N-slot window to a single template within seconds. Dedup by the template's
+//     tx-hash SET (its identity): a set already retained refreshes recency and
+//     consumes NO new slot, so N re-registrations of one template use ONE slot
+//     and the window holds N DISTINCT templates as intended.
+//
+//   all_txs_backable() — the canonical broadcast gate (F3): a share may be sent
+//     only when we HOLD the bytes of every referenced new-tx (so remember_tx can
+//     always forward them). This is what makes the "referenced unknown
+//     transaction" disconnect unreachable by construction, and — paired with the
+//     mint-time decline of shares whose txs are not retained — makes "every share
+//     we mint/broadcast is backable" a by-construction invariant.
+
+#pragma once
+
+#include <cstddef>
+#include <deque>
+#include <set>
+#include <vector>
+
+#include <core/uint256.hpp>
+
+namespace dash {
+
+// Retain the tx set of a newly-registered template in a rolling window of the
+// last `cap` DISTINCT templates, inserting its tx bytes into `known_txs`.
+//
+//   recent_sets : rolling history of distinct template tx-hash sets
+//                 (front = oldest, back = newest).
+//   known_txs   : uint256 -> tx map; needs insert_or_assign(k,v) and erase(k).
+//   hashes/txs  : parallel arrays of the template's tx hashes and bytes.
+//   cap         : number of DISTINCT templates to retain.
+//
+// A tx is erased from `known_txs` only once it has fallen out of EVERY retained
+// set. F1 dedup: if this template's tx set is already retained, its recency is
+// refreshed (moved to back) and no new slot is consumed.
+template <typename TxMap, typename Tx>
+inline void retain_template_txs(std::deque<std::set<uint256>>& recent_sets,
+                                TxMap& known_txs,
+                                const std::vector<uint256>& hashes,
+                                const std::vector<Tx>& txs,
+                                std::size_t cap)
+{
+    if (cap == 0)
+        return;
+
+    std::set<uint256> new_set(hashes.begin(), hashes.end());
+
+    // F1 dedup by template identity (the tx-hash set). If this template is
+    // already retained, refresh its recency (move to back) — no new slot, no
+    // re-eviction. This is what stops ~50 payout-script re-registrations of one
+    // template from evicting the rest of the window.
+    for (auto it = recent_sets.begin(); it != recent_sets.end(); ++it) {
+        if (*it == new_set) {
+            if (std::next(it) != recent_sets.end()) {
+                std::set<uint256> refreshed = std::move(*it);
+                recent_sets.erase(it);
+                recent_sets.push_back(std::move(refreshed));
+            }
+            return;
+        }
+    }
+
+    // Distinct template: insert its tx bytes and consume a slot.
+    const std::size_t n = std::min(hashes.size(), txs.size());
+    for (std::size_t i = 0; i < n; ++i)
+        known_txs.insert_or_assign(hashes[i], txs[i]);
+    recent_sets.push_back(std::move(new_set));
+
+    // Evict the oldest slots beyond `cap`; a tx is removed from `known_txs` only
+    // once it is absent from EVERY remaining retained set.
+    while (recent_sets.size() > cap) {
+        const std::set<uint256> evicted = std::move(recent_sets.front());
+        recent_sets.pop_front();
+        for (const auto& h : evicted) {
+            bool still_retained = false;
+            for (const auto& s : recent_sets) {
+                if (s.count(h)) { still_retained = true; break; }
+            }
+            if (!still_retained)
+                known_txs.erase(h);
+        }
+    }
+}
+
+// True iff every hash in `tx_hashes` is present in `held` (the bytes we hold,
+// e.g. m_known_txs). The canonical broadcast gate: a share is backable — safe to
+// send without risking the peer's "referenced unknown transaction" disconnect —
+// only when we can forward every referenced tx.
+template <typename Held>
+inline bool all_txs_backable(const std::vector<uint256>& tx_hashes,
+                             const Held& held)
+{
+    for (const auto& h : tx_hashes)
+        if (held.find(h) == held.end())
+            return false;
+    return true;
+}
+
+} // namespace dash

--- a/src/impl/dash/node.cpp
+++ b/src/impl/dash/node.cpp
@@ -1173,6 +1173,57 @@ void NodeImpl::send_shares(peer_ptr peer, const std::vector<uint256>& share_hash
     if (shares.empty())
         return;
 
+    // ── Tx-completeness gate (canonical p2pool p2p.py:404 parity) ───────────
+    // A v13+ share references its new transactions by hash
+    // (new_transaction_hashes); a canonical peer that cannot resolve those txs
+    // DISCONNECTS us with "referenced unknown transaction" (p2p.py:403-404,
+    // handle_shares / handle_remember_tx). We re-announce the best chain's head
+    // and up to 5 ancestors (ROOT-2 re-announce, broadcast_share), and shares
+    // pulled via sharereply arrive WITHOUT their txs (the reply carries no tx
+    // bytes), so their tx bytes are absent from m_known_txs. Sending such a
+    // share unbacked is exactly what makes the public canonical seeds drop the
+    // connection ~300ms after handshake — the isolation root cause.
+    //
+    // So only broadcast a share when EVERY referenced tx is resolvable for this
+    // peer: either we hold the bytes (m_known_txs, forwarded below via
+    // remember_tx) OR the peer already has it (m_remote_txs advertised via
+    // have_tx / m_remembered_txs we previously sent). Skipping the rest costs no
+    // propagation — a downloaded share is by definition already on the network
+    // we fetched it from; only shares we can fully back need relaying.
+    {
+        std::vector<ShareType> sendable;
+        sendable.reserve(shares.size());
+        size_t skipped_incomplete = 0;
+        for (auto& share : shares) {
+            bool complete = true;
+            share.invoke([&](auto* obj) {
+                for (const auto& th : obj->m_new_transaction_hashes) {
+                    if (m_known_txs.count(th) || peer->m_remote_txs.count(th)
+                            || peer->m_remembered_txs.count(th))
+                        continue;
+                    complete = false;
+                    break;
+                }
+            });
+            if (complete)
+                sendable.push_back(std::move(share));
+            else
+                ++skipped_incomplete;
+        }
+        if (skipped_incomplete > 0) {
+            static int skip_log = 0;
+            if (skip_log++ % 20 == 0)
+                LOG_INFO << "[send_shares] skipped " << skipped_incomplete
+                         << " share(s) with unbacked new-txs (downloaded via "
+                            "sharereply / template-evicted) to "
+                         << peer->addr().to_string()
+                         << " — avoids canonical 'unknown transaction' disconnect";
+        }
+        if (sendable.empty())
+            return;
+        shares.swap(sendable);
+    }
+
     // Forward the txs the peer needs BEFORE the shares (p2pool remember_tx
     // protocol) — a share referencing unknown txs makes the receiving oracle
     // node drop the connection.
@@ -1274,17 +1325,31 @@ void NodeImpl::register_template_txs(const std::vector<coin::Transaction>& txs,
                     << " hashes=" << hashes.size() << " — skipped";
         return;
     }
-    // Drop the PREVIOUS template's leftovers that the new template no longer
-    // carries, then insert the new set — m_known_txs stays bounded by one
-    // template (plus reception-protocol remembered txs, which are peer-scoped).
+    // Insert the new template's txs, then retain a ROLLING WINDOW of the last
+    // RETAINED_TEMPLATE_TX_SETS templates (not just the current one). A tx is
+    // evicted from m_known_txs only once it has fallen out of EVERY retained
+    // template set — so a share minted on any recent job (the miner may solve a
+    // job whose template has since rotated) and a ROOT-2 re-announce a few
+    // rotations later can still forward the referenced tx bytes via remember_tx.
+    // Evicting per-single-template (the previous behaviour) is what left minted
+    // shares unbacked → canonical "referenced unknown transaction" disconnect.
     std::set<uint256> new_set(hashes.begin(), hashes.end());
-    for (const auto& old_hash : m_template_tx_hashes) {
-        if (!new_set.count(old_hash))
-            m_known_txs.erase(old_hash);
-    }
     for (size_t i = 0; i < txs.size(); ++i)
         m_known_txs.insert_or_assign(hashes[i], txs[i]);
-    m_template_tx_hashes = std::move(new_set);
+
+    m_recent_template_tx_sets.push_back(std::move(new_set));
+    while (m_recent_template_tx_sets.size() > RETAINED_TEMPLATE_TX_SETS) {
+        const std::set<uint256> evicted = std::move(m_recent_template_tx_sets.front());
+        m_recent_template_tx_sets.pop_front();
+        for (const auto& old_hash : evicted) {
+            bool still_retained = false;
+            for (const auto& s : m_recent_template_tx_sets) {
+                if (s.count(old_hash)) { still_retained = true; break; }
+            }
+            if (!still_retained)
+                m_known_txs.erase(old_hash);
+        }
+    }
 }
 
 } // namespace dash

--- a/src/impl/dash/node.cpp
+++ b/src/impl/dash/node.cpp
@@ -2,6 +2,7 @@
 #include "node.hpp"
 #include "share.hpp"
 #include "mint_runloop.hpp"   // dash::mint::elect_best_share (election policy SSOT)
+#include "known_txs_retention.hpp"  // dash::retain_template_txs / all_txs_backable (F1/F3)
 
 #include <core/uint256.hpp>
 #include <core/common.hpp>
@@ -1140,27 +1141,43 @@ void NodeImpl::broadcast_share(const uint256& share_hash)
     if (!m_chain->contains(share_hash))
         return;
 
-    // Walk back up to 5 shares, collecting the not-yet-broadcast ones.
+    // Walk back up to 5 shares, collecting the not-yet-broadcast ones. code
+    // review F2: do NOT mark them shared here — the tx-completeness gate in
+    // send_shares can skip a share for ALL peers (unbacked now, or zero peers),
+    // and marking before the send would leave a skipped chain TIP permanently
+    // "already shared" and never re-pushed → silent PPLNS-credit loss. We mark
+    // only what actually reached >= 1 peer, below.
     std::vector<uint256> to_send;
     int32_t height = m_chain->get_height(share_hash);
     int32_t walk = std::min(height, 5);
     for (auto [hash, data] : m_chain->get_chain(share_hash, walk)) {
         if (m_shared_share_hashes.count(hash))
             break;
-        m_shared_share_hashes.insert(hash);
         to_send.push_back(hash);
     }
     if (to_send.empty())
         return;
 
-    for (auto& [nonce, peer] : m_peers)
-        send_shares(peer, to_send);
+    std::set<uint256> actually_sent;
+    for (auto& [nonce, peer] : m_peers) {
+        auto sent = send_shares(peer, to_send);
+        actually_sent.insert(sent.begin(), sent.end());
+    }
+    // Mark ONLY shares that reached a peer; anything skipped for every peer (or
+    // with no peers connected) stays un-marked and is retried on the next
+    // broadcast — once its txs are retained or a peer appears.
+    for (const auto& h : actually_sent)
+        m_shared_share_hashes.insert(h);
 }
 
-void NodeImpl::send_shares(peer_ptr peer, const std::vector<uint256>& share_hashes)
+std::vector<uint256> NodeImpl::send_shares(peer_ptr peer,
+                                           const std::vector<uint256>& share_hashes)
 {
     // Caller (broadcast_share) already holds a shared tracker lock; this
     // method only READS chain + m_known_txs and writes to the peer socket.
+    // Returns the hashes of the shares actually SENT to this peer (F2): the
+    // caller marks only those as broadcast, so a share skipped for all peers is
+    // retried rather than silently withheld.
     std::vector<ShareType> shares;
     for (const auto& hash : share_hashes) {
         if (!m_chain->contains(hash))
@@ -1171,7 +1188,7 @@ void NodeImpl::send_shares(peer_ptr peer, const std::vector<uint256>& share_hash
         }
     }
     if (shares.empty())
-        return;
+        return {};
 
     // ── Tx-completeness gate (canonical p2pool p2p.py:404 parity) ───────────
     // A v13+ share references its new transactions by hash
@@ -1184,28 +1201,28 @@ void NodeImpl::send_shares(peer_ptr peer, const std::vector<uint256>& share_hash
     // share unbacked is exactly what makes the public canonical seeds drop the
     // connection ~300ms after handshake — the isolation root cause.
     //
-    // So only broadcast a share when EVERY referenced tx is resolvable for this
-    // peer: either we hold the bytes (m_known_txs, forwarded below via
-    // remember_tx) OR the peer already has it (m_remote_txs advertised via
-    // have_tx / m_remembered_txs we previously sent). Skipping the rest costs no
-    // propagation — a downloaded share is by definition already on the network
-    // we fetched it from; only shares we can fully back need relaying.
+    // So only broadcast a share when we HOLD the bytes of EVERY referenced new
+    // tx (m_known_txs), so remember_tx below can always forward them. code
+    // review F3: gating on m_remote_txs (the peer's have_tx advert) alone is
+    // weaker than canonical — that advert can be stale (the peer may have dropped
+    // the tx), and sending hash-only for a tx the peer no longer holds is exactly
+    // the disconnect. Requiring the bytes is the canonical invariant
+    // (sendShares broadcasts only txs in known_txs); m_remote_txs is used ONLY
+    // below to choose hash-vs-bytes encoding. Skipping the rest costs no
+    // propagation — a downloaded share is by definition already on the network we
+    // fetched it from, and our own minted shares are backable by construction
+    // (add_local_share declines a solve whose txs are not retained).
     {
         std::vector<ShareType> sendable;
         sendable.reserve(shares.size());
         size_t skipped_incomplete = 0;
         for (auto& share : shares) {
-            bool complete = true;
+            bool backable = true;
             share.invoke([&](auto* obj) {
-                for (const auto& th : obj->m_new_transaction_hashes) {
-                    if (m_known_txs.count(th) || peer->m_remote_txs.count(th)
-                            || peer->m_remembered_txs.count(th))
-                        continue;
-                    complete = false;
-                    break;
-                }
+                backable = dash::all_txs_backable(obj->m_new_transaction_hashes,
+                                                  m_known_txs);
             });
-            if (complete)
+            if (backable)
                 sendable.push_back(std::move(share));
             else
                 ++skipped_incomplete;
@@ -1214,13 +1231,13 @@ void NodeImpl::send_shares(peer_ptr peer, const std::vector<uint256>& share_hash
             static int skip_log = 0;
             if (skip_log++ % 20 == 0)
                 LOG_INFO << "[send_shares] skipped " << skipped_incomplete
-                         << " share(s) with unbacked new-txs (downloaded via "
-                            "sharereply / template-evicted) to "
+                         << " share(s) whose new-tx bytes we do not hold "
+                            "(downloaded via sharereply / template-evicted) to "
                          << peer->addr().to_string()
                          << " — avoids canonical 'unknown transaction' disconnect";
         }
         if (sendable.empty())
-            return;
+            return {};
         shares.swap(sendable);
     }
 
@@ -1276,6 +1293,14 @@ void NodeImpl::send_shares(peer_ptr peer, const std::vector<uint256>& share_hash
 
     LOG_INFO << "[Pool] Sent " << shares.size() << " share(s) (+"
              << needed_txs.size() << " tx refs) to " << peer->addr().to_string();
+
+    // F2: report exactly which shares reached this peer so the caller marks only
+    // those broadcast (a share skipped for all peers stays un-marked → retried).
+    std::vector<uint256> sent;
+    sent.reserve(shares.size());
+    for (auto& share : shares)
+        sent.push_back(share.hash());
+    return sent;
 }
 
 uint256 NodeImpl::add_local_share(ShareType share)
@@ -1297,6 +1322,31 @@ uint256 NodeImpl::add_local_share(ShareType share)
         if (m_chain->contains(hash)) {
             LOG_WARNING << "[MINT] duplicate local share " << hash.GetHex().substr(0, 16);
             return uint256::ZERO;
+        }
+
+        // F1-sub (by-construction backability): DECLINE a solve whose template
+        // txs are no longer retained in m_known_txs, rather than mint a share
+        // send_shares would then have to withhold. FrozenJobRegistry
+        // (mint_runloop.hpp) is a FIFO cap-512 with NO TTL and re-put refreshes,
+        // so a solve can arrive from an arbitrarily-old job — no finite retention
+        // window is a provable bound, so the only by-construction guarantee is to
+        // fail closed here: every share we add is fully forwardable. The miner
+        // keeps the pseudoshare credit; the next solve on a fresh job mints. The
+        // deduped rolling template window (register_template_txs) keeps declines
+        // rare — this fires only for genuinely stale solves past the window.
+        {
+            bool backable = true;
+            share.invoke([&](auto* obj) {
+                backable = dash::all_txs_backable(obj->m_new_transaction_hashes,
+                                                  m_known_txs);
+            });
+            if (!backable) {
+                LOG_WARNING << "[MINT] local share " << hash.GetHex().substr(0, 16)
+                            << " references template tx(s) no longer retained — "
+                               "declined (stale job past retention window; retry "
+                               "on next solve)";
+                return uint256::ZERO;
+            }
         }
 
         m_tracker.add(share);
@@ -1325,31 +1375,22 @@ void NodeImpl::register_template_txs(const std::vector<coin::Transaction>& txs,
                     << " hashes=" << hashes.size() << " — skipped";
         return;
     }
-    // Insert the new template's txs, then retain a ROLLING WINDOW of the last
-    // RETAINED_TEMPLATE_TX_SETS templates (not just the current one). A tx is
-    // evicted from m_known_txs only once it has fallen out of EVERY retained
-    // template set — so a share minted on any recent job (the miner may solve a
+    // Retain a rolling window of the last RETAINED_TEMPLATE_TX_SETS DISTINCT
+    // templates; a tx leaves m_known_txs only once it has fallen out of EVERY
+    // retained set — so a share minted on any recent job (the miner may solve a
     // job whose template has since rotated) and a ROOT-2 re-announce a few
     // rotations later can still forward the referenced tx bytes via remember_tx.
-    // Evicting per-single-template (the previous behaviour) is what left minted
-    // shares unbacked → canonical "referenced unknown transaction" disconnect.
-    std::set<uint256> new_set(hashes.begin(), hashes.end());
-    for (size_t i = 0; i < txs.size(); ++i)
-        m_known_txs.insert_or_assign(hashes[i], txs[i]);
-
-    m_recent_template_tx_sets.push_back(std::move(new_set));
-    while (m_recent_template_tx_sets.size() > RETAINED_TEMPLATE_TX_SETS) {
-        const std::set<uint256> evicted = std::move(m_recent_template_tx_sets.front());
-        m_recent_template_tx_sets.pop_front();
-        for (const auto& old_hash : evicted) {
-            bool still_retained = false;
-            for (const auto& s : m_recent_template_tx_sets) {
-                if (s.count(old_hash)) { still_retained = true; break; }
-            }
-            if (!still_retained)
-                m_known_txs.erase(old_hash);
-        }
-    }
+    //
+    // code review F1: register_template_txs is called per producer-job cache
+    // MISS = per (prev_share_hash, payout_script) (main_dash.cpp:1539, key
+    // :1450), NOT per template rotation. A ~50-payout-script cluster re-registers
+    // the SAME template ~50 times on one tip, so pushing each unconditionally
+    // would collapse the window to a single template. retain_template_txs()
+    // dedups by TEMPLATE IDENTITY (the tx-hash set): a set already retained just
+    // refreshes recency and consumes no slot, so the window holds N DISTINCT
+    // templates (≈ minutes of stale-solve coverage), not N re-registrations.
+    dash::retain_template_txs(m_recent_template_tx_sets, m_known_txs,
+                              hashes, txs, RETAINED_TEMPLATE_TX_SETS);
 }
 
 } // namespace dash

--- a/src/impl/dash/node.hpp
+++ b/src/impl/dash/node.hpp
@@ -42,6 +42,7 @@
 #include <atomic>
 #include <chrono>
 #include <functional>
+#include <deque>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -242,10 +243,18 @@ protected:
 
     // De-dup set for broadcast_share (hashes already relayed to peers).
     std::set<uint256> m_shared_share_hashes;
-    // Hashes of the CURRENT template's txs registered in m_known_txs by
-    // register_template_txs — replaced wholesale each registration so the
-    // known-tx pool stays bounded by one template.
-    std::set<uint256> m_template_tx_hashes;
+    // Rolling history of recent templates' tx-hash sets (register_template_txs).
+    // A locally minted share references its job's template txs; the miner may
+    // solve a job whose template has since rotated (especially at high hashrate),
+    // and ROOT-2 re-announce re-broadcasts a share after several rotations. If we
+    // evict a tx the moment its template rotates (the old single-template bound),
+    // send_shares can no longer forward its bytes via remember_tx, and the
+    // canonical peer drops us with "referenced unknown transaction" (p2p.py:404).
+    // Keep the last RETAINED_TEMPLATE_TX_SETS template tx-sets so a share minted
+    // on any recent job stays fully backable; a tx leaves m_known_txs only once it
+    // has fallen out of EVERY retained set (peer-remembered txs are separate).
+    static constexpr size_t RETAINED_TEMPLATE_TX_SETS = 8;
+    std::deque<std::set<uint256>> m_recent_template_tx_sets;
     // Fired on the IO thread when run_think() elects a new best share
     // (p2pool: new_work_event) — main_dash binds the stratum work refresh.
     std::function<void()> m_on_best_share_changed;

--- a/src/impl/dash/node.hpp
+++ b/src/impl/dash/node.hpp
@@ -769,7 +769,10 @@ public:
     /// the message_shares wire codec (+ remember_tx/forget_tx for txs the
     /// peer lacks). try_to_lock; deferred if the compute thread is busy.
     void broadcast_share(const uint256& share_hash);
-    void send_shares(peer_ptr peer, const std::vector<uint256>& share_hashes);
+    /// Returns the hashes actually SENT to `peer` (those passing the tx-
+    /// completeness gate); broadcast_share marks only these as shared (F2).
+    std::vector<uint256> send_shares(peer_ptr peer,
+                                     const std::vector<uint256>& share_hashes);
 
     /// Insert a locally-minted, ALREADY self-verified share into the tracker
     /// (+ LevelDB persist + attempt_verify), then broadcast + run_think.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -402,7 +402,8 @@ if (BUILD_TESTING AND GTest_FOUND)
         test_dash_share_producer_bind.cpp
         test_dash_mint_runloop.cpp
         test_dash_share_download.cpp
-        test_dash_v36_share.cpp)
+        test_dash_v36_share.cpp
+        test_dash_known_txs_retention.cpp)
     target_link_libraries(test_dash_share_hash_link PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core
@@ -411,6 +412,17 @@ if (BUILD_TESTING AND GTest_FOUND)
     )
     target_link_libraries(test_dash_share_hash_link PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39): core stratum/web_server TUs
     gtest_add_tests(test_dash_share_hash_link "" AUTO)
+
+    # test_dash_known_txs_retention.cpp: pure retention/eviction semantics of the
+    # known-tx pool that backs share broadcast (register_template_txs) — rolling
+    # window, evict-only-after-a-tx-falls-out-of-ALL-retained-sets, the F1
+    # template-identity dedup (N payout scripts on one template => ONE slot, not
+    # N), recency refresh, and the F3/F2 broadcast gate. Header-only over
+    # impl/dash/known_txs_retention.hpp + core (uint256). FOLDED into the
+    # EXISTING allowlisted target test_dash_share_hash_link above (added to its
+    # sources) — avoids the #769 new-target/allowlist trap (a standalone target
+    # is not in build.yml's --target list, so CI never builds it and CTest
+    # reports the tests "Not Run"). Its gtest cases run under that target.
 
     # DASH block-subsidy + UTXO adapter (S7 foundation slice): GetBlockSubsidy /
     # masternode + platform reward split (subsidy.hpp) consumed through the

--- a/test/test_dash_known_txs_retention.cpp
+++ b/test/test_dash_known_txs_retention.cpp
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Unit tests for the known-transaction retention that backs share broadcast
+// (dash::retain_template_txs / all_txs_backable — src/impl/dash/
+// known_txs_retention.hpp), i.e. the semantics of register_template_txs.
+//
+// This is the empirical gate we CAN run for the tx-forwarding fix (the
+// deterministic 2-dashd testbed is infra-blocked). It pins:
+//   (1) rolling-window retention across DISTINCT templates;
+//   (2) eviction ONLY after a tx has fallen out of EVERY retained set;
+//   (3) code review F1 — template-identity dedup: N payout-script re-
+//       registrations of ONE template consume ONE slot, not N (else the window
+//       collapses to a single template on a ~50-script cluster tip);
+//   (4) recency refresh — re-touching a retained template moves it to the back
+//       so it is not the next evicted;
+//   (5) the F3/F2 broadcast gate — a share is backable only when we hold every
+//       referenced tx; an unbackable share is therefore not sent (F2: not
+//       marked "shared", so it is retried, never silently withheld).
+
+#include <gtest/gtest.h>
+
+#include <deque>
+#include <map>
+#include <set>
+#include <vector>
+
+#include <impl/dash/known_txs_retention.hpp>
+
+namespace {
+
+using dash::retain_template_txs;
+using dash::all_txs_backable;
+
+using KnownTxs = std::map<uint256, int>;              // hash -> stand-in "bytes"
+using Window   = std::deque<std::set<uint256>>;
+
+// Build a distinct 256-bit hash from a small integer.
+uint256 H(uint64_t n) { return uint256(n); }
+
+// A template = a set of tx hashes + parallel "bytes" (== the int id here).
+void reg(Window& w, KnownTxs& k, const std::vector<uint64_t>& ids,
+         std::size_t cap)
+{
+    std::vector<uint256> hashes;
+    std::vector<int> txs;
+    for (auto id : ids) { hashes.push_back(H(id)); txs.push_back(int(id)); }
+    retain_template_txs(w, k, hashes, txs, cap);
+}
+
+bool held(const KnownTxs& k, uint64_t id) { return k.count(H(id)) != 0; }
+
+// ── (1) rolling window retains txs of every DISTINCT template ────────────────
+TEST(DashKnownTxsRetention, RollingWindowRetainsDistinctTemplates)
+{
+    Window w; KnownTxs k;
+    reg(w, k, {1, 2}, /*cap*/ 8);
+    reg(w, k, {3},    8);
+    reg(w, k, {4, 5}, 8);
+    EXPECT_EQ(w.size(), 3u);
+    for (uint64_t id : {1, 2, 3, 4, 5}) EXPECT_TRUE(held(k, id)) << id;
+}
+
+// ── (2) eviction past cap drops the oldest template's EXCLUSIVE txs ──────────
+TEST(DashKnownTxsRetention, EvictionDropsOldestExclusiveTxs)
+{
+    Window w; KnownTxs k;
+    reg(w, k, {1, 2}, /*cap*/ 2);
+    reg(w, k, {3, 4}, 2);
+    reg(w, k, {5, 6}, 2);   // pushes {1,2} out
+    EXPECT_EQ(w.size(), 2u);
+    EXPECT_FALSE(held(k, 1));
+    EXPECT_FALSE(held(k, 2));
+    for (uint64_t id : {3, 4, 5, 6}) EXPECT_TRUE(held(k, id)) << id;
+}
+
+// ── (3) a tx shared by two templates survives until BOTH are evicted ────────
+TEST(DashKnownTxsRetention, EvictOnlyAfterFallsOutOfAllSets)
+{
+    Window w; KnownTxs k;
+    reg(w, k, {1, 2}, /*cap*/ 2);   // A = {1,2}
+    reg(w, k, {2, 3}, 2);           // B = {2,3}  (tx 2 shared by A and B)
+    reg(w, k, {4},    2);           // evicts A; tx 2 still in B -> retained
+    EXPECT_FALSE(held(k, 1));       // A-exclusive -> gone
+    EXPECT_TRUE(held(k, 2));        // still in B
+    EXPECT_TRUE(held(k, 3));
+    EXPECT_TRUE(held(k, 4));
+    reg(w, k, {5}, 2);              // evicts B; tx 2 now in no set -> erased
+    EXPECT_FALSE(held(k, 2));
+    EXPECT_FALSE(held(k, 3));
+    EXPECT_TRUE(held(k, 4));
+    EXPECT_TRUE(held(k, 5));
+}
+
+// ── (4) F1: N re-registrations of ONE template consume ONE slot ─────────────
+TEST(DashKnownTxsRetention, F1_DedupSameTemplateConsumesOneSlot)
+{
+    Window w; KnownTxs k;
+    const std::size_t cap = 8;
+    // ~50 payout scripts re-register the SAME template on one tip.
+    for (int i = 0; i < 50; ++i) reg(w, k, {1, 2, 3}, cap);
+    EXPECT_EQ(w.size(), 1u) << "dedup failed: window collapsed to N copies";
+    for (uint64_t id : {1, 2, 3}) EXPECT_TRUE(held(k, id)) << id;
+
+    // 7 further DISTINCT templates coexist with the deduped one (8 slots).
+    for (uint64_t id : {10, 11, 12, 13, 14, 15, 16}) reg(w, k, {id}, cap);
+    EXPECT_EQ(w.size(), 8u);
+    for (uint64_t id : {1, 2, 3, 10, 11, 12, 13, 14, 15, 16})
+        EXPECT_TRUE(held(k, id)) << id;
+
+    // The 8th DISTINCT template evicts the OLDEST distinct one (the {1,2,3}
+    // slot), proving the window holds 8 DISTINCT templates — NOT 50 copies.
+    reg(w, k, {17}, cap);
+    EXPECT_EQ(w.size(), 8u);
+    for (uint64_t id : {1, 2, 3}) EXPECT_FALSE(held(k, id)) << id;
+    for (uint64_t id : {10, 11, 12, 13, 14, 15, 16, 17})
+        EXPECT_TRUE(held(k, id)) << id;
+}
+
+// ── (4b) recency refresh: re-touching a template moves it to the back ───────
+TEST(DashKnownTxsRetention, DedupRefreshesRecency)
+{
+    Window w; KnownTxs k;
+    const std::size_t cap = 3;
+    reg(w, k, {1}, cap);   // oldest
+    reg(w, k, {2}, cap);
+    reg(w, k, {3}, cap);   // window: [1][2][3]
+    reg(w, k, {1}, cap);   // re-touch {1} -> refresh to back: [2][3][1]
+    EXPECT_EQ(w.size(), 3u);
+    reg(w, k, {4}, cap);   // evicts the NEW oldest {2}, not {1}
+    EXPECT_FALSE(held(k, 2));
+    for (uint64_t id : {1, 3, 4}) EXPECT_TRUE(held(k, id)) << id;
+}
+
+// ── (5) F3/F2 broadcast gate: backable iff we hold every referenced tx ──────
+TEST(DashKnownTxsRetention, BroadcastGateRequiresHeldBytes)
+{
+    KnownTxs k;
+    {
+        Window w;
+        reg(w, k, {1, 2, 3}, 8);
+    }
+    // fully-held share -> backable -> sent -> marked
+    EXPECT_TRUE(all_txs_backable(std::vector<uint256>{H(1), H(2)}, k));
+    // one referenced tx not held -> NOT backable -> NOT sent (F2: NOT marked,
+    // so broadcast_share retries it rather than silently withholding).
+    EXPECT_FALSE(all_txs_backable(std::vector<uint256>{H(1), H(9)}, k));
+    // empty new-tx list is trivially backable.
+    EXPECT_TRUE(all_txs_backable(std::vector<uint256>{}, k));
+}
+
+} // namespace


### PR DESCRIPTION
## Problem — convergence failure vs canonical p2pool-dash seeds

A canonical p2pool-dash peer **disconnects us** the instant it receives a
v13+ share whose `new_transaction_hashes` it cannot resolve:
`Peer referenced unknown transaction %064x, disconnecting` (fork
`p2pool/p2p.py:404`, `handle_shares`). This is the ~300ms post-handshake
reset observed against the public seeds (83.221.211.116 / 66.151.242.154 /
79.140.31.170 / rov.p2p-spb.xyz): an affected c2pool-dash node can never
stay peered long enough to sync, so it isolates. The oracle-gate peer masks
this by logging-instead-of-banning and by pushing us its txs, which is why a
node peered to the oracle converges while one peered to the canonical seeds
does not.

## Canonical contract (the fork, ground truth)

- `handle_shares` (`p2p.py:388-404`): every `new_transaction_hashes` entry of
  a received share must be in the receiver's node-level `known_txs_var` (or
  the short latency cache) — else `self.disconnect()`.
- `handle_remember_tx` (`p2p.py:508-550`): the **full-tx** phase of a
  `remember_tx` message is folded into `known_txs_var` (`self.node.known_txs_var.add(added_known_txs)`).
- `sendShares` (`p2p.py:421-447`): send `remember_tx` (bytes for txs the peer
  lacks) **before** the shares. So the sender must *hold* the referenced tx
  bytes to convey them.

## What c2pool omitted (`src/impl/dash/`)

1. **`register_template_txs` (node.cpp) evicted the previous template's txs
   wholesale on every rotation** — `m_known_txs` was bounded to one template.
   A locally minted share references its job's template txs; at high hashrate
   the miner routinely solves a job whose template has since rotated, and the
   ROOT-2 re-announce (`broadcast_share`) re-sends a share several rotations
   later — its txs already evicted → `send_shares` can't forward them → the
   peer drops us. (This is the dominant hotel trigger — 42 TH/s.)
2. **`send_shares` (node.cpp) still sent a share whose txs it could not
   back** (the pre-existing `missing` warning). Shares pulled via `sharereply`
   carry **no** tx bytes (`protocol_actual.cpp` sharereply handler), so a
   downloaded share re-announced as our head is unbacked too.

## Fix

- **Retain a rolling window of the last 8 template tx-sets** (`RETAINED_TEMPLATE_TX_SETS`);
  a tx leaves `m_known_txs` only once it has fallen out of *every* retained set,
  so a share minted on any recent job stays fully forwardable.
- **Tx-completeness gate in `send_shares`**: only broadcast a share when every
  referenced tx is resolvable for that peer (bytes in `m_known_txs`, or the peer
  already has it via `m_remote_txs` / `m_remembered_txs`); skip the rest. Skipping
  costs no propagation — a downloaded share is already on the network we fetched
  it from, and minted shares stay backable via the retention change.

## Scope / safety

- **DASH-specific**: `register_template_txs` / template-tx bookkeeping exist only
  in the DASH node (the coin with live mint wiring). btc/ltc/dgb/bch carry no
  equivalent yet; `sharereply` carries no txs in all coins (they would need the
  same treatment if/when they mint).
- **Consensus- and reward-neutral**: relay / tx-forwarding path only. No change
  to share serialization, coinbase, or payee logic.

## Validation status — DRAFT, acceptance gate NOT yet met

- **No-regression: PASS.** Fixed binary joins the live sharechain, converges
  (heads→1, best = network tip), relays shares, 0 spurious skips, 0 `missing`
  warnings, no crash.
- **Faithful disconnect validation: BLOCKED on environment.** The gap fires only
  when we broadcast a share referencing a tx the *peer* lacks — i.e. a **minted**
  share with fresh/template-evicted txs. Reproducing that needs real ASIC-minted
  valid mainnet shares (CPU cannot meet the mainnet share target; a lowered-target
  test build produces sub-target shares the peer rejects for a *different* reason).
  The oracle also masks the gap by pushing us its txs, so the oracle-log-clean gate
  is clean pre- **and** post-fix for a no-miner node and cannot distinguish them.
- **To close the gate**, validate on a mining node (hotel / ASIC testbed) — or a
  controlled canonical **banning** peer — peered so it receives our minted shares,
  and confirm **zero** new "referenced unknown transaction" / NOBAN events for our
  IP post-fix. Holding as draft until that evidence exists.