### PR TITLE
core(web): emit V36-GATE sampling_signaling time series to journal

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -5209,6 +5209,16 @@ nlohmann::json MiningInterface::rest_version_signaling(const nlohmann::json* cac
     }
     double sampling_signaling = sampling_total_weight > 0
         ? (sampling_v36_weight * 100.0 / sampling_total_weight) : 0;
+    // [V36-GATE] Authoritative work-weighted signaling time series: emit the
+    // ratchet gate figure on every evaluation. This is the only site where
+    // sampling_signaling is computed; it previously reached only the HTTP JSON
+    // (result["sampling_signaling"]) and was otherwise dropped, so no time
+    // series existed anywhere. Log-only: does NOT touch the >=95/>=60 predicate
+    // below or the sampling-window definition above.
+    LOG_INFO << "[V36-GATE] sampling_signaling=" << sampling_signaling
+             << "% sampling_v36_weight=" << sampling_v36_weight
+             << " sampling_total_weight=" << sampling_total_weight
+             << " window=" << sampling_window_size;
 
     // ── Transition detection ─────────────────────────────────────────────────
     // The crossing banner, the signed authority notice and the progress bar are


### PR DESCRIPTION
Closes the v36 LTC ratchet observability blind spot.

The binding activation predicate is `sampling_signaling`, computed inside `rest_version_signaling()` at `src/core/web_server.cpp:5211`. It was recomputed per HTTP request and never journalled, so there was no authoritative time series anywhere — the by-WORK gate is not exposed in `/v36_status` at all. Every ratchet trend read to date has been a by-COUNT proxy scraped off the status endpoint.

This adds ONE `[V36-GATE]` `LOG_INFO` emit immediately after the predicate is computed, carrying `sampling_signaling` / `sampling_v36_weight` / `sampling_total_weight` per evaluation.

Scope fence (held): log-only, 10-line insertion. The >=95 / >=60 predicate and the window definition are UNTOUCHED. No behavior change.

Authored by ltc-doge-production-steward (GPG-signed, `fe1ab7fd`); opened by integrator per handoff. Per-coin isolation: touches shared `src/core/web_server.cpp` but is log-emit only — no consensus/predicate surface.