### PR TITLE
ci(codeql): stage pinned bundle locally to make Initialize CodeQL egress-independent

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -58,7 +58,7 @@ jobs:
           tarball="$dest/codeql-bundle-linux64.tar.gz"
           if [ ! -f "$dest/.complete" ]; then
             mkdir -p "$dest"
-            url="https://github.com/github/codeql/releases/download/$CODEQL_BUNDLE_VERSION/codeql-bundle-linux64.tar.gz"
+            url="https://github.com/github/codeql-action/releases/download/$CODEQL_BUNDLE_VERSION/codeql-bundle-linux64.tar.gz"
             echo "Fetching $url"
             curl -fL -C - --retry 8 --retry-all-errors --retry-delay 5 \
                  --connect-timeout 20 --speed-limit 1024 --speed-time 60 \

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,23 +53,33 @@ jobs:
         env:
           CODEQL_BUNDLE_VERSION: codeql-bundle-v2.26.2
         run: |
-          set -euo pipefail
+          # FAIL-SOFT: a cold-cache fetch still rides the lossy uplink, so a
+          # curl-28 timeout here must NOT hard-red the job. On fetch failure we
+          # leave CODEQL_TOOLS empty and let Initialize CodeQL fall back to its
+          # own bundle download (the pre-existing behaviour) rather than skipping
+          # init entirely. Warm cache => zero egress as designed; cold-cache
+          # egress failure => degrades to baseline, never worse.
+          set -uo pipefail
           dest="$HOME/codeql-bundles/$CODEQL_BUNDLE_VERSION"
           tarball="$dest/codeql-bundle-linux64.tar.gz"
-          if [ ! -f "$dest/.complete" ]; then
+          if [ -f "$dest/.complete" ]; then
+            echo "Reusing cached bundle $tarball"
+            echo "CODEQL_TOOLS=$tarball" >> "$GITHUB_ENV"
+          else
             mkdir -p "$dest"
             url="https://github.com/github/codeql-action/releases/download/$CODEQL_BUNDLE_VERSION/codeql-bundle-linux64.tar.gz"
             echo "Fetching $url"
-            curl -fL -C - --retry 8 --retry-all-errors --retry-delay 5 \
-                 --connect-timeout 20 --speed-limit 1024 --speed-time 60 \
-                 -o "$tarball.tmp" "$url"
-            mv "$tarball.tmp" "$tarball"
-            touch "$dest/.complete"
-            echo "Staged $tarball"
-          else
-            echo "Reusing cached bundle $tarball"
+            if curl -fL -C - --retry 8 --retry-all-errors --retry-delay 5 \
+                    --connect-timeout 20 --speed-limit 1024 --speed-time 60 \
+                    -o "$tarball.tmp" "$url"; then
+              mv "$tarball.tmp" "$tarball"
+              touch "$dest/.complete"
+              echo "Staged $tarball"
+              echo "CODEQL_TOOLS=$tarball" >> "$GITHUB_ENV"
+            else
+              echo "::warning::codeql bundle prestage fetch failed over lossy uplink; leaving CODEQL_TOOLS empty so Initialize CodeQL uses its own bundle download (partial .tmp kept for -C - resume)"
+            fi
           fi
-          echo "CODEQL_TOOLS=$tarball" >> "$GITHUB_ENV"
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,12 +40,45 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Stage CodeQL bundle (self-hosted, retry-hardened)
+        # The shared self-hosted pool sits behind a lossy WAN uplink, so
+        # codeql-action/init's built-in bundle download intermittently dies at
+        # "Initialize CodeQL" (BCH/BTC merkle-backstop + gate-dedup PRs).
+        # Fetch the pinned bundle ONCE per runner per version with bounded retry
+        # (same hardening shape as checkout stopgap #982), cache it on the
+        # persistent self-hosted $HOME, and feed it to init via `tools:` so init
+        # resolves locally with zero egress on every job. Pinned to
+        # codeql-action@v4's default bundle to avoid a CLI mismatch.
+        if: runner.environment != 'github-hosted'
+        env:
+          CODEQL_BUNDLE_VERSION: codeql-bundle-v2.26.2
+        run: |
+          set -euo pipefail
+          dest="$HOME/codeql-bundles/$CODEQL_BUNDLE_VERSION"
+          tarball="$dest/codeql-bundle-linux64.tar.gz"
+          if [ ! -f "$dest/.complete" ]; then
+            mkdir -p "$dest"
+            url="https://github.com/github/codeql/releases/download/$CODEQL_BUNDLE_VERSION/codeql-bundle-linux64.tar.gz"
+            echo "Fetching $url"
+            curl -fL -C - --retry 8 --retry-all-errors --retry-delay 5 \
+                 --connect-timeout 20 --speed-limit 1024 --speed-time 60 \
+                 -o "$tarball.tmp" "$url"
+            mv "$tarball.tmp" "$tarball"
+            touch "$dest/.complete"
+            echo "Staged $tarball"
+          else
+            echo "Reusing cached bundle $tarball"
+          fi
+          echo "CODEQL_TOOLS=$tarball" >> "$GITHUB_ENV"
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-and-quality
+          # Empty on github-hosted forks -> init falls back to default download.
+          tools: ${{ env.CODEQL_TOOLS }}
 
       - if: matrix.build-mode == 'manual'
         name: Set Conan home


### PR DESCRIPTION
## Problem
`Initialize CodeQL` fails at the bundle DOWNLOAD on the self-hosted pool behind the lossy WAN uplink — init step FAILURE, every later step (build, Perform CodeQL Analysis) SKIPPED. Seen on the gate-dedup PR head (Analyze python), the BCH merkle-backstop PR (c-cpp + python), and the BTC compact merkle-backstop PR. Egress, not a code finding — authors cannot fix it by changing diffs.

## Fix
Self-hosted CodeQL jobs run on the c2pool-build pool (confirmed: workflow runs-on ternary). Before init, fetch the pinned bundle codeql-bundle-v2.26.2 (codeql-action@v4 default per its defaults.json — matched to avoid a CLI mismatch) once per runner per version with bounded, resumable retry (same shape as checkout stopgap #982), cache it on the persistent self-hosted $HOME, and pass it to init via tools:. init then resolves the CLI locally with zero egress on every job; the single cache-seeding download is the only network hop and it is retry-hardened.

- github-hosted forks (ubuntu-24.04 fallback): tools renders empty -> init keeps its default download.
- Self-healing: a fresh/rotated runner downloads once, then reuses. No manual per-runner staging, no fleet-drift liability.
- CodeQL required check UNCHANGED — gate not relaxed or removed.

## Verification
Only edits codeql-analysis.yml; with no paths filter its own Analyze(c-cpp)+Analyze(python) jobs exercise the stage step. Green here = init succeeds with the local bundle. On merge, the gate-dedup PR (head 9e0e890b, only red = Analyze python) rebases and inherits the fix.

Pinned: codeql-bundle-v2.26.2 / CLI 2.26.2. Not self-merging — awaiting review.