### PR TITLE
web(#921): Share-Version Crossing card reads a schema /v36_status never emits

### DIFF
--- a/test/test_web_honesty_regression.cpp
+++ b/test/test_web_honesty_regression.cpp
@@ -1376,3 +1376,93 @@ TEST_F(BestShareRoundReset, RoundTracksNewRoundIndependentlyAfterReset) {
         << "#922 regression guard: round must not degenerate back into a "
            "duplicate of all_time";
 }
+// ===========================================================================
+// #921 -- Share-Version Crossing card schema contract.
+//
+// The operator reported the crossing card "not serving": /v36_status emits a
+// NESTED shape (auto_ratchet{...} + share_chain{...}) with NOTHING at top level,
+// but renderV36Status() read only TOP-LEVEL keys (v.status, v.overall_v36_vote_pct,
+// v.sampling_signaling, v.message, v.target_version, ...). The endpoint returned
+// 200, the card rendered, nothing threw -- every field just fell through to '-'.
+// A present-but-meaningless card, invisible to every existing test (same shape
+// as the local_share_hash_rates aliasing class). These two KATs pin the contract
+// from BOTH sides so it cannot drift back.
+// ===========================================================================
+
+// Side 1 (backend): rest_v36_status() must actually EMIT, under the nested paths,
+// every field the fixed card reads. If a refactor flattens or renames the shape,
+// this fails.
+TEST(WebHonestyRegression, V36StatusEmitsEveryNestedFieldTheCrossingCardReads) {
+    MiningInterface mi(/*testnet=*/true, /*node=*/nullptr, Blockchain::LITECOIN);
+    mi.set_cached_share_version(36);              // latched -> exercises the active path
+    json v = mi.rest_v36_status();
+
+    // The card reads exactly these nested paths (dashboard.html renderV36Status):
+    ASSERT_TRUE(v.contains("auto_ratchet")) << "/v36_status must emit auto_ratchet";
+    ASSERT_TRUE(v.contains("share_chain"))  << "/v36_status must emit share_chain";
+    const auto& ar = v["auto_ratchet"];
+    const auto& sc = v["share_chain"];
+    EXPECT_TRUE(ar.contains("state"))
+        << "card reads auto_ratchet.state for its status label";
+    EXPECT_TRUE(ar.contains("live_share_version"))
+        << "card reads auto_ratchet.live_share_version for the current-version label";
+    EXPECT_TRUE(ar.contains("v36_active"))
+        << "card reads auto_ratchet.v36_active for the live-latch line";
+    EXPECT_TRUE(sc.contains("v36_percentage"))
+        << "card reads share_chain.v36_percentage for the signalling %";
+    // The endpoint must NOT be relied on for the top-level keys the buggy card
+    // read -- their absence is exactly why the card was empty. Guard that the
+    // card is not silently re-coupled to a shape the endpoint doesn't provide.
+    for (const char* absent : {"status", "overall_v36_vote_pct", "sampling_signaling",
+                               "message", "target_version", "current_share_name"}) {
+        EXPECT_FALSE(v.contains(absent))
+            << "top-level '" << absent << "' is NOT emitted by /v36_status; the "
+               "card must not read it (this was the #921 empty-card bug)";
+    }
+}
+
+// Side 2 (frontend, static-HTML): the crossing-card render function must read the
+// nested shape and must NOT read any of the top-level keys the endpoint does not
+// emit. This is the KAT the issue asked for -- it fails if the card reads a field
+// the endpoint does not serve, the defect class that returns 200 and throws
+// nothing. Folded into this allowlisted target (not a new add_executable -> the
+// #769 Not-Run trap).
+TEST(DashboardCrossingCard, ReadsOnlyEmittedNestedFields) {
+    const auto html = read_dashboard();
+    auto start = html.find("function renderV36Status(v)");
+    ASSERT_NE(start, std::string::npos) << "renderV36Status not found";
+    // Slice to the next top-level function declaration (same 8-space indent).
+    auto end = html.find("\n        function ", start + 1);
+    ASSERT_NE(end, std::string::npos);
+    const std::string fn = html.substr(start, end - start);
+
+    // Must read the canonical nested shape the endpoint emits.
+    EXPECT_NE(fn.find("v.auto_ratchet"), std::string::npos)
+        << "renderV36Status does not read v.auto_ratchet -- /v36_status emits the "
+           "ratchet state nested there, not at top level.";
+    EXPECT_NE(fn.find("v.share_chain"), std::string::npos)
+        << "renderV36Status does not read v.share_chain -- v36_percentage lives "
+           "there, not at top level.";
+
+    // Must NOT read the top-level keys /v36_status never emits (the #921 bug).
+    for (const char* dead : {"v.status", "v.overall_v36_vote_pct", "v.sampling_signaling",
+                             "v.current_share_name", "v.current_share_type",
+                             "v.target_version_name", "v.target_version",
+                             "v.message", "v.is_transitioning"}) {
+        EXPECT_EQ(fn.find(dead), std::string::npos)
+            << "renderV36Status reads '" << dead << "', a field /v36_status does "
+               "NOT emit -- it will render as '-' and produce the empty card the "
+               "operator reported. Read the nested auto_ratchet/share_chain path.";
+    }
+
+    // The backwards label must be gone: 'ACTIVATED' must never be the no-transition
+    // fallback (a quiet pre-cross node claiming it had activated).
+    EXPECT_EQ(fn.find("no_transition"), std::string::npos)
+        << "the no_transition:'ACTIVATED' label is semantically backwards -- a "
+           "node with nothing happening would read ACTIVATED.";
+
+    // Visibility must be gated, not unconditional: a hide path must exist.
+    EXPECT_NE(fn.find("card.style.display = 'none'"), std::string::npos)
+        << "the crossing card display is unconditional; it must hide when the node "
+           "is plainly pre-crossing (operator design point on #921).";
+}

--- a/web-static/dashboard.html
+++ b/web-static/dashboard.html
@@ -1806,8 +1806,8 @@
                 <div class="stat-card" id="v36_card" style="display:none;">
                     <h3><span class="icon">🔀</span> Share-Version Crossing</h3>
                     <div class="stat-value" id="v36_status_label">-</div>
-                    <div class="stat-sub">Vote: <span id="v36_vote_pct">-</span> &nbsp;·&nbsp; Work-weighted: <span id="v36_ww_pct">-</span></div>
-                    <div class="stat-detail"><span id="v36_share_label">-</span> &rarr; <span id="v36_target_label">-</span> <span id="v36_msg" style="opacity:0.7;"></span></div>
+                    <div class="stat-sub">Signalling: <span id="v36_signal_pct">-</span></div>
+                    <div class="stat-detail"><span id="v36_share_label">-</span> &rarr; <span id="v36_target_label">-</span></div>
                     <div class="stat-detail">Live latch: <span id="v36_active_label" style="font-weight:600;">-</span></div>
                 </div>
                 <!-- Per-node topology: THIS node's REAL coin set from /api/node_topology (charter #2, config-driven/auto-detected -- never a baked-in coin list) -->
@@ -2934,31 +2934,45 @@
         function renderV36Status(v) {
             var card = document.getElementById('v36_card');
             if (!card) return;
-            var labels = {
-                no_transition: 'ACTIVATED',
-                activating: 'ACTIVATING',
-                signaling_strong: 'VOTING (strong)',
-                signaling: 'VOTING',
-                propagating: 'PROPAGATING',
-                building_chain: 'BUILDING CHAIN',
-                waiting: 'WAITING'
-            };
+            // /v36_status emits a NESTED shape -- auto_ratchet{state,live_share_version,
+            // v36_active,...} + share_chain{v36_percentage,...} -- and nothing at top
+            // level (rest_v36_status, web_server.cpp). Read that one canonical shape;
+            // #921 was this card reading top-level keys the endpoint never emits, so
+            // every field fell through to '-' and the card rendered empty.
+            var ar = v.auto_ratchet || {};
+            var sc = v.share_chain || {};
+            var state = ar.state;                 // coarse latch: voting|activated|confirmed
+            var pct = sc.v36_percentage;          // work-weighted signalling %
+            var live = ar.live_share_version;
+            var active = ar.v36_active;
+            // Visibility gate (operator design point on #921): show the crossing card
+            // ONLY while a cross is genuinely underway or done. A quiet pre-crossing
+            // node (voting, 0% signalled, not latched) must not render a card at all --
+            // the old unconditional display plus a backwards 'ACTIVATED' fallback label
+            // made such a node claim it had already activated. Floor is 0: any signalling
+            // means a cross is really in progress; exactly-zero + voting + not-active
+            // is plainly pre-crossing -> hide.
+            var crossing = active === true || state === 'activated' || state === 'confirmed'
+                           || (typeof pct === 'number' && pct > 0);
+            if (!crossing) { card.style.display = 'none'; return; }
             card.style.display = '';
-            card.classList.toggle('transitioning', !!v.is_transitioning);
-            d3.select('#v36_status_label').text(labels[v.status] || v.status || '-');
-            d3.select('#v36_vote_pct').text(v.overall_v36_vote_pct != null ? v.overall_v36_vote_pct + '%' : '-');
-            d3.select('#v36_ww_pct').text(v.sampling_signaling != null ? v.sampling_signaling + '%' : '-');
-            d3.select('#v36_share_label').text(v.current_share_name || (v.current_share_type != null ? 'V' + v.current_share_type : '-'));
-            d3.select('#v36_target_label').text(v.target_version_name || (v.target_version != null ? 'V' + v.target_version : '-'));
-            d3.select('#v36_msg').text(v.message ? '\u00b7 ' + v.message : '');
-            // Authoritative live-latch ground truth (m_cached_share_version), distinct from the
-            // re-derived sampling status above -- operators see ACTIVE the instant the chain crosses,
-            // not when sampling catches up. Only rendered when the backend reports it (charter #3).
-            if (typeof v.v36_active === 'boolean') {
-                var lv = (v.live_share_version != null) ? 'V' + v.live_share_version : '-';
+            card.classList.toggle('transitioning', state === 'voting' && active !== true);
+            // Label vocabulary matches what the endpoint actually emits (auto_ratchet.state).
+            var labels = { voting: 'VOTING', activated: 'ACTIVATED', confirmed: 'CONFIRMED' };
+            d3.select('#v36_status_label').text(labels[state] || (state ? state.toUpperCase() : '-'));
+            d3.select('#v36_signal_pct').text(typeof pct === 'number' ? pct + '%' : '-');
+            // current -> target: current is the live latch version; the ratchet endpoint
+            // is V36 for every coin's cross (LTC/DOGE V35->V36, DASH V16->V36).
+            d3.select('#v36_share_label').text(live != null ? 'V' + live : '-');
+            d3.select('#v36_target_label').text('V36');
+            // Authoritative live-latch ground truth (m_cached_share_version / DASH's
+            // ratchet-derived live_share_version). Only rendered when the backend
+            // reports it (charter #3).
+            if (typeof active === 'boolean') {
+                var lv = (live != null) ? 'V' + live : '-';
                 d3.select('#v36_active_label')
-                    .text(v.v36_active ? ('ACTIVE (' + lv + ')') : ('not active (' + lv + ')'))
-                    .style('color', v.v36_active ? '#22c55e' : '#94a3b8');
+                    .text(active ? ('ACTIVE (' + lv + ')') : ('not active (' + lv + ')'))
+                    .style('color', active ? '#22c55e' : '#94a3b8');
             } else {
                 d3.select('#v36_active_label').text('-').style('color', null);
             }


### PR DESCRIPTION
## #921 — Share-Version Crossing card renders empty (schema mismatch)

**Root cause (current master 2b54f4861).** `renderV36Status(v)` (`web-static/dashboard.html:2934`) reads TOP-LEVEL keys — `v.status`, `v.overall_v36_vote_pct`, `v.sampling_signaling`, `v.message`, `v.target_version`, `v.current_share_name`, `v.is_transitioning` — but `rest_v36_status()` (`src/core/web_server.cpp:5536`) emits a **nested** shape and nothing at top level:

```
auto_ratchet { state, live_share_version, v36_active, ... }
share_chain  { v36_percentage, sample_size, v35/v36_shares, height }
```

Every read misses → each field renders `-`. The endpoint returns 200, the card renders, nothing throws: an empty card, which the operator read as "not serving". Additionally `card.style.display = ''` (`:2946`) is unconditional and `no_transition: 'ACTIVATED'` (`:2938`) is semantically backwards — a quiet pre-crossing node shows an ACTIVATED-looking card.

**Decision on req #1 (read nested vs. add flat backend):** read the nested shape. It is the one canonical shape; a flat backend mirror would be a second shape that can drift — exactly what the issue warns against.

**Fix (frontend-only):**
1. Read `v.auto_ratchet` / `v.share_chain`.
2. Label vocabulary now matches `auto_ratchet.state` (`voting|activated|confirmed`); backwards `ACTIVATED` fallback removed.
3. Drop rows the endpoint cannot fill — the duplicate Work-weighted % (only one percentage is emitted) and `message`. A row that can only show `-` does not ship (req #2).
4. `current → target`: live latch version → `V36` (ratchet endpoint for every coin's cross — LTC/DOGE V35→V36, DASH V16→V36; derived, not a dead row).
5. Visibility gate (req #4): show only when a cross is genuinely underway or done — `v36_active || state ∈ {activated,confirmed} || v36_percentage > 0`. Floor is 0: any nonzero signalling is a real cross; exactly-zero + voting + not-active is pre-crossing → hide.

**KATs (req #5) — folded into the allowlisted `test_web_honesty_regression` target, no new `add_executable`:**
- `WebHonestyRegression.V36StatusEmitsEveryNestedFieldTheCrossingCardReads` — backend contract guard: the endpoint emits every nested field the card reads and does NOT emit the old top-level keys.
- `DashboardCrossingCard.ReadsOnlyEmittedNestedFields` — static-HTML guard that **fails if the card reads a field `/v36_status` does not emit**. Verified **red on unpatched master** (flags all 11 dead reads + backwards label + unconditional display), green after fix.

Full honesty suite **51/51** green on the workstation.

**Cross-coin:** the card and `/v36_status` are shared surface — this frontend fix applies uniformly to LTC/DOGE/BTC/DGB/DASH/BCH; no per-coin work needed.

**Node Topology card (second half of the report):** `/api/node_topology`, the DOM ids, and the `../api/node_topology` relative fetch path are all correct on master — **no reproducible backend/DOM/fetch defect** from static analysis, and it is a separate `d3.json` callback from the crossing card (one cannot break the other). It needs a browser-console check on the served page; reporting that rather than inventing a cause. Not fixed here.

Display-only, non-consensus, no reward path. GPG-signed off master. No self-merge — designated reviewer then integrator merge tap.

