### PR TITLE
dash(qc): feed MineableCommitmentCache over request/response — close qc-plan-underivable's transport dependency

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -3171,6 +3171,105 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                         if (cp) cp->send_getmnlistd(base, tgt);
                     });
 
+            // ── ONE admission path for EVERY commitment transport ──────────
+            // (qc-plan-underivable fix). The cache used to be fed from exactly
+            // one source: the qfcommit push subscription below. Push requires
+            // being connected at the instant of the inv — measured on the
+            // 2026-08 soaks as a 14 s – 5 m 35 s arrival race after
+            // window-open on a healthy-peer host (7.5% of wall-clock declined
+            // qc-plan-underivable) and total cold-start starvation on a host
+            // whose peers churn. But FULL commitments also arrive over
+            // request/response — mnlistdiff `newQuorums` and qrinfo
+            // `lastCommitmentPerIndex` carry the complete DIP-4
+            // CFinalCommitment — and were dropped after existence
+            // bookkeeping. Every transport now funnels through THIS ingest,
+            // so the admission guarantees (structural checks + the BLS verify
+            // hook behind verified_for) hold identically regardless of
+            // arrival shape, and every ingest names its transport in the
+            // [QC-MINEABLE] line — the soak-checkable evidence of which
+            // transport actually supplied a commitment.
+            //
+            // SAY WHY on the reject path too: a dropped commitment that
+            // leaves no trace makes a later "no-commitment-cached" refusal
+            // indistinguishable from "never reached us" — opposite diagnoses
+            // (our bug vs a relay hole).
+            auto qc_ingest_from =
+                [qc_cache, qc_net, qc_member_source](
+                    const dash::coin::vendor::CFinalCommitment& c,
+                    const char* source, bool kick_member_fetch) {
+                    using Adm = dash::coin::MineableCommitmentCache::Admission;
+                    const auto adm = qc_cache->ingest_ex(qc_net, c);
+                    if (adm == Adm::Accepted) {
+                        LOG_INFO << "[QC-MINEABLE] cached commitment type="
+                                 << static_cast<int>(c.llmqType)
+                                 << " quorum="
+                                 << c.quorumHash.GetHex().substr(0, 16)
+                                 << "... signers=" << c.CountSigners()
+                                 << " source=" << source
+                                 << " cache=" << qc_cache->size();
+                        // Proactively source the member set so it is READY by
+                        // the DKG-window height that must serve it.
+                        if (kick_member_fetch)
+                            qc_member_source->request(c.llmqType, c.quorumHash);
+                    } else if (adm == Adm::NotBetterThanCached) {
+                        // EXPECTED steady-state overlap now that several
+                        // transports carry the same commitment (push +
+                        // mnlistdiff + qrinfo): an equal-or-better copy is
+                        // already held, the arrival is a no-op and NEVER a
+                        // downgrade. Same tag so a soak can still count
+                        // arrivals per transport, but named as the duplicate
+                        // it is, not a defect.
+                        LOG_INFO << "[QC-MINEABLE] duplicate commitment type="
+                                 << static_cast<int>(c.llmqType)
+                                 << " quorum="
+                                 << c.quorumHash.GetHex().substr(0, 16)
+                                 << "... signers=" << c.CountSigners()
+                                 << " source=" << source
+                                 << " cache=" << qc_cache->size();
+                    } else {
+                        LOG_INFO << "[QC-MINEABLE] REJECTED relayed"
+                                    " commitment type="
+                                 << static_cast<int>(c.llmqType)
+                                 << " quorum="
+                                 << c.quorumHash.GetHex().substr(0, 16)
+                                 << "... signers=" << c.CountSigners()
+                                 << " reason="
+                                 << dash::coin::MineableCommitmentCache
+                                        ::admission_name(adm)
+                                 << " source=" << source
+                                 << " cache=" << qc_cache->size();
+                    }
+                };
+
+            // Member-set fetch amplification guard for the BATCH transports:
+            // a cold full mnlistdiff snapshot re-carries EVERY active quorum
+            // (~100-200 on mainnet), and kicking a historical getmnlistd
+            // member-set fetch for each would fan out megabytes of wire
+            // traffic for quorums whose DKG mining window closed long ago
+            // (their slots cannot be required again short of a reorg wipe).
+            // Only commitments whose mining window is still open at the
+            // header tip get the proactive fetch; INGEST itself is
+            // unconditional — the cache entry is cheap, and the case where a
+            // closed-window commitment matters again (a reorg wiping the
+            // QuorumManager near the tip) re-offers it inside a window this
+            // filter passes.
+            auto qc_member_fetch_worthwhile =
+                [hc = header_chain.get(), qc_net](
+                    const dash::coin::vendor::CFinalCommitment& c) -> bool {
+                    auto tip = hc->tip();
+                    if (!tip) return false;
+                    auto base = hc->get_header(c.quorumHash);
+                    if (!base) return false;
+                    for (const auto& p : dash::coin::enabled_llmqs(qc_net)) {
+                        if (p.type != c.llmqType) continue;
+                        if (p.dkg_interval == 0) return false;
+                        const auto wb =
+                            dash::coin::qc_window_bound(p, base->height);
+                        return tip->height <= wb.last_height;
+                    }
+                    return false;
+                };
+
             // DIP-24 rotated lane: the getqrinfo send seam + the qrinfo reply
             // consumer. Both are OPTIONAL by construction — with neither wired
             // the rotated branch of request() simply cannot send and every
