### PR TITLE
dash(qc): name and bound the DKG-window refusal; stop the false fallback line

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -1796,12 +1796,30 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // to real dashd (both merkle roots reproduced from the mnlistdiff wire); the
     // SML+quorum freshness + superblock viability gates keep it fail-safe.
     work_source->set_embedded_mainnet(embedded_mainnet);
-    // Reward-safety backstop: when a dashd fallback is configured, cross-check
-    // the embedded creditPool against dashd's GBT before serving (catches any
-    // seed bug the daemonless self-checks miss). Enabled alongside the embedded
-    // arm; pure-daemonless deployments (no dashd) leave it off and rely on the
-    // independent seed-height gate.
-    work_source->set_gbt_xcheck(testnet || embedded_mainnet);
+    // Reward-safety backstop: when a dashd fallback is ARMED, cross-check the
+    // embedded creditPool against dashd's GBT before serving (catches any seed
+    // pool bug the daemonless self-checks miss).
+    //
+    // THE `&& rpc`, added 2026-08-03 — it is not a tightening, it makes the
+    // code do what this comment always claimed. The cross-check invokes the
+    // dashd_fallback lambda on EVERY embedded template. On a daemonless node
+    // that lambda is unarmed, so it printed
+    //   "[DASH-STRATUM-GBT] fallback arm UNARMED ... serving empty set-gap
+    //    template"
+    // immediately before every SUCCESSFUL EMBEDDED serve: the empty payload
+    // then failed parse_cbtx, the mismatch branch was skipped, and EMBEDDED
+    // was served correctly. Harmless to correctness, but it made a healthy
+    // daemonless log read as if the node fell back on every single template
+    // — and it stole the ONE line that should mean a real fallback. With the
+    // arm-check the line now fires only when the fallback is genuinely
+    // consulted, i.e. during an actual embedded outage.
+    const bool xcheck_wanted = (testnet || embedded_mainnet);
+    work_source->set_gbt_xcheck(xcheck_wanted && static_cast<bool>(rpc));
+    if (xcheck_wanted && !rpc) {
+        std::cout << "[DASH-STRATUM-GBT] GBT cross-check DISABLED: dashd RPC "
+                     "arm UNARMED (pure-daemonless) -- the embedded arm relies "
+                     "on the independent seed-height + pre-emit gates\n";
+    }
 
     // ── Mint slice 3/3: run-loop share minting wiring ─────────────────────
     // ShareAccept -> build_mint_share -> tracker insert -> peer broadcast.
@@ -3061,6 +3079,16 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                             "sourced; fail-closed to null-serve otherwise)";
             }
 
+            // REFUSAL-DIAGNOSIS seam (observability only, never gates a serve):
+            // lets [QC-COMPLETENESS] tell "the member-set fetch is still in
+            // flight" apart from "the BLS signature genuinely did not verify".
+            // Reads the SAME cache the MemberKeysProvider above already reads
+            // from the template thread — no new sharing, no new lock domain.
+            qc_cache->set_members_ready_fn(
+                [qc_member_source](uint8_t t, const uint256& qh) {
+                    return qc_member_source->lookup(t, qh).has_value();
+                });
+
             // DEMUX: route the source's HISTORICAL getmnlistd replies away from
             // the tip-SML maintainer (a base=ZERO snapshot would overwrite it).
             // ADDITIVE, not a slot: the MN-checkpoint lane registers its own
