### PR TITLE
dash(embedded): recover from SML-attested PoSe bans during checkpoint bridge replay

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -3429,6 +3429,31 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     if (!e) return std::nullopt;
                     return e->hash;
                 });
+            // SML validity attestation — the ONLY carrier of a post-anchor
+            // PoSe ban. dashd applies those from consensus, never as a special
+            // tx, so the bridge's block replay is structurally unable to see
+            // one: a masternode banned after the anchor height stays eligible
+            // in our projection, the coinbase pays somebody else, and the
+            // bridge fail-closes forever — the daemonless arm then never
+            // publishes a masternode set at all. With this seam the replay may
+            // demote a projected payee the SML ATTESTS INVALID, and only onto a
+            // candidate whose scriptPayout exactly matches this coinbase.
+            // Three-state on purpose: absent-from-SML is nullopt, never "fine".
+            // See mn_checkpoint_lane.hpp's residuals note.
+            //
+            // Same thread as everything else the lane touches: the SML is
+            // updated on the mnlistdiff ingest leg and read here from the
+            // block-connect / tip-changed callbacks, all on the single
+            // io_context thread main_dash runs. No lock is taken or needed.
+            mn_ckpt_lane->set_sml_validity_fn(
+                [&node_coin_state](const uint256& proTxHash)
+                    -> std::optional<bool> {
+                    if (!node_coin_state.have_sml()) return std::nullopt;
+                    for (const auto& e : node_coin_state.sml().mnList) {
+                        if (e.proRegTxHash == proTxHash) return e.isValid;
+                    }
+                    return std::nullopt;
+                });
             // Publish through the EXACT leg-4 event the E2c RPC seed uses, so
             // CoinStateMaintainer::on_mn_list_update takes the bridged set as
             // an ordinary authoritative resync — snapshot fence set to the

--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -89,6 +89,50 @@
 /// that path is proven live. There is no exclusive lock held across any call
 /// into this lane.
 ///
+/// ─────────────────────────────────────────────────────────────────────────
+/// POST-ANCHOR PoSe BANS, AND THE TWO RESIDUALS THAT REMAIN
+/// ─────────────────────────────────────────────────────────────────────────
+/// The falsification test above has one structural blind spot. A PoSe ban is
+/// applied by dashd from CONSENSUS (accumulated MAX_PoSe_PENALTY), never as a
+/// special transaction. MnStateMachine::apply_block walks special txs, so it
+/// cannot observe one at any price. A masternode banned AFTER the anchor
+/// height therefore stays isValid=true in the replay, keeps its place at the
+/// head of our payment queue, and is projected as the payee for a block dashd
+/// paid to somebody else — payee_desync, which here is TERMINAL. One such ban
+/// anywhere in the replay window permanently prevents the daemonless arm from
+/// publishing a masternode set at all.
+///
+/// The Simplified Masternode List is the only carrier of that ban, so the lane
+/// exposes set_sml_validity_fn() and hands it to its private machine. On a
+/// payee mismatch the machine may walk down the ranked queue, but ONLY while
+/// each demoted candidate is ATTESTED INVALID by the SML and the accepted
+/// candidate's scriptPayout EXACTLY matches an output this block pays. Any
+/// step that cannot satisfy both reports payee_desync exactly as before. The
+/// walk is capped per bridge (see pump()), every event logs at WARNING, and
+/// the running count is surfaced in status() and in the publish line — a
+/// count that lives only in scrollback is half-silent, and this file exists
+/// to prevent silent degradation.
+///
+/// TWO RESIDUALS, stated honestly:
+///
+///  (a) A masternode banned AND revived entirely inside the replay window,
+///      whose CURRENT SML entry therefore reads isValid==true, still fails
+///      closed. The SML is a snapshot of NOW; it cannot attest a historical
+///      ban, and an attested-valid answer is treated as counter-evidence (it
+///      must be — that is what stops the walk from excusing a real desync).
+///      This is exactly today's behaviour for that case, not worse.
+///
+///  (b) A post-anchor ban INSIDE a shared-payoutAddress group can escape both
+///      the cross-check and this recovery, because both are SCRIPT-granular:
+///      if the banned MN and the MN dashd actually paid share one payout
+///      address, the coinbase output still matches our projected script, the
+///      mismatch never fires, and the payment is attributed to the wrong
+///      member of the group. That is a PRE-EXISTING blind spot in the
+///      projection cross-check (the same granularity the gap_detected note in
+///      mn_state_machine.hpp calls out), not something this recovery
+///      introduces — the recovery only ever runs when the cross-check already
+///      failed.
+///
 /// FENCED: src/impl/dash only. Constructed exclusively by the opt-in embedded
 /// path in main_dash.cpp; the dashd-RPC fallback never touches this file.
 
@@ -124,6 +168,12 @@ public:
     using TipHeightFn = std::function<uint32_t()>;
     /// Block hash our header chain holds at `height`, if known.
     using HeaderHashAtFn = std::function<std::optional<uint256>(uint32_t)>;
+    /// Three-state SML validity attestation for a proTxHash — nullopt when the
+    /// masternode is absent from the SML (no opinion), false when the SML
+    /// attests it PoSe-banned, true when it attests it live. See
+    /// MnStateMachine::SmlValidityFn and the residuals note in this file's
+    /// header. Wired by main_dash to NodeCoinState::sml() + have_sml().
+    using SmlValidityFn = MnStateMachine::SmlValidityFn;
 
     enum class State {
         Unarmed,      ///< no checkpoint loaded — the lane does nothing
@@ -153,6 +203,13 @@ public:
     void set_publish_fn(PublishFn fn)            { m_publish = std::move(fn); }
     void set_tip_height_fn(TipHeightFn fn)       { m_tip_height = std::move(fn); }
     void set_header_hash_at_fn(HeaderHashAtFn fn){ m_header_hash_at = std::move(fn); }
+    /// OPTIONAL. Unwired, the bridge behaves exactly as it did before this
+    /// seam existed: any payee mismatch during replay is terminal.
+    void set_sml_validity_fn(SmlValidityFn fn)
+    {
+        m_has_sml_fn = static_cast<bool>(fn);
+        m_machine.set_sml_validity_fn(std::move(fn));
+    }
 
     /// Maximum number of blocks the bridge is willing to replay. A checkpoint
     /// further behind the tip than this is treated as STALE and refused: the
@@ -197,6 +254,11 @@ public:
     uint32_t anchor_height() const { return m_anchor_height; }
     uint32_t cursor_height() const { return m_next == 0 ? 0 : m_next - 1; }
     size_t   set_size()      const { return m_machine.size(); }
+    /// Masternodes PERMANENTLY excluded during this bridge on SML-attested
+    /// PoSe bans. Non-zero is not a failure — it is the repair working — but
+    /// it IS a degradation of how much of the published set the replay
+    /// verified, so it is surfaced here, in status(), and in the publish log.
+    size_t   sml_recovered() const { return m_sml_recovered; }
     bool     failed_closed() const { return m_state == State::FailedClosed; }
     bool     published()     const { return m_state == State::Published; }
 
@@ -269,6 +331,14 @@ public:
 
         if (m_state == State::Waiting) {
             m_state = State::Bridging;
+            // Size the SML ban-recovery budget against the replay distance.
+            // A PoSe ban is a rare per-masternode event, so the count of them
+            // inside a window scales with the window, not with the set size:
+            // 4 covers a short bridge, +1 per 1000 blocks covers a long one.
+            // Past that, "recovery" stops being a repair of a few known-banned
+            // nodes and becomes a wholesale override of the projection, which
+            // is precisely what this lane must never do.
+            m_machine.set_sml_recovery_cap(4 + (tip - m_anchor_height) / 1000);
             LOG_INFO << "[MN-CKPT] bridge START: replaying h=" << m_next
                      << ".." << tip << " (" << (tip - m_next + 1)
                      << " blocks) onto the anchored set";
@@ -317,9 +387,16 @@ public:
                 + (r.gap_detected ? "GAP" : "PAYEE DESYNC") + " at h="
                 + std::to_string(height)
                 + " — the pinned masternode-set anchor does not reproduce this"
-                  " block's actual coinbase payee. The anchor is wrong or the"
-                  " replay is incomplete; refusing to publish a masternode set"
-                  " that would mint a rejected coinbase");
+                  " block's actual coinbase payee. The anchor is wrong, the"
+                  " replay is incomplete, or a post-anchor PoSe ban could not"
+                  " be attested"
+                + (m_has_sml_fn
+                       ? std::string(" by the SML (absent entry, or attested"
+                                     " VALID because the masternode was banned"
+                                     " AND revived inside the replay window)")
+                       : std::string(" — no SML validity seam is wired"))
+                + ". Refusing to publish a masternode set that would mint a"
+                  " rejected coinbase");
         }
         if (r.total_after == 0) {
             return fail_closed(
@@ -329,12 +406,13 @@ public:
 
         m_next = height + 1;
         ++m_applied;
+        m_sml_recovered += r.sml_recovered;
         m_stalled_pumps = 0;
 
         if ((m_applied % 500) == 0) {
             LOG_INFO << "[MN-CKPT] bridge progress: applied " << m_applied
                      << " blocks, cursor h=" << height << " set="
-                     << r.total_after;
+                     << r.total_after << " sml-recovered=" << m_sml_recovered;
         }
 
         if (!m_tip_height) return;
@@ -363,7 +441,9 @@ private:
         // (an ordered stream, or a test harness), and the answer can publish or
         // fail the bridge — whose status must not then be overwritten by ours.
         m_status = "bridging: cursor h=" + std::to_string(m_next) + " target h="
-                   + std::to_string(tip);
+                   + std::to_string(tip) + " ("
+                   + std::to_string(m_sml_recovered)
+                   + " SML-recovered exclusions)";
         for (uint32_t h = from; h <= end; ++h) {
             // Same reason: a synchronous answer may have finished or failed the
             // bridge mid-loop. Never keep pulling history for a lane that is no
@@ -389,14 +469,19 @@ private:
                                " publish");
         }
         m_state  = State::Published;
+        // The recovery count rides on BOTH the status string and the log
+        // line. A degradation that is only visible in scrollback is
+        // half-silent, and this lane exists to make degradation loud.
         m_status = "published " + std::to_string(out.size())
-                   + " masternodes as-of h=" + std::to_string(as_of)
+                   + " masternodes (" + std::to_string(m_sml_recovered)
+                   + " SML-recovered exclusions) as-of h=" + std::to_string(as_of)
                    + " (anchor h=" + std::to_string(m_anchor_height)
                    + " + " + std::to_string(m_applied) + " replayed blocks)";
-        LOG_INFO << "[MN-CKPT] bridge COMPLETE: " << out.size()
-                 << " masternodes as-of h=" << as_of << " (anchor h="
-                 << m_anchor_height << ", replayed " << m_applied
-                 << " blocks, tip h=" << bridged_to
+        LOG_INFO << "[MN-CKPT] bridge COMPLETE: published " << out.size()
+                 << " masternodes (" << m_sml_recovered
+                 << " SML-recovered exclusions) as-of h=" << as_of
+                 << " (anchor h=" << m_anchor_height << ", replayed "
+                 << m_applied << " blocks, tip h=" << bridged_to
                  << ") -> publishing to the maintainer";
         m_publish(std::move(out), as_of);
     }
