### PR TITLE
dash(dip24): register qrinfo on the wire; name every rotated-lane outcome

### DIFF
--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -49,6 +49,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -243,6 +244,10 @@ private:
     // means a received qrinfo is logged and dropped.
     using QrInfoConsumer = std::function<void(const vendor::CQuorumRotationInfo&)>;
     std::vector<QrInfoConsumer> m_qrinfo_consumers;
+
+    // Commands already reported as dropped-unhandled, so the WARNING fires
+    // once per distinct command instead of once per message. See handle().
+    std::set<std::string> m_unhandled_seen;
 
 public:
     CoinClient(io::io_context* context, dash::interfaces::Node* coin, config_t* config,
@@ -558,8 +563,28 @@ public:
             // Command outside our Handler set — dashd peers push spork/
             // governance/quorum traffic (spork, senddsq, qsendrecsigs, ...)
             // unsolicited; ignoring them is protocol-legal for a light client.
-            LOG_DEBUG_COIND << "[" << m_chain_label << "] ignoring unhandled command '"
-                            << rmsg->m_command << "' (" << rmsg->m_data.size() << " bytes)";
+            //
+            // But a DROPPED REPLY TO A REQUEST WE SENT is not benign, and this
+            // path used to be indistinguishable from it: the DIP-24 rotated
+            // lane sent getqrinfo, dashd answered, and the qrinfo landed here
+            // because the type was missing from p2p::Handler. At DEBUG level
+            // nobody ever saw it; the whole rotated path looked like "nothing
+            // happened". So the FIRST drop of each distinct command is now a
+            // WARNING that names the command and its size. Bounded by the
+            // number of distinct commands a peer can send (tiny), so this can
+            // never become a log flood — every repeat stays at DEBUG.
+            const bool first = m_unhandled_seen.insert(rmsg->m_command).second;
+            if (first) {
+                LOG_WARNING << "[" << m_chain_label << "] DROPPED unhandled p2p command '"
+                            << rmsg->m_command << "' cause=not_in_handler_set value="
+                            << rmsg->m_data.size() << "B (first occurrence; further "
+                               "drops of this command log at debug). If this is a "
+                               "REPLY to something we requested, the requesting lane "
+                               "is silently dead — add the type to p2p::Handler.";
+            } else {
+                LOG_DEBUG_COIND << "[" << m_chain_label << "] ignoring unhandled command '"
+                                << rmsg->m_command << "' (" << rmsg->m_data.size() << " bytes)";
+            }
             return;
         }
 
@@ -882,12 +907,14 @@ private:
         // exception on the coin connection — see p2p_messages.hpp.
         vendor::CQuorumRotationInfo info;
         if (!vendor::decode_quorum_rotation_info(msg->m_raw, info)) {
-            LOG_WARNING << "[" << m_chain_label << "] qrinfo: UNDECODABLE ("
-                        << msg->m_raw.size()
-                        << "B) — dropped, rotated sourcing stays fail-closed";
+            LOG_WARNING << "[" << m_chain_label << "] qrinfo REJECTED cause=undecodable"
+                        << " value=" << msg->m_raw.size()
+                        << "B — dropped, rotated sourcing stays fail-closed";
             return;
         }
-        LOG_INFO << "[" << m_chain_label << "] qrinfo: tip="
+        // RECEIVED is its own named event: before this existed, "no reply came"
+        // and "a reply came and was dropped" were indistinguishable from a log.
+        LOG_INFO << "[" << m_chain_label << "] qrinfo RECEIVED tip="
                  << info.mnListDiffTip.blockHash.GetHex().substr(0, 16)
                  << " H=" << info.mnListDiffH.blockHash.GetHex().substr(0, 16)
                  << " snapshots(active)="
@@ -895,7 +922,16 @@ private:
                  << info.quorumSnapshotAtHMinus2C.activeQuorumMembers.size() << "/"
                  << info.quorumSnapshotAtHMinus3C.activeQuorumMembers.size()
                  << " lastCommitmentPerIndex=" << info.lastCommitmentPerIndex.size()
-                 << " extraShare=" << (info.extraShare ? 1 : 0);
+                 << " extraShare=" << (info.extraShare ? 1 : 0)
+                 << " consumers=" << m_qrinfo_consumers.size();
+        if (m_qrinfo_consumers.empty()) {
+            // Reachable posture, not a bug: coin-P2P on but the rotated lane
+            // unwired. Say so rather than letting the reply vanish.
+            LOG_WARNING << "[" << m_chain_label << "] qrinfo DISCARDED cause=no_consumer"
+                        << " — rotated member sourcing is not wired, every rotated "
+                           "quorum stays null-serve";
+            return;
+        }
         for (auto& c : m_qrinfo_consumers) c(info);
     }
 

--- a/src/impl/dash/coin/p2p_messages.hpp
+++ b/src/impl/dash/coin/p2p_messages.hpp
@@ -371,6 +371,17 @@ using Handler = MessageHandler<
     message_qfcommit,
     message_getmnlistd,
     message_mnlistdiff,
+    // ⚠ DIP-24 ROTATED LANE — these two MUST stay in this list.
+    // A message type absent here is NOT in MessageHandler::m_handlers, so
+    // MessageHandler::parse() throws std::out_of_range and CoinClient::handle
+    // drops the payload on the "unhandled command" path — at DEBUG level.
+    // That is exactly how the rotated lane failed silently in production: the
+    // getqrinfo went out, dashd answered, and the ~600 kB qrinfo was discarded
+    // before ADD_P2P_HANDLER(qrinfo) — which existed, fully written, with a
+    // registered consumer — could ever run. Nothing in any log said so.
+    // test_dash_qrinfo_wire.cpp gates the registry membership directly.
+    message_getqrinfo,
+    message_qrinfo,
     message_govobj,
     message_govobjvote,
     message_govsync

--- a/src/impl/dash/coin/quorum_member_source.hpp
+++ b/src/impl/dash/coin/quorum_member_source.hpp
@@ -82,6 +82,20 @@
 /// non-rotated one (one outstanding per cycle base, deduped, FIFO-reaped) and
 /// is only made for a cycle whose geometry validates locally first.
 ///
+/// OBSERVABILITY ON THE ROTATED LANE (the defect this discipline exists for):
+/// three live soaks cached 32 type-5 (LLMQ_60_75) qfcommits and produced ZERO
+/// "[QC-MEMBERS] READY type=5", and NOTHING in the logs could distinguish
+///   (a) the getqrinfo was never sent,
+///   (b) it was sent and no reply came,
+///   (c) a reply came and was dropped.
+/// It was (c): message_qrinfo was missing from the p2p::Handler type list, so
+/// every reply died in the "unhandled command" catch at DEBUG level and
+/// on_qrinfo() was never called. Both the registry gap and the silence are
+/// fixed. Every terminal state of this lane is now a RotatedOutcome that names
+/// itself in the log with the cause=/value=/threshold= discipline the serve
+/// gate uses, and an unanswered getqrinfo TIMES OUT by name — which also stops
+/// one lost reply from wedging its cycle forever behind the dedup branch.
+///
 /// FAIL-CLOSED throughout: pre-V20 work block, base not dkgInterval-aligned,
 /// header gap, unknown type, snapshot authentication failure, member
 /// computation ambiguous (score tie / short quarter / zero operator key)
@@ -104,15 +118,85 @@
 #include <core/log.hpp>
 
 #include <array>
+#include <chrono>
 #include <cstdint>
 #include <deque>
 #include <functional>
 #include <map>
 #include <optional>
