### PR TITLE
dgb(dashboard): wire share-peers feed into the WebServer stat-log (D-DGB)

### DIFF
--- a/src/c2pool/main_dgb.cpp
+++ b/src/c2pool/main_dgb.cpp
@@ -1326,6 +1326,16 @@ int run_node(const core::CoinParams& params, bool testnet,
             return static_cast<double>(aps.GetLow64());
         });
 
+        // (6) share-peers — the pool node sharechain P2P peer snapshot
+        //     (IO-thread-published, lock-free; NEVER iterates the live
+        //     m_peers map). Feeds core MiningInterface::update_stat_log ->
+        //     entry.peers (incoming/outgoing counts), so /web/graph_data
+        //     serves a real "peers" series and the share-peers dashboard
+        //     panel populates. Mirrors bch #1055 (set_peer_info_fn ->
+        //     node.get_peer_info_json()). Display-only; p2pool-merged-v36
+        //     surface: NONE (dashboard reporting, not share/PPLNS bytes).
+        mi->set_peer_info_fn([&p2p_node]() { return p2p_node.get_peer_info_json(); });
+
         // graph_db stats persistence — survives restarts (LTC-parity site 2/3).
         // DGB-namespaced sub-dir isolates the per-coin stat log under config_path().
         {


### PR DESCRIPTION
## D-DGB — wire the share-peers feed into the WebServer stat-log

Mirrors the **merged bch #1055**. The H-STATS.944 seam (#1051) + D-DGB feeds (#1056) already stand up `core::WebServer` with `node_topology / sharechain_stats / pool_hashrate / coin_peers / spv_progress`, and #1063 fixed `graph_db` persistence. The single bch-#1055 feed still missing on DGB was **`set_peer_info_fn`** — without it `MiningInterface::update_stat_log()` left `entry.peers` at `incoming=0/outgoing=0` regardless of the live sharechain P2P peer set, so the `/web/graph_data` `peers` series and the share-peers panel could never reflect real peers.

**Change (1 line + comment):** `mi->set_peer_info_fn([&p2p_node]() { return p2p_node.get_peer_info_json(); });` — the pool node IO-thread-published, lock-free snapshot (`src/impl/dgb/node.hpp:373`), exact array-of-`{..,"incoming":bool,..}` shape core parses. Same call shape as bch #1055; no second pattern.

**Isolation:** consumer edit in `main_dgb.cpp` only, **ZERO `src/core`**. p2pool-merged-v36 surface: **NONE** (dashboard reporting, not share/PPLNS/coinbase/AuxPoW bytes). Base: `origin/master` @ 82c805704 (#1063 already landed there — no unmerged stacking).

## Acceptance evidence (curl, both sides of a full process restart)

`c2pool-dgb --run --stratum 127.0.0.1:18100 --http 127.0.0.1:18099 --data-dir <D>`, isolated (no miners/peers → values are truthfully 0, structure is live).

**RUN1 (135s, crosses the 100s save timer):**
```
$ curl -s http://127.0.0.1:18099/web/graph_data/pool_hash_rate/last_hour
[[1785793323.0,0.0,300.0,0],[1785793383.0,0.0,300.0,0],[1785793443.0,0.0,300.0,0]]

$ curl -s http://127.0.0.1:18099/web/graph_data/peers/last_hour     # NEW feed
[[1785793323.0,{"incoming":0,"outgoing":0},300.0,0],[1785793383.0,{"incoming":0,"outgoing":0},300.0,0],[1785793443.0,{"incoming":0,"outgoing":0},300.0,0]]

[StatLog] Saved 2 entries to <D>/mainnet/dgb/graph_db
sha256(graph_db) = e360fe277d51da522903eed9881a62e24adeb48d220943163f1fc7b0023001ce
```

**RUN2 (full restart, same datadir):**
```
[StatLog] Loaded 2 entries from <D>/mainnet/dgb/graph_db

$ curl -s http://127.0.0.1:18099/web/graph_data/pool_hash_rate/last_hour
[[1785793323.0,0.0,300.0,0],[1785793383.0,0.0,300.0,0],[1785793462.0,0.0,300.0,0]]
sha256(graph_db) = e360fe277d51da522903eed9881a62e24adeb48d220943163f1fc7b0023001ce   # byte-identical
```
The two persisted datapoints (`…323`, `…383`) are identical across the restart; `…462` is RUN2 own fresh sample. `graph_db` bytes are identical (same SHA256). The new `peers` series carries the structured `{incoming,outgoing}` datum.

No self-merge — integrator merges on operator `push approved`.
