### PR TITLE
ltc: fix subsidy_func halving off-by-one ((height+1)->height)

### DIFF
--- a/src/impl/ltc/params.hpp
+++ b/src/impl/ltc/params.hpp
@@ -37,7 +37,7 @@ inline core::CoinParams make_coin_params(bool testnet)
 
     // Subsidy: 50 LTC halving every 840,000 blocks
     p.subsidy_func = [](uint32_t height) -> uint64_t {
-        return uint64_t(50) * 100000000ULL >> ((height + 1) / 840000);
+        return uint64_t(50) * 100000000ULL >> (height / 840000);
     };
 
     p.dust_threshold = 100000;  // 0.001 LTC


### PR DESCRIPTION
## What

One-line fix to the LTC `CoinParams.subsidy_func` halving schedule: it halved one block early.

```diff
--- a/src/impl/ltc/params.hpp
+++ b/src/impl/ltc/params.hpp
@@ -37,7 +37,7 @@ inline core::CoinParams make_coin_params(bool testnet)
     // Subsidy: 50 LTC halving every 840,000 blocks
     p.subsidy_func = [](uint32_t height) -> uint64_t {
-        return uint64_t(50) * 100000000ULL >> ((height + 1) / 840000);
+        return uint64_t(50) * 100000000ULL >> (height / 840000);
     };
```

`(height + 1) / 840000` crosses each halving boundary one block early, diverging from Litecoin Core `GetBlockSubsidy` (`nHeight / nSubsidyHalvingInterval`) and from the live `get_block_subsidy` overload (`template_builder.hpp:57`).

## Consensus-neutrality (F-A2)

**Inert today.** There is no live LTC reader of `CoinParams.subsidy_func`. The live LTC coinbase-value path is `template_builder.hpp:222 -> get_block_subsidy(:57 overload)`, which does NOT consult `subsidy_func`. Grep evidence (every *caller* of `.subsidy_func(...)` is DGB or dash, never LTC):

```
$ grep -rn "subsidy_func" src/ include/
src/impl/ltc/params.hpp:39:    p.subsidy_func = [](uint32_t height) -> uint64_t {        # <- definition (this PR)
src/impl/ltc/coin/template_builder.hpp:48:/// Coins without halvings (DOGE, Dash) should use CoinParams.subsidy_func instead.   # comment only
src/impl/dgb/params.hpp:71:    p.subsidy_func = [](uint32_t height) -> uint64_t {        # DGB definition
src/impl/dash/params.hpp:81:    p.subsidy_func = [](uint32_t height) -> uint64_t {       # dash definition
src/c2pool/main_dgb.cpp:274:        header_chain, params.subsidy_func,                   # DGB live caller
src/c2pool/main_dgb.cpp:648:        params.subsidy_func);                                # DGB live caller
src/c2pool/main_dgb.cpp:829:        const uint64_t subsidy = params.subsidy_func             # DGB live caller
src/c2pool/main_ltc.cpp:5421:  ... *dgb_aux_chain, *dgb_aux_pool, dgb_cp.subsidy_func, cfg);   # DGB aux chain params, NOT LTC
src/impl/dgb/stratum/work_source.cpp:154:  ... resolve_coinbase_value(subsidy_func_, height, ...    # DGB live caller
```

The only LTC touch-points are the definition (fixed here) and a doc comment. `main_ltc.cpp:5421` passes `dgb_cp.subsidy_func` — the DGB aux-chain params, not LTC.

Because nothing on the LTC path reads this today, the change cannot invalidate old tips (pre-v36 vardiff/consensus-neutrality rule satisfied).

**Inert today; goes live only if LTC migrates onto the CoinParams SSOT (V37)** — as DGB already has via `CoinParams::subsidy`. This is a latent V37-standardization trap, corrected now while it is harmless.

## Notes

- Single commit, GPG-signed, no third-party attribution trailers.
- Held for merge-tap; integrator surfaces the merge card once CI is green.
