### PR TITLE
dash: say "refuse", not "null-serve", in the DKG-window operator log lines (+ two stale-comment corrections)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -3210,7 +3210,9 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             if (dash::coin::vendor::bls_backend_available()) {
                 LOG_INFO << "[QC-PHASE-L] dashbls verifier + member-set sourcing "
                             "installed (real qc inclusion when the member set is "
-                            "sourced; fail-closed to null-serve otherwise)";
+                            "sourced; otherwise the slot is unsatisfiable and the "
+                            "WHOLE height refuses with cause=qc-plan-underivable "
+                            "and falls back to dashd -- never null-served)";
             }
 
             // REFUSAL-DIAGNOSIS seam (observability only, never gates a serve):

--- a/src/impl/dash/coin/quorum_member_source.hpp
+++ b/src/impl/dash/coin/quorum_member_source.hpp
@@ -36,7 +36,12 @@
 ///       hashMerkleRoot (header already PoW-verified by the header chain) at
 ///       tx index 0 (the coinbase);
 ///   (c) the snapshot SML's computed merkle root == cbTx.merkleRootMNList.
-/// Any failure -> the pending quorums for that hash FAIL CLOSED (null-serve).
+/// Any failure -> the pending quorums for that hash FAIL CLOSED: their member
+/// set stays unsourced, so no commitment can be BLS-verified for those slots.
+/// That is a REFUSAL, not a null serve — the slot is unsatisfiable and the
+/// whole height falls back to dashd (cause=qc-plan-underivable). c2pool never
+/// mines a null commitment to fill the shortfall (dkg_commitments.hpp HEIGHT
+/// COMPLETENESS: doing so diverged merkleRootQuorums at block 1520106).
 ///
 /// MODIFIER (#814 review R5): the coinbase ChainLock input is the work block's
 /// OWN cbTx bestCLSignature — v23.1.7 GetNonNullCoinbaseChainlock does NOT
@@ -452,7 +457,8 @@ public:
             LOG_WARNING << "[QC-MEMBERS] rotated member computation AMBIGUOUS "
                            "for cycle_base_h=" << in.cycle_base_height
                         << " type=" << static_cast<int>(in.llmq_type)
-                        << " -> fail closed (null-serve for the whole cycle)";
+                        << " -> fail closed (whole cycle stays unsourced; its "
+                           "slots refuse, they are NOT null-served)";
             return 0;
         }
 
@@ -475,7 +481,7 @@ public:
                         << static_cast<int>(in.llmq_type)
                         << " computed " << sets->size() << " member sets but NO "
                            "slot base-block header is held -> nothing published, "
-                           "cycle stays null-serve";
+                           "cycle stays unsourced (its slots refuse)";
         } else {
             LOG_INFO << "[QC-MEMBERS] ROTATED READY type="
                      << static_cast<int>(in.llmq_type) << " cycle_base_h="
@@ -588,7 +594,8 @@ private:
             diff, expect_h, m_merkle_root_of_hash, cbtx_out, "QC-MEMBERS");
         if (!sml) {
             LOG_WARNING << "[QC-MEMBERS] " << keys.size()
-                        << " quorum(s) fail closed (null-serve)";
+                        << " quorum(s) fail closed (member set unsourced -> "
+                           "those slots refuse, they are NOT null-served)";
         }
         return sml;
     }
@@ -628,7 +635,8 @@ private:
         } else {
             LOG_WARNING << "[QC-MEMBERS] member computation ambiguous for quorum "
                         << pend.quorum_hash.GetHex().substr(0, 16)
-                        << " -> fail closed (null-serve)";
+                        << " -> fail closed (member set unsourced -> this slot "
+                           "refuses, it is NOT null-served)";
         }
     }
 
@@ -642,7 +650,8 @@ private:
 
     // Same bound + rationale as reap_if_needed(), for the qrinfo lane. A
     // rotated cycle is 32 slots wide, so far fewer outstanding requests are
