### PR TITLE
dash(payee): wire SML->payee validity reconcile on the maintainer axis (live-run half; checkpoint lane still open)

### DIFF
--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -234,6 +234,24 @@ public:
         // fetch and the first live full-block ingest were the soak's
         // 2-slot cursor lag -> bad-cb-payee at the address-group boundary).
         m_state.mnstates().load(std::move(mnstates), as_of_height);
+        // Startup / reseed join (2026-07-30): the PAYEE axis was just (re)seeded
+        // -- reconcile it against an already-present SML so a warm-loaded or
+        // live-advanced SML's authoritative isValid lands on the fresh queue
+        // immediately, without waiting for the next mnlistdiff. Handles the
+        // seed-arrives-after-SML startup ordering (mirror of the on_mnlistdiff
+        // reconcile, which handles SML-arrives-after-seed). No-op when no SML has
+        // applied yet (m_have_mn_sml false) or nothing flipped. Height falls back
+        // to the seed's as_of_height when no live diff has set m_sml_current_height.
+        if (m_have_mn && m_have_mn_sml) {
+            const uint32_t vh = m_sml_current_height ? m_sml_current_height
+                                                     : as_of_height;
+            const auto vr = m_state.mnstates().sync_validity_from_sml(
+                m_state.sml(), vh);
+            if (vr.flipped_to_invalid || vr.flipped_to_valid)
+                LOG_INFO << "[SML->PAYEE] seed reconcile: -"
+                         << vr.flipped_to_invalid << " banned +"
+                         << vr.flipped_to_valid << " revived @ h=" << vh;
+        }
         if (!m_have_mn)
             demote();
         else
@@ -418,6 +436,30 @@ public:
                  << " MNs; quorums +" << q_added << " -" << q_deleted
                  << " => " << m_state.qmgr().active_count()
                  << " active; have_sml=" << (m_have_mn_sml ? "yes" : "no");
+
+        // -- PAYEE-axis validity reconcile (Bug 12/14 wiring, 2026-07-30) ------
+        // The SML just advanced and carries the AUTHORITATIVE per-MN isValid.
+        // PoSe bans are CONSENSUS-driven, not tx-driven, so apply_block() can
+        // NEVER observe them -- the PAYEE MnStateMachine keeps a phantom-eligible
+        // banned MN as isValid=true forever and find_expected_payee determinist-
+        // ically projects it (daemonless payee-desync, live-observed ~h2513489).
+        // sync_validity_from_sml() is the reconciler that fixes exactly this and
+        // was DEAD CODE (zero production callers) until this line. It reconciles
+        // the BOOLEAN off the freshly-applied SML (ban/revive heights stay SML-
+        // approximate, bounded by m_sml_current_height -- see the function's
+        // field-ownership contract) and early-continues on entries whose isValid
+        // did NOT flip, so queue POSITION for unchanged nodes is never perturbed.
+        // Guarded on a non-empty SML (an empty set is a gap, handled below).
+        if (m_have_mn_sml) {
+            const auto vr = m_state.mnstates().sync_validity_from_sml(
+                m_state.sml(), m_sml_current_height);
+            if (vr.flipped_to_invalid || vr.flipped_to_valid)
+                LOG_INFO << "[SML->PAYEE] validity reconcile: -"
+                         << vr.flipped_to_invalid << " banned +"
+                         << vr.flipped_to_valid << " revived (scanned "
+                         << vr.scanned << ", matched " << vr.matched
+                         << ") @ h=" << m_sml_current_height;
+        }
         // SML/quorum persistence (SMLDb/QuorumDb): the applied state is now
         // current AT diff.blockHash — flush it so a restart resumes from this
         // tip incrementally instead of a cold mnlistdiff(zero, tip). Only when

