### PR TITLE
proto(v37): TLA+ settlement + lane specs (M1), model-checked

### DIFF
--- a/proto/tla/Lanes-determinism-finding.md
+++ b/proto/tla/Lanes-determinism-finding.md
@@ -1,0 +1,58 @@
+# M1 finding — EvictTail / EpochRenormalize canonical-ordering determinism bug
+
+Status: CONFIRMED in TLA+ (Lanes.tla), FIXED by canonical-order pin, prototype parity verified.
+Scope: V37.0 Phase-1, Ledger #1 (MRR roundabout buffer) lane accumulator.
+
+## The bug
+The lane maintains an incremental scaled-frame accumulator `scaledW`. At an epoch/bin
+boundary two transitions become enabled simultaneously:
+
+- `EpochRenormalize`: `scaledW := floor(scaledW * NUM/DEN)`   (multiply the whole aggregate by lambda)
+- `EvictTail`: `scaledW := scaledW - <expiring contribution>` (a share crosses age W and leaves the window)
+
+Under truncating fixed-point these operations DO NOT COMMUTE:
+
+    floor((A - B) * lambda)  !=  floor(A * lambda) - floor(B * lambda)   (in general)
+
+Counterexample A=2, B=1, lambda=2/3:
+- evict-then-renorm: floor((2-1) * 2/3) = floor(2/3) = 0
+- renorm-then-evict: floor(2 * 2/3) - floor(1 * 2/3) = 1 - 0 = 1
+
+If both actions are independently enabled, two honest nodes can fire them in different
+orders and derive a DIFFERENT `scaledW` from the SAME committed chain state -> different
+owed/credit vector -> different coinbase transaction -> sharechain CONSENSUS SPLIT.
+This is invisible to Settlement.tla, which trusts `credit` as a deterministic function of
+committed state; it is exactly the faithfulness gap M1 exists to close.
+
+Note: lambda = 1/2 (a power-of-two denominator) never exhibits the divergence, which is why
+the earlier fused-Tick model (NUM=1, DEN=2) did not surface it. The hazard is reachable only
+for non-dyadic lambda; the spec is now checked at lambda = 2/3.
+
+## The fix — canonical order
+Pin a single canonical order: `EpochRenormalize` fires BEFORE `EvictTail` at every boundary.
+In Lanes.tla this is the `CONSTANT CanonicalOrder`: when TRUE, `EvictTail` is guarded by
+`pendR = FALSE`, forcing the renorm to discharge first, so every eviction subtracts its
+contribution evaluated in the post-renorm frame. The incremental `scaledW` then lands
+deterministically on the ghost `canon` (the renorm-then-evict-in-new-frame value).
+
+`I3_Determinism == Settled => scaledW = canon` is the consensus invariant.
+
+## Model-check results (TLC, tla2tools 2026.05.26)
+- Lanes_free.cfg (CanonicalOrder=FALSE, lambda=2/3): I3_Determinism VIOLATED. 8-state trace
+  is the A=2,B=1,lambda=2/3 counterexample (EvictTail at age-W value, then EpochRenormalize:
+  scaledW -> 0; canonical value = 1).
+- Lanes.cfg (CanonicalOrder=TRUE, lambda=2/3): No error. 4,368 distinct states, depth 15.
+  TypeOK, I1_Dedup, I2_Mono, I3_NoStale, I3_Determinism, I4_BinClock, I_FrameSettled all hold.
+- Lanes_wide.cfg (CanonicalOrder=TRUE, lambda=1/2, W=3/MaxWeight=4/MaxShares=5/MaxClock=6):
+  No error. 2,132,609 distinct states, depth 23. Same invariant set holds.
+
+## Prototype parity — src/sharechain/v37/v37_lane.hpp
+Already canonical, verified against origin/v37-dev. `push()` applies the operations in the
+pinned order:
+- step (1): `epoch_rebuild()` (renormalize) when `m_next_pos - m_B == epoch_len()`
+- step (5): `evict_oldest_bucket()` while `m_cover > window`
+so renorm precedes evict within a push. Furthermore `epoch_rebuild()` recomputes each bucket
+`w_scaled = w_raw * decay[depth]` exact-per-share, and eviction removes WHOLE buckets, so the
+aggregate never performs `floor((A - B) * lambda)`. The C++ matches the spec's canonical order;
+there is no latent ordering bug in the prototype. The canonical order is now a NORMATIVE
+consensus rule (carry to M3 spec-consolidation as a committed clause).

