### PR TITLE
ci(prune): preserve .github so local composite actions survive post-step prep (fixes #890 red leg)

### DIFF
--- a/.github/actions/prune-runner-workspace/action.yml
+++ b/.github/actions/prune-runner-workspace/action.yml
@@ -37,9 +37,14 @@ runs:
         # Everything under the workspace except the checkout's .git. Keeping .git
         # (~230 MiB) lets actions/checkout's post-step unset its auth header
         # instead of erroring, and lets the next job fetch incrementally. The
-        # build trees, which are the actual ~5 GiB, all go.
+        # build trees, which are the actual ~5 GiB, all go. .github is also
+        # kept: local composite actions (./.github/actions/*) resolve from
+        # the workspace, not _actions/, and the runner re-reads their
+        # action.yml during end-of-job post-step preparation. Deleting it
+        # made provision-dashbls unresolvable and failed every DASH-impl
+        # job red AFTER a fully green build+KAT run.
         find "$RUNNER_WORKSPACE" -mindepth 1 -maxdepth 1 ! -path "$GITHUB_WORKSPACE" -exec rm -rf -- {} +
-        find "$GITHUB_WORKSPACE" -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf -- {} +
+        find "$GITHUB_WORKSPACE" -mindepth 1 -maxdepth 1 ! -name .git ! -name .github -exec rm -rf -- {} +
 
         # _temp: empty it, keep the directory itself -- the runner holds it open
         # for the remainder of the job. conan2/ is exempt: release.yml's linux


### PR DESCRIPTION
Root cause: prune-runner-workspace was deleting .github/ so the runner cannot re-read provision-dashbls action.yml during post-step prep. That is what turned #890 red on the dash-bls leg — a failure with nothing to do with libgmp.

The prune step now preserves .github/ (composite action definitions) alongside _actions/_tool, so post-step prep can re-read local action.yml files. Workspace-size reclaim is otherwise unchanged.

Note: #890 still needs a rebase onto this branch once merged.