@@ -3079,7 +3107,27 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 coin_state.new_qfcommit.subscribe(
                     [qc_cache, qc_net, qc_member_source]
                     (const dash::coin::vendor::CFinalCommitment& c) {
-                        if (qc_cache->ingest(qc_net, c)) {
+                        // SAY WHY on the reject path too. A relayed qfcommit
+                        // that structural admission drops used to leave NO
+                        // trace, so a later "no-commitment-cached" refusal was
+                        // indistinguishable from "the commitment never reached
+                        // us" — opposite diagnoses (our bug vs a relay hole).
+                        using Adm =
+                            dash::coin::MineableCommitmentCache::Admission;
+                        const auto adm = qc_cache->ingest_ex(qc_net, c);
+                        if (adm != Adm::Accepted) {
+                            LOG_INFO << "[QC-MINEABLE] REJECTED relayed"
+                                        " commitment type="
+                                     << static_cast<int>(c.llmqType)
+                                     << " quorum="
+                                     << c.quorumHash.GetHex().substr(0, 16)
+                                     << "... signers=" << c.CountSigners()
+                                     << " reason="
+                                     << dash::coin::MineableCommitmentCache
+                                            ::admission_name(adm)
+                                     << " cache=" << qc_cache->size();
+                        }
+                        if (adm == Adm::Accepted) {
                             LOG_INFO << "[QC-MINEABLE] cached commitment type="
                                      << static_cast<int>(c.llmqType)
                                      << " quorum="
@@ -3098,11 +3146,28 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             // dashd fallback. Log the first gap once per height so the soak
             // can attribute the fallback (the hot path re-derives the plan
             // on every template build — do not log unthrottled).
-            auto qc_gap_logged_h = std::make_shared<uint32_t>(0u);
+            //
+            // BOUNDING THE REFUSAL (mainnet 2026-08-03, h=2515381 type=1 qi=0,
+            // 11 min / 14 serves dark): the commitment for a mandatory slot is
+            // announced ONCE by inv relay at DKG finalize and is only servable
+            // on getdata BY COMMITMENT HASH — a commitment relayed before this
+            // process connected CANNOT be pulled back (see the COLD-START HOLE
+            // note in dkg_commitments.hpp; verified against dashpay/dash
+            // v21.1.0). So the refusal is not a bug to route around, it is a
+            // wait — and a wait must say how long. Each refusal now names the
+            // CLASSIFIED cause, the measured commitment state, and the DKG
+            // mining window that bounds it. `qc_first_plan_h` is the first
+            // height this process ever planned; a slot whose commitment must
+            // have been relayed before that provably predates our wire
+            // presence (before we have that datum the field prints n/a).
+            auto qc_gap_logged_h  = std::make_shared<uint32_t>(0u);
+            auto qc_first_plan_h  = std::make_shared<uint32_t>(0u);
+            auto qc_cold_note_done = std::make_shared<bool>(false);
             node_coin_state.set_qc_plan_fn(
                 [&node_coin_state, hc = header_chain.get(), qc_net, qc_cache,
-                 qc_gap_logged_h]
+                 qc_gap_logged_h, qc_first_plan_h, qc_cold_note_done]
                 (uint32_t next_h) -> std::optional<dash::coin::QcBlockPlan> {
+                    if (*qc_first_plan_h == 0u) *qc_first_plan_h = next_h;
                     dash::coin::RequiredQcSlot gap{};
                     auto plan = dash::coin::build_daemonless_qc_plan(
                         qc_net, next_h, node_coin_state.qmgr(),
@@ -3121,15 +3186,77 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     if (!plan && !gap.quorum_hash.IsNull()
                         && *qc_gap_logged_h != next_h) {
                         *qc_gap_logged_h = next_h;
+                        const auto wb =
+                            dash::coin::qc_window_bound(gap.params, next_h);
+                        // "Could we ever have seen this commitment?" — the
+                        // relay happens by the window's first height at the
+                        // latest, so a window that opened before our first
+                        // planned height provably predates our wire presence.
+                        std::string predates = "n/a";
+                        if (*qc_first_plan_h != 0u && *qc_first_plan_h != next_h)
+                            predates = (wb.first_height < *qc_first_plan_h)
+                                ? "yes" : "no";
+                        std::string signers = "n/a";
+                        if (gap.cached_signers >= 0)
+                            signers = std::to_string(gap.cached_signers);
+                        // Only meaningful once a commitment is actually held —
+                        // with nothing cached the member set was never sought,
+                        // so the honest value is n/a, not "no".
+                        std::string members_ready = "n/a";
+                        if (qc_cache->has_commitment(gap.params.type,
+                                                     gap.quorum_hash)) {
+                            if (auto mr = qc_cache->members_ready(
+                                    gap.params.type, gap.quorum_hash))
+                                members_ready = *mr ? "yes" : "no";
+                        }
                         LOG_INFO << "[QC-COMPLETENESS] h=" << next_h
                                  << " mandatory slot type="
                                  << static_cast<int>(gap.params.type)
                                  << " qi=" << gap.quorum_index
                                  << " quorum="
                                  << gap.quorum_hash.GetHex().substr(0, 16)
-                                 << "... has no verified real commitment and no"
-                                    " failed-DKG evidence -> WHOLE height"
-                                    " fails closed (arm=dashd-fallback)";
+                                 << "... reason="
+                                 << dash::coin::qc_slot_gap_name(gap.gap)
+                                 << " cached_signers=" << signers
+                                 << "/" << gap.params.min_size << "(min)"
+                                 << " cache=" << qc_cache->size()
+                                 << " bls_verifier="
+                                 << (qc_cache->has_bls_verifier() ? "yes" : "no")
+                                 << " member_set_ready=" << members_ready
+                                 << " window=[" << wb.first_height << ","
+                                 << wb.last_height << "]"
+                                 << " remaining=" << wb.heights_remaining
+                                 << " first_planned_h=" << *qc_first_plan_h
+                                 << " predates_our_wire=" << predates
+                                 << " -> WHOLE height fails closed"
+                                    " (arm=dashd-fallback)";
+                        // ONE explainer per process, on the first cold-start
+                        // shaped gap: the operator must not have to re-derive
+                        // "why can't it just ask a peer?" from the source.
+                        if (gap.gap == dash::coin::QcSlotGap::NoCommitmentCached
+                            && !*qc_cold_note_done) {
+                            *qc_cold_note_done = true;
+                            LOG_INFO
+                                << "[QC-COMPLETENESS] NOTE: a mineable quorum"
+                                   " commitment is announced ONCE by inv relay"
+                                   " at DKG finalize and is served on getdata BY"
+                                   " COMMITMENT HASH only (dashcore"
+                                   " llmq/blockprocessor.cpp"
+                                   " AddMineableCommitment /"
+                                   " GetMineableCommitmentByHash) — there is NO"
+                                   " P2P request that pulls one for a"
+                                   " (type,quorumHash) we did not witness live,"
+                                   " and mnlistdiff/qrinfo carry MINED"
+                                   " commitments only. dashd's own miner mines"
+                                   " the NULL commitment here"
+                                   " (GetMineableCommitments \"null commitment"
+                                   " required\" arm); c2pool refuses instead"
+                                   " because null-serving a SUCCEEDED DKG"
+                                   " diverged merkleRootQuorums at block"
+                                   " 1520106. The refusal clears when any miner"
+                                   " mines the commitment or when the window"
+                                   " above closes — whichever comes first.";
+                        }
                     }
                     return plan;
                 });

--- a/src/impl/dash/coin/dkg_commitments.hpp
+++ b/src/impl/dash/coin/dkg_commitments.hpp
@@ -127,6 +127,42 @@
 /// whose mandatory set includes a rotated slot therefore falls back
 /// unless every rotated slot has attested-null evidence.
 ///
+/// COLD-START HOLE — WHY THERE IS NO BACK-FILL (prior art, settled against
+/// dashpay/dash v21.1.0, 2026-08-03; mainnet incident h=2515381 type=1 qi=0):
+///
+/// A mandatory slot's commitment is NOT in any block yet — `has_mined` is
+/// false by construction, so it lives only in every full node's in-memory
+/// `minableCommitments` map. Upstream, that map is filled from exactly two
+/// places (llmq/blockprocessor.cpp):
+///   * `ProcessMessage`/`ProcessCommitment` on a relayed `qfcommit`, and
+///   * `UndoBlock` (re-mineable after a reorg),
+/// and `AddMineableCommitment` announces it ONCE — `RelayInv(CInv(
+/// MSG_QUORUM_FINAL_COMMITMENT, ::SerializeHash(fqc)))` — at DKG finalize
+/// (dkgsessionhandler.cpp HandleDKGRound tail). It is served on getdata BY
+/// COMMITMENT HASH only (`GetMineableCommitmentByHash`). There is NO
+/// request keyed by (llmqType, quorumHash), and the hash is a digest of the
+/// full commitment (signers bitset + BLS sigs), so it is not derivable from
+/// anything a cold node holds. The light-client messages do not close it
+/// either: `mnlistdiff.newQuorums` and `qrinfo.lastCommitmentPerIndex` both
+/// carry MINED commitments only — i.e. exactly the ones for which the slot
+/// no longer exists.
+///
+/// So a commitment relayed before this process connected CANNOT be pulled.
+/// Dash Core does not solve this; it has the identical hole and resolves it
+/// by MINING NULL: `GetMineableCommitments` is documented "Will return a
+/// null commitment if no mineable commitment is known and none was mined
+/// yet" and takes the `// null commitment required` arm whenever
+/// `minableCommitmentsByQuorum` has no entry for the quorum. c2pool
+/// deliberately does NOT copy that arm — see HEIGHT COMPLETENESS above: at
+/// block 1520106 null-serving a SUCCEEDED DKG diverged merkleRootQuorums.
+/// The refusal is therefore correct and stays; what this module owes the
+/// operator is a refusal that NAMES which of the several distinct causes
+/// fired and BOUNDS the wait (QcSlotGap + qc_window_bound below). The wait
+/// ends when any other miner mines the commitment (the slot then reads
+/// already-mined off the mnlistdiff-fed QuorumManager) or when the DKG
+/// mining window closes — both are bounded by cycleStart +
+/// dkgMiningWindowEnd, which is why the incident self-healed in 4 blocks.
+///
 /// MAINTENANCE: the params table + enabled sets + V19 floors below are
 /// copied VERBATIM from dashcore llmq/params.h + chainparams.cpp @
 /// cfad414. RE-DIFF on every vendored-dashcore pin bump (same rule as
@@ -220,11 +256,74 @@ inline bool is_mining_phase(const LlmqParamsView& p, uint32_t height)
 
 // ── Mandatory-slot computation ─────────────────────────────────────────────
 
+/// WHY one mandatory slot could not be satisfied. The pre-fix gate collapsed
+/// every one of these into "no verified real commitment", which is the same
+/// sentence for a cold-start relay hole (wait, bounded), a missing verifier
+/// (build defect), an unsourced member set (in flight), a failed signature
+/// (hostile/corrupt peer) and an index-flipped copy (relay DoS) — five
+/// different operator responses. `Unevaluated` is the honest value for a
+/// field/branch never reached, and prints `n/a`, never a fabricated 0.
+/// There is deliberately NO `None` value: nothing in this module can produce
+/// one. `diagnose()` is defined only AFTER verified_for has already failed
+/// (it re-runs no BLS math, so it cannot observe success), and a satisfied
+/// slot is reported by the plan existing, not by a gap code. A `None` here
+/// would be a value no code path can ever set — the kind of field that
+/// silently reads as "fine" when it simply was not measured.
+enum class QcSlotGap : uint8_t {
+    Unevaluated = 0,       // no gap was recorded on this path
+    NoCommitmentCached,    // nothing admitted for (llmqType, quorumHash)
+    VerifierAbsent,        // cached, but no BLS verifier is installed
+    MemberSetUnsourced,    // cached + verifier, member set not ready yet
+    BlsVerifyFailed,       // cached + members ready, signature check FAILED
+    QuorumIndexMismatch,   // verified, but quorumIndex != this slot's index
+};
+
+inline const char* qc_slot_gap_name(QcSlotGap g)
+{
+    switch (g) {
+        case QcSlotGap::Unevaluated:        return "n/a";
+        case QcSlotGap::NoCommitmentCached: return "no-commitment-cached";
+        case QcSlotGap::VerifierAbsent:     return "bls-verifier-absent";
+        case QcSlotGap::MemberSetUnsourced: return "member-set-unsourced";
+        case QcSlotGap::BlsVerifyFailed:    return "bls-verify-failed";
+        case QcSlotGap::QuorumIndexMismatch:return "quorum-index-mismatch";
+    }
+    return "n/a";
+}
+
 struct RequiredQcSlot {
     LlmqParamsView params;
     int16_t        quorum_index{0};
     uint256        quorum_hash;      // base block hash at cycleStart+index
+    // Observability only — never consulted by the serve decision. Populated
+    // ONLY on the fail-closed path (`first_gap`); slots returned in the
+    // mandatory-set vector leave them at their unevaluated defaults.
+    QcSlotGap      gap{QcSlotGap::Unevaluated};
+    int32_t        cached_signers{-1};   // -1 == not evaluated -> prints n/a
 };
+
+/// The bound on a refusal: the DKG mining window this slot belongs to. A
+/// mandatory slot cannot outlive its window — at cycleStart+miningWindowEnd
+/// the slot stops being required (dashcore IsMiningPhase), and in practice it
+/// disappears earlier, the moment any miner mines the commitment. So the
+/// worst-case outage IS `heights_remaining`, and it is printable.
+struct QcWindowBound {
+    uint32_t cycle_start{0};
+    uint32_t first_height{0};       // cycleStart + dkgMiningWindowStart
+    uint32_t last_height{0};        // cycleStart + dkgMiningWindowEnd (incl.)
+    uint32_t heights_remaining{0};  // incl. next_height; 0 once past the window
+};
+
+inline QcWindowBound qc_window_bound(const LlmqParamsView& p, uint32_t next_height)
+{
+    QcWindowBound b;
+    b.cycle_start  = next_height - (next_height % p.dkg_interval);
+    b.first_height = b.cycle_start + p.mining_window_start;
+    b.last_height  = b.cycle_start + p.mining_window_end;
+    b.heights_remaining = (next_height <= b.last_height)
+        ? (b.last_height - next_height + 1u) : 0u;
+    return b;
+}
 
 /// dashcore GetNumCommitmentsRequired, computed daemonlessly.
 ///
@@ -319,50 +418,135 @@ inline MutableTransaction build_qc_tx(uint32_t height,
 class MineableCommitmentCache {
 public:
     using BlsVerifyFn = std::function<bool(const vendor::CFinalCommitment&)>;
+    /// OBSERVABILITY ONLY (never gates a serve): is the deterministic member
+    /// set for (llmqType, quorumHash) already sourced? Lets a refusal
+    /// distinguish "the member-set fetch is still in flight" (wait) from "the
+    /// signature genuinely did not verify" (hostile or corrupt peer). Unset =>
+    /// the distinction is UNEVALUATED and prints n/a — it is never guessed.
+    using MembersReadyFn = std::function<bool(uint8_t, const uint256&)>;
 
     void set_bls_verify_fn(BlsVerifyFn fn) { m_bls_verify = std::move(fn); }
     bool has_bls_verifier() const { return static_cast<bool>(m_bls_verify); }
+    void set_members_ready_fn(MembersReadyFn fn) { m_members_ready = std::move(fn); }
+    bool has_members_ready_fn() const { return static_cast<bool>(m_members_ready); }
+
+    /// Member-set readiness for the slot, or std::nullopt when no probe is
+    /// installed — the caller MUST print n/a for nullopt, never a guessed bool.
+    std::optional<bool> members_ready(uint8_t llmq_type,
+                                      const uint256& quorum_hash) const
+    {
+        if (!m_members_ready) return std::nullopt;
+        return m_members_ready(llmq_type, quorum_hash);
+    }
+
+    /// Is ANY commitment admitted for this slot key (regardless of verify)?
+    bool has_commitment(uint8_t llmq_type, const uint256& quorum_hash) const
+    {
+        return m_cache.count(Key{llmq_type, quorum_hash}) != 0;
+    }
+
+    /// CountSigners of the admitted commitment, or -1 when none is held
+    /// (-1 prints n/a; a real 0 is impossible past the minSize admission).
+    int32_t cached_signers(uint8_t llmq_type, const uint256& quorum_hash) const
+    {
+        auto it = m_cache.find(Key{llmq_type, quorum_hash});
+        if (it == m_cache.end()) return -1;
+        return static_cast<int32_t>(it->second.CountSigners());
+    }
+
+    /// Classify why `verified_for` withheld this slot. Callers MUST have just
+    /// had verified_for fail — this re-runs NO BLS math (the hot path already
+    /// paid for it), it only reads the cheap state that discriminates the
+    /// causes, so it is safe on the per-template plan path.
+    QcSlotGap diagnose(uint8_t llmq_type, const uint256& quorum_hash) const
+    {
+        if (!has_commitment(llmq_type, quorum_hash))
+            return QcSlotGap::NoCommitmentCached;
+        if (!m_bls_verify) return QcSlotGap::VerifierAbsent;
+        if (m_members_ready && !m_members_ready(llmq_type, quorum_hash))
+            return QcSlotGap::MemberSetUnsourced;
+        return QcSlotGap::BlsVerifyFailed;
+    }
+
+    /// Why a relayed commitment was (not) admitted. A rejected qfcommit used
+    /// to vanish without a trace — `ingest` returned bare false and the only
+    /// log line was on the ACCEPT path, so an operator staring at a
+    /// no-commitment-cached refusal could not tell "never arrived on the
+    /// wire" from "arrived and was dropped here", which are opposite
+    /// diagnoses. Every rejection now has a name.
+    enum class Admission : uint8_t {
+        Accepted = 0,
+        UnknownType,          // llmqType not enabled on this network
+        WrongVersion,         // not the post-V19 basic-scheme variant
+        BitsetSizeMismatch,   // signers/validMembers not params.size
+        ValidMembersBelowMin, // CountValidMembers < params.minSize
+        SignersBelowMin,      // CountSigners < params.minSize
+        NullCryptoFields,     // zero pubkey / vvec / quorumSig / membersSig
+        NotBetterThanCached,  // keep-best-by-CountSigners, same as dashd
+    };
+
+    static const char* admission_name(Admission a)
+    {
+        switch (a) {
+            case Admission::Accepted:             return "accepted";
+            case Admission::UnknownType:          return "unknown-llmq-type";
+            case Admission::WrongVersion:         return "wrong-version";
+            case Admission::BitsetSizeMismatch:   return "bitset-size-mismatch";
+            case Admission::ValidMembersBelowMin: return "valid-members-below-minsize";
+            case Admission::SignersBelowMin:      return "signers-below-minsize";
+            case Admission::NullCryptoFields:     return "null-crypto-fields";
+            case Admission::NotBetterThanCached:  return "not-better-than-cached";
+        }
+        return "n/a";
+    }
 
     /// Structural admission of a relayed commitment. Returns true when the
     /// commitment was cached (new, or better than the cached one).
     bool ingest(LlmqNetwork net, const vendor::CFinalCommitment& c)
     {
+        return ingest_ex(net, c) == Admission::Accepted;
+    }
+
+    /// Same admission, but SAYING WHY on every rejection.
+    Admission ingest_ex(LlmqNetwork net, const vendor::CFinalCommitment& c)
+    {
         const LlmqParamsView* p = nullptr;
         for (const auto& e : enabled_llmqs(net))
             if (e.type == c.llmqType) { p = &e; break; }
-        if (p == nullptr) return false;
+        if (p == nullptr) return Admission::UnknownType;
         // Version must be the post-V19 basic-scheme variant for the type's
         // rotation flag (dashcore CFinalCommitment::Verify version check).
         const uint16_t expected = p->use_rotation
             ? vendor::CFinalCommitment::BASIC_BLS_INDEXED_QUORUM_VERSION
             : vendor::CFinalCommitment::BASIC_BLS_NON_INDEXED_QUORUM_VERSION;
-        if (c.nVersion != expected) return false;
+        if (c.nVersion != expected) return Admission::WrongVersion;
         // VerifySizes.
         if (c.signers.size() != p->size || c.validMembers.size() != p->size)
-            return false;
+            return Admission::BitsetSizeMismatch;
         // A REAL commitment: dashcore CFinalCommitment::Verify enforces the
         // count FLOOR at minSize, NOT threshold (VerifySizes/quorum count check:
         // CountValidMembers() >= minSize and CountSigners() >= minSize). A
         // colluding >=threshold-but-<minSize commitment passes the BLS math yet
         // is bad-qc-invalid to every dashd — admitting it (and, once member
         // sourcing lands, serving it) loses the block. Enforce minSize.
-        if (c.CountValidMembers() < p->min_size) return false;
-        if (c.CountSigners() < p->min_size) return false;
+        if (c.CountValidMembers() < p->min_size)
+            return Admission::ValidMembersBelowMin;
+        if (c.CountSigners() < p->min_size) return Admission::SignersBelowMin;
         auto all_zero = [](const auto& arr) {
             for (auto b : arr) if (b != 0) return false;
             return true;
         };
         if (all_zero(c.quorumPublicKey) || c.quorumVvecHash.IsNull()
             || all_zero(c.quorumSig) || all_zero(c.membersSig))
-            return false;
+            return Admission::NullCryptoFields;
 
         const Key k{c.llmqType, c.quorumHash};
         auto it = m_cache.find(k);
         if (it != m_cache.end()
             && it->second.CountSigners() >= c.CountSigners())
-            return false;   // already hold an equal-or-better one
+            return Admission::NotBetterThanCached;   // hold an equal-or-better one
         m_cache[k] = c;
-        return true;
+        return Admission::Accepted;
     }
 
     /// The mineable commitment for a slot — ONLY once BLS-verified. The
@@ -392,6 +576,7 @@ private:
     };
     std::map<Key, vendor::CFinalCommitment> m_cache;
     BlsVerifyFn m_bls_verify;   // unset until Phase L lands a BLS12-381 lib
+    MembersReadyFn m_members_ready;   // observability only; unset => n/a
 };
 
 // ── Daemonless provider (the piece main_dash wires in) ─────────────────────
@@ -413,7 +598,10 @@ using DkgNullEvidenceFn =
 /// attested-null (null_evidence): std::nullopt => at least one mandatory
 /// slot is unsatisfiable (or the slot set itself cannot be derived) and the
 /// embedded arm must fail closed for the WHOLE height. `first_gap`, when
-/// non-null, receives the first unsatisfiable slot (observability only).
+/// non-null, receives the first unsatisfiable slot INCLUDING its classified
+/// `gap` reason and the measured `cached_signers` (observability only — it
+/// is left untouched when the slot set itself was underivable, so a null
+/// `quorum_hash` still discriminates that case).
 inline std::optional<std::vector<vendor::CFinalCommitment>>
 daemonless_qc_commitments(
     LlmqNetwork net, uint32_t next_height,
@@ -429,6 +617,10 @@ daemonless_qc_commitments(
     std::vector<vendor::CFinalCommitment> out;
     out.reserve(slots->size());
     for (const auto& s : *slots) {
+        // Recorded ONLY if this slot ends up being the fail-closed gap; it
+        // never influences the serve decision.
+        QcSlotGap gap_reason = cache != nullptr ? QcSlotGap::Unevaluated
+                                                : QcSlotGap::NoCommitmentCached;
         if (cache != nullptr) {
             if (auto real = cache->verified_for(s.params.type, s.quorum_hash)) {
                 // quorumIndex is OUTSIDE BuildCommitmentHash (confirmed vs
@@ -444,6 +636,9 @@ daemonless_qc_commitments(
                     out.push_back(std::move(*real));
                     continue;
                 }
+                gap_reason = QcSlotGap::QuorumIndexMismatch;
+            } else {
+                gap_reason = cache->diagnose(s.params.type, s.quorum_hash);
             }
         }
         // No verified real commitment for this mandatory slot. Null is
@@ -454,7 +649,12 @@ daemonless_qc_commitments(
                                                 s.quorum_index));
             continue;
         }
-        if (first_gap != nullptr) *first_gap = s;
+        if (first_gap != nullptr) {
+            *first_gap = s;
+            first_gap->gap = gap_reason;
+            first_gap->cached_signers = cache != nullptr
+                ? cache->cached_signers(s.params.type, s.quorum_hash) : -1;
+        }
         return std::nullopt;
     }
     return out;

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -363,7 +363,21 @@ void DASHWorkSource::resource_template_now() const
             // is reachable, cross-check the embedded CbTx creditPoolBalance
             // against dashd getblocktemplate; on a same-height mismatch serve
             // dashd's template. Catches ANY seed bug the daemonless self-checks
-            // miss. Opt-in (--embedded-mainnet-with-dashd), not pure-daemonless.
+            // miss.
+            //
+            // WIRING (corrected 2026-08-03 — the previous claim that this is
+            // "opt-in via --embedded-mainnet-with-dashd" was stale; no such
+            // flag exists). main_dash sets gbt_xcheck_ whenever the embedded
+            // arm is enabled (testnet or --embedded-mainnet) AND a dashd RPC
+            // arm is actually ARMED. The arm-check matters: dashd_fallback_()
+            // is invoked HERE on every embedded template, and an UNARMED arm
+            // returns the empty set-gap default after printing "fallback arm
+            // UNARMED ... serving empty set-gap template" — which made every
+            // healthy daemonless serve read as a fallback. The empty payload
+            // fails parse_cbtx below so the mismatch branch is skipped and
+            // EMBEDDED is served either way; the defect was purely in what the
+            // log said, and it stole the one line that should mean a REAL
+            // fallback.
             if (sel.source == coin::WorkSource::Embedded && gbt_xcheck_ && dashd_fallback_) {
                 coin::DashWorkData dref = dashd_fallback_();
                 coin::vendor::CCbTx emb_cb, dref_cb;

--- a/test/test_dash_dkg_commitments.cpp
+++ b/test/test_dash_dkg_commitments.cpp
@@ -748,3 +748,347 @@ TEST(DashDkgCommitments, EmbeddedWorkdataCarriesQcTxsFirstAndOverrideRoot)
     ASSERT_TRUE(vendor::parse_cbtx(w0.m_coinbase_payload, cb0));
     EXPECT_EQ(cb0.merkleRootQuorums, uint256::ZERO);
 }
+
+// ── COLD-START HOLE: classified + bounded refusal (mainnet 2026-08-03) ─────
+//
+// THE INCIDENT, replayed as a KAT. Daemonless mainnet node, binary
+// 0.2.4-237-gdf160971, uptime 75 min, ONE qfcommit seen on the wire since
+// start (type=4). At next_height 2515381 the type-1 (LLMQ_50_60) mandatory
+// slot's commitment had been relayed BEFORE the process connected, so it was
+// not in the MineableCommitmentCache; with no attested-null evidence source
+// the WHOLE height failed closed and — the fallback arm being unarmed on a
+// daemonless node — the stratum surface served an empty h=0 template for 11
+// minutes / 14 serves (heights 2515381..2515384), self-healing at 2515385
+// when another miner mined the commitment.
+//
+// PRIOR ART (dashpay/dash v21.1.0, verified): that commitment CANNOT be
+// pulled. AddMineableCommitment announces it ONCE by inv at DKG finalize and
+// GetMineableCommitmentByHash serves it BY COMMITMENT HASH only — there is
+// no (llmqType, quorumHash)-keyed request, and mnlistdiff/qrinfo carry MINED
+// commitments only. dashd has the same hole and mines NULL through it; we
+// must not (block 1520106). So these KATs pin the two things we DO owe:
+//   1. the gate still fails closed on EVERY unsatisfiable shape (no
+//      weakening — each case below asserts nullopt), and
+//   2. the refusal NAMES which of the five distinct causes fired, carries
+//      the measured signer count (n/a, never 0, when nothing is held), and
+//      BOUNDS the wait with the DKG mining window.
+namespace {
+
+// The incident's real coordinates.
+constexpr uint32_t kIncidentHeight    = 2'515'381u;
+constexpr uint32_t kIncidentCycleBase = 2'515'368u;   // 2515381 - 2515381%24
+
+// Mainnet at kIncidentHeight has TWO interval-24 windows open (types 1 and
+// 4). Pin type 4 as already-mined so the type-1 slot is the whole story —
+// exactly the shape the incident logged (first gap = type 1, qi 0).
+QuorumManager qmgr_with_type4_mined()
+{
+    vendor::QuorumTail tail;
+    tail.newQuorums.push_back(
+        real_commitment(kLlmq100_67, *fake_hash_at(kIncidentCycleBase), 0, 0x44));
+    QuorumManager q;
+    q.apply(tail);
+    EXPECT_TRUE(q.find(4, *fake_hash_at(kIncidentCycleBase)).has_value());
+    return q;
+}
+
+std::optional<QcBlockPlan> incident_plan(const QuorumManager& qmgr,
+                                         const MineableCommitmentCache* cache,
+                                         RequiredQcSlot* gap)
+{
+    return build_daemonless_qc_plan(
+        LlmqNetwork::Mainnet, kIncidentHeight, qmgr, fake_hash_at,
+        [](const uint256&) -> std::optional<uint32_t> { return std::nullopt; },
+        cache, /*null_evidence=*/nullptr, gap);
+}
+
+} // namespace
+
+TEST(DashDkgColdStart, WindowBoundIsTheRefusalsUpperBound)
+{
+    // The measured bound the incident log now prints: LLMQ_50_60 window is
+    // [cycleStart+10, cycleStart+18] = [2515378, 2515386].
+    auto wb = qc_window_bound(kLlmq50_60, kIncidentHeight);
+    EXPECT_EQ(wb.cycle_start, kIncidentCycleBase);
+    EXPECT_EQ(wb.first_height, 2'515'378u);
+    EXPECT_EQ(wb.last_height, 2'515'386u);
+    EXPECT_EQ(wb.heights_remaining, 6u);   // 2515381..2515386 inclusive
+
+    // NEGATIVE TWIN: past the window the slot is not required at all, so the
+    // bound must collapse to zero rather than keep counting down forever.
+    auto after = qc_window_bound(kLlmq50_60, 2'515'387u);
+    EXPECT_EQ(after.heights_remaining, 0u);
+    EXPECT_FALSE(is_mining_phase(kLlmq50_60, 2'515'387u));
+    EXPECT_TRUE(is_mining_phase(kLlmq50_60, kIncidentHeight));
+
+    // And the window the bound reports is the one the slot actually lives in:
+    // every height in [first,last] is a mining phase, the flanks are not.
+    for (uint32_t h = wb.first_height; h <= wb.last_height; ++h)
+        EXPECT_TRUE(is_mining_phase(kLlmq50_60, h)) << "h=" << h;
+    EXPECT_FALSE(is_mining_phase(kLlmq50_60, wb.first_height - 1));
+    EXPECT_FALSE(is_mining_phase(kLlmq50_60, wb.last_height + 1));
+}
+
+TEST(DashDkgColdStart, IncidentReplayFailsClosedNamingTheColdStartCause)
+{
+    auto qmgr = qmgr_with_type4_mined();
+
+    // Only the type-1 slot is outstanding — the incident's exact shape.
+    auto slots = compute_required_qc_slots(
+        LlmqNetwork::Mainnet, kIncidentHeight, fake_hash_at,
+        [&qmgr](uint8_t t, const uint256& qh) {
+            return qmgr.find(t, qh).has_value();
+        });
+    ASSERT_TRUE(slots.has_value());
+    ASSERT_EQ(slots->size(), 1u);
+    EXPECT_EQ((*slots)[0].params.type, 1);
+    EXPECT_EQ((*slots)[0].quorum_index, 0);
+    EXPECT_EQ((*slots)[0].quorum_hash, *fake_hash_at(kIncidentCycleBase));
+    // A slot handed back in the mandatory set is NOT a gap — its diagnosis
+    // fields must read unevaluated, never a fabricated cause or a zero.
+    EXPECT_EQ((*slots)[0].gap, QcSlotGap::Unevaluated);
+    EXPECT_EQ((*slots)[0].cached_signers, -1);
+
+    // THE COLD START: the commitment predates the process, so the cache is
+    // empty for it. FAIL CLOSED — unchanged behaviour — but now named.
+    MineableCommitmentCache cache;
+    RequiredQcSlot gap{};
+    EXPECT_FALSE(incident_plan(qmgr, &cache, &gap).has_value())
+        << "a mandatory slot with no commitment must fail the WHOLE height";
+    EXPECT_EQ(gap.params.type, 1);
+    EXPECT_EQ(gap.quorum_index, 0);
+    EXPECT_EQ(gap.gap, QcSlotGap::NoCommitmentCached);
+    EXPECT_STREQ(qc_slot_gap_name(gap.gap), "no-commitment-cached");
+    // n/a, NOT 0: nothing was held, so no signer count was ever measured.
+    EXPECT_EQ(gap.cached_signers, -1);
+    EXPECT_EQ(cache.cached_signers(1, *fake_hash_at(kIncidentCycleBase)), -1);
+    EXPECT_FALSE(cache.has_commitment(1, *fake_hash_at(kIncidentCycleBase)));
+
+    // No cache wired at all reads the same way (nothing is held either way).
+    RequiredQcSlot gap_nocache{};
+    EXPECT_FALSE(incident_plan(qmgr, nullptr, &gap_nocache).has_value());
+    EXPECT_EQ(gap_nocache.gap, QcSlotGap::NoCommitmentCached);
+    EXPECT_EQ(gap_nocache.cached_signers, -1);
+}
+
+TEST(DashDkgColdStart, BackFilledCommitmentServesAndItsRemovalFailsClosed)
+{
+    // THE POSITIVE: whatever fills the cache for a slot whose commitment
+    // predates startup — today only live relay; no P2P back-fill exists —
+    // the height must serve the moment it is BLS-verifiable, with dashd's
+    // real commitment in the plan rather than a null.
+    auto qmgr = qmgr_with_type4_mined();
+    const uint256 qh = *fake_hash_at(kIncidentCycleBase);
+    auto real = real_commitment(kLlmq50_60, qh, /*quorumIndex=*/0, 0x11);
+
+    MineableCommitmentCache cache;
+    ASSERT_TRUE(cache.ingest(LlmqNetwork::Mainnet, real));
+    cache.set_bls_verify_fn([](const CFinalCommitment&) { return true; });
+    cache.set_members_ready_fn([](uint8_t, const uint256&) { return true; });
+
+    RequiredQcSlot gap{};
+    auto plan = incident_plan(qmgr, &cache, &gap);
+    ASSERT_TRUE(plan.has_value()) << "a verifiable commitment must SERVE";
+    ASSERT_EQ(plan->commitments.size(), 1u);
+    EXPECT_EQ(plan->commitments[0].llmqType, 1);
+    EXPECT_EQ(plan->commitments[0].quorumHash, qh);
+    // A REAL commitment, not the null dashd would have mined here.
+    EXPECT_EQ(plan->commitments[0].CountSigners(), 50);
+    EXPECT_GT(plan->commitments[0].CountSigners(), 0);
+    // Measured, not guessed.
+    EXPECT_EQ(cache.cached_signers(1, qh), 50);
+
+    // THE NEGATIVE TWIN — the back-fill removed: same qmgr, same height,
+    // same verifier, cache emptied. Must fail closed.
+    cache.clear();
+    RequiredQcSlot gap2{};
+    EXPECT_FALSE(incident_plan(qmgr, &cache, &gap2).has_value())
+        << "without the commitment the WHOLE height must fail closed";
+    EXPECT_EQ(gap2.gap, QcSlotGap::NoCommitmentCached);
+    EXPECT_EQ(gap2.cached_signers, -1);
+}
+
+TEST(DashDkgColdStart, EveryUnsatisfiableShapeFailsClosedWithItsOwnName)
+{
+    auto qmgr = qmgr_with_type4_mined();
+    const uint256 qh = *fake_hash_at(kIncidentCycleBase);
+    auto real = real_commitment(kLlmq50_60, qh, 0, 0x11);
+
+    // (1) cached, but NO BLS verifier installed => bls-verifier-absent.
+    {
+        MineableCommitmentCache cache;
+        ASSERT_TRUE(cache.ingest(LlmqNetwork::Mainnet, real));
+        EXPECT_FALSE(cache.has_bls_verifier());
+        RequiredQcSlot gap{};
+        EXPECT_FALSE(incident_plan(qmgr, &cache, &gap).has_value());
+        EXPECT_EQ(gap.gap, QcSlotGap::VerifierAbsent);
+        EXPECT_STREQ(qc_slot_gap_name(gap.gap), "bls-verifier-absent");
+        // The signer count IS measured here — something is held.
+        EXPECT_EQ(gap.cached_signers, 50);
+        // No member probe installed => the readiness axis is n/a, not "no".
+        EXPECT_FALSE(cache.members_ready(1, qh).has_value());
+    }
+
+    // (2) cached + verifier, member set still in flight => member-set-unsourced.
+    {
+        MineableCommitmentCache cache;
+        ASSERT_TRUE(cache.ingest(LlmqNetwork::Mainnet, real));
+        cache.set_bls_verify_fn([](const CFinalCommitment&) { return false; });
+        cache.set_members_ready_fn([](uint8_t, const uint256&) { return false; });
+        RequiredQcSlot gap{};
+        EXPECT_FALSE(incident_plan(qmgr, &cache, &gap).has_value());
+        EXPECT_EQ(gap.gap, QcSlotGap::MemberSetUnsourced);
+        ASSERT_TRUE(cache.members_ready(1, qh).has_value());
+        EXPECT_FALSE(*cache.members_ready(1, qh));
+    }
+
+    // (3) cached + verifier + members READY, signature rejected => the
+    //     hostile/corrupt-peer case, which must read differently from (2).
+    {
+        MineableCommitmentCache cache;
+        ASSERT_TRUE(cache.ingest(LlmqNetwork::Mainnet, real));
+        cache.set_bls_verify_fn([](const CFinalCommitment&) { return false; });
+        cache.set_members_ready_fn([](uint8_t, const uint256&) { return true; });
+        RequiredQcSlot gap{};
+        EXPECT_FALSE(incident_plan(qmgr, &cache, &gap).has_value());
+        EXPECT_EQ(gap.gap, QcSlotGap::BlsVerifyFailed);
+        EXPECT_STREQ(qc_slot_gap_name(gap.gap), "bls-verify-failed");
+    }
+
+    // (4) verified, but the relayed copy carries a flipped quorumIndex —
+    //     serving it is bad-qc-invalid, so the slot stays unsatisfiable and
+    //     must NOT be reported as a relay gap.
+    {
+        MineableCommitmentCache cache;
+        auto flipped = real;
+        flipped.quorumIndex = 7;    // slot's index is 0
+        ASSERT_TRUE(cache.ingest(LlmqNetwork::Mainnet, flipped));
+        cache.set_bls_verify_fn([](const CFinalCommitment&) { return true; });
+        cache.set_members_ready_fn([](uint8_t, const uint256&) { return true; });
+        RequiredQcSlot gap{};
+        EXPECT_FALSE(incident_plan(qmgr, &cache, &gap).has_value());
+        EXPECT_EQ(gap.gap, QcSlotGap::QuorumIndexMismatch);
+        EXPECT_STREQ(qc_slot_gap_name(gap.gap), "quorum-index-mismatch");
+    }
+
+    // (5) THE ONE SERVING SHAPE, for contrast: all four defects absent.
+    {
+        MineableCommitmentCache cache;
+        ASSERT_TRUE(cache.ingest(LlmqNetwork::Mainnet, real));
+        cache.set_bls_verify_fn([](const CFinalCommitment&) { return true; });
+        cache.set_members_ready_fn([](uint8_t, const uint256&) { return true; });
+        RequiredQcSlot gap{};
+        EXPECT_TRUE(incident_plan(qmgr, &cache, &gap).has_value());
+        EXPECT_TRUE(cache.verified_for(1, qh).has_value());
+        // A served height leaves the gap code UNTOUCHED. There is no "none"
+        // code to assert here on purpose: success is reported by the plan
+        // existing, never by a status word that could read as "fine" when it
+        // was in fact never measured.
+        EXPECT_EQ(gap.gap, QcSlotGap::Unevaluated);
+        EXPECT_STREQ(qc_slot_gap_name(gap.gap), "n/a");
+    }
+}
+
+TEST(DashDkgColdStart, DiagnosisNeverInfluencesTheServeDecision)
+{
+    // The gate must key off verified_for ALONE. A members_ready probe that
+    // lies in either direction changes the NAME on the refusal and nothing
+    // else — belt-and-braces against the diagnosis seam becoming a bypass.
+    auto qmgr = qmgr_with_type4_mined();
+    const uint256 qh = *fake_hash_at(kIncidentCycleBase);
+    auto real = real_commitment(kLlmq50_60, qh, 0, 0x11);
+
+    // Probe says "ready" while the verifier rejects: still fails closed.
+    MineableCommitmentCache lying_ready;
+    ASSERT_TRUE(lying_ready.ingest(LlmqNetwork::Mainnet, real));
+    lying_ready.set_bls_verify_fn([](const CFinalCommitment&) { return false; });
+    lying_ready.set_members_ready_fn([](uint8_t, const uint256&) { return true; });
+    EXPECT_FALSE(incident_plan(qmgr, &lying_ready, nullptr).has_value());
+
+    // Probe says "not ready" while the verifier accepts: still SERVES (the
+    // probe is observability, it can never withhold a valid commitment).
+    MineableCommitmentCache lying_unready;
+    ASSERT_TRUE(lying_unready.ingest(LlmqNetwork::Mainnet, real));
+    lying_unready.set_bls_verify_fn([](const CFinalCommitment&) { return true; });
+    lying_unready.set_members_ready_fn([](uint8_t, const uint256&) { return false; });
+    EXPECT_TRUE(incident_plan(qmgr, &lying_unready, nullptr).has_value());
+}
+
+TEST(DashDkgColdStart, EveryAdmissionRejectionHasItsOwnName)
+{
+    // A relayed qfcommit that structural admission drops must SAY SO. Before
+    // this, ingest returned bare false and only the accept path logged — so a
+    // later "no-commitment-cached" refusal could not be told apart from "the
+    // commitment never reached us on the wire". Opposite diagnoses.
+    using Adm = MineableCommitmentCache::Admission;
+    const uint256 qh = h256(0x55);
+    auto good = real_commitment(kLlmq50_60, qh, 0, 0x11);
+
+    MineableCommitmentCache cache;
+    // POSITIVE: the good one is accepted and says so.
+    EXPECT_EQ(cache.ingest_ex(LlmqNetwork::Mainnet, good), Adm::Accepted);
+    EXPECT_STREQ(MineableCommitmentCache::admission_name(Adm::Accepted),
+                 "accepted");
+    EXPECT_EQ(cache.cached_signers(1, qh), 50);
+
+    // NEGATIVE TWINS: one per rejection branch, each named distinctly.
+    {
+        auto bad = good; bad.llmqType = 99;
+        MineableCommitmentCache c2;
+        EXPECT_EQ(c2.ingest_ex(LlmqNetwork::Mainnet, bad), Adm::UnknownType);
+    }
+    {
+        auto bad = good;
+        bad.nVersion = CFinalCommitment::LEGACY_BLS_NON_INDEXED_QUORUM_VERSION;
+        MineableCommitmentCache c2;
+        EXPECT_EQ(c2.ingest_ex(LlmqNetwork::Mainnet, bad), Adm::WrongVersion);
+    }
+    {
+        auto bad = good; bad.signers.assign(10, true);
+        MineableCommitmentCache c2;
+        EXPECT_EQ(c2.ingest_ex(LlmqNetwork::Mainnet, bad),
+                  Adm::BitsetSizeMismatch);
+    }
+    {
+        auto bad = good;
+        bad.validMembers.assign(50, false);
+        for (int i = 0; i < 35; ++i) bad.validMembers[static_cast<size_t>(i)] = true;
+        MineableCommitmentCache c2;
+        EXPECT_EQ(c2.ingest_ex(LlmqNetwork::Mainnet, bad),
+                  Adm::ValidMembersBelowMin);
+    }
+    {
+        auto bad = good;
+        bad.signers.assign(50, false);
+        for (int i = 0; i < 35; ++i) bad.signers[static_cast<size_t>(i)] = true;
+        MineableCommitmentCache c2;
+        EXPECT_EQ(c2.ingest_ex(LlmqNetwork::Mainnet, bad), Adm::SignersBelowMin);
+    }
+    {
+        auto bad = good; bad.membersSig.fill(0);
+        MineableCommitmentCache c2;
+        EXPECT_EQ(c2.ingest_ex(LlmqNetwork::Mainnet, bad),
+                  Adm::NullCryptoFields);
+    }
+    // Keep-best-by-CountSigners: a re-relay of the SAME commitment is not a
+    // defect and must not read like one.
+    EXPECT_EQ(cache.ingest_ex(LlmqNetwork::Mainnet, good),
+              Adm::NotBetterThanCached);
+    EXPECT_EQ(cache.size(), 1u);
+
+    // Every name is distinct — a shared string would re-collapse the causes.
+    const Adm all[] = {Adm::Accepted, Adm::UnknownType, Adm::WrongVersion,
+                       Adm::BitsetSizeMismatch, Adm::ValidMembersBelowMin,
+                       Adm::SignersBelowMin, Adm::NullCryptoFields,
+                       Adm::NotBetterThanCached};
+    std::vector<std::string> names;
+    for (auto a : all) names.emplace_back(MineableCommitmentCache::admission_name(a));
+    std::sort(names.begin(), names.end());
+    EXPECT_EQ(std::adjacent_find(names.begin(), names.end()), names.end())
+        << "two admission outcomes share a name";
+
+    // And the legacy bool wrapper still means exactly "accepted".
+    MineableCommitmentCache c3;
+    EXPECT_TRUE(c3.ingest(LlmqNetwork::Mainnet, good));
+    EXPECT_FALSE(c3.ingest(LlmqNetwork::Mainnet, good));
+}


### PR DESCRIPTION
## Prior art first: can a historical quorum commitment be fetched?

**No — and Dash Core does not fetch it either.** Verified against `dashpay/dash` v21.1.0 (`src/llmq/blockprocessor.cpp`, `src/llmq/dkgsessionhandler.cpp`), not inferred.

A *mandatory* slot exists precisely because its commitment has **not been mined yet** — `has_mined` is false by construction. So it is in no block, and it lives only in each full node's in-memory `minableCommitments` map. That map is filled from exactly two places: `ProcessCommitment` on a relayed `qfcommit`, and `UndoBlock` (re-mineable after a reorg). `AddMineableCommitment` announces it **once** — `RelayInv(CInv(MSG_QUORUM_FINAL_COMMITMENT, ::SerializeHash(fqc)))` — at DKG finalize, and it is served on `getdata` **by commitment hash only** (`GetMineableCommitmentByHash`). There is no `(llmqType, quorumHash)`-keyed request anywhere in the protocol, and the hash digests the full commitment (signers bitset + BLS sigs), so a cold node cannot derive it.

The light-client messages do not close the gap either. `mnlistdiff.newQuorums` and `qrinfo.lastCommitmentPerIndex` both carry **mined** commitments only — i.e. exactly the ones for which the slot no longer exists. The `getqrinfo` path we already have documented as a rotated-member-sourcing follow-up would not have helped here regardless: the incident slot was type 1 (`llmq_50_60`), non-rotated.

**How the reference implementation avoids the problem: it doesn't.** It has the identical hole and resolves it by *mining the null commitment*. `GetMineableCommitments` is documented upstream as *"Will return a null commitment if no mineable commitment is known and none was mined yet"* and takes the `// null commitment required` arm whenever `minableCommitmentsByQuorum` has no entry. A cold-started dashd inside a DKG mining window is in exactly our state and mines null through it.

We must not copy that arm — block 1520106 is the evidence that null-serving a *succeeded* DKG diverges `merkleRootQuorums`. So the gate is right, there is nothing to back-fill from, and per the brief the answer is the other one: **bound the outage, surface it honestly, make the wait predictable.**

## The design, and why

The gate is untouched. Every path still fails closed, and the mutation set below proves it. What was actually defective is that a **correct refusal was mute**: one sentence — *"has no verified real commitment and no failed-DKG evidence"* — covered five situations with five different operator responses (cold-start relay hole → wait; missing verifier → build defect; unsourced member set → in flight; failed signature → hostile or corrupt peer; index-flipped copy → relay DoS). And it gave no indication of how long the wait would be.

1. **`QcSlotGap`** classifies the blocking slot: `no-commitment-cached` / `bls-verifier-absent` / `member-set-unsourced` / `bls-verify-failed` / `quorum-index-mismatch`. There is deliberately **no `None` value**: no code path could set one, and a status word nobody can set reads as "fine" when it was never measured.
2. **`qc_window_bound()`** gives the refusal its upper bound. A mandatory slot cannot outlive its DKG mining window `[cycleStart+miningWindowStart, cycleStart+miningWindowEnd]`, so `heights_remaining` *is* the worst case. The incident cleared in 4 of its 6 remaining heights, when another miner mined the commitment.
3. **The log carries measured values**: reason, `cached_signers`/minSize, cache size, `bls_verifier`, `member_set_ready`, window, remaining, `first_planned_h`, `predates_our_wire`. Anything not evaluated prints `n/a` — never `0`, never a guessed bool. A once-per-process note states the upstream finding so nobody has to re-derive "why can't it just ask a peer?" from source.
4. **`MineableCommitmentCache::ingest_ex()` names every rejection.** A relayed `qfcommit` dropped by structural admission previously left **no trace at all** — only the accept path logged. That made a later `no-commitment-cached` refusal indistinguishable from "the commitment never reached us on the wire", which are opposite diagnoses. This one matters for the incident specifically (see below).

Not done, on purpose: pre-warming the member-set source from the plan path would be a cross-thread call into `QuorumMemberSource`, which documents single-coin-ioc-thread entry. It is a real follow-up, but it belongs on the coin thread and it would not have prevented this outage.

## Also fixed: the false fallback line

`[DASH-STRATUM-GBT] fallback arm UNARMED (no dashd RPC creds) -- serving empty set-gap template` printed immediately before **every successful embedded serve**. `set_gbt_xcheck(testnet || embedded_mainnet)` ran the cross-check on every embedded template and invoked the unarmed dashd lambda; the empty payload then failed `parse_cbtx`, the mismatch branch was skipped, and EMBEDDED was served correctly. Harmless to correctness — but a healthy daemonless log read as though the node fell back on every single template, and it stole the one line that should mean a *real* fallback.

The cross-check now also requires an armed RPC arm, which is what its own comment always claimed. The stale `work_source.cpp` comment about an opt-in `--embedded-mainnet-with-dashd` flag (no such flag exists) is corrected.

## Files

- `src/impl/dash/coin/dkg_commitments.hpp` — cold-start prior-art note, `QcSlotGap`, `qc_window_bound`, cache diagnosis seam, `ingest_ex`
- `src/c2pool/main_dash.cpp` — classified/bounded `[QC-COMPLETENESS]` line, `[QC-MINEABLE] REJECTED` line, member-readiness probe wiring, `set_gbt_xcheck` arm-check
- `src/impl/dash/stratum/work_source.cpp` — stale cross-check comment corrected
- `test/test_dash_dkg_commitments.cpp` — 6 new cases

## Build and test

Fresh clone off `origin/master` (base `5ac68f05`), real BLS the CI way:

```
conan install . -pr:a=ci/conan/linux-gcc13.profile --build=missing --output-folder=build_dash_bls
cmake -S . -B build_dash_bls -DCMAKE_TOOLCHAIN_FILE=build_dash_bls/conan_toolchain.cmake \
      -DCMAKE_BUILD_TYPE=Release -DC2POOL_DASH_BLS=ON -DDASHBLS_ROOT=/home/ubuntu/dashbls
cmake --build build_dash_bls -j$(nproc) --target c2pool-dash <all test targets>
```

- `scripts/ci/dash_bls_linked_guard.sh build_dash_bls/src/c2pool/c2pool-dash` → **PASS** (dashbls ciphersuite in rodata, `bls::G1Element::FromBytes`, `bls::G2Element::FromBytes`)
- BLS KATs (`DashBlsVerify|DashQuorumMembers|DashQuorumMemberSource|DashGovVoteBLS`): **33/33 passed, 0 failed**
- `test_dash_embedded_gbt` (holds the new cases): **64/64 passed** (58 before this change)
- Full suite: `ctest -j8` → **2150/2150 passed, 0 failed** (2149 before)

## Mutation proof — 11 mutations, 11 red, 0 green

Each mutation was applied to the shipped source, rebuilt, and the suite re-run.

| # | Mutation | Result |
|---|---|---|
| M1 | drop the gap classification (never call `diagnose`) | RED |
| M2 | **weaken the gate** — `verified_for` serves without BLS verification | RED |
| M3 | `qc_window_bound` off-by-one on `last_height` | RED |
| M4 | `cached_signers` fabricates `0` instead of `-1`/`n/a` | RED |
| M5 | `diagnose` collapses `member-set-unsourced` into `bls-verify-failed` | RED |
| M6 | the diagnosis probe becomes a **gate** (withholds a valid commitment) | RED |
| M7 | `quorum-index-mismatch` mislabelled as `bls-verify-failed` | RED |
| M8 | collapse every admission rejection into one reason | RED |
| M9 | two admission outcomes share a name | RED |
| M10 | `ingest()` bool wrapper stops meaning "accepted" | RED |
| M11 | keep-best-by-CountSigners dedup removed | RED |

No mutation produced zero red. M2 and M6 are the two that matter most: they are the gate-weakening and gate-bypass shapes, and both are caught.

## Where the brief was wrong about the code

Two corrections worth carrying forward, both from the incident's own arithmetic.

**1. The commitment probably did *not* predate startup.** `llmq_50_60` mainnet is `dkgInterval=24, miningWindow=[10,18]`. For `h=2515381` the cycle base is 2515368, so the window is **[2515378, 2515386]** — which is why 2515377 (phase 9) served, 2515381-2515384 (phases 13-16) were dark, and 2515388 (phase 20) served again. DKG finalize for that cycle lands around phase 9-10, i.e. **~01:20-01:25 — inside the node's 75-minute uptime**, and the type-4 `qfcommit` the node *did* accept arrived at 01:23:08, from that same finalization burst. So the node was almost certainly online when the type-1 commitment was relayed and did not end up holding it. The new `predates_our_wire` field is exactly the datum that settles this on the next occurrence, and it will read `no` for this shape.

**2. That makes the silent ingest rejection the live suspect.** `ingest()` returned bare `false` and only the accept path logged, so a `qfcommit` that arrived and was dropped by structural admission (`wrong-version`, `bitset-size-mismatch`, `*-below-minsize`, `null-crypto-fields`, `not-better-than-cached`) was **completely invisible**. That is why `ingest_ex` is in this PR rather than deferred: without it, the next occurrence still cannot distinguish "never relayed to us" from "relayed and dropped here". The p2p layer does log every `qfcommit` arrival (`p2p_client.hpp:809`), so the two lines together now bracket the question.

Everything else in the brief matched the code: `main_dash.cpp:1804` `set_gbt_xcheck(testnet || embedded_mainnet)`, the unarmed-lambda mechanism, the stale `work_source.cpp:366` comment, `null_evidence=nullptr`, and the qc_cache filling only from live wire.
