### PR TITLE
dash(daemonless): make the MN-bridge re-arm ladder reachable after a fail-close

### DIFF
--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -480,6 +480,11 @@ public:
         auto say = [&](RearmOutcome o, const std::string& detail) {
             m_last_rearm_reason = std::string(rearm_outcome_name(o)) + ": "
                                   + detail;
+            // WHO pulled the trigger, kept separately from WHAT happened. With
+            // two callers (the maintainer's ask and the lane's own tip-seam
+            // poll) "a re-arm occurred" no longer identifies the path, and the
+            // path is the thing this file got wrong.
+            m_last_rearm_trigger = why;
             std::ostringstream ln;
             ln << "[MN-CKPT] RE-ARM " << rearm_outcome_name(o)
                << " (ask #" << m_rearm_asks << ", attempt " << attempt_s
@@ -621,6 +626,181 @@ public:
                    " the dashd fallback.");
     }
 
+    // ─────────────────────────────────────────────────────────────────────
+    // SELF RE-ARM — the trigger path that SURVIVES the failure it recovers
+    // ─────────────────────────────────────────────────────────────────────
+    //
+    // WHAT WAS BROKEN (measured, contabo daemonless soak0803c/d, 2026-08-03).
+    // rearm() had exactly ONE caller: main_dash's
+    // maintainer->set_on_mn_reseed callback. That callback has exactly ONE
+    // invoker: CoinStateMaintainer::on_block_connected's payee-desync /
+    // apply-gap branch. That branch can only fire when apply_block resolves a
+    // PROJECTED payee — i.e. on a NON-EMPTY payee queue — and its own first act
+    // is to WIPE that queue (mnstates().load({}), which also zeroes the apply
+    // cursor, so gap_detected cannot fire either). Only a lane PUBLISH refills
+    // it. So the ask chain is a closed cycle:
+    //
+    //     ask -> rearm() -> bridge -> PUBLISH -> queue refilled -> next ask
+    //
+    // and a bridge that FAILS CLOSED never publishes, so a second ask is
+    // arithmetically impossible. The re-arm ladder was triggerable only by an
+    // event that its own failure had already made unreachable.
+    //
+    // THE MEASUREMENT, verbatim. soak0803c failed closed at 06:13:50 with
+    // "re-arms remaining: 2 — a further payee desync from the maintainer will
+    // trigger one". 2h39m later the process was alive, the tip had advanced 69
+    // blocks (2515479 -> 2515548, i.e. 68 blocks PAST the 64-block backoff
+    // gate at h=2515543), 90 templates had been served, the EMBED-GATE
+    // heartbeat was still printing "cause=mn-needs-reseed value=latched" every
+    // five minutes — and there were ZERO further asks and ZERO MN-CKPT lines of
+    // any kind. Those two remaining rungs were never available capacity; they
+    // were UNREACHABLE capacity, and the log said the opposite.
+    //
+    // WHY THE FIX IS THE TRIGGER AND NOT THE POLICY. pump() is already invoked
+    // on EVERY tip change (main_dash's header_chain->set_on_tip_changed) and is
+    // the one lane seam that keeps running after a fail-close — it simply
+    // returned at its state guard. It now re-evaluates the ladder FIRST. The
+    // attempt still goes through rearm(), so everything that bounded the ladder
+    // still bounds it: the kMaxRearms cap, the doubling block backoff, the
+    // never-a-newer-anchor guards and every terminal block are unchanged. What
+    // changed is only WHO may pull the trigger — a caller that is still alive
+    // when the payee queue is wiped.
+    //
+    // AND IT MUST NOT REPLAY A WINDOW THAT WOULD FAIL IDENTICALLY. Two bounds,
+    // both named in the log:
+    //   1. the gate (rearm_gate_height): the chain must advance
+    //      kRearmBackoffBlocks past the tip AT WHICH THE LANE FAILED CLOSED, on
+    //      top of the existing per-re-arm ladder backoff. Without the first
+    //      half, the ORIGINAL arm's fail-close (m_rearms == 0, so no ladder
+    //      backoff applies yet) would self re-arm on the very next block over
+    //      the identical window.
+    //   2. the deterministic-repeat block (fail_closed): if a RE-ARMED replay
+    //      dies at the same cursor height as the previous one, that is measured
+    //      proof the failure is deterministic — the ladder is blocked
+    //      TERMINALLY and says so, instead of spending its remaining rungs on
+    //      the same block.
+
+    /// The tip height at or after which the NEXT re-arm is admissible.
+    /// 0 means NO height admits one (cap spent, terminally blocked, or the tip
+    /// at the fail-close was never observed) — 0 is never a real gate height,
+    /// so it is safe as the sentinel.
+    uint32_t rearm_gate_height() const
+    {
+        if (m_rearm_blocked || m_rearms >= kMaxRearms) return 0;
+        if (!m_failed_at_tip_known)                    return 0;
+        uint32_t gate = m_failed_at_tip + kRearmBackoffBlocks;
+        if (m_rearms > 0 && m_last_rearm_at_known) {
+            const uint32_t ladder =
+                m_last_rearm_at + (kRearmBackoffBlocks << (m_rearms - 1));
+            if (ladder > gate) gate = ladder;
+        }
+        return gate;
+    }
+
+    /// Is there a LIVE path that can still spend the remaining ladder? This is
+    /// the question "re-arms remaining: 2" used to answer wrongly.
+    bool rearm_self_reachable() const
+    {
+        return m_state == State::FailedClosed && m_rearm_pending
+               && !m_rearm_blocked && m_rearms < kMaxRearms
+               && static_cast<bool>(m_tip_height) && rearm_gate_height() != 0;
+    }
+
+    /// The ladder's posture as ONE greppable sentence that distinguishes
+    /// exhausted / terminally blocked / structurally unreachable / waiting on
+    /// backoff / ready. A remaining-count on its own is not an answer: the
+    /// defect this replaces printed "re-arms remaining: 2" for 2h39m about
+    /// capacity nothing could spend.
+    std::string rearm_posture() const
+    {
+        std::ostringstream o;
+        o << "RE-ARM POSTURE: "
+          << (m_rearms == 0
+                  ? std::string("the ORIGINAL arm is down")
+                  : ("RE-ARM " + std::to_string(m_rearms) + "/"
+                     + std::to_string(kMaxRearms) + " is down"))
+          << "; re-seed asks so far: " << m_rearm_asks << "; ";
+        if (m_rearm_blocked) {
+            o << "further re-arms are TERMINALLY BLOCKED ("
+              << m_rearm_block_reason << ") — remaining capacity: NONE";
+        } else if (m_rearms >= kMaxRearms) {
+            o << "the re-arm cap of " << kMaxRearms
+              << " is EXHAUSTED — remaining capacity: NONE";
+        } else if (m_state != State::FailedClosed || !m_rearm_pending) {
+            o << "re-arms remaining: " << (kMaxRearms - m_rearms)
+              << ", none wanted — the lane is not in a failed-closed state that"
+                 " asks for one";
+        } else if (!m_tip_height || !m_failed_at_tip_known) {
+            o << "re-arms remaining: " << (kMaxRearms - m_rearms)
+              << " but STRUCTURALLY UNREACHABLE: no tip-height seam is wired, so"
+                 " the lane has no live trigger and no way to measure the"
+                 " backoff. This capacity CANNOT be spent by this process";
+        } else {
+            const uint32_t gate = rearm_gate_height();
+            const uint32_t now  = m_tip_height();
+            o << "re-arms remaining: " << (kMaxRearms - m_rearms)
+              << " and REACHABLE: the lane re-arms ITSELF on a tip advance at"
+                 " h>=" << gate << " (tip h=" << now << " — "
+              << (now >= gate
+                      ? std::string("gate CLEARED, the next tip advance re-arms")
+                      : ("waiting on " + std::to_string(gate - now)
+                         + " more block(s)"))
+              << "). No further maintainer desync ask is needed, and none is"
+                 " possible: the wiped payee queue cannot project a payee, so it"
+                 " cannot desync again until this bridge publishes.";
+        }
+        return o.str();
+    }
+
+    /// The TICK. Called from pump() — which main_dash drives on every tip
+    /// change — and therefore from a path that is still alive after the
+    /// fail-close it recovers from. Returns true when a re-arm was ARMED.
+    ///
+    /// Cheap by construction: on the overwhelmingly common path it does two
+    /// bool tests and returns. The anchor is only COPIED when the gate has
+    /// actually cleared, so a per-block tick never copies ~2000 entries, and
+    /// rearm() is never called with a request it would only DEFER — which is
+    /// what keeps the log free of a per-block DEFERRED storm.
+    ///
+    /// HONEST NOTE ON COVERAGE. Deleting the `m_rearms >= kMaxRearms` half of
+    /// the guard below produces NO red on its own: rearm_gate_height() carries
+    /// the same check and returns 0, and rearm() itself would refuse. It is
+    /// stated rather than papered over — three layers say the same thing, and
+    /// only removing the cap from BOTH this guard AND rearm_gate_height() reds
+    /// AnExhaustedLadderIsNotReAskedOncePerBlock. Kept anyway: the guard is
+    /// what makes "poll_rearm never asks past the cap" true by reading rather
+    /// than by tracing a callee.
+    bool poll_rearm()
+    {
+        if (m_state != State::FailedClosed) return false;
+        if (!m_rearm_pending)               return false;
+        if (m_rearm_blocked || m_rearms >= kMaxRearms) return false;
+        if (!m_tip_height || !m_failed_at_tip_known)   return false;
+
+        const uint32_t now  = m_tip_height();
+        const uint32_t gate = rearm_gate_height();
+        if (gate == 0 || now < gate) {
+            // A lane waiting hours on a gate must not be SILENT about it —
+            // silence is what made the original defect invisible for 2h39m.
+            // Rate-limited in BLOCKS (the lane owns no timer and must not grow
+            // one), so it costs one line per ~kPendingLogEvery blocks.
+            if (now >= m_last_pending_log + kPendingLogEvery) {
+                m_last_pending_log = now;
+                LOG_WARNING << "[MN-CKPT] " << rearm_posture();
+            }
+            return false;
+        }
+        // Copy: rearm() -> reset_for_arm() writes m_anchor_cp, and passing it
+        // its own member would be a self-referential read during the write.
+        const MnCheckpoint cp = m_anchor_cp;
+        const auto out = rearm(
+            cp,
+            "the bridge FAILED CLOSED and the chain has advanced past the"
+            " backoff gate — SELF RE-ARM from the tip seam (the maintainer"
+            " cannot ask: its payee queue is wiped, so it cannot desync)");
+        return out == RearmOutcome::Armed;
+    }
+
     /// How many re-arms have actually been spent against the cap.
     uint32_t rearms() const           { return m_rearms; }
     /// How many times a re-seed was ASKED for, including deferrals and
