### PR TITLE
dash: show blocks found by ANY pool participant on the dashboard (bind ShareTracker::m_on_block_found)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -91,6 +91,7 @@
 #include <impl/dash/params.hpp>                // dash::make_coin_params (already via top include)
 #include <core/uint256.hpp>                    // uint160 payout pubkey hash
 #include <core/target_utils.hpp>              // chain::target_to_difficulty (dashboard net-diff)
+#include <impl/dash/dashboard_found_block.hpp> // any-participant /recent_blocks feed (peer-found blocks)
 
 #include <core/stratum_server.hpp>             // core::StratumServer — miner-facing accept-loop (run-path caller)
 #include <impl/dash/stratum/work_source.hpp>   // dash::stratum::DASHWorkSource — concrete core::stratum::IWorkSource
@@ -1099,6 +1100,54 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 [ws](double diff, const std::string& miner) {
                     ws->get_mining_interface()->record_share_difficulty(diff, miner);
                 };
+        }
+
+        // ── ANY-PARTICIPANT found-block feed (main_ltc.cpp:4230 parity) ────
+        // /recent_blocks is fed exclusively by record_found_block(), and the
+        // ONLY DASH binding of it was the LOCAL stratum win below
+        // (set_on_found_block_fn). A block found by another pool participant
+        // arrives as a gossiped share whose X11 header hash also clears the
+        // coin BLOCK target; the tracker already fires m_on_block_found for
+        // it (share_tracker.hpp:368/574-578) and ltc/btc/dgb/bch all bind
+        // that hook -- DASH never did, so peer-found blocks paid out but
+        // showed up nowhere on the dashboard.
+        //
+        // LOCKS. The hook fires with the caller holding m_tracker_mutex
+        // EXCLUSIVELY (compute thread in think()->attempt_verify, or
+        // add_local_share's try-lock). read_tracker() is reentrancy-aware and
+        // takes NO lock on the compute thread, so the handler cannot self-
+        // lock; it snapshots plain data and posts the dashboard write -- which
+        // takes m_blocks_mutex and may hit LevelDB -- onto the io_context, so
+        // nothing heavy and no second mutex is entered under the tracker lock.
+        //
+        // DEDUP. A local win is recorded by the stratum arm first and then
+        // re-fires here once #888 mints the winning share; both carry the same
+        // block hash (on DASH the share hash IS X11(block header)) and the same
+        // "DASH" label, and record_found_block dedups on exactly that pair.
+        //
+        // Display only: no submit, mint, target or payout path is reachable.
+        {
+            core::WebServer* ws = web_server.get();
+            dash::Node* node = &p2p_node;
+            p2p_node.tracker().m_on_block_found =
+                dash::dashboard::make_on_block_found(
+                    node, testnet,
+                    [&ioc](std::function<void()> work) {
+                        boost::asio::post(ioc, std::move(work));
+                    },
+                    [ws](const dash::dashboard::FoundBlockRow& row) {
+                        auto* mi = ws->get_mining_interface();
+                        LOG_INFO << "[DASH] GOT BLOCK FROM POOL! height=" << row.height
+                                 << " hash=" << row.block_hash.GetHex().substr(0, 16)
+                                 << " miner=" << row.miner;
+                        mi->record_found_block(
+                            row.height, row.block_hash, row.timestamp,
+                            row.chain, row.miner, row.share_hash,
+                            mi->get_network_difficulty(),
+                            row.share_difficulty,
+                            mi->get_local_hashrate(),
+                            row.subsidy);
+                    });
         }
 
         // ── REAL node-owner fee (already parsed from argv above) ──────────

