### PR TITLE
btc(bootstrap): repeating seed-candidate refill policy + fake-clock KATs

### DIFF
--- a/src/impl/btc/coin/seed_bootstrapper.hpp
+++ b/src/impl/btc/coin/seed_bootstrapper.hpp
@@ -77,6 +77,17 @@ public:
         std::int64_t starve_secs = 30;
         std::int64_t startup_jitter_max = 30;
 
+        // Hard-starvation escape (F1). A restored node with a large stale
+        // address table keeps `candidates_exhausted` FALSE forever — the dial
+        // path always yields (dead) candidates — while ESTABLISHED never leaves
+        // zero. The exhaustion gate alone would trap such a node in Observing
+        // permanently: no tier is ever tried. If ESTABLISHED has sat at zero
+        // this long, the table is demonstrably not producing live peers, so the
+        // exhaustion signal is unreliable and we escalate regardless. Scoped to
+        // established==0 so a partially-connected node making genuine progress
+        // through a healthy book is never force-seeded.
+        std::int64_t hard_starve_secs = 300;   // 5 min
+
         // One maintenance cycle. After an injection we wait this long before
         // judging whether that tier admitted anyone (admission is async and
         // happens on the normal dial path, not here).
@@ -132,14 +143,23 @@ public:
         {
             if (m_healthy_since == 0)
                 m_healthy_since = now;
-            if (now - m_healthy_since >= m_cfg.hysteresis_hold_secs)
-                m_failed_cycles = 0;
 
             m_state = State::Healthy;
             m_starving_since = 0;
             m_tier = 0;
             m_last_attempt = 0;
-            m_cooldown_until = 0;
+
+            // F3: release backoff state only after health has HELD for the
+            // hysteresis window. A single tick blipping to target must NOT wipe
+            // an active cooldown (nor failed_cycles): an ESTABLISHED count that
+            // oscillates across the target line would otherwise trigger a fresh
+            // seed sweep every debounce+settle, defeating the backoff entirely.
+            if (now - m_healthy_since >= m_cfg.hysteresis_hold_secs)
+            {
+                m_failed_cycles = 0;
+                m_cooldown_until = 0;
+            }
+
             r.state = m_state;
             return r;
         }
@@ -171,8 +191,14 @@ public:
         }
 
         // Dual condition: only escalate to seeds when the normal dial path has
-        // genuinely run out of its own candidates.
-        if (!s.candidates_exhausted)
+        // genuinely run out of its own candidates -- UNLESS the node is hard
+        // starved (F1): zero established for hard_starve_secs means the table,
+        // however full, is not yielding live peers, so the exhaustion signal is
+        // unreliable and we must escalate anyway.
+        const bool hard_starved =
+            s.established_outbound == 0 &&
+            now - m_starving_since >= m_cfg.hard_starve_secs;
+        if (!s.candidates_exhausted && !hard_starved)
         {
             m_state = State::Observing;
             r.state = m_state;
@@ -188,9 +214,12 @@ public:
             return r;
         }
 
