### PR TITLE
dash(coin-p2p): Dash Core ping/pong liveness — stop killing quiet peers at 100s

### DIFF
--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -12,7 +12,8 @@
 //   * handshake: version/verack (HandshakeTracker below — the KAT'd state
 //     machine), advertising protocol 70230, the SAME version the vendored
 //     SML/clsig codecs assume (vendor/smldiff.hpp, vendor/quorum_tail.hpp);
-//   * keep-alive: 30s ping cadence + idle/handshake timeout teardown;
+//   * keep-alive: Dash-Core-semantics ping/pong liveness (PeerLiveness below)
+//     + handshake timeout teardown;
 //   * reconnect: 30s retry while disconnected, rotating the dial plan.
 //
 // Ported 1:1 from the PROVEN per-coin clients (src/impl/dgb/coin/p2p_node.hpp
@@ -48,6 +49,9 @@
 #include <impl/dash/coin/historical_sml.hpp>    // HistoricalMnListDiffDemux (reward-critical tip/historical split)
 
 #include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <exception>
 #include <memory>
 #include <string>
 #include <vector>
@@ -160,6 +164,127 @@ public:
     }
 };
 
+// ── Peer liveness policy (pure, KAT-able) ────────────────────────────────
+//
+// Decides, from timestamps alone, whether a peer is still alive. Extracted
+// from the client so the rules are unit-testable without sockets or wall
+// clocks (test/test_dash_coin_p2p_client.cpp).
+//
+// WHY THIS EXISTS. The previous rule was a single "no inbound message for
+// IDLE_TIMEOUT_SEC (100s) => drop". That rule cannot tell "healthy and quiet"
+// from "dead": a peer that is synced with us at the chain tip legitimately
+// sends nothing for minutes at a time, so the better-synced we are, the
+// faster we killed our own peers. Every inv-PUSHED message type — qfcommit
+// (announced once, at DKG finalize) and clsig (announced ~once per block) —
+// requires being connected AT THE MOMENT the peer announces, so peer churn
+// destroys their acquisition probability. Request/response traffic
+// (getmnlistd -> mnlistdiff) survives churn because we re-ask on every fresh
+// handshake; inv-push does not. That asymmetry is exactly why the masternode
+// bridge completes while the quorum plan never does.
+//
+// The replacement mirrors Dash Core / Bitcoin Core net.cpp:
+//
+//   * ping the peer once it has been quiet for m_ping_interval_sec
+//     (Dash Core PING_INTERVAL = 2 min);
+//   * ANY inbound message — pong included — is liveness evidence and pushes
+//     the deadline out;
+//   * only drop when a ping has gone UNANSWERED past m_peer_timeout_sec
+//     (Dash Core TIMEOUT_INTERVAL = 20 min), or when nothing at all has been
+//     received for that same interval.
+//
+// INVARIANT: liveness is evidence about the PEER. Nothing we SEND may push
+// the deadline out — that is what turns a half-open socket into a connection
+// we believe is healthy. The only mutator of m_last_recv is on_inbound().
+class PeerLiveness
+{
+public:
+    enum class Action
+    {
+        None,             // nothing to do this tick
+        SendPing,         // peer has been quiet for ping_interval; probe it
+        DropIdle,         // nothing received at all within peer_timeout
+        DropPingTimeout,  // our ping went unanswered past peer_timeout
+    };
+
+private:
+    time_t m_ping_interval_sec{120};
+    time_t m_peer_timeout_sec{1200};
+
+    int64_t  m_last_recv{0};
+    bool     m_ping_outstanding{false};
+    int64_t  m_ping_sent_at{0};
+    uint64_t m_ping_nonce{0};
+    uint64_t m_pings_sent{0};
+    uint64_t m_pongs_matched{0};
+
+public:
+    void configure(time_t ping_interval_sec, time_t peer_timeout_sec)
+    {
+        if (ping_interval_sec > 0) m_ping_interval_sec = ping_interval_sec;
+        if (peer_timeout_sec > 0)  m_peer_timeout_sec = peer_timeout_sec;
+    }
+
+    time_t ping_interval_sec() const { return m_ping_interval_sec; }
+    time_t peer_timeout_sec() const { return m_peer_timeout_sec; }
+
+    /// Begin (or restart) a session at `now` — call on handshake completion.
+    /// Counters are session-scoped and reset with it.
+    void start(int64_t now)
+    {
+        m_last_recv = now;
+        m_ping_outstanding = false;
+        m_ping_sent_at = 0;
+        m_ping_nonce = 0;
+        m_pings_sent = 0;
+        m_pongs_matched = 0;
+    }
+
+    /// ANY inbound message. The ONLY thing that pushes the deadline out.
+    void on_inbound(int64_t now) { m_last_recv = now; }
+
+    /// A pong. Only a nonce MATCHING the outstanding ping clears it — a peer
+    /// must not be able to hold a link "alive" by replaying an old nonce, and
+    /// an unsolicited pong is not an answer to anything. Returns true if this
+    /// pong closed the outstanding ping.
+    bool on_pong(uint64_t nonce, int64_t now)
+    {
+        on_inbound(now);
+        if (!m_ping_outstanding || nonce != m_ping_nonce)
+            return false;
+        m_ping_outstanding = false;
+        ++m_pongs_matched;
+        return true;
+    }
+
+    /// Record that a ping with `nonce` was actually written to the wire.
+    void note_ping_sent(uint64_t nonce, int64_t now)
+    {
+        m_ping_outstanding = true;
+        m_ping_nonce = nonce;
+        m_ping_sent_at = now;
+        ++m_pings_sent;
+    }
+
+    /// Evaluate the policy. Pure: the caller performs the action and reports
+    /// a ping back through note_ping_sent().
+    Action tick(int64_t now) const
+    {
+        if (m_ping_outstanding && (now - m_ping_sent_at) >= m_peer_timeout_sec)
+            return Action::DropPingTimeout;
+        if ((now - m_last_recv) >= m_peer_timeout_sec)
+            return Action::DropIdle;
+        if (!m_ping_outstanding && (now - m_last_recv) >= m_ping_interval_sec)
+            return Action::SendPing;
+        return Action::None;
+    }
+
+    bool ping_outstanding() const { return m_ping_outstanding; }
+    uint64_t ping_nonce() const { return m_ping_nonce; }
+    uint64_t pings_sent() const { return m_pings_sent; }
+    uint64_t pongs_matched() const { return m_pongs_matched; }
+    int64_t last_recv() const { return m_last_recv; }
+};
+
 #define ADD_P2P_HANDLER(name)\
     void handle(std::unique_ptr<dash::coin::p2p::message_##name> msg)
 
@@ -172,8 +297,16 @@ class CoinClient : public core::ICommunicator, public core::INetwork, public cor
 
 private:
     static constexpr time_t CONNECT_TIMEOUT_SEC = 10;
-    static constexpr time_t IDLE_TIMEOUT_SEC = 100;
-    static constexpr time_t PING_INTERVAL_SEC = 30;
+    // Dash Core net.h PING_INTERVAL: probe a peer that has been quiet this long.
+    static constexpr time_t PING_INTERVAL_SEC = 120;
+    // Dash Core net.h TIMEOUT_INTERVAL: drop only when a ping has gone
+    // UNANSWERED this long (or nothing at all arrived in that window). This
+    // replaces the old 100s "peer sent us nothing => peer is dead" rule, which
+    // could not distinguish a healthy tip-synced peer from a dead one.
+    static constexpr time_t PEER_TIMEOUT_SEC = 1200;
+    // How often the liveness policy is evaluated. Only a scheduling grain —
+    // the decisions themselves are timestamp-based, so this never changes them.
+    static constexpr time_t LIVENESS_TICK_SEC = 10;
     static constexpr time_t RECONNECT_INTERVAL_SEC = 30;
 
     // Dash Core PROTOCOL_VERSION we advertise. MUST stay >= 70230: the
@@ -190,8 +323,13 @@ private:
 
     std::unique_ptr<Connection> m_peer;
     std::unique_ptr<core::Timer> m_reconnect_timer;
-    std::unique_ptr<core::Timer> m_ping_timer;
+    // Repeating post-handshake keepalive/liveness tick. Drives m_liveness.
+    std::unique_ptr<core::Timer> m_liveness_timer;
+    // One-shot HANDSHAKE deadline only (CONNECT_TIMEOUT_SEC). Post-handshake
+    // liveness is m_liveness_timer's job.
     std::unique_ptr<core::Timer> m_timeout_timer;
+    PeerLiveness m_liveness;
+    time_t m_liveness_tick_sec{LIVENESS_TICK_SEC};
     DialPlan m_dial_plan;
     bool m_reconnect_enabled = false;
     HandshakeTracker m_handshake;
@@ -257,7 +395,7 @@ public:
     {
         m_reconnect_enabled = false;
         if (m_reconnect_timer) m_reconnect_timer->stop();
-        stop_ping_timer();
+        stop_liveness_timer();
         stop_timeout_timer();
     }
 
@@ -347,7 +485,7 @@ public:
 
     void disconnect() override
     {
-        stop_ping_timer();
+        stop_liveness_timer();
         stop_timeout_timer();
         m_handshake.reset();
         m_peer.reset();
@@ -387,6 +525,29 @@ public:
     int64_t peer_uptime_sec() const {
         return std::chrono::duration_cast<std::chrono::seconds>(
             std::chrono::steady_clock::now() - m_connected_at).count();
+    }
+
+    // ── keepalive observability ──────────────────────────────────────────
+    /// Whether a ping we sent is still waiting for its pong.
+    bool ping_outstanding() const { return m_liveness.ping_outstanding(); }
+    /// Pings sent / pongs matched in the CURRENT session (reset per handshake).
+    uint64_t pings_sent() const { return m_liveness.pings_sent(); }
+    uint64_t pongs_matched() const { return m_liveness.pongs_matched(); }
+    /// Nonce of the most recent ping (0 before the first one).
+    uint64_t last_ping_nonce() const { return m_liveness.ping_nonce(); }
+    time_t ping_interval_sec() const { return m_liveness.ping_interval_sec(); }
+    time_t peer_timeout_sec() const { return m_liveness.peer_timeout_sec(); }
+
+    /// TEST-ONLY: scale the keepalive cadence so the liveness policy can be
+    /// driven in seconds of real time rather than minutes. Production never
+    /// calls this — the defaults are PING_INTERVAL_SEC / PEER_TIMEOUT_SEC /
+    /// LIVENESS_TICK_SEC. Call BEFORE the handshake completes; the tick
+    /// interval is read when the liveness timer is armed.
+    void set_keepalive_for_test(time_t ping_interval_sec, time_t peer_timeout_sec,
+                                time_t tick_sec)
+    {
+        m_liveness.configure(ping_interval_sec, peer_timeout_sec);
+        if (tick_sec > 0) m_liveness_tick_sec = tick_sec;
     }
 
     // ── E2+ seams ────────────────────────────────────────────────────────
@@ -530,7 +691,7 @@ public:
             m_peer.reset();
         // else: already disconnected (double-fire race) — safe to ignore
 
-        stop_ping_timer();
+        stop_liveness_timer();
         stop_timeout_timer();
         m_handshake.reset();
     }
@@ -544,14 +705,18 @@ public:
     {
         on_activity();
 
+        // Copy the command BEFORE parse: parse() consumes rmsg, and the guard
+        // below has to be able to name what threw.
+        const std::string cmd = rmsg ? rmsg->m_command : std::string("<null>");
+
         p2p::Handler::result_t result;
         try
         {
             result = m_handler.parse(rmsg);
         } catch (const std::runtime_error& ec)
         {
-            LOG_ERROR << "[" << m_chain_label << "] handle(" << rmsg->m_command
-                      << ", " << rmsg->m_data.size() << " bytes): " << ec.what();
+            LOG_ERROR << "[" << m_chain_label << "] handle(" << cmd
+                      << "): " << ec.what();
             return;
         } catch (const std::out_of_range&)
         {
@@ -559,11 +724,50 @@ public:
             // governance/quorum traffic (spork, senddsq, qsendrecsigs, ...)
             // unsolicited; ignoring them is protocol-legal for a light client.
             LOG_DEBUG_COIND << "[" << m_chain_label << "] ignoring unhandled command '"
-                            << rmsg->m_command << "' (" << rmsg->m_data.size() << " bytes)";
+                            << cmd << "'";
+            return;
+        } catch (const std::exception& ec)
+        {
+            // Anything else out of the codec (std::length_error / bad_alloc /
+            // ios_base::failure variants) — see the dispatch guard below for
+            // why NOTHING may escape this function.
+            LOG_ERROR << "[" << m_chain_label << "] parse('" << cmd
+                      << "') threw: " << ec.what() << " — message dropped";
             return;
         }
 
-        std::visit([&](auto& msg){ handle(std::move(msg)); }, result);
+        // ── READ-LOOP PRESERVATION GUARD ─────────────────────────────────
+        //
+        // This function is called from core::Socket::message_processing, and
+        // the socket's read loop is re-armed by the line AFTER that call
+        // (core/socket.cpp Socket::read_payload: `message_processing(packet);
+        // read();`). An exception escaping here therefore unwinds straight
+        // past `read()` and out of the asio completion handler — the socket
+        // stays OPEN, no error() callback ever fires, and the connection
+        // becomes permanently deaf while still looking connected. main_dash's
+        // #755 io-handler guard catches the throw at ioc.run() and resumes the
+        // loop, so the process survives and the damage is invisible: the ONLY
+        // subsequent symptom is this client's own liveness timer firing later
+        // on a peer that has actually been silenced by us.
+        //
+        // Handlers below fan out into subscriber code (new_block /
+        // new_mnlistdiff / new_qfcommit / new_chainlock ...) that we do not
+        // own, so a throw from any of them must be contained here. A bad
+        // message costs that message, never the peer.
+        try
+        {
+            std::visit([&](auto& msg){ handle(std::move(msg)); }, result);
+        } catch (const std::exception& ec)
+        {
+            LOG_ERROR << "[" << m_chain_label << "] handler for '" << cmd
+                      << "' threw: " << ec.what()
+                      << " — message dropped, peer kept (read loop preserved)";
+        } catch (...)
+        {
+            LOG_ERROR << "[" << m_chain_label << "] handler for '" << cmd
+                      << "' threw a non-std exception"
+                      << " — message dropped, peer kept (read loop preserved)";
+        }
     }
 
     const std::vector<std::byte>& get_prefix() const override
@@ -596,10 +800,10 @@ private:
             m_timeout_timer = std::make_unique<core::Timer>(m_context, false);
     }
 
