### PR TITLE
fix(web): reset best-share round on block-found (#922 round never resets)

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -3366,6 +3366,14 @@ void MiningInterface::record_found_block(uint64_t height, const uint256& hash, u
             LOG_WARNING << "[THE] Failed to create checkpoint: " << e.what();
         }
     }
+
+    // #922: a pool block was found -> a new sharechain round begins. Reset the
+    // round best-share tracker so /best_share.round reflects THIS round rather
+    // than staying pinned to the last winning share forever. Reached only for
+    // genuinely new blocks -- the (hash, chain) dedup above returns early on
+    // duplicates, so twin / replayed notifications never double-reset. Tied to
+    // the block-found event, not a timer.
+    reset_best_difficulty_round(ts);
 }
 
 void MiningInterface::set_found_block_persistence(block_store_fn_t persist_fn, block_load_fn_t load_fn)
@@ -6644,6 +6652,31 @@ nlohmann::json MiningInterface::rest_web_graph_data(const std::string& source, c
 }
 
 // ──────────── Difficulty tracking and stat log helpers ────────────────────
+
+// #922: restart the round-level best-share tracker at a block-found boundary.
+// all_time.* and session.* are deliberately preserved -- only the round leg is
+// cleared and its start timestamp advanced. Shared-core by necessity: the round
+// counters live on the core MiningInterface (m_best_difficulty) and are fed by
+// the core record_share_difficulty path, so the reset must fire from the same
+// core record_found_block that every coin already calls -- there is no per-coin
+// surface that could do it without duplicating the logic in each main_<coin>.
+void MiningInterface::reset_best_difficulty_round(uint64_t ts)
+{
+    if (ts == 0) ts = static_cast<uint64_t>(std::time(nullptr));
+    std::lock_guard<std::mutex> lock(m_best_diff_mutex);
+    // Primary-chain round leg.
+    m_best_difficulty.round = 0.0;
+    m_best_difficulty.miner.clear();
+    m_best_difficulty.hash.clear();
+    m_best_difficulty.timestamp = 0;
+    m_best_difficulty.round_start = ts;
+    // Merged (aux) round leg shares the same sharechain -> same boundary. A
+    // node without merged mining leaves these at 0, so this is a no-op there.
+    m_best_difficulty.merged_round = 0.0;
+    m_best_difficulty.merged_round_miner.clear();
+    m_best_difficulty.merged_round_ts = 0;
+    m_best_difficulty.merged_round_start = ts;
+}
 
 void MiningInterface::record_share_difficulty(double difficulty, const std::string& miner,
                                               const std::string& share_hash)

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -1394,6 +1394,11 @@ public:
     void record_share_difficulty(double difficulty, const std::string& miner,
                                  const std::string& share_hash = "");
     void record_merged_share_difficulty(double difficulty, const std::string& miner);
+    // A pool block was won -> the sharechain round boundary moved. Reset the
+    // round-level best-share tracker (all_time / session are left untouched).
+    // See #922: round previously only ever raised, degenerating into a
+    // permanent duplicate of all_time after the first block.
+    void reset_best_difficulty_round(uint64_t ts = 0);
 
     // Stat log entry (appended every 5 minutes, rolling 24h window for /web/log JSON)
     void update_stat_log();

--- a/test/test_web_honesty_regression.cpp
+++ b/test/test_web_honesty_regression.cpp
@@ -1290,3 +1290,89 @@ TEST(DashboardMergedGating, MergedExplorerRoutedThroughCurrencyInfo) {
         << "the merged payout-address link is a hardcoded blockchair URL; route "
            "it through currency_info.merged_child_address_explorer_url_prefix.";
 }