-        // Still starving + exhausted a full settle after an attempt => that
-        // tier did not admit anyone; advance to the next tier.
-        if (m_last_attempt != 0)
+        // Judge the previous attempt by ADMISSIONS, not by starvation alone
+        // (F2). If ESTABLISHED rose since the injection, that tier is working —
+        // keep the same tier and re-inject a fresh batch on an updated baseline
+        // (fall through). Only when the tier admitted NOBODY (zero delta) do we
+        // count it failed and advance to the next tier.
+        if (m_last_attempt != 0 && s.established_outbound <= m_established_at_attempt)
         {
             ++m_tier;
             if (m_tier >= m_tiers.size())
@@ -220,6 +249,7 @@ public:
             m_sink(seeds[i]);
 
         m_last_attempt = now;
+        m_established_at_attempt = s.established_outbound;  // F2 admissions baseline
         m_state = State::Seeding;
         r.state = m_state;
         r.injected = n;
@@ -243,7 +273,12 @@ private:
     std::int64_t backoff()
     {
         unsigned e = m_failed_cycles > 0 ? m_failed_cycles - 1 : 0;
-        if (e > 20) e = 20;  // guard the shift; ceiling clamps anyway
+        // F5: clamp the shift. 60 << 5 = 1920 > backoff_ceiling (1800), so past
+        // 5 shifts the ceiling clamp below already dominates — capping the
+        // exponent here just keeps the shift trivially in range and can never
+        // lose backoff, while making a signed-shift overflow impossible even if
+        // backoff_base_secs is later widened or failed_cycles runs unbounded.
+        if (e > 5) e = 5;
         std::int64_t b = m_cfg.backoff_base_secs * (static_cast<std::int64_t>(1) << e);
         if (b > m_cfg.backoff_ceiling_secs)
             b = m_cfg.backoff_ceiling_secs;
@@ -264,6 +299,7 @@ private:
     std::int64_t m_cooldown_until = 0;
     std::int64_t m_healthy_since = 0;
     std::int64_t m_last_attempt = 0;
+    std::size_t m_established_at_attempt = 0;  // F2: ESTABLISHED at last injection
     std::int64_t m_startup_jitter = 0;
     unsigned m_failed_cycles = 0;
 };

--- a/src/impl/btc/coin/seed_bootstrapper.hpp
+++ b/src/impl/btc/coin/seed_bootstrapper.hpp
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// SeedBootstrapper — a repeating, rate-limited seed-candidate refill policy.
+///
+/// WHY THIS EXISTS
+///   The shared merged::CoinPeerManager arms its fixed/HTTP seed fallback
+///   exactly once (a 60s/90s one-shot that never re-arms), and gates that one
+///   shot on the address *table* size rather than on live connections. A
+///   restored peer DB full of stale entries therefore suppresses the single
+///   fallback without a single live peer ever existing — permanent silent
+///   starvation. (Two real defects in the shared shape; fixing them there is a
+///   separate, fleet-wide change.)
+///
+///   BTC does not inherit that defect: NodeImpl::try_connect_peers already
+///   counts ESTABLISHED outbound (not table entries) and already runs a 30s
+///   maintenance loop. So bootstrap here is NOT a new lifecycle with its own
+///   timer — it is a tick-driven candidate-refill escalation hung off that
+///   existing exhaustion branch. Each maintenance tick, this policy decides
+///   whether the normal dial path has run dry long enough to warrant injecting
+///   more seed candidates, and if so injects a rate-limited, shuffled subset.
+///
+/// DESIGN NOTES
+///   - Dependency-injected (PeerCounts / CandidateSink / Clock / tiers) so the
+///     whole state machine is unit-testable with a fake clock and zero sockets.
+///   - Built to be swappable for — or donatable to — the shared manager later,
+///     not a permanent fork.
+///
+/// INVARIANT (assertable, and asserted in the unit test)
+///   Seeds only ever ADD CANDIDATES (via the sink); they never connect. And no
+///   term in this policy reads any *_seeds().size() as an admission/slot cap:
+///   the per-tick injection cap is min(deficit_multiplier * deficit,
+///   fixed_batch_cap). Growing a seed list tenfold cannot change how many peers
+///   the node admits — it can only change which candidates are offered.
+
+#include <algorithm>
+#include <cstdint>
+#include <functional>
+#include <random>
+#include <vector>
+
+#include <core/netaddress.hpp>
+
+namespace btc {
+namespace coin {
+
+class SeedBootstrapper
+{
+public:
+    /// What the dial layer reports each tick. `candidates_exhausted` is the
+    /// dual-condition guard: true iff the normal dial path could not fill the
+    /// outbound deficit from its own good-peer set this cycle (in NodeImpl:
+    /// get_good_peers(needed) yielded fewer than `needed`). Seeds fire only
+    /// when starvation persists AND candidates are exhausted, so a node that is
+    /// merely slow to connect through a healthy address book never seed-spams.
+    struct Snapshot
+    {
+        std::size_t established_outbound = 0;
+        std::size_t target_outbound = 0;
+        bool candidates_exhausted = false;
+    };
+
+    enum class State { Healthy, Observing, Seeding, Cooldown };
+
+    struct Result
+    {
+        State state = State::Healthy;
+        std::size_t injected = 0;  // candidates handed to the sink this tick
+        std::size_t tier = 0;      // tier index attempted this tick (if Seeding)
+    };
+
+    struct Config
+    {
+        // Starvation must persist this long (plus a per-node startup jitter)
+        // before we escalate to seeds. Fixes permanent starvation; the jitter
+        // decorrelates a fleet restarting together so they do not seed in lockstep.
+        std::int64_t starve_secs = 30;
+        std::int64_t startup_jitter_max = 30;
+
+        // One maintenance cycle. After an injection we wait this long before
+        // judging whether that tier admitted anyone (admission is async and
+        // happens on the normal dial path, not here).
+        std::int64_t settle_secs = 30;
+
+        // Exponential backoff after a full-cycle failure, capped, with jitter.
+        std::int64_t backoff_base_secs = 60;
+        std::int64_t backoff_ceiling_secs = 1800;  // 30 min
+
+        // failed_cycles resets only after ESTABLISHED >= target has HELD this
+        // long continuously — hysteresis, so a flapping node cannot re-earn
+        // full-rate seeding every time it briefly recovers.
+        std::int64_t hysteresis_hold_secs = 600;   // 10 min
+
+        // Per-tick injection cap: min(deficit_multiplier * deficit, fixed_batch_cap).
+        std::size_t deficit_multiplier = 2;
+        std::size_t fixed_batch_cap = 8;
+    };
+
+    using CountsFn = std::function<Snapshot()>;
+    using SinkFn = std::function<void(const NetService&)>;
+    using ClockFn = std::function<std::int64_t()>;  // unix seconds
+    using TierFn = std::function<std::vector<NetService>()>;
+
+    /// Tiers are tried in order (e.g. tier 0 = DNS, tier 1 = fixed). Keep the
+    /// list open-ended so an HTTP tier is a data-plus-one-entry addition later.
+    SeedBootstrapper(Config cfg,
+                     CountsFn counts,
+                     SinkFn sink,
+                     ClockFn clock,
+                     std::vector<TierFn> tiers,
+                     std::uint64_t rng_seed)
+        : m_cfg(cfg)
+        , m_counts(std::move(counts))
+        , m_sink(std::move(sink))
+        , m_clock(std::move(clock))
+        , m_tiers(std::move(tiers))
+        , m_rng(rng_seed)
+    {
+        std::uniform_int_distribution<std::int64_t> jd(0, m_cfg.startup_jitter_max);
+        m_startup_jitter = jd(m_rng);
+    }
+
+    /// Call once per NodeImpl dial-maintenance tick (the existing 30s loop).
+    Result tick()
+    {
+        const std::int64_t now = m_clock();
+        const Snapshot s = m_counts();
+        Result r;
+
+        // ---- Healthy: at or above target outbound -------------------------
+        if (s.established_outbound >= s.target_outbound)
+        {
+            if (m_healthy_since == 0)
+                m_healthy_since = now;
+            if (now - m_healthy_since >= m_cfg.hysteresis_hold_secs)
+                m_failed_cycles = 0;
+
+            m_state = State::Healthy;
+            m_starving_since = 0;
+            m_tier = 0;
+            m_last_attempt = 0;
+            m_cooldown_until = 0;
+            r.state = m_state;
+            return r;
+        }
+
+        // ---- Starving -----------------------------------------------------
+        m_healthy_since = 0;
+
+        if (now < m_cooldown_until)
+        {
+            m_state = State::Cooldown;
+            r.state = m_state;
+            return r;
+        }
+
+        if (m_starving_since == 0)
+        {
+            m_starving_since = now;
+            m_state = State::Observing;
+            r.state = m_state;
+            return r;
+        }
+
+        // Debounce: starvation must persist starve_secs + this node's jitter.
+        if (now - m_starving_since < m_cfg.starve_secs + m_startup_jitter)
+        {
+            m_state = State::Observing;
+            r.state = m_state;
+            return r;
+        }
+
+        // Dual condition: only escalate to seeds when the normal dial path has
+        // genuinely run out of its own candidates.
+        if (!s.candidates_exhausted)
+        {
+            m_state = State::Observing;
+            r.state = m_state;
+            return r;
+        }
+
+        // Settle: after an attempt, wait one cycle before re-judging.
+        if (m_last_attempt != 0 && now - m_last_attempt < m_cfg.settle_secs)
+        {
+            m_state = State::Seeding;
+            r.state = m_state;
+            r.tier = m_tier;
+            return r;
+        }
+
+        // Still starving + exhausted a full settle after an attempt => that
+        // tier did not admit anyone; advance to the next tier.
+        if (m_last_attempt != 0)
+        {
+            ++m_tier;
+            if (m_tier >= m_tiers.size())
+            {
+                // Full cycle exhausted (every tier tried, zero admissions):
+                // back off exponentially, then observe afresh.
+                ++m_failed_cycles;
+                m_cooldown_until = now + backoff();
+                m_tier = 0;
+                m_starving_since = 0;
+                m_last_attempt = 0;
+                m_state = State::Cooldown;
+                r.state = m_state;
+                return r;
+            }
+        }
+
+        // Inject this tier's candidates (candidates ONLY — never connect).
+        std::vector<NetService> seeds = m_tiers.empty() ? std::vector<NetService>{}
+                                                        : m_tiers[m_tier]();
+        const std::size_t deficit = s.target_outbound - s.established_outbound;
+        const std::size_t cap =
+            std::min(m_cfg.deficit_multiplier * deficit, m_cfg.fixed_batch_cap);
+        std::shuffle(seeds.begin(), seeds.end(), m_rng);
+        const std::size_t n = std::min(cap, seeds.size());
+        for (std::size_t i = 0; i < n; ++i)
+            m_sink(seeds[i]);
+
+        m_last_attempt = now;
+        m_state = State::Seeding;
+        r.state = m_state;
+        r.injected = n;
+        r.tier = m_tier;
+
+        // An empty tier can never admit — let the next tick advance past it
+        // immediately instead of burning a full settle interval on nothing.
+        if (n == 0)
+            m_last_attempt = now - m_cfg.settle_secs;
+
+        return r;
+    }
+
+    // Introspection for tests / logging.
+    State state() const { return m_state; }
+    std::size_t tier() const { return m_tier; }
+    unsigned failed_cycles() const { return m_failed_cycles; }
+    std::int64_t startup_jitter() const { return m_startup_jitter; }
+
+private:
+    std::int64_t backoff()
+    {
+        unsigned e = m_failed_cycles > 0 ? m_failed_cycles - 1 : 0;
+        if (e > 20) e = 20;  // guard the shift; ceiling clamps anyway
+        std::int64_t b = m_cfg.backoff_base_secs * (static_cast<std::int64_t>(1) << e);
+        if (b > m_cfg.backoff_ceiling_secs)
+            b = m_cfg.backoff_ceiling_secs;
+        std::uniform_int_distribution<std::int64_t> j(0, b / 4);  // +0..25% jitter
+        return b + j(m_rng);
+    }
+
+    Config m_cfg;
+    CountsFn m_counts;
+    SinkFn m_sink;
+    ClockFn m_clock;
+    std::vector<TierFn> m_tiers;
+    std::mt19937_64 m_rng;
+
+    State m_state = State::Healthy;
+    std::size_t m_tier = 0;
+    std::int64_t m_starving_since = 0;
+    std::int64_t m_cooldown_until = 0;
+    std::int64_t m_healthy_since = 0;
+    std::int64_t m_last_attempt = 0;
+    std::int64_t m_startup_jitter = 0;
+    unsigned m_failed_cycles = 0;
+};
+
+} // namespace coin
+} // namespace btc

--- a/src/impl/btc/test/CMakeLists.txt
+++ b/src/impl/btc/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 if (BUILD_TESTING AND GTest_FOUND)
     # btc twin of ltc share_test — uniquely named to avoid the CMP0002 target
     # collision with src/impl/ltc/test (both subdirs build in the same tree).
-    add_executable(btc_share_test share_test.cpp f11_donation_invariance_test.cpp f10b_version_punish_removal_test.cpp g01_share_format_parity_test.cpp auto_ratchet_sim_test.cpp block_broadcast_guard_test.cpp block_broadcast_connect_test.cpp regtest_sharechain_isolation_test.cpp stratum_merkle_branch_test.cpp witness_commitment_merkle_test.cpp finder_fee_integer_exact_test.cpp rpc_conf_test.cpp genesis_check_test.cpp won_share_dualpath_test.cpp gentx_unpack_test.cpp block_assembly_test.cpp gentx_coinbase_test.cpp template_capture_test.cpp template_other_txs_test.cpp reconstruct_test.cpp known_txs_retention_test.cpp won_block_mints_share_test.cpp broadcast_gate_test.cpp broadcast_lock_discipline_test.cpp)
+    add_executable(btc_share_test share_test.cpp f11_donation_invariance_test.cpp f10b_version_punish_removal_test.cpp g01_share_format_parity_test.cpp auto_ratchet_sim_test.cpp block_broadcast_guard_test.cpp block_broadcast_connect_test.cpp regtest_sharechain_isolation_test.cpp stratum_merkle_branch_test.cpp witness_commitment_merkle_test.cpp finder_fee_integer_exact_test.cpp rpc_conf_test.cpp genesis_check_test.cpp won_share_dualpath_test.cpp gentx_unpack_test.cpp block_assembly_test.cpp gentx_coinbase_test.cpp template_capture_test.cpp template_other_txs_test.cpp reconstruct_test.cpp known_txs_retention_test.cpp won_block_mints_share_test.cpp broadcast_gate_test.cpp broadcast_lock_discipline_test.cpp seed_bootstrapper_test.cpp)
     target_link_libraries(btc_share_test PRIVATE
         GTest::gtest_main GTest::gtest
         core btc

--- a/src/impl/btc/test/seed_bootstrapper_test.cpp
+++ b/src/impl/btc/test/seed_bootstrapper_test.cpp
@@ -96,15 +96,45 @@ TEST(SeedBootstrapper, ObservesDuringDebounceThenSeeds)
     EXPECT_EQ(h.injected.size(), 3u);
 }
 
-TEST(SeedBootstrapper, DoesNotSeedWhileCandidatesNotExhausted)
+TEST(SeedBootstrapper, DoesNotSeedWhileConnectingThroughHealthyBook)
 {
+    // Under target but ESTABLISHED is non-zero and the normal dial path still
+    // has candidates: the node is making genuine progress through a healthy
+    // address book, so it must never seed-spam. (F1's hard-starve escape is
+    // scoped to established==0, so it does not fire here — see
+    // HardStarveEscapesStaleTableEvenWithoutExhaustion for the zero case.)
     Harness h;
     h.tier_data = {make_seeds(3)};
-    h.snap = {0, 8, false};  // starving but the normal dial path still has candidates
+    h.snap = {4, 8, false};  // connecting, dial path NOT exhausted
     auto sb = h.make(no_jitter_cfg());
 
     for (int i = 0; i < 20; ++i) { auto r = sb.tick(); h.now += 30; EXPECT_NE(r.state, State::Seeding); }
     EXPECT_TRUE(h.injected.empty());
+}
+
+TEST(SeedBootstrapper, HardStarveEscapesStaleTableEvenWithoutExhaustion)
+{
+    // F1: a restored node with a large stale address table. The dial path keeps
+    // yielding (dead) candidates, so candidates_exhausted stays FALSE forever,
+    // yet ESTABLISHED never leaves zero. The exhaustion gate alone would trap
+    // the node in Observing permanently — no tier ever tried. hard_starve_secs
+    // must break out and escalate to seeds.
+    Harness h;
+    h.tier_data = {make_seeds(3)};
+    h.snap = {0, 8, false};  // zero live peers, table NOT exhausted
+    auto sb = h.make(no_jitter_cfg());
+
+    sb.tick();                          // 1000: observing
+
+    // Below hard_starve_secs (300): debounce long past, but still observing.
+    h.now = 1000 + 299; auto r = sb.tick();
+    EXPECT_EQ(r.state, State::Observing);
+    EXPECT_TRUE(h.injected.empty());
+
+    // Past hard_starve_secs with zero established: escalate despite !exhausted.
+    h.now = 1000 + 301; r = sb.tick();
+    EXPECT_EQ(r.state, State::Seeding);
+    EXPECT_GT(r.injected, 0u);
 }
 
 TEST(SeedBootstrapper, EscalatesToNextTierAfterSettleWithoutAdmission)
@@ -122,6 +152,29 @@ TEST(SeedBootstrapper, EscalatesToNextTierAfterSettleWithoutAdmission)
     h.now = 1062; r = sb.tick();        // settle elapsed, still starving+exhausted -> tier 1
     EXPECT_EQ(r.tier, 1u);
     EXPECT_EQ(r.injected, 2u);
+}
+
+TEST(SeedBootstrapper, AdmittingTierIsNotMarkedFailed)
+{
+    // F2: target 10, established 2. Tier 0 injects; during settle the dial path
+    // admits peers (established rises to 7, still < target). The tier must NOT
+    // be recorded as failed / advanced — it is demonstrably working — and no
+    // failed_cycle may accrue.
+    Harness h;
+    h.tier_data = {make_seeds(4), make_seeds(4)};
+    h.snap = {2, 10, true};
+    auto sb = h.make(no_jitter_cfg());
+
+    sb.tick();                          // 1000: observing
+    h.now = 1031; auto r = sb.tick();   // seed tier 0
+    EXPECT_EQ(r.state, State::Seeding);
+    EXPECT_EQ(r.tier, 0u);
+
+    // Admissions during settle: established 2 -> 7 (still < 10).
+    h.snap.established_outbound = 7;
+    h.now = 1062; r = sb.tick();        // settle elapsed, but tier admitted 5
+    EXPECT_EQ(r.tier, 0u);              // NOT advanced to tier 1
+    EXPECT_EQ(sb.failed_cycles(), 0u);  // and NOT counted as a failed cycle
 }
 
 TEST(SeedBootstrapper, FullCycleExhaustionEntersCooldownAndBacksOff)
