### PR TITLE
core(tx-advert): GAP 2 — ordered same-sweep have/losing two-part drain over #863 queue

### DIFF
--- a/src/core/test/tx_advertiser_test.cpp
+++ b/src/core/test/tx_advertiser_test.cpp
@@ -192,27 +192,24 @@ TEST(TxAdvertiser, EvictionEmitsLosingTx)
     EXPECT_EQ(st.m_advertised, hashes(6, 10));
 }
 
-// p2p.py:261-274 (transitioned): additions go out BEFORE retractions. With the
-// one-message-per-sweep bound this becomes "adds this sweep, retractions the
-// next" — the ordering canonical guarantees is preserved across sweeps.
+// p2p.py:261-274 (transitioned): additions go out BEFORE retractions, and the
+// #863 write queue lets both go in ONE sweep -- have_tx then losing_tx, ordered.
 TEST(TxAdvertiser, MixedDeltaSendsHaveBeforeLosing)
 {
     TxAdvertState st;
     Wire w0;
     sweep(st, hashes(1, 5), w0);
 
+    // One sweep that both adds {6..9} and drops {1..3}: two ordered messages.
     Wire a;
-    sweep(st, hashes(4, 9), a); // drop 1..3, add 6..9
-    ASSERT_EQ(a.msgs.size(), 1u);
+    sweep(st, hashes(4, 9), a);
+    ASSERT_EQ(a.msgs.size(), 2u);
     EXPECT_EQ(a.msgs[0].kind, Wire::Kind::have);
+    EXPECT_EQ(a.msgs[1].kind, Wire::Kind::losing);
     EXPECT_EQ(std::set<uint256>(a.msgs[0].hashes.begin(), a.msgs[0].hashes.end()), hashes(6, 9));
+    EXPECT_EQ(std::set<uint256>(a.msgs[1].hashes.begin(), a.msgs[1].hashes.end()), hashes(1, 3));
 
-    Wire b;
-    sweep(st, hashes(4, 9), b);
-    ASSERT_EQ(b.msgs.size(), 1u);
-    EXPECT_EQ(b.msgs[0].kind, Wire::Kind::losing);
-    EXPECT_EQ(std::set<uint256>(b.msgs[0].hashes.begin(), b.msgs[0].hashes.end()), hashes(1, 3));
-
+    // Fully drained -> next sweep says nothing.
     Wire c;
     sweep(st, hashes(4, 9), c);
     EXPECT_TRUE(c.msgs.empty());
@@ -234,7 +231,7 @@ TEST(TxAdvertiser, NothingAdvertisedTwiceAndReLearnReAdvertises)
             sweep(st, pool, w);
             if (w.msgs.empty())
                 return;
-            ASSERT_EQ(w.msgs.size(), 1u);
+            ASSERT_LE(w.msgs.size(), 2u); // have and/or losing in one sweep
             for (const auto& h : w.all(Wire::Kind::have))
                 ever_advertised.push_back(h);
         }
@@ -256,10 +253,10 @@ TEST(TxAdvertiser, NothingAdvertisedTwiceAndReLearnReAdvertises)
     EXPECT_EQ(st.m_advertised, hashes(1, 6));
 }
 
-// Write-safety bound: a sweep emits AT MOST ONE message. core::Socket::write has
-// no outbound queue (socket.cpp:110-137), so a chunk burst would overlap composed
-// async_writes and interleave bytes mid-message -> bad checksum -> the canonical
-// peer drops us. Over-budget hashes are NOT committed; they resurface next sweep.
+// Budget bound: an ADDS-ONLY sweep emits exactly one have_tx of `budget` hashes;
+// over-budget hashes are NOT committed and resurface next sweep. (Since #863 the
+// two-part drain may emit have_tx AND losing_tx in one sweep -- covered by
+// SameSweepDrainsHaveThenLosingInOrder -- but with no retractions, just one here.)
 TEST(TxAdvertiser, OneMessagePerSweepAndCommitsOnlyWhatWasEmitted)
 {
     constexpr size_t budget = 4;
@@ -307,9 +304,10 @@ TEST(TxAdvertiser, RemainderIsAdvertisedOnSubsequentSweeps)
     EXPECT_EQ(st.m_advertised, pool);
 }
 
