### PR TITLE
dash(daemonless): measure the PoSe ban a ProUpServTx revive turns on

### DIFF
--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -360,6 +360,17 @@ public:
         m_ondemand_cap_forced = true;
     }
 
+    /// Override the per-bridge ban-state probe cap. Unset, it is sized against
+    /// the replay distance at bridge start (see pump()). ZERO disables the
+    /// probe entirely, which restores the pre-change behaviour exactly: a
+    /// ProUpServTx whose revive turns on an unmeasured ban is applied as a
+    /// plain service update — and, unlike before, COUNTED as unmeasured.
+    void set_revive_probe_cap(size_t n)
+    {
+        m_revive_probe_cap        = n;
+        m_revive_probe_cap_forced = true;
+    }
+
     /// Maximum number of blocks the bridge is willing to replay. A checkpoint
     /// further behind the tip than this is treated as STALE and refused: the
     /// replay would take longer than an operator would tolerate, and a
@@ -657,6 +668,67 @@ public:
     /// projection is one queue slot ahead of the chain's.
     size_t   revive_dropped()     const { return m_revive_dropped; }
 
+    /// ── BAN-STATE PROBE accounting ────────────────────────────────────────
+    /// A ProUpServTx revives only a masternode that IS PoSe-banned, and a PoSe
+    /// ban is consensus-computed — never a transaction. A replay therefore
+    /// cannot decide the revive from the block; it decides it from whatever
+    /// masternode list it last folded. These count the times the replay had to
+    /// go and MEASURE that, and the times it could not.
+    ///
+    ///   probes            — folds fired by an ambiguous ProUpServTx, dated at
+    ///                       the block BEFORE it (the list dashcore reads).
+    ///   revive_unmeasured — ProUpServTx applied with the ban state at their
+    ///                       own height still unknown. NON-ZERO IS A BLIND
+    ///                       SPOT: if the chain had those banned, dashd set a
+    ///                       revive height and this replay did not.
+    ///   revive_declined_measured — ProUpServTx a dated list proved were NOT
+    ///                       revives. This is the zero that IS a measurement.
+    size_t   revive_probes()      const { return m_revive_probes; }
+    size_t   revive_unmeasured()  const { return m_revive_unmeasured; }
+    size_t   revive_declined()    const { return m_revive_declined; }
+    size_t   revive_probe_cap()   const { return m_revive_probe_cap; }
+    bool     revive_probe_cap_hit() const { return m_revive_probe_cap_hit; }
+
+    /// The ban-state probe's own line, in every report and on the published
+    /// status. Same discipline as ondemand_report(): a field that was never
+    /// evaluated prints n/a, never 0.
+    std::string revive_probe_report() const
+    {
+        if (m_revive_unmeasured != 0) {
+            return "BAN-STATE PROBE: " + std::to_string(m_revive_unmeasured)
+                 + " ProUpServTx were applied WITHOUT a masternode list dated"
+                   " at their own pre-block height, so their revive outcome is"
+                   " UNKNOWN. A PoSe ban that starts AND ends between two folds"
+                   " never appears in any fold's input, so for these heights"
+                   " 'no reinstatement' is an ABSENCE OF MEASUREMENT. If the"
+                   " chain had them banned it set nPoSeRevivedHeight and this"
+                   " replay did not, and each one puts that masternode ~one"
+                   " queue length ahead of the chain in every later projection."
+                 + (m_revive_probe_cap_hit
+                        ? " THE PROBE CAP IS EXHAUSTED ("
+                          + std::to_string(m_revive_probes) + "/"
+                          + std::to_string(m_revive_probe_cap)
+                          + "): further ambiguity was left unmeasured rather"
+                            " than asking a peer for another list."
+                        : " The per-height snapshot seam was unavailable, so"
+                          " no probe could be issued at all.");
+        }
+        if (m_revive_probes == 0 && m_revive_declined == 0) {
+            return "BAN-STATE PROBE: n/a — no ProUpServTx in this replay"
+                   " landed on a masternode whose ban state was both"
+                   " undecided and load-bearing, so the probe path was never"
+                   " exercised.";
+        }
+        return "BAN-STATE PROBE: " + std::to_string(m_revive_probes)
+             + "/" + std::to_string(m_revive_probe_cap)
+             + " used; every ProUpServTx whose revive turned on an unmeasured"
+               " ban was adjudicated against a list dated EXACTLY at the block"
+               " before it. " + std::to_string(m_revive_declined)
+             + " were attested NOT banned (dashcore revives nothing there"
+               " either, so that zero is a measurement); the rest became"
+               " ordinary revives counted above. 0 left unmeasured.";
+    }
+
     /// Why "REINSTATED: 0" is not automatically good news.
     ///
     /// Reinstatement has two sources — the wholesale SML fold flipping an
@@ -683,6 +755,7 @@ public:
                    + " ProUpServTx revive(s) were DROPPED as unknown"
                      " masternodes during this replay.";
             }
+            s += " " + revive_probe_report();
             return s;
         }
         std::string s =
@@ -699,6 +772,12 @@ public:
                  " axis and every later projection is that many queue slots"
                  " ahead of the chain's.";
         }
+        // The second way "reinstated 0" lies. The first (above) is a
+        // `valid`-filtered anchor with nothing revivable in it. This one is a
+        // COMPLETE anchor whose fold sampling cannot see a ban that begins and
+        // ends inside one interval — the wholesale fold's own "+0 revived"
+        // then reports an interval it structurally could not observe.
+        s += " " + revive_probe_report();
         return s;
     }
     bool     sml_folded()         const { return m_sml_folded; }
@@ -878,6 +957,11 @@ public:
                 m_ondemand_cap = kOnDemandFoldBase
                                + (tip - m_anchor_height) / kOnDemandFoldPerBlocks;
             }
+            if (!m_revive_probe_cap_forced) {
+                m_revive_probe_cap =
+                    kReviveProbeBase
+                    + (tip - m_anchor_height) / kReviveProbePerBlocks;
+            }
             LOG_INFO << "[MN-CKPT] bridge START: replaying h=" << m_next
                      << ".." << tip << " (" << (tip - m_next + 1)
                      << " blocks) onto the anchored set";
@@ -957,6 +1041,14 @@ public:
         // PERMANENT demotion.
         refresh_sml_height();
 
+        // ── BAN-STATE PROBE. Fire BEFORE the apply, because the question is
+        // about the PRE-block list and the cursor is standing exactly on
+        // height-1 right now — the one position at which a fold for height-1
+        // is valid by the same construction every other fold here relies on.
+        // Returns true when a request is outstanding (replay PAUSED; the reply
+        // resumes it and re-delivers this very block).
+        if (begin_revive_probe(block, height)) return;
+
         const auto r = m_machine.apply_block(block, height);
 
         // The anchor's own falsification test. apply_block already logs the
@@ -1008,6 +1100,8 @@ public:
         m_spent         += r.spent;
         m_tx_revived    += r.revived;
         m_revive_dropped += r.revive_dropped_unknown;
+        m_revive_unmeasured += r.revive_unmeasured;
+        m_revive_declined   += r.revive_declined_measured;
         m_stalled_pumps = 0;
 
         if ((m_applied % 500) == 0) {
@@ -1127,6 +1221,20 @@ public:
     static constexpr size_t   kOnDemandFoldBase      = 8;
     static constexpr uint32_t kOnDemandFoldPerBlocks = 250;
 
+    /// ── The BAN-STATE PROBE cap, per bridge ───────────────────────────────
+    /// cap = kReviveProbeBase + replay_blocks / kReviveProbePerBlocks.
+    /// Sized from the SAME mainnet window the defect was traced in: 22
+    /// ProUpServTx across 2530 blocks (~1 per 115), of which 7 landed on a
+    /// masternode the replay believed valid and therefore needed a probe
+    /// (~1 per 360). kReviveProbePerBlocks = 100 tracks that with better than
+    /// 3x headroom; the base covers a short bridge where the ratio term is 0
+    /// but a ProUpServTx can still land. Exhausting it does NOT fail the
+    /// bridge — it leaves the ambiguity UNMEASURED and says so, because a
+    /// bridge that has run out of probe budget is still more useful than one
+    /// that hammers a peer, and the blind spot is now nameable either way.
+    static constexpr size_t   kReviveProbeBase      = 8;
+    static constexpr uint32_t kReviveProbePerBlocks = 100;
+
     /// The next height at or after `cursor` at which we want a snapshot, or
     /// nullopt when none remains before `tip`. Always includes the tip so the
     /// published set is current, and the anchor so the first replayed block is
@@ -1141,9 +1249,129 @@ public:
         return std::nullopt;
     }
 