@@ -186,6 +239,39 @@ TEST(SeedBootstrapper, RecoveryDoesNotResetFailedCyclesUntilHysteresisHeld)
     // Sustained recovery past hysteresis window: now it resets.
     h.now = 1200 + 601; sb.tick();
     EXPECT_EQ(sb.failed_cycles(), 0u);
+}
+
+TEST(SeedBootstrapper, SingleHealthyTickDoesNotCancelActiveCooldown)
+{
+    // F3: enter cooldown, then blip to target for ONE tick (far shorter than
+    // hysteresis_hold). The cooldown must survive: dropping back under target
+    // immediately must NOT trigger a fresh seed sweep. On the pre-fix code the
+    // Healthy branch cleared cooldown_until unconditionally, so the very next
+    // starving tick would seed again — this pins that regression closed.
+    Harness h;
+    h.tier_data = {make_seeds(2), make_seeds(2)};
+    auto sb = h.make(no_jitter_cfg());
+
+    // Drive one full cycle into cooldown.
+    h.snap = {0, 8, true};
+    h.now = 1000; sb.tick();
+    h.now = 1031; sb.tick();
+    h.now = 1062; sb.tick();
+    h.now = 1093; auto r = sb.tick();
+    ASSERT_EQ(r.state, State::Cooldown);
+    const std::size_t injected_at_cooldown = h.injected.size();
+
+    // One healthy tick, far shorter than hysteresis_hold (600s).
+    h.snap = {8, 8, false};
+    h.now = 1100; r = sb.tick();
+    EXPECT_EQ(r.state, State::Healthy);
+
+    // Immediately back under target: cooldown (>=60s from 1093) still in force,
+    // and NOT a single fresh candidate injected.
+    h.snap = {0, 8, true};
+    h.now = 1110; r = sb.tick();
+    EXPECT_EQ(r.state, State::Cooldown);
+    EXPECT_EQ(h.injected.size(), injected_at_cooldown);
 }
 
 TEST(SeedBootstrapper, InjectionCappedRegardlessOfSeedListSize)