--- a/src/impl/dash/dashboard_found_block.hpp
+++ b/src/impl/dash/dashboard_found_block.hpp
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+//
+// dashboard_found_block.hpp — the ANY-PARTICIPANT found-block feed for DASH.
+//
+// THE GAP THIS CLOSES
+// -------------------
+// /recent_blocks is served from MiningInterface::m_found_blocks, and the only
+// thing that ever appends to it is record_found_block(). On DASH the only
+// binding of that was the LOCAL stratum win (main_dash.cpp, DASHWorkSource
+// set_on_found_block_fn), so a block found by ANY OTHER pool participant --
+// gossiped in as a share whose X11 header hash also clears the coin's BLOCK
+// target -- was paid out correctly but NEVER appeared on the dashboard.
+//
+// dash::ShareTracker already fires m_on_block_found for exactly that event
+// (share_tracker.hpp: declared :368, fired from attempt_verify :574-578 and
+// from scan_chain_for_blocks :398). ltc/btc/dgb/bch all bind that hook; DASH
+// never did. This header holds the handler DASH binds, factored so the parts
+// that carry logic are unit-testable off a real ShareTracker.
+//
+// THREADING / LOCK CONTRACT (the #878/#881 dead-callee class)
+// ----------------------------------------------------------
+// m_on_block_found fires from INSIDE the tracker, with the CALLER already
+// holding m_tracker_mutex EXCLUSIVELY:
+//   * peer share  : io -> post(m_think_pool) -> compute thread takes
+//                   unique_lock(m_tracker_mutex) (node.cpp:540/972/…) ->
+//                   tracker.think() -> attempt_verify() -> hook.
+//   * local mint  : add_local_share() holds unique_lock(m_tracker_mutex,
+//                   try_to_lock) (node.cpp:1387) -> attempt_verify() -> hook.
+// So the handler MUST NOT take m_tracker_mutex itself. It reads the share
+// through Node::read_tracker(), which is reentrancy-aware: on the compute
+// thread it takes NO lock (the exclusive one is already held), off it a
+// shared try-lock. It then copies out PLAIN DATA (no tracker pointers escape,
+// #828 GP-fault class) and hands the finished row to `post` so the actual
+// dashboard write -- which takes m_blocks_mutex and can hit LevelDB and the
+// THE-checkpoint hook -- runs on the io_context with NO tracker lock held.
+//
+// DEDUP. A locally-won block reaches the dashboard twice: once from the
+// stratum win, and again after #888 mints that same winning share onto the
+// sharechain (attempt_verify -> this hook). Both carry the SAME uint256 --
+// for DASH the share hash IS X11(block header) (share_check.hpp:334), which
+// is exactly what the stratum path records as its block hash -- and the same
+// chain label "DASH". record_found_block() dedups on (block hash, chain)
+// under m_blocks_mutex (web_server.cpp:3311-3318), the same block-hash-keyed
+// contract web_server.cpp:1911 already relies on. Nothing here keys on a
+// prev-hash.
+//
+// Display only. No block submission, minting, target or payout logic is
+// reachable from this file.
+
+#include <core/address_utils.hpp>     // core::script_to_address
+#include <core/coinbase_builder.hpp>  // c2pool::ParsedScriptSig (BIP34 height)
+#include <core/target_utils.hpp>      // chain::bits_to_target / target_to_difficulty
+#include <core/uint256.hpp>
+
+#include <impl/dash/share_check.hpp>  // dash::pubkey_hash_to_script2
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <utility>
+
+namespace dash::dashboard {
+
+// Dash base58 version bytes (web_server.cpp:2353-2356 is the same SSOT):
+// mainnet P2PKH 'X' = 76 / P2SH '7' = 16; testnet 'y' = 140 / '8'-'9' = 19.
+inline constexpr uint8_t P2PKH_VERSION_MAINNET = 76;
+inline constexpr uint8_t P2PKH_VERSION_TESTNET = 140;
+inline constexpr uint8_t P2SH_VERSION_MAINNET  = 16;
+inline constexpr uint8_t P2SH_VERSION_TESTNET  = 19;
+
+/// The DASH chain label every found-block row carries. record_found_block()
+/// dedups on (hash, chain), so the sharechain arm and the stratum arm MUST
+/// agree on this exact string or a local win double-lists.
+inline constexpr const char* CHAIN_LABEL = "DASH";
+
+/// One dashboard row. Field-for-field the argument list
+/// MiningInterface::record_found_block() takes, so main_dash.cpp forwards it
+/// verbatim and the mapping cannot drift. network_difficulty / pool_hashrate
+/// are deliberately absent: they are live node readings, not share facts, and
+/// are read at record time on the io_context.
+struct FoundBlockRow
+{
+    uint64_t    height{0};            ///< coin block height (BIP34, from the coinbase)
+    uint256     block_hash;           ///< X11(block header) == the share hash on DASH
+    uint64_t    timestamp{0};         ///< the block header's nTime
+    std::string chain{CHAIN_LABEL};
+    std::string miner;                ///< finder's DASH address ('X…' / 'y…')
+    std::string share_hash;
+    double      share_difficulty{0.0};
+    uint64_t    subsidy{0};           ///< block reward the share committed to
+};
+
+/// Derive the dashboard row from a verified share that met the BLOCK target.
+/// Pure: no locks, no I/O, no globals. `share_hash` is the tracker's own key
+/// for the share and, on DASH, the block's identity hash -- it is used rather
+/// than the share's cached m_hash so the row can never disagree with the key
+/// the tracker fired on.
+template <class ShareT>
+inline FoundBlockRow row_from_share(const uint256& share_hash,
+                                    const ShareT& s,
+                                    bool testnet)
+{
+    FoundBlockRow row;
+    row.block_hash = share_hash;
+    row.share_hash = share_hash.GetHex();
+    row.timestamp  = static_cast<uint64_t>(s.m_min_header.m_timestamp);
+    row.chain      = CHAIN_LABEL;
+
+    // Share difficulty from the share's OWN committed target (share_info bits),
+    // matching what the tracker reports through m_on_share_difficulty.
+    if (s.m_bits != 0)
+        row.share_difficulty = chain::target_to_difficulty(chain::bits_to_target(s.m_bits));
+
+    if constexpr (requires { s.m_subsidy; })
+        row.subsidy = s.m_subsidy;
+
+    // Coin block height: the BIP34 push at the head of the share's coinbase
+    // scriptSig. dashd's ContextualCheckBlock enforces that prefix (bad-cb-
+    // height), so it is the height the finder actually built on -- not the
+    // sharechain absheight, which would render as a nonsense block number
+    // next to the stratum-recorded rows.
+    {
+        const auto& cb = s.m_coinbase.m_data;
+        if (!cb.empty()) {
+            c2pool::ParsedScriptSig parsed;
+            (void)c2pool::ParsedScriptSig::parse(cb.data(), cb.size(), parsed);
+            if (parsed.block_height > 0)
+                row.height = static_cast<uint64_t>(parsed.block_height);
+        }
+    }
+
+    // Finder address. DASH shares are always P2PKH over m_pubkey_hash.
+    if constexpr (requires { s.m_pubkey_hash; }) {
+        row.miner = core::script_to_address(
+            dash::pubkey_hash_to_script2(s.m_pubkey_hash),
+            /*bech32_hrp=*/"",
+            testnet ? P2PKH_VERSION_TESTNET : P2PKH_VERSION_MAINNET,
+            testnet ? P2SH_VERSION_TESTNET  : P2SH_VERSION_MAINNET);
+    }
+
+    return row;
+}
+
+/// Writes a finished row to the dashboard's found-block store. Supplied by
+/// main_dash.cpp as a verbatim forward into record_found_block().
+using RowSink = std::function<void(const FoundBlockRow&)>;
+
+/// Hands work to the io_context. Supplied by main_dash.cpp as
+/// boost::asio::post(ioc, …) so the dashboard write never runs under the
+/// tracker lock (see the lock contract above).
+using PostFn = std::function<void(std::function<void()>)>;
+
+/// Build the handler main_dash.cpp installs as ShareTracker::m_on_block_found.
+///
+/// `node` must expose read_tracker() with dash::NodeImpl's semantics: truthy
+/// without locking on the compute thread (exclusive lock already held by the
+/// caller of this hook), shared try-lock elsewhere, falsy when that try-lock
+/// loses. A falsy guard is a SKIP, never a blocking wait -- an io-thread
+/// caller must not stall behind think(), and the only path that reaches here
+/// with a falsy guard is the local mint, which the stratum arm has already
+/// recorded.
+template <class NodeT>
+inline std::function<void(const uint256&)>
+make_on_block_found(NodeT* node, bool testnet, PostFn post, RowSink sink)
+{
+    return [node, testnet, post = std::move(post), sink = std::move(sink)]
+           (const uint256& share_hash)
+    {
+        if (!node || !post || !sink) return;
+
+        FoundBlockRow row;
+        bool have_row = false;
+
+        {
+            // No lock is taken on the compute thread (the hook's caller holds
+            // the exclusive one); off it this is a shared TRY-lock.
+            auto guard = node->read_tracker();
+            if (!guard) return;
+            auto& tracker_chain = guard->chain;
+            if (!tracker_chain.contains(share_hash)) return;
+            tracker_chain.get(share_hash).share.invoke([&](auto* s) {
+                if (!s) return;
+                row = row_from_share(share_hash, *s, testnet);
+                have_row = true;
+            });
+        }   // guard released -- nothing below touches the tracker
+
+        if (!have_row) return;
+
+        // Plain-data copy only; the dashboard write happens on the io_context.
+        post([sink, row = std::move(row)]() { sink(row); });
+    };
+}
+
+} // namespace dash::dashboard

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -299,7 +299,12 @@ if (BUILD_TESTING AND GTest_FOUND)
     # publish/getters, tracker()/read_tracker()/tracker_shared_lock() accessors.
     # Rig-free (no io_context/sockets). Needs pool (BaseNode) + c2pool_storage
     # (SharechainStorage) on top of the dash_x11 + core link set.
