### PR TITLE
ltc(v36): name the blocking ratchet condition; keep the bar label inside the canvas

### DIFF
--- a/src/impl/ltc/auto_ratchet.hpp
+++ b/src/impl/ltc/auto_ratchet.hpp
@@ -33,6 +33,7 @@
 #include <cstdint>
 #include <fstream>
 #include <set>
+#include <sstream>
 #include <string>
 
 namespace ltc
@@ -54,6 +55,48 @@ inline const char* ratchet_state_str(RatchetState s)
     }
     return "UNKNOWN";
 }
+
+// ---------------------------------------------------------------------------
+// OBSERVABILITY ONLY (no consensus surface).
+//
+// VOTING -> ACTIVATED has FOUR conditions. Until 08-02 a node stuck in VOTING
+// logged only `state=VOTING` and, for two of the four, nothing at all: the two
+// refusal lines lived INSIDE the `full_window && vote_pct >= 95` branch, so a
+// window that was merely under-filled or under-voted produced total silence.
+// A live LTC prod node sat like that for >10h while the dashboard showed 95.31%,
+// and answering "why" required reading this source.
+//
+// RatchetBlocker names the FIRST unmet condition in evaluation order so the log
+// is greppable and unambiguous — exactly one name, never a list of maybes.
+// ---------------------------------------------------------------------------
+enum class RatchetBlocker : uint8_t
+{
+    NONE           = 0,  // all four conditions met — activation proceeds
+    WINDOW_FILL    = 1,  // (1) total < chain_length
+    VOTE_PCT       = 2,  // (2) vote_pct < ACTIVATION_THRESHOLD
+    TAIL_WORK      = 3,  // (3) oldest 10% carries < SWITCH_THRESHOLD% of WORK signalling
+    SELF_VOTE_ONLY = 4   // (4) distinct non-self YES-vote authors < MIN_DISTINCT_NONSELF_AUTHORS
+};
+
+inline const char* ratchet_blocker_str(RatchetBlocker b)
+{
+    switch (b) {
+    case RatchetBlocker::NONE:           return "none";
+    case RatchetBlocker::WINDOW_FILL:    return "window-fill";
+    case RatchetBlocker::VOTE_PCT:       return "vote-pct";
+    case RatchetBlocker::TAIL_WORK:      return "tail-work";
+    case RatchetBlocker::SELF_VOTE_ONLY: return "self-vote-only";
+    }
+    return "unknown";
+}
+
+// Tri-state for condition (3). The work-weighted tail guard is EXPENSIVE (it
+// walks the oldest 10% of the window and tallies uint288 work weights) and the
+// live path only measures it once conditions (1) and (2) already hold. When an
+// earlier condition blocks, the tail is NOT_MEASURED and must be reported as
+// `n/a` — a zero that silently means "not measured" is precisely the trap this
+// whole change exists to remove.
+enum class RatchetTail : uint8_t { NOT_MEASURED = 0, FAIL = 1, PASS = 2 };
 
 class AutoRatchet
 {
@@ -82,6 +125,34 @@ public:
 
     RatchetState state() const { return state_; }
     int64_t target_version() const { return target_version_; }
+
+    /// OBSERVABILITY ONLY — pure, side-effect-free, no consensus surface.
+    ///
+    /// Names the FIRST unmet VOTING->ACTIVATED condition in the SAME order the
+    /// live state machine evaluates them:
+    ///   1. window-fill     total >= chain_length
+    ///   2. vote-pct        vote_pct >= ACTIVATION_THRESHOLD (95)
+    ///   3. tail-work       oldest 10% of the window carries >= SWITCH_THRESHOLD
+    ///                      (60) percent of WORK signalling the target (WEIGHT,
+    ///                      not head-count)
+    ///   4. self-vote-only  distinct_nonself_authors >= MIN_DISTINCT_NONSELF_AUTHORS
+    ///
+    /// Returns NONE when all four hold. `tail` is a tri-state: NOT_MEASURED is
+    /// treated as blocking on (3), which is unreachable from the live caller
+    /// (it always measures the tail once (1) and (2) hold) but keeps this
+    /// function total, so it can never report "activate" off an unmeasured tail.
+    static RatchetBlocker first_unmet(bool full_window,
+                                      int vote_pct,
+                                      RatchetTail tail,
+                                      int distinct_nonself_authors)
+    {
+        if (!full_window)                             return RatchetBlocker::WINDOW_FILL;
+        if (vote_pct < ACTIVATION_THRESHOLD)          return RatchetBlocker::VOTE_PCT;
+        if (tail != RatchetTail::PASS)                return RatchetBlocker::TAIL_WORK;
+        if (distinct_nonself_authors < MIN_DISTINCT_NONSELF_AUTHORS)
+            return RatchetBlocker::SELF_VOTE_ONLY;
+        return RatchetBlocker::NONE;
+    }
 
     /// Determine which share version to produce based on network state.
     /// Returns (share_version, desired_version_to_vote).
@@ -124,10 +195,16 @@ public:
         // so reading it here is consensus-neutral (see the ACTIVATE branch note).
         std::set<NetService> nonself_voting_authors;
 
+        // OBSERVABILITY: depth (distance from the tip, 0 = tip) of the SHALLOWEST
+        // — i.e. newest — share in the sample that does NOT signal the target.
+        // Feeds the tail-guard ETA below. -1 = no such share in the sample.
+        int32_t newest_nonsignal_depth = -1;
+
         auto chain_view = tracker.chain.get_chain(best_share_hash, sample);
         for (auto [hash, data] : chain_view)
         {
             ++total;
+            const int32_t depth = total - 1;
             data.share.invoke([&](auto* obj) {
                 if (static_cast<int64_t>(obj->m_desired_version) >= target_version_) {
                     ++target_votes;
@@ -135,6 +212,9 @@ public:
                                            obj->peer_addr == NetService{});
                     if (!is_local)
                         nonself_voting_authors.insert(obj->peer_addr);
+                }
+                else if (newest_nonsignal_depth < 0) {
+                    newest_nonsignal_depth = depth;   // get_chain walks tip -> parents
                 }
                 if (static_cast<int64_t>(std::remove_pointer_t<decltype(obj)>::version) >= target_version_)
                     ++target_shares;
@@ -157,6 +237,15 @@ public:
 
         if (state_ == RatchetState::VOTING)
         {
+            // OBSERVABILITY scratch — carried out of the (possibly skipped)
+            // measurement branch so the single explain-line below always has
+            // the numbers that justify whatever it names.
+            RatchetTail tail_state = RatchetTail::NOT_MEASURED;
+            int tail_pct = -1;          // -1 => not measured => printed as n/a
+            int32_t eta_shares = -1;    // -1 => not computable => omitted
+            const int distinct_nonself_authors_obs =
+                static_cast<int>(nonself_voting_authors.size());
+
             if (full_window && vote_pct >= ACTIVATION_THRESHOLD)
             {
                 // Tail guard: oldest 10% of window must have >= 60% signaling
@@ -215,23 +304,54 @@ public:
                 const int distinct_nonself_authors = static_cast<int>(nonself_voting_authors.size());
                 const bool multi_party = distinct_nonself_authors >= MIN_DISTINCT_NONSELF_AUTHORS;
 
+                // --- OBSERVABILITY ONLY from here to the `if (!tail_ok)` ------
+                tail_state = tail_ok ? RatchetTail::PASS : RatchetTail::FAIL;
+                // Largest p in [0,100] with tail_target*100 >= tail_total*p, i.e.
+                // the floor'd work-weighted signalling percentage of the tail.
+                // uint288 has no division, and this only runs once conditions (1)
+                // and (2) already hold, so a 101-step descent is free. Measured
+                // whether the guard passes or fails — `n/a` is reserved for the
+                // case where the tail was genuinely never looked at.
+                tail_pct = 0;
+                if (!tail_total.IsNull()) {
+                    for (int p = 100; p >= 0; --p) {
+                        if (!(tail_target * uint32_t(100) < tail_total * uint32_t(p))) {
+                            tail_pct = p;
+                            break;
+                        }
+                    }
+                }
                 if (!tail_ok) {
-                    static int tail_log = 0;
-                    if (tail_log++ % 20 == 0)
-                        LOG_INFO << "[AutoRatchet] VOTING: full window " << vote_pct
-                                 << "% >= " << ACTIVATION_THRESHOLD << "% but oldest 10% work-weighted V"
-                                 << target_version_ << " desire < " << SWITCH_THRESHOLD << "%) — waiting";
-                    // Don't transition yet
+                    // ETA: how many further shares until the tail window has
+                    // rolled entirely past today's non-signalling shares.
+                    //
+                    // The tail is always depths [tail_start, tail_start+tail_size)
+                    // from the tip. A share now at depth d sits at depth d+k after
+                    // k new shares, so it has LEFT the tail once
+                    // k >= tail_start + tail_size - d. Every share currently
+                    // shallower than the tail will still pass through it, so the
+                    // binding one is the SHALLOWEST non-signalling share, at depth
+                    // newest_nonsignal_depth. Hence:
+                    //
+                    //     eta_shares = (tail_start + tail_size) - newest_nonsignal_depth
+                    //
+                    // ASSUMPTION, stated in the log as `<=`: every share minted
+                    // from here on signals the target. It is therefore an UPPER
+                    // bound — the 60%-by-work gate can clear earlier, since it
+                    // needs 60%, not 100%. If the sample holds no non-signalling
+                    // share at all the number is not derivable and we print none
+                    // rather than a guess.
+                    const int32_t tail_end = static_cast<int32_t>(tail_start + tail_size);
+                    if (newest_nonsignal_depth >= 0 && newest_nonsignal_depth < tail_end)
+                        eta_shares = tail_end - newest_nonsignal_depth;
+                }
+                // --- end observability ---------------------------------------
+
+                if (!tail_ok) {
+                    // Don't transition yet — explained by the single line below.
                 }
                 else if (!multi_party) {
-                    static int self_log = 0;
-                    if (self_log++ % 20 == 0)
-                        LOG_INFO << "[AutoRatchet] VOTING: full window " << vote_pct
-                                 << "% >= " << ACTIVATION_THRESHOLD << "% but only "
-                                 << distinct_nonself_authors << " distinct non-self author(s) < "
-                                 << MIN_DISTINCT_NONSELF_AUTHORS
-                                 << " — self-authored window, refusing activation (mode-2 guard)";
-                    // Don't transition yet
+                    // Don't transition yet — explained by the single line below.
                 }
                 else
                 {
@@ -260,6 +380,20 @@ public:
                 }
                 save();
                 } // else (tail guard passed)
+            }
+
+            // OBSERVABILITY ONLY — one greppable line per evaluation naming the
+            // FIRST unmet condition, with the measurement AND the threshold that
+            // justifies it. Rate-limited: on CHANGE of blocked-by, plus a
+            // heartbeat every VOTING_EXPLAIN_HEARTBEAT evaluations. Emits
+            // nothing once nothing blocks (the ACTIVATED transition above speaks
+            // for itself).
+            if (state_ == RatchetState::VOTING)
+            {
+                const RatchetBlocker blocker = first_unmet(
+                    full_window, vote_pct, tail_state, distinct_nonself_authors_obs);
+                log_voting_block(blocker, total, chain_length, vote_pct, tail_pct,
+                                 distinct_nonself_authors_obs, eta_shares);
             }
         }
         else if (state_ == RatchetState::ACTIVATED)
@@ -341,6 +475,12 @@ public:
     // count-based -- a flat-count tail guard would let a 95%-by-count activation
     // outrun the 60%-by-work accept gate and wedge the crossing.
 
+public:
+    // Heartbeat period for the VOTING explain-line, in evaluations. The ratchet
+    // is evaluated once per share, so this bounds the line to roughly one per
+    // 60 shares (~15 min at LTC's 15s share period) when nothing is changing.
+    static constexpr int VOTING_EXPLAIN_HEARTBEAT = 60;
+
 private:
     std::string state_file_;
     int64_t target_version_;
@@ -350,6 +490,64 @@ private:
     int64_t confirmed_at_ = 0;
     int32_t confirm_count_ = 0;
     int32_t last_seen_height_ = 0;
+
+    // OBSERVABILITY ONLY — VOTING explain-line rate limiter. Per-instance, not
+    // a function-local static: a function-local static in this header-inline
+    // method is shared across every AutoRatchet in the process.
+    RatchetBlocker last_blocker_ = RatchetBlocker::NONE;
+    bool blocker_logged_once_ = false;
+    int evals_since_block_log_ = 0;
+
+    /// OBSERVABILITY ONLY. Emits at most one line naming exactly ONE blocking
+    /// condition, always carrying the measured value AND its threshold.
+    void log_voting_block(RatchetBlocker blocker,
+                          int32_t total, uint32_t chain_length,
+                          int vote_pct, int tail_pct,
+                          int distinct_nonself_authors,
+                          int32_t eta_shares)
+    {
+        if (blocker == RatchetBlocker::NONE) {
+            // Nothing blocks: reset the limiter so the next block re-announces.
+            last_blocker_ = RatchetBlocker::NONE;
+            blocker_logged_once_ = false;
+            evals_since_block_log_ = 0;
+            return;
+        }
+
+        const bool changed = (!blocker_logged_once_ || blocker != last_blocker_);
+        if (!changed && ++evals_since_block_log_ < VOTING_EXPLAIN_HEARTBEAT)
+            return;
+        last_blocker_ = blocker;
+        blocker_logged_once_ = true;
+        evals_since_block_log_ = 0;
+
+        std::ostringstream line;
+        line << "[AutoRatchet] VOTING blocked-by=" << ratchet_blocker_str(blocker)
+             << " window=" << total << "/" << chain_length
+             << " vote=" << vote_pct << "% (need " << ACTIVATION_THRESHOLD << ")"
+             << " tail10%work=";
+        if (tail_pct < 0) line << "n/a";              // NOT measured — never "0"
+        else              line << tail_pct << "%";
+        line << " (need " << SWITCH_THRESHOLD << ")"
+             << " nonself_authors=" << distinct_nonself_authors
+             << " (need " << MIN_DISTINCT_NONSELF_AUTHORS << ")";
+
+        // ETA is emitted ONLY for the tail guard, and only when derivable.
+        if (blocker == RatchetBlocker::TAIL_WORK && eta_shares > 0) {
+            const uint32_t period = PoolConfig::share_period();
+            line << " eta_shares<=" << eta_shares;
+            if (period > 0) {
+                const double hours =
+                    (static_cast<double>(eta_shares) * static_cast<double>(period)) / 3600.0;
+                std::ostringstream h;
+                h.setf(std::ios::fixed, std::ios::floatfield);
+                h.precision(1);
+                h << hours;
+                line << " eta<=" << h.str() << "h";
+            }
+        }
+        LOG_INFO << line.str();
+    }
 
     static int64_t now_seconds()
     {

--- a/src/impl/ltc/test/CMakeLists.txt
+++ b/src/impl/ltc/test/CMakeLists.txt
@@ -12,7 +12,13 @@ if (BUILD_TESTING AND GTest_FOUND)
     # cannot grant a shared lock to a thread already holding it exclusively — and
     # that without that lock the walk runs and the per-peer send loop is entered.
     # Same folding rule: into the existing allowlisted target.
-    add_executable(share_test share_test.cpp f11_donation_invariance_test.cpp emergency_decay_overflow_test.cpp wirecompat_runtime_test.cpp desired_version_tally_test.cpp auto_ratchet_sim_test.cpp auto_ratchet_tail_guard_test.cpp chain_walk_window_test.cpp doge_template_underfill_test.cpp broadcast_tx_completeness_test.cpp broadcast_lock_discipline_test.cpp compact_block_merkle_test.cpp)
+    #
+    # auto_ratchet_blocked_by_test.cpp: the VOTING explain-line — asserts the
+    # ratchet names the FIRST unmet of its four activation conditions, with the
+    # measurement that justifies it, and that an all-pass window logs no blocked
+    # line and actually activates. Same folding rule: into the existing
+    # allowlisted target.
+    add_executable(share_test share_test.cpp f11_donation_invariance_test.cpp emergency_decay_overflow_test.cpp wirecompat_runtime_test.cpp desired_version_tally_test.cpp auto_ratchet_sim_test.cpp auto_ratchet_tail_guard_test.cpp auto_ratchet_blocked_by_test.cpp chain_walk_window_test.cpp doge_template_underfill_test.cpp broadcast_tx_completeness_test.cpp broadcast_lock_discipline_test.cpp compact_block_merkle_test.cpp)
     target_link_libraries(share_test PRIVATE
         GTest::gtest_main GTest::gtest
         core ltc

--- a/src/impl/ltc/test/auto_ratchet_blocked_by_test.cpp
+++ b/src/impl/ltc/test/auto_ratchet_blocked_by_test.cpp
@@ -1,0 +1,391 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// ltc_auto_ratchet_blocked_by_test: KATs for the VOTING explain-line — the
+// OBSERVABILITY-ONLY change that makes a stuck v36 AutoRatchet name the ONE
+// condition that is holding it, with the measurement that justifies the name.
+//
+// WHY. A live LTC prod node logged nothing but
+//     [AutoRatchet] share_version=35 desired=36 state=VOTING
+// for >10h while the dashboard showed a 95.31% vote. The two pre-existing
+// refusal lines sat INSIDE the `full_window && vote_pct >= 95` branch, so the
+// two most common blockers — an under-filled window and an under-voted one —
+// produced TOTAL SILENCE. Silence is the defect; a state name that never says
+// which of its four gates is shut is not observability.
+//
+// WHAT IS PINNED. VOTING -> ACTIVATED has FOUR conditions:
+//   1  window-fill     total >= chain_length
+//   2  vote-pct        vote_pct >= ACTIVATION_THRESHOLD (95)
+//   3  tail-work       oldest 10% of the window carries >= SWITCH_THRESHOLD (60)
+//                      percent of WORK signalling the target (WEIGHT, not count)
+//   4  self-vote-only  distinct_nonself_authors >= MIN_DISTINCT_NONSELF_AUTHORS
+//
+// Two layers, both driving REAL production code — no lifted oracle, no replica:
+//
+//   A) AutoRatchet::first_unmet — the pure ordering predicate the live path
+//      calls. One KAT per blocked-by value plus the all-pass NONE case, and a
+//      precedence KAT pinning that a MULTIPLY-blocked window names the FIRST
+//      unmet condition, never a list.
+//
+//   B) End-to-end through AutoRatchet::get_share_version over a REAL populated
+//      ltc::ShareTracker (the chain_walk_window_test construction precedent),
+//      with a Boost.Log sink capturing what the node would actually print. Each
+//      of the four blockers is provoked by CHAIN SHAPE alone and the emitted
+//      line is asserted verbatim on its blocked-by name, its numbers, and the
+//      `n/a` vs measured discipline for the tail field. The NEGATIVE TWIN asserts
+//      an all-conditions-pass window logs NO blocked line and DOES activate.
+//
+// CONSENSUS SURFACE IS NOT TOUCHED. Every assertion here is about what the
+// ratchet SAYS. The activation decision itself is asserted only via
+// ar.state(), so a drift in behaviour (not just wording) also reddens these.
+//
+// Folded into the EXISTING allowlisted `share_test` target rather than a new
+// add_executable — a standalone target is absent from build.yml's --target list
+// and would become a #143 NOT_BUILT CTest sentinel.
+
+#include <gtest/gtest.h>
+
+#include <impl/ltc/auto_ratchet.hpp>
+#include <impl/ltc/share.hpp>
+#include <impl/ltc/share_tracker.hpp>
+#include <core/uint256.hpp>
+
+#include <boost/log/core.hpp>
+#include <boost/log/sinks/sync_frontend.hpp>
+#include <boost/log/sinks/text_ostream_backend.hpp>
+#include <boost/make_shared.hpp>
+#include <boost/shared_ptr.hpp>
+
+#include <cstdint>
+#include <cstdio>
+#include <sstream>
+#include <string>
+
+using ltc::AutoRatchet;
+using ltc::RatchetBlocker;
+using ltc::RatchetState;
+using ltc::RatchetTail;
+
+namespace {
+
+constexpr int64_t TARGET_VERSION = 36;
+
+// ---------------------------------------------------------------------------
+// A) Pure ordering predicate — AutoRatchet::first_unmet, the REAL function the
+//    live VOTING path calls to name its blocker.
+// ---------------------------------------------------------------------------
+
+TEST(LTC_RatchetBlockedBy, A_WindowFillIsNamedWhenWindowIsShort)
+{
+    // Under-filled window. Every LATER condition is satisfied, and the tail was
+    // deliberately never measured — the live path short-circuits before it.
+    EXPECT_EQ(AutoRatchet::first_unmet(/*full_window*/ false, /*vote*/ 100,
+                                       RatchetTail::NOT_MEASURED, /*nonself*/ 9),
+              RatchetBlocker::WINDOW_FILL);
+    EXPECT_STREQ(ltc::ratchet_blocker_str(RatchetBlocker::WINDOW_FILL), "window-fill");
+}
+
+TEST(LTC_RatchetBlockedBy, A_VotePctIsNamedWhenVoteIsShort)
+{
+    EXPECT_EQ(AutoRatchet::first_unmet(true, AutoRatchet::ACTIVATION_THRESHOLD - 1,
+                                       RatchetTail::NOT_MEASURED, 9),
+              RatchetBlocker::VOTE_PCT);
+    // Exactly AT the threshold is NOT a vote-pct block (>=, not >).
+    EXPECT_NE(AutoRatchet::first_unmet(true, AutoRatchet::ACTIVATION_THRESHOLD,
+                                       RatchetTail::PASS, 9),
+              RatchetBlocker::VOTE_PCT);
+    EXPECT_STREQ(ltc::ratchet_blocker_str(RatchetBlocker::VOTE_PCT), "vote-pct");
+}
+
+TEST(LTC_RatchetBlockedBy, A_TailWorkIsNamedWhenTailGuardFails)
+{
+    EXPECT_EQ(AutoRatchet::first_unmet(true, 100, RatchetTail::FAIL, 9),
+              RatchetBlocker::TAIL_WORK);
+    EXPECT_STREQ(ltc::ratchet_blocker_str(RatchetBlocker::TAIL_WORK), "tail-work");
+
+    // Totality: an UNMEASURED tail can never be reported as activate-ready. If
+    // it were treated as a pass, an unmeasured zero would silently green-light.
+    EXPECT_EQ(AutoRatchet::first_unmet(true, 100, RatchetTail::NOT_MEASURED, 9),
+              RatchetBlocker::TAIL_WORK);
+}
+
+TEST(LTC_RatchetBlockedBy, A_SelfVoteOnlyIsNamedWhenWindowIsSelfAuthored)
+{
+    EXPECT_EQ(AutoRatchet::first_unmet(true, 100, RatchetTail::PASS,
+                                       AutoRatchet::MIN_DISTINCT_NONSELF_AUTHORS - 1),
+              RatchetBlocker::SELF_VOTE_ONLY);
+    EXPECT_STREQ(ltc::ratchet_blocker_str(RatchetBlocker::SELF_VOTE_ONLY), "self-vote-only");
+}
+
+TEST(LTC_RatchetBlockedBy, A_NoneWhenAllFourConditionsHold)
+{
+    EXPECT_EQ(AutoRatchet::first_unmet(true, AutoRatchet::ACTIVATION_THRESHOLD,
+                                       RatchetTail::PASS,
+                                       AutoRatchet::MIN_DISTINCT_NONSELF_AUTHORS),
+              RatchetBlocker::NONE);
+}
+
+TEST(LTC_RatchetBlockedBy, A_PrecedenceNamesTheFirstUnmetNotAList)
+{
+    // ALL FOUR unmet at once: the report must be the FIRST in evaluation order
+    // so the log stays greppable and unambiguous.
+    EXPECT_EQ(AutoRatchet::first_unmet(false, 0, RatchetTail::FAIL, 0),
+              RatchetBlocker::WINDOW_FILL);
+    // Window fills -> the next one surfaces, and so on down the chain.
+    EXPECT_EQ(AutoRatchet::first_unmet(true, 0, RatchetTail::FAIL, 0),
+              RatchetBlocker::VOTE_PCT);
+    EXPECT_EQ(AutoRatchet::first_unmet(true, 100, RatchetTail::FAIL, 0),
+              RatchetBlocker::TAIL_WORK);
+    EXPECT_EQ(AutoRatchet::first_unmet(true, 100, RatchetTail::PASS, 0),
+              RatchetBlocker::SELF_VOTE_ONLY);
+    EXPECT_EQ(AutoRatchet::first_unmet(true, 100, RatchetTail::PASS, 1),
+              RatchetBlocker::NONE);
+}
+
+// ---------------------------------------------------------------------------
+// B) End-to-end: drive the REAL AutoRatchet over a REAL populated ShareTracker
+//    and read back what the node actually logged.
+// ---------------------------------------------------------------------------
+
+// Boost.Log sink capture. LOG_INFO is BOOST_LOG_TRIVIAL(info); attaching an
+// ostream sink to the core records every formatted line for inspection.
+class LogCapture
+{
+public:
+    LogCapture()
+        : stream_(boost::make_shared<std::ostringstream>())
+    {
+        auto backend = boost::make_shared<boost::log::sinks::text_ostream_backend>();
+        backend->add_stream(stream_);
+        backend->auto_flush(true);
+        sink_ = boost::make_shared<sink_t>(backend);
+        boost::log::core::get()->add_sink(sink_);
+    }
+    ~LogCapture() { boost::log::core::get()->remove_sink(sink_); }
+
+    std::string str() const { return stream_->str(); }
+    void clear() { stream_->str(std::string()); }
+
+private:
+    using sink_t = boost::log::sinks::synchronous_sink<boost::log::sinks::text_ostream_backend>;
+    boost::shared_ptr<std::ostringstream> stream_;
+    boost::shared_ptr<sink_t> sink_;
+};
+
+// Short hex tail -> uint256, the LTC test-tree hx() convention.
+uint256 hx(const std::string& tail)
+{
+    uint256 v;
+    v.SetHex(std::string(64 - tail.size(), '0') + tail);
+    return v;
+}
+
+// Chain shape knobs. Share i (0 = oldest) signals `TARGET_VERSION` iff
+// i >= old_prefix, i.e. the OLDEST `old_prefix` shares are the non-signalling
+// ones — which is exactly where the [9/10*CL, CL] tail guard looks.
+struct ChainSpec
+{
+    int32_t count       = 0;
+    int32_t old_prefix  = 0;    // number of oldest shares voting TARGET-1
+    bool    external    = true; // give YES-voters a non-local peer_addr
+};
+
+// Build a resolved ltc::ShareTracker of uniform-work V36-format shares.
+// Uniform m_bits => uniform work weight, so the work-weighted tail guard
+// reduces to a head-count over the tail and the spec is exactly predictive.
+uint256 build_chain(ltc::ShareTracker& tracker, const ChainSpec& spec, size_t salt)
+{
+    uint256 prev;
+    prev.SetNull();
+    uint256 tip;
+    tip.SetNull();
+    for (int32_t i = 0; i < spec.count; ++i) {
+        char buf[24];
+        std::snprintf(buf, sizeof(buf), "%zx",
+                      static_cast<size_t>((salt << 20) + 0x5100 + static_cast<size_t>(i)));
+        uint256 h = hx(buf);
+        auto* sh = new ltc::MergedMiningShare();
+        sh->m_hash = h;
+        if (i == 0) sh->m_prev_hash.SetNull(); else sh->m_prev_hash = prev;
+        const bool signals = (i >= spec.old_prefix);
+        sh->m_desired_version = signals ? static_cast<uint64_t>(TARGET_VERSION)
+                                        : static_cast<uint64_t>(TARGET_VERSION - 1);
+        sh->m_bits     = 0x1e0ffff0;
+        sh->m_max_bits = 0x1e0ffff0;
+        if (signals && spec.external)
+            sh->peer_addr = NetService{"203.0.113.7", 9333};
+        ltc::ShareType st;
+        st = sh;
+        tracker.add(st);
+        prev = h;
+        tip = h;
+    }
+    return tip;
+}
+
+// Testnet params give CHAIN_LENGTH = 400 (vs mainnet 8640), so a full window is
+// cheap to build. The flag is process-global; the fixture restores it.
+class RatchetExplainLine : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        saved_testnet_ = ltc::PoolConfig::is_testnet;
+        ltc::PoolConfig::is_testnet = true;
+    }
+    void TearDown() override { ltc::PoolConfig::is_testnet = saved_testnet_; }
+
+    // Drive one evaluation and return everything the node logged during it.
+    static std::string evaluate(AutoRatchet& ar, ltc::ShareTracker& tracker,
+                                const uint256& tip)
+    {
+        LogCapture cap;
+        ar.get_share_version(tracker, tip);
+        return cap.str();
+    }
+
+    bool saved_testnet_ = false;
+};
+
+TEST_F(RatchetExplainLine, B_WindowFill_ShortWindowIsNoLongerSilent)
+{
+    // THE SILENT CASE. Pre-change this branch logged absolutely nothing.
+    const uint32_t CL = ltc::PoolConfig::chain_length();
+    ASSERT_EQ(CL, 400u);
+
+    ltc::ShareTracker tracker;
+    ChainSpec spec; spec.count = 120; spec.old_prefix = 0;   // 100% YES, short window
+    auto tip = build_chain(tracker, spec, 1);
+
+    AutoRatchet ar("", TARGET_VERSION);
+    const std::string out = evaluate(ar, tracker, tip);
+
+    EXPECT_NE(out.find("blocked-by=window-fill"), std::string::npos) << out;
+    EXPECT_NE(out.find("window=120/400"), std::string::npos) << out;
+    // The measurement AND the threshold, both present.
+    EXPECT_NE(out.find("vote=100% (need 95)"), std::string::npos) << out;
+    // Tail was never evaluated -> `n/a`, NEVER a zero that means "not measured".
+    EXPECT_NE(out.find("tail10%work=n/a (need 60)"), std::string::npos) << out;
+    EXPECT_EQ(out.find("tail10%work=0%"), std::string::npos) << out;
+    // ETA is tail-guard-only.
+    EXPECT_EQ(out.find("eta_shares"), std::string::npos) << out;
+    EXPECT_EQ(ar.state(), RatchetState::VOTING);
+}
+
+TEST_F(RatchetExplainLine, B_VotePct_UnderVotedWindowIsNoLongerSilent)
+{
+    // THE OTHER SILENT CASE: window is full, vote is short.
+    ltc::ShareTracker tracker;
+    ChainSpec spec; spec.count = 400; spec.old_prefix = 80;  // 320/400 = 80%
+    auto tip = build_chain(tracker, spec, 2);
+
+    AutoRatchet ar("", TARGET_VERSION);
+    const std::string out = evaluate(ar, tracker, tip);
+
+    EXPECT_NE(out.find("blocked-by=vote-pct"), std::string::npos) << out;
+    EXPECT_NE(out.find("window=400/400"), std::string::npos) << out;
+    EXPECT_NE(out.find("vote=80% (need 95)"), std::string::npos) << out;
+    EXPECT_NE(out.find("tail10%work=n/a (need 60)"), std::string::npos) << out;
+    EXPECT_EQ(out.find("eta_shares"), std::string::npos) << out;
+    EXPECT_EQ(ar.state(), RatchetState::VOTING);
+}
+
+TEST_F(RatchetExplainLine, B_TailWork_NamedWithMeasuredTailAndEta)
+{
+    // Window full, vote EXACTLY at 95% (380/400) — so conditions 1 and 2 hold —
+    // but the oldest 20 of the 40-share tail still vote V35, so the tail carries
+    // only 50% of the work signalling: below the 60% switch gate.
+    ltc::ShareTracker tracker;
+    ChainSpec spec; spec.count = 400; spec.old_prefix = 20;
+    auto tip = build_chain(tracker, spec, 3);
+
+    AutoRatchet ar("", TARGET_VERSION);
+    const std::string out = evaluate(ar, tracker, tip);
+
+    EXPECT_NE(out.find("blocked-by=tail-work"), std::string::npos) << out;
+    EXPECT_NE(out.find("window=400/400"), std::string::npos) << out;
+    EXPECT_NE(out.find("vote=95% (need 95)"), std::string::npos) << out;
+    // The tail WAS measured here, so a real number must appear — not `n/a`.
+    EXPECT_NE(out.find("tail10%work=50% (need 60)"), std::string::npos) << out;
+    EXPECT_EQ(out.find("tail10%work=n/a"), std::string::npos) << out;
+    // ETA, and ONLY for this blocker. Shallowest non-signalling share sits at
+    // depth 380 (share index 19 of 400), tail end = 400, so 20 more shares; at
+    // the 4s testnet share period that is 80s = 0.0h to one decimal.
+    EXPECT_NE(out.find("eta_shares<=20"), std::string::npos) << out;
+    EXPECT_NE(out.find("eta<=0.0h"), std::string::npos) << out;
+    EXPECT_EQ(ar.state(), RatchetState::VOTING);
+}
+
+TEST_F(RatchetExplainLine, B_SelfVoteOnly_NamedOnAFullySelfAuthoredWindow)
+{
+    // 100% YES by count AND by tail work, but every YES-vote is locally minted
+    // (default peer_addr), so the mode-2 guard holds. The tail WAS measured and
+    // passed, so it must report 100%, not `n/a`.
+    ltc::ShareTracker tracker;
+    ChainSpec spec; spec.count = 400; spec.old_prefix = 0; spec.external = false;
+    auto tip = build_chain(tracker, spec, 4);
+
+    AutoRatchet ar("", TARGET_VERSION);
+    const std::string out = evaluate(ar, tracker, tip);
+
+    EXPECT_NE(out.find("blocked-by=self-vote-only"), std::string::npos) << out;
+    EXPECT_NE(out.find("vote=100% (need 95)"), std::string::npos) << out;
+    EXPECT_NE(out.find("tail10%work=100% (need 60)"), std::string::npos) << out;
+    EXPECT_NE(out.find("nonself_authors=0 (need 1)"), std::string::npos) << out;
+    EXPECT_EQ(out.find("eta_shares"), std::string::npos) << out;
+    EXPECT_EQ(ar.state(), RatchetState::VOTING);
+}
+
+// --- NEGATIVE TWIN ---------------------------------------------------------
+TEST_F(RatchetExplainLine, B_AllFourPass_NoBlockedLineAndItActivates)
+{
+    // Same 400-share window, 100% YES, tail 100% by work, and the YES-votes
+    // carry an EXTERNAL peer_addr. All four conditions hold.
+    ltc::ShareTracker tracker;
+    ChainSpec spec; spec.count = 400; spec.old_prefix = 0; spec.external = true;
+    auto tip = build_chain(tracker, spec, 5);
+
+    AutoRatchet ar("", TARGET_VERSION);
+    const std::string out = evaluate(ar, tracker, tip);
+
+    // It must NOT claim to be blocked...
+    EXPECT_EQ(out.find("blocked-by="), std::string::npos) << out;
+    // ...and it must actually cross, not merely stay quiet.
+    EXPECT_NE(ar.state(), RatchetState::VOTING) << out;
+    EXPECT_NE(out.find("VOTING -> "), std::string::npos) << out;
+}
+
+// --- RATE LIMIT ------------------------------------------------------------
+TEST_F(RatchetExplainLine, B_RateLimitedToChangePlusHeartbeat)
+{
+    // This runs once per share; an unthrottled line would flood the log. The
+    // rule is: emit on CHANGE of blocked-by, plus a heartbeat every
+    // VOTING_EXPLAIN_HEARTBEAT evaluations.
+    ltc::ShareTracker tracker;
+    ChainSpec spec; spec.count = 120; spec.old_prefix = 0;
+    auto tip = build_chain(tracker, spec, 6);
+
+    AutoRatchet ar("", TARGET_VERSION);
+
+    // First evaluation: change (nothing logged before) -> one line.
+    EXPECT_NE(evaluate(ar, tracker, tip).find("blocked-by=window-fill"),
+              std::string::npos);
+
+    // Next HEARTBEAT-1 evaluations: same blocker, suppressed.
+    for (int i = 0; i < AutoRatchet::VOTING_EXPLAIN_HEARTBEAT - 1; ++i) {
+        const std::string quiet = evaluate(ar, tracker, tip);
+        EXPECT_EQ(quiet.find("blocked-by="), std::string::npos)
+            << "flooded at i=" << i << ": " << quiet;
+    }
+    // The heartbeat evaluation speaks again.
+    EXPECT_NE(evaluate(ar, tracker, tip).find("blocked-by=window-fill"),
+              std::string::npos);
+
+    // A CHANGE of blocker breaks the silence immediately, without waiting for
+    // the next heartbeat: same ratchet, a chain that now blocks on vote-pct.
+    ltc::ShareTracker tracker2;
+    ChainSpec spec2; spec2.count = 400; spec2.old_prefix = 80;
+    auto tip2 = build_chain(tracker2, spec2, 7);
+    const std::string changed = evaluate(ar, tracker2, tip2);
+    EXPECT_NE(changed.find("blocked-by=vote-pct"), std::string::npos) << changed;
+}
+
+} // namespace

--- a/web-static/dashboard.html
+++ b/web-static/dashboard.html
@@ -2408,7 +2408,55 @@
         }
         
         function values(o) { var res = []; for(var x in o) res.push(o[x]); return res; }
-        
+
+        // ---- progress-bar label placement -----------------------------------
+        // DEFECT this fixes: every `.bar-label` is a <span> INSIDE the filled
+        // `.signaling-bar`, anchored `right:6px` by CSS. At 0% the fill has zero
+        // width, so that anchor sits on the track's LEFT edge and the
+        // (white-space:nowrap) label is laid out entirely at NEGATIVE x — drawn
+        // outside the canvas to the left. Only the sampling-window bar had any
+        // mitigation, and it was a hardcoded 15% cutover that the wider
+        // two-number label ("95.3% chain / 60.1% window") still overflowed.
+        //
+        // RULE: choose inside vs outside from the label's RENDERED width against
+        // the filled width. Inside (`.bar-label`, white on the fill) whenever the
+        // fill can hold the label plus padding; otherwise `.bar-label-outside`
+        // on the track just right of the fill, CLAMPED to the track so the label
+        // can never leave the canvas at either end.
+        //
+        // `pct` is passed rather than measured because `.signaling-bar` carries
+        // `transition: width 0.5s` — a getBoundingClientRect() taken right after
+        // the width is assigned still reports the OLD width.
+        var BAR_LABEL_PAD = 6;   // px gap from the fill's inner right edge
+        var BAR_LABEL_GAP = 6;   // px gap between the fill and an outside label
+        function placeBarLabel(fillId, labelId, pct) {
+            var fill = document.getElementById(fillId);
+            var label = document.getElementById(labelId);
+            if (!fill || !label) return;
+            var track = fill.parentNode;
+            var trackW = track.clientWidth;
+            if (!trackW || !label.textContent) return;
+            var p = Math.max(0, Math.min(100, pct || 0));
+            var fillW = trackW * p / 100;
+            var labelW = label.getBoundingClientRect().width;
+            if (labelW + 2 * BAR_LABEL_PAD <= fillW) {
+                label.className = 'bar-label';
+                label.style.left = '';
+                label.style.right = '';
+            } else {
+                // `left` is relative to the fill, whose left edge IS the track's
+                // left edge, so these are track coordinates. The inline value
+                // overrides `.bar-label-outside`'s `left: calc(100% + 6px)`,
+                // which is unclamped and runs off the right end near 100%.
+                var maxLeft = trackW - labelW - BAR_LABEL_PAD;
+                var leftInTrack = Math.max(BAR_LABEL_PAD,
+                                           Math.min(fillW + BAR_LABEL_GAP, maxLeft));
+                label.className = 'bar-label-outside';
+                label.style.right = 'auto';
+                label.style.left = leftInTrack + 'px';
+            }
+        }
+
         function populateActiveMiners(local_stats, global_stats) {
             d3.select('#active_miners_loading').style('display', 'none');
             
@@ -3239,6 +3287,7 @@
                         d3.select('#chain-maturity-section').style('display', 'block');
                         d3.select('#chain-maturity-bar').style('width', vs.chain_maturity + '%');
                         d3.select('#chain-maturity-bar-label').text(d3.format('.1f')(vs.chain_maturity) + '%');
+                        placeBarLabel('chain-maturity-bar', 'chain-maturity-bar-label', vs.chain_maturity);
                         d3.select('#chain-maturity-text').text(
                             vs.chain_height + ' / ' + vs.chain_length_required + 
                             ' (' + d3.format('.1f')(vs.chain_maturity) + '%) \u2014 need ' + 
@@ -3252,6 +3301,7 @@
                         d3.select('#propagation-section').style('display', 'block');
                         d3.select('#propagation-bar').style('width', vs.propagation_pct + '%');
                         d3.select('#propagation-bar-label').text(d3.format('.1f')(vs.overall_v36_vote_pct) + '% V36');
+                        placeBarLabel('propagation-bar', 'propagation-bar-label', vs.propagation_pct);
                         var etaMin = Math.round(vs.time_to_window_seconds / 60);
                         var etaH = Math.floor(etaMin / 60);
                         var etaM = etaMin % 60;
@@ -3291,6 +3341,7 @@
                             var countdownPct = confirmWindow > 0 ? Math.min(100, sharesSince * 100 / confirmWindow) : 0;
                             d3.select('#countdown-bar').style('width', countdownPct + '%');
                             d3.select('#countdown-bar-label').text(d3.format('.1f')(countdownPct) + '%');
+                            placeBarLabel('countdown-bar', 'countdown-bar-label', countdownPct);
                             // ETA calculation
                             var sharesRemaining = Math.max(0, confirmWindow - sharesSince);
                             var etaSec = sharesRemaining * 10; // ~10 sec per share
@@ -3309,6 +3360,7 @@
                             var fillPct = Math.min(100, v36FormatPct);
                             d3.select('#confirmation-bar').style('width', fillPct + '%');
                             d3.select('#confirmation-bar-label').text(d3.format('.1f')(v36FormatPct) + '% V36');
+                            placeBarLabel('confirmation-bar', 'confirmation-bar-label', fillPct);
                             if (v36FormatPct >= 95) {
                                 d3.select('#confirmation-bar').style('background', 'linear-gradient(90deg, #4CAF50, #00E676)');
                             } else {
@@ -3333,12 +3385,11 @@
                         if (vs.overall_v36_vote_pct > sigPct + 0.1) {
                             sigLabel = d3.format('.1f')(vs.overall_v36_vote_pct) + '% chain / ' + d3.format('.1f')(sigPct) + '% window';
                         }
-                        var sigLabelEl = d3.select('#signaling-bar-label');
-                        if (barPct >= 15) {
-                            sigLabelEl.attr('class', 'bar-label').text(sigLabel);
-                        } else {
-                            sigLabelEl.attr('class', 'bar-label-outside').text(sigLabel);
-                        }
+                        // Text unchanged; placement now comes from the measured
+                        // label width (see placeBarLabel), replacing the hardcoded
+                        // 15% cutover that the wider two-number label overflowed.
+                        d3.select('#signaling-bar-label').text(sigLabel);
+                        placeBarLabel('signaling-bar', 'signaling-bar-label', Math.min(100, barPct));
                         if (vs.chain_ready) {
                             var samplingText;
                             if (vs.overall_v36_vote_pct > sigPct + 0.1) {

--- a/web-static/index.html
+++ b/web-static/index.html
@@ -31,7 +31,58 @@
             }
             
             function values(o){ res = []; for(var x in o) res.push(o[x]); return res; }
-            
+
+            // ---- progress-bar label placement -------------------------------
+            // DEFECT this fixes: every bar label is a <span> INSIDE the filled
+            // <div>, anchored `right:6px`. At 0% the fill has zero width, so that
+            // anchor sits on the track's LEFT edge and the (white-space:nowrap)
+            // label is laid out entirely at NEGATIVE x — drawn outside the canvas
+            // to the left, and clipped away completely where the track is
+            // overflow:hidden. Same thing, less severely, at any fill narrower
+            // than the label.
+            //
+            // RULE: choose inside vs outside from the label's RENDERED width
+            // against the filled width, not from a hardcoded percentage — the
+            // labels vary from "0.0%" to "95.3% chain / 60.1% window", so one
+            // fixed cutover cannot be right for both. Inside (white on the fill)
+            // whenever the fill can hold the label plus padding; otherwise on the
+            // track just right of the fill, in a dark colour that reads against
+            // the #ddd track. The outside position is CLAMPED to the track, so
+            // the label can never leave the canvas at either end.
+            //
+            // `pct` is passed rather than measured because the fill carries
+            // `transition: width 0.5s` — a getBoundingClientRect() taken right
+            // after the width is assigned still reports the OLD width.
+            var BAR_LABEL_PAD = 6;   // px gap from the fill's inner right edge
+            var BAR_LABEL_GAP = 6;   // px gap between the fill and an outside label
+            function placeBarLabel(fillId, labelId, pct) {
+                var fill = document.getElementById(fillId);
+                var label = document.getElementById(labelId);
+                if (!fill || !label) return;
+                var track = fill.parentNode;
+                var trackW = track.clientWidth;
+                if (!trackW || !label.textContent) return;
+                var p = Math.max(0, Math.min(100, pct || 0));
+                var fillW = trackW * p / 100;
+                var labelW = label.getBoundingClientRect().width;
+                if (labelW + 2 * BAR_LABEL_PAD <= fillW) {
+                    label.style.left = 'auto';
+                    label.style.right = BAR_LABEL_PAD + 'px';
+                    label.style.color = '#fff';
+                    label.style.textShadow = '0 1px 2px rgba(0,0,0,0.5)';
+                } else {
+                    // `left` is relative to the fill, whose left edge IS the
+                    // track's left edge, so these are track coordinates.
+                    var maxLeft = trackW - labelW - BAR_LABEL_PAD;
+                    var leftInTrack = Math.max(BAR_LABEL_PAD,
+                                               Math.min(fillW + BAR_LABEL_GAP, maxLeft));
+                    label.style.right = 'auto';
+                    label.style.left = leftInTrack + 'px';
+                    label.style.color = '#555';
+                    label.style.textShadow = 'none';
+                }
+            }
+
             d3.json('../local_stats', function(local_stats) {
                 d3.select('#peers_in').text(local_stats.peers.incoming);
                 d3.select('#peers_out').text(local_stats.peers.outgoing);
@@ -78,6 +129,7 @@
                         d3.select('#index-chain-maturity').style('display', 'block');
                         d3.select('#index-chain-bar').style('width', vs.chain_maturity + '%');
                         d3.select('#index-chain-bar-label').text(d3.format('.1f')(vs.chain_maturity) + '%');
+                        placeBarLabel('index-chain-bar', 'index-chain-bar-label', vs.chain_maturity);
                         d3.select('#index-chain-progress-text').text(
                             vs.chain_height + ' / ' + vs.chain_length_required + 
                             ' (' + d3.format('.1f')(vs.chain_maturity) + '%) \u2014 need ' +
@@ -89,6 +141,7 @@
                         d3.select('#index-propagation').style('display', 'block');
                         d3.select('#index-propagation-bar').style('width', vs.propagation_pct + '%');
                         d3.select('#index-propagation-bar-label').text(d3.format('.1f')(vs.overall_v36_vote_pct) + '% V36');
+                        placeBarLabel('index-propagation-bar', 'index-propagation-bar-label', vs.propagation_pct);
                         var etaMin = Math.round(vs.time_to_window_seconds / 60);
                         var etaH = Math.floor(etaMin / 60); var etaM = etaMin % 60;
                         var etaStr = etaH > 0 ? etaH + 'h ' + etaM + 'm' : etaM + 'm';
@@ -102,21 +155,18 @@
                     var sigPct = vs.sampling_signaling;
                     var barPct = vs.overall_v36_vote_pct > sigPct ? vs.overall_v36_vote_pct : sigPct;
                     d3.select('#version-signaling-bar').style('width', Math.min(100, barPct) + '%');
-                    var idxSigLabel = barPct >= 15 ? d3.format('.1f')(barPct) + '%' : '';
+                    // Text is unchanged: the two-number form only when the chain
+                    // and window figures actually differ and the bar is wide
+                    // enough to be worth it, the plain percentage otherwise.
+                    var idxSigLabel = d3.format('.1f')(barPct) + '%';
                     if (vs.overall_v36_vote_pct > sigPct + 0.1 && barPct >= 20) {
                         idxSigLabel = d3.format('.1f')(vs.overall_v36_vote_pct) + '% chain / ' + d3.format('.1f')(sigPct) + '% window';
                     }
                     d3.select('#index-signaling-bar-label').text(idxSigLabel);
-                    if (barPct < 15) {
-                        d3.select('#index-signaling-bar-label')
-                            .style('right', 'auto').style('left', 'calc(100% + 6px)')
-                            .style('color', '#555').style('text-shadow', 'none')
-                            .text(d3.format('.1f')(barPct) + '%');
-                    } else {
-                        d3.select('#index-signaling-bar-label')
-                            .style('left', null).style('right', '6px')
-                            .style('color', '#fff').style('text-shadow', '0 1px 2px rgba(0,0,0,0.5)');
-                    }
+                    // Placement now comes from the measured label width (see
+                    // placeBarLabel), replacing the hardcoded 15% cutover which
+                    // still let the wider two-number label overhang the fill.
+                    placeBarLabel('version-signaling-bar', 'index-signaling-bar-label', barPct);
                     var samplingStr;
                     if (vs.chain_ready) {
                         if (vs.overall_v36_vote_pct > sigPct + 0.1) {
@@ -526,7 +576,11 @@
             </div>
             <div id="index-chain-maturity" style="display:none; margin-top:8px;">
                 <div style="font-size:0.85em; color:#555;">Chain Maturity: <span id="index-chain-progress-text">-</span></div>
-                <div style="background:#ddd; height:20px; border-radius:10px; margin-top:4px; overflow:hidden; position:relative;">
+                <!-- overflow:visible (was hidden) so a low-fill label placed on
+                     the track to the right of the fill is not clipped away; the
+                     fill carries its own border-radius, so nothing needed the
+                     clip. Matches the other two tracks below. -->
+                <div style="background:#ddd; height:20px; border-radius:10px; margin-top:4px; overflow:visible; position:relative;">
                     <div id="index-chain-bar" style="height:100%; background:linear-gradient(90deg, #FFC107, #FF9800); width:0%; transition:width 0.5s; position:relative; border-radius:10px;"><span id="index-chain-bar-label" style="position:absolute; right:6px; top:50%; transform:translateY(-50%); font-size:0.72em; font-weight:700; color:#fff; text-shadow:0 1px 2px rgba(0,0,0,0.5); white-space:nowrap;"></span></div>
                 </div>
             </div>


### PR DESCRIPTION
Two operator-reported UX defects on the LTC v36 crossing: a ratchet that would not say why it was stuck, and a progress-bar label drawn outside its canvas.

## FIX 1 — the AutoRatchet names the blocking condition

**OBSERVABILITY ONLY. No consensus change.** No threshold, no activation condition and no state-machine behaviour is modified. The ratchet decides exactly what it decided before; only what it *says* changes. The one structural edit is that the `if (!tail_ok) / else if (!multi_party) / else activate` chain now sits behind the same two predicates it always did, with the two old refusal log lines replaced by a single unified line emitted after the branch.

**The defect.** A live LTC production node logged nothing but

```
[AutoRatchet] share_version=35 desired=36 state=VOTING
```

for over ten hours while the dashboard showed a 95.31% vote. There *were* two refusal lines, but both lived INSIDE the `full_window && vote_pct >= ACTIVATION_THRESHOLD` branch — so whenever the window was merely under-filled or under-voted, nothing was logged at all. That is the silent case and it is the common case. Answering "why" required reading this header.

**The four activation conditions**, in the order the state machine evaluates them:

| # | `blocked-by` | condition |
|---|---|---|
| 1 | `window-fill` | `total >= chain_length` |
| 2 | `vote-pct` | `vote_pct >= ACTIVATION_THRESHOLD` (95) |
| 3 | `tail-work` | the oldest 10% of the window (`[9/10*CL, CL]`) carries `>= SWITCH_THRESHOLD` (60) percent of **WORK** signalling the target — weight, not head-count |
| 4 | `self-vote-only` | `distinct_nonself_authors >= MIN_DISTINCT_NONSELF_AUTHORS` |

**What it emits now.** One greppable line per VOTING evaluation naming exactly ONE `blocked-by` — the FIRST unmet, never a list of maybes — always carrying the measurement AND the threshold that justifies it. Real captured output:

```
[AutoRatchet] VOTING blocked-by=window-fill window=120/400 vote=100% (need 95) tail10%work=n/a (need 60) nonself_authors=1 (need 1)
[AutoRatchet] VOTING blocked-by=vote-pct window=400/400 vote=80% (need 95) tail10%work=n/a (need 60) nonself_authors=1 (need 1)
[AutoRatchet] VOTING blocked-by=tail-work window=400/400 vote=95% (need 95) tail10%work=50% (need 60) nonself_authors=1 (need 1) eta_shares<=20 eta<=0.0h
[AutoRatchet] VOTING blocked-by=self-vote-only window=400/400 vote=100% (need 95) tail10%work=100% (need 60) nonself_authors=0 (need 1)
```

- **`n/a` is load-bearing.** The work-weighted tail is only measured once conditions 1 and 2 already hold. When an earlier condition short-circuits, the tail field prints `n/a`, never `0%`. A zero that silently means "not measured" is exactly the trap this change exists to remove. `first_unmet` treats an unmeasured tail as blocking, so it can never report activate-ready off a tail nobody looked at.
- **Rate-limited.** This runs once per share. It logs on CHANGE of `blocked-by`, plus a heartbeat every 60 evaluations (~15 min at LTC's 15s share period). The limiter is per-instance, not a function-local static in a header-inline method.
- **ETA, tail guard only.** The tail is always depths `[tail_start, tail_start+tail_size)` from the tip, so a share now at depth `d` has left it after `k >= tail_start + tail_size - d` further shares. The binding one is the shallowest non-signalling share in the sample, giving `eta_shares = (tail_start + tail_size) - newest_nonsignal_depth`, converted to hours at `PoolConfig::share_period()`. It is printed as `<=`: it assumes every future share signals, and the 60%-by-work gate needs only 60%, not 100%, so it can clear earlier. When the sample holds no non-signalling share the number is not derivable and nothing is printed rather than a guess.

## FIX 2 — the bar label stays inside the canvas

**The defect, diagnosed from the markup.** Each percentage label is a `<span>` INSIDE the *filled* `<div>`, anchored `position:absolute; right:6px`. At 0% the fill has zero width, so that anchor sits on the track's LEFT edge, and because the label is `white-space:nowrap` it is laid out entirely at negative x — drawn outside the canvas to the left, and clipped away completely where the track was `overflow:hidden`.

**The switch rule.** Placement now comes from the label's RENDERED width against the filled width, not a hardcoded percentage — the labels range from `0.0%` to `95.3% chain / 60.1% window`, so no single fixed cutover can be right for both.

- fill can hold `label + 2x6px` padding → INSIDE the fill, white with a text shadow, as today;
- otherwise → OUTSIDE, on the track 6px right of the fill, in a dark colour that reads against the track;
- the outside position is CLAMPED to `[6px, trackWidth - labelWidth - 6px]`, so the label can never leave the canvas at either end, including at 100%.

The percentage is derived from the passed `pct` rather than measured, because the fill carries `transition: width 0.5s` and a `getBoundingClientRect()` taken right after the width is assigned still reports the OLD width.

**Numbers displayed are unchanged** — only placement.

Applied to all three bars in `index.html` and all five in `dashboard.html`. The previous hardcoded 15% cutover on the sampling-signaling bar is replaced: at exactly 15% the wider two-number label still overhung the left edge by 94px. `index.html`'s chain-maturity track becomes `overflow:visible` (the fill carries its own `border-radius`, so nothing needed the clip; the other two tracks were already visible). `miner.html` and `share.html` do not carry this widget. `#v36_signal_pct` in `dashboard.html` is a plain text stat, not a bar, and is untouched.

The markup IS duplicated between `index.html` (inline styles) and `dashboard.html` (`.bar-label` / `.bar-label-outside` classes). Rather than diverge them, the same `placeBarLabel(fillId, labelId, pct)` helper with the same rule and the same constants is added to each, adapted to that page's styling mechanism.

## Verification

**Fix 1** — 12 new KATs folded into the existing allowlisted `share_test` target (a new `add_executable` would be absent from `build.yml`'s `--target` list and become a NOT_BUILT ctest sentinel).

- Layer A drives the real `AutoRatchet::first_unmet` — one KAT per `blocked-by` value, the all-pass `NONE` case, and a precedence KAT pinning that a window failing all four names only the first.
- Layer B drives the real `AutoRatchet::get_share_version` over a REAL populated `ltc::ShareTracker`, provoking each of the four blockers by chain shape alone and reading back what the node actually logged through a Boost.Log sink. The negative twin asserts an all-conditions-pass window logs NO blocked line AND actually reaches ACTIVATED.

```
ctest -R "LTC_RatchetBlockedBy|RatchetExplainLine" -V   ->  12/12 passed, 0 failed
./src/impl/ltc/test/share_test                          ->  77/77 passed (whole LTC suite)
ctest -R LtcG3aPopulated                                ->   1/1  passed
cmake --build build_ci --target c2pool                  ->  production LTC binary builds
```

Each KAT was proven able to fail by mutating the production code: swapping the evaluation order, deleting the `window-fill` return, printing `0%` instead of `n/a`, dropping the ETA, removing the rate limiter, treating an unmeasured tail as a pass, removing the self-vote guard, logging on `NONE`, and suppressing the activation itself. Every mutation reddened the intended KAT; all were reverted.

**Fix 2** — both pages rendered in a headless browser against a stub API at 0%, 1%, 15%, 50%, 95% and 100%, on `index.html` and on `dashboard.html` in both VOTING and ACTIVATED layouts, at a 1280px and a 420px viewport, with both the short and the wide label variants. Measured label bounds vs track bounds:

| | measurements | outside-canvas violations |
|---|---|---|
| before | 48 | 12 |
| after | 48 | **0** |

The reported case, `index.html` propagation bar at 0%: track `[20, 1260]`, label **`[-48, 14]`** before — 68px off the left edge — and `[26, 88]` after, fully inside. Narrow-viewport wide-label run: 17 violations before, 0 after.
