### PR TITLE
dash: acquire ChainLocks over p2p and BLS-verify before adopting them

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,7 +189,7 @@ jobs:
                     core_test sharechain_test share_test btc_share_test \
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
-                    test_doge_chain test_compact_blocks test_dash_x11_kat test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_underfill_guard test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer test_dash_embedded_relay_e2e test_dash_block_relay_plan test_dash_version_activation_latch test_dash_block_relay_binding test_dash_block_relay_dual_arm test_dash_coinbase_parity test_dash_coinbase_muldiv test_dash_donation_combined test_dash_g3_assembled test_dash_work_target test_dash_work_job_targets test_dash_stratum_binding test_dash_job_notify_roundtrip test_dash_cb_payee test_dash_stratum_notify_roundtrip test_dash_poolnode_messages test_dash_peer test_dash_share_tracker test_dash_node test_dash_share_messages test_dash_stratum_extranonce_split test_dash_stratum_submit_reassembly test_dash_difficulty_parity test_dash_auto_ratchet test_dash_min_protocol_gate test_dash_work_source test_dash_node_coin_state test_dash_coin_state_maintainer test_dash_node_embedded_wire test_dash_node_reception_wire test_dash_get_work test_dash_stratum_work_source test_dash_superblock test_dash_oracle_byte_parity \
+                    test_doge_chain test_compact_blocks test_dash_x11_kat test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_underfill_guard test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer test_dash_embedded_relay_e2e test_dash_block_relay_plan test_dash_version_activation_latch test_dash_block_relay_binding test_dash_block_relay_dual_arm test_dash_coinbase_parity test_dash_coinbase_muldiv test_dash_donation_combined test_dash_g3_assembled test_dash_work_target test_dash_work_job_targets test_dash_stratum_binding test_dash_job_notify_roundtrip test_dash_cb_payee test_dash_stratum_notify_roundtrip test_dash_poolnode_messages test_dash_peer test_dash_share_tracker test_dash_node test_dash_share_messages test_dash_stratum_extranonce_split test_dash_stratum_submit_reassembly test_dash_difficulty_parity test_dash_auto_ratchet test_dash_min_protocol_gate test_dash_work_source test_dash_node_coin_state test_dash_coin_state_maintainer test_dash_node_embedded_wire test_dash_node_reception_wire test_dash_get_work test_dash_stratum_work_source test_dash_superblock test_dash_oracle_byte_parity test_dash_chainlock_verify \
                     test_multiaddress_pplns test_pplns_stress \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
@@ -381,7 +381,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_underfill_guard test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer test_dash_embedded_relay_e2e test_dash_block_relay_plan test_dash_version_activation_latch test_dash_block_relay_binding test_dash_block_relay_dual_arm test_dash_coinbase_parity test_dash_coinbase_muldiv test_dash_donation_combined test_dash_g3_assembled test_dash_work_target test_dash_work_job_targets test_dash_stratum_binding test_dash_job_notify_roundtrip test_dash_cb_payee test_dash_stratum_notify_roundtrip test_dash_poolnode_messages test_dash_peer test_dash_share_tracker test_dash_node test_dash_share_messages test_dash_stratum_extranonce_split test_dash_stratum_submit_reassembly test_dash_difficulty_parity test_dash_auto_ratchet test_dash_min_protocol_gate test_dash_work_source test_dash_node_coin_state test_dash_coin_state_maintainer test_dash_node_embedded_wire test_dash_node_reception_wire test_dash_get_work test_dash_stratum_work_source test_dash_superblock test_dash_oracle_byte_parity \
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_underfill_guard test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer test_dash_embedded_relay_e2e test_dash_block_relay_plan test_dash_version_activation_latch test_dash_block_relay_binding test_dash_block_relay_dual_arm test_dash_coinbase_parity test_dash_coinbase_muldiv test_dash_donation_combined test_dash_g3_assembled test_dash_work_target test_dash_work_job_targets test_dash_stratum_binding test_dash_job_notify_roundtrip test_dash_cb_payee test_dash_stratum_notify_roundtrip test_dash_poolnode_messages test_dash_peer test_dash_share_tracker test_dash_node test_dash_share_messages test_dash_stratum_extranonce_split test_dash_stratum_submit_reassembly test_dash_difficulty_parity test_dash_auto_ratchet test_dash_min_protocol_gate test_dash_work_source test_dash_node_coin_state test_dash_coin_state_maintainer test_dash_node_embedded_wire test_dash_node_reception_wire test_dash_get_work test_dash_stratum_work_source test_dash_superblock test_dash_oracle_byte_parity test_dash_chainlock_verify \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
                     test_v36_script_sorting test_v36_cross_impl_refhash \
@@ -1438,6 +1438,7 @@ jobs:
             --target c2pool-dash \
                      test_dash_bls_verify test_dash_quorum_members \
                      test_dash_quorum_member_source test_dash_govvote_bls \
+                     test_dash_chainlock_verify \
             -j8
 
       # LEG 2: the artefact itself carries the dashbls backend.
@@ -1446,7 +1447,7 @@ jobs:
 
       - name: Run BLS KATs
         working-directory: build_dash_bls
-        run: ctest --output-on-failure -j8 -R 'DashBlsVerify|DashQuorumMembers|DashQuorumMemberSource|DashGovVoteBLS'
+        run: ctest --output-on-failure -j8 -R 'DashBlsVerify|DashQuorumMembers|DashQuorumMemberSource|DashGovVoteBLS|DashChainLockVerify'
 
       # LEG 3: the BLS-ONLY cases actually ran. Each of these is inside
       # #ifdef C2POOL_DASH_BLS, so on a stub build they do not fail -- they
@@ -1458,8 +1459,9 @@ jobs:
           # `|| true`: pass/fail is already gated by the ctest step above. Here
           # the only question is which cases EXIST, so a non-zero exit must not
           # abort before the per-case report below is printed.
-          ./test/test_dash_bls_verify     > bls_kat.log 2>&1 || true
-          ./test/test_dash_quorum_members >> bls_kat.log 2>&1 || true
+          ./test/test_dash_bls_verify        > bls_kat.log 2>&1 || true
+          ./test/test_dash_quorum_members    >> bls_kat.log 2>&1 || true
+          ./test/test_dash_chainlock_verify  >> bls_kat.log 2>&1 || true
           log="$(cat bls_kat.log)"
           missing=0
           for t in \
@@ -1468,7 +1470,13 @@ jobs:
             DashBlsVerify.VerifyFinalCommitmentSyntheticRoundTrip \
             DashQuorumMembers.RealCommitmentVerifiesWithComputedMembers \
             DashQuorumMembers.RealPlatformCommitmentVerifiesWithEvoOnlyMembers \
-            DashQuorumMembers.PartialSignersAndValidMembers
+            DashQuorumMembers.PartialSignersAndValidMembers \
+            DashChainLockVerify.RealChainLockVerifies \
+            DashChainLockVerify.TamperedSignatureIsRejected \
+            DashChainLockVerify.ForgedSignatureIsRejected \
+            DashChainLockVerify.InternallyValidSignatureFromWrongQuorumIsRejected \
+            DashChainLockVerify.WrongQuorumKeyIsRejected \
+            DashChainLockVerify.RejectedWhenSigningQuorumIsMissingFromTheSet
           do
             # Pure-shell match, not `grep -q` in a pipeline: under pipefail a
             # `grep -q` that matches SIGPIPEs its producer and the pipeline

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -66,6 +66,7 @@
 #include <impl/dash/coin/dkg_window.hpp>       // dash::coin::is_dkg_commitment_window (BLOCKER-1 guard)
 #include <impl/dash/coin/dkg_commitments.hpp>  // E1: build_daemonless_qc_plan (serve DKG windows daemonlessly)
 #include <impl/dash/coin/vendor/bls_verify.hpp>  // E1 Phase-L: make_commitment_bls_verifier (real qc verify seam)
+#include <impl/dash/coin/chainlock_verify.hpp>   // live-path ChainLock quorum selection + BLS verify gate
 #include <impl/dash/coin/llmq_type_reconciler.hpp>  // negative-capable enabled_llmqs backstop
 #include <impl/dash/coin/quorum_member_source.hpp>  // E1 Phase-L: daemonless member-set sourcing (the provider)
 #include <impl/dash/coin/utxo_lane.hpp>    // dash::coin::UtxoLane — embedded UTXO/fee lane (E2b, #738)
@@ -3470,15 +3471,67 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 if (cp) cp->send_getmnlistd(uint256::ZERO, tip);
             });
 
+        // ChainLock verifier: BLS-verify a relayed clsig against the quorum
+        // dashcore's SelectQuorumForSigning says must have signed it, before
+        // the maintainer may adopt its height as the CCbTx bestCL*. Candidate
+        // quorums come from the mnlistdiff-sourced active set (llmqTypeChainLocks
+        // = LLMQ_400_60 on mainnet, LLMQ_50_60 on testnet); each quorumHash is
+        // itself a block hash, so the header chain supplies its base height.
+        // Fail-closed at every step — see chainlock_verify.hpp.
+        maintainer->set_chainlock_verify_fn(
+            [st = &node_coin_state, hc = header_chain.get(),
+             net = (testnet ? dash::coin::LlmqNetwork::Testnet
+                            : dash::coin::LlmqNetwork::Mainnet)](
+                int32_t height, const uint256& block_hash,
+                const std::array<uint8_t, 96>& sig) -> bool {
+                const auto* p = dash::coin::chainlock::chainlock_params(net);
+                if (p == nullptr) return false;
+
+                // Never adopt a ChainLock ABOVE our own header tip. Adoption is
+                // monotonic, and embedded_gbt.hpp:496-503 clears bestCLHeightDiff
+                // /bestCLSignature entirely whenever best_cl_height exceeds the
+                // height we are building on — so adopting an over-tip ChainLock
+                // would pin the CCbTx bestCL* fields to ZERO (diverging from
+                // dashd, which would commit a real diff) until our tip caught up,
+                // and we could never fall back to the older usable value. Holding
+                // the previous ChainLock is strictly better. Self-correcting:
+                // dashd re-announces its best ChainLock roughly every block.
+                // This also bounds BLS work on a peer replaying junk heights.
+                auto tip = hc->tip();
+                if (!tip || height > static_cast<int32_t>(tip->height)) return false;
+
+                // Collect the active quorums of the ChainLock-signing type,
+                // each with the height of its base block (the quorumHash IS a
+                // block hash, so the header chain resolves it directly — the
+                // same lookup QuorumMemberSource's HeightOfHash seam uses).
+                std::vector<dash::coin::chainlock::QuorumCandidate> cands;
+                for (const auto& e : st->qmgr().active_entries()) {
+                    if (e.key.llmqType != p->type) continue;
+                    auto hdr = hc->get_header(e.key.quorumHash);
+                    if (!hdr) continue;          // base header not held => skip
+                    dash::coin::chainlock::QuorumCandidate c;
+                    c.quorum_hash        = e.key.quorumHash;
+                    c.base_height        = hdr->height;
+                    c.quorum_public_key  = e.commitment.quorumPublicKey;
+                    cands.push_back(c);
+                }
+                auto target = dash::coin::chainlock::build_sign_target(
+                    *p, std::move(cands), height, block_hash);
+                if (!target) return false;       // no quorum selectable => fail closed
+                return dash::coin::vendor::verify_chainlock_sig(
+                    target->quorum.quorum_public_key, target->sign_hash, sig);
+            });
+
         // Leg 6 (ChainLock sig): Node::new_chainlock_sig -> maintainer
         // .on_new_chainlock. The clsig message carries the recovered 96-byte
         // threshold sig (new_chainlock above drops it); the maintainer adopts
