### PR TITLE
dash(embedded): fold the PoSe list ON DEMAND at a payee mismatch, not only at fixed fold points

### DIFF
--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -131,6 +131,18 @@
 ///     reactive walk's attestations (a stale list must not license a permanent
 ///     demotion of a since-revived masternode).
 ///
+///     A fold point is COARSE (kDefaultFoldInterval blocks), so a ban landing
+///     strictly BETWEEN two of them is invisible to it. That gap is closed by
+///     the ON-DEMAND fold below, not by shrinking the interval.
+///
+///   • THE ON-DEMAND FOLD — the same request machinery, fired BY A PAYEE
+///     MISMATCH rather than by a fold point. Measured on mainnet: the bridge
+///     fail-closed at h=2513489 having projected a masternode PoSe-banned at
+///     h<=2513488, with the next scheduled fold point ELEVEN BLOCKS LATER at
+///     2513500. The mismatch itself is the perfect trigger — it fires exactly
+///     when, and only when, the queue is wrong. See the ON-DEMAND PoSe FOLD
+///     block below for the cap and the safety argument.
+///
 ///   • set_sml_validity_fn() — the per-hash attestation used by the REACTIVE
 ///     per-mismatch demotion walk, which remains the second line of defence
 ///     for a ban the fold could not cover (no verified SML, or an SML whose
@@ -304,8 +316,20 @@ public:
         m_merkle_root_at = std::move(fn);
     }
     /// How many blocks between fold points. Coarse on purpose: a fold is a
-    /// network round trip and the per-mismatch walk covers the gaps.
+    /// network round trip, and a ban that lands BETWEEN two fold points is
+    /// caught by the ON-DEMAND fold at the mismatch it causes (see the
+    /// ON-DEMAND PoSe FOLD block below), not by shrinking this.
     void set_fold_interval(uint32_t n) { m_fold_interval = n ? n : 1; }
+
+    /// Override the per-bridge on-demand fold cap. Unset, the cap is sized
+    /// against the replay distance at bridge start (see pump()). ZERO disables
+    /// the on-demand path entirely, which restores the pre-change behaviour
+    /// exactly: a payee mismatch between fold points is terminal.
+    void set_ondemand_fold_cap(size_t n)
+    {
+        m_ondemand_cap       = n;
+        m_ondemand_cap_forced = true;
+    }
 
     /// Maximum number of blocks the bridge is willing to replay. A checkpoint
     /// further behind the tip than this is treated as STALE and refused: the
@@ -351,6 +375,15 @@ public:
         m_snapshot_waits   = 0;
         m_abandoned_folds  = 0;
         m_abandoned.clear();
+        m_ondemand_pending  = false;
+        m_ondemand_height   = 0;
+        m_ondemand_folds    = 0;
+        m_ondemand_excluded = 0;
+        m_ondemand_cap_hit  = false;
+        m_ondemand_evaluated = false;
+        m_ondemand_abandoned = 0;
+        m_ondemand_block    = BlockType{};
+        m_ondemand_r        = MnStateMachine::ApplyResult{};
         m_pose_removed    = 0;
         m_pose_reinstated = 0;
         m_sml_recovered   = 0;
@@ -396,6 +429,17 @@ public:
     /// tip, so "did we fold before the first block" is a different question
     /// from "where did we fold last".
     uint32_t first_fold_height()  const { return m_first_fold_height; }
+    /// ── On-demand fold accounting ─────────────────────────────────────────
+    /// How many folds were triggered BY A PAYEE MISMATCH rather than by a
+    /// fold point, how many queue heads they retired, the per-bridge cap, and
+    /// whether that cap was ever hit. `ondemand_evaluated()` is false when no
+    /// mismatch ever occurred — in which case every other number here is
+    /// "never evaluated", NOT "evaluated and zero", and the reports say n/a.
+    size_t   ondemand_folds()     const { return m_ondemand_folds; }
+    size_t   ondemand_excluded()  const { return m_ondemand_excluded; }
+    size_t   ondemand_cap()       const { return m_ondemand_cap; }
+    bool     ondemand_cap_hit()   const { return m_ondemand_cap_hit; }
+    bool     ondemand_evaluated() const { return m_ondemand_evaluated; }
     size_t   replay_registered()  const { return m_registered; }
     size_t   replay_spent()       const { return m_spent; }
     bool     failed_closed() const { return m_state == State::FailedClosed; }
@@ -493,6 +537,35 @@ public:
             // refuse, and the fold already removes the need.
             m_sml_recovery_cap = 4 + (tip - m_anchor_height) / 1000;
             m_machine.set_sml_recovery_cap(m_sml_recovery_cap);
+            // ── THE ON-DEMAND FOLD CAP ───────────────────────────────────
+            // Bounds ROUND TRIPS, not trust: every on-demand fold is DIP-4
+            // client-verified against the coinbase of the very block it
+            // judges, so an extra one costs correctness nothing. What it
+            // costs is one getmnlistd and one paused replay, and a bridge
+            // that mismatches on EVERY block is not experiencing bans — it
+            // has a wrong anchor or a broken replay, and must stop rather
+            // than hammer a peer for thousands of lists.
+            //
+            // SIZING, from the measurement. One on-demand fold repairs an
+            // entire BURST at once (the wholesale pass retires every
+            // masternode the list attests banned, not just the queue head),
+            // so the cost is one round trip per DISTINCT ban EVENT that
+            // reaches the queue head between two fold points. Mainnet
+            // 2026-08-02: 9 masternodes left `protx list valid` across 1874
+            // blocks — about one ban event per 200 blocks, and only a
+            // fraction of those hit the queue head before the next scheduled
+            // fold. kOnDemandFoldPerBlocks = 250 tracks that rate with
+            // headroom; kOnDemandFoldBase = 8 covers a SHORT bridge, where
+            // the ratio term contributes nothing but a burst can still land.
+            //
+            // At the default 20000-block bridge bound that is 8 + 80 = 88
+            // round trips worst case, which is negligible against the 20000
+            // getdata the same bridge already issues — while a runaway
+            // stops after 88 instead of after 20000.
+            if (!m_ondemand_cap_forced) {
+                m_ondemand_cap = kOnDemandFoldBase
+                               + (tip - m_anchor_height) / kOnDemandFoldPerBlocks;
+            }
             LOG_INFO << "[MN-CKPT] bridge START: replaying h=" << m_next
                      << ".." << tip << " (" << (tip - m_next + 1)
                      << " blocks) onto the anchored set";
@@ -578,6 +651,16 @@ public:
         // detail; here it is TERMINAL (unlike the maintainer's path, which can
         // ask for an RPC re-seed — daemonless has nothing to re-seed from, and
         // guessing is exactly what must never happen).
