### PR TITLE
bch(dashboard): D-BCH — wire live BCH feeds into the WebServer seam

### DIFF
--- a/src/impl/bch/coin/embedded_daemon.hpp
+++ b/src/impl/bch/coin/embedded_daemon.hpp
@@ -624,6 +624,32 @@ public:
         return "none";
     }
 
+    /// D-BCH dashboard feed: per-coin embedded-daemon topology surfaced at
+    /// core::WebServer /api/node_topology (MiningInterface::set_node_topology_fn).
+    /// Display-only -- reads live daemon state, mutates no serving/consensus
+    /// path. Each datum is named TRUTHFULLY: BCH embedded transport is
+    /// SINGLE-PEER (one explicit BCHN peer or the RPC fallback, no
+    /// coin_peer_mgr), so `embedded_peers` is 0-or-1 alongside `broadcast_route`,
+    /// NOT a multi-peer getpeerinfo table (acceptance #2: name the datum the
+    /// lane cannot supply rather than render a placeholder). p2pool-merged-v36
+    /// surface: NONE (dashboard reporting, not share/PPLNS/coinbase bytes).
+    nlohmann::json dashboard_topology() {
+        const bool     emb_p2p  = m_node.has_p2p();
+        const bool     ext_rpc  = (m_coin_node && m_coin_node->has_rpc());
+        const uint32_t synced   = ibd_synced_height();
+        const uint32_t peer_tip = m_chain.peer_tip_height();
+        return nlohmann::json{
+            {"coin", "BCH"},
+            {"embedded", true},
+            {"has_rpc", ext_rpc},
+            {"synced_height", synced},
+            {"peer_tip_height", peer_tip},
+            {"sync_pct", (peer_tip > 0 ? 100.0 * synced / peer_tip : 0.0)},
+            {"embedded_peers", emb_p2p ? 1 : 0},   // single-peer embedded transport
+            {"broadcast_route", broadcast_route()},
+        };
+    }
+
 private:
     /// Populate the three converged seed tiers (idempotent). Mirrors the DGB
     /// tier-3 wire (main_dgb.cpp): DNS (tier 1) + fixed (tier 2) from

--- a/src/impl/bch/coin/header_chain.hpp
+++ b/src/impl/bch/coin/header_chain.hpp
@@ -443,6 +443,11 @@ public:
     /// Set the estimated network tip height (from peer's version message).
     void set_peer_tip_height(uint32_t height) { m_peer_tip_height.store(height); }
 
+    /// Estimated network tip height (from the peer version handshake); 0
+    /// before the first peer reports. Read-only display accessor for the
+    /// D-BCH dashboard sync-progress datum (synced_height vs peer_tip).
+    uint32_t peer_tip_height() const { return m_peer_tip_height.load(std::memory_order_relaxed); }
+
     /// Dynamically seed a checkpoint at runtime (e.g., from RPC getblockhash).
     /// Only applied if the chain is still at or below the hardcoded checkpoint.
     /// This allows an accessible daemon to provide a more recent starting point.

--- a/src/impl/bch/pool_entrypoint.hpp
+++ b/src/impl/bch/pool_entrypoint.hpp
@@ -668,6 +668,31 @@ inline void standup_pool_run(boost::asio::io_context& ioc,
         mi->set_io_context(&ioc);
         web_server->set_stratum_port(stratum_port);
 
+        // D-BCH dashboard feeds (integrator 2026-08-03): wire the live BCH
+        // data sources into the MiningInterface the H-STATS.944 seam already
+        // stood up (it was constructed with a NULL IMiningNode + zero feeds,
+        // so /api rendered empty). Reuses core/web_server.hpp generic feed
+        // setters (the same LTC-parity shape) -- ZERO src/core edit. The
+        // lambdas capture daemon/node by reference; both are declared at the
+        // top of standup_pool_run and outlive ioc.run(), so no dangle. All
+        // reads are display-only (lock-free snapshots / atomics).
+        //   /api/node_topology -- BCHN embedded daemon peers + synced height.
+        mi->set_node_topology_fn([&daemon]() { return daemon.dashboard_topology(); });
+        //   share-peers -- the pool node sharechain P2P peer snapshot.
+        mi->set_peer_info_fn([&node]() { return node.get_peer_info_json(); });
+        //   pool hashrate -- lock-free tracker snapshot published by think().
+        mi->set_pool_hashrate_fn([&node]() { return node.get_tracker_snapshot().pool_hashrate; });
+        //   sharechain stats -- chain/verified/head counts + hashrate.
+        mi->set_sharechain_stats_fn([&node]() {
+            auto s = node.get_tracker_snapshot();
+            return nlohmann::json{
+                {"chain_count", s.chain_count},
+                {"verified_count", s.verified_count},
+                {"head_count", s.head_count},
+                {"pool_hashrate", s.pool_hashrate},
+            };
+        });
+
         // graph_db stats persistence -- survives restarts (LTC-parity site 2/3;
         // mirrors main_ltc.cpp:1967-1973). BCH-namespaced sub-dir keeps the
         // per-coin stat log isolated under the shared config path.


### PR DESCRIPTION
## D-BCH — BCH dashboard off the now-open WebServer seam

Milestone D-BCH: serve BCHN embedded daemon peers + synced height, share-peers, and hashrate off the WebServer seam H-STATS.944 stood up in `pool_entrypoint.hpp`.

### Problem
The H-STATS.944 seam constructs `core::WebServer` + `MiningInterface` inside `standup_pool_run`, but with a **NULL `IMiningNode`** and **zero data feeds** — so `/api` renders empty.

### Change (all `src/impl/bch/`, ZERO `src/core`)
Extends the **same live `MiningInterface`** (no second server) with the BCH data sources, reusing the generic LTC-parity feed setters already in `core/web_server.hpp`:

| feed | surface | source |
|------|---------|--------|
| `set_node_topology_fn` | `/api/node_topology` | `EmbeddedDaemon::dashboard_topology()` — synced_height / peer_tip_height / sync_pct / broadcast_route / has_rpc |
| `set_peer_info_fn` | share-peers panel | pool node lock-free peer snapshot |
| `set_pool_hashrate_fn` | hashrate | published tracker snapshot |
| `set_sharechain_stats_fn` | chain stats | chain/verified/head counts + hashrate |

### Named non-supplied datum (acceptance #2)
BCH embedded transport is **single-peer** (one explicit BCHN peer or the RPC fallback, no `coin_peer_mgr`). `embedded_peers` is surfaced **truthfully as 0-or-1** alongside `broadcast_route`, **not** faked as a multi-peer `getpeerinfo` table.

### Notes
- Adds read-only `HeaderChain::peer_tip_height()` accessor.
- Feed reads are display-only (lock-free snapshots / atomics); lambdas capture daemon/node by reference, both outlive `ioc.run()`.
- Isolation: `src/impl/bch` only. p2pool-merged-v36 surface: **NONE**.
- Local `-fsyntax-only` on `main_bch.cpp` TU: EXIT=0.

Do not merge — integrator merges on operator `push approved`.