-// Retractions are budgeted the same way, and additions always drain FIRST
-// (canonical have-before-losing, p2p.py:264-267) — so a sweep never emits a
-// have_tx and a losing_tx back to back.
+// Retractions are budgeted like additions, and within a sweep additions drain
+// FIRST (canonical have-before-losing, p2p.py:261-274). With the two-part drain
+// a sweep emits have_tx AND losing_tx together, each capped at the budget; the
+// losing_tx remainder carries to the following sweeps.
 TEST(TxAdvertiser, LosingTxIsBudgetedAndDrainsAfterHaveTx)
 {
     constexpr size_t budget = 4;
@@ -319,34 +317,31 @@ TEST(TxAdvertiser, LosingTxIsBudgetedAndDrainsAfterHaveTx)
     for (int i = 0; i < 3; ++i) { Wire w; sweep(st, hashes(1, 9), w, budget); }
     ASSERT_EQ(st.m_advertised, hashes(1, 9));
 
-    // Now the pool drops to {1..2} AND gains {20..21}: adds go first.
+    // Pool drops to {1,2} AND gains {20,21}: 2 adds, 7 retractions ({3..9}).
     std::set<uint256> next = hashes(1, 2);
     next.insert(H(20));
     next.insert(H(21));
 
+    // Sweep 1: both adds, PLUS the first `budget` retractions -- have before losing.
     Wire a;
     sweep(st, next, a, budget);
-    ASSERT_EQ(a.msgs.size(), 1u);
+    ASSERT_EQ(a.msgs.size(), 2u);
     EXPECT_EQ(a.msgs[0].kind, Wire::Kind::have);
     EXPECT_EQ(std::set<uint256>(a.msgs[0].hashes.begin(), a.msgs[0].hashes.end()),
               (std::set<uint256>{H(20), H(21)}));
+    EXPECT_EQ(a.msgs[1].kind, Wire::Kind::losing);
+    EXPECT_EQ(a.msgs[1].hashes.size(), budget);
 
-    // Only once additions are exhausted do retractions start, one message each.
+    // Sweep 2: no adds left, the remaining 3 retractions.
     Wire b;
     sweep(st, next, b, budget);
     ASSERT_EQ(b.msgs.size(), 1u);
     EXPECT_EQ(b.msgs[0].kind, Wire::Kind::losing);
-    EXPECT_EQ(b.msgs[0].hashes.size(), budget);
+    EXPECT_EQ(b.msgs[0].hashes.size(), 3u); // 7 retractions total: 4 + 3
 
     Wire c;
     sweep(st, next, c, budget);
-    ASSERT_EQ(c.msgs.size(), 1u);
-    EXPECT_EQ(c.msgs[0].kind, Wire::Kind::losing);
-    EXPECT_EQ(c.msgs[0].hashes.size(), 3u); // 7 retractions total: 4 + 3
-
-    Wire d;
-    sweep(st, next, d, budget);
-    EXPECT_TRUE(d.msgs.empty());
+    EXPECT_TRUE(c.msgs.empty());
     EXPECT_EQ(st.m_advertised, next);
 }
 

--- a/src/core/test/tx_advertiser_test.cpp
+++ b/src/core/test/tx_advertiser_test.cpp
@@ -350,6 +350,48 @@ TEST(TxAdvertiser, LosingTxIsBudgetedAndDrainsAfterHaveTx)
     EXPECT_EQ(st.m_advertised, next);
 }
 
