### PR TITLE
bch(pool): name the WebServer standup per-lane in the boot log (bootstrap/no-silent-ctor)

### DIFF
--- a/src/impl/bch/pool_entrypoint.hpp
+++ b/src/impl/bch/pool_entrypoint.hpp
@@ -640,11 +640,27 @@ inline void standup_pool_run(boost::asio::io_context& ioc,
     std::unique_ptr<core::WebServer> web_server;
     std::shared_ptr<boost::asio::steady_timer> stats_timer;
     if (http_port != 0) {
+        // No-silent-ctor bracket (integrator req #2, per-lane port of ltc #1041).
+        // core::WebServer's ctor already logs "core::WebServer constructed on ..."
+        // (shared, blockchain= numeric only); these two BCH-namespaced lines make
+        // the boot log self-identify THIS lane's dashboard standup on the way in
+        // and out, so a ctor that throws mid-standup shows as an unmatched
+        // "standing up" with no "constructed" follow-up. src/impl/bch only.
+        LOG_INFO << "[BCH-POOL] standing up core::WebServer + MiningInterface (http bind "
+                 << http_addr << ":" << http_port << ") ...";
         web_server = std::make_unique<core::WebServer>(
             ioc, http_addr, http_port, is_testnet,
             std::shared_ptr<core::IMiningNode>{},        // no IMiningNode adapter yet
             c2pool::address::Blockchain::BITCOIN);       // SHA256d graph_db pairing
         auto* mi = web_server->get_mining_interface();
+        if (mi == nullptr) {
+            LOG_ERROR << "[BCH-POOL] core::WebServer constructed but MiningInterface is"
+                      << " NULL -- dashboard disabled, run-loop continues.";
+            web_server.reset();
+        }
+        if (mi != nullptr) {
+        LOG_INFO << "[BCH-POOL] core::WebServer + MiningInterface constructed (coin=BCH, "
+                 << "http " << http_addr << ":" << http_port << "); MiningInterface alive.";
 #ifdef C2POOL_VERSION
         mi->set_coin_label("BCH");
         mi->set_pool_version("c2pool/" C2POOL_VERSION);
@@ -686,6 +702,7 @@ inline void standup_pool_run(boost::asio::io_context& ioc,
                       << http_port << " -- dashboard disabled, run-loop continues.";
             web_server.reset();
         }
+        } // if (mi != nullptr)
     } else {
         LOG_INFO << "[BCH-POOL] dashboard disabled (no --http bind given).";
     }


### PR DESCRIPTION
Bootstrap + broadcaster-reuse milestone (integrator 2026-08-03), BCH lane. Reuses the LTC embedded run-path shape (/var/lib/agentmail/ltc-embedded-runpath-shape.md).

## What already landed (H-STATS.944, #1040)
standup_pool_run already constructs core::WebServer + MiningInterface, wires set_stratum_port, graph_db persistence, start() before ioc.run(), and the http_port bootstrap arg. The 6-arg core::WebServer ctor already logs its own construction (shared, per #1041) — but only as blockchain= numeric, not naming the coin.

## What this PR adds (acceptance #2: no silent/anonymous ctor, per-lane)
- BCH-namespaced bracket around the WebServer construction: a standing-up line before make_unique and a constructed (coin=BCH) ... MiningInterface alive line after get_mining_interface(). A ctor that throws mid-standup shows as an unmatched standing-up with no constructed follow-up.
- Null-MiningInterface guard: disables the dashboard and continues the run-loop instead of dereferencing null.

## Isolation (acceptance #3)
src/impl/bch/pool_entrypoint.hpp only. Constructs existing core classes; ZERO src/core / bitcoin_family edits; stays off the four-coin smoke gate.

## Verification
-fsyntax-only with the real build_911verify flags = exit 0. CI to compile (acceptance #1). do-not-merge until integrator routes on operator tap.

Head SHA a2831714b, GPG Good (285EFE76).