### PR TITLE
btc(bootstrap): name WebServer standup per-lane + guard null MiningInterface (no-silent-ctor)

### DIFF
--- a/src/c2pool/main_btc.cpp
+++ b/src/c2pool/main_btc.cpp
@@ -1633,11 +1633,26 @@ int main(int argc, char* argv[])
     std::shared_ptr<boost::asio::steady_timer> stats_timer;
     if (http_port != 0) {
         const bool web_is_testnet = testnet || testnet4 || regtest;
+        // No-silent-ctor bracket (integrator req #2, per-lane port of bch #1050
+        // "name the WebServer standup per-lane" / ltc #1041): name THIS lane's
+        // dashboard standup on the way IN and OUT so a ctor that throws mid-standup
+        // shows as an unmatched "standing up" with no "constructed" follow-up, and
+        // guard a null MiningInterface before use. src/c2pool/main_btc.cpp only.
+        LOG_INFO << "[BTC-POOL] standing up core::WebServer + MiningInterface (http bind "
+                 << http_addr << ":" << http_port << ") ...";
         web_server = std::make_unique<core::WebServer>(
             ioc, http_addr, http_port, web_is_testnet,
             std::shared_ptr<core::IMiningNode>{},          // no IMiningNode adapter yet
             c2pool::address::Blockchain::BITCOIN);         // SHA256d graph_db pairing
         auto* mi = web_server->get_mining_interface();
+        if (mi == nullptr) {
+            LOG_ERROR << "[BTC-POOL] core::WebServer constructed but MiningInterface is"
+                      << " NULL -- dashboard disabled, run-loop continues.";
+            web_server.reset();
+        }
+        if (mi != nullptr) {
+        LOG_INFO << "[BTC-POOL] core::WebServer + MiningInterface constructed (coin=BTC, "
+                 << "http " << http_addr << ":" << http_port << "); MiningInterface alive.";
 #ifdef C2POOL_VERSION
         mi->set_coin_label("BTC");
         mi->set_pool_version("c2pool/" C2POOL_VERSION);
@@ -1679,6 +1694,7 @@ int main(int argc, char* argv[])
                       << http_port << " â dashboard disabled, run-loop continues.";
             web_server.reset();
         }
+        } // if (mi != nullptr)
     } else {
         LOG_INFO << "[BTC-POOL] dashboard disabled (no --http bind given).";
     }


### PR DESCRIPTION
## What

Port the no-silent-ctor boot-log convention (bch PR #1050, "name the WebServer
standup per-lane") into the `main_btc` `core::WebServer` standup that landed in
PR #1049 ("stand up core::WebServer + graph_db persist inline in main_btc").

Two BTC-namespaced boot lines now bracket the ctor:
- on the way IN: `[BTC-POOL] standing up core::WebServer + MiningInterface (http bind ...)`
- on the way OUT: `[BTC-POOL] core::WebServer + MiningInterface constructed (coin=BTC ...); MiningInterface alive.`

A ctor that throws mid-standup now reads as an unmatched "standing up" with no
"constructed" follow-up, so a BTC boot is distinguishable in the journal. Adds a
null-`MiningInterface` guard: a half-built WebServer disables the dashboard and
lets the run-loop continue instead of dereferencing null.

## Reuse (no second copy)

Bootstrap (`set_http_peer_seeds`, sharechain bootstrap addrs) and the broadcaster
(submitblock RPC backup + `on_block_found` P2P dispatch) are the SAME primitives
already wired in `main_btc` off the LTC run-path shape (`main_ltc.cpp`); this
slice only makes the dashboard standup observable per-lane. No fork of a second
bootstrap/broadcaster.

## Shape note vs bch #1050

`main_btc` has no factored `standup_pool_run` (bch has `src/impl/bch/pool_entrypoint.hpp`),
so the same convention is applied inline in `main_btc.cpp`. Semantics match: same
named in/out lines, same `mi == nullptr` guard, same `if (mi != nullptr) { ... }`
wrap. No divergence in behaviour.

## Isolation

`src/c2pool/main_btc.cpp` only. Zero `src/core` and zero other `src/impl/<coin>`
edits — off the four-coin smoke gate.

## Caveat (IMPLEMENTED != PROVEN-BY-GATE)

This is boot-log/observability wiring. There is still no dedicated DNS-resolve ->
connect -> verack -> getheaders -> tip CI job; correctness of the standup is
covered only by build + existing smoke, not a live-serve gate.
