### PR TITLE
ci: fail-fast + bounded retry on lossy WAN uplink checkout

### DIFF
--- a/.github/actions/git-fetch-retry/action.yml
+++ b/.github/actions/git-fetch-retry/action.yml
@@ -8,7 +8,7 @@ inputs:
   retries:
     description: "Maximum attempts before the step fails."
     required: false
-    default: "5"
+    default: "3"
   initial-delay:
     description: "Seconds to wait before the first retry; doubles each attempt."
     required: false
@@ -23,7 +23,7 @@ runs:
         git config --global http.version HTTP/1.1
         git config --global http.postBuffer 524288000
         git config --global http.lowSpeedLimit 1000
-        git config --global http.lowSpeedTime 300
+        git config --global http.lowSpeedTime 20
         n=0; max="${{ inputs.retries }}"; delay="${{ inputs.initial-delay }}"
         until git fetch ${{ inputs.args }}; do
           n=$((n+1))

--- a/.github/workflows/attribution-gate.yml
+++ b/.github/workflows/attribution-gate.yml
@@ -12,6 +12,14 @@ on:
 permissions:
   contents: read
 
+env:
+  # Fail-fast on a stalled git HTTP transfer instead of hanging to the job
+  # timeout. Our WAN uplink stalls ~12% of codeload fetches (they neither
+  # finish nor error out); aborting a sub-1000 B/s transfer after 20s lets
+  # actions/checkout built-in 3-attempt fetch retry recover in ~1 min.
+  GIT_HTTP_LOW_SPEED_LIMIT: '1000'
+  GIT_HTTP_LOW_SPEED_TIME: '20'
+
 jobs:
   attribution-gate:
     name: attribution-gate

--- a/.github/workflows/bch-gate-g3a-regtest-block-production.yml
+++ b/.github/workflows/bch-gate-g3a-regtest-block-production.yml
@@ -28,6 +28,14 @@ on:
   pull_request:
     branches: [master]
 
+env:
+  # Fail-fast on a stalled git HTTP transfer instead of hanging to the job
+  # timeout. Our WAN uplink stalls ~12% of codeload fetches (they neither
+  # finish nor error out); aborting a sub-1000 B/s transfer after 20s lets
+  # actions/checkout built-in 3-attempt fetch retry recover in ~1 min.
+  GIT_HTTP_LOW_SPEED_LIMIT: '1000'
+  GIT_HTTP_LOW_SPEED_TIME: '20'
+
 jobs:
   g3a-regtest-block-production:
     name: BCH gate G3a — populated-regtest block production

--- a/.github/workflows/bch-gate-g3b-genuine-activation.yml
+++ b/.github/workflows/bch-gate-g3b-genuine-activation.yml
@@ -25,6 +25,14 @@ on:
   pull_request:
     branches: [master]
 
+env:
+  # Fail-fast on a stalled git HTTP transfer instead of hanging to the job
+  # timeout. Our WAN uplink stalls ~12% of codeload fetches (they neither
+  # finish nor error out); aborting a sub-1000 B/s transfer after 20s lets
+  # actions/checkout built-in 3-attempt fetch retry recover in ~1 min.
+  GIT_HTTP_LOW_SPEED_LIMIT: '1000'
+  GIT_HTTP_LOW_SPEED_TIME: '20'
+
 jobs:
   g3b-genuine-activation:
     name: BCH gate G3b — genuine Upgrade9 activation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,14 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'push' }}
 
 
+env:
+  # Fail-fast on a stalled git HTTP transfer instead of hanging to the job
+  # timeout. Our WAN uplink stalls ~12% of codeload fetches (they neither
+  # finish nor error out); aborting a sub-1000 B/s transfer after 20s lets
+  # actions/checkout built-in 3-attempt fetch retry recover in ~1 min.
+  GIT_HTTP_LOW_SPEED_LIMIT: '1000'
+  GIT_HTTP_LOW_SPEED_TIME: '20'
+
 jobs:
   # ------------------------------------------------------------------------
   # PR job-selection filter. On pull_request, skip expensive jobs whose
