### PR TITLE
dash(daemonless): refuse to fold blocks into an UNSEEDED payee queue

### DIFF
--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -761,6 +761,65 @@ public:
             r.total_after = m_state.mnstates().size();
             return r;
         }
+        // ── UNSEEDED PAYEE FOLD (soak-found 2026-08-03, phantom-desync class).
+        // The payee machine may fold a block ONLY while an authoritative,
+        // height-stamped snapshot is in force. Without one it holds no payment
+        // queue, so a projection off it is a guess -- precisely what the
+        // anti-mint latch below refuses to SERVE, but which was still being
+        // COMPUTED, and whose mismatch was then reported as a divergence.
+        //
+        // MEASURED, three independent runs (contabo soaks 0803c/d/e, started at
+        // tips 2515478/2515518/2515558, identical heights every time). In the
+        // pure-daemonless posture nothing seeds this machine until
+        // MnCheckpointLane publishes. Meanwhile the lane's own request_window()
+        // downloads HISTORICAL block bodies from the anchor forward, and both
+        // the lane and this maintainer subscribe to the SAME
+        // Node::block_connected event -- so those historical bodies were folded
+        // in here too. Both of MnStateMachine::apply_block's ordering guards are
+        // conditioned on `m_last_applied_height != 0`, so a cold cursor accepts
+        // the first body and then rides the window contiguously.
+        //
+        // The chain did the rest. Block 2513167 carried the first ProRegTx in
+        // the window; it registered the ONE entry this set held. Block 2513168
+        // projected it -- a one-element queue ranks by nothing, so nRegisteredHeight
+        // and payee_score() never entered into it -- the real coinbase paid the
+        // real queue head, and that was reported as PAYEE DESYNC. Wipe, demote,
+        // and one of only three bridge re-arms spent on a masternode set that
+        // never existed. The wipe resets the cursor to 0, re-opening the same
+        // hole, so it repeated at the next registration (2513260 -> 2513261) and
+        // stopped only when a live tip block pinned the cursor forward and the
+        // out-of-order guard began dropping the remaining bodies. Of the nine
+        // ProRegTx in 2513001..2515567, both that landed inside the unguarded
+        // run mis-scored; the other seven were never applied at all.
+        //
+        // Refuse the fold, and SAY WHICH refusal this is. "No seed yet" and "the
+        // queue diverged from the chain" are opposite conditions -- one is
+        // ordinary startup, the other is a defect -- and in the log they were
+        // indistinguishable.
+        if (m_require_seeded_mn && m_mn_snapshot_height == 0) {
+            ++m_unseeded_payee_folds;
+            if (m_unseeded_payee_first_h == 0) m_unseeded_payee_first_h = height;
+            m_unseeded_payee_last_h = height;
+            if (m_unseeded_payee_folds == 1
+                || (m_unseeded_payee_folds % 1000) == 0) {
+                LOG_INFO
+                    << "[EMB-DASH] payee fold SKIPPED at h=" << height
+                    << ": no authoritative masternode snapshot is in force"
+                       " (snapshot height 0, "
+                    << (m_mn_needs_reseed ? "re-seed pending after a wipe"
+                                          : "never seeded")
+                    << ") — NOT a divergence. An unseeded payee machine has no"
+                       " payment queue, so any projection off it would be a"
+                       " guess and any mismatch a phantom. "
+                    << m_unseeded_payee_folds << " block(s) skipped so far (h="
+                    << m_unseeded_payee_first_h << ".." << height
+                    << "). Folding resumes when the checkpoint bridge or an RPC"
+                       " seed publishes a height-stamped set.";
+            }
+            MnStateMachine::ApplyResult r;
+            r.total_after = m_state.mnstates().size();
+            return r;
+        }
         auto r    = m_state.mnstates().apply_block(block, height);
         // PAYEE DESYNC (soak-found 2026-07-22, bad-cb-payee class): the
         // connected block's coinbase does not pay the MN our queue projects.
@@ -857,6 +916,16 @@ public:
     /// turns it on for the whole embedded arm.
     void set_require_seeded_mn_set(bool on) { m_require_seeded_mn = on; }
     bool require_seeded_mn_set() const { return m_require_seeded_mn; }
+
+    /// The unseeded-payee-fold guard's own witnesses: how many blocks it
+    /// refused to fold because no height-stamped masternode snapshot was in
+    /// force, and the height span they covered. A nonzero count during a
+    /// checkpoint bridge is EXPECTED and benign — it is the historical block
+    /// bodies the bridge is downloading, which belong to the lane's private
+    /// replay machine and not to this one.
+    size_t   unseeded_payee_folds_skipped() const { return m_unseeded_payee_folds; }
+    uint32_t unseeded_payee_first_height()  const { return m_unseeded_payee_first_h; }
+    uint32_t unseeded_payee_last_height()   const { return m_unseeded_payee_last_h; }
 
     /// Height the applied SML/quorum state is current AT (0 = none yet),
     /// tracked off each accepted mnlistdiff's cbTx.nHeight. Read-only;