-    add_executable(test_dash_node test_dash_node.cpp)
+    # test_dash_dashboard_found_block.cpp is FOLDED into this already-allowlisted
+    # target as a second TU rather than added as a standalone executable: a new
+    # target would need a build.yml --target edit and, until it had one, would
+    # trip CI's NOT_BUILT sentinel (the drift-guard audit, #883/#893). It needs
+    # exactly this link set — NodeImpl + ShareTracker + core MiningInterface.
+    add_executable(test_dash_node test_dash_node.cpp test_dash_dashboard_found_block.cpp)
     target_link_libraries(test_dash_node PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core

--- a/test/test_dash_dashboard_found_block.cpp
+++ b/test/test_dash_dashboard_found_block.cpp
@@ -1,0 +1,337 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// ---------------------------------------------------------------------------
+// test_dash_dashboard_found_block — the BINDING KAT for DASH's any-participant
+// found-block dashboard feed.
+//
+// THE DEFECT. /recent_blocks is served from MiningInterface::m_found_blocks,
+// appended only by record_found_block(). On DASH the sole binding of that was
+// the LOCAL stratum win, so a block found by ANOTHER pool participant paid out
+// correctly and appeared NOWHERE on the dashboard. dash::ShareTracker already
+// fires m_on_block_found for that event (share_tracker.hpp:368 declared, :398
+// and :574-578 fired) and ltc/btc/dgb/bch all bind it; DASH did not.
+//
+// WHY THESE KATs ARE NOT VACUOUS. The hook fires with the caller ALREADY
+// holding m_tracker_mutex EXCLUSIVELY (compute thread inside think() ->
+// attempt_verify, or add_local_share's try-lock). A handler that took that
+// lock would be permanently dead code — the #878/#881 class, where a callee
+// under a caller-held exclusive lock never runs and its unit tests pass on
+// unreachable code. So KAT 1 reproduces the PRODUCTION lock context exactly:
+// a real dash::NodeImpl, the exclusive tracker lock HELD, this thread marked
+// as the compute thread, and the REAL tracker firing the REAL handler
+// (dash::dashboard::make_on_block_found — the same closure main_dash.cpp
+// installs). KAT 2 is the negative control: identical setup with the hook
+// UNBOUND records nothing, which is precisely the shipped defect.
+//
+// Display-only surface: no block submission, mint, target or payout path is
+// reachable from any code these KATs drive.
+// ---------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/node.hpp>
+#include <impl/dash/dashboard_found_block.hpp>
+#include <impl/dash/share.hpp>
+
+#include <core/uint256.hpp>
+#include <core/target_utils.hpp>
+#include <core/web_server.hpp>
+
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/post.hpp>
+
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+#include <shared_mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+// A block target so slack that any pow_hash we choose clears it — the block
+// detection arithmetic itself is pinned elsewhere; here we only need the
+// tracker to decide "this share is a block" and fire.
+constexpr uint32_t BLOCK_BITS = 0x1d00ffff;
+// A distinct, harder share target so share_difficulty is non-zero and
+// demonstrably read from the share's OWN bits, not from min_header.
+constexpr uint32_t SHARE_BITS = 0x1e0ffff0;
+
+constexpr uint32_t BLOCK_HEIGHT = 2511303;   // 0x2651c7 — a real DASH height
+constexpr uint32_t HEADER_TIME  = 1753000000;
+constexpr uint64_t SUBSIDY      = 155000000; // duffs
+
+// Distinct, deterministic share identities. base_uint::begin() yields
+// uint32_t*, so these go through SetHex rather than byte indexing.
+uint256 hash_from_byte(unsigned char b)
+{
+    static const char* digits = "0123456789abcdef";
+    std::string s = "11";
+    s += digits[b >> 4];
+    s += digits[b & 0x0f];
+    s += std::string(64 - s.size(), '0');
+    uint256 h;
+    h.SetHex(s);
+    return h;
+}
+
+// A pow_hash small enough to clear BLOCK_BITS (0x1d00ffff -> 0x00000000ffff…).
+uint256 winning_pow_hash()
+{
+    uint256 h;
+    h.SetHex(std::string(63, '0') + "1");
+    return h;
+}
+
+uint160 miner_pubkey_hash()
+{
+    uint160 h;
+    h.SetHex("a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3");
+    return h;
+}
+
+// BIP34 height push, hand-encoded here rather than reused from the production
+// builder so the decode under test is pinned against an INDEPENDENT encoding.
+// 2511303 == 0x2651c7 -> LE c7 51 26, minimal data push of length 3.
+std::vector<unsigned char> bip34_scriptsig()
+{
+    std::vector<unsigned char> cb{0x03, 0xc7, 0x51, 0x26};
+    const std::string tag = "/P2Pool-DASH/c2pool/";
+    cb.insert(cb.end(), tag.begin(), tag.end());
+    return cb;
+}
+
+// A share whose header hash also clears the coin BLOCK target — i.e. exactly
+// what a peer gossips in when the pool wins a block off a foreign rig.
+dash::DashShare* make_won_block_share(const uint256& share_hash)
+{
+    auto* s = new dash::DashShare();
+    s->m_hash      = share_hash;
+    s->m_prev_hash = uint256::ZERO;
+    s->m_min_header.m_bits      = BLOCK_BITS;
+    s->m_min_header.m_timestamp = HEADER_TIME;
+    s->m_bits        = SHARE_BITS;
+    s->m_pubkey_hash = miner_pubkey_hash();
+    s->m_subsidy     = SUBSIDY;
+    s->m_coinbase.m_data = bip34_scriptsig();
+    return s;
+}
+
+// Real node, with the one seam a KAT needs: the ability to declare THIS thread
+// the compute thread, so read_tracker() takes the production (no-lock,
+// exclusive-already-held) branch instead of the try-lock branch.
+class HookNode : public dash::NodeImpl
+{
+public:
+    using dash::NodeImpl::NodeImpl;
+    void mark_this_thread_compute()
+    {
+        m_compute_thread_id.store(std::this_thread::get_id(), std::memory_order_relaxed);
+    }
+};
+
+// The fixture stands up the node + share + handler exactly as main_dash.cpp
+// does, and captures the rows the sink is handed.
+struct Harness
+{
+    HookNode                                    node;
+    boost::asio::io_context                     ioc;
+    std::vector<dash::dashboard::FoundBlockRow> rows;
+    uint256                                     share_hash{hash_from_byte(0x7e)};
+
+    Harness()
+    {
+        node.tracker().chain.add(make_won_block_share(share_hash));
+        auto* idx = node.tracker().chain.get_index(share_hash);
+        idx->pow_hash = winning_pow_hash();
+    }
+
+    // Bind the PRODUCTION handler (the closure main_dash.cpp installs).
+    void bind(bool testnet)
+    {
+        node.tracker().m_on_block_found =
+            dash::dashboard::make_on_block_found(
+                &node, testnet,
+                [this](std::function<void()> work) {
+                    boost::asio::post(ioc, std::move(work));
+                },
+                [this](const dash::dashboard::FoundBlockRow& row) {
+                    rows.push_back(row);
+                });
+    }
+
+    // Run whatever the handler posted. restart() is required before every
+    // poll() after the first: an io_context that has run out of work is left
+    // stopped and silently drops later handlers otherwise.
+    void drain()
+    {
+        ioc.restart();
+        ioc.poll();
+    }
+
+    // Drive the REAL tracker fire path under the REAL production lock context:
+    // exclusive tracker lock held, this thread marked as the compute thread.
+    // Returns the number of rows delivered BEFORE the io_context is drained.
+    size_t fire_under_exclusive_lock()
+    {
+        size_t during_lock = 0;
+        {
+            std::unique_lock<std::shared_mutex> lk(node.tracker_mutex());
+            node.mark_this_thread_compute();
+            node.tracker().scan_chain_for_blocks(share_hash, 4);
+            during_lock = rows.size();
+        }
+        drain();
+        return during_lock;
+    }
+};
+
+} // namespace
+
+// 1) THE GATE. With the hook BOUND, a block found by any pool participant
+//    reaches the dashboard sink — fired from inside the tracker with the
+//    exclusive lock held, i.e. the handler is NOT dead code under the
+//    caller-side lock (#878/#881).
+TEST(DashDashboardFoundBlock, BoundHookRecordsPeerFoundBlock)
+{
+    Harness h;
+    h.bind(/*testnet=*/false);
+
+    const size_t during_lock = h.fire_under_exclusive_lock();
+
+    ASSERT_EQ(h.rows.size(), 1u)
+        << "the tracker fired m_on_block_found but no dashboard row arrived";
+    EXPECT_EQ(during_lock, 0u)
+        << "the dashboard write must be POSTED, never performed under the "
+           "exclusive tracker lock";
+
+    const auto& row = h.rows.front();
+    // Block identity is the tracker's own key: on DASH the share hash IS
+    // X11(block header), which is what the stratum arm records too.
+    EXPECT_EQ(row.block_hash, h.share_hash);
+    EXPECT_EQ(row.share_hash, h.share_hash.GetHex());
+    // Chain label must match the stratum arm's exactly or a local win double-lists.
+    EXPECT_EQ(row.chain, "DASH");
+    // Coin block height comes from the BIP34 push, NOT the sharechain absheight.
+    EXPECT_EQ(row.height, static_cast<uint64_t>(BLOCK_HEIGHT));
+    EXPECT_EQ(row.timestamp, static_cast<uint64_t>(HEADER_TIME));
+    EXPECT_EQ(row.subsidy, SUBSIDY);
+    // Share difficulty is read from the share's own committed target.
+    EXPECT_DOUBLE_EQ(row.share_difficulty,
+                     chain::target_to_difficulty(chain::bits_to_target(SHARE_BITS)));
+    EXPECT_NE(row.share_difficulty,
+              chain::target_to_difficulty(chain::bits_to_target(BLOCK_BITS)));
+    // Finder renders as a DASH mainnet address, not a Bitcoin '1…'.
+    ASSERT_FALSE(row.miner.empty());
+    EXPECT_EQ(row.miner[0], 'X');
+}
+
+// 2) THE NEGATIVE CONTROL — the shipped defect. Identical tracker, identical
+//    won block, hook UNBOUND: nothing is recorded. This is the assertion that
+//    fails without the main_dash.cpp binding.
+TEST(DashDashboardFoundBlock, UnboundHookRecordsNothing)
+{
+    Harness h;   // deliberately no bind()
+
+    h.fire_under_exclusive_lock();
+
+    EXPECT_TRUE(h.rows.empty())
+        << "no binding must mean no dashboard row — this is the defect state";
+}
+
+// 3) Testnet renders a testnet address. Pins the version-byte selection the
+//    row derivation makes (76/'X' vs 140/'y'), which is the only thing that
+//    can silently mis-render a finder.
+TEST(DashDashboardFoundBlock, TestnetFinderAddressUsesTestnetVersion)
+{
+    Harness main_h;   main_h.bind(/*testnet=*/false);
+    Harness test_h;   test_h.bind(/*testnet=*/true);
+    main_h.fire_under_exclusive_lock();
+    test_h.fire_under_exclusive_lock();
+
+    ASSERT_EQ(main_h.rows.size(), 1u);
+    ASSERT_EQ(test_h.rows.size(), 1u);
+    EXPECT_EQ(test_h.rows.front().miner[0], 'y');
+    EXPECT_NE(test_h.rows.front().miner, main_h.rows.front().miner);
+}
+
+// 4) THE LOCK TRACE, pinned. When the exclusive tracker lock is held by a
+//    DIFFERENT thread and we are not the compute thread, read_tracker() hands
+//    back a falsy guard: the handler SKIPS. It must never block behind
+//    think() and never deadlock. (The only production path that reaches here
+//    falsy is the local mint, whose win the stratum arm already recorded.)
+TEST(DashDashboardFoundBlock, HandlerSkipsRatherThanBlockingWhenTrackerBusy)
+{
+    Harness h;
+    h.bind(/*testnet=*/false);
+
+    std::mutex               m;
+    std::condition_variable  cv;
+    bool                     locked = false;
+    bool                     release = false;
+
+    std::thread holder([&] {
+        std::unique_lock<std::shared_mutex> lk(h.node.tracker_mutex());
+        {
+            std::lock_guard<std::mutex> g(m);
+            locked = true;
+        }
+        cv.notify_one();
+        std::unique_lock<std::mutex> g(m);
+        cv.wait(g, [&] { return release; });
+    });
+
+    {
+        std::unique_lock<std::mutex> g(m);
+        cv.wait(g, [&] { return locked; });
+    }
+
+    // Not the compute thread, exclusive lock held elsewhere: must return
+    // promptly having recorded nothing.
+    h.node.tracker().m_on_block_found(h.share_hash);
+    h.drain();
+    EXPECT_TRUE(h.rows.empty()) << "a busy tracker must be skipped, not read unlocked";
+
+    {
+        std::lock_guard<std::mutex> g(m);
+        release = true;
+    }
+    cv.notify_one();
+    holder.join();
+
+    // With the lock free again the same call records normally — the skip above
+    // was a live try-lock miss, not a permanently dead handler.
+    h.node.tracker().m_on_block_found(h.share_hash);
+    h.drain();
+    EXPECT_EQ(h.rows.size(), 1u);
+}
+
+// 5) DEDUP is keyed on the BLOCK HASH (never a prev-hash). A local win is
+//    recorded by the stratum arm and then re-fires through this hook once the
+//    winning share is minted onto the sharechain (#888); both carry the same
+//    block hash and the same "DASH" label, and record_found_block collapses
+//    them. A genuinely different block still lists.
+TEST(DashDashboardFoundBlock, RecordFoundBlockDedupsOnBlockHash)
+{
+    core::MiningInterface mi(/*testnet=*/false, nullptr, Blockchain::DASH);
+
+    const uint256 block_a = hash_from_byte(0x41);
+    const uint256 block_b = hash_from_byte(0x42);
+
+    // The stratum arm records the local win first.
+    mi.record_found_block(BLOCK_HEIGHT, block_a, HEADER_TIME, "DASH",
+                          "Xminer", block_a.GetHex(), 1.0, 2.0, 3.0, SUBSIDY);
+    ASSERT_EQ(mi.rest_recent_blocks().size(), 1u);
+
+    // The sharechain arm re-fires for the SAME block — same hash, same chain.
+    mi.record_found_block(BLOCK_HEIGHT, block_a, HEADER_TIME + 5, "DASH",
+                          "Xminer", block_a.GetHex(), 1.0, 2.0, 3.0, SUBSIDY);
+    EXPECT_EQ(mi.rest_recent_blocks().size(), 1u)
+        << "a locally-won block must not list twice";
+
+    // A different block at the SAME height must still list — the key is the
+    // block hash, not the height and not any prev-hash.
+    mi.record_found_block(BLOCK_HEIGHT, block_b, HEADER_TIME + 9, "DASH",
+                          "Xminer", block_b.GetHex(), 1.0, 2.0, 3.0, SUBSIDY);
+    EXPECT_EQ(mi.rest_recent_blocks().size(), 2u);
+}


