### PR TITLE
dash(embedded): the serve gate NAMES its refusal — returned reason, not a bool with a log beside it

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -2413,6 +2413,19 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         header_chain = std::make_unique<dash::coin::HeaderChain>(dash_params, hdr_db);
         header_chain->init();
 
+        // CROSS-LANE ASYMMETRY CLOSED: HeaderChain::is_synced() was DEFINED
+        // AND NEVER CALLED on the DASH path (bch 13 callers, ltc 12, nmc 12,
+        // btc 6, dgb 6, dash 0) -- a predicate nothing invokes is a lie about
+        // what the code checks. Every other freshness gate on NodeCoinState is
+        // relative to OUR OWN tip and so is satisfied by a node that is
+        // thousands of blocks behind but internally consistent; this is the
+        // only comparison against anything outside our own view. LTC's
+        // template_builder.hpp:376 is the reference pattern (refuse, do not
+        // serve). A refusal here is a template-SERVE refusal, never a
+        // block-SUBMIT refusal, and it now NAMES itself as "chain-not-synced".
+        node_coin_state.set_chain_synced_fn(
+            [hc = header_chain.get()] { return hc && hc->is_synced(); });
+
         // ── Daemonless chain queries ──────────────────────────────────────
         // getbestblockhash / getblockhash / getblockchaininfo are answered
         // from the header chain we just opened — a PoW(X11)+DGW-validated,
@@ -2439,6 +2452,66 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             std::cout << "[run] daemonless chain queries ARMED "
                          "(getbestblockhash/getblockhash/getblockchaininfo "
                          "answered from the header chain)\n";
+
+            // ── DEFECT-3 operator surface: WHY the embedded arm is not serving ──
+            // web-static/dashboard.html has read a per-coin `no_work_reason` since
+            // 08-02 and test_web_honesty_regression pins the contract from both
+            // sides -- but NOTHING in the tree ever produced one: main_dash never
+            // called set_node_topology_fn at all, so the field was permanently
+            // absent and the card rendered a declining node identically to a dead
+            // one. This is the producer. The reason is the SAME DeclineReport the
+            // arm-selection branch returned (DASHWorkSource::embedded_arm_status_json),
+            // so the page and the journal cannot disagree.
+            //
+            // Lifetime: web_server is explicitly reset() after ioc.run() returns,
+            // BEFORE header_chain / coin_p2p unwind at scope exit, so these raw
+            // captures cannot outlive their targets.
+            web_server->get_mining_interface()->set_node_topology_fn(
+                [ws = work_source, hc = header_chain.get(),
+                 cp = coin_p2p.get(), testnet]() -> nlohmann::json {
+                    nlohmann::json c = nlohmann::json::object();
+                    c["coin"]     = "DASH";
+                    c["primary"]  = true;
+                    c["embedded"] = true;
+                    // CoinClient is a single-peer client: 1 or 0, measured, not
+                    // guessed. Omitting it would make the dashboard default to
+                    // 0 and mislabel every decline as "faulted".
+                    const bool connected = cp && cp->is_connected();
+                    c["peers"] = connected ? 1 : 0;
+                    if (hc) {
+                        const uint32_t hh = hc->height();
+                        c["header_height"] = hh;
+                        // The peer's advertised best height is the only target
+                        // we actually observe; absent it we publish NO target
+                        // and no synced flag rather than invent one.
+                        const uint32_t target = connected ? cp->peer_start_height() : 0;
+                        if (target > 0) {
+                            c["target_height"] = target;
+                            c["sync_percent"]  =
+                                100.0 * static_cast<double>(hh) / static_cast<double>(target);
+                            c["synced"] = (hh + 1 >= target);
+                        }
+                    }
+                    // arm + the ONE named cause, with value and threshold.
+                    nlohmann::json arm = ws->embedded_arm_status_json();
+                    c["arm"]               = arm.value("arm", std::string("unknown"));
+                    c["no_work_cause"]     = arm.value("no_work_reason", std::string());
+                    c["no_work_value"]     = arm.value("no_work_value", std::string("n/a"));
+                    c["no_work_threshold"] = arm.value("no_work_threshold", std::string("n/a"));
+                    // The dashboard renders no_work_reason VERBATIM, so carry
+                    // the value and threshold in it -- "declined" alone repeats
+                    // the very defect this exists to fix.
+                    const std::string cause = c["no_work_cause"].get<std::string>();
+                    c["no_work_reason"] = cause.empty()
+                        ? std::string()
+                        : cause + " (value=" + c["no_work_value"].get<std::string>()
+                                + " threshold=" + c["no_work_threshold"].get<std::string>() + ")";
+                    return nlohmann::json{
+                        {"node_symbol", "DASH"},
+                        {"auto_detected", false},
+                        {"testnet", testnet},
+                        {"coins", nlohmann::json::array({c})}};
+                });
         }
 
         maintainer = std::make_unique<dash::coin::CoinStateMaintainer>(node_coin_state);

