### PR TITLE
web(graphs): real share-difficulty vs network-difficulty trend line

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -6650,9 +6650,13 @@ nlohmann::json MiningInterface::rest_web_graph_data(const std::string& source, c
             result.push_back({entry.time, entry.memory_usage, bin_width, 0});
         }
         else if (source == "network_difficulty") {
-            double nd = 0;
-            // Use network difficulty from snapshot if available
-            result.push_back({entry.time, entry.pool_hash_rate > 0 ? m_network_difficulty.load() : 0.0, bin_width, 0});
+            // Per-entry historical snapshot (fixes the flat-line bug where every
+            // point back-filled the current atomic). 0 = honest-absent.
+            result.push_back({entry.time, entry.network_difficulty, bin_width, 0});
+        }
+        else if (source == "share_difficulty") {
+            // Real share (vardiff) difficulty trend; honest-absent 0.
+            result.push_back({entry.time, entry.share_difficulty, bin_width, 0});
         }
         else {
             result.push_back({entry.time, 0.0, bin_width, 0});
@@ -6695,6 +6699,12 @@ void MiningInterface::record_share_difficulty(double difficulty, const std::stri
     // tracking below; the ring has its own internal lock.
     m_hashrate_ring.record(miner, difficulty,
         static_cast<int64_t>(std::time(nullptr)));
+
+    // Snapshot the latest real share difficulty for the share-difficulty trend
+    // line (fallback for coins whose sharechain stats omit min_difficulty).
+    // This is the true vardiff target, not an approximation.
+    if (difficulty > 0)
+        m_recent_share_difficulty.store(difficulty, std::memory_order_relaxed);
 
     std::lock_guard<std::mutex> lock(m_best_diff_mutex);
     auto now_ts = static_cast<uint64_t>(std::time(nullptr));
@@ -6911,6 +6921,26 @@ void MiningInterface::update_stat_log()
     double net_diff = m_network_difficulty.load(std::memory_order_relaxed);
     entry.attempts_to_block = net_diff * 4294967296.0;
 
+    // Historize the chain difficulty at THIS sample time so the graph plots a
+    // real trend instead of back-filling the current atomic across every point
+    // (the flat-line bug). 0 until the first work update populates it.
+    entry.network_difficulty = net_diff;
+
+    // Real share (vardiff) difficulty for the share-vs-network trend line.
+    // Priority: the sharechain published min_difficulty (the p2pool share
+    // target that vardiff retargets), then the last recorded real share diff,
+    // else honest-absent 0. Never the net/65536 approximation.
+    double real_share_diff = 0.0;
+    if (m_sharechain_stats_fn) {
+        auto scd = m_sharechain_stats_fn();
+        if (scd.contains("min_difficulty") && scd["min_difficulty"].is_number()
+            && scd["min_difficulty"].get<double>() > 0.0)
+            real_share_diff = scd["min_difficulty"].get<double>();
+    }
+    if (real_share_diff <= 0.0)
+        real_share_diff = m_recent_share_difficulty.load(std::memory_order_relaxed);
+    entry.share_difficulty = real_share_diff;
+
     // Block value
     entry.block_value = 0.0;
     {
@@ -7002,7 +7032,8 @@ void MiningInterface::save_stat_log()
                     {"pe", e.peers}, {"dv", e.desired_versions},
                     {"as", e.attempts_to_share}, {"ab", e.attempts_to_block},
                     {"bv", e.block_value}, {"mu", e.memory_usage},
-                    {"wl", e.work_latency}, {"tr", e.traffic}
+                    {"wl", e.work_latency}, {"tr", e.traffic},
+                    {"nd", e.network_difficulty}, {"sd", e.share_difficulty}
                 };
                 f << one.dump();
             }
@@ -7055,6 +7086,8 @@ void MiningInterface::load_stat_log()
             e.memory_usage = j.value("mu", 0.0);
             e.work_latency = j.value("wl", 0.0);
             e.traffic = j.value("tr", nlohmann::json::object());
+            e.network_difficulty = j.value("nd", 0.0);
+            e.share_difficulty = j.value("sd", 0.0);
             m_stat_log.push_back(std::move(e));
         }
         LOG_INFO << "[StatLog] Loaded " << m_stat_log.size() << " entries from " << m_stat_log_path;

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -1487,11 +1487,18 @@ private:
     // (hashrate_hps) + rest_pplns_miner (hashrate_series).
     HashrateRing m_hashrate_ring;
 
