### PR TITLE
dash(mint): apply the canonical 1.67% pool-share cap to the producer target

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -101,6 +101,8 @@
 #include <impl/dash/share_messages.hpp>        // dash::unpack_share_messages — signed transitional-blob DISPLAY+VERIFY feed
 #include <core/log.hpp>
 
+#include <algorithm>    // std::copy (pool-share-cap pubkey_hash extract)
+#include <array>        // std::array<uint8_t,20> — AddrRateMap key
 #include <chrono>
 #include <ctime>
 #include <optional>
@@ -1676,7 +1678,14 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             std::map<ProducerJobKey, ProducerJobCacheEntry>>();
 
         work_source->set_producer_job_fn(
-            [node_ptr, mint_params, mint_registry, job_cache, fee_policy](
+            // stratum_server is captured BY REFERENCE (the sibling lambdas'
+            // established style — set_on_best_share_changed below, and
+            // set_on_state_dirty): the acceptor is constructed further down and
+            // stays null under --stratum-port 0, and it is reset BEFORE
+            // work_source unwinds, so every use is null-guarded. It supplies the
+            // per-address hashrate the 1.67% pool-share cap modulates on.
+            [node_ptr, mint_params, mint_registry, job_cache, fee_policy,
+             &stratum_server](
                 const uint256& prev_share_hash,
                 const std::vector<unsigned char>& payout_script,
                 const dash::coin::DashWorkData& wd)
@@ -1761,13 +1770,72 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                     "redistribute policy (node-owner)";
                 }
 
+                // ── Canonical 1.67% pool-share cap input (work.py:309-312) ──
+                //
+                // The measured hashrate of THIS miner, keyed on its own payout
+                // pubkey_hash — the same RateMonitor aggregation p2pool's
+                // get_local_addr_rates() feeds the cap with. Mirrors the LTC
+                // wiring (main_ltc.cpp:4504-4550, with the band clip at
+                // :4595-4597): pull the hash160 straight out of the P2PKH payout
+                // script, look it up, apply Cap 1, and hand the result to
+                // compute_share_target as the pre-clip desired target.
+                //
+                // Keyed on the MINER's script, NOT identity->payout_script: the
+                // --fee/--redistribute substitution changes whose PPLNS weight
+                // the share carries, but the work was done by this miner and the
+                // cap is a property of that work rate.
+                //
+                // Unknown rate (fresh session, no pseudoshare in the RateMonitor
+                // window, non-P2PKH credentials, --stratum-port 0) -> 0.0 -> the
+                // cap is inert and the desired target is bit-identical to the
+                // previous params.max_target behaviour.
+                //
+                // Lock note: get_local_addr_rates() takes only StratumServer's
+                // RateMonitor/cache LEAF mutexes (no sessions_mutex_, no
+                // m_work_mutex), so no new lock-order edge is introduced on the
+                // build_connection_coinbase path.
+                double local_hash_rate = 0.0;
+                if (stratum_server && payout_script.size() == 25 &&
+                    payout_script[0] == 0x76 && payout_script[1] == 0xa9 &&
+                    payout_script[2] == 0x14 && payout_script[23] == 0x88 &&
+                    payout_script[24] == 0xac)
+                {
+                    std::array<uint8_t, 20> miner_pubkey{};
+                    std::copy(payout_script.begin() + 3, payout_script.begin() + 23,
+                              miner_pubkey.begin());
+                    const auto rates = stratum_server->get_local_addr_rates();
+                    auto it = rates.find(miner_pubkey);
+                    if (it != rates.end() && it->second > 0.0)
+                        local_hash_rate = it->second;
+                }
+
                 auto built = dash::mint::build_producer_job(
                     guard->chain, mint_params, prev_share_hash,
                     identity->payout_script, wd,
                     static_cast<uint32_t>(std::time(nullptr)), share_nonce,
-                    identity->donation_u16, /*pool_tag=*/"c2pool");
+                    identity->donation_u16, /*pool_tag=*/"c2pool",
+                    local_hash_rate);
                 if (!built)
                     return std::nullopt;
+
+                {
+                    // Observability for the consensus-visible target choice:
+                    // what the cap asked for vs what the chain band allowed.
+                    static int cap_log = 0;
+                    if (cap_log++ % 50 == 0) {
+                        const uint256 desired = dash::mint::desired_share_target(
+                            mint_params, local_hash_rate);
+                        LOG_INFO << "[MINT-CAP] local_hr=" << local_hash_rate
+                                 << " H/s desired="
+                                 << desired.GetHex().substr(0, 16)
+                                 << " -> share_bits=0x" << std::hex
+                                 << built->job.share_bits << " max_bits=0x"
+                                 << built->job.share_max_bits << std::dec
+                                 << " share_diff="
+                                 << chain::target_to_difficulty(
+                                        chain::bits_to_target(built->job.share_bits));
+                    }
+                }
 
                 mint_registry->put(built->job.ref_hash, built->frozen);
                 // Template txs -> m_known_txs so share relay can serve

--- a/src/impl/dash/mint_runloop.hpp
+++ b/src/impl/dash/mint_runloop.hpp
@@ -36,6 +36,7 @@
 #include "coinbase_builder.hpp"        // push_bip34_height (BIP34 scriptSig SSOT)
 #include "coin/rpc_data.hpp"           // dash::coin::DashWorkData
 #include "stratum/work_source.hpp"     // DASHWorkSource::{MintShareInputs, ProducerJob, PplnsWeights}
+#include "stratum/work_target.hpp"     // dash::stratum::modulate_desired_share_target (Cap 1)
 
 #include <core/coin_params.hpp>
 #include <core/target_utils.hpp>