-        // the freshest observed ChainLock height+sig as the CCbTx bestCL*.
+        // the freshest observed ChainLock height+sig as the CCbTx bestCL*
+        // ONLY IF the verifier above accepts it.
         coin_feed_subs.push_back(
             coin_state.new_chainlock_sig.subscribe(
                 [m = maintainer.get()]
                 (const dash::interfaces::Node::ChainLockSigEvent& c) {
-                    m->on_new_chainlock(c.height, c.sig);
+                    m->on_new_chainlock(c.height, c.block_hash, c.sig);
                 }));
 
         // Bridge: new_headers -> HeaderChain::add_headers (X11 PoW + DGW

--- a/src/impl/bitcoin_family/coin/base_p2p_messages.hpp
+++ b/src/impl/bitcoin_family/coin/base_p2p_messages.hpp
@@ -113,6 +113,10 @@ struct inventory_type
         filtered_block  = 3,
         cmpct_block     = 4,
         wtx             = 5,            // MSG_WTX (BIP 339)
+        // Dash-specific getdata/inv types (dashcore src/protocol.h:495-524,
+        // enum GetDataMsg). Only the ones we actually request are listed.
+        quorum_final_commitment = 21,   // MSG_QUORUM_FINAL_COMMITMENT
+        clsig           = 29,           // MSG_CLSIG (dashcore protocol.h:522)
         witness_tx      = 0x40000001,   // MSG_WITNESS_TX (BIP 144)
         witness_block   = 0x40000002,   // MSG_WITNESS_BLOCK (BIP 144)
     };

