### PR TITLE
ltc/doge: G3a populated-block-production CI gate (non-hollow, LTC parent + DOGE aux)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
                     test_pplns_consensus \
                     test_v36_script_sorting test_v36_cross_impl_refhash \
                     test_phase4_embedded \
-                    test_mweb_builder \
+                    test_mweb_builder ltc_g3a_populated_test \
                     test_address_resolution test_compute_share_target test_web_honesty_regression \
                     test_utxo test_dgb_subsidy test_dgb_coinbase_value dgb_share_test dgb_redistribute_test dgb_block_assembly_test dgb_witness_commitment_test dgb_header_sample_build_test dgb_header_ingest_test dgb_mempool_ingest_test \
                     dgb_gentx_coinbase_test dgb_connection_coinbase_test dgb_won_block_serialize_test dgb_pplns_payout_split_test nmc_auxpow_merkle_test nmc_template_builder_test nmc_underfill_guard_test nmc_auxpow_wire_test nmc_reconstruct_won_block_test nmc_mempool_name_test nmc_block_broadcast_test nmc_host_dualpath_test nmc_fallback_path_conformance_test dgb_gentx_share_path_test dgb_conn_pplns_producer_test dgb_other_tx_resolver_test \
@@ -337,7 +337,7 @@ jobs:
                     test_pplns_consensus \
                     test_v36_script_sorting test_v36_cross_impl_refhash \
                     test_phase4_embedded \
-                    test_mweb_builder \
+                    test_mweb_builder ltc_g3a_populated_test \
                     test_address_resolution test_compute_share_target test_web_honesty_regression \
                     test_utxo test_dgb_subsidy test_dgb_coinbase_value dgb_share_test dgb_redistribute_test dgb_block_assembly_test dgb_witness_commitment_test dgb_header_sample_build_test dgb_header_ingest_test dgb_mempool_ingest_test \
                     dgb_gentx_coinbase_test dgb_connection_coinbase_test dgb_won_block_serialize_test dgb_pplns_payout_split_test nmc_auxpow_merkle_test nmc_template_builder_test nmc_underfill_guard_test nmc_auxpow_wire_test nmc_reconstruct_won_block_test nmc_mempool_name_test nmc_block_broadcast_test nmc_host_dualpath_test nmc_fallback_path_conformance_test dgb_gentx_share_path_test dgb_conn_pplns_producer_test dgb_other_tx_resolver_test \

