### PR TITLE
proto(v37): libmrr M2 Drop 2 — self-carry compaction ledger + KAT-3 goldens (prototype-only)

### DIFF
--- a/prototypes/libmrr/README.md
+++ b/prototypes/libmrr/README.md
@@ -23,6 +23,29 @@ only — no live risk, no production wiring. Landing is held for the merge-tap.
   of the m1 settlement state machine (dedup / expiry / bin-clock-convergence
   invariants). **Not** in this drop: self-carry compaction (Drop 2) and the
   finality-gated owed/overlay ledger (Drop 3).
+- **m2 Drop 2 — Self-carry compaction: complete.** `mrr.Ledger`
+  (`compaction.go`): the deterministic fold from the buffer's position-indexed
+  live work into a position-free, per-identity accrued balance. `Fold(id, w)`
+  accrues integer weight; `Compact(cs)` builds a ledger from a contribution
+  batch; `Merge` folds one ledger into another. "Self-carry" is the property
+  that an identity's balance persists past window expiry — a small miner's
+  sub-threshold work, spread thin and forever expiring out of the live window,
+  is consolidated into one durable owed total rather than forfeited
+  (small-miner-equity §6; the V36 failure this removes). The canonical
+  `Digest()` is invariant to fold order and to how contributions are batched
+  across sub-ledgers — **compact-then-digest == digest-then-compact** — since
+  accrual is a commutative, associative integer add (proved by
+  `TestLedger_CompactDigestCommute`: every rotation, reverse, weight-sorted
+  order, and split-compact-then-merge cut hashes identically). A zero-weight
+  fold is a no-op (no phantom entry). KAT-3 golden vectors
+  (`mrr/testdata/kat3_compaction_vectors.json`, two scenarios:
+  `small_miner_consolidation`, `carry_forward_many_ids`) pin per-step running
+  total, distinct-identity count, digest, and the hand-derived final balances.
+  `TestLedger_SelfCarryOutlivesBufferExpiry` cross-links Drop 1: the same stream
+  fed to both stages agrees in-window, then the buffer live sum drops on
+  eviction while the ledger total is unchanged. **Not** in this drop: any
+  finality gating, block-found overlay, or owed→settled transition — that is the
+  finality-gated owed/overlay ledger (Drop 3), a hard scope fence.
 - Phases 1 (query-side decay) and 2 (pure `retarget()` + EMA + observables +
   offline simulator) are next, per the blueprint. Phase 3 (live adaptive
   dimensioning) is **v38-fenced** — hard stop.
@@ -63,12 +86,17 @@ go test ./... -count=1
 Regenerate the golden vectors on a reference build and review the diff:
 
 ```
-go run ./cmd/genkat  > mrr/testdata/kat1_vectors.json          # KAT-1: Geometry
-go run ./cmd/genkat2 > mrr/testdata/kat2_buffer_vectors.json   # KAT-2: Buffer
+go run ./cmd/genkat  > mrr/testdata/kat1_vectors.json               # KAT-1: Geometry
+go run ./cmd/genkat2 > mrr/testdata/kat2_buffer_vectors.json        # KAT-2: Buffer
+go run ./cmd/genkat3 > mrr/testdata/kat3_compaction_vectors.json    # KAT-3: Compaction
 ```
 
 `genkat2` asserts every hand-derived per-step disposition/sum/count/head before
-it emits a vector, so a wrong implementation cannot mint a golden.
+it emits a vector, so a wrong implementation cannot mint a golden. `genkat3`
+does the same for compaction — per-step total/count/digest and the final
+per-identity balances — and additionally asserts the commutativity invariant
+(reverse, weight-sorted, and split-compact-then-merge all reproduce the
+canonical digest) inside the generator before minting.
 
 ## Open items (flagged, non-blocking)
 

