### PR TITLE
ci(attribution-gate): bound checkout to PR commit range, not whole-repo unshallow

### DIFF
--- a/.github/workflows/attribution-gate.yml
+++ b/.github/workflows/attribution-gate.yml
@@ -31,9 +31,14 @@ jobs:
           # Attribution scan only reads BASE_SHA..HEAD_SHA. A whole-repo
           # unshallow (fetch-depth: 0) is the single most fragile checkout we
           # run and reds clean PRs when a runner link drops packets. Bound the
-          # fetch to the PR own commits + merge base; the scan step keeps its
-          # git log -50 HEAD fallback if the range is unreachable.
-          fetch-depth: ${{ github.event.pull_request.commits && github.event.pull_request.commits + 1 || 50 }}
+          # fetch to the PR own commits. GitHub Actions expressions have NO
+          # arithmetic operators (commits + 1 is a compile-time startup
+          # failure), so we deepen by one commit below to reach the merge base;
+          # the scan step keeps its git log -50 HEAD fallback if unreachable.
+          fetch-depth: ${{ github.event.pull_request.commits || 50 }}
+
+      - name: Deepen one commit to reach the PR merge base
+        run: git fetch --deepen=1 || true
 
       - name: Scan commits + PR metadata for AI attribution
         env:

--- a/.github/workflows/attribution-gate.yml
+++ b/.github/workflows/attribution-gate.yml
@@ -25,10 +25,15 @@ jobs:
     name: attribution-gate
     runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-latest' }}
     steps:
-      - name: Checkout full history
+      - name: Checkout PR commit range (bounded fetch)
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          # Attribution scan only reads BASE_SHA..HEAD_SHA. A whole-repo
+          # unshallow (fetch-depth: 0) is the single most fragile checkout we
+          # run and reds clean PRs when a runner link drops packets. Bound the
+          # fetch to the PR own commits + merge base; the scan step keeps its
+          # git log -50 HEAD fallback if the range is unreachable.
+          fetch-depth: ${{ github.event.pull_request.commits && github.event.pull_request.commits + 1 || 50 }}
 
       - name: Scan commits + PR metadata for AI attribution
         env:


### PR DESCRIPTION
attribution-gate ran actions/checkout with fetch-depth: 0 (full-repo unshallow) purely to scan BASE_SHA..HEAD_SHA commit messages. That makes it the most fragile checkout in CI: on VM905, which currently has ~10% packet loss to github.com Azure edge (20.205.243.166, 145ms RTT), the unshallow stalls mid-transfer and dies with curl 56/28/92, redding PRs that have no attribution problem (seen twice on #978-family LTC compact-merkle re-runs).

Change: fetch-depth bounded to github.event.pull_request.commits + 1 (PR commits + merge base). The scan step keeps its existing git log -50 HEAD fallback. Cuts the transfer from whole-repo to a handful of objects, so a lossy link can no longer red a clean PR.

Does NOT fix the underlying VM905 -> github packet loss (network/peering, operator scope) — this only removes attribution-gate as a victim of it. Not self-merging: required-check workflow, integrator gate.