### PR TITLE
dash: UTXO-immature window -- default refuses (p2pool semantics); opt-in coinbase-only serving for pure-daemonless nodes

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -259,6 +259,7 @@ void print_banner(const char* argv0)
         << "           [--web-port PORT] [--web-host ADDR] [--dashboard-dir PATH]\n"
         << "           [--external-ip ADDR]\n"
         << "           [--embedded-utxo] [--embedded-mainnet] [--embedded-mn-bridge-max N]\n"
+        << "           [--embedded-utxo-immature-refuse]\n"
         << "           [--bestcl-policy freshness|consensus-exact]\n"
         << "           [--embedded-oracle-shadow]\n"
         << "           [--oracle-graduation-blocks N] [--oracle-class-coverage K]\n"
@@ -537,7 +538,12 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              // geometrically in this number (see p2p_client.hpp).
              std::size_t coin_p2p_peers =
                  dash::coin::p2p::CoinClient<dash::Config>::DEFAULT_POOL_PEERS,
-             const std::string& bestcl_policy = "freshness")
+             const std::string& bestcl_policy = "freshness",
+             // --embedded-utxo-immature-refuse: true restores the pre-existing
+             // refuse-until-blocks_connected>=106 posture. Default false serves
+             // the immature window with a coinbase-only (empty mempool tx set)
+             // template -- consensus-valid, fees exactly 0, nothing to overstate.
+             bool embedded_utxo_immature_refuse = false)
 {
     namespace io = boost::asio;
 
@@ -1617,6 +1623,19 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             // spends. The dashd fallback is unaffected.
             node_coin_state.set_utxo_ready_fn(
                 [&utxo_lane]() { return utxo_lane.mining_utxo_ready(); });
+            // What the arm DOES during that window. Default (flag absent):
+            // SERVE it with a coinbase-only body rather than refuse outright.
+            // Consensus never requires a mempool tx, so a tx-free block is
+            // valid; with zero txs the fee term is exactly 0, so the subsidy,
+            // MN payment and creditPool this template commits are all exact and
+            // the bad-cb-amount risk the gate existed to prevent is absent by
+            // construction rather than merely improbable. The trade is the
+            // forgone fees, which the builder reports on every such template.
+            // --embedded-utxo-immature-refuse restores the old posture.
+            node_coin_state.set_utxo_immature_policy(
+                embedded_utxo_immature_refuse
+                    ? dash::coin::UtxoImmaturePolicy::Refuse
+                    : dash::coin::UtxoImmaturePolicy::ServeEmptyTxSet);
             utxo_block_sub = coin_state.block_connected.subscribe(
                 [&utxo_lane](const dash::interfaces::BlockConnected& bc) {
                     utxo_lane.on_block_connected(bc.block, bc.height);
@@ -1625,7 +1644,11 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                       << " best_height=" << utxo_lane.cache()->get_best_height()
                       << " (mempool fee pricing live; block feed = E1/E2a leg;"
                          " maturity gate " << dash::coin::DASH_MINING_GATE_DEPTH
-                      << " blocks)\n";
+                      << " blocks, immature-window policy="
+                      << (embedded_utxo_immature_refuse
+                              ? "REFUSE (dashd fallback for the whole window)"
+                              : "SERVE-EMPTY-TXSET (coinbase-only, fees=0)")
+                      << ")\n";
         } else {
             std::cout << "[run] embedded UTXO/fee lane FAILED to open " << utxo_path
                       << " -- fees stay unknown; dashd-RPC fallback unaffected\n";
@@ -3953,7 +3976,13 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                   << ") + CoinStateMaintainer + 6 ingest subscriptions;"
                      " populate flips get_work to the EMBEDDED arm once the tip"
                      " (headers) AND the DMN set (block-connect apply_block) are"
-                     " present" << (embedded_utxo ? " + UTXO maturity>=106" : "")
+                     " present"
+                  << (embedded_utxo
+                          ? (embedded_utxo_immature_refuse
+                                 ? " + UTXO maturity>=106"
+                                 : " (UTXO immaturity serves coinbase-only, not"
+                                   " a refusal)")
+                          : "")
                   << "\n";
 
         // ── E2c (#738): RPC MN-set SEED — flip the DMN half of populated() ──
@@ -4963,6 +4992,13 @@ int main(int argc, char** argv)
     std::string stratum_host = "0.0.0.0";      // --stratum [HOST:]PORT bind interface (default all)
     uint16_t    stratum_port = 0;              // 0 disables the Stratum accept-loop; --stratum sets it
     bool embedded_utxo = false;                // --embedded-utxo: arm the E2b UTXO/fee lane (opt-in)
+    // --embedded-utxo-immature-refuse: restore the pre-existing CONSERVATIVE
+    // posture -- refuse EVERY embedded template until the UTXO lane reaches
+    // blocks_connected >= 106 (~4.4 h of a cold start served by dashd only).
+    // Default OFF: the immature window is served with a coinbase-only body,
+    // which is consensus-valid and cannot overstate a fee (see
+    // NodeCoinState::set_utxo_immature_policy).
+    bool embedded_utxo_immature_refuse = false;
     std::string bestcl_policy = "freshness";   // --bestcl-policy: freshness (default, conservative proxy) | consensus-exact (dashcore's actual CheckCbTxBestChainlock rule)
     bool embedded_oracle_shadow = false;       // --embedded-oracle-shadow: per-block dashd cross-check (OBSERVE-only)
     uint64_t oracle_grad_blocks = 5000;        // --oracle-graduation-blocks N (consecutive clean)
@@ -5041,6 +5077,8 @@ int main(int argc, char** argv)
             embedded_superblock = true;
         else if (std::strcmp(argv[i], "--embedded-utxo") == 0)
             embedded_utxo = true;
+        else if (std::strcmp(argv[i], "--embedded-utxo-immature-refuse") == 0)
+            embedded_utxo_immature_refuse = true;
         else if (std::strcmp(argv[i], "--bestcl-policy") == 0 && i + 1 < argc)
             bestcl_policy = argv[++i];
         else if (std::strcmp(argv[i], "--coinbase-text") == 0 && i + 1 < argc)
@@ -5196,7 +5234,8 @@ int main(int argc, char** argv)
                         coin_p2p_magic, force_won_block,
                         operator_message_blob_hex, embedded_superblock,
                         embedded_oracle_shadow, oracle_grad_blocks,
-                        oracle_class_coverage, coin_p2p_peers, bestcl_policy);
+                        oracle_class_coverage, coin_p2p_peers, bestcl_policy,
+                        embedded_utxo_immature_refuse);
     }
     return run_selftest();
 }

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -259,7 +259,7 @@ void print_banner(const char* argv0)
         << "           [--web-port PORT] [--web-host ADDR] [--dashboard-dir PATH]\n"
         << "           [--external-ip ADDR]\n"
         << "           [--embedded-utxo] [--embedded-mainnet] [--embedded-mn-bridge-max N]\n"
-        << "           [--embedded-utxo-immature-refuse]\n"
+        << "           [--embedded-utxo-immature-serve-empty]\n"
         << "           [--bestcl-policy freshness|consensus-exact]\n"
         << "           [--embedded-oracle-shadow]\n"
         << "           [--oracle-graduation-blocks N] [--oracle-class-coverage K]\n"
@@ -539,11 +539,13 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              std::size_t coin_p2p_peers =
                  dash::coin::p2p::CoinClient<dash::Config>::DEFAULT_POOL_PEERS,
              const std::string& bestcl_policy = "freshness",