--- a/src/impl/dash/coin/chainlock_verify.hpp
+++ b/src/impl/dash/coin/chainlock_verify.hpp
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// Live-path ChainLock verification — the gate a clsig MUST pass before its
+/// height may move `best_cl_height`.
+///
+/// WHY THIS EXISTS. The daemonless CCbTx path commits bestCLHeightDiff /
+/// bestCLSignature. Until this file existed, the only live writer of
+/// best_cl_height was the LAGGING derivation from a block's already-committed
+/// bestCLHeightDiff (coin_state_maintainer.hpp) — our template freshness was
+/// coupled to whatever ChainLock some OTHER miner's node happened to hold. The
+/// clsig p2p message carries a fresher ChainLock directly, but adopting one
+/// unverified would let a hostile peer feed a bogus (height, blockHash, sig)
+/// triple straight into the coinbase we mine — a template we cannot justify,
+/// and a lost block. An unverified fetch is WORSE than the lagging derivation,
+/// because the lagging value is at least chain-committed. So: acquisition and
+/// verification land together, and adoption is gated on verification.
+///
+/// REUSE-FIRST (operator mandate — mirror Dash Core, do not invent). Every step
+/// below is dashcore v23.1.7, cited at the line it came from:
+///
+///   requestId = SerializeHash(make_pair("clsig"sv, nHeight))
+///               -- src/chainlock/clsig.cpp:29-32 (GenSigRequestId), with
+///                  CLSIG_REQUESTID_PREFIX at :12. SerializeHash is
+///                  CHashWriter(SER_GETHASH, PROTOCOL_VERSION) + GetHash()
+///                  (SHA256d) -- src/hash.h:231-236. A string_view serializes
+///                  as CompactSize(len) + bytes, so the preimage is exactly
+///                  0x05 "clsig" int32LE(nHeight) -- 10 bytes.
+///
+///   quorum    = SelectQuorumForSigning(params, chain, qman, requestId,
+///                                      signHeight = clsig.nHeight, offset = 8)
+///               -- src/llmq/quorumsman.cpp:676-737, SIGN_HEIGHT_OFFSET at
+///                  src/llmq/quorumsman.h:184. Non-rotated branch (:718-735):
+///                  score each of the signingActiveQuorumCount newest quorums
+///                  with CHashWriter(SER_NETWORK,0) << llmqType << quorumHash
+///                  << selectionHash, sort ASCENDING, take the LOWEST.
+///
+///   signHash  = SHA256d(u8(llmqType) || quorumHash || requestId || msgHash)
+///               -- src/llmq/signhash.cpp:14-22 (SignHash ctor, formerly
+///                  BuildSignHash). msgHash is the ChainLock's blockHash
+///                  -- src/chainlock/handler.cpp:330-333 (VerifyChainLock).
+///
+///   verify    = sig.VerifyInsecure(quorum.quorumPublicKey, signHash)
+///               -- src/llmq/quorumsman.cpp:749-751. VerifyInsecure is
+///                  Scheme(legacy)->Verify(pk, hash_bytes, sig)
+///                  -- src/bls/bls.cpp:294-310; post-V19 the scheme is
+///                  BasicSchemeMPL (bls_legacy_scheme flipped false at V19
+///                  activation, src/evo/specialtxman.cpp). The 32 signHash
+///                  bytes are the MESSAGE; the scheme's own hash-to-curve
+///                  (DST "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_") is
+///                  applied to them -- do NOT pre-hash again.
+///
+///   llmqTypeChainLocks: mainnet LLMQ_400_60 (=2), testnet LLMQ_50_60 (=1)
+///               -- src/chainparams.cpp:274 / :467.
+///
+/// ⚠ ORDERING TRAP (locked by a real-vector KAT). dashcore sorts the selection
+/// scores with uint256::operator<, which for its base_blob is
+/// memcmp(m_data, ...) -- LEAST-significant byte first (src/uint256.h:55).
+/// c2pool's uint256 is base_uint<256>, an ARITHMETIC bignum whose operator<
+/// is CompareTo -- MOST-significant word first (core/uint256.cpp:122-131).
+/// The two orderings DISAGREE, and on the real mainnet vector in
+/// test_dash_chainlock_verify.cpp they select DIFFERENT quorums (dashd picks
+/// the memcmp winner; the bignum ordering picks another candidate, which
+/// fails to verify). So the score comparison here is an explicit
+/// LSB-first memcmp over the raw hash bytes and must NEVER be replaced by
+/// uint256::operator<.
+///
+/// FAIL-CLOSED. Every entry point returns false / nullopt when anything is
+/// uncertain: no BLS backend, no candidate quorums, the quorum we selected is
+/// not one whose public key we hold, a size mismatch, or the BLS verify fails.
+/// A refusal costs us the freshness of one ChainLock (we fall back to the
+/// lagging chain-committed derivation, i.e. exactly today's behaviour); an
+/// erroneous acceptance costs us a block.
+
+#include <impl/dash/coin/dkg_commitments.hpp>   // LlmqParamsView, kLlmq*, LlmqNetwork
+#include <impl/dash/coin/vendor/llmq_commitment.hpp>
+
+#include <core/hash.hpp>
+#include <core/pack.hpp>
+#include <core/uint256.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <span>
+#include <string_view>
+#include <vector>
+
+namespace dash {
+namespace coin {
+namespace chainlock {
+
+/// dashcore SIGN_HEIGHT_OFFSET (src/llmq/quorumsman.h:184). Signing and
+/// verification both scan from (signHeight - 8) so that a node which is not
+/// exactly at the tip still selects the same quorum.
+inline constexpr int32_t kSignHeightOffset = 8;
+
+/// One candidate signing quorum: its base block (the DKG cycle-start block
+/// whose hash IS the quorumHash), that block's height, and the aggregate
+/// quorum public key the recovered threshold signature verifies against
+/// (CFinalCommitment::quorumPublicKey, G1/48 bytes).
+struct QuorumCandidate {
+    uint256                                                           quorum_hash;
+    uint32_t                                                          base_height{0};
+    std::array<uint8_t, vendor::CFinalCommitment::BLS_PUBKEY_SIZE>    quorum_public_key{};
+};
+
+// ── primitive hashes ────────────────────────────────────────────────────────
+
+/// SHA256d over a PackStream's contents. (PackStream::get_span is non-const,
+/// so this takes a mutable reference; all callers own a local stream.)
+inline uint256 sha256d_of(::PackStream& s)
+{
+    auto sp = s.get_span();
+    uint256 h;
+    CHash256()
+        .Write(std::span<const unsigned char>(
+            reinterpret_cast<const unsigned char*>(sp.data()), sp.size()))
+        .Finalize(std::span<unsigned char>(h.data(), 32));
+    return h;
+}
+
+/// dashcore chainlock::GenSigRequestId (src/chainlock/clsig.cpp:29-32).
+/// Preimage: CompactSize(5) || "clsig" || int32LE(nHeight), then SHA256d.
+inline uint256 gen_sig_request_id(int32_t n_height)
+{
+    static constexpr std::string_view kPrefix{"clsig"};
+    ::PackStream s;
+    WriteCompactSize(s, kPrefix.size());
+    s.write(std::as_bytes(std::span{kPrefix.data(), kPrefix.size()}));
+    s << n_height;                       // int32, little-endian
+    return sha256d_of(s);
+}
+
+/// dashcore llmq::SignHash ctor (src/llmq/signhash.cpp:14-22), formerly
+/// BuildSignHash: SHA256d(u8(llmqType) || quorumHash || id || msgHash).
+inline uint256 build_sign_hash(uint8_t llmq_type, const uint256& quorum_hash,
+                               const uint256& id, const uint256& msg_hash)
+{
+    ::PackStream s;
+    s << llmq_type;                      // LLMQType is enum class : uint8_t
+    s << quorum_hash;
+    s << id;
+    s << msg_hash;
+    return sha256d_of(s);
+}
+
+/// The per-candidate selection score, dashcore quorumsman.cpp:725-732:
+/// CHashWriter(SER_NETWORK,0) << llmqType << quorumHash << selectionHash.
+/// (SER_NETWORK vs SER_GETHASH is immaterial here — neither uint8_t nor
+/// uint256 has a version-dependent encoding — but we mirror the call anyway.)
+inline uint256 build_selection_score(uint8_t llmq_type, const uint256& quorum_hash,
+                                     const uint256& selection_hash)
+{
+    ::PackStream s;
+    s << llmq_type;
+    s << quorum_hash;
+    s << selection_hash;
+    return sha256d_of(s);
+}
+
+/// dashcore's uint256 score ordering: memcmp over the internal byte array,
+/// LEAST-significant byte first (src/uint256.h:55). See the ORDERING TRAP note
+/// at the top of this file — this must NOT become uint256::operator<, whose
+/// c2pool implementation is a most-significant-word-first bignum compare and
+/// selects a DIFFERENT quorum.
+inline bool score_less(const uint256& a, const uint256& b)
+{
+    return std::memcmp(a.data(), b.data(), 32) < 0;
+}
+
+// ── quorum scan set + selection ─────────────────────────────────────────────
+
+/// Reproduce the SET dashcore's ScanQuorums(llmqType, pindexStart, poolSize)
+/// yields for a NON-ROTATED type (src/llmq/quorumsman.cpp:199-243).
+///
+/// Upstream snaps pindexStart to the enclosing DKG mining window, then walks
+/// mined commitments backwards taking the newest `signingActiveQuorumCount`.
+/// We hold the quorums' BASE heights (the quorumHash's own block), not their
+/// mined-commitment heights; for a non-rotated type the commitment for base B
+/// is mined within [B + mining_window_start, B + mining_window_end], so a
+/// quorum is eligible iff its LATEST possible mined height (B +
+/// mining_window_end) is at or before the snapped store height. That is the
+/// conservative direction: it can only ever omit a quorum that upstream would
+/// have included (=> selection mismatch => verify fails => we fall back), never
+/// admit one upstream would not.
+///
+/// `all` may be in any order and may contain older quorums than the pool size;
+/// the result is the newest-first pool, capped at signingActiveQuorumCount.
+inline std::vector<QuorumCandidate>
+scan_quorum_set(const LlmqParamsView& p, std::vector<QuorumCandidate> all,
+                int32_t sign_height, int32_t sign_offset = kSignHeightOffset)
+{
+    if (p.dkg_interval == 0 || p.use_rotation) return {};   // rotated => unsupported here
+
+    const int32_t start_height = sign_height - sign_offset;
+    if (start_height < 0) return {};
+
+    // Snap to the DKG mining window exactly as ScanQuorums does
+    // (quorumsman.cpp:213-226).
+    const int32_t interval    = static_cast<int32_t>(p.dkg_interval);
+    const int32_t cycle_start = start_height - (start_height % interval);
+    const int32_t mining_start = cycle_start + static_cast<int32_t>(p.mining_window_start);
+    const int32_t mining_end   = cycle_start + static_cast<int32_t>(p.mining_window_end);
+
+    int32_t store_height;
+    if (start_height < mining_start) {
+        // Too early for this cycle — use the previous one.
+        if (mining_end < interval) return {};   // below genesis; upstream bails
+        store_height = mining_end - interval;
+    } else if (start_height > mining_end) {
+        store_height = mining_end;
+    } else {
+        store_height = start_height;
+    }
+    if (store_height < 0) return {};
+
+    std::vector<QuorumCandidate> eligible;
+    eligible.reserve(all.size());
+    for (auto& c : all) {
+        const int64_t latest_mined =
+            static_cast<int64_t>(c.base_height) + static_cast<int64_t>(p.mining_window_end);
+        if (latest_mined <= static_cast<int64_t>(store_height))
+            eligible.push_back(std::move(c));
+    }
+
+    // Newest first (upstream reads DB_MINED_COMMITMENT_BY_INVERSED_HEIGHT,
+    // i.e. descending mined height), then cap at the signing pool size.
+    std::sort(eligible.begin(), eligible.end(),
+              [](const QuorumCandidate& a, const QuorumCandidate& b) {
+                  if (a.base_height != b.base_height) return a.base_height > b.base_height;
+                  return score_less(a.quorum_hash, b.quorum_hash);   // deterministic tie-break
+              });
+    if (eligible.size() > p.signing_active_quorum_count)
+        eligible.resize(p.signing_active_quorum_count);
+    return eligible;
+}
+
+/// dashcore SelectQuorumForSigning, non-rotated branch
+/// (src/llmq/quorumsman.cpp:718-735): score every quorum in the scan set and
+/// return the LOWEST. Ties break on the candidate's index in the scan set,
+/// matching upstream's std::sort over std::pair<uint256, size_t>.
+inline std::optional<QuorumCandidate>
+select_quorum_for_signing(const LlmqParamsView& p,
+                          const std::vector<QuorumCandidate>& scan_set,
+                          const uint256& selection_hash)
+{
+    if (scan_set.empty()) return std::nullopt;
+
+    size_t  best_i = 0;
+    uint256 best_score = build_selection_score(p.type, scan_set[0].quorum_hash, selection_hash);
+    for (size_t i = 1; i < scan_set.size(); ++i) {
+        const uint256 sc = build_selection_score(p.type, scan_set[i].quorum_hash, selection_hash);
+        if (score_less(sc, best_score)) {
+            best_score = sc;
+            best_i     = i;
+        }
+    }
+    return scan_set[best_i];
+}
+
+/// The full pre-BLS half of dashcore's VerifyChainLock: from a ChainLock's
+/// height, pick the quorum that must have signed it and build the sign hash
+/// its recovered threshold signature has to verify against. Returns nullopt
+/// (fail closed) when no quorum can be selected.
+struct SignTarget {
+    QuorumCandidate quorum;
+    uint256         request_id;
+    uint256         sign_hash;
+};
+
+inline std::optional<SignTarget>
+build_sign_target(const LlmqParamsView& p, std::vector<QuorumCandidate> candidates,
+                  int32_t cl_height, const uint256& cl_block_hash,
+                  int32_t sign_offset = kSignHeightOffset)
+{
+    const uint256 request_id = gen_sig_request_id(cl_height);
+    auto scan_set = scan_quorum_set(p, std::move(candidates), cl_height, sign_offset);
+    auto q = select_quorum_for_signing(p, scan_set, request_id);
+    if (!q) return std::nullopt;
+
+    SignTarget t;
+    t.quorum     = *q;
+    t.request_id = request_id;
+    // msgHash is the ChainLock's blockHash (handler.cpp:330-333).
+    t.sign_hash  = build_sign_hash(p.type, q->quorum_hash, request_id, cl_block_hash);
+    return t;
+}
+
+/// The LLMQ type used for ChainLock signing on a network
+/// (src/chainparams.cpp:274 mainnet, :467 testnet).
+inline const LlmqParamsView* chainlock_params(LlmqNetwork net)
+{
+    // LlmqNetwork has exactly these two enumerators; a devnet/regtest network
+    // would need its own row before ChainLock verification could run there.
+    return net == LlmqNetwork::Mainnet ? &kLlmq400_60    // LLMQ_400_60
+                                       : &kLlmq50_60;    // LLMQ_50_60
+}
+
+} // namespace chainlock
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -613,17 +613,46 @@ public:
         notify_state_dirty();
     }
 
+    /// Verifier seam for live ChainLock adoption: BLS-verifies a clsig's
+    /// recovered threshold signature against the quorum that dashcore's
+    /// SelectQuorumForSigning says must have signed it. Installed by main_dash
+    /// from chainlock_verify.hpp; UNSET IS FAIL-CLOSED (see on_new_chainlock).
+    using ChainLockVerifyFn = std::function<bool(
+        int32_t height, const uint256& block_hash,
+        const std::array<uint8_t, 96>& sig)>;
+
+    void set_chainlock_verify_fn(ChainLockVerifyFn fn) {
+        m_chainlock_verify = std::move(fn);
+    }
+
     /// ChainLock reception: adopt the freshly-observed ChainLock as the best CL
     /// for the CCbTx bestCL* fields. The clsig message carries {height,
     /// block_hash, 96-byte recovered threshold sig}. Only advances forward.
-    void on_new_chainlock(int32_t height,
+    ///
+    /// ⚠ VERIFICATION IS MANDATORY. This value is committed into the coinbase
+    /// of every template we then serve (bestCLHeightDiff / bestCLSignature). A
+    /// clsig arrives from an arbitrary p2p peer, so adopting one unverified
+    /// would let a hostile peer choose our coinbase's ChainLock fields — dashd
+    /// would reject the resulting block and we would lose it. When no verifier
+    /// is installed, or verification FAILS, we adopt NOTHING and keep the
+    /// lagging-but-chain-committed bestCL derived from an observed block's
+    /// CCbTx (the pre-existing behaviour) — a refusal costs freshness, an
+    /// erroneous acceptance costs a block.
+    void on_new_chainlock(int32_t height, const uint256& block_hash,
                           const std::array<uint8_t, 96>& sig) {
-        if (height > m_state.best_cl_height()) {
-            m_state.set_best_cl(height, sig);
-            // A fresher bestCL* changes the next template's committed CCbTx —
-            // re-issue work so the served template carries the new ChainLock.
-            notify_state_dirty();
+        if (height <= m_state.best_cl_height()) return;   // never regress
+        if (!m_chainlock_verify) return;                  // no verifier => fail closed
+        if (!m_chainlock_verify(height, block_hash, sig)) {
+            LOG_WARNING << "[CL] rejected unverified ChainLock height=" << height
+                        << " block=" << block_hash.GetHex().substr(0, 16) << "...";
+            return;
         }
+        m_state.set_best_cl(height, sig);
+        LOG_INFO << "[CL] adopted VERIFIED ChainLock height=" << height
+                 << " block=" << block_hash.GetHex().substr(0, 16) << "...";
+        // A fresher bestCL* changes the next template's committed CCbTx —
+        // re-issue work so the served template carries the new ChainLock.
+        notify_state_dirty();
     }
 
     /// Reorg (SML axis): a chain reorganisation can invalidate the incremental
@@ -1232,6 +1261,7 @@ private:
     std::function<void()> m_on_full_resync;  // H-1 heal -> reset sml_base + full re-sync
     std::function<void(const uint256&)> m_on_sml_persist;  // accepted diff -> SMLDb/QuorumDb write
     std::function<void()> m_on_sml_clear;    // reorg/heal -> SMLDb/QuorumDb wipe (extended to CreditPoolDb)
+    ChainLockVerifyFn     m_chainlock_verify; // unset => live ChainLocks never adopted (fail closed)
     // E2: independent DIP-0027 credit-pool accrual, advanced per ingested block
     // (on_block_connected) and re-anchored per accepted mnlistdiff. Verified
     // against each block's own from-wire cbTx; persisted via the hook below.

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -717,19 +717,31 @@ private:
 
     ADD_P2P_HANDLER(inv)
     {
-        // E1: announce-only. Block invs fire new_block (the E2 ingest seam);
-        // NO getdata pulls yet — the ingest legs are later slices.
+        // Block invs fire new_block (the E2 ingest seam, which pulls headers
+        // then the block). Object invs in the pull policy get an immediate
+        // getdata; everything else is ignored.
         for (auto& inv : msg->m_invs)
         {
-            // E1 Phase-L sourcing leg: pull relayed DKG final commitments
-            // (MSG_QUORUM_FINAL_COMMITMENT = 21, dashcore protocol.h). The
-            // qfcommit handler below feeds the MineableCommitmentCache.
-            if (static_cast<uint32_t>(inv.m_type) == 21u)
+            // Sourcing legs: pull the announced object for every inv type in
+            // the pull policy (inv_type_is_pulled, p2p_messages.hpp) —
+            // MSG_QUORUM_FINAL_COMMITMENT = 21 feeding the Phase-L
+            // MineableCommitmentCache, and MSG_CLSIG = 29 feeding the
+            // ChainLock lane. Dash announces both by inv and serves them only
+            // on getdata; without this the clsig handler below can never fire,
+            // which is exactly why on_new_chainlock had never been reached.
+            //
+            // NOTE the ChainLock inv hash is SerializeHash(clsig) — SHA256d
+            // over the whole 132-byte ChainLockSig — NOT the locked block's
+            // hash, so it is only ever echoed straight back in the getdata; we
+            // cannot derive it and must not try. dashd also serves ONLY its
+            // current best ChainLock (GetChainLockByHash refuses anything
+            // else), so a getdata for a superseded announcement legitimately
+            // comes back notfound; that is benign and self-correcting — the
+            // next ChainLock is announced ~2.5 min later.
+            if (inv_type_is_pulled(inv.m_type))
             {
                 auto getdata_msg = message_getdata::make_raw(
-                    {inventory_type(
-                        static_cast<inventory_type::inv_type>(21u),
-                        inv.m_hash)});
+                    {inventory_type(inv.m_type, inv.m_hash)});
                 m_peer->write(getdata_msg);
                 continue;
             }

--- a/src/impl/dash/coin/p2p_messages.hpp
+++ b/src/impl/dash/coin/p2p_messages.hpp
@@ -90,10 +90,22 @@ END_MESSAGE()
 // SPV A1 (parity audit): Dash ChainLockSig (clsig) message.
 // Reference: dashcore/src/chainlock/clsig.h — ChainLockSig struct.
 // Wire layout: nHeight(i32 LE) + blockHash(32B LE) + sig(96B BLS blob).
-// Peers push this unsolicited when a ChainLock is freshly aggregated,
-// and also on demand via inv+getdata(MSG_CLSIG=29). Parsing the sig is
-// not required — we treat it as opaque bytes; the fact that we received
-// the message at all is dashd's signal that the block is finalized.
+//
+// ACQUISITION: Dash Core ANNOUNCES a ChainLock by inv and serves the object
+// only on getdata (announce: chainlock/handler.cpp:128 + RelayInv; serve:
+// net_processing.cpp:2992-2998). It does NOT push clsig unsolicited — so the
+// inv→getdata(MSG_CLSIG=29) leg in p2p_client's inv handler is what makes this
+// message reachable at all. dashd serves ONLY its current best ChainLock, so a
+// getdata for a superseded announcement returns notfound; that is benign.
+//
+// ⚠ THE SIGNATURE IS NOT OPAQUE. Receiving this message is NOT by itself
+// evidence that the block is finalized — a clsig arrives from an arbitrary
+// peer and its height/blockHash/sig are committed into the coinbase of every
+// template we then serve (CCbTx bestCLHeightDiff/bestCLSignature). The 96-byte
+// recovered threshold signature MUST be BLS-verified against the quorum
+// dashcore's SelectQuorumForSigning designates before any of it is adopted —
+// see chainlock_verify.hpp and CoinStateMaintainer::on_new_chainlock, which is
+// fail-closed without a verifier.
 // ── BIP 152 compact-block messages (Phase S2) ─────────────────────────────
 // Wire types vendored from dashcore at src/impl/dash/coin/vendor/; see
 // vendor/README.md for the adaptation notes.
@@ -141,6 +153,28 @@ BEGIN_MESSAGE(clsig)
         READWRITE(Using<ArrayType<DefaultFormat, 96>>(obj.m_sig));
     }
 END_MESSAGE()
+
+/// The inv-announcement sourcing policy: which inv types the DASH coin-P2P
+/// client answers with a getdata for the object itself.
+///
+/// Dash relays these objects announce-first (inv), serving the body only on
+/// request, so an inv type absent from this set is an object we can NEVER
+/// receive — which is exactly how the ChainLock leg stayed dark: clsig was
+/// decodable and handled, but nothing ever asked for one, so the handler had
+/// never once fired. Kept as a free function (rather than inline in the inv
+/// handler) so the policy is unit-testable without a live socket peer.
+///
+///   MSG_QUORUM_FINAL_COMMITMENT = 21 — relayed DKG final commitments
+///                                      (Phase-L MineableCommitmentCache)
+///   MSG_CLSIG                   = 29 — ChainLocks (dashcore protocol.h:522)
+///
+/// Block invs are deliberately NOT here: they take the getheaders-then-block
+/// path in the inv handler, not a bare getdata.
+inline bool inv_type_is_pulled(inventory_type::inv_type t)
+{
+    return t == inventory_type::quorum_final_commitment
+        || t == inventory_type::clsig;
+}
 
 // ── Phase C-SML step 4: Simplified MN List sync messages ──────────────
 // Wire commands (dashcore protocol.cpp:68-69):

--- a/src/impl/dash/coin/vendor/bls_verify.cpp
+++ b/src/impl/dash/coin/vendor/bls_verify.cpp
@@ -248,6 +248,50 @@ bool verify_govvote_operator_sig(
 #endif // C2POOL_DASH_BLS
 }
 
+// ── ChainLock recovered-threshold-signature verify ──────────────────────────
+
+bool verify_chainlock_sig(
+    const std::array<uint8_t, CFinalCommitment::BLS_PUBKEY_SIZE>& quorum_public_key,
+    const uint256& sign_hash,
+    const std::array<uint8_t, CFinalCommitment::BLS_SIG_SIZE>& sig)
+{
+#ifndef C2POOL_DASH_BLS
+    (void)quorum_public_key;
+    (void)sign_hash;
+    (void)sig;
+    return false;   // no BLS backend → fail closed (ChainLock never adopted)
+#else
+    try {
+        // Quorum public key: G1, basic scheme (post-V19 wire encoding).
+        bls::G1Element pk;
+        try {
+            pk = bls::G1Element::FromBytes(
+                bls::Bytes(quorum_public_key.data(), quorum_public_key.size()),
+                /*fLegacy=*/false);
+        } catch (...) {
+            return false;
+        }
+        if (!pk.IsValid()) return false;
+
+        // Recovered threshold signature: G2, basic scheme.
+        bls::G2Element s;
+        try {
+            s = bls::G2Element::FromBytes(bls::Bytes(sig.data(), sig.size()),
+                                          /*fLegacy=*/false);
+        } catch (...) {
+            return false;   // not a basic-encoded G2 point → dashd rejects too
+        }
+
+        // The 32 sign-hash bytes are the message; BasicSchemeMPL applies the
+        // DST "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_" hash-to-curve.
+        return bls::BasicSchemeMPL().Verify(
+            pk, bls::Bytes(sign_hash.data(), 32), s);
+    } catch (...) {
+        return false;   // any relic/dashbls throw → fail closed
+    }
+#endif // C2POOL_DASH_BLS
+}
+
 // ── seam factory ────────────────────────────────────────────────────────────
 
 std::function<bool(const CFinalCommitment&)>

--- a/src/impl/dash/coin/vendor/bls_verify.hpp
+++ b/src/impl/dash/coin/vendor/bls_verify.hpp
@@ -141,6 +141,36 @@ bool verify_govvote_operator_sig(
     const uint256& digest,
     const std::vector<uint8_t>& vch_sig);
 
+// ── ChainLock recovered-threshold-signature verify ──────────────────────────
+//
+// dashcore llmq::VerifyRecoveredSig's final step (src/llmq/quorumsman.cpp:749-751):
+//     SignHash signHash{llmqType, quorum->qc->quorumHash, id, msgHash};
+//     sig.VerifyInsecure(quorum->qc->quorumPublicKey, signHash.Get());
+// and VerifyInsecure (src/bls/bls.cpp:294-310) is
+//     Scheme(legacy)->Verify(pubKey.impl, bls::Bytes(hash.begin(), 32), impl)
+// i.e. the 32 sign-hash bytes are the MESSAGE handed to the scheme, which
+// applies its own hash-to-curve — do NOT pre-hash them again here.
+//
+// SCHEME IS HARD-PINNED TO BASIC (fLegacy=false), for BOTH the 96-byte
+// signature wire decode and the verify DST, and for the 48-byte G1 quorum
+// public key. dashcore flips bls::bls_legacy_scheme to false at V19 activation
+// (src/evo/specialtxman.cpp) and every live ChainLock we can act on is
+// post-V19. Unlike the govvote path there is NO pubkey-encoding fallback: the
+// quorumPublicKey reaches us from a mnlistdiff-sourced CFinalCommitment whose
+// wire encoding is basic post-V19, and a legacy retry here would only ever
+// broaden what we accept on a consensus-critical adoption.
+//
+// The caller (chainlock_verify.hpp) is responsible for having selected the
+// CORRECT signing quorum — this function only answers "did THIS key sign THIS
+// hash". Passing the wrong quorum's key yields false (fail closed).
+//
+// FAIL-CLOSED: returns false when the BLS backend is absent, either point
+// fails to deserialize, or the verify fails. Never throws.
+bool verify_chainlock_sig(
+    const std::array<uint8_t, CFinalCommitment::BLS_PUBKEY_SIZE>& quorum_public_key,
+    const uint256& sign_hash,
+    const std::array<uint8_t, CFinalCommitment::BLS_SIG_SIZE>& sig);
+
 } // namespace vendor
 } // namespace coin
 } // namespace dash

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -566,6 +566,26 @@ if (BUILD_TESTING AND GTest_FOUND)
     target_link_libraries(test_dash_quorum_root PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
     gtest_add_tests(test_dash_quorum_root "" AUTO)
 
+    # Live-path ChainLock acquisition + verification KAT, against a REAL mainnet
+    # ChainLock (tip 2515965) and the real LLMQ_400_60 candidate set.
+    # DELIBERATELY *NOT* inside the C2POOL_DASH_BLS gate: the request-id, DKG-
+    # window scan-set and quorum-SELECTION halves need no BLS backend, and they
+    # are the pieces most likely to drift silently (in particular the memcmp-vs-
+    # bignum score-ordering trap, which selects a DIFFERENT quorum if broken).
+    # Those run in EVERY build; the BLS crypto KATs — including the tampered-
+    # signature negative — are #ifdef C2POOL_DASH_BLS-gated in the source and
+    # exercise only when the backend is linked. dash_bls_verify compiles
+    # unconditionally (fail-closed stub without the backend), so this always links.
+    add_executable(test_dash_chainlock_verify test_dash_chainlock_verify.cpp)
+    target_link_libraries(test_dash_chainlock_verify PRIVATE
+        GTest::gtest_main GTest::gtest
+        dash_bls_verify dash_x11 core
+        nlohmann_json::nlohmann_json
+        ${Boost_LIBRARIES}
+    )
+    target_link_libraries(test_dash_chainlock_verify PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
+    gtest_add_tests(test_dash_chainlock_verify "" AUTO)
+
     # KNOWN COVERAGE GAP (surfaced by the top-level drift-guard, #883 follow-up):
     # the three targets below are gated behind C2POOL_DASH_BLS, but no workflow
     # in .github/workflows/ enables that flag yet, so they are never built or run

--- a/test/test_dash_chainlock_verify.cpp
+++ b/test/test_dash_chainlock_verify.cpp
@@ -1,0 +1,494 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Live-path ChainLock acquisition + verification KATs.
+//
+// THE REAL VECTOR. Captured read-only from a mainnet dashd (v23.1.7) via
+// `dash-cli getbestchainlock` at tip 2515965, plus `dash-cli quorum list` /
+// `quorum info 2 <hash>` for the LLMQ_400_60 candidate set and their aggregate
+// public keys. Everything below is real mainnet consensus data, not synthetic.
+//
+//   clsig wire (132 B, from getbestchainlock "hex"):
+//     fd632600                          int32LE height   = 2515965
+//     8ba8205c...00                     blockHash (LE)
+//     b37fa65f...7dd                    recovered threshold sig (96 B)
+//
+// WHAT EACH TEST LOCKS
+//
+//   RequestIdMatchesDashcore      -- GenSigRequestId preimage/hash
+//                                    (clsig.cpp:29-32). Cross-checked below by
+//                                    the fact that dashd's OWN `quorum
+//                                    selectquorum 2 <requestId>` returns the
+//                                    quorum this request id selects.
+//   ScanSetMatchesDashdQuorumList -- the DKG-window snapping + newest-N pool
+//                                    reproduces exactly the 4 quorums dashd
+//                                    lists for llmq_400_60.
+//   SelectsTheQuorumDashdSelected -- SelectQuorumForSigning picks the SAME
+//                                    quorum dashd's selectquorum RPC returned.
+//   ScoreOrderingIsMemcmpNotBignum-- THE ordering trap: c2pool's
+//                                    uint256::operator< (bignum, MSW-first)
+//                                    selects a DIFFERENT quorum than dashcore's
+//                                    base_blob memcmp (LSB-first). This test
+//                                    fails if anyone "simplifies" score_less
+//                                    into operator<.
+//   SignHashMatchesDashcore       -- BuildSignHash/SignHash preimage.
+//   RealChainLockVerifies         -- the real sig verifies (BLS-gated).
+//   TamperedSignatureIsRejected   -- ** the load-bearing negative **
+//   ForgedSignatureIsRejected     -- attacker-keyed valid G2 point rejected.
+//   WrongQuorumKeyIsRejected      -- right sig, wrong quorum key.
+//   WrongHeightIsRejected         -- right sig, off-by-one height.
+//   FailClosed*                   -- empty/short candidate sets.
+//
+// The BLS-dependent tests are gated on C2POOL_DASH_BLS; the hash/selection
+// tests ALWAYS run, so the hardest-to-get-right pieces (request id, quorum
+// selection, sign hash) are locked even in a build without dashbls.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/chainlock_verify.hpp>
+#include <impl/dash/coin/vendor/bls_verify.hpp>
+#include <core/uint256.hpp>
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+using namespace dash::coin;
+using namespace dash::coin::chainlock;
+
+namespace {
+
+std::vector<uint8_t> unhex(const std::string& s)
+{
+    std::vector<uint8_t> o;
+    o.reserve(s.size() / 2);
+    for (size_t i = 0; i + 1 < s.size(); i += 2)
+        o.push_back(static_cast<uint8_t>(std::stoul(s.substr(i, 2), nullptr, 16)));
+    return o;
+}
+
+template <size_t N>
+std::array<uint8_t, N> to_array(const std::string& hex)
+{
+    auto v = unhex(hex);
+    std::array<uint8_t, N> a{};
+    EXPECT_EQ(v.size(), N);
+    for (size_t i = 0; i < N && i < v.size(); ++i) a[i] = v[i];
+    return a;
+}
+
+/// uint256 from raw little-endian wire bytes (as they appear on the wire).
+uint256 u256_le(const std::string& le_hex) { return uint256(unhex(le_hex)); }
+
+// ── the real mainnet ChainLock (tip 2515965) ────────────────────────────────
+
+constexpr int32_t kClHeight = 2515965;
+const char* kClBlockHashLe =
+    "8ba8205c0861bc9b6063b67aeff818075a148d1a989502250b00000000000000";
+const char* kClSig =
+    "b37fa65f662141fde71d5ead7f3548547aa08915274c188c47554e814770a381"
+    "6b0c772c10fdb6ca1cc8bf851bcb218301454d5aa6c2fd0d3d25162096f416b9"
+    "a629196307efe214b20380c2606c9191550cbefee9ad7e59c05d691929d4a7dd";
+
+// dashd's own answers, for cross-checking:
+//   requestId  (from `quorum selectquorum 2 <id>` input)
+//   signHash   (derived; locked here so a preimage regression is caught)
+const char* kExpectRequestIdLe =
+    "79727ab893d36d0fd3a3a5c6d35b1e26587613570870e4fe9854cb1885b5d3a2";
+const char* kExpectSignHashLe =
+    "f17e368f665809c68a083f55ea08865ad9059de62e1b7ebf2ed2ec4788b177b9";
+
+// The four active LLMQ_400_60 quorums as dashd listed them (newest first),
+// each with the height of its base block and its aggregate public key.
+// Index 0 is the one dashd's `quorum selectquorum` returned for kClHeight.
+struct RawQuorum { const char* hash_le; uint32_t height; const char* pubkey; };
+const RawQuorum kQuorums[4] = {
+    {"c3477828c2736b7a8c5f860a80b5fca78a2d901ac73779cf2d00000000000000", 2515680,
+     "a87321e6161b32915457b292bd32d568765f99e13c9b892fb539ffa66d10c4a2"
+     "2eccb7ac3fb510d219cab1dcaa6c1771"},
+    {"bc8914c62c17d66b30a32808d60f3d8e942511cfa18555770000000000000000", 2515392,
+     "89a90b1a63ef64930b6b758de2ef664c58a7d13eec3db9fe1d65eacfb4fd51f1"
+     "8bfdca398b5e5e7b5ec092ccdb8969ea"},
+    {"e1cff3e1a2884f4c6bf683716b43d4ab450c720fc0304c2e1f00000000000000", 2515104,
+     "990586fe72b887e6237120c8247346acbb0335e13bda9ca228c1cc201c7afe52"
+     "8fe14b21533cbdc3d6a9f3f71245c38b"},
+    {"2e55076a38ec415a176e5f8917fceb39ce5a1f9a6660bde02c00000000000000", 2514816,
+     "84818d01b681fd6ea8f438f834b5296341695e17019c77967a861f7877828e97"
+     "ec965eb8cf7d8a87ed9f77997bc683de"},
+};
+
+std::vector<QuorumCandidate> all_candidates()
+{
+    std::vector<QuorumCandidate> v;
+    for (const auto& r : kQuorums) {
+        QuorumCandidate c;
+        c.quorum_hash       = u256_le(r.hash_le);
+        c.base_height       = r.height;
+        c.quorum_public_key = to_array<48>(r.pubkey);
+        v.push_back(c);
+    }
+    return v;
+}
+
+const LlmqParamsView& mainnet_params()
+{
+    return *chainlock_params(LlmqNetwork::Mainnet);   // LLMQ_400_60
+}
+
+} // namespace
+
+// ── hash / selection layer (always runs, no BLS backend needed) ─────────────
+
+TEST(DashChainLockVerify, ChainLockParamsAreLlmq400_60OnMainnet)
+{
+    const auto& p = mainnet_params();
+    // dashcore chainparams.cpp:274 + params.h llmq_400_60 row.
+    EXPECT_EQ(p.type, 2u);
+    EXPECT_EQ(p.dkg_interval, 288u);
+    EXPECT_EQ(p.mining_window_start, 20u);
+    EXPECT_EQ(p.mining_window_end, 28u);
+    EXPECT_EQ(p.signing_active_quorum_count, 4u);
+    EXPECT_FALSE(p.use_rotation);
+    // testnet signs ChainLocks with LLMQ_50_60 (chainparams.cpp:467).
+    EXPECT_EQ(chainlock_params(LlmqNetwork::Testnet)->type, 1u);
+}
+
+TEST(DashChainLockVerify, RequestIdMatchesDashcore)
+{
+    // dashcore GenSigRequestId: SHA256d(0x05 "clsig" int32LE(height)).
+    EXPECT_EQ(gen_sig_request_id(kClHeight), u256_le(kExpectRequestIdLe));
+    // Mutation: a different height must give a different request id (this is
+    // what binds the signature to the height).
+    EXPECT_NE(gen_sig_request_id(kClHeight + 1), u256_le(kExpectRequestIdLe));
+}
+
+TEST(DashChainLockVerify, ScanSetMatchesDashdQuorumList)
+{
+    auto set = scan_quorum_set(mainnet_params(), all_candidates(), kClHeight);
+    ASSERT_EQ(set.size(), 4u) << "signingActiveQuorumCount for llmq_400_60";
+    // Newest-first, exactly the order+membership dashd's `quorum list` gave.
+    for (size_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(set[i].quorum_hash, u256_le(kQuorums[i].hash_le)) << "index " << i;
+        EXPECT_EQ(set[i].base_height, kQuorums[i].height) << "index " << i;
+    }
+}
+
+// The pool MUST be capped at signingActiveQuorumCount. dashd's `quorum list`
+// happened to show exactly 4 active llmq_400_60 quorums, but the
+// mnlistdiff-sourced active set we feed the verifier in production also
+// retains OLDER quorums (dashcore keeps keepOldConnections=5 and the SML does
+// not drop them the instant they leave the signing pool). Without the cap those
+// stale quorums get scored and can win the selection — picking a quorum that
+// never signed, so every ChainLock would fail to verify.
+TEST(DashChainLockVerify, ScanSetIsCappedAtSigningActiveQuorumCount)
+{
+    auto cands = all_candidates();
+    // Four EXPIRED quorums, older than the signing pool (288 apart, as real
+    // llmq_400_60 cycles are). Keys are irrelevant — they must never be chosen.
+    for (uint32_t i = 1; i <= 4; ++i) {
+        QuorumCandidate old = cands.back();
+        old.base_height = 2514816 - 288 * i;
+        auto raw = unhex(kQuorums[3].hash_le);
+        raw[0] = static_cast<uint8_t>(i);        // distinct hashes
+        old.quorum_hash = uint256(raw);
+        cands.push_back(old);
+    }
+    ASSERT_EQ(cands.size(), 8u);
+
+    auto set = scan_quorum_set(mainnet_params(), cands, kClHeight);
+    ASSERT_EQ(set.size(), 4u) << "pool must be capped at signingActiveQuorumCount";
+    for (size_t i = 0; i < 4; ++i)
+        EXPECT_EQ(set[i].quorum_hash, u256_le(kQuorums[i].hash_le)) << "index " << i;
+
+    // And the selection is unchanged by the presence of the expired quorums.
+    auto q = select_quorum_for_signing(mainnet_params(), set,
+                                       gen_sig_request_id(kClHeight));
+    ASSERT_TRUE(q.has_value());
+    EXPECT_EQ(q->quorum_hash, u256_le(kQuorums[0].hash_le));
+}
+
+TEST(DashChainLockVerify, ScanSetExcludesQuorumsNotYetMinedAtScanHeight)
+{
+    // A quorum whose commitment could not have been mined by (height - 8),
+    // snapped to the DKG mining window, must not enter the pool. Give the
+    // newest quorum a base height far past the ChainLock and it drops out.
+    auto cands = all_candidates();
+    cands[0].base_height = static_cast<uint32_t>(kClHeight) + 288;
+    auto set = scan_quorum_set(mainnet_params(), cands, kClHeight);
+    ASSERT_EQ(set.size(), 3u);
+    EXPECT_EQ(set[0].quorum_hash, u256_le(kQuorums[1].hash_le));
+}
+
+// SIGN_HEIGHT_OFFSET must be 8 (dashcore quorumsman.h:184). At most heights
+// the offset is invisible — h and h-8 snap to the same DKG mining window, so
+// the scan set is identical and an offset regression hides. This height is
+// chosen to STRADDLE the window end of cycle 2515680 (mining window
+// [2515700, 2515708]): with the correct offset 8 the scan starts at 2515701,
+// INSIDE the window, so the cycle's own quorum is not yet usable; with a
+// wrong offset of 0 the scan starts at 2515709, PAST the window, and the
+// 2515680 quorum would wrongly enter the pool.
+TEST(DashChainLockVerify, SignHeightOffsetIsEightAndChangesTheScanSet)
+{
+    constexpr int32_t kStraddle = 2515680 + 29;   // 2515709
+    auto set = scan_quorum_set(mainnet_params(), all_candidates(), kStraddle);
+    ASSERT_EQ(set.size(), 3u)
+        << "with offset 8 the cycle-2515680 quorum is not yet in the pool";
+    EXPECT_EQ(set[0].quorum_hash, u256_le(kQuorums[1].hash_le));
+
+    // Control: with offset 0 the same height DOES pull in the newest quorum —
+    // proving this height actually discriminates the offset.
+    auto set0 = scan_quorum_set(mainnet_params(), all_candidates(), kStraddle,
+                                /*sign_offset=*/0);
+    ASSERT_EQ(set0.size(), 4u);
+    EXPECT_EQ(set0[0].quorum_hash, u256_le(kQuorums[0].hash_le));
+}
+
+TEST(DashChainLockVerify, SelectsTheQuorumDashdSelected)
+{
+    auto set = scan_quorum_set(mainnet_params(), all_candidates(), kClHeight);
+    auto q = select_quorum_for_signing(mainnet_params(), set,
+                                       gen_sig_request_id(kClHeight));
+    ASSERT_TRUE(q.has_value());
+    // Ground truth: `dash-cli quorum selectquorum 2 a2d3b585...7279` returned
+    // quorumHash 000000000000002dcf7937c71a902d8aa7fcb5800a865f8c7a6b73c2287847c3.
+    EXPECT_EQ(q->quorum_hash, u256_le(kQuorums[0].hash_le));
+}
+
+// THE ORDERING TRAP. dashcore sorts selection scores with base_blob's memcmp
+// (LSB-first); c2pool's uint256::operator< is an MSW-first bignum compare.
+// On this real vector the two disagree — memcmp picks candidate 0 (what dashd
+// picked), bignum picks candidate 1. If score_less is ever "simplified" into
+// operator<, this test goes red and SelectsTheQuorumDashdSelected goes red too.
+TEST(DashChainLockVerify, ScoreOrderingIsMemcmpNotBignum)
+{
+    const auto& p = mainnet_params();
+    const uint256 rid = gen_sig_request_id(kClHeight);
+    auto set = scan_quorum_set(p, all_candidates(), kClHeight);
+    ASSERT_EQ(set.size(), 4u);
+
+    std::vector<uint256> scores;
+    for (const auto& c : set)
+        scores.push_back(build_selection_score(p.type, c.quorum_hash, rid));
+
+    size_t memcmp_win = 0, bignum_win = 0;
+    for (size_t i = 1; i < scores.size(); ++i) {
+        if (score_less(scores[i], scores[memcmp_win]))  memcmp_win = i;
+        if (scores[i] < scores[bignum_win])             bignum_win = i;  // uint256::operator<
+    }
+    EXPECT_EQ(memcmp_win, 0u) << "dashcore memcmp ordering must pick candidate 0";
+    EXPECT_NE(memcmp_win, bignum_win)
+        << "this vector is only a useful guard while the two orderings differ";
+}
+
+TEST(DashChainLockVerify, SignHashMatchesDashcore)
+{
+    auto t = build_sign_target(mainnet_params(), all_candidates(), kClHeight,
+                               u256_le(kClBlockHashLe));
+    ASSERT_TRUE(t.has_value());
+    EXPECT_EQ(t->request_id, u256_le(kExpectRequestIdLe));
+    EXPECT_EQ(t->sign_hash,  u256_le(kExpectSignHashLe));
+    EXPECT_EQ(t->quorum.quorum_hash, u256_le(kQuorums[0].hash_le));
+}
+
+TEST(DashChainLockVerify, FailsClosedWithNoCandidates)
+{
+    EXPECT_FALSE(build_sign_target(mainnet_params(), {}, kClHeight,
+                                   u256_le(kClBlockHashLe)).has_value());
+}
+
+TEST(DashChainLockVerify, FailsClosedBelowScanHeight)
+{
+    // A ChainLock height below the sign offset cannot select a quorum.
+    EXPECT_FALSE(build_sign_target(mainnet_params(), all_candidates(), 4,
+                                   u256_le(kClBlockHashLe)).has_value());
+}
+
+// ── BLS layer (gated on the dashbls backend) ────────────────────────────────
+
+#ifdef C2POOL_DASH_BLS
+
+// dashbls — needed by the wrong-quorum attack test, which must MINT a real
+// threshold key and produce a genuinely valid signature to attack with.
+#include <dashbls/bls.hpp>
+#include <dashbls/schemes.hpp>
+#include <dashbls/elements.hpp>
+
+namespace {
+/// The full live path: select the quorum for this ChainLock, then BLS-verify.
+bool verify_real_chainlock(int32_t height, const uint256& block_hash,
+                           const std::array<uint8_t, 96>& sig,
+                           std::vector<QuorumCandidate> cands)
+{
+    auto t = build_sign_target(mainnet_params(), std::move(cands), height, block_hash);
+    if (!t) return false;
+    return vendor::verify_chainlock_sig(t->quorum.quorum_public_key, t->sign_hash, sig);
+}
+} // namespace
+
+TEST(DashChainLockVerify, RealChainLockVerifies)
+{
+    EXPECT_TRUE(verify_real_chainlock(kClHeight, u256_le(kClBlockHashLe),
+                                      to_array<96>(kClSig), all_candidates()))
+        << "a real mainnet ChainLock must verify end-to-end";
+}
+
+// ** THE LOAD-BEARING NEGATIVE **
+// A verifier that accepts everything would pass "does it verify?" trivially.
+// This flips ONE BIT of the real signature. The chosen bit (byte 0, bit 5) was
+// picked because the result STILL DESERIALIZES as a valid G2 point — so the
+// rejection comes from the pairing check itself, not from the decoder. The
+// second case flips a bit that breaks the encoding, covering the decoder path.
+TEST(DashChainLockVerify, TamperedSignatureIsRejected)
+{
+    // (a) parseable tamper — exercises the actual BLS verify
+    auto tampered = to_array<96>(kClSig);
+    tampered[0] ^= 0x20;                       // byte 0, bit 5
+    EXPECT_FALSE(verify_real_chainlock(kClHeight, u256_le(kClBlockHashLe),
+                                       tampered, all_candidates()))
+        << "a one-bit-tampered ChainLock signature MUST NOT verify";
+
+    // (b) every other single-bit flip in the signature must also fail. This is
+    // the strongest form of the claim and cheap enough to assert exhaustively
+    // over a sample of positions.
+    for (size_t byte_i : {1u, 7u, 31u, 48u, 64u, 95u}) {
+        for (int bit = 0; bit < 8; ++bit) {
+            auto t = to_array<96>(kClSig);
+            t[byte_i] ^= static_cast<uint8_t>(1u << bit);
+            EXPECT_FALSE(verify_real_chainlock(kClHeight, u256_le(kClBlockHashLe),
+                                               t, all_candidates()))
+                << "flip byte " << byte_i << " bit " << bit << " verified!";
+        }
+    }
+}
+
+TEST(DashChainLockVerify, ForgedSignatureIsRejected)
+{
+    // A structurally PERFECT signature over the correct sign hash, produced by
+    // a key the attacker controls. Deserializes cleanly; must still fail,
+    // because it is not the selected quorum's threshold key.
+    const char* kForged =
+        "a1f776cce2360d4ac9d6cb86e79673a2ae75f1c5cd2a6d3f4a459ff17e6c49cd"
+        "90f68ae9c2c334dbf74c36bb68c8df730215c0e0bad3ccfe6f5e0d96244e0372"
+        "c926d4bbf954fa23a0f1e1d483d605c4a80b8e23685e4e0100b64ebff7e78532";
+    EXPECT_FALSE(verify_real_chainlock(kClHeight, u256_le(kClBlockHashLe),
+                                       to_array<96>(kForged), all_candidates()))
+        << "an attacker-keyed signature MUST NOT verify";
+}
+
+// ** THE WRONG-QUORUM ATTACK **
+//
+// The sharpest form of the safety property, and the one a naive "does the BLS
+// math check out" implementation PASSES and a correct one rejects.
+//
+// The attacker produces a signature that is *internally perfect*: a real BLS
+// signature over a correctly-constructed ChainLock sign hash, verifying under
+// the very public key that ChainLock names. It is simply the WRONG QUORUM —
+// not the one dashcore's SelectQuorumForSigning designates for this height.
+//
+// An implementation that verified "the signature against whichever quorum the
+// message points at" would accept this and commit a hostile ChainLock into our
+// coinbase. Ours pins the quorum by the deterministic selection rule FIRST and
+// verifies only against that quorum's key, so it rejects.
+//
+// The control assertion is what makes this test meaningful: the same signature
+// DOES verify against the quorum it was made for. So the rejection is
+// specifically the selection binding, not a broken signature.
+TEST(DashChainLockVerify, InternallyValidSignatureFromWrongQuorumIsRejected)
+{
+    // Selection for this ChainLock designates candidate 0.
+    auto set = scan_quorum_set(mainnet_params(), all_candidates(), kClHeight);
+    auto designated = select_quorum_for_signing(mainnet_params(), set,
+                                                gen_sig_request_id(kClHeight));
+    ASSERT_TRUE(designated.has_value());
+    ASSERT_EQ(designated->quorum_hash, u256_le(kQuorums[0].hash_le));
+
+    // The attacker controls a different quorum slot (candidate 1) — they mint
+    // their own threshold key and substitute it into the active set.
+    std::vector<uint8_t> seed(32, 0x7E);
+    auto attacker_sk = bls::BasicSchemeMPL().KeyGen(bls::Bytes(seed.data(), seed.size()));
+    auto attacker_pk = attacker_sk.GetG1Element();
+    auto attacker_pk_bytes = attacker_pk.Serialize(/*fLegacy=*/false);
+    ASSERT_EQ(attacker_pk_bytes.size(), 48u);
+
+    auto cands = all_candidates();
+    std::array<uint8_t, 48> apk{};
+    for (size_t i = 0; i < 48; ++i) apk[i] = attacker_pk_bytes[i];
+    cands[1].quorum_public_key = apk;
+
+    // They sign the sign hash built for THEIR quorum — a fully well-formed
+    // ChainLock signature, just from the wrong signer.
+    const uint256 rid = gen_sig_request_id(kClHeight);
+    const uint256 wrong_sign_hash = build_sign_hash(
+        mainnet_params().type, cands[1].quorum_hash, rid, u256_le(kClBlockHashLe));
+    auto forged = bls::BasicSchemeMPL().Sign(
+        attacker_sk, bls::Bytes(wrong_sign_hash.data(), 32));
+    auto forged_bytes = forged.Serialize(/*fLegacy=*/false);
+    ASSERT_EQ(forged_bytes.size(), 96u);
+    std::array<uint8_t, 96> fsig{};
+    for (size_t i = 0; i < 96; ++i) fsig[i] = forged_bytes[i];
+
+    // CONTROL: the signature really is internally valid — it verifies against
+    // the quorum it was made for, over that quorum's own sign hash.
+    ASSERT_TRUE(vendor::verify_chainlock_sig(apk, wrong_sign_hash, fsig))
+        << "the attack vector must itself be a VALID signature, else this "
+           "test proves nothing";
+
+    // THE CLAIM: presented as a ChainLock for kClHeight it is REJECTED,
+    // because selection designates candidate 0, not the attacker's slot.
+    EXPECT_FALSE(verify_real_chainlock(kClHeight, u256_le(kClBlockHashLe),
+                                       fsig, cands))
+        << "an internally valid signature from a NON-DESIGNATED quorum MUST "
+           "NOT be adopted";
+}
+
+TEST(DashChainLockVerify, WrongQuorumKeyIsRejected)
+{
+    // Right signature, right sign hash — but verified against a DIFFERENT real
+    // quorum's public key. Fails closed.
+    auto t = build_sign_target(mainnet_params(), all_candidates(), kClHeight,
+                               u256_le(kClBlockHashLe));
+    ASSERT_TRUE(t.has_value());
+    EXPECT_FALSE(vendor::verify_chainlock_sig(to_array<48>(kQuorums[1].pubkey),
+                                              t->sign_hash, to_array<96>(kClSig)));
+    EXPECT_FALSE(vendor::verify_chainlock_sig(to_array<48>(kQuorums[2].pubkey),
+                                              t->sign_hash, to_array<96>(kClSig)));
+    // Control: the correct key DOES verify the same sign hash.
+    EXPECT_TRUE(vendor::verify_chainlock_sig(to_array<48>(kQuorums[0].pubkey),
+                                             t->sign_hash, to_array<96>(kClSig)));
+}
+
+TEST(DashChainLockVerify, WrongHeightIsRejected)
+{
+    // The height is bound into the signature twice: through the request id
+    // (which selects the quorum) and through the sign hash. Claiming the same
+    // signature locks a different height must fail.
+    for (int32_t d : {-2, -1, 1, 2, 288}) {
+        EXPECT_FALSE(verify_real_chainlock(kClHeight + d, u256_le(kClBlockHashLe),
+                                           to_array<96>(kClSig), all_candidates()))
+            << "height offset " << d << " verified!";
+    }
+}
+
+TEST(DashChainLockVerify, WrongBlockHashIsRejected)
+{
+    // msgHash is the locked block's hash — a ChainLock replayed onto a
+    // different block must fail.
+    auto bad = unhex(kClBlockHashLe);
+    bad[0] ^= 0x01;
+    EXPECT_FALSE(verify_real_chainlock(kClHeight, uint256(bad),
+                                       to_array<96>(kClSig), all_candidates()))
+        << "a ChainLock pointed at a different block MUST NOT verify";
+}
+
+TEST(DashChainLockVerify, RejectedWhenSigningQuorumIsMissingFromTheSet)
+{
+    // We hold the other three quorums but not the one that actually signed.
+    // Selection then picks a quorum that did not sign => verify fails closed.
+    // (This is the daemonless SML-gap case: a refusal, never a wrong adoption.)
+    auto cands = all_candidates();
+    cands.erase(cands.begin());
+    EXPECT_FALSE(verify_real_chainlock(kClHeight, u256_le(kClBlockHashLe),
+                                       to_array<96>(kClSig), cands));
+}
+
+#endif // C2POOL_DASH_BLS

--- a/test/test_dash_coin_state_maintainer.cpp
+++ b/test/test_dash_coin_state_maintainer.cpp
@@ -500,22 +500,70 @@ TEST(DashCoinStateMaintainer, OnNewChainlockAdoptsForwardOnlyAndFiresDirty) {
     CoinStateMaintainer m(st);
     int dirty = 0;
     m.set_on_state_dirty([&] { ++dirty; });
+    // Accepting verifier: this test covers the forward-only/dirty axis only.
+    m.set_chainlock_verify_fn(
+        [](int32_t, const uint256&, const std::array<uint8_t, 96>&) { return true; });
 
+    const uint256 bh = uint256::ZERO;
     std::array<uint8_t, 96> sig{}; sig[0] = 0x11;
-    m.on_new_chainlock(1500000, sig);
+    m.on_new_chainlock(1500000, bh, sig);
     EXPECT_EQ(st.best_cl_height(), 1500000);
     EXPECT_EQ(dirty, 1) << "a fresher ChainLock must re-issue work";
 
     // A stale (<=) height is ignored — no adoption, no re-issue.
     std::array<uint8_t, 96> older{}; older[0] = 0x22;
-    m.on_new_chainlock(1499999, older);
+    m.on_new_chainlock(1499999, bh, older);
     EXPECT_EQ(st.best_cl_height(), 1500000);
     EXPECT_EQ(dirty, 1);
 
     // A forward ChainLock advances + re-issues again.
-    m.on_new_chainlock(1500005, sig);
+    m.on_new_chainlock(1500005, bh, sig);
     EXPECT_EQ(st.best_cl_height(), 1500005);
     EXPECT_EQ(dirty, 2);
+}
+
+// C-2b chainlock adoption is GATED ON VERIFICATION. These are the reward-
+// critical negatives: an unverified clsig from a hostile peer must never reach
+// the CCbTx bestCL* fields we commit into a served template.
+TEST(DashCoinStateMaintainer, OnNewChainlockFailsClosedWithoutVerifier) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    int dirty = 0;
+    m.set_on_state_dirty([&] { ++dirty; });
+
+    // NO verifier installed -> adopt nothing (the pre-existing lagging
+    // chain-committed derivation stays authoritative).
+    std::array<uint8_t, 96> sig{}; sig[0] = 0x11;
+    m.on_new_chainlock(1500000, uint256::ZERO, sig);
+    EXPECT_EQ(st.best_cl_height(), 0)
+        << "no verifier must mean no adoption, not blind adoption";
+    EXPECT_EQ(dirty, 0);
+}
+
+TEST(DashCoinStateMaintainer, OnNewChainlockRejectedWhenVerifierSaysNo) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    int dirty = 0, calls = 0;
+    m.set_on_state_dirty([&] { ++dirty; });
+    m.set_chainlock_verify_fn(
+        [&](int32_t, const uint256&, const std::array<uint8_t, 96>&) {
+            ++calls;
+            return false;                 // verification FAILS
+        });
+
+    std::array<uint8_t, 96> sig{}; sig[0] = 0x11;
+    m.on_new_chainlock(1500000, uint256::ZERO, sig);
+    EXPECT_EQ(calls, 1) << "the verifier must actually be consulted";
+    EXPECT_EQ(st.best_cl_height(), 0) << "a failing verify must not adopt";
+    EXPECT_EQ(dirty, 0);
+
+    // And the identical ChainLock IS adopted once the verifier accepts it —
+    // proving the refusal above came from the gate, not from some other guard.
+    m.set_chainlock_verify_fn(
+        [](int32_t, const uint256&, const std::array<uint8_t, 96>&) { return true; });
+    m.on_new_chainlock(1500000, uint256::ZERO, sig);
+    EXPECT_EQ(st.best_cl_height(), 1500000);
+    EXPECT_EQ(dirty, 1);
 }
 
 // H-1 (PR #780): a malformed quorum tail must NOT be papered over. It heals like

