### PR TITLE
ltc(bootstrap): live CI gate — DNS→verack→getheaders→tip advance

### DIFF
--- a/.github/workflows/ltc-embedded-bootstrap-live-gate.yml
+++ b/.github/workflows/ltc-embedded-bootstrap-live-gate.yml
@@ -58,10 +58,18 @@ jobs:
           path: ${{ runner.temp }}/conan2
           key: conan2-ubuntu24-gcc13-${{ hashFiles('conanfile.txt', 'ci/conan/linux-gcc13.profile') }}
 
+      # Match the green coin-matrix provisioning exactly: lockfile-pinned deps
+      # and an EXPLICIT build_type=Release so conan generates the Release dep
+      # data cmake then consumes (no host/build build_type drift).
       - name: Conan install
         run: |
           for attempt in 1 2 3; do
-            if conan install . -pr:a=ci/conan/linux-gcc13.profile --build=missing --output-folder=build_ci; then exit 0; fi
+            if conan install . \
+              -pr:a=ci/conan/linux-gcc13.profile \
+              --lockfile=conan.lock \
+              --build=missing \
+              --output-folder=build_ci \
+              --settings=build_type=Release; then exit 0; fi
             echo "conan install failed (attempt $attempt/3); retrying in $((attempt * 15))s"
             sleep $((attempt * 15))
           done