-             // --embedded-utxo-immature-refuse: true restores the pre-existing
-             // refuse-until-blocks_connected>=106 posture. Default false serves
-             // the immature window with a coinbase-only (empty mempool tx set)
-             // template -- consensus-valid, fees exactly 0, nothing to overstate.
-             bool embedded_utxo_immature_refuse = false)
+             // --embedded-utxo-immature-serve-empty: pure-daemonless OPT-IN --
+             // during the blocks_connected<106 window serve a coinbase-only
+             // (empty mempool tx set) template: consensus-valid, fees exactly 0,
+             // nothing to overstate. Default false = REFUSE the window (p2pool
+             // semantics: an unsynced node does not serve templates; the dashd
+             // fallback serves full ones where armed) -- the pre-policy behaviour.
+             bool embedded_utxo_immature_serve_empty = false)
 {
     namespace io = boost::asio;
 
@@ -1624,18 +1626,20 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             node_coin_state.set_utxo_ready_fn(
                 [&utxo_lane]() { return utxo_lane.mining_utxo_ready(); });
             // What the arm DOES during that window. Default (flag absent):
-            // SERVE it with a coinbase-only body rather than refuse outright.
-            // Consensus never requires a mempool tx, so a tx-free block is
-            // valid; with zero txs the fee term is exactly 0, so the subsidy,
-            // MN payment and creditPool this template commits are all exact and
-            // the bad-cb-amount risk the gate existed to prevent is absent by
-            // construction rather than merely improbable. The trade is the
-            // forgone fees, which the builder reports on every such template.
-            // --embedded-utxo-immature-refuse restores the old posture.
+            // REFUSE -- p2pool semantics, the project design law: an unsynced
+            // node does not serve block templates; miners idling is correct,
+            // and where the dashd fallback is armed it serves FULL templates
+            // for the whole window. --embedded-utxo-immature-serve-empty is
+            // the pure-daemonless opt-in: serve a coinbase-only body instead
+            // (consensus never requires a mempool tx; with zero txs the fee
+            // term is exactly 0, so the subsidy, MN payment and creditPool the
+            // template commits are all exact -- nothing to overstate). The
+            // trade is the forgone fees, which the builder reports on every
+            // such template.
             node_coin_state.set_utxo_immature_policy(
-                embedded_utxo_immature_refuse
-                    ? dash::coin::UtxoImmaturePolicy::Refuse
-                    : dash::coin::UtxoImmaturePolicy::ServeEmptyTxSet);
+                embedded_utxo_immature_serve_empty
+                    ? dash::coin::UtxoImmaturePolicy::ServeEmptyTxSet
+                    : dash::coin::UtxoImmaturePolicy::Refuse);
             utxo_block_sub = coin_state.block_connected.subscribe(
                 [&utxo_lane](const dash::interfaces::BlockConnected& bc) {
                     utxo_lane.on_block_connected(bc.block, bc.height);
@@ -1645,9 +1649,9 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                       << " (mempool fee pricing live; block feed = E1/E2a leg;"
                          " maturity gate " << dash::coin::DASH_MINING_GATE_DEPTH
                       << " blocks, immature-window policy="
-                      << (embedded_utxo_immature_refuse
-                              ? "REFUSE (dashd fallback for the whole window)"
-                              : "SERVE-EMPTY-TXSET (coinbase-only, fees=0)")
+                      << (embedded_utxo_immature_serve_empty
+                              ? "SERVE-EMPTY-TXSET (opt-in: coinbase-only, fees=0)"
+                              : "REFUSE (default: dashd fallback for the whole window)")
                       << ")\n";
         } else {
             std::cout << "[run] embedded UTXO/fee lane FAILED to open " << utxo_path
@@ -3978,10 +3982,10 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                      " (headers) AND the DMN set (block-connect apply_block) are"
                      " present"
                   << (embedded_utxo
-                          ? (embedded_utxo_immature_refuse
-                                 ? " + UTXO maturity>=106"
-                                 : " (UTXO immaturity serves coinbase-only, not"
-                                   " a refusal)")
+                          ? (embedded_utxo_immature_serve_empty
+                                 ? " (UTXO immaturity serves coinbase-only --"
+                                   " opt-in, not a refusal)"
+                                 : " + UTXO maturity>=106")
                           : "")
                   << "\n";
 
@@ -4992,13 +4996,14 @@ int main(int argc, char** argv)
     std::string stratum_host = "0.0.0.0";      // --stratum [HOST:]PORT bind interface (default all)
     uint16_t    stratum_port = 0;              // 0 disables the Stratum accept-loop; --stratum sets it
     bool embedded_utxo = false;                // --embedded-utxo: arm the E2b UTXO/fee lane (opt-in)
-    // --embedded-utxo-immature-refuse: restore the pre-existing CONSERVATIVE
-    // posture -- refuse EVERY embedded template until the UTXO lane reaches
-    // blocks_connected >= 106 (~4.4 h of a cold start served by dashd only).
-    // Default OFF: the immature window is served with a coinbase-only body,
-    // which is consensus-valid and cannot overstate a fee (see
-    // NodeCoinState::set_utxo_immature_policy).
-    bool embedded_utxo_immature_refuse = false;
+    // --embedded-utxo-immature-serve-empty: pure-daemonless OPT-IN. Default
+    // OFF refuses every embedded template until the UTXO lane reaches
+    // blocks_connected >= 106 (p2pool semantics: an unsynced node does not
+    // serve templates; the dashd fallback serves full ones where armed).
+    // With the flag, the immature window is served with a coinbase-only
+    // body instead -- consensus-valid, fees exactly 0, nothing to overstate
+    // (see NodeCoinState::set_utxo_immature_policy).
+    bool embedded_utxo_immature_serve_empty = false;
     std::string bestcl_policy = "freshness";   // --bestcl-policy: freshness (default, conservative proxy) | consensus-exact (dashcore's actual CheckCbTxBestChainlock rule)
     bool embedded_oracle_shadow = false;       // --embedded-oracle-shadow: per-block dashd cross-check (OBSERVE-only)
     uint64_t oracle_grad_blocks = 5000;        // --oracle-graduation-blocks N (consecutive clean)
@@ -5077,8 +5082,8 @@ int main(int argc, char** argv)
             embedded_superblock = true;
         else if (std::strcmp(argv[i], "--embedded-utxo") == 0)
             embedded_utxo = true;
-        else if (std::strcmp(argv[i], "--embedded-utxo-immature-refuse") == 0)
-            embedded_utxo_immature_refuse = true;
+        else if (std::strcmp(argv[i], "--embedded-utxo-immature-serve-empty") == 0)
+            embedded_utxo_immature_serve_empty = true;
         else if (std::strcmp(argv[i], "--bestcl-policy") == 0 && i + 1 < argc)
             bestcl_policy = argv[++i];
         else if (std::strcmp(argv[i], "--coinbase-text") == 0 && i + 1 < argc)
@@ -5235,7 +5240,7 @@ int main(int argc, char** argv)
                         operator_message_blob_hex, embedded_superblock,
                         embedded_oracle_shadow, oracle_grad_blocks,
                         oracle_class_coverage, coin_p2p_peers, bestcl_policy,
-                        embedded_utxo_immature_refuse);
+                        embedded_utxo_immature_serve_empty);
     }
     return run_selftest();
 }