--- a/src/impl/dash/coin/mn_state_machine.hpp
+++ b/src/impl/dash/coin/mn_state_machine.hpp
@@ -254,6 +254,20 @@ public:
         int best_h = std::numeric_limits<int>::max();
         for (const auto& [hash, st] : m_entries) {
             if (!st.isValid) continue;
+            // Bug 14 guard: nPoSeBanHeight is write-only on the selection
+            // path, so a divergent persisted snapshot could carry
+            // isValid==true alongside a live ban height and pay a banned MN
+            // on the boolean alone. Reconciled invariant: isValid==true =>
+            // ban height clear (0, or the -1/UINT32_MAX never-banned
+            // sentinel). Fail-closed (a crash here would kill the daemonless
+            // payee projection outright, worse than a skip) with a logged
+            // warning so the invariant violation is never silent.
+            if (sane(st.nPoSeBanHeight) != 0) {
+                LOG_INFO << "[MNS] fail-closed: valid MN " << hash.GetHex().substr(0,16)
+                         << " carries live PoSe banHeight=" << st.nPoSeBanHeight
+                         << " (divergent snapshot) -- excluded from selection";
+                continue;
+            }
             if (st.scriptPayout.m_data != script) continue;
             uint32_t lastPaid = sane(st.nLastPaidHeight);
             uint32_t revived  = sane(st.nPoSeRevivedHeight);
@@ -348,6 +362,14 @@ public:
         };
         for (const auto& [hash, st] : m_entries) {
             if (!st.isValid) continue;
+            // Bug 14 guard (see pick_paid_mn): fail-closed on the write-only
+            // ban field so a divergent snapshot cannot project a banned MN.
+            if (sane_height(st.nPoSeBanHeight) != 0) {
+                LOG_INFO << "[MNS] fail-closed: valid MN " << hash.GetHex().substr(0,16)
+                         << " carries live PoSe banHeight=" << st.nPoSeBanHeight
+                         << " (divergent snapshot) -- excluded from projection";
+                continue;
+            }
             uint32_t lastPaid = sane_height(st.nLastPaidHeight);
             uint32_t revived  = sane_height(st.nPoSeRevivedHeight);
             int h = static_cast<int>(lastPaid);

--- a/test/test_dash_coin_state_maintainer.cpp
+++ b/test/test_dash_coin_state_maintainer.cpp
@@ -734,3 +734,87 @@ TEST(DashCoinStateMaintainer, StaleZeroBaseSnapshotDoesNotCorruptTipSml) {
     EXPECT_EQ(st.sml_current_hash(), raw256(0x60))
         << "post-reorg cold resync must not be blocked by the stale-guard";
 }
+
+// ════════════════════════════════════════════════════════════════════════
+// SML -> PAYEE validity reconcile wiring (2026-07-30, daemonless payee-desync).
+//
+// A PoSe ban is CONSENSUS-driven, never a special tx, so apply_block() can
+// never observe it. The ONLY authoritative signal is the SML axis's per-entry
+// isValid, which advances on every mnlistdiff. Before this wiring the reconciler
+// MnStateMachine::sync_validity_from_sml() was DEAD CODE (zero production
+// callers), so a banned MN stayed isValid=true on the PAYEE axis forever and
+// find_expected_payee() kept projecting the phantom-eligible node -> the
+// embedded template's payee disagreed with dashd -> bridge fail-closed. These
+// two tests pin that the maintainer now actually CALLS the reconciler on both
+// the live-diff path and the seed-join path.
+// ════════════════════════════════════════════════════════════════════════
+
+// Call site 1 (on_mnlistdiff): a ban that lands AFTER the payee axis was seeded
+// valid must flip the payee entry — the exact live-observed ~h2513489 defect.
+TEST(DashCoinStateMaintainer, MnlistdiffBanReconcilesOntoPayeeAxis) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+
+    // Seed the payee axis valid (mirrors a `protx list valid true` checkpoint,
+    // which pre-filters banned nodes — so the ban can only appear post-seed).
+    m.on_mn_list_update(single_mn(p2pkh_script(0x30)), H - 2);
+    ASSERT_EQ(st.mnstates().size(), 1u);
+    ASSERT_TRUE(st.mnstates().entries().at(raw256(0x01)).isValid);
+    ASSERT_TRUE(st.mnstates().find_expected_payee().has_value());
+
+    // SML full snapshot @ H-1: same MN (proRegTxHash raw256(0x01)), still valid.
+    {
+        CSimplifiedMNListEntry e = sml_entry(0x01);   // proRegTxHash = raw256(0x01)
+        e.isValid = true;
+        m.on_mnlistdiff(diff_with_seed(uint256::ZERO, raw256(0x54), H - 1,
+                                       100'000'000LL, e));
+    }
+    EXPECT_TRUE(st.mnstates().entries().at(raw256(0x01)).isValid)
+        << "no flip while the SML agrees the MN is valid";
+
+    // Consensus PoSe ban lands as the NEXT incremental mnlistdiff: isValid=false.
+    // No special tx exists for it; the SML axis is the only place it surfaces.
+    {
+        CSimplifiedMNListEntry e = sml_entry(0x01);
+        e.isValid = false;
+        m.on_mnlistdiff(diff_with_seed(raw256(0x54), raw256(0x55), H,
+                                       100'000'001LL, e));
+    }
+
+    // The formerly-dead reconciler must have flipped the payee entry, so the
+    // banned MN is no longer projected as the expected payee.
+    EXPECT_FALSE(st.mnstates().entries().at(raw256(0x01)).isValid)
+        << "SML ban must reconcile onto the payee axis (dead-code wiring)";
+    EXPECT_FALSE(st.mnstates().find_expected_payee().has_value())
+        << "a banned MN must never be projected as expected payee";
+    // Position invariant (trap #2): the reconcile only touched the flipped
+    // entry; it never added or removed entries.
+    EXPECT_EQ(st.mnstates().size(), 1u);
+}
+
+// Call site 2 (on_mn_list_update): an SML ban already applied BEFORE the payee
+// axis is (re)seeded must be applied at seed time — the startup/reseed join,
+// robust to the seed-arrives-after-SML ordering.
+TEST(DashCoinStateMaintainer, SeedReconcileAppliesAlreadyPresentSmlBan) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+
+    // SML already carries the MN as BANNED, applied while the payee axis is
+    // still empty (so on_mnlistdiff's reconcile has nothing to flip yet).
+    {
+        CSimplifiedMNListEntry e = sml_entry(0x01);
+        e.isValid = false;
+        m.on_mnlistdiff(diff_with_seed(uint256::ZERO, raw256(0x54), H - 1,
+                                       100'000'000LL, e));
+    }
+    ASSERT_EQ(st.mnstates().size(), 0u);
+
+    // Now the payee axis is seeded valid (a checkpoint taken a moment before the
+    // ban still listed the MN valid). The seed-join reconcile must apply the
+    // SML's authoritative ban immediately, not wait for the next diff.
+    m.on_mn_list_update(single_mn(p2pkh_script(0x30)), H - 1);
+    EXPECT_FALSE(st.mnstates().entries().at(raw256(0x01)).isValid)
+        << "seed reconcile must apply the already-present SML ban at seed time";
+    EXPECT_FALSE(st.mnstates().find_expected_payee().has_value())
+        << "a banned MN must never be projected as expected payee";
+}

