### PR TITLE
p2p: resolve DNS-named addnodes before advertising them (#910)

### DIFF
--- a/src/core/factory.hpp
+++ b/src/core/factory.hpp
@@ -166,6 +166,24 @@ private:
 					return;
 				}
 
+				// #910: this is the ONE resolver in the outbound path, and it
+				// has just produced the answer the serializer needs. Memoise
+				// the A record against the configured host string so an
+				// `--addnode rov.p2p-spb.xyz:8999` seed is advertised to peers
+				// by its real address instead of being rewritten to 127.0.0.1
+				// in NetAddress::Write_IPV4. No second lookup is introduced,
+				// so the two paths cannot disagree; the memo is skipped
+				// automatically when the host is already a literal.
+				for (const auto& entry : endpoints)
+				{
+					if (entry.endpoint().address().is_v4())
+					{
+						core::record_resolved_host(addr.address(),
+							entry.endpoint().address().to_string());
+						break;
+					}
+				}
+
 				// If the node WAS managed at registration but is now expired,
 				// it has been destroyed — skip the connect to avoid the UAF
 				// on m_node->connected(socket) inside connect_socket().

--- a/src/core/netaddress.cpp
+++ b/src/core/netaddress.cpp
@@ -7,6 +7,137 @@
 #include <boost/lexical_cast.hpp>
 #include <sstream>
 #include <iomanip>