-    void ensure_ping_timer()
+    void ensure_liveness_timer()
     {
-        if (!m_ping_timer)
-            m_ping_timer = std::make_unique<core::Timer>(m_context, true);
+        if (!m_liveness_timer)
+            m_liveness_timer = std::make_unique<core::Timer>(m_context, true);
     }
 
     void stop_timeout_timer()
@@ -608,22 +812,36 @@ private:
             m_timeout_timer->stop();
     }
 
-    void stop_ping_timer()
+    void stop_liveness_timer()
     {
-        if (m_ping_timer)
-            m_ping_timer->stop();
+        if (m_liveness_timer)
+            m_liveness_timer->stop();
     }
 
+    static int64_t now_sec()
+    {
+        return std::chrono::duration_cast<std::chrono::seconds>(
+            std::chrono::steady_clock::now().time_since_epoch()).count();
+    }
+
+    /// Inbound traffic observed. This is the ONLY liveness input — nothing we
+    /// SEND may push the deadline out (see PeerLiveness's invariant).
     void on_activity()
     {
         if (!m_peer)
             return;
-        ensure_timeout_timer();
-        auto timeout = m_handshake.complete() ? IDLE_TIMEOUT_SEC : CONNECT_TIMEOUT_SEC;
-        m_timeout_timer->restart(timeout);
+        m_liveness.on_inbound(now_sec());
+        if (!m_handshake.complete())
+        {
+            // Pre-handshake the deadline is still the short CONNECT one: a
+            // peer that opens a socket and then stalls mid-version must not
+            // hold an outbound slot for the full liveness window.
+            ensure_timeout_timer();
+            m_timeout_timer->restart(CONNECT_TIMEOUT_SEC);
+        }
     }
 
