### PR TITLE
ci(runner-host): reap orphaned ppid=1 build trees left by a dead Runner.Worker

### DIFF
--- a/deploy/systemd/c2pool-runner-orphan-reaper.README.md
+++ b/deploy/systemd/c2pool-runner-orphan-reaper.README.md
@@ -1,0 +1,55 @@
+# c2pool CI runner-host orphan-build reaper
+
+Unattended guard for self-hosted **Linux** CI runner hosts. Reaps build trees
+(`cmake`/`make`/`cc1plus`/`cc`/`c++`) that a dead `Runner.Worker` left
+reparented to `ppid=1`, where they peg host load and starve the runner pool
+(observed on 192.168.86.198, 2026-08-02).
+
+Companion of the mac self-heal watchdogs in `scripts/ci/runner-watchdog-mac-*.sh`.
+Script: `scripts/ci/runner-orphan-reaper-linux.sh` (self-documenting header).
+
+## Why ppid=1 is the signal
+A legit compiler always has a live `Runner.Worker` ancestor. When the Worker
+dies, the kernel reparents its orphans to pid 1 — so `ppid=1` + build-comm +
+under `_work/.../build_codeql` = orphaned, by construction. This is safe on
+**multi-runner hosts** (VM905 = 8 runners): a busy sibling runner's compilers
+are children of *its* live Worker, never `ppid=1`, so they are never touched.
+An age floor (>15 min) is layered on as belt-and-suspenders. The script also
+does an explicit Worker-ancestor walk right before any signal (HARD rule:
+never touch a tree under a live Runner.Worker).
+
+## Install (per Linux runner host — .198 primary; then VM905 / 198-2 / 198-3)
+
+    mkdir -p ~/.local/bin ~/.config/systemd/user ~/.local/state/runner-orphan-reaper
+    cp scripts/ci/runner-orphan-reaper-linux.sh ~/.local/bin/
+    chmod +x ~/.local/bin/runner-orphan-reaper-linux.sh
+    cp deploy/systemd/c2pool-runner-orphan-reaper.service \
+       deploy/systemd/c2pool-runner-orphan-reaper.timer   ~/.config/systemd/user/
+    loginctl enable-linger "$USER"            # keep the timer firing without a login session
+    systemctl --user daemon-reload
+    systemctl --user enable --now c2pool-runner-orphan-reaper.timer
+
+## Verify / safe rehearsal (kills nothing)
+
+    systemctl --user list-timers c2pool-runner-orphan-reaper.timer
+    ~/.local/bin/runner-orphan-reaper-linux.sh --dry-run     # prints what WOULD be reaped
+    journalctl --user -t runner-orphan-reaper -n 50
+    journalctl --user -u c2pool-runner-orphan-reaper.service -n 50
+
+## Tunables (env; defaults match the .198 incident)
+- `REAP_PATH_RE`    build-tree path regex. Default `_work/.*build_codeql`;
+                    widen to `_work/.*/build` to cover all CI builds.
+- `REAP_COMM_RE`    toolchain leader `comm` set.
+- `REAP_MIN_AGE`    age floor, seconds (default 900).
+- `REAP_ROOT_PPID`  orphan-root parent pid (default 1; change only if the host
+                    installs a child-subreaper in the runner tree).
+- `REAP_ALERT_MAILTO`  if set and a local `mail`/`sendmail` exists, each kill is
+                    ALSO emailed inline. Otherwise kills are journalled and
+                    appended to `REAP_SPOOL` (`~/.local/state/runner-orphan-reaper/
+                    reaped.jsonl`), which ci-steward tails each heartbeat to
+                    forward to decisions@ for recurrence tracking.
+
+## Revert
+    systemctl --user disable --now c2pool-runner-orphan-reaper.timer
+    rm ~/.config/systemd/user/c2pool-runner-orphan-reaper.{service,timer} ~/.local/bin/runner-orphan-reaper-linux.sh
+No persistent host change is made beyond killing the orphaned processes it reports.

--- a/deploy/systemd/c2pool-runner-orphan-reaper.service
+++ b/deploy/systemd/c2pool-runner-orphan-reaper.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=c2pool CI — reap orphaned (ppid=1) build trees left by a dead Runner.Worker
+Documentation=https://github.com/frstrtr/c2pool/blob/master/scripts/ci/runner-orphan-reaper-linux.sh
+
+[Service]
+Type=oneshot
+# Optional inline alert transport; if unset, kills are logged to the journal
+# and appended to the spool for ci-steward's heartbeat to forward to decisions@.
+Environment=REAP_ALERT_MAILTO=
+ExecStart=%h/.local/bin/runner-orphan-reaper-linux.sh
+Nice=10
+
+[Install]
+WantedBy=default.target

