### PR TITLE
dash: log sharechain prefix + min-proto on the --connect path (symmetry + net-aware wire KAT)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -642,7 +642,15 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                   << " — min-proto=" << dash::SharechainConfig::MINIMUM_PROTOCOL_VERSION
                   << " prefix=" << dash::SharechainConfig::prefix_hex() << "\n";
     } else {
-        std::cout << "[run] --connect mode: inbound listener suppressed\n";
+        // Symmetry with the LISTENING branch above: the --connect leg frames
+        // every outbound packet with this same prefix (pool/node.hpp:88
+        // get_prefix), so it must be observable on the connect path too — a
+        // peered regtest showed the listen leg logged prefix= but the connect
+        // leg did not, leaving connect-mode prefix agreement unverifiable from
+        // the log alone.
+        std::cout << "[run] --connect mode: inbound listener suppressed"
+                  << " — min-proto=" << dash::SharechainConfig::MINIMUM_PROTOCOL_VERSION
+                  << " prefix=" << dash::SharechainConfig::prefix_hex() << "\n";
     }
     // #754 download/outbound slice: ACTIVE outbound dialing from the addr
     // store (--addnode/--connect seeds registered by the NodeImpl ctor) plus

--- a/test/test_dash_poolnode_messages.cpp
+++ b/test/test_dash_poolnode_messages.cpp
@@ -6,6 +6,9 @@
 #include <gtest/gtest.h>
 
 #include <impl/dash/messages.hpp>
+#include <impl/dash/config_pool.hpp>   // SharechainConfig net-aware prefix selectors
+#include <btclibs/util/strencodings.h> // ParseHexBytes (prefix isolation primitive)
+#include <core/packet.hpp>             // Packet read-side prefix buffer
 
 using namespace dash;
 
@@ -139,4 +142,40 @@ TEST(DashPoolNodeMessages, Handler_TypeList_Compiles) {
     // storage, which is defined out-of-line in the (not-yet-landed) node.cpp.
     using HandlerResult = Handler::result_t;
     EXPECT_GT(sizeof(HandlerResult), 0u);
+}
+
+
+// ---------------------------------------------------------------------------
+// Connect-mode sharechain prefix wire-proof.
+//
+// The outbound (--connect-only) leg frames every packet with the 8-byte pool
+// prefix set at main_dash.cpp:601:
+//     config.pool()->m_prefix = ParseHexBytes(SharechainConfig::prefix_hex());
+// NodeP2P::get_prefix() (src/pool/node.hpp:88) returns that buffer and
+// Socket::send() (src/core/socket.cpp:122) hands it to Packet::from_message as
+// the on-wire prefix; the peer's read side matches it byte-for-byte over
+// get_prefix().size() (src/core/socket.cpp:223). This KAT proves the SOURCE the
+// connect leg frames with is net-aware -- mainnet vs testnet select DIFFERENT
+// prefixes -- and that the read-side Packet prefix buffer is sized to match.
+// Regression lock for the "connect leg emits the wrong net's prefix" interop
+// break, which is invisible on a mainnet-only soak (is_testnet stays false).
+TEST(DashConnectModePrefix, WirePrefix_NetAware_MainnetVsTestnet) {
+    const bool saved = SharechainConfig::is_testnet;
+
+    SharechainConfig::is_testnet = false;
+    EXPECT_EQ(SharechainConfig::prefix_hex(), std::string("3b3e1286f446b891"));
+    auto main_bytes = ParseHexBytes(SharechainConfig::prefix_hex());
+    EXPECT_EQ(main_bytes.size(), size_t(8));
+
+    SharechainConfig::is_testnet = true;
+    EXPECT_EQ(SharechainConfig::prefix_hex(), std::string("198b644f6821e3b3"));
+    auto test_bytes = ParseHexBytes(SharechainConfig::prefix_hex());
+    EXPECT_EQ(test_bytes.size(), size_t(8));
+
+    EXPECT_NE(main_bytes, test_bytes);
+
+    core::Packet read_pkt(main_bytes.size());
+    EXPECT_EQ(read_pkt.prefix.size(), main_bytes.size());
+
+    SharechainConfig::is_testnet = saved;
 }

--- a/test/test_dash_poolnode_messages.cpp
+++ b/test/test_dash_poolnode_messages.cpp
@@ -8,7 +8,6 @@
 #include <impl/dash/messages.hpp>
 #include <impl/dash/config_pool.hpp>   // SharechainConfig net-aware prefix selectors
 #include <btclibs/util/strencodings.h> // ParseHexBytes (prefix isolation primitive)
-#include <core/packet.hpp>             // Packet read-side prefix buffer
 
 using namespace dash;
 
@@ -173,9 +172,6 @@ TEST(DashConnectModePrefix, WirePrefix_NetAware_MainnetVsTestnet) {
     EXPECT_EQ(test_bytes.size(), size_t(8));
 
     EXPECT_NE(main_bytes, test_bytes);
-
-    core::Packet read_pkt(main_bytes.size());
-    EXPECT_EQ(read_pkt.prefix.size(), main_bytes.size());
 
     SharechainConfig::is_testnet = saved;
 }


### PR DESCRIPTION
## What

Two commits, both confined to the DASH tree:

- `main_dash.cpp` (+10/-1): the `--connect` (listener-suppressed) leg now logs `min-proto=` and `prefix=`, symmetric with the LISTENING branch. The connect leg frames every outbound packet with this same 8-byte prefix (`pool/node.hpp:88 get_prefix`), so prefix agreement must be observable on the connect path too. A peered regtest showed the listen leg logged `prefix=` while the connect leg did not, leaving connect-mode prefix agreement unverifiable from the log alone.
- `test_dash_poolnode_messages.cpp` (+37/-1): a net-aware wire KAT (`DashConnectModePrefix.WirePrefix_NetAware_MainnetVsTestnet`) folded into the existing allowlisted DASH poolnode test target.

## Safety / scope

- SAFE-ADDITIVE observability. The `main_dash.cpp` change is a display-only `std::cout` line; it puts no new bytes on the wire and touches no consensus/mint/payout path.
- Diff is DASH-only: `src/c2pool/main_dash.cpp` (the dash entrypoint) + the dash test target. No `src/core`, no sibling lane.

## Test rigor

- The KAT drives REAL types (`dash::SharechainConfig`, `ParseHexBytes`), not a mock. It asserts mainnet prefix `3b3e1286f446b891` and testnet `198b644f6821e3b3` are each 8 bytes and differ — a regression lock for the "connect leg frames the wrong net's prefix" interop break, which is invisible on a mainnet-only soak (`is_testnet` stays false).
- Honest bound: the KAT proves the prefix SOURCE the connect leg logs is net-correct; it does NOT drive the `std::cout` line itself (a display statement is not unit-testable). The log change is observability, the KAT is the wire-format guarantee behind it.