+    // ─────────────────────────────────────────────────────────────────────
+    // THE BAN-STATE PROBE — measure the gate, never guess it
+    // ─────────────────────────────────────────────────────────────────────
+    //
+    // dashcore revives on a ProUpServTx if and only if the masternode
+    // IsBanned() in the PRE-BLOCK list (specialtxman.cpp:361-370). We mirror
+    // that gate against OUR belief about who is banned — and that belief is a
+    // sample, taken at fold points. A ban that starts and ends between two
+    // samples never enters our belief at all, so the gate reads false, the
+    // revive is dropped on the floor, and nPoSeRevivedHeight stays at the
+    // masternode's stale last payment. From there payee_score() sorts it ~one
+    // full queue length ahead of where dashd sorts it.
+    //
+    // MEASURED (mainnet, anchor 2513000, fold interval 500, replay to 2515511;
+    // dashd 23.1.7 asked directly for the pre-block state of every ProUpServTx
+    // in the window):
+    //
+    //   22 ProUpServTx in 2513001..2515530
+    //   20 of them landed on a masternode dashd HAD banned  -> dashd revived
+    //   15 of those 20 this replay also believed banned      -> applied
+    //    5 it did not (banned AND revived between two folds) -> MISSED
+    //    2 landed on a masternode that was NOT banned        -> no revive,
+    //      and dashd set no revive height either
+    //
+    // The 5 missed ones, scored our way, reach the head of our queue at
+    // 2515511 / ~2516175 / ~2516176 / ~2516332 / ~2517466. The replay
+    // fail-closed at 2515511 projecting the first of them, 80b4892b…, which
+    // dashd will not pay until ~2516627.
+    //
+    // WHY NOT JUST SET revivedHeight ON EVERY ProUpServTx. Because of the 2.
+    // d07e1f49… sent a service update at 2515068 with ban height -1 and PoSe
+    // penalty 0; dashd left its revive height at 2501164 and its score at its
+    // last payment, 2513500. Setting 2515068 there moves it 1568 blocks DOWN
+    // the queue and fails at ~2515558 instead — a guess that trades one
+    // divergence for another 47 blocks later. 3da232a3… shows the same shape
+    // one block wide: two ProUpServTx in consecutive blocks, only the FIRST a
+    // revive. The transaction does not carry the answer.
+    //
+    // WHY NOT SHRINK THE FOLD INTERVAL. It cannot work, at any interval. A
+    // ban+revive pair fits between any two fixed samples — 80b4892b…'s was
+    // FOUR blocks wide — so a finer cadence only shrinks the window while
+    // paying a round trip continuously, ban or no ban. At interval 1 it is no
+    // longer a replay, it is a list fetch per block, which is the daemon
+    // dependency this whole lane exists to remove.
+    //
+    // WHY EVENT-TRIGGERED SAMPLING IS EXACTLY ENOUGH. The set of heights at
+    // which an unobserved ban can permanently move a masternode's queue
+    // position is EXACTLY the set of heights carrying a ProUpServTx for a
+    // masternode we hold and believe valid: nowhere else does the ban state
+    // feed a field that outlives the ban. So the replay fires a fold at those
+    // heights and only those. On the measured window that is 7 probes across
+    // 2530 blocks — ~0.3% — against 5 permanent divergences removed. An
+    // unobserved ban still costs eligibility WHILE it lasts, but that is
+    // transient and already carried by the on-demand fold at the mismatch it
+    // causes.
+    //
+    // The probe is the ORDINARY fold: same request, same DIP-4 client
+    // verification, same one-in-flight pause, same cursor==H-by-construction
+    // invariant (the cursor sits on height-1 when the probe is issued). It
+    // needs no new trust and no new reply route.
+    bool begin_revive_probe(const BlockType& block, uint32_t height)
+    {
+        if (height == 0) return false;
+        // LATCH. A probe that was abandoned, or answered by a list that did
+        // not move the gate, must not re-fire when the block is re-delivered:
+        // that is a livelock, not a retry.
+        if (m_revive_probe_at == height - 1) return false;
+        const auto cands = m_machine.unmeasured_revive_candidates(block, height);
+        if (cands.empty()) return false;
+
+        if (m_revive_probes >= m_revive_probe_cap) {
+            m_revive_probe_cap_hit = true;
+            LOG_WARNING
+                << "[MN-CKPT] BAN-STATE PROBE REFUSED at h=" << height
+                << ": " << m_revive_probes << "/" << m_revive_probe_cap
+                << " probes already spent. " << cands.size()
+                << " ProUpServTx here will be applied with the pre-block ban"
+                   " state UNMEASURED. This is reported, not swallowed — see"
+                   " the BAN-STATE PROBE line.";
+            return false;
+        }
+        // THE LATCH IS SET BEFORE THE REQUEST, and that ordering is
+        // load-bearing rather than tidy. m_request_snapshot may be answered
+        // INLINE — an ordered stream, or a same-thread demux — in which case
+        // on_historical_snapshot() clears m_snapshot_pending, folds, and
+        // resumes the replay, re-delivering THIS block into
+        // on_block_connected() before begin_fold() has even returned. With the
+        // latch set afterwards that re-entry sees an unlatched lane and asks
+        // again, recursively: mutation-tested, and it does not terminate on
+        // its own. Setting it first makes the re-entry a no-op.
+        const uint32_t probe_at      = height - 1;
+        const uint32_t latch_before  = m_revive_probe_at;
+        const size_t   probes_before = m_revive_probes;
+        m_revive_probe_at = probe_at;
+        ++m_revive_probes;
+        // THIS block was already requested and has just been dropped on the
+        // floor. request_window() asks only for heights above
+        // m_requested_through, so without this the resume would ask for
+        // height+1 — which on_block_connected ignores (height != m_next) — and
+        // the bridge would sit on the stall probe until the next tip change.
+        // The probe is the one path that pauses on a block it has ALREADY
+        // consumed, so it is the one path that has to say so.
+        m_rerequest_from_cursor = true;
+        if (!begin_fold(probe_at, /*on_demand=*/false,
+                        "BAN-STATE PROBE (a ProUpServTx at h="
+                        + std::to_string(height)
+                        + " whose revive turns on a ban this set never"
+                          " measured)")) {
+            // No snapshot seam, or the header for height-1 is not held.
+            // Nothing was asked, so nothing was spent: put the budget and the
+            // latch back exactly as they were. The ambiguity survives and
+            // apply_block will COUNT it.
+            m_revive_probe_at = latch_before;
+            m_revive_probes   = probes_before;
+            return false;
+        }
+        return true;
+    }
+
     /// Ask for the list as of `height`, and pause the replay until it lands.
     /// Returns true when a request was issued (caller must stop pulling).
-    bool begin_fold(uint32_t height, bool on_demand = false)
+    bool begin_fold(uint32_t height, bool on_demand = false,
+                    const std::string& why = std::string())
     {
         if (!m_request_snapshot || !m_merkle_root_at || !m_header_hash_at)
             return false;
@@ -1154,9 +1382,13 @@ public:
         m_snapshot_height  = height;
         m_snapshot_waits   = 0;
         LOG_INFO << "[MN-CKPT] "
-                 << (on_demand ? "ON-DEMAND PoSe fold (triggered by the payee"
-                                 " mismatch itself, not by a fold point)"
-                               : "PoSe fold")
+                 << (!why.empty()
+                         ? why
+                         : (on_demand
+                                ? std::string("ON-DEMAND PoSe fold (triggered"
+                                              " by the payee mismatch itself,"
+                                              " not by a fold point)")
+                                : std::string("PoSe fold")))
                  << ": requesting the masternode list AS OF"
                     " h=" << height << " (" << hash->GetHex().substr(0, 16)
                  << ") — replay PAUSED until it lands, so the cursor cannot"
@@ -1521,6 +1753,27 @@ private:
         // downgrade every walk attestation to "no opinion" until the next
         // block's refresh_sml_height() undid it. The two lists are dated
         // independently because they ARE independent.
+        // WHICH ZERO. "+0 revived" here means one specific thing: no
+        // masternode this set was holding as banned is attested VALID by THIS
+        // list. It does NOT mean no reinstatement happened since the last
+        // fold, and it never could — a PoSe ban that starts AND ends inside a
+        // fold interval is absent from BOTH folds' inputs, so no cadence of
+        // folds can observe it. Those heights are covered by the ban-state
+        // probe instead, and the count of ones it could not reach is the only
+        // honest answer to "did we miss a reinstatement". Saying so at the
+        // fold is the point: this is the line an operator reads as
+        // reassurance.
+        const std::string zero_note =
+            vr.flipped_to_valid != 0
+                ? std::string()
+                : (" The +0 revived is scoped to THIS list: it says no"
+                   " masternode this set held as banned is attested valid at h="
+                   + std::to_string(height) + ", NOT that no reinstatement"
+                     " happened since the last fold — a ban that starts and"
+                     " ends inside a fold interval appears in no fold's input."
+                     " Those are measured by the ban-state probe: "
+                   + std::to_string(m_revive_probes) + " taken, "
+                   + std::to_string(m_revive_unmeasured) + " left unmeasured.");
         LOG_INFO << "[MN-CKPT] PoSe FOLD at h=" << height
                  << " (cursor == the height the list describes, by"
                     " construction): payee-eligible " << before << " -> "
@@ -1528,7 +1781,7 @@ private:
                  << vr.flipped_to_valid << " revived; scanned " << vr.scanned
                  << " entries, " << vr.matched << " ours). List was DIP-4"
                     " client-verified against the block's own coinbase"
-                    " commitment.";
+                    " commitment." << zero_note;
     }
 
 public:
@@ -1654,6 +1907,7 @@ public:
                    " per-mismatch walk alone.";
         }
         s += " " + ondemand_report();
