### PR TITLE
dash(stratum): push new work on sharechain tip change (fixes ~76% sibling/orphan rate)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -92,6 +92,8 @@
 #include <core/stratum_server.hpp>             // core::StratumServer — miner-facing accept-loop (run-path caller)
 #include <impl/dash/stratum/work_source.hpp>   // dash::stratum::DASHWorkSource — concrete core::stratum::IWorkSource
 #include <impl/dash/mint_runloop.hpp>          // dash::mint — run-loop share minting (slice 3/3)
+#include <impl/dash/stratum/tip_refresh.hpp>   // dash::stratum::fire_share_tip_refresh — bump + notify_all + dashboard refresh
+#include <impl/dash/local_mint_ledger.hpp>     // dash::mint::LocalMintLedger — display-only local orphan/sibling gauge
 #include <impl/dash/share_messages.hpp>        // dash::validate_message_data — operator message-blob validation (EMIT side, mirrors main_ltc.cpp)
 #include <c2pool/storage/found_block_store.hpp>  // FoundBlockStore/Record + LevelDBStore (persistence, main_ltc parity)
 #include <core/web_server.hpp>                 // core::WebServer — the EXISTING c2pool dashboard (same wiring main_ltc.cpp uses)
@@ -569,6 +571,14 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                   << " seed peer[s]); share-download leg ARMED\n";
 
 
+    // ── Local-mint orphan/sibling gauge (display only) ────────────────────
+    // Declared HERE (before the dashboard wiring) because two later blocks
+    // need it: the sharechain stats fn reads it, and the mint fn records into
+    // it. shared_ptr so both closures can hold it without lifetime coupling to
+    // this frame. Nothing consensus-visible reads this — see
+    // local_mint_ledger.hpp.
+    auto mint_ledger = std::make_shared<dash::mint::LocalMintLedger>();
+
     // ── DASH web dashboard standup (the EXISTING c2pool dashboard) ────────
     // This is main_ltc.cpp's WebServer wiring, reused verbatim where the DASH
     // side has a real source for the datum. No stub metrics are invented: a
@@ -748,7 +758,7 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             // tally + work-weighted sampling mirror what apply_min_protocol_ratchet
             // keys on (version_negotiation::get_desired_version_weights), so the
             // dashboard shows the SAME numbers the ratchet decides on.
