### PR TITLE
ci(dash-bls): keep the real-BLS binary as an artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1511,3 +1511,12 @@ jobs:
 
   # Releases are built and published manually (not via CI).
   # See installer/ for packaging scripts (DMG, ZIP, Inno Setup).
+      - name: Upload the real-BLS binary
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: c2pool-dash-real-bls-linux-x86_64
+          path: build_dash_bls/src/c2pool/c2pool-dash
+          retention-days: 7
+          if-no-files-found: error
+


### PR DESCRIPTION
## Why

`linux-dash-bls` builds `c2pool-dash` with `C2POOL_DASH_BLS=ON`, runs `dash_bls_linked_guard.sh` against the binary and executes the six BLS KATs — then **throws the binary away**.

That binary is exactly what a daemonless DASH deploy needs. Today it gets rebuilt by hand, and the build host has no conan cache, so "by hand" is not straightforward. Every green run already produces a deployable candidate; we just don't keep it.

## What

One step appended to `linux-dash-bls`:

```yaml
- name: Upload the real-BLS binary
  if: success()
  uses: actions/upload-artifact@v4
  with:
    name: c2pool-dash-real-bls-linux-x86_64
    path: build_dash_bls/src/c2pool/c2pool-dash
    retention-days: 7
    if-no-files-found: error
```

`if-no-files-found: error` is deliberate: a silently-missing binary should fail the job, not publish an empty artifact. Publishing nothing and publishing something are otherwise indistinguishable downstream — the failure mode that cost four days on this same file.

No change to the build, the link guard, or the KATs. Verified the step parses and lands inside `linux-dash-bls` (18 steps, last one is this).