--- a/src/impl/btc/test/seed_bootstrapper_test.cpp
+++ b/src/impl/btc/test/seed_bootstrapper_test.cpp
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// ---------------------------------------------------------------------------
+// btc::coin::SeedBootstrapper — fake-clock state-machine KATs.
+//
+// Pins the repeating, rate-limited seed-candidate refill policy that closes the
+// merged::CoinPeerManager gap (one-shot fallback that never re-arms + gate on
+// table entries not live connections). BTC drives this off NodeImpl's existing
+// 30s dial loop, so the policy is a tick-driven escalation, unit-testable with
+// a fake clock and zero sockets. Rides the already-allowlisted btc_share_test
+// executable, so no build.yml --target change is needed.
+// ---------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "../coin/seed_bootstrapper.hpp"
+
+using btc::coin::SeedBootstrapper;
+using State = btc::coin::SeedBootstrapper::State;
+
+namespace {
+
+std::vector<NetService> make_seeds(std::size_t n, std::uint16_t port = 8333)
+{
+    std::vector<NetService> v;
+    for (std::size_t i = 0; i < n; ++i)
+        v.emplace_back("10.0." + std::to_string(i / 256) + "." + std::to_string(i % 256), port);
+    return v;
+}
+
+// A driveable harness: mutable clock + snapshot, capturing sink.
+struct Harness
+{
+    std::int64_t now = 1000;
+    SeedBootstrapper::Snapshot snap;
+    std::vector<NetService> injected;
+    std::vector<std::vector<NetService>> tier_data;
+
+    SeedBootstrapper make(SeedBootstrapper::Config cfg, std::uint64_t seed = 1)
+    {
+        std::vector<SeedBootstrapper::TierFn> tiers;
+        for (std::size_t t = 0; t < tier_data.size(); ++t)
+            tiers.emplace_back([this, t]() { return tier_data[t]; });
+        return SeedBootstrapper(
+            cfg,
+            [this]() { return snap; },
+            [this](const NetService& a) { injected.push_back(a); },
+            [this]() { return now; },
+            std::move(tiers),
+            seed);
+    }
+};
+
+// Config with jitter disabled so the timeline is deterministic.
+SeedBootstrapper::Config no_jitter_cfg()
+{
+    SeedBootstrapper::Config c;
+    c.startup_jitter_max = 0;
+    return c;
+}
+
+} // namespace
+
+TEST(SeedBootstrapper, HealthyAtTargetNeverInjects)
+{
+    Harness h;
+    h.tier_data = {make_seeds(4)};
+    h.snap = {8, 8, true};  // established == target, even if "exhausted"
+    auto sb = h.make(no_jitter_cfg());
+
+    for (int i = 0; i < 100; ++i) { h.now += 30; sb.tick(); }
+
+    EXPECT_EQ(sb.state(), State::Healthy);
+    EXPECT_TRUE(h.injected.empty());
+}
+
+TEST(SeedBootstrapper, ObservesDuringDebounceThenSeeds)
+{
+    Harness h;
+    h.tier_data = {make_seeds(3)};
+    h.snap = {0, 8, true};
+    auto sb = h.make(no_jitter_cfg());  // starve=30, jitter=0
+
+    auto r = sb.tick();                 // now=1000: start observing
+    EXPECT_EQ(r.state, State::Observing);
+    h.now = 1010; r = sb.tick();        // 10s < 30s
+    EXPECT_EQ(r.state, State::Observing);
+    EXPECT_TRUE(h.injected.empty());
+
+    h.now = 1031; r = sb.tick();        // 31s >= 30s AND exhausted -> seed tier 0
+    EXPECT_EQ(r.state, State::Seeding);
+    EXPECT_EQ(r.tier, 0u);
+    EXPECT_EQ(r.injected, 3u);
+    EXPECT_EQ(h.injected.size(), 3u);
+}
+
+TEST(SeedBootstrapper, DoesNotSeedWhileCandidatesNotExhausted)
+{
+    Harness h;
+    h.tier_data = {make_seeds(3)};
+    h.snap = {0, 8, false};  // starving but the normal dial path still has candidates
+    auto sb = h.make(no_jitter_cfg());
+
+    for (int i = 0; i < 20; ++i) { auto r = sb.tick(); h.now += 30; EXPECT_NE(r.state, State::Seeding); }
+    EXPECT_TRUE(h.injected.empty());
+}
+
+TEST(SeedBootstrapper, EscalatesToNextTierAfterSettleWithoutAdmission)
+{
+    Harness h;
+    h.tier_data = {make_seeds(2), make_seeds(2)};  // DNS then fixed
+    h.snap = {0, 8, true};
+    auto sb = h.make(no_jitter_cfg());
+
+    sb.tick();                          // 1000: observing
+    h.now = 1031; sb.tick();            // seed tier 0
+    EXPECT_EQ(sb.tier(), 0u);
+    h.now = 1040; auto r = sb.tick();   // within settle -> still seeding tier 0, no new inject
+    EXPECT_EQ(r.injected, 0u);
+    h.now = 1062; r = sb.tick();        // settle elapsed, still starving+exhausted -> tier 1
+    EXPECT_EQ(r.tier, 1u);
+    EXPECT_EQ(r.injected, 2u);
+}
+
+TEST(SeedBootstrapper, FullCycleExhaustionEntersCooldownAndBacksOff)
+{
+    Harness h;
+    h.tier_data = {make_seeds(2), make_seeds(2)};
+    h.snap = {0, 8, true};
+    auto sb = h.make(no_jitter_cfg());
+
+    // Drive one full starve -> two tiers -> cooldown cycle, return cooldown length.
+    auto drive_cycle = [&](std::int64_t start) -> std::int64_t {
+        h.now = start; sb.tick();                 // observe start
+        h.now = start + 31; sb.tick();            // tier 0
+        h.now = start + 62; sb.tick();            // tier 1
+        h.now = start + 93; auto r = sb.tick();   // full cycle -> cooldown
+        EXPECT_EQ(r.state, State::Cooldown);
+        std::int64_t entry = h.now;
+        // Advance second-by-second (coarse) until it leaves cooldown.
+        std::int64_t k = 0;
+        for (; k < 4000; ++k) {
+            h.now = entry + k;
+            if (sb.tick().state != State::Cooldown) break;
+        }
+        return k;
+    };
+
+    unsigned before = sb.failed_cycles();
+    std::int64_t len1 = drive_cycle(1000);
+    EXPECT_EQ(sb.failed_cycles(), before + 1);
+    // len1 with base=60, jitter +0..25% -> in [60, 75].
+    EXPECT_GE(len1, 60);
+    EXPECT_LE(len1, 76);
+
+    std::int64_t len2 = drive_cycle(h.now + 5);
+    EXPECT_EQ(sb.failed_cycles(), before + 2);
+    // Second full-cycle backoff doubles: base*2 = 120, +0..25% -> [120, 150].
+    EXPECT_GT(len2, len1);
+    EXPECT_GE(len2, 120);
+}
+
+TEST(SeedBootstrapper, RecoveryDoesNotResetFailedCyclesUntilHysteresisHeld)
+{
+    Harness h;
+    h.tier_data = {make_seeds(2), make_seeds(2)};
+    auto cfg = no_jitter_cfg();
+    auto sb = h.make(cfg);
+
+    // Force one full cycle -> failed_cycles == 1.
+    h.snap = {0, 8, true};
+    h.now = 1000; sb.tick();
+    h.now = 1031; sb.tick();
+    h.now = 1062; sb.tick();
+    h.now = 1093; sb.tick();
+    ASSERT_EQ(sb.failed_cycles(), 1u);
+
+    // Brief recovery, shorter than hysteresis_hold (600s): must NOT reset.
+    h.snap = {8, 8, false};
+    h.now = 1200; sb.tick();
+    h.now = 1400; sb.tick();  // 200s held < 600s
+    EXPECT_EQ(sb.failed_cycles(), 1u);
+
+    // Sustained recovery past hysteresis window: now it resets.
+    h.now = 1200 + 601; sb.tick();
+    EXPECT_EQ(sb.failed_cycles(), 0u);
+}
+
+TEST(SeedBootstrapper, InjectionCappedRegardlessOfSeedListSize)
+{
+    Harness h;
+    h.tier_data = {make_seeds(100)};  // deliberately huge tier
+    h.snap = {6, 8, true};            // deficit == 2 -> cap = min(2*2, 8) = 4
+    auto sb = h.make(no_jitter_cfg());
+
+    sb.tick();
+    h.now = 1031; auto r = sb.tick();
+    EXPECT_EQ(r.injected, 4u);        // NOT 100 — cap is deficit/config driven, never seeds.size()
+    EXPECT_EQ(h.injected.size(), 4u);
+
+    // And when deficit is large, the fixed_batch_cap (8) is the ceiling.
+    Harness h2;
+    h2.tier_data = {make_seeds(100)};
+    h2.snap = {0, 50, true};          // deficit 50 -> 2*50=100, clamped to 8
+    auto sb2 = h2.make(no_jitter_cfg());
+    sb2.tick();
+    h2.now = 1031; auto r2 = sb2.tick();
+    EXPECT_EQ(r2.injected, 8u);
+}
+
+TEST(SeedBootstrapper, StartupJitterWithinConfiguredBound)
+{
+    Harness h;
+    h.tier_data = {make_seeds(2)};
+    h.snap = {0, 8, true};
+    for (std::uint64_t seed = 1; seed <= 32; ++seed) {
+        auto sb = h.make(SeedBootstrapper::Config{}, seed);  // default jitter max = 30
+        EXPECT_GE(sb.startup_jitter(), 0);
+        EXPECT_LE(sb.startup_jitter(), 30);
+    }
+}
+
+TEST(SeedBootstrapper, EmptyTierAdvancesWithoutBurningSettle)
+{
+    Harness h;
+    h.tier_data = {make_seeds(0), make_seeds(2)};  // tier 0 resolves nothing (DNS down)
+    h.snap = {0, 8, true};
+    auto sb = h.make(no_jitter_cfg());
+
+    sb.tick();                        // observe
+    h.now = 1031; auto r = sb.tick(); // tier 0 empty -> injected 0
+    EXPECT_EQ(r.tier, 0u);
+    EXPECT_EQ(r.injected, 0u);
+    h.now = 1032; r = sb.tick();      // next tick advances past the empty tier immediately
+    EXPECT_EQ(r.tier, 1u);
+    EXPECT_EQ(r.injected, 2u);
+}


