### PR TITLE
ci(asan): reduce ASan+UBSan compile to -j4 to avoid cgroup memory.high wedge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -345,7 +345,7 @@ jobs:
                     rpc_request_test softfork_check_test genesis_check_test algo_select_test digishield_walk_test header_chain_test \
                     dgb_coin_node_seam_test dgb_block_broadcast_test dgb_won_block_dispatch_test dgb_forced_won_share_dualpath_test dgb_scrypt_pow_test dgb_nonce_grinder_test dgb_regrind_block_test dgb_won_block_finalize_test dgb_share_target_genesis_test dgb_share_target_retarget_test dgb_share_bits_oracle_pin_test dgb_pool_msg_wire_test dgb_get_shares_walk_test dgb_download_stops_test dgb_think_p1_walk_bounds_test dgb_think_p1_desired_emit_test dgb_think_p6_desired_cutoff_test dgb_think_p4_head_keys_test dgb_think_p3_best_head_test dgb_g1_oracle_byte_parity_test dgb_think_p2_walk_bounds_test dgb_expected_time_to_block_test dgb_tail_score_endpoints_test dgb_pool_attempts_per_second_test dgb_pool_efficiency_test dgb_think_p5_best_share_punish_test dgb_auto_ratchet_tail_guard_test dgb_auto_ratchet_sim_test dgb_binomial_conf_interval_test dgb_desired_version_tally_test dgb_min_protocol_ratchet_test dgb_get_height_and_last_endpoints_test dgb_chain_walk_window_test dgb_redistribute_delegate_ghal_test dgb_share_weight_decay_test dgb_naughty_propagation_test dgb_hash_format_parity_test dgb_emergency_decay_saturation_test dgb_arith256_muldiv_kat_test dgb_share_tx_relay_refs_test test_coin_broadcaster test_multiaddress_pplns test_pplns_stress \
                     v37_test \
-            -j8
+            -j4  # ASan+UBSan: cc1plus RSS ~2-3GB each; -j8 wedged runner cgroup memory.high (throttle-hang). -j4 caps peak <12G.
 
       - name: Run tests under sanitizers
         working-directory: build_asan
@@ -625,7 +625,7 @@ jobs:
                     bch_muldiv_kat_test \
                     bch_g1_oracle_byte_parity_test bch_g1_share_serialization_parity_test bch_g0_canonical_pin_test bch_g2_ratchet_gate_kat_test test_bch_underfill_guard \
                     bch_g2_block_assembly_roundtrip_test \
-            -j8
+            -j4  # ASan+UBSan: cc1plus RSS ~2-3GB each; -j8 wedged runner cgroup memory.high (throttle-hang). -j4 caps peak <12G.
 
       - name: Run BCH tests under sanitizers
         working-directory: build_bch_asan


### PR DESCRIPTION
Durable fix for the recurring "COIN_BCH Linux x86_64 (AsAN+UBSan)" hang on self-hosted runners (ran 13h then GitHub-Abandoned, twice).

**Root cause:** the ASan+UBSan compile step built at `-j8`. Each cc1plus under `-fsanitize=address,undefined` carries ~2-3GB RSS; at -j8 peak drives the runner cgroup past `MemoryHigh`. With swap off and current pinned near `MemoryMax`, the kernel throttles all allocating tasks in `mem_cgroup_handle_over_high` and reclaim cannot progress, so the build silently wedges (all cc1plus D-state, near-zero CPU) instead of OOM-killing. memory.events: high~19.6M, oom_kill=0. Host RAM was fine — the cap is per-cgroup.

**Change:** cap the two ASan compile steps (linux-asan, bch-asan) at `-j4`; peak RSS then stays <12G, well inside a sane slice cap. Non-ASan jobs stay `-j8`. Both ASan jobs are informational (non-gating), so this is low-risk on master.

Companion host-lane fix (persistent slice MemoryHigh/Max + swap) is operator-owned, tracked separately.