### PR TITLE
#886 core(web_server): stop LTC/DOGE submit path from silently losing valid blocks

### DIFF
--- a/src/core/test/web_server_submitblock_test.cpp
+++ b/src/core/test/web_server_submitblock_test.cpp
@@ -5,6 +5,7 @@
 #include <cstring>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include <nlohmann/json.hpp>
@@ -231,6 +232,90 @@ TEST(SubmitblockResult, DuplicateAndInconclusiveAreAck)
     EXPECT_FALSE(submitblock_result_accepted("duplicate-invalid"));
     EXPECT_FALSE(submitblock_result_accepted("high-hash"));
     EXPECT_FALSE(submitblock_result_accepted("bad-txnmrklroot"));
+}
+
+
+// ------------- #886 BUG 1: recent-won-block dedup, keyed on BLOCK HASH --------
+//
+// The pre-fix code kept a process-lifetime `static uint256 s_last_*_submitted_prev`,
+// assigned BEFORE submitblock ran and keyed on the PREV-hash. That (a) permanently
+// retired a prev-hash on an ATTEMPTED submit — so a second, DISTINCT valid block at
+// the same prev was silently never submitted — and (b) never recorded the actual
+// result. The fix keys on the BLOCK HASH and records ONLY on a successful submit.
+
+uint256 mk_hash(uint32_t seed) {
+    uint256 h;                                   // zero-initialised
+    std::memcpy(h.data(), &seed, sizeof(seed));  // distinct hash per seed
+    return h;
+}
+
+// The core regression: two DISTINCT blocks sharing one prev must BOTH be
+// submittable. (Prev-hash keying dropped the second; block-hash keying does not.)
+TEST(RecentBlockDedup, DistinctBlocksSamePrev_BothSubmittable)
+{
+    core::MiningInterface mi{/*testnet=*/true};
+    uint256 a = mk_hash(1), b = mk_hash(2);      // same prev in reality, different block
+
+    EXPECT_FALSE(mi.already_submitted_block(a));
+    mi.mark_block_submitted(a);                  // A submitted successfully
+    EXPECT_TRUE(mi.already_submitted_block(a));
+    EXPECT_FALSE(mi.already_submitted_block(b))
+        << "a DISTINCT block must remain submittable — the #886 BUG 1 regression";
+}
+
+// A block whose submit FAILED is never marked, so it stays resubmittable — the
+// caller invariant that fixes the "retired-on-attempt, submit then failed" loss.
+TEST(RecentBlockDedup, UnmarkedBlockStaysSubmittable)
+{
+    core::MiningInterface mi{/*testnet=*/true};
+    uint256 a = mk_hash(7);
+    EXPECT_FALSE(mi.already_submitted_block(a));
+    EXPECT_FALSE(mi.already_submitted_block(a)) << "querying must not implicitly record";
+}
+
+// Marking is idempotent: a duplicate successful submit does not double-record.
+TEST(RecentBlockDedup, MarkIsIdempotent)
+{
+    core::MiningInterface mi{/*testnet=*/true};
+    uint256 a = mk_hash(3);
+    mi.mark_block_submitted(a);
+    mi.mark_block_submitted(a);
+    EXPECT_TRUE(mi.already_submitted_block(a));
+}
+
+// The set is bounded (kRecentSubmitCap == 256): oldest entries are evicted, so it
+// cannot grow without bound over a long-running process.
+TEST(RecentBlockDedup, BoundedFifoEvictsOldest)
+{
+    core::MiningInterface mi{/*testnet=*/true};
+    const uint32_t CAP = 256;                     // mirrors kRecentSubmitCap
+    for (uint32_t i = 0; i < CAP + 10; ++i) mi.mark_block_submitted(mk_hash(i));
+    EXPECT_FALSE(mi.already_submitted_block(mk_hash(0)))   << "oldest must be evicted";
+    EXPECT_FALSE(mi.already_submitted_block(mk_hash(9)))   << "oldest must be evicted";
+    EXPECT_TRUE (mi.already_submitted_block(mk_hash(10)));
+    EXPECT_TRUE (mi.already_submitted_block(mk_hash(CAP + 9)));
+}
+
+// Thread-safety: the pre-fix static was written unsynchronised from many stratum
+// session threads. Concurrent mark/query must not race or crash, and bounding
+// must still hold. (Run under TSan to catch the data race the static had.)
+TEST(RecentBlockDedup, ConcurrentMarksAreSafeAndBounded)
+{
+    core::MiningInterface mi{/*testnet=*/true};
+    std::vector<std::thread> ts;
+    for (int t = 0; t < 8; ++t) {
+        ts.emplace_back([&mi, t]() {
+            for (uint32_t i = 0; i < 200; ++i) {
+                uint32_t seed = static_cast<uint32_t>(t) * 1000u + i;
+                mi.mark_block_submitted(mk_hash(seed));
+                (void)mi.already_submitted_block(mk_hash(seed));
+            }
+        });
+    }
+    for (auto& th : ts) th.join();
+    // 1600 distinct marks >> cap(256): an early one MUST have been evicted, proving
+    // the bound held across concurrent writers without corruption.
+    EXPECT_FALSE(mi.already_submitted_block(mk_hash(0)));
 }
 
 } // namespace

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -1807,6 +1807,27 @@ nlohmann::json MiningInterface::getblocktemplate(const nlohmann::json& params, c
     };
 }
 