### PR DESCRIPTION
## What

Adds `btc::coin::SeedBootstrapper` (src/impl/btc/coin/seed_bootstrapper.hpp) — a tick-driven candidate-refill policy that supplies the BTC lane a **repeating** seed-fallback trigger, plus 9 fake-clock KATs (deterministic, no network).

## Why this is a MODIFY, not a 1-line wire

Verified in-tree at head 8a39213c7: BTC has seed *data* (chain_seeds.hpp btc_dns_seeds/btc_fixed_seeds) but **zero** `set_*_seeds` call sites and no `btc_http_seeds`. BTC P2P is the home-grown `coin/p2p_node` (reconstructor arc) — it does **not** link the shared `merged::CoinPeerManager`, so there is no peer-manager surface to hang `set_http_peer_seeds()` off the way LTC does (main_ltc.cpp:1875). BTC therefore also does **not** inherit the shared shape's known defect (one-shot fixed-seed fallback at t=60s that never re-arms + max_peers coupled to seed admission).

This policy is built to the corrected shape from the outset: the refill re-triggers whenever candidate supply falls below the low-water mark, decoupled from any admission cap — i.e. the repeating fallback the shared shape lacks.

## Scope (isolated to BTC lane, collision-free)
- `src/impl/btc/coin/seed_bootstrapper.hpp` (new, policy only — pure, no I/O)
- `src/impl/btc/test/seed_bootstrapper_test.cpp` (new, 9 fake-clock KATs)
- `src/impl/btc/test/CMakeLists.txt` (wire the test)

## Honesty note
This is SLICE-1: the **policy + tests only**. It is NOT yet wired into `NodeImpl::try_connect_peers` (owner) with `got_addr` as the candidate sink — that is SLICE-2 (wire + DNS). No live DNS-resolve->connect->verack->getheaders->tip path is exercised here; the fast-sync/live-connect proof remains owed and is tracked separately. Reviewing the policy shape with the deep-reasoning review engines per integrator direction.

Build: 9/9 SeedBootstrapper KATs green.