-    // ever legitimate; an evicted cycle simply stays null-serve.
+    // ever legitimate; an evicted cycle simply stays unsourced, so its slots
+    // refuse (fail-safe) — they are never null-served.
     static constexpr size_t kRotatedPendingCap = 8;
     void reap_rotated_if_needed()
     {
@@ -663,7 +672,8 @@ private:
 
     // Bound outstanding requests: evict the OLDEST pending (and its await
     // membership) once the cap is hit — a dead peer must not grow state
-    // forever, and an evicted quorum simply stays null-serve (fail-safe).
+    // forever, and an evicted quorum simply stays unsourced, so its slot
+    // refuses (fail-safe) — it is never null-served.
     void reap_if_needed()
     {
         while (m_pending.size() >= kPendingCap && !m_pending_fifo.empty()) {

--- a/src/impl/dash/node.hpp
+++ b/src/impl/dash/node.hpp
@@ -129,8 +129,35 @@ protected:
     // a RawMessage into a typed message variant. Mirrors dgb::NodeImpl::m_handler.
     dash::Handler m_handler;
 
-    // Callback fired when a bestblock message is received from a peer; wired by
-    // the work layer (slice .4) to trigger a work refresh. Mirrors dgb.
+    // Callback fired when a bestblock message is received from a pool peer.
+    //
+    // NOT WIRED ON THE DASH LANE (audited 2026-08-04) — and that is the norm,
+    // not a DASH regression: btc/dgb/bch declare the identical seam and leave
+    // it unset too; src/c2pool/main_ltc.cpp is the ONLY set_on_bestblock call
+    // site in the tree. Inbound bestblock on DASH is therefore observability
+    // only (the "[Pool] New best block from peer" line in
+    // dash/protocol_actual.cpp + protocol_legacy.cpp). The SEND side IS wired:
+    // main_dash's fallback-arm tip-notify announces via broadcast_bestblock().
+    //
+    // DASH does not need it as a tip source. Both arms already have a
+    // first-party coin-tip signal that the refresh trio (invalidate template
+    // cache + bump work generation + notify_all) hangs off:
+    //   * embedded arm  -> header_chain->set_on_tip_changed (coin-P2P headers),
+    //   * fallback arm  -> --coin-zmq-hashblock (instant) with a 3 s
+    //                      getbestblockhash poll backstop, behind one shared
+    //                      last-seen-tip dedup.
+    // LTC wires it because pool-P2P is its PRIMARY block source; DASH's is not.
+    //
+    // IF IT IS EVER WIRED, the hazard to solve first: the argument is a
+    // PEER-ASSERTED header hash, not our own tip. Feeding it straight into the
+    // fallback arm's fire_refresh would (a) let an unbounded stream of distinct
+    // bogus hashes drive a template-rebuild storm (LTC's leading-edge dedup is
+    // per-hash, so it does not bound that), and (b) POISON the shared tip_dedup
+    // with a hash dashd has not connected yet — the re-source returns the OLD
+    // template and the real tip-change refresh is then suppressed as
+    // "not a new tip", i.e. exactly the stale-work outcome the hook exists to
+    // prevent. Any wiring must confirm the hash against our own tip source
+    // before it is allowed to touch the dedup.
     std::function<void(const uint256&)> m_on_bestblock;
 
     // Thread pool for parallel share_init_verify (X11 CPU work). Keeps the
@@ -1157,7 +1184,10 @@ public:
         catch (const std::invalid_argument&) { /* request already timed out */ }
     }
 
-    // Register a callback fired when a bestblock message is received from a peer.
+    // Register a callback fired when a bestblock message is received from a
+    // pool peer. Currently UNCALLED on the DASH lane by design — see the
+    // m_on_bestblock declaration for why, and for the dedup-poisoning hazard
+    // that must be handled before anything is wired here.
     void set_on_bestblock(std::function<void(const uint256&)> fn) { m_on_bestblock = std::move(fn); }
 
     // ── Tracker accessors ───────────────────────────────────────────────

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -302,9 +302,20 @@ public:
     /// dashd getblocktemplate's before serving; on mismatch, serve dashd's
     /// reward-safe template instead. Catches ANY credit-pool seed bug (present or
     /// future) that the daemonless self-checks cannot. NOT pure-daemonless (uses
-    /// dashd), so it is opt-in; main_dash enables it for --embedded-mainnet where
-    /// a dashd fallback is configured. Pure-daemonless mode leaves it off and
-    /// relies on the independent seed-height gate.
+    /// dashd), so it is armed only where a dashd RPC arm actually exists.
+    ///
+    /// WIRING (main_dash.cpp): gbt_xcheck_ is set whenever the EMBEDDED ARM IS
+    /// ENABLED **AND** a dashd RPC arm is ARMED — i.e.
+    /// `(testnet || embedded_mainnet) && rpc`. The `testnet` leg is not an
+    /// accident: the embedded arm is enabled unconditionally on testnet/regtest
+    /// (embedded_arm_enabled = is_testnet_ || embedded_mainnet_, see
+    /// work_source.cpp resource_template_now), so the backstop covers exactly
+    /// the set of configurations that can serve an embedded template. The
+    /// `&& rpc` leg matters because dashd_fallback_() is invoked on EVERY
+    /// embedded template; an UNARMED arm returns the empty set-gap default and
+    /// made every healthy daemonless serve read as a fallback in the log.
+    /// Pure-daemonless mode (no rpc) therefore leaves it off and relies on the
+    /// independent seed-height + pre-emit gates.
     void set_gbt_xcheck(bool v) { gbt_xcheck_ = v; }
 
     /// Set the current share-target bits (compact-target encoding).


### PR DESCRIPTION
Three DASH-lane follow-ups that the comment-only PR #1079 correctly declined
to touch. Strings-and-comments only in the end: **no behaviour change on any
path**, and the one item that could have been a behaviour change (Item 3) is
resolved as "the condition was already right".

Complementary to #1079, not overlapping: #1079 covers `main_dash.cpp`
comments, `vendor/bls_verify.hpp` and `vendor/quorum_members.hpp`. This PR
covers the `main_dash.cpp` **log string**, all of
`coin/quorum_member_source.hpp`, `node.hpp` and `stratum/work_source.hpp`.
The two remaining `null-serve` comment sites in `main_dash.cpp` (L3186,
L4694) are left alone precisely because #1079 already fixes them.

---

## Item 1 — the operator-facing log line said the wrong thing (**MEASURED**)

`main_dash.cpp` printed, at startup, on every BLS-armed node:

```
[QC-PHASE-L] dashbls verifier + member-set sourcing installed (real qc
inclusion when the member set is sourced; fail-closed to null-serve otherwise)
```

That is false, and false in the one direction that matters. **MEASURED** by
following the actual code path: an unsourced member set makes
`MemberKeysProvider` return `nullopt`, `make_commitment_bls_verifier` returns
`false` for the slot, no commitment is admitted, `build_daemonless_qc_plan`
returns `nullopt`, and `node_coin_state.hpp:690` takes
`refuse("qc-plan-underivable", ...)`. Nothing null is ever constructed:
production passes `/*null_evidence=*/nullptr`. Null-serving a SUCCEEDED DKG
is exactly what diverged `merkleRootQuorums` at mainnet block 1520106
(`dkg_commitments.hpp` HEIGHT COMPLETENESS). Now reads:

```
... sourced; otherwise the slot is unsatisfiable and the WHOLE height refuses
with cause=qc-plan-underivable and falls back to dashd -- never null-served)
```

### Terminology sweep

`null-serve` was being used as a loose synonym for "fail closed". Swept so it
appears only where a null commitment is genuinely constructed, or where it is
explicitly negated. **MEASURED** count: 7 sites in
`coin/quorum_member_source.hpp` — 4 log strings and 3 comments.

| site | kind | was |
|---|---|---|
| L39 AUTHENTICATION block | comment | `FAIL CLOSED (null-serve)` |
| L455 rotated member computation AMBIGUOUS | **log** | `fail closed (null-serve for the whole cycle)` |
| L478 rotated cycle, no slot header held | **log** | `cycle stays null-serve` |
| L591 snapshot authentication failure | **log** | `quorum(s) fail closed (null-serve)` |
| L631 non-rotated member computation ambiguous | **log** | `fail closed (null-serve)` |
| L645 `kRotatedPendingCap` rationale | comment | `evicted cycle simply stays null-serve` |
| L666 `reap_if_needed` rationale | comment | `evicted quorum simply stays null-serve` |

Deliberately **kept**: `dkg_commitments.hpp:117`, "all 32 mandatory rotated
slots null-served" — that describes the 1520106 incident itself, where null
genuinely was served. That is the only surviving unqualified use in the DASH
tree.

**Tests: MEASURED — none.** `grep` for `QC-MEMBERS` / `QC-PHASE-L` /
`null-serve` across `tests/` returns nothing; no test asserts on any changed
string, so nothing needed updating.

---

## Item 2 — `set_on_bestblock`: neither dead nor a gap; the comment was the defect (**MEASURED + INFERRED**)

The reported finding is **confirmed and then some**. `node.hpp` said the hook
is "wired by the work layer (slice .4)".

**MEASURED:** `src/c2pool/main_ltc.cpp:2779` is the **only**
`set_on_bestblock` call site in the entire tree. `btc/node.hpp:377`,
`dgb/node.hpp:380`, `bch/node.hpp:603` and `dash/node.hpp` all declare the
identical seam and all leave it unset. So this is not a DASH regression — LTC
is the outlier, and it says why in its own comment: "P2P is our primary block
source". DASH's is not.

**I removed nothing, and I wired nothing.** Reasoning, per the brief's
instruction to decide from what the callback would do:

*Not a functional gap.* **MEASURED** — DASH already has a first-party coin-tip
signal on **both** arms, each firing the same invalidate + bump + notify trio:

- embedded arm: `header_chain->set_on_tip_changed` (`main_dash.cpp:3599`),
  driven by the coin-P2P header stream;
- fallback arm: `--coin-zmq-hashblock` (instant) with a 3 s
  `getbestblockhash` poll backstop, both behind one shared last-seen-tip
  dedup (`main_dash.cpp:~4235`).

The send side is wired too — `p2p_node.broadcast_bestblock(hdr)` at
`main_dash.cpp:4238` — so DASH announces its tip to pool peers; it just does
not consume theirs. Inbound is observability-only (the `[Pool] New best block
from peer` line in `protocol_actual.cpp:200` / `protocol_legacy.cpp`).

*Not dead code either, and removing it would be wrong.* It is a uniform
cross-lane seam. Deleting DASH's alone would require touching
`dash/protocol_actual.cpp` and `dash/protocol_legacy.cpp` (the
`if (m_on_bestblock)` call sites), diverge DASH from four sibling lanes, and
buy nothing.

*The hazard, if anyone ever does wire it* — **INFERRED** from reading the
fallback arm's dedup, not measured on a live node, and recorded in the
comment so the next person does not have to re-derive it. The argument is a
**peer-asserted** header hash, not our own tip. Feeding it straight into
`fire_refresh` would (a) let an unbounded stream of distinct bogus hashes
drive a template-rebuild storm — LTC's leading-edge dedup is per-hash and does
not bound that — and (b) **poison the shared `tip_dedup`** with a hash dashd
has not connected yet: the re-source returns the OLD template, and the real
tip-change refresh is then suppressed as "not a new tip". That is precisely
the stale-work outcome the hook exists to prevent. Any wiring must confirm the
hash against our own tip source before it is allowed to touch the dedup.

---

## Item 3 — the **comment** was wrong; the condition is right and stays (**MEASURED**)

`work_source.hpp` documented the GBT cross-check as `--embedded-mainnet`
only; `main_dash.cpp:1827` gates it on `(testnet || embedded_mainnet) && rpc`.

**Changed the comment. Did not touch the condition.** Intent is not ambiguous
here — it is corroborated in-tree, so there was nothing to guess:

1. **MEASURED**, `work_source.cpp:327`:
   `const bool embedded_arm_enabled = is_testnet_ || embedded_mainnet_;`
   and `work_source.cpp:205` short-circuits to the dashd fallback on
   `!is_testnet_ && !embedded_mainnet_`. The embedded arm is enabled
   **unconditionally on testnet/regtest**; `--embedded-mainnet` only lifts the
   **mainnet** gate. So `(testnet || embedded_mainnet)` is literally
   "wherever an embedded template can be served" — exactly the set a backstop
   guarding embedded serves must cover. Gating the cross-check on
   `embedded_mainnet` alone would leave every testnet embedded serve
   **unbackstopped**, which is the opposite of the stated purpose.
2. **MEASURED**, `work_source.cpp:394-397`: the sibling comment in the .cpp
   *already* states the corrected wiring — "main_dash sets `gbt_xcheck_`
   whenever the embedded arm is enabled (testnet or `--embedded-mainnet`) AND
   a dashd RPC arm is actually ARMED" — dated 2026-08-03, same day as the
   `&& rpc` fix. The .hpp doc was simply the copy that did not get updated.

The header now records both legs, including why `&& rpc` matters
(`dashd_fallback_()` is invoked on every embedded template; an unarmed arm
returns the empty set-gap default and made every healthy daemonless serve read
as a fallback in the log).

---

## Verification

- `python3 tools/ci/check_test_target_allowlist.py` -> `CI drift-guard OK: 229
  per-coin test target(s) across 6 coin lane(s) all present in build.yml
  --target allowlist.`
- `g++ -fsyntax-only -std=c++20` on each touched header
  (`quorum_member_source.hpp`, `stratum/work_source.hpp`, `node.hpp`) — clean
  (one pre-existing unrelated `backslash-newline at end of file` warning from
  `sharechain/share.hpp`).
- No test added or touched: nothing asserts on the changed strings and no
  behaviour changed, so there is no new red-able surface to register.

## Scope

DASH lane only. No cross-coin edits; the LTC `set_on_bestblock` call site is
untouched. Non-destructive, no branches deleted, nothing merged.
