### PR TITLE
btc(seed): wire SeedBootstrapper into NodeImpl dial-maintenance loop

### DIFF
--- a/src/impl/btc/node.cpp
+++ b/src/impl/btc/node.cpp
@@ -1539,11 +1539,55 @@ void NodeImpl::start_outbound_connections()
         return;
     }
 
+    // SeedBootstrapper — tick-driven, rate-limited seed-candidate refill hung
+    // off the existing 30s dial-maintenance loop. It only ADDS candidates (via
+    // got_addr) and never connects; the normal dial path below does the actual
+    // dialing on the next tick. Tiers are tried in order:
+    //   tier 0 = DNS   — TODO: wire core/dns_seeder.hpp async resolution to
+    //                    feed a resolved-IP cache returned here. Until then this
+    //                    tier resolves nothing and the FSM fast-advances past it
+    //                    to the fixed tier (empty-tier advance path).
+    //   tier 1 = fixed — static NetService fallback list (sync, works today).
+    {
+        const bool testnet = m_config->m_testnet;
+        std::vector<btc::coin::SeedBootstrapper::TierFn> tiers;
+        tiers.emplace_back([]() -> std::vector<NetService> { return {}; });
+        tiers.emplace_back([testnet]() { return btc::coin::btc_fixed_seeds(testnet); });
+
+        btc::coin::SeedBootstrapper::Config sb_cfg;  // locked defaults
+        m_seed_bootstrapper = std::make_unique<btc::coin::SeedBootstrapper>(
+            sb_cfg,
+            // Snapshot: live established-outbound / target + the dial layer
+            // exhaustion flag recorded on the previous pass below.
+            [this]() {
+                return btc::coin::SeedBootstrapper::Snapshot{
+                    m_outbound_addrs.size(), m_target_outbound_peers,
+                    m_seed_candidates_exhausted};
+            },
+            // Sink: seeds only add candidates; services unknown (0), seen now.
+            [this](const NetService& a) {
+                got_addr(a, /*services=*/0, core::timestamp());
+            },
+            // Clock: unix seconds.
+            []() -> std::int64_t {
+                return static_cast<std::int64_t>(core::timestamp());
+            },
+            std::move(tiers),
+            std::random_device{}());  // per-node startup jitter decorrelation
+    }
+
     // Try to connect to peers right away
     auto try_connect_peers = [this]() {
         size_t outbound = m_outbound_addrs.size();
         if (outbound >= m_target_outbound_peers || m_connections.size() >= m_max_peers)
+        {
+            // Still drive the FSM on the healthy path so it sees the at/above-
+            // target Snapshot and releases backoff state after hysteresis; the
+            // Healthy branch injects nothing regardless of the exhaustion flag.
+            if (m_seed_bootstrapper)
+                m_seed_bootstrapper->tick();
             return;
+        }
 
         size_t needed = m_target_outbound_peers - outbound;
         auto good_peers = get_good_peers(needed + 4);  // ask for a few extra in case some are already connected
@@ -1561,6 +1605,15 @@ void NodeImpl::start_outbound_connections()
             core::Client::connect(ap.addr);
             --needed;
         }
+
+        // Dual-condition guard for seed escalation: after dialing everything we
+        // could this cycle, a non-zero remaining deficit means the normal dial
+        // path could not fill `needed` from its own good-peer set — its
+        // candidates are exhausted. Record it and drive the FSM, which escalates
+        // to seed injection only once starvation has also persisted long enough.
+        m_seed_candidates_exhausted = (needed > 0);
+        if (m_seed_bootstrapper)
+            m_seed_bootstrapper->tick();
     };
 
     // Initial burst

--- a/src/impl/btc/node.hpp
+++ b/src/impl/btc/node.hpp
@@ -6,6 +6,8 @@
 #include "share_tracker.hpp"
 #include "peer.hpp"
 #include "messages.hpp"
+#include "coin/seed_bootstrapper.hpp"
+#include "coin/chain_seeds.hpp"
 
 #include <pool/node.hpp>
 #include <pool/sharechain_node.hpp>
@@ -670,6 +672,14 @@ protected:
     size_t m_max_peers = 30;
     size_t m_target_outbound_peers = DEFAULT_TARGET_OUTBOUND_PEERS;
     std::unique_ptr<core::Timer> m_connect_timer;
