### PR TITLE
docs: add CONTRIBUTING.md + PR template — state the review bar that PR #962 had no way to know

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,60 @@
+<!--
+Please read CONTRIBUTING.md before opening this PR.
+
+c2pool constructs coinbase transactions and decides who gets paid. Review is
+deliberately strict. Delete this comment block and fill in the sections below —
+a PR left with template placeholders will be closed unread.
+-->
+
+## What this changes
+
+<!-- One or two sentences. What was wrong, what does this do about it. -->
+
+Fixes #<!-- issue number — a real one, not a placeholder -->
+
+## Why this approach
+
+<!-- Why here, why this way. If you considered a broader change and chose not
+to, say so. -->
+
+## Checklist
+
+- [ ] **CI is green on this branch.** I opened this PR only after the build and
+      tests passed. (A PR with no checks reported has not been verified to
+      compile.)
+- [ ] **No `SPDX-License-Identifier` line is removed or altered.** This project
+      is AGPL-3.0-or-later with an Apache-2.0 engine split.
+- [ ] I have the right to contribute this code and agree it may be distributed
+      under the project's licence.
+- [ ] **This is the smallest change that fixes the problem.** No unrelated
+      reformatting, no file replaced wholesale, no public signature changed as
+      a side effect.
+- [ ] If I deleted anything, I counted its call sites first and either updated
+      them or confirmed there are none.
+- [ ] Tests included that **fail without this change**.
+
+## Blast radius
+
+<!-- Which coin lanes does this touch? src/core/ is shared by LTC, DOGE, DGB,
+BCH, BTC and DASH — a change there affects all of them. Say "single lane: X" or
+list them. -->
+
+## Consensus safety
+
+<!-- Tick one.
+
+- [ ] Transport / logging / telemetry / tooling only — cannot change share
+      bytes or coinbase outputs.
+- [ ] Touches share serialisation, coinbase construction, or payout weighting.
+      (If so: explain how it is version-gated. A node producing different bytes
+      from its peers has its shares rejected.)
+- [ ] Not sure — please advise.
+
+"Not sure" is a fine answer and asking early is welcome.
+-->
+
+## How this was tested
+
+<!-- What you actually ran, and what it showed. Include the negative cases for
+anything touching address handling, payouts, or P2P message handlers:
+malformed input, wrong network, short buffers, peers lacking support. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,88 @@
+# Contributing to c2pool
+
+Contributions are welcome. c2pool is a mining pool: it constructs coinbase
+transactions and decides who gets paid. A subtle change in the wrong place
+moves other people's money, so the review bar is deliberately high — higher
+than the size of a diff would usually suggest.
+
+Please read this before opening a pull request.
+
+## Hard requirements
+
+A PR will not be reviewed until all of these hold.
+
+1. **CI is green on your branch.** Open the PR only after the build and tests
+   pass. A PR with no checks reported has not been verified to compile, and
+   reviewing uncompiled code wastes everyone's time.
+2. **Licensing is preserved.** This project is `AGPL-3.0-or-later`, with an
+   Apache-2.0 engine (`c2pool-core-engine`) split out. Every source file
+   carries an `SPDX-License-Identifier` line. **Do not remove, alter, or omit
+   it.** A PR that strips a license identifier will be closed.
+3. **You have the right to contribute the code**, and you agree it may be
+   distributed under the project's licence.
+4. **The PR description says what changed and why**, and links the issue it
+   addresses with a real number. Leave no template placeholders.
+
+## Scope discipline
+
+**Change the smallest thing that fixes the problem.**
+
+- Do not reformat, restructure, or rewrite a file you are fixing a function in.
+- Do not replace a file wholesale. If a diff deletes far more than it adds,
+  something has gone wrong.
+- Do not change a public function's signature or return type as a side effect.
+  `src/core/` is shared by every coin lane — LTC, DOGE, DGB, BCH, BTC, DASH —
+  and a signature change there breaks all of them.
+- Before deleting anything, count its call sites. If it is called, it is used.
+
+If a fix genuinely requires broad change, open an issue and discuss the
+approach first.
+
+## Areas with extra scrutiny
+
+Changes here get read line by line, and need tests that demonstrate the
+behaviour rather than assert that it compiles:
+
+- **Address handling** (`src/core/address_utils.*`, `address_validator.*`) —
+  feeds payout script construction. Never weaken checksum validation. Never
+  drop a bounds check before a fixed-width copy.
+- **Coinbase construction and payouts** (`*/coinbase_builder.*`, `pplns.*`,
+  `share_producer.*`) — consensus-visible. Any change to who receives share
+  weight alters share content and must be version-gated, not silently applied.
+- **Sharechain and share serialisation** — a node producing different bytes
+  from its peers is a node whose shares are rejected.
+- **P2P message handlers** — a handler that parses a message and discards the
+  result is worse than one that does not exist, because it looks implemented.
+  Either do the work or log loudly that you did not.
+
+## Consensus safety
+
+Transport, logging, telemetry and tooling changes are low risk. Anything that
+can change the bytes of a share, or the outputs of a coinbase, is not. If you
+are unsure which category your change is in, say so in the PR — that question
+is welcome and asking it early saves a revert later.
+
+## Tests
+
+New behaviour needs a test that would fail without the change. For the
+scrutiny areas above, include the negative cases: malformed input, wrong
+network, short buffers, missing peer support. "It builds" is not evidence.
+
+## Reporting a security issue
+
+Do not open a public issue or PR for a vulnerability that could be used to
+misdirect funds or disrupt a running pool. Contact the maintainers privately
+first.
+
+## What gets closed without detailed review
+
+- PRs with no CI run
+- PRs that remove or alter licence identifiers
+- Whole-file replacements offered as small fixes
+- Machine-generated changes submitted without being built or read, including
+  ones that delete working code they do not appear to have examined
+- PRs whose description still contains unfilled template text
+
+None of this is meant to discourage genuine contributions. Small, focused,
+tested fixes are very welcome, and a first PR that follows the rules above
+will get a careful read.


