### PR TITLE
web(topology): surface pre-sync state + no-work reason per coin

### DIFF
--- a/test/test_web_honesty_regression.cpp
+++ b/test/test_web_honesty_regression.cpp
@@ -1527,3 +1527,84 @@ TEST(ShareDifficultyTrend, GraphFallsBackToRecordedShareDifficulty) {
            "fall back to the last recorded real share difficulty, not a "
            "difficulty/65536 approximation.";
 }
+
+
+// ===========================================================================
+// PRE-SYNC / NO-WORK-REASON surface (integrator 08-02, PERMANENT lane item).
+//
+// Measured gap: nothing in web_server.cpp / dashboard.html referenced sync
+// state or a no-work reason, so a node healthily SYNCING and a node FAULTED
+// rendered identically -- "nothing happening". The truth existed only in a
+// log line (stratum_server.cpp: "header sync in progress") and in the log-only
+// classify_decline() (dash node_coin_state.hpp). These KATs pin the web-owned
+// contract from both sides: the render must surface header-sync progress + the
+// no-work reason, categorised, and the hook payload must pass those fields
+// through verbatim so each lane can feed classify_decline()/header heights.
+// ===========================================================================
+
+// Side 1 (backend): the per-coin node_topology hook is a verbatim passthrough
+// (rest_node_topology returns the hook JSON as-is). A lane feeding a no-work
+// reason + header-sync heights must have them survive to the API untouched --
+// the contract the front-end reads.
+TEST(WebHonestyRegression, NodeTopologyHookPassesNoWorkReasonAndHeaderSyncVerbatim) {
+    MiningInterface mi(/*testnet=*/true, /*node=*/nullptr, Blockchain::LITECOIN);
+    mi.set_node_topology_fn([] {
+        return json{{"node_symbol", "DASH"}, {"auto_detected", false},
+            {"coins", json::array({
+                json{{"coin", "DASH"}, {"primary", true}, {"peers", 8},
+                     {"synced", false},
+                     {"header_height", 2515029}, {"target_height", 2515025},
+                     {"sync_percent", 100.0},
+                     {"no_work_reason", "superblock-refused"}}})}};
+    });
+    json t = mi.rest_node_topology();
+    ASSERT_TRUE(t.contains("coins") && t["coins"].is_array() && !t["coins"].empty());
+    const auto& c = t["coins"][0];
+    EXPECT_EQ(c.value("no_work_reason", std::string{}), "superblock-refused")
+        << "the lane no-work reason (classify_decline output) must survive the "
+           "topology hook verbatim -- it is the money-relevant field.";
+    EXPECT_EQ(c.value("header_height", 0), 2515029)
+        << "header-sync current height must pass through for the progress line";
+    EXPECT_EQ(c.value("target_height", 0), 2515025)
+        << "header-sync target height must pass through for the progress line";
+}
+
+// Side 2 (frontend, static-HTML): renderNodeTopology must READ the header-sync
+// heights and the no-work reason, and must categorise the reason so a syncing
+// node is legibly different from a faulted or a declining one. Fails-without-fix:
+// if the render drops back to the peers/synced-only shape, a syncing node and a
+// dead node collapse to identical output -- the exact defect this item exists to
+// kill. Folded into this allowlisted target (no new add_executable -> #769 trap).
+TEST(DashboardNoWorkReason, RendersHeaderSyncAndCategorisedReason) {
+    const auto html = read_dashboard();
+    auto start = html.find("function renderNodeTopology(t)");
+    ASSERT_NE(start, std::string::npos) << "renderNodeTopology not found";
+    auto end = html.find("\n        function ", start + 1);
+    ASSERT_NE(end, std::string::npos);
+    const std::string fn = html.substr(start, end - start);
+
+    // Header-sync progress: must read current AND target height.
+    EXPECT_NE(fn.find("c.header_height"), std::string::npos)
+        << "render must read c.header_height for the sync-progress line";
+    EXPECT_NE(fn.find("c.target_height"), std::string::npos)
+        << "render must read c.target_height for the sync-progress line";
+
+    // The no-work reason must be read and surfaced.
+    EXPECT_NE(fn.find("c.no_work_reason"), std::string::npos)
+        << "render must read c.no_work_reason -- without it a node serving no "
+           "work renders blank, indistinguishable from a dead node (the gap "
+           "this permanent item exists to close).";
+
+    // The three states must each be legibly named -- collapsing them was the bug.
+    for (const char* cat : {"syncing", "faulted", "armed, declining"}) {
+        EXPECT_NE(fn.find(cat), std::string::npos)
+            << "render must name the  << cat <<  state; the whole point is "
+               "that syncing / faulted / declining are NOT identical on screen.";
+    }
+
+    // Honest-absent: the reason line is guarded on the field being present, so a
+    // lane that feeds no reason stays silent rather than claiming a false state.
+    EXPECT_NE(fn.find("c.no_work_reason != null"), std::string::npos)
+        << "the no-work line must be gated on the reason being present "
+           "(honest-absent), not rendered unconditionally.";
+}

