### PR TITLE
dash(embedded): MN diff-ladder recovery — daemonless re-seed key for the payee-desync latch

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -216,6 +216,17 @@ const char* const kDashMnCheckpointTestnet =
 uint32_t g_mn_bridge_max_blocks =
     dash::coin::MnCheckpointLane::kDefaultMaxBridgeBlocks;
 
+// --embedded-mn-ladder-reseed: ⚠ DEFAULT OFF. Arms the MN diff-ladder RE-ARM
+// (DASH_MN_DIFF_LADDER_RECOVERY.md). The ladder itself ('D'/'A' keyspaces in
+// dash_sml_db) is written unconditionally — retaining the diffs we already
+// receive, parse and validate costs nothing and cannot change behaviour. What
+// this flag gates is whether a payee desync is allowed to attempt the local
+// root-verified replay instead of latching permanently. It is OFF because the
+// RECOVERY SEMANTICS (not the storage) are still under review; flipping the
+// default is a deliberate one-line change, not a side effect of this slice.
+// Same file-scope rationale as g_mn_bridge_max_blocks above.
+bool g_mn_ladder_reseed = false;
+
 // Report the requested sharechain peering topology at run-loop bring-up. Honest
 // about the deferred live bind: a won/seen share does NOT yet cross the wire
 // until the sharechain pool-node leaf lands.
@@ -256,6 +267,7 @@ void print_banner(const char* argv0)
         << "           [--web-port PORT] [--web-host ADDR] [--dashboard-dir PATH]\n"
         << "           [--external-ip ADDR]\n"
         << "           [--embedded-utxo] [--embedded-mainnet] [--embedded-mn-bridge-max N]\n"
+        << "           [--embedded-mn-ladder-reseed]\n"
         << "           [--embedded-oracle-shadow]\n"
         << "           [--oracle-graduation-blocks N] [--oracle-class-coverage K]\n"
         << "           [--give-author PCT] [-f|--fee PCT] [--node-owner-address ADDR]\n"
@@ -290,6 +302,13 @@ void print_banner(const char* argv0)
         << "        are transport only and NEVER move the arm. Even when armed, every\n"
         << "        per-template gate (SML fresh at tip, non-superblock, credit-pool seed\n"
         << "        height, bestCL, MN-payee cursor, DKG plan) fails closed to dashd.\n"
+        << "        --embedded-mn-ladder-reseed (DEFAULT OFF) lets a masternode\n"
+        << "        payee DESYNC attempt a LOCAL root-verified replay of the retained\n"
+        << "        mnlistdiff ladder instead of latching until an authoritative\n"
+        << "        `protx` re-seed a daemonless node cannot obtain. The ladder is\n"
+        << "        recorded either way; this flag only gates the RE-ARM. Every\n"
+        << "        replay failure (missing anchor, a gap at any height, any root\n"
+        << "        mismatch) leaves the latch SET — i.e. exactly today's behaviour.\n"
         << "        --coin-p2p-magic HEX overrides the embedded coin-P2P wire magic\n"
         << "        (default mainnet bf0c6bbd / testnet cee2caff; regtest fcc1b7dc).\n"
         << "        --regtest-force-won-block (regtest E5 harness, fail-closed) drives\n"
@@ -2691,14 +2710,63 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
 
             // Persist-on-apply: after each accepted mnlistdiff the maintainer
             // fires this with the block the SML/quorum state is now current at.
+            // MN DIFF-LADDER: the accepted diff rides along so write_sml can
+            // append 'D'@h (+ 'A' on an anchor boundary) and prune the window
+            // in the SAME WriteBatch as the 'S'/'B' rewrite — one atomic
+            // commit point, so the ladder can never disagree with the tip state.
             maintainer->set_on_sml_persist(
                 [&node_coin_state, sml_db, quorum_db, hc = header_chain.get()]
-                (const uint256& cur_hash) {
+                (const uint256& cur_hash,
+                 const dash::coin::vendor::CSimplifiedMNListDiff& accepted) {
                     uint32_t h = 0;
                     if (auto e = hc->get_header(cur_hash)) h = e->height;
-                    sml_db->write_sml(node_coin_state.sml(), cur_hash, h);
+                    sml_db->write_sml(node_coin_state.sml(), cur_hash, h,
+                                      &accepted);
                     quorum_db->write_quorums(node_coin_state.qmgr(), cur_hash, h);
                 });
+
+            // ── MN DIFF-LADDER RE-SEED SEAM (default OFF) ────────────────
+            // Wired ALWAYS so the outcome is observable; ARMED only by
+            // --embedded-mn-ladder-reseed. With the flag off the maintainer
+            // never calls it and a payee desync latches exactly as before.
+            maintainer->set_mn_ladder_reseed_fn(
+                [&node_coin_state, sml_db](uint32_t target_h) -> bool {
+                    auto rep = sml_db->replay_from_ladder(target_h);
+                    if (!rep.ok()) {
+                        LOG_WARNING << "[MN-LADDER] REFUSED target h=" << target_h
+                                    << " reason=" << rep.reason()
+                                    << " anchor_h=" << rep.anchor_height
+                                    << " replayed=" << rep.replayed
+                                    << " — latch stays set, cold"
+                                       " mnlistdiff(zero,tip) fallback";
+                        return false;
+                    }
+                    LOG_WARNING << "[MN-LADDER] REPLAY OK target h=" << target_h
+                                << " reason=" << rep.reason()
+                                << " anchor_h=" << rep.anchor_height
+                                << " MNs=" << rep.sml.size()
+                                << " root=" << rep.root.GetHex().substr(0, 16);
+                    // Install the REBUILT (not merely retained) SML: the state
+                    // we re-arm on is the one we just recomputed and
+                    // root-verified at every replayed height.
+                    node_coin_state.sml() = std::move(rep.sml);
+                    node_coin_state.set_have_sml(
+                        node_coin_state.sml().size() != 0);
+                    node_coin_state.set_sml_current_hash(rep.block_hash);
+                    return true;
+                });
+            maintainer->set_mn_ladder_reseed_enabled(g_mn_ladder_reseed);
+
+            // Ladder depth banner (startup): one line a human can read to see
+            // how far back a local re-seed could reach, and with which
+            // PENDING-REVIEW sizing constants.
+            {
+                const auto ls = sml_db->ladder_stats();
+                LOG_INFO << "[MN-LADDER] depth: " << ls.banner()
+                         << " reseed=" << (g_mn_ladder_reseed
+                                               ? "ARMED (--embedded-mn-ladder-reseed)"
+                                               : "OFF (default)");
+            }
             // E2 credit-pool persist: written per accepted mnlistdiff with the SAME
             // (blockHash, height) the SML persist uses, so the CreditPoolDb tip
             // tracks the SML tip and the restart sentinel (cp_hash == sml_hash)
@@ -4297,6 +4365,11 @@ int main(int argc, char** argv)
                  && i + 1 < argc)
             g_mn_bridge_max_blocks = static_cast<uint32_t>(
                 std::strtoul(argv[++i], nullptr, 10));
+        // MN diff-ladder RE-ARM opt-in (⚠ DEFAULT OFF). Without it a payee
+        // desync latches exactly as it does today; the ladder is still written
+        // and its depth still reported.
+        else if (std::strcmp(argv[i], "--embedded-mn-ladder-reseed") == 0)
+            g_mn_ladder_reseed = true;
         else if ((std::strcmp(argv[i], "--give-author") == 0 ||
                   std::strcmp(argv[i], "--dev-donation") == 0) && i + 1 < argc)
             dev_donation = std::strtod(argv[++i], nullptr);

--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -329,8 +329,10 @@ public:
         m_mn_snapshot_height = as_of_height;
         // An authoritative (non-empty) resync clears the payee-desync latch:
         // the queue is trustworthy again from this snapshot forward.
-        if (m_have_mn)
+        if (m_have_mn) {
             m_mn_needs_reseed = false;
+            m_state.set_mn_needs_reseed(false);
+        }
         // as_of_height also seeds the machine's forward-contiguous apply
         // cursor (E4 re-soak fix): the snapshot IS the payment queue as of
         // that block, so only as_of+1 may fold next; a later block reports
@@ -572,7 +574,7 @@ public:
         // persistable tip). main_dash points this at SMLDb::write_sml +
         // QuorumDb::write_quorums; unset (KAT posture) makes it a no-op.
         if (m_have_mn_sml && m_on_sml_persist)
-            m_on_sml_persist(diff.blockHash);
+            m_on_sml_persist(diff.blockHash, diff);
         // E2: persist the credit-pool tip alongside the SML tip (same blockHash +
         // height), so the CreditPoolDb sentinel (cp_hash == sml_hash) holds and a
         // warm restart restores the pool to exactly the SML's resume point. Only
@@ -777,8 +779,16 @@ public:
             // block would register into the wiped set and republish a 1-MN
             // "queue" — a guessed payee by another name.
             m_mn_needs_reseed = true;
+            m_state.set_mn_needs_reseed(true);   // make the state SAY ITS NAME
             demote();
             notify_state_dirty();
+            // MN DIFF-LADDER (DASH_MN_DIFF_LADDER_RECOVERY.md): before falling
+            // back to the authoritative-re-seed sink — which on a DAEMONLESS
+            // node does not exist, making this latch permanent — try the LOCAL
+            // root-verified replay of the retained anchor + diffs. DEFAULT OFF;
+            // every failure path (and the disabled path) leaves the latch SET,
+            // i.e. exactly today's behaviour.
+            try_mn_ladder_reseed(height);
             if (m_on_mn_reseed) m_on_mn_reseed();
             return r;
         }
@@ -867,9 +877,39 @@ public:
     /// state is now current at, so a restart resumes incrementally from that
     /// tip. Optional (unset in KATs = no-op; persistence is a restart
     /// optimisation, never a correctness prerequisite for the running arm).
