### PR TITLE
dash(daemonless): drop the runtime-DISABLED LLMQ_50_60 from mainnet's required LLMQ set + a negative-capable type reconciler

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -66,6 +66,7 @@
 #include <impl/dash/coin/dkg_window.hpp>       // dash::coin::is_dkg_commitment_window (BLOCKER-1 guard)
 #include <impl/dash/coin/dkg_commitments.hpp>  // E1: build_daemonless_qc_plan (serve DKG windows daemonlessly)
 #include <impl/dash/coin/vendor/bls_verify.hpp>  // E1 Phase-L: make_commitment_bls_verifier (real qc verify seam)
+#include <impl/dash/coin/llmq_type_reconciler.hpp>  // negative-capable enabled_llmqs backstop
 #include <impl/dash/coin/quorum_member_source.hpp>  // E1 Phase-L: daemonless member-set sourcing (the provider)
 #include <impl/dash/coin/utxo_lane.hpp>    // dash::coin::UtxoLane — embedded UTXO/fee lane (E2b, #738)
 #include <impl/dash/coin/header_chain.hpp>       // dash::coin::HeaderChain — SPV header/tip authority (E2a)
@@ -3265,11 +3266,35 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             auto qc_gap_logged_h  = std::make_shared<uint32_t>(0u);
             auto qc_first_plan_h  = std::make_shared<uint32_t>(0u);
             auto qc_cold_note_done = std::make_shared<bool>(false);
