### PR TITLE
dash: set_current_payouts_fn seam so /current_payouts stops emitting {} (web-half of #939)

### DIFF
--- a/src/core/test/CMakeLists.txt
+++ b/src/core/test/CMakeLists.txt
@@ -54,7 +54,7 @@ if (BUILD_TESTING AND (GTest_FOUND OR GTEST_FOUND))
     # carries a source KAT pinning the is_wire_advertisable() guard into all ten
     # per-coin getaddrs handlers. Same reasoning as above: FOLDED into the
     # EXISTING allowlisted core_test target, never a new add_executable.
-    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp core_merkle_branches_test.cpp version_gate_test.cpp filesystem_test.cpp web_server_submitblock_test.cpp known_txs_eviction_test.cpp tx_advertiser_test.cpp socket_write_queue_test.cpp known_txs_backing_test.cpp random_choice_guard_test.cpp p2p_message_stats_test.cpp netaddress_resolution_test.cpp)
+    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp core_merkle_branches_test.cpp version_gate_test.cpp filesystem_test.cpp web_server_submitblock_test.cpp web_server_current_payouts_test.cpp known_txs_eviction_test.cpp tx_advertiser_test.cpp socket_write_queue_test.cpp known_txs_backing_test.cpp random_choice_guard_test.cpp p2p_message_stats_test.cpp netaddress_resolution_test.cpp)
     target_compile_definitions(core_test PRIVATE C2POOL_SRC_ROOT="${CMAKE_SOURCE_DIR}/src")
     target_link_libraries(core_test PRIVATE GTest::gtest_main core c2pool_merged_mining GTest::gtest)
     target_link_libraries(core_test PRIVATE c2pool_payout c2pool_hashrate ltc_coin)  # OBJECT-lib SCC direct-naming (#22/#39)

--- a/src/core/test/web_server_current_payouts_test.cpp
+++ b/src/core/test/web_server_current_payouts_test.cpp
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+#include <core/web_server.hpp>
+#include <core/address_validator.hpp>
+
+// ---------------------------------------------------------------------------
+// KATs for core::MiningInterface::rest_current_payouts — the /current_payouts
+// JSON endpoint. Regression lock for #939: on a live DASH node with a full
+// share window and real balances the endpoint returned {}. Root cause: DASH
+// has no coinbase-builder PPLNS cache feeding this endpoint and wires no
+// PayoutManager (unlike LTC's set_payout_manager), so BOTH web-layer sources
+// are empty and the endpoint faithfully reports {} — the data is absent at the
+// boundary. Fix: a direct-source injection seam (set_current_payouts_fn) so a
+// coin whose payout set lives outside the web coinbase builder can feed it.
+//
+// A dashboard must not report "no payouts" when a source exists; equally it
+// must not fabricate one when none does. These KATs lock both directions.
+// ---------------------------------------------------------------------------
+
+// The injected direct source is authoritative when present and non-empty.
+// FAILS WITHOUT THE SEAM (endpoint has no way to see the DASH payout set -> {}).
+TEST(CurrentPayoutsSeam, DirectSourceIsAuthoritative) {
+    core::MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                             c2pool::address::Blockchain::DASH);
+
+    nlohmann::json feed = {
+        {"XmR5w1yQ8oExampleDashAddr0000000000", 1.25},
+        {"XpQ7z2aB9nExampleDashAddr1111111111", 0.50},
+    };
+    mi.set_current_payouts_fn([feed]() { return feed; });
+
+    auto r = mi.rest_current_payouts();
+    ASSERT_TRUE(r.is_object());
+    EXPECT_EQ(r, feed) << "direct current-payouts source was not surfaced";
+}
+
+// An empty/absent feed must NOT mask the ordinary path — with no cache and no
+// PayoutManager data the endpoint honestly returns {} rather than a stale or
+// fabricated set. Guards against the seam swallowing the fallthrough.
+TEST(CurrentPayoutsSeam, EmptyFeedFallsThroughToHonestEmpty) {
+    core::MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                             c2pool::address::Blockchain::DASH);
+
+    mi.set_current_payouts_fn([]() { return nlohmann::json::object(); });  // absent
+
+    auto r = mi.rest_current_payouts();
+    ASSERT_TRUE(r.is_object());
+    EXPECT_TRUE(r.empty()) << "empty feed must fall through to honest {}";
+}
+
+// With no seam wired at all, behaviour is unchanged: honest {} when no source.
+TEST(CurrentPayoutsSeam, NoSeamUnchangedHonestEmpty) {
+    core::MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                             c2pool::address::Blockchain::DASH);
+    auto r = mi.rest_current_payouts();
+    ASSERT_TRUE(r.is_object());
+    EXPECT_TRUE(r.empty());
+}

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -2347,6 +2347,17 @@ nlohmann::json MiningInterface::rest_current_payouts()
     nlohmann::json result = nlohmann::json::object();
     bool is_ltc = (m_blockchain == Blockchain::LITECOIN);
 
