### PR TITLE
port(coins): bounded known-tx eviction (recency window) -> LTC/DGB/BCH/BTC

### DIFF
--- a/src/core/known_txs_eviction.hpp
+++ b/src/core/known_txs_eviction.hpp
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Bounded, recency-preserving eviction for the node-level known-tx relay cache
+// (m_known_txs) that backs share broadcast (remember_tx forwarding).
+//
+// Shared by the LTC / DGB / BCH / BTC node lanes. These coins populate
+// m_known_txs ONLY from inbound peer remember_tx (they have no template-set
+// registration), so the DASH template-window helper (known_txs_retention.hpp)
+// does not apply. What they share is the bug: when the cache exceeds its cap a
+// WHOLESALE clear() drops every forwardable tx byte at once, so a subsequent
+// share relay referencing a just-dropped tx can no longer remember_tx-forward it
+// and the receiving canonical peer disconnects with "referenced unknown
+// transaction" (p2p.py:404) -> sharechain fragmentation / non-convergence.
+//
+// The fix replaces the wholesale clear() with oldest-first eviction down to the
+// cap, preserving the most-recently-learned txs (the ones recent shares are most
+// likely to reference). A parallel insertion-order deque records recency; the
+// map holds the bytes.
+//
+// Reward-safety: tx-forwarding only. No consensus / subsidy / coinbase / payee
+// state is touched, and the won-block and local-mint paths never read or write
+// m_known_txs in these coins.
+
+#pragma once
+
+#include <cstddef>
+#include <deque>
+
+namespace core {
+
+// Evict oldest known-txs until the map holds at most `cap` entries, preserving
+// the most-recently-inserted (the entries most likely to be referenced by a
+// recent share we may still have to relay). `order` is the insertion-order
+// sidecar recorded at each new insert (front = oldest, back = newest).
+//
+// Desync-tolerant by construction: a key present in `order` but already absent
+// from `known_txs` (evicted by some other path) erases as a harmless no-op and
+// is still popped, so the loop makes progress on `order` shrinking even if the
+// map size is unchanged. Leading stale entries are then pruned so `order` cannot
+// accrete tombstones unbounded relative to the live map.
+//
+// cap == 0 degenerates to emptying the map (the old wholesale semantics),
+// preserved so a zero cap is never a foot-gun.
+template <typename Map, typename Key>
+inline void evict_known_txs_to_cap(Map& known_txs, std::deque<Key>& order,
+                                   std::size_t cap)
+{
+    while (known_txs.size() > cap && !order.empty()) {
+        const Key oldest = order.front();
+        order.pop_front();
+        known_txs.erase(oldest); // no-op if already gone (desync tolerance)
+    }
+    // Bound deque slack: drop leading keys no longer in the map even when
+    // already under cap, so `order` tracks the live set rather than tombstones.
+    while (!order.empty() && known_txs.find(order.front()) == known_txs.end())
+        order.pop_front();
+}
+
+} // namespace core

--- a/src/core/test/CMakeLists.txt
+++ b/src/core/test/CMakeLists.txt
@@ -1,5 +1,13 @@
 if (BUILD_TESTING AND (GTest_FOUND OR GTEST_FOUND))
-    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp core_merkle_branches_test.cpp version_gate_test.cpp filesystem_test.cpp web_server_submitblock_test.cpp)
+    # known_txs_eviction_test.cpp: recency-preserving bounded eviction of the
+    # node-level known-tx relay cache (core/known_txs_eviction.hpp), the shared
+    # helper that replaces the wholesale m_known_txs.clear() in all four of the
+    # LTC/DGB/BCH/BTC node lanes. Header-only over core (uint256), so it is FOLDED
+    # into the EXISTING allowlisted core_test target rather than a new
+    # add_executable — a standalone target is not in build.yml's --target list, so
+    # CI never builds it and CTest reports the cases "Not Run" (the #769 trap). One
+    # KAT covers all four coins since they consume one shared core helper.
+    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp core_merkle_branches_test.cpp version_gate_test.cpp filesystem_test.cpp web_server_submitblock_test.cpp known_txs_eviction_test.cpp)
     target_link_libraries(core_test PRIVATE GTest::gtest_main core c2pool_merged_mining GTest::gtest)
     target_link_libraries(core_test PRIVATE c2pool_payout c2pool_hashrate ltc_coin)  # OBJECT-lib SCC direct-naming (#22/#39)
 

