### PR TITLE
dash(#996): rescope payee guard — empty MN set is not a resolution failure

### DIFF
--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -135,11 +135,15 @@ public:
 
     /// #996 payee fail-closed gate. When enabled (default ON), viability
     /// refuses the embedded arm at any height where a MN payment is due but
-    /// find_expected_payee() cannot be resolved to a live SML entry — the
+    /// the NON-empty payee queue cannot resolve it to a live SML entry — the
     /// builder would otherwise emit a coinbase claiming m_payment_amount with
-    /// no MN output (fail-OPEN, bad-cb-payee). Refusal downgrades to the
-    /// reward-safe dashd GBT fallback; it is a template-SERVE refusal (free),
-    /// never a block-SUBMIT refusal. Exposed for the negative-pass test.
+    /// no MN output (fail-OPEN, bad-cb-payee). An EMPTY queue never trips:
+    /// it means no masternode set at all (a network with none serves
+    /// normally; a mid-sync empty queue is already fail-closed by
+    /// require_sml + require_fresh_mn_payee), not a resolution failure.
+    /// Refusal downgrades to the reward-safe dashd GBT fallback; it is a
+    /// template-SERVE refusal (free), never a block-SUBMIT refusal. Exposed
+    /// for the negative-pass test.
     void set_require_resolvable_payee(bool v) { m_require_resolvable_payee = v; }
 
     /// creditPool freshness gate (soak fix). dashcore CheckCreditPoolDiffForBlock
@@ -427,10 +431,12 @@ public:
         // daemonless provider is trigger-confident) and thread the schedule.
         SuperblockDisposition sb = resolve_superblock(m_prev_height + 1);
         // #996 fail-closed: a MN payment is due at the tip we build on but the
-        // payee is unresolvable (find_expected_payee() nullopt -- every entry
-        // isValid=false or the set is empty -- or, defensively, a projected
-        // payee absent from the SML entry set). The embedded builder would omit
-        // the MN coinbase output while m_payment_amount still claims it:
+        // NON-empty payee queue resolves no payee (find_expected_payee()
+        // nullopt -- every entry isValid=false -- or, defensively, a projected
+        // payee absent from the SML entry set); an empty queue means no
+        // masternode set at all, not a resolution failure, and never trips.
+        // The embedded builder would omit the MN coinbase output while
+        // m_payment_amount still claims it:
         // fail-OPEN on a money path (bad-cb-payee). Refusing downgrades to the
         // dashd GBT fallback -- a template-SERVE refusal (free), not a
         // block-SUBMIT refusal.
@@ -475,9 +481,10 @@ public:
         if (m_require_resolvable_payee && !payee_resolvable) {
             LOG_WARNING << "[EMBED-GATE] h=" << (m_prev_height + 1)
                         << " REFUSE embedded template: MN payment due but payee"
-                        << " unresolvable (find_expected_payee nullopt or"
-                        << " projected payee absent from SML set) -- falling back"
-                        << " to dashd GBT [#996 bad-cb-payee fail-closed].";
+                        << " unresolvable from a non-empty MN set"
+                        << " (find_expected_payee nullopt or projected payee"
+                        << " absent from SML set) -- falling back to dashd GBT"
+                        << " [#996 bad-cb-payee fail-closed].";
         }
         e.prev_height          = m_prev_height;
         e.prev_hash            = m_prev_hash;
@@ -575,13 +582,22 @@ private:
     // #996 helper: is the MN payee the embedded builder will need actually
     // resolvable at the tip we build on? Mirrors embedded_gbt.hpp's build-time
     // condition (build_embedded_workdata gates the MN PackedPayment on
-    // mn_payment > 0). Returns false ONLY when a MN payment is due but
-    // find_expected_payee() is nullopt (all entries isValid=false / empty set)
-    // or, defensively, names a payee absent from entries(). Uses the fee-free
-    // subsidy floor: mempool fees only RAISE block_value, so if the floor MN
-    // payment is <= 0 no MN output is due and an absent payee is legitimately
-    // fine -- the gate never over-refuses at a genuine no-MN-payment height.
+    // mn_payment > 0). Returns false ONLY when a MN payment is due and the
+    // NON-empty payee queue resolves no payee: every entry isValid=false (an
+    // unobserved PoSe ban) or, defensively, the projection names a payee
+    // absent from entries(). An EMPTY queue is not a resolution failure -- it
+    // means no masternode set at all: either a network that legitimately has
+    // none (the builder emits no MN output and dashd expects none) or a queue
+    // not yet seeded, which the armed posture already fails closed via
+    // require_sml (have_sml + sml current at tip) and require_fresh_mn_payee
+    // (last_applied_height == prev_height). Firing on the empty set made the
+    // embedded arm permanently non-viable on no-MN-set networks. Uses the
+    // fee-free subsidy floor: mempool fees only RAISE block_value, so if the
+    // floor MN payment is <= 0 no MN output is due and an absent payee is
+    // legitimately fine -- the gate never over-refuses at a genuine
+    // no-MN-payment height.
     bool mn_payee_resolvable_at_tip() const {
+        if (m_mnstates.entries().empty()) return true;  // no MN set: nothing to resolve
         const uint32_t next_h = m_prev_height + 1;
         const int64_t reward = compute_dash_block_reward_post_v20(next_h);
         const int64_t platform_reward =

--- a/test/test_dash_node_coin_state.cpp
+++ b/test/test_dash_node_coin_state.cpp
@@ -430,6 +430,25 @@ TEST(DashNodeCoinState, UnresolvablePayeeFailsClosedToDashd) {
         << "#996 guard must NOT refuse when the due payee resolves";
 }
 
+// #996 rescope: an EMPTY payee queue must NOT trip the guard (default ON).
+// No-masternode-set is not a resolution failure: a network that genuinely
+// has none serves normally (the builder emits no MN output and dashd expects
+// none), and a mid-sync empty queue is already fail-closed on the armed
+// posture by require_sml + require_fresh_mn_payee. Distinguishes the
+// no-MN-set case from UnresolvablePayeeFailsClosedToDashd above, where
+// entries EXIST but none resolves -- that one must keep refusing.
+TEST(DashNodeCoinState, EmptyMnSetDoesNotTripPayeeGuard) {
+    NodeCoinState st;
+    st.set_tip(H - 1, raw256(0xAB), 0x1b104be3u, 1700000000u,
+               DASH_PUBKEY_VER, DASH_P2SH_VER);
+    ASSERT_TRUE(st.populated());
+    ASSERT_TRUE(st.mnstates().entries().empty());
+    ASSERT_FALSE(st.mnstates().find_expected_payee().has_value());
+    // Guard at its DEFAULT (ON): the empty set stays viable at a height where
+    // a MN payment WOULD be due if a masternode set existed.
+    EXPECT_TRUE(st.make_embedded_work_inputs().viable());
+}
+
 // BLOCKER-1 (PR #780): is_dkg_commitment_window over REAL live-testnet heights —
 // the DKG mining windows the review pulled must be flagged, the fixture height
 // (a non-qc coinbase-only block) must not.


### PR DESCRIPTION
## The defect

#1005 closed a real fail-open (a payee resolving to nothing while `mn_payment > 0` silently omitted the masternode output — `bad-cb-payee` on a real block). But the guard it added was scoped too broadly: it could not tell **a payee that ought to exist and failed to resolve** from **a network that legitimately has no masternode set**.

Consequence: on a network with no MN set, the guard fired at every height, `make_embedded_work_inputs().viable()` stayed false, and the embedded arm never armed at all. Six arm-safety tests went red.

## The rescope

The discriminator is read off existing state rather than a new flag:

- `entries()` **non-empty** — a MN payment is owed at this height, so a `nullopt` from `find_expected_payee()` (every entry PoSe-banned, or the projected payee absent from the set) is a **genuine resolution failure** → still refuse, fall back to dashd. The #996 hole stays closed.
- `entries()` **empty** — there is no masternode set; the builder emits no MN output and the network expects none → nothing to resolve, guard does not fire.

The residual case — an empty set because sync has not seeded it yet — is fail-closed by the other clauses on the armed posture: `require_sml` (SML present and current at the exact tip hash) and `require_fresh_mn_payee` (payee queue folded through the tip).

## Negative pass

Captured with real exit codes, not asserted:

```
clean HEAD d75e5c41    0% tests passed, 6 tests failed out of 6
with the rescope     100% tests passed, 0 tests failed out of 6   exit 0
```

The six:
`DashStratumC1MainnetGate.{MainnetPopulatedCoinStateRoutesToDashdFallback, TestnetPopulatedCoinStateServesEmbedded, EmbeddedCacheHitReValidatesCreditPoolAndReSources}`
`DashRunArmResolution.{EmbeddedMainnetOptInArmsBothHalvesEndToEnd, EmbeddedMainnetWithPinnedPeerDoesNotImplyDiscovery, TestnetWithCoinP2pIsUnchangedEmbedded}`

Also green: `DashNodeCoinState` 17/17, and a 259-test run — both exit 0.

## Scope

Serve-path only. Refusing an embedded template is free (it downgrades to the dashd fallback); the block-submit path is untouched.

```
src/impl/dash/coin/node_coin_state.hpp   +33/-17
test/test_dash_node_coin_state.cpp       +19/-0
```

Cherry-picked onto current master (the original was cut at `d75e5c41`, before ~13 of today's merges). The six tests must be re-verified by CI against this base — a stale-base negative pass proves nothing about today's tree.

## Open question for review

Whether `require_sml` + `require_fresh_mn_payee` genuinely close the unsynced-empty case is the load-bearing claim here and deserves an independent reading, ideally from whoever raised it. Specifically: can `require_sml` be satisfied by an SML that is current-at-tip but empty, and is the `entries()`-empty branch evaluated before or after those clauses?