### PR TITLE
ci: backport arm64 watchdog fixes to Intel runner-watchdog (drop test deferred to .204 access)

### DIFF
--- a/scripts/ci/runner-watchdog-mac-intel.sh
+++ b/scripts/ci/runner-watchdog-mac-intel.sh
@@ -13,16 +13,19 @@
 #   token minted with repo-admin creds, which live here on the bridge, not
 #   on the Mac node. This watchdog closes that gap.
 #
+#   Sibling of runner-watchdog-mac-arm.sh (PR #923). This is the backport of
+#   that PR's three drop-test-proven fixes onto the Intel node.
+#
 # WHAT IT DOES (idempotent, non-destructive):
 #   1. Polls the repo's runners API for macpro-intel-204.
 #   2. If the runner is absent or "offline" for >= THRESHOLD consecutive
 #      checks, mints a fresh registration token and re-registers the runner
-#      over SSH using `config.sh --replace` (no delete; --replace reuses the
-#      same name), then reloads the launchd service.
+#      over SSH (see the launchd/config sequence below), then reloads the
+#      launchd service into the GUI domain.
 #   3. Resets the failure counter as soon as the runner is seen online.
 #
 # REVERT: delete this file + remove its launchd/cron entry on the bridge.
-#   It never deletes the runner; --replace is the only mutation it makes.
+#   It never deletes the runner; it re-registers under the same name.
 #
 set -euo pipefail
 
@@ -62,20 +65,61 @@ log "status=${status} consecutive_fails=${fails}/${THRESHOLD}"
 [ "$fails" -lt "$THRESHOLD" ] && exit 0
 
 log "threshold reached -> re-registering"
-TOKEN=$(gh api --method POST "repos/${REPO}/actions/runners/registration-token" --jq .token)
-[ -z "$TOKEN" ] && { log "ERROR: empty registration token"; exit 1; }
+REG_TOKEN=$(gh api --method POST "repos/${REPO}/actions/runners/registration-token" --jq .token)
+[ -z "$REG_TOKEN" ] && { log "ERROR: empty registration token"; exit 1; }
+# Removal token deregisters the stale server-side registration + wipes local
+# config so a clean re-register succeeds. Best-effort: if GitHub already
+# dropped the runner ("absent"), remove is a no-op and we fall back to
+# wiping the local config files directly.
+RM_TOKEN=$(gh api --method POST "repos/${REPO}/actions/runners/remove-token" --jq .token 2>/dev/null || true)
 
-ssh -i "$NODE_KEY" -o IdentitiesOnly=yes -o StrictHostKeyChecking=no "$NODE_SSH" bash -s <<EOF
+# The original Intel 5-liner (svc.sh stop -> config.sh --replace -> svc.sh
+# start) was never drop-tested and is non-functional for a *deregistered*
+# runner, for two reasons proven by the .227 arm64 drop test 2026-07-27
+# (PR #923) and expected to hold identically on this Intel node:
+#   (a) The runner's launchd LaunchAgent lives in the user's *GUI* (Aqua)
+#       domain. Over a non-GUI SSH session `svc.sh install/uninstall`
+#       (plain `launchctl load/unload`) fail with "Unload failed: 5:
+#       Input/output error". The agent must be managed with an explicit
+#       `launchctl bootout|bootstrap gui/$UID ...` target.
+#   (b) `config.sh --replace` does NOT bypass the local "already configured"
+#       guard; a real `config.sh remove` (or wiping .runner/.credentials)
+#       must precede a fresh `config.sh` configure.
+# Sequence: bootout+uninstall service -> unconfigure -> fresh configure ->
+# install + bootstrap+kickstart into the GUI domain. Non-destructive: no
+# runner is deleted beyond its own re-registration under the same name.
+ssh -i "$NODE_KEY" -o IdentitiesOnly=yes -o StrictHostKeyChecking=no "$NODE_SSH" \
+  REG_TOKEN="$REG_TOKEN" RM_TOKEN="$RM_TOKEN" REPO="$REPO" \
+  RUNNER_NAME="$RUNNER_NAME" RUNNER_LABELS="$RUNNER_LABELS" RUNNER_DIR="$RUNNER_DIR" \
+  bash -s <<'EOF'
 set -e
