### PR TITLE
bch(hstats-944): create graph_db parent dir so stat-log actually persists across restart

### DIFF
--- a/src/impl/bch/pool_entrypoint.hpp
+++ b/src/impl/bch/pool_entrypoint.hpp
@@ -700,6 +700,14 @@ inline void standup_pool_run(boost::asio::io_context& ioc,
             std::string net_label = is_testnet ? "testnet" : "mainnet";
             std::string graph_db_path = (core::filesystem::config_path()
                 / net_label / "bch" / "graph_db").string();
+            // #1040 gap (STATS.944 restart proof, 2026-08-03): the graph_db parent
+            // dir (config_path()/<net>/bch/) was never created, so save_stat_log's
+            // tmp-write + rename failed every 100s and NO stats survived restart.
+            // Mirror the main_btc.cpp:358 / main_dgb.cpp:196 create_directories(net_dir)
+            // best-effort pattern, targeting the actual stat-log parent.
+            std::error_code graph_db_mkdir_ec;
+            std::filesystem::create_directories(
+                std::filesystem::path(graph_db_path).parent_path(), graph_db_mkdir_ec);
             mi->set_stat_log_path(graph_db_path);
             mi->load_stat_log();
             LOG_INFO << "[BCH-POOL] graph_db stats persistence -> " << graph_db_path;


### PR DESCRIPTION
## STATS.944 BCH restart proof — persist leg was a silent no-op

**Milestone:** BCH side of the STATS.944 3-lane gap (parity with BTC #1049 / DGB #1051), integrator task 2026-08-03.

### Finding (caught by the restart proof, not the build)
The graph_db wiring landed by #1040 is present — `set_stat_log_path` + `load_stat_log` at `src/impl/bch/pool_entrypoint.hpp:703-704`, periodic `save_stat_log` at `:717` — but it **never created the parent directory** `config_path()/<net>/bch/`. `save_stat_log` writes `<path>.new` then renames; with the parent absent the `ofstream` silently failed and the rename threw every 100s:

```
[StatLog] Save failed: cannot rename ...testnet/bch/graph_db.new -> .../graph_db: No such file or directory
```

So **no stats survived a restart** despite a green build. BCH's LevelDB uses a different net string (`bitcoincash_testnet`), so nothing else created `<net>/bch/`.

### Fix
Mirror the `main_btc.cpp:358` / `main_dgb.cpp:196` `create_directories(net_dir)` best-effort pattern, targeted at the actual stat-log parent. One header, `src/impl/bch/pool_entrypoint.hpp`, zero core.

### Restart proof (regtest, `--pool --http`)
- **Run 1:** recorded `memory_usage` **9,834,496** / **9,838,592** B at t=1785779345 / 1785779405 then logged `[StatLog] Saved 2 entries` (535 B on disk).
- **Restart** at epoch 1785779440 — both datapoints predate it.
- **Run 2:** `[StatLog] Loaded 2 entries`; `/web/graph_data/memory_usage/last_day` returns the **identical** pre-restart datapoints.

### Cross-lane FYI
BTC #1049 and DGB #1051 use the same `config_path()/<net>/<coin>/graph_db` path whose parent differs from the `net_dir` they `create_directories`, so they carry the identical missing-mkdir. A core-side `create_directories` in `MiningInterface::save_stat_log` would fix all lanes at once (3-bucket: shared infra) — flagged to integrator/decisions.

Signed (GPG 285EFE76). Do not merge — integrator merges on operator tap.