-    void set_on_sml_persist(std::function<void(const uint256&)> fn) {
+    void set_on_sml_persist(
+        std::function<void(const uint256&,
+                           const vendor::CSimplifiedMNListDiff&)> fn) {
         m_on_sml_persist = std::move(fn);
     }
+
+    /// Wire the MN DIFF-LADDER re-seed seam (main_dash points this at
+    /// SMLDb::replay_from_ladder + install-rebuilt-SML). Called with the height
+    /// the payee desync fired at; returns true iff a root-verified local replay
+    /// rebuilt the SML from the retained anchor + diffs. Optional (unset = the
+    /// ladder path is simply unavailable and the latch behaves as today).
+    void set_mn_ladder_reseed_fn(std::function<bool(uint32_t)> fn) {
+        m_mn_ladder_reseed_fn = std::move(fn);
+    }
+
+    /// ⚠ THE RE-ARM GATE — DEFAULT OFF (`--embedded-mn-ladder-reseed`).
+    ///
+    /// OFF (default): the ladder is written on every accepted diff and the
+    /// replay is exercised by the KATs, but a payee desync latches EXACTLY as
+    /// it does on master. Nothing about the served template changes.
+    ///
+    /// ON: a desync first attempts the local root-verified replay. On success
+    /// the payee latch is cleared. Note what that does and does NOT do: the
+    /// P2P Simplified MN List omits scriptPayout and nLastPaidHeight (see
+    /// mn_checkpoint.hpp's trust-anchor preamble), so a ladder replay CANNOT
+    /// reconstruct the payout-bearing queue. Clearing the latch is therefore
+    /// NECESSARY-BUT-NOT-SUFFICIENT: m_have_mn additionally requires a
+    /// non-empty payee set AND a height-stamped snapshot, both zeroed by the
+    /// desync wipe. There is no new way to serve a template.
+    void set_mn_ladder_reseed_enabled(bool on) {
+        m_mn_ladder_reseed_enabled = on;
+    }
+    bool mn_ladder_reseed_enabled() const { return m_mn_ladder_reseed_enabled; }
 
     /// Wire the SML/quorum store WIPE sink (main_dash points this at
     /// SMLDb::clear + QuorumDb::clear). Invoked on the reorg / H-1 heal path
@@ -906,6 +946,53 @@ public:
 private:
     void notify_state_dirty() {
         if (m_on_state_dirty) m_on_state_dirty();
+    }
+
+    // MN DIFF-LADDER re-seed attempt. Returns true iff the payee latch was
+    // cleared. EVERY early return leaves the latch SET (today's behaviour) and
+    // NAMES ITS REASON in the log — a gate that can silently refuse is the
+    // defect, not the refusal.
+    bool try_mn_ladder_reseed(uint32_t target_h) {
+        if (!m_mn_ladder_reseed_enabled) {
+            LOG_WARNING << "[MN-LADDER] re-seed DISABLED at h=" << target_h
+                        << " (reason=flag-off; enable with"
+                           " --embedded-mn-ladder-reseed) — latch STAYS SET;"
+                           " recovery still requires an authoritative re-seed"
+                           " (protx list / checkpoint bridge)";
+            return false;
+        }
+        if (!m_mn_ladder_reseed_fn) {
+            LOG_WARNING << "[MN-LADDER] re-seed UNAVAILABLE at h=" << target_h
+                        << " (reason=no-ladder-source-wired) — latch STAYS SET";
+            return false;
+        }
+        // ANTI-MINT interlock (E2d, #738). Clearing the payee latch is only
+        // safe while the seeded-MN requirement is ACTIVE: that requirement is
+        // what still makes it impossible for block-connect alone to arm
+        // MN-readiness off an incidental ProRegTx. Without it, clearing the
+        // latch would reopen exactly the hole the latch was added to close.
+        if (!m_require_seeded_mn) {
+            LOG_WARNING << "[MN-LADDER] re-seed REFUSED at h=" << target_h
+                        << " (reason=anti-mint-interlock: require_seeded_mn is"
+                           " OFF) — latch STAYS SET";
+            return false;
+        }
+        if (!m_mn_ladder_reseed_fn(target_h)) {
+            // The source logs the specific outcome (anchor-missing /
+            // anchor-root-mismatch / diff-gap-at-h / diff-root-mismatch-at-h).
+            LOG_WARNING << "[MN-LADDER] replay FAILED at target h=" << target_h
+                        << " — latch STAYS SET, cold mnlistdiff(zero,tip)"
+                           " fallback (see the [MN-LADDER] outcome line above)";
+            return false;
+        }
+        m_mn_needs_reseed = false;
+        m_state.set_mn_needs_reseed(false);
+        LOG_WARNING << "[MN-LADDER] payee latch CLEARED by verified local"
+                       " replay at h=" << target_h
+                    << " — NOTE: the SML carries no scriptPayout /"
+                       " nLastPaidHeight, so MN-readiness still needs a"
+                       " payout-bearing snapshot before any template is served";
+        return true;
     }
 
     // Block identity hash (Dash: X11 of the 80-byte header). Marks the credit-pool
@@ -1110,7 +1197,15 @@ private:
     std::function<void()> m_on_state_dirty;  // SML/bestCL/reorg -> re-issue work
     std::function<void()> m_on_mn_reseed;    // payee desync -> authoritative protx re-seed
     std::function<void()> m_on_full_resync;  // H-1 heal -> reset sml_base + full re-sync
-    std::function<void(const uint256&)> m_on_sml_persist;  // accepted diff -> SMLDb/QuorumDb write
+    std::function<void(const uint256&,
+                       const vendor::CSimplifiedMNListDiff&)> m_on_sml_persist;  // accepted diff -> SMLDb/QuorumDb write (+ MN diff-ladder append)
+    // MN DIFF-LADDER re-seed seam (DASH_MN_DIFF_LADDER_RECOVERY.md). Takes the
+    // desync height, returns true iff a verified local replay rebuilt the SML.
+    // main_dash points it at SMLDb::replay_from_ladder; unset = no-op.
+    std::function<bool(uint32_t)> m_mn_ladder_reseed_fn;
+    // ⚠ DEFAULT OFF (--embedded-mn-ladder-reseed). With this false the ladder is
+    // still WRITTEN, but a payee desync latches EXACTLY as it does today.
+    bool m_mn_ladder_reseed_enabled{false};
     std::function<void()> m_on_sml_clear;    // reorg/heal -> SMLDb/QuorumDb wipe (extended to CreditPoolDb)
     // E2: independent DIP-0027 credit-pool accrual, advanced per ingested block
     // (on_block_connected) and re-anchored per accepted mnlistdiff. Verified

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -313,6 +313,13 @@ public:
     void set_quorum_healthy(bool v) { m_quorum_healthy = v; }
     bool quorum_healthy() const { return m_quorum_healthy; }
 
+    /// DIAGNOSTIC MIRROR of the maintainer's payee-desync latch, so
+    /// classify_decline() can report "mn-needs-reseed" instead of the far less
+    /// useful "not-populated". Purely observational: nothing on the serve or
+    /// reward path reads it.
+    void set_mn_needs_reseed(bool v) { m_mn_needs_reseed = v; }
+    bool mn_needs_reseed() const { return m_mn_needs_reseed; }
+
     /// BLOCKER-3 pre-emit HARD GATE. Before the embedded arm's template is
     /// served/mined, re-validate the BUILT CbTx against consensus invariants;
     /// any failure => the caller must fall back to the reward-safe dashd path.
@@ -547,6 +554,14 @@ public:
     /// gate-off node is how the absent mainnet opt-in manifests here.
     std::string classify_decline() const {
         const uint32_t next_h = m_prev_height + 1;
+        // MN PAYEE-DESYNC LATCH — checked FIRST because it is a strictly more
+        // informative cause of the not-populated state that follows it. Before
+        // this line the latch was log-only: the smoke rig reported 639
+        // consecutive "not-populated" declines while the actual cause (a payee
+        // desync at h=2514874 that can only be cleared by an authoritative
+        // re-seed a daemonless node cannot obtain) appeared nowhere a human
+        // reading the decline classification would look.
+        if (m_mn_needs_reseed) return "mn-needs-reseed";
         if (!m_populated)      return "not-populated";
         if (m_prev_hash.IsNull()) return "no-tip";
         if (m_qc_plan_fn && !m_qc_plan_fn(next_h)) return "qc-plan-underivable";
@@ -673,6 +688,10 @@ private:
     uint256  m_credit_pool_current_hash;     // block hash the credit-pool seed is current at
     int32_t  m_credit_pool_height{-1};       // seed cbTx's OWN height (-1 = never seeded)
     bool     m_quorum_healthy{true};         // last diff's quorum tail parsed OK
+    // Mirror of CoinStateMaintainer's payee-desync latch, published here purely
+    // so classify_decline() can NAME it. Never consulted by any serve/reward
+    // path — the latch itself lives (and gates) in the maintainer.
+    bool     m_mn_needs_reseed{false};
     uint32_t m_prev_height{0};
     uint256  m_prev_hash;
     uint32_t m_bits_for_next{0};

--- a/src/impl/dash/coin/sml_quorum_db.hpp
+++ b/src/impl/dash/coin/sml_quorum_db.hpp
@@ -32,11 +32,33 @@
 /// these stores (see CoinStateMaintainer::set_on_sml_clear) — an orphaned-branch
 /// state is self-consistent and would pass the root-verify.
 ///
+/// MN DIFF-LADDER (2026-08-02, DASH_MN_DIFF_LADDER_RECOVERY.md): the store
+/// additionally RETAINS the accepted mnlistdiffs and periodic full anchors so a
+/// desynced arm has a LOCAL re-seed key instead of an authoritative `protx` RPC
+/// it does not have on a daemonless node. Purely ADDITIVE keyspaces: the 'S' /
+/// 'B' live-tip state and its full-rewrite path are untouched, so the change
+/// cannot regress the warm-restart path, and every ladder failure path lands on
+/// exactly today's behaviour (cold mnlistdiff(zero,tip)).
+///
+/// NOT A NEW TRUST ROOT. Each retained diff's resulting merkleRootMNList was
+/// itself supplied by the peer that sent the diff; a consistently-lying peer
+/// produces a self-consistent chain of roots that passes every check here. We
+/// hold headers, not blocks, so cbTx (dashd's independent root source) is not
+/// available. This is the SAME trust exposure the arm already carries live —
+/// the ladder does not worsen it — but the ladder must NOT be described as
+/// consensus-anchored. (Design doc gate G1.)
+///
 /// Schemas
 ///   SMLDb  ('sml_db/'):
 ///     'S' + proRegTxHash(32B)       -> pack(CSimplifiedMNListEntry)
 ///     'B'                            -> best_hash(32B) height(4B LE)
 ///                                        expected_merkleRootMNList(32B)
+///     'D' + height(4B BE)            -> pack(CSimplifiedMNListDiff)
+///                                        resulting_merkleRootMNList(32B)
+///     'A' + height(4B BE)            -> pack(vector<CSimplifiedMNListEntry>)
+///                                        merkleRootMNList(32B) block_hash(32B)
+///   Heights are BIG-endian so LevelDB's byte-lexicographic key order IS
+///   height order (list_keys / the replay scan rely on it).
 ///   QuorumDb ('quorum_db/'):
 ///     'Q' + seq(4B BE)               -> pack(CFinalCommitment) mining_height(4B LE)
 ///     'L' + seq(4B BE)               -> sig(96B) count(4B LE) count*index(2B LE)
@@ -44,6 +66,7 @@
 ///                                        expected_merkleRootQuorums(32B)
 
 #include <impl/dash/coin/vendor/simplifiedmns.hpp>  // vendor::CSimplifiedMNList(Entry)
+#include <impl/dash/coin/vendor/smldiff.hpp>        // vendor::CSimplifiedMNListDiff / apply_diff
 #include <impl/dash/coin/quorum_manager.hpp>        // QuorumManager
 #include <impl/dash/coin/quorum_root.hpp>           // compute_merkle_root_quorums
 
@@ -101,6 +124,97 @@ inline std::vector<uint8_t> pack_bytes(const T& obj)
 
 } // namespace sml_db_detail
 
+// ─────────────────────────────────────────────────────────────────────────
+// MN DIFF-LADDER SIZING — ⚠ PENDING REVIEW SIZING. THESE ARE PLACEHOLDERS.
+// ─────────────────────────────────────────────────────────────────────────
+// The design doc (gate G2) leaves both numbers explicitly UNSET: a recommended
+// anchor interval and retention window are being computed by the in-flight
+// review harness. The values below are STARTING PLACEHOLDERS chosen to be
+// obviously-safe rather than tuned, and MUST be revisited before the ladder
+// re-seed default is flipped on:
+//
+//   * MN_LADDER_ANCHOR_INTERVAL mirrors dashd's MINI_SNAPSHOT_INTERVAL (32,
+//     evo/deterministicmns.h) purely because that is the one published number
+//     in the neighbourhood — it is NOT evidence that 32 is right for us.
+//   * MN_LADDER_RETENTION_HEIGHTS (4096 ≈ 7 days at Dash's 2.5 min spacing)
+//     bounds the store. The only real-world data point is the contabo smoke
+//     rig's two desync events 155 heights apart — a data point of exactly one.
+inline constexpr uint32_t MN_LADDER_ANCHOR_INTERVAL   = 32;    // PLACEHOLDER
+inline constexpr uint32_t MN_LADDER_RETENTION_HEIGHTS = 4096;  // PLACEHOLDER
+
+/// Why a ladder replay ended. Every non-Ok value must land the caller on
+/// TODAY'S behaviour (latch stays set, cold mnlistdiff(zero,tip) re-sync).
+enum class LadderOutcome {
+    Ok,                  ///< replayed anchor..target, every root recomputed+matched
+    StoreClosed,         ///< db not open — nothing to replay
+    AnchorMissing,       ///< no 'A' anchor at height <= target
+    AnchorDecodeFailed,  ///< 'A' value unreadable / entry deserialize threw
+    AnchorRootMismatch,  ///< recomputed anchor merkleRootMNList != stored root
+    DiffGap,             ///< a height in (anchor, target] has NO 'D' record
+    DiffDecodeFailed,    ///< 'D' value unreadable / diff deserialize threw
+    DiffBaseMismatch,    ///< 'D'@h base does not chain onto the previous block
+    DiffRootMismatch,    ///< recomputed root after applying 'D'@h != stored root
+};
+
+/// Result of SMLDb::replay_from_ladder(). `reason` is the human-facing string
+/// the observability law requires: a gate that can silently refuse must say
+/// WHY, in a place a human looks.
+struct LadderReplay {
+    LadderOutcome outcome{LadderOutcome::AnchorMissing};
+    uint32_t      target_height{0};
+    uint32_t      anchor_height{0};
+    uint32_t      failed_height{0};   ///< the height that aborted (0 = n/a)
+    uint32_t      replayed{0};        ///< diffs successfully applied
+    uint256       block_hash;         ///< block the rebuilt SML is current at
+    uint256       root;               ///< recomputed merkleRootMNList
+    vendor::CSimplifiedMNList sml;    ///< rebuilt state (only meaningful on Ok)
+
+    bool ok() const { return outcome == LadderOutcome::Ok; }
+
+    std::string reason() const
+    {
+        switch (outcome) {
+        case LadderOutcome::Ok:
+            return "ok-replayed-" + std::to_string(replayed) + "-diffs";
+        case LadderOutcome::StoreClosed:      return "store-closed";
+        case LadderOutcome::AnchorMissing:    return "anchor-missing";
+        case LadderOutcome::AnchorDecodeFailed:
+            return "anchor-decode-failed-at-h=" + std::to_string(anchor_height);
+        case LadderOutcome::AnchorRootMismatch:
+            return "anchor-root-mismatch-at-h=" + std::to_string(anchor_height);
+        case LadderOutcome::DiffGap:
+            return "diff-gap-at-h=" + std::to_string(failed_height);
+        case LadderOutcome::DiffDecodeFailed:
+            return "diff-decode-failed-at-h=" + std::to_string(failed_height);
+        case LadderOutcome::DiffBaseMismatch:
+            return "diff-base-mismatch-at-h=" + std::to_string(failed_height);
+        case LadderOutcome::DiffRootMismatch:
+            return "diff-root-mismatch-at-h=" + std::to_string(failed_height);
+        }
+        return "unknown";
+    }
+};
+
+/// One-line ladder depth report (the startup / state banner).
+struct LadderStats {
+    uint32_t anchors{0};        ///< number of retained 'A' records
+    uint32_t diffs{0};          ///< number of retained 'D' records
+    uint32_t lowest_diff{0};    ///< lowest retained diff height (0 = none)
+    uint32_t highest_diff{0};   ///< highest retained diff height (0 = none)
+    uint32_t highest_anchor{0}; ///< highest retained anchor height (0 = none)
+
+    std::string banner() const
+    {
+        return "anchors=" + std::to_string(anchors)
+             + " diffs=" + std::to_string(diffs)
+             + " heights=[" + std::to_string(lowest_diff) + ".."
+             + std::to_string(highest_diff) + "]"
+             + " top_anchor=" + std::to_string(highest_anchor)
+             + " interval=" + std::to_string(MN_LADDER_ANCHOR_INTERVAL)
+             + " window=" + std::to_string(MN_LADDER_RETENTION_HEIGHTS);
+    }
+};
+
 // ── SMLDb: persist the CSimplifiedMNList (merkleRootMNList source) ─────────
 class SMLDb
 {
@@ -128,8 +242,17 @@ public:
     // Atomic full-rewrite of the SML entry set + BEST sentinel. The sentinel
     // carries the merkleRootMNList computed HERE (the independent verify anchor
     // load_verified re-derives and compares against).
+    //
+    // MN DIFF-LADDER (additive): when `accepted` is non-null and best_height is
+    // known, the SAME WriteBatch also appends 'D'@best_height (the diff that
+    // produced this state + the root it results in), writes 'A'@best_height on
+    // an anchor boundary, and prunes both keyspaces below the retention window.
+    // ONE batch, still atomic, NO new commit point — the ladder can never be
+    // half-written relative to the 'S'/'B' state it describes. Passing nullptr
+    // (every pre-existing call site) writes exactly the old bytes.
     bool write_sml(const vendor::CSimplifiedMNList& sml,
-                   const uint256& best_hash, uint32_t best_height)
+                   const uint256& best_hash, uint32_t best_height,
+                   const vendor::CSimplifiedMNListDiff* accepted = nullptr)
     {
         const uint256 expected_root = sml.CalcMerkleRoot();
 
@@ -142,6 +265,24 @@ public:
         batch.put(make_state_key(),
                   encode_best_state(best_hash, best_height, expected_root));
 
+        // ── ladder append + prune, IN THIS BATCH ──────────────────────────
+        // best_height == 0 means the caller could not resolve the height (the
+        // header is not in the chain yet). A ladder rung with no height cannot
+        // be replayed and cannot be gap-checked, so it is simply not written —
+        // the replay's density check will then abort at that height, which is
+        // the fail-toward-today behaviour we want.
+        bool ladder_wrote_anchor = false;
+        if (accepted != nullptr && best_height != 0) {
+            batch.put(sml_db_detail::make_seq_key('D', best_height),
+                      encode_ladder_diff(*accepted, expected_root));
+            if (best_height % MN_LADDER_ANCHOR_INTERVAL == 0) {
+                batch.put(sml_db_detail::make_seq_key('A', best_height),
+                          encode_ladder_anchor(sml, expected_root, best_hash));
+                ladder_wrote_anchor = true;
+            }
+            prune_ladder_into(batch, best_height);
+        }
+
         if (!batch.commit()) {
             LOG_WARNING << "[SML-DB] write_sml batch commit failed";
             return false;
@@ -149,6 +290,173 @@ public:
         m_best_hash     = best_hash;
         m_best_height   = best_height;
         m_expected_root = expected_root;
+        if (accepted != nullptr && best_height != 0 && ladder_wrote_anchor)
+            LOG_INFO << "[MN-LADDER] anchor written @h=" << best_height
+                     << " (" << sml.size() << " MNs, root "
+                     << expected_root.GetHex().substr(0, 16) << ")";
+        return true;
+    }
+
+    // ── MN DIFF-LADDER RECOVERY ───────────────────────────────────────────
+    // Rebuild the SML at `target_h` from the retained anchor + diffs, with the
+    // SAME fail-closed discipline load_verified() uses at EVERY step: the root
+    // is RECOMPUTED from the reconstructed state and compared against the root
+    // stored alongside the record. Never partial, never "best effort":
+    //
+    //   1. greatest 'A' anchor at height <= target_h; none  -> AnchorMissing
+    //   2. load it, RECOMPUTE the root, mismatch            -> AnchorRootMismatch
+    //   3. for h in anchor_h+1 .. target_h:
+    //        'D'@h MUST EXIST — a MISSING height ABORTS     -> DiffGap
+    //        its baseBlockHash must chain onto the previous -> DiffBaseMismatch
+    //        apply, RECOMPUTE the root, compare to stored   -> DiffRootMismatch
+    //   4. success -> the rebuilt state is RETURNED; the CALLER decides what to
+    //      re-arm. This function never mutates live state and never clears a
+    //      latch by itself.
+    //
+    // DENSITY IS REQUIRED, NOT ASSUMED (design doc gate G1). A diff that
+    // legitimately spans several heights (base h, to h+3) leaves h+1/h+2
+    // without a 'D' record and is therefore REFUSED even though base-hash
+    // continuity would prove it correct. That over-refusal is deliberate: it
+    // fails toward today's behaviour, and distinguishing "we never saw those
+    // heights" from "one diff covered them" is exactly the semantics question
+    // the in-flight reviews must settle before the re-seed default is flipped.
+    LadderReplay replay_from_ladder(uint32_t target_h)
+    {
+        LadderReplay r;
+        r.target_height = target_h;
+        if (!m_store.is_open()) {
+            r.outcome = LadderOutcome::StoreClosed;
+            return r;
+        }
+
+        // 1) greatest anchor at height <= target_h (keys are BE => ascending).
+        uint32_t anchor_h = 0;
+        bool     found    = false;
+        for (const auto& key : m_store.list_keys(std::string(1, 'A'), 500000)) {
+            uint32_t h = 0;
+            if (!parse_seq_key(key, 'A', h)) continue;
+            if (h > target_h) break;
+            anchor_h = h;
+            found    = true;
+        }
+        if (!found) {
+            r.outcome = LadderOutcome::AnchorMissing;
+            return r;
+        }
+        r.anchor_height = anchor_h;
+
+        // 2) load + INDEPENDENTLY recompute the anchor's root.
+        std::vector<uint8_t> abuf;
+        if (!m_store.get(sml_db_detail::make_seq_key('A', anchor_h), abuf)
+            || abuf.size() < 64) {
+            r.outcome = LadderOutcome::AnchorDecodeFailed;
+            return r;
+        }
+        uint256 stored_root, stored_hash;
+        std::memcpy(stored_root.data(), abuf.data() + abuf.size() - 64, 32);
+        std::memcpy(stored_hash.data(), abuf.data() + abuf.size() - 32, 32);
+        std::vector<vendor::CSimplifiedMNListEntry> entries;
+        try {
+            std::vector<uint8_t> body(abuf.begin(), abuf.end() - 64);
+            ::PackStream ps(body);
+            ps >> entries;
+        } catch (const std::exception&) {
+            r.outcome = LadderOutcome::AnchorDecodeFailed;
+            return r;
+        }
+        vendor::CSimplifiedMNList state(std::move(entries));   // ctor re-sorts
+        if (state.CalcMerkleRoot() != stored_root) {
+            r.outcome = LadderOutcome::AnchorRootMismatch;
+            return r;
+        }
+        uint256 cur_hash = stored_hash;
+
+        // 3) dense forward replay, root-verified at every single height.
+        for (uint32_t h = anchor_h + 1; h <= target_h; ++h) {
+            std::vector<uint8_t> dbuf;
+            if (!m_store.get(sml_db_detail::make_seq_key('D', h), dbuf)) {
+                r.failed_height = h;
+                r.outcome = LadderOutcome::DiffGap;
+                return r;
+            }
+            if (dbuf.size() < 32) {
+                r.failed_height = h;
+                r.outcome = LadderOutcome::DiffDecodeFailed;
+                return r;
+            }
+            uint256 want_root;
+            std::memcpy(want_root.data(), dbuf.data() + dbuf.size() - 32, 32);
+            vendor::CSimplifiedMNListDiff diff;
+            try {
+                std::vector<uint8_t> body(dbuf.begin(), dbuf.end() - 32);
+                ::PackStream ps(body);
+                ps >> diff;
+            } catch (const std::exception&) {
+                r.failed_height = h;
+                r.outcome = LadderOutcome::DiffDecodeFailed;
+                return r;
+            }
+            // Base-continuity: the SAME guard on_mnlistdiff applies live. A
+            // ZERO base is a full snapshot and always chains (it replaces).
+            if (!diff.baseBlockHash.IsNull() && diff.baseBlockHash != cur_hash) {
+                r.failed_height = h;
+                r.outcome = LadderOutcome::DiffBaseMismatch;
+                return r;
+            }
+            if (diff.baseBlockHash.IsNull()) state.mnList.clear();
+            vendor::apply_diff(state, diff);
+            if (state.CalcMerkleRoot() != want_root) {
+                r.failed_height = h;
+                r.outcome = LadderOutcome::DiffRootMismatch;
+                return r;
+            }
+            cur_hash = diff.blockHash;
+            ++r.replayed;
+        }
+
+        r.outcome    = LadderOutcome::Ok;
+        r.block_hash = cur_hash;
+        r.root       = state.CalcMerkleRoot();
+        r.sml        = std::move(state);
+        return r;
+    }
+
+    /// Ladder depth, for the startup / state banner.
+    LadderStats ladder_stats()
+    {
+        LadderStats s;
+        if (!m_store.is_open()) return s;
+        for (const auto& key : m_store.list_keys(std::string(1, 'A'), 500000)) {
+            uint32_t h = 0;
+            if (!parse_seq_key(key, 'A', h)) continue;
+            ++s.anchors;
+            s.highest_anchor = h;
+        }
+        for (const auto& key : m_store.list_keys(std::string(1, 'D'), 500000)) {
+            uint32_t h = 0;
+            if (!parse_seq_key(key, 'D', h)) continue;
+            if (s.diffs == 0) s.lowest_diff = h;
+            ++s.diffs;
+            s.highest_diff = h;
+        }
+        return s;
+    }
+
+    /// Drop the ladder only (leaves the 'S'/'B' live-tip state alone).
+    /// Design-doc gate G3: the reorg/heal wipe MUST take the ladder with it —
+    /// an orphaned-branch ladder is self-consistent and would replay clean.
+    bool clear_ladder()
+    {
+        auto batch = m_store.create_batch();
+        size_t n = 0;
+        for (const auto& k : m_store.list_keys(std::string(1, 'D'), 500000)) {
+            batch.remove(k); ++n;
+        }
+        for (const auto& k : m_store.list_keys(std::string(1, 'A'), 500000)) {
+            batch.remove(k); ++n;
+        }
+        if (!batch.commit()) return false;
+        if (n) LOG_INFO << "[MN-LADDER] cleared " << n << " ladder records";
         return true;
     }
 
@@ -190,17 +498,29 @@ public:
         return true;
     }
 
+    // G3 DECISION (design doc, "does the ladder survive the fail-closed wipe?"):
+    // clear() takes the LADDER WITH IT. The reorg / H-1 heal case is
+    // unambiguous — an orphaned-branch ladder is self-consistent and would
+    // replay clean into a wrong-branch state. The corrupt-load case is the one
+    // the doc leaves OPEN; we take the conservative side (wipe) so that a store
+    // we have just proven untrustworthy cannot supply the re-seed key. That
+    // choice costs recovery in exactly the corrupt case and is a candidate for
+    // the in-flight reviews to revisit; it is deliberately NOT a silent default.
     bool clear()
     {
         auto batch = m_store.create_batch();
         for (const auto& k : m_store.list_keys(std::string(1, 'S'), 500000))
+            batch.remove(k);
+        for (const auto& k : m_store.list_keys(std::string(1, 'D'), 500000))
+            batch.remove(k);
+        for (const auto& k : m_store.list_keys(std::string(1, 'A'), 500000))
             batch.remove(k);
         batch.remove(make_state_key());
         if (!batch.commit()) return false;
         m_best_hash     = uint256{};
         m_best_height   = 0;
         m_expected_root = uint256{};
-        LOG_INFO << "[SML-DB] cleared";
+        LOG_INFO << "[SML-DB] cleared (incl. MN diff-ladder)";
         return true;
     }
 
@@ -209,6 +529,72 @@ private:
     uint256              m_best_hash;
     uint256              m_expected_root;
     uint32_t             m_best_height{0};
+
+    // 'D' value = pack(diff) ++ resulting_merkleRootMNList(32B). The root is a
+    // FIXED-WIDTH SUFFIX because CSimplifiedMNListDiff's unserializer drains
+    // the remaining stream bytes as its opaque quorum tail — the replay hands
+    // it a body slice that stops 32 bytes short, never the whole value.
+    static std::vector<uint8_t> encode_ladder_diff(
+        const vendor::CSimplifiedMNListDiff& diff, const uint256& root)
+    {
+        auto out = sml_db_detail::pack_bytes(diff);
+        out.insert(out.end(), root.data(), root.data() + 32);
+        return out;
+    }
+
+    // 'A' value = pack(vector<entry>) ++ root(32B) ++ block_hash(32B). The
+    // block hash is what lets the replay bind the FIRST diff's baseBlockHash to
+    // the anchor instead of trusting the diff chain to start in the right place.
+    static std::vector<uint8_t> encode_ladder_anchor(
+        const vendor::CSimplifiedMNList& sml, const uint256& root,
+        const uint256& block_hash)
+    {
+        auto stream = ::pack(sml.mnList);
+        auto sp = stream.get_span();
+        std::vector<uint8_t> out(
+            reinterpret_cast<const uint8_t*>(sp.data()),
+            reinterpret_cast<const uint8_t*>(sp.data()) + sp.size());
+        out.insert(out.end(), root.data(), root.data() + 32);
+        out.insert(out.end(), block_hash.data(), block_hash.data() + 32);
+        return out;
+    }
+
+    static bool parse_seq_key(const std::string& key, char tag, uint32_t& out_h)
+    {
+        if (key.size() != 5 || key[0] != tag) return false;
+        out_h = (uint32_t(uint8_t(key[1])) << 24)
+              | (uint32_t(uint8_t(key[2])) << 16)
+              | (uint32_t(uint8_t(key[3])) <<  8)
+              |  uint32_t(uint8_t(key[4]));
+        return true;
+    }
+
+    // Retention (design doc gate G2): drop 'D'/'A' below the window floor in
+    // the SAME batch as the append, so the store cannot grow without limit and
+    // the prune can never be observed apart from the write it rides with.
+    // Bounded scan: the walk starts at the LOWEST retained height (BE keys are
+    // ascending) and stops at the window floor, so in steady state — where at
+    // most one record leaves the window per write — a handful of keys are
+    // examined. The cap keeps a per-diff write O(1)-ish instead of O(window);
+    // a larger backlog (e.g. after the retention constant is lowered) simply
+    // drains over the following writes rather than stalling one of them.
+    static constexpr size_t kLadderPruneScanLimit = 256;
+
+    void prune_ladder_into(::core::LevelDBStore::BatchWriter& batch,
+                           uint32_t tip_height)
+    {
+        if (tip_height <= MN_LADDER_RETENTION_HEIGHTS) return;
+        const uint32_t floor_h = tip_height - MN_LADDER_RETENTION_HEIGHTS;
+        for (char tag : {'D', 'A'}) {
+            for (const auto& key : m_store.list_keys(std::string(1, tag),
+                                                     kLadderPruneScanLimit)) {
+                uint32_t h = 0;
+                if (!parse_seq_key(key, tag, h)) continue;
+                if (h >= floor_h) break;      // BE keys => ascending => done
+                batch.remove(key);
+            }
+        }
+    }
 
     bool fail_closed(const std::string& why)
     {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -691,6 +691,11 @@ if (BUILD_TESTING AND GTest_FOUND)
     # -> a standalone target would be a NOT_BUILT sentinel). Do NOT re-add
     # standalone add_executable/gtest_add_tests for any of them — CTest would
     # register unbuilt executables (ctest "Not Run" exit 8, the Linux x86_64 red).
+    # test_dash_mn_diff_ladder.cpp (MN diff-ladder storage + recovery KAT) is
+    # folded here for exactly that reason: this executable is already in the
+    # build.yml --target allowlist, so its DashMnDiffLadder* suites are BUILT
+    # and RUN, whereas a fresh standalone target would register as a NOT_BUILT
+    # sentinel that reports green while never executing a line.
     # DASH_FIXTURE_DIR is needed by the from-wire fixture loader (mnlistdiff).
     add_executable(test_dash_embedded_gbt
         test_dash_embedded_gbt.cpp
@@ -698,6 +703,7 @@ if (BUILD_TESTING AND GTest_FOUND)
         test_dash_mnlistdiff_root_parity.cpp
         test_dash_dkg_commitments.cpp
         test_dash_sml_quorum_db.cpp
+        test_dash_mn_diff_ladder.cpp
         test_dash_embedded_oracle_shadow.cpp)
     target_compile_definitions(test_dash_embedded_gbt PRIVATE
         DASH_FIXTURE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/fixtures")

--- a/test/test_dash_mn_diff_ladder.cpp
+++ b/test/test_dash_mn_diff_ladder.cpp
@@ -1,0 +1,761 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/// MN DIFF-LADDER recovery KAT (DASH_MN_DIFF_LADDER_RECOVERY.md).
+///
+/// The defect being closed: a masternode PAYEE DESYNC latches
+/// CoinStateMaintainer::m_mn_needs_reseed, and the ONLY key that opens that
+/// latch is an authoritative re-seed obtained via the `protx` coin RPC. A
+/// daemonless node has no coin RPC, so the latch is permanent and the node is
+/// demoted to an arm that does not exist (contabo smoke rig, 639 consecutive
+/// empty-set-gap templates over 76 minutes).
+///
+/// EVERY POSITIVE TEST HERE HAS A NEGATIVE TWIN. This project has repeatedly
+/// shipped tests that could only return one answer; a test that cannot fail is
+/// not evidence. The twins are named ...Aborts / ...Refused / ...StaysLatched
+/// and each one deletes or corrupts exactly one thing and asserts the ladder
+/// REFUSES — landing on today's behaviour rather than on a rebuilt state.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/sml_quorum_db.hpp>
+#include <impl/dash/coin/coin_state_maintainer.hpp>
+#include <impl/dash/coin/node_coin_state.hpp>
+#include <impl/dash/coin/block_producer.hpp>   // compute_merkle_root (body<->header bind)
+#include <impl/dash/coin/vendor/smldiff.hpp>
+#include <impl/dash/coin/vendor/simplifiedmns.hpp>
+
+#include <core/leveldb_store.hpp>
+#include <core/pack.hpp>
+#include <core/uint256.hpp>
+
+#include <atomic>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <random>
+#include <string>
+#include <vector>
+
+using dash::coin::SMLDb;
+using dash::coin::LadderOutcome;
+using dash::coin::LadderReplay;
+using dash::coin::MN_LADDER_ANCHOR_INTERVAL;
+using dash::coin::MN_LADDER_RETENTION_HEIGHTS;
+using dash::coin::CoinStateMaintainer;
+using dash::coin::NodeCoinState;
+using dash::coin::MNState;
+using dash::coin::BlockType;
+using dash::coin::MutableTransaction;
+using dash::coin::vendor::CSimplifiedMNList;
+using dash::coin::vendor::CSimplifiedMNListEntry;
+using dash::coin::vendor::CSimplifiedMNListDiff;
+using dash::coin::vendor::apply_diff;
+using ::bitcoin_family::coin::TxIn;
+using ::bitcoin_family::coin::TxOut;
+
+namespace {
+
+// ── scratch dir (same shape as test_dash_sml_quorum_db.cpp) ───────────────
+std::string ladder_scratch_dir(const char* tag) {
+    static std::atomic<int> seq{0};
+    std::random_device rd;
+    auto p = std::filesystem::temp_directory_path()
+           / ("c2pool_mn_ladder_" + std::string(tag) + "_"
+              + std::to_string(rd()) + "_" + std::to_string(seq++));
+    std::filesystem::remove_all(p);
+    std::filesystem::create_directories(p);
+    return p.string();
+}
+
+struct ScratchDb {
+    std::string path;
+    explicit ScratchDb(const char* tag) : path(ladder_scratch_dir(tag)) {}
+    ~ScratchDb() {
+        std::error_code ec;
+        std::filesystem::remove_all(path, ec);
+    }
+};
+
+uint256 hash_from(uint32_t seed) {
+    uint256 h;
+    for (int i = 0; i < 32; ++i)
+        h.data()[i] = static_cast<uint8_t>((seed * 31u + i * 7u + 11u) & 0xFF);
+    return h;
+}
+
+CSimplifiedMNListEntry make_entry(uint32_t seed, bool is_valid = true) {
+    CSimplifiedMNListEntry e;
+    e.nVersion      = CSimplifiedMNListEntry::VER_BASIC_BLS;
+    e.nType         = CSimplifiedMNListEntry::TYPE_REGULAR;
+    e.proRegTxHash  = hash_from(seed);
+    e.confirmedHash = hash_from(seed + 1000);
+    for (int i = 0; i < 16; ++i)
+        e.netAddress[i] = static_cast<uint8_t>(seed + i);
+    e.netPort = static_cast<uint16_t>(9999 + (seed % 100));
+    for (int i = 0; i < 48; ++i)
+        e.pubKeyOperator[i] = static_cast<uint8_t>(seed * 3 + i);
+    e.isValid = is_valid;
+    return e;
+}
+
+// A ZERO-base diff = a full snapshot at `block_hash`.
+CSimplifiedMNListDiff make_snapshot_diff(const std::vector<CSimplifiedMNListEntry>& set,
+                                         const uint256& block_hash) {
+    CSimplifiedMNListDiff d;
+    d.baseBlockHash = uint256::ZERO;
+    d.blockHash     = block_hash;
+    d.mnList        = set;
+    return d;
+}
+
+// An INCREMENTAL diff: chains onto `base`, adds/updates one entry.
+CSimplifiedMNListDiff make_incr_diff(const uint256& base, const uint256& block_hash,
+                                     const CSimplifiedMNListEntry& upsert) {
+    CSimplifiedMNListDiff d;
+    d.baseBlockHash = base;
+    d.blockHash     = block_hash;
+    d.mnList.push_back(upsert);
+    return d;
+}
+
+// Drive the store the way main_dash's persist hook does: apply the diff to the
+// live SML, then write the resulting state + the accepted diff in ONE batch.
+struct LadderFixture {
+    CSimplifiedMNList live;
+    uint32_t          anchor_h{0};
+    uint32_t          top_h{0};
+
+    void seed(SMLDb& db, uint32_t anchor_height, uint32_t n_incremental,
+              size_t base_entries = 6) {
+        anchor_h = anchor_height;
+        std::vector<CSimplifiedMNListEntry> set;
+        for (size_t i = 0; i < base_entries; ++i)
+            set.push_back(make_entry(static_cast<uint32_t>(i + 1)));
+
+        auto snap = make_snapshot_diff(set, hash_from(anchor_height));
+        live.mnList.clear();
+        apply_diff(live, snap);
+        ASSERT_TRUE(db.write_sml(live, snap.blockHash, anchor_height, &snap));
+
+        for (uint32_t k = 1; k <= n_incremental; ++k) {
+            const uint32_t h = anchor_height + k;
+            auto d = make_incr_diff(hash_from(h - 1), hash_from(h),
+                                    make_entry(1000 + k));
+            apply_diff(live, d);
+            ASSERT_TRUE(db.write_sml(live, d.blockHash, h, &d));
+        }
+        top_h = anchor_height + n_incremental;
+    }
+};
+
+// Raw mutation of the CLOSED store — the only way to express "one record went
+// missing" / "one stored root is wrong" without a fake seam in production code.
+void with_raw_store(const std::string& path,
+                    const std::function<void(::core::LevelDBStore&)>& fn) {
+    ::core::LevelDBStore raw(path, {});
+    ASSERT_TRUE(raw.open());
+    fn(raw);
+    raw.close();
+}
+
+std::string ladder_key(char tag, uint32_t h) {
+    std::string k;
+    k.push_back(tag);
+    k.push_back(static_cast<char>((h >> 24) & 0xFF));
+    k.push_back(static_cast<char>((h >> 16) & 0xFF));
+    k.push_back(static_cast<char>((h >>  8) & 0xFF));
+    k.push_back(static_cast<char>( h        & 0xFF));
+    return k;
+}
+
+// Anchor height must be a multiple of the interval or no 'A' is ever written.
+constexpr uint32_t kAnchorH = 32u * 100u;   // 3200
+
+}  // namespace
+
+// ════════════════════════════════════════════════════════════════════════
+// STORAGE LAYER
+// ════════════════════════════════════════════════════════════════════════
+
+// Guard on the codec the whole ladder rests on: CSimplifiedMNListDiff's
+// unserializer DRAINS the rest of the stream as its opaque quorum tail, so a
+// value laid out as pack(diff)++root(32B) is only readable if the reader stops
+// 32 bytes short. If this ever silently changes, every replay would swallow the
+// root into quorum_tail and the root-compare would be meaningless.
+TEST(DashMnDiffLadderStore, DiffRecordRoundTripsWithRootSuffix) {
+    auto d = make_incr_diff(hash_from(7), hash_from(8), make_entry(42));
+    d.quorum_tail = {0xde, 0xad, 0xbe, 0xef};
+    const uint256 root = hash_from(999);
+
+    auto stream = ::pack(d);
+    auto sp = stream.get_span();
+    std::vector<uint8_t> value(
+        reinterpret_cast<const uint8_t*>(sp.data()),
+        reinterpret_cast<const uint8_t*>(sp.data()) + sp.size());
+    value.insert(value.end(), root.data(), root.data() + 32);
+
+    uint256 read_root;
+    std::memcpy(read_root.data(), value.data() + value.size() - 32, 32);
+    EXPECT_EQ(read_root, root);
+
+    std::vector<uint8_t> body(value.begin(), value.end() - 32);
+    ::PackStream ps(body);
+    CSimplifiedMNListDiff back;
+    ASSERT_NO_THROW(ps >> back);
+    EXPECT_EQ(back.baseBlockHash, d.baseBlockHash);
+    EXPECT_EQ(back.blockHash, d.blockHash);
+    ASSERT_EQ(back.mnList.size(), 1u);
+    EXPECT_EQ(back.mnList[0].proRegTxHash, d.mnList[0].proRegTxHash);
+    EXPECT_EQ(back.quorum_tail, d.quorum_tail);
+}
+
+TEST(DashMnDiffLadderStore, WriteAppendsDiffsAndAnchorsAndReportsDepth) {
+    ScratchDb dir("depth");
+    SMLDb db(dir.path);
+    ASSERT_TRUE(db.open());
+
+    LadderFixture fx;
+    fx.seed(db, kAnchorH, /*n_incremental=*/5);
+
+    const auto st = db.ladder_stats();
+    EXPECT_EQ(st.diffs, 6u) << "one 'D' per accepted diff (anchor height + 5)";
+    EXPECT_EQ(st.anchors, 1u) << "one 'A' at the anchor-interval boundary";
+    EXPECT_EQ(st.lowest_diff, kAnchorH);
+    EXPECT_EQ(st.highest_diff, kAnchorH + 5);
+    EXPECT_EQ(st.highest_anchor, kAnchorH);
+    EXPECT_NE(st.banner().find("interval=32"), std::string::npos)
+        << "the banner must state the sizing constants it is running with";
+    db.close();
+}
+
+// The whole point of the "additive keyspace" claim: the ladder append must not
+// perturb the 'S'/'B' warm-restart bytes AT ALL. Two stores, same diffs, one
+// written the master way (no ladder) and one the new way; the reloaded state
+// must be identical in every observable respect.
+TEST(DashMnDiffLadderStore, WarmRestartIsByteIdenticalWithAndWithoutLadder) {
+    ScratchDb dir_old("warm_master");
+    ScratchDb dir_new("warm_ladder");
+    SMLDb db_old(dir_old.path), db_new(dir_new.path);
+    ASSERT_TRUE(db_old.open());
+    ASSERT_TRUE(db_new.open());
+
+    std::vector<CSimplifiedMNListEntry> set;
+    for (uint32_t i = 1; i <= 6; ++i) set.push_back(make_entry(i));
+    auto snap = make_snapshot_diff(set, hash_from(kAnchorH));
+    CSimplifiedMNList live_old, live_new;
+    apply_diff(live_old, snap);
+    apply_diff(live_new, snap);
+    ASSERT_TRUE(db_old.write_sml(live_old, snap.blockHash, kAnchorH));       // master path
+    ASSERT_TRUE(db_new.write_sml(live_new, snap.blockHash, kAnchorH, &snap)); // ladder path
+
+    for (uint32_t k = 1; k <= 4; ++k) {
+        const uint32_t h = kAnchorH + k;
+        auto d = make_incr_diff(hash_from(h - 1), hash_from(h), make_entry(2000 + k));
+        apply_diff(live_old, d);
+        apply_diff(live_new, d);
+        ASSERT_TRUE(db_old.write_sml(live_old, d.blockHash, h));
+        ASSERT_TRUE(db_new.write_sml(live_new, d.blockHash, h, &d));
+    }
+    db_old.close();
+    db_new.close();
+
+    SMLDb re_old(dir_old.path), re_new(dir_new.path);
+    ASSERT_TRUE(re_old.open());
+    ASSERT_TRUE(re_new.open());
+    CSimplifiedMNList out_old, out_new;
+    ASSERT_TRUE(re_old.load_verified(out_old));
+    ASSERT_TRUE(re_new.load_verified(out_new));
+
+    EXPECT_EQ(re_old.get_best_hash(), re_new.get_best_hash());
+    EXPECT_EQ(re_old.get_best_height(), re_new.get_best_height());
+    EXPECT_EQ(re_old.get_expected_root(), re_new.get_expected_root());
+    ASSERT_EQ(out_old.size(), out_new.size());
+    EXPECT_EQ(out_old.CalcMerkleRoot(), out_new.CalcMerkleRoot());
+    for (size_t i = 0; i < out_old.size(); ++i)
+        EXPECT_TRUE(out_old.mnList[i] == out_new.mnList[i]) << "entry " << i;
+    // ...and the ladder is present in exactly one of them.
+    EXPECT_EQ(re_old.ladder_stats().diffs, 0u);
+    EXPECT_EQ(re_new.ladder_stats().diffs, 5u);
+    re_old.close();
+    re_new.close();
+}
+
+TEST(DashMnDiffLadderStore, PruneKeepsTheWindowBounded) {
+    ScratchDb dir("prune");
+    SMLDb db(dir.path);
+    ASSERT_TRUE(db.open());
+
+    // The window must be OVERFILLED for this test to mean anything: writing
+    // fewer than MN_LADDER_RETENTION_HEIGHTS records would satisfy the bound
+    // whether or not a prune exists, i.e. a test that could only pass. Start
+    // well below the floor and end well above it so ~200 records MUST have
+    // been dropped. Small SML so the per-write 'S' rewrite stays cheap.
+    const uint32_t start = 100;
+    const uint32_t end   = MN_LADDER_RETENTION_HEIGHTS + 304;  // 4400
+    std::vector<CSimplifiedMNListEntry> set{make_entry(1), make_entry(2)};
+    CSimplifiedMNList live;
+    auto snap = make_snapshot_diff(set, hash_from(start));
+    apply_diff(live, snap);
+    ASSERT_TRUE(db.write_sml(live, snap.blockHash, start, &snap));
+    for (uint32_t h = start + 1; h <= end; ++h) {
+        auto d = make_incr_diff(hash_from(h - 1), hash_from(h),
+                                make_entry(1 + (h % 2)));
+        apply_diff(live, d);
+        ASSERT_TRUE(db.write_sml(live, d.blockHash, h, &d));
+    }
+
+    // Sanity: without a prune this store would hold end-start+1 == 4301
+    // records, so the bound below is only satisfiable BY the prune.
+    ASSERT_GT(end - start + 1, MN_LADDER_RETENTION_HEIGHTS + 1);
+
+    const auto st = db.ladder_stats();
+    EXPECT_EQ(st.diffs, MN_LADDER_RETENTION_HEIGHTS + 1)
+        << "retention window must bound the ladder exactly";
+    EXPECT_EQ(st.lowest_diff, end - MN_LADDER_RETENTION_HEIGHTS)
+        << "records below the window floor must be gone";
+    EXPECT_EQ(st.highest_diff, end);
+    // Anchors ride the same window.
+    EXPECT_GE(st.highest_anchor, end - MN_LADDER_ANCHOR_INTERVAL);
+    db.close();
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// RECOVERY — positive, then one negative twin per failure mode
+// ════════════════════════════════════════════════════════════════════════
+
+TEST(DashMnDiffLadderReplay, RebuildsStateFromAnchorPlusDiffs) {
+    ScratchDb dir("replay_ok");
+    SMLDb db(dir.path);
+    ASSERT_TRUE(db.open());
+    LadderFixture fx;
+    fx.seed(db, kAnchorH, /*n_incremental=*/5);
+
+    auto r = db.replay_from_ladder(fx.top_h);
+    ASSERT_TRUE(r.ok()) << "reason=" << r.reason();
+    EXPECT_EQ(r.reason(), "ok-replayed-5-diffs");
+    EXPECT_EQ(r.anchor_height, kAnchorH);
+    EXPECT_EQ(r.replayed, 5u);
+    EXPECT_EQ(r.block_hash, hash_from(fx.top_h));
+    // The rebuilt state must be the SAME state the live path holds, proven by
+    // the independently-recomputed root, not by a stored value.
+    EXPECT_EQ(r.root, fx.live.CalcMerkleRoot());
+    ASSERT_EQ(r.sml.size(), fx.live.size());
+    for (size_t i = 0; i < r.sml.size(); ++i)
+        EXPECT_TRUE(r.sml.mnList[i] == fx.live.mnList[i]) << "entry " << i;
+    db.close();
+}
+
+TEST(DashMnDiffLadderReplay, ReplayToTheAnchorItselfAppliesNoDiffs) {
+    ScratchDb dir("replay_anchor_only");
+    SMLDb db(dir.path);
+    ASSERT_TRUE(db.open());
+    LadderFixture fx;
+    fx.seed(db, kAnchorH, /*n_incremental=*/5);
+
+    auto r = db.replay_from_ladder(kAnchorH);
+    ASSERT_TRUE(r.ok()) << "reason=" << r.reason();
+    EXPECT_EQ(r.replayed, 0u);
+    EXPECT_EQ(r.anchor_height, kAnchorH);
+    db.close();
+}
+
+// NEGATIVE TWIN 1 — no anchor at or below the target.
+TEST(DashMnDiffLadderReplay, MissingAnchorRefuses) {
+    ScratchDb dir("no_anchor");
+    SMLDb db(dir.path);
+    ASSERT_TRUE(db.open());
+    // Seed starting one height PAST the anchor boundary so no 'A' is written.
+    LadderFixture fx;
+    fx.seed(db, kAnchorH + 1, /*n_incremental=*/4);
+    ASSERT_EQ(db.ladder_stats().anchors, 0u);
+
+    auto r = db.replay_from_ladder(fx.top_h);
+    EXPECT_FALSE(r.ok());
+    EXPECT_EQ(r.outcome, LadderOutcome::AnchorMissing);
+    EXPECT_EQ(r.reason(), "anchor-missing");
+    EXPECT_EQ(r.sml.size(), 0u) << "a refused replay must return NO state";
+    db.close();
+}
+
+// NEGATIVE TWIN 2 — the ladder is dense except for ONE height. This is the
+// missed-diff case: replaying around it would rebuild a queue that skipped a
+// block's worth of changes. It must ABORT, never skip.
+TEST(DashMnDiffLadderReplay, DeletedDiffHeightAborts) {
+    ScratchDb dir("gap");
+    uint32_t top = 0;
+    {
+        SMLDb db(dir.path);
+        ASSERT_TRUE(db.open());
+        LadderFixture fx;
+        fx.seed(db, kAnchorH, /*n_incremental=*/5);
+        top = fx.top_h;
+        ASSERT_TRUE(db.replay_from_ladder(top).ok()) << "pre-condition: clean replay";
+        db.close();
+    }
+    const uint32_t victim = kAnchorH + 3;
+    with_raw_store(dir.path, [&](::core::LevelDBStore& raw) {
+        ASSERT_TRUE(raw.exists(ladder_key('D', victim)));
+        ASSERT_TRUE(raw.remove(ladder_key('D', victim)));
+    });
+    {
+        SMLDb db(dir.path);
+        ASSERT_TRUE(db.open());
+        auto r = db.replay_from_ladder(top);
+        EXPECT_FALSE(r.ok());
+        EXPECT_EQ(r.outcome, LadderOutcome::DiffGap);
+        EXPECT_EQ(r.failed_height, victim);
+        EXPECT_EQ(r.reason(), "diff-gap-at-h=" + std::to_string(victim));
+        EXPECT_EQ(r.sml.size(), 0u);
+        db.close();
+    }
+}
+
+// NEGATIVE TWIN 3 — the anchor's stored root does not reproduce.
+TEST(DashMnDiffLadderReplay, CorruptedAnchorRootRefuses) {
+    ScratchDb dir("anchor_root");
+    uint32_t top = 0;
+    {
+        SMLDb db(dir.path);
+        ASSERT_TRUE(db.open());
+        LadderFixture fx;
+        fx.seed(db, kAnchorH, /*n_incremental=*/5);
+        top = fx.top_h;
+        ASSERT_TRUE(db.replay_from_ladder(top).ok()) << "pre-condition: clean replay";
+        db.close();
+    }
+    with_raw_store(dir.path, [&](::core::LevelDBStore& raw) {
+        std::vector<uint8_t> v;
+        ASSERT_TRUE(raw.get(ladder_key('A', kAnchorH), v));
+        ASSERT_GE(v.size(), 64u);
+        v[v.size() - 64] ^= 0xFF;      // flip a byte of the stored root
+        ASSERT_TRUE(raw.put(ladder_key('A', kAnchorH), v));
+    });
+    {
+        SMLDb db(dir.path);
+        ASSERT_TRUE(db.open());
+        auto r = db.replay_from_ladder(top);
+        EXPECT_FALSE(r.ok());
+        EXPECT_EQ(r.outcome, LadderOutcome::AnchorRootMismatch);
+        EXPECT_EQ(r.reason(),
+                  "anchor-root-mismatch-at-h=" + std::to_string(kAnchorH));
+        EXPECT_EQ(r.sml.size(), 0u);
+        db.close();
+    }
+}
+
+// NEGATIVE TWIN 4 — a mid-ladder record's resulting root does not reproduce.
+TEST(DashMnDiffLadderReplay, CorruptedDiffResultRootRefusesAtThatHeight) {
+    ScratchDb dir("diff_root");
+    uint32_t top = 0;
+    {
+        SMLDb db(dir.path);
+        ASSERT_TRUE(db.open());
+        LadderFixture fx;
+        fx.seed(db, kAnchorH, /*n_incremental=*/5);
+        top = fx.top_h;
+        ASSERT_TRUE(db.replay_from_ladder(top).ok()) << "pre-condition: clean replay";
+        db.close();
+    }
+    const uint32_t victim = kAnchorH + 2;
+    with_raw_store(dir.path, [&](::core::LevelDBStore& raw) {
+        std::vector<uint8_t> v;
+        ASSERT_TRUE(raw.get(ladder_key('D', victim), v));
+        ASSERT_GE(v.size(), 32u);
+        v[v.size() - 1] ^= 0x01;
+        ASSERT_TRUE(raw.put(ladder_key('D', victim), v));
+    });
+    {
+        SMLDb db(dir.path);
+        ASSERT_TRUE(db.open());
+        auto r = db.replay_from_ladder(top);
+        EXPECT_FALSE(r.ok());
+        EXPECT_EQ(r.outcome, LadderOutcome::DiffRootMismatch);
+        EXPECT_EQ(r.failed_height, victim);
+        EXPECT_EQ(r.sml.size(), 0u);
+        db.close();
+    }
+}
+
+// NEGATIVE TWIN 5 — a record that does not CHAIN onto the previous block, even
+// though it exists at the right height and carries a self-consistent root.
+TEST(DashMnDiffLadderReplay, BrokenBaseContinuityRefuses) {
+    ScratchDb dir("base_chain");
+    SMLDb db(dir.path);
+    ASSERT_TRUE(db.open());
+
+    std::vector<CSimplifiedMNListEntry> set;
+    for (uint32_t i = 1; i <= 4; ++i) set.push_back(make_entry(i));
+    CSimplifiedMNList live;
+    auto snap = make_snapshot_diff(set, hash_from(kAnchorH));
+    apply_diff(live, snap);
+    ASSERT_TRUE(db.write_sml(live, snap.blockHash, kAnchorH, &snap));
+    // h+1 chains correctly.
+    auto d1 = make_incr_diff(hash_from(kAnchorH), hash_from(kAnchorH + 1),
+                             make_entry(500));
+    apply_diff(live, d1);
+    ASSERT_TRUE(db.write_sml(live, d1.blockHash, kAnchorH + 1, &d1));
+    // h+2 claims a base we were never at (an off-branch record).
+    auto d2 = make_incr_diff(hash_from(777777), hash_from(kAnchorH + 2),
+                             make_entry(501));
+    apply_diff(live, d2);
+    ASSERT_TRUE(db.write_sml(live, d2.blockHash, kAnchorH + 2, &d2));
+
+    auto r = db.replay_from_ladder(kAnchorH + 2);
+    EXPECT_FALSE(r.ok());
+    EXPECT_EQ(r.outcome, LadderOutcome::DiffBaseMismatch);
+    EXPECT_EQ(r.failed_height, kAnchorH + 2);
+    db.close();
+}
+
+// G3: the reorg / fail-closed wipe MUST take the ladder with it. An
+// orphaned-branch ladder is self-consistent and would replay perfectly clean
+// into a wrong-branch state — the exact hazard clear() exists to prevent.
+TEST(DashMnDiffLadderReplay, StoreClearWipesTheLadderToo) {
+    ScratchDb dir("clear");
+    SMLDb db(dir.path);
+    ASSERT_TRUE(db.open());
+    LadderFixture fx;
+    fx.seed(db, kAnchorH, /*n_incremental=*/3);
+    ASSERT_TRUE(db.replay_from_ladder(fx.top_h).ok());
+
+    ASSERT_TRUE(db.clear());
+    EXPECT_EQ(db.ladder_stats().diffs, 0u);
+    EXPECT_EQ(db.ladder_stats().anchors, 0u);
+    auto r = db.replay_from_ladder(fx.top_h);
+    EXPECT_FALSE(r.ok());
+    EXPECT_EQ(r.outcome, LadderOutcome::AnchorMissing);
+    db.close();
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// THE LATCH — end-to-end through CoinStateMaintainer
+// ════════════════════════════════════════════════════════════════════════
+namespace {
+
+constexpr uint8_t  kAddrVer  = 76;
+constexpr uint8_t  kP2shVer  = 16;
+constexpr uint32_t kTipH     = 2'400'000;
+
+uint256 seq256(uint8_t base) {
+    uint256 h;
+    for (int i = 0; i < 32; ++i) h.data()[i] = static_cast<uint8_t>(base + i);
+    return h;
+}
+
+std::vector<unsigned char> pkh_script(uint8_t seed) {
+    std::vector<unsigned char> s{0x76, 0xa9, 0x14};
+    for (int i = 0; i < 20; ++i) s.push_back(static_cast<unsigned char>(seed + i));
+    s.push_back(0x88); s.push_back(0xac);
+    return s;
+}
+
+void bind(BlockType& b) {
+    std::vector<uint256> ids;
+    for (const auto& tx : b.m_txs) ids.push_back(dash::coin::dash_txid(tx));
+    b.m_merkle_root = dash::coin::compute_merkle_root(ids);
+}
+
+MutableTransaction coinbase_paying(const std::vector<unsigned char>& script) {
+    MutableTransaction tx;
+    tx.version = 1; tx.type = 0; tx.locktime = 1;
+    TxIn in; in.prevout.hash = seq256(0x90); in.prevout.index = 0;
+    in.sequence = 0xffffffffu;
+    tx.vin.push_back(in);
+    TxOut o; o.value = 500000000; o.scriptPubKey.m_data = script;
+    tx.vout.push_back(o);
+    return tx;
+}
+
+std::vector<std::pair<uint256, MNState>> one_mn(const std::vector<unsigned char>& payout) {
+    MNState s;
+    s.isValid = true;
+    s.nRegisteredHeight = 2'300'000;
+    s.nLastPaidHeight = 0;
+    s.scriptPayout.m_data = payout;
+    return {{seq256(0x01), s}};
+}
+
+// Arm a maintainer into the live embedded posture, then feed it a block whose
+// coinbase pays somebody OTHER than the projected masternode = payee desync.
+struct DesyncRig {
+    NodeCoinState st;
+    CoinStateMaintainer m{st};
+
+    void arm() {
+        m.set_require_seeded_mn_set(true);   // the embedded-arm posture
+        m.on_mn_list_update(one_mn(pkh_script(0x30)), kTipH - 1);
+        m.on_new_tip(kTipH - 1, seq256(0x50), 0x1d00ffff, 1'700'000'000,
+                     kAddrVer, kP2shVer, 1'700'000'100, 4);
+    }
+    dash::coin::MnStateMachine::ApplyResult desync() {
+        BlockType blk;
+        blk.m_txs.push_back(coinbase_paying(pkh_script(0x77)));  // NOT the MN
+        bind(blk);
+        return m.on_block_connected(blk, kTipH);
+    }
+};
+
+}  // namespace
+
+// Flag OFF (the shipped default) — a desync must latch EXACTLY as on master,
+// even with a perfectly replayable ladder wired up.
+TEST(DashMnDiffLadderLatch, FlagOffKeepsTodaysLatchBehaviour) {
+    DesyncRig rig;
+    int ladder_calls = 0;
+    rig.m.set_mn_ladder_reseed_fn([&](uint32_t) { ++ladder_calls; return true; });
+    // deliberately NOT calling set_mn_ladder_reseed_enabled(true)
+    ASSERT_FALSE(rig.m.mn_ladder_reseed_enabled());
+    rig.arm();
+    ASSERT_TRUE(rig.m.live());
+
+    auto r = rig.desync();
+    ASSERT_TRUE(r.payee_desync);
+    EXPECT_EQ(ladder_calls, 0)
+        << "with the flag off the ladder must not even be consulted";
+    EXPECT_FALSE(rig.m.live());
+    EXPECT_TRUE(rig.st.mn_needs_reseed()) << "latch must STAY SET";
+    EXPECT_EQ(rig.st.classify_decline(), "mn-needs-reseed");
+}
+
+// Flag ON + a replay that succeeds — the latch opens.
+TEST(DashMnDiffLadderLatch, FlagOnAndReplayOkClearsTheLatch) {
+    DesyncRig rig;
+    uint32_t seen_target = 0;
+    rig.m.set_mn_ladder_reseed_fn([&](uint32_t h) { seen_target = h; return true; });
+    rig.m.set_mn_ladder_reseed_enabled(true);
+    rig.arm();
+    ASSERT_TRUE(rig.m.live());
+
+    auto r = rig.desync();
+    ASSERT_TRUE(r.payee_desync);
+    EXPECT_EQ(seen_target, kTipH) << "the replay target is the desync height";
+    EXPECT_FALSE(rig.st.mn_needs_reseed()) << "verified replay must clear the latch";
+
+    // ...and clearing the latch is NOT sufficient to serve. The Simplified MN
+    // List carries no scriptPayout / nLastPaidHeight, so the payee queue is
+    // still empty and MN-readiness stays down. There is no new way to serve.
+    EXPECT_FALSE(rig.m.live());
+    EXPECT_EQ(rig.st.mnstates().size(), 0u);
+    bool fell_back = false;
+    auto sel = rig.st.select_work([&]() {
+        fell_back = true;
+        return dash::coin::DashWorkData{};
+    });
+    EXPECT_EQ(sel.source, dash::coin::WorkSource::DashdFallback);
+    EXPECT_TRUE(fell_back);
+}
+
+// NEGATIVE TWIN — flag ON but the replay REFUSES. Failure must land on today's
+// behaviour: latch set, arm demoted, decline named.
+TEST(DashMnDiffLadderLatch, FlagOnButReplayRefusedStaysLatched) {
+    DesyncRig rig;
+    int calls = 0;
+    rig.m.set_mn_ladder_reseed_fn([&](uint32_t) { ++calls; return false; });
+    rig.m.set_mn_ladder_reseed_enabled(true);
+    rig.arm();
+    ASSERT_TRUE(rig.m.live());
+
+    auto r = rig.desync();
+    ASSERT_TRUE(r.payee_desync);
+    EXPECT_EQ(calls, 1);
+    EXPECT_TRUE(rig.st.mn_needs_reseed()) << "a refused replay must NOT open the latch";
+    EXPECT_FALSE(rig.m.live());
+    EXPECT_EQ(rig.st.classify_decline(), "mn-needs-reseed");
+}
+
+// NEGATIVE TWIN — flag ON, replay would succeed, but the anti-mint seeded-MN
+// requirement is OFF. Clearing the latch there would reopen the E2d hole
+// (block-connect alone arming MN-readiness off an incidental ProRegTx), so the
+// ladder must refuse to clear.
+TEST(DashMnDiffLadderLatch, AntiMintInterlockRefusesWhenSeededMnNotRequired) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    int calls = 0;
+    m.set_mn_ladder_reseed_fn([&](uint32_t) { ++calls; return true; });
+    m.set_mn_ladder_reseed_enabled(true);
+    // NOTE: set_require_seeded_mn_set() deliberately NOT called (KAT default).
+    m.on_mn_list_update(one_mn(pkh_script(0x30)), kTipH - 1);
+    m.on_new_tip(kTipH - 1, seq256(0x50), 0x1d00ffff, 1'700'000'000,
+                 kAddrVer, kP2shVer, 1'700'000'100, 4);
+    ASSERT_TRUE(m.live());
+
+    BlockType blk;
+    blk.m_txs.push_back(coinbase_paying(pkh_script(0x77)));
+    bind(blk);
+    auto r = m.on_block_connected(blk, kTipH);
+
+    ASSERT_TRUE(r.payee_desync);
+    EXPECT_EQ(calls, 0) << "the interlock must short-circuit BEFORE the replay";
+    EXPECT_TRUE(st.mn_needs_reseed());
+    EXPECT_FALSE(m.live());
+}
+
+// Observability: before this slice the latch was invisible to the decline
+// classifier — the smoke rig reported "not-populated" 639 times while the real
+// cause was a payee desync. classify_decline must now NAME it.
+TEST(DashMnDiffLadderLatch, ClassifyDeclineNamesTheLatch) {
+    NodeCoinState st;
+    EXPECT_NE(st.classify_decline(), "mn-needs-reseed");
+    st.set_mn_needs_reseed(true);
+    EXPECT_EQ(st.classify_decline(), "mn-needs-reseed");
+    st.set_mn_needs_reseed(false);
+    EXPECT_NE(st.classify_decline(), "mn-needs-reseed");
+}
+
+// End-to-end: a REAL ladder store behind the maintainer seam. Proves the two
+// halves compose — the store replays, the maintainer opens the latch — and,
+// in the twin, that deleting one 'D' height keeps the arm latched.
+TEST(DashMnDiffLadderLatch, EndToEndRealLadderRearms) {
+    ScratchDb dir("e2e");
+    SMLDb db(dir.path);
+    ASSERT_TRUE(db.open());
+    LadderFixture fx;
+    fx.seed(db, kAnchorH, /*n_incremental=*/6);
+
+    DesyncRig rig;
+    std::string outcome;
+    rig.m.set_mn_ladder_reseed_fn([&](uint32_t) {
+        auto rep = db.replay_from_ladder(fx.top_h);
+        outcome = rep.reason();
+        return rep.ok();
+    });
+    rig.m.set_mn_ladder_reseed_enabled(true);
+    rig.arm();
+    ASSERT_TRUE(rig.desync().payee_desync);
+    EXPECT_EQ(outcome, "ok-replayed-6-diffs");
+    EXPECT_FALSE(rig.st.mn_needs_reseed());
+    db.close();
+}
+
+TEST(DashMnDiffLadderLatch, EndToEndMissingDiffKeepsArmLatched) {
+    ScratchDb dir("e2e_gap");
+    uint32_t top = 0;
+    {
+        SMLDb seedb(dir.path);
+        ASSERT_TRUE(seedb.open());
+        LadderFixture fx;
+        fx.seed(seedb, kAnchorH, /*n_incremental=*/6);
+        top = fx.top_h;
+        seedb.close();
+    }
+    with_raw_store(dir.path, [&](::core::LevelDBStore& raw) {
+        ASSERT_TRUE(raw.remove(ladder_key('D', kAnchorH + 4)));
+    });
+
+    SMLDb db(dir.path);
+    ASSERT_TRUE(db.open());
+    DesyncRig rig;
+    std::string outcome;
+    rig.m.set_mn_ladder_reseed_fn([&](uint32_t) {
+        auto rep = db.replay_from_ladder(top);
+        outcome = rep.reason();
+        return rep.ok();
+    });
+    rig.m.set_mn_ladder_reseed_enabled(true);
+    rig.arm();
+    ASSERT_TRUE(rig.desync().payee_desync);
+    EXPECT_EQ(outcome, "diff-gap-at-h=" + std::to_string(kAnchorH + 4));
+    EXPECT_TRUE(rig.st.mn_needs_reseed()) << "a gap must leave the arm LATCHED";
+    EXPECT_FALSE(rig.m.live());
+    EXPECT_EQ(rig.st.classify_decline(), "mn-needs-reseed");
+    db.close();
+}


### PR DESCRIPTION
Implements the storage layer and recovery function from
`DASH_MN_DIFF_LADDER_RECOVERY.md` (frstrtr/the).

## The defect

`coin_state_maintainer.hpp` latches `m_mn_needs_reseed` on a masternode payee
desync. The latch is deliberate and correct — a desynced payee projection would
mint a consensus-invalid coinbase, so refusing is right. The defect is that the
**only key that opens the latch is an authoritative re-seed obtained via the
`protx` coin RPC**. A daemonless node has no coin RPC, so the latch is permanent
and the node is demoted to an arm that does not exist. The contabo smoke rig
(`c2pool-dash-smoke0802`, 2026-08-02) served 639 consecutive empty set-gap
templates over 76 minutes for exactly this reason.

The diffs that could rebuild the state are already received, parsed and
validated — and then discarded, because the store does an atomic full-rewrite
per accepted `mnlistdiff`. This PR retains them.

## (a) The re-arm is behind a flag that DEFAULTS OFF, and why

`--embedded-mn-ladder-reseed`, default **off**.

* The **ladder is written unconditionally**. Retaining data we already receive,
  parse and validate cannot change behaviour, and the write rides the SAME
  `WriteBatch` that already rewrites `'S'`/`'B'` — one atomic commit point, no
  new failure mode.
* What the flag gates is only the **RE-ARM**. With it off, a payee desync
  latches *exactly* as it does on master; the replay is exercised by the KATs
  and by nothing else.
* Two independent reviews are in flight — a test-harness review and a
  minority report — that could change the RECOVERY SEMANTICS. They cannot change the STORAGE layer. Gating
  this way makes the PR merge-safe regardless of what they conclude, and
  flipping the default becomes a separate one-line change.

Every failure path — and the disabled path — lands on **today's** behaviour:
latch stays set, cold `mnlistdiff(zero, tip)` fallback. There is no new way to
serve a template.

## (b) The three open gates, verbatim from the design doc

> **G1 — does replay reproduce the same divergence?**
> If the projection desynced because a diff was *missed*, replaying the diffs we
> hold rebuilds the same wrong queue and the latch re-fires. Two mitigations,
> and the second is unresolved:
>
> - *Gap detection*: step 3 aborts on a missing height rather than skipping.
>   This catches the missed-diff case **provided** we know a height is missing —
>   i.e. `'D'` keys must be dense over the window, and density must be checked,
>   not assumed.
> - *Anchor trust*: `load_verified()` recomputes `merkleRootMNList` and compares
>   it to a root **that was itself supplied by the peer's diff**. A
>   consistently-lying peer produces a self-consistent chain of roots that
>   passes every check. dashd is immune because it derives the root from `cbTx`
>   in a validated block. **We hold headers, not blocks — `cbTx` is not
>   available to us.** This is the same trust exposure the arm already carries
>   today, so the change does not worsen it; but it is the reason this ladder
>   cannot be called "consensus-anchored", and it must not be described as such.
>   *Open: whether a `merkleRootMNList` commitment reachable from the header
>   chain, or the existing checkpoint bridge, can serve as an independent
>   anchor.*
>
> **G2 — retention.**
> dashd keeps diffs indefinitely. We want a bounded window: large enough to
> cover any plausible desync-to-recovery span, small enough that the store does
> not grow without limit. `N` (anchor interval) and the window length are both
> unset pending review. Note the smoke rig's two desync events were 155 heights
> apart, which is a data point of exactly one.
>
> **G3 — does the ladder survive the fail-closed wipe?**
> `load_verified()` wipes the store on corrupt load, and `set_on_sml_clear`
> wipes on reorg/H-1 heal. If those wipes also destroy `'A'`/`'D'`, the ladder
> is unavailable in precisely the situations that need it. Reorg-wipe is
> *correct* (an orphaned-branch ladder is self-consistent and wrong).
> Corrupt-wipe scope needs deciding.

Where this PR lands against them:

* **G1** — density is REQUIRED, not assumed: the replay walks every integer
  height in `(anchor, target]` and aborts on the first one with no `'D'`
  record. It additionally requires base-hash continuity at each step. Anchor
  trust is UNRESOLVED and is documented as such in the store header; the ladder
  is nowhere described as consensus-anchored.
* **G2** — `MN_LADDER_ANCHOR_INTERVAL = 32` and
  `MN_LADDER_RETENTION_HEIGHTS = 4096` are labelled **PENDING REVIEW SIZING**
  placeholders in the source, with the reasoning (and its weakness) written
  next to them. They must be revisited before the default is flipped.
* **G3** — decided conservatively for now and stated in the code: `clear()`
  takes the ladder with it. The reorg case is unambiguous. The corrupt-load
  case is the one the doc leaves open; wiping means a store we have just proven
  untrustworthy cannot supply the re-seed key, at the cost of recovery in
  exactly that case. Flagged for the reviews to revisit.

## (c) Reviews in flight

Both in-flight reviews — the test-harness review and the minority report — bear
on the RECOVERY SEMANTICS — including the recommended values for `N` and the
retention window, and whether strict height-density is the right density rule.
**Those reviews gate flipping the default**, not this PR.

## What is in the change

**Storage** (`sml_quorum_db.hpp`, additive keyspaces):

```
'D' + height(4B BE) -> pack(CSimplifiedMNListDiff) ++ resulting_root(32B)
'A' + height(4B BE) -> pack(vector<entry>) ++ root(32B) ++ block_hash(32B)
```

Big-endian heights so LevelDB key order IS height order. `'S'`/`'B'` and their
full-rewrite path are untouched. The root is a fixed-width SUFFIX because
`CSimplifiedMNListDiff`'s unserializer drains the remaining stream as its opaque
quorum tail — the reader hands it a body slice that stops 32 bytes short. The
anchor additionally records its block hash so the first replayed diff's
`baseBlockHash` can be bound to the anchor rather than trusted to start in the
right place.

**Recovery** — `SMLDb::replay_from_ladder(target_h)`:

1. greatest `'A'` anchor at height `<= target_h`; none -> `anchor-missing`
2. load it, RECOMPUTE the merkle root, mismatch -> `anchor-root-mismatch-at-h`
3. for `h in anchor_h+1 .. target_h`: `'D'@h` MUST EXIST (`diff-gap-at-h`),
   must chain onto the previous block (`diff-base-mismatch-at-h`), apply,
   RECOMPUTE the root, compare to the stored resulting root
   (`diff-root-mismatch-at-h`)
4. success -> the rebuilt state is RETURNED; the function never mutates live
   state and never clears a latch by itself
5. any abort -> no state returned, caller stays on today's path

**Observability** (this is a standing project law — a gate that can silently
refuse must say WHY, where a human looks):

* `classify_decline()` gains `mn-needs-reseed`, checked FIRST because it is a
  strictly more informative cause of the `not-populated` it used to report. The
  smoke rig reported "not-populated" 639 times while the actual cause appeared
  nowhere in the decline classification.
* Every ladder outcome logs its reason: `anchor-missing` /
  `anchor-root-mismatch-at-h` / `diff-gap-at-h` / `diff-root-mismatch-at-h` /
  `ok-replayed-N-diffs`.
* A startup banner reports ladder depth: anchors, diffs, height range, top
  anchor, and the sizing constants in force.

**Anti-mint interlock**: the ladder clears the payee latch only while
`require_seeded_mn_set` is ACTIVE. That requirement is what still makes it
impossible for block-connect alone to arm MN-readiness off an incidental
ProRegTx; without it, clearing the latch would reopen the exact E2d hole the
latch was added to close.

## Honest scope note (a place the design doc is wrong about the code)

The design doc's step 4 says "on success: `mnstates().load(rebuilt)`". That is
not achievable from this ladder and the PR does not claim it. The DIP-0004
Simplified MN List **omits `scriptPayout` and `nLastPaidHeight`** (see
`mn_checkpoint.hpp`'s trust-anchor preamble), so an SML replay cannot
reconstruct the payout-bearing payee queue. Clearing the latch is therefore
NECESSARY-BUT-NOT-SUFFICIENT: `m_have_mn` still requires a non-empty payee set
AND a height-stamped snapshot, both zeroed by the desync wipe. A KAT asserts
precisely this — after a successful ladder re-arm the arm still routes to the
dashd fallback. Closing the payee axis daemonlessly is a separate problem from
closing the SML axis, and this PR closes the SML axis only.

## Tests — each one proven able to fail

19 KATs in `test/test_dash_mn_diff_ladder.cpp`, folded into the already
build.yml-allowlisted `test_dash_embedded_gbt` executable (a fresh standalone
target would register as a NOT_BUILT CTest sentinel that reports green while
never executing a line — the #137 / test_dgb_subsidy class).

Every positive test has a negative twin. Proven by mutation, not asserted:

| mutation | tests that went RED |
|---|---|
| missing `'D'` height `continue`s instead of aborting | `DeletedDiffHeightAborts`, `EndToEndMissingDiffKeepsArmLatched` |
| anchor root verify removed | `CorruptedAnchorRootRefuses` |
| per-height root verify removed | `CorruptedDiffResultRootRefusesAtThatHeight` |
| flag check removed from the re-arm | `FlagOffKeepsTodaysLatchBehaviour` |
| prune call removed | `PruneKeepsTheWindowBounded` |

The prune test was rewritten during that exercise: as first written it wrote
fewer records than the retention window, so it passed with the prune deleted —
a test that could only return one answer. It now overfills the window.

Do not merge on my behalf.

(Sizing constants `MN_LADDER_ANCHOR_INTERVAL=32` / `MN_LADDER_RETENTION_HEIGHTS=4096` are placeholders pending the review recommendations; flipping the flag default is a separate change.)
