### PR TITLE
dash(#996): fail-closed embedded gate on an unresolvable MN payee

### DIFF
--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -133,6 +133,15 @@ public:
     /// Default OFF preserves prior unit-test posture.
     void set_require_fresh_mn_payee(bool v) { m_require_fresh_mn_payee = v; }
 
+    /// #996 payee fail-closed gate. When enabled (default ON), viability
+    /// refuses the embedded arm at any height where a MN payment is due but
+    /// find_expected_payee() cannot be resolved to a live SML entry — the
+    /// builder would otherwise emit a coinbase claiming m_payment_amount with
+    /// no MN output (fail-OPEN, bad-cb-payee). Refusal downgrades to the
+    /// reward-safe dashd GBT fallback; it is a template-SERVE refusal (free),
+    /// never a block-SUBMIT refusal. Exposed for the negative-pass test.
+    void set_require_resolvable_payee(bool v) { m_require_resolvable_payee = v; }
+
     /// creditPool freshness gate (soak fix). dashcore CheckCreditPoolDiffForBlock
     /// rejects a block whose committed creditPoolBalance is off by a block's
     /// accrual (bad-cbtx-assetlocked-amount). When enabled, viability + the
@@ -417,6 +426,16 @@ public:
         // Resolve the superblock disposition ONCE (fail-closed unless the
         // daemonless provider is trigger-confident) and thread the schedule.
         SuperblockDisposition sb = resolve_superblock(m_prev_height + 1);
+        // #996 fail-closed: a MN payment is due at the tip we build on but the
+        // payee is unresolvable (find_expected_payee() nullopt -- every entry
+        // isValid=false or the set is empty -- or, defensively, a projected
+        // payee absent from the SML entry set). The embedded builder would omit
+        // the MN coinbase output while m_payment_amount still claims it:
+        // fail-OPEN on a money path (bad-cb-payee). Refusing downgrades to the
+        // dashd GBT fallback -- a template-SERVE refusal (free), not a
+        // block-SUBMIT refusal.
+        const bool payee_resolvable =
+            !m_require_resolvable_payee || mn_payee_resolvable_at_tip();
         e.has_state            = m_populated
                                  && qc_ok
                                  && (!m_utxo_ready_fn || m_utxo_ready_fn())
@@ -451,7 +470,15 @@ public:
                                  && (!m_require_sml
                                      || (m_have_sml
                                          && m_quorum_healthy
-                                         && m_sml_current_hash == m_prev_hash));
+                                         && m_sml_current_hash == m_prev_hash))
+                                 && payee_resolvable;
+        if (m_require_resolvable_payee && !payee_resolvable) {
+            LOG_WARNING << "[EMBED-GATE] h=" << (m_prev_height + 1)
+                        << " REFUSE embedded template: MN payment due but payee"
+                        << " unresolvable (find_expected_payee nullopt or"
+                        << " projected payee absent from SML set) -- falling back"
+                        << " to dashd GBT [#996 bad-cb-payee fail-closed].";
+        }
         e.prev_height          = m_prev_height;
         e.prev_hash            = m_prev_hash;
         e.mnstates             = &m_mnstates;
@@ -502,6 +529,28 @@ public:
     }
 
 private:
