### PR TITLE
core(socket): outbound write queue — stop overlapping composed writes losing shares (#863)

### DIFF
--- a/src/core/socket.cpp
+++ b/src/core/socket.cpp
@@ -120,18 +120,92 @@ void Socket::write(std::unique_ptr<RawMessage> msg_data)
     }
 
     auto packet = std::make_shared<PackStream>(Packet::from_message(m_node->get_prefix(), msg_data));
+
+    // Queue, then start the drain ONLY if no composed write is in flight. The
+    // framing is done here (on the caller's thread, as before) so the bytes are
+    // captured in submission order; the wire order is then exactly the order in
+    // which callers reached this line. See the m_write_queue comment in
+    // socket.hpp for why overlapping composed writes cost shares.
+    bool start_drain = false;
+    {
+        std::lock_guard<std::mutex> lock(m_write_mutex);
+        m_write_queue.push_back(std::move(packet));
+        if (!m_writing)
+        {
+            m_writing = true;
+            start_drain = true;
+        }
+    }
+
+    // Outside the lock: do_write() initiates asio work and must never run with
+    // m_write_mutex held (leaf-lock discipline).
+    if (start_drain)
+        do_write();
+}
+
+void Socket::fail_write_queue()
+{
+    std::deque<std::shared_ptr<PackStream>> dropped;
+    {
+        std::lock_guard<std::mutex> lock(m_write_mutex);
+        dropped.swap(m_write_queue);
+        m_writing = false;
+    }
+    // `dropped` is released here, outside the lock.
+}
+
+void Socket::do_write()
+{
+    std::shared_ptr<PackStream> packet;
+    {
+        std::lock_guard<std::mutex> lock(m_write_mutex);
+        if (m_write_queue.empty())
+        {
+            m_writing = false;
+            return;
+        }
+        packet = m_write_queue.front();
+    }
+
+    // Socket closed under us between queueing and draining: fail the whole
+    // chain rather than leave buffers pinned behind a stuck in-flight flag.
+    // Matches the pre-queue behaviour, where write() on a closed socket was a
+    // silent no-op with no error() callback.
+    if (!m_status || !m_socket || !m_socket->is_open())
+    {
+        fail_write_queue();
+        return;
+    }
+
     boost::asio::async_write(*m_socket, boost::asio::buffer(packet->data(), packet->size()),
         [self = shared_from_this(), this, packet](const boost::system::error_code& ec, std::size_t length)
         {
             if (!ec) g_bytes_sent.fetch_add(length, std::memory_order_relaxed);
             if (ec) {
+                // A failed write kills the connection, so everything still
+                // queued behind it could never be delivered either: drop the
+                // chain and report ONCE — exactly what a single failed write
+                // did before the queue existed.
+                fail_write_queue();
                 std::shared_ptr<INetwork> strong;
                 if (!acquire_node(strong)) {
                     abort_connection();
                     return;
                 }
                 m_node->error("Socket::write error: " + ec.message(), get_addr());
+                return;
             }
+
+            {
+                std::lock_guard<std::mutex> lock(m_write_mutex);
+                if (!m_write_queue.empty())
+                    m_write_queue.pop_front();
+            }
+            // Start the NEXT composed write only from here — that ordering is
+            // the whole point of the queue. Not unbounded recursion:
+            // async_write never invokes its handler inline from the initiating
+            // call, so each do_write() returns before the next one runs.
+            do_write();
         }
     );
 }

--- a/src/core/socket.hpp
+++ b/src/core/socket.hpp
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 #pragma once
 
+#include <deque>
 #include <map>
+#include <mutex>
 #include <vector>
 #include <string>
 #include <memory>
@@ -73,6 +75,42 @@ class Socket : public std::enable_shared_from_this<Socket>
     NetService m_addr;
     NetService m_addr_local;
 