--- a/src/core/test/known_txs_eviction_test.cpp
+++ b/src/core/test/known_txs_eviction_test.cpp
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#include <gtest/gtest.h>
+
+#include <deque>
+#include <map>
+
+#include <core/known_txs_eviction.hpp>
+#include <core/uint256.hpp>
+
+// KATs for core::evict_known_txs_to_cap — the recency-preserving bounded
+// eviction that replaces the wholesale m_known_txs.clear() in the LTC/DGB/BCH/BTC
+// node relay path (tx-forwarding robustness; no consensus state). The map stands
+// in for m_known_txs (value type is irrelevant to eviction, so int here), and
+// the deque is the insertion-order recency sidecar the protocol handlers push to.
+
+using core::evict_known_txs_to_cap;
+
+namespace {
+
+// Distinct uint256 tx-hash stand-ins (uint256(uint64_t) ctor).
+uint256 H(uint64_t i) { return uint256(i); }
+
+// Insert like a remember_tx handler would: new key -> map + order sidecar.
+void insert_known(std::map<uint256, int>& m, std::deque<uint256>& order,
+                  const uint256& h, int v)
+{
+    if (!m.contains(h)) {
+        m.emplace(h, v);
+        order.push_back(h);
+    }
+}
+
+} // namespace
+
+// Over-cap insert evicts oldest-first; only the most-recent `cap` survive, and
+// the survivors are exactly the last `cap` inserted (recency preserved).
+TEST(KnownTxsEviction, EvictsOldestKeepsMostRecent)
+{
+    std::map<uint256, int> m;
+    std::deque<uint256> order;
+    constexpr size_t cap = 4;
+
+    for (uint64_t i = 1; i <= 10; ++i)
+        insert_known(m, order, H(i), static_cast<int>(i));
+
+    evict_known_txs_to_cap(m, order, cap);
+
+    ASSERT_EQ(m.size(), cap);
+    // Oldest (1..6) gone, most-recent (7..10) retained.
+    for (uint64_t i = 1; i <= 6; ++i)
+        EXPECT_FALSE(m.contains(H(i))) << "stale tx " << i << " should be evicted";
+    for (uint64_t i = 7; i <= 10; ++i)
+        EXPECT_TRUE(m.contains(H(i))) << "recent tx " << i << " should survive";
+    // Order deque tracks exactly the live survivors, oldest-first.
+    ASSERT_EQ(order.size(), cap);
+    EXPECT_EQ(order.front(), H(7));
+    EXPECT_EQ(order.back(), H(10));
+}
+
+// Under cap: no eviction, nothing touched.
+TEST(KnownTxsEviction, NoOpWhenUnderCap)
+{
+    std::map<uint256, int> m;
+    std::deque<uint256> order;
+    for (uint64_t i = 1; i <= 3; ++i)
+        insert_known(m, order, H(i), static_cast<int>(i));
+
+    evict_known_txs_to_cap(m, order, /*cap=*/8);
+
+    EXPECT_EQ(m.size(), 3u);
+    EXPECT_EQ(order.size(), 3u);
+    for (uint64_t i = 1; i <= 3; ++i)
+        EXPECT_TRUE(m.contains(H(i)));
+}
+
+// Desync tolerance: a key erased from the map by some other path leaves a stale
+// entry in the order deque. Eviction must skip it as a no-op (never crash),
+// never let the map exceed cap, and must not evict a live key on its behalf.
+TEST(KnownTxsEviction, ToleratesStaleOrderEntries)
+{
+    std::map<uint256, int> m;
+    std::deque<uint256> order;
+    for (uint64_t i = 1; i <= 6; ++i)
+        insert_known(m, order, H(i), static_cast<int>(i));
+
+    // Externally erase two entries WITHOUT touching the order deque (simulated
+    // desync): H(2) is in the middle, H(1) is the oldest/front.
+    m.erase(H(1));
+    m.erase(H(2));
+    ASSERT_EQ(m.size(), 4u);
+    ASSERT_EQ(order.size(), 6u); // deque still holds the tombstones
+
+    evict_known_txs_to_cap(m, order, /*cap=*/3);
+
+    // Map is brought to cap using live entries; a stale front erase is a no-op
+    // that still advances the deque, so exactly one live key (H(3)) is dropped.
+    EXPECT_EQ(m.size(), 3u);
+    EXPECT_FALSE(m.contains(H(3)));
+    for (uint64_t i = 4; i <= 6; ++i)
+        EXPECT_TRUE(m.contains(H(i)));
+    // Deque no longer holds keys absent from the map (front pruned of tombstones).
+    for (const auto& h : order)
+        EXPECT_TRUE(m.contains(h)) << "order deque must not retain tombstones";
+    EXPECT_EQ(order.size(), m.size());
+}
+
+// Leading tombstones are pruned even when the map is already under cap, so the
+// order deque cannot accrete unbounded relative to the live map.
+TEST(KnownTxsEviction, PrunesLeadingTombstonesUnderCap)
+{
+    std::map<uint256, int> m;
+    std::deque<uint256> order;
+    for (uint64_t i = 1; i <= 3; ++i)
+        insert_known(m, order, H(i), static_cast<int>(i));
+    m.erase(H(1)); // front tombstone; map now under any reasonable cap
+
+    evict_known_txs_to_cap(m, order, /*cap=*/8);
+
+    EXPECT_EQ(m.size(), 2u);
+    EXPECT_EQ(order.size(), 2u);
+    EXPECT_EQ(order.front(), H(2));
+}
+
+// cap == 0 degenerates to the old wholesale-empty semantics (never a foot-gun).
+TEST(KnownTxsEviction, ZeroCapEmpties)
+{
+    std::map<uint256, int> m;
+    std::deque<uint256> order;
+    for (uint64_t i = 1; i <= 5; ++i)
+        insert_known(m, order, H(i), static_cast<int>(i));
+
+    evict_known_txs_to_cap(m, order, /*cap=*/0);
+
+    EXPECT_TRUE(m.empty());
+    EXPECT_TRUE(order.empty());
+}