@@ -3184,8 +3283,17 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 // Unlike mnlistdiff there is no tip-feed hazard here: nothing
                 // else consumes qrinfo, so this consumer needs no demux.
                 coin_p2p->add_qrinfo_consumer(
-                    [qc_member_source]
+                    [qc_member_source, qc_ingest_from,
+                     qc_member_fetch_worthwhile]
                     (const dash::coin::vendor::CQuorumRotationInfo& info) {
+                        // Rotated-quorum tee (DIP-24, type 5):
+                        // lastCommitmentPerIndex carries the FULL final
+                        // commitments per quorumIndex — same admission path
+                        // as every other transport, source-tagged for the
+                        // soak.
+                        for (const auto& c : info.lastCommitmentPerIndex)
+                            qc_ingest_from(c, "qrinfo",
+                                           qc_member_fetch_worthwhile(c));
                         qc_member_source->on_qrinfo(info);
                     });
             }
@@ -3230,40 +3338,33 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
 
             coin_feed_subs.push_back(
                 coin_state.new_qfcommit.subscribe(
-                    [qc_cache, qc_net, qc_member_source]
+                    [qc_ingest_from]
                     (const dash::coin::vendor::CFinalCommitment& c) {
-                        // SAY WHY on the reject path too. A relayed qfcommit
-                        // that structural admission drops used to leave NO
-                        // trace, so a later "no-commitment-cached" refusal was
-                        // indistinguishable from "the commitment never reached
-                        // us" — opposite diagnoses (our bug vs a relay hole).
-                        using Adm =
-                            dash::coin::MineableCommitmentCache::Admission;
-                        const auto adm = qc_cache->ingest_ex(qc_net, c);
-                        if (adm != Adm::Accepted) {
-                            LOG_INFO << "[QC-MINEABLE] REJECTED relayed"
-                                        " commitment type="
-                                     << static_cast<int>(c.llmqType)
-                                     << " quorum="
-                                     << c.quorumHash.GetHex().substr(0, 16)
-                                     << "... signers=" << c.CountSigners()
-                                     << " reason="
-                                     << dash::coin::MineableCommitmentCache
-                                            ::admission_name(adm)
-                                     << " cache=" << qc_cache->size();
-                        }
-                        if (adm == Adm::Accepted) {
-                            LOG_INFO << "[QC-MINEABLE] cached commitment type="
-                                     << static_cast<int>(c.llmqType)
-                                     << " quorum="
-                                     << c.quorumHash.GetHex().substr(0, 16)
-                                     << "... signers=" << c.CountSigners()
-                                     << " cache=" << qc_cache->size();
-                            // Proactively source the member set so it is READY by
-                            // the DKG-window height that must serve it.
-                            qc_member_source->request(c.llmqType, c.quorumHash);
-                        }
+                        // PUSH transport: relayed once at DKG finalize, so a
+                        // live arrival is inside (or just ahead of) an open
+                        // window by construction — kick the member fetch
+                        // unconditionally, exactly the pre-fix behaviour.
+                        qc_ingest_from(c, "qfcommit-push",
+                                       /*kick_member_fetch=*/true);
                     }));
+            // ── qc-plan-underivable CLOSURE: the request/response tee ──────
+            // mnlistdiff is the transport that measurably ALWAYS works
+            // (277/277 per soak on both hosts, including the one whose peers
+            // churn every 101 s) and is re-requested on every fresh
+            // handshake, so feeding the cache from it removes the
+            // be-connected-at-the-inv dependency the push-only feed had. The
+            // maintainer hands over tail.newQuorums of every ACCEPTED diff
+            // (its base-continuity / stale-snapshot R1 / malformed-tail H-1
+            // guards have already run); admission is the SAME ingest as the
+            // push path above, so verified_for's guarantees are
+            // transport-independent.
+            maintainer->set_on_new_quorum_commitments(
+                [qc_ingest_from, qc_member_fetch_worthwhile]
+                (const std::vector<dash::coin::vendor::CFinalCommitment>& qcs) {
+                    for (const auto& c : qcs)
+                        qc_ingest_from(c, "mnlistdiff",
+                                       qc_member_fetch_worthwhile(c));
+                });
             // COMPLETENESS GATE (definitive-soak block 1520106): the plan is
             // per-height all-or-nothing — any mandatory slot without a
             // BLS-verified real commitment (no attested-null evidence source

