### PR TITLE
fix(p2p): addrme relays when we HAVE peers, not when we have none (#869)

### DIFF
--- a/src/core/random.hpp
+++ b/src/core/random.hpp
@@ -2,6 +2,7 @@
 #include <vector>
 #include <map>
 #include <list>
+#include <stdexcept>
 #include <core/uint256.hpp>
 
 namespace core::random
@@ -16,9 +17,23 @@ namespace core::random
 
 	uint256 random_uint256();
 
+    // random_choice on an EMPTY container used to be undefined behaviour:
+    // random_int(0, 0) returns 0, and the vector overload then indexed [0]
+    // past the end while the map/list overloads dereferenced end(). Every
+    // call site is expected to guard on !container.empty() first; this throw
+    // is the defence-in-depth backstop so a missed guard degrades into a
+    // logged handler error (the protocol dispatchers wrap handle() in a
+    // catch(const std::exception&)) instead of a freed-memory read.
+    [[noreturn]] inline void throw_empty_choice()
+    {
+        throw std::out_of_range("core::random::random_choice on empty container");
+    }
+
     template <typename T>
     T random_choice(std::vector<T> &list)
     {
+        if (list.empty())
+            throw_empty_choice();
         int pos = core::random::random_int(0, list.size());
         return list[pos];
     }
@@ -26,6 +41,8 @@ namespace core::random
     template <typename T>
     T random_choice(const std::vector<T> &list)
     {
+        if (list.empty())
+            throw_empty_choice();
         int pos = core::random::random_int(0, list.size());
         return list[pos];
     }
@@ -34,6 +51,8 @@ namespace core::random
     template <typename Key, typename Value>
     Value random_choice(std::map<Key, Value> _map)
     {
+        if (_map.empty())
+            throw_empty_choice();
         int pos = core::random::random_int(0, _map.size());
         auto item = _map.begin();
         std::advance(item, pos);
@@ -43,6 +62,8 @@ namespace core::random
     template <typename Value>
     Value random_choice(std::list<Value> _list)
     {
+        if (_list.empty())
+            throw_empty_choice();
         int pos = core::random::random_int(0, _list.size());
         auto item = _list.begin();
         std::advance(item, pos);

--- a/src/core/test/CMakeLists.txt
+++ b/src/core/test/CMakeLists.txt
@@ -30,7 +30,14 @@ if (BUILD_TESTING AND (GTest_FOUND OR GTEST_FOUND))
     # ONE definition instead of each growing a copy. Same reasoning again:
     # header-only over core, so it is FOLDED into the EXISTING allowlisted
     # core_test target, never a new add_executable (the #769 "Not Run" trap).
-    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp core_merkle_branches_test.cpp version_gate_test.cpp filesystem_test.cpp web_server_submitblock_test.cpp known_txs_eviction_test.cpp tx_advertiser_test.cpp socket_write_queue_test.cpp known_txs_backing_test.cpp)
+    # random_choice_guard_test.cpp: the #869 addrme peer-relay guard. Covers the
+    # core/random.hpp empty-container backstop plus a source KAT pinning the
+    # !m_peers.empty() / !m_connections.empty() relay predicates across all five
+    # per-coin protocol_legacy.cpp / protocol_actual.cpp addrme+addrs handlers.
+    # Same reasoning as above: FOLDED into the EXISTING allowlisted core_test
+    # target, never a new add_executable.
+    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp core_merkle_branches_test.cpp version_gate_test.cpp filesystem_test.cpp web_server_submitblock_test.cpp known_txs_eviction_test.cpp tx_advertiser_test.cpp socket_write_queue_test.cpp known_txs_backing_test.cpp random_choice_guard_test.cpp)
+    target_compile_definitions(core_test PRIVATE C2POOL_SRC_ROOT="${CMAKE_SOURCE_DIR}/src")
     target_link_libraries(core_test PRIVATE GTest::gtest_main core c2pool_merged_mining GTest::gtest)
     target_link_libraries(core_test PRIVATE c2pool_payout c2pool_hashrate ltc_coin)  # OBJECT-lib SCC direct-naming (#22/#39)
 

--- a/src/core/test/random_choice_guard_test.cpp
+++ b/src/core/test/random_choice_guard_test.cpp
@@ -1,0 +1,206 @@
+// Regression cover for issue #869 — the inverted addrme peer-relay guard.
+//
+// Two independent layers:
+//
+//  1. core::random::random_choice() must never index/dereference past the end
+//     of an empty container. Before the fix random_int(0, 0) returned 0 and the
+//     vector overload read list[0] while the map/list overloads dereferenced
+//     end() — undefined behaviour reachable from a protocol handler.
+//
+//  2. A source KAT over the five per-coin protocol_legacy.cpp / protocol_actual.cpp
+//     addrme handlers. Canonical p2pool (p2p.py handle_addrme) relays only when
+//     the node HAS peers; the Legacy handlers shipped the inverted
+//     `m_peers.empty()` predicate, so the relay fired only when there was
+//     nothing to relay to and then picked a random element out of the empty
+//     container. The KAT pins every guard to the `!m_peers.empty()` form so the
+//     inversion cannot silently return in any of the ten sites.
+//
+// Folded into the EXISTING allowlisted core_test target — a standalone
+// add_executable is not in build.yml's --target list, so CI would never build
+// it and CTest would report the cases "Not Run".
+
+#include <gtest/gtest.h>
+
+#include <core/random.hpp>
+
+#include <fstream>
+#include <list>
+#include <map>
+#include <memory>
+#include <regex>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// Layer 1: empty-container defence in depth
+// ---------------------------------------------------------------------------
+
+TEST(RandomChoiceGuard, EmptyVectorThrowsInsteadOfIndexingPastEnd)
+{
+    std::vector<int> empty;
+    EXPECT_THROW(core::random::random_choice(empty), std::out_of_range);
+}
+
+TEST(RandomChoiceGuard, EmptyConstVectorThrowsInsteadOfIndexingPastEnd)
+{
+    const std::vector<int> empty;
+    EXPECT_THROW(core::random::random_choice(empty), std::out_of_range);
+}
+
+TEST(RandomChoiceGuard, EmptyMapThrowsInsteadOfDereferencingEnd)
+{
+    // Mirrors pool::NodeInterface::m_peers — std::map<uint64_t, peer_ptr>.
+    std::map<uint64_t, std::shared_ptr<int>> empty;
+    EXPECT_THROW(core::random::random_choice(empty), std::out_of_range);
+}
+
+TEST(RandomChoiceGuard, EmptyListThrowsInsteadOfDereferencingEnd)
+{
+    std::list<int> empty;
+    EXPECT_THROW(core::random::random_choice(empty), std::out_of_range);
+}
+
+TEST(RandomChoiceGuard, NonEmptyContainersStillReturnAMember)
+{
+    std::vector<int> v{7};
+    EXPECT_EQ(7, core::random::random_choice(v));
+
+    const std::vector<int> cv{9};
+    EXPECT_EQ(9, core::random::random_choice(cv));
+
+    std::map<uint64_t, int> m{{42u, 11}};
+    EXPECT_EQ(11, core::random::random_choice(m));
+
+    std::list<int> l{13};
+    EXPECT_EQ(13, core::random::random_choice(l));
+
+    // Multi-element: every draw must be an actual member, never a past-the-end
+    // read. 64 draws is plenty to shake out an off-by-one in random_int's
+    // half-open [min, max) contract.
+    std::vector<int> many{1, 2, 3, 4, 5};
+    for (int i = 0; i < 64; ++i)
+    {
+        const int drawn = core::random::random_choice(many);
+        EXPECT_GE(drawn, 1);
+        EXPECT_LE(drawn, 5);
+    }
+
+    std::map<uint64_t, int> mmany{{1u, 10}, {2u, 20}, {3u, 30}};
+    for (int i = 0; i < 64; ++i)
+    {
+        const int drawn = core::random::random_choice(mmany);
+        EXPECT_TRUE(drawn == 10 || drawn == 20 || drawn == 30);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Layer 2: source KAT over the per-coin addrme handlers
+// ---------------------------------------------------------------------------
+
+namespace
+{
+
+const char* const kCoins[] = {"dash", "ltc", "btc", "dgb", "bch"};
+
+std::string read_source(const std::string& coin, const std::string& generation)
+{
+    const std::string path =
+        std::string(C2POOL_SRC_ROOT) + "/impl/" + coin + "/protocol_" + generation + ".cpp";
+    std::ifstream in(path);
+    EXPECT_TRUE(in.good()) << "cannot open " << path;
+    std::ostringstream buf;
+    buf << in.rdbuf();
+    return buf.str();
+}
+
+// Extract the body of `void <Qualifier>::HANDLER(<name>)` up to the closing
+// brace of the handler (the handlers are brace-balanced and never contain a
+// string literal with an unbalanced brace).
+std::string handler_body(const std::string& src, const std::string& handler)
+{
+    const std::string needle = "::HANDLER(" + handler + ")";
+    const auto at = src.find(needle);
+    EXPECT_NE(std::string::npos, at) << "handler " << handler << " not found";
+    if (at == std::string::npos)
+        return {};
+
+    const auto open = src.find('{', at);
+    EXPECT_NE(std::string::npos, open);
+    if (open == std::string::npos)
+        return {};
+
+    int depth = 0;
+    for (auto i = open; i < src.size(); ++i)
+    {
+        if (src[i] == '{')
+            ++depth;
+        else if (src[i] == '}')
+        {
+            --depth;
+            if (depth == 0)
+                return src.substr(open, i - open + 1);
+        }
+    }
+    ADD_FAILURE() << "unbalanced handler body for " << handler;
+    return {};
+}
+
+size_t count_matches(const std::string& hay, const std::regex& re)
+{
+    return static_cast<size_t>(
+        std::distance(std::sregex_iterator(hay.begin(), hay.end(), re), std::sregex_iterator()));
+}
+
+} // namespace
+
+// The relay guard must be `!m_peers.empty()` in BOTH generations of all five
+// coins, on BOTH branches of addrme (the 127.x self-probe branch and the
+// ordinary-peer branch). The inverted form must appear nowhere.
+TEST(AddrmeRelayGuard, GuardsOnHavingPeersNotOnHavingNone)
+{
+    const std::regex correct(R"(!\s*m_peers\.empty\(\))");
+    // A `m_peers.empty()` that is NOT preceded by `!` — the #869 inversion.
+    const std::regex inverted(R"((^|[^!])\s*\(?\s*m_peers\.empty\(\))");
+
+    for (const char* coin : kCoins)
+    {
+        for (const char* generation : {"legacy", "actual"})
+        {
+            const std::string src = read_source(coin, generation);
+            const std::string body = handler_body(src, "addrme");
+            ASSERT_FALSE(body.empty()) << coin << "/" << generation;
+
+            EXPECT_EQ(2u, count_matches(body, correct))
+                << coin << "::" << generation
+                << " addrme must relay on !m_peers.empty() on BOTH branches";
+            EXPECT_EQ(0u, count_matches(body, inverted))
+                << coin << "::" << generation
+                << " addrme still carries the inverted m_peers.empty() guard (#869)";
+        }
+    }
+}
+
+// Audit companion: HANDLER(addrs) relays through m_connections and was already
+// guarded correctly. Pin it so it does not drift into the same inversion.
+TEST(AddrsRelayGuard, GuardsOnHavingConnections)
+{
+    const std::regex correct(R"(!\s*m_connections\.empty\(\))");
+    const std::regex inverted(R"((^|[^!])\s*\(?\s*m_connections\.empty\(\))");
+
+    for (const char* coin : kCoins)
+    {
+        for (const char* generation : {"legacy", "actual"})
+        {
+            const std::string src = read_source(coin, generation);
+            const std::string body = handler_body(src, "addrs");
+            ASSERT_FALSE(body.empty()) << coin << "/" << generation;
+
+            EXPECT_EQ(1u, count_matches(body, correct))
+                << coin << "::" << generation << " addrs must relay on !m_connections.empty()";
+            EXPECT_EQ(0u, count_matches(body, inverted))
+                << coin << "::" << generation << " addrs carries an inverted connections guard";
+        }
+    }
+}

--- a/src/impl/bch/protocol_actual.cpp
+++ b/src/impl/bch/protocol_actual.cpp
@@ -9,8 +9,10 @@
 // shape: the router body is byte-identical to Legacy, but the HANDLER bodies
 // carry the genuine Actual-generation differences the reviewer diffs against
 // the oracle -- they are NOT a qualifier-swap of bch::Legacy:
-//   * addrme self-probe is 127.0.0.1 (Legacy: 127.0.0.0), and the relay
-//     guard is !m_peers.empty() (Legacy: m_peers.empty()).
+//   * addrme self-probe is 127.0.0.1 (Legacy: 127.0.0.0). The relay guard is
+//     !m_peers.empty() in BOTH generations -- Legacy's inverted m_peers.empty()
+//     was a defect, not a generation difference, and was corrected to match
+//     canonical p2pool p2p.py handle_addrme.
 //   * shares preserves the original raw bytes (chain::RawShare raw_copy)
 //     before deserialization consumes them and feeds the 3-arg
 //     result.add(share, txs, raw_copy) (Legacy: 2-arg add).
@@ -68,7 +70,7 @@ void Actual::handle_message(std::unique_ptr<RawMessage> rmsg, peer_ptr peer)
 // ---------------------------------------------------------------------------
 // Peer-book HANDLER cluster (addrs / addrme / ping / getaddrs).
 // Mechanical mirror of btc::Actual peer-book handlers; addrme carries the
-// Actual-generation 127.0.0.1 / !m_peers.empty() form. Zero v36 surface.
+// Actual-generation 127.0.0.1 self-probe form. Zero v36 surface.
 // ---------------------------------------------------------------------------
 
 void Actual::HANDLER(addrs)

--- a/src/impl/bch/protocol_legacy.cpp
+++ b/src/impl/bch/protocol_legacy.cpp
@@ -83,7 +83,7 @@ void Legacy::HANDLER(addrme)
 {
     if (peer->addr().address() == "127.0.0.0")
     {
-        if (m_peers.empty() && (core::random::random_float(0, 1) < 0.8))
+        if (!m_peers.empty() && (core::random::random_float(0, 1) < 0.8))
         {
             auto random_peer = core::random::random_choice(m_peers);
             auto rmsg = bch::message_addrme::make_raw(msg->m_port);
@@ -93,7 +93,7 @@ void Legacy::HANDLER(addrme)
     {
         auto endpoint = NetService{peer->addr().address(), msg->m_port};
         got_addr(endpoint, peer->m_other_services, core::timestamp());
-        if (m_peers.empty() && (core::random::random_float(0, 1) < 0.8))
+        if (!m_peers.empty() && (core::random::random_float(0, 1) < 0.8))
         {
             auto random_peer = core::random::random_choice(m_peers);
             auto rmsg = bch::message_addrs::make_raw({addr_record_t{peer->m_other_services, endpoint, core::timestamp()} });

--- a/src/impl/btc/protocol_legacy.cpp
+++ b/src/impl/btc/protocol_legacy.cpp
@@ -54,7 +54,7 @@ void Legacy::HANDLER(addrme)
 {
     if (peer->addr().address() == "127.0.0.0")
     {
-        if (m_peers.empty() && (core::random::random_float(0, 1) < 0.8))
+        if (!m_peers.empty() && (core::random::random_float(0, 1) < 0.8))
         {
             auto random_peer = core::random::random_choice(m_peers);
             auto rmsg = btc::message_addrme::make_raw(msg->m_port);
@@ -64,7 +64,7 @@ void Legacy::HANDLER(addrme)
     {
         auto endpoint = NetService{peer->addr().address(), msg->m_port};
         got_addr(endpoint, peer->m_other_services, core::timestamp());
-        if (m_peers.empty() && (core::random::random_float(0, 1) < 0.8))
+        if (!m_peers.empty() && (core::random::random_float(0, 1) < 0.8))
         {
             auto random_peer = core::random::random_choice(m_peers);
             auto rmsg = btc::message_addrs::make_raw({addr_record_t{peer->m_other_services, endpoint, core::timestamp()} });

--- a/src/impl/dash/protocol_legacy.cpp
+++ b/src/impl/dash/protocol_legacy.cpp
@@ -54,7 +54,7 @@ void Legacy::HANDLER(addrme)
 {
     if (peer->addr().address() == "127.0.0.0")
     {
-        if (m_peers.empty() && (core::random::random_float(0, 1) < 0.8))
+        if (!m_peers.empty() && (core::random::random_float(0, 1) < 0.8))
         {
             auto random_peer = core::random::random_choice(m_peers);
             auto rmsg = dash::message_addrme::make_raw(msg->m_port);
@@ -64,7 +64,7 @@ void Legacy::HANDLER(addrme)
     {
         auto endpoint = NetService{peer->addr().address(), msg->m_port};
         got_addr(endpoint, peer->m_other_services, core::timestamp());
-        if (m_peers.empty() && (core::random::random_float(0, 1) < 0.8))
+        if (!m_peers.empty() && (core::random::random_float(0, 1) < 0.8))
         {
             auto random_peer = core::random::random_choice(m_peers);
             auto rmsg = dash::message_addrs::make_raw({addr_record_t{peer->m_other_services, endpoint, core::timestamp()} });

--- a/src/impl/dgb/protocol_legacy.cpp
+++ b/src/impl/dgb/protocol_legacy.cpp
@@ -54,7 +54,7 @@ void Legacy::HANDLER(addrme)
 {
     if (peer->addr().address() == "127.0.0.0")
     {
-        if (m_peers.empty() && (core::random::random_float(0, 1) < 0.8))
+        if (!m_peers.empty() && (core::random::random_float(0, 1) < 0.8))
         {
             auto random_peer = core::random::random_choice(m_peers);
             auto rmsg = dgb::message_addrme::make_raw(msg->m_port);
@@ -64,7 +64,7 @@ void Legacy::HANDLER(addrme)
     {
         auto endpoint = NetService{peer->addr().address(), msg->m_port};
         got_addr(endpoint, peer->m_other_services, core::timestamp());
-        if (m_peers.empty() && (core::random::random_float(0, 1) < 0.8))
+        if (!m_peers.empty() && (core::random::random_float(0, 1) < 0.8))
         {
             auto random_peer = core::random::random_choice(m_peers);
             auto rmsg = dgb::message_addrs::make_raw({addr_record_t{peer->m_other_services, endpoint, core::timestamp()} });

--- a/src/impl/ltc/protocol_legacy.cpp
+++ b/src/impl/ltc/protocol_legacy.cpp
@@ -54,7 +54,7 @@ void Legacy::HANDLER(addrme)
 {
     if (peer->addr().address() == "127.0.0.0")
     {
-        if (m_peers.empty() && (core::random::random_float(0, 1) < 0.8))
+        if (!m_peers.empty() && (core::random::random_float(0, 1) < 0.8))
         {
             auto random_peer = core::random::random_choice(m_peers);
             auto rmsg = ltc::message_addrme::make_raw(msg->m_port);
@@ -64,7 +64,7 @@ void Legacy::HANDLER(addrme)
     {
         auto endpoint = NetService{peer->addr().address(), msg->m_port};
         got_addr(endpoint, peer->m_other_services, core::timestamp());
-        if (m_peers.empty() && (core::random::random_float(0, 1) < 0.8))
+        if (!m_peers.empty() && (core::random::random_float(0, 1) < 0.8))
         {
             auto random_peer = core::random::random_choice(m_peers);
             auto rmsg = ltc::message_addrs::make_raw({addr_record_t{peer->m_other_services, endpoint, core::timestamp()} });


### PR DESCRIPTION
Fixes #869.

## The bug

`HANDLER(addrme)` in each coin's `protocol_legacy.cpp` guards **both** relay branches on `m_peers.empty()`. Canonical p2pool ([p2p.py `handle_addrme`](https://github.com/p2pool/p2pool/blob/master/p2pool/p2p.py)) relays when the node **has** peers:

```python
if random.random() < .8 and self.node.peers:
    random.choice(self.node.peers.values()).send_addrme(port=port)
```

Ours is inverted, so:

1. **Functional bug (total):** addrme is relayed on *no* coin, ever.
2. **Latent UB:** when the guard does pass, `m_peers` is by construction empty, and `core::random::random_choice(m_peers)` — `std::map<uint64_t, peer_ptr>` — does `random_int(0,0) == 0`, `std::advance(begin, 0) == end()`, then `item->second`. Past-the-end dereference.

`protocol_actual.cpp` already carried the correct `!m_peers.empty()` in all five coins, so this aligns Legacy with its Actual sibling.

## Verified sites

| coin | legacy (fixed) | actual (already correct, reference) |
|---|---|---|
| dash | `protocol_legacy.cpp:57,67` | `protocol_actual.cpp:59,69` |
| ltc  | `protocol_legacy.cpp:57,67` | `protocol_actual.cpp:59,69` |
| btc  | `protocol_legacy.cpp:57,67` | `protocol_actual.cpp:59,69` |
| dgb  | `protocol_legacy.cpp:57,67` | `protocol_actual.cpp:59,69` |
| bch  | `protocol_legacy.cpp:86,96` | `protocol_actual.cpp:94,104` |

## Changes

- **Invert the guard** to `!m_peers.empty()` on both branches in all five `protocol_legacy.cpp`.
- **Defence in depth:** `core::random::random_choice()` now throws `std::out_of_range` on an empty container instead of reading past the end. All 30 call sites already guard on `!empty()`, and the protocol dispatchers wrap `handle()` in `catch (const std::exception&)`, so a future missed guard degrades into a logged handler warning rather than a freed-memory read.
- **`bch/protocol_actual.cpp` header comment** claimed the inverted Legacy guard was a deliberate wire-generation difference. It was a defect; the comment is corrected. (The 127.0.0.0/127.0.0.1 half of that comment is left standing — see "Not addressed" below.)

## `HANDLER(addrs)` audit — confirmed already correct

Audited in all ten files. Every one guards on `(random_float(0,1) < 0.8) && (!m_connections.empty())` and relays through `m_connections`, not `m_peers`. No change needed; now pinned by test so it cannot drift into the same inversion.

## Blast radius

`handle_version` returns `PeerConnectionType::legacy` unconditionally on ltc (`node.cpp:365`), btc (`:366`), dgb (`:373`) and bch (`:366`), so Legacy is the only live dispatch on those four. DASH is the exception: its dispatch lives in `node.hpp:713-714` (not `node.cpp`) and *can* select Actual once the operator ratchets the min-protocol floor above the oracle baseline. Either way the Legacy path is live on every coin, and addrme relay is currently dead on all five.

No consensus surface: addrme/addrs are peer-book gossip only.

## Test

Folded into the **existing allowlisted `core_test`** target (`src/core/test/random_choice_guard_test.cpp` added to the existing `add_executable`) — never a new standalone target, which CI would not build and CTest would report "Not Run".

- `RandomChoiceGuard.*` — all four `random_choice` overloads throw on empty, and still return a real member for non-empty containers.
- `AddrmeRelayGuard.GuardsOnHavingPeersNotOnHavingNone` — source KAT over all ten `protocol_{legacy,actual}.cpp` addrme handlers: exactly two `!m_peers.empty()` guards each, zero bare `m_peers.empty()`.
- `AddrsRelayGuard.GuardsOnHavingConnections` — same pin for the addrs handler.

```
[==========] 96 tests from 16 test suites ran.
[  PASSED  ] 96 tests.
```

**Negative control:** re-inverting a single guard in `ltc/protocol_legacy.cpp` makes the KAT fail with
`ltc::legacy addrme still carries the inverted m_peers.empty() guard (#869)`.

Full `c2pool` target also builds clean with the `random.hpp` change.

## Not addressed here (separate finding)

All five `protocol_legacy.cpp` compare the addrme self-probe against **`"127.0.0.0"`**; `protocol_actual.cpp` and canonical p2pool both use **`"127.0.0.1"`**. The Legacy string matches no real loopback peer, so a genuine 127.0.0.1 addrme falls into the else branch, gets `got_addr()`d into the peer book and gossiped out as a routable address. That is a real parity defect but it is a behavioural change to p2p address handling rather than the guard inversion #869 describes, so it is deliberately left out of this PR. Happy to fold it in or open a follow-up — say which.

## One correction to the issue text

> Combined with the absence of any origination site, peers never learn our listen port

An origination site **does** exist on four of the five coins — `handle_version` writes a `message_addrme` carrying `core::Server::listen_port()` immediately after the handshake:
`ltc/node.cpp:343`, `btc/node.cpp:344`, `bch/node.cpp:344`, `dgb/node.cpp:351`.

**DASH is the exception** — `dash::message_addrme` is registered as a handler (`node.hpp:1125,1144`) but nothing ever writes one, so DASH genuinely has no origination path. That is a second, independent gap and is *not* fixed here (it means touching the DASH handshake write ordering, which is load-bearing). Flagging it for a follow-up.