### PR TITLE
fix(dash): #940 feed embedded dial failures into the peer scorer

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -1315,6 +1315,13 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 [mgr = coin_peer_mgr.get()](const NetService& s) {
                     mgr->notify_disconnected(s.to_string());
                 });
+            // #940: dial failures (ECONNREFUSED/ETIMEDOUT/resolve error) never
+            // reach connect/disconnect scoring — feed them explicitly so dead
+            // top-scored seeds are penalised instead of re-dialed forever.
+            coin_p2p->set_on_dial_failed(
+                [mgr = coin_peer_mgr.get()](const NetService& s) {
+                    mgr->notify_dial_failed(s.to_string());
+                });
 
             // Pinned keys: passed to get_peers_to_connect() as the "already
             // handled" set so the protected pinned node (score 999999, always

--- a/src/core/factory.hpp
+++ b/src/core/factory.hpp
@@ -125,7 +125,7 @@ private:
     std::optional<io::ip::tcp::resolver> m_resolver;
     std::string m_label = "Net";  // chain/protocol label for log messages
 
-	void connect_socket(boost::asio::ip::tcp::resolver::results_type endpoints)
+	void connect_socket(boost::asio::ip::tcp::resolver::results_type endpoints, NetService addr)
 	{
 		auto tcp_socket = std::make_unique<io::ip::tcp::socket>(*m_context);
 		auto socket = core::make_socket(std::move(tcp_socket), core::connection_type::outgoing, m_node);
@@ -138,13 +138,22 @@ private:
 		auto weak_node = m_node->weak_from_this();
 		bool was_managed = weak_node.lock() != nullptr;
 		io::async_connect(*socket->raw(), endpoints,
-			[this, weak_node, was_managed, socket = socket]
+			[this, weak_node, was_managed, addr, socket = socket]
 			(const auto& ec, boost::asio::ip::tcp::endpoint ep)
 			{
 				if (ec)
 				{
 					if (ec != boost::system::errc::operation_canceled)
+					{
 						LOG_TRACE << "[" << m_label << "] Connection failed: " << ec.message();
+						// #940: feed the dial failure back to the node so a scored
+						// peer manager can penalise the dead target (attempt++/
+						// backoff) instead of re-selecting it forever. Same
+						// weak_node lifetime guard as the success path below.
+						std::shared_ptr<INetwork> strong_node = weak_node.lock();
+						if (!was_managed || strong_node)
+							(strong_node ? strong_node.get() : m_node)->connect_failed(addr);
+					}
 					else
 						LOG_DEBUG_COIND << "Factory::Client::connect_socket canceled";
 					return;
@@ -187,7 +196,14 @@ private:
 				if (ec)
 				{
 					if (ec != boost::system::errc::operation_canceled)
+					{
 						LOG_TRACE << "[" << m_label << "] DNS resolve failed: " << ec.message();
+						// #940: a resolve failure is also a dial failure — report
+						// it so the target is scored (same lifetime guard).
+						std::shared_ptr<INetwork> strong_node = weak_node.lock();
+						if (!was_managed || strong_node)
+							(strong_node ? strong_node.get() : m_node)->connect_failed(addr);
+					}
 					else
 						LOG_DEBUG_OTHER << "Factory::Client::resolve canceled";
 					return;
@@ -198,7 +214,7 @@ private:
 				// on m_node->connected(socket) inside connect_socket().
 				if (was_managed && weak_node.expired()) return;
 
-				connect_socket(endpoints);
+				connect_socket(endpoints, addr);
 			}
 		);
 	}

--- a/src/core/inetwork.hpp
+++ b/src/core/inetwork.hpp
@@ -3,6 +3,12 @@
 
 #include <memory>
 
+// Forward declaration (global namespace): the outbound dial-failure hook below
+// takes a NetService by const-ref. Only the declaration is needed here — the
+// coin-layer overriders and the Factory caller already include the full
+// core/netaddress.hpp. Keeps inetwork.hpp free of that heavy header.
+class NetService;
+
 namespace core
 {
 // Forward declaration: INetwork only needs Socket as an incomplete type for the
@@ -33,6 +39,15 @@ struct INetwork : public std::enable_shared_from_this<INetwork>
     virtual ~INetwork() = default;
     virtual void connected(std::shared_ptr<core::Socket> socket) = 0;
     virtual void disconnect() = 0;
+
+    // Outbound dial-failure hook — fired by Factory::Client when an outbound
+    // connect (or its DNS resolve) fails BEFORE connected() ever runs (the
+    // socket never came up: ECONNREFUSED / ETIMEDOUT / resolve error). Default
+    // no-op so existing nodes (LTC/DOGE/merged) are unaffected; the DASH-isolated
+    // CoinClient overrides it to feed the dead target into the CoinPeerManager
+    // scorer. Without this, dial failures never reach the scorer, so the same
+    // top-scored dead seeds are re-selected on every refresh forever (#940).
+    virtual void connect_failed(const ::NetService& /*addr*/) {}
 };
 
 } // namespace core

--- a/src/impl/dash/coin/coin_peer_manager.hpp
+++ b/src/impl/dash/coin/coin_peer_manager.hpp
@@ -151,6 +151,23 @@ struct DashPeerInfo
     void record_disconnected()
     {
         ++attempt_count;
+        last_attempt = std::chrono::steady_clock::now();
+        backoff_sec = std::min(backoff_sec * 2, is_protected ? 600 : 3600);
+    }
+
+    // #940: an outbound dial that never completed the socket (ECONNREFUSED /
+    // ETIMEDOUT / DNS-resolve error). Weighted MORE heavily than a post-
+    // handshake disconnect: a peer that never answered is worse evidence than
+    // one that answered and dropped. So on top of the shared attempt++/backoff
+    // this also drops the raw score directly (record_disconnected leaves score
+    // untouched), pushing the dead target down the ranking as well as gating it.
+    // Stamping last_attempt makes can_retry()'s backoff branch actually gate the
+    // next attempt — without a stamp it stays at the epoch and backoff is inert.
+    void record_dial_failed()
+    {
+        ++attempt_count;
+        last_attempt = std::chrono::steady_clock::now();
+        score -= 15;
         backoff_sec = std::min(backoff_sec * 2, is_protected ? 600 : 3600);
     }
 
@@ -427,6 +444,22 @@ public:
         auto it = m_peers.find(key);
         if (it != m_peers.end()) {
             it->second.record_disconnected();
+        }
+    }
+
+    /// #940: Notify that an OUTBOUND DIAL to a peer failed before the socket
+    /// came up (connect/DNS-resolve error — never reached the handshake, so
+    /// notify_connected/notify_disconnected never fire for it). Applies the
+    /// heavier dial-failure penalty (attempt++/backoff + score drop) so dead
+    /// top-scored seeds stop being re-selected on every 60s dial-plan refresh.
+    /// The key must match the manager's stored key (PeerEndpoint::to_string() ==
+    /// the dialed NetService::to_string()); an unknown key is a silent no-op.
+    void notify_dial_failed(const std::string& key)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        auto it = m_peers.find(key);
+        if (it != m_peers.end()) {
+            it->second.record_dial_failed();
         }
     }
 

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -217,6 +217,13 @@ private:
     using PeerLifecycleCallback = std::function<void(const NetService&)>;
     PeerLifecycleCallback m_on_peer_connected;
     PeerLifecycleCallback m_on_peer_disconnected;