--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -490,6 +490,20 @@ public:
         const size_t q_deleted = qr.deleted;
         m_state.set_quorum_healthy(true);
 
+        // 2b) qc-plan-underivable tee: newQuorums are COMPLETE DIP-4
+        //     CFinalCommitments (pubkey, vvec hash, quorumSig, membersSig,
+        //     bitsets), not just (llmqType, quorumHash) existence — hand them
+        //     to the wired consumer (main_dash funnels them through the SAME
+        //     MineableCommitmentCache admission path the qfcommit push uses)
+        //     instead of dropping the crypto payload on the floor after the
+        //     has_mined bookkeeping above. Fired only for an ACCEPTED diff:
+        //     every reject/heal path (base-continuity, stale-snapshot R1,
+        //     malformed-tail H-1) returned before this point, so a consumer
+        //     never sees commitments off a diff whose SML apply was refused.
+        //     Optional (unset in KATs = no-op).
+        if (m_on_new_quorum_commitments && !qt.newQuorums.empty())
+            m_on_new_quorum_commitments(qt.newQuorums);
+
         // 3) bestCL* + creditPool: the diff's embedded cbTx is the coinbase of
         //    diff.blockHash and its extra_payload is the authoritative type-5
         //    CCbTx for that height. Seed the fields the roots don't carry so the
@@ -975,6 +989,20 @@ public:
         m_on_full_resync = std::move(fn);
     }
 
+    /// Wire the mnlistdiff QUORUM-COMMITMENT tee (qc-plan-underivable fix).
+    /// Invoked from on_mnlistdiff with `tail.newQuorums` of every ACCEPTED
+    /// diff — the full CFinalCommitments the wire already carries. main_dash
+    /// points this at the MineableCommitmentCache ingest (the SAME admission
+    /// path the coin-P2P qfcommit push subscription uses), which removes the
+    /// be-connected-at-the-inv transport dependency the push-only feed had:
+    /// mnlistdiff is request/response and re-requested on every fresh
+    /// handshake, so a commitment missed as a push is still sourced. Optional
+    /// (unset in KATs / non-embedded postures = no-op).
+    void set_on_new_quorum_commitments(
+        std::function<void(const std::vector<vendor::CFinalCommitment>&)> fn) {
+        m_on_new_quorum_commitments = std::move(fn);
+    }
+
     /// Wire the SML/quorum PERSISTENCE sink (main_dash points this at
     /// SMLDb::write_sml + QuorumDb::write_quorums). Invoked after each accepted
     /// mnlistdiff that leaves a non-empty SML applied, with the block hash the
@@ -1232,6 +1260,10 @@ private:
     std::function<void()> m_on_full_resync;  // H-1 heal -> reset sml_base + full re-sync
     std::function<void(const uint256&)> m_on_sml_persist;  // accepted diff -> SMLDb/QuorumDb write
     std::function<void()> m_on_sml_clear;    // reorg/heal -> SMLDb/QuorumDb wipe (extended to CreditPoolDb)
+    // qc-plan-underivable tee: accepted diff's full tail.newQuorums ->
+    // MineableCommitmentCache admission (see set_on_new_quorum_commitments).
+    std::function<void(const std::vector<vendor::CFinalCommitment>&)>
+        m_on_new_quorum_commitments;
     // E2: independent DIP-0027 credit-pool accrual, advanced per ingested block
     // (on_block_connected) and re-anchored per accepted mnlistdiff. Verified
     // against each block's own from-wire cbTx; persisted via the hook below.

--- a/test/test_dash_coin_state_maintainer.cpp
+++ b/test/test_dash_coin_state_maintainer.cpp
@@ -818,3 +818,334 @@ TEST(DashCoinStateMaintainer, SeedReconcileAppliesAlreadyPresentSmlBan) {
     EXPECT_FALSE(st.mnstates().find_expected_payee().has_value())
         << "a banned MN must never be projected as expected payee";
 }