--- a/deploy/systemd/c2pool-runner-orphan-reaper.timer
+++ b/deploy/systemd/c2pool-runner-orphan-reaper.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=c2pool CI — periodic orphaned-build-tree reap (~10 min)
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=10min
+AccuracySec=1min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/ci/runner-orphan-reaper-linux.sh
+++ b/scripts/ci/runner-orphan-reaper-linux.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+#
+# runner-orphan-reaper-linux.sh
+#
+# Detect and reap ORPHANED build trees on a self-hosted Linux CI runner host.
+#
+# THE FAILURE IT GUARDS (observed on 192.168.86.198, 2026-08-02):
+#   A Runner.Worker died mid-job at a ~10-min zero-step with no logs. Its
+#   build children (cmake / make / cc1plus / cc / c++) were reparented to
+#   ppid=1 and kept running, pegging load ~8 and starving every other runner
+#   on the pool. Manual reap-by-hand does not scale across the .198 / VM905 /
+#   198-2 / 198-3 pattern, so this runs unattended on each host.
+#
+# WHY ppid=1 IS THE SIGNAL (not "no Runner.Worker anywhere on the host"):
+#   A LEGIT build compiler always has a live Runner.Worker as an ANCESTOR.
+#   When the Worker dies, the kernel reparents its orphaned descendants to
+#   pid 1 (init) -- there is no subreaper in the runner process tree. So a
+#   build-toolchain process whose parent is pid 1 has, by construction, no
+#   Worker ancestor: it is orphaned. This is the precise disqualifier, and
+#   it is safe on MULTI-RUNNER hosts (VM905 runs 8 runners): other runners
+#   can be mid-build with live Workers -- their compilers are NOT ppid=1, so
+#   they are never candidates. Gating on "no Runner.Worker exists on the
+#   host" (the loose phrasing) would refuse to ever fire on a busy pool;
+#   the ppid=1 ancestor test is correct there. An age floor (>15 min) is
+#   layered on as belt-and-suspenders against a just-reparented transient.
+#
+# ACTION on a confirmed orphan root: kill -STOP the root (freeze it so it
+#   spawns no more children), enumerate the full descendant set, SIGKILL the
+#   descendants, then SIGKILL the root. Every kill is logged to the journal
+#   and appended to a machine-parseable spool (REAP_SPOOL) that ci-steward
+#   tails each heartbeat to alert decisions@ (recurrence tracking). If a
+#   local mailer is configured (REAP_ALERT_MAILTO + mail/sendmail present)
+#   the alert is ALSO sent inline.
+#
+# HARD RULE: never touch a tree that has a live Runner.Worker ancestor.
+#   Enforced by the ppid=1 test + an explicit ancestor walk before any kill.
+#
+# SAFE REHEARSAL:  runner-orphan-reaper-linux.sh --dry-run
+#   Prints exactly what WOULD be reaped and exits without signalling anything.
+#
+# REVERT: disable the timer and delete this file. It makes no persistent
+#   change to the host beyond killing the orphaned processes it reports.
+#
+set -euo pipefail
+
+DRY_RUN=0
+[ "${1:-}" = "--dry-run" ] && DRY_RUN=1
+
+# --- tunables (env-overridable; defaults match the observed .198 incident) ---
+# comm values of build-toolchain leaders we consider (ps comm, 15-char max).
+REAP_COMM_RE="${REAP_COMM_RE:-^(cmake|gmake|make|cc1plus|cc1|cc|c\+\+)$}"
+# cwd/argv must match this to be a CI build tree. Defaults to the CodeQL build
+# dir from the incident; widen to '_work/.*/build' to cover all CI builds.
+REAP_PATH_RE="${REAP_PATH_RE:-_work/.*build_codeql}"
+# orphan-root parent pid. Kernel reparents orphans to 1 (init); no subreaper
+# sits in the runner tree. Override only if a host installs a subreaper.
+REAP_ROOT_PPID="${REAP_ROOT_PPID:-1}"
+# age floor in seconds (belt-and-suspenders vs a just-reparented transient).
+REAP_MIN_AGE="${REAP_MIN_AGE:-900}"
+REAP_SPOOL="${REAP_SPOOL:-$HOME/.local/state/runner-orphan-reaper/reaped.jsonl}"
+REAP_ALERT_MAILTO="${REAP_ALERT_MAILTO:-}"   # empty => journal + spool only
+HOST="$(hostname -s 2>/dev/null || hostname)"
+
+log() { printf '%s [orphan-reaper:%s] %s\n' "$(date -u +%FT%TZ)" "$HOST" "$*"; }
+
+# Walk PID -> pid 1. Return 0 if a Runner.Worker is found as an ancestor.
+has_worker_ancestor() {
+  local pid="$1" ppid comm
+  while [ -n "$pid" ] && [ "$pid" -gt 1 ]; do
+    read -r ppid comm < <(ps -o ppid=,comm= -p "$pid" 2>/dev/null || true)
+    [ -z "${ppid:-}" ] && break
+    case "$comm" in Runner.Worker*) return 0 ;; esac
+    pid="$ppid"
+  done
+  return 1
+}
+
+# All descendant pids of $1, deepest-last (BFS over the ppid map snapshot).
+descendants() {
+  local root="$1" queue="$1" out="" p child
+  # snapshot pid<space>ppid once so the tree does not shift under us
+  local map; map="$(ps -eo pid=,ppid=)"
+  while [ -n "$queue" ]; do
+    p="${queue%% *}"; queue="${queue#$p}"; queue="${queue# }"
+    while read -r pid ppid; do
+      [ "$ppid" = "$p" ] || continue
+      out="$out $pid"; queue="$queue $pid"
+    done <<< "$map"
+  done
+  echo "$out"
+}
+
+emit_alert() {
+  local root="$1" comm="$2" age="$3" cwd="$4" nkilled="$5" mode="$6"
+  local ts; ts="$(date -u +%FT%TZ)"
+  mkdir -p "$(dirname "$REAP_SPOOL")"
+  # hand-built JSON (no jq dependency on the runner host)
+  printf '{"ts":"%s","host":"%s","action":"%s","root_pid":%s,"comm":"%s","age_s":%s,"cwd":"%s","descendants_killed":%s}\n' \
+    "$ts" "$HOST" "$mode" "$root" "$comm" "$age" "$cwd" "$nkilled" >> "$REAP_SPOOL"
+  local subject body
+  subject="[reap] orphaned CI build reaped on ${HOST} (pid ${root} ${comm})"
+  body=$(printf 'host=%s\nmode=%s\nroot_pid=%s comm=%s age_s=%s\ncwd=%s\ndescendants_killed=%s\nspool=%s\n' \
+    "$HOST" "$mode" "$root" "$comm" "$age" "$cwd" "$nkilled" "$REAP_SPOOL")
+  log "ALERT $subject"
+  printf '%s\n\n%s\n' "$subject" "$body" | systemd-cat -t runner-orphan-reaper -p warning 2>/dev/null || true
+  if [ -n "$REAP_ALERT_MAILTO" ]; then
+    if command -v mail >/dev/null 2>&1; then
+      printf '%s\n' "$body" | mail -s "$subject" "$REAP_ALERT_MAILTO" 2>/dev/null \
+        && log "alert mailed to $REAP_ALERT_MAILTO" || log "WARN inline mail failed; spool retained"
+    elif command -v sendmail >/dev/null 2>&1; then
+      { printf 'To: %s\nSubject: %s\n\n%s\n' "$REAP_ALERT_MAILTO" "$subject" "$body"; } \
+        | sendmail -t 2>/dev/null && log "alert sendmail'd to $REAP_ALERT_MAILTO" \
+        || log "WARN inline sendmail failed; spool retained"
+    else
+      log "no local mailer; alert left on spool for ci-steward heartbeat forward"
+    fi
+  fi
+}
+
+reap_one() {
+  local root="$1" comm="$2" age="$3" cwd="$4"
+  # FINAL safety gate before any signal: refuse if a Worker ancestor exists.
+  if has_worker_ancestor "$root"; then
+    log "SKIP pid=$root ($comm): live Runner.Worker ancestor -- NOT an orphan"
+    return 0
+  fi
+  local kids; kids="$(descendants "$root")"
+  local nkids; nkids="$(printf '%s\n' $kids | grep -c . || true)"
+  if [ "$DRY_RUN" = 1 ]; then
+    log "DRY-RUN would reap root=$root ($comm) age=${age}s cwd=$cwd descendants=[$kids ]"
+    return 0
+  fi
+  log "REAP root=$root ($comm) age=${age}s cwd=$cwd descendants_count=$nkids"
+  kill -STOP "$root" 2>/dev/null || true      # freeze the root: no new children
+  # shellcheck disable=SC2086
+  [ -n "$kids" ] && kill -KILL $kids 2>/dev/null || true
+  kill -KILL "$root" 2>/dev/null || true
+  emit_alert "$root" "$comm" "$age" "$cwd" "$nkids" "reap"
+}
+
+main() {
+  local found=0
+  # pid ppid etimes comm  -- filter to ppid==ROOT_PPID, comm in set, age>=floor
+  while read -r pid ppid etimes comm; do
+    [ "$ppid" = "$REAP_ROOT_PPID" ] || continue
+    [[ "$comm" =~ $REAP_COMM_RE ]] || continue
+    [ "${etimes:-0}" -ge "$REAP_MIN_AGE" ] || continue
+    # cwd (symlink) OR argv must sit under the CI build path.
+    local cwd cmd hay
+    cwd="$(readlink -f "/proc/$pid/cwd" 2>/dev/null || true)"
+    cmd="$(tr "\0" " " < "/proc/$pid/cmdline" 2>/dev/null || true)"
+    hay="$cwd $cmd"
+    [[ "$hay" =~ $REAP_PATH_RE ]] || continue
+    found=$((found + 1))
+    reap_one "$pid" "$comm" "$etimes" "${cwd:-?}"
+  done < <(ps -eo pid=,ppid=,etimes=,comm=)
+  [ "$found" = 0 ] && log "clean: no orphaned CI build trees (ppid=$REAP_ROOT_PPID, path~$REAP_PATH_RE)"
+  return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Problem
On .198 (2026-08-02) a Runner.Worker died mid-job at a ~10-min zero-step with no logs. Its build children (cmake/make/cc1plus/cc/c++) were reparented to `ppid=1` and kept running, pegging load ~8 and starving the runner pool. vm-fleet-steward reaped it by hand. This recurs; hand-reaping does not scale across .198 / VM905 / 198-2 / 198-3.

## What this adds
- `scripts/ci/runner-orphan-reaper-linux.sh` — detects a build-toolchain process with `ppid=1`, cwd/argv under `_work/.../build_codeql`, older than 15 min, with no live Runner.Worker ancestor; then `kill -STOP` the root, SIGKILL the descendant set, SIGKILL the root. Logs to journal + a JSONL spool; optional inline mail.
- `deploy/systemd/c2pool-runner-orphan-reaper.{service,timer}` — oneshot on a ~10-min user timer.
- `deploy/systemd/c2pool-runner-orphan-reaper.README.md` — per-host install (.198 primary, then VM905/198-2/198-3) + safe rehearsal.

## Acceptance criteria mapping
1. Periodic ~10-min check via systemd timer — `OnUnitActiveSec=10min`.
2. Detect `ppid=1` + comm in {cmake,gmake,make,cc1plus,cc,c++} + under `_work/.../build_codeql` + no Runner.Worker.
3. False-positive guard — ppid=1 is the disqualifier (an orphan has no Worker ancestor by construction) + explicit ancestor walk + >15-min age floor.
4. `kill -STOP` root, kill descendants, journal + spool + decisions@ alert on each kill.
5. HARD: never touch a tree under a live Runner.Worker — enforced by the ppid=1 test and a re-checked ancestor walk immediately before any signal.

## Design note (refinement of criterion 2)
The gate is ppid=1 + no-Worker-ancestor, not "no Runner.Worker exists anywhere on the host". The loose host-global form would never fire on a busy multi-runner host (VM905 = 8 runners); a busy sibling runner's compilers are children of its live Worker and are never ppid=1, so they are never candidates. This keeps the guard safe and functional on the pool.

## Validation
- `bash -n` clean; `--dry-run` on a clean host reports no orphans.
- Synthetic orphan (renamed `sleep` as `cmake` under `_work/.../build_codeql`, reparented to init via `setsid --fork`): detected at `REAP_MIN_AGE=0`, and correctly skipped under the default 900s age floor (too young). No live process was signalled during testing.

Tunables (`REAP_PATH_RE`, `REAP_COMM_RE`, `REAP_MIN_AGE`, `REAP_ROOT_PPID`, `REAP_ALERT_MAILTO`) are env-overridable; default `REAP_PATH_RE` matches the CodeQL incident and widens to `_work/.*/build` in one line.

Not self-merging — awaiting review + push-approval.
