### PR TITLE
ci(codeql): 60-min step-level timeout on the analyze phase

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -208,6 +208,13 @@ jobs:
       # ── Analysis ──────────────────────────────────────────────────────────
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
+        # Step-level cap on the analyze phase only. The 90-min job cap
+        # (see analyze.timeout-minutes) covers init+build+analyze together;
+        # this tighter step cap fast-reds a wedged run-queries/extractor
+        # (the CodeQL-java-tracer runaway class, e.g. runner 145-1) without
+        # waiting on the whole-job budget. Whole-job p95 of successful runs
+        # is 59.2 min, so analyze alone sits comfortably under 60.
+        timeout-minutes: 60
         with:
           category: "/language:${{ matrix.language }}"
           # Cap the run-queries footprint on the shared self-hosted 905 box so


### PR DESCRIPTION
Adds a step-level `timeout-minutes: 60` on the *Perform CodeQL Analysis* step.

## Why
The 90-min cap from #1035 is job-level (init+build+analyze together). A wedged `run-queries`/extractor — the CodeQL-java-tracer runaway class that pinned runner 145-1 (id 36) into steps=0 job-setup failures — can still burn most of that budget before the job cap fires. A tighter step-level cap on the analyze phase alone fast-reds that hang.

## Sizing
Whole-job p95 of the recent successful runs is 59.2 min, so the analyze phase alone sits comfortably under 60. The cap converts a hang to a deterministic red without touching any legitimate run.

## Scope
- One step, one `timeout-minutes: 60` line + comment. No behavior change to healthy runs.
- Complements (does not replace) the existing `ram: 20000` / `threads: 12` footprint caps and the 90-min job cap.

Not self-merging — surfacing the merge tap to integrator.