--- a/src/impl/bch/node.cpp
+++ b/src/impl/bch/node.cpp
@@ -1385,8 +1385,13 @@ void NodeImpl::prune_shares(const uint256& /*best_share*/)
     // Cache cleanup (kept from original)
     if (m_shared_share_hashes.size() > m_max_shared_hashes)
         m_shared_share_hashes.clear();
+    // Recency-preserving bounded eviction (was: wholesale clear()). Dropping the
+    // whole cache at once destroyed every forwardable tx byte, so a share relay
+    // that referenced a just-dropped tx could no longer remember_tx-forward it
+    // and the canonical peer disconnected with "referenced unknown transaction".
+    // Evict oldest-first down to the cap, keeping the most-recently-learned txs.
     if (m_known_txs.size() > m_max_known_txs)
-        m_known_txs.clear();
+        core::evict_known_txs_to_cap(m_known_txs, m_known_txs_order, m_max_known_txs);
     if (m_raw_share_cache.size() > m_max_raw_shares)
         m_raw_share_cache.clear();
 }

--- a/src/impl/bch/node.hpp
+++ b/src/impl/bch/node.hpp
@@ -35,6 +35,7 @@
 #include <pool/protocol.hpp>
 #include <core/message.hpp>
 #include <core/reply_matcher.hpp>
+#include <core/known_txs_eviction.hpp>
 #include <sharechain/prepared_list.hpp>
 #include <c2pool/storage/sharechain_storage.hpp>
 
@@ -78,6 +79,13 @@ protected:
     // Global pool of known transactions, populated by remember_tx and coin daemon.
     // Protocol handlers look up tx hashes here when processing shares.
     std::map<uint256, coin::Transaction> m_known_txs;