@@ -632,6 +812,9 @@ public:
     /// The last named outcome, verbatim. Empty until the first ask — which is
     /// itself the answer to "was a re-seed ever asked for".
     const std::string& last_rearm_reason() const { return m_last_rearm_reason; }
+    /// The trigger text of the last ask, verbatim — which PATH asked. Empty
+    /// until the first ask.
+    const std::string& last_rearm_trigger() const { return m_last_rearm_trigger; }
     /// The earliest height at which a re-seed ask gave us evidence of
     /// divergence; 0 = no such evidence (never a valid height here).
     uint32_t first_divergence_height() const { return m_first_divergence; }
@@ -844,6 +1027,18 @@ public:
     /// idempotent and cheap when there is nothing to do.
     void pump()
     {
+        // THE RE-ARM TICK, and it must come BEFORE the state guard. This is
+        // the whole fix: pump() is driven by the tip-changed callback, which
+        // keeps firing after a fail-close (the soak proves it — the tip
+        // advanced 69 blocks while the lane sat terminal), and it was the guard
+        // below that dropped every one of those ticks on the floor. poll_rearm
+        // is a no-op unless the lane is failed-closed with a cleared gate; when
+        // it does arm, the state is Waiting and the ordinary body below picks
+        // the bridge straight up on this same call.
+        if (m_state == State::FailedClosed) {
+            poll_rearm();
+            if (m_state == State::FailedClosed) return;
+        }
         if (m_state != State::Waiting && m_state != State::Bridging) return;
         if (!m_tip_height) return;
 
@@ -2072,6 +2267,10 @@ public:
     void fail_closed(const std::string& why)
     {
         if (m_state == State::FailedClosed) return;
+        // The height the replay DIED ON, captured before anything resets it.
+        // Two fail-closes at the identical cursor are the measurement that says
+        // "this failure is deterministic" — see the block below.
+        const uint32_t cursor = m_next;
         m_state  = State::FailedClosed;
         m_status = why;
         // Deliberately ERROR, not WARNING: the operator's embedded arm will
@@ -2080,26 +2279,51 @@ public:
         LOG_ERROR << "[MN-CKPT] the embedded DASH template arm will NOT serve;"
                      " templates keep routing to the dashd fallback arm (if"
                      " configured). No masternode payee will be guessed.";
-        // Say which generation of the bridge this was, and whether any budget
-        // to try again remains. "FAIL-CLOSED" on its own does not distinguish
-        // "first attempt, three re-arms left" from "last attempt, nothing left".
-        LOG_ERROR << "[MN-CKPT] RE-ARM POSTURE: "
-                  << (m_rearms == 0 ? std::string("this was the ORIGINAL arm")
-                                    : ("this was RE-ARM " + std::to_string(m_rearms)
-                                       + "/" + std::to_string(kMaxRearms)))
-                  << "; re-seed asks so far: " << m_rearm_asks << "; "
-                  << (m_rearm_blocked
-                          ? ("further re-arms are TERMINALLY BLOCKED ("
-                             + m_rearm_block_reason + ")")
-                          : ("re-arms remaining: "
-                             + std::to_string(kMaxRearms - m_rearms)
-                             + " — a further payee desync from the maintainer"
-                               " will trigger one"))
-                  << ". Last re-arm outcome: "
+        // DETERMINISTIC REPEAT. A re-armed replay that dies at the SAME cursor
+        // as the previous one is not a transient: the window between the anchor
+        // and that height produces the same wrong queue every time, and burning
+        // the rest of the ladder on it is the fail-loop the cap exists to
+        // prevent. Requires m_rearms > 0 — the ORIGINAL arm has nothing to
+        // repeat yet — so a single fail-close never blocks the first recovery.
+        if (m_rearms > 0 && m_have_last_fail_cursor
+            && cursor == m_last_fail_cursor && !m_rearm_blocked) {
+            m_rearm_blocked      = true;
+            m_rearm_block_reason =
+                "the re-armed replay failed closed at the IDENTICAL height h="
+                + std::to_string(cursor) + " as the previous attempt, so"
+                  " replaying this anchor is DETERMINISTIC — a further re-arm"
+                  " would reproduce it";
+        }
+        m_last_fail_cursor      = cursor;
+        m_have_last_fail_cursor = true;
+
+        // ARM THE SELF RE-ARM. The tip AT THE FAIL-CLOSE is what the gate is
+        // measured from: without it the ORIGINAL arm's failure (m_rearms == 0,
+        // so the ladder backoff does not apply yet) would be retried over the
+        // identical window on the very next block.
+        m_rearm_pending    = true;
+        m_last_pending_log = 0;
+        if (m_tip_height) {
+            m_failed_at_tip       = m_tip_height();
+            m_failed_at_tip_known = true;
+        } else {
+            m_failed_at_tip_known = false;
+        }
+
+        // Say which generation of the bridge this was, whether any budget to
+        // try again remains AND — the half that used to be missing — whether
+        // anything can still spend it. "re-arms remaining: 2" was printed for
+        // 2h39m about capacity no live path could reach.
+        LOG_ERROR << "[MN-CKPT] " << rearm_posture()
+                  << " Last re-arm outcome: "
                   << (m_last_rearm_reason.empty()
                           ? std::string("n/a (no re-seed has ever been asked"
                                         " for)")
                           : m_last_rearm_reason);
+        // The STATE says its own name too, not just the scrollback: status() is
+        // what the operator surfaces read, and a posture that lives only in a
+        // log line is half-silent.
+        m_status += " — " + rearm_posture();
     }
 
     /// EVERY field an arm starts from, in ONE place.
@@ -2149,6 +2373,14 @@ public:
     /// m_has_sml_fn, which are wiring, not bridge state.
     void reset_for_arm(const MnCheckpoint& cp)
     {
+        // The lane KEEPS its own anchor. poll_rearm() has no caller to hand it
+        // one — that is the point of it — and a self re-arm that depended on an
+        // extra seam being wired in main_dash would be one more thing that can
+        // be forgotten, i.e. the same defect class again. Guarded because
+        // poll_rearm() passes a copy of this very member.
+        if (&cp != &m_anchor_cp) m_anchor_cp = cp;
+        // A fresh arm is not a lane WAITING to re-arm.
+        m_rearm_pending = false;
         m_anchor_height = cp.height;
         m_anchor_hash   = cp.blockhash;
         m_anchor_source = cp.source;
@@ -2328,6 +2560,23 @@ public:
     bool        m_rearm_blocked{false};   // terminal: no further re-arms
     std::string m_rearm_block_reason;
     std::string m_last_rearm_reason;
+    std::string m_last_rearm_trigger;
+
+    // ── SELF RE-ARM state. Also survives reset_for_arm() (except the pending
+    // flag, which a fresh arm clears): the gate is measured across bridges.
+    /// The anchor this lane is armed from, kept so poll_rearm() needs no
+    /// caller and no extra seam. One copy, overwritten per arm.
+    MnCheckpoint m_anchor_cp;
+    bool     m_rearm_pending{false};        // failed closed, wants a re-arm
+    uint32_t m_failed_at_tip{0};            // tip observed AT the fail-close
+    bool     m_failed_at_tip_known{false};  // ...if a tip seam was wired then
+    uint32_t m_last_fail_cursor{0};         // cursor the previous replay died on
+    bool     m_have_last_fail_cursor{false};
+    uint32_t m_last_pending_log{0};         // tip at the last pending line
+    /// Blocks between two "waiting on the gate" lines. ~8 DASH blocks is ~20
+    /// minutes: loud enough that a wedged ladder cannot hide for 2h39m again,
+    /// quiet enough that it is not a per-block storm.
+    static constexpr uint32_t kPendingLogEvery = 8;
 };
 
 } // namespace coin

