### PR TITLE
ltc-doge: name WebServer ctor in startup log (silent-ctor fix)

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -7893,6 +7893,7 @@ WebServer::WebServer(net::io_context& ioc, const std::string& address, uint16_t 
     , solo_mode_(false)
 {
     mining_interface_ = std::make_shared<MiningInterface>(testnet);
+    LOG_INFO << "core::WebServer constructed on " << bind_address_ << ":" << port_ << " (MiningInterface " << (mining_interface_ ? "alive" : "NULL") << ", blockchain=" << static_cast<int>(blockchain_) << ")";
 }
 
 WebServer::WebServer(net::io_context& ioc, const std::string& address, uint16_t port, bool testnet, std::shared_ptr<IMiningNode> node)
@@ -7907,6 +7908,7 @@ WebServer::WebServer(net::io_context& ioc, const std::string& address, uint16_t 
     , solo_mode_(false)
 {
     mining_interface_ = std::make_shared<MiningInterface>(testnet, node);
+    LOG_INFO << "core::WebServer constructed on " << bind_address_ << ":" << port_ << " (MiningInterface " << (mining_interface_ ? "alive" : "NULL") << ", blockchain=" << static_cast<int>(blockchain_) << ")";
 }
 
 WebServer::WebServer(net::io_context& ioc, const std::string& address, uint16_t port, bool testnet, std::shared_ptr<IMiningNode> node, Blockchain blockchain)
@@ -7921,6 +7923,7 @@ WebServer::WebServer(net::io_context& ioc, const std::string& address, uint16_t 
     , solo_mode_(false)
 {
     mining_interface_ = std::make_shared<MiningInterface>(testnet, node, blockchain);
+    LOG_INFO << "core::WebServer constructed on " << bind_address_ << ":" << port_ << " (MiningInterface " << (mining_interface_ ? "alive" : "NULL") << ", blockchain=" << static_cast<int>(blockchain_) << ")";
 }
 
 WebServer::~WebServer()


### PR DESCRIPTION
Adds a LOG_INFO "core::WebServer constructed on <addr>:<port>..." to all three WebServer constructors so the webserver announces itself at startup (silent-ctor fix).

Scope: single-coin / shared webserver logging only. HEAD 2054930fd, off master 9d0d22745. Commit is GPG-signed.

CAVEAT (steward-flagged): the DNS->verack->getheaders->tip live-bootstrap CI gate still does NOT exist. This is implemented, not proven-by-gate. Do not read a green CI here as bootstrap verification.

Owner: ltc-doge-production-steward. No self-merge.