### PR TITLE
ci(build): PR-only path filter for web-static & qt-webengine (slice 1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,37 @@ concurrency:
 
 
 jobs:
+  # ------------------------------------------------------------------------
+  # PR job-selection filter. On pull_request, skip expensive jobs whose
+  # inputs did not change; on push/tag/dispatch this filter is BYPASSED and
+  # every job runs (the master rollup and release builds stay authoritative).
+  # NONE of the jobs gated here are branch-protection required checks, so a
+  # skip reports as "Skipped" (never a false-green on a required gate) and
+  # nothing needs: them, so no downstream cascade. Required coin/consensus
+  # gates are deliberately NOT filtered here (tracked in ci-steward card).
+  # ------------------------------------------------------------------------
+  changes:
+    name: PR path filter
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
+    outputs:
+      web: ${{ steps.filter.outputs.web }}
+      qt: ${{ steps.filter.outputs.qt }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            web:
+              - 'web-static/**'
+              - '.github/workflows/build.yml'
+            qt:
+              - 'ui/**'
+              - 'src/**'
+              - 'CMakeLists.txt'
+              - 'conanfile*'
+              - 'cmake/**'
+              - '.github/workflows/build.yml'
   # ════════════════════════════════════════════════════════════════════════════
   # Test-allowlist drift-guard (fast, no build): every per-coin test executable
   # declared in src/impl/<coin>/test/CMakeLists.txt must appear in a build.yml
@@ -653,6 +684,8 @@ jobs:
   # ════════════════════════════════════════════════════════════════════════════
   web-static:
     name: Web-static verify
+    needs: changes
+    if: ${{ needs.changes.outputs.web == 'true' || github.event_name != 'pull_request' }}
     # Route to self-hosted for trusted events; fork PRs fall back to
     # GitHub-hosted ubuntu-24.04 (never run untrusted fork code self-hosted).
     runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
@@ -764,6 +797,8 @@ jobs:
   # ════════════════════════════════════════════════════════════════════════════
   qt-webengine:
     name: Qt WebEngine leak gate
+    needs: changes
+    if: ${{ needs.changes.outputs.qt == 'true' || github.event_name != 'pull_request' }}
     runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
     # Hard ceiling: orphaned QtWebEngine/Chromium helper children survive
     # the inner `timeout 180`, holding the xvfb pipe open and hanging the


### PR DESCRIPTION
## ci(build): PR-only path filter for web-static & qt-webengine

Adds a `changes` job (dorny/paths-filter) that lets the two costliest
non-required jobs skip on a PR when their inputs did not change.
"Web-static verify" is our top recurring gate-drag (wedged 4h44m on #930,
forced two manual run cancels, left #880 with a CANCELLED required check).

### (a) The filter CANNOT skip a job whose inputs changed
Explicit trigger paths (a PR touching ANY of these RUNS the job):

**web-static** runs when the PR touches:
- `web-static/**`  (the entire web source + visual harness — the job runs `npm run visual` and uploads from `web-static/sharechain-explorer/tests/visual/out/`, all under this prefix)
- `.github/workflows/build.yml`  (self-referential: any change to this workflow re-runs it)

**qt-webengine** runs when the PR touches:
- `ui/**`  (the job configures/builds `ui/c2pool-qt`)
- `src/**`, `CMakeLists.txt`, `conanfile*`, `cmake/**`  (over-inclusive on the C++/build surface — errs toward running)
- `.github/workflows/build.yml`

The filter is bypassed entirely on `push`, tag, and `workflow_dispatch`
(`|| github.event_name != 'pull_request'`), so the master rollup and
release builds always run the full set and stay authoritative.

### (b) No per-coin source-presence guard relaxed (#47 protection intact)
Only `web-static` and `qt-webengine` gain `needs: changes` + an `if:`.
No per-coin build/smoke job and none of the #47 source-presence guards
are touched. Diff is a single file (`.github/workflows/build.yml`, +35).

### Safety
None of the gated jobs are branch-protection required checks and nothing
`needs:` them — a skip reports as **Skipped**, never a false-green on a
required gate, with no downstream cascade. Required coin/consensus gates
are deliberately left unfiltered (that needs an always-run aggregator +
branch-protection re-point, tracked separately).