### PR TITLE
ltc(compact): merkle backstop on reconstructed blocks + wtxid/txid reconciliation

### DIFF
--- a/src/impl/ltc/coin/compact_blocks.hpp
+++ b/src/impl/ltc/coin/compact_blocks.hpp
@@ -238,9 +238,34 @@ inline CompactBlock BuildCompactBlock(const BlockHeaderType& header,
 /// Result of attempting to reconstruct a full block from a compact block.
 struct CompactBlockReconstructionResult {
     bool complete{false};
+    bool merkle_mismatch{false};  // reconstructed txs failed the header Merkle check -> DISCARD, never deliver
     BlockType block;
     std::vector<uint32_t> missing_indexes;  // absolute tx indexes still needed
 };
+
+/// Compute the SHA256d Merkle root over a block's transaction vector (txid-based).
+/// Mirrors template_builder::compute_merkle_root; kept self-contained here so this
+/// lightweight wire header need not pull the heavy template_builder include chain.
+inline uint256 ComputeTxMerkleRoot(const std::vector<MutableTransaction>& txs) {
+    if (txs.empty()) return uint256::ZERO;
+    std::vector<uint256> hashes;
+    hashes.reserve(txs.size());
+    for (const auto& tx : txs)
+        hashes.push_back(compute_txid(tx));
+    while (hashes.size() > 1) {
+        if (hashes.size() & 1u)
+            hashes.push_back(hashes.back());  // duplicate last for odd count
+        std::vector<uint256> next;
+        next.reserve(hashes.size() / 2);
+        for (size_t i = 0; i < hashes.size(); i += 2) {
+            auto sl = std::span<const uint8_t>(hashes[i].data(),     32);
+            auto sr = std::span<const uint8_t>(hashes[i + 1].data(), 32);
+            next.push_back(Hash(sl, sr));
+        }
+        hashes = std::move(next);
+    }
+    return hashes[0];
+}
 
 /// Attempt to reconstruct a full block from a compact block + known transactions.
 /// @param cb        The received compact block.
@@ -308,6 +333,16 @@ inline CompactBlockReconstructionResult ReconstructBlock(
     }
 
     if (result.missing_indexes.empty()) {
+        // BIP 152: a filled short-ID slot is NOT proof of correctness. Short IDs are
+        // 48-bit SipHash, so a collision can silently substitute the wrong tx. The
+        // header Merkle root is the ONLY backstop (Core tolerates mempool-based
+        // reconstruction only because of it) -- verify BEFORE delivery, and on
+        // mismatch DISCARD so the caller falls back to a full getdata/getblocktxn.
+        if (ComputeTxMerkleRoot(txs) != cb.header.m_merkle_root) {
+            result.complete = false;
+            result.merkle_mismatch = true;
+            return result;
+        }
         result.complete = true;
         static_cast<BlockHeaderType&>(result.block) = cb.header;
         result.block.m_txs = std::move(txs);

--- a/src/impl/ltc/coin/p2p_node.hpp
+++ b/src/impl/ltc/coin/p2p_node.hpp
@@ -828,6 +828,15 @@ private:
             m_peer->get_header(blockhash, header);
             // Fire full block event (carries MWEB data for state extraction)
             m_coin->full_block.happened(result.block);
+        } else if (result.merkle_mismatch) {
+            // Defect 1: every slot filled but the reconstructed txs fail the header
+            // Merkle root -> a short-ID collision substituted a wrong tx. Discard and
+            // pull the authoritative full block; never deliver the mismatched one.
+            LOG_WARNING << "[" << m_chain_label << "] Compact block " << blockhash.GetHex()
+                        << " reconstructed but FAILED header Merkle check — discarding, "
+                        << "requesting full block via getdata";
+            auto getdata_msg = message_getdata::make_raw({inventory_type(inventory_type::block, blockhash)});
+            m_peer->write(getdata_msg);
         } else {
             LOG_INFO << "[" << m_chain_label << "] Compact block incomplete, "
                      << result.missing_indexes.size() << " txs missing — requesting via getblocktxn";
@@ -904,12 +913,21 @@ private:
             }
         }
 
