### PR TITLE
fix(web/best_share): stop masquerading sharechain average as a best-share record (#945)

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -4936,17 +4936,16 @@ nlohmann::json MiningInterface::rest_best_share()
         std::lock_guard<std::mutex> lock(m_best_diff_mutex);
         auto now_ts = static_cast<uint64_t>(std::time(nullptr));
 
-        // If no local best share, use sharechain average difficulty as baseline
+        // Honest-absent: until a real record share is seen, best-share
+        // difficulty reads 0. We deliberately do NOT substitute the sharechain
+        // AVERAGE here (#945) -- an average is not a record, yet the card labels
+        // this a "Best Share" / "record", so the average masqueraded as the
+        // all-time/round best. The window average legitimately surfaces on its
+        // own below as median_pct; has_best_share lets the card render
+        // honest-absent instead of a fake average-as-record value.
         double best_all = m_best_difficulty.all_time;
         double best_sess = m_best_difficulty.session;
         double best_round = m_best_difficulty.round;
-        if (best_all == 0.0 && m_sharechain_stats_fn) {
-            auto sc = m_sharechain_stats_fn();
-            double avg = sc.value("average_difficulty", 0.0);
-            best_all = avg;
-            best_sess = avg;
-            best_round = avg;
-        }
 
         auto make_entry = [&](double diff, const std::string& miner, uint64_t ts,
                               const std::string& hash) {
@@ -4972,6 +4971,11 @@ nlohmann::json MiningInterface::rest_best_share()
             m_best_difficulty.hash);
         round["started"] = m_best_difficulty.round_start;
         result["round"] = round;
+
+        // A real record was recorded iff the all-time best difficulty is > 0.
+        // The card gates on this so it never presents a 0 (or, pre-#945, a
+        // sharechain average) as a "best share" record.
+        result["has_best_share"] = (best_all > 0.0);
     }
 
     // ── Merged (aux) chain best share stats - symbol from the real aux chain, never hardcoded ──

--- a/test/test_web_honesty_regression.cpp
+++ b/test/test_web_honesty_regression.cpp
@@ -1041,6 +1041,35 @@ TEST(WebGaugeParity, MinDifficultyPropagatesThroughP2poolShapeWhenKnown) {
     EXPECT_DOUBLE_EQ(p["min_difficulty"].get<double>(), 8.75);
 }
 
