### PR TITLE
test(ltc): fix stale compact-block fixture — supply real Merkle root

### DIFF
--- a/test/test_compact_blocks.cpp
+++ b/test/test_compact_blocks.cpp
@@ -92,6 +92,10 @@ static BlockType make_block(const std::vector<MutableTransaction>& txs) {
     block.m_bits = 0x1d00ffff;
     block.m_nonce = 42;
     block.m_txs = txs;
+    // A real block header carries the Merkle root over its own transactions.
+    // ReconstructBlock (#977) verifies this root before delivery, so the fixture
+    // must supply it rather than a null placeholder (was: m_merkle_root.SetNull()).
+    block.m_merkle_root = ComputeTxMerkleRoot(txs);
     return block;
 }
 


### PR DESCRIPTION
## What

test/test_compact_blocks.cpp — FullReconstruction (line 237/239) and EmptyBlock_OnlyCoinbase (274/275) asserted result.complete == true but returned false. Un-hidden by #1010 (head 7512049d) exposing build.yml on Linux x86_64.

## Root cause (verified, not inferred)

#977 (commit f7cb40c8d, merged 2026-07-30) added a header **Merkle-root backstop** to ReconstructBlock: after filling all tx slots it recomputes the Merkle root over the reconstructed txs and, on mismatch, sets merkle_mismatch and discards (complete=false). This is BIP 152 correct — a filled 48-bit short-ID slot is not proof of correctness.

The test fixture make_block() predates the backstop and set m_merkle_root.SetNull() — a null root no real block header carries. The backstop correctly rejected it. EmptyBlock has **zero** short IDs (coinbase-only, prefilled), so its failure can only be the Merkle check — isolating the cause to the header root, not the wtxid short-ID path.

## Fix

Derive the fixture header root from its own transactions via ComputeTxMerkleRoot(txs), as every real header does. **Reconstruction logic is unchanged** — this is a stale fixture, not a protocol/consensus bug.

## Evidence

Base origin/master f4b7083ea (contains #977):
- Without change: FullReconstruction + EmptyBlock_OnlyCoinbase FAIL (complete=false).
- With change: all 15 CompactBlockTest cases PASS.

Change is confined to the ltc test file; folded into the existing allowlisted test_compact_blocks target (no new add_executable).

## Ownership

Shared BIP 152 protocol fixture, not coin-specific consensus — owning it rather than handing back.
