### PR TITLE
qt: coin-generic control panel (add DASH/DGB/BCH) + reward-safe launch defaults

### DIFF
--- a/ui/c2pool-qt/CMakeLists.txt
+++ b/ui/c2pool-qt/CMakeLists.txt
@@ -150,4 +150,17 @@ if(C2POOL_QT_BUILD_TESTS)
         target_compile_definitions(c2pool-qt_test_embedded_leak PRIVATE
             C2POOL_QT_DEV_BUNDLE=1)
     endif()
+
+    # ── ★ Reward-safety gate ─────────────────────────────────────────────
+    # Proves the per-coin launch command core never emits the reward-UNSAFE
+    # embedded arm (--coin-p2p-connect / --embedded-mainnet) by default and
+    # that the default parent-daemon link is the reward-SAFE --coin-rpc arm.
+    # Qt-free (LaunchCommand.hpp is std-only) so it runs anywhere.
+    enable_testing()
+    add_executable(c2pool-qt_test_reward_safe_launch
+        test/test_reward_safe_launch.cpp
+    )
+    target_include_directories(c2pool-qt_test_reward_safe_launch PRIVATE src)
+    add_test(NAME reward_safe_launch
+             COMMAND c2pool-qt_test_reward_safe_launch)
 endif()

--- a/ui/c2pool-qt/README.md
+++ b/ui/c2pool-qt/README.md
@@ -1,8 +1,10 @@
-# c2pool Qt Control Panel (MVP Scaffold)
+# c2pool Qt Control Panel
 
-This is the initial mining-first MVP scaffold for the desktop control panel.
+Desktop control panel for c2pool. First-pass toward full finalization —
+the qt-steward owns deeper controls; this cut makes the launcher
+coin-generic and reward-safe.
 
-Implemented in this first cut:
+Implemented:
 
 - Qt Widgets app shell
 - Sidebar navigation
@@ -11,18 +13,61 @@ Implemented in this first cut:
 - Logs page
 - Basic node/miner monitoring refresh loop
 - Log export action (calls /logs/export endpoint)
