### PR TITLE
dash(llmq): port DIP-0024 quarter rotation and serve rotated quorum member sets

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -3139,10 +3139,13 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             // per-MN SML nVersion populating MemberOperatorKey::legacy_scheme
             // — a mixed quorum needs the scheme flag; Evo-only for the
             // platform type, #814 R4), and caches it. The provider is a pure
-            // cache lookup (never blocks the template path). NON-ROTATED types
-            // only (llmq_50_60 etc.); rotated (DIP-24) returns nullopt ->
-            // null-serve (qrinfo-based rotated sourcing is a documented
-            // follow-up). Anything uncertain -> nullopt -> fail-closed.
+            // cache lookup (never blocks the template path). ROTATED (DIP-24,
+            // llmq_60_75) types source instead via ONE getqrinfo per CYCLE:
+            // the reply carries the four cycle work-block lists + the three
+            // quarter-rotation snapshots, is DIP-4 authenticated per cycle
+            // diff, and yields all signingActiveQuorumCount member sets in one
+            // go (each keyed by its own quorumHash = cycleBase + quorumIndex).
+            // Anything uncertain -> nullopt -> fail-closed.
             auto qc_member_source =
                 std::make_shared<dash::coin::QuorumMemberSource>(
                     qc_net,
@@ -3167,6 +3170,25 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     [cp = coin_p2p.get()](const uint256& base, const uint256& tgt) {
                         if (cp) cp->send_getmnlistd(base, tgt);
                     });
+
+            // DIP-24 rotated lane: the getqrinfo send seam + the qrinfo reply
+            // consumer. Both are OPTIONAL by construction — with neither wired
+            // the rotated branch of request() simply cannot send and every
+            // rotated quorum stays null-serve, which is the pre-item-4 posture.
+            if (coin_p2p) {
+                qc_member_source->set_send_getqrinfo(
+                    [cp = coin_p2p.get()](const std::vector<uint256>& bases,
+                                          const uint256& req, bool extra) {
+                        if (cp) cp->send_getqrinfo(bases, req, extra);
+                    });
+                // Unlike mnlistdiff there is no tip-feed hazard here: nothing
+                // else consumes qrinfo, so this consumer needs no demux.
+                coin_p2p->add_qrinfo_consumer(
+                    [qc_member_source]
+                    (const dash::coin::vendor::CQuorumRotationInfo& info) {
+                        qc_member_source->on_qrinfo(info);
+                    });
+            }
 
             dash::coin::vendor::MemberKeysProvider qc_member_keys =
                 [qc_member_source](uint8_t llmq_type, const uint256& quorum_hash)

--- a/src/impl/dash/coin/quorum_member_source.hpp
+++ b/src/impl/dash/coin/quorum_member_source.hpp
@@ -58,19 +58,34 @@
 /// replies here and skips the tip feed. Only STRICT matches consume: the diff
 /// must be a full snapshot (baseBlockHash null) at an awaited block hash.
 ///
-/// ROTATED (DIP-24): request() still no-ops for a rotated type and the
-/// verifier stays fail-closed, because the quarter-rotation member COMPUTATION
-/// is not ported yet. What DOES exist now is the sourcing half: request_rotated()
-/// emits a getqrinfo and on_qrinfo() DIP-4 authenticates all four cycle
-/// mnlistdiffs (each bound to the height the cycle geometry demands) and hands
-/// back the authenticated SMLs + snapshots. Wiring those into m_ready is the
-/// remaining follow-up — see the item 3/4 note on the rotated branch of
-/// request().
+/// ROTATED (DIP-24) — NOW SERVED, one qrinfo per CYCLE fills 32 slots:
+/// request() derives the cycle base from the quorum's own base height
+/// (quorumIndex = baseHeight % dkgInterval, cycleBase = baseHeight -
+/// quorumIndex — dashcore utils.cpp GetAllQuorumMembers), emits ONE getqrinfo
+/// for that cycle base, and on_qrinfo() DIP-4 authenticates all four cycle
+/// mnlistdiffs (each bound to the height the cycle geometry demands), runs
+/// vendor::compute_quorum_members_by_quarter_rotation, and inserts ALL 32
+/// resulting member sets into the SAME m_ready map the non-rotated path uses.
+///
+/// WHY (type, quorumHash) STAYS THE KEY: every one of the 32 rotated quorums
+/// in a cycle has its OWN quorumHash — the block at cycleBase + quorumIndex
+/// (DIP-0024; dashcore stores them as {cycleBaseHash, quorumIndex} internally
+/// but the COMMITMENT carries the per-index base block hash). So no key,
+/// provider signature or commitment-cache change was needed: one authenticated
+/// reply simply populates 32 distinct keys at once.
+///
+/// DELIBERATE REVERSAL (was: "issue no getqrinfo"): the previous slice left
+/// request() silent for rotated types on the reasoning that a live request
+/// whose reply could not yet produce a member set is traffic on a money path
+/// for no gain. Now that the reply DOES produce the member set, that reasoning
+/// inverts and the branch emits. The request is still bounded exactly like the
+/// non-rotated one (one outstanding per cycle base, deduped, FIFO-reaped) and
+/// is only made for a cycle whose geometry validates locally first.
 ///
 /// FAIL-CLOSED throughout: pre-V20 work block, base not dkgInterval-aligned,
-/// header gap, rotated type, snapshot authentication failure, member
-/// computation ambiguous -> the quorum simply never becomes ready and the
-/// verifier serves null.
+/// header gap, unknown type, snapshot authentication failure, member
+/// computation ambiguous (score tie / short quarter / zero operator key)
+/// -> the quorum simply never becomes ready and the verifier serves null.
 ///
 /// Threading: all entry points run on the single coin ioc thread (same
 /// assumption as QuorumManager) — no internal locking.
@@ -79,6 +94,7 @@
 #include <impl/dash/coin/dkg_commitments.hpp>          // LlmqNetwork, enabled_llmqs
 #include <impl/dash/coin/utxo_adapter.hpp>             // dash_txid
 #include <impl/dash/coin/vendor/quorum_members.hpp>    // compute_quorum_members
+#include <impl/dash/coin/vendor/quorum_members_rotated.hpp>  // DIP-24 quarter rotation
 #include <impl/dash/coin/vendor/smldiff.hpp>           // CSimplifiedMNListDiff, apply_diff, ExtractMatches
 #include <impl/dash/coin/vendor/cbtx.hpp>              // CCbTx, parse_cbtx
 #include <impl/dash/coin/vendor/simplifiedmns.hpp>     // CSimplifiedMNList
@@ -142,54 +158,27 @@ public:
         const LlmqParamsView* p = params_for(llmq_type);
         if (p == nullptr) return;                       // unknown type => fail closed
         if (p->use_rotation) {
-            // ── ROTATED (DIP-24, e.g. llmq_60_75) SOURCING SEAM ─────────────
-            // The non-rotated path above sources ONE full snapshot at the work
-            // block (base-8) and runs ComputeQuorumMembers. A rotated quorum's
-            // member set is NOT derivable from a single snapshot: dashcore
-            // ComputeQuorumMembersByQuarterRotation (llmq/utils.cpp) assembles
-            // it from the QUARTER-ROTATION snapshots + cycle-base mnlistdiffs
-            // that only the qrinfo message carries. That wire + decode +
-            // quarter-rotation port is the ITEM 2 follow-up; UNTIL it lands the
-            // rotated path FAILS CLOSED here (no ready set is produced), so the
-            // #816 completeness gate leaves the mixed-quorum DKG window
-            // unserveable and get_work routes to the reward-safe dashd fallback.
+            // ── ROTATED (DIP-24, e.g. llmq_60_75) ───────────────────────────
+            // A rotated quorum's member set is NOT derivable from a single
+            // work-block snapshot: dashcore ComputeQuorumMembersByQuarterRotation
+            // (llmq/utils.cpp) assembles it from the three QUARTER-ROTATION
+            // snapshots plus the four cycle work-block lists, which only the
+            // qrinfo message carries. Sourcing is therefore per CYCLE, not per
+            // quorum — and ONE reply yields all signingActiveQuorumCount sets.
             //
-            // STATUS — items 1 and 2 have LANDED; 3 and 4 have not:
-            //   1. DONE — getqrinfo/qrinfo wire: p2p_messages.hpp
-            //      message_getqrinfo / message_qrinfo, send seam
-            //      CoinClient::send_getqrinfo (analogous to send_getmnlistd).
-            //   2. DONE — CQuorumRotationInfo decode
-            //      (vendor/quorum_rotation_info.hpp), field order PINNED against
-            //      a real 602'189-byte capture, plus per-mnlistdiff DIP-4
-            //      authentication with the SAME discipline as
-            //      authenticate_snapshot: see request_rotated() / on_qrinfo()
-            //      below. Each cycle diff is bound to its EXPECTED height, so a
-            //      peer cannot substitute another block's genuine snapshot.
-            //   3. TODO — vendor::compute_quorum_members_by_quarter_rotation:
-            //      port of dashcore ComputeQuorumMembersByQuarterRotation +
-            //      BuildNewQuorumQuarterMembers + the snapshot skip-list decode
-            //      (GetQuorumQuarterMembersBySnapshot), producing the ordered
-            //      MemberOperatorKey vector — MUST reproduce the captured order
-            //      in test/data/dash_rotated_quorum_members_kat.hpp.
-            //   4. TODO — feed that set to the SAME m_ready map so lookup() (and
-            //      #812's verify_final_commitment) serves rotated commitments
-            //      real.
-            //
-            // Until 3 lands there is NOTHING to put in m_ready, so THIS entry
-            // point stays fail-closed and, deliberately, does NOT emit a
-            // getqrinfo: issuing a live request whose reply cannot yet produce
-            // a member set would add traffic to the reward path for no gain.
-            // The sourcing half is reachable and tested via request_rotated()
-            // + on_qrinfo(); item 3 flips this branch to call request_rotated()
-            // and finalize_rotated() to fill m_ready. That is the whole delta.
-            // Fail-closed if qrinfo can't be sourced or any cycle mnlistdiff
-            // fails DIP-4 authentication (same discipline as the non-rotated
-            // authenticate_snapshot).
-            LOG_DEBUG_COIND << "[QC-MEMBERS] rotated type="
-                            << static_cast<int>(llmq_type) << " quorum="
-                            << quorum_hash.GetHex().substr(0, 16)
-                            << " => fail closed (qrinfo quarter-rotation sourcing "
-                               "not yet wired; reward-safe dashd fallback)";
+            // Derive the cycle base exactly as upstream GetAllQuorumMembers
+            // does: quorumIndex = baseHeight % dkgInterval, and the cycle base
+            // is baseHeight - quorumIndex. Upstream also REFUSES an index at or
+            // beyond signingActiveQuorumCount (`return {}`), so do we.
+            auto rot_base_h = m_height_of_hash(quorum_hash);
+            if (!rot_base_h) return;                    // base header not held
+            if (p->dkg_interval == 0) return;
+            const uint32_t quorum_index = *rot_base_h % p->dkg_interval;
+            if (quorum_index >= p->signing_active_quorum_count) return;
+            const uint32_t cycle_h = *rot_base_h - quorum_index;
+            auto cycle_hash = m_hash_at_height(cycle_h);
+            if (!cycle_hash || cycle_hash->IsNull()) return;   // header gap
+            request_rotated(llmq_type, *cycle_hash);
             return;
         }
 
@@ -243,11 +232,11 @@ public:
         return m_await.count(block_hash) != 0;
     }
 
