### PR TITLE
btc: wire F3 backable-broadcast gate + template-tx retention (a+b+c)

### DIFF
--- a/src/c2pool/main_btc.cpp
+++ b/src/c2pool/main_btc.cpp
@@ -1331,6 +1331,12 @@ int main(int argc, char* argv[])
                 if (job.tx_data)
                     for (const auto& tx_hex : *job.tx_data)
                         tmpl_txs.push_back(nlohmann::json::object({{"data", tx_hex}}));
+                // F3: hand the template's tx set to the node (which owns
+                // m_known_txs and takes its own lock) so every tx this share's
+                // template committed to is forwardable and the share is backable
+                // BEFORE we broadcast it. Must precede the capture move.
+                p2p_node_raw->register_template_txs(share_hash, tmpl_txs);
+
                 template_capture.capture(share_hash, std::move(tmpl_txs));
 
                 p2p_node_raw->broadcast_share(share_hash);

--- a/src/impl/btc/known_txs_retention.hpp
+++ b/src/impl/btc/known_txs_retention.hpp
@@ -114,4 +114,23 @@ inline bool all_txs_backable(const std::vector<uint256>& tx_hashes,
     return true;
 }
 
+// F3 send-gate over a batch: returns the indices of shares that are backable —
+// every referenced new-tx hash is held. send_shares transmits ONLY these and
+// withholds the rest (a share we cannot fully forward would trip the peer's
+// "referenced unknown transaction" disconnect). Pure so the wiring's withhold
+// decision is unit-testable: mutating this to admit-all (push every index)
+// reddens BtcSendGate.WithholdsShareMissingTemplateTx.
+template <typename Held>
+inline std::vector<std::size_t> select_backable_shares(
+    const std::vector<std::vector<uint256>>& per_share_refs,
+    const Held& held)
+{
+    std::vector<std::size_t> out;
+    out.reserve(per_share_refs.size());
+    for (std::size_t i = 0; i < per_share_refs.size(); ++i)
+        if (all_txs_backable(per_share_refs[i], held))
+            out.push_back(i);
+    return out;
+}
+
 } // namespace btc

--- a/src/impl/btc/node.cpp
+++ b/src/impl/btc/node.cpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 #include "node.hpp"
+#include "known_txs_retention.hpp"      // F3 retain_template_txs + select_backable_shares
+#include "coin/template_other_txs.hpp"  // deserialize_template_other_txs (GBT data[] -> MutableTransaction)
 
 #include <core/common.hpp>
 #include <core/hash.hpp>
@@ -679,6 +681,52 @@ std::vector<btc::ShareType> NodeImpl::handle_get_share(std::vector<uint256> hash
 	return shares;
 }
 
