### PR TITLE
coins: mint the block-winning share onto the sharechain (dash/btc/bch/dgb)

### DIFF
--- a/src/impl/bch/stratum/work_source.cpp
+++ b/src/impl/bch/stratum/work_source.cpp
@@ -690,6 +690,52 @@ nlohmann::json BCHWorkSource::mining_submit(
 
     auto pow_hex_short = pow_hash.GetHex().substr(0, 16);
 
+    // -- Sharechain write (#887) --
+    // Dispatch to create_share_fn_ (v36 share add). SHARED by both accept
+    // classes: block_target <= share_target, so a solve that meets the block
+    // target meets the share target too -- it is the highest-work share this
+    // node will ever produce, and the sharechain and the coin blockchain are
+    // independent systems. Before #887 the won-block arm returned without ever
+    // reaching this seam, forfeiting our own PPLNS weight in the very window
+    // the block pays out from and denying peers our best work. LTC has always
+    // written on both classes (web_server.cpp).
+    //
+    // ORDERING -- reward invariant: on the won-block arm this runs AFTER the
+    // block has already been dispatched, never before. create_share_fn_ takes
+    // the exclusive tracker lock, can decline, and can throw; the block submit
+    // must never sit behind any of that.
+    //
+    // CONSENSUS: unchanged. Share construction, target derivation and
+    // serialisation live entirely inside the (untouched) create_local_share
+    // seam -- this changes only WHETHER it is invoked, not what it builds.
+    auto write_solved_share = [&](bool won_block) {
+        const char* tag = won_block ? "[BCH-STRATUM-BLOCK-SHARE]"
+                                    : "[BCH-STRATUM-SHARE]";
+        CreateShareFn create_fn;
+        { std::lock_guard<std::mutex> lk(callback_mutex_); create_fn = create_share_fn_; }
+
+        uint256 share_hash;
+        if (create_fn) {
+            auto payout_script = core::address_to_script(username);
+            try { share_hash = create_fn(coinbase, header, *job, payout_script); }
+            catch (const std::exception& e) {
+                LOG_WARNING << tag << " create_share_fn threw: " << e.what()
+                            << " -- share not added";
+            }
+        }
+
+        if (!share_hash.IsNull())
+            LOG_INFO << tag << " ACCEPTED + ADDED user=" << username
+                     << " share_hash=" << share_hash.GetHex().substr(0, 16)
+                     << " pow_hash=" << pow_hex_short << " job=" << job_id;
+        else if (create_fn)
+            LOG_INFO << tag << " accepted (deferred) user=" << username
+                     << " pow_hash=" << pow_hex_short << " job=" << job_id;
+        else
+            LOG_INFO << tag << " accepted (no-tracker) user=" << username
+                     << " pow_hash=" << pow_hex_short << " job=" << job_id;
+    };
+
     // -- Classify --
     if (!(pow_hash > block_target)) {
         // BLOCK FOUND.
@@ -731,6 +777,11 @@ nlohmann::json BCHWorkSource::mining_submit(
                       << height << " not broadcast -- lost subsidy!";
         }
 
+        // #887: the won block is a SHARE too. The dispatch above has already
+        // happened, so nothing here can delay, gate or endanger the block
+        // submit -- the sharechain write is strictly downstream of it.
+        write_solved_share(/*won_block=*/true);
+
         {
             std::lock_guard<std::mutex> lk(workers_mutex_);
             for (auto& [sid, w] : workers_) { (void)sid; if (w.username == username) { w.accepted++; break; } }
@@ -740,29 +791,7 @@ nlohmann::json BCHWorkSource::mining_submit(
 
     if (!(pow_hash > share_target)) {
         // Share meets sharechain target -> create_share_fn_ (v36 share add).
-        CreateShareFn create_fn;
-        { std::lock_guard<std::mutex> lk(callback_mutex_); create_fn = create_share_fn_; }
-
-        uint256 share_hash;
-        if (create_fn) {
-            auto payout_script = core::address_to_script(username);
-            try { share_hash = create_fn(coinbase, header, *job, payout_script); }
-            catch (const std::exception& e) {
-                LOG_WARNING << "[BCH-STRATUM-SHARE] create_share_fn threw: " << e.what()
-                            << " -- share not added";
-            }
-        }
-
-        if (!share_hash.IsNull())
-            LOG_INFO << "[BCH-STRATUM-SHARE] ACCEPTED + ADDED user=" << username
-                     << " share_hash=" << share_hash.GetHex().substr(0, 16)
-                     << " pow_hash=" << pow_hex_short << " job=" << job_id;
-        else if (create_fn)
-            LOG_INFO << "[BCH-STRATUM-SHARE] accepted (deferred) user=" << username
-                     << " pow_hash=" << pow_hex_short << " job=" << job_id;
-        else
-            LOG_INFO << "[BCH-STRATUM-SHARE] accepted (no-tracker) user=" << username
-                     << " pow_hash=" << pow_hex_short << " job=" << job_id;
+        write_solved_share(/*won_block=*/false);
 
         {
             std::lock_guard<std::mutex> lk(workers_mutex_);

--- a/src/impl/bch/test/CMakeLists.txt
+++ b/src/impl/bch/test/CMakeLists.txt
@@ -212,6 +212,14 @@ if(BUILD_TESTING)
     # Needs coin/transaction.cpp for the MutableTransaction ctors, same as
     # block_connector_test; link set and header-only-over-coin/*.hpp posture are
     # otherwise identical, so per-coin isolation stays clean.
+    #
+    # #887 fold-in: the same file now also drives BCHWorkSource::mining_submit
+    # to pin that a WON BLOCK is written to the sharechain as well (block
+    # dispatch first, share write strictly after). That needs bch_stratum
+    # (work_source.cpp) and its bch_coin dependency. FOLDED into this EXISTING
+    # allowlisted target rather than a new add_executable -- a new one would
+    # silently report "Not Run" (see merged PR #868). Still bch-only, so the
+    # per-coin isolation invariant holds.
     add_executable(bch_g2_block_assembly_roundtrip_test
         g2_block_assembly_roundtrip_test.cpp
         ${CMAKE_SOURCE_DIR}/src/impl/bch/coin/transaction.cpp)
@@ -219,6 +227,7 @@ if(BUILD_TESTING)
     target_link_libraries(bch_g2_block_assembly_roundtrip_test PRIVATE
         core pool sharechain
         c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage c2pool_difficulty
+        bch_stratum bch_coin
         btclibs)
     add_test(NAME bch_g2_block_assembly_roundtrip_test COMMAND bch_g2_block_assembly_roundtrip_test)
 endif()

--- a/src/impl/bch/test/g2_block_assembly_roundtrip_test.cpp
+++ b/src/impl/bch/test/g2_block_assembly_roundtrip_test.cpp
@@ -49,13 +49,20 @@
 #include <string>
 #include <vector>
 
+#include <memory>
+#include <stdexcept>
+
 #include "../coin/block.hpp"
 #include "../coin/block_assembly.hpp"
+#include "../coin/header_chain.hpp"
 #include "../coin/mempool.hpp"
 #include "../coin/merkle.hpp"
 #include "../coin/reconstruct_won_block.hpp"
 #include "../coin/transaction.hpp"
 #include "../stratum/coinbase_slot_guard.hpp"
+#include "../stratum/work_source.hpp"
+
+#include <core/stratum_types.hpp>
 
 namespace {
 
@@ -349,6 +356,138 @@ void test_truncation_and_trailing_bytes()
     CHECK(std::string(hv.reason).find("no transactions") != std::string::npos);
 }
 
+// ---------------------------------------------------------------------------
+// #887 -- the block-winning share must ALSO be written to the sharechain.
+//
+// BCHWorkSource::mining_submit classifies tighten-first: block target, then
+// share target. block_target <= share_target, so a solve that clears the block
+// target clears the share target BY DEFINITION -- it is the highest-work share
+// this node will ever produce. Before #887 the won-block arm dispatched the
+// block and RETURNED, so create_share_fn_ was never reached and that share was
+// discarded: our own PPLNS weight in the very window the block pays out from,
+// and the strongest share peers would ever have seen from us, forfeited on
+// every block won. LTC has always written on both classes (core/web_server.cpp).
+//
+// The sharechain and the coin blockchain are independent systems; the solve
+// belongs in both.
+//
+// Determinism: SHA256d of a fixed header is not steerable, so the outcome CLASS
+// is pinned by the TARGETS, not the hash (the dgb_work_source_test idiom).
+// block_nbits 0x2100ffff expands to 0xffff << 240 (~2^256): every practical
+// digest clears it -> WonBlock. 0x03000001 expands to 1: none clears it.
+// ---------------------------------------------------------------------------
+
+struct WorkSourceRig {
+    bch::coin::BCHChainParams params = bch::coin::BCHChainParams::mainnet();
+    bch::coin::HeaderChain    chain{params};
+    bch::coin::Mempool        mempool;
+    bool                      submit_called = false;
+
+    std::unique_ptr<bch::stratum::BCHWorkSource> make()
+    {
+        auto fn = [this](const std::vector<unsigned char>&, uint32_t) -> bool {
+            submit_called = true;
+            return true;
+        };
+        return std::make_unique<bch::stratum::BCHWorkSource>(
+            chain, mempool, /*is_testnet=*/false, fn);
+    }
+};
+
+core::stratum::JobSnapshot make_submit_job(uint32_t share_bits,
+                                           const std::string& block_nbits)
+{
+    core::stratum::JobSnapshot j;
+    j.coinb1       = "01000000";            // minimal well-formed coinbase head
+    j.coinb2       = "00000000";            // minimal coinbase tail
+    j.gbt_prevhash = std::string(64, '0');  // 32-byte prevhash, BE display hex
+    j.nbits        = "1e0fffff";            // header (share) bits
+    j.version      = 0x20000000u;
+    j.share_bits   = share_bits;
+    j.block_nbits  = block_nbits;
+    j.subsidy      = 312500000ULL;
+    return j;
+}
+
+void test_won_block_also_writes_share()
+{
+    WorkSourceRig rig;
+    auto ws = rig.make();
+
+    bool share_written = false;
+    bool saw_block_already_submitted = false;
+    std::size_t seen_header_size = 0;
+    ws->set_create_share_fn(
+        [&](const std::vector<unsigned char>&,
+            const std::vector<uint8_t>&       header_80b,
+            const core::stratum::JobSnapshot&,
+            const std::vector<unsigned char>&) -> uint256
+        {
+            share_written    = true;
+            seen_header_size = header_80b.size();
+            // Reward-invariant witness: the block MUST already be dispatched.
+            saw_block_already_submitted = rig.submit_called;
+            return uint256(uint64_t(0xb10c5));
+        });
+
+    auto job = make_submit_job(/*share_bits=*/0x2100ffffu, /*block_nbits=*/"2100ffff");
+    auto result = ws->mining_submit(
+        "bchtest.worker1", "job-won-share", "00000000", "00000000",
+        "60000000", "00000000", "rid", /*merged_addresses=*/{}, &job);
+
+    CHECK(result.is_boolean() && result.get<bool>());
+    CHECK(rig.submit_called);                 // block dispatched, unchanged
+    CHECK(share_written);                     // ...AND the share is written
+    CHECK(saw_block_already_submitted);       // block FIRST, always
+    CHECK(seen_header_size == 80u);
+}
+
+void test_won_block_survives_throwing_share_write()
+{
+    WorkSourceRig rig;
+    auto ws = rig.make();
+    ws->set_create_share_fn(
+        [](const std::vector<unsigned char>&,
+           const std::vector<uint8_t>&,
+           const core::stratum::JobSnapshot&,
+           const std::vector<unsigned char>&) -> uint256 {
+            throw std::runtime_error("share write blew up");
+        });
+
+    auto job = make_submit_job(/*share_bits=*/0x2100ffffu, /*block_nbits=*/"2100ffff");
+    auto result = ws->mining_submit(
+        "bchtest.worker1", "job-won-throw", "00000000", "00000000",
+        "60000000", "00000000", "rid", /*merged_addresses=*/{}, &job);
+
+    CHECK(rig.submit_called);                     // block reached the sink
+    CHECK(result.is_boolean() && result.get<bool>());  // throw did not escape
+}
+
+void test_plain_share_still_writes_and_does_not_broadcast()
+{
+    WorkSourceRig rig;
+    auto ws = rig.make();
+    bool share_written = false;
+    ws->set_create_share_fn(
+        [&](const std::vector<unsigned char>&,
+            const std::vector<uint8_t>&,
+            const core::stratum::JobSnapshot&,
+            const std::vector<unsigned char>&) -> uint256 {
+            share_written = true;
+            return uint256(uint64_t(0x5157));
+        });
+
+    // block target 1 -> no digest is a block; share target maximal -> accepted.
+    auto job = make_submit_job(/*share_bits=*/0x2100ffffu, /*block_nbits=*/"03000001");
+    auto result = ws->mining_submit(
+        "bchtest.worker1", "job-share", "00000000", "00000000",
+        "60000000", "00000000", "rid", /*merged_addresses=*/{}, &job);
+
+    CHECK(result.is_boolean() && result.get<bool>());
+    CHECK(share_written);
+    CHECK(!rig.submit_called);
+}
+
 } // namespace
 
 int main()
@@ -358,6 +497,9 @@ int main()
     test_degraded_reference_hash_absent();
     test_job_builder_commitment_slot_invariant();
     test_truncation_and_trailing_bytes();
+    test_won_block_also_writes_share();
+    test_won_block_survives_throwing_share_write();
+    test_plain_share_still_writes_and_does_not_broadcast();
 
     if (failures) {
         std::cerr << failures << " CHECK(s) failed\n";

--- a/src/impl/btc/stratum/work_source.cpp
+++ b/src/impl/btc/stratum/work_source.cpp
@@ -840,6 +840,76 @@ nlohmann::json BTCWorkSource::mining_submit(
 
     auto pow_hex_short = pow_hash.GetHex().substr(0, 16);
 
+    // ── Sharechain write (#887) ───────────────────────────────────────────
+    // Phase 11 dispatch to create_share_fn_, which builds a v35
+    // PaddingBugfixShare, adds it to btc::ShareTracker, broadcasts to peers
+    // and bumps the local best. If the callback is unset (degraded mode) we
+    // just log the acceptance — miner gets a success reply but the share
+    // doesn't earn sharechain credit.
+    //
+    // SHARED by both accept classes: block_target <= share_target, so a solve
+    // that meets the block target meets the share target too — it is the
+    // highest-work share this node will ever produce, and the sharechain and
+    // the coin blockchain are independent systems. Before #887 the won-block
+    // arm returned without ever reaching this seam, forfeiting our own PPLNS
+    // weight in the very window the block pays out from and denying peers our
+    // best work. LTC has always written on both classes (web_server.cpp).
+    //
+    // ORDERING — reward invariant: on the won-block arm this runs AFTER the
+    // block has already been dispatched, never before. create_share_fn_ takes
+    // the exclusive tracker lock, can decline, and can throw; the block submit
+    // must never sit behind any of that.
+    //
+    // CONSENSUS: unchanged. Share construction, target derivation and
+    // serialisation live entirely inside the (untouched) create_local_share
+    // seam — this changes only WHETHER it is invoked, not what it builds.
+    auto write_solved_share = [&](bool won_block) {
+        const char* tag = won_block ? "[BTC-STRATUM-BLOCK-SHARE]"
+                                    : "[BTC-STRATUM-SHARE]";
+        CreateShareFn create_fn;
+        {
+            std::lock_guard<std::mutex> lk(callback_mutex_);
+            create_fn = create_share_fn_;
+        }
+
+        uint256 share_hash;
+        if (create_fn) {
+            // Reconstruct the miner's payout_script from the username.
+            // address_to_script handles bech32 (P2WPKH/P2WSH) + base58
+            // (P2PKH/P2SH). Empty script (unsupported address format)
+            // means the share can still be ADDED locally but won't carry
+            // a payout — peers will reject it on consensus check, which
+            // we tolerate during dev.
+            auto payout_script = core::address_to_script(username);
+
+            try {
+                share_hash = create_fn(coinbase, header, *job, payout_script);
+            } catch (const std::exception& e) {
+                LOG_WARNING << tag << " create_share_fn threw: "
+                            << e.what() << " — share not added";
+            }
+        }
+
+        if (!share_hash.IsNull()) {
+            LOG_INFO << tag << " ACCEPTED + ADDED user=" << username
+                     << " share_hash=" << share_hash.GetHex().substr(0, 16)
+                     << " pow_hash="   << pow_hex_short
+                     << " job=" << job_id;
+        } else if (create_fn) {
+            // Callback was wired but couldn't add (tracker busy, prev_share
+            // unknown, PoW recheck failed inside create_local_share, etc.).
+            // Miner still gets a success reply since their PoW was valid.
+            LOG_INFO << tag << " accepted (deferred) user=" << username
+                     << " pow_hash=" << pow_hex_short
+                     << " job=" << job_id;
+        } else {
+            // No callback wired — degraded mode (proxy without sharechain).
+            LOG_INFO << tag << " accepted (no-tracker) user=" << username
+                     << " pow_hash=" << pow_hex_short
+                     << " job=" << job_id;
+        }
+    };
+
     // ── Classify ──────────────────────────────────────────────────────────
 
     if (!(pow_hash > block_target)) {
@@ -915,6 +985,11 @@ nlohmann::json BTCWorkSource::mining_submit(
                       << height << " not broadcast — lost subsidy!";
         }
 
+        // #887: the won block is a SHARE too. The dispatch above has already
+        // happened, so nothing here can delay, gate or endanger the block
+        // submit — the sharechain write is strictly downstream of it.
+        write_solved_share(/*won_block=*/true);
+
         // Update worker stats (block-find counts as accepted)
         {
             std::lock_guard<std::mutex> lk(workers_mutex_);
@@ -927,54 +1002,7 @@ nlohmann::json BTCWorkSource::mining_submit(
 
     if (!(pow_hash > share_target)) {
         // pow_hash <= share_target → share meets sharechain target.
-        // Phase 11: dispatch to create_share_fn_ which builds a v35
-        // PaddingBugfixShare, adds it to btc::ShareTracker, broadcasts
-        // to peers, and bumps the local best. If the callback is unset
-        // (degraded mode) we just log the acceptance — miner gets a
-        // success reply but the share doesn't earn sharechain credit.
-
-        CreateShareFn create_fn;
-        {
-            std::lock_guard<std::mutex> lk(callback_mutex_);
-            create_fn = create_share_fn_;
-        }
-
-        uint256 share_hash;
-        if (create_fn) {
-            // Reconstruct the miner's payout_script from the username.
-            // address_to_script handles bech32 (P2WPKH/P2WSH) + base58
-            // (P2PKH/P2SH). Empty script (unsupported address format)
-            // means the share can still be ADDED locally but won't carry
-            // a payout — peers will reject it on consensus check, which
-            // we tolerate during dev.
-            auto payout_script = core::address_to_script(username);
-
-            try {
-                share_hash = create_fn(coinbase, header, *job, payout_script);
-            } catch (const std::exception& e) {
-                LOG_WARNING << "[BTC-STRATUM-SHARE] create_share_fn threw: "
-                            << e.what() << " — share not added";
-            }
-        }
-
-        if (!share_hash.IsNull()) {
-            LOG_INFO << "[BTC-STRATUM-SHARE] ACCEPTED + ADDED user=" << username
-                     << " share_hash=" << share_hash.GetHex().substr(0, 16)
-                     << " pow_hash="   << pow_hex_short
-                     << " job=" << job_id;
-        } else if (create_fn) {
-            // Callback was wired but couldn't add (tracker busy, prev_share
-            // unknown, PoW recheck failed inside create_local_share, etc.).
-            // Miner still gets a success reply since their PoW was valid.
-            LOG_INFO << "[BTC-STRATUM-SHARE] accepted (deferred) user=" << username
-                     << " pow_hash=" << pow_hex_short
-                     << " job=" << job_id;
-        } else {
-            // No callback wired — degraded mode (proxy without sharechain).
-            LOG_INFO << "[BTC-STRATUM-SHARE] accepted (no-tracker) user=" << username
-                     << " pow_hash=" << pow_hex_short
-                     << " job=" << job_id;
-        }
+        write_solved_share(/*won_block=*/false);
 
         {
             std::lock_guard<std::mutex> lk(workers_mutex_);

--- a/src/impl/btc/test/CMakeLists.txt
+++ b/src/impl/btc/test/CMakeLists.txt
@@ -1,12 +1,16 @@
 if (BUILD_TESTING AND GTest_FOUND)
     # btc twin of ltc share_test — uniquely named to avoid the CMP0002 target
     # collision with src/impl/ltc/test (both subdirs build in the same tree).
-    add_executable(btc_share_test share_test.cpp f11_donation_invariance_test.cpp f10b_version_punish_removal_test.cpp g01_share_format_parity_test.cpp auto_ratchet_sim_test.cpp block_broadcast_guard_test.cpp block_broadcast_connect_test.cpp regtest_sharechain_isolation_test.cpp stratum_merkle_branch_test.cpp witness_commitment_merkle_test.cpp finder_fee_integer_exact_test.cpp rpc_conf_test.cpp genesis_check_test.cpp won_share_dualpath_test.cpp gentx_unpack_test.cpp block_assembly_test.cpp gentx_coinbase_test.cpp template_capture_test.cpp template_other_txs_test.cpp reconstruct_test.cpp known_txs_retention_test.cpp)
+    add_executable(btc_share_test share_test.cpp f11_donation_invariance_test.cpp f10b_version_punish_removal_test.cpp g01_share_format_parity_test.cpp auto_ratchet_sim_test.cpp block_broadcast_guard_test.cpp block_broadcast_connect_test.cpp regtest_sharechain_isolation_test.cpp stratum_merkle_branch_test.cpp witness_commitment_merkle_test.cpp finder_fee_integer_exact_test.cpp rpc_conf_test.cpp genesis_check_test.cpp won_share_dualpath_test.cpp gentx_unpack_test.cpp block_assembly_test.cpp gentx_coinbase_test.cpp template_capture_test.cpp template_other_txs_test.cpp reconstruct_test.cpp known_txs_retention_test.cpp won_block_mints_share_test.cpp)
     target_link_libraries(btc_share_test PRIVATE
         GTest::gtest_main GTest::gtest
         core btc
     )
-    target_link_libraries(btc_share_test PRIVATE c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage btc_coin btclibs pool sharechain ${SECP256K1_LIBRARIES})  # OBJECT-lib SCC direct-naming (#22/#39), btc twin
+    # btc_stratum: won_block_mints_share_test.cpp (#887) constructs a live
+    # BTCWorkSource and drives mining_submit. FOLDED into this EXISTING
+    # allowlisted target rather than a new add_executable -- a new one would
+    # silently report "Not Run" (see merged PR #868).
+    target_link_libraries(btc_share_test PRIVATE c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage btc_coin btc_stratum btclibs pool sharechain ${SECP256K1_LIBRARIES})  # OBJECT-lib SCC direct-naming (#22/#39), btc twin
 
     include(GoogleTest)
     include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})

--- a/src/impl/btc/test/won_block_mints_share_test.cpp
+++ b/src/impl/btc/test/won_block_mints_share_test.cpp
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// ---------------------------------------------------------------------------
+// #887 -- the block-winning share must ALSO be written to the sharechain.
+//
+// BTCWorkSource::mining_submit classifies a solve tighten-first: block target,
+// then share target. Because block_target <= share_target, a solve that clears
+// the block target clears the share target BY DEFINITION -- it is the
+// highest-work share this node will ever produce. Before #887 the won-block arm
+// dispatched the block and RETURNED, so create_share_fn_ was never reached and
+// the share was thrown away: our own PPLNS weight in the very window the block
+// pays out from, and the strongest share peers would ever have seen from us,
+// forfeited on every block won. LTC has always written on both classes
+// (core/web_server.cpp).
+//
+// The two systems are independent -- the sharechain is not the coin blockchain
+// -- and the solve belongs in both.
+//
+// Determinism: SHA256d of a fixed header is not steerable, so each KAT pins the
+// OUTCOME CLASS by the TARGETS, not by the hash (the dgb_work_source_test
+// idiom). block_nbits = 0x2100ffff expands to 0xffff << 240, i.e. ~2^256 --
+// every practical digest clears it, so WonBlock is deterministic.
+//
+// Folded into the existing btc_share_test target (never a standalone
+// add_executable -- those silently report "Not Run"; see PR #868).
+// ---------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <impl/btc/stratum/work_source.hpp>
+#include <impl/btc/coin/header_chain.hpp>
+#include <impl/btc/coin/mempool.hpp>
+#include <core/stratum_types.hpp>
+#include <core/uint256.hpp>
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+// A BTCWorkSource over default coin deps. The submit callback records the
+// won-block dispatch so the tests can pin BOTH that it happened and WHEN.
+struct Fixture {
+    btc::coin::BTCChainParams params = btc::coin::BTCChainParams::mainnet();
+    btc::coin::HeaderChain    chain{params};
+    btc::coin::Mempool        mempool;
+    bool                      submit_called = false;
+
+    std::unique_ptr<btc::stratum::BTCWorkSource> make()
+    {
+        auto fn = [this](const std::vector<unsigned char>&, uint32_t) -> bool {
+            submit_called = true;
+            return true;
+        };
+        return std::make_unique<btc::stratum::BTCWorkSource>(
+            chain, mempool, /*is_testnet=*/false, fn);
+    }
+};
+
+core::stratum::JobSnapshot make_job(uint32_t share_bits,
+                                    const std::string& block_nbits)
+{
+    core::stratum::JobSnapshot j;
+    j.coinb1        = "01000000";              // minimal well-formed coinbase head
+    j.coinb2        = "00000000";              // minimal coinbase tail
+    j.gbt_prevhash  = std::string(64, '0');    // 32-byte prevhash, BE display hex
+    j.nbits         = "1e0fffff";              // header (share) bits
+    j.version       = 0x20000000u;
+    j.share_bits    = share_bits;
+    j.block_nbits   = block_nbits;
+    j.subsidy       = 625000000ULL;
+    j.segwit_active = false;
+    return j;
+}
+
+const char* kEN1 = "00000000";
+const char* kEN2 = "00000000";
+const char* kNT  = "60000000";
+const char* kNON = "00000000";
+
+}  // namespace
+
+// Baseline (pre-existing behaviour, unchanged by #887): a won block still
+// reaches the dual-path broadcaster.
+TEST(BtcWonBlockMintsShare, WonBlockStillDispatchesBroadcaster)
+{
+    Fixture fx;
+    auto ws = fx.make();
+    auto job = make_job(/*share_bits=*/0x2100ffffu, /*block_nbits=*/"2100ffff");
+    auto result = ws->mining_submit(
+        "1BitcoinEaterAddressDontSendf59kuE.w1", "job-won", kEN1, kEN2, kNT, kNON,
+        "rid", /*merged_addresses=*/{}, &job);
+    ASSERT_TRUE(result.is_boolean());
+    EXPECT_TRUE(result.get<bool>());
+    EXPECT_TRUE(fx.submit_called);
+}
+
+// THE #887 FIX: the won block is a share too -- create_share_fn_ must be
+// reached, and it must be reached AFTER the block has already been dispatched.
+TEST(BtcWonBlockMintsShare, WonBlockAlsoWritesTheShare)
+{
+    Fixture fx;
+    auto ws = fx.make();
+
+    bool share_written = false;
+    bool saw_block_already_submitted = false;
+    std::vector<uint8_t> seen_header;
+    ws->set_create_share_fn(
+        [&](const std::vector<unsigned char>& /*full_coinbase*/,
+            const std::vector<uint8_t>&       header_80b,
+            const core::stratum::JobSnapshot& /*job*/,
+            const std::vector<unsigned char>& /*payout_script*/) -> uint256
+        {
+            share_written = true;
+            seen_header   = header_80b;
+            // Reward-invariant witness: the block MUST already be out.
+            saw_block_already_submitted = fx.submit_called;
+            return uint256(uint64_t(0xb10c5));
+        });
+
+    auto job = make_job(/*share_bits=*/0x2100ffffu, /*block_nbits=*/"2100ffff");
+    auto result = ws->mining_submit(
+        "1BitcoinEaterAddressDontSendf59kuE.w1", "job-won-share", kEN1, kEN2,
+        kNT, kNON, "rid", /*merged_addresses=*/{}, &job);
+
+    ASSERT_TRUE(result.is_boolean());
+    EXPECT_TRUE(result.get<bool>());
+    EXPECT_TRUE(fx.submit_called);              // block dispatched, unchanged
+    EXPECT_TRUE(share_written);                 // ...AND the share is written
+    EXPECT_TRUE(saw_block_already_submitted);   // block FIRST, always
+    EXPECT_EQ(seen_header.size(), 80u);         // the solved header, forwarded
+}
+
+// REWARD INVARIANT: a sharechain write that throws must not cost the block and
+// must not turn a won block into a stratum reject.
+TEST(BtcWonBlockMintsShare, WonBlockSurvivesAThrowingShareWrite)
+{
+    Fixture fx;
+    auto ws = fx.make();
+    ws->set_create_share_fn(
+        [](const std::vector<unsigned char>&,
+           const std::vector<uint8_t>&,
+           const core::stratum::JobSnapshot&,
+           const std::vector<unsigned char>&) -> uint256 {
+            throw std::runtime_error("share write blew up");
+        });
+
+    auto job = make_job(/*share_bits=*/0x2100ffffu, /*block_nbits=*/"2100ffff");
+    auto result = ws->mining_submit(
+        "1BitcoinEaterAddressDontSendf59kuE.w1", "job-won-throw", kEN1, kEN2,
+        kNT, kNON, "rid", /*merged_addresses=*/{}, &job);
+
+    EXPECT_TRUE(fx.submit_called);
+    ASSERT_TRUE(result.is_boolean());
+    EXPECT_TRUE(result.get<bool>());
+}
+
+// Ordinary share path stays exactly as it was: share target cleared, block
+// target not -> the share is written and NOTHING is broadcast to the network.
+TEST(BtcWonBlockMintsShare, PlainShareStillWritesAndDoesNotBroadcast)
+{
+    Fixture fx;
+    auto ws = fx.make();
+    bool share_written = false;
+    ws->set_create_share_fn(
+        [&](const std::vector<unsigned char>&,
+            const std::vector<uint8_t>&,
+            const core::stratum::JobSnapshot&,
+            const std::vector<unsigned char>&) -> uint256 {
+            share_written = true;
+            return uint256(uint64_t(0x5157));
+        });
+
+    // block_nbits = 0x03000001 -> target 1: no digest is a block.
+    auto job = make_job(/*share_bits=*/0x2100ffffu, /*block_nbits=*/"03000001");
+    auto result = ws->mining_submit(
+        "1BitcoinEaterAddressDontSendf59kuE.w1", "job-share", kEN1, kEN2,
+        kNT, kNON, "rid", /*merged_addresses=*/{}, &job);
+
+    ASSERT_TRUE(result.is_boolean());
+    EXPECT_TRUE(result.get<bool>());
+    EXPECT_TRUE(share_written);
+    EXPECT_FALSE(fx.submit_called);
+}

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -816,6 +816,87 @@ nlohmann::json DASHWorkSource::mining_submit(
     // pseudoshare is instead recorded via record_best_pseudoshare(), which the
     // core stratum session calls on the vardiff-accept path.
 
+    // ── Sharechain mint (#887) ───────────────────────────────────────────────
+    // Assemble the found-share fields and hand them to the mint seam. SHARED by
+    // both accept classes: block_target <= share_target, so a solve that meets
+    // the block target meets the share target too — it is the highest-work
+    // share this node will ever produce, and the sharechain and the coin
+    // blockchain are independent systems. Before #887 the won-block arm
+    // returned without ever reaching the mint, forfeiting our own PPLNS weight
+    // in the very window the block pays out from and denying peers our best
+    // work. LTC has always minted on both classes (web_server.cpp).
+    //
+    // ORDERING — reward invariant: on the won-block arm this runs AFTER the
+    // block has already been dispatched, never before. The mint walks the
+    // tracker, can decline, and can throw; the block submit must never sit
+    // behind any of that. Nothing below can affect a dispatch that already
+    // happened.
+    //
+    // CONSENSUS: unchanged. Share construction, target derivation and
+    // serialisation are entirely inside the (untouched) mint seam — this
+    // changes only WHETHER it is invoked, not what it builds.
+    //
+    // SINGLE-CALL CONTRACT: it MOVES `coinbase` / `branch_hashes` into the mint
+    // inputs, so exactly one classify arm may invoke it, exactly once. The
+    // won-block arm therefore calls it only after block_bytes is fully built.
+    auto mint_solved_share = [&](bool won_block) {
+        const char* tag = won_block ? "[DASH-STRATUM-BLOCK-SHARE]"
+                                    : "[DASH-STRATUM-SHARE]";
+        MintShareFn mint_fn;
+        {
+            std::lock_guard<std::mutex> lk(mint_share_mutex_);
+            mint_fn = mint_share_fn_;
+        }
+
+        uint256 share_hash;
+        if (mint_fn) {
+            MintShareInputs in;
+            in.header_bytes.assign(header, header + 80);
+            in.subsidy         = job->subsidy;
+            in.prev_share_hash = job->prev_share_hash;
+            in.merkle_branches = std::move(branch_hashes);
+            in.payout_script   = core::address_to_script(username);
+            in.pow_hash        = pow_hash;
+            // ref_hash: the coinb1/coinb2 split sits immediately after the
+            // 32-byte OP_RETURN ref_hash (before the 8B nonce64 slot), so the
+            // commitment is the coinb1 tail. Raw LE-internal bytes — embedded
+            // via ref_hash.data() at build time, recovered the same way.
+            if (coinb1_bytes.size() >= 32)
+                std::memcpy(in.ref_hash.begin(),
+                            coinb1_bytes.data() + coinb1_bytes.size() - 32, 32);
+            // nonce64 = LE u64 of extranonce1 || extranonce2 (4+4 bytes).
+            if (en1_bytes.size() + en2_bytes.size() == 8) {
+                unsigned char n64[8];
+                std::memcpy(n64, en1_bytes.data(), en1_bytes.size());
+                std::memcpy(n64 + en1_bytes.size(), en2_bytes.data(), en2_bytes.size());
+                uint64_t v = 0;
+                for (int i = 7; i >= 0; --i) v = (v << 8) | n64[i];
+                in.last_txout_nonce = v;
+            }
+            in.tx_data         = job->tx_data;
+            in.coinbase_bytes  = std::move(coinbase);
+            try {
+                share_hash = mint_fn(in);
+            } catch (const std::exception& e) {
+                LOG_WARNING << tag << " mint_share_fn threw: "
+                            << e.what() << " -- share not minted";
+            }
+        }
+
+        if (!share_hash.IsNull()) {
+            LOG_INFO << tag << " ACCEPTED + MINTED user=" << username
+                     << " share_hash=" << share_hash.GetHex().substr(0, 16)
+                     << " job=" << job_id;
+        } else if (mint_fn) {
+            LOG_INFO << tag << " accepted (mint deferred/declined) "
+                        "user=" << username << " job=" << job_id;
+        } else {
+            LOG_WARNING << tag << " accepted WITHOUT sharechain "
+                           "credit (mint seam unbound -- set_mint_share_fn): user="
+                        << username << " job=" << job_id;
+        }
+    };
+
     // 6. Classify (tighten-first: block target before share target).
     if (pow_hash <= block_target) {
         // A full network block. NEVER drop it.
@@ -950,6 +1031,21 @@ nlohmann::json DASHWorkSource::mining_submit(
             if (fb_fn) fb_fn(height, pow_hash, username, reached_network);
         }
 
+        // #887: the won block is a SHARE too. Everything above (guard verdict,
+        // dispatch, dashboard record) has already run, so nothing here can
+        // delay, gate or endanger the block submit -- the mint is strictly
+        // downstream of it.
+        //
+        // UNCONDITIONAL, including after a payee-guard reject: the guard is a
+        // COIN-side verdict about a stale masternode payee, and the sharechain
+        // is a different system with its own acceptance rule (the mint's own
+        // X11-identity + pow<=own-committed-target gates). The existing reject
+        // branch above already says as much -- "the share still counts for the
+        // miner; the stale template was ours" -- and the share arm below has
+        // never consulted the payee guard either. Withholding here would be a
+        // second, self-inflicted loss on top of the forfeited block.
+        mint_solved_share(/*won_block=*/true);
+
         bump(true);
         return nlohmann::json(true);
     }
@@ -959,59 +1055,7 @@ nlohmann::json DASHWorkSource::mining_submit(
         // share fields to the mint seam. While the DASH node-side share-
         // creation seam is unbound, accept for vardiff + LOUD log (documented
         // 4d follow-up) -- never a silent drop, never a false reject.
-        MintShareFn mint_fn;
-        {
-            std::lock_guard<std::mutex> lk(mint_share_mutex_);
-            mint_fn = mint_share_fn_;
-        }
-
-        uint256 share_hash;
-        if (mint_fn) {
-            MintShareInputs in;
-            in.header_bytes.assign(header, header + 80);
-            in.subsidy         = job->subsidy;
-            in.prev_share_hash = job->prev_share_hash;
-            in.merkle_branches = std::move(branch_hashes);
-            in.payout_script   = core::address_to_script(username);
-            in.pow_hash        = pow_hash;
-            // ref_hash: the coinb1/coinb2 split sits immediately after the
-            // 32-byte OP_RETURN ref_hash (before the 8B nonce64 slot), so the
-            // commitment is the coinb1 tail. Raw LE-internal bytes — embedded
-            // via ref_hash.data() at build time, recovered the same way.
-            if (coinb1_bytes.size() >= 32)
-                std::memcpy(in.ref_hash.begin(),
-                            coinb1_bytes.data() + coinb1_bytes.size() - 32, 32);
-            // nonce64 = LE u64 of extranonce1 || extranonce2 (4+4 bytes).
-            if (en1_bytes.size() + en2_bytes.size() == 8) {
-                unsigned char n64[8];
-                std::memcpy(n64, en1_bytes.data(), en1_bytes.size());
-                std::memcpy(n64 + en1_bytes.size(), en2_bytes.data(), en2_bytes.size());
-                uint64_t v = 0;
-                for (int i = 7; i >= 0; --i) v = (v << 8) | n64[i];
-                in.last_txout_nonce = v;
-            }
-            in.tx_data         = job->tx_data;
-            in.coinbase_bytes  = std::move(coinbase);
-            try {
-                share_hash = mint_fn(in);
-            } catch (const std::exception& e) {
-                LOG_WARNING << "[DASH-STRATUM-SHARE] mint_share_fn threw: "
-                            << e.what() << " -- share not minted";
-            }
-        }
-
-        if (!share_hash.IsNull()) {
-            LOG_INFO << "[DASH-STRATUM-SHARE] ACCEPTED + MINTED user=" << username
-                     << " share_hash=" << share_hash.GetHex().substr(0, 16)
-                     << " job=" << job_id;
-        } else if (mint_fn) {
-            LOG_INFO << "[DASH-STRATUM-SHARE] accepted (mint deferred/declined) "
-                        "user=" << username << " job=" << job_id;
-        } else {
-            LOG_WARNING << "[DASH-STRATUM-SHARE] accepted WITHOUT sharechain "
-                           "credit (mint seam unbound -- set_mint_share_fn): user="
-                        << username << " job=" << job_id;
-        }
+        mint_solved_share(/*won_block=*/false);
 
         bump(true);
         return nlohmann::json(true);

--- a/src/impl/dgb/stratum/work_source.cpp
+++ b/src/impl/dgb/stratum/work_source.cpp
@@ -526,6 +526,81 @@ nlohmann::json DGBWorkSource::mining_submit(
         }
     };
 
+    // -- Sharechain mint (#887) --
+    // Hand the found-share fields to the run-loop mint dispatch
+    // (try_mint_share -> mint_local_share_with_ratchet, #294). SHARED by both
+    // accept classes: block_target <= share_target, so a solve that meets the
+    // block target meets the share target too -- it is the highest-work share
+    // this node will ever produce, and the sharechain and the coin blockchain
+    // are independent systems. Before #887 the WonBlock case returned without
+    // ever reaching this seam, forfeiting our own PPLNS weight in the very
+    // window the block pays out from and denying peers our best work. LTC has
+    // always minted on both classes (web_server.cpp).
+    //
+    // PRE-WIRING ON DGB (#884): main_dgb.cpp never calls set_mint_share_fn, so
+    // DGB cannot mint ANY local share today -- neither this one nor an ordinary
+    // ShareAccept. try_mint_share logs the unbound seam loudly and returns
+    // null. This change makes the WonBlock arm REACH the seam so that DGB gets
+    // the fix for free the moment #884 binds it; it does not by itself make a
+    // DGB mint happen.
+    //
+    // ORDERING -- reward invariant: on the WonBlock arm this runs AFTER the
+    // block has already been dispatched, never before. The mint can decline and
+    // can throw; the block submit must never sit behind any of that.
+    //
+    // CONSENSUS: unchanged. Share construction, target derivation and
+    // serialisation live entirely inside the (untouched) mint seam -- this
+    // changes only WHETHER it is invoked, not what it builds.
+    auto mint_solved_share = [&](bool won_block) {
+        const char* tag = won_block ? "[DGB-STRATUM-BLOCK-SHARE]"
+                                    : "[DGB-STRATUM-SHARE]";
+        MintShareInputs in;
+        in.header_bytes    = header;
+        in.coinbase_bytes  = coinbase;
+        in.subsidy         = job->subsidy;
+        in.prev_share      = job->prev_share_hash;
+        in.merkle_branches = branch_hashes;
+        in.payout_script   = core::address_to_script(username);
+        // Redistribute V2 (#307): a miner with empty/broken stratum creds
+        // yields no payout script. When the operator opted into a
+        // --redistribute policy (fallback bound) let it choose the pubkey this
+        // node stamps onto the minted share; else leave it empty (byte-
+        // identical to before). Fail-safe: an empty fallback is left empty.
+        if (in.payout_script.empty()) {
+            FallbackPayoutFn fb;
+            { std::lock_guard<std::mutex> lk(fallback_payout_mutex_); fb = fallback_payout_fn_; }
+            if (fb) {
+                in.payout_script = fb();
+                if (!in.payout_script.empty())
+                    LOG_INFO << tag << " empty payout addr (user=" << username
+                             << ") -> redistribute policy stamped fallback script ("
+                             << in.payout_script.size() << "B)";
+            }
+        }
+        in.segwit_active   = job->segwit_active;
+
+        uint256 share_hash;
+        try {
+            share_hash = try_mint_share(in);
+        } catch (const std::exception& e) {
+            LOG_WARNING << tag << " mint dispatch threw: " << e.what()
+                        << " -- share not minted";
+        }
+
+        if (!share_hash.IsNull()) {
+            LOG_INFO << tag << " ACCEPTED + MINTED user=" << username
+                     << " share_hash=" << share_hash.GetHex().substr(0, 16)
+                     << " job=" << job_id;
+        } else {
+            // PoW was valid (cleared the share target) so the miner still gets a
+            // success reply; the share just earned no sharechain credit (no mint
+            // fn wired, or the mint deferred/failed). try_mint_share logs the
+            // reason -- never a silent drop.
+            LOG_INFO << tag << " accepted (no sharechain credit) user="
+                     << username << " job=" << job_id;
+        }
+    };
+
     switch (klass) {
     case dgb::coin::SubmitClass::WonBlock: {
         // pow_hash <= block_target -> a full network block. NEVER drop it.
@@ -609,53 +684,20 @@ nlohmann::json DGBWorkSource::mining_submit(
                       << " height=" << height << " not broadcast -- lost subsidy!";
         }
 
+        // #887: the won block is a SHARE too. The dispatch above has already
+        // happened, so nothing here can delay, gate or endanger the block
+        // submit -- the mint is strictly downstream of it. Pre-wiring on DGB
+        // until #884 binds set_mint_share_fn in main_dgb.cpp.
+        mint_solved_share(/*won_block=*/true);
+
         bump_accepted();
         return nlohmann::json(true);
     }
 
     case dgb::coin::SubmitClass::ShareAccept: {
         // share_target >= pow_hash > block_target -> meets sharechain difficulty
-        // but not the full block. Hand the found-share fields to the run-loop
-        // mint dispatch (try_mint_share -> mint_local_share_with_ratchet, #294).
-        MintShareInputs in;
-        in.header_bytes    = header;
-        in.coinbase_bytes  = coinbase;
-        in.subsidy         = job->subsidy;
-        in.prev_share      = job->prev_share_hash;
-        in.merkle_branches = branch_hashes;
-        in.payout_script   = core::address_to_script(username);
-        // Redistribute V2 (#307): a miner with empty/broken stratum creds
-        // yields no payout script. When the operator opted into a
-        // --redistribute policy (fallback bound) let it choose the pubkey this
-        // node stamps onto the minted share; else leave it empty (byte-
-        // identical to before). Fail-safe: an empty fallback is left empty.
-        if (in.payout_script.empty()) {
-            FallbackPayoutFn fb;
-            { std::lock_guard<std::mutex> lk(fallback_payout_mutex_); fb = fallback_payout_fn_; }
-            if (fb) {
-                in.payout_script = fb();
-                if (!in.payout_script.empty())
-                    LOG_INFO << "[DGB-STRATUM-SHARE] empty payout addr (user=" << username
-                             << ") -> redistribute policy stamped fallback script ("
-                             << in.payout_script.size() << "B)";
-            }
-        }
-        in.segwit_active   = job->segwit_active;
-
-        uint256 share_hash = try_mint_share(in);
-
-        if (!share_hash.IsNull()) {
-            LOG_INFO << "[DGB-STRATUM-SHARE] ACCEPTED + MINTED user=" << username
-                     << " share_hash=" << share_hash.GetHex().substr(0, 16)
-                     << " job=" << job_id;
-        } else {
-            // PoW was valid (cleared the share target) so the miner still gets a
-            // success reply; the share just earned no sharechain credit (no mint
-            // fn wired, or the mint deferred/failed). try_mint_share logs the
-            // reason -- never a silent drop.
-            LOG_INFO << "[DGB-STRATUM-SHARE] accepted (no sharechain credit) user="
-                     << username << " job=" << job_id;
-        }
+        // but not the full block.
+        mint_solved_share(/*won_block=*/false);
 
         bump_accepted();
         return nlohmann::json(true);

--- a/src/impl/dgb/test/work_source_test.cpp
+++ b/src/impl/dgb/test/work_source_test.cpp
@@ -31,6 +31,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <stdexcept>
 
 namespace {
 
@@ -302,6 +303,70 @@ TEST(DgbWorkSource, MiningSubmitShareAcceptDispatchesMint)
     EXPECT_FALSE(fx.submit_called);        // NOT a block -> no broadcast
     EXPECT_EQ(seen.header_bytes.size(), 80u);   // 80-byte header forwarded
     EXPECT_EQ(seen.subsidy, 500000000ULL);      // subsidy carried from the job
+}
+
+// -- #887 WonBlock -> mint SEAM reachability (PRE-WIRING ONLY on DGB) ---------
+//
+// block_target <= share_target, so a WonBlock solve clears the share target
+// too -- it is the highest-work share the node will ever produce and belongs on
+// the sharechain as well as in the coin block. Before #887 the WonBlock case
+// returned right after the broadcaster, so the mint seam was never reached.
+//
+// SCOPE HONESTY -- this KAT proves ONLY that the WonBlock arm now REACHES
+// DGBWorkSource::try_mint_share, with a mint fn the TEST binds itself. It does
+// NOT prove a DGB share is minted in production: per #884 main_dgb.cpp never
+// calls set_mint_share_fn, so DGB cannot mint ANY local share today (not this
+// one, and not an ordinary ShareAccept either). The DGB half of #887 is
+// pre-wiring that pays off the moment #884 binds the seam.
+TEST(DgbWorkSource, MiningSubmitWonBlockAlsoReachesMintSeam)
+{
+    Fixture fx;
+    auto ws = fx.make();
+    bool minted = false;
+    bool mint_saw_block_already_submitted = false;
+    dgb::stratum::DGBWorkSource::MintShareInputs seen;
+    ws->set_mint_share_fn(
+        [&](const dgb::stratum::DGBWorkSource::MintShareInputs& got) -> uint256 {
+            minted = true;
+            seen   = got;
+            // Reward-invariant witness: the broadcaster must already have run.
+            mint_saw_block_already_submitted = fx.submit_called;
+            uint256 h; h.SetHex(
+                "00000000000000000000000000000000000000000000000000000000000b10c6");
+            return h;
+        });
+    // Maximal target on BOTH bits: every Scrypt digest clears the block target
+    // -> WonBlock. The broadcaster fires AND the mint seam is reached.
+    auto job = make_job(/*share_bits=*/0x2100ffffu, /*block_nbits=*/"2100ffff");
+    auto result = ws->mining_submit(
+        "DGBaddr.worker1", "job-won-share", kEN1, kEN2, kNT, kNON, "rid",
+        /*merged_addresses=*/{}, &job);
+    ASSERT_TRUE(result.is_boolean());
+    EXPECT_TRUE(result.get<bool>());       // won block -> accepted reply
+    EXPECT_TRUE(fx.submit_called);         // block still broadcast, unchanged
+    EXPECT_TRUE(minted);                   // ...and the mint seam is reached
+    EXPECT_TRUE(mint_saw_block_already_submitted);  // block dispatched FIRST
+    EXPECT_EQ(seen.header_bytes.size(), 80u);
+    EXPECT_EQ(seen.subsidy, 500000000ULL);
+}
+
+// REWARD INVARIANT: a mint that throws must not cost the block, and must not
+// turn a won block into a stratum reject.
+TEST(DgbWorkSource, MiningSubmitWonBlockSurvivesAThrowingMint)
+{
+    Fixture fx;
+    auto ws = fx.make();
+    ws->set_mint_share_fn(
+        [](const dgb::stratum::DGBWorkSource::MintShareInputs&) -> uint256 {
+            throw std::runtime_error("mint blew up");
+        });
+    auto job = make_job(/*share_bits=*/0x2100ffffu, /*block_nbits=*/"2100ffff");
+    auto result = ws->mining_submit(
+        "DGBaddr.worker1", "job-won-throw", kEN1, kEN2, kNT, kNON, "rid",
+        /*merged_addresses=*/{}, &job);
+    EXPECT_TRUE(fx.submit_called);         // block reached the broadcaster
+    ASSERT_TRUE(result.is_boolean());
+    EXPECT_TRUE(result.get<bool>());       // and the throw did not escape
 }
 
 TEST(DgbWorkSource, MiningSubmitLowDifficultyRejectsNeitherDispatch)

--- a/test/test_dash_stratum_work_source.cpp
+++ b/test/test_dash_stratum_work_source.cpp
@@ -36,9 +36,11 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <atomic>
 #include <cstring>
 #include <functional>
+#include <stdexcept>
 #include <memory>
 #include <mutex>
 #include <span>
@@ -622,6 +624,107 @@ TEST(DashStratumWorkSource, MiningSubmitRoutesShareIntoMintSeam)
               reassemble(rig.job.coinb1, rig.en1, rig.en2, rig.job.coinb2));
     EXPECT_EQ(seen.subsidy, kCoinbaseValue);
     EXPECT_EQ(seen.pow_hash, rig.pow_for(nonce));
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// #887 -- the block-winning share must ALSO be minted onto the sharechain.
+//
+// block_target <= share_target, so a solve that clears the block target clears
+// the share target by definition: it is the highest-work share this node will
+// ever produce. Before #887 the won-block arm dispatched the block and
+// RETURNED, so the mint seam was never reached -- forfeiting our own PPLNS
+// weight in the very window the block pays out from, on every block won.
+//
+// The two systems are independent (sharechain vs coin blockchain); the solve
+// belongs in BOTH.
+// ═════════════════════════════════════════════════════════════════════════════
+
+// Positive: a WonBlock submit reaches the broadcaster AND the mint seam, and
+// the fields handed to the mint describe the SAME solve that was dispatched.
+TEST(DashStratumWorkSource, MiningSubmitWonBlockAlsoMintsTheShare)
+{
+    SubmitRig rig;
+    // Trivial block target -> deterministic WonBlock (same setup as
+    // MiningSubmitWonBlockAssemblesAndBroadcasts).
+    rig.job.share_bits  = 0x207fffffu;
+    rig.job.block_nbits = "207fffff";
+    const uint256 block_target = dash::coin::target_from_nbits(0x207fffffu);
+    const uint256 share_target = dash::coin::target_from_nbits(0x207fffffu);
+    const uint32_t nonce = rig.find_nonce([&](const uint256& pow) {
+        return pow <= block_target;
+    });
+    // The premise of the fix: a block solve is also a share solve.
+    ASSERT_LE(rig.pow_for(nonce), share_target);
+
+    bool mint_called = false;
+    dash::stratum::DASHWorkSource::MintShareInputs seen;
+    rig.ws->set_mint_share_fn(
+        [&](const dash::stratum::DASHWorkSource::MintShareInputs& in) -> uint256 {
+            mint_called = true;
+            seen = in;
+            uint256 h;
+            h.SetHex("5555555555555555555555555555555555555555555555555555555555555555");
+            return h;
+        });
+
+    auto result = rig.submit(nonce);
+    ASSERT_TRUE(result.is_boolean());
+    EXPECT_TRUE(result.get<bool>());
+
+    // The block still goes out -- unchanged, and first.
+    ASSERT_TRUE(rig.fx.submit_called);
+    EXPECT_EQ(rig.fx.submit_height, 424242u);
+
+    // ...AND the winning share is minted (the #887 fix).
+    ASSERT_TRUE(mint_called);
+    EXPECT_EQ(seen.header_bytes, rig.header_for(nonce));
+    EXPECT_EQ(seen.pow_hash, rig.pow_for(nonce));
+    EXPECT_EQ(seen.subsidy, kCoinbaseValue);
+    EXPECT_EQ(seen.coinbase_bytes,
+              reassemble(rig.job.coinb1, rig.en1, rig.en2, rig.job.coinb2));
+    // The minted share describes the block that was dispatched: the block's
+    // first 80 bytes ARE this share's header.
+    ASSERT_GE(rig.fx.submitted_block.size(), 80u);
+    EXPECT_TRUE(std::equal(seen.header_bytes.begin(), seen.header_bytes.end(),
+                           rig.fx.submitted_block.begin()));
+}
+
+// REWARD INVARIANT: the block submit runs FIRST and is never gated by the
+// mint. A mint that throws (tracker error, rebuild fault) must not cost the
+// block -- and must not turn a won block into a stratum reject either.
+TEST(DashStratumWorkSource, MiningSubmitWonBlockDispatchesBeforeAndDespiteAThrowingMint)
+{
+    SubmitRig rig;
+    rig.job.share_bits  = 0x207fffffu;
+    rig.job.block_nbits = "207fffff";
+    const uint256 block_target = dash::coin::target_from_nbits(0x207fffffu);
+    const uint32_t nonce = rig.find_nonce([&](const uint256& pow) {
+        return pow <= block_target;
+    });
+
+    // Ordering witness: the mint records whether the block had already been
+    // dispatched by the time it ran. Anything other than "already dispatched"
+    // means the mint was wired AHEAD of the submit -- the one arrangement this
+    // codebase forbids on a reward path.
+    bool mint_saw_block_already_submitted = false;
+    bool mint_called = false;
+    rig.ws->set_mint_share_fn(
+        [&](const dash::stratum::DASHWorkSource::MintShareInputs&) -> uint256 {
+            mint_called = true;
+            mint_saw_block_already_submitted = rig.fx.submit_called;
+            throw std::runtime_error("mint blew up");
+        });
+
+    auto result = rig.submit(nonce);
+
+    // Block dispatched, and the throw did not escape mining_submit.
+    ASSERT_TRUE(rig.fx.submit_called);
+    EXPECT_EQ(rig.fx.submit_height, 424242u);
+    ASSERT_TRUE(mint_called);
+    EXPECT_TRUE(mint_saw_block_already_submitted);
+    // Won block still answers the miner with the accepted reply.
+    ASSERT_TRUE(result.is_boolean());
+    EXPECT_TRUE(result.get<bool>());
 }
 
 // ═════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Fixes #887.

## The defect

`mining_submit` classifies a solve tighten-first: block target, then share target. On **dash, btc, bch and dgb** the block arm dispatched the won block and `return`ed, so the share arm — the *only* place the sharechain mint / create-share seam is invoked — was never reached.

Because `block_target <= share_target`, a solve that clears the block target clears the share target **by definition**. It is the highest-work share the node will ever produce, and it was discarded on every block won.

**This is not block loss.** The block submits correctly on all four coins (re-verified: every won-block KAT still passes). But "share-weight loss" undersells it — there are three consequences, and the third is the serious one.

### 1. Our own PPLNS weight

Forfeited, in the very window the block pays out from.

### 2. Peers never see our best work

We never advertise the strongest share on the chain, weakening our position in the sharechain race.

### 3. ★ Our blocks are INVISIBLE to every legacy p2pool node on the network

This surfaced after the PR was opened and is the reason it was escalated. The hotel won **two blocks today** on the live sharechain — `2511241` (64 confirmations) and `2511303`. Both accepted by dashd, both paid out correctly. **No legacy p2pool-dash node registered either one — including our own oracle**, whose `/recent_blocks` still shows a block from 21 hours earlier as the pool's most recent.

p2pool nodes do not learn about pool blocks from a block announcement. They detect them **through the sharechain**, by watching for a SHARE that satisfies `pow_hash <= header['bits'].target`. Verified against canonical p2pool-dash source (not taken on trust — read locally at `/home/ubuntu/p2pool-dash`):

`p2pool/node.py:145-147` — the detection watcher:

```python
@self.node.tracker.verified.added.watch
def _(share):
    if not (share.pow_hash <= share.header['bits'].target):
        return
    ...
    spread()
```

The same predicate is the block identity everywhere else in p2pool:

- `p2pool/data.py:436` — `if self.pow_hash <= self.header['bits'].target: return -1, 'block solution'`
- `p2pool/data.py:802` — `is_block = share.pow_hash <= share.header['bits'].target`

and `web.py:1663 get_recent_blocks()` states in its own docstring that it returns blocks *"from both persistent storage and sharechain ... merged with **current sharechain data**"*.

So the causal chain is: **block-winning share never minted → never propagates → no peer ever sees a share meeting the block target → `verified.added` watcher never fires → the block is never recorded by any p2pool node, ours included.** We are ~87% of the pool's hashrate and our blocks do not appear to exist. That lands immediately before we approach a peer operator about migrating to c2pool.

**Ruled out en route** (recorded so nobody chases it): `bestblock` is *not* the mechanism. `p2p.py:803-804`'s handler is a bare `print 'handle_bestblock', header` — verified — and it is sent on every coin-tip change with no pool attribution.

This makes the fix a **visibility and reputation** fix as much as a reward fix.

LTC is unaffected: the create-share hook runs before and independently of the block check.

### Citation check (issue line numbers verified against `3548684`)

| claim | verdict |
|---|---|
| `src/impl/dash/stratum/work_source.cpp:954` | exact — block-arm `return nlohmann::json(true);` |
| `src/impl/btc/stratum/work_source.cpp:925` | exact |
| `src/impl/bch/stratum/work_source.cpp:738` | exact |
| `src/impl/dgb/stratum/work_source.cpp:613` | exact |
| `src/core/web_server.cpp:7463` (LTC `m_create_share_fn`) | **off by one** — 7463 is the `if (!params.payout_script.empty() && params.bits != 0)` guard; the call `m_create_share_fn(params);` is 7464. (Its `if (m_create_share_fn)` outer guard is 7251.) Substance unchanged: LTC creates the share, then falls through to the block-submission block below. |

## The fix

Each coin's mint invocation is lifted **verbatim** out of the share arm into a local helper (`mint_solved_share` / `write_solved_share`) and invoked from **both** arms.

### Ordering — block submit stays absolutely first

LTC mints first. Here the helper runs on the won-block arm **strictly after** the block has been dispatched (on dash, also after the payee-guard verdict and the recent-blocks dashboard record). The invariant is *"never refuse a block the daemon would ACCEPT — a bad block is rejected free, a false refusal is guaranteed loss"*, so nothing may be inserted ahead of the submit: the mint walks the tracker, takes locks, can decline, and can throw. Running it downstream reaches the same end state as LTC with none of that exposure.

The helper also catches exceptions locally on every coin (dgb's `ShareAccept` previously had no `try`/`catch`), so a mint fault can never cost the block nor turn a won block into a stratum reject. There is a KAT per coin for exactly that.

### Per-coin

| coin | seam | change |
|---|---|---|
| **dash** | `mint_share_fn_` (bound `main_dash.cpp:1854`) | LIVE. The hotel's 9 won blocks each forfeited their own share; from here they mint. Runs **even after a payee-guard reject** — see below. |
| **btc** | `create_share_fn_` (bound `main_btc.cpp:1208`) | LIVE. |
| **bch** | `create_share_fn_` (bound `pool_entrypoint.hpp:423`) | LIVE. |
| **dgb** | `try_mint_share` | **PRE-WIRING ONLY (#884)** — see below. |

**dash + payee guard.** The mint runs even when the submit-time payee guard refused to dispatch. The guard is a *coin-side* verdict about a stale masternode payee; the sharechain is a different system with its own acceptance rule (the mint's X11-identity gate plus `pow <= own committed target`), and the share arm has never consulted the guard. The existing reject branch already says as much in its comment — *"the share still counts for the miner; the stale template was ours"*. Withholding here would be a second, self-inflicted loss on top of the forfeited block.

**dgb is pre-wiring.** Per #884 `main_dgb.cpp` never calls `set_mint_share_fn`, so dgb cannot mint **any** local share today — not this one, and not an ordinary `ShareAccept` either. The won-block arm now *reaches* the seam so dgb inherits this fix the moment #884 binds it. The dgb KAT is named `MiningSubmitWonBlockAlsoReachesMintSeam`, its comment carries an explicit SCOPE HONESTY paragraph, and it asserts only seam reachability — it does not claim a mint that cannot happen.

### No consensus change

Share construction, target derivation and serialisation live entirely inside the untouched mint / `create_local_share` seams. This changes only **whether** the seam is invoked, never what it builds. `git diff` touches no share struct, no target math, no serializer.

## ★ Caller-side lock trace

The #878/#881 hazard is: a caller holding the exclusive tracker lock across a call into a self-locking callee makes the callee permanently dead code, and a test that binds its own callback still passes. Traced explicitly:

**Caller side — zero locks held.**
`asio async_read_until` handler → `StratumSession::process_message` (`stratum_server.cpp:504`) → `handle_submit` (`:1036`) → `mining_interface_->mining_submit(...)` (`:1332` pool-share arm, `:1347` pseudoshare-is-a-block arm). Neither `process_message` nor `handle_submit` acquires any mutex; `handle_submit` deliberately *copies* the job snapshot rather than holding a reference, and holds no lock at either call site. **No tracker lock, no session lock, enters `mining_submit`.**

**Inside `mining_submit` — zero locks held across the seam, on both arms.**
Every mutex is scoped and released before the callback is invoked: dash copies `mint_share_fn_` under `mint_share_mutex_` then releases; btc/bch copy `create_share_fn_` under `callback_mutex_` then release; dgb's `try_mint_share` does the same. `workers_mutex_` is only taken *after*, in the `bump` lambda. `found_block_mutex_` (dash) is scoped and released before its callback too.

**The decisive point: the block arm and the share arm are in the SAME function, at the SAME lock depth (zero), with the SAME caller.** There is no lock-state difference between them, so the seam I call from the block arm is exactly as reachable as the one that already runs on the share arm.

**Callee side (dash, the live one).** `main_dash.cpp:1854` takes `node_ptr->read_tracker()` — a *try* `shared_lock` — inside a scoped block, **releases it**, and only then calls `add_local_share`, which takes `unique_lock(m_tracker_mutex, try_to_lock)`. No self-deadlock, and no held-lock-blocks-callee pattern. On the stratum IO thread both try-locks can genuinely succeed. btc/bch do the same (`unique_lock(tracker_mutex(), try_to_lock)`, released before `broadcast_share` / `notify_local_share`).

**How this was proved, not assumed.**
1. *Static:* the trace above — every mutex on the path is scoped, and both arms sit at lock depth zero in one function under one caller.
2. *Dynamic:* the KATs bind a real callback and assert **it ran** (`mint_called` / `share_written`), not merely that the code compiles. Deleting the one-line call reddens them (negative control below).
3. *Ordering:* each coin has an **ordering witness** — the bound callback records `submit_called` at the moment it runs and the test asserts it was already `true`. If anyone later reorders the mint ahead of the submit, that assertion goes red.
4. *Production corroboration:* the identical seam, from the identical function, at the identical lock depth, is what mints DASH shares on the live hotel sharechain today (share arm). That is the part a test cannot prove and reading can.

**Honest limit:** the KATs bind their own callback, so they prove work-source-level reachability, not that `main_dash.cpp`'s real lambda succeeds under production contention. That last step rests on the production share arm already working through the same lock topology. See "Not verified" below.

## Test evidence

Folded into **existing allowlisted targets** — never a new `add_executable` (which silently reports "Not Run"; PR #868 pattern). `tools/ci/check_test_target_allowlist.py` → `CI drift-guard OK: 120 per-coin test target(s) ... all present`. `.github/workflows/` untouched.

| target | file | result |
|---|---|---|
| `test_dash_stratum_work_source` | `test/test_dash_stratum_work_source.cpp` (+2 tests) | **46/46 PASSED** |
| `dgb_work_source_test` | `src/impl/dgb/test/work_source_test.cpp` (+2 tests) | **33/33 PASSED** |
| `btc_share_test` | new `src/impl/btc/test/won_block_mints_share_test.cpp` folded in (+`btc_stratum` link) | **116/116 PASSED** |
| `bch_g2_block_assembly_roundtrip_test` | `g2_block_assembly_roundtrip_test.cpp` (+3 checks, +`bch_stratum`/`bch_coin` link) | **all checks passed** |

Build: `Release`, gcc 13.3, `-DCOIN_DGB=ON -DCOIN_BCH=ON`. All four targets built with **zero errors**.

Representative live output (dash):

```
[DASH-STRATUM-BLOCK] *** BLOCK FOUND *** user=XfixtureMinerAddress height~=424242 pow_hash=1ce12ab821404976
[DASH-STRATUM-PAYEE-GUARD] coinbase pays all mandated payee scripts ... submitting
[DASH-STRATUM-BLOCK-SHARE] ACCEPTED + MINTED user=XfixtureMinerAddress share_hash=5555555555555555
[       OK ] DashStratumWorkSource.MiningSubmitWonBlockAlsoMintsTheShare
```

and the throw case — block already out, exception contained, miner still gets `true`:

```
[DASH-STRATUM-BLOCK-SHARE] mint_share_fn threw: mint blew up -- share not minted
[       OK ] DashStratumWorkSource.MiningSubmitWonBlockDispatchesBeforeAndDespiteAThrowingMint
```

### Negative control

Deleting **only** the one-line call from each block arm (`// NEGATIVE CONTROL: fix removed`), rebuilding, re-running:

```
dash: [  FAILED  ] MiningSubmitWonBlockAlsoMintsTheShare              (mint_called = false)
      [  FAILED  ] MiningSubmitWonBlockDispatchesBeforeAndDespiteAThrowingMint
dgb:  [  FAILED  ] MiningSubmitWonBlockAlsoReachesMintSeam            (minted = false)
btc:  [  FAILED  ] BtcWonBlockMintsShare.WonBlockAlsoWritesTheShare   (share_written = false)
bch:  FAIL: share_written @ 440 / saw_block_already_submitted @ 441 /
      seen_header_size == 80u @ 442  -> 3 CHECK(s) failed
```

Restored, rebuilt, re-ran → all four green again (numbers in the table above). Note the `SurvivesAThrowing*` KATs stay green under the negative control by design — they guard the reward invariant, not the fix; the fix-detectors are the ones listed here.

## Not verified / follow-ups

- **#889 is NOT closed by this PR.** `add_local_share` uses `try_to_lock` and *declines* if the compute thread is mid-think. For an ordinary share that is fine ("the next solve mints"); for a **block-winning** share there is no next solve on that job, so a busy tracker still forfeits it — and, per consequence 3 above, that also means the block stays invisible to p2pool peers in exactly that window. Making that one case blocking is a threading change beyond this PR's scope. **Tracked separately as #889 — do not read #888 as closing it.**
- **Production-contention behaviour of the real bound lambdas** cannot be exercised from a unit test (the KATs bind their own callback). That last step rests on the production share arm already working through the same lock topology.
- **bch** `create_share_fn_` binding lives in `pool_entrypoint.hpp`, not `main_bch.cpp`; I confirmed it is bound but did not soak the bch lane.
- **dgb** end-to-end minting remains impossible until #884.
- No live-node soak was run; this is a unit-level change verified by KAT plus negative control.

## CI: `Linux x86_64 (AsAN+UBSan)` red — diagnosed, NOT caused by this PR

The failure is **not** a crash and **not** a static-init-order abort. Full error:

```
CMake Error at /usr/share/cmake-3.28/Modules/GoogleTestAddTests.cmake:112 (message):
  Error running test executable.
    Path:   '.../build_asan/test/test_utxo'
    Result: Process terminated due to timeout
    Output:
```

`test_utxo` — a file this PR does not touch. `Result: Process terminated due to timeout` with **empty output** means `gtest_discover_tests(... DISCOVERY_MODE PRE_TEST)` ran `test_utxo --gtest_list_tests` and hit CMake's default 5 s `DISCOVERY_TIMEOUT`.

**Timing from the log proves no test had started yet:**

```
12:04:56.235  Test project .../build_asan     <- ctest begins
12:05:02.410  CMake Error ... test_utxo       <- 6.18 s later, zero tests run
```

PRE_TEST discovery happens during ctest **startup**. Nothing this PR adds was running.

### Reproduced locally under the identical flags

Same `-fsanitize=address,undefined -fno-sanitize=vptr -fno-omit-frame-pointer -fno-sanitize-recover=undefined -g`, same `ASAN_OPTIONS=detect_leaks=0:check_initialization_order=1:strict_string_checks=1:abort_on_error=0`, same `UBSAN_OPTIONS`:

```
run1: 0.19 s   (cold, first run after link)
run2: 0.06 s
run3: 0.05 s
run4: 0.06 s
exit = 0
```

and the binary itself is fully healthy — `14 tests from UTXOTest ... [ PASSED ] 14 tests`, exit 0, no ASAN or UBSAN diagnostic. **0.06 s of work against a 5 s budget.** Non-sanitized discovery is 0.00 s.

So the binary does not crash, does not abort on `check_initialization_order`, and does not need anywhere near 5 s. The CI process was starved of CPU, not broken.

### Proof the changed files cannot reach the failing binary

`test_utxo` links `core ltc ltc_coin pool c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage`. Mechanically, from its generated `link.txt`:

- `work_source` objects in the link line: **0**
- `dash_stratum` / `btc_stratum` / `bch_stratum` / `dgb_stratum`: **absent**
- the only `stratum` hit is `core/stratum_server.cpp.o`, which this PR does not modify

Every file in this PR's diff is either a coin `stratum/work_source.cpp` (in a lib `test_utxo` does not link), a per-coin test source, or a per-coin test `CMakeLists.txt`. None is compiled into `test_utxo`.

Additional corroboration: the sibling **`COIN_BCH Linux x86_64 (AsAN+UBSan)` job passed on this same PR**, and the same ASAN job is green on master runs `30191188565`, `30190238757` and on PR run `30197898389` — none of which contain this error string.

### The `check_initialization_order=1` hypothesis, ruled out

A plausible reading of "error running test executable" under ASAN is a static-init-order abort. It is not that, on four independent grounds:

1. The reported result is `Process terminated due to timeout`. An ASAN abort produces a diagnostic; **`Output:` was empty**. Confirmed at source: `GoogleTest.cmake:443` defaults `DISCOVERY_TIMEOUT` to 5, and `GoogleTestAddTests.cmake:105-112` raises `FATAL_ERROR` for any non-zero `execute_process(... TIMEOUT ...)` result — the timeout path.
2. This PR introduces **no new global or static with a dynamic initializer**. The only static initializer in the new TU is googletest's own per-`TEST` `test_info_` registration — `nm` shows exactly one `_GLOBAL__sub_I__ZN61BtcWonBlockMintsShare_...test_info_E`, the identical pattern to the pre-existing `share_test.cpp.o` (control: also exactly one). No ordering was changed.
3. That TU is not linked into `test_utxo` at all (`grep -c won_block_mints_share` on its link line: **0**).
4. `test_utxo` runs locally **with `check_initialization_order=1` active**, enumerating in 0.06 s and passing 14/14, exit 0, with no ASAN or UBSan output.

### Conclusion

Pre-existing latent CI-infra flake: a 5 s wall-clock `DISCOVERY_TIMEOUT` on an oversubscribed self-hosted host. Confirmed live while the re-run sat queued — `gh api .../actions/runners` shows **eight runners on VM905 (`c2pool-linux-905` … `-905-8`) all `busy=true` simultaneously**, each building `-j8`, with a 12-run queue and zero in progress. The failing job ran on `c2pool-linux-905-7`. **Not bundled into this PR** — filed separately as #898. The job is `continue-on-error: true` (informational, not gating) by design. Re-run of the identical commit is the environmental control.

Recommended separate fix, which does **not** weaken discovery in the #895 sense (the binary is still executed, and a genuine failure still hard-errors — it only stops a *slow but successful* enumeration being misread as a crash): add an explicit `DISCOVERY_TIMEOUT` to the three `gtest_discover_tests(... PRE_TEST)` calls in `test/CMakeLists.txt` (`test_dgb_subsidy`, `test_dgb_coinbase_value`, `test_utxo`).

## Scope

Untouched by design: `src/core/socket.cpp`, `src/core/web_server.cpp`, `src/impl/*/protocol_legacy.cpp`, `send_shares` / `broadcast_share` bodies, `.github/workflows/`.

