### PR TITLE
dash(embedded): reconcile PoSe validity from the SML into the payee axis

### DIFF
--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -234,10 +234,63 @@ public:
         // fetch and the first live full-block ingest were the soak's
         // 2-slot cursor lag -> bad-cb-payee at the address-group boundary).
         m_state.mnstates().load(std::move(mnstates), as_of_height);
+        // Reconcile the freshly-seeded payee axis against the SML we already
+        // hold (warm restart from SMLDb, or a seed arriving after the coin-P2P
+        // feed came up). Without this the two axes stay independent: the seed
+        // comes from `protx list valid true`, so it is correct AT its height,
+        // but any PoSe state the SML already knows about is not reflected.
+        // Idempotent and O(|SML|); a no-op when no SML is loaded yet.
+        reconcile_mn_validity("seed");
         if (!m_have_mn)
             demote();
         else
             republish();
+    }
+
+    /// Join the SML axis to the PAYEE axis: push the SML's authoritative
+    /// per-entry `isValid` into MnStateMachine so PoSe-banned masternodes are
+    /// excluded from the payment queue.
+    ///
+    /// WHY THIS EXISTS AS A CALL AND NOT AS LOGIC: MnStateMachine already
+    /// filters on `isValid` when projecting a payee, and
+    /// MnStateMachine::sync_validity_from_sml() already implements the
+    /// reconciliation correctly (both flip directions, ban/revive heights,
+    /// precedence of a precise tx-derived height over the SML approximation).
+    /// It simply had NO production caller, so the payee axis never learned
+    /// about a ban and kept projecting banned nodes until a reseed.
+    ///
+    /// That gap is not observable through apply_block(): a PoSe ban is
+    /// CONSENSUS-DRIVEN, not transaction-driven. It never appears as a special
+    /// transaction, so no amount of block folding can see it. The SML is the
+    /// only feed that carries it, which is why the join has to happen here.
+    ///
+    /// Live failure this closes (embedded mainnet, daemonless): a masternode
+    /// PoSe-banned at h=2513418 was still projected as the expected payee at
+    /// h=2513489. dashd paid the next eligible node, the coinbase cross-check
+    /// disagreed, the bridge replay fail-closed, the masternode set was never
+    /// published, per-template viability never passed, and every template
+    /// request fell through to an unarmed dashd arm. One uncalled function.
+    void reconcile_mn_validity(const char* reason) {
+        if (m_state.sml().mnList.empty())
+            return;
+        // Height the SML is current at, taken from the diff's own cbTx
+        // (authoritative off the wire). Only an upper bound for an implicit
+        // ban, which sync_validity_from_sml() accounts for — it will not
+        // overwrite a precise tx-derived height with this one.
+        if (m_sml_current_height == 0)
+            return;
+        auto r = m_state.mnstates().sync_validity_from_sml(
+            m_state.sml(), m_sml_current_height);
+        // Log only when something actually changed. A flip is rare (bans and
+        // revivals are), so a silent pass here is the expected steady state
+        // and logging every diff would bury the interesting case.
+        if (r.flipped_to_invalid || r.flipped_to_valid) {
+            LOG_INFO << "[MNS-SM] PoSe validity reconciled from SML ("
+                     << reason << ") @h=" << m_sml_current_height
+                     << ": -" << r.flipped_to_invalid << " banned, +"
+                     << r.flipped_to_valid << " revived (scanned "
+                     << r.scanned << ", matched " << r.matched << ")";
+        }
     }
 
     /// Reception path (mnlistdiff, SML axis — DAEMONLESS CCbTx source): apply a
@@ -413,6 +466,11 @@ public:
         // (NodeCoinState::make_embedded_work_inputs) compares this to the tip
         // we build on, and the next incremental diff's base must match it.
         m_state.set_sml_current_hash(diff.blockHash);