+    // Insertion-order recency sidecar for m_known_txs. Recorded at each NEW
+    // remember_tx insert; consumed by prune_shares to evict OLDEST-first down to
+    // m_max_known_txs instead of the old wholesale clear() (which dropped every
+    // forwardable tx byte at once -> canonical "referenced unknown transaction"
+    // disconnect). Tx-forwarding only; no consensus/mint state. See
+    // core::evict_known_txs_to_cap (core/known_txs_eviction.hpp).
+    std::deque<uint256> m_known_txs_order;
 
     // -- Won-block broadcaster sink (broadcaster-gate A+B in-operation fire) --
     // The pool node stays coin-daemon-agnostic: the binary entrypoint wires this

--- a/src/impl/bch/protocol_actual.cpp
+++ b/src/impl/bch/protocol_actual.cpp
@@ -309,7 +309,10 @@ void Actual::HANDLER(remember_tx)
         peer->m_remembered_txs.insert_or_assign(tx_hash, full_tx);
 
         if (!m_known_txs.contains(tx_hash))
+        {
             m_known_txs.emplace(tx_hash, std::move(full_tx));
+            m_known_txs_order.push_back(tx_hash); // recency for bounded eviction
+        }
     }
 }
 

--- a/src/impl/bch/protocol_legacy.cpp
+++ b/src/impl/bch/protocol_legacy.cpp
@@ -326,7 +326,10 @@ void Legacy::HANDLER(remember_tx)
         peer->m_remembered_txs.insert_or_assign(tx_hash, full_tx);
 
         if (!m_known_txs.contains(tx_hash))
+        {
             m_known_txs.emplace(tx_hash, std::move(full_tx));
+            m_known_txs_order.push_back(tx_hash); // recency for bounded eviction
+        }
     }
 }
 

--- a/src/impl/btc/node.cpp
+++ b/src/impl/btc/node.cpp
@@ -1382,8 +1382,13 @@ void NodeImpl::prune_shares(const uint256& /*best_share*/)
     // Cache cleanup (kept from original)
     if (m_shared_share_hashes.size() > m_max_shared_hashes)
         m_shared_share_hashes.clear();
+    // Recency-preserving bounded eviction (was: wholesale clear()). Dropping the
+    // whole cache at once destroyed every forwardable tx byte, so a share relay
+    // that referenced a just-dropped tx could no longer remember_tx-forward it
+    // and the canonical peer disconnected with "referenced unknown transaction".
+    // Evict oldest-first down to the cap, keeping the most-recently-learned txs.
     if (m_known_txs.size() > m_max_known_txs)
-        m_known_txs.clear();
+        core::evict_known_txs_to_cap(m_known_txs, m_known_txs_order, m_max_known_txs);
     if (m_raw_share_cache.size() > m_max_raw_shares)
         m_raw_share_cache.clear();
 }

--- a/src/impl/btc/node.hpp
+++ b/src/impl/btc/node.hpp
@@ -12,6 +12,7 @@
 #include <pool/protocol.hpp>
 #include <core/message.hpp>
 #include <core/reply_matcher.hpp>
+#include <core/known_txs_eviction.hpp>
 #include <sharechain/prepared_list.hpp>
 #include <c2pool/storage/sharechain_storage.hpp>
 
@@ -54,6 +55,13 @@ protected:
     // Global pool of known transactions, populated by remember_tx and coin daemon.
     // Protocol handlers look up tx hashes here when processing shares.
     std::map<uint256, coin::Transaction> m_known_txs;
+    // Insertion-order recency sidecar for m_known_txs. Recorded at each NEW
+    // remember_tx insert; consumed by prune_shares to evict OLDEST-first down to
+    // m_max_known_txs instead of the old wholesale clear() (which dropped every
+    // forwardable tx byte at once -> canonical "referenced unknown transaction"
+    // disconnect). Tx-forwarding only; no consensus/mint state. See
+    // core::evict_known_txs_to_cap (core/known_txs_eviction.hpp).
+    std::deque<uint256> m_known_txs_order;
 
     // Thread pool for parallel share_init_verify (scrypt CPU work).
     // Keeps expensive crypto off the io_context thread.

