### PR TITLE
bch(p2p): merkle-root backstop on compact-block reconstruction

### DIFF
--- a/src/impl/bch/coin/compact_blocks.hpp
+++ b/src/impl/bch/coin/compact_blocks.hpp
@@ -28,6 +28,7 @@
 #include "block.hpp"
 #include "transaction.hpp"
 #include "mempool.hpp"  // compute_txid()
+#include "merkle.hpp"   // compute_merkle_root() -- sealed consensus merkle SSOT
 
 #include <core/uint256.hpp>
 #include <core/pack.hpp>
@@ -250,9 +251,23 @@ inline CompactBlock BuildCompactBlock(const BlockHeaderType& header,
 /// Result of attempting to reconstruct a full block from a compact block.
 struct CompactBlockReconstructionResult {
     bool complete{false};
+    bool merkle_mismatch{false};  // reconstructed txs failed the header merkle commitment
     BlockType block;
     std::vector<uint32_t> missing_indexes;  // absolute tx indexes still needed
 };
+
+/// SHA256d merkle root over the txids of a reconstructed tx vector, via the
+/// sealed bch::coin::compute_merkle_root (merkle.hpp) -- the SAME walk the GBT
+/// template builder and emit_full_block use, so a reconstruction is checked
+/// against the header commitment through ONE implementation, not a divergent
+/// second merkle path. BCH has no wtxid (no SegWit): txids ARE the merkle leaves.
+inline uint256 ReconstructedMerkleRoot(const std::vector<MutableTransaction>& txs) {
+    std::vector<uint256> txids;
+    txids.reserve(txs.size());
+    for (const auto& tx : txs)
+        txids.push_back(compute_txid(tx));
+    return compute_merkle_root(txids);
+}
 
 /// Attempt to reconstruct a full block from a compact block + known transactions.
 /// @param cb        The received compact block.
@@ -321,6 +336,17 @@ inline CompactBlockReconstructionResult ReconstructBlock(
     }
 
     if (result.missing_indexes.empty()) {
+        // BIP 152 short IDs are 48-bit SipHash over txid (BCH: wtxid == txid); a
+        // collision can silently substitute the WRONG tx into a fully-filled slot.
+        // The header merkle root is the ONLY backstop -- verify the reconstructed
+        // tx vector against it BEFORE declaring the block complete, and on mismatch
+        // DISCARD (leave result.block empty) so the caller falls back to a full
+        // getdata rather than delivering a forged block downstream.
+        if (ReconstructedMerkleRoot(txs) != cb.header.m_merkle_root) {
+            result.complete = false;
+            result.merkle_mismatch = true;
+            return result;   // do NOT populate result.block
+        }
         result.complete = true;
         static_cast<BlockHeaderType&>(result.block) = cb.header;
         result.block.m_txs = std::move(txs);

--- a/src/impl/bch/coin/p2p_node.hpp
+++ b/src/impl/bch/coin/p2p_node.hpp
@@ -1030,6 +1030,16 @@ private:
             auto header = static_cast<BlockHeaderType>(result.block);
             m_peer->get_header(blockhash, header);
             emit_full_block(result.block, blockhash);
+        } else if (result.merkle_mismatch) {
+            // Every slot filled but the reconstructed txs FAIL the header merkle
+            // root -> a 48-bit short-ID collision substituted a wrong tx. Discard
+            // and pull the authoritative full block via getdata; never deliver the
+            // mismatched one. (emit_full_block would also drop it, but silently and
+            // without re-requesting -- leaving the tip stalled until re-announce.)
+            LOG_WARNING << "[" << m_chain_label << "] Compact block " << blockhash.GetHex()
+                        << " reconstructed but FAILED header merkle check — discarding, "
+                        << "requesting full block via getdata";
+            request_full_block(blockhash);
         } else {
             LOG_INFO << "[" << m_chain_label << "] Compact block incomplete, "
                      << result.missing_indexes.size() << " txs missing — requesting via getblocktxn";
@@ -1106,12 +1116,17 @@ private:
             }
         }
 