--- a/test/test_dash_mn_checkpoint.cpp
+++ b/test/test_dash_mn_checkpoint.cpp
@@ -4508,3 +4508,292 @@ TEST(DashMnCheckpointReviveProbe, ProbeAnsweringNotBannedIsAMeasurementAndAsksOn
               std::string::npos)
         << rig.h.lane.revive_probe_report();
 }
+
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 16. THE RE-ARM LADDER MUST BE REACHABLE FROM A PATH THE FAILURE DOES NOT KILL
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// MEASURED (contabo daemonless soak0803c/d, 2026-08-03). The bridge failed
+// closed at 06:13:50 announcing "re-arms remaining: 2 — a further payee desync
+// from the maintainer will trigger one". 2h39m later: process alive, tip
+// advanced 69 blocks (68 PAST the 64-block backoff gate), 90 templates served,
+// the EMBED-GATE heartbeat still printing "cause=mn-needs-reseed value=latched"
+// every five minutes — and ZERO further asks, ZERO re-arms, ZERO MN-CKPT lines
+// of any kind.
+//
+// The cause is structural, not a missed if. rearm() had ONE caller
+// (main_dash's set_on_mn_reseed lambda); that callback has ONE invoker
+// (CoinStateMaintainer::on_block_connected's payee-desync/apply-gap branch);
+// that branch needs a PROJECTED payee, i.e. a NON-EMPTY payee queue; and its
+// own first act is to WIPE the queue and zero the apply cursor. Only a lane
+// PUBLISH refills it. A bridge that fails closed never publishes, so a second
+// ask is arithmetically impossible: the ladder's trigger was the one event its
+// own failure had already ruled out.
+//
+// These cases pin the fix AT THE TRIGGER. Each fails on the pre-fix lane,
+// because there pump() returns at its state guard and nothing else ever
+// reaches rearm().
+
+namespace {
+
+// A lane driven exactly the way main_dash drives it: pump() on every tip
+// change and nothing else. No test-only entry point — "reachable from the real
+// driver" is the property under test.
+//
+// Never returned by value: BridgeHarness's seams capture `this`.
+struct TipDrivenLane {
+    BridgeHarness h;
+    MnCheckpoint  cp{good_checkpoint()};
+
+    TipDrivenLane()
+    {
+        h.headers[kAnchorHeight] = uint256S(kAnchorHash);
+        h.blocks[1519544] = block_from_hex(kBlockHex1519544);
+        h.blocks[1519545] = block_from_hex(kBlockHex1519545);
+        h.blocks[1519546] = block_from_hex(kBlockHex1519546);
+        h.tip = 1519546;
+    }
+
+    // main_dash: header_chain->set_on_tip_changed -> mnl->pump().
+    void tip_advances_to(uint32_t height)
+    {
+        h.tip = height;
+        h.lane.pump();
+    }
+};
+
+// Fail the lane closed AFTER a full replay: the bridge reaches the tip and
+// finds no publish seam. Distinct cursor, repairable cause.
+void fail_closed_on_publish_seam(TipDrivenLane& t)
+{
+    t.h.lane.set_publish_fn({});
+    t.h.lane.arm(t.cp);
+    t.h.lane.pump();
+    ASSERT_EQ(t.h.lane.state(), MnCheckpointLane::State::FailedClosed)
+        << t.h.lane.status();
+}
+
+} // namespace
+
+// ── 16.1 THE FINDING, AND THE FIX. A tip advance past the gate re-arms the
+// bridge with NO maintainer ask — because no maintainer ask is possible.
+TEST(DashMnCheckpointSelfReArm, TipAdvancePastTheGateReArmsWithNoDesyncAsk)
+{
+    TipDrivenLane t;
+    ASSERT_NO_FATAL_FAILURE(fail_closed_on_publish_seam(t));
+    auto& lane = t.h.lane;
+    ASSERT_EQ(lane.rearms(), 0u);
+    ASSERT_EQ(lane.rearm_asks(), 0u)
+        << "the trigger under test is NOT an ask — nothing may have asked";
+
+    const uint32_t gate = lane.rearm_gate_height();
+    ASSERT_NE(gate, 0u) << "a recoverable fail-close must publish a gate";
+
+    // The ONLY input from here on: the chain moves. No ask, no callback, no
+    // restart, no operator.
+    t.tip_advances_to(gate);
+
+    EXPECT_EQ(lane.rearms(), 1u)
+        << "THE DEFECT: the ladder was triggerable only by an event the"
+           " fail-close had already made impossible. "
+        << lane.rearm_posture();
+    EXPECT_EQ(lane.rearm_asks(), 1u);
+    EXPECT_NE(lane.state(), MnCheckpointLane::State::FailedClosed)
+        << "the lane must have left the terminal state: " << lane.status();
+    EXPECT_NE(lane.last_rearm_trigger().find("SELF RE-ARM"), std::string::npos)
+        << "the recovery must name which PATH pulled the trigger — with two"
+           " callers, 'a re-arm happened' no longer identifies it: "
+        << lane.last_rearm_trigger();
+    EXPECT_EQ(lane.anchor_height(), kAnchorHeight)
+        << "a self re-arm is still oldest-first: the release-pinned anchor";
+}
+
+// ── 16.2 BOUNDED. The gate is measured from the tip AT THE FAIL-CLOSE, so the
+// ORIGINAL arm's failure (no ladder backoff applies yet) is never retried over
+// the identical window on the very next block.
+TEST(DashMnCheckpointSelfReArm, TheGateHoldsUntilTheChainHasActuallyMoved)
+{
+    TipDrivenLane t;
+    ASSERT_NO_FATAL_FAILURE(fail_closed_on_publish_seam(t));
+    auto& lane = t.h.lane;
+
+    const uint32_t failed_at = t.h.tip;
+    const uint32_t gate      = lane.rearm_gate_height();
+    ASSERT_EQ(gate, failed_at + MnCheckpointLane::kRearmBackoffBlocks)
+        << "the gate must be the fail-close tip plus the backoff, or the very"
+           " next block replays the identical window";
+
+    // Every block up to gate-1 is a real tip advance through the real driver.
+    for (uint32_t h = failed_at + 1; h < gate; ++h) {
+        t.tip_advances_to(h);
+        ASSERT_EQ(lane.rearms(), 0u)
+            << "re-armed at h=" << h << ", " << (gate - h)
+            << " blocks early: " << lane.rearm_posture();
+        ASSERT_EQ(lane.rearm_asks(), 0u)
+            << "a deferred attempt must not even be ASKED for once per block —"
+               " that is a per-block log storm dressed as recovery";
+        ASSERT_EQ(lane.state(), MnCheckpointLane::State::FailedClosed);
+    }
+
+    t.tip_advances_to(gate);
+    EXPECT_EQ(lane.rearms(), 1u)
+        << "and at the gate it must actually fire: " << lane.rearm_posture();
+}
+
+// ── 16.3 BOUNDED, TERMINALLY. A re-armed replay that dies at the SAME cursor
+// is measured proof the failure is deterministic; the ladder must stop rather
+// than spend its remaining rungs reproducing it.
+TEST(DashMnCheckpointSelfReArm, IdenticalRepeatFailureBlocksTheLadderAndSaysSo)
+{
+    TipDrivenLane t;
+    auto& lane = t.h.lane;
+    // A staleness refusal reproduces EXACTLY: same cursor, every time.
+    lane.set_max_bridge_blocks(10);
+    t.h.tip = kAnchorHeight + 100;
+    lane.arm(t.cp);
+    lane.pump();
+    ASSERT_EQ(lane.state(), MnCheckpointLane::State::FailedClosed);
+    ASSERT_NE(lane.status().find("STALE"), std::string::npos) << lane.status();
+    ASSERT_FALSE(lane.rearm_blocked())
+        << "ONE fail-close is not evidence of determinism — the first recovery"
+           " must not be pre-emptively blocked";
+
+    t.tip_advances_to(lane.rearm_gate_height());
+    EXPECT_EQ(lane.rearms(), 1u)
+        << "the ladder must still get its first rung: " << lane.rearm_posture();
+    EXPECT_TRUE(lane.rearm_blocked())
+        << "the re-armed replay died at the same cursor — deterministic, so"
+           " terminal: " << lane.rearm_posture();
+    EXPECT_NE(lane.rearm_posture().find("IDENTICAL"), std::string::npos)
+        << lane.rearm_posture();
+    EXPECT_EQ(lane.rearm_gate_height(), 0u)
+        << "a blocked ladder has no gate — 0 is 'no height admits one'";
+
+    // ...and it stays blocked however far the chain moves.
+    for (int i = 0; i < 5; ++i) t.tip_advances_to(t.h.tip + 1000);
+    EXPECT_EQ(lane.rearms(), 1u);
+    EXPECT_NE(lane.rearm_posture().find("remaining capacity: NONE"),
+              std::string::npos)
+        << lane.rearm_posture();
+}
+
+// ── 16.4 THE MISLEADING NUMBER. "re-arms remaining: 2" was printed for 2h39m
+// about capacity nothing could spend. The posture must distinguish reachable
+// from unreachable, and it must ride on status(), not only on scrollback.
+TEST(DashMnCheckpointSelfReArm, PostureNamesReachableVersusUnreachableCapacity)
+{
+    TipDrivenLane t;
+    ASSERT_NO_FATAL_FAILURE(fail_closed_on_publish_seam(t));
+    auto& lane = t.h.lane;
+
+    // REACHABLE: says so, and says at which height.
+    EXPECT_NE(lane.status().find("REACHABLE"), std::string::npos)
+        << "the STATE must say its own name, not just the log: " << lane.status();
+    EXPECT_NE(lane.status().find(std::to_string(lane.rearm_gate_height())),
+              std::string::npos)
+        << "an operator must be able to read the gate height off the state: "
+        << lane.status();
+    EXPECT_EQ(lane.status().find("a further payee desync from the maintainer"
+                                 " will trigger one"),
+              std::string::npos)
+        << "THE MISLEADING SENTENCE: no such desync is possible — the"
+           " maintainer's queue is wiped: " << lane.status();
+    EXPECT_TRUE(lane.rearm_self_reachable()) << lane.rearm_posture();
+
+    // STRUCTURALLY UNREACHABLE: with no tip seam there is no live trigger and
+    // no way to measure the backoff. Remaining capacity is still 2 — and it is
+    // still unspendable, which is exactly what must NOT read as availability.
+    lane.set_tip_height_fn({});
+    EXPECT_FALSE(lane.rearm_self_reachable());
+    EXPECT_NE(lane.rearm_posture().find("STRUCTURALLY UNREACHABLE"),
+              std::string::npos)
+        << lane.rearm_posture();
+    EXPECT_NE(lane.rearm_posture().find("CANNOT be spent"), std::string::npos)
+        << lane.rearm_posture();
+}
+
+// ── 16.5 THE CAP STILL BOUNDS THE NEW TRIGGER. An exhausted ladder must not be
+// re-ASKED once per block: that is a per-block ERROR storm, and it is how a
+// bounded mechanism turns back into the fail-loop the cap exists to prevent.
+TEST(DashMnCheckpointSelfReArm, AnExhaustedLadderIsNotReAskedOncePerBlock)
+{
+    TipDrivenLane t;
+    auto& lane = t.h.lane;
+    lane.arm(t.cp);
+    lane.pump();
+    ASSERT_EQ(lane.state(), MnCheckpointLane::State::Published);
+
+    // Spend the whole ladder through the ask path, exactly as case 12 does.
+    ASSERT_EQ(lane.rearm(t.cp, "desync 1"), MnCheckpointLane::RearmOutcome::Armed);
+    t.h.tip += MnCheckpointLane::kRearmBackoffBlocks;
+    ASSERT_EQ(lane.rearm(t.cp, "desync 2"), MnCheckpointLane::RearmOutcome::Armed);
+    t.h.tip += MnCheckpointLane::kRearmBackoffBlocks * 2;
+    ASSERT_EQ(lane.rearm(t.cp, "desync 3"), MnCheckpointLane::RearmOutcome::Armed);
+    ASSERT_EQ(lane.rearms(), MnCheckpointLane::kMaxRearms);
+
+    // Fail it closed with the cap already spent.
+    lane.set_max_bridge_blocks(10);
+    lane.pump();
+    ASSERT_EQ(lane.state(), MnCheckpointLane::State::FailedClosed) << lane.status();
+    const uint32_t asks = lane.rearm_asks();
+
+    for (int i = 0; i < 200; ++i) t.tip_advances_to(t.h.tip + 1);
+
+    EXPECT_EQ(lane.rearms(), MnCheckpointLane::kMaxRearms)
+        << "the cap must survive the new trigger";
+    EXPECT_EQ(lane.rearm_asks(), asks)
+        << "200 tip advances produced " << (lane.rearm_asks() - asks)
+        << " fresh asks — an exhausted ladder must go quiet, not print an ERROR"
+           " per block";
+    EXPECT_EQ(lane.rearm_gate_height(), 0u);
+    EXPECT_FALSE(lane.rearm_self_reachable());
+    EXPECT_NE(lane.rearm_posture().find("EXHAUSTED"), std::string::npos)
+        << lane.rearm_posture();
+}
+
+// ── 16.6 END TO END, through the REAL maintainer. The finding and the fix in
+// one rig: after a fail-closed bridge the maintainer can NEVER ask again, and
+// the lane has to come back without one.
+TEST(DashMnCheckpointSelfReArm, NoSecondAskIsPossibleSoTheLaneMustRecoverAlone)
+{
+    ReseedRig r(/*wire_the_reseed_seam=*/true);
+    r.h.lane.arm(r.anchor);
+    r.h.lane.pump();
+    ASSERT_EQ(r.h.lane.state(), MnCheckpointLane::State::Published);
+    r.fire_tip();
+    ASSERT_TRUE(r.state.populated());
+
+    // Break the publish seam first, so the re-arm the ask produces FAILS
+    // CLOSED — the soak's shape exactly.
+    r.h.lane.set_publish_fn({});
+    ASSERT_TRUE(r.force_apply_gap().gap_detected);
+    ASSERT_EQ(r.reseed_calls, 1u);
+    ASSERT_EQ(r.h.lane.rearms(), 1u);
+    ASSERT_EQ(r.h.lane.state(), MnCheckpointLane::State::FailedClosed)
+        << r.h.lane.status();
+    ASSERT_TRUE(r.state.mn_needs_reseed());
+    ASSERT_FALSE(r.state.populated());
+
+    // THE FINDING. Keep feeding the maintainer blocks. It cannot ask again:
+    // its payee queue is wiped, so apply_block resolves no projected payee and
+    // the desync branch is unreachable. This holds before AND after the fix —
+    // it is the reason the fix cannot live on the ask path.
+    for (uint32_t h = 1519549; h < 1519559; ++h)
+        r.maint.on_block_connected(block_from_hex(kBlockHex1519546), h);
+    EXPECT_EQ(r.reseed_calls, 1u)
+        << "a second ask is arithmetically impossible after the wipe — any"
+           " recovery that waits for one waits forever";
+
+    // ...so the recovery has to come from the tip seam, which is still alive.
+    const uint32_t gate = r.h.lane.rearm_gate_height();
+    ASSERT_NE(gate, 0u) << r.h.lane.rearm_posture();
+    r.h.tip = gate;
+    r.h.lane.pump();
+
+    EXPECT_EQ(r.reseed_calls, 1u) << "and it must do so WITHOUT a second ask";
+    EXPECT_EQ(r.h.lane.rearms(), 2u) << r.h.lane.rearm_posture();
+    EXPECT_NE(r.h.lane.state(), MnCheckpointLane::State::FailedClosed)
+        << "the lane stayed terminal with the gate long cleared — this is the"
+           " 2h39m the soak measured: " << r.h.lane.status();
+}