--- a/src/impl/btc/protocol_actual.cpp
+++ b/src/impl/btc/protocol_actual.cpp
@@ -260,7 +260,10 @@ void Actual::HANDLER(remember_tx)
         peer->m_remembered_txs.insert_or_assign(tx_hash, full_tx);
 
         if (!m_known_txs.contains(tx_hash))
+        {
             m_known_txs.emplace(tx_hash, std::move(full_tx));
+            m_known_txs_order.push_back(tx_hash); // recency for bounded eviction
+        }
     }
 }
 

--- a/src/impl/btc/protocol_legacy.cpp
+++ b/src/impl/btc/protocol_legacy.cpp
@@ -296,7 +296,10 @@ void Legacy::HANDLER(remember_tx)
         peer->m_remembered_txs.insert_or_assign(tx_hash, full_tx);
 
         if (!m_known_txs.contains(tx_hash))
+        {
             m_known_txs.emplace(tx_hash, std::move(full_tx));
+            m_known_txs_order.push_back(tx_hash); // recency for bounded eviction
+        }
     }
 }
 

--- a/src/impl/dgb/node.cpp
+++ b/src/impl/dgb/node.cpp
@@ -1442,8 +1442,13 @@ void NodeImpl::prune_shares(const uint256& /*best_share*/)
     // Cache cleanup (kept from original)
     if (m_shared_share_hashes.size() > m_max_shared_hashes)
         m_shared_share_hashes.clear();
+    // Recency-preserving bounded eviction (was: wholesale clear()). Dropping the
+    // whole cache at once destroyed every forwardable tx byte, so a share relay
+    // that referenced a just-dropped tx could no longer remember_tx-forward it
+    // and the canonical peer disconnected with "referenced unknown transaction".
+    // Evict oldest-first down to the cap, keeping the most-recently-learned txs.
     if (m_known_txs.size() > m_max_known_txs)
-        m_known_txs.clear();
+        core::evict_known_txs_to_cap(m_known_txs, m_known_txs_order, m_max_known_txs);
     if (m_raw_share_cache.size() > m_max_raw_shares)
         m_raw_share_cache.clear();
 }

--- a/src/impl/dgb/node.hpp
+++ b/src/impl/dgb/node.hpp
@@ -19,6 +19,7 @@
 #include <pool/protocol.hpp>
 #include <core/message.hpp>
 #include <core/reply_matcher.hpp>
+#include <core/known_txs_eviction.hpp>
 #include <sharechain/prepared_list.hpp>
 #include <c2pool/storage/sharechain_storage.hpp>
 
@@ -93,6 +94,13 @@ protected:
     // Global pool of known transactions, populated by remember_tx and coin daemon.
     // Protocol handlers look up tx hashes here when processing shares.
     std::map<uint256, coin::Transaction> m_known_txs;
+    // Insertion-order recency sidecar for m_known_txs. Recorded at each NEW
+    // remember_tx insert; consumed by prune_shares to evict OLDEST-first down to
+    // m_max_known_txs instead of the old wholesale clear() (which dropped every
+    // forwardable tx byte at once -> canonical "referenced unknown transaction"
+    // disconnect). Tx-forwarding only; no consensus/mint state. See
+    // core::evict_known_txs_to_cap (core/known_txs_eviction.hpp).
+    std::deque<uint256> m_known_txs_order;
 
     // Thread pool for parallel share_init_verify (scrypt CPU work).
     // Keeps expensive crypto off the io_context thread.

--- a/src/impl/dgb/protocol_actual.cpp
+++ b/src/impl/dgb/protocol_actual.cpp
@@ -260,7 +260,10 @@ void Actual::HANDLER(remember_tx)
         peer->m_remembered_txs.insert_or_assign(tx_hash, full_tx);
 
         if (!m_known_txs.contains(tx_hash))