-    void timeout(const char* reason)
+    void timeout(const std::string& reason)
     {
         auto endpoint = m_peer ? m_peer->get_addr()
                                : (m_dial_plan.empty() ? NetService{} : m_dial_plan.current());
@@ -634,8 +852,42 @@ private:
     {
         if (!m_peer || !m_handshake.complete())
             return;
-        auto msg_ping = message_ping::make_raw(core::random::random_nonce());
+        const uint64_t nonce = core::random::random_nonce();
+        auto msg_ping = message_ping::make_raw(nonce);
         m_peer->write(msg_ping);
+        m_liveness.note_ping_sent(nonce, now_sec());
+        LOG_DEBUG_COIND << "[" << m_chain_label << "] ping sent (nonce="
+                        << nonce << ", quiet for "
+                        << (now_sec() - m_liveness.last_recv()) << "s)";
+    }
+
+    /// Post-handshake keepalive tick. Sends a ping to a peer that has gone
+    /// quiet, and drops the peer ONLY on an unanswered ping / total silence
+    /// past PEER_TIMEOUT_SEC.
+    void on_liveness_tick()
+    {
+        if (!m_peer || !m_handshake.complete())
+            return;
+        const int64_t now = now_sec();
+        switch (m_liveness.tick(now))
+        {
+        case PeerLiveness::Action::SendPing:
+            send_ping();
+            break;
+        case PeerLiveness::Action::DropPingTimeout:
+            LOG_WARNING << "[" << m_chain_label << "] ping (nonce="
+                        << m_liveness.ping_nonce() << ") unanswered for "
+                        << m_liveness.peer_timeout_sec() << "s";
+            timeout("ping unanswered for "
+                    + std::to_string(m_liveness.peer_timeout_sec()) + "s");
+            break;
+        case PeerLiveness::Action::DropIdle:
+            timeout("no message received in "
+                    + std::to_string(m_liveness.peer_timeout_sec()) + "s");
+            break;
+        case PeerLiveness::Action::None:
+            break;
+        }
     }
 
     // ── handshake ────────────────────────────────────────────────────────
@@ -682,18 +934,14 @@ private:
                  << " (peer proto=" << m_peer_version
                  << " height=" << m_peer_start_height << ")";
 
-        ensure_timeout_timer();
-        // Rebind the timeout reason at handshake completion: post-handshake
-        // expiries are idle timeouts, not the "handshake timeout" armed in
-        // connected(). start() re-sets m_handler, and on_activity()'s restart()
-        // reuses it — so idle expiries now log the correct reason.
-        m_timeout_timer->start(IDLE_TIMEOUT_SEC, [this]() {
-            timeout("idle timeout");
-        });
+        // The handshake deadline has been met — retire it. From here liveness
+        // is the ping/pong policy, NOT a bare "peer went quiet" stopwatch.
+        stop_timeout_timer();
 
-        ensure_ping_timer();
-        m_ping_timer->start(PING_INTERVAL_SEC, [this]() {
-            send_ping();
+        m_liveness.start(now_sec());
+        ensure_liveness_timer();
+        m_liveness_timer->start(m_liveness_tick_sec, [this]() {
+            on_liveness_tick();
         });
 
         if (m_on_handshake_complete)
@@ -710,7 +958,14 @@ private:
 
     ADD_P2P_HANDLER(pong)
     {
-        // liveness already refreshed by on_activity()
+        // on_activity() already refreshed last-recv for ANY inbound message;
+        // this additionally CLOSES the outstanding ping, which is what stops
+        // the ping-unanswered deadline from ever maturing on a live peer. A
+        // nonce that does not match an outstanding ping is still liveness
+        // evidence but answers nothing.
+        const bool matched = m_liveness.on_pong(msg->m_nonce, now_sec());
+        LOG_DEBUG_COIND << "[" << m_chain_label << "] pong (nonce=" << msg->m_nonce
+                        << (matched ? ") — ping answered" : ") — unsolicited/stale");
     }
 
     // ── E1 seam handlers: parse + fire interfaces::Node events, NO ingest ─

--- a/test/test_dash_coin_p2p_client.cpp
+++ b/test/test_dash_coin_p2p_client.cpp
@@ -12,12 +12,31 @@
 ///       targets: single-target plans stay put; multi-target plans rotate on
 ///       each reconnect attempt so a dead first target cannot wedge redial.
 ///
+///   (b2) PeerLiveness — the extracted ping/pong keepalive policy that
+///       replaced the old bare "no inbound message for 100s => drop" rule:
+///       a quiet peer is PINGED, any inbound message (pong included) is
+///       liveness evidence, our own outbound traffic is NOT, and a drop
+///       happens only once a ping has gone unanswered past the (much longer)
+///       peer timeout.
+///
 ///   (c) CoinClient handshake drive — the REAL client class fed byte-exact
 ///       wire messages (message_version / message_verack round-tripped
 ///       through make_raw -> Handler::parse, the same path live socket bytes
 ///       take): peer metadata capture, handshake completion, the
 ///       on_handshake_complete seam, unknown-command tolerance (dashd spork/
 ///       governance traffic), and teardown-on-error resetting the session.
+///
+///   (d) Read-loop preservation — a subscriber that THROWS out of a message
+///       handler must not escape handle(). core::Socket re-arms its read only
+///       on the line AFTER message_processing(), so an escaping exception
+///       leaves the socket open but permanently deaf, and every inv-PUSHED
+///       message type (qfcommit, clsig, block invs) is lost for the rest of
+///       that connection's life.
+///
+///   (e) Keepalive over the REAL client + a real io_context (scaled cadence):
+///       a peer that answers pings and sends nothing else stays connected far
+///       past the retired 100s deadline; a peer that answers nothing is still
+///       dropped, but only after the peer timeout.
 ///
 /// SCOPE NOTE (honest): the wire transport here is direct handle() delivery,
 /// not a live TCP socket — the live-socket leg is the E1 smoke gate run
@@ -38,13 +57,16 @@
 
 #include <boost/asio.hpp>
 
+#include <chrono>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
 using dash::coin::p2p::CoinClient;
 using dash::coin::p2p::DialPlan;
 using dash::coin::p2p::HandshakeTracker;
+using dash::coin::p2p::PeerLiveness;
 
 namespace {
 
@@ -134,6 +156,227 @@ TEST(DashCoinP2PClient, dial_plan_multi_target_rotates_round_robin)
     EXPECT_EQ(p.advance().to_string(), "10.0.0.2:9999");
     EXPECT_EQ(p.advance().to_string(), "10.0.0.3:9999");
     EXPECT_EQ(p.advance().to_string(), "10.0.0.1:9999");   // wraps
+}
+
+// ── (b2) PeerLiveness keepalive policy ────────────────────────────────────
+//
+// Production defaults, mirrored from Dash Core net.h, so the KATs below read
+// against the same numbers the client ships with.
+constexpr time_t kPingInterval = 120;    // Dash Core PING_INTERVAL
+constexpr time_t kPeerTimeout  = 1200;   // Dash Core TIMEOUT_INTERVAL
+constexpr time_t kRetiredIdleTimeout = 100;  // the rule this replaced (measured)
+// The two protocol constants the retired rule sat below. See
+// tolerates_silence_past_peer_ping_and_block_interval for why they matter.
+constexpr time_t kPeerKeepalivePing = 120;   // the PEER's own ping cadence
+constexpr time_t kDashBlockInterval = 150;   // DASH target block spacing
+
+using Action = PeerLiveness::Action;
+
+TEST(DashCoinP2PLiveness, quiet_peer_is_pinged_not_killed)
+{
+    PeerLiveness lv;
+    lv.configure(kPingInterval, kPeerTimeout);
+    lv.start(/*now=*/0);
+
+    // The window the retired rule used to kill in: still nothing to do.
+    EXPECT_EQ(lv.tick(kRetiredIdleTimeout), Action::None);
+    EXPECT_EQ(lv.tick(kRetiredIdleTimeout + 1), Action::None);
+
+    // Once the peer has been quiet for the ping interval we PROBE it — we do
+    // not conclude anything about it yet.
+    EXPECT_EQ(lv.tick(kPingInterval), Action::SendPing);
+}
+
+// THE ESSENTIAL PROPERTY (the live defect, stated as a test):
+// a peer that completes the handshake and then sends nothing but valid pongs
+// must stay connected indefinitely — and in particular far past the retired
+// 100s deadline that was killing every hotel peer at 101s.
+TEST(DashCoinP2PLiveness, peer_answering_only_pongs_is_never_dropped)
+{
+    PeerLiveness lv;
+    lv.configure(kPingInterval, kPeerTimeout);
+    lv.start(/*now=*/0);
+
+    uint64_t nonce_seq = 0;
+    // Two full peer-timeout windows of a peer that relays NOTHING and only
+    // answers our pings. 40 minutes; the old rule killed at 100 seconds.
+    for (int64_t now = 1; now <= 2 * kPeerTimeout; ++now)
+    {
+        const Action a = lv.tick(now);
+        ASSERT_NE(a, Action::DropIdle) << "dropped a pong-answering peer at t=" << now;
+        ASSERT_NE(a, Action::DropPingTimeout) << "ping-timeout on an answered ping at t=" << now;
+        if (a == Action::SendPing)
+        {
+            const uint64_t nonce = ++nonce_seq;
+            lv.note_ping_sent(nonce, now);
+            EXPECT_TRUE(lv.ping_outstanding());
+            EXPECT_TRUE(lv.on_pong(nonce, now));       // peer answers immediately
+            EXPECT_FALSE(lv.ping_outstanding());
+        }
+    }
+
+    EXPECT_GE(lv.pings_sent(), 2u * kPeerTimeout / kPingInterval - 1);
+    EXPECT_EQ(lv.pongs_matched(), lv.pings_sent());
+}
+
+TEST(DashCoinP2PLiveness, any_inbound_message_is_liveness_not_just_pong)
+{
+    PeerLiveness lv;
+    lv.configure(kPingInterval, kPeerTimeout);
+    lv.start(0);
+
+    // An inv-push (a block/tx announcement) is just as good as a pong: it is
+    // evidence the peer is alive and talking to us.
+    lv.on_inbound(kPingInterval - 1);
+    EXPECT_EQ(lv.tick(kPingInterval), Action::None);          // deadline moved
+    EXPECT_EQ(lv.tick(kPingInterval * 2 - 2), Action::None);
+    EXPECT_EQ(lv.tick(kPingInterval * 2 - 1), Action::SendPing);
+}
+
+TEST(DashCoinP2PLiveness, our_own_outbound_traffic_never_pushes_the_deadline)
+{
+    PeerLiveness lv;
+    lv.configure(kPingInterval, kPeerTimeout);
+    lv.start(0);
+    ASSERT_EQ(lv.last_recv(), 0);
+
+    // Sending is not evidence about the PEER. If our own writes reset the
+    // clock, a half-open socket looks healthy forever.
+    lv.note_ping_sent(/*nonce=*/7, /*now=*/kPingInterval);
+    EXPECT_EQ(lv.last_recv(), 0) << "an outbound ping moved the inbound deadline";
+
+    // The inbound deadline therefore still matures measured from t=0, NOT
+    // from the moment we sent the ping.
+    EXPECT_EQ(lv.tick(kPeerTimeout - 1), Action::None);
+    EXPECT_EQ(lv.tick(kPeerTimeout), Action::DropIdle);
+}
+
+TEST(DashCoinP2PLiveness, unanswered_ping_drops_only_after_the_peer_timeout)
+{
+    // Isolate the ping-timeout arm: the peer keeps RELAYING (so the
+    // "nothing received at all" arm never matures) but never answers a ping.
+    // That is the half-open case only ping/pong can catch.
+    PeerLiveness lv;
+    lv.configure(kPingInterval, kPeerTimeout);
+    lv.start(0);
+
+    ASSERT_EQ(lv.tick(kPingInterval), Action::SendPing);
+    lv.note_ping_sent(/*nonce=*/42, /*now=*/kPingInterval);
+
+    // A genuinely unresponsive peer IS still dropped — that half of the
+    // contract must not regress. It just takes the Core-semantics deadline.
+    for (int64_t now = kPingInterval + 1; now < kPingInterval + kPeerTimeout; ++now)
+    {
+        lv.on_inbound(now);                       // relay traffic keeps flowing
+        ASSERT_EQ(lv.tick(now), Action::None) << "dropped early at t=" << now;
+    }
+    lv.on_inbound(kPingInterval + kPeerTimeout);
+    EXPECT_EQ(lv.tick(kPingInterval + kPeerTimeout), Action::DropPingTimeout);
+}
+
+// ORDERING RELATION, not a magic number. The three constants that decide
+// whether a threshold is meaningful at all:
+//
+//     our old drop deadline   100 s   (measured, +/-0.1 ms over 6 cycles)
+//   < Dash Core ping cadence  120 s   (the peer's own keepalive)
+//   < DASH block interval     150 s   (earliest possible block inv)
+//
+// The old 100 s deadline sat BELOW both, so the peer was never going to speak
+// inside our window and every connection died at the identical instant by
+// construction. Any replacement must clear both — a 110 s timeout would still
+// be broken, and a test hard-coded to "survives 101 s" would have passed it.
+TEST(DashCoinP2PLiveness, tolerates_silence_past_peer_ping_and_block_interval)
+{
+    ASSERT_LT(kRetiredIdleTimeout, kPeerKeepalivePing) << "premise of the defect";
+    ASSERT_LT(kPeerKeepalivePing, kDashBlockInterval);
+
+    PeerLiveness lv;   // SHIPPED defaults — no test scaling here on purpose
+    lv.start(0);
+
+    // Structural: the drop deadline must clear both protocol constants, so a
+    // peer that says nothing until its own keepalive (or until the next block)
+    // is never concluded dead first.
+    EXPECT_GT(lv.peer_timeout_sec(), kPeerKeepalivePing);
+    EXPECT_GT(lv.peer_timeout_sec(), kDashBlockInterval);
+
+    // Behavioural: a peer that handshakes and then stays silent for longer
+    // than BOTH must still be connected — and must have been probed by us.
+    for (int64_t now = 1; now <= kDashBlockInterval * 2; ++now)
+    {
+        const Action a = lv.tick(now);
+        ASSERT_NE(a, Action::DropIdle) << "dropped at t=" << now
+            << "s, before the peer's own " << kPeerKeepalivePing << "s ping";
+        ASSERT_NE(a, Action::DropPingTimeout) << "ping-timeout at t=" << now;
+        if (a == Action::SendPing)
+            lv.note_ping_sent(/*nonce=*/1, now);   // sent; peer has not answered yet
+    }
+    EXPECT_GE(lv.pings_sent(), 1u)
+        << "we must generate our own liveness evidence, not bet on peer chattiness";
+}
+
+TEST(DashCoinP2PLiveness, total_silence_drops_at_the_peer_timeout)
+{
+    // Degenerate config (ping interval >= peer timeout, i.e. we never get to
+    // probe): the "nothing at all received" arm must still fire.
+    PeerLiveness lv;
+    lv.configure(/*ping_interval=*/kPeerTimeout * 2, kPeerTimeout);
+    lv.start(0);
+
+    EXPECT_EQ(lv.tick(kPeerTimeout - 1), Action::None);
+    EXPECT_EQ(lv.tick(kPeerTimeout), Action::DropIdle);
+}
+
+TEST(DashCoinP2PLiveness, stale_or_unsolicited_pong_nonce_answers_nothing)
+{
+    PeerLiveness lv;
+    lv.configure(kPingInterval, kPeerTimeout);
+    lv.start(0);
+
+    // Unsolicited pong with no ping outstanding: liveness, but answers nothing.
+    EXPECT_FALSE(lv.on_pong(/*nonce=*/999, /*now=*/10));
+    EXPECT_EQ(lv.last_recv(), 10);
+
+    ASSERT_EQ(lv.tick(10 + kPingInterval), Action::SendPing);
+    lv.note_ping_sent(/*nonce=*/1234, 10 + kPingInterval);
+
+    // Replayed old nonce must NOT close the outstanding ping — otherwise a
+    // peer could hold a dead link open with a recording.
+    EXPECT_FALSE(lv.on_pong(/*nonce=*/999, 10 + kPingInterval + 1));
+    EXPECT_TRUE(lv.ping_outstanding());
+    EXPECT_EQ(lv.pongs_matched(), 0u);
+
+    EXPECT_TRUE(lv.on_pong(/*nonce=*/1234, 10 + kPingInterval + 2));
+    EXPECT_FALSE(lv.ping_outstanding());
+    EXPECT_EQ(lv.pongs_matched(), 1u);
+}
+
+TEST(DashCoinP2PLiveness, session_restart_clears_the_previous_peer_state)
+{
+    PeerLiveness lv;
+    lv.configure(kPingInterval, kPeerTimeout);
+    lv.start(0);
+    ASSERT_EQ(lv.tick(kPingInterval), Action::SendPing);
+    lv.note_ping_sent(/*nonce=*/5, kPingInterval);
+    ASSERT_TRUE(lv.ping_outstanding());
+
+    // Reconnect: the new peer must not inherit the old one's outstanding ping
+    // (which would drop it the moment the previous deadline matured).
+    lv.start(/*now=*/5000);
+    EXPECT_FALSE(lv.ping_outstanding());
+    EXPECT_EQ(lv.pings_sent(), 0u);
+    EXPECT_EQ(lv.tick(5000 + kRetiredIdleTimeout), Action::None);
+}
+
+TEST(DashCoinP2PLiveness, shipped_defaults_are_the_dash_core_values)
+{
+    PeerLiveness lv;   // default-constructed == the shipped policy
+    EXPECT_EQ(lv.ping_interval_sec(), kPingInterval);
+    EXPECT_EQ(lv.peer_timeout_sec(), kPeerTimeout);
+    EXPECT_GT(lv.peer_timeout_sec(), kRetiredIdleTimeout)
+        << "the drop deadline must be far longer than the rule it replaced";
+    // 100 < 120 < 150 < ping_interval? no — the ping cadence MAY equal the
+    // peer's, but the DROP deadline must clear both by a wide margin.
+    EXPECT_GT(lv.peer_timeout_sec(), kDashBlockInterval * 4);
 }
 
 // ── (c) CoinClient handshake drive ────────────────────────────────────────
@@ -260,6 +503,165 @@ TEST(DashCoinP2PClient, client_error_tears_session_down_for_redial)
     rig.wire_connected();
     EXPECT_TRUE(rig.client.is_connected());
     EXPECT_FALSE(rig.client.is_handshake_complete());
+}
+
+// ── (d) Read-loop preservation ────────────────────────────────────────────
+//
+// core::Socket::read_payload is literally:
+//
+//     message_processing(packet);   // -> CoinClient::handle(rmsg, addr)
+//     read();                       // re-arm the read loop
+//
+// so an exception escaping handle() unwinds PAST read(). The socket stays
+// open, error() never fires, the client keeps believing it has a healthy
+// peer — and not one further byte is ever processed from that peer. In
+// production main_dash's #755 io-handler guard catches the throw at
+// ioc.run() and resumes the loop, which is precisely why the damage is
+// silent: nothing is logged about the connection, and the only visible
+// consequence arrives when this client's own liveness deadline matures on a
+// peer it silenced itself.
+//
+// Message handlers fan out into subscriber code we do not own
+// (new_block / new_mnlistdiff / new_qfcommit / new_chainlock ...), so a
+// throwing subscriber must cost that message and nothing more.
+TEST(DashCoinP2PClient, throwing_subscriber_does_not_escape_handle)
+{
+    ClientRig rig;
+    rig.wire_connected();
+    rig.deliver(rig.peer_version(70230, 1, 100, "/Dash Core:21.1.0/"));
+    rig.deliver(dash::coin::p2p::message_verack::make_raw());
+    ASSERT_TRUE(rig.client.is_handshake_complete());
+
+    int fired = 0;
+    rig.coin_state.new_block.subscribe([&](uint256){
+        ++fired;
+        throw std::runtime_error("KAT: subscriber blew up");
+    });
+
+    auto block_inv = dash::coin::p2p::message_inv::make_raw(
+        std::vector<dash::coin::p2p::inventory_type>{
+            dash::coin::p2p::inventory_type(
+                dash::coin::p2p::inventory_type::block, uint256::ONE)});
+
+    // The whole point: this must NOT throw out of handle().
+    EXPECT_NO_THROW(rig.deliver(std::move(block_inv)));
+    EXPECT_EQ(fired, 1);
+
+    // ... and the session must be intact so the read loop keeps going.
+    EXPECT_TRUE(rig.client.is_connected());
+    EXPECT_TRUE(rig.client.is_handshake_complete());
+}
+
+TEST(DashCoinP2PClient, message_after_a_throwing_handler_is_still_processed)
+{
+    ClientRig rig;
+    rig.wire_connected();
+    rig.deliver(rig.peer_version(70230, 1, 100, "/Dash Core:21.1.0/"));
+    rig.deliver(dash::coin::p2p::message_verack::make_raw());
+    ASSERT_TRUE(rig.client.is_handshake_complete());
+
+    rig.coin_state.new_block.subscribe([](uint256){
+        throw std::runtime_error("KAT: subscriber blew up");
+    });
+    auto bad = dash::coin::p2p::message_inv::make_raw(
+        std::vector<dash::coin::p2p::inventory_type>{
+            dash::coin::p2p::inventory_type(
+                dash::coin::p2p::inventory_type::block, uint256::ONE)});
+    EXPECT_NO_THROW(rig.deliver(std::move(bad)));
+
+    // The NEXT inbound message — in production this is exactly the qfcommit /
+    // clsig inv-push we exist to witness — must still be dispatched. A
+    // post-handshake version updates the peer metadata unconditionally
+    // (the handshake tracker only gates the verack reply), so it is a
+    // side-effect we can observe without a socket.
+    ASSERT_EQ(rig.client.peer_subver(), "/Dash Core:21.1.0/");
+    rig.deliver(rig.peer_version(70230, 1, 101, "/Dash Core:22.0.0/"));
+    EXPECT_EQ(rig.client.peer_subver(), "/Dash Core:22.0.0/")
+        << "inbound dispatch stopped after a handler threw";
+    EXPECT_EQ(rig.client.peer_start_height(), 101u);
+    EXPECT_TRUE(rig.client.is_connected());
+}
+
+// ── (e) Keepalive over the real client + real io_context ──────────────────
+//
+// Scaled cadence (seconds, not minutes) so the REAL timer path — liveness
+// timer -> PeerLiveness::tick -> send_ping / timeout -> error() — runs in a
+// unit test. The policy itself is unchanged; only the constants are. These two
+// tests prove the PLUMBING (timer armed, ping written, pong routed, drop
+// raised through error()); the SHIPPED thresholds are asserted against the
+// real protocol constants in tolerates_silence_past_peer_ping_and_block_interval
+// above, where simulated time makes a >150s window free.
+TEST(DashCoinP2PClient, quiet_peer_that_answers_pings_survives_past_old_deadline)
+{
+    ClientRig rig;
+    // ping every 1s, drop only after 4s unanswered, evaluate every 1s.
+    rig.client.set_keepalive_for_test(/*ping*/1, /*peer_timeout*/4, /*tick*/1);
+    rig.wire_connected();
+    rig.deliver(rig.peer_version(70230, 1, 100, "/Dash Core:21.1.0/"));
+    rig.deliver(dash::coin::p2p::message_verack::make_raw());
+    ASSERT_TRUE(rig.client.is_handshake_complete());
+
+    // Stand in for the peer: whenever a ping is outstanding, answer it with a
+    // matching pong through the real inbound path — and send NOTHING else.
+    boost::asio::steady_timer peer(rig.ioc);
+    std::function<void()> pump = [&]{
+        peer.expires_after(std::chrono::milliseconds(50));
+        peer.async_wait([&](const boost::system::error_code& ec){
+            if (ec) return;
+            if (rig.client.is_connected() && rig.client.ping_outstanding())
+                rig.deliver(dash::coin::p2p::message_pong::make_raw(
+                    rig.client.last_ping_nonce()));
+            if (rig.client.is_connected()) pump();
+        });
+    };
+    pump();
+
+    // The client's liveness timer repeats for as long as the peer lives, so
+    // run() would never return on a HEALTHY peer — which is the point. Bound
+    // the observation window explicitly.
+    boost::asio::steady_timer stop(rig.ioc);
+    stop.expires_after(std::chrono::seconds(6));   // > 1.5x the peer timeout
+    stop.async_wait([&](const boost::system::error_code&){
+        peer.cancel();
+        rig.ioc.stop();
+    });
+
+    rig.ioc.run();
+
+    EXPECT_TRUE(rig.client.is_connected())
+        << "a peer that answers every ping was dropped";
+    EXPECT_TRUE(rig.client.is_handshake_complete());
+    EXPECT_GE(rig.client.pings_sent(), 2u);
+    EXPECT_EQ(rig.client.pongs_matched(), rig.client.pings_sent());
+    EXPECT_FALSE(rig.client.ping_outstanding());
+}
+
+TEST(DashCoinP2PClient, silent_peer_is_still_dropped_but_only_after_peer_timeout)
+{
+    // Negative control: lifting the deadline must NOT make us keep dead peers.
+    ClientRig rig;
+    rig.client.set_keepalive_for_test(/*ping*/1, /*peer_timeout*/3, /*tick*/1);
+    rig.client.set_on_peer_disconnected([&](const NetService&){ rig.ioc.stop(); });
+    rig.wire_connected();
+    rig.deliver(rig.peer_version(70230, 1, 100, "/Dash Core:21.1.0/"));
+    rig.deliver(dash::coin::p2p::message_verack::make_raw());
+    ASSERT_TRUE(rig.client.is_handshake_complete());
+
+    // Watchdog: if the drop never happens the liveness timer repeats forever,
+    // so bound the run and let the assertion below report it instead of hanging.
+    boost::asio::steady_timer watchdog(rig.ioc);
+    watchdog.expires_after(std::chrono::seconds(15));
+    watchdog.async_wait([&](const boost::system::error_code&){ rig.ioc.stop(); });
+
+    const auto t0 = std::chrono::steady_clock::now();
+    rig.ioc.run();                                  // returns once the peer is dropped
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - t0).count();
+
+    EXPECT_FALSE(rig.client.is_connected()) << "a fully silent peer was never dropped";
+    EXPECT_GE(rig.client.pings_sent(), 1u) << "we must probe before concluding";
+    EXPECT_EQ(rig.client.pongs_matched(), 0u);
+    EXPECT_GE(elapsed, 3000) << "dropped before the peer timeout matured";
 }
 
 } // namespace