+        if (r.payee_desync && !r.gap_detected) {
+            // ── ON-DEMAND FOLD. The mismatch IS the trigger: ask for the
+            // masternode list dated exactly at this height and re-adjudicate.
+            // Returns true when the request was issued (the replay is now
+            // PAUSED and the reply resumes it) or when the reply arrived
+            // inline and has already resolved or failed the bridge. False
+            // means the path was unavailable, and the ONLY other answer is
+            // the one this lane has always given.
+            if (begin_ondemand_fold(block, height, r)) return;
+        }
         if (r.gap_detected || r.payee_desync) {
             return fail_closed(
                 std::string("bridge replay ")
@@ -714,6 +797,16 @@ public:
     /// Blocks between fold points.
     static constexpr uint32_t kDefaultFoldInterval = 500;
 
+    /// ── The ON-DEMAND fold cap, per bridge ────────────────────────────────
+    /// cap = kOnDemandFoldBase + replay_blocks / kOnDemandFoldPerBlocks.
+    /// The reasoning is written out at the sizing site in pump(); the short
+    /// version is that this bounds ROUND TRIPS (each fold is DIP-4 verified,
+    /// so more of them costs correctness nothing) and that one fold repairs a
+    /// whole burst, so the rate that matters is DISTINCT BAN EVENTS — measured
+    /// at roughly one per 200 blocks on mainnet 2026-08-02.
+    static constexpr size_t   kOnDemandFoldBase      = 8;
+    static constexpr uint32_t kOnDemandFoldPerBlocks = 250;
+
     /// The next height at or after `cursor` at which we want a snapshot, or
     /// nullopt when none remains before `tip`. Always includes the tip so the
     /// published set is current, and the anchor so the first replayed block is
@@ -730,7 +823,7 @@ public:
 
     /// Ask for the list as of `height`, and pause the replay until it lands.
     /// Returns true when a request was issued (caller must stop pulling).
-    bool begin_fold(uint32_t height)
+    bool begin_fold(uint32_t height, bool on_demand = false)
     {
         if (!m_request_snapshot || !m_merkle_root_at || !m_header_hash_at)
             return false;
@@ -740,11 +833,110 @@ public:
         m_snapshot_hash    = *hash;
         m_snapshot_height  = height;
         m_snapshot_waits   = 0;
-        LOG_INFO << "[MN-CKPT] PoSe fold: requesting the masternode list AS OF"
+        LOG_INFO << "[MN-CKPT] "
+                 << (on_demand ? "ON-DEMAND PoSe fold (triggered by the payee"
+                                 " mismatch itself, not by a fold point)"
+                               : "PoSe fold")
+                 << ": requesting the masternode list AS OF"
                     " h=" << height << " (" << hash->GetHex().substr(0, 16)
                  << ") — replay PAUSED until it lands, so the cursor cannot"
                     " run past the height the list describes";
         m_request_snapshot(*hash);
+        return true;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // ON-DEMAND PoSe FOLD — fire AT the mismatch, not at a fold point
+    // ─────────────────────────────────────────────────────────────────────
+    //
+    // MEASURED (contabo daemonless soak vs hotel dashd, mainnet, anchor
+    // 2513000, fold interval 500):
+    //
+    //     h=2513000  protx list valid 2068  projected payee PRESENT  <- folded
+    //     h=2513400                   2068  PRESENT
+    //     h=2513488                   2066  ABSENT  <- PoSe-banned in this range
+    //     h=2513489                   2066  ABSENT  <- projected anyway -> DEAD
+    //     next fold point   h=2513500                <- ELEVEN BLOCKS TOO LATE
+    //
+    // The chain paid 4cad8728bb473c80…; we projected e8626fcd57f6394d…, which
+    // the chain had already banned. THREE separate builds fail-closed at that
+    // identical height — one of them carrying no fold code at all. So the fold
+    // MECHANISM is right and only its GRANULARITY was wrong: a ban landing
+    // strictly inside a fold interval is invisible to fold points.
+    //
+    // WHY NOT JUST SHRINK THE INTERVAL. A finer interval pays a network round
+    // trip CONTINUOUSLY (every interval, ban or no ban) and STILL leaves a
+    // window — it only makes the window smaller. Firing at the mismatch pays a
+    // round trip only when a mismatch actually occurs, and leaves NO window at
+    // all, because the list we ask for is dated at the very height that failed.
+    //
+    // SAFETY IS THE #1028 ARGUMENT, UNCHANGED:
+    //   * the list is DIP-4 client-verified against the block's own coinbase
+    //     commitment (historical_sml.hpp), before it is believed;
+    //   * cursor == H holds BY CONSTRUCTION — we name the height being
+    //     adjudicated, ask for hash_at(H) from our OWN PoW-validated header
+    //     chain, and authenticate that the reply's cbTx nHeight IS H;
+    //   * the replay PAUSES while the request is outstanding, because exactly
+    //     one getmnlistd may be in flight (a duplicate reply is
+    //     indistinguishable from the first). Same m_snapshot_pending latch as
+    //     the interval fold, so there is one pause mechanism, not two;
+    //   * the reply comes back through the SAME HistoricalMnListDiffDemux —
+    //     no second filter slot, no second route to the live tip SML;
+    //   * every failure lands on TODAY'S behaviour: fail closed, never a
+    //     guessed payee.
+    //
+    // Returns TRUE when the mismatch has been TAKEN OVER by this path — either
+    // a request is outstanding (replay paused) or an inline reply has already
+    // resolved or failed the bridge. FALSE means the caller must fail closed
+    // exactly as it did before this path existed.
+    bool begin_ondemand_fold(const BlockType& block, uint32_t height,
+                             const MnStateMachine::ApplyResult& r)
+    {
+        // Nothing to re-adjudicate: the machine refused for a reason a better
+        // list cannot change (e.g. the pre-block queue was empty).
+        if (!m_machine.pending_payee_adjudication().present) return false;
+        if (m_machine.pending_payee_adjudication().height != height) return false;
+        // The seams are wired as a pair or not at all (main_dash), but a lane
+        // driven without them must degrade, not wedge.
+        if (!m_request_snapshot || !m_merkle_root_at || !m_header_hash_at)
+            return false;
+        // ONE outstanding getmnlistd. UNREACHABLE today and mutation testing
+        // says so — deleting it produces no red, because on_block_connected
+        // returns early while paused, so no block can be applied to mismatch
+        // while a request is in flight. Kept as a backstop: the constraint is
+        // hard (a second in-flight ask draws a reply that matches no await and
+        // leaks past the demux), and it is checked where it would be spent.
+        if (m_snapshot_pending) return false;
+
+        // From here on the cap has been EVALUATED, so its counters mean
+        // "measured", not "never looked".
+        m_ondemand_evaluated = true;
+        if (m_ondemand_folds >= m_ondemand_cap) {
+            m_ondemand_cap_hit = true;
+            LOG_WARNING << "[MN-CKPT] ON-DEMAND PoSe FOLD REFUSED at h="
+                        << height << ": " << m_ondemand_folds
+                        << " on-demand folds already used of a per-bridge cap of "
+                        << m_ondemand_cap << " (cap = " << kOnDemandFoldBase
+                        << " + replay_blocks/" << kOnDemandFoldPerBlocks
+                        << "). A bridge that needs more than this is not"
+                           " experiencing PoSe bans — it has a wrong anchor or a"
+                           " broken replay — so it stops here rather than asking"
+                           " a peer for a masternode list per block.";
+            return false;
+        }
+
+        // Stash everything the re-adjudication needs. The block is copied
+        // because the reply is asynchronous in production and the caller's
+        // buffer will be long gone; this costs one block copy per MISMATCH,
+        // not per block.
+        m_ondemand_block  = block;
+        m_ondemand_height = height;
+        m_ondemand_r      = r;
+        m_ondemand_pending = true;
+        if (!begin_fold(height, /*on_demand=*/true)) {
+            m_ondemand_pending = false;
+            return false;
+        }
         return true;
     }
 
@@ -764,6 +956,29 @@ public:
             return false;
         }
         if (m_snapshot_waits < kFoldGiveUpPumps) return false;
+
+        // An ON-DEMAND fold cannot be abandoned "degraded": the replay is
+        // parked on an UNRESOLVED payee mismatch, so resuming would mean
+        // carrying on with a queue we already know disagrees with the chain.
+        // The honest end is the one this lane always had.
+        if (m_ondemand_pending) {
+            remember_abandoned(m_snapshot_hash);
+            m_snapshot_pending = false;
+            m_ondemand_pending = false;
+            // Counted SEPARATELY from m_abandoned_folds on purpose: that
+            // counter's whole meaning is "the replay carried on degraded over
+            // that interval", and this replay did not carry on at all.
+            ++m_ondemand_abandoned;
+            fail_closed(
+                "bridge replay PAYEE DESYNC at h="
+                + std::to_string(m_ondemand_height)
+                + ": the ON-DEMAND masternode-list request for that exact"
+                  " height went unanswered across "
+                + std::to_string(m_snapshot_waits)
+                + " drives, so the mismatch was never adjudicated. "
+                + divergence_report(m_ondemand_r));
+            return false;   // the caller must NOT resume
+        }
 
         // GIVE UP on this fold point rather than wedge the whole bridge. The
         // cursor is still exactly at m_snapshot_height, so nothing is
@@ -811,18 +1026,26 @@ public:
 
         m_snapshot_pending = false;
         const uint32_t h = m_snapshot_height;
+        const bool on_demand = m_ondemand_pending;
 
         vendor::CCbTx cbtx;
         auto sml = authenticate_historical_snapshot(
             diff, h, m_merkle_root_at, cbtx, "MN-CKPT");
         if (!sml) {
+            m_ondemand_pending = false;
             fail_closed(
                 "the masternode list served for h=" + std::to_string(h)
                 + " failed DIP-4 client verification (see the AUTH FAILED line"
                   " above). Refusing to fold an unauthenticated list into the"
-                  " payee set — that list decides who gets paid.");
+                  " payee set — that list decides who gets paid."
+                + (on_demand
+                       ? " This was an ON-DEMAND fold, so the payee mismatch"
+                         " at that height also stands unresolved."
+                       : ""));
             return true;   // consumed: it matched our await
         }
+
+        if (on_demand) { finish_ondemand_fold(*sml, h); return true; }
 
         apply_fold(*sml, h);
         if (m_state != State::Bridging) return true;
@@ -860,6 +1083,76 @@ private:
     {
         return std::find(m_abandoned.begin(), m_abandoned.end(), h)
                != m_abandoned.end();
+    }
+
+    /// Resolve an ON-DEMAND fold: an AUTHENTICATED list dated exactly at the
+    /// height whose payee mismatched. Two steps, in this order and for two
+    /// different reasons:
+    ///
+    ///   1. WHOLESALE FOLD. Every masternode the list attests banned leaves
+    ///      the payee-eligible set in one pass, so a ban BURST inside the fold
+    ///      interval costs the same as a single ban. Same apply_fold() the
+    ///      interval folds use — same F5 sanity bound, same counters, same log
+    ///      line — and legitimate here for the same reason: the cursor is
+    ///      exactly at the height the list describes.
+    ///
+    ///   2. RE-ADJUDICATE THIS BLOCK'S PAYEE. The fold repairs the queue for
+    ///      every LATER block, but block `height` itself still has an
+    ///      unattributed payment; leaving it unattributed would desync the
+    ///      very next block. The re-adjudication demands the same unrelaxed
+    ///      evidence the walk always did — the accepted candidate's
+    ///      scriptPayout must EXACTLY equal an output this block pays.
+    ///
+    /// Any refusal at either step is TERMINAL, exactly as a payee mismatch has
+    /// always been on this lane.
+    void finish_ondemand_fold(const vendor::CSimplifiedMNList& sml,
+                              uint32_t height)
+    {
+        m_ondemand_pending = false;
+        ++m_ondemand_folds;
+
+        apply_fold(sml, height);
+        if (m_state != State::Bridging) return;   // F5 refused; already closed
+
+        const auto rr =
+            m_machine.readjudicate_payee(m_ondemand_block, height, sml);
+        if (!rr.recovered) {
+            return fail_closed(
+                "bridge replay PAYEE DESYNC at h=" + std::to_string(height)
+                + " SURVIVED the ON-DEMAND PoSe fold: " + rr.refusal
+                + ". The masternode list dated EXACTLY at that height was"
+                  " fetched and DIP-4 client-verified, so staleness is ruled"
+                  " out — this is a real divergence, not a missed ban. "
+                + divergence_report(m_ondemand_r));
+        }
+        m_ondemand_excluded += rr.excluded;
+        // The one post-apply check the desync branch jumped over. Structurally
+        // unreachable — a payee mismatch requires a non-empty projection — but
+        // "publishing a set that cannot back a payee" is exactly what this lane
+        // exists to prevent, so it is not left to an argument.
+        if (m_ondemand_r.total_after == 0) {
+            return fail_closed(
+                "bridge replay emptied the masternode set at h="
+                + std::to_string(height) + " — cannot back a payee");
+        }
+
+        // The bookkeeping the ordinary post-apply path would have done. It was
+        // skipped when apply_block reported the mismatch, and the block IS
+        // applied — only its attribution was withheld until now.
+        m_next = height + 1;
+        ++m_applied;
+        m_sml_recovered += m_ondemand_r.sml_recovered;
+        m_registered    += m_ondemand_r.registered;
+        m_spent         += m_ondemand_r.spent;
+        m_stalled_pumps = 0;
+        m_ondemand_r    = MnStateMachine::ApplyResult{};
+        m_ondemand_block = BlockType{};
+
+        // Resume: the cursor is exactly at `height`, so the next block is +1.
+        if (!m_tip_height) return;
+        const uint32_t tip = m_tip_height();
+        if (m_next > tip) { publish(tip); return; }
+        request_window(tip);
     }
 
     /// Apply an AUTHENTICATED list dated exactly at `height`, with the cursor
@@ -939,6 +1232,61 @@ public:
         return n;
     }
 
