### PR TITLE
ci(dgb): wire DGB G3a populated-block gate (CI arm + opt-in live regtest)

### DIFF
--- a/.github/workflows/dgb-g3a-smoke.yml
+++ b/.github/workflows/dgb-g3a-smoke.yml
@@ -1,0 +1,100 @@
+name: DGB G3a smoke — populated block production
+
+# ci-steward 2026-08-03. Per-coin populated-block gate for the DGB (DigiByte)
+# lane, mirroring BCH G3a and DASH G3a. CI plumbing only — NO consensus knowledge
+# here; the dgb lane owns the targets, the gate script (tests/gates/
+# dgb_g3a_regtest_block_production.sh) and the live driver.
+#
+# Network-free CI arm only in CI: ctest -R the populated-block assembly / witness
+# commitment / won-block reconstruction suites BY NAME with an empty-suite guard
+# demanding a positive test count (false-green trap caught in the script). The
+# optional live-regtest arm stays opt-in (DGB_REGTEST_LIVE=1 + DGB_SRC) and is
+# never enabled in CI, so this leg needs no live digibyted.
+#
+# Neutral-skip: on branches/coins without the DGB populated-block sources the job
+# is a green no-op (PR #47 per-coin source guard preserved). Register as a required
+# check only after a confirmed non-hollow green rollup on the runner.
+
+on:
+  # additive: callable by ci-required.yml aggregator (no push/PR behaviour change)
+  workflow_call:
+  push:
+    branches: [master]
+
+env:
+  GIT_HTTP_LOW_SPEED_LIMIT: '1000'
+  GIT_HTTP_LOW_SPEED_TIME: '20'
+
+jobs:
+  dgb-g3a-smoke:
+    name: DGB G3a smoke — populated block production
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set per-job Conan home
+        run: |
+          if [ "${{ runner.environment }}" = "github-hosted" ]; then
+            echo "CONAN_HOME=$RUNNER_TEMP/conan2" >> "$GITHUB_ENV"
+          else
+            echo "CONAN_HOME=$HOME/.conan2-ci/$RUNNER_NAME" >> "$GITHUB_ENV"
+          fi
+
+      - name: Check DGB populated-block source presence
+        id: presence
+        run: |
+          if [ -f "src/impl/dgb/test/block_assembly_test.cpp" ] && [ -f "tests/gates/dgb_g3a_regtest_block_production.sh" ]; then
+            echo "exists=1" >> "$GITHUB_OUTPUT"
+            echo "::notice::DGB populated-block sources present — running G3a smoke."
+          else
+            echo "exists=0" >> "$GITHUB_OUTPUT"
+            echo "::notice::DGB populated-block sources absent on this branch — neutral skip."
+          fi
+
+      - name: Install system dependencies
+        if: steps.presence.outputs.exists == '1' && runner.environment == 'github-hosted'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends g++ cmake make libleveldb-dev libsecp256k1-dev
+
+      - uses: actions/setup-python@v6
+        if: steps.presence.outputs.exists == '1' && runner.environment == 'github-hosted'
+        with: { python-version: '3.12' }
+
+      - name: Install Conan 2
+        if: steps.presence.outputs.exists == '1'
+        run: |
+          if [ "${{ runner.environment }}" = "github-hosted" ]; then
+            pip install "conan>=2.0,<3.0"
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          else
+            conan --version
+          fi
+
+      - name: Show committed Conan profile
+        if: steps.presence.outputs.exists == '1'
+        run: conan profile show -pr:a=ci/conan/linux-gcc13.profile
+
+      - name: Restore Conan cache (github-hosted only)
+        if: runner.environment == 'github-hosted' && steps.presence.outputs.exists == '1'
+        uses: actions/cache@v5
+        with:
+          path: ${{ runner.temp }}/conan2
+          key: conan2-ubuntu24-gcc13-dgb-g3a-${{ hashFiles('conanfile.txt', 'ci/conan/linux-gcc13.profile', 'conan.lock') }}
+          restore-keys: |
+            conan2-ubuntu24-gcc13-dgb-g3a-
+            conan2-ubuntu24-gcc13-
+
+      - name: Clean stale build dir (self-hosted workspace is reused)
+        if: steps.presence.outputs.exists == '1' && runner.environment != 'github-hosted'
+        run: rm -rf build_dgb_g3a
+
+      - name: Run DGB G3a smoke (dgb-lane entrypoint)
+        if: steps.presence.outputs.exists == '1'
+        env:
+          BUILD_DIR: ${{ github.workspace }}/build_dgb_g3a
+        run: bash tests/gates/dgb_g3a_regtest_block_production.sh
+
+      - name: Prune runner workspace
+        if: always()
+        uses: ./.github/actions/prune-runner-workspace

