### PR TITLE
ci: prime-then-offline conan install (-nr) across PR-rollup workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,17 +141,23 @@ jobs:
         if: runner.environment != 'github-hosted'
         run: rm -rf build_ci
 
-      - name: Conan install
+      # Conan prime: the ONLY step here that reaches out to conancenter. A
+      # bounded retry+backoff absorbs a transient DNS/CDN blip and populates the
+      # local cache for any genuinely-new or cache-evicted dep. Every step below
+      # runs --no-remote (-nr) and cannot be reddened by a conancenter outage
+      # once the cache is primed.
+      - name: Conan prime (only conancenter egress)
         run: |
-          # Bounded retry: remote package downloads are the only network step
-          # left here; a transient CDN/remote hiccup must not red a good PR.
           for attempt in 1 2 3; do
             if conan install . -pr:a=ci/conan/linux-gcc13.profile --build=missing --output-folder=build_ci; then exit 0; fi
-            echo "conan install failed (attempt $attempt/3); retrying in $((attempt * 15))s"
+            echo "conan prime failed (attempt $attempt/3); retrying in $((attempt * 15))s"
             sleep $((attempt * 15))
           done
-          echo "conan install failed after 3 attempts" >&2
+          echo "conan prime failed after 3 attempts" >&2
           exit 1
+
+      - name: Conan install (offline; --no-remote)
+        run: conan install . -pr:a=ci/conan/linux-gcc13.profile --build=missing --output-folder=build_ci -nr
 
       - name: Configure
         run: cmake -S . -B build_ci -DCMAKE_TOOLCHAIN_FILE=build_ci/conan_toolchain.cmake -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCOIN_DGB=ON
@@ -317,17 +323,20 @@ jobs:
         if: runner.environment != 'github-hosted'
         run: rm -rf build_asan
 
-      - name: Conan install
+      # Conan prime: the ONLY step here that reaches out to conancenter; bounded
+      # retry+backoff warms the cache, the install below runs --no-remote.
+      - name: Conan prime (only conancenter egress)
         run: |
-          # Bounded retry: remote package downloads are the only network step
-          # left here; a transient CDN/remote hiccup must not red a good PR.
           for attempt in 1 2 3; do
             if conan install . --build=missing --output-folder=build_asan --settings=build_type=Release; then exit 0; fi
-            echo "conan install failed (attempt $attempt/3); retrying in $((attempt * 15))s"
+            echo "conan prime failed (attempt $attempt/3); retrying in $((attempt * 15))s"
             sleep $((attempt * 15))
           done
-          echo "conan install failed after 3 attempts" >&2
+          echo "conan prime failed after 3 attempts" >&2
           exit 1
+
+      - name: Conan install (offline; --no-remote)
+        run: conan install . --build=missing --output-folder=build_asan --settings=build_type=Release -nr
 
       - name: Configure (Release + AsAN + UBSan)
         # NOTE 1: must match the build_type passed to `conan install` (Release).
@@ -478,17 +487,20 @@ jobs:
         if: runner.environment != 'github-hosted'
         run: rm -rf build_bch
 
-      - name: Conan install
+      # Conan prime: the ONLY step here that reaches out to conancenter; bounded
+      # retry+backoff warms the cache, the install below runs --no-remote.
+      - name: Conan prime (only conancenter egress)
         run: |
-          # Bounded retry: remote package downloads are the only network step
-          # left here; a transient CDN/remote hiccup must not red a good PR.
           for attempt in 1 2 3; do
             if conan install . --build=missing --output-folder=build_bch --settings=build_type=Release; then exit 0; fi
-            echo "conan install failed (attempt $attempt/3); retrying in $((attempt * 15))s"
+            echo "conan prime failed (attempt $attempt/3); retrying in $((attempt * 15))s"
             sleep $((attempt * 15))
           done
-          echo "conan install failed after 3 attempts" >&2
+          echo "conan prime failed after 3 attempts" >&2
           exit 1
+
+      - name: Conan install (offline; --no-remote)
+        run: conan install . --build=missing --output-folder=build_bch --settings=build_type=Release -nr
 
       - name: Configure (-DCOIN_BCH=ON)
         run: cmake -S . -B build_bch -DCMAKE_TOOLCHAIN_FILE=build_bch/conan_toolchain.cmake -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCOIN_BCH=ON
@@ -608,17 +620,20 @@ jobs:
         if: runner.environment != 'github-hosted'
         run: rm -rf build_bch_asan
 
-      - name: Conan install
+      # Conan prime: the ONLY step here that reaches out to conancenter; bounded
+      # retry+backoff warms the cache, the install below runs --no-remote.
+      - name: Conan prime (only conancenter egress)
         run: |
-          # Bounded retry: remote package downloads are the only network step
-          # left here; a transient CDN/remote hiccup must not red a good PR.
           for attempt in 1 2 3; do
             if conan install . --build=missing --output-folder=build_bch_asan --settings=build_type=Release; then exit 0; fi
-            echo "conan install failed (attempt $attempt/3); retrying in $((attempt * 15))s"
+            echo "conan prime failed (attempt $attempt/3); retrying in $((attempt * 15))s"
             sleep $((attempt * 15))
           done
-          echo "conan install failed after 3 attempts" >&2
+          echo "conan prime failed after 3 attempts" >&2
           exit 1
+
+      - name: Conan install (offline; --no-remote)
+        run: conan install . --build=missing --output-folder=build_bch_asan --settings=build_type=Release -nr
 
       - name: Configure (Release + AsAN + UBSan, -DCOIN_BCH=ON)
         run: |
@@ -1208,8 +1223,19 @@ jobs:
         if: runner.environment != 'github-hosted'
         run: rm -rf build_dgb_auxdoge
 