-        // Re-match from mempool (same as cmpctblock handler)
+        // Re-match from mempool (same as cmpctblock handler).
+        // Defect 2: BIP 152 v2 short IDs are keyed by WTXID; the cmpctblock pass and
+        // BuildCompactBlock both use wtxid, so this pass must too. Keying by txid here
+        // would mis-key every segwit tx and ship default-constructed empties once a
+        // mempool is wired. For non-segwit txs wtxid == txid, so this is a strict
+        // superset of the old behaviour.
         std::map<uint256, MutableTransaction> known;
-        for (const auto& [txid, tx] : m_coin->known_txs)
-            known[txid] = MutableTransaction(tx);
+        for (const auto& [txid, tx] : m_coin->known_txs) {
+            MutableTransaction mtx(tx);
+            auto packed = pack(TX_WITH_WITNESS(mtx));
+            uint256 wtxid = Hash(packed.get_span());
+            known[wtxid] = std::move(mtx);
+        }
         if (m_mempool) {
-            auto mp_txs = m_mempool->all_txs_map();
+            auto mp_txs = m_mempool->all_txs_map_wtxid();
             known.merge(mp_txs);
         }
 
@@ -947,6 +965,20 @@ private:
         BlockType block;
         static_cast<BlockHeaderType&>(block) = cb.header;
         block.m_txs = std::move(txs);
+
+        // Defect 1 backstop on the getblocktxn completion path (same invariant as
+        // ReconstructBlock): verify the header Merkle root before delivering. A
+        // collision or a malicious blocktxn response must never reach the UTXO cache.
+        if (ComputeTxMerkleRoot(block.m_txs) != cb.header.m_merkle_root) {
+            LOG_WARNING << "[" << m_chain_label << "] blocktxn-completed block "
+                        << blockhash.GetHex() << " FAILED header Merkle check — discarding, "
+                        << "requesting full block via getdata";
+            auto getdata_msg = message_getdata::make_raw({inventory_type(inventory_type::block, blockhash)});
+            m_peer->write(getdata_msg);
+            m_pending_cmpct.reset();
+            m_pending_missing_indexes.clear();
+            return;
+        }
 
         m_peer->get_block(blockhash, block);
         auto header = static_cast<BlockHeaderType>(block);

--- a/src/impl/ltc/test/CMakeLists.txt
+++ b/src/impl/ltc/test/CMakeLists.txt
@@ -12,7 +12,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     # cannot grant a shared lock to a thread already holding it exclusively — and
     # that without that lock the walk runs and the per-peer send loop is entered.
     # Same folding rule: into the existing allowlisted target.