@@ -431,6 +516,8 @@ private:
 
     uint32_t m_next{0};             // the ONLY height apply_block may fold next
     uint32_t m_applied{0};
+    size_t   m_sml_recovered{0};    // masternodes excluded on SML-attested bans
+    bool     m_has_sml_fn{false};   // an SML validity seam was wired
     uint32_t m_max_bridge{kDefaultMaxBridgeBlocks};
     uint32_t m_stalled_pumps{0};
     uint32_t m_last_pump_next{0};        // cursor at the previous pump (stall probe)

--- a/src/impl/dash/coin/mn_state_machine.hpp
+++ b/src/impl/dash/coin/mn_state_machine.hpp
@@ -94,11 +94,15 @@
 #include <core/pack.hpp>
 #include <core/uint256.hpp>
 
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
+#include <functional>
+#include <limits>
 #include <map>
 #include <optional>
 #include <span>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -160,7 +164,58 @@ public:
         // payment was NOT attributed — never guess. Caller must fail
         // closed (stop backing templates with this payee set) + re-seed.
         bool payee_desync{false};
+        // The DIP-3 payee this machine projected from the PRE-block list
+        // (pass 0). Present whenever the pre-block list was non-empty,
+        // whether or not the coinbase agreed. Surfaced so a caller can name
+        // the MN in its own diagnostics without re-deriving it — and
+        // re-deriving POST-apply gives a DIFFERENT answer, because a
+        // successful mark moves that MN to the back of the queue.
+        std::optional<uint256> projected_payee;
+        // Number of ranked candidates PERMANENTLY excluded this block by the
+        // SML-attested PoSe-ban recovery walk (see set_sml_validity_fn). 0 on
+        // every ordinary block. A nonzero value means the projected payee
+        // disagreed with the coinbase AND the SML proved the disagreement was
+        // a post-anchor consensus PoSe ban rather than a real desync.
+        size_t sml_recovered{0};
     };
+
+    /// Optional validity attestation for a proTxHash, sourced from the
+    /// Simplified Masternode List. THREE-state on purpose:
+    ///
+    ///   std::nullopt — the proTxHash is ABSENT from the SML. No opinion.
+    ///                  Never treated as evidence of anything.
+    ///   false        — the SML ATTESTS INVALID (PoSe-banned / revoked).
+    ///   true         — the SML ATTESTS VALID.
+    ///
+    /// The distinction is load-bearing. "Absent" and "attested valid" both
+    /// BLOCK a demotion; only "attested invalid" may license one. A two-state
+    /// bool would collapse "I don't know" into one of the other two answers
+    /// and, either way, let the recovery walk act on non-evidence.
+    ///
+    /// DEFAULT IS NULL. With no hook installed this class behaves EXACTLY as
+    /// it did before the hook existed — same mutations, same ApplyResult
+    /// flags, same log lines. Every pre-existing caller and KAT is untouched.
+    using SmlValidityFn = std::function<std::optional<bool>(const uint256&)>;
+
+    void set_sml_validity_fn(SmlValidityFn fn) { m_sml_validity = std::move(fn); }
+    bool has_sml_validity_fn() const { return static_cast<bool>(m_sml_validity); }
+
+    /// Cumulative budget for SML-attested exclusions over the lifetime of
+    /// this machine (i.e. per bridge). The recovery walk REPAIRS a bounded,
+    /// expected phenomenon — a handful of masternodes PoSe-banned in the
+    /// window between a pinned anchor and the tip. A replay that needs dozens
+    /// of them is not being repaired, it is being overridden, and the honest
+    /// response to that is to fail closed. The caller sizes the budget
+    /// against its replay distance; see MnCheckpointLane::pump().
+    void set_sml_recovery_cap(size_t n) { m_sml_recovery_cap = n; }
+    size_t sml_recovery_cap() const     { return m_sml_recovery_cap; }
+    size_t sml_recovered_total() const  { return m_sml_recovered_total; }
+
+    /// How deep pass 0's ranked candidate list goes. The recovery walk can
+    /// never look past this depth, which bounds both the work and the blast
+    /// radius: a genuine desync cannot be "walked off" by marching down an
+    /// unbounded queue until something happens to match.
+    static constexpr size_t kPayeeCandidates = 8;
 
     /// as_of_height: the chain height this snapshot is CURRENT AT (0 =
     /// unknown / cold). It seeds the forward-contiguous apply cursor: the
@@ -342,10 +397,22 @@ public:
                  << " scriptPayout(" << s.scriptPayout.m_data.size() << ")=" << sphex;
     }
 
-    std::optional<uint256> find_expected_payee() const
+    /// The first `k` masternodes of the DIP-3 payment queue, in dashd's
+    /// CompareByLastPaid order (ascending). ranked[0] IS find_expected_payee()
+    /// — the two share this scan so they can never disagree.
+    ///
+    /// Why a LIST and not just the winner: PoSe bans are consensus-driven and
+    /// never appear as a transaction, so apply_block cannot observe one. If
+    /// dashd banned the MN at the head of our queue after our snapshot was
+    /// taken, dashd's payee is the SECOND entry of OUR queue and the coinbase
+    /// cross-check fails. Only the SML carries that ban. Recovering needs the
+    /// runners-up, in order, computed on the SAME pre-block state dashd
+    /// projects from.
+    std::vector<uint256> rank_payee_candidates(size_t k) const
     {
-        std::optional<uint256> best_hash;
-        int best_h = 0;
+        std::vector<std::pair<int, uint256>> cands;
+        if (k == 0) return {};
+        cands.reserve(m_entries.size());
         // Defensive: dashd's protx info JSON reports "lastPaidHeight": -1
         // (and PoSeRevivedHeight: -1, PoSeBanHeight: -1) as sentinel for
         // "never paid / never revived / never banned". Snapshots dumped by
@@ -378,17 +445,33 @@ public:
             } else if (h == 0) {
                 h = static_cast<int>(st.nRegisteredHeight);
             }