-    // ═══ DIP-24 ROTATED SOURCING (items 1+2) ═══════════════════════════════
-    // Wire + authenticated decode. The member-set computation itself (item 3,
-    // compute_quorum_members_by_quarter_rotation) is NOT here yet, so nothing
-    // reaches m_ready down this path and lookup() still fails closed for
-    // rotated types. Everything below is exercised by the real-vector KAT.
+    // ═══ DIP-24 ROTATED SOURCING + SERVING ═════════════════════════════════
+    // Wire + authenticated decode + the quarter-rotation member computation.
+    // on_qrinfo() ends by inserting all signingActiveQuorumCount member sets
+    // into m_ready, so lookup() serves rotated commitments for real.
+    // Everything below is exercised by the real-vector KAT.
 
     using SendGetQrInfo = std::function<void(const std::vector<uint256>& bases,
                                             const uint256& request_hash,
@@ -265,6 +254,11 @@ public:
         // heights: H = base-8, then -C, -2C, -3C
         std::array<uint32_t, 4>                      heights{};
         std::array<vendor::CSimplifiedMNList, 4>     smls{};
+        // GetHashModifier for each of the four CYCLE BASES (not the work
+        // blocks): post-V20 that is SHA256d(type, workHeight, bestCLSignature)
+        // taken from each cycle work block's OWN cbTx, with the
+        // SHA256d(type, workBlockHash) fallback when that CL is null.
+        std::array<uint256, 4>                       modifiers{};
         std::array<vendor::CQuorumSnapshot, 3>       snapshots{};  // H-C, H-2C, H-3C
         std::vector<vendor::CFinalCommitment>        last_commitment_per_index;
     };
@@ -275,6 +269,8 @@ public:
     /// EMPTY baseBlockHashes on purpose: it makes the peer answer with FULL
     /// (from-genesis) lists, and only a full list is self-authenticating
     /// against its own cbTx.merkleRootMNList.
+    /// `quorum_hash` is the CYCLE BASE block hash (dkgInterval-aligned) — the
+    /// per-index entry point is request(), which derives it.
     bool request_rotated(uint8_t llmq_type, const uint256& quorum_hash)
     {
         const LlmqParamsView* p = params_for(llmq_type);
@@ -290,7 +286,18 @@ public:
         if (*base_h < span) return false;
         if (*base_h - kWorkDiffDepth < quorum_members_v20_floor()) return false;
 
-        m_rotated_pending[Key{llmq_type, quorum_hash}] = *base_h;
+        const Key ckey{llmq_type, quorum_hash};
+        // ONE outstanding getqrinfo per cycle base: the 32 slots of a cycle all
+        // resolve to this same request, and a duplicate would draw a second
+        // 600 kB reply that no await matches (the R1 hazard, per-cycle form).
+        if (m_rotated_pending.count(ckey)) return true;
+        // The cycle's index-0 quorum hash IS the cycle base hash, so a ready
+        // cycle needs no re-request.
+        if (m_ready.count(ckey)) return true;
+        reap_rotated_if_needed();
+
+        m_rotated_pending[ckey] = *base_h;
+        m_rotated_fifo.push_back(ckey);
         m_send_qrinfo(std::vector<uint256>{}, quorum_hash, /*extra_share=*/false);
         LOG_INFO << "[QC-MEMBERS] sourcing qrinfo for ROTATED type="
                  << static_cast<int>(llmq_type) << " quorum="
@@ -337,7 +344,7 @@ public:
 
         const LlmqParamsView* p = params_for(key.llmqType);
         if (p == nullptr || !p->use_rotation || p->dkg_interval == 0) {
-            m_rotated_pending.erase(key);
+            erase_rotated_pending(key);
             return std::nullopt;
         }
         const uint32_t C = p->dkg_interval;
@@ -374,7 +381,7 @@ public:
                 LOG_WARNING << "[QC-MEMBERS] qrinfo cycle diff " << i
                             << " deletes " << diffs[i]->deletedMNs.size()
                             << " entries — not a FULL list, fail closed";
-                m_rotated_pending.erase(key);
+                erase_rotated_pending(key);
                 return std::nullopt;
             }
             vendor::CCbTx cbtx;
@@ -384,10 +391,23 @@ public:
                 LOG_WARNING << "[QC-MEMBERS] qrinfo cycle diff " << i
                             << " failed DIP-4 authentication at expected h="
                             << expect_h << " — whole reply fails closed";
-                m_rotated_pending.erase(key);
+                erase_rotated_pending(key);
                 return std::nullopt;
             }
             out.smls[i] = std::move(*sml);
+
+            // GetHashModifier for cycle base (base - i*C): post-V20 it hashes
+            // the WORK block's height + its OWN cbTx bestCLSignature (R5 — no
+            // walk-back), else falls back to (type, workBlockHash). The
+            // work-block hash is the diff's own blockHash, which leg (b) of the
+            // authentication above has just tied to a PoW-verified header.
+            std::optional<std::array<uint8_t, vendor::CFinalCommitment::BLS_SIG_SIZE>> clsig;
+            if (cbtx.nVersion >= vendor::CCbTx::VERSION_CLSIG_AND_BALANCE
+                && cbtx.has_best_cl_signature()) {
+                clsig = cbtx.bestCLSignature;
+            }
+            out.modifiers[i] = vendor::compute_quorum_modifier(
+                key.llmqType, expect_h, clsig, diffs[i]->blockHash);
         }
 
         out.snapshots[0] = info.quorumSnapshotAtHMinusC;
@@ -395,15 +415,75 @@ public:
         out.snapshots[2] = info.quorumSnapshotAtHMinus3C;
         out.last_commitment_per_index = info.lastCommitmentPerIndex;
 
-        m_rotated_pending.erase(key);
+        erase_rotated_pending(key);
         LOG_INFO << "[QC-MEMBERS] qrinfo AUTHENTICATED for rotated type="
-                 << static_cast<int>(key.llmqType) << " quorum="
+                 << static_cast<int>(key.llmqType) << " cycle_base="
                  << key.quorumHash.GetHex().substr(0, 16)
                  << " cycle_base_h=" << base_h
-                 << " (H=" << out.heights[0] << ") — inputs ready; member "
-                    "computation (quarter rotation) NOT YET PORTED, so this "
-                    "quorum remains null-serve";
+                 << " (H=" << out.heights[0] << ")";
+
+        // ITEM 4: the authenticated inputs go straight into the SAME m_ready
+        // map the non-rotated path fills, so lookup() serves these quorums.
+        finalize_rotated(out);
         return out;
+    }
+
+    /// Run the quarter rotation over already-authenticated inputs and publish
+    /// every resulting member set. Separated from on_qrinfo() so the compute
+    /// can be gated in isolation. Returns the number of slots published.
+    size_t finalize_rotated(const RotatedInputs& in)
+    {
+        const LlmqParamsView* p = params_for(in.llmq_type);
+        if (p == nullptr || !p->use_rotation) return 0;
+
+        vendor::RotatedQuorumParams rp{p->type, p->size,
+                                       p->signing_active_quorum_count};
+        std::array<vendor::RotatedCycleInput, 4> cycles{};
+        for (size_t i = 0; i < 4; ++i) {
+            cycles[i].sml      = &in.smls[i];
+            cycles[i].modifier = in.modifiers[i];
+        }
+        const std::array<const vendor::CQuorumSnapshot*, 3> snaps{
+            &in.snapshots[0], &in.snapshots[1], &in.snapshots[2]};
+
+        auto sets = vendor::compute_quorum_members_by_quarter_rotation(
+            rp, cycles, snaps);
+        if (!sets) {
+            LOG_WARNING << "[QC-MEMBERS] rotated member computation AMBIGUOUS "
+                           "for cycle_base_h=" << in.cycle_base_height
+                        << " type=" << static_cast<int>(in.llmq_type)
+                        << " -> fail closed (null-serve for the whole cycle)";
+            return 0;
+        }
+
+        // Each of the 32 quorums in the cycle carries its OWN quorumHash: the
+        // block at cycleBase + quorumIndex (DIP-0024). A slot whose header we
+        // do not hold yet is simply skipped — it will be re-requested and the
+        // ride-the-outstanding dedup will not fire once the cycle is ready,
+        // because index 0's key IS the cycle key.
+        size_t published = 0;
+        for (size_t qi = 0; qi < sets->size(); ++qi) {
+            auto qh = m_hash_at_height(in.cycle_base_height
+                                       + static_cast<uint32_t>(qi));
+            if (!qh || qh->IsNull()) continue;
+            insert_ready(Key{in.llmq_type, *qh}, std::move((*sets)[qi]));
+            ++published;
+        }
+        if (published == 0) {
+            LOG_WARNING << "[QC-MEMBERS] rotated cycle_base_h="
+                        << in.cycle_base_height << " type="
+                        << static_cast<int>(in.llmq_type)
+                        << " computed " << sets->size() << " member sets but NO "
+                           "slot base-block header is held -> nothing published, "
+                           "cycle stays null-serve";
+        } else {
+            LOG_INFO << "[QC-MEMBERS] ROTATED READY type="
+                     << static_cast<int>(in.llmq_type) << " cycle_base_h="
+                     << in.cycle_base_height << " slots=" << published << "/"
+                     << sets->size() << " members=" << p->size
+                     << " (real-commitment serving ENABLED for this cycle)";
+        }
+        return published;
     }
 
     size_t rotated_pending_count() const { return m_rotated_pending.size(); }
@@ -552,6 +632,27 @@ private:
         }
     }
 
+    void erase_rotated_pending(const Key& key)
+    {
+        m_rotated_pending.erase(key);
+        for (auto it = m_rotated_fifo.begin(); it != m_rotated_fifo.end(); ++it) {
+            if (*it == key) { m_rotated_fifo.erase(it); break; }
+        }
+    }
+
+    // Same bound + rationale as reap_if_needed(), for the qrinfo lane. A
+    // rotated cycle is 32 slots wide, so far fewer outstanding requests are
+    // ever legitimate; an evicted cycle simply stays null-serve.
+    static constexpr size_t kRotatedPendingCap = 8;
+    void reap_rotated_if_needed()
+    {
+        while (m_rotated_pending.size() >= kRotatedPendingCap
+               && !m_rotated_fifo.empty()) {
+            m_rotated_pending.erase(m_rotated_fifo.front());
+            m_rotated_fifo.pop_front();
+        }
+    }
+
     void erase_pending(const Key& key)
     {
         m_pending.erase(key);
@@ -608,7 +709,8 @@ private:
     std::map<uint256, std::vector<Key>> m_await;   // work-block hash -> waiters
 
     SendGetQrInfo             m_send_qrinfo;
-    std::map<Key, uint32_t>   m_rotated_pending;   // rotated key -> cycle base h
+    std::map<Key, uint32_t>   m_rotated_pending;   // cycle-base key -> cycle base h
+    std::deque<Key>           m_rotated_fifo;
 };
 
 } // namespace coin

--- a/src/impl/dash/coin/vendor/quorum_members.hpp
+++ b/src/impl/dash/coin/vendor/quorum_members.hpp
@@ -57,11 +57,12 @@
 ///     legacy_scheme = (nVersion == VER_LEGACY_BLS) — the #812 finding: the SML
 ///     nVersion is the ONLY unambiguous scheme signal for a mixed quorum.
 ///
-/// ROTATED (DIP-24, llmq_60_75): ComputeQuorumMembersByQuarterRotation over
-/// the cycle snapshots (qrinfo) is NOT implemented here — compute_quorum_members
-/// returns std::nullopt for a rotated type, so the verifier FAILS CLOSED and
-/// the rotated-window slot mines the consensus-valid null commitment (reward-
-/// safe). Documented follow-up.
+/// ROTATED (DIP-24, llmq_60_75) LIVES NEXT DOOR: a rotated member set cannot be
+/// selected from ONE snapshot, so compute_quorum_members below returns
+/// std::nullopt for a rotated type — deliberately, and permanently. The
+/// quarter-rotation computation over the qrinfo cycle snapshots is
+/// vendor::compute_quorum_members_by_quarter_rotation in
+/// quorum_members_rotated.hpp; QuorumMemberSource routes rotated types there.
 ///
 /// FAIL-CLOSED throughout: pre-V20 height, rotated type, empty/short SML, a
 /// selected MN with a zero operator key, fewer confirmed+valid MNs than the