+// GAP 2 — end-to-end ordering: within ONE sweep the drain enqueues have_tx
+// THEN losing_tx (canonical p2p.py:261-274, transitioned). Both messages land
+// on the peer's #863 outbound write queue (core/socket.hpp:78), which drains
+// FIFO with at most one composed async_write in flight (proven separately by
+// socket_write_queue_test.cpp), so SUBMISSION order is WIRE order. End-to-end
+// ordering is therefore the composition of two proven halves: run_tx_advert
+// submits have-before-losing (asserted here, driving the REAL run_tx_advert and
+// a REAL TxAdvertState; the send fns are recorder lambdas, NOT the live socket),
+// and the #863 queue preserves that order on the wire.
+//
+// Without the two-part drain this test REDS: the old one-message-per-sweep code
+// emits only the have_tx this sweep and defers every losing_tx to a later one,
+// so a busy pool that keeps additions flowing starves losing_tx (GAP 2).
+TEST(TxAdvertiser, SameSweepDrainsHaveThenLosingInOrder)
+{
+    TxAdvertState st;
+
+    // Advertise {1..5} to quiescence.
+    { Wire w0; sweep(st, hashes(1, 5), w0); }
+    ASSERT_EQ(st.m_advertised, hashes(1, 5));
+
+    // ONE sweep that BOTH drops {1,2,3} and adds {6,7,8,9}.
+    Wire w;
+    auto plan = sweep(st, hashes(4, 9), w);
+
+    // Both kinds go out in this single sweep, have STRICTLY before losing.
+    ASSERT_EQ(w.msgs.size(), 2u);
+    EXPECT_EQ(w.msgs[0].kind, Wire::Kind::have);
+    EXPECT_EQ(w.msgs[1].kind, Wire::Kind::losing);
+    EXPECT_EQ(std::set<uint256>(w.msgs[0].hashes.begin(), w.msgs[0].hashes.end()), hashes(6, 9));
+    EXPECT_EQ(std::set<uint256>(w.msgs[1].hashes.begin(), w.msgs[1].hashes.end()), hashes(1, 3));
+
+    // Both parts committed in the SAME sweep — no losing_tx deferral.
+    EXPECT_EQ(plan.m_have, w.msgs[0].hashes);
+    EXPECT_EQ(plan.m_losing, w.msgs[1].hashes);
+    EXPECT_EQ(st.m_advertised, hashes(4, 9));
+
+    // Nothing left to say next sweep.
+    Wire w2;
+    EXPECT_TRUE(sweep(st, hashes(4, 9), w2).empty());
+}
+
 // Fail closed on a zero budget: nothing can be emitted, so nothing may be
 // committed. Committing under a zero budget would mark hashes advertised that
 // never reached the wire -> they would never resurface in a later diff.

--- a/src/core/tx_advertiser.hpp
+++ b/src/core/tx_advertiser.hpp
@@ -39,7 +39,13 @@
 // txs to turn into a burst of outbound adverts.
 //
 // ── Write-safety: ONE MESSAGE PER PEER, AND NEVER TWO IN FLIGHT ─────────────
-// This is a HARD constraint imposed by c2pool's socket layer, not by canonical.
+// SUPERSEDED by #863 (outbound write queue in core::Socket): overlapping
+// composed writes can no longer interleave, so the one-message-per-sweep rule
+// below is NO LONGER a write-safety requirement. run_tx_advert now drains
+// have_tx THEN losing_tx in one sweep over that queue. The text below is kept as
+// the historical rationale for the shape.
+//
+// This WAS a HARD constraint imposed by c2pool's socket layer, not by canonical.
 //
 // core::Socket::write (core/socket.cpp:110-137) starts a composed
 // boost::asio::async_write IMMEDIATELY — there is NO outbound queue. Asio's
@@ -79,8 +85,8 @@
 // the halves BACK-TO-BACK — exactly the overlapping-write pattern our socket
 // layer cannot survive. Spreading across sweeps is the queue-free equivalent.
 //
-// FOLLOW-UP (deliberately NOT done here): the proper fix is an outbound write
-// queue in core::Socket, which would make both guards unnecessary and would also
+// DONE (#863): the proper fix was an outbound write queue in core::Socket, now
+// on master. It makes the one-message-per-sweep guard unnecessary and also
 // cure the PRE-EXISTING violation in the share-broadcast path
 // (dash/node.cpp:1290/1301/1307 issues three back-to-back writes) for every
 // coin. That is a core change needing its own review.
@@ -197,13 +203,14 @@ inline void commit_tx_advert(TxAdvertState& state, const TxAdvertPlan& emitted)
 
 // Drive one advert sweep for one peer.
 //
-// Emits AT MOST ONE message (see the write-safety section in the header
-// comment): the first `max_per_message` outstanding have_tx hashes if there are
-// any, otherwise the first `max_per_message` outstanding losing_tx hashes.
-// Additions therefore always precede retractions across sweeps, preserving
-// canonical's have-before-losing ordering (p2p.py:264-267). Whatever is left
-// over is recomputed from scratch by the next sweep, so nothing is lost and
-// nothing is sent twice.
+// Emits an ordered two-part drain in a SINGLE sweep: up to `max_per_message`
+// outstanding have_tx hashes, THEN up to `max_per_message` outstanding losing_tx
+// hashes -- additions always precede retractions, matching canonical's
+// have-before-losing ordering (p2p.py:261-274). Both messages are submitted to
+// the peer's #863 outbound write queue (core/socket.hpp), which serialises them
+// FIFO so they cannot interleave on the wire. Whatever is left over (either part
+// truncated by `max_per_message`) is recomputed from scratch by the next sweep,
+// so nothing is lost and nothing is sent twice
 //
 // Emits NOTHING if this peer was advertised to less than `min_interval` ago —
 // one message per sweep is not one message in flight, and initiating a second
