### PR TITLE
ci: stop aggregated gates double-firing on master PRs

### DIFF
--- a/.github/workflows/bch-gate-g3a-regtest-block-production.yml
+++ b/.github/workflows/bch-gate-g3a-regtest-block-production.yml
@@ -25,8 +25,6 @@ on:
   workflow_call:
   push:
     branches: [master]
-  pull_request:
-    branches: [master]
 
 jobs:
   g3a-regtest-block-production:

--- a/.github/workflows/bch-gate-g3b-genuine-activation.yml
+++ b/.github/workflows/bch-gate-g3b-genuine-activation.yml
@@ -22,8 +22,6 @@ on:
   workflow_call:
   push:
     branches: [master]
-  pull_request:
-    branches: [master]
 
 jobs:
   g3b-genuine-activation:

--- a/.github/workflows/coin-matrix.yml
+++ b/.github/workflows/coin-matrix.yml
@@ -17,7 +17,7 @@ on:
   push:
     branches: [master, btc-embedded, dash-spv-embedded, dgb/pool-pillars-port, windows-build, service-update]
   pull_request:
-    branches: [master, btc-embedded, dash-spv-embedded, dgb/slice4-skeleton, dgb/pool-pillars-port]
+    branches: [btc-embedded, dash-spv-embedded, dgb/slice4-skeleton, dgb/pool-pillars-port]
 
 # Concurrency: a newer run on the same ref cancels the stale in-progress
 # one, cutting concurrent load on the shared self-hosted pool (the OOM/

--- a/.github/workflows/dash-gate-g1-byte-parity.yml
+++ b/.github/workflows/dash-gate-g1-byte-parity.yml
@@ -24,7 +24,7 @@ on:
   push:
     branches: [master, dash-spv-embedded]
   pull_request:
-    branches: [master, dash-spv-embedded]
+    branches: [dash-spv-embedded]
 
 jobs:
   g1-byte-parity-kat:

--- a/.github/workflows/dash-gate-g3a-regtest-block-production.yml
+++ b/.github/workflows/dash-gate-g3a-regtest-block-production.yml
@@ -27,7 +27,7 @@ on:
   push:
     branches: [master, dash-spv-embedded]
   pull_request:
-    branches: [master, dash-spv-embedded]
+    branches: [dash-spv-embedded]
 
 jobs:
   g3a-regtest-block-production:

--- a/.github/workflows/dgb-phase-b-smoke.yml
+++ b/.github/workflows/dgb-phase-b-smoke.yml
@@ -18,8 +18,6 @@ on:
   workflow_call:
   push:
     branches: [master]
-  pull_request:
-    branches: [master]
 
 jobs:
   dgb-phase-b-smoke:


### PR DESCRIPTION
## Root cause

The six gates aggregated by `ci-required.yml` (coin-matrix, dash G1/G3a, DGB Phase-B, BCH G3a/G3b) each carried their own `pull_request: [master]` trigger *in addition* to `workflow_call`. `ci-required.yml` fires on `pull_request: [master]` and invokes each gate via `workflow_call`, so every master PR ran each gate **twice**: once inside the CI Required aggregate, once standalone. `coin-matrix`s per-ref concurrency did not collapse them because the group key `github.workflow` differs between the two paths (`CI Required` vs `coin-matrix`). Evidence (.198 journal 2026-07-30): dash smoke ran 12:00:39 and 12:27:46; BCH G3b ran 12:19:11 and 12:39:26 — same commit, ~20m apart = queue latency on the starved 8-slot pool, not a re-run. ~1 runner-slot-hour/PR of pure duplication.

## Fix

Remove `master` from each gates `pull_request` trigger, leaving the aggregator as the sole master-PR entrypoint:
- coin-matrix / dash-G1 / dash-G3a: drop `master`, keep non-master feature branches (btc-embedded, dash-spv-embedded, dgb/*) where the aggregator does not run.
- DGB Phase-B / BCH G3a / BCH G3b: `pull_request` was master-only, so the block is removed entirely.
- All six keep `workflow_call` (aggregator PR path) and `push: [master]` (post-merge validation).

## Safety

Master branch protection requires only the single `aggregate` context (verified via API), which `ci-required.yml` posts on every PR. PR coverage is therefore unchanged — each gate still runs once per master PR, inside the aggregate.

Not self-merging — integrator gate.