+    // Most-recent real recorded share difficulty (vardiff target), fed by
+    // record_share_difficulty and snapshotted into the stat log to drive the
+    // share-difficulty trend line. 0 == no shares seen yet (honest-absent).
+    std::atomic<double> m_recent_share_difficulty{0.0};
+
     // Stat log for /web/log JSON endpoint (rolling 24h window)
     struct StatLogEntry {
         double time;
         double pool_hash_rate;
         double pool_stale_prop;
+        double network_difficulty{0};   // chain difficulty snapshot at sample time
+        double share_difficulty{0};     // real share (vardiff) difficulty; honest-absent 0
         nlohmann::json local_hash_rates;       // {addr: hashrate}
         nlohmann::json local_dead_hash_rates;  // {addr: dead_hashrate}
         int worker_count{0};              // unique address.worker combos

--- a/test/test_web_honesty_regression.cpp
+++ b/test/test_web_honesty_regression.cpp
@@ -1466,3 +1466,64 @@ TEST(DashboardCrossingCard, ReadsOnlyEmittedNestedFields) {
         << "the crossing card display is unconditional; it must hide when the node "
            "is plainly pre-crossing (operator design point on #921).";
 }
+
+// ─────────────────────────────────────────────────────────────────────────
+// Share-difficulty trend line (operator-requested, 2026-08-01): the graph must
+// plot a REAL share-difficulty trend against network difficulty. The pre-fix
+// source had no "share_difficulty" graph series at all, and the stat-log's
+// share_diff was a hardcoded net_difficulty/65536 approximation — a flat scaled
+// copy of the chain difficulty, not the true vardiff target. These KATs pin the
+// real source in place; they FAIL on the pre-fix code (no source → 0.0).
+// ─────────────────────────────────────────────────────────────────────────
+
+// The share_difficulty graph series must carry the sharechain's published
+// min_difficulty (the p2pool share target that vardiff retargets), NOT the
+// net/65536 approximation (which would be 0 here since no chain difficulty is
+// set) and NOT an absent-source 0.
+TEST(ShareDifficultyTrend, GraphSourcesRealVardiffFromSharechainStats) {
+    MiningInterface mi(/*testnet=*/true, /*node=*/nullptr);
+    mi.set_pool_hashrate_fn([] { return 1.5e12; });   // ~1.5 TH/s per hotel
+    mi.set_sharechain_stats_fn([] {
+        return json{{"total_shares", 4096}, {"orphan_shares", 0},
+                    {"dead_shares", 0}, {"min_difficulty", 2048.0}};
+    });
+
+    mi.update_stat_log();
+    json series = mi.rest_web_graph_data("share_difficulty", "last_hour");
+
+    ASSERT_TRUE(series.is_array());
+    ASSERT_FALSE(series.empty())
+        << "share_difficulty graph series is empty; the trend line has no data";
+    const auto& last = series.back();
+    ASSERT_TRUE(last.is_array() && last.size() >= 2);
+    EXPECT_DOUBLE_EQ(last[1].get<double>(), 2048.0)
+        << "share_difficulty must come from the sharechain's min_difficulty "
+           "(the real vardiff target), not the net/65536 approximation or a "
+           "0-stub.";
+}
+
+// When the sharechain omits min_difficulty, the trend must fall back to the
+// last real RECORDED share difficulty — never the net/65536 approximation.
+TEST(ShareDifficultyTrend, GraphFallsBackToRecordedShareDifficulty) {
+    MiningInterface mi(/*testnet=*/true, /*node=*/nullptr);
+    mi.set_pool_hashrate_fn([] { return 1.5e12; });
+    // sharechain stats WITHOUT min_difficulty (the honest-absent case):
+    mi.set_sharechain_stats_fn([] {
+        return json{{"total_shares", 4096}, {"orphan_shares", 0},
+                    {"dead_shares", 0}};
+    });
+    // A real accepted share at difficulty 4096 (vardiff top of the 2048<->4096
+    // retarget band the hotel node was running).
+    mi.record_share_difficulty(4096.0, "miner1", "deadbeef");
+
+    mi.update_stat_log();
+    json series = mi.rest_web_graph_data("share_difficulty", "last_hour");
+
+    ASSERT_TRUE(series.is_array() && !series.empty());
+    const auto& last = series.back();
+    ASSERT_TRUE(last.is_array() && last.size() >= 2);
+    EXPECT_DOUBLE_EQ(last[1].get<double>(), 4096.0)
+        << "with no published min_difficulty the share_difficulty trend must "
+           "fall back to the last recorded real share difficulty, not a "
+           "difficulty/65536 approximation.";
+}

--- a/web-static/graphs.html
+++ b/web-static/graphs.html
@@ -84,6 +84,9 @@
         
         <h2>Pool rate</h2>
         <svg id="pool"></svg>
+
+        <h2>Share difficulty vs Network difficulty</h2>
+        <svg id="share_vs_network_diff"></svg>
         
         <h2>Peers</h2>
         <svg id="peers"></svg>
@@ -521,6 +524,14 @@
                 d3.json("../web/graph_data/pool_rates/last_" + lowerperiod, function(data) {
                     plot(d3.select('#pool'), 'H/s', 'H', data_to_lines(data), true);
                 });
+                // Share difficulty vs network difficulty on shared axes. Not
+                // stacked -- these are two independent difficulty levels, and
+                // plotting them together shows how far below chain difficulty
+                // the share target sits.
+                plot_later(d3.select("#share_vs_network_diff"), "", "", [
+                    {"url": "../web/graph_data/share_difficulty/last_" + lowerperiod, "color": "#00A000", "label": "Share Difficulty"},
+                    {"url": "../web/graph_data/network_difficulty/last_" + lowerperiod, "color": "#FF8800", "label": "Network Difficulty"}
+                ], false);
                 d3.json("../web/graph_data/peers/last_" + lowerperiod, function(data) {
                     plot(d3.select('#peers'), 'Total', null, data_to_lines(data, function(line){ return line.label == "incoming" }), true);
                 });


### PR DESCRIPTION
## Operator-requested: share-difficulty trend line on the main graph

Plots share difficulty against network difficulty on the same axes so a miner sees share frequency and how far below chain difficulty the share target sits.

### Why the old graph could not show this honestly
- No `share_difficulty` graph series existed.
- The stat-log `share_diff` was a hardcoded `net_difficulty / 65536` scaled copy of chain difficulty (a fake), not the real vardiff target.
- The `network_difficulty` series back-filled the current atomic across every historical point → flat line (wiring, not data — matches the "looks flat" symptom the hotel node would show against live 2048<->4096 vardiff).

### Fix
- `StatLogEntry` gains `network_difficulty` + `share_difficulty`, snapshotted per sample and persisted (`nd`/`sd` keys) → real history.
- `share_difficulty` sourced from the sharechain published `min_difficulty` (the p2pool share target vardiff retargets), else the last recorded real share difficulty, else honest-absent `0`. Never the `/65536` approximation.
- `network_difficulty` graph source reads the per-entry snapshot.
- `graphs.html`: new "Share difficulty vs Network difficulty" chart, both series on shared axes (unstacked).

### Tests
Two fails-without-fix honesty KATs (sharechain-sourced + recorded fallback). `test_web_honesty_regression` 51/51 green locally (build_ci, gcc13/Release, DGB on).

Non-consensus web layer. Review-gate: designated reviewer before CI/merge; integrator merges (no self-merge).