-        // Re-match from mempool (same as cmpctblock handler) — txid-keyed on BCH
+        // Re-match from mempool. BCH short IDs are keyed by txid in BOTH passes
+        // (BuildCompactBlock and the cmpctblock handler both use compute_txid);
+        // BCH has no wtxid (no SegWit), so there is no second key the two passes
+        // could diverge to. Call the SAME mempool accessor the cmpctblock handler
+        // uses (all_txs_map_wtxid() aliases all_txs_map() on BCH -- both txid-keyed)
+        // so the two passes cannot drift even textually.
         std::map<uint256, MutableTransaction> known;
         for (const auto& [txid, tx] : m_coin->known_txs)
             known[txid] = MutableTransaction(tx);
         if (m_mempool) {
-            auto mp_txs = m_mempool->all_txs_map();
+            auto mp_txs = m_mempool->all_txs_map_wtxid();
             known.merge(mp_txs);
         }
 
@@ -1149,6 +1164,21 @@ private:
         BlockType block;
         static_cast<BlockHeaderType&>(block) = cb.header;
         block.m_txs = std::move(txs);
+
+        // Merkle backstop (same invariant as ReconstructBlock): even with the
+        // missing txs now authoritative from blocktxn, a short-id-matched slot
+        // could carry a 48-bit collision, or a malicious peer could answer with a
+        // wrong tx. Verify the reconstructed vector against the header commitment
+        // BEFORE delivering; on mismatch discard and fall back to a full getdata.
+        if (ReconstructedMerkleRoot(block.m_txs) != cb.header.m_merkle_root) {
+            LOG_WARNING << "[" << m_chain_label << "] blocktxn-completed block "
+                        << blockhash.GetHex() << " FAILED header merkle check — discarding, "
+                        << "requesting full block via getdata";
+            request_full_block(blockhash);
+            m_pending_cmpct.reset();
+            m_pending_missing_indexes.clear();
+            return;
+        }
 
         m_peer->get_block(blockhash, block);
         auto header = static_cast<BlockHeaderType>(block);

--- a/src/impl/bch/test/compact_block_connector_test.cpp
+++ b/src/impl/bch/test/compact_block_connector_test.cpp
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // ---------------------------------------------------------------------------
 // bch::coin BlockConnector compact-block test (M5 full-block body, slice (b):
-// BIP152 compact-block depth on the connector seam).
+// BIP152 compact-block depth on the connector seam) + the compact-block
+// reconstruction MERKLE BACKSTOP (milestone bch-cmpct-merkle).
 //
 // compact_blocks.hpp already carried the BIP152 wire types + ReconstructBlock,
 // but nothing tied them to the block-connect path: a received compact block had
@@ -21,6 +22,25 @@
 //   3. UNKNOWN/EXPIRED blocktxn -- a blocktxn for a blockhash we never parked is
 //      a clean no-op (returns false, no crash, parked count unchanged).
 //