-cd "${RUNNER_DIR}"
-./svc.sh stop || true
-./config.sh remove --token "${TOKEN}" || true
-./config.sh --unattended --replace \
+cd "$RUNNER_DIR"
+U=$(id -u)
+LABEL="actions.runner.$(echo "$REPO" | tr '/' '-').${RUNNER_NAME}"
+PLIST="$HOME/Library/LaunchAgents/${LABEL}.plist"
+
+# 1) stop + uninstall the LaunchAgent from the GUI domain
+launchctl bootout "gui/${U}/${LABEL}" 2>/dev/null || true
+./svc.sh uninstall 2>/dev/null || true
+
+# 2) unconfigure (deregister + wipe local config); fall back to wiping files
+if [ -n "$RM_TOKEN" ]; then
+  ./config.sh remove --token "$RM_TOKEN" || rm -f .runner .credentials .credentials_rsaparams
+else
+  rm -f .runner .credentials .credentials_rsaparams
+fi
+
+# 3) fresh register under the same name + labels
+./config.sh --unattended \
   --url "https://github.com/${REPO}" \
-  --token "${TOKEN}" \
-  --name "${RUNNER_NAME}" \
-  --labels "${RUNNER_LABELS}"
-./svc.sh start
+  --token "$REG_TOKEN" \
+  --name "$RUNNER_NAME" \
+  --labels "$RUNNER_LABELS"
+
+# 4) (re)install + load the service into the GUI domain
+./svc.sh install
+launchctl bootstrap "gui/${U}" "$PLIST" 2>/dev/null || true
+launchctl kickstart -k "gui/${U}/${LABEL}"
 EOF
 
 log "re-registration issued; clearing fail counter"


### PR DESCRIPTION
Backports the three drop-test-proven fixes from the arm64 watchdog (PR #923) onto the Intel node's `scripts/ci/runner-watchdog-mac-intel.sh`. The original Intel flow (`svc.sh stop` -> `config.sh --replace` -> `svc.sh start`) was never drop-tested and is non-functional for a *deregistered* runner.

Three fixes ported:
1. **launchd GUI domain** — manage the LaunchAgent via `launchctl bootout|bootstrap|kickstart gui/$UID ...`; plain `svc.sh` load/unload fails over non-GUI SSH with "Unload failed: 5: Input/output error".
2. **config.sh remove, not --replace** — `--replace` does not bypass the local "already configured" guard; a real `config.sh remove` (fallback: wipe `.runner`/`.credentials`) must precede a fresh configure.
3. **remove-token** — mint a remove-token to deregister the stale server-side registration before re-registering under the same name.

**What this DOES fix:** once the watchdog can reach .204, the deregister-and-re-register self-heal path now uses the same mechanism proven on arm64 (#923). This is the best-available remediation and is landed as such per operator approval of the .204 card (2026-07-27 21:00Z).

**What this does NOT fix:** it cannot restore SSH to a host that refuses every identity we hold. The Intel leg is currently key-locked; no CI-side change can re-open access. Restoring SSH/console to .204 is a physical/console action outside this PR's scope and should be carded separately as operator-only.

**Drop test: deferred, not passed.** The real deregister-and-self-heal drop test on the Intel node remains UNVERIFIED until .204 access is restored; the code is ready to run it the same hour access returns. Un-drafted per operator approval to land the remediation now rather than gate it on access we do not control.

Revert: delete `scripts/ci/runner-watchdog-mac-intel.sh` changes on this branch; no runtime state is touched until the watchdog is wired on the bridge.