### PR DESCRIPTION
> **Status: hardening, not a cure.** This PR fixes a measured defect that is a
> *sufficient* cause of the peer churn. It does **not** fully explain the live
> signature, and it is **not** proven to restore `qfcommit`/`clsig` acquisition.
> Ranked honestly below. Please read the "What is still unexplained" section
> before treating this as closing the daemonless blocker.

## The live signature

Hotel node, binary `82c80570`, 9-hour journal:

```
296 "peer version"    296 "CP1 parse headers"   <- exactly 1:1
batch values seen: 0,1,2,3,4                    <- we DO parse it, and it varies
then NOTHING, every time, 296 of 296

peer lifetime: 101 s, measured 100.000 s +/- 0.1 ms from the CP1 line to the drop
disconnects:   275 "peer timeout: idle timeout" / 4 "Connection reset by peer"
qfcommit: 0    clsig: 0    distinct peers: 3
```

The 100.000 s measured *from the CP1 line* is what proves CP1 was genuinely the
last inbound message: anything unlogged arriving in between would have moved the
drop to 100 s after *that*.

## (1) What is fixed here — measured

`src/impl/dash/coin/p2p_client.hpp:175`, `IDLE_TIMEOUT_SEC = 100`: a bare
"no inbound message for 100 s => drop", armed at `:690`, reset at `:622`. A 30 s
`send_ping()` cadence existed, but **nothing ever consulted whether a ping was
answered** — the sole drop rule was inbound silence.

