### PR TITLE
dash web: stop serving LTC+DOGE merged worker instructions on standalone DASH pools

### DIFF
--- a/p2pool-dash/DASH_DASHBOARD_PLAN.md
+++ b/p2pool-dash/DASH_DASHBOARD_PLAN.md
@@ -1,0 +1,48 @@
+# DASH dashboard plan (web_server / JSON API layer)
+
+Owner: dashboard-steward. Charter: a dashboard must never lie about prod health
+— and must never serve a tenant *wrong instructions*. Progress is logged here so
+it is visible without anyone asking.
+
+## Live context
+- Hotel DASH node LIVE on PPLNS, real tenant watching (109.161.57.3:8080).
+- Gauge truth caveat: build on #877 (pool_hash_rate / min_difficulty un-fudge)
+  and cross-check any new card against an oracle node, not our own JSON.
+
+## P4 — cross-coin dashboard correctness (coin-specific strings data-driven)
+
+Trigger: 2026-07-26 integrator HIGH — the DASH node served the LTC dashboard
+essentially unmodified: LTC+DOGE **merged-mining worker-username** instructions
+(`<ADDR>,<DOGE_ADDR>.WORKER`) on a standalone DASH pool with no merged child, plus
+LTC branding/explorer links throughout. Wrong instructions actively mislead a
+paying tenant.
+
+### (a) Minimal — data-drive coin strings  [IN PROGRESS: branch dash/coin-topology-username-honesty]
+- [x] Backend: `rest_web_currency_info()` emits merged-mining **topology**
+      (`merged_child_symbol`) — `"DOGE"` for LTC parent, ABSENT for standalone
+      coins (DASH/BTC/DGB). currency_info already carried per-coin symbol/name/
+      explorer prefixes (incl. DASH), so only topology was missing.
+- [x] Frontend: the Username connection-instruction line is now topology-driven —
+      merged parent → `PARENT_ADDR,CHILD_ADDR.WORKER`; standalone → `PARENT_ADDR.WORKER`.
+      DASH now renders `<DASH_ADDR>.WORKER`; the merged child span is hidden.
+- [x] Honesty KAT (test_web_honesty_regression): DASH advertises no merged child
+      and DASH (not litecoin) explorer branding; LTC advertises DOGE. Not
+      `#ifdef`-guarded (issue #895) — the test actually executes.
+- [ ] Follow-up within (a): route the found-block miner/block explorer links
+      (still hardcoded blockchair litecoin/dogecoin at web-static/dashboard.html
+      ~3887/3918/4033/6401) through `currency_info.*_explorer_url_prefix`.
+
+### (b) Structural — one template, every lane renders its own coin  [FOLLOW-UP]
+- Canvas block labels ("LTC BLOCK"), page title/branding sweep (7x "Ltc",
+  6x "LtcBlock", 5x "litecoin"), and full coin-profile parameterization so
+  LTC/DOGE, DASH, DGB, BCH, BTC each render correctly from one source.
+
+## Watchlist
+- PR #879 (draft) `/p2p_stats`: tip lag + timestamp-saturation fraction are the
+  HONEST sharechain-health signals; under saturation pool_hash_rate is a
+  difficulty-history gauge, not a hashrate gauge. Surface once merged.
+  (bg: p2pool-dash/PPLNS_TIMESTAMP_CLIP_SATURATION.md)
+
+## Non-issues (do not "fix")
+- `record_merged_share_difficulty` absent on DASH is CORRECT — standalone parent,
+  no merged child. That absence is exactly what (a) makes the dashboard honest about.

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -3988,6 +3988,11 @@ nlohmann::json MiningInterface::rest_web_currency_info()
     case Blockchain::LITECOIN:
         result["symbol"] = "LTC";
         result["name"] = "Litecoin";
+        // LTC parent merge-mines DOGE across the fleet; expose the child so
+        // the dashboard renders the merged worker-username format. Standalone
+        // coins (DASH/BTC/DGB) set NO merged child -> field absent -> parent-
+        // only instructions. Never advertise a merged child a coin lacks.
+        result["merged_child_symbol"] = "DOGE";
         result["block_period"] = 150;  // 2.5 min average
         if (!m_custom_address_explorer.empty()) {
             result["address_explorer_url_prefix"] = m_custom_address_explorer;

--- a/test/test_web_honesty_regression.cpp
+++ b/test/test_web_honesty_regression.cpp
@@ -1117,3 +1117,28 @@ TEST(WebGaugeParity, DisplayLookbehindIsOneHourOfSharesNotTargetLookbehind) {
     EXPECT_NE(3600u / ltc::PoolConfig::SHARE_PERIOD,
               ltc::PoolConfig::TARGET_LOOKBEHIND);
 }
+
+// Coin-topology honesty (2026-07-26 integrator HIGH): a standalone parent (DASH)
+// must NOT advertise a merged child -- serving LTC+DOGE merged-mining worker-
+// username instructions on a DASH pool misconfigures a live tenant. The
+// dashboard's Username line is driven by currency_info.merged_child_symbol, so
+// that field must be present ONLY for a genuine merged parent (LTC->DOGE) and
+// ABSENT for standalone coins. Not #ifdef-guarded (issue #895): always runs.
+TEST(WebHonestyRegression, CurrencyInfoNoFalseMergedChildOnDash) {
+    MiningInterface dash(/*testnet=*/true, /*node=*/nullptr, Blockchain::DASH);
+    json d = dash.rest_web_currency_info();
+    EXPECT_EQ(d.value("symbol", std::string()), "DASH");
+    EXPECT_FALSE(d.contains("merged_child_symbol"))
+        << "DASH is a standalone parent with no merged child; advertising one "
+           "serves wrong LTC+DOGE worker-username instructions to tenants";
+    // Branding/explorer must be DASH, never a hardcoded litecoin fallback.
+    std::string dpfx = d.value("address_explorer_url_prefix", std::string());
+    EXPECT_NE(dpfx.find("dash"), std::string::npos);
+    EXPECT_EQ(dpfx.find("litecoin"), std::string::npos);
+
+    MiningInterface ltc(/*testnet=*/true, /*node=*/nullptr, Blockchain::LITECOIN);
+    json l = ltc.rest_web_currency_info();
+    EXPECT_EQ(l.value("merged_child_symbol", std::string()), "DOGE")
+        << "LTC parent merge-mines DOGE; the merged worker-username format is "
+           "correct here";
+}

--- a/web-static/dashboard.html
+++ b/web-static/dashboard.html
@@ -1678,7 +1678,7 @@
                     <div style="font-size: 0.9rem; font-weight: 600; margin-bottom: 5px;">⛏️ Miner Configuration</div>
                     <div style="font-size: 0.85rem; font-family: monospace; background: rgba(0,0,0,0.3); padding: 8px; border-radius: 4px;">
                         <div><strong>Stratum URL:</strong> <span id="miner-url">detecting...</span></div>
-                        <div style="margin-top: 3px;"><strong>Username:</strong> <span style="color: #ffc107;">&lt;<span class="parent-symbol-hint">ADDR</span>&gt;</span><span style="color: #888;">,</span><span style="color: #c3a634;">&lt;DOGE_ADDR&gt;</span><span style="color: #888;">.WORKER</span></div>
+                        <div style="margin-top: 3px;"><strong>Username:</strong> <span style="color: #ffc107;">&lt;<span class="parent-symbol-hint">ADDR</span>&gt;</span><span class="merged-child-hint"><span style="color: #888;">,</span><span style="color: #c3a634;">&lt;<span class="merged-child-symbol-hint">DOGE</span>_ADDR&gt;</span></span><span style="color: #888;">.WORKER</span></div>
                         <div style="margin-top: 3px;"><strong>Password:</strong> <span style="color: #888;">anything</span></div>
                     </div>
                 </div>
@@ -2820,6 +2820,17 @@
             d3.selectAll('.symbol-small').text(sym);
             d3.select('#currency-symbol').text(sym);
             d3.selectAll('.parent-symbol-hint').text(sym + '_ADDR');
+            // Worker-username format is coin-topology-driven: a merged parent
+            // (LTC->DOGE) shows PARENT_ADDR,CHILD_ADDR.WORKER; a standalone coin
+            // (DASH/BTC/DGB) shows just PARENT_ADDR.WORKER. Never serve merged-
+            // mining worker instructions on a coin with no merged child.
+            var mergedChild = info && info.merged_child_symbol;
+            if (mergedChild) {
+                d3.selectAll('.merged-child-symbol-hint').text(mergedChild);
+                d3.selectAll('.merged-child-hint').style('display', null);
+            } else {
+                d3.selectAll('.merged-child-hint').style('display', 'none');
+            }
             d3.select('#parent_chain_peers_title').text(chainName);
             if (info && info.block_period) {
                 parentBlockPeriodMs = info.block_period * 1000;

--- a/web-static/dashboard.html
+++ b/web-static/dashboard.html
@@ -5847,8 +5847,8 @@
                         html += '<div class="tt-block" style="color:#ff8000;border-color:rgba(255,128,0,0.4)">TWIN BLOCK — LEGENDARY</div>';
                     } else {
                         var blockLabel = [];
-                        if (isLtcBlock) blockLabel.push('<span style="color:#ffd700">LTC BLOCK</span>');
-                        if (isDogeBlock) blockLabel.push('<span style="color:#00e5ff">DOGE BLOCK</span>');
+                        if (isLtcBlock) blockLabel.push('<span style="color:#ffd700">' + (((typeof currency_info!=="undefined"&&currency_info.symbol)||"LTC").toUpperCase()) + ' BLOCK</span>');
+                        if (isDogeBlock) blockLabel.push('<span style="color:#00e5ff">' + (((typeof currency_info!=="undefined"&&currency_info.merged_child_symbol)||"DOGE").toUpperCase()) + ' BLOCK</span>');
                         html += '<div class="tt-block">' + blockLabel.join(' ') + '</div>';
                     }
                 }


### PR DESCRIPTION
## HIGH — DASH pool served LTC+DOGE merged worker instructions to a live tenant

Operator/integrator-reported (2026-07-26): the standalone DASH node at
109.161.57.3:8080 served `/dashboard.html` with the LTC+DOGE **merged-mining**
worker-username format (`<ADDR>,<DOGE_ADDR>.WORKER`). DASH has no merged child
(`record_merged_share_difficulty` absent is correct/intentional), so those
instructions would misconfigure a paying tenant. Wrong instructions are worse
than a missing gauge.

### Fix — option (a): data-drive the coin-specific strings
- **Backend** `rest_web_currency_info()` now emits merged-mining **topology**:
  `merged_child_symbol = "DOGE"` for the LTC parent, **absent** for standalone
  coins (DASH/BTC/DGB). currency_info already carried per-coin symbol/name/
  explorer prefixes (incl. DASH) — only topology was missing.
- **Frontend** the Username connection-instruction line is topology-driven:
  merged parent → `PARENT_ADDR,CHILD_ADDR.WORKER`; standalone → `PARENT_ADDR.WORKER`.
  DASH now renders `<DASH_ADDR>.WORKER` (merged-child span hidden).
- **Honesty KAT** in `test_web_honesty_regression`: DASH advertises no merged
  child + DASH (not litecoin) explorer branding; LTC advertises DOGE. **Not
  `#ifdef`-guarded (issue #895)** — verified it actually executes (RUN→OK).

Full suite green: **42/42**.

### Scope / follow-ups
- (a) residual folded next: route the found-block miner/block explorer links
  (still hardcoded blockchair litecoin/dogecoin) through
  `currency_info.*_explorer_url_prefix`.
- (b) structural sweep (canvas "LTC BLOCK" labels, page-title branding, full
  coin-profile templating for every lane) tracked in
  `p2pool-dash/DASH_DASHBOARD_PLAN.md`.
- Gauge fields untouched here; will build on #877 and cross-check an oracle
  before adding cards. #879 `/p2p_stats` saturation signals on the watchlist.