### PR DESCRIPTION
## The finding: the re-arm ladder was never invocable after a fail-close

Measured on the contabo daemonless soaks (`soak0803c`, `soak0803d`, 2026-08-03), not inferred from the source.

`soak0803c` failed closed at 06:13:50 at h=2515416 and printed:

> `RE-ARM POSTURE: this was RE-ARM 1/3; re-seed asks so far: 3; re-arms remaining: 2 — a further payee desync from the maintainer will trigger one.`

2h39m later, at 08:52:54:

| observation | value |
|---|---|
| process | alive, still logging |
| tip | 2515548 (backoff gate was h>=2515543 — cleared 68 blocks earlier) |
| tip-advance events since the fail-close | 69, one per block, `[EMB-DASH] tip advanced ... -> new_tip fired` |
| templates served since the fail-close | 90 |
| `EMBED-GATE` heartbeat | still printing `cause=mn-needs-reseed value=latched` every 5 min |
| further re-seed asks | **0** |
| `[MN-CKPT]` lines of any kind | **0** |

`soak0803d` has the identical shape (fail-closed at h=2515511).

### It is structural, not a missed branch

`MnCheckpointLane::rearm()` had exactly **one** caller — `main_dash.cpp:3992`'s `maintainer->set_on_mn_reseed(...)` lambda. That callback has exactly **one** invoker: `coin_state_maintainer.hpp:800`, inside the `if (r.payee_desync || r.gap_detected)` branch of `on_block_connected`.