--- a/test/test_dash_mn_state.cpp
+++ b/test/test_dash_mn_state.cpp
@@ -1059,3 +1059,59 @@ TEST(DashMnState, SyncValidityFromSmlIdempotentAndSmlOnly) {
     EXPECT_EQ(r2.sml_only, 1u);
     EXPECT_EQ(r2.matched, 0u);
 }
+
+
+// --------------------------------------------------------------------------
+// Bug 14 selection-path guard. nPoSeBanHeight is write-only when picking a
+// payee, so a divergent persisted snapshot (isValid==true alongside a live
+// ban height -- reachable after a consensus PoSe ban that never appears as a
+// special tx) must be fail-closed OUT of BOTH selection scans, never paid on
+// the boolean alone. Pairs with the maintainer caller-guard tests
+// (MnlistdiffBanReconcilesOntoPayeeAxis / SeedReconcileAppliesAlreadyPresentSmlBan)
+// that prove sync_validity_from_sml() keeps a production caller.
+// --------------------------------------------------------------------------
+TEST(DashMnState, SelectionGuardExcludesValidButBannedSnapshot) {
+    MnStateMachine m;
+    uint256 banned = raw256_byte(0, 0x0A);
+    uint256 clean  = raw256_byte(0, 0x0B);
+
+    MNState sb; sb.isValid = true; sb.nRegisteredHeight = 2400000;
+    sb.nPoSeBanHeight = 2513418;               // live ban, yet bool left true
+    sb.scriptPayout.m_data = script_bytes(0x76, 25);
+
+    MNState sc; sc.isValid = true; sc.nRegisteredHeight = 2400001;
+    sc.nPoSeBanHeight = 0;                      // genuinely valid
+    sc.scriptPayout.m_data = script_bytes(0x77, 25);
+
+    m.load(std::vector<std::pair<uint256, MNState>>{{banned, sb}, {clean, sc}});
+
+    // find_expected_payee must skip the banned snapshot and pick the clean MN.
+    auto exp = m.find_expected_payee();
+    ASSERT_TRUE(exp.has_value());
+    EXPECT_EQ(*exp, clean);
+
+    // pick_paid_mn on the banned MN's own script must refuse it outright...
+    EXPECT_FALSE(m.pick_paid_mn(sb.scriptPayout.m_data).has_value());
+    // ...but still serve the clean MN on its script.
+    auto pk = m.pick_paid_mn(sc.scriptPayout.m_data);
+    ASSERT_TRUE(pk.has_value());
+    EXPECT_EQ(*pk, clean);
+}
+
+// The -1 / UINT32_MAX "never banned" sentinel must NOT read as a live ban --
+// the guard normalizes it exactly as the height scoring does.
+TEST(DashMnState, SelectionGuardTreatsSentinelBanHeightAsNeverBanned) {
+    MnStateMachine m;
+    uint256 h = raw256_byte(0, 0x0C);
+    MNState s; s.isValid = true; s.nRegisteredHeight = 2400000;
+    s.nPoSeBanHeight = 0xFFFFFFFFu;            // dashd protx -1 sentinel
+    s.scriptPayout.m_data = script_bytes(0x78, 25);
+    m.load(std::vector<std::pair<uint256, MNState>>{{h, s}});
+
+    auto exp = m.find_expected_payee();
+    ASSERT_TRUE(exp.has_value());
+    EXPECT_EQ(*exp, h);
+    auto pk = m.pick_paid_mn(s.scriptPayout.m_data);
+    ASSERT_TRUE(pk.has_value());
+    EXPECT_EQ(*pk, h);
+}