+// (#945) The "Best Share" card claims a RECORD share; it must never present the
+// sharechain window AVERAGE as that record. Pre-fix, rest_best_share()
+// substituted average_difficulty into the all-time/session/round difficulty
+// whenever no local record had been seen -- so a freshly-started node showed the
+// window average under a "Best Share / record" label. Fails-without-fix: the
+// substitution set all three difficulties to 1024.0 (make_stats' average).
+TEST(WebGaugeParity, BestShareRecordIsRealNotSharechainAverage) {
+    MiningInterface mi(/*testnet=*/true, /*node=*/nullptr);
+    // Live sharechain with a fat average, but NO recorded best share yet.
+    mi.set_sharechain_stats_fn([] { return make_stats(1000, 0, 0, 3.5); });
+
+    json b = mi.rest_best_share();
+
+    // has_best_share is the honest flag the card gates on.
+    ASSERT_TRUE(b.contains("has_best_share"));
+    EXPECT_FALSE(b["has_best_share"].get<bool>())
+        << "no record share was ever recorded; has_best_share must be false";
+
+    for (const char* scope : {"all_time", "session", "round"}) {
+        ASSERT_TRUE(b.contains(scope)) << scope << " entry missing";
+        const double d = b[scope].value("difficulty", -1.0);
+        EXPECT_DOUBLE_EQ(d, 0.0)
+            << scope << " best-share difficulty must read 0 (honest-absent), "
+               "not the sharechain average";
+        EXPECT_NE(d, 1024.0)
+            << scope << " must not be re-sourced from average_difficulty";
+    }
+}
+
 // (c) aps IS the non-stale rate; the gross rate is that grossed UP.
 TEST(WebGaugeParity, StaleRelationshipMatchesP2poolNotItsInverse) {
     MiningInterface mi(/*testnet=*/true, /*node=*/nullptr);
@@ -1607,4 +1636,22 @@ TEST(DashboardNoWorkReason, RendersHeaderSyncAndCategorisedReason) {
     EXPECT_NE(fn.find("c.no_work_reason != null"), std::string::npos)
         << "the no-work line must be gated on the reason being present "
            "(honest-absent), not rendered unconditionally.";
+}
+
+// (#945, frontend) renderBestShare must gate the record on has_best_share and
+// must not present a value when absent. Pre-fix it unconditionally wrote
+// bs.round.difficulty / bs.all_time.pct_of_block, so when the backend fell back
+// to the sharechain average the card rendered that average as a record.
+// Fails-without-fix: the pre-fix function never references has_best_share.
+TEST(DashboardBestShare, RecordGatesOnHasBestNotAverage) {
+    const auto html = read_dashboard();
+    auto start = html.find("function renderBestShare(bs)");
+    ASSERT_NE(start, std::string::npos) << "renderBestShare not found";
+    auto end = html.find("\n        function ", start + 1);
+    ASSERT_NE(end, std::string::npos);
+    const std::string fn = html.substr(start, end - start);
+
+    EXPECT_NE(fn.find("has_best_share"), std::string::npos)
+        << "renderBestShare must gate the record on bs.has_best_share; without "
+           "it a syncing node renders the sharechain average as a 'Best Share'.";
 }

--- a/web-static/dashboard.html
+++ b/web-static/dashboard.html
@@ -3095,10 +3095,23 @@
 
         function renderBestShare(bs) {
             if (!bs || !bs.round) return;
-            d3.select('#best_share_round_pct_fancy').html(format_pct_fancy(bs.round.pct_of_block));
-            d3.select('#best_share_round_diff').text(format_difficulty(bs.round.difficulty));
+            // #945: gate the "Best Share" record on has_best_share. A false flag
+            // (or a 0 difficulty) means no record share has been seen yet -- do
+            // NOT render the value as a record. Pre-fix the backend substituted
+            // the sharechain AVERAGE here, so this card silently showed a window
+            // average under a "Best Share / \u{1F3C6} record" label.
+            var hasBest = (bs.has_best_share !== false) &&
+                          bs.round && bs.round.difficulty > 0;
+            if (hasBest) {
+                d3.select('#best_share_round_pct_fancy').html(format_pct_fancy(bs.round.pct_of_block));
+                d3.select('#best_share_round_diff').text(format_difficulty(bs.round.difficulty));
+                d3.select('#best_share_alltime_pct_fancy').html(format_pct_fancy(bs.all_time.pct_of_block));
+            } else {
+                d3.select('#best_share_round_pct_fancy').html('\u2014');
+                d3.select('#best_share_round_diff').text('no record yet');
+                d3.select('#best_share_alltime_pct_fancy').html('\u2014');
+            }
             d3.select('#best_share_net_diff').text(format_difficulty(bs.network_difficulty));
-            d3.select('#best_share_alltime_pct_fancy').html(format_pct_fancy(bs.all_time.pct_of_block));
             // Record-share hash (the exact hash that got closest to a block).
             var recHash = (bs.round && bs.round.hash) ? bs.round.hash
                         : ((bs.all_time && bs.all_time.hash) ? bs.all_time.hash : '');


### PR DESCRIPTION
Closes #945.

## The lie
`rest_best_share()` (core/web_server.cpp, the shared node-wide `/best_share` reader) substituted the sharechain **`average_difficulty`** into the `all_time` / `session` / `round` best-share difficulty whenever no local record share had been seen. The dashboard card is labelled **"🎯 Best Share"** with a **"🏆 record"** line and renders `bs.round.difficulty` / `bs.all_time.pct_of_block` — so a freshly-started or still-syncing node showed the window **average** under a **record** label. An average is not a record; this is exactly the class of dashboard lie this lane exists to kill.

## The fix (one shared reader, no per-coin fork)
- **Backend:** drop the average substitution. Best-share difficulties read **0 (honest-absent)** until a real record is recorded, and a new top-level **`has_best_share`** flag lets the card gate. The window average still surfaces correctly, on its own, as `median_pct` (the `x̃` line) — where it belongs.
- **Frontend (`web-static/dashboard.html` `renderBestShare`):** gate the record on `bs.has_best_share`; render **"no record yet"** / "—" when absent instead of a fabricated value.

## Tests (both fail without the fix)
- `WebGaugeParity.BestShareRecordIsRealNotSharechainAverage` — no record + a 1024.0 window average ⇒ all three scopes read 0, `has_best_share` false (pre-fix all three were 1024.0). Parallels the existing `MinDifficultyIsPoolFloorNotSharechainAverage` gauge-parity KAT.
- `DashboardBestShare.RecordGatesOnHasBestNotAverage` — static-HTML: `renderBestShare` must reference `has_best_share`. Folded into the allowlisted honesty target (no new `add_executable`, avoids the #769 Not-Run trap).

Cut from master `ad916a217`. Web layer (non-consensus). GPG-signed.