+#include <mutex>
+#include <shared_mutex>
+#include <unordered_map>
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Resolved-host memo (#910) — see netaddress.hpp for the rationale.
+//
+// Written from the outbound-connect resolver's completion handler
+// (core::Factory's Client::resolve, core/factory.hpp), read from the serializer.
+// Those run on different threads, hence the shared_mutex; the read side is the
+// one on the IO path, so it takes only the shared lock and never does DNS.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+namespace
+{
+    // Sources are bounded by config (--addnode, seed lists), but the memo is fed
+    // from a network-adjacent path, so it gets an explicit ceiling.
+    constexpr size_t MAX_RESOLVED_HOSTS = 1024;
+
+    std::shared_mutex& resolved_hosts_mutex()
+    {
+        static std::shared_mutex m;
+        return m;
+    }
+
+    std::unordered_map<std::string, std::string>& resolved_hosts()
+    {
+        static std::unordered_map<std::string, std::string> m;
+        return m;
+    }
+
+    bool is_numeric_address(const std::string& s)
+    {
+        boost::system::error_code ec;
+        boost::asio::ip::make_address(s, ec);
+        return !ec;
+    }
+
+    bool is_numeric_v4(const std::string& s)
+    {
+        boost::system::error_code ec;
+        boost::asio::ip::make_address_v4(s, ec);
+        return !ec;
+    }
+}
+
+namespace core
+{
+
+void record_resolved_host(const std::string& host, const std::string& ip)
+{
+    // A literal needs no memo, and we refuse to store anything that is not
+    // itself numeric — the memo must never become a second source of names.
+    if (host.empty() || is_numeric_address(host) || !is_numeric_address(ip))
+        return;
+
+    std::unique_lock lock(resolved_hosts_mutex());
+    auto& map = resolved_hosts();
+
+    auto it = map.find(host);
+    if (it != map.end())
+    {
+        if (it->second != ip)
+        {
+            LOG_INFO << "DNS: '" << host << "' moved " << it->second << " -> " << ip;
+            it->second = ip;
+        }
+        return;
+    }
+
+    if (map.size() >= MAX_RESOLVED_HOSTS)
+    {
+        LOG_WARNING << "DNS memo full (" << MAX_RESOLVED_HOSTS
+                    << " hosts); not recording '" << host << "'";
+        return;
+    }
+
+    map.emplace(host, ip);
+    LOG_DEBUG_OTHER << "DNS: '" << host << "' -> " << ip;
+}
+
+std::optional<std::string> lookup_resolved_host(const std::string& host)
+{
+    std::shared_lock lock(resolved_hosts_mutex());
+    const auto& map = resolved_hosts();
+    auto it = map.find(host);
+    if (it == map.end())
+        return std::nullopt;
+    return it->second;
+}
+
+void clear_resolved_hosts()
+{
+    std::unique_lock lock(resolved_hosts_mutex());
+    resolved_hosts().clear();
+}
+
+} // namespace core
+
+std::optional<std::string> NetAddress::wire_ipv4_literal() const
+{
+    // Already a dotted quad: hand it back unchanged so the bytes we emit are
+    // byte-for-byte the bytes we emitted before this fix.
+    if (is_numeric_v4(m_ip))
+        return m_ip;
+
+    // "localhost" genuinely IS 127.0.0.1. That is a real resolution, not the
+    // blanket loopback substitution #910 is about, and it keeps the
+    // default-constructed NetAddress (m_ip == "localhost") serializing to the
+    // same four bytes it always has.
+    if (m_ip == "localhost")
+        return std::string("127.0.0.1");
+
+    // A DNS name: render whatever the outbound-connect resolver last resolved
+    // it to. Never resolve here — this runs on the serialize/IO path.
+    //
+    // Only an A record is usable: the caller splits on '.' and must produce
+    // exactly four bytes, so a memoised AAAA answer is deliberately treated as
+    // "unknown" rather than fed into the IPv4 encoder.
+    auto memo = core::lookup_resolved_host(m_ip);
+    if (memo && is_numeric_v4(*memo))
+        return memo;
+    return std::nullopt;
+}
+
+bool NetAddress::is_wire_advertisable() const
+{
+    if (m_type == NET_IPV6)
+        return is_numeric_address(m_ip);
+    return wire_ipv4_literal().has_value();
+}
 
 void NetAddress::Write_IPV4(PackStream& os) const
 {
@@ -18,14 +149,26 @@ void NetAddress::Write_IPV4(PackStream& os) const
         data = ParseHex(ip);
     } else
     {
+        // #910: a DNS-named address used to be silently rewritten to 127.0.0.1
+        // right here, and that rewrite is what we advertised — pointing every
+        // peer that learned the address from us back at itself. Render the name
+        // as the A record the connect path has already resolved instead.
+        auto literal = wire_ipv4_literal();
+        if (!literal)
+        {
+            // Loud, and NOT loopback. 0.0.0.0 is rejected by is_connectable()
+            // on the receiving side, so it misdirects nobody. Getting here at
+            // all means an unresolved entry slipped past the
+            // is_wire_advertisable() filter on the advertisement path.
+            LOG_ERROR << "Write_IPV4: '" << ip << "' is not an IPv4 literal and has no "
+                      << "resolved address; emitting 0.0.0.0 (unroutable) rather than "
+                      << "loopback. This entry should not have been advertised.";
+            literal = std::string("0.0.0.0");
+        }
+        ip = *literal;
+
         std::vector<std::string> split_res;
         boost::algorithm::split(split_res, ip, boost::is_any_of("."));
-        if (split_res.size() != 4)
-        {
-            // Not a dotted-decimal IPv4 address (e.g. "localhost") — use loopback 127.0.0.1
-            LOG_WARNING << "Write_IPV4: non-dotted address '" << ip << "', substituting 127.0.0.1";
-            split_res = {"127", "0", "0", "1"};
-        }
 
         std::vector<unsigned int> bits;
         for (auto bit: split_res)

--- a/src/core/netaddress.hpp
+++ b/src/core/netaddress.hpp
@@ -22,6 +22,37 @@ enum AddrType
 static const std::array<uint8_t, 12> IPV4_IN_IPV6_PREFIX
     {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF};
 
+// ═══════════════════════════════════════════════════════════════════════════════
+// Resolved-host memo (#910)
+//
+// A NetAddress may hold a DNS NAME rather than a numeric literal — that is the
+// entire point of `--addnode rov.p2p-spb.xyz:8999`, and the name has to be kept
+// so every reconnect re-resolves it and the seed survives an IP change.
+//
+// The outbound connect path already resolves those names: core::Factory's
+// Client::resolve() issues one async_resolve() per dial (core/factory.hpp).
+// What follows is nothing more than a memo of THAT resolver's answers, so the
+// serializer can render a name as its real A record without introducing a
+// second resolution path that could disagree, and without ever performing a
+// blocking lookup on the serialize/IO path.
+//
+// Numeric literals are never stored — they need no resolution.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+namespace core
+{
+    /// Memoise a DNS answer produced by the outbound-connect resolver.
+    /// No-op when `host` is already a numeric literal, or `ip` is not one.
+    void record_resolved_host(const std::string& host, const std::string& ip);
+
+    /// Last address the connect path resolved `host` to, if any.
+    /// Pure in-memory lookup — never performs DNS.
+    std::optional<std::string> lookup_resolved_host(const std::string& host);
+
+    /// Test/reset hook. Not called from production paths.
+    void clear_resolved_hosts();
+}
+
 inline auto parse_address(std::string_view address_spec, std::string_view default_service = "https")
 {
     using namespace boost::spirit::x3;
@@ -54,6 +85,24 @@ public:
 
     void set_address(std::string ip) { m_ip = ip; }
     auto address() const { return m_ip; }
+
+    /// The numeric IPv4 literal this address will put on the wire (#910).
+    ///
+    ///   • already a dotted quad  -> itself (byte-for-byte identical wire output)
+    ///   • "localhost"            -> "127.0.0.1" (a genuine resolution, not a fallback)
+    ///   • a DNS name the connect path has resolved -> that A record
+    ///   • anything else          -> nullopt
+    ///
+    /// nullopt means "we do not know where this name points"; it must NEVER be
+    /// turned into loopback — a valid-looking address that misdirects every peer
+    /// that learns it back at itself.
+    std::optional<std::string> wire_ipv4_literal() const;
+
+    /// True when Serialize() will emit a real address for this entry. False for
+    /// a DNS name that has not been resolved yet; such an entry must be skipped
+    /// rather than advertised. Numeric literals — including a legitimate
+    /// `--addnode 127.0.0.1:18999` — are always advertisable.
+    bool is_wire_advertisable() const;
 
     friend bool operator==(const NetAddress& l, const NetAddress& r)
     { return (l.m_type == r.m_type) && (l.m_ip == r.m_ip); }

--- a/src/core/test/CMakeLists.txt
+++ b/src/core/test/CMakeLists.txt
@@ -45,7 +45,16 @@ if (BUILD_TESTING AND (GTest_FOUND OR GTEST_FOUND))
     # code every coin lane routes through, so one KAT covers all coins. Same
     # reasoning as above: FOLDED into the EXISTING allowlisted core_test target,
     # never a new add_executable (the #769 "Not Run" trap).
-    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp core_merkle_branches_test.cpp version_gate_test.cpp filesystem_test.cpp web_server_submitblock_test.cpp known_txs_eviction_test.cpp tx_advertiser_test.cpp socket_write_queue_test.cpp known_txs_backing_test.cpp random_choice_guard_test.cpp p2p_message_stats_test.cpp)
+    #
+    # netaddress_resolution_test.cpp: the #910 DNS-named-addnode defect. Pins the
+    # Write_IPV4 wire bytes for dotted quads and for genuine loopback (a p2p
+    # surface shared with canonical python p2pool — a byte change would be a
+    # compat break), proves a hostname never serializes to 127.0.0.1 and does
+    # serialize to the A record the outbound-connect resolver memoised, and
+    # carries a source KAT pinning the is_wire_advertisable() guard into all ten
+    # per-coin getaddrs handlers. Same reasoning as above: FOLDED into the
+    # EXISTING allowlisted core_test target, never a new add_executable.
+    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp core_merkle_branches_test.cpp version_gate_test.cpp filesystem_test.cpp web_server_submitblock_test.cpp known_txs_eviction_test.cpp tx_advertiser_test.cpp socket_write_queue_test.cpp known_txs_backing_test.cpp random_choice_guard_test.cpp p2p_message_stats_test.cpp netaddress_resolution_test.cpp)
     target_compile_definitions(core_test PRIVATE C2POOL_SRC_ROOT="${CMAKE_SOURCE_DIR}/src")
     target_link_libraries(core_test PRIVATE GTest::gtest_main core c2pool_merged_mining GTest::gtest)
     target_link_libraries(core_test PRIVATE c2pool_payout c2pool_hashrate ltc_coin)  # OBJECT-lib SCC direct-naming (#22/#39)

--- a/src/core/test/netaddress_resolution_test.cpp
+++ b/src/core/test/netaddress_resolution_test.cpp
@@ -1,0 +1,335 @@
+// Regression cover for issue #910 — a DNS-named --addnode was advertised to
+// peers as 127.0.0.1.
+//
+// NetAddress::Write_IPV4 used to split the address string on '.', demand
+// exactly four parts, and silently substitute loopback otherwise. The stored
+// string for `--addnode rov.p2p-spb.xyz:8999` is the HOSTNAME (kept on purpose,
+// so every reconnect re-resolves it), so every addrs/getaddrs reply carrying
+// that seed put 127.0.0.1 on the wire — an address that, for the peer learning
+// it, points back at itself.
+//
+// Three layers here:
+//
+//  1. WIRE PINS. Write_IPV4 emits 4 raw IPv4 bytes inside a 16-byte
+//     IPv4-in-IPv6 envelope. That is a p2p surface shared with canonical python
+//     p2pool, so the fix must not move a single byte for numeric input. Every
+//     dotted-quad KAT below is the byte string this serializer produced before
+//     the fix and must keep producing — including a genuine
+//     `--addnode 127.0.0.1:18999`, which the hotel legitimately runs.
+//
+//  2. THE DEFECT. A hostname must not serialize to loopback, and once the
+//     outbound-connect resolver has resolved it, it must serialize to that A
+//     record. Both of these fail on the pre-fix serializer.
+//
+//  3. THE ADVERTISEMENT FILTER. A source KAT pinning the
+//     is_wire_advertisable() guard into all ten per-coin
+//     protocol_actual.cpp / protocol_legacy.cpp getaddrs handlers, so no lane
+//     can quietly regress to advertising an unrenderable address.
+//
+// Folded into the EXISTING allowlisted core_test target — a standalone
+// add_executable is not in build.yml's --target list, so CI would never build
+// it and CTest would report the cases "Not Run" (the #769 trap). One KAT covers
+// every coin because all five node lanes consume this one shared core file.
+
+#include <gtest/gtest.h>
+
+#include <core/netaddress.hpp>
+#include <core/pack.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
+#include <regex>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+// The IPv4-in-IPv6 envelope every Write_IPV4 output carries.
+const std::vector<uint8_t> V4_PREFIX{
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff};
+
+std::vector<uint8_t> serialize(const NetAddress& addr)
+{
+    PackStream stream;
+    stream << addr;
+
+    std::vector<uint8_t> out;
+    for (auto b : stream.get_span())
+        out.push_back(std::to_integer<uint8_t>(b));
+    return out;
+}
+
+// The four address bytes, after asserting the 16-byte envelope.
+std::vector<uint8_t> wire_quad(const NetAddress& addr)
+{
+    auto bytes = serialize(addr);
+    EXPECT_EQ(bytes.size(), 16u) << "IPv4 addresses must occupy exactly 16 wire bytes";
+    if (bytes.size() != 16)
+        return {};
+    EXPECT_TRUE(std::equal(V4_PREFIX.begin(), V4_PREFIX.end(), bytes.begin()))
+        << "IPv4-in-IPv6 prefix must be unchanged";
+    return std::vector<uint8_t>(bytes.begin() + 12, bytes.end());
+}
+
+const std::vector<uint8_t> LOOPBACK_QUAD{0x7f, 0x00, 0x00, 0x01};
+
+// The two DNS names from the production hotel's --addnode list, and the
+// addresses they actually resolve to (issue #910).
+constexpr const char* HOST_ROV = "rov.p2p-spb.xyz";
+constexpr const char* HOST_USA = "usa.p2p-spb.xyz";
+constexpr const char* IP_ROV   = "83.221.211.116";
+constexpr const char* IP_USA   = "66.151.242.154";
+
+struct ResolvedHostsFixture : public ::testing::Test
+{
+    void SetUp() override { core::clear_resolved_hosts(); }
+    void TearDown() override { core::clear_resolved_hosts(); }
+};
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Layer 1: wire-format pins. These must be byte-identical before and after.
+// ---------------------------------------------------------------------------
+
+TEST_F(ResolvedHostsFixture, DottedQuadWireBytesAreUnchanged)
+{
+    struct Case { const char* ip; std::vector<uint8_t> quad; };
+    const std::vector<Case> cases{
+        {"0.0.0.0",         {0x00, 0x00, 0x00, 0x00}},
+        {"1.2.3.4",         {0x01, 0x02, 0x03, 0x04}},
+        {"10.0.0.1",        {0x0a, 0x00, 0x00, 0x01}},
+        {"192.168.1.1",     {0xc0, 0xa8, 0x01, 0x01}},
+        {"83.221.211.116",  {0x53, 0xdd, 0xd3, 0x74}},   // rov.p2p-spb.xyz
+        {"66.151.242.154",  {0x42, 0x97, 0xf2, 0x9a}},   // usa.p2p-spb.xyz
+        {"255.255.255.255", {0xff, 0xff, 0xff, 0xff}},
+    };
+
+    for (const auto& c : cases)
+    {
+        EXPECT_EQ(wire_quad(NetAddress(std::string(c.ip))), c.quad)
+            << "wire encoding changed for " << c.ip;
+    }
+}
+
+TEST_F(ResolvedHostsFixture, GenuineLoopbackStillSerializesAndRoundTrips)
+{
+    // The hotel legitimately runs `--addnode 127.0.0.1:18999`. A real loopback
+    // address is NOT what #910 is about and must keep working untouched.
+    EXPECT_EQ(wire_quad(NetAddress(std::string("127.0.0.1"))), LOOPBACK_QUAD);
+
+    PackStream stream;
+    NetService written{std::string("127.0.0.1"), uint16_t{18999}};
+    stream << written;
+    EXPECT_EQ(stream.get_span().size(), 18u);  // 16 address bytes + 2 port bytes
+
+    NetService read;
+    stream >> read;
+    EXPECT_EQ(read.address(), "127.0.0.1");
+    EXPECT_EQ(read.port(), uint16_t{18999});
+}
+
+TEST_F(ResolvedHostsFixture, LocalhostStillMapsToLoopback)
+{
+    // "localhost" IS 127.0.0.1 — a genuine resolution, not the blanket
+    // substitution. The default-constructed NetAddress carries "localhost", so
+    // this also pins the default ctor's wire bytes.
+    EXPECT_EQ(wire_quad(NetAddress(std::string("localhost"))), LOOPBACK_QUAD);
+    EXPECT_EQ(wire_quad(NetAddress()), LOOPBACK_QUAD);
+}
+
+TEST_F(ResolvedHostsFixture, DottedQuadRoundTripsThroughUnserialize)
+{
+    PackStream stream;
+    NetAddress written{std::string("83.221.211.116")};
+    stream << written;
+
+    NetAddress read;
+    stream >> read;
+    EXPECT_EQ(read.address(), "83.221.211.116");
+}
+
+// ---------------------------------------------------------------------------
+// Layer 2: the defect. Both of these fail on the pre-fix serializer.
+// ---------------------------------------------------------------------------
+
+TEST_F(ResolvedHostsFixture, UnresolvedHostnameDoesNotSerializeToLoopback)
+{
+    // Pre-fix: split("rov.p2p-spb.xyz", '.') yields 3 parts, so the serializer
+    // substituted {127,0,0,1} and we advertised loopback to every peer.
+    auto quad = wire_quad(NetAddress(std::string(HOST_ROV)));
+    EXPECT_NE(quad, LOOPBACK_QUAD)
+        << "a DNS name must never be advertised as loopback (#910)";
+
+    // Nor may it become any other plausible-looking address. Unknown means
+    // unroutable: 0.0.0.0 is rejected by is_connectable() at the far end.
+    EXPECT_EQ(quad, (std::vector<uint8_t>{0x00, 0x00, 0x00, 0x00}));
+}
+
+TEST_F(ResolvedHostsFixture, HostnameWithFourLabelsDoesNotSerializeAsGarbage)
+{
+    // A four-label name split into exactly four parts pre-fix and was fed
+    // straight into lexical_cast, producing silent garbage rather than an
+    // error. It is a name, not a literal, and must be treated as one.
+    auto quad = wire_quad(NetAddress(std::string("seed.node.example.com")));
+    EXPECT_NE(quad, LOOPBACK_QUAD);
+    EXPECT_EQ(quad, (std::vector<uint8_t>{0x00, 0x00, 0x00, 0x00}));
+
+    core::record_resolved_host("seed.node.example.com", IP_USA);
+    EXPECT_EQ(wire_quad(NetAddress(std::string("seed.node.example.com"))),
+              (std::vector<uint8_t>{0x42, 0x97, 0xf2, 0x9a}));
+}
+
+TEST_F(ResolvedHostsFixture, ResolvedHostnameSerializesToItsARecord)
+{
+    // This is what the outbound-connect resolver records on every dial.
+    core::record_resolved_host(HOST_ROV, IP_ROV);
+    core::record_resolved_host(HOST_USA, IP_USA);
+
+    EXPECT_EQ(wire_quad(NetAddress(std::string(HOST_ROV))),
+              (std::vector<uint8_t>{0x53, 0xdd, 0xd3, 0x74}));
+    EXPECT_EQ(wire_quad(NetAddress(std::string(HOST_USA))),
+              (std::vector<uint8_t>{0x42, 0x97, 0xf2, 0x9a}));
+
+    // ...and identical to serializing the literal directly.
+    EXPECT_EQ(wire_quad(NetAddress(std::string(HOST_ROV))),
+              wire_quad(NetAddress(std::string(IP_ROV))));
+}
+
+TEST_F(ResolvedHostsFixture, ResolvedHostnameKeepsItsNameForReconnect)
+{
+    // The whole point of a DNS seed is that it survives an IP change, so the
+    // name must stay the stored/dialled identity — only the wire rendering
+    // changes.
+    core::record_resolved_host(HOST_USA, IP_USA);
+    NetService svc{std::string(HOST_USA), uint16_t{8999}};
+    EXPECT_EQ(svc.address(), HOST_USA);
+    EXPECT_EQ(svc.to_string(), std::string(HOST_USA) + ":8999");
+}
+
+TEST_F(ResolvedHostsFixture, ReResolutionTracksAnIpChange)
+{
+    core::record_resolved_host(HOST_USA, IP_ROV);
+    EXPECT_EQ(wire_quad(NetAddress(std::string(HOST_USA))),
+              (std::vector<uint8_t>{0x53, 0xdd, 0xd3, 0x74}));
+
+    core::record_resolved_host(HOST_USA, IP_USA);   // next dial, new answer
+    EXPECT_EQ(wire_quad(NetAddress(std::string(HOST_USA))),
+              (std::vector<uint8_t>{0x42, 0x97, 0xf2, 0x9a}));
+}
+
+TEST_F(ResolvedHostsFixture, MemoRefusesNonNumericAnswersAndLiteralKeys)
+{
+    // The memo records answers from the ONE existing resolver; it must never
+    // become a second source of names, and a literal needs no memo.
+    core::record_resolved_host(HOST_ROV, "not-an-address");
+    EXPECT_FALSE(core::lookup_resolved_host(HOST_ROV).has_value());
+
+    core::record_resolved_host("1.2.3.4", IP_ROV);
+    EXPECT_FALSE(core::lookup_resolved_host("1.2.3.4").has_value());
+    // ...and a literal still serializes as itself regardless.
+    EXPECT_EQ(wire_quad(NetAddress(std::string("1.2.3.4"))),
+              (std::vector<uint8_t>{0x01, 0x02, 0x03, 0x04}));
+
+    // An AAAA-only answer cannot be squeezed into four IPv4 bytes, so it is
+    // treated as unknown rather than corrupting the envelope.
+    core::record_resolved_host(HOST_USA, "2001:db8::1");
+    EXPECT_TRUE(core::lookup_resolved_host(HOST_USA).has_value());
+    EXPECT_FALSE(NetAddress(std::string(HOST_USA)).is_wire_advertisable());
+    EXPECT_EQ(wire_quad(NetAddress(std::string(HOST_USA))),
+              (std::vector<uint8_t>{0x00, 0x00, 0x00, 0x00}));
+}
+
+// ---------------------------------------------------------------------------
+// Layer 3: the advertisement gate
+// ---------------------------------------------------------------------------
+
+TEST_F(ResolvedHostsFixture, AdvertisabilityGate)
+{
+    // Numeric literals are always advertisable — including genuine loopback,
+    // which is existing behaviour this fix must not disturb.
+    EXPECT_TRUE(NetAddress(std::string("83.221.211.116")).is_wire_advertisable());
+    EXPECT_TRUE(NetAddress(std::string("127.0.0.1")).is_wire_advertisable());
+    EXPECT_TRUE(NetAddress(std::string("0.0.0.0")).is_wire_advertisable());
+    EXPECT_TRUE(NetAddress(std::string("localhost")).is_wire_advertisable());
+
+    // An unresolved name is not — it gets skipped rather than advertised.
+    EXPECT_FALSE(NetAddress(std::string(HOST_ROV)).is_wire_advertisable());
+
+    core::record_resolved_host(HOST_ROV, IP_ROV);
+    EXPECT_TRUE(NetAddress(std::string(HOST_ROV)).is_wire_advertisable());
+
+    // NetService inherits the gate, which is the form the addr store holds.
+    EXPECT_FALSE(NetService(std::string(HOST_USA), uint16_t{8999}).is_wire_advertisable());
+    core::record_resolved_host(HOST_USA, IP_USA);
+    EXPECT_TRUE(NetService(std::string(HOST_USA), uint16_t{8999}).is_wire_advertisable());
+}
+
+// ---------------------------------------------------------------------------
+// Source KAT: every per-coin getaddrs handler must carry the filter.
+//
+// get_good_peers() feeds both the outbound dialler (where a hostname is
+// correct and must NOT be filtered) and the getaddrs reply (where an
+// unrenderable address must never reach the wire), so the guard lives at the
+// ten reply sites. This pins it there for all five lanes.
+// ---------------------------------------------------------------------------
+
+namespace
+{
+
+std::string read_source(const std::string& rel)
+{
+#ifndef C2POOL_SRC_ROOT
+#error "C2POOL_SRC_ROOT must be defined for the source KAT"
+#endif
+    const std::string path = std::string(C2POOL_SRC_ROOT) + "/" + rel;
+    std::ifstream f(path);
+    if (!f)
+        throw std::runtime_error("cannot open source file: " + path);
+    std::stringstream ss;
+    ss << f.rdbuf();
+    return ss.str();
+}
+
+} // namespace
+
+TEST(NetAddressAdvertiseFilterSourceKAT, EveryLaneFiltersUnrenderableAddrsFromGetaddrs)
+{
+    const std::vector<std::string> coins{"btc", "ltc", "bch", "dgb", "dash"};
+    const std::vector<std::string> protocols{"protocol_actual.cpp", "protocol_legacy.cpp"};
+
+    // The push that puts an addr store entry onto the wire.
+    const std::regex push_re(
+        R"(addrs\.push_back\(\{pair\.value\.m_service,\s*pair\.addr,\s*pair\.value\.m_last_seen\}\);)");
+    // The guard that must precede it.
+    const std::regex guard_re(
+        R"(if\s*\(!pair\.addr\.is_wire_advertisable\(\)\)\s*continue;)");
+
+    for (const auto& coin : coins)
+    {
+        for (const auto& proto : protocols)
+        {
+            const std::string rel = "impl/" + coin + "/" + proto;
+            const std::string src = read_source(rel);
+
+            EXPECT_TRUE(std::regex_search(src, push_re))
+                << rel << ": getaddrs reply push site not found — the KAT has "
+                          "drifted from the code it is meant to pin";
+
+            std::smatch guard_m, push_m;
+            ASSERT_TRUE(std::regex_search(src, guard_m, guard_re))
+                << rel << ": getaddrs must skip addresses that cannot be "
+                          "rendered on the wire (#910)";
+            ASSERT_TRUE(std::regex_search(src, push_m, push_re));
+
+            EXPECT_LT(guard_m.position(0), push_m.position(0))
+                << rel << ": the is_wire_advertisable() guard must precede the "
+                          "addrs.push_back()";
+        }
+    }
+}

--- a/src/impl/bch/protocol_actual.cpp
+++ b/src/impl/bch/protocol_actual.cpp
@@ -124,6 +124,13 @@ void Actual::HANDLER(getaddrs)
     std::vector<addr_record_t> addrs;
     for (const auto& pair : get_good_peers(msg->m_count))
     {
+        // #910: never advertise an address we cannot render on the wire. A
+        // DNS-named seed that the outbound-connect resolver has not resolved
+        // yet used to serialize as 127.0.0.1, pointing every peer that learned
+        // it from us back at itself. Skip it; the next sweep re-offers it once
+        // a dial has resolved the name.
+        if (!pair.addr.is_wire_advertisable())
+            continue;
         addrs.push_back({pair.value.m_service, pair.addr, pair.value.m_last_seen});
     }
 

--- a/src/impl/bch/protocol_legacy.cpp
+++ b/src/impl/bch/protocol_legacy.cpp
@@ -114,6 +114,13 @@ void Legacy::HANDLER(getaddrs)
     std::vector<addr_record_t> addrs;
     for (const auto& pair : get_good_peers(msg->m_count))
     {
+        // #910: never advertise an address we cannot render on the wire. A
+        // DNS-named seed that the outbound-connect resolver has not resolved
+        // yet used to serialize as 127.0.0.1, pointing every peer that learned
+        // it from us back at itself. Skip it; the next sweep re-offers it once
+        // a dial has resolved the name.
+        if (!pair.addr.is_wire_advertisable())
+            continue;
         addrs.push_back({pair.value.m_service, pair.addr, pair.value.m_last_seen});
     }
 

--- a/src/impl/btc/protocol_actual.cpp
+++ b/src/impl/btc/protocol_actual.cpp
@@ -87,6 +87,13 @@ void Actual::HANDLER(getaddrs)
     std::vector<addr_record_t> addrs;
     for (const auto& pair : get_good_peers(msg->m_count))
     {
+        // #910: never advertise an address we cannot render on the wire. A
+        // DNS-named seed that the outbound-connect resolver has not resolved
+        // yet used to serialize as 127.0.0.1, pointing every peer that learned
+        // it from us back at itself. Skip it; the next sweep re-offers it once
+        // a dial has resolved the name.
+        if (!pair.addr.is_wire_advertisable())
+            continue;
         addrs.push_back({pair.value.m_service, pair.addr, pair.value.m_last_seen});
     }
 

--- a/src/impl/btc/protocol_legacy.cpp
+++ b/src/impl/btc/protocol_legacy.cpp
@@ -85,6 +85,13 @@ void Legacy::HANDLER(getaddrs)
     std::vector<addr_record_t> addrs;
     for (const auto& pair : get_good_peers(msg->m_count))
     {
+        // #910: never advertise an address we cannot render on the wire. A
+        // DNS-named seed that the outbound-connect resolver has not resolved
+        // yet used to serialize as 127.0.0.1, pointing every peer that learned
+        // it from us back at itself. Skip it; the next sweep re-offers it once
+        // a dial has resolved the name.
+        if (!pair.addr.is_wire_advertisable())
+            continue;
         addrs.push_back({pair.value.m_service, pair.addr, pair.value.m_last_seen});
     }
 

--- a/src/impl/dash/protocol_actual.cpp
+++ b/src/impl/dash/protocol_actual.cpp
@@ -87,6 +87,13 @@ void Actual::HANDLER(getaddrs)
     std::vector<addr_record_t> addrs;
     for (const auto& pair : get_good_peers(msg->m_count))
     {
+        // #910: never advertise an address we cannot render on the wire. A
+        // DNS-named seed that the outbound-connect resolver has not resolved
+        // yet used to serialize as 127.0.0.1, pointing every peer that learned
+        // it from us back at itself. Skip it; the next sweep re-offers it once
+        // a dial has resolved the name.
+        if (!pair.addr.is_wire_advertisable())
+            continue;
         addrs.push_back({pair.value.m_service, pair.addr, pair.value.m_last_seen});
     }
 

--- a/src/impl/dash/protocol_legacy.cpp
+++ b/src/impl/dash/protocol_legacy.cpp
@@ -85,6 +85,13 @@ void Legacy::HANDLER(getaddrs)
     std::vector<addr_record_t> addrs;
     for (const auto& pair : get_good_peers(msg->m_count))
     {
+        // #910: never advertise an address we cannot render on the wire. A
+        // DNS-named seed that the outbound-connect resolver has not resolved
+        // yet used to serialize as 127.0.0.1, pointing every peer that learned
+        // it from us back at itself. Skip it; the next sweep re-offers it once
+        // a dial has resolved the name.
+        if (!pair.addr.is_wire_advertisable())
+            continue;
         addrs.push_back({pair.value.m_service, pair.addr, pair.value.m_last_seen});
     }
 

--- a/src/impl/dgb/protocol_actual.cpp
+++ b/src/impl/dgb/protocol_actual.cpp
@@ -87,6 +87,13 @@ void Actual::HANDLER(getaddrs)
     std::vector<addr_record_t> addrs;
     for (const auto& pair : get_good_peers(msg->m_count))
     {
+        // #910: never advertise an address we cannot render on the wire. A
+        // DNS-named seed that the outbound-connect resolver has not resolved
+        // yet used to serialize as 127.0.0.1, pointing every peer that learned
+        // it from us back at itself. Skip it; the next sweep re-offers it once
+        // a dial has resolved the name.
+        if (!pair.addr.is_wire_advertisable())
+            continue;
         addrs.push_back({pair.value.m_service, pair.addr, pair.value.m_last_seen});
     }
 

--- a/src/impl/dgb/protocol_legacy.cpp
+++ b/src/impl/dgb/protocol_legacy.cpp
@@ -85,6 +85,13 @@ void Legacy::HANDLER(getaddrs)
     std::vector<addr_record_t> addrs;
     for (const auto& pair : get_good_peers(msg->m_count))
     {
+        // #910: never advertise an address we cannot render on the wire. A
+        // DNS-named seed that the outbound-connect resolver has not resolved
+        // yet used to serialize as 127.0.0.1, pointing every peer that learned
+        // it from us back at itself. Skip it; the next sweep re-offers it once
+        // a dial has resolved the name.
+        if (!pair.addr.is_wire_advertisable())
+            continue;
         addrs.push_back({pair.value.m_service, pair.addr, pair.value.m_last_seen});
     }
 

--- a/src/impl/ltc/protocol_actual.cpp
+++ b/src/impl/ltc/protocol_actual.cpp
@@ -87,6 +87,13 @@ void Actual::HANDLER(getaddrs)
     std::vector<addr_record_t> addrs;
     for (const auto& pair : get_good_peers(msg->m_count))
     {
+        // #910: never advertise an address we cannot render on the wire. A
+        // DNS-named seed that the outbound-connect resolver has not resolved
+        // yet used to serialize as 127.0.0.1, pointing every peer that learned
+        // it from us back at itself. Skip it; the next sweep re-offers it once
+        // a dial has resolved the name.
+        if (!pair.addr.is_wire_advertisable())
+            continue;
         addrs.push_back({pair.value.m_service, pair.addr, pair.value.m_last_seen});
     }
 

--- a/src/impl/ltc/protocol_legacy.cpp
+++ b/src/impl/ltc/protocol_legacy.cpp
@@ -85,6 +85,13 @@ void Legacy::HANDLER(getaddrs)
     std::vector<addr_record_t> addrs;
     for (const auto& pair : get_good_peers(msg->m_count))
     {
+        // #910: never advertise an address we cannot render on the wire. A
+        // DNS-named seed that the outbound-connect resolver has not resolved
+        // yet used to serialize as 127.0.0.1, pointing every peer that learned
+        // it from us back at itself. Skip it; the next sweep re-offers it once
+        // a dial has resolved the name.
+        if (!pair.addr.is_wire_advertisable())
+            continue;
         addrs.push_back({pair.value.m_service, pair.addr, pair.value.m_last_seen});
     }
 


### PR DESCRIPTION
Fixes #910.

A DNS-named `--addnode` was advertised to peers as `127.0.0.1`.

## Verified root cause

`src/core/netaddress.cpp` — `NetAddress::Write_IPV4` opens at **line 11**; the defect is the fallback block at **lines 23-28** (pre-fix):

```cpp
std::vector<std::string> split_res;
boost::algorithm::split(split_res, ip, boost::is_any_of("."));
if (split_res.size() != 4)
{
    LOG_WARNING << "Write_IPV4: non-dotted address '" << ip << "', substituting 127.0.0.1";
    split_res = {"127", "0", "0", "1"};
}
```

`NetAddress` stores the address as a *string*, and for a hostname seed that string is the hostname — deliberately, so every reconnect re-resolves it. The serializer split it on `.`, saw 3 parts for `rov.p2p-spb.xyz`, and wrote loopback. `Write_IPV4` is what we put on the wire, so any peer that learned that seed from us got an address pointing back at itself.

Confirmed on this tree:

* The **outbound connect path resolves correctly** — `src/core/factory.hpp:157`, `Client::resolve()` issues `async_resolve(addr.address(), addr.port_str())` per dial, and `pool::BaseNode` (`src/pool/node.hpp:37`) inherits `core::Factory<Server, Client>`, so this is the one dialler for all five lanes. That matches the field observation that the hotel is connected to `66.151.242.154` while logging the substitution warning for `usa.p2p-spb.xyz`.
* The **hostname reaches the wire** via the addr store: bootstrap seeds go in verbatim (`core::AddrStore::load`), `get_good_peers()` (`src/pool/node.hpp:169`) hands them back verbatim, and the ten per-coin `HANDLER(getaddrs)` sites serialize them into an `addrs` reply.

Two corrections to the reported details, neither of which changes the fix:

1. The cited `netaddress.cpp:11` is the function signature, not the substitution — that is lines 23-28.
2. The loopback substitution only catches names with a label count other than 4. A **four**-label name (`seed.node.example.com`) passed the `size() != 4` check and fell through to `lexical_cast`, which threw per label and produced `0.0.0.0` plus four `LOG_ERROR` lines. So the pre-fix behaviour was "3-label name -> loopback, 4-label name -> garbage". Both are covered here.

## Which resolver was reused, and why

The existing one — `core::Factory`'s `Client::resolve()` in `src/core/factory.hpp`. Its completion handler already holds both the configured host string and the resolved endpoints, so the fix memoises the A record there (`core::record_resolved_host`). No second lookup is introduced anywhere, which is the point: two independent resolution paths that can disagree would be its own defect. It also means the fix is cross-coin by construction — every lane dials through this one `Client`.

## Where resolution now happens

Not at serialization, and not blocking anywhere.

* **Resolve**: on the outbound dial, where it already happened. Async, on the io_context, unchanged.
* **Serialize**: `Write_IPV4` does a `shared_lock` map lookup — `NetAddress::wire_ipv4_literal()`. Never DNS. A dotted quad short-circuits before the lookup is even reached.
* **Store**: the hostname stays the stored and dialled identity. `address()`, `to_string()`, the addr store key and the JSON persistence are all untouched, so a DNS seed still survives an IP change — that is the entire reason to use a hostname. A re-resolution that returns a different address simply overwrites the memo (logged at INFO).

`"localhost"` is handled explicitly as a genuine resolution to `127.0.0.1`, not as a fallback. That also keeps the default-constructed `NetAddress` (whose `m_ip` is `"localhost"`) serializing to exactly the bytes it always has.

## On resolution failure

Never loopback. Two layers:

1. **Skip the entry.** `NetAddress::is_wire_advertisable()` is false for a name with no memoised A record, and all ten `HANDLER(getaddrs)` sites now `continue` past such entries instead of putting them in the `addrs` reply. The seed is still dialled and still re-offered on the next sweep once a dial has resolved it — only the *advertisement* is withheld.
2. **Loud, unroutable, if one slips through.** `Write_IPV4` cannot skip — the message has a count prefix and the field is fixed-width — so an unrenderable address becomes `0.0.0.0` with a `LOG_ERROR` naming the address. `0.0.0.0` is classified `AddrClass::unspecified` and rejected by the existing `is_connectable()` at the receiving end, so it misdirects nobody. Loopback is worse than no address precisely because it is valid-looking.

A memoised AAAA answer is also treated as "unknown" rather than being fed into the four-byte IPv4 encoder.

## Wire format

Unchanged. `Write_IPV4` still emits exactly 16 bytes (12-byte IPv4-in-IPv6 prefix + 4 address bytes), and the byte-producing code — the split/`lexical_cast`/append loop — is untouched. The only change is *what string it is handed*: for a numeric literal, itself, byte-for-byte as before.

The one behavioural difference for non-hostname input is that a malformed 4-part string (`1.2.3.999`, `a.b.c.d`) now takes the loud `0.0.0.0` path instead of silently emitting `1.2.3.231` / `0.0.0.0`. That input was already producing garbage.

## What the tests prove

`src/core/test/netaddress_resolution_test.cpp`, folded into the **existing** allowlisted `core_test` target — no new `add_executable`, so it cannot land as a "Not Run" (the #769 trap).

**Wire pins (must not move a byte):**
* `DottedQuadWireBytesAreUnchanged` — seven KATs, including both hotel seed IPs, `0.0.0.0` and `255.255.255.255`, pinned to their exact 4 bytes inside the exact 16-byte envelope.
* `GenuineLoopbackStillSerializesAndRoundTrips` — `127.0.0.1` still gives `7f 00 00 01`, and `NetService("127.0.0.1", 18999)` still round-trips through `Serialize`/`Unserialize` at 18 bytes. The hotel legitimately runs `--addnode 127.0.0.1:18999`.
* `LocalhostStillMapsToLoopback` — `"localhost"` and the default-constructed `NetAddress` still serialize to loopback.
* `DottedQuadRoundTripsThroughUnserialize`.

**The defect (these fail on the pre-fix serializer):**
* `UnresolvedHostnameDoesNotSerializeToLoopback` — `rov.p2p-spb.xyz` must not produce `7f 00 00 01`. Pre-fix it produces exactly that.
* `ResolvedHostnameSerializesToItsARecord` — after the connect path records the A record, both hotel hostnames serialize byte-identically to their literals.
* `HostnameWithFourLabelsDoesNotSerializeAsGarbage` — covers the second pre-fix path described above.
* `ReResolutionTracksAnIpChange`, `ResolvedHostnameKeepsItsNameForReconnect` — the seed keeps its name and follows its IP.
* `MemoRefusesNonNumericAnswersAndLiteralKeys` — the memo can never become a second source of *names*, and an AAAA answer does not corrupt the IPv4 envelope.
* `AdvertisabilityGate` — the skip predicate, including that genuine loopback stays advertisable.

**Regression fence:**
* `EveryLaneFiltersUnrenderableAddrsFromGetaddrs` — a source KAT asserting the `is_wire_advertisable()` guard exists and precedes the `addrs.push_back(...)` in all ten `src/impl/{btc,ltc,bch,dgb,dash}/protocol_{actual,legacy}.cpp` getaddrs handlers, so no lane can quietly regress.

## Blast radius

`src/core/netaddress.cpp` and `src/core/factory.hpp` are shared core: **all five lanes (ltc / btc / bch / dgb / dash)**, both `Actual` and `Legacy` protocols. This is not DASH-only — `src/impl/btc/config_pool.hpp:212-222`, `src/impl/ltc/config_pool.hpp:216-228` and `src/impl/bch/config_pool.hpp:251-259` ship **hardcoded DNS-name bootstrap seeds** (`p2p-spb.xyz`, `ekb.p2p-spb.xyz`, `rov.p2p-spb.xyz`, `usa.p2p-spb.xyz`, `ml.toom.im`, `btc.p2pool.leblancnet.us`, `bch.p2pool.leblancnet.us`, `siberia.mine.nu`), so a default-configured BTC/LTC/BCH node was advertising those as loopback with no operator action at all.

Not reward-affecting: no share, block, payout or consensus path is touched. Peer-discovery quality only.

## Not changed here

* `version`'s `addr_from` is still the hardcoded `NetService{"0.0.0.0", <compile-time default port>}` in every lane, and the coin-facing `version` still sends `192.168.0.1` / `0.0.0.0`. Both are pre-existing and separate from this issue.
* #882 (addrme self-probe comparing `127.0.0.0`) is untouched — that is the receive end of the same loopback mishandling.
