### PR TITLE
dash: commit the verifier's MN-list root — confirmedHash rollover projection + MN-collateral spend exclusion (bad-cbtx-mnmerkleroot silent block loss)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -3078,6 +3078,17 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             testnet ? dash::coin::DASH_MN_RR_HEIGHT_TESTNET
                     : dash::coin::DASH_MN_RR_HEIGHT_MAINNET);
 
+        // confirmedHash rollover projection threshold (sml_projection.hpp):
+        // the network's nMasternodeMinimumConfirmations (per-chainparams in
+        // dashcore v23.1.7 chainparams.cpp — mainnet 15 at :177, testnet 1 at
+        // :376). Gates the height-driven confirmation pass the template build
+        // + viability + pre-emit gates replicate so the committed
+        // merkleRootMNList matches the verifier's rebuilt list at an MN's
+        // confirmation-crossing height (bad-cbtx-mnmerkleroot otherwise).
+        node_coin_state.set_mn_min_confirmations(
+            testnet ? dash::coin::DASH_MN_MIN_CONFIRMATIONS_TESTNET
+                    : dash::coin::DASH_MN_MIN_CONFIRMATIONS_MAINNET);
+
         // review PR #780 BLOCKER-1 (CRITICAL): refuse the embedded arm on DKG
         // commitment-window heights. There the block MUST carry mandatory type-6
         // quorum-commitment txs (which the C-3 filter strips) and merkleRootQuorums

--- a/src/impl/dash/coin/embedded_gbt.hpp
+++ b/src/impl/dash/coin/embedded_gbt.hpp
@@ -29,6 +29,7 @@
 /// the actual coin_rpc->getwork() output, logging match/mismatch.
 
 #include <impl/dash/coin/mn_state_machine.hpp>
+#include <impl/dash/coin/sml_projection.hpp>    // confirmedHash rollover pass + collateral-spend predicate
 #include <impl/dash/coin/mempool.hpp>
 #include <impl/dash/coin/subsidy.hpp>
 #include <impl/dash/coin/governance_object.hpp>   // SuperblockPayment (daemonless superblock outputs)