--- a/test/test_dash_p2p_messages.cpp
+++ b/test/test_dash_p2p_messages.cpp
@@ -227,3 +227,68 @@ TEST(DashP2PMessages, CommandStringsPinned) {
     CSimplifiedMNListDiff d;
     EXPECT_EQ(message_mnlistdiff::make_raw(d)->m_command, "mnlistdiff");
 }
+// ─── inv → getdata sourcing policy (the ChainLock acquisition leg) ──────────
+//
+// MSG_CLSIG was decodable and handled long before it was ever REQUESTED: the
+// inv handler only ever issued a getdata for type 21, so `clsig` never arrived
+// and on_new_chainlock never fired. These lock the pull policy the inv handler
+// actually consults (dash::coin::p2p::inv_type_is_pulled), so dropping the
+// ChainLock leg again goes red.
+
+TEST(DashP2PMessages, InvTypeNumbersMatchDashcoreProtocol) {
+    // dashcore src/protocol.h enum GetDataMsg
+    EXPECT_EQ(static_cast<uint32_t>(inventory_type::quorum_final_commitment), 21u);
+    EXPECT_EQ(static_cast<uint32_t>(inventory_type::clsig), 29u);   // protocol.h:522
+}
+
+TEST(DashP2PMessages, InvPullPolicyCoversChainLocksAndCommitments) {
+    EXPECT_TRUE(inv_type_is_pulled(inventory_type::clsig))
+        << "ChainLocks are inv-announced and served only on getdata; without "
+           "this the clsig handler can never fire";
+    EXPECT_TRUE(inv_type_is_pulled(inventory_type::quorum_final_commitment));
+
+    // Types we must NOT blind-getdata: blocks take the getheaders-first path,
+    // and we do not pull the tx mempool.
+    EXPECT_FALSE(inv_type_is_pulled(inventory_type::block));
+    EXPECT_FALSE(inv_type_is_pulled(inventory_type::tx));
+    EXPECT_FALSE(inv_type_is_pulled(inventory_type::filtered_block));
+}
+
+TEST(DashP2PMessages, GetdataForClsigInvRoundTripsOnTheWire) {
+    // What the inv handler builds for an announced ChainLock: a getdata
+    // echoing the announcement's type and hash (the hash is
+    // SerializeHash(clsig), which we cannot derive and must echo verbatim).
+    const uint256 inv_hash = raw256_seq(0xC1);
+    auto raw = message_getdata::make_raw(
+        {inventory_type(inventory_type::clsig, inv_hash)});
+    EXPECT_EQ(raw->m_command, "getdata");
+
+    auto parsed = message_getdata::make(raw->m_data);
+    ASSERT_EQ(parsed->m_requests.size(), 1u);
+    EXPECT_EQ(static_cast<uint32_t>(parsed->m_requests[0].m_type), 29u);
+    EXPECT_EQ(parsed->m_requests[0].m_hash, inv_hash);
+}
+
+TEST(DashP2PMessages, ClsigWireLayoutMatchesRealMainnetChainLock) {
+    // The real 132-byte clsig body from mainnet `getbestchainlock` at 2515965:
+    // int32LE height || blockHash(32 LE) || sig(96). Decoding it must recover
+    // exactly the height and block hash dashd reported.
+    const std::string hex =
+        "fd632600"
+        "8ba8205c0861bc9b6063b67aeff818075a148d1a989502250b00000000000000"
+        "b37fa65f662141fde71d5ead7f3548547aa08915274c188c47554e814770a381"
+        "6b0c772c10fdb6ca1cc8bf851bcb218301454d5aa6c2fd0d3d25162096f416b9"
+        "a629196307efe214b20380c2606c9191550cbefee9ad7e59c05d691929d4a7dd";
+    std::vector<std::byte> body;
+    for (size_t i = 0; i + 1 < hex.size(); i += 2)
+        body.push_back(static_cast<std::byte>(
+            std::stoul(hex.substr(i, 2), nullptr, 16)));
+    ASSERT_EQ(body.size(), 132u);
+
+    PackStream ps(body);
+    auto parsed = message_clsig::make(ps);
+    EXPECT_EQ(parsed->m_height, 2515965);
+    EXPECT_EQ(parsed->m_sig.size(), 96u);
+    EXPECT_EQ(parsed->m_block_hash.GetHex(),
+              "000000000000000b250295981a8d145a0718f8ef7ab663609bbc61085c20a88b");
+}