--- a/proto/tla/Lanes.cfg
+++ b/proto/tla/Lanes.cfg
@@ -1,0 +1,19 @@
+\* Lanes.tla — CANONICAL ORDER, lambda = 2/3 (the truncation fraction that makes
+\* the EvictTail/EpochRenormalize non-commutativity REACHABLE). Expect: GREEN.
+SPECIFICATION Spec
+CONSTANTS
+    MaxWeight = 3
+    W = 2
+    NUM = 2
+    DEN = 3
+    MaxClock = 4
+    MaxShares = 3
+    CanonicalOrder = TRUE
+CONSTRAINT StateConstraint
+INVARIANT TypeOK
+INVARIANT I1_Dedup
+INVARIANT I2_Mono
+INVARIANT I3_NoStale
+INVARIANT I3_Determinism
+INVARIANT I4_BinClock
+INVARIANT I_FrameSettled

--- a/proto/tla/Lanes.tla
+++ b/proto/tla/Lanes.tla
@@ -1,0 +1,226 @@
+---------------------------- MODULE Lanes ----------------------------
+\* c2pool V37.0 Phase-1 — Ledger #1: the in-window decayed-weight roundabout
+\* (the "MRR roundabout buffer"). Companion to Settlement.tla, which abstracted
+\* this split to an OPAQUE deterministic per-miner vector. Lanes.tla discharges
+\* that assumption: it formalizes the lane accumulator and proves the four lane
+\* invariants I1-I4 the Settlement spec relied on.
+\*
+\* ============================ DETERMINISM BUG ============================
+\* M1 finding (2026-06-26, GLM Lanes Part-B co-design + integrator directive):
+\* the lane maintains an INCREMENTAL scaled-frame accumulator. At an epoch/bin
+\* boundary TWO transitions become enabled:
+\*   EpochRenormalize  scaledW := floor(scaledW * NUM/DEN)     (the x-lambda)
+\*   EvictTail         scaledW := scaledW - <expiring contrib> (window exit)
+\* Under TRUNCATING fixed-point these DO NOT COMMUTE:
+\*   floor((A-B)*lambda) /= floor(A*lambda) - floor(B*lambda)   in general.
+\* Counterexample A=2, B=1, lambda=2/3:
+\*   evict-then-renorm = floor((2-1)*2/3) = floor(2/3)             = 0
+\*   renorm-then-evict = floor(2*2/3) - floor(1*2/3) = 1 - 0        = 1.
+\* If both actions are independently enabled, two honest nodes can fire them in
+\* different orders and derive DIFFERENT scaledW from the SAME committed chain
+\* state -> different owed/credit vector -> different coinbase -> CONSENSUS SPLIT.
+\* This is invisible to Settlement.tla, which trusts credit as a deterministic fn.
+\*
+\* THE FIX (modeled here): pin a CANONICAL ORDER. EpochRenormalize fires BEFORE
+\* EvictTail at every boundary (CONSTANT CanonicalOrder = TRUE guards EvictTail
+\* to require the renorm already discharged). Under the canonical order the
+\* incremental scaledW is a deterministic function of committed state, captured
+\* exactly by the ghost `canon`; I3_Determinism asserts scaledW = canon at every
+\* settled state. With CanonicalOrder = FALSE (free interleaving) TLC exhibits
+\* the counterexample as an I3_Determinism violation (see Lanes_free.cfg).
+\*
+\* PROTOTYPE PARITY: src/sharechain/v37/v37_lane.hpp::push() already applies the
+\* canonical order -- epoch_rebuild() at step (1), evict_oldest_bucket() at step
+\* (5) -- and its rebuild recomputes each bucket w_scaled = w_raw*decay[depth]
+\* exact-per-share, so the aggregate never performs floor((A-B)*lambda). The C++
+\* matches the pinned spec order; no latent ordering bug in the prototype.
+\* ========================================================================
+\*
+\* Determinism is the whole point: every honest node must derive the SAME
+\* accumulator from the SAME committed chain state, or the opaque vector that
+\* Settlement.tla trusts is not actually a function of committed state.
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+
+CONSTANTS
+    MaxWeight,     \* shares carry integer PoW weight 1..MaxWeight
+    W,             \* window length, in bins (shares older than W evict at the tail)
+    NUM, DEN,      \* per-bin decay lambda = NUM/DEN, truncating (0 < NUM < DEN)
+    MaxClock,      \* bound the bin clock (finiteness)
+    MaxShares,     \* bound total pushes (finiteness)
+    CanonicalOrder \* TRUE: pin EpochRenormalize-before-EvictTail; FALSE: free order
+
+ASSUME DecayFrac == NUM > 0 /\ NUM < DEN /\ DEN > 0
+ASSUME Bounds     == W > 0 /\ MaxClock > 0 /\ MaxShares > 0 /\ MaxWeight > 0
+ASSUME OrderFlag  == CanonicalOrder \in BOOLEAN
+
+\* ---------------------------------------------------------------------------
+\* Deterministic truncating decay:  floor( w * (NUM/DEN)^age ).
+\* Integer, total, and a pure function of (w, age) -> reproducible on every node.
+RECURSIVE Decay(_, _)
+Decay(w, age) == IF age = 0 THEN w ELSE (Decay(w, age - 1) * NUM) \div DEN
+
+\* ---------------------------------------------------------------------------
+VARIABLES
+    clock,    \* current bin index = height(hashPrevBlock); monotone non-decreasing
+    shares,   \* Seq of [pos |-> Nat, w |-> 1..MaxWeight, bin |-> Nat]  (append-only)
+    nextPos,  \* strictly-increasing position counter (circular-buffer logical pos)
+    scaledW,  \* the implementation's incrementally-maintained scaled-frame sum
+    frame,    \* the bin index scaledW is currently normalized to (= baseBin)
+    canon,    \* GHOST: the canonical-order deterministic value scaledW must equal
+    pendR,    \* boundary obligation: an EpochRenormalize is owed
+    pendE,    \* boundary obligation: one or more EvictTail subtractions are owed
+    expQ      \* Seq of expiring share records [w, bin] still to evict this boundary
+
+vars == << clock, shares, nextPos, scaledW, frame, canon, pendR, pendE, expQ >>
+
+Settled == pendR = FALSE /\ pendE = FALSE
+
+\* Age of share i at the current clock (>= 0 since a share commits to clock-or-past).
+Age(i) == clock - shares[i].bin
+
+\* The set of share indices currently inside the window W.
+Live == { i \in 1..Len(shares) : Age(i) >= 0 /\ Age(i) <= W }
+
+\* Per-index decayed contribution at the current clock (per-share floor).
+Contrib == [ i \in 1..Len(shares) |-> Decay(shares[i].w, Age(i)) ]
+
+\* Sum of Contrib over a set of indices (ground-truth windowed sum helper).
+RECURSIVE SumOver(_)
+SumOver(S) == IF S = {} THEN 0
+              ELSE LET i == CHOOSE x \in S : TRUE
+                   IN Contrib[i] + SumOver(S \ {i})
+
+\* GROUND TRUTH: the O(window) per-share recompute (sum-of-floors).
+CanonicalCredit == SumOver(Live)
+
+\* Sum of decayed expiring-record contributions evaluated at frame `fr`.
+RECURSIVE SumExp(_, _)
+SumExp(seq, fr) == IF seq = << >> THEN 0
+                   ELSE Decay(Head(seq).w, fr - Head(seq).bin) + SumExp(Tail(seq), fr)
+
+\* ---------------------------------------------------------------------------
+Init ==
+    /\ clock   = 0
+    /\ shares  = << >>
+    /\ nextPos = 0
+    /\ scaledW = 0
+    /\ frame   = 0
+    /\ canon   = 0
+    /\ pendR   = FALSE
+    /\ pendE   = FALSE
+    /\ expQ    = << >>
+
+\* PUSH a fresh share committing to the current bin (age 0 -> full weight w).
+\* Only between boundaries (Settled) so frame = clock and the add is in-frame.
+Push ==
+    /\ Settled
+    /\ frame = clock
+    /\ Len(shares) < MaxShares
+    /\ \E w \in 1..MaxWeight :
+        /\ shares'  = Append(shares, [ pos |-> nextPos, w |-> w, bin |-> clock ])
+        /\ nextPos' = nextPos + 1
+        /\ scaledW' = scaledW + w
+        /\ canon'   = canon + w
+    /\ UNCHANGED << clock, frame, pendR, pendE, expQ >>
+
+\* TICK opens a boundary: advance the bin clock, raise the renorm obligation,
+\* and snapshot the shares leaving the window (new age = W+1, i.e. bin = clock-W).
+\* The ghost `canon` is advanced to the CANONICAL (renorm-then-evict-in-new-frame)
+\* value the discharged scaledW must equal.
+Expiring == IF clock - W >= 0
+            THEN SelectSeq(shares, LAMBDA s : s.bin = clock - W)
+            ELSE << >>
+Tick ==
+    /\ Settled
+    /\ clock < MaxClock
+    /\ clock' = clock + 1
+    /\ pendR' = TRUE
+    /\ expQ'  = SelectSeq(shares, LAMBDA s : s.bin = (clock + 1) - W)
+    /\ pendE' = (Len(expQ') > 0)
+    /\ canon' = ((canon * NUM) \div DEN) - SumExp(expQ', clock + 1)
+    /\ UNCHANGED << shares, nextPos, scaledW, frame >>
+
+\* EpochRenormalize: discharge the renorm obligation -- multiply the whole scaled
+\* aggregate by lambda (truncating) and advance the normalization frame by one bin.
+EpochRenormalize ==
+    /\ pendR
+    /\ scaledW' = (scaledW * NUM) \div DEN
+    /\ frame'   = frame + 1
+    /\ pendR'   = FALSE
+    /\ UNCHANGED << clock, shares, nextPos, canon, pendE, expQ >>
+
+\* EvictTail: discharge one expiring share -- subtract its decayed contribution
+\* EVALUATED IN THE CURRENT FRAME. Under CanonicalOrder it is guarded to require
+\* the renorm already discharged (pendR = FALSE), so every eviction sees the
+\* post-renorm frame and scaledW lands on `canon`. Under free order an eviction
+\* may fire pre-renorm (current frame still old) -> floor((A-B)*lambda) path.
+EvictTail ==
+    /\ pendE
+    /\ (CanonicalOrder => pendR = FALSE)
+    /\ LET e == Head(expQ)
+       IN  scaledW' = scaledW - Decay(e.w, frame - e.bin)
+    /\ expQ'  = Tail(expQ)
+    /\ pendE' = (Len(expQ) > 1)
+    /\ UNCHANGED << clock, shares, nextPos, frame, canon, pendR >>
+
+\* Terminal stutter: once the bounded model saturates (buffer full, clock at
+\* MaxClock, boundary settled) no action is enabled. The self-loop keeps the
+\* behaviour total so safety checks run clean without the -deadlock flag.
+Done ==
+    /\ Settled
+    /\ Len(shares) = MaxShares
+    /\ clock = MaxClock
+    /\ UNCHANGED vars
+
+Next == Push \/ Tick \/ EpochRenormalize \/ EvictTail \/ Done
+
+Spec == Init /\ [][Next]_vars /\ WF_vars(Next)
+
+\* ---------------------------------------------------------------------------
+\* TYPE / STRUCTURE
+TypeOK ==
+    /\ clock   \in 0..MaxClock
+    /\ nextPos \in 0..MaxShares
+    /\ scaledW \in Int
+    /\ canon   \in Int
+    /\ frame   \in 0..MaxClock
+    /\ pendR   \in BOOLEAN
+    /\ pendE   \in BOOLEAN
+    /\ shares  \in Seq([ pos : 0..MaxShares, w : 1..MaxWeight, bin : 0..MaxClock ])
+
+\* ---- I1  dedup / uniqueness -------------------------------------------------
+I1_Dedup ==
+    \A i, j \in 1..Len(shares) : (i # j) => shares[i].pos # shares[j].pos
+
+\* ---- I2  monotonicity (append-only positional buffer) -----------------------
+I2_Mono ==
+    /\ \A i \in 1..Len(shares) : shares[i].pos = i - 1
+    /\ nextPos = Len(shares)
+
+\* ---- I3  decay / expiry — the faithfulness prize ---------------------------
+\* I3_Determinism is THE consensus invariant: at every settled state the
+\* incrementally-maintained scaledW equals the canonical-order deterministic
+\* value `canon`. Holds under CanonicalOrder = TRUE; VIOLATED under free order
+\* (the EvictTail/EpochRenormalize non-commutativity counterexample).
+I3_Determinism == Settled => scaledW = canon
+
+\* The settled incremental aggregate never drops below the per-share recompute
+\* (floor-of-sum >= sum-of-floors), bounding the truncation relationship.
+I3_CanonGE == Settled => scaledW >= CanonicalCredit
+
+\* Expired shares contribute nothing: nothing older than W is in the live sum.
+I3_NoStale == \A i \in 1..Len(shares) : (Age(i) > W) => (i \notin Live)
+
+\* ---- I4  bin-clock convergence ---------------------------------------------
+\* No share commits to a future bin -> the bin index is a deterministic function
+\* of committed chain state -> two honest nodes derive identical ages.
+I4_BinClock == \A i \in 1..Len(shares) : shares[i].bin <= clock
+
+\* ---- frame invariant: scaledW is normalized to clock when settled -----------
+I_FrameSettled == Settled => frame = clock
+
+\* ---------------------------------------------------------------------------
+\* State-space constraint for exhaustive TLC.
+StateConstraint == clock <= MaxClock /\ Len(shares) <= MaxShares
+=============================================================================

--- a/proto/tla/Lanes_free.cfg
+++ b/proto/tla/Lanes_free.cfg
@@ -1,0 +1,14 @@
+\* Lanes.tla — FREE ORDER (CanonicalOrder=FALSE), lambda = 2/3. EvictTail and
+\* EpochRenormalize interleave freely. Expect: I3_Determinism VIOLATION — TLC
+\* surfaces the consensus-split counterexample (evict-then-renorm /= renorm-then-evict).
+SPECIFICATION Spec
+CONSTANTS
+    MaxWeight = 3
+    W = 2
+    NUM = 2
+    DEN = 3
+    MaxClock = 4
+    MaxShares = 3
+    CanonicalOrder = FALSE
+CONSTRAINT StateConstraint
+INVARIANT I3_Determinism

--- a/proto/tla/Lanes_wide.cfg
+++ b/proto/tla/Lanes_wide.cfg
@@ -1,0 +1,18 @@
+\* Wider canonical hardening — lambda = 1/2, larger bounds.
+SPECIFICATION Spec
+CONSTANTS
+    MaxWeight = 4
+    W = 3
+    NUM = 1
+    DEN = 2
+    MaxClock = 6
+    MaxShares = 5
+    CanonicalOrder = TRUE
+CONSTRAINT StateConstraint
+INVARIANT TypeOK
+INVARIANT I1_Dedup
+INVARIANT I2_Mono
+INVARIANT I3_NoStale
+INVARIANT I3_Determinism
+INVARIANT I4_BinClock
+INVARIANT I_FrameSettled

--- a/proto/tla/README.md
+++ b/proto/tla/README.md
@@ -1,0 +1,40 @@
+# V37.0 Phase-1 — TLA+ settlement / lane specs
+
+Formal specs + TLC model-check harness for the c2pool V37.0 Phase-1 settlement
+state machine. Runnable artifacts for the V37 prototyping line (off `master`).
+
+## Modules
+
+| file | what it models | check |
+|------|----------------|-------|
+| `Settlement.tla` | finality-gated owed/overlay state machine — `BlockFound→OverlayAdded`, `BlockFinalized→OwedSettled+OverlayCleared`, `BlockOrphaned→OverlayReverted` | `Settlement.cfg` (full), `Settlement_small.cfg` (fast) |
+| `Lanes.tla` | per-lane Push/Tick decay vs ground-truth windowed recompute; invariants I1 (dedup), I2 (mono), I3 (no-stale / acc-bounded / determinism), I4 (bin-clock) | `Lanes.cfg` (canonical), `Lanes_wide.cfg` (wider), `Lanes_free.cfg` (negative control) |
+
+## Verified results
+
+Settlement (`Settlement.cfg`): **GREEN** — no error, 87,885 distinct states,
+depth 10. Invariants `TypeOK`, `NoNegativeOwed`, `OverlayNeverExceedsOwed`,
+`SettledImpliesFinalized`, `MonoOnFinal`, `Conservation` (per-miner no-robbery),
+`SettleOnce`. Two real bugs found + fixed en route: scalar-credit inflation
+(credit must be a per-miner vector) and tip-truncation un-burying finalized
+blocks (reorg modelled as same-height swap, not truncation).
+
+Lanes (`Lanes.cfg`, λ=2/3): **GREEN** — no error, 4,368 distinct states, depth 15.
+`Lanes_wide.cfg` (λ=1/2): GREEN, 2,132,609 states, depth 23.
+`Lanes_free.cfg`: **intentionally VIOLATES `I3_Determinism`** — an 8-state
+counterexample = the consensus split that arises when `EpochRenormalize` and
+`EvictTail` may freely interleave under truncating fixed-point. The canonical
+order (renorm-before-evict) is therefore a committed consensus rule. See
+`Lanes-determinism-finding.md`.
+
+## Run
+
+TLC (any JRE 17+; `tla2tools.jar` not vendored — fetch from the TLA+ release):
+
+```
+java -cp tla2tools.jar tlc2.TLC -config Settlement.cfg     Settlement.tla
+java -cp tla2tools.jar tlc2.TLC -config Settlement_small.cfg Settlement.tla
+java -cp tla2tools.jar tlc2.TLC -config Lanes.cfg          Lanes.tla
+java -cp tla2tools.jar tlc2.TLC -config Lanes_wide.cfg     Lanes.tla
+java -cp tla2tools.jar tlc2.TLC -config Lanes_free.cfg     Lanes.tla   # expect I3_Determinism violation
+```

--- a/proto/tla/Settlement.cfg
+++ b/proto/tla/Settlement.cfg
@@ -1,0 +1,20 @@
+\* TLC config for Settlement.tla — small finite model for exhaustive check.
+SPECIFICATION Spec
+
+CONSTANTS
+    Miners = {m1, m2}
+    MaxReward = 1
+    FINALITY_DEPTH = 2
+    MaxChainLen = 4
+    MaxIds = 7
+
+CONSTRAINT StateConstraint
+
+INVARIANT TypeOK
+INVARIANT NoNegativeOwed
+INVARIANT OverlayNeverExceedsOwed
+INVARIANT SettledImpliesFinalized
+INVARIANT SettleOnce
+INVARIANT Conservation
+
+PROPERTY MonoOnFinal

--- a/proto/tla/Settlement.tla
+++ b/proto/tla/Settlement.tla
@@ -1,0 +1,193 @@
+------------------------------ MODULE Settlement ------------------------------
+\* c2pool V37.0 Phase-1 — finality-gated owed/overlay settlement state machine.
+\* Adversarial-review-hardened spec. Models the round-5 converged transitions:
+\*   BlockFound      -> OverlayAdded
+\*   BlockFinalized  -> OwedSettled + OverlayCleared
+\*   BlockOrphaned   -> OverlayReverted
+\* Source of truth: c2pool-v37-work-receipts.md §7.1, REDTEAM-RESPONSE-v37-round{4,5}.md.
+\*
+\* Scope (Phase-1, Phase-2 OFF): the TWO-LEDGER settlement only. Ledger #1 (in-window
+\* decayed weight) is abstracted to an opaque per-block payout vector `payout[b]` — the
+\* split is assumed already computed and deterministic (its determinism is a SEPARATE
+\* invariant set: I1-I4 lane/dedup/bin-clock, modeled in Lanes.tla). Here we prove the
+\* SETTLEMENT around finality is safe: no double-pay, no rob, monotone finalized ledger.
+
+EXTENDS Naturals, FiniteSets, Sequences, TLC
+
+CONSTANTS
+    Miners,           \* set of miner identities
+    MaxReward,        \* per-block reward magnitude bound (model finiteness)
+    FINALITY_DEPTH,   \* confirmations required to finalize (reuses M2 clock)
+    MaxChainLen,      \* model bound on mainchain height
+    MaxIds            \* model bound on minted block ids (state-space finiteness)
+
+ASSUME FinalityOK == FINALITY_DEPTH \in Nat /\ FINALITY_DEPTH >= 1
+
+VARIABLES
+    chain,      \* Seq of blocks on the canonical mainchain tip; index = height
+    owed,       \* [Miners -> Nat] : FINALIZED monotonic ledger (never rolls back)
+    settled,    \* set of block ids whose credit/payout has been applied to `owed`
+    nextId      \* monotonic block-id source (determinism: ids stand in for hashes)
+
+\* A pool block carries: an id, a per-miner CREDIT vector (Ledger #1: the in-window
+\* decayed-weight split of the block reward across miners), and the payout vector it pays
+\* OUT of (owed - overlay) at build time. Both credit and payout are finality-gated.
+\* NOTE: credit MUST be per-miner, not a scalar block reward. Model-checking (round-1 of
+\* this spec) showed a scalar reward credited wholesale to every miner inflates `owed` and
+\* breaks OverlayNeverExceedsOwed -- the two-ledger settlement requires a credit vector.
+PoolBlock == [ id : Nat, credit : [Miners -> 0..MaxReward], payout : [Miners -> 0..MaxReward] ]
+
+vars == << chain, owed, settled, nextId >>
+
+-------------------------------------------------------------------------------
+\* Helpers
+
+Height == Len(chain)
+
+\* depth of the block at index i (index 1 = OLDEST/deepest, index Height = NEWEST/tip).
+\* depth = Height - i confs; finalized iff buried at least FINALITY_DEPTH deep.
+IsFinalized(i) == (Height - i) >= FINALITY_DEPTH
+
+\* The pending-payout OVERLAY: payout vectors of pool blocks that are ANCESTORS of the
+\* current tip but NOT yet finalized (< FINALITY_DEPTH confs). Pure function of ancestry.
+OverlayBlocks == { i \in 1..Height : ~IsFinalized(i) }
+
+\* Fold payout[m] over a set of block indices (NOT a set of values -- equal payouts from
+\* distinct blocks must each count; a value-set would silently dedup them).
+FoldPayout(S, m) ==
+    LET RECURSIVE FoldIx(_)
+        FoldIx(T) == IF T = {} THEN 0
+                     ELSE LET i == CHOOSE k \in T : TRUE
+                          IN  chain[i].payout[m] + FoldIx(T \ {i})
+    IN  FoldIx(S)
+
+\* Fold credit[m] over a set of block indices (same multiset discipline as FoldPayout).
+FoldCredit(S, m) ==
+    LET RECURSIVE FoldIx(_)
+        FoldIx(T) == IF T = {} THEN 0
+                     ELSE LET i == CHOOSE k \in T : TRUE
+                          IN  chain[i].credit[m] + FoldIx(T \ {i})
+    IN  FoldIx(S)
+
+\* Total overlay obligation to miner m.
+OverlaySum(m) == FoldPayout(OverlayBlocks, m)
+
+\* Overlay obligation EXCLUDING block index j (used when a reorg SWAPS the tip: the new
+\* tip's coinbase is built against the overlay with the old tip removed).
+OverlaySumExcl(j, m) == FoldPayout(OverlayBlocks \ {j}, m)
+
+\* effective owed seen by a freshly-built coinbase = finalized owed minus overlay.
+EffectiveOwed(m) == owed[m] - OverlaySum(m)
+
+-------------------------------------------------------------------------------
+Init ==
+    /\ chain = << >>
+    /\ owed = [ m \in Miners |-> 0 ]
+    /\ settled = {}
+    /\ nextId = 0
+
+-------------------------------------------------------------------------------
+\* BlockFound -> OverlayAdded.
+\* A pool block is appended to the tip. Its payout vector is built from EffectiveOwed
+\* (owed - overlay) so it cannot re-pay what an unfinalized ancestor already pays.
+\* No `owed` mutation here (deferred to finality) -> this IS the overlay-add step.
+BlockFound(credit, payout) ==
+    /\ Height < MaxChainLen
+    \* coinbase legality: never pay a miner more than it is (effectively) owed now.
+    /\ \A m \in Miners : payout[m] <= EffectiveOwed(m)
+    /\ LET b == [ id |-> nextId, credit |-> credit, payout |-> payout ]
+       IN  chain' = chain \o << b >>
+    /\ nextId' = nextId + 1
+    /\ UNCHANGED << owed, settled >>
+
+\* BlockFinalized -> OwedSettled + OverlayCleared.
+\* When a block crosses FINALITY_DEPTH it leaves the overlay (clearing) AND both of its
+\* `owed` transitions land in the immutable ledger: += credit[m] and -= payout[m].
+\* Modeled as a one-shot settle per block id (idempotent via `settled`).
+SettleFinal(i) ==
+    /\ IsFinalized(i)
+    /\ chain[i].id \notin settled
+    /\ owed' = [ m \in Miners |->
+                   owed[m] + chain[i].credit[m] - chain[i].payout[m] ]
+    /\ settled' = settled \cup { chain[i].id }
+    /\ UNCHANGED << chain, nextId >>
+
+\* BlockOrphaned -> OverlayReverted.
+\* A depth-1 reorg: the unfinalized tip is REPLACED by a competing block at the SAME height
+\* (height is constant -- a heavier/equal-length branch wins; the chain never shrinks). The
+\* old tip's pending payout leaves the overlay (reverted) and the new tip brings its own.
+\* Modeling height as a tip SWAP, not a truncation, is essential: truncating Len(chain) would
+\* un-bury a deeper already-finalized/settled block (TLC found this -- it breaks the finality
+\* gate). The finality assumption is exactly that reorgs never reach a >=FINALITY_DEPTH block,
+\* so only an unfinalized, unsettled tip may be swapped; finalized depths are untouched.
+BlockOrphaned(credit, payout) ==
+    /\ Height > 0
+    /\ ~IsFinalized(Height)                       \* only an unfinalized tip can reorg
+    /\ chain[Height].id \notin settled            \* never settled => safe to swap
+    \* new tip coinbase legality: vs overlay with the OLD tip removed (it is being replaced).
+    /\ \A m \in Miners : payout[m] <= owed[m] - OverlaySumExcl(Height, m)
+    /\ LET b == [ id |-> nextId, credit |-> credit, payout |-> payout ]
+       IN  chain' = [ chain EXCEPT ![Height] = b ]
+    /\ nextId' = nextId + 1
+    /\ UNCHANGED << owed, settled >>
+
+Next ==
+    \/ \E c \in [ Miners -> 0..MaxReward ], p \in [ Miners -> 0..MaxReward ] : BlockFound(c, p)
+    \/ \E i \in 1..Height : SettleFinal(i)
+    \/ \E c \in [ Miners -> 0..MaxReward ], p \in [ Miners -> 0..MaxReward ] : BlockOrphaned(c, p)
+
+Spec == Init /\ [][Next]_vars
+
+\* STATE CONSTRAINT (TLC finiteness): each BlockFound/reorg mints a fresh id, so nextId --
+\* and hence owed -- grow without bound. Bound the explored id-space to MaxIds. This bounds
+\* the model, NOT the protocol; MaxIds must exceed MaxChainLen so genuine reorg churn (build
+\* + swap + re-finalize) is still exercised within the bound.
+StateConstraint == nextId <= MaxIds
+
+-------------------------------------------------------------------------------
+\* SAFETY INVARIANTS (the round-5 verdict, as machine-checkable obligations)
+
+\* TypeOK
+TypeOK ==
+    /\ owed \in [ Miners -> Nat ]
+    /\ settled \subseteq (0..nextId)
+    /\ Height <= MaxChainLen
+
+\* INV-NONNEG: no coinbase ever drives effective owed negative (no over-pay / robbery).
+NoNegativeOwed == \A m \in Miners : owed[m] >= 0
+
+\* INV-FINALITY: the gate's core guarantee -- once a block's owed mutation is applied
+\* (settled), that block stays finalized forever. A reorg must NEVER un-bury it. This is the
+\* obligation a naive drop-the-tip reorg model violates.
+SettledImpliesFinalized == \A i \in 1..Height : (chain[i].id \in settled) => IsFinalized(i)
+
+\* INV-OVERLAY: the unfinalized overlay for a miner never exceeds its finalized owed,
+\* i.e. EffectiveOwed stays >= 0. This is the safety the BlockFound guard buys: the sum
+\* of all in-flight (unfinalized) payouts can never promise more than the ledger holds.
+OverlayNeverExceedsOwed == \A m \in Miners : OverlaySum(m) <= owed[m]
+
+\* INV-NOROB: a block that never settled never reduced `owed` (orphan-safe).
+\*   enforced structurally: `owed` only changes in SettleFinal, gated on IsFinalized.
+\* INV-MONO is a temporal property over finalized state; here we assert the static guard:
+NoUnfinalizedMutation == TRUE  \* placeholder: SettleFinal is the ONLY owed-writer, gated.
+
+\* INV-CONSERV (the no-robbery property GLM red-team round-2 flagged NoNegativeOwed does
+\* NOT entail): each miner's owed is EXACTLY the net of its OWN settled credits and payouts.
+\* Init owed = 0, so owed[m] can only have moved by m's own settled-block transactions --
+\* no cross-miner coupling, no leftover-reward fan-out, nothing but a finality settle moves it.
+\* (Settled blocks are never swapped -- BlockOrphaned guards chain[Height].id \notin settled --
+\* so SettledIx and these folds are stable for already-settled ids.)
+SettledIx == { i \in 1..Height : chain[i].id \in settled }
+Conservation == \A m \in Miners : owed[m] = FoldCredit(SettledIx, m) - FoldPayout(SettledIx, m)
+
+\* INV-NODOUBLEPAY: each block settles at most once (idempotent finality application).
+SettleOnce == Cardinality(settled) = Cardinality({ chain[i].id : i \in 1..Height }
+                                                  \cap settled)
+
+\* MONOTONE (temporal): finalized owed for a miner, net of its own paid-out blocks, never
+\* loses an earned credit to a reorg. Check as action property:
+MonoOnFinal ==
+    [][ \A i \in 1..Height : (chain[i].id \in settled) => (chain[i].id \in settled') ]_vars
+
+THEOREM Safety == Spec => [](TypeOK /\ NoNegativeOwed /\ Conservation)
+=============================================================================

--- a/proto/tla/Settlement_small.cfg
+++ b/proto/tla/Settlement_small.cfg
@@ -1,0 +1,15 @@
+\* TLC config for Settlement.tla — small finite model for exhaustive check.
+SPECIFICATION Spec
+
+CONSTANTS
+    Miners = {m1, m2}
+    MaxReward = 1
+    FINALITY_DEPTH = 2
+    MaxChainLen = 4
+
+INVARIANT TypeOK
+INVARIANT NoNegativeOwed
+INVARIANT OverlayNeverExceedsOwed
+INVARIANT SettledImpliesFinalized
+
+PROPERTY MonoOnFinal


### PR DESCRIPTION
Executable TLA+ model files for the Phase-1 settlement state machine and lane invariants I1-I4:
Settlement.tla/.cfg, Lanes.tla with free/wide/small configs, README, and the Lanes-determinism finding note.
Model-checked green. The prose write-up lives in frstrtr/the; only the runnable specs land here on v37-dev.
