### PR TITLE
dgb(hstats-944): create graph_db parent dir so stat-log actually persists

### DIFF
--- a/src/c2pool/main_dgb.cpp
+++ b/src/c2pool/main_dgb.cpp
@@ -1330,8 +1330,17 @@ int run_node(const core::CoinParams& params, bool testnet,
         // DGB-namespaced sub-dir isolates the per-coin stat log under config_path().
         {
             std::string net_label = testnet ? "testnet" : "mainnet";
-            std::string graph_db_path = (core::filesystem::config_path()
-                / net_label / "dgb" / "graph_db").string();
+            // #1061 parity: the stat-log parent dir must exist before the first
+            // save_stat_log() tmp-write+rename, otherwise the ofstream silently
+            // fails and rename() throws every 100s — nothing survives a restart
+            // while the build stays green. net_label ("testnet"/"mainnet") is a
+            // DIFFERENT subtree from net_dir ("digibyte_testnet"/"digibyte", L195),
+            // so the L198 create_directories does not cover this path.
+            const std::filesystem::path graph_db_dir =
+                core::filesystem::config_path() / net_label / "dgb";
+            std::error_code stat_mkdir_ec;
+            std::filesystem::create_directories(graph_db_dir, stat_mkdir_ec);  // best effort
+            std::string graph_db_path = (graph_db_dir / "graph_db").string();
             mi->set_stat_log_path(graph_db_path);
             mi->load_stat_log();
             std::cout << "[DGB] graph_db stats persistence -> " << graph_db_path << std::endl;


### PR DESCRIPTION
Addendum fix to G-STATS.944 (#1051): the stat-log path is `config_path()/<net_label>/dgb/graph_db` (net_label = testnet/mainnet) but the only `create_directories` builds `config_path()/<net_subdir>` (digibyte_testnet/digibyte) — a different subtree. The graph_db parent never exists, so `save_stat_log()` fails silently every 100s (ofstream on missing dir + rename throw, caught as WARNING). Build stays green; nothing survives a restart. #1051 landed on a green build, not a verified restart.

Mirror of the BCH #1061 fix: one `create_directories(parent)` before `set_stat_log_path`, main_dgb.cpp only, zero src/core.

**Acceptance (regtest --run --http, isolated datadir):**
- run1: `[StatLog] Saved 2 entries to .../mainnet/dgb/graph_db` (datapoints t=1785781410 mu=9805824.0, t=1785781470 mu=9809920.0)
- full process restart, same datadir: `[StatLog] Loaded 2 entries`, two datapoints byte-identical, then grew to `Saved 4 entries`
- pre-fix this path yields Loaded 0.

Note: `rest_web_graph_data` HTTP route is still undispatched in DGB (node==nullptr live-adapter follow-up, per #1051/#1056) — persistence verified via the on-disk graph_db + Saved/Loaded logs.

No self-merge.