--- a/.github/workflows/ltc-embedded-bootstrap-live-gate.yml
+++ b/.github/workflows/ltc-embedded-bootstrap-live-gate.yml
@@ -1,0 +1,84 @@
+name: LTC embedded-bootstrap live gate
+
+# Proves the DEFAULT-ON embedded LTC bootstrap end-to-end against the REAL
+# Litecoin P2P network: DNS-seed resolve -> connect -> version/verack ->
+# getheaders -> HeaderChain tip advances. This is the first CI coverage of the
+# bootstrap path that BTC/DGB/BCH/DASH copy as "reuse".
+#
+# Runs on a github-hosted runner for guaranteed internet egress (the whole
+# point is to exercise real DNS + real P2P). The gate GTEST_SKIPs with a NAMED,
+# logged reason if DNS or P2P egress is blocked, so a silent skip can never
+# read as green.
+
+on:
+  push:
+    branches:
+      - 'ltc-doge/embedded-bootstrap-live-gate'
+  pull_request:
+    paths:
+      - 'src/impl/ltc/test/embedded_bootstrap_live_test.cpp'
+      - 'src/impl/ltc/test/CMakeLists.txt'
+      - 'src/impl/ltc/coin/chain_seeds.hpp'
+      - 'src/core/dns_seeder.hpp'
+      - '.github/workflows/ltc-embedded-bootstrap-live-gate.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
+
+jobs:
+  live-bootstrap-gate:
+    name: LTC embedded-bootstrap live gate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set per-job Conan home
+        run: echo "CONAN_HOME=$RUNNER_TEMP/conan2" >> "$GITHUB_ENV"
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            g++ ccache cmake make libleveldb-dev libsecp256k1-dev
+
+      - uses: actions/setup-python@v6
+        with: { python-version: '3.12' }
+
+      - name: Install Conan 2
+        run: |
+          pip install "conan>=2.0,<3.0"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Restore Conan cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/conan2
+          key: conan2-ubuntu24-gcc13-${{ hashFiles('conanfile.txt', 'ci/conan/linux-gcc13.profile') }}
+
+      - name: Conan install
+        run: |
+          for attempt in 1 2 3; do
+            if conan install . -pr:a=ci/conan/linux-gcc13.profile --build=missing --output-folder=build_ci; then exit 0; fi
+            echo "conan install failed (attempt $attempt/3); retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
+          exit 1
+
+      - name: Configure (LTC live-bootstrap gate ON)
+        run: |
+          cmake -S . -B build_ci \
+            -DCMAKE_TOOLCHAIN_FILE=build_ci/conan_toolchain.cmake \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DLTC_LIVE_BOOTSTRAP_GATE=ON
+
+      - name: Build the gate target
+        run: cmake --build build_ci --target ltc_embedded_bootstrap_gate -j"$(nproc)"
+
+      # Run the gate directly (NOT ctest --exclude-regex 'LiveTest\.'); -V so the
+      # [bootstrap-gate] resolve/handshake/tip-advance lines are on the log.
+      - name: Run the live-bootstrap gate
+        run: ctest --test-dir build_ci -R '^LtcEmbeddedBootstrapGate$' --output-on-failure -V

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -42,10 +42,18 @@ set(source
 
 find_package(yaml-cpp REQUIRED)
 
-# core_util: dependency-free leaf carrying core::timestamp(), split out to
-# break the core <-> {pool,ltc,c2pool} static-link SCC (V36 gate). Source
+# core_util: link-dependency-free leaf carrying core::timestamp(), split out
+# to break the core <-> {pool,ltc,c2pool} static-link SCC (V36 gate). Source
 # half landed in 07165699; this wires the leaf library into the build.
 add_library(core_util STATIC core_util.cpp)
+# Boost::headers is an INTERFACE (include-dirs-only) target, so this adds NO
+# link edge and does NOT reintroduce the SCC the split was made to break. It
+# is required because the top-level -include core/boost_asio_compat.hpp force-
+# include (CMakeLists.txt) injects <boost/version.hpp> into EVERY CXX TU,
+# including this one. Self-hosted runners masked the gap with a system libboost
+# on the default include path; the github-hosted live-bootstrap gate has boost
+# only as conan target-scoped includes, so the leaf must carry the header path.
+target_link_libraries(core_util PUBLIC Boost::headers)
 
 add_library(core OBJECT ${source})
 target_link_libraries(core PUBLIC core_util btclibs)

--- a/src/impl/ltc/test/CMakeLists.txt
+++ b/src/impl/ltc/test/CMakeLists.txt
@@ -38,3 +38,34 @@ if (BUILD_TESTING)
     target_include_directories(ltc_g3a_populated_test PRIVATE ${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/src/btclibs)
     add_test(NAME LtcG3aPopulated COMMAND ltc_g3a_populated_test)
 endif()
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ci-allowlist-exempt: ltc_embedded_bootstrap_gate  -- LIVE network gate; built +
+# run ONLY by .github/workflows/ltc-embedded-bootstrap-live-gate.yml (real DNS +
+# P2P egress). It MUST NOT run inside the hermetic offline `share_test` suite or
+# the default build.yml --target list, so it is exempt from the allowlist
+# drift-guard by design (a standalone live harness, per the checker's escape
+# hatch) and is only defined when its own workflow sets LTC_LIVE_BOOTSTRAP_GATE.
+#
+# embedded_bootstrap_live_test.cpp: proves the DEFAULT-ON embedded LTC bootstrap
+# (main_ltc.cpp `embedded_ltc = true`): DNS-seed resolve -> TCP connect ->
+# version/verack -> getheaders -> HeaderChain tip ADVANCES past genesis, against
+# the REAL LTC P2P network with no LAN daemon and no hardcoded IP. Fixture name
+# is deliberately NOT *LiveTest, so `ctest --exclude-regex 'LiveTest\.'` does not
+# silently skip it. The five test/test_phase*_live.cpp harnesses fail all three
+# of the acceptance conditions (LAN IP default, *LiveTest name, ctest-excluded);
+# this target is the first coverage of the reuse-source bootstrap path.
+option(LTC_LIVE_BOOTSTRAP_GATE
+       "Build the LTC embedded-bootstrap live network gate (real egress)" OFF)
+if (LTC_LIVE_BOOTSTRAP_GATE AND BUILD_TESTING AND GTest_FOUND)
+    add_executable(ltc_embedded_bootstrap_gate embedded_bootstrap_live_test.cpp)
+    target_link_libraries(ltc_embedded_bootstrap_gate PRIVATE
+        GTest::gtest_main GTest::gtest
+        core ltc
+        c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage ltc_coin pool)
+    target_include_directories(ltc_embedded_bootstrap_gate PRIVATE
+        ${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/src/btclibs)
+    add_test(NAME LtcEmbeddedBootstrapGate COMMAND ltc_embedded_bootstrap_gate)
+    set_tests_properties(LtcEmbeddedBootstrapGate PROPERTIES
+        LABELS "live;bootstrap" TIMEOUT 240)
+endif()

--- a/src/impl/ltc/test/embedded_bootstrap_live_test.cpp
+++ b/src/impl/ltc/test/embedded_bootstrap_live_test.cpp
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/// LTC embedded-bootstrap live gate.
+///
+/// Proves the DEFAULT-ON embedded LTC bootstrap path end-to-end against the
+/// REAL Litecoin P2P network, with NO operator-supplied peers and NO hardcoded
+/// LAN daemon:
+///
+///   DNS-seed resolve  ->  TCP connect  ->  version/verack  ->  getheaders
+///   ->  HeaderChain tip ADVANCES past genesis.
+///
+/// This is the coverage the five test/test_phase*_live.cpp harnesses do NOT
+/// provide: they dial a hardcoded LAN testnet daemon (192.168.86.26), their
+/// fixtures are named *LiveTest and are excluded by
+/// `ctest --exclude-regex 'LiveTest\.'`. So the bootstrap that
+/// main_ltc.cpp `bool embedded_ltc = true` turns on for every mainnet user had,
+/// until this gate, ZERO CI coverage — and BTC/DGB/BCH/DASH copy this path as
+/// "reuse", i.e. they copy UNPROVEN code.
+///
+/// Reachability contract (so a silent skip can never masquerade as green):
+///   * DNS resolves zero peers          -> GTEST_SKIP naming the DNS failure.
+///   * DNS ok but NO peer is TCP-reachable on the P2P port
+///                                      -> GTEST_SKIP naming the egress failure.
+///   * A peer IS reachable              -> NO skip. We ASSERT the tip advances.
+///     A reachable network that fails to advance the tip is a real FAILURE of
+///     the bootstrap path — exactly what this gate exists to catch.
+///
+/// Seed source: ltc_mainnet_dns_seeds() (the real public LTC DNS seeds) by
+/// default, overridable to our own deterministic bootstrap host via the
+/// LTC_BOOTSTRAP_DNS_SEED env var once
+/// chain_seeds.hpp:ltc_embedded_bootstrap_seeds() is pinned. Either way the
+/// seed is resolved THROUGH the DnsSeeder — never a hardcoded IP.
+
+#include <gtest/gtest.h>
+
+#include <impl/ltc/config_coin.hpp>
+#include <impl/ltc/coin/header_chain.hpp>
+#include <impl/ltc/coin/chain_seeds.hpp>
+#include <c2pool/merged/coin_broadcaster.hpp>
+
+#include <core/dns_seeder.hpp>
+#include <core/netaddress.hpp>
+#include <core/log.hpp>
+
+#include <boost/asio.hpp>
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace io = boost::asio;
+using namespace ltc::coin;
+using namespace c2pool::merged;
+
+// LTC mainnet P2P message-start magic (pchMessageStart): fb c0 b6 db.
+static const std::vector<std::byte> LTC_MAINNET_PREFIX = {
+    std::byte{0xfb}, std::byte{0xc0}, std::byte{0xb6}, std::byte{0xdb}
+};
+
+static std::string get_env(const char* name, const char* def) {
+    const char* v = std::getenv(name);
+    return v ? v : def;
+}
+
+// Synchronous, bounded TCP reachability probe. Mirrors the harness helper.
+static bool tcp_probe(const std::string& host, uint16_t port, int timeout_ms = 3000) {
+    try {
+        io::io_context ioc;
+        io::ip::tcp::socket socket(ioc);
+        io::ip::tcp::resolver resolver(ioc);
+        auto endpoints = resolver.resolve(host, std::to_string(port));
+        io::steady_timer timer(ioc);
+        timer.expires_after(std::chrono::milliseconds(timeout_ms));
+        bool connected = false, timed_out = false;
+        io::async_connect(socket, endpoints,
+            [&](const boost::system::error_code& e, const io::ip::tcp::endpoint&) {
+                if (!e) connected = true;
+                timer.cancel();
+            });
+        timer.async_wait([&](const boost::system::error_code& e) {
+            if (!e) { timed_out = true; socket.close(); }
+        });
+        ioc.run();
+        return connected && !timed_out;
+    } catch (...) { return false; }
+}
+
+// Resolve LTC mainnet DNS seeds THROUGH the DnsSeeder (never a hardcoded IP).
+static std::vector<NetService> resolve_seeds() {
+    io::io_context ioc;
+    std::vector<c2pool::dns::DnsSeed> seeds;
+    std::string override_host = get_env("LTC_BOOTSTRAP_DNS_SEED", "");
+    if (!override_host.empty())
+        seeds.push_back({override_host, 9333});
+    else
+        seeds = ltc_mainnet_dns_seeds();
+
+    std::vector<NetService> out;
+    c2pool::dns::DnsSeeder seeder(ioc, seeds);
+    seeder.resolve_all([&](std::vector<NetService> peers) { out = std::move(peers); });
+    ioc.run();
+    return out;
+}
+
+TEST(EmbeddedBootstrapGate, DnsResolveHandshakeGetheadersTipAdvance)
+{
+    core::log::Logger::init();
+
+    // ── Stage 1: DNS resolve through the seeder ──────────────────────────────
+    auto peers = resolve_seeds();
+    if (peers.empty()) {
+        GTEST_SKIP() << "SKIP[dns-unreachable]: DnsSeeder resolved ZERO peers "
+                        "from the LTC mainnet DNS seeds — DNS egress is blocked "
+                        "on this runner. The bootstrap path was NOT exercised.";
+    }
+    std::cout << "[bootstrap-gate] DNS resolved " << peers.size()
+              << " candidate peers" << std::endl;
+
+    // ── Stage 2: find a TCP-reachable peer on the P2P port ───────────────────
+    std::optional<NetService> reachable;
+    int probed = 0;
+    for (const auto& p : peers) {
+        ++probed;
+        if (tcp_probe(p.address(), p.port())) { reachable = p; break; }
+        if (probed >= 12) break;   // bound the probe budget
+    }
+    if (!reachable.has_value()) {
+        GTEST_SKIP() << "SKIP[p2p-egress-blocked]: DNS resolved " << peers.size()
+                     << " peers but NONE accepted a TCP connection on the LTC "
+                        "P2P port within the probe window — P2P egress is blocked "
+                        "on this runner. Handshake was NOT exercised.";
+    }
+    std::cout << "[bootstrap-gate] TCP-reachable peer: "
+              << reachable->to_string() << std::endl;
+
+    // ── Stage 3: real handshake + getheaders against that peer ───────────────
+    // Network is reachable from here on — NO further skips; we ASSERT.
+    io::io_context ioc;
+    NetService addr = *reachable;
+    BroadcastPeer peer(&ioc, addr.to_string(), LTC_MAINNET_PREFIX, addr);
+
+    auto params = make_ltc_chain_params_mainnet();
+    HeaderChain chain(params);
+    ASSERT_TRUE(chain.init());
+
+    // Seed with the LTC mainnet genesis so received height-1 headers connect.
+    BlockHeaderType genesis;
+    genesis.m_version = 1;
+    genesis.m_previous_block.SetNull();
+    genesis.m_merkle_root.SetHex("97ddfbbae6be97fd6cdf3e7ca13232a3afff2353e29badfab7f73011edd4ced9");
+    genesis.m_timestamp = 1317972665;
+    genesis.m_bits = 0x1e0ffff0;
+    genesis.m_nonce = 2084524493;
+    ASSERT_TRUE(chain.add_header(genesis));
+    ASSERT_EQ(chain.height(), 0u);
+
+    std::atomic<int> header_msgs{0};
+    std::atomic<int> accepted_total{0};
+
+    peer.coin_node.new_headers.subscribe(
+        [&](const std::vector<BlockHeaderType>& hdrs) {
+            header_msgs.fetch_add(1, std::memory_order_relaxed);
+            int accepted = chain.add_headers(hdrs);
+            accepted_total.fetch_add(accepted, std::memory_order_relaxed);
+            std::cout << "[bootstrap-gate] headers msg: got " << hdrs.size()
+                      << " accepted " << accepted
+                      << " tip=" << chain.height() << std::endl;
+            if (accepted > 0) {
+                // Keep pulling to demonstrate a sustained advance.
+                peer.node_p2p.send_getheaders(70017, chain.get_locator(), uint256::ZERO);
+            }
+        });
+
+    peer.node_p2p.connect(addr);
+
+    // After version/verack settles, issue getheaders from genesis.
+    io::steady_timer handshake_wait(ioc);
+    handshake_wait.expires_after(std::chrono::seconds(5));
+    handshake_wait.async_wait([&](const boost::system::error_code& ec) {
+        if (ec) return;
+        peer.node_p2p.send_getheaders(70017, chain.get_locator(), uint256::ZERO);
+    });
+
+    io::steady_timer deadline(ioc);
+    deadline.expires_after(std::chrono::seconds(90));
+    deadline.async_wait([&](const boost::system::error_code&) { ioc.stop(); });
+
+    ioc.run();
+
+    const uint32_t final_height = chain.height();
+    std::cout << "[bootstrap-gate] RESULT: header_msgs=" << header_msgs.load()
+              << " accepted_total=" << accepted_total.load()
+              << " tip_height=" << final_height << std::endl;
+
+    // ── Assertions: the TIP ADVANCED (not merely "no crash") ─────────────────
+    ASSERT_GT(header_msgs.load(), 0)
+        << "Reachable peer completed TCP connect but delivered no headers "
+           "message — the version/verack or getheaders path is BROKEN.";
+    EXPECT_GT(final_height, 0u)
+        << "TIP DID NOT ADVANCE past genesis after getheaders — the embedded "
+           "bootstrap header-sync path is broken.";
+
+    auto tip = chain.tip();
+    ASSERT_TRUE(tip.has_value());
+    EXPECT_EQ(tip->status, HEADER_VALID_CHAIN);
+    EXPECT_EQ(tip->height, final_height);
+    for (uint32_t h = 0; h <= std::min(final_height, 10u); ++h) {
+        EXPECT_TRUE(chain.get_header_by_height(h).has_value())
+            << "gap on the best chain at height " << h;
+    }
+
+    std::cout << "[bootstrap-gate] PASS: tip advanced genesis(0) -> "
+              << final_height << " via DNS-discovered peer "
+              << addr.to_string() << std::endl;
+}


### PR DESCRIPTION
First CI coverage of the DEFAULT-ON embedded LTC bootstrap, exercised against the REAL Litecoin P2P network on a github-hosted runner (guaranteed internet egress): DNS-seed resolve → connect → version/verack → getheaders → HeaderChain tip advances 0→N. This is the path BTC/DGB/BCH/DASH copy as bootstrap reuse; proven ON LTC ONLY (set_http_peer_seeds wired for main_ltc only — integrator routes per-lane).

Build fix in this PR (run 30852249481 was RED): the top-level -include core/boost_asio_compat.hpp force-injects <boost/version.hpp> into every CXX TU including core_util.cpp, but the core_util leaf linked no boost target. Self-hosted runners masked it with system libboost; the github-hosted gate has boost only as conan target-scoped includes. Fix links core_util against Boost::headers (INTERFACE include-dirs only — no link edge, does not reintroduce the SCC the leaf split broke). Gate workflow conan install also pinned to conan.lock + explicit build_type=Release to match green coin-matrix provisioning.

Green here means step 11 (Run the live-bootstrap gate) EXECUTED and the log carries the tip-advance line, not just build-ok. Reviewer: dash-consensus-pay-replay. Merge tap: integrator.