-    add_executable(share_test share_test.cpp f11_donation_invariance_test.cpp emergency_decay_overflow_test.cpp wirecompat_runtime_test.cpp desired_version_tally_test.cpp auto_ratchet_sim_test.cpp auto_ratchet_tail_guard_test.cpp chain_walk_window_test.cpp doge_template_underfill_test.cpp broadcast_tx_completeness_test.cpp broadcast_lock_discipline_test.cpp)
+    add_executable(share_test share_test.cpp f11_donation_invariance_test.cpp emergency_decay_overflow_test.cpp wirecompat_runtime_test.cpp desired_version_tally_test.cpp auto_ratchet_sim_test.cpp auto_ratchet_tail_guard_test.cpp chain_walk_window_test.cpp doge_template_underfill_test.cpp broadcast_tx_completeness_test.cpp broadcast_lock_discipline_test.cpp compact_block_merkle_test.cpp)
     target_link_libraries(share_test PRIVATE
         GTest::gtest_main GTest::gtest
         core ltc

--- a/src/impl/ltc/test/compact_block_merkle_test.cpp
+++ b/src/impl/ltc/test/compact_block_merkle_test.cpp
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Compact-block reconstruction Merkle backstop (Defect 1) + short-ID id-path
+// agreement (Defect 2) KAT.
+//
+// Defect 1: ReconstructBlock() used to declare a block complete the instant every
+// short-ID slot was filled, never checking the reconstructed tx vector against the
+// header Merkle root. A 48-bit SipHash short-ID collision could substitute the wrong
+// transaction and nothing would catch it before it reached the UTXO cache. The fix
+// computes the Merkle root over the reconstructed txids and DISCARDS on mismatch
+// (signalling a full getdata fallback) instead of delivering.
+//
+// Defect 2: the cmpctblock pass keys known txs by wtxid (BIP 152 v2 short IDs are
+// over wtxid) while the blocktxn pass re-matched by txid. A non-segwit tx has
+// wtxid == txid, so this KAT pins that such a tx reconstructs identically under
+// both id conventions -- the invariant the handler fix relies on.
+//
+// Folded into the allowlisted share_test target (NOT a standalone executable) to
+// avoid the #769 "Not Run" CI trap.
+
+#include <cstdint>
+#include <map>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <impl/ltc/coin/compact_blocks.hpp>
+#include <impl/ltc/coin/transaction.hpp>
+#include <impl/ltc/coin/block.hpp>
+#include <impl/ltc/coin/mempool.hpp>
+#include <core/uint256.hpp>
+#include <core/pack.hpp>
+#include <core/hash.hpp>
+
+using ltc::coin::MutableTransaction;
+using ltc::coin::TxIn;
+using ltc::coin::TxOut;
+using ltc::coin::CompactBlock;
+using ltc::coin::BlockHeaderType;
+using ltc::coin::BuildCompactBlock;
+using ltc::coin::ReconstructBlock;
+using ltc::coin::ComputeTxMerkleRoot;
+using ltc::coin::compute_txid;
+using bitcoin_family::coin::TX_WITH_WITNESS;
+
+namespace {
+
+// A minimal non-segwit transaction (no witness -> wtxid == txid).
+MutableTransaction make_tx(int64_t value, uint32_t index)
+{
+    MutableTransaction tx;
+    tx.version = 1;
+    tx.locktime = 0;
+    TxIn in;
+    in.prevout.hash.SetNull();
+    in.prevout.index = index;
+    in.sequence = 0xffffffff;
+    tx.vin.push_back(in);
+    TxOut out;
+    out.value = value;
+    tx.vout.push_back(out);
+    return tx;
+}
+
+uint256 wtxid_of(const MutableTransaction& tx)
+{
+    MutableTransaction mtx(tx);
+    auto packed = pack(TX_WITH_WITNESS(mtx));
+    return Hash(packed.get_span());
+}
+
+// The non-coinbase txs (index >= 1) keyed by wtxid, as the cmpctblock handler does.
+// The coinbase (index 0) is carried prefilled by BuildCompactBlock.
+std::map<uint256, MutableTransaction> known_by_wtxid(const std::vector<MutableTransaction>& txs)
+{
+    std::map<uint256, MutableTransaction> known;
+    for (size_t i = 1; i < txs.size(); ++i)
+        known[wtxid_of(txs[i])] = txs[i];
+    return known;
+}
+
+std::vector<MutableTransaction> sample_block_txs()
+{
+    std::vector<MutableTransaction> txs;
+    for (int i = 0; i < 4; ++i)
+        txs.push_back(make_tx(5000 + i, static_cast<uint32_t>(i)));
+    return txs;
+}
+
+} // namespace
+
+// Defect 1: correct header Merkle root -> reconstruction completes and delivers.
+TEST(CompactBlockMerkle, ReconstructsWhenMerkleMatches)
+{
+    auto txs = sample_block_txs();
+    BlockHeaderType header;
+    header.SetNull();
+    header.m_merkle_root = ComputeTxMerkleRoot(txs);
+
+    auto cb = BuildCompactBlock(header, txs);
+    auto result = ReconstructBlock(cb, known_by_wtxid(txs));
+
+    ASSERT_TRUE(result.complete);
+    EXPECT_FALSE(result.merkle_mismatch);
+    ASSERT_EQ(result.block.m_txs.size(), txs.size());
+    EXPECT_EQ(ComputeTxMerkleRoot(result.block.m_txs), header.m_merkle_root);
+}
+
+// Defect 1: a header Merkle root that does NOT match the reconstructed txs must
+// DISCARD, not deliver. Simulates a short-ID collision substituting a wrong tx:
+// every slot still fills from known_txs, so only the Merkle check can catch it.
+TEST(CompactBlockMerkle, DiscardsOnMerkleMismatch)
+{
+    auto txs = sample_block_txs();
+    BlockHeaderType header;
+    header.SetNull();
+    header.m_merkle_root = ComputeTxMerkleRoot(txs);
+    header.m_merkle_root.data()[0] ^= 0x01;  // flip one bit -> deliberately wrong root
+
+    auto cb = BuildCompactBlock(header, txs);
+    auto result = ReconstructBlock(cb, known_by_wtxid(txs));
+
+    EXPECT_FALSE(result.complete) << "must NOT deliver a block whose txs fail the header Merkle check";
+    EXPECT_TRUE(result.merkle_mismatch) << "must signal discard + full-block getdata fallback";
+    EXPECT_TRUE(result.block.m_txs.empty());
+}
+
+// Defect 2: a non-segwit tx has wtxid == txid, so the wtxid-keyed cmpctblock pass
+// and a txid-keyed pass compute the SAME short ID. This is the invariant that makes
+// the two handler passes agree once both key on wtxid: reconstruction from a
+// txid-keyed map must still succeed for such a tx.
+TEST(CompactBlockMerkle, NonSegwitTxIdPathsAgree)
+{
+    auto txs = sample_block_txs();
+    for (const auto& tx : txs)
+        EXPECT_EQ(compute_txid(tx), wtxid_of(tx)) << "non-segwit tx must have wtxid == txid";
+
+    BlockHeaderType header;
+    header.SetNull();
+    header.m_merkle_root = ComputeTxMerkleRoot(txs);
+    auto cb = BuildCompactBlock(header, txs);
+
+    std::map<uint256, MutableTransaction> known_by_txid;
+    for (size_t i = 1; i < txs.size(); ++i)
+        known_by_txid[compute_txid(txs[i])] = txs[i];
+
+    auto result = ReconstructBlock(cb, known_by_txid);
+    ASSERT_TRUE(result.complete);
+    EXPECT_FALSE(result.merkle_mismatch);
+}


### PR DESCRIPTION
Lane fix for #976. LTC copy only — per-coin isolation, no cross-coin bundle.

## What was wrong

`src/impl/ltc/coin/compact_blocks.hpp` reconstructed blocks and declared them complete the instant every slot was filled, **never comparing against `header.m_merkle_root`**, then delivered them downstream into the UTXO cache.

BIP 152 short IDs are 48-bit SipHash. A collision silently substitutes the **wrong transaction** into a block we then treat as valid. Core only tolerates mempool-backed reconstruction *because* the merkle check is the backstop.

Companion defect, also fixed: the `cmpctblock` pass matched on **wtxid** while the `blocktxn` pass re-matched on **txid**, so wiring a mempool would have shipped default-constructed empty transactions into the delivered block. Dormant today (`set_mempool` has no call sites) — it armed the moment anyone wired one up.

## Verification

Lane reports KAT + build green on `0da2b568b`. Please confirm the KAT actually exercises the collision path rather than only the happy path — a backstop that is never made to fire is the defect class we have been fighting all week.

## Scope

LTC tree only. The four per-coin copies are independent; BTC is #975, DGB is queued (dormant lane), BCH is skeleton. A diff spanning two coin trees should be refused.