### PR TITLE
dash(embedded): answer the maintainer's MN re-seed ask with a capped bridge re-arm

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -3708,17 +3708,62 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                         mnl->on_block_connected(bc.block, bc.height);
                     }));
 
-            // KNOWN GAP, deliberately left: this branch arms the lane and
-            // sets NO maintainer->set_on_mn_reseed() callback (the RPC branch
-            // above does). If the maintainer later wipes a desynced payee
-            // queue it has nothing to ask for a fresh authoritative set, so
-            // the embedded arm stays demoted until restart. Filling that seam
-            // is real work and depends on what fills it — a re-armed bridge
-            // from a NEWER anchor is the obvious candidate and is exactly the
-            // wrong-axis trap the anchor-selection TODO in
-            // mn_checkpoint_lane.hpp describes (an anchor cut after the
-            // divergence began replays cleanly and re-arms a wrong queue).
-            // Not wired here rather than wired wrongly.
+            // ── THE RE-SEED SEAM, now WIRED (was the KNOWN GAP) ───────────
+            // CoinStateMaintainer::on_block_connected, on a payee DESYNC or an
+            // apply GAP, wipes the payee set, latches m_mn_needs_reseed,
+            // demotes to the dashd fallback and calls m_on_mn_reseed(). The RPC
+            // branch above answers it with a fresh `protx list valid`. This
+            // branch used to answer it with NOTHING — the ask went into a void.
+            //
+            // MEASURED, contabo daemonless soak: the ask fired THREE times in
+            // one run (h=2513168, 2513261, 2515266). The last is ABOVE the
+            // bridge's own failure height, i.e. it fires on LIVE TIP ADVANCES,
+            // independently of any bridge replay. Nothing answered, so the
+            // payee set stayed wiped for the rest of the run and only a restart
+            // recovered it.
+            //
+            // The answer is a bridge RE-ARM from the SAME release-pinned
+            // anchor. NOT a newer one: an anchor cut AFTER a divergence began
+            // replays cleanly over a shorter window and re-arms a queue that is
+            // already wrong, which mints a coinbase the network rejects.
+            // MnCheckpointLane::rearm() refuses a newer anchor terminally, caps
+            // the re-arms, backs off in blocks between them, and names every
+            // outcome. See its header block for the policy and for what a
+            // genuine oldest-first LADDER would still need (a multi-anchor
+            // store that does not exist in this build).
+            //
+            // ORDERING IS SAFE: m_on_mn_reseed fires AFTER the maintainer has
+            // wiped the set, latched and demoted — so the embedded arm is
+            // already down and stays down until this bridge PUBLISHES through
+            // the leg-4 event, which is the only thing that clears the latch.
+            // Same io thread, no lock held (the lane takes none). The anchor is
+            // captured BY VALUE rather than re-parsed per ask: parsing is not
+            // free and a deferred ask must stay cheap.
+            maintainer->set_on_mn_reseed(
+                [mnl = mn_ckpt_lane.get(), anchor = ckpt]() {
+                    using Lane    = dash::coin::MnCheckpointLane;
+                    const auto out = mnl->rearm(
+                        anchor,
+                        "CoinStateMaintainer wiped a desynced/gapped payee"
+                        " queue and asked for an authoritative re-seed");
+                    std::cout << "[run] E2d MN-set RE-SEED ask -> bridge re-arm "
+                              << Lane::rearm_outcome_name(out)
+                              << " (" << mnl->rearms() << "/"
+                              << mnl->rearm_cap() << " re-arms used, "
+                              << mnl->rearm_asks() << " asks) — "
+                              << mnl->last_rearm_reason() << "\n";
+                    if (out != Lane::RearmOutcome::Armed) {
+                        std::cout << "[run] the embedded DASH arm stays DEMOTED;"
+                                     " templates keep routing to the dashd"
+                                     " fallback arm (if configured). No"
+                                     " masternode payee will be guessed.\n";
+                        return;
+                    }
+                    // Drive it immediately: the header chain is already well
+                    // past the anchor, so the replay starts on this call rather
+                    // than waiting for the next tip change.
+                    mnl->pump();
+                });
 
             // Kick the lane once now in case the header chain is already past
             // the anchor from a previous run's persisted header DB.

--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -179,20 +179,27 @@
 ///   The removal pass narrows it — a banned member is now dropped from the
 ///   group before it can be projected — but does not close it.
 ///
-/// TODO (separate change, deliberately NOT half-done here): ANCHOR SELECTION
-/// ON REPEAT DESYNC. When a bridge fails closed and the operator re-arms,
-/// picking the NEWEST anchor is wrong: an anchor cut AFTER a divergence began
-/// replays cleanly over a shorter window and re-arms a queue that is already
-/// wrong, which mints a rejected coinbase. The correct policy is oldest-first
-/// on a repeat desync, with capped re-arms + backoff and the compiled-in
-/// checkpoint as the floor. It is not implementable in this file today: this
-/// build carries exactly ONE anchor per network
+/// ANCHOR SELECTION ON REPEAT DESYNC — PARTLY DONE, AND THE REST IS SCOPED
+/// RATHER THAN HALF-BUILT. rearm() (below) now answers the maintainer's
+/// authoritative-re-seed ask on the daemonless arm, capped and backed off, and
+/// it enforces the half of the policy this build CAN enforce: never an anchor
+/// newer than the one in use, never one at or after the earliest observed
+/// divergence, always the release-pinned floor. Picking the NEWEST anchor is
+/// wrong — an anchor cut AFTER a divergence began replays cleanly over a
+/// shorter window and re-arms a queue that is already wrong, which mints a
+/// rejected coinbase — and that case is now REFUSED terminally rather than
+/// merely warned about.
+///
+/// STILL MISSING, and required before a genuine oldest-first LADDER exists:
+/// this build carries exactly ONE anchor per network
 /// (src/impl/dash/coin/checkpoints/dash_mn_checkpoint_{mainnet,testnet}.inc,
-/// referenced once from main_dash.cpp), there is no anchor LIST to order and
-/// no persisted desync history to count re-arms against across restarts.
-/// Prerequisites: (1) a multi-anchor checkpoint store keyed by height,
-/// (2) a persisted per-anchor desync counter, (3) an arm()/re-arm API that
-/// takes a candidate list rather than a single MnCheckpoint.
+/// referenced once from main_dash.cpp), so there is no anchor LIST to order and
+/// no persisted desync history to count re-arms against ACROSS RESTARTS (the
+/// cap here is per-process). Prerequisites, unchanged: (1) a multi-anchor
+/// checkpoint store keyed by height, (2) a persisted per-anchor desync counter,
+/// (3) an arm()/re-arm API that takes a candidate list rather than a single
+/// MnCheckpoint. Until (1) exists, "oldest-first" and "the compiled-in anchor"
+/// are the same choice, which is why re-arming from it is legitimate today.
 ///
 /// FENCED: src/impl/dash only. Constructed exclusively by the opt-in embedded
 /// path in main_dash.cpp; the dashd-RPC fallback never touches this file.
@@ -212,6 +219,7 @@
 #include <cstdint>
 #include <functional>
 #include <optional>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -272,6 +280,26 @@ public:
         Published,    ///< set handed to the maintainer; lane is done
         FailedClosed, ///< terminal refusal — the arm must NOT serve templates
     };
+
+    /// What rearm() did. Every value is a NAMED outcome an operator can grep;
+    /// there is no "returned false, good luck" case.
+    enum class RearmOutcome {
+        Armed,        ///< the bridge is re-armed and will replay from the anchor
+        Deferred,     ///< backoff not satisfied yet — try again on a later trigger
+        CapExhausted, ///< TERMINAL: the re-arm budget is spent, the arm stays down
+        Refused,      ///< TERMINAL: this anchor may not be used (see the log)
+    };
+
+    static const char* rearm_outcome_name(RearmOutcome o)
+    {
+        switch (o) {
+            case RearmOutcome::Armed:        return "ARMED";
+            case RearmOutcome::Deferred:     return "DEFERRED";
+            case RearmOutcome::CapExhausted: return "CAP-EXHAUSTED";
+            case RearmOutcome::Refused:      return "REFUSED";
+        }
+        return "UNKNOWN";
+    }
 
     /// ~34 days of DASH blocks at 2.5 min spacing. Chosen so a release cut
     /// within the last month bridges in minutes over the coin-P2P feed, and
@@ -354,46 +382,7 @@ public:
             LOG_ERROR << "[MN-CKPT] " << m_status;
             return;
         }
-        m_anchor_height = cp.height;
-        m_anchor_hash   = cp.blockhash;
-        m_anchor_source = cp.source;
-        m_anchor_count  = cp.entries.size();
-        m_machine.load(cp.entries, cp.height);
-        // F6: reset the one-shot fold latch and its counters. The latch is the
-        // dangerous one — a second bridge on a re-armed lane would run
-        // additions-only while sml_folded() still reported true, i.e. it would
-        // LIE about having applied removals.
-        m_sml_folded       = false;
-        m_sml_folded_at    = 0;
-        m_folds            = 0;
-        m_first_fold_height = 0;
-        m_last_fold_height = 0;
-        m_anchor_fold_done = false;
-        m_snapshot_pending = false;
-        m_snapshot_hash    = uint256();
-        m_snapshot_height  = 0;
-        m_snapshot_waits   = 0;
-        m_abandoned_folds  = 0;
-        m_abandoned.clear();
-        m_ondemand_pending  = false;
-        m_ondemand_height   = 0;
-        m_ondemand_folds    = 0;
-        m_ondemand_excluded = 0;
-        m_ondemand_cap_hit  = false;
-        m_ondemand_evaluated = false;
-        m_ondemand_abandoned = 0;
-        m_ondemand_block    = BlockType{};
-        m_ondemand_r        = MnStateMachine::ApplyResult{};
-        m_pose_removed    = 0;
-        m_pose_reinstated = 0;
-        m_sml_recovered   = 0;
-        m_registered      = 0;
-        m_spent           = 0;
-        m_applied         = 0;
-        m_warned_no_sml   = false;
-        m_anchor_eligible = m_machine.eligible_size();
-        m_next  = cp.height + 1;
-        m_state = State::Waiting;
+        reset_for_arm(cp);
         m_status = "armed at h=" + std::to_string(cp.height) + " ("
                    + std::to_string(m_anchor_count) + " masternodes), waiting"
                      " for headers to reach the anchor";
@@ -401,6 +390,239 @@ public:
                  << cp.blockhash.GetHex().substr(0, 16) << " count="
                  << m_anchor_count << " source='" << cp.source << "'";
     }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // RE-ARM — the answer to CoinStateMaintainer's authoritative-re-seed ask