+        s += " " + revive_probe_report();
         if (m_snapshot_pending) {
             s += " A masternode-list request for h="
                  + std::to_string(m_snapshot_height) + " is OUTSTANDING and the"
@@ -1780,7 +2034,8 @@ public:
                    + " + " + std::to_string(m_applied) + " replayed blocks) "
                    + delta
                    + " PoSe folds: " + std::to_string(m_folds)
-                   + " (" + ondemand_report() + ")";
+                   + " (" + ondemand_report() + " "
+                   + revive_probe_report() + ")";
         // A DEGRADED publish must say so. Publishing a set that was assembled
         // without the fold points it asked for looks identical, from outside,
         // to a clean bridge — and that silence is the defect: the operator has
@@ -1942,6 +2197,16 @@ public:
         // m_ondemand_cap_forced is CONFIG (set_ondemand_fold_cap) and survives,
         // which is why the reset is guarded the same way pump()'s sizing is.
         if (!m_ondemand_cap_forced) m_ondemand_cap = kOnDemandFoldBase;
+        // Same argument for the probe budget, plus one more: the latch. A
+        // re-armed bridge replays the SAME heights from the SAME anchor, so a
+        // latch left standing would suppress the very probe the second attempt
+        // exists to take.
+        m_revive_probes        = 0;
+        m_revive_probe_at      = 0;
+        m_revive_unmeasured    = 0;
+        m_revive_declined      = 0;
+        m_revive_probe_cap_hit = false;
+        if (!m_revive_probe_cap_forced) m_revive_probe_cap = kReviveProbeBase;
         m_pose_removed    = 0;
         m_pose_reinstated = 0;
         m_tx_revived      = 0;
@@ -2024,6 +2289,19 @@ public:
     bool      m_ondemand_cap_hit{false};
     bool      m_ondemand_evaluated{false};     // a mismatch ever reached it
     size_t    m_ondemand_abandoned{0};         // on-demand asks never answered
+    // ── BAN-STATE PROBE state. Rides the SAME m_snapshot_pending pause and
+    // the SAME reply route as a scheduled fold — it IS a scheduled fold, just
+    // scheduled by a ProUpServTx instead of by a counter. m_revive_probe_at is
+    // the anti-livelock latch: the probed height, so a re-delivered block
+    // cannot re-ask for a list that has already been asked for and consumed,
+    // refused or abandoned.
+    size_t    m_revive_probes{0};
+    uint32_t  m_revive_probe_at{0};
+    size_t    m_revive_unmeasured{0};
+    size_t    m_revive_declined{0};
+    size_t    m_revive_probe_cap{kReviveProbeBase};
+    bool      m_revive_probe_cap_forced{false};
+    bool      m_revive_probe_cap_hit{false};
     RequestSnapshotFn m_request_snapshot;
     MerkleRootAtFn    m_merkle_root_at;
     size_t   m_sml_recovery_cap{0}; // budget handed to the machine, mirrored

--- a/src/impl/dash/coin/mn_state_machine.hpp
+++ b/src/impl/dash/coin/mn_state_machine.hpp
@@ -151,6 +151,51 @@ public:
         //          have not, i.e. a permanent one-slot offset in every later
         //          projection. NON-ZERO IS A DEFECT, not a statistic.
         size_t revive_dropped_unknown{0};
+        // ── THE BAN WE NEVER MEASURED ────────────────────────────────────
+        // dashcore revives on a ProUpServTx ONLY when the masternode
+        // IsBanned() at that point (specialtxman.cpp:361-370), and the branch
+        // below mirrors that gate exactly. The mirror is only as good as our
+        // belief about who is banned — and a PoSe ban is not a transaction. A
+        // block replay NEVER observes one; we learn of bans only by folding a
+        // masternode list sampled at discrete heights. So a masternode banned
+        // AND revived strictly BETWEEN two folds is, to this machine, never
+        // banned at all: the ProUpServTx arrives, the gate is false, and
+        // nPoSeRevivedHeight is left alone. dashd set it. From then on
+        // payee_score() scores that masternode by its stale nLastPaidHeight
+        // instead of its revive height, and we project it as queue head
+        // roughly one full queue length before dashd will pay it.
+        //
+        // TRACED ON MAINNET (2026-08-03, anchor 2513000, fold interval 500):
+        // proTx 80b4892b… PoSe-banned at 2514570 and revived by a ProUpServTx
+        // at 2514574 — a four-block ban, entirely inside the 2514150..2514650
+        // fold interval. dashd scores it 2514574; we scored it 2513453, its
+        // last payment. At h=2515511 that put it at the head of OUR queue and
+        // at rank 1116 of dashd's. Five of the window's 22 ProUpServTx had
+        // this shape, and their our-score ranks predict the failure order
+        // exactly: 2515511, ~2516175, ~2516176, ~2516332, ~2517466.
+        //
+        // "Just set revivedHeight on every ProUpServTx" is REFUTED by the
+        // same dataset: 2 of those 22 were service updates from masternodes
+        // that were NOT banned (d07e1f49… at 2515068, ban height -1, penalty
+        // 0), and dashd set no revive height for them. Guessing a revive
+        // there pushes the masternode 1568 blocks DOWN the queue and fails
+        // the other way round. The ban state is not derivable from the
+        // transaction; it has to be measured.
+        //
+        // revive_unmeasured: ProUpServTx applied for a masternode this set
+        //          holds and believes NOT banned, WITHOUT a masternode list
+        //          dated at the pre-block height to check that belief. The
+        //          revive outcome at this height is UNKNOWN — not "no
+        //          revive". NON-ZERO IS A BLIND SPOT, not a statistic.
+        size_t revive_unmeasured{0};
+        // The proTxHashes behind revive_unmeasured, so a caller can name them
+        // instead of reporting a bare count.
+        std::vector<uint256> revive_unmeasured_protx;
+        // revive_declined_measured: ProUpServTx for a masternode a list dated
+        //          EXACTLY at height-1 attests NOT banned. dashcore revives
+        //          nothing here and neither do we — and that zero IS a
+        //          measurement.
+        size_t revive_declined_measured{0};
         size_t spent{0};       // collateral spent → MN removed
         size_t paid{0};        // projected payee marked paid this block
         size_t total_after{0};
@@ -355,6 +400,10 @@ public:
         m_entries.clear();
         m_collateral_index.clear();
         m_last_applied_height = as_of_height;
+        // The ban-state measurement described the ENTRIES, not the machine.
+        // Replacing the entries retires it: a fold dated at some height says
+        // nothing about a set that was not the one it was folded into.
+        m_ban_state_measured_at = 0;
         // A pending mismatch describes a queue that no longer exists once the
         // set is reloaded. Leaving it would let a re-armed lane re-adjudicate
         // an old height against a new set.
@@ -369,6 +418,45 @@ public:
     // apply_block is FORWARD-ONLY: any call at height <= this is skipped
     // whole (see ApplyResult::skipped_out_of_order).
     uint32_t last_applied_height() const { return m_last_applied_height; }
+
+    /// The height a wholesale masternode-list fold last reconciled this set's
+    /// PoSe ban state at (0 = never). Set by sync_validity_from_sml(), which
+    /// is the ONLY path that can observe a consensus PoSe ban, and cleared by
+    /// load(). This is what turns "we do not believe it is banned" into
+    /// either a measurement or an assumption.
+    uint32_t ban_state_measured_at() const { return m_ban_state_measured_at; }
+
+    /// True when the ban state this machine holds was measured against a list
+    /// dated at the block BEFORE `height` — i.e. the exact pre-block list
+    /// dashcore consults when it decides whether a ProUpServTx revives.
+    bool ban_state_measured_for(uint32_t height) const
+    {
+        return m_ban_state_measured_at != 0
+            && m_ban_state_measured_at + 1 == height;
+    }
+
+    /// The proTxHashes in `block` whose revive outcome this machine cannot
+    /// decide: a ProUpServTx for a masternode it HOLDS and believes NOT
+    /// banned, at a height whose pre-block ban state was never measured.
+    ///
+    /// Called BEFORE apply_block so a caller can go and measure — the cursor
+    /// is standing exactly on height-1 at that moment, which is the one
+    /// position at which a fold for height-1 is valid. Empty means apply_block
+    /// will report revive_unmeasured == 0 for this block, and the two share
+    /// the predicate below so they cannot drift apart.
+    std::vector<uint256> unmeasured_revive_candidates(
+        const dash::coin::BlockType& block, uint32_t height) const
+    {
+        std::vector<uint256> out;
+        if (ban_state_measured_for(height)) return out;
+        for_each_proupserv(block, [&](const uint256& protx) {
+            auto it = m_entries.find(protx);
+            if (it == m_entries.end()) return;          // revive_dropped_unknown
+            if (it->second.nPoSeBanHeight != 0) return; // gate already true
+            out.push_back(protx);
+        });
+        return out;
+    }
 
     size_t size() const { return m_entries.size(); }
 
@@ -701,6 +789,12 @@ public:
         uint32_t current_height)
     {
         SyncFromSmlResult r;
+        // This IS the ban-state measurement. A fold is the only input this
+        // machine has that can carry a consensus PoSe ban, so the height it
+        // is dated at is the height up to which "not banned" means something.
+        // Recorded before the walk so it holds even when nothing flipped —
+        // "nothing flipped" is the most important case to be able to date.
+        m_ban_state_measured_at = current_height;
         for (const auto& sml_entry : sml.mnList) {
             ++r.scanned;
             auto it = m_entries.find(sml_entry.proRegTxHash);
@@ -1112,6 +1206,41 @@ public:
                     it->second.nPoSeRevivedHeight = height;
                     it->second.isValid          = true;
                     ++r.revived;
+                } else if (ban_state_measured_for(height)) {
+                    // The gate is false and we KNOW it: a list dated exactly
+                    // at height-1 — the same pre-block list dashcore's
+                    // IsBanned() reads — attests this masternode not banned.
+                    // dashcore revives nothing here either. This zero is a
+                    // measurement, so it gets its own counter rather than
+                    // disappearing into `updated`.
+                    ++r.revive_declined_measured;
+                } else {
+                    // The gate is false and we DO NOT KNOW it. See
+                    // ApplyResult::revive_unmeasured. Nothing is guessed in
+                    // either direction — a guessed revive is as wrong as a
+                    // missed one, and both have been measured on mainnet.
+                    ++r.revive_unmeasured;
+                    r.revive_unmeasured_protx.push_back(ptx.proTxHash);
+                    LOG_WARNING
+                        << "[MNS-SM] ProUpServTx h=" << height << " for proTx "
+                        << ptx.proTxHash.GetHex().substr(0, 16)
+                        << " applied as a plain service update: this set"
+                           " believes the masternode NOT PoSe-banned, but that"
+                           " belief was never measured — the last wholesale"
+                           " ban-state fold is dated h="
+                        << (m_ban_state_measured_at == 0
+                                ? std::string("NEVER")
+                                : std::to_string(m_ban_state_measured_at))
+                        << ", not h=" << (height == 0 ? 0u : height - 1)
+                        << ". A PoSe ban is consensus-computed, never a"
+                           " transaction, so a ban that starts AND ends"
+                           " between two folds is invisible to a block replay."
+                           " If dashd had it banned here it set"
+                           " nPoSeRevivedHeight=" << height
+                        << " and we did not, and every later projection puts"
+                           " it ~one queue length ahead of the chain. Fold a"
+                           " list dated at h=" << (height == 0 ? 0u : height - 1)
+                        << " BEFORE applying this block to decide it.";
                 }
                 ++r.updated;
                 break;
@@ -1472,6 +1601,29 @@ private:
     // Forward-only apply cursor: height of the last block folded by
     // apply_block (0 = none since load). See ApplyResult::skipped_out_of_order.
     uint32_t m_last_applied_height{0};
+
+    // Height of the last wholesale ban-state reconcile (sync_validity_from_sml).
+    // 0 = the ban state in this set has NEVER been measured against a dated
+    // list; it is whatever the seed carried plus whatever transactions moved.
+    uint32_t m_ban_state_measured_at{0};
+
+    /// Walk every ProUpServTx in a block, in tx order, handing the caller the
+    /// proTxHash it names. The pre-scan and the apply BOTH go through here so
+    /// "what this block will do to the revive gate" has one definition.
+    /// Parse failures are skipped silently: apply_block logs them at the point
+    /// where it can also name the height.
+    template <typename Fn>
+    static void for_each_proupserv(const dash::coin::BlockType& block, Fn&& fn)
+    {
+        for (size_t i = 1; i < block.m_txs.size(); ++i) {
+            const auto& tx = block.m_txs[i];
+            if (tx.type != 2) continue;
+            if (tx.extra_payload.empty()) continue;
+            vendor::CProUpServTx ptx;
+            if (!vendor::parse_protx_payload(tx.extra_payload, ptx)) continue;
+            fn(ptx.proTxHash);
+        }
+    }
 
     // Compute a tx's identifying hash. Mirrors dashcore's
     // CTransaction::GetHash() which is SHA256d(serialized_tx).

--- a/test/test_dash_mn_checkpoint.cpp
+++ b/test/test_dash_mn_checkpoint.cpp
@@ -4068,6 +4068,14 @@ TEST(DashMnAnchorSeedCompleteness, ReinstatementReportSeparatesNoneFromImpossibl
         const std::string s = h.lane.reinstatement_report();
         EXPECT_NE(s.find("REINSTATEMENT: measurable"), std::string::npos) << s;
         EXPECT_EQ(s.find("NOT MEASURABLE"), std::string::npos) << s;
+        // ...and "measurable" is still not the whole truth. A complete anchor
+        // makes a revive REPRESENTABLE; it does not make an unobserved ban
+        // OBSERVABLE. Both branches of this report have to carry the
+        // second qualification, so a reader of either one is told which zero
+        // they are looking at.
+        EXPECT_NE(s.find("BAN-STATE PROBE"), std::string::npos)
+            << "a complete anchor still cannot see a PoSe ban that starts and"
+               " ends inside one fold interval: " << s;
     }
 }
 