-            mi->set_sharechain_stats_fn([node_ptr]() -> nlohmann::json {
+            mi->set_sharechain_stats_fn([node_ptr, mint_ledger]() -> nlohmann::json {
                 // Last-good cache (mirrors main_ltc.cpp's stats_fn): think() holds the
                 // tracker lock frequently during normal operation, and returning a
                 // 4-field snapshot then would make the transition gauge (which reads
@@ -766,6 +776,23 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 out["verified_count"] = snap.verified_count;
                 out["orphan_shares"]  = snap.orphan_shares;
                 out["dead_shares"]    = snap.dead_shares;
+
+                // ── Local-mint orphan/sibling gauge (display only) ─────────────
+                // snap.orphan_shares/dead_shares are the sharechain-wide StaleInfo
+                // tally, and every share WE mint is stamped StaleInfo::none — so a
+                // locally minted share that is verified and then loses the head
+                // race shows up in NEITHER. These fields answer the question those
+                // cannot: of the shares this node minted, how many are still on the
+                // best chain? Consensus-invisible (no StaleInfo stamping change).
+                {
+                    const auto lm = mint_ledger->stats();
+                    out["local_minted_shares"]   = lm.minted;
+                    out["local_on_chain_shares"] = lm.on_chain;
+                    out["local_orphan_shares"]   = lm.orphaned;
+                    out["local_pending_shares"]  = lm.pending;
+                    out["local_gone_shares"]     = lm.gone;
+                    out["local_orphan_rate"]     = lm.orphan_rate;
+                }
 
                 // Protocol-floor gauge inputs (v16→v36 crossing). The live accept-floor
                 // is the ratchet output (1700 pre-crossing → 3600 once ≥95% v36-weighted);
@@ -794,6 +821,13 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                         cached["fork_count"]     = snap.fork_count;
                         cached["min_protocol_version"]  = live_floor;
                         cached["live_share_version"]    = out["live_share_version"];
+                        // Local-mint gauge is lock-free (its own mutex) — always fresh.
+                        cached["local_minted_shares"]   = out["local_minted_shares"];
+                        cached["local_on_chain_shares"] = out["local_on_chain_shares"];
+                        cached["local_orphan_shares"]   = out["local_orphan_shares"];
+                        cached["local_pending_shares"]  = out["local_pending_shares"];
+                        cached["local_gone_shares"]     = out["local_gone_shares"];
+                        cached["local_orphan_rate"]     = out["local_orphan_rate"];
                         return cached;
                     }
                     out["chain_height"] = snap.chain_count;
@@ -1750,7 +1784,7 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         // commitment, deterministic producer rebuild (X11 identity gate +
         // pow<=target ban-safety gate inside), tracker insert + broadcast.
         work_source->set_mint_share_fn(
-            [node_ptr, mint_params, mint_registry](
+            [node_ptr, mint_params, mint_registry, mint_ledger](
                 const dash::stratum::DASHWorkSource::MintShareInputs& in) -> uint256
             {
                 if (in.ref_hash.IsNull()) {
@@ -1794,6 +1828,10 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 LOG_INFO << "[MINT] share " << minted.GetHex().substr(0, 16)
                          << " minted onto the sharechain (prev="
                          << in.prev_share_hash.GetHex().substr(0, 16) << ")";
+                // Display-only: remember what we minted so the best-share-changed
+                // leg below can tell us later whether it stayed on the best chain
+                // (see local_mint_ledger.hpp). Never gates the mint.
+                mint_ledger->record_mint(minted);
                 return minted;
             });
 
@@ -1818,15 +1856,56 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     guard->chain, mint_params, prev_share_hash, block_bits);
             });
 
-        // New best share -> stratum work refresh (sessions re-notify) AND a
+        // New best share -> PUSH new work to every stratum session, plus a
         // debounced dashboard work refresh, so /api tip + graphs move on the
         // real tip-change event (main_ltc.cpp:2768) rather than a poll timer.
+        //
+        // The notify_all() leg is the fix for the sibling/orphan defect: this
+        // callback used to only bump_work_generation(), which INVALIDATES the
+        // served payload but pushes nothing. Connected rigs therefore kept
+        // hashing the previous prev_share_hash until their per-session
+        // keepalive timer fired (StratumConfig::keepalive_notify_sec = 25 s,
+        // work_source.cpp; stratum_server.cpp idle-timer leg), and because the
+        // producer job_cache is keyed (prev_share_hash, payout_script) every
+        // solve in that window rebuilt the SAME frozen job -> a fan of siblings
+        // at one sharechain height instead of a linear chain. notify_all()
+        // issues send_notify_work(force_clean=true), i.e. clean_jobs=true, so
+        // the miner switches to the new prev_share immediately (p2pool
+        // behaviour) -- exactly what the coin-tip legs below already do
+        // (set_on_state_dirty, the coin-P2P tip leg, and fire_refresh).
+        //
+        // stratum_server is captured BY REFERENCE (the sibling lambda's style):
+        // the acceptor is constructed further down, and stays null under
+        // --stratum-port 0. fire_share_tip_refresh null-guards every leg.
+        //
+        // Reward-safety: a tip change means a NEW prev_share_hash -> a new
+        // job_cache key -> a fresh build_producer_job. No existing share's
+        // committed bytes are touched; we only stop re-serving a stale job.
         {
             core::WebServer* web = web_server.get();   // may be null (dashboard off)
             p2p_node.set_on_best_share_changed(
-                [ws = work_source.get(), web]() {
-                    ws->bump_work_generation();
-                    if (web) web->trigger_work_refresh_debounced();
+                [ws = work_source.get(), web, &stratum_server, node_ptr,
+                 mint_ledger]() {
+                    dash::stratum::fire_share_tip_refresh(
+                        ws, stratum_server.get(), web);
+
+                    // Display-only: settle the local-mint orphan gauge against
+                    // the new best chain. Runs AFTER the notify (miners first)
+                    // and on a try-lock read guard, so a busy tracker simply
+                    // defers the verdict to the next tip change.
+                    if (mint_ledger->pending_count() > 0) {
+                        auto guard = node_ptr->read_tracker();
+                        if (guard) {
+                            const uint256 best = node_ptr->snapshot_best_share();
+                            auto& chain = guard->chain;
+                            mint_ledger->settle(
+                                [&chain, &best](const uint256& h) {
+                                    return dash::mint::classify_local_mint(
+                                        chain, best, h,
+                                        dash::mint::LocalMintLedger::kSettleDepth);
+                                });
+                        }
+                    }
                 });
         }
 

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -3623,6 +3623,23 @@ nlohmann::json MiningInterface::rest_local_stats()
     }
     result["shares"] = {{"total", total_shares}, {"orphan", orphan_shares}, {"dead", dead_shares}};
 
+    // local_shares — fate of the shares THIS node minted (display only).
+    // shares{orphan,dead} above is the sharechain-wide StaleInfo tally, which
+    // by construction cannot see a locally minted share that was accepted and
+    // then lost the head race (we stamp StaleInfo::none on our own mints). A
+    // coin whose stats fn publishes the local-mint gauge (DASH) gets this extra
+    // object; every other coin's payload is byte-identical to before.
+    if (cached_sc.contains("local_minted_shares")) {
+        result["local_shares"] = {
+            {"minted",      cached_sc.value("local_minted_shares",   uint64_t(0))},
+            {"on_chain",    cached_sc.value("local_on_chain_shares", uint64_t(0))},
+            {"orphan",      cached_sc.value("local_orphan_shares",   uint64_t(0))},
+            {"pending",     cached_sc.value("local_pending_shares",  uint64_t(0))},
+            {"gone",        cached_sc.value("local_gone_shares",     uint64_t(0))},
+            {"orphan_rate", cached_sc.value("local_orphan_rate",     0.0)},
+        };
+    }
+
     // efficiency = valid / total (null if no shares)
     if (total_shares > 0) {
         int valid = total_shares - orphan_shares - dead_shares;

--- a/src/impl/dash/local_mint_ledger.hpp
+++ b/src/impl/dash/local_mint_ledger.hpp
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// ============================================================================
+// local_mint_ledger.hpp — display-only orphan/sibling gauge for LOCAL mints.
+//
+// Why this exists: /local_stats reported `orphan 0 / dead 0 / efficiency 1.0`
+// on a node that was in fact losing ~76% of the shares it minted to siblings.
+// Those numbers come from the sharechain-wide StaleInfo tally, and every share
+// this node mints is stamped StaleInfo::none (mint_runloop.hpp) — so a share
+// that is minted, broadcast, verified, and then simply LOSES the head race is
+// invisible in every existing counter. We were blind to a revenue-sized defect
+// for hours because of it.
+//
+// This ledger closes that hole from the other end: remember the hashes WE
+// minted, and once the best chain has grown `settle_depth` shares past one of
+// them, ask a single cheap question — is it still an ancestor of the best
+// share? If not, it is a sibling/orphan and it earns us nothing.
+//
+// Strictly display-only:
+//   * nothing here is consulted by share validation, mint contents, the
+//     coinbase, PPLNS weights, or the won-block path;
+//   * StaleInfo stamping is NOT touched (that IS consensus-visible);
+//   * the pending set is bounded (kMaxPending) and settle() is O(pending),
+//     driven off the existing best-share-changed event — no new timer.
+//
+// Header-only, fenced to src/impl/dash/, KAT-able with a fake chain.
+// ============================================================================
+
+#include <core/uint256.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <mutex>
+
+namespace dash::mint {
+
+/// Verdict for one locally minted share, as of the current best chain.
+enum class MintVerdict {
+    pending,    ///< best chain has not yet grown settle_depth past it
+    on_chain,   ///< still an ancestor of (or equal to) the best share
+    off_chain,  ///< a sibling/orphan — it lost the head race
+    gone        ///< no longer in the tracker (pruned/dropped) — unknowable
+};
+
+/// Classify one locally minted share against the current best share.
+///
+/// Cheap by construction: get_acc_height() is the cached O(1) TrackerView
+/// height and get_nth_parent_via_skip() is the O(log n) Bitcoin-Core skip-list
+/// walk — the same two primitives the producer walks already use. The caller
+/// holds the tracker read guard.
+template <typename ChainT>
+inline MintVerdict classify_local_mint(ChainT& chain,
+                                       const uint256& best_share,
+                                       const uint256& minted,
+                                       int32_t settle_depth)
+{
+    if (best_share.IsNull() || minted.IsNull())
+        return MintVerdict::pending;
+    if (!chain.contains(minted))
+        return MintVerdict::gone;          // pruned/dropped before it settled
+    if (!chain.contains(best_share))
+        return MintVerdict::pending;       // best not (yet) in this view
+
+    const int32_t minted_height = chain.get_acc_height(minted);
+    const int32_t best_height   = chain.get_acc_height(best_share);
+    if (minted_height <= 0 || best_height <= 0)
+        return MintVerdict::pending;       // heights not resolvable yet
+
+    const int32_t depth = best_height - minted_height;
+    if (depth < settle_depth)
+        return MintVerdict::pending;       // too shallow to call — reorg window
+
+    const uint256 ancestor = chain.get_nth_parent_via_skip(best_share, depth);
+    if (ancestor.IsNull())
+        return MintVerdict::pending;       // skip-list could not answer
+    return (ancestor == minted) ? MintVerdict::on_chain : MintVerdict::off_chain;
+}
+
+/// Bounded, thread-safe tally of locally minted shares and their fate.
+class LocalMintLedger
+{
+public:
+    /// Best-chain depth a mint must be buried under before we call it. Small
+    /// (the DASH sharechain reorgs shallowly) but non-zero so a share that is
+    /// merely NEWER than the published best share is never miscounted.
+    static constexpr int32_t kSettleDepth = 3;
+    /// Hard bound on the un-settled set (a stalled/looping settle can never
+    /// grow memory). Oldest entries are dropped and counted as `dropped`.
+    static constexpr std::size_t kMaxPending = 512;
+
+    struct Stats {
+        uint64_t minted   = 0;   ///< local mints recorded since start
+        uint64_t on_chain = 0;   ///< settled: still on the best chain
+        uint64_t orphaned = 0;   ///< settled: sibling/orphan (lost the race)
+        uint64_t gone     = 0;   ///< settled: left the tracker before verdict
+        uint64_t dropped  = 0;   ///< evicted un-settled (pending bound hit)
+        uint64_t pending  = 0;   ///< awaiting settle depth
+        /// orphaned / (orphaned + on_chain); 0.0 when nothing settled yet.
+        double   orphan_rate = 0.0;
+    };
+
+    /// Record a share this node just minted onto the sharechain.
+    void record_mint(const uint256& hash)
+    {
+        if (hash.IsNull()) return;
+        std::lock_guard<std::mutex> lk(m_mutex);
+        ++m_minted;
+        m_pending.push_back(hash);
+        while (m_pending.size() > kMaxPending) {
+            m_pending.pop_front();
+            ++m_dropped;
+        }
+    }
+
+    /// Settle every pending mint the classifier can now call. `classify` is
+    /// invoked once per pending entry and must be cheap (see
+    /// classify_local_mint). Safe to call as often as the tip moves.
+    template <typename ClassifyFn>
+    void settle(ClassifyFn classify)
+    {
+        std::lock_guard<std::mutex> lk(m_mutex);
+        for (auto it = m_pending.begin(); it != m_pending.end();) {
+            switch (classify(*it)) {
+            case MintVerdict::on_chain:  ++m_on_chain; it = m_pending.erase(it); break;
+            case MintVerdict::off_chain: ++m_orphaned; it = m_pending.erase(it); break;
+            case MintVerdict::gone:      ++m_gone;     it = m_pending.erase(it); break;
+            case MintVerdict::pending:   ++it;                                   break;
+            }
+        }
+    }
+
+    Stats stats() const
+    {
+        std::lock_guard<std::mutex> lk(m_mutex);
+        Stats s;
+        s.minted   = m_minted;
+        s.on_chain = m_on_chain;
+        s.orphaned = m_orphaned;
+        s.gone     = m_gone;
+        s.dropped  = m_dropped;
+        s.pending  = static_cast<uint64_t>(m_pending.size());
+        const uint64_t settled = m_on_chain + m_orphaned;
+        if (settled > 0)
+            s.orphan_rate = static_cast<double>(m_orphaned) / static_cast<double>(settled);
+        return s;
+    }
+
+    std::size_t pending_count() const
+    {
+        std::lock_guard<std::mutex> lk(m_mutex);
+        return m_pending.size();
+    }
+
+private:
+    mutable std::mutex     m_mutex;
+    std::deque<uint256>    m_pending;
+    uint64_t m_minted{0};
+    uint64_t m_on_chain{0};
+    uint64_t m_orphaned{0};
+    uint64_t m_gone{0};
+    uint64_t m_dropped{0};
+};
+
+} // namespace dash::mint

--- a/src/impl/dash/stratum/tip_refresh.hpp
+++ b/src/impl/dash/stratum/tip_refresh.hpp
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// ============================================================================
+// tip_refresh.hpp — the DASH "new work is available" fan-out, in ONE place.
+//
+// Every tip-change source on the DASH path (coin tip via ZMQ/poll, embedded
+// state-dirty, sharechain best-share advance) has to do the SAME three things,
+// in this order:
+//
+//   1. bump_work_generation()          — invalidate the served work payload so
+//                                        the next get_work/notify re-sources;
+//   2. notify_all()                    — PUSH mining.notify to every subscribed
+//                                        session with clean_jobs=true, so rigs
+//                                        drop the previous prev_share_hash job
+//                                        IMMEDIATELY (p2pool behaviour);
+//   3. trigger_work_refresh_debounced()— move the dashboard/graphs off the poll
+//                                        timer onto the real event.
+//
+// Step (2) is the one that was silently missing on the SHARECHAIN tip-change
+// leg: bump_work_generation() only invalidates a cache, it pushes nothing, so
+// connected rigs kept hashing the previous prev_share_hash until their per-
+// session keepalive timer fired (StratumConfig::keepalive_notify_sec, 25 s on
+// DASH). Because the producer job_cache is keyed (prev_share_hash, payout
+// script), every solve inside that window rebuilt the SAME frozen job — i.e.
+// siblings at one sharechain height instead of a linear chain.
+//
+// Display/liveness only: nothing here touches share bytes, the coinbase, the
+// payee, PPLNS math or the won-block path. A tip change means a NEW
+// prev_share_hash, hence a new job_cache key and a fresh build_producer_job —
+// no existing share's committed bytes can change.
+//
+// Templated on the three collaborators so the fan-out is KAT-able without a
+// live work source / stratum acceptor / dashboard (test_dash_stratum_notify_
+// roundtrip). Header-only, fenced to src/impl/dash/.
+// ============================================================================
+
+namespace dash::stratum {
+
+/// Fire the full new-work fan-out. Every leg is null-tolerant: the stratum
+/// acceptor is absent with --stratum-port 0 (and is constructed AFTER the
+/// sharechain callback is bound, so the call site passes it late), and the
+/// dashboard is absent when the web port is off.
+template <typename WorkSourceT, typename StratumServerT, typename WebServerT>
+inline void fire_share_tip_refresh(WorkSourceT* work_source,
+                                   StratumServerT* stratum_server,
+                                   WebServerT* web_server)
+{
+    if (work_source)    work_source->bump_work_generation();
+    if (stratum_server) stratum_server->notify_all();
+    if (web_server)     web_server->trigger_work_refresh_debounced();
+}
+
+} // namespace dash::stratum

--- a/test/test_dash_stratum_notify_roundtrip.cpp
+++ b/test/test_dash_stratum_notify_roundtrip.cpp
@@ -41,11 +41,14 @@
 
 #include <cstddef>
 #include <cstring>
+#include <map>
 #include <span>
 #include <string>
 #include <vector>
 
 #include <impl/dash/coinbase_builder.hpp>  // merkle_branches_raw, sha256d, EXTRANONCE2_SIZE
+#include <impl/dash/stratum/tip_refresh.hpp>   // fire_share_tip_refresh (tip-change fan-out)
+#include <impl/dash/local_mint_ledger.hpp>     // LocalMintLedger / classify_local_mint
 #include <btclibs/util/strencodings.h>     // HexStr
 #include <core/uint256.hpp>
 
@@ -225,4 +228,240 @@ TEST(DashStratumNotifyRoundtrip, GoldenAnchors) {
     EXPECT_EQ(coinbase_hash(E2_A).GetHex(),    GOLD_CBHASH_A);
     EXPECT_EQ(coinbase_hash(E2_B).GetHex(),    GOLD_CBHASH_B);
     EXPECT_EQ(merkle_branches_raw(leaves_with(coinbase_hash(E2_ZERO)))[1].GetHex(), GOLD_BRANCH1);
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Sharechain tip-change -> stratum PUSH fan-out, and the local-mint gauge.
+//
+// Same file/target as the notify wire-contract KATs above (allowlisted), one
+// step upstream: WHEN does a notify get pushed at all. The production defect
+// these pin: the sharechain best-share-changed callback only invalidated the
+// served payload (bump_work_generation) and never called notify_all(), so rigs
+// kept hashing the previous prev_share_hash until the 25 s keepalive timer
+// fired. The producer job_cache is keyed (prev_share_hash, payout_script), so
+// every solve inside that window rebuilt the SAME frozen job -> siblings at one
+// sharechain height (measured 4.13 shares/height, ~76% orphan) instead of a
+// linear chain.
+//
+// (a) fire_share_tip_refresh (src/impl/dash/stratum/tip_refresh.hpp) is the
+//     REAL fan-out the run loop binds -- these run the landed code, not a copy.
+// (b) LocalMintLedger/classify_local_mint (src/impl/dash/local_mint_ledger.hpp)
+//     is the display-only gauge that makes the failure visible: of the shares
+//     WE minted, how many are still on the best chain. Consensus-invisible.
+// ═════════════════════════════════════════════════════════════════════════════
+
+namespace {
+
+// ── Fan-out spies ────────────────────────────────────────────────────────────
+struct SpyLog { std::vector<std::string> calls; };
+
+struct SpyWorkSource {
+    SpyLog* log; int bumps = 0;
+    void bump_work_generation() { ++bumps; log->calls.push_back("bump"); }
+};
+struct SpyStratumServer {
+    SpyLog* log; int notifies = 0;
+    void notify_all() { ++notifies; log->calls.push_back("notify"); }
+};
+struct SpyWebServer {
+    SpyLog* log; int refreshes = 0;
+    void trigger_work_refresh_debounced() { ++refreshes; log->calls.push_back("web"); }
+};
+
+// ── Fake sharechain: the three primitives classify_local_mint uses ───────────
+class FakeChain {
+public:
+    void add(const uint256& hash, const uint256& parent, int32_t height) {
+        m_parent[hash] = parent;
+        m_height[hash] = height;
+    }
+    bool contains(const uint256& h) const { return m_height.count(h) != 0; }
+    int32_t get_acc_height(const uint256& h) {
+        auto it = m_height.find(h);
+        return it == m_height.end() ? 0 : it->second;
+    }
+    uint256 get_nth_parent_via_skip(const uint256& h, int32_t n) const {
+        uint256 cur = h;
+        for (int32_t i = 0; i < n; ++i) {
+            auto it = m_parent.find(cur);
+            if (it == m_parent.end()) return uint256();
+            cur = it->second;
+        }
+        return cur;
+    }
+private:
+    std::map<uint256, uint256> m_parent;
+    std::map<uint256, int32_t> m_height;
+};
+
+// A linear chain h1..h6 (heights 1..6) plus one SIBLING of h4 (same parent h3).
+// h1 is the root; sibling shares h4's parent and height but not the best chain.
+struct SiblingFixture {
+    FakeChain chain;
+    uint256 h[7];
+    uint256 sibling;
+    SiblingFixture() {
+        for (int i = 1; i <= 6; ++i) h[i] = fill_hash(static_cast<unsigned char>(0x10 + i));
+        chain.add(h[1], uint256(), 1);
+        for (int i = 2; i <= 6; ++i) chain.add(h[i], h[i - 1], i);
+        sibling = fill_hash(0xAB);
+        chain.add(sibling, h[3], 4);            // same height as h4, off the best chain
+    }
+};
+
+} // namespace
+
+// (8) THE REGRESSION PIN: a sharechain tip change must PUSH work to the miners,
+//     not merely invalidate the cached payload. bump-only is the defect.
+TEST(DashSharechainTipRefresh, TipChangePushesNotifyToMiners) {
+    SpyLog log;
+    SpyWorkSource ws{&log};
+    SpyStratumServer ss{&log};
+    SpyWebServer web{&log};
+
+    dash::stratum::fire_share_tip_refresh(&ws, &ss, &web);
+
+    EXPECT_EQ(ws.bumps, 1);
+    EXPECT_EQ(ss.notifies, 1) << "sharechain tip change did not push mining.notify "
+                                 "-- rigs keep the stale prev_share_hash job";
+    EXPECT_EQ(web.refreshes, 1);
+    // Order matters: invalidate the payload BEFORE pushing, so the notify a
+    // session builds is sourced from the new tip, and notify the miners BEFORE
+    // the dashboard (miners first).
+    ASSERT_EQ(log.calls.size(), 3u);
+    EXPECT_EQ(log.calls[0], "bump");
+    EXPECT_EQ(log.calls[1], "notify");
+    EXPECT_EQ(log.calls[2], "web");
+}
+
+// (9) Every leg is independently optional: --stratum-port 0 (no acceptor) and
+//     the dashboard-off build must not fault, and must not lose the bump.
+TEST(DashSharechainTipRefresh, LegsAreNullTolerant) {
+    SpyLog log;
+    SpyWorkSource ws{&log};
+    SpyStratumServer ss{&log};
+
+    dash::stratum::fire_share_tip_refresh(&ws, static_cast<SpyStratumServer*>(nullptr),
+                                          static_cast<SpyWebServer*>(nullptr));
+    EXPECT_EQ(ws.bumps, 1);
+    EXPECT_EQ(ss.notifies, 0);
+
+    dash::stratum::fire_share_tip_refresh(static_cast<SpyWorkSource*>(nullptr), &ss,
+                                          static_cast<SpyWebServer*>(nullptr));
+    EXPECT_EQ(ws.bumps, 1);
+    EXPECT_EQ(ss.notifies, 1);
+}
+
+// (10) One notify per tip change -- N tip changes push N times (the keepalive
+//      timer is a SAFETY net, never the work-delivery mechanism).
+TEST(DashSharechainTipRefresh, OneNotifyPerTipChange) {
+    SpyLog log;
+    SpyWorkSource ws{&log};
+    SpyStratumServer ss{&log};
+    SpyWebServer web{&log};
+    for (int i = 0; i < 7; ++i)
+        dash::stratum::fire_share_tip_refresh(&ws, &ss, &web);
+    EXPECT_EQ(ss.notifies, 7);
+    EXPECT_EQ(ws.bumps, 7);
+}
+
+// (11) Gauge: a mint that is still an ancestor of the best share is on-chain;
+//      a sibling at the same height is not. This is the number that was 0.
+TEST(DashLocalMintLedger, ClassifiesOnChainVsSibling) {
+    SiblingFixture f;
+    const int32_t depth = dash::mint::LocalMintLedger::kSettleDepth;   // 3
+
+    // best = h6 -> h3 is buried 3 deep: settled, on-chain.
+    EXPECT_EQ(dash::mint::classify_local_mint(f.chain, f.h[6], f.h[3], depth),
+              dash::mint::MintVerdict::on_chain);
+    // The sibling of h4 is buried 2 deep at best=h6 -> still pending...
+    EXPECT_EQ(dash::mint::classify_local_mint(f.chain, f.h[6], f.sibling, depth),
+              dash::mint::MintVerdict::pending);
+    // ...and h4 itself is likewise pending at that depth (symmetry check).
+    EXPECT_EQ(dash::mint::classify_local_mint(f.chain, f.h[6], f.h[4], depth),
+              dash::mint::MintVerdict::pending);
+
+    // Grow the chain to h7/h8 so the height-4 pair settles: h4 on-chain,
+    // its sibling off-chain (an orphan that earns nothing).
+    uint256 h7 = fill_hash(0x21), h8 = fill_hash(0x22);
+    f.chain.add(h7, f.h[6], 7);
+    f.chain.add(h8, h7, 8);
+    EXPECT_EQ(dash::mint::classify_local_mint(f.chain, h8, f.h[4], depth),
+              dash::mint::MintVerdict::on_chain);
+    EXPECT_EQ(dash::mint::classify_local_mint(f.chain, h8, f.sibling, depth),
+              dash::mint::MintVerdict::off_chain);
+}
+
+// (12) Unknowables never inflate the rate: a hash the tracker no longer holds
+//      settles as `gone`, and a null best share stays pending.
+TEST(DashLocalMintLedger, PrunedAndUnknownAreNotCountedAsOrphans) {
+    SiblingFixture f;
+    const int32_t depth = dash::mint::LocalMintLedger::kSettleDepth;
+    EXPECT_EQ(dash::mint::classify_local_mint(f.chain, f.h[6], fill_hash(0x77), depth),
+              dash::mint::MintVerdict::gone);
+    EXPECT_EQ(dash::mint::classify_local_mint(f.chain, uint256(), f.h[1], depth),
+              dash::mint::MintVerdict::pending);
+}
+
+// (13) End-to-end gauge: mint 2 winners + 2 siblings, settle against the best
+//      chain, read the rate. 50% here; the live node measured ~76%.
+TEST(DashLocalMintLedger, SettlesAndReportsOrphanRate) {
+    SiblingFixture f;
+    uint256 sib2 = fill_hash(0xCD);
+    f.chain.add(sib2, f.h[1], 2);          // sibling of h2
+
+    dash::mint::LocalMintLedger ledger;
+    ledger.record_mint(f.h[2]);
+    ledger.record_mint(sib2);
+    ledger.record_mint(f.h[3]);
+    ledger.record_mint(f.sibling);         // sibling of h4
+
+    EXPECT_EQ(ledger.stats().minted, 4u);
+    EXPECT_EQ(ledger.stats().pending, 4u);
+
+    auto settle_against = [&](const uint256& best) {
+        ledger.settle([&](const uint256& h) {
+            return dash::mint::classify_local_mint(
+                f.chain, best, h, dash::mint::LocalMintLedger::kSettleDepth);
+        });
+    };
+
+    // best = h6: heights 2 and 3 are deep enough; height 4 is not.
+    settle_against(f.h[6]);
+    auto s = ledger.stats();
+    EXPECT_EQ(s.on_chain, 2u);             // h2, h3
+    EXPECT_EQ(s.orphaned, 1u);             // sib2
+    EXPECT_EQ(s.pending,  1u);             // f.sibling — still too shallow
+    EXPECT_DOUBLE_EQ(s.orphan_rate, 1.0 / 3.0);
+
+    // Chain grows two more: the height-4 sibling now settles as an orphan.
+    uint256 h7 = fill_hash(0x21), h8 = fill_hash(0x22);
+    f.chain.add(h7, f.h[6], 7);
+    f.chain.add(h8, h7, 8);
+    settle_against(h8);
+    s = ledger.stats();
+    EXPECT_EQ(s.minted,   4u);
+    EXPECT_EQ(s.on_chain, 2u);
+    EXPECT_EQ(s.orphaned, 2u);
+    EXPECT_EQ(s.pending,  0u);
+    EXPECT_DOUBLE_EQ(s.orphan_rate, 0.5);
+}
+
+// (14) The gauge is bounded and cheap: the un-settled set can never grow past
+//      kMaxPending, and evictions are accounted (never silently lost).
+TEST(DashLocalMintLedger, PendingSetIsBounded) {
+    dash::mint::LocalMintLedger ledger;
+    const std::size_t over = dash::mint::LocalMintLedger::kMaxPending + 10;
+    for (std::size_t i = 0; i < over; ++i) {
+        std::vector<unsigned char> raw(32, 0);
+        raw[0] = static_cast<unsigned char>(i & 0xff);
+        raw[1] = static_cast<unsigned char>((i >> 8) & 0xff);
+        raw[2] = 0x01;             // never the null hash (record_mint ignores null)
+        ledger.record_mint(uint256(raw));
+    }
+    auto s = ledger.stats();
+    EXPECT_EQ(s.minted,  static_cast<uint64_t>(over));
+    EXPECT_EQ(s.pending, static_cast<uint64_t>(dash::mint::LocalMintLedger::kMaxPending));
+    EXPECT_EQ(s.dropped, 10u);
+    EXPECT_DOUBLE_EQ(s.orphan_rate, 0.0);   // nothing settled -> no rate invented
 }


### PR DESCRIPTION
## The defect (production, measured)

`main_dash.cpp`, sharechain best-share-changed callback:

```cpp
p2p_node.set_on_best_share_changed(
    [ws = work_source.get(), web]() {
        ws->bump_work_generation();
        if (web) web->trigger_work_refresh_debounced();
    });
```

The comment claimed "sessions re-notify", but `stratum_server->notify_all()` was
never called. `bump_work_generation()` only invalidates the served payload cache
— it pushes nothing to miners. So when the SHARECHAIN tip changed, connected
rigs kept mining the previous `prev_share_hash` until the per-session keepalive
timer fired (`StratumConfig::keepalive_notify_sec = 25 s`, set in
`work_source.cpp`; timer leg in `core/stratum_server.cpp`). Worse, that late
push is non-clean: `clean_jobs = force_clean || (prevhash != last_prevhash_)`
and `prevhash` there is the COIN block prevhash, which a sharechain-only tip
change does not move — so `clean_jobs` stayed false and an ASIC drained its
queued work first.

All rigs share one producer `job_cache` entry (keyed `(prev_share_hash,
payout_script)`; all 24 rigs use the same payout address), so every solve inside
that window rebuilt the SAME frozen job — siblings at one sharechain height
instead of a linear chain.

**Measured on the live node:** 4.13 shares minted per chain height = **75.8%
orphan rate**; we hold **57.6% of PPLNS window work-weight while supplying ~88%
of pool hashrate** ≈ 0.40 DASH lost per pool block (~1.5 DASH/day). The oracle
showed 50 heads, all ours, all `verified:true`, all zero-children, clustered by
absheight.

## The fix

The callback now runs the SAME fan-out the coin-tip legs in this file already
run (`set_on_state_dirty`, the coin-P2P tip leg, `fire_refresh`):

1. `bump_work_generation()` — invalidate the served payload;
2. `StratumServer::notify_all()` — **push** `mining.notify` to every subscribed
   session with `send_notify_work(true, &frozen_best)`, i.e. `clean_jobs=true`,
   whose own in-source comment reads *"miner switches to new prev_share
   immediately (p2pool behavior)"*;
3. `trigger_work_refresh_debounced()` — dashboard/graphs off the poll timer.

`stratum_server` is captured **by reference** (the acceptor is constructed
further down and stays null under `--stratum-port 0`), matching the sibling
lambda's existing capture style; every leg is null-guarded.

The three-step fan-out is factored into
`dash::stratum::fire_share_tip_refresh()` (`src/impl/dash/stratum/tip_refresh.hpp`)
so the run-loop binding is the SAME code the KAT exercises — no parallel copy
that can drift from what ships.

## Also in this PR: a local-mint orphan/sibling gauge (display only)

We were blind to this for hours because the node reported `orphan 0 / dead 0 /
efficiency 1.0`. Those counters are the sharechain-wide `StaleInfo` tally, and
every share we mint is stamped `StaleInfo::none` — so a locally minted share
that is accepted, verified, and then simply loses the head race is invisible in
every existing counter.

`dash::mint::LocalMintLedger` (`src/impl/dash/local_mint_ledger.hpp`) closes
that hole from the other end: record the hashes WE mint, and once the best chain
has grown `kSettleDepth` (3) shares past one of them, ask one cheap question —
is it still an ancestor of the best share? The check uses the cached O(1)
`get_acc_height()` plus the O(log n) skip-list `get_nth_parent_via_skip()`, runs
off the existing best-share-changed event (no new timer), on a try-lock read
guard (a busy tracker just defers the verdict), and the pending set is bounded
at 512.

Surfaced on `/local_stats` as:

```json
"local_shares": { "minted": N, "on_chain": N, "orphan": N,
                  "pending": N, "gone": N, "orphan_rate": 0.0 }
```

The `core/web_server.cpp` leg is gated on the key being present in the coin's
stats payload, so every non-DASH coin's `/local_stats` body is byte-identical to
before. `StaleInfo` stamping and `shares{total,orphan,dead}` / `efficiency` are
untouched.

## REWARD-SAFETY

No change to consensus, share validation, mint contents, the coinbase, the
payee, PPLNS math, or the won-block path.

- **Byte-parity: none required.** A tip change means a new `prev_share_hash` →
  a new `job_cache` key → a fresh `build_producer_job` with a fresh
  `std::time(nullptr)`, hence a new frozen gentx and `ref_hash`. Nothing about
  an existing share's bytes changes; we merely stop re-serving a stale job.
- **Share timestamps are deliberately NOT re-stamped.** The timestamp is inside
  the committed bytes (`share_producer.hpp` → `compute_ref_hash` → coinbase
  OP_RETURN → coinb1 → merkle root → the solved 80-byte header); re-stamping at
  mint would invalidate the PoW. Measurement already proved the stamps correct.
- **The won-block path is unaffected.** It runs first and independently in
  `work_source.cpp mining_submit` (block-target check + submit), before and
  regardless of any sharechain-side job bookkeeping. Pushing work earlier can
  only change WHICH template a miner is working on next — never how a solved
  header is scored or submitted.
- The gauge is read-only: it observes hashes after `add_local_share()` has
  already returned and never gates a mint.

## Tests

Folded into the EXISTING allowlisted target `test_dash_stratum_notify_roundtrip`
(no new `add_executable`; `tools/ci/check_test_target_allowlist.py` passes):

- `DashSharechainTipRefresh.TipChangePushesNotifyToMiners` — the regression pin:
  a tip change must PUSH a notify, not merely invalidate. Also pins the order
  (bump → notify → dashboard).
- `DashSharechainTipRefresh.LegsAreNullTolerant` — `--stratum-port 0` /
  dashboard-off builds.
- `DashSharechainTipRefresh.OneNotifyPerTipChange` — N tip changes → N pushes
  (the keepalive timer is a safety net, never the work-delivery mechanism).
- `DashLocalMintLedger.ClassifiesOnChainVsSibling` — a fake chain with a real
  sibling: ancestor → on-chain, sibling → orphan, too-shallow → pending.
- `DashLocalMintLedger.PrunedAndUnknownAreNotCountedAsOrphans`.
- `DashLocalMintLedger.SettlesAndReportsOrphanRate` — end-to-end 2 winners +
  2 siblings → rate 0.5, incl. the deferred settle as the chain grows.
- `DashLocalMintLedger.PendingSetIsBounded` — bound + eviction accounting.

**Local results:** `c2pool-dash` builds clean; `--selftest` OK (X11 KATs,
subsidy, MN payment); `ctest -R Dash` **701/701 passed**;
`test_dash_stratum_notify_roundtrip` 14/14; core stratum suites
(`StratumHotelInterim`, `StratumExtensions`) and `WebHonestyRegression` green.

## Deliberately NOT in this PR

- **Wiring `dash::stratum::modulate_desired_share_target()`** (the canonical
  1.67% pool-share cap, `src/impl/dash/stratum/work_target.hpp`) into the DASH
  producer-job `desired_target` (`mint_runloop.hpp:128`, currently hard-set to
  `params.max_target`). It exists in-tree with ZERO call sites on the DASH path
  (only LTC uses it, inlined at `main_ltc.cpp:4502-4516`). It would raise our
  share difficulty ~30x and cut the mint rate to ~1/120 s, making us robust to
  any residual refresh latency — but it changes the `bits` we stamp, so it is
  **consensus-visible** and needs its own pre-v36 consensus-neutrality review.
  Separate PR.
- Any change to `StaleInfo` stamping, share timestamps, or vardiff.

## Manual verification on the live node

The orphan gauge gives a real before/after number without a redeploy of the
measurement tooling: run the current binary long enough to record a baseline
`local_shares.orphan_rate` (it should reproduce the ~0.76 measured externally),
then restart on this build and watch the same field converge toward ~0. Both
numbers come from the same code path, so the comparison is apples-to-apples.
Counters are process-lifetime (not persisted), so the baseline must be captured
before the restart.
