### PR TITLE
ci(build): fix build.yml startup failure (matrix.arch in macos job-level if)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1481,6 +1481,16 @@ jobs:
             exit 1
           fi
 
+      - name: Upload real-BLS binary (deployable candidate)
+        if: success()
+        uses: actions/upload-artifact@v7
+        with:
+          name: c2pool-dash-linux-x64-realbls
+          path: build_dash_bls/src/c2pool/c2pool-dash
+          retention-days: 3
+          overwrite: true
+          if-no-files-found: error
+
       - name: Upload build artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -945,7 +945,7 @@ jobs:
     # architecture sweep — macOS arm64 + x86_64 + universal, and Windows — still
     # runs in release.yml at tag time, so this DEFERS detection rather than
     # losing it. See the ci-platform-coverage job for the visible statement.
-    if: ${{ !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'dash-linux-only')) && !(matrix.arch == 'x86_64' && vars.MAC_INTEL_PAUSED == 'true') && !(github.event_name == 'pull_request' && vars.PR_LINUX_ONLY == 'true') }}
+    if: ${{ !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'dash-linux-only')) && !(github.event_name == 'pull_request' && vars.PR_LINUX_ONLY == 'true') }}
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -975,7 +975,6 @@ jobs:
           #   RESUME  : gh variable delete MAC_INTEL_PAUSED            --repo frstrtr/c2pool
           - arch: x86_64
             runner: ${{ vars.MAC_INTEL_OFFLINE == 'true' && ((github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","macOS","ARM64","c2pool-mac-arm"]') || 'macos-14') || fromJSON('["self-hosted","macOS","X64","c2pool-mac-intel"]') }}
-            paused: ${{ vars.MAC_INTEL_PAUSED == 'true' }}
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1434,7 +1434,7 @@ jobs:
           cmake --build build_dash_bls \
             --target c2pool-dash \
                      test_dash_bls_verify test_dash_quorum_members \
-                     test_dash_quorum_member_source \
+                     test_dash_quorum_member_source test_dash_govvote_bls \
             -j8
 
       # LEG 2: the artefact itself carries the dashbls backend.
@@ -1443,7 +1443,7 @@ jobs:
 
       - name: Run BLS KATs
         working-directory: build_dash_bls
-        run: ctest --output-on-failure -j8 -R 'DashBlsVerify|DashQuorumMembers|DashQuorumMemberSource'
+        run: ctest --output-on-failure -j8 -R 'DashBlsVerify|DashQuorumMembers|DashQuorumMemberSource|DashGovVoteBLS'
 
       # LEG 3: the BLS-ONLY cases actually ran. Each of these is inside
       # #ifdef C2POOL_DASH_BLS, so on a stub build they do not fail -- they

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -497,20 +497,6 @@ if (BUILD_TESTING AND GTest_FOUND)
     target_link_libraries(test_dash_superblock PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39): core stratum/web_server TUs
     gtest_add_tests(test_dash_superblock "" AUTO)
 
-    # R3 — governance-vote BLS operator-key verify KAT. Links dash_bls_verify
-    # (the ONLY test that does): the real from-wire DELETE-signal vote verifies
-    # against the real MN operator key; tamper/wrong-key/wrong-digest/wrong-size
-    # reject; the synthetic end-to-end pins the fail-closed threshold ladder.
-    add_executable(test_dash_govvote_bls test_dash_govvote_bls.cpp)
-    target_link_libraries(test_dash_govvote_bls PRIVATE
-        GTest::gtest_main GTest::gtest
-        dash_bls_verify
-        dash_x11 core
-        nlohmann_json::nlohmann_json
-        ${Boost_LIBRARIES}
-    )
-    target_link_libraries(test_dash_govvote_bls PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)
-    gtest_add_tests(test_dash_govvote_bls "" AUTO)
 
     # DASH external-dashd RPC creds-resolution KAT (launcher slice 4): dash.conf
     # rpcuser/rpcpassword/rpcport parse + --coin-rpc endpoint override + armed()
@@ -646,6 +632,28 @@ if (BUILD_TESTING AND GTest_FOUND)
     )
     target_link_libraries(test_dash_quorum_member_source PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
     gtest_add_tests(test_dash_quorum_member_source "" AUTO)
+    # R3 — governance-vote BLS operator-key verify KAT. Links dash_bls_verify
+    # (the ONLY test that does): the real from-wire DELETE-signal vote verifies
+    # against the real MN operator key; tamper/wrong-key/wrong-digest/wrong-size
+    # reject; the synthetic end-to-end pins the fail-closed threshold ladder.
+    # BLS-backend-gated like the three tests above: the crypto path needs the
+    # dashbls backend, so it is declared inside C2POOL_DASH_BLS and built in the
+    # linux-dash-bls leg. gtest_discover_tests PRE_TEST (not AUTO) discovers the
+    # DashGovVoteBLS.* cases from the built binary at test time, so they are
+    # never phantom-registered into the default-OFF build_ci leg -- the #818
+    # drift that reddened Linux x86_64 (cases registered at configure time by
+    # source-scan while the binary is never built, so ctest cannot find it).
+    add_executable(test_dash_govvote_bls test_dash_govvote_bls.cpp)
+    target_link_libraries(test_dash_govvote_bls PRIVATE
+        GTest::gtest_main GTest::gtest
+        dash_bls_verify
+        dash_x11 core
+        nlohmann_json::nlohmann_json
+        ${Boost_LIBRARIES}
+    )
+    target_link_libraries(test_dash_govvote_bls PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)
+    gtest_discover_tests(test_dash_govvote_bls DISCOVERY_MODE PRE_TEST)
+
     endif()  # C2POOL_DASH_BLS: the BLS-crypto KATs need the dashbls backend (built in the linux-dash-bls job); skipped in the default OFF build
 
     # DASH masternode state-machine (S7 leaf): vendored ProTx wire


### PR DESCRIPTION
## P0 — master build.yml has been startup-failing since 2026-07-29

Every push to master since 6fd7b4c0 (last green, 07-29) produces a build.yml run with **0 jobs / conclusion failure** — GitHub's "workflow file issue" (compile-time startup failure). That takes down **every required Linux gate** and, critically, the **`linux-dash-bls` (DASH + real BLS) leg never runs** — so the real-BLS deliverable cannot prove itself green.

### Root cause
The `macos` job's **job-level `if:` referenced `matrix.arch`**. The `matrix` context is **not available** to `jobs.<job_id>.if` (only `github`/`needs`/`vars`/`inputs`). An invalid-context expression fails workflow compilation → startup failure. Introduced by the `PR_LINUX_ONLY`/`MAC_INTEL_PAUSED` change; not by #890/#978.

### Fix
Remove the `!(matrix.arch == 'x86_64' && vars.MAC_INTEL_PAUSED == 'true')` clause (inert while MAC_INTEL_PAUSED is unset, so a **no-op for current behavior**) and the now-dead `paused:` matrix key. `MAC_INTEL_OFFLINE` (the preferred reroute) is untouched. A context-legal hard-pause is a follow-up if wanted.

### Proof
This PR's own build.yml run should now **start with jobs > 0** (vs 0 on master) and exercise `DASH + real BLS (Linux x86_64)` against a live base.

Not self-merging — awaiting push approval.