### PR DESCRIPTION
## The defect

The operator hit this live: the pool found a DASH block via a **foreign ASIC**, our node paid out on it correctly, and the dashboard's found-blocks card showed **nothing**.

`/recent_blocks` is served from `MiningInterface::m_found_blocks` (`src/core/http_session.cpp:214` → `src/core/web_server.cpp:2460`), and the only thing that ever appends to it is `record_found_block()` (`src/core/web_server.cpp:3299`). On DASH the **only** binding of that was the LOCAL stratum win — `work_source->set_on_found_block_fn(...)` at `src/c2pool/main_dash.cpp:1707`. Any block found by another pool participant arrives instead as a gossiped share whose X11 header hash also clears the coin BLOCK target, and nothing on the DASH path listened for it.

## Verified diagnosis (every file:line re-checked against master)

| Claim | Verdict |
|---|---|
| `dash::ShareTracker::m_on_block_found` declared at `src/impl/dash/share_tracker.hpp:368` | ✅ exact |
| fired at `src/impl/dash/share_tracker.hpp:398` (`scan_chain_for_blocks`) | ✅ exact |
| fired at `src/impl/dash/share_tracker.hpp:574-578` (`attempt_verify`) | ✅ exact |
| never bound in `main_dash.cpp` | ✅ zero hits repo-wide before this PR |
| ltc binds at `src/c2pool/main_ltc.cpp:4230` | ✅ exact |
| btc binds at `src/c2pool/main_btc.cpp:1418` | ✅ exact |
| dgb binds at `src/c2pool/main_dgb.cpp:476` | ✅ exact |
| bch binds at `src/impl/bch/node.hpp:438` | ✅ exact |