@@ -4177,4 +4185,326 @@ TEST(DashMnPayeeTiebreak, ScoreOutranksTheHashWhenTheTieIsBroken)
         << "the lower CompareByLastPaid score must win even though the byte"
            " order puts the other masternode first — the tiebreak is a"
            " TIEbreak, not the primary key";
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 15. THE BAN-STATE PROBE — a ban that starts AND ends between two folds
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// MEASURED (mainnet, anchor 2513000, fold interval 500, replay to 2515511;
+// hotel dashd 23.1.7 asked directly for the PRE-BLOCK state of every
+// ProUpServTx in the window, 2026-08-03):
+//
+//   22 ProUpServTx in 2513001..2515530
+//   20 landed on a masternode dashd HAD banned            -> dashd revived
+//   15 of those 20 this replay also believed banned       -> applied
+//    5 it did not (banned AND revived between two folds)  -> MISSED
+//    2 landed on a masternode that was NOT banned         -> no revive, and
+//      dashd set no revive height either
+//
+// The replay's own progress line agreed: "+15 reinstated [0 SML-fold, 15
+// ProUpServTx]". Scored our way, the 5 missed masternodes reach the head of
+// our queue at 2515511 / ~2516175 / ~2516176 / ~2516332 / ~2517466 — and the
+// bridge fail-closed at 2515511 projecting the first of them, 80b4892b…,
+// which dashd does not pay until ~2516627. The failure ORDER is predicted by
+// the defect, not just the single failing height.
+//
+// 80b4892b… was PoSe-banned at 2514570 and revived at 2514574: a FOUR-BLOCK
+// ban inside the 2514150..2514650 fold interval. No cadence of fold points can
+// see that — a ban+revive pair fits between any two fixed samples — so the
+// repair is to sample AT the event: fold the list dated at the block BEFORE a
+// ProUpServTx whose revive turns on a ban we have not measured.
+namespace {
+
+constexpr uint32_t kRpAnchor = 2513000;
+constexpr uint32_t kRpTip    = 2513005;
+constexpr uint32_t kRpRevive = 2513003;   // the ProUpServTx block
+constexpr size_t   kRpRank   = 40;        // far from the queue head on purpose
+constexpr size_t   kRpSetSize = 64;
+
+// The ban is invisible to every fold point, by construction.
+static_assert(kRpRevive > kRpAnchor && kRpRevive < kRpTip,
+              "the ProUpServTx must land strictly between the anchor fold and"
+              " the tip fold");
+static_assert(kRpRevive - kRpAnchor < MnCheckpointLane::kDefaultFoldInterval,
+              "and strictly inside one fold interval — that is the defect");
+
+MutableTransaction pro_up_serv_tx_for(const uint256& protx)
+{
+    CProUpServTx p;
+    p.nVersion  = dash::coin::vendor::ProTxVersion::BASIC_BLS;
+    p.nType     = dash::coin::vendor::MnType::REGULAR;
+    p.proTxHash = protx;
+    p.netInfo.port_be = 0x2334;
+
+    MutableTransaction tx;
+    tx.type          = CProUpServTx::SPECIALTX_TYPE;
+    tx.extra_payload = protx_payload_bytes(p);
+    bitcoin_family::coin::TxIn in;
+    in.prevout.hash  = uint256{};
+    in.prevout.index = 0xFFFFFFFF;
+    in.sequence      = 0xFFFFFFFF;
+    tx.vin.push_back(in);
+    return tx;
+}
+
+// The measured shape, network-free:
+//   * every list attests every masternode VALID — including the anchor's and
+//     the tip's, so no fold point can ever learn of the ban;
+//   * EXCEPT the list dated at kRpRevive-1, which attests rank kRpRank banned.
+//     That is the only height at which the ban is observable at all;
+//   * block kRpRevive carries a ProUpServTx for rank kRpRank on top of the
+//     coinbase the chain actually produced.
+MnCheckpoint build_revive_probe_scenario(SnapshotRig& rig)
+{
+    const uint256 anchor_hash = uint256S(kAnchorHash);
+    MnCheckpoint cp = synthetic_anchor(kRpSetSize, kRpAnchor, anchor_hash);
+
+    std::vector<std::pair<uint256, bool>> all_valid, banned_one;
+    for (size_t i = 0; i < cp.entries.size(); ++i) {
+        all_valid.emplace_back(cp.entries[i].first, true);
+        banned_one.emplace_back(cp.entries[i].first, i != kRpRank);
+    }
+    rig.attest = all_valid;                       // the default at ANY height
+    rig.install(kRpAnchor, kRpTip, anchor_hash);
+    // The one height at which the ban exists.
+    rig.by_height[kRpRevive - 1] =
+        make_snapshot(rig.h.headers[kRpRevive - 1], kRpRevive - 1, banned_one);
+
+    rig.h.blocks = simulate_chain(cp, kRpAnchor, kRpTip, 0, {});
+    rig.h.blocks[kRpRevive].m_txs.push_back(
+        pro_up_serv_tx_for(cp.entries[kRpRank].first));
+    return cp;
+}
+
+void drive_to_publish(SnapshotRig& rig)
+{
+    for (uint32_t i = 0; i < 64 && !rig.h.published
+                         && !rig.h.lane.failed_closed(); ++i)
+        rig.h.lane.pump();
+}
+
+} // namespace
+
+// ── CASE 15.1 (THE LOAD-BEARING ONE). The revive must land with dashd's
+// height. PREVIOUSLY RED: no fold covers kRpRevive-1, so the machine believed
+// the masternode never banned, the gate read false, and nPoSeRevivedHeight
+// stayed at 0 while dashd set kRpRevive.
+TEST(DashMnCheckpointReviveProbe, BanBetweenFoldsIsMeasuredAtTheProUpServTx)
+{
+    SnapshotRig rig;
+    const auto cp = build_revive_probe_scenario(rig);
+
+    rig.h.lane.arm(cp);
+    drive_to_publish(rig);
+
+    ASSERT_TRUE(rig.h.published) << rig.h.lane.status();
+    EXPECT_EQ(rig.h.lane.revive_probes(), 1u)
+        << "exactly one ProUpServTx in this replay turned on an unmeasured"
+           " ban, so exactly one list should have been asked for";
+    EXPECT_EQ(rig.h.lane.revive_unmeasured(), 0u)
+        << "nothing may be left unmeasured when a probe was available: "
+        << rig.h.lane.revive_probe_report();
+    EXPECT_EQ(rig.h.lane.tx_revived(), 1u);
+
+    const MNState& revived = published_rank(rig.h, cp, kRpRank);
+    EXPECT_EQ(revived.nPoSeRevivedHeight, kRpRevive)
+        << "dashd scores this masternode by its revive height from here on."
+           " Leaving it at the stale last payment is what put mainnet"
+           " 80b4892b… at the head of our queue at 2515511, ~1100 blocks"
+           " before dashd will pay it.";
+    EXPECT_TRUE(revived.isValid);
+    EXPECT_EQ(revived.nPoSeBanHeight, 0u);
+    EXPECT_EQ(MnStateMachine::payee_score(revived),
+              static_cast<int>(kRpRevive));
+}
+
+// ── CASE 15.2. THE TWIN, with the probe disabled. Same chain, same lists —
+// the pre-change behaviour exactly. The revive is lost, and the ONLY
+// difference the change makes here is that the loss is now NAMED.
+TEST(DashMnCheckpointReviveProbe, ProbeDisabledLosesTheReviveAndSaysSo)
+{
+    SnapshotRig rig;
+    const auto cp = build_revive_probe_scenario(rig);
+    rig.h.lane.set_revive_probe_cap(0);
+
+    rig.h.lane.arm(cp);
+    drive_to_publish(rig);
+
+    ASSERT_TRUE(rig.h.published) << rig.h.lane.status();
+    EXPECT_EQ(rig.h.lane.revive_probes(), 0u);
+    EXPECT_EQ(rig.h.lane.revive_unmeasured(), 1u)
+        << "a ProUpServTx applied without measuring its gate is a BLIND SPOT"
+           " and must be counted, not swallowed into `updated`";
+    EXPECT_EQ(rig.h.lane.tx_revived(), 0u);
+    EXPECT_EQ(published_rank(rig.h, cp, kRpRank).nPoSeRevivedHeight, 0u)
+        << "this IS the defect, reproduced: our score for this masternode is"
+           " now its stale last payment and dashd's is the revive height";
+
+    const std::string s = rig.h.lane.revive_probe_report();
+    EXPECT_NE(s.find("UNKNOWN"), std::string::npos) << s;
+    EXPECT_NE(s.find("ABSENCE OF MEASUREMENT"), std::string::npos)
+        << "the report must say WHICH zero this is: " << s;
+    // And the reinstatement report — the line an operator actually reads —
+    // must carry it too, instead of a bare "reinstated 0".
+    EXPECT_NE(rig.h.lane.reinstatement_report().find("BAN-STATE PROBE"),
+              std::string::npos)
+        << rig.h.lane.reinstatement_report();
+}
+
+// ── CASE 15.3. "n/a", not "0". A replay in which no ProUpServTx ever needed a
+// probe has NOT measured zero blind spots; it has never exercised the path.
+// Same discipline as ondemand_report().
+TEST(DashMnCheckpointReviveProbe, NeverExercisedReportsNotApplicableNotZero)
+{
+    SnapshotRig rig;
+    const uint256 anchor_hash = uint256S(kAnchorHash);
+    const auto cp = synthetic_anchor(kRpSetSize, kRpAnchor, anchor_hash);
+    std::vector<std::pair<uint256, bool>> all_valid;
+    for (const auto& e : cp.entries) all_valid.emplace_back(e.first, true);
+    rig.attest = all_valid;
+    rig.install(kRpAnchor, kRpTip, anchor_hash);
+    rig.h.blocks = simulate_chain(cp, kRpAnchor, kRpTip, 0, {});
+
+    rig.h.lane.arm(cp);
+    drive_to_publish(rig);
+
+    ASSERT_TRUE(rig.h.published) << rig.h.lane.status();
+    EXPECT_EQ(rig.h.lane.revive_probes(), 0u);
+    EXPECT_EQ(rig.h.lane.revive_unmeasured(), 0u);
+    EXPECT_NE(rig.h.lane.revive_probe_report().find("n/a"), std::string::npos)
+        << "no ProUpServTx reached the probe path, so every number here is"
+           " NEVER EVALUATED — printing a bare 0 would claim a measurement: "
+        << rig.h.lane.revive_probe_report();
+}
+
+// ── CASE 15.4. An UNANSWERED probe must not wedge the bridge and must not
+// re-ask forever: the latch is on the height, so a re-delivered block cannot
+// re-open a request that was already abandoned. The blind spot survives and is
+// reported — that is the honest outcome, not a fail-closed.
+TEST(DashMnCheckpointReviveProbe, UnansweredProbeAbandonsWithoutWedgingOrRelooping)
+{
+    SnapshotRig rig;
+    const auto cp = build_revive_probe_scenario(rig);
+    // Answer the fold POINTS (anchor + tip) but never the probe.
+    rig.h.lane.set_request_snapshot_fn([&rig](const uint256& bh) {
+        rig.requested.push_back(bh);
+        auto hi = rig.height_of.find(bh);
+        if (hi == rig.height_of.end()) return;
+        if (hi->second == kRpRevive - 1) return;     // the probe: no reply
+        rig.h.lane.on_historical_snapshot(
+            rig.snapshot_for(hi->second, bh).diff);
+    });
+
+    rig.h.lane.arm(cp);
+    const uint32_t kBound = 8 * (MnCheckpointLane::kFoldGiveUpPumps + 2);
+    for (uint32_t i = 0; i < kBound && !rig.h.published
+                         && !rig.h.lane.failed_closed(); ++i)
+        rig.h.lane.pump();
+
+    EXPECT_TRUE(rig.h.published)
+        << "an unanswered PROBE must degrade, not wedge: " << rig.h.lane.status();
+    EXPECT_EQ(rig.h.lane.revive_probes(), 1u)
+        << "the latch is on the probed height, so the re-delivered block must"
+           " not open a second probe for it";
+    EXPECT_EQ(rig.h.lane.revive_unmeasured(), 1u)
+        << "the ambiguity survived unmeasured and has to say so";
+    size_t asks_for_the_probe = 0;
+    for (const auto& bh : rig.requested)
+        if (rig.height_of[bh] == kRpRevive - 1) ++asks_for_the_probe;
+    EXPECT_LE(asks_for_the_probe, MnCheckpointLane::kFoldRetryPumps + 1u)
+        << "the probe re-asked " << asks_for_the_probe
+        << " times — the give-up path is not bounding it";
+}
+
+// ── CASE 15.5. A re-arm replays the SAME heights from the SAME anchor. A latch
+// or a spent budget carried across would suppress exactly the probe the second
+// attempt exists to take.
+TEST(DashMnCheckpointReviveProbe, ReArmGivesTheSecondBridgeAFreshProbeBudget)
+{
+    SnapshotRig rig;
+    const auto cp = build_revive_probe_scenario(rig);
+    rig.h.lane.arm(cp);
+    drive_to_publish(rig);
+    ASSERT_TRUE(rig.h.published);
+    ASSERT_EQ(rig.h.lane.revive_probes(), 1u);
+
+    SnapshotRig rig2;
+    const auto cp2 = build_revive_probe_scenario(rig2);
+    rig2.h.lane.arm(cp2);
+    drive_to_publish(rig2);
+    ASSERT_TRUE(rig2.h.published);
+    ASSERT_EQ(rig2.h.lane.rearm(cp2, "test re-arm"),
+              MnCheckpointLane::RearmOutcome::Armed)
+        << rig2.h.lane.status();
+    EXPECT_EQ(rig2.h.lane.revive_probes(), 0u);
+    EXPECT_EQ(rig2.h.lane.revive_unmeasured(), 0u);
+    EXPECT_EQ(rig2.h.lane.revive_probe_cap(),
+              MnCheckpointLane::kReviveProbeBase)
+        << "a re-armed bridge must not quote the previous bridge's sized"
+           " budget before its own pump() has sized one";
+
+    rig2.h.published = false;
+    drive_to_publish(rig2);
+    ASSERT_TRUE(rig2.h.published) << rig2.h.lane.status();
+    EXPECT_EQ(rig2.h.lane.revive_probes(), 1u)
+        << "the second bridge must take the probe again — a latch left"
+           " standing would silently skip it";
+    EXPECT_EQ(published_rank(rig2.h, cp2, kRpRank).nPoSeRevivedHeight,
+              kRpRevive);
+}
+
+// ── CASE 15.6. The probe that answers "NOT banned" — mainnet d07e1f49… at
+// 2515068, which had ban height -1 and PoSe penalty 0. dashcore revives
+// nothing there, so neither may we; the point of the probe is that this zero
+// is now a MEASUREMENT rather than an assumption.
+//
+// It is also the case that pins ASK-ONCE. A snapshot answered INLINE re-enters
+// on_block_connected() with this very block while begin_fold() is still on the
+// stack, so "ask once" is a property of the code, not of the call graph. What
+// terminates it here is that the fold RECORDS its own date: the re-entry finds
+// the ban state measured for this height and has nothing left to ask about.
+// Mutating the probe to fold the WRONG height removes that and the request
+// count went to 3377 — which is the mutation this assertion is here for.
+//
+// The height LATCH is the second, independent terminator, and it is the only
+// one left when the probe goes UNANSWERED (no reply, no recorded date). That
+// case is CASE 15.4, not this one.
+TEST(DashMnCheckpointReviveProbe, ProbeAnsweringNotBannedIsAMeasurementAndAsksOnce)
+{
+    SnapshotRig rig;
+    const uint256 anchor_hash = uint256S(kAnchorHash);
+    const auto cp = synthetic_anchor(kRpSetSize, kRpAnchor, anchor_hash);
+    std::vector<std::pair<uint256, bool>> all_valid;
+    for (const auto& e : cp.entries) all_valid.emplace_back(e.first, true);
+    rig.attest = all_valid;                       // NO ban at any height
+    rig.install(kRpAnchor, kRpTip, anchor_hash);
+    rig.h.blocks = simulate_chain(cp, kRpAnchor, kRpTip, 0, {});
+    rig.h.blocks[kRpRevive].m_txs.push_back(
+        pro_up_serv_tx_for(cp.entries[kRpRank].first));
+
+    rig.h.lane.arm(cp);
+    drive_to_publish(rig);
+
+    ASSERT_TRUE(rig.h.published) << rig.h.lane.status();
+    EXPECT_EQ(rig.h.lane.revive_probes(), 1u);
+    EXPECT_EQ(rig.h.lane.revive_declined(), 1u)
+        << "a list dated at h-1 attesting NOT banned is an answer, and has to"
+           " be counted apart from 'we never looked'";
+    EXPECT_EQ(rig.h.lane.revive_unmeasured(), 0u);
+    EXPECT_EQ(rig.h.lane.tx_revived(), 0u);
+    EXPECT_EQ(published_rank(rig.h, cp, kRpRank).nPoSeRevivedHeight, 0u)
+        << "dashd set no revive height here either — writing one would move"
+           " this masternode DOWN the queue and diverge the other way";
+
+    size_t asks = 0;
+    for (const auto& bh : rig.requested)
+        if (rig.height_of[bh] == kRpRevive - 1) ++asks;
+    EXPECT_EQ(asks, 1u)
+        << "the probe asked " << asks << " times for h=" << (kRpRevive - 1)
+        << " — the latch is not closing over an INLINE reply, which re-enters"
+           " on_block_connected() before begin_fold() returns";
+    EXPECT_NE(rig.h.lane.revive_probe_report().find("0 left unmeasured"),
+              std::string::npos)
+        << rig.h.lane.revive_probe_report();
 }