+    // ─────────────────────────────────────────────────────────────────────
+    //
+    // WHAT WAS BROKEN. CoinStateMaintainer::on_block_connected, on a payee
+    // DESYNC or an apply GAP, wipes the payee set, latches m_mn_needs_reseed,
+    // demotes to the dashd fallback and calls m_on_mn_reseed(). On the
+    // dashd-RPC arm that callback re-runs `protx list valid`. On the DAEMONLESS
+    // arm main_dash set NO callback at all, so the ask went into a void: MEASURED
+    // on the contabo daemonless soak, three times in one run (h=2513168,
+    // 2513261, 2515266 — the last ABOVE the bridge's own failure height, i.e.
+    // on a LIVE tip advance, not a bridge-replay artefact). The payee set stayed
+    // wiped for the rest of the run and only a restart recovered it.
+    //
+    // WHAT ANSWERS IT NOW. A bridge RE-ARM: reload the anchor, replay forward to
+    // the current tip, publish through the same leg-4 event. arm() alone cannot
+    // do this — it assumes a VIRGIN lane and both terminal states are one-way —
+    // so the reset is factored into reset_for_arm(), which arm() and rearm()
+    // BOTH call. That is deliberate: two hand-maintained reset lists drift, and
+    // a field the second list forgets is a silent wrong-set bug, not a crash.
+    //
+    // ANCHOR SELECTION — THE TRAP THIS MUST NOT FALL INTO. On a REPEAT desync,
+    // picking the NEWEST anchor is WRONG: an anchor cut AFTER a divergence began
+    // replays perfectly cleanly over a shorter window and re-arms a queue that
+    // is ALREADY wrong, which mints a coinbase the network rejects — the exact
+    // failure this whole lane exists to prevent. The correct policy is
+    // OLDEST-FIRST. This build carries exactly ONE anchor per network, so:
+    //
+    //   • re-arming from the SAME compiled-in anchor is legitimate — it is the
+    //     release-pinned trust root, it is by construction not newer than any
+    //     divergence this process has observed, and it is the floor of any
+    //     future ladder.
+    //   • an anchor NEWER than the one in use, or at/after the earliest
+    //     divergence we have evidence of, is REFUSED TERMINALLY. It is a wiring
+    //     error, it is deterministic, and retrying it forever would be a
+    //     fail-loop dressed as recovery.
+    //
+    // A genuine oldest-first LADDER still needs what the TODO at the top of this
+    // file lists and this change does NOT half-build: a multi-anchor store keyed
+    // by height, a persisted per-anchor desync counter, and an arm() that takes
+    // a candidate list. Scoped, not started.
+    //
+    // CAP + BACKOFF. An unbounded re-arm against a deterministic failure is a
+    // fail-loop with extra steps — worse than staying down, because it hides the
+    // problem. Cap: kMaxRearms. Backoff: measured in BLOCKS observed at the tip
+    // seam (the lane owns no timer and must not grow one), doubling per attempt.
+    // Neither counter is reset by a successful publish: a bridge that publishes
+    // and then desyncs AGAIN is precisely the loop being bounded.
+
+    /// How many re-arms one process will attempt. THREE, because three is what
+    /// the measurement showed: the soak's live path asked three times in one
+    /// run. A fourth ask inside one process is no longer "a transient desync",
+    /// it is a standing disagreement between our replayed queue and the chain,
+    /// and the honest response is to stay down loudly.
+    static constexpr uint32_t kMaxRearms = 3;
+    /// Blocks that must pass at the tip before the SECOND re-arm; doubled for
+    /// each one after that (64, then 128). Sized off the same measurement: the
+    /// observed repeat gaps were 93 and 2005 blocks, so 64 admits both real
+    /// repeats while refusing the pathological back-to-back retry that would
+    /// replay the identical window and fail identically.
+    static constexpr uint32_t kRearmBackoffBlocks = 64;
+
+    /// Re-arm the bridge after the maintainer wiped a desynced payee queue.
+    /// `why` is the operator-facing trigger text and appears in every line.
+    RearmOutcome rearm(const MnCheckpoint& cp, const std::string& why)
+    {
+        ++m_rearm_asks;
+        // A field never evaluated prints "n/a", never "0" — 0 is a height.
+        const bool     have_tip = static_cast<bool>(m_tip_height);
+        const uint32_t at       = have_tip ? m_tip_height() : 0;
+        const std::string at_s  = have_tip ? std::to_string(at)
+                                           : std::string("n/a");
+        const std::string attempt_s = std::to_string(m_rearms + 1) + "/"
+                                      + std::to_string(kMaxRearms);
+        auto say = [&](RearmOutcome o, const std::string& detail) {
+            m_last_rearm_reason = std::string(rearm_outcome_name(o)) + ": "
+                                  + detail;
+            std::ostringstream ln;
+            ln << "[MN-CKPT] RE-ARM " << rearm_outcome_name(o)
+               << " (ask #" << m_rearm_asks << ", attempt " << attempt_s
+               << ", " << m_rearms << " already used)"
+               << " trigger='" << why << "'"
+               << " anchor h=" << (cp.ok ? std::to_string(cp.height)
+                                         : std::string("n/a"))
+               << " source='" << (cp.ok ? cp.source : std::string("n/a")) << "'"
+               << " observed tip h=" << at_s
+               << " last re-arm at h="
+               << (m_rearms == 0 ? std::string("n/a")
+                                 : (m_last_rearm_at_known
+                                        ? std::to_string(m_last_rearm_at)
+                                        : std::string("n/a")))
+               << " — " << detail;
+            if (o == RearmOutcome::Armed) LOG_INFO << ln.str();
+            else if (o == RearmOutcome::Deferred) LOG_WARNING << ln.str();
+            else LOG_ERROR << ln.str();
+            return o;
+        };
+
+        if (m_rearm_blocked) {
+            return say(RearmOutcome::Refused,
+                       "re-arming is TERMINALLY BLOCKED for this process: "
+                       + m_rearm_block_reason
+                       + ". The embedded DASH arm stays demoted to the dashd"
+                         " fallback until the operator restarts with a fixed"
+                         " anchor or a coin RPC (--coin-rpc-*).");
+        }
+        if (m_rearms >= kMaxRearms) {
+            m_rearm_blocked = true;
+            m_rearm_block_reason =
+                "the re-arm cap of " + std::to_string(kMaxRearms)
+                + " is EXHAUSTED";
+            return say(RearmOutcome::CapExhausted,
+                       "the re-arm cap of " + std::to_string(kMaxRearms)
+                       + " is EXHAUSTED. Our replayed payee queue keeps"
+                         " diverging from the chain, so re-replaying the SAME"
+                         " release-pinned anchor will keep producing the SAME"
+                         " wrong queue. STAYING DOWN ON PURPOSE — a fourth"
+                         " re-arm would be a fail-loop that hides this. The"
+                         " embedded DASH arm will NOT serve templates;"
+                         " templates keep routing to the dashd fallback arm (if"
+                         " configured). Fix: upgrade to a release carrying a"
+                         " fresher masternode-set anchor, or run with a coin"
+                         " RPC (--coin-rpc-*) so the authoritative protx seed"
+                         " is used.");
+        }
+        if (!cp.ok) {
+            m_rearm_blocked      = true;
+            m_rearm_block_reason = "the candidate anchor does not parse ("
+                                   + cp.error + ")";
+            return say(RearmOutcome::Refused,
+                       "the candidate anchor does not parse: " + cp.error
+                       + ". Nothing to re-arm from.");
+        }
+
+        // ── THE ANCHOR-SELECTION GUARD (never newest-first) ───────────────
+        // Record the earliest height at which we have evidence of divergence.
+        // Every re-seed ask IS such evidence: the maintainer only calls back
+        // after apply_block reported a payee desync or an apply gap.
+        if (have_tip && (m_first_divergence == 0 || at < m_first_divergence))
+            m_first_divergence = at;
+
+        if (m_anchor_height != 0 && cp.height > m_anchor_height) {
+            m_rearm_blocked = true;
+            m_rearm_block_reason =
+                "the candidate anchor h=" + std::to_string(cp.height)
+                + " is NEWER than the anchor already in use h="
+                + std::to_string(m_anchor_height);
+            return say(RearmOutcome::Refused,
+                       "REFUSING A NEWER ANCHOR. Candidate h="
+                       + std::to_string(cp.height) + " is newer than the anchor"
+                         " already in use h=" + std::to_string(m_anchor_height)
+                       + ". On a REPEAT desync an anchor cut AFTER the"
+                         " divergence began replays cleanly over a shorter"
+                         " window and re-arms a queue that is ALREADY wrong —"
+                         " which mints a coinbase the network rejects. Policy"
+                         " is oldest-first with the compiled-in checkpoint as"
+                         " the floor; this build carries one anchor per network"
+                         " and there is no older one to fall back to.");
+        }
+        if (m_first_divergence != 0 && cp.height >= m_first_divergence) {
+            m_rearm_blocked = true;
+            m_rearm_block_reason =
+                "the candidate anchor h=" + std::to_string(cp.height)
+                + " is at or after the earliest observed divergence h="
+                + std::to_string(m_first_divergence);
+            return say(RearmOutcome::Refused,
+                       "REFUSING AN ANCHOR AT OR AFTER THE DIVERGENCE."
+                       " Candidate h=" + std::to_string(cp.height)
+                       + " is not strictly older than the earliest divergence"
+                         " we have evidence of (h="
+                       + std::to_string(m_first_divergence)
+                       + "). Such an anchor replays cleanly BECAUSE it already"
+                         " contains the divergence — it would re-arm a wrong"
+                         " queue and mint a rejected coinbase.");
+        }
+
+        // ── BACKOFF ──────────────────────────────────────────────────────
+        if (m_rearms > 0) {
+            const uint32_t need = kRearmBackoffBlocks << (m_rearms - 1);
+            if (!have_tip || !m_last_rearm_at_known) {
+                return say(RearmOutcome::Deferred,
+                           "cannot evaluate the " + std::to_string(need)
+                           + "-block backoff: no tip-height seam is wired, so"
+                             " the lane cannot tell how far the chain has moved"
+                             " since the last re-arm. Deferring rather than"
+                             " guessing.");
+            }
+            if (at < m_last_rearm_at + need) {
+                return say(RearmOutcome::Deferred,
+                           "BACKOFF: only "
+                           + std::to_string(at - m_last_rearm_at)
+                           + " blocks since the last re-arm at h="
+                           + std::to_string(m_last_rearm_at) + ", need "
+                           + std::to_string(need)
+                           + ". Re-replaying the same window immediately would"
+                             " fail identically. The arm stays down until the"
+                             " chain has moved on; this attempt is NOT counted"
+                             " against the cap.");
+            }
+        }
+
+        ++m_rearms;
+        m_last_rearm_at       = at;
+        m_last_rearm_at_known = have_tip;
+        reset_for_arm(cp);
+        m_status = "RE-ARMED " + std::to_string(m_rearms) + "/"
+                   + std::to_string(kMaxRearms) + " at h="
+                   + std::to_string(cp.height) + " ("
+                   + std::to_string(m_anchor_count) + " masternodes) after "
+                   + why + "; replaying forward to the tip";
+        return say(RearmOutcome::Armed,
+                   "re-armed from the release-pinned anchor (the trust root, and"
+                   " by construction not newer than any observed divergence);"
+                   " replaying anchor+1..tip. Until this bridge PUBLISHES the"
+                   " embedded arm stays demoted and templates keep routing to"
+                   " the dashd fallback.");
+    }
+
+    /// How many re-arms have actually been spent against the cap.
+    uint32_t rearms() const           { return m_rearms; }
+    /// How many times a re-seed was ASKED for, including deferrals and
+    /// refusals. Deliberately distinct from rearms(): "asked 9 times, re-armed
+    /// 3" and "asked 3 times, re-armed 3" are different diagnoses.
+    uint32_t rearm_asks() const       { return m_rearm_asks; }
+    uint32_t rearm_cap() const        { return kMaxRearms; }
+    bool     rearm_blocked() const    { return m_rearm_blocked; }
+    /// The last named outcome, verbatim. Empty until the first ask — which is
+    /// itself the answer to "was a re-seed ever asked for".
+    const std::string& last_rearm_reason() const { return m_last_rearm_reason; }
+    /// The earliest height at which a re-seed ask gave us evidence of
+    /// divergence; 0 = no such evidence (never a valid height here).
+    uint32_t first_divergence_height() const { return m_first_divergence; }
 
     State              state()  const { return m_state; }
     const std::string& status() const { return m_status; }