+
+// ════════════════════════════════════════════════════════════════════════
+// qc-plan-underivable fix: the mnlistdiff → MineableCommitmentCache tee.
+//
+// Pre-fix, the cache was fed from EXACTLY one source — the coin-P2P qfcommit
+// push subscription — which requires being connected at the instant of the
+// inv (measured: a 14 s – 5 m 35 s arrival race after window-open, 7.5% of
+// wall-clock declined qc-plan-underivable on a healthy-peer host, total
+// cold-start starvation on a churning host). mnlistdiff replies carry the
+// COMPLETE CFinalCommitments in tail.newQuorums and the maintainer recorded
+// only (llmqType, quorumHash) existence, dropping the crypto payload. These
+// tests pin the tee: set_on_new_quorum_commitments hands every ACCEPTED
+// diff's newQuorums to the wired consumer, which (as main_dash wires it)
+// funnels them through the SAME ingest_ex admission path the push uses.
+// ════════════════════════════════════════════════════════════════════════
+
+using dash::coin::MineableCommitmentCache;
+using dash::coin::LlmqNetwork;
+using dash::coin::LlmqParamsView;
+using dash::coin::vendor::CFinalCommitment;
+
+namespace {
+
+// Deterministic per-height pseudo hash (mirrors the dkg_commitments KATs).
+std::optional<uint256> qc_fake_hash_at(uint32_t h)
+{
+    uint256 u;
+    std::memset(u.data(), 0xAB, 32);
+    std::memcpy(u.data(), &h, 4);
+    return u;
+}
+
+bool qc_never_mined(uint8_t, const uint256&) { return false; }
+
+// A structurally-admissible REAL commitment for params `p` (all signers set,
+// non-null crypto fields) — same shape the dkg_commitments KATs use.
+CFinalCommitment qc_real_commitment(const LlmqParamsView& p, const uint256& qh,
+                                    int16_t qi, uint8_t seed)
+{
+    CFinalCommitment c;
+    c.nVersion = p.use_rotation
+        ? CFinalCommitment::BASIC_BLS_INDEXED_QUORUM_VERSION
+        : CFinalCommitment::BASIC_BLS_NON_INDEXED_QUORUM_VERSION;
+    c.llmqType    = p.type;
+    c.quorumHash  = qh;
+    c.quorumIndex = qi;
+    c.signers.assign(p.size, true);
+    c.validMembers.assign(p.size, true);
+    c.quorumPublicKey.fill(seed);
+    uint256 vv; std::memset(vv.data(), seed, 32); c.quorumVvecHash = vv;
+    c.quorumSig.fill(seed);
+    c.membersSig.fill(seed);
+    return c;
+}
+
+// Serialize a quorum tail carrying only newQuorums (no deletions, no CL sigs)
+// in the exact wire shape parse_quorum_tail expects.
+std::vector<unsigned char> qc_tail_bytes(const std::vector<CFinalCommitment>& qcs)
+{
+    ::PackStream s;
+    WriteCompactSize(s, 0);                      // deletedQuorums
+    WriteCompactSize(s, qcs.size());             // newQuorums
+    for (const auto& c : qcs) s << c;
+    WriteCompactSize(s, 0);                      // quorumsCLSigs
+    auto sp = s.get_span();
+    return std::vector<unsigned char>(
+        reinterpret_cast<const unsigned char*>(sp.data()),
+        reinterpret_cast<const unsigned char*>(sp.data()) + sp.size());
+}
+
+} // namespace
+
+// THE headline: a commitment that arrives ONLY via mnlistdiff — ZERO qfcommit
+// push messages — must make verified_for serve it, i.e. the daemonless qc plan
+// becomes derivable over request/response alone. Verified to FAIL on pre-fix
+// master: set_on_new_quorum_commitments does not exist there (this TU does not
+// compile), and the behavioural core is impossible by construction — the only
+// production feed into MineableCommitmentCache was the push subscription
+// (main_dash.cpp new_qfcommit), so after on_mnlistdiff the cache is empty and
+// daemonless_qc_commitments returns nullopt = the qc-plan-underivable decline.
+TEST(DashCoinStateMaintainer, CommitmentOnlyViaMnlistdiffMakesQcPlanDerivable) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    MineableCommitmentCache cache;
+
+    // Wire the tee exactly as main_dash does: the SAME admission path
+    // (ingest_ex, testnet enabled-set) the qfcommit push subscription uses.
+    m.set_on_new_quorum_commitments(
+        [&cache](const std::vector<CFinalCommitment>& qcs) {
+            for (const auto& c : qcs)
+                cache.ingest_ex(LlmqNetwork::Testnet, c);
+        });
+
+    // 1900812 is phase 12 of the 24-cycle, above the testnet serve floor:
+    // the mandatory set is one slot each for types 1 / 4 / 6, all at the
+    // cycle base 1900800.
+    const uint32_t next_h = 1'900'812u;
+    const uint256  qh     = *qc_fake_hash_at(1'900'800u);
+    const std::vector<CFinalCommitment> qcs{
+        qc_real_commitment(dash::coin::kLlmq50_60,  qh, 0, 0x11),
+        qc_real_commitment(dash::coin::kLlmq100_67, qh, 0, 0x22),
+        qc_real_commitment(dash::coin::kLlmq25_67,  qh, 0, 0x33)};
+
+    CSimplifiedMNListDiff d = diff_with_seed(uint256::ZERO, raw256(0xA0),
+                                             1'900'811, 100'000'000LL,
+                                             sml_entry(0x40));
+    d.quorum_tail = qc_tail_bytes(qcs);
+    m.on_mnlistdiff(d);
+
+    // The cache holds all three commitments off the diff alone.
+    EXPECT_EQ(cache.size(), 3u);
+    EXPECT_TRUE(cache.has_commitment(1, qh));
+    EXPECT_TRUE(cache.has_commitment(4, qh));
+    EXPECT_TRUE(cache.has_commitment(6, qh));
+
+    // With the BLS hook passing (stub — the hook is the SAME seam the push
+    // path serves through), verified_for yields them and the plan for the
+    // window height is derivable. has_mined is deliberately `never`: this is
+    // the posture where the slots are still REQUIRED (pre-mine race /
+    // reorg-wiped QuorumManager), i.e. exactly when the cache must serve.
+    cache.set_bls_verify_fn([](const CFinalCommitment&) { return true; });
+    auto plan = dash::coin::daemonless_qc_commitments(
+        LlmqNetwork::Testnet, next_h, qc_fake_hash_at, qc_never_mined, &cache);
+    ASSERT_TRUE(plan.has_value())
+        << "commitments sourced ONLY via mnlistdiff must derive the qc plan";
+    ASSERT_EQ(plan->size(), 3u);
+    for (const auto& c : *plan)
+        EXPECT_GT(c.CountSigners(), 0) << "a REAL commitment must be served, not null";
+}
+
+// The tee fires ONLY for an ACCEPTED diff: every reject/heal path
+// (base-continuity, stale-ZERO-base R1, malformed-tail H-1) must not hand
+// commitments to the consumer — a refused diff's payload is untrusted.
+TEST(DashCoinStateMaintainer, QuorumCommitmentTeeFiresOnlyForAcceptedDiffs) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    size_t batches = 0, commitments = 0;
+    m.set_on_new_quorum_commitments(
+        [&](const std::vector<CFinalCommitment>& qcs) {
+            ++batches;
+            commitments += qcs.size();
+        });
+
+    const uint256 qh = *qc_fake_hash_at(1'900'800u);
+
+    // 1) Accepted cold full snapshot → tee fires once with one commitment.
+    CSimplifiedMNListDiff d1 = diff_with_seed(uint256::ZERO, raw256(0xA0),
+                                              1'900'811, 100'000'000LL,
+                                              sml_entry(0x40));
+    d1.quorum_tail = qc_tail_bytes({qc_real_commitment(dash::coin::kLlmq50_60,
+                                                       qh, 0, 0x11)});
+    m.on_mnlistdiff(d1);
+    EXPECT_EQ(batches, 1u);
+    EXPECT_EQ(commitments, 1u);
+
+    // 2) Base-continuity reject (base != SML-current) → NO tee.
+    CSimplifiedMNListDiff bad = diff_with_seed(raw256(0xB0), raw256(0xC0),
+                                               1'900'812, 100'000'001LL,
+                                               sml_entry(0x41));
+    bad.quorum_tail = qc_tail_bytes({qc_real_commitment(dash::coin::kLlmq100_67,
+                                                        qh, 0, 0x22)});
+    m.on_mnlistdiff(bad);
+    EXPECT_EQ(batches, 1u) << "a base-continuity-rejected diff must not tee";
+
+    // 3) Stale ZERO-base snapshot (R1: cb height <= current) → NO tee.
+    CSimplifiedMNListDiff stale = diff_with_seed(uint256::ZERO, raw256(0xD0),
+                                                 1'900'810, 100'000'002LL,
+                                                 sml_entry(0x42));
+    stale.quorum_tail = qc_tail_bytes({qc_real_commitment(dash::coin::kLlmq25_67,
+                                                          qh, 0, 0x33)});
+    m.on_mnlistdiff(stale);
+    EXPECT_EQ(batches, 1u) << "a stale-snapshot-rejected diff must not tee";
+
+    // 4) Malformed tail (H-1 heal path) → NO tee.
+    CSimplifiedMNListDiff mal = diff_with_seed(raw256(0xA0), raw256(0xE0),
+                                               1'900'812, 100'000'003LL,
+                                               sml_entry(0x43));
+    mal.quorum_tail = {0x01};   // deletedQuorums count=1 with no body
+    m.on_mnlistdiff(mal);
+    EXPECT_EQ(batches, 1u) << "a malformed-tail diff must not tee";
+    EXPECT_EQ(commitments, 1u);
+}
+
+// A tampered commitment arriving via mnlistdiff must be rejected EXACTLY as
+// the same commitment arriving as a qfcommit push — same admission verdicts,
+// nothing cached; and a structurally-admissible copy whose BLS signature the
+// verifier refuses is withheld by verified_for regardless of transport.
+TEST(DashCoinStateMaintainer, TamperedCommitmentViaMnlistdiffRejectedAsPush) {
+    using Adm = MineableCommitmentCache::Admission;
+    const uint256 qh = *qc_fake_hash_at(1'900'800u);
+
+    // Tampered shapes: >=threshold-but-<minSize signers (the block-losing
+    // colluding shape) and null crypto fields.
+    auto below_min = qc_real_commitment(dash::coin::kLlmq50_60, qh, 0, 0x11);
+    below_min.signers.assign(50, false);
+    for (int i = 0; i < 35; ++i) below_min.signers[static_cast<size_t>(i)] = true;
+    auto null_crypto = qc_real_commitment(dash::coin::kLlmq50_60, qh, 0, 0x11);
+    null_crypto.quorumSig.fill(0);
+    auto good = qc_real_commitment(dash::coin::kLlmq50_60, qh, 0, 0x11);
+
+    // Push-path verdicts (the reference: direct ingest_ex, as the qfcommit
+    // subscription calls it).
+    MineableCommitmentCache push_cache;
+    const auto push_v1 = push_cache.ingest_ex(LlmqNetwork::Testnet, below_min);
+    const auto push_v2 = push_cache.ingest_ex(LlmqNetwork::Testnet, null_crypto);
+    EXPECT_EQ(push_v1, Adm::SignersBelowMin);
+    EXPECT_EQ(push_v2, Adm::NullCryptoFields);
+    EXPECT_EQ(push_cache.size(), 0u);
+
+    // mnlistdiff-path verdicts through the tee: MUST be identical.
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    MineableCommitmentCache cache;
+    std::vector<Adm> seen;
+    m.set_on_new_quorum_commitments(
+        [&](const std::vector<CFinalCommitment>& qcs) {
+            for (const auto& c : qcs)
+                seen.push_back(cache.ingest_ex(LlmqNetwork::Testnet, c));
+        });
+    CSimplifiedMNListDiff d = diff_with_seed(uint256::ZERO, raw256(0xA0),
+                                             1'900'811, 100'000'000LL,
+                                             sml_entry(0x40));
+    d.quorum_tail = qc_tail_bytes({below_min, null_crypto, good});
+    m.on_mnlistdiff(d);
+
+    ASSERT_EQ(seen.size(), 3u);
+    EXPECT_EQ(seen[0], push_v1) << "mnlistdiff admission must equal push admission";
+    EXPECT_EQ(seen[1], push_v2) << "mnlistdiff admission must equal push admission";
+    EXPECT_EQ(seen[2], Adm::Accepted);
+    EXPECT_EQ(cache.size(), 1u) << "only the untampered commitment may be cached";
+
+    // BLS-invalid (structurally fine, wrong signature): the SAME verifier
+    // hook gates both transports — verified_for withholds it.
+    cache.set_bls_verify_fn(
+        [](const CFinalCommitment& c) { return c.quorumSig[0] == 0x11; });
+    ASSERT_TRUE(cache.verified_for(1, qh).has_value());
+    const uint256 qh2 = *qc_fake_hash_at(1'900'776u);   // previous cycle base
+    auto sig_bad = qc_real_commitment(dash::coin::kLlmq50_60, qh2, 0, 0x99);
+    CSimplifiedMNListDiff d2 = diff_with_seed(raw256(0xA0), raw256(0xB0),
+                                              1'900'812, 100'000'001LL,
+                                              sml_entry(0x41));
+    d2.quorum_tail = qc_tail_bytes({sig_bad});
+    m.on_mnlistdiff(d2);
+    EXPECT_TRUE(cache.has_commitment(1, qh2))
+        << "structural admission cannot detect a bad signature";
+    EXPECT_FALSE(cache.verified_for(1, qh2).has_value())
+        << "a BLS-refused commitment must be withheld whatever its transport";
+}
+
+// Duplicate arrival across transports — push then mnlistdiff AND mnlistdiff
+// then push — is a no-op: keep-best-by-CountSigners holds the first copy, the
+// cache never grows, and a weaker (fewer-signers) later copy NEVER downgrades
+// a served entry.
+TEST(DashCoinStateMaintainer, DuplicateAcrossTransportsIsNoOpNeverDowngrades) {
+    using Adm = MineableCommitmentCache::Admission;
+    const uint256 qh = *qc_fake_hash_at(1'900'800u);
+    auto good = qc_real_commitment(dash::coin::kLlmq50_60, qh, 0, 0x11);
+
+    // ── push first, mnlistdiff second ────────────────────────────────────
+    {
+        NodeCoinState st;
+        CoinStateMaintainer m(st);
+        MineableCommitmentCache cache;
+        std::vector<Adm> seen;
+        m.set_on_new_quorum_commitments(
+            [&](const std::vector<CFinalCommitment>& qcs) {
+                for (const auto& c : qcs)
+                    seen.push_back(cache.ingest_ex(LlmqNetwork::Testnet, c));
+            });
+        ASSERT_EQ(cache.ingest_ex(LlmqNetwork::Testnet, good), Adm::Accepted);
+
+        CSimplifiedMNListDiff d = diff_with_seed(uint256::ZERO, raw256(0xA0),
+                                                 1'900'811, 100'000'000LL,
+                                                 sml_entry(0x40));
+        d.quorum_tail = qc_tail_bytes({good});
+        m.on_mnlistdiff(d);
+        ASSERT_EQ(seen.size(), 1u);
+        EXPECT_EQ(seen[0], Adm::NotBetterThanCached) << "duplicate must be a no-op";
+        EXPECT_EQ(cache.size(), 1u);
+
+        cache.set_bls_verify_fn([](const CFinalCommitment&) { return true; });
+        auto served = cache.verified_for(1, qh);
+        ASSERT_TRUE(served.has_value());
+        EXPECT_EQ(served->CountSigners(), 50);
+
+        // A WEAKER copy (45 of 50 signers, still >= minSize 40) arriving on a
+        // later incremental must not replace the held 50-signer copy.
+        auto weaker = good;
+        weaker.signers.assign(50, false);
+        for (int i = 0; i < 45; ++i) weaker.signers[static_cast<size_t>(i)] = true;
+        CSimplifiedMNListDiff d2 = diff_with_seed(raw256(0xA0), raw256(0xB0),
+                                                  1'900'812, 100'000'001LL,
+                                                  sml_entry(0x41));
+        d2.quorum_tail = qc_tail_bytes({weaker});
+        m.on_mnlistdiff(d2);
+        ASSERT_EQ(seen.size(), 2u);
+        EXPECT_EQ(seen[1], Adm::NotBetterThanCached);
+        auto still = cache.verified_for(1, qh);
+        ASSERT_TRUE(still.has_value());
+        EXPECT_EQ(still->CountSigners(), 50) << "a verified entry must never downgrade";
+    }
+
+    // ── mnlistdiff first, push second ────────────────────────────────────
+    {
+        NodeCoinState st;
+        CoinStateMaintainer m(st);
+        MineableCommitmentCache cache;
+        std::vector<Adm> seen;
+        m.set_on_new_quorum_commitments(
+            [&](const std::vector<CFinalCommitment>& qcs) {
+                for (const auto& c : qcs)
+                    seen.push_back(cache.ingest_ex(LlmqNetwork::Testnet, c));
+            });
+        CSimplifiedMNListDiff d = diff_with_seed(uint256::ZERO, raw256(0xA0),
+                                                 1'900'811, 100'000'000LL,
+                                                 sml_entry(0x40));
+        d.quorum_tail = qc_tail_bytes({good});
+        m.on_mnlistdiff(d);
+        ASSERT_EQ(seen.size(), 1u);
+        EXPECT_EQ(seen[0], Adm::Accepted);
+
+        // The SAME commitment now arrives as a push: no-op, no growth.
+        EXPECT_EQ(cache.ingest_ex(LlmqNetwork::Testnet, good),
+                  Adm::NotBetterThanCached);
+        EXPECT_EQ(cache.size(), 1u);
+        cache.set_bls_verify_fn([](const CFinalCommitment&) { return true; });
+        auto served = cache.verified_for(1, qh);
+        ASSERT_TRUE(served.has_value());
+        EXPECT_EQ(served->CountSigners(), 50);
+    }
+}