+    /// The ON-DEMAND fold's own line, in every report and on the published
+    /// status. It NAMES ITS CAP: measured value, threshold, and the formula
+    /// that produced the threshold.
+    ///
+    /// A field that was never evaluated prints `n/a`, never `0` — "no mismatch
+    /// ever happened" and "mismatches happened and no fold was needed" are
+    /// different facts, and a bare 0 says the second while meaning the first.
+    std::string ondemand_report() const
+    {
+        if (!m_request_snapshot || !m_merkle_root_at || !m_header_hash_at) {
+            return "ON-DEMAND PoSe folds: n/a (the per-height snapshot seam is"
+                   " not wired, so a mismatch can never be re-adjudicated"
+                   " against a list dated at its own height).";
+        }
+        const std::string cap_source =
+            m_ondemand_cap_forced
+                ? std::string("cap set explicitly")
+                : ("cap = " + std::to_string(kOnDemandFoldBase)
+                   + " + replay_blocks/"
+                   + std::to_string(kOnDemandFoldPerBlocks));
+        if (m_ondemand_cap == 0) {
+            return "ON-DEMAND PoSe folds: DISABLED (cap 0, " + cap_source
+                 + ") — a payee mismatch between fold points is terminal, which"
+                   " is the pre-on-demand behaviour."
+                 + (m_ondemand_evaluated
+                        ? " One was refused on that basis."
+                        : " None was ever attempted.");
+        }
+        if (!m_ondemand_evaluated) {
+            return "ON-DEMAND PoSe folds: n/a — no payee mismatch ever reached"
+                   " the on-demand path, so its cap ("
+                   + std::to_string(m_ondemand_cap) + ", " + cap_source
+                   + ") was never tested.";
+        }
+        std::string s = "ON-DEMAND PoSe folds: " + std::to_string(m_ondemand_folds)
+            + "/" + std::to_string(m_ondemand_cap) + " used (" + cap_source
+            + "), " + std::to_string(m_ondemand_excluded)
+            + " queue-head exclusion(s) licensed by a list dated EXACTLY at the"
+              " height it judged.";
+        if (m_ondemand_cap_hit) {
+            s += " THE CAP IS EXHAUSTED: " + std::to_string(m_ondemand_folds)
+                 + " of " + std::to_string(m_ondemand_cap)
+                 + " — a further mismatch was REFUSED rather than asking a peer"
+                   " for another list. A bridge that needs more than this is not"
+                   " experiencing PoSe bans; suspect the anchor or the replay.";
+        }
+        if (m_ondemand_abandoned != 0) {
+            s += " " + std::to_string(m_ondemand_abandoned)
+                 + " on-demand request(s) went UNANSWERED — the replay did NOT"
+                   " carry on degraded, it failed closed, because it was parked"
+                   " on a payee mismatch it had not adjudicated.";
+        }
+        return s;
+    }
+
     /// The measurement that replaces three hypotheses. Every fail-closed on
     /// the replay path carries it, so an operator can separate "the anchor is
     /// wrong" from "the replay is incomplete" from "a PoSe ban could not be
@@ -980,6 +1328,7 @@ public:
                    " replay carried on degraded over those intervals, with the"
                    " per-mismatch walk alone.";
         }
+        s += " " + ondemand_report();
         if (m_snapshot_pending) {
             s += " A masternode-list request for h="
                  + std::to_string(m_snapshot_height) + " is OUTSTANDING and the"
@@ -1105,7 +1454,8 @@ public:
                    + " (anchor h=" + std::to_string(m_anchor_height)
                    + " + " + std::to_string(m_applied) + " replayed blocks) "
                    + delta
-                   + " PoSe folds: " + std::to_string(m_folds);
+                   + " PoSe folds: " + std::to_string(m_folds)
+                   + " (" + ondemand_report() + ")";
         // A DEGRADED publish must say so. Publishing a set that was assembled
         // without the fold points it asked for looks identical, from outside,
         // to a clean bridge — and that silence is the defect: the operator has
@@ -1180,6 +1530,21 @@ public:
     uint32_t m_snapshot_waits{0};     // pumps spent waiting on the current one
     uint32_t m_abandoned_folds{0};
     std::vector<uint256> m_abandoned; // requests we gave up on but still claim
+    // ── ON-DEMAND fold state. m_ondemand_pending rides ALONGSIDE
+    // m_snapshot_pending rather than replacing it: there is one pause
+    // mechanism and one outstanding request, and this only says which of the
+    // two dispatch reasons owns the reply.
+    bool      m_ondemand_pending{false};
+    BlockType m_ondemand_block;         // the mismatching block, kept to re-judge
+    uint32_t  m_ondemand_height{0};
+    MnStateMachine::ApplyResult m_ondemand_r;  // its counters + projected payee
+    size_t    m_ondemand_folds{0};
+    size_t    m_ondemand_excluded{0};
+    size_t    m_ondemand_cap{kOnDemandFoldBase};
+    bool      m_ondemand_cap_forced{false};    // set_ondemand_fold_cap() wins
+    bool      m_ondemand_cap_hit{false};
+    bool      m_ondemand_evaluated{false};     // a mismatch ever reached it
+    size_t    m_ondemand_abandoned{0};         // on-demand asks never answered
     RequestSnapshotFn m_request_snapshot;
     MerkleRootAtFn    m_merkle_root_at;
     size_t   m_sml_recovery_cap{0}; // budget handed to the machine, mirrored

--- a/src/impl/dash/coin/mn_state_machine.hpp
+++ b/src/impl/dash/coin/mn_state_machine.hpp
@@ -179,6 +179,42 @@ public:
         size_t sml_recovered{0};
     };
 
+    /// ─────────────────────────────────────────────────────────────────────
+    /// WHAT A MISMATCH LEAVES BEHIND, SO IT CAN BE RE-ASKED
+    /// ─────────────────────────────────────────────────────────────────────
+    /// When pass 3 reports payee_desync it has already refused to attribute
+    /// anything — no state was guessed. But the block's own passes 1/2 DID
+    /// run, and `ranked` was computed from the PRE-block list, which no longer
+    /// exists once those passes have run. So a caller that later obtains a
+    /// BETTER-DATED masternode list cannot simply re-apply the block: the
+    /// forward-only cursor refuses it, and re-deriving `ranked` post-apply
+    /// gives a different queue.
+    ///
+    /// This is the exact context needed to re-adjudicate ONLY pass 3 against a
+    /// list we did not have when the block arrived. It is written on every
+    /// payee_desync and cleared the moment another block is applied, so it can
+    /// only ever describe the height the cursor is standing on.
+    struct PendingPayeeAdjudication {
+        bool                   present{false};
+        uint32_t               height{0};
+        std::vector<uint256>   ranked;      ///< PRE-block DIP-3 queue, in order
+        std::optional<uint256> projected;   ///< ranked.front()
+    };
+    const PendingPayeeAdjudication& pending_payee_adjudication() const
+    {
+        return m_pending;
+    }
+
+    /// Outcome of readjudicate_payee(). `refusal` is a sentence, not a code:
+    /// it lands verbatim in the lane's fail-closed line, which is the only
+    /// record an operator gets.
+    struct ReadjudicateResult {
+        bool                   recovered{false};
+        size_t                 excluded{0};   ///< queue heads permanently retired
+        std::optional<uint256> accepted;      ///< who the payment was attributed to
+        std::string            refusal;
+    };
+
     /// Optional validity attestation for a proTxHash, sourced from the
     /// Simplified Masternode List. THREE-state on purpose:
     ///
@@ -287,6 +323,10 @@ public:
         m_entries.clear();
         m_collateral_index.clear();
         m_last_applied_height = as_of_height;
+        // A pending mismatch describes a queue that no longer exists once the
+        // set is reloaded. Leaving it would let a re-armed lane re-adjudicate
+        // an old height against a new set.
+        m_pending = PendingPayeeAdjudication{};
         for (auto& [h, st] : entries) {
             m_collateral_index[st.collateralOutpoint] = h;
             m_entries.emplace(h, std::move(st));
@@ -300,7 +340,8 @@ public:
 
     size_t size() const { return m_entries.size(); }
 
-    const std::map<uint256, MNState>& entries() const { return m_entries; }
+    using Entries = std::map<uint256, MNState>;
+    const Entries& entries() const { return m_entries; }
 
     std::optional<uint256> find_by_collateral(
         const bitcoin_family::coin::TxPrevOut& outpoint) const
@@ -702,6 +743,139 @@ public:
         return m_sml_height >= height;
     }
 