+        {
             m_known_txs.emplace(tx_hash, std::move(full_tx));
+            m_known_txs_order.push_back(tx_hash); // recency for bounded eviction
+        }
     }
 }
 

--- a/src/impl/dgb/protocol_legacy.cpp
+++ b/src/impl/dgb/protocol_legacy.cpp
@@ -296,7 +296,10 @@ void Legacy::HANDLER(remember_tx)
         peer->m_remembered_txs.insert_or_assign(tx_hash, full_tx);
 
         if (!m_known_txs.contains(tx_hash))
+        {
             m_known_txs.emplace(tx_hash, std::move(full_tx));
+            m_known_txs_order.push_back(tx_hash); // recency for bounded eviction
+        }
     }
 }
 

--- a/src/impl/ltc/node.cpp
+++ b/src/impl/ltc/node.cpp
@@ -1413,8 +1413,13 @@ void NodeImpl::prune_shares(const uint256& /*best_share*/)
     // Cache cleanup (kept from original)
     if (m_shared_share_hashes.size() > m_max_shared_hashes)
         m_shared_share_hashes.clear();
+    // Recency-preserving bounded eviction (was: wholesale clear()). Dropping the
+    // whole cache at once destroyed every forwardable tx byte, so a share relay
+    // that referenced a just-dropped tx could no longer remember_tx-forward it
+    // and the canonical peer disconnected with "referenced unknown transaction".
+    // Evict oldest-first down to the cap, keeping the most-recently-learned txs.
     if (m_known_txs.size() > m_max_known_txs)
-        m_known_txs.clear();
+        core::evict_known_txs_to_cap(m_known_txs, m_known_txs_order, m_max_known_txs);
     if (m_raw_share_cache.size() > m_max_raw_shares)
         m_raw_share_cache.clear();
 }

--- a/src/impl/ltc/node.hpp
+++ b/src/impl/ltc/node.hpp
@@ -14,6 +14,7 @@
 #include <pool/protocol.hpp>
 #include <core/message.hpp>
 #include <core/reply_matcher.hpp>
+#include <core/known_txs_eviction.hpp>
 #include <sharechain/prepared_list.hpp>
 #include <c2pool/storage/sharechain_storage.hpp>
 
@@ -55,6 +56,13 @@ protected:
     // Global pool of known transactions, populated by remember_tx and coin daemon.
     // Protocol handlers look up tx hashes here when processing shares.
     std::map<uint256, coin::Transaction> m_known_txs;
+    // Insertion-order recency sidecar for m_known_txs. Recorded at each NEW
+    // remember_tx insert; consumed by prune_shares to evict OLDEST-first down to
+    // m_max_known_txs instead of the old wholesale clear() (which dropped every
+    // forwardable tx byte at once -> canonical "referenced unknown transaction"
+    // disconnect). Tx-forwarding only; no consensus/mint state. See
+    // core::evict_known_txs_to_cap (core/known_txs_eviction.hpp).
+    std::deque<uint256> m_known_txs_order;
 
     // Thread pool for parallel share_init_verify (scrypt CPU work).
     // Keeps expensive crypto off the io_context thread.

--- a/src/impl/ltc/protocol_actual.cpp
+++ b/src/impl/ltc/protocol_actual.cpp
@@ -260,7 +260,10 @@ void Actual::HANDLER(remember_tx)
         peer->m_remembered_txs.insert_or_assign(tx_hash, full_tx);
 
         if (!m_known_txs.contains(tx_hash))
+        {
             m_known_txs.emplace(tx_hash, std::move(full_tx));
+            m_known_txs_order.push_back(tx_hash); // recency for bounded eviction
+        }
     }
 }
 

--- a/src/impl/ltc/protocol_legacy.cpp
+++ b/src/impl/ltc/protocol_legacy.cpp
@@ -296,7 +296,10 @@ void Legacy::HANDLER(remember_tx)
         peer->m_remembered_txs.insert_or_assign(tx_hash, full_tx);
 
         if (!m_known_txs.contains(tx_hash))
