### PR TITLE
dash: correct stale null-serve comments on the DKG-window serve path (+ stale-invariant audit)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -2912,10 +2912,13 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             //      threshold itself reseeds from the weighted VALID SML count
             //      on every diff (reseed_funding_threshold — dashcore's own
             //      tally/denominator asymmetry).
-            //   3. the R5 govsync-completeness gate
-            //      (set_superblock_sync_complete_fn) is STILL NOT wired — the
-            //      NodeCoinState guard refuses the serve path structurally,
-            //      so R3 landing here can never by itself open it.
+            //   3. the R5 govsync-completeness gate IS wired
+            //      (set_superblock_sync_complete_fn, below), so the guard is no
+            //      longer a structural refusal: it is a RUNTIME predicate over
+            //      GovernanceMaintainer::gov_sync_complete() (>= min peers,
+            //      settled, quiesced). It still closes on its own whenever
+            //      govsync has not completed, and R3 landing here does not by
+            //      itself open it.
             // The parse/selection/template-emit logic is proven by the KATs;
             // flipping this fully live is still gated on R5 completeness + the
             // R6 desync latch + a funded-superblock soak.
@@ -3098,15 +3101,17 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         // are SERVED instead of refused: the mandatory type-6 commitment set is
         // derived from local state only — params-table math + quorum base
         // hashes off the embedded header chain + the mnlistdiff-fed