That branch cannot fire on a wiped queue:

* `payee_desync` (`mn_state_machine.hpp:1215`) is only reachable under `if (projected && ...)` — it needs a ranked, non-empty payee queue.
* `gap_detected` (`mn_state_machine.hpp:974`) is only reachable under `m_last_applied_height != 0`.
* The branch's own first act is `m_state.mnstates().load({})`, and `load()` sets `m_last_applied_height = as_of_height` — **0** by default.

So both trigger conditions are switched off by the very handler that would ask, and only a lane **publish** (through leg 4 → `on_mn_list_update`) refills the queue. The ask chain is a closed cycle:

```
ask -> rearm() -> bridge -> PUBLISH -> queue refilled -> next ask
```

A bridge that fails closed never publishes. **The second ask is arithmetically impossible.** The three asks the original PR measured were each preceded by a successful publish; a fail-close ends the cycle for the life of the process.

### "Reaches it and doesn't" vs "structurally cannot": it is the second

A live loop *does* reach the lane object — `main_dash.cpp:3499` calls `mnl->pump()` on every tip change, and the soak proves it fired 69 times after the fail-close. But `pump()` returned at `if (m_state != State::Waiting && m_state != State::Bridging) return;`, and **no** tick path anywhere called `rearm()`. The backoff expiring did nothing because nothing polled it.