That deadline sits below the floor on peer-initiated traffic. Measured live
against the two peers from the journal, six runs, paired and simultaneous:

```
max inbound silence gap, 460-900 s windows:
  113.86  114.41  114.82  118.17  120.02  120.05    (seconds)

  all six > our 100 s deadline
  all six <= 120.1 s = the peer's own PING_INTERVAL keepalive
```

The clustering is the point. **In a quiet period the peer's own 120 s keepalive
ping is the only inbound event on the wire, and we hang up 20 s before it
arrives, every single time.** That is a deterministic 100 s lifetime with no
variance to it — which is exactly the observed signature. The ordering that
makes it inevitable:

```
our drop deadline        100 s   (measured, +/-0.1 ms over 6 cycles)
Dash Core ping cadence   120 s   (protocol constant, and the measured traffic floor)
DASH block interval      150 s   (protocol constant, earliest possible block inv)
100 < 120 < 150
```

**The change.** A pure, KAT-able `PeerLiveness` policy mirroring Dash Core
`net.h`: ping a peer quiet for `PING_INTERVAL` (120 s); treat **any** inbound
message, pong included, as liveness; drop only once a ping has gone unanswered
past `TIMEOUT_INTERVAL` (1200 s), or nothing at all arrived in that window.
1200 s clears both the 120 s keepalive and the 150 s block interval by 8-10x, so
the fallback only ever fires on a genuinely half-open socket. Only a
nonce-matching pong closes an outstanding ping. Our own outbound traffic never
moves the deadline — liveness must be evidence about the **peer**. Pre-handshake
keeps the short 10 s CONNECT deadline.