-        // QuorumManager as dashd's HasMinedCommitment — and filled with the
-        // consensus-valid NULL commitments dashd's own miner mines when it
-        // holds no verified DKG result (real relayed commitments are Phase L,
-        // behind a BLS verifier). merkleRootQuorums stays the PROVEN
-        // active-set root (null commitments never fold in). Any height where
-        // the set cannot be derived (header gap, below the per-network V19
-        // serve floor — which also covers --regtest chains riding the testnet
-        // flag) yields nullopt and the arm fails closed to the dashd fallback,
-        // exactly the old refusal. The emit gate re-derives this same plan and
+        // QuorumManager as dashd's HasMinedCommitment — and every mandatory
+        // slot must carry a BLS-VERIFIED REAL commitment. Serving is PER-HEIGHT
+        // ALL-OR-NOTHING: one unsatisfiable slot fails the WHOLE height closed
+        // to the dashd fallback. Null commitments are NOT mined to fill the
+        // shortfall (that arm is dashd's, and copying it diverged
+        // merkleRootQuorums at block 1520106 — see dkg_commitments.hpp HEIGHT
+        // COMPLETENESS). merkleRootQuorums stays the PROVEN active-set root.
+        // The same nullopt/fail-closed result covers a set that cannot be
+        // derived at all (header gap, below the per-network V19 serve floor —
+        // which also covers --regtest chains riding the testnet flag), exactly
+        // the old refusal. The emit gate re-derives this same plan and
         // hard-rejects any template whose type-6 set drifts from it.
         if (run_arm.embedded_arm_enabled) {
             const auto qc_net = testnet ? dash::coin::LlmqNetwork::Testnet
@@ -3114,11 +3119,28 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             // Phase-L sourcing leg: collect REAL relayed DKG commitments off
             // the coin-P2P qfcommit stream (structural admission only). The
             // cache serves NOTHING into templates until a BLS12-381 verifier
-            // is installed (MineableCommitmentCache::set_bls_verify_fn — the
-            // exact Phase-L follow-up); until then every required slot mines
-            // the consensus-valid null commitment, same as dashd without a
-            // DKG result. [QC-MINEABLE] is the field-checkable signal that
-            // the sourcing leg is live.
+            // is installed (MineableCommitmentCache::set_bls_verify_fn — done
+            // by the VERIFY leg below, and inert unless the build actually
+            // links dashbls).
+            //
+            // A required slot with no verified commitment is NOT null-served.
+            // dashd's miner does mine the null commitment there
+            // (GetMineableCommitments, "null commitment required" arm); c2pool
+            // deliberately does not copy it, because a null is only CANONICAL
+            // when that DKG genuinely failed: at block 1520106 null-serving a
+            // SUCCEEDED DKG skipped leaves every dashd folds in and diverged
+            // merkleRootQuorums (bad-cbtx). So the slot is unsatisfiable and
+            // the WHOLE height fails closed to the dashd fallback, NAMED
+            // cause=qc-plan-underivable. The refusal is BOUNDED: it ends when
+            // any other miner mines the commitment (the slot then reads
+            // already-mined off the mnlistdiff-fed QuorumManager) or when the
+            // DKG mining window closes — both by cycleStart +
+            // dkgMiningWindowEnd. Full reasoning: dkg_commitments.hpp, HEIGHT
+            // COMPLETENESS + COLD-START HOLE. Null is served ONLY on positive
+            // failed-DKG evidence (DkgNullEvidenceFn), and production passes
+            // no such source — see /*null_evidence=*/nullptr at the
+            // build_daemonless_qc_plan call below. [QC-MINEABLE] is the
+            // field-checkable signal that the sourcing leg is live.
             auto qc_cache =
                 std::make_shared<dash::coin::MineableCommitmentCache>();
 
@@ -3129,8 +3151,9 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             // quorumPublicKey, both over BuildCommitmentHash). The verifier
             // sources the ordered member operator key set via the provider
             // below; anything it cannot establish with certainty fails CLOSED
-            // (verified_for -> nullopt -> the slot mines the consensus-valid
-            // null commitment, exactly the pre-Phase-L posture — reward-safe).
+            // (verified_for -> nullopt -> the slot is unsatisfiable -> the
+            // whole height falls back to dashd, exactly the pre-Phase-L
+            // posture — reward-safe; the slot is NOT null-served).
             //
             // MEMBER-SET SOURCING (E1 Phase-L, the piece that ENABLES real-
             // commitment serving): the deterministic quorum member selection
@@ -3182,8 +3205,11 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
 
             // DIP-24 rotated lane: the getqrinfo send seam + the qrinfo reply
             // consumer. Both are OPTIONAL by construction — with neither wired
-            // the rotated branch of request() simply cannot send and every
-            // rotated quorum stays null-serve, which is the pre-item-4 posture.
+            // the rotated branch of request() simply cannot send, so no rotated
+            // member set is ever sourced and every rotated slot stays
+            // unsatisfiable: any height whose mandatory set contains one fails
+            // closed to the dashd fallback (NOT null-served — dkg_commitments.hpp
+            // HEIGHT COMPLETENESS). That is the pre-item-4 posture.
             if (coin_p2p) {
                 qc_member_source->set_send_getqrinfo(
                     [cp = coin_p2p.get()](const std::vector<uint256>& bases,
@@ -4689,7 +4715,8 @@ int main(int argc, char** argv)
 
     // Name the BLS backend unconditionally at startup: a stub (BLS-dark) node
     // is otherwise indistinguishable from an armed one until a DKG-window
-    // height silently null-serves -- which is how this fleet ran BLS-dark for
+    // height silently fails closed to the dashd fallback (no verifier => no
+    // slot can ever be satisfied) -- which is how this fleet ran BLS-dark for
     // months without anyone noticing.
     std::cout << "[init] DASH BLS backend: "
               << (dash::coin::vendor::bls_backend_available()

--- a/src/impl/dash/coin/vendor/bls_verify.hpp
+++ b/src/impl/dash/coin/vendor/bls_verify.hpp
@@ -5,12 +5,14 @@
 /// commitments, reusing Dash Core's own verify logic + BLS backend.
 ///
 /// This is the piece the MineableCommitmentCache::set_bls_verify_fn seam
-/// (dkg_commitments.hpp) was cut for. Without it every DKG-window slot mines
-/// the consensus-valid NULL commitment (dashd's own behaviour when it holds no
-/// verified DKG result); with it, a peer-relayed commitment that PASSES
-/// dashcore's CFinalCommitment::Verify may be INCLUDED in the template, so a
-/// mainnet DKG-window block carries the same REAL commitment dashd's block
-/// carries (null-serve would diverge → bad-qc reject on a successful DKG).
+/// (dkg_commitments.hpp) was cut for. Without it no DKG-window slot can ever
+/// be satisfied, so every DKG-window height fails closed to the dashd fallback
+/// — c2pool does NOT take dashd's "mine the null commitment" arm (null-serving
+/// a SUCCEEDED DKG diverged merkleRootQuorums at block 1520106; see
+/// dkg_commitments.hpp HEIGHT COMPLETENESS). With it, a peer-relayed commitment
+/// that PASSES dashcore's CFinalCommitment::Verify may be INCLUDED in the
+/// template, so a mainnet DKG-window block carries the same REAL commitment
+/// dashd's block carries.
 ///
 /// REUSE-FIRST (operator mandate — vendor Dash Core, do not hand-roll):
 ///
@@ -76,7 +78,8 @@ uint256 build_commitment_hash(uint8_t llmq_type, const uint256& quorum_hash,
 /// True iff the dashbls backend is compiled in (C2POOL_DASH_BLS). When false,
 /// verify_final_commitment / the produced verifier fn always return false and
 /// the serve path fails closed — a build without BLS keeps the pre-Phase-L
-/// null-serve posture exactly.
+/// posture exactly: every DKG-window height refuses and falls back to dashd
+/// (it does NOT null-serve).
 bool bls_backend_available();
 
 /// Verify one commitment's crypto EXACTLY as dashcore CFinalCommitment::Verify

--- a/src/impl/dash/coin/vendor/quorum_members.hpp
+++ b/src/impl/dash/coin/vendor/quorum_members.hpp
@@ -108,9 +108,11 @@ inline constexpr uint8_t kLlmqTypePlatformTestnet = 6;   // LLMQ_25_67
 
 // V20 activation floor (chainparams.cpp DEPLOYMENT_V20 nActivationHeight).
 // This module ONLY serves member sets for quorums whose WORK block is post-V20
-// (the modifier era it reproduces). Below it -> std::nullopt -> null-serve
-// (reward-safe: the DKG-window slot mines the consensus-valid null commitment,
-// or the arm falls back to dashd). RE-DIFF on a vendored-dashcore pin bump.
+// (the modifier era it reproduces). Below it -> std::nullopt -> the member set
+// is unsourced, so the slot cannot be satisfied and the whole DKG-window height
+// falls back to dashd (reward-safe; the slot is NOT null-served — see
+// dkg_commitments.hpp HEIGHT COMPLETENESS). RE-DIFF on a vendored-dashcore pin
+// bump.
 inline constexpr uint32_t kV20FloorMainnet = 1'987'776u;
 inline constexpr uint32_t kV20FloorTestnet =   905'100u;
 


### PR DESCRIPTION
## What this is

A stale-invariant comment on the DASH DKG-window serve path asserted the exact opposite of what the code does, on the money path. This corrects it and five siblings of the same false claim, plus one unrelated stale "not wired" claim. **Comments only — the diff contains zero non-comment lines** (verified: `git diff -U0 | grep -vE '^[+-][[:space:]]*(//|///)'` is empty).

## The defect (MEASURED)

`src/c2pool/main_dash.cpp` carried, on the `MineableCommitmentCache` construction:

> The cache serves NOTHING into templates until a BLS12-381 verifier is installed ...; **until then every required slot mines the consensus-valid null commitment, same as dashd without a DKG result.**

That arm is not taken and must not be. 220 lines below, the production `build_daemonless_qc_plan` call passes `/*null_evidence=*/nullptr` (`main_dash.cpp:3342` pre-change). In `daemonless_qc_commitments` (`dkg_commitments.hpp:713-724`) the null arm is guarded by `if (null_evidence && null_evidence(...))`; with a null fn the function falls through to `return std::nullopt` — the slot is unsatisfiable and the **whole height** fails closed to the dashd fallback, named `cause=qc-plan-underivable` (`node_coin_state.hpp:690`).

The authoritative reasoning is already vendored at `dkg_commitments.hpp` HEIGHT COMPLETENESS / COLD-START HOLE: at block **1520106** (first height of the rotated LLMQ_60_75 window) all 32 mandatory rotated slots null-served while dashd mined 29 REAL rotated commitments; the served root was byte-identical to 1520105's and diverged `merkleRootQuorums` = bad-cbtx. The refusal is correct and stays.

So the comment described behaviour that was tried, diverged consensus at a real mainnet height, and was removed. A reader trusting it models the arm as null-serving when it in fact fails closed — and could "restore" the arm believing it an oversight.

## Task 1 — the comment now states

- required slots are **not** null-served; the height fails closed to dashd
- null-serving a SUCCEEDED DKG diverged `merkleRootQuorums` at block 1520106
- the refusal is correct, is **NAMED** (`cause=qc-plan-underivable`), and is **BOUNDED** — it ends when another miner mines the commitment (the slot then reads already-mined off the mnlistdiff-fed QuorumManager) or when the DKG mining window closes, both by `cycleStart + dkgMiningWindowEnd`
- it points at `dkg_commitments.hpp` (HEIGHT COMPLETENESS + COLD-START HOLE) so the full reasoning is one hop away
- it names `/*null_evidence=*/nullptr` at the call site below, so the contradiction cannot silently re-open

## Task 2 — audit of the same defect class

### Fixed here — same false claim, same path (all MEASURED, all DANGEROUS)

| file:line (pre-change) | comment claimed | code actually does |
|---|---|---|
| `src/c2pool/main_dash.cpp:3100-3102` | the derived type-6 set is "filled with the consensus-valid NULL commitments dashd's own miner mines when it holds no verified DKG result" | never filled; unsatisfiable slot ⇒ `nullopt` ⇒ whole height falls back |
| `src/c2pool/main_dash.cpp:3117-3120` | (the primary defect above) | as above |
| `src/c2pool/main_dash.cpp:3132-3133` | verifier failure ⇒ "the slot mines the consensus-valid null commitment, exactly the pre-Phase-L posture" | `verified_for -> nullopt` ⇒ slot unsatisfiable ⇒ height falls back. The pre-Phase-L posture was refusal, not null-serve |
| `src/c2pool/main_dash.cpp:3186` | with the qrinfo seam unwired "every rotated quorum stays null-serve, which is the pre-item-4 posture" | unsourced rotated slot ⇒ any height whose mandatory set contains one fails closed |
| `src/c2pool/main_dash.cpp:4692` | a BLS-dark node is invisible "until a DKG-window height silently null-serves" | a BLS-dark node satisfies no slot at all, so it silently *fails closed*. The `[init]` string two lines below already says `STUB (fail-closed; ...)` — the comment contradicts its own code |
| `src/impl/dash/coin/vendor/bls_verify.hpp:8-10` | without the verifier "every DKG-window slot mines the consensus-valid NULL commitment (dashd's own behaviour ...)" | no slot can be satisfied; every DKG-window height falls back |
| `src/impl/dash/coin/vendor/bls_verify.hpp:78-79` | a build without BLS "keeps the pre-Phase-L null-serve posture exactly" | keeps the pre-Phase-L *refusal* posture |
| `src/impl/dash/coin/vendor/quorum_members.hpp:110-111` | below the V20 floor ⇒ "null-serve (reward-safe: the DKG-window slot mines the consensus-valid null commitment ...)" | member set unsourced ⇒ slot unsatisfiable ⇒ height falls back |

Also fixed, different class, same hazard shape:

| file:line | comment claimed | code actually does | verdict |
|---|---|---|---|
| `src/c2pool/main_dash.cpp:2915-2918` | "the R5 govsync-completeness gate (`set_superblock_sync_complete_fn`) is **STILL NOT wired** — the NodeCoinState guard refuses the serve path **structurally**" | `node_coin_state.set_superblock_sync_complete_fn(...)` is called **unconditionally** 47 lines below (`main_dash.cpp:2965`, plain block scope, not behind `embedded_superblock`), and the reconciled log at `:3046` prints `BOTH gates WIRED`. The guard is now a *runtime* predicate over `gov_sync_complete()`, not a structural refusal | DANGEROUS — a reader planning superblock work would mis-model the safety posture as unconditional |

### NOT fixed — reported for review

**1. DANGEROUS — functional gap, not a comment bug. `qrinfo` is never dispatched, so the whole DIP-24 rotated member-source lane is dead code.** (MEASURED)
`message_qrinfo` / `message_getqrinfo` are defined (`src/impl/dash/coin/p2p_messages.hpp:237,258`) but neither appears in the `using Handler = MessageHandler<...>` list (`p2p_messages.hpp:378-410`, which ends `message_govobj, message_govobjvote, message_govsync`). `core/message.hpp:81-84` throws `out_of_range` for an unlisted command; `p2p_client.hpp:721-727` catches it and logs `ignoring unhandled command` at `LOG_DEBUG_COIND`. Therefore `ADD_P2P_HANDLER(qrinfo)` (`p2p_client.hpp:1145`) and its consumer fan-out (`:1166`) are unreachable, and the consumer registered at `main_dash.cpp:3195-3199` never fires. The **send** side works, so `getqrinfo` goes out and the reply is silently discarded.
Stale comments downstream of this: `quorum_member_source.hpp:61` ("ROTATED (DIP-24) — **NOW SERVED**, one qrinfo per CYCLE fills 32 slots"), `:237-238` ("`on_qrinfo()` ends by inserting all signingActiveQuorumCount member sets into m_ready, so lookup() **serves rotated commitments for real**"), `main_dash.cpp:3152-3156`, and `p2p_client.hpp:378-381` ("no registered consumer means a received qrinfo is **logged and dropped**" — it is not logged at that site at all).
Not touched here because the correct fix is registering the handler (a behaviour change), not rewriting the comments to describe a dead lane.

**2. DANGEROUS — operator-visible log string asserts the removed arm.** (MEASURED)
`src/c2pool/main_dash.cpp:3213` (now `:3233`):
```
LOG_INFO << "[QC-PHASE-L] dashbls verifier + member-set sourcing installed "
            "(real qc inclusion when the member set is sourced; "
            "fail-closed to null-serve otherwise)";
```
`fail-closed to null-serve` is a contradiction in terms and tells the operator the node null-serves. Left alone because editing a log string changes program output; suggested replacement: `fail-closed to the dashd fallback otherwise`.

**3. Merely stale — `null-serve` used as a synonym for "fail closed" throughout `quorum_member_source.hpp`.** (MEASURED)
Comments at `:39` ("FAIL CLOSED (null-serve)"), `:645`, `:666`; log strings at `:455`, `:478`, `:591`, `:631`. Each pairs the term with "fail closed", so a reader gets the right model, but the vocabulary is the same trap. Four of the seven are log strings. Recommend a single terminology sweep rather than piecemeal edits; not guessed at here.

**4. Merely stale — dead callback documented as wired.** (MEASURED)
`src/impl/dash/node.hpp:132-133`: "Callback fired when a bestblock message is received from a peer; **wired by the work layer (slice .4)** to trigger a work refresh." `set_on_bestblock` (`node.hpp:1161`) has no DASH call site — repo-wide the only caller is `main_ltc.cpp:2779`. `m_on_bestblock` stays default-constructed for the whole DASH run, so both invocation sites (`protocol_actual.cpp:207`, `protocol_legacy.cpp:249`) are permanently dead and no work refresh is triggered by a peer `bestblock`. Not fixed because it is unclear whether the intent is to wire it or to delete it.

**5. Unsure — condition drift on an opt-in.** (INFERRED)
`src/impl/dash/stratum/work_source.hpp:305-306` says GBT cross-check is "opt-in; main_dash enables it for `--embedded-mainnet`", but `main_dash.cpp:1827-1828` is `const bool xcheck_wanted = (testnet || embedded_mainnet);` — also on testnet. The sibling comment in `work_source.cpp:395-398` states the condition correctly, so the header copy looks like the drifted one. An omitted disjunct rather than a flat contradiction; listed, not fixed.

### Checked and found consistent (no finding)

`LLMQ_50_60` handling is **clean** — the mainnet defect is already fixed and correctly documented (`dkg_commitments.hpp:230,245,262,281`, `llmq_type_reconciler.hpp:7-10`); the only remaining mainnet reference is the ChainLocks type selection `LLMQ_400_60` mainnet / `LLMQ_50_60` testnet (`chainlock_verify.hpp:53,299`), which is correct. Also verified consistent: `DASH_MINING_GATE_DEPTH` 100+6; superblock cycle 16616/24; `PeerLiveness` 120s/1200s and the 30s/10s connect deadlines; `3600/SHARE_PERIOD = 180` and `TARGET_LOOKBEHIND = 100`; the 1700→3600 protocol-floor ratchet and 60/95 gates; `kStaleAfter = 30s`, `keepalive_notify_sec = 25`, `kDefaultFoldInterval = 500`; `enabled_llmqs` mainnet-4 / testnet-6 and the 9-in-24 window arithmetic; `m_commitment_window_fn` "dormant when the qc plan is installed"; the `/*underfill_tripped=*/nullptr` seam (comment correctly says it is left default); and the "governance invs are not pulled ⇒ govsync leg is INERT" claim.

The `[QC-COMPLETENESS]` cold-start explainer at `main_dash.cpp:3409-3416` is **already correct** and was the model for the rewritten comments — it states plainly that dashd mines the null here and c2pool refuses because of 1520106.

## Verification

- MEASURED: `git diff -U0` contains no non-comment lines — comment-only, zero behaviour change.
- MEASURED: `python3 tools/ci/check_test_target_allowlist.py` ⇒ `CI drift-guard OK: 229 per-coin test target(s) across 6 coin lane(s)`, exit 0. Nothing test-related was touched.
- Branched off `master` at `c179524`. Fresh clone; no existing checkout reused.