Two corrections to the surrounding picture, neither of which changes the fix:

* The local stratum `record_found_block` is at **`main_dash.cpp:1707`**, not `:1685` — `:1685` is the head of the enclosing comment block.
* `scan_chain_for_blocks` (the `:398` fire site) is **never called anywhere for DASH** — it is dead on this lane. The only live fire site is `attempt_verify` at `:574-578`. Wiring the startup block-scan is deliberately **out of scope** here.

## The fix

`src/impl/dash/dashboard_found_block.hpp` (new) holds the handler; `main_dash.cpp` binds it next to the existing `m_on_share_difficulty` binding, mirroring LTC.

## Caller-side lock trace (required — the #878/#881 dead-callee class)

`m_on_block_found` fires **from inside the tracker, with the caller already holding `m_tracker_mutex` EXCLUSIVELY**:

* **peer share (the broken path)** — io thread → `post(m_think_pool)` → compute thread stores `m_compute_thread_id` and takes `std::unique_lock(m_tracker_mutex)` (`src/impl/dash/node.cpp:540`, `:972`, `:1106`) → `tracker.think()` → `attempt_verify` (`share_tracker.hpp:793` Phase 1 / `:1076` Phase 2) → **hook**.
* **local mint** — `add_local_share` holds `std::unique_lock(m_tracker_mutex, try_to_lock)` (`src/impl/dash/node.cpp:1387`) and calls `attempt_verify` inline at `:1426` → **hook**. This is on the **io thread**, not the compute thread.

