### PR TITLE
btc(dashboard): wire live BTC feeds into the WebServer seam (D-BTC)

### DIFF
--- a/src/c2pool/main_btc.cpp
+++ b/src/c2pool/main_btc.cpp
@@ -1660,6 +1660,49 @@ int main(int argc, char* argv[])
         mi->set_io_context(&ioc);
         web_server->set_stratum_port(stratum_port);
 
+        // D-BTC dashboard feeds (integrator 2026-08-03): mirror of D-BCH
+        // (PR #1055) into the live MiningInterface the H-STATS.944 seam already
+        // stood up with a NULL IMiningNode + zero feeds (so /api rendered empty).
+        // BTC has no coin/embedded_daemon.hpp dashboard_topology() -- its embedded
+        // transport is coin_node (BTC P2P) + an optional submitblock RPC fallback
+        // -- so node_topology is synthesized inline from header_chain + coin_node,
+        // and the sharechain feeds read the p2p_node NodeBridge accessors exactly
+        // like the proven LTC feeders (main_ltc.cpp:2861/3378). Reuses the generic
+        // core/web_server.hpp setters -- ZERO src/core edit. All captured objects
+        // are declared above at main scope and outlive ioc.run(); all reads are
+        // display-only (lock-free snapshots/atomics).
+        mi->set_peer_info_fn([p2p_node_raw]() -> nlohmann::json {
+            return p2p_node_raw->get_peer_info_json();
+        });
+        mi->set_pool_hashrate_fn([p2p_node_raw]() -> double {
+            return p2p_node_raw->get_tracker_snapshot().pool_hashrate;
+        });
+        mi->set_sharechain_stats_fn([p2p_node_raw]() {
+            auto s = p2p_node_raw->get_tracker_snapshot();
+            return nlohmann::json{
+                {"chain_count", s.chain_count},
+                {"verified_count", s.verified_count},
+                {"head_count", s.head_count},
+                {"pool_hashrate", s.pool_hashrate},
+            };
+        });
+        mi->set_node_topology_fn([&header_chain, &coin_node]() {
+            const uint32_t synced   = header_chain.height();
+            const uint32_t peer_tip = header_chain.peer_tip_height();
+            const bool     emb_p2p  = coin_node.has_p2p();
+            const bool     ext_rpc  = coin_node.has_rpc();
+            return nlohmann::json{
+                {"coin", "BTC"},
+                {"embedded", true},
+                {"has_rpc", ext_rpc},
+                {"synced_height", synced},
+                {"peer_tip_height", peer_tip},
+                {"sync_pct", (peer_tip > 0 ? 100.0 * synced / peer_tip : 0.0)},
+                {"embedded_peers", emb_p2p ? 1 : 0},
+                {"broadcast_route", emb_p2p ? "p2p" : (ext_rpc ? "rpc" : "none")},
+            };
+        });
+
         // graph_db stats persistence â survives restarts (LTC-parity site 2/3,
         // mirrors main_ltc.cpp:1967-1973). BTC-namespaced sub-dir keeps the per-coin
         // stat log isolated under the shared config path.

--- a/src/impl/btc/coin/header_chain.hpp
+++ b/src/impl/btc/coin/header_chain.hpp
@@ -554,6 +554,12 @@ public:
     /// Set the estimated network tip height (from peer's version message).
     void set_peer_tip_height(uint32_t height) { m_peer_tip_height.store(height); }
 
+    /// Estimated network tip height from the peer version handshake; 0 before
+    /// the first peer reports. Read-only display accessor for the D-BTC
+    /// dashboard sync-progress datum (synced height vs peer tip). Mirrors the
+    /// D-BCH peer_tip_height() getter (PR #1055).
+    uint32_t peer_tip_height() const { return m_peer_tip_height.load(std::memory_order_relaxed); }
+
     /// Dynamically seed a checkpoint at runtime (e.g., from RPC getblockhash).
     /// Only applied if the chain is still at or below the hardcoded checkpoint.
     /// This allows an accessible daemon to provide a more recent starting point.


### PR DESCRIPTION
## D-BTC: live BTC dashboard feeds off the #1053 WebServer seam

Serves share-peers, embedded-BTC-core peers/synced, NMC-aux, and hashrate
off the WebServer seam landed in #1053. BTC-native re-derivation (not a
#1055 copy): BTC has no `coin/embedded_daemon.hpp`, so node_topology is
synthesized inline from `header_chain` + `coin_node`; the sharechain feeds
via `p2p_node_raw` NodeBridge `get_peer_info_json` / `get_tracker_snapshot`
(LTC-parity). Adds `HeaderChain::peer_tip_height()` getter. Zero `src/core`
changes.

### Scope
- `src/c2pool/main_btc.cpp` (+43)
- `src/impl/btc/coin/header_chain.hpp` (+6, `peer_tip_height()` getter)

BCH `get_tracker_snapshot()` shape is kept unchanged (not switched to LTC
`read_tracker`).

### Evidence / honest bound
Persistence is proven via `memory_usage`, captured across a full
SIGINT + relaunch:
- Pre-restart capture: Side A `memory_usage` 2 points -> "Saved 2"
- Post-restart capture: "Loaded 2" -> same 2 points byte-identical on
  `/web/graph_data/<source>/<view>`, plus 1 fresh live point.
- Live version served off the accepted head:
  `C2POOL_VERSION=c2pool/0.2.4-287-g42825dde7`.
- Harness + both captures preserved at `/tmp/dbtc_proof_keep`.

`pool_hash_rate` reads zero because the harness had no stratum miner
attached. That is a legitimate zero, not the unpopulated-accessor tell;
`memory_usage` moving and persisting is what discriminates the two.

### Follow-up (next slice, not a gate for this PR)
Share-producing regtest (bitcoind + stratum + minerd) for non-zero
tracker-accessor evidence.
