### PR TITLE
btc: F3 known-txs retention/backable primitives + unit KAT

### DIFF
--- a/src/impl/btc/known_txs_retention.hpp
+++ b/src/impl/btc/known_txs_retention.hpp
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Pure, unit-testable bookkeeping for the known-transaction pool that backs
+// share broadcast (remember_tx forwarding). Ported to the BTC variant from
+// src/impl/dash/known_txs_retention.hpp so the retention/eviction and
+// broadcast-gate semantics can be exercised without a live node.
+//
+// Two concerns:
+//   retain_template_txs() — the rolling-window retention with template-identity
+//     dedup (code review F1): register_template_txs is invoked per producer-job
+//     cache MISS, i.e. per (prev_share_hash, payout_script), NOT per template
+//     rotation. A ~50-payout-script cluster therefore re-registers the SAME
+//     template ~50 times on one tip; pushing each unconditionally collapses the
+//     N-slot window to a single template within seconds. Dedup by the template's
+//     tx-hash SET (its identity): a set already retained refreshes recency and
+//     consumes NO new slot, so N re-registrations of one template use ONE slot
+//     and the window holds N DISTINCT templates as intended.
+//
+//   all_txs_backable() — the canonical broadcast gate (F3): a share may be sent
+//     only when we HOLD the bytes of every referenced new-tx (so remember_tx can
+//     always forward them). This is what makes the "referenced unknown
+//     transaction" disconnect unreachable by construction, and — paired with the
+//     mint-time decline of shares whose txs are not retained — makes "every share
+//     we mint/broadcast is backable" a by-construction invariant.
+//
+// NOTE (BTC wiring): the call-sites that plug these primitives into
+// send_shares / create_share_fn depend on how the BTC share model carries its
+// referenced new-tx hashes; that wiring is tracked separately. This header is
+// the pure primitive + its unit coverage.
+
+#pragma once
+
+#include <cstddef>
+#include <deque>
+#include <set>
+#include <vector>
+
+#include <core/uint256.hpp>
+
+namespace btc {
+
+// Retain the tx set of a newly-registered template in a rolling window of the
+// last `cap` DISTINCT templates, inserting its tx bytes into `known_txs`.
+//
+//   recent_sets : rolling history of distinct template tx-hash sets
+//                 (front = oldest, back = newest).
+//   known_txs   : uint256 -> tx map; needs insert_or_assign(k,v) and erase(k).
+//   hashes/txs  : parallel arrays of the template's tx hashes and bytes.
+//   cap         : number of DISTINCT templates to retain.
+//
+// A tx is erased from `known_txs` only once it has fallen out of EVERY retained
+// set. F1 dedup: if this template's tx set is already retained, its recency is
+// refreshed (moved to back) and no new slot is consumed.
+template <typename TxMap, typename Tx>
+inline void retain_template_txs(std::deque<std::set<uint256>>& recent_sets,
+                                TxMap& known_txs,
+                                const std::vector<uint256>& hashes,
+                                const std::vector<Tx>& txs,
+                                std::size_t cap)
+{
+    if (cap == 0)
+        return;
+
+    std::set<uint256> new_set(hashes.begin(), hashes.end());
+
+    // F1 dedup by template identity (the tx-hash set). If this template is
+    // already retained, refresh its recency (move to back) — no new slot, no
+    // re-eviction. This is what stops ~50 payout-script re-registrations of one
+    // template from evicting the rest of the window.
+    for (auto it = recent_sets.begin(); it != recent_sets.end(); ++it) {
+        if (*it == new_set) {
+            if (std::next(it) != recent_sets.end()) {
+                std::set<uint256> refreshed = std::move(*it);
+                recent_sets.erase(it);
+                recent_sets.push_back(std::move(refreshed));
+            }
+            return;
+        }
+    }
+
+    // Distinct template: insert its tx bytes and consume a slot.
+    const std::size_t n = std::min(hashes.size(), txs.size());
+    for (std::size_t i = 0; i < n; ++i)
+        known_txs.insert_or_assign(hashes[i], txs[i]);
+    recent_sets.push_back(std::move(new_set));
+
+    // Evict the oldest slots beyond `cap`; a tx is removed from `known_txs` only
+    // once it is absent from EVERY remaining retained set.
+    while (recent_sets.size() > cap) {
+        const std::set<uint256> evicted = std::move(recent_sets.front());
+        recent_sets.pop_front();
+        for (const auto& h : evicted) {
+            bool still_retained = false;
+            for (const auto& s : recent_sets) {
+                if (s.count(h)) { still_retained = true; break; }
+            }
+            if (!still_retained)
+                known_txs.erase(h);
+        }
+    }
+}
+
+// True iff every hash in `tx_hashes` is present in `held` (the bytes we hold,
+// e.g. m_known_txs). The canonical broadcast gate: a share is backable — safe to
+// send without risking the peer's "referenced unknown transaction" disconnect —
+// only when we can forward every referenced tx.
+template <typename Held>
+inline bool all_txs_backable(const std::vector<uint256>& tx_hashes,
+                             const Held& held)
+{
+    for (const auto& h : tx_hashes)
+        if (held.find(h) == held.end())
+            return false;
+    return true;
+}
+
+} // namespace btc

