### PR TITLE
ci(codeql): cap analyze job at 90min timeout-minutes (durable lever for #1001)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,6 +28,15 @@ env:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
+    # Hard cap: the analyze job had no timeout-minutes, so a wedged
+    # CodeQL tracer build (uncapped, not the orphan-reap class of #1027/
+    # #1031) ran ~2h to a silent death (#1001) instead of a fast red.
+    # Honest p95 of the 25 most-recent SUCCESSFUL runs is 59.2 min (max
+    # legit 59.2); the only longer sample was the 600 min runaway this
+    # cap targets. 90 min sits above p95 with cold-cache headroom and
+    # well under the ~2h death point, converting the hang to a
+    # deterministic red without touching any legitimate run.
+    timeout-minutes: 90
     runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
     permissions:
       security-events: write


### PR DESCRIPTION
## What

Adds `timeout-minutes: 90` to the CodeQL `analyze` job in `.github/workflows/codeql-analysis.yml`. The job previously had **no** timeout-minutes.

## Why — the durable lever for #1001

`#1001 Analyze (c-cpp)` died at ~2h with an uncapped CodeQL tracer build. This is a **distinct class** from the runner-orphan reap handled by #1027/#1031: those reap squatting orphan processes; #1001 is a wedged tracer build inside a live job with no wall-clock cap, so it ran to a silent ~2h death instead of a fast red. #1027/#1031 landing will **not** fix #1001; this cap is the only thing that does. #1001 is currently the only PR in the fleet whose sole red is this leg.

## Cap sizing (from run history, not a round guess)

Observed durations of the 25 most-recent **successful** CodeQL runs:

- min 21.1 min, p50 27.7 min, **p95 59.2 min**, max-legitimate 59.2 min
- the only sample above that was a single **600 min** runaway — the class this cap targets

`90 min` sits above the honest p95 (59.2) with cold-cache / loaded-runner headroom, and well under the ~2h death point. No legitimate run in the sample would be cut; the wedge becomes a deterministic red ~30 min sooner than its current 2h manifestation.

## Scope / what this does and does NOT address

- **Does:** convert an uncapped hang into a fast, deterministic job failure.
- **Does NOT:** change cgroup `memory.high`. Whether the wedge root cause is `memory.high` throttle or CPU/RAM starvation is **unresolved and orthogonal** to capping the wall clock. This PR deliberately leaves memory.high untouched; the cap is correct regardless of which root cause holds.

## Verification note (per acceptance criterion 3)

The starvation-vs-throttle log evidence I flagged has **expired**: `dmesg -T` on the self-hosted host `.178` no longer shows any oom/`memory.high`/throttle records (kernel ring buffer rotated since the #1001 run). The cap was therefore sized from the 25-run success-duration distribution above, **not** from a fresh starvation/throttle measurement — I am not claiming a measurement I could not take.

## Isolation

CI-only workflow change; per-coin isolation n/a. GPG-signed, no attribution. Nothing else folded in.