+    /// ─────────────────────────────────────────────────────────────────────
+    /// readjudicate_payee — the ON-DEMAND arm of the PoSe repair
+    /// ─────────────────────────────────────────────────────────────────────
+    ///
+    /// THE DEFECT THIS CLOSES, measured on mainnet (contabo daemonless soak,
+    /// anchor 2513000):
+    ///
+    ///     h=2513000  protx list valid 2068  projected payee PRESENT   <- fold
+    ///     h=2513400                   2068  PRESENT
+    ///     h=2513488                   2066  ABSENT   <- PoSe-banned in here
+    ///     h=2513489                   2066  ABSENT   <- we projected it anyway
+    ///     next scheduled fold point   2513500        <- ELEVEN BLOCKS LATE
+    ///
+    /// The fold MECHANISM was right; its GRANULARITY was wrong. A ban landing
+    /// strictly INSIDE a fold interval is invisible to fold points, and the
+    /// reactive walk that does fire at the mismatch was consulting a list up
+    /// to `fold_interval - 1` blocks stale.
+    ///
+    /// Shrinking the interval is the wrong fix twice over: it pays a network
+    /// round trip continuously, AND it still leaves a window. Asking AT the
+    /// mismatch pays a round trip only when a mismatch actually happens, and
+    /// leaves NO window — the list is dated at the very height being judged.
+    ///
+    /// CONTRACT. `sml` MUST be dated exactly at `height` and MUST already have
+    /// been DIP-4 client-verified by the caller (historical_sml.hpp). This
+    /// function does not authenticate; it adjudicates. `height` must be the
+    /// height of the pending mismatch AND the current apply cursor — both are
+    /// checked, and a mismatch on either is a refusal, never an attempt.
+    ///
+    /// WHY A LIST DATED AT `height` IS THE RIGHT JUDGE. dashd chooses block
+    /// H's payee from the list as of H-1, so a masternode banned exactly AT H
+    /// would still have been paid at H. We only get here because the projected
+    /// masternode was NOT paid, so any ban this list attests for it either
+    /// predates H (the case we are repairing) or is simultaneous with H — and
+    /// in the simultaneous case the masternode is genuinely out from H onward,
+    /// so retiring it with banHeight=H is exactly right for every later block.
+    ///
+    /// The ACCEPTANCE evidence is unchanged and unrelaxed: the accepted
+    /// candidate's scriptPayout must EXACTLY equal an output this block pays.
+    /// A better-dated list buys a better attestation; it never buys a guess.
+    ///
+    /// NO BUDGET IS SPENT. The budgeted walk (recover_from_sml_ban) is bounded
+    /// because it acts on the LIVE TIP list — an approximation, dated
+    /// elsewhere, that could in principle license a wrong permanent demotion.
+    /// This walk acts on a list whose merkle root is committed in the coinbase
+    /// of the very block being adjudicated, so the bound that matters is on
+    /// the number of ROUND TRIPS, which is the caller's on-demand fold cap.
+    /// Charging both would make one legitimate ban cost two budgets.
+    ReadjudicateResult readjudicate_payee(const dash::coin::BlockType& block,
+                                          uint32_t height,
+                                          const vendor::CSimplifiedMNList& sml)
+    {
+        ReadjudicateResult out;
+        if (!m_pending.present) {
+            out.refusal = "there is no pending payee mismatch to re-adjudicate";
+            return out;
+        }
+        if (m_pending.height != height) {
+            out.refusal = "the pending mismatch is at h="
+                        + std::to_string(m_pending.height) + ", not h="
+                        + std::to_string(height);
+            return out;
+        }
+        // BACKSTOP, not enforcement. The lane pauses its replay while the
+        // request is outstanding, so nothing can move the cursor between the
+        // mismatch and this call — and mutation testing agrees: deleting this
+        // guard produces no red today. It is kept because the load-bearing
+        // pause lives in ANOTHER file, and a future caller that reaches here
+        // by a third route must not adjudicate a height it is not standing on.
+        if (m_last_applied_height != height) {
+            out.refusal = "the apply cursor has moved to h="
+                        + std::to_string(m_last_applied_height)
+                        + " since the mismatch at h=" + std::to_string(height)
+                        + " — refusing to adjudicate a height we are no longer"
+                          " standing on";
+            return out;
+        }
+        if (block.m_txs.empty()) {
+            out.refusal = "the block carries no coinbase to cross-check against";
+            return out;
+        }
+
+        // The attestation source for THIS walk is the passed list and nothing
+        // else. m_sml_validity (the live tip list) is deliberately not
+        // consulted: mixing a tip-dated opinion into a height-exact
+        // adjudication would reintroduce the staleness this exists to remove.
+        std::map<uint256, bool> attested;
+        for (const auto& e : sml.mnList) attested[e.proRegTxHash] = e.isValid;
+        auto attest = [&attested](const uint256& h) -> std::optional<bool> {
+            auto it = attested.find(h);
+            if (it == attested.end()) return std::nullopt;
+            return it->second;
+        };
+        auto paid_in_cb = [&block](const std::vector<unsigned char>& script) {
+            if (script.empty()) return false;
+            for (const auto& vout : block.m_txs[0].vout)
+                if (vout.scriptPubKey.m_data == script) return true;
+            return false;
+        };
+
+        const WalkOutcome w =
+            walk_to_paid_candidate(m_pending.ranked, attest, paid_in_cb);
+        if (!w.accepted) {
+            out.refusal = std::string("the masternode list dated exactly at h=")
+                        + std::to_string(height) + " does not license a repair: "
+                        + (w.refusal ? w.refusal : "no candidate accepted");
+            return out;
+        }
+
+        const std::string demoted_hexes =
+            commit_walk_outcome(w, height,
+                                [this, height](Entries::iterator it) {
+                                    mark_paid_entry(it, height);
+                                });
+        out.recovered = true;
+        out.excluded  = w.demoted.size();
+        out.accepted  = w.accepted;
+        LOG_WARNING << "[MNS-SM] ON-DEMAND PoSe RE-ADJUDICATION h=" << height
+                    << ": projected payee(s) [" << demoted_hexes
+                    << "] attested INVALID by the masternode list dated EXACTLY"
+                       " at h=" << height << " (DIP-4 client-verified against"
+                       " this block's own coinbase commitment) — excluded"
+                       " permanently with banHeight=" << height
+                    << "; payment attributed to "
+                    << out.accepted->GetHex().substr(0, 16)
+                    << " whose scriptPayout matches this coinbase exactly. No"
+                       " demotion-walk budget was spent: this list is not an"
+                       " approximation of the height it judges, it IS that"
+                       " height.";
+        m_pending = PendingPayeeAdjudication{};
+        return out;
+    }
+
     // Process a single block. Mutates state per dashcore's
     // RebuildListFromBlock algorithm. Returns counts for logging.
     ApplyResult apply_block(const dash::coin::BlockType& block,
@@ -762,6 +936,13 @@ public:
             ranked.empty() ? std::optional<uint256>{}
                            : std::optional<uint256>{ranked.front()};
         r.projected_payee = projected;
+
+        // Past the guards, so this block WILL be applied: any pending
+        // re-adjudication belongs to an earlier height and is now unusable
+        // (its `ranked` was computed on a list this block is about to change).
+        // Dropping it here is what makes pending_payee_adjudication() mean
+        // "the cursor is standing on an unresolved mismatch" and nothing else.
+        m_pending = PendingPayeeAdjudication{};
 
         // ── Pass 1: special-tx records ─────────────────────────────
         // Walk all non-coinbase txs (i=1+). The order of types within
@@ -926,17 +1107,8 @@ public:
                 }
                 return false;
             };
