### PR TITLE
btc(hstats-944): stand up core::WebServer + graph_db persist inline in main_btc

### DIFF
--- a/src/c2pool/main_btc.cpp
+++ b/src/c2pool/main_btc.cpp
@@ -55,6 +55,7 @@
 #include <core/pack.hpp>
 #include <core/hash.hpp>
 #include <core/stratum_server.hpp>
+#include <core/web_server.hpp>          // H-STATS.944: operator dashboard + graph_db persist
 #include <btclibs/util/strencodings.h>
 
 #include <boost/asio.hpp>
@@ -152,6 +153,8 @@ int main(int argc, char* argv[])
     uint16_t    p2pool_port   = 0;
     std::string stratum_addr  = "0.0.0.0";  // listen all interfaces by default
     uint16_t    stratum_port  = 0;          // 0 disables stratum; --stratum sets it
+    std::string http_addr     = "0.0.0.0";  // dashboard bind; --http sets it (H-STATS.944)
+    uint16_t    http_port     = 0;          // 0 disables dashboard; --http sets it (H-STATS.944)
     uint16_t    sharechain_port = 0;        // 0 = default P2P_PORT (9333); --sharechain-port overrides (opt-in isolation)
     std::string network_id_hex;             // --network-id: c2pool IDENTIFIER override (empty = public net)
     std::string prefix_hex;                 // --prefix: c2pool PREFIX override (empty = compiled default)
@@ -230,6 +233,20 @@ int main(int argc, char* argv[])
             } else {
                 stratum_addr = ep.substr(0, colon);
                 stratum_port = static_cast<uint16_t>(std::stoi(ep.substr(colon + 1)));
+            }
+        }
+        else if (arg == "--http" && i + 1 < argc)
+        {
+            // --http [HOST:]PORT — bind the H-STATS.944 operator dashboard.
+            // HOST defaults to 0.0.0.0. When omitted entirely, the dashboard
+            // is disabled (mirrors --stratum).
+            std::string ep = argv[++i];
+            auto colon = ep.find(':');
+            if (colon == std::string::npos) {
+                http_port = static_cast<uint16_t>(std::stoi(ep));
+            } else {
+                http_addr = ep.substr(0, colon);
+                http_port = static_cast<uint16_t>(std::stoi(ep.substr(colon + 1)));
             }
         }
         else if (arg == "--sharechain-port" && i + 1 < argc)
@@ -1601,6 +1618,70 @@ int main(int argc, char* argv[])
     // if a signal arrived during early init. That's fine — the `if` guard in
     // the lambda handles it.
     stratum_server_for_shutdown = std::move(stratum_server);
+
+    // ââ Operator dashboard + graph_db stats persistence (H-STATS.944) ââ
+    // Mirror of bch standup_pool_run (PR #1040 "stand up core::WebServer + graph_db
+    // persist", commit 2b9fc26c; integrator 2026-08-03 "copy the shape"). main_btc
+    // has no factored standup_pool_run, so the SAME core::WebServer standup lives
+    // inline here, right after the stratum block, held at main scope so it and its
+    // stats timer outlive the run-loop. ISOLATION: constructs existing core classes
+    // only â ZERO src/core edits â so this stays OFF the four-coin smoke gate. node
+    // == nullptr: BTC coin_node does not implement core::IMiningNode; the dashboard +
+    // graph_db stat-log path does not require it (a live adapter is a follow-up
+    // slice). Blockchain::BITCOIN selects the SHA256d graph_db constant pairing.
+    std::unique_ptr<core::WebServer> web_server;
+    std::shared_ptr<boost::asio::steady_timer> stats_timer;
+    if (http_port != 0) {
+        const bool web_is_testnet = testnet || testnet4 || regtest;
+        web_server = std::make_unique<core::WebServer>(
+            ioc, http_addr, http_port, web_is_testnet,
+            std::shared_ptr<core::IMiningNode>{},          // no IMiningNode adapter yet
+            c2pool::address::Blockchain::BITCOIN);         // SHA256d graph_db pairing
+        auto* mi = web_server->get_mining_interface();
+#ifdef C2POOL_VERSION
+        mi->set_coin_label("BTC");
+        mi->set_pool_version("c2pool/" C2POOL_VERSION);
+#endif
+        mi->set_io_context(&ioc);
+        web_server->set_stratum_port(stratum_port);
+
+        // graph_db stats persistence â survives restarts (LTC-parity site 2/3,
+        // mirrors main_ltc.cpp:1967-1973). BTC-namespaced sub-dir keeps the per-coin
+        // stat log isolated under the shared config path.
+        {
+            std::string net_label = web_is_testnet ? "testnet" : "mainnet";
+            std::string graph_db_path = (core::filesystem::config_path()
+                / net_label / "btc" / "graph_db").string();
+            mi->set_stat_log_path(graph_db_path);
+            mi->load_stat_log();
+            LOG_INFO << "[BTC-POOL] graph_db stats persistence -> " << graph_db_path;
+        }
+
+        if (web_server->start()) {
+            // LTC-parity site 3/3: periodic save_stat_log every 100s (matches p2pool
+            // graph_db + main_ltc.cpp:7429). Self-rescheduling steady_timer on the SAME
+            // ioc the run-loop drives; captured by shared_ptr so it outlives each
+            // async_wait continuation.
+            stats_timer = std::make_shared<boost::asio::steady_timer>(ioc);
+            auto save_fn = std::make_shared<std::function<void(boost::system::error_code)>>();
+            *save_fn = [stats_timer, save_fn, mi](boost::system::error_code ec) {
+                if (ec) return;
+                mi->save_stat_log();
+                stats_timer->expires_after(std::chrono::seconds(100));
+                stats_timer->async_wait(*save_fn);
+            };
+            stats_timer->expires_after(std::chrono::seconds(100));
+            stats_timer->async_wait(*save_fn);
+            LOG_INFO << "[BTC-POOL] dashboard live on http://" << http_addr << ":"
+                     << http_port << " (graph_db persist every 100s).";
+        } else {
+            LOG_ERROR << "[BTC-POOL] WebServer FAILED to bind " << http_addr << ":"
+                      << http_port << " â dashboard disabled, run-loop continues.";
+            web_server.reset();
+        }
+    } else {
+        LOG_INFO << "[BTC-POOL] dashboard disabled (no --http bind given).";
+    }
 
     LOG_INFO << "[BTC] io_context running. Ctrl-C to stop.";
 


### PR DESCRIPTION
Stands up the operator dashboard + graph_db stats persistence for the BTC pool, mirroring the bch standup shape (PR #1040 "stand up core::WebServer + graph_db persist", commit 2b9fc26c).

Scope: `src/c2pool/main_btc.cpp` only, 81 insertions, ZERO `src/core` edits.

- Adds `--http [HOST:]PORT` to bind the dashboard (mirrors `--stratum`; omitted = disabled).
- Constructs `core::WebServer` held at main scope so it and its stats timer outlive the run-loop; `Blockchain::BITCOIN` selects the SHA256d graph_db pairing.
- graph_db `load_stat_log` / periodic `save_stat_log` every 100s on the run-loop ioc (LTC-parity, main_ltc.cpp:1967/7429), BTC-namespaced sub-dir.
- Bind failure logs and disables the dashboard; the run-loop continues.

Isolation: constructs existing core classes only, so it stays off the four-coin smoke gate. `node == nullptr` — BTC coin_node does not yet implement `core::IMiningNode`; a live adapter is a follow-up slice.
