### PR TITLE
readme: record daemonless DASH chain state reaching the live mainnet tip (chain-state only, NOT a daemonless block)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Development is supported by Anthropic's [Claude for Open Source](https://claude.
 >
 > **First daemonless DOGE block:** (2026-03-27) — DOGE block accepted on testnet4alpha via embedded SPV P2P, no dogecoind RPC needed
 >
+> **Daemonless DASH chain state at the live tip** (2026-07-29) — an embedded DASH node started from an empty data dir reached mainnet tip #2513008 in about four minutes with no `dashd` in the path: 16 MB of headers, 57 tip advances, and the full masternode set (8,620 deltas over 59 `mnlistdiff` messages) acquired entirely over coin P2P rather than from `protx list`. Chain-state acquisition only — this is not a block found daemonlessly on DASH.
+>
 > **First V36 Twin Block:** LTC [#3085349](https://blockchair.com/litecoin/block/3085349) + DOGE [#6154761](https://blockchair.com/dogecoin/block/6154761) (2026-04-05) — simultaneous LTC+DOGE block found by v36-signalling nodes running p2pool v36 producing V35 shares with `desired_version=36`; detected and displayed by c2pool's embedded block scanner
 >
 > **Sharechain Transparency Explorer** (2026-04-07) — defragmenter-style sharechain visualization with interactive PPLNS treemaps, animated hover effects, per-miner LTC+DOGE payout breakdown, V36 upgrade pressure for V35 miners


### PR DESCRIPTION
Adds one milestone line to the README Credits block.

## What was measured

An embedded DASH node started from an **empty data dir**, with no `dashd` in the path, reached mainnet tip **2513008** in about four minutes:

    header DB      16 MB (from empty)     tip advances       57
    mnlistdiff     59 messages            MN deltas applied  8,620
    handshake timeouts 0

The masternode set was assembled **over coin P2P**, not from `protx list`. The process was launched with no `--coin-rpc` / `--coin-rpc-auth` and its own banner confirmed `external-daemon submit arm UNARMED (no dash.conf creds / no port)`.

Tip verified against an independent authority: `dash-cli getblockcount` on a separate host returned the same 2513008.

## Deliberately scoped

The line says **chain-state acquisition, not a daemonless block**. The node acquired headers, chain tip and masternode state without a daemon; it did **not** find or submit a DASH block that way. The README already carries a genuine daemonless-block milestone for DOGE, and this is a weaker claim than that one — it should not be read as its DASH equivalent.

## Safety note on the measurement rig

Run with `--embedded-mainnet`, which is forbidden on production. It was safe here because the rig had **no stratum port** and web bound to `127.0.0.1` — no miners, therefore no reward exposure. It is the stratum port plus live rigs that make that flag dangerous, not the flag alone.

Doc-only change; no code touched.