+            // NEGATIVE-CAPABLE BACKSTOP for the enabled-type table itself
+            // (llmq_type_reconciler.hpp). The mainnet LLMQ_50_60 defect was
+            // invisible because "required but NONEXISTENT" and "required but
+            // NOT YET ARRIVED" print the same refusal — the second looks like
+            // patience. This watches the mnlistdiff-fed mined set (already
+            // current at every template build, so no new wire traffic) and
+            // says the thing no per-height log can: which required type has
+            // NEVER been mined while the others plainly were — and the
+            // reverse, a mined type we do not require.
+            auto qc_type_recon =
+                std::make_shared<dash::coin::LlmqTypeReconciler>(qc_net);
+            auto qc_recon_said = std::make_shared<std::string>();
             node_coin_state.set_qc_plan_fn(
                 [&node_coin_state, hc = header_chain.get(), qc_net, qc_cache,
-                 qc_gap_logged_h, qc_first_plan_h, qc_cold_note_done]
+                 qc_gap_logged_h, qc_first_plan_h, qc_cold_note_done,
+                 qc_type_recon, qc_recon_said]
                 (uint32_t next_h) -> std::optional<dash::coin::QcBlockPlan> {
                     if (*qc_first_plan_h == 0u) *qc_first_plan_h = next_h;
+                    // Observe the MINED set at the tip we are building on.
+                    if (next_h > 0)
+                        qc_type_recon->observe(next_h - 1u,
+                                               node_coin_state.qmgr());
+                    // Log only when the SENTENCE CHANGES — a new offending
+                    // type must never be swallowed by dedup on an old one.
+                    if (auto said = qc_type_recon->format_defects();
+                        !said.empty() && said != *qc_recon_said) {
+                        *qc_recon_said = said;
+                        LOG_WARNING << said;
+                    }
                     dash::coin::RequiredQcSlot gap{};
                     auto plan = dash::coin::build_daemonless_qc_plan(
                         qc_net, next_h, node_coin_state.qmgr(),

--- a/src/impl/dash/coin/dkg_commitments.hpp
+++ b/src/impl/dash/coin/dkg_commitments.hpp
@@ -163,11 +163,17 @@
 /// mining window closes — both are bounded by cycleStart +
 /// dkgMiningWindowEnd, which is why the incident self-healed in 4 blocks.
 ///
-/// MAINTENANCE: the params table + enabled sets + V19 floors below are
-/// copied VERBATIM from dashcore llmq/params.h + chainparams.cpp @
-/// cfad414. RE-DIFF on every vendored-dashcore pin bump (same rule as
-/// dkg_window.hpp) — a params change silently mis-shapes the mandatory
-/// set at window heights.
+/// MAINTENANCE: the params table + V19 floors below are copied VERBATIM
+/// from dashcore llmq/params.h + chainparams.cpp @ cfad414. The ENABLED
+/// SETS are NOT a copy of anything — they are DERIVED (see enabled_llmqs
+/// below) by evaluating dashd's runtime IsQuorumTypeEnabled predicate at
+/// our serve floor, because that predicate, not the chainparams AddLLMQ
+/// list, is what ProcessBlock requires. RE-DERIVE on every
+/// vendored-dashcore pin bump (same rule as dkg_window.hpp) — a params
+/// OR predicate change silently mis-shapes the mandatory set at window
+/// heights, and a type we require that the chain does not mine fails
+/// every window height closed forever. LlmqTypeReconciler
+/// (llmq_type_reconciler.hpp) is the runtime backstop for exactly that.
 
 #include <impl/dash/coin/quorum_manager.hpp>
 #include <impl/dash/coin/quorum_root.hpp>
@@ -218,14 +224,75 @@ inline constexpr LlmqParamsView kLlmq400_85 {3, 400, 350, 340, 576, 20, 48, 4,  
 inline constexpr LlmqParamsView kLlmq100_67 {4, 100, 80,  67,  24,  10, 18, 24, false};
 inline constexpr LlmqParamsView kLlmq25_67  {6, 25,  22,  17,  24,  10, 18, 24, false};
 
-/// Enabled LLMQ types per network, IN dashd's AddLLMQ ORDER (chainparams.cpp:
-/// mainnet 269-273, testnet 459-464). The order matters for byte parity: the
-/// miner emits qc txs in GetEnabledQuorumParams enumeration order
-/// (node/miner.cpp CreateNewBlock), which is AddLLMQ insertion order.
+/// Enabled LLMQ types per network, in dashd's enumeration order.
+///
+/// ⚠ THE ENABLED SET IS *NOT* THE chainparams AddLLMQ LIST. That was the bug
+/// this table shipped with (mainnet, fixed 2026-08-03; see LLMQ_50_60 below).
+/// dashd's consensus requirement is driven by
+/// `GetEnabledQuorumParams(chainman, pindexPrev)` (llmq/options.cpp), which
+/// FILTERS the chainparams list through
+/// `ChainstateManager::IsQuorumTypeEnabled` (validation.cpp) — a RUNTIME,
+/// HEIGHT- AND NETWORK-dependent predicate. `CQuorumBlockProcessor::ProcessBlock`
+/// iterates that filtered list, so a chainparams type the predicate rejects is
+/// NOT required (and must NOT be emitted: bad-qc-not-allowed). The filter
+/// preserves chainparams order, so the byte-parity ordering argument is
+/// unchanged: the miner emits qc txs in this enumeration order
+/// (node/miner.cpp CreateNewBlock).
+///
+/// The predicate, verbatim (dashpay/dash v23.1.7 validation.cpp
+/// ChainstateManager::IsQuorumTypeEnabled), for the types we carry:
+///
+///   LLMQ_50_60  : !fDIP0024IsActive || !fHaveDIP0024Quorums
+///                 || network == testnet || network == devnet
+///   LLMQ_60_75  : fDIP0024IsActive
+///   LLMQ_400_60 : true
+///   LLMQ_400_85 : true
+///   LLMQ_100_67 : DeploymentActiveAfter(DIP0020)
+///   LLMQ_25_67  : height >= 847000        (testnet-only type)
+///
+/// where fDIP0024IsActive = DeploymentActiveAfter(pindexPrev, DIP0024) and
+/// fHaveDIP0024Quorums = pindexPrev->nHeight >= consensus.DIP0024QuorumsHeight.
+///
+/// Evaluated at (and only at) the heights this table is ever consulted — i.e.
+/// at or above qc_serve_floor(), which is V19Height on both networks
+/// (compute_required_qc_slots refuses below it):
+///
+///   MAINNET, floor 1899072 (chainparams.cpp: DIP0020Height 1516032,
+///   DIP0024Height 1737792, DIP0024QuorumsHeight 1738698, V19Height 1899072).
+///     * LLMQ_50_60 is DISABLED: at every height >= 1738698 both DIP0024 legs
+///       are true and mainnet is neither testnet nor devnet, so the predicate
+///       returns false — PERMANENTLY, 160374 blocks BELOW our serve floor.
+///       Requiring it emitted a mandatory type-1 slot that can never be
+///       satisfied (has_mined is false forever, no commitment is ever
+///       relayed), failing the WHOLE height closed at every height in the
+///       interval-24 window [10,18] — a structural 9-in-24 outage.
+///       CORROBORATED against a live Dash Core 23.1.7 mainnet node at height
+///       2515629: `quorum list` returns exactly the four keys below, in this
+///       order, and `quorum info 1 <hash>` returns "quorum not found" where
+///       type 4 on the same hash returns a full quorum. (Note `quorum info`
+///       says "invalid LLMQ type" only for types absent from CHAINPARAMS —
+///       type 1 IS in mainnet chainparams; it is the runtime predicate that
+///       disables it. Absence from `quorum list` is the enabled-set evidence,
+///       because quorum_list enumerates GetEnabledQuorumTypes.)
+///     * The other four are all enabled at/above the floor. => 4 types.
+///
+///   TESTNET, floor 850100 (DIP0020Height 414100, DIP0024Height 769700,
+///   DIP0024QuorumsHeight 770730, V19Height 850100).
+///     * LLMQ_50_60 STAYS. The predicate's third disjunct
+///       (`NetworkIDString() == TESTNET`) is unconditional and height-
+///       independent, so LLMQ_50_60 is enabled on testnet FOREVER — it is
+///       also testnet's llmqTypeChainLocks and llmqTypeMnhf. Removing it here
+///       would be a NEW defect, symmetric-looking and wrong.
+///     * LLMQ_25_67 is enabled from height 847000 < 850100. => 6 types.
+///
+/// RE-DERIVE THIS on every vendored-dashcore pin bump, from the PREDICATE, not
+/// from the AddLLMQ list. `LlmqTypeReconciler` (llmq_type_reconciler.hpp) is
+/// the runtime backstop that names a type we require here but that the chain
+/// never actually mines — and the reverse.
 inline const std::vector<LlmqParamsView>& enabled_llmqs(LlmqNetwork net)
 {
     static const std::vector<LlmqParamsView> kMainnet{
-        kLlmq50_60, kLlmq60_75, kLlmq400_60, kLlmq400_85, kLlmq100_67};
+        kLlmq60_75, kLlmq400_60, kLlmq400_85, kLlmq100_67};
     static const std::vector<LlmqParamsView> kTestnet{
         kLlmq50_60, kLlmq60_75, kLlmq400_60, kLlmq400_85, kLlmq100_67,
         kLlmq25_67};

--- a/src/impl/dash/coin/llmq_type_reconciler.hpp
+++ b/src/impl/dash/coin/llmq_type_reconciler.hpp
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// LLMQ-TYPE RECONCILER — the negative-capable backstop for enabled_llmqs().
+///
+/// WHY THIS EXISTS (mainnet, discovered 2026-08-03, shipped-wrong for months):
+/// `enabled_llmqs(Mainnet)` listed LLMQ_50_60 (type 1). dashd's consensus
+/// requirement is not the chainparams AddLLMQ list but that list FILTERED
+/// through the runtime `IsQuorumTypeEnabled` predicate, which disables
+/// LLMQ_50_60 on mainnet at every height >= DIP0024QuorumsHeight (1738698).
+/// So c2pool emitted a mandatory type-1 slot every 24-block DKG cycle that
+/// NOTHING could ever satisfy: `has_mined` false forever (no such commitment
+/// is ever mined), no qfcommit ever relayed, and the per-height completeness
+/// gate therefore failed the WHOLE height closed at every height whose phase
+/// lands in [10,18] — a permanent 9-in-24 structural outage.
+///
+/// THE REASON IT SURVIVED IS THE POINT OF THIS FILE. Every refusal it caused
+/// was indistinguishable from a refusal that is CORRECT: the log said
+/// "no-commitment-cached ... window=[...] remaining=N -> WHOLE height fails
+/// closed", which is exactly what a genuine cold-start relay gap says. The
+/// difference between "required but NONEXISTENT" and "required but NOT YET
+/// ARRIVED" is invisible at any single height — the second one looks like
+/// patience, and patience is the correct posture, so the operator waits. The
+/// only thing that separates them is TIME plus the negative: a type that is
+/// required and has NEVER, across whole DKG cycles, been observed in a mined
+/// commitment while OTHER required types were plainly being mined.
+///
+/// SO THIS CHECK IS BUILT TO BE ABLE TO FAIL. A check that cannot produce a
+/// negative is not evidence. `reconcile()` returns a verdict PER required
+/// type, and two of the four verdicts are defects:
+///
+///   * NeverObserved — we require it, the observation window covers a full
+///     DKG cycle of that type, other required types WERE observed mined in
+///     that same window, and this one produced zero sightings. That is the
+///     defect above, named, and it is reachable: feeding a mainnet-shaped
+///     observation stream with type 1 in the required set produces it.
+///   * UnexpectedType — the chain mines a type we do NOT require. This is the
+///     SAME class of error in the opposite direction (upstream ADDS a type, or
+///     re-enables one) and is the half a one-directional check would miss:
+///     the symptom there is bad-qc-missing on a block we thought was complete.
+///
+/// and two are not:
+///
+///   * Observed — required and seen. The healthy state.
+///   * Unevaluated — not enough observation yet. The HONEST value for a
+///     bootstrap that has not run long enough. It is never silently rendered
+///     as "fine"; `defects()` excludes it and `verdict_name()` prints it.
+///
+/// FALSE-POSITIVE DISCIPLINE. Slandering a type would be as bad as missing
+/// one, so promoting silence to NeverObserved requires POSITIVE proof that the
+/// observation channel was live: `kCorroborationRequired` — at least one OTHER
+/// required type must have been observed. Without that, a drained/bootstrapping
+/// QuorumManager (which reports nothing for ANY type) stays Unevaluated for
+/// every type rather than indicting all of them. Absence is only evidence when
+/// presence was demonstrable on the same channel.
+///
+/// THE OBSERVATION SOURCE is the mnlistdiff-fed QuorumManager active set. Per
+/// dkg_commitments.hpp that set IS dashd's
+/// GetMinedAndActiveCommitmentsUntilBlock(tip) — i.e. MINED commitments, which
+/// is precisely "which llmqTypes actually appear in mined qcTx". It is also
+/// already current at every template build, so the reconciler needs no new
+/// wire traffic and reaches a verdict inside one DKG cycle of the fastest
+/// type (24 blocks) rather than never.
+///
+/// A note on why a SINGLE tip sample is already nearly conclusive, and why we
+/// still do not act on one: an enabled non-rotated type holds
+/// signingActiveQuorumCount quorums active (24 for the interval-24 types,
+/// spanning 576 blocks of history), so a current active set contains EVERY
+/// enabled type. One sample would therefore be enough — except during our own
+/// SML bootstrap, when the set is legitimately partial. `kMinObservations`
+/// plus the corroboration rule buy that distinction cheaply.
+
+#include <impl/dash/coin/dkg_commitments.hpp>
+#include <impl/dash/coin/quorum_manager.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace dash {
+namespace coin {
+
+enum class LlmqTypeVerdict : uint8_t {
+    Unevaluated = 0,   // insufficient observation — the honest "don't know"
+    Observed,          // required AND seen in mined commitments
+    NeverObserved,     // required, span sufficient, corroborated, ZERO sightings
+    UnexpectedType,    // mined on-chain but NOT in our required set
+};
+
+inline const char* llmq_type_verdict_name(LlmqTypeVerdict v)
+{
+    switch (v) {
+        case LlmqTypeVerdict::Unevaluated:    return "unevaluated";
+        case LlmqTypeVerdict::Observed:       return "observed";
+        case LlmqTypeVerdict::NeverObserved:  return "REQUIRED-BUT-NEVER-OBSERVED";
+        case LlmqTypeVerdict::UnexpectedType: return "MINED-BUT-NOT-REQUIRED";
+    }
+    return "unevaluated";
+}
+
+/// True for the verdicts that are DEFECTS — a type table that disagrees with
+/// the chain, in either direction.
+inline bool is_llmq_type_defect(LlmqTypeVerdict v)
+{
+    return v == LlmqTypeVerdict::NeverObserved
+        || v == LlmqTypeVerdict::UnexpectedType;
+}
+
+struct LlmqTypeFinding {
+    uint8_t         llmq_type{0};
+    LlmqTypeVerdict verdict{LlmqTypeVerdict::Unevaluated};
+    bool            required{false};      // present in enabled_llmqs(net)
+    uint64_t        sightings{0};         // observations in which it appeared
+    uint32_t        first_height{0};      // 0 == never observed anything
+    uint32_t        last_height{0};
+    uint32_t        span_heights{0};      // last - first
+    uint32_t        dkg_interval{0};      // 0 for a non-required type
+    /// Why a verdict stayed Unevaluated — never guessed, never blank.
+    const char*     pending_reason{"n/a"};
+};
+
+class LlmqTypeReconciler {
+public:
+    /// Minimum number of observe() calls before ANY promotion out of
+    /// Unevaluated. Guards against a single degenerate sample.
+    static constexpr uint32_t kMinObservations = 8;
+    /// A required type is only indicted once the observation window spans at
+    /// least this many of ITS OWN full DKG cycles. One is enough: the type is
+    /// mined once per dkgInterval, so a complete cycle with zero sightings is
+    /// already a completed experiment.
+    static constexpr uint32_t kMinCyclesCovered = 1;
+    /// ...and only if at least one OTHER required type was observed, proving
+    /// the channel was live. See FALSE-POSITIVE DISCIPLINE above.
+    static constexpr bool kCorroborationRequired = true;
+
+    explicit LlmqTypeReconciler(LlmqNetwork net) : m_net(net) {}
+
+    /// Record the set of llmqTypes present in MINED commitments as of `tip`.
+    /// Duplicate types within one call count once (this is a set observation,
+    /// not a count of quorums).
+    void observe(uint32_t tip_height, const std::vector<uint8_t>& mined_types)
+    {
+        ++m_observations;
+        if (m_first_height == 0 || tip_height < m_first_height)
+            m_first_height = tip_height;
+        if (tip_height > m_last_height) m_last_height = tip_height;
+
+        std::set<uint8_t> uniq(mined_types.begin(), mined_types.end());
+        for (uint8_t t : uniq) {
+            auto& s = m_seen[t];
+            ++s.sightings;
+            if (s.first_height == 0 || tip_height < s.first_height)
+                s.first_height = tip_height;
+            if (tip_height > s.last_height) s.last_height = tip_height;
+        }
+    }
+
+    /// The production overload: the mnlistdiff-fed active set IS dashd's
+    /// mined-and-active commitment set (dkg_commitments.hpp header note).
+    void observe(uint32_t tip_height, const QuorumManager& qmgr)
+    {
+        std::vector<uint8_t> types;
+        types.reserve(qmgr.active_entries().size());
+        for (const auto& e : qmgr.active_entries())
+            types.push_back(e.key.llmqType);
+        observe(tip_height, types);
+    }
+
+    uint32_t observations() const { return m_observations; }
+    uint32_t span_heights() const
+    {
+        return m_last_height > m_first_height
+            ? (m_last_height - m_first_height) : 0u;
+    }
+
+    /// One finding per required type, plus one per observed-but-not-required
+    /// type. Deterministically ordered by llmqType so logs are diffable.
+    std::vector<LlmqTypeFinding> reconcile() const
+    {
+        const auto& required = enabled_llmqs(m_net);
+
+        // Corroboration: did ANY required type actually show up? Without this
+        // the channel itself may simply be empty, and an empty channel is not
+        // evidence about any particular type.
+        bool corroborated = false;
+        for (const auto& p : required) {
+            auto it = m_seen.find(p.type);
+            if (it != m_seen.end() && it->second.sightings > 0) {
+                corroborated = true;
+                break;
+            }
+        }
+
+        std::map<uint8_t, LlmqTypeFinding> out;
+
+        for (const auto& p : required) {
+            LlmqTypeFinding f;
+            f.llmq_type    = p.type;
+            f.required     = true;
+            f.dkg_interval = p.dkg_interval;
+            auto it = m_seen.find(p.type);
+            if (it != m_seen.end()) {
+                f.sightings    = it->second.sightings;
+                f.first_height = it->second.first_height;
+                f.last_height  = it->second.last_height;
+            }
+            f.span_heights = span_heights();
+
+            if (f.sightings > 0) {
+                f.verdict = LlmqTypeVerdict::Observed;
+            } else if (m_observations < kMinObservations) {
+                f.verdict = LlmqTypeVerdict::Unevaluated;
+                f.pending_reason = "too-few-observations";
+            } else if (p.dkg_interval == 0
+                       || f.span_heights < p.dkg_interval * kMinCyclesCovered) {
+                f.verdict = LlmqTypeVerdict::Unevaluated;
+                f.pending_reason = "span-shorter-than-one-dkg-cycle";
+            } else if (kCorroborationRequired && !corroborated) {
+                // Nothing at all was observed on this channel — indicting a
+                // type here would be slander, not a finding.
+                f.verdict = LlmqTypeVerdict::Unevaluated;
+                f.pending_reason = "no-required-type-observed-anywhere";
+            } else {
+                f.verdict = LlmqTypeVerdict::NeverObserved;
+                f.pending_reason = "n/a";
+            }
+            out[p.type] = f;
+        }
+
+        // The other direction: a type the chain mines that we do not require.
+        for (const auto& [t, s] : m_seen) {
+            if (out.count(t) != 0) continue;   // required, already handled
+            LlmqTypeFinding f;
+            f.llmq_type    = t;
+            f.required     = false;
+            f.sightings    = s.sightings;
+            f.first_height = s.first_height;
+            f.last_height  = s.last_height;
+            f.span_heights = span_heights();
+            if (m_observations < kMinObservations) {
+                f.verdict = LlmqTypeVerdict::Unevaluated;
+                f.pending_reason = "too-few-observations";
+            } else {
+                f.verdict = LlmqTypeVerdict::UnexpectedType;
+                f.pending_reason = "n/a";
+            }
+            out[t] = f;
+        }
+
+        std::vector<LlmqTypeFinding> v;
+        v.reserve(out.size());
+        for (const auto& [t, f] : out) v.push_back(f);
+        return v;
+    }
+
+    /// Only the findings that are defects. EMPTY IS A REAL RESULT — it means
+    /// the table agrees with the chain as far as the evidence goes, not that
+    /// nothing was checked (use observations()/span_heights() for that).
+    std::vector<LlmqTypeFinding> defects() const
+    {
+        std::vector<LlmqTypeFinding> v;
+        for (auto& f : reconcile())
+            if (is_llmq_type_defect(f.verdict)) v.push_back(f);
+        return v;
+    }
+
+    /// A LOUD one-line rendering, naming every offending type. Empty string
+    /// when there is nothing to say — callers must not log a bare "ok".
+    std::string format_defects() const
+    {
+        auto d = defects();
+        if (d.empty()) return {};
+        std::string s = "[LLMQ-TYPE-RECONCILE] ENABLED-SET DISAGREES WITH THE"
+                        " CHAIN — ";
+        s += (m_net == LlmqNetwork::Mainnet ? "mainnet" : "testnet");
+        s += " observations=" + std::to_string(m_observations)
+           + " span=" + std::to_string(span_heights()) + "b"
+           + " heights=[" + std::to_string(m_first_height) + ","
+           + std::to_string(m_last_height) + "]";
+        for (const auto& f : d) {
+            s += " | type=" + std::to_string(static_cast<int>(f.llmq_type))
+               + " " + llmq_type_verdict_name(f.verdict)
+               + " required=" + (f.required ? "yes" : "no")
+               + " sightings=" + std::to_string(f.sightings);
+            if (f.required)
+                s += " dkg_interval=" + std::to_string(f.dkg_interval);
+        }
+        if (std::any_of(d.begin(), d.end(), [](const LlmqTypeFinding& f) {
+                return f.verdict == LlmqTypeVerdict::NeverObserved; })) {
+            s += " || a REQUIRED type that is never mined makes every DKG"
+                 " mining-window height of that type PERMANENTLY unserveable"
+                 " (the slot can never be satisfied). Re-derive"
+                 " enabled_llmqs() from dashd's IsQuorumTypeEnabled predicate"
+                 " at our serve floor — NOT from the chainparams AddLLMQ list.";
+        }
+        if (std::any_of(d.begin(), d.end(), [](const LlmqTypeFinding& f) {
+                return f.verdict == LlmqTypeVerdict::UnexpectedType; })) {
+            s += " || a MINED type we do not require means our blocks omit a"
+                 " mandatory commitment (bad-qc-missing). Re-derive"
+                 " enabled_llmqs() before the next window height.";
+        }
+        return s;
+    }
+
+    void reset()
+    {
+        m_seen.clear();
+        m_observations = 0;
+        m_first_height = 0;
+        m_last_height  = 0;
+    }
+
+private:
+    struct Sighting {
+        uint64_t sightings{0};
+        uint32_t first_height{0};
+        uint32_t last_height{0};
+    };
+
+    LlmqNetwork m_net;
+    std::map<uint8_t, Sighting> m_seen;
+    uint32_t m_observations{0};
+    uint32_t m_first_height{0};
+    uint32_t m_last_height{0};
+};
+
+} // namespace coin
+} // namespace dash

--- a/test/test_dash_dkg_commitments.cpp
+++ b/test/test_dash_dkg_commitments.cpp
@@ -25,6 +25,7 @@
 
 #include <impl/dash/coin/dkg_commitments.hpp>
 #include <impl/dash/coin/dkg_window.hpp>
+#include <impl/dash/coin/llmq_type_reconciler.hpp>
 #include <impl/dash/coin/quorum_manager.hpp>
 #include <impl/dash/coin/quorum_root.hpp>
 #include <impl/dash/coin/vendor/llmq_commitment.hpp>
@@ -40,6 +41,7 @@
 #include <fstream>
 #include <map>
 #include <optional>
+#include <set>
 #include <span>
 #include <string>
 #include <vector>
@@ -79,11 +81,14 @@ TEST(DashDkgCommitments, MainnetInterval24WindowYieldsOneSlotPerType)
     auto slots = compute_required_qc_slots(
         LlmqNetwork::Mainnet, h, fake_hash_at, never_mined);
     ASSERT_TRUE(slots.has_value());
-    // Interval-24 mainnet types in AddLLMQ order: LLMQ_50_60 (1), LLMQ_100_67
-    // (4). 288/576-interval types are at phase 12, outside their windows.
-    ASSERT_EQ(slots->size(), 2u);
-    EXPECT_EQ((*slots)[0].params.type, 1);
-    EXPECT_EQ((*slots)[1].params.type, 4);
+    // The ONLY interval-24 type enabled on mainnet is LLMQ_100_67 (4).
+    // LLMQ_50_60 (1) is in mainnet chainparams but dashd's runtime
+    // IsQuorumTypeEnabled disables it at every height >= DIP0024QuorumsHeight
+    // (1738698) — far below this serve floor — so it is NOT required and
+    // must NOT appear here. 288/576-interval types are at phase 12, outside
+    // their windows.
+    ASSERT_EQ(slots->size(), 1u);
+    EXPECT_EQ((*slots)[0].params.type, 4);
     for (const auto& s : *slots) {
         EXPECT_EQ(s.quorum_index, 0);
         EXPECT_EQ(s.quorum_hash, *fake_hash_at(1'900'800u));
@@ -95,33 +100,41 @@ TEST(DashDkgCommitments, RotatedWindowFansOutPerQuorumIndexInAddLlmqOrder)
     // 1900800 is 0 mod 24/288/576, so at phase 42: LLMQ_60_75's window start
     // ([42,50], 32 rotated slots), LLMQ_400_85's window ([20,48], 1 slot),
     // AND the last interval-24 window height (42 % 24 == 18) — the slot list
-    // interleaves per AddLLMQ order: [50_60, 60_75 x32, 400_85, 100_67].
+    // interleaves per enabled-set order: [60_75 x32, 400_85, 100_67].
+    // LLMQ_50_60 is runtime-disabled on mainnet and contributes nothing.
     const uint32_t h = 1'900'800u + 42;
     auto slots = compute_required_qc_slots(
         LlmqNetwork::Mainnet, h, fake_hash_at, never_mined);
     ASSERT_TRUE(slots.has_value());
-    ASSERT_EQ(slots->size(), 1u + 32u + 1u + 1u);
-    EXPECT_EQ((*slots)[0].params.type, 1);
+    ASSERT_EQ(slots->size(), 32u + 1u + 1u);
     for (int i = 0; i < 32; ++i) {
-        const auto& s = (*slots)[1 + static_cast<size_t>(i)];
+        const auto& s = (*slots)[static_cast<size_t>(i)];
         EXPECT_EQ(s.params.type, 5);
         EXPECT_EQ(s.quorum_index, i);
         // Rotated base blocks: cycleStart + quorumIndex — DISTINCT hashes.
         EXPECT_EQ(s.quorum_hash, *fake_hash_at(1'900'800u + static_cast<uint32_t>(i)));
     }
-    EXPECT_EQ((*slots)[33].params.type, 3);
+    EXPECT_EQ((*slots)[32].params.type, 3);
     EXPECT_EQ(slots->back().params.type, 4);
 }
 
 TEST(DashDkgCommitments, AlreadyMinedCommitmentSuppressesItsSlot)
 {
     const uint32_t h = 1'900'800u + 12;
-    auto mined_type1 = [](uint8_t t, const uint256&) { return t == 1; };
+    // Mainnet's only interval-24 type is 4; mining it empties the set.
+    auto mined_type4 = [](uint8_t t, const uint256&) { return t == 4; };
     auto slots = compute_required_qc_slots(
-        LlmqNetwork::Mainnet, h, fake_hash_at, mined_type1);
+        LlmqNetwork::Mainnet, h, fake_hash_at, mined_type4);
     ASSERT_TRUE(slots.has_value());
-    ASSERT_EQ(slots->size(), 1u);
-    EXPECT_EQ((*slots)[0].params.type, 4);
+    EXPECT_TRUE(slots->empty());
+    // Testnet at the same phase keeps types 1 and 6 outstanding — the
+    // suppression is per (type, quorumHash), not blanket.
+    auto tslots = compute_required_qc_slots(
+        LlmqNetwork::Testnet, h, fake_hash_at, mined_type4);
+    ASSERT_TRUE(tslots.has_value());
+    ASSERT_EQ(tslots->size(), 2u);
+    EXPECT_EQ((*tslots)[0].params.type, 1);
+    EXPECT_EQ((*tslots)[1].params.type, 6);
 }
 
 TEST(DashDkgCommitments, NonWindowHeightYieldsEmptySet)
@@ -423,6 +436,11 @@ TEST(DashDkgCommitments, WithBlockFoldReplacesRotatedSameIndexAndSkipsNulls)
 
 TEST(DashDkgCommitments, MineableCacheStructuralAdmissionAndBlsGate)
 {
+    // NETWORK: testnet. LLMQ_50_60 (type 1) is enabled on testnet FOREVER
+    // (dashd IsQuorumTypeEnabled has an unconditional `network == testnet`
+    // disjunct) and is DISABLED on mainnet from DIP0024QuorumsHeight. This
+    // test is about admission mechanics at the 50/40/30 size/minSize/threshold
+    // shape, so it runs where that shape is real.
     MineableCommitmentCache cache;
     const uint256 qh = h256(0x55);
     auto good = real_commitment(kLlmq50_60, qh, 0, 0x11);
@@ -431,17 +449,17 @@ TEST(DashDkgCommitments, MineableCacheStructuralAdmissionAndBlsGate)
     // null crypto fields.
     {
         auto bad = good; bad.nVersion = CFinalCommitment::LEGACY_BLS_NON_INDEXED_QUORUM_VERSION;
-        EXPECT_FALSE(cache.ingest(LlmqNetwork::Mainnet, bad));
+        EXPECT_FALSE(cache.ingest(LlmqNetwork::Testnet, bad));
     }
     {
         auto bad = good; bad.signers.assign(10, true);
-        EXPECT_FALSE(cache.ingest(LlmqNetwork::Mainnet, bad));
+        EXPECT_FALSE(cache.ingest(LlmqNetwork::Testnet, bad));
     }
     {
         auto bad = good;
         bad.signers.assign(50, false);
         for (int i = 0; i < 29; ++i) bad.signers[static_cast<size_t>(i)] = true;  // below threshold (30)
-        EXPECT_FALSE(cache.ingest(LlmqNetwork::Mainnet, bad));
+        EXPECT_FALSE(cache.ingest(LlmqNetwork::Testnet, bad));
     }
     {
         // must-fix: >= threshold (30) but < minSize (40) — cryptographically
@@ -450,20 +468,20 @@ TEST(DashDkgCommitments, MineableCacheStructuralAdmissionAndBlsGate)
         auto bad = good;
         bad.signers.assign(50, false);
         for (int i = 0; i < 35; ++i) bad.signers[static_cast<size_t>(i)] = true;
-        EXPECT_FALSE(cache.ingest(LlmqNetwork::Mainnet, bad))
+        EXPECT_FALSE(cache.ingest(LlmqNetwork::Testnet, bad))
             << "admitted a >=threshold but <minSize commitment (block-losing)";
         auto bad2 = good;
         bad2.validMembers.assign(50, false);
         for (int i = 0; i < 35; ++i) bad2.validMembers[static_cast<size_t>(i)] = true;
-        EXPECT_FALSE(cache.ingest(LlmqNetwork::Mainnet, bad2));
+        EXPECT_FALSE(cache.ingest(LlmqNetwork::Testnet, bad2));
     }
     {
         auto bad = good; bad.quorumSig.fill(0);
-        EXPECT_FALSE(cache.ingest(LlmqNetwork::Mainnet, bad));
+        EXPECT_FALSE(cache.ingest(LlmqNetwork::Testnet, bad));
     }
     EXPECT_EQ(cache.size(), 0u);
 
-    ASSERT_TRUE(cache.ingest(LlmqNetwork::Mainnet, good));
+    ASSERT_TRUE(cache.ingest(LlmqNetwork::Testnet, good));
     EXPECT_EQ(cache.size(), 1u);
 
     // THE Phase-L line: without a BLS verifier the cache NEVER serves. Under
@@ -472,13 +490,13 @@ TEST(DashDkgCommitments, MineableCacheStructuralAdmissionAndBlsGate)
     EXPECT_FALSE(cache.has_bls_verifier());
     EXPECT_FALSE(cache.verified_for(1, qh).has_value());
     EXPECT_FALSE(daemonless_qc_commitments(
-        LlmqNetwork::Mainnet, 1'900'812u, fake_hash_at, never_mined, &cache)
+        LlmqNetwork::Testnet, 1'900'812u, fake_hash_at, never_mined, &cache)
             .has_value())
         << "unverifiable mandatory slots must fail the whole height closed";
     // ...and with attested failed-DKG evidence the consensus-valid nulls are
     // mined (the only case where null is canonical).
     auto plan_commitments = daemonless_qc_commitments(
-        LlmqNetwork::Mainnet, 1'900'812u, fake_hash_at, never_mined, &cache,
+        LlmqNetwork::Testnet, 1'900'812u, fake_hash_at, never_mined, &cache,
         [](uint8_t, const uint256&) { return true; });
     ASSERT_TRUE(plan_commitments.has_value());
     for (const auto& c : *plan_commitments)
@@ -778,26 +796,40 @@ namespace {
 constexpr uint32_t kIncidentHeight    = 2'515'381u;
 constexpr uint32_t kIncidentCycleBase = 2'515'368u;   // 2515381 - 2515381%24
 
-// Mainnet at kIncidentHeight has TWO interval-24 windows open (types 1 and
-// 4). Pin type 4 as already-mined so the type-1 slot is the whole story —
-// exactly the shape the incident logged (first gap = type 1, qi 0).
-QuorumManager qmgr_with_type4_mined()
+// NETWORK NOTE. The incident was LOGGED on mainnet as "type=1 qi=0", but
+// type 1 was never actually required there — that report WAS the LLMQ_50_60
+// defect (dashd's IsQuorumTypeEnabled disables LLMQ_50_60 on mainnet from
+// DIP0024QuorumsHeight=1738698, so the slot could never be satisfied by
+// anything). The mainnet coordinates are therefore now a REGRESSION vector
+// (see IncidentHeightNoLongerRequiresTheDisabledType), while the cold-start
+// NAMING mechanics — which are network-independent and still matter — are
+// exercised on TESTNET, where type 1 genuinely is enabled forever.
+//
+// At kIncidentHeight the interval-24 types are all in phase 13 of [10,18]:
+// mainnet has {4}, testnet has {1, 4, 6}. Pin every type EXCEPT 1 as
+// already-mined so the type-1 slot is the whole story — exactly the shape
+// the incident logged (first gap = type 1, qi 0).
+QuorumManager qmgr_with_others_mined()
 {
     vendor::QuorumTail tail;
     tail.newQuorums.push_back(
         real_commitment(kLlmq100_67, *fake_hash_at(kIncidentCycleBase), 0, 0x44));
+    tail.newQuorums.push_back(
+        real_commitment(kLlmq25_67, *fake_hash_at(kIncidentCycleBase), 0, 0x66));
     QuorumManager q;
     q.apply(tail);
     EXPECT_TRUE(q.find(4, *fake_hash_at(kIncidentCycleBase)).has_value());
+    EXPECT_TRUE(q.find(6, *fake_hash_at(kIncidentCycleBase)).has_value());
     return q;
 }
 
 std::optional<QcBlockPlan> incident_plan(const QuorumManager& qmgr,
                                          const MineableCommitmentCache* cache,
-                                         RequiredQcSlot* gap)
+                                         RequiredQcSlot* gap,
+                                         LlmqNetwork net = LlmqNetwork::Testnet)
 {
     return build_daemonless_qc_plan(
-        LlmqNetwork::Mainnet, kIncidentHeight, qmgr, fake_hash_at,
+        net, kIncidentHeight, qmgr, fake_hash_at,
         [](const uint256&) -> std::optional<uint32_t> { return std::nullopt; },
         cache, /*null_evidence=*/nullptr, gap);
 }
@@ -829,13 +861,56 @@ TEST(DashDkgColdStart, WindowBoundIsTheRefusalsUpperBound)
     EXPECT_FALSE(is_mining_phase(kLlmq50_60, wb.last_height + 1));
 }
 