+    // #940: fired when an OUTBOUND DIAL fails before the socket comes up (the
+    // core Factory could not connect/resolve the target). Distinct from
+    // m_on_peer_disconnected, which only fires AFTER a socket was established —
+    // a dial that dies at ECONNREFUSED/ETIMEDOUT never reaches that seam. Feeds
+    // the CoinPeerManager scorer so dead targets are penalised instead of
+    // re-selected forever. Optional; unset on the legacy single-peer path.
+    PeerLifecycleCallback m_on_dial_failed;
 
     // E1 Phase-L member-set sourcing DEMUX: a filter that consumes HISTORICAL
     // mnlistdiff replies (full base=ZERO snapshots at old quorum-base / work
@@ -337,6 +344,21 @@ public:
         m_peer.reset();
     }
 
+    // #940: INetwork hook — an outbound dial failed BEFORE the socket came up
+    // (ECONNREFUSED / ETIMEDOUT / DNS-resolve error), so connected() never ran
+    // and neither did the m_on_peer_connected/disconnected seams. Feed the dead
+    // target to the scored peer manager (attempt_count++/backoff + score drop)
+    // so the dial plan rotates onto a fresh target. The 30s reconnect loop
+    // (arm_reconnect_timer) already handles the actual redial; this only reports
+    // the failure for scoring, so no dial is issued here (no retry-storm).
+    void connect_failed(const NetService& addr) override
+    {
+        LOG_DEBUG_COIND << "[" << m_chain_label << "] dial failed to "
+                        << addr.to_string() << " — feeding peer scorer";
+        if (m_on_dial_failed)
+            m_on_dial_failed(addr);
+    }
+
     /// Whether the version/verack handshake with the peer is complete.
     bool is_handshake_complete() const { return m_handshake.complete(); }
     bool is_connected() const { return m_peer != nullptr; }