@@ -440,10 +662,43 @@ public:
     size_t   ondemand_cap()       const { return m_ondemand_cap; }
     bool     ondemand_cap_hit()   const { return m_ondemand_cap_hit; }
     bool     ondemand_evaluated() const { return m_ondemand_evaluated; }
+    /// On-demand asks that were never answered. #1033 kept this SEPARATE from
+    /// m_abandoned_folds on purpose (reusing that one made the report claim
+    /// "the replay carried on degraded" when it had not); it is surfaced here
+    /// for the same reason the fold counters are — and so a re-arm can be
+    /// proven to clear it.
+    size_t   ondemand_abandoned() const { return m_ondemand_abandoned; }
+    /// #1033's preserved mismatch context, read through the lane. A re-arm
+    /// reloads the anchor via MnStateMachine::load(), which already drops
+    /// this — exposing it is how that path is PROVEN to be reached rather
+    /// than assumed.
+    const MnStateMachine::PendingPayeeAdjudication&
+    pending_payee_adjudication() const
+    {
+        return m_machine.pending_payee_adjudication();
+    }
     size_t   replay_registered()  const { return m_registered; }
     size_t   replay_spent()       const { return m_spent; }
     bool     failed_closed() const { return m_state == State::FailedClosed; }
     bool     published()     const { return m_state == State::Published; }
+    /// ── The RE-ARM RESET witnesses ────────────────────────────────────────
+    /// Exposed so a test can assert that rearm() actually cleared them, not
+    /// merely that the lane "looked armed". Each of these was set by a
+    /// COMPLETED bridge and, before reset_for_arm() existed, survived arm():
+    /// m_requested_through is the load-bearing one — left stale it makes
+    /// request_window() compute `from > end` and issue NO getdata at all, so a
+    /// re-armed bridge would sit at its cursor forever with no symptom.
+    bool     position_verified()  const { return m_position_verified; }
+    uint32_t requested_through()  const { return m_requested_through; }
+    uint32_t stalled_pumps()      const { return m_stalled_pumps; }
+    size_t   sml_recovery_cap()   const { return m_sml_recovery_cap; }
+    /// The machine's SPENT per-bridge demotion-walk budget. MnStateMachine::
+    /// load() does not zero it, so a re-armed bridge would otherwise inherit
+    /// the previous bridge's spend and fail closed on its first PoSe ban.
+    size_t   sml_recovery_spent() const { return m_machine.sml_recovered_total(); }
+    uint32_t last_fold_height()   const { return m_last_fold_height; }
+    bool     anchor_fold_done()   const { return m_anchor_fold_done; }
+    size_t   replay_applied()     const { return m_applied; }
 
     /// Drive the bridge: verify the anchor's chain position once the header
     /// chain reaches it, enforce the staleness bound, request the next window
@@ -1471,6 +1726,15 @@ public:
             m_status += " — NO per-height fold was ever applied; this set is"
                         " the additions-only replay plus the walk";
         }
+        // A publish that is the OUTPUT OF A RE-ARM must not read like a clean
+        // cold start. It is a recovery from a payee desync, and how much of the
+        // per-process budget it consumed is the operator's warning that the
+        // next desync may be the last one this process can answer.
+        if (m_rearms != 0) {
+            m_status += " [RE-ARM " + std::to_string(m_rearms) + "/"
+                        + std::to_string(kMaxRearms) + " — this set is a"
+                          " recovery from a payee desync, not a cold start]";
+        }
         LOG_INFO << "[MN-CKPT] bridge COMPLETE: published " << out.size()
                  << " masternodes (" << m_sml_recovered
                  << " SML-recovered exclusions) as-of h=" << as_of
@@ -1491,6 +1755,141 @@ public:
         LOG_ERROR << "[MN-CKPT] the embedded DASH template arm will NOT serve;"
                      " templates keep routing to the dashd fallback arm (if"
                      " configured). No masternode payee will be guessed.";
+        // Say which generation of the bridge this was, and whether any budget
+        // to try again remains. "FAIL-CLOSED" on its own does not distinguish
+        // "first attempt, three re-arms left" from "last attempt, nothing left".
+        LOG_ERROR << "[MN-CKPT] RE-ARM POSTURE: "
+                  << (m_rearms == 0 ? std::string("this was the ORIGINAL arm")
+                                    : ("this was RE-ARM " + std::to_string(m_rearms)
+                                       + "/" + std::to_string(kMaxRearms)))
+                  << "; re-seed asks so far: " << m_rearm_asks << "; "
+                  << (m_rearm_blocked
+                          ? ("further re-arms are TERMINALLY BLOCKED ("
+                             + m_rearm_block_reason + ")")
+                          : ("re-arms remaining: "
+                             + std::to_string(kMaxRearms - m_rearms)
+                             + " — a further payee desync from the maintainer"
+                               " will trigger one"))
+                  << ". Last re-arm outcome: "
+                  << (m_last_rearm_reason.empty()
+                          ? std::string("n/a (no re-seed has ever been asked"
+                                        " for)")
+                          : m_last_rearm_reason);
+    }
+
+    /// EVERY field an arm starts from, in ONE place.
+    ///
+    /// arm() and rearm() both call this. That is the whole point: a second,
+    /// hand-maintained reset list inside rearm() would drift from this one, and
+    /// a field it forgot would not crash — it would publish a WRONG masternode
+    /// set. "rearm() resets everything arm() sets" is therefore true by
+    /// construction rather than by review.
+    ///
+    /// It also resets seven fields the old arm() did NOT, all of which are
+    /// harmless on a virgin lane (they are zero-initialised, so this is a no-op
+    /// at startup) and all of which are bugs on a re-arm:
+    ///
+    ///   m_requested_through     — stale => request_window() computes from>end
+    ///                             and issues NO getdata; the bridge wedges.
+    ///   m_last_pump_next        — stale => the stall probe fires (or fails to)
+    ///                             against the PREVIOUS bridge's cursor.
+    ///   m_stalled_pumps         — stale => a fresh bridge inherits a stall
+    ///                             count it did not earn.
+    ///   m_rerequest_from_cursor — stale => one spurious full-window re-request.
+    ///   m_position_verified     — stale => a DIFFERENT anchor would skip the
+    ///                             chain-position check entirely.
+    ///   m_last_wait_log         — stale => the "waiting for headers" line is
+    ///                             suppressed for the whole next decade of
+    ///                             heights.
+    ///   m_sml_recovery_cap      — stale => status()/divergence_report() quote
+    ///                             the previous bridge's budget.
+    ///
+    /// The machine's SPENT walk budget is zeroed too (see
+    /// MnStateMachine::reset_sml_recovery_budget) — load() deliberately does
+    /// not, and a re-arm is a new bridge.
+    ///
+    /// HONEST NOTE ON COVERAGE. Mutation testing kills the deletion of every
+    /// line in this function EXCEPT two, and they are stated rather than
+    /// papered over: m_rerequest_from_cursor (unreset: at most one spurious
+    /// duplicate getdata pass, which apply_block skips) and m_last_wait_log
+    /// (unreset: one INFO line's rate limiter is off for the next 10000
+    /// heights). Neither has a reward-path or diagnostic effect worth a test;
+    /// both are reset anyway, because leaving a field dirty on purpose is how
+    /// the next one gets missed.
+    ///
+    /// NOT reset here, on purpose: the re-arm bookkeeping (m_rearms,
+    /// m_rearm_asks, m_last_rearm_at, m_first_divergence, m_rearm_blocked,
+    /// m_last_rearm_reason). It MUST survive a re-arm or the cap can never
+    /// fire. Nor the configured seams / m_max_bridge / m_fold_interval /
+    /// m_has_sml_fn, which are wiring, not bridge state.
+    void reset_for_arm(const MnCheckpoint& cp)
+    {
+        m_anchor_height = cp.height;
+        m_anchor_hash   = cp.blockhash;
+        m_anchor_source = cp.source;
+        m_anchor_count  = cp.entries.size();
+        m_machine.load(cp.entries, cp.height);
+        m_machine.reset_sml_recovery_budget();
+        // F6: reset the one-shot fold latch and its counters. The latch is the
+        // dangerous one — a second bridge on a re-armed lane would run
+        // additions-only while sml_folded() still reported true, i.e. it would
+        // LIE about having applied removals.
+        m_sml_folded       = false;
+        m_sml_folded_at    = 0;
+        m_folds            = 0;
+        m_first_fold_height = 0;
+        m_last_fold_height = 0;
+        m_anchor_fold_done = false;
+        m_snapshot_pending = false;
+        m_snapshot_hash    = uint256();
+        m_snapshot_height  = 0;
+        m_snapshot_waits   = 0;
+        m_abandoned_folds  = 0;
+        m_abandoned.clear();
+        // ── #1033 ON-DEMAND fold state. Every field the on-demand arm carries
+        // across a bridge, reset for the next one. The one-shot-ish latches
+        // are the dangerous half again: m_ondemand_cap_hit unreset makes a
+        // fresh bridge report a budget it never spent, and m_ondemand_evaluated
+        // unreset makes ondemand_report() claim a mismatch reached the arm on a
+        // bridge where none did — a report that lies in the SAFE-looking
+        // direction is still a report an operator will act on.
+        m_ondemand_pending   = false;
+        m_ondemand_height    = 0;
+        m_ondemand_folds     = 0;
+        m_ondemand_excluded  = 0;
+        m_ondemand_cap_hit   = false;
+        m_ondemand_evaluated = false;
+        m_ondemand_abandoned = 0;
+        m_ondemand_block     = BlockType{};
+        m_ondemand_r         = MnStateMachine::ApplyResult{};
+        // The SIZED cap, which #1033's arm() did not reset. pump() recomputes
+        // it at the Waiting->Bridging edge (kOnDemandFoldBase + replay/250),
+        // exactly like m_sml_recovery_cap — so between a re-arm and the first
+        // pump, status() and ondemand_report() would otherwise quote the
+        // PREVIOUS bridge's budget. Restored to the declared default, never to
+        // 0: a 0 cap has its own meaning ("the on-demand arm is disabled"),
+        // and manufacturing that state here would be a different lie.
+        // m_ondemand_cap_forced is CONFIG (set_ondemand_fold_cap) and survives,
+        // which is why the reset is guarded the same way pump()'s sizing is.
+        if (!m_ondemand_cap_forced) m_ondemand_cap = kOnDemandFoldBase;
+        m_pose_removed    = 0;
+        m_pose_reinstated = 0;
+        m_sml_recovered   = 0;
+        m_registered      = 0;
+        m_spent           = 0;
+        m_applied         = 0;
+        m_warned_no_sml   = false;
+        // The seven arm() used to forget.
+        m_sml_recovery_cap      = 0;
+        m_stalled_pumps         = 0;
+        m_last_pump_next        = 0;
+        m_requested_through     = 0;
+        m_rerequest_from_cursor = false;
+        m_last_wait_log         = 0;
+        m_position_verified     = false;
+        m_anchor_eligible = m_machine.eligible_size();
+        m_next  = cp.height + 1;
+        m_state = State::Waiting;
     }
 
     MnStateMachine m_machine;