@@ -62,16 +63,57 @@ namespace dash::mint {
 // producer walks are backward from prev_share_hash and therefore deterministic
 // even if the chain has since grown).
 //
-// desired_target policy: params.max_target. The oracle clips desired into
-// [pre_target3/30, pre_target3] (data.py:141-145), so max_target clips to
-// pre_target3 — the pool's ACTUAL current share target. Per-miner pseudoshare
-// difficulty stays a session/vardiff concern; the share target the mint gate
-// enforces is the network one.
+// desired_target policy: the ORACLE per-miner modulation (work.py:308-312),
+// Cap 1 only — the 1.67% pool-share cap:
+//
+//   desired = 2**256-1
+//   desired = min(desired, average_attempts_to_target(
+//                              local_hash_rate * SHARE_PERIOD / 0.0167))
+//   desired = min(desired, params.max_target)      <- c2pool ceiling, unchanged
+//
+// and then generate_prospective_share_info -> compute_share_target clips it
+// into the chain band [pre_target3//30, pre_target3] (data.py:141-145). The
+// band clip is applied LAST and is the ONLY thing that reaches the share's
+// committed m_bits, so a modulated desired can never leave the range canonical
+// peers' check() accepts: too easy -> pre_target3, too hard -> pre_target3//30.
+//
+// local_hash_rate == 0 (fresh start, no measured pseudoshares, non-P2PKH
+// credentials, stratum server down) degrades to "no meaningful cap": Cap 1 is
+// a no-op, desired == params.max_target, i.e. BIT-IDENTICAL to the pre-cap
+// behaviour (max_target >= pre_target3 always clips to pre_target3 -- the
+// pool's current share target).
+//
+// Cap 2 (the dust-threshold EASE, work.py:317-326) is deliberately NOT wired
+// here: it needs a pool-attempts-per-second estimate at job time and only ever
+// makes the target EASIER, i.e. it cannot mitigate the over-minting this cap
+// addresses. work_target.hpp carries it for the later port.
+//
+// Per-miner pseudoshare (vardiff) difficulty stays a session concern and is
+// untouched; the share target the mint gate enforces is the modulated one.
 struct ProducerJobBuild
 {
     dash::stratum::DASHWorkSource::ProducerJob job;   // gentx bytes + split point + ref_hash + bits
     dash::stratum::FrozenMintJob               frozen; // per-job mint context (registry payload)
 };
+
+// desired_share_target — the pre-clip desired target a producer job commits to.
+// Pure (KAT-able): oracle Cap 1 over the coin's SHARE_PERIOD, then floored by
+// the c2pool max_target ceiling so the local_hash_rate == 0 path reproduces the
+// pre-cap value EXACTLY. compute_share_target applies the [pre_target3//30,
+// pre_target3] band afterwards; nothing here can escape it.
+inline uint256 desired_share_target(const core::CoinParams& params,
+                                    double local_hash_rate)
+{
+    dash::stratum::WorkTargetInputs wt;
+    wt.local_hash_rate = local_hash_rate;
+    wt.share_period    = static_cast<uint32_t>(params.share_period);
+    wt.dust_gate       = false;   // Cap 2 not wired (see the note above)
+
+    uint256 desired = dash::stratum::modulate_desired_share_target(wt);
+    if (params.max_target < desired)
+        desired = params.max_target;
+    return desired;
+}
 
 template <typename ChainT>
 inline std::optional<ProducerJobBuild> build_producer_job(
@@ -83,7 +125,8 @@ inline std::optional<ProducerJobBuild> build_producer_job(
     uint32_t desired_timestamp,
     uint32_t share_nonce,
     uint16_t donation,
-    const std::string& pool_tag)
+    const std::string& pool_tag,
+    double local_hash_rate = 0.0)
 {
     // Miner identity: DASH sharechain payouts are P2PKH-keyed (share_data
     // pubkey_hash). Non-P2PKH -> no producer job (the caller's non-producer
@@ -125,7 +168,7 @@ inline std::optional<ProducerJobBuild> build_producer_job(
     }
     pin.desired_tx_hashes  = wd.m_tx_hashes;
     pin.desired_timestamp  = desired_timestamp;
-    pin.desired_target     = params.max_target;
+    pin.desired_target     = desired_share_target(params, local_hash_rate);
 
     auto info = dash::producer::generate_prospective_share_info(chain, params, pin);
 

--- a/src/impl/dash/stratum/work_target.hpp
+++ b/src/impl/dash/stratum/work_target.hpp
@@ -43,6 +43,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <limits>
 
 #include <core/target_utils.hpp>   // chain::bits_to_target / target_to_average_attempts
 #include <core/uint256.hpp>        // uint256 / uint288
@@ -54,6 +55,18 @@ namespace dash::stratum {
 //   [1, 2**256-1]. Mirrors c2pool_refactored.cpp:4453-4458 (LTC reference).
 // `avg_attempts` is a double (hashrate*time arithmetic). Values <= 1.0 mean
 // "no meaningful cap" and yield the maximum target (2**256-1).
+//
+// SATURATION (fail-safe, not oracle-divergent): the uint64 narrowing below is
+// UNDEFINED BEHAVIOUR once avg_attempts >= 2**64, and on x86-64 it yields 0 ->
+// a "Division by zero" THROW out of the caller. Cap 1 multiplies the miner's
+// hashrate by SHARE_PERIOD/0.0167 (~1198x for DASH), so that boundary is only
+// ~1.5e16 H/s of measured local rate -- reachable by a large aggregator, and a
+// throw on the producer-job path would silently disable minting entirely
+// (work_source.cpp catches it and degrades to the non-producer coinbase).
+// Saturating the divisor at UINT64_MAX yields 2**256//2**64 - 1: a target far
+// harder than any chain band, so the subsequent clip pins it to the band's hard
+// edge -- the same answer the unbounded oracle integer would clip to. The
+// oracle's own value is only ever observable INSIDE the band.
 inline uint256 average_attempts_to_target(double avg_attempts)
 {
     uint256 max_t;
@@ -61,9 +74,16 @@ inline uint256 average_attempts_to_target(double avg_attempts)
     if (!(avg_attempts > 1.0))
         return max_t;
 
+    // 2**64 exactly, as a double: any avg_attempts at or above it cannot be
+    // narrowed to uint64. (NaN falls out through the !(>1.0) guard above.)
+    constexpr double kTwo64 = 18446744073709551616.0;
+    const uint64_t avg_u64 = (avg_attempts >= kTwo64)
+        ? std::numeric_limits<uint64_t>::max()
+        : static_cast<uint64_t>(avg_attempts);
+
     uint288 two_256;
     two_256.SetHex("10000000000000000000000000000000000000000000000000000000000000000");
-    uint288 avg_288(static_cast<uint64_t>(avg_attempts));
+    uint288 avg_288(avg_u64);
     uint288 t_288 = two_256 / avg_288;
     if (t_288 > uint288(1))
         t_288 = t_288 - uint288(1);

--- a/test/test_dash_mint_runloop.cpp
+++ b/test/test_dash_mint_runloop.cpp
@@ -659,3 +659,151 @@ TEST(DashMintRunloop, DonationFieldDecaysPplnsWeight)
     EXPECT_EQ(w.donation_weight, att * static_cast<uint32_t>(donation));
     EXPECT_EQ(w.total_weight, att * 65535u);
 }
+
+// ═════════════════════════════════════════════════════════════════════════════
+// (8) 1.67% pool-share cap END-TO-END through build_producer_job.
+//
+// The producer job's desired_target is now the ORACLE per-miner modulation
+// (work.py:309-312) instead of a flat params.max_target. What lands in the
+// share is clip(desired, (pre_target3//30, pre_target3)) — the band applied
+// LAST by compute_share_target — so these KATs assert the JOB's committed
+// share_bits, i.e. the consensus-visible field.
+//
+// Fixture: REAL mainnet params on an EMPTY chain -> the genesis retarget arm,
+// pre_target3 = params.max_target (bdiff 1), band = [MAX//30 (bdiff 30), MAX].
+// SHARE_PERIOD = 20 s.
+// ═════════════════════════════════════════════════════════════════════════════
+
+namespace {
+uint32_t job_share_bits(double local_hash_rate, uint32_t* max_bits_out = nullptr)
+{
+    const core::CoinParams params = dash::make_coin_params(false);
+    dash::ShareTracker tracker;
+    tracker.m_coin_params = params;
+
+    auto wd = make_workdata();
+    const auto payout_script = dash::pubkey_hash_to_script2(h160_uniform(0x63));
+    auto built = build_producer_job(tracker.chain, params, uint256(),
+                                    payout_script, wd, wd.m_curtime,
+                                    /*share_nonce=*/7, /*donation=*/0, "c2pool",
+                                    local_hash_rate);
+    if (!built) return 0;
+    if (max_bits_out) *max_bits_out = built->job.share_max_bits;
+    return built->job.share_bits;
+}
+}  // namespace
+
+// Unknown/zero rate degrades to "no meaningful cap": desired == max_target,
+// exactly the pre-cap value. Also pins the DEFAULT-ARGUMENT overload (the call
+// shape every other KAT in this file uses) to the same result — the cap is
+// opt-in via a measured rate, never implicit.
+TEST(DashMintRunloopPoolShareCap, ZeroRateIsPreCapBehaviour)
+{
+    uint32_t max_bits = 0;
+    EXPECT_EQ(job_share_bits(0.0, &max_bits), 0x1d00ffffu);
+    EXPECT_EQ(max_bits, 0x1d00ffffu);
+
+    const core::CoinParams params = dash::make_coin_params(false);
+    dash::ShareTracker tracker;
+    tracker.m_coin_params = params;
+    auto wd = make_workdata();
+    const auto payout_script = dash::pubkey_hash_to_script2(h160_uniform(0x63));
+    auto legacy = build_producer_job(tracker.chain, params, uint256(),
+                                     payout_script, wd, wd.m_curtime, 7, 0, "c2pool");
+    ASSERT_TRUE(legacy.has_value());
+    EXPECT_EQ(legacy->job.share_bits, 0x1d00ffffu);
+
+    // desired_share_target itself must be bit-identical to the old constant.
+    EXPECT_EQ(dash::mint::desired_share_target(params, 0.0).GetHex(),
+              params.max_target.GetHex());
+}
+
+// A SMALL miner is inert: 1 MH/s -> cap bdiff 0.2788 (EASIER than pre_target3
+// at bdiff 1) -> upper clip -> unchanged bits.
+TEST(DashMintRunloopPoolShareCap, SmallMinerUnaffected)
+{
+    EXPECT_EQ(job_share_bits(1e6), 0x1d00ffffu);
+}
+
+// A MID miner lands strictly inside the band: 100 MH/s -> cap bdiff 27.8835,
+// between pre_target3 (1) and the MAX//30 edge (30).
+//   avg = int(1e8*20/0.0167) = 119760479041 ; target = 2**256//avg - 1
+//   compact(target) = 0x1c092e50
+TEST(DashMintRunloopPoolShareCap, MidMinerInsideBand)
+{
+    EXPECT_EQ(job_share_bits(1e8), 0x1c092e50u);
+}
+
+// A LARGE miner clamps AT the band edge, never beyond. 43 TH/s (the live node's
+// measured rate) -> cap bdiff 11989898, ~4e5x past the MAX//30 edge -> the
+// emitted bits are compact(MAX_TARGET//30) = 0x1c088880 (bdiff exactly 30).
+// max_bits is untouched, so peers recompute the SAME band and accept.
+TEST(DashMintRunloopPoolShareCap, LargeMinerClampsAtBandEdge)
+{
+    uint32_t max_bits = 0;
+    EXPECT_EQ(job_share_bits(43e12, &max_bits), 0x1c088880u);
+    EXPECT_EQ(max_bits, 0x1d00ffffu);
+
+    // Canonical acceptance: a peer re-derives our bits by feeding OUR OWN
+    // emitted target back through clip(.., (pre3//30, pre3)) +
+    // from_target_upper_bound and requiring the SAME bits (p2pool Share.check()
+    // regenerates share_info and compares equal). Compact encoding truncates,
+    // so a naive "target >= pre3//30" check is the wrong predicate; the fixed
+    // point is what wire-compat actually requires.
+    const uint256 pre3    = chain::bits_to_target(max_bits);
+    const uint256 emitted = chain::bits_to_target(0x1c088880u);
+    EXPECT_LE(emitted, pre3);           // never EASIER than the pool target
+    const uint256 band_lo = pre3 / 30;
+    EXPECT_EQ(chain::target_to_bits_upper_bound(
+                  dash::producer::clip(emitted, band_lo, pre3)),
+              0x1c088880u);
+
+    // An absurd rate cannot push it past the edge either -- including rates
+    // whose raw cap overflows the uint64 narrowing (saturation path).
+    EXPECT_EQ(job_share_bits(1e18), 0x1c088880u);
+    EXPECT_EQ(job_share_bits(1e30), 0x1c088880u);
+}
+
+// The cap does NOT perturb anything else the job commits to: with the SAME
+// inputs and a rate that leaves the cap inert, the gentx bytes / ref_hash /
+// nonce64 offset are byte-identical to the pre-cap build.
+TEST(DashMintRunloopPoolShareCap, InertCapLeavesJobBytesIdentical)
+{
+    const core::CoinParams params = dash::make_coin_params(false);
+    dash::ShareTracker tracker;
+    tracker.m_coin_params = params;
+    auto wd = make_workdata();
+    const auto payout_script = dash::pubkey_hash_to_script2(h160_uniform(0x63));
+
+    auto a = build_producer_job(tracker.chain, params, uint256(), payout_script,
+                                wd, wd.m_curtime, 7, 0, "c2pool");
+    auto b = build_producer_job(tracker.chain, params, uint256(), payout_script,
+                                wd, wd.m_curtime, 7, 0, "c2pool", /*rate=*/1e6);
+    ASSERT_TRUE(a.has_value());
+    ASSERT_TRUE(b.has_value());
+    EXPECT_EQ(a->job.gentx_bytes, b->job.gentx_bytes);
+    EXPECT_EQ(a->job.ref_hash.GetHex(), b->job.ref_hash.GetHex());
+    EXPECT_EQ(a->job.nonce64_offset, b->job.nonce64_offset);
+    EXPECT_EQ(a->frozen.desired_timestamp, b->frozen.desired_timestamp);
+    EXPECT_EQ(a->frozen.desired_target.GetHex(), b->frozen.desired_target.GetHex());
+}
+
+// A capped job stays MINT-CONSISTENT: the frozen desired_target the registry
+// stores is the modulated one, so the mint-time rebuild reproduces the same
+// committed bits (the byte-parity invariant the whole producer path rests on).
+TEST(DashMintRunloopPoolShareCap, FrozenDesiredTargetIsTheModulatedOne)
+{
+    const core::CoinParams params = dash::make_coin_params(false);
+    dash::ShareTracker tracker;
+    tracker.m_coin_params = params;
+    auto wd = make_workdata();
+    const auto payout_script = dash::pubkey_hash_to_script2(h160_uniform(0x63));
+
+    auto built = build_producer_job(tracker.chain, params, uint256(), payout_script,
+                                    wd, wd.m_curtime, 7, 0, "c2pool", 43e12);
+    ASSERT_TRUE(built.has_value());
+    EXPECT_EQ(built->frozen.desired_target.GetHex(),
+              dash::mint::desired_share_target(params, 43e12).GetHex());
+    EXPECT_EQ(built->frozen.desired_target.GetHex(),
+        "000000000000016635c48b2e932ea609a3b4aa32cefaa1ba023ea945da766f85");
+}

--- a/test/test_dash_share_producer.cpp
+++ b/test/test_dash_share_producer.cpp
@@ -27,6 +27,7 @@
 #include <impl/dash/share.hpp>
 #include <impl/dash/params.hpp>
 #include <impl/dash/coinbase_builder.hpp>   // coinbase::merkle_branches_raw (drift fence)
+#include <impl/dash/stratum/work_target.hpp> // stratum::cap_pool_share (1.67% pool-share cap)
 
 #include <core/coin_params.hpp>
 #include <core/hash.hpp>
@@ -176,6 +177,155 @@ TEST(DashShareProducerRetarget, FastPoolClampsToNineTenths) {
     auto st = dash::producer::compute_share_target(sc.chain, tip, uint256(1), params);
     EXPECT_EQ(st.max_bits, 0x1c1ccccbu);
     EXPECT_EQ(st.bits, 0x1c00f5c2u);
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// (c2) 1.67% pool-share cap COMPOSED WITH the chain band clip.
+//
+// The cap (work.py:309-312, dash::stratum::cap_pool_share) only ever produces a
+// *desired* target; the value that reaches the share's committed m_bits is
+// clip(desired, (pre_target3//30, pre_target3)) — applied LAST inside
+// compute_share_target_pure. These KATs pin that composition so a capped target
+// can never leave the band canonical check() accepts.
+//
+// Chain: 100 shares at bits 0x1c1fffff, 200 s spacing (the SlowPool fixture) ->
+//   prev_max    = 0x1fffff * 2^200
+//   pre_target3 = prev_max*11//10 = 0x2333321999...  (compact 0x1c233332, bdiff 7.2726)
+//   band_lo     = pre_target3//30 = 0x012c5f8962fc... (compact 0x1c012c5f, bdiff 218.18)
+// SHARE_PERIOD = 20 s (dash::SharechainConfig SSOT).
+// ═════════════════════════════════════════════════════════════════════════════
+
+namespace {
+// The mint path's desired-target policy, replicated here over the PUBLIC
+// helpers so this KAT pins the COMPOSITION (cap -> band) without pulling the
+// run-loop header in: identical to dash::mint::desired_share_target.
+uint256 capped_desired(const core::CoinParams& params, double local_hash_rate) {
+    uint256 d;
+    d.SetHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    d = dash::stratum::cap_pool_share(d, local_hash_rate,
+                                      static_cast<uint32_t>(params.share_period));
+    if (params.max_target < d)
+        d = params.max_target;
+    return d;
+}
+constexpr uint32_t BITS_PRE3    = 0x1c233332u;  // compact(pre_target3)
+constexpr uint32_t BITS_BAND_LO = 0x1c012c5fu;  // compact(pre_target3//30) — the HARD edge
+
+uint256 build_slow_pool_tip(SyntheticChain& sc) {
+    return build_uniform_chain(sc, 100, 0x1c1fffffu, 1000000, 200, h160_uniform(0x11));
+}
+}  // namespace
+
+// No measured hashrate -> cap inert -> desired == max_target -> upper band clip
+// -> bits == compact(pre_target3). BIT-IDENTICAL to the pre-cap behaviour.
+TEST(DashShareProducerCapBand, ZeroHashrateIsUnchanged) {
+    const auto params = dash::make_coin_params(false);
+    SyntheticChain sc;
+    uint256 tip = build_slow_pool_tip(sc);
+
+    auto ref = dash::producer::compute_share_target(sc.chain, tip, params.max_target, params);
+    auto st  = dash::producer::compute_share_target(sc.chain, tip,
+                   capped_desired(params, /*local_hash_rate=*/0.0), params);
+    EXPECT_EQ(st.bits, ref.bits);
+    EXPECT_EQ(st.max_bits, ref.max_bits);
+    EXPECT_EQ(st.bits, BITS_PRE3);
+}
+
+// A SMALL miner is unaffected: 1 MH/s -> cap bdiff 0.2788, i.e. EASIER than
+// pre_target3 (bdiff 7.27) -> the upper clip returns pre_target3 unchanged.
+TEST(DashShareProducerCapBand, SmallMinerUnaffected) {
+    const auto params = dash::make_coin_params(false);
+    SyntheticChain sc;
+    uint256 tip = build_slow_pool_tip(sc);
+
+    auto st = dash::producer::compute_share_target(sc.chain, tip,
+                  capped_desired(params, /*local_hash_rate=*/1e6), params);
+    EXPECT_EQ(st.bits, BITS_PRE3);
+    EXPECT_EQ(st.max_bits, BITS_PRE3);
+}
+
+// A MID miner lands strictly INSIDE the band — proving the clamp is a real clip
+// and not an unconditional snap to the edge. 100 MH/s -> avg = int(1e8*20/0.0167)
+// = 119760479041 -> target = 2**256//avg - 1 = 0x092e50e904436073... (bdiff
+// 27.8835), between pre_target3 (7.27) and band_lo (218.18).
+// Derive (python3): "%08x" % compact(2**256//119760479041 - 1)
+TEST(DashShareProducerCapBand, MidMinerInsideBand) {
+    const auto params = dash::make_coin_params(false);
+    SyntheticChain sc;
+    uint256 tip = build_slow_pool_tip(sc);
+
+    auto st = dash::producer::compute_share_target(sc.chain, tip,
+                  capped_desired(params, /*local_hash_rate=*/1e8), params);
+    EXPECT_EQ(st.bits, 0x1c092e50u);
+    EXPECT_EQ(st.max_bits, BITS_PRE3);
+}
+
+// ── The canonical acceptance predicate ───────────────────────────────────────
+// A peer does NOT range-check our bits directly. p2pool's Share.check() re-runs
+// generate_transaction() feeding OUR OWN emitted bits' target back in as
+// `desired_target` and requires the regenerated share_info to compare equal —
+// i.e. the emitted bits must be a FIXED POINT of
+//
+//   bits |-> from_target_upper_bound(clip(bits.target, (pre3//30, pre3)))
+//
+// A plain "target inside the band" assertion is the WRONG check: compact
+// encoding is mantissa-TRUNCATING, so the target that round-trips out of the
+// band-edge bits is always <= pre3//30 by up to one mantissa ulp. What matters
+// is that re-clipping and re-encoding lands on the same 32-bit bits value.
+namespace {
+bool peer_recheck_accepts(const dash::producer::ShareTarget& st) {
+    const uint256 pre3    = chain::bits_to_target(st.max_bits);
+    const uint256 band_lo = pre3 / 30;
+    const uint256 emitted = chain::bits_to_target(st.bits);
+    return chain::target_to_bits_upper_bound(
+               dash::producer::clip(emitted, band_lo, pre3)) == st.bits;
+}
+}  // namespace
+
+// A LARGE miner is clamped AT the band edge, not beyond it. 43 TH/s (the live
+// node's measured rate) -> cap bdiff 11989898, ~1.65e6x harder than pre_target3
+// and ~10x harder than band_lo -> clipped UP to exactly pre_target3//30.
+// This is the wire-safety assertion: the emitted bits ARE the band edge value
+// and they survive a canonical peer's re-derivation unchanged.
+TEST(DashShareProducerCapBand, LargeMinerClampsAtBandEdgeNotBeyond) {
+    const auto params = dash::make_coin_params(false);
+    SyntheticChain sc;
+    uint256 tip = build_slow_pool_tip(sc);
+
+    const uint256 desired = capped_desired(params, /*local_hash_rate=*/43e12);
+    auto st = dash::producer::compute_share_target(sc.chain, tip, desired, params);
+
+    EXPECT_EQ(st.bits, BITS_BAND_LO);
+    EXPECT_EQ(st.max_bits, BITS_PRE3);   // max_bits is NOT modulated
+
+    // The raw (unclipped) cap really WAS outside the band, so the clamp fired...
+    const uint256 pre3 = chain::bits_to_target(st.max_bits);
+    const uint256 band_lo = pre3 / 30;
+    EXPECT_LT(desired, band_lo);
+    // ...and the emitted bits are still what a canonical peer re-derives.
+    EXPECT_TRUE(peer_recheck_accepts(st));
+    // The emitted target never gets EASIER than the pool target either.
+    EXPECT_LE(chain::bits_to_target(st.bits), pre3);
+}
+
+// Sweep: over a wide hashrate range — including rates whose raw cap overflows
+// the uint64 narrowing in average_attempts_to_target — the emitted bits are
+// ALWAYS a fixed point of the canonical re-derivation.
+TEST(DashShareProducerCapBand, EmittedBitsAlwaysSurvivePeerRecheck) {
+    const auto params = dash::make_coin_params(false);
+    SyntheticChain sc;
+    uint256 tip = build_slow_pool_tip(sc);
+
+    for (double hr : {0.0, 1.0, 1e3, 1e6, 1e8, 1e9, 1e10, 1e12, 43e12, 1e18, 1e30}) {
+        auto st = dash::producer::compute_share_target(sc.chain, tip,
+                      capped_desired(params, hr), params);
+        const uint256 pre3    = chain::bits_to_target(st.max_bits);
+        const uint256 emitted = chain::bits_to_target(st.bits);
+        ASSERT_NE(st.bits, 0u) << "hr=" << hr;
+        ASSERT_FALSE(emitted.IsNull()) << "hr=" << hr;
+        EXPECT_LE(emitted, pre3) << "hr=" << hr;               // never easier than the pool target
+        EXPECT_TRUE(peer_recheck_accepts(st)) << "hr=" << hr;  // canonical acceptance
+    }
 }
 
 TEST(DashShareProducerRetarget, SlowPoolClampsToElevenTenths) {

--- a/test/test_dash_work_target.cpp
+++ b/test/test_dash_work_target.cpp
@@ -42,6 +42,27 @@ TEST(DashWorkTarget, AverageAttemptsToTargetExact)
         "0000000000eb08174d325a04e29e57c52c14f6dcfc48f79979535e202dcecf3d");
 }
 
+// average_attempts_to_target SATURATES instead of invoking UB / throwing when
+// avg_attempts >= 2**64. The uint64 narrowing is undefined there and on x86-64
+// produces 0 -> "Division by zero" out of the divide. Cap 1 scales the miner's
+// hashrate by SHARE_PERIOD/0.0167 (~1198x), so the boundary is only ~1.5e16 H/s
+// of measured rate; a throw on the producer-job path would disable minting.
+// Saturating at UINT64_MAX gives 2**256//2**64 - 1 -- harder than any chain
+// band, so the band clip pins it to the edge (see the CapBand KATs).
+TEST(DashWorkTarget, AverageAttemptsToTargetSaturatesAboveU64)
+{
+    const char* SAT_HEX =
+        "0000000000000001000000000000000100000000000000010000000000000000";
+    EXPECT_EQ(average_attempts_to_target(1e20).GetHex(), SAT_HEX);
+    EXPECT_EQ(average_attempts_to_target(1e40).GetHex(), SAT_HEX);
+    // Cap 1 must not throw for any plausible (or implausible) local rate.
+    uint256 start; start.SetHex(MAX_TARGET_HEX);
+    EXPECT_NO_THROW((void)cap_pool_share(start, 1e18,
+                        dash::SharechainConfig::SHARE_PERIOD));
+    EXPECT_NO_THROW((void)cap_pool_share(start, 1e30,
+                        dash::SharechainConfig::SHARE_PERIOD));
+}
+
 // Cap 1 (pool-share, 1.67%): local_hash_rate=1e9 H/s, SHARE_PERIOD=20.
 //   avg = int(1e9 * 20 / 0.0167) = 1197604790419
 //   target = average_attempts_to_target(avg)  (same value as above)
@@ -63,6 +84,57 @@ TEST(DashWorkTarget, Cap1NoHashrateNoOp)
     uint256 start; start.SetHex("00000000ffff0000000000000000000000000000000000000000000000000000");
     EXPECT_EQ(cap_pool_share(start, 0.0, dash::SharechainConfig::SHARE_PERIOD).GetHex(),
               start.GetHex());
+}
+
+// ── Cap 1 at the LIVE production operating point ────────────────────────────
+// Measured on the hotel DASH node: local_hash_rate ~= 43 TH/s, SHARE_PERIOD 20.
+//   avg    = int(43e12 * 20 / 0.0167)     = 51497005988023952
+//   target = 2**256 // avg - 1
+// Derive (python3): "%064x" % (2**256//51497005988023952 - 1)
+// The double->uint64 truncation in average_attempts_to_target is EXACTLY what
+// python's int(43e12*20/0.0167) reproduces (both are IEEE-754 doubles), so this
+// vector also pins the truncation, not just the big-int division.
+TEST(DashWorkTarget, Cap1ProductionOperatingPoint)
+{
+    uint256 start; start.SetHex(MAX_TARGET_HEX);
+    uint256 capped = cap_pool_share(start, /*local_hash_rate=*/43e12,
+                                    dash::SharechainConfig::SHARE_PERIOD);
+    EXPECT_EQ(capped.GetHex(),
+        "000000000000016635c48b2e932ea609a3b4aa32cefaa1ba023ea945da766f85");
+}
+
+// ── Cap 1 is INERT for a small miner ────────────────────────────────────────
+// The cap only ever binds once the miner exceeds 1.67% of the pool rate the
+// current share target implies. Feed cap_pool_share the pool's own share
+// target as `desired` (what the mint path effectively compares against after
+// the band clip) and check the min() leaves it untouched.
+//
+// pre_target3 pinned at share difficulty 40000 (the value observed on the live
+// node): pre3 = 0xFFFF*2**208 // 40000. Implied pool rate = ata(pre3)/20 =
+// 8.59e12 H/s, so the cap binds only above 1.67% of that = 1.43e11 H/s.
+//   100 GH/s  -> cap difficulty 27883 < 40000 -> cap target EASIER -> no-op.
+TEST(DashWorkTarget, Cap1SmallMinerInert)
+{
+    uint256 pre3;
+    pre3.SetHex("000000000001a36c8b4395810624dd2f1a9fbe76c8b4395810624dd2f1a9fbe7");
+    EXPECT_EQ(cap_pool_share(pre3, /*local_hash_rate=*/1e11,
+                             dash::SharechainConfig::SHARE_PERIOD).GetHex(),
+              pre3.GetHex());
+}
+
+// ...and it DOES bind for a miner past that threshold: 1 TH/s -> cap difficulty
+// 278834 > 40000, so the min() takes the (harder) cap target.
+//   avg = int(1e12*20/0.0167) = 1197604790419161
+// Derive (python3): "%064x" % (2**256//1197604790419161 - 1)
+TEST(DashWorkTarget, Cap1LargeMinerBinds)
+{
+    uint256 pre3;
+    pre3.SetHex("000000000001a36c8b4395810624dd2f1a9fbe76c8b4395810624dd2f1a9fbe7");
+    uint256 capped = cap_pool_share(pre3, /*local_hash_rate=*/1e12,
+                                    dash::SharechainConfig::SHARE_PERIOD);
+    EXPECT_LT(capped, pre3);
+    EXPECT_EQ(capped.GetHex(),
+        "0000000000003c2b080360d2c25f6b37738a73ba1fd9f288bd67b93cf5e4af28");
 }
 
 // Cap 2 (dust ease): block_bits=0x1b00ffff, subsidy=5e8, SPREAD=10,


### PR DESCRIPTION
## What

`build_producer_job` hard-set `pin.desired_target = params.max_target` (`mint_runloop.hpp:128`), so every minted DASH share landed at the chain difficulty floor — `pre_target3`, the pool's own share target. This PR replaces that constant with the canonical per-miner modulation, **Cap 1 only** (the 1.67% pool-share cap), and leaves everything else on the mint path untouched.

The port already existed in `src/impl/dash/stratum/work_target.hpp` (`dash::stratum::cap_pool_share`, documented against oracle `work.py:309-312`, literal `0.0167`) with **zero call sites**. This wires it; it does not rewrite it.

Oracle (`p2pool/work.py:311`):

```python
desired_share_target = min(desired_share_target,
    average_attempts_to_target(local_hash_rate * self.node.net.SHARE_PERIOD / 0.0167))
```

## How it is wired

New pure helper `dash::mint::desired_share_target(params, local_hash_rate)`:

```
desired = 2**256-1
desired = min(desired, average_attempts_to_target(local_hr * SHARE_PERIOD / 0.0167))   # Cap 1
desired = min(desired, params.max_target)                                              # pre-existing ceiling
```

`build_producer_job` gains a trailing `double local_hash_rate = 0.0` and feeds this to `pin.desired_target`. `generate_prospective_share_info -> compute_share_target -> compute_share_target_pure` then clips it into the chain band exactly as before:

```
bits = from_target_upper_bound(clip(desired_target, (pre_target3//30, pre_target3)))
```

**The band clip is applied last** (`share_producer.hpp:185-189`) and is the only value that reaches the share's committed `m_bits`. Nothing the cap produces can escape it.

The `min(..., params.max_target)` step is deliberate: with `local_hash_rate == 0` the result is `params.max_target`, i.e. **bit-identical to the previous behaviour**, rather than the oracle's `2**256-1` (both clip to `pre_target3`, but this keeps the no-signal path provably a no-op).

### LTC lines mirrored

`main_ltc.cpp` `ref_hash_fn`:

| LTC | what | DASH equivalent |
|---|---|---|
| `4504-4510` | start `desired_target` at `2^256-1` | `desired_share_target()` in `mint_runloop.hpp` |
| `4511-4519` | extract hash160 from the P2PKH payout script | `main_dash.cpp` producer-job lambda |
| `4520-4530` | `get_local_addr_rates()` lookup by that hash160 | `stratum_server->get_local_addr_rates()` |
| `4532-4550` | Cap 1 (`* SHARE_PERIOD / 0.0167`, `min()`) | `dash::stratum::cap_pool_share` (existing helper, not re-inlined) |
| `4551-4592` | Cap 2 (dust ease) | **not wired** — see below |
| `4595-4597` | hand `desired_target` to `compute_share_target` (band clip) | unchanged existing call inside `generate_prospective_share_info` |

Difference from LTC by design: LTC re-inlines the arithmetic inside the `ref_hash_fn` lambda; DASH calls the existing pure `work_target.hpp` accessor, which is what its header comment says it is for (Bucket-2, v37-foldable).

### Local-rate signal

`StratumServer::get_local_addr_rates()` — the same `RateMonitor` aggregation p2pool's `get_local_addr_rates()` (`work.py:1975-1990`) feeds the cap with, keyed on the miner's payout `pubkey_hash`, 1000 s window, 2 s cache.

- Keyed on the **miner's** `payout_script`, not `identity->payout_script`: `--fee` / `--redistribute` substitution changes whose PPLNS weight the share carries, but the cap is a property of who did the work.
- Unknown rate — fresh session, no pseudoshare in the window, non-P2PKH credentials, `--stratum-port 0`, stratum server torn down — yields `0.0` and the cap is inert.
- `stratum_server` is captured by reference and null-guarded, following the established style of the sibling lambdas in the same scope (`set_on_best_share_changed`, `set_on_state_dirty`). It is `reset()` before `work_source` unwinds.
- Lock order: `get_local_addr_rates()` takes only `StratumServer`'s `RateMonitor`/cache **leaf** mutexes — not `sessions_mutex_`, not `m_work_mutex` — so no new edge is added to the `build_connection_coinbase` lock graph.
- The producer `job_cache` (keyed `(prev_share_hash, payout_script)`, 30 s TTL) is unchanged, so the target is re-evaluated at most once per job rebuild. That damps rate jitter rather than churning `bits`.

### Cap 2 not wired

The dust-threshold ease (`work.py:317-326`) only ever makes the target **easier**, so it cannot mitigate over-minting, and it needs a pool-aps estimate at job time. `work_target.hpp` keeps it for a later port. Called out in the header comment.

## Worked numbers

Constants: `SHARE_PERIOD = 20`, `MAX_TARGET = 0xFFFF * 2**208` (bdiff 1), `ata(MAX_TARGET) = 4295032833`.

### Live operating point — 43 TH/s, `pre_target3` at share difficulty 40 000

```
pre_target3     = 0xFFFF*2**208 // 40000
                = 000000000001a36c8b4395810624dd2f1a9fbe76c8b4395810624dd2f1a9fbe7
                  bdiff 40 000        bits 0x1b01a36c
band            = [pre_target3//30, pre_target3]
pre_target3//30 = 0000000000000dfb15b573eab367a0f9096bb98c7e28240b780346dc5d638865
                  bdiff 1 200 000     bits 0x1a0dfb15

avg_attempts    = int(43e12 * 20 / 0.0167) = 51 497 005 988 023 952
cap target      = 2**256 // avg - 1
                = 000000000000016635c48b2e932ea609a3b4aa32cefaa1ba023ea945da766f85
                  bdiff 11 989 898     (~300x harder than pre_target3)

cap  <  band_lo  ->  clipped UP to the band edge
emitted bits    = 0x1a0dfb15, bdiff 1 200 000 = exactly 30x pre_target3
```

Expected mint interval, holding `pre_target3` fixed: **30x** the current interval. At the measured ~4 s/share that is **~120 s/share**, so a stale-work window spans ~0.2 shares instead of ~6.2.

Consistency check on the same figures: the pool rate implied by `pre_target3` is `ata(pre3)/SHARE_PERIOD = 8.59e12 H/s`. Our 43 TH/s is 5.0x that — which is exactly why the node mints ~5x too fast today. The cap binds above 1.67% of the implied pool rate (**143 GH/s**) and saturates at the band edge above `30 x 1.67% = 50.1%` (**4.30 TH/s**).

### Degenerate cases

| local rate | cap bdiff | vs band | emitted |
|---|---|---|---|
| `0` (unknown) | — (inert) | desired = `max_target` | `pre_target3` — **bit-identical to today** |
| 1 MH/s | 0.279 | easier than `pre_target3` | `pre_target3` — cap inert |
| 100 GH/s | 27 883 | easier than `pre_target3` (40 000) | `pre_target3` — cap inert |
| 1 TH/s | 278 835 | inside the band | `min(cap, pre3)` → cap binds |
| 43 TH/s | 11 989 898 | past `band_lo` | `band_lo` — clamped at the edge |
| ≥ 1.5e16 H/s | saturated | past `band_lo` | `band_lo` — clamped at the edge |

### Band-clamp verification

The clamp order is: **cap → `max_target` ceiling → chain band, band last**. `compute_share_target_pure` is unchanged; the cap only supplies its `desired_target` argument.

A canonical peer does **not** range-check our `bits` directly. `Share.check()` re-runs `generate_transaction()` feeding **our own emitted bits' target** back in as `desired_target` and requires the regenerated `share_info` to compare equal. So wire-compat requires the emitted bits to be a **fixed point** of

```
bits |-> from_target_upper_bound(clip(bits.target, (pre3//30, pre3)))
```

This matters: compact encoding is mantissa-**truncating**, so the target that round-trips out of the band-edge bits is always `<= pre_target3//30` by up to one mantissa ulp. A naive "emitted target inside `[pre3//30, pre3]`" assertion is the *wrong* predicate and fails on a correct implementation — the KATs assert the fixed point instead. (This is the single thing I most want a reviewer to check.)

`max_bits` is never modulated, so peers recompute the identical band.

## Consensus-neutrality (pre-v36 gate)

Files touched under `src/`: `main_dash.cpp`, `mint_runloop.hpp`, `stratum/work_target.hpp` — all DASH-fenced. Nothing in `src/core`, `src/sharechain`, or any other coin.

`git diff -U0 -- src/`, comment and blank lines removed, is 45 lines. The complete set of **behavioural** changes:

1. `mint_runloop.hpp`: `pin.desired_target = params.max_target;` → `pin.desired_target = desired_share_target(params, local_hash_rate);` — **the one consensus-path line**.
2. `mint_runloop.hpp`: new pure `desired_share_target()`; new defaulted trailing parameter on `build_producer_job`.
3. `main_dash.cpp`: rate lookup + capture of `stratum_server` + a rate-limited `[MINT-CAP]` log line (reads only).
4. `work_target.hpp`: uint64 saturation in `average_attempts_to_target` (below).

Grepping the diff's non-comment `+`/`-` lines for `timestamp|ref_hash|gentx|pplns|weight|coinbase|payee|donation|subsidy|serial|hash_link|absheight|abswork|far_share|tx_hashes|broadcast|block` returns exactly three hits, all non-behavioural:

- `identity->donation_u16, /*pool_tag=*/"c2pool"` — unchanged arguments, the line moved only because a new trailing argument was appended;
- `built->job.share_bits` / `built->job.share_max_bits` — read-only, inside the `LOG_INFO`.

Explicitly **not** touched: share serialization, `ref_hash` / gentx construction, PPLNS weight math, coinbase layout, masternode payee, `desired_timestamp` and the timestamp clip, the won-block dispatch path, `max_bits`, the vardiff/pseudoshare path, the X11 PoW and subsidy KATs.

`DashMintRunloopPoolShareCap.InertCapLeavesJobBytesIdentical` asserts byte-identity of `gentx_bytes`, `ref_hash`, `nonce64_offset` and `desired_timestamp` between a pre-cap build and an inert-cap build.

## Incidental fix: uint64 overflow in `average_attempts_to_target`

```cpp
uint288 avg_288(static_cast<uint64_t>(avg_attempts));   // UB when avg >= 2**64
```

Above `2**64` the narrowing is undefined and yields `0` on x86-64, so the following `two_256 / avg_288` **throws "Division by zero"**. `work_source.cpp` catches that and degrades to the non-producer coinbase — i.e. minting silently stops.

Previously unreachable (the only caller passed `local_hash_rate` un-multiplied). Cap 1 scales by `SHARE_PERIOD/0.0167 ≈ 1198`, putting the boundary at **~1.5e16 H/s of measured local rate** — high, but this is a fail-open-into-no-minting failure on a consensus path, so it is fixed here rather than left latent. It was found by the sweep KAT, not by review.

Saturating at `UINT64_MAX` gives `2**256//2**64 - 1`, far harder than any chain band, which the band clip pins to the edge — the same answer the unbounded oracle integer clips to. The oracle's exact value is only ever observable *inside* the band, where no saturation occurs.

The same latent narrowing exists in the LTC inlined copy (`main_ltc.cpp:4538`). **Not** touched here — out of scope for a DASH consensus PR. Worth a follow-up.

## Tests

Folded into existing allowlisted CI targets (`.github/workflows/build.yml` `--target`); no new `add_executable`, no `build.yml` change.

**`test_dash_work_target`** (allowlisted directly) — cap arithmetic:
- `Cap1ProductionOperatingPoint` — 43 TH/s → the exact hex above
- `Cap1SmallMinerInert` — 100 GH/s against `pre_target3`@40 000 is a no-op
- `Cap1LargeMinerBinds` — 1 TH/s binds, exact hex
- `AverageAttemptsToTargetSaturatesAboveU64` — saturation vector + `EXPECT_NO_THROW` at 1e18 / 1e30 H/s

**`test_dash_share_producer.cpp`** (compiled into allowlisted `test_dash_share_hash_link`) — cap composed with the band, on a deep synthetic chain where `pre_target3 = prev_max*11//10` (bits `0x1c233332`, band edge `0x1c012c5f`):
- `ZeroHashrateIsUnchanged` — identical `bits`/`max_bits` to the `params.max_target` call
- `SmallMinerUnaffected` — 1 MH/s → `pre_target3`
- `MidMinerInsideBand` — 100 MH/s → `0x1c092e50`, strictly interior (proves the clamp is a real clip, not an unconditional snap to the edge)
- `LargeMinerClampsAtBandEdgeNotBeyond` — 43 TH/s → exactly `0x1c012c5f`, raw cap asserted to have been outside the band, emitted bits survive the canonical re-derivation
- `EmittedBitsAlwaysSurvivePeerRecheck` — sweep `{0, 1, 1e3, 1e6, 1e8, 1e9, 1e10, 1e12, 43e12, 1e18, 1e30}`, fixed point holds for all

**`test_dash_mint_runloop.cpp`** (same target) — end-to-end through `build_producer_job`, mainnet params, genesis retarget arm (`pre_target3 = MAX`, band `[MAX//30, MAX]`):
- `ZeroRateIsPreCapBehaviour` — `0x1d00ffff`, plus the default-argument overload, plus `desired_share_target(params, 0) == params.max_target`
- `SmallMinerUnaffected` — 1 MH/s → `0x1d00ffff`
- `MidMinerInsideBand` — 100 MH/s → `0x1c092e50`
- `LargeMinerClampsAtBandEdge` — 43 TH/s / 1e18 / 1e30 → `0x1c088880` (bdiff exactly 30), `max_bits` untouched
- `InertCapLeavesJobBytesIdentical` — gentx / ref_hash / offset / timestamp byte-identity
- `FrozenDesiredTargetIsTheModulatedOne` — the registry-frozen `desired_target` is the modulated one, so the mint-time rebuild reproduces the same committed bits

All goldens were derived independently from the oracle integer formulas in `python3` (derive line on each vector), not from the SUT.

### Results (Linux x86_64, GCC 13, Release)

```
cmake --build build_ci --target c2pool-dash            -> OK
ctest -R Dash                                          -> 100% tests passed, 0 failed out of 718
./src/c2pool/c2pool-dash --selftest                    -> OK
    x11 KAT mainnet-genesis  ok
    x11 KAT testnet3-#1497944  ok
    subsidy h=2459985 reward = 177022505  ok
    masternode payment 3/4 of 2.0 DASH = 150000000  ok
```

## Residual risk — what I want the reviewer to focus on

1. **The fixed-point predicate.** The wire-compat argument rests on `Share.check()` re-deriving `bits` from our own emitted target rather than range-checking it. If a canonical peer instead compares against the *exact* `pre_target3//30` big-integer, the truncating compact encoding puts us one mantissa ulp on the wrong side. Worth confirming against the oracle source before this leaves draft.

2. **Rate-signal quality at job time.** The `RateMonitor` window is 1000 s with a 2 s cache; the job cache holds a target for up to 30 s. A miner that ramps hard inside one window is capped on a stale (low) estimate — safe direction (under-capping = today's behaviour). A miner that stops and restarts within the window is capped on a stale (high) estimate, which makes its target harder than warranted and lowers its share rate; it cannot produce an out-of-band target, but it can under-mint. No hysteresis is applied.

3. **Retarget interaction.** `get_pool_attempts_per_second` uses `min_work = ata(max_bits)`, i.e. it counts each share as one *pool-target* unit regardless of the share's own `bits`. So the cap reduces our share *count*, which feeds back into `pre_target3` through the ±10% per-share clamp. The immediate effect (30x harder, ~120 s/share) is what the numbers above show at fixed `pre_target3`; the equilibrium the chain settles into afterwards is a separate question and is **not** claimed here. A soak on a live tip is the right way to confirm it.

4. **`&stratum_server` capture.** It follows the established pattern of the two sibling lambdas in the same scope and is null-guarded, but it is a raw reference into `main`'s frame held by a `shared_ptr`-owned lambda. Destruction order (`work_source` before `stratum_server`, plus the explicit `stratum_server.reset()` at the end of `run_node`) makes it safe today.

5. **Cap 2 absence.** Small miners on a high-difficulty chain still get no dust ease. Unchanged from today, but now the asymmetry is more visible.

Draft. Not for self-merge.
