### PR TITLE
ci(doge): real DOGE AuxPoW smoke — fixes the hollow-green doge coin-matrix cell

### DIFF
--- a/.github/workflows/doge-aux-smoke.yml
+++ b/.github/workflows/doge-aux-smoke.yml
@@ -1,0 +1,105 @@
+name: DOGE AuxPoW smoke — embedded per-coin gtests
+
+# Per-coin smoke for the DOGE lane. DOGE is the AuxPoW child embedded in the
+# merged c2pool-ltc binary — there is no standalone main_doge.cpp — so the
+# coin-matrix "doge" cell gated on that path and if:-skipped every real step
+# (hollow green). This job instead exercises the embedded DOGE path directly:
+# ctest -R the DOGE gtest suites BY NAME over the impl/doge/coin objects, with
+# an empty-suite guard demanding a positive test count (false-green trap lives
+# in the gate script). CI plumbing only — NO consensus knowledge here; the
+# ltc-doge lane owns the targets and tests/gates/doge_aux_smoke.sh.
+#
+# Neutral-skip: on branches lacking the DOGE AuxPoW sources the job is a green
+# no-op. Register as a required check only after a confirmed non-hollow green
+# rollup on the runner.
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  doge-aux-smoke:
+    name: DOGE AuxPoW smoke — embedded per-coin gtests
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set per-job Conan home
+        run: |
+          # github-hosted: ephemeral per-job home, warmed by actions/cache below.
+          # self-hosted:   PERSISTENT home keyed on the runner instance. A runner
+          # executes one job at a time, so this home is never contended (no
+          # sqlite "failed to acquire database lock in 20s") while still keeping
+          # the per-job isolation of #704/#710 -- no two concurrent jobs share it.
+          # Being persistent, it also takes the GH cache-service restore off the
+          # hot path: that restore times out on VM905 ("Failed to restore: The
+          # operation cannot be completed in timeout") and its miss cascaded into
+          # a cold from-source Boost rebuild on all 8 runners at once.
+          if [ "${{ runner.environment }}" = "github-hosted" ]; then
+            echo "CONAN_HOME=$RUNNER_TEMP/conan2" >> "$GITHUB_ENV"
+          else
+            echo "CONAN_HOME=$HOME/.conan2-ci/$RUNNER_NAME" >> "$GITHUB_ENV"
+          fi
+
+      - name: Check DOGE AuxPoW source presence
+        id: presence
+        run: |
+          if [ -f "src/impl/doge/coin/auxpow_header.hpp" ] && [ -f "tests/gates/doge_aux_smoke.sh" ]; then
+            echo "exists=1" >> "$GITHUB_OUTPUT"
+            echo "::notice::DOGE AuxPoW sources present — running per-coin smoke."
+          else
+            echo "exists=0" >> "$GITHUB_OUTPUT"
+            echo "::notice::DOGE AuxPoW sources absent on this branch — neutral skip."
+          fi
+
+      - name: Install system dependencies
+        if: steps.presence.outputs.exists == '1' && runner.environment == 'github-hosted'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends g++ cmake make libleveldb-dev libsecp256k1-dev
+
+      - uses: actions/setup-python@v6
+        if: steps.presence.outputs.exists == '1' && runner.environment == 'github-hosted'
+        with: { python-version: '3.12' }
+
+      - name: Install Conan 2
+        if: steps.presence.outputs.exists == '1'
+        run: |
+          if [ "${{ runner.environment }}" = "github-hosted" ]; then
+            pip install "conan>=2.0,<3.0"
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          else
+            conan --version   # pre-provisioned at /usr/local/bin on self-hosted
+          fi
+
+      - name: Show committed Conan profile
+        if: steps.presence.outputs.exists == '1'
+        run: conan profile show -pr:a=ci/conan/linux-gcc13.profile
+
+      - name: Restore Conan cache (github-hosted only)
+        if: runner.environment == 'github-hosted' && steps.presence.outputs.exists == '1'
+        uses: actions/cache@v5
+        with:
+          path: ${{ runner.temp }}/conan2
+          key: conan2-ubuntu24-gcc13-doge-smoke-${{ hashFiles('conanfile.txt', 'ci/conan/linux-gcc13.profile', 'conan.lock') }}
+          restore-keys: |
+            conan2-ubuntu24-gcc13-doge-smoke-
+            conan2-ubuntu24-gcc13-
+
+      - name: Clean stale build dir (self-hosted workspace is reused)
+        if: steps.presence.outputs.exists == '1' && runner.environment != 'github-hosted'
+        run: rm -rf build_doge_smoke
+
+      - name: Run DOGE AuxPoW smoke (ltc-doge-lane entrypoint)
+        if: steps.presence.outputs.exists == '1'
+        env:
+          BUILD_DIR: ${{ github.workspace }}/build_doge_smoke
+        run: bash tests/gates/doge_aux_smoke.sh
+
+      # Steady-state disk hygiene on the VM905 self-hosted runners: drop the
+      # checkout payload and _temp, keep _actions/_tool/_update. Always runs.
+      - name: Prune runner workspace
+        if: always()
+        uses: ./.github/actions/prune-runner-workspace