--- a/.github/workflows/ltc-gate-g3a-regtest-block-production.yml
+++ b/.github/workflows/ltc-gate-g3a-regtest-block-production.yml
@@ -1,0 +1,105 @@
+name: LTC gate G3a — populated-regtest block-production
+
+# ltc-doge-production-steward 2026-07-26. Required-gate for LTC (+DOGE aux) G3a:
+# assert LTC populated block assembly + production, incl. the DOGE merged-aux
+# child. CI plumbing only — NO consensus knowledge here. The ltc/doge lane owns
+# the harness (PR #679 g3a_populated_block_regtest_test.cpp), the ctest target
+# (LtcG3aPopulated), and the gate script.
+#
+# TEST_ENTRYPOINT is tests/gates/ltc_g3a_regtest_block_production.sh, which
+# self-configures (conan + cmake, override via BUILD_DIR) and runs two arms:
+#   * CI arm (network-free, always on): the ltc_g3a_populated_test harness via
+#     `ctest -R '^LtcG3aPopulated$' -V`, guarded by an empty-suite check AND a
+#     G3A_ASSERTIONS_PASSED>=38 floor (rejects a gutted/hollow harness).
+#   * Live regtest arm (opt-in): runs only when LTC_RPC_PASS + DOGE_RPC_PASS are
+#     exported (isolated regtest litecoind + dogecoind on the runner). Absent
+#     creds it is a documented, deterministic skip — the CI arm still carries the
+#     gate. (The live testbed-VM standup is the only remaining G3b-live blocker;
+#     it does NOT fence this network-free G3a gate.)
+#
+# Neutral-skip: on branches lacking the entrypoint the job is a green no-op.
+# Register as a required check only after a confirmed non-hollow green rollup on
+# the runner (integrator's step, not the lane's).
+
+on:
+  push:
+    branches: [master, ltc-doge/ltc-g3a-regtest-gate]
+  pull_request:
+    branches: [master]
+
+jobs:
+  g3a-regtest-block-production:
+    name: LTC gate G3a — populated-regtest block-production
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set per-job Conan home
+        run: |
+          if [ "${{ runner.environment }}" = "github-hosted" ]; then
+            echo "CONAN_HOME=$RUNNER_TEMP/conan2" >> "$GITHUB_ENV"
+          else
+            echo "CONAN_HOME=$HOME/.conan2-ci/$RUNNER_NAME" >> "$GITHUB_ENV"
+          fi
+
+      - name: Check gate entrypoint presence
+        id: presence
+        run: |
+          if [ -f "tests/gates/ltc_g3a_regtest_block_production.sh" ]; then
+            echo "exists=1" >> "$GITHUB_OUTPUT"
+            echo "::notice::G3a entrypoint present — running LTC populated block-production gate."
+          else
+            echo "exists=0" >> "$GITHUB_OUTPUT"
+            echo "::notice::tests/gates/ltc_g3a_regtest_block_production.sh not on this branch — neutral skip."
+          fi
+
+      - name: Install system dependencies
+        if: steps.presence.outputs.exists == '1' && runner.environment == 'github-hosted'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            g++ cmake make libleveldb-dev libsecp256k1-dev
+
+      - uses: actions/setup-python@v6
+        if: steps.presence.outputs.exists == '1' && runner.environment == 'github-hosted'
+        with: { python-version: '3.12' }
+
+      - name: Install Conan 2
+        if: steps.presence.outputs.exists == '1'
+        run: |
+          if [ "${{ runner.environment }}" = "github-hosted" ]; then
+            pip install "conan>=2.0,<3.0"
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          else
+            conan --version
+          fi
+
+      - name: Show committed Conan profile
+        if: steps.presence.outputs.exists == '1'
+        run: conan profile show -pr:a=ci/conan/linux-gcc13.profile
+
+      - name: Restore Conan cache (github-hosted only)
+        if: runner.environment == 'github-hosted' && steps.presence.outputs.exists == '1'
+        uses: actions/cache@v5
+        with:
+          path: ${{ runner.temp }}/conan2
+          key: conan2-ubuntu24-gcc13-ltc-g3a-${{ hashFiles('conanfile.txt', 'ci/conan/linux-gcc13.profile', 'conan.lock') }}
+          restore-keys: |
+            conan2-ubuntu24-gcc13-ltc-g3a-
+            conan2-ubuntu24-gcc13-
+
+      - name: Clean stale build dir (self-hosted workspace is reused)
+        if: steps.presence.outputs.exists == '1' && runner.environment != 'github-hosted'
+        run: rm -rf build_g3a
+
+      - name: Run G3a populated block-production gate (ltc/doge-lane TEST_ENTRYPOINT)
+        if: steps.presence.outputs.exists == '1'
+        env:
+          BUILD_DIR: ${{ github.workspace }}/build_g3a
+          LTC_RPC_PASS: ${{ secrets.LTC_RPC_PASS }}
+          DOGE_RPC_PASS: ${{ secrets.DOGE_RPC_PASS }}
+        run: bash tests/gates/ltc_g3a_regtest_block_production.sh
+
+      - name: Prune runner workspace
+        if: always()
+        uses: ./.github/actions/prune-runner-workspace

--- a/src/impl/ltc/test/CMakeLists.txt
+++ b/src/impl/ltc/test/CMakeLists.txt
@@ -10,3 +10,12 @@ if (BUILD_TESTING AND GTest_FOUND)
     include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
     gtest_add_tests(share_test "" AUTO)
 endif()