@@ -1157,7 +1165,16 @@ jobs:
 
       - name: Build secp256k1
         run: |
-          git clone https://github.com/bitcoin-core/secp256k1 secp256k1-src
+          # Bounded retry + shallow: survive a stalled fetch on the lossy
+          # WAN uplink (GIT_HTTP_LOW_SPEED_* aborts the stall in ~20s).
+          for ($i = 1; $i -le 3; $i++) {
+            git clone --depth 1 https://github.com/bitcoin-core/secp256k1 secp256k1-src
+            if ($LASTEXITCODE -eq 0) { break }
+            if ($i -eq 3) { Write-Host "::error::secp256k1 clone failed after 3 attempts"; exit 1 }
+            Write-Host "::warning::secp256k1 clone attempt $i/3 stalled; retrying"
+            Remove-Item -Recurse -Force secp256k1-src -ErrorAction SilentlyContinue
+            Start-Sleep -Seconds ($i * 5)
+          }
           cmake -B secp256k1-src/build -S secp256k1-src -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${env:GITHUB_WORKSPACE}/secp256k1" -DSECP256K1_BUILD_TESTS=OFF -DSECP256K1_BUILD_EXHAUSTIVE_TESTS=OFF -DSECP256K1_BUILD_BENCHMARK=OFF -DSECP256K1_BUILD_EXAMPLES=OFF
           cmake --build secp256k1-src/build --config Release
           cmake --install secp256k1-src/build --config Release

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,6 +17,14 @@ concurrency:
   cancel-in-progress: true
 
 
+env:
+  # Fail-fast on a stalled git HTTP transfer instead of hanging to the job
+  # timeout. Our WAN uplink stalls ~12% of codeload fetches (they neither
+  # finish nor error out); aborting a sub-1000 B/s transfer after 20s lets
+  # actions/checkout built-in 3-attempt fetch retry recover in ~1 min.
+  GIT_HTTP_LOW_SPEED_LIMIT: '1000'
+  GIT_HTTP_LOW_SPEED_TIME: '20'
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/coin-matrix.yml
+++ b/.github/workflows/coin-matrix.yml
@@ -28,6 +28,14 @@ concurrency:
   cancel-in-progress: true
 
 
+env:
+  # Fail-fast on a stalled git HTTP transfer instead of hanging to the job
+  # timeout. Our WAN uplink stalls ~12% of codeload fetches (they neither
+  # finish nor error out); aborting a sub-1000 B/s transfer after 20s lets
+  # actions/checkout built-in 3-attempt fetch retry recover in ~1 min.
+  GIT_HTTP_LOW_SPEED_LIMIT: '1000'
+  GIT_HTTP_LOW_SPEED_TIME: '20'
+
 jobs:
   coin:
     name: ${{ matrix.coin }} smoke (Linux x86_64)

--- a/.github/workflows/dash-gate-g1-byte-parity.yml
+++ b/.github/workflows/dash-gate-g1-byte-parity.yml
@@ -26,6 +26,14 @@ on:
   pull_request:
     branches: [master, dash-spv-embedded]
 
+env:
+  # Fail-fast on a stalled git HTTP transfer instead of hanging to the job
+  # timeout. Our WAN uplink stalls ~12% of codeload fetches (they neither
+  # finish nor error out); aborting a sub-1000 B/s transfer after 20s lets
+  # actions/checkout built-in 3-attempt fetch retry recover in ~1 min.
+  GIT_HTTP_LOW_SPEED_LIMIT: '1000'
+  GIT_HTTP_LOW_SPEED_TIME: '20'
+
 jobs:
   g1-byte-parity-kat:
     name: DASH gate G1 — byte-parity KAT

--- a/.github/workflows/dash-gate-g3a-regtest-block-production.yml
+++ b/.github/workflows/dash-gate-g3a-regtest-block-production.yml
@@ -29,6 +29,14 @@ on:
   pull_request:
     branches: [master, dash-spv-embedded]
 