+        {
             m_known_txs.emplace(tx_hash, std::move(full_tx));
+            m_known_txs_order.push_back(tx_hash); // recency for bounded eviction
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Ports the #834 tx-forwarding robustness fix to the **LTC / DGB / BCH / BTC** node lanes, adapted to their actual architecture. Reward-neutral: tx-forwarding only, no consensus / subsidy / coinbase / payee change.

## The bug (present in all four coins)

When the node-level known-tx relay cache exceeds its cap, `prune_shares()` did a **wholesale** `clear()`:

```cpp
if (m_known_txs.size() > m_max_known_txs)
    m_known_txs.clear();
```

Dropping the whole cache at once destroys every forwardable tx byte. A subsequent share relay that references a just-dropped tx can then no longer `remember_tx`-forward it, so the receiving canonical peer disconnects with **"referenced unknown transaction"** (p2p.py:404) → sharechain fragmentation / non-convergence. This is the same failure class that broke the DASH hotel repoint; it is latent here and matters because **LTC+DOGE is LIVE**.

## Why this is an *adaptation*, not a literal port of #834

DASH retains **template tx-sets** via `register_template_txs` and the `retain_template_txs` rolling window. The other four coins have **no** `register_template_txs`: their `m_known_txs` is populated **only** by inbound peer `remember_tx` handlers (`protocol_actual.cpp` / `protocol_legacy.cpp`). So the DASH template-window helper has no call site here. What they share is the wholesale-`clear()` bug on the relay cache. (This divergence was flagged first via a code review before implementing.)

## The fix

Replace the wholesale `clear()` with **recency-preserving bounded eviction**:

- A per-node `std::deque<uint256> m_known_txs_order` insertion-order sidecar, pushed at each **new** `remember_tx` insert.
- `prune_shares()` evicts **oldest-first** down to `m_max_known_txs`, keeping the most-recently-learned txs (the ones recent shares are most likely to reference).
- One shared, desync-tolerant helper — `core::evict_known_txs_to_cap` in `src/core/known_txs_eviction.hpp` — backs all four coins (4 consumers → one implementation, DRY). It tolerates a stale order entry already absent from the map (no-op erase) and prunes leading tombstones, so the deque cannot accrete unbounded relative to the live map.

## Per-coin change (identical shape ×4)

For each of ltc / dgb / bch / btc:
- `node.hpp`: `#include <core/known_txs_eviction.hpp>` + `std::deque<uint256> m_known_txs_order;` member.
- `protocol_actual.cpp` + `protocol_legacy.cpp` `remember_tx` handler: record recency (`m_known_txs_order.push_back(tx_hash)`) inside the existing `if (!contains)` new-insert guard.
- `node.cpp` `prune_shares()`: swap `clear()` for `core::evict_known_txs_to_cap(...)`.

## Reward-safety

Tx-forwarding only. The **only** writers of `m_known_txs` in these coins are the `remember_tx` protocol handlers; the **won-block** and **local-mint / block-submit** paths never read or write it, so they are untouched. No consensus, subsidy, coinbase, payee, or dispatch change.

## Tests

KATs for the helper — oldest-first eviction, recency preserved, under-cap no-op, **stale-entry/desync tolerance**, tombstone pruning under cap, and zero-cap empty — folded into the **existing allowlisted `core_test`** target (verified present in `build.yml` `--target`). No new standalone `add_executable` (avoids the "Not Run" allowlist trap). One KAT covers all four coins since they consume one shared core helper.

## Local build + test

- Configured with Conan (linux-gcc13) + DGB module.
- Built and linked cleanly: `core_test`, `c2pool` (LTC), `c2pool-dgb`, `c2pool-bch`, `c2pool-btc` — all EXIT 0, no errors.
- `core_test --gtest_filter=KnownTxsEviction.*` → **5/5 PASSED**.

## Review note

This touches the **LIVE LTC+DOGE relay path** — please review carefully. The behavioral change is confined to the cache-eviction policy (wholesale → recency-bounded); tx forwarding, share packing, and the won-block path are unchanged.
