### PR TITLE
dash(daemonless): answer getbestblockhash/getblockhash/getblockchaininfo from the header chain

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -69,6 +69,7 @@
 #include <impl/dash/coin/quorum_member_source.hpp>  // E1 Phase-L: daemonless member-set sourcing (the provider)
 #include <impl/dash/coin/utxo_lane.hpp>    // dash::coin::UtxoLane — embedded UTXO/fee lane (E2b, #738)
 #include <impl/dash/coin/header_chain.hpp>       // dash::coin::HeaderChain — SPV header/tip authority (E2a)
+#include <impl/dash/coin/chain_rpc.hpp>          // dash::coin::chain_rpc — daemonless getbestblockhash/getblockhash/getblockchaininfo
 #include <impl/dash/coin/coin_state_maintainer.hpp>  // dash::coin::CoinStateMaintainer — populate ordering gate (E2a)
 #include <impl/dash/coin/sml_quorum_db.hpp>      // dash::coin::SMLDb / QuorumDb — SML+quorum persistence (incremental restart)
 #include <impl/dash/coin/credit_pool_db.hpp>     // dash::coin::CreditPoolDb — credit-pool tip persistence (E2 restart resume)
@@ -2411,6 +2412,34 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             / net_subdir / "dash_headers").string();
         header_chain = std::make_unique<dash::coin::HeaderChain>(dash_params, hdr_db);
         header_chain->init();
+
+        // ── Daemonless chain queries ──────────────────────────────────────
+        // getbestblockhash / getblockhash / getblockchaininfo are answered
+        // from the header chain we just opened — a PoW(X11)+DGW-validated,
+        // height-indexed, on-disk chain — instead of from dashd. These three
+        // and no more: the remaining six daemon RPCs (getblock, getpeerinfo,
+        // getrawmempool, getnetworkinfo, getmininginfo, protx) need block
+        // bodies, peer tables, a mempool or the masternode set, which a header
+        // chain does not own. See impl/dash/coin/chain_rpc.hpp.
+        //
+        // Refusals are forwarded verbatim: a query the chain cannot answer
+        // (no tip, stale tip, height below the fast-start anchor) returns the
+        // named condition with its measured value and threshold, never a zero.
+        if (web_server) {
+            web_server->get_mining_interface()->set_coin_chain_query_fn(
+                [hc = header_chain.get()](const std::string& method,
+                                          const nlohmann::json& params,
+                                          const std::string& chain) -> nlohmann::json {
+                    if (chain != "dash")
+                        return nlohmann::json{
+                            {"error", "chain '" + chain + "' is not served by this "
+                                      "node (owned chain: dash)"}};
+                    return dash::coin::chain_rpc::chain_query(*hc, method, params);
+                });
+            std::cout << "[run] daemonless chain queries ARMED "
+                         "(getbestblockhash/getblockhash/getblockchaininfo "
+                         "answered from the header chain)\n";
+        }
 
         maintainer = std::make_unique<dash::coin::CoinStateMaintainer>(node_coin_state);
         mn_ckpt_lane = std::make_unique<dash::coin::MnCheckpointLane>();

--- a/src/core/http_session.cpp
+++ b/src/core/http_session.cpp
@@ -746,7 +746,31 @@ void HttpSession::process_request()
 
                     std::string ep = target.substr(14);
 
