### PR TITLE
dash: fix 2 DashStratumC1MainnetGate KATs red on #1010 (#996 fixture staleness)

### DIFF
--- a/test/test_dash_stratum_work_source.cpp
+++ b/test/test_dash_stratum_work_source.cpp
@@ -28,6 +28,7 @@
 #include <impl/dash/coin/vendor/cbtx.hpp>           // parse_cbtx (read served creditPool)
 #include <impl/dash/coin/embedded_gbt.hpp>          // encode_cbtx (GBT-xcheck fallback fixture)
 #include <impl/dash/coin/arm_resolution.hpp>       // #738 resolve_embedded_arm (run-path arm decision)
+#include <impl/dash/coin/mn_state_db.hpp>         // MNState (seed a resolvable MN payee for the #996 fail-closed gate)
 
 #include <core/stratum_work_source.hpp>
 #include <core/target_utils.hpp>
@@ -1677,6 +1678,28 @@ namespace {
 const char* const kEmbeddedPrevHashHex =
     "0000000000000000abcdef0123456789abcdef0123456789abcdef0123456789";
 constexpr uint32_t kEmbeddedPrevHeight = 500000u;   // embedded template -> +1
+// #996 fail-closed guard (node_coin_state.hpp::mn_payee_resolvable_at_tip):
+// the embedded arm now REFUSES to serve when a MN payment is due at the tip
+// but find_expected_payee() is nullopt (empty MN set). These C1-gate fixtures
+// predate that guard and seed only the header tip, so post-#996 the embedded
+// arm is (correctly) refused for want of a MN set -- which would MASK the
+// mainnet/testnet DISCRIMINATOR this suite actually pins. Seed ONE live MN
+// into the payee queue so the embedded arm is genuinely viable and the gate
+// under test is the net discriminator, not the (separately-covered) #996
+// payee guard (see test_dash_cb_payee / test_dash_mn_state).
+void seed_resolvable_mn(dash::coin::NodeCoinState& cs)
+{
+    dash::coin::MNState mn;
+    mn.isValid           = true;              // eligible (nPoSeBanHeight == 0)
+    mn.nRegisteredHeight = 1;                 // a positive payment-queue slot
+    mn.collateralOutpoint.hash.SetHex(std::string(64, '9'));
+    mn.collateralOutpoint.index = 0;
+    mn.scriptPayout.m_data = fixture_miner_script();   // standard P2PKH payout
+    uint256 protx;
+    protx.SetHex(std::string(64, 'a'));
+    cs.mnstates().load({{protx, mn}}, /*as_of_height=*/kEmbeddedPrevHeight);
+}
+
 void seed_populated(dash::coin::NodeCoinState& cs)
 {
     uint256 emb_prev;
@@ -1684,6 +1707,7 @@ void seed_populated(dash::coin::NodeCoinState& cs)
     cs.set_tip(kEmbeddedPrevHeight, emb_prev, /*bits_for_next=*/0x1e0ffff0u,
                /*mtp_at_tip=*/1'700'000'000u, /*addr_ver=*/76, /*p2sh_ver=*/16,
                /*curtime=*/kCurtime, /*version=*/static_cast<uint32_t>(kVersion));
+    seed_resolvable_mn(cs);   // #996: make the embedded arm genuinely viable
 }
 }  // namespace
 
@@ -1783,6 +1807,7 @@ TEST(DashStratumC1MainnetGate, EmbeddedCacheHitReValidatesCreditPoolAndReSources
     cs.set_sml_current_hash(emb_prev);
     cs.set_require_sml(true);
     cs.set_require_fresh_credit_pool(true);
+    seed_resolvable_mn(cs);   // #996: resolvable payee so the embedded arm serves
 
     const int64_t S1 = 33971546001156LL;
     const int64_t S2 = 33971612967986LL;   // advanced seed (one reward later)


### PR DESCRIPTION
## What

Fixes the two `DashStratumC1MainnetGate` gtest failures that red the **Linux x86_64** leg on #1010 (run 30709379466):

- `MainnetPopulatedCoinStateRoutesToDashdFallback`
- `TestnetPopulatedCoinStateServesEmbedded`

(`EmbeddedCacheHitReValidatesCreditPoolAndReSources` is red on the same tree for the identical reason and is fixed here too; `GbtXcheckServesDashdOnCreditPoolMismatch` already passed.)

## Root cause — test-fixture staleness, NOT a routing bug

The reds are latent master breakage that #1010 merely makes visible again (master build.yml was in startup_failure, so the Linux leg had not executed). #996 (merged @2b54f486) added a **fail-closed payee guard** `node_coin_state.hpp::mn_payee_resolvable_at_tip()`: the embedded arm REFUSES to serve when a MN payment is due at the tip but `find_expected_payee()` is nullopt (empty MN set) — routing to the reward-safe dashd GBT fallback.

The C1-gate fixtures predate #996 and seed only the header tip (`seed_populated` = `set_tip` only; they populate `sml()` but never the `mnstates()` payee queue that the guard reads). Post-#996 the embedded arm is therefore **correctly** refused for want of a MN set — which masks the mainnet/testnet **discriminator** the suite actually pins. Confirmed by the runtime log: `[EMBED-GATE] h=500001 REFUSE embedded template ... [#996 bad-cb-payee fail-closed]`.

The #996 routing is correct prod behavior and is left untouched.

## Fix (test-only, per-coin isolation — `test/` only)

Seed one live MN into the payee queue (`cs.mnstates().load(...)`) so the embedded arm is genuinely viable, isolating the net discriminator under test from the orthogonal #996 payee guard. That guard stays active and is separately covered by `test_dash_cb_payee` / `test_dash_mn_state`.

## Verification (workstation, Linux x86_64)

- `DashStratumC1MainnetGate.*` → **4/4 PASSED**
- full `test_dash_stratum_work_source` binary → **58/58 PASSED**

Not bundled into #1010. Commit GPG-signed.