+    // #939: authoritative direct source, when a coin wires one (DASH has no
+    // coinbase-builder PPLNS cache feeding this endpoint, so it returned {} on
+    // a node with a full window and live balances). Only trust a non-empty
+    // object -- an empty/absent feed falls through to the cache + fallback
+    // below rather than masking them.
+    if (m_current_payouts_fn) {
+        auto direct = m_current_payouts_fn();
+        if (direct.is_object() && !direct.empty())
+            return direct;
+    }
+
     // Script-to-address resolver — picks chain-specific version bytes so
     // Dash payouts render as 'X...' not Bitcoin '1...'.
     auto resolve_addr = [this, is_ltc](const std::vector<unsigned char>& s) -> std::string {
@@ -2393,7 +2404,12 @@ nlohmann::json MiningInterface::rest_current_payouts()
             // p2pool returns coins (not satoshis)
             result[addr] = static_cast<double>(amount) / 1e8;
         }
-        return result;
+        // Only short-circuit when we actually surfaced real payouts. If the
+        // cache held ONLY the zero-address burn placeholder (PPLNS-empty
+        // fallback state), result is empty here -- do NOT report {} as final;
+        // fall through to the PayoutManager source below (#939).
+        if (!result.empty())
+            return result;
     }
 
     // Fallback: PayoutManager (for modes without coinbase builder)
@@ -2408,7 +2424,7 @@ nlohmann::json MiningInterface::rest_current_payouts()
         if (subsidy > 0) {
             auto outputs = pm->calculate_pplns_outputs(subsidy);
             for (const auto& [script, amount] : outputs) {
-                std::string addr = core::script_to_address(script, is_ltc, m_testnet);
+                std::string addr = resolve_addr(script);
                 if (addr.empty() && script.size() > 33 && script.back() == 0xac) {
                     size_t pk_len = script[0];
                     if (pk_len + 1 == script.size() - 1) {
@@ -2419,7 +2435,7 @@ nlohmann::json MiningInterface::rest_current_payouts()
                         p2pkh.insert(p2pkh.end(), rip, rip + 20);
                         p2pkh.push_back(0x88);
                         p2pkh.push_back(0xac);
-                        addr = core::script_to_address(p2pkh, is_ltc, m_testnet);
+                        addr = resolve_addr(p2pkh);
                     }
                 }
                 if (addr.empty()) {

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -362,6 +362,13 @@ public:
         const uint256& best_hash, const uint256& block_target,
         uint64_t subsidy, const std::vector<unsigned char>& donation_script)>;
     void set_pplns_fn(pplns_fn_t fn) { m_pplns_fn = thread_safe_wrap(std::move(fn)); }
+    // Direct current-payouts source (#939). Coins whose payout set is NOT
+    // derivable from the web coinbase-builder PPLNS cache (e.g. DASH, which
+    // wires no set_payout_manager feed) inject it here; when set and non-empty
+    // it is the authoritative source for /current_payouts. Unset -> unchanged
+    // (cache, then PayoutManager fallback). Contract owned by the web layer;
+    // the per-coin feed is wired by that coin's node (cross-steward).
+    void set_current_payouts_fn(std::function<nlohmann::json()> fn) { m_current_payouts_fn = thread_safe_wrap(std::move(fn)); }
 
     // Hook: computes the p2pool ref_hash for a given coinbase scriptSig.
     // Returns (ref_hash, last_txout_nonce) pair.  The ref_hash depends on
@@ -1055,6 +1062,7 @@ private:
 
     // Sharechain stats callback
     sharechain_stats_fn_t m_sharechain_stats_fn;
+    std::function<nlohmann::json()> m_current_payouts_fn;  // #939 direct source seam
     spv_progress_fn_t m_spv_progress_fn;
     coin_peers_fn_t m_coin_peers_fn;
     node_topology_fn_t m_node_topology_fn;  // D0.3 per-coin stats provider (optional)


### PR DESCRIPTION
Web-half of the empty /current_payouts endpoint (#939).

Problem: on a DASH node with a full window and live balances, /current_payouts returns {} unconditionally. Root cause is structural, not a filter bug: main_dash wires no payouts source at all (main_ltc.cpp wires set_payout_manager; grep is LTC-only), so the web serializer has nothing to emit. Re-verified live on 109.161.57.3:8080 (/global_stats full, /users 5, /current_payouts {}).

This branch (web layer):
- Adds a core set_current_payouts_fn seam to web_server (new; authoritative when non-empty, else falls through to PayoutManager fallback).
- Burn-only cache no longer short-circuits before the fallback.
- Fallback uses resolve_addr for coin-correct DASH X... addresses.
- 3 deterministic KATs green; full core_test 142/142.

Remaining half (NOT this PR, cross-steward): the per-coin FEED into the seam from main_dash (pplns_weights_for -> compute_dash_payouts) is DASH payout/consensus territory = dash-consensus-pay-replay lane (CC on the 07-31 priority thread). Money flows once that feed lands; the seam is the socket, no dead-code risk once fed.

Draft pending deep-review per the review gate; not self-merged.

Note: PR body re-saved 2026-08-02 to re-fire the attribution-gate against the current text (its last run read the stale opened-payload body and could never go green on a bare re-run).

<!-- re-save 2026-08-02: attribution-gate red is a STALE event-payload snapshot; the current body, title and branch name contain zero matches for the gate's own patterns. A rerun re-reads the opened-event payload and can never clear it — only an edit fires a fresh scan. -->