--- a/test/test_dash_mn_state.cpp
+++ b/test/test_dash_mn_state.cpp
@@ -1374,3 +1374,212 @@ TEST(DashMnState, SmlRecoveryExclusionSurvivesTheNextQueueTurn) {
     EXPECT_EQ(m.sml_recovered_total(), 1u);
     EXPECT_EQ(m.entries().at(b).nLastPaidHeight, 2400002u);
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// THE BAN WE NEVER MEASURED — ProUpServTx revive gate vs fold sampling
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// dashcore revives on a ProUpServTx iff the masternode IsBanned() in the
+// PRE-BLOCK list. This machine mirrors that gate against ITS OWN belief about
+// who is banned — and that belief only ever changes at a fold. A PoSe ban is
+// consensus-computed, never a transaction, so a ban that starts AND ends
+// between two folds never enters the belief, the gate reads false, and
+// nPoSeRevivedHeight is left at the masternode's stale last payment while
+// dashd moves it to the revive height.
+//
+// TRACED ON MAINNET (2026-08-03, anchor 2513000, fold interval 500): proTx
+// 80b4892b… banned at 2514570, revived by a ProUpServTx at 2514574 — four
+// blocks, entirely inside the 2514150..2514650 fold interval. We scored it
+// 2513453 (its last payment); dashd scored it 2514574. That put it at the head
+// of OUR queue at 2515511 and at rank 1116 of dashd's.
+//
+// The obvious repair — set nPoSeRevivedHeight on EVERY ProUpServTx — is
+// refuted by the same window: 2 of its 22 ProUpServTx came from masternodes
+// that were NOT banned (d07e1f49… at 2515068, ban height -1, PoSe penalty 0)
+// and dashd set no revive height for them. So the machine must MEASURE the
+// gate, and where it cannot, say so.
+
+namespace {
+
+// A masternode set holding one entry that is valid and unbanned — the state in
+// which a ProUpServTx's outcome depends entirely on a ban we may not have seen.
+struct ReviveFixture {
+    MnStateMachine m;
+    uint256        mn;
+    BlockType      blk;      // coinbase pays `mn`, plus a ProUpServTx for it
+
+    explicit ReviveFixture(uint32_t last_paid = 2513453)
+    {
+        mn = raw256_byte(0, 0x5A);
+        MNState s;
+        s.isValid             = true;
+        s.nRegisteredHeight   = 2400000;
+        s.nLastPaidHeight     = last_paid;
+        s.nPoSeBanHeight      = 0;
+        s.nPoSeRevivedHeight  = 0;
+        s.scriptPayout.m_data = script_bytes(0xE1);
+        m.load(std::vector<std::pair<uint256, MNState>>{{mn, s}}, 2514573);
+
+        CProUpServTx ups;
+        ups.nVersion  = ProTxVersion::BASIC_BLS;
+        ups.nType     = MnType::REGULAR;
+        ups.proTxHash = mn;
+        ups.netInfo.ip = seq_array<16>(0x22);
+        ups.netInfo.port_be = 0x2334;
+        ups.inputsHash = raw256(0x41);
+        ups.sig        = seq_array<96>(0x42);
+        blk.m_txs.push_back(coinbase_tx({script_bytes(0xE1)}));
+        blk.m_txs.push_back(
+            special_tx(CProUpServTx::SPECIALTX_TYPE, protx_payload(ups)));
+    }
+
+    // Fold a list dated at `height` attesting `mn` valid/invalid.
+    void fold(uint32_t height, bool valid)
+    {
+        CSimplifiedMNListEntry e;
+        e.proRegTxHash = mn;
+        e.isValid      = valid;
+        m.sync_validity_from_sml(
+            CSimplifiedMNList(std::vector<CSimplifiedMNListEntry>{e}), height);
+    }
+};
+
+} // namespace
+
+// ── CASE A. No fold dated at the pre-block height: the revive outcome is
+// UNKNOWN and must be counted as such. Nothing is guessed in either direction.
+TEST(DashMnReviveBanState, UnmeasuredBanIsCountedNotGuessed) {
+    ReviveFixture f;
+    ASSERT_EQ(f.m.ban_state_measured_at(), 0u);
+    ASSERT_FALSE(f.m.ban_state_measured_for(2514574));
+
+    const auto r = f.m.apply_block(f.blk, 2514574);
+    EXPECT_EQ(r.revive_unmeasured, 1u)
+        << "a ProUpServTx whose revive turns on a ban state this set never"
+           " measured is a BLIND SPOT and has to be counted as one";
+    ASSERT_EQ(r.revive_unmeasured_protx.size(), 1u);
+    EXPECT_EQ(r.revive_unmeasured_protx.front(), f.mn)
+        << "the report must NAME the masternode, not just count it";
+    EXPECT_EQ(r.revived, 0u);
+    EXPECT_EQ(r.revive_declined_measured, 0u);
+    EXPECT_EQ(r.updated, 1u) << "the service update itself still applies";
+    // The refuted repair, pinned: nothing is written to the revive height on a
+    // ban we did not measure. Mutating the else-branch into
+    // `nPoSeRevivedHeight = height` reds exactly here.
+    EXPECT_EQ(f.m.entries().at(f.mn).nPoSeRevivedHeight, 0u)
+        << "mainnet d07e1f49… sent a ProUpServTx at 2515068 while NOT banned"
+           " (ban height -1, PoSe penalty 0) and dashd set no revive height."
+           " Guessing one there moves the masternode 1568 blocks DOWN the"
+           " queue — a divergence in the other direction, not a fix.";
+}
+
+// ── CASE B. A list dated EXACTLY at the pre-block height attesting the
+// masternode NOT banned. dashcore revives nothing here and neither do we — but
+// this zero is a MEASUREMENT and gets its own counter.
+TEST(DashMnReviveBanState, MeasuredNotBannedIsADifferentZero) {
+    ReviveFixture f;
+    f.fold(2514573, /*valid=*/true);
+    ASSERT_EQ(f.m.ban_state_measured_at(), 2514573u);
+    ASSERT_TRUE(f.m.ban_state_measured_for(2514574));
+
+    const auto r = f.m.apply_block(f.blk, 2514574);
+    EXPECT_EQ(r.revive_declined_measured, 1u);
+    EXPECT_EQ(r.revive_unmeasured, 0u)
+        << "'the list at h-1 says not banned' and 'we never looked' are"
+           " different facts and must not share a counter";
+    EXPECT_TRUE(r.revive_unmeasured_protx.empty());
+    EXPECT_EQ(r.revived, 0u);
+    EXPECT_EQ(f.m.entries().at(f.mn).nPoSeRevivedHeight, 0u);
+}
+
+// ── CASE C. The same list dated at the same height, attesting the masternode
+// BANNED. That is the mainnet 80b4892b… shape, and the revive must land with
+// dashd's height.
+TEST(DashMnReviveBanState, MeasuredBanAtThePreBlockHeightLandsTheRevive) {
+    ReviveFixture f;
+    f.fold(2514573, /*valid=*/false);
+    ASSERT_FALSE(f.m.entries().at(f.mn).isValid);
+    ASSERT_EQ(f.m.entries().at(f.mn).nPoSeBanHeight, 2514573u);
+
+    const auto r = f.m.apply_block(f.blk, 2514574);
+    EXPECT_EQ(r.revived, 1u);
+    EXPECT_EQ(r.revive_unmeasured, 0u);
+    EXPECT_EQ(r.revive_declined_measured, 0u);
+    const MNState& back = f.m.entries().at(f.mn);
+    EXPECT_TRUE(back.isValid);
+    EXPECT_EQ(back.nPoSeBanHeight, 0u);
+    EXPECT_EQ(back.nPoSeRevivedHeight, 2514574u)
+        << "dashd scores this masternode by its revive height from here on;"
+           " scoring it by its last payment (2513453) puts it at the head of"
+           " our queue ~1100 blocks before dashd will pay it";
+    EXPECT_EQ(MnStateMachine::payee_score(back), 2514574);
+}
+
+// ── CASE D. A list dated at the WRONG height is not a measurement of this
+// block's gate. h-2 cannot speak for h-1: the ban we are looking for is
+// exactly the kind that lasts four blocks.
+TEST(DashMnReviveBanState, AListDatedOffByOneIsNotAMeasurement) {
+    ReviveFixture f;
+    f.fold(2514572, /*valid=*/true);          // one block too early
+    EXPECT_FALSE(f.m.ban_state_measured_for(2514574));
+    const auto r = f.m.apply_block(f.blk, 2514574);
+    EXPECT_EQ(r.revive_unmeasured, 1u);
+    EXPECT_EQ(r.revive_declined_measured, 0u);
+}
+
+// ── CASE E. The pre-scan and the apply must agree about what a block contains,
+// because the whole repair is "ask BEFORE applying". They share the predicate;
+// this pins that they cannot drift.
+TEST(DashMnReviveBanState, PreScanAgreesWithTheApply) {
+    {
+        ReviveFixture f;
+        const auto cands = f.m.unmeasured_revive_candidates(f.blk, 2514574);
+        ASSERT_EQ(cands.size(), 1u);
+        EXPECT_EQ(cands.front(), f.mn);
+        EXPECT_EQ(f.m.apply_block(f.blk, 2514574).revive_unmeasured,
+                  cands.size());
+    }
+    {   // measured at h-1: nothing to ask about
+        ReviveFixture f;
+        f.fold(2514573, true);
+        EXPECT_TRUE(f.m.unmeasured_revive_candidates(f.blk, 2514574).empty());
+        EXPECT_EQ(f.m.apply_block(f.blk, 2514574).revive_unmeasured, 0u);
+    }
+    {   // already believed banned: the gate is decided, no ambiguity
+        ReviveFixture f;
+        f.fold(2514573, false);
+        EXPECT_TRUE(f.m.unmeasured_revive_candidates(f.blk, 2514574).empty());
+        const auto r = f.m.apply_block(f.blk, 2514574);
+        EXPECT_EQ(r.revive_unmeasured, 0u);
+        EXPECT_EQ(r.revived, 1u);
+    }
+    {   // proTxHash we do not hold at all: that is revive_dropped_unknown, a
+        // DIFFERENT defect (seed completeness) with its own counter. A probe
+        // would tell us nothing, so it must not be requested.
+        ReviveFixture f;
+        f.m.load(std::vector<std::pair<uint256, MNState>>{}, 2514573);
+        EXPECT_TRUE(f.m.unmeasured_revive_candidates(f.blk, 2514574).empty());
+        const auto r = f.m.apply_block(f.blk, 2514574);
+        EXPECT_EQ(r.revive_unmeasured, 0u);
+        EXPECT_EQ(r.revive_dropped_unknown, 1u);
+    }
+}
+
+// ── CASE F. A measurement describes the ENTRIES it was folded into. Replacing
+// them (a re-seed / re-arm) retires it — otherwise a re-armed bridge would
+// believe it had measured a set it has never looked at.
+TEST(DashMnReviveBanState, LoadRetiresTheMeasurement) {
+    ReviveFixture f;
+    f.fold(2514573, true);
+    ASSERT_TRUE(f.m.ban_state_measured_for(2514574));
+
+    MNState s;
+    s.isValid             = true;
+    s.nRegisteredHeight   = 2400000;
+    s.nLastPaidHeight     = 2513453;
+    s.scriptPayout.m_data = script_bytes(0xE1);
+    f.m.load(std::vector<std::pair<uint256, MNState>>{{f.mn, s}}, 2514573);
+    EXPECT_EQ(f.m.ban_state_measured_at(), 0u);
+    EXPECT_FALSE(f.m.ban_state_measured_for(2514574));
+    EXPECT_EQ(f.m.apply_block(f.blk, 2514574).revive_unmeasured, 1u);
+}


### PR DESCRIPTION
## The defect

`#1043` moved the failing height from 2515416 to 2515511. At 2515511 the daemonless
bridge projects proTx `80b4892bf01e19ef…`; the chain paid `7017218c756cb3f2…`. The
on-demand fold cannot repair it, and its own fail-closed line says why: *"the SML
attests it VALID — so this is NOT an unobserved PoSe ban."*

`80b4892b…` was PoSe-banned by dashd at **2514570** and revived by a ProUpServTx at
**2514574**. A four-block ban, entirely inside the 2514150..2514650 fold interval.

`MnStateMachine::apply_block`'s ProUpServTx branch mirrors dashcore
(`specialtxman.cpp:361-370`) exactly: revive iff the masternode `IsBanned()`. The
mirror is only as good as our belief about who is banned — and a PoSe ban is
consensus-computed, never a transaction, so a block replay can never observe one. We
learn of bans **only** by folding a masternode list sampled at discrete heights. A ban
that starts *and ends* between two samples never enters the belief at all: the gate
reads false, `nPoSeRevivedHeight` is left at the masternode's stale last payment, and
`payee_score()` sorts it roughly one full queue length ahead of where dashd sorts it.

Our score for `80b4892b…` was 2513453 (its last payment). dashd's was 2514574.
That put it at **rank 0 of our queue and rank 1116 of dashd's** at h=2515511.

## It generalises — the whole window, not one height

Every ProUpServTx in 2513001..2515530 (22 of them), with the **pre-block** state asked
of dashd directly (`protx list registered true h-1`, hotel primary, Dash Core 23.1.7):

| tx height | proTx | dashd ban @ h-1 | dashd revives | we believed banned | verdict |
|---|---|---|---|---|---|
| 2513357 | 7afbd798 | 2511957 | yes | yes | applied |
| 2513869 | 2808c6d3 | 2512266 | yes | yes | applied |
| 2514283 | 3da232a3 | 2514282 | yes | **no** | **MISSED** |
| 2514284 | 3da232a3 | −1 | no | no | correct no-op |
| 2514458 | de39d198 | 2503050 | yes | yes | applied |
| 2514574 | 80b4892b | 2514570 | yes | **no** | **MISSED** |
| 2514620 | 32cd6825 | 2513723 | yes | yes | applied |
| 2514670 | 594ce04d | 2514282 | yes | yes | applied |
| 2514749 | 7daa17e4 | 2513892 | yes | yes | applied |
| 2514917 | 5366fffe | 2513994 | yes | yes | applied |
| 2515005 | bf915754 | 2420682 | yes | yes | applied |
| 2515068 | 5543983a | 2503338 | yes | yes | applied |
| 2515068 | d07e1f49 | −1 | no | no | correct no-op |
| 2515071 | 5031dfff | 2513994 | yes | yes | applied |
| 2515139 | e064e3a4 | 2514131 | yes | yes | applied |
| 2515219 | 2c325600 | 2513418 | yes | yes | applied |
| 2515219 | 2e52e4f2 | 2513994 | yes | yes | applied |
| 2515219 | e8626fcd | 2513418 | yes | yes | applied |
| 2515397 | 34275283 | 2515331 | yes | yes | applied |
| 2515421 | edf362e5 | 2515403 | yes | **no** | **MISSED** |
| 2515440 | 34275283 | 2515434 | yes | **no** | **MISSED** |
| 2515440 | a9447e21 | 2515434 | yes | **no** | **MISSED** |

"we believed banned" is reconstructed from the anchor plus the eight folds the soak
actually took (2513000, 2513489, 2513860, 2514150, 2514650, 2514874, 2515374, 2515511).
It totals **15 applied** — the running binary's own progress line says
`+15 reinstated [0 SML-fold, 15 ProUpServTx]`. The model is not fitted to the failing
height; it reproduces the replay's counter.

**The five missed revives predict the whole failure schedule.** Scoring the 2515510
eligible set (2070 masternodes) our way vs dashd's:

| proTx | our score | dashd score | our rank | dashd rank | we project head at | dashd pays at |
|---|---|---|---|---|---|---|
| 80b4892b | 2513453 | 2514574 | **0** | 1116 | **2515511** | ~2516627 |
| a9447e21 | 2514121 | 2515440 | 664 | 1998 | ~2516175 | ~2517509 |
| edf362e5 | 2514122 | 2515421 | 665 | 1977 | ~2516176 | ~2517488 |
| 3da232a3 | 2514277 | 2514283 | 821 | 824 | ~2516332 | ~2516335 |
| 34275283 | 2515397 | 2515440 | 1955 | 1997 | ~2517466 | ~2517508 |

Our head at 2515510 is `80b4892b…` (score 2513453); dashd's is `7017218c…` (score
2513454) — the masternode the chain actually paid. Our queue is dashd's queue with
exactly **one extra entry inserted at the front**, and the next four failures are
already scheduled.