@@ -1194,6 +1263,15 @@ private:
     // queue; only a non-empty on_mn_list_update resync clears it. While set,
     // MN-readiness must not re-arm off incidental per-block registrations.
     bool m_mn_needs_reseed{false};
+
+    // Blocks the unseeded-payee-fold guard refused, and the height span they
+    // covered. Counted rather than merely skipped so a test can assert the
+    // guard FIRED: "no payee desync was reported" is also what a silently
+    // broken block_connected subscription produces, and the two must not be
+    // the same observation.
+    size_t   m_unseeded_payee_folds{0};
+    uint32_t m_unseeded_payee_first_h{0};
+    uint32_t m_unseeded_payee_last_h{0};
 
     // Last observed tip params, applied on republish().
     uint32_t m_prev_height{0};

--- a/test/test_dash_mn_checkpoint.cpp
+++ b/test/test_dash_mn_checkpoint.cpp
@@ -4797,3 +4797,104 @@ TEST(DashMnCheckpointSelfReArm, NoSecondAskIsPossibleSoTheLaneMustRecoverAlone)
         << "the lane stayed terminal with the gate long cleared — this is the"
            " 2h39m the soak measured: " << r.h.lane.status();
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 17. THE UNSEEDED PAYEE FOLD — the phantom desync the 0803 soaks reported.
+//
+// Three independent contabo soaks (0803c/d/e, started at tips 2515478 /
+// 2515518 / 2515558) each reported PAYEE DESYNC at exactly h=2513168 and
+// h=2513261, wiped the payee set, demoted, and spent a bridge re-arm. Neither
+// height is a divergence.
+//
+// The maintainer and MnCheckpointLane subscribe to the SAME
+// Node::block_connected event and hold SEPARATE MnStateMachines. The lane's
+// request_window() downloads historical block bodies from the anchor forward;
+// every one of them was also delivered here, to a payee machine that no
+// authoritative snapshot had ever seeded. apply_block's out-of-order and
+// contiguity guards are both conditioned on `m_last_applied_height != 0`, so a
+// cold cursor accepted the first body and rode the window. The ProRegTx in
+// mainnet block 2513167 then registered the ONE entry this set held, and
+// 2513168 projected it — a one-element queue ranks by nothing, so this was
+// never a payee_score()/nRegisteredHeight fault. The real coinbase paid the
+// real queue head, and the mismatch was reported as a divergence.
+//
+// The lane, replaying the SAME blocks through the SAME apply_block but holding
+// the full 2974-entry anchor, mis-scored NEITHER registration. That contrast is
+// the whole diagnosis, and these cases pin both halves of it.
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashMnPayeeLatch, UnseededMaintainerRefusesToFoldBridgeWindowBodies)
+{
+    dash::coin::NodeCoinState st;
+    dash::coin::CoinStateMaintainer m{st};
+    m.set_require_seeded_mn_set(true);          // the embedded-arm posture
+
+    // The pure-daemonless startup state, not a contrived one: the checkpoint is
+    // armed into the LANE, and nothing seeds this machine until the bridge
+    // publishes.
+    ASSERT_EQ(st.mnstates().size(), 0u);
+    ASSERT_EQ(st.mnstates().last_applied_height(), 0u);
+
+    // A historical bridge-window body carrying the window's first ProRegTx —
+    // mainnet 2513167's shape.
+    const uint32_t kReg = 2513167;
+    auto reg_blk = block_from_hex(kBlockHex1519544);
+    reg_blk.m_txs.push_back(pro_reg_tx(synth_script(0x42), 1));
+    latch_bind(reg_blk);   // the body must still bind to its header
+
+    const auto r1 = m.on_block_connected(reg_blk, kReg);
+    EXPECT_EQ(r1.registered, 0u)
+        << "a ProRegTx carried by a bridge-window body must not enter the LIVE"
+           " payee machine — that registration belongs to the lane's private"
+           " replay, which holds the anchored set to put it in context";
+    EXPECT_EQ(st.mnstates().size(), 0u);
+    EXPECT_EQ(st.mnstates().last_applied_height(), 0u)
+        << "the cursor must stay cold. Pinning it to a historical height is what"
+           " manufactured the 2005-block APPLY GAP the moment the live tip"
+           " arrived, and that gap burned a third re-seed ask";
+
+    // The next block is the one that reported PAYEE DESYNC on mainnet, because
+    // its predecessor had left a payment queue of exactly one masternode.
+    auto next_blk = block_from_hex(kBlockHex1519544);
+    const auto r2 = m.on_block_connected(next_blk, kReg + 1);
+    EXPECT_FALSE(r2.payee_desync)
+        << "an unseeded queue cannot diverge from anything. Reporting a desync"
+           " here wiped a masternode set that never existed, demoted the arm,"
+           " and spent one of only three bridge re-arms";
+    EXPECT_FALSE(r2.gap_detected);
+    EXPECT_FALSE(st.mn_needs_reseed());
+
+    // The guard must SAY IT FIRED. Without this witness every expectation above
+    // also passes on a maintainer whose block_connected subscription is simply
+    // dead — an absence and a refusal must not be the same observation.
+    EXPECT_EQ(m.unseeded_payee_folds_skipped(), 2u);
+    EXPECT_EQ(m.unseeded_payee_first_height(), kReg);
+    EXPECT_EQ(m.unseeded_payee_last_height(), kReg + 1);
+}
+
+// The other half: the guard must not have bought its silence by disabling
+// detection. Once a height-stamped snapshot is in force, the SAME machine folds
+// normally and a REAL divergence is still terminal.
+TEST(DashMnPayeeLatch, SeededMaintainerStillFoldsAndStillReportsDivergence)
+{
+    dash::coin::NodeCoinState st;
+    dash::coin::CoinStateMaintainer m{st};
+    m.set_require_seeded_mn_set(true);
+
+    auto cp = good_checkpoint();
+    m.on_mn_list_update(cp.entries, kAnchorHeight);
+    ASSERT_FALSE(st.mn_needs_reseed());
+
+    // A coinbase that pays nobody this set projects: a genuine divergence.
+    auto blk = repay_coinbase(block_from_hex(kBlockHex1519544),
+                              payout_of(cp, kQ1), synth_script(0x7f));
+    const auto r = m.on_block_connected(blk, kAnchorHeight + 1);
+
+    EXPECT_TRUE(r.payee_desync)
+        << "the guard must gate on 'is a snapshot in force', never on 'is a"
+           " mismatch inconvenient' — a seeded queue that disagrees with an"
+           " accepted coinbase is exactly the bad-cb-payee this arm exists to"
+           " refuse to serve";
+    EXPECT_TRUE(st.mn_needs_reseed());
+    EXPECT_EQ(m.unseeded_payee_folds_skipped(), 0u)
+        << "a seeded fold must never be counted as an unseeded skip";
+}