-            bool better = !best_hash.has_value()
-                       || h < best_h
-                       || (h == best_h
-                           && std::memcmp(hash.data(),
-                                          best_hash->data(), 32) < 0);
-            if (better) {
-                best_h    = h;
-                best_hash = hash;
-            }
+            cands.emplace_back(h, hash);
         }
-        return best_hash;
+        // dashcore CompareByLastPaid: score ascending, ties broken by
+        // proTxHash memcmp ascending (LE-byte, NOT c2pool's CompareTo).
+        auto by_last_paid = [](const std::pair<int, uint256>& a,
+                               const std::pair<int, uint256>& b) {
+            if (a.first != b.first) return a.first < b.first;
+            return std::memcmp(a.second.data(), b.second.data(), 32) < 0;
+        };
+        if (cands.size() > k) {
+            std::partial_sort(cands.begin(), cands.begin() + k, cands.end(),
+                              by_last_paid);
+            cands.resize(k);
+        } else {
+            std::sort(cands.begin(), cands.end(), by_last_paid);
+        }
+        std::vector<uint256> out;
+        out.reserve(cands.size());
+        for (auto& c : cands) out.push_back(c.second);
+        return out;
+    }
+
+    std::optional<uint256> find_expected_payee() const
+    {
+        auto ranked = rank_payee_candidates(1);
+        if (ranked.empty()) return std::nullopt;
+        return ranked.front();
     }
 
     // Dump entire current state for persistence (mn_state_db.write_all).
@@ -586,7 +669,18 @@ public:
         // PRE-block list (oldList.GetMNPayee(pindexPrev)) BEFORE folding
         // this block's special txs; the mark lands after passes 1/2 (and
         // only if the MN survived them — newList.HasMN). Mirror exactly.
-        const std::optional<uint256> projected = find_expected_payee();
+        //
+        // We keep the top-K queue, not just the winner. ranked[0] IS what
+        // find_expected_payee() returns, so the ordinary path is unchanged;
+        // the runners-up exist only for the SML-attested PoSe-ban recovery in
+        // pass 3, and are computed HERE, from the PRE-block state, because
+        // that is the list dashd projects from.
+        const std::vector<uint256> ranked =
+            rank_payee_candidates(kPayeeCandidates);
+        const std::optional<uint256> projected =
+            ranked.empty() ? std::optional<uint256>{}
+                           : std::optional<uint256>{ranked.front()};
+        r.projected_payee = projected;
 
         // ── Pass 1: special-tx records ─────────────────────────────
         // Walk all non-coinbase txs (i=1+). The order of types within