## Why "set revivedHeight on every ProUpServTx" is refused

Two of the 22 came from masternodes that were **not** banned — `d07e1f49…` at 2515068
(ban height −1, PoSe penalty 0) and the second `3da232a3…` at 2514284 (revived one
block earlier). dashd set no revive height for either. Writing one moves `d07e1f49…`
from score 2513500 to 2515068 — **1568 blocks down the queue** — and fails the other
way round at ~2515558, 47 blocks past the height we fail at today. The transaction does
not carry the answer. The ban state has to be measured.

## Why not shrink the fold interval

It cannot work at any interval. A ban+revive pair fits between any two fixed samples —
`80b4892b…`'s was four blocks wide — so a finer cadence shrinks the window while paying
a round trip continuously, ban or no ban. At interval 1 it is not a replay any more, it
is a list fetch per block: the daemon dependency this lane exists to remove.

## What this does instead: sample at the event

The set of heights at which an unobserved ban can *permanently* move a masternode's
queue position is exactly the set of heights carrying a ProUpServTx for a masternode we
hold and believe valid — nowhere else does the ban state feed a field that outlives the
ban. So the replay folds at those heights and only those.

Before applying block *h*, the lane pre-scans it. If it carries a ProUpServTx whose
revive turns on a ban we have not measured, it folds the list dated at ***h−1*** — the
exact pre-block list dashcore's `IsBanned()` reads — and then applies the block. The
existing revive gate then fires, or does not, on measured evidence.

