### PR TITLE
fix(web): p2pool-parity /global_stats gauges (#864)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -856,6 +856,19 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 int deepest_v36_pos = 0;
                 int v36_contiguous_from_tip = 0;
                 bool contiguous = true;
+                // Gauge inputs the SHARED core /global_stats path expects and DASH
+                // never published, so it fell back to a literal 1.0 (#864):
+                //   min_difficulty  = target_to_difficulty(best_share.max_target)
+                //                     -- p2pool web.py get_global_stats(). This is
+                //                     the pool's share-difficulty FLOOR, NOT the
+                //                     window average; the two are different
+                //                     quantities and only the floor is p2pool's.
+                //   average_difficulty = window mean of the per-share difficulty,
+                //                     which getinfo()/rest_sharechain_stats read.
+                // Both DISPLAY ONLY. m_max_bits / m_bits are read straight off the
+                // share header; nothing here mutates the tracker or the retarget.
+                double best_min_difficulty = 0.0;
+                double difficulty_sum = 0.0;
                 const int skip_count   = std::min(chain_ht, chain_len * 9 / 10);
                 const int sample_count = std::min(chain_ht - skip_count, chain_len / 10);
                 uint256 sampling_start;
@@ -869,6 +882,13 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                             desired_counts[dv] += 1;
                             format_v16 += 1;  // DashShare is wire-format v16
                             miner_counts[s->m_pubkey_hash.GetHex()] += 1;
+                            // i == 0 is the best share (get_chain walks tip-first).
+                            if (i == 0 && s->m_max_bits != 0)
+                                best_min_difficulty = chain::target_to_difficulty(
+                                    chain::bits_to_target(s->m_max_bits));
+                            if (s->m_bits != 0)
+                                difficulty_sum += chain::target_to_difficulty(
+                                    chain::bits_to_target(s->m_bits));
                             if (dv >= 36) {
                                 deepest_v36_pos = i + 1;
                                 if (contiguous) v36_contiguous_from_tip = i + 1;
@@ -885,6 +905,15 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 // main_ltc.cpp, where total_shares is the windowed skiplist count), so
                 // the gauge's version percentages divide by the same denominator.
                 out["total_shares"] = format_v16;
+
+                // Only publish when we actually measured one; an absent key makes
+                // /global_stats emit min_difficulty:null, which is the honest
+                // answer on a chain too young to have a floor (p2pool returns the
+                // whole payload as None below 10 shares).
+                if (best_min_difficulty > 0.0)
+                    out["min_difficulty"] = best_min_difficulty;
+                if (format_v16 > 0 && difficulty_sum > 0.0)
+                    out["average_difficulty"] = difficulty_sum / format_v16;
 
                 nlohmann::json sbv = nlohmann::json::object();
                 if (format_v16 > 0) sbv["16"] = format_v16;
@@ -991,9 +1020,16 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
 
             // ── REAL pool hashrate (ported from main_ltc.cpp:2865) ────────
             // dash::ShareTracker::get_pool_attempts_per_second is the same
-            // p2pool estimator LTC uses (share_tracker.hpp:1353), over DASH's
-            // own TARGET_LOOKBEHIND. Returns the last good value on lock
-            // contention rather than a spurious 0.
+            // p2pool estimator LTC uses (share_tracker.hpp:1353). Returns the
+            // last good value on lock contention rather than a spurious 0.
+            //
+            // DISPLAY LOOKBEHIND (#864): p2pool web.py get_global_stats() averages
+            // the gauge over ONE HOUR of shares -- min(height, 3600//SHARE_PERIOD)
+            // -- which is 180 shares on DASH, not TARGET_LOOKBEHIND (100). This is
+            // the DISPLAY window ONLY. The CONSENSUS retarget keeps
+            // TARGET_LOOKBEHIND (p2pool data.py:137,140), and c2pool already
+            // matches canonical there; nothing on this hook feeds the retarget --
+            // m_pool_hashrate_fn is read exclusively by web_server REST handlers.
             mi->set_pool_hashrate_fn([node_ptr]() -> double {
                 static double s_last_good = 0.0;
                 auto best = node_ptr->best_share_hash();
@@ -1003,9 +1039,9 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 if (!guard->chain.contains(best)) return s_last_good;
                 int height = guard->chain.get_height(best);
                 if (height < 3) return s_last_good;
-                auto lookbehind = std::min(
-                    height - 1,
-                    static_cast<int>(dash::SharechainConfig::TARGET_LOOKBEHIND));
+                const int display_lookbehind =
+                    3600 / static_cast<int>(dash::SharechainConfig::share_period());
+                auto lookbehind = std::min(height - 1, display_lookbehind);
                 auto aps = guard->get_pool_attempts_per_second(best, lookbehind, false);
                 double hr = static_cast<double>(aps.GetLow64());
                 if (hr > 0) s_last_good = hr;

--- a/src/c2pool/main_ltc.cpp
+++ b/src/c2pool/main_ltc.cpp
@@ -2903,8 +2903,15 @@ int main(int argc, char* argv[]) {
                         if (!guard->chain.contains(best)) return s_last_good;
                         int height = guard->chain.get_height(best);
                         if (height < 3) return s_last_good;
-                        auto lookbehind = std::min(height - 1,
-                            static_cast<int>(ltc::PoolConfig::TARGET_LOOKBEHIND));
+                        // DISPLAY LOOKBEHIND (#864): p2pool web.py get_global_stats()
+                        // averages the gauge over ONE HOUR of shares --
+                        // min(height, 3600//SHARE_PERIOD) -- not TARGET_LOOKBEHIND.
+                        // DISPLAY ONLY: the CONSENSUS retarget keeps TARGET_LOOKBEHIND
+                        // (p2pool data.py:137,140) and is untouched; m_pool_hashrate_fn
+                        // is read exclusively by web_server REST handlers.
+                        const int display_lookbehind =
+                            3600 / static_cast<int>(ltc::PoolConfig::share_period());
+                        auto lookbehind = std::min(height - 1, display_lookbehind);
                         auto aps = guard->get_pool_attempts_per_second(best, lookbehind, false);
                         double hr = static_cast<double>(aps.GetLow64());
                         if (hr > 0) s_last_good = hr;
@@ -3474,6 +3481,21 @@ int main(int argc, char* argv[]) {
                 result["shares_by_miner"]   = sr.miner_counts;
                 result["average_difficulty"] = sr.share_count > 0
                     ? sr.difficulty_sum / sr.share_count : 1.0;
+                // p2pool web.py get_global_stats() reports the pool's share-difficulty
+                // FLOOR, target_to_difficulty(tracker.items[best_share].max_target) --
+                // a different quantity from the window average above, which is what
+                // /global_stats had been publishing as min_difficulty (#864). Display
+                // only; read straight off the best share's header.
+                if (!best.IsNull() && chain.contains(best)) {
+                    try {
+                        auto& bcd = chain.get(best);
+                        bcd.share.invoke([&](auto* s) {
+                            if (s->m_max_bits != 0)
+                                result["min_difficulty"] = chain::target_to_difficulty(
+                                    chain::bits_to_target(s->m_max_bits));
+                        });
+                    } catch (...) { /* no floor to report; field stays absent -> null */ }
+                }
                 result["heaviest_fork_weight"] = chain.size() > 0
                     ? static_cast<double>(best_height) / static_cast<double>(chain.size())
                     : 0.0;

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -2675,11 +2675,22 @@ nlohmann::json MiningInterface::rest_global_stats()
     nlohmann::json result = nlohmann::json::object();
     
     double pool_rate = 0.0;
-    double share_diff = 1.0;
     int unique_miners = 0;
     int total_shares = 0;
     int orphan_shares = 0, dead_shares = 0;
     int chain_height = 0;
+
+    // p2pool web.py get_global_stats() reports the pool's FLOOR share
+    // difficulty, not the sharechain average:
+    //     min_difficulty = target_to_difficulty(tracker.items[best_share].max_target)
+    // These are different quantities -- max_target is the per-share difficulty
+    // FLOOR carried in the share header, while the average is a window mean that
+    // drifts with vardiff. The per-coin sharechain-stats hook publishes the
+    // p2pool quantity as "min_difficulty"; a coin that does not publish it has
+    // no honest answer, and p2pool itself returns None for the whole payload
+    // while the chain is too young, so the field is emitted as null rather than
+    // a literal 1.0 that reads as a real floor.
+    std::optional<double> min_difficulty;
 
     // Populate from sharechain
     if (m_sharechain_stats_fn) {
@@ -2692,8 +2703,9 @@ nlohmann::json MiningInterface::rest_global_stats()
             dead_shares = sc["dead_shares"].get<int>();
         if (sc.contains("chain_height"))
             chain_height = sc["chain_height"].get<int>();
-        if (sc.contains("average_difficulty"))
-            share_diff = sc["average_difficulty"].get<double>();
+        if (sc.contains("min_difficulty") && sc["min_difficulty"].is_number()
+            && sc["min_difficulty"].get<double>() > 0.0)
+            min_difficulty = sc["min_difficulty"].get<double>();
         if (sc.contains("shares_by_miner") && sc["shares_by_miner"].is_object())
             unique_miners = static_cast<int>(sc["shares_by_miner"].size());
     }
@@ -2718,10 +2730,25 @@ nlohmann::json MiningInterface::rest_global_stats()
     int stales = orphan_shares + dead_shares;
     int good = total_shares - stales;
     double pool_stale_prop = (good + stales > 0) ? static_cast<double>(stales) / (good + stales) : 0.0;
-    result["pool_hash_rate"] = pool_rate;
-    result["pool_nonstale_hash_rate"] = pool_rate * (1.0 - pool_stale_prop);
+    // p2pool web.py get_global_stats():
+    //     nonstale_hash_rate      = get_pool_attempts_per_second(...)
+    //     pool_nonstale_hash_rate = nonstale_hash_rate
+    //     pool_hash_rate          = nonstale_hash_rate / (1 - stale_prop)
+    // get_pool_attempts_per_second sums the work of shares that actually made
+    // the chain, so the estimator output IS the NON-STALE rate; the gross rate
+    // is that grossed UP by the stale fraction. c2pool had the two fields
+    // assigned the other way round (gross = estimator, nonstale = estimator
+    // scaled DOWN), i.e. both wrong and in opposite directions. Masked so far
+    // only because pool_stale_prop has been 0 in practice.
+    result["pool_nonstale_hash_rate"] = pool_rate;
+    result["pool_hash_rate"] = (pool_stale_prop < 1.0)
+        ? pool_rate / (1.0 - pool_stale_prop)
+        : pool_rate;  // degenerate all-stale window: do not divide by zero
     result["pool_stale_prop"] = pool_stale_prop;
-    result["min_difficulty"] = share_diff;
+    if (min_difficulty)
+        result["min_difficulty"] = *min_difficulty;
+    else
+        result["min_difficulty"] = nullptr;
     result["network_block_difficulty"] = net_diff;
 
     // Additional fields
@@ -3900,7 +3927,11 @@ nlohmann::json MiningInterface::rest_p2pool_global_stats()
     nlohmann::json result = nlohmann::json::object();
     result["pool_hash_rate"] = full.value("pool_hash_rate", 0.0);
     result["pool_stale_prop"] = full.value("pool_stale_prop", 0.0);
-    result["min_difficulty"] = full.value("min_difficulty", 1.0);
+    // Propagate the null through rather than substituting a literal 1.0: an
+    // unknown floor must read as unknown on the p2pool-shaped endpoint too.
+    result["min_difficulty"] = (full.contains("min_difficulty") && full["min_difficulty"].is_number())
+        ? full["min_difficulty"]
+        : nlohmann::json(nullptr);
     result["pool_nonstale_hash_rate"] = full.value("pool_nonstale_hash_rate", 0.0);
     result["network_block_difficulty"] = full.value("network_block_difficulty", 0.0);
     result["network_hashrate"] = full.value("network_hashrate", 0.0);

--- a/test/test_web_honesty_regression.cpp
+++ b/test/test_web_honesty_regression.cpp
@@ -18,6 +18,10 @@
 #include <nlohmann/json.hpp>
 
 #include <core/web_server.hpp>
+#include <impl/dash/config_pool.hpp>   // dash::SharechainConfig SHARE_PERIOD / TARGET_LOOKBEHIND
+#include <impl/ltc/config_pool.hpp>    // ltc::PoolConfig  SHARE_PERIOD / TARGET_LOOKBEHIND
+
+#include <cmath>
 
 using namespace core;
 using nlohmann::json;
@@ -950,4 +954,166 @@ TEST(WebHonestyRegression, NodeInfoExternalIpServesOperatorAdvertisedHost) {
     EXPECT_EQ(ni.value("external_ip", std::string{}), "109.161.57.3")
         << "served external_ip must be the operator-advertised miner-facing "
            "host so the dashboard Stratum URL is not the wrong NAT IP";
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// #864 — /global_stats gauges must agree with canonical p2pool
+//
+// Three independent defects, all DISPLAY-only (no consensus path touched):
+//
+//  (a) min_difficulty fell back to a literal 1.0 for any coin whose
+//      sharechain-stats hook does not publish it (DASH published no
+//      difficulty key at all), so the dashboard showed a fabricated floor.
+//  (b) Even when populated it carried the sharechain AVERAGE difficulty.
+//      p2pool web.py get_global_stats() reports
+//      target_to_difficulty(tracker.items[best_share].max_target) -- the
+//      pool's share-difficulty FLOOR. Different quantity.
+//  (c) The stale relationship was inverted. p2pool:
+//          pool_nonstale_hash_rate = get_pool_attempts_per_second(...)
+//          pool_hash_rate          = nonstale / (1 - stale_prop)
+//      c2pool had pool_hash_rate = aps and nonstale = aps*(1-stale_prop) --
+//      both fields wrong, in opposite directions. Masked while stale_prop==0.
+// ═══════════════════════════════════════════════════════════════════════════
+
+namespace {
+
+// Stats hook shaped like the real per-coin lambdas, with a controllable
+// stale tally and an optionally-absent min_difficulty.
+json make_stats(int total, int orphan, int dead, const json& min_diff)
+{
+    json j{{"total_shares", total},
+           {"orphan_shares", orphan},
+           {"dead_shares", dead},
+           // The average is deliberately far from any plausible floor so a
+           // regression that re-sources min_difficulty from it is unmissable.
+           {"average_difficulty", 1024.0}};
+    if (!min_diff.is_null())
+        j["min_difficulty"] = min_diff;
+    return j;
+}
+
+} // namespace
+
+// (b) The floor is the floor, not the window average.
+TEST(WebGaugeParity, MinDifficultyIsPoolFloorNotSharechainAverage) {
+    MiningInterface mi(/*testnet=*/true, /*node=*/nullptr);
+    mi.set_sharechain_stats_fn([] { return make_stats(1000, 0, 0, 3.5); });
+    mi.set_pool_hashrate_fn([] { return 1e9; });
+
+    json g = mi.rest_global_stats();
+    ASSERT_TRUE(g["min_difficulty"].is_number());
+    EXPECT_DOUBLE_EQ(g["min_difficulty"].get<double>(), 3.5)
+        << "min_difficulty must be the best share's max_target floor "
+           "(p2pool web.py), never the sharechain average";
+    EXPECT_NE(g["min_difficulty"].get<double>(), 1024.0)
+        << "min_difficulty must not be re-sourced from average_difficulty";
+}
+
+// (a) No floor published => null, never a fabricated 1.0.
+TEST(WebGaugeParity, MinDifficultyIsNullWhenTheCoinPublishesNoFloor) {
+    MiningInterface mi(/*testnet=*/true, /*node=*/nullptr, Blockchain::DASH);
+    // Exactly the pre-fix DASH shape: chain/stale keys, no difficulty floor.
+    mi.set_sharechain_stats_fn([] { return make_stats(500, 0, 0, json(nullptr)); });
+    mi.set_pool_hashrate_fn([] { return 1e9; });
+
+    json g = mi.rest_global_stats();
+    EXPECT_TRUE(g["min_difficulty"].is_null())
+        << "an unknown difficulty floor must read as unknown, not as a "
+           "literal 1.0 that the dashboard renders as a real value";
+    EXPECT_FALSE(g["min_difficulty"] == 1.0);
+
+    // The p2pool-shaped endpoint must propagate the null, not re-substitute.
+    json p = mi.rest_p2pool_global_stats();
+    EXPECT_TRUE(p["min_difficulty"].is_null())
+        << "/global_stats (p2pool shape) must not restore the 1.0 literal";
+}
+
+TEST(WebGaugeParity, MinDifficultyPropagatesThroughP2poolShapeWhenKnown) {
+    MiningInterface mi(/*testnet=*/true, /*node=*/nullptr);
+    mi.set_sharechain_stats_fn([] { return make_stats(1000, 0, 0, 8.75); });
+    mi.set_pool_hashrate_fn([] { return 1e9; });
+
+    json p = mi.rest_p2pool_global_stats();
+    ASSERT_TRUE(p["min_difficulty"].is_number());
+    EXPECT_DOUBLE_EQ(p["min_difficulty"].get<double>(), 8.75);
+}
+
+// (c) aps IS the non-stale rate; the gross rate is that grossed UP.
+TEST(WebGaugeParity, StaleRelationshipMatchesP2poolNotItsInverse) {
+    MiningInterface mi(/*testnet=*/true, /*node=*/nullptr);
+    // 100 shares, 10 stale => pool_stale_prop = 0.10
+    mi.set_sharechain_stats_fn([] { return make_stats(100, 5, 5, 4.0); });
+    mi.set_pool_hashrate_fn([] { return 1e9; });  // get_pool_attempts_per_second
+
+    json g = mi.rest_global_stats();
+    const double aps = 1e9;
+    const double stale = g["pool_stale_prop"].get<double>();
+    ASSERT_DOUBLE_EQ(stale, 0.10);
+
+    EXPECT_DOUBLE_EQ(g["pool_nonstale_hash_rate"].get<double>(), aps)
+        << "p2pool: pool_nonstale_hash_rate = get_pool_attempts_per_second()";
+    EXPECT_DOUBLE_EQ(g["pool_hash_rate"].get<double>(), aps / (1.0 - stale))
+        << "p2pool: pool_hash_rate = nonstale / (1 - stale_prop)";
+
+    // The pre-fix values, pinned as explicitly WRONG so the inversion cannot
+    // come back: gross must exceed non-stale, never fall below it.
+    EXPECT_GT(g["pool_hash_rate"].get<double>(), g["pool_nonstale_hash_rate"].get<double>())
+        << "gross hashrate must be >= non-stale; the inverted form had it lower";
+    EXPECT_NE(g["pool_nonstale_hash_rate"].get<double>(), aps * (1.0 - stale))
+        << "non-stale must not be the estimator scaled DOWN (the pre-fix form)";
+}
+
+// The two fields must stay equal exactly when there are no stales -- the
+// condition that masked the inversion in production.
+TEST(WebGaugeParity, ZeroStalesLeavesBothHashRatesEqual) {
+    MiningInterface mi(/*testnet=*/true, /*node=*/nullptr);
+    mi.set_sharechain_stats_fn([] { return make_stats(100, 0, 0, 4.0); });
+    mi.set_pool_hashrate_fn([] { return 1e9; });
+
+    json g = mi.rest_global_stats();
+    ASSERT_DOUBLE_EQ(g["pool_stale_prop"].get<double>(), 0.0);
+    EXPECT_DOUBLE_EQ(g["pool_hash_rate"].get<double>(), 1e9);
+    EXPECT_DOUBLE_EQ(g["pool_nonstale_hash_rate"].get<double>(), 1e9);
+}
+
+// Degenerate all-stale window must not divide by zero into inf/NaN.
+TEST(WebGaugeParity, AllStaleWindowDoesNotDivideByZero) {
+    MiningInterface mi(/*testnet=*/true, /*node=*/nullptr);
+    mi.set_sharechain_stats_fn([] { return make_stats(10, 5, 5, 4.0); });
+    mi.set_pool_hashrate_fn([] { return 1e9; });
+
+    json g = mi.rest_global_stats();
+    ASSERT_DOUBLE_EQ(g["pool_stale_prop"].get<double>(), 1.0);
+    EXPECT_TRUE(std::isfinite(g["pool_hash_rate"].get<double>()));
+    EXPECT_TRUE(std::isfinite(g["pool_nonstale_hash_rate"].get<double>()));
+}
+
+// ── (d) DISPLAY lookbehind vs CONSENSUS retarget lookbehind ────────────────
+// p2pool web.py get_global_stats() averages the gauge over ONE HOUR of shares:
+//     lookbehind = min(height, 3600 // net.SHARE_PERIOD)
+// The CONSENSUS retarget is a different window entirely (p2pool data.py:137,140
+// uses net.TARGET_LOOKBEHIND) and c2pool already matches canonical there. The
+// two must NOT be conflated: this pins the display formula AND pins
+// TARGET_LOOKBEHIND at its canonical per-coin value so a future "unification"
+// cannot drag the retarget along with the gauge.
+TEST(WebGaugeParity, DisplayLookbehindIsOneHourOfSharesNotTargetLookbehind) {
+    // DASH: SHARE_PERIOD 20s -> 3600/20 = 180 display shares; retarget stays 100.
+    EXPECT_EQ(dash::SharechainConfig::SHARE_PERIOD, 20u);
+    EXPECT_EQ(3600u / dash::SharechainConfig::SHARE_PERIOD, 180u)
+        << "DASH display gauge must look back one hour = 180 shares";
+    EXPECT_EQ(dash::SharechainConfig::TARGET_LOOKBEHIND, 100u)
+        << "CONSENSUS retarget lookbehind is canonical and MUST NOT move";
+    EXPECT_NE(3600u / dash::SharechainConfig::SHARE_PERIOD,
+              dash::SharechainConfig::TARGET_LOOKBEHIND)
+        << "display and consensus windows are distinct on DASH -- conflating "
+           "them is exactly the #864 defect";
+
+    // LTC: SHARE_PERIOD 15s -> 3600/15 = 240 display shares; retarget stays 200.
+    EXPECT_EQ(ltc::PoolConfig::SHARE_PERIOD, 15u);
+    EXPECT_EQ(3600u / ltc::PoolConfig::SHARE_PERIOD, 240u)
+        << "LTC display gauge must look back one hour = 240 shares";
+    EXPECT_EQ(ltc::PoolConfig::TARGET_LOOKBEHIND, 200u)
+        << "CONSENSUS retarget lookbehind is canonical and MUST NOT move";
+    EXPECT_NE(3600u / ltc::PoolConfig::SHARE_PERIOD,
+              ltc::PoolConfig::TARGET_LOOKBEHIND);
 }

--- a/web-static/dashboard.html
+++ b/web-static/dashboard.html
@@ -3045,7 +3045,11 @@
             populateActiveMiners(local_stats, global_stats);
             d3.select('#pool_rate').text(format_hashrate(global_stats.pool_hash_rate));
             d3.select('#pool_stale').text(d3.format('.2p')(global_stats.pool_stale_prop));
-            d3.select('#difficulty').text(d3.format('.3r')(global_stats.min_difficulty));
+            // min_difficulty is null when the coin has no measurable share-difficulty
+            // floor yet (young chain / stats hook not wired). Say so rather than
+            // formatting a null into a number that reads as a real floor.
+            d3.select('#difficulty').text(global_stats.min_difficulty == null
+                ? '\u2014' : d3.format('.3r')(global_stats.min_difficulty));
             var time_to_block = local_stats.attempts_to_block / global_stats.pool_hash_rate;
             d3.select('#time_to_block').text(isFinite(time_to_block) ? format_dt(time_to_block) : '\u221E');
             var blocks_in_24h = (24 * 3600) / time_to_block;

--- a/web-static/index.html
+++ b/web-static/index.html
@@ -223,7 +223,11 @@
                 d3.json('../global_stats', function(global_stats) {
                     d3.select('#pool_rate').text(d3.format('.3s')(global_stats.pool_hash_rate) + 'H/s');
                     d3.select('#pool_stale').text(d3.format('.2p')(global_stats.pool_stale_prop));
-                    d3.select('#difficulty').text(d3.format('.3r')(global_stats.min_difficulty));
+                    // min_difficulty is null when the coin has no measurable share-difficulty
+                    // floor yet (young chain / stats hook not wired). Say so rather than
+                    // formatting a null into a number that reads as a real floor.
+                    d3.select('#difficulty').text(global_stats.min_difficulty == null
+                        ? '\u2014' : d3.format('.3r')(global_stats.min_difficulty));
                     
                     var time_to_block = local_stats.attempts_to_block/global_stats.pool_hash_rate;
                     d3.select('#time_to_block').text(format_dt(time_to_block));


### PR DESCRIPTION
Fixes #864.

Three independent defects making our gauges disagree with a joined canonical p2pool node on the same chain (34.30 TH/s vs 45.73 TH/s; `min_difficulty` 1.0 vs 5259.2), plus a fourth window mismatch found while verifying them.

**All DISPLAY-only. The consensus retarget is deliberately untouched — see (d).**

---

## (a) `min_difficulty` was a literal 1.0

`web_server.cpp:3903` (issue cites `:3848`; line has drifted) reads `full.value("min_difficulty", 1.0)` off a key `rest_global_stats` derived at `:2724` from `share_diff`, initialised `1.0` at `:2678` and overwritten only if the sharechain-stats callback supplies `"average_difficulty"` (`:2695-2696`). `main_dash.cpp`'s stats lambda (`763-916`) emits `chain_length` / `fork_count` / `verified_count` / `orphan_shares` / `dead_shares` / the local-mint gauge / the protocol-floor gauge — and **no difficulty key at all**. So DASH reported a fabricated `1.0`.

## (b) Wrong quantity even where populated

`main_ltc.cpp:3475` does supply `average_difficulty`, but that is the **sharechain window mean**. p2pool `web.py get_global_stats()` reports

```python
min_difficulty = bitcoin_data.target_to_difficulty(node.tracker.items[best_share].max_target)
```

— the pool's share-difficulty **FLOOR**, off the best share's header. Different quantity; only the floor is p2pool's. (`main_ltc.cpp:4148` already computes exactly this for the per-share `/share` view, so the definition was already in-tree, just not wired to the global gauge.)

## (c) Inverted stale relationship

p2pool:
```python
nonstale_hash_rate      = get_pool_attempts_per_second(tracker, best_share, lookbehind)
pool_nonstale_hash_rate = nonstale_hash_rate
pool_hash_rate          = nonstale_hash_rate / (1 - stale_prop)
```
c2pool (`web_server.cpp:2721-2722`):
```cpp
result["pool_hash_rate"] = pool_rate;                              // = aps
result["pool_nonstale_hash_rate"] = pool_rate * (1.0 - stale);     // = aps scaled DOWN
```
`get_pool_attempts_per_second` sums the work of shares that actually made the chain, so its output **is** the non-stale rate and the gross rate is that grossed **up**. Both fields were wrong, in opposite directions. Masked in production only because `pool_stale_prop` has been 0 — but it is one of the two contributors to the reported hashrate divergence.

## (d) DISPLAY lookbehind ≠ p2pool's — ★ retarget NOT touched

p2pool `web.py` averages the gauge over **one hour of shares**: `lookbehind = min(height, 3600 // net.SHARE_PERIOD)`. Both `pool_hashrate_fn` hooks used `TARGET_LOOKBEHIND` instead:

| coin | SHARE_PERIOD | p2pool display window | c2pool used (TARGET_LOOKBEHIND) |
|---|---|---|---|
| DASH | 20s | **180** | 100 |
| LTC  | 15s | **240** | 200 |

**This applies ONLY to the display gauge.** The consensus retarget keys on `net.TARGET_LOOKBEHIND` (p2pool `data.py`) and c2pool already matches canonical there. `m_pool_hashrate_fn` is read exclusively by `web_server` REST handlers (`web_server.cpp:2702, 3288, 3693, 4330, 4652, 6623`, `web_server.hpp:568` → `:2042, :2130`) — nothing on this hook reaches the retarget. `TARGET_LOOKBEHIND` is unchanged in every `config_pool.hpp`, and the new test pins **both** windows so a future "unification" cannot drag the retarget along with the gauge.

---

## Changes

- `web_server.cpp` `rest_global_stats()` — source `min_difficulty` from a new `"min_difficulty"` stats key; emit **null** (not 1.0) when the coin has no floor to report; swap the two hash-rate fields onto the p2pool relationship with a divide-by-zero guard for a degenerate all-stale window.
- `web_server.cpp` `rest_p2pool_global_stats()` — propagate the null rather than restoring the literal.
- `main_dash.cpp` stats lambda — publish `min_difficulty` (best share `m_max_bits`) **and** `average_difficulty` (window mean of `m_bits`), both computed inside the backward walk it already performs. Header reads only; no tracker mutation. This also fixes the same fabricated `1.0` in `getinfo()`'s `difficulty` field on DASH (`web_server.cpp:2055-2057`).
- `main_ltc.cpp` stats lambda — publish `min_difficulty` off the best share's `m_max_bits` alongside the existing `average_difficulty`.
- `main_dash.cpp` / `main_ltc.cpp` `pool_hashrate_fn` — p2pool display lookbehind (via `share_period()`, so testnet is handled).
- `web-static/index.html`, `web-static/dashboard.html` — render an em dash for a null floor instead of feeding `null` to `d3.format('.3r')`.

`main_dash.cpp` and `main_ltc.cpp` are the **only** two mains that register `set_sharechain_stats_fn` / `set_pool_hashrate_fn`; btc/dgb/bch wire neither, so on those coins `min_difficulty` now correctly reads `null` instead of a fabricated 1.0.

## Test

Folded into the **existing allowlisted `test_web_honesty_regression`** target (7 new `WebGaugeParity` cases; no new `add_executable`). Its charter is literally "a dashboard must never lie about prod health", which is the same defect class.

```
[==========] 41 tests from 2 test suites ran.
[  PASSED  ] 41 tests.
```

**Negative controls, both verified:**
- restoring `min_difficulty.value_or(1.0)` → `MinDifficultyIsNullWhenTheCoinPublishesNoFloor` FAILS
- restoring `pool_hash_rate = aps; nonstale = aps*(1-stale)` → `StaleRelationshipMatchesP2poolNotItsInverse` FAILS

`c2pool` (main_ltc) and `c2pool-dash` (main_dash) both build clean.

## Not covered

The acceptance criterion "agrees with a joined python node on the same chain within stale-prop rounding" needs a live joined node and is not something a unit KAT can assert. What is pinned here is the formula and the field mapping against canonical; end-to-end agreement still wants a soak against the oracle before these gauges are used as deploy abort criteria again.