### PR DESCRIPTION
## Live-path ChainLock acquisition + BLS verification

`best_cl_height`'s only live writer was the **lagging** derivation from a block's
already-committed `bestCLHeightDiff` (`coin_state_maintainer.hpp`), so our CCbTx
freshness was coupled to whatever ChainLock some *other* miner's node happened to
hold when it mined the tip. This adds the direct lane: pull ChainLocks off the
coin-P2P stream, and **BLS-verify each one against the quorum dashcore says must
have signed it** before its height may move `best_cl_height`.

> ### ⚠ This only functions in a `C2POOL_DASH_BLS=ON` build
> Without the backend, `verify_chainlock_sig()` is a fail-closed stub that
> returns `false`, so **no ChainLock is ever adopted** and `best_cl_height`
> stays exactly where it is today. The option defaults to **OFF** and no CI
> workflow enables it yet (PR #890). Merging this PR alone therefore does **not**
> unblock the embedded arm — the deployed binary must be built with the backend
> linked. `scripts/ci/dash_bls_linked_guard.sh` is the check
> (`strings <bin> | grep BLS_SIG_BLS12381G2_XMD...`); a BLS-dark binary is
> indistinguishable from a real one at runtime except that it silently never
> adopts.

Acquisition and verification land **together**, deliberately. A fetch without
verification would be *worse* than the status quo: a `clsig` arrives from an
arbitrary peer and its `{height, blockHash, sig}` go straight into the coinbase of
every template we then serve, so an unverified adoption hands a hostile peer our
CCbTx and costs us the block. The lagging value is at least chain-committed.

### Premise verified against the tree, with one correction

Confirmed at master `82c80570`:

* `MSG_CLSIG = 29` was absent from `inventory_type` (`base_p2p_messages.hpp`), and
  the inv handler (`p2p_client.hpp`) issued `getdata` only for type 21. Dash
  **announces** ChainLocks by inv and serves them only on `getdata`
  (dashcore `chainlock/handler.cpp:128` + `RelayInv`; `net_processing.cpp:2992-2998`)
  — it never pushes `clsig`. So the `clsig` handler was **unreachable**: decodable,
  wired, and never once fired. `chainlock_verify.hpp` did not exist.

Corroborated in the field: the hotel node on current master with the embedded
arm opted in refuses every template with
`[EMBED-GATE] cause=bestcl-stale value=n/a threshold=>=2515969` — `value=n/a`,
i.e. `best_cl_height` has never been written at all, not merely stale.

**Corrected:** the brief's "one piece of work, two causes" does not hold. The
Phase-L commitment verifier `qc-plan-underivable` needs is **not** missing — it
exists (`vendor/bls_verify.cpp` `verify_final_commitment` /
`make_commitment_bls_verifier`) and is already wired with a real member-key
provider at `main_dash.cpp:3193-3200`. That lane is blocked by member-set
*sourcing* and by `C2POOL_DASH_BLS` being OFF in CI (PR #890), not by a missing
verifier. ChainLock verification is a genuinely different function (one recovered
threshold signature vs. aggregate `membersSig` + `quorumSig`); the two share only
the BLS backend. This PR does not unblock the QC lane.

### Upstream contract (dashcore v23.1.7, cited per step)

```
requestId = SHA256d(0x05 "clsig" int32LE(nHeight))        chainlock/clsig.cpp:29-32 (+ :12)
quorum    = argmin over the signingActiveQuorumCount newest quorums at (nHeight-8)
            of SHA256d(u8(llmqType) || quorumHash || requestId)
                                                          llmq/quorumsman.cpp:676-737
            SIGN_HEIGHT_OFFSET=8                          llmq/quorumsman.h:184
signHash  = SHA256d(u8(llmqType) || quorumHash || requestId || blockHash)
                                                          llmq/signhash.cpp:14-22
            msgHash = clsig.blockHash                     chainlock/handler.cpp:330-333
verify    = BasicSchemeMPL.Verify(quorumPublicKey/G1, signHash/32B, sig/G2)
                                                          llmq/quorumsman.cpp:749-751
                                                          bls/bls.cpp:294-310
llmqTypeChainLocks: mainnet LLMQ_400_60(2), testnet LLMQ_50_60(1)
                                                          chainparams.cpp:274 / :467
MSG_CLSIG = 29                                            protocol.h:522
```

The in-tree `kLlmq400_60 {2,400,300,240,288,20,28,4,false}` row was checked
against upstream `llmq/params.h` and matches exactly.

### An ordering trap this would have silently hit

dashcore sorts the selection scores with `uint256::operator<`, which for its
`base_blob` is **`memcmp`, least-significant byte first** (`uint256.h:55`).
c2pool's `uint256` is `base_uint<256>` — an **arithmetic bignum** whose
`operator<` compares **most-significant word first** (`core/uint256.cpp:122-131`).
The two orderings **disagree**, and on the real mainnet vector below they select
**different quorums**. `score_less()` is therefore an explicit LSB-first `memcmp`
and must never be "simplified" into `operator<`;
`ScoreOrderingIsMemcmpNotBignum` fails if it is.

### What landed

* `src/impl/dash/coin/chainlock_verify.hpp` *(new)* — request id, sign hash,
  the `ScanQuorums` DKG-window snapping, and `SelectQuorumForSigning`. No BLS
  dependency, so it is testable in every build.
* `vendor/bls_verify.{hpp,cpp}` — `verify_chainlock_sig()`, basic scheme
  hard-pinned, fail-closed; reuses the existing gated dashbls backend.
* `base_p2p_messages.hpp` — `clsig = 29` and `quorum_final_commitment = 21` in
  the inventory enum (type 21 was a bare magic number).
* `p2p_messages.hpp` — `inv_type_is_pulled()`, the inv→getdata policy the
  handler consults, so it is testable without a live socket. Also **corrects a
  stale comment** that claimed the signature "is not required — we treat it as
  opaque bytes".
* `p2p_client.hpp` — the inv handler now issues `getdata` for both pulled types.
* `coin_state_maintainer.hpp` — `set_chainlock_verify_fn()` seam;
  `on_new_chainlock()` takes the block hash and is **fail-closed**: no verifier
  or a failing verify adopts nothing.
* `main_dash.cpp` — installs the real verifier over the mnlistdiff-sourced
  active quorum set + header-chain heights, and refuses ChainLocks above our own
  tip (`embedded_gbt.hpp:496-503` zeroes the bestCL fields in that case, and
  adoption is monotonic, so we would be pinned at zero — holding the previous
  ChainLock is strictly better).

### Tests — real mainnet vector, and mutations

Fixture captured read-only from mainnet dashd v23.1.7: `getbestchainlock` at tip
**2515965**, plus `quorum list` / `quorum info 2 <hash>` for the four LLMQ_400_60
candidates and their aggregate public keys. Ground truth for the selection is
dashd's **own** `quorum selectquorum 2 <requestId>`.

| Claim | Test |
|---|---|
| request id preimage | `RequestIdMatchesDashcore` |
| scan set == dashd's `quorum list` | `ScanSetMatchesDashdQuorumList` |
| pool capped at `signingActiveQuorumCount` | `ScanSetIsCappedAtSigningActiveQuorumCount` |
| `SIGN_HEIGHT_OFFSET` == 8 | `SignHeightOffsetIsEightAndChangesTheScanSet` |
| selection == dashd's `selectquorum` | `SelectsTheQuorumDashdSelected` |
| memcmp (not bignum) score ordering | `ScoreOrderingIsMemcmpNotBignum` |
| sign hash preimage | `SignHashMatchesDashcore` |
| **real mainnet ChainLock verifies** | `RealChainLockVerifies` |
| **tampered signature rejected** | `TamperedSignatureIsRejected` |
| forged (attacker-keyed) sig rejected | `ForgedSignatureIsRejected` |
| **internally valid sig from a non-designated quorum rejected** | `InternallyValidSignatureFromWrongQuorumIsRejected` |
| wrong quorum key rejected | `WrongQuorumKeyIsRejected` |
| wrong height / wrong block rejected | `WrongHeightIsRejected`, `WrongBlockHashIsRejected` |
| adoption gated on verification | `OnNewChainlockFailsClosedWithoutVerifier`, `OnNewChainlockRejectedWhenVerifierSaysNo` |
| inv→getdata path | `InvPullPolicyCoversChainLocksAndCommitments`, `GetdataForClsigInvRoundTripsOnTheWire`, `ClsigWireLayoutMatchesRealMainnetChainLock` |

**Tampered-signature mutation (the load-bearing one).** `TamperedSignatureIsRejected`
flips one bit at byte 0 bit 5 — chosen because the result **still deserializes as a
valid G2 point**, so the rejection comes from the pairing check itself rather than
the decoder — then sweeps every single-bit flip across a sample of byte positions.
`ForgedSignatureIsRejected` uses a structurally perfect signature over the correct
sign hash produced by an attacker-controlled key.

**The wrong-quorum attack.** `InternallyValidSignatureFromWrongQuorumIsRejected`
is the case a naive "does the BLS math check out" implementation *passes*: the
attacker mints a real threshold key, substitutes it into the active quorum set,
and signs a correctly-constructed ChainLock sign hash for **their** slot. The
signature is internally perfect. The test carries a **control assertion** proving
it genuinely verifies under the quorum it was made for — so the rejection is
specifically the selection binding, not a broken signature. Because
`SelectQuorumForSigning` designates a different quorum for this height, and we
verify only against that quorum's key, it is refused.

Mutation results (each applied, rebuilt, run, reverted):

| # | Mutation | Caught by |
|---|---|---|
| 1 | `score_less` → `uint256::operator<` (the bignum trap) | `ScoreOrderingIsMemcmpNotBignum`, `SelectsTheQuorumDashdSelected`, `SignHashMatchesDashcore`, `RealChainLockVerifies`, `WrongQuorumKeyIsRejected` |
| 2 | `verify_chainlock_sig` → `return true` (accept-everything) | **6 tests**, incl. `TamperedSignatureIsRejected` |
| 3 | request-id prefix `"clsig"` → `"clsg"` | 4 tests |
| 4 | `SIGN_HEIGHT_OFFSET` 8 → 0 | `SignHeightOffsetIsEightAndChangesTheScanSet` |
| 5 | scan-set cap removed | `ScanSetIsCappedAtSigningActiveQuorumCount` |
| 6 | drop `clsig` from the inv pull policy (re-creates the original bug) | `InvPullPolicyCoversChainLocksAndCommitments` |
| 7 | selection binding broken (designate a non-lowest-score quorum) | `InternallyValidSignatureFromWrongQuorumIsRejected` + 5 others |

Mutation 7 is the one that matters for the safety property: with the selection
binding broken, the wrong-quorum attack **succeeds**. Mutation 2
(`verify_chainlock_sig` → `return true`) reds **7 tests**, including both the
tampered-signature and wrong-quorum negatives — so an accept-everything verifier,
which would produce a flawless live soak, cannot reach master.

Mutations 4 and 5 were **not** caught by the first draft — the fixture has exactly
four quorums and most heights snap identically under offset 0 and 8. Both tests
were added specifically to close those holes, and each carries a control assertion
proving the case is reachable.

Built and run with the real backend (`-DC2POOL_DASH_BLS=ON`):
`test_dash_chainlock_verify` **19/19**, `test_dash_p2p_messages` 12/12,
`test_dash_coin_state_maintainer` 19/19. Also configured and built with
`-DC2POOL_DASH_BLS=OFF` (the CI default): compiles clean, and the 11 non-BLS
tests pass. `c2pool-dash` links in both configurations.

### Not established

* **No live soak.** Correctness is proven against a captured mainnet ChainLock,
  not against a running node adopting ChainLocks over hours. The availability
  claim (~14% of wall-clock) is *not* re-measured here. Note a soak cannot
  substitute for the mutations above: a soak only ever meets honest peers, so an
  accept-everything verifier would produce a perfect soak.
* **The getdata leg has not been exercised against a live peer.** That the
  inv→getdata policy is correct is unit-tested; that a real dashd answers our
  getdata with a `clsig` is not yet observed. This is the first thing a soak
  should confirm.
* `test_dash_chainlock_verify`'s BLS half only runs where `C2POOL_DASH_BLS=ON`;
  no CI workflow enables it yet (PR #890). The hash/selection half — including
  the ordering trap and the offset — runs in **every** build, which is why the
  target is deliberately registered outside the BLS gate.
* Rotated (DIP-24) LLMQ types are not supported by `scan_quorum_set`; neither
  network signs ChainLocks with one.
* The scan set uses each quorum's base height plus `mining_window_end` as the
  conservative bound on its mined-commitment height. That can only ever *omit* a
  quorum upstream would include (→ selection mismatch → verify fails → we keep
  the old value), never admit one it would not.