This is the **ordinary fold**: same request, same DIP-4 client verification, same
one-in-flight pause, same `cursor == H`-by-construction invariant (the cursor stands on
*h−1* when the probe is issued). No new trust, no new reply route. On the measured
window it is 7 probes across 2530 blocks (~0.3%) against 5 permanent divergences
removed. An unobserved ban still costs *eligibility* while it lasts, but that is
transient and already carried by the on-demand fold at the mismatch it causes.

## The zero that means "not measured"

`+0 revived` and `REINSTATED: 0 by SML fold` currently read as reassurance. #1043 added
a report guard for the anchor-ineligible==0 case. This extends the same discipline:

- `ApplyResult::revive_unmeasured` (+ the proTxHashes) — ProUpServTx applied with the
  pre-block ban state unknown. **Non-zero is a blind spot, not a statistic.**
- `ApplyResult::revive_declined_measured` — a list dated at *h−1* proved this was not a
  revive. This zero **is** a measurement, and has its own counter.
- `MnCheckpointLane::revive_probe_report()` — `n/a` when the path was never exercised,
  never a bare `0`; names the cap and whether it was exhausted. Carried in
  `reinstatement_report()` (both branches), `divergence_report()` and `status()`.
- The fold's `+0 revived` line now scopes itself: it says no masternode *this set held
  as banned* is attested valid by *this list*, and states that a ban beginning and
  ending inside an interval appears in no fold's input — with the probe counts.