+    // ── Outbound write queue (issue #863) ──────────────────────────────────
+    //
+    // Asio forbids initiating a second COMPOSED write on a descriptor before
+    // the first one completes: the two async_write_some continuations are
+    // serviced FIFO per descriptor, so a message needing more than one round
+    // gets bytes from the other message spliced into its middle. The peer then
+    // sees a bad length/checksum and drops the connection.
+    //
+    // Every coin's send_shares issues three back-to-back writes on one socket
+    // in a single handler turn (remember_tx -> shares -> forget_tx), and
+    // handle_version writes getaddrs/addrme before the (potentially ~32 KB)
+    // have_tx advert. Because send_shares reports its hashes as "sent" on
+    // SUBMISSION and broadcast_share never retries, a spliced frame loses that
+    // share to that peer permanently — silent PPLNS loss.
+    //
+    // Fix: buffer composed writes here and drain strictly in submission order,
+    // starting the next one only from the previous completion handler, so at
+    // most ONE composed async_write is ever in flight per socket. Same shape as
+    // StratumSession::send_response/do_write (core/stratum_server.cpp).
+    //
+    // m_write_mutex is a LEAF lock: it is only ever held around the deque/flag
+    // mutation and is never held across async_write initiation, an m_node
+    // callback, or any other lock — writes are submitted from node/compute
+    // threads as well as from the io_context thread, so the queue itself must
+    // be guarded, but no new lock-order edge is introduced.
+    //
+    // Deliberately UNCAPPED, unlike StratumSession's backlog cap: before this
+    // queue existed a stalled peer already pinned one PackStream per
+    // overlapping in-flight async_write, so the memory profile is unchanged,
+    // and dropping a queued p2p message would reintroduce exactly the silent
+    // share loss this fixes. A stuck peer is still reaped by the existing
+    // read-side error path.
+    mutable std::mutex m_write_mutex;
+    std::deque<std::shared_ptr<PackStream>> m_write_queue;
+    bool m_writing {false}; // true while a composed async_write is in flight
+
 public:
     // Global P2P traffic counters (all sockets combined)
     static inline std::atomic<uint64_t> g_bytes_recv{0};
@@ -93,6 +131,16 @@ private:
     void abort_connection();
 
     void read();   // moved out-of-line; needs INetwork complete via acquire_node
+
+    // Drain step of the outbound queue: initiates the composed async_write for
+    // the front element and re-arms itself from that write's completion
+    // handler. Never called while another composed write is in flight.
+    void do_write();
+
+    // Drop every still-queued buffer and clear the in-flight flag. Used on
+    // write error / closed socket so the whole queued chain fails together,
+    // exactly as the single pre-queue write failed as a unit.
+    void fail_write_queue();
 
     void read_prefix(std::shared_ptr<Packet> packet);
 	void read_command(std::shared_ptr<Packet> packet);

--- a/src/core/test/CMakeLists.txt
+++ b/src/core/test/CMakeLists.txt
@@ -15,7 +15,15 @@ if (BUILD_TESTING AND (GTest_FOUND OR GTEST_FOUND))
     # EXISTING allowlisted core_test target (never a new add_executable — that is
     # the #769 "Not Run" trap), and one KAT covers every coin because all five
     # node lanes consume this one shared helper.
-    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp core_merkle_branches_test.cpp version_gate_test.cpp filesystem_test.cpp web_server_submitblock_test.cpp known_txs_eviction_test.cpp tx_advertiser_test.cpp)
+    #
+    # socket_write_queue_test.cpp: the core::Socket OUTBOUND WRITE QUEUE (#863).
+    # Drives a real loopback TCP pair with a small send buffer and submits
+    # overlapping composed writes from off-io threads; without the queue those
+    # writes splice bytes mid-message and the assertions fail. One KAT covers
+    # every coin because all five node lanes share this one socket layer. Same
+    # reasoning as above: FOLDED into the EXISTING allowlisted core_test target,
+    # never a new add_executable (the #769 "Not Run" trap).
+    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp core_merkle_branches_test.cpp version_gate_test.cpp filesystem_test.cpp web_server_submitblock_test.cpp known_txs_eviction_test.cpp tx_advertiser_test.cpp socket_write_queue_test.cpp)
     target_link_libraries(core_test PRIVATE GTest::gtest_main core c2pool_merged_mining GTest::gtest)
     target_link_libraries(core_test PRIVATE c2pool_payout c2pool_hashrate ltc_coin)  # OBJECT-lib SCC direct-naming (#22/#39)
 