@@ -1559,6 +1958,18 @@ public:
     bool     m_rerequest_from_cursor{false};
     uint32_t m_last_wait_log{0};
     bool     m_position_verified{false};
+
+    // ── RE-ARM bookkeeping. Survives reset_for_arm() by design: if a re-arm
+    // cleared its own counters the cap could never fire and the "recovery"
+    // would be an unbounded fail-loop.
+    uint32_t    m_rearms{0};              // spent against kMaxRearms
+    uint32_t    m_rearm_asks{0};          // asks, including deferred/refused
+    uint32_t    m_last_rearm_at{0};       // tip height at the last re-arm
+    bool        m_last_rearm_at_known{false};
+    uint32_t    m_first_divergence{0};    // earliest divergence evidence
+    bool        m_rearm_blocked{false};   // terminal: no further re-arms
+    std::string m_rearm_block_reason;
+    std::string m_last_rearm_reason;
 };
 
 } // namespace coin

--- a/src/impl/dash/coin/mn_state_machine.hpp
+++ b/src/impl/dash/coin/mn_state_machine.hpp
@@ -270,6 +270,17 @@ public:
     void set_sml_recovery_cap(size_t n) { m_sml_recovery_cap = n; }
     size_t sml_recovery_cap() const     { return m_sml_recovery_cap; }
     size_t sml_recovered_total() const  { return m_sml_recovered_total; }
+    /// Zero the SPENT half of the per-bridge demotion-walk budget.
+    ///
+    /// load() deliberately does NOT do this — it reloads the ENTRIES, and a
+    /// caller that reloads a snapshot mid-run must not thereby hand itself a
+    /// fresh licence to override the projection. But a bridge that is RE-ARMED
+    /// from its anchor is a NEW bridge: the budget is documented as
+    /// "per-bridge", and carrying the previous bridge's spend into it would
+    /// start the replay with the walk already exhausted — silently converting
+    /// the first post-anchor PoSe ban into a terminal fail-close. Only
+    /// MnCheckpointLane::rearm() calls this, on exactly that boundary.
+    void reset_sml_recovery_budget() { m_sml_recovered_total = 0; }
 
     /// How deep pass 0's ranked candidate list goes. The recovery walk can
     /// never look past this depth, which bounds both the work and the blast

--- a/test/test_dash_mn_checkpoint.cpp
+++ b/test/test_dash_mn_checkpoint.cpp
@@ -3162,3 +3162,665 @@ TEST(DashMnCheckpointOnDemandFold, ScriptMatchIsTheOnlyLicenceToAttribute)
         << "the refusal must name the SCRIPT rule, not the attestation rule: "
         << s;
 }
