### PR TITLE
ci(v37)+web-static: wire v37_test into build matrix; clamp explorer totalPrimary finite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,7 @@ jobs:
                     test_mweb_builder \
                     test_address_resolution test_compute_share_target \
                     test_utxo \
+                    v37_test \
             -j$(nproc)
 
       - name: Run tests
@@ -192,6 +193,7 @@ jobs:
                     test_address_resolution test_compute_share_target \
                     test_utxo \
                     test_coin_broadcaster test_multiaddress_pplns test_pplns_stress \
+                    v37_test \
             -j$(nproc)
 
       - name: Run tests under sanitizers

--- a/web-static/sharechain-explorer/src/pplns/parse.ts
+++ b/web-static/sharechain-explorer/src/pplns/parse.ts
@@ -119,7 +119,10 @@ function parseNewShape(obj: Record<string, unknown>): PplnsSnapshot {
   const snap: PplnsSnapshot = {
     totalPrimary: totalPrimary > 0
       ? totalPrimary
-      : miners.reduce((s, m) => s + m.amount, 0),
+      // Clamp the fallback sum: amounts are individually finite, but a
+      // sum of values near Number.MAX_VALUE overflows to Infinity, which
+      // breaks the "totalPrimary is finite" invariant (parse-properties #204).
+      : num(miners.reduce((s, m) => s + m.amount, 0)),
     mergedChains,
     mergedTotals,
     schemaVersion: str(obj.schema_version) ?? '1.0',
@@ -258,7 +261,9 @@ function parseLegacyShape(obj: Record<string, unknown>): PplnsSnapshot {
     entries.push({ address: addr, amount, merged });
   }
 
-  const totalPrimary = entries.reduce((s, e) => s + e.amount, 0);
+  // num() clamps an overflowed sum (values near Number.MAX_VALUE) back to a
+  // finite 0 rather than Infinity; see parse-properties #204.
+  const totalPrimary = num(entries.reduce((s, e) => s + e.amount, 0));
   entries.sort((a, b) => b.amount - a.amount);
 
   const miners: PplnsMiner[] = entries.map((e) => ({


### PR DESCRIPTION
Two small enabling changes:

- build.yml: add the v37_test target to both the build list and the sanitizer build list so its ctest entry actually runs.
- sharechain-explorer parse.ts: clamp the parseSnapshot totalPrimary fallback sum through num() so a sum near Number.MAX_VALUE cannot overflow to Infinity (parse-properties invariant).

Note: touches shared-infra .github/workflows/build.yml (additive only). These two commits are also carried by v37/consensus-fixes via merged branch-PR; merging that PR subsumes this one.
