### PR TITLE
dash(embedded): bridge replay applies PoSe removals, not only additions

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -3570,6 +3570,27 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     }
                     return std::nullopt;
                 });
+            // SML REMOVAL pass — the whole list, not one hash at a time. The
+            // per-hash seam above can only answer a question about a
+            // masternode the projection already surfaced; a PoSe REMOVAL has
+            // to be applied before that masternode is ever projected, which
+            // means sweeping the list once per replayed height. Measured on
+            // mainnet 2026-08-02 over 2513000..2514874: the chain's
+            // payee-eligible set fell 2068 -> 2059 while a replay with no
+            // removal pass CLIMBED 2067 -> 2070, because a block replay can
+            // only ever ADD (PoSe bans are consensus-derived, never txs).
+            //
+            // Same thread as everything else the lane touches: the SML is
+            // updated on the mnlistdiff ingest leg and read here from the
+            // block-connect / tip-changed callbacks, all on the single
+            // io_context thread main_dash runs. No lock is taken or needed,
+            // and the returned pointer never escapes the call.
+            mn_ckpt_lane->set_sml_snapshot_fn(
+                [&node_coin_state]()
+                    -> const dash::coin::vendor::CSimplifiedMNList* {
+                    if (!node_coin_state.have_sml()) return nullptr;
+                    return &node_coin_state.sml();
+                });
             // Publish through the EXACT leg-4 event the E2c RPC seed uses, so
             // CoinStateMaintainer::on_mn_list_update takes the bridged set as
             // an ordinary authoritative resync — snapshot fence set to the
@@ -3608,6 +3629,18 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     (const dash::interfaces::BlockConnected& bc) {
                         mnl->on_block_connected(bc.block, bc.height);
                     }));
+
+            // KNOWN GAP, deliberately left: this branch arms the lane and
+            // sets NO maintainer->set_on_mn_reseed() callback (the RPC branch
+            // above does). If the maintainer later wipes a desynced payee
+            // queue it has nothing to ask for a fresh authoritative set, so
+            // the embedded arm stays demoted until restart. Filling that seam
+            // is real work and depends on what fills it — a re-armed bridge
+            // from a NEWER anchor is the obvious candidate and is exactly the
+            // wrong-axis trap the anchor-selection TODO in
+            // mn_checkpoint_lane.hpp describes (an anchor cut after the
+            // divergence began replays cleanly and re-arms a wrong queue).
+            // Not wired here rather than wired wrongly.
 
             // Kick the lane once now in case the header chain is already past
             // the anchor from a previous run's persisted header DB.

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -3570,15 +3570,25 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     }
                     return std::nullopt;
                 });
-            // SML REMOVAL pass — the whole list, not one hash at a time. The
-            // per-hash seam above can only answer a question about a
-            // masternode the projection already surfaced; a PoSe REMOVAL has
-            // to be applied before that masternode is ever projected, which
-            // means sweeping the list once per replayed height. Measured on
-            // mainnet 2026-08-02 over 2513000..2514874: the chain's
-            // payee-eligible set fell 2068 -> 2059 while a replay with no
-            // removal pass CLIMBED 2067 -> 2070, because a block replay can
-            // only ever ADD (PoSe bans are consensus-derived, never txs).
+            // WHOLESALE SML PoSe FOLD seam — the whole list PLUS the height
+            // it is current at. The per-hash seam above can only answer a
+            // question about a masternode the projection already surfaced,
+            // and the walk behind it adjudicates ONE exclusion per height
+            // with an exact coinbase script match required at every step.
+            // That is proven to work for ISOLATED bans (mainnet 2026-08-02:
+            // it succeeded five times during the replay) and proven NOT to
+            // work for a BURST — the same chain put THREE masternodes out of
+            // `protx list valid` inside 73 blocks (2062 -> 2059 over
+            // 2514800..2514873) and the bridge fail-closed. A wholesale fold
+            // removes all three in one pass, which is what makes a burst
+            // indistinguishable from a single ban.
+            //
+            // The HEIGHT half is mandatory, not decoration: the lane folds
+            // ONLY when its apply cursor equals this height (never earlier —
+            // an early fold can silently publish a wrong queue inside a
+            // shared-payoutAddress group), and it gates the walk's
+            // attestations so a STALE SML cannot license a permanent
+            // demotion of a since-revived masternode.
             //
             // Same thread as everything else the lane touches: the SML is
             // updated on the mnlistdiff ingest leg and read here from the
@@ -3586,11 +3596,15 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             // io_context thread main_dash runs. No lock is taken or needed,
             // and the returned pointer never escapes the call.
             mn_ckpt_lane->set_sml_snapshot_fn(
-                [&node_coin_state]()
-                    -> const dash::coin::vendor::CSimplifiedMNList* {
-                    if (!node_coin_state.have_sml()) return nullptr;
-                    return &node_coin_state.sml();
+                [&node_coin_state, m = maintainer.get()]()
+                    -> dash::coin::MnCheckpointLane::SmlSnapshot {
+                    dash::coin::MnCheckpointLane::SmlSnapshot snap;
+                    if (!node_coin_state.have_sml()) return snap;
+                    snap.list   = &node_coin_state.sml();
+                    snap.height = m ? m->sml_current_height() : 0;
+                    return snap;
                 });
+
             // Publish through the EXACT leg-4 event the E2c RPC seed uses, so
             // CoinStateMaintainer::on_mn_list_update takes the bridged set as
             // an ordinary authoritative resync — snapshot fence set to the

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -3063,8 +3063,12 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
 
             // DEMUX: route the source's HISTORICAL getmnlistd replies away from
             // the tip-SML maintainer (a base=ZERO snapshot would overwrite it).
+            // ADDITIVE, not a slot: the MN-checkpoint lane registers its own
+            // filter below for the per-height PoSe fold, and both consumers
+            // must be offered every reply (a fold point can coincide with a
+            // quorum work block, and then ONE reply answers BOTH awaits).
             if (coin_p2p) {
-                coin_p2p->set_historical_mnlistdiff_filter(
+                coin_p2p->add_historical_mnlistdiff_filter(
                     [qc_member_source]
                     (const dash::coin::vendor::CSimplifiedMNListDiff& d) {
                         return qc_member_source->on_mnlistdiff(d);
@@ -3603,6 +3607,50 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             // block-connect / tip-changed callbacks, all on the single
             // io_context thread main_dash runs. No lock is taken or needed,
             // and the returned pointer never escapes the call.
+            // PER-HEIGHT PoSe FOLD seams. The lane asks for the masternode
+            // list AS OF the height its replay cursor is standing on, using
+            // the SAME getmnlistd primitive quorum_member_source.hpp already
+            // uses for historical member sets. This is what makes
+            // cursor == H_sml true BY CONSTRUCTION instead of by luck: the tip
+            // SML runs ahead of a catching-up replay, so waiting for the two
+            // to coincide loses the race at exactly the heights that matter.
+            //
+            // WIRED AS A PAIR OR NOT AT ALL. The request seam and the reply
+            // demux are two halves of one round trip: a lane that can ask but
+            // never be answered would PAUSE its replay on the first fold point
+            // and never resume. So both are installed inside the same
+            // `if (coin_p2p)` — with no coin-P2P client there is no request
+            // seam either, and the lane degrades to the additions-only replay
+            // plus the per-mismatch walk and says so in status().
+            if (coin_p2p) {
+                auto* cp = coin_p2p.get();
+                mn_ckpt_lane->set_request_snapshot_fn(
+                    [cp](const uint256& block_hash) {
+                        cp->send_getmnlistd(uint256::ZERO, block_hash);
+                    });
+                // DEMUX (reward-critical): the reply comes back on the SAME
+                // mnlistdiff message the tip sync uses. Routed here it is
+                // consumed as historical and the LIVE tip SML is never
+                // touched; routed to the maintainer it would silently rewrite
+                // the tip SML to the replayed (past) height — on the money
+                // path. See historical_sml.hpp.
+                coin_p2p->add_historical_mnlistdiff_filter(
+                    [mnl = mn_ckpt_lane.get()]
+                    (const dash::coin::vendor::CSimplifiedMNListDiff& d) {
+                        return mnl->on_historical_snapshot(d);
+                    });
+            }
+            // The DIP-4 trust anchor: our own PoW-validated header's merkle
+            // root. Without it a snapshot cannot be authenticated and the lane
+            // refuses to fold at all.
+            mn_ckpt_lane->set_merkle_root_at_fn(
+                [hc = header_chain.get()](const uint256& block_hash)
+                    -> std::optional<uint256> {
+                    // The SAME lookup QuorumMemberSource's R3 anchor uses.
+                    if (auto e = hc->get_header(block_hash))
+                        return e->header.m_merkle_root;
+                    return std::nullopt;
+                });
             mn_ckpt_lane->set_sml_snapshot_fn(
                 [&node_coin_state, m = maintainer.get()]()
                     -> dash::coin::MnCheckpointLane::SmlSnapshot {

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -2636,6 +2636,14 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 node_coin_state.sml() = std::move(loaded_sml);
                 node_coin_state.set_have_sml(node_coin_state.sml().size() != 0);
                 node_coin_state.set_sml_current_hash(sml_db->get_best_hash());
+                // F1: restore the HEIGHT the warm SML is current at, not just
+                // the list. Without this m_sml_current_height stayed 0 while
+                // have_sml() was true, and every freshness check keyed on it
+                // passed vacuously — a masternode banned before the persisted
+                // tip and revived after it could be permanently demoted at a
+                // height the chain held it valid. Mirrors restore_credit_pool()
+                // immediately below, which exists for the same reason.
+                maintainer->restore_sml_height(sml_db->get_best_height());
                 *sml_base = sml_db->get_best_hash();  // handshake -> incremental
                 LOG_INFO << "[SML-DB] WARM restart: SML(" << node_coin_state.sml().size()
                          << ") + quorums(" << node_coin_state.qmgr().active_count()
@@ -3601,7 +3609,15 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     dash::coin::MnCheckpointLane::SmlSnapshot snap;
                     if (!node_coin_state.have_sml()) return snap;
                     snap.list   = &node_coin_state.sml();
-                    snap.height = m ? m->sml_current_height() : 0;
+                    // F2: report the height ONLY while it is paired with the
+                    // list actually held. A diff can advance the list without
+                    // advancing the height (unparseable cbTx is not a
+                    // rejection), and folding a list that describes H2 at
+                    // cursor H1 is the EARLY case. Unpaired -> no height, which
+                    // both suppresses the fold and downgrades every walk
+                    // attestation to "no opinion".
+                    snap.height = (m && m->sml_height_paired())
+                                      ? m->sml_current_height() : 0;
                     return snap;
                 });
 

--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -840,6 +840,14 @@ public:
     void set_require_seeded_mn_set(bool on) { m_require_seeded_mn = on; }
     bool require_seeded_mn_set() const { return m_require_seeded_mn; }
 
+    /// Height the applied SML/quorum state is current AT (0 = none yet),
+    /// tracked off each accepted mnlistdiff's cbTx.nHeight. Read-only;
+    /// exposed so the daemonless MN-set bridge can (a) fold the SML's PoSe
+    /// verdicts at the ONE cursor position where a wholesale fold is valid,
+    /// and (b) refuse a demotion attested by an SML older than the height
+    /// being adjudicated. See MnCheckpointLane::maybe_fold_sml().
+    uint32_t sml_current_height() const { return m_sml_current_height; }
+
     /// Wire the authoritative MN re-seed sink (main_dash points this at the
     /// E2c `protx list valid true` seed fetch when a coin RPC is configured).
     /// Invoked from on_block_connected's payee-desync fail-closed path AFTER

--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -329,8 +329,10 @@ public:
         m_mn_snapshot_height = as_of_height;
         // An authoritative (non-empty) resync clears the payee-desync latch:
         // the queue is trustworthy again from this snapshot forward.
-        if (m_have_mn)
+        if (m_have_mn) {
             m_mn_needs_reseed = false;
+            m_state.set_mn_needs_reseed(false);
+        }
         // as_of_height also seeds the machine's forward-contiguous apply
         // cursor (E4 re-soak fix): the snapshot IS the payment queue as of
         // that block, so only as_of+1 may fold next; a later block reports
@@ -792,6 +794,7 @@ public:
             // block would register into the wiped set and republish a 1-MN
             // "queue" — a guessed payee by another name.
             m_mn_needs_reseed = true;
+            m_state.set_mn_needs_reseed(true);   // MAKE THE STATE SAY ITS NAME
             demote();
             notify_state_dirty();
             if (m_on_mn_reseed) m_on_mn_reseed();

--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -471,6 +471,16 @@ public:
         //    diff.mnList, and re-sorts by proRegTxHash (memcmp order — the
         //    Bug-A-critical ordering, already pinned by test_dash_simplifiedmns).
         auto sml_r = vendor::apply_diff(m_state.sml(), diff);
+        // F2: the list has just advanced to diff.blockHash UNCONDITIONALLY,
+        // but m_sml_current_height advances only if this diff's cbTx parses as
+        // a type-5 CCbTx with nHeight > 0 (below). An unparseable cbTx is NOT a
+        // rejection — the diff still applies — so the pair (list, height) can
+        // silently desynchronise, leaving a consumer folding a list that
+        // describes H2 at cursor H1. A peer can trigger that deliberately and
+        // choose H1. Break the pairing here and let the height branch below
+        // re-establish it; consumers that need the two to agree read
+        // sml_height_paired() and treat "unpaired" as "no height at all".
+        m_sml_height_paired = false;
 
         // 2) Quorum set (merkleRootQuorums) — tail already parsed clean above.
         auto qr = m_state.qmgr().apply(qt);
@@ -489,9 +499,13 @@ public:
                 // state is now current at (authoritative off the diff's own
                 // cbTx). Monotone by construction: incrementals ride the
                 // base-continuity guard, full snapshots the R1 guard above.
-                if (observed.nHeight > 0)
+                if (observed.nHeight > 0) {
                     m_sml_current_height =
                         static_cast<uint32_t>(observed.nHeight);
+                    // The height now describes THIS list, at this application
+                    // point. This is the only place the pair is valid.
+                    m_sml_height_paired = true;
+                }
                 if (observed.nVersion >= vendor::CCbTx::VERSION_CLSIG_AND_BALANCE) {
                     // Seed with the cbTx's OWN nHeight (authoritative off the
                     // wire) as the seed height — the independent freshness key.
@@ -630,6 +644,7 @@ public:
         // heights may legitimately be at/below the old ones — the cold
         // full-snapshot resync must not be blocked by the stale-guard.
         m_sml_current_height = 0;
+        m_sml_height_paired  = false;
         // Invalidate the credit-pool seed's freshness too (height -1 != any tip),
         // so the arm fails closed on the credit-pool axis until a fresh re-seed.
         m_state.set_credit_pool(0, uint256::ZERO, -1);
@@ -847,6 +862,25 @@ public:
     /// and (b) refuse a demotion attested by an SML older than the height
     /// being adjudicated. See MnCheckpointLane::maybe_fold_sml().
     uint32_t sml_current_height() const { return m_sml_current_height; }
+
+    /// Whether m_sml_current_height actually describes the SML currently held.
+    /// FALSE after a diff advanced the list without a parseable type-5 cbTx to
+    /// advance the height with it (F2). A consumer that pairs the two — the
+    /// daemonless bridge folds a list AT a height — must treat an unpaired
+    /// height as NO height, not as a stale-but-usable one: folding a list that
+    /// describes H2 at cursor H1 is the EARLY case, off by H2-H1 blocks, whose
+    /// worst outcome is a script-invisible wrong-queue publish.
+    bool sml_height_paired() const { return m_sml_height_paired; }
+
+    /// Warm-restart restore (F1). main_dash loads a persisted SML and its
+    /// height from SMLDb; without this the height stayed 0 while have_sml()
+    /// was true, so every freshness check keyed on it silently passed. Mirrors
+    /// restore_credit_pool(), which already exists for the same reason.
+    void restore_sml_height(uint32_t h)
+    {
+        m_sml_current_height = h;
+        m_sml_height_paired  = (h != 0);
+    }
 
     /// Wire the authoritative MN re-seed sink (main_dash points this at the
     /// E2c `protx list valid true` seed fetch when a coin RPC is configured).
@@ -1138,6 +1172,10 @@ private:
     // off each accepted diff's cbTx.nHeight — the freshness key the #814 R1
     // stale-ZERO-base-snapshot guard compares against.
     uint32_t m_sml_current_height{0};
+
+    // Whether m_sml_current_height describes the SML currently held — see
+    // sml_height_paired(). Starts FALSE: a cold maintainer has no height.
+    bool m_sml_height_paired{false};
 
     // Height the last MN-set snapshot was current at (0 = none/unknown);
     // on_block_connected skips re-applying blocks at or below it.

--- a/src/impl/dash/coin/historical_sml.hpp
+++ b/src/impl/dash/coin/historical_sml.hpp
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// DIP-4 client verification of a HISTORICAL Simplified Masternode List
+/// snapshot, shared by every consumer that sources an SML at a height other
+/// than the tip.
+///
+/// ─────────────────────────────────────────────────────────────────────────
+/// WHY THIS IS A SHARED FUNCTION AND NOT A METHOD
+/// ─────────────────────────────────────────────────────────────────────────
+/// There are now two consumers of `getmnlistd(ZERO, <historical block>)`:
+///
+///   • quorum_member_source.hpp — the ordered operator-key set as of a
+///     quorum's WORK block (#814 R3);
+///   • mn_checkpoint_lane.hpp — the PoSe-validity view as of a REPLAYED
+///     block, so the daemonless bridge can fold removals at the exact height
+///     they apply to.
+///
+/// Both are on the reward path and both are trusting a peer-supplied list, so
+/// both need the identical authentication. Two copies of that check would be
+/// two places for it to rot; this is the one implementation.
+///
+/// ─────────────────────────────────────────────────────────────────────────
+/// WHAT IS PROVEN (and why a snapshot may be believed at all)
+/// ─────────────────────────────────────────────────────────────────────────
+/// A lying peer can serve any list it likes. What it cannot forge is the
+/// PoW-validated header chain we already hold. So:
+///
+///   (a) the reply's embedded cbTx is a coinbase special-tx (type-5 CCbTx),
+///       parses, and its nHeight equals the height we asked about — a peer
+///       cannot satisfy the request with a different, even genuine, block;
+///   (b) `cbTxMerkleTree` proves that cbTx's hash into the block header's
+///       hashMerkleRoot at tx index 0 (the coinbase position) — and that
+///       header is PoW-verified by our own HeaderChain;
+///   (c) the SML rebuilt from the snapshot hashes to `cbTx.merkleRootMNList`.
+///
+/// Chained, that means: the returned list IS the deterministic masternode
+/// list that consensus committed to in the coinbase of that exact block. It
+/// is not "a list a peer sent"; it is dated, committed and header-anchored.
+///
+/// ANY failure returns std::nullopt. There is no partial acceptance — a
+/// half-authenticated masternode set projects a wrong payee, and a wrong
+/// payee is a coinbase the network rejects.
+
+#include <impl/dash/coin/utxo_adapter.hpp>            // dash_txid
+#include <impl/dash/coin/vendor/cbtx.hpp>             // CCbTx, parse_cbtx
+#include <impl/dash/coin/vendor/simplifiedmns.hpp>    // CSimplifiedMNList
+#include <impl/dash/coin/vendor/smldiff.hpp>          // CSimplifiedMNListDiff, apply_diff
+
+#include <core/log.hpp>
+#include <core/uint256.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace dash {
+namespace coin {
+
+/// The PoW-verified header's hashMerkleRoot for a held block hash, or nullopt
+/// when the header is not held. This is the trust anchor for step (b).
+using MerkleRootOfHashFn =
+    std::function<std::optional<uint256>(const uint256&)>;
+
+/// Authenticate a historical full snapshot (base == ZERO) and return the SML
+/// it commits to.
+///
+/// `expected_height` is the height the CALLER asked about; binding it here is
+/// what stops a peer answering with some other block's genuine snapshot.
+/// `tag` only names the consumer in the log line.
+inline std::optional<vendor::CSimplifiedMNList>
+authenticate_historical_snapshot(const vendor::CSimplifiedMNListDiff& diff,
+                                 uint32_t expected_height,
+                                 const MerkleRootOfHashFn& merkle_root_of_hash,
+                                 vendor::CCbTx& cbtx_out,
+                                 const char* tag)
+{
+    auto fail = [&](const char* why) -> std::optional<vendor::CSimplifiedMNList> {
+        LOG_WARNING << "[" << tag << "] historical snapshot AUTH FAILED ("
+                    << why << ") for block "
+                    << diff.blockHash.GetHex().substr(0, 16)
+                    << " at expected h=" << expected_height
+                    << " — fail closed";
+        return std::nullopt;
+    };
+
+    // (a) cbTx: coinbase, special-tx type 5, parseable, height bound to the
+    // request.
+    if (diff.cbTx.type != 5 || diff.cbTx.extra_payload.empty())
+        return fail("cbTx not a type-5 CbTx");
+    if (!vendor::parse_cbtx(diff.cbTx.extra_payload, cbtx_out))
+        return fail("cbTx payload unparseable");
+    if (expected_height == 0 || cbtx_out.nHeight < 0
+        || static_cast<uint32_t>(cbtx_out.nHeight) != expected_height)
+        return fail("cbTx height != expected height");
+
+    // (b) merkle proof against the PoW-verified header.
+    auto header_root = merkle_root_of_hash(diff.blockHash);
+    if (!header_root || header_root->IsNull())
+        return fail("block header not held");
+    std::vector<uint256>      matches;
+    std::vector<unsigned int> match_idx;
+    const uint256 proof_root = diff.cbTxMerkleTree.ExtractMatches(matches, match_idx);
+    if (proof_root.IsNull() || proof_root != *header_root)
+        return fail("cbTxMerkleTree root != header merkle root");
+    const uint256 cbtx_hash = dash_txid(diff.cbTx);
+    if (matches.size() != 1 || match_idx.size() != 1 || match_idx[0] != 0
+        || matches[0] != cbtx_hash)
+        return fail("cbTx not proven at coinbase position");
+
+    // (c) SML root commitment.
+    vendor::CSimplifiedMNList sml;
+    vendor::apply_diff(sml, diff);   // base == ZERO: apply onto empty
+    if (sml.CalcMerkleRoot() != cbtx_out.merkleRootMNList)
+        return fail("SML root != cbTx.merkleRootMNList");
+
+    return sml;
+}
+
+/// ─────────────────────────────────────────────────────────────────────────
+/// THE DEMUX (reward-critical)
+/// ─────────────────────────────────────────────────────────────────────────
+/// There is exactly ONE mnlistdiff message type on the wire, and it carries
+/// two utterly different things depending on who asked for it:
+///
+///   • a TIP-sync diff, which the CoinStateMaintainer applies to the LIVE SML
+///     the block template is validated against;
+///   • a HISTORICAL full snapshot (base == ZERO at an old block), which some
+///     consumer asked for in order to read the past.
+///
+/// The maintainer treats ANY base==ZERO diff as a full snapshot and adopts it
+/// wholesale. So a historical reply reaching it REWRITES THE LIVE TIP SML TO A
+/// PAST STATE — silently, on the money path. That is the corruption this class
+/// exists to prevent, and it is why consumption is decided BEFORE the tip feed
+/// is ever called.
+///
+/// There is now more than one historical consumer (QuorumMemberSource and the
+/// MnCheckpointLane), so this is a CHAIN rather than a single slot — and it is
+/// deliberately NOT short-circuiting. Two consumers may legitimately await the
+/// SAME block hash (a bridge fold point can coincide with a quorum work
+/// block); the reply is immutable, so both may take it. Short-circuiting would
+/// leave whichever filter sits later in the chain waiting forever on a reply
+/// that had already arrived and been swallowed.
+///
+/// Consumption is decided by ANY filter claiming the reply. A claim is a claim
+/// even when that consumer then REFUSES the content (authentication failure):
+/// the reply was still an answer to a historical request, and still must not
+/// reach the tip.
+class HistoricalMnListDiffDemux {
+public:
+    /// Returns true iff the diff answered THIS consumer's outstanding request.
+    using Filter = std::function<bool(const vendor::CSimplifiedMNListDiff&)>;
+    /// Hand a tip-sync diff on to the live SML maintainer.
+    using TipFeed = std::function<void(const vendor::CSimplifiedMNListDiff&)>;
+
+    void add_filter(Filter f)
+    {
+        if (f) m_filters.push_back(std::move(f));
+    }
+    size_t filter_count() const { return m_filters.size(); }
+
+    /// Route one reply. Returns true when it was consumed as HISTORICAL, in
+    /// which case `tip_feed` was NOT called.
+    bool dispatch(const vendor::CSimplifiedMNListDiff& diff,
+                  const TipFeed& tip_feed) const
+    {
+        bool consumed = false;
+        // NOT short-circuiting, on purpose — see the class comment. Every
+        // filter is offered every reply.
+        for (const auto& f : m_filters) {
+            if (f(diff)) consumed = true;
+        }
+        if (consumed) return true;
+        if (tip_feed) tip_feed(diff);
+        return false;
+    }
+
+private:
+    std::vector<Filter> m_filters;
+};
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -90,48 +90,84 @@
 /// into this lane.
 ///
 /// ─────────────────────────────────────────────────────────────────────────
-/// POST-ANCHOR PoSe BANS, AND THE TWO RESIDUALS THAT REMAIN
+/// POST-ANCHOR PoSe BANS — THE REPLAY APPLIES REMOVALS, NOT ONLY ADDITIONS
 /// ─────────────────────────────────────────────────────────────────────────
-/// The falsification test above has one structural blind spot. A PoSe ban is
-/// applied by dashd from CONSENSUS (accumulated MAX_PoSe_PENALTY), never as a
-/// special transaction. MnStateMachine::apply_block walks special txs, so it
-/// cannot observe one at any price. A masternode banned AFTER the anchor
-/// height therefore stays isValid=true in the replay, keeps its place at the
-/// head of our payment queue, and is projected as the payee for a block dashd
-/// paid to somebody else — payee_desync, which here is TERMINAL. One such ban
-/// anywhere in the replay window permanently prevents the daemonless arm from
-/// publishing a masternode set at all.
+/// A PoSe ban is applied by dashd from CONSENSUS (accumulated
+/// MAX_PoSe_PENALTY), never as a special transaction. MnStateMachine::
+/// apply_block walks special txs, so a block replay is STRUCTURALLY incapable
+/// of observing one: it can only ever ADD.
 ///
-/// The Simplified Masternode List is the only carrier of that ban, so the lane
-/// exposes set_sml_validity_fn() and hands it to its private machine. On a
-/// payee mismatch the machine may walk down the ranked queue, but ONLY while
-/// each demoted candidate is ATTESTED INVALID by the SML and the accepted
-/// candidate's scriptPayout EXACTLY matches an output this block pays. Any
-/// step that cannot satisfy both reports payee_desync exactly as before. The
-/// walk is capped per bridge (see pump()), every event logs at WARNING, and
-/// the running count is surfaced in status() and in the publish line — a
-/// count that lives only in scrollback is half-silent, and this file exists
-/// to prevent silent degradation.
+/// MEASURED, mainnet, hotel dashd 23.1.7, 2026-08-02, anchor 2513000 -> tip
+/// 2514874:
 ///
-/// TWO RESIDUALS, stated honestly:
+///     protx list valid false 2513000   -> 2068 entries
+///     protx list valid false 2514874   -> 2059 entries   the chain FELL by 9
+///     this bridge's replayed set        2067 -> 2070      we CLIMBED by 3
 ///
-///  (a) A masternode banned AND revived entirely inside the replay window,
-///      whose CURRENT SML entry therefore reads isValid==true, still fails
-///      closed. The SML is a snapshot of NOW; it cannot attest a historical
-///      ban, and an attested-valid answer is treated as counter-evidence (it
-///      must be — that is what stops the walk from excusing a real desync).
-///      This is exactly today's behaviour for that case, not worse.
+/// The bridge fail-closed at h=2514874 having projected a masternode that the
+/// chain had PoSe-banned inside the window (still `registered`, no longer
+/// `valid`). Correct refusal, wrong set.
 ///
-///  (b) A post-anchor ban INSIDE a shared-payoutAddress group can escape both
-///      the cross-check and this recovery, because both are SCRIPT-granular:
-///      if the banned MN and the MN dashd actually paid share one payout
-///      address, the coinbase output still matches our projected script, the
-///      mismatch never fires, and the payment is attributed to the wrong
-///      member of the group. That is a PRE-EXISTING blind spot in the
-///      projection cross-check (the same granularity the gap_detected note in
-///      mn_state_machine.hpp calls out), not something this recovery
-///      introduces — the recovery only ever runs when the cross-check already
-///      failed.
+/// The Simplified Masternode List is the only carrier of that ban, and we
+/// already receive and persist it. There are now TWO seams onto it, and they
+/// do different jobs:
+///
+///   • set_sml_snapshot_fn() — the REMOVAL pass. Once per replayed height,
+///     BEFORE the block is folded, MnStateMachine::reconcile_pose_from_sml()
+///     drops every masternode the SML attests not-valid out of the
+///     payee-eligible set, and lifts a bridge-owned exclusion again if a
+///     refreshed SML attests it valid. This is what stops a banned masternode
+///     ever reaching the head of the queue. The ordering rationale — and why
+///     pre-block is the only correct choice when a registration and a removal
+///     land in the same block — is written out in full at that function.
+///
+///   • set_sml_validity_fn() — the per-hash attestation used by the REACTIVE
+///     demotion walk, which remains as the second line of defence for a ban
+///     the removal pass could not see (no verified SML yet, or an SML older
+///     than the ban). It may walk down the ranked queue, but ONLY while each
+///     demoted candidate is ATTESTED INVALID and the accepted candidate's
+///     scriptPayout EXACTLY matches an output this block pays. The walk is
+///     capped per bridge (see pump()).
+///
+/// Because the SML is a snapshot of NOW rather than of the replayed height, a
+/// removal can be EARLY — the ban may have fallen after the block being
+/// replayed. That is handled explicitly, not hoped away: pass 3's
+/// recover_premature_pose_exclusion() recognises "this block pays a
+/// masternode we excluded, and it outranked our projection", attributes the
+/// payment so the DIP-3 queue cursor stays dashd-identical, and KEEPS the
+/// exclusion.
+///
+/// Every count is surfaced on status(), on the publish line, and on every
+/// fail-closed message (divergence_report()): a count that lives only in
+/// scrollback is half-silent, and this file exists to prevent silent
+/// degradation.
+///
+/// ONE RESIDUAL, stated honestly:
+///
+///   A post-anchor ban INSIDE a shared-payoutAddress group can escape the
+///   coinbase cross-check, because it is SCRIPT-granular: if the banned MN
+///   and the MN dashd actually paid share one payout address, the coinbase
+///   output still matches our projected script, the mismatch never fires, and
+///   the payment is attributed to the wrong member of the group. That is a
+///   PRE-EXISTING blind spot in the projection cross-check (the same
+///   granularity the gap_detected note in mn_state_machine.hpp calls out).
+///   The removal pass narrows it — a banned member is now dropped from the
+///   group before it can be projected — but does not close it.
+///
+/// TODO (separate change, deliberately NOT half-done here): ANCHOR SELECTION
+/// ON REPEAT DESYNC. When a bridge fails closed and the operator re-arms,
+/// picking the NEWEST anchor is wrong: an anchor cut AFTER a divergence began
+/// replays cleanly over a shorter window and re-arms a queue that is already
+/// wrong, which mints a rejected coinbase. The correct policy is oldest-first
+/// on a repeat desync, with capped re-arms + backoff and the compiled-in
+/// checkpoint as the floor. It is not implementable in this file today: this
+/// build carries exactly ONE anchor per network
+/// (src/impl/dash/coin/checkpoints/dash_mn_checkpoint_{mainnet,testnet}.inc,
+/// referenced once from main_dash.cpp), there is no anchor LIST to order and
+/// no persisted desync history to count re-arms against across restarts.
+/// Prerequisites: (1) a multi-anchor checkpoint store keyed by height,
+/// (2) a persisted per-anchor desync counter, (3) an arm()/re-arm API that
+/// takes a candidate list rather than a single MnCheckpoint.
 ///
 /// FENCED: src/impl/dash only. Constructed exclusively by the opt-in embedded
 /// path in main_dash.cpp; the dashd-RPC fallback never touches this file.
@@ -139,6 +175,7 @@
 #include <impl/dash/coin/block.hpp>
 #include <impl/dash/coin/mn_checkpoint.hpp>
 #include <impl/dash/coin/mn_state_machine.hpp>
+#include <impl/dash/coin/vendor/simplifiedmns.hpp>
 
 #include <core/log.hpp>
 #include <core/uint256.hpp>
@@ -174,6 +211,17 @@ public:
     /// MnStateMachine::SmlValidityFn and the residuals note in this file's
     /// header. Wired by main_dash to NodeCoinState::sml() + have_sml().
     using SmlValidityFn = MnStateMachine::SmlValidityFn;
+    /// The WHOLE persisted Simplified Masternode List, or nullptr when this
+    /// node has none yet. This is the seam that carries PoSe REMOVALS: the
+    /// per-hash SmlValidityFn above can only answer questions about a
+    /// masternode we already suspect, whereas the removal pass has to sweep
+    /// the list. Wired by main_dash to NodeCoinState::sml() + have_sml().
+    ///
+    /// Returns a pointer, not a copy: the list is ~3000 entries and the lane
+    /// consults it once per replayed height, on the same io thread that
+    /// updates it (mnlistdiff ingest). No lock is taken or needed; the
+    /// pointer is used and discarded inside one call.
+    using SmlSnapshotFn = std::function<const vendor::CSimplifiedMNList*()>;
 
     enum class State {
         Unarmed,      ///< no checkpoint loaded — the lane does nothing
@@ -210,6 +258,10 @@ public:
         m_has_sml_fn = static_cast<bool>(fn);
         m_machine.set_sml_validity_fn(std::move(fn));
     }
+    /// OPTIONAL, but this is the seam that fixes the measured 2068->2059 vs
+    /// 2067->2070 divergence. Unwired, the replay can still only ADD.
+    void set_sml_snapshot_fn(SmlSnapshotFn fn) { m_sml_snapshot = std::move(fn); }
+    bool has_sml_snapshot_fn() const { return static_cast<bool>(m_sml_snapshot); }
 
     /// Maximum number of blocks the bridge is willing to replay. A checkpoint
     /// further behind the tip than this is treated as STALE and refused: the
@@ -239,6 +291,7 @@ public:
         m_anchor_source = cp.source;
         m_anchor_count  = cp.entries.size();
         m_machine.load(cp.entries, cp.height);
+        m_anchor_eligible = m_machine.eligible_size();
         m_next  = cp.height + 1;
         m_state = State::Waiting;
         m_status = "armed at h=" + std::to_string(cp.height) + " ("
@@ -259,6 +312,19 @@ public:
     /// it IS a degradation of how much of the published set the replay
     /// verified, so it is surfaced here, in status(), and in the publish log.
     size_t   sml_recovered() const { return m_sml_recovered; }
+    /// ── The self-describing divergence counters ───────────────────────────
+    /// A bridge that fails closed used to say "the anchor is wrong, the replay
+    /// is incomplete, or a post-anchor PoSe ban could not be attested" — three
+    /// hypotheses and no measurement. These are the measurement: an operator
+    /// can tell the three apart from the log alone, and can compare
+    /// eligible_size() directly against `protx list valid <h>` on any dashd.
+    size_t   eligible_size()      const { return m_machine.eligible_size(); }
+    size_t   anchor_eligible()    const { return m_anchor_eligible; }
+    size_t   pose_removed()       const { return m_machine.pose_removed_total(); }
+    size_t   pose_reinstated()    const { return m_machine.pose_reinstated_total(); }
+    size_t   pose_premature()     const { return m_machine.pose_premature_total(); }
+    size_t   replay_registered()  const { return m_registered; }
+    size_t   replay_spent()       const { return m_spent; }
     bool     failed_closed() const { return m_state == State::FailedClosed; }
     bool     published()     const { return m_state == State::Published; }
 
@@ -375,6 +441,27 @@ public:
         if (m_state != State::Bridging) return;
         if (height != m_next) return;
 
+        // ── PoSe REMOVAL pass, BEFORE the block is folded ─────────────────
+        // A PoSe ban is consensus-derived, never a transaction, so the block
+        // replay below can only ever ADD masternodes. Measured on mainnet
+        // 2026-08-02 over 2513000..2514874: the chain's payee-eligible set
+        // FELL 2068 -> 2059 while this replay CLIMBED 2067 -> 2070. The SML is
+        // the only carrier of the removals and we already persist it.
+        //
+        // ORDERING — pre-block, and the reasons are in
+        // MnStateMachine::reconcile_pose_from_sml() in full. In short:
+        // dashcore projects height H's payee from the list as of H-1, and
+        // validity is part of that list, so the removal must land before
+        // pass 0 ranks candidates. Pre-block is also the only ordering that
+        // keeps a removal and a registration in the SAME block correct: an MN
+        // registered by block H is not yet in the set here, so H's
+        // reconciliation cannot touch it — which is right, because it was not
+        // in dashd's H-1 list and cannot be H's payee. And pass 1's tx-driven
+        // ban (ProUpRevTx) still lands afterwards at its exact consensus
+        // height, overwriting our provisional one.
+        reconcile_pose(height);
+        if (m_state != State::Bridging) return;   // reconcile can fail closed
+
         const auto r = m_machine.apply_block(block, height);
 
         // The anchor's own falsification test. apply_block already logs the
@@ -385,18 +472,7 @@ public:
             return fail_closed(
                 std::string("bridge replay ")
                 + (r.gap_detected ? "GAP" : "PAYEE DESYNC") + " at h="
-                + std::to_string(height)
-                + " — the pinned masternode-set anchor does not reproduce this"
-                  " block's actual coinbase payee. The anchor is wrong, the"
-                  " replay is incomplete, or a post-anchor PoSe ban could not"
-                  " be attested"
-                + (m_has_sml_fn
-                       ? std::string(" by the SML (absent entry, or attested"
-                                     " VALID because the masternode was banned"
-                                     " AND revived inside the replay window)")
-                       : std::string(" — no SML validity seam is wired"))
-                + ". Refusing to publish a masternode set that would mint a"
-                  " rejected coinbase");
+                + std::to_string(height) + ". " + divergence_report(r));
         }
         if (r.total_after == 0) {
             return fail_closed(
@@ -407,12 +483,20 @@ public:
         m_next = height + 1;
         ++m_applied;
         m_sml_recovered += r.sml_recovered;
+        m_registered    += r.registered;
+        m_spent         += r.spent;
         m_stalled_pumps = 0;
 
         if ((m_applied % 500) == 0) {
             LOG_INFO << "[MN-CKPT] bridge progress: applied " << m_applied
-                     << " blocks, cursor h=" << height << " set="
-                     << r.total_after << " sml-recovered=" << m_sml_recovered;
+                     << " blocks, cursor h=" << height << " registered="
+                     << r.total_after << " eligible=" << m_machine.eligible_size()
+                     << " (anchor " << m_anchor_eligible << "; +"
+                     << m_registered << " reg, -" << m_spent << " spent, -"
+                     << m_machine.pose_removed_total() << " PoSe-removed, +"
+                     << m_machine.pose_reinstated_total() << " reinstated)"
+                     << " sml-recovered=" << m_sml_recovered
+                     << " early-exclusions=" << m_machine.pose_premature_total();
         }
 
         if (!m_tip_height) return;
@@ -422,6 +506,93 @@ public:
     }
 
 private:
+    /// Apply the SML's PoSe verdicts to the working set for `height`. Called
+    /// exactly once per replayed height, immediately before apply_block.
+    void reconcile_pose(uint32_t height)
+    {
+        if (!m_sml_snapshot) return;          // seam unwired: additions only
+        const vendor::CSimplifiedMNList* sml = m_sml_snapshot();
+        if (!sml || sml->size() == 0) {
+            // Not an error: on a cold start the mnlistdiff feed may not have
+            // produced a verified list yet. Say so at a bounded rate — a
+            // replay running with no removal source is exactly the silent
+            // degradation this lane exists to prevent, and it is the state
+            // that produced the measured 2067 -> 2070 climb.
+            if (!m_warned_no_sml) {
+                m_warned_no_sml = true;
+                LOG_WARNING << "[MN-CKPT] no verified SML available at h="
+                            << height << " — the replay can only ADD"
+                               " masternodes until one arrives. A PoSe ban"
+                               " inside the window will read as a payee"
+                               " desync.";
+            }
+            return;
+        }
+        const auto pr = m_machine.reconcile_pose_from_sml(*sml, height);
+        if (pr.removed == 0 && pr.reinstated == 0) return;
+        LOG_INFO << "[MN-CKPT] PoSe reconcile h=" << height << ": eligible "
+                 << pr.eligible_before << " -> " << pr.eligible_after
+                 << " (-" << pr.removed << " removed, +" << pr.reinstated
+                 << " reinstated; SML " << pr.scanned << " entries, "
+                 << pr.matched << " ours)";
+    }
+
+    /// The measurement that replaces three hypotheses. Every fail-closed on
+    /// the replay path carries it, so an operator can separate "the anchor is
+    /// wrong" from "the replay is incomplete" from "a PoSe ban could not be
+    /// attested" WITHOUT attaching a debugger.
+    std::string divergence_report(const MnStateMachine::ApplyResult& r) const
+    {
+        const size_t elig = m_machine.eligible_size();
+        std::string s =
+            "SET DELTA: payee-eligible " + std::to_string(m_anchor_eligible)
+            + " at the anchor -> " + std::to_string(elig) + " now"
+            + " (registered total " + std::to_string(m_machine.size()) + ")."
+            + " ADDS: " + std::to_string(m_registered) + " registrations."
+            + " REMOVALS: " + std::to_string(m_machine.pose_removed_total())
+            + " PoSe (SML-attested), " + std::to_string(m_spent)
+            + " collateral spends, "
+            + std::to_string(m_sml_recovered) + " demotion-walk exclusions."
+            + " REINSTATED: " + std::to_string(m_machine.pose_reinstated_total())
+            + ". EARLY-EXCLUSION REPAIRS: "
+            + std::to_string(m_machine.pose_premature_total()) + ".";
+
+        if (!m_sml_snapshot) {
+            s += " NO SML SNAPSHOT SEAM IS WIRED — this replay could only ADD"
+                 " masternodes, so ANY post-anchor PoSe ban lands here.";
+        } else if (m_machine.pose_removed_total() == 0) {
+            s += " The SML removal pass applied ZERO removals: either no"
+                 " masternode was banned in the window, or no verified SML"
+                 " was available to say so.";
+        }
+
+        if (r.projected_payee) {
+            s += " PROJECTED PAYEE: " + r.projected_payee->GetHex() + ";";
+            if (!m_has_sml_fn) {
+                s += " no SML validity seam is wired, so nothing can attest it.";
+            } else {
+                const auto op = m_machine.sml_opinion(*r.projected_payee);
+                s += !op ? std::string(" the SML has NO ENTRY for it (absent is"
+                                       " never treated as evidence of a ban).")
+                     : (*op ? std::string(" the SML attests it VALID — so this"
+                                          " is NOT an unobserved PoSe ban;"
+                                          " suspect the anchor or a missed"
+                                          " block (or a ban+revive entirely"
+                                          " inside the window).")
+                            : std::string(" the SML attests it INVALID, yet no"
+                                          " candidate below it matched this"
+                                          " coinbase exactly — the queue has"
+                                          " diverged by more than one ban."));
+            }
+        } else {
+            s += " No payee was projected (the pre-block eligible set was"
+                 " empty).";
+        }
+        s += " Refusing to publish a masternode set that would mint a rejected"
+             " coinbase.";
+        return s;
+    }
+
     void request_window(uint32_t tip)
     {
         if (!m_request) {
@@ -469,20 +640,34 @@ private:
                                " publish");
         }
         m_state  = State::Published;
-        // The recovery count rides on BOTH the status string and the log
-        // line. A degradation that is only visible in scrollback is
-        // half-silent, and this lane exists to make degradation loud.
+        // The full delta rides on BOTH the status string and the log line. A
+        // degradation that is only visible in scrollback is half-silent, and
+        // this lane exists to make degradation loud. `eligible` is directly
+        // comparable to dashd's `protx list valid <as_of>` — which is how the
+        // 2068->2059 vs 2067->2070 divergence was measured in the first place.
+        const std::string delta =
+            "eligible " + std::to_string(m_anchor_eligible) + " -> "
+            + std::to_string(m_machine.eligible_size()) + " (+"
+            + std::to_string(m_registered) + " reg, -" + std::to_string(m_spent)
+            + " spent, -" + std::to_string(m_machine.pose_removed_total())
+            + " PoSe-removed, +"
+            + std::to_string(m_machine.pose_reinstated_total())
+            + " reinstated, -" + std::to_string(m_sml_recovered)
+            + " SML-recovered exclusions, "
+            + std::to_string(m_machine.pose_premature_total())
+            + " early-exclusion repairs)";
         m_status = "published " + std::to_string(out.size())
                    + " masternodes (" + std::to_string(m_sml_recovered)
                    + " SML-recovered exclusions) as-of h=" + std::to_string(as_of)
                    + " (anchor h=" + std::to_string(m_anchor_height)
-                   + " + " + std::to_string(m_applied) + " replayed blocks)";
+                   + " + " + std::to_string(m_applied) + " replayed blocks) "
+                   + delta;
         LOG_INFO << "[MN-CKPT] bridge COMPLETE: published " << out.size()
                  << " masternodes (" << m_sml_recovered
                  << " SML-recovered exclusions) as-of h=" << as_of
                  << " (anchor h=" << m_anchor_height << ", replayed "
                  << m_applied << " blocks, tip h=" << bridged_to
-                 << ") -> publishing to the maintainer";
+                 << ") " << delta << " -> publishing to the maintainer";
         m_publish(std::move(out), as_of);
     }
 
@@ -505,6 +690,7 @@ private:
     PublishFn      m_publish;
     TipHeightFn    m_tip_height;
     HeaderHashAtFn m_header_hash_at;
+    SmlSnapshotFn  m_sml_snapshot;
 
     State       m_state{State::Unarmed};
     std::string m_status{"unarmed"};
@@ -517,6 +703,10 @@ private:
     uint32_t m_next{0};             // the ONLY height apply_block may fold next
     uint32_t m_applied{0};
     size_t   m_sml_recovered{0};    // masternodes excluded on SML-attested bans
+    size_t   m_anchor_eligible{0};  // payee-eligible count AT the anchor
+    size_t   m_registered{0};       // ADDS observed across the replay
+    size_t   m_spent{0};            // collateral-spend removals across the replay
+    bool     m_warned_no_sml{false};
     bool     m_has_sml_fn{false};   // an SML validity seam was wired
     uint32_t m_max_bridge{kDefaultMaxBridgeBlocks};
     uint32_t m_stalled_pumps{0};

--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -301,6 +301,19 @@ public:
         m_anchor_source = cp.source;
         m_anchor_count  = cp.entries.size();
         m_machine.load(cp.entries, cp.height);
+        // F6: reset the one-shot fold latch and its counters. The latch is the
+        // dangerous one — a second bridge on a re-armed lane would run
+        // additions-only while sml_folded() still reported true, i.e. it would
+        // LIE about having applied removals.
+        m_sml_folded      = false;
+        m_sml_folded_at   = 0;
+        m_pose_removed    = 0;
+        m_pose_reinstated = 0;
+        m_sml_recovered   = 0;
+        m_registered      = 0;
+        m_spent           = 0;
+        m_applied         = 0;
+        m_warned_no_sml   = false;
         m_anchor_eligible = m_machine.eligible_size();
         m_next  = cp.height + 1;
         m_state = State::Waiting;
@@ -497,6 +510,11 @@ public:
         // ── WHOLESALE PoSe fold, at the ONE cursor position where it is safe.
         // Sequenced by HEIGHT, never by arrival order: see maybe_fold_sml().
         maybe_fold_sml();
+        // The fold can fail closed (oversized list). Return immediately: the
+        // tail of this function calls request_window(), which unconditionally
+        // rewrites m_status and would erase the refusal reason the operator
+        // needs.
+        if (m_state != State::Bridging) return;
         m_sml_recovered += r.sml_recovered;
         m_registered    += r.registered;
         m_spent         += r.spent;
@@ -511,7 +529,7 @@ public:
                      << m_pose_removed << " PoSe-removed, +"
                      << m_pose_reinstated << " reinstated)"
                      << " sml-recovered=" << m_sml_recovered
-                     << " early-exclusions=" << 0;
+                     << " sml-folded=" << (m_sml_folded ? "yes" : "no");
         }
 
         if (!m_tip_height) return;
@@ -607,6 +625,35 @@ private:
         if (cursor != snap.height) return;   // never early; late is benign
 
         const size_t before = m_machine.eligible_size();
+
+        // F5 SANITY BOUND. The per-mismatch walk is capped AND cross-checked
+        // against the real coinbase at every step precisely so that "recovery"
+        // can never become a wholesale override of the projection. This fold IS
+        // a wholesale override — it rewrites validity for the entire set from
+        // one message, and on_mnlistdiff does not currently re-derive
+        // sml.CalcMerkleRoot() against diff.cbTx.merkleRootMNList, so the list
+        // is trusted rather than verified. A PoSe ban is a rare per-masternode
+        // event: a diff that would retire a large fraction of the set at once
+        // is not a ban wave, it is a corrupt or hostile list. Refuse it and say
+        // so, rather than publish a set with a hole in it.
+        const size_t would_remove = count_fold_removals(*snap.list);
+        const size_t bound = std::max<size_t>(kMinFoldRemovals,
+                                             before / kMaxFoldRemovalDivisor);
+        if (before != 0 && would_remove > bound) {
+            return fail_closed(
+                "SML PoSe FOLD REFUSED at cursor h=" + std::to_string(cursor)
+                + ": the list would retire " + std::to_string(would_remove)
+                + " of " + std::to_string(before)
+                + " payee-eligible masternodes in one pass, over the 1/"
+                + std::to_string(kMaxFoldRemovalDivisor) + " sanity bound of "
+                + std::to_string(bound) + ". A PoSe ban is a rare per-node"
+                  " event; a fold this large is a corrupt or hostile SML, not a"
+                  " ban wave. NOTE: the SML is NOT root-verified against"
+                  " cbTx.merkleRootMNList on the diff ingest path, so this"
+                  " bound is the only thing standing between a bad list and a"
+                  " wholesale rewrite of the payee set.");
+        }
+
         const auto vr = m_machine.sync_validity_from_sml(*snap.list, snap.height);
         const size_t after = m_machine.eligible_size();
         m_sml_folded    = true;
@@ -620,6 +667,28 @@ private:
                  << vr.scanned << " SML entries, " << vr.matched << " ours)."
                  << " A ban BURST leaves in one pass here, which the"
                     " per-mismatch walk cannot do.";
+    }
+
+    /// How much of the payee-eligible set a single fold may retire: at most
+    /// 1/N of it. Deliberately blunt — the point is to bound the blast radius
+    /// of an unverified list, not to model ban rates.
+    static constexpr size_t kMaxFoldRemovalDivisor = 8;
+    /// Absolute floor, so the bound is never zero on a small set (which would
+    /// refuse every legitimate fold) and a handful of genuine bans always fits.
+    static constexpr size_t kMinFoldRemovals = 4;
+
+    /// Dry-run the fold's removal count without mutating anything, so the
+    /// sanity bound can refuse BEFORE any state changes.
+    size_t count_fold_removals(const vendor::CSimplifiedMNList& sml) const
+    {
+        size_t n = 0;
+        for (const auto& e : sml.mnList) {
+            if (e.isValid) continue;
+            auto it = m_machine.entries().find(e.proRegTxHash);
+            if (it == m_machine.entries().end()) continue;
+            if (it->second.isValid) ++n;
+        }
+        return n;
     }
 
     /// The measurement that replaces three hypotheses. Every fail-closed on
@@ -693,6 +762,9 @@ private:
 
     void request_window(uint32_t tip)
     {
+        // Never rewrite the status of a lane that has already finished or
+        // refused — that status is the only record of WHY.
+        if (m_state != State::Bridging) return;
         if (!m_request) {
             return fail_closed("no block-request seam wired — the bridge cannot"
                                " fetch the blocks it must replay");

--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -449,6 +449,20 @@ public:
                      << " blocks) onto the anchored set";
         }
 
+        // F4: the anchor height is itself a valid fold cursor -- and the ONLY
+        // dispatch that can ever observe it. The post-apply fold in
+        // on_block_connected first runs at cursor == anchor+1, and the publish()
+        // fold runs at the final cursor, so an SML current EXACTLY at the anchor
+        // (cursor == H_sml == anchor -- the canonical NON-early position: the
+        // loaded snapshot IS the state after connecting H_sml) is otherwise
+        // silently forfeited, leaving the first replayed blocks unprotected.
+        // Dispatch once here at bridge start; maybe_fold_sml()'s own
+        // cursor == snap.height guard makes this a no-op unless H_sml == anchor,
+        // so it can never fold early. (One-shot latch: it will not re-run once
+        // the post-apply site takes over for cursor > anchor.)
+        maybe_fold_sml();
+        if (m_state != State::Bridging) return;   // the fold can fail closed
+
         // Cursor already at (or past) the tip: the bridge is complete.
         if (m_next > tip) { publish(tip); return; }
 

--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -112,30 +112,35 @@
 /// already receive and persist it. There are now TWO seams onto it, and they
 /// do different jobs:
 ///
-///   • set_sml_snapshot_fn() — the REMOVAL pass. Once per replayed height,
-///     BEFORE the block is folded, MnStateMachine::reconcile_pose_from_sml()
-///     drops every masternode the SML attests not-valid out of the
-///     payee-eligible set, and lifts a bridge-owned exclusion again if a
-///     refreshed SML attests it valid. This is what stops a banned masternode
-///     ever reaching the head of the queue. The ordering rationale — and why
-///     pre-block is the only correct choice when a registration and a removal
-///     land in the same block — is written out in full at that function.
+///   • set_sml_snapshot_fn() — the WHOLESALE REMOVAL fold. Supplies the whole
+///     list PLUS the height it is current at. At exactly ONE cursor position
+///     — apply cursor == that height — the lane folds
+///     MnStateMachine::sync_validity_from_sml() over the working set, so every
+///     masternode the SML attests not-valid leaves the payee-eligible set in a
+///     single pass. That single-pass property is the point: it makes a BURST
+///     of bans indistinguishable from one ban. The ordering rule, and why
+///     violating it EARLY is dangerous while LATE is benign, is written out in
+///     full at maybe_fold_sml(). The same seam supplies the freshness height
+///     that gates the walk below.
 ///
 ///   • set_sml_validity_fn() — the per-hash attestation used by the REACTIVE
-///     demotion walk, which remains as the second line of defence for a ban
-///     the removal pass could not see (no verified SML yet, or an SML older
-///     than the ban). It may walk down the ranked queue, but ONLY while each
-///     demoted candidate is ATTESTED INVALID and the accepted candidate's
+///     per-mismatch demotion walk, which remains the second line of defence
+///     for a ban the fold could not cover (no verified SML, or an SML whose
+///     height the cursor never lands on). It may walk down the ranked queue,
+///     but ONLY while each demoted candidate is ATTESTED INVALID by an SML
+///     FRESH ENOUGH to speak about that height and the accepted candidate's
 ///     scriptPayout EXACTLY matches an output this block pays. The walk is
-///     capped per bridge (see pump()).
+///     capped per bridge (see pump()) and adjudicates ONE exclusion per
+///     height, which is exactly why it cannot carry a burst.
 ///
-/// Because the SML is a snapshot of NOW rather than of the replayed height, a
-/// removal can be EARLY — the ban may have fallen after the block being
-/// replayed. That is handled explicitly, not hoped away: pass 3's
-/// recover_premature_pose_exclusion() recognises "this block pays a
-/// masternode we excluded, and it outranked our projection", attributes the
-/// payment so the DIP-3 queue cursor stays dashd-identical, and KEEPS the
-/// exclusion.
+/// MEASURED CAUSE OF THE h=2514874 FAIL-CLOSE — it was a BURST, not missing
+/// machinery. The walk RAN AND WORKED five times during that replay (bridge
+/// total 1/6 … 5/6). The chain then shows three masternodes
+/// (824da5790b93de99…, 91c8c62b1245a1f5…, a459ade702cbe47a…) leaving `protx
+/// list valid` together inside 73 blocks: valid 2062 at h=2514800, 2059 at
+/// h=2514873, and still absent at h=2515025 (never revived, so the SML held
+/// isValid=false correctly). Three consecutive banned queue-head candidates
+/// defeat a walk that must land an exact coinbase script match at each step.
 ///
 /// Every count is surfaced on status(), on the publish line, and on every
 /// fail-closed message (divergence_report()): a count that lives only in
@@ -211,17 +216,21 @@ public:
     /// MnStateMachine::SmlValidityFn and the residuals note in this file's
     /// header. Wired by main_dash to NodeCoinState::sml() + have_sml().
     using SmlValidityFn = MnStateMachine::SmlValidityFn;
-    /// The WHOLE persisted Simplified Masternode List, or nullptr when this
-    /// node has none yet. This is the seam that carries PoSe REMOVALS: the
-    /// per-hash SmlValidityFn above can only answer questions about a
-    /// masternode we already suspect, whereas the removal pass has to sweep
-    /// the list. Wired by main_dash to NodeCoinState::sml() + have_sml().
+    /// The WHOLE persisted Simplified Masternode List TOGETHER WITH THE
+    /// HEIGHT IT IS CURRENT AT. Both halves are mandatory: the list carries
+    /// the PoSe REMOVALS, and the height is what makes them safe to apply
+    /// (see maybe_fold_sml() — a wholesale fold is only valid at ONE cursor
+    /// position) and what gates the reactive walk's attestations for
+    /// staleness. `list == nullptr` means this node has no verified SML yet.
     ///
-    /// Returns a pointer, not a copy: the list is ~3000 entries and the lane
-    /// consults it once per replayed height, on the same io thread that
-    /// updates it (mnlistdiff ingest). No lock is taken or needed; the
-    /// pointer is used and discarded inside one call.
-    using SmlSnapshotFn = std::function<const vendor::CSimplifiedMNList*()>;
+    /// Returns a pointer, not a copy: the list is ~3000 entries and is read on
+    /// the same io thread that updates it (mnlistdiff ingest). No lock is
+    /// taken or needed; the pointer is used and discarded inside one call.
+    struct SmlSnapshot {
+        const vendor::CSimplifiedMNList* list{nullptr};
+        uint32_t                         height{0};
+    };
+    using SmlSnapshotFn = std::function<SmlSnapshot()>;
 
     enum class State {
         Unarmed,      ///< no checkpoint loaded — the lane does nothing
@@ -259,7 +268,8 @@ public:
         m_machine.set_sml_validity_fn(std::move(fn));
     }
     /// OPTIONAL, but this is the seam that fixes the measured 2068->2059 vs
-    /// 2067->2070 divergence. Unwired, the replay can still only ADD.
+    /// 2067->2070 divergence. Unwired, the replay can still only ADD, and the
+    /// reactive walk runs with no freshness gate (its pre-existing behaviour).
     void set_sml_snapshot_fn(SmlSnapshotFn fn) { m_sml_snapshot = std::move(fn); }
     bool has_sml_snapshot_fn() const { return static_cast<bool>(m_sml_snapshot); }
 
@@ -320,9 +330,10 @@ public:
     /// eligible_size() directly against `protx list valid <h>` on any dashd.
     size_t   eligible_size()      const { return m_machine.eligible_size(); }
     size_t   anchor_eligible()    const { return m_anchor_eligible; }
-    size_t   pose_removed()       const { return m_machine.pose_removed_total(); }
-    size_t   pose_reinstated()    const { return m_machine.pose_reinstated_total(); }
-    size_t   pose_premature()     const { return m_machine.pose_premature_total(); }
+    size_t   pose_removed()       const { return m_pose_removed; }
+    size_t   pose_reinstated()    const { return m_pose_reinstated; }
+    bool     sml_folded()         const { return m_sml_folded; }
+    uint32_t sml_folded_at()      const { return m_sml_folded_at; }
     size_t   replay_registered()  const { return m_registered; }
     size_t   replay_spent()       const { return m_spent; }
     bool     failed_closed() const { return m_state == State::FailedClosed; }
@@ -397,14 +408,29 @@ public:
 
         if (m_state == State::Waiting) {
             m_state = State::Bridging;
-            // Size the SML ban-recovery budget against the replay distance.
-            // A PoSe ban is a rare per-masternode event, so the count of them
-            // inside a window scales with the window, not with the set size:
-            // 4 covers a short bridge, +1 per 1000 blocks covers a long one.
-            // Past that, "recovery" stops being a repair of a few known-banned
-            // nodes and becomes a wholesale override of the projection, which
-            // is precisely what this lane must never do.
-            m_machine.set_sml_recovery_cap(4 + (tip - m_anchor_height) / 1000);
+            // Size the per-mismatch demotion-walk budget against the replay
+            // distance. A PoSe ban is a rare per-masternode event, so the
+            // count inside a window scales with the window, not with the set
+            // size: 4 covers a short bridge, +1 per 1000 blocks covers a long
+            // one. Past that, "recovery" stops being a repair of a few
+            // known-banned nodes and becomes a wholesale override of the
+            // projection, which is precisely what this walk must never do.
+            //
+            // MEASURED SHAPE MISMATCH — this cap is sized for ISOLATED bans
+            // and a legitimate ban BURST can exhaust it. On mainnet
+            // 2026-08-02 the walk reached 5/6 legitimately, and the chain put
+            // THREE masternodes out inside 73 blocks; two such bursts in one
+            // ~2000-block window is 6 exclusions, i.e. the whole budget, and a
+            // third masternode in either burst overruns it. Exhaustion is
+            // TERMINAL. That is a real limitation of the walk, and it is a
+            // second reason the wholesale fold (maybe_fold_sml) is the right
+            // mechanism: a fold is ONE pass over the list and spends NO budget
+            // at all, so a burst costs it nothing. The cap is deliberately
+            // left as-is rather than widened — widening it would license
+            // exactly the wholesale-override-by-inference this walk exists to
+            // refuse, and the fold already removes the need.
+            m_sml_recovery_cap = 4 + (tip - m_anchor_height) / 1000;
+            m_machine.set_sml_recovery_cap(m_sml_recovery_cap);
             LOG_INFO << "[MN-CKPT] bridge START: replaying h=" << m_next
                      << ".." << tip << " (" << (tip - m_next + 1)
                      << " blocks) onto the anchored set";
@@ -441,26 +467,12 @@ public:
         if (m_state != State::Bridging) return;
         if (height != m_next) return;
 
-        // ── PoSe REMOVAL pass, BEFORE the block is folded ─────────────────
-        // A PoSe ban is consensus-derived, never a transaction, so the block
-        // replay below can only ever ADD masternodes. Measured on mainnet
-        // 2026-08-02 over 2513000..2514874: the chain's payee-eligible set
-        // FELL 2068 -> 2059 while this replay CLIMBED 2067 -> 2070. The SML is
-        // the only carrier of the removals and we already persist it.
-        //
-        // ORDERING — pre-block, and the reasons are in
-        // MnStateMachine::reconcile_pose_from_sml() in full. In short:
-        // dashcore projects height H's payee from the list as of H-1, and
-        // validity is part of that list, so the removal must land before
-        // pass 0 ranks candidates. Pre-block is also the only ordering that
-        // keeps a removal and a registration in the SAME block correct: an MN
-        // registered by block H is not yet in the set here, so H's
-        // reconciliation cannot touch it — which is right, because it was not
-        // in dashd's H-1 list and cannot be H's payee. And pass 1's tx-driven
-        // ban (ProUpRevTx) still lands afterwards at its exact consensus
-        // height, overwriting our provisional one.
-        reconcile_pose(height);
-        if (m_state != State::Bridging) return;   // reconcile can fail closed
+        // Publish the SML's own height into the machine BEFORE it adjudicates
+        // anything, so the reactive demotion walk's attestations are gated on
+        // freshness (MnStateMachine::sml_attest). A stale SML attesting a
+        // since-revived masternode "invalid" would otherwise license a
+        // PERMANENT demotion.
+        refresh_sml_height();
 
         const auto r = m_machine.apply_block(block, height);
 
@@ -482,6 +494,9 @@ public:
 
         m_next = height + 1;
         ++m_applied;
+        // ── WHOLESALE PoSe fold, at the ONE cursor position where it is safe.
+        // Sequenced by HEIGHT, never by arrival order: see maybe_fold_sml().
+        maybe_fold_sml();
         m_sml_recovered += r.sml_recovered;
         m_registered    += r.registered;
         m_spent         += r.spent;
@@ -493,10 +508,10 @@ public:
                      << r.total_after << " eligible=" << m_machine.eligible_size()
                      << " (anchor " << m_anchor_eligible << "; +"
                      << m_registered << " reg, -" << m_spent << " spent, -"
-                     << m_machine.pose_removed_total() << " PoSe-removed, +"
-                     << m_machine.pose_reinstated_total() << " reinstated)"
+                     << m_pose_removed << " PoSe-removed, +"
+                     << m_pose_reinstated << " reinstated)"
                      << " sml-recovered=" << m_sml_recovered
-                     << " early-exclusions=" << m_machine.pose_premature_total();
+                     << " early-exclusions=" << 0;
         }
 
         if (!m_tip_height) return;
@@ -506,35 +521,105 @@ public:
     }
 
 private:
-    /// Apply the SML's PoSe verdicts to the working set for `height`. Called
-    /// exactly once per replayed height, immediately before apply_block.
-    void reconcile_pose(uint32_t height)
+    /// Push the SML's current height into the machine so the reactive
+    /// demotion walk can refuse a STALE attestation. Cheap; called on every
+    /// folded block because the mnlistdiff feed advances underneath us.
+    void refresh_sml_height()
     {
-        if (!m_sml_snapshot) return;          // seam unwired: additions only
-        const vendor::CSimplifiedMNList* sml = m_sml_snapshot();
-        if (!sml || sml->size() == 0) {
-            // Not an error: on a cold start the mnlistdiff feed may not have
-            // produced a verified list yet. Say so at a bounded rate — a
-            // replay running with no removal source is exactly the silent
-            // degradation this lane exists to prevent, and it is the state
-            // that produced the measured 2067 -> 2070 climb.
+        if (!m_sml_snapshot) return;
+        const SmlSnapshot snap = m_sml_snapshot();
+        m_machine.set_sml_current_height(snap.list ? snap.height : 0);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // maybe_fold_sml — the WHOLESALE PoSe removal, at the ONE safe cursor
+    // ─────────────────────────────────────────────────────────────────────
+    //
+    // WHY IT IS NEEDED. The reactive walk (recover_from_sml_ban) adjudicates
+    // ONE queue-head exclusion per height, and each success must re-attribute
+    // the payment to the next candidate "whose scriptPayout matches this
+    // coinbase exactly". That works for ISOLATED bans and is proven to: on
+    // mainnet 2026-08-02 it ran and succeeded five times during the replay
+    // (bridge total 1/6 … 5/6). It cannot work for a BURST. The chain shows
+    // what actually broke:
+    //
+    //     h=2514800   valid 2062, our projected MN PRESENT
+    //     h=2514873   valid 2059, our projected MN ABSENT
+    //                 -> THREE masternodes banned inside 73 blocks
+    //     h=2515025   valid 2063, still ABSENT (never revived)
+    //
+    // Three consecutive banned queue-head candidates defeat a walk that has
+    // to land an exact coinbase script match at every step. The wholesale
+    // fold fixes it precisely BECAUSE it makes a burst indistinguishable from
+    // a single ban: all three leave the eligible set in one pass, before any
+    // of them is ever projected.
+    //
+    // ── THE ORDERING RULE, AND WHY VIOLATING IT IS ASYMMETRIC ────────────
+    //
+    // The SML is a snapshot of the state AFTER connecting H_sml. A wholesale
+    // fold is valid at EXACTLY ONE cursor position: apply cursor == H_sml —
+    // after apply_block(H_sml), before apply_block(H_sml+1). Sequenced by
+    // HEIGHT, never by arrival order.
+    //
+    //   EARLY (cursor < H_sml) is DANGEROUS, and this is the whole reason the
+    //   fold is gated rather than run per-height. A masternode banned at
+    //   h_ban <= H_sml would be removed at heights where the chain still held
+    //   it valid and actually paid it. The mild outcome is a spurious terminal
+    //   fail-close. The severe one is silent: inside a shared-payoutAddress
+    //   group the divergence is SCRIPT-INVISIBLE (see the residual note in
+    //   this file's header), the coinbase cross-check still passes, and the
+    //   bridge PUBLISHES A WRONG QUEUE — the exact bad-cb-payee this lane
+    //   exists to prevent. An early fold also perturbs queue POSITION for
+    //   nodes it touches, because sync_validity_from_sml bumps
+    //   nPoSeRevivedHeight, which is a CompareByLastPaid sort key.
+    //
+    //   LATE (cursor > H_sml) is BENIGN: it is today's behaviour, and the
+    //   reactive walk still catches a ban when it reaches the queue head.
+    //
+    // So the fold NEVER runs early. If the cursor passes H_sml without an SML
+    // present, it simply does not happen and the walk carries the window
+    // alone — degraded, and said so out loud.
+    //
+    // TWO DISPATCH POINTS, ONE RULE. This is called after each successful
+    // apply_block (catching cursor == H_sml mid-replay, which is what lets a
+    // burst at H_sml+1 be survived) and once more from publish() (catching
+    // H_sml == tip, and the zero-block bridge). Both test the same equality
+    // and the fold is one-shot, so they cannot double-apply.
+    void maybe_fold_sml()
+    {
+        if (m_sml_folded) return;
+        if (!m_sml_snapshot) return;
+        const SmlSnapshot snap = m_sml_snapshot();
+        if (!snap.list || snap.list->size() == 0) {
             if (!m_warned_no_sml) {
                 m_warned_no_sml = true;
-                LOG_WARNING << "[MN-CKPT] no verified SML available at h="
-                            << height << " — the replay can only ADD"
-                               " masternodes until one arrives. A PoSe ban"
-                               " inside the window will read as a payee"
-                               " desync.";
+                LOG_WARNING << "[MN-CKPT] no verified SML available at cursor h="
+                            << cursor_height()
+                            << " — the replay can only ADD masternodes until"
+                               " one arrives, and a PoSe ban inside the window"
+                               " must then be carried by the per-mismatch walk"
+                               " alone (which a multi-masternode ban BURST can"
+                               " defeat).";
             }
             return;
         }
-        const auto pr = m_machine.reconcile_pose_from_sml(*sml, height);
-        if (pr.removed == 0 && pr.reinstated == 0) return;
-        LOG_INFO << "[MN-CKPT] PoSe reconcile h=" << height << ": eligible "
-                 << pr.eligible_before << " -> " << pr.eligible_after
-                 << " (-" << pr.removed << " removed, +" << pr.reinstated
-                 << " reinstated; SML " << pr.scanned << " entries, "
-                 << pr.matched << " ours)";
+        const uint32_t cursor = cursor_height();
+        if (cursor != snap.height) return;   // never early; late is benign
+
+        const size_t before = m_machine.eligible_size();
+        const auto vr = m_machine.sync_validity_from_sml(*snap.list, snap.height);
+        const size_t after = m_machine.eligible_size();
+        m_sml_folded    = true;
+        m_sml_folded_at = snap.height;
+        m_pose_removed    = vr.flipped_to_invalid;
+        m_pose_reinstated = vr.flipped_to_valid;
+        LOG_INFO << "[MN-CKPT] SML PoSe FOLD at cursor h=" << cursor
+                 << " (== the height the SML is current at): payee-eligible "
+                 << before << " -> " << after << " (-" << vr.flipped_to_invalid
+                 << " banned, +" << vr.flipped_to_valid << " revived; scanned "
+                 << vr.scanned << " SML entries, " << vr.matched << " ours)."
+                 << " A ban BURST leaves in one pass here, which the"
+                    " per-mismatch walk cannot do.";
     }
 
     /// The measurement that replaces three hypotheses. Every fail-closed on
@@ -549,21 +634,34 @@ private:
             + " at the anchor -> " + std::to_string(elig) + " now"
             + " (registered total " + std::to_string(m_machine.size()) + ")."
             + " ADDS: " + std::to_string(m_registered) + " registrations."
-            + " REMOVALS: " + std::to_string(m_machine.pose_removed_total())
+            + " REMOVALS: " + std::to_string(m_pose_removed)
             + " PoSe (SML-attested), " + std::to_string(m_spent)
             + " collateral spends, "
             + std::to_string(m_sml_recovered) + " demotion-walk exclusions."
-            + " REINSTATED: " + std::to_string(m_machine.pose_reinstated_total())
-            + ". EARLY-EXCLUSION REPAIRS: "
-            + std::to_string(m_machine.pose_premature_total()) + ".";
+            + " REINSTATED: " + std::to_string(m_pose_reinstated)
+            + ".";
 
         if (!m_sml_snapshot) {
             s += " NO SML SNAPSHOT SEAM IS WIRED — this replay could only ADD"
                  " masternodes, so ANY post-anchor PoSe ban lands here.";
-        } else if (m_machine.pose_removed_total() == 0) {
-            s += " The SML removal pass applied ZERO removals: either no"
-                 " masternode was banned in the window, or no verified SML"
-                 " was available to say so.";
+        } else if (!m_sml_folded) {
+            s += " The WHOLESALE SML fold has NOT run (it applies only at"
+                 " cursor == the height the SML is current at, and never"
+                 " earlier — an early fold can publish a wrong queue"
+                 " silently). Every ban in this window is therefore being"
+                 " carried by the per-mismatch walk alone, which a BURST of"
+                 " masternodes banned close together defeats: it adjudicates"
+                 " one exclusion per height and must land an exact coinbase"
+                 " script match at each step.";
+        } else {
+            s += " The wholesale SML fold ran at h="
+                 + std::to_string(m_sml_folded_at) + ".";
+        }
+        if (m_sml_recovered >= m_sml_recovery_cap && m_sml_recovery_cap != 0) {
+            s += " The per-bridge demotion-walk BUDGET is EXHAUSTED ("
+                 + std::to_string(m_sml_recovered) + "/"
+                 + std::to_string(m_sml_recovery_cap)
+                 + "): further exclusions are refused by design.";
         }
 
         if (r.projected_payee) {
@@ -631,6 +729,13 @@ private:
             return fail_closed("no publish seam wired — the bridged masternode"
                                " set has nowhere to go");
         }
+        // Last chance for the wholesale PoSe fold: this is the cursor ==
+        // H_sml case when the SML is current at the bridge target (and the
+        // only chance at all for a zero-block bridge). Same one-shot equality
+        // gate as the mid-replay call — it cannot double-apply and it cannot
+        // fire early.
+        maybe_fold_sml();
+
         const uint32_t as_of = m_next - 1;
         std::vector<std::pair<uint256, MNState>> out;
         out.reserve(m_machine.entries().size());
@@ -649,13 +754,11 @@ private:
             "eligible " + std::to_string(m_anchor_eligible) + " -> "
             + std::to_string(m_machine.eligible_size()) + " (+"
             + std::to_string(m_registered) + " reg, -" + std::to_string(m_spent)
-            + " spent, -" + std::to_string(m_machine.pose_removed_total())
+            + " spent, -" + std::to_string(m_pose_removed)
             + " PoSe-removed, +"
-            + std::to_string(m_machine.pose_reinstated_total())
+            + std::to_string(m_pose_reinstated)
             + " reinstated, -" + std::to_string(m_sml_recovered)
-            + " SML-recovered exclusions, "
-            + std::to_string(m_machine.pose_premature_total())
-            + " early-exclusion repairs)";
+            + " SML-recovered exclusions)";
         m_status = "published " + std::to_string(out.size())
                    + " masternodes (" + std::to_string(m_sml_recovered)
                    + " SML-recovered exclusions) as-of h=" + std::to_string(as_of)
@@ -704,6 +807,11 @@ private:
     uint32_t m_applied{0};
     size_t   m_sml_recovered{0};    // masternodes excluded on SML-attested bans
     size_t   m_anchor_eligible{0};  // payee-eligible count AT the anchor
+    size_t   m_pose_removed{0};     // masternodes the wholesale fold banned
+    size_t   m_pose_reinstated{0};  // masternodes the wholesale fold revived
+    bool     m_sml_folded{false};   // the one-shot wholesale fold has run
+    uint32_t m_sml_folded_at{0};    // ...at this height (== the SML's height)
+    size_t   m_sml_recovery_cap{0}; // budget handed to the machine, mirrored
     size_t   m_registered{0};       // ADDS observed across the replay
     size_t   m_spent{0};            // collateral-spend removals across the replay
     bool     m_warned_no_sml{false};

--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -687,9 +687,11 @@ private:
     // and leaks past the demux. The lane therefore has at most ONE request in
     // flight, enforced structurally rather than by bookkeeping:
     //
-    //   • On reaching a fold height the lane sets m_snapshot_pending and
-    //     STOPS pulling blocks (request_window() returns immediately while
-    //     paused). The replay cannot run ahead of its own fold.
+    //   • On reaching a fold height the lane sets m_snapshot_pending. pump()
+    //     then returns before it can request another window, so the replay
+    //     stops pulling blocks and cannot run ahead of its own fold. (There is
+    //     a second check inside request_window(); mutation testing shows
+    //     nothing reaches it today, so read that one as a backstop.)
     //   • It issues exactly one request and will not issue another until that
     //     one is consumed, refused, or the lane fails closed.
     //   • on_block_connected() ignores blocks while paused (the cursor cannot

--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -109,19 +109,27 @@
 /// `valid`). Correct refusal, wrong set.
 ///
 /// The Simplified Masternode List is the only carrier of that ban, and we
-/// already receive and persist it. There are now TWO seams onto it, and they
+/// already receive and persist it. There are now THREE seams onto it, and they
 /// do different jobs:
 ///
-///   • set_sml_snapshot_fn() — the WHOLESALE REMOVAL fold. Supplies the whole
-///     list PLUS the height it is current at. At exactly ONE cursor position
-///     — apply cursor == that height — the lane folds
-///     MnStateMachine::sync_validity_from_sml() over the working set, so every
-///     masternode the SML attests not-valid leaves the payee-eligible set in a
-///     single pass. That single-pass property is the point: it makes a BURST
-///     of bans indistinguishable from one ban. The ordering rule, and why
-///     violating it EARLY is dangerous while LATE is benign, is written out in
-///     full at maybe_fold_sml(). The same seam supplies the freshness height
-///     that gates the walk below.
+///   • set_request_snapshot_fn() + set_merkle_root_at_fn() — the PER-HEIGHT
+///     WHOLESALE REMOVAL fold, and the reason this lane no longer reads the
+///     tip SML for a past height at all. At a fold point the lane issues
+///     getmnlistd(ZERO, hash_at(H)) — the same primitive
+///     quorum_member_source.hpp uses — and folds the list AS OF H with the
+///     cursor standing exactly on H. Every masternode that list attests
+///     not-valid leaves the payee-eligible set in a SINGLE pass, which is the
+///     whole point: it makes a BURST of bans indistinguishable from one ban.
+///     Because the list is requested for the cursor's own height rather than
+///     read off the moving tip, `cursor == H_sml` holds BY CONSTRUCTION and
+///     the dangerous EARLY case is unreachable rather than merely unlikely.
+///     The full argument, the sequencing, and the one-outstanding-request rule
+///     are written out at the PER-HEIGHT PoSe FOLD block below.
+///
+///   • set_sml_snapshot_fn() — the TIP SML, still wired, but no longer the
+///     fold's input. It supplies only the FRESHNESS HEIGHT that gates the
+///     reactive walk's attestations (a stale list must not license a permanent
+///     demotion of a since-revived masternode).
 ///
 ///   • set_sml_validity_fn() — the per-hash attestation used by the REACTIVE
 ///     per-mismatch demotion walk, which remains the second line of defence
@@ -180,7 +188,10 @@
 #include <impl/dash/coin/block.hpp>
 #include <impl/dash/coin/mn_checkpoint.hpp>
 #include <impl/dash/coin/mn_state_machine.hpp>
+#include <impl/dash/coin/historical_sml.hpp>   // authenticate_historical_snapshot
 #include <impl/dash/coin/vendor/simplifiedmns.hpp>
+#include <impl/dash/coin/vendor/smldiff.hpp>    // CSimplifiedMNListDiff
+#include <impl/dash/coin/vendor/cbtx.hpp>       // CCbTx
 
 #include <core/log.hpp>
 #include <core/uint256.hpp>
@@ -219,7 +230,7 @@ public:
     /// The WHOLE persisted Simplified Masternode List TOGETHER WITH THE
     /// HEIGHT IT IS CURRENT AT. Both halves are mandatory: the list carries
     /// the PoSe REMOVALS, and the height is what makes them safe to apply
-    /// (see maybe_fold_sml() — a wholesale fold is only valid at ONE cursor
+    /// (see the PER-HEIGHT PoSe FOLD block — a fold is only valid at ONE cursor
     /// position) and what gates the reactive walk's attestations for
     /// staleness. `list == nullptr` means this node has no verified SML yet.
     ///
@@ -231,6 +242,16 @@ public:
         uint32_t                         height{0};
     };
     using SmlSnapshotFn = std::function<SmlSnapshot()>;
+
+    /// Request the FULL Simplified Masternode List as of a specific historical
+    /// block: getmnlistd(ZERO, block_hash). Wired by main_dash to the same
+    /// coin-P2P primitive quorum_member_source.hpp already uses, and the reply
+    /// is routed back through the SAME historical demux — a historical reply
+    /// must never reach the tip-SML maintainer.
+    using RequestSnapshotFn = std::function<void(const uint256& block_hash)>;
+    /// The PoW-verified header's hashMerkleRoot for a held block hash — the
+    /// DIP-4 trust anchor for authenticating a snapshot.
+    using MerkleRootAtFn = MerkleRootOfHashFn;
 
     enum class State {
         Unarmed,      ///< no checkpoint loaded — the lane does nothing
@@ -272,6 +293,19 @@ public:
     /// reactive walk runs with no freshness gate (its pre-existing behaviour).
     void set_sml_snapshot_fn(SmlSnapshotFn fn) { m_sml_snapshot = std::move(fn); }
     bool has_sml_snapshot_fn() const { return static_cast<bool>(m_sml_snapshot); }
+    /// Both are REQUIRED for per-height folding. Unwired, the lane degrades to
+    /// the additions-only replay plus the per-mismatch walk, and says so.
+    void set_request_snapshot_fn(RequestSnapshotFn fn)
+    {
+        m_request_snapshot = std::move(fn);
+    }
+    void set_merkle_root_at_fn(MerkleRootAtFn fn)
+    {
+        m_merkle_root_at = std::move(fn);
+    }
+    /// How many blocks between fold points. Coarse on purpose: a fold is a
+    /// network round trip and the per-mismatch walk covers the gaps.
+    void set_fold_interval(uint32_t n) { m_fold_interval = n ? n : 1; }
 
     /// Maximum number of blocks the bridge is willing to replay. A checkpoint
     /// further behind the tip than this is treated as STALE and refused: the
@@ -305,8 +339,18 @@ public:
         // dangerous one — a second bridge on a re-armed lane would run
         // additions-only while sml_folded() still reported true, i.e. it would
         // LIE about having applied removals.
-        m_sml_folded      = false;
-        m_sml_folded_at   = 0;
+        m_sml_folded       = false;
+        m_sml_folded_at    = 0;
+        m_folds            = 0;
+        m_first_fold_height = 0;
+        m_last_fold_height = 0;
+        m_anchor_fold_done = false;
+        m_snapshot_pending = false;
+        m_snapshot_hash    = uint256();
+        m_snapshot_height  = 0;
+        m_snapshot_waits   = 0;
+        m_abandoned_folds  = 0;
+        m_abandoned.clear();
         m_pose_removed    = 0;
         m_pose_reinstated = 0;
         m_sml_recovered   = 0;
@@ -347,6 +391,11 @@ public:
     size_t   pose_reinstated()    const { return m_pose_reinstated; }
     bool     sml_folded()         const { return m_sml_folded; }
     uint32_t sml_folded_at()      const { return m_sml_folded_at; }
+    /// The FIRST fold's height. Distinct from sml_folded_at(), which tracks the
+    /// most recent — a bridge folds at the anchor, at intervals, and at the
+    /// tip, so "did we fold before the first block" is a different question
+    /// from "where did we fold last".
+    uint32_t first_fold_height()  const { return m_first_fold_height; }
     size_t   replay_registered()  const { return m_registered; }
     size_t   replay_spent()       const { return m_spent; }
     bool     failed_closed() const { return m_state == State::FailedClosed; }
@@ -436,7 +485,7 @@ public:
             // ~2000-block window is 6 exclusions, i.e. the whole budget, and a
             // third masternode in either burst overruns it. Exhaustion is
             // TERMINAL. That is a real limitation of the walk, and it is a
-            // second reason the wholesale fold (maybe_fold_sml) is the right
+            // second reason the per-height wholesale fold is the right
             // mechanism: a fold is ONE pass over the list and spends NO budget
             // at all, so a burst costs it nothing. The cap is deliberately
             // left as-is rather than widened — widening it would license
@@ -449,19 +498,36 @@ public:
                      << " blocks) onto the anchored set";
         }
 
-        // F4: the anchor height is itself a valid fold cursor -- and the ONLY
-        // dispatch that can ever observe it. The post-apply fold in
-        // on_block_connected first runs at cursor == anchor+1, and the publish()
-        // fold runs at the final cursor, so an SML current EXACTLY at the anchor
-        // (cursor == H_sml == anchor -- the canonical NON-early position: the
-        // loaded snapshot IS the state after connecting H_sml) is otherwise
-        // silently forfeited, leaving the first replayed blocks unprotected.
-        // Dispatch once here at bridge start; maybe_fold_sml()'s own
-        // cursor == snap.height guard makes this a no-op unless H_sml == anchor,
-        // so it can never fold early. (One-shot latch: it will not re-run once
-        // the post-apply site takes over for cursor > anchor.)
-        maybe_fold_sml();
-        if (m_state != State::Bridging) return;   // the fold can fail closed
+        // ── ANCHOR FOLD (F4). Two separate fixes meet on this line and BOTH
+        // are kept:
+        //
+        //   • WHERE the fold is dispatched from. Bridge start is the only
+        //     dispatch site that can ever observe cursor == anchor: the
+        //     post-apply site in on_block_connected first runs at cursor ==
+        //     anchor+1, and publish() runs at the final cursor, so the anchor
+        //     position — the canonical NON-early one, because the loaded
+        //     snapshot IS the state after connecting the anchor — was silently
+        //     forfeited and the first replayed blocks went unprotected. That
+        //     is the fix in "fold at the anchor cursor, not only post-apply",
+        //     and this call site is it.
+        //
+        //   • WHICH list the fold consumes. Dispatching here was necessary but
+        //     not sufficient: the old dispatch folded the TIP SML and was a
+        //     no-op unless H_sml happened to equal the anchor, which during a
+        //     catch-up it does not. So the dispatch now REQUESTS the list as of
+        //     the anchor rather than hoping the tip one is dated there, and the
+        //     anchor fold fires every time instead of by coincidence.
+        if (!m_snapshot_pending && !m_anchor_fold_done
+            && m_next == m_anchor_height + 1 && m_request_snapshot) {
+            m_anchor_fold_done = true;
+            if (begin_fold(m_anchor_height)) return;   // paused; reply resumes
+        }
+        // A PAUSED replay is a stopped replay. If the reply never comes (peer
+        // dropped it, swapped, or does not serve that height) the bridge would
+        // wait forever with no symptom other than "the arm never armed" — the
+        // silent-refusal defect class. Re-ask, then give up on THAT fold point
+        // and carry on degraded rather than wedge.
+        if (m_snapshot_pending && !tick_pending_fold()) return;
 
         // Cursor already at (or past) the tip: the bridge is complete.
         if (m_next > tip) { publish(tip); return; }
@@ -492,6 +558,11 @@ public:
     void on_block_connected(const BlockType& block, uint32_t height)
     {
         if (m_state != State::Bridging) return;
+        // PAUSED: a fold request is outstanding for the current cursor. The
+        // cursor must not advance past the height the pending list describes,
+        // or the fold would land EARLY. Blocks arriving now are dropped; they
+        // are re-requested when the fold completes.
+        if (m_snapshot_pending) return;
         if (height != m_next) return;
 
         // Publish the SML's own height into the machine BEFORE it adjudicates
@@ -521,14 +592,20 @@ public:
 
         m_next = height + 1;
         ++m_applied;
-        // ── WHOLESALE PoSe fold, at the ONE cursor position where it is safe.
-        // Sequenced by HEIGHT, never by arrival order: see maybe_fold_sml().
-        maybe_fold_sml();
-        // The fold can fail closed (oversized list). Return immediately: the
-        // tail of this function calls request_window(), which unconditionally
-        // rewrites m_status and would erase the refusal reason the operator
-        // needs.
-        if (m_state != State::Bridging) return;
+        // ── PER-HEIGHT PoSe fold. The cursor is now exactly `height`; if
+        // this is a fold point, request the list AS OF it and pause.
+        if (m_tip_height) {
+            const uint32_t tip_now = m_tip_height();
+            auto target = fold_target(height, tip_now);
+            if (target && *target == height && begin_fold(height)) {
+                // Paused. Do not fall through to request_window(): the reply
+                // resumes the replay.
+                m_sml_recovered += r.sml_recovered;
+                m_registered    += r.registered;
+                m_spent         += r.spent;
+                return;
+            }
+        }
         m_sml_recovered += r.sml_recovered;
         m_registered    += r.registered;
         m_spent         += r.spent;
@@ -564,125 +641,280 @@ private:
     }
 
     // ─────────────────────────────────────────────────────────────────────
-    // maybe_fold_sml — the WHOLESALE PoSe removal, at the ONE safe cursor
+    // PER-HEIGHT PoSe FOLD — cursor == H_sml BY CONSTRUCTION
     // ─────────────────────────────────────────────────────────────────────
     //
-    // WHY IT IS NEEDED. The reactive walk (recover_from_sml_ban) adjudicates
-    // ONE queue-head exclusion per height, and each success must re-attribute
-    // the payment to the next candidate "whose scriptPayout matches this
-    // coinbase exactly". That works for ISOLATED bans and is proven to: on
-    // mainnet 2026-08-02 it ran and succeeded five times during the replay
-    // (bridge total 1/6 … 5/6). It cannot work for a BURST. The chain shows
-    // what actually broke:
+    // WHY THE TIP SML COULD NEVER DO THIS. A fold is only valid at one cursor
+    // position: apply cursor == the height the list describes. The embedded
+    // SML tracks the TIP (main_dash issues getmnlistd on every tip change), so
+    // during catch-up H_sml sits at or ahead of the tip while the replay
+    // cursor is behind it. Waiting for the two to coincide is a race between
+    // replay rate and mnlistdiff cadence, and it loses: every failing height
+    // during catch-up is a height the tip fold cannot reach. That is pinned by
+    // FoldMissesTheWindowWhenTheSmlTracksTheMovingTip.
     //
-    //     h=2514800   valid 2062, our projected MN PRESENT
-    //     h=2514873   valid 2059, our projected MN ABSENT
-    //                 -> THREE masternodes banned inside 73 blocks
-    //     h=2515025   valid 2063, still ABSENT (never revived)
+    // THE FIX IS TO STOP GUESSING AND ASK. getmnlistd(ZERO, hash_at(H)) yields
+    // the FULL list as of H — the same primitive quorum_member_source.hpp
+    // already uses to source a historical member set. So the lane requests the
+    // list for the height it is standing on, and folds THAT.
     //
-    // Three consecutive banned queue-head candidates defeat a walk that has
-    // to land an exact coinbase script match at every step. The wholesale
-    // fold fixes it precisely BECAUSE it makes a burst indistinguishable from
-    // a single ban: all three leave the eligible set in one pass, before any
-    // of them is ever projected.
+    // ── WHY "EARLY" IS NOW UNREACHABLE, FROM THE CODE ────────────────────
     //
-    // ── THE ORDERING RULE, AND WHY VIOLATING IT IS ASYMMETRIC ────────────
+    // EARLY meant: applying validity from a list dated LATER than the cursor,
+    // so a masternode banned between the cursor and the list's date is removed
+    // at heights the chain still paid it. That required the list's date and
+    // the cursor to differ. Here they cannot:
     //
-    // The SML is a snapshot of the state AFTER connecting H_sml. A wholesale
-    // fold is valid at EXACTLY ONE cursor position: apply cursor == H_sml —
-    // after apply_block(H_sml), before apply_block(H_sml+1). Sequenced by
-    // HEIGHT, never by arrival order.
+    //   1. fold_target() picks H, and we request hash_at(H) from our OWN
+    //      PoW-validated header chain. The request names a block, not a range.
+    //   2. on_historical_snapshot() consumes a reply ONLY if
+    //      diff.blockHash == m_snapshot_hash (the exact block we asked for)
+    //      AND diff.baseBlockHash.IsNull() (a full snapshot, not a delta).
+    //   3. authenticate_historical_snapshot() then REFUSES the reply unless
+    //      the embedded cbTx's nHeight == H. A peer cannot substitute another
+    //      block's genuine snapshot.
+    //   4. The fold is applied only while m_paused_at == H == cursor_height().
     //
-    //   EARLY (cursor < H_sml) is DANGEROUS, and this is the whole reason the
-    //   fold is gated rather than run per-height. A masternode banned at
-    //   h_ban <= H_sml would be removed at heights where the chain still held
-    //   it valid and actually paid it. The mild outcome is a spurious terminal
-    //   fail-close. The severe one is silent: inside a shared-payoutAddress
-    //   group the divergence is SCRIPT-INVISIBLE (see the residual note in
-    //   this file's header), the coinbase cross-check still passes, and the
-    //   bridge PUBLISHES A WRONG QUEUE — the exact bad-cb-payee this lane
-    //   exists to prevent. An early fold also perturbs queue POSITION for
-    //   nodes it touches, because sync_validity_from_sml bumps
-    //   nPoSeRevivedHeight, which is a CompareByLastPaid sort key.
+    // So the list is consensus-committed AT H (its root is proven into the
+    // coinbase of block H, whose header we PoW-validated) and it is applied
+    // with the cursor exactly at H. "Dated later than the cursor" has no
+    // representable state. EARLY is not unlikely here; it is unreachable.
     //
-    //   LATE (cursor > H_sml) is BENIGN: it is today's behaviour, and the
-    //   reactive walk still catches a ban when it reaches the queue head.
+    // ── SEQUENCING, AND THE ONE-OUTSTANDING-REQUEST CONSTRAINT ───────────
     //
-    // So the fold NEVER runs early. If the cursor passes H_sml without an SML
-    // present, it simply does not happen and the walk carries the window
-    // alone — degraded, and said so out loud.
+    // Only one getmnlistd may be outstanding: replies are matched by block
+    // hash and a second in-flight request draws a reply that matches no await
+    // and leaks past the demux. The lane therefore has at most ONE request in
+    // flight, enforced structurally rather than by bookkeeping:
     //
-    // TWO DISPATCH POINTS, ONE RULE. This is called after each successful
-    // apply_block (catching cursor == H_sml mid-replay, which is what lets a
-    // burst at H_sml+1 be survived) and once more from publish() (catching
-    // H_sml == tip, and the zero-block bridge). Both test the same equality
-    // and the fold is one-shot, so they cannot double-apply.
-    void maybe_fold_sml()
-    {
-        if (m_sml_folded) return;
-        if (!m_sml_snapshot) return;
-        const SmlSnapshot snap = m_sml_snapshot();
-        if (!snap.list || snap.list->size() == 0) {
-            if (!m_warned_no_sml) {
-                m_warned_no_sml = true;
-                LOG_WARNING << "[MN-CKPT] no verified SML available at cursor h="
-                            << cursor_height()
-                            << " — the replay can only ADD masternodes until"
-                               " one arrives, and a PoSe ban inside the window"
-                               " must then be carried by the per-mismatch walk"
-                               " alone (which a multi-masternode ban BURST can"
-                               " defeat).";
-            }
-            return;
-        }
-        const uint32_t cursor = cursor_height();
-        if (cursor != snap.height) return;   // never early; late is benign
+    //   • On reaching a fold height the lane sets m_snapshot_pending and
+    //     STOPS pulling blocks (request_window() returns immediately while
+    //     paused). The replay cannot run ahead of its own fold.
+    //   • It issues exactly one request and will not issue another until that
+    //     one is consumed, refused, or the lane fails closed.
+    //   • on_block_connected() ignores blocks while paused (the cursor cannot
+    //     advance past the fold height), so no second fold height can be
+    //     reached while one is in flight.
+    //
+    // Coarse-grained on purpose: kDefaultFoldInterval blocks between folds,
+    // plus the anchor and the final height. The per-mismatch walk covers the
+    // gaps, which is the split that was already right — it was just being fed
+    // the wrong SML.
+    //
+    // ── WHAT THE FOLD IS WORTH NOW ───────────────────────────────────────
+    //
+    // The tip-SML fold trusted a list that on_mnlistdiff never checks against
+    // cbTx.merkleRootMNList. This one is DIP-4 client-verified before it is
+    // believed (historical_sml.hpp), so the F5 size bound below is now
+    // defence-in-depth rather than the only defence.
 
+public:
+    /// Blocks between fold points.
+    static constexpr uint32_t kDefaultFoldInterval = 500;
+
+    /// The next height at or after `cursor` at which we want a snapshot, or
+    /// nullopt when none remains before `tip`. Always includes the tip so the
+    /// published set is current, and the anchor so the first replayed block is
+    /// already projected from a correct eligible set.
+    std::optional<uint32_t> fold_target(uint32_t cursor, uint32_t tip) const
+    {
+        if (cursor > tip) return std::nullopt;
+        if (cursor == m_anchor_height) return cursor;          // anchor
+        if (cursor == tip) return cursor;                      // final
+        if (m_last_fold_height == 0) return cursor;
+        if (cursor - m_last_fold_height >= m_fold_interval) return cursor;
+        return std::nullopt;
+    }
+
+    /// Ask for the list as of `height`, and pause the replay until it lands.
+    /// Returns true when a request was issued (caller must stop pulling).
+    bool begin_fold(uint32_t height)
+    {
+        if (!m_request_snapshot || !m_merkle_root_at || !m_header_hash_at)
+            return false;
+        auto hash = m_header_hash_at(height);
+        if (!hash) return false;              // header not held yet; retry later
+        m_snapshot_pending = true;
+        m_snapshot_hash    = *hash;
+        m_snapshot_height  = height;
+        m_snapshot_waits   = 0;
+        LOG_INFO << "[MN-CKPT] PoSe fold: requesting the masternode list AS OF"
+                    " h=" << height << " (" << hash->GetHex().substr(0, 16)
+                 << ") — replay PAUSED until it lands, so the cursor cannot"
+                    " run past the height the list describes";
+        m_request_snapshot(*hash);
+        return true;
+    }
+
+    /// Called once per pump() while a fold request is outstanding. Returns
+    /// TRUE when the fold has been ABANDONED and the caller may resume the
+    /// replay; FALSE while it is still worth waiting.
+    bool tick_pending_fold()
+    {
+        ++m_snapshot_waits;
+        if (m_snapshot_waits == kFoldRetryPumps && m_request_snapshot) {
+            LOG_WARNING << "[MN-CKPT] no reply to the h=" << m_snapshot_height
+                        << " masternode-list request after " << m_snapshot_waits
+                        << " drives — re-asking (same block, so still ONE"
+                           " outstanding request: a reply to either ask is"
+                           " indistinguishable and both are ours)";
+            m_request_snapshot(m_snapshot_hash);
+            return false;
+        }
+        if (m_snapshot_waits < kFoldGiveUpPumps) return false;
+
+        // GIVE UP on this fold point rather than wedge the whole bridge. The
+        // cursor is still exactly at m_snapshot_height, so nothing is
+        // mis-dated; we simply do not get this fold, and the per-mismatch walk
+        // carries the interval as it did before the fold existed.
+        LOG_WARNING << "[MN-CKPT] ABANDONING the PoSe fold at h="
+                    << m_snapshot_height << " after " << m_snapshot_waits
+                    << " drives with no usable reply. The replay RESUMES"
+                       " degraded: this interval is carried by the"
+                       " per-mismatch walk alone, whose budget a ban BURST can"
+                       " exhaust. This is reported in status(), not swallowed.";
+        // The claim is NOT released. A late reply to an abandoned request is
+        // still a base=ZERO snapshot at an OLD block, and letting it fall
+        // through to the tip feed would rewrite the LIVE tip SML to a past
+        // state — the reward-critical corruption. We keep claiming it and drop
+        // it on the floor.
+        remember_abandoned(m_snapshot_hash);
+        m_snapshot_pending = false;
+        m_abandoned_folds++;
+        m_last_fold_height = m_snapshot_height;   // do not re-ask immediately
+        return true;
+    }
+
+    /// Consume a historical snapshot reply. Returns TRUE iff it answered a
+    /// request THIS lane made — in which case the caller must NOT also feed
+    /// the tip-SML maintainer, even if the lane then refuses the content or
+    /// had already given up waiting for it.
+    bool on_historical_snapshot(const vendor::CSimplifiedMNListDiff& diff)
+    {
+        if (!diff.baseBlockHash.IsNull()) return false;   // not a full snapshot
+        if (!m_snapshot_pending || diff.blockHash != m_snapshot_hash) {
+            // A LATE reply to a request we abandoned. Claim it (so it cannot
+            // reach the live tip SML) and drop it: the cursor has moved on, so
+            // applying it now would be a fold dated BEFORE the cursor.
+            if (is_abandoned(diff.blockHash)) {
+                LOG_WARNING << "[MN-CKPT] late masternode-list reply for an"
+                               " ABANDONED fold ("
+                            << diff.blockHash.GetHex().substr(0, 16)
+                            << ") — claimed and DROPPED. It must not reach the"
+                               " live tip SML, and it is too late to fold.";
+                return true;
+            }
+            return false;
+        }
+
+        m_snapshot_pending = false;
+        const uint32_t h = m_snapshot_height;
+
+        vendor::CCbTx cbtx;
+        auto sml = authenticate_historical_snapshot(
+            diff, h, m_merkle_root_at, cbtx, "MN-CKPT");
+        if (!sml) {
+            fail_closed(
+                "the masternode list served for h=" + std::to_string(h)
+                + " failed DIP-4 client verification (see the AUTH FAILED line"
+                  " above). Refusing to fold an unauthenticated list into the"
+                  " payee set — that list decides who gets paid.");
+            return true;   // consumed: it matched our await
+        }
+
+        apply_fold(*sml, h);
+        if (m_state != State::Bridging) return true;
+
+        // Resume: the cursor is exactly at h, so the next block is h+1.
+        if (m_tip_height) {
+            const uint32_t tip = m_tip_height();
+            if (m_next > tip) { publish(tip); return true; }
+            request_window(tip);
+        }
+        return true;
+    }
+
+    bool snapshot_pending() const { return m_snapshot_pending; }
+    uint32_t folds_applied() const { return m_folds; }
+    uint32_t abandoned_folds() const { return m_abandoned_folds; }
+
+    /// Pumps to wait before re-asking, and before giving up on a fold point.
+    /// pump() is driven by tip changes (~2.5 min on mainnet), so these are
+    /// generous in wall-clock terms and deliberately so: abandoning a fold
+    /// costs the bridge its burst-proof mechanism for that interval.
+    static constexpr uint32_t kFoldRetryPumps  = 3;
+    static constexpr uint32_t kFoldGiveUpPumps = 12;
+
+private:
+    /// Keep claiming a small ring of abandoned request hashes. Bounded: this
+    /// is a leak-proof guard, not a history.
+    static constexpr size_t kAbandonedRing = 16;
+    void remember_abandoned(const uint256& h)
+    {
+        if (m_abandoned.size() >= kAbandonedRing) m_abandoned.erase(m_abandoned.begin());
+        m_abandoned.push_back(h);
+    }
+    bool is_abandoned(const uint256& h) const
+    {
+        return std::find(m_abandoned.begin(), m_abandoned.end(), h)
+               != m_abandoned.end();
+    }
+
+    /// Apply an AUTHENTICATED list dated exactly at `height`, with the cursor
+    /// at `height`. Every caller must have established that equality.
+    void apply_fold(const vendor::CSimplifiedMNList& sml, uint32_t height)
+    {
         const size_t before = m_machine.eligible_size();
 
-        // F5 SANITY BOUND. The per-mismatch walk is capped AND cross-checked
-        // against the real coinbase at every step precisely so that "recovery"
-        // can never become a wholesale override of the projection. This fold IS
-        // a wholesale override — it rewrites validity for the entire set from
-        // one message, and on_mnlistdiff does not currently re-derive
-        // sml.CalcMerkleRoot() against diff.cbTx.merkleRootMNList, so the list
-        // is trusted rather than verified. A PoSe ban is a rare per-masternode
-        // event: a diff that would retire a large fraction of the set at once
-        // is not a ban wave, it is a corrupt or hostile list. Refuse it and say
-        // so, rather than publish a set with a hole in it.
-        const size_t would_remove = count_fold_removals(*snap.list);
+        // F5 SANITY BOUND, now defence-in-depth. The list is DIP-4 verified
+        // above, so this no longer stands alone — but a fold is still a
+        // wholesale rewrite of who may be paid, and a bound that costs nothing
+        // is worth keeping against a future path that forgets to verify.
+        const size_t would_remove = count_fold_removals(sml);
         const size_t bound = std::max<size_t>(kMinFoldRemovals,
                                              before / kMaxFoldRemovalDivisor);
         if (before != 0 && would_remove > bound) {
             return fail_closed(
-                "SML PoSe FOLD REFUSED at cursor h=" + std::to_string(cursor)
+                "SML PoSe FOLD REFUSED at h=" + std::to_string(height)
                 + ": the list would retire " + std::to_string(would_remove)
                 + " of " + std::to_string(before)
                 + " payee-eligible masternodes in one pass, over the 1/"
                 + std::to_string(kMaxFoldRemovalDivisor) + " sanity bound of "
                 + std::to_string(bound) + ". A PoSe ban is a rare per-node"
-                  " event; a fold this large is a corrupt or hostile SML, not a"
-                  " ban wave. NOTE: the SML is NOT root-verified against"
-                  " cbTx.merkleRootMNList on the diff ingest path, so this"
-                  " bound is the only thing standing between a bad list and a"
-                  " wholesale rewrite of the payee set.");
+                  " event; a fold this large is not a ban wave. (The list WAS"
+                  " DIP-4 client-verified, so this is defence-in-depth, not"
+                  " the only defence — treat it as a signal that the anchor or"
+                  " the replay is wrong rather than that the peer lied.)");
         }
 
-        const auto vr = m_machine.sync_validity_from_sml(*snap.list, snap.height);
+        const auto vr = m_machine.sync_validity_from_sml(sml, height);
         const size_t after = m_machine.eligible_size();
-        m_sml_folded    = true;
-        m_sml_folded_at = snap.height;
-        m_pose_removed    = vr.flipped_to_invalid;
-        m_pose_reinstated = vr.flipped_to_valid;
-        LOG_INFO << "[MN-CKPT] SML PoSe FOLD at cursor h=" << cursor
-                 << " (== the height the SML is current at): payee-eligible "
-                 << before << " -> " << after << " (-" << vr.flipped_to_invalid
-                 << " banned, +" << vr.flipped_to_valid << " revived; scanned "
-                 << vr.scanned << " SML entries, " << vr.matched << " ours)."
-                 << " A ban BURST leaves in one pass here, which the"
-                    " per-mismatch walk cannot do.";
+        if (!m_sml_folded) m_first_fold_height = height;
+        m_sml_folded       = true;
+        m_sml_folded_at    = height;
+        m_last_fold_height = height;
+        m_folds            += 1;
+        m_pose_removed     += vr.flipped_to_invalid;
+        m_pose_reinstated  += vr.flipped_to_valid;
+        // DELIBERATELY NOT set_sml_current_height(height) here. That looks
+        // right and is wrong. The freshness gate dates the list the WALK
+        // consults, and the walk consults set_sml_validity_fn() — the LIVE TIP
+        // list, not this historical snapshot. Declaring the fold's (past)
+        // height would UNDERSTATE the tip list's freshness and silently
+        // downgrade every walk attestation to "no opinion" until the next
+        // block's refresh_sml_height() undid it. The two lists are dated
+        // independently because they ARE independent.
+        LOG_INFO << "[MN-CKPT] PoSe FOLD at h=" << height
+                 << " (cursor == the height the list describes, by"
+                    " construction): payee-eligible " << before << " -> "
+                 << after << " (-" << vr.flipped_to_invalid << " banned, +"
+                 << vr.flipped_to_valid << " revived; scanned " << vr.scanned
+                 << " entries, " << vr.matched << " ours). List was DIP-4"
+                    " client-verified against the block's own coinbase"
+                    " commitment.";
     }
 
+public:
     /// How much of the payee-eligible set a single fold may retire: at most
     /// 1/N of it. Deliberately blunt — the point is to bound the blast radius
     /// of an unverified list, not to model ban rates.
@@ -724,21 +956,33 @@ private:
             + " REINSTATED: " + std::to_string(m_pose_reinstated)
             + ".";
 
-        if (!m_sml_snapshot) {
-            s += " NO SML SNAPSHOT SEAM IS WIRED — this replay could only ADD"
+        if (!m_request_snapshot || !m_merkle_root_at) {
+            s += " NO PER-HEIGHT SNAPSHOT SEAM IS WIRED (getmnlistd + header"
+                 " merkle-root lookup) — this replay could only ADD"
                  " masternodes, so ANY post-anchor PoSe ban lands here.";
         } else if (!m_sml_folded) {
-            s += " The WHOLESALE SML fold has NOT run (it applies only at"
-                 " cursor == the height the SML is current at, and never"
-                 " earlier — an early fold can publish a wrong queue"
-                 " silently). Every ban in this window is therefore being"
-                 " carried by the per-mismatch walk alone, which a BURST of"
-                 " masternodes banned close together defeats: it adjudicates"
-                 " one exclusion per height and must land an exact coinbase"
-                 " script match at each step.";
+            s += " NO per-height PoSe fold has been applied yet, so every ban"
+                 " in this window is being carried by the per-mismatch walk"
+                 " alone — and the walk's per-bridge budget is sized for"
+                 " ISOLATED bans, so a BURST can exhaust it.";
         } else {
-            s += " The wholesale SML fold ran at h="
-                 + std::to_string(m_sml_folded_at) + ".";
+            s += " Per-height PoSe folds applied: " + std::to_string(m_folds)
+                 + " (first at h=" + std::to_string(m_first_fold_height)
+                 + ", latest at h=" + std::to_string(m_sml_folded_at)
+                 + "); each was DIP-4 client-verified and applied with the"
+                   " cursor exactly at the height the list describes.";
+        }
+        if (m_abandoned_folds != 0) {
+            s += " " + std::to_string(m_abandoned_folds)
+                 + " fold point(s) were ABANDONED after no usable reply — the"
+                   " replay carried on degraded over those intervals, with the"
+                   " per-mismatch walk alone.";
+        }
+        if (m_snapshot_pending) {
+            s += " A masternode-list request for h="
+                 + std::to_string(m_snapshot_height) + " is OUTSTANDING and the"
+                   " replay is PAUSED on it (" + std::to_string(m_snapshot_waits)
+                 + " drives waited).";
         }
         if (m_sml_recovered >= m_sml_recovery_cap && m_sml_recovery_cap != 0) {
             s += " The per-bridge demotion-walk BUDGET is EXHAUSTED ("
@@ -779,6 +1023,16 @@ private:
         // Never rewrite the status of a lane that has already finished or
         // refused — that status is the only record of WHY.
         if (m_state != State::Bridging) return;
+        // Belt-and-braces on the one-outstanding-getmnlistd rule. TODAY THIS
+        // IS UNREACHABLE and mutation-testing says so: deleting it produces no
+        // red, because pump() already returns before request_window() while a
+        // fold is pending and on_historical_snapshot() clears the flag before
+        // resuming. It is kept because the load-bearing guards are two
+        // early-returns in two other functions, and a future caller that
+        // reaches request_window() by a third route must not start pulling
+        // blocks past the height the pending list describes. Read it as a
+        // backstop, not as the enforcement.
+        if (m_snapshot_pending) return;
         if (!m_request) {
             return fail_closed("no block-request seam wired — the bridge cannot"
                                " fetch the blocks it must replay");
@@ -820,8 +1074,6 @@ private:
         // only chance at all for a zero-block bridge). Same one-shot equality
         // gate as the mid-replay call — it cannot double-apply and it cannot
         // fire early.
-        maybe_fold_sml();
-
         const uint32_t as_of = m_next - 1;
         std::vector<std::pair<uint256, MNState>> out;
         out.reserve(m_machine.entries().size());
@@ -850,7 +1102,23 @@ private:
                    + " SML-recovered exclusions) as-of h=" + std::to_string(as_of)
                    + " (anchor h=" + std::to_string(m_anchor_height)
                    + " + " + std::to_string(m_applied) + " replayed blocks) "
-                   + delta;
+                   + delta
+                   + " PoSe folds: " + std::to_string(m_folds);
+        // A DEGRADED publish must say so. Publishing a set that was assembled
+        // without the fold points it asked for looks identical, from outside,
+        // to a clean bridge — and that silence is the defect: the operator has
+        // no way to tell that a ban BURST in an unfolded interval was carried
+        // by the walk alone, or not carried at all.
+        if (m_abandoned_folds != 0) {
+            m_status += " (DEGRADED: " + std::to_string(m_abandoned_folds)
+                        + " fold point(s) ABANDONED — no usable masternode-list"
+                          " reply, so those intervals were carried by the"
+                          " per-mismatch walk alone)";
+        }
+        if (m_folds == 0) {
+            m_status += " — NO per-height fold was ever applied; this set is"
+                        " the additions-only replay plus the walk";
+        }
         LOG_INFO << "[MN-CKPT] bridge COMPLETE: published " << out.size()
                  << " masternodes (" << m_sml_recovered
                  << " SML-recovered exclusions) as-of h=" << as_of
@@ -895,8 +1163,23 @@ private:
     size_t   m_anchor_eligible{0};  // payee-eligible count AT the anchor
     size_t   m_pose_removed{0};     // masternodes the wholesale fold banned
     size_t   m_pose_reinstated{0};  // masternodes the wholesale fold revived
-    bool     m_sml_folded{false};   // the one-shot wholesale fold has run
-    uint32_t m_sml_folded_at{0};    // ...at this height (== the SML's height)
+    bool     m_sml_folded{false};   // at least one per-height fold has run
+    uint32_t m_sml_folded_at{0};    // ...most recently at this height
+    uint32_t m_folds{0};            // how many per-height folds were applied
+    uint32_t m_first_fold_height{0};
+    uint32_t m_last_fold_height{0};
+    uint32_t m_fold_interval{kDefaultFoldInterval};
+    bool     m_anchor_fold_done{false};
+    // At most ONE outstanding getmnlistd, enforced structurally (request_window
+    // and on_block_connected both bail while this is set).
+    bool     m_snapshot_pending{false};
+    uint256  m_snapshot_hash;
+    uint32_t m_snapshot_height{0};
+    uint32_t m_snapshot_waits{0};     // pumps spent waiting on the current one
+    uint32_t m_abandoned_folds{0};
+    std::vector<uint256> m_abandoned; // requests we gave up on but still claim
+    RequestSnapshotFn m_request_snapshot;
+    MerkleRootAtFn    m_merkle_root_at;
     size_t   m_sml_recovery_cap{0}; // budget handed to the machine, mirrored
     size_t   m_registered{0};       // ADDS observed across the replay
     size_t   m_spent{0};            // collateral-spend removals across the replay

--- a/src/impl/dash/coin/mn_state_machine.hpp
+++ b/src/impl/dash/coin/mn_state_machine.hpp
@@ -218,7 +218,17 @@ public:
     /// published queue that diverges from dashd's for the rest of the run.
     /// An SML older than the height being adjudicated cannot speak to that
     /// height, so it is not evidence — nullopt, never false.
-    void set_sml_current_height(uint32_t h) { m_sml_height = h; }
+    /// Setting this ONCE opts the machine into fail-closed freshness: from
+    /// then on a height of 0 means "the SML covers NOTHING", not "covers
+    /// everything". The distinction matters because 0 is exactly what a warm
+    /// restart (F1) and an unpaired list/height (F2) produce, and in both
+    /// cases the honest answer is that we cannot date the attestation.
+    /// Callers that never call this keep the pre-gate behaviour byte for byte.
+    void set_sml_current_height(uint32_t h)
+    {
+        m_sml_height       = h;
+        m_sml_height_known = true;
+    }
     uint32_t sml_current_height() const     { return m_sml_height; }
 
     void set_sml_recovery_cap(size_t n) { m_sml_recovery_cap = n; }
@@ -683,7 +693,13 @@ public:
     /// operator actions.
     bool sml_covers(uint32_t height) const
     {
-        return m_sml_height == 0 || m_sml_height >= height;
+        // Caller never declared a height: pre-gate behaviour, unchanged.
+        if (!m_sml_height_known) return true;
+        // Declared, but zero — warm restart with no height restored, or a
+        // list/height pair that desynchronised. FAIL CLOSED: an undated
+        // attestation cannot license a permanent exclusion.
+        if (m_sml_height == 0) return false;
+        return m_sml_height >= height;
     }
 
     // Process a single block. Mutates state per dashcore's
@@ -1071,12 +1087,15 @@ private:
     {
         if (!m_sml_validity) return std::nullopt;
         if (!sml_covers(height)) {
-            LOG_WARNING << "[MNS-SM] SML STALE at h=" << height
-                        << ": the applied SML is current only at h="
-                        << m_sml_height
-                        << " and cannot attest this height — treating it as NO"
-                           " OPINION (a stale ban attestation would license a"
-                           " permanent demotion of a since-revived masternode)";
+            LOG_WARNING << "[MNS-SM] SML CANNOT DATE h=" << height
+                        << ": applied SML height="
+                        << (m_sml_height == 0 ? std::string("UNKNOWN (warm"
+                               " restart with no restored height, or a"
+                               " list/height pair that desynchronised)")
+                                              : std::to_string(m_sml_height))
+                        << " — treating it as NO OPINION (an undated or stale"
+                           " ban attestation would license a PERMANENT"
+                           " demotion of a since-revived masternode)";
             return std::nullopt;
         }
         return m_sml_validity(h);
@@ -1084,6 +1103,7 @@ private:
 
     SmlValidityFn m_sml_validity;
     uint32_t      m_sml_height{0};
+    bool          m_sml_height_known{false};
     size_t        m_sml_recovery_cap{0};
     size_t        m_sml_recovered_total{0};
 

--- a/src/impl/dash/coin/mn_state_machine.hpp
+++ b/src/impl/dash/coin/mn_state_machine.hpp
@@ -101,6 +101,7 @@
 #include <limits>
 #include <map>
 #include <optional>
+#include <set>
 #include <span>
 #include <string>
 #include <utility>
@@ -177,6 +178,12 @@ public:
         // disagreed with the coinbase AND the SML proved the disagreement was
         // a post-anchor consensus PoSe ban rather than a real desync.
         size_t sml_recovered{0};
+        // The coinbase paid a masternode that reconcile_pose_from_sml() had
+        // already excluded — proof that its PoSe ban had NOT yet taken effect
+        // at this height. The payment was attributed to it (the queue cursor
+        // must match dashd's) and the exclusion was KEPT. See
+        // recover_premature_pose_exclusion().
+        size_t pose_premature{0};
     };
 
     /// Optional validity attestation for a proTxHash, sourced from the
@@ -217,6 +224,38 @@ public:
     /// unbounded queue until something happens to match.
     static constexpr size_t kPayeeCandidates = 8;
 
+    /// dashcore CompareByLastPaid_GetHeight (deterministicmns.cpp:158-167),
+    /// extracted so the projection scan, the shared-payoutAddress
+    /// disambiguator and the premature-exclusion recovery can never drift
+    /// apart. Also normalises dashd's -1 "never" sentinels (stored as
+    /// UINT32_MAX by older snapshots), which cast back to int would otherwise
+    /// beat every real height.
+    static int payee_score(const MNState& st)
+    {
+        constexpr uint32_t SENTINEL = std::numeric_limits<uint32_t>::max();
+        auto sane = [](uint32_t v) -> uint32_t {
+            return (v == SENTINEL) ? 0u : v;
+        };
+        const uint32_t lastPaid = sane(st.nLastPaidHeight);
+        const uint32_t revived  = sane(st.nPoSeRevivedHeight);
+        int h = static_cast<int>(lastPaid);
+        if (revived != 0 && static_cast<int>(revived) > h) {
+            h = static_cast<int>(revived);
+        } else if (h == 0) {
+            h = static_cast<int>(st.nRegisteredHeight);
+        }
+        return h;
+    }
+
+    /// dashcore CompareByLastPaid: score ascending, ties by proTxHash memcmp
+    /// ascending (LE-byte wire order, NOT c2pool's CompareTo).
+    static bool payee_order_before(int a_score, const uint256& a,
+                                   int b_score, const uint256& b)
+    {
+        if (a_score != b_score) return a_score < b_score;
+        return std::memcmp(a.data(), b.data(), 32) < 0;
+    }
+
     /// as_of_height: the chain height this snapshot is CURRENT AT (0 =
     /// unknown / cold). It seeds the forward-contiguous apply cursor: the
     /// snapshot's lastPaidHeight set IS the DIP-3 payment queue as dashd
@@ -230,6 +269,10 @@ public:
     {
         m_entries.clear();
         m_collateral_index.clear();
+        // Bridge-owned PoSe exclusions name entries in the OLD set; carrying
+        // them across a reseed would let a later SML refresh "reinstate" a
+        // masternode this machine never excluded.
+        m_pose_excluded.clear();
         m_last_applied_height = as_of_height;
         for (auto& [h, st] : entries) {
             m_collateral_index[st.collateralOutpoint] = h;
@@ -324,19 +367,9 @@ public:
                 continue;
             }
             if (st.scriptPayout.m_data != script) continue;
-            uint32_t lastPaid = sane(st.nLastPaidHeight);
-            uint32_t revived  = sane(st.nPoSeRevivedHeight);
-            int h = static_cast<int>(lastPaid);
-            if (revived != 0 && static_cast<int>(revived) > h) {
-                h = static_cast<int>(revived);
-            } else if (h == 0) {
-                h = static_cast<int>(st.nRegisteredHeight);
-            }
+            const int h = payee_score(st);
             bool better = !best.has_value()
-                       || h < best_h
-                       || (h == best_h
-                           && std::memcmp(hash.data(),
-                                          best->data(), 32) < 0);
+                       || payee_order_before(h, hash, best_h, *best);
             if (better) {
                 best_h = h;
                 best   = hash;
@@ -437,22 +470,13 @@ public:
                          << " (divergent snapshot) -- excluded from projection";
                 continue;
             }
-            uint32_t lastPaid = sane_height(st.nLastPaidHeight);
-            uint32_t revived  = sane_height(st.nPoSeRevivedHeight);
-            int h = static_cast<int>(lastPaid);
-            if (revived != 0 && static_cast<int>(revived) > h) {
-                h = static_cast<int>(revived);
-            } else if (h == 0) {
-                h = static_cast<int>(st.nRegisteredHeight);
-            }
-            cands.emplace_back(h, hash);
+            cands.emplace_back(payee_score(st), hash);
         }
         // dashcore CompareByLastPaid: score ascending, ties broken by
         // proTxHash memcmp ascending (LE-byte, NOT c2pool's CompareTo).
         auto by_last_paid = [](const std::pair<int, uint256>& a,
                                const std::pair<int, uint256>& b) {
-            if (a.first != b.first) return a.first < b.first;
-            return std::memcmp(a.second.data(), b.second.data(), 32) < 0;
+            return payee_order_before(a.first, a.second, b.first, b.second);
         };
         if (cands.size() > k) {
             std::partial_sort(cands.begin(), cands.begin() + k, cands.end(),
@@ -619,6 +643,177 @@ public:
             it->second.isValid = sml_entry.isValid;
         }
         return r;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // reconcile_pose_from_sml — REMOVALS, not only additions
+    // ─────────────────────────────────────────────────────────────────────
+    //
+    // THE MEASURED DEFECT (mainnet, hotel dashd 23.1.7, 2026-08-02):
+    //
+    //     protx list valid false 2513000  -> 2068 entries (anchor)
+    //     protx list valid false 2514874  -> 2059 entries (tip)
+    //     the chain's payee-eligible set over that window  FELL  by 9
+    //     the checkpoint bridge's replayed set             CLIMBED by 3
+    //
+    // A forward replay of block special transactions can only ever ADD. A
+    // PoSe ban is NOT a transaction: dashd's CDeterministicMNManager derives
+    // it from consensus once an MN crosses MAX_PoSe_PENALTY. So the replay
+    // sees every ProRegTx and no ban at all, and the two sets diverge the
+    // moment any masternode is banned inside the window — near-certain over
+    // ~1900 mainnet blocks. The bridge then projects a banned masternode as
+    // payee and fails closed (correct refusal, wrong set).
+    //
+    // The Simplified Masternode List is the ONLY carrier of that ban, and we
+    // already receive and persist it. This is the pass that applies it: an
+    // entry the SML attests not-valid is REMOVED from the payee-eligible set,
+    // not merely skipped when it happens to be projected.
+    //
+    // ── WHY THIS RUNS *BEFORE* apply_block, NOT AFTER ────────────────────
+    //
+    // dashcore's BuildNewListFromBlock projects the payee for height H from
+    // the list as it stood after connecting H-1 (oldList.GetMNPayee), and
+    // per-MN VALIDITY is part of that list. So the reconciliation for H must
+    // land on the PRE-block set, before pass 0 ranks candidates — reconciling
+    // after apply_block(H) would leave H itself projected from stale validity
+    // (exactly today's bug) and only fix H+1.
+    //
+    // Pre-block ordering is ALSO what makes a removal and a registration in
+    // the SAME block safe, and it is the only ordering that is:
+    //
+    //   • A masternode REGISTERED by block H did not exist in dashd's H-1
+    //     list, so it cannot be H's payee and must not be touched by H's
+    //     reconciliation. Running pre-block gives that for free: it is not
+    //     yet in m_entries, so the SML entry for it is a no-op here. It
+    //     becomes reconcilable from H+1 — the first height at which it could
+    //     ever be projected.
+    //   • Post-block ordering would do the opposite and retro-ban a
+    //     masternode at its OWN registration height, which cannot happen in
+    //     consensus (a ProRegTx masternode enters valid, with zero penalty).
+    //   • A tx-driven ban in block H (ProUpRevTx / operator-key-change
+    //     ProUpRegTx) is applied by pass 1 AFTER this pass, at its exact
+    //     consensus height, and overwrites the provisional ban height this
+    //     pass would have written. Precision wins where it exists.
+    //
+    // ── THE SNAPSHOT HAZARD, AND WHY IT IS SELF-CORRECTING ───────────────
+    //
+    // The SML is a snapshot of NOW, not of H. Applying it at H < now removes
+    // a masternode EARLY when its ban actually fell between H and now — and
+    // if dashd paid it at H, our projection now disagrees with a real
+    // coinbase. That is a genuine hazard and it is handled, not hoped away:
+    // recover_premature_pose_exclusion() (pass 3) recognises the exact
+    // signature — the block pays a masternode WE excluded, which outranks our
+    // projection — attributes the payment to it so the queue cursor stays
+    // dashd-identical, and KEEPS the exclusion (it really is banned by now).
+    //
+    // ── OWNERSHIP: WHAT THIS PASS MAY AND MAY NOT UNDO ───────────────────
+    //
+    // Removals recorded here are BRIDGE-OWNED (m_pose_excluded) and only
+    // those may be reinstated when a later SML refresh attests the masternode
+    // valid again — the mnlistdiff feed keeps updating for the whole life of
+    // a multi-hour bridge, so a ban-then-revive inside the window is
+    // observable and must end VALID. A tx-driven ban is NOT bridge-owned and
+    // is never undone here: it is consensus-exact at a known height, and an
+    // SML that shows the masternode live at the TIP means it was revived by a
+    // ProUpServTx we have not folded yet. Undoing it early would put it back
+    // in the queue ahead of dashd's.
+    //
+    // COST: O(|SML|) map lookups per call (~3000 on DASH mainnet, tens of
+    // microseconds). The caller runs it once per replayed height; a 20k-block
+    // bridge pays a few seconds total against a replay that takes minutes.
+    struct PoseReconcileResult {
+        size_t scanned{0};          // SML entries iterated
+        size_t matched{0};          // also present in m_entries
+        size_t removed{0};          // payee-eligible -> excluded THIS pass
+        size_t reinstated{0};       // bridge-owned exclusion lifted THIS pass
+        size_t eligible_before{0};
+        size_t eligible_after{0};
+    };
+
+    PoseReconcileResult reconcile_pose_from_sml(
+        const vendor::CSimplifiedMNList& sml, uint32_t height)
+    {
+        PoseReconcileResult r;
+        r.eligible_before = eligible_size();
+        for (const auto& e : sml.mnList) {
+            ++r.scanned;
+            auto it = m_entries.find(e.proRegTxHash);
+            if (it == m_entries.end()) continue;   // not ours (yet) — no-op
+            ++r.matched;
+            MNState& st = it->second;
+
+            if (!e.isValid) {
+                // Already ineligible (tx-driven ban, or excluded by an
+                // earlier pass): nothing to do, and DO NOT claim ownership of
+                // a ban we did not create.
+                if (!st.isValid) continue;
+                st.isValid = false;
+                // Only stamp a provisional height where none exists — an
+                // exact tx-observed ban height must never be clobbered by our
+                // upper bound.
+                if (st.nPoSeBanHeight == 0) st.nPoSeBanHeight = height;
+                m_pose_excluded.insert(e.proRegTxHash);
+                ++r.removed;
+                ++m_pose_removed_total;
+                LOG_INFO << "[MNS-SM] PoSe REMOVAL h=" << height << ": "
+                         << e.proRegTxHash.GetHex().substr(0, 16)
+                         << " attested INVALID by the SML — dropped from the"
+                            " payee-eligible set (bridge-owned exclusion "
+                         << m_pose_removed_total << ")";
+                continue;
+            }
+
+            // SML attests VALID. Only lift exclusions this pass created.
+            auto owned = m_pose_excluded.find(e.proRegTxHash);
+            if (owned == m_pose_excluded.end()) continue;
+            m_pose_excluded.erase(owned);
+            if (st.isValid) continue;   // a ProUpServTx already revived it
+            st.isValid          = true;
+            st.nPoSeBanHeight   = 0;
+            if (height > st.nPoSeRevivedHeight) st.nPoSeRevivedHeight = height;
+            ++r.reinstated;
+            ++m_pose_reinstated_total;
+            LOG_WARNING << "[MNS-SM] PoSe REINSTATE h=" << height << ": "
+                        << e.proRegTxHash.GetHex().substr(0, 16)
+                        << " attested VALID again by a refreshed SML —"
+                           " bridge-owned exclusion lifted";
+        }
+        r.eligible_after = eligible_size();
+        return r;
+    }
+
+    /// Masternodes that would be projected as payee: valid, with no live PoSe
+    /// ban height. This — NOT size() — is the number to compare against
+    /// dashd's `protx list valid`. size() counts REGISTERED masternodes, and
+    /// the two moving in opposite directions is precisely the defect
+    /// reconcile_pose_from_sml() exists to fix.
+    size_t eligible_size() const
+    {
+        constexpr uint32_t SENTINEL = std::numeric_limits<uint32_t>::max();
+        size_t n = 0;
+        for (const auto& [hash, st] : m_entries) {
+            if (!st.isValid) continue;
+            const uint32_t ban =
+                (st.nPoSeBanHeight == SENTINEL) ? 0u : st.nPoSeBanHeight;
+            if (ban != 0) continue;
+            ++n;
+        }
+        return n;
+    }
+
+    size_t pose_removed_total() const    { return m_pose_removed_total; }
+    size_t pose_reinstated_total() const { return m_pose_reinstated_total; }
+    size_t pose_premature_total() const  { return m_pose_premature_total; }
+    size_t pose_excluded_count() const   { return m_pose_excluded.size(); }
+
+    /// What the installed SML hook says about a proTxHash, verbatim (nullopt
+    /// = absent from the SML / no hook). Exposed so a caller's fail-closed
+    /// diagnostic can NAME the masternode it projected and state whether the
+    /// SML considers it valid, instead of listing hypotheses.
+    std::optional<bool> sml_opinion(const uint256& h) const
+    {
+        if (!m_sml_validity) return std::nullopt;
+        return m_sml_validity(h);
     }
 
     // Process a single block. Mutates state per dashcore's
@@ -866,6 +1061,9 @@ public:
             if (it != m_entries.end()) {
                 if (paid_in_cb(it->second.scriptPayout.m_data)) {
                     mark_paid(it);
+                } else if (recover_premature_pose_exclusion(
+                               *projected, height, paid_in_cb, mark_paid, r)) {
+                    // handled: our SML removal was ahead of the real ban
                 } else if (!recover_from_sml_ban(ranked, height, paid_in_cb,
                                                  mark_paid, r)) {
                     r.payee_desync = true;
@@ -883,6 +1081,81 @@ public:
     }
 
 private:
+    // ─────────────────────────────────────────────────────────────────────
+    // recover_premature_pose_exclusion — the SML is a snapshot of NOW
+    // ─────────────────────────────────────────────────────────────────────
+    //
+    // reconcile_pose_from_sml() removes a masternode the SML attests banned
+    // AT THE TIP. During a replay of past blocks that removal can be EARLY:
+    // the ban may have fallen anywhere between the replayed height and the
+    // tip, and dashd paid the masternode normally right up to it.
+    //
+    // That case has an unmistakable signature, and it is the only one this
+    // accepts:
+    //
+    //   * the block pays, EXACTLY, the scriptPayout of a masternode THIS
+    //     BRIDGE excluded (m_pose_excluded — never a tx-driven ban, never an
+    //     arbitrary set member), and
+    //   * that masternode outranks our projected payee under dashcore's
+    //     CompareByLastPaid. If it sorted AFTER the projection, dashd would
+    //     have paid the projection first, so the coinbase is not explained by
+    //     a premature exclusion and this must not fire.
+    //
+    // On acceptance the payment is attributed to it — the DIP-3 queue cursor
+    // has to stay bit-identical to dashd's or every later projection is off
+    // by a slot — and the exclusion is KEPT: the masternode is genuinely
+    // banned by the time the bridge publishes, and marking it paid pushes it
+    // to the back of the queue anyway.
+    //
+    // No budget cap, deliberately: this is self-limiting. Each excluded
+    // masternode can be paid at most once per full queue rotation (~|set|
+    // blocks, ~2068 on mainnet — longer than a typical bridge), and every
+    // acceptance requires an exact coinbase script match plus a rank
+    // comparison. The count is surfaced (pose_premature_total) so the
+    // operator sees it, which is the point of the whole diagnostic contract.
+    template <typename PaidInCbFn, typename MarkPaidFn>
+    bool recover_premature_pose_exclusion(const uint256& projected,
+                                          uint32_t height,
+                                          const PaidInCbFn& paid_in_cb,
+                                          const MarkPaidFn& mark_paid,
+                                          ApplyResult& r)
+    {
+        if (m_pose_excluded.empty()) return false;
+        auto pit = m_entries.find(projected);
+        if (pit == m_entries.end()) return false;
+        const int projected_score = payee_score(pit->second);
+
+        std::optional<uint256> best;
+        int best_score = 0;
+        for (const auto& h : m_pose_excluded) {
+            auto it = m_entries.find(h);
+            if (it == m_entries.end()) continue;
+            if (!paid_in_cb(it->second.scriptPayout.m_data)) continue;
+            const int score = payee_score(it->second);
+            // Must have been AHEAD of what we projected, or dashd would not
+            // have paid it at this height.
+            if (!payee_order_before(score, h, projected_score, projected))
+                continue;
+            if (!best || payee_order_before(score, h, best_score, *best)) {
+                best_score = score;
+                best       = h;
+            }
+        }
+        if (!best) return false;
+
+        auto bit = m_entries.find(*best);
+        mark_paid(bit);
+        ++r.pose_premature;
+        ++m_pose_premature_total;
+        LOG_WARNING << "[MNS-SM] PoSe EXCLUSION WAS EARLY h=" << height
+                    << ": this block pays " << best->GetHex().substr(0, 16)
+                    << ", which the SML attests banned AT THE TIP but which"
+                       " was still eligible here — payment attributed (queue"
+                       " cursor stays dashd-exact), exclusion KEPT (bridge"
+                       " total " << m_pose_premature_total << ")";
+        return true;
+    }
+
     // ─────────────────────────────────────────────────────────────────────
     // recover_from_sml_ban — the ONLY licensed alternative to payee_desync
     // ─────────────────────────────────────────────────────────────────────
@@ -1002,6 +1275,15 @@ private:
     SmlValidityFn m_sml_validity;
     size_t        m_sml_recovery_cap{0};
     size_t        m_sml_recovered_total{0};
+
+    // Masternodes removed from the payee-eligible set by
+    // reconcile_pose_from_sml(). BRIDGE-OWNED: only these may be reinstated
+    // by a later SML refresh, and only these are candidates for the
+    // premature-exclusion recovery. A tx-driven ban never lands here.
+    std::set<uint256> m_pose_excluded;
+    size_t            m_pose_removed_total{0};
+    size_t            m_pose_reinstated_total{0};
+    size_t            m_pose_premature_total{0};
 
     // Forward-only apply cursor: height of the last block folded by
     // apply_block (0 = none since load). See ApplyResult::skipped_out_of_order.

--- a/src/impl/dash/coin/mn_state_machine.hpp
+++ b/src/impl/dash/coin/mn_state_machine.hpp
@@ -101,7 +101,6 @@
 #include <limits>
 #include <map>
 #include <optional>
-#include <set>
 #include <span>
 #include <string>
 #include <utility>
@@ -178,12 +177,6 @@ public:
         // disagreed with the coinbase AND the SML proved the disagreement was
         // a post-anchor consensus PoSe ban rather than a real desync.
         size_t sml_recovered{0};
-        // The coinbase paid a masternode that reconcile_pose_from_sml() had
-        // already excluded — proof that its PoSe ban had NOT yet taken effect
-        // at this height. The payment was attributed to it (the queue cursor
-        // must match dashd's) and the exclusion was KEPT. See
-        // recover_premature_pose_exclusion().
-        size_t pose_premature{0};
     };
 
     /// Optional validity attestation for a proTxHash, sourced from the
@@ -214,6 +207,20 @@ public:
     /// of them is not being repaired, it is being overridden, and the honest
     /// response to that is to fail closed. The caller sizes the budget
     /// against its replay distance; see MnCheckpointLane::pump().
+    /// FRESHNESS GATE for the reactive demotion walk. The height the
+    /// installed SML is CURRENT AT (0 = unknown, which keeps the pre-gate
+    /// behaviour for callers that do not track it).
+    ///
+    /// Why this is load-bearing: recover_from_sml_ban() turns an attestation
+    /// into a PERMANENT exclusion. A STALE SML can attest isValid=false for a
+    /// masternode that has since been revived; combined with a coincidental
+    /// runner-up script match, that licenses a wrong permanent demotion and a
+    /// published queue that diverges from dashd's for the rest of the run.
+    /// An SML older than the height being adjudicated cannot speak to that
+    /// height, so it is not evidence — nullopt, never false.
+    void set_sml_current_height(uint32_t h) { m_sml_height = h; }
+    uint32_t sml_current_height() const     { return m_sml_height; }
+
     void set_sml_recovery_cap(size_t n) { m_sml_recovery_cap = n; }
     size_t sml_recovery_cap() const     { return m_sml_recovery_cap; }
     size_t sml_recovered_total() const  { return m_sml_recovered_total; }
@@ -269,10 +276,6 @@ public:
     {
         m_entries.clear();
         m_collateral_index.clear();
-        // Bridge-owned PoSe exclusions name entries in the OLD set; carrying
-        // them across a reseed would let a later SML refresh "reinstate" a
-        // masternode this machine never excluded.
-        m_pose_excluded.clear();
         m_last_applied_height = as_of_height;
         for (auto& [h, st] : entries) {
             m_collateral_index[st.collateralOutpoint] = h;
@@ -645,148 +648,11 @@ public:
         return r;
     }
 
-    // ─────────────────────────────────────────────────────────────────────
-    // reconcile_pose_from_sml — REMOVALS, not only additions
-    // ─────────────────────────────────────────────────────────────────────
-    //
-    // THE MEASURED DEFECT (mainnet, hotel dashd 23.1.7, 2026-08-02):
-    //
-    //     protx list valid false 2513000  -> 2068 entries (anchor)
-    //     protx list valid false 2514874  -> 2059 entries (tip)
-    //     the chain's payee-eligible set over that window  FELL  by 9
-    //     the checkpoint bridge's replayed set             CLIMBED by 3
-    //
-    // A forward replay of block special transactions can only ever ADD. A
-    // PoSe ban is NOT a transaction: dashd's CDeterministicMNManager derives
-    // it from consensus once an MN crosses MAX_PoSe_PENALTY. So the replay
-    // sees every ProRegTx and no ban at all, and the two sets diverge the
-    // moment any masternode is banned inside the window — near-certain over
-    // ~1900 mainnet blocks. The bridge then projects a banned masternode as
-    // payee and fails closed (correct refusal, wrong set).
-    //
-    // The Simplified Masternode List is the ONLY carrier of that ban, and we
-    // already receive and persist it. This is the pass that applies it: an
-    // entry the SML attests not-valid is REMOVED from the payee-eligible set,
-    // not merely skipped when it happens to be projected.
-    //
-    // ── WHY THIS RUNS *BEFORE* apply_block, NOT AFTER ────────────────────
-    //
-    // dashcore's BuildNewListFromBlock projects the payee for height H from
-    // the list as it stood after connecting H-1 (oldList.GetMNPayee), and
-    // per-MN VALIDITY is part of that list. So the reconciliation for H must
-    // land on the PRE-block set, before pass 0 ranks candidates — reconciling
-    // after apply_block(H) would leave H itself projected from stale validity
-    // (exactly today's bug) and only fix H+1.
-    //
-    // Pre-block ordering is ALSO what makes a removal and a registration in
-    // the SAME block safe, and it is the only ordering that is:
-    //
-    //   • A masternode REGISTERED by block H did not exist in dashd's H-1
-    //     list, so it cannot be H's payee and must not be touched by H's
-    //     reconciliation. Running pre-block gives that for free: it is not
-    //     yet in m_entries, so the SML entry for it is a no-op here. It
-    //     becomes reconcilable from H+1 — the first height at which it could
-    //     ever be projected.
-    //   • Post-block ordering would do the opposite and retro-ban a
-    //     masternode at its OWN registration height, which cannot happen in
-    //     consensus (a ProRegTx masternode enters valid, with zero penalty).
-    //   • A tx-driven ban in block H (ProUpRevTx / operator-key-change
-    //     ProUpRegTx) is applied by pass 1 AFTER this pass, at its exact
-    //     consensus height, and overwrites the provisional ban height this
-    //     pass would have written. Precision wins where it exists.
-    //
-    // ── THE SNAPSHOT HAZARD, AND WHY IT IS SELF-CORRECTING ───────────────
-    //
-    // The SML is a snapshot of NOW, not of H. Applying it at H < now removes
-    // a masternode EARLY when its ban actually fell between H and now — and
-    // if dashd paid it at H, our projection now disagrees with a real
-    // coinbase. That is a genuine hazard and it is handled, not hoped away:
-    // recover_premature_pose_exclusion() (pass 3) recognises the exact
-    // signature — the block pays a masternode WE excluded, which outranks our
-    // projection — attributes the payment to it so the queue cursor stays
-    // dashd-identical, and KEEPS the exclusion (it really is banned by now).
-    //
-    // ── OWNERSHIP: WHAT THIS PASS MAY AND MAY NOT UNDO ───────────────────
-    //
-    // Removals recorded here are BRIDGE-OWNED (m_pose_excluded) and only
-    // those may be reinstated when a later SML refresh attests the masternode
-    // valid again — the mnlistdiff feed keeps updating for the whole life of
-    // a multi-hour bridge, so a ban-then-revive inside the window is
-    // observable and must end VALID. A tx-driven ban is NOT bridge-owned and
-    // is never undone here: it is consensus-exact at a known height, and an
-    // SML that shows the masternode live at the TIP means it was revived by a
-    // ProUpServTx we have not folded yet. Undoing it early would put it back
-    // in the queue ahead of dashd's.
-    //
-    // COST: O(|SML|) map lookups per call (~3000 on DASH mainnet, tens of
-    // microseconds). The caller runs it once per replayed height; a 20k-block
-    // bridge pays a few seconds total against a replay that takes minutes.
-    struct PoseReconcileResult {
-        size_t scanned{0};          // SML entries iterated
-        size_t matched{0};          // also present in m_entries
-        size_t removed{0};          // payee-eligible -> excluded THIS pass
-        size_t reinstated{0};       // bridge-owned exclusion lifted THIS pass
-        size_t eligible_before{0};
-        size_t eligible_after{0};
-    };
-
-    PoseReconcileResult reconcile_pose_from_sml(
-        const vendor::CSimplifiedMNList& sml, uint32_t height)
-    {
-        PoseReconcileResult r;
-        r.eligible_before = eligible_size();
-        for (const auto& e : sml.mnList) {
-            ++r.scanned;
-            auto it = m_entries.find(e.proRegTxHash);
-            if (it == m_entries.end()) continue;   // not ours (yet) — no-op
-            ++r.matched;
-            MNState& st = it->second;
-
-            if (!e.isValid) {
-                // Already ineligible (tx-driven ban, or excluded by an
-                // earlier pass): nothing to do, and DO NOT claim ownership of
-                // a ban we did not create.
-                if (!st.isValid) continue;
-                st.isValid = false;
-                // Only stamp a provisional height where none exists — an
-                // exact tx-observed ban height must never be clobbered by our
-                // upper bound.
-                if (st.nPoSeBanHeight == 0) st.nPoSeBanHeight = height;
-                m_pose_excluded.insert(e.proRegTxHash);
-                ++r.removed;
-                ++m_pose_removed_total;
-                LOG_INFO << "[MNS-SM] PoSe REMOVAL h=" << height << ": "
-                         << e.proRegTxHash.GetHex().substr(0, 16)
-                         << " attested INVALID by the SML — dropped from the"
-                            " payee-eligible set (bridge-owned exclusion "
-                         << m_pose_removed_total << ")";
-                continue;
-            }
-
-            // SML attests VALID. Only lift exclusions this pass created.
-            auto owned = m_pose_excluded.find(e.proRegTxHash);
-            if (owned == m_pose_excluded.end()) continue;
-            m_pose_excluded.erase(owned);
-            if (st.isValid) continue;   // a ProUpServTx already revived it
-            st.isValid          = true;
-            st.nPoSeBanHeight   = 0;
-            if (height > st.nPoSeRevivedHeight) st.nPoSeRevivedHeight = height;
-            ++r.reinstated;
-            ++m_pose_reinstated_total;
-            LOG_WARNING << "[MNS-SM] PoSe REINSTATE h=" << height << ": "
-                        << e.proRegTxHash.GetHex().substr(0, 16)
-                        << " attested VALID again by a refreshed SML —"
-                           " bridge-owned exclusion lifted";
-        }
-        r.eligible_after = eligible_size();
-        return r;
-    }
-
     /// Masternodes that would be projected as payee: valid, with no live PoSe
     /// ban height. This — NOT size() — is the number to compare against
     /// dashd's `protx list valid`. size() counts REGISTERED masternodes, and
-    /// the two moving in opposite directions is precisely the defect
-    /// reconcile_pose_from_sml() exists to fix.
+    /// the two moving in opposite directions is precisely the defect the
+    /// bridge's wholesale sync_validity_from_sml() fold exists to fix.
     size_t eligible_size() const
     {
         constexpr uint32_t SENTINEL = std::numeric_limits<uint32_t>::max();
@@ -801,11 +667,6 @@ public:
         return n;
     }
 
-    size_t pose_removed_total() const    { return m_pose_removed_total; }
-    size_t pose_reinstated_total() const { return m_pose_reinstated_total; }
-    size_t pose_premature_total() const  { return m_pose_premature_total; }
-    size_t pose_excluded_count() const   { return m_pose_excluded.size(); }
-
     /// What the installed SML hook says about a proTxHash, verbatim (nullopt
     /// = absent from the SML / no hook). Exposed so a caller's fail-closed
     /// diagnostic can NAME the masternode it projected and state whether the
@@ -814,6 +675,15 @@ public:
     {
         if (!m_sml_validity) return std::nullopt;
         return m_sml_validity(h);
+    }
+
+    /// True when the installed SML is new enough to speak about `height`.
+    /// Exposed so a caller's fail-closed diagnostic can say "the SML is
+    /// STALE" rather than "the SML had no opinion", which are different
+    /// operator actions.
+    bool sml_covers(uint32_t height) const
+    {
+        return m_sml_height == 0 || m_sml_height >= height;
     }
 
     // Process a single block. Mutates state per dashcore's
@@ -1061,9 +931,6 @@ public:
             if (it != m_entries.end()) {
                 if (paid_in_cb(it->second.scriptPayout.m_data)) {
                     mark_paid(it);
-                } else if (recover_premature_pose_exclusion(
-                               *projected, height, paid_in_cb, mark_paid, r)) {
-                    // handled: our SML removal was ahead of the real ban
                 } else if (!recover_from_sml_ban(ranked, height, paid_in_cb,
                                                  mark_paid, r)) {
                     r.payee_desync = true;
@@ -1081,81 +948,6 @@ public:
     }
 
 private:
-    // ─────────────────────────────────────────────────────────────────────
-    // recover_premature_pose_exclusion — the SML is a snapshot of NOW
-    // ─────────────────────────────────────────────────────────────────────
-    //
-    // reconcile_pose_from_sml() removes a masternode the SML attests banned
-    // AT THE TIP. During a replay of past blocks that removal can be EARLY:
-    // the ban may have fallen anywhere between the replayed height and the
-    // tip, and dashd paid the masternode normally right up to it.
-    //
-    // That case has an unmistakable signature, and it is the only one this
-    // accepts:
-    //
-    //   * the block pays, EXACTLY, the scriptPayout of a masternode THIS
-    //     BRIDGE excluded (m_pose_excluded — never a tx-driven ban, never an
-    //     arbitrary set member), and
-    //   * that masternode outranks our projected payee under dashcore's
-    //     CompareByLastPaid. If it sorted AFTER the projection, dashd would
-    //     have paid the projection first, so the coinbase is not explained by
-    //     a premature exclusion and this must not fire.
-    //
-    // On acceptance the payment is attributed to it — the DIP-3 queue cursor
-    // has to stay bit-identical to dashd's or every later projection is off
-    // by a slot — and the exclusion is KEPT: the masternode is genuinely
-    // banned by the time the bridge publishes, and marking it paid pushes it
-    // to the back of the queue anyway.
-    //
-    // No budget cap, deliberately: this is self-limiting. Each excluded
-    // masternode can be paid at most once per full queue rotation (~|set|
-    // blocks, ~2068 on mainnet — longer than a typical bridge), and every
-    // acceptance requires an exact coinbase script match plus a rank
-    // comparison. The count is surfaced (pose_premature_total) so the
-    // operator sees it, which is the point of the whole diagnostic contract.
-    template <typename PaidInCbFn, typename MarkPaidFn>
-    bool recover_premature_pose_exclusion(const uint256& projected,
-                                          uint32_t height,
-                                          const PaidInCbFn& paid_in_cb,
-                                          const MarkPaidFn& mark_paid,
-                                          ApplyResult& r)
-    {
-        if (m_pose_excluded.empty()) return false;
-        auto pit = m_entries.find(projected);
-        if (pit == m_entries.end()) return false;
-        const int projected_score = payee_score(pit->second);
-
-        std::optional<uint256> best;
-        int best_score = 0;
-        for (const auto& h : m_pose_excluded) {
-            auto it = m_entries.find(h);
-            if (it == m_entries.end()) continue;
-            if (!paid_in_cb(it->second.scriptPayout.m_data)) continue;
-            const int score = payee_score(it->second);
-            // Must have been AHEAD of what we projected, or dashd would not
-            // have paid it at this height.
-            if (!payee_order_before(score, h, projected_score, projected))
-                continue;
-            if (!best || payee_order_before(score, h, best_score, *best)) {
-                best_score = score;
-                best       = h;
-            }
-        }
-        if (!best) return false;
-
-        auto bit = m_entries.find(*best);
-        mark_paid(bit);
-        ++r.pose_premature;
-        ++m_pose_premature_total;
-        LOG_WARNING << "[MNS-SM] PoSe EXCLUSION WAS EARLY h=" << height
-                    << ": this block pays " << best->GetHex().substr(0, 16)
-                    << ", which the SML attests banned AT THE TIP but which"
-                       " was still eligible here — payment attributed (queue"
-                       " cursor stays dashd-exact), exclusion KEPT (bridge"
-                       " total " << m_pose_premature_total << ")";
-        return true;
-    }
-
     // ─────────────────────────────────────────────────────────────────────
     // recover_from_sml_ban — the ONLY licensed alternative to payee_desync
     // ─────────────────────────────────────────────────────────────────────
@@ -1208,7 +1000,7 @@ private:
         std::vector<uint256> demoted;
         std::optional<uint256> accepted;
         for (size_t i = 0; i + 1 < ranked.size(); ++i) {
-            const std::optional<bool> att = m_sml_validity(ranked[i]);
+            const std::optional<bool> att = sml_attest(ranked[i], height);
             // nullopt (absent from the SML) or true (attested valid): no
             // licence to demote. Stop — this is a real desync.
             if (!att.has_value() || *att) break;
@@ -1272,18 +1064,28 @@ private:
 
     // Optional SML attestation hook (see set_sml_validity_fn). NULL by
     // default: no hook, no recovery, byte-identical pre-hook behaviour.
+    /// Attestation AS USED BY THE WALK: sml_opinion() narrowed by the
+    /// freshness gate. A stale SML is downgraded to "no opinion" per entry,
+    /// which is exactly what stops it licensing a permanent demotion.
+    std::optional<bool> sml_attest(const uint256& h, uint32_t height) const
+    {
+        if (!m_sml_validity) return std::nullopt;
+        if (!sml_covers(height)) {
+            LOG_WARNING << "[MNS-SM] SML STALE at h=" << height
+                        << ": the applied SML is current only at h="
+                        << m_sml_height
+                        << " and cannot attest this height — treating it as NO"
+                           " OPINION (a stale ban attestation would license a"
+                           " permanent demotion of a since-revived masternode)";
+            return std::nullopt;
+        }
+        return m_sml_validity(h);
+    }
+
     SmlValidityFn m_sml_validity;
+    uint32_t      m_sml_height{0};
     size_t        m_sml_recovery_cap{0};
     size_t        m_sml_recovered_total{0};
-
-    // Masternodes removed from the payee-eligible set by
-    // reconcile_pose_from_sml(). BRIDGE-OWNED: only these may be reinstated
-    // by a later SML refresh, and only these are candidates for the
-    // premature-exclusion recovery. A tx-driven ban never lands here.
-    std::set<uint256> m_pose_excluded;
-    size_t            m_pose_removed_total{0};
-    size_t            m_pose_reinstated_total{0};
-    size_t            m_pose_premature_total{0};
 
     // Forward-only apply cursor: height of the last block folded by
     // apply_block (0 = none since load). See ApplyResult::skipped_out_of_order.

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -313,6 +313,13 @@ public:
     void set_quorum_healthy(bool v) { m_quorum_healthy = v; }
     bool quorum_healthy() const { return m_quorum_healthy; }
 
+    /// DIAGNOSTIC MIRROR of the maintainer's payee-desync latch, so
+    /// classify_decline() can report "mn-needs-reseed" instead of the far less
+    /// useful "not-populated". Purely observational: nothing on the serve or
+    /// reward path reads it.
+    void set_mn_needs_reseed(bool v) { m_mn_needs_reseed = v; }
+    bool mn_needs_reseed() const { return m_mn_needs_reseed; }
+
     /// BLOCKER-3 pre-emit HARD GATE. Before the embedded arm's template is
     /// served/mined, re-validate the BUILT CbTx against consensus invariants;
     /// any failure => the caller must fall back to the reward-safe dashd path.
@@ -547,6 +554,14 @@ public:
     /// gate-off node is how the absent mainnet opt-in manifests here.
     std::string classify_decline() const {
         const uint32_t next_h = m_prev_height + 1;
+        // MN PAYEE-DESYNC LATCH — checked FIRST because it is a strictly more
+        // informative cause of the not-populated state that follows it. Before
+        // this line the latch was log-only: the smoke rig reported 639
+        // consecutive "not-populated" declines while the actual cause (a payee
+        // desync at h=2514874 that can only be cleared by an authoritative
+        // re-seed a daemonless node cannot obtain) appeared nowhere a human
+        // reading the decline classification would look.
+        if (m_mn_needs_reseed) return "mn-needs-reseed";
         if (!m_populated)      return "not-populated";
         if (m_prev_hash.IsNull()) return "no-tip";
         if (m_qc_plan_fn && !m_qc_plan_fn(next_h)) return "qc-plan-underivable";
@@ -673,6 +688,10 @@ private:
     uint256  m_credit_pool_current_hash;     // block hash the credit-pool seed is current at
     int32_t  m_credit_pool_height{-1};       // seed cbTx's OWN height (-1 = never seeded)
     bool     m_quorum_healthy{true};         // last diff's quorum tail parsed OK
+    // Mirror of CoinStateMaintainer's payee-desync latch, published here purely
+    // so classify_decline() can NAME it. Never consulted by any serve/reward
+    // path — the latch itself lives (and gates) in the maintainer.
+    bool     m_mn_needs_reseed{false};
     uint32_t m_prev_height{0};
     uint256  m_prev_hash;
     uint32_t m_bits_for_next{0};

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -45,6 +45,7 @@
 
 #include <impl/dash/crypto/hash_x11.hpp>   // block identity on Dash = X11(header)
 #include <impl/dash/coin/governance_object.hpp> // govobject_hash / govvote_signature_hash (dashcore-exact digests)
+#include <impl/dash/coin/historical_sml.hpp>    // HistoricalMnListDiffDemux (reward-critical tip/historical split)
 
 #include <algorithm>
 #include <memory>
@@ -225,15 +226,16 @@ private:
     // re-selected forever. Optional; unset on the legacy single-peer path.
     PeerLifecycleCallback m_on_dial_failed;
 
-    // E1 Phase-L member-set sourcing DEMUX: a filter that consumes HISTORICAL
-    // mnlistdiff replies (full base=ZERO snapshots at old quorum-base / work
-    // blocks, requested by QuorumMemberSource) BEFORE they reach the tip-SML
-    // maintainer — which treats any ZERO-base diff as a full snapshot and would
-    // overwrite the tip SML to that historical block. Returns true iff it
-    // consumed the diff; then new_mnlistdiff is NOT fired. Unset => no demux.
-    using MnListDiffFilter =
-        std::function<bool(const vendor::CSimplifiedMNListDiff&)>;
-    MnListDiffFilter m_historical_mnlistdiff_filter;
+    // HISTORICAL mnlistdiff DEMUX: consumes full base=ZERO snapshots at OLD
+    // blocks — requested by QuorumMemberSource (quorum work blocks) and by
+    // MnCheckpointLane (per-height PoSe fold points) — BEFORE they reach the
+    // tip-SML maintainer, which treats any ZERO-base diff as a full snapshot
+    // and would overwrite the LIVE tip SML to that historical block. See
+    // historical_sml.hpp for the chain semantics (non-short-circuiting: two
+    // consumers may legitimately await the same block hash). No filters
+    // registered => every diff falls through to the tip feed, as before.
+    using MnListDiffFilter = HistoricalMnListDiffDemux::Filter;
+    HistoricalMnListDiffDemux m_historical_mnlistdiff_demux;
 
 public:
     CoinClient(io::io_context* context, dash::interfaces::Node* coin, config_t* config,
@@ -388,8 +390,17 @@ public:
     /// Fired once per session when the version/verack handshake completes —
     /// the hook E2 uses to kick the initial getheaders/mnlistdiff sync.
     void set_on_handshake_complete(HandshakeCallback cb) { m_on_handshake_complete = std::move(cb); }
-    /// Install the Phase-L historical-mnlistdiff demux (QuorumMemberSource).
-    void set_historical_mnlistdiff_filter(MnListDiffFilter f) { m_historical_mnlistdiff_filter = std::move(f); }
+    /// Register ONE historical-mnlistdiff consumer. Additive, not a slot: the
+    /// Phase-L member source and the MN-checkpoint lane both source historical
+    /// snapshots off this client and both must be offered every reply.
+    void add_historical_mnlistdiff_filter(MnListDiffFilter f)
+    {
+        m_historical_mnlistdiff_demux.add_filter(std::move(f));
+    }
+    size_t historical_mnlistdiff_filter_count() const
+    {
+        return m_historical_mnlistdiff_demux.filter_count();
+    }
     /// Fired on socket connect (before handshake) with the peer endpoint — the
     /// DashCoinPeerManager scores the connect + tracks anchors off this.
     void set_on_peer_connected(PeerLifecycleCallback cb) { m_on_peer_connected = std::move(cb); }
@@ -819,16 +830,21 @@ private:
                  << " +" << msg->m_diff.mnList.size() << "mn -"
                  << msg->m_diff.deletedMNs.size() << "del qtail="
                  << msg->m_diff.quorum_tail.size() << "B";
-        // Phase-L DEMUX: a HISTORICAL member-sourcing reply is consumed here and
-        // must NOT reach the tip-SML maintainer (base=ZERO would overwrite the
-        // tip SML to the old block). Only tip-sync diffs fall through.
-        if (m_historical_mnlistdiff_filter
-            && m_historical_mnlistdiff_filter(msg->m_diff)) {
-            LOG_INFO << "[" << m_chain_label << "] mnlistdiff consumed by "
-                        "member-set sourcing (historical; tip SML untouched)";
-            return;
+        // DEMUX: a HISTORICAL reply (member sourcing, or the MN-checkpoint
+        // lane's per-height PoSe fold) is consumed here and must NOT reach the
+        // tip-SML maintainer — base=ZERO would overwrite the LIVE tip SML to
+        // the old block. Only tip-sync diffs fall through. The tip feed is
+        // passed IN so it is structurally impossible to fire it on a consumed
+        // reply (see HistoricalMnListDiffDemux::dispatch).
+        const bool consumed = m_historical_mnlistdiff_demux.dispatch(
+            msg->m_diff,
+            [this](const vendor::CSimplifiedMNListDiff& d) {
+                m_coin->new_mnlistdiff.happened(d);
+            });
+        if (consumed) {
+            LOG_INFO << "[" << m_chain_label << "] mnlistdiff consumed as "
+                        "HISTORICAL (tip SML untouched)";
         }
-        m_coin->new_mnlistdiff.happened(msg->m_diff);
     }
 
     // ── E-SUPERBLOCK: governance objects + votes (daemonless superblock) ──

--- a/src/impl/dash/coin/quorum_member_source.hpp
+++ b/src/impl/dash/coin/quorum_member_source.hpp
@@ -70,6 +70,7 @@
 /// Threading: all entry points run on the single coin ioc thread (same
 /// assumption as QuorumManager) — no internal locking.
 
+#include <impl/dash/coin/historical_sml.hpp>       // authenticate_historical_snapshot (shared R3)
 #include <impl/dash/coin/dkg_commitments.hpp>          // LlmqNetwork, enabled_llmqs
 #include <impl/dash/coin/utxo_adapter.hpp>             // dash_txid
 #include <impl/dash/coin/vendor/quorum_members.hpp>    // compute_quorum_members
@@ -317,48 +318,18 @@ private:
         const vendor::CSimplifiedMNListDiff& diff,
         const std::vector<Key>& keys, vendor::CCbTx& cbtx_out) const
     {
+        // Shared with the daemonless MN-set bridge — see historical_sml.hpp.
+        // Both consumers authenticate a peer-supplied historical list on the
+        // reward path and must do it identically; two copies would be two
+        // places for it to rot.
         const uint32_t expect_h =
             keys.empty() ? 0 : expected_work_height(keys.front());
-        auto fail = [&](const char* why) -> std::optional<vendor::CSimplifiedMNList> {
-            LOG_WARNING << "[QC-MEMBERS] snapshot AUTH FAILED (" << why
-                        << ") for block " << diff.blockHash.GetHex().substr(0, 16)
-                        << " — " << keys.size()
+        auto sml = authenticate_historical_snapshot(
+            diff, expect_h, m_merkle_root_of_hash, cbtx_out, "QC-MEMBERS");
+        if (!sml) {
+            LOG_WARNING << "[QC-MEMBERS] " << keys.size()
                         << " quorum(s) fail closed (null-serve)";
-            return std::nullopt;
-        };
-
-        // (a) cbTx: coinbase, special-tx type 5, parseable payload, height
-        // bound to the request (a peer cannot satisfy the await with a
-        // different — even genuine — block's snapshot).
-        if (diff.cbTx.type != 5 || diff.cbTx.extra_payload.empty())
-            return fail("cbTx not a type-5 CbTx");
-        if (!vendor::parse_cbtx(diff.cbTx.extra_payload, cbtx_out))
-            return fail("cbTx payload unparseable");
-        if (expect_h == 0 || cbtx_out.nHeight < 0
-            || static_cast<uint32_t>(cbtx_out.nHeight) != expect_h)
-            return fail("cbTx height != expected work height");
-
-        // (b) merkle proof against the verified header.
-        auto header_root = m_merkle_root_of_hash(diff.blockHash);
-        if (!header_root || header_root->IsNull())
-            return fail("work-block header not held");
-        std::vector<uint256> matches;
-        std::vector<unsigned int> match_idx;
-        const uint256 proof_root =
-            diff.cbTxMerkleTree.ExtractMatches(matches, match_idx);
-        if (proof_root.IsNull() || proof_root != *header_root)
-            return fail("cbTxMerkleTree root != header merkle root");
-        const uint256 cbtx_hash = dash_txid(diff.cbTx);
-        if (matches.size() != 1 || match_idx.size() != 1 || match_idx[0] != 0
-            || matches[0] != cbtx_hash)
-            return fail("cbTx not proven at coinbase position");
-
-        // (c) SML root commitment.
-        vendor::CSimplifiedMNList sml;
-        vendor::apply_diff(sml, diff);   // base=ZERO: apply onto empty
-        if (sml.CalcMerkleRoot() != cbtx_out.merkleRootMNList)
-            return fail("SML root != cbTx.merkleRootMNList");
-
+        }
         return sml;
     }
 

--- a/test/test_dash_mn_checkpoint.cpp
+++ b/test/test_dash_mn_checkpoint.cpp
@@ -1196,6 +1196,21 @@ struct SmlSource {
         height  = h;
         present = true;
     }
+    void set_hashes(uint32_t h,
+                    const std::vector<std::pair<uint256, bool>>& es)
+    {
+        std::vector<CSimplifiedMNListEntry> v;
+        v.reserve(es.size());
+        for (const auto& [hash, valid] : es) {
+            CSimplifiedMNListEntry e;
+            e.proRegTxHash = hash;
+            e.isValid      = valid;
+            v.push_back(e);
+        }
+        list    = CSimplifiedMNList(std::move(v));
+        height  = h;
+        present = true;
+    }
 };
 
 void wire_sml_snapshot(MnCheckpointLane& lane, const SmlSource& src)
@@ -1715,4 +1730,299 @@ TEST(DashMnCheckpointPoseFold, FailClosedDistinguishesAnAttestedBan)
         << "the two verdicts must not be reported with the same words: " << s;
     EXPECT_NE(s.find("NO SML SNAPSHOT SEAM IS WIRED"), std::string::npos)
         << "an operator whose fold seam is unwired must be told so: " << s;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 8. F3 — DOES THE FOLD ACTUALLY COVER THE FAILURE WE MEASURED?
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// The fold is dispatched AFTER apply_block and AFTER the terminal fail-close
+// (on_block_connected: refresh_sml_height -> apply_block -> fail_closed ->
+// maybe_fold_sml). So a fold at cursor == H_sml can only influence heights
+// STRICTLY GREATER than H_sml. A failure AT H_sml, or at any height below it,
+// is decided before the fold ever runs.
+//
+// In production the SML tracks the HEADER TIP: main_dash issues getmnlistd on
+// every tip change, so while the bridge is catching up H_sml sits at or ahead
+// of the tip and the replay cursor is always BEHIND it. Every failing height
+// during catch-up is therefore a height the fold cannot reach.
+//
+// The three existing fold tests all pin H_sml one block BELOW the failing
+// block (H_sml=1519544, burst at 1519545) with a STATIC SmlSource. That is the
+// one arrangement in which the fold does help, and it cannot express the
+// production arrangement at all.
+//
+// This case models the production arrangement: the SML is refreshed to the
+// harness tip on every block delivery, exactly as a getmnlistd-per-tip node
+// behaves. It asserts what the PR CLAIMS — that the bridge survives a ban
+// burst — and it is expected to be RED on this branch.
+// ═══════════════════════════════════════════════════════════════════════════
+namespace {
+
+// A synthetic anchor: N masternodes with UNIQUE payout scripts in strict
+// CompareByLastPaid order (index 0 = queue head). Built directly rather than
+// parsed, so rank and script are exactly controlled -- the 6-MN testnet
+// fixture's shared payout groups short-circuit the demotion walk and cannot
+// express a deep burst.
+MnCheckpoint synthetic_anchor(size_t n, uint32_t height, const uint256& hash)
+{
+    MnCheckpoint cp;
+    cp.ok        = true;
+    cp.network   = "testnet";
+    cp.height    = height;
+    cp.blockhash = hash;
+    cp.source    = "synthetic F3 fixture";
+    for (size_t i = 0; i < n; ++i) {
+        MNState st;
+        st.isValid             = true;
+        st.nRegisteredHeight   = height - 100000;
+        st.nLastPaidHeight     = static_cast<uint32_t>(height - 2100 + i);
+        st.scriptPayout.m_data = synth_script(static_cast<uint8_t>(0x40 + i));
+        st.collateralOutpoint.hash  = uint256S(kQ1);
+        st.collateralOutpoint.index = static_cast<uint32_t>(i);
+        uint256 h = uint256S(kQ2);
+        h.data()[0] = static_cast<unsigned char>(0xa0 + i);
+        cp.entries.emplace_back(h, st);
+    }
+    return cp;
+}
+
+} // namespace
+
+TEST(DashMnCheckpointPoseFold, FoldMissesTheWindowWhenTheSmlTracksTheMovingTip)
+{
+    constexpr uint32_t kAnchorH = 2513000;
+    constexpr uint32_t kTip     = 2513004;
+    const uint256 anchor_hash = uint256S(kAnchorHash);
+
+    const auto cp = synthetic_anchor(10, kAnchorH, anchor_hash);
+
+    // Five masternodes banned at consecutive queue-head positions. Sized to
+    // exceed the per-bridge walk budget (4 + distance/1000 == 4 here), which
+    // is the mainnet shape: a burst arriving against a budget that cannot
+    // absorb it.
+    std::vector<std::pair<uint256, bool>> attest;
+    for (size_t i = 0; i < cp.entries.size(); ++i)
+        attest.emplace_back(cp.entries[i].first, i >= 5);
+
+    SmlSource sml;
+    sml.set_hashes(kTip, attest);
+
+    BridgeHarness h;
+    h.headers[kAnchorH] = anchor_hash;
+    h.tip = kTip;
+
+    // Every block pays the first masternode the chain still holds eligible.
+    for (uint32_t bh = kAnchorH + 1; bh <= kTip; ++bh)
+        h.blocks[bh] = block_paying(cp.entries[5].second.scriptPayout.m_data);
+
+    // THE PRODUCTION ARRANGEMENT: the SML tracks the header tip. main_dash
+    // issues getmnlistd on every tip change, so H_sml is at or ahead of the
+    // tip while the replay cursor is still catching up. Re-point the snapshot
+    // at the harness tip on every delivery to model that.
+    h.lane.set_request_block_fn([&h, &sml](uint32_t bh) {
+        h.requested.push_back(bh);
+        sml.height = h.tip;                // <- tip-tracking, not hand-placed
+        auto it = h.blocks.find(bh);
+        if (it == h.blocks.end()) return;
+        h.lane.on_block_connected(it->second, bh);
+    });
+    wire_sml_snapshot(h.lane, sml);
+    h.lane.set_sml_validity_fn([&sml](const uint256& x) -> std::optional<bool> {
+        for (const auto& e : sml.list.mnList)
+            if (e.proRegTxHash == x) return e.isValid;
+        return std::nullopt;
+    });
+
+    h.lane.arm(cp);
+    h.lane.pump();
+
+    // What the PR claims: the wholesale fold makes a ban burst survivable.
+    EXPECT_TRUE(h.lane.sml_folded())
+        << "the fold never ran: cursor never equalled H_sml=" << sml.height
+        << " before the bridge was decided. Folded_at="
+        << h.lane.sml_folded_at() << ", cursor=" << h.lane.cursor_height();
+    EXPECT_NE(h.lane.state(), MnCheckpointLane::State::FailedClosed)
+        << "the bridge still fails closed on a burst when the SML tracks the"
+           " tip -- i.e. in production. status: " << h.lane.status();
+    EXPECT_TRUE(h.published)
+        << "removals never reached the payee-eligible set before the failing"
+           " height; eligible=" << h.lane.eligible_size()
+        << " pose_removed=" << h.lane.pose_removed();
+}
+
+// ── The anchor fold position. The post-apply dispatch site's FIRST call is at
+// cursor == anchor+1, so an SML current exactly AT the anchor height is never
+// tested against the cursor and a legitimate, perfectly safe fold position is
+// silently forfeited. (publish() also calls maybe_fold_sml, but only after the
+// whole replay — far too late to protect the first blocks.)
+//
+// This is the test that turns the earlier "0 red" mutation row into
+// information: it is RED as shipped and GREEN with a fold dispatched before
+// apply_block, because only that placement ever observes cursor == anchor.
+TEST(DashMnCheckpointPoseFold, FoldFiresAtTheAnchorWhenTheSmlIsCurrentAtTheAnchorHeight)
+{
+    constexpr uint32_t kAnchorH = 2513000;
+    const uint256 anchor_hash = uint256S(kAnchorHash);
+    const auto cp = synthetic_anchor(10, kAnchorH, anchor_hash);
+
+    // The SML is current exactly AT the anchor and retires the queue head.
+    std::vector<std::pair<uint256, bool>> attest;
+    for (size_t i = 0; i < cp.entries.size(); ++i)
+        attest.emplace_back(cp.entries[i].first, i != 0);
+
+    SmlSource sml;
+    sml.set_hashes(kAnchorH, attest);
+
+    BridgeHarness h;
+    h.headers[kAnchorH] = anchor_hash;
+    h.tip = kAnchorH + 1;
+    // The chain skipped the banned head and paid queue slot 1.
+    h.blocks[kAnchorH + 1] =
+        block_paying(cp.entries[1].second.scriptPayout.m_data);
+
+    wire_sml_snapshot(h.lane, sml);
+    h.lane.arm(cp);
+    h.lane.pump();
+
+    EXPECT_TRUE(h.lane.sml_folded())
+        << "an SML current AT the anchor is a valid, non-EARLY fold position"
+           " (cursor == H_sml == anchor) and must be taken before the first"
+           " replayed block is projected";
+    EXPECT_EQ(h.lane.sml_folded_at(), kAnchorH);
+    EXPECT_TRUE(h.published) << h.lane.status();
+}
+
+// ── F5. The fold is a wholesale override of the payee set from one unverified
+// message. A list that would retire a large fraction of the set in one pass is
+// a corrupt or hostile SML, not a ban wave, and must be refused.
+TEST(DashMnCheckpointPoseFold, OversizedFoldIsRefusedRatherThanApplied)
+{
+    constexpr uint32_t kAnchorH = 2513000;
+    const uint256 anchor_hash = uint256S(kAnchorHash);
+    const auto cp = synthetic_anchor(16, kAnchorH, anchor_hash);
+
+    // Retire half the set at once — far over the 1/8 bound.
+    std::vector<std::pair<uint256, bool>> attest;
+    for (size_t i = 0; i < cp.entries.size(); ++i)
+        attest.emplace_back(cp.entries[i].first, i >= 8);
+
+    // H_sml one block ABOVE the anchor, and that block pays the (still
+    // eligible) queue head, so the replay reaches the fold's dispatch point
+    // cleanly and the refusal under test is the BOUND, not a payee desync.
+    SmlSource sml;
+    sml.set_hashes(kAnchorH + 1, attest);
+
+    BridgeHarness h;
+    h.headers[kAnchorH] = anchor_hash;
+    h.tip = kAnchorH + 2;
+    h.blocks[kAnchorH + 1] =
+        block_paying(cp.entries[0].second.scriptPayout.m_data);
+    h.blocks[kAnchorH + 2] =
+        block_paying(cp.entries[8].second.scriptPayout.m_data);
+
+    wire_sml_snapshot(h.lane, sml);
+    h.lane.arm(cp);
+    h.lane.pump();
+
+    EXPECT_EQ(h.lane.state(), MnCheckpointLane::State::FailedClosed)
+        << h.lane.status();
+    EXPECT_FALSE(h.lane.sml_folded());
+    EXPECT_NE(h.lane.status().find("SML PoSe FOLD REFUSED"), std::string::npos)
+        << h.lane.status();
+    EXPECT_NE(h.lane.status().find("NOT root-verified"), std::string::npos)
+        << "the operator must be told the list is trusted, not verified: "
+        << h.lane.status();
+}
+
+// ── F1. An UNDATED SML must not license a permanent demotion. This is the warm
+// restart shape: the persisted list is loaded and have_sml() goes true, but no
+// height was restored, so every attestation is undateable.
+TEST(DashMnCheckpointPoseFold, UndatedSmlHeightCannotLicenseADemotion)
+{
+    MnStateMachine m;
+    auto cp = good_checkpoint();
+    m.load(cp.entries, 1519543);
+    m.set_sml_recovery_cap(8);
+    m.set_sml_validity_fn(
+        [](const uint256& x) -> std::optional<bool> {
+            return x == uint256S(kQ1) ? std::optional<bool>{false}
+                                      : std::optional<bool>{true};
+        });
+    m.set_sml_current_height(0);          // warm SML present, height unknown
+    EXPECT_FALSE(m.sml_covers(1519544))
+        << "height 0 must mean 'covers NOTHING', not 'covers everything' --"
+           " the latter made the whole freshness gate vacuous on warm restart";
+
+    auto blk = repay_coinbase(block_from_hex(kBlockHex1519544),
+                              payout_of(cp, kQ1), payout_of(cp, kQ2));
+    const auto r = m.apply_block(blk, 1519544);
+
+    EXPECT_TRUE(r.payee_desync);
+    EXPECT_EQ(r.sml_recovered, 0u);
+    EXPECT_TRUE(m.entries().at(uint256S(kQ1)).isValid)
+        << "an undated attestation must never flip isValid permanently";
+}
+
+// ── F1-TWIN. A caller that never declares a height at all keeps the pre-gate
+// behaviour byte for byte. Without this, the fail-closed reading of 0 would
+// silently disable the walk for every existing caller.
+TEST(DashMnCheckpointPoseFold, TwinUndeclaredHeightKeepsPreGateBehaviour)
+{
+    MnStateMachine m;
+    auto cp = good_checkpoint();
+    m.load(cp.entries, 1519543);
+    m.set_sml_recovery_cap(8);
+    m.set_sml_validity_fn(
+        [](const uint256& x) -> std::optional<bool> {
+            return x == uint256S(kQ1) ? std::optional<bool>{false}
+                                      : std::optional<bool>{true};
+        });
+    // deliberately NO set_sml_current_height()
+    EXPECT_TRUE(m.sml_covers(1519544));
+
+    auto blk = repay_coinbase(block_from_hex(kBlockHex1519544),
+                              payout_of(cp, kQ1), payout_of(cp, kQ2));
+    const auto r = m.apply_block(blk, 1519544);
+    EXPECT_FALSE(r.payee_desync);
+    EXPECT_EQ(r.sml_recovered, 1u);
+}
+
+// ── F6. arm() must clear the one-shot fold latch. A re-armed lane that still
+// reported sml_folded()==true would run additions-only while claiming removals
+// had been applied -- a silent lie in the operator-facing state.
+TEST(DashMnCheckpointPoseFold, ArmResetsTheFoldLatchAndCounters)
+{
+    constexpr uint32_t kAnchorH = 2513000;
+    const uint256 anchor_hash = uint256S(kAnchorHash);
+    const auto cp = synthetic_anchor(10, kAnchorH, anchor_hash);
+
+    std::vector<std::pair<uint256, bool>> attest;
+    for (size_t i = 0; i < cp.entries.size(); ++i)
+        attest.emplace_back(cp.entries[i].first, i != 0);
+
+    // H_sml at anchor+1 so the fold is actually reachable from the post-apply
+    // dispatch site (see FoldFiresAtTheAnchor... for why anchor itself is not).
+    SmlSource sml;
+    sml.set_hashes(kAnchorH + 1, attest);
+
+    BridgeHarness h;
+    h.headers[kAnchorH] = anchor_hash;
+    h.tip = kAnchorH + 2;
+    h.blocks[kAnchorH + 1] =
+        block_paying(cp.entries[0].second.scriptPayout.m_data);
+    h.blocks[kAnchorH + 2] =
+        block_paying(cp.entries[1].second.scriptPayout.m_data);
+    wire_sml_snapshot(h.lane, sml);
+    h.lane.arm(cp);
+    h.lane.pump();
+    ASSERT_TRUE(h.lane.sml_folded()) << h.lane.status();
+
+    h.lane.arm(cp);   // re-arm
+    EXPECT_FALSE(h.lane.sml_folded())
+        << "a re-armed lane must not claim a fold it has not performed";
+    EXPECT_EQ(h.lane.sml_folded_at(), 0u);
+    EXPECT_EQ(h.lane.pose_removed(), 0u);
+    EXPECT_EQ(h.lane.pose_reinstated(), 0u);
+    EXPECT_EQ(h.lane.sml_recovered(), 0u);
 }

--- a/test/test_dash_mn_checkpoint.cpp
+++ b/test/test_dash_mn_checkpoint.cpp
@@ -49,6 +49,7 @@
 #include <impl/dash/coin/coin_state_maintainer.hpp>
 #include <impl/dash/coin/node_coin_state.hpp>
 
+#include <core/hash.hpp>
 #include <core/pack.hpp>
 #include <core/uint256.hpp>
 
@@ -57,6 +58,7 @@
 #include <algorithm>
 #include <functional>
 #include <map>
+#include <span>
 #include <optional>
 #include <string>
 #include <utility>
@@ -1082,4 +1084,557 @@ TEST(DashMnCheckpointSmlRecovery, RevivalTxLaterInWindowFiresOffTheRecoveredBan)
     // 1519545's own payee is unaffected: pass 0 projects from the PRE-block
     // list, where kQ1 is still excluded, so queue slot 3 was paid.
     EXPECT_EQ(out.at(uint256S(kQ3)).nLastPaidHeight, 1519545u);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 7. PoSe REMOVALS — the replay must SUBTRACT, not only ADD.
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// MEASURED, mainnet, hotel dashd 23.1.7, 2026-08-02:
+//
+//     protx list valid false 2513000  -> 2068 entries   (the anchor)
+//     protx list valid false 2514874  -> 2059 entries   the chain FELL by 9
+//     the bridge's replayed set        2067 -> 2070      we CLIMBED by 3
+//
+// A block replay can only ADD: a PoSe ban is derived by dashd from consensus
+// (accumulated MAX_PoSe_PENALTY) and never appears as a special transaction,
+// so apply_block is structurally unable to see one. The SML carries it, we
+// already persist it, and MnStateMachine::reconcile_pose_from_sml() is the
+// pass that applies it — BEFORE each replayed block is folded, for the
+// ordering reasons written out at that function.
+//
+// Every positive case below has a negative twin that must go red if the
+// removal path is deleted.
+// ═══════════════════════════════════════════════════════════════════════════
+namespace {
+
+using dash::coin::MnStateMachine;
+using dash::coin::vendor::CProRegTx;
+
+// An SML the test can REFRESH between replayed heights. The mnlistdiff feed
+// keeps running for the whole life of a multi-hour bridge, so "banned at
+// h=N, valid again at h=N+1" is a real sequence, not a contrivance. Keyed by
+// height; the newest entry at or below the queried height wins.
+struct RefreshingSml {
+    std::map<uint32_t, CSimplifiedMNList> by_height;
+
+    void set(uint32_t h, const std::vector<std::pair<const char*, bool>>& es)
+    {
+        std::vector<CSimplifiedMNListEntry> v;
+        v.reserve(es.size());
+        for (const auto& [hex, valid] : es) {
+            CSimplifiedMNListEntry e;
+            e.proRegTxHash = uint256S(hex);
+            e.isValid      = valid;
+            v.push_back(e);
+        }
+        by_height.insert_or_assign(h, CSimplifiedMNList(std::move(v)));
+    }
+    void set_hashes(uint32_t h,
+                    const std::vector<std::pair<uint256, bool>>& es)
+    {
+        std::vector<CSimplifiedMNListEntry> v;
+        v.reserve(es.size());
+        for (const auto& [hash, valid] : es) {
+            CSimplifiedMNListEntry e;
+            e.proRegTxHash = hash;
+            e.isValid      = valid;
+            v.push_back(e);
+        }
+        by_height.insert_or_assign(h, CSimplifiedMNList(std::move(v)));
+    }
+    const CSimplifiedMNList* at(uint32_t h) const
+    {
+        if (by_height.empty()) return nullptr;
+        auto it = by_height.upper_bound(h);
+        if (it == by_height.begin()) return nullptr;
+        --it;
+        return &it->second;
+    }
+};
+
+// Wire the production snapshot seam. reconcile_pose() runs while the lane's
+// cursor still points at the PREVIOUS height, so cursor_height()+1 is exactly
+// the height being reconciled.
+void wire_sml_snapshot(MnCheckpointLane& lane, const RefreshingSml& src)
+{
+    lane.set_sml_snapshot_fn([&lane, &src]() -> const CSimplifiedMNList* {
+        return src.at(lane.cursor_height() + 1);
+    });
+}
+
+uint256 synth_tx_hash(const MutableTransaction& tx)
+{
+    ::PackStream s;
+    s << tx;
+    auto sp = s.get_span();
+    uint256 h;
+    CHash256()
+        .Write(std::span<const unsigned char>(
+            reinterpret_cast<const unsigned char*>(sp.data()), sp.size()))
+        .Finalize(std::span<unsigned char>(h.data(), 32));
+    return h;
+}
+
+// A ProRegTx registering a brand-new masternode with `payout` as its
+// scriptPayout. Its proTxHash is the tx hash, so tests compute it with
+// synth_tx_hash() and can name it in the SML.
+MutableTransaction pro_reg_tx(const std::vector<unsigned char>& payout,
+                              uint32_t nonce)
+{
+    CProRegTx p;
+    p.nVersion = dash::coin::vendor::ProTxVersion::BASIC_BLS;
+    p.nType    = dash::coin::vendor::MnType::REGULAR;
+    p.collateralOutpoint.hash  = uint256{};   // "this tx's own output N"
+    p.collateralOutpoint.index = nonce;
+    p.netInfo.port_be          = 0x2334;
+    p.scriptPayout.m_data      = payout;
+
+    MutableTransaction tx;
+    tx.type = CProRegTx::SPECIALTX_TYPE;
+    {
+        auto ps = ::pack(p);
+        auto sp = ps.get_span();
+        tx.extra_payload.assign(
+            reinterpret_cast<const unsigned char*>(sp.data()),
+            reinterpret_cast<const unsigned char*>(sp.data()) + sp.size());
+    }
+    bitcoin_family::coin::TxIn in;
+    in.prevout.hash  = uint256{};
+    in.prevout.index = 0xFFFF0000u | nonce;   // never a known collateral
+    in.sequence      = 0xFFFFFFFF;
+    tx.vin.push_back(in);
+    return tx;
+}
+
+// A distinctive P2PKH-shaped script no fixture masternode owns.
+std::vector<unsigned char> synth_script(uint8_t tag)
+{
+    std::vector<unsigned char> s{0x76, 0xa9, 0x14};
+    for (int i = 0; i < 20; ++i) s.push_back(static_cast<unsigned char>(tag));
+    s.push_back(0x88);
+    s.push_back(0xac);
+    return s;
+}
+
+} // namespace
+
+// ── CASE R1 (POSITIVE). A masternode valid at the anchor and PoSe-banned
+// inside the window is REMOVED from the payee-eligible set, so it is never
+// projected. The bridge completes with NO help from the reactive demotion
+// walk — the per-hash validity seam is deliberately left unwired here, so the
+// only thing that can produce this result is the removal pass.
+TEST(DashMnCheckpointPoseRemoval, BannedMidWindowIsRemovedFromTheEligibleSet)
+{
+    RecoveryRig r;
+    RefreshingSml sml;
+    sml.set(1519544, all_valid_except({kQ1}));
+    wire_sml_snapshot(r.h.lane, sml);
+
+    // dashd skipped the banned Q1 and paid queue slot 2.
+    auto blk = repay_coinbase(block_from_hex(kBlockHex1519544),
+                              payout_of(r.cp, kQ1), payout_of(r.cp, kQ2));
+    r.run(blk);
+
+    ASSERT_TRUE(r.h.published) << "lane status: " << r.h.lane.status();
+    EXPECT_EQ(r.h.lane.pose_removed(), 1u)
+        << "the SML removal pass is what has to fire here";
+    EXPECT_EQ(r.h.lane.sml_recovered(), 0u)
+        << "the reactive demotion walk must NOT be needed once the removal"
+           " pass runs -- it is the capped second line of defence";
+    EXPECT_EQ(r.h.lane.anchor_eligible(), 6u);
+    EXPECT_EQ(r.h.lane.eligible_size(), 5u)
+        << "the payee-eligible set must FALL, which is exactly what the"
+           " measured 2068->2059 vs 2067->2070 divergence says it never did";
+
+    std::map<uint256, MNState> out(r.h.published_set.begin(),
+                                   r.h.published_set.end());
+    const MNState& banned = out.at(uint256S(kQ1));
+    EXPECT_FALSE(banned.isValid);
+    EXPECT_EQ(banned.nPoSeBanHeight, 1519544u);
+    EXPECT_EQ(banned.nLastPaidHeight, 1519459u)
+        << "a removed masternode must not be credited with the payment";
+    EXPECT_EQ(out.at(uint256S(kQ2)).nLastPaidHeight, 1519544u);
+}
+
+// ── CASE R1-TWIN (NEGATIVE). The identical scenario with the removal seam
+// unwired -- i.e. the code as it stood when the bridge fail-closed at
+// h=2514874. The replay can only ADD, the banned masternode keeps the head of
+// the queue, and the bridge refuses. If deleting the removal path did not
+// change behaviour, R1 above would be proving nothing.
+TEST(DashMnCheckpointPoseRemoval, TwinNoRemovalSeamStillFailsClosed)
+{
+    RecoveryRig r;
+    auto blk = repay_coinbase(block_from_hex(kBlockHex1519544),
+                              payout_of(r.cp, kQ1), payout_of(r.cp, kQ2));
+    r.run(blk);   // no snapshot seam, no validity seam
+
+    EXPECT_EQ(r.h.lane.state(), MnCheckpointLane::State::FailedClosed)
+        << r.h.lane.status();
+    EXPECT_FALSE(r.h.published);
+    EXPECT_EQ(r.h.lane.pose_removed(), 0u);
+    EXPECT_EQ(r.h.lane.eligible_size(), 6u)
+        << "with no removal pass the eligible set can only stay flat or climb";
+}
+
+// ── CASE R2. The fail-closed message must MEASURE the divergence, not list
+// hypotheses. An operator has to be able to tell "the anchor is wrong" from
+// "the replay is incomplete" from "a PoSe ban could not be attested" out of
+// the log alone.
+TEST(DashMnCheckpointPoseRemoval, FailClosedReportsTheActualDelta)
+{
+    RecoveryRig r;
+    RefreshingSml sml;
+    // The SML attests every masternode VALID, so the removal pass has nothing
+    // to remove and the mismatch is a REAL desync.
+    sml.set(1519544, all_valid_except({}));
+    wire_sml_snapshot(r.h.lane, sml);
+    r.h.lane.set_sml_validity_fn(sml_fn(all_valid_except({})));
+
+    auto blk = repay_coinbase(block_from_hex(kBlockHex1519544),
+                              payout_of(r.cp, kQ1), payout_of(r.cp, kQ2));
+    r.run(blk);
+
+    ASSERT_EQ(r.h.lane.state(), MnCheckpointLane::State::FailedClosed);
+    const std::string s = r.h.lane.status();
+    EXPECT_NE(s.find("SET DELTA"), std::string::npos) << s;
+    EXPECT_NE(s.find("6 at the anchor"), std::string::npos)
+        << "set size before must be stated: " << s;
+    EXPECT_NE(s.find("ADDS: 0 registrations"), std::string::npos) << s;
+    EXPECT_NE(s.find("0 PoSe (SML-attested)"), std::string::npos)
+        << "the removal count must be stated even when it is zero: " << s;
+    EXPECT_NE(s.find("PROJECTED PAYEE: " + uint256S(kQ1).GetHex()),
+              std::string::npos)
+        << "the operator must be told WHICH masternode we projected: " << s;
+    EXPECT_NE(s.find("attests it VALID"), std::string::npos)
+        << "...and what the SML thinks of it: " << s;
+}
+
+// ── CASE R2-TWIN (NEGATIVE). Same shape, but the SML DOES attest the
+// projected payee invalid and no candidate below it matches the coinbase.
+// The report must say something DIFFERENT, or it is not a measurement.
+TEST(DashMnCheckpointPoseRemoval, FailClosedDistinguishesAnAttestedBan)
+{
+    RecoveryRig r;
+    // Pay a script no masternode below Q1 owns, so nothing can be repaired.
+    r.h.lane.set_sml_validity_fn(sml_fn(all_valid_except({kQ1})));
+    auto blk = repay_coinbase(block_from_hex(kBlockHex1519544),
+                              payout_of(r.cp, kQ1), synth_script(0x5a));
+    r.run(blk);
+
+    ASSERT_EQ(r.h.lane.state(), MnCheckpointLane::State::FailedClosed);
+    const std::string s = r.h.lane.status();
+    EXPECT_NE(s.find("attests it INVALID"), std::string::npos) << s;
+    EXPECT_EQ(s.find("attests it VALID"), std::string::npos)
+        << "the two verdicts must not be reported with the same words: " << s;
+    EXPECT_NE(s.find("NO SML SNAPSHOT SEAM IS WIRED"), std::string::npos)
+        << "an operator whose removal pass is not wired must be told so: " << s;
+}
+
+// ── CASE R3. Banned AND revived inside the replay window must end VALID.
+// The SML refreshes during the bridge (mnlistdiffs keep arriving for its whole
+// duration), so h=1519544 sees the ban and h=1519545 sees the revival. Only a
+// bridge-owned exclusion may be lifted this way.
+TEST(DashMnCheckpointPoseRemoval, BannedThenRevivedInsideTheWindowEndsValid)
+{
+    RecoveryRig r;
+    RefreshingSml sml;
+    sml.set(1519544, all_valid_except({kQ1}));   // banned
+    sml.set(1519545, all_valid_except({}));      // revived
+    wire_sml_snapshot(r.h.lane, sml);
+
+    auto b44 = repay_coinbase(block_from_hex(kBlockHex1519544),
+                              payout_of(r.cp, kQ1), payout_of(r.cp, kQ2));
+    r.h.blocks[1519545] = block_from_hex(kBlockHex1519545);
+    r.run(b44, /*tip=*/1519545);
+
+    ASSERT_TRUE(r.h.published) << "lane status: " << r.h.lane.status();
+    EXPECT_EQ(r.h.published_as_of, 1519545u);
+    EXPECT_EQ(r.h.lane.pose_removed(), 1u);
+    EXPECT_EQ(r.h.lane.pose_reinstated(), 1u);
+    EXPECT_EQ(r.h.lane.eligible_size(), 6u)
+        << "the set must be back to full strength once the ban is lifted";
+
+    std::map<uint256, MNState> out(r.h.published_set.begin(),
+                                   r.h.published_set.end());
+    const MNState& revived = out.at(uint256S(kQ1));
+    EXPECT_TRUE(revived.isValid) << "a ban+revive inside the window ends VALID";
+    EXPECT_EQ(revived.nPoSeBanHeight, 0u);
+    EXPECT_EQ(revived.nPoSeRevivedHeight, 1519545u);
+}
+
+// ── CASE R3-TWIN (NEGATIVE). The reinstatement is OWNERSHIP-bounded: a
+// tx-driven ban (ProUpRevTx, or the operator-key-change ProUpRegTx) is
+// consensus-exact at a known height and must NEVER be undone by an SML that
+// merely shows the masternode live at the TIP -- that only means it will be
+// revived by a ProUpServTx we have not folded yet, and lifting it early puts
+// it back in the queue ahead of dashd's. Driven at the state machine, which
+// is where the ownership rule lives.
+TEST(DashMnCheckpointPoseRemoval, TwinTxDrivenBanIsNotReinstatedBySml)
+{
+    MnStateMachine m;
+    std::vector<std::pair<uint256, MNState>> seed;
+    MNState st;
+    st.isValid           = false;          // banned by a ProUpRevTx at 1519500
+    st.nPoSeBanHeight    = 1519500;
+    st.nRegisteredHeight = 1000000;
+    st.scriptPayout.m_data = synth_script(0x11);
+    seed.emplace_back(uint256S(kQ1), st);
+    m.load(std::move(seed), 1519543);
+
+    std::vector<CSimplifiedMNListEntry> v(1);
+    v[0].proRegTxHash = uint256S(kQ1);
+    v[0].isValid      = true;              // the SML shows it live AT THE TIP
+    CSimplifiedMNList sml(std::move(v));
+
+    const auto pr = m.reconcile_pose_from_sml(sml, 1519544);
+    EXPECT_EQ(pr.reinstated, 0u)
+        << "only exclusions this bridge created may be lifted";
+    EXPECT_EQ(m.pose_reinstated_total(), 0u);
+    EXPECT_FALSE(m.entries().at(uint256S(kQ1)).isValid);
+    EXPECT_EQ(m.entries().at(uint256S(kQ1)).nPoSeBanHeight, 1519500u)
+        << "the exact tx-observed ban height must survive untouched";
+}
+
+// ── CASE R4. Set-size accounting, on a fixture modelled directly on the real
+// mainnet delta: 2068 payee-eligible masternodes at the anchor, 12 PoSe-banned
+// and 3 registered inside the window. The chain's number is 2068 -> 2059; a
+// replay that only ADDS reports 2068 -> 2071 (climbs by 3 -- the measured
+// +3). Both machines below are driven identically except for the removal pass.
+TEST(DashMnCheckpointPoseRemoval, SetSizeAccountingMatchesTheMainnetDelta)
+{
+    constexpr uint32_t kAnchor  = 2513000;
+    constexpr uint32_t kApplyAt = 2513001;
+    constexpr size_t   kAnchorEligible = 2068;
+    constexpr size_t   kBanned = 12;
+    constexpr size_t   kAdds   = 3;
+
+    auto seed_set = [&] {
+        std::vector<std::pair<uint256, MNState>> out;
+        out.reserve(kAnchorEligible);
+        for (size_t i = 0; i < kAnchorEligible; ++i) {
+            MNState st;
+            st.isValid             = true;
+            st.nRegisteredHeight   = 2000000;
+            st.nLastPaidHeight     = static_cast<uint32_t>(kAnchor - 2100 + i);
+            st.scriptPayout.m_data = synth_script(0)  ;
+            // Unique 20-byte hash160 body per masternode so no two share a
+            // payout script (a shared script would hide a wrong attribution).
+            st.scriptPayout.m_data[3] = static_cast<unsigned char>(i & 0xff);
+            st.scriptPayout.m_data[4] = static_cast<unsigned char>(i >> 8);
+            st.collateralOutpoint.hash  = uint256S(kQ1);
+            st.collateralOutpoint.index = static_cast<uint32_t>(i);
+            uint256 h = uint256S(kQ2);
+            h.data()[0] = static_cast<unsigned char>(i & 0xff);
+            h.data()[1] = static_cast<unsigned char>(i >> 8);
+            out.emplace_back(h, st);
+        }
+        return out;
+    };
+
+    // The 12 the SML attests banned: masternodes 3, 6, 9, ... — deliberately
+    // NOT the head of the queue, so the removal has to be proactive rather
+    // than something the coinbase cross-check could have stumbled into.
+    auto sml_marking_banned = [&](const std::vector<std::pair<uint256, MNState>>& set) {
+        std::vector<CSimplifiedMNListEntry> v;
+        v.reserve(set.size());
+        for (size_t i = 0; i < set.size(); ++i) {
+            CSimplifiedMNListEntry e;
+            e.proRegTxHash = set[i].first;
+            e.isValid      = !((i % 3 == 0) && (i / 3) < kBanned);
+            v.push_back(e);
+        }
+        return CSimplifiedMNList(std::move(v));
+    };
+
+    const auto anchor_set = seed_set();
+    const CSimplifiedMNList sml = sml_marking_banned(anchor_set);
+
+    // Three registrations, folded from a real accepted block body whose
+    // coinbase is rewritten to pay whichever masternode the machine projects.
+    auto make_block = [&](const std::vector<unsigned char>& pay_to) {
+        auto blk = block_from_hex(kBlockHex1519544);
+        blk.m_txs[0].vout[1].scriptPubKey.m_data = pay_to;
+        for (size_t i = 0; i < kAdds; ++i)
+            blk.m_txs.push_back(
+                pro_reg_tx(synth_script(static_cast<uint8_t>(0xd0 + i)),
+                           static_cast<uint32_t>(i)));
+        return blk;
+    };
+
+    // ── The replay AS IT WAS: additions only. ──────────────────────────────
+    MnStateMachine before;
+    before.load(anchor_set, kAnchor);
+    ASSERT_EQ(before.eligible_size(), kAnchorEligible);
+    {
+        auto proj = before.find_expected_payee();
+        ASSERT_TRUE(proj.has_value());
+        const auto r =
+            before.apply_block(make_block(before.entries().at(*proj)
+                                              .scriptPayout.m_data), kApplyAt);
+        ASSERT_FALSE(r.payee_desync);
+        EXPECT_EQ(r.registered, kAdds);
+    }
+    EXPECT_EQ(before.eligible_size(), kAnchorEligible + kAdds)
+        << "a replay that can only ADD climbs -- the measured 2067 -> 2070";
+
+    // ── The replay WITH the removal pass. ──────────────────────────────────
+    MnStateMachine after;
+    after.load(anchor_set, kAnchor);
+    const auto pr = after.reconcile_pose_from_sml(sml, kApplyAt);
+    EXPECT_EQ(pr.eligible_before, kAnchorEligible);
+    EXPECT_EQ(pr.removed, kBanned);
+    EXPECT_EQ(pr.eligible_after, kAnchorEligible - kBanned);
+    {
+        auto proj = after.find_expected_payee();
+        ASSERT_TRUE(proj.has_value());
+        const auto r =
+            after.apply_block(make_block(after.entries().at(*proj)
+                                             .scriptPayout.m_data), kApplyAt);
+        ASSERT_FALSE(r.payee_desync);
+        EXPECT_EQ(r.registered, kAdds);
+    }
+    EXPECT_EQ(after.eligible_size(), 2059u)
+        << "2068 - 12 banned + 3 registered = 2059, which is what"
+           " `protx list valid false 2514874` actually returned";
+    EXPECT_EQ(after.size(), kAnchorEligible + kAdds)
+        << "REGISTERED is unchanged by a PoSe ban -- comparing that number"
+           " against `protx list valid` is what hid this bug";
+    EXPECT_EQ(after.pose_removed_total(), kBanned);
+}
+
+// ── CASE R5. A registration and a removal in the SAME block, in the
+// documented order. reconcile runs PRE-block, so:
+//   * the masternode registered BY this block is not in the set yet and
+//     cannot be removed at its own registration height -- which is right,
+//     because it was not in dashd's H-1 list either and a ProRegTx
+//     masternode enters with zero penalty;
+//   * an existing masternode IS removed before pass 0 ranks candidates.
+// The newcomer becomes removable at H+1, the first height at which it could
+// ever be projected.
+TEST(DashMnCheckpointPoseRemoval, RegistrationAndRemovalInOneBlockApplyInOrder)
+{
+    const auto newcomer_script = synth_script(0xc7);
+    const MutableTransaction reg = pro_reg_tx(newcomer_script, 7);
+    const uint256 newcomer = synth_tx_hash(reg);
+
+    // ---- H only: the newcomer must survive its own registration height ----
+    {
+        RecoveryRig r;
+        RefreshingSml sml;
+        auto es = all_valid_except({kQ1});
+        std::vector<std::pair<uint256, bool>> hs;
+        for (auto& [hex, v] : es) hs.emplace_back(uint256S(hex), v);
+        hs.emplace_back(newcomer, false);   // the SML wants it gone TOO
+        sml.set_hashes(1519544, hs);
+        wire_sml_snapshot(r.h.lane, sml);
+
+        auto b44 = repay_coinbase(block_from_hex(kBlockHex1519544),
+                                  payout_of(r.cp, kQ1), payout_of(r.cp, kQ2));
+        b44.m_txs.push_back(reg);
+        r.run(b44);
+
+        ASSERT_TRUE(r.h.published) << r.h.lane.status();
+        EXPECT_EQ(r.h.lane.pose_removed(), 1u)
+            << "exactly ONE removal at h=1519544: the pre-existing kQ1."
+               " Removing the newcomer too would mean the reconcile ran"
+               " AFTER the block and retro-banned a masternode at its own"
+               " registration height";
+        EXPECT_EQ(r.h.lane.replay_registered(), 1u);
+
+        std::map<uint256, MNState> out(r.h.published_set.begin(),
+                                       r.h.published_set.end());
+        ASSERT_EQ(out.count(newcomer), 1u)
+            << "the ProRegTx must have registered the newcomer";
+        EXPECT_TRUE(out.at(newcomer).isValid)
+            << "a masternode cannot be PoSe-banned at the height it registers";
+        EXPECT_FALSE(out.at(uint256S(kQ1)).isValid);
+        EXPECT_EQ(r.h.lane.eligible_size(), 6u)   // 6 - 1 banned + 1 new
+            << "one out, one in";
+    }
+
+    // ---- H and H+1: at the NEXT height the newcomer is removable ----------
+    {
+        RecoveryRig r;
+        RefreshingSml sml;
+        auto es = all_valid_except({kQ1});
+        std::vector<std::pair<uint256, bool>> hs;
+        for (auto& [hex, v] : es) hs.emplace_back(uint256S(hex), v);
+        hs.emplace_back(newcomer, false);
+        sml.set_hashes(1519544, hs);
+        wire_sml_snapshot(r.h.lane, sml);
+
+        auto b44 = repay_coinbase(block_from_hex(kBlockHex1519544),
+                                  payout_of(r.cp, kQ1), payout_of(r.cp, kQ2));
+        b44.m_txs.push_back(reg);
+        r.h.blocks[1519545] = block_from_hex(kBlockHex1519545);
+        r.run(b44, /*tip=*/1519545);
+
+        ASSERT_TRUE(r.h.published) << r.h.lane.status();
+        EXPECT_EQ(r.h.lane.pose_removed(), 2u)
+            << "kQ1 at h=1519544, the newcomer at h=1519545";
+        std::map<uint256, MNState> out(r.h.published_set.begin(),
+                                       r.h.published_set.end());
+        EXPECT_FALSE(out.at(newcomer).isValid);
+        EXPECT_EQ(out.at(newcomer).nPoSeBanHeight, 1519545u)
+            << "removed at the FIRST height it could have been projected,"
+               " not at the height it registered";
+        EXPECT_EQ(r.h.lane.eligible_size(), 5u);
+    }
+}
+
+// ── CASE R6. The SML is a snapshot of NOW, so a removal can be EARLY: the ban
+// may have fallen after the block being replayed, and dashd paid the
+// masternode normally right up to it. Here block 1519544 is the REAL,
+// unmodified accepted block -- it pays kQ1, which the tip SML says is banned.
+// The repair attributes the payment (the DIP-3 queue cursor has to stay
+// dashd-identical) and KEEPS the exclusion.
+TEST(DashMnCheckpointPoseRemoval, EarlyRemovalIsRepairedByTheRealCoinbase)
+{
+    RecoveryRig r;
+    RefreshingSml sml;
+    sml.set(1519544, all_valid_except({kQ1}));
+    wire_sml_snapshot(r.h.lane, sml);
+    r.run(block_from_hex(kBlockHex1519544));   // untouched real block
+
+    ASSERT_TRUE(r.h.published) << r.h.lane.status();
+    EXPECT_EQ(r.h.lane.pose_removed(), 1u);
+    EXPECT_EQ(r.h.lane.pose_premature(), 1u)
+        << "the block pays a masternode we had already excluded -- that is"
+           " proof its ban had not taken effect yet at this height";
+
+    std::map<uint256, MNState> out(r.h.published_set.begin(),
+                                   r.h.published_set.end());
+    EXPECT_EQ(out.at(uint256S(kQ1)).nLastPaidHeight, 1519544u)
+        << "the payment must be attributed or every later projection is one"
+           " queue slot off";
+    EXPECT_FALSE(out.at(uint256S(kQ1)).isValid)
+        << "the exclusion is KEPT: it really is banned by the time we publish";
+    EXPECT_EQ(out.at(uint256S(kQ2)).nLastPaidHeight, 1519460u)
+        << "queue slot 2 must NOT have been credited";
+}
+
+// ── CASE R6-TWIN (NEGATIVE). The repair is rank-gated. An excluded masternode
+// that sorts AFTER our projection cannot explain the coinbase -- dashd would
+// have paid the projection first -- so the repair must refuse and the bridge
+// must fail closed. Without that gate, any excluded masternode whose script
+// happens to appear in a coinbase would license a re-attribution.
+TEST(DashMnCheckpointPoseRemoval, TwinExcludedButLowerRankedDoesNotRepair)
+{
+    RecoveryRig r;
+    RefreshingSml sml;
+    sml.set(1519544, all_valid_except({kQ6}));   // kQ6 is LAST in the queue
+    wire_sml_snapshot(r.h.lane, sml);
+
+    // The block pays kQ6's script; our projection is still kQ1 (untouched).
+    auto blk = repay_coinbase(block_from_hex(kBlockHex1519544),
+                              payout_of(r.cp, kQ1), payout_of(r.cp, kQ6));
+    r.run(blk);
+
+    EXPECT_EQ(r.h.lane.state(), MnCheckpointLane::State::FailedClosed)
+        << r.h.lane.status();
+    EXPECT_FALSE(r.h.published);
+    EXPECT_EQ(r.h.lane.pose_removed(), 1u);
+    EXPECT_EQ(r.h.lane.pose_premature(), 0u)
+        << "a lower-ranked exclusion must never be accepted as the payee";
 }

--- a/test/test_dash_mn_checkpoint.cpp
+++ b/test/test_dash_mn_checkpoint.cpp
@@ -912,6 +912,59 @@ MutableTransaction pro_up_serv_tx(const char* protx)
     return tx;
 }
 
+uint256 synth_tx_hash(const MutableTransaction& tx)
+{
+    ::PackStream s;
+    s << tx;
+    auto sp = s.get_span();
+    uint256 h;
+    CHash256()
+        .Write(std::span<const unsigned char>(
+            reinterpret_cast<const unsigned char*>(sp.data()), sp.size()))
+        .Finalize(std::span<unsigned char>(h.data(), 32));
+    return h;
+}
+
+// A ProRegTx registering a brand-new masternode with `payout` as its
+// scriptPayout. Its proTxHash is the tx hash (synth_tx_hash).
+MutableTransaction pro_reg_tx(const std::vector<unsigned char>& payout,
+                              uint32_t nonce)
+{
+    dash::coin::vendor::CProRegTx p;
+    p.nVersion = dash::coin::vendor::ProTxVersion::BASIC_BLS;
+    p.nType    = dash::coin::vendor::MnType::REGULAR;
+    p.collateralOutpoint.hash  = uint256{};
+    p.collateralOutpoint.index = nonce;
+    p.netInfo.port_be          = 0x2334;
+    p.scriptPayout.m_data      = payout;
+
+    MutableTransaction tx;
+    tx.type = dash::coin::vendor::CProRegTx::SPECIALTX_TYPE;
+    {
+        auto ps = ::pack(p);
+        auto sp = ps.get_span();
+        tx.extra_payload.assign(
+            reinterpret_cast<const unsigned char*>(sp.data()),
+            reinterpret_cast<const unsigned char*>(sp.data()) + sp.size());
+    }
+    bitcoin_family::coin::TxIn in;
+    in.prevout.hash  = uint256{};
+    in.prevout.index = 0xFFFF0000u | nonce;
+    in.sequence      = 0xFFFFFFFF;
+    tx.vin.push_back(in);
+    return tx;
+}
+
+// A distinctive P2PKH-shaped script no fixture masternode owns.
+std::vector<unsigned char> synth_script(uint8_t tag)
+{
+    std::vector<unsigned char> s{0x76, 0xa9, 0x14};
+    for (int i = 0; i < 20; ++i) s.push_back(static_cast<unsigned char>(tag));
+    s.push_back(0x88);
+    s.push_back(0xac);
+    return s;
+}
+
 } // namespace
 
 // CASE 1. The bug this whole change exists for. dashd banned our queue head
@@ -1086,8 +1139,9 @@ TEST(DashMnCheckpointSmlRecovery, RevivalTxLaterInWindowFiresOffTheRecoveredBan)
     EXPECT_EQ(out.at(uint256S(kQ3)).nLastPaidHeight, 1519545u);
 }
 
+
 // ═══════════════════════════════════════════════════════════════════════════
-// 7. PoSe REMOVALS — the replay must SUBTRACT, not only ADD.
+// 7. PoSe REMOVALS — the replay must SUBTRACT, and must survive a ban BURST
 // ═══════════════════════════════════════════════════════════════════════════
 //
 // MEASURED, mainnet, hotel dashd 23.1.7, 2026-08-02:
@@ -1097,26 +1151,36 @@ TEST(DashMnCheckpointSmlRecovery, RevivalTxLaterInWindowFiresOffTheRecoveredBan)
 //     the bridge's replayed set        2067 -> 2070      we CLIMBED by 3
 //
 // A block replay can only ADD: a PoSe ban is derived by dashd from consensus
-// (accumulated MAX_PoSe_PENALTY) and never appears as a special transaction,
-// so apply_block is structurally unable to see one. The SML carries it, we
-// already persist it, and MnStateMachine::reconcile_pose_from_sml() is the
-// pass that applies it — BEFORE each replayed block is folded, for the
-// ordering reasons written out at that function.
+// and never appears as a special transaction.
 //
-// Every positive case below has a negative twin that must go red if the
-// removal path is deleted.
+// WHAT ACTUALLY BROKE was NOT missing machinery. The reactive per-mismatch
+// walk RAN AND WORKED five times during that replay (bridge total 1/6 … 5/6).
+// The chain then shows THREE masternodes leaving `protx list valid` together:
+//
+//     h=2514800   valid 2062, the projected MN PRESENT
+//     h=2514873   valid 2059, the projected MN ABSENT   <- 3 bans / 73 blocks
+//     h=2515025   valid 2063, still ABSENT (never revived)
+//
+// The walk adjudicates ONE exclusion per height and every step must land an
+// exact coinbase script match, so three consecutive banned queue-head
+// candidates defeat it. The WHOLESALE fold of sync_validity_from_sml() at the
+// bridge's apply cursor is the fix precisely because it makes a burst
+// indistinguishable from a single ban.
+//
+// The fold is valid at EXACTLY ONE cursor position (cursor == the height the
+// SML is current at). Early is dangerous, late is benign — the cases below
+// pin both directions.
 // ═══════════════════════════════════════════════════════════════════════════
 namespace {
 
 using dash::coin::MnStateMachine;
-using dash::coin::vendor::CProRegTx;
 
-// An SML the test can REFRESH between replayed heights. The mnlistdiff feed
-// keeps running for the whole life of a multi-hour bridge, so "banned at
-// h=N, valid again at h=N+1" is a real sequence, not a contrivance. Keyed by
-// height; the newest entry at or below the queried height wins.
-struct RefreshingSml {
-    std::map<uint32_t, CSimplifiedMNList> by_height;
+// The SML the production seam hands the lane: the whole list plus the height
+// it is current at. Both halves are load-bearing.
+struct SmlSource {
+    CSimplifiedMNList list;
+    uint32_t          height{0};
+    bool              present{false};
 
     void set(uint32_t h, const std::vector<std::pair<const char*, bool>>& es)
     {
@@ -1128,280 +1192,386 @@ struct RefreshingSml {
             e.isValid      = valid;
             v.push_back(e);
         }
-        by_height.insert_or_assign(h, CSimplifiedMNList(std::move(v)));
-    }
-    void set_hashes(uint32_t h,
-                    const std::vector<std::pair<uint256, bool>>& es)
-    {
-        std::vector<CSimplifiedMNListEntry> v;
-        v.reserve(es.size());
-        for (const auto& [hash, valid] : es) {
-            CSimplifiedMNListEntry e;
-            e.proRegTxHash = hash;
-            e.isValid      = valid;
-            v.push_back(e);
-        }
-        by_height.insert_or_assign(h, CSimplifiedMNList(std::move(v)));
-    }
-    const CSimplifiedMNList* at(uint32_t h) const
-    {
-        if (by_height.empty()) return nullptr;
-        auto it = by_height.upper_bound(h);
-        if (it == by_height.begin()) return nullptr;
-        --it;
-        return &it->second;
+        list    = CSimplifiedMNList(std::move(v));
+        height  = h;
+        present = true;
     }
 };
 
-// Wire the production snapshot seam. reconcile_pose() runs while the lane's
-// cursor still points at the PREVIOUS height, so cursor_height()+1 is exactly
-// the height being reconciled.
-void wire_sml_snapshot(MnCheckpointLane& lane, const RefreshingSml& src)
+void wire_sml_snapshot(MnCheckpointLane& lane, const SmlSource& src)
 {
-    lane.set_sml_snapshot_fn([&lane, &src]() -> const CSimplifiedMNList* {
-        return src.at(lane.cursor_height() + 1);
+    lane.set_sml_snapshot_fn([&src]() -> MnCheckpointLane::SmlSnapshot {
+        MnCheckpointLane::SmlSnapshot snap;
+        if (!src.present) return snap;
+        snap.list   = &src.list;
+        snap.height = src.height;
+        return snap;
     });
-}
-
-uint256 synth_tx_hash(const MutableTransaction& tx)
-{
-    ::PackStream s;
-    s << tx;
-    auto sp = s.get_span();
-    uint256 h;
-    CHash256()
-        .Write(std::span<const unsigned char>(
-            reinterpret_cast<const unsigned char*>(sp.data()), sp.size()))
-        .Finalize(std::span<unsigned char>(h.data(), 32));
-    return h;
-}
-
-// A ProRegTx registering a brand-new masternode with `payout` as its
-// scriptPayout. Its proTxHash is the tx hash, so tests compute it with
-// synth_tx_hash() and can name it in the SML.
-MutableTransaction pro_reg_tx(const std::vector<unsigned char>& payout,
-                              uint32_t nonce)
-{
-    CProRegTx p;
-    p.nVersion = dash::coin::vendor::ProTxVersion::BASIC_BLS;
-    p.nType    = dash::coin::vendor::MnType::REGULAR;
-    p.collateralOutpoint.hash  = uint256{};   // "this tx's own output N"
-    p.collateralOutpoint.index = nonce;
-    p.netInfo.port_be          = 0x2334;
-    p.scriptPayout.m_data      = payout;
-
-    MutableTransaction tx;
-    tx.type = CProRegTx::SPECIALTX_TYPE;
-    {
-        auto ps = ::pack(p);
-        auto sp = ps.get_span();
-        tx.extra_payload.assign(
-            reinterpret_cast<const unsigned char*>(sp.data()),
-            reinterpret_cast<const unsigned char*>(sp.data()) + sp.size());
-    }
-    bitcoin_family::coin::TxIn in;
-    in.prevout.hash  = uint256{};
-    in.prevout.index = 0xFFFF0000u | nonce;   // never a known collateral
-    in.sequence      = 0xFFFFFFFF;
-    tx.vin.push_back(in);
-    return tx;
-}
-
-// A distinctive P2PKH-shaped script no fixture masternode owns.
-std::vector<unsigned char> synth_script(uint8_t tag)
-{
-    std::vector<unsigned char> s{0x76, 0xa9, 0x14};
-    for (int i = 0; i < 20; ++i) s.push_back(static_cast<unsigned char>(tag));
-    s.push_back(0x88);
-    s.push_back(0xac);
-    return s;
 }
 
 } // namespace
 
-// ── CASE R1 (POSITIVE). A masternode valid at the anchor and PoSe-banned
-// inside the window is REMOVED from the payee-eligible set, so it is never
-// projected. The bridge completes with NO help from the reactive demotion
-// walk — the per-hash validity seam is deliberately left unwired here, so the
-// only thing that can produce this result is the removal pass.
-TEST(DashMnCheckpointPoseRemoval, BannedMidWindowIsRemovedFromTheEligibleSet)
+// ── CASE B1 (THE LOAD-BEARING ONE). A ban BURST: three masternodes banned at
+// consecutive queue-head positions. This is the measured h=2514874 shape.
+//
+// The per-mismatch walk cannot carry it — it demotes kQ1, must then attribute
+// the payment to kQ2 by exact coinbase script match, and kQ2 is banned too, so
+// the block does not pay kQ2's script either and the walk stalls. The
+// WHOLESALE fold removes all three in one pass before any of them is
+// projected, and the bridge completes.
+//
+// The fold lands at cursor == H_sml = 1519544 (after that block is folded),
+// and the burst bites at 1519545 — the first height the three could be
+// projected. That is the ordering rule doing exactly its job.
+TEST(DashMnCheckpointPoseFold, BanBurstSurvivesWholesaleFold)
 {
     RecoveryRig r;
-    RefreshingSml sml;
-    sml.set(1519544, all_valid_except({kQ1}));
+    SmlSource sml;
+    sml.set(1519544, all_valid_except({kQ1, kQ2, kQ3}));
     wire_sml_snapshot(r.h.lane, sml);
+    r.h.lane.set_sml_validity_fn(sml_fn(all_valid_except({kQ1, kQ2, kQ3})));
 
-    // dashd skipped the banned Q1 and paid queue slot 2.
-    auto blk = repay_coinbase(block_from_hex(kBlockHex1519544),
-                              payout_of(r.cp, kQ1), payout_of(r.cp, kQ2));
-    r.run(blk);
+    // 1519544 is the REAL accepted block and pays kQ1 — untouched, so the
+    // pre-fold replay of it must succeed on its own.
+    // 1519545 really pays the kQ2/kQ3 (yeRZB) group; with kQ1..kQ3 all gone the
+    // queue head is kQ4, so re-point that coinbase at kQ4's script.
+    auto b45 = repay_coinbase(block_from_hex(kBlockHex1519545),
+                              payout_of(r.cp, kQ2), payout_of(r.cp, kQ4));
+    r.h.blocks[1519545] = b45;
+    r.run(block_from_hex(kBlockHex1519544), /*tip=*/1519545);
 
     ASSERT_TRUE(r.h.published) << "lane status: " << r.h.lane.status();
-    EXPECT_EQ(r.h.lane.pose_removed(), 1u)
-        << "the SML removal pass is what has to fire here";
+    EXPECT_TRUE(r.h.lane.sml_folded());
+    EXPECT_EQ(r.h.lane.sml_folded_at(), 1519544u)
+        << "the fold must land at cursor == the height the SML is current at";
+    EXPECT_EQ(r.h.lane.pose_removed(), 3u)
+        << "all three leave in ONE pass -- that is what makes a burst"
+           " indistinguishable from a single ban";
     EXPECT_EQ(r.h.lane.sml_recovered(), 0u)
-        << "the reactive demotion walk must NOT be needed once the removal"
-           " pass runs -- it is the capped second line of defence";
-    EXPECT_EQ(r.h.lane.anchor_eligible(), 6u);
-    EXPECT_EQ(r.h.lane.eligible_size(), 5u)
-        << "the payee-eligible set must FALL, which is exactly what the"
-           " measured 2068->2059 vs 2067->2070 divergence says it never did";
+        << "the per-mismatch walk must not have been needed, and must not"
+           " have spent ANY of its per-bridge budget -- budget exhaustion is"
+           " what actually kills a bridge on a burst (see"
+           " TwinBanBurstExhaustsTheWalkBudgetAndIsTerminal)";
+    EXPECT_EQ(r.h.lane.eligible_size(), 3u);
 
     std::map<uint256, MNState> out(r.h.published_set.begin(),
                                    r.h.published_set.end());
-    const MNState& banned = out.at(uint256S(kQ1));
-    EXPECT_FALSE(banned.isValid);
-    EXPECT_EQ(banned.nPoSeBanHeight, 1519544u);
-    EXPECT_EQ(banned.nLastPaidHeight, 1519459u)
-        << "a removed masternode must not be credited with the payment";
-    EXPECT_EQ(out.at(uint256S(kQ2)).nLastPaidHeight, 1519544u);
+    for (const char* q : {kQ1, kQ2, kQ3})
+        EXPECT_FALSE(out.at(uint256S(q)).isValid) << q;
+    EXPECT_EQ(out.at(uint256S(kQ4)).nLastPaidHeight, 1519545u);
 }
 
-// ── CASE R1-TWIN (NEGATIVE). The identical scenario with the removal seam
-// unwired -- i.e. the code as it stood when the bridge fail-closed at
-// h=2514874. The replay can only ADD, the banned masternode keeps the head of
-// the queue, and the bridge refuses. If deleting the removal path did not
-// change behaviour, R1 above would be proving nothing.
-TEST(DashMnCheckpointPoseRemoval, TwinNoRemovalSeamStillFailsClosed)
-{
-    RecoveryRig r;
-    auto blk = repay_coinbase(block_from_hex(kBlockHex1519544),
-                              payout_of(r.cp, kQ1), payout_of(r.cp, kQ2));
-    r.run(blk);   // no snapshot seam, no validity seam
+// ── CASE B1-TWIN (NEGATIVE) + THE CORRECTED MECHANISM.
+//
+// A burst does NOT defeat the per-mismatch walk merely by being consecutive:
+// recover_from_sml_ban demotes a consecutive RUN inside one height (its loop
+// keeps going while each candidate is attested invalid). What actually stops
+// it is the CUMULATIVE PER-BRIDGE BUDGET —
+//
+//     m_sml_recovered_total + demoted.size() > m_sml_recovery_cap  -> refuse
+//
+// — and that budget is sized for ISOLATED bans: 4 + replay_distance/1000.
+// The mainnet incident fits this exactly: the walk had legitimately reached
+// "bridge total 5/6", the chain then put THREE masternodes out inside 73
+// blocks, 5 + 3 = 8 > 6, the walk refused, and refusal is TERMINAL.
+//
+// This drives that arithmetic on a synthetic set with UNIQUE payout scripts,
+// so rank and script are controlled exactly and no shared-payoutAddress group
+// can short-circuit the walk. Budget 2 stands in for "4 of 6 already spent".
+// The wholesale fold spends NO budget at all, which is why it survives.
+namespace {
 
-    EXPECT_EQ(r.h.lane.state(), MnCheckpointLane::State::FailedClosed)
-        << r.h.lane.status();
-    EXPECT_FALSE(r.h.published);
-    EXPECT_EQ(r.h.lane.pose_removed(), 0u);
-    EXPECT_EQ(r.h.lane.eligible_size(), 6u)
-        << "with no removal pass the eligible set can only stay flat or climb";
+// Ten masternodes, unique scripts, strictly ascending CompareByLastPaid
+// order: index 0 is the queue head.
+std::vector<std::pair<uint256, MNState>> ranked_synthetic_set(size_t n)
+{
+    std::vector<std::pair<uint256, MNState>> out;
+    for (size_t i = 0; i < n; ++i) {
+        MNState st;
+        st.isValid             = true;
+        st.nRegisteredHeight   = 1000000;
+        st.nLastPaidHeight     = static_cast<uint32_t>(1500000 + i);
+        st.scriptPayout.m_data = synth_script(static_cast<uint8_t>(0x40 + i));
+        st.collateralOutpoint.hash  = uint256S(kQ1);
+        st.collateralOutpoint.index = static_cast<uint32_t>(i);
+        uint256 h = uint256S(kQ2);
+        h.data()[0] = static_cast<unsigned char>(0xa0 + i);
+        out.emplace_back(h, st);
+    }
+    return out;
 }
 
-// ── CASE R2. The fail-closed message must MEASURE the divergence, not list
-// hypotheses. An operator has to be able to tell "the anchor is wrong" from
-// "the replay is incomplete" from "a PoSe ban could not be attested" out of
-// the log alone.
-TEST(DashMnCheckpointPoseRemoval, FailClosedReportsTheActualDelta)
+CSimplifiedMNList sml_banning(
+    const std::vector<std::pair<uint256, MNState>>& set,
+    std::initializer_list<size_t> banned_ranks)
+{
+    std::vector<CSimplifiedMNListEntry> v;
+    for (size_t i = 0; i < set.size(); ++i) {
+        CSimplifiedMNListEntry e;
+        e.proRegTxHash = set[i].first;
+        e.isValid      = true;
+        for (size_t b : banned_ranks) if (b == i) e.isValid = false;
+        v.push_back(e);
+    }
+    return CSimplifiedMNList(std::move(v));
+}
+
+// Block 1519544's real body with its coinbase re-pointed at one script.
+dash::coin::BlockType block_paying(const std::vector<unsigned char>& script)
+{
+    auto blk = block_from_hex(kBlockHex1519544);
+    blk.m_txs[0].vout[1].scriptPubKey.m_data = script;
+    return blk;
+}
+
+MnStateMachine::SmlValidityFn validity_from(const CSimplifiedMNList& sml)
+{
+    return [&sml](const uint256& h) -> std::optional<bool> {
+        for (const auto& e : sml.mnList)
+            if (e.proRegTxHash == h) return e.isValid;
+        return std::nullopt;
+    };
+}
+
+} // namespace
+
+TEST(DashMnCheckpointPoseFold, TwinBanBurstExhaustsTheWalkBudgetAndIsTerminal)
+{
+    const auto set = ranked_synthetic_set(10);
+    const auto sml = sml_banning(set, {0, 1, 2});   // three at the queue head
+    const auto blk = block_paying(set[3].second.scriptPayout.m_data);
+
+    MnStateMachine walk_only;
+    walk_only.load(set, 2514873);
+    walk_only.set_sml_validity_fn(validity_from(sml));
+    walk_only.set_sml_current_height(2514874);
+    // Budget left after the walk legitimately reached 5/6 on this bridge.
+    walk_only.set_sml_recovery_cap(2);
+
+    const auto r = walk_only.apply_block(blk, 2514874);
+
+    EXPECT_TRUE(r.payee_desync)
+        << "3 demotions against a budget of 2 must be REFUSED, and refusal on"
+           " the bridge is terminal -- this is the h=2514874 fail-close";
+    EXPECT_EQ(r.sml_recovered, 0u);
+    EXPECT_TRUE(walk_only.entries().at(set[0].first).isValid)
+        << "a refused walk must not leave a partial exclusion behind";
+    EXPECT_EQ(walk_only.eligible_size(), 10u)
+        << "the set did not fall at all -- the measured 'we only ever ADD'";
+}
+
+// The same burst, same budget, with the WHOLESALE FOLD applied first. The fold
+// spends no budget, so the burst costs nothing and the queue head is already
+// correct when the block is projected.
+TEST(DashMnCheckpointPoseFold, WholesaleFoldSurvivesTheSameBurstOnTheSameBudget)
+{
+    const auto set = ranked_synthetic_set(10);
+    const auto sml = sml_banning(set, {0, 1, 2});
+    const auto blk = block_paying(set[3].second.scriptPayout.m_data);
+
+    MnStateMachine folded;
+    folded.load(set, 2514873);
+    folded.set_sml_validity_fn(validity_from(sml));
+    folded.set_sml_current_height(2514873);
+    folded.set_sml_recovery_cap(2);
+
+    // Fold at cursor == the height the SML is current at (2514873), i.e. after
+    // apply_block(2514873) and BEFORE apply_block(2514874).
+    const auto vr = folded.sync_validity_from_sml(sml, 2514873);
+    EXPECT_EQ(vr.flipped_to_invalid, 3u) << "all three leave in ONE pass";
+    EXPECT_EQ(folded.eligible_size(), 7u) << "the set FALLS, as the chain's did";
+
+    const auto r = folded.apply_block(blk, 2514874);
+
+    EXPECT_FALSE(r.payee_desync) << "the bridge survives the burst";
+    EXPECT_EQ(r.sml_recovered, 0u)
+        << "a fold spends NO walk budget -- that is why a burst costs nothing";
+    EXPECT_EQ(r.paid, 1u);
+    EXPECT_EQ(folded.entries().at(set[3].first).nLastPaidHeight, 2514874u)
+        << "the payment lands on the first masternode the chain still held"
+           " eligible";
+}
+
+// ISOLATION CONTROL. The very same burst with a budget that can absorb it is
+// handled by the walk alone. Without this, the two cases above would look like
+// "bursts are unhandleable" rather than "the BUDGET is the binding constraint",
+// which is the finding that matters for sizing it.
+TEST(DashMnCheckpointPoseFold, SameBurstWithAmpleBudgetIsHandledByTheWalk)
+{
+    const auto set = ranked_synthetic_set(10);
+    const auto sml = sml_banning(set, {0, 1, 2});
+    const auto blk = block_paying(set[3].second.scriptPayout.m_data);
+
+    MnStateMachine m;
+    m.load(set, 2514873);
+    m.set_sml_validity_fn(validity_from(sml));
+    m.set_sml_current_height(2514874);
+    m.set_sml_recovery_cap(8);
+
+    const auto r = m.apply_block(blk, 2514874);
+    EXPECT_FALSE(r.payee_desync);
+    EXPECT_EQ(r.sml_recovered, 3u)
+        << "the walk CAN demote a consecutive run inside one height -- it is"
+           " the cumulative cap, not the burst shape, that defeats it";
+}
+
+// ── CASE B2. ORDERING: the fold NEVER runs early. cursor < H_sml must leave
+// the set untouched.
+//
+// Why early is the dangerous direction: a masternode banned at h_ban <= H_sml
+// would be removed at heights where the chain still held it valid and paid it.
+// Inside a shared-payoutAddress group that divergence is SCRIPT-INVISIBLE, so
+// the coinbase cross-check passes and the bridge publishes a WRONG queue
+// silently. An early fold also perturbs queue POSITION, because
+// sync_validity_from_sml bumps nPoSeRevivedHeight -- a CompareByLastPaid key.
+TEST(DashMnCheckpointPoseFold, FoldNeverRunsBeforeTheCursorReachesTheSmlHeight)
 {
     RecoveryRig r;
-    RefreshingSml sml;
-    // The SML attests every masternode VALID, so the removal pass has nothing
-    // to remove and the mismatch is a REAL desync.
-    sml.set(1519544, all_valid_except({}));
+    SmlSource sml;
+    // The SML is current at a height the bridge never reaches.
+    sml.set(1519600, all_valid_except({kQ1}));
     wire_sml_snapshot(r.h.lane, sml);
-    r.h.lane.set_sml_validity_fn(sml_fn(all_valid_except({})));
-
-    auto blk = repay_coinbase(block_from_hex(kBlockHex1519544),
-                              payout_of(r.cp, kQ1), payout_of(r.cp, kQ2));
-    r.run(blk);
-
-    ASSERT_EQ(r.h.lane.state(), MnCheckpointLane::State::FailedClosed);
-    const std::string s = r.h.lane.status();
-    EXPECT_NE(s.find("SET DELTA"), std::string::npos) << s;
-    EXPECT_NE(s.find("6 at the anchor"), std::string::npos)
-        << "set size before must be stated: " << s;
-    EXPECT_NE(s.find("ADDS: 0 registrations"), std::string::npos) << s;
-    EXPECT_NE(s.find("0 PoSe (SML-attested)"), std::string::npos)
-        << "the removal count must be stated even when it is zero: " << s;
-    EXPECT_NE(s.find("PROJECTED PAYEE: " + uint256S(kQ1).GetHex()),
-              std::string::npos)
-        << "the operator must be told WHICH masternode we projected: " << s;
-    EXPECT_NE(s.find("attests it VALID"), std::string::npos)
-        << "...and what the SML thinks of it: " << s;
-}
-
-// ── CASE R2-TWIN (NEGATIVE). Same shape, but the SML DOES attest the
-// projected payee invalid and no candidate below it matches the coinbase.
-// The report must say something DIFFERENT, or it is not a measurement.
-TEST(DashMnCheckpointPoseRemoval, FailClosedDistinguishesAnAttestedBan)
-{
-    RecoveryRig r;
-    // Pay a script no masternode below Q1 owns, so nothing can be repaired.
     r.h.lane.set_sml_validity_fn(sml_fn(all_valid_except({kQ1})));
-    auto blk = repay_coinbase(block_from_hex(kBlockHex1519544),
-                              payout_of(r.cp, kQ1), synth_script(0x5a));
-    r.run(blk);
 
-    ASSERT_EQ(r.h.lane.state(), MnCheckpointLane::State::FailedClosed);
-    const std::string s = r.h.lane.status();
-    EXPECT_NE(s.find("attests it INVALID"), std::string::npos) << s;
-    EXPECT_EQ(s.find("attests it VALID"), std::string::npos)
-        << "the two verdicts must not be reported with the same words: " << s;
-    EXPECT_NE(s.find("NO SML SNAPSHOT SEAM IS WIRED"), std::string::npos)
-        << "an operator whose removal pass is not wired must be told so: " << s;
+    // The real block pays kQ1, which is still eligible at this height. An
+    // early fold would have removed it, projected kQ2, and desynced.
+    r.run(block_from_hex(kBlockHex1519544));
+
+    ASSERT_TRUE(r.h.published) << r.h.lane.status();
+    EXPECT_FALSE(r.h.lane.sml_folded())
+        << "cursor 1519544 != SML height 1519600 -- the fold must NOT run";
+    EXPECT_EQ(r.h.lane.pose_removed(), 0u);
+    EXPECT_EQ(r.h.lane.eligible_size(), 6u);
+
+    std::map<uint256, MNState> out(r.h.published_set.begin(),
+                                   r.h.published_set.end());
+    EXPECT_TRUE(out.at(uint256S(kQ1)).isValid)
+        << "the chain still held it valid here and actually paid it";
+    EXPECT_EQ(out.at(uint256S(kQ1)).nLastPaidHeight, 1519544u);
+    EXPECT_EQ(out.at(uint256S(kQ1)).nPoSeRevivedHeight, 1367840u)
+        << "an early fold would also have moved its CompareByLastPaid key";
 }
 
-// ── CASE R3. Banned AND revived inside the replay window must end VALID.
-// The SML refreshes during the bridge (mnlistdiffs keep arriving for its whole
-// duration), so h=1519544 sees the ban and h=1519545 sees the revival. Only a
-// bridge-owned exclusion may be lifted this way.
-TEST(DashMnCheckpointPoseRemoval, BannedThenRevivedInsideTheWindowEndsValid)
+// ── CASE B2-TWIN (POSITIVE CONTROL for B2). Move the SML's height onto the
+// cursor and the very same wiring folds. Without this, B2 could be passing
+// because the seam does nothing at all.
+TEST(DashMnCheckpointPoseFold, TwinSameWiringFoldsOnceTheHeightsMeet)
 {
     RecoveryRig r;
-    RefreshingSml sml;
-    sml.set(1519544, all_valid_except({kQ1}));   // banned
-    sml.set(1519545, all_valid_except({}));      // revived
+    SmlSource sml;
+    sml.set(1519544, all_valid_except({kQ1}));
     wire_sml_snapshot(r.h.lane, sml);
+    r.run(block_from_hex(kBlockHex1519544));
 
+    ASSERT_TRUE(r.h.published) << r.h.lane.status();
+    EXPECT_TRUE(r.h.lane.sml_folded());
+    EXPECT_EQ(r.h.lane.sml_folded_at(), 1519544u);
+    EXPECT_EQ(r.h.lane.pose_removed(), 1u);
+    EXPECT_EQ(r.h.lane.eligible_size(), 5u);
+    // The fold runs AFTER apply_block(1519544), so that block's own payee was
+    // still projected from the pre-fold set -- kQ1 was paid, exactly as the
+    // chain did. That is the "late is benign" half of the ordering rule.
+    std::map<uint256, MNState> out(r.h.published_set.begin(),
+                                   r.h.published_set.end());
+    EXPECT_EQ(out.at(uint256S(kQ1)).nLastPaidHeight, 1519544u);
+    EXPECT_FALSE(out.at(uint256S(kQ1)).isValid);
+}
+
+// ── CASE B3. A masternode banned AND revived inside the window ends VALID.
+// sync_validity_from_sml owns the (isValid, banHeight, revivedHeight) triple,
+// so a fold against an SML that shows it live leaves it live.
+TEST(DashMnCheckpointPoseFold, BannedThenRevivedInsideTheWindowEndsValid)
+{
+    RecoveryRig r;
+    SmlSource sml;
+    sml.set(1519545, all_valid_except({}));   // live again by the fold height
+    wire_sml_snapshot(r.h.lane, sml);
+    r.h.lane.set_sml_validity_fn(sml_fn(all_valid_except({kQ1})));
+
+    // 1519544 is repaid to kQ2, i.e. dashd skipped kQ1 while it was banned.
+    // The walk carries that single mismatch; the fold at 1519545 then confirms
+    // kQ1 is live again and lifts the exclusion the walk recorded.
     auto b44 = repay_coinbase(block_from_hex(kBlockHex1519544),
                               payout_of(r.cp, kQ1), payout_of(r.cp, kQ2));
     r.h.blocks[1519545] = block_from_hex(kBlockHex1519545);
     r.run(b44, /*tip=*/1519545);
 
-    ASSERT_TRUE(r.h.published) << "lane status: " << r.h.lane.status();
-    EXPECT_EQ(r.h.published_as_of, 1519545u);
-    EXPECT_EQ(r.h.lane.pose_removed(), 1u);
-    EXPECT_EQ(r.h.lane.pose_reinstated(), 1u);
-    EXPECT_EQ(r.h.lane.eligible_size(), 6u)
-        << "the set must be back to full strength once the ban is lifted";
+    ASSERT_TRUE(r.h.published) << r.h.lane.status();
+    EXPECT_EQ(r.h.lane.sml_recovered(), 1u) << "the walk handled the mismatch";
+    EXPECT_TRUE(r.h.lane.sml_folded());
+    EXPECT_EQ(r.h.lane.pose_reinstated(), 1u)
+        << "the fold must be able to REVIVE, not only remove";
 
     std::map<uint256, MNState> out(r.h.published_set.begin(),
                                    r.h.published_set.end());
     const MNState& revived = out.at(uint256S(kQ1));
-    EXPECT_TRUE(revived.isValid) << "a ban+revive inside the window ends VALID";
+    EXPECT_TRUE(revived.isValid) << "ban+revive inside the window ends VALID";
     EXPECT_EQ(revived.nPoSeBanHeight, 0u);
-    EXPECT_EQ(revived.nPoSeRevivedHeight, 1519545u);
 }
 
-// ── CASE R3-TWIN (NEGATIVE). The reinstatement is OWNERSHIP-bounded: a
-// tx-driven ban (ProUpRevTx, or the operator-key-change ProUpRegTx) is
-// consensus-exact at a known height and must NEVER be undone by an SML that
-// merely shows the masternode live at the TIP -- that only means it will be
-// revived by a ProUpServTx we have not folded yet, and lifting it early puts
-// it back in the queue ahead of dashd's. Driven at the state machine, which
-// is where the ownership rule lives.
-TEST(DashMnCheckpointPoseRemoval, TwinTxDrivenBanIsNotReinstatedBySml)
+// ── CASE B4. FRESHNESS GATE. A STALE SML must not license a PERMANENT
+// demotion: it can attest isValid=false for a masternode that has since been
+// revived, and with a coincidental runner-up script match the walk would
+// exclude it for the rest of the bridge. An SML older than the height being
+// adjudicated cannot speak to that height, so it is NO OPINION, never false.
+TEST(DashMnCheckpointPoseFold, StaleSmlCannotLicenseAPermanentDemotion)
 {
     MnStateMachine m;
-    std::vector<std::pair<uint256, MNState>> seed;
-    MNState st;
-    st.isValid           = false;          // banned by a ProUpRevTx at 1519500
-    st.nPoSeBanHeight    = 1519500;
-    st.nRegisteredHeight = 1000000;
-    st.scriptPayout.m_data = synth_script(0x11);
-    seed.emplace_back(uint256S(kQ1), st);
-    m.load(std::move(seed), 1519543);
+    auto cp = good_checkpoint();
+    m.load(cp.entries, 1519543);
+    m.set_sml_recovery_cap(8);
+    m.set_sml_validity_fn(
+        [](const uint256& h) -> std::optional<bool> {
+            return h == uint256S(kQ1) ? std::optional<bool>{false}
+                                      : std::optional<bool>{true};
+        });
+    // The SML is current at 1519500 — BEFORE the block being adjudicated.
+    m.set_sml_current_height(1519500);
+    EXPECT_FALSE(m.sml_covers(1519544));
 
-    std::vector<CSimplifiedMNListEntry> v(1);
-    v[0].proRegTxHash = uint256S(kQ1);
-    v[0].isValid      = true;              // the SML shows it live AT THE TIP
-    CSimplifiedMNList sml(std::move(v));
+    auto blk = repay_coinbase(block_from_hex(kBlockHex1519544),
+                              payout_of(cp, kQ1), payout_of(cp, kQ2));
+    const auto r = m.apply_block(blk, 1519544);
 
-    const auto pr = m.reconcile_pose_from_sml(sml, 1519544);
-    EXPECT_EQ(pr.reinstated, 0u)
-        << "only exclusions this bridge created may be lifted";
-    EXPECT_EQ(m.pose_reinstated_total(), 0u);
-    EXPECT_FALSE(m.entries().at(uint256S(kQ1)).isValid);
-    EXPECT_EQ(m.entries().at(uint256S(kQ1)).nPoSeBanHeight, 1519500u)
-        << "the exact tx-observed ban height must survive untouched";
+    EXPECT_TRUE(r.payee_desync)
+        << "a stale attestation must not be accepted as evidence of a ban";
+    EXPECT_EQ(r.sml_recovered, 0u);
+    EXPECT_TRUE(m.entries().at(uint256S(kQ1)).isValid)
+        << "nothing may be permanently excluded on a stale SML";
 }
 
-// ── CASE R4. Set-size accounting, on a fixture modelled directly on the real
-// mainnet delta: 2068 payee-eligible masternodes at the anchor, 12 PoSe-banned
-// and 3 registered inside the window. The chain's number is 2068 -> 2059; a
-// replay that only ADDS reports 2068 -> 2071 (climbs by 3 -- the measured
-// +3). Both machines below are driven identically except for the removal pass.
-TEST(DashMnCheckpointPoseRemoval, SetSizeAccountingMatchesTheMainnetDelta)
+// ── CASE B4-TWIN (POSITIVE CONTROL). The same attestation from an SML that IS
+// current at the adjudicated height is accepted. Without this twin, B4 could
+// be passing because the walk never fires at all.
+TEST(DashMnCheckpointPoseFold, TwinFreshSmlAtTheSameHeightIsAccepted)
+{
+    MnStateMachine m;
+    auto cp = good_checkpoint();
+    m.load(cp.entries, 1519543);
+    m.set_sml_recovery_cap(8);
+    m.set_sml_validity_fn(
+        [](const uint256& h) -> std::optional<bool> {
+            return h == uint256S(kQ1) ? std::optional<bool>{false}
+                                      : std::optional<bool>{true};
+        });
+    m.set_sml_current_height(1519544);
+    EXPECT_TRUE(m.sml_covers(1519544));
+
+    auto blk = repay_coinbase(block_from_hex(kBlockHex1519544),
+                              payout_of(cp, kQ1), payout_of(cp, kQ2));
+    const auto r = m.apply_block(blk, 1519544);
+
+    EXPECT_FALSE(r.payee_desync);
+    EXPECT_EQ(r.sml_recovered, 1u);
+    EXPECT_FALSE(m.entries().at(uint256S(kQ1)).isValid);
+}
+
+// ── CASE B5. Set-size accounting on a fixture modelled directly on the real
+// mainnet delta: 2068 payee-eligible at the anchor, 12 PoSe-banned and 3
+// registered inside the window. The chain reported 2068 -> 2059. A replay that
+// can only ADD reports 2068 -> 2071 — a climb of exactly the +3 that was
+// measured. Both machines are driven identically except for the fold.
+TEST(DashMnCheckpointPoseFold, SetSizeAccountingMatchesTheMainnetDelta)
 {
     constexpr uint32_t kAnchor  = 2513000;
     constexpr uint32_t kApplyAt = 2513001;
@@ -1417,9 +1587,9 @@ TEST(DashMnCheckpointPoseRemoval, SetSizeAccountingMatchesTheMainnetDelta)
             st.isValid             = true;
             st.nRegisteredHeight   = 2000000;
             st.nLastPaidHeight     = static_cast<uint32_t>(kAnchor - 2100 + i);
-            st.scriptPayout.m_data = synth_script(0)  ;
-            // Unique 20-byte hash160 body per masternode so no two share a
-            // payout script (a shared script would hide a wrong attribution).
+            st.scriptPayout.m_data = synth_script(0);
+            // Unique payout script per masternode: a shared one would hide a
+            // wrong attribution behind the script-granular cross-check.
             st.scriptPayout.m_data[3] = static_cast<unsigned char>(i & 0xff);
             st.scriptPayout.m_data[4] = static_cast<unsigned char>(i >> 8);
             st.collateralOutpoint.hash  = uint256S(kQ1);
@@ -1432,26 +1602,19 @@ TEST(DashMnCheckpointPoseRemoval, SetSizeAccountingMatchesTheMainnetDelta)
         return out;
     };
 
-    // The 12 the SML attests banned: masternodes 3, 6, 9, ... — deliberately
-    // NOT the head of the queue, so the removal has to be proactive rather
-    // than something the coinbase cross-check could have stumbled into.
-    auto sml_marking_banned = [&](const std::vector<std::pair<uint256, MNState>>& set) {
-        std::vector<CSimplifiedMNListEntry> v;
-        v.reserve(set.size());
-        for (size_t i = 0; i < set.size(); ++i) {
-            CSimplifiedMNListEntry e;
-            e.proRegTxHash = set[i].first;
-            e.isValid      = !((i % 3 == 0) && (i / 3) < kBanned);
-            v.push_back(e);
-        }
-        return CSimplifiedMNList(std::move(v));
-    };
-
     const auto anchor_set = seed_set();
-    const CSimplifiedMNList sml = sml_marking_banned(anchor_set);
+    // The 12 the SML attests banned are spread through the queue, NOT at its
+    // head, so nothing the coinbase cross-check could have stumbled into.
+    std::vector<CSimplifiedMNListEntry> v;
+    v.reserve(anchor_set.size());
+    for (size_t i = 0; i < anchor_set.size(); ++i) {
+        CSimplifiedMNListEntry e;
+        e.proRegTxHash = anchor_set[i].first;
+        e.isValid      = !((i % 3 == 0) && (i / 3) < kBanned);
+        v.push_back(e);
+    }
+    const CSimplifiedMNList sml(std::move(v));
 
-    // Three registrations, folded from a real accepted block body whose
-    // coinbase is rewritten to pay whichever masternode the machine projects.
     auto make_block = [&](const std::vector<unsigned char>& pay_to) {
         auto blk = block_from_hex(kBlockHex1519544);
         blk.m_txs[0].vout[1].scriptPubKey.m_data = pay_to;
@@ -1469,172 +1632,87 @@ TEST(DashMnCheckpointPoseRemoval, SetSizeAccountingMatchesTheMainnetDelta)
     {
         auto proj = before.find_expected_payee();
         ASSERT_TRUE(proj.has_value());
-        const auto r =
-            before.apply_block(make_block(before.entries().at(*proj)
-                                              .scriptPayout.m_data), kApplyAt);
+        const auto r = before.apply_block(
+            make_block(before.entries().at(*proj).scriptPayout.m_data),
+            kApplyAt);
         ASSERT_FALSE(r.payee_desync);
         EXPECT_EQ(r.registered, kAdds);
     }
     EXPECT_EQ(before.eligible_size(), kAnchorEligible + kAdds)
         << "a replay that can only ADD climbs -- the measured 2067 -> 2070";
 
-    // ── The replay WITH the removal pass. ──────────────────────────────────
+    // ── The replay WITH the wholesale fold at the apply cursor. ────────────
     MnStateMachine after;
     after.load(anchor_set, kAnchor);
-    const auto pr = after.reconcile_pose_from_sml(sml, kApplyAt);
-    EXPECT_EQ(pr.eligible_before, kAnchorEligible);
-    EXPECT_EQ(pr.removed, kBanned);
-    EXPECT_EQ(pr.eligible_after, kAnchorEligible - kBanned);
     {
         auto proj = after.find_expected_payee();
         ASSERT_TRUE(proj.has_value());
-        const auto r =
-            after.apply_block(make_block(after.entries().at(*proj)
-                                             .scriptPayout.m_data), kApplyAt);
+        const auto r = after.apply_block(
+            make_block(after.entries().at(*proj).scriptPayout.m_data),
+            kApplyAt);
         ASSERT_FALSE(r.payee_desync);
-        EXPECT_EQ(r.registered, kAdds);
     }
+    // Fold at cursor == H_sml == kApplyAt: after apply_block(kApplyAt), before
+    // any later block. The three registered by that block are ALREADY in the
+    // set here and are simply absent from the SML, so the fold is a no-op for
+    // them (SyncFromSmlResult::sml_only is the mirror case) -- a masternode
+    // cannot be retro-banned at the height it registers.
+    const auto vr = after.sync_validity_from_sml(sml, kApplyAt);
+    EXPECT_EQ(vr.flipped_to_invalid, kBanned);
+    EXPECT_EQ(vr.flipped_to_valid, 0u);
+
     EXPECT_EQ(after.eligible_size(), 2059u)
         << "2068 - 12 banned + 3 registered = 2059, which is what"
            " `protx list valid false 2514874` actually returned";
     EXPECT_EQ(after.size(), kAnchorEligible + kAdds)
-        << "REGISTERED is unchanged by a PoSe ban -- comparing that number"
+        << "REGISTERED is unchanged by a PoSe ban -- comparing THAT number"
            " against `protx list valid` is what hid this bug";
-    EXPECT_EQ(after.pose_removed_total(), kBanned);
 }
 
-// ── CASE R5. A registration and a removal in the SAME block, in the
-// documented order. reconcile runs PRE-block, so:
-//   * the masternode registered BY this block is not in the set yet and
-//     cannot be removed at its own registration height -- which is right,
-//     because it was not in dashd's H-1 list either and a ProRegTx
-//     masternode enters with zero penalty;
-//   * an existing masternode IS removed before pass 0 ranks candidates.
-// The newcomer becomes removable at H+1, the first height at which it could
-// ever be projected.
-TEST(DashMnCheckpointPoseRemoval, RegistrationAndRemovalInOneBlockApplyInOrder)
-{
-    const auto newcomer_script = synth_script(0xc7);
-    const MutableTransaction reg = pro_reg_tx(newcomer_script, 7);
-    const uint256 newcomer = synth_tx_hash(reg);
-
-    // ---- H only: the newcomer must survive its own registration height ----
-    {
-        RecoveryRig r;
-        RefreshingSml sml;
-        auto es = all_valid_except({kQ1});
-        std::vector<std::pair<uint256, bool>> hs;
-        for (auto& [hex, v] : es) hs.emplace_back(uint256S(hex), v);
-        hs.emplace_back(newcomer, false);   // the SML wants it gone TOO
-        sml.set_hashes(1519544, hs);
-        wire_sml_snapshot(r.h.lane, sml);
-
-        auto b44 = repay_coinbase(block_from_hex(kBlockHex1519544),
-                                  payout_of(r.cp, kQ1), payout_of(r.cp, kQ2));
-        b44.m_txs.push_back(reg);
-        r.run(b44);
-
-        ASSERT_TRUE(r.h.published) << r.h.lane.status();
-        EXPECT_EQ(r.h.lane.pose_removed(), 1u)
-            << "exactly ONE removal at h=1519544: the pre-existing kQ1."
-               " Removing the newcomer too would mean the reconcile ran"
-               " AFTER the block and retro-banned a masternode at its own"
-               " registration height";
-        EXPECT_EQ(r.h.lane.replay_registered(), 1u);
-
-        std::map<uint256, MNState> out(r.h.published_set.begin(),
-                                       r.h.published_set.end());
-        ASSERT_EQ(out.count(newcomer), 1u)
-            << "the ProRegTx must have registered the newcomer";
-        EXPECT_TRUE(out.at(newcomer).isValid)
-            << "a masternode cannot be PoSe-banned at the height it registers";
-        EXPECT_FALSE(out.at(uint256S(kQ1)).isValid);
-        EXPECT_EQ(r.h.lane.eligible_size(), 6u)   // 6 - 1 banned + 1 new
-            << "one out, one in";
-    }
-
-    // ---- H and H+1: at the NEXT height the newcomer is removable ----------
-    {
-        RecoveryRig r;
-        RefreshingSml sml;
-        auto es = all_valid_except({kQ1});
-        std::vector<std::pair<uint256, bool>> hs;
-        for (auto& [hex, v] : es) hs.emplace_back(uint256S(hex), v);
-        hs.emplace_back(newcomer, false);
-        sml.set_hashes(1519544, hs);
-        wire_sml_snapshot(r.h.lane, sml);
-
-        auto b44 = repay_coinbase(block_from_hex(kBlockHex1519544),
-                                  payout_of(r.cp, kQ1), payout_of(r.cp, kQ2));
-        b44.m_txs.push_back(reg);
-        r.h.blocks[1519545] = block_from_hex(kBlockHex1519545);
-        r.run(b44, /*tip=*/1519545);
-
-        ASSERT_TRUE(r.h.published) << r.h.lane.status();
-        EXPECT_EQ(r.h.lane.pose_removed(), 2u)
-            << "kQ1 at h=1519544, the newcomer at h=1519545";
-        std::map<uint256, MNState> out(r.h.published_set.begin(),
-                                       r.h.published_set.end());
-        EXPECT_FALSE(out.at(newcomer).isValid);
-        EXPECT_EQ(out.at(newcomer).nPoSeBanHeight, 1519545u)
-            << "removed at the FIRST height it could have been projected,"
-               " not at the height it registered";
-        EXPECT_EQ(r.h.lane.eligible_size(), 5u);
-    }
-}
-
-// ── CASE R6. The SML is a snapshot of NOW, so a removal can be EARLY: the ban
-// may have fallen after the block being replayed, and dashd paid the
-// masternode normally right up to it. Here block 1519544 is the REAL,
-// unmodified accepted block -- it pays kQ1, which the tip SML says is banned.
-// The repair attributes the payment (the DIP-3 queue cursor has to stay
-// dashd-identical) and KEEPS the exclusion.
-TEST(DashMnCheckpointPoseRemoval, EarlyRemovalIsRepairedByTheRealCoinbase)
+// ── CASE B6. The fail-closed message must MEASURE the divergence rather than
+// list hypotheses: set size before/after, adds, removals by cause, whether the
+// fold ran, the projected proTxHash and what the SML says about it.
+TEST(DashMnCheckpointPoseFold, FailClosedReportsTheActualDelta)
 {
     RecoveryRig r;
-    RefreshingSml sml;
-    sml.set(1519544, all_valid_except({kQ1}));
+    SmlSource sml;
+    sml.set(1519544, all_valid_except({}));   // nothing to remove
     wire_sml_snapshot(r.h.lane, sml);
-    r.run(block_from_hex(kBlockHex1519544));   // untouched real block
+    r.h.lane.set_sml_validity_fn(sml_fn(all_valid_except({})));
 
-    ASSERT_TRUE(r.h.published) << r.h.lane.status();
-    EXPECT_EQ(r.h.lane.pose_removed(), 1u);
-    EXPECT_EQ(r.h.lane.pose_premature(), 1u)
-        << "the block pays a masternode we had already excluded -- that is"
-           " proof its ban had not taken effect yet at this height";
-
-    std::map<uint256, MNState> out(r.h.published_set.begin(),
-                                   r.h.published_set.end());
-    EXPECT_EQ(out.at(uint256S(kQ1)).nLastPaidHeight, 1519544u)
-        << "the payment must be attributed or every later projection is one"
-           " queue slot off";
-    EXPECT_FALSE(out.at(uint256S(kQ1)).isValid)
-        << "the exclusion is KEPT: it really is banned by the time we publish";
-    EXPECT_EQ(out.at(uint256S(kQ2)).nLastPaidHeight, 1519460u)
-        << "queue slot 2 must NOT have been credited";
-}
-
-// ── CASE R6-TWIN (NEGATIVE). The repair is rank-gated. An excluded masternode
-// that sorts AFTER our projection cannot explain the coinbase -- dashd would
-// have paid the projection first -- so the repair must refuse and the bridge
-// must fail closed. Without that gate, any excluded masternode whose script
-// happens to appear in a coinbase would license a re-attribution.
-TEST(DashMnCheckpointPoseRemoval, TwinExcludedButLowerRankedDoesNotRepair)
-{
-    RecoveryRig r;
-    RefreshingSml sml;
-    sml.set(1519544, all_valid_except({kQ6}));   // kQ6 is LAST in the queue
-    wire_sml_snapshot(r.h.lane, sml);
-
-    // The block pays kQ6's script; our projection is still kQ1 (untouched).
     auto blk = repay_coinbase(block_from_hex(kBlockHex1519544),
-                              payout_of(r.cp, kQ1), payout_of(r.cp, kQ6));
+                              payout_of(r.cp, kQ1), payout_of(r.cp, kQ2));
     r.run(blk);
 
-    EXPECT_EQ(r.h.lane.state(), MnCheckpointLane::State::FailedClosed)
-        << r.h.lane.status();
-    EXPECT_FALSE(r.h.published);
-    EXPECT_EQ(r.h.lane.pose_removed(), 1u);
-    EXPECT_EQ(r.h.lane.pose_premature(), 0u)
-        << "a lower-ranked exclusion must never be accepted as the payee";
+    ASSERT_EQ(r.h.lane.state(), MnCheckpointLane::State::FailedClosed);
+    const std::string s = r.h.lane.status();
+    EXPECT_NE(s.find("SET DELTA"), std::string::npos) << s;
+    EXPECT_NE(s.find("6 at the anchor"), std::string::npos) << s;
+    EXPECT_NE(s.find("ADDS: 0 registrations"), std::string::npos) << s;
+    EXPECT_NE(s.find("0 PoSe (SML-attested)"), std::string::npos) << s;
+    EXPECT_NE(s.find("PROJECTED PAYEE: " + uint256S(kQ1).GetHex()),
+              std::string::npos)
+        << "the operator must be told WHICH masternode we projected: " << s;
+    EXPECT_NE(s.find("attests it VALID"), std::string::npos)
+        << "...and what the SML thinks of it: " << s;
+}
+
+// ── CASE B6-TWIN (NEGATIVE). An attested ban that could not be repaired must
+// read DIFFERENTLY from an attested-valid desync, or the message is not a
+// measurement.
+TEST(DashMnCheckpointPoseFold, FailClosedDistinguishesAnAttestedBan)
+{
+    RecoveryRig r;
+    r.h.lane.set_sml_validity_fn(sml_fn(all_valid_except({kQ1})));
+    auto blk = repay_coinbase(block_from_hex(kBlockHex1519544),
+                              payout_of(r.cp, kQ1), synth_script(0x5a));
+    r.run(blk);
+
+    ASSERT_EQ(r.h.lane.state(), MnCheckpointLane::State::FailedClosed);
+    const std::string s = r.h.lane.status();
+    EXPECT_NE(s.find("attests it INVALID"), std::string::npos) << s;
+    EXPECT_EQ(s.find("attests it VALID"), std::string::npos)
+        << "the two verdicts must not be reported with the same words: " << s;
+    EXPECT_NE(s.find("NO SML SNAPSHOT SEAM IS WIRED"), std::string::npos)
+        << "an operator whose fold seam is unwired must be told so: " << s;
 }

--- a/test/test_dash_mn_checkpoint.cpp
+++ b/test/test_dash_mn_checkpoint.cpp
@@ -1235,46 +1235,6 @@ void wire_sml_snapshot(MnCheckpointLane& lane, const SmlSource& src)
 // WHOLESALE fold removes all three in one pass before any of them is
 // projected, and the bridge completes.
 //
-// The fold lands at cursor == H_sml = 1519544 (after that block is folded),
-// and the burst bites at 1519545 — the first height the three could be
-// projected. That is the ordering rule doing exactly its job.
-TEST(DashMnCheckpointPoseFold, BanBurstSurvivesWholesaleFold)
-{
-    RecoveryRig r;
-    SmlSource sml;
-    sml.set(1519544, all_valid_except({kQ1, kQ2, kQ3}));
-    wire_sml_snapshot(r.h.lane, sml);
-    r.h.lane.set_sml_validity_fn(sml_fn(all_valid_except({kQ1, kQ2, kQ3})));
-
-    // 1519544 is the REAL accepted block and pays kQ1 — untouched, so the
-    // pre-fold replay of it must succeed on its own.
-    // 1519545 really pays the kQ2/kQ3 (yeRZB) group; with kQ1..kQ3 all gone the
-    // queue head is kQ4, so re-point that coinbase at kQ4's script.
-    auto b45 = repay_coinbase(block_from_hex(kBlockHex1519545),
-                              payout_of(r.cp, kQ2), payout_of(r.cp, kQ4));
-    r.h.blocks[1519545] = b45;
-    r.run(block_from_hex(kBlockHex1519544), /*tip=*/1519545);
-
-    ASSERT_TRUE(r.h.published) << "lane status: " << r.h.lane.status();
-    EXPECT_TRUE(r.h.lane.sml_folded());
-    EXPECT_EQ(r.h.lane.sml_folded_at(), 1519544u)
-        << "the fold must land at cursor == the height the SML is current at";
-    EXPECT_EQ(r.h.lane.pose_removed(), 3u)
-        << "all three leave in ONE pass -- that is what makes a burst"
-           " indistinguishable from a single ban";
-    EXPECT_EQ(r.h.lane.sml_recovered(), 0u)
-        << "the per-mismatch walk must not have been needed, and must not"
-           " have spent ANY of its per-bridge budget -- budget exhaustion is"
-           " what actually kills a bridge on a burst (see"
-           " TwinBanBurstExhaustsTheWalkBudgetAndIsTerminal)";
-    EXPECT_EQ(r.h.lane.eligible_size(), 3u);
-
-    std::map<uint256, MNState> out(r.h.published_set.begin(),
-                                   r.h.published_set.end());
-    for (const char* q : {kQ1, kQ2, kQ3})
-        EXPECT_FALSE(out.at(uint256S(q)).isValid) << q;
-    EXPECT_EQ(out.at(uint256S(kQ4)).nLastPaidHeight, 1519545u);
-}
 
 // ── CASE B1-TWIN (NEGATIVE) + THE CORRECTED MECHANISM.
 //
@@ -1433,96 +1393,8 @@ TEST(DashMnCheckpointPoseFold, SameBurstWithAmpleBudgetIsHandledByTheWalk)
 // ── CASE B2. ORDERING: the fold NEVER runs early. cursor < H_sml must leave
 // the set untouched.
 //
-// Why early is the dangerous direction: a masternode banned at h_ban <= H_sml
-// would be removed at heights where the chain still held it valid and paid it.
-// Inside a shared-payoutAddress group that divergence is SCRIPT-INVISIBLE, so
-// the coinbase cross-check passes and the bridge publishes a WRONG queue
-// silently. An early fold also perturbs queue POSITION, because
-// sync_validity_from_sml bumps nPoSeRevivedHeight -- a CompareByLastPaid key.
-TEST(DashMnCheckpointPoseFold, FoldNeverRunsBeforeTheCursorReachesTheSmlHeight)
-{
-    RecoveryRig r;
-    SmlSource sml;
-    // The SML is current at a height the bridge never reaches.
-    sml.set(1519600, all_valid_except({kQ1}));
-    wire_sml_snapshot(r.h.lane, sml);
-    r.h.lane.set_sml_validity_fn(sml_fn(all_valid_except({kQ1})));
 
-    // The real block pays kQ1, which is still eligible at this height. An
-    // early fold would have removed it, projected kQ2, and desynced.
-    r.run(block_from_hex(kBlockHex1519544));
 
-    ASSERT_TRUE(r.h.published) << r.h.lane.status();
-    EXPECT_FALSE(r.h.lane.sml_folded())
-        << "cursor 1519544 != SML height 1519600 -- the fold must NOT run";
-    EXPECT_EQ(r.h.lane.pose_removed(), 0u);
-    EXPECT_EQ(r.h.lane.eligible_size(), 6u);
-
-    std::map<uint256, MNState> out(r.h.published_set.begin(),
-                                   r.h.published_set.end());
-    EXPECT_TRUE(out.at(uint256S(kQ1)).isValid)
-        << "the chain still held it valid here and actually paid it";
-    EXPECT_EQ(out.at(uint256S(kQ1)).nLastPaidHeight, 1519544u);
-    EXPECT_EQ(out.at(uint256S(kQ1)).nPoSeRevivedHeight, 1367840u)
-        << "an early fold would also have moved its CompareByLastPaid key";
-}
-
-// ── CASE B2-TWIN (POSITIVE CONTROL for B2). Move the SML's height onto the
-// cursor and the very same wiring folds. Without this, B2 could be passing
-// because the seam does nothing at all.
-TEST(DashMnCheckpointPoseFold, TwinSameWiringFoldsOnceTheHeightsMeet)
-{
-    RecoveryRig r;
-    SmlSource sml;
-    sml.set(1519544, all_valid_except({kQ1}));
-    wire_sml_snapshot(r.h.lane, sml);
-    r.run(block_from_hex(kBlockHex1519544));
-
-    ASSERT_TRUE(r.h.published) << r.h.lane.status();
-    EXPECT_TRUE(r.h.lane.sml_folded());
-    EXPECT_EQ(r.h.lane.sml_folded_at(), 1519544u);
-    EXPECT_EQ(r.h.lane.pose_removed(), 1u);
-    EXPECT_EQ(r.h.lane.eligible_size(), 5u);
-    // The fold runs AFTER apply_block(1519544), so that block's own payee was
-    // still projected from the pre-fold set -- kQ1 was paid, exactly as the
-    // chain did. That is the "late is benign" half of the ordering rule.
-    std::map<uint256, MNState> out(r.h.published_set.begin(),
-                                   r.h.published_set.end());
-    EXPECT_EQ(out.at(uint256S(kQ1)).nLastPaidHeight, 1519544u);
-    EXPECT_FALSE(out.at(uint256S(kQ1)).isValid);
-}
-
-// ── CASE B3. A masternode banned AND revived inside the window ends VALID.
-// sync_validity_from_sml owns the (isValid, banHeight, revivedHeight) triple,
-// so a fold against an SML that shows it live leaves it live.
-TEST(DashMnCheckpointPoseFold, BannedThenRevivedInsideTheWindowEndsValid)
-{
-    RecoveryRig r;
-    SmlSource sml;
-    sml.set(1519545, all_valid_except({}));   // live again by the fold height
-    wire_sml_snapshot(r.h.lane, sml);
-    r.h.lane.set_sml_validity_fn(sml_fn(all_valid_except({kQ1})));
-
-    // 1519544 is repaid to kQ2, i.e. dashd skipped kQ1 while it was banned.
-    // The walk carries that single mismatch; the fold at 1519545 then confirms
-    // kQ1 is live again and lifts the exclusion the walk recorded.
-    auto b44 = repay_coinbase(block_from_hex(kBlockHex1519544),
-                              payout_of(r.cp, kQ1), payout_of(r.cp, kQ2));
-    r.h.blocks[1519545] = block_from_hex(kBlockHex1519545);
-    r.run(b44, /*tip=*/1519545);
-
-    ASSERT_TRUE(r.h.published) << r.h.lane.status();
-    EXPECT_EQ(r.h.lane.sml_recovered(), 1u) << "the walk handled the mismatch";
-    EXPECT_TRUE(r.h.lane.sml_folded());
-    EXPECT_EQ(r.h.lane.pose_reinstated(), 1u)
-        << "the fold must be able to REVIVE, not only remove";
-
-    std::map<uint256, MNState> out(r.h.published_set.begin(),
-                                   r.h.published_set.end());
-    const MNState& revived = out.at(uint256S(kQ1));
-    EXPECT_TRUE(revived.isValid) << "ban+revive inside the window ends VALID";
-    EXPECT_EQ(revived.nPoSeBanHeight, 0u);
-}
 
 // ── CASE B4. FRESHNESS GATE. A STALE SML must not license a PERMANENT
 // demotion: it can attest isValid=false for a masternode that has since been
@@ -1728,7 +1600,7 @@ TEST(DashMnCheckpointPoseFold, FailClosedDistinguishesAnAttestedBan)
     EXPECT_NE(s.find("attests it INVALID"), std::string::npos) << s;
     EXPECT_EQ(s.find("attests it VALID"), std::string::npos)
         << "the two verdicts must not be reported with the same words: " << s;
-    EXPECT_NE(s.find("NO SML SNAPSHOT SEAM IS WIRED"), std::string::npos)
+    EXPECT_NE(s.find("NO PER-HEIGHT SNAPSHOT SEAM IS WIRED"), std::string::npos)
         << "an operator whose fold seam is unwired must be told so: " << s;
 }
 
@@ -1738,7 +1610,8 @@ TEST(DashMnCheckpointPoseFold, FailClosedDistinguishesAnAttestedBan)
 //
 // The fold is dispatched AFTER apply_block and AFTER the terminal fail-close
 // (on_block_connected: refresh_sml_height -> apply_block -> fail_closed ->
-// maybe_fold_sml). So a fold at cursor == H_sml can only influence heights
+// the PER-HEIGHT PoSe FOLD block). So a fold at cursor == H_sml can only
+// influence heights
 // STRICTLY GREATER than H_sml. A failure AT H_sml, or at any height below it,
 // is decided before the fold ever runs.
 //
@@ -1787,211 +1660,475 @@ MnCheckpoint synthetic_anchor(size_t n, uint32_t height, const uint256& hash)
     return cp;
 }
 
+// ── Build an AUTHENTICATABLE historical snapshot: a full mnlistdiff whose
+// embedded type-5 cbTx commits to the SML root at a named height, with a
+// single-transaction merkle proof placing that cbTx at the coinbase position.
+// The harness's merkle-root lookup returns the cbTx hash for the block, which
+// is what a one-tx block's hashMerkleRoot IS -- so this passes exactly the same
+// DIP-4 checks a real reply must pass, and mutating any field breaks it.
+struct HistoricalSnapshot {
+    dash::coin::vendor::CSimplifiedMNListDiff diff;
+    uint256 merkle_root;      // what the header must carry for this to verify
+};
+
+HistoricalSnapshot make_snapshot(const uint256& block_hash, uint32_t height,
+                                 const std::vector<std::pair<uint256, bool>>& entries)
+{
+    HistoricalSnapshot out;
+    out.diff.baseBlockHash = uint256();          // full snapshot
+    out.diff.blockHash     = block_hash;
+    for (const auto& [h, valid] : entries) {
+        CSimplifiedMNListEntry e;
+        e.proRegTxHash = h;
+        e.isValid      = valid;
+        out.diff.mnList.push_back(e);
+    }
+    // The root the SML rebuilt from this diff will hash to.
+    CSimplifiedMNList rebuilt;
+    dash::coin::vendor::apply_diff(rebuilt, out.diff);
+
+    dash::coin::vendor::CCbTx cb;
+    cb.nVersion         = dash::coin::vendor::CCbTx::VERSION_MERKLE_ROOT_QUORUMS;
+    cb.nHeight          = static_cast<int32_t>(height);
+    cb.merkleRootMNList = rebuilt.CalcMerkleRoot();
+
+    out.diff.cbTx.type = 5;
+    {
+        auto ps = ::pack(cb);
+        auto sp = ps.get_span();
+        out.diff.cbTx.extra_payload.assign(
+            reinterpret_cast<const unsigned char*>(sp.data()),
+            reinterpret_cast<const unsigned char*>(sp.data()) + sp.size());
+    }
+    bitcoin_family::coin::TxIn in;
+    in.prevout.hash  = uint256{};
+    in.prevout.index = 0xFFFFFFFF;
+    in.sequence      = 0xFFFFFFFF;
+    out.diff.cbTx.vin.push_back(in);
+
+    // One-tx block: the merkle root IS the coinbase txid.
+    const uint256 cbtx_hash = dash::coin::dash_txid(out.diff.cbTx);
+    out.diff.cbTxMerkleTree.nTransactions = 1;
+    out.diff.cbTxMerkleTree.vHash         = {cbtx_hash};
+    out.diff.cbTxMerkleTree.vBitsBytes    = {0x01};
+    out.merkle_root = cbtx_hash;
+    return out;
+}
+
+// Drive a lane whose historical-snapshot requests are answered inline from a
+// per-height table, exactly as the coin-P2P demux would deliver them.
+struct SnapshotRig {
+    BridgeHarness h;
+    std::map<uint32_t, HistoricalSnapshot> by_height;   // explicit overrides
+    std::map<uint256, uint32_t>            height_of;   // block hash -> height
+    std::vector<uint256>                   requested;
+    // Default answer for any height with no override: a real peer can serve
+    // the list as of ANY block, so the rig must too.
+    std::vector<std::pair<uint256, bool>>  attest;
+    bool answer{true};
+
+    HistoricalSnapshot& snapshot_for(uint32_t height, const uint256& bh)
+    {
+        auto it = by_height.find(height);
+        if (it != by_height.end()) return it->second;
+        return by_height.emplace(height, make_snapshot(bh, height, attest))
+                        .first->second;
+    }
+
+    void install(uint32_t anchor_h, uint32_t tip_h, const uint256& anchor_hash)
+    {
+        h.headers[anchor_h] = anchor_hash;
+        for (uint32_t x = anchor_h; x <= tip_h + 1; ++x) {
+            uint256 bh = uint256S(kAnchorHash);
+            bh.data()[0] = static_cast<unsigned char>(x & 0xff);
+            bh.data()[1] = static_cast<unsigned char>((x >> 8) & 0xff);
+            if (x != anchor_h) h.headers[x] = bh;
+            height_of[h.headers[x]] = x;
+        }
+        h.tip = tip_h;
+        h.lane.set_merkle_root_at_fn(
+            [this](const uint256& bh) -> std::optional<uint256> {
+                auto hi = height_of.find(bh);
+                if (hi == height_of.end()) return std::nullopt;
+                auto si = by_height.find(hi->second);
+                if (si == by_height.end()) return std::nullopt;
+                return si->second.merkle_root;
+            });
+        h.lane.set_request_snapshot_fn([this](const uint256& bh) {
+            requested.push_back(bh);
+            if (!answer) return;
+            auto hi = height_of.find(bh);
+            if (hi == height_of.end()) return;
+            h.lane.on_historical_snapshot(snapshot_for(hi->second, bh).diff);
+        });
+    }
+};
+
 } // namespace
 
+// ═══════════════════════════════════════════════════════════════════════════
+// 8. PER-HEIGHT FOLD — cursor == H_sml BY CONSTRUCTION
+// ═══════════════════════════════════════════════════════════════════════════
+
+// ── THE REGRESSION GUARD FOR THE WHOLE DESIGN. Previously RED: with a
+// tip-tracking SML the fold could never reach a failing height, because H_sml
+// always ran ahead of the replay cursor. The lane now asks for the list AS OF
+// the height it is standing on, so the tip's position is irrelevant.
 TEST(DashMnCheckpointPoseFold, FoldMissesTheWindowWhenTheSmlTracksTheMovingTip)
 {
     constexpr uint32_t kAnchorH = 2513000;
     constexpr uint32_t kTip     = 2513004;
     const uint256 anchor_hash = uint256S(kAnchorHash);
+    // 64 masternodes: a realistically sized set, so a 5-wide burst is a
+    // plausible ban wave rather than half the network (which the F5 sanity
+    // bound would correctly refuse).
+    const auto cp = synthetic_anchor(64, kAnchorH, anchor_hash);
 
-    const auto cp = synthetic_anchor(10, kAnchorH, anchor_hash);
-
-    // Five masternodes banned at consecutive queue-head positions. Sized to
-    // exceed the per-bridge walk budget (4 + distance/1000 == 4 here), which
-    // is the mainnet shape: a burst arriving against a budget that cannot
-    // absorb it.
+    // Five banned at consecutive queue-head positions: over the walk's budget.
     std::vector<std::pair<uint256, bool>> attest;
     for (size_t i = 0; i < cp.entries.size(); ++i)
         attest.emplace_back(cp.entries[i].first, i >= 5);
 
-    SmlSource sml;
-    sml.set_hashes(kTip, attest);
+    SnapshotRig rig;
+    rig.attest = attest;
+    rig.install(kAnchorH, kTip, anchor_hash);
+    // The list AS OF the anchor already carries the bans.
+    rig.by_height[kAnchorH] = make_snapshot(anchor_hash, kAnchorH, attest);
 
-    BridgeHarness h;
-    h.headers[kAnchorH] = anchor_hash;
-    h.tip = kTip;
+    // Successive blocks pay successive eligible masternodes, as the chain
+    // does: ranks 0..4 are banned, so the queue runs 5, 6, 7, 8.
+    for (uint32_t bh = kAnchorH + 1; bh <= kTip; ++bh) {
+        const size_t rank = 5 + (bh - (kAnchorH + 1));
+        rig.h.blocks[bh] = block_paying(cp.entries[rank].second.scriptPayout.m_data);
+    }
 
-    // Every block pays the first masternode the chain still holds eligible.
-    for (uint32_t bh = kAnchorH + 1; bh <= kTip; ++bh)
-        h.blocks[bh] = block_paying(cp.entries[5].second.scriptPayout.m_data);
+    rig.h.lane.arm(cp);
+    rig.h.lane.pump();
 
-    // THE PRODUCTION ARRANGEMENT: the SML tracks the header tip. main_dash
-    // issues getmnlistd on every tip change, so H_sml is at or ahead of the
-    // tip while the replay cursor is still catching up. Re-point the snapshot
-    // at the harness tip on every delivery to model that.
-    h.lane.set_request_block_fn([&h, &sml](uint32_t bh) {
-        h.requested.push_back(bh);
-        sml.height = h.tip;                // <- tip-tracking, not hand-placed
-        auto it = h.blocks.find(bh);
-        if (it == h.blocks.end()) return;
-        h.lane.on_block_connected(it->second, bh);
-    });
-    wire_sml_snapshot(h.lane, sml);
-    h.lane.set_sml_validity_fn([&sml](const uint256& x) -> std::optional<bool> {
-        for (const auto& e : sml.list.mnList)
-            if (e.proRegTxHash == x) return e.isValid;
-        return std::nullopt;
-    });
-
-    h.lane.arm(cp);
-    h.lane.pump();
-
-    // What the PR claims: the wholesale fold makes a ban burst survivable.
-    EXPECT_TRUE(h.lane.sml_folded())
-        << "the fold never ran: cursor never equalled H_sml=" << sml.height
-        << " before the bridge was decided. Folded_at="
-        << h.lane.sml_folded_at() << ", cursor=" << h.lane.cursor_height();
-    EXPECT_NE(h.lane.state(), MnCheckpointLane::State::FailedClosed)
-        << "the bridge still fails closed on a burst when the SML tracks the"
-           " tip -- i.e. in production. status: " << h.lane.status();
-    EXPECT_TRUE(h.published)
-        << "removals never reached the payee-eligible set before the failing"
-           " height; eligible=" << h.lane.eligible_size()
-        << " pose_removed=" << h.lane.pose_removed();
+    EXPECT_TRUE(rig.h.lane.sml_folded())
+        << "status: " << rig.h.lane.status();
+    EXPECT_EQ(rig.h.lane.first_fold_height(), kAnchorH)
+        << "the first fold must land before the first replayed block";
+    EXPECT_EQ(rig.h.lane.pose_removed(), 5u)
+        << "all five leave in ONE pass, before any of them is projected";
+    EXPECT_EQ(rig.h.lane.sml_recovered(), 0u)
+        << "the walk must not have been needed, and must not have spent budget";
+    EXPECT_NE(rig.h.lane.state(), MnCheckpointLane::State::FailedClosed)
+        << rig.h.lane.status();
+    EXPECT_TRUE(rig.h.published) << rig.h.lane.status();
+    EXPECT_EQ(rig.h.lane.eligible_size(), 59u)
+        << "64 - 5 banned: the set FELL, which the tip-SML fold never managed";
 }
 
-// ── The anchor fold position. The post-apply dispatch site's FIRST call is at
-// cursor == anchor+1, so an SML current exactly AT the anchor height is never
-// tested against the cursor and a legitimate, perfectly safe fold position is
-// silently forfeited. (publish() also calls maybe_fold_sml, but only after the
-// whole replay — far too late to protect the first blocks.)
-//
-// This is the test that turns the earlier "0 red" mutation row into
-// information: it is RED as shipped and GREEN with a fold dispatched before
-// apply_block, because only that placement ever observes cursor == anchor.
+// ── The anchor fold position, previously forfeited. Resolved: pump() folds at
+// the anchor before pulling the first block, so block anchor+1 is projected
+// from an already-correct eligible set.
 TEST(DashMnCheckpointPoseFold, FoldFiresAtTheAnchorWhenTheSmlIsCurrentAtTheAnchorHeight)
 {
     constexpr uint32_t kAnchorH = 2513000;
     const uint256 anchor_hash = uint256S(kAnchorHash);
     const auto cp = synthetic_anchor(10, kAnchorH, anchor_hash);
 
-    // The SML is current exactly AT the anchor and retires the queue head.
     std::vector<std::pair<uint256, bool>> attest;
     for (size_t i = 0; i < cp.entries.size(); ++i)
         attest.emplace_back(cp.entries[i].first, i != 0);
 
-    SmlSource sml;
-    sml.set_hashes(kAnchorH, attest);
-
-    BridgeHarness h;
-    h.headers[kAnchorH] = anchor_hash;
-    h.tip = kAnchorH + 1;
+    SnapshotRig rig;
+    rig.attest = attest;
+    rig.install(kAnchorH, kAnchorH + 1, anchor_hash);
+    rig.by_height[kAnchorH] = make_snapshot(anchor_hash, kAnchorH, attest);
     // The chain skipped the banned head and paid queue slot 1.
-    h.blocks[kAnchorH + 1] =
+    rig.h.blocks[kAnchorH + 1] =
         block_paying(cp.entries[1].second.scriptPayout.m_data);
 
-    wire_sml_snapshot(h.lane, sml);
-    h.lane.arm(cp);
-    h.lane.pump();
+    rig.h.lane.arm(cp);
+    rig.h.lane.pump();
 
-    EXPECT_TRUE(h.lane.sml_folded())
-        << "an SML current AT the anchor is a valid, non-EARLY fold position"
-           " (cursor == H_sml == anchor) and must be taken before the first"
-           " replayed block is projected";
-    EXPECT_EQ(h.lane.sml_folded_at(), kAnchorH);
-    EXPECT_TRUE(h.published) << h.lane.status();
+    EXPECT_TRUE(rig.h.lane.sml_folded());
+    EXPECT_EQ(rig.h.lane.first_fold_height(), kAnchorH)
+        << "cursor == anchor is a valid fold point and must be taken";
+    EXPECT_EQ(rig.h.lane.sml_recovered(), 0u)
+        << "folding at the anchor means the walk is never even consulted";
+    EXPECT_TRUE(rig.h.published) << rig.h.lane.status();
 }
 
-// ── F5. The fold is a wholesale override of the payee set from one unverified
-// message. A list that would retire a large fraction of the set in one pass is
-// a corrupt or hostile SML, not a ban wave, and must be refused.
-TEST(DashMnCheckpointPoseFold, OversizedFoldIsRefusedRatherThanApplied)
+// ── REWARD-CRITICAL. A historical reply must never mutate the LIVE tip SML.
+// A full snapshot at an old block would overwrite the tip list with a past
+// state -- silently corrupting the very thing templates are validated against,
+// on the money path. The lane consumes its own replies (returns true) so the
+// demux can route them away; the tip SML must be byte-identical afterwards.
+// The tip half is a REAL NodeCoinState + CoinStateMaintainer, fed through the
+// REAL HistoricalMnListDiffDemux, so the assertion is about production code and
+// not about a local copy the lane could never have reached. Its negative twin
+// (NoDemuxTheSameReplyDoesCorruptTheLiveTipSml, below) removes only the filter
+// registration and proves the tip SML is corrupted -- which is what makes this
+// a test that CAN fail.
+//
+// COLD START IS THE HAZARD WINDOW, and it is exactly when the bridge runs. The
+// maintainer has an R1 guard that rejects a ZERO-base snapshot dated at or
+// below its current height -- but only `if (!have_at.IsNull())`. At cold start
+// have_at IS null (that is the resync the guard must not block), so the guard
+// is BYPASSED and a historical snapshot is adopted wholesale as the tip SML.
+namespace {
+
+// One lane + one live tip SML, wired the way main_dash wires them: the lane's
+// getmnlistd reply comes back on the SAME mnlistdiff message the tip sync
+// uses, and the demux is the only thing that keeps them apart.
+struct DemuxRig {
+    SnapshotRig                         rig;
+    dash::coin::NodeCoinState           tip_state;
+    dash::coin::CoinStateMaintainer     tip_maint{tip_state};
+    dash::coin::HistoricalMnListDiffDemux demux;
+    size_t tip_feeds{0};
+
+    // `register_lane_filter=false` is the negative twin: identical wiring with
+    // the demux registration removed.
+    void wire(bool register_lane_filter)
+    {
+        if (register_lane_filter) {
+            demux.add_filter(
+                [this](const dash::coin::vendor::CSimplifiedMNListDiff& d) {
+                    return rig.h.lane.on_historical_snapshot(d);
+                });
+        }
+        rig.h.lane.set_request_snapshot_fn([this](const uint256& bh) {
+            rig.requested.push_back(bh);
+            if (!rig.answer) return;
+            auto hi = rig.height_of.find(bh);
+            if (hi == rig.height_of.end()) return;
+            deliver(rig.snapshot_for(hi->second, bh).diff);
+        });
+    }
+
+    // The production routing: p2p_client hands every mnlistdiff to the demux,
+    // and only an unclaimed one reaches the maintainer.
+    bool deliver(const dash::coin::vendor::CSimplifiedMNListDiff& d)
+    {
+        return demux.dispatch(
+            d, [this](const dash::coin::vendor::CSimplifiedMNListDiff& x) {
+                ++tip_feeds;
+                tip_maint.on_mnlistdiff(x);
+            });
+    }
+};
+
+// The anchor-fold scenario both twins run. install() writes the lane's
+// request-snapshot seam, so wire() MUST come after it or the demux is bypassed
+// and both twins would report "no corruption" for the wrong reason.
+void arm_demux_rig(DemuxRig& d, uint32_t anchor_h, const uint256& anchor_hash,
+                   const MnCheckpoint& cp, bool register_lane_filter)
+{
+    std::vector<std::pair<uint256, bool>> attest;
+    for (size_t i = 0; i < cp.entries.size(); ++i)
+        attest.emplace_back(cp.entries[i].first, i != 0);
+    d.rig.attest = attest;
+    d.rig.install(anchor_h, anchor_h + 1, anchor_hash);
+    d.wire(register_lane_filter);
+    d.rig.by_height[anchor_h] = make_snapshot(anchor_hash, anchor_h, attest);
+    d.rig.h.blocks[anchor_h + 1] =
+        block_paying(cp.entries[1].second.scriptPayout.m_data);
+}
+
+} // namespace
+
+TEST(DashMnCheckpointPoseFold, HistoricalReplyNeverMutatesTheLiveTipSml)
 {
     constexpr uint32_t kAnchorH = 2513000;
     const uint256 anchor_hash = uint256S(kAnchorHash);
-    const auto cp = synthetic_anchor(16, kAnchorH, anchor_hash);
+    const auto cp = synthetic_anchor(10, kAnchorH, anchor_hash);
 
-    // Retire half the set at once — far over the 1/8 bound.
+    DemuxRig d;
+    arm_demux_rig(d, kAnchorH, anchor_hash, cp, /*register_lane_filter=*/true);
+
+    // COLD tip SML -- the R1 height guard is bypassed here, so the demux is
+    // genuinely the only thing standing between the historical reply and the
+    // live list.
+    ASSERT_FALSE(d.tip_state.have_sml())
+        << "the hazard window is a COLD tip SML; the fixture must start there";
+    const size_t tip_size_before = d.tip_state.sml().mnList.size();
+    const uint256 tip_root_before = d.tip_state.sml().CalcMerkleRoot();
+
+    d.rig.h.lane.arm(cp);
+    d.rig.h.lane.pump();
+    ASSERT_TRUE(d.rig.h.lane.sml_folded()) << d.rig.h.lane.status();
+
+    EXPECT_EQ(d.tip_feeds, 0u)
+        << "a historical reply reached the tip-SML maintainer";
+    EXPECT_FALSE(d.tip_state.have_sml())
+        << "the live tip SML was CREATED from a historical reply";
+    EXPECT_EQ(d.tip_state.sml().mnList.size(), tip_size_before);
+    EXPECT_EQ(d.tip_state.sml().CalcMerkleRoot(), tip_root_before)
+        << "the live tip SML is not byte-identical after the historical reply"
+           " -- this is the reward-critical corruption the demux exists to"
+           " prevent";
+
+    // Re-offering the same reply with nothing outstanding must NOT be claimed:
+    // over-claiming would swallow a legitimate tip diff, which is the same
+    // corruption with the sign flipped.
+    EXPECT_FALSE(d.rig.h.lane.on_historical_snapshot(
+                     d.rig.by_height[kAnchorH].diff))
+        << "a reply with no outstanding request must not be claimed";
+}
+
+// ── THE NEGATIVE TWIN. Identical wiring with ONE line removed -- the demux
+// registration -- and the corruption appears. Without this, the test above is
+// unfalsifiable: it would pass just as happily if nothing were connected.
+TEST(DashMnCheckpointPoseFold, NoDemuxTheSameReplyDoesCorruptTheLiveTipSml)
+{
+    constexpr uint32_t kAnchorH = 2513000;
+    const uint256 anchor_hash = uint256S(kAnchorHash);
+    const auto cp = synthetic_anchor(10, kAnchorH, anchor_hash);
+
+    DemuxRig d;
+    // The ONLY difference from the test above.
+    arm_demux_rig(d, kAnchorH, anchor_hash, cp, /*register_lane_filter=*/false);
+
+    ASSERT_FALSE(d.tip_state.have_sml());
+
+    d.rig.h.lane.arm(cp);
+    d.rig.h.lane.pump();
+
+    EXPECT_EQ(d.tip_feeds, 1u)
+        << "with no filter registered the historical reply MUST reach the tip"
+           " feed -- if it does not, the positive test above proves nothing";
+    EXPECT_TRUE(d.tip_state.have_sml())
+        << "the live tip SML was overwritten by a snapshot dated at h="
+        << kAnchorH << " -- exactly the silent past-state rewrite on the money"
+           " path that the demux prevents";
+    EXPECT_EQ(d.tip_state.sml().mnList.size(), cp.entries.size())
+        << "and it is the HISTORICAL list, entry for entry";
+}
+
+// ── The demux must not be a black hole either: a genuine TIP diff that no
+// consumer claims has to reach the maintainer. A demux that swallowed
+// everything would stall the live SML instead of corrupting it -- a different
+// failure, equally silent.
+TEST(DashMnCheckpointPoseFold, UnclaimedTipDiffStillReachesTheMaintainer)
+{
+    constexpr uint32_t kAnchorH = 2513000;
+    const uint256 anchor_hash = uint256S(kAnchorHash);
+    const auto cp = synthetic_anchor(10, kAnchorH, anchor_hash);
+
+    DemuxRig d;
+    arm_demux_rig(d, kAnchorH, anchor_hash, cp, /*register_lane_filter=*/true);
+    d.rig.h.lane.arm(cp);
+    d.rig.h.lane.pump();
+    ASSERT_TRUE(d.rig.h.lane.sml_folded());
+    ASSERT_EQ(d.tip_feeds, 0u);
+
+    // A snapshot at a DIFFERENT block: nobody is awaiting it, so it is a tip
+    // diff and must fall through.
+    uint256 other = uint256S(kAnchorHash);
+    other.data()[31] ^= 0xff;
     std::vector<std::pair<uint256, bool>> attest;
     for (size_t i = 0; i < cp.entries.size(); ++i)
-        attest.emplace_back(cp.entries[i].first, i >= 8);
+        attest.emplace_back(cp.entries[i].first, true);
+    const auto tip_diff = make_snapshot(other, kAnchorH + 900, attest);
 
-    // H_sml one block ABOVE the anchor, and that block pays the (still
-    // eligible) queue head, so the replay reaches the fold's dispatch point
-    // cleanly and the refusal under test is the BOUND, not a payee desync.
-    SmlSource sml;
-    sml.set_hashes(kAnchorH + 1, attest);
-
-    BridgeHarness h;
-    h.headers[kAnchorH] = anchor_hash;
-    h.tip = kAnchorH + 2;
-    h.blocks[kAnchorH + 1] =
-        block_paying(cp.entries[0].second.scriptPayout.m_data);
-    h.blocks[kAnchorH + 2] =
-        block_paying(cp.entries[8].second.scriptPayout.m_data);
-
-    wire_sml_snapshot(h.lane, sml);
-    h.lane.arm(cp);
-    h.lane.pump();
-
-    EXPECT_EQ(h.lane.state(), MnCheckpointLane::State::FailedClosed)
-        << h.lane.status();
-    EXPECT_FALSE(h.lane.sml_folded());
-    EXPECT_NE(h.lane.status().find("SML PoSe FOLD REFUSED"), std::string::npos)
-        << h.lane.status();
-    EXPECT_NE(h.lane.status().find("NOT root-verified"), std::string::npos)
-        << "the operator must be told the list is trusted, not verified: "
-        << h.lane.status();
+    EXPECT_FALSE(d.deliver(tip_diff.diff))
+        << "an unclaimed diff must not be reported as consumed";
+    EXPECT_EQ(d.tip_feeds, 1u)
+        << "the live SML would stall forever if the demux ate tip diffs";
 }
 
-// ── F1. An UNDATED SML must not license a permanent demotion. This is the warm
-// restart shape: the persisted list is loaded and have_sml() goes true, but no
-// height was restored, so every attestation is undateable.
-TEST(DashMnCheckpointPoseFold, UndatedSmlHeightCannotLicenseADemotion)
+// ── NON-SHORT-CIRCUITING. Two historical consumers may legitimately await the
+// SAME block hash (a bridge fold point can land on a quorum work block). One
+// reply answers both awaits; a short-circuiting chain would deliver it to the
+// first filter only and leave the second waiting forever on a message that
+// already arrived and was swallowed.
+TEST(DashMnCheckpointPoseFold, DemuxOffersOneReplyToEveryHistoricalConsumer)
 {
-    MnStateMachine m;
-    auto cp = good_checkpoint();
-    m.load(cp.entries, 1519543);
-    m.set_sml_recovery_cap(8);
-    m.set_sml_validity_fn(
-        [](const uint256& x) -> std::optional<bool> {
-            return x == uint256S(kQ1) ? std::optional<bool>{false}
-                                      : std::optional<bool>{true};
-        });
-    m.set_sml_current_height(0);          // warm SML present, height unknown
-    EXPECT_FALSE(m.sml_covers(1519544))
-        << "height 0 must mean 'covers NOTHING', not 'covers everything' --"
-           " the latter made the whole freshness gate vacuous on warm restart";
+    dash::coin::HistoricalMnListDiffDemux demux;
+    std::vector<std::pair<uint256, bool>> attest;
+    attest.emplace_back(uint256S(kQ1), true);
+    const uint256 hash = uint256S(kAnchorHash);
+    const auto snap = make_snapshot(hash, 2513000, attest);
 
-    auto blk = repay_coinbase(block_from_hex(kBlockHex1519544),
-                              payout_of(cp, kQ1), payout_of(cp, kQ2));
-    const auto r = m.apply_block(blk, 1519544);
+    int first = 0, second = 0;
+    demux.add_filter([&](const dash::coin::vendor::CSimplifiedMNListDiff& d) {
+        ++first;  return d.blockHash == hash;
+    });
+    demux.add_filter([&](const dash::coin::vendor::CSimplifiedMNListDiff& d) {
+        ++second; return d.blockHash == hash;
+    });
+    ASSERT_EQ(demux.filter_count(), 2u);
 
-    EXPECT_TRUE(r.payee_desync);
-    EXPECT_EQ(r.sml_recovered, 0u);
-    EXPECT_TRUE(m.entries().at(uint256S(kQ1)).isValid)
-        << "an undated attestation must never flip isValid permanently";
+    size_t tip = 0;
+    const bool consumed = demux.dispatch(
+        snap.diff,
+        [&](const dash::coin::vendor::CSimplifiedMNListDiff&) { ++tip; });
+
+    EXPECT_TRUE(consumed);
+    EXPECT_EQ(tip, 0u);
+    EXPECT_EQ(first, 1);
+    EXPECT_EQ(second, 1)
+        << "the second consumer was never offered the reply -- it would wait"
+           " forever on a message that had already arrived";
 }
 
-// ── F1-TWIN. A caller that never declares a height at all keeps the pre-gate
-// behaviour byte for byte. Without this, the fail-closed reading of 0 would
-// silently disable the walk for every existing caller.
-TEST(DashMnCheckpointPoseFold, TwinUndeclaredHeightKeepsPreGateBehaviour)
+// ── One outstanding request at a time, enforced structurally. While a fold is
+// in flight the replay pulls nothing and folds nothing, so it can neither race
+// its own request nor advance past the height the pending list describes --
+// which is what makes EARLY unreachable rather than merely unlikely.
+TEST(DashMnCheckpointPoseFold, ReplayPausesWhileAFoldRequestIsOutstanding)
 {
-    MnStateMachine m;
-    auto cp = good_checkpoint();
-    m.load(cp.entries, 1519543);
-    m.set_sml_recovery_cap(8);
-    m.set_sml_validity_fn(
-        [](const uint256& x) -> std::optional<bool> {
-            return x == uint256S(kQ1) ? std::optional<bool>{false}
-                                      : std::optional<bool>{true};
-        });
-    // deliberately NO set_sml_current_height()
-    EXPECT_TRUE(m.sml_covers(1519544));
+    constexpr uint32_t kAnchorH = 2513000;
+    constexpr uint32_t kTip     = 2513004;
+    const uint256 anchor_hash = uint256S(kAnchorHash);
+    const auto cp = synthetic_anchor(10, kAnchorH, anchor_hash);
 
-    auto blk = repay_coinbase(block_from_hex(kBlockHex1519544),
-                              payout_of(cp, kQ1), payout_of(cp, kQ2));
-    const auto r = m.apply_block(blk, 1519544);
-    EXPECT_FALSE(r.payee_desync);
-    EXPECT_EQ(r.sml_recovered, 1u);
+    std::vector<std::pair<uint256, bool>> attest;
+    for (size_t i = 0; i < cp.entries.size(); ++i)
+        attest.emplace_back(cp.entries[i].first, i != 0);
+
+    SnapshotRig rig;
+    rig.attest = attest;
+    rig.install(kAnchorH, kTip, anchor_hash);
+    rig.by_height[kAnchorH] = make_snapshot(anchor_hash, kAnchorH, attest);
+    rig.answer = false;                       // hold the reply
+    for (uint32_t bh = kAnchorH + 1; bh <= kTip; ++bh) {
+        const size_t rank = 1 + (bh - (kAnchorH + 1));
+        rig.h.blocks[bh] = block_paying(cp.entries[rank].second.scriptPayout.m_data);
+    }
+
+    // Materialise the anchor reply up front so the test can hand it over
+    // manually after the pause.
+    (void)rig.snapshot_for(kAnchorH, anchor_hash);
+
+    rig.h.lane.arm(cp);
+    rig.h.lane.pump();
+
+    EXPECT_TRUE(rig.h.lane.snapshot_pending());
+    EXPECT_EQ(rig.requested.size(), 1u) << "exactly one request in flight";
+    EXPECT_TRUE(rig.h.requested.empty())
+        << "no block bodies may be pulled while a fold is outstanding --"
+           " otherwise the cursor could pass the height the list describes";
+
+    // Further pumps must not issue a second request.
+    rig.h.lane.pump();
+    rig.h.lane.pump();
+    EXPECT_EQ(rig.requested.size(), 1u)
+        << "a duplicate getmnlistd draws a second reply that matches no await"
+           " and leaks past the demux";
+
+    // Delivering a block while paused must be ignored, not folded.
+    rig.h.lane.on_block_connected(rig.h.blocks[kAnchorH + 1], kAnchorH + 1);
+    EXPECT_EQ(rig.h.lane.cursor_height(), kAnchorH)
+        << "the cursor must not advance past a pending fold height";
+
+    // Now answer: the replay resumes from exactly where it paused.
+    rig.answer = true;
+    rig.h.lane.on_historical_snapshot(rig.by_height[kAnchorH].diff);
+    EXPECT_FALSE(rig.h.lane.snapshot_pending());
+    EXPECT_TRUE(rig.h.lane.sml_folded());
+    EXPECT_TRUE(rig.h.published) << rig.h.lane.status();
 }
 
-// ── F6. arm() must clear the one-shot fold latch. A re-armed lane that still
-// reported sml_folded()==true would run additions-only while claiming removals
-// had been applied -- a silent lie in the operator-facing state.
-TEST(DashMnCheckpointPoseFold, ArmResetsTheFoldLatchAndCounters)
+// ── An unauthenticated list must never reach the payee set. The snapshot is
+// the root of trust for who gets paid; a lying peer that can fold arbitrary
+// validity can mint a rejected coinbase. Mutating the committed root must
+// break verification.
+TEST(DashMnCheckpointPoseFold, UnauthenticatedSnapshotFailsClosed)
 {
     constexpr uint32_t kAnchorH = 2513000;
     const uint256 anchor_hash = uint256S(kAnchorHash);
@@ -2001,28 +2138,555 @@ TEST(DashMnCheckpointPoseFold, ArmResetsTheFoldLatchAndCounters)
     for (size_t i = 0; i < cp.entries.size(); ++i)
         attest.emplace_back(cp.entries[i].first, i != 0);
 
-    // H_sml at anchor+1 so the fold is actually reachable from the post-apply
-    // dispatch site (see FoldFiresAtTheAnchor... for why anchor itself is not).
-    SmlSource sml;
-    sml.set_hashes(kAnchorH + 1, attest);
-
-    BridgeHarness h;
-    h.headers[kAnchorH] = anchor_hash;
-    h.tip = kAnchorH + 2;
-    h.blocks[kAnchorH + 1] =
-        block_paying(cp.entries[0].second.scriptPayout.m_data);
-    h.blocks[kAnchorH + 2] =
+    SnapshotRig rig;
+    rig.attest = attest;
+    rig.install(kAnchorH, kAnchorH + 1, anchor_hash);
+    auto snap = make_snapshot(anchor_hash, kAnchorH, attest);
+    // Tamper: add a masternode AFTER the cbTx committed to the root. The
+    // rebuilt SML no longer hashes to cbTx.merkleRootMNList.
+    {
+        CSimplifiedMNListEntry rogue;
+        rogue.proRegTxHash = uint256S(kQ6);
+        rogue.isValid      = false;
+        snap.diff.mnList.push_back(rogue);
+    }
+    rig.by_height[kAnchorH] = snap;
+    rig.h.blocks[kAnchorH + 1] =
         block_paying(cp.entries[1].second.scriptPayout.m_data);
-    wire_sml_snapshot(h.lane, sml);
-    h.lane.arm(cp);
-    h.lane.pump();
-    ASSERT_TRUE(h.lane.sml_folded()) << h.lane.status();
 
-    h.lane.arm(cp);   // re-arm
-    EXPECT_FALSE(h.lane.sml_folded())
-        << "a re-armed lane must not claim a fold it has not performed";
-    EXPECT_EQ(h.lane.sml_folded_at(), 0u);
-    EXPECT_EQ(h.lane.pose_removed(), 0u);
-    EXPECT_EQ(h.lane.pose_reinstated(), 0u);
-    EXPECT_EQ(h.lane.sml_recovered(), 0u);
+    rig.h.lane.arm(cp);
+    rig.h.lane.pump();
+
+    EXPECT_EQ(rig.h.lane.state(), MnCheckpointLane::State::FailedClosed)
+        << rig.h.lane.status();
+    EXPECT_FALSE(rig.h.lane.sml_folded());
+    EXPECT_FALSE(rig.h.published);
+    EXPECT_NE(rig.h.lane.status().find("DIP-4 client verification"),
+              std::string::npos)
+        << rig.h.lane.status();
+}
+
+// ── A peer answering with a DIFFERENT block's genuine snapshot must be
+// refused: the height is bound to the request.
+TEST(DashMnCheckpointPoseFold, SnapshotForTheWrongHeightIsRefused)
+{
+    constexpr uint32_t kAnchorH = 2513000;
+    const uint256 anchor_hash = uint256S(kAnchorHash);
+    const auto cp = synthetic_anchor(10, kAnchorH, anchor_hash);
+
+    std::vector<std::pair<uint256, bool>> attest;
+    for (size_t i = 0; i < cp.entries.size(); ++i)
+        attest.emplace_back(cp.entries[i].first, i != 0);
+
+    SnapshotRig rig;
+    rig.attest = attest;
+    rig.install(kAnchorH, kAnchorH + 1, anchor_hash);
+    // A perfectly well-formed snapshot -- for the WRONG height.
+    rig.by_height[kAnchorH] = make_snapshot(anchor_hash, kAnchorH + 99, attest);
+    rig.h.blocks[kAnchorH + 1] =
+        block_paying(cp.entries[1].second.scriptPayout.m_data);
+
+    rig.h.lane.arm(cp);
+    rig.h.lane.pump();
+
+    EXPECT_EQ(rig.h.lane.state(), MnCheckpointLane::State::FailedClosed)
+        << rig.h.lane.status();
+    EXPECT_FALSE(rig.h.lane.sml_folded());
+}
+
+// ── The status-clobber defect class. A fail_closed() raised inside the fold
+// path had its status immediately overwritten by request_window(), destroying
+// the only record of WHY the lane refused. Silent refusal is the defect.
+TEST(DashMnCheckpointPoseFold, RefusalReasonSurvivesAndIsNotOverwritten)
+{
+    constexpr uint32_t kAnchorH = 2513000;
+    const uint256 anchor_hash = uint256S(kAnchorHash);
+    const auto cp = synthetic_anchor(16, kAnchorH, anchor_hash);
+
+    // Retire half the set at once: over the 1/8 sanity bound.
+    std::vector<std::pair<uint256, bool>> attest;
+    for (size_t i = 0; i < cp.entries.size(); ++i)
+        attest.emplace_back(cp.entries[i].first, i >= 8);
+
+    SnapshotRig rig;
+    rig.attest = attest;
+    rig.install(kAnchorH, kAnchorH + 2, anchor_hash);
+    rig.by_height[kAnchorH] = make_snapshot(anchor_hash, kAnchorH, attest);
+    for (uint32_t bh = kAnchorH + 1; bh <= kAnchorH + 2; ++bh)
+        rig.h.blocks[bh] = block_paying(cp.entries[8].second.scriptPayout.m_data);
+
+    rig.h.lane.arm(cp);
+    rig.h.lane.pump();
+
+    ASSERT_EQ(rig.h.lane.state(), MnCheckpointLane::State::FailedClosed);
+    EXPECT_NE(rig.h.lane.status().find("SML PoSe FOLD REFUSED"),
+              std::string::npos)
+        << "the refusal reason must survive the tail of the call that raised"
+           " it -- a lane that refuses silently is the defect: "
+        << rig.h.lane.status();
+    EXPECT_EQ(rig.h.lane.status().find("bridging: cursor"), std::string::npos)
+        << "request_window() overwrote the refusal with a progress line";
+}
+
+namespace {
+
+// ── AN INDEPENDENT MODEL OF WHAT dashd WOULD HAVE PAID.
+//
+// A replay window of any length cannot have its payees written by hand: every
+// payment moves its masternode to the tail of the DIP-3 queue, so the payee at
+// h+1 depends on every payment before it. Guessing produces a PAYEE DESYNC
+// that looks like a bug in the lane and is not.
+//
+// So the expected coinbase is generated from a SEPARATE MnStateMachine, driven
+// forward one height at a time, with the bans applied to it at the height the
+// chain applied them. That machine is the ORACLE (dashd's side); the lane is
+// the DUT. They share the CompareByLastPaid scan, which is the point: the
+// question under test is whether the lane's per-height FOLD makes its eligible
+// set agree with the oracle's, not whether the sort is right.
+//
+// `ban_at` == 0 means no bans anywhere.
+std::map<uint32_t, dash::coin::BlockType> simulate_chain(
+    const MnCheckpoint& cp, uint32_t anchor_h, uint32_t tip_h,
+    uint32_t ban_at, const std::vector<std::pair<uint256, bool>>& post_ban)
+{
+    MnStateMachine oracle;
+    oracle.load(cp.entries, anchor_h);
+    std::map<uint32_t, dash::coin::BlockType> out;
+    for (uint32_t h = anchor_h + 1; h <= tip_h; ++h) {
+        if (ban_at != 0 && h == ban_at) {
+            std::vector<CSimplifiedMNListEntry> v;
+            for (const auto& [hash, valid] : post_ban) {
+                CSimplifiedMNListEntry e;
+                e.proRegTxHash = hash;
+                e.isValid      = valid;
+                v.push_back(e);
+            }
+            oracle.sync_validity_from_sml(CSimplifiedMNList(std::move(v)), h - 1);
+        }
+        const auto ranked = oracle.rank_payee_candidates(1);
+        EXPECT_FALSE(ranked.empty()) << "oracle queue empty at h=" << h;
+        if (ranked.empty()) break;
+        const auto& st = oracle.entries().at(ranked[0]);
+        auto blk = block_paying(st.scriptPayout.m_data);
+        oracle.apply_block(blk, h);
+        out[h] = std::move(blk);
+    }
+    return out;
+}
+
+} // namespace
+
+// ── A PAUSED replay is a STOPPED replay. If the peer never answers the fold
+// request, the bridge must not wait forever with no symptom other than "the
+// arm never armed" -- that is the silent-refusal defect class. It re-asks,
+// then abandons THAT fold point and carries on degraded, and says so.
+TEST(DashMnCheckpointPoseFold, UnansweredFoldReAsksThenAbandonsRatherThanWedging)
+{
+    constexpr uint32_t kAnchorH = 2513000;
+    constexpr uint32_t kTip     = 2513003;
+    const uint256 anchor_hash = uint256S(kAnchorHash);
+    const auto cp = synthetic_anchor(10, kAnchorH, anchor_hash);
+
+    std::vector<std::pair<uint256, bool>> attest;
+    for (size_t i = 0; i < cp.entries.size(); ++i)
+        attest.emplace_back(cp.entries[i].first, true);   // no bans at all
+
+    SnapshotRig rig;
+    rig.attest = attest;
+    rig.install(kAnchorH, kTip, anchor_hash);
+    rig.answer = false;                       // the peer never replies
+    rig.h.blocks = simulate_chain(cp, kAnchorH, kTip, 0, {});
+
+    rig.h.lane.arm(cp);
+    rig.h.lane.pump();
+    ASSERT_TRUE(rig.h.lane.snapshot_pending());
+    ASSERT_EQ(rig.requested.size(), 1u);
+
+    // Re-ask, once, at the retry threshold -- and to the SAME block, so there
+    // is still only one thing outstanding.
+    for (uint32_t i = 0; i < MnCheckpointLane::kFoldRetryPumps; ++i)
+        rig.h.lane.pump();
+    EXPECT_EQ(rig.requested.size(), 2u) << "the request was never re-asked";
+    EXPECT_EQ(rig.requested[0], rig.requested[1])
+        << "a re-ask must name the SAME block: a different one would put two"
+           " distinguishable-only-by-luck replies in flight";
+
+    // Then give up and RESUME. The bridge completes degraded rather than
+    // hanging. (Two fold points go unanswered here -- the anchor and the tip --
+    // because the peer answers nothing at all; each is abandoned on its own
+    // budget, which is the point: one dead fold point does not poison the
+    // next.) The loop is BOUNDED so a genuine wedge fails the test instead of
+    // hanging the suite.
+    const uint32_t kBound = 4 * (MnCheckpointLane::kFoldGiveUpPumps + 2);
+    for (uint32_t i = 0; i < kBound && !rig.h.published; ++i)
+        rig.h.lane.pump();
+
+    EXPECT_FALSE(rig.h.lane.snapshot_pending());
+    EXPECT_GE(rig.h.lane.abandoned_folds(), 1u);
+    EXPECT_FALSE(rig.h.lane.sml_folded())
+        << "nothing was ever answered, so nothing may claim to have folded";
+    EXPECT_TRUE(rig.h.published)
+        << "the bridge WEDGED on an unanswered fold request: " << rig.h.lane.status();
+    EXPECT_NE(rig.h.lane.status().find("ABANDONED"), std::string::npos)
+        << "degradation must be stated, not swallowed: " << rig.h.lane.status();
+}
+
+// ── The late reply to an ABANDONED request is still a base=ZERO snapshot at an
+// OLD block. Releasing the claim when we gave up waiting would let it fall
+// through to the live tip SML -- the same reward-critical rewrite, arriving by
+// the back door. It stays claimed and is dropped.
+TEST(DashMnCheckpointPoseFold, LateReplyToAnAbandonedFoldIsStillClaimedAndDropped)
+{
+    constexpr uint32_t kAnchorH = 2513000;
+    constexpr uint32_t kTip     = 2513002;
+    const uint256 anchor_hash = uint256S(kAnchorHash);
+    const auto cp = synthetic_anchor(10, kAnchorH, anchor_hash);
+
+    std::vector<std::pair<uint256, bool>> attest;
+    for (size_t i = 0; i < cp.entries.size(); ++i)
+        attest.emplace_back(cp.entries[i].first, true);
+
+    DemuxRig d;
+    d.rig.attest = attest;
+    d.rig.install(kAnchorH, kTip, anchor_hash);
+    d.wire(/*register_lane_filter=*/true);    // AFTER install: it owns the seam
+    d.rig.answer = false;
+    d.rig.h.blocks = simulate_chain(cp, kAnchorH, kTip, 0, {});
+    const auto late = make_snapshot(anchor_hash, kAnchorH, attest);
+
+    d.rig.h.lane.arm(cp);
+    for (uint32_t i = 0; i <= MnCheckpointLane::kFoldGiveUpPumps + 1
+                         && d.rig.h.lane.abandoned_folds() == 0; ++i)
+        d.rig.h.lane.pump();
+    ASSERT_EQ(d.rig.h.lane.abandoned_folds(), 1u) << d.rig.h.lane.status();
+    ASSERT_EQ(d.tip_feeds, 0u);
+
+    // The peer finally answers, long after we stopped waiting.
+    const bool consumed = d.deliver(late.diff);
+
+    EXPECT_TRUE(consumed)
+        << "an abandoned request's reply must STILL be claimed";
+    EXPECT_EQ(d.tip_feeds, 0u)
+        << "the late reply reached the live tip SML -- releasing the claim on"
+           " abandonment reopens the exact corruption the demux prevents";
+    EXPECT_FALSE(d.tip_state.have_sml());
+    EXPECT_FALSE(d.rig.h.lane.sml_folded())
+        << "and it must not be folded either: the cursor has moved on, so the"
+           " list is now dated BEFORE the cursor";
+}
+
+// ── THE MEASURED SHAPE, END TO END. The mainnet 2026-08-02 incident: three
+// masternodes leaving `protx list valid` inside 73 blocks while the bridge
+// replayed. The walk's budget cannot carry it (4 + distance/1000, already
+// partly spent) and the tip-tracking fold could never reach those heights.
+// The per-height fold must replay the whole window and SURVIVE.
+TEST(DashMnCheckpointPoseFold, ThreeBanBurstInsideTheWindowReplaysEndToEnd)
+{
+    constexpr uint32_t kAnchorH = 2514800;
+    constexpr uint32_t kBurstAt = 2514873;
+    constexpr uint32_t kTip     = 2515025;
+    const uint256 anchor_hash = uint256S(kAnchorHash);
+    // 64 masternodes so a 3-wide burst is well inside the F5 sanity bound.
+    const auto cp = synthetic_anchor(64, kAnchorH, anchor_hash);
+
+    // BEFORE the burst everyone is valid; from kBurstAt the queue head three
+    // are banned, exactly as the chain showed (2062 -> 2059, never revived).
+    std::vector<std::pair<uint256, bool>> all_valid, post_burst;
+    for (size_t i = 0; i < cp.entries.size(); ++i) {
+        all_valid.emplace_back(cp.entries[i].first, true);
+        post_burst.emplace_back(cp.entries[i].first, i >= 3);
+    }
+
+    SnapshotRig rig;
+    rig.attest = all_valid;                    // default answer for any height
+    rig.install(kAnchorH, kTip, anchor_hash);
+    // Fold interval small enough that a fold point lands inside the burst
+    // window -- the coarse-graining knob, exercised rather than assumed.
+    rig.h.lane.set_fold_interval(50);
+
+    // Every height from the burst onward serves the post-burst list.
+    for (uint32_t h = kBurstAt; h <= kTip; ++h) {
+        auto it = rig.height_of.begin();
+        for (; it != rig.height_of.end(); ++it) if (it->second == h) break;
+        ASSERT_NE(it, rig.height_of.end());
+        rig.by_height[h] = make_snapshot(it->first, h, post_burst);
+    }
+
+    // What dashd would actually have paid, burst included.
+    rig.h.blocks = simulate_chain(cp, kAnchorH, kTip, kBurstAt, post_burst);
+
+    // The walk's budget for this distance, as the lane sizes it: 4 + 225/1000
+    // = 4. The burst is carried by folds, so the budget must be untouched.
+    rig.h.lane.arm(cp);
+    rig.h.lane.pump();
+
+    EXPECT_NE(rig.h.lane.state(), MnCheckpointLane::State::FailedClosed)
+        << rig.h.lane.status();
+    EXPECT_TRUE(rig.h.published) << rig.h.lane.status();
+    EXPECT_EQ(rig.h.published_as_of, kTip);
+    EXPECT_EQ(rig.h.lane.pose_removed(), 3u)
+        << "the three banned masternodes must have LEFT the eligible set: "
+        << rig.h.lane.status();
+    EXPECT_EQ(rig.h.lane.eligible_size(), 61u)
+        << "64 - 3: the set FELL across the window, which is the measured"
+           " direction the additions-only replay got backwards";
+    EXPECT_EQ(rig.h.lane.sml_recovered(), 0u)
+        << "a fold spends NO walk budget -- that is why a burst costs nothing";
+    EXPECT_GT(rig.h.lane.folds_applied(), 1u)
+        << "the interval folds must actually have fired, not just the anchor"
+           " and the tip";
+}
+
+// ── The FOLD-POINT SCHEDULE itself. Coarse-graining is a correctness claim
+// (round trips are bounded) and a completeness claim (the anchor and the tip
+// are always fold points), so it is pinned rather than left to inspection.
+TEST(DashMnCheckpointPoseFold, FoldPointsAreCoarseGrainedButAlwaysCoverTheEnds)
+{
+    constexpr uint32_t kAnchorH = 2500000;
+    constexpr uint32_t kTip     = 2502000;
+    const uint256 anchor_hash = uint256S(kAnchorHash);
+    const auto cp = synthetic_anchor(10, kAnchorH, anchor_hash);
+
+    std::vector<std::pair<uint256, bool>> attest;
+    for (size_t i = 0; i < cp.entries.size(); ++i)
+        attest.emplace_back(cp.entries[i].first, true);
+
+    SnapshotRig rig;
+    rig.attest = attest;
+    rig.install(kAnchorH, kTip, anchor_hash);
+    rig.h.lane.set_fold_interval(500);
+    rig.h.blocks = simulate_chain(cp, kAnchorH, kTip, 0, {});
+
+    rig.h.lane.arm(cp);
+    rig.h.lane.pump();
+
+    ASSERT_TRUE(rig.h.published) << rig.h.lane.status();
+    // anchor + 500/1000/1500/2000(==tip) = 5. One per height would be 2001.
+    EXPECT_EQ(rig.requested.size(), 5u)
+        << "the fold schedule is not coarse-grained -- a round trip per height"
+           " is not a bridge, it is a denial of service on the peer";
+    EXPECT_EQ(rig.h.lane.first_fold_height(), kAnchorH)
+        << "the anchor is always a fold point";
+    EXPECT_EQ(rig.h.lane.sml_folded_at(), kTip)
+        << "the tip is always a fold point, so the PUBLISHED set is current";
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 9. MAKE THE LATCH SAY ITS OWN NAME (folded in from the closed MN
+//    diff-ladder slice -- the observability half only; no ladder).
+//
+// The maintainer's payee-desync latch is what a daemonless node hits when the
+// bridge's projection and the chain disagree, and on a daemonless node it is
+// PERMANENT: only an authoritative re-seed clears it and there is no daemon to
+// re-seed from. It was log-only. The smoke rig reported 639 consecutive
+// "not-populated" declines while the actual cause -- a payee desync at
+// h=2514874 -- appeared nowhere a human reading the classification would look.
+// A state that refuses without naming itself is the defect.
+// ═══════════════════════════════════════════════════════════════════════════
+namespace {
+
+std::vector<unsigned char> latch_pkh_script(uint8_t seed)
+{
+    std::vector<unsigned char> s{0x76, 0xa9, 0x14};
+    for (int i = 0; i < 20; ++i) s.push_back(static_cast<unsigned char>(seed + i));
+    s.push_back(0x88); s.push_back(0xac);
+    return s;
+}
+
+uint256 latch_seq256(uint8_t base)
+{
+    uint256 h;
+    for (int i = 0; i < 32; ++i) h.data()[i] = static_cast<uint8_t>(base + i);
+    return h;
+}
+
+void latch_bind(dash::coin::BlockType& b)
+{
+    std::vector<uint256> ids;
+    for (const auto& tx : b.m_txs) ids.push_back(dash::coin::dash_txid(tx));
+    b.m_merkle_root = dash::coin::compute_merkle_root(ids);
+}
+
+dash::coin::MutableTransaction latch_coinbase_paying(
+    const std::vector<unsigned char>& script)
+{
+    dash::coin::MutableTransaction tx;
+    tx.version = 1; tx.type = 0; tx.locktime = 1;
+    dash::coin::TxIn in;
+    in.prevout.hash  = latch_seq256(0x90);
+    in.prevout.index = 0;
+    in.sequence      = 0xffffffffu;
+    tx.vin.push_back(in);
+    dash::coin::TxOut o;
+    o.value = 500000000;
+    o.scriptPubKey.m_data = script;
+    tx.vout.push_back(o);
+    return tx;
+}
+
+constexpr uint32_t kLatchTipH   = 2514874;
+constexpr uint8_t  kLatchAddrV  = 76;
+constexpr uint8_t  kLatchP2shV  = 16;
+
+} // namespace
+
+TEST(DashMnPayeeLatch, ClassifyDeclineNamesTheLatch)
+{
+    dash::coin::NodeCoinState st;
+    EXPECT_NE(st.classify_decline(), "mn-needs-reseed");
+    st.set_mn_needs_reseed(true);
+    EXPECT_EQ(st.classify_decline(), "mn-needs-reseed")
+        << "the latch must be NAMED, not hidden behind 'not-populated'";
+    st.set_mn_needs_reseed(false);
+    EXPECT_NE(st.classify_decline(), "mn-needs-reseed")
+        << "and it must clear -- a latch that never clears is a different bug";
+}
+
+// The real maintainer, driven into the real desync, must publish the latch.
+// Without the mirror this reports "not-populated" -- true, useless, and the
+// reason the incident took 639 declines to diagnose.
+TEST(DashMnPayeeLatch, RealPayeeDesyncPublishesTheLatchToTheClassifier)
+{
+    dash::coin::NodeCoinState st;
+    dash::coin::CoinStateMaintainer m{st};
+    m.set_require_seeded_mn_set(true);          // the embedded-arm posture
+
+    MNState mn;
+    mn.isValid            = true;
+    mn.nRegisteredHeight  = 2300000;
+    mn.nLastPaidHeight    = 0;
+    mn.scriptPayout.m_data = latch_pkh_script(0x30);
+    m.on_mn_list_update({{latch_seq256(0x01), mn}}, kLatchTipH - 1);
+    m.on_new_tip(kLatchTipH - 1, latch_seq256(0x50), 0x1d00ffff, 1700000000,
+                 kLatchAddrV, kLatchP2shV, 1700000100, 4);
+    ASSERT_TRUE(m.live());
+    ASSERT_FALSE(st.mn_needs_reseed());
+
+    // A coinbase paying somebody OTHER than the projected masternode.
+    dash::coin::BlockType blk;
+    blk.m_txs.push_back(latch_coinbase_paying(latch_pkh_script(0x77)));
+    latch_bind(blk);
+    const auto r = m.on_block_connected(blk, kLatchTipH);
+
+    ASSERT_TRUE(r.payee_desync);
+    EXPECT_FALSE(m.live());
+    EXPECT_TRUE(st.mn_needs_reseed());
+    EXPECT_EQ(st.classify_decline(), "mn-needs-reseed")
+        << "the arm refused and did not say why -- that silence IS the defect";
+}
+
+// The clearing half, driven the same way: an authoritative resync must open
+// the latch AND the classifier must stop naming it. A latch that says its name
+// forever is as useless as one that never does.
+TEST(DashMnPayeeLatch, AuthoritativeResyncClearsTheLatchAndTheClassification)
+{
+    dash::coin::NodeCoinState st;
+    dash::coin::CoinStateMaintainer m{st};
+    m.set_require_seeded_mn_set(true);
+
+    MNState mn;
+    mn.isValid            = true;
+    mn.nRegisteredHeight  = 2300000;
+    mn.nLastPaidHeight    = 0;
+    mn.scriptPayout.m_data = latch_pkh_script(0x30);
+    m.on_mn_list_update({{latch_seq256(0x01), mn}}, kLatchTipH - 1);
+    m.on_new_tip(kLatchTipH - 1, latch_seq256(0x50), 0x1d00ffff, 1700000000,
+                 kLatchAddrV, kLatchP2shV, 1700000100, 4);
+    dash::coin::BlockType blk;
+    blk.m_txs.push_back(latch_coinbase_paying(latch_pkh_script(0x77)));
+    latch_bind(blk);
+    ASSERT_TRUE(m.on_block_connected(blk, kLatchTipH).payee_desync);
+    ASSERT_EQ(st.classify_decline(), "mn-needs-reseed");
+
+    // The bridge's publish is exactly this event.
+    m.on_mn_list_update({{latch_seq256(0x01), mn}}, kLatchTipH);
+
+    EXPECT_FALSE(st.mn_needs_reseed());
+    EXPECT_NE(st.classify_decline(), "mn-needs-reseed");
+}
+
+// ── GAP CLOSED BY MUTATION TESTING. Two branches of the DIP-4 authentication
+// had NO test: deleting either produced a fully green run.
+//
+//   * the cbTxMerkleTree proof against the PoW-verified header (step b) --
+//     without it a peer may serve any list with any cbTx it likes, since the
+//     cbTx would no longer have to be the one the block actually committed to;
+//   * the `expected_height == 0` refusal -- "the caller does not know what it
+//     asked about" must fail closed, not authenticate against nothing.
+//
+// Both are on the reward path. A check nothing can falsify is not a check.
+TEST(DashMnCheckpointPoseFold, SnapshotWithAForgedMerkleProofIsRefused)
+{
+    constexpr uint32_t kAnchorH = 2513000;
+    const uint256 anchor_hash = uint256S(kAnchorHash);
+    const auto cp = synthetic_anchor(10, kAnchorH, anchor_hash);
+
+    std::vector<std::pair<uint256, bool>> attest;
+    for (size_t i = 0; i < cp.entries.size(); ++i)
+        attest.emplace_back(cp.entries[i].first, i != 0);
+
+    SnapshotRig rig;
+    rig.attest = attest;
+    rig.install(kAnchorH, kAnchorH + 1, anchor_hash);
+    auto snap = make_snapshot(anchor_hash, kAnchorH, attest);
+    // The reply is INTERNALLY consistent -- its cbTx, its SML and its own
+    // merkle proof all agree with each other. What it cannot match is OUR
+    // PoW-validated header for that block. That is exactly the shape a lying
+    // peer can produce for free, and step (b) is the only thing that catches
+    // it: tampering the proof itself would also trip the coinbase-position
+    // check and would not isolate this branch. (Found by mutation: deleting
+    // step (b) left the whole suite green until this case existed.)
+    snap.merkle_root.data()[0] ^= 0xff;   // == what our header chain reports
+    rig.by_height[kAnchorH] = snap;
+    rig.h.blocks[kAnchorH + 1] =
+        block_paying(cp.entries[1].second.scriptPayout.m_data);
+
+    rig.h.lane.arm(cp);
+    rig.h.lane.pump();
+
+    EXPECT_EQ(rig.h.lane.state(), MnCheckpointLane::State::FailedClosed)
+        << rig.h.lane.status();
+    EXPECT_FALSE(rig.h.lane.sml_folded());
+    EXPECT_FALSE(rig.h.published);
+}
+
+TEST(DashMnCheckpointPoseFold, SnapshotWithNoExpectedHeightIsRefused)
+{
+    const uint256 hash = uint256S(kAnchorHash);
+    std::vector<std::pair<uint256, bool>> attest;
+    attest.emplace_back(uint256S(kQ1), true);
+    const auto snap = make_snapshot(hash, 2513000, attest);
+
+    auto root_ok = [&](const uint256&) -> std::optional<uint256> {
+        return snap.merkle_root;
+    };
+    dash::coin::vendor::CCbTx cbtx;
+
+    // A caller that knows the height authenticates.
+    EXPECT_TRUE(dash::coin::authenticate_historical_snapshot(
+        snap.diff, 2513000, root_ok, cbtx, "KAT").has_value());
+
+    // A caller that does NOT must fail closed rather than accept anything.
+    EXPECT_FALSE(dash::coin::authenticate_historical_snapshot(
+        snap.diff, 0, root_ok, cbtx, "KAT").has_value())
+        << "expected_height == 0 means 'we do not know what we asked about' --"
+           " authenticating against nothing is not authentication";
+
+    // ...and a caller whose header chain does not hold the block must too.
+    auto root_absent = [](const uint256&) -> std::optional<uint256> {
+        return std::nullopt;
+    };
+    EXPECT_FALSE(dash::coin::authenticate_historical_snapshot(
+        snap.diff, 2513000, root_absent, cbtx, "KAT").has_value())
+        << "without our own PoW-verified header there is no trust anchor";
+
+    // A held-but-NULL root is the same absence wearing a different hat: it
+    // would compare equal to a proof root the peer can trivially make null.
+    auto root_null = [](const uint256&) -> std::optional<uint256> {
+        return uint256();
+    };
+    EXPECT_FALSE(dash::coin::authenticate_historical_snapshot(
+        snap.diff, 2513000, root_null, cbtx, "KAT").has_value())
+        << "a null header merkle root is not an anchor, it is the absence of"
+           " one -- accepting it lets a peer authenticate against nothing";
 }

--- a/test/test_dash_smldiff.cpp
+++ b/test/test_dash_smldiff.cpp
@@ -29,6 +29,7 @@
 #include <core/uint256.hpp>
 #include <core/pack.hpp>
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <cstring>
@@ -211,6 +212,62 @@ TEST(DashSMLDiff, OpaqueQuorumTailVerbatim) {
     PackStream in0(bytes_of(ps0));
     in0 >> out0;
     EXPECT_TRUE(out0.quorum_tail.empty());
+}
+
+// ─── KAT 3b: THE DRAIN-TO-END HAZARD (folded in from the closed MN
+// diff-ladder slice). CSimplifiedMNListDiff::Unserialize DRAINS THE REST OF
+// THE STREAM as its opaque quorum tail. That is correct for a wire message,
+// where the diff IS the whole payload — but it means ANY value laid out as
+// pack(diff) ++ <trailing field> is unreadable by the obvious
+// `stream >> diff; stream >> trailing;` : the unserializer has already
+// swallowed the trailing field into quorum_tail, and it does so SILENTLY,
+// with no short-read, no throw, and a diff that round-trips fine on its own.
+//
+// Every consumer that appends anything after a packed diff must therefore
+// read it by FIXED-WIDTH SLICING from the END of the buffer, and hand only
+// the remaining prefix to the unserializer. Both directions are pinned here:
+// the correct slicing reads back exactly, and the naive read demonstrably
+// swallows the suffix — so this KAT fails if the drain semantics ever change
+// in either direction.
+TEST(DashSMLDiff, TrailingFieldAfterAPackedDiffNeedsFixedWidthSlicing) {
+    auto d = make_diff();
+    d.quorum_tail = {0xde, 0xad, 0xbe, 0xef};
+    const uint256 trailing = raw256_byte(0, 0x5A);   // e.g. a committed root
+
+    auto ps = ::pack(d);
+    std::vector<unsigned char> value = bytes_of(ps);
+    const size_t body_len = value.size();
+    value.insert(value.end(), trailing.data(), trailing.data() + 32);
+
+    // (a) CORRECT: slice the fixed-width suffix off the end first.
+    uint256 read_back;
+    std::memcpy(read_back.data(), value.data() + value.size() - 32, 32);
+    EXPECT_EQ(read_back, trailing);
+
+    std::vector<unsigned char> body(value.begin(), value.end() - 32);
+    ASSERT_EQ(body.size(), body_len);
+    PackStream sliced(body);
+    CSimplifiedMNListDiff ok;
+    ASSERT_NO_THROW(sliced >> ok);
+    EXPECT_EQ(ok.baseBlockHash, d.baseBlockHash);
+    EXPECT_EQ(ok.blockHash, d.blockHash);
+    ASSERT_EQ(ok.mnList.size(), d.mnList.size());
+    EXPECT_EQ(ok.quorum_tail, d.quorum_tail)
+        << "slicing must leave the diff's OWN opaque tail untouched";
+
+    // (b) THE TRAP: read the whole buffer as a diff. No error is raised; the
+    // trailing 32 bytes are simply gone, appended to quorum_tail.
+    PackStream naive(value);
+    CSimplifiedMNListDiff swallowed;
+    ASSERT_NO_THROW(naive >> swallowed);
+    EXPECT_EQ(swallowed.quorum_tail.size(), d.quorum_tail.size() + 32u)
+        << "if this stops holding, the drain-to-end semantics changed and"
+           " every fixed-width slicing site must be revisited";
+    ASSERT_GE(swallowed.quorum_tail.size(), 32u);
+    EXPECT_TRUE(std::equal(trailing.data(), trailing.data() + 32,
+                           swallowed.quorum_tail.end() - 32))
+        << "the trailing field was swallowed VERBATIM and silently -- there is"
+           " no short-read to detect, which is exactly why this KAT exists";
 }
 
 // ─── KAT 4: apply_diff delete + update + insert, then memcmp re-sort ────────


### PR DESCRIPTION
Stop folding the TIP masternode list into a replay of the PAST. Request the
list **as of the replayed height** instead, so `cursor == H_sml` holds by
construction and PoSe removals land at the heights they actually apply to.

Both tests that were deliberately RED on this branch are now green **by being
fixed**, not by being weakened or deleted.

## Why the previous fix was inadequate

The bridge replays block special-transactions forward from a pinned anchor.
A PoSe ban is not a transaction — validity is consensus-computed — so the
replay sees every ADD and no REMOVE. Measured on mainnet over
2513000..2514874: the chain's valid set fell 2068 -> 2059 while ours climbed
2067 -> 2070, and the bridge fail-closed having projected a masternode banned
inside the window.

Folding the tip SML did not close it. The embedded SML tracks the header tip
(`getmnlistd` per tip change), so during catch-up `H_sml` sits at or ahead of
the tip while the replay cursor is behind it. `cursor == H_sml` was a race
between replay rate and mnlistdiff cadence, and it loses at exactly the heights
that matter. `FoldMissesTheWindowWhenTheSmlTracksTheMovingTip` pinned that and
was RED.

## The mechanism

At a fold point the lane issues `getmnlistd(ZERO, hash_at(H))` — the same
primitive `quorum_member_source.hpp` already uses for historical member sets —
and folds the list dated at `H` with the cursor standing on `H`.

**Why EARLY is unreachable, from the code.** EARLY meant applying validity from
a list dated LATER than the cursor. That requires the two to differ, and they
cannot:

1. `fold_target()` picks `H`; the request names `hash_at(H)` from our OWN
   PoW-validated header chain — a block, not a range.
2. `on_historical_snapshot()` consumes a reply only if `diff.blockHash` is the
   exact block requested AND `baseBlockHash.IsNull()` (a full snapshot).
3. `authenticate_historical_snapshot()` refuses unless the embedded cbTx's
   `nHeight == H`. A peer cannot substitute another block's genuine snapshot.
4. The replay is PAUSED while the request is outstanding, so the cursor cannot
   advance past `H` before the reply is applied.

"Dated later than the cursor" has no representable state.

**Sequencing / one outstanding request.** Enforced structurally, not by
bookkeeping: on reaching a fold height the lane sets `m_snapshot_pending`, and
both `pump()` and `on_block_connected()` return immediately while it is set. The
replay pulls no blocks and reaches no second fold height, so it cannot race its
own request.

**Coarse-grained.** Anchor + every `kDefaultFoldInterval` (500) blocks + the
tip. A 2000-block bridge costs 5 round trips, not 2001. The lazy per-mismatch
walk covers the gaps — that split was already the right shape, it was just
being fed the wrong SML.

## R3 verification came free — and F5 stops being the only defence

`quorum_member_source.hpp`'s DIP-4 client verification is now
`historical_sml.hpp::authenticate_historical_snapshot()`, shared verbatim by
both consumers: cbTx is a type-5 CCbTx at the requested height, `cbTxMerkleTree`
proves it into our PoW-verified header's merkle root at the coinbase position,
and the rebuilt SML hashes to `cbTx.merkleRootMNList`. So the folded list is not
"a list a peer sent" — it is dated, committed and header-anchored.

That downgrades **F5** (the fold is an uncapped, un-cross-checked wholesale
override) from the only defence to defence-in-depth. The size bound is kept and
its operator message rewritten: over the bound now signals the anchor or the
replay is wrong, not that the peer lied.

## The demux, and the hazard it closes

`getmnlistd` replies come back on the same `mnlistdiff` message the tip sync
uses. A historical reply reaching `CoinStateMaintainer::on_mnlistdiff` would
rewrite the LIVE tip SML to a past state — silently, on the money path.

The maintainer's R1 guard rejects a ZERO-base snapshot dated at or below its
current height, but only `if (!have_at.IsNull())`. **At cold start `have_at` IS
null** — that is the resync the guard must not block — and cold start is exactly
when the bridge runs. So the guard is bypassed and the demux is the only thing
standing there.

The single filter slot is now a chain (`HistoricalMnListDiffDemux`) that
deliberately does **not** short-circuit: a bridge fold point can coincide with a
quorum work block, one reply answers both awaits, and swallowing it at the first
filter would leave the second waiting forever on a message that already arrived.

## Not wedging on a dead peer

A paused replay is a stopped replay. An unanswered fold request re-asks once (to
the same block, so still one thing outstanding), then ABANDONS that fold point
and resumes degraded rather than hanging with no symptom other than "the arm
never armed". The claim on an abandoned request is **not** released — a late
reply is still a base=ZERO snapshot at an old block, so it stays claimed and is
dropped. Abandonment is stated on `status()` and on the publish line; a degraded
publish that looks identical to a clean one is the defect this file exists to
prevent.

## Folded in from the closed diff-ladder slice (no ladder)

- `classify_decline()` now names the payee-desync latch (`mn-needs-reseed`).
  It was log-only: the smoke rig reported 639 consecutive `not-populated`
  declines while the real cause appeared nowhere a human would look.
- A codec KAT pinning that `CSimplifiedMNListDiff::Unserialize` DRAINS the rest
  of the stream as its opaque quorum tail, so a field appended after a packed
  diff must be read by fixed-width slicing or it is swallowed **silently** —
  no short-read, no throw. Both directions pinned.

## Tests

| test | before | now |
|---|---|---|
| `FoldMissesTheWindowWhenTheSmlTracksTheMovingTip` | RED | GREEN — kept as the permanent regression guard |
| `FoldFiresAtTheAnchorWhenTheSmlIsCurrentAtTheAnchorHeight` | RED | GREEN |
| `ThreeBanBurstInsideTheWindowReplaysEndToEnd` | — | new: the measured 3-ban/73-block shape replays 225 blocks and SURVIVES, spending zero walk budget |
| `HistoricalReplyNeverMutatesTheLiveTipSml` | — | new: real `NodeCoinState` + `CoinStateMaintainer` behind the real demux; tip SML byte-identical |
| `NoDemuxTheSameReplyDoesCorruptTheLiveTipSml` | — | new: its negative twin — one line removed and the corruption appears |

The burst test's expected coinbases come from an INDEPENDENT `MnStateMachine`
oracle driven height by height, not from hand-written ranks: every payment moves
its masternode to the tail of the DIP-3 queue, so guessing produces a payee
desync that looks like a bug in the lane and is not.

### Mutation results

Reverting the design (fold reads the tip SML again) reds the burst and
fold-schedule tests. Removing the anchor dispatch reds 10. Releasing the demux
claim reds 4 including the tip-SML pair. Short-circuiting the chain reds the
non-short-circuit test. Dropping the height binding, the SML root commitment,
the pause, the re-ask/give-up, the F5 bound or the degraded-publish line each
red their own case.

Three mutations produced ZERO red and each was chased down:

- **merkle proof against the PoW-verified header** — a real missing test. The
  first attempt at one tampered the proof and was caught by the coinbase-position
  check instead, so it did not isolate the branch. Rewritten to serve an
  internally-consistent reply that simply does not match our header. Now reds.
- **`expected_height == 0` and the null-header-root refusal** — gates working,
  not missing tests: both are subsumed by checks immediately after them
  (`nHeight != expected_height`, `proof_root.IsNull()`). Direct unit coverage
  added anyway since they are on the reward path.
- **`set_sml_current_height()` after a fold** — zero red because nothing depended
  on it, and it was WRONG: it dated the walk's freshness gate with the historical
  snapshot's height while the walk consults the LIVE tip list. Removed, with the
  reasoning written where the call used to be.

One guard is documented as an unreachable backstop rather than left to look
load-bearing: `request_window()`'s pause check, which mutation testing shows
nothing reaches today.

## Build / verify

```
cmake --build build_dash_bls --target c2pool-dash <59 allowlisted test_dash_*> \
      test_dash_quorum_member_source test_dash_bls_verify \
      test_dash_quorum_members test_dash_govvote_bls -j8     # rc=0, no errors
scripts/ci/dash_bls_linked_guard.sh .../c2pool-dash          # PASS (real BLS)
tools/ci/check_test_target_allowlist.py                      # OK, 225 targets
ctest -R 'Dash|MnState' -j8                                  # 910/910 passed
ctest -R 'DashBlsVerify|DashQuorumMembers|DashQuorumMemberSource|DashGovVoteBLS'
                                                             # 33/33 passed
```

All six BLS-only KAT cases reported as run (leg-3 check), so the build is not
BLS-dark.

## Attribution note

`08263abe` ("fold at the anchor cursor, not only post-apply") is what turned
`FoldFiresAtTheAnchorWhenTheSmlIsCurrentAtTheAnchorHeight` green — verified by
building at that commit, where it passes and
`FoldMissesTheWindowWhenTheSmlTracksTheMovingTip` still fails. The per-height
redesign is what turns the second one green. The two are orthogonal: one changes
WHERE the fold is dispatched from, the other WHICH list it consumes, and both
are kept.