So a handler that took the tracker lock would be permanently dead code. This one does not:

* It reads via `Node::read_tracker()` (`src/impl/dash/node.hpp:1049`), which is **reentrancy-aware** (`TrackerReadGuard`, `node.hpp:1020`): on the compute thread it takes **no lock at all** (the exclusive one is already held), off it a `shared_lock(try_to_lock)`, and it is **falsy rather than blocking** when that try-lock loses.
* On the local-mint path the guard is correctly falsy (io thread holding the exclusive lock; `is_compute_thread()` is false), so the handler **skips** — no `try_lock_shared` while self-holding the exclusive lock is ever relied on for correctness, and no deadlock is possible. That win is already recorded by the stratum arm.
* Under the guard it copies out **plain data only** — no tracker pointer, reference or iterator escapes — so it cannot introduce an unlocked tracker read racing `think()` (the #828 GP-fault class).
* It then **posts the dashboard write to the io_context**. `record_found_block` takes `m_blocks_mutex`, can hit the found-block LevelDB and fires the THE-checkpoint hook; none of that now runs under the tracker lock, and no second mutex is entered while the tracker lock is held.

## Dedup — keyed on BLOCK HASH, never prev-hash

On DASH the share hash **is** `X11(block header)` (`src/impl/dash/share_check.hpp:334`), which is exactly the value the stratum arm records as its block hash; both arms label the row `"DASH"`. `record_found_block` dedups on that `(hash, chain)` pair under `m_blocks_mutex` (`src/core/web_server.cpp:3311-3318`) — the same block-hash-keyed contract `web_server.cpp:1911` already documents ("record_found_block dedups by block hash, so firing at verdict time is double-record-safe"). Nothing here keys on a prev-hash (the #894 mistake).

Two independent layers keep a locally-won block from listing twice after #888 mints the winning share onto the sharechain:

1. `add_local_share`'s inline verify runs off the compute thread under the exclusive lock → the guard is falsy → the hook skips outright; a later `think()` then short-circuits on `verified.contains(share_hash)` at `share_tracker.hpp:461` and never re-fires.
2. If that inline verify fails and the share is verified later on the compute thread, the hook does fire — and `record_found_block`'s `(hash, chain)` dedup collapses it.

This deliberately does **not** reuse `already_submitted_block` / `mark_block_submitted`: those track *submission* state (256-entry FIFO, marked only on a successful submit) and a peer-found block is never submitted by us, so keying display dedup on them would suppress exactly the rows this PR exists to show. `record_found_block`'s own dedup is the correct, already-block-hash-keyed mechanism, and this PR pins it with a test.

## Height

Coin block height is decoded from the **BIP34 push** at the head of the share's coinbase scriptSig via the existing `c2pool::ParsedScriptSig::parse` (`src/core/coinbase_builder.hpp:231`). dashd's `ContextualCheckBlock` enforces that prefix (`bad-cb-height`), so it is the height the finder actually built on. LTC's binding passes `m_absheight` (the *sharechain* height), which on the DASH card would render as a nonsense block number beside the stratum-recorded rows.

## What the test proves

`test/test_dash_dashboard_found_block.cpp`, folded into the already-allowlisted `test_dash_node` target (a standalone target would trip CI's NOT_BUILT sentinel until `build.yml` caught up — #883/#893).

It is **not** a test over unreachable code: it stands up a real `dash::NodeImpl`, inserts a real share into the real tracker chain, installs the **production closure** (`dash::dashboard::make_on_block_found` — the same one `main_dash.cpp` binds), and fires it through the **real tracker** with the **exclusive tracker lock held** and this thread marked as the compute thread — i.e. the exact production lock context.

1. **`BoundHookRecordsPeerFoundBlock`** — the gate. The row arrives; `during_lock == 0` proves nothing is written while the tracker lock is held; block hash == the tracker's key, BIP34 height 2511303, header time, subsidy, share difficulty (read from the share's own bits, asserted *different* from the min_header bits), finder renders `X…`.
2. **`UnboundHookRecordsNothing`** — the negative control, and the shipped defect state: same tracker, same won block, hook unbound → nothing recorded. This is the assertion that fails without the binding.
3. **`TestnetFinderAddressUsesTestnetVersion`** — `y…` on testnet, and testnet ≠ mainnet address (pins the version-byte selection).
4. **`HandlerSkipsRatherThanBlockingWhenTrackerBusy`** — the lock trace pinned: exclusive lock held by another thread and not the compute thread → falsy guard → skip, promptly, recording nothing; then with the lock free the same call records normally, proving the skip was a live try-lock miss and not a permanently dead handler.
5. **`RecordFoundBlockDedupsOnBlockHash`** — real `core::MiningInterface`: the same block hash recorded twice lists once; a *different* block at the *same height* still lists.

The BIP34 push in the test is hand-encoded rather than reused from the production builder, so the decode is pinned against an independent encoding.

## Verification

* `make c2pool-dash` — clean build and link with the binding in place.
* `test_dash_node` — 13/13 pass (8 pre-existing + 5 new).
* Zero real ctest failures in the warm tree (the `Not Run` entries are unbuilt targets in the local tree, unaffected by this change).

## Scope

Display only. `git diff` touches: one new header under `src/impl/dash/`, one binding block in `main_dash.cpp`, one new test, one `test/CMakeLists.txt` line. No block submission, minting, target or payout logic is reachable from any of it. Per-coin isolation held — nothing outside `src/impl/dash/` and the DASH launcher is modified.

Fixes the peer-found-block dashboard gap.