+// #886 recent-won-block dedup helpers. Keyed on the BLOCK HASH, recorded only
+// on a SUCCESSFUL submit. Linear scan over a bounded FIFO (<=256) — the won-block
+// path is rare, so this is trivially cheap and avoids a std::hash<uint256>.
+bool MiningInterface::already_submitted_block(const uint256& block_hash) const
+{
+    std::lock_guard<std::mutex> lk(m_recent_submit_mutex);
+    for (const auto& h : m_recent_submitted_blocks)
+        if (h == block_hash) return true;
+    return false;
+}
+
+void MiningInterface::mark_block_submitted(const uint256& block_hash)
+{
+    std::lock_guard<std::mutex> lk(m_recent_submit_mutex);
+    for (const auto& h : m_recent_submitted_blocks)
+        if (h == block_hash) return;              // already recorded
+    m_recent_submitted_blocks.push_back(block_hash);
+    while (m_recent_submitted_blocks.size() > kRecentSubmitCap)
+        m_recent_submitted_blocks.pop_front();
+}
+
 nlohmann::json MiningInterface::submitblock(const std::string& hex_data, const std::string& request_id)
 {
     LOG_TRACE << "[LTC] submitblock: received " << hex_data.length() / 2 << " bytes";
@@ -7143,22 +7164,33 @@ nlohmann::json MiningInterface::mining_submit(const std::string& username, const
                             expected_merkle = reconstruct_merkle_root(coinbase_hex, branches);
                         }
 
+                        // #886 BUG 2: the merkle self-check is ADVISORY ONLY,
+                        // never a refusal. expected_merkle is rebuilt from
+                        // job/cache; a template roll between job freeze and submit
+                        // yields a benign FALSE mismatch. Log loudly, then SUBMIT
+                        // ANYWAY and let the daemon be the authority (mirrors BTC
+                        // work_source.cpp:802). INVARIANT: never REFUSE a block the
+                        // daemon might accept — a false refusal is a guaranteed loss.
                         if (header_merkle != expected_merkle) {
-                            LOG_ERROR << "Block merkle_root mismatch!"
-                                      << " header=" << header_merkle.GetHex()
-                                      << " expected=" << expected_merkle.GetHex();
-                        } else {
-                            // Skip duplicate blocks at the same prev_block
-                            // (multiple shares can meet the target at the same height)
-                            uint256 prev_block;
-                            std::memcpy(prev_block.data(), block_bytes.data() + 4, 32);
-                            static uint256 s_last_submitted_prev;
-                            if (prev_block != s_last_submitted_prev) {
-                                s_last_submitted_prev = prev_block;
-                                uint256 block_hash = Hash(std::span<const unsigned char>(block_bytes.data(), block_bytes.size()));
+                            LOG_WARNING << "Block merkle self-check DIVERGENCE"
+                                        << " header=" << header_merkle.GetHex()
+                                        << " expected=" << expected_merkle.GetHex()
+                                        << " — submitting anyway (daemon is authority; template roll or leaf-set bug)";
+                        }
+                        // #886 BUG 1: dedup on the BLOCK HASH (not prev-hash — many
+                        // distinct valid blocks share one prev), recorded ONLY on a
+                        // SUCCESSFUL submit so a failed submit (stale template,
+                        // transient RPC, -1 verdict) stays resubmittable. Bounded +
+                        // thread-safe (see already_submitted_block).
+                        {
+                            uint256 block_hash = Hash(std::span<const unsigned char>(block_bytes.data(), block_bytes.size()));
+                            if (!already_submitted_block(block_hash)) {
                                 LOG_INFO << "[BLOCK] Parent block found by " << username
                                          << " hash=" << block_hash.GetHex().substr(0,16);
-                                submitblock(block_hex);
+                                auto submit_res = submitblock(block_hex);
+                                if (!submit_res.contains("error")) {
+                                    mark_block_submitted(block_hash);
+                                }
                             }
                         }
                     }
@@ -7530,22 +7562,26 @@ nlohmann::json MiningInterface::mining_submit(const std::string& username, const
                             expected_merkle = reconstruct_merkle_root(coinbase_hex, branches);
                         }
 
+                        // #886 BUG 2: merkle self-check is ADVISORY ONLY (see
+                        // solo path). A template roll yields a benign FALSE
+                        // mismatch; log loudly then SUBMIT ANYWAY, daemon decides.
                         if (header_merkle != expected_merkle) {
-                            LOG_ERROR << "Pool block merkle_root mismatch!"
-                                      << " header=" << header_merkle.GetHex()
-                                      << " expected=" << expected_merkle.GetHex();
-                        } else {
-                            // Skip duplicate blocks at the same prev_block
-                            uint256 prev_block;
-                            std::memcpy(prev_block.data(), block_bytes.data() + 4, 32);
-                            static uint256 s_last_pool_submitted_prev;
-                            if (prev_block != s_last_pool_submitted_prev) {
-                                s_last_pool_submitted_prev = prev_block;
-                                uint256 block_hash = Hash(std::span<const unsigned char>(block_bytes.data(), block_bytes.size()));
+                            LOG_WARNING << "Pool block merkle self-check DIVERGENCE"
+                                        << " header=" << header_merkle.GetHex()
+                                        << " expected=" << expected_merkle.GetHex()
+                                        << " — submitting anyway (daemon is authority; template roll or leaf-set bug)";
+                        }
+                        // #886 BUG 1: dedup on BLOCK HASH, recorded only on success.
+                        {
+                            uint256 block_hash = Hash(std::span<const unsigned char>(block_bytes.data(), block_bytes.size()));
+                            if (!already_submitted_block(block_hash)) {
                                 LOG_INFO << "[BLOCK] " << (merged_found ? "Twin" : "Parent")
                                          << " block found by " << username
                                          << " hash=" << block_hash.GetHex().substr(0,16);
-                                submitblock(block_hex);
+                                auto submit_res = submitblock(block_hex);
+                                if (!submit_res.contains("error")) {
+                                    mark_block_submitted(block_hash);
+                                }
                             }
                         }
                     }

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -8,6 +8,7 @@
 #include <thread>
 #include <atomic>
 #include <mutex>
+#include <deque>
 #include <future>
 #include <set>
 #include <map>
@@ -128,6 +129,15 @@ public:
     nlohmann::json submitwork(const std::string& nonce, const std::string& header, const std::string& mix, const std::string& request_id = "");
     nlohmann::json getblocktemplate(const nlohmann::json& params = nlohmann::json::array(), const std::string& request_id = "");
     nlohmann::json submitblock(const std::string& hex_data, const std::string& request_id = "");
+
+    // Recent-won-block dedup (#886). Keyed on the BLOCK HASH (SHA256d of the
+    // 80-byte header), NOT the prev-hash: many distinct valid blocks share one
+    // prev, so a prev-hash key drops real winnable blocks. Membership is
+    // recorded ONLY on a SUCCESSFUL submit, so a failed submit leaves the block
+    // eligible for resubmission by the next share. Bounded FIFO, own mutex
+    // (mining_submit runs on many stratum session threads). Public for KATs.
+    bool already_submitted_block(const uint256& block_hash) const;
+    void mark_block_submitted(const uint256& block_hash);
     
     // Pool stats and info methods
     nlohmann::json getinfo(const std::string& request_id = "");
@@ -1013,6 +1023,11 @@ private:
     std::string             m_cached_coinb1;
     std::string             m_cached_coinb2;
     mutable std::mutex      m_work_mutex;
+
+    // Recent-won-block dedup state (#886) — see already_submitted_block().
+    mutable std::mutex      m_recent_submit_mutex;
+    std::deque<uint256>     m_recent_submitted_blocks;
+    static constexpr size_t kRecentSubmitCap = 256;
 
     // Block-found callback (header_hex, stale_info: 0=none, 253=orphan, 254=doa)
     std::function<void(const std::string&, int)> m_on_block_submitted;


### PR DESCRIPTION
Fixes two false-refusal bugs in `core::MiningInterface::mining_submit` (the LTC/DOGE submit path; BTC/DASH/DGB/BCH use the separate `IWorkSource::mining_submit` family and are unaffected).

BUG 1 (dedup): process-lifetime static keyed on prev-hash replaced with a bounded (256) thread-safe recent-submission set keyed on the BLOCK HASH, recorded ONLY on successful submit. Distinct blocks sharing a prev both submit; a failed submit stays resubmittable.

BUG 2 (merkle): self-check is now advisory — LOG_WARNING then submit anyway (daemon is authority; mirrors BTC work_source.cpp:802). Never refuse a block the daemon might accept.

Scope: src/core/web_server.cpp + .hpp only (shared file, LTC/DOGE-scoped behavior). Isolation-reviewed: no other coin submit semantics change; auto-detect fallback can only make submits safer.

Reachability (caller-side lock trace): mining_submit is dispatched per-share from stratum_server.cpp:1332/1347, NOT inside a held tracker exclusive lock — the block branch runs lock-free, so the fix is live code (structurally unlike #878/#881). No empirical [BLOCK] fired (0 LTC blocks in 30d at current hashrate) — structural trace, not live-fired.

Tests: 5 new RecentBlockDedup KATs folded into core_test (web_server_submitblock_test.cpp). core_test 98/98 green locally on Linux x86_64.

GPG-signed 16be9867 (key 50AB1379).