### PR TITLE
proto(v37): libmrr M2 Drop 3 — finality-gated owed/overlay ledger + KAT-4 goldens

### DIFF
--- a/prototypes/libmrr/README.md
+++ b/prototypes/libmrr/README.md
@@ -46,6 +46,37 @@ only — no live risk, no production wiring. Landing is held for the merge-tap.
   eviction while the ledger total is unchanged. **Not** in this drop: any
   finality gating, block-found overlay, or owed→settled transition — that is the
   finality-gated owed/overlay ledger (Drop 3), a hard scope fence.
+- **m2 Drop 3 — Finality-gated owed/overlay ledger: complete.** `mrr.Settlement`
+  (`overlay.go`): the finality gate that turns owed work into paid work. State is
+  three integer ledgers over one identity space — `owed` (accrued, un-earmarked),
+  `pending` (earmarked to a found-but-not-final block's overlay, reversible), and
+  `settled` (paid by a finalized block, irreversible) — with the conservation
+  invariant `accrued == owed + pending + settled` (**I-CONSERVE**) held across
+  every transition. The three block transitions of the m1 settlement state
+  machine are weight moves that leave I-CONSERVE invariant:
+  `BlockFound → OverlayAdded` (owed→pending), `BlockFinalized → OwedSettled +
+  OverlayCleared` (pending→settled), `BlockOrphaned → OverlayReverted`
+  (pending→owed). `Finalize(blockID, depth)` is the **symmetric finality-gate**
+  (the round-4/5 conceded fix): a payout may not settle below `finalityK` (the
+  same `Geometry.FinalityDepthK` that seals the work side) — `depth < K` returns
+  `NotFinal` and moves nothing. Because Found only *moves* owed into a keyed
+  overlay and Orphan moves the identical weight back, a found→orphaned round trip
+  restores the prior digest bit-for-bit — the reorg-safety snapshot-revert
+  property (`TestSettlement_RevertRoundTrip`); found order over disjoint
+  identities commutes (`TestSettlement_FoundOrderCommutes`); a found overlay
+  cannot draw more than an identity's owed and is rejected atomically
+  (`TestSettlement_OverdrawRejectedAtomic`, `…NoDoubleSpendAcrossBlocks`); the
+  owed base seeds from a Drop-2 `Ledger` (`NewSettlementFromLedger`, reading only
+  its exported sorted accessors — Drop 2 is untouched). The canonical `Digest()`
+  commits owed, settled, and every keyed pending overlay in ascending order,
+  domain-separated from the buffer and ledger digests. KAT-4 golden vectors
+  (`mrr/testdata/kat4_overlay_vectors.json`, three scenarios:
+  `single_block_lifecycle`, `reorg_revert_roundtrip`,
+  `concurrent_two_blocks_split_outcome`) pin per-step disposition, owed/pending/
+  settled totals, digest, the hand-derived final owed/settled balances, and the
+  snapshot-revert digest pairs; `cmd/genkat4` asserts all of that plus I-CONSERVE
+  at every step before it will mint. **Not** in this drop: Phase-2 delegated-carry
+  / carriage-liveness and the O(1) commit-root tail hybrid — hard-stop fences.
 - Phases 1 (query-side decay) and 2 (pure `retarget()` + EMA + observables +
   offline simulator) are next, per the blueprint. Phase 3 (live adaptive
   dimensioning) is **v38-fenced** — hard stop.
@@ -89,6 +120,7 @@ Regenerate the golden vectors on a reference build and review the diff:
 go run ./cmd/genkat  > mrr/testdata/kat1_vectors.json               # KAT-1: Geometry
 go run ./cmd/genkat2 > mrr/testdata/kat2_buffer_vectors.json        # KAT-2: Buffer
 go run ./cmd/genkat3 > mrr/testdata/kat3_compaction_vectors.json    # KAT-3: Compaction
+go run ./cmd/genkat4 > mrr/testdata/kat4_overlay_vectors.json       # KAT-4: Overlay
 ```
 
 `genkat2` asserts every hand-derived per-step disposition/sum/count/head before
@@ -96,7 +128,10 @@ it emits a vector, so a wrong implementation cannot mint a golden. `genkat3`
 does the same for compaction — per-step total/count/digest and the final
 per-identity balances — and additionally asserts the commutativity invariant
 (reverse, weight-sorted, and split-compact-then-merge all reproduce the
-canonical digest) inside the generator before minting.
+canonical digest) inside the generator before minting. `genkat4` asserts each
+step's disposition/totals/digest, I-CONSERVE (owed+pending+settled == accrued)
+at every step, the hand-derived final owed/settled sets, and each snapshot-revert
+digest pair before minting.
 
 ## Open items (flagged, non-blocking)
 

--- a/prototypes/libmrr/cmd/genkat4/main.go
+++ b/prototypes/libmrr/cmd/genkat4/main.go
@@ -1,0 +1,266 @@
+// genkat4 regenerates the KAT-4 golden vectors for the finality-gated
+// owed/overlay ledger (V37 m2 Drop 3). Run on a reference build; paste stdout
+// into mrr/testdata/kat4_overlay_vectors.json. The generator drives a scripted
+// event stream (accrue / found / finalize / orphan) through a Settlement and,
+// before it emits any vector, ASSERTS:
+//
+//   - the disposition, owed/pending/settled totals, and canonical digest at
+//     each step;
+//   - I-CONSERVE at every step: owed_total + pending_total + settled_total ==
+//     total accrued so far (weight is conserved across every transition);
+//   - the hand-derived final owed and settled balances (exact sets, no extras);
+//   - each declared snapshot-revert pair: the digest after a found->orphaned
+//     round trip is bit-identical to the digest before the block was found.
+//
+// A wrong implementation cannot mint a golden. overlay_test.go then
+// independently replays the committed vectors and re-checks every field, and
+// the property tests pin the algebra (revert round-trip, found-order
+// commutativity, the symmetric finality gate).
+package main
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"libmrr/mrr"
+)
+
+// contrib is one payout entry (identity, amount) inside a found block.
+type contrib struct {
+	ID     uint64 `json:"id"`
+	Weight uint64 `json:"weight"`
+}
+
+// event is one scripted transition. Kind selects which fields are read:
+//
+//	accrue:   ID = identity, Weight = work folded into owed
+//	found:    ID = blockID,  Payout = tentative per-identity payout
+//	finalize: ID = blockID,  Depth  = confirmation depth (gate vs finality K)
+//	orphan:   ID = blockID
+type event struct {
+	Kind   string    `json:"kind"`
+	ID     uint64    `json:"id"`
+	Weight uint64    `json:"weight,omitempty"`
+	Depth  uint32    `json:"depth,omitempty"`
+	Payout []contrib `json:"payout,omitempty"`
+}
+
+// balance is one identity's final owed or settled total (sorted by id).
+type balance struct {
+	ID     uint64 `json:"id"`
+	Weight uint64 `json:"weight"`
+}
+
+// step is the observable post-state after applying event i (0-indexed).
+type step struct {
+	Index        int    `json:"index"`
+	Result       string `json:"result"` // ApplyResult string, or "accrued"
+	OwedTotal    uint64 `json:"owed_total"`
+	PendingTotal uint64 `json:"pending_total"`
+	SettledTotal uint64 `json:"settled_total"`
+	Digest       string `json:"digest_hex"`
+}
+
+// scenario is a named event script plus hand-derived final expectations.
+type scenario struct {
+	Name      string  `json:"name"`
+	FinalityK uint32  `json:"finality_k"`
+	Events    []event `json:"events"`
+	Trace     []step  `json:"trace"`
+	// Hand-derived final state (asserted before emit).
+	WantOwed         []balance `json:"want_owed"`
+	WantSettled      []balance `json:"want_settled"`
+	WantOwedTotal    uint64    `json:"want_owed_total"`
+	WantPendingTotal uint64    `json:"want_pending_total"`
+	WantSettledTotal uint64    `json:"want_settled_total"`
+	// AssertDigestEqual lists [a,b] step-index pairs whose digests must match —
+	// the snapshot-revert obligation (found->orphan restores the prior digest).
+	AssertDigestEqual [][2]int `json:"assert_digest_equal,omitempty"`
+	FinalDigest       string   `json:"final_digest_hex"`
+}
+
+func scenarios() []scenario {
+	return []scenario{
+		{
+			// One block's full lifecycle: accrue owed, find the block (owed ->
+			// pending), try to finalize BELOW depth K (gate holds, NotFinal), then
+			// finalize AT depth K (pending -> settled). Includes a zero-amount
+			// payout entry (id 4) that must earmark nothing.
+			Name:      "single_block_lifecycle",
+			FinalityK: 6,
+			Events: []event{
+				{Kind: "accrue", ID: 1, Weight: 10},
+				{Kind: "accrue", ID: 2, Weight: 5},
+				{Kind: "accrue", ID: 3, Weight: 7},
+				{Kind: "found", ID: 100, Payout: []contrib{{1, 10}, {2, 5}, {4, 0}}},
+				{Kind: "finalize", ID: 100, Depth: 5}, // below K -> NotFinal
+				{Kind: "finalize", ID: 100, Depth: 6}, // at K -> OwedSettled
+			},
+			// After settle: owed = {3:7} (1 and 2 fully paid), settled = {1:10,2:5}.
+			WantOwed:         []balance{{3, 7}},
+			WantSettled:      []balance{{1, 10}, {2, 5}},
+			WantOwedTotal:    7,
+			WantPendingTotal: 0,
+			WantSettledTotal: 15,
+		},
+		{
+			// Reorg safety: accrue, find a block, then orphan it. The found->
+			// orphaned round trip must restore the exact pre-found digest. Step
+			// indices: 0,1 accrue; 2 found; 3 orphan. digest[3] == digest[1].
+			Name:      "reorg_revert_roundtrip",
+			FinalityK: 4,
+			Events: []event{
+				{Kind: "accrue", ID: 7, Weight: 20},
+				{Kind: "accrue", ID: 8, Weight: 13},
+				{Kind: "found", ID: 200, Payout: []contrib{{7, 20}, {8, 13}}},
+				{Kind: "orphan", ID: 200},
+			},
+			// Orphan reverts everything back to owed; nothing settled.
+			WantOwed:          []balance{{7, 20}, {8, 13}},
+			WantSettled:       nil,
+			WantOwedTotal:     33,
+			WantPendingTotal:  0,
+			WantSettledTotal:  0,
+			AssertDigestEqual: [][2]int{{1, 3}},
+		},
+		{
+			// Two candidate tips pending at once over disjoint identities: both
+			// found, then one finalized and one orphaned. Exercises multi-block
+			// pending state and partial settlement. Order-independence of the two
+			// found events over the disjoint end-state is pinned as a property
+			// test, not here.
+			Name:      "concurrent_two_blocks_split_outcome",
+			FinalityK: 3,
+			Events: []event{
+				{Kind: "accrue", ID: 1, Weight: 8},
+				{Kind: "accrue", ID: 2, Weight: 8},
+				{Kind: "accrue", ID: 3, Weight: 8},
+				{Kind: "accrue", ID: 4, Weight: 8},
+				{Kind: "found", ID: 300, Payout: []contrib{{1, 8}, {2, 8}}},
+				{Kind: "found", ID: 301, Payout: []contrib{{3, 8}, {4, 8}}},
+				{Kind: "finalize", ID: 300, Depth: 3}, // block 300 settles
+				{Kind: "orphan", ID: 301},             // block 301 reverts
+			},
+			// 300 settles ids 1,2; 301 reverts ids 3,4 back to owed.
+			WantOwed:         []balance{{3, 8}, {4, 8}},
+			WantSettled:      []balance{{1, 8}, {2, 8}},
+			WantOwedTotal:    16,
+			WantPendingTotal: 0,
+			WantSettledTotal: 16,
+		},
+	}
+}
+
+// resultString applies event e to s and returns the transition disposition as
+// the string the golden pins ("accrued" for accrue, else ApplyResult.String()).
+func apply(s *mrr.Settlement, e event) string {
+	switch e.Kind {
+	case "accrue":
+		s.Accrue(e.ID, e.Weight)
+		return "accrued"
+	case "found":
+		p := make([]mrr.Contribution, len(e.Payout))
+		for i, c := range e.Payout {
+			p[i] = mrr.Contribution{ID: c.ID, Weight: c.Weight}
+		}
+		return s.BlockFound(e.ID, p).String()
+	case "finalize":
+		return s.Finalize(e.ID, e.Depth).String()
+	case "orphan":
+		return s.Orphan(e.ID).String()
+	default:
+		return "BAD_KIND:" + e.Kind
+	}
+}
+
+func run(sc *scenario) error {
+	s := mrr.NewSettlement(sc.FinalityK)
+	sc.Trace = make([]step, 0, len(sc.Events))
+	var accrued uint64 // total ever accrued, for the I-CONSERVE check
+	for i, e := range sc.Events {
+		if e.Kind == "accrue" {
+			accrued += e.Weight
+		}
+		res := apply(s, e)
+		d := s.Digest()
+		st := step{
+			Index: i, Result: res,
+			OwedTotal: s.OwedTotal(), PendingTotal: s.PendingTotal(),
+			SettledTotal: s.SettledTotal(),
+			Digest:       hex.EncodeToString(d[:]),
+		}
+		// I-CONSERVE: nothing is created or destroyed by any transition.
+		if got := st.OwedTotal + st.PendingTotal + st.SettledTotal; got != accrued {
+			return fmt.Errorf("%s step %d: owed+pending+settled=%d, want accrued=%d",
+				sc.Name, i, got, accrued)
+		}
+		sc.Trace = append(sc.Trace, st)
+	}
+
+	// Hand-derived final owed/settled (exact sets, no extras).
+	if err := checkSet(sc.Name, "owed", s.Owed, s.OwedTotal(), sc.WantOwed, sc.WantOwedTotal); err != nil {
+		return err
+	}
+	if err := checkSet(sc.Name, "settled", s.Settled, s.SettledTotal(), sc.WantSettled, sc.WantSettledTotal); err != nil {
+		return err
+	}
+	if s.PendingTotal() != sc.WantPendingTotal {
+		return fmt.Errorf("%s: pending_total=%d, want %d", sc.Name, s.PendingTotal(), sc.WantPendingTotal)
+	}
+
+	// Snapshot-revert obligations: each declared pair of step digests must match.
+	for _, pair := range sc.AssertDigestEqual {
+		a, b := pair[0], pair[1]
+		if a < 0 || b < 0 || a >= len(sc.Trace) || b >= len(sc.Trace) {
+			return fmt.Errorf("%s: assert_digest_equal index out of range %v", sc.Name, pair)
+		}
+		if sc.Trace[a].Digest != sc.Trace[b].Digest {
+			return fmt.Errorf("%s: snapshot-revert failed: digest[%d]=%s != digest[%d]=%s",
+				sc.Name, a, sc.Trace[a].Digest, b, sc.Trace[b].Digest)
+		}
+	}
+
+	d := s.Digest()
+	sc.FinalDigest = hex.EncodeToString(d[:])
+	if n := len(sc.Trace); n > 0 && sc.Trace[n-1].Digest != sc.FinalDigest {
+		return fmt.Errorf("%s: last trace digest != final digest", sc.Name)
+	}
+	return nil
+}
+
+// checkSet verifies a ledger accessor against a hand-derived balance set: the
+// exact membership (no extra credited ids), each amount, and the total.
+func checkSet(name, which string, get func(uint64) uint64, gotTotal uint64, want []balance, wantTotal uint64) error {
+	if gotTotal != wantTotal {
+		return fmt.Errorf("%s: %s_total=%d, want %d", name, which, gotTotal, wantTotal)
+	}
+	var sum uint64
+	for _, b := range want {
+		if g := get(b.ID); g != b.Weight {
+			return fmt.Errorf("%s: %s[%d]=%d, want %d", name, which, b.ID, g, b.Weight)
+		}
+		sum += b.Weight
+	}
+	if sum != wantTotal {
+		return fmt.Errorf("%s: %s want-set sums to %d, want_total=%d", name, which, sum, wantTotal)
+	}
+	return nil
+}
+
+func main() {
+	scs := scenarios()
+	for i := range scs {
+		if err := run(&scs[i]); err != nil {
+			fmt.Fprintln(os.Stderr, "genkat4: assertion failed:", err)
+			os.Exit(1)
+		}
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(scs); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/prototypes/libmrr/mrr/overlay.go
+++ b/prototypes/libmrr/mrr/overlay.go
@@ -1,0 +1,344 @@
+// overlay.go — finality-gated owed/overlay ledger (V37 m2 Drop 3).
+//
+// Drop 2 (compaction.go) gave the durable, position-free per-identity accrued
+// balance: what the pool OWES a miner for work it has folded in. That owed
+// total is off-chain accounting only (work-receipts.md: OWED is a ledger, never
+// an on-chain address). This drop adds the finality gate that turns owed into
+// paid: the overlay that earmarks a payout when a block is FOUND, and the
+// settlement that discharges it only once that block is FINAL.
+//
+// The core problem this solves is reorg safety on the payout side. A found
+// block is not yet permanent — the chain can reorg it away before it reaches
+// finality depth K. So a payout must not become irreversible the instant a
+// block is found; it must stay reversible until the block is as final as the
+// work that funded it. That is the SYMMETRIC finality-gate (the round-4/5
+// conceded fix): the payout side gates on the same finality depth K
+// (Geometry.FinalityDepthK) that seals the work side. Work becomes irreversible
+// at depth K; a payout becomes irreversible at depth K; neither sooner.
+//
+// The state is three integer ledgers over one identity space, and every
+// transition just moves weight between them, conserving the per-identity total:
+//
+//		accrued[id]  ==  owed[id] + pending[id] + settled[id]      (I-CONSERVE)
+//
+//	  - owed:    accrued work not yet earmarked to any live block payout.
+//	  - pending: earmarked to a found-but-not-final block's overlay; reversible.
+//	  - settled: paid out by a finalized block; irreversible.
+//
+// The three block transitions the m1 settlement state machine names map exactly
+// onto weight moves that leave I-CONSERVE invariant:
+//
+//	BlockFound     -> OverlayAdded      owed    -> pending   (earmark, reversible)
+//	BlockFinalized -> OwedSettled       pending -> settled   (+ OverlayCleared)
+//	BlockOrphaned  -> OverlayReverted   pending -> owed      (snapshot restore)
+//
+// Because Found only MOVES owed into a keyed overlay and Orphaned moves the
+// exact same weight back, a found→orphaned round trip restores the prior state
+// bit-for-bit — the digest returns identical (the KEYED_CRDT snapshot-revert
+// property). Multiple blocks can be pending at once (a fork with several
+// candidate tips); each overlay is keyed by block id and drawn from the shared
+// owed pool, so disjoint or sufficiently-funded found events compose
+// order-independently.
+//
+// Determinism is absolute, same mandate as buffer.go and compaction.go:
+// fixed-width integer serialization, integer add/sub, no floating point, no
+// wall-clock, no map iteration in any consensus-visible path (Digest sorts
+// identities and block ids before hashing). Nothing here is wired to
+// production — this is the Drop-3 prototype substrate only.
+package mrr
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"sort"
+)
+
+// ApplyResult is the disposition of one block transition. Exactly one applies;
+// like the buffer, the ledger never silently drops — a rejected or no-effect
+// transition is reported, not swallowed. On any non-mutating result the state
+// (and therefore the Digest) is left bit-identical.
+type ApplyResult uint8
+
+const (
+	// OverlayAdded: BlockFound accepted — the payout was earmarked owed->pending.
+	OverlayAdded ApplyResult = iota
+	// OwedSettled: BlockFinalized applied — pending->settled, overlay cleared.
+	OwedSettled
+	// OverlayReverted: BlockOrphaned applied — pending->owed, overlay reverted.
+	OverlayReverted
+	// NotFinal: Finalize called below finality depth K; the gate held, nothing
+	// moved (the payout stays reversible in the overlay).
+	NotFinal
+	// BlockKnown: BlockFound for a block id that is already pending; unchanged.
+	BlockKnown
+	// BlockUnknown: Finalize/Orphan of a block id that is not pending; unchanged.
+	BlockUnknown
+	// Overdraw: a found overlay would draw more than an identity's available
+	// owed; the whole transition is rejected atomically (nothing mutated).
+	Overdraw
+)
+
+func (r ApplyResult) String() string {
+	switch r {
+	case OverlayAdded:
+		return "overlay_added"
+	case OwedSettled:
+		return "owed_settled"
+	case OverlayReverted:
+		return "overlay_reverted"
+	case NotFinal:
+		return "not_final"
+	case BlockKnown:
+		return "block_known"
+	case BlockUnknown:
+		return "block_unknown"
+	case Overdraw:
+		return "overdraw"
+	default:
+		return "unknown"
+	}
+}
+
+// overlay is one found-but-not-final block's tentative payout: identity ->
+// amount earmarked from owed. Every amount is > 0 (zero payout entries fold to
+// nothing, exactly as a zero-weight Fold does), so an id is present iff it is
+// paid something by this block.
+type overlay struct {
+	amt map[uint64]uint64
+}
+
+func (o *overlay) total() uint64 {
+	var sum uint64
+	for _, a := range o.amt {
+		sum += a
+	}
+	return sum
+}
+
+// Settlement is the finality-gated owed/overlay ledger. The zero value is not
+// usable; construct with NewSettlement or NewSettlementFromLedger.
+type Settlement struct {
+	finalityK uint32              // K: depth at which a payout may settle (symmetric gate)
+	owed      map[uint64]uint64   // id -> accrued, un-earmarked (absent iff 0)
+	pending   map[uint64]*overlay // blockID -> reversible earmark (absent iff never found / cleared)
+	settled   map[uint64]uint64   // id -> paid-and-final (absent iff 0)
+}
+
+// NewSettlement returns an empty finality-gated ledger whose payout side seals
+// at depth finalityK — the same K (Geometry.FinalityDepthK) that seals the
+// work side, so the gate is symmetric.
+func NewSettlement(finalityK uint32) *Settlement {
+	return &Settlement{
+		finalityK: finalityK,
+		owed:      make(map[uint64]uint64),
+		pending:   make(map[uint64]*overlay),
+		settled:   make(map[uint64]uint64),
+	}
+}
+
+// NewSettlementFromLedger seeds owed from a compacted Drop-2 Ledger — the owed
+// base IS the self-carry accrued balance — without mutating or depending on the
+// Ledger's internals (it reads only the exported sorted Identities/Balance).
+func NewSettlementFromLedger(l *Ledger, finalityK uint32) *Settlement {
+	s := NewSettlement(finalityK)
+	for _, id := range l.Identities() {
+		s.owed[id] = l.Balance(id) // Balance is always > 0 for a listed id
+	}
+	return s
+}
+
+// Accrue folds work into the owed base (self-carry), mirroring Ledger.Fold: a
+// zero-weight accrual is a no-op that creates no phantom entry.
+func (s *Settlement) Accrue(id, weight uint64) {
+	if weight == 0 {
+		return
+	}
+	s.owed[id] += weight
+}
+
+// availableOwed is the ceiling a new found overlay may draw for an identity.
+// owed is decremented at BlockFound, so it already excludes every live earmark;
+// available owed is therefore just the current owed. Kept as a named method so
+// the guard (draw <= availableOwed) reads clearly at the call site.
+func (s *Settlement) availableOwed(id uint64) uint64 { return s.owed[id] }
+
+// BlockFound records a found block's tentative payout and earmarks it owed ->
+// pending (OverlayAdded). Validation is two-pass and atomic: if the block id is
+// already pending (BlockKnown) or any payout entry exceeds the identity's owed
+// (Overdraw), nothing is mutated. Zero-amount entries are skipped (no phantom
+// earmark), exactly as a zero-weight Fold creates no entry.
+func (s *Settlement) BlockFound(blockID uint64, payout []Contribution) ApplyResult {
+	if _, dup := s.pending[blockID]; dup {
+		return BlockKnown
+	}
+	// Pass 1: coalesce the payout per identity and validate against owed. A
+	// payout may name an identity twice; the earmark is the sum, and the sum is
+	// what must fit within owed.
+	want := make(map[uint64]uint64, len(payout))
+	for _, c := range payout {
+		if c.Weight == 0 {
+			continue
+		}
+		want[c.ID] += c.Weight
+	}
+	for id, a := range want {
+		if a > s.availableOwed(id) {
+			return Overdraw
+		}
+	}
+	// Pass 2: commit — move owed -> pending. Registers the block even if the
+	// coalesced payout is empty (a found block that pays nobody is still a
+	// tracked pending block, so a later Finalize/Orphan is well-defined).
+	o := &overlay{amt: make(map[uint64]uint64, len(want))}
+	for id, a := range want {
+		s.owed[id] -= a
+		if s.owed[id] == 0 {
+			delete(s.owed, id) // keep owed free of zero entries (canonical form)
+		}
+		o.amt[id] = a
+	}
+	s.pending[blockID] = o
+	return OverlayAdded
+}
+
+// Finalize applies BlockFinalized -> OwedSettled + OverlayCleared, but only if
+// the block has reached finality depth K (the symmetric gate). depth is the
+// block's confirmation depth on the active chain; depth < K holds the gate and
+// returns NotFinal with no mutation. At or past K, the earmarked overlay moves
+// pending -> settled and is cleared. An unknown (not pending) block is
+// BlockUnknown.
+func (s *Settlement) Finalize(blockID uint64, depth uint32) ApplyResult {
+	o, ok := s.pending[blockID]
+	if !ok {
+		return BlockUnknown
+	}
+	if depth < s.finalityK {
+		return NotFinal
+	}
+	for id, a := range o.amt {
+		s.settled[id] += a // a is always > 0
+	}
+	delete(s.pending, blockID)
+	return OwedSettled
+}
+
+// Orphan applies BlockOrphaned -> OverlayReverted: the reversible earmark moves
+// pending -> owed, exactly restoring the pre-found owed balances (snapshot
+// revert). An unknown (not pending) block is BlockUnknown. There is no depth
+// gate — an orphan can happen at any depth below K, which is precisely why the
+// payout was held reversible.
+func (s *Settlement) Orphan(blockID uint64) ApplyResult {
+	o, ok := s.pending[blockID]
+	if !ok {
+		return BlockUnknown
+	}
+	for id, a := range o.amt {
+		s.owed[id] += a // restore; a is always > 0
+	}
+	delete(s.pending, blockID)
+	return OverlayReverted
+}
+
+// Owed reports an identity's un-earmarked accrued balance.
+func (s *Settlement) Owed(id uint64) uint64 { return s.owed[id] }
+
+// Settled reports an identity's paid-and-final total.
+func (s *Settlement) Settled(id uint64) uint64 { return s.settled[id] }
+
+// Pending reports an identity's total currently earmarked across all found-but-
+// not-final blocks.
+func (s *Settlement) Pending(id uint64) uint64 {
+	var sum uint64
+	for _, o := range s.pending {
+		sum += o.amt[id]
+	}
+	return sum
+}
+
+// Accrued reports an identity's full carried work: owed + pending + settled.
+// I-CONSERVE holds this equal to everything ever accrued for the id, across
+// every transition.
+func (s *Settlement) Accrued(id uint64) uint64 {
+	return s.owed[id] + s.Pending(id) + s.settled[id]
+}
+
+// OwedTotal, PendingTotal, SettledTotal are the summed ledgers (deterministic).
+func (s *Settlement) OwedTotal() uint64    { return sumMap(s.owed) }
+func (s *Settlement) SettledTotal() uint64 { return sumMap(s.settled) }
+func (s *Settlement) PendingTotal() uint64 {
+	var sum uint64
+	for _, o := range s.pending {
+		sum += o.total()
+	}
+	return sum
+}
+
+// PendingBlocks is the count of currently found-but-not-final blocks.
+func (s *Settlement) PendingBlocks() int { return len(s.pending) }
+
+func sumMap(m map[uint64]uint64) uint64 {
+	var sum uint64
+	for _, v := range m {
+		sum += v
+	}
+	return sum
+}
+
+// sortedIDs returns a map's keys ascending — the canonical iteration order
+// (never range a map in a consensus-visible path).
+func sortedIDs(m map[uint64]uint64) []uint64 {
+	ids := make([]uint64, 0, len(m))
+	for id := range m {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
+}
+
+// Digest is the canonical SHA-256 commitment over the whole finality-gated
+// state: a header (finality K, the three section lengths), then the owed,
+// settled, and pending sections, each with ids/blocks in ascending order. The
+// header shape domain-separates this from the buffer and ledger digests (they
+// commit to different things and must never collide). Because Found only moves
+// owed into a keyed overlay and Orphan moves the identical weight back, a
+// found->orphaned round trip reproduces the exact prior digest.
+func (s *Settlement) Digest() Digest {
+	h := sha256.New()
+	var hdr [28]byte
+	binary.LittleEndian.PutUint32(hdr[0:4], s.finalityK)
+	binary.LittleEndian.PutUint64(hdr[4:12], uint64(len(s.owed)))
+	binary.LittleEndian.PutUint64(hdr[12:20], uint64(len(s.settled)))
+	binary.LittleEndian.PutUint64(hdr[20:28], uint64(len(s.pending)))
+	h.Write(hdr[:])
+
+	var rec [16]byte
+	writeSection := func(m map[uint64]uint64) {
+		for _, id := range sortedIDs(m) {
+			binary.LittleEndian.PutUint64(rec[0:8], id)
+			binary.LittleEndian.PutUint64(rec[8:16], m[id])
+			h.Write(rec[:])
+		}
+	}
+	writeSection(s.owed)
+	writeSection(s.settled)
+
+	// Pending: block ids ascending; each block writes its id + entry count, then
+	// its (id, amount) entries ascending.
+	blocks := make([]uint64, 0, len(s.pending))
+	for b := range s.pending {
+		blocks = append(blocks, b)
+	}
+	sort.Slice(blocks, func(i, j int) bool { return blocks[i] < blocks[j] })
+	var bhdr [16]byte
+	for _, b := range blocks {
+		o := s.pending[b]
+		binary.LittleEndian.PutUint64(bhdr[0:8], b)
+		binary.LittleEndian.PutUint64(bhdr[8:16], uint64(len(o.amt)))
+		h.Write(bhdr[:])
+		writeSection(o.amt)
+	}
+
+	var d Digest
+	copy(d[:], h.Sum(nil))
+	return d
+}

--- a/prototypes/libmrr/mrr/overlay_test.go
+++ b/prototypes/libmrr/mrr/overlay_test.go
@@ -1,0 +1,409 @@
+package mrr
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+// --- KAT-4 golden replay ---------------------------------------------------
+//
+// The finality-gated ledger must reproduce every pinned vector: the disposition,
+// owed/pending/settled totals, and canonical digest after each transition, the
+// hand-derived final owed/settled balances, and each snapshot-revert digest
+// pair. A change to any digest here is a change to the consensus-visible
+// settlement commitment and must be deliberate (regenerate with cmd/genkat4 and
+// review the diff).
+
+type katContribJSON struct {
+	ID     uint64 `json:"id"`
+	Weight uint64 `json:"weight"`
+}
+
+type katEvent struct {
+	Kind   string           `json:"kind"`
+	ID     uint64           `json:"id"`
+	Weight uint64           `json:"weight"`
+	Depth  uint32           `json:"depth"`
+	Payout []katContribJSON `json:"payout"`
+}
+
+type katOverlayStep struct {
+	Index        int    `json:"index"`
+	Result       string `json:"result"`
+	OwedTotal    uint64 `json:"owed_total"`
+	PendingTotal uint64 `json:"pending_total"`
+	SettledTotal uint64 `json:"settled_total"`
+	Digest       string `json:"digest_hex"`
+}
+
+type katOverlayBalance struct {
+	ID     uint64 `json:"id"`
+	Weight uint64 `json:"weight"`
+}
+
+type katOverlayScenario struct {
+	Name              string              `json:"name"`
+	FinalityK         uint32              `json:"finality_k"`
+	Events            []katEvent          `json:"events"`
+	Trace             []katOverlayStep    `json:"trace"`
+	WantOwed          []katOverlayBalance `json:"want_owed"`
+	WantSettled       []katOverlayBalance `json:"want_settled"`
+	WantOwedTotal     uint64              `json:"want_owed_total"`
+	WantPendingTotal  uint64              `json:"want_pending_total"`
+	WantSettledTotal  uint64              `json:"want_settled_total"`
+	AssertDigestEqual [][2]int            `json:"assert_digest_equal"`
+	FinalDigest       string              `json:"final_digest_hex"`
+}
+
+func loadKAT4(t *testing.T) []katOverlayScenario {
+	t.Helper()
+	b, err := os.ReadFile("testdata/kat4_overlay_vectors.json")
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	var scs []katOverlayScenario
+	if err := json.Unmarshal(b, &scs); err != nil {
+		t.Fatalf("parse golden: %v", err)
+	}
+	if len(scs) == 0 {
+		t.Fatal("no golden scenarios")
+	}
+	return scs
+}
+
+// applyEvent drives one golden event through s and returns its disposition
+// string, exactly as genkat4 does.
+func applyEvent(s *Settlement, e katEvent) string {
+	switch e.Kind {
+	case "accrue":
+		s.Accrue(e.ID, e.Weight)
+		return "accrued"
+	case "found":
+		p := make([]Contribution, len(e.Payout))
+		for i, c := range e.Payout {
+			p[i] = Contribution{ID: c.ID, Weight: c.Weight}
+		}
+		return s.BlockFound(e.ID, p).String()
+	case "finalize":
+		return s.Finalize(e.ID, e.Depth).String()
+	case "orphan":
+		return s.Orphan(e.ID).String()
+	default:
+		return "BAD_KIND:" + e.Kind
+	}
+}
+
+func TestKAT4_OverlayGolden(t *testing.T) {
+	for _, sc := range loadKAT4(t) {
+		sc := sc
+		t.Run(sc.Name, func(t *testing.T) {
+			if len(sc.Events) != len(sc.Trace) {
+				t.Fatalf("events/trace length mismatch: %d vs %d", len(sc.Events), len(sc.Trace))
+			}
+			s := NewSettlement(sc.FinalityK)
+			for i, e := range sc.Events {
+				res := applyEvent(s, e)
+				w := sc.Trace[i]
+				if res != w.Result {
+					t.Fatalf("step %d: result=%q, want %q", i, res, w.Result)
+				}
+				if s.OwedTotal() != w.OwedTotal || s.PendingTotal() != w.PendingTotal || s.SettledTotal() != w.SettledTotal {
+					t.Fatalf("step %d: totals owed=%d pending=%d settled=%d, want %d/%d/%d",
+						i, s.OwedTotal(), s.PendingTotal(), s.SettledTotal(),
+						w.OwedTotal, w.PendingTotal, w.SettledTotal)
+				}
+				d := s.Digest()
+				if got := hex.EncodeToString(d[:]); got != w.Digest {
+					t.Fatalf("step %d: digest\n got %s\nwant %s", i, got, w.Digest)
+				}
+			}
+
+			// Final hand-derived owed/settled sets (exact membership + amount).
+			if s.OwedTotal() != sc.WantOwedTotal || s.SettledTotal() != sc.WantSettledTotal || s.PendingTotal() != sc.WantPendingTotal {
+				t.Fatalf("final totals owed=%d pending=%d settled=%d, want %d/%d/%d",
+					s.OwedTotal(), s.PendingTotal(), s.SettledTotal(),
+					sc.WantOwedTotal, sc.WantPendingTotal, sc.WantSettledTotal)
+			}
+			for _, b := range sc.WantOwed {
+				if g := s.Owed(b.ID); g != b.Weight {
+					t.Fatalf("owed[%d]=%d, want %d", b.ID, g, b.Weight)
+				}
+			}
+			for _, b := range sc.WantSettled {
+				if g := s.Settled(b.ID); g != b.Weight {
+					t.Fatalf("settled[%d]=%d, want %d", b.ID, g, b.Weight)
+				}
+			}
+
+			// Snapshot-revert obligations declared in the golden.
+			for _, pair := range sc.AssertDigestEqual {
+				if sc.Trace[pair[0]].Digest != sc.Trace[pair[1]].Digest {
+					t.Fatalf("snapshot-revert failed: digest[%d] != digest[%d]", pair[0], pair[1])
+				}
+			}
+
+			d := s.Digest()
+			if got := hex.EncodeToString(d[:]); got != sc.FinalDigest {
+				t.Fatalf("final digest\n got %s\nwant %s", got, sc.FinalDigest)
+			}
+		})
+	}
+}
+
+// --- Property tests --------------------------------------------------------
+
+// Snapshot revert: a found->orphaned round trip restores the exact prior state,
+// bit-for-bit, at every point in an arbitrary event history. This is the
+// core reorg-safety property — no payout leaves a trace once its block is
+// orphaned.
+func TestSettlement_RevertRoundTrip(t *testing.T) {
+	s := NewSettlement(5)
+	s.Accrue(1, 30)
+	s.Accrue(2, 20)
+	s.Accrue(3, 10)
+	// Another block already pending, to prove the revert is independent of
+	// unrelated overlay state.
+	if r := s.BlockFound(900, []Contribution{{3, 10}}); r != OverlayAdded {
+		t.Fatalf("setup found: %s", r)
+	}
+	before := s.Digest()
+
+	if r := s.BlockFound(901, []Contribution{{1, 30}, {2, 15}}); r != OverlayAdded {
+		t.Fatalf("found 901: %s", r)
+	}
+	if s.Digest() == before {
+		t.Fatal("found did not change the digest")
+	}
+	if r := s.Orphan(901); r != OverlayReverted {
+		t.Fatalf("orphan 901: %s", r)
+	}
+	if s.Digest() != before {
+		t.Fatal("found->orphan did not restore the prior digest (snapshot revert violated)")
+	}
+	// Owed for the touched ids is exactly restored.
+	if s.Owed(1) != 30 || s.Owed(2) != 20 {
+		t.Fatalf("owed not restored: id1=%d id2=%d", s.Owed(1), s.Owed(2))
+	}
+}
+
+// Found-order commutativity: two blocks over disjoint identities found in either
+// order reach the identical digest — both while both are pending and after both
+// finalize. The keyed overlays draw from the shared owed pool without ordering
+// interference when they do not contend for the same id.
+func TestSettlement_FoundOrderCommutes(t *testing.T) {
+	build := func(firstA bool) *Settlement {
+		s := NewSettlement(2)
+		s.Accrue(1, 10)
+		s.Accrue(2, 10)
+		s.Accrue(3, 10)
+		s.Accrue(4, 10)
+		a := func() { s.BlockFound(500, []Contribution{{1, 10}, {2, 10}}) }
+		b := func() { s.BlockFound(501, []Contribution{{3, 10}, {4, 10}}) }
+		if firstA {
+			a()
+			b()
+		} else {
+			b()
+			a()
+		}
+		return s
+	}
+	ab, ba := build(true), build(false)
+	if ab.Digest() != ba.Digest() {
+		t.Fatal("found order changed the pending digest (commutativity violated)")
+	}
+	// Finalize both in opposite orders; end-state still agrees.
+	ab.Finalize(500, 2)
+	ab.Finalize(501, 2)
+	ba.Finalize(501, 2)
+	ba.Finalize(500, 2)
+	if ab.Digest() != ba.Digest() {
+		t.Fatal("finalize order changed the settled digest")
+	}
+	if ab.SettledTotal() != 40 || ab.OwedTotal() != 0 || ab.PendingTotal() != 0 {
+		t.Fatalf("unexpected end-state: owed=%d pending=%d settled=%d",
+			ab.OwedTotal(), ab.PendingTotal(), ab.SettledTotal())
+	}
+}
+
+// Symmetric finality gate: a payout may not settle before depth K. Finalize
+// below K is a no-op (NotFinal) that leaves the digest untouched and the overlay
+// reversible; at/above K it settles.
+func TestSettlement_SymmetricFinalityGate(t *testing.T) {
+	const K = 6
+	s := NewSettlement(K)
+	s.Accrue(1, 100)
+	s.BlockFound(1, []Contribution{{1, 100}})
+	pendingDigest := s.Digest()
+
+	for depth := uint32(0); depth < K; depth++ {
+		if r := s.Finalize(1, depth); r != NotFinal {
+			t.Fatalf("depth %d: result=%s, want not_final", depth, r)
+		}
+		if s.Digest() != pendingDigest {
+			t.Fatalf("depth %d: below-K finalize mutated state", depth)
+		}
+		if s.SettledTotal() != 0 {
+			t.Fatalf("depth %d: settled before finality", depth)
+		}
+		// Still reversible while the gate holds.
+	}
+	if r := s.Finalize(1, K); r != OwedSettled {
+		t.Fatalf("depth K: result=%s, want owed_settled", r)
+	}
+	if s.SettledTotal() != 100 || s.Settled(1) != 100 || s.PendingTotal() != 0 {
+		t.Fatalf("post-settle: settled=%d pending=%d", s.SettledTotal(), s.PendingTotal())
+	}
+}
+
+// I-CONSERVE: owed + pending + settled equals total accrued after every
+// transition, regardless of the event mix.
+func TestSettlement_Conservation(t *testing.T) {
+	s := NewSettlement(3)
+	type ev struct {
+		kind   string
+		id     uint64
+		w      uint64
+		depth  uint32
+		payout []Contribution
+	}
+	var accrued uint64
+	evs := []ev{
+		{kind: "accrue", id: 1, w: 50},
+		{kind: "accrue", id: 2, w: 40},
+		{kind: "found", id: 10, payout: []Contribution{{1, 50}, {2, 20}}},
+		{kind: "accrue", id: 2, w: 5},
+		{kind: "found", id: 11, payout: []Contribution{{2, 25}}},
+		{kind: "finalize", id: 10, depth: 3},
+		{kind: "orphan", id: 11},
+		{kind: "finalize", id: 11, depth: 9}, // unknown now -> no-op
+	}
+	for i, e := range evs {
+		switch e.kind {
+		case "accrue":
+			s.Accrue(e.id, e.w)
+			accrued += e.w
+		case "found":
+			s.BlockFound(e.id, e.payout)
+		case "finalize":
+			s.Finalize(e.id, e.depth)
+		case "orphan":
+			s.Orphan(e.id)
+		}
+		if got := s.OwedTotal() + s.PendingTotal() + s.SettledTotal(); got != accrued {
+			t.Fatalf("step %d (%s): conservation broke: sum=%d accrued=%d", i, e.kind, got, accrued)
+		}
+	}
+}
+
+// A found overlay may not draw more than an identity's owed; the whole
+// transition is rejected atomically and nothing is mutated.
+func TestSettlement_OverdrawRejectedAtomic(t *testing.T) {
+	s := NewSettlement(2)
+	s.Accrue(1, 10)
+	s.Accrue(2, 10)
+	before := s.Digest()
+	// id2 wants 11 but only 10 is owed -> Overdraw; id1's valid 10 must NOT be
+	// applied (atomic rejection).
+	if r := s.BlockFound(1, []Contribution{{1, 10}, {2, 11}}); r != Overdraw {
+		t.Fatalf("result=%s, want overdraw", r)
+	}
+	if s.Digest() != before {
+		t.Fatal("overdraw partially mutated state")
+	}
+	if s.Owed(1) != 10 || s.PendingBlocks() != 0 {
+		t.Fatalf("overdraw left residue: owed1=%d blocks=%d", s.Owed(1), s.PendingBlocks())
+	}
+}
+
+// Two overlays cannot double-spend the same owed: after the first draws it, the
+// second sees reduced availability and is rejected.
+func TestSettlement_NoDoubleSpendAcrossBlocks(t *testing.T) {
+	s := NewSettlement(2)
+	s.Accrue(1, 10)
+	if r := s.BlockFound(1, []Contribution{{1, 8}}); r != OverlayAdded {
+		t.Fatalf("first found: %s", r)
+	}
+	// Only 2 owed remains available; a second draw of 5 must be rejected.
+	if r := s.BlockFound(2, []Contribution{{1, 5}}); r != Overdraw {
+		t.Fatalf("second found: %s, want overdraw", r)
+	}
+	// A draw within the remainder succeeds.
+	if r := s.BlockFound(3, []Contribution{{1, 2}}); r != OverlayAdded {
+		t.Fatalf("third found: %s", r)
+	}
+	if s.Owed(1) != 0 || s.PendingTotal() != 10 {
+		t.Fatalf("owed=%d pending=%d, want 0/10", s.Owed(1), s.PendingTotal())
+	}
+}
+
+// The owed base seeds from a compacted Drop-2 Ledger (cross-link): the
+// Settlement's owed exactly equals the ledger's per-identity accrued balances.
+func TestSettlement_FromLedgerSeedsOwed(t *testing.T) {
+	l := Compact([]Contribution{{1, 5}, {2, 3}, {1, 7}, {3, 1}})
+	s := NewSettlementFromLedger(l, 4)
+	if s.OwedTotal() != l.Total() {
+		t.Fatalf("owed total %d != ledger total %d", s.OwedTotal(), l.Total())
+	}
+	for _, id := range l.Identities() {
+		if s.Owed(id) != l.Balance(id) {
+			t.Fatalf("owed[%d]=%d != balance %d", id, s.Owed(id), l.Balance(id))
+		}
+	}
+}
+
+// Duplicate found and unknown finalize/orphan are reported no-ops.
+func TestSettlement_KnownAndUnknownBlocks(t *testing.T) {
+	s := NewSettlement(2)
+	s.Accrue(1, 10)
+	if r := s.BlockFound(1, []Contribution{{1, 5}}); r != OverlayAdded {
+		t.Fatalf("found: %s", r)
+	}
+	before := s.Digest()
+	if r := s.BlockFound(1, []Contribution{{1, 1}}); r != BlockKnown {
+		t.Fatalf("dup found: %s, want block_known", r)
+	}
+	if r := s.Finalize(999, 9); r != BlockUnknown {
+		t.Fatalf("finalize unknown: %s, want block_unknown", r)
+	}
+	if r := s.Orphan(999); r != BlockUnknown {
+		t.Fatalf("orphan unknown: %s, want block_unknown", r)
+	}
+	if s.Digest() != before {
+		t.Fatal("a no-op transition mutated state")
+	}
+}
+
+// Two empty settlements hash equal; the digest changes once work is accrued.
+// Finality K is part of the commitment, so it separates otherwise-equal states.
+func TestSettlement_EmptyDigestStableAndKSeparated(t *testing.T) {
+	if NewSettlement(4).Digest() != NewSettlement(4).Digest() {
+		t.Fatal("two empty settlements must hash equal")
+	}
+	if NewSettlement(4).Digest() == NewSettlement(5).Digest() {
+		t.Fatal("different finality K must not collide")
+	}
+	s := NewSettlement(4)
+	empty := s.Digest()
+	s.Accrue(1, 1)
+	if s.Digest() == empty {
+		t.Fatal("digest must change after the first accrual")
+	}
+}
+
+// A zero-weight accrual is a no-op that creates no phantom owed entry.
+func TestSettlement_ZeroAccrueNoOp(t *testing.T) {
+	s := NewSettlement(3)
+	s.Accrue(1, 10)
+	before := s.Digest()
+	s.Accrue(2, 0)
+	s.Accrue(1, 0)
+	if s.Digest() != before {
+		t.Fatal("zero accrual changed the digest")
+	}
+	if s.Owed(2) != 0 || s.OwedTotal() != 10 {
+		t.Fatalf("zero accrual created residue: owed2=%d total=%d", s.Owed(2), s.OwedTotal())
+	}
+}

--- a/prototypes/libmrr/mrr/testdata/kat4_overlay_vectors.json
+++ b/prototypes/libmrr/mrr/testdata/kat4_overlay_vectors.json
@@ -1,0 +1,363 @@
+[
+  {
+    "name": "single_block_lifecycle",
+    "finality_k": 6,
+    "events": [
+      {
+        "kind": "accrue",
+        "id": 1,
+        "weight": 10
+      },
+      {
+        "kind": "accrue",
+        "id": 2,
+        "weight": 5
+      },
+      {
+        "kind": "accrue",
+        "id": 3,
+        "weight": 7
+      },
+      {
+        "kind": "found",
+        "id": 100,
+        "payout": [
+          {
+            "id": 1,
+            "weight": 10
+          },
+          {
+            "id": 2,
+            "weight": 5
+          },
+          {
+            "id": 4,
+            "weight": 0
+          }
+        ]
+      },
+      {
+        "kind": "finalize",
+        "id": 100,
+        "depth": 5
+      },
+      {
+        "kind": "finalize",
+        "id": 100,
+        "depth": 6
+      }
+    ],
+    "trace": [
+      {
+        "index": 0,
+        "result": "accrued",
+        "owed_total": 10,
+        "pending_total": 0,
+        "settled_total": 0,
+        "digest_hex": "09b3edefb48c335bcc54dbb4767ab4d999d2269a65cca9b297888b48ec555840"
+      },
+      {
+        "index": 1,
+        "result": "accrued",
+        "owed_total": 15,
+        "pending_total": 0,
+        "settled_total": 0,
+        "digest_hex": "b74cf6e985b1c6ebc8f77beb37996b3d8471814896d64e2320e35ba122d74ebc"
+      },
+      {
+        "index": 2,
+        "result": "accrued",
+        "owed_total": 22,
+        "pending_total": 0,
+        "settled_total": 0,
+        "digest_hex": "2d9c6a911da5ef590b29434e35af481177b5a552d34075afa778d4ff1e75f7f1"
+      },
+      {
+        "index": 3,
+        "result": "overlay_added",
+        "owed_total": 7,
+        "pending_total": 15,
+        "settled_total": 0,
+        "digest_hex": "f62a44e3110e5825bdb4218a3e0cd56f6b90bd1a06068e93df32abe091426764"
+      },
+      {
+        "index": 4,
+        "result": "not_final",
+        "owed_total": 7,
+        "pending_total": 15,
+        "settled_total": 0,
+        "digest_hex": "f62a44e3110e5825bdb4218a3e0cd56f6b90bd1a06068e93df32abe091426764"
+      },
+      {
+        "index": 5,
+        "result": "owed_settled",
+        "owed_total": 7,
+        "pending_total": 0,
+        "settled_total": 15,
+        "digest_hex": "6ed54bae0ebbb23332019939b4b6a475cb7c06fdfc5458d5439ff963c2a6ceb4"
+      }
+    ],
+    "want_owed": [
+      {
+        "id": 3,
+        "weight": 7
+      }
+    ],
+    "want_settled": [
+      {
+        "id": 1,
+        "weight": 10
+      },
+      {
+        "id": 2,
+        "weight": 5
+      }
+    ],
+    "want_owed_total": 7,
+    "want_pending_total": 0,
+    "want_settled_total": 15,
+    "final_digest_hex": "6ed54bae0ebbb23332019939b4b6a475cb7c06fdfc5458d5439ff963c2a6ceb4"
+  },
+  {
+    "name": "reorg_revert_roundtrip",
+    "finality_k": 4,
+    "events": [
+      {
+        "kind": "accrue",
+        "id": 7,
+        "weight": 20
+      },
+      {
+        "kind": "accrue",
+        "id": 8,
+        "weight": 13
+      },
+      {
+        "kind": "found",
+        "id": 200,
+        "payout": [
+          {
+            "id": 7,
+            "weight": 20
+          },
+          {
+            "id": 8,
+            "weight": 13
+          }
+        ]
+      },
+      {
+        "kind": "orphan",
+        "id": 200
+      }
+    ],
+    "trace": [
+      {
+        "index": 0,
+        "result": "accrued",
+        "owed_total": 20,
+        "pending_total": 0,
+        "settled_total": 0,
+        "digest_hex": "77c5480d5631424ee48b4f2ccd7d1fe92f19c65ab09ce5167685a787877ece78"
+      },
+      {
+        "index": 1,
+        "result": "accrued",
+        "owed_total": 33,
+        "pending_total": 0,
+        "settled_total": 0,
+        "digest_hex": "2a5aefaee45d41c09b2eb6a7730a91bc8a96d665181b0ed879b17f7672a9ef5e"
+      },
+      {
+        "index": 2,
+        "result": "overlay_added",
+        "owed_total": 0,
+        "pending_total": 33,
+        "settled_total": 0,
+        "digest_hex": "98da2d699b744fb443a06b4c43f2b74a1b09752d785469aeab6e0aef139db7d3"
+      },
+      {
+        "index": 3,
+        "result": "overlay_reverted",
+        "owed_total": 33,
+        "pending_total": 0,
+        "settled_total": 0,
+        "digest_hex": "2a5aefaee45d41c09b2eb6a7730a91bc8a96d665181b0ed879b17f7672a9ef5e"
+      }
+    ],
+    "want_owed": [
+      {
+        "id": 7,
+        "weight": 20
+      },
+      {
+        "id": 8,
+        "weight": 13
+      }
+    ],
+    "want_settled": null,
+    "want_owed_total": 33,
+    "want_pending_total": 0,
+    "want_settled_total": 0,
+    "assert_digest_equal": [
+      [
+        1,
+        3
+      ]
+    ],
+    "final_digest_hex": "2a5aefaee45d41c09b2eb6a7730a91bc8a96d665181b0ed879b17f7672a9ef5e"
+  },
+  {
+    "name": "concurrent_two_blocks_split_outcome",
+    "finality_k": 3,
+    "events": [
+      {
+        "kind": "accrue",
+        "id": 1,
+        "weight": 8
+      },
+      {
+        "kind": "accrue",
+        "id": 2,
+        "weight": 8
+      },
+      {
+        "kind": "accrue",
+        "id": 3,
+        "weight": 8
+      },
+      {
+        "kind": "accrue",
+        "id": 4,
+        "weight": 8
+      },
+      {
+        "kind": "found",
+        "id": 300,
+        "payout": [
+          {
+            "id": 1,
+            "weight": 8
+          },
+          {
+            "id": 2,
+            "weight": 8
+          }
+        ]
+      },
+      {
+        "kind": "found",
+        "id": 301,
+        "payout": [
+          {
+            "id": 3,
+            "weight": 8
+          },
+          {
+            "id": 4,
+            "weight": 8
+          }
+        ]
+      },
+      {
+        "kind": "finalize",
+        "id": 300,
+        "depth": 3
+      },
+      {
+        "kind": "orphan",
+        "id": 301
+      }
+    ],
+    "trace": [
+      {
+        "index": 0,
+        "result": "accrued",
+        "owed_total": 8,
+        "pending_total": 0,
+        "settled_total": 0,
+        "digest_hex": "93e3c3ed97af657e74e865fb34f42f9f79930478fe02c04cdc4e2e2d59aefe6c"
+      },
+      {
+        "index": 1,
+        "result": "accrued",
+        "owed_total": 16,
+        "pending_total": 0,
+        "settled_total": 0,
+        "digest_hex": "9a1abbfd29713ee67f845b84852196079299c5f1e2c406067d838ea6c8a5b856"
+      },
+      {
+        "index": 2,
+        "result": "accrued",
+        "owed_total": 24,
+        "pending_total": 0,
+        "settled_total": 0,
+        "digest_hex": "1f54b77a9b5e0c5528f92e6fe2ba92648773a7484bba021e2fdc22bc59485c26"
+      },
+      {
+        "index": 3,
+        "result": "accrued",
+        "owed_total": 32,
+        "pending_total": 0,
+        "settled_total": 0,
+        "digest_hex": "fe5aab2ac45581438f1d125d7ec8aae65a5ad9e7621a0a13e0daaaedd6630803"
+      },
+      {
+        "index": 4,
+        "result": "overlay_added",
+        "owed_total": 16,
+        "pending_total": 16,
+        "settled_total": 0,
+        "digest_hex": "bd66039707c9fcf24c456b891291b2c053baaae5f1380ea346feba0477f2b399"
+      },
+      {
+        "index": 5,
+        "result": "overlay_added",
+        "owed_total": 0,
+        "pending_total": 32,
+        "settled_total": 0,
+        "digest_hex": "c126ae30d8f5736e2f33e0c15b344a753daacc701859149c3910a07f20387c7d"
+      },
+      {
+        "index": 6,
+        "result": "owed_settled",
+        "owed_total": 0,
+        "pending_total": 16,
+        "settled_total": 16,
+        "digest_hex": "c56a8f0f8479f906fb4a1b13ef7058eb6eda9a8aecac61a2a116f01aea065200"
+      },
+      {
+        "index": 7,
+        "result": "overlay_reverted",
+        "owed_total": 16,
+        "pending_total": 0,
+        "settled_total": 16,
+        "digest_hex": "d47e5955559899d3d888ded18c95b267954b6fd172b45e6d135655cdb0363c40"
+      }
+    ],
+    "want_owed": [
+      {
+        "id": 3,
+        "weight": 8
+      },
+      {
+        "id": 4,
+        "weight": 8
+      }
+    ],
+    "want_settled": [
+      {
+        "id": 1,
+        "weight": 8
+      },
+      {
+        "id": 2,
+        "weight": 8
+      }
+    ],
+    "want_owed_total": 16,
+    "want_pending_total": 0,
+    "want_settled_total": 16,
+    "final_digest_hex": "d47e5955559899d3d888ded18c95b267954b6fd172b45e6d135655cdb0363c40"
+  }
+]


### PR DESCRIPTION
## What

Drop 3 of the libmrr V37 prototype line: `mrr.Settlement` (`prototypes/libmrr/mrr/overlay.go`) — the finality gate that turns owed work into paid work, built additively on the Drop-2 owed base. Prototype/research only; no production wiring.

## Model

Three integer ledgers over one identity space with the conservation invariant `accrued == owed + pending + settled` (**I-CONSERVE**) held across every transition:

- `owed` — accrued, un-earmarked (the Drop-2 self-carry base)
- `pending` — earmarked to a found-but-not-final block overlay (reversible)
- `settled` — paid by a finalized block (irreversible)

The three m1 settlement-machine block transitions are weight moves that leave I-CONSERVE invariant:

| transition | effect |
|---|---|
| `BlockFound → OverlayAdded` | owed → pending (earmark, reversible) |
| `BlockFinalized → OwedSettled + OverlayCleared` | pending → settled |
| `BlockOrphaned → OverlayReverted` | pending → owed (snapshot restore) |

`Finalize(blockID, depth)` is the **symmetric payout-side finality-gate** (round-4/5 conceded fix): a payout cannot settle below `finalityK` (the same `Geometry.FinalityDepthK` that seals the work side) — `depth < K` returns `NotFinal` and moves nothing.

## Properties pinned (tests)

- **Snapshot revert** — a found→orphaned round trip restores the prior digest bit-for-bit (reorg safety).
- **Found-order commutativity** over disjoint identities.
- **No overdraw / no double-spend** — a found overlay cannot draw more than an identity's owed; rejected atomically.
- **Symmetric gate** — settle blocked below K.
- Owed base seeds from a Drop-2 `Ledger` via its exported accessors; **Drop 2 is untouched**.

KAT-4 golden vectors (`kat4_overlay_vectors.json`, 3 scenarios) pin per-step disposition/totals/digest + hand-derived final balances; `cmd/genkat4` asserts I-CONSERVE and the snapshot-revert pairs before it will mint. KAT-4 golden is regeneration-deterministic (identical hash across repeated runs).

## MUST-NOTs honored

- KAT-1/2/3 golden hashes **bit-identical** (additive only — those files are not in the diff).
- **Zero production call sites** — referenced only by its own tests and `cmd/genkat4`.
- Diff **confined to `prototypes/libmrr`**.

## Base

Off `v37-dev` @ `86c46bba` (Drop-2 tip). PR targets **v37-dev**, not master. Merge-cp into master is a separate later ask.