--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -1125,6 +1125,11 @@ private:
     // holder in whatever (un)published state it is in -- callers reach demote()
     // explicitly for the invalidating transitions.
     void republish() {
+        // Publish the two publish-preconditions FIRST, whichever way this
+        // goes: a refusal that says only "not-populated" cannot tell an
+        // operator whether headers are still syncing or the MN set was never
+        // seeded, and those need opposite responses.
+        m_state.set_populate_inputs(m_have_tip, m_have_mn);
         if (m_have_tip && m_have_mn)
             m_state.set_tip(m_prev_height, m_prev_hash, m_bits_for_next,
                             m_mtp_at_tip, m_address_version, m_address_p2sh_version,
@@ -1132,6 +1137,7 @@ private:
     }
 
     void demote() {
+        m_state.set_populate_inputs(m_have_tip, m_have_mn);
         if (m_state.populated())
             m_state.invalidate();
     }

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -38,6 +38,7 @@
 #include <cstdint>
 #include <functional>
 #include <optional>
+#include <string>
 #include <vector>
 
 namespace dash {
@@ -164,6 +165,43 @@ public:
     /// exactly one block's platform reward (constant 66,966,830 duffs).
     void set_mn_rr_height(int h) { m_mn_rr_height = h; }
     int mn_rr_height() const { return m_mn_rr_height; }
+
+    /// HEADER-SYNC gate (the DASH half of a cross-lane asymmetry: bch 13, ltc
+    /// 12, nmc 12, btc 6, dgb 6 callers of is_synced(); DASH had ZERO —
+    /// HeaderChain::is_synced() was DEFINED AND NEVER CALLED, machinery that
+    /// compiled and could not be reached).
+    ///
+    /// Every other freshness gate on this class is RELATIVE to our own tip:
+    /// credit-pool height == prev_height, SML hash == prev_hash, payee cursor
+    /// == prev_height. All of them hold perfectly on a node thousands of blocks
+    /// behind but internally CONSISTENT — a peer answering getmnlistd at OUR
+    /// tip returns a diff for that old block, the credit pool advances off the
+    /// same old blocks, and the payee queue folds them in step. Nothing in the
+    /// set can tell "current" from "self-consistently stale", because none of
+    /// them compares against anything outside our own view.
+    ///
+    /// This is that comparison. LTC's builder is the reference pattern in our
+    /// own tree: template_builder.hpp:116 defaults is_synced() to FALSE so a
+    /// subclass must positively PROVE sync, and :376 THROWS rather than serve.
+    /// Unset here (default) leaves the clause unevaluated so every pre-existing
+    /// KAT is byte-unchanged; main_dash wires it to HeaderChain::is_synced() so
+    /// the production daemonless arm cannot mine on a stale tip.
+    void set_chain_synced_fn(std::function<bool()> fn) {
+        m_chain_synced_fn = std::move(fn);
+    }
+
+    /// DIAGNOSTIC: which half of the publish precondition the maintainer is
+    /// still missing. `populated()` is set by set_tip() only when the
+    /// maintainer holds BOTH a tip and an authoritative MN set, so a bare
+    /// "not-populated" collapses two very different operator situations —
+    /// "still syncing headers" and "the MN set has not been seeded/bridged" —
+    /// into one uninformative word. The maintainer publishes both bits here so
+    /// the refusal can carry them as its MEASURED value. Never read by any
+    /// serve or reward path. Unset => the report prints "n/a", not "0".
+    void set_populate_inputs(bool have_tip, bool have_mn) {
+        m_have_tip_dbg = have_tip ? 1 : 0;
+        m_have_mn_dbg  = have_mn ? 1 : 0;
+    }
 
     /// Enable the SML-required viability gate. main_dash.cpp turns this on for
     /// the embedded coin-P2P arm so a template is only served once the CCbTx
@@ -333,17 +371,43 @@ public:
     ///   - a non-null ChainLock is committed when freshness is required.
     /// Only enforced under the require_sml (embedded/CCbTx) posture; the legacy
     /// empty-payload posture is unchanged.
-    bool embedded_template_emit_ok(const DashWorkData& w) const {
+    /// `why` mirrors dashd's `TestBlockValidity(BlockValidationState& state, ...)`
+    /// (dashcore src/node/miner.cpp:337): an optional out-param naming the
+    /// FAILING check, so the caller can say what it discarded instead of
+    /// logging a bare "pre-emit check FAILED". Defaulted null keeps every
+    /// existing caller and KAT source-compatible.
+    bool embedded_template_emit_ok(const DashWorkData& w,
+                                   DeclineReport* why = nullptr) const {
+        auto reject = [why](const char* c, std::string v, std::string t) -> bool {
+            if (why) {
+                why->viable    = false;
+                why->cause     = c;
+                why->value     = std::move(v);
+                why->threshold = std::move(t);
+            }
+            return false;
+        };
+        if (why) *why = DeclineReport{};
         if (!m_require_sml) return true;
         // Symmetry with viability (review PR #780 nit): a stale quorum set must
         // never reach emit. (Under the H-1 heal this is already gated by
         // have_sml=false, but re-asserting keeps the defence-in-depth uniform.)
-        if (!m_quorum_healthy) return false;
+        if (!m_quorum_healthy)
+            return reject("emit-quorum-unhealthy", "quorum-tail-parse-failed", "parsed-ok");
+        // Defence in depth (the pre-emit gate re-asserts the height-class
+        // guards even if viability was bypassed): a cached template built while
+        // synced must not be SERVED after the chain has fallen behind.
+        if (m_chain_synced_fn && !m_chain_synced_fn())
+            return reject("emit-chain-not-synced",
+                          "tip=" + std::to_string(m_prev_height) + ",synced=false",
+                          "header-tip-current");
         const uint32_t next_h = m_prev_height + 1;
         // Superblock height-class guard (E-SUPERBLOCK): refuse unless the
         // daemonless govsync provider is trigger-confident for this height
         // (resolve_superblock().ok folds disabled-arm + unfunded cases).
-        if (!resolve_superblock(next_h).ok) return false;
+        if (!resolve_superblock(next_h).ok)
+            return reject("emit-superblock-refused", "not-trigger-confident",
+                          "trigger-confident@h=" + std::to_string(next_h));
         // E1: with a qc plan installed the DKG-window heights are SERVED,
         // not refused — re-derive the mandatory type-6 set here and require
         // the BUILT template to carry exactly it (count + payload bytes, in
@@ -352,30 +416,43 @@ public:
         std::optional<QcBlockPlan> qc_plan;
         if (m_qc_plan_fn) {
             qc_plan = m_qc_plan_fn(next_h);
-            if (!qc_plan) return false;   // underivable — fail closed
+            if (!qc_plan)   // underivable — fail closed
+                return reject("emit-qc-plan-underivable", "nullopt",
+                              "derivable-qc-plan@h=" + std::to_string(next_h));
             // Collect the type-6 payloads actually in the template.
             std::vector<std::vector<unsigned char>> got;
             for (const auto& tx : w.m_txs)
                 if (tx.type == vendor::CFinalCommitmentTxPayload::SPECIALTX_TYPE)
                     got.push_back(tx.extra_payload);
-            if (got.size() != qc_plan->commitments.size()) return false;
+            if (got.size() != qc_plan->commitments.size())
+                return reject("emit-qc-count-drift", std::to_string(got.size()),
+                              std::to_string(qc_plan->commitments.size()));
             for (size_t i = 0; i < got.size(); ++i) {
                 auto expect = build_qc_tx(next_h, qc_plan->commitments[i]);
-                if (got[i] != expect.extra_payload) return false;
+                if (got[i] != expect.extra_payload)
+                    return reject("emit-qc-payload-drift", "qc[" + std::to_string(i) + "]-bytes",
+                                  "planned-qc[" + std::to_string(i) + "]-bytes");
             }
         } else if (m_commitment_window_fn && m_commitment_window_fn(next_h)) {
-            return false;
+            return reject("emit-dkg-commitment-window",
+                          "in-window@h=" + std::to_string(next_h), "off-window");
         }
         if (m_require_fresh_bestcl
             && m_best_cl_height < static_cast<int32_t>(m_prev_height) - 1)
-            return false;
+            return reject("emit-bestcl-stale",
+                          m_best_cl_height > 0 ? std::to_string(m_best_cl_height)
+                                               : std::string("n/a"),
+                          ">=" + std::to_string(static_cast<int64_t>(m_prev_height) - 1));
         // SOAK FIX (independent HEIGHT check): the credit-pool seed's OWN cbTx
         // height must be the tip we build on, else the accrual commits a stale
         // creditPoolBalance (bad-cbtx-assetlocked-amount). Independent of the
         // seed's value/hash — the only check that catches a one-block-behind seed.
         if (m_require_fresh_credit_pool
             && m_credit_pool_height != static_cast<int32_t>(m_prev_height))
-            return false;
+            return reject("emit-creditpool-stale",
+                          m_credit_pool_height >= 0 ? std::to_string(m_credit_pool_height)
+                                                    : std::string("n/a"),
+                          std::to_string(m_prev_height));
         // E4 re-soak fix: the payee queue must have folded every block
         // through the tip this template builds on, else the projected
         // masternode payee is a stale queue slot (bad-cb-payee). Re-assert
@@ -383,12 +460,24 @@ public:
         // viability bypass) can never reach a miner.
         if (m_require_fresh_mn_payee
             && m_mnstates.last_applied_height() != m_prev_height)
-            return false;
+            return reject("emit-payee-stale",
+                          m_mnstates.last_applied_height() != 0
+                              ? std::to_string(m_mnstates.last_applied_height())
+                              : std::string("n/a"),
+                          std::to_string(m_prev_height));
         vendor::CCbTx cb;
-        if (!vendor::parse_cbtx(w.m_coinbase_payload, cb)) return false;
-        if (cb.nHeight != static_cast<int32_t>(next_h)) return false;
+        if (!vendor::parse_cbtx(w.m_coinbase_payload, cb))
+            return reject("emit-cbtx-unparseable",
+                          std::to_string(w.m_coinbase_payload.size()) + "-payload-bytes",
+                          "parseable-CCbTx");
+        if (cb.nHeight != static_cast<int32_t>(next_h))
+            return reject("emit-cbtx-height-drift", std::to_string(cb.nHeight),
+                          std::to_string(next_h));
         auto sml_copy = m_sml;
-        if (cb.merkleRootMNList != sml_copy.CalcMerkleRoot()) return false;
+        if (cb.merkleRootMNList != sml_copy.CalcMerkleRoot())
+            return reject("emit-mnlist-root-drift",
+                          cb.merkleRootMNList.GetHex().substr(0, 12),
+                          sml_copy.CalcMerkleRoot().GetHex().substr(0, 12));
         // E1: under a qc plan the committed root must be the WITH-BLOCK root
         // (fold of the plan's commitments over the active set — equal to the
         // plain root while the plan is all-null, diverging only once Phase L
@@ -396,8 +485,12 @@ public:
         const uint256 expected_quorum_root = qc_plan
             ? qc_plan->merkle_root_quorums
             : compute_merkle_root_quorums(m_qmgr);
-        if (cb.merkleRootQuorums != expected_quorum_root) return false;
-        if (m_require_fresh_bestcl && !cb.has_best_cl_signature()) return false;
+        if (cb.merkleRootQuorums != expected_quorum_root)
+            return reject("emit-quorum-root-drift",
+                          cb.merkleRootQuorums.GetHex().substr(0, 12),
+                          expected_quorum_root.GetHex().substr(0, 12));
+        if (m_require_fresh_bestcl && !cb.has_best_cl_signature())
+            return reject("emit-bestcl-null-committed", "null-clsig", "non-null-clsig");
         // SOAK RE-FIX (build-vs-serve skew): re-derive the expected creditPool
         // from the CURRENT seed at emit/serve time and require the BUILT CbTx to
         // commit exactly that — mirroring the merkle-root re-derivation above.
@@ -412,7 +505,10 @@ public:
                 m_credit_pool
                 + compute_dash_platform_reward_post_v20_mn_rr(next_h,
                                                               m_mn_rr_height);
-            if (cb.creditPoolBalance != expected_credit_pool) return false;
+            if (cb.creditPoolBalance != expected_credit_pool)
+                return reject("emit-creditpool-value-drift",
+                              std::to_string(cb.creditPoolBalance),
+                              std::to_string(expected_credit_pool));
         }
         return true;
     }
@@ -449,42 +545,16 @@ public:
         // block-SUBMIT refusal.
         const bool payee_resolvable =
             !m_require_resolvable_payee || mn_payee_resolvable_at_tip();
-        e.has_state            = m_populated
-                                 && qc_ok
-                                 && (!m_utxo_ready_fn || m_utxo_ready_fn())
-                                 && sb.ok
-                                 // BLOCKER-1: refuse DKG commitment-window
-                                 // heights — unless the E1 qc plan serves them.
-                                 && (m_qc_plan_fn
-                                     || !m_commitment_window_fn
-                                     || !m_commitment_window_fn(m_prev_height + 1))
-                                 // BLOCKER-2: refuse a stale/absent bestCL.
-                                 && (!m_require_fresh_bestcl
-                                     || m_best_cl_height
-                                            >= static_cast<int32_t>(m_prev_height) - 1)
-                                 // SOAK FIX (independent HEIGHT check): refuse a
-                                 // credit-pool seed whose OWN cbTx height is not
-                                 // the tip we build on — catches a seed lagging by
-                                 // a block even when its (self-consistent) value
-                                 // and hash-tag look fresh (bad-cbtx-assetlocked-amount).
-                                 && (!m_require_fresh_credit_pool
-                                     || m_credit_pool_height
-                                            == static_cast<int32_t>(m_prev_height))
-                                 // E4 re-soak fix (bad-cb-payee at 1519827):
-                                 // refuse a payee queue that has not folded
-                                 // every block through the tip we build on —
-                                 // its projected payee is a stale queue slot
-                                 // (dashd-exact projection requires
-                                 // GetMNPayee on the list that connected
-                                 // pindexPrev).
-                                 && (!m_require_fresh_mn_payee
-                                     || m_mnstates.last_applied_height()
-                                            == m_prev_height)
-                                 && (!m_require_sml
-                                     || (m_have_sml
-                                         && m_quorum_healthy
-                                         && m_sml_current_hash == m_prev_hash))
-                                 && payee_resolvable;
+        // ── THE decision, and its reason, from ONE evaluation ────────────────
+        // dashd's ValidationState idiom (consensus/validation.h:69): the call
+        // that returns false is the call that records why. Previously this was
+        // a ten-clause AND producing a bare bool, with classify_decline()
+        // holding an independent SECOND transcription of the same clauses for
+        // logging — and the two had already drifted (classify_decline never
+        // checked payee_resolvable, so a #996 money-path refusal surfaced as
+        // "viable-race"). There is now exactly one list.
+        e.decline   = evaluate_viability(qc_ok, sb.ok, payee_resolvable);
+        e.has_state = e.decline.viable;
         if (m_require_resolvable_payee && !payee_resolvable) {
             LOG_WARNING << "[EMBED-GATE] h=" << (m_prev_height + 1)
                         << " REFUSE embedded template: MN payment due but payee"
@@ -542,58 +612,174 @@ public:
         return select_dash_work(make_embedded_work_inputs(), dashd_fallback);
     }
 
-    /// DIAGNOSTIC (log-only): when select_work() falls closed to the dashd arm,
-    /// name WHICH viability clause in make_embedded_work_inputs() was the FIRST
-    /// unsatisfied one. Pure const read of the SAME members, evaluated in the
-    /// same AND-order has_state uses -- it NEVER alters arm selection or any
-    /// reward/serve path. Turns the shadow oracle's identical FALL-CLOSED lines
-    /// into a diagnosis instead of a tally. NOTE: this classifies embedded
-    /// VIABILITY only. The shadow calls select_work() directly, so the live
-    /// get_work mainnet gate (--embedded-mainnet, work_source.cpp) is NOT on
-    /// this path; a wholly-unfed bundle surfaces as "not-populated", which on a
-    /// gate-off node is how the absent mainnet opt-in manifests here.
+    /// DIAGNOSTIC surface over the SINGLE evaluation in
+    /// make_embedded_work_inputs(). This does NOT re-derive anything: it runs
+    /// the same bundle assembly and returns the reason that assembly recorded,
+    /// so the name an operator reads is by construction the name of the branch
+    /// that actually fired. (Before, this method held its own copy of the
+    /// clause list — the drift that mislabelled #996 payee-unresolvable
+    /// refusals as "viable-race".)
+    ///
+    /// NOTE: this classifies embedded VIABILITY only. The live get_work mainnet
+    /// gate (--embedded-mainnet, work_source.cpp) sits ABOVE it; a wholly-unfed
+    /// bundle surfaces as "not-populated", which on a gate-off node is how the
+    /// absent mainnet opt-in manifests here.
+    DeclineReport describe_decline() const {
+        return make_embedded_work_inputs().decline;
+    }
+
+    /// Legacy string form — byte-identical wire text for every pre-existing
+    /// cause, because the shadow ledger and its KATs key on it. New callers
+    /// should take describe_decline(), which keeps value and threshold apart.
     std::string classify_decline() const {
-        const uint32_t next_h = m_prev_height + 1;
-        // MN PAYEE-DESYNC LATCH — checked FIRST because it is a strictly more
-        // informative cause of the not-populated state that follows it. Before
-        // this line the latch was log-only: the smoke rig reported 639
-        // consecutive "not-populated" declines while the actual cause (a payee
-        // desync at h=2514874 that can only be cleared by an authoritative
-        // re-seed a daemonless node cannot obtain) appeared nowhere a human
-        // reading the decline classification would look.
-        if (m_mn_needs_reseed) return "mn-needs-reseed";
-        if (!m_populated)      return "not-populated";
-        if (m_prev_hash.IsNull()) return "no-tip";
-        if (m_qc_plan_fn && !m_qc_plan_fn(next_h)) return "qc-plan-underivable";
-        if (m_utxo_ready_fn && !m_utxo_ready_fn())  return "utxo-immature";
-        if (!resolve_superblock(next_h).ok)         return "superblock-refused";
-        if (!m_qc_plan_fn && m_commitment_window_fn && m_commitment_window_fn(next_h))
-            return "dkg-commitment-window";
-        if (m_require_fresh_bestcl
-            && m_best_cl_height < static_cast<int32_t>(m_prev_height) - 1)
-            return "bestcl-stale h=" + std::to_string(m_best_cl_height)
-                 + " vs tip=" + std::to_string(m_prev_height);
-        if (m_require_fresh_credit_pool
-            && m_credit_pool_height != static_cast<int32_t>(m_prev_height))
-            return "creditpool-stale h=" + std::to_string(m_credit_pool_height)
-                 + " vs tip=" + std::to_string(m_prev_height);
-        if (m_require_fresh_mn_payee
-            && m_mnstates.last_applied_height() != m_prev_height)
-            return "payee-stale h=" + std::to_string(m_mnstates.last_applied_height())
-                 + " vs tip=" + std::to_string(m_prev_height);
-        if (m_require_sml) {
-            if (!m_have_sml)       return "no-dmn-set";
-            if (!m_quorum_healthy) return "quorum-unhealthy";
-            if (m_sml_current_hash != m_prev_hash)
-                return "dmn-stale sml=" + m_sml_current_hash.GetHex().substr(0, 12)
-                     + " vs tip=" + m_prev_hash.GetHex().substr(0, 12);
-        }
-        // has_state says viable => the Phase-1 select_work sample and this read
-        // straddled a concurrent apply_block. Rare, and named honestly.
-        return "viable-race";
+        const DeclineReport d = describe_decline();
+        if (d.viable) return "viable-race";
+        if (d.cause == "bestcl-stale")
+            return d.cause + " h=" + d.value + " vs tip=" + std::to_string(m_prev_height);
+        if (d.cause == "creditpool-stale" || d.cause == "payee-stale")
+            return d.cause + " h=" + d.value + " vs tip=" + d.threshold;
+        if (d.cause == "dmn-stale")
+            return "dmn-stale sml=" + d.value + " vs tip=" + d.threshold;
+        return d.cause;
     }
 
 private:
+    /// THE clause list. The ONLY transcription of embedded-arm viability:
+    /// make_embedded_work_inputs() derives has_state from `.viable`, and
+    /// describe_decline()/classify_decline() read the very same object, so the
+    /// decision and its name are one thing. Clauses are evaluated in the order
+    /// the old AND used, and the FIRST unmet one is returned — exactly one
+    /// named cause, never a list of maybes.
+    ///
+    /// qc_ok / sb_ok / payee_resolvable are passed IN because the caller has
+    /// already paid for them (the qc plan and superblock schedule are needed by
+    /// the builder regardless); re-invoking those predicates here would double
+    /// the cost on a per-template path and, worse, could observe a different
+    /// answer than the one the bundle was built from.
+    DeclineReport evaluate_viability(bool qc_ok, bool sb_ok,
+                                     bool payee_resolvable) const {
+        const uint32_t next_h = m_prev_height + 1;
+        const std::string tip = std::to_string(m_prev_height);
+        auto refuse = [](const char* c, std::string v, std::string t) {
+            DeclineReport r;
+            r.viable    = false;
+            r.cause     = c;
+            r.value     = std::move(v);
+            r.threshold = std::move(t);
+            return r;
+        };
+
+        DeclineReport d;   // viable by default
+
+        if (!m_populated)
+            // Say WHICH half the maintainer is missing. -1 means it has never
+            // reported, which is "n/a" — not "0", which would read as "we
+            // measured have_tip and it was false".
+            d = refuse("not-populated",
+                       (m_have_tip_dbg < 0 || m_have_mn_dbg < 0)
+                           ? std::string("n/a")
+                           : "have_tip=" + std::to_string(m_have_tip_dbg)
+                                 + ",have_mn=" + std::to_string(m_have_mn_dbg),
+                       "have_tip=1,have_mn=1");
+        else if (m_chain_synced_fn && !m_chain_synced_fn())
+            // Checked EARLY: on a stale tip every relative gate below can be
+            // satisfied and still be wrong, so their answers are not evidence.
+            d = refuse("chain-not-synced", "tip=" + tip + ",synced=false",
+                       "header-tip-current");
+        else if (!qc_ok)
+            d = refuse("qc-plan-underivable", "nullopt",
+                       "derivable-qc-plan@h=" + std::to_string(next_h));
+        else if (m_utxo_ready_fn && !m_utxo_ready_fn())
+            d = refuse("utxo-immature", "utxo_ready=false", "utxo_ready=true");
+        else if (!sb_ok)
+            d = refuse("superblock-refused", "not-trigger-confident",
+                       "trigger-confident@h=" + std::to_string(next_h));
+        else if (!m_qc_plan_fn && m_commitment_window_fn && m_commitment_window_fn(next_h))
+            d = refuse("dkg-commitment-window", "in-window@h=" + std::to_string(next_h),
+                       "off-window");
+        else if (m_require_fresh_bestcl
+                 && m_best_cl_height < static_cast<int32_t>(m_prev_height) - 1)
+            // best_cl_height 0 means "no clsig ever observed", NOT "ChainLock at
+            // height 0" — print n/a rather than report a measurement never taken.
+            d = refuse("bestcl-stale",
+                       m_best_cl_height > 0 ? std::to_string(m_best_cl_height)
+                                            : std::string("n/a"),
+                       ">=" + std::to_string(static_cast<int64_t>(m_prev_height) - 1));
+        else if (m_require_fresh_credit_pool
+                 && m_credit_pool_height != static_cast<int32_t>(m_prev_height))
+            // -1 is the member's own "never seeded" sentinel.
+            d = refuse("creditpool-stale",
+                       m_credit_pool_height >= 0 ? std::to_string(m_credit_pool_height)
+                                                 : std::string("n/a"),
+                       tip);
+        else if (m_require_fresh_mn_payee
+                 && m_mnstates.last_applied_height() != m_prev_height)
+            // 0 means the payee queue has never folded a block.
+            d = refuse("payee-stale",
+                       m_mnstates.last_applied_height() != 0
+                           ? std::to_string(m_mnstates.last_applied_height())
+                           : std::string("n/a"),
+                       tip);
+        else if (m_require_sml && !m_have_sml)
+            d = refuse("no-dmn-set", std::to_string(m_sml.size()) + "-entries",
+                       ">=1-entry");
+        else if (m_require_sml && !m_quorum_healthy)
+            d = refuse("quorum-unhealthy", "quorum-tail-parse-failed", "parsed-ok");
+        else if (m_require_sml && m_sml_current_hash != m_prev_hash)
+            // A ZERO sml hash is "cold / wiped by reorg", not a block hash.
+            d = refuse("dmn-stale",
+                       m_sml_current_hash.IsNull()
+                           ? std::string("n/a")
+                           : m_sml_current_hash.GetHex().substr(0, 12),
+                       m_prev_hash.GetHex().substr(0, 12));
+        else if (!payee_resolvable)
+            d = refuse("payee-unresolvable",
+                       std::to_string(m_mnstates.entries().size())
+                           + "-entries-none-payable",
+                       "expected-payee-in-SML@h=" + std::to_string(next_h));
+
+        if (d.viable) return d;
+
+        // DIAGNOSTIC REFINEMENT — renames an already-taken refusal, never
+        // creates one. Both of these are strictly more informative than the
+        // clause they replace, and neither is part of has_state, so they can
+        // only run once viability has already failed. (The old classify_decline
+        // checked m_prev_hash.IsNull() unconditionally and could therefore
+        // report "no-tip" for an arm that was in fact serving.)
+        if (m_mn_needs_reseed) {
+            // The smoke rig once reported 639 consecutive "not-populated"
+            // declines while the real cause was a payee desync that only an
+            // authoritative re-seed clears — invisible to anyone reading the
+            // classification.
+            d.cause     = "mn-needs-reseed";
+            d.value     = "latched";
+            d.threshold = "cleared-by-authoritative-reseed";
+        } else if (d.cause == "not-populated" && m_prev_hash.IsNull()
+                   && m_have_tip_dbg < 0) {
+            // ONLY when the maintainer has told us nothing (never reported).
+            //
+            // Measured on the daemonless rig 2026-08-03: the header chain was
+            // at h=2515420 and advancing every ~60 s, and this refinement was
+            // reporting "no-tip". THIS CLASS's m_prev_hash is null merely
+            // BECAUSE set_tip() has not run — a consequence of not publishing,
+            // not an independent fact — and set_tip() only runs once the
+            // maintainer holds BOTH halves. So while the MN set is unseeded,
+            // prev_hash stays null forever no matter how current the headers
+            // are, and relabelling to "no-tip" told the operator the exact
+            // opposite of the truth: chase a header-sync fault that does not
+            // exist, while the real blocker (have_mn=0) went unnamed.
+            //
+            // When the maintainer HAS reported, its have_tip/have_mn pair is
+            // strictly better information than our own null pointer, in both
+            // directions — have_tip=0 says headers, have_tip=1 says MN set —
+            // so it wins.
+            d.cause     = "no-tip";
+            d.value     = "prev_hash=null,maintainer-never-reported";
+            d.threshold = "prev_hash!=null";
+        }
+        return d;
+    }
+
     // #996 helper: is the MN payee the embedded builder will need actually
     // resolvable at the tip we build on? Mirrors embedded_gbt.hpp's build-time
     // condition (build_embedded_workdata gates the MN PackedPayment on
@@ -666,6 +852,7 @@ private:
     uint256  m_sml_current_hash;              // block hash the SML is current at (ZERO = cold/reorg)
     bool     m_require_sml{false};            // gate viability on have_sml (embedded arm)
     std::function<bool()> m_utxo_ready_fn;   // optional UTXO maturity gate (E2b)
+    std::function<bool()> m_chain_synced_fn; // optional ABSOLUTE header-sync gate (never serve a stale tip)
     std::function<bool(uint32_t)> m_is_superblock_fn;  // superblock-height predicate
     // E-SUPERBLOCK: daemonless governance-sourced superblock schedule provider
     // + opt-in gate. Default gate OFF => every superblock height refuses (old
@@ -692,6 +879,9 @@ private:
     // so classify_decline() can NAME it. Never consulted by any serve/reward
     // path — the latch itself lives (and gates) in the maintainer.
     bool     m_mn_needs_reseed{false};
+    // Publish-precondition mirror (-1 = the maintainer has never reported).
+    int8_t   m_have_tip_dbg{-1};
+    int8_t   m_have_mn_dbg{-1};
     uint32_t m_prev_height{0};
     uint256  m_prev_hash;
     uint32_t m_bits_for_next{0};

--- a/src/impl/dash/coin/serve_gate_journal.hpp
+++ b/src/impl/dash/coin/serve_gate_journal.hpp
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// DEFECT-3 (daemonless soak, 2026-08-03): the DASH embedded serve gate
+/// refused SILENTLY.
+///
+/// Measured on the contabo daemonless soak: the bridge completed, 2071
+/// masternodes published, and the embedded arm served three templates whose MN
+/// payee was byte-identical to a real dashd getblocktemplate at the same
+/// height. It then flipped to the fallback arm and stayed there, and the ONLY
+/// trace was
+///
+///     [DASH-STRATUM-GBT] template sourced: arm=dashd-fallback h=0 mn_payee=(none)
+///
+/// with no reason line of any kind. NodeCoinState::classify_decline() already
+/// knew the answer, but it is reachable ONLY from EmbeddedOracleShadow, which
+/// (a) requires --embedded-oracle-shadow and (b) returns at its first line when
+/// no dashd oracle is bound -- i.e. it can never run on a daemonless node, the
+/// only node where the question is asked. A gate that refuses in silence is
+/// indistinguishable from a broken node.
+///
+/// ServeGateJournal is the rate policy for putting that answer on the live
+/// serve path without flooding it (the path runs per template re-source):
+///
+///   * the EMBEDDED -> fallback TRANSITION always logs, even when the cause is
+///     identical to a previous decline -- that edge is the event an operator
+///     cares about and suppressing it is how the defect stayed invisible;
+///   * a CHANGE of cause always logs (a different first-unmet condition is a
+///     different fault);
+///   * an unchanged cause logs on a slow HEARTBEAT so a stuck arm still names
+///     itself in any window of the journal, not only at the moment it broke;
+///   * everything else is suppressed and COUNTED, so the next emitted line can
+///     say how many it stood for.
+///
+/// Pure policy: no I/O, no clock of its own (the caller passes monotonic
+/// seconds), no coin state. Header-only so it folds into the already
+/// allowlisted dash test targets.
+
+#include <cstdint>
+#include <string>
+
+namespace dash {
+namespace coin {
+
+class ServeGateJournal {
+public:
+    /// Why this observation is being emitted. Rendered into the log line so a
+    /// grep can separate "it just broke" from "it is still broken".
+    enum class Trigger {
+        None,        ///< suppressed
+        First,       ///< first observation ever, and it is a decline
+        Transition,  ///< EMBEDDED -> fallback: always emitted
+        CauseChange, ///< still declining, but a DIFFERENT first-unmet condition
+        Heartbeat,   ///< still declining, same cause, heartbeat interval elapsed
+        Resumed      ///< fallback -> EMBEDDED: the arm is serving again
+    };
+
+    struct Decision {
+        Trigger  trigger{Trigger::None};
+        /// Declines suppressed since the previous emitted line (0 on the
+        /// emitted line itself unless some were folded into it).
+        uint64_t suppressed{0};
+        /// The cause the previous emitted decline named ("" if none). Lets the
+        /// Resumed / CauseChange lines say what they replaced.
+        std::string previous_cause;
+
+        bool emit() const { return trigger != Trigger::None; }
+    };
+
+    explicit ServeGateJournal(int64_t heartbeat_sec = 300)
+        : m_heartbeat_sec(heartbeat_sec) {}
+
+    /// Feed ONE arm-selection outcome. `cause` is ignored when
+    /// `served_embedded` is true. `now_sec` is monotonic seconds.
+    Decision observe(bool served_embedded, const std::string& cause, int64_t now_sec) {
+        Decision d;
+        d.previous_cause = m_last_cause;
+
+        if (served_embedded) {
+            const bool was_declining = (m_arm == Arm::Declining);
+            m_arm = Arm::Embedded;
+            m_last_cause.clear();
+            if (was_declining) {
+                d.trigger    = Trigger::Resumed;
+                d.suppressed = m_suppressed;
+                m_suppressed = 0;
+                m_last_emit_sec = now_sec;
+                m_have_emitted  = true;
+            }
+            return d;
+        }
+
+        const Arm prev_arm = m_arm;
+        m_arm = Arm::Declining;
+
+        if (prev_arm == Arm::Embedded)
+            d.trigger = Trigger::Transition;
+        else if (prev_arm == Arm::Unknown)
+            d.trigger = Trigger::First;
+        else if (cause != m_last_cause)
+            d.trigger = Trigger::CauseChange;
+        else if (!m_have_emitted || now_sec - m_last_emit_sec >= m_heartbeat_sec)
+            d.trigger = Trigger::Heartbeat;
+
+        m_last_cause = cause;
+
+        if (d.trigger == Trigger::None) {
+            ++m_suppressed;
+            return d;
+        }
+        d.suppressed    = m_suppressed;
+        m_suppressed    = 0;
+        m_last_emit_sec = now_sec;
+        m_have_emitted  = true;
+        return d;
+    }
+
+    /// Human name for a trigger, for the log line.
+    static const char* trigger_name(Trigger t) {
+        switch (t) {
+            case Trigger::First:       return "first";
+            case Trigger::Transition:  return "transition";
+            case Trigger::CauseChange: return "cause-change";
+            case Trigger::Heartbeat:   return "heartbeat";
+            case Trigger::Resumed:     return "resumed";
+            case Trigger::None:        break;
+        }
+        return "none";
+    }
+
+    /// The cause of the most recent decline ("" while the arm is serving or
+    /// before the first observation). This is what the operator-facing web
+    /// surface publishes.
+    const std::string& last_cause() const { return m_last_cause; }
+    bool serving() const { return m_arm == Arm::Embedded; }
+    bool observed() const { return m_arm != Arm::Unknown; }
+    uint64_t suppressed_since_emit() const { return m_suppressed; }
+
+private:
+    enum class Arm { Unknown, Embedded, Declining };
+
+    int64_t     m_heartbeat_sec;
+    Arm         m_arm{Arm::Unknown};
+    std::string m_last_cause;
+    int64_t     m_last_emit_sec{0};
+    bool        m_have_emitted{false};
+    uint64_t    m_suppressed{0};
+};
+
+}  // namespace coin
+}  // namespace dash

--- a/src/impl/dash/coin/work_source.hpp
+++ b/src/impl/dash/coin/work_source.hpp
@@ -29,11 +29,60 @@
 #include <ctime>
 #include <cstdint>
 #include <functional>
+#include <string>
 #include <utility>
 #include <vector>
 
 namespace dash {
 namespace coin {
+
+/// ONE named refusal, carried up the call chain BESIDE the decision that
+/// produced it.
+///
+/// PRIOR ART (dashcore v23.1.7, src/consensus/validation.h:69 `ValidationState`):
+/// dashd never returns a bare bool for "I cannot build this". Every refusal
+/// path calls `state.Invalid(result, reject_reason, debug_message)`, which
+/// RETURNS FALSE WHILE RECORDING WHY — the boolean and its reason are produced
+/// by the same statement and so cannot drift. That state is threaded down
+/// through `BuildNewListFromBlock` / `CalcCbTxMerkleRootQuorums` /
+/// `GetCreditPoolDiffForBlock` / `TestBlockValidity` (src/node/miner.cpp:291-341)
+/// and surfaced to the caller by `BIP22ValidationResult` (src/rpc/mining.cpp:515);
+/// the getblocktemplate PRE-conditions ("…is not connected!", "…is in initial
+/// sync and waiting for blocks…", "…is syncing with network…" — the last being
+/// dashd's OWN superblock-not-synced refusal, src/rpc/mining.cpp:727-741) throw
+/// a typed, named JSONRPCError. Either way the caller learns WHY; nothing
+/// degrades silently.
+///
+/// We adopt the IDIOM, not the file. dashd's `Result` enum is block-rejection
+/// taxonomy (BLOCK_MUTATED, BLOCK_CHAINLOCK …) with no overlap with arm
+/// viability, and dashd's refusals THROW — which on our per-template hot path
+/// would be swallowed by the caller's catch-all (work_source.cpp) and reproduce
+/// the exact silence this type exists to end. So: reason RETURNED, not thrown,
+/// and never re-derived by a parallel copy of the predicate list.
+///
+/// WHY IT MATTERS HERE, MEASURED: before this struct, `has_state` and
+/// `NodeCoinState::classify_decline()` were two independent transcriptions of
+/// the same ten-clause AND — and they HAD already drifted. classify_decline()
+/// omitted the #996 `mn_payee_resolvable_at_tip()` clause entirely, so a
+/// genuine unresolvable-payee refusal (a money path) was reported as
+/// "viable-race", a benign race. A returned reason makes that unrepresentable.
+///
+/// `value` / `threshold` are STRINGS, not numbers, for one reason: a field that
+/// was never evaluated must print the literal "n/a" and NEVER "0". Three
+/// members of the coin state use zero/negative as "never measured" —
+/// best_cl_height==0 is "no ChainLock ever observed", credit_pool_height==-1 is
+/// "never seeded", last_applied_height()==0 is "never folded". Printing those
+/// as heights reads like a measurement and is not one.
+struct DeclineReport {
+    std::string cause{"viable"};   ///< single greppable token, never a list, no spaces
+    std::string value{"n/a"};      ///< what we MEASURED ("n/a" = never evaluated)
+    std::string threshold{"n/a"};  ///< what it had to be ("n/a" = not numeric)
+    bool        viable{true};      ///< true => no refusal; cause/value/threshold unused
+
+    std::string one_line() const {
+        return "cause=" + cause + " value=" + value + " threshold=" + threshold;
+    }
+};
 
 /// The inputs build_embedded_workdata() consumes, plus a validity flag. For the
 /// embedded path to be taken, has_state must be true AND both pointers non-null
@@ -41,6 +90,10 @@ namespace coin {
 /// leave has_state=false and the selector routes to the dashd fallback.
 struct EmbeddedWorkInputs {
     bool                  has_state{false};
+    /// The reason has_state is false, produced by the SAME evaluation that set
+    /// it. Hand-built test bundles leave it viable=true; production fills it in
+    /// NodeCoinState::make_embedded_work_inputs().
+    DeclineReport         decline;
     uint32_t              prev_height{0};
     uint256               prev_hash;
     const MnStateMachine* mnstates{nullptr};
@@ -97,6 +150,12 @@ enum class WorkSource { Embedded, DashdFallback };
 struct WorkSelection {
     DashWorkData work;
     WorkSource   source{WorkSource::DashdFallback};
+    /// WHY the fallback arm was chosen, carried out of the SAME branch that
+    /// chose it (dashd's ValidationState idiom — see DeclineReport). viable on
+    /// the Embedded branch. The arm-selection call site logs THIS; it must
+    /// never re-derive a reason of its own, because a reason computed beside
+    /// the branch instead of by it can be right today and lie tomorrow.
+    DeclineReport decline;
 };
 
 /// Injectable core — the routing decision, testable without a live daemon or a
@@ -108,8 +167,18 @@ inline WorkSelection select_dash_work(
     const std::function<DashWorkData()>& dashd_fallback)
 {
     if (emb.viable())
-        return WorkSelection{embedded_builder(), WorkSource::Embedded};
-    return WorkSelection{dashd_fallback(), WorkSource::DashdFallback};
+        return WorkSelection{embedded_builder(), WorkSource::Embedded, DeclineReport{}};
+    // The two pointer members are the only part of viable() that has_state does
+    // not already cover, so name them rather than inherit a stale bundle reason.
+    DeclineReport why = emb.decline;
+    if (emb.has_state && (emb.mnstates == nullptr || emb.mempool == nullptr)) {
+        why.viable    = false;
+        why.cause     = "bundle-pointers-null";
+        why.value     = std::string(emb.mnstates ? "mnstates=ok" : "mnstates=null")
+                      + "," + (emb.mempool ? "mempool=ok" : "mempool=null");
+        why.threshold = "mnstates!=null,mempool!=null";
+    }
+    return WorkSelection{dashd_fallback(), WorkSource::DashdFallback, std::move(why)};
 }
 
 /// Production entry point: builds the embedded template from `emb` when viable,

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -341,23 +341,49 @@ void DASHWorkSource::resource_template_now() const
         try {
             // Mainnet-gated: bypass select_work and source the reward-safe dashd
             // fallback directly; testnet/regtest picks embedded-when-viable.
-            coin::WorkSelection sel = try_embedded
-                ? coin_state_.select_work(dashd_fallback_)
-                : coin::WorkSelection{
-                      dashd_fallback_ ? dashd_fallback_() : coin::DashWorkData{},
-                      coin::WorkSource::DashdFallback };
+            coin::WorkSelection sel;
+            if (try_embedded) {
+                sel = coin_state_.select_work(dashd_fallback_);
+            } else {
+                // The mainnet gate refused BEFORE viability was ever consulted;
+                // name that, or the operator reads "dashd-fallback" and starts
+                // hunting a coin-state fault that does not exist.
+                coin::DeclineReport gated;
+                if (!embedded_arm_enabled) {
+                    // The mainnet opt-in is off, so viability was never even
+                    // consulted. Name the GATE, not the coin state -- an
+                    // operator here must flip a flag, not chase a sync fault.
+                    gated.viable    = false;
+                    gated.cause     = "mainnet-gate-off";
+                    gated.value     = "embedded_mainnet=false";
+                    gated.threshold = "--embedded-mainnet";
+                } else {
+                    // Armed but unpopulated. Ask THE clause list rather than
+                    // restating a poorer version of it here; that duplication
+                    // is precisely the drift this design exists to prevent.
+                    gated = coin_state_.describe_decline();
+                }
+                sel = coin::WorkSelection{
+                    dashd_fallback_ ? dashd_fallback_() : coin::DashWorkData{},
+                    coin::WorkSource::DashdFallback, std::move(gated) };
+            }
             // BLOCKER-3 pre-emit HARD GATE (PR #780): re-validate an EMBEDDED
             // template's CbTx against consensus invariants (both roots recomputed,
             // DKG/superblock/bestCL/credit-pool-height guards) before it can be
             // served; on any failure DISCARD it for the reward-safe dashd arm.
+            coin::DeclineReport emit_why;
             if (sel.source == coin::WorkSource::Embedded
-                && !coin_state_.embedded_template_emit_ok(sel.work)) {
-                LOG_WARNING << "[DASH-STRATUM-GBT] embedded CbTx pre-emit check "
-                               "FAILED at h=" << sel.work.m_height
-                            << " — discarding, using dashd fallback";
+                && !coin_state_.embedded_template_emit_ok(sel.work, &emit_why)) {
+                const uint32_t declined_h = sel.work.m_height;
                 sel = coin::WorkSelection{
                     dashd_fallback_ ? dashd_fallback_() : coin::DashWorkData{},
-                    coin::WorkSource::DashdFallback };
+                    coin::WorkSource::DashdFallback, emit_why };
+                // On a daemonless node the fallback arm is UNARMED and returns
+                // an empty template (m_height == 0). Keep the height the
+                // embedded arm was refusing AT -- "h=0" told the operator
+                // nothing, and it is the single most misleading field in the
+                // measured 08-03 fallback lines.
+                if (sel.work.m_height == 0) sel.work.m_height = declined_h;
             }
             // GBT-xcheck reward-safety BACKSTOP (soak): when enabled and a dashd
             // is reachable, cross-check the embedded CbTx creditPoolBalance
@@ -377,8 +403,14 @@ void DASHWorkSource::resource_template_now() const
                                 << emb_cb.creditPoolBalance << " dashd="
                                 << dref_cb.creditPoolBalance
                                 << " — serving dashd template (reward-safety backstop)";
+                    coin::DeclineReport xcheck;
+                    xcheck.viable    = false;
+                    xcheck.cause     = "gbt-xcheck-creditpool-mismatch";
+                    xcheck.value     = std::to_string(emb_cb.creditPoolBalance);
+                    xcheck.threshold = std::to_string(dref_cb.creditPoolBalance);
                     sel = coin::WorkSelection{ std::move(dref),
-                                               coin::WorkSource::DashdFallback };
+                                               coin::WorkSource::DashdFallback,
+                                               std::move(xcheck) };
                 }
             }
             // E2c observability: WHICH arm served this template + the MN payee
@@ -395,6 +427,13 @@ void DASHWorkSource::resource_template_now() const
                      << " h=" << sel.work.m_height
                      << " mn_payee=" << mn_payee;
             work_is_embedded = (sel.source == coin::WorkSource::Embedded);
+            // ── DEFECT-3: the gate must SAY WHY it refused ──────────────────
+            // sel.decline came out of the branch that chose the arm (dashd's
+            // ValidationState idiom), so this line cannot drift from the
+            // decision the way a reason recomputed here would. Rate policy:
+            // the EMBEDDED->fallback transition and any change of cause emit
+            // immediately; an unchanged cause emits on a slow heartbeat.
+            note_arm_decision(work_is_embedded, sel.decline, sel.work.m_height);
             work = std::move(sel.work);
         } catch (const std::exception& e) {
             LOG_WARNING << "[DASH-STRATUM] template sourcing threw: " << e.what();
@@ -422,6 +461,81 @@ void DASHWorkSource::resource_template_now() const
     template_cache_at_  = now;
     template_cache_is_embedded_ = work_is_embedded;
     template_last_fail_at_ = {};
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DEFECT-3 (daemonless soak 2026-08-03): the serve gate refused SILENTLY.
+//
+// Measured: the embedded arm served three templates whose MN payee was
+// byte-identical to a real dashd getblocktemplate, then flipped to
+// "arm=dashd-fallback h=0 mn_payee=(none)" and stayed there, with the tip
+// advancing normally and NO reason line of any kind. classify_decline() already
+// knew the answer but was reachable only from EmbeddedOracleShadow, which needs
+// --embedded-oracle-shadow AND a bound dashd oracle -- so on a daemonless node,
+// the only node where the question is asked, it could never run.
+//
+// This is the one place the answer is emitted, and it emits the report the
+// selecting branch RETURNED, so it cannot drift from the decision.
+// ─────────────────────────────────────────────────────────────────────────────
+void DASHWorkSource::note_arm_decision(bool served_embedded,
+                                       const coin::DeclineReport& why,
+                                       uint32_t height) const
+{
+    const auto now_sec = std::chrono::duration_cast<std::chrono::seconds>(
+                             std::chrono::steady_clock::now().time_since_epoch())
+                             .count();
+    coin::ServeGateJournal::Decision d;
+    {
+        std::lock_guard<std::mutex> lk(serve_gate_mutex_);
+        d = serve_gate_journal_.observe(served_embedded, why.cause, now_sec);
+        last_decline_      = served_embedded ? coin::DeclineReport{} : why;
+        last_arm_embedded_ = served_embedded;
+        arm_ever_observed_ = true;
+    }
+    if (!d.emit()) return;
+
+    if (d.trigger == coin::ServeGateJournal::Trigger::Resumed) {
+        LOG_WARNING << "[EMBED-GATE] h=" << height
+                    << " arm=EMBEDDED RESUMED (was declining: "
+                    << (d.previous_cause.empty() ? "unknown" : d.previous_cause)
+                    << "; " << d.suppressed << " decline(s) suppressed)";
+        return;
+    }
+    // ONE named cause with its measured value and threshold -- never a list of
+    // maybes, and never "declined" alone.
+    LOG_WARNING << "[EMBED-GATE] h=" << height
+                << " arm=dashd-fallback DECLINED " << why.one_line()
+                << " trigger=" << coin::ServeGateJournal::trigger_name(d.trigger)
+                << " suppressed=" << d.suppressed;
+}
+
+// Operator surface (per-coin /api/node_topology no_work_reason). Publishes the
+// SAME DeclineReport the journal logged, so the page and the log cannot
+// disagree; "unknown" before the first template is sourced, never a fabricated
+// "ok".
+nlohmann::json DASHWorkSource::embedded_arm_status_json() const
+{
+    std::lock_guard<std::mutex> lk(serve_gate_mutex_);
+    nlohmann::json j;
+    if (!arm_ever_observed_) {
+        j["arm"]               = "unknown";
+        j["no_work_reason"]    = "no-template-sourced-yet";
+        j["no_work_value"]     = "n/a";
+        j["no_work_threshold"] = "n/a";
+        return j;
+    }
+    if (last_arm_embedded_) {
+        j["arm"]               = "EMBEDDED";
+        j["no_work_reason"]    = "";
+        j["no_work_value"]     = "n/a";
+        j["no_work_threshold"] = "n/a";
+        return j;
+    }
+    j["arm"]               = "dashd-fallback";
+    j["no_work_reason"]    = last_decline_.cause;
+    j["no_work_value"]     = last_decline_.value;
+    j["no_work_threshold"] = last_decline_.threshold;
+    return j;
 }
 
 std::shared_ptr<const coin::DashWorkData> DASHWorkSource::cached_work() const

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -51,6 +51,7 @@
 #include <core/uint256.hpp>
 
 #include <impl/dash/coin/node_coin_state.hpp>   // coin::NodeCoinState, coin::DashWorkData seam
+#include <impl/dash/coin/serve_gate_journal.hpp> // coin::ServeGateJournal — decline rate policy (DEFECT-3)
 #include <impl/dash/stratum/get_work.hpp>       // dash::stratum::get_work() fused capstone
 
 #include <atomic>
@@ -401,7 +402,22 @@ public:
     void set_refresh_executor(std::function<void(std::function<void()>)> fn)
     { refresh_executor_ = std::move(fn); }
 
+    /// DEFECT-3 operator surface: WHY the embedded arm is not serving, in the
+    /// shape the per-coin /api/node_topology entry publishes (no_work_reason +
+    /// its measured value and threshold). Sourced from the SAME DeclineReport
+    /// the arm-selection branch returned, so the web page and the journal can
+    /// never disagree. `arm` is "EMBEDDED" while serving; "unknown" before the
+    /// first template has been sourced -- never a fabricated "ok".
+    nlohmann::json embedded_arm_status_json() const;
+
 private:
+    /// Record ONE arm-selection outcome and, if the rate policy says so, emit
+    /// the single named line. `why` MUST be the report the selecting branch
+    /// returned -- never one recomputed here.
+    void note_arm_decision(bool served_embedded,
+                           const coin::DeclineReport& why,
+                           uint32_t height) const;
+
     // External dependencies (non-owning references) -- see Lifetime note.
     const coin::NodeCoinState&  coin_state_;    ///< embedded work arm (populated -> Embedded)
     std::function<coin::DashWorkData()> dashd_fallback_;  ///< always-reachable dashd GBT RPC arm (never removed)
@@ -416,6 +432,25 @@ private:
     bool is_testnet_{false};
     bool embedded_mainnet_{false};   // gate-lift opt-in: daemonless embedded arm on mainnet
     bool gbt_xcheck_{false};         // reward-safety backstop: cross-check embedded creditPool vs dashd
+
+    // Slow heartbeat for an UNCHANGED decline cause. The transition and any
+    // change of cause are emitted immediately regardless; this only bounds how
+    // long a steady-state refusal can go unnamed in the journal. Long enough
+    // that a per-template path (a re-source every few seconds under load)
+    // cannot flood, short enough that any 5-minute window of the journal
+    // answers "why is the arm not serving".
+    static constexpr int64_t kDeclineHeartbeatSec = 300;
+
+    // DEFECT-3: the serve gate must NAME its refusal. `serve_gate_journal_` is
+    // the rate policy (transition / cause-change / heartbeat); `last_decline_`
+    // is the most recent DeclineReport as returned BY the arm-selection branch
+    // -- never re-derived beside it -- and is what the web surface publishes.
+    // Mutable because resource_template_now() is const.
+    mutable std::mutex              serve_gate_mutex_;
+    mutable coin::ServeGateJournal  serve_gate_journal_{kDeclineHeartbeatSec};
+    mutable coin::DeclineReport     last_decline_;
+    mutable bool                    last_arm_embedded_{false};
+    mutable bool                    arm_ever_observed_{false};
 
     // Atomic state. work_generation_ is mutable: the const template-cache
     // resolve (cached_work) bumps it when a refresh observes a moved tip.

--- a/test/test_dash_node_coin_state.cpp
+++ b/test/test_dash_node_coin_state.cpp
@@ -775,3 +775,506 @@ TEST(DashNodeCoinState, MaintainerOnMnlistdiffPopulatesSmlAndEmitsPayload) {
     EXPECT_EQ(st.sml().size(), 0u);
     EXPECT_FALSE(st.make_embedded_work_inputs().viable());
 }
+
+// ════════════════════════════════════════════════════════════════════════
+// DEFECT-3 (daemonless soak 2026-08-03): the serve gate must NAME its refusal.
+//
+// Measured: the embedded arm served three templates whose MN payee was
+// byte-identical to a real dashd getblocktemplate, then flipped to
+// "arm=dashd-fallback h=0 mn_payee=(none)" and stayed there with the tip
+// advancing normally and NO reason line of any kind.
+//
+// The design property these KATs pin is the one the prior art has and we had
+// dropped (dashcore src/consensus/validation.h:69 ValidationState — the call
+// that returns false is the call that records why): the reason RIDES THE
+// DECISION. `make_embedded_work_inputs()` sets has_state from
+// `decline.viable`, so a bundle that is not viable ALWAYS carries a non-viable
+// report and vice versa. That equivalence is not a convention a future
+// refactor can quietly break; it is the code.
+//
+// Each positive has its negative twin: every "names cause X" test is paired
+// with the same state minus the fault, asserting the arm is viable and the
+// report says so.
+// ════════════════════════════════════════════════════════════════════════
+
+using dash::coin::DeclineReport;
+
+// A fully HEALTHY armed bundle: every optional gate enabled and satisfied.
+// Every decline test below starts here and breaks exactly ONE thing, so the
+// cause it names is unambiguous.
+static void seed_healthy_armed(NodeCoinState& st) {
+    seed_single_mn(st, p2pkh_script(0x30));
+    seed_sml(st);
+    st.set_require_sml(true);
+    st.set_sml_current_hash(raw256(0xAB));
+    st.set_require_fresh_bestcl(true);
+    st.set_best_cl(static_cast<int32_t>(H - 1), {});
+    st.set_require_fresh_credit_pool(true);
+    st.set_credit_pool(0, raw256(0xAB), static_cast<int32_t>(H - 1));
+    st.set_require_fresh_mn_payee(true);
+    st.mnstates().load(
+        std::vector<std::pair<uint256, MNState>>{}, H - 1);
+    // Re-seed the single MN AT the tip so last_applied_height == prev_height.
+    {
+        MNState s;
+        s.isValid = true;
+        s.nRegisteredHeight = 2'300'000;
+        s.nLastPaidHeight = 0;
+        s.scriptPayout.m_data = p2pkh_script(0x30);
+        st.mnstates().load(
+            std::vector<std::pair<uint256, MNState>>{{raw256(0x01), s}}, H - 1);
+    }
+    st.set_tip(H - 1, raw256(0xAB), 0x1b104be3u, 1'700'000'000u,
+               DASH_PUBKEY_VER, DASH_P2SH_VER, 1'700'000'123u, 0x20000000u);
+}
+
+// ── The baseline (NEGATIVE TWIN for every decline case below) ───────────
+TEST(DashServeGateNamesRefusal, HealthyArmedBundleIsViableAndReportsSo) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    const auto e = st.make_embedded_work_inputs();
+    ASSERT_TRUE(e.has_state)
+        << "the shared baseline must be VIABLE, else every decline test below "
+           "could pass for the wrong reason";
+    EXPECT_TRUE(e.decline.viable);
+    EXPECT_EQ(st.classify_decline(), "viable-race");
+}
+
+// ── THE INVARIANT: reason rides the decision, never beside it ────────────
+// This is the property a returned reason buys over a parallel log statement.
+// If a future edit adds a clause to has_state and forgets the report (the
+// failure that let a #996 payee-unresolvable refusal masquerade as
+// "viable-race"), this goes red.
+TEST(DashServeGateNamesRefusal, HasStateAndDeclineViableAreTheSameBit) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    EXPECT_EQ(st.make_embedded_work_inputs().has_state,
+              st.make_embedded_work_inputs().decline.viable);
+
+    // …and stays the same bit across every single-fault mutation.
+    st.set_credit_pool(0, raw256(0xAB), static_cast<int32_t>(H - 5));
+    const auto stale = st.make_embedded_work_inputs();
+    EXPECT_EQ(stale.has_state, stale.decline.viable);
+    EXPECT_FALSE(stale.has_state);
+}
+
+// ── One case per condition, each naming its FIRST unmet clause ──────────
+TEST(DashServeGateNamesRefusal, CreditPoolStaleNamesValueAndThreshold) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_credit_pool(0, raw256(0xAB), static_cast<int32_t>(H - 4));
+    const DeclineReport d = st.describe_decline();
+    EXPECT_FALSE(d.viable);
+    EXPECT_EQ(d.cause, "creditpool-stale");
+    EXPECT_EQ(d.value, std::to_string(H - 4))     << "the MEASURED seed height";
+    EXPECT_EQ(d.threshold, std::to_string(H - 1)) << "the tip it had to equal";
+}
+
+TEST(DashServeGateNamesRefusal, CreditPoolFreshIsViable) {   // negative twin
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_credit_pool(0, raw256(0xAB), static_cast<int32_t>(H - 1));
+    EXPECT_TRUE(st.describe_decline().viable);
+}
+
+TEST(DashServeGateNamesRefusal, PayeeStaleNamesValueAndThreshold) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    MNState s;
+    s.isValid = true;
+    s.nRegisteredHeight = 2'300'000;
+    s.scriptPayout.m_data = p2pkh_script(0x30);
+    st.mnstates().load(
+        std::vector<std::pair<uint256, MNState>>{{raw256(0x01), s}}, H - 3);
+    const DeclineReport d = st.describe_decline();
+    EXPECT_EQ(d.cause, "payee-stale");
+    EXPECT_EQ(d.value, std::to_string(H - 3));
+    EXPECT_EQ(d.threshold, std::to_string(H - 1));
+}
+
+TEST(DashServeGateNamesRefusal, PayeeFreshIsViable) {        // negative twin
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    EXPECT_TRUE(st.describe_decline().viable);
+}
+
+TEST(DashServeGateNamesRefusal, DmnStaleNamesSmlHashAndTipHash) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_sml_current_hash(raw256(0xCD));   // SML current at a DIFFERENT block
+    const DeclineReport d = st.describe_decline();
+    EXPECT_EQ(d.cause, "dmn-stale");
+    EXPECT_EQ(d.value, raw256(0xCD).GetHex().substr(0, 12));
+    EXPECT_EQ(d.threshold, raw256(0xAB).GetHex().substr(0, 12));
+}
+
+TEST(DashServeGateNamesRefusal, DmnCurrentAtTipIsViable) {   // negative twin
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_sml_current_hash(raw256(0xAB));
+    EXPECT_TRUE(st.describe_decline().viable);
+}
+
+TEST(DashServeGateNamesRefusal, BestClStaleNamesHeightAndFloor) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_best_cl(static_cast<int32_t>(H - 50), {});
+    const DeclineReport d = st.describe_decline();
+    EXPECT_EQ(d.cause, "bestcl-stale");
+    EXPECT_EQ(d.value, std::to_string(H - 50));
+    EXPECT_EQ(d.threshold, ">=" + std::to_string(H - 2));
+}
+
+TEST(DashServeGateNamesRefusal, BestClFreshIsViable) {       // negative twin
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_best_cl(static_cast<int32_t>(H - 2), {});   // exactly at the floor
+    EXPECT_TRUE(st.describe_decline().viable);
+}
+
+TEST(DashServeGateNamesRefusal, QuorumUnhealthyIsNamed) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_quorum_healthy(false);
+    EXPECT_EQ(st.describe_decline().cause, "quorum-unhealthy");
+}
+
+TEST(DashServeGateNamesRefusal, QuorumHealthyIsViable) {     // negative twin
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_quorum_healthy(true);
+    EXPECT_TRUE(st.describe_decline().viable);
+}
+
+TEST(DashServeGateNamesRefusal, SuperblockRefusalIsNamed) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_is_superblock_fn([](uint32_t) { return true; });
+    EXPECT_EQ(st.describe_decline().cause, "superblock-refused");
+}
+
+TEST(DashServeGateNamesRefusal, NonSuperblockHeightIsViable) {  // negative twin
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_is_superblock_fn([](uint32_t) { return false; });
+    EXPECT_TRUE(st.describe_decline().viable);
+}
+
+TEST(DashServeGateNamesRefusal, DkgCommitmentWindowIsNamed) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_commitment_window_fn([](uint32_t) { return true; });
+    const DeclineReport d = st.describe_decline();
+    EXPECT_EQ(d.cause, "dkg-commitment-window");
+    EXPECT_EQ(d.value, "in-window@h=" + std::to_string(H));
+}
+
+TEST(DashServeGateNamesRefusal, OffCommitmentWindowIsViable) {  // negative twin
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_commitment_window_fn([](uint32_t) { return false; });
+    EXPECT_TRUE(st.describe_decline().viable);
+}
+
+TEST(DashServeGateNamesRefusal, UtxoImmatureIsNamed) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_utxo_ready_fn([] { return false; });
+    EXPECT_EQ(st.describe_decline().cause, "utxo-immature");
+}
+
+TEST(DashServeGateNamesRefusal, UtxoMatureIsViable) {          // negative twin
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_utxo_ready_fn([] { return true; });
+    EXPECT_TRUE(st.describe_decline().viable);
+}
+
+TEST(DashServeGateNamesRefusal, QcPlanUnderivableIsNamed) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_qc_plan_fn([](uint32_t) { return std::optional<dash::coin::QcBlockPlan>{}; });
+    EXPECT_EQ(st.describe_decline().cause, "qc-plan-underivable");
+}
+
+TEST(DashServeGateNamesRefusal, QcPlanDerivableIsViable) {     // negative twin
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_qc_plan_fn([](uint32_t) {
+        dash::coin::QcBlockPlan p;
+        p.merkle_root_quorums = uint256::ZERO;
+        return std::optional<dash::coin::QcBlockPlan>{p};
+    });
+    EXPECT_TRUE(st.describe_decline().viable);
+}
+
+TEST(DashServeGateNamesRefusal, NotPopulatedIsNamed) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.invalidate();
+    EXPECT_EQ(st.describe_decline().cause, "not-populated");
+}
+
+TEST(DashServeGateNamesRefusal, MnNeedsReseedOutranksNotPopulated) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.invalidate();
+    st.set_mn_needs_reseed(true);
+    const DeclineReport d = st.describe_decline();
+    EXPECT_EQ(d.cause, "mn-needs-reseed")
+        << "the latch is strictly more informative than the not-populated "
+           "state it causes (the smoke rig logged 639 'not-populated' declines "
+           "while the real cause was a payee desync)";
+    EXPECT_EQ(st.classify_decline(), "mn-needs-reseed")
+        << "legacy wire text must not change -- the shadow ledger keys on it";
+}
+
+TEST(DashServeGateNamesRefusal, MnReseedLatchClearIsViable) {   // negative twin
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_mn_needs_reseed(false);
+    EXPECT_TRUE(st.describe_decline().viable);
+}
+
+// A DIAGNOSTIC refinement must never CREATE a refusal. Before the single-list
+// rewrite, classify_decline() tested prev_hash.IsNull() unconditionally and so
+// could report "no-tip" for an arm that was in fact serving.
+TEST(DashServeGateNamesRefusal, DiagnosticRefinementNeverContradictsHasState) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_mn_needs_reseed(true);   // latch ON while the bundle is healthy
+    const auto e = st.make_embedded_work_inputs();
+    EXPECT_TRUE(e.has_state)
+        << "the reseed latch is diagnostic-only: it must not gate serving";
+    EXPECT_TRUE(e.decline.viable)
+        << "and it must not manufacture a decline report either";
+    EXPECT_EQ(e.decline.cause, "viable")
+        << "nor RENAME a viable report: the refinement block must be "
+           "unreachable while the arm is serving, or an operator reads a cause "
+           "for a refusal that never happened";
+    EXPECT_EQ(st.classify_decline(), "viable-race");
+}
+
+// ── THE n/a RULE: an unevaluated field must NEVER print as 0 ─────────────
+// A zero standing in for "not measured" is the same silent-refusal defect in
+// new clothes. Each of these three members uses a zero/negative as its own
+// "never measured" sentinel.
+TEST(DashServeGateNamesRefusal, NeverSeededCreditPoolPrintsNaNotZero) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    NodeCoinState fresh;                    // credit_pool_height == -1 sentinel
+    seed_single_mn(fresh, p2pkh_script(0x30));
+    fresh.set_require_fresh_credit_pool(true);
+    fresh.set_tip(H - 1, raw256(0xAB), 0x1b104be3u, 1'700'000'000u,
+                  DASH_PUBKEY_VER, DASH_P2SH_VER, 1'700'000'123u, 0x20000000u);
+    const DeclineReport d = fresh.describe_decline();
+    ASSERT_EQ(d.cause, "creditpool-stale");
+    EXPECT_EQ(d.value, "n/a")
+        << "credit_pool_height==-1 means NEVER SEEDED; printing it as a height "
+           "reads like a measurement that was never taken";
+    EXPECT_NE(d.value, "-1");
+    EXPECT_NE(d.value, "0");
+}
+
+TEST(DashServeGateNamesRefusal, NeverObservedChainLockPrintsNaNotZero) {
+    NodeCoinState st;
+    seed_single_mn(st, p2pkh_script(0x30));
+    st.set_require_fresh_bestcl(true);       // best_cl_height stays 0 = never seen
+    st.set_tip(H - 1, raw256(0xAB), 0x1b104be3u, 1'700'000'000u,
+               DASH_PUBKEY_VER, DASH_P2SH_VER, 1'700'000'123u, 0x20000000u);
+    const DeclineReport d = st.describe_decline();
+    ASSERT_EQ(d.cause, "bestcl-stale");
+    EXPECT_EQ(d.value, "n/a")
+        << "best_cl_height==0 means no clsig EVER observed, not 'ChainLock at "
+           "height 0'";
+    EXPECT_NE(d.value, "0");
+}
+
+TEST(DashServeGateNamesRefusal, NeverFoldedPayeeQueuePrintsNaNotZero) {
+    NodeCoinState st;
+    seed_single_mn(st, p2pkh_script(0x30));  // load() with no as_of => cursor 0
+    st.set_require_fresh_mn_payee(true);
+    st.set_tip(H - 1, raw256(0xAB), 0x1b104be3u, 1'700'000'000u,
+               DASH_PUBKEY_VER, DASH_P2SH_VER, 1'700'000'123u, 0x20000000u);
+    const DeclineReport d = st.describe_decline();
+    ASSERT_EQ(d.cause, "payee-stale");
+    EXPECT_EQ(d.value, "n/a")
+        << "last_applied_height()==0 means the queue has never folded a block";
+    EXPECT_NE(d.value, "0");
+}
+
+// A MEASURED zero, by contrast, must still print as 0 -- the n/a rule must not
+// swallow real data. (Fails-without-fix guard on the rule itself.)
+TEST(DashServeGateNamesRefusal, MeasuredHeightsStillPrintNumerically) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_credit_pool(0, raw256(0xAB), 7);
+    const DeclineReport d = st.describe_decline();
+    ASSERT_EQ(d.cause, "creditpool-stale");
+    EXPECT_EQ(d.value, "7") << "7 was measured; it must not be blanked to n/a";
+}
+
+// ── one_line() is the greppable contract ────────────────────────────────
+TEST(DashServeGateNamesRefusal, OneLineCarriesCauseValueAndThreshold) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_credit_pool(0, raw256(0xAB), static_cast<int32_t>(H - 4));
+    const std::string line = st.describe_decline().one_line();
+    EXPECT_EQ(line, "cause=creditpool-stale value=" + std::to_string(H - 4)
+                        + " threshold=" + std::to_string(H - 1));
+    EXPECT_EQ(line.find(' '), line.find(" value="))
+        << "the cause token must contain no spaces -- it is grepped";
+}
+
+// ── HEADER-SYNC gate: the ONE absolute check (cross-lane asymmetry) ─────
+// HeaderChain::is_synced() existed and had ZERO callers on the DASH template
+// path (bch 13, ltc 12, nmc 12, btc 6, dgb 6, dash 0). These KATs pin why that
+// mattered: every other gate is relative to our own tip, so a node that is
+// self-consistently STALE passes all of them.
+TEST(DashServeGateNamesRefusal, UnsyncedChainIsNamedAndRefused) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    ASSERT_TRUE(st.make_embedded_work_inputs().has_state)
+        << "baseline must be viable before the sync gate is applied";
+    st.set_chain_synced_fn([] { return false; });
+    const auto e = st.make_embedded_work_inputs();
+    EXPECT_FALSE(e.has_state);
+    EXPECT_EQ(e.decline.cause, "chain-not-synced");
+    EXPECT_EQ(e.decline.threshold, "header-tip-current");
+}
+
+TEST(DashServeGateNamesRefusal, SyncedChainIsViable) {          // negative twin
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_chain_synced_fn([] { return true; });
+    EXPECT_TRUE(st.make_embedded_work_inputs().has_state);
+}
+
+TEST(DashServeGateNamesRefusal, UnsetSyncFnLeavesEveryPriorKatUnchanged) {
+    NodeCoinState st;
+    seed_healthy_armed(st);   // no set_chain_synced_fn call at all
+    EXPECT_TRUE(st.make_embedded_work_inputs().has_state)
+        << "an unwired sync predicate must not silently close the arm -- that "
+           "would break every pre-existing KAT and every testnet harness";
+}
+
+// THE POINT of the gate: a stale-but-self-consistent node passes every
+// RELATIVE freshness check. Without the absolute one it would serve.
+TEST(DashServeGateNamesRefusal, SelfConsistentStaleTipPassesEveryRelativeGate) {
+    NodeCoinState st;
+    // Same construction as the healthy baseline, but "the tip" is an ancient
+    // height. Credit pool, payee cursor and SML hash are all current AT it.
+    const uint32_t ancient = H - 500'000;
+    seed_sml(st);
+    st.set_require_sml(true);
+    st.set_sml_current_hash(raw256(0xAB));
+    st.set_require_fresh_bestcl(true);
+    st.set_best_cl(static_cast<int32_t>(ancient), {});
+    st.set_require_fresh_credit_pool(true);
+    st.set_credit_pool(0, raw256(0xAB), static_cast<int32_t>(ancient));
+    st.set_require_fresh_mn_payee(true);
+    {
+        MNState s;
+        s.isValid = true;
+        s.nRegisteredHeight = 1'000'000;
+        s.scriptPayout.m_data = p2pkh_script(0x30);
+        st.mnstates().load(
+            std::vector<std::pair<uint256, MNState>>{{raw256(0x01), s}}, ancient);
+    }
+    st.set_tip(ancient, raw256(0xAB), 0x1b104be3u, 1'700'000'000u,
+               DASH_PUBKEY_VER, DASH_P2SH_VER, 1'700'000'123u, 0x20000000u);
+
+    EXPECT_TRUE(st.make_embedded_work_inputs().has_state)
+        << "THIS IS THE HAZARD: every relative gate is satisfied on a tip half "
+           "a million blocks behind, because none of them compares against "
+           "anything outside our own view";
+
+    st.set_chain_synced_fn([] { return false; });
+    const auto gated = st.make_embedded_work_inputs();
+    EXPECT_FALSE(gated.has_state)
+        << "the absolute gate is the only thing that can refuse this";
+    EXPECT_EQ(gated.decline.cause, "chain-not-synced");
+}
+
+// "not-populated" collapsed two operator situations needing opposite responses
+// (headers still syncing vs the MN set never seeded) into one word. It now
+// carries which half the maintainer is missing — and prints n/a, not 0, when
+// the maintainer has never reported.
+TEST(DashServeGateNamesRefusal, NotPopulatedNamesWhichHalfIsMissing) {
+    NodeCoinState st;
+    // A real tip is required first: with a NULL prev_hash the diagnostic
+    // refinement (correctly) relabels this to the more informative "no-tip".
+    st.set_tip(H - 1, raw256(0xAB), 0x1b104be3u, 1'700'000'000u,
+               DASH_PUBKEY_VER, DASH_P2SH_VER, 1'700'000'123u, 0x20000000u);
+    st.invalidate();
+    st.set_populate_inputs(/*have_tip=*/true, /*have_mn=*/false);
+    const DeclineReport d = st.describe_decline();
+    ASSERT_EQ(d.cause, "not-populated");
+    EXPECT_EQ(d.value, "have_tip=1,have_mn=0")
+        << "'MN set never seeded' and 'headers still syncing' need opposite "
+           "operator responses; one word cannot carry both";
+    EXPECT_EQ(d.threshold, "have_tip=1,have_mn=1");
+}
+
+TEST(DashServeGateNamesRefusal, NotPopulatedOtherHalf) {          // twin
+    NodeCoinState st;
+    st.set_tip(H - 1, raw256(0xAB), 0x1b104be3u, 1'700'000'000u,
+               DASH_PUBKEY_VER, DASH_P2SH_VER, 1'700'000'123u, 0x20000000u);
+    st.invalidate();
+    st.set_populate_inputs(/*have_tip=*/false, /*have_mn=*/true);
+    EXPECT_EQ(st.describe_decline().value, "have_tip=0,have_mn=1");
+}
+
+TEST(DashServeGateNamesRefusal, UnreportedPopulateInputsPrintNaNotZero) {
+    NodeCoinState st;   // maintainer has never called set_populate_inputs
+    st.set_tip(H - 1, raw256(0xAB), 0x1b104be3u, 1'700'000'000u,
+               DASH_PUBKEY_VER, DASH_P2SH_VER, 1'700'000'123u, 0x20000000u);
+    st.invalidate();
+    const DeclineReport d = st.describe_decline();
+    ASSERT_EQ(d.cause, "not-populated");
+    EXPECT_EQ(d.value, "n/a")
+        << "never reported is NOT reported-false; printing have_tip=0 here "
+           "would be a measurement we never took";
+    EXPECT_EQ(d.value.find('0'), std::string::npos);
+}
+
+// The no-tip refinement, pinned so the ordering cannot silently flip.
+//
+// CAUGHT LIVE on the daemonless rig 2026-08-03: the header chain was at
+// h=2515420 and advancing every ~60 s while this refinement reported "no-tip".
+// NodeCoinState::m_prev_hash is only written by set_tip(), which the maintainer
+// calls only once it holds BOTH a tip and an MN set — so while the MN set is
+// unseeded, prev_hash stays null no matter how current the headers are. Reading
+// that null as "no tip" told the operator to chase a header-sync fault that did
+// not exist while the real blocker went unnamed: the same silent-refusal defect
+// this whole change exists to kill, reintroduced by the diagnostic meant to fix
+// it. The maintainer's report wins whenever it exists.
+TEST(DashServeGateNamesRefusal, MaintainerReportOutranksOurOwnNullPrevHash) {
+    NodeCoinState st;
+    st.set_populate_inputs(/*have_tip=*/true, /*have_mn=*/false);
+    const DeclineReport d = st.describe_decline();
+    EXPECT_EQ(d.cause, "not-populated")
+        << "have_tip=1 explains the null prev_hash; calling it 'no-tip' would "
+           "point the operator at headers when the MN set is the blocker";
+    EXPECT_EQ(d.value, "have_tip=1,have_mn=0");
+}
+
+TEST(DashServeGateNamesRefusal, MaintainerReportWinsInTheOtherDirectionToo) {
+    NodeCoinState st;
+    st.set_populate_inputs(/*have_tip=*/false, /*have_mn=*/true);
+    const DeclineReport d = st.describe_decline();
+    EXPECT_EQ(d.cause, "not-populated");
+    EXPECT_EQ(d.value, "have_tip=0,have_mn=1")
+        << "even when the maintainer agrees there is no tip, its report is the "
+           "measurement -- our null pointer is only a consequence of it";
+}
+
+TEST(DashServeGateNamesRefusal, NoTipOnlyWhenTheMaintainerNeverReported) {
+    NodeCoinState st;   // set_populate_inputs never called
+    const DeclineReport d = st.describe_decline();
+    EXPECT_EQ(d.cause, "no-tip")
+        << "with NO maintainer report, our own null prev_hash is the only "
+           "evidence there is, and it is worth naming";
+    EXPECT_EQ(d.value, "prev_hash=null,maintainer-never-reported")
+        << "and it must say that it is inferring, not measuring";
+}

--- a/test/test_dash_stratum_work_source.cpp
+++ b/test/test_dash_stratum_work_source.cpp
@@ -2185,3 +2185,128 @@ TEST(DashRunArmResolution, NoMainnetCombinationWithoutOptInEverEnablesTheArm)
 }
 
 }  // namespace
+
+// ════════════════════════════════════════════════════════════════════════
+// DEFECT-3: the RATE POLICY for the named refusal (ServeGateJournal).
+//
+// The serve gate sits on a per-template path, so the reason cannot simply be
+// logged on every observation. The policy that makes a silent gate impossible
+// without flooding it:
+//
+//   * the EMBEDDED -> fallback TRANSITION always logs, EVEN IF the cause is
+//     unchanged from an earlier decline -- that edge is the event the operator
+//     cares about, and suppressing it is exactly how the 08-03 flip went
+//     unexplained;
+//   * a CHANGE of cause always logs;
+//   * an unchanged cause logs on a slow heartbeat;
+//   * everything else is suppressed and COUNTED.
+//
+// Negative twins throughout: each "must emit" is paired with the neighbouring
+// state that must NOT emit, so a journal that simply logs everything (or
+// nothing) fails.
+// ════════════════════════════════════════════════════════════════════════
+
+#include <impl/dash/coin/serve_gate_journal.hpp>
+
+using dash::coin::ServeGateJournal;
+using Trig = dash::coin::ServeGateJournal::Trigger;
+
+TEST(DashServeGateJournal, FirstObservationEverIsAlwaysEmitted) {
+    ServeGateJournal j(300);
+    auto d = j.observe(false, "dmn-stale", 1000);
+    EXPECT_TRUE(d.emit());
+    EXPECT_EQ(d.trigger, Trig::First)
+        << "a node that has NEVER served must name its reason immediately -- "
+           "otherwise a cold node that never arms is silent forever";
+}
+
+TEST(DashServeGateJournal, EmbeddedToFallbackTransitionAlwaysEmits) {
+    ServeGateJournal j(300);
+    j.observe(false, "dmn-stale", 1000);          // first decline, emitted
+    j.observe(true,  "",          1010);          // arm resumes
+    // SAME cause as before, and well inside the heartbeat window: the ONLY
+    // thing that makes this emit is that the arm just flipped.
+    auto d = j.observe(false, "dmn-stale", 1011);
+    EXPECT_TRUE(d.emit());
+    EXPECT_EQ(d.trigger, Trig::Transition)
+        << "the EMBEDDED->fallback edge must log even when the cause is "
+           "identical to a previous decline -- this is the measured 08-03 "
+           "event and the rate limiter must never eat it";
+}
+
+TEST(DashServeGateJournal, RepeatOfSameCauseInsideHeartbeatIsSuppressed) {  // twin
+    ServeGateJournal j(300);
+    j.observe(false, "dmn-stale", 1000);
+    auto d = j.observe(false, "dmn-stale", 1001);
+    EXPECT_FALSE(d.emit())
+        << "an unchanged cause on a per-template path must NOT flood";
+    EXPECT_EQ(j.suppressed_since_emit(), 1u);
+}
+
+TEST(DashServeGateJournal, ChangeOfCauseEmitsImmediately) {
+    ServeGateJournal j(300);
+    j.observe(false, "dmn-stale", 1000);
+    auto d = j.observe(false, "creditpool-stale", 1001);
+    EXPECT_TRUE(d.emit());
+    EXPECT_EQ(d.trigger, Trig::CauseChange)
+        << "a different first-unmet condition is a different fault";
+    EXPECT_EQ(d.previous_cause, "dmn-stale");
+}
+
+TEST(DashServeGateJournal, HeartbeatEmitsOnlyAfterTheIntervalElapses) {
+    ServeGateJournal j(300);
+    j.observe(false, "dmn-stale", 1000);
+    EXPECT_FALSE(j.observe(false, "dmn-stale", 1299).emit())
+        << "one second short of the interval must stay suppressed";
+    auto d = j.observe(false, "dmn-stale", 1300);
+    EXPECT_TRUE(d.emit());
+    EXPECT_EQ(d.trigger, Trig::Heartbeat)
+        << "a stuck arm must still name itself in any 5-minute window";
+}
+
+TEST(DashServeGateJournal, SuppressedCountRidesTheNextEmittedLine) {
+    ServeGateJournal j(300);
+    j.observe(false, "dmn-stale", 1000);
+    for (int i = 1; i <= 7; ++i) j.observe(false, "dmn-stale", 1000 + i);
+    auto d = j.observe(false, "creditpool-stale", 1010);
+    ASSERT_TRUE(d.emit());
+    EXPECT_EQ(d.suppressed, 7u)
+        << "the emitted line must say how many observations it stands for; a "
+           "bare reason hides whether this is a blip or a wedge";
+    EXPECT_EQ(j.suppressed_since_emit(), 0u) << "counter resets on emit";
+}
+
+TEST(DashServeGateJournal, ResumeEmitsAndNamesWhatItReplaced) {
+    ServeGateJournal j(300);
+    j.observe(false, "dmn-stale", 1000);
+    auto d = j.observe(true, "", 1005);
+    EXPECT_TRUE(d.emit());
+    EXPECT_EQ(d.trigger, Trig::Resumed);
+    EXPECT_EQ(d.previous_cause, "dmn-stale");
+    EXPECT_TRUE(j.serving());
+    EXPECT_TRUE(j.last_cause().empty());
+}
+
+TEST(DashServeGateJournal, SteadyServingNeverEmits) {          // negative twin
+    ServeGateJournal j(300);
+    j.observe(true, "", 1000);
+    for (int i = 1; i < 50; ++i)
+        EXPECT_FALSE(j.observe(true, "", 1000 + i * 10).emit())
+            << "a healthy arm must be silent -- the journal is for refusals";
+}
+
+TEST(DashServeGateJournal, TwoTransitionsBothEmitEvenWithOneCause) {
+    // The measured 08-03 shape: serve, serve, decline, (recover), decline.
+    // Every arm flip must be visible.
+    ServeGateJournal j(300);
+    int emitted = 0;
+    const std::pair<bool, int64_t> seq[] = {
+        {true, 1000}, {true, 1005}, {false, 1010}, {false, 1011},
+        {true, 1020}, {false, 1030}, {false, 1031},
+    };
+    for (const auto& [served, t] : seq)
+        if (j.observe(served, served ? "" : "dmn-stale", t).emit()) ++emitted;
+    EXPECT_EQ(emitted, 3)
+        << "expected: first decline (transition), resume, second decline "
+           "(transition) -- three edges, none swallowed by the same-cause rule";
+}


### PR DESCRIPTION
## What this changes

The DASH embedded serve gate ANDs ten conditions into a bool and routes to the dashd fallback when
it is false, with logging bolted on beside it — so twelve of the eighteen paths that can select the
fallback arm did so with no reason of any kind. This replaces the bool with a returned
`DeclineReport` produced by the same evaluation that makes the decision, so every refusal names one
condition with its measured value and its threshold, on the live serve path.

Fixes #1002

## Why this approach

**The prior art was checked first, and it changed the design.** dashcore v23.1.7 never returns a
bare bool for "I cannot build this": `ValidationState` (`src/consensus/validation.h:69`) has
`state.Invalid(result, reject_reason, debug_message)` **return false while recording why**, so the
boolean and its reason come from the same statement and cannot drift. That state is threaded
through `BuildNewListFromBlock` / `CalcCbTxMerkleRootQuorums` / `GetCreditPoolDiffForBlock` /
`TestBlockValidity` (`src/node/miner.cpp:291-341`) and surfaced by `BIP22ValidationResult`
(`src/rpc/mining.cpp:515`); the `getblocktemplate` pre-conditions — `"…is not connected!"`, `"…is
in initial sync and waiting for blocks…"`, `"…is syncing with network…"` (dashd's own
superblock-not-synced refusal, `src/rpc/mining.cpp:727-741`) — throw typed, named `JSONRPCError`s.

We adopt the **idiom, not the file**. dashd's `Result` enum is block-rejection taxonomy
(`BLOCK_MUTATED`, `BLOCK_CHAINLOCK`, …) with no overlap with arm viability, and dashd's refusals
*throw* — which on our per-template hot path would be swallowed by the existing catch-all in
`resource_template_now()` and reproduce the very silence being fixed. So: reason **returned**, not
thrown, and never re-derived beside the branch.

Before this, `has_state` and `classify_decline()` were two independent transcriptions of the same
ten-clause AND — **and they had already drifted.** `classify_decline()` omitted the `#996`
`mn_payee_resolvable_at_tip()` clause entirely, so a genuine unresolvable-payee refusal, a money
path, was reported as `"viable-race"` — a benign race. `evaluate_viability()` is now the only
transcription; `has_state = decline.viable` and `describe_decline()` returns that same object.
The drift class is unrepresentable rather than fixed.

### Why the general fix rather than patching branches

Enumerating every path that can set `arm=dashd-fallback` on `origin/master`:

| # | Path | file:line | Names itself? |
|---|---|---|---|
| 1 | `has_state` — `m_populated` | `node_coin_state.hpp:452` | **SILENT** |
| 2 | `has_state` — `qc_ok` | `node_coin_state.hpp:453` | indirect only (below) |
| 3 | `has_state` — UTXO maturity | `node_coin_state.hpp:454` | **SILENT** |
| 4 | `has_state` — superblock `sb.ok` | `node_coin_state.hpp:455` | **SILENT** |
| 5 | `has_state` — DKG commitment window | `node_coin_state.hpp:458-461` | **SILENT** |
| 6 | `has_state` — bestCL freshness | `node_coin_state.hpp:462-465` | **SILENT** |
| 7 | `has_state` — credit-pool freshness | `node_coin_state.hpp:470-473` | **SILENT** |
| 8 | `has_state` — MN-payee cursor freshness | `node_coin_state.hpp:480-482` | **SILENT** |
| 9 | `has_state` — `require_sml` trio | `node_coin_state.hpp:483-486` | **SILENT** — 3 causes, 0 lines |
| 10 | `has_state` — `payee_resolvable` (#996) | `node_coin_state.hpp:487` | names itself (`:488-495`) |
| 11 | `select_dash_work` — `viable()` null pointers | `coin/work_source.hpp:112` | **SILENT** |
| 12 | `get_work()` mainnet-gate early return | `stratum/work_source.cpp:205-210` | **SILENT** |
| 13 | mainnet-gate notice | `stratum/work_source.cpp:328-335` | `std::call_once` — once per process, silent after |
| 14 | `try_embedded == false` → direct fallback | `stratum/work_source.cpp:344-348` | **SILENT** |
| 15 | pre-emit gate `embedded_template_emit_ok` | `stratum/work_source.cpp:353-361` | partial — says it failed, never which of 15 checks |
| 16 | GBT-xcheck creditPool mismatch | `stratum/work_source.cpp:367-382` | names itself |
| 17 | exception during sourcing | `stratum/work_source.cpp:399-401` | names itself |
| 18 | cached-template serve-time re-check | `stratum/work_source.cpp:451` | partial — guesses "stale creditPool/roots", measures nothing |

**Twelve silent, three named, two partial.** Ten-plus holes, not one or two.

It also explains why some fallbacks announced themselves and others did not. The
`[QC-COMPLETENESS] … (arm=dashd-fallback)` line lives **inside the qc-plan producer closure**
(`main_dash.cpp:3128-3134`), not at the arm decision. That closure is invoked from three places —
viability (`:434`), the pre-emit gate (`:354`) and `classify_decline` (`:567`) — so it can log when
no fallback happened and stay silent when one did, and it covers exactly one clause of ten. Nights
differed by *which clause fired*, not by any difference in how the gate reports.

### The `n/a` rule

Three members use a zero/negative as their own "never measured" sentinel: `best_cl_height == 0`
("no ChainLock ever observed"), `credit_pool_height == -1` ("never seeded"),
`last_applied_height() == 0` ("never folded"). Printing those as heights reads like a measurement
that was never taken, so `value`/`threshold` are strings and an unevaluated field prints `n/a`. A
*measured* zero still prints numerically, pinned by its own KAT so the rule cannot swallow real
data.

`not-populated` also stopped being one word for two opposite operator situations: the maintainer
publishes both publish-preconditions, so the refusal carries `have_tip=1,have_mn=0` (MN set
unseeded — needs a re-seed) vs `have_tip=0,have_mn=1` (headers syncing — self-resolving), and `n/a`
when the maintainer has never reported.

### `is_synced()` — DASH was the outlier, and it is a real gap

`HeaderChain::is_synced()` was **defined and never called** on the DASH template path. Callers per
lane: bch 13, ltc 12, nmc 12, btc 6, dgb 6, **dash 0**. LTC is the reference pattern in this tree:
`ltc/coin/template_builder.hpp:116` defaults `is_synced()` to **false** so a subclass must
positively prove sync, and `:376` **throws** rather than serve.

Not indirect coverage — a real gap. Every other freshness gate on `NodeCoinState` is **relative to
our own tip**: credit-pool height `== prev_height`, SML hash `== prev_hash`, payee cursor
`== prev_height`. All hold on a node thousands of blocks behind but internally *consistent* — a
peer answering `getmnlistd` at **our** tip returns a diff for that old block, the credit pool
advances off the same old blocks, the payee queue folds them in step. Nothing in the set can
distinguish "current" from "self-consistently stale". Closed by `set_chain_synced_fn`, wired to
`HeaderChain::is_synced()`, named `chain-not-synced`, re-asserted at the pre-emit gate. Unset
(default) leaves the clause unevaluated so every pre-existing KAT is byte-unchanged.

### Operator surface

`web-static/dashboard.html` has rendered a per-coin `no_work_reason` since 08-02 and
`test_web_honesty_regression` pins the contract from both sides — but **nothing ever produced one**:
`main_dash` never called `set_node_topology_fn` at all, so a declining node rendered identically to
a dead one. This adds the producer, publishing the same `DeclineReport` the journal logs.

## Checklist

- [x] **Build and tests pass on this branch.** Full `build.yml` target allowlist built clean
      (0 errors) and the whole suite run **on the rebased tree**: **2788 passed, 0 failed**
      out of 2806 registered. The 18 not-run are the `PhaseNLiveTest` harnesses (Phase0-4),
      marked in `test/CMakeLists.txt` as
      `ci-allowlist-exempt: live-only harness (needs a running coin daemon); not CI-built by
      design` — pre-existing and unrelated. Hosted CI is still in flight at the time of
      opening; I am not merging this.
- [x] **No `SPDX-License-Identifier` line is removed or altered.**
- [x] I have the right to contribute this code and agree it may be distributed under the project's
      licence.
- [x] **This is the smallest change that fixes the problem.** `classify_decline()`'s wire text is
      byte-unchanged for every pre-existing cause (the shadow ledger and its KATs key on it);
      `embedded_template_emit_ok()`'s new parameter is defaulted so every existing caller is
      source-compatible; the sync gate is unset by default.
- [x] If I deleted anything, I counted its call sites first. `classify_decline()`'s body was
      replaced by a formatter over `describe_decline()`; its 6 call sites (5 KAT, 1 shadow) are
      unchanged and still pass.
- [x] Tests included that **fail without this change** — 16 mutations run, results below.

## Blast radius

**Single lane: DASH.** `src/impl/dash/` plus `src/c2pool/main_dash.cpp`. No `src/core/` change, so
LTC, DOGE, DGB, BCH and BTC are untouched. `web-static/dashboard.html` is not modified — it already
reads the field; only the DASH producer is new.

## Consensus safety

- [x] **Transport / logging / telemetry / tooling only — cannot change share bytes or coinbase
      outputs.**

The refusal reason is carried alongside the decision; it never *changes* it. `has_state` evaluates
the identical clauses in the identical order, so which arm is selected is bit-for-bit what master
selects, with two deliberate exceptions, both fail-CLOSED and both template-SERVE refusals (free)
rather than block-SUBMIT refusals:

1. **`chain-not-synced`** — opt-in via `set_chain_synced_fn`; unset preserves master exactly.
2. **`no-tip` no longer over-fires** — master's `classify_decline()` tested
   `m_prev_hash.IsNull()` unconditionally and could report `no-tip` for an arm that was in fact
   *serving*. It is now a refinement applied only after viability has already failed, so it can
   rename a refusal but never create one. This makes the diagnostic *more* conservative, never
   less.

`describe_decline()` is a const read; `ServeGateJournal` holds no coin state, does no I/O, and has
no clock of its own.

## How this was tested

Build, as CI runs it, after rebasing onto `origin/master`:

```
conan install . -pr:a=ci/conan/linux-gcc13.profile --build=missing --output-folder=build_ci -nr
cmake -S . -B build_ci -DCMAKE_TOOLCHAIN_FILE=build_ci/conan_toolchain.cmake \
      -DCMAKE_BUILD_TYPE=Release -DCOIN_DGB=ON
cmake --build build_ci --target <the full build.yml allowlist> -j8
```

Real-BLS leg as CI runs it (`-DC2POOL_DASH_BLS=ON -DDASHBLS_ROOT=…`), verified by
`scripts/ci/dash_bls_linked_guard.sh`: **PASS — real BLS verification is linked in** (ciphersuite ID
in rodata, `bls::G1Element::FromBytes`, `bls::G2Element::FromBytes`).

Tests are folded into the already-allowlisted `test_dash_node_coin_state` and
`test_dash_stratum_work_source` — no new target, no `build.yml` edit, no NOT_BUILT sentinel.

**Negative twins throughout**: every "names cause X" case is paired with the same state minus the
fault, asserting the arm is viable and the report says so — so a gate that simply refuses
everything, or names everything, fails.

**Mutations run to prove the tests can go red:**

| Mutation | Result |
|---|---|
| M1 / M2 / M3 — revert the `n/a` rule for credit-pool / bestCL / payee | RED (each) |
| M4 — untie `has_state` from `decline.viable` | RED |
| M5 — reseed latch no longer outranks not-populated | RED |
| M6, M6b — weaken the diagnostic-refinement guard | **GREEN — equivalent mutants** (below) |
| M6c — remove the early return before the refinement | RED, after adding the missing assertion |
| M7 — remove the transition rule | RED |
| M8 — emit always (no suppression) | RED (3 cases) |
| M9 — heartbeat off-by-one | RED |
| M10 — remove the cause-change rule | RED (2 cases) |
| M11 — drop the suppressed count | RED |
| M12 — silent resume | RED (2 cases) |
| M13 / M14 / M15 — remove / invert / default-close the sync gate | RED (each) |
| M16 — rename the first-unmet cause | RED (4 cases) |

**M6 and M6b produced zero red, and probing why was worth doing.** Both are inert: the
`if (d.viable) return d;` guard makes the refinement block unreachable while the arm is serving, so
mutating inside it changes nothing — the gate genuinely works. But it exposed a **missing
assertion**: nothing checked that a *viable* bundle reports `cause == "viable"` rather than a
relabelled one. Added; M6c (deleting the guard) then goes red.

**Live, on the contabo daemonless rig, real-BLS binary, mainnet:**

```
[EMBED-GATE] h=… arm=dashd-fallback DECLINED cause=no-tip value=prev_hash=null \
             threshold=prev_hash!=null trigger=first suppressed=0
[EMBED-GATE] h=… arm=dashd-fallback DECLINED cause=not-populated value=… \
             threshold=have_tip=1,have_mn=1 trigger=heartbeat suppressed=6
```

The first decline after start is named immediately (`trigger=first`), repeats inside the window are
suppressed and counted, and the count rides the next emitted line. This is the log line that did not
exist when the soak flipped arms.

---

## Rebase onto `0468453c` (2026-08-03)

Master moved while CI was running (#1001, #1030, #1031, #1034, #1036 merged). Rebased, not merged.

**One conflict: `src/c2pool/main_dash.cpp`.** Purely positional — #1036 and this PR both insert
wiring immediately after `header_chain->init()`, and both open an `if (web_server)` block there.
Resolved by keeping **both**, nested into a single `if (web_server)`:

* `node_coin_state.set_chain_synced_fn(...)` lifted out of the block (it needs no web server);
* #1036's `set_coin_chain_query_fn(...)` and its startup banner first;
* this PR's `set_node_topology_fn(...)` after it, with its rationale comment reattached to its own
  producer (the mechanical merge had stranded it above #1036's hook).

Nothing was discarded from either side.

**The two sync predicates were deliberately NOT merged.** #1036's `chain_rpc::sync_status()`
reimplements freshness over `HeaderChain`'s public API and is pinned to the original by
`DashChainRpc.SyncStatusMatchesHeaderChainIsSynced`. This PR's serve gate calls
`HeaderChain::is_synced()` **directly**, so gate, RPC surface and guard are consistent by
construction. Consolidating them is a separate decision, not a conflict resolution.

**`no_work_reason` did not collide.** #1036 added no `set_node_topology_fn` and no
`no_work_reason` producer (`git show origin/master:src/c2pool/main_dash.cpp | grep` → nothing;
`web_server.cpp` → 0 hits). This PR remains the single producer. Worth noting the independent
convergence: #1036's refusal strings name the condition with its measured value and threshold and
explicitly refuse "a bare 'not synced'" — the same contract this PR imposes on the serve gate.

`src/impl/dash/coin/chain_rpc.hpp`, `src/core/web_server.{hpp,cpp}`,
`src/core/http_session.cpp` and `src/impl/dash/coin/header_chain.hpp` are untouched by this PR.

## One further defect, caught by running the instrumentation on the live rig

The daemonless rig reached h=2515420 with headers advancing every ~60 s, and the new gate line
said `cause=no-tip`. That was **wrong, and wrong in exactly the way this PR exists to prevent**:
`NodeCoinState::m_prev_hash` is only written by `set_tip()`, which the maintainer calls only once
it holds *both* a tip and an MN set — so while the MN set is unseeded, `prev_hash` stays null no
matter how current the headers are. The `no-tip` refinement read that null as evidence and pointed
the operator at a header-sync fault that did not exist, while the real blocker (`have_mn=0`) went
unnamed.

Fixed: the maintainer's `have_tip`/`have_mn` report wins whenever it exists, in **both** directions;
`no-tip` is now reached only when the maintainer has never reported, and says so
(`value=prev_hash=null,maintainer-never-reported`) rather than implying a measurement. Three tests
added; mutation **M17** (restoring the unconditional relabel) goes RED on two of them.

This is the argument for the change stated against itself: a diagnostic that infers from a value it
did not measure will mislead, even when the diagnostic is the fix.