@@ -201,7 +202,9 @@ inline std::optional<std::vector<MemberOperatorKey>> compute_quorum_members(
     const QuorumMemberParams& params, const uint256& modifier,
     const CSimplifiedMNList& sml)
 {
-    if (params.use_rotation) return std::nullopt;   // DIP-24: qrinfo follow-up
+    // DIP-24: rotated selection is quarter rotation over a qrinfo, never a
+    // single snapshot — see quorum_members_rotated.hpp.
+    if (params.use_rotation) return std::nullopt;
     if (params.size == 0) return std::nullopt;
 
     struct Scored {

--- a/src/impl/dash/coin/vendor/quorum_members_rotated.hpp
+++ b/src/impl/dash/coin/vendor/quorum_members_rotated.hpp
@@ -1,0 +1,462 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// E1 Phase-L, item 3 — DIP-0024 ROTATED (quarter-rotation) quorum member-set
+/// computation: the piece quorum_member_source.hpp's rotated branch was
+/// fail-closed for.
+///
+/// This is a PORT, not a design. Source of truth is dashcore v23.1.7
+/// src/llmq/utils.cpp (anonymous namespace):
+///
+///   * ComputeQuorumMembersByQuarterRotation  — assembles nQuorums (=
+///     signingActiveQuorumCount, 32 for llmq_60_75) member vectors, each
+///     `llmqParams.size` (60) long, from FOUR quarters:
+///         [H-3C quarter][H-2C quarter][H-C quarter][NEW quarter]
+///     in exactly that order. The upstream loop iterates the previous cycles
+///     REVERSED (`prev_cycles | std::views::reverse`), which is why the OLDEST
+///     quarter comes first. MEMBER INDEX IS CONSENSUS: it selects the
+///     signers/validMembers bitset slot, so this order is not cosmetic.
+///   * GetQuorumQuarterMembersBySnapshot — recovers the three PREVIOUS quarters
+///     from the CQuorumSnapshot each cycle committed (active-member bitset +
+///     skip-list), replayed against that cycle's own score-sorted MN list.
+///   * BuildNewQuorumQuarterMembers — derives the NEW quarter at the cycle base
+///     from the H list minus everything the previous quarters already used.
+///
+/// DAEMONLESS INPUTS — ALL FOUR AVAILABLE FROM ONE qrinfo
+/// -----------------------------------------------------
+/// Upstream reads `dmnman.GetListForBlock(cycleBase - WORK_DIFF_DEPTH)` for
+/// each of the four cycles and `qsnapman.GetSnapshotForBlock(cycleBase)` for
+/// the three previous ones. A single qrinfo carries exactly that set:
+/// mnListDiff{H,AtHMinusC,AtHMinus2C,AtHMinus3C} are the lists at
+/// cycleBase_i - 8 (llmq/snapshot.cpp ConstructCycle: m_work_index =
+/// m_cycle_index - WORK_DIFF_DEPTH), and quorumSnapshotAtHMinus{C,2C,3C} are
+/// the three snapshots. quorum_member_source.hpp already DIP-4 authenticates
+/// every one of those diffs against its expected height before they get here,
+/// so nothing in this header trusts a peer for anything other than the
+/// snapshot bitsets — and a wrong bitset cannot forge a member set, it can
+/// only produce one whose commitment then fails the BLS aggregate.
+///
+/// The per-cycle MODIFIER is likewise sourced from the qrinfo: upstream's
+/// GetHashModifier(llmqParams, cycleBase) is post-V20
+/// SerializeHash((type, workHeight, bestCLSignature)) with the CL taken from
+/// the WORK block's own cbTx — and each cycle diff carries that exact cbTx.
+/// The caller computes it with vendor::compute_quorum_modifier (shared with
+/// the non-rotated path) and passes it in, so this header stays pure.
+///
+/// FAIL-CLOSED, and STRICTER THAN UPSTREAM IN EXACTLY ONE PLACE
+/// ------------------------------------------------------------
+/// Upstream breaks a score TIE by collateralOutpoint. The SML does not carry
+/// the collateral outpoint, so a tie ANYWHERE in a sorted list could reorder
+/// members we cannot resolve — and here, unlike the non-rotated path, the full
+/// sorted list matters (the snapshot bitset indexes it), not just its head.
+/// So ANY adjacent equal score in ANY sorted list -> std::nullopt. That needs
+/// a SHA256 collision to trigger; it is a correctness fence, not a live risk.
+///
+/// Also nullopt: a snapshot bitset shorter than the list it indexes, a cycle
+/// input missing, an assembled quorum that is not exactly `size` members, a
+/// selected member with an all-zero operator key, or either fill loop failing
+/// to terminate within its bound (upstream's loops can spin on pathological
+/// input; we refuse instead of hanging the template thread).
+///
+/// OPERATOR KEY PROVENANCE — a real subtlety, ported faithfully
+/// ------------------------------------------------------------
+/// A member selected into the H-3C quarter is, upstream, the CDeterministicMN
+/// object AS OF the H-3C cycle's work block, and CFinalCommitment::Verify uses
+/// `members[i]->pdmnState->pubKeyOperator` — i.e. THAT cycle's key, not the
+/// key the same masternode holds at H. So each quarter's members carry their
+/// OWN cycle SML entry's pubKeyOperator and nVersion (BLS scheme flag). If a
+/// masternode rotated its operator key mid-cycle, dashd verifies with the old
+/// one; we reproduce that rather than "fixing" it.
+///
+/// DEVIATION NOTE (dedup): upstream's CDeterministicMNList::AddMN also enforces
+/// uniqueness of service / owner key / operator key and throws (silently
+/// caught) on a conflict. The SML cannot express collateral outpoints or owner
+/// keys, so dedup here is by proRegTxHash only. A duplicate service or operator
+/// key across two distinct proRegTxHashes is rejected by ProTx consensus, so
+/// the two agree on any list a node will accept.
+
+#include <impl/dash/coin/vendor/quorum_members.hpp>         // MemberOperatorKey, detail::mn_score/score_lt
+#include <impl/dash/coin/vendor/quorum_rotation_info.hpp>   // CQuorumSnapshot
+#include <impl/dash/coin/vendor/simplifiedmns.hpp>          // CSimplifiedMNList[Entry]
+
+#include <core/uint256.hpp>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <set>
+#include <vector>
+
+namespace dash {
+namespace coin {
+namespace vendor {
+
+/// One cycle's inputs: the SML AS OF (cycleBase - WORK_DIFF_DEPTH) and the
+/// modifier GetHashModifier() yields for that cycle base.
+struct RotatedCycleInput {
+    const CSimplifiedMNList* sml{nullptr};
+    uint256                  modifier;
+};
+
+/// The subset of LLMQParams the rotation needs.
+struct RotatedQuorumParams {
+    uint8_t  type{0};
+    uint16_t size{0};                          // llmqParams.size (60)
+    uint16_t signing_active_quorum_count{0};   // nQuorums (32)
+};
+
+namespace detail {
+
+using MnRef = const CSimplifiedMNListEntry*;
+
+/// Upstream memcmp ordering on proRegTxHash (the SML's own sort order) — used
+/// only for the dedup sets, never for member order.
+struct ProRegLess {
+    bool operator()(const uint256& a, const uint256& b) const
+    {
+        return std::memcmp(a.data(), b.data(), 32) < 0;
+    }
+};
+using ProRegSet = std::set<uint256, ProRegLess>;
+
+/// CalculateScoresForQuorum's eligibility filter: PoSe-banned out
+/// (ForEachMN(onlyValid=true) / IsBanned()), unconfirmed out (the
+/// ProRegTxHash-grinding guard), and — for a platform type — non-Evo out.
+/// The rotation path never sets evo_only (llmq_60_75 is not llmqTypePlatform);
+/// the parameter exists so the filter reads identically to upstream.
+inline bool rot_mn_eligible(const CSimplifiedMNListEntry& e, bool evo_only)
+{
+    if (!e.isValid) return false;
+    if (e.confirmedHash.IsNull()) return false;
+    if (evo_only && e.nType != CSimplifiedMNListEntry::TYPE_EVO) return false;
+    return true;
+}
+
+/// dashcore CalculateQuorum<List> with maxSize == 0: score every eligible
+/// candidate under `modifier` and sort DESCENDING. std::nullopt on a tie (see
+/// the header note — upstream's collateralOutpoint tiebreak is not sourceable
+/// from an SML).
+inline std::optional<std::vector<MnRef>> calculate_quorum_all(
+    const std::vector<MnRef>& candidates, const uint256& modifier,
+    bool evo_only = false)
+{
+    struct Scored {
+        std::array<uint8_t, 32> score;
+        MnRef                   mn;
+    };
+    std::vector<Scored> scored;
+    scored.reserve(candidates.size());
+    for (MnRef e : candidates) {
+        if (e == nullptr) return std::nullopt;
+        if (!rot_mn_eligible(*e, evo_only)) continue;
+        scored.push_back(Scored{mn_score(*e, modifier), e});
+    }
+    std::sort(scored.begin(), scored.end(),
+              [](const Scored& a, const Scored& b) {
+                  return score_lt(b.score, a.score);   // descending
+              });
+    for (size_t i = 0; i + 1 < scored.size(); ++i) {
+        if (scored[i].score == scored[i + 1].score) return std::nullopt;
+    }
+    std::vector<MnRef> out;
+    out.reserve(scored.size());
+    for (const auto& s : scored) out.push_back(s.mn);
+    return out;
+}
+
+inline std::vector<MnRef> all_refs(const CSimplifiedMNList& sml)
+{
+    std::vector<MnRef> v;
+    v.reserve(sml.mnList.size());
+    for (const auto& e : sml.mnList) v.push_back(&e);
+    return v;
+}
+
+inline MnRef find_by_protx(const CSimplifiedMNList& sml, const uint256& protx)
+{
+    for (const auto& e : sml.mnList)
+        if (std::memcmp(e.proRegTxHash.data(), protx.data(), 32) == 0) return &e;
+    return nullptr;
+}
+
+/// dashcore GetQuorumQuarterMembersBySnapshot (llmq/utils.cpp).
+/// `sml`/`modifier` are the cycle's own work-block list and hash modifier.
+/// Returns num_quorums quarters (each <= quarter_size), or nullopt if the
+/// snapshot cannot be replayed deterministically.
+inline std::optional<std::vector<std::vector<MnRef>>>
+get_quorum_quarter_members_by_snapshot(
+    size_t num_quorums, size_t quarter_size,
+    const CSimplifiedMNList& sml, const uint256& modifier,
+    const CQuorumSnapshot& snapshot)
+{
+    std::vector<MnRef> sorted_combined;
+    {
+        auto sorted_all = calculate_quorum_all(all_refs(sml), modifier);
+        if (!sorted_all) return std::nullopt;
+
+        // Upstream indexes snapshot.activeQuorumMembers[i] over the SCORE-
+        // SORTED eligible list (BuildQuorumSnapshot sizes the bitset to the
+        // list TOTAL, which is >= that). A short bitset would be an
+        // out-of-bounds read upstream; here it fails closed.
+        if (snapshot.activeQuorumMembers.size() < sorted_all->size())
+            return std::nullopt;
+
+        std::vector<MnRef> used;
+        used.reserve(sorted_all->size());
+        size_t i = 0;
+        for (MnRef dmn : *sorted_all) {
+            if (snapshot.activeQuorumMembers[i]) {
+                used.push_back(dmn);
+            } else {
+                // Upstream re-checks !IsBanned here; calculate_quorum_all has
+                // already dropped banned entries, so this is a no-op kept for
+                // line-by-line traceability.
+                if (dmn->isValid) sorted_combined.push_back(dmn);
+            }
+            ++i;
+        }
+        // ...and the already-used ones go to the END of the list.
+        sorted_combined.insert(sorted_combined.end(), used.begin(), used.end());
+    }
+
+    std::vector<std::vector<MnRef>> quarters(num_quorums);
+    if (sorted_combined.empty()) return quarters;   // upstream returns empty
+
+    switch (snapshot.mnSkipListMode) {
+    case CQuorumSnapshot::MODE_NO_SKIPPING: {
+        size_t itm = 0;
+        for (size_t i = 0; i < num_quorums; ++i) {
+            while (quarters[i].size() < quarter_size) {
+                quarters[i].push_back(sorted_combined[itm]);
+                if (++itm == sorted_combined.size()) itm = 0;
+            }
+        }
+        return quarters;
+    }
+    case CQuorumSnapshot::MODE_SKIPPING_ENTRIES: {
+        // Skip list is stored RELATIVE TO THE FIRST SKIPPED INDEX (see
+        // BuildNewQuorumQuarterMembers' skipList construction below): the
+        // first entry is absolute, every later entry is first + s. Note the
+        // upstream quirk that `first_entry_index == 0` is the "not yet set"
+        // sentinel, so a genuine first skip at index 0 keeps taking the
+        // first branch. Ported verbatim — it is consensus behaviour.
+        size_t first_entry_index = 0;
+        std::vector<int64_t> processed_skip_list;
+        processed_skip_list.reserve(snapshot.mnSkipList.size());
+        for (int32_t s : snapshot.mnSkipList) {
+            if (first_entry_index == 0) {
+                first_entry_index = static_cast<size_t>(s);
+                processed_skip_list.push_back(s);
+            } else {
+                processed_skip_list.push_back(
+                    static_cast<int64_t>(first_entry_index) + s);
+            }
+        }
+
+        int64_t idx = 0;
+        size_t  itsk = 0;
+        // Termination bound: `itsk` only ever advances, so once it is spent
+        // every iteration pushes. Upstream has no such bound; we refuse
+        // rather than spin on the template thread.
+        const uint64_t max_iters =
+            static_cast<uint64_t>(processed_skip_list.size())
+            + static_cast<uint64_t>(num_quorums) * quarter_size
+            + sorted_combined.size() + 1;
+        uint64_t iters = 0;
+        for (size_t i = 0; i < num_quorums; ++i) {
+            while (quarters[i].size() < quarter_size) {
+                if (++iters > max_iters) return std::nullopt;
+                if (idx < 0 || static_cast<size_t>(idx) >= sorted_combined.size())
+                    return std::nullopt;
+                if (itsk < processed_skip_list.size()
+                    && idx == processed_skip_list[itsk]) {
+                    ++itsk;
+                } else {
+                    quarters[i].push_back(sorted_combined[static_cast<size_t>(idx)]);
+                }
+                ++idx;
+                if (static_cast<size_t>(idx) == sorted_combined.size()) idx = 0;
+            }
+        }
+        return quarters;
+    }
+    case CQuorumSnapshot::MODE_NO_SKIPPING_ENTRIES:
+    case CQuorumSnapshot::MODE_ALL_SKIPPED:
+    default:
+        // Upstream returns the EMPTY quarters for these two modes. The
+        // assembled quorum will then be short of `size` and the caller fails
+        // closed, which is the honest outcome: we cannot serve a member set
+        // dashd would build from data the snapshot did not encode.
+        return quarters;
+    }
+}
+
+/// dashcore BuildNewQuorumQuarterMembers (llmq/utils.cpp) minus the snapshot
+/// STORE (we are a consumer, never a producer, so BuildQuorumSnapshot and the
+/// skipList it emits are deliberately not ported).
+inline std::optional<std::vector<std::vector<MnRef>>>
+build_new_quorum_quarter_members(
+    size_t num_quorums, size_t quarter_size,
+    const CSimplifiedMNList& all_mns, const uint256& modifier,
+    const std::array<std::vector<std::vector<MnRef>>, 3>& previous_quarters)
+{
+    std::vector<std::vector<MnRef>> quarters(num_quorums);
+
+    size_t enabled = 0;
+    for (const auto& e : all_mns.mnList) if (e.isValid) ++enabled;
+    if (enabled < quarter_size) return quarters;   // upstream: empty quarters
+
+    // MnsUsedAtH (union over all quorum indices) + MnsUsedAtHIndexed[i].
+    // Upstream stores the CDeterministicMN object FROM THE PREVIOUS QUARTER,
+    // and AddMN keeps the FIRST insertion — so does this.
+    ProRegSet          used_all;
+    std::vector<MnRef> used_all_refs;
+    std::vector<ProRegSet> used_indexed(num_quorums);
+
+    // Post-V19 (and on testnet unconditionally) upstream drops previous-quarter
+    // members that are no longer in the H list. This module only serves
+    // post-V20, so skipRemovedMNs is ALWAYS true here.
+    for (size_t idx = 0; idx < num_quorums; ++idx) {
+        for (size_t c = 0; c < previous_quarters.size(); ++c) {   // H-C, H-2C, H-3C
+            if (idx >= previous_quarters[c].size()) continue;
+            for (MnRef mn : previous_quarters[c][idx]) {
+                if (mn == nullptr) return std::nullopt;
+                MnRef at_h = find_by_protx(all_mns, mn->proRegTxHash);
+                if (at_h == nullptr) continue;          // !allMns.HasMN
+                if (!at_h->isValid) continue;           // allMns.IsMNPoSeBanned
+                if (used_all.insert(mn->proRegTxHash).second)
+                    used_all_refs.push_back(mn);
+                used_indexed[idx].insert(mn->proRegTxHash);
+            }
+        }
+    }
+
+    // MnsNotUsedAtH: everything in the H list that no quarter used and that is
+    // not PoSe-banned (upstream iterates onlyValid=false then filters IsBanned).
+    std::vector<MnRef> not_used;
+    not_used.reserve(all_mns.mnList.size());
+    for (const auto& e : all_mns.mnList) {
+        if (used_all.count(e.proRegTxHash)) continue;
+        if (!e.isValid) continue;
+        not_used.push_back(&e);
+    }
+
+    auto sorted_used = calculate_quorum_all(used_all_refs, modifier);
+    if (!sorted_used) return std::nullopt;
+    auto sorted_combined = calculate_quorum_all(not_used, modifier);
+    if (!sorted_combined) return std::nullopt;
+    // NOT-USED first, then USED — upstream appends sortedMnsUsedAtHM.
+    sorted_combined->insert(sorted_combined->end(),
+                            sorted_used->begin(), sorted_used->end());
+    if (sorted_combined->empty()) return quarters;
+
+    size_t idx = 0;
+    const uint64_t max_iters =
+        static_cast<uint64_t>(num_quorums + 1) * sorted_combined->size()
+        + static_cast<uint64_t>(num_quorums) * quarter_size + 1;
+    uint64_t iters = 0;
+    for (size_t i = 0; i < num_quorums; ++i) {
+        const size_t used_count = used_indexed[i].size();
+        bool   updated = false;
+        size_t initial_loop_idx = idx;
+        while (quarters[i].size() < quarter_size
+               && (used_count + quarters[i].size() < sorted_combined->size())) {
+            if (++iters > max_iters) return std::nullopt;
+            bool skip = true;
+            MnRef cand = (*sorted_combined)[idx];
+            if (!used_indexed[i].count(cand->proRegTxHash)) {
+                used_indexed[i].insert(cand->proRegTxHash);
+                quarters[i].push_back(cand);
+                updated = true;
+                skip    = false;
+            }
+            (void)skip;   // upstream records a skipList here; producer-only.
+            if (++idx == sorted_combined->size()) idx = 0;
+            if (idx == initial_loop_idx) {
+                // Full pass with nothing added => not enough MNs; upstream
+                // abandons the WHOLE new quarter set.
+                if (!updated) return std::vector<std::vector<MnRef>>(num_quorums);
+                updated = false;
+            }
+        }
+    }
+    return quarters;
+}
+
+} // namespace detail
+
+/// dashcore ComputeQuorumMembersByQuarterRotation. `cycles` is indexed
+/// 0 = H (the cycle base), 1 = H-C, 2 = H-2C, 3 = H-3C; `snapshots` is
+/// indexed 0 = H-C, 1 = H-2C, 2 = H-3C — i.e. the qrinfo field order.
+///
+/// Returns signing_active_quorum_count member vectors, EACH EXACTLY
+/// params.size long and in dashd's consensus order, or std::nullopt.
+inline std::optional<std::vector<std::vector<MemberOperatorKey>>>
+compute_quorum_members_by_quarter_rotation(
+    const RotatedQuorumParams& params,
+    const std::array<RotatedCycleInput, 4>& cycles,
+    const std::array<const CQuorumSnapshot*, 3>& snapshots)
+{
+    const size_t num_quorums = params.signing_active_quorum_count;
+    const size_t quorum_size = params.size;
+    if (num_quorums == 0 || quorum_size == 0) return std::nullopt;
+    // Upstream computes quarterSize = size / 4 and assembles 4 of them; a size
+    // that is not a multiple of 4 could never yield `size` members.
+    if (quorum_size % 4 != 0) return std::nullopt;
+    const size_t quarter_size = quorum_size / 4;
+
+    for (const auto& c : cycles)
+        if (c.sml == nullptr) return std::nullopt;
+    for (const auto* s : snapshots)
+        if (s == nullptr || !s->sane()) return std::nullopt;
+
+    // The three PREVIOUS quarters, each replayed from its own cycle's snapshot.
+    std::array<std::vector<std::vector<detail::MnRef>>, 3> previous;
+    for (size_t i = 0; i < 3; ++i) {
+        auto q = detail::get_quorum_quarter_members_by_snapshot(
+            num_quorums, quarter_size, *cycles[i + 1].sml,
+            cycles[i + 1].modifier, *snapshots[i]);
+        if (!q) return std::nullopt;
+        previous[i] = std::move(*q);
+    }
+
+    auto new_quarter = detail::build_new_quorum_quarter_members(
+        num_quorums, quarter_size, *cycles[0].sml, cycles[0].modifier, previous);
+    if (!new_quarter) return std::nullopt;
+
+    // ORDER: oldest quarter first (upstream iterates the previous cycles
+    // reversed), then the new one.
+    std::vector<std::vector<MemberOperatorKey>> out(num_quorums);
+    for (size_t i = 0; i < num_quorums; ++i) {
+        std::vector<detail::MnRef> members;
+        members.reserve(quorum_size);
+        for (size_t c = previous.size(); c-- > 0;) {          // H-3C, H-2C, H-C
+            members.insert(members.end(), previous[c][i].begin(),
+                           previous[c][i].end());
+        }
+        members.insert(members.end(), (*new_quarter)[i].begin(),
+                       (*new_quarter)[i].end());
+
+        // A short (or over-long) quorum means the snapshots did not encode a
+        // set we can reproduce — never serve a partial member set.
+        if (members.size() != quorum_size) return std::nullopt;
+
+        out[i].reserve(quorum_size);
+        for (detail::MnRef mn : members) {
+            if (detail::is_all_zero(mn->pubKeyOperator)) return std::nullopt;
+            MemberOperatorKey k;
+            k.pubKeyOperator = mn->pubKeyOperator;
+            // The #812 finding: the SML entry's own nVersion is the only
+            // unambiguous legacy/basic scheme signal, and each quarter's
+            // members carry THEIR cycle's entry (see the header note).
+            k.legacy_scheme = (mn->nVersion == CSimplifiedMNListEntry::VER_LEGACY_BLS);
+            out[i].push_back(k);
+        }
+    }
+    return out;
+}
+
+} // namespace vendor
+} // namespace coin
+} // namespace dash

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -691,12 +691,18 @@ if (BUILD_TESTING AND GTest_FOUND)
     # -> a standalone target would be a NOT_BUILT sentinel). Do NOT re-add
     # standalone add_executable/gtest_add_tests for any of them — CTest would
     # register unbuilt executables (ctest "Not Run" exit 8, the Linux x86_64 red).
-    # DASH_FIXTURE_DIR is needed by the from-wire fixture loader (mnlistdiff).
+    # DASH_FIXTURE_DIR is needed by the from-wire fixture loader (mnlistdiff)
+    # and by the qrinfo / rotated-quorum suites, which read the real 602'189-byte
+    # testnet qrinfo capture. test_dash_rotated_quorum_members.cpp is folded here
+    # for the same reason as test_dash_qrinfo.cpp: this target IS in the build.yml
+    # "Build tests" --target allowlist, and a standalone target would be a
+    # NOT_BUILT sentinel (the push bot lacks `workflow` scope, #769).
     add_executable(test_dash_embedded_gbt
         test_dash_embedded_gbt.cpp
         test_dash_embedded_cbtx_byte_parity.cpp
         test_dash_mnlistdiff_root_parity.cpp
         test_dash_qrinfo.cpp
+        test_dash_rotated_quorum_members.cpp
         test_dash_dkg_commitments.cpp
         test_dash_sml_quorum_db.cpp
         test_dash_embedded_oracle_shadow.cpp)

--- a/test/data/dash_rotated_quorum_members_kat.hpp
+++ b/test/data/dash_rotated_quorum_members_kat.hpp
@@ -6,12 +6,15 @@
 // testnet dashd @192.168.86.52 (`quorum info 5 <quorumHash> false`).
 //
 // This is dashd's AUTHORITATIVE ordered member set for a rotated quorum: the
-// exact order + operator BLS keys that ComputeQuorumMembersByQuarterRotation
-// (llmq/utils.cpp) must reproduce before the rotated DKG window can serve
-// real (instead of the reward-safe fail-closed null-serve). The follow-up
-// qrinfo wire + CQuorumSnapshot decode + quarter-rotation port pins against
-// THIS vector (member order + keys) exactly as the non-rotated path pins
-// against dash_quorum_members_kat.hpp.
+// exact order + operator BLS keys ComputeQuorumMembersByQuarterRotation
+// (llmq/utils.cpp) must reproduce before the rotated DKG window can serve real
+// (instead of the reward-safe fail-closed null-serve).
+//
+// THE ORDER GATE THAT PINS AGAINST THIS VECTOR IS
+// test/test_dash_rotated_quorum_members.cpp — index-by-index, exactly as the
+// non-rotated path pins against dash_quorum_members_kat.hpp. Membership-only
+// uses of this vector (test_dash_qrinfo.cpp, test_dash_quorum_member_source.cpp)
+// check a NECESSARY CONDITION only and are labelled as such where they appear.
 // ===========================================================================
 #include <array>
 #include <cstdint>

--- a/test/test_dash_qrinfo.cpp
+++ b/test/test_dash_qrinfo.cpp
@@ -29,14 +29,14 @@
 //
 // WHAT THIS SUITE DOES *NOT* ESTABLISH
 // ------------------------------------
-// The quarter-rotation member COMPUTATION (item 3,
-// ComputeQuorumMembersByQuarterRotation) is NOT ported yet, so this suite
-// makes NO claim about member ORDER and does not exercise
-// test/data/dash_rotated_quorum_members_kat.hpp's ordering. What it does prove
-// about that KAT is the NECESSARY CONDITION: every one of the 60 ground-truth
-// members is present in each authenticated cycle SML with a byte-identical
-// operator key, so the sourced inputs are sufficient and only the ordering
-// algorithm is missing. Do not mistake that for the ordering gate.
+// Member ORDER. This suite gates the WIRE and the AUTHENTICATION only; what it
+// proves about test/data/dash_rotated_quorum_members_kat.hpp is the NECESSARY
+// CONDITION — every one of the 60 ground-truth members is present in each
+// authenticated cycle SML with a byte-identical operator key, so the sourced
+// inputs are sufficient. The ORDERING gate against that KAT lives in
+// test_dash_rotated_quorum_members.cpp (same executable), which pins
+// ComputeQuorumMembersByQuarterRotation index-by-index. Do not mistake the
+// membership check below for the ordering gate.
 //
 // Merkle-proof leg note: leg (b) of authenticate_historical_snapshot (cbTx
 // proven into the PoW-VERIFIED header) is the same shared function the
@@ -517,20 +517,24 @@ TEST(DashQrInfo, OnQrInfoDropsAnUnsolicitedReply)
     EXPECT_FALSE(src.on_qrinfo(h.info).has_value());
 }
 
-// The point of the whole slice: sourcing does NOT make a rotated quorum
-// serveable yet. lookup() must still fail closed.
-TEST(DashQrInfo, RotatedLookupStillFailsClosedAfterSourcing)
+// A cycle whose per-index BASE BLOCK HASHES are not held cannot be published:
+// each rotated quorum is keyed by the hash of the block at cycleBase +
+// quorumIndex, and this Harness deliberately holds no height index at all. The
+// member set is computed, has nowhere to go, and the quorum stays null-serve.
+// The POSITIVE path — a header index present, lookup() serving dashd's exact
+// order — is gated in test_dash_rotated_quorum_members.cpp.
+TEST(DashQrInfo, RotatedCycleWithoutAHeightIndexPublishesNothing)
 {
     Harness h;
     h.load();
-    auto src = h.make();
+    auto src = h.make();   // hash_at_height() returns nullopt for every height
     uint256 qh;
     qh.SetHex(dash::coin::testdata::kRot6075_QuorumHash);
     ASSERT_TRUE(src.request_rotated(dash::coin::testdata::kRot6075_LlmqType, qh));
     ASSERT_TRUE(src.on_qrinfo(h.info).has_value());
 
     EXPECT_FALSE(src.lookup(dash::coin::testdata::kRot6075_LlmqType, qh).has_value())
-        << "item 3 (quarter-rotation compute) is not ported; rotated serving "
-           "MUST remain null-serve";
+        << "no held header for the slot base block => nothing to key on => "
+           "null-serve";
     EXPECT_EQ(src.ready_count(), 0u);
 }

--- a/test/test_dash_quorum_member_source.cpp
+++ b/test/test_dash_quorum_member_source.cpp
@@ -502,15 +502,16 @@ TEST(DashQuorumMemberSource, RequestGuardsAndPendingReap)
     EXPECT_TRUE(h.sends.empty());
     EXPECT_EQ(h.src->pending_count(), 0u);
 
-    // rotated type -> refused (qrinfo follow-up).
+    // rotated type -> NEVER a getmnlistd. A rotated member set is sourced from
+    // a qrinfo (quarter rotation), and this Harness wires no getqrinfo seam, so
+    // the request cannot send at all and the quorum stays null-serve. The
+    // rotated SOURCING + SERVING path is gated in
+    // test_dash_rotated_quorum_members.cpp against the real captured cycle.
     const uint256 rot_base = raw256(0xE0);
     h.add_block(1'520'064, rot_base);       // 1520064 % 288 == 0
     h.add_block(1'520'056, raw256(0xE1));
     h.src->request(/*llmq_60_75*/ 5, rot_base);
-    EXPECT_TRUE(h.sends.empty());
-    // ...and no ready set is ever produced for the rotated quorum (fail closed
-    // end-to-end: lookup() returns nullopt, so #812 verify_final_commitment
-    // null-serves and the #816 completeness gate leaves the window to dashd).
+    EXPECT_TRUE(h.sends.empty()) << "the rotated lane must not use getmnlistd";
     EXPECT_FALSE(h.src->lookup(5, rot_base).has_value());
 
     // pending reap: > kPendingCap outstanding requests evict the oldest
@@ -531,15 +532,14 @@ TEST(DashQuorumMemberSource, RequestGuardsAndPendingReap)
     EXPECT_LE(h.src->pending_count(), QuorumMemberSource::kPendingCap);
 }
 