@@ -368,6 +390,9 @@ public:
     /// Fired on disconnect/error with the peer endpoint — the DashCoinPeerManager
     /// scores the drop + applies exponential backoff off this.
     void set_on_peer_disconnected(PeerLifecycleCallback cb) { m_on_peer_disconnected = std::move(cb); }
+    /// #940: fired when an outbound dial fails before the socket comes up — the
+    /// DashCoinPeerManager penalises the dead target so it stops being reselected.
+    void set_on_dial_failed(PeerLifecycleCallback cb) { m_on_dial_failed = std::move(cb); }
 
     /// Send a getheaders request (E2 sync driver seam; unused by E1 run_node).
     void send_getheaders(uint32_t version, const std::vector<uint256>& locator, const uint256& stop)

--- a/test/test_dash_coin_peer_manager.cpp
+++ b/test/test_dash_coin_peer_manager.cpp
@@ -34,6 +34,7 @@
 #include <boost/asio.hpp>
 
 #include <filesystem>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -202,6 +203,87 @@ TEST(DashCoinPeerManager, dash_mainnet_seeds_are_canonical)
     auto fixed = dash::coin::dash_fixed_seeds(/*testnet=*/false);
     EXPECT_FALSE(fixed.empty());
     for (auto& s : fixed) EXPECT_EQ(s.port(), 9999);
+}
+
+// ── (f) #940: dial-failure feedback penalises dead targets ───────────────────
+//
+// Direct DashPeerInfo KAT: a failed dial is scored MORE heavily than a
+// post-handshake disconnect. record_disconnected() leaves score untouched and
+// only grows attempt/backoff; record_dial_failed() ALSO drops the raw score.
+TEST(DashCoinPeerManager, dial_failure_penalised_heavier_than_disconnect)
+{
+    DashPeerInfo dropped;   // answered, then dropped after handshake
+    DashPeerInfo never;     // never answered (dial failed)
+    dropped.record_disconnected();
+    never.record_dial_failed();
+
+    EXPECT_EQ(dropped.attempt_count, never.attempt_count);        // both count an attempt
+    EXPECT_EQ(dropped.score, 0);                                  // disconnect: score untouched
+    EXPECT_LT(never.score, dropped.score);                        // dial failure: score dropped
+    EXPECT_EQ(never.backoff_sec, dropped.backoff_sec);            // same backoff growth
+}
+
+// ── (g) #940 REGRESSION: dead top-scored peers must not be re-dialed forever ──
+//
+// Reproduces the contabo bootstrap failure: the same three top-scored peers are
+// re-selected on every 60s dial-plan refresh because dial failures never reach
+// the scorer. get_peers_to_connect() with an EMPTY connected set (0 handshakes,
+// exactly the observed live state) must, once dial failures are fed back via
+// notify_dial_failed(), rotate onto a FOURTH distinct target.
+//
+// A test that only asserts "3 targets selected" would PASS against the broken
+// behaviour — so the assertion is that the union of all targets ever selected
+// grows beyond the budget of 3. The negative control below proves the OLD
+// (no-feedback) path stays wedged at exactly those 3.
+TEST(DashCoinPeerManager, dial_failure_feedback_reaches_fourth_target)
+{
+    boost::asio::io_context ioc;
+
+    // Five candidates, each in a DISTINCT /16 group so the Sybil group cap does
+    // not interfere; the per-cycle budget is min(cycle=5, min(concurrent=3,
+    // max_peers-0)) = 3, matching the three IPs observed live on contabo.
+    const std::vector<std::string> hosts =
+        {"11.0.0.1", "22.0.0.1", "33.0.0.1", "44.0.0.1", "55.0.0.1"};
+
+    auto add_all = [&](DashCoinPeerManager& pm) {
+        for (auto& h : hosts) pm.add_discovered_peer(NetService{h, 9999});
+    };
+
+    // First selection is capped at the budget of 3 (the live symptom).
+    {
+        DashCoinPeerManager probe(ioc, "DASH", unique_tmp_dir("g940_probe"), make_cfg());
+        add_all(probe);
+        EXPECT_EQ(probe.get_peers_to_connect({}).size(), 3u);
+    }
+
+    // ── WITH #940 feedback: fail every selected target, watch the plan rotate ──
+    DashCoinPeerManager fixed(ioc, "DASH", unique_tmp_dir("g940_fixed"), make_cfg());
+    add_all(fixed);
+    std::set<std::string> seen_fixed;
+    for (int round = 0; round < 8; ++round) {
+        auto picks = fixed.get_peers_to_connect({});   // nothing ever connects
+        if (picks.empty()) break;
+        for (auto& ep : picks) {
+            seen_fixed.insert(ep.host());
+            fixed.notify_dial_failed(ep.to_string());  // the dial died — feed it back
+        }
+    }
+    // The rotation must have reached beyond the initial budget of 3.
+    EXPECT_GE(seen_fixed.size(), 4u)
+        << "dial-failure feedback should rotate onto fresh targets";
+
+    // ── NEGATIVE CONTROL: pre-#940 behaviour (dial failures never fed back) ──
+    DashCoinPeerManager broken(ioc, "DASH", unique_tmp_dir("g940_broken"), make_cfg());
+    add_all(broken);
+    std::set<std::string> seen_broken;
+    for (int round = 0; round < 8; ++round) {
+        auto picks = broken.get_peers_to_connect({});
+        for (auto& ep : picks) seen_broken.insert(ep.host());
+        // (no notify_dial_failed — this is the wedged path)
+    }
+    // Wedged: the SAME three top-scored peers, forever — never a fourth.
+    EXPECT_EQ(seen_broken.size(), 3u)
+        << "without feedback the dial plan must stay stuck on 3 dead peers";
 }
 
 } // namespace


