### PR TITLE
fix(qt): resolve #852 PageEmbedded teardown crash; gate it in ctest

### DIFF
--- a/ui/c2pool-qt/CMakeLists.txt
+++ b/ui/c2pool-qt/CMakeLists.txt
@@ -163,4 +163,15 @@ if(C2POOL_QT_BUILD_TESTS)
     target_include_directories(c2pool-qt_test_reward_safe_launch PRIVATE src)
     add_test(NAME reward_safe_launch
              COMMAND c2pool-qt_test_reward_safe_launch)
+
+    # ── Teardown leak/crash gate (issue #852) ────────────────────────────
+    # The embedded-view host tore itself down via deregisterObject(nullptr),
+    # a null-deref inside QWebChannel. This KAT exercises the destroy fence
+    # over 100 build/destroy iterations and crashed before the fix. Needs a
+    # WebEngine backend; runs offscreen with software GL.
+    add_test(NAME embedded_leak
+             COMMAND c2pool-qt_test_embedded_leak)
+    set_tests_properties(embedded_leak PROPERTIES
+        ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+        TIMEOUT 90)
 endif()

--- a/ui/c2pool-qt/src/PageEmbedded.cpp
+++ b/ui/c2pool-qt/src/PageEmbedded.cpp
@@ -126,7 +126,14 @@ void PageEmbedded::reload()
 void PageEmbedded::destroyView()
 {
     if (channel_ != nullptr) {
-        channel_->deregisterObject(nullptr);
+        // Deregister exactly the bridges buildView() registered, passing a
+        // valid pointer per object. deregisterObject(nullptr) dereferences
+        // the null object inside QWebChannel (objectName lookup) and crashes
+        // on teardown (issue #852).
+        for (QObject* bridge : cfg_.bridges) {
+            if (bridge == nullptr || bridge->objectName().isEmpty()) continue;
+            channel_->deregisterObject(bridge);
+        }
         channel_->deleteLater();
         channel_ = nullptr;
     }


### PR DESCRIPTION
Closes #852 (QP-A).

## What
`PageEmbedded::destroyView()` tore the embedded view down with `QWebChannel::deregisterObject(nullptr)`. `deregisterObject` reads the passed object's `objectName()` to locate its registration, so a null pointer is a guaranteed null-deref inside QWebChannel on every teardown/reload — the byte-identical segfault tracked as #852.

Fix: deregister exactly the bridge objects `buildView()` registered, mirroring that loop and passing a valid pointer per object.

## Why CI never caught it
The teardown KAT `c2pool-qt_test_embedded_leak` was built but never `add_test`-registered, so `ctest` reported 1/1 green while the binary core-dumped. This PR registers it as the `embedded_leak` test (offscreen, 90s timeout). Note: Qt tests are still default-OFF (`-DC2POOL_QT_BUILD_TESTS=ON`); wiring them into CI (`build.yml`) is a separate step I will hand over rather than self-apply.

## Verification (Qt 6.4.2 / GCC 13.3 / noble)
- Before: `c2pool-qt_test_embedded_leak` dumps core on teardown.
- After: 100 build/destroy iterations pass, helper count stable at 2 (peak 2, tolerance 1) — no leak — across 3 runs.
- `ctest -DC2POOL_QT_BUILD_TESTS=ON`: **2/2 passed** (`reward_safe_launch` unchanged and still passing; `embedded_leak` now green).
- Full `c2pool-qt` build: 0 errors, 0 warnings; app links and `--help` smoke rc=0.

## Reward-safety
No change to `LaunchCommand.hpp`/command assembly; `reward_safe_launch` still passes. Diff is 2 files, +19/-1.