### PR DESCRIPTION
## What

Closes the `qc-plan-underivable` decline cause on the DASH daemonless embedded arm by feeding the `MineableCommitmentCache` from **request/response transports** in addition to the p2p push:

1. **`CoinStateMaintainer::set_on_new_quorum_commitments`** (new seam): `on_mnlistdiff` hands `tail.newQuorums` — the COMPLETE DIP-4 `CFinalCommitment`s (pubkey, vvec hash, quorumSig, membersSig, bitsets) — to the wired consumer for every **accepted** diff. All existing guards (base-continuity, stale-ZERO-base R1, malformed-tail H-1) run first; a refused diff never tees.
2. **`main_dash`: ONE admission path for every transport.** A single `qc_ingest_from(commitment, source, kick_member_fetch)` helper wraps `ingest_ex` — identical structural checks and the same BLS verification hook (`verified_for` = structurally admitted + BLS-verified + quorumIndex match) regardless of arrival shape. Wired to:
   - the existing `qfcommit` push subscription (`source=qfcommit-push`, unchanged behaviour),
   - the mnlistdiff tee (`source=mnlistdiff`),
   - the already-decoded `qrinfo.lastCommitmentPerIndex` (rotated type-5 commitments, `source=qrinfo`), teed inside the existing qrinfo consumer in `main_dash` — `quorum_member_source.hpp` is untouched.