+
+// ─────────────────────────────────────────────────────────────────────────
+// #922 — BEST-SHARE "round" must RESET at a block-found boundary.
+//
+// Operator-reported + reproduced on the live hotel: GET /best_share returned
+// round.hash == all_time.hash and round.difficulty == all_time.difficulty for
+// a share attached to a block found hours (and hundreds of shares) earlier —
+// both rows 932.28% of target. The all_time/round SPLIT already existed in the
+// payload; the RESET was missing, so `round` only ever raised and degenerated
+// into a permanent duplicate of `all_time` the instant a block was won.
+//
+// These cases pin the reset in place. They FAIL against the pre-fix source
+// (round never cleared, round_start never written).
+class BestShareRoundReset : public ::testing::Test {
+protected:
+    // Read /best_share and pull out the round + all_time legs.
+    static void snapshot(MiningInterface& mi,
+                         double& round_diff, uint64_t& round_started,
+                         double& all_time_diff) {
+        const nlohmann::json bs = mi.rest_best_share();
+        round_diff    = bs.at("round").at("difficulty").get<double>();
+        round_started = bs.at("round").at("started").get<uint64_t>();
+        all_time_diff = bs.at("all_time").at("difficulty").get<double>();
+    }
+};
+
+// The round leg resets on block-found while all_time is preserved untouched.
+TEST_F(BestShareRoundReset, RoundResetsOnBlockFoundAllTimePreserved) {
+    MiningInterface mi(/*testnet=*/true, /*node=*/nullptr);
+
+    // A round's worth of shares, culminating in the record 900000-diff winner —
+    // the share that will go on to solve the block.
+    mi.record_share_difficulty(12.0,     "minerA", "aa");
+    mi.record_share_difficulty(4096.0,   "minerB", "bb");
+    mi.record_share_difficulty(900000.0, "minerC", "cc");   // block-solving share
+
+    double round_diff, all_time_diff; uint64_t round_started;
+    snapshot(mi, round_diff, round_started, all_time_diff);
+
+    // Pre-block: this is exactly the reproduced 932%-style state — round is a
+    // duplicate of all_time, and round.started was never written.
+    EXPECT_DOUBLE_EQ(round_diff, 900000.0);
+    EXPECT_DOUBLE_EQ(all_time_diff, 900000.0);
+    EXPECT_EQ(round_started, 0u)
+        << "pre-fix baseline: round_start is never written until the first reset";
+
+    // The pool wins the block that minerC's share solved.
+    mi.record_found_block(/*height=*/2511601, uint256{}, /*ts=*/0, "LTC",
+                          "minerC", "cc", /*network_difficulty=*/96540.0);
+
+    snapshot(mi, round_diff, round_started, all_time_diff);
+
+    // Acceptance #1: round.* reset on block-found.
+    EXPECT_DOUBLE_EQ(round_diff, 0.0)
+        << "#922: round best-share must reset to 0 when a block is won";
+    EXPECT_GT(round_started, 0u)
+        << "#922: round.started must be stamped to the block-found event";
+
+    // Acceptance #2: all_time.* untouched by the reset.
+    EXPECT_DOUBLE_EQ(all_time_diff, 900000.0)
+        << "#922: all_time must survive the round reset";
+}
+
+// After the reset, the round leg tracks THIS round independently — a new,
+// smaller share raises round without disturbing the preserved all_time record.
+// This is the property whose absence produced the permanent round==all_time bug.
+TEST_F(BestShareRoundReset, RoundTracksNewRoundIndependentlyAfterReset) {
+    MiningInterface mi(/*testnet=*/true, /*node=*/nullptr);
+
+    mi.record_share_difficulty(900000.0, "minerC", "cc");   // last round's record
+    mi.record_found_block(2511601, uint256{}, 0, "LTC", "minerC", "cc", 96540.0);
+
+    // A modest share arrives in the new round.
+    mi.record_share_difficulty(250.0, "minerD", "dd");
+
+    double round_diff, all_time_diff; uint64_t round_started;
+    snapshot(mi, round_diff, round_started, all_time_diff);
+
+    EXPECT_DOUBLE_EQ(round_diff, 250.0)
+        << "#922: round must now reflect the new round's best share, not last round's";
+    EXPECT_DOUBLE_EQ(all_time_diff, 900000.0)
+        << "#922: the all_time record must remain the last round's 900000";
+    EXPECT_NE(round_diff, all_time_diff)
+        << "#922 regression guard: round must not degenerate back into a "
+           "duplicate of all_time";
+}


### PR DESCRIPTION
## #922 — best-share "round" never resets after a block

**Bug (operator-reported, reproduced on the live hotel):** `GET /best_share`
returned `round` as a byte-for-byte duplicate of `all_time` — same hash
(`0000…04b2934a9c…`, block 2511601 found 05:40), same `difficulty` 914283537,
both `pct_of_block` 932.28% — for a share attached to a block found hours and
several hundred shares earlier. The `all_time` / `round` split already existed
in the payload; the **structure was right, the reset was missing**. `round`
only ever *raised* (`if (difficulty > m_best_difficulty.round)`), so the moment
a block was won it degenerated into a permanent copy of `all_time` and stayed
that way until something beat a 932%-of-target share — i.e. never.

## Fix

New `MiningInterface::reset_best_difficulty_round(ts)` clears only the round
leg (`round`, `miner`, `hash`, `timestamp`) and stamps `round_start = ts`;
`all_time.*` and `session.*` are left untouched. It also clears the merged
(aux) round leg, which shares the same sharechain boundary (no-op on a node
without merged mining). It is called from `record_found_block()` at its end —
**tied to the block-found event, not a timer** (acceptance #1). The
`(hash, chain)` dedup at the top of `record_found_block` returns early on
duplicates, so twin / replayed block notifications never double-reset.

- `src/core/web_server.cpp` — `reset_best_difficulty_round()` impl + call site in `record_found_block()`
- `src/core/web_server.hpp` — declaration
- `test/test_web_honesty_regression.cpp` — 2 KATs (fail against pre-fix source)

## Acceptance #3 — where it lives: shared core, justified

The reset is entirely in shared `core::MiningInterface`; **no per-coin tree is
touched.** This is the EXCEPTIONAL-but-correct placement under the isolation
rule: the round counters (`m_best_difficulty`) are core state, fed by the core
`record_share_difficulty` path, and the reset must fire from the same core
`record_found_block()` that every coin's `main_<coin>.cpp` already calls.
Doing it per-coin would duplicate identical logic in 5 mains and re-introduce
the drift this fixes. One event, one place.

## Acceptance #2 — before/after payload (all_time preserved)

From the KAT scenario (record 900000-diff winner solves the block, then a
250-diff share arrives in the new round):

```
BEFORE block-found (the reproduced 932% state — round == all_time):
  all_time: { difficulty: 900000, miner: minerC, hash: cc }
  round:    { difficulty: 900000, miner: minerC, hash: cc, started: 0 }   # started never written

AFTER record_found_block(2511601, LTC) + one new 250-diff share:
  all_time: { difficulty: 900000, miner: minerC, hash: cc }               # UNTOUCHED
  round:    { difficulty: 250,    miner: minerD, hash: dd, started: <block ts> }
```

`all_time.difficulty` is identical across the boundary; `round` drops to the
new round's real best and `round.started` advances to the block-found time.

## Tests

Added to `test_web_honesty_regression`:
- `RoundResetsOnBlockFoundAllTimePreserved` — round → 0 and `round.started` > 0
  on block-found; `all_time` unchanged.
- `RoundTracksNewRoundIndependentlyAfterReset` — a post-reset share raises
  `round` (250) below the preserved `all_time` (900000); regression-guards that
  `round` never degenerates back into a duplicate of `all_time`.

Both fail against the pre-fix source.