-                    if (ep == "getblockchaininfo" && mining_interface_->has_explorer_chaininfo_fn()) {
+                    // Daemonless coin-chain query hook first: when a coin
+                    // backend can answer from its own validated state (DASH's
+                    // header chain), its answer — including a refusal that
+                    // names the blocking condition — is served verbatim.
+                    if ((ep == "getblockchaininfo" || ep == "getbestblockhash" || ep == "getblockhash")
+                        && mining_interface_->has_coin_chain_query_fn()) {
+                        rest_result = [&]() -> nlohmann::json {
+                            nlohmann::json qp = nlohmann::json::array();
+                            if (ep == "getblockhash") {
+                                std::string height_str = getQueryParam("height");
+                                if (height_str.empty())
+                                    return nlohmann::json{
+                                        {"error", "getblockhash withheld: missing height "
+                                                  "parameter (threshold: ?height=<n> required)"}};
+                                try { qp.push_back(static_cast<uint32_t>(std::stoul(height_str))); }
+                                catch (...) {
+                                    return nlohmann::json{
+                                        {"error", "getblockhash withheld: height parameter '"
+                                                  + height_str + "' is not a number "
+                                                  "(threshold: decimal height)"}};
+                                }
+                            }
+                            return mining_interface_->call_coin_chain_query(ep, qp, chain);
+                        }();
+                    } else if (ep == "getblockchaininfo" && mining_interface_->has_explorer_chaininfo_fn()) {
                         rest_result = mining_interface_->call_explorer_chaininfo(chain);
                     } else if (ep == "getblockhash" && mining_interface_->has_explorer_blockhash_fn()) {
                         std::string height_str = getQueryParam("height");

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -165,13 +165,31 @@ void MiningInterface::setup_methods()
 
     // Explorer JSON-RPC adapter — allows Python explorer to talk to c2pool
     // as if it were a standard Bitcoin/Litecoin daemon.
+    // Daemonless coin-chain queries take precedence over the explorer
+    // callbacks when a coin backend installed one (DASH answers these three
+    // from its own PoW-validated header chain). The hook returns a refusal
+    // object naming the blocking condition when it cannot answer; forward it
+    // verbatim rather than flattening it to a zero or an empty string.
     Add("getblockchaininfo", jsonrpccxx::MethodHandle([this](const nlohmann::json& params) -> nlohmann::json {
+        if (has_coin_chain_query_fn())
+            return call_coin_chain_query("getblockchaininfo", params, primary_chain_key());
         if (has_explorer_chaininfo_fn())
             return call_explorer_chaininfo(primary_chain_key());
         return nlohmann::json{{"error", "explorer not enabled"}};
     }));
 
+    Add("getbestblockhash", jsonrpccxx::MethodHandle([this](const nlohmann::json& params) -> nlohmann::json {
+        if (has_coin_chain_query_fn())
+            return call_coin_chain_query("getbestblockhash", params, primary_chain_key());
+        return nlohmann::json{
+            {"error", "getbestblockhash unavailable: no coin chain-query backend "
+                      "is installed for this node (threshold: a coin backend must "
+                      "call set_coin_chain_query_fn)"}};
+    }));
+
     Add("getblockhash", jsonrpccxx::MethodHandle([this](const nlohmann::json& params) -> nlohmann::json {
+        if (has_coin_chain_query_fn())
+            return call_coin_chain_query("getblockhash", params, primary_chain_key());
         if (!has_explorer_blockhash_fn() || params.empty())
             return nullptr;
         uint32_t h = params[0].get<uint32_t>();

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -1302,6 +1302,29 @@ public:
     std::string call_explorer_blockhash(uint32_t h, const std::string& c) { return m_explorer_blockhash_fn(h, c); }
     nlohmann::json call_explorer_getblock(const std::string& h, const std::string& c) { return m_explorer_getblock_fn(h, c); }
 
+    // ── Daemonless coin-chain query hook ───────────────────────────────────
+    // A coin backend that can answer chain queries (getbestblockhash /
+    // getblockhash / getblockchaininfo) from its OWN validated state — e.g.
+    // DASH's SPV HeaderChain — installs one function here instead of three.
+    // One hook for all three keeps the answers structurally consistent: a
+    // bestblockhash can never disagree with the bestblockhash inside the same
+    // backend's getblockchaininfo.
+    //
+    // The return value is the bare daemon-compatible result on success, or an
+    // object carrying "error"/"unavailable_reason" naming the condition that
+    // blocked the answer, with the measured value and the threshold. A backend
+    // must never substitute a plausible zero for state it does not own — the
+    // callers here forward the refusal verbatim rather than flattening it.
+    using coin_chain_query_fn_t = std::function<nlohmann::json(
+        const std::string& method, const nlohmann::json& params, const std::string& chain)>;
+    void set_coin_chain_query_fn(coin_chain_query_fn_t fn) { m_coin_chain_query_fn = thread_safe_wrap(std::move(fn)); }
+    bool has_coin_chain_query_fn() const { return !!m_coin_chain_query_fn; }
+    nlohmann::json call_coin_chain_query(const std::string& method,
+                                         const nlohmann::json& params,
+                                         const std::string& chain) {
+        return m_coin_chain_query_fn(method, params, chain);
+    }
+
     // Mempool explorer callbacks
     using explorer_mempoolinfo_fn_t  = std::function<nlohmann::json(const std::string& chain)>;
     using explorer_rawmempool_fn_t   = std::function<nlohmann::json(const std::string& chain, bool verbose, uint32_t limit)>;
@@ -1427,6 +1450,8 @@ private:
     explorer_chaininfo_fn_t m_explorer_chaininfo_fn;
     explorer_blockhash_fn_t m_explorer_blockhash_fn;
     explorer_getblock_fn_t  m_explorer_getblock_fn;
+    // Daemonless coin-chain query hook (DASH header chain; see setter above)
+    coin_chain_query_fn_t   m_coin_chain_query_fn;
     // Mempool explorer callbacks
     explorer_mempoolinfo_fn_t  m_explorer_mempoolinfo_fn;
     explorer_rawmempool_fn_t   m_explorer_rawmempool_fn;

--- a/src/impl/dash/coin/chain_rpc.hpp
+++ b/src/impl/dash/coin/chain_rpc.hpp
@@ -1,0 +1,375 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// Daemonless chain queries for DASH — getbestblockhash / getblockhash /
+/// getblockchaininfo answered from the PoW-validated header chain we already
+/// hold on disk, instead of from an external dashd.
+///
+/// WHY THESE THREE, AND ONLY THESE THREE
+/// ------------------------------------
+/// HeaderChain (header_chain.hpp) is an SPV header chain: every entry past the
+/// anchor carries a real X11 PoW check plus a DarkGravityWave-v3 difficulty
+/// check, is indexed by height on the active branch, and is persisted to
+/// LevelDB. That is precisely the state the three queries below need:
+///
+///   getbestblockhash   -> HeaderChain::tip()->hash
+///   getblockhash <h>   -> HeaderChain::get_header_by_height(h)->hash
+///   getblockchaininfo  -> chain name / tip height / tip hash / tip time
+///                         + an HONEST sync indicator
+///
+/// It is NOT enough for the other six daemon RPCs (getblock, getpeerinfo,
+/// getrawmempool, getnetworkinfo, getmininginfo, protx) — those need block
+/// bodies, peer tables, a mempool or the masternode set, none of which the
+/// header chain owns. This header deliberately answers three and no more.
+///
+/// WHAT THIS FILE REFUSES TO DO
+/// ---------------------------
+/// A field that cannot be sourced from owned state is OMITTED and listed in
+/// `unavailable` with the reason — it is never emitted as a plausible zero.
+/// Three concrete cases this actually hits in production:
+///
+///  1. `chainwork`. HeaderChain seeds its anchor entry (fast-start checkpoint,
+///     dynamic checkpoint, or genesis stub) with chain_work = 1, so
+///     cumulative_work() is work-ABOVE-THE-ANCHOR, not dashd's absolute
+///     chainwork. It is never comparable to a daemon's value, so it is never
+///     emitted.
+///  2. `difficulty` / `mediantime` at a synthetic anchor. A checkpoint entry
+///     has a DEFAULT-CONSTRUCTED header: m_bits == 0, m_timestamp == 0.
+///     Deriving difficulty from bits==0 divides by a null target and
+///     median_time_past() returns 0. Both would be fabricated zeros, so both
+///     are withheld until a real header lands on top.
+///  3. Everything under a stale tip. When the tip is older than
+///     TIP_MAX_AGE_SECONDS we do not know the network best block, so
+///     bestblockhash/blocks/headers move OUT of the answer and into `stale`,
+///     clearly labelled, with the measured age and the threshold.
+
+#include "header_chain.hpp"
+
+#include <core/uint256.hpp>
+
+#include <nlohmann/json.hpp>
+
+#include <cstdint>
+#include <cstdio>
+#include <ctime>
+#include <optional>
+#include <string>
+
+namespace dash {
+namespace coin {
+namespace chain_rpc {
+
+/// Tip-age window separating "our header chain tracks the network" from "we
+/// are behind". Mirrors HeaderChain::is_synced()'s 24 h window; the
+/// SyncStatusMatchesHeaderChainIsSynced test asserts the two never drift.
+inline constexpr int64_t TIP_MAX_AGE_SECONDS = 86400;
+
+/// Heights within this many blocks of a STALE tip are not served by
+/// getblockhash: a chain we know is behind may still be reorged across its
+/// own last few blocks, so those hashes are not yet ours to assert. Buried
+/// heights below the margin are PoW-final enough to answer regardless.
+inline constexpr uint32_t STALE_TIP_REORG_MARGIN = 6;
+
+/// A checkpoint/genesis stub entry is injected WITHOUT a real header (see
+/// HeaderChain::init and set_dynamic_checkpoint): m_bits and m_timestamp are
+/// default-constructed. Real headers always carry a nonzero compact target —
+/// bits == 0 encodes a zero target, which no valid block can satisfy — so
+/// bits == 0 is an exact synthetic-anchor discriminator.
+inline bool is_synthetic_anchor(const IndexEntry& e) { return e.header.m_bits == 0; }
+
+inline std::string hex8(uint32_t v) {
+    char b[16];
+    std::snprintf(b, sizeof b, "%08x", v);
+    return std::string(b);
+}
+
+/// What we know about tip freshness, with the numbers that decided it.
+struct SyncStatus {
+    bool     has_tip{false};
+    bool     synced{false};
+    bool     tip_is_synthetic_anchor{false};
+    uint32_t tip_height{0};
+    uint32_t tip_time{0};
+    int64_t  tip_age_seconds{0};
+    int64_t  max_age_seconds{TIP_MAX_AGE_SECONDS};
+    uint256  tip_hash;
+    /// Empty when synced. Otherwise names the condition, the measured value
+    /// and the threshold — never a bare "not synced".
+    std::string blocked_by;
+};
+
+inline uint32_t now_unix() { return static_cast<uint32_t>(std::time(nullptr)); }
+
+/// Freshness of the header chain, computed only from HeaderChain's public API
+/// so this file needs no edit to header_chain.hpp.
+inline SyncStatus sync_status(const HeaderChain& hc, uint32_t now = now_unix())
+{
+    SyncStatus s;
+    auto t = hc.tip();
+    if (!t) {
+        s.blocked_by = "header chain has no tip (0 headers indexed, threshold >=1)";
+        return s;
+    }
+    s.has_tip    = true;
+    s.tip_hash   = t->hash;
+    s.tip_height = t->height;
+    s.tip_time   = t->header.m_timestamp;
+    s.tip_is_synthetic_anchor = is_synthetic_anchor(*t);
+
+    if (s.tip_is_synthetic_anchor) {
+        s.blocked_by = "tip is a synthetic anchor (checkpoint/genesis stub at height "
+                     + std::to_string(s.tip_height)
+                     + " with bits=0, threshold: a real header must be connected)";
+        return s;
+    }
+
+    s.tip_age_seconds = static_cast<int64_t>(now) - static_cast<int64_t>(s.tip_time);
+    if (s.tip_age_seconds >= s.max_age_seconds) {
+        s.blocked_by = "tip age " + std::to_string(s.tip_age_seconds)
+                     + "s >= threshold " + std::to_string(s.max_age_seconds)
+                     + "s (tip height " + std::to_string(s.tip_height)
+                     + ", tip time " + std::to_string(s.tip_time) + ")";
+        return s;
+    }
+    s.synced = true;
+    return s;
+}
+
+/// Lowest height present in the active-branch height index. HeaderChain
+/// indexes [anchor .. tip] contiguously (rebuild_height_index walks prev_hash
+/// from the tip; linear extension appends), so a binary search finds the
+/// anchor in ~log2(len) lookups rather than walking the whole chain.
+inline std::optional<uint32_t> first_indexed_height(const HeaderChain& hc)
+{
+    auto t = hc.tip();
+    if (!t) return std::nullopt;
+    uint32_t lo = 0, hi = t->height;   // hi is known present
+    while (lo < hi) {
+        uint32_t mid = lo + (hi - lo) / 2;
+        if (hc.get_header_by_height(mid)) hi = mid;
+        else                              lo = mid + 1;
+    }
+    return lo;
+}
+
+/// One query outcome. `available == false` always carries a reason naming the
+/// blocking condition, the measured value and the threshold.
+struct Answer {
+    bool           available{false};
+    nlohmann::json value;
+    std::string    unavailable_reason;
+
+    static Answer ok(nlohmann::json v) { Answer a; a.available = true; a.value = std::move(v); return a; }
+    static Answer no(std::string why)  { Answer a; a.unavailable_reason = std::move(why); return a; }
+};
+
+/// The daemonless answer source, echoed on every response so a consumer can
+/// never confuse it with a real dashd reply.
+inline constexpr const char* SOURCE_TAG = "c2pool-embedded-header-chain";
+
+/// getbestblockhash. Answerable only while the chain is synced: the tip of a
+/// chain we know is behind is not the network best block, and returning it
+/// anyway is exactly the stale answer this path exists to avoid.
+inline Answer getbestblockhash(const HeaderChain& hc, uint32_t now = now_unix())
+{
+    auto s = sync_status(hc, now);
+    if (!s.synced)
+        return Answer::no("getbestblockhash withheld: " + s.blocked_by);
+    return Answer::ok(s.tip_hash.GetHex());
+}
+
+/// getblockhash <height>. Answerable for any height on the active branch that
+/// we actually hold, i.e. [anchor .. tip]. Below the anchor the header is not
+/// ours to serve (fast-start skipped it); above the tip it does not exist yet.
+/// Within STALE_TIP_REORG_MARGIN of a stale tip we decline rather than assert
+/// a hash the network may already have reorged away.
+inline Answer getblockhash(const HeaderChain& hc, uint32_t height,
+                           uint32_t now = now_unix())
+{
+    auto s = sync_status(hc, now);
+    if (!s.has_tip)
+        return Answer::no("getblockhash withheld: " + s.blocked_by);
+
+    if (height > s.tip_height)
+        return Answer::no("getblockhash withheld: requested height "
+                          + std::to_string(height) + " above owned tip height "
+                          + std::to_string(s.tip_height)
+                          + " (threshold: height <= tip height)");
+
+    auto e = hc.get_header_by_height(height);
+    if (!e) {
+        auto anchor = first_indexed_height(hc);
+        return Answer::no("getblockhash withheld: requested height "
+                          + std::to_string(height)
+                          + " below owned anchor height "
+                          + (anchor ? std::to_string(*anchor) : std::string("n/a"))
+                          + " (threshold: height >= anchor height; headers below "
+                            "the fast-start anchor were never downloaded)");
+    }
+
+    if (!s.synced && height + STALE_TIP_REORG_MARGIN > s.tip_height)
+        return Answer::no("getblockhash withheld: height " + std::to_string(height)
+                          + " is within " + std::to_string(STALE_TIP_REORG_MARGIN)
+                          + " of a tip that is not synced (tip height "
+                          + std::to_string(s.tip_height) + "); " + s.blocked_by);
+
+    if (is_synthetic_anchor(*e))
+        return Answer::no("getblockhash withheld: height " + std::to_string(height)
+                          + " is the synthetic anchor entry (bits=0, no real "
+                            "header connected; threshold: a real header at this height)");
+
+    return Answer::ok(e->hash.GetHex());
+}
+
+/// getblockchaininfo. Emits only fields backed by owned state; every field we
+/// cannot source is listed under `unavailable` with its reason and is NOT
+/// emitted as a zero. When the tip is stale, blocks/headers/bestblockhash move
+/// into `stale` so an operator still sees where we are without any consumer
+/// mistaking it for the network tip.
+inline nlohmann::json getblockchaininfo(const HeaderChain& hc,
+                                        uint32_t now = now_unix())
+{
+    const auto& p = hc.params();
+    auto s = sync_status(hc, now);
+
+    nlohmann::json r;
+    nlohmann::json unavailable = nlohmann::json::object();
+
+    r["chain"]  = p.allow_min_difficulty ? "test" : "main";
+    r["source"] = SOURCE_TAG;
+    // SPV: headers are PoW+DGW validated, block BODIES are not fully validated
+    // here. Say so, so `blocks` is never read as dashd's fully-validated height.
+    r["validation"] = "x11-pow + dgw-v3 headers (SPV; block bodies not validated here)";
+    r["synced"] = s.synced;
+    r["tip_max_age_seconds"] = s.max_age_seconds;
+    r["headers_stored"] = static_cast<uint64_t>(hc.size());
+
+    // Fields no header chain can source. Named individually, never zeroed.
+    unavailable["chainwork"] =
+        "header chain anchors its first entry at chain_work=1 (fast-start "
+        "checkpoint / genesis stub), so cumulative work is relative to the "
+        "anchor and not comparable to a daemon's absolute chainwork";
+    unavailable["verificationprogress"] =
+        "requires the network's total work estimate, which is daemon state we "
+        "do not hold";
+    unavailable["size_on_disk"] =
+        "measures the daemon's block store; we keep headers only";
+    unavailable["pruned"] =
+        "block-store property of a daemon; not applicable to a header chain";
+    unavailable["softforks"] =
+        "requires a full-node deployment/BIP9 state machine we do not run";
+    unavailable["warnings"] =
+        "daemon-level warning surface; not owned";
+
+    if (!s.has_tip) {
+        for (const char* f : {"blocks", "headers", "bestblockhash", "mediantime", "difficulty"})
+            unavailable[f] = s.blocked_by;
+        r["sync_blocked_by"] = s.blocked_by;
+        r["unavailable"] = unavailable;
+        return r;
+    }
+
+    if (auto anchor = first_indexed_height(hc)) r["first_indexed_height"] = *anchor;
+
+    if (s.synced) {
+        r["blocks"]        = s.tip_height;
+        r["headers"]       = s.tip_height;
+        r["bestblockhash"] = s.tip_hash.GetHex();
+        r["tip_age_seconds"] = s.tip_age_seconds;
+    } else {
+        // We own these numbers but they are NOT the network tip. Label them.
+        r["sync_blocked_by"] = s.blocked_by;
+        nlohmann::json stale;
+        stale["tip_height"] = s.tip_height;
+        stale["tip_hash"]   = s.tip_hash.GetHex();
+        if (s.tip_is_synthetic_anchor) {
+            stale["tip_time"]        = nullptr;
+            stale["tip_age_seconds"] = nullptr;
+        } else {
+            stale["tip_time"]        = s.tip_time;
+            stale["tip_age_seconds"] = s.tip_age_seconds;
+        }
+        r["stale"] = stale;
+        for (const char* f : {"blocks", "headers", "bestblockhash"})
+            unavailable[f] = s.blocked_by + " -- last owned value reported under \"stale\"";
+    }
+
+    auto tip = hc.tip();
+    if (tip && is_synthetic_anchor(*tip)) {
+        const std::string why =
+            "tip is a synthetic anchor entry with bits=0 and timestamp=0 (no "
+            "real header connected yet); deriving this would emit a fabricated "
+            "zero (threshold: a real header at the tip)";
+        unavailable["difficulty"] = why;
+        unavailable["mediantime"] = why;
+    } else if (tip) {
+        uint256 target = target_from_bits(tip->header.m_bits);
+        if (target.IsNull()) {
+            unavailable["difficulty"] =
+                "tip bits 0x" + hex8(tip->header.m_bits)
+                + " decode to a null target; the difficulty ratio is undefined "
+                  "(threshold: nonzero target)";
+        } else {
+            r["difficulty"] = p.pow_limit.getdouble() / target.getdouble();
+        }
+        uint32_t mtp = hc.median_time_past();
+        if (mtp == 0)
+            unavailable["mediantime"] =
+                "median_time_past() returned 0, which only happens with no "
+                "timestamped headers indexed (threshold: >=1 real header)";
+        else
+            r["mediantime"] = mtp;
+    }
+
+    r["unavailable"] = unavailable;
+    return r;
+}
+
+/// Single dispatch entry point for the three queries, shaped for the web
+/// server's coin-chain-query hook. Returns the bare dashd-compatible result on
+/// success; on refusal an object carrying the named blocking condition.
+/// `params` follows the JSON-RPC positional convention (getblockhash takes
+/// [height]).
+inline nlohmann::json chain_query(const HeaderChain& hc,
+                                  const std::string& method,
+                                  const nlohmann::json& params,
+                                  uint32_t now = now_unix())
+{
+    auto refuse = [&](const Answer& a) {
+        return nlohmann::json{{"error", a.unavailable_reason},
+                              {"unavailable_reason", a.unavailable_reason},
+                              {"method", method},
+                              {"source", SOURCE_TAG}};
+    };
+
+    if (method == "getblockchaininfo")
+        return getblockchaininfo(hc, now);
+
+    if (method == "getbestblockhash") {
+        auto a = getbestblockhash(hc, now);
+        return a.available ? a.value : refuse(a);
+    }
+
+    if (method == "getblockhash") {
+        if (!params.is_array() || params.empty() || !params[0].is_number()) {
+            return nlohmann::json{
+                {"error", "getblockhash withheld: missing or non-numeric height "
+                          "parameter (threshold: params[0] must be a number)"},
+                {"method", method},
+                {"source", SOURCE_TAG}};
+        }
+        auto a = getblockhash(hc, params[0].get<uint32_t>(), now);
+        return a.available ? a.value : refuse(a);
+    }
+
+    return nlohmann::json{
+        {"error", std::string("method '") + method +
+                  "' is not answerable from the header chain (owned: "
+                  "getbestblockhash, getblockhash, getblockchaininfo)"},
+        {"method", method},
+        {"source", SOURCE_TAG}};
+}
+
+} // namespace chain_rpc
+} // namespace coin
+} // namespace dash

--- a/test/test_dash_header_chain.cpp
+++ b/test/test_dash_header_chain.cpp
@@ -24,13 +24,19 @@
 #include <gtest/gtest.h>
 
 #include <impl/dash/coin/header_chain.hpp>
+#include <impl/dash/coin/chain_rpc.hpp>
 #include <impl/dash/coin/block.hpp>
 
 #include <core/uint256.hpp>
 
+#include <nlohmann/json.hpp>
+
 #include <cstdint>
+#include <ctime>
 #include <functional>
+#include <memory>
 #include <optional>
+#include <string>
 #include <vector>
 
 using namespace dash::coin;
@@ -222,4 +228,387 @@ TEST(DashDGWv3Kat, RealTestnet3Window1497944ReproducesNextBits) {
     EXPECT_EQ(bits, 0x1e00f256u)
         << "DGW-v3 over the real 1497920..1497943 window must reproduce the "
            "node-assigned bits of block 1497944";
+}
+// ════════════════════════════════════════════════════════════════════════════
+// Daemonless chain queries — getbestblockhash / getblockhash /
+// getblockchaininfo answered from the header chain (chain_rpc.hpp).
+//
+// Every positive assertion below has a negative twin: for each query there is
+// a state in which the header chain CANNOT answer, and the test asserts the
+// response NAMES that state (condition + measured value + threshold) instead
+// of returning a stale hash, an empty string, or a zero.
+// ════════════════════════════════════════════════════════════════════════════
+
+namespace {
+
+// A chain whose PoW target is easy enough to mine in a unit test (top 8 bits
+// zero => ~256 X11 attempts per header) while still exercising the REAL
+// check_pow / add_header_internal path — the headers below are genuinely
+// PoW-valid, not injected. allow_min_difficulty short-circuits the DGW bits
+// check at pow-limit difficulty, which is what a testnet chain does anyway.
+DashChainParams make_easy_test_params() {
+    DashChainParams p;
+    p.target_timespan = 3600;
+    p.target_spacing  = 150;
+    p.allow_min_difficulty = true;
+    p.no_retargeting = false;
+    p.pow_limit.SetHex("00ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    // Arbitrary but fixed: init() seeds this as a genesis STUB without a PoW
+    // check, and every mined header below builds on it.
+    p.genesis_hash.SetHex("00000000000000000000000000000000000000000000000000000000000000aa");
+    p.halving_interval = 210240;
+    p.initial_subsidy = 500000000ULL;
+    p.pow_func = [](std::span<const unsigned char> data) -> uint256 {
+        return dash::crypto::hash_x11(data);
+    };
+    p.block_hash_func = p.pow_func;
+    return p;
+}
+
+// Mine a real header on top of `prev` at the pow-limit target.
+BlockHeaderType mine_header(const uint256& prev, uint32_t timestamp,
+                            uint32_t bits, const uint256& pow_limit) {
+    BlockHeaderType h;
+    h.m_version = 536870912;
+    h.m_previous_block = prev;
+    h.m_merkle_root.SetHex("00000000000000000000000000000000000000000000000000000000000000bb");
+    h.m_timestamp = timestamp;
+    h.m_bits = bits;
+    for (uint32_t nonce = 0; nonce < 50'000'000u; ++nonce) {
+        h.m_nonce = nonce;
+        if (check_pow(x11_hash(h), bits, pow_limit)) return h;
+    }
+    ADD_FAILURE() << "mine_header exhausted the nonce range — pow_limit too hard "
+                     "for a unit test";
+    return h;
+}
+
+// Build an in-memory chain of `count` real headers above the genesis stub,
+// spaced 150 s apart ending at `tip_time`. Returns the per-height hashes
+// (index 0 == genesis stub).
+struct MinedChain {
+    DashChainParams params;
+    std::unique_ptr<HeaderChain> hc;
+    std::vector<uint256> hashes;   // hashes[h] is the hash at height h
+    uint32_t tip_time{0};
+};
+
+MinedChain build_mined_chain(uint32_t count, uint32_t tip_time) {
+    MinedChain mc;
+    mc.params = make_easy_test_params();
+    mc.hc = std::make_unique<HeaderChain>(mc.params, /*db_path=*/"");
+    EXPECT_TRUE(mc.hc->init());
+    mc.hashes.push_back(mc.params.genesis_hash);
+    const uint32_t bits = mc.params.pow_limit.GetCompact();
+    uint32_t t = tip_time - count * 150u;
+    for (uint32_t i = 0; i < count; ++i) {
+        t += 150u;
+        auto h = mine_header(mc.hashes.back(), t, bits, mc.params.pow_limit);
+        EXPECT_TRUE(mc.hc->add_header(h))
+            << "mined header at height " << (i + 1) << " must be accepted";
+        mc.hashes.push_back(x11_hash(h));
+    }
+    mc.tip_time = t;
+    return mc;
+}
+
+// Assert the two honesty invariants that hold for EVERY getblockchaininfo
+// response: nothing listed as unavailable is also emitted, and no emitted
+// numeric field is a placeholder zero.
+void expect_no_field_is_both_emitted_and_unavailable(const nlohmann::json& r) {
+    ASSERT_TRUE(r.contains("unavailable")) << r.dump(2);
+    for (auto it = r["unavailable"].begin(); it != r["unavailable"].end(); ++it) {
+        EXPECT_FALSE(r.contains(it.key()))
+            << "field '" << it.key() << "' is listed unavailable but ALSO emitted "
+            << "— that is exactly the fabricated-value defect: " << r.dump(2);
+        EXPECT_FALSE(it.value().get<std::string>().empty())
+            << "unavailable['" << it.key() << "'] must name the blocking condition";
+    }
+}
+
+} // namespace
+
+// ─── getbestblockhash ───────────────────────────────────────────────────────
+
+TEST(DashChainRpc, BestBlockHashAnsweredFromSyncedHeaderChain) {
+    auto mc = build_mined_chain(3, /*tip_time=*/1'800'000'000u);
+    auto a = chain_rpc::getbestblockhash(*mc.hc, /*now=*/mc.tip_time + 60);
+    ASSERT_TRUE(a.available) << a.unavailable_reason;
+    EXPECT_EQ(a.value.get<std::string>(), mc.hashes.back().GetHex());
+    EXPECT_EQ(mc.hc->height(), 3u);
+}
+
+// NEGATIVE TWIN: a tip older than the 24 h window is not the network best
+// block. The answer must say so and name the age and the threshold.
+TEST(DashChainRpc, BestBlockHashWithheldWhenTipStale) {
+    auto mc = build_mined_chain(3, /*tip_time=*/1'800'000'000u);
+    const uint32_t now = mc.tip_time + 90'000u;   // 25 h past the tip
+    auto a = chain_rpc::getbestblockhash(*mc.hc, now);
+    ASSERT_FALSE(a.available)
+        << "a 25 h-old tip must NOT be served as bestblockhash";
+    EXPECT_NE(a.unavailable_reason.find("90000"), std::string::npos)
+        << "refusal must carry the MEASURED tip age: " << a.unavailable_reason;
+    EXPECT_NE(a.unavailable_reason.find("86400"), std::string::npos)
+        << "refusal must carry the THRESHOLD: " << a.unavailable_reason;
+    EXPECT_TRUE(a.value.is_null()) << "no stale hash may leak through the refusal";
+}
+
+// NEGATIVE TWIN: a chain that has never been initialised has no tip at all.
+TEST(DashChainRpc, BestBlockHashWithheldWhenChainHasNoTip) {
+    auto params = make_easy_test_params();
+    HeaderChain hc(params, /*db_path=*/"");   // deliberately NOT init()ed
+    auto a = chain_rpc::getbestblockhash(hc, /*now=*/1'800'000'000u);
+    ASSERT_FALSE(a.available);
+    EXPECT_NE(a.unavailable_reason.find("no tip"), std::string::npos)
+        << a.unavailable_reason;
+}
+
+// NEGATIVE TWIN: a fast-start checkpoint tip is a SYNTHETIC entry (bits=0,
+// timestamp=0) — a hard-coded anchor, not an observed best block.
+TEST(DashChainRpc, BestBlockHashWithheldAtSyntheticCheckpointAnchor) {
+    auto params = make_dash_chain_params_mainnet();
+    ASSERT_TRUE(params.fast_start_checkpoint.has_value());
+    HeaderChain hc(params, /*db_path=*/"");
+    ASSERT_TRUE(hc.init());
+    ASSERT_EQ(hc.height(), params.fast_start_checkpoint->height);
+
+    auto a = chain_rpc::getbestblockhash(hc, /*now=*/static_cast<uint32_t>(std::time(nullptr)));
+    ASSERT_FALSE(a.available)
+        << "the compiled-in checkpoint hash must not be served as the network tip";
+    EXPECT_NE(a.unavailable_reason.find("synthetic anchor"), std::string::npos)
+        << a.unavailable_reason;
+    EXPECT_NE(a.unavailable_reason.find("bits=0"), std::string::npos)
+        << a.unavailable_reason;
+}
+
+// ─── getblockhash ───────────────────────────────────────────────────────────
+
+TEST(DashChainRpc, BlockHashAnsweredForEveryOwnedHeight) {
+    auto mc = build_mined_chain(4, /*tip_time=*/1'800'000'000u);
+    const uint32_t now = mc.tip_time + 60;
+    for (uint32_t h = 1; h <= 4; ++h) {
+        auto a = chain_rpc::getblockhash(*mc.hc, h, now);
+        ASSERT_TRUE(a.available) << "height " << h << ": " << a.unavailable_reason;
+        EXPECT_EQ(a.value.get<std::string>(), mc.hashes[h].GetHex());
+    }
+}
+
+// NEGATIVE TWIN: above the tip there is no block, and the refusal names both
+// the requested height and the tip height it was compared against.
+TEST(DashChainRpc, BlockHashWithheldAboveTip) {
+    auto mc = build_mined_chain(3, /*tip_time=*/1'800'000'000u);
+    auto a = chain_rpc::getblockhash(*mc.hc, 9999u, mc.tip_time + 60);
+    ASSERT_FALSE(a.available);
+    EXPECT_NE(a.unavailable_reason.find("9999"), std::string::npos) << a.unavailable_reason;
+    EXPECT_NE(a.unavailable_reason.find("above owned tip"), std::string::npos)
+        << a.unavailable_reason;
+    EXPECT_TRUE(a.value.is_null());
+}
+
+// NEGATIVE TWIN: below the fast-start anchor the headers were never
+// downloaded. The refusal must name the anchor height, not return "".
+TEST(DashChainRpc, BlockHashWithheldBelowFastStartAnchor) {
+    auto params = make_dash_chain_params_mainnet();
+    const uint32_t cp = params.fast_start_checkpoint->height;
+    HeaderChain hc(params, /*db_path=*/"");
+    ASSERT_TRUE(hc.init());
+
+    auto a = chain_rpc::getblockhash(hc, cp - 1, /*now=*/1'800'000'000u);
+    ASSERT_FALSE(a.available);
+    EXPECT_NE(a.unavailable_reason.find("below owned anchor"), std::string::npos)
+        << a.unavailable_reason;
+    EXPECT_NE(a.unavailable_reason.find(std::to_string(cp)), std::string::npos)
+        << "refusal must name the MEASURED anchor height: " << a.unavailable_reason;
+}
+
+// NEGATIVE TWIN: the anchor height itself resolves to a synthetic entry with
+// no real header behind it.
+TEST(DashChainRpc, BlockHashWithheldAtSyntheticAnchorHeight) {
+    auto params = make_dash_chain_params_mainnet();
+    const uint32_t cp = params.fast_start_checkpoint->height;
+    HeaderChain hc(params, /*db_path=*/"");
+    ASSERT_TRUE(hc.init());
+    auto a = chain_rpc::getblockhash(hc, cp, /*now=*/1'800'000'000u);
+    ASSERT_FALSE(a.available);
+    EXPECT_NE(a.unavailable_reason.find("synthetic anchor"), std::string::npos)
+        << a.unavailable_reason;
+}
+
+// NEGATIVE TWIN: on a STALE tip the last few blocks may still be reorged away.
+// Buried heights stay answerable; heights inside the margin do not.
+TEST(DashChainRpc, BlockHashStaleTipServesBuriedWithholdsRecent) {
+    auto mc = build_mined_chain(10, /*tip_time=*/1'800'000'000u);
+    const uint32_t now = mc.tip_time + 90'000u;   // stale
+    const uint32_t tip = mc.hc->height();
+    ASSERT_EQ(tip, 10u);
+
+    // Inside the reorg margin -> withheld, and the refusal names the margin.
+    for (uint32_t h = tip - chain_rpc::STALE_TIP_REORG_MARGIN + 1; h <= tip; ++h) {
+        auto a = chain_rpc::getblockhash(*mc.hc, h, now);
+        EXPECT_FALSE(a.available) << "height " << h << " is within the margin of a stale tip";
+        EXPECT_NE(a.unavailable_reason.find("not synced"), std::string::npos)
+            << a.unavailable_reason;
+    }
+    // Buried -> still answered, because PoW does not go stale.
+    for (uint32_t h = 1; h <= tip - chain_rpc::STALE_TIP_REORG_MARGIN; ++h) {
+        auto a = chain_rpc::getblockhash(*mc.hc, h, now);
+        EXPECT_TRUE(a.available) << "height " << h << ": " << a.unavailable_reason;
+        EXPECT_EQ(a.value.get<std::string>(), mc.hashes[h].GetHex());
+    }
+}
+
+// ─── getblockchaininfo ──────────────────────────────────────────────────────
+
+TEST(DashChainRpc, ChainInfoSyncedEmitsOwnedFieldsOnly) {
+    auto mc = build_mined_chain(3, /*tip_time=*/1'800'000'000u);
+    auto r = chain_rpc::getblockchaininfo(*mc.hc, /*now=*/mc.tip_time + 60);
+
+    EXPECT_EQ(r["chain"], "test");
+    EXPECT_TRUE(r["synced"].get<bool>()) << r.dump(2);
+    EXPECT_EQ(r["blocks"].get<uint32_t>(), 3u);
+    EXPECT_EQ(r["headers"].get<uint32_t>(), 3u);
+    EXPECT_EQ(r["bestblockhash"].get<std::string>(), mc.hashes.back().GetHex());
+    EXPECT_EQ(r["tip_age_seconds"].get<int64_t>(), 60);
+    EXPECT_EQ(r["tip_max_age_seconds"].get<int64_t>(), chain_rpc::TIP_MAX_AGE_SECONDS);
+    EXPECT_EQ(r["source"], chain_rpc::SOURCE_TAG);
+    EXPECT_GT(r["difficulty"].get<double>(), 0.0);
+    EXPECT_EQ(r["mediantime"].get<uint32_t>(), mc.hc->median_time_past());
+
+    // chainwork is anchor-relative here and is therefore NEVER emitted.
+    EXPECT_FALSE(r.contains("chainwork"))
+        << "anchor-relative work must not masquerade as a daemon chainwork";
+    EXPECT_TRUE(r["unavailable"].contains("chainwork"));
+    EXPECT_FALSE(r.contains("verificationprogress"));
+    expect_no_field_is_both_emitted_and_unavailable(r);
+}
+
+// NEGATIVE TWIN: a stale tip must not present blocks/headers/bestblockhash as
+// current. They move under "stale" and are named in "unavailable".
+TEST(DashChainRpc, ChainInfoStaleTipMovesTipFieldsToStale) {
+    auto mc = build_mined_chain(3, /*tip_time=*/1'800'000'000u);
+    auto r = chain_rpc::getblockchaininfo(*mc.hc, /*now=*/mc.tip_time + 90'000u);
+
+    EXPECT_FALSE(r["synced"].get<bool>());
+    EXPECT_FALSE(r.contains("blocks"))        << r.dump(2);
+    EXPECT_FALSE(r.contains("headers"))       << r.dump(2);
+    EXPECT_FALSE(r.contains("bestblockhash")) << r.dump(2);
+    ASSERT_TRUE(r.contains("sync_blocked_by"));
+    EXPECT_NE(r["sync_blocked_by"].get<std::string>().find("90000"), std::string::npos);
+    EXPECT_NE(r["sync_blocked_by"].get<std::string>().find("86400"), std::string::npos);
+
+    ASSERT_TRUE(r.contains("stale"));
+    EXPECT_EQ(r["stale"]["tip_height"].get<uint32_t>(), 3u);
+    EXPECT_EQ(r["stale"]["tip_hash"].get<std::string>(), mc.hashes.back().GetHex());
+    expect_no_field_is_both_emitted_and_unavailable(r);
+}
+
+// NEGATIVE TWIN: at a synthetic checkpoint anchor, difficulty and mediantime
+// would both be fabricated zeros. They must be withheld, not zeroed.
+TEST(DashChainRpc, ChainInfoSyntheticAnchorWithholdsDifficultyAndMediantime) {
+    auto params = make_dash_chain_params_mainnet();
+    HeaderChain hc(params, /*db_path=*/"");
+    ASSERT_TRUE(hc.init());
+    auto r = chain_rpc::getblockchaininfo(hc, /*now=*/1'800'000'000u);
+
+    EXPECT_EQ(r["chain"], "main");
+    EXPECT_FALSE(r["synced"].get<bool>());
+    EXPECT_FALSE(r.contains("difficulty"))
+        << "bits=0 would divide by a null target — a fabricated zero: " << r.dump(2);
+    EXPECT_FALSE(r.contains("mediantime"))
+        << "median_time_past() is 0 at a synthetic anchor — a fabricated zero";
+    EXPECT_NE(r["unavailable"]["difficulty"].get<std::string>().find("fabricated"),
+              std::string::npos);
+    EXPECT_EQ(r["first_indexed_height"].get<uint32_t>(),
+              params.fast_start_checkpoint->height);
+    // Confirms that median_time_past() really would have returned the zero we
+    // refused to publish — the withheld field is not a false alarm.
+    EXPECT_EQ(hc.median_time_past(), 0u);
+    expect_no_field_is_both_emitted_and_unavailable(r);
+}
+
+// NEGATIVE TWIN: with no tip at all, every tip-derived field is unavailable
+// and none is emitted as 0 / "".
+TEST(DashChainRpc, ChainInfoNoTipWithholdsEveryTipDerivedField) {
+    auto params = make_easy_test_params();
+    HeaderChain hc(params, /*db_path=*/"");   // deliberately NOT init()ed
+    auto r = chain_rpc::getblockchaininfo(hc, /*now=*/1'800'000'000u);
+
+    for (const char* f : {"blocks", "headers", "bestblockhash", "mediantime", "difficulty"}) {
+        EXPECT_FALSE(r.contains(f)) << f << " must not be emitted with no tip: " << r.dump(2);
+        EXPECT_TRUE(r["unavailable"].contains(f)) << f << " must be named unavailable";
+    }
+    EXPECT_FALSE(r["synced"].get<bool>());
+    EXPECT_EQ(r["headers_stored"].get<uint64_t>(), 0u);
+    expect_no_field_is_both_emitted_and_unavailable(r);
+}
+
+// ─── invariants across the three ────────────────────────────────────────────
+
+// Anti-drift guard. chain_rpc::sync_status() reimplements the freshness
+// predicate over HeaderChain's PUBLIC api so header_chain.hpp needs no edit.
+// If someone changes HeaderChain::is_synced()'s window (or ours) without the
+// other, this goes red instead of the two silently disagreeing.
+TEST(DashChainRpc, SyncStatusMatchesHeaderChainIsSynced) {
+    const uint32_t now = static_cast<uint32_t>(std::time(nullptr));
+
+    auto fresh = build_mined_chain(2, /*tip_time=*/now - 600);       // 10 min old
+    EXPECT_TRUE(fresh.hc->is_synced());
+    EXPECT_EQ(chain_rpc::sync_status(*fresh.hc, now).synced, fresh.hc->is_synced());
+
+    auto stale = build_mined_chain(2, /*tip_time=*/now - 200'000u);  // ~55 h old
+    EXPECT_FALSE(stale.hc->is_synced());
+    EXPECT_EQ(chain_rpc::sync_status(*stale.hc, now).synced, stale.hc->is_synced());
+}
+
+// getbestblockhash and getblockchaininfo are served by one backend, so they
+// can never report different tips.
+TEST(DashChainRpc, BestBlockHashAgreesWithChainInfo) {
+    auto mc = build_mined_chain(3, /*tip_time=*/1'800'000'000u);
+    const uint32_t now = mc.tip_time + 60;
+    auto best = chain_rpc::getbestblockhash(*mc.hc, now);
+    auto info = chain_rpc::getblockchaininfo(*mc.hc, now);
+    ASSERT_TRUE(best.available);
+    EXPECT_EQ(best.value.get<std::string>(), info["bestblockhash"].get<std::string>());
+    // ... and the tip that getblockhash reports at the chain-info height.
+    auto at_tip = chain_rpc::getblockhash(*mc.hc, info["blocks"].get<uint32_t>(), now);
+    ASSERT_TRUE(at_tip.available) << at_tip.unavailable_reason;
+    EXPECT_EQ(at_tip.value.get<std::string>(), best.value.get<std::string>());
+}
+
+TEST(DashChainRpc, FirstIndexedHeightFindsTheAnchor) {
+    auto mc = build_mined_chain(5, /*tip_time=*/1'800'000'000u);
+    auto anchor = chain_rpc::first_indexed_height(*mc.hc);
+    ASSERT_TRUE(anchor.has_value());
+    EXPECT_EQ(*anchor, 0u) << "genesis-stub chains are indexed from height 0";
+
+    auto params = make_dash_chain_params_mainnet();
+    HeaderChain cp_chain(params, /*db_path=*/"");
+    ASSERT_TRUE(cp_chain.init());
+    auto cp_anchor = chain_rpc::first_indexed_height(cp_chain);
+    ASSERT_TRUE(cp_anchor.has_value());
+    EXPECT_EQ(*cp_anchor, params.fast_start_checkpoint->height)
+        << "the binary search must land on the fast-start checkpoint, not 0";
+}
+
+// The dispatch surface the web server installs: unknown methods are refused by
+// name rather than answered, so the six remaining daemon RPCs can never be
+// silently faked by this backend.
+TEST(DashChainRpc, ChainQueryRefusesMethodsTheHeaderChainDoesNotOwn) {
+    auto mc = build_mined_chain(2, /*tip_time=*/1'800'000'000u);
+    const uint32_t now = mc.tip_time + 60;
+    for (const char* m : {"getblock", "getpeerinfo", "getrawmempool",
+                          "getnetworkinfo", "getmininginfo", "protx"}) {
+        auto r = chain_rpc::chain_query(*mc.hc, m, nlohmann::json::array(), now);
+        ASSERT_TRUE(r.contains("error")) << m << " must be refused: " << r.dump();
+        EXPECT_NE(r["error"].get<std::string>().find(m), std::string::npos);
+    }
+    // getblockhash with no height is a caller error, and says so.
+    auto bad = chain_rpc::chain_query(*mc.hc, "getblockhash", nlohmann::json::array(), now);
+    ASSERT_TRUE(bad.contains("error"));
+    EXPECT_NE(bad["error"].get<std::string>().find("height parameter"), std::string::npos);
+
+    // Happy path through the same dispatch returns the BARE daemon-shaped value.
+    auto ok = chain_rpc::chain_query(*mc.hc, "getbestblockhash", nlohmann::json::array(), now);
+    EXPECT_TRUE(ok.is_string()) << ok.dump();
+    EXPECT_EQ(ok.get<std::string>(), mc.hashes.back().GetHex());
 }


### PR DESCRIPTION
## What

Three of the eleven coin-RPC methods the DASH lane still calls into `dashd` are answerable from state we already own on disk. This PR answers them from the SPV header chain and stops calling out for them.

| RPC | Answerable from owned state? | Source |
|---|---|---|
| `getbestblockhash` | **Yes**, while synced | `HeaderChain::tip()->hash` |
| `getblockhash <h>` | **Yes**, for heights in `[anchor .. tip]` | `HeaderChain::get_header_by_height(h)->hash` |
| `getblockchaininfo` | **Partly** — per field, see below | tip height / hash / time + `params()` |

`HeaderChain` (`src/impl/dash/coin/header_chain.hpp`) validates every header above its anchor with X11 PoW plus a DarkGravityWave-v3 difficulty check, indexes the active branch by height, and persists to LevelDB. That is exactly — and only — what these three need. It is **not** enough for the other six (`getblock`, `getpeerinfo`, `getrawmempool`, `getnetworkinfo`, `getmininginfo`, `protx`), which need block bodies, peer tables, a mempool, or the masternode set. The new dispatcher refuses those **by name** so this backend can never silently fake one.

## Scope, stated precisely

When this lands the correct phrasing is **"daemonless block template production plus tip and chain queries"**. Six coin RPCs still require `dashd`. This is not "daemonless is done".

## Honesty rules, enforced by construction

Each of these has a test that goes red without it.

- **`chainwork` is never emitted.** `HeaderChain` seeds its anchor entry (fast-start checkpoint / dynamic checkpoint / genesis stub) at `chain_work = 1`, so `cumulative_work()` is work-*above-the-anchor*. It is not comparable to a daemon's absolute chainwork, so it is listed under `unavailable` instead of published.
- **`difficulty` and `mediantime` are withheld at a synthetic anchor.** A checkpoint entry carries a default-constructed header: `bits == 0`, `timestamp == 0`. Deriving difficulty divides by a null target, and `median_time_past()` returns `0`. Both would be fabricated zeros. (The LTC explorer callback publishes `difficulty = 0.0` in exactly this situation; this path does not.)
- **A stale tip is not the network best block.** Past the 86400 s window, `blocks` / `headers` / `bestblockhash` move out of the answer into a clearly-labelled `stale` object and are named in `unavailable`, so an operator still sees where we are and no consumer can mistake it for the tip.
- **`getblockhash` refuses** below the fast-start anchor (those headers were never downloaded), above the tip, and — on a chain known to be behind — within 6 blocks of that stale tip where a reorg may still land. Buried heights stay answerable: PoW does not go stale.
- **Every refusal names the blocking condition with its measured value and the threshold it was compared against.** No refusal path returns `0` or `""`.
- `verificationprogress`, `size_on_disk`, `pruned`, `softforks`, `warnings` are listed under `unavailable` with reasons rather than invented.

`blocks` is additionally accompanied by `"validation": "x11-pow + dgw-v3 headers (SPV; block bodies not validated here)"` so it is never read as a daemon's fully-validated block height.

## Files

- **New** `src/impl/dash/coin/chain_rpc.hpp` — the answerer. Header-only, built entirely on `HeaderChain`'s existing **public** API.
- **`src/impl/dash/coin/header_chain.hpp` is deliberately untouched.** The freshness predicate is reimplemented over the public API rather than refactoring `is_synced()`, and `DashChainRpc.SyncStatusMatchesHeaderChainIsSynced` pins the two together so they cannot drift apart unnoticed. (`is_synced()` still has zero callers on any DASH path; giving it one is a separate change.)
- `src/core/web_server.hpp` / `.cpp` — one new hook, `set_coin_chain_query_fn`. One function for all three queries, so a `getbestblockhash` can never disagree with the `bestblockhash` inside the same backend's `getblockchaininfo`. The JSON-RPC handlers prefer the hook and fall back to the pre-existing explorer callbacks, so the LTC path is unchanged. `getbestblockhash` is newly registered on that surface.
- `src/core/http_session.cpp` — the REST `/api/explorer` surface prefers the hook too, and stays gated on explorer-enabled exactly as before. DASH does not enable it, so no existing endpoint changes behaviour.
- `src/c2pool/main_dash.cpp` — installs the hook from the header chain on the embedded arm (`if (coin_p2p)`), immediately after `header_chain->init()`.

## Tests

17 new cases folded into **`test_dash_header_chain`**, which is already on the `build.yml` `--target` allowlist — no allowlist edit, no `NOT_BUILT` sentinel. `tools/ci/check_test_target_allowlist.py` passes (226 targets, 6 lanes).

Every positive case has a negative twin asserting the unsynced / unanchored / out-of-range answer **names** the condition rather than returning a stale or zero value. The headers under test are genuinely mined (an easy pow-limit exercises the real `check_pow` / `add_header` path), not injected.

Local run, Release, real BLS (`-DC2POOL_DASH_BLS=ON`, `dash_bls_linked_guard.sh` PASS on the built `c2pool-dash`):

```
ctest -R 'DashChainRpc|DashDGWv3Kat'  ->  25/25 passed, 0 failed
```

### Mutation results

Twelve mutations were applied to `chain_rpc.hpp`, each rebuilt and re-run. **Every one produced red; none produced zero red**, and across the set **all 17 new tests were shown able to fail**.

| # | Mutation | Tests reddened |
|---|---|---|
| 1 | drop the sync gate on `getbestblockhash` | 3 |
| 2 | emit stale tip fields as current | 2 |
| 3 | publish `difficulty = 0.0` at a synthetic anchor | 1 |
| 4 | return `""` instead of a refusal above the tip | 1 |
| 5 | widen the sync threshold 100x | 4 |
| 6 | anchor binary-search returns 0 | 3 |
| 7 | emit anchor-relative `chainwork` | 4 |
| 8 | synthetic-anchor detector always false | 3 |
| 9 | drop the stale-tip reorg margin | 1 |
| 10 | dispatcher answers methods it does not own | 1 |
| 11 | `getbestblockhash` returns the anchor, not the tip | 3 |
| 12 | `getblockhash` ignores its height argument | 2 |
