### PR TITLE
ci(runner-host): orphan-reaper default path covers all CI builds (re-provision durability)

### DIFF
--- a/deploy/systemd/c2pool-runner-orphan-reaper.README.md
+++ b/deploy/systemd/c2pool-runner-orphan-reaper.README.md
@@ -11,7 +11,7 @@ Script: `scripts/ci/runner-orphan-reaper-linux.sh` (self-documenting header).
 ## Why ppid=1 is the signal
 A legit compiler always has a live `Runner.Worker` ancestor. When the Worker
 dies, the kernel reparents its orphans to pid 1 — so `ppid=1` + build-comm +
-under `_work/.../build_codeql` = orphaned, by construction. This is safe on
+under `_work/.../build` (incl. build_codeql) = orphaned, by construction. This is safe on
 **multi-runner hosts** (VM905 = 8 runners): a busy sibling runner's compilers
 are children of *its* live Worker, never `ppid=1`, so they are never touched.
 An age floor (>15 min) is layered on as belt-and-suspenders. The script also
@@ -37,8 +37,9 @@ never touch a tree under a live Runner.Worker).
     journalctl --user -u c2pool-runner-orphan-reaper.service -n 50
 
 ## Tunables (env; defaults match the .198 incident)
-- `REAP_PATH_RE`    build-tree path regex. Default `_work/.*build_codeql`;
-                    widen to `_work/.*/build` to cover all CI builds.
+- `REAP_PATH_RE`    build-tree path regex. Default `_work/.*/build` (covers
+                    both build_codeql and the coin-matrix build dir). Narrow to
+                    `_work/.*build_codeql` for CodeQL-only hosts.
 - `REAP_COMM_RE`    toolchain leader `comm` set.
 - `REAP_MIN_AGE`    age floor, seconds (default 900).
 - `REAP_ROOT_PPID`  orphan-root parent pid (default 1; change only if the host

--- a/scripts/ci/runner-orphan-reaper-linux.sh
+++ b/scripts/ci/runner-orphan-reaper-linux.sh
@@ -51,7 +51,7 @@ DRY_RUN=0
 REAP_COMM_RE="${REAP_COMM_RE:-^(cmake|gmake|make|cc1plus|cc1|cc|c\+\+)$}"
 # cwd/argv must match this to be a CI build tree. Defaults to the CodeQL build
 # dir from the incident; widen to '_work/.*/build' to cover all CI builds.
-REAP_PATH_RE="${REAP_PATH_RE:-_work/.*build_codeql}"
+REAP_PATH_RE="${REAP_PATH_RE:-_work/.*/build}"
 # orphan-root parent pid. Kernel reparents orphans to 1 (init); no subreaper
 # sits in the runner tree. Override only if a host installs a subreaper.
 REAP_ROOT_PPID="${REAP_ROOT_PPID:-1}"


### PR DESCRIPTION
Reconciles the hand-installed reaper dropin (REAP_PATH_RE=_work/.*/build, sha fed9686 by vm-fleet-steward) into the master canonical path.

**Finding.** master already carries the reaper canonically (deploy/systemd/c2pool-runner-orphan-reaper.{service,timer} + scripts/ci/runner-orphan-reaper-linux.sh + README, landed 40c07634). The install path is the README manual procedure — there is no automated re-provision hook for runner-host user units. The durability gap is not the units, it is the script default: REAP_PATH_RE=_work/.*build_codeql (CodeQL leg only). A faithful re-provision from master would restore that narrow default and drop the coin-matrix build-dir coverage the hand-install dropin supplies.

**Change.** Widen the canonical default to _work/.*/build (strict superset — matches build_codeql as a substring too). Safety is unchanged: kills stay gated by ppid=1 + explicit Runner.Worker-ancestor walk + >15min age floor; the path regex only scopes which trees are considered. Proven safe by the live hand-install reaping clean on .198 and VM905 (.178) at 2026-08-02 19:06Z. README tunable doc + rationale updated to match.

After this lands the single-source default carries both legs, so no per-host dropin is needed and re-provision preserves coverage. Not self-merging; awaiting integrator gate.