### PR TITLE
[WIP] web: collapse triplicated share_version switch in rest_web_currency_info

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -4772,28 +4772,6 @@ nlohmann::json MiningInterface::rest_web_currency_info()
     default:                   result["share_version"] = 36; break;
     }
 
-    // p2pool share version for the current coin — consumed by the
-    // bundled @c2pool/sharechain-explorer to classify share cells.
-    // Dash = v16, LTC/DOGE/BTC = v36.
-    switch (m_blockchain) {
-    case Blockchain::DASH:     result["share_version"] = 16; break;
-    case Blockchain::LITECOIN:
-    case Blockchain::BITCOIN:
-    case Blockchain::DOGECOIN:
-    default:                   result["share_version"] = 36; break;
-    }
-
-    // p2pool share version for the current coin — consumed by the
-    // bundled @c2pool/sharechain-explorer to classify share cells.
-    // Dash = v16, LTC/DOGE/BTC = v36.
-    switch (m_blockchain) {
-    case Blockchain::DASH:     result["share_version"] = 16; break;
-    case Blockchain::LITECOIN:
-    case Blockchain::BITCOIN:
-    case Blockchain::DOGECOIN:
-    default:                   result["share_version"] = 36; break;
-    }
-
     // ─── Per-coin explorer map (operator 2026-06-23: each coin = a distinct
     // blockchain). On merged-mining nodes (e.g. LTC primary + DOGE aux) the
     // dashboard switcher must link each coin's blocks/txs/addresses to the


### PR DESCRIPTION
Refactor: collapse three duplicated share_version switch blocks into one in rest_web_currency_info. Behaviour-preserving. Draft for CI.