3. **Every ingest logs its transport** in the `[QC-MINEABLE]` line (`cached` / `duplicate` / `REJECTED ... reason=`), so a soak can prove which transport actually supplied each commitment. Cross-transport duplicates are named `duplicate` (expected no-op), not `REJECTED`.
4. **Member-set fetch amplification guard**: batch transports (mnlistdiff/qrinfo) kick the proactive `QuorumMemberSource::request` only for commitments whose DKG mining window is still open at the header tip. A cold full snapshot re-carries every active quorum (~100-200 on mainnet); fetching member sets for all of them would fan out megabytes of historical `getmnlistd` traffic for slots that can never be required again. Ingest itself is unconditional. Push keeps the unconditional fetch (pre-fix behaviour).

## Why (MEASURED)

- The cache was fed from exactly ONE source: the `qfcommit` push subscription. Push requires being connected at the instant of the inv — measured cost: **7.5% of wall-clock declined `qc-plan-underivable`** on a healthy-peer host (arrival race of 14 s – 5 m 35 s after window-open), and **100% cold-start starvation** on a host whose peers churn every 101 s.
- mnlistdiff succeeds **277/277 per soak on BOTH hosts** and is re-requested on every fresh handshake — it has no be-connected-at-the-inv dependency.
- `dkg_commitments.hpp` already documented that `mnlistdiff.newQuorums` and `qrinfo.lastCommitmentPerIndex` carry commitments; they were decoded and dropped after existence bookkeeping (`quorum_manager.hpp` records only `(llmqType, quorumHash)`).