+
+// 10. THE RE-SEED SEAM — the maintainer asks, and something ANSWERS
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// MEASURED DEFECT (contabo daemonless soak): CoinStateMaintainer fired
+//
+//   [EMB-DASH] MN payee queue APPLY GAP / DESYNC at h= 2513168, 2513261, 2515266
+//              -> "wiping payee set, demoting to dashd fallback,
+//                  requesting authoritative re-seed"
+//
+// three times in ONE run. h=2515266 is ABOVE the bridge's own failure height
+// (2513489), so it fires on LIVE TIP ADVANCES, not only as a replay artefact.
+// Nothing answered: set_on_mn_reseed was wired ONLY in main_dash's `if (rpc)`
+// branch, so on the daemonless arm `if (m_on_mn_reseed) m_on_mn_reseed();` was
+// a no-op and the payee set stayed wiped for the rest of the run.
+//
+// These cases pin the fill (MnCheckpointLane::rearm) and, crucially, its
+// NEGATIVE TWIN: with the wiring removed the arm must stay down, which is what
+// makes the positive case evidence rather than decoration.
+
+namespace {
+
+// main_dash's daemonless else-branch, in miniature: lane -> leg-4 event ->
+// maintainer, plus the re-seed callback the branch used to omit.
+struct ReseedRig {
+    dash::interfaces::Node                        node;
+    dash::coin::NodeCoinState                     state;
+    dash::coin::CoinStateMaintainer               maint{state};
+    std::vector<std::shared_ptr<EventDisposable>> subs;
+    BridgeHarness                                 h;
+    MnCheckpoint                                  anchor{good_checkpoint()};
+    size_t                                        reseed_calls{0};
+    std::vector<MnCheckpointLane::RearmOutcome>   outcomes;
+
+    explicit ReseedRig(bool wire_the_reseed_seam)
+    {
+        maint.set_require_seeded_mn_set(true);
+        subs.push_back(c2pool::dash::wire_mn_list_ingest(node, maint));
+        subs.push_back(c2pool::dash::wire_tip_ingest(node, maint));
+        h.lane.set_publish_fn(
+            [this](std::vector<std::pair<uint256, MNState>> set, uint32_t as_of) {
+                dash::interfaces::MnListUpdate up;
+                up.mnstates     = std::move(set);
+                up.as_of_height = as_of;
+                node.mn_list_update.happened(up);
+            });
+        h.headers[kAnchorHeight] = uint256S(kAnchorHash);
+        h.blocks[1519544] = block_from_hex(kBlockHex1519544);
+        h.blocks[1519545] = block_from_hex(kBlockHex1519545);
+        h.blocks[1519546] = block_from_hex(kBlockHex1519546);
+        h.tip = 1519546;
+
+        // THE SEAM UNDER TEST. The negative twin passes false and changes
+        // NOTHING else, so any difference in outcome is this wiring alone.
+        if (wire_the_reseed_seam) {
+            maint.set_on_mn_reseed([this] {
+                ++reseed_calls;
+                const auto out = h.lane.rearm(
+                    anchor, "maintainer wiped a desynced/gapped payee queue");
+                outcomes.push_back(out);
+                if (out == MnCheckpointLane::RearmOutcome::Armed)
+                    h.lane.pump();
+            });
+        }
+    }
+
+    void fire_tip()
+    {
+        dash::interfaces::TipAdvance ta;
+        ta.prev_height          = h.tip;
+        ta.prev_hash            = uint256S(kAnchorHash);
+        ta.bits_for_next        = 0x1d00ffff;
+        ta.mtp_at_tip           = 1751000000;
+        ta.address_version      = TESTNET_PUBKEY_VER;
+        ta.address_p2sh_version = TESTNET_P2SH_VER;
+        node.new_tip.happened(ta);
+    }
+
+    // The measured trigger: a block the maintainer's forward-contiguous apply
+    // cursor cannot reach (one height skipped) -> APPLY GAP -> wipe, latch,
+    // demote, ask for a re-seed. A real accepted body, so nothing else about
+    // the block is synthetic.
+    MnStateMachine::ApplyResult force_apply_gap()
+    {
+        return maint.on_block_connected(block_from_hex(kBlockHex1519546),
+                                        /*height=*/1519548);
+    }
+};
+
+} // namespace
+
+TEST(DashMnCheckpointReseed, DesyncAskReArmsTheBridgeAndTheArmComesBack)
+{
+    ReseedRig r(/*wire_the_reseed_seam=*/true);
+
+    // Cold start -> bridge -> published -> populated.
+    r.h.lane.arm(r.anchor);
+    r.h.lane.pump();
+    ASSERT_EQ(r.h.lane.state(), MnCheckpointLane::State::Published)
+        << r.h.lane.status();
+    r.fire_tip();
+    ASSERT_TRUE(r.state.populated());
+    ASSERT_FALSE(r.state.mn_needs_reseed());
+
+    // The measured event.
+    const auto gap = r.force_apply_gap();
+    ASSERT_TRUE(gap.gap_detected) << "the trigger itself must actually fire";
+
+    EXPECT_EQ(r.reseed_calls, 1u)
+        << "the maintainer asked for an authoritative re-seed and NOTHING"
+           " answered -- this is the measured daemonless defect";
+    ASSERT_EQ(r.outcomes.size(), 1u);
+    EXPECT_EQ(r.outcomes[0], MnCheckpointLane::RearmOutcome::Armed)
+        << r.h.lane.last_rearm_reason();
+    EXPECT_EQ(r.h.lane.rearms(), 1u);
+
+    // The re-armed bridge ran to completion on the SAME anchor...
+    EXPECT_EQ(r.h.lane.state(), MnCheckpointLane::State::Published)
+        << r.h.lane.status();
+    EXPECT_EQ(r.h.lane.anchor_height(), kAnchorHeight)
+        << "the re-arm must use the release-pinned anchor, never a newer one";
+    // ...and its publish cleared the maintainer's latch through the REAL
+    // leg-4 event, which is the only thing that can.
+    EXPECT_FALSE(r.state.mn_needs_reseed())
+        << "an authoritative resync must clear the payee-desync latch";
+    r.fire_tip();
+    EXPECT_TRUE(r.state.populated())
+        << "the embedded arm must come back up after the re-arm publishes";
+    EXPECT_NE(r.h.lane.status().find("RE-ARM 1/3"), std::string::npos)
+        << "a publish that is a RECOVERY must not read like a cold start: "
+        << r.h.lane.status();
+}
+
+// ── NEGATIVE TWIN. Byte-identical rig with the re-seed wiring REMOVED. This
+// is today's shipped daemonless behaviour, and it must be demonstrably worse:
+// nothing is invoked, the lane never re-arms, and the arm stays down forever.
+TEST(DashMnCheckpointReseed, NegativeControlNoReseedWiringLeavesTheArmDown)
+{
+    ReseedRig r(/*wire_the_reseed_seam=*/false);
+
+    r.h.lane.arm(r.anchor);
+    r.h.lane.pump();
+    ASSERT_EQ(r.h.lane.state(), MnCheckpointLane::State::Published);
+    r.fire_tip();
+    ASSERT_TRUE(r.state.populated());
+
+    const auto gap = r.force_apply_gap();
+    ASSERT_TRUE(gap.gap_detected);
+
+    EXPECT_EQ(r.reseed_calls, 0u) << "nothing may be invoked";
+    EXPECT_EQ(r.h.lane.rearms(), 0u);
+    EXPECT_EQ(r.h.lane.rearm_asks(), 0u);
+    EXPECT_TRUE(r.h.lane.last_rearm_reason().empty())
+        << "no ask was ever made, so there is no outcome to report";
+    EXPECT_TRUE(r.state.mn_needs_reseed())
+        << "the latch stays set: only an authoritative resync clears it, and"
+           " unwired there is nothing to produce one";
+    r.fire_tip();
+    EXPECT_FALSE(r.state.populated())
+        << "THE MEASURED DEFECT: the payee set stays wiped and the embedded"
+           " arm stays demoted for the rest of the run";
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 11. RE-ARM RESETS EVERY FIELD arm() SETS
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// arm() assumed a virgin lane. A field it leaves dirty does not crash a
+// re-armed bridge -- it makes it publish a WRONG masternode set, or wedge with
+// no symptom. The load-bearing one is m_requested_through: left stale it makes
+// request_window() compute `from > end` and issue NO getdata at all.
+
+namespace {
+
+// A bridge that runs to Published having exercised the fold, the counters and
+// the request window -- i.e. every field arm()/rearm() must clear.
+struct DirtyBridge {
+    static constexpr uint32_t kAnchorH = 2513000;
+    static constexpr uint32_t kTip     = 2513004;
+    MnCheckpoint cp{synthetic_anchor(64, kAnchorH, uint256S(kAnchorHash))};
+    SnapshotRig  rig;
+
+    DirtyBridge()
+    {
+        std::vector<std::pair<uint256, bool>> attest;
+        for (size_t i = 0; i < cp.entries.size(); ++i)
+            attest.emplace_back(cp.entries[i].first, i >= 5);   // 5 banned
+        rig.attest = attest;
+        rig.install(kAnchorH, kTip, uint256S(kAnchorHash));
+        rig.by_height[kAnchorH] =
+            make_snapshot(uint256S(kAnchorHash), kAnchorH, attest);
+        for (uint32_t bh = kAnchorH + 1; bh <= kTip; ++bh) {
+            const size_t rank = 5 + (bh - (kAnchorH + 1));
+            rig.h.blocks[bh] =
+                block_paying(cp.entries[rank].second.scriptPayout.m_data);
+        }
+    }
+};
+
+} // namespace
+
+TEST(DashMnCheckpointReseed, ReArmResetsEveryFieldArmSets)
+{
+    DirtyBridge d;
+    d.rig.h.lane.arm(d.cp);
+    d.rig.h.lane.pump();
+    auto& lane = d.rig.h.lane;
+
+    // Establish the state is genuinely DIRTY, field by field. A reset test
+    // over an already-clean object proves nothing.
+    ASSERT_EQ(lane.state(), MnCheckpointLane::State::Published) << lane.status();
+    ASSERT_TRUE(lane.sml_folded());
+    ASSERT_NE(lane.sml_folded_at(), 0u);
+    ASSERT_NE(lane.first_fold_height(), 0u);
+    ASSERT_NE(lane.last_fold_height(), 0u);
+    ASSERT_NE(lane.folds_applied(), 0u);
+    ASSERT_TRUE(lane.anchor_fold_done());
+    ASSERT_NE(lane.pose_removed(), 0u);
+    ASSERT_NE(lane.replay_applied(), 0u);
+    ASSERT_NE(lane.cursor_height(), DirtyBridge::kAnchorH);
+    ASSERT_TRUE(lane.position_verified());
+    ASSERT_NE(lane.requested_through(), 0u);
+    ASSERT_NE(lane.sml_recovery_cap(), 0u);
+
+    const size_t anchor_elig = lane.anchor_eligible();
+
+    ASSERT_EQ(lane.rearm(d.cp, "unit test"), MnCheckpointLane::RearmOutcome::Armed)
+        << lane.last_rearm_reason();
+
+    // ── EVERY field arm() sets, back at its armed value. Grouped exactly as
+    // reset_for_arm() groups them so a new field on one side is visible here.
+    EXPECT_EQ(lane.state(), MnCheckpointLane::State::Waiting);
+    EXPECT_EQ(lane.anchor_height(), DirtyBridge::kAnchorH);
+    EXPECT_EQ(lane.cursor_height(), DirtyBridge::kAnchorH);
+    EXPECT_EQ(lane.set_size(), d.cp.entries.size());
+    EXPECT_EQ(lane.anchor_eligible(), anchor_elig);
+    EXPECT_EQ(lane.eligible_size(), anchor_elig)
+        << "the machine must be reloaded from the anchor, bans and all";
+    // #1028 fold state -- the one-shot latch is the SILENT one.
+    EXPECT_FALSE(lane.sml_folded());
+    EXPECT_EQ(lane.sml_folded_at(), 0u);
+    EXPECT_EQ(lane.first_fold_height(), 0u);
+    EXPECT_EQ(lane.last_fold_height(), 0u);
+    EXPECT_EQ(lane.folds_applied(), 0u);
+    EXPECT_FALSE(lane.anchor_fold_done());
+    EXPECT_EQ(lane.abandoned_folds(), 0u);
+    EXPECT_FALSE(lane.snapshot_pending());
+    EXPECT_EQ(lane.pose_removed(), 0u);
+    EXPECT_EQ(lane.pose_reinstated(), 0u);
+    EXPECT_EQ(lane.sml_recovered(), 0u);
+    EXPECT_EQ(lane.replay_registered(), 0u);
+    EXPECT_EQ(lane.replay_spent(), 0u);
+    EXPECT_EQ(lane.replay_applied(), 0u);
+    // The seven arm() ITSELF forgot -- latent on a virgin lane (all
+    // zero-initialised), bugs on a re-arm.
+    EXPECT_FALSE(lane.position_verified());
+    EXPECT_EQ(lane.requested_through(), 0u);
+    EXPECT_EQ(lane.stalled_pumps(), 0u);
+    EXPECT_EQ(lane.sml_recovery_cap(), 0u);
+    EXPECT_EQ(lane.sml_recovery_spent(), 0u)
+        << "MnStateMachine::load() does NOT zero the per-bridge demotion-walk"
+           " spend; carrying it in would exhaust the budget before the replay"
+           " starts";
+    // The re-arm bookkeeping must NOT be reset, or the cap can never fire.
+    EXPECT_EQ(lane.rearms(), 1u);
+    EXPECT_EQ(lane.rearm_asks(), 1u);
+
+    // BEHAVIOURAL PROOF, because several of those fields have no observable
+    // effect until the bridge runs again: the second bridge must actually
+    // fetch blocks and complete. With m_requested_through left stale this
+    // request list is EMPTY and the lane sits at its cursor forever.
+    d.rig.h.requested.clear();
+    lane.pump();
+    EXPECT_FALSE(d.rig.h.requested.empty())
+        << "a re-armed bridge that issues no getdata is wedged, not working";
+    EXPECT_EQ(lane.state(), MnCheckpointLane::State::Published) << lane.status();
+    EXPECT_EQ(lane.replay_applied(), DirtyBridge::kTip - DirtyBridge::kAnchorH);
+}
+
+// ── THE #1028 ONE-SHOT FOLD LATCH, named. A second bridge that ran
+// additions-only while sml_folded() still reported true from the first would
+// LIE about having applied PoSe removals -- and additions-only is exactly the
+// measured 2068->2059 vs 2067->2070 divergence this fold exists to fix.
+TEST(DashMnCheckpointReseed, SecondBridgeFoldsAgainRatherThanRunningAdditionsOnly)
+{
+    DirtyBridge d;
+    auto& lane = d.rig.h.lane;
+    lane.arm(d.cp);
+    lane.pump();
+    ASSERT_EQ(lane.state(), MnCheckpointLane::State::Published) << lane.status();
+    const uint32_t folds_1   = lane.folds_applied();
+    const size_t   removed_1 = lane.pose_removed();
+    const size_t   elig_1    = lane.eligible_size();
+    ASSERT_GT(folds_1, 0u);
+    ASSERT_EQ(removed_1, 5u);
+    ASSERT_EQ(elig_1, 59u);
+
+    ASSERT_EQ(lane.rearm(d.cp, "unit test"), MnCheckpointLane::RearmOutcome::Armed);
+    ASSERT_FALSE(lane.sml_folded()) << "the one-shot latch must be down again";
+    lane.pump();
+
+    ASSERT_EQ(lane.state(), MnCheckpointLane::State::Published) << lane.status();
+    EXPECT_TRUE(lane.sml_folded());
+    EXPECT_EQ(lane.folds_applied(), folds_1)
+        << "the second bridge must fold the SAME number of times, not zero";
+    EXPECT_EQ(lane.pose_removed(), removed_1)
+        << "additions-only would report 0 removals here while sml_folded()"
+           " still said yes -- the silent half of the defect";
+    EXPECT_EQ(lane.eligible_size(), elig_1)
+        << "the published set must be identical, not 64 (unfolded)";
+    EXPECT_EQ(lane.first_fold_height(), DirtyBridge::kAnchorH);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 12. THE CAP AND THE BACKOFF NAME THEMSELVES
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// An unbounded re-arm against a deterministic failure is a fail-loop with
+// extra steps, and it is WORSE than staying down because it hides the problem.
+
+TEST(DashMnCheckpointReseed, ReArmCapFiresBacksOffAndNamesItself)
+{
+    DirtyBridge d;
+    auto& lane = d.rig.h.lane;
+    lane.arm(d.cp);
+    lane.pump();
+    ASSERT_EQ(lane.state(), MnCheckpointLane::State::Published);
+
+    // #1 -- free.
+    EXPECT_EQ(lane.rearm(d.cp, "desync 1"), MnCheckpointLane::RearmOutcome::Armed);
+    EXPECT_EQ(lane.rearms(), 1u);
+
+    // Immediately again: BACKOFF. Re-replaying the identical window would fail
+    // identically, so this is deferred and does NOT burn an attempt.
+    EXPECT_EQ(lane.rearm(d.cp, "desync 1b"),
+              MnCheckpointLane::RearmOutcome::Deferred);
+    EXPECT_EQ(lane.rearms(), 1u) << "a deferral must not consume the cap";
+    EXPECT_EQ(lane.rearm_asks(), 2u);
+    EXPECT_NE(lane.last_rearm_reason().find("BACKOFF"), std::string::npos)
+        << lane.last_rearm_reason();
+
+    // Move the chain past the first backoff window (64 blocks).
+    d.rig.h.tip += MnCheckpointLane::kRearmBackoffBlocks;
+    EXPECT_EQ(lane.rearm(d.cp, "desync 2"), MnCheckpointLane::RearmOutcome::Armed);
+    EXPECT_EQ(lane.rearms(), 2u);
+
+    // The window DOUBLES: 64 is no longer enough.
+    d.rig.h.tip += MnCheckpointLane::kRearmBackoffBlocks;
+    EXPECT_EQ(lane.rearm(d.cp, "desync 2b"),
+              MnCheckpointLane::RearmOutcome::Deferred)
+        << lane.last_rearm_reason();
+    d.rig.h.tip += MnCheckpointLane::kRearmBackoffBlocks;
+    EXPECT_EQ(lane.rearm(d.cp, "desync 3"), MnCheckpointLane::RearmOutcome::Armed);
+    EXPECT_EQ(lane.rearms(), MnCheckpointLane::kMaxRearms);
+
+    // #4 -- the cap. TERMINAL, and it must SAY so, not go quiet.
+    d.rig.h.tip += 100000;
+    EXPECT_EQ(lane.rearm(d.cp, "desync 4"),
+              MnCheckpointLane::RearmOutcome::CapExhausted);
+    EXPECT_EQ(lane.rearms(), MnCheckpointLane::kMaxRearms)
+        << "the cap must not be exceeded";
+    EXPECT_TRUE(lane.rearm_blocked());
+    EXPECT_NE(lane.last_rearm_reason().find("EXHAUSTED"), std::string::npos)
+        << lane.last_rearm_reason();
+    EXPECT_NE(lane.last_rearm_reason().find("STAYING DOWN ON PURPOSE"),
+              std::string::npos)
+        << "an operator must be able to grep the terminal reason: "
+        << lane.last_rearm_reason();
+
+    // ...and it stays terminal, restating itself rather than falling silent.
+    d.rig.h.tip += 100000;
+    EXPECT_EQ(lane.rearm(d.cp, "desync 5"),
+              MnCheckpointLane::RearmOutcome::Refused);
+    EXPECT_NE(lane.last_rearm_reason().find("TERMINALLY BLOCKED"),
+              std::string::npos)
+        << lane.last_rearm_reason();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 13. THE TRAP: a re-arm must NEVER select an anchor newer than the divergence
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// An anchor cut AFTER a divergence began replays PERFECTLY CLEANLY over a
+// shorter window -- and re-arms a queue that is already wrong, which mints a
+// coinbase the network rejects. That is the exact failure this whole lane
+// exists to prevent (mn_checkpoint_lane.hpp's header warns against it by
+// name). Newest-first is not a heuristic that is sometimes worse; it is the
+// bug.
+
+TEST(DashMnCheckpointReseed, ReArmRefusesAnAnchorNewerThanTheOneInUse)
+{
+    DirtyBridge d;
+    auto& lane = d.rig.h.lane;
+    lane.arm(d.cp);
+    lane.pump();
+    ASSERT_EQ(lane.state(), MnCheckpointLane::State::Published);
+
+    // The tempting candidate: a FRESHER anchor, closer to the tip, which would
+    // bridge in fewer blocks and replay without a single mismatch.
+    const uint32_t newer_h = DirtyBridge::kAnchorH + 2;
+    uint256 newer_hash = uint256S(kAnchorHash);
+    newer_hash.data()[0] = static_cast<unsigned char>(newer_h & 0xff);
+    newer_hash.data()[1] = static_cast<unsigned char>((newer_h >> 8) & 0xff);
+    auto newer = synthetic_anchor(64, newer_h, newer_hash);
+    ASSERT_TRUE(newer.ok);
+
+    EXPECT_EQ(lane.rearm(newer, "desync"), MnCheckpointLane::RearmOutcome::Refused);
+    EXPECT_EQ(lane.rearms(), 0u) << "nothing may be re-armed from it";
+    EXPECT_EQ(lane.anchor_height(), DirtyBridge::kAnchorH)
+        << "the lane must still be pinned to the release anchor";
+    EXPECT_EQ(lane.state(), MnCheckpointLane::State::Published)
+        << "a refused candidate must not disturb the lane's state";
+    EXPECT_NE(lane.last_rearm_reason().find("REFUSING A NEWER ANCHOR"),
+              std::string::npos)
+        << lane.last_rearm_reason();
+    EXPECT_TRUE(lane.rearm_blocked())
+        << "a newer anchor is a deterministic wiring error -- retrying it"
+           " forever would be a fail-loop";
+
+    // And it stays refused: even the CORRECT anchor cannot revive a lane that
+    // was asked to do the dangerous thing. Fail closed, loudly, once.
+    EXPECT_EQ(lane.rearm(d.cp, "desync"), MnCheckpointLane::RearmOutcome::Refused);
+    EXPECT_EQ(lane.rearms(), 0u);
+}
+
+// ── The second half of the same rule, isolated: even an anchor that is NOT
+// newer than the one in use is refused when it is not strictly OLDER than the
+// earliest divergence we have evidence of. Constructed with a zero-block
+// bridge (tip == anchor), which is the only way the anchor height and the
+// divergence height can coincide.
+TEST(DashMnCheckpointReseed, ReArmRefusesAnAnchorAtOrAfterTheDivergence)
+{
+    constexpr uint32_t kAnchorH = 2513000;
+    const uint256 anchor_hash = uint256S(kAnchorHash);
+    auto cp = synthetic_anchor(10, kAnchorH, anchor_hash);
+
+    BridgeHarness h;
+    h.headers[kAnchorH] = anchor_hash;
+    h.tip = kAnchorH;                    // zero-block bridge: publishes at once
+    h.lane.arm(cp);
+    h.lane.pump();
+    ASSERT_EQ(h.lane.state(), MnCheckpointLane::State::Published)
+        << h.lane.status();
+
+    // The ask itself IS the divergence evidence, and it is dated at the tip --
+    // which here equals the anchor height. So the anchor is not strictly older
+    // than the divergence and may not be replayed as if it were.
+    EXPECT_EQ(h.lane.rearm(cp, "desync at the anchor height"),
+              MnCheckpointLane::RearmOutcome::Refused);
+    EXPECT_EQ(h.lane.first_divergence_height(), kAnchorH);
+    EXPECT_EQ(h.lane.rearms(), 0u);
+    EXPECT_NE(h.lane.last_rearm_reason().find(
+                  "REFUSING AN ANCHOR AT OR AFTER THE DIVERGENCE"),
+              std::string::npos)
+        << h.lane.last_rearm_reason();
+}
+
+// ── FOUND BY MUTATION. Every assertion above survived deleting the body of
+// MnStateMachine::reset_sml_recovery_budget(): the DirtyBridge rig folds
+// wholesale, so its walk never SPENDS budget and `sml_recovery_spent() == 0`
+// held either way. A reset nothing can falsify is not a reset.
+//
+// MnStateMachine::load() deliberately does NOT zero the spend — a mid-run
+// snapshot reload must not hand itself a fresh licence to override the
+// projection — so a re-armed bridge inherits the previous bridge's spend
+// unless rearm() clears it. Inherited, the FIRST post-anchor PoSe ban of the
+// second bridge is refused over a budget it never used, and a bridge that
+// completed once fails closed on the replay of the identical window.
+TEST(DashMnCheckpointReseed, ReArmGivesTheSecondBridgeAFreshDemotionWalkBudget)
+{
+    RecoveryRig r;
+    // The walk's own scenario: dashd banned our queue head after the anchor
+    // was cut, so the block pays queue slot 2 and the walk spends one.
+    auto blk = repay_coinbase(block_from_hex(kBlockHex1519544),
+                              payout_of(r.cp, kQ1), payout_of(r.cp, kQ2));
+    r.h.lane.set_sml_validity_fn(sml_fn(all_valid_except({kQ1})));
+    r.run(blk);
+
+    ASSERT_EQ(r.h.lane.state(), MnCheckpointLane::State::Published)
+        << r.h.lane.status();
+    ASSERT_EQ(r.h.lane.sml_recovered(), 1u) << "the walk must actually have run";
+    ASSERT_EQ(r.h.lane.sml_recovery_spent(), 1u)
+        << "...and the MACHINE must be carrying that spend, or this test is"
+           " asserting nothing";
+
+    ASSERT_EQ(r.h.lane.rearm(r.cp, "unit test"),
+              MnCheckpointLane::RearmOutcome::Armed)
+        << r.h.lane.last_rearm_reason();
+    EXPECT_EQ(r.h.lane.sml_recovery_spent(), 0u)
+        << "a re-arm is a NEW bridge; the per-bridge walk budget must start"
+           " unspent or the first ban of the replay is refused over a budget"
+           " the replay never used";
+    EXPECT_EQ(r.h.lane.sml_recovered(), 0u);
+
+    // ...and the identical window replays to the identical result.
+    r.h.lane.pump();
+    EXPECT_EQ(r.h.lane.state(), MnCheckpointLane::State::Published)
+        << r.h.lane.status();
+    EXPECT_EQ(r.h.lane.sml_recovered(), 1u);
+    EXPECT_EQ(r.h.lane.sml_recovery_spent(), 1u);
+
+    // ── ALSO FOUND BY MUTATION: m_last_pump_next. This one-block rig is the
+    // only shape in which the stale value COLLIDES with the re-armed cursor
+    // (the first bridge left it at 1519544; the re-arm sets m_next to 1519544),
+    // so unreset it makes the very first pump of a healthy bridge report
+    // "bridge stalled ... re-requesting from the cursor". Nothing breaks — and
+    // that is the point: the lane would be lying about its own state on the
+    // one output an operator reads to decide whether the peer is serving.
+}
+
+// ── ALSO FOUND BY MUTATION: m_last_pump_next, the stall probe's memory.
+// Deleting its reset left every other case green, because on_block_connected
+// zeroes m_stalled_pumps as soon as a block lands — so the false stall is
+// invisible the instant the peer answers. It is visible exactly when it
+// matters: a re-armed bridge whose peer has NOT yet answered. Unreset, the
+// very first pump of a healthy bridge reports
+//
+//     [MN-CKPT] bridge stalled at h=... — re-requesting from the cursor
+//
+// which is the lane lying about its own state on the one line an operator
+// reads to decide whether to swap the peer. Nothing breaks; the diagnosis does.
+TEST(DashMnCheckpointReseed, ReArmClearsTheStallProbeSoAHealthyBridgeIsNotStalled)
+{
+    RecoveryRig r;
+    // A one-block bridge is the shape where the stale probe value COLLIDES
+    // with the re-armed cursor: the first bridge leaves m_last_pump_next at
+    // 1519544, and the re-arm sets the cursor back to exactly 1519544.
+    r.run(block_from_hex(kBlockHex1519544));
+    ASSERT_EQ(r.h.lane.state(), MnCheckpointLane::State::Published)
+        << r.h.lane.status();
+
+    // Silence the peer, so nothing can zero the counter behind our back.
+    r.h.auto_deliver = false;
+    ASSERT_EQ(r.h.lane.rearm(r.cp, "unit test"),
+              MnCheckpointLane::RearmOutcome::Armed);
+    r.h.lane.pump();
+
+    ASSERT_EQ(r.h.lane.state(), MnCheckpointLane::State::Bridging)
+        << r.h.lane.status();
+    EXPECT_EQ(r.h.lane.stalled_pumps(), 0u)
+        << "one pump into a fresh bridge cannot be a stall; a nonzero count"
+           " here is the PREVIOUS bridge's cursor talking";
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 14. RECONCILIATION WITH #1033 — the on-demand arm's per-bridge state
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// #1033 added a second, independently-budgeted repair arm. Its counters are
+// per-BRIDGE in exactly the way the demotion walk's are, so a re-arm that does
+// not clear them hands the second bridge a budget the first one already spent.
+// With an explicit cap of 1 that is not a cosmetic miscount: the re-armed
+// bridge refuses the very fold it needs and FAILS CLOSED on a window it had
+// already replayed successfully — the daemonless arm then never comes back,
+// which is the whole defect this branch exists to fix, reintroduced one layer
+// down.
+//
+// The forced cap is the point of the fixture: it makes the carried counter
+// LETHAL rather than merely wrong, so the mutation that drops the reset is
+// caught by behaviour and not only by an equality on a getter.
+TEST(DashMnCheckpointReseed, ReArmGivesTheSecondBridgeAFreshOnDemandFoldBudget)
+{
+    SnapshotRig rig;
+    const auto cp = build_ondemand_scenario(rig);
+    // Exactly enough budget for the one repair this window needs. Carried into
+    // a second bridge, it is exactly one short.
+    rig.h.lane.set_ondemand_fold_cap(1);
+
+    rig.h.lane.arm(cp);
+    rig.h.lane.pump();
+
+    ASSERT_EQ(rig.h.lane.state(), MnCheckpointLane::State::Published)
+        << rig.h.lane.status();
+    ASSERT_EQ(rig.h.lane.ondemand_folds(), 1u)
+        << "the on-demand arm must actually have fired, or this test asserts"
+           " nothing: " << rig.h.lane.status();
+    ASSERT_EQ(rig.h.lane.ondemand_excluded(), 1u);
+    ASSERT_TRUE(rig.h.lane.ondemand_evaluated());
+    const size_t elig_1 = rig.h.lane.eligible_size();
+
+    ASSERT_EQ(rig.h.lane.rearm(cp, "unit test"),
+              MnCheckpointLane::RearmOutcome::Armed)
+        << rig.h.lane.last_rearm_reason();
+
+    // ── Every #1033 per-bridge field, back at its armed value.
+    EXPECT_EQ(rig.h.lane.ondemand_folds(), 0u)
+        << "a re-arm is a NEW bridge; its on-demand budget must start unspent";
+    EXPECT_EQ(rig.h.lane.ondemand_excluded(), 0u);
+    EXPECT_EQ(rig.h.lane.ondemand_abandoned(), 0u);
+    EXPECT_FALSE(rig.h.lane.ondemand_cap_hit());
+    EXPECT_FALSE(rig.h.lane.ondemand_evaluated())
+        << "ondemand_report() must not claim a mismatch reached the arm on a"
+           " bridge where none has yet";
+    // The FORCED cap is configuration and must SURVIVE — resetting it would
+    // silently re-enable an arm the operator disabled or re-sized.
+    EXPECT_EQ(rig.h.lane.ondemand_cap(), 1u)
+        << "an explicitly set cap is wiring, not bridge state";
+
+    // ── BEHAVIOURAL PROOF. With the counter carried, this second bridge hits
+    // the cap on the fold it needs and fails closed on a window it just
+    // replayed successfully.
+    rig.h.lane.pump();
+    EXPECT_EQ(rig.h.lane.state(), MnCheckpointLane::State::Published)
+        << "the re-armed bridge must recover the SAME ban it recovered the"
+           " first time: " << rig.h.lane.status();
+    EXPECT_EQ(rig.h.lane.ondemand_folds(), 1u);
+    EXPECT_EQ(rig.h.lane.ondemand_excluded(), 1u);
+    EXPECT_FALSE(rig.h.lane.ondemand_cap_hit());
+    EXPECT_EQ(rig.h.lane.eligible_size(), elig_1)
+        << "the published set must be identical to the first bridge's";
+}
+
+// ── The preserved mismatch context (#1033's PendingPayeeAdjudication), on the
+// ONLY path where a re-arm can actually observe it set.
+//
+// FIRST ATTEMPT AT THIS WAS A NON-TEST, and mutation caught it: asserting
+// `present == false` after a bridge that PUBLISHED proves nothing, because
+// apply_block clears m_pending on every block past its guards — so the last
+// successful block had already cleared it and deleting load()'s clear left the
+// suite green. The context is only still set when the bridge stopped ON the
+// mismatch, i.e. when it FAILED CLOSED.
+//
+// That state is reachable and is not hypothetical: bridge 1 publishes, the
+// maintainer desyncs live, the re-arm replays, and THAT bridge fails closed on
+// a mismatch its budget could not repair. A later desync re-arms again — and
+// the stale `ranked` from the failed bridge describes a queue the reloaded
+// anchor no longer has. Re-adjudicating against it is the wrong-queue publish
+// this whole lane exists to prevent.
+TEST(DashMnCheckpointReseed, ReArmDropsThePreservedMismatchOfAFailedBridge)
+{
+    SnapshotRig rig;
+    const auto cp = build_ondemand_scenario(rig);
+    rig.h.lane.set_ondemand_fold_cap(0);      // no repair -> stop ON the mismatch
+
+    rig.h.lane.arm(cp);
+    rig.h.lane.pump();
+    ASSERT_EQ(rig.h.lane.state(), MnCheckpointLane::State::FailedClosed)
+        << rig.h.lane.status();
+
+    // The context IS preserved here — that is what makes the assertion below
+    // able to fail.
+    const auto& before = rig.h.lane.pending_payee_adjudication();
+    ASSERT_TRUE(before.present)
+        << "a bridge that stopped on a payee mismatch must have kept the"
+           " context, or this test is asserting nothing";
+    ASSERT_EQ(before.height, kOdMismatch);
+    ASSERT_FALSE(before.ranked.empty());
+
+    ASSERT_EQ(rig.h.lane.rearm(cp, "unit test"),
+              MnCheckpointLane::RearmOutcome::Armed)
+        << rig.h.lane.last_rearm_reason();
+
+    // reset_for_arm() reaches it through MnStateMachine::load(), which #1033
+    // already made responsible for dropping it. This asserts the PATH is
+    // reached, not that a second reset exists.
+    const auto& after = rig.h.lane.pending_payee_adjudication();
+    EXPECT_FALSE(after.present)
+        << "the preserved queue belongs to a set that no longer exists";
+    EXPECT_EQ(after.height, 0u);
+    EXPECT_TRUE(after.ranked.empty());
+    EXPECT_FALSE(after.projected.has_value());
+}


### PR DESCRIPTION
## The defect, measured

`CoinStateMaintainer::on_block_connected`, on a payee **DESYNC** or an apply **GAP**, wipes the payee set, latches `m_mn_needs_reseed`, demotes to the dashd fallback and calls `m_on_mn_reseed()`.

`main_dash.cpp` wired that callback **only** inside the `if (rpc)` branch (~:3475). The daemonless `else` branch armed the checkpoint lane and set **no callback at all**, so `if (m_on_mn_reseed) m_on_mn_reseed();` (`coin_state_maintainer.hpp` ~:800) was a no-op.

Contabo daemonless soak:

```
[EMB-DASH] MN payee queue APPLY GAP / DESYNC at h= 2513168, 2513261, 2515266
           -> "wiping payee set, demoting to dashd fallback, requesting authoritative re-seed"
```

Three asks in one run. **h=2515266 is above the bridge's own failure height (2513489)** — this fires on live tip advances, independently of the bridge replay. Nothing answered. The payee set stayed wiped for the rest of the run and only a restart recovered it.

## The fill

`MnCheckpointLane::rearm()`. `arm()` could not do this: it assumed a virgin lane, and both terminal states (`Published`, `FailedClosed`) are one-way.

The reset is factored into a private `reset_for_arm()` that **`arm()` and `rearm()` both call**. That is the whole design point — two hand-maintained reset lists drift, and a field the second one forgets does not crash, it publishes a wrong masternode set.

### Fields `arm()` set vs. what is now reset

`arm()` already reset the #1028 fold state (the brief that commissioned this expected otherwise — see "Where the brief was wrong" below). What `arm()` **did not** reset, all no-ops on a virgin lane and all bugs on a re-arm:

| field | consequence if left stale on a re-arm |
|---|---|
| `m_requested_through` | **load-bearing.** `request_window()` computes `from = m_requested_through + 1 > end` and issues **no getdata at all** — the re-armed bridge sits at its cursor forever with no symptom |
| `m_last_pump_next` | the very first pump of a healthy bridge reports `bridge stalled ... re-requesting from the cursor` — the lane lying about its own state |
| `m_stalled_pumps` | a fresh bridge inherits a stall count it did not earn |
| `m_position_verified` | a *different* anchor would skip the chain-position check entirely |
| `m_sml_recovery_cap` | `status()` / `divergence_report()` quote the previous bridge's budget |
| `m_rerequest_from_cursor` | one spurious duplicate getdata pass (`apply_block` skips it) |
| `m_last_wait_log` | one INFO line's rate limiter off for the next 10000 heights |

Plus one field owned by the state machine, not the lane:

* `MnStateMachine::m_sml_recovered_total` — the **spent** half of the per-bridge demotion-walk budget. `load()` deliberately does not zero it (a mid-run snapshot reload must not hand itself a fresh licence to override the projection), so a re-armed bridge would start with its budget already exhausted and fail closed on the first post-anchor PoSe ban. A new `reset_sml_recovery_budget()` is called from `reset_for_arm()` only.

## Anchor selection — the trap

An anchor cut **after** a divergence began replays perfectly cleanly over a shorter window and re-arms a queue that is *already wrong*, which mints a coinbase the network rejects. Newest-first is not a heuristic that is sometimes worse; it is the bug.

`rearm()` refuses **terminally**:

* any candidate **newer than the anchor in use**;
* any candidate **not strictly older than the earliest divergence observed** (every re-seed ask is dated divergence evidence).

Re-arming from the same compiled-in anchor **is** legitimate: it is the release-pinned trust root, it is by construction not newer than any observed divergence, and it is the floor of any future ladder.

### Still scoped, deliberately not half-built

A genuine oldest-first **ladder** needs what the file header already listed and this change does not start: (1) a multi-anchor checkpoint store keyed by height, (2) a persisted per-anchor desync counter (the cap here is per-process), (3) an `arm()`/re-arm API taking a candidate list. Until (1) exists, "oldest-first" and "the compiled-in anchor" are the same choice.

## Cap and backoff

* **Cap: 3 re-arms per process.** Three is what the measurement showed — the live path asked three times in one run. A fourth ask inside one process is not a transient desync, it is a standing disagreement between our replayed queue and the chain.
* **Backoff: 64 blocks before the second re-arm, doubling (128) after that.** Measured in blocks at the tip seam; the lane owns no timer and must not grow one. The observed repeat gaps were 93 and 2005 blocks, so 64 admits both real repeats while refusing the back-to-back retry that would replay the identical window and fail identically.
* A **deferral does not consume the cap**; only an actual arm does.
* Neither counter is reset by a successful publish — a bridge that publishes and then desyncs again is precisely the loop being bounded.

An unbounded re-arm against a deterministic failure is a fail-loop with extra steps, and worse than staying down because it hides the problem.

## It says its own name

Every attempt logs the trigger text, the anchor and its source, `ask #N`, `attempt N/3`, the observed tip, the last re-arm height, and a named outcome (`ARMED` / `DEFERRED` / `CAP-EXHAUSTED` / `REFUSED`). A field never evaluated prints `n/a`, never `0`.

Cap exhaustion is a greppable terminal reason:

```
[MN-CKPT] RE-ARM CAP-EXHAUSTED (ask #4, attempt 4/3, 3 already used) trigger='...'
  anchor h=2513000 source='...' observed tip h=... last re-arm at h=... —
  the re-arm cap of 3 is EXHAUSTED. ... STAYING DOWN ON PURPOSE — a fourth
  re-arm would be a fail-loop that hides this. ...
```

`fail_closed()` now also prints a RE-ARM POSTURE line (which generation this was, asks so far, re-arms remaining or the terminal block reason, last outcome), and a publish that is a recovery is tagged `[RE-ARM n/3 — this set is a recovery from a payee desync, not a cold start]` so it cannot read like a clean start.

## Tests

Folded into `test/test_dash_mn_checkpoint.cpp`, already compiled into the **allowlisted** `test_dash_node_reception_wire` target — no new `add_executable`, no `build.yml` edit, no NOT_BUILT sentinel.

```
ctest -R DashMnCheckpointReseed -V     ->  9/9 passed
ctest -R "DashMnCheckpoint|DashNodeReceptionWire|DashLiveFeed|DashMnSeed"
                                       -> 75/75 passed
ctest -R Dash (all built DASH targets) -> 311 passed, 0 failed
```

Cases: the desync ask re-arms the bridge and the arm comes back; the **negative twin** with the wiring removed (nothing invoked, `rearms()==0`, latch stays set, `populated()` false — today's shipped behaviour); re-arm resets every field `arm()` sets; the second bridge actually **folds again** rather than running additions-only behind a `sml_folded()` that still says yes; a fresh demotion-walk budget; the stall probe is cleared; the cap fires, backs off and names itself; and both halves of the anchor-selection refusal.

### Mutation testing — every case proved able to go red

| mutation | killed |
|---|---|
| `rearm()` never arms | 6 cases |
| negative twin re-wired (`if (true)`) | the twin |
| drop `m_requested_through = 0` | 3 cases |
| drop the fold-latch resets | 2 cases |
| `kMaxRearms = 100` + backoff disabled | 2 cases |
| drop the newer-anchor guard | the newer-anchor case |
| drop the divergence guard | the divergence case |
| `reset_sml_recovery_budget()` body emptied | the walk-budget case |
| drop `m_position_verified` / `m_sml_recovery_cap` / `m_stalled_pumps` | the reset case |
| drop `m_last_pump_next = 0` | the stall-probe case |

Two survivors, named in the source rather than papered over: `m_rerequest_from_cursor` and `m_last_wait_log`. Neither has a reward-path or diagnostic effect worth a test; both are reset anyway, because leaving a field dirty on purpose is how the next one gets missed.

The `reset_sml_recovery_budget()` and `m_last_pump_next` cases exist **because** the first mutation pass found the original assertions could not fail.

## Build

Real BLS, the way CI does it:

```
conan install . -pr:a=ci/conan/linux-gcc13.profile --build=missing --output-folder=build_dash_bls
cmake -S . -B build_dash_bls -DCMAKE_TOOLCHAIN_FILE=build_dash_bls/conan_toolchain.cmake \
      -DCMAKE_BUILD_TYPE=Release -DC2POOL_DASH_BLS=ON -DDASHBLS_ROOT="$HOME/.c2pool-deps/dashbls"
cmake --build build_dash_bls --target c2pool-dash test_dash_node_reception_wire -j12
```

`c2pool-dash` links and carries the real backend (`strings | grep BLS_SIG_BLS12381G2_XMD` → 3 hits). `tools/ci/check_test_target_allowlist.py` → OK, 226 targets, no drift.

## Ordering safety

`m_on_mn_reseed` fires **after** the maintainer has wiped, latched and demoted, so the embedded arm is already down and stays down until the re-armed bridge publishes through the leg-4 event — the only thing that clears the latch. Same io thread, no lock held (the lane takes none). The anchor is captured by value rather than re-parsed per ask, so a deferred ask stays cheap.

---

## Rebased onto #1033 (master `52e8e051`) — reconciliation

Rebased, not merged-over. Two conflicts, both in files #1033 also owns:

| file | conflict | resolution |
|---|---|---|
| `mn_checkpoint_lane.hpp` | `arm()` — #1033 added its on-demand resets to the same block this branch extracted into `reset_for_arm()` | took **this branch's** `reset_for_arm(cp);` call and **relocated #1033's nine on-demand resets into `reset_for_arm()`**. Nothing of #1033's was dropped; it now runs for `rearm()` too, which is the point of the extraction. |
| `test_dash_mn_checkpoint.cpp` | both sides appended a new section 9 at the same anchor | kept **both**; #1033 keeps section 9, this branch renumbered to 10–14. All 10 `DashMnCheckpointOnDemandFold` cases intact and passing. |
| `mn_state_machine.hpp` | none — auto-merged | this branch only *adds* `reset_sml_recovery_budget()`; #1033's `walk_to_paid_candidate()` / `commit_walk_outcome()` refactor is untouched. |

### #1033 state now reset by `reset_for_arm()`

Enumerated from #1033's diff, not from a hand-off list:

`m_ondemand_pending`, `m_ondemand_height`, `m_ondemand_folds`, `m_ondemand_excluded`, `m_ondemand_cap_hit`, `m_ondemand_evaluated`, `m_ondemand_abandoned` (deliberately separate from `m_abandoned_folds`), `m_ondemand_block`, `m_ondemand_r`.

Plus one **#1033's own `arm()` does not reset**: `m_ondemand_cap`. `pump()` recomputes it at the `Waiting→Bridging` edge (`kOnDemandFoldBase + replay/250`), exactly like `m_sml_recovery_cap` — so between a re-arm and the first pump, `status()` and `ondemand_report()` quote the *previous* bridge's budget. Restored to `kOnDemandFoldBase`, never to `0` (a 0 cap means "the arm is disabled" — manufacturing that would be a different lie), and **guarded by `m_ondemand_cap_forced`** so an explicitly set cap survives as configuration. Dropping that guard turns two of #1033's own tests red.

Deliberately **not** reset: `m_ondemand_cap_forced` (config, `set_ondemand_fold_cap()`).

`PendingPayeeAdjudication` needs no new reset — #1033's `MnStateMachine::load()` already clears it and `reset_for_arm()` goes through `load()`. A test asserts the path is *reached* rather than assuming it.

### Two new cases, both mutation-proved

* `ReArmGivesTheSecondBridgeAFreshOnDemandFoldBudget` — forces `set_ondemand_fold_cap(1)` so a carried counter is **lethal, not cosmetic**: the re-armed bridge would refuse the very fold it needs and fail closed on a window it had already replayed. Killed by dropping `m_ondemand_folds = 0` and by dropping the four report fields.
* `ReArmDropsThePreservedMismatchOfAFailedBridge` — **the first version of this was a non-test and mutation caught it.** Asserting `present == false` after a bridge that *published* proves nothing: `apply_block` clears `m_pending` on every block past its guards, so deleting `load()`'s clear left the suite green. The context is only still set when the bridge stopped **on** the mismatch, i.e. failed closed. Rewritten on that path (`set_ondemand_fold_cap(0)`), it now goes red when `load()`'s clear is removed.

Also re-verified post-rebase that the pre-existing mutations are still lethal on the new base: `m_requested_through` (5 cases), the fold latch (3), and `reset_sml_recovery_budget()` (1).

### Post-rebase numbers (run on the rebased tree, not the old base)

```
ctest -R DashMnCheckpointReseed          11/11 passed, 0 failed
ctest -R DashMnCheckpointOnDemandFold    10/10 passed, 0 failed   (#1033 intact)
ctest -R "DashMnCheckpoint|DashNodeReceptionWire|DashLiveFeed|DashMnSeed"
                                         87/87 passed, 0 failed
ctest -R Dash (all built DASH targets)  323    passed, 0 failed
```

`c2pool-dash` rebuilt with `-DC2POOL_DASH_BLS=ON`; `strings | grep BLS_SIG_BLS12381G2_XMD` → 3 hits. Allowlist drift-guard OK (226 targets).