### PR TITLE
dash: a busy tracker must not forfeit the block-winning share (#889)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -1907,12 +1907,44 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     return uint256();
                 }
 
+                // #889: a WON BLOCK is unrepeatable — there is no next solve to
+                // mint instead, and an unminted block-winning share is a block
+                // no p2pool peer can ever see (they detect pool blocks by
+                // watching the sharechain for a share meeting the block target,
+                // p2pool/node.py:145-147). So the block arm takes a BOUNDED WAIT
+                // for the tracker; the ordinary share arm keeps today's single
+                // try-and-decline, which is the right trade when the next solve
+                // mints. THE BLOCK IS ALREADY SUBMITTED at this point — the
+                // won-block arm in work_source.cpp dispatches it before invoking
+                // this seam — so no wait here can delay or endanger it.
+                //
+                // #878/#881: this lambda holds ZERO locks on entry (stratum
+                // asio handler -> process_message -> handle_submit ->
+                // mining_submit -> mint seam; verified lock-free end to end),
+                // which is what makes a bounded wait viable instead of a
+                // deadlock. The guard below is scoped and RELEASED before
+                // add_local_share takes the exclusive lock — never nested.
+                const auto urgency = in.won_block
+                    ? dash::tracker_acquire::Urgency::BlockWinning
+                    : dash::tracker_acquire::Urgency::Opportunistic;
+
                 std::optional<dash::producer::BuiltShare> built;
                 {
-                    auto guard = node_ptr->read_tracker();
+                    auto guard = node_ptr->read_tracker(urgency);
                     if (!guard) {
-                        LOG_WARNING << "[MINT] tracker busy — solve declined "
-                                       "(retry on next share)";
+                        if (in.won_block) {
+                            LOG_ERROR << "[MINT-BLOCK] FORFEIT — tracker still "
+                                         "busy after "
+                                      << dash::tracker_acquire::
+                                             BLOCK_SHARE_LOCK_BUDGET.count()
+                                      << "ms; cannot even REBUILD the "
+                                         "block-winning share. The block was "
+                                         "already submitted, but no p2pool peer "
+                                         "will see it.";
+                        } else {
+                            LOG_WARNING << "[MINT] tracker busy — solve declined "
+                                           "(retry on next share)";
+                        }
                         return uint256();
                     }
                     built = dash::mint::mint_from_inputs(
@@ -1926,7 +1958,13 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
 
                 dash::ShareType share;
                 share = new dash::DashShare(std::move(built->share));
-                const uint256 minted = node_ptr->add_local_share(share);
+                // #889: same urgency for the tracker WRITE. add_local_share
+                // still returns ZERO if the bounded wait expires — the decline
+                // is preserved, it is just no longer silent (LOG_ERROR + a
+                // forfeit counter) and no longer triggered by a merely
+                // momentary think().
+                const uint256 minted =
+                    node_ptr->add_local_share(share, in.won_block);
                 if (minted.IsNull()) {
                     // Not inserted (busy/duplicate) — reclaim the allocation.
                     share.invoke([](auto* obj) { delete obj; });

--- a/src/impl/dash/node.cpp
+++ b/src/impl/dash/node.cpp
@@ -1374,20 +1374,65 @@ std::vector<uint256> NodeImpl::send_shares(peer_ptr peer,
     return sent;
 }
 
-uint256 NodeImpl::add_local_share(ShareType share)
+uint256 NodeImpl::add_local_share(ShareType share, bool block_winning)
 {
     const uint256 hash = share.hash();
     if (hash.IsNull())
         return uint256::ZERO;
 
     {
-        // Exclusive tracker lock, non-blocking (architectural rule): if the
-        // compute thread is mid-think, DECLINE the mint (fail-closed) — the
-        // miner keeps the pseudoshare credit, the next solve mints.
-        std::unique_lock lock(m_tracker_mutex, std::try_to_lock);
+        // Exclusive tracker lock.
+        //
+        // ORDINARY SHARE (block_winning == false) — UNCHANGED. Non-blocking
+        // (architectural rule, node.hpp): if the compute thread is mid-think,
+        // DECLINE the mint (fail-closed) — the miner keeps the pseudoshare
+        // credit, the next solve mints. That trade is correct and stays exactly
+        // as it was; tracker_acquire::exclusive() with Urgency::Opportunistic is
+        // literally the same single `try_to_lock`.
+        //
+        // BLOCK-WINNING SHARE (#889) — BOUNDED WAIT. There is no next solve: the
+        // block is found once, so a decline here permanently forfeits the
+        // highest-work share this node will ever produce. Worse, it is not only
+        // OUR share weight. p2pool nodes detect a pool block by watching for a
+        // SHARE with pow_hash <= header bits target (p2pool/node.py:145-147), so
+        // a block-winning share that never enters the sharechain is a block NO
+        // peer — not even our own oracle — can ever record. A momentarily busy
+        // tracker must not be allowed to do that.
+        //
+        // ⚠️ THE BLOCK IS ALREADY SUBMITTED BEFORE WE GET HERE. The won-block
+        // arm in stratum/work_source.cpp dispatches the block via
+        // submit_block_fn_ and only THEN calls the mint seam (#887/#888
+        // ordering, with an ordering-witness KAT pinning it). So whatever this
+        // wait costs, it can never delay, gate or endanger the block submit.
+        //
+        // #878/#881 GUARD: the compute thread already owns this mutex
+        // exclusively, so it must never wait on it. is_compute_thread() degrades
+        // the bounded path to a single try there. The live block-winning caller
+        // (main_dash.cpp's mint lambda, reached from the stratum handler via
+        // process_message -> handle_submit -> mining_submit) holds zero locks.
+        const auto urgency = block_winning
+            ? tracker_acquire::Urgency::BlockWinning
+            : tracker_acquire::Urgency::Opportunistic;
+        auto lock = tracker_acquire::exclusive(m_tracker_mutex, urgency,
+                                               is_compute_thread());
         if (!lock.owns_lock()) {
-            LOG_WARNING << "[MINT] tracker busy — local share "
-                        << hash.GetHex().substr(0, 16) << " declined (retry on next solve)";
+            if (block_winning) {
+                // LOUD + COUNTED. A silent drop is precisely the defect; this
+                // is the only remaining way a won block can go unseen, and it
+                // must be impossible to miss in a log or a dashboard.
+                m_block_share_lock_forfeits.fetch_add(1, std::memory_order_relaxed);
+                LOG_ERROR << "[MINT-BLOCK] FORFEIT — tracker still busy after "
+                          << tracker_acquire::BLOCK_SHARE_LOCK_BUDGET.count()
+                          << "ms; BLOCK-WINNING share "
+                          << hash.GetHex().substr(0, 16)
+                          << " NOT minted. The block itself was already "
+                             "submitted, but no p2pool peer will see it and its "
+                             "PPLNS weight is lost. forfeits="
+                          << m_block_share_lock_forfeits.load(std::memory_order_relaxed);
+            } else {
+                LOG_WARNING << "[MINT] tracker busy — local share "
+                            << hash.GetHex().substr(0, 16) << " declined (retry on next solve)";
+            }
             return uint256::ZERO;
         }
         if (m_chain->contains(hash)) {
@@ -1412,10 +1457,26 @@ uint256 NodeImpl::add_local_share(ShareType share)
                                                   m_known_txs);
             });
             if (!backable) {
-                LOG_WARNING << "[MINT] local share " << hash.GetHex().substr(0, 16)
-                            << " references template tx(s) no longer retained — "
-                               "declined (stale job past retention window; retry "
-                               "on next solve)";
+                // #889 scope note: this decline is NOT the lock hazard and is
+                // deliberately NOT bypassed for a block-winning share — minting
+                // a share whose txs we cannot serve would produce a share
+                // send_shares must withhold, i.e. the same invisibility by a
+                // different route. It is escalated to LOG_ERROR on the block
+                // path only so the loss is never quiet.
+                if (block_winning) {
+                    LOG_ERROR << "[MINT-BLOCK] BLOCK-WINNING share "
+                              << hash.GetHex().substr(0, 16)
+                              << " references template tx(s) no longer retained "
+                                 "— NOT minted (stale job past the retention "
+                                 "window). The block itself was already "
+                                 "submitted; this is a separate, non-lock "
+                                 "forfeit — see register_template_txs retention.";
+                } else {
+                    LOG_WARNING << "[MINT] local share " << hash.GetHex().substr(0, 16)
+                                << " references template tx(s) no longer retained — "
+                                   "declined (stale job past retention window; retry "
+                                   "on next solve)";
+                }
                 return uint256::ZERO;
             }
         }

--- a/src/impl/dash/node.hpp
+++ b/src/impl/dash/node.hpp
@@ -22,6 +22,7 @@
 #include "share_tracker.hpp"
 #include "peer.hpp"
 #include "min_protocol_gate.hpp"
+#include "tracker_acquire.hpp"       // #889: bounded acquisition — BLOCK-WINNING mint path only
 #include "auto_ratchet.hpp"          // dash::apply_min_protocol_ratchet_decision (v36 accept-floor ratchet)
 #include "version_negotiation.hpp"   // dash::version_negotiation::get_desired_version_weights (ratchet window)
 #include "messages.hpp"
@@ -243,6 +244,12 @@ protected:
     // Best-share election result — published by run_think() on the compute
     // thread under m_tracker_mutex (mirrors btc::NodeImpl::m_best_share_hash).
     uint256 m_best_share_hash;
+
+    // #889: block-winning mints forfeited because the BOUNDED wait on the
+    // exclusive tracker lock expired. Written from the stratum IO thread only,
+    // read from anywhere (dashboard/KAT) — atomic, relaxed; it is a diagnostic
+    // gauge, not a synchronisation point.
+    std::atomic<uint64_t> m_block_share_lock_forfeits{0};
 
     // ── v36 min-protocol accept-floor ratchet (#643/#646, mirrors dgb) ──────────
     // Runtime P2P accept-floor, seeded from the COLD config floor (1700, accept-all)
@@ -829,7 +836,29 @@ public:
     /// (+ LevelDB persist + attempt_verify), then broadcast + run_think.
     /// Returns the share hash, or ZERO when the tracker lock is busy or the
     /// share is a duplicate (fail-closed: caller declines the mint).
-    uint256 add_local_share(ShareType share);
+    ///
+    /// #889 `block_winning`: true ONLY when this solve already cleared the COIN
+    /// BLOCK target. That share is unrepeatable — there is no next solve — and a
+    /// share that is never minted is also a block no p2pool peer can ever see
+    /// (they detect pool blocks through the sharechain, not through a block
+    /// announcement). It therefore takes a BOUNDED WAIT on the exclusive lock
+    /// instead of the single try. false (the default) is the ordinary share
+    /// path: byte-for-byte today's `try_to_lock` decline, deliberately unchanged.
+    ///
+    /// CALLER CONTRACT (#878/#881): a `block_winning` caller MUST hold no
+    /// tracker lock. The block-arm caller (main_dash.cpp's mint lambda, reached
+    /// from the stratum handler) holds zero locks; the compute thread is guarded
+    /// against explicitly inside.
+    uint256 add_local_share(ShareType share, bool block_winning = false);
+
+    /// #889 observability: block-winning mints lost because the bounded wait on
+    /// the tracker expired. MUST stay 0 in production — every increment is one
+    /// won block that is invisible to the whole p2pool network. Each one also
+    /// emits a LOG_ERROR; this counter is what makes it aggregatable instead of
+    /// a line someone has to notice.
+    uint64_t block_share_lock_forfeits() const {
+        return m_block_share_lock_forfeits.load(std::memory_order_relaxed);
+    }
 
     /// Register the current template's txs in m_known_txs so send_shares can
     /// serve remember_tx for a minted share's new_transaction_hashes. The
@@ -1017,16 +1046,29 @@ public:
     /// RAII guard for IO-thread tracker reads.
     /// - IO thread:      acquires shared_lock(try_to_lock); falsy if busy.
     /// - Compute thread: skips locking (exclusive already held); always truthy.
+    ///
+    /// #889: an optional `urgency` selects a BOUNDED WAIT instead of the single
+    /// try. It defaults to Opportunistic, so every existing call site keeps
+    /// today's exact non-blocking behaviour; only the block-winning mint (which
+    /// has no "next solve" to fall back on) passes BlockWinning.
     class TrackerReadGuard {
         std::shared_lock<std::shared_mutex> lock_;
         ShareTracker& tracker_;
         bool ok_;
     public:
-        TrackerReadGuard(std::shared_mutex& mtx, ShareTracker& t, bool on_compute)
+        TrackerReadGuard(std::shared_mutex& mtx, ShareTracker& t, bool on_compute,
+                         tracker_acquire::Urgency urgency =
+                             tracker_acquire::Urgency::Opportunistic)
             : lock_(mtx, std::defer_lock), tracker_(t)
         {
-            if (on_compute) ok_ = true;          // exclusive lock already held
-            else            ok_ = lock_.try_lock();
+            if (on_compute) {
+                ok_ = true;                      // exclusive lock already held
+            } else if (urgency == tracker_acquire::Urgency::Opportunistic) {
+                ok_ = lock_.try_lock();          // unchanged: single try, skip if busy
+            } else {
+                lock_ = tracker_acquire::shared(mtx, urgency, /*on_compute=*/false);
+                ok_ = lock_.owns_lock();
+            }
         }
         TrackerReadGuard(TrackerReadGuard&&) = default;
         TrackerReadGuard(const TrackerReadGuard&) = delete;
@@ -1046,8 +1088,14 @@ public:
     /// Preferred tracker accessor for IO-thread callbacks. On the IO thread it
     /// acquires shared_lock(try_to_lock) (check `if (!guard)`); on the compute
     /// thread it skips locking (exclusive already held).
-    TrackerReadGuard read_tracker() {
-        return TrackerReadGuard(m_tracker_mutex, m_tracker, is_compute_thread());
+    ///
+    /// #889: pass tracker_acquire::Urgency::BlockWinning ONLY from a solve that
+    /// already cleared the BLOCK target, and ONLY from a caller holding zero
+    /// locks (#878/#881). Everything else keeps the default, i.e. no change.
+    TrackerReadGuard read_tracker(tracker_acquire::Urgency urgency =
+                                      tracker_acquire::Urgency::Opportunistic) {
+        return TrackerReadGuard(m_tracker_mutex, m_tracker, is_compute_thread(),
+                                urgency);
     }
 
     /// Acquire shared (reader) lock on the tracker mutex — BLOCKING. Only for

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -857,6 +857,12 @@ nlohmann::json DASHWorkSource::mining_submit(
             in.merkle_branches = std::move(branch_hashes);
             in.payout_script   = core::address_to_script(username);
             in.pow_hash        = pow_hash;
+            // #889: tell the mint binding this solve is a WON BLOCK, so it
+            // takes a bounded wait on the tracker rather than the ordinary
+            // try-and-decline. The block has already been dispatched above —
+            // this flag can only affect how hard we try to MINT, never the
+            // submit. On the share arm it stays false: unchanged behaviour.
+            in.won_block       = won_block;
             // ref_hash: the coinb1/coinb2 split sits immediately after the
             // 32-byte OP_RETURN ref_hash (before the 8B nonce64 slot), so the
             // commitment is the coinb1 tail. Raw LE-internal bytes — embedded

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -124,6 +124,16 @@ public:
         /// Template tx hex frozen with the job (shared, may be null) — the
         /// run-loop registers these for share relay (remember_tx serving).
         std::shared_ptr<const std::vector<std::string>> tx_data;
+        /// #889: this solve already cleared the COIN BLOCK target — the block
+        /// has ALREADY been dispatched by the time the mint seam is invoked
+        /// (#887/#888 ordering). It matters because the share is unrepeatable:
+        /// there is no next solve to mint instead, and p2pool peers detect a
+        /// pool block ONLY by seeing a share that meets the block target
+        /// (p2pool/node.py:145-147), so failing to mint it also makes the won
+        /// block invisible to the entire network. The mint binding uses this to
+        /// take a BOUNDED WAIT on the tracker instead of the ordinary
+        /// try-and-decline. false on the ordinary share arm — unchanged path.
+        bool                       won_block{false};
     };
     /// Returns the minted share hash, or null-uint256 when the mint was
     /// declined/deferred (reason logged by the callee).

--- a/src/impl/dash/tracker_acquire.hpp
+++ b/src/impl/dash/tracker_acquire.hpp
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// ═══════════════════════════════════════════════════════════════════════════
+//  Bounded tracker acquisition for the BLOCK-WINNING mint path (#889)
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// THE PROBLEM
+// -----------
+// Every IO-thread tracker acquisition in this node is `try_to_lock` and
+// DECLINES when the compute thread is mid-think() (node.hpp's synchronisation
+// contract: "IO thread reads: shared_lock(try_to_lock) — non-blocking, skip if
+// busy"). For an ordinary share that trade is sound — the decline costs one
+// share and the NEXT solve mints instead.
+//
+// A block-winning share has no next solve. The block is found once, so a
+// momentarily busy tracker permanently forfeits the highest-work share the node
+// will ever produce. And because p2pool nodes detect pool blocks THROUGH the
+// sharechain (p2pool/node.py:145-147 fires only for a share with
+// `pow_hash <= header['bits'].target`), a share that is never minted is a block
+// that no peer — including our own oracle — can ever see. The decline is
+// therefore not merely share-weight loss: it reproduces the FULL #887 symptom,
+// just intermittently.
+//
+// THE SHAPE OF THE FIX
+// --------------------
+// Make the acquisition BOUNDED-BLOCKING on the block-winning path ONLY. The
+// ordinary share path keeps `Urgency::Opportunistic`, i.e. exactly today's
+// single `try_lock` with no behavioural change whatsoever.
+//
+// WHY POLLED try_lock AND NOT A BLOCKING lock()
+// ---------------------------------------------
+//  * It must be BOUNDED. An unbounded `lock()` on the stratum IO thread would
+//    stall every other miner's submissions for as long as the compute thread
+//    wanted, with no ceiling and no diagnostic.
+//  * `std::shared_mutex` has NO timed acquire — that is `std::shared_timed_mutex`.
+//    Switching the type would rewrite ~30 explicit `std::shared_lock<std::shared_mutex>`
+//    reader-discipline call sites across node.hpp/node.cpp, i.e. a far larger and
+//    riskier diff than the defect warrants on a live reward path.
+//  * A poll loop keeps the mutex type, the reader discipline and every existing
+//    call site byte-identical, and gives an exact, testable deadline.
+//
+// COST OF THE POLL: at BLOCK_SHARE_LOCK_POLL = 200 us the worst case is 10 000
+// wakeups over the full 2 s budget; the EXPECTED case is one think() tail
+// (measured p50 125 ms => ~625 wakeups). Both are noise against a solved block.
+//
+// FAIRNESS, HONESTLY STATED: polled try_lock is not fair. A writer poll can in
+// principle be starved by an unbroken stream of shared readers. Every shared
+// reader on this mutex is itself an IO-thread `try_to_lock` that holds for
+// microseconds (an advert walk, a stats read), so unbroken coverage for 2 s is
+// not a realistic state — and if it ever happened the bound converts it into a
+// LOGGED, COUNTED forfeit rather than a wedged IO thread. That is strictly
+// better than today, where the same situation is a silent drop.
+//
+// ⚠️ #878/#881 DEFECT CLASS — READ BEFORE ADDING A CALLER
+// -------------------------------------------------------
+// A caller that already holds the tracker lock and then calls into a
+// self-locking callee makes the callee dead code; making that callee BLOCKING
+// turns dead code into a DEADLOCK. Every `Urgency::BlockWinning` call site must
+// therefore hold ZERO locks on entry. The two live ones (main_dash.cpp's mint
+// lambda and NodeImpl::add_local_share) are reached from the stratum handler
+// at lock depth zero — see the trace in the PR. `on_compute_thread` below is
+// the belt-and-braces guard: the compute thread already owns the exclusive
+// lock, so it NEVER waits here.
+
+#include <atomic>
+#include <chrono>
+#include <mutex>
+#include <shared_mutex>
+#include <thread>
+
+namespace dash {
+namespace tracker_acquire {
+
+/// How badly the caller needs the lock.
+enum class Urgency {
+    /// Today's behaviour, unchanged: one `try_lock`, decline if busy.
+    /// Correct for ordinary shares — the next solve mints.
+    Opportunistic,
+    /// Bounded wait. ONLY for a solve that already cleared the BLOCK target:
+    /// there is no next solve, so a decline is permanent and also hides the
+    /// block from every p2pool peer.
+    BlockWinning,
+};
+
+/// Wait budget for a block-winning acquisition.
+///
+/// RATIONALE — measured, not guessed. From a 42 h DASH sharechain soak
+/// (`[ASYNC-THINK] compute done in Nms`, n = 6721 think cycles, post-join
+/// steady state):
+///
+///     p50 = 125 ms   p90 = 193 ms   p99 = 300 ms   p99.9 = 512 ms   max = 1074 ms
+///     > 500 ms: 8 cycles (0.119%)   > 750 ms: 3 (0.045%)   > 1000 ms: 1 (0.015%)
+///
+/// 2000 ms covers 100% of the observed steady-state distribution with ~1.9x
+/// headroom over the single worst cycle. It is deliberately NOT tighter: the
+/// exclusive hold also covers publish_snapshot() + flush_verified_to_leveldb()
+/// (a little beyond the logged think_ms), and clean_tracker() takes the same
+/// exclusive lock for a think + stale-head eat + tail drop + LevelDB prune that
+/// this build does not time at all. Against an unmeasured second holder, the
+/// safe direction is more headroom, because the failure mode of a too-tight
+/// budget is exactly the loss we are fixing.
+///
+/// It is also deliberately NOT looser. During the first ~5 minutes after a
+/// cold join the same log shows think cycles of 6–15 s (the bootstrap
+/// full-verify pass over an empty verified set). A budget that covered THOSE
+/// would stall the stratum IO thread for 15 s. A node in bootstrap has no
+/// sharechain to mint onto and is not winning blocks, so covering that state is
+/// worthless — capping below it is the point of having a bound at all.
+inline constexpr std::chrono::milliseconds BLOCK_SHARE_LOCK_BUDGET{2000};
+
+/// Re-poll interval while waiting. 200 us is ~0.16% of the p50 think tail, so
+/// the added latency over a true blocking acquire is immaterial, and 10 000
+/// wakeups is the worst-case ceiling.
+inline constexpr std::chrono::microseconds BLOCK_SHARE_LOCK_POLL{200};
+
+/// Bounded EXCLUSIVE acquisition.
+///
+/// Returns an owning `unique_lock` on success, or a NON-owning one on expiry —
+/// callers MUST check `owns_lock()` exactly as they check it today, so an
+/// expired budget degrades to precisely the pre-#889 decline (never a silent
+/// or unchecked proceed).
+///
+/// `on_compute_thread` is the #878/#881 guard: the compute thread already holds
+/// this mutex exclusively, so it degrades to a single try and never waits.
+template <class Mutex>
+std::unique_lock<Mutex> exclusive(
+    Mutex& m,
+    Urgency urgency,
+    bool on_compute_thread = false,
+    std::chrono::milliseconds budget = BLOCK_SHARE_LOCK_BUDGET,
+    std::chrono::microseconds poll   = BLOCK_SHARE_LOCK_POLL)
+{
+    std::unique_lock<Mutex> lock(m, std::try_to_lock);
+    if (lock.owns_lock() || urgency == Urgency::Opportunistic || on_compute_thread
+        || budget <= std::chrono::milliseconds::zero())
+        return lock;
+
+    const auto deadline = std::chrono::steady_clock::now() + budget;
+    while (std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(poll);
+        if (lock.try_lock())
+            return lock;
+    }
+    return lock;   // non-owning — budget expired, caller declines + counts it
+}
+
+/// Bounded SHARED acquisition. Same contract as `exclusive` above.
+template <class Mutex>
+std::shared_lock<Mutex> shared(
+    Mutex& m,
+    Urgency urgency,
+    bool on_compute_thread = false,
+    std::chrono::milliseconds budget = BLOCK_SHARE_LOCK_BUDGET,
+    std::chrono::microseconds poll   = BLOCK_SHARE_LOCK_POLL)
+{
+    std::shared_lock<Mutex> lock(m, std::try_to_lock);
+    if (lock.owns_lock() || urgency == Urgency::Opportunistic || on_compute_thread
+        || budget <= std::chrono::milliseconds::zero())
+        return lock;
+
+    const auto deadline = std::chrono::steady_clock::now() + budget;
+    while (std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(poll);
+        if (lock.try_lock())
+            return lock;
+    }
+    return lock;
+}
+
+} // namespace tracker_acquire
+} // namespace dash

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -307,6 +307,14 @@ if (BUILD_TESTING AND GTest_FOUND)
         ${Boost_LIBRARIES}
     )
     target_link_libraries(test_dash_node PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining c2pool_storage pool)  # OBJECT-lib SCC direct-naming (#22/#39)
+    # #889: the block-winning-mint KATs drive the REAL NodeImpl::add_local_share
+    # against the REAL m_tracker_mutex held exclusively by another thread, so
+    # this target now needs the `dash` OBJECT lib (node.cpp) it previously only
+    # type-checked against. No new add_executable — folded into the existing
+    # allowlisted target. `dash`'s own deps (core pool sharechain c2pool_storage
+    # dash_x11 btclibs json boost secp256k1) are already on this line or come in
+    # transitively; nothing outside src/impl/dash is added.
+    target_link_libraries(test_dash_node PRIVATE dash sharechain)
     gtest_add_tests(test_dash_node "" AUTO)
 
     # DASH S8 per-miner work-target MODULATION KAT (work.py:308-326 oracle pin):

--- a/test/test_dash_node.cpp
+++ b/test/test_dash_node.cpp
@@ -207,3 +207,252 @@ TEST(DashNodeDispatch, NodeBridgeAliasBindsLegacyActual)
                   "Actual must derive from NodeImpl");
     SUCCEED();
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// #889 — the BLOCK-WINNING mint must not be forfeited by a momentarily busy
+//        tracker.
+//
+// THE DEFECT. add_local_share() acquires the exclusive tracker lock with
+// std::try_to_lock and DECLINES when the compute thread is mid-think(). For an
+// ordinary share that is a sound trade: the decline costs one share and the
+// NEXT solve mints instead. A block-winning share has no next solve — the block
+// is found once — so the same decline permanently forfeits the highest-work
+// share the node will ever produce.
+//
+// AND IT IS NOT ONLY OUR SHARE WEIGHT. p2pool nodes do not learn about a pool
+// block from a block announcement; they detect it THROUGH THE SHARECHAIN, by
+// watching for a share with pow_hash <= header['bits'].target
+// (p2pool/node.py:145-147). A block-winning share that never enters the
+// sharechain is therefore a won block that NO peer — including our own oracle —
+// can ever record. The try_to_lock decline reproduces the full #887 symptom,
+// just intermittently and far harder to notice.
+//
+// WHAT THESE TESTS PIN. Nothing existing covers this: every prior mint KAT runs
+// against a FREE tracker, where try_to_lock and a bounded wait are
+// indistinguishable. These hold the real m_tracker_mutex EXCLUSIVELY from
+// another thread — exactly the state think() puts it in — and drive the mint.
+//
+//   1. block-winning  + tracker held -> the share STILL LANDS (this is the fix)
+//   2. ordinary share + tracker held -> still declines (the trade we must NOT
+//      change; also the negative control that proves test 1 is not passing
+//      merely because the lock happened to be free)
+//   3. budget expiry  -> declines LOUDLY and COUNTED, never silently
+//
+// NOTE (#895): these are plain TESTs, not #ifdef-guarded, so gtest_add_tests
+// (AUTO) registers cases that genuinely execute.
+
+#include <impl/dash/tracker_acquire.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+namespace {
+
+// Minimal locally-minted share. add_local_share() only needs a non-null
+// identity hash and (for the F1-sub backability gate) an empty
+// m_new_transaction_hashes — everything the real producer builds on top of that
+// is share CONSTRUCTION, which #889 does not touch. Heap-allocated because
+// dash::ShareType is a non-owning variant handle: the tracker takes ownership
+// on a successful add, and the caller reclaims on a decline (main_dash.cpp).
+dash::ShareType make_local_share(unsigned char tag)
+{
+    auto* s = new dash::DashShare();
+    // NB uint256::begin() is a uint32_t* over 8 WORDS (core/uint256.hpp), not a
+    // byte pointer. Word 7 is the most significant, so it renders first in
+    // GetHex() -- the share is then identifiable in the very log lines these
+    // tests pin the behaviour of.
+    s->m_hash.begin()[7] = 0x89000000u | static_cast<uint32_t>(tag);
+    return dash::ShareType(s);
+}
+
+void discard(dash::ShareType& share)
+{
+    share.invoke([](auto* obj) { delete obj; });
+}
+
+// Holds the node's REAL exclusive tracker lock for `hold`, i.e. reproduces a
+// think() cycle in flight. Signals once the lock is actually held so the test
+// body can never race ahead of it.
+class ExclusiveTrackerHolder {
+public:
+    ExclusiveTrackerHolder(std::shared_mutex& mtx, std::chrono::milliseconds hold)
+    {
+        thread_ = std::thread([this, &mtx, hold] {
+            std::unique_lock<std::shared_mutex> lk(mtx);
+            held_.store(true);
+            std::this_thread::sleep_for(hold);
+            held_.store(false);
+        });
+        // Spin until the lock is genuinely held — no sleep-and-hope.
+        while (!held_.load())
+            std::this_thread::sleep_for(std::chrono::microseconds(100));
+    }
+    ~ExclusiveTrackerHolder() { if (thread_.joinable()) thread_.join(); }
+private:
+    std::atomic<bool> held_{false};
+    std::thread thread_;
+};
+
+} // namespace
+
+// 9. ★ THE REGRESSION. Tracker held EXCLUSIVELY; a block-winning mint still
+//    lands. Pre-#889 this returned ZERO and the share — and with it every
+//    peer's only way of seeing the block — was gone for good.
+TEST(DashBlockWinningMint, LandsWhileTrackerHeldExclusively)
+{
+    TestNode node;
+    ASSERT_EQ(node.tracker().chain.size(), 0u);
+
+    constexpr auto kHold = std::chrono::milliseconds(400);
+    const auto t0 = std::chrono::steady_clock::now();
+
+    uint256 minted;
+    {
+        ExclusiveTrackerHolder holder(node.tracker_mutex(), kHold);
+        auto share = make_local_share(0xB1);
+        minted = node.add_local_share(share, /*block_winning=*/true);
+        if (minted.IsNull())
+            discard(share);
+    }
+    const auto waited = std::chrono::steady_clock::now() - t0;
+
+    // The share landed.
+    EXPECT_FALSE(minted.IsNull())
+        << "block-winning share forfeited by a busy tracker (#889)";
+    EXPECT_EQ(node.tracker().chain.size(), 1u);
+    // No forfeit was recorded — the wait succeeded, it did not merely give up.
+    EXPECT_EQ(node.block_share_lock_forfeits(), 0u);
+
+    // It genuinely WAITED for the holder rather than finding a free lock: the
+    // call could not have returned before the holder released. This is what
+    // makes the test a real exercise of the bounded acquire and not an
+    // accidental pass on an idle mutex.
+    EXPECT_GE(waited, kHold - std::chrono::milliseconds(50));
+}
+
+// 10. THE TRADE WE MUST NOT CHANGE (and the in-tree negative control for #9):
+//     an ORDINARY share under the identical held lock still declines, exactly
+//     as before. If #9 ever passed because the lock was free, this would fail
+//     alongside it.
+TEST(DashBlockWinningMint, OrdinaryShareStillDeclinesWhileTrackerHeld)
+{
+    TestNode node;
+
+    uint256 minted;
+    {
+        ExclusiveTrackerHolder holder(node.tracker_mutex(),
+                                      std::chrono::milliseconds(400));
+        auto share = make_local_share(0xC2);
+        minted = node.add_local_share(share, /*block_winning=*/false);
+        if (minted.IsNull())
+            discard(share);
+    }
+
+    EXPECT_TRUE(minted.IsNull())
+        << "the ordinary share path must keep today's try_to_lock decline";
+    EXPECT_EQ(node.tracker().chain.size(), 0u);
+    EXPECT_EQ(node.block_share_lock_forfeits(), 0u);
+}
+
+// 11. Default argument keeps every existing caller on the ordinary path — the
+//     fix cannot leak into share traffic by omission.
+TEST(DashBlockWinningMint, DefaultArgumentIsTheOpportunisticPath)
+{
+    TestNode node;
+
+    uint256 minted;
+    {
+        ExclusiveTrackerHolder holder(node.tracker_mutex(),
+                                      std::chrono::milliseconds(300));
+        auto share = make_local_share(0xD3);
+        minted = node.add_local_share(share);   // no second argument
+        if (minted.IsNull())
+            discard(share);
+    }
+    EXPECT_TRUE(minted.IsNull());
+}
+
+// 12. THE BOUND IS REAL AND THE FORFEIT IS LOUD. Hold the tracker past the
+//     whole budget: the mint declines (fail-closed, unchanged end state) but
+//     now increments a counter and logs at ERROR. A silent drop is the defect;
+//     an accounted one is the fix's failure mode.
+//
+//     Runtime is BLOCK_SHARE_LOCK_BUDGET + margin by construction — that is the
+//     property under test, not incidental slowness.
+TEST(DashBlockWinningMint, BudgetExpiryIsACountedForfeitNotASilentDrop)
+{
+    TestNode node;
+    ASSERT_EQ(node.block_share_lock_forfeits(), 0u);
+
+    const auto over_budget =
+        dash::tracker_acquire::BLOCK_SHARE_LOCK_BUDGET
+        + std::chrono::milliseconds(300);
+
+    uint256 minted;
+    std::chrono::steady_clock::duration waited{};
+    {
+        ExclusiveTrackerHolder holder(node.tracker_mutex(), over_budget);
+        auto share = make_local_share(0xE4);
+        const auto t0 = std::chrono::steady_clock::now();
+        minted = node.add_local_share(share, /*block_winning=*/true);
+        waited = std::chrono::steady_clock::now() - t0;
+        if (minted.IsNull())
+            discard(share);
+    }
+
+    EXPECT_TRUE(minted.IsNull());
+    // It spent the WHOLE budget before giving up — not an instant try_to_lock
+    // decline wearing a counter. (This is also what keeps the test a fix
+    // detector: without the bounded wait it returns in ~0 ms.)
+    EXPECT_GE(waited, dash::tracker_acquire::BLOCK_SHARE_LOCK_BUDGET
+                          - std::chrono::milliseconds(100));
+    EXPECT_EQ(node.tracker().chain.size(), 0u);
+    EXPECT_EQ(node.block_share_lock_forfeits(), 1u)
+        << "an expired budget must be COUNTED, not dropped silently";
+}
+
+// 13. The acquisition primitive itself: Opportunistic is one try (today's
+//     behaviour, bit-for-bit), BlockWinning waits, and the compute-thread guard
+//     never waits — the #878/#881 deadlock hazard, closed at the source.
+TEST(DashBlockWinningMint, AcquirePrimitiveContract)
+{
+    using namespace dash::tracker_acquire;
+    std::shared_mutex mtx;
+
+    {   // free mutex: both urgencies succeed immediately
+        auto a = exclusive(mtx, Urgency::Opportunistic);
+        EXPECT_TRUE(a.owns_lock());
+    }
+    {
+        auto a = exclusive(mtx, Urgency::BlockWinning);
+        EXPECT_TRUE(a.owns_lock());
+    }
+
+    {   // held mutex: Opportunistic gives up at once, BlockWinning waits it out
+        ExclusiveTrackerHolder holder(mtx, std::chrono::milliseconds(250));
+        {
+            auto a = exclusive(mtx, Urgency::Opportunistic);
+            EXPECT_FALSE(a.owns_lock());
+        }
+        {
+            // Compute-thread guard: already owns the exclusive lock, so it must
+            // NEVER wait here — waiting would be the #878/#881 self-deadlock.
+            auto a = exclusive(mtx, Urgency::BlockWinning,
+                               /*on_compute_thread=*/true);
+            EXPECT_FALSE(a.owns_lock());
+        }
+        {
+            auto a = exclusive(mtx, Urgency::BlockWinning);
+            EXPECT_TRUE(a.owns_lock());
+        }
+    }
+
+    {   // budget expiry returns a NON-OWNING lock, so callers decline exactly
+        // as they do today rather than proceeding unlocked
+        ExclusiveTrackerHolder holder(mtx, std::chrono::milliseconds(400));
+        auto a = exclusive(mtx, Urgency::BlockWinning, /*on_compute_thread=*/false,
+                           std::chrono::milliseconds(50));
+        EXPECT_FALSE(a.owns_lock());
+    }
+}

--- a/test/test_dash_stratum_work_source.cpp
+++ b/test/test_dash_stratum_work_source.cpp
@@ -23,6 +23,7 @@
 #include <impl/dash/coin/zmq_tip_notify.hpp>  // dash::coin::TipHashDedup, zmq_hashblock_frame_to_hex (ZMQ hashblock instant tip-notify)
 #include <impl/dash/crypto/hash_x11.hpp>
 #include <impl/dash/params.hpp>
+#include <impl/dash/tracker_acquire.hpp>            // #889 bounded block-winning acquisition
 #include <impl/dash/coin/vendor/simplifiedmns.hpp>  // CSimplifiedMNListEntry (embedded SML seed)
 #include <impl/dash/coin/vendor/cbtx.hpp>           // parse_cbtx (read served creditPool)
 #include <impl/dash/coin/embedded_gbt.hpp>          // encode_cbtx (GBT-xcheck fallback fixture)
@@ -38,11 +39,13 @@
 
 #include <algorithm>
 #include <atomic>
+#include <chrono>
 #include <cstring>
 #include <functional>
 #include <stdexcept>
 #include <memory>
 #include <mutex>
+#include <shared_mutex>
 #include <span>
 #include <string>
 #include <thread>
@@ -725,6 +728,230 @@ TEST(DashStratumWorkSource, MiningSubmitWonBlockDispatchesBeforeAndDespiteAThrow
     // Won block still answers the miner with the accepted reply.
     ASSERT_TRUE(result.is_boolean());
     EXPECT_TRUE(result.get<bool>());
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// #889 -- a BUSY TRACKER must not forfeit the block-winning share.
+//
+// #888 made the block arm REACH the mint seam. This is about that mint then
+// being DECLINED: every tracker acquisition on the mint path is try_to_lock and
+// gives up if the compute thread is mid-think(). For an ordinary share that is
+// right -- the next solve mints. A block-winning share has no next solve, so
+// the same decline is permanent, and because p2pool peers detect a pool block
+// by watching the sharechain for a share meeting the block target
+// (p2pool/node.py:145-147), the won block also becomes invisible to every node
+// on the network. A momentary lock contention reproduces the whole #887
+// symptom.
+//
+// The seam carries `won_block` so the mint binding can take a BOUNDED WAIT on
+// that path ONLY. These pin (a) the flag actually reaches the mint, set on the
+// block arm and clear on the share arm, and (b) end to end through
+// mining_submit: with the tracker HELD EXCLUSIVELY by another thread, a
+// block-target submit still lands its share while an ordinary one still
+// declines.
+// ═════════════════════════════════════════════════════════════════════════════
+
+// The block arm marks the solve as block-winning; nothing else about the mint
+// inputs changes.
+TEST(DashStratumWorkSource, MiningSubmitWonBlockFlagsTheMintAsBlockWinning)
+{
+    SubmitRig rig;
+    rig.job.share_bits  = 0x207fffffu;
+    rig.job.block_nbits = "207fffff";
+    const uint256 block_target = dash::coin::target_from_nbits(0x207fffffu);
+    const uint32_t nonce = rig.find_nonce([&](const uint256& pow) {
+        return pow <= block_target;
+    });
+
+    bool mint_called = false;
+    bool seen_won_block = false;
+    rig.ws->set_mint_share_fn(
+        [&](const dash::stratum::DASHWorkSource::MintShareInputs& in) -> uint256 {
+            mint_called = true;
+            seen_won_block = in.won_block;
+            uint256 h;
+            h.SetHex("6666666666666666666666666666666666666666666666666666666666666666");
+            return h;
+        });
+
+    auto result = rig.submit(nonce);
+    ASSERT_TRUE(result.is_boolean());
+    EXPECT_TRUE(result.get<bool>());
+    ASSERT_TRUE(rig.fx.submit_called);      // block out first, unchanged
+    ASSERT_TRUE(mint_called);
+    EXPECT_TRUE(seen_won_block)
+        << "the mint seam must be told this solve already won a block -- "
+           "without it the binding cannot know a decline is permanent (#889)";
+}
+
+// ...and the ordinary share arm does NOT. This is the guard that the bounded
+// wait can never leak onto ordinary share traffic, where try-and-decline is
+// the correct trade and must stay exactly as it is.
+TEST(DashStratumWorkSource, MiningSubmitOrdinaryShareIsNotFlaggedBlockWinning)
+{
+    SubmitRig rig;
+    // Easy share target, impossible block target -> deterministic share arm.
+    rig.job.share_bits  = 0x207fffffu;
+    rig.job.block_nbits = "1d00ffff";
+    const uint256 share_target = dash::coin::target_from_nbits(0x207fffffu);
+    const uint256 block_target = dash::coin::target_from_nbits(0x1d00ffffu);
+    const uint32_t nonce = rig.find_nonce([&](const uint256& pow) {
+        return pow <= share_target && pow > block_target;
+    });
+
+    bool mint_called = false;
+    bool seen_won_block = true;             // must be overwritten with false
+    rig.ws->set_mint_share_fn(
+        [&](const dash::stratum::DASHWorkSource::MintShareInputs& in) -> uint256 {
+            mint_called = true;
+            seen_won_block = in.won_block;
+            uint256 h;
+            h.SetHex("7777777777777777777777777777777777777777777777777777777777777777");
+            return h;
+        });
+
+    auto result = rig.submit(nonce);
+    ASSERT_TRUE(result.is_boolean());
+    EXPECT_TRUE(result.get<bool>());
+    EXPECT_FALSE(rig.fx.submit_called);     // not a block
+    ASSERT_TRUE(mint_called);
+    EXPECT_FALSE(seen_won_block);
+}
+
+// ★ THE REGRESSION, end to end through mining_submit: the tracker is HELD
+//   EXCLUSIVELY by another thread for the whole call -- exactly the state
+//   think() puts it in -- and a block-target submit STILL lands its share.
+//
+//   The bound mint here mirrors the production binding's lock discipline
+//   (main_dash.cpp): it derives urgency from in.won_block and acquires through
+//   the SAME dash::tracker_acquire helper the live path uses, so what is under
+//   test is the shipped mechanism, not a stand-in for it.
+//
+//   The paired ordinary-share case is the negative control: identical held
+//   lock, identical helper, and it declines -- which is what proves the block
+//   case is not passing merely because the mutex happened to be free.
+TEST(DashStratumWorkSource, WonBlockShareMintsThroughAnExclusivelyHeldTracker)
+{
+    std::shared_mutex tracker_mutex;        // stands in for NodeImpl::m_tracker_mutex
+
+    // Holder thread: takes the exclusive lock and keeps it, like a think()
+    // cycle in flight. Spin-wait until it is genuinely held so the submit can
+    // never race ahead of it.
+    std::atomic<bool> held{false};
+    std::atomic<bool> stop{false};
+    std::thread holder([&] {
+        std::unique_lock<std::shared_mutex> lk(tracker_mutex);
+        held.store(true);
+        while (!stop.load())
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    });
+    while (!held.load())
+        std::this_thread::sleep_for(std::chrono::microseconds(100));
+
+    // Release the tracker shortly after the submit begins -- a think() cycle
+    // ends, it does not last forever. A try_to_lock mint gives up instantly and
+    // loses the share; a bounded one rides it out.
+    std::thread releaser([&] {
+        std::this_thread::sleep_for(std::chrono::milliseconds(250));
+        stop.store(true);
+    });
+
+    auto mint_under_lock =
+        [&](const dash::stratum::DASHWorkSource::MintShareInputs& in) -> uint256 {
+            const auto urgency = in.won_block
+                ? dash::tracker_acquire::Urgency::BlockWinning
+                : dash::tracker_acquire::Urgency::Opportunistic;
+            auto lk = dash::tracker_acquire::exclusive(tracker_mutex, urgency);
+            if (!lk.owns_lock())
+                return uint256();           // declined -- share lost
+            uint256 h;
+            h.SetHex("8888888888888888888888888888888888888888888888888888888888888888");
+            return h;                        // minted
+        };
+
+    // --- the block arm ---
+    SubmitRig rig;
+    rig.job.share_bits  = 0x207fffffu;
+    rig.job.block_nbits = "207fffff";
+    const uint256 block_target = dash::coin::target_from_nbits(0x207fffffu);
+    const uint32_t nonce = rig.find_nonce([&](const uint256& pow) {
+        return pow <= block_target;
+    });
+
+    bool minted = false;
+    bool block_was_out_before_the_wait = false;
+    rig.ws->set_mint_share_fn(
+        [&](const dash::stratum::DASHWorkSource::MintShareInputs& in) -> uint256 {
+            // ORDERING WITNESS: whatever the wait below costs, the block has
+            // ALREADY been dispatched. This is the invariant #888 established
+            // and #889 must not regress -- if a bounded wait ever moved ahead
+            // of the submit, this flips false.
+            block_was_out_before_the_wait = rig.fx.submit_called;
+            const uint256 h = mint_under_lock(in);
+            minted = !h.IsNull();
+            return h;
+        });
+
+    auto result = rig.submit(nonce);
+
+    holder.join();
+    releaser.join();
+
+    ASSERT_TRUE(result.is_boolean());
+    EXPECT_TRUE(result.get<bool>());
+    ASSERT_TRUE(rig.fx.submit_called);
+    EXPECT_TRUE(block_was_out_before_the_wait)
+        << "the block submit must remain strictly first and unconditional";
+    EXPECT_TRUE(minted)
+        << "a busy tracker forfeited the block-winning share -- the block is "
+           "then invisible to every p2pool peer (#889)";
+}
+
+// Negative control for the test above: same helper, same permanently-held
+// tracker, ORDINARY share -> declines, unchanged from today.
+TEST(DashStratumWorkSource, OrdinaryShareStillDeclinesThroughAHeldTracker)
+{
+    std::shared_mutex tracker_mutex;
+    std::atomic<bool> held{false};
+    std::atomic<bool> stop{false};
+    std::thread holder([&] {
+        std::unique_lock<std::shared_mutex> lk(tracker_mutex);
+        held.store(true);
+        while (!stop.load())
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    });
+    while (!held.load())
+        std::this_thread::sleep_for(std::chrono::microseconds(100));
+
+    SubmitRig rig;
+    rig.job.share_bits  = 0x207fffffu;
+    rig.job.block_nbits = "1d00ffff";
+    const uint256 share_target = dash::coin::target_from_nbits(0x207fffffu);
+    const uint256 block_target = dash::coin::target_from_nbits(0x1d00ffffu);
+    const uint32_t nonce = rig.find_nonce([&](const uint256& pow) {
+        return pow <= share_target && pow > block_target;
+    });
+
+    bool minted = true;
+    rig.ws->set_mint_share_fn(
+        [&](const dash::stratum::DASHWorkSource::MintShareInputs& in) -> uint256 {
+            const auto urgency = in.won_block
+                ? dash::tracker_acquire::Urgency::BlockWinning
+                : dash::tracker_acquire::Urgency::Opportunistic;
+            auto lk = dash::tracker_acquire::exclusive(tracker_mutex, urgency);
+            minted = lk.owns_lock();
+            return uint256();
+        });
+
+    auto result = rig.submit(nonce);
+    stop.store(true);
+    holder.join();
+
+    ASSERT_TRUE(result.is_boolean());
+    EXPECT_TRUE(result.get<bool>());
+    EXPECT_FALSE(rig.fx.submit_called);
+    EXPECT_FALSE(minted)
+        << "ordinary shares must keep the try-and-decline trade (#889 scope)";
 }
 
 // ═════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Addresses the **dash lane** of #889.

> ⚠️ **#889 MUST NOT BE AUTO-CLOSED BY THIS MERGE.** There is deliberately no `Fixes`/`Closes` keyword above: this PR fixes **dash only**. `btc` and `bch` remain exposed to the identical defect and `dgb` inherits it the moment #884 lands. See [Scope](#scope). Please close #889 by hand only once those lanes are done, or split them into follow-up issues first.

**Rebased onto master** (`22e8c692`) now that #888 has squash-merged as `3e8a88c9`. This branch previously carried #888's original commits; those were dropped with `git rebase --onto origin/master 3866a460`, which replayed cleanly with **no conflicts** — the two files the merge route conflicted in (`src/impl/dash/stratum/work_source.cpp`, `test/test_dash_stratum_work_source.cpp`) were the same content arriving twice, which a rebase simply does not have to reconcile. The diff is now **only** the #889 work: the `Urgency` enum, `tracker_acquire.hpp`, the 2000 ms bound, the `on_compute_thread` guard, the forfeit counter, and the tests.

<details>
<summary><b>Post-rebase verification (all five coordinator checks, re-run on the rebased tree)</b></summary>

**1. Block-arm ordering still block-dispatch-FIRST.** Unchanged and confirmed by line order in the rebased `work_source.cpp`: `submit_block_fn_(block_bytes, ...)` at **:1013** → dashboard `fb_fn(height, ...)` at **:1037** → `mint_solved_share(/*won_block=*/true)` at **:1053** → `bump(true)` / `return` at **:1055-1056**. My entire change to that file is a **6-line addition** inside the already-downstream helper — `git diff origin/master...HEAD -- src/impl/dash/stratum/work_source.cpp` is one hunk, `in.won_block = won_block;` plus its comment. Nothing was moved or reordered.

**2. The `submit_called`-before-mint ordering KATs pass.**
```
[ OK ] DashStratumWorkSource.MiningSubmitWonBlockAlsoMintsTheShare                        (0 ms)
[ OK ] DashStratumWorkSource.MiningSubmitWonBlockDispatchesBeforeAndDespiteAThrowingMint  (0 ms)
[ OK ] DashStratumWorkSource.WonBlockShareMintsThroughAnExclusivelyHeldTracker          (251 ms)
```
The third is mine and carries its own ordering witness: it reads `rig.fx.submit_called` at the instant the mint runs, **before** it waits, and asserts it was already `true`.

**3. `Urgency::Opportunistic` is still what the ordinary share path gets.** Audited by grep rather than by eye, because the coordinator is right that this would not necessarily fail a test:
- `add_local_share(ShareType share, bool block_winning = false)` — default `false`.
- `read_tracker(Urgency = Urgency::Opportunistic)` — default Opportunistic.
- **Every** `read_tracker(` call site in `src/` is bare `read_tracker()` except exactly one: `main_dash.cpp:1933`, the mint lambda, which passes the urgency derived from `in.won_block`.
- `add_local_share` has exactly **one** production caller — `main_dash.cpp:1967` — which passes `in.won_block`.
- `Urgency::Opportunistic` short-circuits before the wait loop in both `tracker_acquire::exclusive` and `::shared`, so it is literally one `try_to_lock`.

Behaviourally pinned too: `OrdinaryShareStillDeclinesWhileTrackerHeld` and `DefaultArgumentIsTheOpportunisticPath` both drive a held tracker and assert the decline still happens.

**4. `mint_solved_share`'s single-call contract survives.** The two `std::move`s (`branch_hashes` at :857, `coinbase` at :883) are inside the helper, and the helper has exactly **two** call sites — `:1053` (block arm) and `:1064` (share arm) — in mutually exclusive classify arms, the block arm returning at `:1056` before the share arm is reachable. At most one invocation per `mining_submit`, unchanged from #888.

**5. Negative control still shows the same pairing** — see [Negative control](#negative-control) below, re-run on the rebased tree with identical results: 4 block-path tests red, all 4 ordinary-path controls green.

Full suites re-run post-rebase: `test_dash_node` **13/13**, `test_dash_stratum_work_source` **50/50**, `c2pool-dash` links clean. CI drift-guard now reports `220 per-coin test target(s) across 6 coin lane(s)` (widened by #893 on master) — still OK.
</details>

## The residual hole

`add_local_share` takes the exclusive tracker with `std::try_to_lock` and **declines** if the compute thread is mid-`think()`. For an ordinary share that is a sound trade: the decline costs one share and the *next solve mints instead*.

**A block-winning share has no next solve.** The block is found once, so a momentarily busy tracker permanently forfeits the highest-work share the node will ever produce.

### Why this is more than share-weight loss

p2pool nodes do not learn about a pool block from a block announcement. They detect it **through the sharechain**, by watching for a share with `pow_hash <= header['bits'].target` (`p2pool/node.py:145-147`). So a block-winning share that never enters the sharechain is a won block **no peer — including our own oracle — can ever record**. Established live today: `2511241` (64 conf) and `2511303`, both dashd-accepted and correctly paid, and no legacy node registered either.

A `try_to_lock` decline therefore reproduces the **full #887 symptom** — invisible block *and* lost weight — just intermittently and far harder to notice.

Measured cost of the share-weight half alone: ~135 shares/hour minted and ~10.9 blocks/day won ⇒ each lost block-share is ~0.2% of daily PPLNS weight. The visibility half is total for that block.

## Approach chosen: bounded blocking, not deferred retry

The issue offered both. I took the **bounded blocking acquire** (its primary suggestion), for three reasons:

1. **The deferred alternative is much larger here.** The mint's first tracker acquisition is a *read*, used to REBUILD the share (`mint_from_inputs` walks the chain). If it declines there is no share object to queue at all — a deferral would have to queue the raw `MintShareInputs` plus its frozen-job handle and re-run the whole mint from a think-completion hook: a new queue, new lifetime rules, and a new re-entrancy surface on a live reward path.
2. **Bounded blocking is measurably cheap here** (numbers below): the wait is entered only on a won block that lands inside a think window, and the expected wait is one think tail.
3. **A deferral still cannot bound latency** — it inherits whatever the next cycle does. The bound is the point.

The ordinary share path is **byte-for-byte unchanged**: `Urgency::Opportunistic` *is* today's single `try_to_lock`, and it is the default argument at every call site, so nothing can inherit the wait by omission.

### Why polled `try_lock` and not a blocking `lock()`

It must be bounded — an unbounded acquire on the stratum IO thread would stall other miners' submissions with no ceiling and no diagnostic. `std::shared_mutex` has **no timed acquire** (that is `std::shared_timed_mutex`); switching the type would rewrite ~30 explicit `std::shared_lock<std::shared_mutex>` reader-discipline call sites across `node.hpp`/`node.cpp` — a far larger and riskier diff than the defect warrants. The poll keeps the mutex type and every existing call site identical, and gives an exact, testable deadline.

Fairness is stated honestly in the header: polled `try_lock` is not fair, and could in principle be starved by an unbroken stream of shared readers. Every shared reader on this mutex is itself an IO-thread `try_to_lock` holding for microseconds, so unbroken 2 s coverage is not a realistic state — and if it happened the bound turns it into a **logged, counted forfeit** instead of a wedged IO thread. Strictly better than today, where the same situation is a silent drop.

## ★ The bound: 2000 ms, and where the number comes from

Measured, not guessed. From a 42 h DASH sharechain soak — `[ASYNC-THINK] compute done in Nms`, **n = 6721** post-join think cycles:

| p50 | p90 | p99 | p99.9 | max |
|---|---|---|---|---|
| 125 ms | 193 ms | 300 ms | 512 ms | **1074 ms** |

`>250 ms`: 242 (3.60%) · `>500 ms`: 8 (0.119%) · `>750 ms`: 3 (0.045%) · `>1000 ms`: **1** (0.015%)

**2000 ms covers 100% of the observed steady-state distribution**, with ~1.9x headroom over the single worst cycle.

- **Not tighter**, because the exclusive hold also covers `publish_snapshot()` + `flush_verified_to_leveldb()` (slightly beyond the logged `think_ms`), and `clean_tracker()` takes the *same* exclusive lock for a think + stale-head eat + tail drop + LevelDB prune which this build **does not time at all**. Against an unmeasured second holder the safe direction is more headroom — the failure mode of a too-tight budget is exactly the loss being fixed.
- **Not looser**, because the same log shows 6–15 s think cycles in the first ~5 minutes after a cold join (the bootstrap full-verify pass over an empty verified set). A budget covering *those* would stall the stratum IO thread for 15 s. A node in bootstrap has no sharechain to mint onto and is not winning blocks, so covering that state is worthless — capping below it is the whole point of having a bound.

**Expected cost in production.** Total exclusive-lock duty cycle over the soak is ~0.7%, so of ~10.9 block solves/day roughly **one every two weeks** enters the wait at all, and its expected wait is one think tail (~125 ms). Worst case is 2 s per acquisition. Both acquisitions on the path use the same budget, so the theoretical ceiling is 4 s — but the second is near-free whenever the first succeeded, because succeeding means the holder had already released. Nothing is lost during a stall: miner submissions sit in the socket buffer, jobs are not invalidated, and vardiff credit is not affected.

On expiry: **`LOG_ERROR` + `m_block_share_lock_forfeits`**, a counter exposed via `block_share_lock_forfeits()`. It must stay 0 in production; every increment is one won block invisible to the whole network. A silent drop is the defect — an accounted one is the fix's failure mode.

## ★ Block submit stays FIRST and UNCONDITIONAL

Not regressed, and verified two ways.

**Statically.** The won-block arm in `src/impl/dash/stratum/work_source.cpp` runs the payee guard, dispatches through `submit_block_fn_`, records the dashboard entry, and *only then* calls `mint_solved_share(true)`. My change adds one field assignment (`in.won_block = won_block`) inside that already-downstream helper. Nothing was moved. **If the bounded wait blocks, the block has already been submitted.**

**Dynamically.** The new end-to-end KAT carries an ordering witness: the bound mint records `rig.fx.submit_called` at the instant it runs, *before* it waits, and the test asserts it was already `true`. Any future reorder of the mint ahead of the submit turns that assertion red.

## ★ Caller-side lock trace — re-verified against this tree

The #878/#881 hazard is that a caller holding the exclusive tracker lock across a call into a self-locking callee makes the callee dead code — and making it *blocking* in that situation is a **deadlock**, not a no-op. #888's trace was not taken on trust; I re-ran it on the tree this builds on.

**Caller side — zero locks held.**
`asio async_read_until` handler → `StratumSession::process_message` (`core/stratum_server.cpp:505`) → `handle_submit` (`:1036`) → `mining_interface_->mining_submit(...)` (`:1332` pool-share arm, `:1347` pseudoshare-is-a-block arm). A scan of `stratum_server.cpp:1030-1360` for `mutex|lock_guard|unique_lock|shared_lock|lock(` returns **zero hits** — `handle_submit` holds nothing, and it deliberately *copies* the job snapshot rather than holding a reference.

**Inside `mining_submit` — zero locks across the seam, on both arms.**
`mint_share_mutex_` is taken in a scoped block that copies `mint_share_fn_` and releases before the call; `found_block_mutex_` on the block arm is likewise scoped and released before the mint; `workers_mutex_` is only touched afterwards in the `bump` lambda. Both classify arms sit in the same function at the same lock depth (zero) under the same caller.

**Callee side.** `main_dash.cpp`'s mint lambda takes its read guard inside a scoped block, **releases it**, and only then calls `add_local_share`, which takes the exclusive lock. Sequential, never nested — so making both bounded cannot self-deadlock.

**Belt and braces.** `tracker_acquire` takes an `on_compute_thread` flag and never waits when set; `add_local_share` passes `is_compute_thread()`. The compute thread already owns the exclusive lock, so the one path that *would* be a self-deadlock degrades to a single try. Pinned by `AcquirePrimitiveContract`.

**Conclusion: the caller holds zero locks, so the bounded blocking acquire is viable — the deferred-retry alternative was not required.**

## Test evidence

The regression is *"hold the tracker exclusively, drive a block-target submit, assert the share still lands"* — and nothing existing covered it: every prior mint KAT runs against a **free** tracker, where `try_to_lock` and a bounded wait are indistinguishable.

Folded into **existing allowlisted targets**; no new `add_executable`. `tools/ci/check_test_target_allowlist.py` → `CI drift-guard OK: 120 per-coin test target(s) across 5 coin lane(s) all present`. `.github/workflows/` untouched.

`test_dash_node` gains `dash` + `sharechain` on its link line so the KATs drive the **real** `NodeImpl::add_local_share` against the **real** `m_tracker_mutex`, held exclusively by another thread. That closes #888's own stated honest limit ("the KATs bind their own callback") for the part #889 is about. `dash`'s deps were already on that line or come in transitively; nothing outside `src/impl/dash` is added.

| target | result |
|---|---|
| `test_dash_node` (+5) | **13/13 PASSED** |
| `test_dash_stratum_work_source` (+4) | **50/50 PASSED** |

Build: Release, gcc 13.3. `c2pool-dash` links clean.

```
[ RUN      ] DashBlockWinningMint.LandsWhileTrackerHeldExclusively
[       OK ] DashBlockWinningMint.LandsWhileTrackerHeldExclusively (401 ms)
[ RUN      ] DashBlockWinningMint.OrdinaryShareStillDeclinesWhileTrackerHeld
[warning] [MINT] tracker busy — local share 890000c200000000 declined (retry on next solve)
[       OK ] DashBlockWinningMint.OrdinaryShareStillDeclinesWhileTrackerHeld (400 ms)
[ RUN      ] DashBlockWinningMint.BudgetExpiryIsACountedForfeitNotASilentDrop
[error]   [MINT-BLOCK] FORFEIT — tracker still busy after 2000ms; BLOCK-WINNING share
          890000e400000000 NOT minted. The block itself was already submitted, but no
          p2pool peer will see it and its PPLNS weight is lost. forfeits=1
[       OK ] DashBlockWinningMint.BudgetExpiryIsACountedForfeitNotASilentDrop (2301 ms)
[       OK ] DashBlockWinningMint.DefaultArgumentIsTheOpportunisticPath (300 ms)
[       OK ] DashBlockWinningMint.AcquirePrimitiveContract (650 ms)

[       OK ] DashStratumWorkSource.MiningSubmitWonBlockFlagsTheMintAsBlockWinning (0 ms)
[       OK ] DashStratumWorkSource.MiningSubmitOrdinaryShareIsNotFlaggedBlockWinning (0 ms)
[       OK ] DashStratumWorkSource.WonBlockShareMintsThroughAnExclusivelyHeldTracker (251 ms)
[       OK ] DashStratumWorkSource.OrdinaryShareStillDeclinesThroughAHeldTracker (1 ms)
```

`LandsWhileTrackerHeldExclusively` also asserts the call **waited ≥ 350 ms** — i.e. it genuinely rode out the holder rather than finding a free mutex, which is what makes it a real exercise of the bounded acquire and not an accidental pass on an idle lock.

### #895 / #898 checks

Every new case is a plain `TEST`, not `#ifdef`-guarded, so `gtest_add_tests(AUTO)` cannot register something unrunnable. **Verified as actually EXECUTED under ctest**, with real durations — not "Not Run", not a phantom pass:

```
803: DashBlockWinningMint.LandsWhileTrackerHeldExclusively ........... Passed  0.41 sec
804: DashBlockWinningMint.OrdinaryShareStillDeclinesWhileTrackerHeld . Passed  0.41 sec
805: DashBlockWinningMint.DefaultArgumentIsTheOpportunisticPath ...... Passed  0.31 sec
806: DashBlockWinningMint.BudgetExpiryIsACountedForfeitNotASilentDrop  Passed  2.31 sec
807: DashBlockWinningMint.AcquirePrimitiveContract ................... Passed  0.66 sec
100% tests passed, 0 tests failed out of 5

1150: ...MiningSubmitWonBlockFlagsTheMintAsBlockWinning ............... Passed  0.01 sec
1151: ...MiningSubmitOrdinaryShareIsNotFlaggedBlockWinning ............ Passed  0.01 sec
1152: ...WonBlockShareMintsThroughAnExclusivelyHeldTracker ............ Passed  0.26 sec
1153: ...OrdinaryShareStillDeclinesThroughAHeldTracker ................ Passed  0.01 sec
100% tests passed, 0 tests failed out of 4
```

`test_dash_node` and `test_dash_stratum_work_source` use `gtest_add_tests(... AUTO)` (source parsing), not `gtest_discover_tests(... PRE_TEST)`, so the #898 5 s discovery timeout does not apply to them.

### Negative control

Fix removed in two places — `add_local_share` forced back to `Urgency::Opportunistic`, and `in.won_block` forced `false` — then rebuilt and re-run:

```
[  FAILED  ] DashBlockWinningMint.LandsWhileTrackerHeldExclusively           (share forfeited)
[  FAILED  ] DashBlockWinningMint.BudgetExpiryIsACountedForfeitNotASilentDrop (declined in ~0ms, not after the budget)
[  FAILED  ] DashStratumWorkSource.MiningSubmitWonBlockFlagsTheMintAsBlockWinning
[  FAILED  ] DashStratumWorkSource.WonBlockShareMintsThroughAnExclusivelyHeldTracker
```

and the ordinary-path controls stayed green by design — `OrdinaryShareStillDeclinesWhileTrackerHeld`, `DefaultArgumentIsTheOpportunisticPath`, `MiningSubmitOrdinaryShareIsNotFlaggedBlockWinning`, `OrdinaryShareStillDeclinesThroughAHeldTracker`. That pairing is deliberate: **if the block-winning tests ever passed merely because the mutex happened to be free, these would fail alongside them.** Restored, rebuilt, re-ran → 13/13 and 50/50 green.

## No consensus change

Share construction, target derivation and serialisation are entirely inside the untouched mint / `create_local_share` seams. This changes only *how hard we try to acquire a lock*. `git diff` touches no share struct, no target math, no serializer.

## Scope

**dash only, deliberately — so #889 stays OPEN after this merges.**

- **btc / bch** reach the same seam through `CreateShareFn`, whose signature carries no solve class. Widening it touches `work_source.hpp`/`.cpp` for both coins plus `main_btc.cpp` and `pool_entrypoint.hpp`, and breaks three existing test binders. Neither is the hotel-deploy path this must ship with, and both would raise conflict probability against sibling PRs. **Not silently assumed fixed** — the same defect is live there and should be a follow-up.
- **dgb** cannot mint any local share until #884 binds `set_mint_share_fn`, so there is nothing to make blocking.

Untouched by design: `src/core/socket.cpp`, `src/core/web_server.cpp`, `src/impl/*/protocol_legacy.cpp`, `src/impl/dash/coin/checkpoints/**`, `mn_checkpoint*` (#899), and `main_dash.cpp`'s arm-resolution block (#891 — its `main_dash.cpp` hunks are at 1148-1349 and 2403+; mine are at 1871-1928, no overlap).

## Not verified / follow-ups

- **No live-node soak.** This is a unit-level change verified by KAT plus negative control. The lock-timing evidence is from soak *logs*, not a soak *of this build*.
- **`clean_tracker()`'s exclusive hold is not instrumented** in this build, so the 2000 ms budget is sized against `think()` alone plus judgement. If clean cycles routinely exceed 2 s the counter will say so — which is precisely why the counter exists. Adding a `[CLEAN] done in Nms` line is a cheap follow-up.
- **The hotel node was not queried directly** (no SSH credentials available from this environment); the distribution above comes from a local 42 h DASH sharechain soak log, not from the hotel itself. Hotel hardware may differ.
- **Production-contention behaviour of the real bound lambda** still cannot be fully exercised from a unit test: `test_dash_node` drives the real `add_local_share` through the real mutex, but `main_dash.cpp`'s lambda body is in the executable TU. Its read guard now uses the same helper under the same urgency, and the work-source KAT exercises that discipline end to end.
- **btc / bch remain exposed** to the identical defect (see Scope).
