### PR TITLE
test(threading): deterministic exercise for Phase2HoldsLockAgainstComputePrune (#883 flake)

### DIFF
--- a/test/test_threading.cpp
+++ b/test/test_threading.cpp
@@ -557,8 +557,18 @@ TEST(VerifyShareThreading, Phase2HoldsLockAgainstComputePrune)
     auto io_body = [&] {
         for (int iter = 0; iter < 20000 && !stop.load(std::memory_order_relaxed); ++iter) {
             // processing_shares_phase2: hold lock across the mutation body.
+            // The first iteration acquires BLOCKING so at least one real
+            // acquisition + under-lock deref is GUARANTEED to exercise the
+            // invariant even when the compute thread monopolises the lock under
+            // sanitizer slowdown on a contended runner (io_ops would otherwise
+            // stay 0 and trip the self-check with nothing actually wrong —
+            // issue #883). Later iterations keep try_to_lock so the non-blocking
+            // defer path is still exercised.
             {
-                std::unique_lock<std::shared_mutex> lock(chain_mutex, std::try_to_lock);
+                std::unique_lock<std::shared_mutex> lock =
+                    (iter == 0)
+                        ? std::unique_lock<std::shared_mutex>(chain_mutex)
+                        : std::unique_lock<std::shared_mutex>(chain_mutex, std::try_to_lock);
                 if (!lock.owns_lock()) { defers.fetch_add(1); continue; }
                 for (auto& [id, node] : chain) {
                     node->touched.fetch_add(1, std::memory_order_relaxed); // deref UNDER lock


### PR DESCRIPTION
Fixes the 3x flake on #872 that is holding a clean PR out of master.

## Root cause
`VerifyShareThreading.Phase2HoldsLockAgainstComputePrune` asserts `io_ops > 0` as a self-check that the invariant was exercised. Both IO bodies acquire with `std::try_to_lock` and `continue` on failure. Under sanitizer slowdown on a contended runner the compute thread can hold the exclusive lock for the entire window, so every try_lock fails, `io_ops` stays 0, and the self-check trips while the discipline under test is correct.

Environmental, cross-confirmed by integrator: #877 (larger surface) passes the identical Linux x86_64 AsAN+UBSan job; #872 own BCH AsAN job passes; test_threading.cpp includes no protocol/random header #872 touched.

## Fix
First iteration acquires BLOCKING so at least one real under-lock deref is guaranteed (io_ops>0). Remaining iterations keep `try_to_lock` so the non-blocking defer path is still exercised. The concurrent-prune UAF property under ASan/TSan is unchanged.

Draft for review, no self-merge.