--- a/src/impl/btc/test/CMakeLists.txt
+++ b/src/impl/btc/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 if (BUILD_TESTING AND GTest_FOUND)
     # btc twin of ltc share_test — uniquely named to avoid the CMP0002 target
     # collision with src/impl/ltc/test (both subdirs build in the same tree).
-    add_executable(btc_share_test share_test.cpp f11_donation_invariance_test.cpp f10b_version_punish_removal_test.cpp g01_share_format_parity_test.cpp auto_ratchet_sim_test.cpp block_broadcast_guard_test.cpp block_broadcast_connect_test.cpp regtest_sharechain_isolation_test.cpp stratum_merkle_branch_test.cpp witness_commitment_merkle_test.cpp finder_fee_integer_exact_test.cpp rpc_conf_test.cpp genesis_check_test.cpp won_share_dualpath_test.cpp gentx_unpack_test.cpp block_assembly_test.cpp gentx_coinbase_test.cpp template_capture_test.cpp template_other_txs_test.cpp reconstruct_test.cpp)
+    add_executable(btc_share_test share_test.cpp f11_donation_invariance_test.cpp f10b_version_punish_removal_test.cpp g01_share_format_parity_test.cpp auto_ratchet_sim_test.cpp block_broadcast_guard_test.cpp block_broadcast_connect_test.cpp regtest_sharechain_isolation_test.cpp stratum_merkle_branch_test.cpp witness_commitment_merkle_test.cpp finder_fee_integer_exact_test.cpp rpc_conf_test.cpp genesis_check_test.cpp won_share_dualpath_test.cpp gentx_unpack_test.cpp block_assembly_test.cpp gentx_coinbase_test.cpp template_capture_test.cpp template_other_txs_test.cpp reconstruct_test.cpp known_txs_retention_test.cpp)
     target_link_libraries(btc_share_test PRIVATE
         GTest::gtest_main GTest::gtest
         core btc

--- a/src/impl/btc/test/known_txs_retention_test.cpp
+++ b/src/impl/btc/test/known_txs_retention_test.cpp
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// F3 backable-broadcast gate + F1 template-identity retention — BTC unit KAT.
+//
+// Covers the two pure primitives ported from the DASH variant into
+// src/impl/btc/known_txs_retention.hpp:
+//
+//   retain_template_txs() — F1 template-identity dedup: N re-registrations of
+//     ONE template consume ONE slot while the rolling window still holds N
+//     DISTINCT templates; a tx leaves known_txs only once it is absent from
+//     EVERY retained set.
+//
+//   all_txs_backable() — F3 broadcast gate: a share is backable (safe to send
+//     without the peer's "referenced unknown transaction" disconnect) only when
+//     we hold the bytes of every referenced new-tx.
+//
+// Non-hollow guard: BackableGate.UnheldTxIsNotBackable asserts false for a share
+// referencing an unheld tx; deleting the gate (all_txs_backable → always true)
+// flips it red. Dedup.OneTemplateConsumesOneSlot asserts size==1 after N
+// re-registrations; dropping the dedup (push every registration) flips it red.
+
+#include <gtest/gtest.h>
+
+#include <deque>
+#include <map>
+#include <set>
+#include <vector>
+
+#include <core/uint256.hpp>
+#include <impl/btc/known_txs_retention.hpp>
+
+namespace {
+
+// Distinct, deterministic uint256 tx hashes A..E.
+uint256 h(const char* hex)
+{
+    uint256 v; v.SetHex(hex); return v;
+}
+const uint256 A = h("aa");
+const uint256 B = h("bb");
+const uint256 C = h("cc");
+const uint256 D = h("dd");
+const uint256 E = h("ee");
+
+// A tx-bytes stand-in; the retention logic is agnostic to the payload type.
+using TxMap = std::map<uint256, int>;
+
+} // namespace
+
+// F1: re-registering the SAME template (identical tx-hash set) N times consumes
+// exactly ONE slot and refreshes recency — it must NOT collapse the window.
+TEST(BtcKnownTxsRetention, OneTemplateConsumesOneSlot)
+{
+    std::deque<std::set<uint256>> recent;
+    TxMap known;
+
+    const std::vector<uint256> hashes{A, B};
+    const std::vector<int>     txs{1, 2};
+
+    for (int i = 0; i < 5; ++i)
+        btc::retain_template_txs(recent, known, hashes, txs, /*cap=*/3);
+
+    EXPECT_EQ(recent.size(), 1u);      // dedup: 5 registrations -> 1 slot
+    EXPECT_EQ(known.size(), 2u);       // A,B inserted once
+    EXPECT_TRUE(known.count(A));
+    EXPECT_TRUE(known.count(B));
+}
+
+// F1: the window holds N DISTINCT templates, and a tx is evicted only once it
+// has fallen out of EVERY retained set (B survives in T2 after T1 is evicted).
+TEST(BtcKnownTxsRetention, WindowHoldsDistinctTemplatesAndEvictsCorrectly)
+{
+    std::deque<std::set<uint256>> recent;
+    TxMap known;
+    const std::vector<int> two{1, 2};
+
+    btc::retain_template_txs(recent, known, std::vector<uint256>{A, B}, two, 3); // T1
+    btc::retain_template_txs(recent, known, std::vector<uint256>{B, C}, two, 3); // T2
+    btc::retain_template_txs(recent, known, std::vector<uint256>{C, D}, two, 3); // T3
+    EXPECT_EQ(recent.size(), 3u);
+    for (const auto& x : {A, B, C, D}) EXPECT_TRUE(known.count(x)) << "missing before evict";
+
+    // T4 pushes the window past cap=3 -> oldest (T1={A,B}) evicted.
+    btc::retain_template_txs(recent, known, std::vector<uint256>{D, E}, two, 3); // T4
+    EXPECT_EQ(recent.size(), 3u);
+    EXPECT_FALSE(known.count(A));  // A only lived in T1 -> erased
+    EXPECT_TRUE(known.count(B));   // B still retained via T2 -> kept
+    EXPECT_TRUE(known.count(C));
+    EXPECT_TRUE(known.count(D));
+    EXPECT_TRUE(known.count(E));
+}
+
+// F3: a share whose referenced new-txs we all hold is backable; one unheld tx
+// makes it NOT backable (must not be broadcast).
+TEST(BtcKnownTxsBackable, UnheldTxIsNotBackable)
+{
+    const std::set<uint256> held{A, B};
+
+    EXPECT_TRUE(btc::all_txs_backable(std::vector<uint256>{A, B}, held));   // all held -> send
+    EXPECT_FALSE(btc::all_txs_backable(std::vector<uint256>{A, C}, held));  // C unheld -> withhold
+    EXPECT_TRUE(btc::all_txs_backable(std::vector<uint256>{}, held));       // no refs -> trivially backable
+}


### PR DESCRIPTION
Ports the pure known-txs bookkeeping from the DASH variant to `src/impl/btc/known_txs_retention.hpp`:

- `btc::retain_template_txs()` — rolling-window retention with F1 template-identity (tx-hash SET) dedup.
- `btc::all_txs_backable()` — the F3 broadcast gate (hold the bytes of every referenced new-tx).

New `src/impl/btc/test/known_txs_retention_test.cpp` (rides btc_share_test, no new target): dedup + eviction correctness + the backable gate. Defeating the gate flips `BtcKnownTxsBackable.UnheldTxIsNotBackable` red. **btc_share_test 112/112 green.**

Scope: `src/impl/btc/` only; nothing lifted to bitcoin_family/ or src/core/. Header primitive + coverage only — call-site wiring at send_shares/mint is deferred pending a structural decision (BTC v35 shares carry no per-share tx refs).