### PR DESCRIPTION
Closes the #940 embedded-bootstrap blocker: dial failures now reach the peer scorer.

## Problem (verified against origin/master, not 9b2865aa)
The embedded daemonless arm could not bootstrap a chain — dial failures were invisible to `DashCoinPeerManager`. Only handshake connect/disconnect drove scoring, so a dial that died at ECONNREFUSED/ETIMEDOUT never reached `connected()`; `notify_connected`/`notify_disconnected` never fired; `attempt_count` stayed 0, `can_retry()` stayed true, `compute_score()` never dropped — and the same three top-scored dead peers were re-selected on every 60s refresh forever (live: 177 attempts / 3 IPs / 0 handshakes).

## Fix (fence-respecting, additive)
- `core::INetwork` gains a **default-no-op** `connect_failed(addr)` virtual. `core::Factory::Client` fires it from **both** the `async_connect` error branch **and** the DNS-resolve error branch, under the same `weak_node` lifetime guard as the success path. LTC/DOGE/BCH/DGB/pool nodes inherit the no-op unchanged (verified: all 6 `INetwork` implementers, plus a full `c2pool` main-binary link).
- dash `CoinClient` overrides `connect_failed` -> new `m_on_dial_failed` seam; `main_dash` wires it to `DashCoinPeerManager::notify_dial_failed`.
- `record_dial_failed()` weights a failed dial **heavier** than a post-handshake disconnect (per #940's steer): `attempt++`/backoff **plus** a direct score drop. It also stamps `last_attempt`.

## Regression guard
`test_dash_coin_peer_manager` (already in both CI `--target` lists, so no build.yml change): with dial-failure feedback the plan rotates onto a **4th** distinct target; the **negative control** (no feedback) stays wedged on exactly 3 — a "3 targets selected" assertion alone would pass the broken behaviour. 8/8 green locally.

## Corrections to #940 (as requested — verify before relying)
1. ~~**Line numbers**: #940 was read off `9b2865aa`, which is not an ancestor of master (HEAD `67a76bb9`). The wiring is at `main_dash.cpp:1310-1317`, not `:1355-1362`.~~ **RETRACTED by integrator — this correction was itself wrong, from a stale checkout.** `origin/master` **is** `9b2865aa` (dash: wire the embedded arm so `--run` can actually take it); `git merge-base --is-ancestor 9b2865aa origin/master` returns true. `67a76bb9` (merge PR #915, dash addrme origination) is a real commit but an **ancestor**, not HEAD. On current master the wiring is at `main_dash.cpp:1355` (`set_on_peer_connected`) and `:1359` (`set_on_peer_disconnected`) — i.e. #940's original `:1355-1362` was correct. `:1310`/`:1314` are the positions in the stale `67a76bb9` tree. **Before citing or correcting a line number, run `git rev-parse --short origin/master` after a fresh fetch** — a stale-worktree correction is worse than none, because it reads as authoritative.
2. **Connect-error site**: it is **not** in `p2p_client.hpp:214` (that line is only a comment). The `"Connection failed:"` log lives in **`src/core/factory.hpp` (`Factory::Client::connect_socket`)** — a **shared core** file. Wiring the dash manager there directly would break the isolation fence, hence the additive `INetwork` hook instead.
3. **`budget == 3` CONFIRMED** from the actual defaults: `main_dash` uses a default `DashPeerManagerConfig`, so `min(max_connections_per_cycle{5}, min(max_concurrent_connections{3}, max_peers{20}-0)) = 3`. Your arithmetic is right.
4. **Bonus latent bug**: `last_attempt` was **never assigned anywhere**, so `can_retry()`'s backoff branch was inert (even `record_disconnected`'s backoff growth did nothing). Both `record_disconnected` and `record_dial_failed` now stamp it.

Do not self-merge — for integrator review + full-CI oracle verify.