+#include <string>
 #include <vector>
 
 namespace dash {
 namespace coin {
+
+/// Every terminal outcome of the DIP-24 ROTATED lane, so the lane can never
+/// again fail without saying which of them happened.
+///
+/// WHY THIS EXISTS: three live soaks cached 32 type-5 (LLMQ_60_75) qfcommits
+/// and produced zero READY, and the logs could not distinguish "the request
+/// was never sent" from "it was sent and no reply came" from "a reply came and
+/// was dropped". Each rotated exit below now names itself with the same
+/// cause=/value=/threshold= discipline the serve gate uses.
+enum class RotatedOutcome {
+    kNone = 0,
+    // request() / request_rotated() — the SEND side
+    kRequestSent,
+    kRequestDeduped,             // a getqrinfo for this cycle is already out
+    kRequestAlreadyReady,        // the cycle is served; no traffic needed
+    kRefusedUnknownType,
+    kRefusedNotRotated,
+    kRefusedNoSendSeam,          // set_send_getqrinfo() never called
+    kRefusedIntervalZero,
+    kRefusedBaseHeaderMissing,   // header chain does not hold the quorum base
+    kRefusedIndexOutOfRange,     // quorumIndex >= signingActiveQuorumCount
+    kRefusedCycleHeaderGap,      // cycle-base header not held
+    kRefusedBaseUnaligned,       // cycle base not on a dkgInterval boundary
+    kRefusedCycleSpanTooShallow, // chain shorter than base-8-3C
+    kRefusedPreV20,
+    // on_qrinfo() — the REPLY side
+    kReplyNoCbTx,
+    kReplyUnsolicited,           // matched no outstanding request
+    kReplyTypeVanished,
+    kReplyNotFullList,
+    kReplyAuthFailed,
+    // finalize_rotated() — the COMPUTE side
+    kComputeAmbiguous,
+    kNoSlotHeaders,
+    kReady,
+    // expire_rotated_requests()
+    kTimedOut,                   // getqrinfo sent, no reply inside the window
+};
+
+inline const char* rotated_outcome_name(RotatedOutcome o)
+{
+    switch (o) {
+    case RotatedOutcome::kNone:                     return "none";
+    case RotatedOutcome::kRequestSent:              return "request_sent";
+    case RotatedOutcome::kRequestDeduped:           return "request_deduped";
+    case RotatedOutcome::kRequestAlreadyReady:      return "already_ready";
+    case RotatedOutcome::kRefusedUnknownType:       return "unknown_llmq_type";
+    case RotatedOutcome::kRefusedNotRotated:        return "type_not_rotated";
+    case RotatedOutcome::kRefusedNoSendSeam:        return "no_send_seam";
+    case RotatedOutcome::kRefusedIntervalZero:      return "dkg_interval_zero";
+    case RotatedOutcome::kRefusedBaseHeaderMissing: return "base_header_not_held";
+    case RotatedOutcome::kRefusedIndexOutOfRange:   return "quorum_index_out_of_range";
+    case RotatedOutcome::kRefusedCycleHeaderGap:    return "cycle_base_header_not_held";
+    case RotatedOutcome::kRefusedBaseUnaligned:     return "cycle_base_unaligned";
+    case RotatedOutcome::kRefusedCycleSpanTooShallow: return "cycle_span_too_shallow";
+    case RotatedOutcome::kRefusedPreV20:            return "pre_v20_work_block";
+    case RotatedOutcome::kReplyNoCbTx:              return "reply_no_type5_cbtx";
+    case RotatedOutcome::kReplyUnsolicited:         return "reply_unsolicited";
+    case RotatedOutcome::kReplyTypeVanished:        return "reply_type_vanished";
+    case RotatedOutcome::kReplyNotFullList:         return "reply_not_full_list";
+    case RotatedOutcome::kReplyAuthFailed:          return "reply_dip4_auth_failed";
+    case RotatedOutcome::kComputeAmbiguous:         return "member_compute_ambiguous";
+    case RotatedOutcome::kNoSlotHeaders:            return "no_slot_base_headers";
+    case RotatedOutcome::kReady:                    return "ready";
+    case RotatedOutcome::kTimedOut:                 return "request_timed_out";
+    }
+    return "unnamed";   // unreachable; a new enumerator without a name is a bug
+}
 
 class QuorumMemberSource {
 public:
@@ -152,11 +236,23 @@ public:
     /// quorum is admitted, so the member set is ready by the DKG-window height.
     void request(uint8_t llmq_type, const uint256& quorum_hash)
     {
+        // request() is kicked on every admitted qfcommit, which makes it the
+        // one reliable heartbeat this class has. Use it to retire rotated
+        // requests that were sent and never answered — otherwise a single
+        // unanswered getqrinfo wedges its cycle FOREVER (every later slot of
+        // that cycle dedupes against the stuck pending and sends nothing).
+        // That is precisely what a dropped reply produced in the soaks.
+        expire_rotated_requests();
+
         const Key key{llmq_type, quorum_hash};
         if (m_ready.count(key) || m_pending.count(key)) return;
 
         const LlmqParamsView* p = params_for(llmq_type);
-        if (p == nullptr) return;                       // unknown type => fail closed
+        if (p == nullptr) {                             // unknown type => fail closed
+            note_rotated(RotatedOutcome::kRefusedUnknownType,
+                         "type=" + std::to_string(static_cast<int>(llmq_type)));
+            return;
+        }
         if (p->use_rotation) {
             // ── ROTATED (DIP-24, e.g. llmq_60_75) ───────────────────────────
             // A rotated quorum's member set is NOT derivable from a single
@@ -170,14 +266,32 @@ public:
             // does: quorumIndex = baseHeight % dkgInterval, and the cycle base
             // is baseHeight - quorumIndex. Upstream also REFUSES an index at or
             // beyond signingActiveQuorumCount (`return {}`), so do we.
+            const std::string who =
+                "type=" + std::to_string(static_cast<int>(llmq_type))
+                + " quorum=" + quorum_hash.GetHex().substr(0, 16);
             auto rot_base_h = m_height_of_hash(quorum_hash);
-            if (!rot_base_h) return;                    // base header not held
-            if (p->dkg_interval == 0) return;
+            if (!rot_base_h) {                          // base header not held
+                note_rotated(RotatedOutcome::kRefusedBaseHeaderMissing, who);
+                return;
+            }
+            if (p->dkg_interval == 0) {
+                note_rotated(RotatedOutcome::kRefusedIntervalZero, who);
+                return;
+            }
             const uint32_t quorum_index = *rot_base_h % p->dkg_interval;
-            if (quorum_index >= p->signing_active_quorum_count) return;
+            if (quorum_index >= p->signing_active_quorum_count) {
+                note_rotated(RotatedOutcome::kRefusedIndexOutOfRange,
+                             who + " value=" + std::to_string(quorum_index)
+                             + " threshold=" + std::to_string(p->signing_active_quorum_count));
+                return;
+            }
             const uint32_t cycle_h = *rot_base_h - quorum_index;
             auto cycle_hash = m_hash_at_height(cycle_h);
-            if (!cycle_hash || cycle_hash->IsNull()) return;   // header gap
+            if (!cycle_hash || cycle_hash->IsNull()) {   // header gap
+                note_rotated(RotatedOutcome::kRefusedCycleHeaderGap,
+                             who + " cycle_base_h=" + std::to_string(cycle_h));
+                return;
+            }
             request_rotated(llmq_type, *cycle_hash);
             return;
         }
@@ -273,36 +387,71 @@ public:
     /// per-index entry point is request(), which derives it.
     bool request_rotated(uint8_t llmq_type, const uint256& quorum_hash)
     {
+        const std::string who =
+            "type=" + std::to_string(static_cast<int>(llmq_type))
+            + " cycle_base=" + quorum_hash.GetHex().substr(0, 16);
+
         const LlmqParamsView* p = params_for(llmq_type);
-        if (p == nullptr || !p->use_rotation) return false;
-        if (!m_send_qrinfo) return false;
+        if (p == nullptr)
+            return note_rotated_false(RotatedOutcome::kRefusedUnknownType, who);
+        if (!p->use_rotation)
+            return note_rotated_false(RotatedOutcome::kRefusedNotRotated, who);
+        // The one refusal that is a WIRING fault, not a data fault: with no
+        // send seam the lane emits nothing at all and every rotated quorum
+        // stays null-serve forever. It must never be silent again.
+        if (!m_send_qrinfo)
+            return note_rotated_false(RotatedOutcome::kRefusedNoSendSeam, who);
 
         auto base_h = m_height_of_hash(quorum_hash);
-        if (!base_h) return false;
-        if (p->dkg_interval == 0 || *base_h % p->dkg_interval != 0) return false;
+        if (!base_h)
+            return note_rotated_false(RotatedOutcome::kRefusedBaseHeaderMissing, who);
+        if (p->dkg_interval == 0)
+            return note_rotated_false(RotatedOutcome::kRefusedIntervalZero, who);
+        if (*base_h % p->dkg_interval != 0)
+            return note_rotated_false(
+                RotatedOutcome::kRefusedBaseUnaligned,
+                who + " value=" + std::to_string(*base_h)
+                + " threshold=dkg_interval:" + std::to_string(p->dkg_interval));
         // Need H-3C to exist: base - 8 - 3*C.
         const uint64_t span = static_cast<uint64_t>(kWorkDiffDepth)
                             + 3ull * p->dkg_interval;
-        if (*base_h < span) return false;
-        if (*base_h - kWorkDiffDepth < quorum_members_v20_floor()) return false;
+        if (*base_h < span)
+            return note_rotated_false(
+                RotatedOutcome::kRefusedCycleSpanTooShallow,
+                who + " value=" + std::to_string(*base_h)
+                + " threshold=" + std::to_string(span));
+        if (*base_h - kWorkDiffDepth < quorum_members_v20_floor())
+            return note_rotated_false(
+                RotatedOutcome::kRefusedPreV20,
+                who + " value=" + std::to_string(*base_h - kWorkDiffDepth)
+                + " threshold=" + std::to_string(quorum_members_v20_floor()));
 
         const Key ckey{llmq_type, quorum_hash};
         // ONE outstanding getqrinfo per cycle base: the 32 slots of a cycle all
         // resolve to this same request, and a duplicate would draw a second
         // 600 kB reply that no await matches (the R1 hazard, per-cycle form).
-        if (m_rotated_pending.count(ckey)) return true;
+        if (m_rotated_pending.count(ckey)) {
+            m_last_rotated = RotatedOutcome::kRequestDeduped;
+            return true;
+        }
         // The cycle's index-0 quorum hash IS the cycle base hash, so a ready
         // cycle needs no re-request.
-        if (m_ready.count(ckey)) return true;
+        if (m_ready.count(ckey)) {
+            m_last_rotated = RotatedOutcome::kRequestAlreadyReady;
+            return true;
+        }
         reap_rotated_if_needed();
 
-        m_rotated_pending[ckey] = *base_h;
+        m_rotated_pending[ckey] = RotatedPending{*base_h, m_now()};
         m_rotated_fifo.push_back(ckey);
         m_send_qrinfo(std::vector<uint256>{}, quorum_hash, /*extra_share=*/false);
-        LOG_INFO << "[QC-MEMBERS] sourcing qrinfo for ROTATED type="
-                 << static_cast<int>(llmq_type) << " quorum="
-                 << quorum_hash.GetHex().substr(0, 16)
-                 << " cycle_base_h=" << *base_h;
+        m_last_rotated = RotatedOutcome::kRequestSent;
+        LOG_INFO << "[QC-MEMBERS] rotated getqrinfo SENT outcome="
+                 << rotated_outcome_name(RotatedOutcome::kRequestSent)
+                 << " " << who << " cycle_base_h=" << *base_h
+                 << " timeout=" << kRotatedRequestTimeoutSec << "s"
+                 << " (awaiting a qrinfo RECEIVED line; if none appears a "
+                    "TIMED OUT line will)";
         return true;
     }
 
@@ -316,28 +465,37 @@ public:
     {
         // Which outstanding rotated request is this? Bind by the H diff's
         // height: H must be (cycle_base - 8) for exactly one pending.
+        // Named ARRIVAL: this is the line whose absence made "no reply came"
+        // and "a reply came and was dropped" indistinguishable in the soaks.
+        LOG_INFO << "[QC-MEMBERS] qrinfo ARRIVED at member source: "
+                 << "lastCommitmentPerIndex=" << info.lastCommitmentPerIndex.size()
+                 << " outstanding=" << m_rotated_pending.size();
+
         vendor::CCbTx probe_cbtx;
         if (info.mnListDiffH.cbTx.type != 5
             || !vendor::parse_cbtx(info.mnListDiffH.cbTx.extra_payload, probe_cbtx)
             || probe_cbtx.nHeight < 0) {
-            LOG_WARNING << "[QC-MEMBERS] qrinfo: mnListDiffH carries no usable "
-                           "type-5 cbTx — fail closed";
+            note_rotated(RotatedOutcome::kReplyNoCbTx,
+                         "mnListDiffH carries no usable type-5 cbTx");
             return std::nullopt;
         }
         const uint64_t h_height = static_cast<uint64_t>(probe_cbtx.nHeight);
 
         const Key* match = nullptr;
         uint32_t   base_h = 0;
-        for (const auto& [key, base] : m_rotated_pending) {
-            if (static_cast<uint64_t>(base) == h_height + kWorkDiffDepth) {
+        for (const auto& [key, pend] : m_rotated_pending) {
+            if (static_cast<uint64_t>(pend.cycle_base_height)
+                == h_height + kWorkDiffDepth) {
                 match = &key;
-                base_h = base;
+                base_h = pend.cycle_base_height;
                 break;
             }
         }
         if (match == nullptr) {
-            LOG_WARNING << "[QC-MEMBERS] qrinfo at H=" << h_height
-                        << " matches no outstanding rotated request — dropped";
+            note_rotated(RotatedOutcome::kReplyUnsolicited,
+                         "value=H:" + std::to_string(h_height)
+                         + " threshold=outstanding:"
+                         + std::to_string(m_rotated_pending.size()));
             return std::nullopt;
         }
         const Key key = *match;
@@ -345,6 +503,8 @@ public:
         const LlmqParamsView* p = params_for(key.llmqType);
         if (p == nullptr || !p->use_rotation || p->dkg_interval == 0) {
             erase_rotated_pending(key);
+            note_rotated(RotatedOutcome::kReplyTypeVanished,
+                         "type=" + std::to_string(static_cast<int>(key.llmqType)));
             return std::nullopt;
         }
         const uint32_t C = p->dkg_interval;
@@ -378,20 +538,23 @@ public:
             // applied-onto-empty SML root must equal cbTx.merkleRootMNList, which
             // an incremental diff cannot satisfy.
             if (!diffs[i]->deletedMNs.empty()) {
-                LOG_WARNING << "[QC-MEMBERS] qrinfo cycle diff " << i
-                            << " deletes " << diffs[i]->deletedMNs.size()
-                            << " entries — not a FULL list, fail closed";
                 erase_rotated_pending(key);
+                note_rotated(RotatedOutcome::kReplyNotFullList,
+                             "cycle_diff=" + std::to_string(i)
+                             + " value=deletedMNs:"
+                             + std::to_string(diffs[i]->deletedMNs.size())
+                             + " threshold=0 — whole reply fails closed");
                 return std::nullopt;
             }
             vendor::CCbTx cbtx;
             auto sml = authenticate_historical_snapshot(
                 *diffs[i], expect_h, m_merkle_root_of_hash, cbtx, "QC-MEMBERS");
             if (!sml) {
-                LOG_WARNING << "[QC-MEMBERS] qrinfo cycle diff " << i
-                            << " failed DIP-4 authentication at expected h="
-                            << expect_h << " — whole reply fails closed";
                 erase_rotated_pending(key);
+                note_rotated(RotatedOutcome::kReplyAuthFailed,
+                             "cycle_diff=" + std::to_string(i)
+                             + " expected_h=" + std::to_string(expect_h)
+                             + " — whole reply fails closed");
                 return std::nullopt;
             }
             out.smls[i] = std::move(*sml);
@@ -449,10 +612,10 @@ public:
         auto sets = vendor::compute_quorum_members_by_quarter_rotation(
             rp, cycles, snaps);
         if (!sets) {
-            LOG_WARNING << "[QC-MEMBERS] rotated member computation AMBIGUOUS "
-                           "for cycle_base_h=" << in.cycle_base_height
-                        << " type=" << static_cast<int>(in.llmq_type)
-                        << " -> fail closed (null-serve for the whole cycle)";
+            note_rotated(RotatedOutcome::kComputeAmbiguous,
+                         "type=" + std::to_string(static_cast<int>(in.llmq_type))
+                         + " cycle_base_h=" + std::to_string(in.cycle_base_height)
+                         + " -> null-serve for the whole cycle");
             return 0;
         }
 
@@ -470,23 +633,70 @@ public:
             ++published;
         }
         if (published == 0) {
-            LOG_WARNING << "[QC-MEMBERS] rotated cycle_base_h="
-                        << in.cycle_base_height << " type="
-                        << static_cast<int>(in.llmq_type)
-                        << " computed " << sets->size() << " member sets but NO "
-                           "slot base-block header is held -> nothing published, "
-                           "cycle stays null-serve";
+            note_rotated(RotatedOutcome::kNoSlotHeaders,
+                         "type=" + std::to_string(static_cast<int>(in.llmq_type))
+                         + " cycle_base_h=" + std::to_string(in.cycle_base_height)
+                         + " value=published:0 threshold=computed:"
+                         + std::to_string(sets->size())
+                         + " — cycle stays null-serve");
         } else {
-            LOG_INFO << "[QC-MEMBERS] ROTATED READY type="
-                     << static_cast<int>(in.llmq_type) << " cycle_base_h="
-                     << in.cycle_base_height << " slots=" << published << "/"
-                     << sets->size() << " members=" << p->size
+            m_last_rotated = RotatedOutcome::kReady;
+            // Mirrors the non-rotated "[QC-MEMBERS] READY type=" token so a
+            // single grep answers "did ANY type reach ready?" for both lanes.
+            LOG_INFO << "[QC-MEMBERS] READY type="
+                     << static_cast<int>(in.llmq_type)
+                     << " members=" << p->size
+                     << " outcome=" << rotated_outcome_name(RotatedOutcome::kReady)
+                     << " lane=ROTATED cycle_base_h=" << in.cycle_base_height
+                     << " slots=" << published << "/" << sets->size()
                      << " (real-commitment serving ENABLED for this cycle)";
         }
         return published;
     }
 
     size_t rotated_pending_count() const { return m_rotated_pending.size(); }
+
+    /// The most recent named outcome of the rotated lane. Exists so a test can
+    /// assert that a failure NAMED ITSELF, not merely that it failed — the
+    /// property the soaks could not check.
+    RotatedOutcome last_rotated_outcome() const { return m_last_rotated; }
+
+    /// Monotonic clock seam (seconds). Defaults to steady_clock; tests inject.
+    using NowSeconds = std::function<int64_t()>;
+    void set_clock(NowSeconds f) { if (f) m_now = std::move(f); }
+
+    /// A getqrinfo the peer never answered must EXPIRE, for two reasons that
+    /// the soaks demonstrated together:
+    ///   (1) DIAGNOSTIC — "sent, never answered" is otherwise indistinguishable
+    ///       from "sent, answered, dropped"; only one of them is a peer problem;
+    ///   (2) LIVENESS — a stuck pending makes every later slot of that cycle
+    ///       take the dedup branch and send nothing, so ONE lost reply wedges
+    ///       the cycle permanently. Expiry re-opens it for the next qfcommit.
+    /// Returns the number expired. Driven off request() (the qfcommit kick).
+    size_t expire_rotated_requests()
+    {
+        const int64_t now = m_now();
+        std::vector<Key> dead;
+        for (const auto& [key, pend] : m_rotated_pending) {
+            if (now - pend.sent_at >= kRotatedRequestTimeoutSec)
+                dead.push_back(key);
+        }
+        for (const auto& key : dead) {
+            const auto it = m_rotated_pending.find(key);
+            const uint32_t base_h = it->second.cycle_base_height;
+            const int64_t  age    = now - it->second.sent_at;
+            erase_rotated_pending(key);
+            note_rotated(RotatedOutcome::kTimedOut,
+                         "type=" + std::to_string(static_cast<int>(key.llmqType))
+                         + " cycle_base=" + key.quorumHash.GetHex().substr(0, 16)
+                         + " cycle_base_h=" + std::to_string(base_h)
+                         + " value=age_s:" + std::to_string(age)
+                         + " threshold=" + std::to_string(kRotatedRequestTimeoutSec)
+                         + " — NO qrinfo reply reached the member source; cycle "
+                           "re-opened for re-request");
+        }
+        return dead.size();
+    }
 
     /// Consume a historical work-block snapshot. Returns TRUE iff the diff
     /// matched an outstanding await (so the caller must NOT also feed the
@@ -528,6 +738,28 @@ private:
     // llmq/snapshot.h @ v23.1.7: WORK_DIFF_DEPTH = 8.
     static constexpr uint32_t kWorkDiffDepth = 8;
 
+    /// How long a getqrinfo may stay outstanding before it is declared dead.
+    /// Sized well above a normal round trip for a ~600 kB reply while staying
+    /// far under DASH's 2.5-minute block time, so a wedged cycle re-opens
+    /// within the same block it was requested in.
+    static constexpr int64_t kRotatedRequestTimeoutSec = 120;
+
+    /// Record + LOG a named rotated outcome. EVERY exit of the rotated lane
+    /// goes through here (or sets m_last_rotated directly for the two
+    /// non-events, dedup and already-ready), so no rotated path can end
+    /// without saying which outcome it was.
+    void note_rotated(RotatedOutcome o, const std::string& detail)
+    {
+        m_last_rotated = o;
+        LOG_WARNING << "[QC-MEMBERS] rotated lane cause="
+                    << rotated_outcome_name(o) << " " << detail;
+    }
+    bool note_rotated_false(RotatedOutcome o, const std::string& detail)
+    {
+        note_rotated(o, detail);
+        return false;
+    }
+
     struct Key {
         uint8_t llmqType;
         uint256 quorumHash;
@@ -546,6 +778,12 @@ private:
         uint256  quorum_hash;
         uint32_t work_height{0};
         uint256  work_hash;
+    };
+    /// An outstanding getqrinfo. `sent_at` is what makes "no reply came" a
+    /// NAMED, TIMED outcome instead of an entry that sits there forever.
+    struct RotatedPending {
+        uint32_t cycle_base_height{0};
+        int64_t  sent_at{0};
     };
 
     const LlmqParamsView* params_for(uint8_t type) const
@@ -648,7 +886,18 @@ private:
     {
         while (m_rotated_pending.size() >= kRotatedPendingCap
                && !m_rotated_fifo.empty()) {
-            m_rotated_pending.erase(m_rotated_fifo.front());
+            const Key victim = m_rotated_fifo.front();
+            auto it = m_rotated_pending.find(victim);
+            if (it != m_rotated_pending.end()) {
+                LOG_WARNING << "[QC-MEMBERS] rotated lane cause=pending_cap_evicted"
+                            << " type=" << static_cast<int>(victim.llmqType)
+                            << " cycle_base_h=" << it->second.cycle_base_height
+                            << " value=" << m_rotated_pending.size()
+                            << " threshold=" << kRotatedPendingCap
+                            << " — oldest outstanding getqrinfo dropped, that "
+                               "cycle stays null-serve until re-requested";
+                m_rotated_pending.erase(it);
+            }
             m_rotated_fifo.pop_front();
         }
     }
@@ -708,9 +957,14 @@ private:
     std::deque<Key> m_pending_fifo;
     std::map<uint256, std::vector<Key>> m_await;   // work-block hash -> waiters
 
-    SendGetQrInfo             m_send_qrinfo;
-    std::map<Key, uint32_t>   m_rotated_pending;   // cycle-base key -> cycle base h
-    std::deque<Key>           m_rotated_fifo;
+    SendGetQrInfo                  m_send_qrinfo;
+    std::map<Key, RotatedPending>  m_rotated_pending;  // cycle-base key -> when/where
+    std::deque<Key>                m_rotated_fifo;
+    RotatedOutcome                 m_last_rotated{RotatedOutcome::kNone};
+    NowSeconds                     m_now{[] {
+        return std::chrono::duration_cast<std::chrono::seconds>(
+                   std::chrono::steady_clock::now().time_since_epoch()).count();
+    }};
 };
 
 } // namespace coin

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -972,7 +972,21 @@ if (BUILD_TESTING AND GTest_FOUND)
     # (coin/coin_peer_manager.hpp): source scoring (daemon penalty / addr-crawl
     # bonus), selection ordering, /16 Sybil group caps, anchor persistence, and
     # the pinned protected local node. Same target, no new allowlist entry.
-    add_executable(test_dash_p2p_node test_dash_p2p_node.cpp test_dash_coin_p2p_client.cpp test_dash_coin_peer_manager.cpp)
+    # Fourth TU: test_dash_qrinfo_wire.cpp — the DIP-24 rotated lane driven
+    # from RAW WIRE BYTES through p2p::Handler::parse() into
+    # QuorumMemberSource, plus the named-outcome / request-timeout gates.
+    # THIS TARGET, not test_dash_embedded_gbt: the gate is Handler REGISTRY
+    # membership, which needs the full p2p Handler instantiated, which
+    # ODR-uses CBlockHeaderAndShortTxIDs::FillShortTxIDSelector() out of
+    # dash_block_replay — only linked here. Same target, no new build.yml
+    # --target allowlist entry needed (test_dash_p2p_node is already in it;
+    # the push bot lacks `workflow` scope, #769, so a standalone target would
+    # be a NOT_BUILT sentinel).
+    # DASH_FIXTURE_DIR is new on this target: the wire suite replays the real
+    # 602'189-byte testnet qrinfo capture.
+    add_executable(test_dash_p2p_node test_dash_p2p_node.cpp test_dash_coin_p2p_client.cpp test_dash_coin_peer_manager.cpp test_dash_qrinfo_wire.cpp)
+    target_compile_definitions(test_dash_p2p_node PRIVATE
+        DASH_FIXTURE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/fixtures")
     target_link_libraries(test_dash_p2p_node PRIVATE
         GTest::gtest_main GTest::gtest
         dash_block_replay   # E1: coin/vendor/blockencodings.cpp — the full p2p Handler

--- a/test/test_dash_qrinfo_wire.cpp
+++ b/test/test_dash_qrinfo_wire.cpp
@@ -1,0 +1,527 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// DIP-0024 rotated quorums: the WIRE-TO-READY gate, and the "every outcome
+// names itself" gate.
+//
+// WHY THIS FILE EXISTS
+// --------------------
+// Three live soaks cached 32 type-5 (LLMQ_60_75) qfcommits and produced ZERO
+// "[QC-MEMBERS] READY type=5". The decode, the DIP-4 authentication and the
+// quarter-rotation member computation were all correct and all covered — by
+// test_dash_qrinfo.cpp and test_dash_rotated_quorum_members.cpp, which hand a
+// DECODED CQuorumRotationInfo straight to QuorumMemberSource::on_qrinfo().
+//
+// That is exactly the seam the defect lived in. `message_qrinfo` was never
+// added to the p2p::Handler type list, so MessageHandler::parse() threw
+// std::out_of_range on every reply and CoinClient::handle dropped it on the
+// "unhandled command" path — at DEBUG level. ADD_P2P_HANDLER(qrinfo) existed,
+// fully written, with a registered consumer, and could never run. Every
+// existing test passed, because every existing test started AFTER the drop.
+//
+// So the tests below start at the RAW BYTES, the way a peer delivers them:
+//
+//     602'189 fixture bytes
+//        -> RawMessage{"qrinfo", ...}
+//        -> p2p::Handler::parse()          <- WHERE IT BROKE
+//        -> message_qrinfo::m_raw
+//        -> decode_quorum_rotation_info()
+//        -> QuorumMemberSource::on_qrinfo()
+//        -> lookup() serves the rotated quorum
+//
+// VERIFIED TO FAIL ON THE PRE-FIX TREE: with message_qrinfo removed from the
+// p2p::Handler list in p2p_messages.hpp (i.e. master as of this branch point),
+// HandlerRegistryDispatchesQrInfo and WireToReadyEndToEnd both RED with
+// "MessageHandler not contain qrinfo" thrown out of parse(). A happy-path test
+// that began at on_qrinfo() would have stayed GREEN through the whole outage —
+// and did.
+//
+// The second half of the file gates the OTHER half of the defect: the rotated
+// lane could fail without saying why. Every refusal must now name itself, and
+// an unanswered getqrinfo must TIME OUT by name rather than wedge its cycle
+// forever.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/p2p_messages.hpp>
+#include <impl/dash/coin/quorum_member_source.hpp>
+#include <impl/dash/coin/vendor/quorum_rotation_info.hpp>
+#include <core/message.hpp>
+#include <core/pack.hpp>
+
+#include "data/dash_rotated_quorum_members_kat.hpp"
+
+#include <fstream>
+#include <iterator>
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+using dash::coin::LlmqNetwork;
+using dash::coin::QuorumMemberSource;
+using dash::coin::RotatedOutcome;
+using dash::coin::rotated_outcome_name;
+using dash::coin::vendor::CQuorumRotationInfo;
+using dash::coin::vendor::CSimplifiedMNListDiff;
+using dash::coin::vendor::decode_quorum_rotation_info;
+
+namespace {
+
+constexpr uint32_t kCycleBase = 1520064;   // llmq_60_75 cycle base
+constexpr uint8_t  kType      = 5;         // LLMQ_60_75 (rotated)
+constexpr size_t   kNQuorums  = 32;        // signingActiveQuorumCount
+constexpr size_t   kFixtureBytes = 602189;
+
+std::vector<unsigned char> read_fixture()
+{
+    const std::string path =
+        std::string(DASH_FIXTURE_DIR) + "/dash_testnet_qrinfo_1520064.bin";
+    std::ifstream f(path, std::ios::binary);
+    EXPECT_TRUE(f.good()) << "cannot open fixture: " << path;
+    return std::vector<unsigned char>(std::istreambuf_iterator<char>(f),
+                                      std::istreambuf_iterator<char>());
+}
+
+/// Deliver `payload` to the coin p2p Handler exactly as the socket read loop
+/// does: as a RawMessage carrying only a command string and opaque bytes.
+/// Throws whatever parse() throws — which is the point.
+dash::coin::p2p::Handler::result_t deliver(const std::string& command,
+                                           const std::vector<unsigned char>& payload)
+{
+    auto raw = std::make_unique<RawMessage>(command, PackStream(payload));
+    dash::coin::p2p::Handler handler;
+    return handler.parse(raw);
+}
+
+// ⚠ These two accessors use std::visit + `requires`, NOT std::get_if<T>.
+// std::get_if<message_qrinfo> against a variant that does not list that
+// alternative is a COMPILE error — which would turn a removed registry entry
+// into a build break instead of a legible RED test. Visiting keeps this file
+// compilable on a tree WITHOUT qrinfo registered, so the failure lands where
+// it belongs: parse() throwing "MessageHandler not contain qrinfo".
+
+/// The command string of whatever alternative the variant now holds.
+std::string parsed_command(const dash::coin::p2p::Handler::result_t& r)
+{
+    return std::visit([](const auto& m) {
+        return m ? m->m_command : std::string{};
+    }, r);
+}
+
+/// The opaque payload of a message that carries one (qrinfo does).
+std::optional<std::vector<unsigned char>>
+parsed_raw(const dash::coin::p2p::Handler::result_t& r)
+{
+    return std::visit([](const auto& m)
+        -> std::optional<std::vector<unsigned char>> {
+        if constexpr (requires { m->m_raw; }) {
+            if (m) return m->m_raw;
+        }
+        return std::nullopt;
+    }, r);
+}
+
+/// The block-request hash of a message that carries one (getqrinfo does).
+std::optional<uint256>
+parsed_block_request_hash(const dash::coin::p2p::Handler::result_t& r)
+{
+    return std::visit([](const auto& m) -> std::optional<uint256> {
+        if constexpr (requires { m->m_block_request_hash; }) {
+            if (m) return m->m_block_request_hash;
+        }
+        return std::nullopt;
+    }, r);
+}
+
+uint256 slot_hash(uint32_t qi)
+{
+    uint256 h;
+    std::string s(64, '0');
+    s[0] = 'e'; s[1] = 'e';
+    s[62] = "0123456789abcdef"[(qi >> 4) & 0xf];
+    s[63] = "0123456789abcdef"[qi & 0xf];
+    h.SetHex(s);
+    return h;
+}
+
+/// A QuorumMemberSource wired against the real fixture's headers, with an
+/// injectable clock so the timeout path is testable without sleeping.
+struct SourceHarness {
+    CQuorumRotationInfo         info;
+    std::map<uint256, uint256>  roots;      // blockHash -> header merkle root
+    std::map<uint32_t, uint256> by_height;
+    int      sends{0};
+    int64_t  now{1000};
+
+    void load()
+    {
+        auto bytes = read_fixture();
+        ASSERT_EQ(bytes.size(), kFixtureBytes) << "fixture length regression";
+        ASSERT_TRUE(decode_quorum_rotation_info(bytes, info));
+        for (const CSimplifiedMNListDiff* d :
+             {&info.mnListDiffH, &info.mnListDiffAtHMinusC,
+              &info.mnListDiffAtHMinus2C, &info.mnListDiffAtHMinus3C}) {
+            std::vector<uint256>      m;
+            std::vector<unsigned int> idx;
+            roots[d->blockHash] = d->cbTxMerkleTree.ExtractMatches(m, idx);
+        }
+        uint256 cycle;
+        cycle.SetHex(dash::coin::testdata::kRot6075_QuorumHash);
+        by_height[kCycleBase] = cycle;                 // quorumIndex 0
+        for (uint32_t qi = 1; qi < kNQuorums; ++qi)
+            by_height[kCycleBase + qi] = slot_hash(qi);
+    }
+
+    QuorumMemberSource make(bool with_send_seam = true)
+    {
+        QuorumMemberSource src(
+            LlmqNetwork::Testnet,
+            [this](uint32_t h) -> std::optional<uint256> {
+                auto it = by_height.find(h);
+                if (it == by_height.end()) return std::nullopt;
+                return it->second;
+            },
+            [this](const uint256& qh) -> std::optional<uint32_t> {
+                for (const auto& [h, hash] : by_height)
+                    if (hash == qh) return h;
+                return std::nullopt;
+            },
+            [this](const uint256& h) -> std::optional<uint256> {
+                auto it = roots.find(h);
+                if (it == roots.end()) return std::nullopt;
+                return it->second;
+            },
+            [](const uint256&, const uint256&) {});
+        src.set_clock([this] { return now; });
+        if (with_send_seam) {
+            src.set_send_getqrinfo(
+                [this](const std::vector<uint256>&, const uint256&, bool) { ++sends; });
+        }
+        return src;
+    }
+
+    uint256 cycle_hash() const
+    {
+        uint256 c;
+        c.SetHex(dash::coin::testdata::kRot6075_QuorumHash);
+        return c;
+    }
+};
+
+} // namespace
+
+// ═══ 1. THE REGISTRY GATE — the exact defect ═══════════════════════════════
+//
+// A message type absent from p2p::Handler is not merely unhandled, it is
+// UNROUTABLE: parse() throws and the payload dies in a catch block. These two
+// tests assert the qrinfo pair is routable at all, which is a property no
+// decode-level test can see.
+
+TEST(DashQrInfoWire, HandlerRegistryDispatchesQrInfo)
+{
+    auto bytes = read_fixture();
+    dash::coin::p2p::Handler::result_t res;
+    ASSERT_NO_THROW(res = deliver("qrinfo", bytes))
+        << "qrinfo is missing from the p2p::Handler type list — every reply "
+           "from dashd is dropped before ADD_P2P_HANDLER(qrinfo) can run, and "
+           "the ONLY trace is a debug-level 'unhandled command' line";
+
+    EXPECT_EQ(parsed_command(res), "qrinfo") << "parsed to the wrong message type";
+    // The codec hands the payload through untouched; the decode is the
+    // handler's job, deliberately (see p2p_messages.hpp).
+    auto raw = parsed_raw(res);
+    ASSERT_TRUE(raw.has_value());
+    EXPECT_EQ(raw->size(), kFixtureBytes);
+    EXPECT_EQ(*raw, bytes);
+}
+
+TEST(DashQrInfoWire, HandlerRegistryDispatchesGetQrInfo)
+{
+    // The inbound side has a handler too (we refuse to serve rotation info).
+    // Absent from the registry it is equally dead, and a peer's getqrinfo
+    // would be an unexplained drop rather than an explicit refusal.
+    std::vector<uint256> bases;
+    uint256 req;
+    req.SetHex(dash::coin::testdata::kRot6075_QuorumHash);
+    auto raw = dash::coin::p2p::message_getqrinfo::make_raw(bases, req, false);
+    std::vector<unsigned char> payload(
+        reinterpret_cast<unsigned char*>(raw->m_data.data()),
+        reinterpret_cast<unsigned char*>(raw->m_data.data()) + raw->m_data.size());
+
+    dash::coin::p2p::Handler::result_t res;
+    ASSERT_NO_THROW(res = deliver("getqrinfo", payload));
+    EXPECT_EQ(parsed_command(res), "getqrinfo");
+    auto got = parsed_block_request_hash(res);
+    ASSERT_TRUE(got.has_value());
+    EXPECT_EQ(*got, req);
+}
+
+// An unregistered command still throws out_of_range — this pins that the drop
+// path we hardened is the one that was actually swallowing qrinfo, and that
+// the registry is a whitelist rather than a fallthrough.
+TEST(DashQrInfoWire, AnUnregisteredCommandStillThrowsOutOfRange)
+{
+    EXPECT_THROW(deliver("qsendrecsigs", {}), std::out_of_range);
+}
+
+// ═══ 2. WIRE TO READY — the end-to-end property ════════════════════════════
+
+TEST(DashQrInfoWire, WireToReadyEndToEnd)
+{
+    SourceHarness h;
+    h.load();
+    auto src = h.make();
+
+    const uint256 cycle = h.cycle_hash();
+    ASSERT_TRUE(src.request_rotated(kType, cycle));
+    EXPECT_EQ(h.sends, 1);
+    EXPECT_EQ(src.last_rotated_outcome(), RotatedOutcome::kRequestSent);
+
+    // ── the reply comes back the way a peer actually delivers it ──
+    auto bytes = read_fixture();
+    dash::coin::p2p::Handler::result_t res;
+    ASSERT_NO_THROW(res = deliver("qrinfo", bytes))
+        << "the reply never reaches ADD_P2P_HANDLER(qrinfo) at all";
+    auto raw = parsed_raw(res);
+    ASSERT_TRUE(raw.has_value());
+
+    // ── what ADD_P2P_HANDLER(qrinfo) then does ──
+    CQuorumRotationInfo info;
+    ASSERT_TRUE(decode_quorum_rotation_info(*raw, info));
+    ASSERT_TRUE(src.on_qrinfo(info).has_value());
+
+    // THE PROPERTY: a rotated type reaches member-set-ready given a valid
+    // qrinfo reply. In the soaks this never happened even once.
+    EXPECT_EQ(src.last_rotated_outcome(), RotatedOutcome::kReady);
+    EXPECT_EQ(src.rotated_pending_count(), 0u);
+    EXPECT_EQ(src.ready_count(), kNQuorums);
+    auto members = src.lookup(kType, cycle);
+    ASSERT_TRUE(members.has_value());
+    EXPECT_EQ(members->size(), 60u);
+    for (uint32_t qi = 1; qi < kNQuorums; ++qi)
+        EXPECT_TRUE(src.lookup(kType, slot_hash(qi)).has_value()) << "slot " << qi;
+}
+
+// ═══ 3. EVERY OUTCOME NAMES ITSELF ═════════════════════════════════════════
+//
+// The other half of the defect: the rotated lane could not report why it
+// failed. These gate that each distinct failure is DISTINGUISHABLE, which is
+// what "impossible to look at a log and not know which happened" reduces to.
+
+TEST(DashQrInfoWire, EveryRotatedOutcomeHasAUniqueName)
+{
+    const RotatedOutcome all[] = {
+        RotatedOutcome::kNone,
+        RotatedOutcome::kRequestSent,
+        RotatedOutcome::kRequestDeduped,
+        RotatedOutcome::kRequestAlreadyReady,
+        RotatedOutcome::kRefusedUnknownType,
+        RotatedOutcome::kRefusedNotRotated,
+        RotatedOutcome::kRefusedNoSendSeam,
+        RotatedOutcome::kRefusedIntervalZero,
+        RotatedOutcome::kRefusedBaseHeaderMissing,
+        RotatedOutcome::kRefusedIndexOutOfRange,
+        RotatedOutcome::kRefusedCycleHeaderGap,
+        RotatedOutcome::kRefusedBaseUnaligned,
+        RotatedOutcome::kRefusedCycleSpanTooShallow,
+        RotatedOutcome::kRefusedPreV20,
+        RotatedOutcome::kReplyNoCbTx,
+        RotatedOutcome::kReplyUnsolicited,
+        RotatedOutcome::kReplyTypeVanished,
+        RotatedOutcome::kReplyNotFullList,
+        RotatedOutcome::kReplyAuthFailed,
+        RotatedOutcome::kComputeAmbiguous,
+        RotatedOutcome::kNoSlotHeaders,
+        RotatedOutcome::kReady,
+        RotatedOutcome::kTimedOut,
+    };
+    std::set<std::string> seen;
+    for (RotatedOutcome o : all) {
+        const std::string n = rotated_outcome_name(o);
+        EXPECT_NE(n, "unnamed") << "a rotated outcome with no name is the bug "
+                                   "this whole file exists to prevent";
+        EXPECT_FALSE(n.empty());
+        EXPECT_TRUE(seen.insert(n).second) << "duplicate outcome name: " << n;
+    }
+}
+
+// The send-seam-not-wired refusal. In production this is the difference
+// between "the peer is broken" and "we never asked" — the two states the
+// soaks could not tell apart.
+TEST(DashQrInfoWire, MissingSendSeamNamesItself)
+{
+    SourceHarness h;
+    h.load();
+    auto src = h.make(/*with_send_seam=*/false);
+    EXPECT_FALSE(src.request_rotated(kType, h.cycle_hash()));
+    EXPECT_EQ(src.last_rotated_outcome(), RotatedOutcome::kRefusedNoSendSeam);
+    EXPECT_EQ(h.sends, 0);
+}
+
+TEST(DashQrInfoWire, NonRotatedTypeRefusalNamesItself)
+{
+    SourceHarness h;
+    h.load();
+    auto src = h.make();
+    EXPECT_FALSE(src.request_rotated(/*llmq_50_60=*/1, h.cycle_hash()));
+    EXPECT_EQ(src.last_rotated_outcome(), RotatedOutcome::kRefusedNotRotated);
+}
+
+TEST(DashQrInfoWire, UnknownTypeRefusalNamesItself)
+{
+    SourceHarness h;
+    h.load();
+    auto src = h.make();
+    EXPECT_FALSE(src.request_rotated(/*not an enabled llmq type=*/200, h.cycle_hash()));
+    EXPECT_EQ(src.last_rotated_outcome(), RotatedOutcome::kRefusedUnknownType);
+}
+
+TEST(DashQrInfoWire, UnalignedCycleBaseRefusalNamesItself)
+{
+    SourceHarness h;
+    h.load();
+    // Point the height index at a base that is NOT on the 288 boundary.
+    uint256 unaligned = slot_hash(7);        // sits at kCycleBase + 7
+    auto src = h.make();
+    EXPECT_FALSE(src.request_rotated(kType, unaligned));
+    EXPECT_EQ(src.last_rotated_outcome(), RotatedOutcome::kRefusedBaseUnaligned);
+}
+
+TEST(DashQrInfoWire, UnheldBaseHeaderRefusalNamesItself)
+{
+    SourceHarness h;
+    h.load();
+    auto src = h.make();
+    uint256 stranger;
+    stranger.SetHex(std::string(63, '0') + "1");
+    EXPECT_FALSE(src.request_rotated(kType, stranger));
+    EXPECT_EQ(src.last_rotated_outcome(), RotatedOutcome::kRefusedBaseHeaderMissing);
+}
+
+TEST(DashQrInfoWire, UnsolicitedReplyNamesItself)
+{
+    SourceHarness h;
+    h.load();
+    auto src = h.make();                 // nothing requested
+    EXPECT_FALSE(src.on_qrinfo(h.info).has_value());
+    EXPECT_EQ(src.last_rotated_outcome(), RotatedOutcome::kReplyUnsolicited);
+}
+
+TEST(DashQrInfoWire, AuthFailureNamesItself)
+{
+    SourceHarness h;
+    h.load();
+    auto src = h.make();
+    ASSERT_TRUE(src.request_rotated(kType, h.cycle_hash()));
+
+    CQuorumRotationInfo tampered = h.info;
+    ASSERT_FALSE(tampered.mnListDiffAtHMinus2C.mnList.empty());
+    tampered.mnListDiffAtHMinus2C.mnList[0].pubKeyOperator[0] ^= 0xff;
+
+    EXPECT_FALSE(src.on_qrinfo(tampered).has_value());
+    EXPECT_EQ(src.last_rotated_outcome(), RotatedOutcome::kReplyAuthFailed)
+        << "a rejected reply must say WHY it was rejected, not just fail";
+}
+
+TEST(DashQrInfoWire, NonFullCycleDiffNamesItself)
+{
+    SourceHarness h;
+    h.load();
+    auto src = h.make();
+    ASSERT_TRUE(src.request_rotated(kType, h.cycle_hash()));
+
+    CQuorumRotationInfo tampered = h.info;
+    tampered.mnListDiffAtHMinus2C.deletedMNs.push_back(
+        tampered.mnListDiffH.blockHash);
+    EXPECT_FALSE(src.on_qrinfo(tampered).has_value());
+    EXPECT_EQ(src.last_rotated_outcome(), RotatedOutcome::kReplyNotFullList);
+}
+
+// ═══ 4. THE WEDGE — an unanswered request must expire, by name ═════════════
+//
+// This is the liveness half of the dropped-reply defect. One lost qrinfo left
+// m_rotated_pending occupied forever; every later slot of that cycle then took
+// the dedup branch and sent nothing. The cycle could never recover, and no log
+// line said so. Both halves are gated here.
+
+TEST(DashQrInfoWire, UnansweredRequestTimesOutWithANamedCause)
+{
+    SourceHarness h;
+    h.load();
+    auto src = h.make();
+
+    ASSERT_TRUE(src.request_rotated(kType, h.cycle_hash()));
+    ASSERT_EQ(src.rotated_pending_count(), 1u);
+
+    // Just inside the window: still outstanding, nothing claimed.
+    h.now += 119;
+    EXPECT_EQ(src.expire_rotated_requests(), 0u);
+    EXPECT_EQ(src.rotated_pending_count(), 1u);
+
+    // Past it: the failure is named and the slot is freed.
+    h.now += 2;
+    EXPECT_EQ(src.expire_rotated_requests(), 1u);
+    EXPECT_EQ(src.last_rotated_outcome(), RotatedOutcome::kTimedOut);
+    EXPECT_EQ(src.rotated_pending_count(), 0u);
+}
+
+TEST(DashQrInfoWire, ATimedOutCycleCanBeReRequested)
+{
+    SourceHarness h;
+    h.load();
+    auto src = h.make();
+
+    ASSERT_TRUE(src.request_rotated(kType, h.cycle_hash()));
+    ASSERT_EQ(h.sends, 1);
+
+    // Before expiry the dedup is correct and must hold.
+    ASSERT_TRUE(src.request_rotated(kType, h.cycle_hash()));
+    EXPECT_EQ(h.sends, 1);
+    EXPECT_EQ(src.last_rotated_outcome(), RotatedOutcome::kRequestDeduped);
+
+    h.now += 121;
+    ASSERT_EQ(src.expire_rotated_requests(), 1u);
+
+    // After expiry the cycle is live again — this is what stops ONE lost
+    // reply from wedging a cycle permanently.
+    ASSERT_TRUE(src.request_rotated(kType, h.cycle_hash()));
+    EXPECT_EQ(h.sends, 2);
+    EXPECT_EQ(src.last_rotated_outcome(), RotatedOutcome::kRequestSent);
+}
+
+// request() is the qfcommit kick, and the only heartbeat this class has. It
+// must drive expiry, or the timeout above never fires in production.
+TEST(DashQrInfoWire, RequestDrivesExpiry)
+{
+    SourceHarness h;
+    h.load();
+    auto src = h.make();
+
+    ASSERT_TRUE(src.request_rotated(kType, h.cycle_hash()));
+    ASSERT_EQ(src.rotated_pending_count(), 1u);
+
+    h.now += 121;
+    // A qfcommit for slot 3 arrives. Before the fix this would have deduped
+    // against the wedged pending and sent nothing, forever.
+    src.request(kType, slot_hash(3));
+    EXPECT_EQ(src.rotated_pending_count(), 1u) << "expired, then re-requested";
+    EXPECT_EQ(h.sends, 2);
+    EXPECT_EQ(src.last_rotated_outcome(), RotatedOutcome::kRequestSent);
+}
+
+// A ready cycle must not be re-requested when a later slot's qfcommit lands.
+TEST(DashQrInfoWire, AReadyCycleIssuesNoFurtherTraffic)
+{
+    SourceHarness h;
+    h.load();
+    auto src = h.make();
+
+    ASSERT_TRUE(src.request_rotated(kType, h.cycle_hash()));
+    ASSERT_TRUE(src.on_qrinfo(h.info).has_value());
+    ASSERT_EQ(h.sends, 1);
+
+    h.now += 100000;                       // long past any timeout
+    src.request(kType, slot_hash(9));
+    EXPECT_EQ(h.sends, 1) << "a served cycle must generate no getqrinfo";
+}


### PR DESCRIPTION
## The defect

**MEASURED (three live soaks on contabo):** 32 type-5 (LLMQ_60_75) qfcommits cached in each of `soak0803f` and `soak0803g`; **0** `[QC-MEMBERS] READY type=5` in **all** soaks. Non-rotated types reach READY normally (`READY type=4 members=100` fires 6–19x per soak). Only the rotated type never becomes ready.

**MEASURED:** there is no reply-side log on the rotated path at all. `soak0803g` shows exactly one `getqrinfo` (03:33:19, `cycle_base_h=2515968`) and nothing after it. "Never sent", "sent, no reply" and "reply came and was dropped" are indistinguishable from the outside.

## Root cause — a fully wired path with no reachable caller

`message_qrinfo` was never added to the `p2p::Handler` type list in `src/impl/dash/coin/p2p_messages.hpp`.

`MessageHandler::parse()` (`src/core/message.hpp:84`) throws `std::out_of_range` for any command not in that list. `CoinClient::handle` catches it and drops the payload on the "unhandled command" path — at `LOG_DEBUG_COIND`. So:

- `send_getqrinfo` (`p2p_client.hpp:478`) works, because it calls `message_getqrinfo::make_raw` directly and never touches the registry. **This is why one getqrinfo appears in the log.**
- `ADD_P2P_HANDLER(qrinfo)` (`p2p_client.hpp:878`) exists, fully written, with a registered consumer wired in `main_dash.cpp:3186` — and **had no reachable caller**. Every ~600 kB reply from dashd died in a catch block.
- `QuorumMemberSource::on_qrinfo` (`quorum_member_source.hpp:315`) was therefore never invoked, `finalize_rotated` never ran, and no rotated member set ever entered `m_ready`.

`message_getqrinfo` was missing too, so `ADD_P2P_HANDLER(getqrinfo)` (`p2p_client.hpp:1012`) was equally dead.

**Why PRs #1054 and #1062 did not catch it:** every rotated test starts *after* the drop point. `test_dash_qrinfo.cpp` and `test_dash_rotated_quorum_members.cpp` hand an already-decoded `CQuorumRotationInfo` straight to `on_qrinfo()`. Both PRs are correct; neither touched the seam that was broken. A happy-path test would have stayed green through the whole outage — and did.

## Trace, as requested

| link | location | status before |
|---|---|---|
| `getqrinfo` sent | `p2p_client.hpp:478` `send_getqrinfo`, driven from `quorum_member_source.hpp:301` | **worked** |
| `qrinfo` reply routed | `p2p_messages.hpp` `Handler` list | **MISSING — the break** |
| `qrinfo` reply handled | `p2p_client.hpp:878` `ADD_P2P_HANDLER(qrinfo)` | written, unreachable |
| members computed | `quorum_member_source.hpp:434` `finalize_rotated` | never invoked |
| READY emitted | `quorum_member_source.hpp:480` | never reached |

## What this PR does

### 1. Diagnostic hole first (the deliverable)

- **`RotatedOutcome`** — an enum covering every terminal state of the rotated lane, each with a name. Ten previously silent `return` / `return false` paths now log `cause=<name>` with `value=` / `threshold=` where a bound is involved, matching the serve gate's discipline.
- **`on_qrinfo()` logs a named `ARRIVED` line on entry** — the reply-side evidence that did not exist.
- **The rotated READY line now carries the same `[QC-MEMBERS] READY type=` token as the non-rotated lane** (plus `lane=ROTATED`), so one grep answers "did any type reach ready?" for both. The measurement's own grep would now find it.
- **`p2p_client.hpp`: the first drop of each distinct unhandled command is a WARNING** naming the command and its size; repeats stay at DEBUG. This is the *generic* form of the defect — a dropped reply to a request we sent is not benign, and was indistinguishable from routine unsolicited `spork`/`senddsq` traffic. Bounded by the number of distinct commands, so it cannot flood.
- A received `qrinfo` with **no registered consumer** says so instead of vanishing.

After this change, every outcome on the rotated path names itself: request sent (with cycle base height and the timeout it is under), reply arrived (with counts), reply rejected (with reason), members computed, READY, or timed out.

### 2. Functional gap (tractable in the same change)

Two entries added to the `p2p::Handler` list. That is the whole functional fix — no protocol work, no design decision. The decode, the DIP-4 authentication and the quarter-rotation computation were all already correct and already covered.

### 3. Liveness — a second-order defect the same dropped reply caused

An unanswered `getqrinfo` now expires after 120s with a named `TIMED OUT` outcome. Without it, one lost reply left `m_rotated_pending` occupied **forever**, and every later slot of that cycle took the dedup branch and sent nothing — the cycle could never recover. Expiry is driven off `request()`, the qfcommit kick, which is the only heartbeat this class has. The clock is an injectable seam so the path is testable without sleeping. The pending-cap eviction also names itself now.

## Tests — and how failure on current behaviour was verified

`test/test_dash_qrinfo_wire.cpp`, 17 cases. The suite starts at **raw wire bytes** and runs to `lookup()` serving the quorum:

```
602'189 fixture bytes -> RawMessage{"qrinfo"} -> p2p::Handler::parse()  <- WHERE IT BROKE
                      -> message_qrinfo::m_raw -> decode_quorum_rotation_info()
                      -> QuorumMemberSource::on_qrinfo() -> lookup() serves
```

**Verified RED on the pre-fix tree.** With the two registry entries removed (i.e. `master` at this branch point), rebuilt and run:

```
[  FAILED  ] DashQrInfoWire.HandlerRegistryDispatchesQrInfo
  Actual: it throws std::out_of_range with description "MessageHandler not contain qrinfo".
[  FAILED  ] DashQrInfoWire.HandlerRegistryDispatchesGetQrInfo
  Actual: it throws std::out_of_range with description "MessageHandler not contain getqrinfo".
[  FAILED  ] DashQrInfoWire.WireToReadyEndToEnd
[  PASSED  ] 14 tests.
```

That is the production symptom, reproduced exactly. With expiry stubbed out to emulate the old behaviour, `UnansweredRequestTimesOutWithANamedCause`, `ATimedOutCycleCanBeReRequested` and `RequestDrivesExpiry` fail (3 red, 14 green). With the full change: **17/17 green**, and the log shows

```
[QC-MEMBERS] READY type=5 members=60 outcome=ready lane=ROTATED cycle_base_h=1520064 slots=32/32
```

Implementation note: the registry tests use `std::visit` + `requires`, **not** `std::get_if<T>`. `std::get_if` against a variant lacking the alternative is a *compile* error, which would turn a removed registry entry into a build break instead of a legible test failure. Visiting keeps the file compilable on a tree without `qrinfo` registered, so the failure lands where it belongs.

The 35 existing cases in `test_dash_qrinfo.cpp` and `test_dash_rotated_quorum_members.cpp` remain green.

## CI registration

Folded into **`test_dash_p2p_node`**, which is already in the `build.yml` `--target` allowlist. That target specifically, not `test_dash_embedded_gbt`: the gate is Handler *registry membership*, which needs the full `p2p::Handler` instantiated, which ODR-uses `CBlockHeaderAndShortTxIDs::FillShortTxIDSelector()` out of `dash_block_replay` — linked only there. `DASH_FIXTURE_DIR` added to that target for the 602'189-byte capture.

No new `--target` entry needed; `python3 tools/ci/check_test_target_allowlist.py` reports **OK, 228 targets across 6 coin lanes**. Nothing here is inside `#ifdef C2POOL_DASH_BLS`, so the BLS-only-KAT list is untouched.

## Scope

DASH lane only. No `src/core` changes. Files touched: `src/impl/dash/coin/p2p_messages.hpp`, `src/impl/dash/coin/p2p_client.hpp`, `src/impl/dash/coin/quorum_member_source.hpp`, `test/CMakeLists.txt`, `test/test_dash_qrinfo_wire.cpp`. No ordering/comparator code was touched, so the `base_blob` memcmp vs `base_uint<256>` trap is not in play.

## Status — INFERRED until a soak says otherwise

**No soak has yet observed type=5 reaching READY. This fix is unproven until one does.** What is proven is that the reply now routes, that the end-to-end path from wire bytes to a served member set works on the real testnet capture, and that every failure mode on the lane is legible from a log.

MEASURED: the soak counts, the absence of reply-side logging, the registry gap, the pre-fix test failures, the 17/17 and 35/35 green runs.
INFERRED: that the registry gap is the *only* remaining blocker on the rotated lane. The self-heal observation supports it — both soaks served EMBEDDED at h=2516014/2516015 (phase 46, inside type-5's window) once another miner mined the commitment, so the slot logic is sound and the failure was confined to our member sourcing.

Type 5's window is `[42,50]` on a 288-block cycle, so this is not the dominant serve blocker (`bestcl-stale` at ~42% is, handled separately). This matters for correctness and the daemonless mandate. The next observation opportunity is bounded by that geometry rather than by uptime.