## Projected effect (INFERRED — honestly stated)

This makes the qc plan derivable via request/response: it closes the 7.5% arrival race on healthy hosts AND the cold-start starvation on churning hosts, because mnlistdiff is re-requested on every fresh handshake. Together with the in-flight clsig acquisition PR this is the second of the two remaining measured decline causes.

**PROOF is a soak** whose `[QC-MINEABLE]` lines show `source=mnlistdiff` supplying commitments and whose `qc-plan-underivable` wall-clock share drops from 7.5% toward zero — **that has not happened yet**. One caveat stated plainly: per the vendored COLD-START analysis (`dkg_commitments.hpp`), a commitment appears in `mnlistdiff.newQuorums` once it is MINED; for a mined slot `has_mined` already suppresses the requirement at that tip, so the tee's measured wins are the timing/asymmetry cases (diff-lead-over-push around the mined tip, reorg-wiped `QuorumManager` with a retained cache, rotated `qrinfo` sourcing) — exactly what the soak's `source=` attribution will confirm or refute.

## Tests (all in the existing allowlisted `test_dash_coin_state_maintainer` target; none BLS-gated — stub verifiers)

- `CommitmentOnlyViaMnlistdiffMakesQcPlanDerivable` — a commitment arriving with ZERO push messages makes `verified_for` serve it and `daemonless_qc_commitments` derive the plan. **Verified to fail on pre-fix master**: `git grep set_on_new_quorum_commitments` → 0 hits; a compile probe against master errors `'class dash::coin::CoinStateMaintainer' has no member named 'set_on_new_quorum_commitments'`; the only production `ingest_ex` call site on master is the push subscription (`main_dash.cpp:3242`), so the behavioural core (cache non-empty after `on_mnlistdiff` alone) is impossible by construction there.
- `QuorumCommitmentTeeFiresOnlyForAcceptedDiffs` — base-continuity / stale-R1 / malformed-H-1 rejects never tee.
- `TamperedCommitmentViaMnlistdiffRejectedAsPush` — identical `Admission` verdicts per transport for tampered shapes (`SignersBelowMin`, `NullCryptoFields`); a BLS-refused commitment is withheld by `verified_for` whatever its transport.
- `DuplicateAcrossTransportsIsNoOpNeverDowngrades` — push→mnlistdiff and mnlistdiff→push both `NotBetterThanCached`; a weaker (fewer-signers) later copy never downgrades a served entry.

`python3 tools/ci/check_test_target_allowlist.py` → OK (228 targets, no new targets added; no BLS-gated cases added).

## Follow-up (NOT in this PR)

- `qrinfo.lastCommitmentPerIndex` was already decoded, so it IS teed here. No new decode was built.
- `MineableCommitmentCache` has no pruning; it grows at quorum-formation rate under the push feed today and this PR does not change that rate class (duplicates are no-ops). Bounding it is a separate concern.

## Scope

DASH lane only: `src/impl/dash/coin/coin_state_maintainer.hpp`, `src/c2pool/main_dash.cpp`, `test/test_dash_coin_state_maintainer.cpp`. `quorum_member_source.hpp` untouched.
