### PR TITLE
ci(drift-guard): audit top-level test/ tree; catches 3 never-built dash-bls targets (#883)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -82,6 +82,11 @@ if (BUILD_TESTING AND GTest_FOUND)
     )
     target_link_libraries(test_redistribute_address PRIVATE ltc_coin c2pool_storage pool)  # OBJECT-lib SCC direct-naming (#22/#39)
 
+    # ci-allowlist-exempt: test_phase0_live  -- live-only harness (needs a running coin daemon); not CI-built by design
+    # ci-allowlist-exempt: test_phase1_live  -- live-only harness (needs a running coin daemon); not CI-built by design
+    # ci-allowlist-exempt: test_phase2_live  -- live-only harness (needs a running coin daemon); not CI-built by design
+    # ci-allowlist-exempt: test_phase3_live  -- live-only harness (needs a running coin daemon); not CI-built by design
+    # ci-allowlist-exempt: test_phase4_live  -- live-only harness (needs a running coin daemon); not CI-built by design
     add_executable(test_phase0_live test_phase0_live.cpp)
     target_link_libraries(test_phase0_live PRIVATE
         GTest::gtest_main GTest::gtest
@@ -507,6 +512,15 @@ if (BUILD_TESTING AND GTest_FOUND)
     target_link_libraries(test_dash_quorum_root PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
     gtest_add_tests(test_dash_quorum_root "" AUTO)
 
+    # KNOWN COVERAGE GAP (surfaced by the top-level drift-guard, #883 follow-up):
+    # the three targets below are gated behind C2POOL_DASH_BLS, but NO workflow
+    # in .github/workflows/ currently enables that flag, so they are never built
+    # or run in CI. Exempted here to keep the guard green; the real fix is a
+    # linux-dash-bls CI job (decision pending with integrator). Do NOT remove
+    # these exemptions without either adding that job or deleting the targets.
+    # ci-allowlist-exempt: test_dash_bls_verify  -- C2POOL_DASH_BLS-gated; no CI job enables it yet (coverage gap tracked)
+    # ci-allowlist-exempt: test_dash_quorum_members  -- C2POOL_DASH_BLS-gated; no CI job enables it yet (coverage gap tracked)
+    # ci-allowlist-exempt: test_dash_quorum_member_source  -- C2POOL_DASH_BLS-gated; no CI job enables it yet (coverage gap tracked)
     if(C2POOL_DASH_BLS)  # gate the BLS-backend-requiring Phase-L test executables to the BLS-ON build
     # E1 Phase-L: type-6 quorum-commitment BLS verify KAT. Links dash_bls_verify
     # (which carries the C2POOL_DASH_BLS define + dashbls include/libs PUBLIC when

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -513,14 +513,16 @@ if (BUILD_TESTING AND GTest_FOUND)
     gtest_add_tests(test_dash_quorum_root "" AUTO)
 
     # KNOWN COVERAGE GAP (surfaced by the top-level drift-guard, #883 follow-up):
-    # the three targets below are gated behind C2POOL_DASH_BLS, but NO workflow
-    # in .github/workflows/ currently enables that flag, so they are never built
-    # or run in CI. Exempted here to keep the guard green; the real fix is a
-    # linux-dash-bls CI job (decision pending with integrator). Do NOT remove
-    # these exemptions without either adding that job or deleting the targets.
-    # ci-allowlist-exempt: test_dash_bls_verify  -- C2POOL_DASH_BLS-gated; no CI job enables it yet (coverage gap tracked)
-    # ci-allowlist-exempt: test_dash_quorum_members  -- C2POOL_DASH_BLS-gated; no CI job enables it yet (coverage gap tracked)
-    # ci-allowlist-exempt: test_dash_quorum_member_source  -- C2POOL_DASH_BLS-gated; no CI job enables it yet (coverage gap tracked)
+    # the three targets below are gated behind C2POOL_DASH_BLS, but no workflow
+    # in .github/workflows/ enables that flag yet, so they are never built or run
+    # in CI. Integrator decision 2026-07-26: restore coverage (fail-closed shape
+    # kept). Coverage is being closed by PR #890 (ci/dash-bls-enable), which
+    # builds+ships DASH with the real BLS backend linked. These exemptions are
+    # SELF-RETIRING: remove all three in a one-line follow-up once #890 lands.
+    # Do NOT remove them before then without adding an equivalent BLS-ON CI job.
+    # ci-allowlist-exempt: test_dash_bls_verify  -- C2POOL_DASH_BLS-gated; coverage restored by PR #890 (ci/dash-bls-enable) — remove exemption when #890 lands
+    # ci-allowlist-exempt: test_dash_quorum_members  -- C2POOL_DASH_BLS-gated; coverage restored by PR #890 (ci/dash-bls-enable) — remove exemption when #890 lands
+    # ci-allowlist-exempt: test_dash_quorum_member_source  -- C2POOL_DASH_BLS-gated; coverage restored by PR #890 (ci/dash-bls-enable) — remove exemption when #890 lands
     if(C2POOL_DASH_BLS)  # gate the BLS-backend-requiring Phase-L test executables to the BLS-ON build
     # E1 Phase-L: type-6 quorum-commitment BLS verify KAT. Links dash_bls_verify
     # (which carries the C2POOL_DASH_BLS define + dashbls include/libs PUBLIC when

--- a/tools/ci/check_test_target_allowlist.py
+++ b/tools/ci/check_test_target_allowlist.py
@@ -23,6 +23,11 @@ import glob
 REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 BUILD_YML = os.path.join(REPO, ".github", "workflows", "build.yml")
 COIN_GLOB = os.path.join(REPO, "src", "impl", "*", "test", "CMakeLists.txt")
+# The top-level shared test tree is ALSO a NOT_BUILT surface: a standalone
+# add_executable here that is missing from build.yml is silently "Not Run"
+# too (this is why targets get hand-folded into allowlisted executables to
+# dodge the trap). Audit it with the same fail-closed rule.
+TOP_LEVEL_TEST = os.path.join(REPO, "test", "CMakeLists.txt")
 
 
 def strip_comment(line):
@@ -106,8 +111,14 @@ def main():
     allowlist = build_yml_targets(BUILD_YML)
     violations = []
     audited = 0
-    for cml in sorted(glob.glob(COIN_GLOB)):
-        coin = cml.split(os.sep)[-3]
+    roots = sorted(glob.glob(COIN_GLOB))
+    if os.path.exists(TOP_LEVEL_TEST):
+        roots.append(TOP_LEVEL_TEST)
+    for cml in roots:
+        # Label: coin name for a per-coin tree (src/impl/<coin>/test/...),
+        # "test/" for the shared top-level tree.
+        rel = os.path.relpath(cml, REPO)
+        coin = cml.split(os.sep)[-3] if rel.startswith("src" + os.sep) else "test/"
         with open(cml) as f:
             exempt = parse_exemptions(f.read())
         for tgt in sorted(parse_coin_targets(cml)):
@@ -129,7 +140,7 @@ def main():
 
     print("CI drift-guard OK: %d per-coin test target(s) across %d coin lane(s) "
           "all present in build.yml --target allowlist."
-          % (audited, len(glob.glob(COIN_GLOB))))
+          % (audited, len(glob.glob(COIN_GLOB)) + (1 if os.path.exists(TOP_LEVEL_TEST) else 0)))
     return 0
 
 


### PR DESCRIPTION
Makes the "Not Run" allowlist trap structurally impossible for the top-level `test/` tree, and in doing so surfaces three genuinely never-built targets.

## What the guard missed
`tools/ci/check_test_target_allowlist.py` only audited `src/impl/*/test/CMakeLists.txt` (per-coin trees). The shared top-level `test/CMakeLists.txt` was **entirely unaudited** — a standalone `add_executable` there that is missing from build.yml's `--target` list is silently "Not Run" too. That is precisely why contributors keep hand-folding new tests into an already-allowlisted executable to dodge the trap (e.g. `test_dash_known_txs_retention.cpp` folded into `test_dash_share_hash_link`).

This extends the guard to audit the top-level tree with the same fail-closed rule. Now 219 targets across 6 lanes are gated.

## Three real never-built targets it caught
- `test_dash_bls_verify`
- `test_dash_quorum_members`
- `test_dash_quorum_member_source`

All three are wrapped in `if(C2POOL_DASH_BLS)` (test/CMakeLists.txt:510-565). The in-tree comment claims "the linux-dash-bls job" builds them — **but no workflow in `.github/workflows/` enables `C2POOL_DASH_BLS`, and no such job exists.** So the Phase-L quorum member-selection, DIP-4 auth, and BLS commitment KATs have never run in CI.

I exempted them with an explicit gap-tracking reason (keeps the guard green rather than landing red and blocking all PRs), and exempted the five `test_phase*_live` harnesses as live-only.

## Decision needed
The honest fix for the BLS three is a dedicated `linux-dash-bls` job that builds with `C2POOL_DASH_BLS=ON` (needs the dashbls backend on the runner) — restoring real coverage. That is a coverage/infra decision. Options: (a) I wire that job, or (b) accept the gap and keep the documented exemptions. Say which.

## Correction to the report
The named instance `test_dash_known_txs_retention.cpp` is actually fine — it was deliberately folded into `test_dash_share_hash_link` (test/CMakeLists.txt:405), which IS in build.yml's `--target` list (lines 147, 335). Its gtest cases do run. The folding was the dodge; this guard removes the need for it.

Draft for review, no self-merge.