## The fix: move the trigger, not the policy

`pump()` now re-evaluates the ladder **before** its state guard, via `poll_rearm()`. The attempt still goes through `rearm()`, so the `kMaxRearms` cap, the doubling block backoff, the never-a-newer-anchor guards and every terminal refusal are unchanged. What changed is only *who* may pull the trigger — a caller that is still alive when the payee queue is wiped.

No `main_dash` wiring is added. The lane keeps its own anchor (`m_anchor_cp`, stored in `reset_for_arm`), because a recovery that depends on one more seam being remembered is the same defect class again.

### Still bounded — and now bounded against the identical-window retry

* **The gate** (`rearm_gate_height()`) is the tip **at the fail-close** plus `kRearmBackoffBlocks`, on top of the existing per-re-arm ladder backoff. Without the first half, the ORIGINAL arm's failure (no ladder backoff applies at `m_rearms == 0`) would be retried over the identical window on the very next block.
* **Deterministic repeat**: a re-armed replay that dies at the SAME cursor as the previous one is measured proof the failure reproduces. The ladder is blocked TERMINALLY and names why, rather than spending its remaining rungs on the same block.
* An exhausted or blocked ladder is **not re-asked once per block** — `poll_rearm()` never calls `rearm()` with a request it would only DEFER, so there is no per-block DEFERRED/ERROR storm.

