### PR TITLE
dash(embedded-oracle): name the FALL-CLOSED decline reason (log-only)

### DIFF
--- a/src/impl/dash/coin/embedded_oracle_shadow.hpp
+++ b/src/impl/dash/coin/embedded_oracle_shadow.hpp
@@ -630,6 +630,10 @@ public:
         // take mu_ only for the fast analysis + ledger phase.
         WorkSelection sel = coin_state_.select_work(dashd_gbt_);
         const bool is_embedded = (sel.source == WorkSource::Embedded);
+        // decline-reason DIAGNOSTIC (log-only): captured on the SAME
+        // sample as is_embedded so it matches the selection decision exactly.
+        const std::string decline_reason =
+            is_embedded ? std::string() : coin_state_.classify_decline();
         DashWorkData emb, dashd;
         bool dashd_rpc_ok = false, aligned = false;
         std::optional<int64_t> base_cp;   // creditPool(N-1) from the CONNECTED block
@@ -675,7 +679,8 @@ public:
             embedded_armed_ = false;
             ledger_.note_fall_closed(next_height, classify(next_height, {}, false, reorg, false));
             LOG_INFO << "[EMB-ORACLE] h=" << next_height
-                     << " FALL-CLOSED (dashd-fallback) — recorded serve-gap";
+                     << " FALL-CLOSED (dashd-fallback) reason=" << decline_reason
+                     << " — recorded serve-gap";
             save_graduation_state();
             remember_tip(next_height, next_prev_hash);
             return;

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -501,6 +501,49 @@ public:
         return select_dash_work(make_embedded_work_inputs(), dashd_fallback);
     }
 
+    /// DIAGNOSTIC (log-only): when select_work() falls closed to the dashd arm,
+    /// name WHICH viability clause in make_embedded_work_inputs() was the FIRST
+    /// unsatisfied one. Pure const read of the SAME members, evaluated in the
+    /// same AND-order has_state uses -- it NEVER alters arm selection or any
+    /// reward/serve path. Turns the shadow oracle's identical FALL-CLOSED lines
+    /// into a diagnosis instead of a tally. NOTE: this classifies embedded
+    /// VIABILITY only. The shadow calls select_work() directly, so the live
+    /// get_work mainnet gate (--embedded-mainnet, work_source.cpp) is NOT on
+    /// this path; a wholly-unfed bundle surfaces as "not-populated", which on a
+    /// gate-off node is how the absent mainnet opt-in manifests here.
+    std::string classify_decline() const {
+        const uint32_t next_h = m_prev_height + 1;
+        if (!m_populated)      return "not-populated";
+        if (m_prev_hash.IsNull()) return "no-tip";
+        if (m_qc_plan_fn && !m_qc_plan_fn(next_h)) return "qc-plan-underivable";
+        if (m_utxo_ready_fn && !m_utxo_ready_fn())  return "utxo-immature";
+        if (!resolve_superblock(next_h).ok)         return "superblock-refused";
+        if (!m_qc_plan_fn && m_commitment_window_fn && m_commitment_window_fn(next_h))
+            return "dkg-commitment-window";
+        if (m_require_fresh_bestcl
+            && m_best_cl_height < static_cast<int32_t>(m_prev_height) - 1)
+            return "bestcl-stale h=" + std::to_string(m_best_cl_height)
+                 + " vs tip=" + std::to_string(m_prev_height);
+        if (m_require_fresh_credit_pool
+            && m_credit_pool_height != static_cast<int32_t>(m_prev_height))
+            return "creditpool-stale h=" + std::to_string(m_credit_pool_height)
+                 + " vs tip=" + std::to_string(m_prev_height);
+        if (m_require_fresh_mn_payee
+            && m_mnstates.last_applied_height() != m_prev_height)
+            return "payee-stale h=" + std::to_string(m_mnstates.last_applied_height())
+                 + " vs tip=" + std::to_string(m_prev_height);
+        if (m_require_sml) {
+            if (!m_have_sml)       return "no-dmn-set";
+            if (!m_quorum_healthy) return "quorum-unhealthy";
+            if (m_sml_current_hash != m_prev_hash)
+                return "dmn-stale sml=" + m_sml_current_hash.GetHex().substr(0, 12)
+                     + " vs tip=" + m_prev_hash.GetHex().substr(0, 12);
+        }
+        // has_state says viable => the Phase-1 select_work sample and this read
+        // straddled a concurrent apply_block. Rare, and named honestly.
+        return "viable-race";
+    }
+
 private:
     /// Superblock disposition for a candidate next height. ok=false => refuse
     /// (fail closed). payments empty+ok => normal block; non-empty+ok => emit.


### PR DESCRIPTION
## What

Adds a decline-reason to the shadow oracle FALL-CLOSED line so the serve-gap becomes a diagnosis, not a tally. Answers integrator [evidence] #1002 (hotel primary: 137/137 heights fell closed, zero reasons).

## Change (2 files, +49/-1)

- `NodeCoinState::classify_decline() const` — a pure read of the SAME members `make_embedded_work_inputs()` ANDs into `has_state`, evaluated in the SAME order, returning the FIRST failing viability gate:
  `not-populated | no-tip | qc-plan-underivable | utxo-immature | superblock-refused | dkg-commitment-window | bestcl-stale h=X vs tip=Y | creditpool-stale h=X vs tip=Y | payee-stale h=X vs tip=Y | no-dmn-set | quorum-unhealthy | dmn-stale sml=.. vs tip=..`
- `embedded_oracle_shadow.hpp` — captures the reason on the SAME `select_work()` sample as `is_embedded` and appends `reason=<...>` to the FALL-CLOSED line.

New line shape: `[EMB-ORACLE] h=NNNN FALL-CLOSED (dashd-fallback) reason=<...> — recorded serve-gap`

## Honours the shadow contract (log-only)

No change to arm selection, the reward path, or what the embedded arm serves.

## Important correction to the #1002 hypothesis

The shadow calls `select_work()` **directly**, bypassing the live get_work `--embedded-mainnet` gate (that gate lives in `work_source.cpp`). So the 137 shadow declines are **embedded VIABILITY**, not the mainnet gate — and the `1 shadow constructed` line proves the bundle IS fed at least once, so these are genuine per-height viability gaps. `gate-mainnet-absent` therefore cannot be the shadow's reason; a wholly-unfed bundle would read `not-populated`. The new field will say which gate (very likely `dmn-stale`/`payee-stale`/`bestcl-stale` given header sync is 100%).

## Verify

Syntax-checked clean (`c++ -fsyntax-only -std=gnu++20`, both headers). Additive/const only — no behavioral TU touched. Requesting full-CI + oracle verify per protocol; no self-merge. Branch off master 8bf62c05 (= the running hotel shadow build).

The MINT-path declines are a separate lower-priority thread (ownerless-work semantics) — not in this PR.