+// MERKLE BACKSTOP (bch-cmpct-merkle) -- ReconstructBlock() used to declare a
+// block complete the instant every short-ID slot was filled, with NO check that
+// the reconstructed txs hash to the header's committed merkle root. BIP 152 short
+// IDs are 48-bit SipHash over txid (BCH: wtxid == txid, no SegWit), so a collision
+// can silently substitute the WRONG tx into a filled slot. The backstop recomputes
+// the merkle root over the reconstructed txids (via the sealed compute_merkle_root
+// SSOT) and, on any divergence from header.m_merkle_root, DISCARDS instead of
+// delivering -- the p2p handler then re-fetches the full block via getdata. Cases:
+//   4. RECONSTRUCT-ON-MATCH  -- honest txs verify: complete=true, no mismatch.
+//   5. DISCARD-ON-MISMATCH   -- a slot filled with the wrong tx fails the header
+//      commitment: complete=false, merkle_mismatch=true, EMPTY block (no forgery).
+//   6. ID-PATH ROUND TRIP    -- BCH keys short IDs by txid in BOTH the build and
+//      the reconstruct pass; wtxid == txid, so the two passes cannot diverge.
+//
+// Because ReconstructBlock now enforces the header commitment, cases 1/2's headers
+// must COMMIT to their bodies (m_merkle_root = merkle over the body txids); a
+// placeholder root would be correctly discarded. Cases 1-3 therefore build a
+// per-case committing header instead of one shared placeholder.
+//
 // Build posture matches the other connector tests: header-only over coin/*.hpp +
 // <core/*>, plus coin/transaction.cpp for the MutableTransaction ctors and the
 // btclibs lib for SipHash. impl_bch is NOT linked -> per-coin isolation holds.
@@ -31,12 +51,14 @@
 #include <cstdint>
 #include <iostream>
 #include <optional>
+#include <vector>
 
 #include "../coin/block.hpp"
 #include "../coin/block_connector.hpp"
 #include "../coin/compact_blocks.hpp"
 #include "../coin/header_chain.hpp"
 #include "../coin/mempool.hpp"
