### PR TITLE
doge(underfill): opt-in fill_unknown_fee Pass 2 -> complete near-empty embedded-GBT template

### DIFF
--- a/src/impl/doge/coin/template_builder.hpp
+++ b/src/impl/doge/coin/template_builder.hpp
@@ -100,7 +100,8 @@ public:
 
         // ── Transactions from mempool (fee-sorted when UTXO available) ──
         auto [selected_txs, total_fees] =
-            pool.get_sorted_txs_with_fees(MAX_BLOCK_WEIGHT - COINBASE_RESERVE);
+            pool.get_sorted_txs_with_fees(MAX_BLOCK_WEIGHT - COINBASE_RESERVE,
+                                          /*fill_unknown_fee=*/true);
 
         // coinbasevalue = block reward + included transaction fees
         uint64_t coinbasevalue = subsidy + total_fees;

--- a/src/impl/ltc/coin/mempool.hpp
+++ b/src/impl/ltc/coin/mempool.hpp
@@ -346,7 +346,8 @@ public:
     /// Transactions with known fees are prioritized; unknown-fee txs fill remaining space.
     /// Returns total_fees across all selected transactions (known fees only).
     std::pair<std::vector<SelectedTx>, uint64_t>
-    get_sorted_txs_with_fees(uint32_t max_weight) const {
+    get_sorted_txs_with_fees(uint32_t max_weight,
+                             bool fill_unknown_fee = false) const {
         std::lock_guard<std::mutex> lock(m_mutex);
 
         std::vector<SelectedTx> result;
@@ -388,10 +389,53 @@ public:
             selected.insert(entry.txid);
         }
 
-        // Unknown-fee txs excluded from template — they'll be included
-        // after fee revalidation once UTXO processes their input blocks.
-        // Including them with fee=0 would cause coinbasevalue mismatch
-        // vs p2pool (which gets accurate fees from daemon GBT).
+        // ── Pass 2: fill remaining weight with unknown-fee txs (opt-in) ─────
+        // Root cause of the [EMB-DOGE]/[EMB-DGB] TemplateBuilder UNDERFILL:
+        // Pass 1 above skips EVERY fee_known=false tx, so an embedded UTXO set
+        // that cannot resolve a large multi-input tx's fee (input unconfirmed /
+        // spent from an in-mempool parent) drops that tx from the template
+        // entirely — a near-empty block on a non-empty mempool. The GBT shapers
+        // already emit these with fee=null and p2pool excludes null-fee txs from
+        // the coinbasevalue (base_subsidy fallback, data.py:876-884), so
+        // including them here is a template-fill completion that leaves
+        // total_fees — hence coinbasevalue and the gentx — byte-for-byte
+        // unchanged. Consensus-neutral for the share; opt-in so the proven LTC
+        // parent path stays untouched.
+        if (fill_unknown_fee) {
+            auto* utxo2 = m_utxo.load();
+            for (const auto& [ts, txid] : m_time_index) {
+                if (selected.count(txid)) continue;                 // in Pass 1 already
+                auto pit = m_pool.find(txid);
+                if (pit == m_pool.end()) continue;
+                const auto& entry = pit->second;
+                if (entry.fee_known) continue;                      // Pass 1 territory
+                if (total_weight + entry.weight > max_weight) continue;
+
+                // Same input-existence guard as Pass 1: never pack a tx that
+                // spends an output absent from BOTH the UTXO set and the mempool
+                // (CPFP parent). Genuinely stale txs stay excluded.
+                if (utxo2) {
+                    bool inputs_ok = true;
+                    for (const auto& vin : entry.tx.vin) {
+                        core::coin::Outpoint op(vin.prevout.hash, vin.prevout.index);
+                        core::coin::Coin coin;
+                        if (!utxo2->get_coin(op, coin)) {
+                            if (!m_pool.count(vin.prevout.hash) ||
+                                vin.prevout.index >= m_pool.at(vin.prevout.hash).tx.vout.size()) {
+                                inputs_ok = false;
+                                break;
+                            }
+                        }
+                    }
+                    if (!inputs_ok) continue;
+                }
+
+                total_weight += entry.weight;
+                // fee intentionally NOT summed — unknown, shaped as fee=null.
+                result.push_back({entry.tx, 0, false});
+                selected.insert(entry.txid);
+            }
+        }
 
         return {std::move(result), total_fees};
     }