-            auto mark_paid = [&](std::map<uint256, MNState>::iterator it) {
-                bool was_consecutive =
-                    (it->second.nLastPaidHeight == height - 1);
-                it->second.nLastPaidHeight = height;
-                if (it->second.nType == vendor::MnType::EVO) {
-                    it->second.nConsecutivePayments =
-                        was_consecutive
-                            ? it->second.nConsecutivePayments + 1 : 1;
-                } else {
-                    it->second.nConsecutivePayments = 0;
-                }
+            auto mark_paid = [&](Entries::iterator it) {
+                mark_paid_entry(it, height);
                 ++r.paid;
             };
 
@@ -950,6 +1122,14 @@ public:
                 } else if (!recover_from_sml_ban(ranked, height, paid_in_cb,
                                                  mark_paid, r)) {
                     r.payee_desync = true;
+                    // Keep the PRE-block queue alive so a caller that goes and
+                    // fetches a masternode list dated exactly at this height
+                    // can re-adjudicate ONLY this decision, without re-applying
+                    // a block the forward-only cursor would refuse.
+                    m_pending.present   = true;
+                    m_pending.height    = height;
+                    m_pending.ranked    = ranked;
+                    m_pending.projected = projected;
                     LOG_WARNING << "[MNS-SM] PAYEE DESYNC h=" << height
                                 << ": coinbase does not pay projected MN "
                                 << projected->GetHex().substr(0, 16)
@@ -1003,6 +1183,109 @@ private:
     //
     // Returns true iff a payment was attributed (r.paid / r.sml_recovered
     // updated); false means "no licensed repair" and the caller must desync.
+    /// The WALK ITSELF, with no opinion about where the attestations came
+    /// from. Two callers need identical stepping rules and identical refusal
+    /// semantics — the budgeted tip-SML walk below, and the on-demand
+    /// re-adjudication against a list dated exactly at the height. Two copies
+    /// of these rules would be two places for the acceptance evidence to rot.
+    ///
+    /// Mutates NOTHING. `refusal` names the FIRST rule that stopped it, so a
+    /// caller's fail-closed line can say which one rather than listing them.
+    struct WalkOutcome {
+        std::vector<uint256>   demoted;
+        std::optional<uint256> accepted;
+        const char*            refusal{nullptr};
+    };
+
+    template <typename AttestFn, typename PaidInCbFn>
+    WalkOutcome walk_to_paid_candidate(const std::vector<uint256>& ranked,
+                                       const AttestFn& attest,
+                                       const PaidInCbFn& paid_in_cb) const
+    {
+        WalkOutcome w;
+        if (ranked.size() < 2) {
+            w.refusal = "fewer than two payee candidates were ranked, so there"
+                        " is no runner-up to attribute the payment to";
+            return w;
+        }
+        for (size_t i = 0; i + 1 < ranked.size(); ++i) {
+            const std::optional<bool> att = attest(ranked[i]);
+            // nullopt (absent from the list) or true (attested valid): no
+            // licence to demote. Stop — this is a real desync.
+            if (!att.has_value()) {
+                w.refusal = "the list has NO ENTRY for the projected candidate,"
+                            " and absent is never evidence of a ban";
+                break;
+            }
+            if (*att) {
+                w.refusal = "the list attests the projected candidate VALID —"
+                            " that is counter-evidence, not a missed ban";
+                break;
+            }
+            w.demoted.push_back(ranked[i]);
+
+            auto nit = m_entries.find(ranked[i + 1]);
+            // The next candidate was removed by THIS block's passes 1/2
+            // (collateral spend / re-registration). We cannot test its script
+            // and the list cannot attest a departed MN, so refuse rather than
+            // skip over it.
+            if (nit == m_entries.end()) {
+                w.refusal = "the next ranked candidate was removed by this"
+                            " block's own special txs / collateral spends, so"
+                            " its script cannot be cross-checked";
+                break;
+            }
+            if (paid_in_cb(nit->second.scriptPayout.m_data)) {
+                w.accepted = ranked[i + 1];
+                w.refusal  = nullptr;
+                break;
+            }
+            // Not paid either — the loop's next iteration must independently
+            // earn the right to demote ranked[i+1] too.
+        }
+        if (!w.accepted && !w.refusal) {
+            w.refusal = "no candidate in the ranked queue has a scriptPayout"
+                        " this coinbase pays exactly";
+        }
+        return w;
+    }
+
+    /// Commit an accepted WalkOutcome: PERMANENT exclusions with a nonzero ban
+    /// height (so the ProUpServTx revival branch stays functional), then the
+    /// attribution. Returns the demoted hashes for the log line.
+    template <typename MarkPaidFn>
+    std::string commit_walk_outcome(const WalkOutcome& w, uint32_t height,
+                                    const MarkPaidFn& mark_paid)
+    {
+        std::string demoted_hexes;
+        for (const auto& d : w.demoted) {
+            auto dit = m_entries.find(d);
+            if (dit != m_entries.end()) {
+                dit->second.isValid        = false;
+                dit->second.nPoSeBanHeight = height;
+            }
+            if (!demoted_hexes.empty()) demoted_hexes += ",";
+            demoted_hexes += d.GetHex().substr(0, 16);
+        }
+        auto ait = m_entries.find(*w.accepted);
+        if (ait != m_entries.end()) mark_paid(ait);
+        return demoted_hexes;
+    }
+
+    /// dashcore's payee mark (nLastPaidHeight + the EVO consecutive-payment
+    /// counter), shared by every path that attributes a payment.
+    void mark_paid_entry(Entries::iterator it, uint32_t height)
+    {
+        const bool was_consecutive = (it->second.nLastPaidHeight == height - 1);
+        it->second.nLastPaidHeight = height;
+        if (it->second.nType == vendor::MnType::EVO) {
+            it->second.nConsecutivePayments =
+                was_consecutive ? it->second.nConsecutivePayments + 1 : 1;
+        } else {
+            it->second.nConsecutivePayments = 0;
+        }
+    }
+
     template <typename PaidInCbFn, typename MarkPaidFn>
     bool recover_from_sml_ban(const std::vector<uint256>& ranked,
                               uint32_t height,
@@ -1011,31 +1294,13 @@ private:
                               ApplyResult& r)
     {
         if (!m_sml_validity) return false;   // null hook → pre-hook behaviour
-        if (ranked.size() < 2) return false;
 
-        std::vector<uint256> demoted;
-        std::optional<uint256> accepted;
-        for (size_t i = 0; i + 1 < ranked.size(); ++i) {
-            const std::optional<bool> att = sml_attest(ranked[i], height);
-            // nullopt (absent from the SML) or true (attested valid): no
-            // licence to demote. Stop — this is a real desync.
-            if (!att.has_value() || *att) break;
-            demoted.push_back(ranked[i]);
-
-            auto nit = m_entries.find(ranked[i + 1]);
-            // The next candidate was removed by THIS block's passes 1/2
-            // (collateral spend / re-registration). We cannot test its script
-            // and the SML cannot attest a departed MN, so refuse rather than
-            // skip over it.
-            if (nit == m_entries.end()) break;
-            if (paid_in_cb(nit->second.scriptPayout.m_data)) {
-                accepted = ranked[i + 1];
-                break;
-            }
-            // Not paid either — the loop's next iteration must independently
-            // earn the right to demote ranked[i+1] too.
-        }
-        if (!accepted) return false;
+        const WalkOutcome w = walk_to_paid_candidate(
+            ranked,
+            [this, height](const uint256& h) { return sml_attest(h, height); },
+            paid_in_cb);
+        if (!w.accepted) return false;
+        const std::vector<uint256>& demoted = w.demoted;
 
         // Budget check LAST, so a refusal here mutates nothing either.
         if (m_sml_recovered_total + demoted.size() > m_sml_recovery_cap) {
@@ -1048,18 +1313,9 @@ private:
             return false;
         }
 
-        std::string demoted_hexes;
-        for (const auto& d : demoted) {
-            auto dit = m_entries.find(d);
-            if (dit != m_entries.end()) {
-                dit->second.isValid       = false;
-                dit->second.nPoSeBanHeight = height;
-            }
-            if (!demoted_hexes.empty()) demoted_hexes += ",";
-            demoted_hexes += d.GetHex().substr(0, 16);
-        }
-        auto ait = m_entries.find(*accepted);
-        if (ait != m_entries.end()) mark_paid(ait);
+        const std::string demoted_hexes =
+            commit_walk_outcome(w, height, mark_paid);
+        const std::optional<uint256>& accepted = w.accepted;
 
         r.sml_recovered        = demoted.size();
         m_sml_recovered_total += demoted.size();
@@ -1075,8 +1331,13 @@ private:
         return true;
     }
 
-    std::map<uint256, MNState>                                          m_entries;
+    Entries                                                             m_entries;
     std::map<bitcoin_family::coin::TxPrevOut, uint256, TxPrevOutLess>   m_collateral_index;
+
+    // The unresolved mismatch the cursor is standing on, if any. Written by
+    // pass 3, cleared by the next apply_block and by a successful
+    // readjudicate_payee(). See PendingPayeeAdjudication.
+    PendingPayeeAdjudication m_pending;
 
     // Optional SML attestation hook (see set_sml_validity_fn). NULL by
     // default: no hook, no recovery, byte-identical pre-hook behaviour.

--- a/test/test_dash_mn_checkpoint.cpp
+++ b/test/test_dash_mn_checkpoint.cpp
@@ -2690,3 +2690,475 @@ TEST(DashMnCheckpointPoseFold, SnapshotWithNoExpectedHeightIsRefused)
         << "a null header merkle root is not an anchor, it is the absence of"
            " one -- accepting it lets a peer authenticate against nothing";
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 9. ON-DEMAND PoSe FOLD — fire AT the payee mismatch, not at a fold point
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// THE MEASUREMENT this section is built from. contabo daemonless soak against
+// mainnet, anchor 2513000, fold interval 500; the chain asked directly (hotel
+// dashd 23.1.7 with addressindex, 2026-08-02):
+//
+//     h=2513000  protx list valid 2068  projected payee e8626fcd57f6394d…
+//                                       PRESENT   <- our anchor fold, correct
+//     h=2513400                   2068  PRESENT
+//     h=2513488                   2066  ABSENT    <- PoSe-banned in this range
+//     h=2513489                   2066  ABSENT    <- projected anyway -> DEAD
+//     next fold point   h=2513500                 <- ELEVEN BLOCKS TOO LATE
+//
+// The chain paid 4cad8728bb473c80fa9862c8d87ff8be7096c29d9eee1f43dd714b53ce…
+// THREE separate builds fail-closed at that identical height, one of them
+// carrying no fold code at all. So the fold MECHANISM was right and only its
+// GRANULARITY was wrong: a ban that lands strictly BETWEEN two fold points is
+// invisible to fold points, and the reactive walk that DOES fire at the
+// mismatch was consulting a list up to fold_interval-1 blocks stale.
+//
+// Shrinking the interval is the wrong fix twice over — it pays a round trip
+// continuously AND still leaves a window. The mismatch itself is the perfect
+// trigger: it fires exactly when, and only when, the queue is wrong.
+//
+// Every fixture below uses the REAL heights, and the fixture arithmetic is
+// static_asserted to sit strictly inside a fold interval, so none of these
+// cases can be quietly rescued by a scheduled fold.
+namespace {
+
+constexpr uint32_t kOdAnchor   = 2513000;   // a fold point (the anchor)
+constexpr uint32_t kOdTip      = 2513005;
+constexpr uint32_t kOdMismatch = 2513003;   // the banned masternode's turn
+constexpr size_t   kOdBannedRank = 2;       // banned STRICTLY inside the window
+constexpr size_t   kOdSetSize    = 64;
+
+// The fixture is only honest if the failing height is unreachable by any
+// scheduled fold. Proven here rather than asserted at runtime, because at
+// runtime m_last_fold_height has already moved.
+static_assert(kOdMismatch > kOdAnchor && kOdMismatch < kOdTip,
+              "the mismatch must be neither the anchor fold nor the final fold");
+static_assert(kOdMismatch - kOdAnchor
+                  < MnCheckpointLane::kDefaultFoldInterval,
+              "the mismatch must land STRICTLY INSIDE one fold interval — that"
+              " is the whole defect");
+
+// Install the measured shape into `rig` and return the anchor.
+//
+//   * the list AS OF THE ANCHOR attests every masternode VALID — the ban has
+//     not happened yet, exactly as `protx list valid 2513000` showed;
+//   * every LATER height attests rank kOdBannedRank banned — the ban lands
+//     inside the interval;
+//   * the coinbases pay ranks 0, 1, then SKIP the banned rank and pay 3, 4, 5,
+//     which is precisely what an accepted block does when dashd has banned our
+//     queue head and we have not noticed.
+MnCheckpoint build_ondemand_scenario(SnapshotRig& rig,
+                                     std::initializer_list<size_t> pays
+                                         = {0, 1, 3, 4, 5},
+                                     std::initializer_list<size_t> banned
+                                         = {kOdBannedRank})
+{
+    const uint256 anchor_hash = uint256S(kAnchorHash);
+    MnCheckpoint cp = synthetic_anchor(kOdSetSize, kOdAnchor, anchor_hash);
+
+    std::vector<std::pair<uint256, bool>> all_valid, with_bans;
+    for (size_t i = 0; i < cp.entries.size(); ++i) {
+        all_valid.emplace_back(cp.entries[i].first, true);
+        bool is_banned = false;
+        for (size_t b : banned) if (b == i) is_banned = true;
+        with_bans.emplace_back(cp.entries[i].first, !is_banned);
+    }
+
+    rig.attest = with_bans;                       // the default for any height
+    rig.install(kOdAnchor, kOdTip, anchor_hash);
+    rig.by_height[kOdAnchor] = make_snapshot(anchor_hash, kOdAnchor, all_valid);
+
+    uint32_t bh = kOdAnchor + 1;
+    for (size_t rank : pays) {
+        rig.h.blocks[bh] =
+            block_paying(cp.entries[rank].second.scriptPayout.m_data);
+        ++bh;
+    }
+    return cp;
+}
+
+const MNState& published_rank(const BridgeHarness& h, const MnCheckpoint& cp,
+                              size_t rank)
+{
+    static MNState missing;
+    for (const auto& [hash, st] : h.published_set)
+        if (hash == cp.entries[rank].first) return st;
+    ADD_FAILURE() << "rank " << rank << " is absent from the published set";
+    return missing;
+}
+
+} // namespace
+
+// ── CASE 1 (THE LOAD-BEARING ONE). A masternode valid at the anchor, PoSe-
+// banned strictly BETWEEN two fold points, and a payee mismatch at a height
+// inside that interval. Today's fold points cannot see it; the on-demand fold
+// must, and the bridge must COMPLETE.
+TEST(DashMnCheckpointOnDemandFold, BanBetweenFoldPointsIsRepairedAtTheMismatch)
+{
+    SnapshotRig rig;
+    const auto cp = build_ondemand_scenario(rig);
+
+    rig.h.lane.arm(cp);
+    rig.h.lane.pump();
+
+    ASSERT_TRUE(rig.h.published) << "status: " << rig.h.lane.status();
+    EXPECT_EQ(rig.h.lane.state(), MnCheckpointLane::State::Published);
+    EXPECT_EQ(rig.h.published_as_of, kOdTip);
+
+    // The anchor fold RAN and correctly removed NOTHING: at h=2513000 the
+    // masternode was still valid. That is what makes this a between-fold-point
+    // ban rather than an anchor that was simply stale.
+    EXPECT_EQ(rig.h.lane.first_fold_height(), kOdAnchor);
+
+    // The repair came from the ON-DEMAND path, not from a fold point and not
+    // from the budgeted walk.
+    EXPECT_EQ(rig.h.lane.ondemand_folds(), 1u)
+        << "status: " << rig.h.lane.status();
+    EXPECT_EQ(rig.h.lane.ondemand_excluded(), 1u);
+    EXPECT_TRUE(rig.h.lane.ondemand_evaluated());
+    EXPECT_FALSE(rig.h.lane.ondemand_cap_hit());
+    // The cap here is the AUTO-SIZED one, and it names its own formula on the
+    // published status — so an operator reading a live node sees the threshold
+    // and how it was derived, not just the count.
+    EXPECT_EQ(rig.h.lane.ondemand_cap(),
+              MnCheckpointLane::kOnDemandFoldBase
+                  + (kOdTip - kOdAnchor)
+                        / MnCheckpointLane::kOnDemandFoldPerBlocks);
+    EXPECT_NE(rig.h.lane.status().find("ON-DEMAND PoSe folds: 1/8 used"
+                                       " (cap = 8 + replay_blocks/250)"),
+              std::string::npos)
+        << "status: " << rig.h.lane.status();
+    EXPECT_EQ(rig.h.lane.sml_recovered(), 0u)
+        << "the tip-SML demotion walk must not have been needed, and must not"
+           " have spent any of its per-bridge budget";
+
+    // The set FELL by exactly one, which is the direction an additions-only
+    // replay structurally cannot move in.
+    EXPECT_EQ(rig.h.lane.eligible_size(), kOdSetSize - 1);
+    EXPECT_EQ(rig.h.lane.pose_removed(), 1u)
+        << "the on-demand fold is WHOLESALE: the banned masternode leaves the"
+           " eligible set, not just this one block's projection";
+
+    // The exclusion is PERMANENT and dated at the height that proved it — a
+    // one-shot skip would put it back at the head of the queue at its next
+    // turn and desync the replay all over again.
+    const MNState& banned = published_rank(rig.h, cp, kOdBannedRank);
+    EXPECT_FALSE(banned.isValid);
+    EXPECT_EQ(banned.nPoSeBanHeight, kOdMismatch);
+    EXPECT_EQ(banned.nLastPaidHeight, kOdAnchor - 2100 + kOdBannedRank)
+        << "the banned masternode must NOT be credited with the payment";
+    // ...and the payment went to the candidate whose scriptPayout this
+    // coinbase actually pays, byte for byte.
+    EXPECT_EQ(published_rank(rig.h, cp, 3).nLastPaidHeight, kOdMismatch);
+    // The replay carried on correctly afterwards, which is the real proof the
+    // queue was repaired and not merely patched for one block.
+    EXPECT_EQ(published_rank(rig.h, cp, 4).nLastPaidHeight, kOdMismatch + 1);
+    EXPECT_EQ(published_rank(rig.h, cp, 5).nLastPaidHeight, kOdMismatch + 2);
+}
+
+// ── CASE 1-TWIN (NEGATIVE). THE SAME FIXTURE with the on-demand path removed
+// — cap 0 disables it at its entry point — must fail closed exactly as this
+// lane always did. Without this the case above is unfalsifiable: it would pass
+// just as happily if the fixture never mismatched at all.
+TEST(DashMnCheckpointOnDemandFold, TwinWithTheOnDemandPathRemovedFailsClosed)
+{
+    SnapshotRig rig;
+    const auto cp = build_ondemand_scenario(rig);
+    rig.h.lane.set_ondemand_fold_cap(0);       // the ONLY difference
+
+    rig.h.lane.arm(cp);
+    rig.h.lane.pump();
+
+    EXPECT_EQ(rig.h.lane.state(), MnCheckpointLane::State::FailedClosed)
+        << "status: " << rig.h.lane.status();
+    EXPECT_FALSE(rig.h.published)
+        << "a masternode set assembled over an unresolved payee mismatch would"
+           " mint a rejected coinbase";
+    EXPECT_NE(rig.h.lane.status().find("PAYEE DESYNC at h="
+                                       + std::to_string(kOdMismatch)),
+              std::string::npos)
+        << "the twin must fail at the SAME height the positive case repairs: "
+        << rig.h.lane.status();
+    EXPECT_EQ(rig.h.lane.ondemand_folds(), 0u);
+    EXPECT_NE(rig.h.lane.status().find("ON-DEMAND PoSe folds: DISABLED (cap 0"),
+              std::string::npos)
+        << "a disabled path must name itself as disabled: " << rig.h.lane.status();
+    EXPECT_EQ(rig.h.lane.eligible_size(), kOdSetSize)
+        << "with no on-demand fold the set can only ever CLIMB — the measured"
+           " 2067->2070-while-the-chain-fell shape";
+}
+
+// ── The reward-critical one. A historical reply must never reach the LIVE tip
+// SML: the maintainer adopts any base==ZERO diff wholesale, so an on-demand
+// reply routed to it would silently rewrite the tip list to a past state on
+// the money path. The on-demand fold adds NO second filter slot — it goes
+// through the same HistoricalMnListDiffDemux #1028 installed.
+TEST(DashMnCheckpointOnDemandFold, OnDemandReplyNeverMutatesTheLiveTipSml)
+{
+    DemuxRig d;
+    const auto cp = build_ondemand_scenario(d.rig);
+    d.wire(/*register_lane_filter=*/true);   // MUST come after install()
+
+    ASSERT_FALSE(d.tip_state.have_sml())
+        << "the hazard window is a COLD tip SML; the fixture must start there";
+    const size_t  size_before = d.tip_state.sml().mnList.size();
+    const uint256 root_before = d.tip_state.sml().CalcMerkleRoot();
+
+    d.rig.h.lane.arm(cp);
+    d.rig.h.lane.pump();
+
+    ASSERT_TRUE(d.rig.h.published) << d.rig.h.lane.status();
+    ASSERT_EQ(d.rig.h.lane.ondemand_folds(), 1u)
+        << "the on-demand reply must actually have been exercised, or this"
+           " proves nothing: " << d.rig.h.lane.status();
+
+    EXPECT_EQ(d.tip_feeds, 0u)
+        << "a historical reply reached the tip-SML maintainer";
+    EXPECT_FALSE(d.tip_state.have_sml())
+        << "the live tip SML was CREATED from an on-demand historical reply";
+    EXPECT_EQ(d.tip_state.sml().mnList.size(), size_before);
+    EXPECT_EQ(d.tip_state.sml().CalcMerkleRoot(), root_before)
+        << "the live tip SML is not byte-identical after the on-demand reply";
+}
+
+// ── ONE OUTSTANDING getmnlistd. Replies are matched by block hash, so a second
+// in-flight request draws a reply that matches no await and leaks past the
+// demux. The replay must therefore PAUSE on its own on-demand request and must
+// not race it — and, unlike an interval fold, it must NOT resume degraded when
+// the reply never comes, because the mismatch it is parked on is unresolved.
+TEST(DashMnCheckpointOnDemandFold, ReplayPausesOnItsOwnOnDemandRequest)
+{
+    SnapshotRig rig;
+    const auto cp = build_ondemand_scenario(rig);
+    // Answer the ANCHOR fold; HOLD the on-demand one, so the pause is on the
+    // request this case is about.
+    rig.h.lane.set_request_snapshot_fn([&rig](const uint256& bh) {
+        rig.requested.push_back(bh);
+        auto hi = rig.height_of.find(bh);
+        if (hi == rig.height_of.end()) return;
+        if (hi->second != kOdAnchor) return;             // held
+        rig.h.lane.on_historical_snapshot(
+            rig.snapshot_for(hi->second, bh).diff);
+    });
+
+    rig.h.lane.arm(cp);
+    rig.h.lane.pump();
+
+    ASSERT_TRUE(rig.h.lane.snapshot_pending()) << rig.h.lane.status();
+    ASSERT_EQ(rig.requested.size(), 2u)
+        << "one anchor fold + one on-demand fold, and nothing else";
+    EXPECT_EQ(rig.h.lane.cursor_height(), kOdMismatch - 1)
+        << "the cursor must NOT have advanced over the mismatching block";
+
+    // A block delivered while paused must be dropped, not folded: the cursor
+    // cannot be allowed past the height the pending list describes.
+    rig.h.lane.on_block_connected(rig.h.blocks[kOdMismatch + 1],
+                                  kOdMismatch + 1);
+    EXPECT_EQ(rig.h.lane.cursor_height(), kOdMismatch - 1);
+
+    // Further drives must not issue a SECOND request...
+    rig.h.lane.pump();
+    rig.h.lane.pump();
+    EXPECT_EQ(rig.requested.size(), 2u)
+        << "a duplicate getmnlistd draws a reply that matches no await";
+    // ...until the re-ask, which is deliberately the SAME block hash, so a
+    // reply to either ask is indistinguishable and both are ours.
+    rig.h.lane.pump();
+    ASSERT_EQ(rig.requested.size(), 3u) << "the re-ask must happen";
+    EXPECT_EQ(rig.requested[2], rig.requested[1])
+        << "the re-ask must name the SAME block, or two replies are in flight";
+
+    // And when it is never answered: FAIL CLOSED. Resuming "degraded" is what
+    // an abandoned INTERVAL fold does, and it would be wrong here — the replay
+    // is parked on a payee mismatch it has not adjudicated.
+    for (int i = 0; i < 9; ++i) rig.h.lane.pump();
+    EXPECT_EQ(rig.h.lane.state(), MnCheckpointLane::State::FailedClosed)
+        << "status: " << rig.h.lane.status();
+    EXPECT_FALSE(rig.h.published);
+    EXPECT_NE(rig.h.lane.status().find("went unanswered"), std::string::npos)
+        << rig.h.lane.status();
+    EXPECT_EQ(rig.h.lane.abandoned_folds(), 0u)
+        << "an unanswered ON-DEMAND ask is not an abandoned fold POINT — that"
+           " counter means 'the replay carried on degraded', and it did not";
+    EXPECT_NE(rig.h.lane.status().find("did NOT carry on degraded"),
+              std::string::npos)
+        << rig.h.lane.status();
+}
+
+// ── THE CAP FIRES AND NAMES ITSELF. Two mismatches whose bans appear in
+// DIFFERENT lists (so the first wholesale fold cannot pre-empt the second),
+// run twice on the identical fixture: once with a cap of 1 (refused, terminal)
+// and once with a cap of 2 (repaired, published). The positive control is what
+// proves the CAP refused rather than the fixture being unrepairable.
+namespace {
+
+// rank 2 banned by the h=kOdMismatch list only; rank 5 banned by every OTHER
+// height's list. The coinbases skip both.
+MnCheckpoint build_two_mismatch_scenario(SnapshotRig& rig)
+{
+    const uint256 anchor_hash = uint256S(kAnchorHash);
+    MnCheckpoint cp = synthetic_anchor(kOdSetSize, kOdAnchor, anchor_hash);
+
+    std::vector<std::pair<uint256, bool>> all_valid, ban2, ban2and5;
+    for (size_t i = 0; i < cp.entries.size(); ++i) {
+        all_valid.emplace_back(cp.entries[i].first, true);
+        ban2.emplace_back(cp.entries[i].first, i != 2);
+        ban2and5.emplace_back(cp.entries[i].first, i != 2 && i != 5);
+    }
+    rig.attest = ban2and5;
+    rig.install(kOdAnchor, kOdTip, anchor_hash);
+    rig.by_height[kOdAnchor]   = make_snapshot(anchor_hash, kOdAnchor, all_valid);
+    rig.by_height[kOdMismatch] =
+        make_snapshot(rig.h.headers[kOdMismatch], kOdMismatch, ban2);
+
+    const size_t pays[] = {0, 1, 3, 4, 6};   // rank 2 and rank 5 both skipped
+    for (uint32_t bh = kOdAnchor + 1; bh <= kOdTip; ++bh)
+        rig.h.blocks[bh] =
+            block_paying(cp.entries[pays[bh - kOdAnchor - 1]]
+                             .second.scriptPayout.m_data);
+    return cp;
+}
+
+} // namespace
+
+TEST(DashMnCheckpointOnDemandFold, CapRefusesTheSecondFoldAndSaysItsOwnName)
+{
+    SnapshotRig rig;
+    const auto cp = build_two_mismatch_scenario(rig);
+    rig.h.lane.set_ondemand_fold_cap(1);
+
+    rig.h.lane.arm(cp);
+    rig.h.lane.pump();
+
+    EXPECT_EQ(rig.h.lane.state(), MnCheckpointLane::State::FailedClosed)
+        << "status: " << rig.h.lane.status();
+    EXPECT_EQ(rig.h.lane.ondemand_folds(), 1u) << rig.h.lane.status();
+    EXPECT_EQ(rig.h.lane.ondemand_cap(), 1u);
+    EXPECT_TRUE(rig.h.lane.ondemand_cap_hit());
+
+    // The cap must SAY ITS OWN NAME: measured value, threshold, and the
+    // formula that produced the threshold.
+    const std::string s = rig.h.lane.status();
+    EXPECT_NE(s.find("ON-DEMAND PoSe folds: 1/1"), std::string::npos) << s;
+    EXPECT_NE(s.find("THE CAP IS EXHAUSTED"), std::string::npos) << s;
+    EXPECT_NE(s.find("cap set explicitly"), std::string::npos)
+        << "a cap that was overridden must not quote the auto-sizing formula"
+           " it did not use: " << s;
+}
+
+TEST(DashMnCheckpointOnDemandFold, TheSameTwoMismatchesFitUnderACapOfTwo)
+{
+    SnapshotRig rig;
+    const auto cp = build_two_mismatch_scenario(rig);
+    rig.h.lane.set_ondemand_fold_cap(2);
+
+    rig.h.lane.arm(cp);
+    rig.h.lane.pump();
+
+    ASSERT_TRUE(rig.h.published) << "status: " << rig.h.lane.status();
+    EXPECT_EQ(rig.h.lane.ondemand_folds(), 2u);
+    EXPECT_EQ(rig.h.lane.ondemand_excluded(), 2u);
+    EXPECT_FALSE(rig.h.lane.ondemand_cap_hit());
+    EXPECT_EQ(rig.h.lane.eligible_size(), kOdSetSize - 2)
+        << "both bans left the eligible set";
+    EXPECT_EQ(published_rank(rig.h, cp, 6).nLastPaidHeight, kOdTip);
+}
+
+// ── A FIELD THAT WAS NEVER EVALUATED PRINTS n/a, NEVER 0. "No mismatch ever
+// happened" and "mismatches happened and needed no fold" are different facts,
+// and a bare 0 asserts the second while meaning the first.
+TEST(DashMnCheckpointOnDemandFold, NeverEvaluatedReportsNotApplicableNotZero)
+{
+    SnapshotRig rig;
+    // A clean replay: every coinbase pays exactly what we project.
+    const auto cp = build_ondemand_scenario(rig, {0, 1, 2, 3, 4}, {});
+
+    rig.h.lane.arm(cp);
+    rig.h.lane.pump();
+
+    ASSERT_TRUE(rig.h.published) << rig.h.lane.status();
+    EXPECT_FALSE(rig.h.lane.ondemand_evaluated());
+    const std::string s = rig.h.lane.status();
+    EXPECT_NE(s.find("ON-DEMAND PoSe folds: n/a"), std::string::npos) << s;
+    EXPECT_EQ(s.find("ON-DEMAND PoSe folds: 0"), std::string::npos)
+        << "a never-evaluated counter must not print as a measured zero: " << s;
+}
+
+TEST(DashMnCheckpointOnDemandFold, UnwiredSnapshotSeamIsReportedAsNotApplicable)
+{
+    // The bridge harness with NO per-height snapshot seam at all: the
+    // pre-#1028 shape, where a mismatch is simply terminal.
+    RecoveryRig r;
+    auto blk = repay_coinbase(block_from_hex(kBlockHex1519544),
+                              payout_of(r.cp, kQ1), payout_of(r.cp, kQ2));
+    r.run(blk);
+
+    ASSERT_EQ(r.h.lane.state(), MnCheckpointLane::State::FailedClosed);
+    const std::string s = r.h.lane.status();
+    EXPECT_NE(s.find("ON-DEMAND PoSe folds: n/a (the per-height snapshot seam"
+                     " is not wired"), std::string::npos)
+        << "an unwired seam must be named as unwired, not reported as zero"
+           " folds used: " << s;
+}
+
+// ── A better-dated list buys a better ATTESTATION; it never buys a guess. If
+// the list dated exactly at the failing height says the projected masternode
+// is still VALID, the mismatch is a real divergence (wrong anchor, missed
+// block) and the answer is the one it always was.
+TEST(DashMnCheckpointOnDemandFold, ListAttestingTheProjectedPayeeValidStillFails)
+{
+    SnapshotRig rig;
+    // The coinbases skip rank 2, but NO list ever attests rank 2 banned.
+    const auto cp = build_ondemand_scenario(rig, {0, 1, 3, 4, 5}, {});
+
+    rig.h.lane.arm(cp);
+    rig.h.lane.pump();
+
+    EXPECT_EQ(rig.h.lane.state(), MnCheckpointLane::State::FailedClosed)
+        << "status: " << rig.h.lane.status();
+    EXPECT_FALSE(rig.h.published);
+    EXPECT_EQ(rig.h.lane.ondemand_folds(), 1u)
+        << "the fold must have been FETCHED and believed — it is the"
+           " adjudication that refused, not the request";
+    const std::string s = rig.h.lane.status();
+    EXPECT_NE(s.find("SURVIVED the ON-DEMAND PoSe fold"), std::string::npos) << s;
+    EXPECT_NE(s.find("attests the projected candidate VALID"), std::string::npos)
+        << "the refusal must name WHICH rule stopped the walk: " << s;
+}
+
+// ── THE ACCEPTANCE RULE, ISOLATED. A better-dated list may license a
+// DEMOTION; only the coinbase may license an ATTRIBUTION. Here every candidate
+// in the ranked window is attested banned — so the walk never stops on
+// attestation — and the block pays a masternode far outside that window. The
+// walk must run out and REFUSE, not attribute the payment to the first
+// runner-up it reaches.
+//
+// ADDED AFTER A MUTATION FOUND NOTHING: relaxing paid_in_cb() inside
+// readjudicate_payee() to "any non-empty script matches" left the whole suite
+// green, because every other on-demand case stops on the ATTESTATION rule
+// before it ever reaches the script comparison. This is the case that reaches
+// it.
+TEST(DashMnCheckpointOnDemandFold, ScriptMatchIsTheOnlyLicenceToAttribute)
+{
+    SnapshotRig rig;
+    // Ranks 2..8 (the whole ranked window bar the last slot) attested banned,
+    // and the coinbase pays rank 40 — inside the set, outside the queue window.
+    const auto cp = build_ondemand_scenario(
+        rig, /*pays=*/{0, 1, 40, 41, 42}, /*banned=*/{2, 3, 4, 5, 6, 7, 8});
+
+    rig.h.lane.arm(cp);
+    rig.h.lane.pump();
+
+    EXPECT_EQ(rig.h.lane.state(), MnCheckpointLane::State::FailedClosed)
+        << "status: " << rig.h.lane.status();
+    EXPECT_FALSE(rig.h.published);
+    const std::string s = rig.h.lane.status();
+    EXPECT_NE(s.find("PAYEE DESYNC at h=" + std::to_string(kOdMismatch)),
+              std::string::npos)
+        << "the refusal must be at the height whose coinbase could not be"
+           " matched: " << s;
+    EXPECT_NE(s.find("no candidate in the ranked queue has a scriptPayout this"
+                     " coinbase pays exactly"), std::string::npos)
+        << "the refusal must name the SCRIPT rule, not the attestation rule: "
+        << s;
+}


### PR DESCRIPTION
## The measurement

The contabo daemonless soak fail-closes at **h=2513489**, every time. Asked of the chain
directly (hotel dashd 23.1.7, addressindex enabled, 2026-08-02), anchor 2513000, fold
interval 500:

```
h=2513000   valid 2068   projected payee e8626fcd57f6394d…  PRESENT   <- our fold ran here, correctly said VALID
h=2513400   valid 2068                                      PRESENT
h=2513488   valid 2066                                      ABSENT    <- PoSe-banned in this range
h=2513489   valid 2066                                      ABSENT    <- we projected it anyway -> fail-closed
next fold point            h=2513500                                  <- ELEVEN BLOCKS TOO LATE
```

The chain paid `4cad8728bb473c80fa9862c8d87ff8be7096c29d9eee1f43dd714b53ce5f948f`.

Three separate builds fail-closed at that identical height — one of them carrying no fold
code at all. So the fold **mechanism** is right and only its **granularity** was wrong: a
PoSe ban landing strictly inside a fold interval is invisible to fold points, and the
reactive per-mismatch walk that *does* fire at the failing height was consulting a list up
to `fold_interval - 1` blocks stale.

## The change

```
today   mismatch at h -> adjudicate against the SML from the last fold point (up to 499 blocks stale)
this PR mismatch at h -> request the SML AS OF h -> re-adjudicate -> exact, zero window
```

`recover_from_sml_ban` already fires exactly when the projected payee does not match the
block's coinbase — i.e. precisely at h=2513489. It just consulted a stale list. The
mismatch is now the trigger for a fold of its own, reusing the per-height request
machinery that landed with the interval fold (`historical_sml.hpp`,
`HistoricalMnListDiffDemux`, `authenticate_historical_snapshot()`). No second request
path, no second demux slot, no `main_dash` wiring change — the seams were already there.

On a mismatch at height H the lane now:

1. pauses the replay and asks for `getmnlistd(ZERO, hash_at(H))`;
2. DIP-4 client-verifies the reply against block H's own coinbase commitment;
3. applies the **wholesale** fold at H — so a ban *burst* costs the same as one ban;
4. re-adjudicates that block's payee against that list, demanding the same unrelaxed
   evidence the walk always did: the accepted candidate's `scriptPayout` must EXACTLY
   equal an output this block pays;
5. resumes at H+1, or fails closed.

### Why not simply shrink the fold interval

A finer interval pays a network round trip *continuously* — every interval, ban or no ban
— and **still leaves a window**; it only makes the window smaller. Firing at the mismatch
pays a round trip only when a mismatch actually occurs, and leaves no window at all,
because the list asked for is dated at the very height that failed.

## Safety — the same argument as the interval fold, intact

* the requested list is DIP-4 client-verified against the block's own coinbase commitment;
* `cursor == H` holds **by construction**: we name the height being adjudicated, ask for
  `hash_at(H)` from our own PoW-validated header chain, and `authenticate_historical_snapshot`
  refuses the reply unless the embedded cbTx's `nHeight` IS H;
* the replay **pauses** while the request is outstanding — one outstanding `getmnlistd` at
  a time, enforced by the same `m_snapshot_pending` latch the interval fold uses, so there
  is one pause mechanism rather than two;
* the reply is routed through the **existing** `HistoricalMnListDiffDemux`. No new filter
  slot, no second route to the live tip SML;
* an unanswered on-demand request **fails closed**. It does not resume "degraded" the way
  an abandoned interval fold does — the replay is parked on a mismatch it has not
  adjudicated, and carrying on would mean publishing a queue we already know disagrees
  with the chain;
* every other failure path lands on today's behaviour: fail closed, never a guessed payee.

No demotion-walk budget is spent by the on-demand path. That budget bounds a walk acting on
the LIVE TIP list — an approximation, dated elsewhere. This walk acts on a list whose merkle
root is committed in the coinbase of the very block being adjudicated, so the bound that
matters is on round trips, which is the cap below. Charging both would make one legitimate
ban cost two budgets.

## The cap

```
cap = 8 + replay_blocks / 250        (kOnDemandFoldBase, kOnDemandFoldPerBlocks)
```

It bounds **round trips, not trust**: every on-demand fold is DIP-4 verified against the
block it judges, so an extra one costs correctness nothing. What it costs is one
`getmnlistd` and one paused replay — and a bridge that mismatches on every block is not
experiencing PoSe bans, it has a wrong anchor or a broken replay, and must stop rather than
ask a peer for a list per block.

Sizing, from the measurement: one on-demand fold repairs an entire burst at once (the
wholesale pass retires every masternode the list attests banned, not just the queue head),
so the cost is one round trip per DISTINCT ban EVENT that reaches the queue head between
two fold points. Mainnet 2026-08-02: 9 masternodes left `protx list valid` across 1874
blocks — roughly one ban event per 200 blocks, and only a fraction of those hit the queue
head before the next scheduled fold. `/250` tracks that with headroom; the base of 8 covers
a SHORT bridge where the ratio term contributes nothing but a burst can still land. At the
default 20000-block bridge bound that is 8 + 80 = 88 round trips worst case — negligible
against the 20000 `getdata` the same bridge already issues, while a runaway stops after 88
instead of after 20000.

`set_ondemand_fold_cap(0)` disables the path entirely, restoring the pre-change behaviour
exactly.

### The cap says its own name

Every fail-closed report, `divergence_report()`, and the published status now carry:

```
ON-DEMAND PoSe folds: 1/8 used (cap = 8 + replay_blocks/250), 1 queue-head exclusion(s)
licensed by a list dated EXACTLY at the height it judged.
```

and when hit:

```
THE CAP IS EXHAUSTED: 1 of 1 — a further mismatch was REFUSED rather than asking a peer for
another list. A bridge that needs more than this is not experiencing PoSe bans; suspect the
anchor or the replay.
```

A field that was **never evaluated prints `n/a`, never `0`** — "no mismatch ever happened"
and "mismatches happened and needed no fold" are different facts, and a bare 0 asserts the
second while meaning the first:

```
ON-DEMAND PoSe folds: n/a — no payee mismatch ever reached the on-demand path, so its cap (8) was never tested.
ON-DEMAND PoSe folds: n/a (the per-height snapshot seam is not wired, …)
ON-DEMAND PoSe folds: DISABLED (cap 0, cap set explicitly) — …
```

## Tests

Ten cases folded into the already-allowlisted `test_dash_node_reception_wire` target (a new
`add_executable` would not be in the `build.yml --target` list and would silently report
"Not Run" — the NOT_BUILT sentinel trap). Every fixture uses the REAL heights, and the
fixture arithmetic is `static_assert`ed to sit strictly inside a fold interval, so no case
can be quietly rescued by a scheduled fold.

* `BanBetweenFoldPointsIsRepairedAtTheMismatch` — the load-bearing one, modelled on the
  measured failure: valid at the anchor, PoSe-banned strictly BETWEEN two fold points,
  payee mismatch inside that interval. Must recover; the set must FALL by one (the direction
  an additions-only replay structurally cannot move in); the exclusion must be permanent and
  dated at the height that proved it; the replay must carry on correctly for two more blocks.
* `TwinWithTheOnDemandPathRemovedFailsClosed` — **the negative twin**. Identical fixture,
  on-demand path removed, must fail closed at the SAME height, and the set must only CLIMB.
* `OnDemandReplyNeverMutatesTheLiveTipSml` — reward-critical: the tip SML is byte-identical
  (size + merkle root) before and after an on-demand historical reply, and the maintainer is
  never fed.
* `ReplayPausesOnItsOwnOnDemandRequest` — exactly one request in flight; blocks delivered
  while paused are dropped; the re-ask names the SAME block hash; an unanswered ask fails
  closed rather than resuming degraded, and is NOT counted as an abandoned fold point.
* `CapRefusesTheSecondFoldAndSaysItsOwnName` / `TheSameTwoMismatchesFitUnderACapOfTwo` —
  the cap fires and names itself, with a positive control on the identical fixture proving
  it was the CAP that refused and not the fixture being unrepairable.
* `NeverEvaluatedReportsNotApplicableNotZero` / `UnwiredSnapshotSeamIsReportedAsNotApplicable`
  — `n/a`, never `0`.
* `ListAttestingTheProjectedPayeeValidStillFails` — a better-dated list buys a better
  attestation, never a guess.
* `ScriptMatchIsTheOnlyLicenceToAttribute` — only the coinbase may license an attribution.

### Real numbers

```
cmake --build build_ci --target test_dash_node_reception_wire -j8
ctest --test-dir build_ci -R 'DashMnCheckpoint|DashMnPayeeLatch'
  -> 100% tests passed, 0 tests failed out of 68   (58 pre-existing + 10 new)
```

### Mutation testing — every new case proved able to go red

| mutation | red |
|---|---|
| M1 on-demand trigger deleted from `on_block_connected` | 6 (incl. the load-bearing case) |
| M2 re-adjudication never called (wholesale fold only) | 4 |
| M3 wholesale fold skipped (re-adjudication only) | 1 |
| M4 on-demand reply not claimed (falls through to the tip feed) | 1 (the tip-SML case) |
| M5 unanswered on-demand ask resumes degraded instead of failing closed | 1 |
| M6 cap check deleted | 2 (cap case + the negative twin) |
| M7 never-evaluated prints `0` instead of `n/a` | 2 |
| M8 walk accepts an attested-VALID candidate | 3 (incl. 2 pre-existing) |
| M9 coinbase script-match relaxed to "any non-empty script" | **0 -> then 1** |
| M10 one-outstanding guard removed from `begin_ondemand_fold` | 0 (documented backstop) |
| M11 apply-cursor guard removed from `readjudicate_payee` | 0 (documented backstop) |

**M9 initially produced ZERO red — a missing test, not a gate working.** Every other
on-demand case stops on the ATTESTATION rule before it ever reaches the script comparison,
so the acceptance rule was untested on this path. `ScriptMatchIsTheOnlyLicenceToAttribute`
was added for it (every candidate in the ranked window attested banned, coinbase paying a
masternode outside that window) and now goes red under M9.

**M10 and M11 are gates working**, in the same sense as the pre-existing
`if (m_snapshot_pending) return;` backstop in `request_window()`: both are structurally
unreachable today because the load-bearing pause is an early return in a different
function. Both are now annotated in code as backstops rather than enforcement, with the
mutation result recorded, so a future reader does not mistake them for the guard that
actually holds.

## Builds

```
conan install . -pr:a=ci/conan/linux-gcc13.profile --build=missing --output-folder=build_ci -nr
cmake -S . -B build_ci -DCMAKE_TOOLCHAIN_FILE=build_ci/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release -DCOIN_DGB=ON
cmake --build build_ci --target <the 58 test_dash_* CI targets> -j8

# real BLS, the way the DASH CI job does it
cmake -S . -B build_dash_bls -DCMAKE_TOOLCHAIN_FILE=build_dash_bls/conan_toolchain.cmake \
      -DCMAKE_BUILD_TYPE=Release -DC2POOL_DASH_BLS=ON -DDASHBLS_ROOT="$HOME/.c2pool-deps/dashbls"
cmake --build build_dash_bls --target c2pool-dash -j6
```

## Scope

`src/impl/dash` only. Header-only change to two files plus the test TU; no `main_dash.cpp`
change, because the request seam, the merkle-root lookup and the demux registration this
path needs were already wired as a pair by the interval fold.