+        // Join the SML axis to the payee axis on EVERY applied diff. This has
+        // to run per-diff, not once at seed: masternode eligibility changes
+        // through the chain, so a set filtered once and reused would go stale
+        // exactly the way the unreconciled seed did.
+        reconcile_mn_validity("diff");
         LOG_INFO << "[SML] applied diff: SML +" << sml_r.added_or_updated
                  << " -" << sml_r.deleted << " => " << m_state.sml().size()
                  << " MNs; quorums +" << q_added << " -" << q_deleted

--- a/test/test_dash_coin_state_maintainer.cpp
+++ b/test/test_dash_coin_state_maintainer.cpp
@@ -734,3 +734,130 @@ TEST(DashCoinStateMaintainer, StaleZeroBaseSnapshotDoesNotCorruptTipSml) {
     EXPECT_EQ(st.sml_current_hash(), raw256(0x60))
         << "post-reorg cold resync must not be blocked by the stale-guard";
 }
+
+// ========================================================================
+// PoSe validity reconciliation (SML axis -> PAYEE axis).
+//
+// A PoSe ban is CONSENSUS-driven, not transaction-driven: it never appears as
+// a special transaction, so apply_block() structurally cannot observe one. The
+// SML is the only feed that carries it. Before this wiring the two axes were
+// independent — MnStateMachine::sync_validity_from_sml() existed, was correct,
+// and had zero production callers — so the payee queue kept projecting banned
+// masternodes until a reseed.
+//
+// Live failure reproduced here (embedded mainnet, daemonless): a masternode
+// PoSe-banned at h=2513418 was still projected as the expected payee at
+// h=2513489. dashd paid the next eligible node, the coinbase cross-check
+// disagreed, bridge replay fail-closed, the masternode set was never
+// published, and every template request fell through to an unarmed dashd arm.
+// ========================================================================
+
+// The doomed masternode is seeded with the LOWEST queue key so it is the
+// unambiguous argmin: without the reconciliation it wins the payee slot.
+TEST(DashCoinStateMaintainer, PoSeBannedMnIsExcludedFromPayeeProjection) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+
+    const uint256 doomed = raw256(0x40);   // banned at h=2513418
+    const uint256 healthy = raw256(0x60);
+
+    MNState s_doomed;
+    s_doomed.isValid           = true;     // correct AT the anchor height
+    s_doomed.nRegisteredHeight = 2000000;
+    s_doomed.nLastPaidHeight   = 2511423;  // lowest -> front of the queue
+    MNState s_healthy;
+    s_healthy.isValid           = true;
+    s_healthy.nRegisteredHeight = 2000000;
+    s_healthy.nLastPaidHeight   = 2512900;
+
+    // Anchor seed at h=2513000. The ban has not happened yet, so seeding it
+    // valid is CORRECT — this is why the defect hid: the seed comes from
+    // `protx list valid true` and is right at its own height.
+    m.on_mn_list_update({{doomed, s_doomed}, {healthy, s_healthy}}, 2513000);
+
+    ASSERT_EQ(st.mnstates().find_expected_payee(), doomed)
+        << "pre-ban the doomed MN must be the argmin, or this test proves nothing";
+
+    // The SML at h=2513489 reports the ban (isValid=false). Delivered through
+    // the ordinary reception path — no manual reconciliation call.
+    CSimplifiedMNListEntry e_doomed = sml_entry(0x40);
+    e_doomed.isValid = false;
+    CSimplifiedMNListEntry e_healthy = sml_entry(0x60);
+    CSimplifiedMNListDiff d;
+    d.baseBlockHash = uint256::ZERO;
+    d.blockHash     = raw256(0xAB);
+    d.mnList = {e_doomed, e_healthy};
+    dash::coin::vendor::CCbTx cb;
+    cb.nVersion = dash::coin::vendor::CCbTx::VERSION_CLSIG_AND_BALANCE;
+    cb.nHeight  = 2513489;
+    cb.creditPoolBalance = 100'000'000LL;
+    d.cbTx.version = 3;
+    d.cbTx.type    = 5;
+    d.cbTx.extra_payload = dash::coin::encode_cbtx(cb);
+    m.on_mnlistdiff(d);
+
+    EXPECT_FALSE(st.mnstates().entries().at(doomed).isValid)
+        << "the SML's authoritative isValid must reach the payee axis";
+    EXPECT_EQ(st.mnstates().entries().at(doomed).nPoSeBanHeight, 2513489u)
+        << "ban height recorded from the SML's current height (upper bound)";
+    EXPECT_EQ(st.mnstates().find_expected_payee(), healthy)
+        << "a PoSe-banned MN must never be projected as the expected payee";
+}
+
+// Guard against this reconciliation rotting back into dead code: it asserts
+// the CALL, not the function. Removing either production call site fails here
+// even though MnStateMachine's own unit tests keep passing — which is exactly
+// how the original defect survived a green suite.
+TEST(DashCoinStateMaintainer, MnlistdiffReceptionPerformsValidityReconciliation) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+
+    const uint256 mn = raw256(0x40);
+    MNState s;
+    s.isValid           = true;
+    s.nRegisteredHeight = 2000000;
+    s.nLastPaidHeight   = 2511423;
+    m.on_mn_list_update({{mn, s}}, 2513000);
+    ASSERT_TRUE(st.mnstates().entries().at(mn).isValid);
+
+    CSimplifiedMNListEntry e = sml_entry(0x40);
+    e.isValid = false;
+    m.on_mnlistdiff(diff_with_seed(uint256::ZERO, raw256(0xCD), 2513489,
+                                   100'000'000LL, e));
+
+    EXPECT_FALSE(st.mnstates().entries().at(mn).isValid)
+        << "on_mnlistdiff must reconcile validity — no manual call may be required";
+}
+
+// Eligibility changes THROUGH the chain, so reconciliation must run on every
+// applied diff rather than once. A revival after a ban must also propagate,
+// otherwise we would under-pay a masternode that dashd has already restored.
+TEST(DashCoinStateMaintainer, ValidityReconciliationTracksRevivalOnLaterDiff) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+
+    const uint256 mn = raw256(0x40);
+    MNState s;
+    s.isValid           = true;
+    s.nRegisteredHeight = 2000000;
+    s.nLastPaidHeight   = 2511423;
+    m.on_mn_list_update({{mn, s}}, 2513000);
+
+    CSimplifiedMNListEntry banned = sml_entry(0x40);
+    banned.isValid = false;
+    m.on_mnlistdiff(diff_with_seed(uint256::ZERO, raw256(0xC1), 2513489,
+                                   100'000'000LL, banned));
+    ASSERT_FALSE(st.mnstates().entries().at(mn).isValid);
+
+    CSimplifiedMNListEntry revived = sml_entry(0x40);
+    revived.isValid = true;
+    m.on_mnlistdiff(diff_with_seed(raw256(0xC1), raw256(0xC2), 2513600,
+                                   100'000'000LL, revived));
+
+    EXPECT_TRUE(st.mnstates().entries().at(mn).isValid)
+        << "an SML revival must restore payee eligibility";
+    EXPECT_EQ(st.mnstates().entries().at(mn).nPoSeBanHeight, 0u)
+        << "revival must clear the recorded ban height";
+    EXPECT_EQ(st.mnstates().entries().at(mn).nPoSeRevivedHeight, 2513600u)
+        << "revival height feeds the queue-position key and must be recorded";
+}