+void NodeImpl::register_template_txs(const uint256& share_hash,
+                                     const nlohmann::json& template_txs)
+{
+    // Decode the GBT transactions[] (`data` = with-witness hex) OUTSIDE the node
+    // lock — the hex parse is the heavy part and must never run under
+    // m_tracker_mutex. Fail CLOSED on a malformed entry (retain nothing) rather
+    // than poison the retention window.
+    std::vector<coin::MutableTransaction> mtxs;
+    try {
+        mtxs = coin::deserialize_template_other_txs(template_txs);
+    } catch (const std::exception& e) {
+        LOG_WARNING << "[Pool] register_template_txs decode failed for share "
+                    << share_hash.GetHex().substr(0, 16) << ": " << e.what();
+        return;
+    }
+    if (mtxs.empty())
+        return;
+
+    // Key each tx exactly as the remember_tx handler does —
+    // Hash(pack(TX_WITH_WITNESS(tx))) — so the retained bytes are addressable by
+    // the same hash a share or peer references and forwarding stays consistent.
+    std::vector<uint256> hashes;
+    std::vector<coin::Transaction> txs;
+    hashes.reserve(mtxs.size());
+    txs.reserve(mtxs.size());
+    for (auto& mtx : mtxs) {
+        auto packed = pack(coin::TX_WITH_WITNESS(mtx));
+        hashes.push_back(Hash(packed.get_span()));
+        txs.emplace_back(mtx);
+    }
+
+    // Only the map mutation is serialized. A blocking unique_lock matches the
+    // stratum-thread write posture already used by create_local_share (main_btc
+    // drops that lock before calling us); the IO thread never blocks here. The
+    // retention window (not m_known_txs_order) owns these entries' lifecycle.
+    {
+        std::unique_lock<std::shared_mutex> lk(m_tracker_mutex);
+        btc::retain_template_txs(m_template_recent_sets, m_known_txs,
+                                 hashes, txs, kTemplateRetainCap);
+    }
+
+    LOG_INFO << "[Pool] register_template_txs share=" << share_hash.GetHex().substr(0, 16)
+              << " retained " << hashes.size() << " template tx(s), window="
+              << m_template_recent_sets.size();
+}
+
 void NodeImpl::send_shares(peer_ptr peer, const std::vector<uint256>& share_hashes)
 {
     // try_to_lock per the architectural rule (node.hpp:67) — see freeze
@@ -714,22 +762,61 @@ void NodeImpl::send_shares(peer_ptr peer, const std::vector<uint256>& share_hash
     if (shares.empty())
         return;
 
-    // Collect transactions that the peer doesn't know about
-    std::set<uint256> needed_txs;
+    // (b) Extract each share's referenced new-tx hashes. BTC shares carry these
+    // inside m_tx_info (btc::ShareTxInfo), NOT as a top-level
+    // m_new_transaction_hashes — the old `requires { obj->m_new_transaction_hashes }`
+    // matched no BTC share type, so the whole block below was silently dead for
+    // ALL versions. Guarding on m_tx_info makes it correct-by-construction for
+    // v17/v33 (which populate it) and dormant on v35 (share_check leaves it empty
+    // for version >= 34) — dormant, never silently dead.
+    std::vector<std::vector<uint256>> per_share_refs;
+    per_share_refs.reserve(shares.size());
     for (auto& share : shares)
     {
+        std::vector<uint256> refs;
         share.invoke([&](auto* obj) {
-            if constexpr (requires { obj->m_new_transaction_hashes; })
-            {
-                for (const auto& th : obj->m_new_transaction_hashes)
-                {
-                    if (!peer->m_remote_txs.count(th) &&
-                        !peer->m_remembered_txs.count(th))
-                        needed_txs.insert(th);
-                }
-            }
+            if constexpr (requires { obj->m_tx_info; })
+                for (const auto& th : obj->m_tx_info.m_new_transaction_hashes)
+                    refs.push_back(th);
         });
+        per_share_refs.push_back(std::move(refs));
     }
+
+    // (a) F3 backable-broadcast gate: withhold any share whose referenced
+    // new-txs we do NOT all hold — transmitting it would trip the peer's
+    // "referenced unknown transaction" disconnect. The gate reads m_known_txs
+    // the same way the needed_txs lookup below does (send_shares' established
+    // access posture for this map). Dormant on v35 (empty refs -> vacuously
+    // backable); live for v17/v33 and any future tx-carrying share.
+    const auto sendable_idx = btc::select_backable_shares(per_share_refs, m_known_txs);
+    if (sendable_idx.size() != shares.size())
+    {
+        LOG_WARNING << "[Pool] Withholding " << (shares.size() - sendable_idx.size())
+                    << " unbacked share(s) from " << peer->addr().to_string()
+                    << " (referenced template tx not held)";
+        std::vector<ShareType> kept_shares;
+        std::vector<std::vector<uint256>> kept_refs;
+        kept_shares.reserve(sendable_idx.size());
+        kept_refs.reserve(sendable_idx.size());
+        for (auto i : sendable_idx)
+        {
+            kept_shares.push_back(std::move(shares[i]));
+            kept_refs.push_back(std::move(per_share_refs[i]));
+        }
+        shares = std::move(kept_shares);
+        per_share_refs = std::move(kept_refs);
+        if (shares.empty())
+            return;
+    }
+
+    // Collect transactions the peer doesn't know about, over the surviving
+    // (backable) shares only.
+    std::set<uint256> needed_txs;
+    for (const auto& refs : per_share_refs)
+        for (const auto& th : refs)
+            if (!peer->m_remote_txs.count(th) &&
+                !peer->m_remembered_txs.count(th))
+                needed_txs.insert(th);
 
     // Send remember_tx for txs the peer needs
     if (!needed_txs.empty())

--- a/src/impl/btc/node.hpp
+++ b/src/impl/btc/node.hpp
@@ -25,6 +25,8 @@
 #include <shared_mutex>
 #include <random>
 #include <thread>
+#include <set>
+#include <nlohmann/json.hpp>
 
 namespace btc
 {
@@ -63,6 +65,18 @@ protected:
     // disconnect). Tx-forwarding only; no consensus/mint state. See
     // core::evict_known_txs_to_cap (core/known_txs_eviction.hpp).
     std::deque<uint256> m_known_txs_order;
+
+    // F3 template-tx retention window (btc::retain_template_txs). Rolling
+    // history of the last kTemplateRetainCap DISTINCT locally-minted templates'
+    // tx-hash SETS; register_template_txs feeds each freshly-minted share's
+    // template txs here so their bytes live in m_known_txs and every referenced
+    // new-tx stays forwardable (the F3 backable invariant). Guarded by
+    // m_tracker_mutex like m_known_txs. Template txs are lifecycle-owned by this
+    // window (erased only when they fall out of every retained set) and are
+    // deliberately NOT enrolled in m_known_txs_order, so the global cap eviction
+    // and this window never fight over the same entries. Tx-forwarding only.
+    std::deque<std::set<uint256>> m_template_recent_sets;
+    static constexpr std::size_t kTemplateRetainCap = 8;
 
     // Thread pool for parallel share_init_verify (scrypt CPU work).
     // Keeps expensive crypto off the io_context thread.
@@ -366,6 +380,16 @@ public:
     /// Send a set of shares (with any needed txs) to a single peer.
     /// Skips shares that originated from that peer.
     void send_shares(peer_ptr peer, const std::vector<uint256>& share_hashes);
+
+    /// F3: retain a freshly-minted share's TEMPLATE tx set so every referenced
+    /// new-tx is forwardable (remember_tx) and the share is backable. Called
+    /// from create_share_fn on the stratum thread; it hands us the template tx
+    /// set (GBT transactions[] json) and NOTHING else — ownership of m_known_txs
+    /// stays here, and this takes m_tracker_mutex internally (the heavy hex
+    /// decode happens BEFORE the lock). See DASH #828: unlocked cross-thread
+    /// reads of node-owned structures racing think() are a live crash class.
+    void register_template_txs(const uint256& share_hash,
+                               const nlohmann::json& template_txs);
 
     /// Broadcast a locally-generated (or newly-received) share to all peers.
     void broadcast_share(const uint256& share_hash);

--- a/src/impl/btc/test/known_txs_retention_test.cpp
+++ b/src/impl/btc/test/known_txs_retention_test.cpp
@@ -99,3 +99,29 @@ TEST(BtcKnownTxsBackable, UnheldTxIsNotBackable)
     EXPECT_FALSE(btc::all_txs_backable(std::vector<uint256>{A, C}, held));  // C unheld -> withhold
     EXPECT_TRUE(btc::all_txs_backable(std::vector<uint256>{}, held));       // no refs -> trivially backable
 }
+
+
+// F3 WIRING (send_shares gate): send_shares extracts each share's referenced
+// new-tx hashes and transmits ONLY the backable ones via
+// btc::select_backable_shares(per_share_refs, m_known_txs). This exercises that
+// exact SSOT function against a std::map keyed like m_known_txs.
+//
+// Non-hollow guard: mutating select_backable_shares to admit-all (push every
+// index) makes this ASSERT_EQ(size, 2) go red; the correct gate drops share 1.
+TEST(BtcSendGate, WithholdsShareMissingTemplateTx)
+{
+    // Same value shape as NodeImpl::m_known_txs (map keyed by tx hash).
+    const std::map<uint256, int> held{{A, 1}, {B, 2}};
+
+    // Three shares' referenced-new-tx hash lists, in send order.
+    const std::vector<std::vector<uint256>> per_share_refs{
+        {A, B},   // share 0: both held        -> send
+        {A, C},   // share 1: C unheld         -> WITHHOLD
+        {},       // share 2: no refs (v35)    -> send (vacuously backable)
+    };
+
+    const auto sendable = btc::select_backable_shares(per_share_refs, held);
+    ASSERT_EQ(sendable.size(), 2u);   // exactly the unbacked share 1 is dropped
+    EXPECT_EQ(sendable[0], 0u);
+    EXPECT_EQ(sendable[1], 2u);       // share 2 kept, indices preserved
+}


### PR DESCRIPTION
Follow-up to #868 (the pure F3 primitives). Wires them into the live BTC mint/broadcast path. Milestone content inside src/impl/btc/ plus the create_share_fn call site in src/c2pool/main_btc.cpp.

## Base / stacking
Stacked on `btc/f3-known-txs-retention-header` (#868) because the wiring depends on `known_txs_retention.hpp`, not yet on master. After #868 merges: retarget this PR to `master` and rebase (the header commit drops out cleanly). Reviewing against the #868 base now so the diff shows ONLY the wiring.

## What lands — integrator's call was (c), all three

(a) The gate, the substantive milestone. `send_shares` withholds any share whose referenced new-txs we do not all hold, via `btc::select_backable_shares(per_share_refs, m_known_txs)`. A share we cannot fully forward would trip the peer's "referenced unknown transaction" disconnect. `NodeImpl::register_template_txs(share_hash, template_txs)` is the template feed: create_share_fn hands the node the freshly-minted template's tx set (GBT transactions[] json) and nothing else. The node decodes the `data[]` hex OUTSIDE its lock, keys each tx exactly as the remember_tx handler does — `Hash(pack(TX_WITH_WITNESS))` — then retains it into `m_known_txs` under `m_tracker_mutex` via `btc::retain_template_txs`. Ownership of `m_known_txs` stays with the node; the stratum thread only hands it data, so no unlocked cross-thread mutation of node-owned state (DASH #828 crash class avoided by construction).

We accept the divergence from DASH's share-field shape: DASH's shape follows from its share carrying the field; BTC v35 does not, so the gate keys on the template tx-hash SET, not a share field.

(b) The dormant fix. `send_shares`' tx-ref extraction now guards on `obj->m_tx_info` instead of the never-matching `obj->m_new_transaction_hashes` — the old guard matched no BTC share type, leaving the whole remember_tx-forwarding block silently dead for all versions. Correct-by-construction for v17/v33 (which populate m_tx_info); dormant on the v35 shares BTC mints today (share_check leaves m_tx_info empty for version >= 34). Dormant, not the live-path fix — stated plainly so nobody later misreads it.

## Non-hollow proof for (a)
Same method as #868 — force the gate open, watch a named test go red, revert:
- baseline: `BtcSendGate.WithholdsShareMissingTemplateTx` GREEN (drops the one share referencing an unheld tx; keeps indices 0 and 2).
- mutate `select_backable_shares` to admit-all -> RED: sendable size 3, expected 2.
- revert -> GREEN.

Full `btc_share_test`: 113/113. `c2pool-btc` links clean (exit 0).

## Eviction interaction
Template txs are lifecycle-owned by the retention window (erased only when they fall out of every retained set) and deliberately NOT enrolled in `m_known_txs_order`, so global-cap eviction and the window never fight over the same entries.

## Scope
src/impl/btc/ only, plus one call in `src/c2pool/main_btc.cpp`'s create_share_fn closure (the template feed's call site — BTC binary glue, the same file the reconstructor arc wired). No `bitcoin_family/` or `src/core/` touched — no shared base, no exceptional-change card needed. Flagging the main_btc.cpp line explicitly for transparency.