+env:
+  # Fail-fast on a stalled git HTTP transfer instead of hanging to the job
+  # timeout. Our WAN uplink stalls ~12% of codeload fetches (they neither
+  # finish nor error out); aborting a sub-1000 B/s transfer after 20s lets
+  # actions/checkout built-in 3-attempt fetch retry recover in ~1 min.
+  GIT_HTTP_LOW_SPEED_LIMIT: '1000'
+  GIT_HTTP_LOW_SPEED_TIME: '20'
+
 jobs:
   g3a-regtest-block-production:
     name: DASH gate G3a — populated-regtest block-production

--- a/.github/workflows/dgb-phase-b-smoke.yml
+++ b/.github/workflows/dgb-phase-b-smoke.yml
@@ -21,6 +21,14 @@ on:
   pull_request:
     branches: [master]
 
+env:
+  # Fail-fast on a stalled git HTTP transfer instead of hanging to the job
+  # timeout. Our WAN uplink stalls ~12% of codeload fetches (they neither
+  # finish nor error out); aborting a sub-1000 B/s transfer after 20s lets
+  # actions/checkout built-in 3-attempt fetch retry recover in ~1 min.
+  GIT_HTTP_LOW_SPEED_LIMIT: '1000'
+  GIT_HTTP_LOW_SPEED_TIME: '20'
+
 jobs:
   dgb-phase-b-smoke:
     name: DGB Phase-B smoke — per-coin pillar gtests

--- a/.github/workflows/doge-aux-smoke.yml
+++ b/.github/workflows/doge-aux-smoke.yml
@@ -19,6 +19,14 @@ on:
   pull_request:
     branches: [master]
 
+env:
+  # Fail-fast on a stalled git HTTP transfer instead of hanging to the job
+  # timeout. Our WAN uplink stalls ~12% of codeload fetches (they neither
+  # finish nor error out); aborting a sub-1000 B/s transfer after 20s lets
+  # actions/checkout built-in 3-attempt fetch retry recover in ~1 min.
+  GIT_HTTP_LOW_SPEED_LIMIT: '1000'
+  GIT_HTTP_LOW_SPEED_TIME: '20'
+
 jobs:
   doge-aux-smoke:
     name: DOGE AuxPoW smoke — embedded per-coin gtests

--- a/.github/workflows/ltc-gate-g3a-regtest-block-production.yml
+++ b/.github/workflows/ltc-gate-g3a-regtest-block-production.yml
@@ -27,6 +27,14 @@ on:
   pull_request:
     branches: [master]
 
+env:
+  # Fail-fast on a stalled git HTTP transfer instead of hanging to the job
+  # timeout. Our WAN uplink stalls ~12% of codeload fetches (they neither
+  # finish nor error out); aborting a sub-1000 B/s transfer after 20s lets
+  # actions/checkout built-in 3-attempt fetch retry recover in ~1 min.
+  GIT_HTTP_LOW_SPEED_LIMIT: '1000'
+  GIT_HTTP_LOW_SPEED_TIME: '20'
+
 jobs:
   g3a-regtest-block-production:
     name: LTC gate G3a — populated-regtest block-production

--- a/.github/workflows/pplns-parse-seedpin.yml
+++ b/.github/workflows/pplns-parse-seedpin.yml
@@ -21,6 +21,14 @@ on:
       - "web-static/sharechain-explorer/**"
       - ".github/workflows/pplns-parse-seedpin.yml"
 