--- a/web-static/dashboard.html
+++ b/web-static/dashboard.html
@@ -3000,11 +3000,44 @@
                     sync = c.synced
                         ? ' &nbsp;&middot;&nbsp; <span style="color:#3c3;">synced</span>'
                         : ' &nbsp;&middot;&nbsp; <span style="color:#e90;">syncing</span>';
+                // Header-sync progress (integrator 08-02): current/target (percent),
+                // sourced from the lane header chain. Rendered only when the lane feeds
+                // real header heights -- honest-absent otherwise, never a guessed 0.
+                var hsync = '';
+                if (c.header_height != null && c.target_height != null) {
+                    var pct = (c.sync_percent != null)
+                        ? c.sync_percent
+                        : (c.target_height > 0 ? (100 * c.header_height / c.target_height) : 0);
+                    hsync = ' &nbsp;&middot;&nbsp; <span style="opacity:0.8;">hdr ' +
+                            c.header_height + '/' + c.target_height +
+                            ' (' + Number(pct).toFixed(1) + '%)</span>';
+                }
+                // NO-WORK REASON (integrator 08-02, permanent lane item): when no template
+                // is being served the dashboard must say WHICH state it is -- syncing
+                // (self-resolving) / armed-but-declining (viability gate refused, WHY) /
+                // faulted -- instead of rendering blank like a dead node. classify_decline()'s
+                // reason string is surfaced VERBATIM, categorised by the same live signals
+                // (synced flag + peer count). Honest-absent when the lane feeds no reason.
+                var nowork = '';
+                if (c.no_work_reason != null && c.no_work_reason !== '') {
+                    var r = String(c.no_work_reason);
+                    var cat, col;
+                    if (c.synced === false) {
+                        cat = 'syncing'; col = '#e90';         // pre-sync, expected
+                    } else if (peers === 0 || r.indexOf('rpc') !== -1
+                               || r.indexOf('dead') !== -1 || r.indexOf('crash') !== -1) {
+                        cat = 'faulted'; col = '#e33';         // no peers / RPC dead / crashed
+                    } else {
+                        cat = 'armed, declining'; col = '#e90'; // viability gate refused
+                    }
+                    nowork = '<div style="opacity:0.85;font-size:0.9em;color:' + col +
+                             ';">no work: ' + cat + ' &mdash; ' + r + '</div>';
+                }
                 var tip = (c.height != null && c.height > 0)
                     ? ' &nbsp;&middot;&nbsp; tip ' + c.height : '';
                 return '<div><strong>' + c.coin + '</strong>' + tagStr +
                        ' &nbsp;&middot;&nbsp; ' + peers + ' peer' + (peers === 1 ? '' : 's') +
-                       sync + tip + '</div>';
+                       sync + hsync + tip + nowork + '</div>';
             }).join('');
             document.getElementById('node_topology_coins').innerHTML = rows;
             d3.select('#node_topology_symbol').text(t.node_symbol ? '(' + t.node_symbol + ')' : '');


### PR DESCRIPTION
## Coin-generic PRE-SYNC state + NO-WORK reason surface (permanent lane item)

Per the 2026-08-02 lane directive. **Measured gap:** nothing on the dashboard referenced sync state or a no-work reason, so a node healthily **syncing** and a node **faulted** rendered identically as "nothing happening". The truth existed only in the header-sync-in-progress stratum log line and in the log-only `classify_decline()` viability classifier (`dash/coin/node_coin_state.hpp`).

### What this lands (web-owned contract)
`renderNodeTopology()` now surfaces, per coin, when the lane feeds them through the existing `node_topology` hook:
- **header-sync progress** — current/target height (percent); honest-absent when no real header heights are fed (never a guessed 0).
- **NO-WORK reason line** — `classify_decline()`s reason string surfaced **verbatim**, categorised by live signals into `syncing` (self-resolving) / `faulted` (no peers, RPC dead, crashed) / `armed, declining` (viability gate refused, with the reason).

The render + the hook passthrough are defined here. The per-coin **feed** (calling `classify_decline()` + reporting header heights through the topology hook) is cross-steward — DASH is the reference since the classifier lives there; other lanes plug in with no web edit. Coins that feed nothing stay silent (honest-absent).

### KATs (folded into the allowlisted web-honesty target — no new executable, avoids the not-run trap)
- **backend:** the topology hook passes `no_work_reason` + header heights through verbatim.
- **frontend static-HTML:** `renderNodeTopology` reads the heights + reason and names all three states distinctly — **fails-without-fix** (a syncing node and a dead node must not collapse to identical output).

Web/diagnostic layer only, non-consensus → normal merge, surfaced for the merge-tap (web on prod = operator awareness). Designated reviewer before merge; no self-merge.