### PR DESCRIPTION
Closes #984.

## What was wrong

`MnStateMachine::sync_validity_from_sml()` was correct, tested, and had **zero production callers**. The payee axis was seeded once from `protx list valid true` and never learned about a masternode banned after that seed.

A PoSe ban is **consensus-driven, not transaction-driven**. It never appears as a special transaction, so `apply_block()` structurally cannot observe one no matter how carefully blocks are folded. The SML is the only feed that carries it — so the two axes have to be joined explicitly, and nothing joined them.

## Live failure this closes

Embedded mainnet, fully daemonless. A masternode PoSe-banned at **h=2513418** was still projected as the expected payee at **h=2513489**:

```
proTxHash          e8626fcd57f6394db6669ad6db6fd44c
PoSeBanHeight      2513418      <- banned 71 blocks before we projected it
PoSeRevivedHeight  2454297      <- an EARLIER revival; the trap
lastPaidHeight     2511423
```

Confirmed against a live dashd — population at that height was **valid 2066 / registered 2972**, and the projected node was in the registered set but not the valid one.

The cascade:

```
anchor 2068 MNs @h=2513000   (CORRECT — protx list valid @2513000 = 2068)
  -> bridge replaying h=2513001..2513557
  -> FAIL-CLOSED: bridge replay PAYEE DESYNC at h=2513489
  -> MN set NEVER published
  -> per-template viability never passes (arm=embedded IS selected)
  -> falls to dashd -> no creds -> serves anyway:
     arm=dashd-fallback h=0 mn_payee=(none)      [11 of 11 requests]
  -> wedges: cursor stuck at 2513552 while chain at 2513560
```