--- a/test/test_dash_mn_checkpoint.cpp
+++ b/test/test_dash_mn_checkpoint.cpp
@@ -4887,6 +4887,7 @@ TEST(DashMnPayeeLatch, SeededMaintainerStillFoldsAndStillReportsDivergence)
     // A coinbase that pays nobody this set projects: a genuine divergence.
     auto blk = repay_coinbase(block_from_hex(kBlockHex1519544),
                               payout_of(cp, kQ1), synth_script(0x7f));
+    latch_bind(blk);   // rewriting the coinbase moved the body's merkle root
     const auto r = m.on_block_connected(blk, kAnchorHeight + 1);
 
     EXPECT_TRUE(r.payee_desync)


### PR DESCRIPTION
## What this is

Three independent contabo soaks (`0803c` / `0803d` / `0803e`, started against tips
2515478 / 2515518 / 2515558) each reported `PAYEE DESYNC` at **exactly** h=2513168 and
h=2513261, wiped the payee set, demoted the embedded arm and spent a bridge re-arm.
Neither height is a divergence. Both are phantoms.

## Why the bridge completed anyway — the two-machine split

`CoinStateMaintainer` and `MnCheckpointLane` subscribe to the **same**
`Node::block_connected` event (`main_dash.cpp` leg-3 wiring and the lane driver leg)
and hold **separate** `MnStateMachine` instances — the lane's is
`mn_checkpoint_lane.hpp:2233`, a private member by value.

That is the whole answer to "h=2513261 desynced inside the final pass and there is no
on-demand fold there, yet the bridge completed". It never desynced in the bridge pass.
The log distinguishes them cleanly:

| Emitter | Next line in the log | Heights in soak0803e |
|---|---|---|
| maintainer (`coin_state_maintainer.hpp:784`) | `[EMB-DASH] MN payee queue …` | 2513168, 2513261 (+ gap at 2515559) |
| lane (`mn_checkpoint_lane.hpp:1057`/`1069`) | `[MN-CKPT] ON-DEMAND PoSe fold` | 2513489, 2513860, 2514150, 2514874 |

Six `MNS-SM` desyncs, exactly three `EMB-DASH` events. All four lane desyncs were
repaired by an on-demand fold. Nothing absorbed 2513261 and no pass restarted — the
bridge simply never saw a mismatch there, so it fail-closed zero times.

## The actual defect

