### PR TITLE
dgb: wire set_http_peer_seeds() tier-3 bootstrap fallback

### DIFF
--- a/src/c2pool/main_dgb.cpp
+++ b/src/c2pool/main_dgb.cpp
@@ -237,6 +237,14 @@ int run_node(const core::CoinParams& params, bool testnet,
             ioc, "DGB", pm_data_dir, pm_cfg);
         coin_peer_mgr->set_dns_seeds(dgb::coin::dgb_dns_seeds(testnet));
         coin_peer_mgr->set_fixed_seeds(dgb::coin::dgb_fixed_seeds(testnet));
+        // Tier 3 (last-resort) bootstrap: the c2pool HTTP seed aggregator.
+        // Fires only when DNS + fixed seeds both fail to yield min_peers within
+        // 90s (schedule_http_peer_fallback), so a DGB lane that loses its DNS
+        // and fixed seeds still has a recovery path. Host mirrors the LTC lane
+        // (main_ltc.cpp:5537); coin selection is by the "dgb" JSON key inside
+        // http_fetch_coin_peers, not the host, so the shared aggregator serves
+        // DGB peers without a DGB-specific endpoint. No-op if the list is empty.
+        coin_peer_mgr->set_http_peer_seeds({{"voidbind.com", 8080}});
         coin_peer_mgr->start();
         const auto pm_stats = coin_peer_mgr->peer_stats();
         std::cout << "[DGB] coin-network peer discovery ARMED (--coin-p2p-discover): "


### PR DESCRIPTION
## What
Wires the third and last bootstrap fallback tier into the DGB `--coin-p2p-discover` peer manager (`src/c2pool/main_dgb.cpp`), one line after the existing tier-1 (`set_dns_seeds`) and tier-2 (`set_fixed_seeds`) calls.

## Why
`set_http_peer_seeds()` is wired ONLY in LTC (main_ltc.cpp:1875 / 5537). DASH/BTC/DGB/BCH wire it zero times. Without tier 3, a DGB lane that loses BOTH its DNS seeds and its fixed seeds has no recovery path.

## Present-but-unwired, not missing
The setter (coin_peer_manager.hpp:319), the 90s fallback timer (`schedule_http_peer_fallback`, :975), and the `http_fetch_coin_peers` loop all already existed. Only the main_dgb call site was absent. Fallback is no-op when the seed list is empty, so behavior is unchanged unless `--coin-p2p-discover` is set.

## Coin isolation of the endpoint
Coin selection is by the `"dgb"` JSON key inside `http_fetch_coin_peers`, not the host — so the shared `voidbind.com:8080` c2pool aggregator serves DGB peers without a DGB-specific endpoint (mirrors LTC exactly).

## Answers to the two review deliverables
- **Fast-sync "scrypt skip" is ALGO-GENERIC.** The notify path (ltc p2p_node.hpp:479-480, `m_on_peer_height(msg->m_start_height)`) is fed purely by the peer version-message `start_height` — a block-count integer, nothing algo-specific. The only Scrypt-coupled part is the downstream cost avoided (re-hashing an expensive Scrypt PoW below the peer tip), not the notify. On V36 DGB, which validates Scrypt only, the skip target is already Scrypt-only by scope — ports as-is, no divergence.
- **Broadcaster peer-ranker: PRESENT-BUT-UNWIRED (this PR does NOT port it).** The dual-path contract is present in DGB (rpc.cpp:434) and the scored/diverse peer table + peer_stats live in `DgbCoinPeerManager`. LTC consumes the ranker via `peer_manager().get_tried_peers(25)` (main_ltc.cpp:3646). Confirming the DGB submit path consumes `get_tried_peers` before porting that in a follow-up — flagged, not silently ported.

## Scope
`src/c2pool/main_dgb.cpp` only. No `bitcoin_family/`, no `src/core/`. GPG-signed. No self-merge — integrator merges on operator push approval.