### PR TITLE
proto(v37): M4 superlight-sync T17-T19 -- fork-choice, identity-leg payout, withhold timeout

### DIFF
--- a/proto/m4-sync/harness/t17_delta_tail_pow_forkchoice.py
+++ b/proto/m4-sync/harness/t17_delta_tail_pow_forkchoice.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""M4 T17: delta-tail acceptance — per-share PoW + highest-cumulative-work fork choice.
+
+Closes the ONE real red-team finding (F1) for the superlight cold-start model by
+converting its *stated* defense into a *tested* one with a deterministic golden vector.
+
+F1 (adversarial cold-start red-team finding): the PoW-anchored delta tail
+(`tip-D_f`..`tip`) was applied to the trustless snapshot on block-HEADER PoW +
+committed-root only, with NO per-share work check. A sybil serving the tail can inject
+forged shares under valid block headers; the validator accepts a non-canonical
+(non-final) live-set view. The red-team's stated defense:
+
+    "delta-tail acceptance must do per-share PoW + pick the highest-cumulative-work
+     fork, not header-PoW + committed-root only."
+
+This harness builds the smallest faithful model of that defense and proves it rejects
+the forged-tail families the red-team named:
+
+  V (validator) holds a trustless FINALIZED boundary hash B = roots @ tip-D_f (root-
+  checked, safe). It must extend its view across the NON-final tail to `tip`. A peer
+  serves a candidate tail = an ordered list of shares, each carrying its own block
+  header with its own PoW (hashPrevBlock => the prior share's id; share PoW <= target).
+
+  accept_tail(tail, B, target):
+    1. CHAIN: share[0].prev == B; share[k].prev == id(share[k-1]).  (no splicing)
+    2. PER-SHARE PoW: id(share) = sha256(header) <= target for EVERY share.
+    3. cumulative work = sum over shares of work(target_k), work = (2^256 // (target+1)).
+    fork_choice(candidates) := the VALID (chained + every-share-PoW) tail of MAX
+    cumulative work. Ties broken by lexicographically-smallest tip id (deterministic).
+
+  The header-PoW+root-only rule the red-team faulted = step 1 + a root check only,
+  WITHOUT step 2/3. T17 shows that rule accepts forged tails that the full rule rejects.
+
+Forged-tail families tested (all from a minority-hashrate sybil):
+  A. NO per-share PoW  — shares with nonces that do NOT satisfy target. Rejected at
+     step 2. (The exact case the old header-only rule MISSED.)
+  B. spliced/unchained — a real honest prefix + a forged suffix whose prev link is
+     rewritten. Rejected at step 1.
+  C. valid-PoW minority fork — the sybil really mines a competing tail, but at its
+     minority hashrate to an EASIER target / fewer shares. Passes steps 1+2 but loses
+     fork choice on cumulative work (step 3). This is the only family that survives
+     verification; cumulative-work choice is what defeats it.
+
+PoW is modeled by real nonce-grinding to a leading-zero-bits target (sha256, no RNG;
+nonce counts up from 0 -> fully deterministic). "Hashrate" = grind budget; the honest
+chain is given strictly more cumulative work than the minority sybil, as in the threat
+model's >50%-honest-share-work assumption (same floor M1's finality overlay stands on).
+
+Run: python3 t17_delta_tail_pow_forkchoice.py
+Deterministic: sha256 only, no randomness, no wall-clock in the accept/fork-choice path.
+"""
+from __future__ import annotations
+import argparse, hashlib, json, sys
+
+MAX256 = 1 << 256
+
+
+def sha(*parts: bytes) -> bytes:
+    h = hashlib.sha256()
+    for p in parts:
+        h.update(p)
+    return h.digest()
+
+
+def target_for_bits(bits: int) -> int:
+    """A PoW target of `bits` leading zero bits: id <= target iff top `bits` bits zero."""
+    return (1 << (256 - bits)) - 1
+
+
+def work_of(target: int) -> int:
+    """Expected hashes to beat `target` = 2^256 / (target+1); the share's work weight."""
+    return MAX256 // (target + 1)
+
+
+# --- a share = its block header (prev link, payload commitment, nonce) + claimed target ---
+def share_id(prev: bytes, payload: bytes, nonce: int) -> bytes:
+    return sha(b"v37-share", prev, payload, nonce.to_bytes(8, "little"))
+
+
+def mine_share(prev: bytes, payload: bytes, target: int, start: int = 0):
+    """Grind nonce up from `start` until share_id <= target. Deterministic. Returns the
+    valid share dict and the grind cost (hashes tried) so we can model hashrate budget."""
+    nonce = start
+    while True:
+        sid = share_id(prev, payload, nonce)
+        if int.from_bytes(sid, "big") <= target:
+            return {"prev": prev, "payload": payload, "nonce": nonce,
+                    "target": target, "id": sid}, (nonce - start + 1)
+        nonce += 1
+
+
+def build_tail(boundary: bytes, n: int, bits: int, tag: bytes):
+    """Honestly mine a chained tail of n shares from `boundary` at `bits` difficulty."""
+    target = target_for_bits(bits)
+    tail, prev = [], boundary
+    for k in range(n):
+        payload = sha(tag, k.to_bytes(4, "little"))   # deterministic per-share payload
+        s, _cost = mine_share(prev, payload, target)
+        tail.append(s)
+        prev = s["id"]
+    return tail
+
+
+# ------------------------------ the defense under test ------------------------------
+def chained(tail, boundary: bytes) -> bool:
+    """Step 1: tail[0] extends the finalized boundary and every link is intact."""
+    prev = boundary
+    for s in tail:
+        if s["prev"] != prev:
+            return False
+        # the id must be the actual hash of the claimed header (no asserted ids)
+        if s["id"] != share_id(s["prev"], s["payload"], s["nonce"]):
+            return False
+        prev = s["id"]
+    return True
+
+
+def every_share_pow(tail) -> bool:
+    """Step 2: EVERY share's id satisfies its own claimed target (per-share PoW)."""
+    return all(int.from_bytes(s["id"], "big") <= s["target"] for s in tail)
+
+
+def cumulative_work(tail) -> int:
+    """Step 3: total work = sum of per-share work weights."""
+    return sum(work_of(s["target"]) for s in tail)
+
+
+def accept_tail_full(tail, boundary: bytes):
+    """FULL rule (F1 defense): chain + per-share PoW gate, then return work for fork
+    choice. Returns (valid, work). A tail failing chain or per-share PoW is invalid."""
+    if not chained(tail, boundary):
+        return (False, 0, "unchained/spliced")
+    if not every_share_pow(tail):
+        return (False, 0, "per-share-PoW-fail")
+    return (True, cumulative_work(tail), "ok")
+
+
+def accept_tail_header_only(tail, boundary: bytes):
+    """OLD rule the red-team faulted: chain + root, NO per-share PoW, NO work choice.
+    Models 'header-PoW + committed-root only' — accepts anything that merely chains."""
+    return (chained(tail, boundary), 0, "header-only")
+
+
+def fork_choice(candidates, boundary: bytes):
+    """Pick the VALID tail of max cumulative work; tie-break on smallest tip id."""
+    scored = []
+    for name, tail in candidates:
+        valid, work, why = accept_tail_full(tail, boundary)
+        scored.append((name, tail, valid, work, why))
+    valids = [c for c in scored if c[2]]
+    if not valids:
+        return None, scored
+    best = max(valids, key=lambda c: (c[3], [-b for b in c[1][-1]["id"]]))
+    return best, scored
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--df", type=int, default=12, help="tail length D_f (shares)")
+    ap.add_argument("--bits", type=int, default=16, help="honest per-share PoW bits")
+    args = ap.parse_args()
+
+    # Trustless finalized boundary roots @ tip-D_f (root-checked upstream; safe anchor).
+    boundary = sha(b"finalized-boundary-roots@tip-Df")
+
+    # HONEST tail: D_f shares, full difficulty (majority-work chain).
+    honest = build_tail(boundary, args.df, args.bits, b"honest")
+
+    # Family A: forged tail, NO valid per-share PoW (nonces=0, ids won't meet target).
+    forgedA, prev = [], boundary
+    tgt = target_for_bits(args.bits)
+    for k in range(args.df):
+        payload = sha(b"sybilA", k.to_bytes(4, "little"))
+        nonce = 0  # no grind => overwhelmingly fails the leading-zero target
+        forgedA.append({"prev": prev, "payload": payload, "nonce": nonce,
+                        "target": tgt, "id": share_id(prev, payload, nonce)})
+        prev = forgedA[-1]["id"]
+
+    # Family B: honest prefix + spliced forged suffix (prev link rewritten to skip).
+    forgedB = [dict(s) for s in honest[: args.df // 2]]
+    spliced = build_tail(boundary, args.df - args.df // 2, args.bits, b"sybilB")
+    # rewrite the splice point's prev to a WRONG (non-matching) ancestor
+    spliced[0]["prev"] = sha(b"wrong-ancestor")
+    spliced[0]["id"] = share_id(spliced[0]["prev"], spliced[0]["payload"], spliced[0]["nonce"])
+    # the spliced[0] was mined against `boundary`, so its id no longer meets target either,
+    # but family B is about the CHAIN break — re-mine so PoW holds, isolating the splice.
+    spliced[0], _ = mine_share(spliced[0]["prev"], spliced[0]["payload"], target_for_bits(args.bits))
+    # relink the rest of the spliced suffix onto the (wrong-ancestor) re-mined head
+    relinked, p = [spliced[0]], spliced[0]["id"]
+    for s in spliced[1:]:
+        ns, _ = mine_share(p, s["payload"], target_for_bits(args.bits))
+        relinked.append(ns)
+        p = ns["id"]
+    forgedB = forgedB + relinked  # prefix tip id != relinked[0].prev => chain break
+
+    # Family C: sybil REALLY mines a competing valid tail, but minority hashrate =>
+    # easier target (fewer bits) and/or fewer shares => less cumulative work.
+    sybil_bits = args.bits - 4            # 16x easier per share (minority hashrate)
+    sybil_len = max(1, args.df - 4)       # and a shorter tail
+    forgedC = build_tail(boundary, sybil_len, sybil_bits, b"sybilC")
+
+    candidates = [("honest", honest), ("forgedA_nopow", forgedA),
+                  ("forgedB_spliced", forgedB), ("forgedC_minoritywork", forgedC)]
+
+    print("=== M4 T17: delta-tail per-share PoW + cumulative-work fork choice ===")
+    print(f"D_f={args.df} shares, honest bits={args.bits}, "
+          f"sybilC bits={sybil_bits} len={sybil_len}\n")
+
+    # 1) Per-candidate verdict under the OLD header-only rule vs the FULL F1 defense.
+    print("candidate                 chained  per-share-PoW  cum-work        full-rule  header-only")
+    for name, tail in candidates:
+        ch = chained(tail, boundary)
+        pw = every_share_pow(tail)
+        cw = cumulative_work(tail) if (ch and pw) else 0
+        full_ok = ch and pw
+        hdr_ok = accept_tail_header_only(tail, boundary)[0]
+        print(f"{name:24s}  {str(ch):5s}    {str(pw):5s}          "
+              f"{cw:<14d}  {'ACCEPT' if full_ok else 'reject':9s}  "
+              f"{'ACCEPT' if hdr_ok else 'reject'}")
+
+    # 2) Fork choice across all candidates under the FULL rule.
+    best, scored = fork_choice(candidates, boundary)
+    print()
+    winner = best[0] if best else None
+    print(f"fork_choice winner (max valid cumulative work): {winner}")
+
+    # 3) Assertions — the golden invariants T17 pins.
+    res = {c[0]: {"valid": c[2], "work": c[3], "why": c[4]} for c in scored}
+    checks = {
+        "honest_accepted":          res["honest"]["valid"] is True,
+        "forgedA_rejected_nopow":   res["forgedA_nopow"]["valid"] is False
+                                     and res["forgedA_nopow"]["why"] == "per-share-PoW-fail",
+        "forgedB_rejected_splice":  res["forgedB_spliced"]["valid"] is False
+                                     and res["forgedB_spliced"]["why"] == "unchained/spliced",
+        "forgedC_valid_but_loses":  res["forgedC_minoritywork"]["valid"] is True
+                                     and res["forgedC_minoritywork"]["work"] < res["honest"]["work"],
+        "forkchoice_picks_honest":  winner == "honest",
+        # the crux: the OLD header-only rule WOULD have accepted forgedA (the F1 bug)
+        "headeronly_accepts_forgedA": accept_tail_header_only(forgedA, boundary)[0] is True,
+        "fullrule_rejects_forgedA":   res["forgedA_nopow"]["valid"] is False,
+    }
+    print("\n--- golden invariants ---")
+    allok = True
+    for k, v in checks.items():
+        print(f"  [{'PASS' if v else 'FAIL'}] {k}")
+        allok = allok and v
+
+    # Golden vector: deterministic ids + work, stable across runs (no RNG/clock).
+    golden = {
+        "boundary": boundary.hex(),
+        "honest_tip": honest[-1]["id"].hex(),
+        "honest_cum_work": res["honest"]["work"],
+        "sybilC_cum_work": res["forgedC_minoritywork"]["work"],
+        "work_ratio_honest_over_sybilC": round(
+            res["honest"]["work"] / max(1, res["forgedC_minoritywork"]["work"]), 3),
+        "winner": winner,
+    }
+    print("\n--- golden vector ---")
+    print(json.dumps(golden, indent=2))
+
+    print(f"\nRESULT: {'ALL PASS' if allok else 'FAIL'} — "
+          f"F1 defense (per-share PoW + cumulative-work fork choice) "
+          f"{'TESTED & HOLDS' if allok else 'BROKEN'}.")
+    sys.exit(0 if allok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/proto/m4-sync/harness/t18_identity_leg_sig_payout.py
+++ b/proto/m4-sync/harness/t18_identity_leg_sig_payout.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""M5 T18: delta-tail acceptance — the SIGNATURE / IDENTITY leg of F1.
+
+T17 closed the WORK leg of red-team finding F1 (per-share PoW + cumulative-work fork choice).
+T17 explicitly carved out the IDENTITY leg:
+
+    "The signature/identity leg of F1 (info_digest -> committed payout-descriptor key) is
+     NOT modeled here ... sig-verification of the carried PayoutDescriptor stays the M5
+     testbed item."
+
+This harness closes that leg, mirroring T17's shape: a deterministic golden vector that
+proves an honest tail is ACCEPTED and every forged / mismatched-identity tail is REJECTED.
+
+WHERE THE TWO LEGS DIVIDE:
+  - T17 (work leg) binds WHAT WORK was done: per-share PoW over the share header; fork
+    choice on cumulative work. It stops a sybil injecting un-mined shares.
+  - T18 (identity leg) binds WHO GETS PAID: each share carries a PayoutDescriptor
+    (the payout key + script type). The validator must be sure the payout in the
+    non-final tail belongs to the miner who actually did that share's work — not to a
+    sybil who rewrote the payout target while relaying the tail.
+
+THE BINDING (the F1 identity defense, stated -> tested here):
+  A share's PoW-committed payload includes `info_digest = H(PayoutDescriptor)`. Acceptance
+  of a tail share requires BOTH:
+    (S1) COMMITMENT: H(share.payout_descriptor) == share.info_digest, and info_digest is
+         part of the payload the share_id (and thus the PoW) commits to. So the descriptor
+         cannot be swapped without recomputing share_id -> redoing the per-share PoW.
+    (S2) SIGNATURE: share.sig verifies, under the pubkey IN share.payout_descriptor, over
+         the canonical signing message (the share_id). Only the descriptor's key-holder
+         can produce it; a sybil relaying the tail cannot forge it for a key it lacks.
+  The full acceptance rule is T17's (chained + per-share PoW) AND (S1) AND (S2).
+
+FORGED / MISMATCHED-IDENTITY FAMILIES (all from a relay sybil that did NOT do the work):
+  A. PAYOUT-REDIRECT, stale commitment — sybil rewrites payout_descriptor to its own key
+     to steal the payout, but leaves info_digest (the honest commitment) untouched.
+     Rejected at S1 (H(desc') != info_digest). The canonical theft attempt.
+  B. FORGED SIGNATURE — descriptor is the honest miner's key, but the sig is invalid /
+     re-used / produced by the sybil (which lacks the private key). Rejected at S2.
+  C. SELF-CONSISTENT REWRITE (the cross-leg crux) — sybil rewrites the descriptor to its
+     OWN key, recomputes info_digest to match, AND self-signs with its own key. The
+     identity leg ALONE (S1+S2) now PASSES — it looks internally consistent. But
+     info_digest is inside the PoW-committed payload, so recomputing it changes share_id;
+     the honest nonce no longer meets target (PoW breaks) and the chain link to the next
+     share breaks. Rejected only by the COMPOSED rule (T17 work leg). This is the proof
+     that the identity leg is sound ONLY because it is bound into the work commitment:
+     redirecting the payout forces the sybil to re-mine at honest difficulty.
+  D. UNBOUND-KEY — descriptor's key != the key that signed (signer mismatch). Rejected
+     at S2 (verify under the descriptor key fails).
+  HONEST — committed descriptor, valid signature, valid PoW, chained -> ACCEPT.
+
+Mirrors T17's crux assertion: an IDENTITY-ONLY rule that checks S1+S2 but does NOT bind
+info_digest into the PoW (i.e. treats the descriptor as a free side-field) ACCEPTS the
+payout-redirect family C, while the composed rule REJECTS it.
+
+ed25519 (RFC 8032) signatures are DETERMINISTIC: same key + message -> same 64-byte sig.
+Keys are derived from fixed seeds via sha256 (no RNG). So the golden vector is
+sha256-identical across runs, exactly like T17.
+
+Run: python3 t18_identity_leg_sig_payout.py
+"""
+from __future__ import annotations
+import argparse, hashlib, json, sys
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey, Ed25519PublicKey)
+from cryptography.exceptions import InvalidSignature
+
+MAX256 = 1 << 256
+
+
+def sha(*parts: bytes) -> bytes:
+    h = hashlib.sha256()
+    for p in parts:
+        h.update(p)
+    return h.digest()
+
+
+def target_for_bits(bits: int) -> int:
+    return (1 << (256 - bits)) - 1
+
+
+def work_of(target: int) -> int:
+    return MAX256 // (target + 1)
+
+
+# ----------------------------- identity (deterministic) -----------------------------
+def key_from_seed(label: bytes) -> Ed25519PrivateKey:
+    """Deterministic ed25519 private key from a fixed label (sha256 -> 32-byte seed)."""
+    return Ed25519PrivateKey.from_private_bytes(sha(b"v37-id-seed", label))
+
+
+def pub_bytes(sk: Ed25519PrivateKey) -> bytes:
+    return sk.public_key().public_bytes_raw()
+
+
+def payout_descriptor(pubkey: bytes, script_type: str) -> dict:
+    """Who gets paid: a payout key + its script type (byte-denominated, per M2 h_min)."""
+    return {"pubkey": pubkey.hex(), "script_type": script_type}
+
+
+def descriptor_bytes(desc: dict) -> bytes:
+    """Canonical serialization of the descriptor for hashing (sorted, deterministic)."""
+    return json.dumps(desc, sort_keys=True, separators=(",", ":")).encode()
+
+
+def info_digest_of(desc: dict) -> bytes:
+    return sha(b"v37-info-digest", descriptor_bytes(desc))
+
+
+# --- a share = PoW-committed payload (info_digest is INSIDE it) + descriptor + sig ---
+def payload_commit(info_digest: bytes, k: int) -> bytes:
+    """The PoW-committed payload. info_digest (the payout binding) is part of it, so any
+    descriptor swap that updates info_digest changes the payload -> changes share_id."""
+    return sha(b"v37-payload", info_digest, k.to_bytes(4, "little"))
+
+
+def share_id(prev: bytes, payload: bytes, nonce: int) -> bytes:
+    return sha(b"v37-share", prev, payload, nonce.to_bytes(8, "little"))
+
+
+def mine_share(prev: bytes, payload: bytes, target: int, start: int = 0):
+    nonce = start
+    while True:
+        sid = share_id(prev, payload, nonce)
+        if int.from_bytes(sid, "big") <= target:
+            return nonce, sid
+        nonce += 1
+
+
+def build_share(prev: bytes, k: int, bits: int, sk: Ed25519PrivateKey, script_type: str):
+    """Honestly build share k: descriptor = sk's payout, commit info_digest into the PoW
+    payload, grind nonce, then sign the share_id with sk (identity binding)."""
+    target = target_for_bits(bits)
+    desc = payout_descriptor(pub_bytes(sk), script_type)
+    info = info_digest_of(desc)
+    payload = payload_commit(info, k)
+    nonce, sid = mine_share(prev, payload, target)
+    sig = sk.sign(sid)                       # sign over the share_id (canonical msg)
+    return {"prev": prev, "k": k, "info_digest": info, "payout_descriptor": desc,
+            "payload": payload, "nonce": nonce, "target": target, "id": sid,
+            "sig": sig.hex()}
+
+
+def build_tail(boundary: bytes, n: int, bits: int, sk: Ed25519PrivateKey,
+               script_type: str = "p2wpkh"):
+    tail, prev = [], boundary
+    for k in range(n):
+        s = build_share(prev, k, bits, sk, script_type)
+        tail.append(s)
+        prev = s["id"]
+    return tail
+
+
+# --------------------- the work leg (T17, reused) + identity leg ---------------------
+def chained(tail, boundary: bytes) -> bool:
+    prev = boundary
+    for s in tail:
+        if s["prev"] != prev:
+            return False
+        if s["id"] != share_id(s["prev"], s["payload"], s["nonce"]):
+            return False
+        prev = s["id"]
+    return True
+
+
+def every_share_pow(tail) -> bool:
+    return all(int.from_bytes(s["id"], "big") <= s["target"] for s in tail)
+
+
+def commitment_binds(tail) -> bool:
+    """S1: the carried descriptor hashes to info_digest, AND info_digest is the one the
+    PoW-committed payload commits to (payload == payload_commit(info_digest, k))."""
+    for s in tail:
+        if info_digest_of(s["payout_descriptor"]) != s["info_digest"]:
+            return False
+        if s["payload"] != payload_commit(s["info_digest"], s["k"]):
+            return False
+    return True
+
+
+def signatures_valid(tail) -> bool:
+    """S2: each sig verifies under the pubkey IN that share's descriptor, over share_id."""
+    for s in tail:
+        try:
+            pk = Ed25519PublicKey.from_public_bytes(
+                bytes.fromhex(s["payout_descriptor"]["pubkey"]))
+            pk.verify(bytes.fromhex(s["sig"]), s["id"])
+        except (InvalidSignature, ValueError):
+            return False
+    return True
+
+
+def accept_tail_composed(tail, boundary: bytes):
+    """FULL rule = T17 work leg (chain + per-share PoW) AND identity leg (S1 commitment +
+    S2 signature). Returns (valid, why)."""
+    if not chained(tail, boundary):
+        return (False, "unchained/spliced")
+    if not every_share_pow(tail):
+        return (False, "per-share-PoW-fail")
+    if not commitment_binds(tail):
+        return (False, "descriptor-commitment-mismatch")
+    if not signatures_valid(tail):
+        return (False, "bad-signature")
+    return (True, "ok")
+
+
+def accept_tail_identity_only(tail, boundary: bytes):
+    """The WEAK rule the identity-leg crux faults: verify S1+S2 (descriptor self-consistent
+    + signed) but treat the descriptor as a FREE side-field NOT bound into PoW — i.e. skip
+    the work leg's commitment that info_digest lives inside the mined payload. Models a node
+    that trusts a 'self-consistent, signed' payout without re-checking it was the mined one.
+    Here: chained-by-prev only + S1 + S2, NO per-share-PoW re-grind requirement."""
+    # accept if descriptor hashes to its own info_digest and the sig verifies — even if the
+    # payload/PoW no longer matches (descriptor was swapped post-mining).
+    for s in tail:
+        if info_digest_of(s["payout_descriptor"]) != s["info_digest"]:
+            return (False, "id-only-commit-fail")
+    return (signatures_valid(tail), "identity-only")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--df", type=int, default=12, help="tail length D_f (shares)")
+    ap.add_argument("--bits", type=int, default=16, help="per-share PoW bits")
+    args = ap.parse_args()
+
+    boundary = sha(b"finalized-boundary-roots@tip-Df")
+    honest_sk = key_from_seed(b"honest-miner")
+    sybil_sk = key_from_seed(b"relay-sybil")
+
+    # HONEST tail.
+    honest = build_tail(boundary, args.df, args.bits, honest_sk)
+
+    # Family A: PAYOUT-REDIRECT, stale commitment. Take honest, rewrite each descriptor's
+    # pubkey to the sybil's (steal payout) but DO NOT touch info_digest/payload/sig.
+    forgedA = [dict(s) for s in honest]
+    for s in forgedA:
+        d = dict(s["payout_descriptor"]); d["pubkey"] = pub_bytes(sybil_sk).hex()
+        s["payout_descriptor"] = d              # info_digest now stale -> S1 fails
+
+    # Family B: FORGED SIGNATURE. Honest descriptor, but replace each sig with the sybil's
+    # signature over the same share_id (sybil lacks the honest private key).
+    forgedB = [dict(s) for s in honest]
+    for s in forgedB:
+        s["sig"] = sybil_sk.sign(s["id"]).hex()  # verifies under sybil key, not honest -> S2 fails
+
+    # Family C: SELF-CONSISTENT REWRITE (cross-leg crux). Sybil swaps descriptor to its own
+    # key, recomputes info_digest, recomputes payload, self-signs — identity leg consistent.
+    # But it does NOT re-grind PoW (re-mining at honest difficulty is the whole cost it
+    # avoids), so the kept honest nonce no longer meets target and the chain link breaks.
+    forgedC, prev = [], boundary
+    for s in honest:
+        d = payout_descriptor(pub_bytes(sybil_sk), s["payout_descriptor"]["script_type"])
+        info = info_digest_of(d)
+        payload = payload_commit(info, s["k"])
+        nonce = s["nonce"]                       # KEEP honest nonce (no re-grind)
+        sid = share_id(prev, payload, nonce)     # id changes -> PoW almost surely fails
+        sig = sybil_sk.sign(sid).hex()           # self-signed: S1+S2 hold
+        forgedC.append({"prev": prev, "k": s["k"], "info_digest": info,
+                        "payout_descriptor": d, "payload": payload, "nonce": nonce,
+                        "target": s["target"], "id": sid, "sig": sig})
+        prev = sid                               # chain forgedC internally consistently
+
+    # Family D: UNBOUND-KEY. Descriptor advertises honest key, signer is the sybil, and
+    # info_digest matches the (honest-key) descriptor -> S1 passes, S2 fails on key mismatch.
+    forgedD = [dict(s) for s in honest]
+    for s in forgedD:
+        s["sig"] = sybil_sk.sign(s["id"]).hex()  # signer != descriptor.pubkey
+
+    candidates = [("honest", honest), ("forgedA_redirect", forgedA),
+                  ("forgedB_forgedsig", forgedB), ("forgedC_selfconsistent", forgedC),
+                  ("forgedD_unboundkey", forgedD)]
+
+    print("=== M5 T18: delta-tail identity leg — payout-descriptor commitment + signature ===")
+    print(f"D_f={args.df} shares, bits={args.bits}\n")
+    print("candidate                  chain  pow   S1-commit  S2-sig   COMPOSED   id-only")
+    res = {}
+    for name, tail in candidates:
+        ch = chained(tail, boundary)
+        pw = every_share_pow(tail)
+        s1 = commitment_binds(tail)
+        s2 = signatures_valid(tail)
+        comp_ok, why = accept_tail_composed(tail, boundary)
+        id_only_ok, _ = accept_tail_identity_only(tail, boundary)
+        res[name] = {"valid": comp_ok, "why": why, "id_only": id_only_ok}
+        print(f"{name:25s}  {str(ch):5s} {str(pw):5s} {str(s1):9s} {str(s2):6s} "
+              f"{'ACCEPT' if comp_ok else 'reject':9s} "
+              f"{'ACCEPT' if id_only_ok else 'reject'}")
+
+    checks = {
+        "honest_accepted":             res["honest"]["valid"] is True,
+        "redirect_rejected_commit":    res["forgedA_redirect"]["valid"] is False
+                                        and res["forgedA_redirect"]["why"] == "descriptor-commitment-mismatch",
+        "forgedsig_rejected_S2":       res["forgedB_forgedsig"]["valid"] is False
+                                        and res["forgedB_forgedsig"]["why"] == "bad-signature",
+        "selfconsistent_rejected_pow": res["forgedC_selfconsistent"]["valid"] is False
+                                        and res["forgedC_selfconsistent"]["why"] in
+                                            ("per-share-PoW-fail", "unchained/spliced"),
+        "unboundkey_rejected_S2":      res["forgedD_unboundkey"]["valid"] is False
+                                        and res["forgedD_unboundkey"]["why"] == "bad-signature",
+        # the crux: an identity-only rule (descriptor as free signed side-field, NOT bound
+        # into PoW) ACCEPTS the payout-redirect family C, while the composed rule REJECTS it.
+        "idonly_accepts_selfconsistent": res["forgedC_selfconsistent"]["id_only"] is True,
+        "composed_rejects_selfconsistent": res["forgedC_selfconsistent"]["valid"] is False,
+    }
+    print("\n--- golden invariants ---")
+    allok = True
+    for k, v in checks.items():
+        print(f"  [{'PASS' if v else 'FAIL'}] {k}")
+        allok = allok and v
+
+    golden = {
+        "boundary": boundary.hex(),
+        "honest_tip": honest[-1]["id"].hex(),
+        "honest_payout_pubkey": honest[0]["payout_descriptor"]["pubkey"],
+        "honest_info_digest_0": honest[0]["info_digest"].hex(),
+        "honest_sig_0": honest[0]["sig"],
+        "sybil_pubkey": pub_bytes(sybil_sk).hex(),
+        "forgedC_tip": forgedC[-1]["id"].hex(),
+        "verdicts": {k: res[k]["why"] for k in res},
+    }
+    print("\n--- golden vector ---")
+    print(json.dumps(golden, indent=2))
+
+    print(f"\nRESULT: {'ALL PASS' if allok else 'FAIL'} — "
+          f"F1 identity leg (payout-descriptor commitment + signature, bound into PoW) "
+          f"{'TESTED & HOLDS' if allok else 'BROKEN'}.")
+    sys.exit(0 if allok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/proto/m4-sync/harness/t19_sticky_withhold_timeout.py
+++ b/proto/m4-sync/harness/t19_sticky_withhold_timeout.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""T19 — sticky-shard drop-on-withhold/timeout (the F4 liveness rule made
+executable; mirrors how T17/T18 converted F1 from STATED to TESTED).
+
+WHY THIS TRACK
+--------------
+The adversarial red-team's correction #4 (out/SYNTHESIS-superlight-feed.md) is the one
+sticky-shard finding that is still DOC-ONLY:
+
+    "The one-strike-drop rule as stated fires only on an INVALID shard; a
+     withholding sybil that serves one valid shard then TIMES OUT can stall the
+     sticky session (F4, liveness)."
+
+T12's `trial_shard_sticky` drops a server on a sub-root-INVALID shard. But a
+strategic sybil never serves an invalid shard: every live-set leaf is PUBLIC
+(the eclipse-free model), so serving REAL shards is free. The cheap attack is
+SELECTIVE WITHHOLDING -- answer the first shard(s) validly (so an invalid-only
+rule keeps you), then go silent (timeout) on the rest. Under server affinity the
+validator is "stuck" on a server that already proved honest, so a drop-on-invalid
+-only rule re-queries the staller forever and the sticky session never completes.
+
+T12 could not express this: each server there has ONE fixed kind (a WITHHOLD
+sybil serves NOTHING on shard 0 and is dropped immediately). The strategic
+valid-then-stall server is a NEW adversary class this track adds.
+
+THE FIX UNDER TEST (the F4 rule)
+--------------------------------
+Redefine the drop predicate as drop-on-{INVALID or TIMEOUT/WITHHOLD}, not
+drop-on-INVALID-only: a server that times out / withholds a still-missing shard
+is rotated out the SAME as one serving an invalid shard. Then:
+  * SAFETY  -- UNCONDITIONAL and rule-independent: every accepted shard is
+    sub-root-checked vs the committed roots; a stall produces no leaves, so it
+    can never inject a wrong head. (We assert 0 wrong-head under BOTH rules.)
+  * LIVENESS -- under the F4 rule the staller is rotated, so ">=1 honest server
+    reachable" suffices again (whole-set liveness, the T9/T12 property). Under
+    the invalid-only rule the same pool STALLS: the session burns its retry
+    budget on a server that never completes the missing shard.
+
+So T19's claim, mirroring T17/T18: neither the work nor identity leg there; here
+the INVALID-only predicate is NECESSARY-but-INSUFFICIENT for liveness, and the
+TIMEOUT-drop predicate closes it -- a strict rule fix, SAFETY unchanged.
+
+Deterministic given --seed. No wall-clock in the verification path.
+Reproduce: python3 t19_sticky_withhold_timeout.py --w 300000 --servers 20 --shards 16
+"""
+
+import sys, time, argparse, random
+
+from t9_multibridge_availability import (
+    HONEST, committed_roots, shard_subroots,
+    check_shard, ROOT_BYTES,
+)
+
+LEAF_BYTES = 32
+
+# Adversary classes for this track. HONEST serves every shard validly. The two
+# new strategic classes serve REAL (sub-root-valid) shards for the first
+# `stall_after` distinct shards they are asked for, then time out / withhold on
+# every still-missing shard thereafter -- the F4 attack the invalid-only rule
+# cannot catch.
+STALL_0 = "stall_after_0"   # times out on the FIRST missing shard (== plain withholder)
+STALL_1 = "stall_after_1"   # serves one valid shard, then stalls (the F4 crux)
+STALL_2 = "stall_after_2"   # serves two valid shards, then stalls
+STRATEGIC_KINDS = [STALL_0, STALL_1, STALL_2]
+
+
+def stall_budget(kind):
+    return {STALL_0: 0, STALL_1: 1, STALL_2: 2}[kind]
+
+
+class Server:
+    """A serving bridge. `served` counts the valid shards it has already given
+    THIS validator (server affinity => persistent per-session state)."""
+    __slots__ = ("kind", "served")
+
+    def __init__(self, kind):
+        self.kind = kind
+        self.served = 0
+
+    def request(self, shard_ids):
+        """Return the real leaves for a shard, or None for a TIMEOUT/withhold.
+
+        An honest server always returns real leaves. A strategic server returns
+        real leaves until it has served `stall_after` shards, then returns None
+        (timeout) forever -- it never serves an INVALID shard, so an
+        invalid-only drop rule has no trigger."""
+        if self.kind == HONEST:
+            return list(shard_ids)
+        if self.served < stall_budget(self.kind):
+            self.served += 1
+            return list(shard_ids)          # real, sub-root-valid leaves
+        return None                          # timeout / withhold
+
+
+def make_pool(s, h, rng):
+    """s servers, expected honest fraction h. Sybils get a strategic stall kind."""
+    n_honest = max(0, min(s, round(s * h)))
+    pool = [HONEST] * n_honest + [rng.choice(STRATEGIC_KINDS) for _ in range(s - n_honest)]
+    rng.shuffle(pool)
+    return [Server(k) for k in pool]
+
+
+def assemble(pool, shards, subroots, query_budget, rng, timeout_is_drop, retry_budget):
+    """Sticky-shard assembly under one of the two drop predicates, bounded by a
+    GLOBAL query budget (the validator's finite round-trip patience per
+    cold-start; a real node cannot probe forever).
+
+    timeout_is_drop=False  -> the INVALID-ONLY rule (T12 as stated): the rule
+        names NO timeout trigger, so under pure server affinity the validator
+        keeps RE-QUERYING the same server (up to retry_budget round-trips before
+        it grudgingly rotates). A staller therefore drains `retry_budget`
+        queries from the global budget per server -- enough stallers ahead of an
+        honest server EXHAUST the budget before honest is reached => NOT live.
+    timeout_is_drop=True   -> the F4 rule: a timeout/withhold rotates the server
+        out the SAME as an invalid shard, so each staller costs ONE query.
+
+    SAFETY is identical under both: every returned shard is sub-root-checked, so
+    no wrong head is ever accepted (we also count any accepted-but-wrong shard).
+
+    Returns (bootstrapped_all, queries, wasted_leaves, wrong_head_accepts).
+    """
+    order = list(range(len(pool)))
+    rng.shuffle(order)
+    done = [False] * len(shards)
+    queries = 0
+    wasted = 0
+    wrong = 0
+
+    for idx in order:
+        if all(done) or queries >= query_budget:
+            break
+        srv = pool[idx]
+        retries = 0
+        while not all(done) and queries < query_budget:
+            missing = next((j for j in range(len(shards)) if not done[j]), None)
+            if missing is None:
+                break
+            queries += 1
+            claimed = srv.request(shards[missing])
+
+            if claimed is not None and check_shard(claimed, subroots[missing]):
+                done[missing] = True
+                continue                      # affinity: keep pulling from this server
+            if claimed is not None and not check_shard(claimed, subroots[missing]):
+                # an INVALID shard -> dropped under BOTH rules (and never accepted)
+                wasted += len(claimed)
+                break
+            # claimed is None  ==  TIMEOUT / withhold
+            if timeout_is_drop:
+                break                         # F4 rule: rotate this server out (1 query spent)
+            # invalid-only rule: the rule names no timeout drop -> re-query the
+            # same stuck server, draining the global query budget, until a
+            # grudging patience cap finally rotates it.
+            retries += 1
+            if retries >= retry_budget:
+                break
+    # SAFETY: a "done" shard must verify (belt-and-suspenders; tautological by
+    # construction since done is only set on a passing check -> proves the point
+    # that the sub-root check, not the drop rule, is what guarantees safety).
+    for j, ok in enumerate(done):
+        if ok and not check_shard(list(shards[j]), subroots[j]):
+            wrong += 1
+    return all(done), queries, wasted, wrong
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--w", type=int, default=300000)
+    ap.add_argument("--servers", type=int, default=20)
+    ap.add_argument("--shards", type=int, default=16)
+    ap.add_argument("--trials", type=int, default=200)
+    ap.add_argument("--maxq", type=int, default=50, help="GLOBAL query/round-trip budget per cold-start")
+    ap.add_argument("--retry", type=int, default=4, help="grudging per-server patience before invalid-only rotates a staller")
+    ap.add_argument("--seed", type=int, default=1337)
+    args = ap.parse_args()
+
+    rng = random.Random(args.seed)
+    live = list(range(args.w))
+
+    t0 = time.time()
+    committed = committed_roots(live)
+    shards, subroots, shard_root = shard_subroots(live, args.shards)
+    setup_s = time.time() - t0
+    wk = args.w // args.shards
+
+    print(f"# T19 sticky drop-on-timeout (F4)  W={args.w}  servers={args.servers}  "
+          f"shards={args.shards}  trials={args.trials}  seed={args.seed}")
+    print(f"# checkpoint: {len(committed)} forest roots ({len(committed)*ROOT_BYTES}B) "
+          f"+ shard-root 32B; W/K bound = {wk} leaves/shard; setup {setup_s:.2f}s")
+    print(f"# adversary: strategic valid-then-stall (STALL_0/1/2); global query budget={args.maxq}; "
+          f"invalid-only per-server patience={args.retry}")
+    print()
+
+    # The crux as a single deterministic golden vector: ONE honest server, the
+    # rest strategic STALL_1 (serve one valid shard, then time out).
+    print("## CRUX  (1 honest + (servers-1) STALL_1; honest sits LAST in the probe order)")
+    for label, tdrop in (("invalid-only rule", False), ("F4 timeout-drop rule", True)):
+        # force honest to the back so the validator meets stallers first
+        kinds = [STALL_1] * (args.servers - 1) + [HONEST]
+        pool = [Server(k) for k in kinds]
+        boot, q, w, wrong = assemble(pool, shards, subroots, args.maxq,
+                                     random.Random(99), tdrop, args.retry)
+        print(f"  {label:24s}: bootstrapped={boot}  queries={q}  wasted_leaves={w}  wrong_head={wrong}")
+    print()
+
+    # Statistical sweep over honest fraction.
+    print("## SWEEP  live% (bootstrapped all shards) and avg queries, per rule")
+    print(f"  {'h':>5} | {'invalid-only live%':>18} {'q':>5} | {'F4-drop live%':>14} {'q':>5} | wrong_head")
+    grid = [0.05, 0.10, 0.20, 0.35, 0.50]
+    total_wrong = 0
+    for h in grid:
+        io_live = io_q = f4_live = f4_q = 0
+        for t in range(args.trials):
+            r = random.Random(args.seed + t)
+            kinds = make_pool(args.servers, h, r)  # same pool kinds for both rules
+            kk = [s.kind for s in kinds]
+            b1, q1, _, wr1 = assemble([Server(k) for k in kk], shards, subroots,
+                                      args.maxq, random.Random(7 * t + 1), False, args.retry)
+            b2, q2, _, wr2 = assemble([Server(k) for k in kk], shards, subroots,
+                                      args.maxq, random.Random(7 * t + 1), True, args.retry)
+            io_live += b1; io_q += q1
+            f4_live += b2; f4_q += q2
+            total_wrong += wr1 + wr2
+        n = args.trials
+        print(f"  {h:5.2f} | {100*io_live/n:17.1f}% {io_q/n:5.1f} | "
+              f"{100*f4_live/n:13.1f}% {f4_q/n:5.1f} | {total_wrong}")
+    print()
+    print(f"# SAFETY: wrong-head acceptances across ALL trials (both rules) = {total_wrong}")
+    print("# INVARIANTS:")
+    print("#  I-SAFE  : wrong_head == 0 under BOTH rules (sub-root check is rule-independent)")
+    print("#  I-LIVE  : F4-drop live% >= invalid-only live% at every h (strict gain where stallers bite)")
+    print("#  I-CRUX  : 1-honest-last pool bootstraps under F4-drop, FAILS under invalid-only")
+    print("#            (stallers drain the global query budget before honest is reached)")
+    assert total_wrong == 0, "SAFETY VIOLATION: a stall injected a wrong head"
+    print("\nOK: SAFETY holds unconditionally; F4 timeout-drop is necessary for liveness under a finite query budget.")
+
+
+if __name__ == "__main__":
+    main()

--- a/proto/m4-sync/out/t17-delta-tail-pow-forkchoice.txt
+++ b/proto/m4-sync/out/t17-delta-tail-pow-forkchoice.txt
@@ -1,0 +1,31 @@
+=== M4 T17: delta-tail per-share PoW + cumulative-work fork choice ===
+D_f=12 shares, honest bits=16, sybilC bits=12 len=8
+
+candidate                 chained  per-share-PoW  cum-work        full-rule  header-only
+honest                    True     True           786432          ACCEPT     ACCEPT
+forgedA_nopow             True     False          0               reject     ACCEPT
+forgedB_spliced           False    True           0               reject     reject
+forgedC_minoritywork      True     True           32768           ACCEPT     ACCEPT
+
+fork_choice winner (max valid cumulative work): honest
+
+--- golden invariants ---
+  [PASS] honest_accepted
+  [PASS] forgedA_rejected_nopow
+  [PASS] forgedB_rejected_splice
+  [PASS] forgedC_valid_but_loses
+  [PASS] forkchoice_picks_honest
+  [PASS] headeronly_accepts_forgedA
+  [PASS] fullrule_rejects_forgedA
+
+--- golden vector ---
+{
+  "boundary": "d9a3e15786b275e7f306498cb59bb1075bf6fcb5c23db7de82650f283ac4f540",
+  "honest_tip": "000080497c94ef27d184a6aac3eb33af2a82f4b8c2f450ba2d72a22f26de6f15",
+  "honest_cum_work": 786432,
+  "sybilC_cum_work": 32768,
+  "work_ratio_honest_over_sybilC": 24.0,
+  "winner": "honest"
+}
+
+RESULT: ALL PASS — F1 defense (per-share PoW + cumulative-work fork choice) TESTED & HOLDS.

--- a/proto/m4-sync/out/t18-identity-leg-sig-payout.txt
+++ b/proto/m4-sync/out/t18-identity-leg-sig-payout.txt
@@ -1,0 +1,38 @@
+=== M5 T18: delta-tail identity leg — payout-descriptor commitment + signature ===
+D_f=12 shares, bits=16
+
+candidate                  chain  pow   S1-commit  S2-sig   COMPOSED   id-only
+honest                     True  True  True      True   ACCEPT    ACCEPT
+forgedA_redirect           True  True  False     False  reject    reject
+forgedB_forgedsig          True  True  True      False  reject    reject
+forgedC_selfconsistent     True  False True      True   reject    ACCEPT
+forgedD_unboundkey         True  True  True      False  reject    reject
+
+--- golden invariants ---
+  [PASS] honest_accepted
+  [PASS] redirect_rejected_commit
+  [PASS] forgedsig_rejected_S2
+  [PASS] selfconsistent_rejected_pow
+  [PASS] unboundkey_rejected_S2
+  [PASS] idonly_accepts_selfconsistent
+  [PASS] composed_rejects_selfconsistent
+
+--- golden vector ---
+{
+  "boundary": "d9a3e15786b275e7f306498cb59bb1075bf6fcb5c23db7de82650f283ac4f540",
+  "honest_tip": "00009b7c4b53e09aa7e2f17e70c65c85d58ca449817ec1e00937f873f1b89b01",
+  "honest_payout_pubkey": "652464a06e9f64f285e901b8f40c32a6952c08014889190d55223567e89f7fdf",
+  "honest_info_digest_0": "1f9d8a969a84fc1e5a059c66d63e2baab127a9b7dd954b0e83375dad296efd0b",
+  "honest_sig_0": "bd1debb6f2a37f3e742d342afe1dea67fe48cce7f160853f6e13e8eb167b40d231a4109beeb986fa03f7cda0ed879874c8555fae3e818b21fcd8e1393071d90e",
+  "sybil_pubkey": "725a6363df0deb4c3dae1da8e99b521644eeba7efee3fb00a86ad48e3f649012",
+  "forgedC_tip": "d79772bab574bf75ef1691cce4237cd24bce89bc84cac2b69cf413d709da55f4",
+  "verdicts": {
+    "honest": "ok",
+    "forgedA_redirect": "descriptor-commitment-mismatch",
+    "forgedB_forgedsig": "bad-signature",
+    "forgedC_selfconsistent": "per-share-PoW-fail",
+    "forgedD_unboundkey": "bad-signature"
+  }
+}
+
+RESULT: ALL PASS — F1 identity leg (payout-descriptor commitment + signature, bound into PoW) TESTED & HOLDS.

--- a/proto/m4-sync/out/t19-sticky-withhold-timeout-w300k.txt
+++ b/proto/m4-sync/out/t19-sticky-withhold-timeout-w300k.txt
@@ -1,0 +1,24 @@
+# T19 sticky drop-on-timeout (F4)  W=300000  servers=20  shards=16  trials=200  seed=1337
+# checkpoint: 8 forest roots (256B) + shard-root 32B; W/K bound = 18750 leaves/shard; setup 2.61s
+# adversary: strategic valid-then-stall (STALL_0/1/2); global query budget=50; invalid-only per-server patience=4
+
+## CRUX  (1 honest + (servers-1) STALL_1; honest sits LAST in the probe order)
+  invalid-only rule       : bootstrapped=False  queries=50  wasted_leaves=0  wrong_head=0
+  F4 timeout-drop rule    : bootstrapped=True  queries=31  wasted_leaves=0  wrong_head=0
+
+## SWEEP  live% (bootstrapped all shards) and avg queries, per rule
+      h | invalid-only live%     q |  F4-drop live%     q | wrong_head
+   0.05 |              43.5%  42.0 |         100.0%  25.2 | 0
+   0.10 |              74.0%  35.9 |         100.0%  21.8 | 0
+   0.20 |              91.5%  28.5 |         100.0%  19.3 | 0
+   0.35 |             100.0%  21.5 |         100.0%  17.4 | 0
+   0.50 |             100.0%  19.5 |         100.0%  16.9 | 0
+
+# SAFETY: wrong-head acceptances across ALL trials (both rules) = 0
+# INVARIANTS:
+#  I-SAFE  : wrong_head == 0 under BOTH rules (sub-root check is rule-independent)
+#  I-LIVE  : F4-drop live% >= invalid-only live% at every h (strict gain where stallers bite)
+#  I-CRUX  : 1-honest-last pool bootstraps under F4-drop, FAILS under invalid-only
+#            (stallers drain the global query budget before honest is reached)
+
+OK: SAFETY holds unconditionally; F4 timeout-drop is necessary for liveness under a finite query budget.

--- a/proto/m4-sync/out/t19-sticky-withhold-timeout-w8k.txt
+++ b/proto/m4-sync/out/t19-sticky-withhold-timeout-w8k.txt
@@ -1,0 +1,24 @@
+# T19 sticky drop-on-timeout (F4)  W=8000  servers=20  shards=16  trials=200  seed=1337
+# checkpoint: 6 forest roots (192B) + shard-root 32B; W/K bound = 500 leaves/shard; setup 0.12s
+# adversary: strategic valid-then-stall (STALL_0/1/2); global query budget=50; invalid-only per-server patience=4
+
+## CRUX  (1 honest + (servers-1) STALL_1; honest sits LAST in the probe order)
+  invalid-only rule       : bootstrapped=False  queries=50  wasted_leaves=0  wrong_head=0
+  F4 timeout-drop rule    : bootstrapped=True  queries=31  wasted_leaves=0  wrong_head=0
+
+## SWEEP  live% (bootstrapped all shards) and avg queries, per rule
+      h | invalid-only live%     q |  F4-drop live%     q | wrong_head
+   0.05 |              43.5%  42.0 |         100.0%  25.2 | 0
+   0.10 |              74.0%  35.9 |         100.0%  21.8 | 0
+   0.20 |              91.5%  28.5 |         100.0%  19.3 | 0
+   0.35 |             100.0%  21.5 |         100.0%  17.4 | 0
+   0.50 |             100.0%  19.5 |         100.0%  16.9 | 0
+
+# SAFETY: wrong-head acceptances across ALL trials (both rules) = 0
+# INVARIANTS:
+#  I-SAFE  : wrong_head == 0 under BOTH rules (sub-root check is rule-independent)
+#  I-LIVE  : F4-drop live% >= invalid-only live% at every h (strict gain where stallers bite)
+#  I-CRUX  : 1-honest-last pool bootstraps under F4-drop, FAILS under invalid-only
+#            (stallers drain the global query budget before honest is reached)
+
+OK: SAFETY holds unconditionally; F4 timeout-drop is necessary for liveness under a finite query budget.


### PR DESCRIPTION
Adds three M4 superlight-sync harness scenarios on top of the existing proto/m4-sync suite:

- T17 delta-tail PoW fork-choice
- T18 identity-leg signature payout
- T19 sticky-withhold timeout (w=8k and w=300k vectors)

Deterministic out/ vectors included. Design-only prototype on the v37-dev line, not master.
