### PR TITLE
[WIP] bch: link pool-node body TUs into embedded body-test set (#911 coverage enabler)

### DIFF
--- a/src/impl/bch/test/CMakeLists.txt
+++ b/src/impl/bch/test/CMakeLists.txt
@@ -199,7 +199,18 @@ if(BUILD_TESTING)
             ${CMAKE_SOURCE_DIR}/src/impl/bch/coin/coin_node.cpp
             ${CMAKE_SOURCE_DIR}/src/impl/bch/coin/p2p_connection.cpp
             ${CMAKE_SOURCE_DIR}/src/impl/bch/coin/p2p_node.cpp
-            ${CMAKE_SOURCE_DIR}/src/impl/bch/coin/rpc.cpp)
+            ${CMAKE_SOURCE_DIR}/src/impl/bch/coin/rpc.cpp
+            # M5 pool-node body TUs (mirror the shipping c2pool-bch target in
+            # src/c2pool/CMakeLists.txt): NodeImpl out-of-line methods + the two
+            # p2pool p2p protocol dispatchers + the stratum work source, so an
+            # embedded body test can construct the real pool-node graph and reach
+            # the Node/protocol/BCHWorkSource symbols -- enabler for the #911
+            # is_wire_advertisable guard test-coverage gap. Additive, src/impl/bch
+            # only -> per-coin isolation holds.
+            ${CMAKE_SOURCE_DIR}/src/impl/bch/node.cpp
+            ${CMAKE_SOURCE_DIR}/src/impl/bch/protocol_actual.cpp
+            ${CMAKE_SOURCE_DIR}/src/impl/bch/protocol_legacy.cpp
+            ${CMAKE_SOURCE_DIR}/src/impl/bch/stratum/work_source.cpp)
         target_include_directories(bch_${t} PRIVATE ${CMAKE_SOURCE_DIR}/src)
         target_link_libraries(bch_${t} PRIVATE
             core pool sharechain


### PR DESCRIPTION
Additive CMake-only change (+12/-1) confined to src/impl/bch/test/CMakeLists.txt.

## What
Master wires only the coin/* out-of-line TUs into the BCH_EMBEDDED_BODY_TESTS foreach; the source list stops at coin/rpc.cpp. Add node.cpp + protocol_actual.cpp + protocol_legacy.cpp + stratum/work_source.cpp so an embedded body test can construct the real pool-node graph and reference the NodeImpl / p2pool protocol dispatcher / BCHWorkSource symbols.

## Why
This is the link-set precondition for covering the #911 is_wire_advertisable send-side guard (currently zero test coverage). Mirrors the shipping c2pool-bch executable target (src/c2pool/CMakeLists.txt) so the link set stays consistent.

## Scope / safety
- Additive; per-coin isolation holds (src/impl/bch only).
- No new add_test -> no build.yml COIN_BCH list change needed.
- DRAFT pending local link-green on VM905; the follow-up is_wire_advertisable test lands on top.

Re-applied fresh on master from the stale bch/embedded-test-link-sources branch (which also carried a test-list reversion and is 429 commits behind); that branch is superseded by this and can be pruned.