Both gates behaved correctly throughout. They were accurately reporting that our own projection had named an ineligible payee.

## The change

Two call sites plus a helper carrying the reasoning. No new logic — the reconciliation already existed and was already right about both flip directions, ban/revive heights, and the precedence of a precise tx-derived height over the SML's approximation.

- **Every applied diff**, not once at seed. Eligibility changes through the chain, so a set filtered once and reused goes stale exactly the way the unreconciled seed did.
- **After a seed lands**, to catch a warm restart where the SML is already loaded.

Logs only when something flips. Bans are rare; logging every diff would bury the interesting case.

## Verification

Tests were confirmed to **fail on master and pass on this branch** — not merely observed green.

Without the fix (master's `coin_state_maintainer.hpp`, tests kept):

```
[  FAILED  ] PoSeBannedMnIsExcludedFromPayeeProjection
      isValid           Actual: true    Expected: false
      nPoSeBanHeight    Which is: 0     Which is: 2513489
      find_expected_payee()  returns ...4140 (BANNED) instead of ...6160
[  FAILED  ] MnlistdiffReceptionPerformsValidityReconciliation
[  FAILED  ] ValidityReconciliationTracksRevivalOnLaterDiff
 3 FAILED TESTS
```

With the fix:

```
[MNS-SM] PoSe validity reconciled from SML (diff) @h=2513489: -1 banned, +0 revived (scanned 2, matched 2)
[MNS-SM] PoSe validity reconciled from SML (diff) @h=2513600: -0 banned, +1 revived (scanned 1, matched 1)
[  PASSED  ] 3 tests.
```

No regressions across adjacent suites:

| suite | result |
|---|---|
| `test_dash_coin_state_maintainer` | 18 passed (15 existing + 3 new) |
| `test_dash_mn_state` | 30 passed |
| `test_dash_embedded_gbt` | 58 passed |
| `test_dash_node_reception_wire` | 46 passed |

## The second test is the point

`MnlistdiffReceptionPerformsValidityReconciliation` asserts the **call**, not the function. Removing either production call site fails it *even though `MnStateMachine`'s own unit tests keep passing* — which is precisely how the original defect survived a green suite.

This is the ninth instance in eight days of machinery that is present, compiles, passes its tests, and is never invoked. The recurrence is worth guarding against directly, not just this one instance.

## Scope

- DASH tree only; per-coin isolation intact.
- Additive — 185 insertions, 0 deletions. No existing behaviour altered.
- Neither gate relaxed. The reconciliation *tightens* fail-closed by removing ineligible nodes before they can occupy a payment slot.

## Not in this PR

The reward-unsafe inversion is separate and still open: when no arm can produce a valid template the node **serves** `h=0` with no payee instead of **refusing**. Failing closed on the masternode set and then failing open on the template undoes the point of the first gate. Deliberately not bundled here.