+    // #996 helper: is the MN payee the embedded builder will need actually
+    // resolvable at the tip we build on? Mirrors embedded_gbt.hpp's build-time
+    // condition (build_embedded_workdata gates the MN PackedPayment on
+    // mn_payment > 0). Returns false ONLY when a MN payment is due but
+    // find_expected_payee() is nullopt (all entries isValid=false / empty set)
+    // or, defensively, names a payee absent from entries(). Uses the fee-free
+    // subsidy floor: mempool fees only RAISE block_value, so if the floor MN
+    // payment is <= 0 no MN output is due and an absent payee is legitimately
+    // fine -- the gate never over-refuses at a genuine no-MN-payment height.
+    bool mn_payee_resolvable_at_tip() const {
+        const uint32_t next_h = m_prev_height + 1;
+        const int64_t reward = compute_dash_block_reward_post_v20(next_h);
+        const int64_t platform_reward =
+            compute_dash_platform_reward_post_v20_mn_rr(next_h, m_mn_rr_height);
+        const int64_t mn_payment_floor =
+            compute_dash_mn_payment_post_v20(reward) - platform_reward;
+        if (mn_payment_floor <= 0) return true;   // no MN payment due at this height
+        const auto expected = m_mnstates.find_expected_payee();
+        if (!expected) return false;              // #996: nullopt while payment due
+        return m_mnstates.entries().find(*expected) != m_mnstates.entries().end();
+    }
+
     /// Superblock disposition for a candidate next height. ok=false => refuse
     /// (fail closed). payments empty+ok => normal block; non-empty+ok => emit.
     struct SuperblockDisposition {
@@ -557,6 +606,10 @@ private:
     bool     m_require_fresh_bestcl{false};  // refuse embedded on a stale/absent bestCL
     bool     m_require_fresh_credit_pool{false}; // refuse embedded on a lagged credit-pool seed
     bool     m_require_fresh_mn_payee{false};    // refuse embedded on a lagged payee queue (stale cursor)
+    // #996: fail-CLOSED default -- reads only mnstates (always present), needs
+    // no external freshness wiring, and guards a money path, so unlike the
+    // freshness gates above it defaults ON.
+    bool     m_require_resolvable_payee{true};   // refuse embedded when a due MN payee is unresolvable (#996)
     int      m_mn_rr_height{DASH_MN_RR_HEIGHT_MAINNET}; // network MN_RR activation height (platform-share gate)
     uint256  m_credit_pool_current_hash;     // block hash the credit-pool seed is current at
     int32_t  m_credit_pool_height{-1};       // seed cbTx's OWN height (-1 = never seeded)

--- a/test/test_dash_node_coin_state.cpp
+++ b/test/test_dash_node_coin_state.cpp
@@ -379,6 +379,57 @@ TEST(DashNodeCoinState, SuperblockHeightRefusesEmbedded) {
     EXPECT_TRUE(st.make_embedded_work_inputs().viable());
 }
 
+// ════════════════════════════════════════════════════════════════════════
+// #996: payee fail-closed gate. A populated, tip-fresh bundle whose MN set
+// resolves NO payee (every entry isValid=false — e.g. a PoSe ban the tx-walk
+// never observed) while a MN payment is due must REFUSE the embedded arm: the
+// builder (build_embedded_workdata) would emit a coinbase claiming
+// m_payment_amount with no MN output — fail-OPEN on a money path (bad-cb-payee).
+// NEGATIVE PASS: with the guard OFF (pre-#996 behaviour) the SAME bundle is
+// (wrongly) viable and would serve the defective template; with the guard ON it
+// falls back to the reward-safe dashd arm. A CONTROL with a resolvable payee at
+// the same tip stays viable, proving the gate is payee-specific, not a blanket
+// refuse.
+// ════════════════════════════════════════════════════════════════════════
+TEST(DashNodeCoinState, UnresolvablePayeeFailsClosedToDashd) {
+    NodeCoinState st;
+    // One MN, marked INVALID — find_expected_payee() skips it => nullopt.
+    MNState banned;
+    banned.isValid          = false;
+    banned.nRegisteredHeight = 2'300'000;
+    banned.scriptPayout.m_data = p2pkh_script(0x30);
+    st.mnstates().load(std::vector<std::pair<uint256, MNState>>{
+        {raw256(0x01), banned}});
+    st.set_tip(H - 1, raw256(0xAB), 0x1b104be3u, 1'700'000'000u,
+               DASH_PUBKEY_VER, DASH_P2SH_VER);
+
+    ASSERT_TRUE(st.populated()) << "bundle is populated (MN set loaded + tip set)";
+    ASSERT_FALSE(st.mnstates().find_expected_payee().has_value())
+        << "precondition: no payee resolves from an all-invalid MN set";
+
+    // NEGATIVE PASS — reproduce the pre-#996 fail-open: guard OFF => the
+    // defective bundle is viable and would serve the MN-less embedded template.
+    st.set_require_resolvable_payee(false);
+    EXPECT_TRUE(st.make_embedded_work_inputs().viable())
+        << "pre-#996: an unresolvable payee was served (fail-open) — the defect";
+
+    // GUARD ON (default posture) => the gate fires: refuse embedded, route dashd.
+    st.set_require_resolvable_payee(true);
+    EXPECT_FALSE(st.make_embedded_work_inputs().viable())
+        << "#996: due MN payment + unresolvable payee must refuse the embedded arm";
+    bool fb = false;
+    EXPECT_EQ(st.select_work([&]{ fb = true; return DashWorkData{}; }).source,
+              WorkSource::DashdFallback);
+    EXPECT_TRUE(fb) << "refused embedded must reach the always-on dashd fallback";
+
+    // CONTROL — a resolvable payee (valid MN) at the SAME tip stays viable with
+    // the guard ON: the gate is payee-specific, not a blanket refuse.
+    seed_single_mn(st, p2pkh_script(0x30));
+    ASSERT_TRUE(st.mnstates().find_expected_payee().has_value());
+    EXPECT_TRUE(st.make_embedded_work_inputs().viable())
+        << "#996 guard must NOT refuse when the due payee resolves";
+}
+
 // BLOCKER-1 (PR #780): is_dkg_commitment_window over REAL live-testnet heights —
 // the DKG mining windows the review pulled must be flagged, the fixture height
 // (a non-qc coinbase-only block) must not.


### PR DESCRIPTION
## #996 — payee fail-closed gate (step 1 of the dashd port sequence)

### Defect
`build_embedded_workdata` (embedded_gbt.hpp) gates the masternode `PackedPayment` on `find_expected_payee()` resolving to a live SML entry, but sets `w.m_payment_amount` unconditionally. When a MN payment is due yet the payee is **unresolvable** — `find_expected_payee()` nullopt (every entry `isValid=false`, e.g. an unobserved PoSe ban, or an empty set) or (defensively) a projected payee absent from `entries()` — the served template claims a payment its coinbase omits. Fail-**open** on a money path (bad-cb-payee).

### Fix
Refuse at the re-evaluated `has_state` predicate (node coin-state gate) via a new **fail-CLOSED-by-default** `m_require_resolvable_payee`. `mn_payee_resolvable_at_tip()` mirrors the builder's `mn_payment > 0` condition using the **fee-free subsidy floor** (fees only raise block_value) so it never over-refuses at a genuine no-MN-payment height. Refusal downgrades to the retained **dashd GBT fallback** — a template-**SERVE** refusal (free), never a block-**SUBMIT** refusal. The refusal is logged with its reason.

Default ON is safe where the freshness gates are not: it reads only `mnstates` (always present) and needs no external wiring.

### Negative pass — `UnresolvablePayeeFailsClosedToDashd`
- guard **OFF** reproduces the pre-fix fail-open: `viable()==true` (defect)
- guard **ON** fires: `viable()==false` -> `select_work` routes `DashdFallback`
- **control**: a resolvable payee at the same tip stays `viable()==true` (payee-specific, not a blanket refuse)

### Local verification (Linux x86_64, Debug)
- test_dash_node_coin_state 17/17 (incl. new negative pass)
- test_dash_coin_state_maintainer 15/15 · test_dash_get_work 4/4 · test_dash_cb_payee 12/12 · test_dash_embedded_gbt 58/58

Scope: 2 files, +~75 LOC. No API removed. Gate = integrator full CI + oracle (frstrtr/p2pool-dash) — no self-merge.