--- a/src/impl/ltc/test/CMakeLists.txt
+++ b/src/impl/ltc/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (BUILD_TESTING AND GTest_FOUND)
-    add_executable(share_test share_test.cpp f11_donation_invariance_test.cpp emergency_decay_overflow_test.cpp wirecompat_runtime_test.cpp desired_version_tally_test.cpp auto_ratchet_sim_test.cpp auto_ratchet_tail_guard_test.cpp chain_walk_window_test.cpp)
+    add_executable(share_test share_test.cpp f11_donation_invariance_test.cpp emergency_decay_overflow_test.cpp wirecompat_runtime_test.cpp desired_version_tally_test.cpp auto_ratchet_sim_test.cpp auto_ratchet_tail_guard_test.cpp chain_walk_window_test.cpp doge_template_underfill_test.cpp)
     target_link_libraries(share_test PRIVATE
         GTest::gtest_main GTest::gtest
         core ltc

--- a/src/impl/ltc/test/doge_template_underfill_test.cpp
+++ b/src/impl/ltc/test/doge_template_underfill_test.cpp
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// ---------------------------------------------------------------------------
+// doge_template_underfill_test.cpp -- regression pin for the [EMB-DOGE]
+// TemplateBuilder UNDERFILL (contabo v36 cutover CODE gate (a)).
+//
+// Root cause: Mempool::get_sorted_txs_with_fees selected ONLY fee_known txs and
+// silently dropped every fee_known=false tx, so an embedded DOGE UTXO set that
+// could not resolve a large multi-input tx's fee produced a near-empty block on
+// a non-empty mempool (24/35 tx, 5298/105766 B in the live journal 2026-07-25).
+// The fix adds an opt-in Pass 2 that fills the remaining weight with unknown-fee
+// txs WITHOUT crediting their (unknown) fees, so total_fees / coinbasevalue /
+// gentx stay byte-for-byte unchanged (consensus-neutral, pre-v36 rule).
+//
+// Fixture: >=35 tx (24 fee_known + 11 fee_unknown) so the regression cannot
+// silently return. Exercises the shared ltc::coin::Mempool directly (the DOGE
+// embedded TemplateBuilder reuses it).
+// ---------------------------------------------------------------------------
+#include <cstdint>
+
+#include <gtest/gtest.h>
+
+#include <impl/ltc/coin/mempool.hpp>
+#include <impl/ltc/coin/transaction.hpp>
+#include <core/uint256.hpp>
+
+using ltc::coin::Mempool;
+using ltc::coin::MutableTransaction;
+using ltc::coin::TxIn;
+using ltc::coin::TxOut;
+using ltc::coin::compute_txid;
+
+namespace {
+
+MutableTransaction tagged_tx(int64_t value, uint32_t index)
+{
+    MutableTransaction tx;
+    tx.version = 1;
+    tx.locktime = 0;
+    TxIn in;
+    in.prevout.hash.SetNull();
+    in.prevout.index = index;
+    in.sequence = 0xffffffff;
+    tx.vin.push_back(in);
+    TxOut out;
+    out.value = value;
+    tx.vout.push_back(out);
+    return tx;
+}
+
+constexpr int      KNOWN       = 24;
+constexpr int      UNKNOWN     = 11;
+constexpr int      TOTAL       = KNOWN + UNKNOWN;   // 35, matching the live journal
+constexpr uint32_t BIG_WEIGHT  = 4000000u;
+
+// Build TOTAL distinct txs; the first KNOWN carry a resolved fee, the remaining
+// UNKNOWN are left fee_known=false. Returns the sum of the known fees.
+uint64_t build_fixture(Mempool& pool)
+{
+    uint64_t known_fee_sum = 0;
+    for (int i = 0; i < TOTAL; ++i) {
+        MutableTransaction tx = tagged_tx(1000 + i, static_cast<uint32_t>(i));
+        EXPECT_TRUE(pool.add_tx(tx));
+        if (i < KNOWN) {
+            const uint64_t fee = 100 + static_cast<uint64_t>(i);
+            pool.set_tx_fee(compute_txid(tx), fee);
+            known_fee_sum += fee;
+        }
+    }
+    EXPECT_EQ(pool.size(), static_cast<size_t>(TOTAL));
+    return known_fee_sum;
+}
+
+} // namespace
+
+// Default (proven LTC parent path): unchanged -- only fee_known txs selected.
+TEST(DogeTemplateUnderfill, DefaultSelectsOnlyKnownFeeTxs)
+{
+    Mempool pool;
+    const uint64_t known_fee_sum = build_fixture(pool);
+
+    auto [selected, total_fees] = pool.get_sorted_txs_with_fees(BIG_WEIGHT);
+    EXPECT_EQ(selected.size(), static_cast<size_t>(KNOWN));
+    EXPECT_EQ(total_fees, known_fee_sum);
+    for (const auto& s : selected) EXPECT_TRUE(s.fee_known);
+}
+
+// Fix (embedded DOGE path): Pass 2 fills the template with the unknown-fee
+// backlog, resolving the UNDERFILL -- WITHOUT moving total_fees (coinbasevalue /
+// gentx byte-identical). This is the regression pin.
+TEST(DogeTemplateUnderfill, FillIncludesUnknownFeeBacklogWithoutMovingFees)
+{
+    Mempool pool;
+    const uint64_t known_fee_sum = build_fixture(pool);
+
+    auto [selected, total_fees] =
+        pool.get_sorted_txs_with_fees(BIG_WEIGHT, /*fill_unknown_fee=*/true);
+    EXPECT_EQ(selected.size(), static_cast<size_t>(TOTAL));   // all 35 packed
+    EXPECT_EQ(total_fees, known_fee_sum);                     // fees UNCHANGED
+
+    int known = 0, unknown = 0;
+    for (const auto& s : selected) (s.fee_known ? known : unknown)++;
+    EXPECT_EQ(known, KNOWN);
+    EXPECT_EQ(unknown, UNKNOWN);
+}
+
+// Pass 2 still honors the weight budget (never overfills the block).
+TEST(DogeTemplateUnderfill, FillRespectsWeightBudget)
+{
+    Mempool pool;
+    build_fixture(pool);
+
+    auto [full, full_fees] =
+        pool.get_sorted_txs_with_fees(BIG_WEIGHT, /*fill_unknown_fee=*/true);
+    (void)full_fees;
+    ASSERT_EQ(full.size(), static_cast<size_t>(TOTAL));
+
+    // A 1-weight budget fits nothing; selection must not exceed it.
+    auto [capped, capped_fees] =
+        pool.get_sorted_txs_with_fees(1u, /*fill_unknown_fee=*/true);
+    (void)capped_fees;
+    EXPECT_LT(capped.size(), static_cast<size_t>(TOTAL));
+}


### PR DESCRIPTION
## Summary
Adds an opt-in second fill pass (fill_unknown_fee) so a near-empty embedded-DOGE GBT template can be completed from the unknown-fee mempool backlog without disturbing the known-fee selection or fee accounting.

## Behavior
- Default OFF: selection is unchanged (known-fee txs only).
- When enabled: unknown-fee backlog is appended under the remaining weight budget; fees are not moved/recomputed for already-selected txs.

## Tests (LTC share_test, HEAD c9f3fca7)
- DogeTemplateUnderfill.DefaultSelectsOnlyKnownFeeTxs
- DogeTemplateUnderfill.FillIncludesUnknownFeeBacklogWithoutMovingFees
- DogeTemplateUnderfill.FillRespectsWeightBudget
Full LTC suite: 46/46 PASS, EXIT=0 (Linux x86_64).

Gates the contabo LTC/DOGE prod cutover embedded-GBT completeness item.