### The state says its own name

`rearm_posture()` distinguishes five postures and rides on `status()`, not only on the log:

* `... is EXHAUSTED — remaining capacity: NONE`
* `further re-arms are TERMINALLY BLOCKED (<reason>) — remaining capacity: NONE`
* `re-arms remaining: N but STRUCTURALLY UNREACHABLE: no tip-height seam is wired ... This capacity CANNOT be spent by this process`
* `re-arms remaining: N and REACHABLE: the lane re-arms ITSELF on a tip advance at h>=G (tip h=T — waiting on K more block(s))`
* `... gate CLEARED, the next tip advance re-arms`

and a lane waiting on the gate says so every ~8 blocks instead of going silent for hours. The sentence `a further payee desync from the maintainer will trigger one` is gone: no such desync is possible.

## Tests — section 15 of `test/test_dash_mn_checkpoint.cpp`

Every case is driven through `pump()` exactly the way `main_dash` drives it. There is no test-only entry point, because *reachable from the real driver* is the property under test.

| case | claim covered |
|---|---|
| 15.1 `TipAdvancePastTheGateReArmsWithNoDesyncAsk` | the ladder is reachable from the tip path with `rearm_asks()` untouched by any maintainer callback |
| 15.2 `TheGateHoldsUntilTheChainHasActuallyMoved` | all 63 blocks before the gate do nothing (and are not even ASKED for); the gate block fires |
| 15.3 `IdenticalRepeatFailureBlocksTheLadderAndSaysSo` | one fail-close is not evidence; two at the same cursor is, and it is terminal and named |
| 15.4 `PostureNamesReachableVersusUnreachableCapacity` | reachable vs structurally-unreachable capacity is distinguishable from `status()` alone |
| 15.5 `AnExhaustedLadderIsNotReAskedOncePerBlock` | 200 tip advances past an exhausted ladder produce zero new asks |
| 15.6 `NoSecondAskIsPossibleSoTheLaneMustRecoverAlone` | end to end through the real `CoinStateMaintainer`: 10 further blocks produce no second ask, and the lane recovers without one |