--- a/src/core/test/socket_write_queue_test.cpp
+++ b/src/core/test/socket_write_queue_test.cpp
@@ -1,0 +1,363 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Outbound write-queue KAT for core::Socket (issue #863).
+//
+// Before the queue landed, core::Socket::write started a composed
+// boost::asio::async_write IMMEDIATELY. Asio forbids initiating a second
+// composed write on a descriptor before the first completes: the two
+// async_write_some continuations are serviced FIFO per descriptor, so any
+// message needing more than one round has bytes from the other message spliced
+// into its middle. The peer then sees a bad length/checksum and drops us.
+//
+// Every coin hits this: send_shares issues three back-to-back writes on ONE
+// socket in ONE handler turn (remember_tx -> shares -> forget_tx) —
+// dash/node.cpp:1346/1357/1362, ltc:756/777/784, btc:757/778/785,
+// dgb:737/758/765, bch:760/781/788 — and handle_version writes getaddrs/addrme
+// before the (potentially ~32 KB) have_tx advert. Because send_shares reports
+// its hashes as "sent" on SUBMISSION and broadcast_share never retries, a
+// spliced frame silently loses that share to that peer forever.
+//
+// These tests drive a real loopback TCP pair with a deliberately small send
+// buffer so every message needs many write_some rounds — the exact condition
+// under which the pre-fix code interleaved. They FAIL without the queue.
+//
+// Folded into the EXISTING allowlisted core_test target, never a standalone
+// add_executable: a target absent from build.yml's --target list is never built
+// in CI and CTest reports its cases "Not Run" (the #769 trap).
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <boost/asio.hpp>
+
+#include <core/hash.hpp>
+#include <core/message.hpp>
+#include <core/netaddress.hpp>
+#include <core/packet.hpp>
+#include <core/socket.hpp>
+
+namespace {
+
+using boost::asio::ip::tcp;
+
+// Small enough that a multi-hundred-KB message needs many write_some rounds,
+// which is precisely when overlapping composed writes splice each other.
+constexpr int kSmallSocketBuf = 4096;
+
+// Wire header layout written by core::Packet::from_message:
+//   prefix(N) | command(12) | length(4, LE) | checksum(4, first word of Hash)
+constexpr size_t kCommandLen  = 12;
+constexpr size_t kLengthLen   = 4;
+constexpr size_t kChecksumLen = 4;
+
+const std::vector<std::byte>& test_prefix()
+{
+    static const std::vector<std::byte> prefix{
+        std::byte{0xfc}, std::byte{0xc1}, std::byte{0xb7}, std::byte{0xdc}};
+    return prefix;
+}
+
+// Minimal ICommunicator: core::Socket only needs get_prefix() on the write
+// path, plus error() for the failure path. Constructed with an empty
+// weak_ptr<INetwork> and was_managed=false, i.e. the legacy unmanaged-node
+// path, so acquire_node() short-circuits to true and no INetwork is needed.
+struct StubCommunicator : public core::ICommunicator
+{
+    std::atomic<int> error_count{0};
+
+    void error(const message_error_type&, const NetService&,
+               const std::source_location = std::source_location::current()) override
+    {
+        error_count.fetch_add(1, std::memory_order_relaxed);
+    }
+    void error(const boost::system::error_code&, const NetService&,
+               const std::source_location = std::source_location::current()) override
+    {
+        error_count.fetch_add(1, std::memory_order_relaxed);
+    }
+    void handle(std::unique_ptr<RawMessage>, const NetService&) override {}
+    const std::vector<std::byte>& get_prefix() const override { return test_prefix(); }
+};
+
+// A message whose payload is `size` copies of `fill` — distinct per message so
+// a splice is visible as a byte mismatch at a known offset.
+std::unique_ptr<RawMessage> make_msg(const char* command, uint8_t fill, size_t size)
+{
+    std::vector<std::byte> payload(size, std::byte{fill});
+    return std::make_unique<RawMessage>(command, PackStream(std::span<const std::byte>(payload)));
+}
+
+std::vector<std::byte> framed_bytes(const char* command, uint8_t fill, size_t size)
+{
+    auto msg = make_msg(command, fill, size);
+    auto stream = core::Packet::from_message(test_prefix(), msg);
+    return std::vector<std::byte>(stream.data(), stream.data() + stream.size());
+}
+
+// Loopback TCP pair. The reader lives on its own io_context and is only ever
+// used synchronously, so the writer's io_context can be run from a dedicated
+// thread — which is also how the bug is reachable in production: node/compute
+// threads submit writes while the io thread drains them.
+struct LoopbackPair
+{
+    boost::asio::io_context ioc_reader;
+    boost::asio::io_context ioc_writer;
+    std::unique_ptr<tcp::acceptor> acceptor;
+    std::unique_ptr<tcp::socket> reader;
+    std::unique_ptr<tcp::socket> writer;
+
+    LoopbackPair()
+    {
+        acceptor = std::make_unique<tcp::acceptor>(
+            ioc_reader, tcp::endpoint(boost::asio::ip::make_address("127.0.0.1"), 0));
+        acceptor->listen();
+
+        writer = std::make_unique<tcp::socket>(ioc_writer);
+        writer->connect(acceptor->local_endpoint());
+
+        reader = std::make_unique<tcp::socket>(acceptor->accept());
+
+        boost::system::error_code ec;
+        // ONLY the send buffer is squeezed: that is what forces async_write to
+        // need many write_some rounds, which is the condition under which two
+        // overlapping composed writes splice each other. The RECEIVE buffer is
+        // left at the default on purpose — shrinking it below the 64 KB
+        // loopback MSS collapses the receive window and the transfer crawls.
+        writer->set_option(boost::asio::socket_base::send_buffer_size(kSmallSocketBuf), ec);
+        writer->set_option(tcp::no_delay(true), ec);
+        reader->set_option(tcp::no_delay(true), ec);
+    }
+};
+
+// Runs the writer io_context on its own thread for the lifetime of the scope.
+struct IoThread
+{
+    boost::asio::executor_work_guard<boost::asio::io_context::executor_type> guard;
+    std::thread thread;
+
+    explicit IoThread(boost::asio::io_context& ioc)
+        : guard(boost::asio::make_work_guard(ioc)), thread([&ioc] { ioc.run(); })
+    {
+    }
+    void stop(boost::asio::io_context& ioc)
+    {
+        guard.reset();
+        ioc.stop();
+        if (thread.joinable()) thread.join();
+    }
+};
+
+// Reads exactly n bytes from a synchronous socket.
+std::vector<std::byte> read_exact(tcp::socket& s, size_t n)
+{
+    std::vector<std::byte> buf(n);
+    boost::system::error_code ec;
+    size_t got = boost::asio::read(s, boost::asio::buffer(buf.data(), n), ec);
+    buf.resize(got);
+    return buf;
+}
+
+size_t first_mismatch(const std::vector<std::byte>& a, const std::vector<std::byte>& b)
+{
+    size_t n = std::min(a.size(), b.size());
+    for (size_t i = 0; i < n; ++i)
+        if (a[i] != b[i]) return i;
+    return (a.size() == b.size()) ? std::string::npos : n;
+}
+
+} // namespace
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. The regression itself: overlapping writes must arrive concatenated in
+//    submission order, with no interleaving. Fails without the queue.
+// ─────────────────────────────────────────────────────────────────────────────
+TEST(SocketWriteQueue, OverlappingWritesArriveConcatenatedInSubmissionOrder)
+{
+    // Mirrors send_shares' three back-to-back writes on one socket in one
+    // handler turn, sized so each needs many write_some rounds.
+    constexpr size_t kPayload = 256 * 1024;
+    const struct { const char* cmd; uint8_t fill; } kMsgs[] = {
+        {"remember_tx", 0xA1},
+        {"shares",      0xB2},
+        {"forget_tx",   0xC3},
+        {"have_tx",     0xD4},
+    };
+
+    LoopbackPair pair;
+    StubCommunicator stub;
+
+    std::vector<std::byte> expected;
+    for (const auto& m : kMsgs)
+    {
+        auto frame = framed_bytes(m.cmd, m.fill, kPayload);
+        expected.insert(expected.end(), frame.begin(), frame.end());
+    }
+
+    auto sock = std::make_shared<core::Socket>(
+        std::move(pair.writer), core::outgoing, &stub,
+        std::weak_ptr<core::INetwork>{}, /*was_managed=*/false);
+
+    IoThread io(pair.ioc_writer);
+
+    // Submitted from the TEST thread, not the io thread — the production shape.
+    for (const auto& m : kMsgs)
+        sock->write(make_msg(m.cmd, m.fill, kPayload));
+
+    auto received = read_exact(*pair.reader, expected.size());
+
+    io.stop(pair.ioc_writer);
+
+    ASSERT_EQ(received.size(), expected.size())
+        << "short read: the stream was corrupted or truncated";
+    size_t bad = first_mismatch(expected, received);
+    EXPECT_EQ(bad, std::string::npos)
+        << "byte streams diverge at offset " << bad
+        << " -- overlapping composed writes spliced bytes mid-message "
+        << "(expected 0x" << std::hex << (bad < expected.size() ? (int)expected[bad] : 0)
+        << ", got 0x" << (bad < received.size() ? (int)received[bad] : 0) << std::dec << ")";
+    EXPECT_EQ(stub.error_count.load(), 0);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. Thread-safety: writes submitted concurrently from many threads must still
+//    produce WHOLE frames (relative order across threads is not defined, but no
+//    frame may ever be spliced). Fails without the queue.
+// ─────────────────────────────────────────────────────────────────────────────
+TEST(SocketWriteQueue, ConcurrentWritersProduceWholeFrames)
+{
+    constexpr int kThreads = 4;
+    constexpr int kPerThread = 3;
+    constexpr size_t kPayload = 64 * 1024;
+    constexpr int kTotal = kThreads * kPerThread;
+
+    LoopbackPair pair;
+    StubCommunicator stub;
+
+    const size_t frame_size = framed_bytes("shares", 0x00, kPayload).size();
+
+    auto sock = std::make_shared<core::Socket>(
+        std::move(pair.writer), core::outgoing, &stub,
+        std::weak_ptr<core::INetwork>{}, /*was_managed=*/false);
+
+    IoThread io(pair.ioc_writer);
+
+    std::vector<std::thread> writers;
+    writers.reserve(kThreads);
+    for (int t = 0; t < kThreads; ++t)
+    {
+        writers.emplace_back([&sock, t] {
+            for (int i = 0; i < kPerThread; ++i)
+                sock->write(make_msg("shares",
+                                     static_cast<uint8_t>(t * kPerThread + i + 1),
+                                     kPayload));
+        });
+    }
+    for (auto& w : writers) w.join();
+
+    auto received = read_exact(*pair.reader, frame_size * kTotal);
+
+    io.stop(pair.ioc_writer);
+
+    ASSERT_EQ(received.size(), frame_size * kTotal);
+
+    // Walk the stream frame by frame. Every frame must carry the right prefix,
+    // a uniform payload (its fill byte), and a checksum matching that payload.
+    const size_t prefix_len = test_prefix().size();
+    const size_t header_len = prefix_len + kCommandLen + kLengthLen + kChecksumLen;
+    std::set<uint8_t> seen_fills;
+
+    for (int f = 0; f < kTotal; ++f)
+    {
+        const std::byte* p = received.data() + static_cast<size_t>(f) * frame_size;
+
+        ASSERT_EQ(0, std::memcmp(p, test_prefix().data(), prefix_len))
+            << "frame " << f << " has a corrupt prefix -- bytes were spliced";
+
+        uint32_t length = 0;
+        std::memcpy(&length, p + prefix_len + kCommandLen, kLengthLen);
+        ASSERT_EQ(length, kPayload) << "frame " << f << " has a corrupt length field";
+
+        uint32_t checksum = 0;
+        std::memcpy(&checksum, p + prefix_len + kCommandLen + kLengthLen, kChecksumLen);
+
+        const std::byte* payload = p + header_len;
+        const uint8_t fill = static_cast<uint8_t>(payload[0]);
+        for (size_t i = 1; i < kPayload; ++i)
+            ASSERT_EQ(static_cast<uint8_t>(payload[i]), fill)
+                << "frame " << f << " payload is not uniform at " << i
+                << " -- another message was spliced into it";
+
+        uint256 h = Hash(std::span<const std::byte>(payload, kPayload));
+        EXPECT_EQ(checksum, h.pn[0]) << "frame " << f << " checksum mismatch";
+
+        EXPECT_TRUE(seen_fills.insert(fill).second)
+            << "duplicate frame payload " << (int)fill;
+    }
+
+    EXPECT_EQ(seen_fills.size(), static_cast<size_t>(kTotal))
+        << "not every submitted message reached the wire intact";
+    EXPECT_EQ(stub.error_count.load(), 0);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. No behaviour change for the single-write case: byte-identical framing.
+// ─────────────────────────────────────────────────────────────────────────────
+TEST(SocketWriteQueue, SingleWriteIsByteIdentical)
+{
+    constexpr size_t kPayload = 1024;
+
+    LoopbackPair pair;
+    StubCommunicator stub;
+
+    auto expected = framed_bytes("shares", 0x5A, kPayload);
+
+    auto sock = std::make_shared<core::Socket>(
+        std::move(pair.writer), core::outgoing, &stub,
+        std::weak_ptr<core::INetwork>{}, /*was_managed=*/false);
+
+    IoThread io(pair.ioc_writer);
+    sock->write(make_msg("shares", 0x5A, kPayload));
+
+    auto received = read_exact(*pair.reader, expected.size());
+    io.stop(pair.ioc_writer);
+
+    ASSERT_EQ(received.size(), expected.size());
+    EXPECT_EQ(first_mismatch(expected, received), std::string::npos);
+    EXPECT_EQ(stub.error_count.load(), 0);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. Close/error semantics preserved: writes queued onto an already-closed
+//    socket are dropped silently, exactly as the pre-queue no-op did, and the
+//    socket does not wedge with a stuck in-flight flag.
+// ─────────────────────────────────────────────────────────────────────────────
+TEST(SocketWriteQueue, WritesOnClosedSocketAreDroppedWithoutError)
+{
+    LoopbackPair pair;
+    StubCommunicator stub;
+
+    auto sock = std::make_shared<core::Socket>(
+        std::move(pair.writer), core::outgoing, &stub,
+        std::weak_ptr<core::INetwork>{}, /*was_managed=*/false);
+
+    IoThread io(pair.ioc_writer);
+
+    sock->close();
+    for (int i = 0; i < 5; ++i)
+        sock->write(make_msg("shares", static_cast<uint8_t>(i), 512));
+
+    io.stop(pair.ioc_writer);
+
+    EXPECT_EQ(stub.error_count.load(), 0)
+        << "write() on a closed socket must stay a silent no-op";
+}


### PR DESCRIPTION
Closes #863.

## The bug

`core::Socket::write` (`src/core/socket.cpp:110`) started a composed `boost::asio::async_write` **immediately**, with no outbound queue. Asio forbids initiating a second composed write on a descriptor before the first completes: the two `async_write_some` continuations are serviced FIFO per descriptor, so any message needing more than one round gets bytes from the other message spliced into its middle. The peer sees a bad length/checksum and drops us.

Already documented in-tree as a known hazard at `src/core/tx_advertiser.hpp:41-90` ("FOLLOW-UP (deliberately NOT done here): the proper fix is an outbound write queue in core::Socket") and `src/impl/ltc/node.cpp:350-362`.

**Reachable on every coin.** `send_shares` issues three back-to-back writes on one socket in one handler turn (`remember_tx` -> `shares` -> `forget_tx`):

| coin | remember_tx | shares | forget_tx |
|---|---|---|---|
| dash | node.cpp:1346 | 1357 | 1362 |
| ltc  | node.cpp:756  | 777  | 784  |
| btc  | node.cpp:757  | 778  | 785  |
| dgb  | node.cpp:737  | 758  | 765  |
| bch  | node.cpp:760  | 781  | 788  |

`handle_version` likewise writes `getaddrs`/`addrme` before the up-to-32 KB `have_tx` advert.

**Why it costs money:** `send_shares` reports its hashes as "sent" on *submission*, and `broadcast_share` then marks them in `m_shared_share_hashes` and never retries. A spliced frame therefore loses that share to that peer permanently — silent PPLNS loss, no counter, no log line.

## The fix

A per-socket `std::deque<std::shared_ptr<PackStream>>` plus a `m_writing` in-flight flag on `core::Socket`.

- `write()` frames the message on the caller's thread exactly as before, pushes it, and starts the drain only if nothing is in flight.
- `do_write()` initiates the composed write for the queue front and re-arms itself **only from that write's completion handler**, so at most ONE composed `async_write` is ever outstanding per socket.

This mirrors the working reference already in this codebase — `StratumSession::send_response` / `StratumSession::do_write` (`src/core/stratum_server.hpp:95`, `src/core/stratum_server.cpp:1378-1424`) — rather than inventing a new pattern.

**Thread-safety.** Writes are submitted from node/compute threads as well as the io_context thread — that is exactly how the bug is reachable. `m_write_mutex` is a **leaf lock**: held only around the deque/flag mutation, never across `async_write` initiation, an `m_node` callback, or any other lock. No new lock-order edge. The empty-queue check and the `m_writing` clear happen under the same lock as the push, so a concurrent submit can never lose the wakeup and strand a non-empty queue.

**Semantics preserved.** On write error the whole queued chain is dropped and `error()` is reported once, exactly as a single failed write did. A write onto an already-closed socket stays a silent no-op with no error callback, as before. The single-write path is byte-identical.

The queue is deliberately **uncapped**, unlike `StratumSession`'s backlog cap: before this change a stalled peer already pinned one `PackStream` per overlapping in-flight `async_write`, so the memory profile is unchanged, and dropping a queued p2p message would reintroduce precisely the silent share loss this fixes.

## Scope

`src/core/socket.{hpp,cpp}` + tests only. No per-coin node file, no web_server, no workflow file touched.

## Tests

New `src/core/test/socket_write_queue_test.cpp`, **folded into the existing allowlisted `core_test` target** (never a new `add_executable` — that silently reports "Not Run"). It drives a real loopback TCP pair with a squeezed send buffer so every message needs many `write_some` rounds:

1. `OverlappingWritesArriveConcatenatedInSubmissionOrder` — 4 x 256 KB messages submitted back-to-back from an off-io thread; asserts the received stream is the exact concatenation of the 4 framed messages in submission order.
2. `ConcurrentWritersProduceWholeFrames` — 4 threads x 3 messages; walks the stream frame by frame and asserts every frame has an intact prefix, an intact length field, a uniform payload, and a checksum matching that payload.
3. `SingleWriteIsByteIdentical` — no behaviour change for the single-write case.
4. `WritesOnClosedSocketAreDroppedWithoutError` — close semantics preserved, no wedged in-flight flag.

### They fail on the pre-fix tree

Same test file, `src/core/socket.{hpp,cpp}` reverted to master:

```
[ RUN      ] SocketWriteQueue.OverlappingWritesArriveConcatenatedInSubmissionOrder
socket_write_queue_test.cpp:223: Failure
byte streams diverge at offset 127077 -- overlapping composed writes spliced
bytes mid-message (expected 0xa1, got 0xfc)
[  FAILED  ] SocketWriteQueue.OverlappingWritesArriveConcatenatedInSubmissionOrder (17 ms)
[ RUN      ] SocketWriteQueue.ConcurrentWritersProduceWholeFrames
socket_write_queue_test.cpp:296: Failure
frame 0 payload is not uniform at 32717 -- another message was spliced into it
[  FAILED  ] SocketWriteQueue.ConcurrentWritersProduceWholeFrames (4 ms)

 2 FAILED TESTS
```

`0xfc` is the first byte of the network magic prefix — the *next* message's header spliced into the middle of the first message's payload. That is the failure mode verbatim.

### They pass with the fix

```
[==========] Running 4 tests from 1 test suite.
[       OK ] SocketWriteQueue.OverlappingWritesArriveConcatenatedInSubmissionOrder (29 ms)
[       OK ] SocketWriteQueue.ConcurrentWritersProduceWholeFrames (15 ms)
[       OK ] SocketWriteQueue.SingleWriteIsByteIdentical (3 ms)
[       OK ] SocketWriteQueue.WritesOnClosedSocketAreDroppedWithoutError (1 ms)
[  PASSED  ] 4 tests.
```

Full `core_test` suite: **93 tests from 14 test suites ran, 93 PASSED** (53 ms). Ten consecutive repeat runs of the new suite: green every time (no flake). Total added runtime ~50 ms.

`cmake --build build_ci --target c2pool` — exit 0, zero errors.
`python3 tools/ci/check_test_target_allowlist.py` — `CI drift-guard OK: 119 per-coin test target(s) across 5 coin lane(s) all present in build.yml --target allowlist.`

No `.github/workflows` change is needed: `core_test` is already in both the Linux and the sanitizer `--target` allowlists.
