### PR TITLE
port(coins): wire set_io_context peer-info liveness → DASH/DGB/BCH/BTC (crash-class consistency)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -589,6 +589,20 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
 
         auto* mi = web_server->get_mining_interface();
 
+        // ── Peer-info liveness: serialize the HTTP-cache rebuild onto the
+        // io_context thread (main_ltc.cpp parity). Once the io_context is wired,
+        // thread_safe_wrap serves the WebServer's HTTP thread a published RCU
+        // snapshot (CacheEntry::get) while the periodic refresh below rebuilds
+        // those caches on THIS thread — the same thread that mutates the
+        // peer/tracker containers in think(). That removes the dashboard-thread-
+        // vs-think() read race at its source (the GP-fault crash class),
+        // completing the wiring that mark_last_cache_tip_driven() below and the
+        // already-merged published-snapshot reads (#828/#830) were built for.
+        // Defense-in-depth: the snapshots keep the read safe on any thread; this
+        // keeps the rebuild off the HTTP thread. Threading/liveness only — no
+        // share/consensus/subsidy/payout path is touched.
+        mi->set_io_context(&ioc);
+
         // ── Real, non-negotiable node identity ────────────────────────────
         mi->set_coin_label("DASH");
 
@@ -2794,6 +2808,32 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                          "off); the 3 s poll is the active tip-notify path\n";
 #endif
         }
+    }
+
+    // ── HTTP cache refresh timer (main_ltc.cpp:7343 parity) ──────────────
+    // Every 2 s rebuild all zero-arg dashboard caches on the io_context thread
+    // so the WebServer's HTTP thread reads pre-computed RCU snapshots instead of
+    // racing think() on the live peer/tracker containers. Pairs with the
+    // mi->set_io_context(&ioc) wired at web-server standup; only armed when the
+    // dashboard is enabled (web_port != 0 → web_server present). The initial
+    // populate gives the dashboard data on the first HTTP hit instead of the
+    // CacheEntry default-constructed value. Display/liveness only — touches no
+    // share/consensus/subsidy/payout path.
+    if (web_server) {
+        auto* cache_mi = web_server->get_mining_interface();
+        auto cache_timer = std::make_shared<io::steady_timer>(ioc);
+        auto cache_tick =
+            std::make_shared<std::function<void(const boost::system::error_code&)>>();
+        *cache_tick = [cache_timer, cache_tick, cache_mi](
+                          const boost::system::error_code& ec) {
+            if (ec) return;   // cancelled at shutdown
+            cache_mi->refresh_http_caches();
+            cache_timer->expires_after(std::chrono::seconds(2));
+            cache_timer->async_wait(*cache_tick);
+        };
+        cache_mi->refresh_http_caches();   // initial populate
+        cache_timer->expires_after(std::chrono::seconds(2));
+        cache_timer->async_wait(*cache_tick);
     }
 
     std::cout << "[run] run-loop up (Ctrl-C to stop); won blocks relay DUAL-PATH:\n"


### PR DESCRIPTION
## What

Closes the cross-coin consistency gap in the GP-fault crash-class hardening: bring the coins with a `core::WebServer` dashboard up to `main_ltc.cpp`'s peer-info liveness wiring so the dashboard-read-vs-`think()` race is removed at its source consistently, not just on LTC.

## The real gap (grep was misleading)

A bare grep says `main_dash/dgb/bch/btc` all lack `set_io_context`. But the crash class only exists where a `core::WebServer` + `MiningInterface` HTTP thread serves peer/tracker JSON. On `master`:

| coin | `core::WebServer` | `set_io_context` | verdict |
|------|-------------------|------------------|---------|
| LTC  | yes | **yes** (+2s refresh timer) | already wired — unchanged |
| DASH | yes (6 refs) | **no** | **the real gap — fixed here** |
| DGB  | no (StratumServer only) | no | crash class N/A — nothing to attach to |
| BCH  | no (StratumServer only) | no | crash class N/A |
| BTC  | no (web dashboard is B3+) | no | crash class N/A |

DGB/BCH/BTC construct no `MiningInterface` HTTP dashboard, so there is no HTTP thread reading tracker JSON and no `set_io_context` target — wiring it there would mean inventing a mechanism, so they are deliberately left unchanged.

## The DASH fix

DASH already stands up the same `core::WebServer`/`MiningInterface` dashboard as LTC, registers the same zero-arg `thread_safe_wrap`'d callbacks (`set_peer_info_fn`, `set_sharechain_stats_fn`, `set_pool_hashrate_fn`, …) and already calls `mark_last_cache_tip_driven()` — but never called `set_io_context(&ioc)` and never armed the refresh timer. So `m_context` stayed null and every dashboard read executed the rebuild **inline on the WebServer HTTP thread**, racing `think()`.

Two changes, faithful mirror of LTC, threading/liveness only:

1. `mi->set_io_context(&ioc)` at web-server standup — `thread_safe_wrap` now serves the HTTP thread a published RCU snapshot (`CacheEntry::get`) and routes the rebuild onto the io_context thread.
2. A 2s `steady_timer` (parity with `main_ltc.cpp:7343`) calling `refresh_http_caches()` with an initial populate, so the caches are rebuilt on the same thread that mutates the peer/tracker containers. Only armed when the dashboard is enabled (`web_port != 0`).

## Compose / redundancy judgment

This is **defense-in-depth atop the already-merged published-snapshot reads (#828/#830)**, and composes cleanly:

- The snapshots (#828/#830) are the safe read *primitive* — they keep the read safe on *any* thread (which is why DASH does not currently GP-fault despite `m_context` being null).
- `set_io_context` + the timer are *thread routing* — they move the snapshot rebuild off the HTTP thread onto the io/main thread and serve HTTP a cached snapshot.

No conflict, no double-compute (HTTP no longer computes; it only reads the cache), and it activates the already-present-but-dormant `mark_last_cache_tip_driven()`. The empty-cache-until-first-refresh window is closed by the initial populate, exactly as LTC does.

## Reward-safety

No consensus / subsidy / coinbase / payee / share-validation / mint path is touched — the diff is 40 lines in `main_dash.cpp`, all `io_context`/timer/cache plumbing. LTC's `main` is untouched (it already has the wiring).

## Build / test

- `c2pool-dash` builds green (Release, conan).
- `--selftest` passes: X11 PoW KATs, subsidy `h=2459985 = 177022505`, masternode 3/4 payment — confirming no consensus disturbance.