### PR TITLE
dash(web): wire main_dash.cpp stat_log persistence call sites (D-WEB.944)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -714,6 +714,18 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         // ── Real, non-negotiable node identity ────────────────────────────
         mi->set_coin_label("DASH");
 
+        // --- Stats persistence: load prior graph_db on start (DASH) ---
+        // Parity with main_ltc.cpp:1968 — restores the persisted stat_log so
+        // hashrate/DOA history survives node restarts instead of resetting to
+        // empty on every bounce. Same per-net data dir + WebServer stat_log
+        // machinery already in master; display/history only, no consensus path.
+        {
+            std::string graph_db_path = (core::filesystem::config_path()
+                / net_subdir / "graph_db").string();
+            mi->set_stat_log_path(graph_db_path);
+            mi->load_stat_log();
+        }
+
         // --- Persistent found-block storage (DASH) ---
         // Parity with main_ltc.cpp:1977 — won DASH blocks survive node
         // restarts on the dashboard /recent_blocks + history cards instead of
@@ -3783,6 +3795,23 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         cache_mi->refresh_http_caches();   // initial populate
         cache_timer->expires_after(std::chrono::seconds(2));
         cache_timer->async_wait(*cache_tick);
+
+        // ── Stats persistence timer (main_ltc.cpp:7429 parity) ───────────
+        // Save the stat_log every 100 s (matches p2pool graph_db cadence) so a
+        // hard kill loses at most ~100 s of history. Reuses cache_mi/ioc; the
+        // timer self-cancels at shutdown. Display/history only.
+        auto stats_timer = std::make_shared<io::steady_timer>(ioc);
+        auto stats_tick =
+            std::make_shared<std::function<void(const boost::system::error_code&)>>();
+        *stats_tick = [stats_timer, stats_tick, cache_mi](
+                          const boost::system::error_code& ec) {
+            if (ec) return;   // cancelled at shutdown
+            cache_mi->save_stat_log();
+            stats_timer->expires_after(std::chrono::seconds(100));
+            stats_timer->async_wait(*stats_tick);
+        };
+        stats_timer->expires_after(std::chrono::seconds(100));
+        stats_timer->async_wait(*stats_tick);
     }
 
     std::cout << "[run] run-loop up (Ctrl-C to stop); won blocks relay DUAL-PATH:\n"
@@ -3811,6 +3840,11 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                          "unknown error";
         }
     }
+
+    // Save stats on shutdown (main_ltc.cpp:7457 parity): flush the final
+    // stat_log so the last window survives the restart. mi still valid here —
+    // run() has returned but web_server/mining-interface teardown is below.
+    if (web_server) web_server->get_mining_interface()->save_stat_log();
 
     // Stop the ZMQ hashblock subscriber (joins its thread) BEFORE the stratum
     // acceptor + work source it refreshes are torn down. Its callback only posts


### PR DESCRIPTION
## What
Wire main_dash.cpp's three `stat_log` persistence call sites off the main_ltc.cpp reference, so DASH hashrate/DOA history survives node restarts instead of resetting to empty on every bounce (D-WEB.944).

The WebServer stat_log machinery is already in master (`web_server.hpp:1514 set_stat_log_path` / `:1516 save_stat_log` / `:1518 load_stat_log`); this PR is the DASH `main_dash.cpp` glue only — the residual after #944's web contribution proved a no-op.

## Three call sites (parity)
1. **load-on-start** — `set_stat_log_path(config/<net>/graph_db)` + `load_stat_log()` (main_ltc.cpp:1968), after `set_coin_label`, before found-block persistence.
2. **periodic save** — 100s `steady_timer` → `save_stat_log()` (main_ltc.cpp:7429), folded into the existing `if(web_server)` cache-timer scope, reuses `cache_mi`/`ioc`, self-cancels at shutdown.
3. **save-on-shutdown** — `save_stat_log()` after the run loop returns, before web_server teardown (main_ltc.cpp:7457).

## Scope / collision safety
Touches **only** the three call sites in `main_dash.cpp` — no other DASH-tree file. Collision-safe against `dash/ingest-cp-probes` (098dfb4e5, ingest observability), which touches only `header_chain.hpp`/`p2p_client.hpp`.

## Smoke (Linux x86_64)
- `c2pool-dash` builds + links green (main_dash.cpp recompiled).
- `--selftest` OK (X11 PoW + subsidy + masternode KATs conform to oracle).
- run-loop boot: on clean SIGINT shutdown logs `[StatLog] Saved N entries to <data-dir>/dash_testnet/graph_db`; graph_db created on disk — all three call sites execute at runtime.

No self-merge — integrator verifies, operator taps.