--- a/tests/gates/dgb_g3a_regtest_block_production.sh
+++ b/tests/gates/dgb_g3a_regtest_block_production.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# G3a — DGB populated block production (CI required-gate entrypoint).
+# ci-steward 2026-08-03. Wires the DGB populated-block story into CI the way
+# BCH (tests/gates/bch_g3a_regtest_block_production.sh) and DASH
+# (tests/gates/g3a_regtest_block_production.sh) already are.
+#
+# Default arm (CI-runner, network-free): the DgbBlockAssembly.* +
+# DgbWitnessCommitment.* + DgbReconstructWonBlock.* gtest suites — c2pool-dgb
+# assembles a POPULATED block (diverse output-script + SegWit witness payload),
+# the witness commitment survives a serialize->deserialize round-trip, and the
+# won block is reconstructed for network submit. Proves populated-block
+# production without a live node.
+#
+# Optional live arm (opt-in when DGB_REGTEST_LIVE=1 and DGB_SRC point at an
+# isolated digibyted): additionally drives scripts/dgb_g3a_populated_block_regtest.sh
+# for a real end-to-end populated regtest block via submitblock — the same
+# machinery the G3b greenlight harness exercised (height 132, 7dd873cb4ce8).
+#
+# Deterministic: exit 0 = pass; nonzero = failure / hollow run. Fenced: tests/gates/
+# entrypoint over EXISTING dgb targets — no consensus / shared-base / build.yml /
+# CMake edits. PR #47 per-coin source-presence guard stays untouched; the workflow
+# neutral-skips when these sources are absent.
+set -euo pipefail
+
+GATE="G3a dgb-populated-block-production"
+TEST_REGEX='^(DgbBlockAssembly|DgbWitnessCommitment|DgbReconstructWonBlock)\.'
+TARGETS=(dgb_block_assembly_test dgb_witness_commitment_test dgb_reconstruct_won_block_test)
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BUILD_DIR="${BUILD_DIR:-$REPO_ROOT/build}"
+
+# 1. Ensure the targets exist (configure+build only if the CI cache is cold).
+if [ ! -f "$BUILD_DIR/CMakeCache.txt" ]; then
+  echo "[$GATE] no build dir at $BUILD_DIR — configuring (conan + cmake)"
+  conan install "$REPO_ROOT" -pr:a="$REPO_ROOT/ci/conan/linux-gcc13.profile" --lockfile="$REPO_ROOT/conan.lock" --build=missing --output-folder="$BUILD_DIR" --settings=build_type=Release
+  cmake -S "$REPO_ROOT" -B "$BUILD_DIR" \
+    -DCMAKE_TOOLCHAIN_FILE="$BUILD_DIR/conan_toolchain.cmake" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_TESTING=ON \
+    -DCOIN_DGB=ON
+fi
+cmake --build "$BUILD_DIR" --target "${TARGETS[@]}" -j"$(nproc)"
+
+# 2. Run from build/ (false-green trap: wrong CWD prints "No tests were found!!!"
+#    and EXITS 0).
+set +e
+OUT="$(cd "$BUILD_DIR" && ctest -R "$TEST_REGEX" --output-on-failure 2>&1)"
+RC=$?
+set -e
+echo "$OUT"
+
+# 3. False-green guard: demand a positive test count actually ran.
+if grep -q "No tests were found" <<<"$OUT"; then
+  echo "[$GATE] FAIL — hollow run: 0 tests matched $TEST_REGEX" >&2
+  exit 1
+fi
+N="$(grep -oE 'out of [0-9]+' <<<"$OUT" | grep -oE '[0-9]+' | tail -1)"
+if [ -z "${N:-}" ] || [ "$N" -lt 1 ]; then
+  echo "[$GATE] FAIL — no positive test count parsed" >&2
+  exit 1
+fi
+if [ "$RC" -ne 0 ]; then
+  echo "[$GATE] FAIL — ctest exit $RC ($N tests)" >&2
+  exit "$RC"
+fi
+echo "[$GATE] PASS (CI arm) — $N populated-block assembly / witness / won-block assertions green"
+
+# 4. Optional live regtest arm — only when an isolated digibyted is wired in via env.
+if [ "${DGB_REGTEST_LIVE:-}" = "1" ] && [ -n "${DGB_SRC:-}" ]; then
+  echo "[$GATE] live arm: driving scripts/dgb_g3a_populated_block_regtest.sh"
+  "$REPO_ROOT/scripts/dgb_g3a_populated_block_regtest.sh"
+  echo "[$GATE] PASS (live arm) — populated regtest block proven via digibyted submitblock"
+else
+  echo "[$GATE] live regtest arm SKIPPED (set DGB_REGTEST_LIVE=1 + DGB_SRC to enable)"
+fi


### PR DESCRIPTION
DGB had smoke legs (coin-matrix `--help` + Phase-B pillar gtests) but **none exercised a populated block** — unlike BCH and DASH, which each carry a `tests/gates/*_g3a_regtest_block_production.sh` two-arm gate. The DGB populated-block drivers already exist (`scripts/dgb_g3a_populated_block_regtest.sh` + the G3b testnet harness that just passed at height 132, block 7dd873cb4ce8); only the CI wiring was missing. This closes that gap.

**CI arm (always-on, network-free):** `ctest -R DgbBlockAssembly|DgbWitnessCommitment|DgbReconstructWonBlock` with the false-green empty-suite guard — proves populated-block assembly, witness-commitment round-trip, and won-block reconstruction without a live node.

**Live arm (opt-in, DGB_REGTEST_LIVE=1 + DGB_SRC):** drives the existing regtest driver for a real submitblock-accepted populated block. Never enabled in CI, so the leg needs no live digibyted.

**Guards preserved:** `.github/workflows/dgb-g3a-smoke.yml` uses the same PR #47 source-presence neutral-skip as `dgb-phase-b-smoke`; `workflow_call` + `push(master)` only. Fenced to `tests/gates/` and existing dgb targets — no consensus, build.yml, or CMake surface; per-coin source guards untouched.

Not self-merging. Register as a required context (ci-required.yml) only after a confirmed non-hollow green rollup on the runner — operator gate.