@@ -158,7 +159,13 @@ inline DashWorkData build_embedded_workdata(
     // confidently-UNFUNDED superblock height serves normally). The MN payment /
     // platform burn / mempool selection above are untouched — superblock
     // outputs are purely additive, matching dashcore GetBlockTxOuts ordering.
-    const std::vector<SuperblockPayment>* superblock_payments = nullptr)
+    const std::vector<SuperblockPayment>* superblock_payments = nullptr,
+    // Network seam: Consensus::Params.nMasternodeMinimumConfirmations for the
+    // confirmedHash rollover projection (sml_projection.hpp). Mainnet default
+    // (15, dashcore chainparams.cpp:177); testnet/devnet/regtest are 1. Only
+    // consulted when the CCbTx seams (sml + qmgr) are supplied. SAFE-ADDITIVE:
+    // appended last so every existing positional caller is byte-unchanged.
+    int mn_min_confirmations = DASH_MN_MIN_CONFIRMATIONS_MAINNET)
 {
     DashWorkData w;
     w.m_height          = prev_height + 1;
@@ -182,6 +189,37 @@ inline DashWorkData build_embedded_workdata(
     // accrual below is exactly the platform-reward term.
     auto [selected, total_fees] =
         mempool.get_sorted_txs_with_fees(MAX_BLOCK_BYTES, /*exclude_special=*/true);
+    // MN-collateral spend filter (sml_projection.hpp, FINDING-2). The C-3
+    // special-tx cut above is NOT sufficient: dashd's verifier removes a
+    // masternode from the list when ANY block tx — special or not — spends
+    // its collateral outpoint (specialtxman.cpp:457-464, no type guard), and
+    // that removal changes the merkleRootMNList the CbTx must commit. A plain
+    // type-0 collateral spend selected here would poison EVERY template built
+    // while it sits in the mempool (bad-cbtx-mnmerkleroot on a winning share
+    // = a silently lost block). No tx is ever mandatory, so EXCLUDING it is
+    // consensus-clean — dashd's own miner folds the removal instead, but the
+    // exclusion needs no second root computation. Fee follows the tx out of
+    // the template so block_value / mn_payment below stay exact.
+    {
+        size_t kept = 0;
+        for (size_t i = 0; i < selected.size(); ++i) {
+            uint256 protx;
+            if (tx_spends_mn_collateral(mnstates, selected[i].tx, &protx)) {
+                total_fees -= selected[i].fee;
+                LOG_WARNING << "[GBT-EMB] excluding tx "
+                            << dash::coin::dash_txid(selected[i].tx).GetHex().substr(0, 16)
+                            << " from template h=" << (prev_height + 1)
+                            << ": spends collateral of MN "
+                            << protx.GetHex().substr(0, 16)
+                            << " (verifier would remove the MN and expect a "
+                            << "different merkleRootMNList)";
+                continue;
+            }
+            if (kept != i) selected[kept] = std::move(selected[i]);
+            ++kept;
+        }
+        selected.resize(kept);
+    }
     int64_t block_value      = reward + static_cast<int64_t>(total_fees);
     int64_t platform_reward  = compute_dash_platform_reward_post_v20_mn_rr(
         w.m_height, mn_rr_height);
@@ -213,6 +251,20 @@ inline DashWorkData build_embedded_workdata(
     // (node/miner.cpp CreateNewBlock), and the daemonless template mirrors
     // that for byte parity. Zero fee, zero in/out; consensus-checked via
     // the NodeCoinState emit gate against the same deterministic plan.
+    //
+    // ██ PHASE-L LANDMINE — PoSe punishment on REAL commitments ██
+    // dashd's verifier PoSe-punishes every !validMembers[i] quorum member
+    // when a NON-NULL commitment is in the block (specialtxman.cpp:159-174
+    // HandleQuorumCommitment -> PoSePunish(CalcPenalty(66))), and a penalty
+    // that crosses the ban threshold flips that MN's isValid IN THE SAME
+    // BLOCK's MN list — changing the merkleRootMNList THIS coinbase commits.
+    // Null commitments are exempt (specialtxman.cpp:432 IsNull() guard), so
+    // today's all-null qc plans cannot trip it and the projected root above
+    // stays correct. THE DAY Phase L serves REAL (non-null) commitments,
+    // this inclusion site MUST fold the PoSe pass into the committed MN root
+    // (mirror of the confirmedHash rollover projection above) or every block
+    // carrying a commitment with a failed member is bad-cbtx-mnmerkleroot —
+    // a silently lost block. Do not ship real commitments without it.
     if (qc_commitments != nullptr) {
         for (const auto& c : *qc_commitments) {
             MutableTransaction qtx = build_qc_tx(w.m_height, c);
@@ -361,8 +413,34 @@ inline DashWorkData build_embedded_workdata(
         // (pre-MN_RR) the balance carries forward unchanged, also correct.
         const int64_t accrued_credit_pool =
             last_observed_credit_pool + platform_reward;
+        // confirmedHash rollover (sml_projection.hpp, FINDING-1): the tip SML
+        // is the verifier's PREV list, not the list for the block being
+        // templated — dashd's rebuild starts with a purely height-driven
+        // confirmation pass (specialtxman.cpp:206-215) that flips a
+        // registered MN's confirmedHash at the crossing height with NO tx
+        // causing it. Commit the PROJECTED root, not the tip root. When the
+        // projection is unprojectable (a null-confirmedHash entry with no
+        // known registration height) the root below may be stale; the
+        // NodeCoinState viability + pre-emit gates fail closed on exactly
+        // that condition ("mn-confirm-rollover-pending"), so this build can
+        // never be SERVED — the warning is for callers outside that gate.
+        auto proj = project_sml_confirmations(
+            *sml, prev_height, prev_hash, mnstates, mn_min_confirmations);
+        if (!proj.ok) {
+            LOG_WARNING << "[GBT-EMB] confirmedHash rollover UNPROJECTABLE at h="
+                        << (prev_height + 1) << ": SML entry "
+                        << proj.unprojectable_protx.GetHex().substr(0, 16)
+                        << " has null confirmedHash but no known registration "
+                        << "height — committed merkleRootMNList may be stale "
+                        << "(emit gate refuses this template)";
+        } else if (proj.confirmed > 0) {
+            LOG_INFO << "[GBT-EMB] confirmedHash rollover: " << proj.confirmed
+                     << " MN(s) cross nMasternodeMinimumConfirmations at h="
+                     << (prev_height + 1)
+                     << " — committing projected merkleRootMNList";
+        }
         vendor::CCbTx cb = build_embedded_cbtx(
-            prev_height, *sml, *qmgr, best_cl_height, best_cl_sig,
+            prev_height, proj.sml, *qmgr, best_cl_height, best_cl_sig,
             accrued_credit_pool, quorum_root_override);
         w.m_coinbase_payload = encode_cbtx(cb);
     } else {

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -27,6 +27,7 @@
 #include <impl/dash/coin/quorum_root.hpp>        // compute_merkle_root_quorums (pre-emit recompute)
 #include <impl/dash/coin/dkg_commitments.hpp>    // QcBlockPlan (E1 daemonless DKG-window serving)
 #include <impl/dash/coin/vendor/simplifiedmns.hpp> // vendor::CSimplifiedMNList (merkleRootMNList source)
+#include <impl/dash/coin/sml_projection.hpp>     // confirmedHash rollover projection + collateral-spend predicate
 #include <impl/dash/coin/vendor/cbtx.hpp>        // vendor::parse_cbtx (pre-emit CbTx self-check)
 #include <impl/dash/coin/subsidy.hpp>            // compute_dash_platform_reward_post_v20_mn_rr (creditPool re-check)
 
@@ -165,6 +166,16 @@ public:
     /// exactly one block's platform reward (constant 66,966,830 duffs).
     void set_mn_rr_height(int h) { m_mn_rr_height = h; }
     int mn_rr_height() const { return m_mn_rr_height; }
+
+    /// Network nMasternodeMinimumConfirmations (dashcore Params().GetConsensus()
+    /// .nMasternodeMinimumConfirmations — per-chainparams: mainnet 15, testnet/
+    /// devnet/regtest 1; see sml_projection.hpp). Gates the confirmedHash
+    /// rollover projection in the template build, the viability clause and the
+    /// pre-emit root re-check. main_dash sets the testnet value next to
+    /// set_mn_rr_height; the mainnet default keeps every existing caller
+    /// byte-unchanged.
+    void set_mn_min_confirmations(int c) { m_mn_min_confirmations = c; }
+    int mn_min_confirmations() const { return m_mn_min_confirmations; }
 
     /// HEADER-SYNC gate (the DASH half of a cross-lane asymmetry: bch 13, ltc
     /// 12, nmc 12, btc 6, dgb 6 callers of is_synced(); DASH had ZERO —
@@ -465,6 +476,20 @@ public:
                               ? std::to_string(m_mnstates.last_applied_height())
                               : std::string("n/a"),
                           std::to_string(m_prev_height));
+        // FINDING-2 defence in depth: no template tx may spend a known MN
+        // collateral outpoint. dashd's verifier removes that MN from the list
+        // for THIS block (specialtxman.cpp:457-464, ALL txs, no special-tx
+        // guard), so a committed root built from the unmodified list is
+        // bad-cbtx-mnmerkleroot — a silently lost block on a winning share.
+        // The builder already filters these out of selection; re-assert here
+        // so a cached/bypassed template can never reach a miner.
+        for (const auto& tx : w.m_txs) {
+            uint256 protx;
+            if (tx_spends_mn_collateral(m_mnstates, tx, &protx))
+                return reject("emit-collateral-spend-in-template",
+                              "mn=" + protx.GetHex().substr(0, 12),
+                              "no-template-tx-spends-mn-collateral");
+        }
         vendor::CCbTx cb;
         if (!vendor::parse_cbtx(w.m_coinbase_payload, cb))
             return reject("emit-cbtx-unparseable",
@@ -473,11 +498,25 @@ public:
         if (cb.nHeight != static_cast<int32_t>(next_h))
             return reject("emit-cbtx-height-drift", std::to_string(cb.nHeight),
                           std::to_string(next_h));
-        auto sml_copy = m_sml;
-        if (cb.merkleRootMNList != sml_copy.CalcMerkleRoot())
+        // FINDING-1: the root block next_h must commit is the tip SML with the
+        // verifier's height-driven confirmation pass applied (specialtxman.cpp
+        // :206-215 — see sml_projection.hpp). Comparing against the RAW tip
+        // root here would re-approve the exact stale root the rollover
+        // poisons, so re-derive the PROJECTED root; fail closed when the pass
+        // is unprojectable (a null-confirmedHash entry with no known
+        // registration height — at most ~nMasternodeMinimumConfirmations
+        // blocks per unknown registration).
+        auto proj = project_sml_confirmations(m_sml, m_prev_height, m_prev_hash,
+                                              m_mnstates,
+                                              m_mn_min_confirmations);
+        if (!proj.ok)
+            return reject("emit-mn-confirm-rollover-pending",
+                          "protx=" + proj.unprojectable_protx.GetHex().substr(0, 12),
+                          "known-registration-height");
+        if (cb.merkleRootMNList != proj.sml.CalcMerkleRoot())
             return reject("emit-mnlist-root-drift",
                           cb.merkleRootMNList.GetHex().substr(0, 12),
-                          sml_copy.CalcMerkleRoot().GetHex().substr(0, 12));
+                          proj.sml.CalcMerkleRoot().GetHex().substr(0, 12));
         // E1: under a qc plan the committed root must be the WITH-BLOCK root
         // (fold of the plan's commitments over the active set — equal to the
         // plain root while the plan is all-null, diverging only once Phase L
@@ -574,6 +613,7 @@ public:
         e.curtime              = m_curtime;
         e.version              = m_version;
         e.mn_rr_height         = m_mn_rr_height;
+        e.mn_min_confirmations = m_mn_min_confirmations;
         // E-SUPERBLOCK: hand the resolved treasury schedule to the builder.
         // Empty at non-superblock heights and confidently-unfunded superblocks
         // (normal block); the winning trigger's payees at a funded superblock.
@@ -732,6 +772,19 @@ private:
                            ? std::string("n/a")
                            : m_sml_current_hash.GetHex().substr(0, 12),
                        m_prev_hash.GetHex().substr(0, 12));
+        else if (m_require_sml && find_unprojectable_confirmation(m_sml, m_mnstates))
+            // FINDING-1 fail-closed fallback: an SML entry awaits its
+            // height-driven confirmedHash rollover (specialtxman.cpp:206-215)
+            // but the DMN view holds no registration height for it, so the
+            // pass — and therefore the merkleRootMNList block next_h must
+            // commit — cannot be projected. Refusing here costs at most
+            // ~nMasternodeMinimumConfirmations blocks of embedded serve per
+            // unknown registration; serving would risk a committed stale root
+            // (bad-cbtx-mnmerkleroot = a silently lost winning share).
+            d = refuse("mn-confirm-rollover-pending",
+                       "protx=" + find_unprojectable_confirmation(m_sml, m_mnstates)
+                                      ->GetHex().substr(0, 12),
+                       "known-registration-height");
         else if (!payee_resolvable)
             d = refuse("payee-unresolvable",
                        std::to_string(m_mnstates.entries().size())
@@ -872,6 +925,7 @@ private:
     // freshness gates above it defaults ON.
     bool     m_require_resolvable_payee{true};   // refuse embedded when a due MN payee is unresolvable (#996)
     int      m_mn_rr_height{DASH_MN_RR_HEIGHT_MAINNET}; // network MN_RR activation height (platform-share gate)
+    int      m_mn_min_confirmations{DASH_MN_MIN_CONFIRMATIONS_MAINNET}; // network nMasternodeMinimumConfirmations (rollover projection)
     uint256  m_credit_pool_current_hash;     // block hash the credit-pool seed is current at
     int32_t  m_credit_pool_height{-1};       // seed cbTx's OWN height (-1 = never seeded)
     bool     m_quorum_healthy{true};         // last diff's quorum tail parsed OK

--- a/src/impl/dash/coin/sml_projection.hpp
+++ b/src/impl/dash/coin/sml_projection.hpp
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// confirmedHash rollover projection — the height-driven MN confirmation pass.
+///
+/// dashcore's verifier rebuilds the deterministic MN list for EVERY block it
+/// connects, and the FIRST thing that rebuild does is a purely height-driven
+/// confirmation pass (dashcore v23.1.7, src/evo/specialtxman.cpp:206-215,
+/// CSpecialTxProcessor::RebuildListFromBlock):
+///
+///     prevList.ForEachMN(false, [&](const auto& dmn) {
+///         if (!dmn.pdmnState->confirmedHash.IsNull()) return;  // already confirmed
+///         int nConfirmations = pindexPrev->nHeight - dmn.pdmnState->nRegisteredHeight;
+///         if (nConfirmations >= nMasternodeMinimumConfirmations) {
+///             newState->UpdateConfirmedHash(dmn.proTxHash, pindexPrev->GetBlockHash());
+///             newList.UpdateMN(dmn.proTxHash, newState);
+///         }
+///     });
+///
+/// `confirmedHash` IS a hashed field of the DIP-0004 Simplified MN List entry
+/// (CSimplifiedMNListEntry::CalcHash — see vendor/simplifiedmns.hpp), so the
+/// merkleRootMNList the verifier expects block N to commit differs from the
+/// TIP list's root at exactly the height where a registered MN crosses
+/// nMasternodeMinimumConfirmations — with NO transaction in the block causing
+/// it. A template that commits the tip SML root verbatim at that height is a
+/// consensus-invalid block (bad-cbtx-mnmerkleroot): a winning share there is a
+/// silently lost block, and no tip-relative freshness gate can catch it
+/// because the tip SML *is* current — it is the projection for the block
+/// BEING TEMPLATED that is missing.
+///
+/// This header is that projection. Given the tip SML (current at prev_hash),
+/// the DMN view (which carries nRegisteredHeight: live ProRegTx applies stamp
+/// it exactly, and the `protx list registered true` seed carries dashd's own
+/// registeredHeight — see mn_seed.hpp), and the tip (prev_height, prev_hash),
+/// it replicates the verifier's confirmation pass:
+///
+///   for every SML entry with a null confirmedHash:
+///     nConfirmations = prev_height - nRegisteredHeight
+///     if nConfirmations >= nMasternodeMinimumConfirmations:
+///         entry.confirmedHash = prev_hash        // UpdateConfirmedHash
+///
+/// (UpdateConfirmedHash additionally derives confirmedHashWithProRegTxHash,
+/// but that field is quorum-scoring state, not an SML entry field — the SML
+/// leaf hashes confirmedHash itself, so setting it is sufficient here.)
+///
+/// FAIL-CLOSED CONTRACT: if any null-confirmedHash entry's registration
+/// height is UNKNOWN to the DMN view (proTxHash absent, or the height is the
+/// 0 / UINT32_MAX "never" sentinel), the projection reports ok=false and the
+/// caller must refuse to serve (NodeCoinState names this
+/// "mn-confirm-rollover-pending"). Serving on a guess would be the exact
+/// silent-wrongness class this file exists to close. The refusal window is
+/// bounded: it can only persist while an unconfirmed (recently registered)
+/// MN with unknown registration height sits in the SML — at most
+/// ~nMasternodeMinimumConfirmations blocks per such registration.
+///
+/// Frequency (INFERRED, not measured): mainnet MN registrations are on the
+/// order of a few per day, and each poisons exactly one height (the crossing
+/// height) — after that block connects, the network's own mnlistdiff carries
+/// the confirmedHash and the tip SML is correct again.
+
+#include <impl/dash/coin/mn_state_machine.hpp>
+#include <impl/dash/coin/vendor/simplifiedmns.hpp>
+
+#include <core/uint256.hpp>
+
+#include <cstdint>
+#include <limits>
+#include <optional>
+
+namespace dash {
+namespace coin {
+
+/// Consensus::Params.nMasternodeMinimumConfirmations, verified against
+/// dashcore v23.1.7 src/chainparams.cpp: mainnet = 15 (line 177); testnet,
+/// devnet and regtest = 1 (lines 376/549/780). NOT 16 — the crossing height
+/// for a mainnet MN registered at height R is R + 16 (the pass runs on
+/// pindexPrev, so confirmation lands one block after 15 confirmations exist,
+/// with confirmedHash = the hash of block R + 15).
+inline constexpr int DASH_MN_MIN_CONFIRMATIONS_MAINNET = 15;
+inline constexpr int DASH_MN_MIN_CONFIRMATIONS_TESTNET = 1;
+
+/// True when the DMN view knows a usable registration height for `protx`.
+/// 0 and UINT32_MAX are the "never / unknown" sentinels (see mn_seed.hpp
+/// sane_height_json and mn_state_machine.hpp payee_score).
+inline bool mn_registration_height_known(const MnStateMachine& mnstates,
+                                         const uint256& protx,
+                                         uint32_t* out_height = nullptr)
+{
+    auto it = mnstates.entries().find(protx);
+    if (it == mnstates.entries().end()) return false;
+    const uint32_t h = it->second.nRegisteredHeight;
+    if (h == 0 || h == std::numeric_limits<uint32_t>::max()) return false;
+    if (out_height) *out_height = h;
+    return true;
+}
+
+/// Cheap viability probe (no SML copy): the first null-confirmedHash SML
+/// entry whose registration height the DMN view cannot supply — i.e. the
+/// entry that makes the confirmation pass unprojectable. nullopt => the pass
+/// is fully projectable for the next block.
+inline std::optional<uint256> find_unprojectable_confirmation(
+    const vendor::CSimplifiedMNList& tip_sml,
+    const MnStateMachine& mnstates)
+{
+    for (const auto& e : tip_sml.mnList) {
+        if (!e.confirmedHash.IsNull()) continue;   // already confirmed
+        if (!mn_registration_height_known(mnstates, e.proRegTxHash))
+            return e.proRegTxHash;
+    }
+    return std::nullopt;
+}
+
+struct SmlConfirmationProjection {
+    vendor::CSimplifiedMNList sml;   ///< tip SML with the confirmation pass applied
+    size_t  confirmed{0};            ///< entries confirmed by the pass (usually 0)
+    bool    ok{true};                ///< false => a null-confirmedHash entry has no known reg height
+    uint256 unprojectable_protx;     ///< first offender when !ok (observability)
+};
+
+/// Apply the verifier's confirmation pass (specialtxman.cpp:206-215) to a
+/// COPY of the tip SML, producing the list whose merkle root block
+/// (prev_height + 1) must commit. Entries are keyed/sorted by proRegTxHash,
+/// which the pass never changes, so no re-sort is needed and the projected
+/// root is CalcMerkleRoot() over the returned list.
+///
+/// When !ok the pass was applied to every projectable entry and skipped the
+/// offender(s); the root is then NOT trustworthy and callers must fail
+/// closed (the NodeCoinState viability + pre-emit gates do).
+inline SmlConfirmationProjection project_sml_confirmations(
+    const vendor::CSimplifiedMNList& tip_sml,
+    uint32_t prev_height,
+    const uint256& prev_hash,
+    const MnStateMachine& mnstates,
+    int mn_min_confirmations = DASH_MN_MIN_CONFIRMATIONS_MAINNET)
+{
+    SmlConfirmationProjection out;
+    out.sml = tip_sml;
+    for (auto& e : out.sml.mnList) {
+        if (!e.confirmedHash.IsNull()) continue;   // already confirmed
+        uint32_t reg_height = 0;
+        if (!mn_registration_height_known(mnstates, e.proRegTxHash,
+                                          &reg_height)) {
+            if (out.ok) out.unprojectable_protx = e.proRegTxHash;
+            out.ok = false;
+            continue;
+        }
+        // dashd: nConfirmations = pindexPrev->nHeight - nRegisteredHeight;
+        // signed arithmetic so a same-block registration (reg == prev+1 via
+        // a not-yet-folded diff) can never wrap into a huge positive count.
+        const int64_t confirmations =
+            static_cast<int64_t>(prev_height) - static_cast<int64_t>(reg_height);
+        if (confirmations >= static_cast<int64_t>(mn_min_confirmations)) {
+            e.confirmedHash = prev_hash;           // UpdateConfirmedHash
+            ++out.confirmed;
+        }
+    }
+    return out;
+}
+
+/// FINDING-2 predicate — collateral spends by NORMAL transactions.
+///
+/// dashcore's verifier (specialtxman.cpp:457-464) runs a second pass over ALL
+/// block txs — with NO special-tx guard — and REMOVES from the MN list any
+/// masternode whose collateral outpoint is spent by any input:
+///
+///     for (int i = 1; i < (int)block.vtx.size(); i++)
+///         for (const auto& in : block.vtx[i]->vin)
+///             if (auto dmn = newList.GetMNByCollateral(in.prevout); ...)
+///                 newList.RemoveMN(dmn->proTxHash);
+///
+/// So a plain type-0 tx spending a 1000-DASH MN collateral forces the
+/// verifier's list for THAT block to drop the MN — and the committed
+/// merkleRootMNList must reflect the removal. The embedded template's
+/// special-tx filter (mempool.hpp exclude_special) does not catch it: the tx
+/// is type 0. Rather than fold the removal into the committed root (dashd's
+/// miner does, but it is a second root computation with its own wrongness
+/// budget), the embedded builder EXCLUDES such txs from selection — no tx is
+/// ever mandatory in a block, so exclusion is consensus-clean and forfeits
+/// only that tx's fee while the spend sits in the mempool.
+///
+/// Coverage / posture: the lookup is MnStateMachine::find_by_collateral —
+/// the UNFILTERED collateral index (banned MNs included, matching dashd's
+/// GetMNByCollateral in this pass). The index is populated for every entry
+/// the DMN view holds (live ProRegTx applies resolve the outpoint exactly,
+/// incl. the null-hash "own output" form; the `protx list registered true`
+/// seed carries collateralHash/collateralIndex — see mn_seed.hpp). An
+/// outpoint the index does not hold is treated as NOT a collateral —
+/// dropping every type-0 tx with any unknown input would gut template fill.
+/// The residual exposure is an MN present in the SML but absent from the DMN
+/// view; the serve path already fails closed on that skew via the #996
+/// payee-resolution and freshness gates. Frequency (INFERRED, not measured):
+/// collateral spends of active MNs are rare — but while such a tx sits in
+/// the mempool it poisons EVERY template that includes it, which is why the
+/// pre-emit gate re-checks this predicate as defence in depth.
+template <typename Tx>
+inline bool tx_spends_mn_collateral(const MnStateMachine& mnstates,
+                                    const Tx& tx,
+                                    uint256* out_protx = nullptr)
+{
+    for (const auto& in : tx.vin) {
+        if (auto protx = mnstates.find_by_collateral(in.prevout)) {
+            if (out_protx) *out_protx = *protx;
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/work_source.hpp
+++ b/src/impl/dash/coin/work_source.hpp
@@ -121,6 +121,10 @@ struct EmbeddedWorkInputs {
     // (per-chainparams in dashcore). Mainnet default; main_dash sets the
     // testnet value via NodeCoinState::set_mn_rr_height (E4 re-soak fix).
     int                              mn_rr_height{DASH_MN_RR_HEIGHT_MAINNET};
+    // Consensus::Params.nMasternodeMinimumConfirmations for the confirmedHash
+    // rollover projection (sml_projection.hpp): mainnet 15, testnet/devnet/
+    // regtest 1. Threaded from NodeCoinState::set_mn_min_confirmations.
+    int                              mn_min_confirmations{DASH_MN_MIN_CONFIRMATIONS_MAINNET};
 
     // E1 daemonless DKG-window seams (dkg_commitments.hpp QcBlockPlan,
     // populated by NodeCoinState::make_embedded_work_inputs when a qc plan fn
@@ -212,7 +216,9 @@ inline WorkSelection select_dash_work(
                 emb.mn_rr_height,
                 // E-SUPERBLOCK: funded superblock schedule (empty => normal block).
                 emb.superblock_payments.empty() ? nullptr
-                                                : &emb.superblock_payments);
+                                                : &emb.superblock_payments,
+                // confirmedHash rollover projection threshold (sml_projection.hpp).
+                emb.mn_min_confirmations);
         },
         dashd_fallback);
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -717,6 +717,13 @@ if (BUILD_TESTING AND GTest_FOUND)
     # for the same reason as test_dash_qrinfo.cpp: this target IS in the build.yml
     # "Build tests" --target allowlist, and a standalone target would be a
     # NOT_BUILT sentinel (the push bot lacks `workflow` scope, #769).
+    # test_dash_mn_confirm_rollover.cpp / test_dash_collateral_spend_filter.cpp
+    # (sml_projection.hpp): the two silent block-loss defects of the committed
+    # merkleRootMNList — the height-driven confirmedHash rollover
+    # (specialtxman.cpp:206-215) and MN-collateral spends by normal type-0 txs
+    # (specialtxman.cpp:457-464). Folded here for the same reason as the other
+    # leaves above: this target IS in the build.yml "Build tests" --target
+    # allowlist, and a standalone target would be a NOT_BUILT sentinel (#769).
     add_executable(test_dash_embedded_gbt
         test_dash_embedded_gbt.cpp
         test_dash_embedded_cbtx_byte_parity.cpp
@@ -725,7 +732,9 @@ if (BUILD_TESTING AND GTest_FOUND)
         test_dash_rotated_quorum_members.cpp
         test_dash_dkg_commitments.cpp
         test_dash_sml_quorum_db.cpp
-        test_dash_embedded_oracle_shadow.cpp)
+        test_dash_embedded_oracle_shadow.cpp
+        test_dash_mn_confirm_rollover.cpp
+        test_dash_collateral_spend_filter.cpp)
     target_compile_definitions(test_dash_embedded_gbt PRIVATE
         DASH_FIXTURE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/fixtures")
     target_link_libraries(test_dash_embedded_gbt PRIVATE

--- a/test/test_dash_collateral_spend_filter.cpp
+++ b/test/test_dash_collateral_spend_filter.cpp
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/// MN-collateral spend filter (sml_projection.hpp tx_spends_mn_collateral +
+/// the embedded_gbt.hpp selection filter + the NodeCoinState pre-emit check).
+///
+/// THE DEFECT PINNED HERE (silent block loss while the tx is in the
+/// mempool): dashcore's verifier runs its collateral pass over ALL block txs
+/// with NO special-tx guard (v23.1.7 specialtxman.cpp:457-464) — a plain
+/// type-0 transaction spending a masternode's collateral outpoint forces the
+/// verifier to REMOVE that MN from the list for that block, changing the
+/// merkleRootMNList the CbTx must commit. The C-3 special-tx cut
+/// (mempool.hpp exclude_special, tx.type != 0) cannot catch it: the tx IS
+/// type 0. Pre-fix, such a tx sailed into the template while the committed
+/// root still contained the MN — bad-cbtx-mnmerkleroot on every template
+/// built while the spend sat in the mempool, invisible to every gate (the
+/// SML is current at tip; the removal only exists in the verifier's rebuild
+/// of the block BEING templated).
+///
+/// The fix EXCLUDES the tx from selection (no tx is ever mandatory, so
+/// exclusion is consensus-clean; dashd's own miner folds the removal into
+/// the root instead — larger, deferred). Posture on coverage: the lookup is
+/// the DMN view's UNFILTERED collateral index (banned MNs included, matching
+/// dashd's GetMNByCollateral in this pass); an outpoint the index does not
+/// hold is treated as NOT a collateral — dropping every type-0 tx with any
+/// unknown input would gut template fill.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/embedded_gbt.hpp>
+#include <impl/dash/coin/sml_projection.hpp>
+#include <impl/dash/coin/mn_state_machine.hpp>
+#include <impl/dash/coin/mn_state_db.hpp>
+#include <impl/dash/coin/mempool.hpp>
+#include <impl/dash/coin/node_coin_state.hpp>
+#include <impl/dash/coin/subsidy.hpp>
+#include <impl/dash/coin/transaction.hpp>
+#include <impl/dash/coin/utxo_adapter.hpp>
+#include <impl/dash/coin/vendor/cbtx.hpp>
+#include <impl/dash/coin/vendor/simplifiedmns.hpp>
+
+#include <core/uint256.hpp>
+#include <core/pack.hpp>
+#include <core/hash.hpp>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+using dash::coin::DashWorkData;
+using dash::coin::DeclineReport;
+using dash::coin::MNState;
+using dash::coin::MnStateMachine;
+using dash::coin::Mempool;
+using dash::coin::MutableTransaction;
+using dash::coin::NodeCoinState;
+using dash::coin::build_embedded_workdata;
+using dash::coin::build_embedded_cbtx;
+using dash::coin::encode_cbtx;
+using dash::coin::compute_dash_block_reward_post_v20;
+using dash::coin::tx_spends_mn_collateral;
+using dash::coin::vendor::CSimplifiedMNList;
+using dash::coin::vendor::CSimplifiedMNListEntry;
+using ::core::coin::UTXOViewCache;
+using ::core::coin::Outpoint;
+using ::core::coin::Coin;
+using ::bitcoin_family::coin::TxIn;
+using ::bitcoin_family::coin::TxOut;
+
+static constexpr uint8_t DASH_PUBKEY_VER = 76;
+static constexpr uint8_t DASH_P2SH_VER   = 16;
+static constexpr uint32_t H = 2'400'000;
+
+static uint256 raw256(uint8_t base) {
+    uint256 h;
+    std::array<uint8_t, 32> p{};
+    for (size_t i = 0; i < 32; ++i) p[i] = static_cast<uint8_t>(base + i);
+    std::memcpy(h.data(), p.data(), 32);
+    return h;
+}
+
+static std::vector<unsigned char> p2pkh_script(uint8_t hashseed) {
+    std::vector<unsigned char> s;
+    s.push_back(0x76); s.push_back(0xa9); s.push_back(0x14);
+    for (int i = 0; i < 20; ++i) s.push_back(static_cast<unsigned char>(hashseed + i));
+    s.push_back(0x88); s.push_back(0xac);
+    return s;
+}
+
+static uint256 mint_hash(uint32_t seed) {
+    MutableTransaction t;
+    t.version = 1; t.type = 0;
+    t.locktime = 0x51000000u ^ seed;
+    auto ps = ::pack(t);
+    return ::Hash(ps.get_span());
+}
+
+static MutableTransaction make_spend(const uint256& prev, uint32_t idx,
+                                     int64_t out_value, uint32_t salt) {
+    MutableTransaction tx;
+    tx.version = 1; tx.type = 0; tx.locktime = salt;
+    TxIn in; in.prevout.hash = prev; in.prevout.index = idx;
+    in.sequence = 0xffffffffu;
+    tx.vin.push_back(in);
+    TxOut o; o.value = out_value;
+    tx.vout.push_back(o);
+    return tx;
+}
+
+// One valid payee MN plus one MN whose collateral outpoint is `collat`:
+// the DMN view whose UNFILTERED collateral index the filter consults.
+static MnStateMachine mn_set_with_collateral(const uint256& collat_hash,
+                                             uint32_t collat_index) {
+    MNState payee;
+    payee.isValid = true;
+    payee.nRegisteredHeight = 2'300'000;
+    payee.scriptPayout.m_data = p2pkh_script(0x30);
+    payee.collateralOutpoint.hash  = raw256(0xE0);  // unrelated outpoint
+    payee.collateralOutpoint.index = 0;
+
+    MNState victim;
+    victim.isValid = true;
+    victim.nRegisteredHeight = 2'310'000;
+    victim.scriptPayout.m_data = p2pkh_script(0x40);
+    victim.collateralOutpoint.hash  = collat_hash;
+    victim.collateralOutpoint.index = collat_index;
+
+    MnStateMachine m;
+    m.load({{raw256(0x01), payee}, {raw256(0x02), victim}}, H - 1);
+    return m;
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// FINDING-2 defect demonstration — MUST FAIL on pre-fix master (the
+// collateral-spending type-0 tx was selected and the committed root went
+// stale for every template built while it sat in the mempool).
+// ════════════════════════════════════════════════════════════════════════
+
+TEST(DashCollateralSpendFilter, NormalTxSpendingCollateralExcludedFromTemplate) {
+    UTXOViewCache utxo(nullptr);
+    Mempool mp;
+    mp.set_utxo(&utxo);
+
+    // An innocent fee-paying type-0 tx — MUST be selected.
+    uint256 p0 = mint_hash(0x50);
+    utxo.add_coin(Outpoint(p0, 0), Coin(100'000, {}, /*height=*/1, /*cb=*/false));
+    auto innocent = make_spend(p0, 0, 90'000, /*salt=*/1);   // fee 10'000
+    ASSERT_TRUE(mp.add_tx(innocent));
+
+    // A type-0 tx spending MN collateral raw256(0xC0):0 — UTXO-priced (fee
+    // known, HIGHER feerate than the innocent tx so ordering alone can never
+    // exclude it) — MUST be excluded by the collateral filter.
+    uint256 collat = raw256(0xC0);
+    utxo.add_coin(Outpoint(collat, 0), Coin(100'000'000'000LL, {}, 1, false));
+    auto spender = make_spend(collat, 0, 99'999'950'000LL, /*salt=*/2);  // fee 50'000
+    ASSERT_TRUE(mp.add_tx(spender));
+
+    auto mnstates = mn_set_with_collateral(collat, 0);
+    auto w = build_embedded_workdata(
+        H - 1, raw256(0xAB), mnstates, mp,
+        0x1b104be3u, 1'700'000'000u, DASH_PUBKEY_VER, DASH_P2SH_VER);
+
+    // Only the innocent tx may be in the template.
+    ASSERT_EQ(w.m_txs.size(), 1u)
+        << "the collateral-spending type-0 tx leaked into the template "
+        << "(verifier removes the MN => committed merkleRootMNList is stale)";
+    EXPECT_EQ(w.m_tx_hashes[0], dash::coin::dash_txid(innocent));
+    for (const auto& h : w.m_tx_hashes)
+        EXPECT_NE(h, dash::coin::dash_txid(spender));
+
+    // And its fee must have left the coinbase with it.
+    const int64_t reward = compute_dash_block_reward_post_v20(H);
+    EXPECT_EQ(w.m_coinbase_value, static_cast<uint64_t>(reward + 10'000))
+        << "excluded tx's fee still counted into coinbasevalue";
+}
+
+// Defence in depth: the pre-emit hard gate must reject a template that
+// carries a collateral-spending tx however it got there (cached template,
+// viability bypass). Pre-fix the gate had no such check and the roots
+// matched, so the template passed — this test fails there.
+TEST(DashCollateralSpendFilter, EmitGateRejectsTemplateCarryingCollateralSpend) {
+    uint256 collat = raw256(0xC0);
+    uint256 prev_hash = raw256(0xAB);
+    auto mnstates_seed = mn_set_with_collateral(collat, 0);
+
+    // Fully-confirmed 2-entry SML so the rollover projection is a no-op and
+    // the ONLY defect in the template is the collateral spend.
+    std::vector<CSimplifiedMNListEntry> entries;
+    for (uint8_t b : {0x01, 0x02}) {
+        CSimplifiedMNListEntry e;
+        e.nVersion = CSimplifiedMNListEntry::VER_BASIC_BLS;
+        e.proRegTxHash = raw256(b);
+        e.confirmedHash = raw256(0x77);
+        e.isValid = true;
+        entries.push_back(e);
+    }
+    CSimplifiedMNList sml(std::move(entries));
+
+    NodeCoinState st;
+    st.set_require_sml(true);
+    st.sml() = sml;
+    st.set_have_sml(true);
+    st.set_sml_current_hash(prev_hash);
+    st.mnstates().load(mnstates_seed.snapshot(), H - 1);
+    st.set_tip(H - 1, prev_hash, 0x1b104be3u, 1'700'000'000u,
+               DASH_PUBKEY_VER, DASH_P2SH_VER);
+
+    // Template with correct roots BUT carrying the collateral-spending tx.
+    DashWorkData w;
+    {
+        auto cb = build_embedded_cbtx(H - 1, sml, st.qmgr(),
+                                      0, std::array<uint8_t, 96>{}, 0, nullptr);
+        w.m_coinbase_payload = encode_cbtx(cb);
+    }
+    w.m_txs.emplace_back(make_spend(collat, 0, 99'999'950'000LL, /*salt=*/2));
+
+    DeclineReport why;
+    EXPECT_FALSE(st.embedded_template_emit_ok(w, &why))
+        << "emit gate passed a template whose tx spends a known MN collateral";
+    EXPECT_EQ(why.cause, "emit-collateral-spend-in-template");
+
+    // Same template without the offending tx passes.
+    w.m_txs.clear();
+    EXPECT_TRUE(st.embedded_template_emit_ok(w, &why))
+        << "cause=" << why.cause << " value=" << why.value;
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Predicate unit KATs (structural).
+// ════════════════════════════════════════════════════════════════════════
+
+TEST(DashCollateralSpendFilter, PredicateMatchesExactOutpointOnly) {
+    uint256 collat = raw256(0xC0);
+    auto mnstates = mn_set_with_collateral(collat, /*collat_index=*/1);
+
+    // Exact outpoint (hash AND index) => hit, naming the victim MN.
+    auto hit = make_spend(collat, 1, 1'000, 1);
+    uint256 protx;
+    EXPECT_TRUE(tx_spends_mn_collateral(mnstates, hit, &protx));
+    EXPECT_EQ(protx, raw256(0x02));
+
+    // Same hash, DIFFERENT index => not a collateral spend.
+    auto near_miss = make_spend(collat, 0, 1'000, 2);
+    EXPECT_FALSE(tx_spends_mn_collateral(mnstates, near_miss));
+
+    // Unknown outpoint => "cannot check" posture: NOT excluded.
+    auto unknown = make_spend(mint_hash(0x99), 0, 1'000, 3);
+    EXPECT_FALSE(tx_spends_mn_collateral(mnstates, unknown));
+
+    // Collateral spend buried in a multi-input tx => still a hit.
+    auto multi = make_spend(mint_hash(0x99), 0, 1'000, 4);
+    TxIn in2; in2.prevout.hash = collat; in2.prevout.index = 1;
+    in2.sequence = 0xffffffffu;
+    multi.vin.push_back(in2);
+    EXPECT_TRUE(tx_spends_mn_collateral(mnstates, multi));
+}

--- a/test/test_dash_mn_confirm_rollover.cpp
+++ b/test/test_dash_mn_confirm_rollover.cpp
@@ -1,0 +1,348 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/// confirmedHash rollover (sml_projection.hpp) — the height-driven MN
+/// confirmation pass the verifier applies to EVERY block it connects
+/// (dashcore v23.1.7 specialtxman.cpp:206-215) and the embedded template
+/// builder must therefore project for the block it is templating.
+///
+/// THE DEFECT PINNED HERE (silent block loss, 2508008-shaped): the tip SML
+/// (mnlistdiff-fed, current at prev_hash) is the verifier's PREV list. At the
+/// height where a registered MN crosses nMasternodeMinimumConfirmations, the
+/// verifier's rebuilt list flips that entry's confirmedHash — an SML-hashed
+/// field — with NO transaction causing it, so the committed merkleRootMNList
+/// must differ from the tip root at exactly that height. A builder that
+/// commits the tip root verbatim produces a bad-cbtx-mnmerkleroot block, and
+/// no tip-relative freshness gate can catch it (the tip SML IS current; the
+/// pre-fix emit gate compared against the SAME stale root).
+///
+/// Oracle discipline: the reference root in every test is rebuilt
+/// INDEPENDENTLY — a hand-copied SML with confirmedHash set to prev_hash on
+/// the crossing entry, hashed through the vendored CalcMerkleRoot — never via
+/// the projection helper under test.
+///
+/// The crossing arithmetic (verified against dashcore, NOT assumed):
+/// nConfirmations = pindexPrev->nHeight - nRegisteredHeight, confirm when
+/// >= nMasternodeMinimumConfirmations = 15 on mainnet (chainparams.cpp:177 —
+/// 15, not 16). So an MN registered at R is first confirmed in block R + 16,
+/// with confirmedHash = hash of block R + 15 (the prev block).
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/embedded_gbt.hpp>
+#include <impl/dash/coin/sml_projection.hpp>
+#include <impl/dash/coin/mn_state_machine.hpp>
+#include <impl/dash/coin/mn_state_db.hpp>
+#include <impl/dash/coin/mempool.hpp>
+#include <impl/dash/coin/node_coin_state.hpp>
+#include <impl/dash/coin/quorum_manager.hpp>
+#include <impl/dash/coin/quorum_root.hpp>
+#include <impl/dash/coin/vendor/cbtx.hpp>
+#include <impl/dash/coin/vendor/simplifiedmns.hpp>
+
+#include <core/uint256.hpp>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+using dash::coin::DashWorkData;
+using dash::coin::DeclineReport;
+using dash::coin::MNState;
+using dash::coin::MnStateMachine;
+using dash::coin::Mempool;
+using dash::coin::NodeCoinState;
+using dash::coin::QuorumManager;
+using dash::coin::build_embedded_workdata;
+using dash::coin::build_embedded_cbtx;
+using dash::coin::encode_cbtx;
+using dash::coin::compute_merkle_root_quorums;
+using dash::coin::project_sml_confirmations;
+using dash::coin::find_unprojectable_confirmation;
+using dash::coin::DASH_MN_MIN_CONFIRMATIONS_MAINNET;
+using dash::coin::vendor::CCbTx;
+using dash::coin::vendor::CSimplifiedMNList;
+using dash::coin::vendor::CSimplifiedMNListEntry;
+using dash::coin::vendor::parse_cbtx;
+
+// Dash mainnet base58 version bytes (chainparams.cpp PUBKEY_ADDRESS=76,
+// SCRIPT_ADDRESS=16) — same constants the embedded_gbt capstone tests use.
+static constexpr uint8_t DASH_PUBKEY_VER = 76;
+static constexpr uint8_t DASH_P2SH_VER   = 16;
+
+// Template height well past V20 + MN_RR, matching mainnet steady state.
+static constexpr uint32_t H = 2'400'000;
+
+static uint256 raw256(uint8_t base) {
+    uint256 h;
+    std::array<uint8_t, 32> p{};
+    for (size_t i = 0; i < 32; ++i) p[i] = static_cast<uint8_t>(base + i);
+    std::memcpy(h.data(), p.data(), 32);
+    return h;
+}
+
+static std::vector<unsigned char> p2pkh_script(uint8_t hashseed) {
+    std::vector<unsigned char> s;
+    s.push_back(0x76); s.push_back(0xa9); s.push_back(0x14);
+    for (int i = 0; i < 20; ++i) s.push_back(static_cast<unsigned char>(hashseed + i));
+    s.push_back(0x88); s.push_back(0xac);
+    return s;
+}
+
+static CSimplifiedMNListEntry sml_entry(const uint256& protx,
+                                        const uint256& confirmed) {
+    CSimplifiedMNListEntry e;
+    e.nVersion      = CSimplifiedMNListEntry::VER_BASIC_BLS;
+    e.proRegTxHash  = protx;
+    e.confirmedHash = confirmed;   // uint256() == null == "not yet confirmed"
+    e.netPort       = 9999;
+    e.isValid       = true;
+    return e;
+}
+
+static MNState mn_state(uint32_t reg_height,
+                        const std::vector<unsigned char>& payout) {
+    MNState s;
+    s.isValid            = true;
+    s.nRegisteredHeight  = reg_height;
+    s.nLastPaidHeight    = 0;
+    s.scriptPayout.m_data = payout;
+    return s;
+}
+
+// The fixture every test shares: MN1 long-confirmed, MN2 registered recently
+// (registration height parameterized), both present in the DMN view.
+struct Rig {
+    uint256 protx1 = raw256(0x01);
+    uint256 protx2 = raw256(0x02);
+    uint256 prev_hash = raw256(0xAB);
+    uint32_t prev_height = H - 1;
+    CSimplifiedMNList sml;
+    MnStateMachine mnstates;
+    QuorumManager qmgr;
+    Mempool mempool;
+
+    explicit Rig(uint32_t mn2_reg_height, bool mn2_in_dmn_view = true) {
+        std::vector<CSimplifiedMNListEntry> entries;
+        entries.push_back(sml_entry(protx1, raw256(0x77)));  // confirmed long ago
+        entries.push_back(sml_entry(protx2, uint256()));     // awaiting rollover
+        sml = CSimplifiedMNList(std::move(entries));
+
+        std::vector<std::pair<uint256, MNState>> dmn;
+        dmn.emplace_back(protx1, mn_state(2'300'000, p2pkh_script(0x30)));
+        if (mn2_in_dmn_view)
+            dmn.emplace_back(protx2, mn_state(mn2_reg_height, p2pkh_script(0x44)));
+        mnstates.load(std::move(dmn), prev_height);
+    }
+
+    DashWorkData build() {
+        return build_embedded_workdata(
+            prev_height, prev_hash, mnstates, mempool,
+            /*bits=*/0x1b104be3u, /*mtp=*/1'700'000'000u,
+            DASH_PUBKEY_VER, DASH_P2SH_VER,
+            /*curtime=*/1'700'000'100u, /*version=*/0x20000000u,
+            /*underfill_tripped=*/nullptr,
+            &sml, &qmgr);
+    }
+
+    // INDEPENDENT reference: the list the verifier rebuilds for block
+    // prev_height+1, copied by hand — MN2's confirmedHash set to prev_hash.
+    uint256 reference_root_with_rollover() const {
+        CSimplifiedMNList ref = sml;
+        for (auto& e : ref.mnList)
+            if (e.proRegTxHash == protx2) e.confirmedHash = prev_hash;
+        return ref.CalcMerkleRoot();
+    }
+
+    uint256 tip_root() const {
+        CSimplifiedMNList tip = sml;
+        return tip.CalcMerkleRoot();
+    }
+};
+
+// ════════════════════════════════════════════════════════════════════════
+// FINDING-1 defect demonstrations — these MUST FAIL on pre-fix master
+// (the builder committed the tip root verbatim; the emit gate re-approved
+// the same stale root).
+// ════════════════════════════════════════════════════════════════════════
+
+// At the crossing height (prev - reg == 15 >= nMasternodeMinimumConfirmations
+// = 15) the committed merkleRootMNList must be the PROJECTED root, not the
+// tip root.
+TEST(DashMnConfirmRollover, CrossingHeightCommitsProjectedRoot) {
+    Rig rig(/*mn2_reg_height=*/H - 1 - DASH_MN_MIN_CONFIRMATIONS_MAINNET);
+    auto w = rig.build();
+
+    CCbTx cb;
+    ASSERT_TRUE(parse_cbtx(w.m_coinbase_payload, cb));
+    const uint256 expected = rig.reference_root_with_rollover();
+    ASSERT_NE(expected, rig.tip_root())
+        << "fixture defect: rollover must change the root or the test proves nothing";
+    EXPECT_EQ(cb.merkleRootMNList, expected)
+        << "block " << H << " must commit the confirmation-pass-projected root "
+        << "(specialtxman.cpp:206-215), not the tip SML root";
+}
+
+// One block BEFORE the crossing (prev - reg == 14 < 15) nothing confirms and
+// the tip root is exactly right — the projection must not over-fire.
+TEST(DashMnConfirmRollover, BelowThresholdCommitsTipRootUnchanged) {
+    Rig rig(/*mn2_reg_height=*/H - DASH_MN_MIN_CONFIRMATIONS_MAINNET);
+    auto w = rig.build();
+
+    CCbTx cb;
+    ASSERT_TRUE(parse_cbtx(w.m_coinbase_payload, cb));
+    EXPECT_EQ(cb.merkleRootMNList, rig.tip_root())
+        << "below the threshold no confirmation fires; the tip root is correct";
+}
+
+// The pre-emit hard gate must REJECT a template that committed the stale tip
+// root at a crossing height, and ACCEPT one committing the projected root.
+// Pre-fix the gate compared against the SAME stale tip root, so the stale
+// template passed — this test fails there.
+TEST(DashMnConfirmRollover, EmitGateRejectsStaleTipRootAtCrossing) {
+    Rig rig(/*mn2_reg_height=*/H - 1 - DASH_MN_MIN_CONFIRMATIONS_MAINNET);
+
+    NodeCoinState st;
+    st.set_require_sml(true);
+    st.sml() = rig.sml;
+    st.set_have_sml(true);
+    st.set_sml_current_hash(rig.prev_hash);
+    st.mnstates().load({{rig.protx1, mn_state(2'300'000, p2pkh_script(0x30))},
+                        {rig.protx2, mn_state(H - 1 - DASH_MN_MIN_CONFIRMATIONS_MAINNET,
+                                              p2pkh_script(0x44))}},
+                       rig.prev_height);
+    st.set_tip(rig.prev_height, rig.prev_hash, 0x1b104be3u, 1'700'000'000u,
+               DASH_PUBKEY_VER, DASH_P2SH_VER);
+
+    // A template whose CbTx commits the RAW TIP root (build_embedded_cbtx is
+    // the raw encoder — no projection — so this reproduces the pre-fix
+    // builder's output byte-for-byte).
+    DashWorkData stale;
+    {
+        CCbTx cb = build_embedded_cbtx(rig.prev_height, rig.sml, st.qmgr(),
+                                       0, std::array<uint8_t, 96>{}, 0, nullptr);
+        stale.m_coinbase_payload = encode_cbtx(cb);
+    }
+    DeclineReport why;
+    EXPECT_FALSE(st.embedded_template_emit_ok(stale, &why))
+        << "the emit gate re-approved the stale tip root at a crossing height";
+    EXPECT_EQ(why.cause, "emit-mnlist-root-drift");
+
+    // The projected-root template must pass the same gate.
+    DashWorkData good;
+    {
+        CSimplifiedMNList projected = rig.sml;
+        for (auto& e : projected.mnList)
+            if (e.proRegTxHash == rig.protx2) e.confirmedHash = rig.prev_hash;
+        CCbTx cb = build_embedded_cbtx(rig.prev_height, projected, st.qmgr(),
+                                       0, std::array<uint8_t, 96>{}, 0, nullptr);
+        good.m_coinbase_payload = encode_cbtx(cb);
+    }
+    EXPECT_TRUE(st.embedded_template_emit_ok(good, &why))
+        << "cause=" << why.cause << " value=" << why.value;
+}
+
+// Fail-closed fallback (posture (b)): an SML entry awaiting rollover whose
+// registration height the DMN view does NOT hold makes the pass
+// unprojectable — viability must refuse with the NAMED cause instead of
+// serving a root it cannot verify. Pre-fix the bundle was fully viable here.
+TEST(DashMnConfirmRollover, ViabilityFailsClosedWhenRegistrationHeightUnknown) {
+    Rig rig(/*mn2_reg_height=*/0, /*mn2_in_dmn_view=*/false);
+
+    NodeCoinState st;
+    st.set_require_sml(true);
+    st.sml() = rig.sml;
+    st.set_have_sml(true);
+    st.set_sml_current_hash(rig.prev_hash);
+    st.mnstates().load({{rig.protx1, mn_state(2'300'000, p2pkh_script(0x30))}},
+                       rig.prev_height);
+    st.set_tip(rig.prev_height, rig.prev_hash, 0x1b104be3u, 1'700'000'000u,
+               DASH_PUBKEY_VER, DASH_P2SH_VER);
+
+    const DeclineReport d = st.describe_decline();
+    EXPECT_FALSE(d.viable)
+        << "an unprojectable rollover must refuse the embedded arm";
+    EXPECT_EQ(d.cause, "mn-confirm-rollover-pending");
+
+    // And the pre-emit gate independently refuses the same condition.
+    DashWorkData w;
+    {
+        CCbTx cb = build_embedded_cbtx(rig.prev_height, rig.sml, st.qmgr(),
+                                       0, std::array<uint8_t, 96>{}, 0, nullptr);
+        w.m_coinbase_payload = encode_cbtx(cb);
+    }
+    DeclineReport why;
+    EXPECT_FALSE(st.embedded_template_emit_ok(w, &why));
+    EXPECT_EQ(why.cause, "emit-mn-confirm-rollover-pending");
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Projection-helper unit KATs (structural — pin the pass semantics).
+// ════════════════════════════════════════════════════════════════════════
+
+TEST(DashMnConfirmRollover, ProjectionConfirmsAtExactThresholdOnly) {
+    // Exactly at threshold: confirms with confirmedHash = prev_hash.
+    {
+        Rig rig(H - 1 - DASH_MN_MIN_CONFIRMATIONS_MAINNET);
+        auto proj = project_sml_confirmations(rig.sml, rig.prev_height,
+                                              rig.prev_hash, rig.mnstates);
+        ASSERT_TRUE(proj.ok);
+        EXPECT_EQ(proj.confirmed, 1u);
+        EXPECT_EQ(proj.sml.CalcMerkleRoot(), rig.reference_root_with_rollover());
+        // Already-confirmed entry untouched.
+        for (const auto& e : proj.sml.mnList)
+            if (e.proRegTxHash == rig.protx1)
+                EXPECT_EQ(e.confirmedHash, raw256(0x77));
+    }
+    // One short of threshold: nothing confirms, list byte-identical.
+    {
+        Rig rig(H - DASH_MN_MIN_CONFIRMATIONS_MAINNET);
+        auto proj = project_sml_confirmations(rig.sml, rig.prev_height,
+                                              rig.prev_hash, rig.mnstates);
+        ASSERT_TRUE(proj.ok);
+        EXPECT_EQ(proj.confirmed, 0u);
+        EXPECT_EQ(proj.sml.CalcMerkleRoot(), rig.tip_root());
+    }
+    // WELL past threshold with a still-null confirmedHash (desynced-view
+    // shape): the verifier's pass confirms at the NEXT rebuild regardless —
+    // mirror it exactly (>=, not ==).
+    {
+        Rig rig(H - 100);
+        auto proj = project_sml_confirmations(rig.sml, rig.prev_height,
+                                              rig.prev_hash, rig.mnstates);
+        ASSERT_TRUE(proj.ok);
+        EXPECT_EQ(proj.confirmed, 1u);
+    }
+}
+
+TEST(DashMnConfirmRollover, ProjectionFailsClosedOnUnknownRegistration) {
+    // Entry absent from the DMN view entirely.
+    {
+        Rig rig(0, /*mn2_in_dmn_view=*/false);
+        EXPECT_TRUE(find_unprojectable_confirmation(rig.sml, rig.mnstates)
+                        .has_value());
+        auto proj = project_sml_confirmations(rig.sml, rig.prev_height,
+                                              rig.prev_hash, rig.mnstates);
+        EXPECT_FALSE(proj.ok);
+        EXPECT_EQ(proj.unprojectable_protx, rig.protx2);
+    }
+    // Present but with the 0 "never" sentinel for registration height.
+    {
+        Rig rig(/*mn2_reg_height=*/0, /*mn2_in_dmn_view=*/true);
+        EXPECT_TRUE(find_unprojectable_confirmation(rig.sml, rig.mnstates)
+                        .has_value());
+        EXPECT_FALSE(project_sml_confirmations(rig.sml, rig.prev_height,
+                                               rig.prev_hash, rig.mnstates)
+                         .ok);
+    }
+    // Fully-confirmed lists never consult registration heights at all.
+    {
+        Rig rig(H - 100);
+        for (auto& e : rig.sml.mnList) e.confirmedHash = raw256(0x77);
+        MnStateMachine empty;
+        EXPECT_FALSE(find_unprojectable_confirmation(rig.sml, empty)
+                         .has_value());
+        EXPECT_TRUE(project_sml_confirmations(rig.sml, rig.prev_height,
+                                              rig.prev_hash, empty)
+                        .ok);
+    }
+}


### PR DESCRIPTION
Two silent block-loss defects in the embedded DASH template builder, found by auditing dashcore v23.1.7 `evo/specialtxman.cpp` against our committed `merkleRootMNList`. Both make the CbTx commit a root the verifier rejects (`bad-cbtx-mnmerkleroot`) with **no gate firing** — a winning share at an affected height is a lost block, the 2508008-shaped loss class. DASH lane only; correctness fixes on the money path, smallest-safe cut chosen for both.

## Finding 1 — confirmedHash rollover (deterministic; ~1 poisoned height per MN registration)

dashd's verifier rebuilds the MN list for EVERY block starting with a purely height-driven confirmation pass (`specialtxman.cpp:206-215`): for each MN with a null `confirmedHash`, `nConfirmations = pindexPrev->nHeight - nRegisteredHeight`, and at `>= nMasternodeMinimumConfirmations` it applies `UpdateConfirmedHash(proTxHash, pindexPrev->GetBlockHash())`. `confirmedHash` IS an SML-hashed entry field, so the root block N must commit differs from the **tip** SML root at exactly the crossing height — with no transaction causing it. We committed the tip root verbatim (`embedded_gbt.hpp`), and the pre-emit gate compared against the SAME stale root, so nothing could fire: `dmn-stale` passes (the SML is genuinely current at tip).

**Threshold verified from source, not assumed:** mainnet `nMasternodeMinimumConfirmations = 15` (`chainparams.cpp:177`), testnet/devnet/regtest = 1 (`:376/:549/:780`). An MN registered at R is first confirmed in block R+16, with `confirmedHash` = hash of block R+15.

**Fix (option (a) with (b) as fallback posture):** new `src/impl/dash/coin/sml_projection.hpp` replicates the pass exactly — `project_sml_confirmations()` copies the tip SML and, for every null-`confirmedHash` entry whose registration height the DMN view holds, applies the `>=` crossing rule with `confirmedHash = prev_hash`. Registration heights are already available on both feed paths: live ProRegTx applies stamp `nRegisteredHeight` exactly (`mn_state_machine.hpp`), and the `protx list registered true` seed carries dashd's own `registeredHeight` (`mn_seed.hpp`). The builder commits the projected root; the emit gate independently re-derives the projected root instead of the tip root.

**Fail-closed fallback (b):** when a null-`confirmedHash` entry has NO known registration height (absent from the DMN view, or the 0/UINT32_MAX "never" sentinel), the pass is unprojectable — viability refuses with the named cause `mn-confirm-rollover-pending` and the emit gate refuses with `emit-mn-confirm-rollover-pending`. The refusal window is bounded: at most ~`nMasternodeMinimumConfirmations` blocks per unknown registration.

`nMasternodeMinimumConfirmations` is threaded per-network like `mn_rr_height` (`NodeCoinState::set_mn_min_confirmations`, wired in `main_dash.cpp` next to `set_mn_rr_height`; mainnet default keeps every existing caller byte-unchanged).

## Finding 2 — collateral spends by normal txs (rare; poisons ALL templates while present)

The verifier's collateral pass runs over ALL block txs with **no special-tx guard** (`specialtxman.cpp:457-464`): a plain type-0 tx spending a 1000-DASH MN collateral forces `RemoveMN` for that block, changing the committed root. Our C-3 mempool filter (`exclude_special`, `tx.type != 0`) cannot catch it.

**Fix (exclusion, not folding):** the builder drops any selected tx that spends a known MN collateral (`tx_spends_mn_collateral`, with its fee following it out of `coinbasevalue`). No tx is ever mandatory in a block, so exclusion is consensus-clean; dashd's miner folds the removal into the root instead, but that is a second root computation with its own wrongness budget — deferred deliberately. The emit gate re-checks the predicate as defence in depth (`emit-collateral-spend-in-template`) so a cached/bypassed template can never reach a miner.

**Coverage posture (documented in `sml_projection.hpp`):** the lookup is `MnStateMachine::find_by_collateral` — the UNFILTERED collateral index (banned MNs included, matching dashd's `GetMNByCollateral` in this pass). The index covers every entry the DMN view holds: live ProRegTx applies resolve the outpoint exactly (incl. the null-hash "own output" form) and the protx-list seed carries `collateralHash`/`collateralIndex`. An outpoint the index does not hold is treated as **not** a collateral — dropping every type-0 tx with any unknown input would gut template fill. The residual exposure (an MN present in the SML but absent from the DMN view) already fails closed via the #996 payee-resolution and freshness gates. The gov-lane helper `gov_mn_by_collateral` (`coin_state_maintainer.hpp`) resolves through this same index, so no second index was added.

## Phase-L landmine filed (comment, not code)

`specialtxman.cpp:159-174` PoSe-punishes `!validMembers[i]` when a REAL commitment is in the block, which can flip `isValid` and change the SAME block's `merkleRootMNList`; null commitments are exempt (`:432`), so today's all-null qc plans are safe. A loud comment now sits at the type-6 commitment-inclusion site in `build_embedded_workdata` requiring the PoSe fold to land WITH real-commitment serving.

## Tests — verified to fail on pre-fix sources (MEASURED)

`test/test_dash_mn_confirm_rollover.cpp` + `test/test_dash_collateral_spend_filter.cpp`, folded into the already-allowlisted `test_dash_embedded_gbt` target (per the in-tree #769 rule: a standalone target not in the build.yml `--target` allowlist becomes a NOT_BUILT sentinel; `tools/ci/check_test_target_allowlist.py` passes — 229 targets, no new one). Reference roots are rebuilt independently in the tests (hand-copied SML + vendored `CalcMerkleRoot`), never via the helper under test.

Verified by building this branch with the source fixes stashed (tests + inert helper only — bit-identical builder/gate behavior to master):

| Test | pre-fix | post-fix |
|---|---|---|
| CrossingHeightCommitsProjectedRoot | **FAILED** | OK |
| EmitGateRejectsStaleTipRootAtCrossing | **FAILED** | OK |
| ViabilityFailsClosedWhenRegistrationHeightUnknown | **FAILED** | OK |
| NormalTxSpendingCollateralExcludedFromTemplate | **FAILED** | OK |
| EmitGateRejectsTemplateCarryingCollateralSpend | **FAILED** | OK |
| BelowThresholdCommitsTipRootUnchanged (negative control) | OK | OK |
| ProjectionConfirmsAtExactThresholdOnly / FailsClosedOnUnknownRegistration / PredicateMatchesExactOutpointOnly (structural) | OK | OK |

With the fixes applied, the full affected-target set is green locally: test_dash_embedded_gbt 118, test_dash_node_coin_state 57, test_dash_work_source 9, test_dash_coin_state_maintainer 19, test_dash_underfill_guard 11, test_dash_get_work 4, test_dash_stratum_work_source 67, test_dash_superblock 26; `c2pool-dash` builds.

## MEASURED vs INFERRED

- MEASURED: the dashd verifier semantics (read from v23.1.7 source, cited by line), the mainnet threshold value 15, the pre-fix test failures and post-fix passes above.
- INFERRED (not measured): mainnet event frequency — MN registrations on the order of a few per day, each poisoning exactly one height (the crossing height); collateral spends of active MNs rare, but each poisons every template built while the tx sits in the mempool.