--- a/src/impl/dash/coin/embedded_gbt.hpp
+++ b/src/impl/dash/coin/embedded_gbt.hpp
@@ -165,7 +165,27 @@ inline DashWorkData build_embedded_workdata(
     // (15, dashcore chainparams.cpp:177); testnet/devnet/regtest are 1. Only
     // consulted when the CCbTx seams (sml + qmgr) are supplied. SAFE-ADDITIVE:
     // appended last so every existing positional caller is byte-unchanged.
-    int mn_min_confirmations = DASH_MN_MIN_CONFIRMATIONS_MAINNET)
+    int mn_min_confirmations = DASH_MN_MIN_CONFIRMATIONS_MAINNET,
+    // ── UTXO-IMMATURE SERVING seam ───────────────────────────────────────────
+    // When true, SKIP mempool selection entirely and build a coinbase-only body
+    // (the mandatory type-6 quorum commitments above still ride -- they are
+    // consensus-REQUIRED at a DKG height and carry zero fee, so dropping them
+    // would make the block invalid while keeping none of them costs nothing).
+    //
+    // WHY THIS IS CONSENSUS-SAFE, not a shortcut: consensus never requires any
+    // mempool transaction in a block. With zero selected txs total_fees is
+    // exactly 0, so block_value == subsidy exactly; platform_reward and the
+    // creditPool accrual are height-derived and never touched fees; mn_payment
+    // is a pure function of block_value. Every value this template commits is
+    // therefore EXACT, and exact by the cheapest possible route -- there is no
+    // fee to overstate, so the bad-cb-amount risk the maturity gate exists to
+    // prevent is structurally absent rather than merely unlikely. That matters
+    // here because this builder has no TestBlockValidity equivalent: fee
+    // exactness normally rides entirely on the UTXO lane, and this mode is the
+    // one path that does not depend on it at all.
+    //
+    // Default false => every existing positional caller is byte-unchanged.
+    bool suppress_mempool_txs = false)
 {
     DashWorkData w;
     w.m_height          = prev_height + 1;
@@ -187,8 +207,15 @@ inline DashWorkData build_embedded_workdata(
     // special txs; including one without accounting for it yields bad-cbtx. The
     // safe-minimal cut keeps the embedded block special-tx-free so the creditPool
     // accrual below is exactly the platform-reward term.
+    // suppress_mempool_txs: coinbase-only body, total_fees == 0 exactly. The
+    // mempool is not even consulted for selection (only, below, for the forgone-
+    // fee report), so no partially-warm UTXO view can price anything into this
+    // template.
     auto [selected, total_fees] =
-        mempool.get_sorted_txs_with_fees(MAX_BLOCK_BYTES, /*exclude_special=*/true);
+        suppress_mempool_txs
+            ? std::pair<std::vector<Mempool::SelectedTx>, uint64_t>{{}, 0ull}
+            : mempool.get_sorted_txs_with_fees(MAX_BLOCK_BYTES,
+                                               /*exclude_special=*/true);
     // MN-collateral spend filter (sml_projection.hpp, FINDING-2). The C-3
     // special-tx cut above is NOT sufficient: dashd's verifier removes a
     // masternode from the list when ANY block tx — special or not — spends
@@ -291,7 +318,7 @@ inline DashWorkData build_embedded_workdata(
     // block as normal. Genuinely empty mempools never trip. Mirrors the
     // LTC/DOGE TemplateBuilder guard; additive only — masternode payment /
     // CbTx / superblock projection below is untouched either way.
-    {
+    if (!suppress_mempool_txs) {
         const uint64_t mempool_bytes = static_cast<uint64_t>(mempool.byte_size());
         const uint64_t mempool_fees  = mempool.total_known_fees();
         const bool tripped = underfill_guard_trips(selected_bytes,
@@ -306,6 +333,27 @@ inline DashWorkData build_embedded_workdata(
                         << " sat fees) — near-empty block on a non-empty "
                         << "mempool; template-fill regression, gates cutover.";
         }
+    } else {
+        // ── NAME THE STATE ───────────────────────────────────────────────────
+        // The underfill guard is DELIBERATELY not consulted here: it exists to
+        // catch an UNEXPLAINED near-empty template, and this one is explained.
+        // Letting it fire would train operators to ignore the one line that is
+        // supposed to mean "template-fill regression".
+        //
+        // Instead the mode says its own name, on the template itself and in the
+        // log, with the price attached. A soak greps this to answer both "how
+        // long did the node run coinbase-only" and "what did that cost".
+        const uint64_t mempool_fees = mempool.total_known_fees();
+        w.m_txset_empty_cause  = "utxo-immature-serving";
+        w.m_txset_forgone_fees = mempool_fees;
+        if (underfill_tripped) *underfill_tripped = false;
+        LOG_INFO << "[GBT-EMB] arm=EMBEDDED txset=empty"
+                 << " cause=utxo-immature-serving"
+                 << " h=" << w.m_height
+                 << " mempool_tx=" << mempool.size()
+                 << " forgone_fees<=" << mempool_fees
+                 << " sat (coinbase-only body: subsidy exact, no fee to"
+                    " overstate; a valid block beats no block)";
     }
 
     // Platform Credit Pool burn (DIP-0027): emit OP_RETURN payment

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -75,6 +75,20 @@ enum class ClProvenance { Unknown, ChainCommitted, BlsVerified };
 ///  - ConsensusExact  : require exactly what dashcore requires, no more.
 enum class BestClPolicy { Off, Freshness, ConsensusExact };
 
+/// What the embedded arm does while the UTXO/fee lane is below its maturity
+/// depth (UtxoLane::mining_utxo_ready == false, i.e. blocks_connected < 106).
+/// See set_utxo_immature_policy() for the reasoning and the default.
+///
+///  - ServeEmptyTxSet : DEFAULT. Stay viable and serve a COINBASE-ONLY template.
+///                      Consensus never requires a mempool transaction, so a
+///                      tx-free block is fully valid; with zero txs the fee term
+///                      is exactly 0, so subsidy / MN payment / creditPool are
+///                      all exact and nothing can be overstated.
+///  - Refuse          : the pre-existing posture. Refuse the arm entirely
+///                      ("utxo-immature") and route to the dashd fallback for
+///                      the whole immature window.
+enum class UtxoImmaturePolicy { ServeEmptyTxSet, Refuse };
+
 /// In-process coin-state the running node maintains for LOCAL template
 /// assembly. Non-copyable: it owns a Mempool (itself non-copyable) and is
 /// node-owned, never duplicated. The maintainer mutates mnstates()/mempool()
@@ -322,13 +336,53 @@ public:
 
     /// Coinbase-maturity mining gate (E2b/#738) — the dash analog of the LTC
     /// EmbeddedCoinNode::set_utxo_ready_fn (main_ltc.cpp ~1785-1801). When
-    /// set, embedded-template viability additionally requires the predicate
-    /// (UtxoLane::mining_utxo_ready: blocks_connected >= 106) so templates
-    /// cannot include txs spending immature coinbase outputs; until then
-    /// has_state stays false and get_work routes to the retained dashd
-    /// fallback. Unset (default) preserves the pre-E2b behaviour exactly.
+    /// set, the predicate (UtxoLane::mining_utxo_ready: blocks_connected >= 106)
+    /// reports whether the UTXO view is deep enough to price mempool txs, so a
+    /// template can never include a tx whose fee we cannot compute exactly.
+    ///
+    /// WHAT THE ARM DOES while that predicate is false is set separately by
+    /// set_utxo_immature_policy(): by DEFAULT the arm stays viable and serves a
+    /// COINBASE-ONLY template (fees exactly 0, nothing to overstate); under
+    /// UtxoImmaturePolicy::Refuse it declines ("utxo-immature") and get_work
+    /// routes to the retained dashd fallback for the whole window, which is the
+    /// pre-existing behaviour. Unset (default) leaves both moot: with no
+    /// predicate installed the window does not exist and nothing is suppressed.
     void set_utxo_ready_fn(std::function<bool()> fn) {
         m_utxo_ready_fn = std::move(fn);
+    }
+
+    /// What to do during the immature window the predicate above reports.
+    ///
+    /// ── WHY THE DEFAULT IS ServeEmptyTxSet ───────────────────────────────────
+    /// The original gate refused ANY template until blocks_connected >= 106. At
+    /// ~150 s/block that is ~4.4 hours of every cold start during which the
+    /// embedded arm serves nothing at all. What it was protecting against is
+    /// real but narrow: a template must not include a tx whose fee we cannot
+    /// price exactly, because this builder has no TestBlockValidity equivalent
+    /// and an overstated fee is bad-cb-amount -- a silently lost block.
+    ///
+    /// But refusing the whole template is far stricter than the risk requires.
+    /// Consensus does not require any mempool transaction in a block: a tx-free
+    /// block is valid, and on Dash fees are a small fraction of the subsidy, so
+    /// a coinbase-only block is worth very nearly a full one. Serving with an
+    /// EMPTY tx set removes the fee-overstatement risk STRUCTURALLY (with zero
+    /// txs the fee term is exactly 0 -- there is nothing to overstate) while
+    /// recovering the entire immature window for block production. Every other
+    /// viability gate here -- chain-synced, qc plan, superblock, bestCL, credit
+    /// pool, payee freshness, SML/quorum roots -- is untouched and still has to
+    /// pass, so this changes only WHETHER a tx-less template is servable, never
+    /// any consensus-bearing field of it.
+    ///
+    /// A valid block beats no block; the cost is only the forgone fees, and the
+    /// builder reports those on every such template (m_txset_forgone_fees).
+    ///
+    /// Refuse restores the previous conservative posture exactly, without a
+    /// rebuild (main_dash: --embedded-utxo-immature-refuse).
+    void set_utxo_immature_policy(UtxoImmaturePolicy p) {
+        m_utxo_immature_policy = p;
+    }
+    UtxoImmaturePolicy utxo_immature_policy() const {
+        return m_utxo_immature_policy;
     }
 
     /// Superblock-height guard. On a Dash superblock height the coinbase MUST
@@ -816,6 +870,11 @@ public:
         // block-SUBMIT refusal.
         const bool payee_resolvable =
             !m_require_resolvable_payee || mn_payee_resolvable_at_tip();
+        // Evaluated ONCE here, like qc_ok / sb_ok, and threaded into BOTH the
+        // viability clause and the tx-suppression flag -- so the decision to
+        // serve and the decision about what to serve cannot observe different
+        // answers from the same predicate.
+        const bool utxo_immature = m_utxo_ready_fn && !m_utxo_ready_fn();
         // ── THE decision, and its reason, from ONE evaluation ────────────────
         // dashd's ValidationState idiom (consensus/validation.h:69): the call
         // that returns false is the call that records why. Previously this was
@@ -824,8 +883,16 @@ public:
         // logging — and the two had already drifted (classify_decline never
         // checked payee_resolvable, so a #996 money-path refusal surfaced as
         // "viable-race"). There is now exactly one list.
-        e.decline   = evaluate_viability(qc_ok, sb.ok, payee_resolvable);
+        e.decline   = evaluate_viability(qc_ok, sb.ok, payee_resolvable,
+                                         utxo_immature);
         e.has_state = e.decline.viable;
+        // NAME THE STATE: while the UTXO lane is immature under the serving
+        // policy we DO serve, but only a coinbase-only body. The builder marks
+        // the template (m_txset_empty_cause) and logs the forgone fees, so this
+        // degraded-but-valid mode is never silent.
+        e.suppress_mempool_txs =
+            utxo_immature
+            && m_utxo_immature_policy == UtxoImmaturePolicy::ServeEmptyTxSet;
         if (m_require_resolvable_payee && !payee_resolvable) {
             LOG_WARNING << "[EMBED-GATE] h=" << (m_prev_height + 1)
                         << " REFUSE embedded template: MN payment due but payee"
@@ -929,7 +996,8 @@ private:
     /// the cost on a per-template path and, worse, could observe a different
     /// answer than the one the bundle was built from.
     DeclineReport evaluate_viability(bool qc_ok, bool sb_ok,
-                                     bool payee_resolvable) const {
+                                     bool payee_resolvable,
+                                     bool utxo_immature) const {
         const uint32_t next_h = m_prev_height + 1;
         const std::string tip = std::to_string(m_prev_height);
         auto refuse = [](const char* c, std::string v, std::string t) {
@@ -964,7 +1032,13 @@ private:
         else if (!qc_ok)
             d = refuse("qc-plan-underivable", "nullopt",
                        "derivable-qc-plan@h=" + std::to_string(next_h));
-        else if (m_utxo_ready_fn && !m_utxo_ready_fn())
+        else if (utxo_immature
+                 && m_utxo_immature_policy == UtxoImmaturePolicy::Refuse)
+            // Only the CONSERVATIVE policy refuses here. Under the default
+            // (ServeEmptyTxSet) the immature window is SERVED with a
+            // coinbase-only body -- see set_utxo_immature_policy(); the arm
+            // stays viable and make_embedded_work_inputs sets
+            // suppress_mempool_txs so the builder emits no mempool txs.
             d = refuse("utxo-immature", "utxo_ready=false", "utxo_ready=true");
         else if (!sb_ok)
             d = refuse("superblock-refused", "not-trigger-confident",
@@ -1141,6 +1215,10 @@ private:
     uint256  m_sml_current_hash;              // block hash the SML is current at (ZERO = cold/reorg)
     bool     m_require_sml{false};            // gate viability on have_sml (embedded arm)
     std::function<bool()> m_utxo_ready_fn;   // optional UTXO maturity gate (E2b)
+    // Default SERVES the immature window with an empty tx set (a valid block
+    // beats no block); Refuse restores the pre-existing refuse-until-106
+    // posture without a rebuild. See set_utxo_immature_policy().
+    UtxoImmaturePolicy m_utxo_immature_policy{UtxoImmaturePolicy::ServeEmptyTxSet};
     std::function<bool()> m_chain_synced_fn; // optional ABSOLUTE header-sync gate (never serve a stale tip)
     std::function<bool(uint32_t)> m_is_superblock_fn;  // superblock-height predicate
     // E-SUPERBLOCK: daemonless governance-sourced superblock schedule provider

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -79,14 +79,18 @@ enum class BestClPolicy { Off, Freshness, ConsensusExact };
 /// depth (UtxoLane::mining_utxo_ready == false, i.e. blocks_connected < 106).
 /// See set_utxo_immature_policy() for the reasoning and the default.
 ///
-///  - ServeEmptyTxSet : DEFAULT. Stay viable and serve a COINBASE-ONLY template.
-///                      Consensus never requires a mempool transaction, so a
-///                      tx-free block is fully valid; with zero txs the fee term
-///                      is exactly 0, so subsidy / MN payment / creditPool are
-///                      all exact and nothing can be overstated.
-///  - Refuse          : the pre-existing posture. Refuse the arm entirely
-///                      ("utxo-immature") and route to the dashd fallback for
-///                      the whole immature window.
+///  - Refuse          : DEFAULT — p2pool semantics, the project design law: an
+///                      unsynced node does not serve block templates. Refuse
+///                      the arm ("utxo-immature") and route to the dashd
+///                      fallback (full templates where one is armed) for the
+///                      whole immature window.
+///  - ServeEmptyTxSet : explicit OPT-IN for pure-daemonless deployments with
+///                      no fallback to route to: stay viable and serve a
+///                      COINBASE-ONLY template. Consensus never requires a
+///                      mempool transaction, so a tx-free block is fully
+///                      valid; with zero txs the fee term is exactly 0, so
+///                      subsidy / MN payment / creditPool are all exact and
+///                      nothing can be overstated.
 enum class UtxoImmaturePolicy { ServeEmptyTxSet, Refuse };
 
 /// In-process coin-state the running node maintains for LOCAL template
@@ -341,43 +345,47 @@ public:
     /// template can never include a tx whose fee we cannot compute exactly.
     ///
     /// WHAT THE ARM DOES while that predicate is false is set separately by
-    /// set_utxo_immature_policy(): by DEFAULT the arm stays viable and serves a
-    /// COINBASE-ONLY template (fees exactly 0, nothing to overstate); under
-    /// UtxoImmaturePolicy::Refuse it declines ("utxo-immature") and get_work
-    /// routes to the retained dashd fallback for the whole window, which is the
-    /// pre-existing behaviour. Unset (default) leaves both moot: with no
-    /// predicate installed the window does not exist and nothing is suppressed.
+    /// set_utxo_immature_policy(): by DEFAULT (Refuse -- p2pool semantics, an
+    /// unsynced node does not serve templates) it declines ("utxo-immature")
+    /// and get_work routes to the retained dashd fallback for the whole
+    /// window, the pre-existing behaviour. Under the opt-in
+    /// UtxoImmaturePolicy::ServeEmptyTxSet the arm stays viable and serves a
+    /// COINBASE-ONLY template (fees exactly 0, nothing to overstate). Unset
+    /// (default) leaves both moot: with no predicate installed the window does
+    /// not exist and nothing is suppressed.
     void set_utxo_ready_fn(std::function<bool()> fn) {
         m_utxo_ready_fn = std::move(fn);
     }
 
     /// What to do during the immature window the predicate above reports.
     ///
-    /// ── WHY THE DEFAULT IS ServeEmptyTxSet ───────────────────────────────────
-    /// The original gate refused ANY template until blocks_connected >= 106. At
-    /// ~150 s/block that is ~4.4 hours of every cold start during which the
-    /// embedded arm serves nothing at all. What it was protecting against is
-    /// real but narrow: a template must not include a tx whose fee we cannot
-    /// price exactly, because this builder has no TestBlockValidity equivalent
-    /// and an overstated fee is bad-cb-amount -- a silently lost block.
+    /// ── WHY THE DEFAULT IS Refuse (operator design law, p2pool semantics) ────
+    /// An unsynced node is a node with unverified state, and the project rule --
+    /// stated repeatedly by the operator, and the behaviour p2pool always had --
+    /// is that an unsynced node does not serve block templates. Miners idling is
+    /// the correct posture: cheaper than hashing work the node cannot fully
+    /// stand behind. Where an external dashd fallback is armed, the refusal is
+    /// also strictly better than any degraded serve -- the fallback returns FULL
+    /// templates. So the default refuses ("utxo-immature") for the whole
+    /// blocks_connected < 106 window, exactly as before this policy existed.
     ///
-    /// But refusing the whole template is far stricter than the risk requires.
-    /// Consensus does not require any mempool transaction in a block: a tx-free
-    /// block is valid, and on Dash fees are a small fraction of the subsidy, so
-    /// a coinbase-only block is worth very nearly a full one. Serving with an
-    /// EMPTY tx set removes the fee-overstatement risk STRUCTURALLY (with zero
-    /// txs the fee term is exactly 0 -- there is nothing to overstate) while
-    /// recovering the entire immature window for block production. Every other
-    /// viability gate here -- chain-synced, qc plan, superblock, bestCL, credit
-    /// pool, payee freshness, SML/quorum roots -- is untouched and still has to
-    /// pass, so this changes only WHETHER a tx-less template is servable, never
-    /// any consensus-bearing field of it.
+    /// ── WHY ServeEmptyTxSet EXISTS AS AN OPT-IN ──────────────────────────────
+    /// On a PURE-DAEMONLESS node there is no fallback to route to: the refusal
+    /// costs the whole window (~106 blocks x ~150 s ~= 4.4 h of a cold start)
+    /// with nothing served by anyone. For operators who prefer a subsidy-only
+    /// block over no block, the opt-in serves a COINBASE-ONLY template instead.
+    /// That is consensus-safe by construction: consensus never requires a
+    /// mempool transaction, and with zero selected txs the fee term is exactly
+    /// 0 -- there is nothing to overstate, so the bad-cb-amount risk the
+    /// maturity gate guards (this builder has no TestBlockValidity equivalent;
+    /// fee exactness rides entirely on the UTXO lane) is structurally absent in
+    /// that mode. Every other viability gate -- chain-synced, qc plan,
+    /// superblock, bestCL, credit pool, payee freshness, SML/quorum roots --
+    /// still has to pass either way. The cost is the forgone fees, which the
+    /// builder reports on every such template (m_txset_forgone_fees).
     ///
-    /// A valid block beats no block; the cost is only the forgone fees, and the
-    /// builder reports those on every such template (m_txset_forgone_fees).
-    ///
-    /// Refuse restores the previous conservative posture exactly, without a
-    /// rebuild (main_dash: --embedded-utxo-immature-refuse).
+    /// main_dash: --embedded-utxo-immature-serve-empty selects the opt-in;
+    /// flag absent = Refuse, byte-identical to the pre-policy behaviour.
     void set_utxo_immature_policy(UtxoImmaturePolicy p) {
         m_utxo_immature_policy = p;
     }
@@ -886,10 +894,10 @@ public:
         e.decline   = evaluate_viability(qc_ok, sb.ok, payee_resolvable,
                                          utxo_immature);
         e.has_state = e.decline.viable;
-        // NAME THE STATE: while the UTXO lane is immature under the serving
-        // policy we DO serve, but only a coinbase-only body. The builder marks
-        // the template (m_txset_empty_cause) and logs the forgone fees, so this
-        // degraded-but-valid mode is never silent.
+        // NAME THE STATE: while the UTXO lane is immature under the OPT-IN
+        // serving policy we DO serve, but only a coinbase-only body. The
+        // builder marks the template (m_txset_empty_cause) and logs the
+        // forgone fees, so this degraded-but-valid mode is never silent.
         e.suppress_mempool_txs =
             utxo_immature
             && m_utxo_immature_policy == UtxoImmaturePolicy::ServeEmptyTxSet;
@@ -1034,11 +1042,12 @@ private:
                        "derivable-qc-plan@h=" + std::to_string(next_h));
         else if (utxo_immature
                  && m_utxo_immature_policy == UtxoImmaturePolicy::Refuse)
-            // Only the CONSERVATIVE policy refuses here. Under the default
-            // (ServeEmptyTxSet) the immature window is SERVED with a
-            // coinbase-only body -- see set_utxo_immature_policy(); the arm
-            // stays viable and make_embedded_work_inputs sets
-            // suppress_mempool_txs so the builder emits no mempool txs.
+            // The DEFAULT posture (p2pool semantics: an unsynced node does not
+            // serve templates). Under the opt-in ServeEmptyTxSet policy the
+            // immature window is SERVED with a coinbase-only body instead --
+            // see set_utxo_immature_policy(); the arm stays viable and
+            // make_embedded_work_inputs sets suppress_mempool_txs so the
+            // builder emits no mempool txs.
             d = refuse("utxo-immature", "utxo_ready=false", "utxo_ready=true");
         else if (!sb_ok)
             d = refuse("superblock-refused", "not-trigger-confident",
@@ -1215,10 +1224,11 @@ private:
     uint256  m_sml_current_hash;              // block hash the SML is current at (ZERO = cold/reorg)
     bool     m_require_sml{false};            // gate viability on have_sml (embedded arm)
     std::function<bool()> m_utxo_ready_fn;   // optional UTXO maturity gate (E2b)
-    // Default SERVES the immature window with an empty tx set (a valid block
-    // beats no block); Refuse restores the pre-existing refuse-until-106
-    // posture without a rebuild. See set_utxo_immature_policy().
-    UtxoImmaturePolicy m_utxo_immature_policy{UtxoImmaturePolicy::ServeEmptyTxSet};
+    // Default REFUSES the immature window (p2pool semantics: an unsynced node
+    // does not serve templates) -- byte-identical to the pre-policy behaviour.
+    // ServeEmptyTxSet is the pure-daemonless opt-in (subsidy-only block beats
+    // no block when there is no fallback). See set_utxo_immature_policy().
+    UtxoImmaturePolicy m_utxo_immature_policy{UtxoImmaturePolicy::Refuse};
     std::function<bool()> m_chain_synced_fn; // optional ABSOLUTE header-sync gate (never serve a stale tip)
     std::function<bool(uint32_t)> m_is_superblock_fn;  // superblock-height predicate
     // E-SUPERBLOCK: daemonless governance-sourced superblock schedule provider

--- a/src/impl/dash/coin/rpc_data.hpp
+++ b/src/impl/dash/coin/rpc_data.hpp
@@ -112,6 +112,21 @@ struct DashWorkData {
 
     // RPC round-trip latency (seconds).
     int64_t m_latency{0};
+
+    // ── NON-CONSENSUS diagnostic: "this template's tx set is empty ON PURPOSE"
+    // Empty string = normal template (mempool selection ran as usual). Non-empty
+    // = the embedded builder DELIBERATELY served a coinbase-only body and this
+    // names WHY (currently only "utxo-immature-serving"). Never serialized, never
+    // read by any consensus path -- it exists so the node can SAY it is in the
+    // degraded-but-valid serving mode instead of running there silently, and so a
+    // soak can measure both the duration and the price.
+    //
+    // m_txset_forgone_fees is the mempool's total KNOWN fees at build time: the
+    // upper bound on what a fully-populated template could have collected. It is
+    // an upper bound, not the exact loss (selection also drops unknown-fee,
+    // special, and MN-collateral-spending txs), so read it as "at most this much".
+    std::string m_txset_empty_cause;
+    uint64_t    m_txset_forgone_fees{0};
 };
 
 } // namespace coin

--- a/src/impl/dash/coin/utxo_lane.hpp
+++ b/src/impl/dash/coin/utxo_lane.hpp
@@ -137,11 +137,13 @@ public:
     /// coinbase outputs / misprice a fee. DASH_MINING_GATE_DEPTH = 100 + 6 = 106
     /// (utxo_adapter.hpp; dashcore consensus.h COINBASE_MATURITY).
     ///
-    /// This predicate reports only the DEPTH. On the dash arm it no longer
-    /// implies "serve nothing": NodeCoinState::set_utxo_immature_policy decides
-    /// what to do while it is false, and the default is to serve a coinbase-only
-    /// template (consensus requires no mempool tx; with zero txs the fee term is
-    /// exactly 0). Refusing the whole window cost ~4.4 h of every cold start.
+    /// This predicate reports only the DEPTH. What the arm does while it is
+    /// false is NodeCoinState::set_utxo_immature_policy's decision: the DEFAULT
+    /// refuses the whole window (p2pool semantics -- an unsynced node does not
+    /// serve templates; the dashd fallback serves full ones where armed), and
+    /// the pure-daemonless opt-in serves a coinbase-only template instead
+    /// (consensus requires no mempool tx; with zero txs the fee term is exactly
+    /// 0, so nothing can be overstated).
     bool mining_utxo_ready() const
     {
         if (!m_cache) return false;

--- a/src/impl/dash/coin/utxo_lane.hpp
+++ b/src/impl/dash/coin/utxo_lane.hpp
@@ -132,10 +132,16 @@ public:
     void set_request_block_fn(RequestBlockFn fn) { m_request_fn = std::move(fn); }
 
     /// Coinbase-maturity mining gate (main_ltc.cpp ~1785-1801): embedded
-    /// templates must not be built until the UTXO view is at least
+    /// templates must not INCLUDE MEMPOOL TXS until the UTXO view is at least
     /// coinbase_maturity + reorg-buffer deep, or they may spend immature
-    /// coinbase outputs. DASH_MINING_GATE_DEPTH = 100 + 6 = 106
+    /// coinbase outputs / misprice a fee. DASH_MINING_GATE_DEPTH = 100 + 6 = 106
     /// (utxo_adapter.hpp; dashcore consensus.h COINBASE_MATURITY).
+    ///
+    /// This predicate reports only the DEPTH. On the dash arm it no longer
+    /// implies "serve nothing": NodeCoinState::set_utxo_immature_policy decides
+    /// what to do while it is false, and the default is to serve a coinbase-only
+    /// template (consensus requires no mempool tx; with zero txs the fee term is
+    /// exactly 0). Refusing the whole window cost ~4.4 h of every cold start.
     bool mining_utxo_ready() const
     {
         if (!m_cache) return false;

--- a/src/impl/dash/coin/work_source.hpp
+++ b/src/impl/dash/coin/work_source.hpp
@@ -144,6 +144,14 @@ struct EmbeddedWorkInputs {
     // (viable()==false) so the arm fails closed to dashd instead.
     std::vector<SuperblockPayment>   superblock_payments;
 
+    // UTXO-IMMATURE SERVING (see NodeCoinState::set_utxo_immature_policy). True
+    // while the UTXO/fee lane is still below its maturity depth AND the policy
+    // is ServeEmptyTxSet: the arm stays VIABLE (has_state true) and the builder
+    // emits a coinbase-only body instead of the arm refusing outright. Does not
+    // participate in viable() -- it is not a reason to serve or not serve, only
+    // a statement about WHAT is served.
+    bool                             suppress_mempool_txs{false};
+
     bool viable() const {
         return has_state && mnstates != nullptr && mempool != nullptr;
     }
@@ -218,7 +226,9 @@ inline WorkSelection select_dash_work(
                 emb.superblock_payments.empty() ? nullptr
                                                 : &emb.superblock_payments,
                 // confirmedHash rollover projection threshold (sml_projection.hpp).
-                emb.mn_min_confirmations);
+                emb.mn_min_confirmations,
+                // UTXO-immature serving: coinbase-only body, fees exactly 0.
+                emb.suppress_mempool_txs);
         },
         dashd_fallback);
 }

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -439,7 +439,16 @@ void DASHWorkSource::resource_template_now() const
                      << (sel.source == coin::WorkSource::Embedded
                              ? "EMBEDDED" : "dashd-fallback")
                      << " h=" << sel.work.m_height
-                     << " mn_payee=" << mn_payee;
+                     << " mn_payee=" << mn_payee
+                     // A deliberately coinbase-only template says so ON THE ARM
+                     // LINE, not only in the builder's log: the soak that
+                     // measures serve-rate reads THIS line, and "served" without
+                     // "served WHAT" would hide the fee trade-off entirely.
+                     << (sel.work.m_txset_empty_cause.empty()
+                             ? std::string()
+                             : " txset=empty cause=" + sel.work.m_txset_empty_cause
+                                   + " forgone_fees<="
+                                   + std::to_string(sel.work.m_txset_forgone_fees));
             work_is_embedded = (sel.source == coin::WorkSource::Embedded);
             // ── DEFECT-3: the gate must SAY WHY it refused ──────────────────
             // sel.decline came out of the branch that chose the arm (dashd's

--- a/test/test_dash_embedded_gbt.cpp
+++ b/test/test_dash_embedded_gbt.cpp
@@ -922,11 +922,16 @@ TEST(DashEmbeddedGbt, E2ForgedBlockBodyRefusedDoesNotAdvanceSeed) {
 }
 
 // ════════════════════════════════════════════════════════════════════════════
-// UTXO-IMMATURE SERVING — the coinbase-only template (cold-start serve-rate)
+// UTXO-IMMATURE SERVING — the coinbase-only template (pure-daemonless OPT-IN)
 //
-// The embedded arm used to refuse EVERY template until the UTXO/fee lane had
-// connected 106 blocks — at ~150 s/block, ~4.4 h of every cold start serving
-// nothing. Consensus never requires a mempool transaction in a block, so a
+// The DEFAULT during the UTXO-immature window is to REFUSE (p2pool semantics:
+// an unsynced node does not serve templates — pinned in
+// test_dash_node_coin_state.cpp DefaultRefusesTheImmatureWindowExactlyAsBefore).
+// The suppress_mempool_txs seam exercised here is the explicit opt-in for
+// pure-daemonless nodes with no fallback: serve a coinbase-only template
+// rather than nothing for ~106 blocks (~4.4 h at ~150 s/block).
+//
+// Consensus never requires a mempool transaction in a block, so a
 // coinbase-only template is a fully valid block; and because this builder has
 // no TestBlockValidity equivalent, the decisive property is that with ZERO
 // selected txs the fee term is exactly 0 — there is no fee to overstate, so

--- a/test/test_dash_embedded_gbt.cpp
+++ b/test/test_dash_embedded_gbt.cpp
@@ -920,3 +920,238 @@ TEST(DashEmbeddedGbt, E2ForgedBlockBodyRefusedDoesNotAdvanceSeed) {
     EXPECT_EQ(st.credit_pool_height(), static_cast<int32_t>(H));
     EXPECT_EQ(st.credit_pool(), CP1_real);
 }
+
+// ════════════════════════════════════════════════════════════════════════════
+// UTXO-IMMATURE SERVING — the coinbase-only template (cold-start serve-rate)
+//
+// The embedded arm used to refuse EVERY template until the UTXO/fee lane had
+// connected 106 blocks — at ~150 s/block, ~4.4 h of every cold start serving
+// nothing. Consensus never requires a mempool transaction in a block, so a
+// coinbase-only template is a fully valid block; and because this builder has
+// no TestBlockValidity equivalent, the decisive property is that with ZERO
+// selected txs the fee term is exactly 0 — there is no fee to overstate, so
+// bad-cb-amount is structurally impossible in this mode rather than merely
+// improbable.
+//
+// These pin exactly that: the suppressed template is byte-valid (subsidy exact,
+// CCbTx fields exact, fees exactly zero and never above the normal template),
+// and it SAYS it is running in that mode.
+// ════════════════════════════════════════════════════════════════════════════
+
+// Build one template from a mempool holding a fee-paying tx, with and without
+// suppression, from otherwise IDENTICAL state — so every difference asserted
+// below is attributable to the suppression flag alone.
+namespace {
+struct ImmatureFixture {
+    UTXOViewCache      utxo{nullptr};
+    Mempool            mp;
+    MnStateMachine     mnstates;
+    uint256            prev_hash{raw256(0xAB)};
+    MutableTransaction tx;
+    static constexpr int64_t  FEE  = 10'000;
+    static constexpr uint32_t BITS = 0x1b104be3u;
+    static constexpr uint32_t MTP  = 1'700'000'000u;
+
+    ImmatureFixture() : mnstates(single_mn(p2pkh_script(0x30))) {
+        uint256 prev = mint_hash(77);
+        utxo.add_coin(Outpoint(prev, 0),
+                      Coin(100'000, {}, /*height=*/1, /*cb=*/false));
+        mp.set_utxo(&utxo);
+        tx = make_spend(prev, 0, 100'000 - FEE, /*salt=*/7);
+        EXPECT_TRUE(mp.add_tx(tx));
+    }
+
+    dash::coin::DashWorkData build(bool suppress,
+                                   const CSimplifiedMNList* sml = nullptr,
+                                   const QuorumManager* qmgr = nullptr,
+                                   int64_t credit_pool = 0) const {
+        return build_embedded_workdata(
+            /*prev_height=*/H - 1, prev_hash, mnstates, mp,
+            BITS, MTP, DASH_PUBKEY_VER, DASH_P2SH_VER,
+            /*curtime=*/1'700'000'123u, /*version=*/0x20000000u,
+            /*underfill_tripped=*/nullptr,
+            sml, qmgr,
+            /*best_cl_height=*/0, dash::coin::k_zero_cl_sig, credit_pool,
+            /*qc_commitments=*/nullptr, /*quorum_root_override=*/nullptr,
+            dash::coin::DASH_MN_RR_HEIGHT_MAINNET,
+            /*superblock_payments=*/nullptr,
+            dash::coin::DASH_MN_MIN_CONFIRMATIONS_MAINNET,
+            /*suppress_mempool_txs=*/suppress);
+    }
+};
+}  // namespace
+
+TEST(DashUtxoImmatureServing, SuppressedTemplateIsCoinbaseOnlyWithExactSubsidy) {
+    ImmatureFixture f;
+
+    // Control: without suppression the fee-paying tx IS selected, so the
+    // fixture genuinely has something to lose (a vacuous mempool would make
+    // every assertion below pass for the wrong reason).
+    auto normal = f.build(/*suppress=*/false);
+    ASSERT_EQ(normal.m_txs.size(), 1u);
+    ASSERT_EQ(normal.m_tx_fees[0], static_cast<uint64_t>(ImmatureFixture::FEE));
+
+    auto empty = f.build(/*suppress=*/true);
+
+    // (1) Coinbase-only body.
+    EXPECT_TRUE(empty.m_txs.empty());
+    EXPECT_TRUE(empty.m_tx_fees.empty());
+    EXPECT_TRUE(empty.m_tx_hashes.empty());
+    EXPECT_TRUE(empty.m_tx_data_hex.empty());
+
+    // (2) Value fields exact, recomputed independently from the same
+    //     closed-form formulas dashcore uses. total_fees is exactly 0.
+    const int64_t reward = compute_dash_block_reward_post_v20(H);
+    const int64_t platform_reward =
+        compute_dash_platform_reward_post_v20_mn_rr(H);
+    const int64_t mn_payment =
+        compute_dash_mn_payment_post_v20(reward) - platform_reward;
+    EXPECT_EQ(empty.m_coinbase_value, static_cast<uint64_t>(reward))
+        << "with zero txs the coinbase value must be the bare subsidy";
+    EXPECT_EQ(empty.m_payment_amount, static_cast<uint64_t>(mn_payment));
+
+    // (3) NO fee overstatement — the one failure mode that costs a block
+    //     (bad-cb-amount). The suppressed template must claim strictly LESS
+    //     than the fee-bearing one, never more.
+    EXPECT_LT(empty.m_coinbase_value, normal.m_coinbase_value);
+    EXPECT_EQ(normal.m_coinbase_value - empty.m_coinbase_value,
+              static_cast<uint64_t>(ImmatureFixture::FEE));
+
+    // (4) Payout structure is otherwise untouched: platform burn first, then
+    //     the base58 MN payee.
+    ASSERT_EQ(empty.m_packed_payments.size(), 2u);
+    EXPECT_EQ(empty.m_packed_payments[0].payee, "!6a");
+    EXPECT_EQ(empty.m_packed_payments[0].amount,
+              static_cast<uint64_t>(platform_reward));
+    EXPECT_EQ(empty.m_packed_payments[1].amount,
+              static_cast<uint64_t>(mn_payment));
+    EXPECT_NE(empty.m_packed_payments[1].payee.front(), '!');
+
+    // (5) Header fields unchanged by the mode.
+    EXPECT_EQ(empty.m_height, H);
+    EXPECT_EQ(empty.m_previous_block, f.prev_hash);
+    EXPECT_EQ(empty.m_bits, ImmatureFixture::BITS);
+    EXPECT_EQ(empty.m_mintime, ImmatureFixture::MTP + 1u);
+    EXPECT_EQ(empty.m_version, normal.m_version);
+}
+
+TEST(DashUtxoImmatureServing, SuppressedTemplateNamesItselfAndReportsThePrice) {
+    ImmatureFixture f;
+
+    auto normal = f.build(/*suppress=*/false);
+    EXPECT_TRUE(normal.m_txset_empty_cause.empty())
+        << "a normal template must NOT claim to be deliberately empty";
+    EXPECT_EQ(normal.m_txset_forgone_fees, 0u);
+
+    auto empty = f.build(/*suppress=*/true);
+    // Silence here would hide a real economic trade-off: a soak has to be able
+    // to measure how long the node ran coinbase-only and what it cost.
+    EXPECT_EQ(empty.m_txset_empty_cause, "utxo-immature-serving");
+    EXPECT_EQ(empty.m_txset_forgone_fees, f.mp.total_known_fees());
+    EXPECT_EQ(empty.m_txset_forgone_fees,
+              static_cast<uint64_t>(ImmatureFixture::FEE));
+}
+
+TEST(DashUtxoImmatureServing, SuppressedTemplateCbTxIsByteIdenticalToNormal) {
+    // The CCbTx commits merkleRootMNList / merkleRootQuorums / bestCL* /
+    // creditPoolBalance — NONE of which is a function of transaction fees
+    // (the credit-pool accrual is prev + platformReward, and platformReward is
+    // height-derived). So suppressing the tx set must not move a single CbTx
+    // byte. If a future edit ever couples fees into that payload, this goes red
+    // before it can cost a block.
+    CSimplifiedMNListEntry e1; e1.proRegTxHash = raw256(0x11); e1.isValid = true;
+    CSimplifiedMNListEntry e2; e2.proRegTxHash = raw256(0x22); e2.isValid = true;
+    CSimplifiedMNList sml(std::vector<CSimplifiedMNListEntry>{e1, e2});
+    QuorumManager qmgr;
+    const int64_t CP = 123'456'789LL;
+
+    ImmatureFixture f;
+    auto normal = f.build(/*suppress=*/false, &sml, &qmgr, CP);
+    auto empty  = f.build(/*suppress=*/true,  &sml, &qmgr, CP);
+
+    ASSERT_FALSE(empty.m_coinbase_payload.empty())
+        << "the suppressed template must still carry a REAL type-5 payload";
+    EXPECT_EQ(empty.m_coinbase_payload, normal.m_coinbase_payload)
+        << "fees do not enter the CCbTx; suppression must not move its bytes";
+
+    // …and it parses to the right height + an unchanged credit-pool accrual.
+    CCbTx got;
+    ASSERT_TRUE(parse_cbtx(empty.m_coinbase_payload, got));
+    EXPECT_EQ(got.nHeight, static_cast<int32_t>(H));
+    EXPECT_EQ(got.creditPoolBalance,
+              CP + compute_dash_platform_reward_post_v20_mn_rr(H));
+    CSimplifiedMNList sml_copy = sml;
+    EXPECT_EQ(got.merkleRootMNList, sml_copy.CalcMerkleRoot());
+    EXPECT_EQ(got.merkleRootQuorums, compute_merkle_root_quorums(qmgr));
+}
+
+TEST(DashUtxoImmatureServing, SuppressionDoesNotTripTheUnderfillGuard) {
+    // The underfill guard exists to flag an UNEXPLAINED near-empty template.
+    // This one is explained, and letting the guard fire here would train
+    // operators to ignore the line that is supposed to mean "template-fill
+    // regression".
+    ImmatureFixture f;
+    bool tripped_normal = false;
+    bool tripped_empty  = false;
+
+    build_embedded_workdata(
+        H - 1, f.prev_hash, f.mnstates, f.mp,
+        ImmatureFixture::BITS, ImmatureFixture::MTP,
+        DASH_PUBKEY_VER, DASH_P2SH_VER,
+        1'700'000'123u, 0x20000000u, &tripped_normal);
+
+    build_embedded_workdata(
+        H - 1, f.prev_hash, f.mnstates, f.mp,
+        ImmatureFixture::BITS, ImmatureFixture::MTP,
+        DASH_PUBKEY_VER, DASH_P2SH_VER,
+        1'700'000'123u, 0x20000000u, &tripped_empty,
+        nullptr, nullptr, 0, dash::coin::k_zero_cl_sig, 0,
+        nullptr, nullptr, dash::coin::DASH_MN_RR_HEIGHT_MAINNET,
+        nullptr, dash::coin::DASH_MN_MIN_CONFIRMATIONS_MAINNET,
+        /*suppress_mempool_txs=*/true);
+
+    EXPECT_FALSE(tripped_empty)
+        << "a deliberately coinbase-only template is not an underfill defect";
+    EXPECT_FALSE(tripped_normal)
+        << "control: this fixture's mempool is too small to trip the guard "
+           "either way, so the assertion above is about the mode, not the size";
+}
+
+// End-to-end through the SELECTOR: NodeCoinState's suppression flag must reach
+// build_embedded_workdata. A flag that is set but never threaded would leave
+// the arm serving a normal template off an immature UTXO view — the one
+// dangerous variant.
+TEST(DashUtxoImmatureServing, SelectorThreadsSuppressionIntoTheBuilder) {
+    ImmatureFixture f;
+    dash::coin::EmbeddedWorkInputs e;
+    e.has_state           = true;
+    e.prev_height         = H - 1;
+    e.prev_hash           = f.prev_hash;
+    e.mnstates            = &f.mnstates;
+    e.mempool             = &f.mp;
+    e.bits_for_next       = ImmatureFixture::BITS;
+    e.mtp_at_tip          = ImmatureFixture::MTP;
+    e.address_version     = DASH_PUBKEY_VER;
+    e.address_p2sh_version = DASH_P2SH_VER;
+    e.curtime             = 1'700'000'123u;
+    e.version             = 0x20000000u;
+
+    auto never = []() -> dash::coin::DashWorkData {
+        ADD_FAILURE() << "viable bundle must not reach the dashd fallback";
+        return {};
+    };
+
+    e.suppress_mempool_txs = false;
+    auto sel_normal = dash::coin::select_dash_work(e, never);
+    ASSERT_EQ(sel_normal.source, dash::coin::WorkSource::Embedded);
+    EXPECT_EQ(sel_normal.work.m_txs.size(), 1u);
+
+    e.suppress_mempool_txs = true;
+    auto sel_empty = dash::coin::select_dash_work(e, never);
+    ASSERT_EQ(sel_empty.source, dash::coin::WorkSource::Embedded)
+        << "suppression changes WHAT is served, never WHETHER";
+    EXPECT_TRUE(sel_empty.work.m_txs.empty());
+    EXPECT_EQ(sel_empty.work.m_txset_empty_cause, "utxo-immature-serving");
+    EXPECT_EQ(sel_empty.work.m_coinbase_value,
+              static_cast<uint64_t>(compute_dash_block_reward_post_v20(H)));
+}

--- a/test/test_dash_node_coin_state.cpp
+++ b/test/test_dash_node_coin_state.cpp
@@ -976,13 +976,12 @@ TEST(DashServeGateNamesRefusal, OffCommitmentWindowIsViable) {  // negative twin
     EXPECT_TRUE(st.describe_decline().viable);
 }
 
-TEST(DashServeGateNamesRefusal, UtxoImmatureIsNamedUnderConservativePolicy) {
+TEST(DashServeGateNamesRefusal, UtxoImmatureIsNamed) {
     NodeCoinState st;
     seed_healthy_armed(st);
     st.set_utxo_ready_fn([] { return false; });
-    // The refusal is now a POLICY, not an unconditional gate: only the
-    // conservative posture still declines the whole template.
-    st.set_utxo_immature_policy(dash::coin::UtxoImmaturePolicy::Refuse);
+    // No policy call: refusing IS the default (p2pool semantics — an unsynced
+    // node does not serve templates), byte-identical to the pre-policy gate.
     EXPECT_EQ(st.describe_decline().cause, "utxo-immature");
 }
 
@@ -993,53 +992,33 @@ TEST(DashServeGateNamesRefusal, UtxoMatureIsViable) {          // negative twin
     EXPECT_TRUE(st.describe_decline().viable);
 }
 
-// ════════════════════════════════════════════════════════════════════════════
-// UTXO-IMMATURE SERVING (cold-start serve-rate)
+// ════════════════════════════════════════════════════════════════════════
+// UTXO-IMMATURE SERVING (pure-daemonless OPT-IN)
 //
-// The old gate refused EVERY embedded template until blocks_connected >= 106 —
-// at ~150 s/block, ~4.4 h of every cold start with the embedded arm serving
-// nothing. Consensus never requires a mempool transaction in a block, so a
-// coinbase-only template is fully valid; and with zero txs the fee term is
-// exactly 0, so there is no fee to overstate and the bad-cb-amount risk the
-// gate guarded is structurally absent, not merely unlikely.
+// The DEFAULT during the blocks_connected < 106 window is to REFUSE — p2pool
+// semantics, the operator's design law: an unsynced node has unverified state
+// and does not serve block templates; miners idling is correct, and the dashd
+// fallback serves FULL templates where armed. The first test pins that default
+// exactly.
 //
-// These four pin the new contract: DEFAULT serves (with the tx set suppressed
-// and SAID so), the conservative flag reproduces the old behaviour exactly, and
-// a MATURE lane is never suppressed.
-// ════════════════════════════════════════════════════════════════════════════
+// ServeEmptyTxSet is the explicit opt-in for pure-daemonless nodes with no
+// fallback to route to: serve a coinbase-only template rather than nothing.
+// Consensus never requires a mempool transaction, and with zero txs the fee
+// term is exactly 0 — no fee to overstate, so the bad-cb-amount risk the gate
+// guards is structurally absent in that mode. The remaining tests pin the
+// opt-in contract: it serves, it suppresses the tx set, it SAYS so, and every
+// other gate still refuses.
+// ════════════════════════════════════════════════════════════════════════
 
-TEST(DashUtxoImmatureServing, DefaultServesTheImmatureWindow) {
+TEST(DashUtxoImmatureServing, DefaultRefusesTheImmatureWindowExactlyAsBefore) {
     NodeCoinState st;
     seed_healthy_armed(st);
     st.set_utxo_ready_fn([] { return false; });
     // No policy call at all — this is the shipped default.
-    const auto e = st.make_embedded_work_inputs();
     EXPECT_EQ(st.utxo_immature_policy(),
-              dash::coin::UtxoImmaturePolicy::ServeEmptyTxSet)
-        << "default must be the serving posture; a valid block beats no block";
-    EXPECT_TRUE(e.has_state)
-        << "an immature UTXO lane must no longer cost the whole template";
-    EXPECT_TRUE(e.decline.viable);
-    EXPECT_NE(st.describe_decline().cause, "utxo-immature");
-}
-
-TEST(DashUtxoImmatureServing, ServingModeSuppressesTheMempoolTxSet) {
-    NodeCoinState st;
-    seed_healthy_armed(st);
-    st.set_utxo_ready_fn([] { return false; });
-    const auto e = st.make_embedded_work_inputs();
-    // THE safety property: we serve, but we serve coinbase-only. Without this
-    // bit the arm would build a normal template off an immature UTXO view.
-    EXPECT_TRUE(e.suppress_mempool_txs)
-        << "serving an immature window WITHOUT suppressing the tx set is the "
-           "one variant that could overstate a fee";
-}
-
-TEST(DashUtxoImmatureServing, ConservativePolicyIsExactlyTheOldBehaviour) {
-    NodeCoinState st;
-    seed_healthy_armed(st);
-    st.set_utxo_ready_fn([] { return false; });
-    st.set_utxo_immature_policy(dash::coin::UtxoImmaturePolicy::Refuse);
+              dash::coin::UtxoImmaturePolicy::Refuse)
+        << "the default posture is REFUSE (p2pool semantics: an unsynced node "
+           "does not serve templates)";
     const auto e = st.make_embedded_work_inputs();
     EXPECT_FALSE(e.has_state);
     EXPECT_EQ(e.decline.cause, "utxo-immature");
@@ -1050,10 +1029,41 @@ TEST(DashUtxoImmatureServing, ConservativePolicyIsExactlyTheOldBehaviour) {
         << "a refusing arm serves nothing, so it suppresses nothing";
 }
 
+TEST(DashUtxoImmatureServing, OptInServesTheImmatureWindow) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_utxo_ready_fn([] { return false; });
+    st.set_utxo_immature_policy(
+        dash::coin::UtxoImmaturePolicy::ServeEmptyTxSet);
+    const auto e = st.make_embedded_work_inputs();
+    EXPECT_TRUE(e.has_state)
+        << "under the opt-in, an immature UTXO lane must not cost the whole "
+           "template";
+    EXPECT_TRUE(e.decline.viable);
+    EXPECT_NE(st.describe_decline().cause, "utxo-immature");
+}
+
+TEST(DashUtxoImmatureServing, OptInSuppressesTheMempoolTxSet) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_utxo_ready_fn([] { return false; });
+    st.set_utxo_immature_policy(
+        dash::coin::UtxoImmaturePolicy::ServeEmptyTxSet);
+    const auto e = st.make_embedded_work_inputs();
+    // THE safety property: we serve, but we serve coinbase-only. Without this
+    // bit the arm would build a normal template off an immature UTXO view.
+    EXPECT_TRUE(e.suppress_mempool_txs)
+        << "serving an immature window WITHOUT suppressing the tx set is the "
+           "one variant that could overstate a fee";
+}
+
 TEST(DashUtxoImmatureServing, MatureLaneNeverSuppresses) {     // negative twin
     NodeCoinState st;
     seed_healthy_armed(st);
     st.set_utxo_ready_fn([] { return true; });
+    // Even WITH the opt-in policy, a mature lane builds normal templates.
+    st.set_utxo_immature_policy(
+        dash::coin::UtxoImmaturePolicy::ServeEmptyTxSet);
     const auto e = st.make_embedded_work_inputs();
     EXPECT_TRUE(e.has_state);
     EXPECT_FALSE(e.suppress_mempool_txs)
@@ -1064,13 +1074,15 @@ TEST(DashUtxoImmatureServing, MatureLaneNeverSuppresses) {     // negative twin
     EXPECT_FALSE(unarmed.make_embedded_work_inputs().suppress_mempool_txs);
 }
 
-// The immature window relaxes ONLY this clause. Every other gate must still
-// refuse — otherwise "serve during immaturity" would have quietly become
-// "serve regardless", which is how a lost block gets shipped as a feature.
-TEST(DashUtxoImmatureServing, OtherGatesStillRefuseDuringTheImmatureWindow) {
+// The opt-in relaxes ONLY this clause. Every other gate must still refuse —
+// otherwise "serve during immaturity" would have quietly become "serve
+// regardless", which is how a lost block gets shipped as a feature.
+TEST(DashUtxoImmatureServing, OtherGatesStillRefuseUnderTheOptIn) {
     NodeCoinState st;
     seed_healthy_armed(st);
     st.set_utxo_ready_fn([] { return false; });
+    st.set_utxo_immature_policy(
+        dash::coin::UtxoImmaturePolicy::ServeEmptyTxSet);
     st.set_credit_pool(0, raw256(0xAB), static_cast<int32_t>(H - 4));
     const DeclineReport d = st.describe_decline();
     EXPECT_FALSE(d.viable);

--- a/test/test_dash_node_coin_state.cpp
+++ b/test/test_dash_node_coin_state.cpp
@@ -976,10 +976,13 @@ TEST(DashServeGateNamesRefusal, OffCommitmentWindowIsViable) {  // negative twin
     EXPECT_TRUE(st.describe_decline().viable);
 }
 
-TEST(DashServeGateNamesRefusal, UtxoImmatureIsNamed) {
+TEST(DashServeGateNamesRefusal, UtxoImmatureIsNamedUnderConservativePolicy) {
     NodeCoinState st;
     seed_healthy_armed(st);
     st.set_utxo_ready_fn([] { return false; });
+    // The refusal is now a POLICY, not an unconditional gate: only the
+    // conservative posture still declines the whole template.
+    st.set_utxo_immature_policy(dash::coin::UtxoImmaturePolicy::Refuse);
     EXPECT_EQ(st.describe_decline().cause, "utxo-immature");
 }
 
@@ -988,6 +991,90 @@ TEST(DashServeGateNamesRefusal, UtxoMatureIsViable) {          // negative twin
     seed_healthy_armed(st);
     st.set_utxo_ready_fn([] { return true; });
     EXPECT_TRUE(st.describe_decline().viable);
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// UTXO-IMMATURE SERVING (cold-start serve-rate)
+//
+// The old gate refused EVERY embedded template until blocks_connected >= 106 —
+// at ~150 s/block, ~4.4 h of every cold start with the embedded arm serving
+// nothing. Consensus never requires a mempool transaction in a block, so a
+// coinbase-only template is fully valid; and with zero txs the fee term is
+// exactly 0, so there is no fee to overstate and the bad-cb-amount risk the
+// gate guarded is structurally absent, not merely unlikely.
+//
+// These four pin the new contract: DEFAULT serves (with the tx set suppressed
+// and SAID so), the conservative flag reproduces the old behaviour exactly, and
+// a MATURE lane is never suppressed.
+// ════════════════════════════════════════════════════════════════════════════
+
+TEST(DashUtxoImmatureServing, DefaultServesTheImmatureWindow) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_utxo_ready_fn([] { return false; });
+    // No policy call at all — this is the shipped default.
+    const auto e = st.make_embedded_work_inputs();
+    EXPECT_EQ(st.utxo_immature_policy(),
+              dash::coin::UtxoImmaturePolicy::ServeEmptyTxSet)
+        << "default must be the serving posture; a valid block beats no block";
+    EXPECT_TRUE(e.has_state)
+        << "an immature UTXO lane must no longer cost the whole template";
+    EXPECT_TRUE(e.decline.viable);
+    EXPECT_NE(st.describe_decline().cause, "utxo-immature");
+}
+
+TEST(DashUtxoImmatureServing, ServingModeSuppressesTheMempoolTxSet) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_utxo_ready_fn([] { return false; });
+    const auto e = st.make_embedded_work_inputs();
+    // THE safety property: we serve, but we serve coinbase-only. Without this
+    // bit the arm would build a normal template off an immature UTXO view.
+    EXPECT_TRUE(e.suppress_mempool_txs)
+        << "serving an immature window WITHOUT suppressing the tx set is the "
+           "one variant that could overstate a fee";
+}
+
+TEST(DashUtxoImmatureServing, ConservativePolicyIsExactlyTheOldBehaviour) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_utxo_ready_fn([] { return false; });
+    st.set_utxo_immature_policy(dash::coin::UtxoImmaturePolicy::Refuse);
+    const auto e = st.make_embedded_work_inputs();
+    EXPECT_FALSE(e.has_state);
+    EXPECT_EQ(e.decline.cause, "utxo-immature");
+    EXPECT_EQ(e.decline.value, "utxo_ready=false");
+    EXPECT_EQ(e.decline.threshold, "utxo_ready=true");
+    EXPECT_EQ(st.classify_decline(), "utxo-immature");
+    EXPECT_FALSE(e.suppress_mempool_txs)
+        << "a refusing arm serves nothing, so it suppresses nothing";
+}
+
+TEST(DashUtxoImmatureServing, MatureLaneNeverSuppresses) {     // negative twin
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_utxo_ready_fn([] { return true; });
+    const auto e = st.make_embedded_work_inputs();
+    EXPECT_TRUE(e.has_state);
+    EXPECT_FALSE(e.suppress_mempool_txs)
+        << "a mature lane must build normal, fee-paying templates";
+    // …and neither does a bundle with no UTXO lane armed at all.
+    NodeCoinState unarmed;
+    seed_healthy_armed(unarmed);
+    EXPECT_FALSE(unarmed.make_embedded_work_inputs().suppress_mempool_txs);
+}
+
+// The immature window relaxes ONLY this clause. Every other gate must still
+// refuse — otherwise "serve during immaturity" would have quietly become
+// "serve regardless", which is how a lost block gets shipped as a feature.
+TEST(DashUtxoImmatureServing, OtherGatesStillRefuseDuringTheImmatureWindow) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_utxo_ready_fn([] { return false; });
+    st.set_credit_pool(0, raw256(0xAB), static_cast<int32_t>(H - 4));
+    const DeclineReport d = st.describe_decline();
+    EXPECT_FALSE(d.viable);
+    EXPECT_EQ(d.cause, "creditpool-stale");
 }
 
 TEST(DashServeGateNamesRefusal, QcPlanUnderivableIsNamed) {


### PR DESCRIPTION
## What

The DASH embedded arm refuses **every** template until the UTXO/fee lane has
connected 106 blocks (`utxo-immature`, `node_coin_state.hpp` / `utxo_lane.hpp`,
wired at `main_dash.cpp`). At ~150 s/block that is ~4.4 h of every cold start
during which the embedded arm serves nothing — and on a **pure-daemonless**
node there is no dashd fallback to absorb it.

This PR keeps the maturity predicate exactly as it is, **keeps refusal as the
default**, and adds an explicit opt-in
(`--embedded-utxo-immature-serve-empty`) under which the arm serves a
**coinbase-only template** (empty mempool tx set) during the immature window
instead of refusing. Every other viability gate — chain-synced, qc plan,
superblock, bestCL, credit pool, payee freshness, SML/quorum roots — is
untouched and still has to pass in both modes.

## Default: Refuse — by design, not by caution

The default posture is the operator's stated design law for the project,
matching p2pool semantics: **an unsynced node does not serve block templates.**
An unsynced node is a node with unverified state; miners idling is cheaper than
miners hashing work the node cannot fully stand behind. Where an external dashd
fallback is armed, refusal is also strictly better than any degraded serve —
the fallback returns **full** templates for the whole window.

Flag absent, behaviour is byte-identical to current master (same
`utxo-immature` DeclineReport cause/value/threshold, same `classify_decline`
wire text, same routing).

## The opt-in: coinbase-only serving for pure-daemonless nodes

Scope: deployments with **no fallback to route to**, where the refusal means
nothing is served by anyone for ~4.4 h of every cold start. For operators who
prefer a subsidy-only block over no block, the opt-in serves a coinbase-only
body. Why this is consensus-safe (verified in-tree, not assumed) — traced every
consumer of the UTXO set:

| Template field | Source | Depends on UTXO? |
|---|---|---|
| `m_coinbase_value` | `subsidy + total_fees` | **only via `total_fees`** |
| `platform_reward` | `compute_dash_platform_reward_post_v20_mn_rr(height, …)` | no — height-derived |
| `m_payment_amount` (MN) | `f(block_value) − platform_reward` | only via `block_value` |
| `creditPoolBalance` (CCbTx) | `last_observed + platform_reward` | no |
| `merkleRootMNList` / `merkleRootQuorums` | SML / QuorumManager | no |
| `bestCL*` | ChainLock lane | no |
| tx selection + stale-input guard | `Mempool::get_sorted_txs_with_fees` | yes — **the only consumer** |

The UTXO set feeds exactly one thing: mempool tx fee pricing. **With zero
selected txs `total_fees` is exactly 0**, so `block_value == subsidy` exactly
and every downstream value is exact. This matters specifically because this
builder has no `TestBlockValidity` equivalent — fee exactness rides entirely on
the UTXO lane, and a coinbase-only template is the one path that does not
depend on it at all. The `bad-cb-amount` risk the gate guards is **structurally
absent** in that mode, not merely improbable.

Mandatory type-6 quorum commitments still ride under the opt-in — they are
consensus-required at a DKG height and carry zero fee.

## Naming the state (opt-in mode only)

Serving degraded is only acceptable if the node says so. Three surfaces, all
greppable:

```
[GBT-EMB] arm=EMBEDDED txset=empty cause=utxo-immature-serving h=… mempool_tx=… forgone_fees<=… sat
[DASH-STRATUM-GBT] template sourced: arm=EMBEDDED h=… mn_payee=… txset=empty cause=utxo-immature-serving forgone_fees<=…
[run] embedded UTXO/fee lane ARMED: … immature-window policy=SERVE-EMPTY-TXSET (opt-in: coinbase-only, fees=0)
```

plus two non-consensus fields on `DashWorkData` (`m_txset_empty_cause`,
`m_txset_forgone_fees`) so a soak can measure both **how long** the node ran
coinbase-only and **what it cost**. `forgone_fees` is the mempool's total known
fees — an upper bound on the loss, not the exact figure. The default (Refuse)
also names itself, as before: `arm=dashd-fallback DECLINED utxo-immature …`.

The underfill guard is deliberately **not** consulted in the opt-in mode: it
exists to flag an *unexplained* near-empty template, and letting it fire on an
explained one would train operators to ignore the line that means
"template-fill regression".

## Tests — and how they were verified against master

All fold into the already-allowlisted `test_dash_node_coin_state` and
`test_dash_embedded_gbt` targets (no new target;
`tools/ci/check_test_target_allowlist.py`: 230 targets, OK).

`test_dash_node_coin_state` — `DashUtxoImmatureServing.*`
- `DefaultRefusesTheImmatureWindowExactlyAsBefore` — no policy call → default is `Refuse`, identical `utxo-immature` DeclineReport (cause/value/threshold), identical `classify_decline` text, no suppression. **This test passes on master by construction** — it asserts master's behaviour is preserved as the default; stated plainly rather than dressed up as a red.
- `OptInServesTheImmatureWindow` — opt-in policy → `has_state == true`
- `OptInSuppressesTheMempoolTxSet` — …and `suppress_mempool_txs == true`
- `MatureLaneNeverSuppresses` — negative twin (mature lane even under the opt-in, and no lane armed)
- `OtherGatesStillRefuseUnderTheOptIn` — a stale credit pool still refuses inside the window with the opt-in active

`test_dash_embedded_gbt` — `DashUtxoImmatureServing.*` (the opt-in serving path)
- `SuppressedTemplateIsCoinbaseOnlyWithExactSubsidy` — empty tx set; `coinbase_value == subsidy` (independently recomputed); MN payment exact; **`normal − empty == fee` exactly**, i.e. never an overstatement
- `SuppressedTemplateCbTxIsByteIdenticalToNormal` — the type-5 payload is byte-identical with and without suppression, and parses to the right height / creditPool accrual / roots
- `SuppressedTemplateNamesItselfAndReportsThePrice` — marker + forgone fees
- `SuppressionDoesNotTripTheUnderfillGuard`
- `SelectorThreadsSuppressionIntoTheBuilder` — end-to-end through `select_dash_work`, so a flag that is set but never threaded goes red

**Fails-on-master verification (empirical).** The opt-in tests use APIs that do
not exist on master, so a compile failure would be a weak proof. A second
pristine clone at master `932302a` was built with probes written **only against
master's own API**, expressing the opt-in's two claims; both fail on master:

- immature window + a template request → `has_state` is **false**, `cause=utxo-immature`
- over a fee-paying mempool, the only template master can build has `m_txs` non-empty and `coinbase_value` = subsidy + fee (measured: 177,032,505 vs 177,022,505)

i.e. master has no such mode at all. The default-behaviour test passes on
master by construction, as stated above.

## Measurement status

- **MEASURED (in-tree):** the gate location, what it guards, and that the UTXO
  set feeds only mempool fee pricing. Test results above.
- **MEASURED (prior soaks, cited by the audit):** `not-populated` + cold-start
  causes = 14.98 % of a 4.03 h soak; a separate soak's cold sync = 36 min of a
  2.16 h window.
- **INFERRED:** that this gate is a large share of that, and 106 × ~150 s ≈ 4.4 h.
- **PROJECTED, not measured:** any serve-rate gain from the opt-in. Nothing here
  has run a cold start. The `txset=empty` marker + `forgone_fees` field exist
  precisely so a pure-daemonless cold-start soak can measure it before anyone
  relies on it.

Scope: DASH lane only. LTC/DOGE `set_utxo_ready_fn` wiring untouched.