--- a/prototypes/libmrr/cmd/genkat3/main.go
+++ b/prototypes/libmrr/cmd/genkat3/main.go
@@ -1,0 +1,202 @@
+// genkat3 regenerates the KAT-3 golden vectors for self-carry compaction
+// (V37 m2 Drop 2). Run on a reference build; paste stdout into
+// mrr/testdata/kat3_compaction_vectors.json. The generator folds a scripted
+// contribution stream into the compacted Ledger and, before it emits any
+// vector, ASSERTS:
+//
+//   - the running total, distinct-identity count, and digest at each step;
+//   - the hand-derived final per-identity balances (exact set, no extras),
+//     total, and count;
+//   - the commutativity invariant three independent ways — reverse fold order,
+//     weight-sorted fold order, and split-compact-then-merge — each must
+//     reproduce the identical final digest (compact-then-digest ==
+//     digest-then-compact).
+//
+// A wrong implementation cannot mint a golden. compaction_test.go then
+// independently replays the committed vectors and checks every field.
+package main
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+
+	"libmrr/mrr"
+)
+
+// contrib is one scripted (id, weight) fold.
+type contrib struct {
+	ID     uint64 `json:"id"`
+	Weight uint64 `json:"weight"`
+}
+
+// balance is one credited identity's final accrued total (sorted by id).
+type balance struct {
+	ID     uint64 `json:"id"`
+	Weight uint64 `json:"weight"`
+}
+
+// ledgerStep is the observable post-state after folding contribution i
+// (0-indexed): the running total, distinct-identity count, and canonical digest.
+type ledgerStep struct {
+	Index  int    `json:"index"`
+	Total  uint64 `json:"total"`
+	Len    int    `json:"len"`
+	Digest string `json:"digest_hex"`
+}
+
+// scenario is a named contribution script, its per-step trace, and the hand-
+// derived final expectations that gate minting.
+type scenario struct {
+	Name     string       `json:"name"`
+	Contribs []contrib    `json:"contribs"`
+	Trace    []ledgerStep `json:"trace"`
+	// Hand-derived final state (asserted before emit).
+	Want        []balance `json:"want_balances"` // exact final set, sorted by id
+	WantTotal   uint64    `json:"want_total"`
+	WantLen     int       `json:"want_len"`
+	FinalDigest string    `json:"final_digest_hex"` // minted; == Trace[last].Digest
+}
+
+func scenarios() []scenario {
+	return []scenario{
+		{
+			// Small-miner consolidation: one identity's work is spread across
+			// many folds (as it would be across many bins) and compacts to a
+			// single accrued balance. Includes a zero-weight fold (id 4) which
+			// must create no entry.
+			Name: "small_miner_consolidation",
+			Contribs: []contrib{
+				{1, 5}, {2, 3}, {1, 7}, {3, 1}, {1, 2}, {2, 4}, {4, 0},
+			},
+			// id1 = 5+7+2 = 14; id2 = 3+4 = 7; id3 = 1; id4 = 0 -> absent.
+			Want:      []balance{{1, 14}, {2, 7}, {3, 1}},
+			WantTotal: 22,
+			WantLen:   3,
+		},
+		{
+			// Carry-forward with several identities and repeated contributions;
+			// larger weights, distinct digest. No zero folds.
+			Name: "carry_forward_many_ids",
+			Contribs: []contrib{
+				{10, 100}, {11, 50}, {12, 25}, {10, 10},
+				{13, 7}, {11, 50}, {12, 25}, {10, 10},
+			},
+			// id10 = 100+10+10 = 120; id11 = 50+50 = 100; id12 = 25+25 = 50; id13 = 7.
+			Want:      []balance{{10, 120}, {11, 100}, {12, 50}, {13, 7}},
+			WantTotal: 277,
+			WantLen:   4,
+		},
+	}
+}
+
+// digestHex compacts cs into a fresh ledger and returns its digest hex.
+func digestHex(cs []contrib) string {
+	l := mrr.NewLedger()
+	for _, c := range cs {
+		l.Fold(c.ID, c.Weight)
+	}
+	d := l.Digest()
+	return hex.EncodeToString(d[:])
+}
+
+func run(sc *scenario) error {
+	l := mrr.NewLedger()
+	sc.Trace = make([]ledgerStep, 0, len(sc.Contribs))
+	for i, c := range sc.Contribs {
+		l.Fold(c.ID, c.Weight)
+		d := l.Digest()
+		sc.Trace = append(sc.Trace, ledgerStep{
+			Index: i, Total: l.Total(), Len: l.Len(),
+			Digest: hex.EncodeToString(d[:]),
+		})
+	}
+
+	// Hand-derived final expectations.
+	if l.Len() != sc.WantLen {
+		return fmt.Errorf("%s: len=%d, want %d", sc.Name, l.Len(), sc.WantLen)
+	}
+	if l.Total() != sc.WantTotal {
+		return fmt.Errorf("%s: total=%d, want %d", sc.Name, l.Total(), sc.WantTotal)
+	}
+	if len(sc.Want) != sc.WantLen {
+		return fmt.Errorf("%s: want_balances has %d entries, want_len=%d", sc.Name, len(sc.Want), sc.WantLen)
+	}
+	for _, b := range sc.Want {
+		if got := l.Balance(b.ID); got != b.Weight {
+			return fmt.Errorf("%s: balance[%d]=%d, want %d", sc.Name, b.ID, got, b.Weight)
+		}
+	}
+	// No identity outside Want may be credited (guards against phantom entries,
+	// e.g. a zero-weight fold that wrongly created one).
+	wantIDs := make(map[uint64]bool, len(sc.Want))
+	for _, b := range sc.Want {
+		wantIDs[b.ID] = true
+	}
+	for _, id := range l.Identities() {
+		if !wantIDs[id] {
+			return fmt.Errorf("%s: unexpected credited identity %d", sc.Name, id)
+		}
+	}
+
+	// Commutativity: compact-then-digest is invariant to fold order and to
+	// batching. Derive the canonical digest three independent ways and require
+	// they all match before minting.
+	canon := digestHex(sc.Contribs)
+
+	rev := make([]contrib, len(sc.Contribs))
+	for i, c := range sc.Contribs {
+		rev[len(sc.Contribs)-1-i] = c
+	}
+	if got := digestHex(rev); got != canon {
+		return fmt.Errorf("%s: reverse-order digest %s != canonical %s", sc.Name, got, canon)
+	}
+
+	byWeight := make([]contrib, len(sc.Contribs))
+	copy(byWeight, sc.Contribs)
+	sort.SliceStable(byWeight, func(i, j int) bool { return byWeight[i].Weight < byWeight[j].Weight })
+	if got := digestHex(byWeight); got != canon {
+		return fmt.Errorf("%s: weight-sorted digest %s != canonical %s", sc.Name, got, canon)
+	}
+
+	// Split-compact-then-merge: partition into halves, compact each, merge.
+	half := len(sc.Contribs) / 2
+	toContribs := func(cs []contrib) []mrr.Contribution {
+		out := make([]mrr.Contribution, len(cs))
+		for i, c := range cs {
+			out[i] = mrr.Contribution{ID: c.ID, Weight: c.Weight}
+		}
+		return out
+	}
+	la := mrr.Compact(toContribs(sc.Contribs[:half]))
+	lb := mrr.Compact(toContribs(sc.Contribs[half:]))
+	la.Merge(lb)
+	md := la.Digest()
+	if got := hex.EncodeToString(md[:]); got != canon {
+		return fmt.Errorf("%s: split-merge digest %s != canonical %s", sc.Name, got, canon)
+	}
+
+	sc.FinalDigest = canon
+	if n := len(sc.Trace); n > 0 && sc.Trace[n-1].Digest != canon {
+		return fmt.Errorf("%s: last trace digest %s != canonical %s", sc.Name, sc.Trace[n-1].Digest, canon)
+	}
+	return nil
+}
+
+func main() {
+	scs := scenarios()
+	for i := range scs {
+		if err := run(&scs[i]); err != nil {
+			fmt.Fprintln(os.Stderr, "genkat3: assertion failed:", err)
+			os.Exit(1)
+		}
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(scs); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/prototypes/libmrr/mrr/compaction.go
+++ b/prototypes/libmrr/mrr/compaction.go
@@ -1,0 +1,164 @@
+// compaction.go — self-carry compaction (V37 m2 Drop 2).
+//
+// The Roundabout buffer (buffer.go, Drop 1) holds transient, position-indexed
+// live work: weight accumulates into absolute bins and falls out of the live
+// set when the bin-clock advances past the window. Settlement, though, must
+// credit an identity's work as one durable, position-free running total that
+// SURVIVES window expiry — otherwise a small miner's sub-threshold work, spread
+// thin across many bins and forever expiring out of the window, is forfeited
+// (the V36 failure this milestone removes; small-miner-equity §6).
+//
+// Compaction is the deterministic fold from the position-indexed representation
+// into a position-free, per-identity accrued Ledger. "Self-carry" is the
+// property that a miner carries its OWN work forward: contributions folded into
+// the Ledger persist as an accrued balance regardless of whether the originating
+// share has since expired from the live window. Many scattered per-bin
+// contributions for one identity collapse ("compact") into a single owed total.
+//
+// Scope fence. This drop is the accounting SUBSTRATE only. It has NO finality
+// gating, NO block-found overlay, and NO owed->settled transition — that is the
+// finality-gated owed/overlay ledger (Drop 3), deliberately NOT in this file.
+// Here every folded contribution is simply "accrued"; nothing settles, nothing
+// reverts, no block event exists.
+//
+// Determinism is absolute, same mandate as geometry.go and buffer.go:
+// fixed-width integer serialization, integer add, no floating point, no
+// wall-clock, no map iteration in any consensus-visible path (the Digest sorts
+// identities before hashing). Accrual is integer addition, which is commutative
+// and associative, so the canonical Digest is invariant to the order in which
+// contributions are folded and to how they are batched across sub-ledgers
+// (compact-then-digest == digest-then-compact). That invariance is the
+// compaction-level analogue of the buffer's order-independent digest and is
+// pinned as a property test, not asserted in prose.
+package mrr
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"sort"
+)
+
+// Contribution is one scored unit of work attributed to a payout identity: the
+// same (id, weight) pair the buffer ingests, viewed for accrual rather than for
+// windowing. Weight is integer score; a zero-weight contribution is not work
+// and folds to nothing (see Ledger.Fold).
+type Contribution struct {
+	ID     uint64
+	Weight uint64
+}
+
+// Ledger is the compacted accrued balance: payout identity -> total integer
+// weight owed, summed across every contribution ever folded in. It is the
+// position-free consolidation of windowed work — one entry per identity, no
+// matter how many bins that identity's work was spread across. There is no
+// expiry here: the Ledger is the durable carry that outlives the live window.
+//
+// The zero value is not usable; construct with NewLedger.
+type Ledger struct {
+	bal map[uint64]uint64 // id -> accrued weight; an id is absent iff its total is 0
+}
+
+// NewLedger returns an empty accrued Ledger.
+func NewLedger() *Ledger {
+	return &Ledger{bal: make(map[uint64]uint64)}
+}
+
+// Fold accrues weight to an identity's running balance (self-carry: the balance
+// persists independently of the live window). Accrual is integer addition, so
+// Fold is commutative and associative across identities and across repeated
+// folds of the same identity.
+//
+// A zero-weight fold is a no-op that creates no entry: accruing zero work must
+// leave the Ledger — and therefore its Digest — identical to not folding at all,
+// so that Digest(Compact(S ∪ {(id,0)})) == Digest(Compact(S)). This keeps the
+// canonical form free of phantom zero-balance identities.
+func (l *Ledger) Fold(id, weight uint64) {
+	if weight == 0 {
+		return
+	}
+	l.bal[id] += weight
+}
+
+// FoldContributions folds a batch in one call. Order within the batch does not
+// affect the result (commutativity).
+func (l *Ledger) FoldContributions(cs []Contribution) {
+	for _, c := range cs {
+		l.Fold(c.ID, c.Weight)
+	}
+}
+
+// Compact builds a fresh Ledger from a batch of contributions — the position-
+// free consolidation of a set of scored work units. Compact(cs) is exactly an
+// empty Ledger with cs folded in; grouping/order of cs is irrelevant.
+func Compact(cs []Contribution) *Ledger {
+	l := NewLedger()
+	l.FoldContributions(cs)
+	return l
+}
+
+// Merge folds every balance of other into l (self-carry across sub-ledgers).
+// Because accrual is associative and commutative, merging compacted sub-ledgers
+// is identical to compacting the union of their contributions:
+//
+//	Digest(Merge(Compact(A), Compact(B))) == Digest(Compact(A ∪ B)).
+//
+// This is the homomorphism that makes "compact-then-digest == digest-then-
+// compact" hold for any partition of the contribution multiset.
+func (l *Ledger) Merge(other *Ledger) {
+	for id, w := range other.bal {
+		l.bal[id] += w // w is always > 0 by the Fold invariant
+	}
+}
+
+// Balance reports an identity's accrued total (0 if never credited).
+func (l *Ledger) Balance(id uint64) uint64 { return l.bal[id] }
+
+// Len is the number of distinct credited identities.
+func (l *Ledger) Len() int { return len(l.bal) }
+
+// Total is the sum of all accrued balances — the full carried work, including
+// contributions whose originating shares have expired from any live window.
+func (l *Ledger) Total() uint64 {
+	var sum uint64
+	for _, w := range l.bal {
+		sum += w
+	}
+	return sum
+}
+
+// Identities returns the credited identities in ascending order — the canonical
+// iteration order (never range a map in a consensus-visible path).
+func (l *Ledger) Identities() []uint64 {
+	ids := make([]uint64, 0, len(l.bal))
+	for id := range l.bal {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
+}
+
+// Digest is the canonical SHA-256 commitment over the compacted Ledger: a
+// header carrying the distinct-identity count, then each credited identity in
+// ascending order with its accrued weight. Sorting identities makes the digest
+// independent of fold order and of how contributions were batched across
+// sub-ledgers — the compaction-level commutativity property. A divergence here
+// is a determinism bug or a tamper and surfaces as an immediate mismatch.
+//
+// The header count is domain separation from the buffer digest: the two commit
+// to different things (per-identity accrued totals vs per-bin live weight) and
+// must never collide by construction.
+func (l *Ledger) Digest() Digest {
+	h := sha256.New()
+	var hdr [8]byte
+	binary.LittleEndian.PutUint64(hdr[:], uint64(len(l.bal)))
+	h.Write(hdr[:])
+	var rec [16]byte
+	for _, id := range l.Identities() {
+		binary.LittleEndian.PutUint64(rec[0:8], id)
+		binary.LittleEndian.PutUint64(rec[8:16], l.bal[id])
+		h.Write(rec[:])
+	}
+	var d Digest
+	copy(d[:], h.Sum(nil))
+	return d
+}

--- a/prototypes/libmrr/mrr/compaction_test.go
+++ b/prototypes/libmrr/mrr/compaction_test.go
@@ -1,0 +1,272 @@
+package mrr
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"sort"
+	"testing"
+)
+
+// --- KAT-3 golden replay ---------------------------------------------------
+//
+// Compaction must reproduce every pinned vector: the running total, distinct-
+// identity count, and canonical digest after each fold, plus the hand-derived
+// final balances. A change to any digest here is a change to the consensus-
+// visible accrued commitment and must be deliberate (regenerate with
+// cmd/genkat3 and review the diff).
+
+type katContrib struct {
+	ID     uint64 `json:"id"`
+	Weight uint64 `json:"weight"`
+}
+
+type katBalance struct {
+	ID     uint64 `json:"id"`
+	Weight uint64 `json:"weight"`
+}
+
+type katLedgerStep struct {
+	Index  int    `json:"index"`
+	Total  uint64 `json:"total"`
+	Len    int    `json:"len"`
+	Digest string `json:"digest_hex"`
+}
+
+type katCompScenario struct {
+	Name        string          `json:"name"`
+	Contribs    []katContrib    `json:"contribs"`
+	Trace       []katLedgerStep `json:"trace"`
+	Want        []katBalance    `json:"want_balances"`
+	WantTotal   uint64          `json:"want_total"`
+	WantLen     int             `json:"want_len"`
+	FinalDigest string          `json:"final_digest_hex"`
+}
+
+func loadKAT3(t *testing.T) []katCompScenario {
+	t.Helper()
+	b, err := os.ReadFile("testdata/kat3_compaction_vectors.json")
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	var scs []katCompScenario
+	if err := json.Unmarshal(b, &scs); err != nil {
+		t.Fatalf("parse golden: %v", err)
+	}
+	if len(scs) == 0 {
+		t.Fatal("no golden scenarios")
+	}
+	return scs
+}
+
+func TestKAT3_CompactionGolden(t *testing.T) {
+	for _, sc := range loadKAT3(t) {
+		sc := sc
+		t.Run(sc.Name, func(t *testing.T) {
+			if len(sc.Contribs) != len(sc.Trace) {
+				t.Fatalf("contribs/trace length mismatch: %d vs %d", len(sc.Contribs), len(sc.Trace))
+			}
+			l := NewLedger()
+			for i, c := range sc.Contribs {
+				l.Fold(c.ID, c.Weight)
+				w := sc.Trace[i]
+				if l.Total() != w.Total {
+					t.Fatalf("step %d: total=%d, want %d", i, l.Total(), w.Total)
+				}
+				if l.Len() != w.Len {
+					t.Fatalf("step %d: len=%d, want %d", i, l.Len(), w.Len)
+				}
+				d := l.Digest()
+				if got := hex.EncodeToString(d[:]); got != w.Digest {
+					t.Fatalf("step %d: digest\n got %s\nwant %s", i, got, w.Digest)
+				}
+			}
+			if l.Total() != sc.WantTotal || l.Len() != sc.WantLen {
+				t.Fatalf("final: total=%d len=%d, want %d/%d", l.Total(), l.Len(), sc.WantTotal, sc.WantLen)
+			}
+			if l.Len() != len(sc.Want) {
+				t.Fatalf("final len=%d but want_balances has %d", l.Len(), len(sc.Want))
+			}
+			for _, b := range sc.Want {
+				if got := l.Balance(b.ID); got != b.Weight {
+					t.Fatalf("balance[%d]=%d, want %d", b.ID, got, b.Weight)
+				}
+			}
+			d := l.Digest()
+			if got := hex.EncodeToString(d[:]); got != sc.FinalDigest {
+				t.Fatalf("final digest\n got %s\nwant %s", got, sc.FinalDigest)
+			}
+		})
+	}
+}
+
+// --- Property tests --------------------------------------------------------
+
+// The pinned invariant: the compacted digest is invariant to fold order and to
+// how contributions are batched across sub-ledgers — compact-then-digest ==
+// digest-then-compact. Proved three ways: any permutation of a single fold
+// stream, and the split-compact-then-merge homomorphism.
+func TestLedger_CompactDigestCommute(t *testing.T) {
+	base := []Contribution{
+		{1, 5}, {2, 3}, {1, 7}, {3, 1}, {1, 2}, {2, 4},
+		{9, 100}, {4, 8}, {9, 1}, {2, 6},
+	}
+	canon := Compact(base).Digest()
+
+	// Every rotation is a distinct fold order; all must hash identically.
+	for r := 0; r < len(base); r++ {
+		perm := make([]Contribution, len(base))
+		for i := range base {
+			perm[i] = base[(i+r)%len(base)]
+		}
+		if Compact(perm).Digest() != canon {
+			t.Fatalf("rotation %d changed the compacted digest (fold order leaked)", r)
+		}
+	}
+
+	// Reverse order.
+	rev := make([]Contribution, len(base))
+	for i := range base {
+		rev[len(base)-1-i] = base[i]
+	}
+	if Compact(rev).Digest() != canon {
+		t.Fatal("reverse fold order changed the compacted digest")
+	}
+
+	// Sorted-by-weight order.
+	byW := make([]Contribution, len(base))
+	copy(byW, base)
+	sort.SliceStable(byW, func(i, j int) bool { return byW[i].Weight < byW[j].Weight })
+	if Compact(byW).Digest() != canon {
+		t.Fatal("weight-sorted fold order changed the compacted digest")
+	}
+
+	// Split-compact-then-merge at every cut point == compact of the union.
+	for cut := 0; cut <= len(base); cut++ {
+		a := Compact(base[:cut])
+		b := Compact(base[cut:])
+		a.Merge(b)
+		if a.Digest() != canon {
+			t.Fatalf("split at %d then merge changed the compacted digest", cut)
+		}
+		if a.Total() != Compact(base).Total() {
+			t.Fatalf("split at %d then merge changed the total", cut)
+		}
+	}
+}
+
+// Merge is commutative: Merge(A,B) and Merge(B,A) agree on every balance and
+// on the digest.
+func TestLedger_MergeCommutative(t *testing.T) {
+	a := []Contribution{{1, 5}, {2, 3}, {5, 9}}
+	b := []Contribution{{2, 4}, {3, 7}, {5, 1}}
+	ab := Compact(a)
+	ab.Merge(Compact(b))
+	ba := Compact(b)
+	ba.Merge(Compact(a))
+	if ab.Digest() != ba.Digest() {
+		t.Fatal("Merge is not commutative on the digest")
+	}
+	if ab.Total() != ba.Total() {
+		t.Fatalf("Merge total differs: %d vs %d", ab.Total(), ba.Total())
+	}
+}
+
+// A zero-weight fold is a no-op: it creates no entry and leaves the digest
+// identical to not folding at all.
+func TestLedger_ZeroWeightIsNoOp(t *testing.T) {
+	l := NewLedger()
+	l.Fold(1, 10)
+	l.Fold(2, 20)
+	before := l.Digest()
+	beforeLen := l.Len()
+	l.Fold(3, 0)
+	l.Fold(1, 0)
+	l.Fold(999, 0)
+	if l.Digest() != before {
+		t.Fatal("zero-weight fold changed the digest")
+	}
+	if l.Len() != beforeLen {
+		t.Fatalf("zero-weight fold changed len: %d -> %d", beforeLen, l.Len())
+	}
+	if l.Balance(3) != 0 || l.Balance(999) != 0 {
+		t.Fatal("zero-weight fold created a phantom entry")
+	}
+}
+
+// Two empty ledgers hash equal; the digest changes once real work is folded.
+func TestLedger_EmptyDigestStable(t *testing.T) {
+	if NewLedger().Digest() != NewLedger().Digest() {
+		t.Fatal("two empty ledgers must hash equal")
+	}
+	l := NewLedger()
+	empty := l.Digest()
+	l.Fold(1, 1)
+	if l.Digest() == empty {
+		t.Fatal("digest must change after the first credited fold")
+	}
+}
+
+// Self-carry: the Ledger carries a miner's work forward past window expiry that
+// the Roundabout buffer forgets. Feeding the same unique-id stream to both, the
+// ledger total equals the buffer live sum while everything is in-window; after
+// the bin-clock advances and evicts, the buffer live sum drops but the ledger
+// total is unchanged — the work is carried, not forfeited.
+func TestLedger_SelfCarryOutlivesBufferExpiry(t *testing.T) {
+	type share struct{ id, bin, w uint64 }
+	// All bins within a window of 16, unique ids: no dedup, no expiry yet.
+	shares := []share{
+		{1, 100, 5}, {2, 101, 7}, {3, 104, 11}, {4, 112, 3}, {5, 114, 9},
+	}
+	buf, err := NewBuffer(geomForWindow(16))
+	if err != nil {
+		t.Fatalf("NewBuffer: %v", err)
+	}
+	led := NewLedger()
+	var fullTotal uint64
+	for _, s := range shares {
+		if r := buf.Ingest(s.id, s.bin, s.w); r != Accepted {
+			t.Fatalf("ingest id=%d: %s, want accepted", s.id, r)
+		}
+		led.Fold(s.id, s.w)
+		fullTotal += s.w
+	}
+	// In-window: the two accountings agree.
+	if buf.LiveSum() != led.Total() {
+		t.Fatalf("in-window mismatch: buffer live sum %d != ledger total %d", buf.LiveSum(), led.Total())
+	}
+	if led.Total() != fullTotal {
+		t.Fatalf("ledger total %d != full accrued %d", led.Total(), fullTotal)
+	}
+
+	// Advance the bin-clock far enough to evict every original share from the
+	// live window (does NOT touch the ledger).
+	buf.Ingest(6, 200, 1)
+	if buf.LiveSum() >= fullTotal {
+		t.Fatalf("expected buffer live sum to drop below %d after eviction, got %d", fullTotal, buf.LiveSum())
+	}
+	// The ledger still carries every unit of the expired work.
+	if led.Total() != fullTotal {
+		t.Fatalf("self-carry violated: ledger total %d != %d after buffer eviction", led.Total(), fullTotal)
+	}
+	for _, s := range shares {
+		if led.Balance(s.id) != s.w {
+			t.Fatalf("carried balance[%d]=%d, want %d", s.id, led.Balance(s.id), s.w)
+		}
+	}
+}
+
+// Identities() is sorted ascending and lists exactly the credited set.
+func TestLedger_IdentitiesSorted(t *testing.T) {
+	l := Compact([]Contribution{{5, 1}, {2, 1}, {9, 1}, {2, 1}, {1, 1}})
+	ids := l.Identities()
+	want := []uint64{1, 2, 5, 9}
+	if len(ids) != len(want) {
+		t.Fatalf("ids=%v, want %v", ids, want)
+	}
+	for i := range want {
+		if ids[i] != want[i] {
+			t.Fatalf("ids=%v not ascending/exact, want %v", ids, want)
+		}
+	}
+}

--- a/prototypes/libmrr/mrr/testdata/kat3_compaction_vectors.json
+++ b/prototypes/libmrr/mrr/testdata/kat3_compaction_vectors.json
@@ -1,0 +1,204 @@
+[
+  {
+    "name": "small_miner_consolidation",
+    "contribs": [
+      {
+        "id": 1,
+        "weight": 5
+      },
+      {
+        "id": 2,
+        "weight": 3
+      },
+      {
+        "id": 1,
+        "weight": 7
+      },
+      {
+        "id": 3,
+        "weight": 1
+      },
+      {
+        "id": 1,
+        "weight": 2
+      },
+      {
+        "id": 2,
+        "weight": 4
+      },
+      {
+        "id": 4,
+        "weight": 0
+      }
+    ],
+    "trace": [
+      {
+        "index": 0,
+        "total": 5,
+        "len": 1,
+        "digest_hex": "90b809b78c624ed61808d38092da4473ea21fa00400a6f79d5b82229c0189d43"
+      },
+      {
+        "index": 1,
+        "total": 8,
+        "len": 2,
+        "digest_hex": "629021dc12741a90f6ad6e42c1a18d655e3b1aa1517c9065248747bf9ca008a8"
+      },
+      {
+        "index": 2,
+        "total": 15,
+        "len": 2,
+        "digest_hex": "20eb76d7b0d3c5958db92d94a4416e1ea2ef20544de9842b73e0185ff85d9eb7"
+      },
+      {
+        "index": 3,
+        "total": 16,
+        "len": 3,
+        "digest_hex": "07c02bb17d52779eada0b54daeefefa79bbec196a2c09175a96b4c493b5b2b05"
+      },
+      {
+        "index": 4,
+        "total": 18,
+        "len": 3,
+        "digest_hex": "d1c81d130e34b89eb61c548951dec4ea87252baf924d203457f363560e216ebb"
+      },
+      {
+        "index": 5,
+        "total": 22,
+        "len": 3,
+        "digest_hex": "90dc14c19b0fb45357060eb0ce4e32aeb0d03e3e04b95289f0d142c34c8556b6"
+      },
+      {
+        "index": 6,
+        "total": 22,
+        "len": 3,
+        "digest_hex": "90dc14c19b0fb45357060eb0ce4e32aeb0d03e3e04b95289f0d142c34c8556b6"
+      }
+    ],
+    "want_balances": [
+      {
+        "id": 1,
+        "weight": 14
+      },
+      {
+        "id": 2,
+        "weight": 7
+      },
+      {
+        "id": 3,
+        "weight": 1
+      }
+    ],
+    "want_total": 22,
+    "want_len": 3,
+    "final_digest_hex": "90dc14c19b0fb45357060eb0ce4e32aeb0d03e3e04b95289f0d142c34c8556b6"
+  },
+  {
+    "name": "carry_forward_many_ids",
+    "contribs": [
+      {
+        "id": 10,
+        "weight": 100
+      },
+      {
+        "id": 11,
+        "weight": 50
+      },
+      {
+        "id": 12,
+        "weight": 25
+      },
+      {
+        "id": 10,
+        "weight": 10
+      },
+      {
+        "id": 13,
+        "weight": 7
+      },
+      {
+        "id": 11,
+        "weight": 50
+      },
+      {
+        "id": 12,
+        "weight": 25
+      },
+      {
+        "id": 10,
+        "weight": 10
+      }
+    ],
+    "trace": [
+      {
+        "index": 0,
+        "total": 100,
+        "len": 1,
+        "digest_hex": "0f200b1284ecd1ef94b9a6a15a18f5f53dd733f0147d795716bb8e16a0c157ac"
+      },
+      {
+        "index": 1,
+        "total": 150,
+        "len": 2,
+        "digest_hex": "26baa6cb06c3723a5c33a0869a5840cdd2e13209f0465177d19ced426adae0e9"
+      },
+      {
+        "index": 2,
+        "total": 175,
+        "len": 3,
+        "digest_hex": "b3927d5a7e08787fc953a9e60ddf9ebf52a9edbf240be2ceb0e74bd0a65b5310"
+      },
+      {
+        "index": 3,
+        "total": 185,
+        "len": 3,
+        "digest_hex": "1730d5b51ccfdbc709b2bb4688d56568f6941674fdeb4d075938b6d3c2cfcfbd"
+      },
+      {
+        "index": 4,
+        "total": 192,
+        "len": 4,
+        "digest_hex": "d884ae9e70d9239010489e70fead877f23fae96cb30093009dc4660204e6ae8b"
+      },
+      {
+        "index": 5,
+        "total": 242,
+        "len": 4,
+        "digest_hex": "75adbfd6d465518be846db0e3041ff9f2b42bf369692ef6daa52cf5965da109e"
+      },
+      {
+        "index": 6,
+        "total": 267,
+        "len": 4,
+        "digest_hex": "3ca84b903bfce27f7b14adf481581323cbf409923fa3662ccf535cd399dc38b4"
+      },
+      {
+        "index": 7,
+        "total": 277,
+        "len": 4,
+        "digest_hex": "77376432d8b51949e25d12ce07331d6c37308578a1229d037629f634fa45bb90"
+      }
+    ],
+    "want_balances": [
+      {
+        "id": 10,
+        "weight": 120
+      },
+      {
+        "id": 11,
+        "weight": 100
+      },
+      {
+        "id": 12,
+        "weight": 50
+      },
+      {
+        "id": 13,
+        "weight": 7
+      }
+    ],
+    "want_total": 277,
+    "want_len": 4,
+    "final_digest_hex": "77376432d8b51949e25d12ce07331d6c37308578a1229d037629f634fa45bb90"
+  }
+]


### PR DESCRIPTION
Prototype-only, same fencing as #1057 (libmrr Phase-0 + Drop-1). No production call sites; diff confined to `prototypes/libmrr`. This banks the tested Drop-2 commit that currently sits on `v37-dev` (`86c46bba`) onto master — a scoped cherry-pick of the single Drop-2 delta, not a `v37-dev` roll-up.

## What this adds
- `mrr/compaction.go` — `Ledger`: the deterministic fold from the Roundabout buffer's position-indexed live work into a position-free, per-identity accrued balance (`Fold` / `Compact` / `Merge`). Self-carry means an identity's sub-threshold work persists past window expiry as one durable owed total instead of being forfeited (small-miner-equity §6 — the V36 forfeiture this removes).
- `cmd/genkat3` — the KAT-3 golden generator; asserts every hand-derived per-step total/count/digest and the commutativity invariant before it will mint a vector.
- `mrr/testdata/kat3_compaction_vectors.json` — deterministic KAT-3 goldens, two scenarios (`small_miner_consolidation`, `carry_forward_many_ids`).
- `mrr/compaction_test.go` — commutativity/associativity property tests (`TestLedger_CompactDigestCommute`: rotation, reverse, weight-sorted order, and split-compact-then-merge all hash identically) plus `TestLedger_SelfCarryOutlivesBufferExpiry`, which cross-links Drop 1 (same stream: buffer live-sum drops on eviction while the ledger total is unchanged).

## Golden tests / acceptance
- MRR buffer goldens: KAT-2 `kat2_buffer_vectors.json` (already in master via #1057).
- Self-carry compaction goldens: KAT-3 `kat3_compaction_vectors.json`, verified byte-identical on regenerate (`go run ./cmd/genkat3`).
- `go test ./...` green, `go vet ./...` clean on the Drop-2 tree.

## Round-4/5 fixes — IN vs deferred (acceptance §2)
Drop 2 is the accounting SUBSTRATE only. It carries an explicit hard scope fence against any finality gating, block-found overlay, or owed→settled/reverted transition (see the scope-fence comment atop `compaction.go`). Accordingly:

- **IN this drop:** none of the round-4/5 settlement-side fixes. What Drop 2 does uphold is the self-carry, commutative-and-associative accrual invariant (order- and batch-independent `Digest`) — the pre-finality precondition those fixes build on.
- **Deferred to v37-m3-spec (and Drop 3, the finality-gated overlay):**
  - symmetric finality-gate on the payout side
  - F-A full-output-set constraint + `MANDATED_OUTPUTS`
  - remainder pot
  - soft-fork activation offset
  - per-chain `f_consensus` (aux-fee denomination)

  All five are settlement / overlay / coinbase-output concerns with no representation in the compaction ledger; they land with Drop 3 and the m3 spec-consolidation pass.

## Fencing
No production wiring; no consensus-value change to shipped code. `v37-dev` stays off master. Merge-tap is the operator/integrator — not self-merged.