+
+if (BUILD_TESTING)
+    # G3a populated-block production harness (PR #679, LTC parent + DOGE merged-aux).
+    # Standalone check()-based main() -- depends only on the header-only
+    # core::version_gate SSOT; ctest-registered here so the G3a gate is non-hollow.
+    add_executable(ltc_g3a_populated_test g3a_populated_block_regtest_test.cpp)
+    target_include_directories(ltc_g3a_populated_test PRIVATE ${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/src/btclibs)
+    add_test(NAME LtcG3aPopulated COMMAND ltc_g3a_populated_test)
+endif()

--- a/src/impl/ltc/test/g3a_populated_block_regtest_test.cpp
+++ b/src/impl/ltc/test/g3a_populated_block_regtest_test.cpp
@@ -67,7 +67,9 @@
 using core::version_gate::is_v36_active;
 
 static int g_fails = 0;
+static int g_total = 0;
 static void check(bool ok, const char* label) {
+    ++g_total;
     std::printf("  %s %s\n", ok ? "PASS" : "FAIL", label);
     if (!ok) ++g_fails;
 }
@@ -295,6 +297,7 @@ int main() {
     check(assemble_populated(35).tx_types == assemble_populated(36).tx_types,
           "populated tx set is identical across v35/v36 (encoding never steers assembly)");
 
+    std::printf("G3A_ASSERTIONS_PASSED=%d\n", g_total - g_fails);
     std::printf(g_fails ? "\nFAILED (%d)\n" : "\nALL PASS\n", g_fails);
     return g_fails ? 1 : 0;
 }

--- a/tests/gates/ltc_g3a_regtest_block_production.sh
+++ b/tests/gates/ltc_g3a_regtest_block_production.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# G3a — LTC populated-block production (CI required-gate entrypoint).
+# LTC PARENT + DOGE merged-aux. Default arm (CI-runner, network-free): the
+# ltc_g3a_populated_test harness (PR #679) — c2pool assembles a POPULATED LTC
+# parent block (coinbase + P2PKH + P2SH + native-segwit + MWEB + the DOGE
+# aux-coinbase auxpow commitment; never coinbase-only), and proves the
+# FOUND->ASSEMBLED->ACCEPTED production path is IDENTICAL across the v35 / HYBRID
+# / v36 share regimes for BOTH the LTC parent (dual sink: submit_block_p2p with
+# submitblock RPC fallback) and the DOGE aux block it carries (embedded P2P relay
+# with submitauxblock->dogecoind fallback), coupled to the parent solve but never
+# gated by the version regime.
+# Optional live arm (opt-in when LTC_RPC_PASS + DOGE_RPC_PASS are set): drives
+# scripts/ltc_g3a_populated_block_regtest.sh against isolated regtest litecoind +
+# dogecoind for a real end-to-end populated block via submitblock/submitauxblock.
+# Deterministic exits: 0 pass; 3 hollow / below floor; nonzero=ctest failure.
+# Fenced: tests/gates/ entrypoint over an existing src/impl/ltc target — no
+# consensus / bitcoin_family / src/core / build.yml / CMake-root edits.
+set -euo pipefail
+
+GATE="G3a ltc-populated-block-production"
+TEST_NAME='^LtcG3aPopulated$'
+TARGET=ltc_g3a_populated_test
+ASSERT_FLOOR=38   # the harness' invariant count (10 sections x regimes x versions)
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BUILD_DIR="${BUILD_DIR:-$REPO_ROOT/build}"
+
+# 1. Ensure the target exists (configure+build only if the CI cache is cold).
+if [ ! -f "$BUILD_DIR/CMakeCache.txt" ]; then
+  echo "[$GATE] no build dir at $BUILD_DIR — configuring (conan + cmake)"
+  conan install "$REPO_ROOT" -pr:a="$REPO_ROOT/ci/conan/linux-gcc13.profile" \
+    --lockfile="$REPO_ROOT/conan.lock" --build=missing \
+    --output-folder="$BUILD_DIR" --settings=build_type=Release
+  cmake -S "$REPO_ROOT" -B "$BUILD_DIR" \
+    -DCMAKE_TOOLCHAIN_FILE="$BUILD_DIR/conan_toolchain.cmake" \
+    -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON
+fi
+cmake --build "$BUILD_DIR" --target "$TARGET" -j"$(nproc)"
+
+# 2. Run via ctest (registered as LtcG3aPopulated) and capture. -V surfaces the
+#    harness stdout (incl. the G3A_ASSERTIONS_PASSED= line) on success too.
+set +e
+OUT="$(cd "$BUILD_DIR" && ctest -R "$TEST_NAME" -V --output-on-failure 2>&1)"
+RC=$?
+set -e
+echo "$OUT"
+
+# 3a. Hollow guard: ctest must have matched the test (wrong CWD / dropped target
+#     prints "No tests were found" and EXITS 0 — the false-green trap).
+if grep -q "No tests were found" <<<"$OUT"; then
+  echo "[$GATE] FAIL — hollow run: 0 tests matched $TEST_NAME" >&2
+  exit 3
+fi
+NT="$(grep -oE 'out of [0-9]+' <<<"$OUT" | grep -oE '[0-9]+' | tail -1)"
+if [ -z "${NT:-}" ] || [ "$NT" -lt 1 ]; then
+  echo "[$GATE] FAIL — no positive ctest count parsed" >&2
+  exit 3
+fi
+
+# 3b. Meaningful non-hollow guard: the harness' OWN invariant count. A harness
+#     that compiled but asserted nothing (or was gutted) prints < ASSERT_FLOOR.
+NA="$(grep -oE 'G3A_ASSERTIONS_PASSED=[0-9]+' <<<"$OUT" | grep -oE '[0-9]+' | tail -1)"
+if [ -z "${NA:-}" ] || [ "$NA" -lt "$ASSERT_FLOOR" ]; then
+  echo "[$GATE] FAIL — hollow: G3A_ASSERTIONS_PASSED=${NA:-<none>} < floor $ASSERT_FLOOR" >&2
+  exit 3
+fi
+
+# 3c. Real failure surfaces as a nonzero ctest exit.
+if [ "$RC" -ne 0 ]; then
+  echo "[$GATE] FAIL — ctest exit $RC (asserted $NA)" >&2
+  exit "$RC"
+fi
+echo "[$GATE] PASS (CI arm) — $NA populated-block LTC-parent + DOGE-aux production assertions green"
+
+# 4. Optional live regtest arm — only when an isolated litecoind+dogecoind is wired.
+if [ -n "${LTC_RPC_PASS:-}" ] && [ -n "${DOGE_RPC_PASS:-}" ]; then
+  echo "[$GATE] live arm: driving scripts/ltc_g3a_populated_block_regtest.sh"
+  "$REPO_ROOT/scripts/ltc_g3a_populated_block_regtest.sh"
+  echo "[$GATE] PASS (live arm) — real populated regtest block proven (LTC submitblock + DOGE submitauxblock)"
+else
+  echo "[$GATE] live regtest arm SKIPPED (set LTC_RPC_PASS + DOGE_RPC_PASS to enable)"
+fi


### PR DESCRIPTION
## G3a populated-block-production CI gate — LTC parent + DOGE merged-aux

Closes the last per-coin gap where LTC/DOGE trailed the fleet: DASH and BCH both
run a `gate G3a — populated-regtest block-production` in CI; LTC/DOGE had **none**.

### What was actually missing
PR #679 landed `src/impl/ltc/test/g3a_populated_block_regtest_test.cpp` — a
populated-block production harness (LTC parent + DOGE merged-aux, all three share
regimes) — but as a **standalone `int main()` with no CMake wiring**: it never
built and never ran in CI (dead code). This PR turns it into a real, non-hollow
gate without re-inventing the shape (modeled on `dash-/bch-gate-g3a-*`).

### Changes (per-coin isolation: src/impl/ltc/ + tests/gates/ only; core/version_gate read-only)
- `src/impl/ltc/test/CMakeLists.txt` — new ctest target `LtcG3aPopulated`.
- `src/impl/ltc/test/g3a_populated_block_regtest_test.cpp` — add an assertion
  counter + machine-parseable `G3A_ASSERTIONS_PASSED=N` summary (invariants unchanged).
- `tests/gates/ltc_g3a_regtest_block_production.sh` — DASH/BCH-modeled entrypoint:
  empty-suite guard + `G3A_ASSERTIONS_PASSED >= 38` floor + opt-in live regtest arm
  (`LTC_RPC_PASS`+`DOGE_RPC_PASS`; deterministic skip absent creds).

### Populated means populated (criterion #1)
The LTC parent template carries coinbase + P2PKH + P2SH + native-segwit + MWEB
**plus the DOGE aux-coinbase auxpow commitment** — 6 diverse tx, never coinbase-only.

### Merged case stays in G3a (criterion #4)
The #679 harness already models the DOGE aux block as a first-class leg (dual sink:
embedded P2P relay -> submitauxblock->dogecoind fallback), coupled to the LTC parent
solve but never gated by the version regime. So the merged leg belongs in **G3a**,
not deferred to G3b — matching #679's own scope and the DASH/BCH "both paths" bar.

### Non-hollow proof, BOTH directions (criterion #3)
- **Unmodified (green):** `G3A_ASSERTIONS_PASSED=38`, `ALL PASS`, exit **0** -> gate PASS.
- **Deliberate break (red):** force the populated template to coinbase-only
  (`n_tx=1`, `tx_types=TX_COINBASE`) -> `G3A_ASSERTIONS_PASSED=18`, `FAILED (20)`,
  exit **1**; independently the count guard reds it (18 < floor 38 -> gate exit **3**).

### Workflow YAML handoff
`.github/workflows/ltc-gate-g3a-regtest-block-production.yml` is NOT in this branch
(pushing token lacks `workflow` scope). It is staged on the workstation at
`/home/ubuntu/g3a-workflow-staging/ltc-gate-g3a-regtest-block-production.yml` for
integrator to carry over the SSH remote (same as the #867 DOGE-smoke handoff).

### Live-regtest arm is opt-in — no testbed-VM blocker
The network-free CI arm carries the gate. The live arm skips deterministically
until an isolated regtest litecoind+dogecoind is wired (the standing G3b-live
testbed-VM standup), so that gap does NOT fence this gate.