-// ── ITEM 2: rotated (DIP-24) member sourcing — ground truth + fail-closed ────
+// ── rotated (DIP-24) KAT SHAPE + the non-rotated leaf's refusal ─────────────
 // The captured real llmq_60_75 vector (dashd `quorum info 5 <hash>` @testnet
-// 192.168.86.52, height 1520064) is dashd's AUTHORITATIVE ordered member set:
-// the 60-member order + operator BLS keys that the follow-up
-// ComputeQuorumMembersByQuarterRotation port must reproduce before the rotated
-// DKG window can serve real. This KAT (a) pins that vector's shape as the
-// validation target, and (b) proves the rotated path currently FAILS CLOSED
-// end-to-end — so the reward-safe dashd fallback is intact until the qrinfo
-// wire + quarter-rotation compute land (each gated on reproducing THIS vector).
+// 192.168.86.52, height 1520064) is dashd's AUTHORITATIVE ordered member set.
+// This test pins its SHAPE and proves that the SINGLE-SNAPSHOT leaf
+// (compute_quorum_members) still refuses a rotated type — rotation must go
+// through compute_quorum_members_by_quarter_rotation over a qrinfo, never
+// through the non-rotated path. The ORDER assertion against this vector lives
+// in test_dash_rotated_quorum_members.cpp.
 TEST(DashQuorumMemberSource, RotatedRealVectorGroundTruthAndFailClosed)
 {
     using namespace dash::coin::testdata;
@@ -555,9 +555,9 @@ TEST(DashQuorumMemberSource, RotatedRealVectorGroundTruthAndFailClosed)
     EXPECT_EQ(kRot6075_LlmqType, 5);
     EXPECT_EQ(kRot6075_CycleBaseHeight % 24, 0);    // sits on the dkgInterval boundary
 
-    // (b) the rotated compute is fail-closed at the vendor leaf: no single-
-    // snapshot member selection exists for a rotated type (quarter-rotation
-    // over qrinfo is required), so compute_quorum_members refuses.
+    // (b) the SINGLE-SNAPSHOT leaf stays fail-closed for a rotated type: no
+    // single-snapshot member selection exists for one (quarter rotation over a
+    // qrinfo is required), so compute_quorum_members must refuse.
     QuorumMemberParams rp;
     rp.type         = kRot6075_LlmqType;
     rp.size         = static_cast<uint16_t>(kRot6075_MemberCount);
@@ -566,11 +566,10 @@ TEST(DashQuorumMemberSource, RotatedRealVectorGroundTruthAndFailClosed)
     CSimplifiedMNList empty_list{std::vector<CSimplifiedMNListEntry>{}};
     auto refused = compute_quorum_members(rp, uint256::ZERO, empty_list);
     EXPECT_FALSE(refused.has_value())
-        << "rotated member selection must fail closed until the quarter-rotation "
-           "port reproduces the captured 60_75 order";
+        << "a rotated type must never be selected from one snapshot";
 
-    // (c) and end-to-end through the sourcing plumbing: a rotated request emits
-    // no wire traffic and never yields a ready set.
+    // (c) and end-to-end through the sourcing plumbing WITHOUT a getqrinfo seam:
+    // no wire traffic, no ready set — the fallback posture is still reachable.
     Harness h;
     const uint256 rot_base = raw256(0xC0);
     h.add_block(kRot6075_CycleBaseHeight, rot_base);

--- a/test/test_dash_quorum_members.cpp
+++ b/test/test_dash_quorum_members.cpp
@@ -294,7 +294,8 @@ TEST(DashQuorumMembers, FailClosedSurfaces)
     CSimplifiedMNList sml = build_kat_sml();
     const uint256 mod = kat_modifier(dash_qmk::kLlmqType);
 
-    // rotated type -> nullopt (DIP-24 quarter rotation is the qrinfo follow-up).
+    // rotated type -> nullopt, permanently: a rotated member set is quarter
+    // rotation over a qrinfo (quorum_members_rotated.hpp), never one snapshot.
     EXPECT_FALSE(compute_quorum_members(
         QuorumMemberParams{5, 60, /*use_rotation=*/true, false}, mod, sml).has_value());
 

--- a/test/test_dash_rotated_quorum_members.cpp
+++ b/test/test_dash_rotated_quorum_members.cpp
@@ -1,0 +1,629 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// DIP-0024 rotated-quorum member-set computation (items 3+4): the ORDER gate.
+//
+// WHY ORDER IS THE GATE
+// ---------------------
+// A member's INDEX in the returned vector selects its slot in the
+// commitment's signers/validMembers bitsets and in the membersSig aggregate.
+// A member set that is correct as a SET but wrong as a SEQUENCE verifies
+// nothing and, served, produces a bad-qc block. So every assertion below that
+// matters compares the ORDERED key sequence, and there is an explicit
+// permutation control proving the comparison is order-sensitive.
+//
+// GROUND TRUTH
+// ------------
+// test/data/dash_rotated_quorum_members_kat.hpp — dashd's own ordered 60-member
+// llmq_60_75 set for quorumIndex 0 at cycle base 1520064 (testnet), captured
+// read-only via `quorum info 5 <quorumHash> false`. All 60 operator keys in it
+// are DISTINCT, so equality of the key sequence IS equality of the member
+// sequence. The inputs come from the same real 602'189-byte qrinfo fixture the
+// item-1/2 suite pins (test/fixtures/dash_testnet_qrinfo_1520064.bin), through
+// the same DIP-4 authentication.
+//
+// WHAT THIS SUITE DOES *NOT* ESTABLISH
+// ------------------------------------
+// At cycle 1520064 the testnet MN list is 371 entries of which only 85 are
+// PoSe-valid, and ALL 85 are marked active in every one of the three cycle
+// snapshots. The "unused MNs first, then already-used MNs" concatenation in
+// GetQuorumQuarterMembersBySnapshot / BuildNewQuorumQuarterMembers is therefore
+// DEGENERATE on this vector — swapping the two halves changes nothing, on any
+// of the 32 slots. That leg is pinned separately below by a synthetic
+// non-degenerate case (UsedMasternodesSortToTheEnd), which is derived from the
+// upstream algorithm, not from this implementation. It is called out here
+// because a reader could otherwise assume the real vector covers it.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/quorum_member_source.hpp>
+#include <impl/dash/coin/vendor/quorum_members_rotated.hpp>
+#include <impl/dash/coin/vendor/quorum_rotation_info.hpp>
+#include <impl/dash/coin/vendor/cbtx.hpp>
+#include <impl/dash/coin/vendor/smldiff.hpp>
+
+#include "data/dash_rotated_quorum_members_kat.hpp"
+
+#include <algorithm>
+#include <fstream>
+#include <iterator>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+using dash::coin::QuorumMemberSource;
+using dash::coin::LlmqNetwork;
+using dash::coin::vendor::CQuorumRotationInfo;
+using dash::coin::vendor::CQuorumSnapshot;
+using dash::coin::vendor::CSimplifiedMNList;
+using dash::coin::vendor::CSimplifiedMNListEntry;
+using dash::coin::vendor::CSimplifiedMNListDiff;
+using dash::coin::vendor::MemberOperatorKey;
+using dash::coin::vendor::RotatedCycleInput;
+using dash::coin::vendor::RotatedQuorumParams;
+using dash::coin::vendor::compute_quorum_members_by_quarter_rotation;
+using dash::coin::vendor::decode_quorum_rotation_info;
+
+namespace {
+
+constexpr uint32_t kCycleBase = 1520064;   // llmq_60_75 cycle base
+constexpr uint32_t kWorkDepth = 8;
+constexpr uint32_t kC         = 288;       // llmq_60_75 dkgInterval
+constexpr uint8_t  kType      = 5;         // LLMQ_60_75
+constexpr size_t   kNQuorums  = 32;        // signingActiveQuorumCount
+constexpr size_t   kQuorumSz  = 60;
+
+std::string hex48(const std::array<uint8_t, 48>& k)
+{
+    static const char* d = "0123456789abcdef";
+    std::string s;
+    s.reserve(96);
+    for (uint8_t b : k) { s.push_back(d[b >> 4]); s.push_back(d[b & 0xf]); }
+    return s;
+}
+
+std::vector<unsigned char> read_fixture()
+{
+    const std::string path =
+        std::string(DASH_FIXTURE_DIR) + "/dash_testnet_qrinfo_1520064.bin";
+    std::ifstream f(path, std::ios::binary);
+    EXPECT_TRUE(f.good()) << "cannot open fixture: " << path;
+    return std::vector<unsigned char>(std::istreambuf_iterator<char>(f),
+                                      std::istreambuf_iterator<char>());
+}
+
+/// The real cycle inputs, built the way quorum_member_source does: the four
+/// authenticated cycle SMLs plus the modifier each cycle base implies (post-V20
+/// SHA256d over (type, workHeight, bestCLSignature) from that work block's OWN
+/// cbTx). Kept in one struct so the SMLs outlive the pointers into them.
+struct RealInputs {
+    CQuorumRotationInfo               info;
+    std::array<CSimplifiedMNList, 4>  smls;
+    std::array<RotatedCycleInput, 4>  cycles;
+    std::array<const CQuorumSnapshot*, 3> snaps{};
+
+    bool load()
+    {
+        auto bytes = read_fixture();
+        if (!decode_quorum_rotation_info(bytes, info)) return false;
+        const CSimplifiedMNListDiff* diffs[4] = {
+            &info.mnListDiffH, &info.mnListDiffAtHMinusC,
+            &info.mnListDiffAtHMinus2C, &info.mnListDiffAtHMinus3C};
+        for (size_t i = 0; i < 4; ++i) {
+            dash::coin::vendor::apply_diff(smls[i], *diffs[i]);
+            dash::coin::vendor::CCbTx cb;
+            if (!dash::coin::vendor::parse_cbtx(diffs[i]->cbTx.extra_payload, cb))
+                return false;
+            // The SML we just rebuilt must be the list that block committed to
+            // — the same leg (c) the authentication path checks.
+            if (smls[i].CalcMerkleRoot() != cb.merkleRootMNList) return false;
+            std::optional<std::array<
+                uint8_t, dash::coin::vendor::CFinalCommitment::BLS_SIG_SIZE>> cl;
+            if (cb.nVersion >= dash::coin::vendor::CCbTx::VERSION_CLSIG_AND_BALANCE
+                && cb.has_best_cl_signature()) {
+                cl = cb.bestCLSignature;
+            }
+            cycles[i].sml      = &smls[i];
+            cycles[i].modifier = dash::coin::vendor::compute_quorum_modifier(
+                kType, static_cast<uint32_t>(cb.nHeight), cl, diffs[i]->blockHash);
+        }
+        snaps = {&info.quorumSnapshotAtHMinusC,
+                 &info.quorumSnapshotAtHMinus2C,
+                 &info.quorumSnapshotAtHMinus3C};
+        return true;
+    }
+};
+
+std::vector<std::string> kat_key_sequence()
+{
+    std::vector<std::string> v;
+    for (const auto& m : dash::coin::testdata::rotated_6075_members())
+        v.emplace_back(m.pub_key_operator);
+    return v;
+}
+
+std::vector<std::string> key_sequence(const std::vector<MemberOperatorKey>& v)
+{
+    std::vector<std::string> out;
+    out.reserve(v.size());
+    for (const auto& k : v) out.push_back(hex48(k.pubKeyOperator));
+    return out;
+}
+
+} // namespace
+
+// ═══════════════════════════════════════════════════════════════════════════
+// THE ORDERING GATE
+// ═══════════════════════════════════════════════════════════════════════════
+
+// dashd's exact ordered 60-member vector for llmq_60_75 quorumIndex 0 at cycle
+// base 1520064, reproduced from qrinfo alone. Index-by-index, not as a set.
+TEST(DashRotatedQuorumMembers, ReproducesDashdMemberORDERForQuorumIndexZero)
+{
+    RealInputs in;
+    ASSERT_TRUE(in.load()) << "fixture must decode and authenticate";
+
+    RotatedQuorumParams p{kType, kQuorumSz, kNQuorums};
+    auto sets = compute_quorum_members_by_quarter_rotation(p, in.cycles, in.snaps);
+    ASSERT_TRUE(sets.has_value())
+        << "the quarter rotation must not fail closed on a genuine cycle";
+    ASSERT_EQ(sets->size(), kNQuorums);
+
+    const auto want = kat_key_sequence();
+    ASSERT_EQ(want.size(), dash::coin::testdata::kRot6075_MemberCount);
+    const auto got = key_sequence((*sets)[dash::coin::testdata::kRot6075_QuorumIndex]);
+    ASSERT_EQ(got.size(), want.size());
+
+    // Index-by-index so a failure names the slot that diverged.
+    for (size_t i = 0; i < want.size(); ++i) {
+        EXPECT_EQ(got[i], want[i])
+            << "member INDEX " << i << " diverges from dashd; member index is "
+               "the signers/validMembers bitset slot, so this is consensus";
+    }
+    EXPECT_EQ(got, want);
+}
+
+// The control that makes the assertion above a real ORDER gate: the SAME set
+// in a different order must NOT compare equal. Without this, a set-equality
+// bug in the test itself would go unnoticed.
+TEST(DashRotatedQuorumMembers, TheOrderAssertionRejectsAPermutationOfTheSameSet)
+{
+    RealInputs in;
+    ASSERT_TRUE(in.load());
+    RotatedQuorumParams p{kType, kQuorumSz, kNQuorums};
+    auto sets = compute_quorum_members_by_quarter_rotation(p, in.cycles, in.snaps);
+    ASSERT_TRUE(sets.has_value());
+
+    const auto want = kat_key_sequence();
+    auto permuted = key_sequence((*sets)[0]);
+    ASSERT_EQ(permuted, want);
+
+    // Same multiset, different sequence.
+    std::swap(permuted[0], permuted[1]);
+    EXPECT_NE(permuted, want) << "a swap of two members must RED the gate";
+
+    std::vector<std::string> a = permuted, b = want;
+    std::sort(a.begin(), a.end());
+    std::sort(b.begin(), b.end());
+    EXPECT_EQ(a, b) << "…while remaining the identical SET — which is exactly "
+                       "what a membership-only test would have accepted";
+
+    // Reversal is the strongest permutation control.
+    auto reversed = key_sequence((*sets)[0]);
+    std::reverse(reversed.begin(), reversed.end());
+    EXPECT_NE(reversed, want);
+}
+
+// All 60 KAT keys are distinct, so key-sequence equality IS member-sequence
+// equality. Asserted rather than assumed.
+TEST(DashRotatedQuorumMembers, KatKeysAreDistinctSoKeyOrderIsMemberOrder)
+{
+    const auto want = kat_key_sequence();
+    std::set<std::string> uniq(want.begin(), want.end());
+    EXPECT_EQ(uniq.size(), want.size());
+
+    std::set<std::string> protx;
+    for (const auto& m : dash::coin::testdata::rotated_6075_members())
+        protx.insert(m.pro_tx_hash);
+    EXPECT_EQ(protx.size(), want.size());
+}
+
+// One qrinfo yields the WHOLE cycle: 32 slots, each exactly quorum size.
+TEST(DashRotatedQuorumMembers, AllThirtyTwoRotatedSlotsAreFullWidth)
+{
+    RealInputs in;
+    ASSERT_TRUE(in.load());
+    RotatedQuorumParams p{kType, kQuorumSz, kNQuorums};
+    auto sets = compute_quorum_members_by_quarter_rotation(p, in.cycles, in.snaps);
+    ASSERT_TRUE(sets.has_value());
+    ASSERT_EQ(sets->size(), kNQuorums);
+    for (size_t i = 0; i < sets->size(); ++i) {
+        EXPECT_EQ((*sets)[i].size(), kQuorumSz) << "slot " << i;
+        for (const auto& k : (*sets)[i]) {
+            bool all_zero = true;
+            for (uint8_t b : k.pubKeyOperator) if (b) { all_zero = false; break; }
+            EXPECT_FALSE(all_zero) << "slot " << i << " carries a zero key";
+        }
+    }
+}
+
+// The quarter geometry is observable in the output: members 0..14 come from the
+// H-3C cycle, 15..29 from H-2C, 30..44 from H-C, 45..59 are new at H. Pinning
+// the boundary catches a quarter-order regression even without the KAT.
+TEST(DashRotatedQuorumMembers, QuarterBoundariesMatchTheOldestFirstAssembly)
+{
+    RealInputs in;
+    ASSERT_TRUE(in.load());
+    RotatedQuorumParams p{kType, kQuorumSz, kNQuorums};
+    auto sets = compute_quorum_members_by_quarter_rotation(p, in.cycles, in.snaps);
+    ASSERT_TRUE(sets.has_value());
+
+    const size_t quarter = kQuorumSz / 4;
+    // Recompute the OLDEST quarter on its own and require it to be the HEAD of
+    // the assembled quorum (upstream iterates the previous cycles reversed).
+    auto oldest = dash::coin::vendor::detail::get_quorum_quarter_members_by_snapshot(
+        kNQuorums, quarter, *in.cycles[3].sml, in.cycles[3].modifier, *in.snaps[2]);
+    ASSERT_TRUE(oldest.has_value());
+    ASSERT_EQ((*oldest)[0].size(), quarter);
+    for (size_t i = 0; i < quarter; ++i) {
+        EXPECT_EQ(hex48((*sets)[0][i].pubKeyOperator),
+                  hex48((*oldest)[0][i]->pubKeyOperator))
+            << "member " << i << " must come from the H-3C quarter";
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// FAIL-CLOSED
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(DashRotatedQuorumMembers, ShortSnapshotBitsetFailsClosed)
+{
+    RealInputs in;
+    ASSERT_TRUE(in.load());
+    // A peer trimming the bitset would make upstream read out of bounds; here
+    // it must simply refuse.
+    CQuorumSnapshot trimmed = in.info.quorumSnapshotAtHMinusC;
+    trimmed.activeQuorumMembers.resize(10);
+    std::array<const CQuorumSnapshot*, 3> snaps = in.snaps;
+    snaps[0] = &trimmed;
+
+    RotatedQuorumParams p{kType, kQuorumSz, kNQuorums};
+    EXPECT_FALSE(compute_quorum_members_by_quarter_rotation(p, in.cycles, snaps)
+                     .has_value());
+}
+
+TEST(DashRotatedQuorumMembers, AllSkippedSnapshotYieldsAShortQuorumAndFailsClosed)
+{
+    RealInputs in;
+    ASSERT_TRUE(in.load());
+    CQuorumSnapshot allskip = in.info.quorumSnapshotAtHMinus2C;
+    allskip.mnSkipListMode = CQuorumSnapshot::MODE_ALL_SKIPPED;
+    std::array<const CQuorumSnapshot*, 3> snaps = in.snaps;
+    snaps[1] = &allskip;
+
+    RotatedQuorumParams p{kType, kQuorumSz, kNQuorums};
+    EXPECT_FALSE(compute_quorum_members_by_quarter_rotation(p, in.cycles, snaps)
+                     .has_value())
+        << "a quarter we cannot reconstruct must never be served short";
+}
+
+TEST(DashRotatedQuorumMembers, MissingCycleInputFailsClosed)
+{
+    RealInputs in;
+    ASSERT_TRUE(in.load());
+    auto cycles = in.cycles;
+    cycles[2].sml = nullptr;
+    RotatedQuorumParams p{kType, kQuorumSz, kNQuorums};
+    EXPECT_FALSE(compute_quorum_members_by_quarter_rotation(p, cycles, in.snaps)
+                     .has_value());
+}
+
+TEST(DashRotatedQuorumMembers, WrongModifierProducesADifferentOrderNotASilentPass)
+{
+    RealInputs in;
+    ASSERT_TRUE(in.load());
+    auto cycles = in.cycles;
+    // Reuse cycle 0's modifier for every cycle — the mistake a port that
+    // forgot GetHashModifier is per-cycle-base would make.
+    for (auto& c : cycles) c.modifier = in.cycles[0].modifier;
+    RotatedQuorumParams p{kType, kQuorumSz, kNQuorums};
+    auto sets = compute_quorum_members_by_quarter_rotation(p, cycles, in.snaps);
+    ASSERT_TRUE(sets.has_value());
+    EXPECT_NE(key_sequence((*sets)[0]), kat_key_sequence())
+        << "the per-cycle modifier must be load-bearing";
+}
+
+// Upstream breaks a score tie by collateralOutpoint, which an SML cannot carry.
+// Two MNs with identical (proRegTxHash, confirmedHash) score identically, and
+// the sort order between them is then not reproducible — refuse.
+TEST(DashRotatedQuorumMembers, ScoreTieFailsClosed)
+{
+    CSimplifiedMNListEntry a;
+    a.nVersion = CSimplifiedMNListEntry::VER_BASIC_BLS;
+    a.proRegTxHash.SetHex(
+        "1111111111111111111111111111111111111111111111111111111111111111");
+    a.confirmedHash.SetHex(
+        "2222222222222222222222222222222222222222222222222222222222222222");
+    a.isValid = true;
+    a.pubKeyOperator[0] = 0xaa;
+    CSimplifiedMNListEntry b = a;
+    b.pubKeyOperator[0] = 0xbb;   // same score inputs, different key
+
+    std::vector<const CSimplifiedMNListEntry*> cands{&a, &b};
+    uint256 modifier;
+    modifier.SetHex(
+        "3333333333333333333333333333333333333333333333333333333333333333");
+    EXPECT_FALSE(
+        dash::coin::vendor::detail::calculate_quorum_all(cands, modifier)
+            .has_value());
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// The leg the real vector CANNOT discriminate (see the header note): the
+// snapshot replay must place ALREADY-USED masternodes at the END of the
+// combined list, after every unused one, whatever their score.
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(DashRotatedQuorumMembers, UsedMasternodesSortToTheEnd)
+{
+    // 8 synthetic MNs, all eligible, all distinct.
+    const size_t kN = 8;
+    std::vector<CSimplifiedMNListEntry> entries(kN);
+    for (size_t i = 0; i < kN; ++i) {
+        auto& e = entries[i];
+        e.nVersion = CSimplifiedMNListEntry::VER_BASIC_BLS;
+        std::string h(64, '0');
+        h[63] = static_cast<char>('1' + i);
+        e.proRegTxHash.SetHex(h);
+        h[62] = '7';
+        e.confirmedHash.SetHex(h);
+        e.isValid = true;
+        e.pubKeyOperator[0] = static_cast<uint8_t>(0x10 + i);
+    }
+    CSimplifiedMNList sml(std::move(entries));
+    ASSERT_EQ(sml.mnList.size(), kN);
+
+    uint256 modifier;
+    modifier.SetHex(
+        "4444444444444444444444444444444444444444444444444444444444444444");
+
+    // The score-sorted list, with nothing marked used, is the control.
+    CQuorumSnapshot none;
+    none.mnSkipListMode = CQuorumSnapshot::MODE_NO_SKIPPING;
+    none.activeQuorumMembers.assign(kN, false);
+    auto ctrl = dash::coin::vendor::detail::get_quorum_quarter_members_by_snapshot(
+        /*num_quorums=*/1, /*quarter_size=*/kN, sml, modifier, none);
+    ASSERT_TRUE(ctrl.has_value());
+    ASSERT_EQ((*ctrl)[0].size(), kN);
+
+    // For EVERY choice of a single already-used MN, that MN must land LAST —
+    // regardless of where its score would otherwise have put it. This is the
+    // upstream rule ("the list begins with all the unused MNs", then the used
+    // ones are appended), asserted without reference to this implementation's
+    // own ordering.
+    for (size_t used = 0; used < kN; ++used) {
+        // Which sorted position does this MN occupy in the control?
+        size_t ctrl_pos = kN;
+        for (size_t j = 0; j < kN; ++j)
+            if ((*ctrl)[0][j] == &sml.mnList[used]) { ctrl_pos = j; break; }
+        ASSERT_LT(ctrl_pos, kN);
+
+        CQuorumSnapshot snap;
+        snap.mnSkipListMode = CQuorumSnapshot::MODE_NO_SKIPPING;
+        snap.activeQuorumMembers.assign(kN, false);
+        // activeQuorumMembers is indexed over the SCORE-SORTED list, not the
+        // SML order — that indexing is itself part of the contract.
+        snap.activeQuorumMembers[ctrl_pos] = true;
+
+        auto q = dash::coin::vendor::detail::get_quorum_quarter_members_by_snapshot(
+            1, kN, sml, modifier, snap);
+        ASSERT_TRUE(q.has_value()) << "used=" << used;
+        ASSERT_EQ((*q)[0].size(), kN);
+        EXPECT_EQ((*q)[0][kN - 1], &sml.mnList[used])
+            << "an already-used MN must be appended AFTER every unused one "
+               "(used=" << used << ", control position " << ctrl_pos << ")";
+        // …and the unused ones keep their relative score order.
+        size_t k = 0;
+        for (size_t j = 0; j < kN; ++j) {
+            if ((*ctrl)[0][j] == &sml.mnList[used]) continue;
+            EXPECT_EQ((*q)[0][k], (*ctrl)[0][j]) << "used=" << used << " j=" << j;
+            ++k;
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ITEM 4 — end to end through QuorumMemberSource: an authenticated qrinfo makes
+// lookup() serve the rotated quorum, in dashd's order.
+// ═══════════════════════════════════════════════════════════════════════════
+
+namespace {
+
+uint256 slot_hash(uint32_t qi)
+{
+    // Synthetic per-index base-block hashes. The fixture cannot carry them
+    // (they are the blocks at cycleBase+1..+31), and only index 0's hash is
+    // consensus-known here — it is the cycle base itself.
+    uint256 h;
+    std::string s(64, '0');
+    s[0] = 'e'; s[1] = 'e';
+    s[62] = "0123456789abcdef"[(qi >> 4) & 0xf];
+    s[63] = "0123456789abcdef"[qi & 0xf];
+    h.SetHex(s);
+    return h;
+}
+
+struct SourceHarness {
+    CQuorumRotationInfo info;
+    std::map<uint256, uint256> roots;
+    std::map<uint32_t, uint256> by_height;
+    int sends{0};
+
+    void load()
+    {
+        auto bytes = read_fixture();
+        ASSERT_TRUE(decode_quorum_rotation_info(bytes, info));
+        for (const CSimplifiedMNListDiff* d :
+             {&info.mnListDiffH, &info.mnListDiffAtHMinusC,
+              &info.mnListDiffAtHMinus2C, &info.mnListDiffAtHMinus3C}) {
+            std::vector<uint256>      m;
+            std::vector<unsigned int> idx;
+            roots[d->blockHash] = d->cbTxMerkleTree.ExtractMatches(m, idx);
+        }
+        uint256 cycle;
+        cycle.SetHex(dash::coin::testdata::kRot6075_QuorumHash);
+        by_height[kCycleBase] = cycle;              // quorumIndex 0
+        for (uint32_t qi = 1; qi < kNQuorums; ++qi)
+            by_height[kCycleBase + qi] = slot_hash(qi);
+    }
+
+    QuorumMemberSource make()
+    {
+        QuorumMemberSource src(
+            LlmqNetwork::Testnet,
+            [this](uint32_t h) -> std::optional<uint256> {
+                auto it = by_height.find(h);
+                if (it == by_height.end()) return std::nullopt;
+                return it->second;
+            },
+            [this](const uint256& qh) -> std::optional<uint32_t> {
+                for (const auto& [h, hash] : by_height)
+                    if (hash == qh) return h;
+                return std::nullopt;
+            },
+            [this](const uint256& h) -> std::optional<uint256> {
+                auto it = roots.find(h);
+                if (it == roots.end()) return std::nullopt;
+                return it->second;
+            },
+            [](const uint256&, const uint256&) {});
+        src.set_send_getqrinfo(
+            [this](const std::vector<uint256>&, const uint256&, bool) { ++sends; });
+        return src;
+    }
+};
+
+} // namespace
+
+TEST(DashRotatedQuorumMembers, LookupServesTheRotatedQuorumInDashdOrder)
+{
+    SourceHarness h;
+    h.load();
+    auto src = h.make();
+
+    uint256 cycle;
+    cycle.SetHex(dash::coin::testdata::kRot6075_QuorumHash);
+    ASSERT_TRUE(src.request_rotated(kType, cycle));
+    ASSERT_EQ(h.sends, 1);
+
+    ASSERT_TRUE(src.on_qrinfo(h.info).has_value());
+    EXPECT_EQ(src.rotated_pending_count(), 0u);
+    // One reply, the whole cycle.
+    EXPECT_EQ(src.ready_count(), kNQuorums);
+
+    auto members = src.lookup(kType, cycle);
+    ASSERT_TRUE(members.has_value())
+        << "item 4: an authenticated qrinfo must make the rotated quorum "
+           "serveable";
+    EXPECT_EQ(key_sequence(*members), kat_key_sequence());
+
+    // Every other slot of the cycle is served too, at full width.
+    for (uint32_t qi = 1; qi < kNQuorums; ++qi) {
+        auto m = src.lookup(kType, slot_hash(qi));
+        ASSERT_TRUE(m.has_value()) << "slot " << qi;
+        EXPECT_EQ(m->size(), kQuorumSz) << "slot " << qi;
+    }
+}
+
+// request() is the entry point the qfcommit feed calls, with the quorum's OWN
+// hash — NOT the cycle base. It must derive the cycle (quorumIndex = height %
+// dkgInterval) and emit exactly one getqrinfo for the whole cycle.
+TEST(DashRotatedQuorumMembers, RequestDerivesTheCycleBaseAndDedupesAcrossSlots)
+{
+    SourceHarness h;
+    h.load();
+    auto src = h.make();
+
+    // Ask for a MID-CYCLE slot first.
+    src.request(kType, slot_hash(7));
+    EXPECT_EQ(h.sends, 1) << "a rotated request must now actually emit a getqrinfo";
+    EXPECT_EQ(src.rotated_pending_count(), 1u);
+
+    // Every other slot of the same cycle rides the outstanding request.
+    for (uint32_t qi = 0; qi < kNQuorums; ++qi) {
+        uint256 qh = (qi == 0) ? h.by_height[kCycleBase] : slot_hash(qi);
+        src.request(kType, qh);
+    }
+    EXPECT_EQ(h.sends, 1) << "32 slots must share ONE 600 kB qrinfo, not 32";
+    EXPECT_EQ(src.rotated_pending_count(), 1u);
+
+    ASSERT_TRUE(src.on_qrinfo(h.info).has_value());
+    EXPECT_EQ(src.ready_count(), kNQuorums);
+
+    // A ready cycle is not re-requested.
+    src.request(kType, slot_hash(7));
+    EXPECT_EQ(h.sends, 1);
+}
+
+// Without a send seam wired there is no rotated traffic at all and every slot
+// stays null-serve — the pre-item-4 posture, still reachable.
+TEST(DashRotatedQuorumMembers, NoSendSeamMeansNoTrafficAndNullServe)
+{
+    SourceHarness h;
+    h.load();
+    QuorumMemberSource src(
+        LlmqNetwork::Testnet,
+        [&h](uint32_t hh) -> std::optional<uint256> {
+            auto it = h.by_height.find(hh);
+            if (it == h.by_height.end()) return std::nullopt;
+            return it->second;
+        },
+        [&h](const uint256& qh) -> std::optional<uint32_t> {
+            for (const auto& [hh, hash] : h.by_height)
+                if (hash == qh) return hh;
+            return std::nullopt;
+        },
+        [](const uint256&) -> std::optional<uint256> { return std::nullopt; },
+        [](const uint256&, const uint256&) {});
+    // no set_send_getqrinfo
+    src.request(kType, slot_hash(3));
+    EXPECT_EQ(src.rotated_pending_count(), 0u);
+    EXPECT_EQ(src.ready_count(), 0u);
+    EXPECT_FALSE(src.lookup(kType, slot_hash(3)).has_value());
+}
+
+// A quorumIndex at or beyond signingActiveQuorumCount does not exist (upstream
+// GetAllQuorumMembers returns {}), so it must not even source.
+TEST(DashRotatedQuorumMembers, IndexBeyondSigningActiveCountIsRefused)
+{
+    SourceHarness h;
+    h.load();
+    auto src = h.make();
+    uint256 far;
+    far.SetHex("00000000000000000000000000000000000000000000000000000000000000ff");
+    h.by_height[kCycleBase + 200] = far;   // 200 >= 32
+    src.request(kType, far);
+    EXPECT_EQ(h.sends, 0);
+    EXPECT_EQ(src.rotated_pending_count(), 0u);
+}
+
+// A tampered operator key breaks the SML root, so the WHOLE cycle fails closed
+// and nothing reaches m_ready — the serve-a-bad-member-set gate, now at the
+// point where a member set actually would have been served.
+TEST(DashRotatedQuorumMembers, TamperedKeyKeepsTheWholeCycleNullServe)
+{
+    SourceHarness h;
+    h.load();
+    auto src = h.make();
+    uint256 cycle;
+    cycle.SetHex(dash::coin::testdata::kRot6075_QuorumHash);
+    ASSERT_TRUE(src.request_rotated(kType, cycle));
+
+    CQuorumRotationInfo tampered = h.info;
+    ASSERT_FALSE(tampered.mnListDiffAtHMinus2C.mnList.empty());
+    tampered.mnListDiffAtHMinus2C.mnList[0].pubKeyOperator[0] ^= 0xff;
+
+    EXPECT_FALSE(src.on_qrinfo(tampered).has_value());
+    EXPECT_EQ(src.ready_count(), 0u);
+    EXPECT_FALSE(src.lookup(kType, cycle).has_value());
+}


### PR DESCRIPTION
Completes E1 Phase-L **items 3 and 4** of the rotated-quorum plan (items 1+2 landed in #1054). This is the last known structural hole on the daemonless block-template path: the rotated `llmq_60_75` DKG window at `h%288 ∈ [42,50]` emits 32 mandatory commitment slots at once, and every one of them was null-served because `request()` no-opped for rotated types and `lookup()` failed closed.

## Item 3 — the quarter rotation

`src/impl/dash/coin/vendor/quorum_members_rotated.hpp` (new) ports dashcore **v23.1.7** `src/llmq/utils.cpp`:

| upstream | here |
|---|---|
| `ComputeQuorumMembersByQuarterRotation` | `vendor::compute_quorum_members_by_quarter_rotation` |
| `GetQuorumQuarterMembersBySnapshot` (bitset + skip-list replay) | `vendor::detail::get_quorum_quarter_members_by_snapshot` |
| `BuildNewQuorumQuarterMembers` | `vendor::detail::build_new_quorum_quarter_members` |
| `CalculateQuorum<List>` with `maxSize == 0` | `vendor::detail::calculate_quorum_all` |

Assembly order is upstream's: oldest quarter first — `[H-3C][H-2C][H-C][new]`, 15 members each — because upstream iterates the previous cycles with `std::views::reverse`. **Member index selects the `signers`/`validMembers` bitset slot and the `membersSig` aggregate position, so the order is consensus, not presentation.**

All four cycle inputs are available daemonlessly from ONE qrinfo: the four `mnListDiff*` are the lists at `cycleBase_i - 8` (`llmq/snapshot.cpp ConstructCycle`), and each carries the cbTx whose `bestCLSignature` feeds `GetHashModifier` for that cycle base. Nothing new is trusted from a peer beyond the snapshot bitsets, and a wrong bitset cannot forge a member set — it can only produce one whose commitment then fails the BLS aggregate.

Two upstream quirks are ported verbatim rather than "fixed", with the reasoning in-header: the skip list is relative to the **first skipped index** (and `first_entry_index == 0` doubles as the not-yet-set sentinel), and a member selected into an older quarter carries **that cycle's** operator key, which is what `CFinalCommitment::Verify` uses.

Stricter than upstream in exactly one place: upstream breaks a score tie by `collateralOutpoint`, which an SML cannot carry, so **any** adjacent equal score fails closed. That needs a SHA256 collision to trigger.

## Item 4 — serving

`QuorumMemberSource` now sources rotated quorums **per cycle**. `request()` derives the cycle base the way upstream `GetAllQuorumMembers` does (`quorumIndex = baseHeight % dkgInterval`, `cycleBase = baseHeight - quorumIndex`, refusing an index ≥ `signingActiveQuorumCount`), emits ONE `getqrinfo`, and `on_qrinfo()` authenticates the four cycle diffs with the unchanged DIP-4 discipline, computes each cycle's modifier, runs the rotation, and inserts **all 32 member sets into the same `m_ready` map** the non-rotated path fills. `main_dash` wires the `send_getqrinfo` seam and the qrinfo consumer (both already existed on `CoinClient`).

**No key, `MemberKeysProvider` signature, or `MineableCommitmentCache` change was needed.** Each of the 32 rotated quorums in a cycle carries its own `quorumHash` — the block at `cycleBase + quorumIndex` (DIP-0024) — so one authenticated reply populates 32 distinct `(llmqType, quorumHash)` keys, and the existing per-slot `quorumIndex` cross-check in `daemonless_qc_commitments` still holds.

### Deliberate reversal, called out

#1054 left `request()` silent for rotated types on the reasoning that a live request whose reply could not yet produce a member set is traffic on a money path for no gain. The reply now produces the member set, so that reasoning inverts and the branch emits. The request is bounded exactly like the non-rotated one: geometry validated locally first, **one** outstanding request per cycle base, deduped across all 32 slots, FIFO-reaped at `kRotatedPendingCap`. With no send seam wired the pre-item-4 posture is still reachable and is asserted.

## The gate: ORDER, not membership

`test/test_dash_rotated_quorum_members.cpp` (new, 16 tests) reproduces **dashd's exact ordered 60-member set** for `llmq_60_75` quorumIndex 0 at cycle base 1520064 — `test/data/dash_rotated_quorum_members_kat.hpp`, captured via `quorum info 5 <hash> false` — **index by index**, from the real 602'189-byte testnet qrinfo fixture alone. All 60 KAT operator keys are distinct (asserted), so key-sequence equality is member-sequence equality.

- explicit **permutation control**: the same multiset in a different sequence must RED the gate, and is shown to be the identical set — exactly what a membership-only test would have accepted;
- the quarter boundary at member 15 (recomputed H-3C quarter must be the head);
- all 32 slots at full width with no zero keys;
- end-to-end through `request_rotated → on_qrinfo → lookup`, and through `request()` with a mid-cycle slot hash (32 slots share ONE 600 kB reply);
- fail-closed: short snapshot bitset, unreconstructable quarter (`MODE_ALL_SKIPPED`), missing cycle input, score tie, wrong per-cycle modifier, tampered operator key taking the whole cycle null-serve, index ≥ 32 refused.

### Mutation results

| mutant | gate |
|---|---|
| swap `members[0]`/`members[1]` — pure permutation, same set | **RED** (4 tests) |
| quarters assembled newest-first (previous cycles not reversed) | **RED** (4 tests) |
| ascending score sort | **RED** (3 tests) |
| skip list decoded cumulatively instead of relative-to-first | **RED** (3 tests) |
| already-used MNs placed first in the snapshot replay | **RED** (1 test) |
| control (restored) | **GREEN** 16/16 |

## What this does NOT establish

At cycle 1520064 only **85 of testnet's 371** masternodes are PoSe-valid, and **all 85 are marked active** in every one of the three snapshots. The "unused MNs first, then already-used MNs" concatenation is therefore **degenerate on the real vector** — swapping the two halves changes nothing on any of the 32 slots. That leg is pinned separately by `UsedMasternodesSortToTheEnd`, a synthetic non-degenerate case derived from the upstream rule rather than from this implementation (it is what reds the fifth mutant above). Called out in the suite header so a reader does not assume the real vector covers it.

Also not established here: the **live cost** of a rotated-window template request. The window has never been probed with a template request on master, so its true cost remains unmeasured — this PR does not claim it is small.

## CI

Tests are folded into `test_dash_embedded_gbt`, which is already in the `build.yml` "Build tests" `--target` allowlist (and already carries `DASH_FIXTURE_DIR`). No new target, so no `workflow`-scope change is needed.

Stale comments in `test_dash_qrinfo.cpp` and `test_dash_quorum_member_source.cpp` that asserted "rotated is not ported / fails closed" were rewritten to say what those tests now actually gate; one of them was silently passing for a new reason and is now explicit about it.