## (2) Also included — hardening, NOT the cause

`handle()` caught only `runtime_error` / `out_of_range`, and only around
`parse` — not around the dispatch, which fans out into subscriber code we do not
own. `src/core/socket.cpp:302-303` re-arms the read on the line *after*
`message_processing()`, so an escaping exception unwinds past `read()`: socket
open, `error()` never fired, connection deaf for life.

**This is explicitly NOT what happened on the hotel node.** `main_dash.cpp:4428`
logs escaped exceptions at LOG_ERROR (`"[run] io handler exception (non-fatal,
#755 guard)"`), LOG_ERROR lands in that file, and the journal has **0 hits for
`#755` and 0 for `exception`**. No exception escaped; `read()` was reached. I
originally proposed this as the root cause and that was **wrong** — retracted.

It is kept because the fragility is real and would silently reproduce the same
symptom once the deadline is lifted. Note the `socket.cpp` ordering exposes
**every coin lane**, not just DASH; a core-side fix belongs in its own PR rather
than smuggled into this one.

## What is still unexplained — the real open question

**Zero variance across 296 connections is explained by the above only if the
whole 9 h window was quiet.** It was not necessarily: in a busy mempool period
the same peers deliver a message every ~3 s. Those invs would have reset the
timer and produced lifetime variance. There is none.