@@ -217,8 +224,8 @@ inline void commit_tx_advert(TxAdvertState& state, const TxAdvertPlan& emitted)
 // Returns the subset that was ACTUALLY emitted (and committed).
 //
 // send_have / send_losing are invoked as f(const std::vector<uint256>&) at most
-// once each, and at most one of the two per call. They MUST NOT throw; the state
-// is only committed after the sender returns.
+// once each -- and, when both fire in a sweep, send_have STRICTLY before
+// send_losing. They MUST NOT throw; state is committed only after both return.
 template <typename HashSet, typename SendHave, typename SendLosing>
 inline TxAdvertPlan run_tx_advert(
     TxAdvertState& state, const HashSet& current,
@@ -254,6 +261,15 @@ inline TxAdvertPlan run_tx_advert(
         return {};
 
     TxAdvertPlan emitted;
+
+    // Ordered two-part drain (canonical p2p.py:261-274, transitioned): within a
+    // SINGLE sweep, additions are enqueued BEFORE retractions. Both messages are
+    // submitted to the peer's #863 outbound write queue (core/socket.hpp), which
+    // drains FIFO with at most one composed async_write in flight, so back-to-back
+    // have_tx then losing_tx can no longer interleave on the wire -- the hazard
+    // the old one-message-per-sweep rule guarded against before #863 landed. This
+    // is what kills the GAP 2 losing_tx starvation: a busy pool that keeps m_have
+    // non-empty no longer defers a pending losing_tx to a later sweep.
     if (!outstanding.m_have.empty())
     {
         const auto n = static_cast<std::ptrdiff_t>(
@@ -262,7 +278,7 @@ inline TxAdvertPlan run_tx_advert(
                               std::next(outstanding.m_have.begin(), n));
         send_have(emitted.m_have);
     }
-    else if (!outstanding.m_losing.empty())
+    if (!outstanding.m_losing.empty())
     {
         const auto n = static_cast<std::ptrdiff_t>(
             std::min(max_per_message, outstanding.m_losing.size()));
@@ -270,7 +286,7 @@ inline TxAdvertPlan run_tx_advert(
                                 std::next(outstanding.m_losing.begin(), n));
         send_losing(emitted.m_losing);
     }
-    else
+    if (emitted.empty())
     {
         // initial && nothing outstanding: the unconditional p2p.py:276 advert.
         send_have(std::vector<uint256>{});


### PR DESCRIPTION
## GAP 2 — losing_tx starvation: ordered same-sweep two-part drain

**Problem.** `run_tx_advert` (`src/core/tx_advertiser.hpp`) emitted at most one
message per sweep, sending `losing_tx` only once the `have_tx` backlog was empty
(the old `else if`). On a busy pool that keeps `m_have` non-empty, a pending
`losing_tx` is deferred sweep after sweep -> starvation (GAP 2).

**Why the old shape existed, and why it is now void.** One-message-per-sweep was
a pre-#863 write-safety guard: `core::Socket` had no outbound queue, so two
back-to-back composed `async_write`s could interleave on the wire. **#863 landed
the FIFO outbound write queue** (`core/socket.hpp`, `socket.cpp:110-208`,
proven by `socket_write_queue_test.cpp`), which makes the guard unnecessary.

**Change.** `run_tx_advert` now drains `have_tx` **THEN** `losing_tx` in the
same sweep (each capped at `max_per_message`, remainder recomputed next sweep).
Additions still strictly precede retractions (canonical `p2p.py:261-274`,
transitioned). Both messages are submitted to the #863 queue, which serialises
them FIFO, so submission order == wire order.

**Test (fails without the fix).** `SameSweepDrainsHaveThenLosingInOrder` was
committed **red first** (513703a6c: mixed sweep emitted 1 message, expected 2),
then made green by the drain (e930aa6b3). It drives the **real** `run_tx_advert`
+ real `TxAdvertState`; send fns are recorder lambdas (**not** the live
`core::Socket`). The wire-order half is proven separately by
`socket_write_queue_test.cpp` — end-to-end ordering is the composition of the
two. `MixedDeltaSendsHaveBeforeLosing` and `LosingTxIsBudgetedAndDrainsAfterHaveTx`
were updated from the old adds-this-sweep/retractions-next shape.

Folded into the existing allowlisted `core_test` target. **Full `core_test`: 140/140.**

**Scope.** Min-emit-interval guard retained as a cheap per-peer rate cap (no
longer a write-safety requirement). Round-robin fairness intentionally **out of
scope**. Core-only diff; no coin tree touched.