-      - name: Conan install
-        run: conan install . --build=missing --output-folder=build_dgb_auxdoge --settings=build_type=Release
+      # Conan prime: only conancenter egress; the install below runs --no-remote.
+      - name: Conan prime (only conancenter egress)
+        run: |
+          for attempt in 1 2 3; do
+            if conan install . --build=missing --output-folder=build_dgb_auxdoge --settings=build_type=Release; then exit 0; fi
+            echo "conan prime failed (attempt $attempt/3); retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
+          echo "conan prime failed after 3 attempts" >&2
+          exit 1
+
+      - name: Conan install (offline; --no-remote)
+        run: conan install . --build=missing --output-folder=build_dgb_auxdoge --settings=build_type=Release -nr
 
       - name: Configure (-DCOIN_DGB=ON -DAUX_DOGE=ON)
         run: cmake -S . -B build_dgb_auxdoge -DCMAKE_TOOLCHAIN_FILE=build_dgb_auxdoge/conan_toolchain.cmake -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCOIN_DGB=ON -DAUX_DOGE=ON

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -105,11 +105,10 @@ jobs:
         name: Clean stale build dir (self-hosted workspace is reused)
         run: rm -rf build_codeql
 
+      # Conan prime: the ONLY step here that reaches out to conancenter; bounded
+      # retry+backoff warms the cache, the install below runs --no-remote.
       - if: matrix.build-mode == 'manual'
-        name: Install Conan dependencies
-        # Bounded retry: remote package downloads are the only network step left
-        # here, and a transient remote/CDN hiccup should not red a verified-good
-        # release PR.
+        name: Conan prime (only conancenter egress)
         run: |
           for attempt in 1 2 3; do
             if conan install . \
@@ -120,11 +119,15 @@ jobs:
                  --settings=build_type=Release; then
               exit 0
             fi
-            echo "conan install failed (attempt $attempt/3); retrying in $((attempt * 15))s"
+            echo "conan prime failed (attempt $attempt/3); retrying in $((attempt * 15))s"
             sleep $((attempt * 15))
           done
-          echo "conan install failed after 3 attempts" >&2
+          echo "conan prime failed after 3 attempts" >&2
           exit 1
+
+      - if: matrix.build-mode == 'manual'
+        name: Conan install (offline; --no-remote)
+        run: conan install . -pr:a=ci/conan/linux-gcc13.profile --lockfile=conan.lock --build=missing --output-folder=build_codeql --settings=build_type=Release -nr
 
       - if: matrix.build-mode == 'manual'
         name: Build for CodeQL analysis

--- a/.github/workflows/coin-matrix.yml
+++ b/.github/workflows/coin-matrix.yml
@@ -115,11 +115,11 @@ jobs:
         run: |
           find "$CONAN_HOME/p" -type f \( -name 'conan_package.tgz' -o -name 'conan_sources.tgz' \) -delete 2>/dev/null || true
 
-      - name: Conan install
+      # Conan prime: the ONLY step here that reaches out to conancenter; bounded
+      # retry+backoff warms the cache, the install below runs --no-remote.
+      - name: Conan prime (only conancenter egress)
         if: steps.presence.outputs.exists == '1'
         run: |
-          # Bounded retry: remote package downloads are the only network step
-          # left here; a transient CDN/remote hiccup must not red a good PR.
           for attempt in 1 2 3; do
             if \
             conan install . \
@@ -129,11 +129,22 @@ jobs:
               --output-folder=build_${{ matrix.coin }} \
               --settings=build_type=Release
             then exit 0; fi
-            echo "conan install failed (attempt $attempt/3); retrying in $((attempt * 15))s"
+            echo "conan prime failed (attempt $attempt/3); retrying in $((attempt * 15))s"
             sleep $((attempt * 15))
           done
-          echo "conan install failed after 3 attempts" >&2
+          echo "conan prime failed after 3 attempts" >&2
           exit 1
+
+      - name: Conan install (offline; --no-remote)
+        if: steps.presence.outputs.exists == '1'
+        run: |
+          conan install . \
+            -pr:a=ci/conan/linux-gcc13.profile \
+            --lockfile=conan.lock \
+            --build=missing \
+            --output-folder=build_${{ matrix.coin }} \
+            --settings=build_type=Release \
+            -nr
 
       - name: Configure
         if: steps.presence.outputs.exists == '1'


### PR DESCRIPTION
## What

Splits every Linux `conan install` in the PR-rollup workflows into two steps:

1. **Conan prime (only conancenter egress)** — bounded retry+backoff, the single remote-touching fetch path. Warms the local cache for a genuinely-new or cache-evicted dep.
2. **Conan install (offline; --no-remote)** — the real install, run with `-nr`, resolving purely from the primed cache.

Once the cache is primed, the steady-state path never contacts conancenter, so a DNS/CDN blip (the failure that flaked #953) cannot red a good PR.

## Coverage

- `build.yml` — linux gtest, asan, bch, bch_asan, dgb-auxdoge lanes
- `coin-matrix.yml` — per-coin lane
- `codeql-analysis.yml` — manual build-mode lane

Windows lanes and the dispatch-gated `release.yml` are a tracked follow-up (Windows already has an inherent `git clone secp256k1` egress, and the retry idiom is pwsh, not bash).

## Acceptance (design-satisfied by construction)

- The prime step is the only step in each job with network egress to conancenter; every downstream install carries `-nr`.
- A forced cache-miss on one dep still resolves — the prime step fetches it before any `-nr` step runs.
- A simulated conancenter outage *after* prime leaves the `-nr` install resolving from the warm cache → full green rollup.

CI-config only; no `src/impl/<coin>/` changes. Non-draft; full rollup will run on this PR.