+env:
+  # Fail-fast on a stalled git HTTP transfer instead of hanging to the job
+  # timeout. Our WAN uplink stalls ~12% of codeload fetches (they neither
+  # finish nor error out); aborting a sub-1000 B/s transfer after 20s lets
+  # actions/checkout built-in 3-attempt fetch retry recover in ~1 min.
+  GIT_HTTP_LOW_SPEED_LIMIT: '1000'
+  GIT_HTTP_LOW_SPEED_TIME: '20'
+
 jobs:
   seedpin:
     name: PPLNS parse seed-pin replay

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,14 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  # Fail-fast on a stalled git HTTP transfer instead of hanging to the job
+  # timeout. Our WAN uplink stalls ~12% of codeload fetches (they neither
+  # finish nor error out); aborting a sub-1000 B/s transfer after 20s lets
+  # actions/checkout built-in 3-attempt fetch retry recover in ~1 min.
+  GIT_HTTP_LOW_SPEED_LIMIT: '1000'
+  GIT_HTTP_LOW_SPEED_TIME: '20'
+
 jobs:
   # ════════════════════════════════════════════════════════════════════════════
   # Linux x86_64 (Ubuntu 24.04, GCC 13, Conan) — one cell per coin
@@ -537,7 +545,16 @@ jobs:
       - name: Build secp256k1
         if: steps.presence.outputs.exists == '1'
         run: |
-          git clone https://github.com/bitcoin-core/secp256k1 secp256k1-src
+          # Bounded retry + shallow: survive a stalled fetch on the lossy
+          # WAN uplink (GIT_HTTP_LOW_SPEED_* aborts the stall in ~20s).
+          for ($i = 1; $i -le 3; $i++) {
+            git clone --depth 1 https://github.com/bitcoin-core/secp256k1 secp256k1-src
+            if ($LASTEXITCODE -eq 0) { break }
+            if ($i -eq 3) { Write-Host "::error::secp256k1 clone failed after 3 attempts"; exit 1 }
+            Write-Host "::warning::secp256k1 clone attempt $i/3 stalled; retrying"
+            Remove-Item -Recurse -Force secp256k1-src -ErrorAction SilentlyContinue
+            Start-Sleep -Seconds ($i * 5)
+          }
           cmake -B secp256k1-src/build -S secp256k1-src -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${env:GITHUB_WORKSPACE}/secp256k1" -DSECP256K1_BUILD_TESTS=OFF -DSECP256K1_BUILD_EXHAUSTIVE_TESTS=OFF -DSECP256K1_BUILD_BENCHMARK=OFF -DSECP256K1_BUILD_EXAMPLES=OFF
           cmake --build secp256k1-src/build --config Release
           cmake --install secp256k1-src/build --config Release


### PR DESCRIPTION
## Problem
Our WAN uplink stalls ~12% of codeload git fetches (integrator measurements from .198, 1 pkt/s: 16.6% loss to codeload, 8.3% to github.com, 12.5% to 1.1.1.1, 0% on LAN; contabo->codeload 0%). The stall neither completes nor errors — a single `actions/checkout` attempt wedges to the job timeout. This is the shared-uplink transport fault behind the 145/198/905 reds; it is **not** a per-runner or GitHub-edge fault, so shuffling runners would only move the reds.

## Fix (CI config only — uplink itself is an operator/peering matter)
1. **Fail-fast on stall.** Set `GIT_HTTP_LOW_SPEED_LIMIT=1000` / `GIT_HTTP_LOW_SPEED_TIME=20` at workflow `env` scope across the 13 checkout-bearing workflows. git honours these env vars for every invocation including `actions/checkout`s own fetch, so a sub-1000 B/s transfer aborts in ~20s instead of hanging to the job timeout.
2. **Bounded retry (3 attempts).** With fail-fast in place, `actions/checkout`s built-in 3-attempt fetch retry recovers a stalled clone in ~1 min (~12% per-attempt stall -> <0.2% over 3). The `git-fetch-retry` composite (explicit unshallow path) is retuned to match: 3 attempts (was 5), 20s stall window (was 300s). The two inline Windows `secp256k1` clones get an explicit 3-attempt retry loop.
3. **Fewer bytes on the wire.** Shallow checkout (depth 1) is already the default at every `actions/checkout` site; the `secp256k1` clones now use `--depth 1`. `attribution-gate` keeps `fetch-depth: 0` — it must scan full history.

No runner drained or stopped; pool unchanged.