### PR TITLE
ci(windows): glob libsecp256k1-*.dll copies to survive upstream SONAME bumps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1193,7 +1193,8 @@ jobs:
 
       - name: Verify binary
         run: |
-          Copy-Item "${env:GITHUB_WORKSPACE}/secp256k1/bin/libsecp256k1-6.dll" build_ci/src/c2pool/Release/
+          # SONAME-agnostic glob: upstream bumps libsecp256k1-N.dll (6->7 etc). Do NOT re-pin a number.
+          Copy-Item "${env:GITHUB_WORKSPACE}/secp256k1/bin/libsecp256k1-*.dll" build_ci/src/c2pool/Release/
           # Run the binary to completion and capture its output BEFORE slicing.
           # Piping straight into `Select-Object -First 3` closes the pipe after 3
           # lines while c2pool.exe is still writing its banner, so the next stdout
@@ -1214,8 +1215,9 @@ jobs:
           Copy-Item build_ci/src/c2pool/Release/c2pool.exe "${PKG}/"
           # DLL must be next to exe for Windows DLL search path (portable ZIP)
           # Also copy to lib/ for Inno Setup installer compatibility
-          Copy-Item "${env:GITHUB_WORKSPACE}/secp256k1/bin/libsecp256k1-6.dll" "${PKG}/"
-          Copy-Item "${env:GITHUB_WORKSPACE}/secp256k1/bin/libsecp256k1-6.dll" "${PKG}/lib/"
+          # SONAME-agnostic glob: upstream bumps libsecp256k1-N.dll (6->7 etc). Do NOT re-pin a number.
+          Copy-Item "${env:GITHUB_WORKSPACE}/secp256k1/bin/libsecp256k1-*.dll" "${PKG}/"
+          Copy-Item "${env:GITHUB_WORKSPACE}/secp256k1/bin/libsecp256k1-*.dll" "${PKG}/lib/"
           Copy-Item start.bat "${PKG}/"
           Copy-Item -Recurse web-static/* "${PKG}/web-static/"
           Copy-Item explorer/explorer.py "${PKG}/explorer/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -636,7 +636,8 @@ jobs:
       - name: Smoke test (--help)
         if: steps.presence.outputs.exists == '1'
         run: |
-          Copy-Item "${env:GITHUB_WORKSPACE}/secp256k1/bin/libsecp256k1-6.dll" build_ci/src/c2pool/Release/
+          # SONAME-agnostic glob: upstream bumps libsecp256k1-N.dll (6->7 etc). Do NOT re-pin a number.
+          Copy-Item "${env:GITHUB_WORKSPACE}/secp256k1/bin/libsecp256k1-*.dll" build_ci/src/c2pool/Release/
           $ErrorActionPreference = 'SilentlyContinue'
           # --help writes usage to stderr; buffer first so Select-Object truncation
           # cannot break the pipe and surface a NativeCommandError (false red).
@@ -654,8 +655,9 @@ jobs:
           Copy-Item "build_ci/src/c2pool/Release/c2pool-${COIN}.exe" "${PKG}/"
           # DLL must be next to exe for Windows DLL search path (portable ZIP)
           # Also copy to lib/ for Inno Setup installer compatibility
-          Copy-Item "${env:GITHUB_WORKSPACE}/secp256k1/bin/libsecp256k1-6.dll" "${PKG}/"
-          Copy-Item "${env:GITHUB_WORKSPACE}/secp256k1/bin/libsecp256k1-6.dll" "${PKG}/lib/"
+          # SONAME-agnostic glob: upstream bumps libsecp256k1-N.dll (6->7 etc). Do NOT re-pin a number.
+          Copy-Item "${env:GITHUB_WORKSPACE}/secp256k1/bin/libsecp256k1-*.dll" "${PKG}/"
+          Copy-Item "${env:GITHUB_WORKSPACE}/secp256k1/bin/libsecp256k1-*.dll" "${PKG}/lib/"
           Copy-Item start.bat "${PKG}/"
           Copy-Item -Recurse web-static/* "${PKG}/web-static/"
           Copy-Item explorer/explorer.py "${PKG}/explorer/"


### PR DESCRIPTION
## Problem
Windows x86_64 is broken repo-wide (master + every open PR), not a flake. The secp256k1 clone (build.yml:1175 / release.yml:599) is `git clone --depth 1` at upstream HEAD; upstream bumped the shared-lib SONAME 6 -> 7, so the runner now emits `libsecp256k1-7.dll`. The Verify/Smoke and Package steps hardcode `Copy-Item .../libsecp256k1-6.dll`, which no longer exists -> `Cannot find path` -> exit 1. Same three copies in each of build.yml and release.yml.

## Fix (option b — SONAME-agnostic)
Generalize all six copies to a `libsecp256k1-*.dll` glob so a future SONAME bump copies whatever the build produced, and add a comment forbidding re-pinning a number. Closes the recurrence class release.yml:223 already flags for the Linux `.so.2`-vs-`.so.1` DOA — now on Windows.

- build.yml: Verify binary + Package release (3 copies)
- release.yml: Smoke test + Package (3 copies)
- No workflow references a hardcoded SONAME number afterward.

## Acceptance
Master Windows x86_64 job green; both files free of a hardcoded SONAME. Unblocks dgb-scrypt-steward #1067 (green on merits, red only on this).