+- **Coin-generic launch** (profile-driven, `src/CoinProfiles.hpp`):
+  litecoin, bitcoin, dogecoin, dash, digibyte, bitcoincash
+- **Reward-safe launch defaults** (see below)
+
+## Coins & launch CLIs
+
+c2pool ships two launch CLIs; the chain profile records which one each coin
+uses, plus its binary, daemon, algo and default RPC ports:
+
+| Coin | Binary | Daemon | Algo | Launch CLI |
+|------|--------|--------|------|------------|
+| litecoin | `c2pool` | litecoind | Scrypt | unified `--net litecoin` |
+| bitcoin | `c2pool` | bitcoind | SHA-256d | unified `--net bitcoin` |
+| dogecoin | `c2pool` | dogecoind | Scrypt (AuxPoW) | unified `--net dogecoin` |
+| dash | `c2pool-dash` | dashd | X11 | per-coin `--run` (masternode-payee) |
+| digibyte | `c2pool-dgb` | digibyted | Scrypt | per-coin `--run` (experimental) |
+| bitcoincash | `c2pool-bch` | bitcoind (BCHN) | SHA-256d | per-coin `--pool` (experimental) |
+
+Adding a coin is a row in `CoinProfiles.hpp`, not a scattered code edit —
+mirroring the coin-generic web dashboard/explorer.
+
+## ★ Reward safety
+
+The default per-coin launch profile is the reward-SAFE dashd-RPC arm
+(`--coin-rpc HOST:PORT` + `--coin-rpc-auth PATH`; the rpcpassword is read
+from the coin's .conf and never placed on argv). The embedded coin-network
+arm (`--coin-p2p-connect` / `--embedded-mainnet`) is reward-UNSAFE until
+validated and is **default OFF** — it is emitted only from the explicit
+"Advanced / embedded (opt-in — REWARD-UNSAFE)" controls. See the DASH hotel
+incident that motivated this gate.
+
+The invariant is unit-tested Qt-free in `test/test_reward_safe_launch.cpp`
+(the default DASH command omits both flags); build tests with
+`-DC2POOL_QT_BUILD_TESTS=ON` and run via `ctest`.
+
+## TODO (qt-steward)
+
+- Deeper per-coin controls for the DGB/BCH run-loops (ZMQ, anchors,
+  sharechain isolation, etc.)
+- Address-flavour validation per coin
+- Wiring the per-coin binaries' full flag surface
 
 ## Build
 
 ```bash
-cmake -S ui/qt-control-panel -B build-qt-mvp
-cmake --build build-qt-mvp -j4
+cmake -S ui/c2pool-qt -B build-qt
+cmake --build build-qt -j4
 ```
+
+Requires Qt6 (Widgets, Network, WebEngineCore/Widgets, WebChannel).
 
 ## Run
 
 ```bash
-./build-qt-mvp/c2pool-qt-control-panel
+./build-qt/c2pool-qt
 ```
 
 Default API base URL in the app:
@@ -38,5 +83,6 @@ Use the top bar to change base URL and refresh pages.
 
 ## Current status
 
-This is a functional skeleton meant to start MVP implementation quickly.
-Data mapping, UI polish, and deeper controls will be implemented incrementally.
+First-pass finalization: coin-generic + reward-safe launch land here; data
+mapping, UI polish, and deeper per-coin controls continue incrementally
+(qt-steward).

--- a/ui/c2pool-qt/src/CoinProfiles.hpp
+++ b/ui/c2pool-qt/src/CoinProfiles.hpp
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// CoinProfiles — single source of truth for the launch page's per-coin
+// knowledge. Keeps c2pool-qt coin-generic (profile-driven) rather than
+// hard-coding LTC/BTC/DOGE assumptions in PageLaunch.
+//
+// c2pool ships TWO distinct launch CLIs and this table records which one
+// each coin uses, plus the binary name, daemon label, algo and default
+// RPC ports so the launch form and the generated command line stay
+// correct across coins:
+//
+//   • CliFamily::LegacyUnified — the unified `c2pool` binary
+//     (src/c2pool/main_ltc.cpp) that selects the chain with `--net
+//     litecoin|bitcoin|dogecoin|digibyte` and uses the Python-p2pool-
+//     compatible flags (--p2pool-port / -w / --web-port /
+//     --coind-address / --coind-rpc-port / --rpcuser / --rpcpassword).
+//     Used for litecoin, bitcoin and dogecoin here.
+//
+//   • CliFamily::PerCoinRun — the dedicated per-coin binaries
+//     (c2pool-dash / c2pool-dgb / c2pool-bch) whose run-loop is stood up
+//     with a subcommand (`--run` or `--pool`) and whose parent-daemon
+//     link is the reward-SAFE RPC arm: `--coin-rpc HOST:PORT` +
+//     `--coin-rpc-auth PATH` (or `--rpc-conf PATH` for BCHN). The
+//     rpcpassword NEVER touches argv — it is read from the coin's .conf.
+//
+// ★ REWARD SAFETY: the embedded coin-network arm (`--coin-p2p-connect`
+//   and `--embedded-mainnet`) is reward-UNSAFE until validated and is
+//   NEVER emitted by default. PageLaunch only emits it from an explicit,
+//   default-OFF "Advanced / embedded (opt-in, reward-unsafe)" control.
+//   See the DASH hotel incident: an unguarded embedded arm produced
+//   reward-unsafe blocks. The default per-coin launch is the dashd-RPC
+//   arm.
+//
+// This header mirrors the coin-generic, profile-driven approach the web
+// dashboard/explorer already use (see CoinBridge's descriptor table):
+// adding a coin is a table row, not a code edit scattered across the UI.
+
+#pragma once
+
+#include <QLatin1String>
+#include <QString>
+
+namespace c2pool_qt {
+
+enum class CliFamily {
+    LegacyUnified,  ///< unified `c2pool` binary, chain via --net
+    PerCoinRun,     ///< dedicated per-coin binary, run-loop subcommand
+};
+
+/// Per-coin launch profile. One row per supported chain; PageLaunch reads
+/// everything it needs to build a correct, reward-safe command line from
+/// this struct instead of branching on the chain string ad hoc.
+struct CoinProfile {
+    QString symbol;         ///< canonical chain id (matches --net value / CoinBridge)
+    QString displayLabel;   ///< human label for combos/groups
+    QString binary;         ///< default binary path (e.g. "c2pool", "c2pool-dash")
+    QString daemonLabel;    ///< parent daemon name (litecoind / dashd / …)
+    QString algoLabel;      ///< PoW algo, for display
+    QString addressFlavor;  ///< short payout-address hint for the form
+
+    CliFamily cli;          ///< which launch CLI family this coin uses
+    QString   subcommand;   ///< PerCoinRun run-loop subcommand ("--run"/"--pool"); empty for legacy
+
+    // Parent-daemon RPC link (PerCoinRun). For LegacyUnified these are the
+    // --coind-rpc-port defaults; PageLaunch maps them to the right flag.
+    int rpcPortMainnet;
+    int rpcPortTestnet;
+
+    // PerCoinRun flag vocabulary — recorded per coin so PageLaunch never
+    // emits a flag the target binary does not accept.
+    QString coinRpcFlag;        ///< endpoint override flag ("--coin-rpc"); empty if unsupported (BCH)
+    QString rpcAuthFlag;        ///< creds-file flag ("--coin-rpc-auth" / "--rpc-conf")
+    QString confHint;           ///< placeholder path for the creds file
+    QString sharechainPortFlag; ///< sharechain P2P listen flag ("--listen"/"--sharechain-port"/"--p2p-port"); empty if none
+    bool supportsTestnetFlag;   ///< binary accepts --testnet
+    bool supportsWebPort;       ///< binary accepts --web-port / --http-port
+
+    // Suggested miner-facing / dashboard ports for PerCoinRun coins.
+    int stratumPortDefault;
+    int webPortDefault;
+
+    bool masternodePayee;   ///< coin pays a masternode/founder split (DASH) — surfaced as a note
+    bool experimental;      ///< PerCoinRun binary still stabilising (DGB/BCH) — surfaced as a note
+};
+
+/// Ordered profile table. Order drives the chain combo. DASH is first-class.
+inline const CoinProfile* coinProfiles(int& countOut)
+{
+    static const CoinProfile kProfiles[] = {
+        // ── LegacyUnified: unified `c2pool` binary, chain via --net ──────────
+        {"litecoin", "Litecoin", "c2pool", "litecoind", "Scrypt",
+         "L… / M… (P2PKH/P2SH)",
+         CliFamily::LegacyUnified, "",
+         9332, 19332,
+         "", "", "", "", false, true,
+         0, 0, false, false},
+        {"bitcoin", "Bitcoin", "c2pool", "bitcoind", "SHA-256d",
+         "1… / bc1… (P2PKH/bech32)",
+         CliFamily::LegacyUnified, "",
+         8332, 18332,
+         "", "", "", "", false, true,
+         0, 0, false, false},
+        {"dogecoin", "Dogecoin", "c2pool", "dogecoind", "Scrypt (AuxPoW)",
+         "D… (P2PKH)",
+         CliFamily::LegacyUnified, "",
+         22555, 44555,
+         "", "", "", "", false, true,
+         0, 0, false, false},
+
+        // ── PerCoinRun: dedicated per-coin binaries ──────────────────────────
+        // DASH — X11, masternode-payee coin, dashd parent. Default launch is
+        // the reward-SAFE dashd-RPC arm; embedded P2P is opt-in only.
+        {"dash", "Dash", "c2pool-dash", "dashd", "X11",
+         "X… / 7… (P2PKH/P2SH)",
+         CliFamily::PerCoinRun, "--run",
+         9998, 19998,
+         "--coin-rpc", "--coin-rpc-auth", "~/.dashcore/dash.conf",
+         "--listen", /*testnet*/ true, /*webPort*/ true,
+         3333, 8080, /*masternode*/ true, /*experimental*/ false},
+
+        // DigiByte — multi-algo (Scrypt here), digibyted parent. No --testnet
+        // flag (mainnet/regtest only) and no --web-port on this binary.
+        {"digibyte", "DigiByte", "c2pool-dgb", "digibyted", "Scrypt",
+         "D… / S… (P2PKH/P2SH)",
+         CliFamily::PerCoinRun, "--run",
+         14024, 14025,
+         "--coin-rpc", "--coin-rpc-auth", "~/.digibyte/digibyte.conf",
+         "--sharechain-port", /*testnet*/ false, /*webPort*/ false,
+         5022, 0, /*masternode*/ false, /*experimental*/ true},
+
+        // Bitcoin Cash — BCHN parent. Uses `--pool`, creds via --rpc-conf
+        // (no --coin-rpc endpoint override), --p2p-port for the sharechain.
+        {"bitcoincash", "Bitcoin Cash", "c2pool-bch", "bitcoind (BCHN)", "SHA-256d",
+         "1… / q… (legacy/cashaddr)",
+         CliFamily::PerCoinRun, "--pool",
+         8332, 18332,
+         "", "--rpc-conf", "~/.bitcoin/bitcoin.conf",
+         "--p2p-port", /*testnet*/ true, /*webPort*/ false,
+         3333, 0, /*masternode*/ false, /*experimental*/ true},
+    };
+    countOut = static_cast<int>(sizeof(kProfiles) / sizeof(kProfiles[0]));
+    return kProfiles;
+}
+
+/// Look up a profile by chain symbol; returns litecoin (index 0) for an
+/// unknown symbol so callers always get a usable profile.
+inline const CoinProfile& coinProfile(const QString& symbol)
+{
+    int n = 0;
+    const CoinProfile* p = coinProfiles(n);
+    for (int i = 0; i < n; ++i) {
+        if (symbol == p[i].symbol) return p[i];
+    }
+    return p[0];
+}
+
+} // namespace c2pool_qt

--- a/ui/c2pool-qt/src/LaunchCommand.hpp
+++ b/ui/c2pool-qt/src/LaunchCommand.hpp
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// LaunchCommand — Qt-free core that assembles the per-coin (PerCoinRun)
+// c2pool command line from plain parameters.
+//
+// Kept deliberately independent of Qt (std::string / std::vector only) so
+// the ★ reward-safety invariant can be unit-tested WITHOUT a display,
+// QApplication, or the widget stack:
+//
+//   With the embedded opt-ins OFF (their default), the generated argv for
+//   ANY coin NEVER contains --coin-p2p-connect or --embedded-mainnet, and
+//   the default parent-daemon link is the reward-SAFE --coin-rpc arm.
+//
+// PageLaunch fills PerCoinParams from the form + the active CoinProfile and
+// calls build_percoin_argv(); this file is where the ordering and the
+// embedded-arm gating actually live. See test/test_reward_safe_launch.cpp.
+
+#pragma once
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+namespace c2pool_qt {
+
+struct PerCoinParams {
+    std::string binary;       ///< e.g. "./build/bin/c2pool-dash"
+    std::string subcommand;   ///< "--run" / "--pool" / ""
+
+    std::string dataDir;      ///< --data-dir PATH (empty ⇒ omit)
+
+    bool testnet = false;
+    bool supportsTestnetFlag = false;  ///< binary accepts --testnet
+
+    // Reward-SAFE parent-daemon RPC arm.
+    std::string coinRpcFlag;  ///< "--coin-rpc" (empty ⇒ binary has no endpoint override, e.g. BCH)
+    std::string rpcHost;
+    int         rpcPort = 0;
+    std::string rpcAuthFlag;  ///< "--coin-rpc-auth" / "--rpc-conf"
+    std::string confPath;     ///< creds file PATH (rpcpassword stays off argv)
+
+    int stratumPort = 0;      ///< --stratum PORT (0 ⇒ omit / disabled)
+
+    bool        supportsWebPort = false;
+    int         webPort = 0;  ///< --web-port PORT
+    std::string webHost;      ///< --web-host ADDR (omit when default 0.0.0.0)
+
+    std::string              sharechainPortFlag; ///< "--listen"/"--sharechain-port"/"--p2p-port"
+    int                      sharechainPort = 0;
+    std::vector<std::string> addnodes;           ///< --addnode HOST:PORT (repeatable)
+
+    // Payout / fee / donation.
+    std::string payoutAddress;    ///< --node-owner-address ADDR
+    double      fee = 0.0;        ///< -f PCT
+    double      giveAuthor = 0.0; ///< --give-author PCT
+    std::string redistribute;     ///< --redistribute MODE (omit when "pplns")
+
+    std::string messageBlob;      ///< --message-blob-hex HEX
+
+    // ── ★ Embedded reward-UNSAFE arm — OPT-IN, default OFF ────────────────
+    bool                     embeddedP2p = false;      ///< gate for --coin-p2p-connect
+    std::vector<std::string> embeddedP2pPeers;         ///< HOST:PORT peers
+    bool                     embeddedMainnet = false;  ///< --embedded-mainnet (DASH)
+};
+
+/// Assemble the argv (binary first). The embedded reward-UNSAFE flags are
+/// appended ONLY when their opt-in bools are true — this is the single
+/// choke point that enforces the reward-safe default.
+inline std::vector<std::string> build_percoin_argv(const PerCoinParams& p)
+{
+    std::vector<std::string> a;
+    auto trimmed = [](const std::string& s) {
+        const auto b = s.find_first_not_of(" \t\r\n");
+        if (b == std::string::npos) return std::string();
+        const auto e = s.find_last_not_of(" \t\r\n");
+        return s.substr(b, e - b + 1);
+    };
+    auto fmtPct = [](double v) {
+        char buf[32];
+        std::snprintf(buf, sizeof(buf), "%.2f", v);
+        return std::string(buf);
+    };
+
+    a.push_back(trimmed(p.binary));
+    if (!p.subcommand.empty()) a.push_back(p.subcommand);
+
+    if (!trimmed(p.dataDir).empty()) { a.push_back("--data-dir"); a.push_back(trimmed(p.dataDir)); }
+
+    if (p.testnet && p.supportsTestnetFlag) a.push_back("--testnet");
+
+    // Reward-SAFE RPC arm (endpoint carries no secret; creds via conf file).
+    if (!p.coinRpcFlag.empty() && !trimmed(p.rpcHost).empty() && p.rpcPort > 0) {
+        a.push_back(p.coinRpcFlag);
+        a.push_back(trimmed(p.rpcHost) + ":" + std::to_string(p.rpcPort));
+    }
+    if (!p.rpcAuthFlag.empty() && !trimmed(p.confPath).empty()) {
+        a.push_back(p.rpcAuthFlag);
+        a.push_back(trimmed(p.confPath));
+    }
+
+    if (p.stratumPort > 0) { a.push_back("--stratum"); a.push_back(std::to_string(p.stratumPort)); }
+
+    if (p.supportsWebPort && p.webPort > 0) {
+        a.push_back("--web-port");
+        a.push_back(std::to_string(p.webPort));
+        const std::string wh = trimmed(p.webHost);
+        if (!wh.empty() && wh != "0.0.0.0") { a.push_back("--web-host"); a.push_back(wh); }
+    }
+
+    if (!p.sharechainPortFlag.empty() && p.sharechainPort > 0) {
+        a.push_back(p.sharechainPortFlag);
+        a.push_back(std::to_string(p.sharechainPort));
+    }
+    for (const auto& n : p.addnodes) {
+        const std::string t = trimmed(n);
+        if (!t.empty()) { a.push_back("--addnode"); a.push_back(t); }
+    }
+
+    if (!trimmed(p.payoutAddress).empty()) {
+        a.push_back("--node-owner-address");
+        a.push_back(trimmed(p.payoutAddress));
+    }
+    if (p.fee > 0.0)        { a.push_back("-f"); a.push_back(fmtPct(p.fee)); }
+    if (p.giveAuthor > 0.0) { a.push_back("--give-author"); a.push_back(fmtPct(p.giveAuthor)); }
+    if (!p.redistribute.empty() && p.redistribute != "pplns") {
+        a.push_back("--redistribute");
+        a.push_back(p.redistribute);
+    }
+    if (!trimmed(p.messageBlob).empty()) {
+        a.push_back("--message-blob-hex");
+        a.push_back(trimmed(p.messageBlob));
+    }
+
+    // ── ★ Embedded reward-UNSAFE arm — appended ONLY when opted in ────────
+    if (p.embeddedP2p) {
+        for (const auto& peer : p.embeddedP2pPeers) {
+            const std::string t = trimmed(peer);
+            if (!t.empty()) { a.push_back("--coin-p2p-connect"); a.push_back(t); }
+        }
+    }
+    if (p.embeddedMainnet) a.push_back("--embedded-mainnet");
+
+    return a;
+}
+
+/// Join an argv into a single shell-preview string (space-separated).
+inline std::string join_argv(const std::vector<std::string>& a)
+{
+    std::string out;
+    for (std::size_t i = 0; i < a.size(); ++i) {
+        if (i) out += ' ';
+        out += a[i];
+    }
+    return out;
+}
+
+} // namespace c2pool_qt

--- a/ui/c2pool-qt/src/PageLaunch.cpp
+++ b/ui/c2pool-qt/src/PageLaunch.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 #include "PageLaunch.hpp"
 
+#include "CoinProfiles.hpp"
+#include "LaunchCommand.hpp"
 #include "SettingsStore.hpp"
 
 #include <QDir>
@@ -16,6 +18,10 @@
 
 namespace {
 
+using c2pool_qt::CliFamily;
+using c2pool_qt::CoinProfile;
+using c2pool_qt::coinProfile;
+
 struct PortDefaults {
     int p2p;
     int stratum;
@@ -25,11 +31,24 @@ struct PortDefaults {
 
 PortDefaults defaultsForNetwork(const QString& chain, bool testnet)
 {
+    const CoinProfile& p = coinProfile(chain);
+    const int rpc = testnet ? p.rpcPortTestnet : p.rpcPortMainnet;
+
+    // PerCoinRun coins (c2pool-dash / -dgb / -bch) use the profile's
+    // miner-facing / dashboard port suggestions; the "p2p sharechain"
+    // spin doubles as the sharechain listen port.
+    if (p.cli == CliFamily::PerCoinRun) {
+        const int stratum = p.stratumPortDefault;
+        const int http = p.supportsWebPort ? p.webPortDefault : 0;
+        const int listen = testnet ? 19339 : 9339;  // sharechain listen suggestion
+        return {listen, stratum, http, rpc};
+    }
+
+    // LegacyUnified coins keep the Python-p2pool-compatible port layout.
     if (chain == "bitcoin") {
         const int p2p = testnet ? 19333 : 9333;
         const int stratum = testnet ? 19332 : 9332;
         const int http = (stratum + 1 == p2p) ? stratum + 2 : stratum + 1;
-        const int rpc = testnet ? 18332 : 8332;
         return {p2p, stratum, http, rpc};
     }
 
@@ -37,14 +56,12 @@ PortDefaults defaultsForNetwork(const QString& chain, bool testnet)
         const int p2p = testnet ? 44556 : 22556;
         const int stratum = testnet ? 44555 : 22555;
         const int http = stratum + 2;
-        const int rpc = testnet ? 44555 : 22555;
         return {p2p, stratum, http, rpc};
     }
 
     const int p2p = testnet ? 19338 : 9338;
     const int stratum = testnet ? 19327 : 9327;
     const int http = stratum + 1;
-    const int rpc = testnet ? 19332 : 9332;
     return {p2p, stratum, http, rpc};
 }
 
@@ -133,11 +150,25 @@ void PageLaunch::setupUi()
         form->addRow("Mode:", modeCombo_);
 
         chainCombo_ = new QComboBox;
-        chainCombo_->addItems({"litecoin", "bitcoin", "dogecoin"});
+        {
+            int n = 0;
+            const c2pool_qt::CoinProfile* profs = c2pool_qt::coinProfiles(n);
+            for (int i = 0; i < n; ++i)
+                chainCombo_->addItem(profs[i].displayLabel, profs[i].symbol);
+        }
+        chainCombo_->setToolTip(
+            "Coin-generic (profile-driven). LTC/BTC/DOGE use the unified\n"
+            "`c2pool --net …` binary; DASH/DGB/BCH use the dedicated per-coin\n"
+            "binary with the reward-safe --coin-rpc arm.");
         form->addRow("Blockchain:", chainCombo_);
 
         testnetCheck_ = new QCheckBox("Use testnet");
         form->addRow("Network:", testnetCheck_);
+
+        coinNoteLabel_ = new QLabel;
+        coinNoteLabel_->setWordWrap(true);
+        coinNoteLabel_->setStyleSheet("color: #555; font-size: 11px;");
+        form->addRow("", coinNoteLabel_);
 
         vbox->addWidget(g);
     }
@@ -182,11 +213,14 @@ void PageLaunch::setupUi()
 
     // ── 4. Parent Coin Daemon ─────────────────────────────────────────────────
     {
-        auto* g = makeGroup("Parent Coin Daemon (litecoind / bitcoind)");
+        auto* g = makeGroup("Parent Coin Daemon");
+        coindGroup_ = g;
         auto* form = new QFormLayout(g);
 
         coindHostEdit_ = new QLineEdit("127.0.0.1");
-        coindHostEdit_->setToolTip("--coind-address / --rpchost");
+        coindHostEdit_->setToolTip(
+            "Legacy (LTC/BTC/DOGE): --coind-address / --rpchost\n"
+            "Per-coin (DASH/DGB): host of --coin-rpc HOST:PORT");
         form->addRow("RPC host:", coindHostEdit_);
 
         coindPortSpin_ = new QSpinBox;
@@ -219,6 +253,22 @@ void PageLaunch::setupUi()
         coindP2pAddrEdit_->setToolTip("--coind-p2p-address  (defaults to RPC host)");
         form->addRow("P2P address:", coindP2pAddrEdit_);
 
+        // Per-coin binaries (DASH/DGB/BCH) read rpcuser/rpcpassword from the
+        // coin's .conf so the password NEVER lands on argv. Blank ⇒ default
+        // conf path for that coin.
+        rpcConfPathEdit_ = new QLineEdit;
+        rpcConfPathEdit_->setToolTip(
+            "--coin-rpc-auth / --rpc-conf PATH\n"
+            "bitcoin.conf-style file carrying rpcuser/rpcpassword. The\n"
+            "password is read from here, never placed on the command line.\n"
+            "Blank ⇒ the binary's default conf path.");
+        form->addRow("RPC conf file:", rpcConfPathEdit_);
+
+        dataDirEdit_ = new QLineEdit;
+        dataDirEdit_->setPlaceholderText("~/.c2pool (default)");
+        dataDirEdit_->setToolTip("--data-dir PATH  (per-instance state root; isolates co-located instances)");
+        form->addRow("Data dir:", dataDirEdit_);
+
         vbox->addWidget(g);
     }
 
@@ -228,7 +278,7 @@ void PageLaunch::setupUi()
         auto* form = new QFormLayout(g);
 
         addressEdit_ = new QLineEdit;
-        addressEdit_->setPlaceholderText("LTC/BTC/DOGE payout address");
+        addressEdit_->setPlaceholderText("payout address for the selected coin");
         addressEdit_->setToolTip("--address / --solo-address  (YOUR mining payout address)");
         form->addRow("Payout address:", addressEdit_);
 
@@ -441,6 +491,68 @@ void PageLaunch::setupUi()
         vbox->addWidget(g);
     }
 
+    // ── 10. ★ Advanced / embedded (opt-in, REWARD-UNSAFE) ────────────────────
+    // Default OFF. This is the ONLY place --coin-p2p-connect /
+    // --embedded-mainnet may be emitted. The default per-coin launch is the
+    // reward-SAFE dashd-RPC arm. See the DASH hotel incident: an unguarded
+    // embedded arm produced reward-unsafe blocks.
+    {
+        auto* g = makeGroup("Advanced / embedded (opt-in — REWARD-UNSAFE)");
+        embeddedGroup_ = g;
+        g->setStyleSheet(
+            "QGroupBox { font-weight: bold; margin-top: 6px; "
+            "  border: 1px solid #b04020; border-radius: 4px; }"
+            "QGroupBox::title { subcontrol-origin: margin; left: 8px; color: #b04020; }");
+        auto* gLayout = new QVBoxLayout(g);
+
+        embeddedWarnLabel_ = new QLabel(
+            "⚠ These options dial the coin's own P2P network directly and/or "
+            "let this node produce mainnet blocks WITHOUT the validated dashd-RPC "
+            "arm. They are REWARD-UNSAFE until validated for your coin and MUST "
+            "stay OFF for normal mining. Leave everything here unchecked to run "
+            "the safe RPC arm.");
+        embeddedWarnLabel_->setWordWrap(true);
+        embeddedWarnLabel_->setStyleSheet("color: #b04020;");
+        gLayout->addWidget(embeddedWarnLabel_);
+
+        embeddedP2pCheck_ = new QCheckBox(
+            "Enable embedded coin-network P2P (--coin-p2p-connect) — reward-unsafe");
+        embeddedP2pCheck_->setChecked(false);   // ★ default OFF
+        embeddedP2pCheck_->setToolTip(
+            "--coin-p2p-connect HOST:PORT (repeatable)\n"
+            "OPT-IN. Dials the coin network directly instead of relying only on\n"
+            "the dashd-RPC submitblock arm. Default OFF — leave unchecked unless\n"
+            "you are deliberately validating the embedded arm.");
+        gLayout->addWidget(embeddedP2pCheck_);
+
+        embeddedP2pPeersEdit_ = new QPlainTextEdit;
+        embeddedP2pPeersEdit_->setMaximumHeight(60);
+        embeddedP2pPeersEdit_->setEnabled(false);
+        embeddedP2pPeersEdit_->setPlaceholderText(
+            "One coin-P2P HOST:PORT per line (e.g. 127.0.0.1:9999)");
+        gLayout->addWidget(embeddedP2pPeersEdit_);
+
+        embeddedMainnetCheck_ = new QCheckBox(
+            "Enable embedded MAINNET block production (--embedded-mainnet) — reward-unsafe");
+        embeddedMainnetCheck_->setChecked(false);   // ★ default OFF
+        embeddedMainnetCheck_->setToolTip(
+            "--embedded-mainnet (DASH)\n"
+            "Lifts the gate that keeps embedded mainnet block production OFF.\n"
+            "Reward-unsafe until validated. Default OFF.");
+        gLayout->addWidget(embeddedMainnetCheck_);
+
+        connect(embeddedP2pCheck_, &QCheckBox::stateChanged, this, [this](int st) {
+            embeddedP2pPeersEdit_->setEnabled(st == Qt::Checked);
+            onBuildPreview();
+        });
+        connect(embeddedMainnetCheck_, &QCheckBox::stateChanged, this,
+                [this](int) { onBuildPreview(); });
+        connect(embeddedP2pPeersEdit_, &QPlainTextEdit::textChanged, this,
+                [this]() { onBuildPreview(); });
+
+        vbox->addWidget(g);
+    }
+
     // ── 8. Command preview + controls ────────────────────────────────────────
     {
         auto* g = makeGroup("Generated Command");
@@ -486,7 +598,25 @@ void PageLaunch::setupUi()
 // Command builder
 // ─────────────────────────────────────────────────────────────────────────────
 
+QString PageLaunch::currentChain() const
+{
+    const QString data = chainCombo_->currentData().toString();
+    return data.isEmpty() ? chainCombo_->currentText() : data;
+}
+
 QString PageLaunch::buildCommand() const
+{
+    // Dispatch on the coin's CLI family. LTC/BTC/DOGE use the unified
+    // `c2pool --net …` binary; DASH/DGB/BCH use the dedicated per-coin
+    // binary with the reward-SAFE --coin-rpc arm.
+    const QString chain = currentChain();
+    const c2pool_qt::CoinProfile& prof = c2pool_qt::coinProfile(chain);
+    return prof.cli == c2pool_qt::CliFamily::PerCoinRun
+               ? buildPerCoinCommand()
+               : buildLegacyCommand();
+}
+
+QString PageLaunch::buildLegacyCommand() const
 {
     QStringList parts;
 
@@ -501,7 +631,7 @@ QString PageLaunch::buildCommand() const
 
     // Network
     if (testnetCheck_->isChecked()) parts << "--testnet";
-    const QString chain = chainCombo_->currentText();
+    const QString chain = currentChain();
     if (chain != "litecoin") parts << "--net" << chain;
 
     // Ports
@@ -617,6 +747,70 @@ QString PageLaunch::buildCommand() const
     return parts.join(" ");
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Per-coin run-loop command (c2pool-dash / -dgb / -bch)
+//
+// ★ REWARD SAFETY: builds the dashd-RPC arm by default —
+//   `<binary> <subcommand> [--testnet] --coin-rpc HOST:PORT
+//    [--coin-rpc-auth PATH] [--stratum PORT] [--web-port PORT]
+//    [--data-dir PATH] …`. The embedded reward-UNSAFE flags
+//   (--coin-p2p-connect / --embedded-mainnet) are appended ONLY when the
+//   explicit, default-OFF "Advanced / embedded (opt-in)" controls are
+//   checked. With those unchecked the generated command NEVER contains
+//   them — proven by the reward-safe launch test.
+// ─────────────────────────────────────────────────────────────────────────────
+QString PageLaunch::buildPerCoinCommand() const
+{
+    const QString chain = currentChain();
+    const c2pool_qt::CoinProfile& prof = c2pool_qt::coinProfile(chain);
+
+    // Marshal form + profile state into the Qt-free command core. The
+    // reward-safety invariant (embedded flags gated behind default-OFF
+    // opt-ins) lives in build_percoin_argv() and is unit-tested there.
+    c2pool_qt::PerCoinParams pp;
+    pp.binary     = binaryEdit_->text().trimmed().toStdString();
+    pp.subcommand = prof.subcommand.toStdString();
+    if (dataDirEdit_) pp.dataDir = dataDirEdit_->text().trimmed().toStdString();
+
+    pp.testnet             = testnetCheck_->isChecked();
+    pp.supportsTestnetFlag = prof.supportsTestnetFlag;
+
+    pp.coinRpcFlag = prof.coinRpcFlag.toStdString();
+    pp.rpcHost     = coindHostEdit_->text().trimmed().toStdString();
+    pp.rpcPort     = coindPortSpin_->value();
+    pp.rpcAuthFlag = prof.rpcAuthFlag.toStdString();
+    if (rpcConfPathEdit_) pp.confPath = rpcConfPathEdit_->text().trimmed().toStdString();
+
+    pp.stratumPort = stratumPortSpin_->value();
+
+    pp.supportsWebPort = prof.supportsWebPort;
+    pp.webPort         = httpPortSpin_->value();
+    pp.webHost         = httpHostEdit_->text().trimmed().toStdString();
+
+    pp.sharechainPortFlag = prof.sharechainPortFlag.toStdString();
+    pp.sharechainPort     = p2pPortSpin_->value();
+    for (const QString& line : seedNodesEdit_->toPlainText().split('\n', Qt::SkipEmptyParts))
+        pp.addnodes.push_back(line.trimmed().toStdString());
+
+    pp.payoutAddress = addressEdit_->text().trimmed().toStdString();
+    pp.fee           = feeSpinBox_->value();
+    pp.giveAuthor    = giveAuthorSpinBox_->value();
+    pp.redistribute  = redistributeCombo_->currentText().toStdString();
+    pp.messageBlob   = messageBlobEdit_->text().trimmed().toStdString();
+
+    // ── ★ Embedded reward-UNSAFE arm — OPT-IN ONLY (default OFF) ──────────
+    pp.embeddedP2p = embeddedP2pCheck_ && embeddedP2pCheck_->isChecked();
+    if (pp.embeddedP2p && embeddedP2pPeersEdit_) {
+        for (const QString& line :
+             embeddedP2pPeersEdit_->toPlainText().split('\n', Qt::SkipEmptyParts))
+            pp.embeddedP2pPeers.push_back(line.trimmed().toStdString());
+    }
+    pp.embeddedMainnet = embeddedMainnetCheck_ && embeddedMainnetCheck_->isChecked();
+
+    return QString::fromStdString(
+        c2pool_qt::join_argv(c2pool_qt::build_percoin_argv(pp)));
+}
+
 QString PageLaunch::suggestedApiBaseUrl() const
 {
     return QString("http://127.0.0.1:%1").arg(httpPortSpin_->value());
@@ -633,14 +827,76 @@ void PageLaunch::onBuildPreview()
 
 void PageLaunch::updateNetworkDefaults()
 {
-    const PortDefaults defaults = defaultsForNetwork(chainCombo_->currentText(), testnetCheck_->isChecked());
+    const QString chain = currentChain();
+    const c2pool_qt::CoinProfile& prof = c2pool_qt::coinProfile(chain);
+    const bool testnet = testnetCheck_->isChecked();
+
+    const PortDefaults defaults = defaultsForNetwork(chain, testnet);
     p2pPortSpin_->setValue(defaults.p2p);
     stratumPortSpin_->setValue(defaults.stratum);
-    httpPortSpin_->setValue(defaults.http);
+    if (defaults.http > 0)
+        httpPortSpin_->setValue(defaults.http);
     coindPortSpin_->setValue(defaults.rpc);
 
+    // Snap the binary path to the profile default on an explicit chain change.
+    binaryEdit_->setText("./build/bin/" + prof.binary);
+
+    applyProfileUi();
     onBuildPreview();
     emitApiBaseUrlChanged();
+}
+
+void PageLaunch::applyProfileUi()
+{
+    const QString chain = currentChain();
+    const c2pool_qt::CoinProfile& prof = c2pool_qt::coinProfile(chain);
+    const bool perCoin = (prof.cli == c2pool_qt::CliFamily::PerCoinRun);
+
+    // Relabel the parent-daemon group with the coin's daemon name.
+    if (coindGroup_)
+        coindGroup_->setTitle(
+            QStringLiteral("Parent Coin Daemon (%1)").arg(prof.daemonLabel));
+
+    // Suggest the coin's default RPC conf path (PerCoinRun only).
+    if (rpcConfPathEdit_) {
+        rpcConfPathEdit_->setPlaceholderText(
+            perCoin && !prof.confHint.isEmpty()
+                ? QStringLiteral("%1 (default)").arg(prof.confHint)
+                : QStringLiteral("(legacy coin uses RPC user/password below)"));
+        rpcConfPathEdit_->setEnabled(perCoin);
+    }
+    if (dataDirEdit_)
+        dataDirEdit_->setEnabled(perCoin);
+
+    // Show the embedded reward-unsafe opt-in only for PerCoinRun coins;
+    // --embedded-mainnet is DASH-only. It always stays default-OFF.
+    if (embeddedGroup_)
+        embeddedGroup_->setVisible(perCoin);
+    if (embeddedMainnetCheck_)
+        embeddedMainnetCheck_->setVisible(chain == QStringLiteral("dash"));
+
+    // Per-coin note: CLI arm, masternode-payee, experimental status.
+    if (coinNoteLabel_) {
+        QString note;
+        if (perCoin) {
+            note = QStringLiteral(
+                       "%1 · %2 · binary %3 · reward-safe %4 arm (creds from %5).")
+                       .arg(prof.displayLabel, prof.algoLabel, prof.binary,
+                            prof.rpcAuthFlag.isEmpty() ? QStringLiteral("RPC")
+                                                       : prof.rpcAuthFlag,
+                            prof.confHint);
+        } else {
+            note = QStringLiteral("%1 · %2 · unified c2pool binary (--net %3).")
+                       .arg(prof.displayLabel, prof.algoLabel, prof.symbol);
+        }
+        if (prof.masternodePayee)
+            note += QStringLiteral("  Masternode-payee coin (block reward is split "
+                                   "with the masternode network).");
+        if (prof.experimental)
+            note += QStringLiteral("  ⚠ per-coin binary still stabilising — deeper "
+                                   "controls are TODO (qt-steward).");
+        coinNoteLabel_->setText(note);
+    }
 }
 
 void PageLaunch::emitApiBaseUrlChanged()
@@ -729,7 +985,7 @@ void PageLaunch::saveSettings() const
     s.beginGroup(launchGroupPath());
     s.setValue("binary",        binaryEdit_->text());
     s.setValue("mode",          modeCombo_->currentIndex());
-    s.setValue("chain",         chainCombo_->currentText());
+    s.setValue("chain",         currentChain());
     s.setValue("testnet",       testnetCheck_->isChecked());
     s.setValue("p2pPort",       p2pPortSpin_->value());
     s.setValue("stratumPort",   stratumPortSpin_->value());
@@ -752,6 +1008,14 @@ void PageLaunch::saveSettings() const
     s.setValue("seedNodes",     seedNodesEdit_->toPlainText());
     s.setValue("configFile",    configFileEdit_->text());
     s.setValue("messageBlob",   messageBlobEdit_->text());
+    // Per-coin run-loop fields
+    if (rpcConfPathEdit_) s.setValue("rpcConfPath", rpcConfPathEdit_->text());
+    if (dataDirEdit_)     s.setValue("dataDir",     dataDirEdit_->text());
+    // Embedded reward-UNSAFE opt-in state (persisted so it is never silently
+    // re-enabled; defaults stay OFF on load).
+    if (embeddedP2pCheck_)     s.setValue("embeddedP2p",      embeddedP2pCheck_->isChecked());
+    if (embeddedP2pPeersEdit_) s.setValue("embeddedP2pPeers", embeddedP2pPeersEdit_->toPlainText());
+    if (embeddedMainnetCheck_) s.setValue("embeddedMainnet",  embeddedMainnetCheck_->isChecked());
 
     // Merged chains
     s.remove("merged");
@@ -774,11 +1038,15 @@ void PageLaunch::loadSettings()
     binaryEdit_->setText(s.value("binary", "./build/bin/c2pool").toString());
     modeCombo_->setCurrentIndex(s.value("mode", 1).toInt());
     {
-        const int idx = chainCombo_->findText(s.value("chain", "litecoin").toString());
+        // Chain persisted by symbol (combo userData). Fall back to legacy
+        // display-text match for older settings written before profiles.
+        const QString saved = s.value("chain", "litecoin").toString();
+        int idx = chainCombo_->findData(saved);
+        if (idx < 0) idx = chainCombo_->findText(saved);
         chainCombo_->setCurrentIndex(idx >= 0 ? idx : 0);
     }
     testnetCheck_->setChecked(s.value("testnet", true).toBool());
-    const PortDefaults defaults = defaultsForNetwork(chainCombo_->currentText(), testnetCheck_->isChecked());
+    const PortDefaults defaults = defaultsForNetwork(currentChain(), testnetCheck_->isChecked());
     p2pPortSpin_->setValue(s.value("p2pPort", defaults.p2p).toInt());
     stratumPortSpin_->setValue(s.value("stratumPort", defaults.stratum).toInt());
     httpPortSpin_->setValue(s.value("httpPort", defaults.http).toInt());
@@ -803,6 +1071,20 @@ void PageLaunch::loadSettings()
     seedNodesEdit_->setPlainText(s.value("seedNodes").toString());
     configFileEdit_->setText(s.value("configFile").toString());
     messageBlobEdit_->setText(s.value("messageBlob").toString());
+    // Per-coin run-loop fields
+    if (rpcConfPathEdit_) rpcConfPathEdit_->setText(s.value("rpcConfPath").toString());
+    if (dataDirEdit_)     dataDirEdit_->setText(s.value("dataDir").toString());
+    // Embedded reward-UNSAFE opt-in — restore prior state (still defaults OFF
+    // for a fresh profile).
+    if (embeddedP2pCheck_)
+        embeddedP2pCheck_->setChecked(s.value("embeddedP2p", false).toBool());
+    if (embeddedP2pPeersEdit_) {
+        embeddedP2pPeersEdit_->setPlainText(s.value("embeddedP2pPeers").toString());
+        if (embeddedP2pCheck_)
+            embeddedP2pPeersEdit_->setEnabled(embeddedP2pCheck_->isChecked());
+    }
+    if (embeddedMainnetCheck_)
+        embeddedMainnetCheck_->setChecked(s.value("embeddedMainnet", false).toBool());
 
     // Merged chains
     mergedTable_->setRowCount(0);
@@ -818,6 +1100,7 @@ void PageLaunch::loadSettings()
     s.endArray();
     s.endGroup();
 
+    applyProfileUi();  // refresh labels/visibility for the loaded chain (keeps ports)
     onBuildPreview();
     emitApiBaseUrlChanged();
 }

--- a/ui/c2pool-qt/src/PageLaunch.hpp
+++ b/ui/c2pool-qt/src/PageLaunch.hpp
@@ -19,14 +19,23 @@ class SettingsStore;
 
 /// Daemon launch-configuration page.
 ///
-/// Provides a complete GUI form covering every important c2pool CLI flag:
+/// Coin-generic (profile-driven — see CoinProfiles.hpp). Supports both
+/// c2pool launch CLIs: the unified `c2pool --net …` binary (LTC/BTC/DOGE)
+/// and the dedicated per-coin binaries (c2pool-dash / c2pool-dgb /
+/// c2pool-bch) whose run-loop uses the reward-SAFE `--coin-rpc` /
+/// `--coin-rpc-auth` arm.
+///
+/// Provides a GUI form covering the important c2pool CLI flags:
 ///   • Operation mode (integrated / sharechain / solo)
-///   • Network (litecoin / bitcoin / dogecoin, testnet toggle)
+///   • Network (litecoin / bitcoin / dogecoin / dash / digibyte /
+///     bitcoincash, testnet toggle)
 ///   • Binary path + ports (P2P, stratum, HTTP API)
-///   • Parent coin-daemon RPC credentials
+///   • Parent coin-daemon RPC credentials / conf-file path
 ///   • Payout address, node-owner fee (-f), dev donation (--give-author)
 ///   • Redistribute mode for invalid-address miners (--redistribute)
 ///   • Merged-mining chains table (--merged SYMBOL:CHAIN_ID:HOST:PORT:USER:PASS[:P2P])
+///   • ★ Advanced / embedded (opt-in, reward-UNSAFE) — default OFF; the
+///     only place --coin-p2p-connect / --embedded-mainnet can be emitted
 ///   • Generated-command preview
 ///   • Launch / Stop / Restart daemon buttons
 ///
@@ -76,6 +85,18 @@ private slots:
 private:
     void setupUi();
     QGroupBox* makeGroup(const QString& title);
+    /// Build the command line for a LegacyUnified coin (`c2pool --net …`).
+    QString buildLegacyCommand() const;
+    /// Build the command line for a PerCoinRun coin (c2pool-dash/-dgb/-bch,
+    /// reward-SAFE dashd-RPC arm; embedded arm only when opted in).
+    QString buildPerCoinCommand() const;
+    /// Currently-selected chain symbol (chain combo userData/text).
+    QString currentChain() const;
+    /// Apply profile-driven UI state (daemon-group label, per-coin note,
+    /// embedded-group visibility, conf-path enablement) for the current
+    /// chain WITHOUT resetting user-edited ports/binary. Called by both
+    /// updateNetworkDefaults() (after it snaps ports) and loadSettings().
+    void applyProfileUi();
     /** Return the QSettings group prefix the form persists to:
      *  "profiles/<active>/launch" when settings_ is set,
      *  "launch" otherwise. */
@@ -87,7 +108,8 @@ private:
     // ── Mode / Network ──────────────────────────────────────────────────────
     QComboBox* modeCombo_;       ///< integrated / sharechain / solo
     QCheckBox* testnetCheck_;
-    QComboBox* chainCombo_;      ///< litecoin / bitcoin / dogecoin
+    QComboBox* chainCombo_;      ///< coin-generic (CoinProfiles.hpp order)
+    QLabel*    coinNoteLabel_{nullptr};  ///< per-coin note (masternode / experimental / CLI arm)
 
     // ── Executable ─────────────────────────────────────────────────────────
     QLineEdit* binaryEdit_;
@@ -98,12 +120,17 @@ private:
     QSpinBox*  httpPortSpin_;
 
     // ── Parent Coin Daemon ──────────────────────────────────────────────────
+    QGroupBox* coindGroup_{nullptr}; ///< relabelled per coin (daemon name)
     QLineEdit* coindHostEdit_;
     QSpinBox*  coindPortSpin_;       ///< 0 = auto-detect from chain
     QLineEdit* rpcUserEdit_;
     QLineEdit* rpcPassEdit_;
     QSpinBox*  coindP2pPortSpin_;    ///< --coind-p2p-port
     QLineEdit* coindP2pAddrEdit_;    ///< --coind-p2p-address
+    // PerCoinRun creds file: rpcpassword is read from the coin .conf and
+    // NEVER placed on argv. Blank ⇒ the binary's default conf path.
+    QLineEdit* rpcConfPathEdit_{nullptr}; ///< --coin-rpc-auth / --rpc-conf PATH
+    QLineEdit* dataDirEdit_{nullptr};     ///< --data-dir PATH (per-instance state root)
 
     // ── Payout & Fees ───────────────────────────────────────────────────────
     QLineEdit*     addressEdit_;
@@ -136,6 +163,16 @@ private:
     QLineEdit* configFileEdit_;      ///< --config (YAML file)
     QLineEdit* messageBlobEdit_;     ///< --message-blob-hex
     QLineEdit* coinbaseTextEdit_;    ///< --coinbase-text
+
+    // ── ★ Advanced / embedded (opt-in, REWARD-UNSAFE) ────────────────────────
+    // Default OFF. This is the ONLY place --coin-p2p-connect /
+    // --embedded-mainnet may be emitted. Guarded per the DASH hotel
+    // incident: an unguarded embedded arm produced reward-unsafe blocks.
+    QGroupBox*      embeddedGroup_{nullptr};
+    QCheckBox*      embeddedP2pCheck_{nullptr};   ///< enables --coin-p2p-connect (default OFF)
+    QPlainTextEdit* embeddedP2pPeersEdit_{nullptr}; ///< HOST:PORT per line
+    QCheckBox*      embeddedMainnetCheck_{nullptr}; ///< enables --embedded-mainnet (default OFF, DASH)
+    QLabel*         embeddedWarnLabel_{nullptr};
 
     // ── Command Preview ─────────────────────────────────────────────────────
     QTextEdit*   cmdPreview_;

--- a/ui/c2pool-qt/src/bridges/CoinBridge.cpp
+++ b/ui/c2pool-qt/src/bridges/CoinBridge.cpp
@@ -49,6 +49,18 @@ constexpr CoinConstants kKnownCoins[] = {
      "https://digiexplorer.info/block/",
      "https://testnetexplorer.digibyteservers.io/block/",
      36, 8640},
+    // dash — X11, masternode-payee; mainnet PUBKEY 76 (X…) / SCRIPT 16 (7…),
+    // testnet PUBKEY 140 (y…) / SCRIPT 19 (see impl/dash/params.hpp)
+    {"dash",      "Dash",      76, 16, 140, 19,
+     "https://blockchair.com/dash/block/",
+     "https://blockexplorer.one/dash/testnet/blockHash/",
+     36, 8640},
+    // bitcoincash — SHA-256d; legacy base58 versions mirror bitcoin
+    // (mainnet PUBKEY 0 / SCRIPT 5, testnet 111 / 196)
+    {"bitcoincash", "Bitcoin Cash", 0, 5, 111, 196,
+     "https://blockchair.com/bitcoin-cash/block/",
+     "https://blockexplorer.one/bitcoin-cash/testnet/blockHash/",
+     36, 8640},
 };
 
 const CoinConstants* findCoin(const QString& chain)

--- a/ui/c2pool-qt/test/test_reward_safe_launch.cpp
+++ b/ui/c2pool-qt/test/test_reward_safe_launch.cpp
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// test_reward_safe_launch — ★ #1 acceptance criterion.
+//
+// Proves the per-coin launch command core NEVER emits the reward-UNSAFE
+// embedded arm (--coin-p2p-connect / --embedded-mainnet) by default, and
+// that the default parent-daemon link is the reward-SAFE --coin-rpc arm.
+// Qt-free: builds and runs with a plain C++17 compiler (no display).
+//
+// Mirrors PageLaunch's DASH default (dashd-RPC arm, embedded opt-ins OFF).
+//
+// Exit: 0 = all pass, 1 = a reward-safety assertion failed.
+
+#include "../src/LaunchCommand.hpp"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using c2pool_qt::PerCoinParams;
+using c2pool_qt::build_percoin_argv;
+using c2pool_qt::join_argv;
+
+namespace {
+
+int failures = 0;
+
+bool contains(const std::vector<std::string>& a, const std::string& flag)
+{
+    for (const auto& s : a) if (s == flag) return true;
+    return false;
+}
+
+void check(bool cond, const char* what)
+{
+    std::printf("  [%s] %s\n", cond ? "PASS" : "FAIL", what);
+    if (!cond) ++failures;
+}
+
+// The DASH default profile as PageLaunch fills it: reward-SAFE dashd-RPC
+// arm, embedded opt-ins OFF.
+PerCoinParams dashDefault()
+{
+    PerCoinParams p;
+    p.binary = "./build/bin/c2pool-dash";
+    p.subcommand = "--run";
+    p.testnet = false;
+    p.supportsTestnetFlag = true;
+    p.coinRpcFlag = "--coin-rpc";
+    p.rpcHost = "127.0.0.1";
+    p.rpcPort = 9998;                 // dashd mainnet RPC
+    p.rpcAuthFlag = "--coin-rpc-auth";
+    p.confPath = "";                  // blank ⇒ dashd default conf, off argv
+    p.stratumPort = 3333;
+    p.supportsWebPort = true;
+    p.webPort = 8080;
+    p.webHost = "0.0.0.0";
+    p.sharechainPortFlag = "--listen";
+    p.sharechainPort = 9339;
+    // embeddedP2p / embeddedMainnet default false
+    return p;
+}
+
+} // namespace
+
+int main()
+{
+    std::printf("test_reward_safe_launch\n");
+
+    // 1) DASH default command is reward-SAFE.
+    {
+        const auto argv = build_percoin_argv(dashDefault());
+        const std::string cmd = join_argv(argv);
+        std::printf("DASH default: %s\n", cmd.c_str());
+        check(!contains(argv, "--coin-p2p-connect"),
+              "DASH default omits --coin-p2p-connect");
+        check(!contains(argv, "--embedded-mainnet"),
+              "DASH default omits --embedded-mainnet");
+        check(contains(argv, "--coin-rpc"),
+              "DASH default uses reward-safe --coin-rpc arm");
+        check(argv.size() >= 2 && argv[0] == "./build/bin/c2pool-dash"
+                  && argv[1] == "--run",
+              "DASH default invokes c2pool-dash --run");
+        // No secret ever on argv.
+        check(cmd.find("rpcpassword") == std::string::npos
+                  && cmd.find("--rpcpassword") == std::string::npos,
+              "DASH default carries no rpcpassword on argv");
+    }
+
+    // 2) Embedded arm appears ONLY when explicitly opted in.
+    {
+        PerCoinParams p = dashDefault();
+        p.embeddedP2p = true;
+        p.embeddedP2pPeers = {"127.0.0.1:9999"};
+        p.embeddedMainnet = true;
+        const auto argv = build_percoin_argv(p);
+        check(contains(argv, "--coin-p2p-connect"),
+              "opt-in ⇒ --coin-p2p-connect present");
+        check(contains(argv, "--embedded-mainnet"),
+              "opt-in ⇒ --embedded-mainnet present");
+    }
+
+    // 3) Opt-in checkbox ON but no peers ⇒ still no --coin-p2p-connect.
+    {
+        PerCoinParams p = dashDefault();
+        p.embeddedP2p = true;   // checkbox ticked, peer list empty
+        const auto argv = build_percoin_argv(p);
+        check(!contains(argv, "--coin-p2p-connect"),
+              "opt-in with empty peer list emits no --coin-p2p-connect");
+    }
+
+    // 4) BCH default (creds via --rpc-conf, no --coin-rpc endpoint) stays safe.
+    {
+        PerCoinParams p;
+        p.binary = "./build/bin/c2pool-bch";
+        p.subcommand = "--pool";
+        p.supportsTestnetFlag = true;
+        p.coinRpcFlag = "";            // BCH has no endpoint override
+        p.rpcAuthFlag = "--rpc-conf";
+        p.confPath = "/home/u/.bitcoin/bitcoin.conf";
+        p.stratumPort = 3333;
+        const auto argv = build_percoin_argv(p);
+        std::printf("BCH default: %s\n", join_argv(argv).c_str());
+        check(!contains(argv, "--coin-p2p-connect")
+                  && !contains(argv, "--embedded-mainnet"),
+              "BCH default omits embedded reward-unsafe flags");
+        check(contains(argv, "--rpc-conf"),
+              "BCH default uses --rpc-conf creds arm");
+    }
+
+    std::printf(failures == 0 ? "ALL PASS\n" : "FAILURES: %d\n", failures);
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## qt: coin-generic control panel + reward-safe launch defaults

First-pass toward full finalization of the c2pool Qt Control Panel. Makes
the launcher **coin-generic** and **reward-safe**. The qt-steward owns the
remaining deeper controls.

### 1. Coin-generic launch (profile-driven)
New `src/CoinProfiles.hpp` is the single source of truth for the launch
page — per coin: display label, binary name, daemon label, algo, address
flavour, default RPC ports (main/test) and **which CLI family** the coin
uses. Adding a coin is one table row, mirroring how the web
dashboard/explorer stay coin-generic.

Chain selector now offers: litecoin, bitcoin, dogecoin, **dash**,
**digibyte**, **bitcoincash** (was hardcoded to LTC/BTC/DOGE).

Two launch CLIs are handled:
- **Unified** `c2pool --net …` (LTC/BTC/DOGE) — existing generator, intact.
- **Per-coin** binaries `c2pool-dash` / `c2pool-dgb` / `c2pool-bch` — new
  generator using each binary's run-loop subcommand (`--run` / `--pool`).

DASH is first-class: X11, `c2pool-dash`, dashd daemon, flagged as a
masternode-payee coin in the UI.

| Coin | Binary | Daemon | Algo | CLI |
|------|--------|--------|------|-----|
| litecoin/bitcoin/dogecoin | `c2pool` | *coind | Scrypt/SHA-256d | `--net` |
| dash | `c2pool-dash` | dashd | X11 | `--run` |
| digibyte | `c2pool-dgb` | digibyted | Scrypt | `--run` (experimental) |
| bitcoincash | `c2pool-bch` | bitcoind (BCHN) | SHA-256d | `--pool` (experimental) |

### 2. ★ Reward-safe launch defaults (critical)
Motivated by the live DASH hotel incident where an unguarded embedded arm
produced reward-unsafe blocks.

- The **default** per-coin launch is the reward-SAFE dashd-RPC arm:
  `--coin-rpc HOST:PORT` + `--coin-rpc-auth PATH`. The rpcpassword is read
  from the coin's `.conf` and **never** placed on argv.
- `--coin-p2p-connect` and `--embedded-mainnet` are **default OFF** and can
  only be emitted from an explicit, clearly-labelled **"Advanced / embedded
  (opt-in — REWARD-UNSAFE)"** group with a prominent warning.

**Proof (default DASH command line — no embedded flags):**
```
./build/bin/c2pool-dash --run --coin-rpc 127.0.0.1:9998 --stratum 3333 --web-port 8080 --listen 9339
```

The command-assembly core (`src/LaunchCommand.hpp`) is **Qt-free**, so the
invariant is unit-tested without a display in
`test/test_reward_safe_launch.cpp` (build with `-DC2POOL_QT_BUILD_TESTS=ON`,
run via `ctest`). All assertions pass:
- default DASH/BCH commands omit `--coin-p2p-connect` / `--embedded-mainnet`
- default uses the reward-safe `--coin-rpc` / `--rpc-conf` arm
- no rpcpassword on argv
- embedded flags appear only when the opt-in is explicitly set

### 3. Completed vs TODO
Completed: coin-generic selector + profiles; correct per-coin generated
command line (binary, subcommand, coin-rpc + conf, stratum, web/data-dir,
listen/addnode, payout/fee/redistribute); reward-safe defaults + opt-in
gate; PageLaunch persists/reloads the new fields (rpc-conf path, data-dir,
embedded opt-in state, chain-by-symbol); CoinBridge gains dash +
bitcoincash descriptor rows so the embedded dashboard/explorer stays
coin-generic and rebinds per coin (embed wiring untouched).

TODO (qt-steward): deeper DGB/BCH run-loop flag surface (ZMQ, anchors,
sharechain isolation), per-coin address-flavour validation.

### Build
Changed translation units compile clean against Qt6 Widgets
(`PageLaunch.cpp`, `CoinBridge.cpp` — `-Wall -Wextra`, no new warnings);
`CoinProfiles.hpp` links+runs; the Qt-free reward-safe test compiles and
passes. A full app build additionally needs Qt WebEngine (not installed in
the dev env; unrelated to this change). The existing
`test/test_embedded_leak.cpp` is untouched and stays green.

Draft — does not touch node consensus code (UI/launch-command only). Not for
self-merge; integrator reviews.