Sharper still: over ~8 h of accumulated connected time the node should have seen
~150+ block announcements. It logged **zero** block invs, zero `qfcommit`, zero
`clsig`.

I chased the obvious explanation — that our handshake keeps us out of the peer's
announcement set, which would explain everything (request/response works,
inv-push never arrives, mnlistdiff works, qfcommit/clsig are zero). **It is
refuted.** A 900 s census against `148.251.73.234:9999`, replaying c2pool's exact
handshake *and* its exact post-handshake burst, with inv types decoded:

```
133 messages, max gap 93.09 s
INV TYPES: {1(tx):32, 2(BLOCK):10, 16(dstx):49, 17(govobj):21,
            21(QFCOMMIT):1, 29:11, 31(isdlock):81}
block invs at t = 286.9, 370.8, 408.7, 421.6, 570.9, 576.9, 633.1, 689.5, ...
```

**A client behaving exactly like ours receives block invs, and received a real
`qfcommit`.** The peer's announcement set includes us; the handshake is not
defective; the burst does not suppress anything. So the wire is not withholding
these messages — which means the remaining question is on *our* side of the
socket, or the 9 h window was uniformly quiet.

Note also that this busier window had a max gap of **93.09 s — under the old
100 s deadline**, while the quiet windows measured 113.9-120.1 s. Traffic is
bursty: the deadline only bites in quiet stretches, and in those it bites
deterministically. That is consistent with 296/296 identical lifetimes *if* the
logged window was quiet throughout, which I cannot verify from here.

