### PR TITLE
btc(hstats-944): create graph_db parent dir so stat-log actually persists

### DIFF
--- a/src/c2pool/main_btc.cpp
+++ b/src/c2pool/main_btc.cpp
@@ -1667,6 +1667,14 @@ int main(int argc, char* argv[])
             std::string net_label = web_is_testnet ? "testnet" : "mainnet";
             std::string graph_db_path = (core::filesystem::config_path()
                 / net_label / "btc" / "graph_db").string();
+            // #1040 gap (STATS.944 restart proof, 2026-08-03): the graph_db parent
+            // dir (config_path()/<net>/btc/) was never created, so save_stat_log's
+            // tmp-write + rename failed every 100s and NO stats survived restart.
+            // Mirror the main_btc.cpp:358 / main_dgb.cpp:196 create_directories(net_dir)
+            // best-effort pattern, targeting the actual stat-log parent.
+            std::error_code graph_db_mkdir_ec;
+            std::filesystem::create_directories(
+                std::filesystem::path(graph_db_path).parent_path(), graph_db_mkdir_ec);
             mi->set_stat_log_path(graph_db_path);
             mi->load_stat_log();
             LOG_INFO << "[BTC-POOL] graph_db stats persistence -> " << graph_db_path;


### PR DESCRIPTION
## Problem
B-STATS.944 (#1049) wired the BTC operator dashboard graph_db stat-log path to `config_path()/<net>/btc/graph_db`, calling `load_stat_log()`/`save_stat_log()`, but never created the **parent** directory. `net_label` there resolves to `testnet`/`mainnet`, a different subtree than the `bitcoin_regtest`/`bitcoin` net_dir created at `main_btc.cpp:358`, and the `btc/` intermediate is absent regardless. `save_stat_log` writes `<path>.new` then `rename`s onto `<path>`; with the parent missing the rename threw every 100s and **nothing persisted** — while the build stayed green. Same class as the BCH fix (#1061).

## Fix
One `create_directories(parent_path)` best-effort call before `set_stat_log_path`, mirroring the `main_btc.cpp:358` / `main_dgb.cpp:196` pattern. Scope: `src/c2pool/main_btc.cpp` only. **Zero core edits** — does not touch `core/web_server.cpp`.

## Restart proof (regtest, `--http`)
- Run 1 accumulated 2 datapoints and logged `[StatLog] Saved 2 entries`:
  - memory_usage `10,018,816` B @ t=`1785781968`
  - memory_usage `10,014,720` B @ t=`1785782028`
  - graph_db file on disk: 537 bytes, valid JSON array.
- Full process restart → `[StatLog] Loaded 2 entries`, and `/web/graph_data/memory_usage/last_day` returned the **identical** pre-restart datapoints.

Before this change the same run produced no persisted file and a rename throw every 100s.
