### PR TITLE
dash(p2p): originate addrme and fix the Legacy loopback self-probe (#882)

### DIFF
--- a/src/core/factory.hpp
+++ b/src/core/factory.hpp
@@ -88,6 +88,33 @@ public:
     }
 
 	uint16_t listen_port() const { return m_acceptor->local_endpoint().port(); }
+
+	/// Canonical p2p.py:110 — `if self.node.serverfactory.listen_port is not None`.
+	///
+	/// listen_port() above is only valid on a node that actually listens: it
+	/// dereferences the optional acceptor unconditionally (empty for the
+	/// rig-free `Server(nullptr, ...)` construction used by the KAT targets)
+	/// and calls local_endpoint() on it, which THROWS boost::system::system_error
+	/// (bad_descriptor) when the acceptor was never opened. c2pool has a real
+	/// non-listening mode — DASH's `--connect` suppresses the inbound listener
+	/// (src/c2pool/main_dash.cpp:566) — so an advertisement path that needs our
+	/// listen port must be able to ask "are we listening at all?" without
+	/// throwing. That is exactly the question canonical asks before deciding
+	/// whether to advertise, and this is the accessor that answers it.
+	///
+	/// Additive: listen_port() is untouched, so no existing caller changes.
+	std::optional<uint16_t> listen_port_or_none() const noexcept
+	{
+		if (!m_acceptor || !m_acceptor->is_open())
+			return std::nullopt;
+
+		boost::system::error_code ec;
+		const auto ep = m_acceptor->local_endpoint(ec);
+		if (ec)
+			return std::nullopt;
+
+		return ep.port();
+	}
 };
 
 class Client

--- a/src/impl/dash/node.hpp
+++ b/src/impl/dash/node.hpp
@@ -743,6 +743,31 @@ public:
         // consensus/mint state touched.
         peer->write(dash::message_getaddrs::make_raw(8));
 
+        // #882 — ORIGINATE addrme. Canonical p2p.py:109-134 sendAdvertisement():
+        // a listening node with no configured external IP asks the peer to
+        // advertise back what IT believes our address to be, carrying our listen
+        // port as the only thing the peer cannot observe for itself. Port of the
+        // ltc reference (src/impl/ltc/node.cpp:343-348; btc node.cpp:344-348,
+        // bch node.cpp:342-346, dgb node.cpp:349-353). DASH registered the
+        // handler on both generations (node.hpp:1272 Legacy / 1291 Actual) but
+        // nothing in the lane ever WROTE one, so a DASH peer could only ever
+        // learn our listen port second-hand from someone else's addrs gossip.
+        // Discovery only; no consensus/mint state touched.
+        //
+        // GUARDED, unlike the ltc/btc port. Canonical gates the whole
+        // advertisement on `if self.node.serverfactory.listen_port is not None`
+        // (p2p.py:110), and DASH has a real non-listening mode: `--connect`
+        // without `--listen` suppresses the inbound listener
+        // (src/c2pool/main_dash.cpp:566). core::Server::listen_port() reads
+        // m_acceptor->local_endpoint() unconditionally, which throws on an
+        // acceptor that was never opened — and a throw out of handle_version
+        // makes the bridge drop the connection, so an unguarded read would break
+        // --connect mode outright. listen_port_or_none() is canonical's
+        // `is not None` test; when we are not listening we advertise nothing,
+        // exactly as canonical does.
+        if (auto our_listen_port = core::Server::listen_port_or_none())
+            peer->write(dash::message_addrme::make_raw(*our_listen_port));
+
         // Canonical p2p.py:276 — one FULL have_tx as soon as the handshake
         // completes, so the peer's view of our tx pool starts correct (and its
         // dashboard stops showing us as txpool = 0). Subsequent sweeps send