+// THE REGRESSION PROOF for the LLMQ_50_60 fix. This test FAILS on the old
+// table (which required type 1 on mainnet -> one unsatisfiable slot -> the
+// whole height fails closed) and passes on the corrected one.
+TEST(DashDkgColdStart, IncidentHeightNoLongerRequiresTheDisabledType)
+{
+    auto qmgr = qmgr_with_others_mined();
+    auto mined = [&qmgr](uint8_t t, const uint256& qh) {
+        return qmgr.find(t, qh).has_value();
+    };
+
+    // MAINNET at the incident height: phase 13 is inside the interval-24
+    // window [10,18], and the ONLY interval-24 type mainnet enables is 4,
+    // which is already mined here. So there is no mandatory slot at all...
+    auto slots = compute_required_qc_slots(
+        LlmqNetwork::Mainnet, kIncidentHeight, fake_hash_at, mined);
+    ASSERT_TRUE(slots.has_value());
+    EXPECT_TRUE(slots->empty())
+        << "mainnet must not require a runtime-disabled llmqType";
+    for (const auto& sl : *slots)
+        EXPECT_NE(sl.params.type, 1)
+            << "LLMQ_50_60 is disabled on mainnet from DIP0024QuorumsHeight";
+
+    // ...and the height SERVES rather than failing closed. This is the
+    // 9-in-24 structural outage, gone.
+    RequiredQcSlot gap{};
+    MineableCommitmentCache empty_cache;
+    auto plan = incident_plan(qmgr, &empty_cache, &gap, LlmqNetwork::Mainnet);
+    ASSERT_TRUE(plan.has_value())
+        << "the mainnet incident height must no longer fail closed";
+    EXPECT_TRUE(plan->commitments.empty());
+
+    // NEGATIVE TWIN — this test can still fail for the right reason: with the
+    // one genuinely-required mainnet type NOT mined, the height must still
+    // fail closed (the completeness gate is untouched by the type fix).
+    QuorumManager nothing_mined;
+    RequiredQcSlot gap2{};
+    EXPECT_FALSE(incident_plan(nothing_mined, &empty_cache, &gap2,
+                               LlmqNetwork::Mainnet).has_value());
+    EXPECT_EQ(gap2.params.type, 4);
+}
+
 TEST(DashDkgColdStart, IncidentReplayFailsClosedNamingTheColdStartCause)
 {
-    auto qmgr = qmgr_with_type4_mined();
+    // TESTNET — where type 1 is genuinely required forever, so the cold-start
+    // naming mechanics the incident exercised remain covered.
+    auto qmgr = qmgr_with_others_mined();
 
     // Only the type-1 slot is outstanding — the incident's exact shape.
     auto slots = compute_required_qc_slots(
-        LlmqNetwork::Mainnet, kIncidentHeight, fake_hash_at,
+        LlmqNetwork::Testnet, kIncidentHeight, fake_hash_at,
         [&qmgr](uint8_t t, const uint256& qh) {
             return qmgr.find(t, qh).has_value();
         });
@@ -877,12 +952,12 @@ TEST(DashDkgColdStart, BackFilledCommitmentServesAndItsRemovalFailsClosed)
     // predates startup — today only live relay; no P2P back-fill exists —
     // the height must serve the moment it is BLS-verifiable, with dashd's
     // real commitment in the plan rather than a null.
-    auto qmgr = qmgr_with_type4_mined();
+    auto qmgr = qmgr_with_others_mined();
     const uint256 qh = *fake_hash_at(kIncidentCycleBase);
     auto real = real_commitment(kLlmq50_60, qh, /*quorumIndex=*/0, 0x11);
 
     MineableCommitmentCache cache;
-    ASSERT_TRUE(cache.ingest(LlmqNetwork::Mainnet, real));
+    ASSERT_TRUE(cache.ingest(LlmqNetwork::Testnet, real));
     cache.set_bls_verify_fn([](const CFinalCommitment&) { return true; });
     cache.set_members_ready_fn([](uint8_t, const uint256&) { return true; });
 
@@ -910,14 +985,14 @@ TEST(DashDkgColdStart, BackFilledCommitmentServesAndItsRemovalFailsClosed)
 
 TEST(DashDkgColdStart, EveryUnsatisfiableShapeFailsClosedWithItsOwnName)
 {
-    auto qmgr = qmgr_with_type4_mined();
+    auto qmgr = qmgr_with_others_mined();
     const uint256 qh = *fake_hash_at(kIncidentCycleBase);
     auto real = real_commitment(kLlmq50_60, qh, 0, 0x11);
 
     // (1) cached, but NO BLS verifier installed => bls-verifier-absent.
     {
         MineableCommitmentCache cache;
-        ASSERT_TRUE(cache.ingest(LlmqNetwork::Mainnet, real));
+        ASSERT_TRUE(cache.ingest(LlmqNetwork::Testnet, real));
         EXPECT_FALSE(cache.has_bls_verifier());
         RequiredQcSlot gap{};
         EXPECT_FALSE(incident_plan(qmgr, &cache, &gap).has_value());
@@ -932,7 +1007,7 @@ TEST(DashDkgColdStart, EveryUnsatisfiableShapeFailsClosedWithItsOwnName)
     // (2) cached + verifier, member set still in flight => member-set-unsourced.
     {
         MineableCommitmentCache cache;
-        ASSERT_TRUE(cache.ingest(LlmqNetwork::Mainnet, real));
+        ASSERT_TRUE(cache.ingest(LlmqNetwork::Testnet, real));
         cache.set_bls_verify_fn([](const CFinalCommitment&) { return false; });
         cache.set_members_ready_fn([](uint8_t, const uint256&) { return false; });
         RequiredQcSlot gap{};
@@ -946,7 +1021,7 @@ TEST(DashDkgColdStart, EveryUnsatisfiableShapeFailsClosedWithItsOwnName)
     //     hostile/corrupt-peer case, which must read differently from (2).
     {
         MineableCommitmentCache cache;
-        ASSERT_TRUE(cache.ingest(LlmqNetwork::Mainnet, real));
+        ASSERT_TRUE(cache.ingest(LlmqNetwork::Testnet, real));
         cache.set_bls_verify_fn([](const CFinalCommitment&) { return false; });
         cache.set_members_ready_fn([](uint8_t, const uint256&) { return true; });
         RequiredQcSlot gap{};
@@ -962,7 +1037,7 @@ TEST(DashDkgColdStart, EveryUnsatisfiableShapeFailsClosedWithItsOwnName)
         MineableCommitmentCache cache;
         auto flipped = real;
         flipped.quorumIndex = 7;    // slot's index is 0
-        ASSERT_TRUE(cache.ingest(LlmqNetwork::Mainnet, flipped));
+        ASSERT_TRUE(cache.ingest(LlmqNetwork::Testnet, flipped));
         cache.set_bls_verify_fn([](const CFinalCommitment&) { return true; });
         cache.set_members_ready_fn([](uint8_t, const uint256&) { return true; });
         RequiredQcSlot gap{};
@@ -974,7 +1049,7 @@ TEST(DashDkgColdStart, EveryUnsatisfiableShapeFailsClosedWithItsOwnName)
     // (5) THE ONE SERVING SHAPE, for contrast: all four defects absent.
     {
         MineableCommitmentCache cache;
-        ASSERT_TRUE(cache.ingest(LlmqNetwork::Mainnet, real));
+        ASSERT_TRUE(cache.ingest(LlmqNetwork::Testnet, real));
         cache.set_bls_verify_fn([](const CFinalCommitment&) { return true; });
         cache.set_members_ready_fn([](uint8_t, const uint256&) { return true; });
         RequiredQcSlot gap{};
@@ -994,13 +1069,13 @@ TEST(DashDkgColdStart, DiagnosisNeverInfluencesTheServeDecision)
     // The gate must key off verified_for ALONE. A members_ready probe that
     // lies in either direction changes the NAME on the refusal and nothing
     // else — belt-and-braces against the diagnosis seam becoming a bypass.
-    auto qmgr = qmgr_with_type4_mined();
+    auto qmgr = qmgr_with_others_mined();
     const uint256 qh = *fake_hash_at(kIncidentCycleBase);
     auto real = real_commitment(kLlmq50_60, qh, 0, 0x11);
 
     // Probe says "ready" while the verifier rejects: still fails closed.
     MineableCommitmentCache lying_ready;
-    ASSERT_TRUE(lying_ready.ingest(LlmqNetwork::Mainnet, real));
+    ASSERT_TRUE(lying_ready.ingest(LlmqNetwork::Testnet, real));
     lying_ready.set_bls_verify_fn([](const CFinalCommitment&) { return false; });
     lying_ready.set_members_ready_fn([](uint8_t, const uint256&) { return true; });
     EXPECT_FALSE(incident_plan(qmgr, &lying_ready, nullptr).has_value());
@@ -1008,7 +1083,7 @@ TEST(DashDkgColdStart, DiagnosisNeverInfluencesTheServeDecision)
     // Probe says "not ready" while the verifier accepts: still SERVES (the
     // probe is observability, it can never withhold a valid commitment).
     MineableCommitmentCache lying_unready;
-    ASSERT_TRUE(lying_unready.ingest(LlmqNetwork::Mainnet, real));
+    ASSERT_TRUE(lying_unready.ingest(LlmqNetwork::Testnet, real));
     lying_unready.set_bls_verify_fn([](const CFinalCommitment&) { return true; });
     lying_unready.set_members_ready_fn([](uint8_t, const uint256&) { return false; });
     EXPECT_TRUE(incident_plan(qmgr, &lying_unready, nullptr).has_value());
@@ -1026,7 +1101,7 @@ TEST(DashDkgColdStart, EveryAdmissionRejectionHasItsOwnName)
 
     MineableCommitmentCache cache;
     // POSITIVE: the good one is accepted and says so.
-    EXPECT_EQ(cache.ingest_ex(LlmqNetwork::Mainnet, good), Adm::Accepted);
+    EXPECT_EQ(cache.ingest_ex(LlmqNetwork::Testnet, good), Adm::Accepted);
     EXPECT_STREQ(MineableCommitmentCache::admission_name(Adm::Accepted),
                  "accepted");
     EXPECT_EQ(cache.cached_signers(1, qh), 50);
@@ -1035,18 +1110,18 @@ TEST(DashDkgColdStart, EveryAdmissionRejectionHasItsOwnName)
     {
         auto bad = good; bad.llmqType = 99;
         MineableCommitmentCache c2;
-        EXPECT_EQ(c2.ingest_ex(LlmqNetwork::Mainnet, bad), Adm::UnknownType);
+        EXPECT_EQ(c2.ingest_ex(LlmqNetwork::Testnet, bad), Adm::UnknownType);
     }
     {
         auto bad = good;
         bad.nVersion = CFinalCommitment::LEGACY_BLS_NON_INDEXED_QUORUM_VERSION;
         MineableCommitmentCache c2;
-        EXPECT_EQ(c2.ingest_ex(LlmqNetwork::Mainnet, bad), Adm::WrongVersion);
+        EXPECT_EQ(c2.ingest_ex(LlmqNetwork::Testnet, bad), Adm::WrongVersion);
     }
     {
         auto bad = good; bad.signers.assign(10, true);
         MineableCommitmentCache c2;
-        EXPECT_EQ(c2.ingest_ex(LlmqNetwork::Mainnet, bad),
+        EXPECT_EQ(c2.ingest_ex(LlmqNetwork::Testnet, bad),
                   Adm::BitsetSizeMismatch);
     }
     {
@@ -1054,7 +1129,7 @@ TEST(DashDkgColdStart, EveryAdmissionRejectionHasItsOwnName)
         bad.validMembers.assign(50, false);
         for (int i = 0; i < 35; ++i) bad.validMembers[static_cast<size_t>(i)] = true;
         MineableCommitmentCache c2;
-        EXPECT_EQ(c2.ingest_ex(LlmqNetwork::Mainnet, bad),
+        EXPECT_EQ(c2.ingest_ex(LlmqNetwork::Testnet, bad),
                   Adm::ValidMembersBelowMin);
     }
     {
@@ -1062,17 +1137,17 @@ TEST(DashDkgColdStart, EveryAdmissionRejectionHasItsOwnName)
         bad.signers.assign(50, false);
         for (int i = 0; i < 35; ++i) bad.signers[static_cast<size_t>(i)] = true;
         MineableCommitmentCache c2;
-        EXPECT_EQ(c2.ingest_ex(LlmqNetwork::Mainnet, bad), Adm::SignersBelowMin);
+        EXPECT_EQ(c2.ingest_ex(LlmqNetwork::Testnet, bad), Adm::SignersBelowMin);
     }
     {
         auto bad = good; bad.membersSig.fill(0);
         MineableCommitmentCache c2;
-        EXPECT_EQ(c2.ingest_ex(LlmqNetwork::Mainnet, bad),
+        EXPECT_EQ(c2.ingest_ex(LlmqNetwork::Testnet, bad),
                   Adm::NullCryptoFields);
     }
     // Keep-best-by-CountSigners: a re-relay of the SAME commitment is not a
     // defect and must not read like one.
-    EXPECT_EQ(cache.ingest_ex(LlmqNetwork::Mainnet, good),
+    EXPECT_EQ(cache.ingest_ex(LlmqNetwork::Testnet, good),
               Adm::NotBetterThanCached);
     EXPECT_EQ(cache.size(), 1u);
 
@@ -1089,6 +1164,298 @@ TEST(DashDkgColdStart, EveryAdmissionRejectionHasItsOwnName)
 
     // And the legacy bool wrapper still means exactly "accepted".
     MineableCommitmentCache c3;
-    EXPECT_TRUE(c3.ingest(LlmqNetwork::Mainnet, good));
-    EXPECT_FALSE(c3.ingest(LlmqNetwork::Mainnet, good));
+    EXPECT_TRUE(c3.ingest(LlmqNetwork::Testnet, good));
+    EXPECT_FALSE(c3.ingest(LlmqNetwork::Testnet, good));
+}
+
+// ── enabled-set parity + the LLMQ_50_60 fix ────────────────────────────────
+//
+// NOTE FOR REVIEWERS: several open PRs append test sections to the END of this
+// file. If this block conflicts, it is a pure append-vs-append conflict — take
+// both sides.
+//
+// GROUND TRUTH used below (all re-derivable, none of it guessed):
+//   * dashpay/dash v23.1.7 validation.cpp ChainstateManager::IsQuorumTypeEnabled
+//     — the RUNTIME predicate CQuorumBlockProcessor::ProcessBlock filters the
+//     chainparams AddLLMQ list through (via GetEnabledQuorumParams). LLMQ_50_60:
+//       !fDIP0024IsActive || !fHaveDIP0024Quorums || testnet || devnet
+//   * chainparams.cpp v23.1.7: mainnet DIP0024QuorumsHeight 1738698,
+//     V19Height 1899072; testnet 770730 / 850100, LLMQ_25_67 from 847000.
+//   * A live Dash Core 23.1.7 mainnet node at height 2515629: `quorum list`
+//     returns exactly {llmq_60_75, llmq_400_60, llmq_400_85, llmq_100_67}, in
+//     that order, and nothing else.
+
+TEST(DashLlmqEnabledSet, MainnetMatchesDashdQuorumListExactlyAndInOrder)
+{
+    // CLAIM: mainnet's enabled set == the four types a live mainnet dashd
+    // reports, in dashd's own enumeration order.
+    const auto& m = enabled_llmqs(LlmqNetwork::Mainnet);
+    ASSERT_EQ(m.size(), 4u);
+    EXPECT_EQ(m[0].type, 5);    // llmq_60_75
+    EXPECT_EQ(m[1].type, 2);    // llmq_400_60
+    EXPECT_EQ(m[2].type, 3);    // llmq_400_85
+    EXPECT_EQ(m[3].type, 4);    // llmq_100_67
+
+    // THE DEFECT, named: LLMQ_50_60 is in mainnet CHAINPARAMS but is disabled
+    // by the runtime predicate at every height >= 1738698 — 160374 blocks
+    // below our serve floor. It must never be required on mainnet.
+    for (const auto& p : m)
+        EXPECT_NE(p.type, 1)
+            << "LLMQ_50_60 is runtime-disabled on mainnet; requiring it emits a"
+               " mandatory slot nothing can ever satisfy";
+    // ...nor LLMQ_25_67, which is testnet-only.
+    for (const auto& p : m) EXPECT_NE(p.type, 6);
+}
+
+TEST(DashLlmqEnabledSet, TestnetKeepsLlmq50_60Deliberately)
+{
+    // CLAIM: the mainnet fix is NOT mirrored to testnet, and that is correct
+    // rather than an oversight. IsQuorumTypeEnabled's third disjunct
+    // (`NetworkIDString() == TESTNET`) is unconditional and height-independent,
+    // so LLMQ_50_60 is enabled on testnet forever — it is also testnet's
+    // llmqTypeChainLocks and llmqTypeMnhf. Deleting it here would be a NEW
+    // defect wearing the shape of a symmetry fix.
+    const auto& t = enabled_llmqs(LlmqNetwork::Testnet);
+    ASSERT_EQ(t.size(), 6u);
+    EXPECT_EQ(t[0].type, 1);    // llmq_50_60 — STAYS
+    EXPECT_EQ(t[1].type, 5);
+    EXPECT_EQ(t[2].type, 2);
+    EXPECT_EQ(t[3].type, 3);
+    EXPECT_EQ(t[4].type, 4);
+    EXPECT_EQ(t[5].type, 6);    // llmq_25_67, enabled from testnet h=847000
+                                // < the testnet serve floor 850100
+    // The two networks genuinely differ — this is not a copy-paste artefact.
+    EXPECT_NE(enabled_llmqs(LlmqNetwork::Mainnet).size(), t.size());
+}
+
+TEST(DashLlmqEnabledSet, NoMainnetWindowHeightEverRequiresADisabledType)
+{
+    // CLAIM: the fix holds across the whole height domain, not at one lucky
+    // height. Sweep a full 576-block superperiod (lcm of 24/288/576) above the
+    // mainnet serve floor: every mandatory slot must name a type the live
+    // mainnet node actually reports.
+    const std::set<uint8_t> dashd_types{5, 2, 3, 4};
+    size_t window_heights = 0, band_24_heights = 0;
+    for (uint32_t h = 1'900'800u; h < 1'900'800u + 576u; ++h) {
+        auto slots = compute_required_qc_slots(
+            LlmqNetwork::Mainnet, h, fake_hash_at, never_mined);
+        ASSERT_TRUE(slots.has_value()) << "h=" << h;
+        if (!slots->empty()) ++window_heights;
+        for (const auto& s : *slots) {
+            EXPECT_TRUE(dashd_types.count(s.params.type) != 0)
+                << "h=" << h << " requires type "
+                << static_cast<int>(s.params.type)
+                << " which mainnet dashd does not enable";
+            EXPECT_NE(s.params.type, 1) << "h=" << h;
+        }
+        // The interval-24 band [10,18] is the one the defect blanked: it is
+        // still a window band, but now every slot in it is type 4 — a type
+        // that IS mined, so the height is satisfiable rather than dead.
+        if (h % 24u >= 10u && h % 24u <= 18u) {
+            ++band_24_heights;
+            bool has24 = false;
+            for (const auto& s : *slots)
+                if (s.params.type == 4) has24 = true;
+            EXPECT_TRUE(has24) << "h=" << h;
+        }
+    }
+    EXPECT_EQ(band_24_heights, 9u * 24u);   // 9 of every 24 heights
+    EXPECT_GT(window_heights, 0u);
+}
+
+// ── LlmqTypeReconciler: the negative-capable backstop ──────────────────────
+
+namespace {
+
+// A mined-type stream shaped like a healthy chain: every required type shows
+// up in the active set at every tip.
+std::vector<uint8_t> healthy_types(LlmqNetwork net)
+{
+    std::vector<uint8_t> v;
+    for (const auto& p : enabled_llmqs(net)) v.push_back(p.type);
+    return v;
+}
+
+std::optional<LlmqTypeFinding> finding_for(
+    const std::vector<LlmqTypeFinding>& fs, uint8_t type)
+{
+    for (const auto& f : fs) if (f.llmq_type == type) return f;
+    return std::nullopt;
+}
+
+} // namespace
+
+TEST(DashLlmqTypeReconciler, NamesARequiredTypeThatIsNeverMined)
+{
+    // CLAIM (the guard's whole reason to exist): a type we REQUIRE but that
+    // the chain never mines is named LOUDLY, while "not yet arrived" is not.
+    // This is the exact pre-fix mainnet shape, reproduced against the REAL
+    // table by starving one genuinely-required testnet type (6 / llmq_25_67).
+    LlmqTypeReconciler r(LlmqNetwork::Testnet);
+    auto stream = healthy_types(LlmqNetwork::Testnet);
+    stream.erase(std::remove(stream.begin(), stream.end(), uint8_t{6}),
+                 stream.end());
+    for (uint32_t h = 850'200u; h <= 850'200u + 48u; ++h)
+        r.observe(h, stream);
+
+    auto d = r.defects();
+    ASSERT_EQ(d.size(), 1u) << "exactly the starved type must be indicted";
+    EXPECT_EQ(d[0].llmq_type, 6);
+    EXPECT_EQ(d[0].verdict, LlmqTypeVerdict::NeverObserved);
+    EXPECT_TRUE(d[0].required);
+    EXPECT_EQ(d[0].sightings, 0u);
+    EXPECT_STREQ(llmq_type_verdict_name(d[0].verdict),
+                 "REQUIRED-BUT-NEVER-OBSERVED");
+
+    // The rendering must NAME the type — an operator must not have to open a
+    // debugger to learn which one.
+    const auto said = r.format_defects();
+    EXPECT_NE(said.find("type=6"), std::string::npos) << said;
+    EXPECT_NE(said.find("REQUIRED-BUT-NEVER-OBSERVED"), std::string::npos)
+        << said;
+
+    // Every OTHER required type reads Observed, not "unevaluated" — the check
+    // discriminates, it does not merely shrug at everything.
+    auto all = r.reconcile();
+    for (const auto& p : enabled_llmqs(LlmqNetwork::Testnet)) {
+        auto f = finding_for(all, p.type);
+        ASSERT_TRUE(f.has_value());
+        EXPECT_EQ(f->verdict, p.type == 6 ? LlmqTypeVerdict::NeverObserved
+                                          : LlmqTypeVerdict::Observed)
+            << "type " << static_cast<int>(p.type);
+    }
+}
+
+TEST(DashLlmqTypeReconciler, SaysNothingOnAHealthyChain)
+{
+    // THE NEGATIVE CONTROL. A check that always fires is as useless as one
+    // that never can: on a chain that mines every required type, the guard
+    // must be SILENT — and format_defects() must return the empty string so
+    // no caller is tempted to log a reassuring "ok" it did not earn.
+    for (auto net : {LlmqNetwork::Mainnet, LlmqNetwork::Testnet}) {
+        LlmqTypeReconciler r(net);
+        for (uint32_t h = 1'900'800u; h <= 1'900'800u + 600u; ++h)
+            r.observe(h, healthy_types(net));
+        EXPECT_TRUE(r.defects().empty());
+        EXPECT_TRUE(r.format_defects().empty());
+        for (const auto& f : r.reconcile()) {
+            EXPECT_EQ(f.verdict, LlmqTypeVerdict::Observed);
+            EXPECT_FALSE(is_llmq_type_defect(f.verdict));
+        }
+    }
+}
+
+TEST(DashLlmqTypeReconciler, RefusesToIndictWhenTheChannelItselfIsSilent)
+{
+    // FALSE-POSITIVE DISCIPLINE. A bootstrapping / drained QuorumManager
+    // reports nothing for ANY type. Absence is only evidence when presence was
+    // demonstrable on the same channel, so the honest verdict here is
+    // Unevaluated for every type — never a blanket indictment of all of them.
+    LlmqTypeReconciler r(LlmqNetwork::Mainnet);
+    for (uint32_t h = 1'900'800u; h <= 1'900'800u + 600u; ++h)
+        r.observe(h, std::vector<uint8_t>{});
+    EXPECT_TRUE(r.defects().empty());
+    for (const auto& f : r.reconcile()) {
+        EXPECT_EQ(f.verdict, LlmqTypeVerdict::Unevaluated);
+        EXPECT_STREQ(f.pending_reason, "no-required-type-observed-anywhere");
+    }
+
+    // ...and the moment ONE required type is corroborated, the same silence
+    // about the others becomes a real finding. The rule buys discrimination,
+    // it does not disable the check.
+    for (uint32_t h = 1'901'401u; h <= 1'901'401u + 48u; ++h)
+        r.observe(h, std::vector<uint8_t>{4});
+    auto d = r.defects();
+    EXPECT_EQ(d.size(), 3u);   // types 5, 2, 3 — required, still never seen
+    for (const auto& f : d)
+        EXPECT_EQ(f.verdict, LlmqTypeVerdict::NeverObserved);
+}
+
+TEST(DashLlmqTypeReconciler, WaitsForAFullDkgCycleAndSaysWhyItIsWaiting)
+{
+    // A verdict must not outrun its evidence. Before one full DKG cycle of the
+    // starved type has elapsed under observation, the verdict is Unevaluated
+    // WITH A NAMED REASON — never a fabricated pass and never a premature
+    // indictment.
+    LlmqTypeReconciler r(LlmqNetwork::Testnet);
+    auto stream = healthy_types(LlmqNetwork::Testnet);
+    stream.erase(std::remove(stream.begin(), stream.end(), uint8_t{3}),
+                 stream.end());
+    // Too few observations first.
+    for (uint32_t h = 850'200u; h < 850'200u + 4u; ++h) r.observe(h, stream);
+    {
+        auto f = finding_for(r.reconcile(), 3);
+        ASSERT_TRUE(f.has_value());
+        EXPECT_EQ(f->verdict, LlmqTypeVerdict::Unevaluated);
+        EXPECT_STREQ(f->pending_reason, "too-few-observations");
+    }
+    // Enough observations, but LLMQ_400_85's dkgInterval is 576 and the span
+    // is far shorter — still not a completed experiment.
+    for (uint32_t h = 850'204u; h < 850'204u + 100u; ++h) r.observe(h, stream);
+    {
+        auto f = finding_for(r.reconcile(), 3);
+        ASSERT_TRUE(f.has_value());
+        EXPECT_EQ(f->verdict, LlmqTypeVerdict::Unevaluated);
+        EXPECT_STREQ(f->pending_reason, "span-shorter-than-one-dkg-cycle");
+        EXPECT_TRUE(r.defects().empty());
+    }
+    // A full 576-block cycle later it IS a completed experiment, and the
+    // guard commits to the negative.
+    for (uint32_t h = 850'304u; h <= 850'304u + 600u; ++h) r.observe(h, stream);
+    {
+        auto f = finding_for(r.reconcile(), 3);
+        ASSERT_TRUE(f.has_value());
+        EXPECT_EQ(f->verdict, LlmqTypeVerdict::NeverObserved);
+        EXPECT_STREQ(f->pending_reason, "n/a");
+    }
+}
+
+TEST(DashLlmqTypeReconciler, NamesAMinedTypeWeDoNotRequire)
+{
+    // THE OTHER DIRECTION — the half a one-directional check would miss, and
+    // the one that makes this survive a future Dash consensus change. If
+    // upstream ADDS or RE-ENABLES a type, our blocks silently omit a mandatory
+    // commitment (bad-qc-missing) with no local symptom at all. Seeing a mined
+    // type we do not require is that symptom.
+    LlmqTypeReconciler r(LlmqNetwork::Mainnet);
+    auto stream = healthy_types(LlmqNetwork::Mainnet);
+    stream.push_back(7);            // a type upstream mines and we do not model
+    for (uint32_t h = 1'900'800u; h <= 1'900'800u + 600u; ++h)
+        r.observe(h, stream);
+
+    auto d = r.defects();
+    ASSERT_EQ(d.size(), 1u);
+    EXPECT_EQ(d[0].llmq_type, 7);
+    EXPECT_EQ(d[0].verdict, LlmqTypeVerdict::UnexpectedType);
+    EXPECT_FALSE(d[0].required);
+    EXPECT_GT(d[0].sightings, 0u);
+    const auto said = r.format_defects();
+    EXPECT_NE(said.find("type=7"), std::string::npos) << said;
+    EXPECT_NE(said.find("MINED-BUT-NOT-REQUIRED"), std::string::npos) << said;
+}
+
+TEST(DashLlmqTypeReconciler, ReadsTheProductionQuorumManagerSource)
+{
+    // The production overload must observe the SAME thing the hand-fed one
+    // does — otherwise the guard tested here is not the guard that ships.
+    // The mnlistdiff-fed active set IS dashd's mined-and-active commitment
+    // set (dkg_commitments.hpp header note), so it is the mined-type source.
+    QuorumManager qmgr;
+    vendor::QuorumTail tail;
+    tail.newQuorums.push_back(real_commitment(kLlmq400_60, h256(0x21), 0, 0x01));
+    tail.newQuorums.push_back(real_commitment(kLlmq400_85, h256(0x22), 0, 0x02));
+    tail.newQuorums.push_back(real_commitment(kLlmq100_67, h256(0x23), 0, 0x03));
+    qmgr.apply(tail);
+
+    LlmqTypeReconciler r(LlmqNetwork::Mainnet);
+    for (uint32_t h = 1'900'800u; h <= 1'900'800u + 600u; ++h)
+        r.observe(h, qmgr);
+    EXPECT_EQ(r.observations(), 601u);
+
+    // Types 2/3/4 are in the active set; type 5 (rotated llmq_60_75) is not,
+    // and IS required — so it is correctly indicted rather than ignored.
+    auto d = r.defects();
+    ASSERT_EQ(d.size(), 1u);
+    EXPECT_EQ(d[0].llmq_type, 5);
+    EXPECT_EQ(d[0].verdict, LlmqTypeVerdict::NeverObserved);
 }


### PR DESCRIPTION
## The defect

`enabled_llmqs(Mainnet)` listed `kLlmq50_60` (type 1). **dashd does not require type 1 on mainnet**, and has not since block 1,738,698.

Consequence: `compute_required_qc_slots` emitted a mandatory type-1 slot every 24-block DKG cycle. `has_mined(1, ...)` is false forever (no such commitment is ever mined), `daemonless_qc_commitments` requires `cache->verified_for(1, qh)` which can never be satisfied, `null_evidence` is hardcoded `nullptr` in production (`src/c2pool/main_dash.cpp:3286`) — so the whole height failed closed at **every height whose phase lands in the interval-24 mining window [10,18]**. A permanent **9-in-24 = 37.5%** structural blackout of the daemonless arm, indistinguishable in the logs from a legitimate cold-start wait.

## Correction to the reported mechanism — please read this part

The diagnosis that motivated this PR said type 1 "does not exist on Dash mainnet" and that the table's `chainparams.cpp: mainnet 269-273` citation was "a stale reading of an older Dash Core". **The conclusion is right; that mechanism is not**, and the difference changes what the comment must say and what the guard must watch.

`LLMQ_50_60` **is** in mainnet chainparams at v23.1.7, today, on the current pin:

```cpp
// chainparams.cpp CMainParams, v23.1.7 — lines 269-273, unchanged
AddLLMQ(Consensus::LLMQType::LLMQ_50_60);
AddLLMQ(Consensus::LLMQType::LLMQ_60_75);
AddLLMQ(Consensus::LLMQType::LLMQ_400_60);
AddLLMQ(Consensus::LLMQType::LLMQ_400_85);
AddLLMQ(Consensus::LLMQType::LLMQ_100_67);
```

The first thing that flagged this was the live node itself. `quorum info` distinguishes two errors:

```
type 1: error code: -8  quorum not found        <-- enabled, no quorum at that hash
type 2: error code: -8  quorum not found        <-- (type 2 is definitely enabled)
type 4: {full quorum}
type 6: error code: -8  invalid LLMQ type       <-- NOT in chainparams
```

`quorum_info` raises `invalid LLMQ type` from `Params().GetLLMQ()`, i.e. the **chainparams** list. Type 1 gets `quorum not found`, exactly like types 2/3/5 — so it is in mainnet chainparams. It is absent from `quorum list` because `quorum_list` enumerates `GetEnabledQuorumTypes`, which is a different thing.

The real mechanism is a **runtime, height- and network-dependent predicate**. `CQuorumBlockProcessor::ProcessBlock` iterates `GetEnabledQuorumParams(chainman, pindex->pprev)` (`llmq/options.cpp`), which filters chainparams through `ChainstateManager::IsQuorumTypeEnabled` (`validation.cpp:6022`):

```cpp
case Consensus::LLMQType::LLMQ_50_60:
    return !fDIP0024IsActive || !fHaveDIP0024Quorums
        || m_chainparams.NetworkIDString() == CBaseChainParams::TESTNET
        || m_chainparams.NetworkIDString() == CBaseChainParams::DEVNET;
```

with `fHaveDIP0024Quorums = pindexPrev->nHeight >= consensus.DIP0024QuorumsHeight`.

Mainnet: `DIP0024Height = 1737792`, `DIP0024QuorumsHeight = 1738698`. At every height ≥ 1,738,698 both DIP0024 legs are true and mainnet is neither testnet nor devnet ⇒ **LLMQ_50_60 is disabled, permanently**. Our own `kQcServeFloorMainnet = 1899072` sits **160,374 blocks above** that, so the removal is unconditional over the entire domain in which this table is ever consulted. No height gate is needed.

This matters beyond pedantry: a comment saying "mainnet chainparams has four types" would be *false*, and would send the next maintainer back to the same wrong source. The comment now carries the predicate and the arithmetic that evaluates it at our serve floor.

**Independent corroboration** (live Dash Core 23.1.7 mainnet node, height 2,515,629): `quorum list` returns exactly `llmq_60_75, llmq_400_60, llmq_400_85, llmq_100_67`, in that order and nothing else. Since `GetEnabledQuorumParams` preserves chainparams order and only filters, a **pure deletion** reproduces dashd's emission order exactly — the byte-parity ordering argument is preserved.

## TESTNET: verified, and deliberately NOT changed

The brief asked me to verify before touching testnet and to leave it alone if I could not. I could verify, at source level, and the answer is **do not touch it**:

The predicate's third disjunct `NetworkIDString() == TESTNET` is **unconditional and height-independent**. `LLMQ_50_60` is enabled on testnet **forever** — it is also testnet's `llmqTypeChainLocks` *and* `llmqTypeMnhf`. Removing it would have been a second defect wearing the shape of a symmetry fix.

Testnet's other five also check out at the testnet floor (V19Height 850100): DIP0020 414100, DIP0024 769700, `LLMQ_25_67` from height 847000 < 850100. **The 6-type testnet table is correct as it stands.**

This is guarded, not merely asserted — see the second mutation below.

## The guard, which matters more than the fix

`src/impl/dash/coin/llmq_type_reconciler.hpp` (new), wired into the per-template `qc_plan_fn` in `main_dash.cpp`.

This survived for months because **"required but nonexistent" and "required but not yet arrived" print the same refusal**, and the second one looks like patience — which is the correct posture, so the operator waits. Nothing at a single height can tell them apart. Only time plus a *negative* can.

So the reconciler is built to be able to fail. It records which `llmqType`s actually appear in mined commitments — source: the mnlistdiff-fed `QuorumManager` active set, which per `dkg_commitments.hpp` **is** dashd's `GetMinedAndActiveCommitmentsUntilBlock(tip)`, is already current at every template build, and therefore costs no new wire traffic — and returns one of four verdicts per type:

| verdict | meaning |
|---|---|
| `Observed` | required and seen — the healthy state |
| `Unevaluated` | not enough observation yet, **with a named `pending_reason`** |
| **`NeverObserved`** | required, one full DKG cycle covered, corroborated, **zero** sightings |
| **`UnexpectedType`** | the chain mines a type we do **not** require |

Two of the four are defects, and `format_defects()` names the offending type numerically.

`UnexpectedType` is the half a one-directional check would miss, and it is the reason this survives a future Dash consensus change: if upstream **adds** or **re-enables** a type, we silently omit a mandatory commitment (`bad-qc-missing`) with no local symptom whatsoever. Seeing a mined type we don't model *is* that symptom.

**False-positive discipline.** Slandering a type is as bad as missing one, so promoting silence to `NeverObserved` requires positive proof the channel was live: at least one *other* required type must have been observed. A bootstrapping / drained `QuorumManager` reports nothing for any type and therefore indicts none of them — it stays `Unevaluated` with `pending_reason = "no-required-type-observed-anywhere"`. Absence is evidence only when presence was demonstrable on the same channel.

Logging fires only when the **sentence changes**, so a newly-appearing offending type is never swallowed by dedup on an older one.

## Expected duty cycle after this: ~88–92%, NOT 100%

Stating this up front so a partial duty cycle is not later read as a regression.

The residue is deliberate policy, not breakage. dashd itself null-served type 4 at several heights because the real commitment had not finalised yet. **We refuse to null-serve**, because null-serving a *succeeded* DKG diverges `merkleRootQuorums` — the block-1520106 lesson, and the reason the completeness gate exists. Those heights are genuinely correct-but-slow and fall back to dashd. Nothing in this PR changes that, and nothing should.

## Explicitly out of scope — and a possibly LARGER blocker sits behind this one

Do not read this fix as "the QC lane is done". One slice per PR; these are named so the next person starts from the right place:

1. **The rotated type-5 (`llmq_60_75`) cliff, entirely unmeasured.** Its mining window is `h % 288 ∈ [42,50]` and it was **never entered during the soak**. It emits **32 mandatory slots at once**, and `quorum_member_source.hpp:154-180` fails closed for rotated types because `getqrinfo` quarter-rotation sourcing is an explicit unwired TODO. That is a cliff recurring **every 288 blocks** and it is plausibly a bigger duty-cycle blocker than the one fixed here.
2. **Type 2 (`llmq_400_60`, window `h % 288 ∈ [20,28]`) and type 3 (`llmq_400_85`, `h % 576 ∈ [20,48]`) windows were also never entered** during the soak. Unmeasured, not proven working.

## Tests — which test covers which claim

All in `test/test_dash_dkg_commitments.cpp` (folds into the already-CI-built `test_dash_embedded_gbt` target — no new `add_executable`, per the standing CMake warning about unbuilt-target CTest reds).

| Claim | Test |
|---|---|
| Mainnet's enabled set equals dashd's four types, in dashd's order, and excludes type 1 | `DashLlmqEnabledSet.MainnetMatchesDashdQuorumListExactlyAndInOrder` |
| Testnet keeps `LLMQ_50_60` deliberately; the two networks genuinely differ | `DashLlmqEnabledSet.TestnetKeepsLlmq50_60Deliberately` |
| The fix holds across the **whole height domain**, not one lucky height (576-block superperiod sweep; every slot names a type the live node reports) | `DashLlmqEnabledSet.NoMainnetWindowHeightEverRequiresADisabledType` |
| The mainnet incident height 2,515,381 now **serves** instead of failing closed — and still fails closed for the *right* reason when the genuinely-required type is unmined (negative twin) | `DashDkgColdStart.IncidentHeightNoLongerRequiresTheDisabledType` |
| A required type never observed in mined commitments **is named** | `DashLlmqTypeReconciler.NamesARequiredTypeThatIsNeverMined` |
| The guard is **silent on a healthy chain** (negative control — a check that always fires is as useless as one that never can) | `DashLlmqTypeReconciler.SaysNothingOnAHealthyChain` |
| The guard **refuses to indict on a silent channel**, and starts working the moment one type corroborates | `DashLlmqTypeReconciler.RefusesToIndictWhenTheChannelItselfIsSilent` |
| A verdict never outruns its evidence; `Unevaluated` carries a **named reason**, never a fabricated pass | `DashLlmqTypeReconciler.WaitsForAFullDkgCycleAndSaysWhyItIsWaiting` |
| The other direction: a **mined type we do not require** is named (survives an upstream consensus change) | `DashLlmqTypeReconciler.NamesAMinedTypeWeDoNotRequire` |
| The production `QuorumManager` overload observes the same thing the hand-fed one does — the guard tested is the guard that ships | `DashLlmqTypeReconciler.ReadsTheProductionQuorumManagerSource` |

Pre-existing cold-start / admission tests that were written on mainnet+type 1 were moved to **testnet**, where type 1 genuinely is required, so that coverage is preserved rather than deleted. The old `IncidentReplayFailsClosedNamingTheColdStartCause` kept its name and its assertions on testnet; its mainnet coordinates became the regression vector above. Note that the incident's own log line — `h=2515381 type=1 qi=0` — *was itself the defect*: type 1 was never actually required there.

### Mutation results

Baseline, corrected tree: **33/33 pass.**

**Mutation A — restore `kLlmq50_60` to `kMainnet` (the defect):** **8 tests red.**
```
DashDkgCommitments.MainnetInterval24WindowYieldsOneSlotPerType
DashDkgCommitments.RotatedWindowFansOutPerQuorumIndexInAddLlmqOrder
DashDkgCommitments.AlreadyMinedCommitmentSuppressesItsSlot
DashDkgColdStart.IncidentHeightNoLongerRequiresTheDisabledType
DashLlmqEnabledSet.MainnetMatchesDashdQuorumListExactlyAndInOrder
DashLlmqEnabledSet.NoMainnetWindowHeightEverRequiresADisabledType
DashLlmqTypeReconciler.RefusesToIndictWhenTheChannelItselfIsSilent
DashLlmqTypeReconciler.ReadsTheProductionQuorumManagerSource
```
The last two are the load-bearing ones: **the guard itself reds under the mutation**, indicting type 1 as `REQUIRED-BUT-NEVER-OBSERVED`. It is not decorative — it detects the exact defect this PR fixes.

**Mutation B — delete `kLlmq50_60` from `kTestnet` (the plausible-looking wrong symmetrical edit):** **9 tests red**, including `DashDkgCommitments.FromWireWindowHeightPlanMatchesDashdQuorumRoot` — the **real from-wire testnet block-1520106 KAT**. That is independent on-chain evidence, not just an assertion about a table, that testnet genuinely requires type 1. The unverified symmetrical edit is guarded.

## Notes for review

- **`test_dash_dkg_commitments.cpp` gets an appended section at end-of-file.** Several open PRs have been appending sections to test files' ends. If this conflicts it will be a pure append-vs-append conflict — take both sides. This is a **different TU from `test_dash_mn_checkpoint.cpp`**, so it does not collide with the `coin_state_maintainer.hpp` PR.
- **`src/c2pool/main_dash.cpp` could not be compiled locally** — `jsonrpccxx` is not in this host's conan cache. The dkg/reconciler headers and the full test TU were compiled and run locally (33/33). The wiring lambda's exact shape was compiled and executed against a stand-in state object. CI is the authority for `main_dash.cpp`.
- `dkg_window.hpp`'s coarse window union is untouched and unchanged: types 1 and 4 share `{interval 24, window [10,18]}`, so removing type 1 does not move the union — the `EverySlotHeightIsInsideTheCoarseWindowUnion` refinement property still holds.
