### PR TITLE
p2p(dash): advertise known txs (have_tx/losing_tx) + port getaddrs & bestblock send side

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -2630,6 +2630,65 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         // refresh trio (the second is_new_tip() returns false → no-op).
         auto tip_dedup = std::make_shared<dash::coin::TipHashDedup>();
 
+        // ── p2p `bestblock` announcement (canonical node.py:137-140) ────────
+        // Canonical p2pool watches the coin daemon's best-block header and
+        // pushes it to every pool peer:
+        //     @self.node.best_block_header.changed.watch
+        //     def _(header):
+        //         for peer in self.peers.itervalues():
+        //             peer.send_bestblock(header=header)
+        // DASH never sent `bestblock` at all (it only HANDLED the inbound one,
+        // protocol_actual.cpp:191). LTC/DGB/BCH/BTC each expose
+        // broadcast_bestblock(); the DASH port is dash::NodeImpl::broadcast_bestblock.
+        //
+        // Trigger: the ALREADY-DEDUPED tip-notify choke point below
+        // (fire_refresh), so exactly ONE announcement per genuinely new dashd
+        // tip -- ~1 per 2.5 min -- and a poll+ZMQ double-observation of the same
+        // block cannot double-send. The header itself is fetched with a single
+        // `getblockheader <tip> false` on the dedicated rpc_pool thread (never
+        // on the io thread), then parsed and broadcast back on ioc. Any failure
+        // is swallowed: bestblock is advisory, and the next tip re-announces.
+        //
+        // REWARD-SAFETY: announcement only. It does not touch the template, the
+        // share chain, the mint path, the coinbase/payee, or the won-block
+        // dispatch -- it is a read of dashd's tip header plus a socket write.
+        std::function<void(const std::string&)> announce_bestblock =
+            [rpc = rpc.get(), rpc_pool, &ioc, &p2p_node](const std::string& tip_hex) {
+                uint256 tip;
+                tip.SetHex(tip_hex);
+                if (tip.IsNull())
+                    return;
+                boost::asio::post(*rpc_pool, [rpc, tip, &ioc, &p2p_node]() {
+                    std::string hdr_hex;
+                    try {
+                        // BLOCKING -- BACKGROUND THREAD (never the io thread).
+                        auto r = rpc->getblockheader(tip, /*verbose=*/false);
+                        if (r.is_string())
+                            hdr_hex = r.get<std::string>();
+                    } catch (const std::exception& e) {
+                        LOG_WARNING << "[Pool] bestblock: getblockheader failed "
+                                       "(non-fatal, next tip re-announces): "
+                                    << e.what();
+                        return;
+                    } catch (...) {
+                        return; // never crash on an advisory announcement
+                    }
+                    if (hdr_hex.size() != 160)
+                        return; // not an 80-byte header -- refuse to send garbage
+                    boost::asio::post(ioc, [hdr_hex = std::move(hdr_hex), &p2p_node]() {
+                        try {
+                            dash::coin::BlockHeaderType hdr;
+                            PackStream ps(ParseHex(hdr_hex));
+                            ps >> hdr;
+                            p2p_node.broadcast_bestblock(hdr);
+                        } catch (const std::exception& e) {
+                            LOG_WARNING << "[Pool] bestblock: header unpack failed: "
+                                        << e.what();
+                        }
+                    });
+                });
+            };
+
         // The refresh trio, shared by both paths. Runs on the io_context thread
         // ONLY (the poll follow-up is posted back to ioc; the ZMQ callback posts
         // onto ioc), so ws/ss/dedup are never touched concurrently. `verb`
@@ -2640,7 +2699,7 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         // a benign idle-timeout reconnect.
         std::function<bool(const std::string&, const char*, const char*)>
             fire_refresh = [ws = work_source.get(), ss = stratum_server.get(),
-                            tip_dedup](const std::string& tip,
+                            tip_dedup, announce_bestblock](const std::string& tip,
                                        const char* source, const char* verb) {
                 if (!tip_dedup->is_new_tip(tip))
                     return false; // dedup: coalesce a poll+ZMQ double-fire on one tip
@@ -2648,6 +2707,10 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     "tip-notify: dashd best-block changed");
                 ws->bump_work_generation();
                 ss->notify_all();
+                // Canonical node.py:137-140 — announce the new tip header to
+                // every pool peer. Deduped by is_new_tip() above, so exactly
+                // one announcement per genuinely new block.
+                announce_bestblock(tip);
                 LOG_INFO << "[Stratum] " << source << ": " << tip.substr(0, 16)
                          << " -> " << verb;
                 std::cout << "[Stratum] " << source << ": " << tip.substr(0, 16)

--- a/src/core/test/CMakeLists.txt
+++ b/src/core/test/CMakeLists.txt
@@ -7,7 +7,15 @@ if (BUILD_TESTING AND (GTest_FOUND OR GTEST_FOUND))
     # add_executable — a standalone target is not in build.yml's --target list, so
     # CI never builds it and CTest reports the cases "Not Run" (the #769 trap). One
     # KAT covers all four coins since they consume one shared core helper.
-    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp core_merkle_branches_test.cpp version_gate_test.cpp filesystem_test.cpp web_server_submitblock_test.cpp known_txs_eviction_test.cpp)
+    #
+    # tx_advertiser_test.cpp: SEND side of the p2pool have_tx / losing_tx tx-pool
+    # advertisement (core/tx_advertiser.hpp) — the per-peer advertised-set delta
+    # model, the have-before-losing ordering, and the wire chunk bound. Same
+    # reasoning as above: header-only over core, so it is FOLDED into the
+    # EXISTING allowlisted core_test target (never a new add_executable — that is
+    # the #769 "Not Run" trap), and one KAT covers every coin because all five
+    # node lanes consume this one shared helper.
+    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp core_merkle_branches_test.cpp version_gate_test.cpp filesystem_test.cpp web_server_submitblock_test.cpp known_txs_eviction_test.cpp tx_advertiser_test.cpp)
     target_link_libraries(core_test PRIVATE GTest::gtest_main core c2pool_merged_mining GTest::gtest)
     target_link_libraries(core_test PRIVATE c2pool_payout c2pool_hashrate ltc_coin)  # OBJECT-lib SCC direct-naming (#22/#39)
 

--- a/src/core/test/tx_advertiser_test.cpp
+++ b/src/core/test/tx_advertiser_test.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <set>
 #include <vector>
 
@@ -65,10 +66,30 @@ struct Wire
     }
 };
 
+// Monotonic virtual clock. Every sweep() advances it by the production sweep
+// cadence, so the per-peer min-emit interval never fires incidentally in the
+// KATs that are exercising delta logic. A fresh TxAdvertState starts at "never
+// emitted", so the clock carrying across tests is harmless. The interval guard
+// itself is driven explicitly via sweep_at().
+std::chrono::steady_clock::time_point& vclock()
+{
+    static std::chrono::steady_clock::time_point t{};
+    return t;
+}
+
 TxAdvertPlan sweep(TxAdvertState& st, const std::set<uint256>& current, Wire& w,
                    size_t cap = core::TX_ADVERT_MAX_HASHES_PER_MESSAGE)
 {
-    return run_tx_advert(st, current, w.have_fn(), w.losing_fn(), cap);
+    vclock() += std::chrono::seconds(core::TX_ADVERT_INTERVAL_SECONDS);
+    return run_tx_advert(st, current, w.have_fn(), w.losing_fn(), cap, vclock());
+}
+
+// Sweep at an explicit instant, for the min-emit-interval KATs.
+TxAdvertPlan sweep_at(TxAdvertState& st, const std::set<uint256>& current, Wire& w,
+                      std::chrono::steady_clock::time_point at,
+                      size_t cap = core::TX_ADVERT_MAX_HASHES_PER_MESSAGE)
+{
+    return run_tx_advert(st, current, w.have_fn(), w.losing_fn(), cap, at);
 }
 
 } // namespace
@@ -352,18 +373,110 @@ TEST(TxAdvertiser, ZeroBudgetEmitsNothingAndCommitsNothing)
     EXPECT_EQ(st.m_advertised, hashes(1, 5));
 }
 
-// The default per-message bound must stay inside a single write_some on a fresh
-// socket (the no-outbound-queue constraint) and inside canonical's own receiver
-// truncation (p2p.py:494) and max_payload (p2p.py:41).
+// The default per-message bound keeps the message SIZE predictable and stays
+// inside what a canonical peer will retain (p2p.py:494) and accept (p2p.py:41).
+//
+// It deliberately does NOT assert that a message fits one write_some: ~32 KB
+// needs >= 2 rounds at the Linux default tcp_wmem[1] of 16384. Safety comes from
+// exclusivity, not size — one message per sweep, nothing else written in the
+// same event, and the min-emit interval below.
 TEST(TxAdvertiser, DefaultBoundsAreWireSafe)
 {
     EXPECT_LE(core::TX_ADVERT_MAX_HASHES_PER_MESSAGE, 2000u);
-    // 32 bytes/hash + framing must stay well under a conservative 64 KB sndbuf.
-    EXPECT_LE(core::TX_ADVERT_MAX_HASHES_PER_MESSAGE * 32u + 64u, 64u * 1024u);
-    // ...and inside what a canonical peer would even retain / accept.
-    EXPECT_LE(core::TX_ADVERT_MAX_HASHES_PER_MESSAGE, 10000u);
-    EXPECT_LE(core::TX_ADVERT_MAX_HASHES_PER_MESSAGE * 32u, 3145728u);
+    // Inside what a canonical peer would even retain / accept.
+    EXPECT_LE(core::TX_ADVERT_MAX_HASHES_PER_MESSAGE, 10000u);      // p2p.py:494
+    EXPECT_LE(core::TX_ADVERT_MAX_HASHES_PER_MESSAGE * 32u, 3145728u); // p2p.py:41
+    // The min-emit interval must be a real gap, and must not exceed the sweep
+    // cadence — otherwise it would throttle steady-state adverts rather than
+    // only suppressing a sweep landing on the handshake advert.
+    EXPECT_GT(core::TX_ADVERT_MIN_EMIT_INTERVAL_SECONDS, 0);
+    EXPECT_LE(core::TX_ADVERT_MIN_EMIT_INTERVAL_SECONDS, core::TX_ADVERT_INTERVAL_SECONDS);
     EXPECT_EQ(core::TX_ADVERT_INTERVAL_SECONDS, 10);
+}
+
+// N2: one message per SWEEP is not one message IN FLIGHT. A sweep landing on top
+// of a just-sent advert (the handshake case: direct advert, then the 10 s timer
+// fires a fraction of a second later) must emit NOTHING, or core::Socket::write
+// initiates a second composed write while the first still drains and the two
+// interleave -> bad checksum -> canonical disconnect.
+TEST(TxAdvertiser, SweepWithinMinIntervalEmitsNothingAndLosesNothing)
+{
+    using namespace std::chrono;
+    const auto t0 = steady_clock::time_point{} + hours(1);
+    TxAdvertState st;
+
+    // Handshake advert: never emitted before, so it always goes out.
+    Wire w0;
+    sweep_at(st, hashes(1, 3), w0, t0);
+    ASSERT_EQ(w0.msgs.size(), 1u);
+    EXPECT_EQ(st.m_advertised, hashes(1, 3));
+    EXPECT_EQ(st.m_last_emit, t0);
+
+    // A sweep 1 s later, with NEW hashes outstanding, is suppressed entirely.
+    Wire w1;
+    auto plan = sweep_at(st, hashes(1, 6), w1, t0 + seconds(1));
+    EXPECT_TRUE(plan.empty());
+    EXPECT_TRUE(w1.msgs.empty());
+    EXPECT_EQ(st.m_advertised, hashes(1, 3));   // nothing committed
+    EXPECT_EQ(st.m_last_emit, t0);              // stamp untouched
+
+    // Still suppressed one tick before the interval elapses.
+    Wire w2;
+    sweep_at(st, hashes(1, 6), w2,
+             t0 + seconds(core::TX_ADVERT_MIN_EMIT_INTERVAL_SECONDS) - milliseconds(1));
+    EXPECT_TRUE(w2.msgs.empty());
+
+    // At the interval it goes out — and the hashes suppressed above are NOT
+    // lost, because nothing was committed for them.
+    Wire w3;
+    const auto t3 = t0 + seconds(core::TX_ADVERT_MIN_EMIT_INTERVAL_SECONDS);
+    sweep_at(st, hashes(1, 6), w3, t3);
+    ASSERT_EQ(w3.msgs.size(), 1u);
+    EXPECT_EQ(w3.msgs[0].kind, Wire::Kind::have);
+    EXPECT_EQ(std::set<uint256>(w3.msgs[0].hashes.begin(), w3.msgs[0].hashes.end()),
+              hashes(4, 6));
+    EXPECT_EQ(st.m_advertised, hashes(1, 6));
+    EXPECT_EQ(st.m_last_emit, t3);
+}
+
+// The guard must not throttle steady state: at the production sweep cadence
+// (10 s) every sweep with an outstanding delta still emits.
+TEST(TxAdvertiser, SteadyStateSweepCadenceIsNeverThrottled)
+{
+    using namespace std::chrono;
+    auto t = steady_clock::time_point{} + hours(2);
+    TxAdvertState st;
+
+    for (uint64_t i = 1; i <= 5; ++i) {
+        Wire w;
+        sweep_at(st, hashes(1, i), w, t);
+        ASSERT_EQ(w.msgs.size(), 1u) << "suppressed at sweep " << i;
+        t += seconds(core::TX_ADVERT_INTERVAL_SECONDS);
+    }
+    EXPECT_EQ(st.m_advertised, hashes(1, 5));
+}
+
+// A suppressed sweep must not consume the unconditional handshake advert: if the
+// very first call is suppressed, m_initial_sent stays false and the advert is
+// still owed. (Only reachable if a caller passes an already-stamped state.)
+TEST(TxAdvertiser, SuppressionDoesNotConsumeTheInitialAdvert)
+{
+    using namespace std::chrono;
+    const auto t0 = steady_clock::time_point{} + hours(3);
+    TxAdvertState st;
+    st.m_last_emit = t0;   // pretend something was just written to this peer
+
+    Wire w;
+    sweep_at(st, std::set<uint256>{}, w, t0 + seconds(1));
+    EXPECT_TRUE(w.msgs.empty());
+    EXPECT_FALSE(st.m_initial_sent);
+
+    Wire w2;
+    sweep_at(st, std::set<uint256>{}, w2,
+             t0 + seconds(core::TX_ADVERT_MIN_EMIT_INTERVAL_SECONDS));
+    ASSERT_EQ(w2.msgs.size(), 1u);
+    EXPECT_TRUE(w2.msgs[0].hashes.empty());
+    EXPECT_TRUE(st.m_initial_sent);
 }
 
 // plan_tx_advert is pure: it must not mutate the state it inspects.