### Mutation results

| mutation | reds |
|---|---|
| remove the `poll_rearm()` tick from `pump()` (i.e. today's shipped behaviour) | 15.1, 15.2, 15.3, 15.6 |
| gate ignores the fail-close tip (ladder backoff only) | 15.1, 15.2 |
| delete the deterministic-repeat block | 15.3 |
| drop the posture from `status()` | 15.4 |
| remove the cap from **both** `poll_rearm()` and `rearm_gate_height()` | 15.5 |

**Surviving mutant, stated rather than hidden:** removing the `m_rearms >= kMaxRearms` half of `poll_rearm()`'s guard **alone** produces no red — `rearm_gate_height()` carries the same check and `rearm()` would refuse anyway. It is kept as defence in depth and the redundancy is documented in the source.

Full `test_dash_node_reception_wire` TU: 113/113 pass. `c2pool-dash` builds clean.

## What this does NOT establish

* **It does not fix the h=2515416 divergence.** The re-arm replays a window that still contains that height, so it may well reproduce — which is exactly why the ladder is capped and why the deterministic-repeat block was added. This PR makes the mechanism reachable; whether the replay then succeeds is a separate question (the in-window ban+revive blind spot named in the soak's own fail-closed line).
* The end-to-end cases stop at "the lane left `FailedClosed` and is bridging again". Driving a self re-armed bridge all the way to a fresh publish needs 64+ consecutive real block bodies, and the test corpus carries three.
* Not measured live: the fix has not yet run on a soak rig. The two soaks in the report were deliberately left untouched as the before/after evidence.

## Scope note

The change is confined to the re-arm trigger path in `mn_checkpoint_lane.hpp` (`pump()`'s first lines, `fail_closed()`, `reset_for_arm()`'s anchor capture, and new accessors). It does not touch `mn_state_machine.hpp`, so it does not overlap the in-window ban+revive (DEF6) work in flight.

---

## Rebased onto `0ded910c` (#1044, the ban-state probe) — and what that merge does NOT mean

This branch was rebased onto master after #1044 squash-merged. Both PRs touch `mn_checkpoint_lane.hpp` and `test/test_dash_mn_checkpoint.cpp`; the conflict was resolved by keeping **both** sides. #1044's `begin_revive_probe()` (called before `apply_block`) and its `revive_probe_report()` inside `reinstatement_report()` are untouched, its probe fields are still reset in `reset_for_arm()` alongside the re-arm fields, and its six `DashMnCheckpointReviveProbe` cases all pass — including `ReArmGivesTheSecondBridgeAFreshProbeBudget`, which exercises the re-arm path this PR changes. `git diff origin/master...HEAD --stat` is two files, +554/-16, with zero probe machinery in it. Full TU after the rebase: **119/119**. `c2pool-dash` builds clean. The `pump()`-tick mutation was re-run on the rebased tree and still reds 16.1/16.2/16.3/16.6.

**Read this PR as a safety net, not as a critical path — and do not read #1044's soak as evidence that the ladder works.** #1044's run was the project's first `bridge COMPLETE` in daemonless mode (2974 masternodes published, 20 ProUpServTx revives, 0 left unmeasured, zero fail-closes, arm EMBEDDED, payee byte-identical to dashd). Because there was no fail-close, the defect this PR fixes never arose in that run and the ladder still **has never fired a second time in any run, on any rig**. The two older soaks remain fail-closed at 2515416 and 2515511 as controls.

What is unchanged by that success: after **any** future fail-close the ladder is still structurally unreachable, because the trigger still depends on a maintainer ask the fail-close itself makes impossible. This PR's value is the same as stated above — it makes the failure honest and recoverable, not more likely to succeed.