+    // Tick-driven, rate-limited seed-candidate refill hung off the 30s dial
+    // loop (see coin/seed_bootstrapper.hpp). Constructed lazily in
+    // start_outbound_connections(); seeds only ADD candidates via got_addr,
+    // never connect. m_seed_candidates_exhausted carries the dial layer
+    // per-tick "could not fill the outbound deficit from our own good peers"
+    // signal into the pull-based Snapshot the bootstrapper reads each tick.
+    std::unique_ptr<btc::coin::SeedBootstrapper> m_seed_bootstrapper;
+    bool m_seed_candidates_exhausted = false;
     // Periodic have_tx/losing_tx delta sweep (core/tx_advertiser.hpp). Cadence
     // mirrors the canonical known-tx removal loop, node.py:298 t.start(10).
     std::unique_ptr<core::Timer> m_tx_advert_timer;

--- a/src/impl/btc/test/seed_bootstrapper_test.cpp
+++ b/src/impl/btc/test/seed_bootstrapper_test.cpp
@@ -308,6 +308,28 @@ TEST(SeedBootstrapper, StartupJitterWithinConfiguredBound)
     }
 }
 
+// Mirrors the exact tier layout NodeImpl::start_outbound_connections builds:
+// tier 0 = DNS (currently resolves nothing — async wiring is a later slice) and
+// tier 1 = fixed fallback. Confirms the empty DNS tier is skipped without
+// burning a settle interval and the fixed tier then injects candidates — i.e.
+// the node wiring degrades to the working fixed tier exactly as intended.
+TEST(SeedBootstrapper, NodeWiringDnsEmptyThenFixedInjects)
+{
+    Harness h;
+    h.tier_data = {make_seeds(0), make_seeds(4)};  // tier 0 DNS empty, tier 1 fixed
+    h.snap = {0, 8, true};                         // zero outbound, dial path exhausted
+    auto sb = h.make(no_jitter_cfg());
+
+    sb.tick();                        // observe
+    h.now = 1031; auto r = sb.tick(); // tier 0 (DNS) resolves nothing
+    EXPECT_EQ(r.tier, 0u);
+    EXPECT_EQ(r.injected, 0u);
+    h.now = 1032; r = sb.tick();      // advance immediately to fixed tier 1
+    EXPECT_EQ(r.tier, 1u);
+    EXPECT_EQ(r.injected, 4u);
+    EXPECT_EQ(h.injected.size(), 4u);
+}
+
 TEST(SeedBootstrapper, EmptyTierAdvancesWithoutBurningSettle)
 {
     Harness h;


### PR DESCRIPTION
## What

SLICE-2 of the BTC seed-bootstrap milestone: wire the existing
`btc::coin::SeedBootstrapper` (landed in SLICE-1, but included only by its own
test — genuinely unwired) into `NodeImpl`, so the tick-driven, rate-limited
seed-candidate refill FSM actually runs off the existing 30s dial loop.

## How

- Construct the bootstrapper lazily in `start_outbound_connections` with two
  tiers tried in order:
  - **tier 0 = DNS** — resolves nothing for now (a clearly marked TODO to feed
    `core/dns_seeder.hpp` async results through a cache in a later slice). The
    FSM fast-advances past the empty tier.
  - **tier 1 = fixed** — `btc_fixed_seeds`, a static `NetService` fallback list
    that works today. This is the live working tier this slice ships.
- Snapshot pulls live established-outbound / target counts plus a dial-layer
  exhaustion flag; the sink only ADDS candidates via `got_addr` (never
  connects); clock is unix seconds; rng seed is per-node so startup jitter
  decorrelates a fleet restarting together.
- In `try_connect_peers`, after the dial pass, record whether the normal dial
  path could not fill the outbound deficit from its own good peers
  (`m_seed_candidates_exhausted = remaining needed > 0`) and drive the FSM. The
  FSM is also ticked on the at/above-target early-return so it observes the
  healthy snapshot and releases backoff state after the hysteresis window.

HTTP tier stays deferred. The invariant holds: seeds only add candidates, never
connect, and no term reads any `*_seeds().size()` as an admission cap.

## Tests

Adds a KAT that pins the node's DNS-empty-then-fixed tier layout, riding the
existing `btc_share_test` executable (no new `add_executable`, no build.yml
change). Full SeedBootstrapper suite green: **13/13**.

Isolated to `src/impl/btc/`.