## Tests — which test covers which claim

`test/test_dash_mn_state.cpp` (`DashMnReviveBanState`)

| test | claim |
|---|---|
| `UnmeasuredBanIsCountedNotGuessed` | an unmeasured gate is counted and NAMED, and nothing is written to `nPoSeRevivedHeight` (the refuted repair) |
| `MeasuredNotBannedIsADifferentZero` | a list dated at *h−1* saying "not banned" is a measurement, on its own counter |
| `MeasuredBanAtThePreBlockHeightLandsTheRevive` | the 80b4892b… shape: measured ban ⇒ revive lands with dashd's height and dashd's score |
| `AListDatedOffByOneIsNotAMeasurement` | *h−2* cannot speak for *h−1* |
| `PreScanAgreesWithTheApply` | pre-scan and apply share the predicate; unknown proTxHash stays `revive_dropped_unknown`, not a probe |
| `LoadRetiresTheMeasurement` | a measurement describes the entries it was folded into |

`test/test_dash_mn_checkpoint.cpp` (`DashMnCheckpointReviveProbe`)

| test | claim |
|---|---|
| `BanBetweenFoldsIsMeasuredAtTheProUpServTx` | **the load-bearing one** — ban visible at exactly one height, invisible to every fold point; the revive lands |
| `ProbeDisabledLosesTheReviveAndSaysSo` | the twin at `set_revive_probe_cap(0)`: pre-change behaviour reproduced, and now NAMED |
| `NeverExercisedReportsNotApplicableNotZero` | `n/a`, not `0` |
| `UnansweredProbeAbandonsWithoutWedgingOrRelooping` | an unanswered probe degrades, the height latch bounds the re-asks, the blind spot is reported |
| `ReArmGivesTheSecondBridgeAFreshProbeBudget` | budget and latch are per-bridge |
| `ProbeAnsweringNotBannedIsAMeasurementAndAsksOnce` | the `d07e1f49…` shape end-to-end; ask-once |
| `DashMnAnchorSeedCompleteness.ReinstatementReportSeparatesNoneFromImpossible` (extended) | a *complete* anchor's "measurable" is still qualified by the probe line |

## Mutation results

| mutation | red |
|---|---|
| M1 probe removed | `BanBetweenFoldsIsMeasuredAtTheProUpServTx`, `ReArmGivesTheSecondBridgeAFreshProbeBudget`, `UnansweredProbeAbandonsWithoutWedgingOrRelooping` |
| M2 set `nPoSeRevivedHeight` on every ProUpServTx (the refuted repair) | `UnmeasuredBanIsCountedNotGuessed`, `ProbeDisabledLosesTheReviveAndSaysSo` |
| M3 probe folds *h* instead of *h−1* | `BanBetweenFolds…`, `ProbeAnsweringNotBanned…`, `ReArmGives…` |
| M5 height latch removed | `UnansweredProbeAbandonsWithoutWedgingOrRelooping` |
| M6 a stale list counts as a measurement (`>=` for `==`) | 6 tests across both suites |
| M7 `load()` keeps a retired measurement | `LoadRetiresTheMeasurement` |
| M8 the fold does not record its own date | `ProbeAnsweringNotBanned…`, `LoadRetires…`, `MeasuredNotBanned…`, `PreScanAgrees…` |
| M9 "never evaluated" prints `0` | `NeverExercisedReportsNotApplicableNotZero` |
| M10 probe line dropped from `reinstatement_report()` | `ReinstatementReportSeparatesNoneFromImpossible` |

M3 also found a real re-entrancy bug in the first draft: `m_request_snapshot` may be
answered **inline**, which re-enters `on_block_connected()` with the same block while
`begin_fold()` is still on the stack. The latch is now set *before* the request. That
ordering is defence-in-depth rather than independently observable — moving it back
(M4) survives, because the fold recording its own date already terminates the answered
case, and the latch is the only terminator left in the *unanswered* case, which M5
kills.

## Not established

- **h=2513168 and h=2513261 remain untraced** and out of scope. One new fact for
  whoever picks them up: each is exactly *ProRegTx height + 1* (registrations at
  2513167 and 2513260), and the projected payee at each is that ProRegTx's own
  proTxHash. `payee_score()` should score a fresh registration at its
  `nRegisteredHeight`, which is far from the queue head, so something is bypassing or
  zeroing that — a distinct defect, not this one.
- The competing hypothesis (a missed / out-of-order block-connect) is **ruled out for
  2515511**, not in general: `gap_detected` refuses non-contiguous applies, the soak
  applied 2500 contiguous blocks from the anchor, and the top of our queue matches
  dashd's scores entry for entry except for the one inserted masternode — a missed
  connect would show as a *stale lastPaidHeight*, and `80b4892b…`'s lastPaid agrees
  with dashd's exactly.
- Verified offline against dashd and in unit tests. **Not yet re-soaked**: the next
  live replay past 2515511 is the real confirmation, and the four later predicted
  failure heights (~2516175, ~2516176, ~2516332, ~2517466) are the falsification test.