### PR DESCRIPTION
Docs only. No code touched.

## Why now

PR #962 (closed) was our first external contribution. It aimed at a real bug (#961 — address version byte not validated against the coin network) and the diagnosis was correct. But it:

- replaced `src/core/address_utils.cpp` wholesale, 450 lines → 17, deleting ~128 call sites' worth of functions across every coin lane, including the pluggable decoder registry and the merged-mining script helper
- changed a public signature as a side effect
- removed the `SPDX-License-Identifier: AGPL-3.0-or-later` line with no replacement
- swapped `DecodeBase58Check` for `DecodeBase58`, **silently dropping checksum validation** on the function that feeds payout script construction
- introduced an out-of-bounds read (guard on `size() < 1`, then a 20-byte copy)
- ran no CI

The last point matters most for this PR: **none of our expectations were written down anywhere.** No `CONTRIBUTING.md`, no PR template. A contributor had no way to know the bar, and a reviewer had nothing to point at.

## What this adds

**`CONTRIBUTING.md`** — hard requirements (green CI before review, SPDX preserved, right-to-contribute, no template placeholders), smallest-change discipline, and an explicit list of extra-scrutiny areas: address handling, coinbase/payout construction, share serialisation, P2P handlers. Includes the rule that a handler which parses a message and discards the result is worse than one that does not exist, because it looks implemented. Adds a private disclosure route for fund-misdirection issues.

**`.github/pull_request_template.md`** — asks for blast radius (which lanes; `src/core/` is all six) and a consensus-safety self-classification before the diff is read. Offers "not sure — please advise" as a valid answer, since that question being asked early is much cheaper than a revert.

## Deliberate choices

- The tone is meant to be firm but not hostile. Small, focused, tested fixes are welcomed explicitly, and a first PR that follows the rules is promised a careful read.
- "It builds" is called out as not being evidence. Negative cases are required in the scrutiny areas — malformed input, wrong network, short buffers, peers lacking support.
- Nothing here is enforced mechanically yet. If we want CI-green-before-review actually gated, that is a separate change to branch protection.