### PR TITLE
dash: ingest-path observability — idle-timeout reason + CP1/CP2/CP3 probes

### DIFF
--- a/src/impl/dash/coin/header_chain.hpp
+++ b/src/impl/dash/coin/header_chain.hpp
@@ -409,6 +409,16 @@ public:
         }
         if (last_ptc.fired && m_on_tip_changed)
             m_on_tip_changed(last_ptc.old_tip, last_ptc.old_height, last_ptc.new_tip, last_ptc.new_height, last_ptc.was_reorg);
+        // CP2 validate: received vs accepted. accepted==0 on a non-empty batch
+        // is the Q3 silent-reject corner — with a checkpoint configured the
+        // genesis stub is not seeded, so headers served from block 1 orphan-
+        // reject invisibly. Log the first header's prev hash so orphan-vs-PoW
+        // is distinguishable.
+        LOG_INFO << "[DASH] CP2 validate add_headers: received=" << headers.size()
+                 << " accepted=" << accepted;
+        if (accepted == 0 && !headers.empty())
+            LOG_INFO << "[DASH] CP2 validate: accepted==0 first_prev_block="
+                     << headers.front().m_previous_block.GetHex();
         return accepted;
     }
 
@@ -680,7 +690,14 @@ private:
             uint8_t((h >> 24) & 0xFF), uint8_t((h >> 16) & 0xFF),
             uint8_t((h >> 8) & 0xFF), uint8_t(h & 0xFF)};
         batch.put("height", height_data);
-        if (batch.commit_sync())
+        size_t written = m_dirty_headers.size();
+        bool ok = batch.commit_sync();
+        // CP3 persist: entries written + LevelDB write status, so a flush that
+        // silently fails (headers accepted but never durable across restart)
+        // becomes visible.
+        LOG_INFO << "[EMB-DASH] CP3 persist flush_dirty: entries=" << written
+                 << " leveldb_status=" << (ok ? "OK" : "FAILED");
+        if (ok)
             m_dirty_headers.clear();
     }
 

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -638,7 +638,13 @@ private:
                  << " height=" << m_peer_start_height << ")";
 
         ensure_timeout_timer();
-        m_timeout_timer->restart(IDLE_TIMEOUT_SEC);
+        // Rebind the timeout reason at handshake completion: post-handshake
+        // expiries are idle timeouts, not the "handshake timeout" armed in
+        // connected(). start() re-sets m_handler, and on_activity()'s restart()
+        // reuses it — so idle expiries now log the correct reason.
+        m_timeout_timer->start(IDLE_TIMEOUT_SEC, [this]() {
+            timeout("idle timeout");
+        });
 
         ensure_ping_timer();
         m_ping_timer->start(PING_INTERVAL_SEC, [this]() {
@@ -715,6 +721,12 @@ private:
 
     ADD_P2P_HANDLER(headers)
     {
+        // CP1 parse: a complete `headers` message was framed and parsed — log
+        // the batch count + wire payload size. Fires only per successfully
+        // parsed message, so a stall upstream of parse stays silent here.
+        LOG_INFO << "[" << m_chain_label << "] CP1 parse headers: batch="
+                 << msg->m_headers.size()
+                 << " payload_bytes=" << pack(msg->m_headers).size();
         // E2a: BlockType now round-trips the wire `headers` layout (each entry
         // is an 80-byte header + CompactSize(0) tx-count), so multi-entry
         // getheaders-driven batches deserialize correctly. The new_headers event


### PR DESCRIPTION
## What

Items 1-2 of the ingest-stall task (integrator, 2026-07-29). Both land unconditionally, independent of CP0.

**Item 1 — timeout-reason mislabel (the fix that costs nothing).**
`verack` armed the idle timer with `restart(IDLE_TIMEOUT_SEC)`, which reuses the `"handshake timeout"` callback set in `connected()`. So a post-handshake idle expiry logged `"handshake timeout"` — the mislabel that sent the investigation down wrong paths. Now `verack` calls `start(IDLE_TIMEOUT_SEC, [](){ timeout("idle timeout"); })`, rebinding the reason; `on_activity()`'s `restart()` reuses the corrected handler.

**Item 2 — CP1/CP2/CP3 one-line probes (safe-additive).**
- **CP1 parse** — at `headers` handler entry (`p2p_client.hpp`): batch count + wire payload size. Fires only per successfully-framed-and-parsed message.
- **CP2 validate** — at end of `add_headers` (`header_chain.hpp`): `received` vs `accepted`; when `accepted==0` on a non-empty batch, also logs the first header's previous-block hash. Closes the Q3 silent-reject corner — with a checkpoint configured the genesis stub is not seeded, so a peer serving from block 1 orphan-rejects every header with zero output today.
- **CP3 persist** — in `flush_dirty` (`header_chain.hpp`): entries written + the LevelDB write status (OK/FAILED).

## Scope / gate
Single-coin `src/impl/dash` only. No `bitcoin_family`, no `src/core` touch -> no cross-coin gate, single DASH smoke suffices.

## Test (Linux x86_64, from build/)
- `test_dash_header_chain` — 8/8 PASSED
- `test_dash_p2p_node` (exercises `p2p_client.hpp` via `test_dash_coin_p2p_client.cpp`) — 25/25 PASSED

No self-merge — integrator verify (oracle + full CI) then operator tap. CP0 remains blocked on host-B; no other ingest-path code changes until CP0 or leg 3 names the layer.
