### PR TITLE
ci(dash-bls): ship DASH with real BLS backend linked (non-draft rebase of #890)

### DIFF
--- a/.github/actions/provision-dashbls/action.yml
+++ b/.github/actions/provision-dashbls/action.yml
@@ -1,0 +1,138 @@
+name: Provision dashbls
+description: >
+  Make the dashbls (BLS12-381) backend available to a DASH build, so
+  -DC2POOL_DASH_BLS=ON links the REAL verifier instead of failing to configure.
+
+  Builds dash's own src/dashbls subtree at the pinned release tag via
+  scripts/build_dashbls.sh (the single source of truth for the tag - this action
+  parses DASH_REF out of that script rather than duplicating it) and installs it
+  into a per-host prefix that is reused across runs. The build is heavy
+  (autotools + relic + mimalloc), so it happens ONCE per runner per pinned tag:
+  a prefix whose .dash-ref marker already matches is used as-is. On
+  github-hosted runners (fork PRs, ephemeral) the prefix is additionally
+  restored from the Actions cache.
+
+  Exports DASHBLS_ROOT to $GITHUB_ENV for the subsequent cmake configure, and
+  FAILS the job if the library or headers are not present when it finishes -
+  never leaves a job believing it has BLS when it does not.
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve dashbls prefix + pinned tag
+      shell: bash
+      run: |
+        set -euo pipefail
+        # Fixed prefix (no input): the github-hosted cache path below must be a
+        # literal, and a configurable prefix that silently misses the cache is
+        # worse than none.
+        prefix="$HOME/.c2pool-deps/dashbls"
+        # Single source of truth for the pin: scripts/build_dashbls.sh. Parsing
+        # it here means a re-pin of the tag cannot silently leave CI on the old
+        # library (the prefix marker below is keyed on this value).
+        ref="$(sed -n 's/^DASH_REF="\${DASH_REF:-\(.*\)}"$/\1/p' scripts/build_dashbls.sh)"
+        if [ -z "$ref" ]; then
+          echo "::error::could not parse DASH_REF from scripts/build_dashbls.sh"
+          exit 1
+        fi
+        echo "dashbls prefix=$prefix pinned dash ref=$ref"
+        echo "DASHBLS_PREFIX=$prefix" >> "$GITHUB_ENV"
+        echo "DASHBLS_PIN=$ref" >> "$GITHUB_ENV"
+
+    # Ephemeral github-hosted runners only (fork PRs). Self-hosted runners keep
+    # the prefix on disk, which is both faster and immune to the cache-service
+    # restore timeouts seen on the VM905 pool.
+    - name: Restore dashbls cache (github-hosted only)
+      if: runner.environment == 'github-hosted'
+      uses: actions/cache@v5
+      with:
+        path: ~/.c2pool-deps/dashbls
+        key: dashbls-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('scripts/build_dashbls.sh') }}
+
+    - name: Install dashbls build dependencies
+      shell: bash
+      run: |
+        set -uo pipefail
+        # relic needs gmp, and the vendored subtree only supports the autotools
+        # path (see the note in scripts/build_dashbls.sh). libgmp-dev is also a
+        # LINK-time requirement of the c2pool find (find_library(gmp)), so it is
+        # ensured even when the prefix is already warm.
+        #
+        # flock: several coin cells run concurrently on the one self-hosted host
+        # and race on the apt lock (the same guard release.yml uses for its own
+        # apt step).
+        #
+        # Non-fatal on purpose: a transient apt hiccup on a host that ALREADY
+        # has these packages must not red the job. What is actually required is
+        # verified right after, and a genuinely missing gmp fails there.
+        exec {lockfd}>/tmp/c2pool-apt.lock
+        flock "$lockfd"
+        sudo apt-get update -qq || true
+        sudo apt-get install -y --no-install-recommends \
+          autoconf automake libtool libgmp-dev || true
+
+    - name: Assert libgmp development files are present
+      shell: bash
+      run: |
+        set -euo pipefail
+        # find_library(DASHBLS_GMP_LIB NAMES gmp) in the root CMakeLists needs
+        # the libgmp.so DEVELOPMENT symlink, not just the versioned runtime
+        # object -- i.e. libgmp-dev. Checked explicitly so a host missing it
+        # says so here instead of surfacing as a confusing "dashbls not found".
+        entries="$(ldconfig -p || true)"
+        case "$entries" in
+          *"libgmp.so ("*) echo "  ok   libgmp runtime present" ;;
+          *) echo "::error::libgmp is not installed on this runner (need libgmp-dev)"; exit 1 ;;
+        esac
+        found=""
+        for d in /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu /usr/lib /usr/local/lib; do
+          if [ -e "$d/libgmp.so" ]; then found="$d/libgmp.so"; break; fi
+        done
+        if [ -z "$found" ]; then
+          echo "::error::libgmp.so development symlink not found (install libgmp-dev on this runner)"
+          exit 1
+        fi
+        echo "  ok   $found"
+
+    - name: Build dashbls if the prefix is cold or pinned to another tag
+      shell: bash
+      run: |
+        set -euo pipefail
+        marker="$DASHBLS_PREFIX/.dash-ref"
+        if [ -f "$DASHBLS_PREFIX/lib/libdashbls.a" ] \
+           && [ -f "$DASHBLS_PREFIX/include/dashbls/bls.hpp" ] \
+           && [ "$(cat "$marker" 2>/dev/null || true)" = "$DASHBLS_PIN" ]; then
+          echo "dashbls $DASHBLS_PIN already installed at $DASHBLS_PREFIX - reusing"
+          exit 0
+        fi
+        echo "building dashbls $DASHBLS_PIN into $DASHBLS_PREFIX (one-time per runner)"
+        # Belt-and-braces before an rm -rf: the prefix must be the resolved
+        # per-user dependency dir, never $HOME or /.
+        case "$DASHBLS_PREFIX" in
+          "$HOME"/.c2pool-deps/*) ;;
+          *) echo "::error::refusing to remove unexpected prefix $DASHBLS_PREFIX"; exit 1 ;;
+        esac
+        rm -rf "$DASHBLS_PREFIX"
+        bash scripts/build_dashbls.sh "$DASHBLS_PREFIX"
+        printf '%s\n' "$DASHBLS_PIN" > "$marker"
+
+    # The whole point of the action: a job must never continue believing it has
+    # a BLS backend when the provisioning silently did nothing.
+    - name: Assert dashbls is present
+      shell: bash
+      run: |
+        set -euo pipefail
+        fail=0
+        for f in "$DASHBLS_PREFIX/lib/libdashbls.a" "$DASHBLS_PREFIX/include/dashbls/bls.hpp"; do
+          if [ -f "$f" ]; then
+            echo "  ok   $f"
+          else
+            echo "  MISS $f"
+            fail=1
+          fi
+        done
+        if [ "$fail" -ne 0 ]; then
+          echo "::error::dashbls provisioning did not produce a usable prefix at $DASHBLS_PREFIX"
+          exit 1
+        fi
+        echo "DASHBLS_ROOT=$DASHBLS_PREFIX" >> "$GITHUB_ENV"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1319,5 +1319,164 @@ jobs:
         if: always()
         uses: ./.github/actions/prune-runner-workspace
 
+  # ════════════════════════════════════════════════════════════════════════════
+  # DASH with the REAL BLS backend linked (C2POOL_DASH_BLS=ON)
+  #
+  # Every other lane builds DASH with the option OFF, where dash_bls_verify is a
+  # fail-closed stub: correct, but it can never serve a real type-6 quorum
+  # commitment. This job is the one that compiles + exercises the actual
+  # BLS12-381 path, and it is the CI mirror of what the release DASH package now
+  # ships.
+  #
+  # NON-HOLLOW BY CONSTRUCTION — three independent legs, because "the flag was
+  # passed" is not evidence:
+  #   1. cmake FATAL_ERRORs if dashbls is missing (root CMakeLists), so this job
+  #      cannot go green on a silently degraded configure;
+  #   2. scripts/ci/dash_bls_linked_guard.sh inspects the produced c2pool-dash
+  #      binary for dashbls rodata + symbols;
+  #   3. the six BLS-crypto KATs are named EXPLICITLY below and each must
+  #      REPORT AS RUN — they live behind #ifdef C2POOL_DASH_BLS, so a stub
+  #      build makes them vanish rather than fail, which is exactly the
+  #      "silently Not Run" shape that has bitten this repo before.
+  #
+  # DASH-ONLY: nothing here touches the shared core the Windows/LTC launcher
+  # builds; no other job's flags change.
+  # ════════════════════════════════════════════════════════════════════════════
+  linux-dash-bls:
+    name: DASH + real BLS (Linux x86_64)
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set per-job Conan home
+        run: |
+          if [ "${{ runner.environment }}" = "github-hosted" ]; then
+            echo "CONAN_HOME=$RUNNER_TEMP/conan2" >> "$GITHUB_ENV"
+          else
+            echo "CONAN_HOME=$HOME/.conan2-ci/$RUNNER_NAME" >> "$GITHUB_ENV"
+          fi
+
+      - name: Install system dependencies
+        if: runner.environment == 'github-hosted'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            g++ ccache cmake make libleveldb-dev libsecp256k1-dev
+
+      - uses: actions/setup-python@v6
+        if: ${{ runner.environment == 'github-hosted' }}
+        with: { python-version: '3.12' }
+
+      - name: Install Conan 2
+        run: |
+          if [ "${{ runner.environment }}" = "github-hosted" ]; then
+            pip install "conan>=2.0,<3.0"
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          else
+            conan --version   # pre-provisioned at /usr/local/bin on self-hosted
+          fi
+
+      - name: Restore Conan cache (github-hosted only)
+        if: runner.environment == 'github-hosted'
+        uses: actions/cache@v5
+        with:
+          path: ${{ runner.temp }}/conan2
+          key: conan2-ubuntu24-gcc13-${{ hashFiles('conanfile.txt', 'ci/conan/linux-gcc13.profile') }}
+
+      - name: Clean stale build dir (self-hosted workspace is reused)
+        if: runner.environment != 'github-hosted'
+        run: rm -rf build_dash_bls
+
+      - name: Conan install
+        run: |
+          for attempt in 1 2 3; do
+            if conan install . -pr:a=ci/conan/linux-gcc13.profile --build=missing --output-folder=build_dash_bls; then exit 0; fi
+            echo "conan install failed (attempt $attempt/3); retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
+          echo "conan install failed after 3 attempts" >&2
+          exit 1
+
+      # Builds dash's own src/dashbls subtree at the pinned tag once per runner
+      # and exports DASHBLS_ROOT. Fails loudly if it cannot produce the prefix.
+      - name: Provision dashbls
+        uses: ./.github/actions/provision-dashbls
+
+      # LEG 1: a missing dashbls is a configure-time FATAL_ERROR, not a warning.
+      - name: Configure (C2POOL_DASH_BLS=ON)
+        run: |
+          cmake -S . -B build_dash_bls \
+            -DCMAKE_TOOLCHAIN_FILE=build_dash_bls/conan_toolchain.cmake \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DC2POOL_DASH_BLS=ON -DDASHBLS_ROOT="$DASHBLS_ROOT"
+
+      - name: Build c2pool-dash + BLS KATs
+        run: |
+          cmake --build build_dash_bls \
+            --target c2pool-dash \
+                     test_dash_bls_verify test_dash_quorum_members \
+                     test_dash_quorum_member_source \
+            -j8
+
+      # LEG 2: the artefact itself carries the dashbls backend.
+      - name: BLS link guard (binary carries dashbls)
+        run: bash scripts/ci/dash_bls_linked_guard.sh build_dash_bls/src/c2pool/c2pool-dash
+
+      - name: Run BLS KATs
+        working-directory: build_dash_bls
+        run: ctest --output-on-failure -j8 -R 'DashBlsVerify|DashQuorumMembers|DashQuorumMemberSource'
+
+      # LEG 3: the BLS-ONLY cases actually ran. Each of these is inside
+      # #ifdef C2POOL_DASH_BLS, so on a stub build they do not fail -- they
+      # cease to exist, and a bare ctest invocation reports green over an empty
+      # set. Requiring each name to appear as a PASSED line closes that.
+      - name: Assert the BLS-only KATs reported as run
+        working-directory: build_dash_bls
+        run: |
+          ./test/test_dash_bls_verify     > bls_kat.log 2>&1
+          ./test/test_dash_quorum_members >> bls_kat.log 2>&1
+          log="$(cat bls_kat.log)"
+          missing=0
+          for t in \
+            DashBlsVerify.RealQuorumSigAcceptsAndTamperRejects \
+            DashBlsVerify.BlsSmokeSignVerify \
+            DashBlsVerify.VerifyFinalCommitmentSyntheticRoundTrip \
+            DashQuorumMembers.RealCommitmentVerifiesWithComputedMembers \
+            DashQuorumMembers.RealPlatformCommitmentVerifiesWithEvoOnlyMembers \
+            DashQuorumMembers.PartialSignersAndValidMembers
+          do
+            # Pure-shell match, not `grep -q` in a pipeline: under pipefail a
+            # `grep -q` that matches SIGPIPEs its producer and the pipeline
+            # reports failure ON SUCCESS. That exact bug turned an earlier draft
+            # of this guard into a false-negative machine.
+            case "$log" in
+              *"OK ] $t"*) echo "  ok   $t" ;;
+              *) echo "  MISS $t did not report as run"; missing=1 ;;
+            esac
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo "::error::BLS-only KATs did not run -- the build is BLS-dark despite C2POOL_DASH_BLS=ON"
+            exit 1
+          fi
+
+      - name: Upload build artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: linux-dash-bls-fail
+          path: |
+            build_dash_bls/CMakeFiles/CMakeOutput.log
+            build_dash_bls/CMakeFiles/CMakeError.log
+            build_dash_bls/bls_kat.log
+          retention-days: 7
+          if-no-files-found: ignore
+
+      # Steady-state disk hygiene on the VM905 self-hosted runners: drop the
+      # checkout payload and _temp, keep _actions/_tool/_update. Always runs.
+      - name: Prune runner workspace
+        if: always()
+        uses: ./.github/actions/prune-runner-workspace
+
   # Releases are built and published manually (not via CI).
   # See installer/ for packaging scripts (DMG, ZIP, Inno Setup).

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1434,8 +1434,11 @@ jobs:
       - name: Assert the BLS-only KATs reported as run
         working-directory: build_dash_bls
         run: |
-          ./test/test_dash_bls_verify     > bls_kat.log 2>&1
-          ./test/test_dash_quorum_members >> bls_kat.log 2>&1
+          # `|| true`: pass/fail is already gated by the ctest step above. Here
+          # the only question is which cases EXIST, so a non-zero exit must not
+          # abort before the per-case report below is printed.
+          ./test/test_dash_bls_verify     > bls_kat.log 2>&1 || true
+          ./test/test_dash_quorum_members >> bls_kat.log 2>&1 || true
           log="$(cat bls_kat.log)"
           missing=0
           for t in \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,16 +142,38 @@ jobs:
             --build=missing \
             --output-folder=build_${{ matrix.coin }}
 
+      # DASH cell only: build/reuse the pinned dashbls prefix and export
+      # DASHBLS_ROOT, so the configure below links the REAL BLS12-381 verifier.
+      # Without this the packaged c2pool-dash carries the fail-closed stub and
+      # can never serve a real type-6 quorum commitment in the field.
+      - name: Provision dashbls (DASH only)
+        if: steps.presence.outputs.exists == '1' && matrix.coin == 'dash'
+        uses: ./.github/actions/provision-dashbls
+
       - name: Configure
         if: steps.presence.outputs.exists == '1'
         run: |
+          # Per-coin extra flags. A case, not `[ ... ] && VAR=`, because the
+          # step runs under `bash -e` and a false test on the last line would
+          # fail the step.
+          #
           # DGB ships the -DAUX_DOGE=ON build: DGB parent + embedded DOGE aux as ONE
-          # binary, the direct parallel to c2pool-ltc carrying DOGE. Gated to the dgb
-          # cell; inert for the other coins. Merged-mining path per #603/#614/#589/#395.
+          # binary, the direct parallel to c2pool-ltc carrying DOGE. Merged-mining
+          # path per #603/#614/#589/#395.
+          #
+          # DASH ships -DC2POOL_DASH_BLS=ON: the E1 Phase-L quorum-commitment
+          # verifier linked against dash's own dashbls at the pinned tag. The
+          # option is a HARD requirement -- cmake FATAL_ERRORs when the library
+          # is missing -- so this cell cannot quietly package a BLS-dark binary.
+          EXTRA=""
+          case "${{ matrix.coin }}" in
+            dgb)  EXTRA="-DAUX_DOGE=ON" ;;
+            dash) EXTRA="-DC2POOL_DASH_BLS=ON -DDASHBLS_ROOT=$DASHBLS_ROOT" ;;
+          esac
           cmake -S . -B build_${{ matrix.coin }} \
             -DCMAKE_TOOLCHAIN_FILE=build_${{ matrix.coin }}/conan_toolchain.cmake \
             -DCMAKE_BUILD_TYPE=Release \
-            ${{ matrix.coin == 'dgb' && '-DAUX_DOGE=ON' || '' }}
+            $EXTRA
 
       # Boost header-integrity + version gate: a torn/mixed Boost tree or an
       # apt-Boost fallback fails HERE (fast, one TU), not deep in the coin
@@ -172,6 +194,12 @@ jobs:
           BIN=build_${{ matrix.coin }}/src/c2pool/c2pool-${{ matrix.coin }}
           file "$BIN"
           "$BIN" --help 2>&1 | head -5 || true
+
+      # Positive assertion on the ARTEFACT, not on the flags: the freshly built
+      # (unstripped) c2pool-dash must actually carry the dashbls backend.
+      - name: BLS link guard (pre-strip)
+        if: steps.presence.outputs.exists == '1' && matrix.coin == 'dash'
+        run: bash scripts/ci/dash_bls_linked_guard.sh build_dash/src/c2pool/c2pool-dash
 
       - name: Package
         if: steps.presence.outputs.exists == '1'
@@ -202,6 +230,26 @@ jobs:
           cp -r web-static/* "${PKG}/web-static/"
           cp explorer/explorer.py "${PKG}/explorer/"
           tar czf "${PKG}.tar.gz" "${PKG}/"
+
+      # ...and again on the STRIPPED binary that is actually inside the tarball
+      # users download. The rodata leg of the guard survives strip, so this is a
+      # true end-of-pipeline check rather than a restatement of the one above:
+      # it would catch a packaging step that copied the wrong build tree.
+      - name: BLS link guard (packaged artefact)
+        if: steps.presence.outputs.exists == '1' && matrix.coin == 'dash'
+        run: |
+          PKG="c2pool-dash-${{ steps.ver.outputs.version }}-linux-x86_64"
+          bash scripts/ci/dash_bls_linked_guard.sh "${PKG}/c2pool-dash"
+          # libdashbls.a is static, but relic's ARITH backend is gmp, which
+          # resolves to the SHARED libgmp.so.10 -- a runtime dependency the
+          # BLS-off build did not have. The generic ldd bundling loop above
+          # picks it up; assert it, in the same shape as the libsecp256k1
+          # tripwire, so a dash tarball can never ship DOA on a host without
+          # libgmp.
+          case "$(ls "${PKG}/lib/")" in
+            *libgmp.so*) echo "  ok   libgmp bundled" ;;
+            *) echo "PKG-ASSERT FAIL: libgmp not bundled in ${PKG}/lib (BLS build needs it)"; exit 1 ;;
+          esac
 
       - name: Upload package
         if: steps.presence.outputs.exists == '1'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,9 +117,10 @@ endif()
 # (dash_bls_verify) + its KAT consume it, never the shared core the Windows
 # main_ltc launcher builds ([[reference_windows_ci_conan_flake]]: Windows CI
 # builds only the LTC launcher, so DASH-only BLS code cannot break it). When the
-# option is OFF (default) or the library is not found, dash_bls_verify compiles a
-# fail-closed stub and the DKG-window serve path keeps the pre-Phase-L
-# null-commitment posture exactly — no dashbls dependency enters any build.
+# option is OFF (the default), dash_bls_verify compiles a fail-closed stub and
+# the DKG-window serve path keeps the pre-Phase-L null-commitment posture
+# exactly — no dashbls dependency enters any build. Turning the option ON and
+# NOT finding the library is an error, not a fallback (see below).
 #
 # Build the library once for the CI factory with scripts/build_dashbls.sh (builds
 # dash's OWN src/dashbls subtree at the v23.1.7 tag — byte-identical to dashd);

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,17 @@ endif()
 # Build the library once for the CI factory with scripts/build_dashbls.sh (builds
 # dash's OWN src/dashbls subtree at the v23.1.7 tag — byte-identical to dashd);
 # point cmake at it with -DDASHBLS_ROOT=<prefix>.
+#
+# ASKING FOR BLS IS A HARD REQUIREMENT. -DC2POOL_DASH_BLS=ON with the library
+# missing used to WARN and fall back to the stub, so the build stayed green and
+# shipped a BLS-dark binary that is indistinguishable from a real-BLS one until
+# it silently null-serves a DKG-window height in production. That failure mode is
+# now a configure-time FATAL_ERROR: OFF (the default) is the supported way to
+# build without BLS, and ON means the caller has asserted the backend must be
+# linked. Set -DC2POOL_DASH_BLS_OPTIONAL=ON to restore the old warn-and-degrade
+# behaviour for a local probe build (never in CI or release).
 option(C2POOL_DASH_BLS "Link dashbls (BLS12-381) for E1 Phase-L real quorum-commitment verify" OFF)
+option(C2POOL_DASH_BLS_OPTIONAL "Downgrade a missing dashbls under C2POOL_DASH_BLS=ON from FATAL_ERROR to a warning (local probe builds only)" OFF)
 set(C2POOL_DASH_BLS_AVAILABLE OFF)
 if(C2POOL_DASH_BLS)
     # Honour a DASHBLS_ROOT hint (the build-factory install prefix), else search
@@ -156,9 +166,22 @@ if(C2POOL_DASH_BLS)
         message(STATUS "dashbls found (E1 Phase-L BLS verify ENABLED): ${DASHBLS_LIB}")
         message(STATUS "dashbls includes: ${DASHBLS_INCLUDE_DIR}")
     else()
-        message(WARNING "C2POOL_DASH_BLS=ON but dashbls not found "
-            "(need dashbls + relic + gmp; run scripts/build_dashbls.sh and pass "
-            "-DDASHBLS_ROOT=<prefix>). Falling back to fail-closed null-serve.")
+        set(_dashbls_miss
+            "C2POOL_DASH_BLS=ON but the dashbls backend was NOT found, so "
+            "dash_bls_verify would compile the fail-closed stub and the binary "
+            "would ship BLS-dark while the build stayed green.\n"
+            "  dashbls/bls.hpp : ${DASHBLS_INCLUDE_DIR}\n"
+            "  libdashbls      : ${DASHBLS_LIB}\n"
+            "  libgmp          : ${DASHBLS_GMP_LIB}\n"
+            "Build the library with scripts/build_dashbls.sh <prefix> (needs "
+            "autoconf/automake/libtool/libgmp-dev) and re-configure with "
+            "-DDASHBLS_ROOT=<prefix>, or build with C2POOL_DASH_BLS=OFF (the "
+            "default) to keep the documented null-serve posture.")
+        if(C2POOL_DASH_BLS_OPTIONAL)
+            message(WARNING ${_dashbls_miss})
+        else()
+            message(FATAL_ERROR ${_dashbls_miss})
+        endif()
     endif()
 endif()
 

--- a/scripts/ci/dash_bls_linked_guard.sh
+++ b/scripts/ci/dash_bls_linked_guard.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# POSITIVE assertion that a c2pool-dash binary really links the dashbls
+# (BLS12-381) backend — i.e. that E1 Phase-L can verify a real type-6 quorum
+# commitment instead of compiling the fail-closed stub.
+#
+# WHY THIS EXISTS. Passing -DC2POOL_DASH_BLS=ON is NOT evidence. Before this
+# guard, a configure that could not find the library only WARNED: the option
+# stayed on, dash_bls_verify compiled the stub, the build went green, and the
+# packaged binary was BLS-dark — indistinguishable from a working one until it
+# silently null-served a DKG-window height in production. The root CMakeLists
+# now FATAL_ERRORs on that path; this script is the independent second check,
+# applied to the ARTEFACT rather than to the build flags, so a future refactor
+# that reintroduces a soft fallback still cannot ship a dark binary quietly.
+#
+#   usage: scripts/ci/dash_bls_linked_guard.sh <path-to-c2pool-dash>
+#
+# Two independent markers, BOTH required:
+#
+#   1. rodata: the BLS12-381 ciphersuite ID that dashbls' BasicSchemeMPL signs
+#      under (verify_final_commitment uses BasicSchemeMPL). It is a string
+#      constant, so it SURVIVES `strip` — this check works on the packaged,
+#      stripped release artefact, which is the binary users actually run.
+#   2. symbols: the dashbls C++ API entry points bls_verify.cpp calls. Only
+#      checked when the binary still has a symbol table (pre-strip); skipped
+#      with a note, never silently, on a stripped binary.
+set -euo pipefail
+
+BIN="${1:-}"
+if [ -z "$BIN" ] || [ ! -f "$BIN" ]; then
+    echo "dash_bls_linked_guard: usage: $0 <path-to-c2pool-dash>" >&2
+    exit 2
+fi
+
+# BasicSchemeMPL::CIPHERSUITE_ID in dashbls (schemes.cpp). The "NUL_" variant is
+# the basic scheme; AUG_/POP_ belong to the other two schemes and travel with
+# the same object, so any of them proves the real library is in the image.
+CIPHERSUITE_RE='BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_(NUL|AUG|POP)_'
+
+fail=0
+
+echo "dash_bls_linked_guard: target = $BIN"
+
+# NOTE ON SHELL SHAPE: every match below is captured into a variable and tested
+# with a pure-shell `case`, deliberately NOT with `grep -q` in a pipeline. Under
+# `set -o pipefail`, `grep -q` exits at the FIRST match and SIGPIPEs the
+# producer, so the pipeline's status is non-zero *because the match succeeded* —
+# a guard written that way reports every real-BLS binary as dark. That bug was
+# caught by running this script against a known-good BLS-linked c2pool-dash; the
+# lesson is the same one that motivates the guard itself, so it stays written
+# down here.
+hits="$(strings -a "$BIN" | grep -E "$CIPHERSUITE_RE" || true)"
+if [ -n "$hits" ]; then
+    echo "  ok   dashbls BLS12-381 ciphersuite ID present in rodata"
+else
+    echo "  FAIL no BLS12-381 ciphersuite ID in $BIN — this binary is BLS-DARK"
+    fail=1
+fi
+
+# Symbol leg. `nm` reports "no symbols" on a stripped binary; that is a SKIP,
+# never a pass and never a failure — the rodata leg above still covers it.
+syms="$(nm -C --defined-only "$BIN" 2>/dev/null || true)"
+if [ -z "$syms" ]; then
+    echo "  skip symbol check (binary is stripped — rodata leg above still applies)"
+else
+    for want in 'bls::G1Element::FromBytes' 'bls::G2Element::FromBytes'; do
+        case "$syms" in
+            *"$want"*) echo "  ok   symbol $want" ;;
+            *)         echo "  FAIL symbol $want absent — dash_bls_verify compiled the stub"
+                       fail=1 ;;
+        esac
+    done
+fi
+
+if [ "$fail" -ne 0 ]; then
+    echo "::error::$BIN does NOT link the dashbls backend. Configure with" \
+         "-DC2POOL_DASH_BLS=ON -DDASHBLS_ROOT=<prefix> after building the" \
+         "library via scripts/build_dashbls.sh."
+    exit 1
+fi
+
+echo "dash_bls_linked_guard: PASS — real BLS verification is linked in"


### PR DESCRIPTION
Rebases the real-BLS content from #890 (draft branch ci/dash-bls-enable) onto current master via a fresh, non-destructive ci-steward/ branch — no force-push of the peer draft.

Carries 3 commits, GPG-signed:
- ci: build and ship DASH with the real BLS backend linked
- ci(dash-bls): correct the option comment that still described a soft fallback
- ci(dash-bls): let the KAT presence report print even if a case fails

Master already carries the .github-preserving prune fix (#916), so this rebase inherits it — the step33 Post-Provision dashbls action.yml is no longer pruned away. No new prune code needed.

Supersedes the merge path of #890 (left open, not closed). Cross-link: #890.