In the pure-daemonless posture the checkpoint is armed into the **lane only**; the
maintainer's payee machine starts empty with `m_mn_snapshot_height == 0` and
`m_last_applied_height == 0`.

1. The lane's `request_window()` downloads **historical** block bodies from the anchor
   forward. Both subscribers receive every one.
2. The E2c snapshot fence (`coin_state_maintainer.hpp:759`) is conditioned on
   `m_mn_snapshot_height != 0`, so with no seed it does not fire.
3. Both of `apply_block`'s ordering guards (`mn_state_machine.hpp:1048` out-of-order,
   `:1066` contiguity) are conditioned on `m_last_applied_height != 0`. A cold cursor
   accepts the first body and then rides the window contiguously.
4. Block 2513167 carried the window's first ProRegTx and registered the **one** entry
   the set held. Block 2513168 projected it (`:1090`, `ranked.front()`).
5. A one-element queue ranks by nothing, so `payee_score()` and `nRegisteredHeight`
   never entered into it. The real coinbase paid the real queue head → `payee_desync`.
6. The wipe calls `load({})`, which resets the cursor to 0 (`mn_state_machine.hpp:402`),
   reopening the hole — so it repeated at the next registration (2513260 → 2513261).

It stopped after two only because a live tip block then tripped the gap guard on a
cursor of 2513553 and pinned it forward, after which the out-of-order guard silently
dropped the remaining bridge bodies.

## The contrast that settles it

The lane replayed the **same blocks** through the **same** `apply_block`, holding the
full 2974-entry anchor, and mis-scored **neither** registration. The set contents
differed; the ranking did not. `payee_score()` is exonerated.

## Generalisation

`protx list registered true 2515567` gives exactly **9** ProRegTx in 2513001..2515567,
matching the bridge's own `+9 reg`:

| Height | mis-scored? | why |
|---|---|---|
| 2513167 | **yes** → desync 2513168 | inside the unguarded run |
| 2513260 | **yes** → desync 2513261 | inside the unguarded run |
| 2513967, 2514219, 2514231, 2515019, 2515024, 2515028 ×2 | no | **never applied** — cursor already pinned to the live tip |

2 of 2 inside the exposed window (2513001..2513553); 0 of 7 outside it. The seven are
**not** a measurement that the defect is bounded — they are the out-of-order guard
dropping them. Had no live block pinned the cursor, each would be expected to
mis-score at exactly ProRegTx+1.

## The change

Refuse the fold while no height-stamped snapshot is in force, and **name** the refusal.
"No seed yet" and "the queue diverged from the chain" are opposite conditions — one is
ordinary startup, the other is a defect — and in the log they were indistinguishable.

Gated on the existing `require_seeded_mn_set()` posture, so every construction site that
has not opted in (the KATs, the dashd-RPC posture) keeps byte-identical behaviour.
`main_dash` opts the embedded arm in.

Witness accessors (`unseeded_payee_folds_skipped()` / `first_height()` / `last_height()`)
exist so a test asserts the guard **fired** — an absence of desyncs is also what a dead
`block_connected` subscription produces, and the two must not be the same observation.

## Tests

- `DashMnPayeeLatch.UnseededMaintainerRefusesToFoldBridgeWindowBodies` — the mainnet
  shape: a ProRegTx-bearing body then its successor must leave the cursor cold, register
  nothing, report no desync, and the guard's counters must show it fired.
- `DashMnPayeeLatch.SeededMaintainerStillFoldsAndStillReportsDivergence` — the paired
  positive control: a seeded queue disagreeing with an accepted coinbase is still a
  terminal `payee_desync`. The guard must gate on "is a snapshot in force", never on
  "is a mismatch inconvenient".

Both live in `test_dash_mn_checkpoint.cpp`, which is folded into the allowlisted
`test_dash_node_reception_wire` target — not a new `add_executable` that would report
"Not Run".

## Scope / overlap

Touches `coin_state_maintainer.hpp` only on the source side. **#1045** touches
`mn_checkpoint_lane.hpp` and `test_dash_mn_checkpoint.cpp`; there is no source overlap,
and the test additions here are appended at end-of-file.

## Separate finding, NOT fixed here

Bridge arming is gated on `tip >= m_anchor_height` (`mn_checkpoint_lane.hpp:851`), not on
header-chain sync — so the bridge arms mid-header-sync and sizes its window from a partial
tip. Reproduced in all three soaks (`bridge START … 2514000` while the real tip was
2515478/2515518/2515558). It is real, and it is **not** the cause of these desyncs: in
soaks c and d header sync reached 100% *before* the desync at 2513168 fired, and the
maintainer's set and cursor have nothing to do with the bridge's window bounds. Gating
arming on `is_synced()` would not have prevented a single one of them. Left for its own
change so a refuted hypothesis's fix does not ride along with the real one.