--- a/src/core/test/tx_advertiser_test.cpp
+++ b/src/core/test/tx_advertiser_test.cpp
@@ -23,7 +23,6 @@
 //   p2p.py:261-274  transitioned      -> have_tx(added) THEN losing_tx(removed)
 //   p2p.py:494-495  receiver truncates its view at 10000 hashes (our chunk cap)
 
-using core::chunk_tx_hashes;
 using core::plan_tx_advert;
 using core::run_tx_advert;
 using core::TxAdvertPlan;
@@ -172,108 +171,199 @@ TEST(TxAdvertiser, EvictionEmitsLosingTx)
     EXPECT_EQ(st.m_advertised, hashes(6, 10));
 }
 
-// p2p.py:261-274 (transitioned): additions go out BEFORE retractions, so a peer
-// that re-learns a hash in the same sweep never ends up with it retracted.
+// p2p.py:261-274 (transitioned): additions go out BEFORE retractions. With the
+// one-message-per-sweep bound this becomes "adds this sweep, retractions the
+// next" — the ordering canonical guarantees is preserved across sweeps.
 TEST(TxAdvertiser, MixedDeltaSendsHaveBeforeLosing)
 {
     TxAdvertState st;
     Wire w0;
     sweep(st, hashes(1, 5), w0);
 
-    Wire w;
-    auto plan = sweep(st, hashes(4, 9), w); // drop 1..3, add 6..9
+    Wire a;
+    sweep(st, hashes(4, 9), a); // drop 1..3, add 6..9
+    ASSERT_EQ(a.msgs.size(), 1u);
+    EXPECT_EQ(a.msgs[0].kind, Wire::Kind::have);
+    EXPECT_EQ(std::set<uint256>(a.msgs[0].hashes.begin(), a.msgs[0].hashes.end()), hashes(6, 9));
 
-    ASSERT_EQ(w.msgs.size(), 2u);
-    EXPECT_EQ(w.msgs[0].kind, Wire::Kind::have);
-    EXPECT_EQ(w.msgs[1].kind, Wire::Kind::losing);
-    EXPECT_EQ(std::set<uint256>(w.msgs[0].hashes.begin(), w.msgs[0].hashes.end()), hashes(6, 9));
-    EXPECT_EQ(std::set<uint256>(w.msgs[1].hashes.begin(), w.msgs[1].hashes.end()), hashes(1, 3));
+    Wire b;
+    sweep(st, hashes(4, 9), b);
+    ASSERT_EQ(b.msgs.size(), 1u);
+    EXPECT_EQ(b.msgs[0].kind, Wire::Kind::losing);
+    EXPECT_EQ(std::set<uint256>(b.msgs[0].hashes.begin(), b.msgs[0].hashes.end()), hashes(1, 3));
+
+    Wire c;
+    sweep(st, hashes(4, 9), c);
+    EXPECT_TRUE(c.msgs.empty());
 }
 
 // No hash is ever advertised twice across a long run of sweeps, and a hash that
 // is retracted and later re-learned IS advertised again (exactly once more).