+#include "../coin/merkle.hpp"
 #include "../coin/transaction.hpp"
 
 namespace {
@@ -61,8 +83,9 @@ bch::coin::MutableTransaction make_tx(const char* prev_hex, uint32_t prev_index,
     return tx;
 }
 
-// Header whose hash is fixed by the 80-byte header (txs do not feed block_hash),
-// so it can be pinned as a fast-start checkpoint and seen as the best tip.
+// Base header whose hash is fixed by the 80-byte header (txs do not feed
+// block_hash directly, but m_merkle_root does), so it can be pinned as a
+// fast-start checkpoint and seen as the best tip.
 bch::coin::BlockType make_block(uint32_t nonce) {
     bch::coin::BlockType b;
     b.m_version = 0x20000000;
@@ -76,10 +99,25 @@ bch::coin::BlockType make_block(uint32_t nonce) {
     return b;
 }
 
+// Header that COMMITS to `body`: m_merkle_root = SHA256d merkle over the body's
+// txids (the same SSOT walk ReconstructBlock's backstop uses). Required now that
+// reconstruction is checked against the header commitment.
+bch::coin::BlockType make_block_committing(
+    uint32_t nonce, const std::vector<bch::coin::MutableTransaction>& body) {
+    bch::coin::BlockType b = make_block(nonce);
+    std::vector<uint256> txids;
+    txids.reserve(body.size());
+    for (const auto& tx : body)
+        txids.push_back(bch::coin::compute_txid(tx));
+    b.m_merkle_root = bch::coin::compute_merkle_root(txids);
+    return b;
+}
+
 const char* OUTPOINT_CB = "c0ffee0000000000000000000000000000000000000000000000000000000000";
 const char* OUTPOINT_A  = "aa00000000000000000000000000000000000000000000000000000000000000";
 const char* OUTPOINT_M  = "11d1551100000000000000000000000000000000000000000000000000000000";
 const char* OUTPOINT_C  = "cc00000000000000000000000000000000000000000000000000000000000000";
+const char* OUTPOINT_W  = "44e0000000000000000000000000000000000000000000000000000000000000";
 
 // A HeaderChain whose fast-start checkpoint IS `header`'s hash at height H, so
 // the connector's best-chain gate treats that header as the tip without fighting
@@ -100,22 +138,24 @@ int main() {
 
     const uint32_t H = 800002;
 
-    // Shared header -> shared block hash -> shared checkpoint across cases.
-    BlockType hdr_block = make_block(/*nonce=*/7);
-    const BlockHeaderType& header = static_cast<const BlockHeaderType&>(hdr_block);
-    const uint256 blk_hash = block_hash(header);
-
     MutableTransaction coinbase = make_tx(OUTPOINT_CB, 0xffffffff, 50);
     MutableTransaction tx_A     = make_tx(OUTPOINT_A, 0, 100);  // mempool-known
     MutableTransaction tx_M     = make_tx(OUTPOINT_M, 0, 200);  // missing from mempool
     MutableTransaction tx_C     = make_tx(OUTPOINT_C, 0, 300);  // unrelated survivor
+    MutableTransaction tx_W     = make_tx(OUTPOINT_W, 0, 400);  // "wrong" collision tx
     const uint256 id_A = compute_txid(tx_A);
     const uint256 id_M = compute_txid(tx_M);
     const uint256 id_C = compute_txid(tx_C);
+    const uint256 id_W = compute_txid(tx_W);
     CHECK(id_A != id_M && id_A != id_C && id_M != id_C);
+    CHECK(id_W != id_A && id_W != id_M);
 
     // ---- 1) Complete-from-mempool: no getblocktxn round ------------------
     {
+        BlockType hdr = make_block_committing(/*nonce=*/7, {coinbase, tx_A});
+        const BlockHeaderType& header = static_cast<const BlockHeaderType&>(hdr);
+        const uint256 blk_hash = block_hash(header);
+
         HeaderChain chain = make_chain_pinning(header, H);
         CHECK(chain.init());
         CHECK(chain.tip() && chain.tip()->block_hash == blk_hash);
@@ -128,7 +168,7 @@ int main() {
         BlockConnector conn(chain, pool);
 
         // Block body = [coinbase, tx_A]; tx_A is in the mempool -> reconstructs
-        // with no missing txs.
+        // with no missing txs and passes the header merkle backstop.
         CompactBlock cb = BuildCompactBlock(header, {coinbase, tx_A}, /*nonce=*/99);
         std::optional<BlockTransactionsRequest> req = conn.on_compact_block(cb);
 
@@ -141,6 +181,10 @@ int main() {
 
     // ---- 2) Missing tx -> getblocktxn -> blocktxn completes --------------
     {
+        BlockType hdr = make_block_committing(/*nonce=*/7, {coinbase, tx_M});
+        const BlockHeaderType& header = static_cast<const BlockHeaderType&>(hdr);
+        const uint256 blk_hash = block_hash(header);
+
         HeaderChain chain = make_chain_pinning(header, H);
         CHECK(chain.init());
 
@@ -172,6 +216,8 @@ int main() {
 
     // ---- 3) Unknown/expired blocktxn is a clean no-op --------------------
     {
+        BlockType hdr = make_block(/*nonce=*/3);   // no reconstruction here
+        const BlockHeaderType& header = static_cast<const BlockHeaderType&>(hdr);
         HeaderChain chain = make_chain_pinning(header, H);
         CHECK(chain.init());
         Mempool pool;
@@ -185,6 +231,71 @@ int main() {
 
         CHECK(!connected);                                 // nothing parked -> no-op
         CHECK(conn.pending_compact_count() == 0);
+    }
+
+    // ---- 4) Merkle backstop: honest reconstruction verifies + completes --
+    {
+        // Header commits to [coinbase, tx_A]; the slot tx IS tx_A.
+        BlockType hdr = make_block_committing(/*nonce=*/11, {coinbase, tx_A});
+        const BlockHeaderType& header = static_cast<const BlockHeaderType&>(hdr);
+        CompactBlock cb = BuildCompactBlock(header, {coinbase, tx_A}, /*nonce=*/0x5151);
+
+        std::map<uint256, MutableTransaction> known;
+        known[id_A] = tx_A;                                // txid-keyed (BCH: == wtxid)
+
+        auto rec = ReconstructBlock(cb, known);
+
+        CHECK(rec.complete);                               // honest block accepted
+        CHECK(!rec.merkle_mismatch);
+        CHECK(rec.missing_indexes.empty());
+        CHECK(rec.block.m_txs.size() == 2);
+        CHECK(compute_txid(rec.block.m_txs[1]) == id_A);
+    }
+
+    // ---- 5) Merkle backstop: collision substitutes wrong tx -> DISCARD ----
+    {
+        // Header commits to the HONEST body [coinbase, tx_A]...
+        BlockType hdr = make_block_committing(/*nonce=*/13, {coinbase, tx_A});
+        const BlockHeaderType& header = static_cast<const BlockHeaderType&>(hdr);
+
+        // ...but the compact block's single short ID is computed over tx_W (the
+        // "wrong" tx), modelling a 48-bit short-ID collision that resolves the
+        // slot to tx_W. The reconstructed body [coinbase, tx_W] therefore hashes
+        // to a DIFFERENT merkle root than the header committed to.
+        CompactBlock cb = BuildCompactBlock(header, {coinbase, tx_W}, /*nonce=*/0x5151);
+
+        std::map<uint256, MutableTransaction> known;
+        known[id_W] = tx_W;                                // only the wrong tx is available
+
+        auto rec = ReconstructBlock(cb, known);
+
+        CHECK(!rec.complete);                              // NOT delivered
+        CHECK(rec.merkle_mismatch);                        // signals the getdata fallback
+        CHECK(rec.block.m_txs.empty());                    // discard-not-deliver: no forgery
+        CHECK(rec.missing_indexes.empty());                // all slots filled -> not getblocktxn
+    }
+
+    // ---- 6) ID-path round trip: BCH keys BOTH passes by txid --------------
+    {
+        // BCH has no wtxid (no SegWit). BuildCompactBlock computes the short ID
+        // over compute_txid(); the reconstruct pass recomputes the same short ID
+        // from the same txid. Pin that the two keys are IDENTICAL, so the
+        // cmpctblock and blocktxn passes cannot diverge on BCH.
+        BlockType hdr = make_block_committing(/*nonce=*/17, {coinbase, tx_A});
+        const BlockHeaderType& header = static_cast<const BlockHeaderType&>(hdr);
+        CompactBlock cb = BuildCompactBlock(header, {coinbase, tx_A}, /*nonce=*/0xABCD);
+
+        CHECK(cb.short_ids.size() == 1);
+        uint64_t k0, k1; cb.GetSipHashKeys(k0, k1);
+        // The reconstruct-pass key (over txid) equals the wire short ID the
+        // builder emitted -> one and the same id-path.
+        CHECK(CompactBlock::GetShortID(k0, k1, id_A) == cb.short_ids[0]);
+
+        std::map<uint256, MutableTransaction> known;
+        known[id_A] = tx_A;
+        auto rec = ReconstructBlock(cb, known);
+        CHECK(rec.complete && !rec.merkle_mismatch);
+        CHECK(rec.block.m_txs.size() == 2);
     }
 
     if (failures == 0) {


### PR DESCRIPTION
BIP152 reconstruction declared a block complete once every slot was filled, with no comparison against the header merkle root. 48-bit short-id collisions can substitute the wrong tx; the header commitment is the only backstop.

- ReconstructedMerkleRoot() over the sealed bch::coin::compute_merkle_root (same walk GBT/emit_full_block use) gates result.complete.
- On mismatch: merkle_mismatch=true, discard, fall back to full getdata. Belt-and-suspenders re-check at the p2p_node delivery site.
- Test case models a 48-bit short-id collision substituting a wrong tx -> complete=false, merkle_mismatch=true, empty block (no forgery). CI-wired (build.yml x2). ctest bch_compact_block_connector_test PASS.

Reachability confirmed: p2p_node.hpp includes compact_blocks.hpp and p2p_node.cpp compiles directly into the c2pool-bch executable (src/c2pool/CMakeLists.txt). Per-coin isolation held: src/impl/bch only.