### PR DESCRIPTION
## Summary

Fixes the daemonless payee-desync (the block-viability gate for daemonless mining). The fix is a narrow two-line wiring change: call the already-existing, already-tested, but **never-invoked** reconciler `MnStateMachine::sync_validity_from_sml()`.

## Root cause (ninth instance of the wired-but-never-called class)

PoSe bans are **consensus-driven, not transaction-driven**. dashd's `CDeterministicMNManager` bans an MN when it crosses `MAX_PoSe_PENALTY`; that ban never appears as a special tx in any block. `apply_block()` walks special txs, so it can **never** observe one — the PAYEE `MnStateMachine` keeps a genuinely-banned MN at `isValid=true` forever, and `find_expected_payee()` (which correctly filters on `isValid`) deterministically projects the phantom-eligible node. The embedded template's payee then disagrees with dashd, the bridge cross-check fail-closes, the MN set never publishes, and the daemonless arm never becomes viable.

The two axes were both live and never joined:

| axis | source | carries |
|---|---|---|
| PAYEE (`MnStateMachine`) | seeded once from `protx list valid true` | full PoSe triple |
| SML (`CSimplifiedMNList`) | advances on **every** mnlistdiff | authoritative per-entry `isValid` |

The reconciler that fixes exactly this — `sync_validity_from_sml()` at `mn_state_machine.hpp:468` — existed, was unit-tested (`DashMnState.SyncValidityFromSml*`), was correct, and had **zero production callers**. Its own doc block promised the call "after every SML root MATCH and once at startup" — which never happened.

Because the seed uses `protx list valid true`, banned nodes are pre-filtered at startup; the desync only surfaces once a ban lands **after** seeding — which is why it looked height-specific and sparse (live-observed ~h2513489 against the h2513000 anchor).

## The fix — two call sites, both where the maintainer owns both axes

1. **`on_mnlistdiff()`** — after each accepted SML apply, reconcile the payee axis from the freshly-applied SML at `m_sml_current_height`. Catches a ban landing **after** the queue was seeded (the live defect).
2. **`on_mn_list_update()`** — after the payee axis is (re)seeded, reconcile against an already-present SML. Handles the seed-arrives-after-SML ordering (warm-loaded / live-advanced SML), so the join does not depend on a fragile fixed startup line racing the async seed.

Trap-compliance:
- **Only the boolean is reconciled.** The SML wire entry carries only `isValid`, not ban/revive heights; those are bounded by `current_height` per the function's field-ownership contract. No ban-height reconstruction.
- **Position is preserved.** `sync_validity_from_sml()` early-continues on entries whose `isValid` did not flip, so queue position for unchanged nodes is never perturbed; the reconcile never adds/removes entries.
- Guarded on a non-empty SML (an empty set is a gap, handled downstream).

Kept narrow — no state-machine restructuring. The `dashd` RPC fallback path is untouched.

## Tests

Two maintainer-level regressions pin the wiring end-to-end (both were impossible to pass before, since the reconciler was never called):

- `MnlistdiffBanReconcilesOntoPayeeAxis` — a ban arriving as a post-seed mnlistdiff flips the payee entry and drops it from `find_expected_payee` (call site 1).
- `SeedReconcileAppliesAlreadyPresentSmlBan` — an SML ban already applied before the seed is applied at seed time (call site 2).

Local (Debug, system deps): **17/17** `test_dash_coin_state_maintainer` + **30/30** `test_dash_mn_state` green. Log lines confirm firing: `[SML->PAYEE] validity reconcile: -1 banned` and `[SML->PAYEE] seed reconcile: -1 banned`.

## Gate

No self-merge — requesting integrator verify (oracle parity + full Linux x86_64 CI, no false-green) before an operator tap. Full-matrix CI has not run in the authoring sandbox; only the two affected targets were built/run locally.