+// Each state is swept to quiescence so the one-message-per-sweep budget does not
+// hide an outstanding delta.
 TEST(TxAdvertiser, NothingAdvertisedTwiceAndReLearnReAdvertises)
 {
     TxAdvertState st;
     std::vector<uint256> ever_advertised;
 
-    auto record = [&](Wire& w) {
-        for (const auto& h : w.all(Wire::Kind::have))
-            ever_advertised.push_back(h);
+    // Sweep `pool` until nothing more is emitted, recording every have_tx hash.
+    auto drain = [&](const std::set<uint256>& pool) {
+        for (int i = 0; i < 20; ++i) {
+            Wire w;
+            sweep(st, pool, w);
+            if (w.msgs.empty())
+                return;
+            ASSERT_EQ(w.msgs.size(), 1u);
+            for (const auto& h : w.all(Wire::Kind::have))
+                ever_advertised.push_back(h);
+        }
+        FAIL() << "advert never reached quiescence";
     };
 
-    Wire a; sweep(st, hashes(1, 4), a); record(a);
-    Wire b; sweep(st, hashes(1, 4), b); record(b);   // no change
-    Wire c; sweep(st, hashes(3, 6), c); record(c);   // drop 1,2 add 5,6
-    Wire d; sweep(st, hashes(3, 6), d); record(d);   // no change
+    drain(hashes(1, 4));   // advertise 1,2,3,4
+    drain(hashes(1, 4));   // no change -> nothing
+    drain(hashes(3, 6));   // drop 1,2 (losing_tx); add 5,6
+    drain(hashes(3, 6));   // no change -> nothing
 
-    // 1,2,3,4 then 5,6 — six adverts, no duplicates.
     EXPECT_EQ(ever_advertised.size(), 6u);
     EXPECT_EQ(std::set<uint256>(ever_advertised.begin(), ever_advertised.end()).size(), 6u);
+    EXPECT_EQ(st.m_advertised, hashes(3, 6));
 
-    // Re-learn hash 1 (evicted at sweep c): it must be advertised again.
-    Wire e; sweep(st, hashes(1, 6), e); record(e);
-    const auto again = e.all(Wire::Kind::have);
-    ASSERT_EQ(again.size(), 2u);
-    EXPECT_EQ(std::set<uint256>(again.begin(), again.end()), hashes(1, 2));
+    // Re-learn 1,2 (retracted above): they must be advertised again.
+    drain(hashes(1, 6));
     EXPECT_EQ(ever_advertised.size(), 8u);
+    EXPECT_EQ(st.m_advertised, hashes(1, 6));
 }
 
-// Wire bound: a pool at exactly the cap is one message; cap+1 is two, and the
-// split is complete and non-overlapping (canonical fragments instead, p2p.py:230).
-TEST(TxAdvertiser, ChunkBoundaryExactAndOverflow)
+// Write-safety bound: a sweep emits AT MOST ONE message. core::Socket::write has
+// no outbound queue (socket.cpp:110-137), so a chunk burst would overlap composed
+// async_writes and interleave bytes mid-message -> bad checksum -> the canonical
+// peer drops us. Over-budget hashes are NOT committed; they resurface next sweep.
+TEST(TxAdvertiser, OneMessagePerSweepAndCommitsOnlyWhatWasEmitted)
 {
-    constexpr size_t cap = 4;
+    constexpr size_t budget = 4;
+    TxAdvertState st;
+    Wire w;
 
-    {
-        TxAdvertState st;
-        Wire w;
-        sweep(st, hashes(1, cap), w, cap);
-        ASSERT_EQ(w.msgs.size(), 1u);
-        EXPECT_EQ(w.msgs[0].hashes.size(), cap);
-    }
-    {
-        TxAdvertState st;
-        Wire w;
-        sweep(st, hashes(1, cap + 1), w, cap);
-        ASSERT_EQ(w.msgs.size(), 2u);
-        EXPECT_EQ(w.msgs[0].hashes.size(), cap);
-        EXPECT_EQ(w.msgs[1].hashes.size(), 1u);
-        const auto all = w.all(Wire::Kind::have);
-        EXPECT_EQ(std::set<uint256>(all.begin(), all.end()), hashes(1, cap + 1));
-    }
-    {
-        // Retractions chunk on the same bound.
-        TxAdvertState st;
-        Wire w0;
-        sweep(st, hashes(1, 9), w0, cap);
-        Wire w;
-        sweep(st, std::set<uint256>{}, w, cap);
-        EXPECT_EQ(w.count(Wire::Kind::have), 0u);
-        EXPECT_EQ(w.count(Wire::Kind::losing), 3u); // 4 + 4 + 1
-        EXPECT_EQ(w.all(Wire::Kind::losing).size(), 9u);
-    }
+    sweep(st, hashes(1, 10), w, budget);
+
+    // Exactly one message, exactly `budget` hashes.
+    ASSERT_EQ(w.msgs.size(), 1u);
+    EXPECT_EQ(w.msgs[0].kind, Wire::Kind::have);
+    EXPECT_EQ(w.msgs[0].hashes.size(), budget);
+    // ...and ONLY those are recorded as advertised — committing the un-sent
+    // remainder would be a permanent per-peer desync.
+    EXPECT_EQ(st.m_advertised.size(), budget);
+    for (const auto& h : w.msgs[0].hashes)
+        EXPECT_TRUE(st.m_advertised.count(h));
 }
 
-// The default cap is the canonical receive-side truncation bound (p2p.py:494),
-// so we never emit a message a canonical peer could not fully retain, and the
-// payload stays ~320 KB — far under canonical's 3 MiB max_payload (p2p.py:41).
-TEST(TxAdvertiser, DefaultChunkCapMatchesCanonicalReceiverBound)
+// The remainder is carried by the FOLLOWING sweeps until the pool converges,
+// with no hash sent twice and none dropped.
+TEST(TxAdvertiser, RemainderIsAdvertisedOnSubsequentSweeps)
 {
-    EXPECT_EQ(core::TX_ADVERT_MAX_HASHES_PER_MESSAGE, 10000u);
+    constexpr size_t budget = 4;
+    TxAdvertState st;
+    const auto pool = hashes(1, 10);
+
+    std::vector<uint256> ever;
+    size_t sweeps = 0;
+    for (; sweeps < 20; ++sweeps) {
+        Wire w;
+        sweep(st, pool, w, budget);
+        if (w.msgs.empty())
+            break;
+        ASSERT_EQ(w.msgs.size(), 1u); // never more than one message per sweep
+        EXPECT_LE(w.msgs[0].hashes.size(), budget);
+        for (const auto& h : w.msgs[0].hashes)
+            ever.push_back(h);
+    }
+
+    // ceil(10/4) = 3 sweeps of adverts, then a 4th that emits nothing.
+    EXPECT_EQ(sweeps, 3u);
+    EXPECT_EQ(ever.size(), 10u);
+    EXPECT_EQ(std::set<uint256>(ever.begin(), ever.end()), pool); // complete, no dupes
+    EXPECT_EQ(st.m_advertised, pool);
+}
+
+// Retractions are budgeted the same way, and additions always drain FIRST
+// (canonical have-before-losing, p2p.py:264-267) — so a sweep never emits a
+// have_tx and a losing_tx back to back.
+TEST(TxAdvertiser, LosingTxIsBudgetedAndDrainsAfterHaveTx)
+{
+    constexpr size_t budget = 4;
+    TxAdvertState st;
+
+    // Seed 9 advertised hashes over 3 sweeps.
+    for (int i = 0; i < 3; ++i) { Wire w; sweep(st, hashes(1, 9), w, budget); }
+    ASSERT_EQ(st.m_advertised, hashes(1, 9));
+
+    // Now the pool drops to {1..2} AND gains {20..21}: adds go first.
+    std::set<uint256> next = hashes(1, 2);
+    next.insert(H(20));
+    next.insert(H(21));
+
+    Wire a;
+    sweep(st, next, a, budget);
+    ASSERT_EQ(a.msgs.size(), 1u);
+    EXPECT_EQ(a.msgs[0].kind, Wire::Kind::have);
+    EXPECT_EQ(std::set<uint256>(a.msgs[0].hashes.begin(), a.msgs[0].hashes.end()),
+              (std::set<uint256>{H(20), H(21)}));
+
+    // Only once additions are exhausted do retractions start, one message each.
+    Wire b;
+    sweep(st, next, b, budget);
+    ASSERT_EQ(b.msgs.size(), 1u);
+    EXPECT_EQ(b.msgs[0].kind, Wire::Kind::losing);
+    EXPECT_EQ(b.msgs[0].hashes.size(), budget);
+
+    Wire c;
+    sweep(st, next, c, budget);
+    ASSERT_EQ(c.msgs.size(), 1u);
+    EXPECT_EQ(c.msgs[0].kind, Wire::Kind::losing);
+    EXPECT_EQ(c.msgs[0].hashes.size(), 3u); // 7 retractions total: 4 + 3
+
+    Wire d;
+    sweep(st, next, d, budget);
+    EXPECT_TRUE(d.msgs.empty());
+    EXPECT_EQ(st.m_advertised, next);
+}
+
+// Fail closed on a zero budget: nothing can be emitted, so nothing may be
+// committed. Committing under a zero budget would mark hashes advertised that
+// never reached the wire -> they would never resurface in a later diff.
+TEST(TxAdvertiser, ZeroBudgetEmitsNothingAndCommitsNothing)
+{
+    TxAdvertState st;
+    Wire w;
+
+    auto plan = sweep(st, hashes(1, 5), w, /*cap=*/0);
+
+    EXPECT_TRUE(plan.empty());
+    EXPECT_TRUE(w.msgs.empty());
+    EXPECT_TRUE(st.m_advertised.empty());
+    EXPECT_FALSE(st.m_initial_sent);   // the handshake advert is still owed
+
+    // A later sweep with a real budget still delivers the full set.
+    Wire w2;
+    sweep(st, hashes(1, 5), w2, 10);
+    ASSERT_EQ(w2.msgs.size(), 1u);
+    EXPECT_EQ(w2.msgs[0].hashes.size(), 5u);
+    EXPECT_EQ(st.m_advertised, hashes(1, 5));
+}
+
+// The default per-message bound must stay inside a single write_some on a fresh
+// socket (the no-outbound-queue constraint) and inside canonical's own receiver
+// truncation (p2p.py:494) and max_payload (p2p.py:41).
+TEST(TxAdvertiser, DefaultBoundsAreWireSafe)
+{
+    EXPECT_LE(core::TX_ADVERT_MAX_HASHES_PER_MESSAGE, 2000u);
+    // 32 bytes/hash + framing must stay well under a conservative 64 KB sndbuf.
+    EXPECT_LE(core::TX_ADVERT_MAX_HASHES_PER_MESSAGE * 32u + 64u, 64u * 1024u);
+    // ...and inside what a canonical peer would even retain / accept.
+    EXPECT_LE(core::TX_ADVERT_MAX_HASHES_PER_MESSAGE, 10000u);
     EXPECT_LE(core::TX_ADVERT_MAX_HASHES_PER_MESSAGE * 32u, 3145728u);
     EXPECT_EQ(core::TX_ADVERT_INTERVAL_SECONDS, 10);
-}
-
-// chunk_tx_hashes never yields an empty chunk — an empty delta must produce no
-// message at all (canonical `if added:` / `if removed:` guards).
-TEST(TxAdvertiser, ChunkingNeverEmitsEmptyChunks)
-{
-    EXPECT_TRUE(chunk_tx_hashes({}, 10).empty());
-    const std::vector<uint256> one{H(1)};
-    const auto c = chunk_tx_hashes(one, 10);
-    ASSERT_EQ(c.size(), 1u);
-    EXPECT_EQ(c[0].size(), 1u);
 }
 
 // plan_tx_advert is pure: it must not mutate the state it inspects.

--- a/src/core/test/tx_advertiser_test.cpp
+++ b/src/core/test/tx_advertiser_test.cpp
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#include <gtest/gtest.h>
+
+#include <set>
+#include <vector>
+
+#include <core/tx_advertiser.hpp>
+#include <core/uint256.hpp>
+
+// KATs for core::run_tx_advert / plan_tx_advert — the SEND side of the p2pool
+// `have_tx` / `losing_tx` tx-pool advertisement that c2pool never implemented
+// (receive-only in every coin, so canonical p2pool dashboards rendered every
+// c2pool node with txpool = 0).
+//
+// The helper is coin-agnostic on purpose: DASH wires it first, LTC/DGB/BCH/BTC
+// follow, and all five consume this one implementation — so one KAT covers the
+// delta semantics for every coin. Advert-only; nothing here is consensus state.
+//
+// Canonical semantics under test (p2pool python, p2pool/p2p.py):
+//   p2p.py:276      full have_tx immediately after the version handshake
+//   p2p.py:243-248  known_txs added   -> have_tx(added)
+//   p2p.py:250-259  known_txs removed -> losing_tx(removed)
+//   p2p.py:261-274  transitioned      -> have_tx(added) THEN losing_tx(removed)
+//   p2p.py:494-495  receiver truncates its view at 10000 hashes (our chunk cap)
+
+using core::chunk_tx_hashes;
+using core::plan_tx_advert;
+using core::run_tx_advert;
+using core::TxAdvertPlan;
+using core::TxAdvertState;
+
+namespace {
+
+uint256 H(uint64_t i) { return uint256(i); }
+
+std::set<uint256> hashes(uint64_t first, uint64_t last)
+{
+    std::set<uint256> s;
+    for (uint64_t i = first; i <= last; ++i)
+        s.insert(H(i));
+    return s;
+}
+
+// Records exactly what would go on the wire, in order.
+struct Wire
+{
+    enum class Kind { have, losing };
+    struct Msg { Kind kind; std::vector<uint256> hashes; };
+    std::vector<Msg> msgs;
+
+    auto have_fn() { return [this](const std::vector<uint256>& h) { msgs.push_back({Kind::have, h}); }; }
+    auto losing_fn() { return [this](const std::vector<uint256>& h) { msgs.push_back({Kind::losing, h}); }; }
+
+    size_t count(Kind k) const
+    {
+        size_t n = 0;
+        for (const auto& m : msgs) if (m.kind == k) ++n;
+        return n;
+    }
+    std::vector<uint256> all(Kind k) const
+    {
+        std::vector<uint256> out;
+        for (const auto& m : msgs)
+            if (m.kind == k) out.insert(out.end(), m.hashes.begin(), m.hashes.end());
+        return out;
+    }
+};
+
+TxAdvertPlan sweep(TxAdvertState& st, const std::set<uint256>& current, Wire& w,
+                   size_t cap = core::TX_ADVERT_MAX_HASHES_PER_MESSAGE)
+{
+    return run_tx_advert(st, current, w.have_fn(), w.losing_fn(), cap);
+}
+
+} // namespace
+
+// p2p.py:276 — the handshake advert carries the FULL current known-tx set.
+TEST(TxAdvertiser, FirstAdvertSendsEverything)
+{
+    TxAdvertState st;
+    Wire w;
+    const auto current = hashes(1, 5);
+
+    auto plan = sweep(st, current, w);
+
+    EXPECT_EQ(plan.m_have.size(), 5u);
+    EXPECT_TRUE(plan.m_losing.empty());
+    EXPECT_EQ(w.count(Wire::Kind::have), 1u);
+    EXPECT_EQ(w.count(Wire::Kind::losing), 0u);
+    EXPECT_EQ(w.all(Wire::Kind::have).size(), 5u);
+    EXPECT_EQ(st.m_advertised, current);
+    EXPECT_TRUE(st.m_initial_sent);
+}
+
+// p2p.py:276 is UNCONDITIONAL — a node with an empty tx pool still announces
+// once, so the peer's view is explicitly established rather than assumed.
+TEST(TxAdvertiser, FirstAdvertOnEmptyPoolStillSendsExactlyOneMessage)
+{
+    TxAdvertState st;
+    Wire w;
+
+    auto plan = sweep(st, std::set<uint256>{}, w);
+
+    EXPECT_TRUE(plan.empty());
+    ASSERT_EQ(w.msgs.size(), 1u);
+    EXPECT_EQ(w.msgs[0].kind, Wire::Kind::have);
+    EXPECT_TRUE(w.msgs[0].hashes.empty());
+    EXPECT_TRUE(st.m_initial_sent);
+
+    // ...and the very next sweep, still empty, sends NOTHING.
+    Wire w2;
+    sweep(st, std::set<uint256>{}, w2);
+    EXPECT_TRUE(w2.msgs.empty());
+}
+
+// The whole point of the per-peer advertised set: a re-sweep over an unchanged
+// pool puts nothing on the wire. Without this the 10s timer would re-broadcast
+// the entire pool six times a minute to every peer.
+TEST(TxAdvertiser, UnchangedPoolSendsNothing)
+{
+    TxAdvertState st;
+    Wire w;
+    const auto current = hashes(1, 100);
+
+    sweep(st, current, w);
+    ASSERT_EQ(w.msgs.size(), 1u);
+
+    for (int i = 0; i < 5; ++i) {
+        Wire again;
+        auto plan = sweep(st, current, again);
+        EXPECT_TRUE(plan.empty());
+        EXPECT_TRUE(again.msgs.empty());
+    }
+}
+
+// p2p.py:243-248 — the second advert carries ONLY what is new.
+TEST(TxAdvertiser, SecondAdvertSendsOnlyTheDelta)
+{
+    TxAdvertState st;
+    Wire w0;
+    sweep(st, hashes(1, 5), w0);
+
+    Wire w;
+    auto plan = sweep(st, hashes(1, 8), w);
+
+    ASSERT_EQ(plan.m_have.size(), 3u);
+    EXPECT_TRUE(plan.m_losing.empty());
+    const auto sent = w.all(Wire::Kind::have);
+    ASSERT_EQ(sent.size(), 3u);
+    const std::set<uint256> sent_set(sent.begin(), sent.end());
+    EXPECT_EQ(sent_set, hashes(6, 8));
+}
+
+// Eviction retraction: hashes that left the known-tx pool (bounded oldest-first
+// eviction on LTC/DGB/BCH/BTC, template-window retention on DASH) are retracted
+// with losing_tx and are NOT re-sent as have_tx.
+TEST(TxAdvertiser, EvictionEmitsLosingTx)
+{
+    TxAdvertState st;
+    Wire w0;
+    sweep(st, hashes(1, 10), w0);
+
+    Wire w;
+    auto plan = sweep(st, hashes(6, 10), w); // 1..5 evicted
+
+    EXPECT_TRUE(plan.m_have.empty());
+    ASSERT_EQ(plan.m_losing.size(), 5u);
+    EXPECT_EQ(w.count(Wire::Kind::have), 0u);
+    ASSERT_EQ(w.count(Wire::Kind::losing), 1u);
+    const auto lost = w.all(Wire::Kind::losing);
+    EXPECT_EQ(std::set<uint256>(lost.begin(), lost.end()), hashes(1, 5));
+    EXPECT_EQ(st.m_advertised, hashes(6, 10));
+}
+
+// p2p.py:261-274 (transitioned): additions go out BEFORE retractions, so a peer
+// that re-learns a hash in the same sweep never ends up with it retracted.
+TEST(TxAdvertiser, MixedDeltaSendsHaveBeforeLosing)
+{
+    TxAdvertState st;
+    Wire w0;
+    sweep(st, hashes(1, 5), w0);
+
+    Wire w;
+    auto plan = sweep(st, hashes(4, 9), w); // drop 1..3, add 6..9
+
+    ASSERT_EQ(w.msgs.size(), 2u);
+    EXPECT_EQ(w.msgs[0].kind, Wire::Kind::have);
+    EXPECT_EQ(w.msgs[1].kind, Wire::Kind::losing);
+    EXPECT_EQ(std::set<uint256>(w.msgs[0].hashes.begin(), w.msgs[0].hashes.end()), hashes(6, 9));
+    EXPECT_EQ(std::set<uint256>(w.msgs[1].hashes.begin(), w.msgs[1].hashes.end()), hashes(1, 3));
+}
+
+// No hash is ever advertised twice across a long run of sweeps, and a hash that
+// is retracted and later re-learned IS advertised again (exactly once more).
+TEST(TxAdvertiser, NothingAdvertisedTwiceAndReLearnReAdvertises)
+{
+    TxAdvertState st;
+    std::vector<uint256> ever_advertised;
+
+    auto record = [&](Wire& w) {
+        for (const auto& h : w.all(Wire::Kind::have))
+            ever_advertised.push_back(h);
+    };
+
+    Wire a; sweep(st, hashes(1, 4), a); record(a);
+    Wire b; sweep(st, hashes(1, 4), b); record(b);   // no change
+    Wire c; sweep(st, hashes(3, 6), c); record(c);   // drop 1,2 add 5,6
+    Wire d; sweep(st, hashes(3, 6), d); record(d);   // no change
+
+    // 1,2,3,4 then 5,6 — six adverts, no duplicates.
+    EXPECT_EQ(ever_advertised.size(), 6u);
+    EXPECT_EQ(std::set<uint256>(ever_advertised.begin(), ever_advertised.end()).size(), 6u);
+
+    // Re-learn hash 1 (evicted at sweep c): it must be advertised again.
+    Wire e; sweep(st, hashes(1, 6), e); record(e);
+    const auto again = e.all(Wire::Kind::have);
+    ASSERT_EQ(again.size(), 2u);
+    EXPECT_EQ(std::set<uint256>(again.begin(), again.end()), hashes(1, 2));
+    EXPECT_EQ(ever_advertised.size(), 8u);
+}
+
+// Wire bound: a pool at exactly the cap is one message; cap+1 is two, and the
+// split is complete and non-overlapping (canonical fragments instead, p2p.py:230).
+TEST(TxAdvertiser, ChunkBoundaryExactAndOverflow)
+{
+    constexpr size_t cap = 4;
+
+    {
+        TxAdvertState st;
+        Wire w;
+        sweep(st, hashes(1, cap), w, cap);
+        ASSERT_EQ(w.msgs.size(), 1u);
+        EXPECT_EQ(w.msgs[0].hashes.size(), cap);
+    }
+    {
+        TxAdvertState st;
+        Wire w;
+        sweep(st, hashes(1, cap + 1), w, cap);
+        ASSERT_EQ(w.msgs.size(), 2u);
+        EXPECT_EQ(w.msgs[0].hashes.size(), cap);
+        EXPECT_EQ(w.msgs[1].hashes.size(), 1u);
+        const auto all = w.all(Wire::Kind::have);
+        EXPECT_EQ(std::set<uint256>(all.begin(), all.end()), hashes(1, cap + 1));
+    }
+    {
+        // Retractions chunk on the same bound.
+        TxAdvertState st;
+        Wire w0;
+        sweep(st, hashes(1, 9), w0, cap);
+        Wire w;
+        sweep(st, std::set<uint256>{}, w, cap);
+        EXPECT_EQ(w.count(Wire::Kind::have), 0u);
+        EXPECT_EQ(w.count(Wire::Kind::losing), 3u); // 4 + 4 + 1
+        EXPECT_EQ(w.all(Wire::Kind::losing).size(), 9u);
+    }
+}
+
+// The default cap is the canonical receive-side truncation bound (p2p.py:494),
+// so we never emit a message a canonical peer could not fully retain, and the
+// payload stays ~320 KB — far under canonical's 3 MiB max_payload (p2p.py:41).
+TEST(TxAdvertiser, DefaultChunkCapMatchesCanonicalReceiverBound)
+{
+    EXPECT_EQ(core::TX_ADVERT_MAX_HASHES_PER_MESSAGE, 10000u);
+    EXPECT_LE(core::TX_ADVERT_MAX_HASHES_PER_MESSAGE * 32u, 3145728u);
+    EXPECT_EQ(core::TX_ADVERT_INTERVAL_SECONDS, 10);
+}
+
+// chunk_tx_hashes never yields an empty chunk — an empty delta must produce no
+// message at all (canonical `if added:` / `if removed:` guards).
+TEST(TxAdvertiser, ChunkingNeverEmitsEmptyChunks)
+{
+    EXPECT_TRUE(chunk_tx_hashes({}, 10).empty());
+    const std::vector<uint256> one{H(1)};
+    const auto c = chunk_tx_hashes(one, 10);
+    ASSERT_EQ(c.size(), 1u);
+    EXPECT_EQ(c[0].size(), 1u);
+}
+
+// plan_tx_advert is pure: it must not mutate the state it inspects.
+TEST(TxAdvertiser, PlanIsPure)
+{
+    TxAdvertState st;
+    st.m_advertised = hashes(1, 3);
+    st.m_initial_sent = true;
+
+    const auto plan = plan_tx_advert(st, hashes(2, 5));
+
+    EXPECT_EQ(st.m_advertised, hashes(1, 3));
+    EXPECT_TRUE(st.m_initial_sent);
+    EXPECT_EQ(std::set<uint256>(plan.m_have.begin(), plan.m_have.end()), hashes(4, 5));
+    ASSERT_EQ(plan.m_losing.size(), 1u);
+    EXPECT_EQ(plan.m_losing[0], H(1));
+}

--- a/src/core/tx_advertiser.hpp
+++ b/src/core/tx_advertiser.hpp
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Send side of the p2pool `have_tx` / `losing_tx` tx-pool advertisement.
+//
+// c2pool has always been RECEIVE-ONLY for these two messages: every coin lane
+// ingests a peer's `have_tx` into Peer::m_remote_txs (and drops on `losing_tx`),
+// but never advertises its OWN known-tx set. The visible consequence is that
+// every canonical p2pool dashboard renders a c2pool peer with txpool = 0 while
+// real p2pool nodes report 12k-16k, and remember_tx forwarding is less efficient
+// than it should be because peers cannot tell which txs we already hold.
+//
+// ── Canonical semantics being mirrored ──────────────────────────────────────
+// Reference: p2pool python fork, p2pool/p2p.py (Protocol.connectionMade →
+// _think / post-handshake block):
+//
+//   p2p.py:276  self.send_have_tx(tx_hashes=self.node.known_txs_var.value.keys())
+//                 — one FULL advert of the current known-tx set, immediately
+//                   after the version handshake completes.
+//   p2p.py:243-248  known_txs_var.added   → send_have_tx(list(added))
+//   p2p.py:250-259  known_txs_var.removed → send_losing_tx(list(removed))
+//   p2p.py:261-274  known_txs_var.transitioned → send_have_tx(added) THEN
+//                                                send_losing_tx(removed)
+//
+// So canonical p2pool sends DELTAS against the per-peer view established by the
+// initial full advert. It has no explicit per-peer "advertised" set because the
+// reactive VariableDict hands it the delta directly; the per-peer view is
+// (full set at handshake) + (every subsequent delta). c2pool has no reactive
+// variable, so an explicit per-peer advertised set (TxAdvertState, parked on the
+// coin's Peer struct next to the existing m_remote_txs) reconstructs exactly the
+// same sequence of messages.
+//
+// Cadence: canonical fires on the change EVENT, and the events are themselves
+// naturally batched — additions arrive one work-refresh at a time and removals
+// arrive from node.py's `forget_old_txs` RobustLoopingCall, started at
+// node.py:298 with t.start(10), i.e. a 10-second sweep. c2pool therefore drives
+// the delta sweep from a 10-second timer (TX_ADVERT_INTERVAL_SECONDS) rather
+// than firing per inbound remember_tx: same eventual per-peer view, strictly
+// fewer and larger messages than canonical, and no way for a burst of inbound
+// txs to turn into a burst of outbound adverts.
+//
+// Size bound: canonical wraps oversized sends in p2p.py:230 `fragment()`, which
+// recursively halves a payload that raises p2protocol.TooLong (the 3 MiB
+// max_payload of p2p.py:41). Rather than reproduce the throw/retry, we chunk
+// up-front at TX_ADVERT_MAX_HASHES_PER_MESSAGE = 10000 hashes -> ~320 KB, which
+// is an order of magnitude under the canonical 3 MiB ceiling and is exactly the
+// bound canonical itself applies to the RECEIVING side of have_tx
+// (p2p.py:494-495 truncates remote_tx_hashes to 10000), so a larger chunk could
+// never be fully retained by the peer anyway.
+//
+// REWARD-SAFETY: advertisement only. Nothing here reads or writes consensus
+// state, share validation, subsidy, coinbase, payee, or the won-block path. A
+// have_tx/losing_tx message carries tx HASHES only and never affects which
+// shares verify or what a block pays.
+
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <set>
+#include <vector>
+
+#include <core/uint256.hpp>
+
+namespace core {
+
+// Max tx hashes per have_tx / losing_tx message. Mirrors the canonical
+// receive-side cap (p2p.py:494 truncates remote_tx_hashes to 10000) and keeps
+// every emitted payload ~320 KB, far under canonical's 3 MiB max_payload.
+inline constexpr std::size_t TX_ADVERT_MAX_HASHES_PER_MESSAGE = 10000;
+
+// Delta-sweep cadence in seconds. Mirrors node.py:298 forget_old_txs t.start(10).
+inline constexpr int TX_ADVERT_INTERVAL_SECONDS = 10;
+
+// What one sweep would put on the wire for one peer.
+struct TxAdvertPlan
+{
+    std::vector<uint256> m_have;   // newly known -> have_tx
+    std::vector<uint256> m_losing; // no longer known -> losing_tx
+
+    bool empty() const { return m_have.empty() && m_losing.empty(); }
+};
+
+// Per-peer reconstruction of "what this peer believes we hold". Lives on the
+// coin's Peer struct alongside m_remote_txs (which is the mirror image: what the
+// peer told US it holds).
+struct TxAdvertState
+{
+    std::set<uint256> m_advertised;
+    bool m_initial_sent{false};
+};
+
+// Pure diff: current known-tx hash set vs what the peer has already been told.
+// `current` may be any ordered/unordered set of uint256 supporting find()/end().
+template <typename HashSet>
+inline TxAdvertPlan plan_tx_advert(const TxAdvertState& state, const HashSet& current)
+{
+    TxAdvertPlan plan;
+    for (const auto& h : current)
+        if (state.m_advertised.find(h) == state.m_advertised.end())
+            plan.m_have.push_back(h);
+    for (const auto& h : state.m_advertised)
+        if (current.find(h) == current.end())
+            plan.m_losing.push_back(h);
+    return plan;
+}
+
+// Fold a committed plan into the per-peer view.
+inline void commit_tx_advert(TxAdvertState& state, const TxAdvertPlan& plan)
+{
+    for (const auto& h : plan.m_have)
+        state.m_advertised.insert(h);
+    for (const auto& h : plan.m_losing)
+        state.m_advertised.erase(h);
+    state.m_initial_sent = true;
+}
+
+// Split a hash list into wire-sized chunks (see TX_ADVERT_MAX_HASHES_PER_MESSAGE).
+// An empty input yields no chunks — we never emit an empty message.
+inline std::vector<std::vector<uint256>>
+chunk_tx_hashes(const std::vector<uint256>& hashes, std::size_t max_per_message)
+{
+    std::vector<std::vector<uint256>> out;
+    if (hashes.empty() || max_per_message == 0)
+        return out;
+    for (std::size_t i = 0; i < hashes.size(); i += max_per_message)
+    {
+        const std::size_t n = std::min(max_per_message, hashes.size() - i);
+        out.emplace_back(hashes.begin() + i, hashes.begin() + i + n);
+    }
+    return out;
+}
+
+// Drive one advert sweep for one peer.
+//
+// Computes the delta, emits it through the coin-specific senders in canonical
+// order (have_tx before losing_tx, p2p.py:264-267), chunked to the wire bound,
+// and folds the result into `state`. Returns the plan so callers can log/test.
+//
+// send_have / send_losing are invoked as f(const std::vector<uint256>&) once per
+// chunk and are never called with an empty vector. They MUST NOT throw; a coin
+// wrapper that can fail should swallow and let the next sweep retry (the state
+// is only committed after the senders return).
+template <typename HashSet, typename SendHave, typename SendLosing>
+inline TxAdvertPlan run_tx_advert(TxAdvertState& state, const HashSet& current,
+                                  SendHave&& send_have, SendLosing&& send_losing,
+                                  std::size_t max_per_message = TX_ADVERT_MAX_HASHES_PER_MESSAGE)
+{
+    TxAdvertPlan plan = plan_tx_advert(state, current);
+
+    // Canonical sends nothing when a change event carries no entries
+    // (p2p.py:244 `if added:` / p2p.py:251 `if removed:`). The one exception is
+    // the handshake advert (p2p.py:276), which canonical issues unconditionally
+    // — including with an empty tx_hashes list — so a peer that has just
+    // connected always learns our (possibly empty) view exactly once.
+    const bool initial = !state.m_initial_sent;
+    if (plan.empty() && !initial)
+        return plan;
+
+    if (initial && plan.m_have.empty())
+    {
+        send_have(std::vector<uint256>{});
+    }
+    else
+    {
+        for (const auto& chunk : chunk_tx_hashes(plan.m_have, max_per_message))
+            send_have(chunk);
+    }
+    for (const auto& chunk : chunk_tx_hashes(plan.m_losing, max_per_message))
+        send_losing(chunk);
+
+    commit_tx_advert(state, plan);
+    return plan;
+}
+
+} // namespace core

--- a/src/core/tx_advertiser.hpp
+++ b/src/core/tx_advertiser.hpp
@@ -38,14 +38,41 @@
 // fewer and larger messages than canonical, and no way for a burst of inbound
 // txs to turn into a burst of outbound adverts.
 //
-// Size bound: canonical wraps oversized sends in p2p.py:230 `fragment()`, which
-// recursively halves a payload that raises p2protocol.TooLong (the 3 MiB
-// max_payload of p2p.py:41). Rather than reproduce the throw/retry, we chunk
-// up-front at TX_ADVERT_MAX_HASHES_PER_MESSAGE = 10000 hashes -> ~320 KB, which
-// is an order of magnitude under the canonical 3 MiB ceiling and is exactly the
-// bound canonical itself applies to the RECEIVING side of have_tx
-// (p2p.py:494-495 truncates remote_tx_hashes to 10000), so a larger chunk could
-// never be fully retained by the peer anyway.
+// ── Write-safety bound: ONE MESSAGE PER PEER PER SWEEP ──────────────────────
+// This is a HARD constraint imposed by c2pool's socket layer, not by canonical.
+//
+// core::Socket::write (core/socket.cpp:110-137) starts a composed
+// boost::asio::async_write IMMEDIATELY — there is NO outbound queue. Asio's
+// contract forbids initiating a second composed write on a descriptor before the
+// first completes: two overlapping composed writes interleave their
+// async_write_some continuations FIFO per descriptor, so any write larger than
+// the kernel send buffer that overlaps another write splices bytes INTO THE
+// MIDDLE of the other message. The result is a framing/checksum error and the
+// canonical peer drops us.
+//
+// The advertiser is the first systematic large-burst writer in the tree, so it
+// must not rely on a queue that does not exist yet:
+//
+//   1. A sweep emits AT MOST ONE message to a given peer. Never a chunk burst,
+//      never have_tx immediately followed by losing_tx.
+//   2. A message carries at most TX_ADVERT_MAX_HASHES_PER_MESSAGE hashes, sized
+//      so the whole payload comfortably fits a single write_some on a fresh
+//      socket (see the constant).
+//   3. Only what was ACTUALLY emitted is committed to the per-peer view, so the
+//      remainder is recomputed and sent by the next sweep. A 10k-tx pool simply
+//      converges over ~100 s of sweeps instead of one multi-chunk burst — which
+//      is indistinguishable to a canonical peer, since have_tx is advisory.
+//
+// Canonical solves the same size problem differently: p2p.py:230 `fragment()`
+// recursively halves a payload that raises p2protocol.TooLong (against the 3 MiB
+// max_payload of p2p.py:41). We cannot use that shape, because fragment() emits
+// the halves BACK-TO-BACK — exactly the overlapping-write pattern our socket
+// layer cannot survive. Spreading across sweeps is the queue-free equivalent.
+//
+// FOLLOW-UP (deliberately NOT done here): the proper fix is an outbound write
+// queue in core::Socket, which would also cure the PRE-EXISTING violation in the
+// share-broadcast path (dash/node.cpp:1290/1301/1307 issues three back-to-back
+// writes) for every coin. That is a core change needing its own review.
 //
 // REWARD-SAFETY: advertisement only. Nothing here reads or writes consensus
 // state, share validation, subsidy, coinbase, payee, or the won-block path. A
@@ -54,8 +81,9 @@
 
 #pragma once
 
-#include <chrono>
+#include <algorithm>
 #include <cstddef>
+#include <iterator>
 #include <set>
 #include <vector>
 
@@ -63,15 +91,27 @@
 
 namespace core {
 
-// Max tx hashes per have_tx / losing_tx message. Mirrors the canonical
-// receive-side cap (p2p.py:494 truncates remote_tx_hashes to 10000) and keeps
-// every emitted payload ~320 KB, far under canonical's 3 MiB max_payload.
-inline constexpr std::size_t TX_ADVERT_MAX_HASHES_PER_MESSAGE = 10000;
+// Max tx hashes in a single have_tx / losing_tx message.
+//
+// 1000 hashes = 32000 bytes of payload (plus a 3-byte list varint and the
+// packet header) ~= 32 KB. That is comfortably inside a single write_some on a
+// fresh socket even at the conservative end of default kernel send-buffer
+// sizing, which is what keeps this write from overlapping the next one in the
+// absence of an outbound queue (see the header comment).
+//
+// Canonical's own receive side truncates its view of a peer's tx set at 10000
+// hashes (p2p.py:494-495), so this is well inside anything a canonical peer
+// would retain, and two orders of magnitude under canonical's 3 MiB max_payload
+// (p2p.py:41). MUST stay <= 2000 — larger risks a partial write_some and the
+// interleaving described above.
+inline constexpr std::size_t TX_ADVERT_MAX_HASHES_PER_MESSAGE = 1000;
 
 // Delta-sweep cadence in seconds. Mirrors node.py:298 forget_old_txs t.start(10).
 inline constexpr int TX_ADVERT_INTERVAL_SECONDS = 10;
 
-// What one sweep would put on the wire for one peer.
+// A set of hashes destined for the wire. Used both for the FULL outstanding
+// delta (plan_tx_advert) and for the truncated subset a single sweep actually
+// emits (run_tx_advert's return value).
 struct TxAdvertPlan
 {
     std::vector<uint256> m_have;   // newly known -> have_tx
@@ -91,6 +131,7 @@ struct TxAdvertState
 
 // Pure diff: current known-tx hash set vs what the peer has already been told.
 // `current` may be any ordered/unordered set of uint256 supporting find()/end().
+// Does NOT mutate `state`.
 template <typename HashSet>
 inline TxAdvertPlan plan_tx_advert(const TxAdvertState& state, const HashSet& current)
 {
@@ -104,72 +145,81 @@ inline TxAdvertPlan plan_tx_advert(const TxAdvertState& state, const HashSet& cu
     return plan;
 }
 
-// Fold a committed plan into the per-peer view.
-inline void commit_tx_advert(TxAdvertState& state, const TxAdvertPlan& plan)
+// Fold an EMITTED plan into the per-peer view. Only ever called with hashes that
+// actually reached the socket — committing more than was sent is a permanent
+// per-peer desync, because the un-sent remainder would never resurface in a
+// later diff.
+inline void commit_tx_advert(TxAdvertState& state, const TxAdvertPlan& emitted)
 {
-    for (const auto& h : plan.m_have)
+    for (const auto& h : emitted.m_have)
         state.m_advertised.insert(h);
-    for (const auto& h : plan.m_losing)
+    for (const auto& h : emitted.m_losing)
         state.m_advertised.erase(h);
     state.m_initial_sent = true;
 }
 
-// Split a hash list into wire-sized chunks (see TX_ADVERT_MAX_HASHES_PER_MESSAGE).
-// An empty input yields no chunks — we never emit an empty message.
-inline std::vector<std::vector<uint256>>
-chunk_tx_hashes(const std::vector<uint256>& hashes, std::size_t max_per_message)
-{
-    std::vector<std::vector<uint256>> out;
-    if (hashes.empty() || max_per_message == 0)
-        return out;
-    for (std::size_t i = 0; i < hashes.size(); i += max_per_message)
-    {
-        const std::size_t n = std::min(max_per_message, hashes.size() - i);
-        out.emplace_back(hashes.begin() + i, hashes.begin() + i + n);
-    }
-    return out;
-}
-
 // Drive one advert sweep for one peer.
 //
-// Computes the delta, emits it through the coin-specific senders in canonical
-// order (have_tx before losing_tx, p2p.py:264-267), chunked to the wire bound,
-// and folds the result into `state`. Returns the plan so callers can log/test.
+// Emits AT MOST ONE message (see the write-safety bound in the header comment):
+// the first `max_per_message` outstanding have_tx hashes if there are any,
+// otherwise the first `max_per_message` outstanding losing_tx hashes. Additions
+// therefore always precede retractions across sweeps, preserving canonical's
+// have-before-losing ordering (p2p.py:264-267). Whatever is left over is
+// recomputed from scratch by the next sweep, so nothing is lost and nothing is
+// sent twice.
 //
-// send_have / send_losing are invoked as f(const std::vector<uint256>&) once per
-// chunk and are never called with an empty vector. They MUST NOT throw; a coin
-// wrapper that can fail should swallow and let the next sweep retry (the state
-// is only committed after the senders return).
+// Returns the subset that was ACTUALLY emitted (and committed).
+//
+// send_have / send_losing are invoked as f(const std::vector<uint256>&) at most
+// once each, and at most one of the two per call. They MUST NOT throw; the state
+// is only committed after the sender returns.
 template <typename HashSet, typename SendHave, typename SendLosing>
 inline TxAdvertPlan run_tx_advert(TxAdvertState& state, const HashSet& current,
                                   SendHave&& send_have, SendLosing&& send_losing,
                                   std::size_t max_per_message = TX_ADVERT_MAX_HASHES_PER_MESSAGE)
 {
-    TxAdvertPlan plan = plan_tx_advert(state, current);
+    // A zero budget can emit nothing, so it must also COMMIT nothing — otherwise
+    // the per-peer view would record hashes that never reached the wire and the
+    // diff would never resurface them (permanent desync). Fail closed.
+    if (max_per_message == 0)
+        return {};
+
+    const TxAdvertPlan outstanding = plan_tx_advert(state, current);
+    const bool initial = !state.m_initial_sent;
 
     // Canonical sends nothing when a change event carries no entries
     // (p2p.py:244 `if added:` / p2p.py:251 `if removed:`). The one exception is
     // the handshake advert (p2p.py:276), which canonical issues unconditionally
     // — including with an empty tx_hashes list — so a peer that has just
     // connected always learns our (possibly empty) view exactly once.
-    const bool initial = !state.m_initial_sent;
-    if (plan.empty() && !initial)
-        return plan;
+    if (outstanding.empty() && !initial)
+        return {};
 
-    if (initial && plan.m_have.empty())
+    TxAdvertPlan emitted;
+    if (!outstanding.m_have.empty())
     {
-        send_have(std::vector<uint256>{});
+        const auto n = static_cast<std::ptrdiff_t>(
+            std::min(max_per_message, outstanding.m_have.size()));
+        emitted.m_have.assign(outstanding.m_have.begin(),
+                              std::next(outstanding.m_have.begin(), n));
+        send_have(emitted.m_have);
+    }
+    else if (!outstanding.m_losing.empty())
+    {
+        const auto n = static_cast<std::ptrdiff_t>(
+            std::min(max_per_message, outstanding.m_losing.size()));
+        emitted.m_losing.assign(outstanding.m_losing.begin(),
+                                std::next(outstanding.m_losing.begin(), n));
+        send_losing(emitted.m_losing);
     }
     else
     {
-        for (const auto& chunk : chunk_tx_hashes(plan.m_have, max_per_message))
-            send_have(chunk);
+        // initial && nothing outstanding: the unconditional p2p.py:276 advert.
+        send_have(std::vector<uint256>{});
     }
-    for (const auto& chunk : chunk_tx_hashes(plan.m_losing, max_per_message))
-        send_losing(chunk);
 
-    commit_tx_advert(state, plan);
-    return plan;
+    commit_tx_advert(state, emitted);
+    return emitted;
 }
 
 } // namespace core

--- a/src/core/tx_advertiser.hpp
+++ b/src/core/tx_advertiser.hpp
@@ -38,41 +38,52 @@
 // fewer and larger messages than canonical, and no way for a burst of inbound
 // txs to turn into a burst of outbound adverts.
 //
-// ── Write-safety bound: ONE MESSAGE PER PEER PER SWEEP ──────────────────────
+// ── Write-safety: ONE MESSAGE PER PEER, AND NEVER TWO IN FLIGHT ─────────────
 // This is a HARD constraint imposed by c2pool's socket layer, not by canonical.
 //
 // core::Socket::write (core/socket.cpp:110-137) starts a composed
 // boost::asio::async_write IMMEDIATELY — there is NO outbound queue. Asio's
 // contract forbids initiating a second composed write on a descriptor before the
 // first completes: two overlapping composed writes interleave their
-// async_write_some continuations FIFO per descriptor, so any write larger than
-// the kernel send buffer that overlaps another write splices bytes INTO THE
-// MIDDLE of the other message. The result is a framing/checksum error and the
-// canonical peer drops us.
+// async_write_some continuations FIFO per descriptor, so a write that needs more
+// than one round splices bytes INTO THE MIDDLE of the other message. The result
+// is a framing/checksum error and the canonical peer drops us.
 //
-// The advertiser is the first systematic large-burst writer in the tree, so it
-// must not rely on a queue that does not exist yet:
+// Note what that does NOT say: it is not about fitting in one write_some. A
+// ~32 KB framed message needs >= 2 rounds at the Linux default tcp_wmem[1] of
+// 16384, and that is fine — a multi-round write is only dangerous if ANOTHER
+// write is initiated while it drains. So the invariants are about exclusivity,
+// not about message size:
 //
-//   1. A sweep emits AT MOST ONE message to a given peer. Never a chunk burst,
-//      never have_tx immediately followed by losing_tx.
-//   2. A message carries at most TX_ADVERT_MAX_HASHES_PER_MESSAGE hashes, sized
-//      so the whole payload comfortably fits a single write_some on a fresh
-//      socket (see the constant).
+//   1. ONE MESSAGE PER SWEEP per peer. Never a chunk burst, never have_tx
+//      immediately followed by losing_tx. Nothing else is written to that peer
+//      in the same event, so within a sweep there is exactly one write.
+//   2. ONE MESSAGE IN FLIGHT per peer. A sweep is not the same thing as a
+//      completed write: if the next sweep fired while the previous advert was
+//      still draining (fresh socket, high RTT, or a stalled/zero-window peer),
+//      it would initiate the overlapping write anyway. TX_ADVERT_MIN_EMIT_
+//      INTERVAL_SECONDS enforces a minimum gap between emits to the SAME peer,
+//      which closes that window without needing a completion callback.
 //   3. Only what was ACTUALLY emitted is committed to the per-peer view, so the
-//      remainder is recomputed and sent by the next sweep. A 10k-tx pool simply
-//      converges over ~100 s of sweeps instead of one multi-chunk burst — which
-//      is indistinguishable to a canonical peer, since have_tx is advisory.
+//      remainder is recomputed and sent by a later sweep. A 10k-tx pool simply
+//      converges over ~100 s instead of one multi-chunk burst — which is
+//      indistinguishable to a canonical peer, since have_tx is advisory.
 //
-// Canonical solves the same size problem differently: p2p.py:230 `fragment()`
+// TX_ADVERT_MAX_HASHES_PER_MESSAGE then exists to bound the message, not to
+// guarantee a single round: it keeps per-write cost and per-peer memory
+// predictable and stays far inside what a canonical peer will accept.
+//
+// Canonical solves the size problem differently: p2p.py:230 `fragment()`
 // recursively halves a payload that raises p2protocol.TooLong (against the 3 MiB
 // max_payload of p2p.py:41). We cannot use that shape, because fragment() emits
 // the halves BACK-TO-BACK — exactly the overlapping-write pattern our socket
 // layer cannot survive. Spreading across sweeps is the queue-free equivalent.
 //
 // FOLLOW-UP (deliberately NOT done here): the proper fix is an outbound write
-// queue in core::Socket, which would also cure the PRE-EXISTING violation in the
-// share-broadcast path (dash/node.cpp:1290/1301/1307 issues three back-to-back
-// writes) for every coin. That is a core change needing its own review.
+// queue in core::Socket, which would make both guards unnecessary and would also
+// cure the PRE-EXISTING violation in the share-broadcast path
+// (dash/node.cpp:1290/1301/1307 issues three back-to-back writes) for every
+// coin. That is a core change needing its own review.
 //
 // REWARD-SAFETY: advertisement only. Nothing here reads or writes consensus
 // state, share validation, subsidy, coinbase, payee, or the won-block path. A
@@ -82,6 +93,7 @@
 #pragma once
 
 #include <algorithm>
+#include <chrono>
 #include <cstddef>
 #include <iterator>
 #include <set>
@@ -93,21 +105,41 @@ namespace core {
 
 // Max tx hashes in a single have_tx / losing_tx message.
 //
-// 1000 hashes = 32000 bytes of payload (plus a 3-byte list varint and the
-// packet header) ~= 32 KB. That is comfortably inside a single write_some on a
-// fresh socket even at the conservative end of default kernel send-buffer
-// sizing, which is what keeps this write from overlapping the next one in the
-// absence of an outbound queue (see the header comment).
+// 1000 hashes = 32000 bytes of payload plus a 3-byte list varint and the packet
+// header, ~32 KB on the wire. This does NOT fit a single write_some on a typical
+// Linux socket (default tcp_wmem[1] = 16384, so >= 2 rounds) and it does not need
+// to: a multi-round write is safe as long as no OTHER write is initiated while it
+// drains, which is what the one-message-per-sweep rule and
+// TX_ADVERT_MIN_EMIT_INTERVAL_SECONDS guarantee (see the header comment).
 //
-// Canonical's own receive side truncates its view of a peer's tx set at 10000
-// hashes (p2p.py:494-495), so this is well inside anything a canonical peer
-// would retain, and two orders of magnitude under canonical's 3 MiB max_payload
-// (p2p.py:41). MUST stay <= 2000 — larger risks a partial write_some and the
-// interleaving described above.
+// The bound exists to keep the message SIZE predictable — bounded per-write cost,
+// bounded per-peer memory, and a drain time short enough that the min-emit
+// interval is never the limiting factor. Canonical's own receive side truncates
+// its view of a peer's tx set at 10000 hashes (p2p.py:494-495), so this is well
+// inside anything a canonical peer would retain, and two orders of magnitude
+// under canonical's 3 MiB max_payload (p2p.py:41).
 inline constexpr std::size_t TX_ADVERT_MAX_HASHES_PER_MESSAGE = 1000;
 
 // Delta-sweep cadence in seconds. Mirrors node.py:298 forget_old_txs t.start(10).
 inline constexpr int TX_ADVERT_INTERVAL_SECONDS = 10;
+
+// Minimum gap between two emits to the SAME peer.
+//
+// One message per SWEEP is not one message IN FLIGHT. If the sweep timer fires
+// while a previous advert to that peer is still draining, core::Socket::write
+// would initiate a second composed write and the two can interleave (see the
+// header comment). The realistic window is the ~1-RTT period right after the
+// handshake advert on a fresh socket, or any time against a stalled/zero-window
+// peer; without this guard the odds are roughly drain_time/sweep_interval per
+// handshake (~1% at 100 ms RTT). The consequence is a bad checksum -> canonical
+// disconnect -> reconnect with fresh per-peer state: self-healing, no ban, not
+// reward-affecting, but a real defect.
+//
+// 5 s is half the sweep cadence, so in steady state (sweeps 10 s apart) this
+// never suppresses anything; it only ever suppresses a sweep that lands right on
+// top of the direct handshake advert. Suppressed hashes are NOT lost — nothing
+// was committed for them, so the next sweep recomputes and sends them.
+inline constexpr int TX_ADVERT_MIN_EMIT_INTERVAL_SECONDS = 5;
 
 // A set of hashes destined for the wire. Used both for the FULL outstanding
 // delta (plan_tx_advert) and for the truncated subset a single sweep actually
@@ -127,6 +159,11 @@ struct TxAdvertState
 {
     std::set<uint256> m_advertised;
     bool m_initial_sent{false};
+    // When we last put a message on this peer's socket. Default-constructed
+    // (epoch) means "never emitted", which always passes the min-interval guard
+    // so a freshly handshaked peer is advertised to immediately. IO-thread-local
+    // — it is only ever read and written from the sweep, so it needs no locking.
+    std::chrono::steady_clock::time_point m_last_emit{};
 };
 
 // Pure diff: current known-tx hash set vs what the peer has already been told.
@@ -160,13 +197,22 @@ inline void commit_tx_advert(TxAdvertState& state, const TxAdvertPlan& emitted)
 
 // Drive one advert sweep for one peer.
 //
-// Emits AT MOST ONE message (see the write-safety bound in the header comment):
-// the first `max_per_message` outstanding have_tx hashes if there are any,
-// otherwise the first `max_per_message` outstanding losing_tx hashes. Additions
-// therefore always precede retractions across sweeps, preserving canonical's
-// have-before-losing ordering (p2p.py:264-267). Whatever is left over is
-// recomputed from scratch by the next sweep, so nothing is lost and nothing is
-// sent twice.
+// Emits AT MOST ONE message (see the write-safety section in the header
+// comment): the first `max_per_message` outstanding have_tx hashes if there are
+// any, otherwise the first `max_per_message` outstanding losing_tx hashes.
+// Additions therefore always precede retractions across sweeps, preserving
+// canonical's have-before-losing ordering (p2p.py:264-267). Whatever is left
+// over is recomputed from scratch by the next sweep, so nothing is lost and
+// nothing is sent twice.
+//
+// Emits NOTHING if this peer was advertised to less than `min_interval` ago —
+// one message per sweep is not one message in flight, and initiating a second
+// composed write while the previous one still drains is exactly the interleaving
+// hazard. Suppression is free: nothing is committed, so the same delta is simply
+// recomputed on the following sweep.
+//
+// `now` is injected so the KATs can drive the interval deterministically; in
+// production callers pass a single steady_clock::now() taken once per sweep.
 //
 // Returns the subset that was ACTUALLY emitted (and committed).
 //
@@ -174,14 +220,26 @@ inline void commit_tx_advert(TxAdvertState& state, const TxAdvertPlan& emitted)
 // once each, and at most one of the two per call. They MUST NOT throw; the state
 // is only committed after the sender returns.
 template <typename HashSet, typename SendHave, typename SendLosing>
-inline TxAdvertPlan run_tx_advert(TxAdvertState& state, const HashSet& current,
-                                  SendHave&& send_have, SendLosing&& send_losing,
-                                  std::size_t max_per_message = TX_ADVERT_MAX_HASHES_PER_MESSAGE)
+inline TxAdvertPlan run_tx_advert(
+    TxAdvertState& state, const HashSet& current,
+    SendHave&& send_have, SendLosing&& send_losing,
+    std::size_t max_per_message = TX_ADVERT_MAX_HASHES_PER_MESSAGE,
+    std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now(),
+    std::chrono::seconds min_interval =
+        std::chrono::seconds(TX_ADVERT_MIN_EMIT_INTERVAL_SECONDS))
 {
     // A zero budget can emit nothing, so it must also COMMIT nothing — otherwise
     // the per-peer view would record hashes that never reached the wire and the
     // diff would never resurface them (permanent desync). Fail closed.
     if (max_per_message == 0)
+        return {};
+
+    // Min-emit interval: never start a second write to this peer while the
+    // previous one may still be draining. A default-constructed m_last_emit
+    // means "never emitted" and always passes, so a freshly handshaked peer is
+    // advertised to immediately. Nothing is committed on the suppressed path.
+    if (state.m_last_emit != std::chrono::steady_clock::time_point{} &&
+        now - state.m_last_emit < min_interval)
         return {};
 
     const TxAdvertPlan outstanding = plan_tx_advert(state, current);
@@ -219,6 +277,10 @@ inline TxAdvertPlan run_tx_advert(TxAdvertState& state, const HashSet& current,
     }
 
     commit_tx_advert(state, emitted);
+    // Stamp AFTER the send: this is the "a message is on this peer's socket"
+    // marker the interval guard above keys on. The unconditional empty
+    // handshake advert counts — it is a real write like any other.
+    state.m_last_emit = now;
     return emitted;
 }
 

--- a/src/impl/dash/node.cpp
+++ b/src/impl/dash/node.cpp
@@ -4,6 +4,8 @@
 #include "mint_runloop.hpp"   // dash::mint::elect_best_share (election policy SSOT)
 #include "known_txs_retention.hpp"  // dash::retain_template_txs / all_txs_backable (F1/F3)
 
+#include <cassert>
+
 #include <core/uint256.hpp>
 #include <core/common.hpp>
 #include <core/random.hpp>
@@ -1385,6 +1387,18 @@ uint256 NodeImpl::add_local_share(ShareType share)
 void NodeImpl::register_template_txs(const std::vector<coin::Transaction>& txs,
                                      const std::vector<uint256>& hashes)
 {
+    // THREAD-CONFINEMENT (enforced, not assumed): every m_known_txs mutator in
+    // this lane must run OFF the compute thread — the two remember_tx ingests
+    // (protocol_actual.cpp:263 / protocol_legacy.cpp:299) are IO-thread by
+    // construction, and so is this one (producer-job cache miss on the stratum
+    // path). advertise_known_txs() reads the map from the IO thread on exactly
+    // that basis. A compute-thread caller here would turn that read into a
+    // genuine data race, so trip loudly in debug builds rather than let it be
+    // discovered in production.
+    assert(!is_compute_thread() &&
+           "register_template_txs must not run on the compute thread — "
+           "m_known_txs is IO-thread-confined (see advertise_known_txs)");
+
     if (txs.size() != hashes.size()) {
         LOG_WARNING << "[register_template_txs] size mismatch txs=" << txs.size()
                     << " hashes=" << hashes.size() << " — skipped";

--- a/src/impl/dash/node.cpp
+++ b/src/impl/dash/node.cpp
@@ -829,6 +829,21 @@ void NodeImpl::start_outbound_connections()
     if (!m_context)
         return;  // rig-free (KAT/standalone) node
 
+    // ── have_tx / losing_tx delta sweep ──────────────────────────────────
+    // Started before the outbound-dialing early-return below: a node with
+    // outbound dialing disabled still accepts inbound peers and must still
+    // advertise its tx pool to them. Advert-only, no consensus state.
+    m_tx_advert_timer = std::make_unique<core::Timer>(m_context, true);
+    m_tx_advert_timer->start(core::TX_ADVERT_INTERVAL_SECONDS,
+                             [this]() { advertise_known_txs(); });
+
+    // ── canonical addr-discovery sweep (p2p.py:794-799) ──────────────────
+    // Also started before the dialing early-return: an inbound-only node needs to
+    // learn addresses. Self-limiting — getaddrs_sweep() is a no-op once the
+    // AddrStore reaches PREFERRED_ADDR_STORAGE (1000) or while we have no peers.
+    m_getaddrs_timer = std::make_unique<core::Timer>(m_context, true);
+    m_getaddrs_timer->start(20, [this]() { getaddrs_sweep(); });
+
     // Advert-drain pump: handle_version (inline, link-free for the KAT
     // targets) only QUEUES a peer's advertised best share; this timer is the
     // node.cpp-side consumer that turns the queue into sharereq dispatches.

--- a/src/impl/dash/node.hpp
+++ b/src/impl/dash/node.hpp
@@ -33,6 +33,7 @@
 #include <pool/protocol.hpp>
 #include <pool/share_download.hpp>  // shared downloader helpers (#754)
 #include <core/reply_matcher.hpp>
+#include <core/tx_advertiser.hpp>
 #include <c2pool/storage/sharechain_storage.hpp>
 
 #include <boost/asio/thread_pool.hpp>
@@ -297,6 +298,16 @@ protected:
     size_t m_max_peers = 30;
     size_t m_target_outbound_peers = DEFAULT_TARGET_OUTBOUND_PEERS;
     std::unique_ptr<core::Timer> m_connect_timer;   // 30s dial maintenance
+    // Periodic have_tx/losing_tx delta sweep (core/tx_advertiser.hpp). Cadence
+    // mirrors the canonical known-tx removal loop, node.py:298 t.start(10).
+    std::unique_ptr<core::Timer> m_tx_advert_timer;
+    // Canonical addr-discovery sweep timer (p2p.py:794-799). Flat 20 s, the
+    // mean of canonical's random.expovariate(1/20) re-arm.
+    std::unique_ptr<core::Timer> m_getaddrs_timer;
+    // Canonical p2p.py:759 preferred_storage default: stop asking for more
+    // addresses once the store holds this many. Keeps the AddrStore bounded
+    // well under the pool/node.hpp got_addr() hard cap of 10000.
+    static constexpr size_t PREFERRED_ADDR_STORAGE = 1000;
     std::unique_ptr<core::Timer> m_advert_timer;    // 2s best-advert drain
     std::set<NetService> m_pending_outbound;  // addresses currently being dialed
     std::set<NetService> m_outbound_addrs;    // established outbound peers
@@ -626,6 +637,23 @@ public:
         m_peer_count.store(m_peers.size(), std::memory_order_relaxed);
         publish_peer_info_snapshot();   // IO thread: refresh the display snapshot
 
+        // Canonical p2p.py:276 — one FULL have_tx as soon as the handshake
+        // completes, so the peer's view of our tx pool starts correct (and its
+        // dashboard stops showing us as txpool = 0). Subsequent sweeps send
+        // deltas only. Advert-only; no consensus/mint state touched.
+        advertise_known_txs(peer);
+
+        // Ask the freshly-handshaked peer for addresses. Straight port of the
+        // LTC reference (src/impl/ltc/node.cpp:309, also dgb node.cpp:318 /
+        // bch node.cpp:316 / btc node.cpp:316); count=8 is exactly canonical
+        // (p2p.py:797 send_getaddrs(count=8)). DASH never sent this, so its
+        // AddrStore only ever held the configured --addnode/--connect seeds and
+        // the node had ZERO organic peer discovery. The reply lands in the
+        // existing HANDLER(addrs) -> got_addr() path, which is already bounded
+        // (pool/node.hpp got_addr caps the store at 10000). Discovery only; no
+        // consensus/mint state touched.
+        peer->write(dash::message_getaddrs::make_raw(8));
+
         // #754 join trigger (oracle p2p.py handle_version → node.py
         // handle_share_hashes): a peer advertising a best share we don't have
         // is THE download entry point for an empty node joining an
@@ -816,6 +844,115 @@ public:
     /// from the run loop after listen(). Body in node.cpp (ltc
     /// node.cpp:1289-1327 port).
     void start_outbound_connections();
+
+    // ── have_tx / losing_tx advertisement (SEND side) ─────────────────────
+    // c2pool was RECEIVE-ONLY for the p2pool tx-pool advertisement: the
+    // protocol handlers ingest a peer's have_tx/losing_tx into
+    // Peer::m_remote_txs, but we never advertised our OWN known-tx set. Every
+    // canonical p2pool dashboard therefore rendered this node with txpool = 0
+    // (real p2pool peers report 12k-16k), and peers could not tell which txs we
+    // already hold, so remember_tx forwarded whole tx bodies needlessly.
+    //
+    // Canonical (p2pool python, p2pool/p2p.py): ONE full have_tx immediately
+    // after the version handshake (p2p.py:276), then pure deltas off the
+    // known_txs_var change events — added -> send_have_tx (p2p.py:243-248),
+    // removed -> send_losing_tx (p2p.py:250-259), transitioned -> both in that
+    // order (p2p.py:261-274). c2pool has no reactive variable, so
+    // Peer::m_tx_advert reconstructs the per-peer view and each sweep emits the
+    // diff; the sweep cadence mirrors node.py:298's 10s forget_old_txs loop.
+    // See core/tx_advertiser.hpp for the full derivation and the wire bound.
+    //
+    // Header-inline on purpose: the DASH handle_version vtable body must stay
+    // link-free for the rig-free KAT targets, and this touches only
+    // header-only message types plus peer->write.
+    //
+    // REWARD-SAFETY: tx hashes only. No consensus, share validation, subsidy,
+    // coinbase, payee or won-block state is read or written here.
+    void advertise_known_txs(peer_ptr only_peer = nullptr)
+    {
+        // m_known_txs is mutated by the COMPUTE thread inside prune_shares()
+        // (core::evict_known_txs_to_cap) under the exclusive tracker lock. This
+        // runs on the IO thread, so take the same NON-BLOCKING shared lock the
+        // other IO-thread readers use (the #828 freed-memory GP-fault class)
+        // and simply skip if the compute thread is mid-cycle — the next sweep
+        // carries the identical delta 10s later.
+        std::set<uint256> current;
+        {
+            std::shared_lock<std::shared_mutex> lk(m_tracker_mutex, std::try_to_lock);
+            if (!lk.owns_lock())
+                return;
+            for (const auto& entry : m_known_txs)
+                current.insert(entry.first);
+        }
+
+        auto advertise_one = [&current](const peer_ptr& p)
+        {
+            if (!p)
+                return;
+            core::run_tx_advert(
+                p->m_tx_advert, current,
+                [&p](const std::vector<uint256>& hashes)
+                { p->write(dash::message_have_tx::make_raw(hashes)); },
+                [&p](const std::vector<uint256>& hashes)
+                { p->write(dash::message_losing_tx::make_raw(hashes)); });
+        };
+
+        if (only_peer)
+        {
+            advertise_one(only_peer);
+            return;
+        }
+        // m_peers is IO-thread-owned and mutated only on this thread
+        // (handle_version insert / error() erase), so plain iteration is safe.
+        for (auto& entry : m_peers)
+            advertise_one(entry.second);
+    }
+
+    /// Broadcast a new best-block notification to every connected pool peer.
+    /// Straight port of the LTC reference (src/impl/ltc/node.hpp:316-320; same
+    /// body in dgb node.hpp:339 / btc node.hpp:320 / bch node.hpp:562), which
+    /// DASH lacked entirely. Canonical trigger is node.py:137-140
+    /// (`best_block_header.changed` -> `peer.send_bestblock(header=header)` for
+    /// every peer), i.e. one message per NEW COIN TIP — on DASH that is ~1 per
+    /// 2.5 min, and the caller (main_dash.cpp) fires it only through the
+    /// already-deduped tip-notify path, so a poll+ZMQ double-observation of the
+    /// same block cannot double-send.
+    ///
+    /// The peer-side HANDLER(bestblock) deliberately does NOT relay
+    /// (protocol_actual.cpp:197), so this cannot amplify across the network.
+    ///
+    /// IO-THREAD ONLY (reads the IO-owned m_peers). Advert-only: no consensus,
+    /// share validation, subsidy, coinbase, payee or won-block state.
+    void broadcast_bestblock(const coin::BlockHeaderType& header)
+    {
+        for (auto& entry : m_peers)
+            if (entry.second)
+                entry.second->write(dash::message_bestblock::make_raw(header));
+    }
+
+    /// Periodic address-discovery sweep. Canonical p2p.py:794-799 (Node._think,
+    /// driven by deferral.run_repeatedly): when the addr store is below
+    /// `preferred_storage` (p2p.py:759 default 1000) and we have any peers, ask
+    /// ONE randomly chosen peer for 8 addresses. Canonical re-arms with
+    /// random.expovariate(1/20) (mean 20 s); core::Timer has no exponential
+    /// jitter, so we use a flat 20 s — same mean, strictly bounded tail.
+    ///
+    /// This is the only piece here with no existing c2pool precedent (LTC/DGB/
+    /// BCH/BTC send getaddrs on handshake only), so it is deliberately the most
+    /// conservative shape possible: one 4-byte request per 20 s to one peer,
+    /// and it stops entirely once the store reaches 1000 entries. Discovery
+    /// only; no consensus/mint state.
+    void getaddrs_sweep()
+    {
+        if (m_peers.empty())
+            return;
+        if (m_addrs.len() >= PREFERRED_ADDR_STORAGE)
+            return; // canonical `len(self.addr_store) < self.preferred_storage`
+        auto it = m_peers.begin();
+        std::advance(it, core::random::random_int(0, static_cast<int>(m_peers.size())));
+        if (it != m_peers.end() && it->second)
+            it->second->write(dash::message_getaddrs::make_raw(8));
+    }
 
     void set_target_outbound_peers(size_t count) { m_target_outbound_peers = count; }
     void set_max_peers(size_t count) { m_max_peers = count; }

--- a/src/impl/dash/node.hpp
+++ b/src/impl/dash/node.hpp
@@ -656,11 +656,13 @@ public:
         // ORDERING IS LOAD-BEARING: this is the LARGEST write the handshake
         // issues (up to TX_ADVERT_MAX_HASHES_PER_MESSAGE hashes, ~32 KB) and it
         // goes LAST. core::Socket::write starts a composed async_write with no
-        // outbound queue (core/socket.cpp:110-137), so a large write that
-        // overlaps a later one would interleave bytes mid-message and get us
-        // dropped on a bad checksum. The tiny getaddrs above (~28 bytes) drains
-        // in a single write_some before this one begins issuing continuations.
-        // See core/tx_advertiser.hpp for the full write-safety rationale.
+        // outbound queue (core/socket.cpp:110-137), so initiating another write
+        // while one is still draining interleaves bytes mid-message and gets us
+        // dropped on a bad checksum. Going last means NOTHING follows it in this
+        // handler; the ~32 KB advert may well take several write_some rounds,
+        // which is harmless precisely because nothing else is queued behind it,
+        // and the per-peer min-emit interval keeps the next timer sweep from
+        // landing on top of it. See core/tx_advertiser.hpp.
         advertise_known_txs(peer);
 
         // #754 join trigger (oracle p2p.py handle_version → node.py
@@ -903,7 +905,13 @@ public:
                 current.insert(entry.first);
         }
 
-        auto advertise_one = [&current](const peer_ptr& p)
+        // One clock reading for the whole sweep: run_tx_advert uses it both to
+        // apply the per-peer min-emit interval (never two writes in flight on
+        // one socket) and to stamp the peer after a send. IO-thread-local, so
+        // Peer::m_tx_advert needs no locking.
+        const auto now = std::chrono::steady_clock::now();
+
+        auto advertise_one = [&current, now](const peer_ptr& p)
         {
             if (!p)
                 return;
@@ -912,7 +920,8 @@ public:
                 [&p](const std::vector<uint256>& hashes)
                 { p->write(dash::message_have_tx::make_raw(hashes)); },
                 [&p](const std::vector<uint256>& hashes)
-                { p->write(dash::message_losing_tx::make_raw(hashes)); });
+                { p->write(dash::message_losing_tx::make_raw(hashes)); },
+                core::TX_ADVERT_MAX_HASHES_PER_MESSAGE, now);
         };
 
         if (only_peer)

--- a/src/impl/dash/node.hpp
+++ b/src/impl/dash/node.hpp
@@ -637,12 +637,6 @@ public:
         m_peer_count.store(m_peers.size(), std::memory_order_relaxed);
         publish_peer_info_snapshot();   // IO thread: refresh the display snapshot
 
-        // Canonical p2p.py:276 — one FULL have_tx as soon as the handshake
-        // completes, so the peer's view of our tx pool starts correct (and its
-        // dashboard stops showing us as txpool = 0). Subsequent sweeps send
-        // deltas only. Advert-only; no consensus/mint state touched.
-        advertise_known_txs(peer);
-
         // Ask the freshly-handshaked peer for addresses. Straight port of the
         // LTC reference (src/impl/ltc/node.cpp:309, also dgb node.cpp:318 /
         // bch node.cpp:316 / btc node.cpp:316); count=8 is exactly canonical
@@ -653,6 +647,21 @@ public:
         // (pool/node.hpp got_addr caps the store at 10000). Discovery only; no
         // consensus/mint state touched.
         peer->write(dash::message_getaddrs::make_raw(8));
+
+        // Canonical p2p.py:276 — one FULL have_tx as soon as the handshake
+        // completes, so the peer's view of our tx pool starts correct (and its
+        // dashboard stops showing us as txpool = 0). Subsequent sweeps send
+        // deltas only. Advert-only; no consensus/mint state touched.
+        //
+        // ORDERING IS LOAD-BEARING: this is the LARGEST write the handshake
+        // issues (up to TX_ADVERT_MAX_HASHES_PER_MESSAGE hashes, ~32 KB) and it
+        // goes LAST. core::Socket::write starts a composed async_write with no
+        // outbound queue (core/socket.cpp:110-137), so a large write that
+        // overlaps a later one would interleave bytes mid-message and get us
+        // dropped on a bad checksum. The tiny getaddrs above (~28 bytes) drains
+        // in a single write_some before this one begins issuing continuations.
+        // See core/tx_advertiser.hpp for the full write-safety rationale.
+        advertise_known_txs(peer);
 
         // #754 join trigger (oracle p2p.py handle_version → node.py
         // handle_share_hashes): a peer advertising a best share we don't have
@@ -870,12 +879,21 @@ public:
     // coinbase, payee or won-block state is read or written here.
     void advertise_known_txs(peer_ptr only_peer = nullptr)
     {
-        // m_known_txs is mutated by the COMPUTE thread inside prune_shares()
-        // (core::evict_known_txs_to_cap) under the exclusive tracker lock. This
-        // runs on the IO thread, so take the same NON-BLOCKING shared lock the
-        // other IO-thread readers use (the #828 freed-memory GP-fault class)
-        // and simply skip if the compute thread is mid-cycle — the next sweep
-        // carries the identical delta 10s later.
+        // THREAD-CONFINEMENT INVARIANT: every m_known_txs mutator in the DASH
+        // lane runs on the IO thread — the two remember_tx ingests
+        // (protocol_actual.cpp:263, protocol_legacy.cpp:299) and
+        // register_template_txs() -> dash::retain_template_txs(). Unlike the
+        // LTC/DGB/BCH/BTC lanes there is NO compute-thread evictor here:
+        // prune_shares() / core::evict_known_txs_to_cap do not exist in this
+        // lane. This sweep is also IO-thread, so the map is same-thread-safe.
+        //
+        // The shared try-lock below is therefore DEFENSIVE, not load-bearing for
+        // m_known_txs: it keeps this reader inside the established #828
+        // discipline for anything tracker-adjacent, and it is what a future
+        // compute-thread evictor would need. Do NOT read it as evidence that one
+        // exists — if you add one, this lock becomes required, not optional.
+        // try_to_lock, never block: if the compute thread is mid-cycle we skip
+        // and the next sweep carries the identical delta 10 s later.
         std::set<uint256> current;
         {
             std::shared_lock<std::shared_mutex> lk(m_tracker_mutex, std::try_to_lock);

--- a/src/impl/dash/peer.hpp
+++ b/src/impl/dash/peer.hpp
@@ -21,6 +21,7 @@
 #include <set>
 #include <string>
 
+#include <core/tx_advertiser.hpp>
 #include <core/uint256.hpp>
 
 namespace dash
@@ -39,6 +40,12 @@ struct Peer
     // === remembered-transaction protocol state ===
     std::set<uint256> m_remote_txs;                       // hashes the remote peer has advertised
     std::map<uint256, coin::Transaction> m_remembered_txs; // full txs keyed by hash
+
+    // Send side of the tx-pool advertisement: our reconstruction of what this
+    // peer believes WE hold, so each sweep can emit only the delta as
+    // have_tx / losing_tx. Mirror image of m_remote_txs above (what the peer
+    // told us IT holds). See core/tx_advertiser.hpp for canonical semantics.
+    core::TxAdvertState m_tx_advert;
 };
 
 }; // namespace dash


### PR DESCRIPTION
## What

The DASH pool node was **receive-only for four canonical p2pool messages**. It handled inbound `have_tx`, `losing_tx`, `getaddrs` and `bestblock`, but `make_raw` for all four was **zero occurrences** in the DASH lane. This PR implements the send side for all four.

Observed live:

* every canonical p2pool dashboard rendered the DASH node with **txpool = 0** (real p2pool peers report 12,089–16,657), and peers could not tell which txs we already hold, so `remember_tx` forwarded whole tx bodies needlessly;
* **zero organic peer discovery** — the AddrStore only ever held the configured `--addnode`/`--connect` seeds, so the node sat at exactly the seed count;
* peers never learned our view of the dash tip.

Cross-coin state before this PR:

| message | ltc | dgb | bch | btc | dash |
|---|---|---|---|---|---|
| `getaddrs` send | yes | yes | yes | yes | **no** |
| `bestblock` send | yes | yes | yes | yes | **no** |
| `have_tx` send | no | no | no | no | **no** |
| `losing_tx` send | no | no | no | no | **no** |

`getaddrs` and `bestblock` are straight ports of the proven LTC implementation (live on the LTC+DOGE line). `have_tx`/`losing_tx` had no implementation in any coin, so canonical python is the reference there. The remaining `have_tx`/`losing_tx` gap in ltc/dgb/bch/btc is a follow-up PR reusing the same shared helper.

## Canonical semantics mirrored

**`have_tx` / `losing_tx`** — `p2pool/p2p.py`:

| ref | behaviour |
|---|---|
| `p2p.py:276` | `send_have_tx(tx_hashes=self.node.known_txs_var.value.keys())` — one **full** advert right after the version handshake, unconditional (an empty pool still announces once) |
| `p2p.py:243-248` | `known_txs_var.added` → `send_have_tx(added)` |
| `p2p.py:250-259` | `known_txs_var.removed` → `send_losing_tx(removed)` |
| `p2p.py:261-274` | `transitioned` → `send_have_tx(added)` **then** `send_losing_tx(removed)` |
| `node.py:298` | `forget_old_txs` `RobustLoopingCall` `t.start(10)` — the canonical removal cadence |
| `p2p.py:494-495` | receiver truncates its view of a peer's tx set at 10000 hashes |
| `p2p.py:41` / `p2p.py:230` | 3 MiB `max_payload`; `fragment()` recursively halves an oversized send |

Canonical has no explicit per-peer "advertised" set — the reactive `VariableDict` hands it the delta directly, so the per-peer view is *(full set at handshake) + (every subsequent delta)*. c2pool has no reactive variable, so `Peer::m_tx_advert` (a `core::TxAdvertState`, parked next to the existing `m_remote_txs`) reconstructs exactly the same sequence of messages.

**`getaddrs`** — `p2p.py:794-799` (`Node._think`, `deferral.run_repeatedly`):

```python
if len(self.addr_store) < self.preferred_storage and self.peers:
    random.choice(self.peers.values()).send_getaddrs(count=8)
...
return random.expovariate(1/20)
```

`preferred_storage` defaults to 1000 (`p2p.py:759`).

**`bestblock`** — `node.py:137-140`:

```python
@self.node.best_block_header.changed.watch
def _(header):
    for peer in self.peers.itervalues():
        peer.send_bestblock(header=header)
```

## LTC references ported

| what | LTC reference |
|---|---|
| handshake `getaddrs`, `count=8` | `src/impl/ltc/node.cpp:309` (same shape at `dgb/node.cpp:318`, `bch/node.cpp:316`, `btc/node.cpp:316`) |
| `broadcast_bestblock(header)` | `src/impl/ltc/node.hpp:316-320` (same at `dgb/node.hpp:339`, `btc/node.hpp:320`, `bch/node.hpp:562`) |

## Implementation

**`src/core/tx_advertiser.hpp` (new, shared)** — the delta model, coin-agnostic:

* `TxAdvertState` — per-peer `advertised` set + `initial_sent` flag, lives on `dash::Peer`.
* `plan_tx_advert()` — pure diff of the current known-tx hash set against the per-peer view.
* `run_tx_advert()` — emits the plan through coin-supplied senders in canonical order (have before losing), chunked, then commits.
* Bounds: `TX_ADVERT_MAX_HASHES_PER_MESSAGE = 10000` (~320 KB), which is exactly the bound canonical applies to the *receiving* side (`p2p.py:494`) and an order of magnitude under canonical's 3 MiB `max_payload`, so a larger chunk could never be fully retained by a canonical peer anyway. Rather than reproduce canonical's throw/retry `fragment()`, we chunk up front.
* Cadence: `TX_ADVERT_INTERVAL_SECONDS = 10`, mirroring `node.py:298`.

**Why a timer instead of firing per change**: canonical fires on the change *event*, and its events are already batched (additions per work refresh, removals from the 10 s `forget_old_txs` loop). c2pool has no such event, so a 10 s sweep gives the identical eventual per-peer view with **strictly fewer and larger messages than canonical**, and no way for a burst of inbound txs to become a burst of outbound adverts. It also makes `losing_tx` retraction accurate against the template-window eviction in `known_txs_retention.hpp` **without touching that code**.

**`src/impl/dash/node.hpp`**
* `advertise_known_txs(peer = nullptr)` — snapshot + sweep (one peer on handshake, all peers on the timer).
* `broadcast_bestblock(header)` — LTC port.
* `getaddrs_sweep()` — canonical periodic discovery, gated on `m_addrs.len() < 1000` and non-empty peers, one random peer, `count=8`.
* handshake now sends the initial full `have_tx` (`p2p.py:276`) and `getaddrs(8)` (LTC `node.cpp:309`).
* All header-inline, because the DASH `handle_version` vtable body must stay link-free for the rig-free KAT targets.

**`src/impl/dash/node.cpp`** — starts the two timers in `start_outbound_connections()`, after the `if (!m_context) return;` rig-free guard and before the `target=0` dialing early-return (an inbound-only node still needs both).

**`src/c2pool/main_dash.cpp`** — `announce_bestblock` wired into the **existing, already-deduped** tip-notify choke point `fire_refresh` (shared by the 3 s `getbestblockhash` poll and the opt-in ZMQ `hashblock` path). No new tip source was invented. One `getblockheader <tip> false` per new tip on the dedicated `rpc_pool` thread (never the io thread), parsed and broadcast back on `ioc`.

## Bounds and conservatism (this ships to a live node)

* `have_tx`/`losing_tx`: at most one sweep per peer per 10 s, and only when the set actually changed. Chunked at 10000 hashes.
* `getaddrs`: one 4-byte request per 20 s to **one** peer, and it stops entirely once the AddrStore reaches 1000. The reply path is the pre-existing `got_addr()`, already hard-capped at 10000.
* `bestblock`: exactly one per genuinely new dashd tip (~1 per 2.5 min on DASH). A poll+ZMQ double-observation of the same block cannot double-send (shared `is_new_tip` dedup). A short header (`!= 160` hex chars) is refused rather than sent. The peer-side handler deliberately does **not** relay (`protocol_actual.cpp:197`), so this cannot amplify across the network.
* Every failure path is swallowed and self-healing: a skipped sweep re-emits the identical delta 10 s later; a failed `getblockheader` is re-announced on the next tip.

## Threading (corrected — was factually wrong in the first revision)

All sends happen on the `io_context` thread.

**The DASH lane has no compute-thread `m_known_txs` mutator at all.** `prune_shares()` / `core::evict_known_txs_to_cap` do **not exist** in this lane — they are LTC/DGB/BCH/BTC-only. Every DASH mutator is IO-thread:

* `protocol_actual.cpp:263` (remember_tx ingest)
* `protocol_legacy.cpp:299` (remember_tx ingest)
* `register_template_txs()` → `retain_template_txs()` (producer-job cache miss, stratum path)

So the sweep's read is **same-thread-safe by confinement**, not by the lock. The shared try-lock is **defensive**: it keeps the reader inside the established #828 discipline for anything tracker-adjacent, and it is what a future compute-thread evictor would need. The code comment now says exactly this, so nobody "restores" a compute-thread evictor believing the lock already covers it.

To make the invariant enforced rather than assumed, `register_template_txs()` now asserts it is off the compute thread. (Release strips the assert, so it was syntax-checked separately with `NDEBUG` off.)

*(The first revision of this PR claimed `prune_shares`/`evict_known_txs_to_cap` as the compute-thread mutator and asked the reviewer to confirm IO-confinement. Review verified the confinement holds and is in fact stronger than claimed; the comment and this section are corrected accordingly.)*

## Write-safety: one message per peer, and never two in flight

`core::Socket::write` (`core/socket.cpp:110-137`) starts a composed `boost::asio::async_write` **immediately — there is no outbound queue**. Asio forbids initiating a second composed write on a descriptor before the first completes: two overlapping composed writes interleave their `async_write_some` continuations FIFO per descriptor, so a write that needs more than one round splices bytes **into the middle** of the other message → framing/checksum garbage → the canonical peer drops us.

Note what that does *not* say: **it is not about fitting in one `write_some`.** A ~32 KB framed message needs ≥2 rounds at the Linux default `tcp_wmem[1]` of 16384, and that is fine — a multi-round write is only dangerous if *another* write is initiated while it drains. The invariants are about exclusivity, not size:

1. **One message per sweep, per peer.** Never a chunk burst, never `have_tx` immediately followed by `losing_tx`. Additions drain first, retractions follow on later sweeps — canonical's have-before-losing ordering (`p2p.py:264-267`) preserved across sweeps.
2. **One message in flight, per peer.** A sweep is not a completed write. If the 10 s timer fires while the previous advert is still draining, the overlapping write happens anyway. `TX_ADVERT_MIN_EMIT_INTERVAL_SECONDS = 5` enforces a minimum gap between emits to the same peer, closing that window without needing a completion callback. Realistic exposure without it: the ~1-RTT window right after the handshake advert on a fresh socket, or any stalled/zero-window peer — roughly `drain_time / sweep_interval` per handshake (~1% at 100 ms RTT).
3. **Only what was actually emitted is committed**, so the remainder — including everything a suppressed sweep would have sent — is recomputed by the next sweep. A 10k-tx pool converges over ~100 s instead of one burst; indistinguishable to a canonical peer, since `have_tx` is advisory.
4. **`handle_version` issues the advert LAST**, after the tiny `getaddrs`. Nothing follows it in that handler.
5. **Fails closed on a zero budget**: it can emit nothing, so it commits nothing.

`TX_ADVERT_MAX_HASHES_PER_MESSAGE = 1000` therefore exists to bound the message, **not** to guarantee a single round: predictable per-write cost and per-peer memory, and a drain time short enough that the 5 s min-emit interval is never the limiting factor. It stays far inside canonical's receiver truncation (10000, `p2p.py:494`) and its 3 MiB `max_payload` (`p2p.py:41`).

Canonical solves the size problem with `fragment()` (`p2p.py:230`), which recursively halves an oversized payload. We cannot mirror that shape *because* it emits the halves back-to-back — exactly the pattern this socket layer cannot survive. Spreading across sweeps is the queue-free equivalent.

**Why the min-interval guard over dropping the direct handshake advert** (the reviewer's stated alternative): it keeps the canonical `p2p.py:276` shape — advert immediately on handshake, zero txpool-view latency — and is strictly local: one `steady_clock::time_point` on the peer struct, one comparison, IO-thread-local, no locking, no timer changes. Dropping the handshake advert would have traded a real behavioural divergence from canonical for no additional safety. 5 s is half the sweep cadence, so steady state is never throttled; it only ever suppresses a sweep landing on top of the handshake advert.

## Reward-safety

**Advertisement and discovery only.** No consensus, share validation, subsidy, coinbase, payee, mint or won-block state is read or written on any of these paths:

* `have_tx`/`losing_tx` carry tx **hashes** only — they cannot affect which shares verify or what a block pays.
* `getaddrs`/`addrs` touch only the AddrStore.
* `bestblock` is a read of dashd's tip header plus a socket write; it does not touch the template, the share chain, the mint path, the coinbase/payee, or the won-block dispatch.
* No receive-side handler behaviour is changed.
* `--selftest` (X11 PoW KATs, subsidy, masternode payment split) passes unchanged.

## Tests

16 KATs in `src/core/test/tx_advertiser_test.cpp`, **folded into the existing allowlisted `core_test` target** (no new `add_executable` — that is the #769 "Not Run" trap; `core_test` is on the `--target` list at `build.yml:144` and `:331`):

* first advert sends everything; unconditional single empty advert on an empty pool
* unchanged pool sends nothing (5 consecutive sweeps)
* second advert sends only the delta
* eviction emits `losing_tx` with exactly the removed hashes
* mixed delta sends have **before** losing (adds this sweep, retractions the next)
* nothing advertised twice across a long run; a retracted-then-re-learned hash *is* re-advertised
* **one message per sweep, committing only the emitted subset**
* **the remainder drains over subsequent sweeps — nothing sent twice, nothing dropped**
* **`losing_tx` is budgeted the same way and drains only after `have_tx`**
* **zero budget emits nothing and commits nothing** (no permanent desync)
* default bound is inside canonical's receiver truncation and `max_payload`, and the min-emit interval is a real gap not exceeding the sweep cadence (this KAT no longer asserts the false single-`write_some` guarantee)
* **a sweep inside the min-emit interval emits nothing, commits nothing, and leaves the stamp untouched — the suppressed hashes appear on the next eligible sweep**
* **steady-state 10 s cadence is never throttled by the guard**
* **a suppressed first call does not consume the unconditional handshake advert**
* `plan_tx_advert` is pure

The harness drives a monotonic virtual clock so the interval guard never fires incidentally in the KATs that exercise delta logic; the guard itself is driven with explicit instants.

## Local build + test

```
cmake -DCOIN_DASH=ON ...            configure OK
cmake --build --target c2pool-dash  OK
cmake --build --target core_test    OK
core_test                           89/89 pass (16 TxAdvertiser)
ctest -R 'Dash|dash'                687/687 pass, 100%, 0 failures
c2pool-dash --selftest              OK - CoinParams + X11 PoW + subsidy conform to oracle
tools/ci/check_test_target_allowlist.py
                                    OK - 118 targets across 5 lanes all allowlisted
register_template_txs assert        syntax-checked with -UNDEBUG (Release strips it)
```

## Follow-ups (deliberately NOT implemented here)

* **Outbound write queue in `core::Socket`.** The real fix for the overlapping-composed-write hazard. It would also cure a **pre-existing** violation for every coin: the share-broadcast path (`dash/node.cpp:1290/1301/1307`) already issues three back-to-back writes. Core change, needs its own review. This PR only makes the advertiser safe under the current queue-free socket.
* **Unbounded `m_known_txs` peer-ingest leak.** `protocol_actual.cpp:262-263` inserts every peer-forwarded tx body, but the only eviction removes a hash when it leaves a retained *template* set — so a never-templated peer ingest is never erased. Canonical bounds this via `node.py:290-298` `forget_old_txs`. The per-message cap here contains the wire-side symptom; the leak itself is a separate fix.
* **Canonical's 20 s `known_txs_cache`** (`p2p.py:250-259`) covering the eviction→`losing_tx` latency window. Verified benign for us.
* **`bestblock` is wired only under the dashd-fallback arm** (`main_dash.cpp:2615`, inside `if (!coin_p2p && rpc && stratum_server)`). The embedded/`--coin-p2p` arm never announces — it has `header_chain->set_on_tip_changed` available and could be wired there, but that arm is not the production path today.
* **`have_tx`/`losing_tx` for ltc/dgb/bch/btc** — #850, reusing this helper unchanged.
* **The canonical periodic `getaddrs` sweep** (`p2p.py:794-799`) is implemented here for DASH but is absent from every other coin; worth back-porting once this soaks.

## Reviewer note

The one deliberate step beyond a pure LTC mirror is the periodic `getaddrs` sweep. LTC sends `getaddrs` on handshake only; canonical also runs the 20 s sweep, and the sweep is what keeps discovery going after the initial seeds are exhausted. It is bounded to one request per 20 s and self-disables at 1000 stored addresses. Easy to drop if you want a strict LTC mirror instead — say the word.

Draft; not self-merging.