--- a/tests/gates/doge_aux_smoke.sh
+++ b/tests/gates/doge_aux_smoke.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# DOGE AuxPoW per-coin smoke (CI entrypoint). ltc-doge-production-steward 2026-07-26.
+#
+# WHY this shape: DOGE is the AuxPoW *child* of the merged LTC/DOGE release, so
+# there is no standalone main_doge.cpp / c2pool-doge binary to smoke — the DOGE
+# path ships EMBEDDED in c2pool-ltc via impl/doge/coin/*. The coin-matrix.yml
+# "doge" cell therefore skip-passes (source-presence gate: no main_doge.cpp) and
+# asserts nothing (hollow-green). This gate replaces that hollow pass with real
+# DOGE-specific assertions over the SAME impl/doge/coin/* objects the merged
+# c2pool-ltc binary links: AuxPoW parent-link construction (parent coinbase +
+# CMerkleTx.block_hash + parent 80B header, KAT against real DOGE mainnet block
+# #371337) and the DOGE coin_params load (AUXPOW_CHAIN_ID 0x0062, era heights).
+#
+# Fenced exactly like tests/gates/dgb_phase_b_smoke.sh: workflow + this entrypoint
+# over an EXISTING doge gtest target (test_doge_chain, wired at test/CMakeLists.txt).
+# No coin-matrix.yml / build.yml / CMake / src/core / bitcoin_family edits.
+# Deterministic: exit 0 = pass; nonzero = failure / hollow run.
+set -euo pipefail
+
+GATE="DOGE AuxPoW smoke"
+# DOGE-specific suites in test_doge_chain: AuxPoW parent-link (structured +
+# real-block KAT), the parser, and the coin_params/consensus-era load. These are
+# the embedded impl/doge/coin/* surfaces the merged c2pool-ltc binary depends on.
+TEST_REGEX="^(AuxPowKnownAnswer|AuxPowStructured|AuxPowParser|DOGEChainParams|DOGESubsidy|DigiShield|MersenneTwister)Test\."
+TARGETS=(test_doge_chain)
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BUILD_DIR="${BUILD_DIR:-$REPO_ROOT/build}"
+
+# 1. Configure (conan + cmake) only if the CI cache is cold.
+if [ ! -f "$BUILD_DIR/CMakeCache.txt" ]; then
+  echo "[$GATE] no build dir at $BUILD_DIR — configuring (conan + cmake)"
+  conan install "$REPO_ROOT" -pr:a="$REPO_ROOT/ci/conan/linux-gcc13.profile" --lockfile="$REPO_ROOT/conan.lock" --build=missing --output-folder="$BUILD_DIR" --settings=build_type=Release
+  cmake -S "$REPO_ROOT" -B "$BUILD_DIR" \
+    -DCMAKE_TOOLCHAIN_FILE="$BUILD_DIR/conan_toolchain.cmake" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_TESTING=ON
+fi
+cmake --build "$BUILD_DIR" --target "${TARGETS[@]}" -j"$(nproc)"
+
+# 2. Run from build/ (false-green trap: wrong CWD prints "No tests were found!!!"
+#    and EXITS 0).
+set +e
+OUT="$(cd "$BUILD_DIR" && ctest -R "$TEST_REGEX" --output-on-failure 2>&1)"
+RC=$?
+set -e
+echo "$OUT"
+
+# 3. Empty-suite guard: demand a positive test count actually ran.
+if grep -q "No tests were found" <<<"$OUT"; then
+  echo "[$GATE] FAIL — hollow run: 0 tests matched $TEST_REGEX" >&2
+  exit 1
+fi
+N="$(grep -oE "out of [0-9]+" <<<"$OUT" | grep -oE "[0-9]+" | tail -1)"
+if [ -z "${N:-}" ] || [ "$N" -lt 1 ]; then
+  echo "[$GATE] FAIL — no positive test count parsed" >&2
+  exit 1
+fi
+if [ "$RC" -ne 0 ]; then
+  echo "[$GATE] FAIL — ctest exit $RC ($N tests)" >&2
+  exit "$RC"
+fi
+echo "[$GATE] PASS — $N DOGE AuxPoW/coin_params assertions green"


### PR DESCRIPTION
Operator tap: **install** (card [decision-needed] "Install DOGE AuxPoW CI smoke workflow", answered 2026-07-26 03:03Z).

Two commits:
1. `897f8a39` (ltc-doge lane) — `tests/gates/doge_aux_smoke.sh`, the per-coin gate script.
2. `6e206610` (integrator) — `.github/workflows/doge-aux-smoke.yml`, structural clone of `dgb-phase-b-smoke.yml`.

**Why:** coin-matrix `doge` cell gates every real step on `src/c2pool/main_doge.cpp`, which does not exist — DOGE is the AuxPoW child embedded in the merged `c2pool-ltc` binary. All steps if:-skip, so the required check asserts nothing.

**Non-hollow evidence (ltc-doge lane, this cycle):**
- Flipping embedded `AUXPOW_CHAIN_ID` 0x0062 -> 0x0063 makes the gate exit 8 (red).
- Unmodified master: 31/31 assertions green, exit 0.
- Asserts AuxPoW parent-link construction as a KAT vs real DOGE mainnet block #371337 + a self-hosted regtest h20 block, plus coin_params load.

**Scope:** gate script + new workflow file only. No coin-matrix.yml / build.yml / CMake / src/core / bitcoin_family edits. Single coin tree (`src/impl/doge/`) — per-coin isolation held.

Register as a required check only after a confirmed non-hollow green on the runner.