So the honest statement is: **we do not yet know why the client receives exactly
one message per connection over a full 9 h, and this PR does not claim to.**
What it does is remove a measured, sufficient cause of the 100 s churn and stop
the client from concluding "dead" on evidence it never gathered. The census also
shows the fix is at least *on* the acquisition path: one held connection caught a
`qfcommit` inside 900 s, where 100 s windows separated by 20 s reconnect gaps
would have had a far smaller chance of catching it.

### Ruled out by experiment (so nobody re-treads them)

* **The post-handshake burst is not it.** `getheaders`+`mempool`+`getaddr`+
  `getmnlistd`+`govsync` (main_dash.cpp:3616-3652) replayed against both peers,
  paired and simultaneous with a no-burst control on the same peer: 10 vs 13
  messages, max gap 113.86 vs 114.82 s and 114.41 vs 118.17 s. The three extra
  messages are just the `addr` and `ssc` replies. No suppression.
* **The handshake bytes are not it.** `addr_t` is 8 B services + 16 B
  IPv6-mapped IP + 2 B big-endian port = the standard 26 B CAddress, and the
  version payload ends at `start_height` with **no trailing BIP37 `fRelay`
  byte** — so the peer defaults `fRelay = true`. A probe sending the identical
  layout is served normally, including block invs and a `qfcommit`.
* **Exclusion from the peer's announcement set is not it** — see the 900 s
  census above: 10 block invs and 1 `qfcommit` to a probe using our exact
  handshake and burst.
* **PMTU is not it.** `mtu 1480` is the NIC's own PPPoE-style MTU, `tracepath`
  completes all 8 hops at `pmtu 1480`, `mss:1428` negotiates correctly, and
  on-wire `qfcommit` (~456 B) / `clsig` (~156 B) fit in one segment.
* **The network is not it.** dashd on the same host and NIC holds 48 peers,
  max age 13.3 days, min 829 s — all 48 exceed our 101 s — receiving `qfcommit`
  from 28 peers and `clsig` from 25 peers continuously.

### A correction to my own earlier measurement

I first reported "77 inbound messages in 240 s, max gap 20.96 s" and argued it
contradicted the timeout theory. **That sample was a busy mempool period and is
not representative.** Paired runs on the same peers minutes later show 113.9 -
120.1 s silence gaps. The contradiction was mine, not the theory's. Retracted.

## Measured before / after

| | before | after |
|---|---|---|
| silence tolerated | 100 s — below the measured 113.9-120.1 s traffic floor | 1200 s — clears the 120 s keepalive and 150 s block interval |
| peer lifetime | 100.000 s +/- 0.1 ms, zero variance over 30 samples | not bounded by a silence stopwatch |
| peer sending only pongs | dropped when the stopwatch ran out | stays connected; asserted over 2x the peer timeout and over the real timer path |
| genuinely dead peer | dropped at 100 s | still dropped, but only after probing first |
| throwing subscriber | escaped `handle()`, skipped `read()` | contained and logged |
| **qfcommit / clsig acquisition** | **0** | **UNPROVEN — see above** |

Staying attached across a DKG finalize is *necessary* to witness the single
`qfcommit` announcement; it is not sufficient, and the "one message per
connection" question is unresolved. Proof requires a soak observing a real
`qfcommit` arrive and `MineableCommitmentCache` go non-zero. Falsifiable
predictions for that soak: `peer timeout` disconnects drop to ~zero, lifetime
stops clustering at 101 s, and **block invs begin appearing** — the census proves
the peer sends them to a client behaving like ours, so if lifetime lifts and
block invs are still zero, the defect is on our receive path, this PR did not fix
it, and that is where the next investigation goes.

## Peer count — reported, deliberately NOT changed

Concurrent cap is **1, structurally**: one `CoinClient` (`main_dash.cpp:1376`)
owning one `unique_ptr<Connection>`. `CoinPeerManager`'s `max_peers{20}`
(`coin_peer_manager.hpp:226`) bounds the *scored candidate set*, not concurrency —
it feeds a round-robin dial plan the single connection rotates through, which is
why 9 h shows 3 distinct addresses. Raising it needs per-peer connection /
handshake / timers / matchers, inbound fan-in with dedup, demux routing, and a
relay-target decision. Separate follow-up rather than half-done here.

## Tests

Existing allowlisted `test_dash_p2p_node` target (second source; no new target,
so no `build.yml` edit). `python3 tools/ci/check_test_target_allowlist.py` => OK,
228 targets. Full target locally: **39/39**.

* 10 `PeerLiveness` policy KATs (simulated time), including
  `tolerates_silence_past_peer_ping_and_block_interval`, which encodes the
  **ordering relation** `100 < 120 < 150` rather than a magic number and asserts
  the shipped deadline clears both protocol constants — a 110 s timeout fails it.
* 2 read-loop containment tests.
* 2 real-`io_context` tests driving the real liveness timer at a scaled cadence.

**Verified red before the fix** (a test that only checks "we drop a dead peer"
passes on the broken code, so both halves were checked by reverting in place):
reverting the dispatch guard fails 2 tests; stubbing `PeerLiveness::tick()` back
to the old 100 s rule fails 11, including the ordering test and the real-timer
test. Both reverts undone, full target re-run green.