@@ -740,34 +834,40 @@ public:
         // desynced — report payee_desync, attribute nothing, and let the
         // caller fail closed + re-seed (never guess).
         if (projected && !block.m_txs.empty()) {
+            // Exact script-equality against a coinbase output. Reused by the
+            // recovery walk below — "the accepted candidate's script matches
+            // an output the block actually pays" is the ONLY acceptance
+            // evidence, and it is never relaxed to "close enough".
+            auto paid_in_cb = [&](const std::vector<unsigned char>& script) {
+                if (script.empty()) return false;
+                for (const auto& vout : block.m_txs[0].vout) {
+                    if (vout.scriptPubKey.m_data == script) return true;
+                }
+                return false;
+            };
+            auto mark_paid = [&](std::map<uint256, MNState>::iterator it) {
+                bool was_consecutive =
+                    (it->second.nLastPaidHeight == height - 1);
+                it->second.nLastPaidHeight = height;
+                if (it->second.nType == vendor::MnType::EVO) {
+                    it->second.nConsecutivePayments =
+                        was_consecutive
+                            ? it->second.nConsecutivePayments + 1 : 1;
+                } else {
+                    it->second.nConsecutivePayments = 0;
+                }
+                ++r.paid;
+            };
+
             auto it = m_entries.find(*projected);
             // Mirrors dashcore's newList.HasMN(payee->proRegTxHash): a
             // payee whose MN was removed by THIS block's passes 1/2 is
             // silently skipped (no mark, no desync).
             if (it != m_entries.end()) {
-                const auto& script = it->second.scriptPayout.m_data;
-                bool paid_in_cb = false;
-                if (!script.empty()) {
-                    for (const auto& vout : block.m_txs[0].vout) {
-                        if (vout.scriptPubKey.m_data == script) {
-                            paid_in_cb = true;
-                            break;
-                        }
-                    }
-                }
-                if (paid_in_cb) {
-                    bool was_consecutive =
-                        (it->second.nLastPaidHeight == height - 1);
-                    it->second.nLastPaidHeight = height;
-                    if (it->second.nType == vendor::MnType::EVO) {
-                        it->second.nConsecutivePayments =
-                            was_consecutive
-                                ? it->second.nConsecutivePayments + 1 : 1;
-                    } else {
-                        it->second.nConsecutivePayments = 0;
-                    }
-                    ++r.paid;
-                } else {
+                if (paid_in_cb(it->second.scriptPayout.m_data)) {
+                    mark_paid(it);
+                } else if (!recover_from_sml_ban(ranked, height, paid_in_cb,
+                                                 mark_paid, r)) {
                     r.payee_desync = true;
                     LOG_WARNING << "[MNS-SM] PAYEE DESYNC h=" << height
                                 << ": coinbase does not pay projected MN "
@@ -783,8 +883,125 @@ public:
     }
 
 private:
+    // ─────────────────────────────────────────────────────────────────────
+    // recover_from_sml_ban — the ONLY licensed alternative to payee_desync
+    // ─────────────────────────────────────────────────────────────────────
+    //
+    // A PoSe ban is applied by dashd's CDeterministicMNManager from consensus
+    // (accumulated MAX_PoSe_PENALTY), never as a special tx. apply_block walks
+    // special txs, so it is STRUCTURALLY incapable of seeing one: an MN banned
+    // after our snapshot/anchor was taken stays isValid=true in m_entries
+    // forever and keeps its place at the head of our payment queue. dashd
+    // skipped it; the block pays the NEXT eligible masternode; our pass-3
+    // cross-check sees a mismatch and reports payee_desync. On the checkpoint
+    // bridge that is terminal, so a single post-anchor ban permanently
+    // prevents the daemonless arm from ever publishing a masternode set.
+    //
+    // The SML is the only carrier of that ban, so it is the only thing that
+    // can license a repair. This walk requires, for EVERY step:
+    //
+    //   * the demoted candidate to be ATTESTED INVALID by the hook. Absent
+    //     from the SML is not evidence. Attested valid is counter-evidence
+    //     and stops the walk immediately.
+    //   * the accepted candidate's scriptPayout to EXACTLY equal an output
+    //     the block actually pays. Never a prefix, never an address-family
+    //     guess, never "the only unexplained output".
+    //
+    // If either cannot be satisfied at any step, the walk refuses and the
+    // caller reports payee_desync EXACTLY as before. There is no partial
+    // outcome: on refusal nothing is mutated.
+    //
+    // On acceptance the demoted entries are flipped isValid=false with
+    // nPoSeBanHeight = height, PERMANENTLY. One-shot exclusion would be
+    // strictly wrong: the MN would return to the head of the queue at its
+    // next turn (~|MN set| blocks later — ~2068 on DASH mainnet) and desync
+    // the replay all over again. The nonzero ban height additionally makes
+    // pass 1's ProUpServTx revival branch (gated on nPoSeBanHeight != 0)
+    // functional for that MN, so a genuine revival inside the replay window
+    // is picked up normally.
+    //
+    // Returns true iff a payment was attributed (r.paid / r.sml_recovered
+    // updated); false means "no licensed repair" and the caller must desync.
+    template <typename PaidInCbFn, typename MarkPaidFn>
+    bool recover_from_sml_ban(const std::vector<uint256>& ranked,
+                              uint32_t height,
+                              const PaidInCbFn& paid_in_cb,
+                              const MarkPaidFn& mark_paid,
+                              ApplyResult& r)
+    {
+        if (!m_sml_validity) return false;   // null hook → pre-hook behaviour
+        if (ranked.size() < 2) return false;
+
+        std::vector<uint256> demoted;
+        std::optional<uint256> accepted;
+        for (size_t i = 0; i + 1 < ranked.size(); ++i) {
+            const std::optional<bool> att = m_sml_validity(ranked[i]);
+            // nullopt (absent from the SML) or true (attested valid): no
+            // licence to demote. Stop — this is a real desync.
+            if (!att.has_value() || *att) break;
+            demoted.push_back(ranked[i]);
+
+            auto nit = m_entries.find(ranked[i + 1]);
+            // The next candidate was removed by THIS block's passes 1/2
+            // (collateral spend / re-registration). We cannot test its script
+            // and the SML cannot attest a departed MN, so refuse rather than
+            // skip over it.
+            if (nit == m_entries.end()) break;
+            if (paid_in_cb(nit->second.scriptPayout.m_data)) {
+                accepted = ranked[i + 1];
+                break;
+            }
+            // Not paid either — the loop's next iteration must independently
+            // earn the right to demote ranked[i+1] too.
+        }
+        if (!accepted) return false;
+
+        // Budget check LAST, so a refusal here mutates nothing either.
+        if (m_sml_recovered_total + demoted.size() > m_sml_recovery_cap) {
+            LOG_WARNING << "[MNS-SM] SML BAN-RECOVERY REFUSED h=" << height
+                        << ": " << demoted.size() << " further exclusion(s) would"
+                           " exceed the per-bridge cap of " << m_sml_recovery_cap
+                        << " (already used " << m_sml_recovered_total
+                        << ") — failing closed instead of overriding the"
+                           " projection wholesale";
+            return false;
+        }
+
+        std::string demoted_hexes;
+        for (const auto& d : demoted) {
+            auto dit = m_entries.find(d);
+            if (dit != m_entries.end()) {
+                dit->second.isValid       = false;
+                dit->second.nPoSeBanHeight = height;
+            }
+            if (!demoted_hexes.empty()) demoted_hexes += ",";
+            demoted_hexes += d.GetHex().substr(0, 16);
+        }
+        auto ait = m_entries.find(*accepted);
+        if (ait != m_entries.end()) mark_paid(ait);
+
+        r.sml_recovered        = demoted.size();
+        m_sml_recovered_total += demoted.size();
+        LOG_WARNING << "[MNS-SM] SML BAN-RECOVERY h=" << height
+                    << ": projected payee(s) [" << demoted_hexes
+                    << "] attested INVALID by the SML (consensus PoSe ban, not"
+                       " tx-visible) — excluded permanently with banHeight="
+                    << height << "; payment attributed to "
+                    << accepted->GetHex().substr(0, 16)
+                    << " whose scriptPayout matches this coinbase exactly"
+                       " (bridge total " << m_sml_recovered_total << "/"
+                    << m_sml_recovery_cap << ")";
+        return true;
+    }
+
     std::map<uint256, MNState>                                          m_entries;
     std::map<bitcoin_family::coin::TxPrevOut, uint256, TxPrevOutLess>   m_collateral_index;
+
+    // Optional SML attestation hook (see set_sml_validity_fn). NULL by
+    // default: no hook, no recovery, byte-identical pre-hook behaviour.
+    SmlValidityFn m_sml_validity;
+    size_t        m_sml_recovery_cap{0};
+    size_t        m_sml_recovered_total{0};
 
     // Forward-only apply cursor: height of the last block folded by
     // apply_block (0 = none since load). See ApplyResult::skipped_out_of_order.

--- a/test/test_dash_mn_checkpoint.cpp
+++ b/test/test_dash_mn_checkpoint.cpp
@@ -40,6 +40,8 @@
 
 #include <impl/dash/coin/mn_checkpoint.hpp>       // parse_mn_checkpoint (DUT)
 #include <impl/dash/coin/mn_checkpoint_lane.hpp>  // MnCheckpointLane (DUT)
+#include <impl/dash/coin/vendor/providertx.hpp>   // CProUpServTx (revival leg)
+#include <impl/dash/coin/vendor/simplifiedmns.hpp>// CSimplifiedMNList (attestation source)
 #include <impl/dash/coin/mn_seed.hpp>             // parse_protx_list_seed (E2c cross-check)
 #include <impl/dash/coin/node_interface.hpp>
 #include <impl/dash/coin/mn_list_ingest.hpp>      // wire_mn_list_ingest (leg 4)
@@ -53,9 +55,11 @@
 #include <nlohmann/json.hpp>
 
 #include <algorithm>
+#include <functional>
 #include <map>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 using dash::coin::MNState;
@@ -749,4 +753,333 @@ TEST(DashMnCheckpointE2e, NegativeControlAntiMintLatchBlocksUnseededArming)
     fire_tip();
     EXPECT_TRUE(state.populated())
         << "a height-stamped authoritative snapshot must still arm normally";
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 6. POST-ANCHOR PoSe BANS — the SML-attested recovery walk.
+//
+// A PoSe ban is applied by dashd from CONSENSUS (accumulated
+// MAX_PoSe_PENALTY); it never appears as a special transaction in any block.
+// MnStateMachine::apply_block walks special txs, so it is STRUCTURALLY unable
+// to observe one. A masternode banned after the anchor height therefore stays
+// isValid=true through the whole replay, holds the head of our payment queue,
+// and is projected as the payee for a block dashd paid to somebody else. The
+// bridge cross-check fires, and here that is TERMINAL — so ONE post-anchor ban
+// anywhere in the window means the daemonless arm never publishes a masternode
+// set at all, and every template keeps routing to dashd.
+//
+// The SML is the only carrier of that ban. These cases drive the recovery
+// through the PRODUCTION SEAMS ONLY: a real MnCheckpointLane, armed with the
+// real fixture checkpoint, all four existing seams wired plus a
+// fixture-SML-backed validity fn built the same way main_dash builds it, then
+// pump()/on_block_connected() with blocks whose non-payee bytes are the REAL
+// accepted testnet blocks. The lane was missed by the original suite precisely
+// because nothing entered it this way.
+// ═══════════════════════════════════════════════════════════════════════════
+namespace {
+
+using dash::coin::MutableTransaction;
+using dash::coin::vendor::CProUpServTx;
+using dash::coin::vendor::CSimplifiedMNList;
+using dash::coin::vendor::CSimplifiedMNListEntry;
+
+// The six anchored masternodes in DIP-3 queue order at h=1519543 (ascending
+// nLastPaidHeight 1519459..1519464, which is the CompareByLastPaid key for all
+// six). The payout-address groups matter: Q1/Q4/Q5 share yVXDA…, Q2/Q3 share
+// yeRZB…, Q6 is alone on yjTpMw… — which is why a demotion from Q1 lands on Q2
+// (different script, cross-checkable) and why reaching Q6 costs five.
+const char* const kQ1 = "dc2e02ac95ce4ccc9843c38de7bdaf32f2a1d5966c054127a3f4ca4f4bbd5991";
+const char* const kQ2 = "9b653e767b978c10346d938c08dc8c5acd03c495f9d913e6fc652bfcae11a348";
+const char* const kQ3 = "91bbce94c34ebde0d099c0a2cb7635c0c31425ebabcec644f4f1a0854bfa605d";
+const char* const kQ4 = "72ee70fa75262781a17d1eb69a6c3e97328208be98b59d5530164f31e481d3aa";
+const char* const kQ5 = "c87218fb9d031f4926c22430c69b4edf1f0fb80c331c1a79e3b1b3873407c0ac";
+const char* const kQ6 = "ecebeb952f56a61abaccd7bda7f4df5eccbd5f87a91bc4a8969535df1058158e";
+
+// Take the payout script from the ANCHOR rather than hardcoding hex, so a
+// fixture regeneration cannot leave these tests quietly probing a script no
+// masternode owns any more.
+std::vector<unsigned char> payout_of(const MnCheckpoint& cp, const char* protx)
+{
+    const uint256 want = uint256S(protx);
+    for (const auto& [h, st] : cp.entries)
+        if (h == want) return st.scriptPayout.m_data;
+    ADD_FAILURE() << "the anchor carries no masternode " << protx;
+    return {};
+}
+
+// Rewrite the coinbase output paying `from` so it pays `to`. This synthesises
+// "dashd skipped our projected payee and paid a later queue slot" on top of a
+// REAL accepted block: every byte except that one output script — header,
+// CbTx payload, the rest of the outputs — stays exactly as the network
+// produced it.
+dash::coin::BlockType repay_coinbase(dash::coin::BlockType blk,
+                                     const std::vector<unsigned char>& from,
+                                     const std::vector<unsigned char>& to)
+{
+    EXPECT_FALSE(blk.m_txs.empty());
+    bool hit = false;
+    for (auto& o : blk.m_txs[0].vout) {
+        if (o.scriptPubKey.m_data == from) {
+            o.scriptPubKey.m_data = to;
+            hit = true;
+        }
+    }
+    EXPECT_TRUE(hit) << "template block does not pay the script being replaced";
+    return blk;
+}
+
+// A fixture SML plus the EXACT lambda shape main_dash wires around
+// NodeCoinState::sml(): linear scan, three-state, std::nullopt when the
+// masternode is absent. Captured BY VALUE so the hook cannot outlive its data.
+MnCheckpointLane::SmlValidityFn sml_fn(
+    const std::vector<std::pair<const char*, bool>>& entries)
+{
+    std::vector<CSimplifiedMNListEntry> v;
+    v.reserve(entries.size());
+    for (const auto& [hex, valid] : entries) {
+        CSimplifiedMNListEntry e;
+        e.proRegTxHash = uint256S(hex);
+        e.isValid      = valid;
+        v.push_back(e);
+    }
+    CSimplifiedMNList sml(std::move(v));
+    return [sml](const uint256& h) -> std::optional<bool> {
+        for (const auto& e : sml.mnList)
+            if (e.proRegTxHash == h) return e.isValid;
+        return std::nullopt;
+    };
+}
+
+// Every masternode attested VALID except the listed ones.
+std::vector<std::pair<const char*, bool>> all_valid_except(
+    std::initializer_list<const char*> banned)
+{
+    std::vector<std::pair<const char*, bool>> out;
+    for (const char* q : {kQ1, kQ2, kQ3, kQ4, kQ5, kQ6}) {
+        bool is_banned = false;
+        for (const char* b : banned) if (std::string(b) == q) is_banned = true;
+        out.emplace_back(q, !is_banned);
+    }
+    return out;
+}
+
+// A one-block bridge over the real anchor: arm, then let pump() pull and fold
+// the single block through the real request/deliver path.
+struct RecoveryRig {
+    MnCheckpoint  cp{good_checkpoint()};
+    BridgeHarness h;
+
+    void run(const dash::coin::BlockType& blk, uint32_t tip = 1519544)
+    {
+        h.headers[kAnchorHeight] = uint256S(kAnchorHash);
+        h.blocks[1519544] = blk;
+        h.tip = tip;
+        h.lane.arm(cp);
+        h.lane.pump();
+    }
+};
+
+std::vector<unsigned char> protx_payload_bytes(const CProUpServTx& p)
+{
+    auto ps = ::pack(p);
+    auto sp = ps.get_span();
+    return std::vector<unsigned char>(
+        reinterpret_cast<const unsigned char*>(sp.data()),
+        reinterpret_cast<const unsigned char*>(sp.data()) + sp.size());
+}
+
+// A ProUpServTx reviving `protx`. dashcore's revival branch — which
+// MnStateMachine mirrors — is gated on nPoSeBanHeight != 0, so this tx is a
+// NO-OP unless something recorded a ban height for that masternode first.
+MutableTransaction pro_up_serv_tx(const char* protx)
+{
+    CProUpServTx p;
+    p.nVersion  = dash::coin::vendor::ProTxVersion::BASIC_BLS;
+    p.nType     = dash::coin::vendor::MnType::REGULAR;
+    p.proTxHash = uint256S(protx);
+    p.netInfo.port_be = 0x2334;
+
+    MutableTransaction tx;
+    tx.type          = CProUpServTx::SPECIALTX_TYPE;
+    tx.extra_payload = protx_payload_bytes(p);
+    bitcoin_family::coin::TxIn in;
+    in.prevout.hash  = uint256{};
+    in.prevout.index = 0xFFFFFFFF;
+    in.sequence      = 0xFFFFFFFF;
+    tx.vin.push_back(in);
+    return tx;
+}
+
+} // namespace
+
+// CASE 1. The bug this whole change exists for. dashd banned our queue head
+// after the anchor was cut, so the block pays queue slot 2. Today that is a
+// terminal payee_desync and the arm never arms. With the SML attesting the
+// ban, the bridge COMPLETES — and the published set carries the exclusion
+// permanently, because a one-shot skip would desync again at that masternode's
+// next queue turn (~|set| blocks later).
+TEST(DashMnCheckpointSmlRecovery, PostAnchorBanAttestedBySmlCompletesTheBridge)
+{
+    RecoveryRig r;
+    auto blk = repay_coinbase(block_from_hex(kBlockHex1519544),
+                              payout_of(r.cp, kQ1), payout_of(r.cp, kQ2));
+    r.h.lane.set_sml_validity_fn(sml_fn(all_valid_except({kQ1})));
+    r.run(blk);
+
+    ASSERT_TRUE(r.h.published) << "lane status: " << r.h.lane.status();
+    EXPECT_EQ(r.h.lane.state(), MnCheckpointLane::State::Published);
+    EXPECT_EQ(r.h.lane.sml_recovered(), 1u);
+    EXPECT_NE(r.h.lane.status().find("1 SML-recovered exclusions"),
+              std::string::npos)
+        << "the recovery count must be on the published status, not only in"
+           " scrollback: " << r.h.lane.status();
+
+    std::map<uint256, MNState> out(r.h.published_set.begin(),
+                                   r.h.published_set.end());
+    const MNState& demoted = out.at(uint256S(kQ1));
+    EXPECT_FALSE(demoted.isValid) << "the exclusion must be PERMANENT";
+    EXPECT_EQ(demoted.nPoSeBanHeight, 1519544u)
+        << "a nonzero ban height is what makes the ProUpServTx revival gate"
+           " functional for this masternode";
+    EXPECT_EQ(demoted.nLastPaidHeight, 1519459u)
+        << "the demoted masternode must NOT be credited with the payment";
+    EXPECT_EQ(out.at(uint256S(kQ2)).nLastPaidHeight, 1519544u)
+        << "the accepted candidate is the one whose script the coinbase pays";
+}
+
+// CASE 2. Same desync, but the SML says the projected payee is LIVE. Then the
+// mismatch is a real desync (bad anchor, missed block, corrupt seed) and the
+// only correct answer is the old one. Attested-valid is COUNTER-evidence, and
+// this is the case that stops the walk from excusing anything it likes.
+TEST(DashMnCheckpointSmlRecovery, SmlAttestingProjectedPayeeValidStillFailsClosed)
+{
+    RecoveryRig r;
+    auto blk = repay_coinbase(block_from_hex(kBlockHex1519544),
+                              payout_of(r.cp, kQ1), payout_of(r.cp, kQ2));
+    r.h.lane.set_sml_validity_fn(sml_fn(all_valid_except({})));
+    r.run(blk);
+
+    EXPECT_EQ(r.h.lane.state(), MnCheckpointLane::State::FailedClosed)
+        << r.h.lane.status();
+    EXPECT_NE(r.h.lane.status().find("PAYEE DESYNC"), std::string::npos)
+        << r.h.lane.status();
+    EXPECT_FALSE(r.h.published);
+    EXPECT_EQ(r.h.lane.sml_recovered(), 0u);
+}
+
+// CASE 3. No hook at all — the pre-change wiring. Behaviour must be exactly
+// what it was: terminal.
+TEST(DashMnCheckpointSmlRecovery, NoSmlSeamWiredKeepsTheTerminalFailClosed)
+{
+    RecoveryRig r;
+    auto blk = repay_coinbase(block_from_hex(kBlockHex1519544),
+                              payout_of(r.cp, kQ1), payout_of(r.cp, kQ2));
+    r.run(blk);   // deliberately no set_sml_validity_fn
+
+    EXPECT_EQ(r.h.lane.state(), MnCheckpointLane::State::FailedClosed)
+        << r.h.lane.status();
+    EXPECT_FALSE(r.h.published);
+    EXPECT_EQ(r.h.lane.sml_recovered(), 0u);
+    EXPECT_NE(r.h.lane.status().find("no SML validity seam is wired"),
+              std::string::npos)
+        << "the operator must be told WHICH input was missing: "
+        << r.h.lane.status();
+}
+
+// CASE 3b. A hook that has no opinion. Absent-from-SML is not evidence of a
+// ban; collapsing nullopt into "banned" would turn every SML gap into a
+// licence to re-attribute payments.
+TEST(DashMnCheckpointSmlRecovery, SmlWithoutTheMasternodeIsNotEvidence)
+{
+    RecoveryRig r;
+    auto blk = repay_coinbase(block_from_hex(kBlockHex1519544),
+                              payout_of(r.cp, kQ1), payout_of(r.cp, kQ2));
+    // An SML that carries only OTHER masternodes: the projected payee is
+    // simply absent, so the hook answers std::nullopt for it.
+    r.h.lane.set_sml_validity_fn(sml_fn({{kQ3, true}, {kQ4, true}}));
+    r.run(blk);
+
+    EXPECT_EQ(r.h.lane.state(), MnCheckpointLane::State::FailedClosed)
+        << r.h.lane.status();
+    EXPECT_FALSE(r.h.published);
+    EXPECT_EQ(r.h.lane.sml_recovered(), 0u);
+}
+
+// CASE 4. The demotion is licensed, but the re-projection ALSO does not match
+// the coinbase, and the next candidate down is attested live. Acceptance
+// requires an EXACT coinbase script match at some licensed step; there is
+// none, so nothing is attributed and nothing is excluded.
+TEST(DashMnCheckpointSmlRecovery, ReProjectionThatAlsoMismatchesFailsClosed)
+{
+    RecoveryRig r;
+    // Pay Q6's script. Q2 (the first demotion target) is on a different
+    // script, so the walk stalls immediately after one licensed demotion.
+    auto blk = repay_coinbase(block_from_hex(kBlockHex1519544),
+                              payout_of(r.cp, kQ1), payout_of(r.cp, kQ6));
+    r.h.lane.set_sml_validity_fn(sml_fn(all_valid_except({kQ1})));
+    r.run(blk);
+
+    EXPECT_EQ(r.h.lane.state(), MnCheckpointLane::State::FailedClosed)
+        << r.h.lane.status();
+    EXPECT_NE(r.h.lane.status().find("PAYEE DESYNC"), std::string::npos)
+        << r.h.lane.status();
+    EXPECT_FALSE(r.h.published);
+    EXPECT_EQ(r.h.lane.sml_recovered(), 0u)
+        << "a refused walk must not leave a partial exclusion behind";
+}
+
+// CASE 5. The budget. The lane sizes it at 4 + replay_distance/1000, so a
+// one-block bridge allows 4. Reaching Q6 costs FIVE demotions (Q1..Q5), and
+// every one of them is attested — the walk would otherwise succeed. Past the
+// cap this stops being a repair of a few known-banned nodes and becomes a
+// wholesale override of the projection, so it fails closed instead.
+TEST(DashMnCheckpointSmlRecovery, ExclusionsPastThePerBridgeCapFailClosed)
+{
+    RecoveryRig r;
+    auto blk = repay_coinbase(block_from_hex(kBlockHex1519544),
+                              payout_of(r.cp, kQ1), payout_of(r.cp, kQ6));
+    r.h.lane.set_sml_validity_fn(
+        sml_fn(all_valid_except({kQ1, kQ2, kQ3, kQ4, kQ5})));
+    r.run(blk);
+
+    EXPECT_EQ(r.h.lane.state(), MnCheckpointLane::State::FailedClosed)
+        << r.h.lane.status();
+    EXPECT_FALSE(r.h.published);
+    EXPECT_EQ(r.h.lane.sml_recovered(), 0u);
+}
+
+// CASE 6. The permanence pays off. The excluded masternode is later revived by
+// a real ProUpServTx inside the same replay window. dashcore's revival branch
+// is gated on nPoSeBanHeight != 0 — so it fires ONLY because the recovery
+// recorded a ban height. Without that (the one-shot-skip design), this
+// masternode's revivedHeight would stay at its stale anchor value of 1367840
+// and it would sit at the wrong queue position for the rest of the bridge.
+TEST(DashMnCheckpointSmlRecovery, RevivalTxLaterInWindowFiresOffTheRecoveredBan)
+{
+    RecoveryRig r;
+    auto b44 = repay_coinbase(block_from_hex(kBlockHex1519544),
+                              payout_of(r.cp, kQ1), payout_of(r.cp, kQ2));
+    auto b45 = block_from_hex(kBlockHex1519545);
+    b45.m_txs.push_back(pro_up_serv_tx(kQ1));
+
+    r.h.blocks[1519545] = b45;
+    r.h.lane.set_sml_validity_fn(sml_fn(all_valid_except({kQ1})));
+    r.run(b44, /*tip=*/1519545);
+
+    ASSERT_TRUE(r.h.published) << "lane status: " << r.h.lane.status();
+    EXPECT_EQ(r.h.published_as_of, 1519545u);
+    EXPECT_EQ(r.h.lane.sml_recovered(), 1u);
+
+    std::map<uint256, MNState> out(r.h.published_set.begin(),
+                                   r.h.published_set.end());
+    const MNState& revived = out.at(uint256S(kQ1));
+    EXPECT_TRUE(revived.isValid) << "the ProUpServTx must bring it back";
+    EXPECT_EQ(revived.nPoSeBanHeight, 0u);
+    EXPECT_EQ(revived.nPoSeRevivedHeight, 1519545u)
+        << "revivedHeight still at the anchor's 1367840 means the revival"
+           " branch never fired -- i.e. the exclusion did not record a ban"
+           " height and the queue position is now wrong";
+    // 1519545's own payee is unaffected: pass 0 projects from the PRE-block
+    // list, where kQ1 is still excluded, so queue slot 3 was paid.
+    EXPECT_EQ(out.at(uint256S(kQ3)).nLastPaidHeight, 1519545u);
 }

--- a/test/test_dash_mn_state.cpp
+++ b/test/test_dash_mn_state.cpp
@@ -1115,3 +1115,262 @@ TEST(DashMnState, SelectionGuardTreatsSentinelBanHeightAsNeverBanned) {
     ASSERT_TRUE(pk.has_value());
     EXPECT_EQ(*pk, h);
 }
+
+// ════════════════════════════════════════════════════════════════════════
+// Ranked payee candidates + the SML-attested PoSe-ban recovery walk.
+//
+// PoSe bans are consensus-driven and never appear as a special tx, so
+// apply_block cannot observe one at any price. A masternode banned after a
+// snapshot/anchor was taken keeps the head of our payment queue forever; the
+// block pays the NEXT eligible node and pass 3 reports payee_desync. The SML
+// is the only carrier of that ban, so it is the only thing that may license a
+// repair. These pin the mechanism at the unit boundary; the production-seam
+// coverage (a real MnCheckpointLane driven through pump()/on_block_connected)
+// lives in test_dash_mn_checkpoint.cpp.
+// ════════════════════════════════════════════════════════════════════════
+
+static MNState payee_mn(uint32_t last_paid,
+                        const std::vector<unsigned char>& script) {
+    MNState s;
+    s.isValid             = true;
+    s.nRegisteredHeight   = 2400000;
+    s.nLastPaidHeight     = last_paid;
+    s.scriptPayout.m_data = script;
+    return s;
+}
+
+// A hook answering from an explicit table; anything absent answers nullopt,
+// which is the "no opinion" state the walk must refuse to act on.
+static MnStateMachine::SmlValidityFn attest(
+    std::vector<std::pair<uint256, bool>> table) {
+    return [table](const uint256& h) -> std::optional<bool> {
+        for (const auto& [k, v] : table)
+            if (k == h) return v;
+        return std::nullopt;
+    };
+}
+
+TEST(DashMnState, RankPayeeCandidatesMirrorsCompareByLastPaid) {
+    MnStateMachine m;
+    // Two ties at 1000 to exercise the proTxHash memcmp tiebreak, then two
+    // distinct heights above them.
+    uint256 a = raw256_byte(0, 0x01), b = raw256_byte(0, 0x02);
+    uint256 c = raw256_byte(0, 0x03), d = raw256_byte(0, 0x04);
+    m.load(std::vector<std::pair<uint256, MNState>>{
+        {d, payee_mn(1002, script_bytes(0x40, 25))},
+        {b, payee_mn(1000, script_bytes(0x41, 25))},
+        {c, payee_mn(1001, script_bytes(0x42, 25))},
+        {a, payee_mn(1000, script_bytes(0x43, 25))}});
+
+    auto ranked = m.rank_payee_candidates(4);
+    ASSERT_EQ(ranked.size(), 4u);
+    EXPECT_EQ(ranked[0], a) << "tie at 1000 breaks on proTxHash memcmp ascending";
+    EXPECT_EQ(ranked[1], b);
+    EXPECT_EQ(ranked[2], c);
+    EXPECT_EQ(ranked[3], d);
+
+    // The winner is find_expected_payee() BY CONSTRUCTION -- the two share one
+    // scan, so they can never drift apart.
+    auto exp = m.find_expected_payee();
+    ASSERT_TRUE(exp.has_value());
+    EXPECT_EQ(*exp, ranked.front());
+
+    // Truncation keeps the FRONT of the queue, not an arbitrary subset.
+    auto top2 = m.rank_payee_candidates(2);
+    ASSERT_EQ(top2.size(), 2u);
+    EXPECT_EQ(top2[0], a);
+    EXPECT_EQ(top2[1], b);
+    EXPECT_TRUE(m.rank_payee_candidates(0).empty());
+}
+
+TEST(DashMnState, RankPayeeCandidatesExcludesInvalidAndBanned) {
+    MnStateMachine m;
+    uint256 a = raw256_byte(0, 0x01), b = raw256_byte(0, 0x02),
+            c = raw256_byte(0, 0x03);
+    MNState sa = payee_mn(1000, script_bytes(0x50, 25)); sa.isValid = false;
+    MNState sb = payee_mn(1001, script_bytes(0x51, 25)); sb.nPoSeBanHeight = 2500000;
+    MNState sc = payee_mn(1002, script_bytes(0x52, 25));
+    m.load(std::vector<std::pair<uint256, MNState>>{{a, sa}, {b, sb}, {c, sc}});
+
+    auto ranked = m.rank_payee_candidates(MnStateMachine::kPayeeCandidates);
+    ASSERT_EQ(ranked.size(), 1u) << "neither an invalid nor a live-banned"
+                                    " masternode may be a payee candidate";
+    EXPECT_EQ(ranked[0], c);
+}
+
+// The default posture: no hook, so a mismatch is a desync and nothing else.
+// This is the guarantee that every pre-existing caller and KAT is untouched.
+TEST(DashMnState, NullSmlHookLeavesPayeeDesyncExactlyAsBefore) {
+    MnStateMachine m;
+    uint256 a = raw256_byte(0, 0x01), b = raw256_byte(0, 0x02);
+    auto s1 = script_bytes(0x60, 25);
+    auto s2 = script_bytes(0x61, 25);
+    m.load(std::vector<std::pair<uint256, MNState>>{
+               {a, payee_mn(1000, s1)}, {b, payee_mn(1001, s2)}},
+           2400000);
+    EXPECT_FALSE(m.has_sml_validity_fn());
+
+    BlockType blk;
+    blk.m_txs.push_back(coinbase_tx({s2}));      // pays queue slot 2
+    auto r = m.apply_block(blk, 2400001);
+
+    EXPECT_TRUE(r.payee_desync);
+    EXPECT_EQ(r.paid, 0u);
+    EXPECT_EQ(r.sml_recovered, 0u);
+    ASSERT_TRUE(r.projected_payee.has_value());
+    EXPECT_EQ(*r.projected_payee, a);
+    EXPECT_TRUE(m.entries().at(a).isValid) << "no hook, no exclusion";
+    EXPECT_EQ(m.entries().at(a).nPoSeBanHeight, 0u);
+    EXPECT_EQ(m.entries().at(b).nLastPaidHeight, 1001u)
+        << "a desync attributes NOTHING";
+}
+
+TEST(DashMnState, SmlAttestedBanDemotesPermanentlyAndAttributesToTheNext) {
+    MnStateMachine m;
+    uint256 a = raw256_byte(0, 0x01), b = raw256_byte(0, 0x02);
+    auto s1 = script_bytes(0x62, 25);
+    auto s2 = script_bytes(0x63, 25);
+    m.load(std::vector<std::pair<uint256, MNState>>{
+               {a, payee_mn(1000, s1)}, {b, payee_mn(1001, s2)}},
+           2400000);
+    m.set_sml_validity_fn(attest({{a, false}, {b, true}}));
+    m.set_sml_recovery_cap(4);
+
+    BlockType blk;
+    blk.m_txs.push_back(coinbase_tx({s2}));
+    auto r = m.apply_block(blk, 2400001);
+
+    EXPECT_FALSE(r.payee_desync);
+    EXPECT_EQ(r.paid, 1u);
+    EXPECT_EQ(r.sml_recovered, 1u);
+    EXPECT_EQ(m.sml_recovered_total(), 1u);
+    EXPECT_FALSE(m.entries().at(a).isValid);
+    EXPECT_EQ(m.entries().at(a).nPoSeBanHeight, 2400001u);
+    EXPECT_EQ(m.entries().at(a).nLastPaidHeight, 1000u);
+    EXPECT_EQ(m.entries().at(b).nLastPaidHeight, 2400001u);
+}
+
+// The acceptance side is EXACT script equality, never "the only unexplained
+// output". A coinbase that pays nobody in the set must not be attributed to
+// whichever candidate happens to be next, no matter how many bans are attested.
+TEST(DashMnState, SmlAttestedBanStillNeedsAnExactCoinbaseScriptMatch) {
+    MnStateMachine m;
+    uint256 a = raw256_byte(0, 0x01), b = raw256_byte(0, 0x02);
+    auto s1 = script_bytes(0x64, 25);
+    auto s2 = script_bytes(0x65, 25);
+    m.load(std::vector<std::pair<uint256, MNState>>{
+               {a, payee_mn(1000, s1)}, {b, payee_mn(1001, s2)}},
+           2400000);
+    m.set_sml_validity_fn(attest({{a, false}, {b, false}}));
+    m.set_sml_recovery_cap(4);
+
+    BlockType blk;
+    blk.m_txs.push_back(coinbase_tx({script_bytes(0x66, 25)}));  // nobody's
+    auto r = m.apply_block(blk, 2400001);
+
+    EXPECT_TRUE(r.payee_desync);
+    EXPECT_EQ(r.sml_recovered, 0u);
+    EXPECT_TRUE(m.entries().at(a).isValid)
+        << "a refused walk must leave NO partial exclusion behind";
+    EXPECT_TRUE(m.entries().at(b).isValid);
+}
+
+// The cap discriminator. IDENTICAL input either side; the only difference is
+// the budget, so a pass/fail split here can only be the cap.
+TEST(DashMnState, SmlRecoveryCapIsTheOnlyDifferenceAtTheBoundary) {
+    uint256 a = raw256_byte(0, 0x01), b = raw256_byte(0, 0x02),
+            c = raw256_byte(0, 0x03), d = raw256_byte(0, 0x04);
+    auto shared = script_bytes(0x70, 25);   // a, b, c all pay this
+    auto lone   = script_bytes(0x71, 25);   // d alone
+
+    auto build = [&](MnStateMachine& m, size_t cap) {
+        m.load(std::vector<std::pair<uint256, MNState>>{
+                   {a, payee_mn(1000, shared)}, {b, payee_mn(1001, shared)},
+                   {c, payee_mn(1002, shared)}, {d, payee_mn(1003, lone)}},
+               2400000);
+        m.set_sml_validity_fn(attest({{a, false}, {b, false}, {c, false},
+                                      {d, true}}));
+        m.set_sml_recovery_cap(cap);
+    };
+    BlockType blk;
+    blk.m_txs.push_back(coinbase_tx({lone}));   // dashd paid queue slot 4
+
+    // Budget 2 < the 3 exclusions the walk needs: refuse, mutate nothing.
+    MnStateMachine tight;
+    build(tight, 2);
+    auto r_tight = tight.apply_block(blk, 2400001);
+    EXPECT_TRUE(r_tight.payee_desync);
+    EXPECT_EQ(r_tight.sml_recovered, 0u);
+    EXPECT_TRUE(tight.entries().at(a).isValid);
+    EXPECT_EQ(tight.entries().at(d).nLastPaidHeight, 1003u);
+
+    // Budget 3 == what it needs: accept.
+    MnStateMachine roomy;
+    build(roomy, 3);
+    auto r_roomy = roomy.apply_block(blk, 2400001);
+    EXPECT_FALSE(r_roomy.payee_desync);
+    EXPECT_EQ(r_roomy.sml_recovered, 3u);
+    EXPECT_EQ(roomy.sml_recovered_total(), 3u);
+    for (const auto& h : {a, b, c}) {
+        EXPECT_FALSE(roomy.entries().at(h).isValid) << h.GetHex();
+        EXPECT_EQ(roomy.entries().at(h).nPoSeBanHeight, 2400001u);
+    }
+    EXPECT_EQ(roomy.entries().at(d).nLastPaidHeight, 2400001u);
+}
+
+// The walk stops at the FIRST candidate the SML does not attest invalid. An
+// attested-valid runner-up is counter-evidence: the mismatch is a genuine
+// desync and must be reported as one even though a deeper candidate would
+// have matched the coinbase.
+TEST(DashMnState, SmlRecoveryStopsAtTheFirstUnattestedCandidate) {
+    MnStateMachine m;
+    uint256 a = raw256_byte(0, 0x01), b = raw256_byte(0, 0x02),
+            c = raw256_byte(0, 0x03);
+    auto s1 = script_bytes(0x72, 25);
+    auto s2 = script_bytes(0x73, 25);
+    auto s3 = script_bytes(0x74, 25);
+    m.load(std::vector<std::pair<uint256, MNState>>{
+               {a, payee_mn(1000, s1)}, {b, payee_mn(1001, s2)},
+               {c, payee_mn(1002, s3)}},
+           2400000);
+    // a is banned, b is LIVE, and the coinbase pays c.
+    m.set_sml_validity_fn(attest({{a, false}, {b, true}, {c, false}}));
+    m.set_sml_recovery_cap(8);
+
+    BlockType blk;
+    blk.m_txs.push_back(coinbase_tx({s3}));
+    auto r = m.apply_block(blk, 2400001);
+
+    EXPECT_TRUE(r.payee_desync);
+    EXPECT_EQ(r.sml_recovered, 0u);
+    EXPECT_TRUE(m.entries().at(a).isValid);
+    EXPECT_EQ(m.entries().at(c).nLastPaidHeight, 1002u);
+}
+
+// Permanence is the whole point: a one-shot skip would put the banned node
+// back at the head of the queue at its next turn and desync the replay again.
+TEST(DashMnState, SmlRecoveryExclusionSurvivesTheNextQueueTurn) {
+    MnStateMachine m;
+    uint256 a = raw256_byte(0, 0x01), b = raw256_byte(0, 0x02);
+    auto s1 = script_bytes(0x75, 25);
+    auto s2 = script_bytes(0x76, 25);
+    m.load(std::vector<std::pair<uint256, MNState>>{
+               {a, payee_mn(1000, s1)}, {b, payee_mn(1001, s2)}},
+           2400000);
+    m.set_sml_validity_fn(attest({{a, false}, {b, true}}));
+    m.set_sml_recovery_cap(4);
+
+    BlockType blk;
+    blk.m_txs.push_back(coinbase_tx({s2}));
+    ASSERT_FALSE(m.apply_block(blk, 2400001).payee_desync);
+
+    // b now has the newest lastPaidHeight, so an un-excluded `a` would be back
+    // at the head of the queue. It must not be a candidate at all.
+    EXPECT_TRUE(m.rank_payee_candidates(8).empty()
+                || m.rank_payee_candidates(8).front() != a);
+    auto r2 = m.apply_block(blk, 2400002);
+    EXPECT_EQ(r2.sml_recovered, 0u) << "no SECOND exclusion should be needed";
+    EXPECT_FALSE(r2.payee_desync);
+    EXPECT_EQ(m.sml_recovered_total(), 1u);
+    EXPECT_EQ(m.entries().at(b).nLastPaidHeight, 2400002u);
+}


### PR DESCRIPTION
Completes #984. Closes the half that #985 left open.

## What was still broken after #985

`MnCheckpointLane` owns a **third, private** `MnStateMachine`. It loads the release-pinned anchor, replays anchor→tip through `apply_block`, and treats any `payee_desync` as **terminal** — the lane fails closed permanently and never publishes.

It never consulted the SML. #985 wired the reconciler into the *maintainer's* machine only.

A PoSe ban is applied by **consensus, never as a transaction**, so the replay is structurally unable to observe one. A masternode banned after the anchor height stays eligible in our projection, the coinbase pays the next eligible node, the bridge fail-closes, and **the daemonless arm never publishes a masternode set at all**.

That is the path the live incident actually died on:

```
anchor 2068 MNs @ h=2513000
  → bridge replaying h=2513001..2513557
  → FAIL-CLOSED: bridge replay PAYEE DESYNC at h=2513489
  → MN set never published
  → every template fell through to an unarmed dashd arm
```

The masternode in question — `e8626fcd57f6394db6669ad6db6fd44c` — was PoSe-banned at **h=2513418**, seventy-one blocks before we projected it. Confirmed against a live dashd: valid 2066 / registered 2972 at that height.

## The change

Pass 0 computes a **ranked candidate list** from the **pre-block** state rather than a single winner, preserving dashcore's projection semantics.

Pass 3, on mismatch, walks that ranking. Every demotion must be **attested invalid by the SML** through a new optional hook, and acceptance requires an **exact** coinbase script match — never a near miss. Demotions are **permanent** and stamp a ban height, so the node does not re-desync at that masternode's next queue turn ~2068 blocks later, and the existing revival gate becomes functional for it.

The hook **defaults to null and behaviour is byte-identical without it**, leaving #985's call site and every existing KAT untouched. Recoveries are capped per bridge, logged per event, and the running count is surfaced in `status()` and the publish line rather than living only in scrollback.

## Design alternatives evaluated and rejected

**Seed-time mask over the anchor.** Disqualified twice over. The queue pays each valid masternode roughly once per set-size blocks (~2068), so a masked masternode was genuinely paid at some height between the anchor and its actual ban — at the 20 000-block max bridge that approaches certainty for *every* mid-window ban. Worse: the pass-3 cross-check is **script-granular**, so inside a shared-`payoutAddress` group the wrong projection **passes** the cross-check and silently mis-attributes payment. That is the soak-found bad-cb-payee corruption class, reintroduced as a side effect of the fix.

**Lane-side desync recovery.** Wrong placement. By the time `payee_desync` is reported, passes 1/2 have run and the applied-height cursor advanced; the pre-block state is gone, `ApplyResult` does not carry which masternode was projected, and re-projecting against the post-pass list is semantically wrong.

**Per-height SML diff replay.** Correct in the limit and the only design that closes the shared-address residual, but it needs a new request seam and a second contiguity discipline. Deferred, not rejected.

## Verification

**Build:** configure 0, all targets 0.

**Tests:** 110 passing across three suites — `test_dash_node_reception_wire` 53, `test_dash_mn_state` 40, `test_dash_coin_state_maintainer` 17.

**Negative pass — behavioural, not a wholesale revert.** Reverting the production files wholesale yields 20 compile errors, which proves only that the tests depend on the new API. Instead the recovery was neutered in place (kept the API, made it never succeed = master behaviour) with the tests untouched:

```
PostAnchorBanAttestedBySmlCompletesTheBridge      FAILED   ← the incident
RevivalTxLaterInWindowFiresOffTheRecoveredBan     FAILED
SmlAttestingProjectedPayeeValidStillFailsClosed   OK
NoSmlSeamWiredKeepsTheTerminalFailClosed          OK
SmlWithoutTheMasternodeIsNotEvidence              OK
ReProjectionThatAlsoMismatchesFailsClosed         OK
ExclusionsPastThePerBridgeCapFailClosed           OK
```

**2 red, 5 green is the correct result.** The five that still pass assert *fail-closed* behaviour, which is what master already does — they must pass with the recovery disabled. Had all seven gone red, the tests would be coupled to the implementation rather than to behaviour.

Tree restored, 7/7 passing again.

## Documented residuals — pre-existing, not introduced

1. A masternode banned **and revived** within the replay window while currently `isValid==true` still fails closed — the SML cannot attest a historical ban. Same as today, not worse.
2. A post-anchor ban inside a shared-`payoutAddress` group can escape both the cross-check and the recovery, because both are **script-granular**. Pre-existing blind spot; only the per-height diff replay closes it.

## Scope

DASH tree only. Contiguity untouched — the recovery happens entirely inside the single `apply_block` at the cursor height; `m_next` advances by exactly one as always, no block re-folded, no height skipped.

Neither gate relaxed. The recovery **tightens** fail-closed by removing ineligible nodes before they can occupy a payment slot, and fires only on evidence the SML explicitly attests.

## Still open, not claimed by this PR

The embedded arm's remaining daemon dependencies (#995 found-block verifier unwired, #996 silent MN-payee omission) and the fee-light daemonless template path. Tracked separately.
