### PR TITLE
ci: single required aggregator (CI Required) over the 10 required contexts

### DIFF
--- a/.github/workflows/bch-gate-g3a-regtest-block-production.yml
+++ b/.github/workflows/bch-gate-g3a-regtest-block-production.yml
@@ -21,6 +21,8 @@ name: BCH gate G3a — populated-regtest block production
 # (operator-side ruleset).
 
 on:
+  # additive: callable by ci-required.yml aggregator (no push/PR behaviour change)
+  workflow_call:
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/bch-gate-g3b-genuine-activation.yml
+++ b/.github/workflows/bch-gate-g3b-genuine-activation.yml
@@ -18,6 +18,8 @@ name: BCH gate G3b — genuine Upgrade9 activation
 # check only after a confirmed non-hollow green rollup (operator-side ruleset).
 
 on:
+  # additive: callable by ci-required.yml aggregator (no push/PR behaviour change)
+  workflow_call:
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -1,0 +1,57 @@
+name: CI Required
+# Single required status that aggregates the 10 previously-required contexts
+# (5 coin smokes from coin-matrix + DASH G1/G3a + DGB Phase-B + BCH G3a/G3b).
+# Path-filtering inside the called workflows may legitimately SKIP a lane on a
+# PR that does not touch it; this aggregate tolerates "skipped" but fails on any
+# failure or cancellation. Branch protection requires ONE context (CI Required /
+# aggregate) instead of 10, so path-filter skips no longer block merges.
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-required-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  coin-matrix:
+    uses: ./.github/workflows/coin-matrix.yml
+    secrets: inherit
+  dash-g1:
+    uses: ./.github/workflows/dash-gate-g1-byte-parity.yml
+    secrets: inherit
+  dash-g3a:
+    uses: ./.github/workflows/dash-gate-g3a-regtest-block-production.yml
+    secrets: inherit
+  dgb-phase-b:
+    uses: ./.github/workflows/dgb-phase-b-smoke.yml
+    secrets: inherit
+  bch-g3a:
+    uses: ./.github/workflows/bch-gate-g3a-regtest-block-production.yml
+    secrets: inherit
+  bch-g3b:
+    uses: ./.github/workflows/bch-gate-g3b-genuine-activation.yml
+    secrets: inherit
+
+  aggregate:
+    name: aggregate
+    needs: [coin-matrix, dash-g1, dash-g3a, dgb-phase-b, bch-g3a, bch-g3b]
+    if: always()
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Fail on any failed or cancelled lane; tolerate skipped
+        run: |
+          results="${{ join(needs.*.result, ' ') }}"
+          echo "lane results: $results"
+          rc=0
+          for r in $results; do
+            case "$r" in
+              success|skipped) ;;
+              *) echo "::error::a required lane reported '$r'"; rc=1 ;;
+            esac
+          done
+          if [ "$rc" -ne 0 ]; then exit 1; fi
+          echo "all required lanes passed or were legitimately skipped"

--- a/.github/workflows/coin-matrix.yml
+++ b/.github/workflows/coin-matrix.yml
@@ -12,6 +12,8 @@ name: Coin matrix
 # split, the other coins activate automatically without YAML changes).
 
 on:
+  # additive: callable by ci-required.yml aggregator (no push/PR behaviour change)
+  workflow_call:
   push:
     branches: [master, btc-embedded, dash-spv-embedded, dgb/pool-pillars-port, windows-build, service-update]
   pull_request:

--- a/.github/workflows/dash-gate-g1-byte-parity.yml
+++ b/.github/workflows/dash-gate-g1-byte-parity.yml
@@ -19,6 +19,8 @@ name: DASH gate G1 — byte-parity KAT
 # only after a confirmed non-hollow green rollup on the runner.
 
 on:
+  # additive: callable by ci-required.yml aggregator (no push/PR behaviour change)
+  workflow_call:
   push:
     branches: [master, dash-spv-embedded]
   pull_request:

--- a/.github/workflows/dash-gate-g3a-regtest-block-production.yml
+++ b/.github/workflows/dash-gate-g3a-regtest-block-production.yml
@@ -22,6 +22,8 @@ name: DASH gate G3a — populated-regtest block-production
 # non-hollow green rollup on the runner.
 
 on:
+  # additive: callable by ci-required.yml aggregator (no push/PR behaviour change)
+  workflow_call:
   push:
     branches: [master, dash-spv-embedded]
   pull_request:

--- a/.github/workflows/dgb-phase-b-smoke.yml
+++ b/.github/workflows/dgb-phase-b-smoke.yml
@@ -14,6 +14,8 @@ name: DGB Phase-B smoke — per-coin pillar gtests
 # green rollup on the runner.
 
 on:
+  # additive: callable by ci-required.yml aggregator (no push/PR behaviour change)
+  workflow_call:
   push:
     branches: [master]
   pull_request:


### PR DESCRIPTION
Reusable-workflow orchestrator so branch protection can require ONE context instead of 10, unblocking path-filter skips.

## What
- New `ci-required.yml` (workflow name: `CI Required`) fires on `pull_request` to master. It calls the 6 workflows carrying the 10 required contexts (coin-matrix + DASH G1/G3a + DGB Phase-B + BCH G3a/G3b) via `workflow_call` with `secrets: inherit`, then runs an `aggregate` job (`needs: [all]`, `if: always()`).
- `aggregate` fails on any lane that is failure/cancelled and tolerates `skipped` — so a PR that path-filters an untouched lane still merges.
- `workflow_call:` added additively to the 6 workflows; their existing push/pull_request triggers and behaviour are unchanged.

## Intended required context (post-merge, operator re-points branch protection)
`CI Required / aggregate` — replaces the 10 individual contexts.

## Transition note
Until branch protection is re-pointed and the legacy direct triggers retired, the 6 lanes run both directly and under the aggregator on a PR. No concurrency collision: only coin-matrix has a concurrency group and it keys on `github.workflow`, which differs between the direct run and the reusable call.

Draft — held for operator branch-protection re-point after the single settle run.