--- a/src/impl/dash/protocol_legacy.cpp
+++ b/src/impl/dash/protocol_legacy.cpp
@@ -52,7 +52,17 @@ void Legacy::HANDLER(addrs)
 
 void Legacy::HANDLER(addrme)
 {
-    if (peer->addr().address() == "127.0.0.0")
+    // #882 — the loopback HOST address, not the loopback NETWORK address.
+    // Canonical p2p.py:281 compares `host == '127.0.0.1'`, and so does the
+    // Actual generation (protocol_actual.cpp:57). Legacy shipped "127.0.0.0",
+    // the /8 network address, which no peer can ever present as its source IP,
+    // so this branch was unreachable and EVERY addrme — including one arriving
+    // over loopback — fell into the else arm below: it recorded
+    // 127.0.0.1:<port> in our AddrStore as if it were a routable peer and then
+    // gossiped that loopback record onward in an addrs message. Legacy is the
+    // only generation live on DASH today. Related to #910, which fixes the
+    // other end of the same subsystem (a hostname serialising AS 127.0.0.1).
+    if (peer->addr().address() == "127.0.0.1")
     {
         if (!m_peers.empty() && (core::random::random_float(0, 1) < 0.8))
         {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -304,7 +304,15 @@ if (BUILD_TESTING AND GTest_FOUND)
     # target would need a build.yml --target edit and, until it had one, would
     # trip CI's NOT_BUILT sentinel (the drift-guard audit, #883/#893). It needs
     # exactly this link set — NodeImpl + ShareTracker + core MiningInterface.
-    add_executable(test_dash_node test_dash_node.cpp test_dash_dashboard_found_block.cpp)
+    # test_dash_addrme.cpp (#882): the addrme origination + Legacy self-probe
+    # KATs. Drives the REAL NodeImpl::handle_version and the REAL
+    # dash::Legacy::handle(message_addrme) over a REAL loopback TCP socket, so it
+    # needs exactly this link set (NodeImpl + the `dash` OBJECT lib carrying
+    # protocol_legacy.cpp + core Socket/Packet). FOLDED in as a third TU for the
+    # same reason as the second: a standalone target would need a build.yml
+    # --target edit and would trip CI's NOT_BUILT sentinel until it had one
+    # (#769/#883/#893).
+    add_executable(test_dash_node test_dash_node.cpp test_dash_dashboard_found_block.cpp test_dash_addrme.cpp)
     target_link_libraries(test_dash_node PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core

--- a/test/test_dash_addrme.cpp
+++ b/test/test_dash_addrme.cpp
@@ -1,0 +1,461 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// DASH addrme KAT — issue #882.
+//
+// Two independent defects, both proven here against the REAL code paths rather
+// than against a re-implementation:
+//
+//  (a) DASH never ORIGINATED an addrme. dash::message_addrme was registered as a
+//      handler on both generations (src/impl/dash/node.hpp:1272 Legacy,
+//      :1291 Actual) but nothing in the lane ever WROTE one, while ltc
+//      (node.cpp:346), btc (:346), bch (:344) and dgb (:352) all write one from
+//      handle_version. A DASH peer therefore never learned our listen port from
+//      us directly. `HandleVersionWritesAddrmeCarryingOurListenPort` drives the
+//      real NodeImpl::handle_version over a real TCP socket and reads the frames
+//      the node actually put on the wire — it sees NO addrme frame before the
+//      fix.
+//
+//  (b) The Legacy addrme self-probe compared "127.0.0.0", the loopback NETWORK
+//      address, which no peer can ever present as its source IP.
+//      `LoopbackPeerPresentsHostAddressNotNetworkAddress` proves that with a
+//      real accepted loopback connection, and
+//      `LoopbackAddrmeIsNotRecordedAsARoutablePeer` drives the real
+//      dash::Legacy::handle(message_addrme) and shows the else-arm consequence:
+//      before the fix a loopback addrme was inserted into the AddrStore as a
+//      routable peer and gossiped onward. Legacy is the ONLY generation live on
+//      DASH today (handle_version returns legacy until the floor is ratcheted).
+//
+// Wire format is UNCHANGED and pinned here as well as in the pre-existing
+// DashPoolNodeMessages.Message_Addrme_LayoutPinned KAT
+// (test/test_dash_poolnode_messages.cpp:50).
+//
+// FOLDED into the EXISTING allowlisted `test_dash_node` target — a standalone
+// add_executable is absent from build.yml's --target list, is never built in CI,
+// and CTest then reports its cases "Not Run" (the #769 trap).
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/node.hpp>
+#include <impl/dash/config.hpp>
+#include <impl/dash/messages.hpp>
+
+#include <core/factory.hpp>
+#include <core/netaddress.hpp>
+#include <core/packet.hpp>
+#include <core/socket.hpp>
+#include <core/uint256.hpp>
+
+#include <boost/asio.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <optional>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+using boost::asio::ip::tcp;
+
+// Wire header written by core::Packet::from_message (src/core/packet.hpp:22):
+//   prefix(N) | command(12, NUL-padded) | length(4, LE) | checksum(4) | payload
+constexpr std::size_t kCommandLen  = 12;
+constexpr std::size_t kLengthLen   = 4;
+constexpr std::size_t kChecksumLen = 4;
+
+const std::vector<std::byte>& test_prefix()
+{
+    // Arbitrary but fixed: the framing prefix is a per-net constant and is not
+    // what this KAT is about. Same shape as core/test/socket_write_queue_test.cpp.
+    static const std::vector<std::byte> prefix{
+        std::byte{0xfc}, std::byte{0xc1}, std::byte{0xb7}, std::byte{0xdc}};
+    return prefix;
+}
+
+// Minimal ICommunicator for core::Socket. On the WRITE path the socket only
+// needs get_prefix(); error() covers the failure path. Constructed with an empty
+// weak_ptr<INetwork> and was_managed=false, i.e. the legacy unmanaged-node path,
+// so acquire_node() short-circuits to true and no INetwork is required.
+struct StubCommunicator : public core::ICommunicator
+{
+    std::atomic<int> error_count{0};
+
+    void error(const message_error_type&, const NetService&,
+               const std::source_location = std::source_location::current()) override
+    {
+        error_count.fetch_add(1, std::memory_order_relaxed);
+    }
+    void error(const boost::system::error_code&, const NetService&,
+               const std::source_location = std::source_location::current()) override
+    {
+        error_count.fetch_add(1, std::memory_order_relaxed);
+    }
+    void handle(std::unique_ptr<RawMessage>, const NetService&) override {}
+    const std::vector<std::byte>& get_prefix() const override { return test_prefix(); }
+};
+
+// Real loopback TCP pair. `ours` is the end the node writes to (wrapped in a
+// core::Socket and handed to a pool::Peer); `theirs` is the peer end, read
+// synchronously so the test sees exactly the bytes that went on the wire.
+struct LoopbackPair
+{
+    boost::asio::io_context ioc_peer;
+    boost::asio::io_context ioc_node;
+    std::unique_ptr<tcp::acceptor> acceptor;
+    std::unique_ptr<tcp::socket> theirs;
+    std::unique_ptr<tcp::socket> ours;
+
+    LoopbackPair()
+    {
+        acceptor = std::make_unique<tcp::acceptor>(
+            ioc_peer, tcp::endpoint(boost::asio::ip::make_address("127.0.0.1"), 0));
+        acceptor->listen();
+
+        ours = std::make_unique<tcp::socket>(ioc_node);
+        ours->connect(acceptor->local_endpoint());
+
+        theirs = std::make_unique<tcp::socket>(acceptor->accept());
+
+        boost::system::error_code ec;
+        ours->set_option(tcp::no_delay(true), ec);
+        theirs->set_option(tcp::no_delay(true), ec);
+    }
+};
+
+// Runs an io_context on its own thread for the lifetime of the scope — the
+// production shape: writes are submitted from the caller's thread and drained
+// by the io thread.
+struct IoThread
+{
+    boost::asio::executor_work_guard<boost::asio::io_context::executor_type> guard;
+    std::thread thread;
+
+    explicit IoThread(boost::asio::io_context& ioc)
+        : guard(boost::asio::make_work_guard(ioc)), thread([&ioc] { ioc.run(); })
+    {
+    }
+    void stop(boost::asio::io_context& ioc)
+    {
+        guard.reset();
+        ioc.stop();
+        if (thread.joinable()) thread.join();
+    }
+};
+
+struct Frame
+{
+    std::string command;                 // trimmed of NUL padding
+    std::vector<std::byte> payload;
+};
+
+// Drains up to `budget` bytes from a synchronous socket, stopping early once the
+// socket goes quiet, then splits the stream into wire frames. Bounded by a read
+// deadline so a missing message fails the assertion instead of hanging CI.
+std::vector<Frame> read_frames(tcp::socket& s, std::chrono::milliseconds quiet_for)
+{
+    std::vector<std::byte> buf;
+    const auto deadline = std::chrono::steady_clock::now() + quiet_for;
+
+    // Non-blocking drain: poll until the deadline, accumulating whatever the
+    // node wrote. There is no length prefix at the stream level to key off, so a
+    // time budget is the honest stop condition.
+    s.non_blocking(true);
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+        std::array<std::byte, 4096> chunk{};
+        boost::system::error_code ec;
+        const std::size_t n = s.read_some(boost::asio::buffer(chunk), ec);
+        if (n > 0)
+            buf.insert(buf.end(), chunk.begin(), chunk.begin() + n);
+        else if (ec == boost::asio::error::would_block)
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        else if (ec)
+            break;
+    }
+
+    std::vector<Frame> frames;
+    const std::size_t prefix_len = test_prefix().size();
+    const std::size_t header = prefix_len + kCommandLen + kLengthLen + kChecksumLen;
+    std::size_t off = 0;
+    while (off + header <= buf.size())
+    {
+        // Prefix must match or the stream is not what we think it is.
+        if (std::memcmp(buf.data() + off, test_prefix().data(), prefix_len) != 0)
+            break;
+
+        const auto* cmd = reinterpret_cast<const char*>(buf.data() + off + prefix_len);
+        std::string command(cmd, kCommandLen);
+        if (const auto z = command.find('\0'); z != std::string::npos)
+            command.resize(z);
+
+        std::uint32_t len = 0;
+        std::memcpy(&len, buf.data() + off + prefix_len + kCommandLen, kLengthLen);
+
+        if (off + header + len > buf.size())
+            break;
+
+        Frame f;
+        f.command = std::move(command);
+        f.payload.assign(buf.begin() + off + header, buf.begin() + off + header + len);
+        frames.push_back(std::move(f));
+
+        off += header + len;
+    }
+    return frames;
+}
+
+const Frame* find_frame(const std::vector<Frame>& frames, std::string_view command)
+{
+    for (const auto& f : frames)
+        if (f.command == command) return &f;
+    return nullptr;
+}
+
+// Exposes the protected AddrStore so the loopback-pollution assertion can look
+// at what the handler actually recorded.
+class ProbeLegacy : public dash::Legacy
+{
+public:
+    using dash::Legacy::Legacy;
+    core::AddrStore& addrs() { return m_addrs; }
+    std::map<uint64_t, peer_ptr>& peers() { return m_peers; }
+};
+
+dash::NodeImpl::peer_ptr make_socket_peer(LoopbackPair& pair, StubCommunicator& stub)
+{
+    auto sock = std::make_shared<core::Socket>(
+        std::move(pair.ours), core::outgoing, &stub,
+        std::weak_ptr<core::INetwork>{}, /*was_managed=*/false);
+    // init() latches m_addr from the REAL remote endpoint — this is where
+    // peer->addr().address() gets its value on the live path.
+    sock->init();
+    return std::make_shared<dash::NodeImpl::peer_t>(sock);
+}
+
+std::unique_ptr<RawMessage> make_version(std::uint64_t nonce)
+{
+    return dash::message_version::make_raw(
+        dash::SharechainConfig::MINIMUM_PROTOCOL_VERSION,          // exactly at the cold floor
+        std::uint64_t{0},                                          // services
+        addr_t(1u, NetService("192.168.1.1", 9999)),          // addr_to
+        addr_t(1u, NetService("192.168.1.2", 8888)),          // addr_from
+        nonce,
+        std::string("c2pool-dash-addrme-kat"),
+        1u,                                                        // mode
+        uint256());                                                // best_share = null
+}
+
+} // namespace
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 0. WIRE FORMAT IS UNCHANGED. The fix adds a CALL SITE, never a byte.
+// ─────────────────────────────────────────────────────────────────────────────
+TEST(DashAddrme, WireFormatByteIdentical)
+{
+    auto rmsg = dash::message_addrme::make_raw(std::uint16_t(0x1234));
+    ASSERT_EQ(rmsg->m_command, "addrme");
+
+    auto span = rmsg->m_data.get_span();
+    ASSERT_EQ(span.size(), 2u);
+    EXPECT_EQ(std::to_integer<int>(span[0]), 0x34);   // uint16 port, little-endian
+    EXPECT_EQ(std::to_integer<int>(span[1]), 0x12);
+
+    // Full framed packet: prefix | "addrme" NUL-padded to 12 | length=2 | ...
+    auto stream = core::Packet::from_message(test_prefix(), rmsg);
+    const auto* bytes = reinterpret_cast<const unsigned char*>(stream.data());
+    ASSERT_GE(stream.size(), test_prefix().size() + kCommandLen + kLengthLen + kChecksumLen + 2);
+
+    const std::size_t p = test_prefix().size();
+    EXPECT_EQ(std::string(reinterpret_cast<const char*>(bytes + p), 6), "addrme");
+    for (std::size_t i = 6; i < kCommandLen; ++i)
+        EXPECT_EQ(bytes[p + i], 0u) << "command field must stay NUL-padded at " << i;
+
+    std::uint32_t len = 0;
+    std::memcpy(&len, bytes + p + kCommandLen, kLengthLen);
+    EXPECT_EQ(len, 2u);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. DEFECT (a): handle_version must ORIGINATE an addrme carrying our listen
+//    port. Drives the REAL NodeImpl::handle_version over a REAL socket and reads
+//    the frames the node actually wrote. Before the fix there is no addrme frame
+//    at all, so the ASSERT_NE below fires.
+// ─────────────────────────────────────────────────────────────────────────────
+TEST(DashAddrme, HandleVersionWritesAddrmeCarryingOurListenPort)
+{
+    LoopbackPair pair;
+    StubCommunicator stub;
+
+    dash::Config cfg{"dash-addrme-kat"};
+    cfg.pool()->m_prefix = test_prefix();
+
+    dash::NodeImpl node(&pair.ioc_node, &cfg);
+    // Bind an EPHEMERAL port: the assertion is that the addrme carries whatever
+    // the OS handed us, not a hardcoded constant.
+    node.core::Server::listen(std::uint16_t{0});
+    const auto listen_port = node.core::Server::listen_port_or_none();
+    ASSERT_TRUE(listen_port.has_value()) << "test node must be listening";
+
+    auto peer = make_socket_peer(pair, stub);
+    IoThread io(pair.ioc_node);
+
+    const auto type = node.handle_version(make_version(0xD45E'C0FF'EE01'2345ull), peer);
+    ASSERT_TRUE(type.has_value()) << "handshake must be accepted at the cold floor";
+    EXPECT_EQ(*type, pool::PeerConnectionType::legacy)
+        << "un-ratcheted DASH negotiates Legacy — the generation the fix targets";
+
+    const auto frames = read_frames(*pair.theirs, std::chrono::milliseconds(400));
+    io.stop(pair.ioc_node);
+
+    // getaddrs is the pre-existing handshake write; its presence proves the
+    // harness really is observing handle_version's output.
+    EXPECT_NE(find_frame(frames, "getaddrs"), nullptr)
+        << "harness sanity: the existing getaddrs write must be visible";
+
+    const Frame* addrme = find_frame(frames, "addrme");
+    ASSERT_NE(addrme, nullptr)
+        << "#882(a): handle_version never originated an addrme on the DASH lane";
+
+    ASSERT_EQ(addrme->payload.size(), 2u);
+    std::uint16_t advertised = 0;
+    std::memcpy(&advertised, addrme->payload.data(), sizeof(advertised));
+    EXPECT_EQ(advertised, *listen_port)
+        << "the addrme must carry OUR real listen port";
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. Canonical parity for the NON-listening case. p2p.py:110 gates the whole
+//    advertisement on `if self.node.serverfactory.listen_port is not None`, and
+//    DASH has a real non-listening mode (`--connect` without `--listen`,
+//    src/c2pool/main_dash.cpp:566). An UNGUARDED core::Server::listen_port()
+//    throws on an acceptor that was never opened, and a throw out of
+//    handle_version makes the bridge drop the connection — so this test is what
+//    keeps the fix from breaking --connect.
+// ─────────────────────────────────────────────────────────────────────────────
+TEST(DashAddrme, NonListeningNodeAdvertisesNothingAndDoesNotThrow)
+{
+    LoopbackPair pair;
+    StubCommunicator stub;
+
+    // Rig-free construction: Factory(nullptr, ...) never even engages the
+    // optional acceptor.
+    dash::NodeImpl node;
+    EXPECT_FALSE(node.core::Server::listen_port_or_none().has_value());
+
+    auto peer = make_socket_peer(pair, stub);
+    IoThread io(pair.ioc_node);
+
+    std::optional<pool::PeerConnectionType> type;
+    ASSERT_NO_THROW(type = node.handle_version(make_version(0x0BAD'F00D'1234'5678ull), peer));
+    ASSERT_TRUE(type.has_value());
+
+    const auto frames = read_frames(*pair.theirs, std::chrono::milliseconds(250));
+    io.stop(pair.ioc_node);
+
+    EXPECT_EQ(find_frame(frames, "addrme"), nullptr)
+        << "canonical advertises nothing when there is no listen port";
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2b. The EXACT `--connect` shape, and the reason the guard is not decoration.
+//     `--connect` without `--listen` constructs the node WITH an io_context (so
+//     the optional acceptor IS engaged) and then never calls listen(), leaving
+//     the acceptor closed. core::Server::listen_port() calls local_endpoint()
+//     on it, which THROWS; a throw out of handle_version is what makes the
+//     bridge drop the connection. listen_port_or_none() answers nullopt
+//     instead, which is what canonical's `is not None` test does.
+// ─────────────────────────────────────────────────────────────────────────────
+TEST(DashAddrme, ConnectOnlyNodeHasNoListenPortAndUnguardedReadWouldThrow)
+{
+    boost::asio::io_context ioc;
+    dash::Config cfg{"dash-addrme-kat"};
+    cfg.pool()->m_prefix = test_prefix();
+
+    // Context present, listen() never called — precisely --connect mode
+    // (src/c2pool/main_dash.cpp:566 skips listen() when connect_only).
+    dash::NodeImpl node(&ioc, &cfg);
+
+    EXPECT_FALSE(node.core::Server::listen_port_or_none().has_value())
+        << "a connect-only node has no listen port to advertise";
+    EXPECT_ANY_THROW((void) node.core::Server::listen_port())
+        << "this is the throw an unguarded ltc/btc-shaped port would have "
+           "taken out of handle_version, dropping every --connect handshake";
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. DEFECT (b), evidence: a real accepted loopback connection presents the
+//    loopback HOST address. "127.0.0.0" is the /8 NETWORK address and is not a
+//    value any peer can ever present, which is precisely why the old Legacy
+//    guard was dead code.
+// ─────────────────────────────────────────────────────────────────────────────
+TEST(DashAddrme, LoopbackPeerPresentsHostAddressNotNetworkAddress)
+{
+    LoopbackPair pair;
+    StubCommunicator stub;
+
+    auto peer = make_socket_peer(pair, stub);
+
+    EXPECT_EQ(peer->addr().address(), "127.0.0.1");
+    EXPECT_NE(peer->addr().address(), "127.0.0.0")
+        << "the pre-#882 Legacy guard compared a value no peer can present";
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. DEFECT (b), behaviour: drive the REAL dash::Legacy addrme handler with a
+//    loopback sender. Canonical (p2p.py:281) takes the self-probe arm and does
+//    NOT record the address. Before the fix the dead guard sent every loopback
+//    addrme down the else arm, which called got_addr(127.0.0.1:port) — inserting
+//    loopback into our AddrStore as a routable peer, from where get_good_peers()
+//    would hand it to other nodes in an addrs reply. Same subsystem as #910,
+//    which fixes the other direction (a hostname serialising AS 127.0.0.1).
+//
+//    Repeated: the relay inside each arm is probabilistic (0.8) and picks a
+//    random peer, but got_addr() in the else arm is UNCONDITIONAL, so a single
+//    iteration is already decisive; the loop simply removes any doubt.
+// ─────────────────────────────────────────────────────────────────────────────
+TEST(DashAddrme, LoopbackAddrmeIsNotRecordedAsARoutablePeer)
+{
+    constexpr std::uint16_t kAdvertisedPort = 41337;  // distinctive; not a real seed port
+
+    LoopbackPair pair;
+    StubCommunicator stub;
+
+    ProbeLegacy legacy;
+    auto peer = make_socket_peer(pair, stub);
+    ASSERT_EQ(peer->addr().address(), "127.0.0.1");
+
+    // A relay target must exist, otherwise the self-probe arm is a no-op and the
+    // two arms would be indistinguishable from the outside.
+    peer->m_nonce = 0x1111'2222'3333'4444ull;
+    legacy.peers()[peer->m_nonce] = peer;
+
+    const NetService loopback_record{std::string("127.0.0.1"), kAdvertisedPort};
+    ASSERT_FALSE(legacy.addrs().check(loopback_record))
+        << "precondition: the store must not already carry this record";
+
+    IoThread io(pair.ioc_node);
+    for (int i = 0; i < 32; ++i)
+    {
+        auto raw = dash::message_addrme::make_raw(kAdvertisedPort);
+        legacy.handle(dash::message_addrme::make(raw->m_data), peer);
+    }
+
+    const auto frames = read_frames(*pair.theirs, std::chrono::milliseconds(300));
+    io.stop(pair.ioc_node);
+
+    EXPECT_FALSE(legacy.addrs().check(loopback_record))
+        << "#882(b): a loopback addrme was recorded in the AddrStore as a "
+           "routable peer — the dead 127.0.0.0 guard sent it down the else arm";
+
+    // The else arm also gossips the bogus record onward as an addrs message.
+    // With the self-probe arm reachable, addrme is what gets relayed instead.
+    EXPECT_EQ(find_frame(frames, "addrs"), nullptr)
+        << "#882(b): loopback was gossiped to peers in an addrs relay";
+    EXPECT_NE(find_frame(frames, "addrme"), nullptr)
+        << "canonical relays the addrme onward so a peer that CAN see our "
+           "public address answers it (p2p.py:282-283)";
+}


### PR DESCRIPTION
Closes #882. Last p2p protocol gap in the DASH lane — the other 12 of the 13 canonical pool messages are already aligned.

## Verified root cause

Both premises in the issue hold. Two line citations in the dispatch brief were off and are corrected below; nothing else changed.

### (a) DASH never ORIGINATED an addrme

`dash::message_addrme` is registered as a handler on both generations — **`src/impl/dash/node.hpp:1272`** (Legacy) and **`:1291`** (Actual), *not* 1173/1192 as cited — but a grep of the whole lane finds no writer. Every other lane writes one from `handle_version`:

| lane | origination site |
|---|---|
| ltc | `src/impl/ltc/node.cpp:346` |
| btc | `src/impl/btc/node.cpp:346` |
| bch | `src/impl/bch/node.cpp:344` |
| dgb | `src/impl/dgb/node.cpp:351` |
| **dash** | **absent** |

DASH's `handle_version` is header-inline (`src/impl/dash/node.hpp:699`); it writes `getaddrs` and the `have_tx` advert and nothing else. So a DASH peer could only ever learn our listen port second-hand, from a third party's `addrs` gossip.

### (b) The Legacy self-probe compared the loopback NETWORK address

**`src/impl/dash/protocol_legacy.cpp:55`** (pre-fix):

```cpp
if (peer->addr().address() == "127.0.0.0")
```

`127.0.0.0` is the `/8` network address. `peer->addr()` is `Socket::m_addr`, latched in `Socket::init()` (`src/core/socket.cpp:78`) from the real `remote_endpoint()` — a peer physically cannot present it. Canonical (`p2p.py:281`) and our own `src/impl/dash/protocol_actual.cpp:57` both compare `127.0.0.1`. Legacy is the **only** generation live on DASH today: `handle_version` returns `legacy` unless the operator has ratcheted the floor above the 1700 baseline.

The same `127.0.0.0` constant is present in the other four `protocol_legacy.cpp` files (btc/ltc/dgb `:55`, bch `:84`). **Deliberately left alone** — this PR is DASH-lane-scoped, and those lanes are live networks whose p2p behaviour should change in their own bisectable commit. #882 should stay open, or spawn a follow-up, for them.

## What canonical does, and how this matches it

`p2pool/p2p.py:109-134` `sendAdvertisement()`:

```python
def sendAdvertisement(self):
    if self.node.serverfactory.listen_port is not None:
        host = self.node.external_ip
        port = self.node.serverfactory.listen_port.getHost().port
        if host is not None:
            ...  send_addrs([our external ip:port])
        else:
            self.send_addrme(port=port)
```

Two things are load-bearing:

1. **The payload is our listen port.** The peer can already see our IP; the port is the one thing it cannot infer. Matched: the addrme carries `core::Server::listen_port_or_none()`.
2. **The whole advertisement is gated on `listen_port is not None`.** Matched — and this is the one place the PR does **not** copy ltc/btc verbatim, because copying them would have been a live regression:

   `core::Server::listen_port()` (`src/core/factory.hpp:90`) is `m_acceptor->local_endpoint().port()` with no guard. DASH has a real non-listening mode: `--connect` without `--listen` skips `listen()` entirely (`src/c2pool/main_dash.cpp:566`), leaving the acceptor **engaged but closed**, on which `local_endpoint()` throws. A throw out of `handle_version` makes the bridge drop the connection — so an unguarded port read would have broken `--connect` mode outright. That is not a theoretical reading: `DashAddrme.ConnectOnlyNodeHasNoListenPortAndUnguardedReadWouldThrow` constructs exactly that node and asserts the throw.

   The fix adds `core::Server::listen_port_or_none()` — canonical's `is not None`, expressed as `std::optional`. Purely additive; `listen_port()` is untouched, so no existing caller in any lane changes.

Two deliberate, documented divergences from canonical, both inherited from the existing ltc/btc port rather than introduced here:

* Canonical re-runs `sendAdvertisement()` on a repeating expovariate timer (`p2p.py:212-214`, mean `100 * len(peers) + 1` s). c2pool sends it **once at handshake**, in all four existing lanes. This PR matches c2pool, per "port the pattern, do not invent one." Adding the timer would be a cross-coin change, not a DASH gap-closure.
* Canonical prefers `send_addrs([external_ip])` when `--external-ip` is configured. c2pool has no `external_ip` knob on this path in any lane, so the `else` arm is the only reachable one and is what all five now implement.

Ordering: the addrme goes immediately after the existing `getaddrs`, **before** `advertise_known_txs()`. The #863 comment block right there is explicit that the (up to ~32 KB) `have_tx` advert must be the last write in the handler; a two-byte message inserted ahead of it preserves that.

## Why this is interop-safe

Our DASH node is joined to the live p2pool-dash sharechain with third-party operators on it, so this was the governing constraint.

* **No wire byte moves.** The fix adds a *call site*. `message_addrme` (`src/impl/dash/messages.hpp:47-55`) is untouched: still `command="addrme"`, still a single little-endian `uint16` port. Pinned by `DashAddrme.WireFormatByteIdentical` (payload bytes + NUL-padded 12-byte command field + `length == 2` inside the full framed packet) and by the pre-existing `DashPoolNodeMessages.Message_Addrme_LayoutPinned`.
* **The message was already in the protocol both ways.** DASH has parsed and handled inbound `addrme` since the reception slice; every canonical p2pool-dash node has originated one at us all along. This makes us *reciprocate* a message the network already speaks. It cannot surprise a peer.
* **Nothing consensus-adjacent is touched.** No share, target, coinbase, payee, subsidy or PPLNS path is read or written. Peer discovery only.
* **(b) is a strict reduction in what we emit and store.** See the behaviour question below.

## Does fixing (b) change observable behaviour toward real peers?

**Yes — but only for addrme sent from a loopback source, and strictly in the direction of emitting less garbage.**

For any peer with a routable address the two constants are indistinguishable: `x != "127.0.0.0"` and `x != "127.0.0.1"` are both true, both take the `else` arm, and the handler behaves identically byte for byte. **The overwhelming majority of live traffic is unaffected.**

When the sender *is* on loopback — a peer on the same host, or anything reaching us through a local proxy/tunnel — the pre-fix behaviour was:

1. `got_addr(NetService{"127.0.0.1", port})` — **loopback entered our AddrStore as a routable peer**, and
2. with p=0.8, an `addrs` message carrying that loopback record was **relayed to a random peer**, where it points at *themselves*.

Post-fix it takes canonical's self-probe arm: record nothing, and relay the `addrme` onward with p=0.8 so a peer that *can* see our public address is the one to answer it (`p2p.py:282-283`).

So the observable change toward real peers is: **we stop injecting `127.0.0.1` into other operators' address books.** That is the same class of harm #910 reports from the other direction, and it is why the issue calls the address-gossip subsystem wrong at both ends.

## Coordination with #910 / PR #911

Read #911 before writing this. The two are complementary and land on opposite ends of the same subsystem:

* **#911** fixes *serialization*: a DNS-named addnode must not be written to the wire **as** `127.0.0.1`. It touches `NetAddress::Write_IPV4`, adds `is_wire_advertisable()`, and guards the ten per-coin `HANDLER(getaddrs)` sites.
* **This PR** fixes *reception*: an addrme arriving **from** loopback must not be recorded and re-gossiped as routable. It touches `HANDLER(addrme)` in `src/impl/dash/protocol_legacy.cpp` only.

No duplication and no contradiction. #911 explicitly preserves `address()` / `to_string()` / the AddrStore key, which is exactly the accessor this fix's comparison reads, so the semantics it depends on are the ones #911 promises to keep.

Overlapping files are `src/core/factory.hpp` (#911 edits `Client::resolve()` ~`:157`; this adds a method to `Server` ~`:90`) and `src/impl/dash/protocol_legacy.cpp` (#911 edits `HANDLER(getaddrs)`; this edits `HANDLER(addrme)`). Verified clean: `git merge-tree --write-tree HEAD origin/fix/910-resolve-hostname-before-advertising` exits 0 — no conflict in either direction, whichever merges first.

## What the tests prove

`test/test_dash_addrme.cpp`, folded in as a **third TU of the existing allowlisted `test_dash_node` target** — no new `add_executable`, so it cannot land as a "Not Run" (#769). `tools/ci/check_test_target_allowlist.py` passes.

These drive the **real** `NodeImpl::handle_version` and the **real** `dash::Legacy::handle(message_addrme)` against a **real** loopback TCP socket, then read back the frames that actually went on the wire — not a re-implementation, and not a mock that could pass over unreachable code (#875/#878).

| test | proves |
|---|---|
| `WireFormatByteIdentical` | the addrme payload, command field and framed length are unchanged |
| `HandleVersionWritesAddrmeCarryingOurListenPort` | a listening node emits an addrme carrying its **actual ephemeral** bound port; `getaddrs` is asserted alongside it as a harness sanity check, so a silent harness failure cannot masquerade as a pass |
| `NonListeningNodeAdvertisesNothingAndDoesNotThrow` | canonical's `is not None` gate: no listen port, no advertisement, no throw |
| `ConnectOnlyNodeHasNoListenPortAndUnguardedReadWouldThrow` | the `--connect` shape (context present, `listen()` never called): `listen_port_or_none()` is `nullopt` **and** the unguarded `listen_port()` really does throw |
| `LoopbackPeerPresentsHostAddressNotNetworkAddress` | a real accepted loopback connection presents `127.0.0.1`, never `127.0.0.0` — the old guard was dead code |
| `LoopbackAddrmeIsNotRecordedAsARoutablePeer` | 32 real loopback addrmes leave the AddrStore free of `127.0.0.1:41337`, emit **no** `addrs` relay, and **do** emit the canonical addrme relay |

### Negative control (run on this tree)

Reverting each fix independently and rebuilding:

```
[  FAILED  ] DashAddrme.HandleVersionWritesAddrmeCarryingOurListenPort
             #882(a): handle_version never originated an addrme on the DASH lane
[  FAILED  ] DashAddrme.LoopbackAddrmeIsNotRecordedAsARoutablePeer
             #882(b): a loopback addrme was recorded in the AddrStore as a routable peer
             #882(b): loopback was gossiped to peers in an addrs relay
[  PASSED  ] 3 tests   (wire pin + both non-listening cases — correctly insensitive to the defects)
```

Each defect fails only its own case. With both fixes in place: **6/6 pass, full `test_dash_node` 24/24.**

## Build verification

Local Release build, gcc-13 + the CI conan profile:

* `c2pool-dash` — clean (the lane that changed)
* `c2pool` — clean (proves the shared `src/core/factory.hpp` addition breaks no other lane)
* `test_dash_node` 24/24, `test_dash_poolnode_messages` 10/10, `test_dash_p2p_messages` 8/8

Nothing was deployed anywhere. No live node was touched.
