### PR TITLE
dash: re-arm coin-peer emergency seed fallback (never-re-arm fix)

### DIFF
--- a/src/impl/dash/coin/coin_peer_manager.hpp
+++ b/src/impl/dash/coin/coin_peer_manager.hpp
@@ -261,6 +261,7 @@ public:
         , m_maintenance_timer(ioc)
         , m_fixed_seed_timer(ioc)
         , m_http_seed_timer(ioc)
+        , m_emergency_timer(ioc)
     {
     }
 
@@ -354,6 +355,7 @@ public:
         m_maintenance_timer.cancel();
         m_fixed_seed_timer.cancel();
         m_http_seed_timer.cancel();
+        m_emergency_timer.cancel();
         save_peers();
     }
 
@@ -434,6 +436,7 @@ public:
             // Track as anchor candidate (most recent successful connections)
             update_anchors(key);
         }
+        m_connected_keys.insert(key);           // live connected count (emergency drive)
         if (!m_bootstrapped) m_bootstrapped = true;
     }
 
@@ -445,6 +448,7 @@ public:
         if (it != m_peers.end()) {
             it->second.record_disconnected();
         }
+        m_connected_keys.erase(key);            // live connected count (emergency drive)
     }
 
     /// #940: Notify that an OUTBOUND DIAL to a peer failed before the socket
@@ -488,6 +492,110 @@ public:
     {
         if (m_config.disable_discovery) return false;
         return connected_count < m_config.min_peers;
+    }
+
+    // ─── Emergency seed re-arm (never-re-arm defect fix) ─────────────────────
+    //
+    // The initial fixed-seed (60s) and HTTP (90s) fallbacks each fire exactly
+    // ONCE and DNS is resolved once at start; nothing re-triggers them if the
+    // peer count later falls below min_peers (churn / seed flap / boot-time DNS
+    // failure). Drives a self-backing-off re-arm cycle off the maintenance tick,
+    // guarded against timer storms, with an explicit recovery reset. All state
+    // is touched only on the io_context thread (maintenance + timer handlers),
+    // so the latch/counter need no lock; peer-map reads keep m_mutex.
+
+    /// Saturating binary exponential backoff: min(base << n, cap), overflow-safe.
+    /// Never a bare `base << n` — early-saturates at the cap so the shift cannot
+    /// overflow for large n (mirrors the emergency-decay overflow precedent).
+    static int saturating_backoff_delay(int base, int n, int cap)
+    {
+        if (base < 0) base = 0;
+        long long delay = base;
+        for (int i = 0; i < n && delay < cap; ++i)
+            delay <<= 1;
+        return delay > cap ? cap : static_cast<int>(delay);
+    }
+
+    /// Re-arm delay for the n-th consecutive attempt (0-based). base is floored
+    /// at 60s so the emergency path never re-arms faster than the original
+    /// 60s/90s one-shot tiers; escalation saturates at max_backoff_sec (~1h).
+    int emergency_delay_sec(int n) const
+    {
+        const int base = std::max(m_config.base_backoff_sec, 60);
+        return saturating_backoff_delay(base, n, m_config.max_backoff_sec);
+    }
+
+    int  emergency_attempt_count() const { return m_emergency_attempt; }
+    bool emergency_active() const        { return m_emergency_active; }
+
+    /// Arm ONE emergency re-arm cycle. Idempotent under the latch: while a cycle
+    /// is pending, subsequent maintenance ticks no-op (no timer storm). The
+    /// dedicated m_emergency_timer is independent of the initial one-shot
+    /// m_fixed_seed_timer / m_http_seed_timer (never stomps their first window).
+    void arm_emergency_fallbacks()
+    {
+        if (!m_running) return;
+        if (m_emergency_active) return;          // re-entry guard: cycle pending
+
+        m_emergency_active = true;
+        const int delay = emergency_delay_sec(m_emergency_attempt);
+        ++m_emergency_attempt;                   // increments per SCHEDULED re-arm
+
+        LOG_WARNING << "[" << m_symbol << "] Emergency peer re-arm #"
+                    << m_emergency_attempt << " scheduled in " << delay
+                    << "s (starved below min_peers=" << m_config.min_peers << ")";
+
+        m_emergency_timer.expires_after(std::chrono::seconds(delay));
+        m_emergency_timer.async_wait(
+            [this](const boost::system::error_code& ec) {
+                handle_emergency_timer(ec);
+            });
+    }
+
+    /// Emergency re-arm timer handler (factored so the KAT can drive a firing
+    /// without real time). Releases the latch at the TOP so the next starved
+    /// tick can arm the following (longer) delay; early-returns on cancel/
+    /// shutdown; otherwise re-runs all three fallback tiers.
+    void handle_emergency_timer(const boost::system::error_code& ec)
+    {
+        m_emergency_active = false;              // release latch at TOP
+        if (ec || !m_running) return;            // cancel (stop) / shutdown
+        run_emergency_refresh();
+    }
+
+    /// Reset the emergency backoff on recovery (connected >= min_peers). The
+    /// next drop starts a fresh cycle from base. Logs once per recovery.
+    void clear_emergency_state()
+    {
+        if (m_emergency_attempt != 0 || m_emergency_active) {
+            LOG_INFO << "[" << m_symbol << "] Peer recovery: connected >= min_peers, "
+                     << "emergency backoff reset (was attempt #"
+                     << m_emergency_attempt << ")";
+        }
+        m_emergency_attempt = 0;
+        m_emergency_active = false;
+        m_emergency_timer.cancel();
+    }
+
+    /// Re-run all three fallback tiers (DNS re-resolve, fixed re-load, HTTP
+    /// re-fetch), each isolated so a throwing tier cannot kill the io_context or
+    /// abort the cycle. Shared by the emergency path.
+    void run_emergency_refresh()
+    {
+        LOG_WARNING << "[" << m_symbol
+                    << "] Emergency peer refresh: re-resolving DNS + fixed + HTTP seeds";
+        try { bootstrap_from_dns_seeds(); }
+        catch (const std::exception& e) {
+            LOG_WARNING << "[" << m_symbol << "] Emergency DNS re-resolve error: " << e.what();
+        }
+        try { load_fixed_seeds(); }
+        catch (const std::exception& e) {
+            LOG_WARNING << "[" << m_symbol << "] Emergency fixed-seed reload error: " << e.what();
+        }
+        try { do_http_peer_fetch(); }
+        catch (const std::exception& e) {
+            LOG_WARNING << "[" << m_symbol << "] Emergency HTTP re-fetch error: " << e.what();
+        }
     }
 
     const DashPeerManagerConfig& config() const { return m_config; }
@@ -749,6 +857,20 @@ private:
         m_maintenance_timer.async_wait([this](const boost::system::error_code& ec) {
             if (ec || !m_running) return;
             schedule_maintenance();
+
+            // Emergency seed re-arm drive (never-re-arm defect fix): observe the
+            // live connected-peer count and, while starved below min_peers, run a
+            // self-backing-off fallback cycle guarded by the re-entry latch;
+            // reset the backoff on recovery.
+            int connected;
+            {
+                std::lock_guard<std::mutex> lock(m_mutex);
+                connected = static_cast<int>(m_connected_keys.size());
+            }
+            if (needs_emergency_refresh(connected))
+                arm_emergency_fallbacks();
+            else
+                clear_emergency_state();
         });
     }
 
@@ -980,54 +1102,64 @@ private:
         m_http_seed_timer.expires_after(std::chrono::seconds(90));
         m_http_seed_timer.async_wait([this](const boost::system::error_code& ec) {
             if (ec || !m_running) return;
-
-            // Only fetch if we still have very few tried peers
-            int tried = 0;
-            {
-                std::lock_guard<std::mutex> lock(m_mutex);
-                for (auto& [k, p] : m_peers)
-                    if (p.in_tried && !p.is_protected) ++tried;
-            }
-            if (tried >= m_config.min_peers) {
-                LOG_DEBUG_COIND << "[" << m_symbol
-                    << "] Skipping HTTP peer fetch: " << tried << " tried peers";
-                return;
-            }
-
-            LOG_INFO << "[" << m_symbol << "] Fetching peers from "
-                     << m_http_peer_seeds.size() << " c2pool seed nodes...";
-
-            // Detached thread: blocking HTTP fetch, results posted to ioc
-            auto seeds = m_http_peer_seeds; // copy for thread
-            auto symbol = m_symbol;
-            auto* self = this;
-            std::thread([seeds, symbol, self]() {
-                std::vector<NetService> result;
-                // JSON key for the DASH chain feed.
-                std::string key = "dash";
-
-                for (auto& [host, port] : seeds) {
-                    try {
-                        result = http_fetch_coin_peers(host, port, key);
-                        if (!result.empty()) {
-                            LOG_INFO << "[" << symbol << "] HTTP seed " << host
-                                     << ":" << port << " returned "
-                                     << result.size() << " peers";
-                            break; // got peers from one seed, done
-                        }
-                    } catch (const std::exception& e) {
-                        LOG_WARNING << "[" << symbol << "] HTTP seed "
-                            << host << ":" << port << " failed: " << e.what();
-                    }
-                }
-
-                if (!result.empty()) {
-                    boost::asio::post(self->m_ioc, [self, result]() {
-                        self->add_http_peers(result);
-                    });
-                }
-            }).detach();
+            do_http_peer_fetch();
         });
+    }
+
+    /// HTTP peer-fetch body, shared by the initial 90s one-shot and the
+    /// emergency re-arm path. Skips when we already have >= min_peers tried
+    /// peers; otherwise runs the blocking fetch on a detached thread and posts
+    /// results back to the io_context.
+    void do_http_peer_fetch()
+    {
+        if (m_http_peer_seeds.empty()) return;
+
+        // Only fetch if we still have very few tried peers
+        int tried = 0;
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            for (auto& [k, p] : m_peers)
+                if (p.in_tried && !p.is_protected) ++tried;
+        }
+        if (tried >= m_config.min_peers) {
+            LOG_DEBUG_COIND << "[" << m_symbol
+                << "] Skipping HTTP peer fetch: " << tried << " tried peers";
+            return;
+        }
+
+        LOG_INFO << "[" << m_symbol << "] Fetching peers from "
+                 << m_http_peer_seeds.size() << " c2pool seed nodes...";
+
+        // Detached thread: blocking HTTP fetch, results posted to ioc
+        auto seeds = m_http_peer_seeds; // copy for thread
+        auto symbol = m_symbol;
+        auto* self = this;
+        std::thread([seeds, symbol, self]() {
+            std::vector<NetService> result;
+            // JSON key for the DASH chain feed.
+            std::string key = "dash";
+
+            for (auto& [host, port] : seeds) {
+                try {
+                    result = http_fetch_coin_peers(host, port, key);
+                    if (!result.empty()) {
+                        LOG_INFO << "[" << symbol << "] HTTP seed " << host
+                                 << ":" << port << " returned "
+                                 << result.size() << " peers";
+                        break; // got peers from one seed, done
+                    }
+                } catch (const std::exception& e) {
+                    LOG_WARNING << "[" << symbol << "] HTTP seed "
+                        << host << ":" << port << " failed: " << e.what();
+                }
+            }
+
+            if (!result.empty()) {
+                boost::asio::post(self->m_ioc, [self, result]() {
+                    self->add_http_peers(result);
+                });
+            }
+        }).detach();
     }
 
     /// Add peers from an HTTP /api/coin_peers fetch.
@@ -1123,10 +1255,16 @@ private:
     std::vector<NetService> m_fixed_seeds;
     std::vector<std::pair<std::string, uint16_t>> m_http_peer_seeds;
     boost::asio::steady_timer m_http_seed_timer;
+    boost::asio::steady_timer m_emergency_timer;    // never-re-arm defect fix
+
+    // Emergency re-arm state — io_context-thread only (no lock needed; see 2.2)
+    bool m_emergency_active{false};                 // re-entry latch (one cycle pending)
+    int  m_emergency_attempt{0};                    // consecutive-attempt counter n
 
     mutable std::mutex m_mutex;
     std::map<std::string, DashPeerInfo> m_peers;    // key = "host:port"
     std::set<std::string> m_coind_peers;            // daemon's own peers (overlap filter)
+    std::set<std::string> m_connected_keys;         // live-connected keys (emergency drive; under m_mutex)
     std::string m_local_node_key;
     std::vector<std::string> m_anchors;             // last N successfully connected (partition resistance)
     bool m_bootstrapped{false};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1032,8 +1032,12 @@ if (BUILD_TESTING AND GTest_FOUND)
     # — only linked here. No new build.yml --target entry needed (test_dash_p2p_node
     # is already allowlisted; the push bot lacks `workflow` scope, #769, so a
     # standalone target would be a NOT_BUILT sentinel).
+    # Sixth TU: test_dash_coin_peer_rearm.cpp — the emergency seed RE-ARM
+    # (never-re-arm defect fix): saturating exponential backoff schedule/floor/
+    # overflow, the single-latch re-entry guard (N ticks -> one re-arm), and the
+    # recovery reset. Same target, no new allowlist entry.
     # DASH_FIXTURE_DIR: the wire suite replays the real 602'189-byte testnet capture.
-    add_executable(test_dash_p2p_node test_dash_p2p_node.cpp test_dash_coin_p2p_client.cpp test_dash_coin_peer_manager.cpp test_dash_coin_p2p_pool.cpp test_dash_qrinfo_wire.cpp)
+    add_executable(test_dash_p2p_node test_dash_p2p_node.cpp test_dash_coin_p2p_client.cpp test_dash_coin_peer_manager.cpp test_dash_coin_p2p_pool.cpp test_dash_qrinfo_wire.cpp test_dash_coin_peer_rearm.cpp)
     target_compile_definitions(test_dash_p2p_node PRIVATE
         DASH_FIXTURE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/fixtures")
     target_link_libraries(test_dash_p2p_node PRIVATE

--- a/test/test_dash_coin_peer_rearm.cpp
+++ b/test/test_dash_coin_peer_rearm.cpp
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/// DASH-isolated CoinPeerManager — emergency seed RE-ARM KATs (never-re-arm fix)
+///
+/// Pins the three MANDATORY properties of the coin-peer emergency fallback
+/// re-arm (docs/coin-peer-manager-rearm.md sections 2.1-2.4), applied to the
+/// DASH per-coin copy src/impl/dash/coin/coin_peer_manager.hpp:
+///
+///   1. BACKOFF — saturating binary exponential: base, 2*base, 4*base, ...
+///      clamped at max_backoff_sec, base floored at 60s, overflow-safe for
+///      large n (never a bare `base << n`).
+///   2. RE-ENTRY GUARD — N starved maintenance ticks between two timer firings
+///      schedule EXACTLY ONE re-arm (attempt counter advances by 1, not N).
+///   3. RECOVERY RESET — a tick with connected >= min_peers zeroes the attempt
+///      counter; the subsequent starvation re-arms from base, not the ceiling.
+///
+/// On master these entry points do not exist (the DASH copy never wired the
+/// emergency path — the maintenance tick only rescheduled itself), so this TU
+/// fails to COMPILE against master: the required red.
+///
+/// Compiled as a fourth TU into the EXISTING allowlisted test_dash_p2p_node
+/// target (no new test target, no workflow edit).
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/coin_peer_manager.hpp>
+
+#include <boost/asio.hpp>
+
+#include <filesystem>
+#include <string>
+#include <unistd.h>
+
+using dash::coin::DashCoinPeerManager;
+using dash::coin::DashPeerManagerConfig;
+
+namespace {
+
+DashPeerManagerConfig rearm_cfg()
+{
+    DashPeerManagerConfig cfg;
+    cfg.valid_ports = {9999};
+    cfg.min_peers = 5;
+    cfg.base_backoff_sec = 30;     // floored to 60 by the emergency path
+    cfg.max_backoff_sec = 3600;
+    return cfg;
+}
+
+std::string rearm_tmp_dir()
+{
+    static int seq = 0;
+    auto dir = std::filesystem::temp_directory_path()
+        / ("c2pool_dash_rearm_" + std::to_string(::getpid()) + "_"
+           + std::to_string(seq++));
+    std::filesystem::remove_all(dir);
+    std::filesystem::create_directories(dir);
+    return dir.string();
+}
+
+// ── 1. BACKOFF schedule + floor + saturation ─────────────────────────────────
+
+TEST(DashCoinPeerRearm, backoff_schedule_floors_at_60_and_saturates)
+{
+    boost::asio::io_context ioc;
+    DashCoinPeerManager pm(ioc, "DASH", rearm_tmp_dir(), rearm_cfg());
+
+    // base floored to 60: 60, 120, 240, 480, 960, 1920, then clamp at 3600.
+    EXPECT_EQ(pm.emergency_delay_sec(0), 60);
+    EXPECT_EQ(pm.emergency_delay_sec(1), 120);
+    EXPECT_EQ(pm.emergency_delay_sec(2), 240);
+    EXPECT_EQ(pm.emergency_delay_sec(3), 480);
+    EXPECT_EQ(pm.emergency_delay_sec(4), 960);
+    EXPECT_EQ(pm.emergency_delay_sec(5), 1920);
+    EXPECT_EQ(pm.emergency_delay_sec(6), 3600);   // 3840 -> clamp
+    EXPECT_EQ(pm.emergency_delay_sec(7), 3600);   // saturated
+
+    // never re-arms faster than the original 60s tier, and never exceeds ceiling.
+    for (int n = 0; n < 64; ++n) {
+        EXPECT_GE(pm.emergency_delay_sec(n), 60);
+        EXPECT_LE(pm.emergency_delay_sec(n), 3600);
+    }
+}
+
+TEST(DashCoinPeerRearm, saturating_helper_is_overflow_safe)
+{
+    // direct helper: `base << n` early-saturates, never overflows.
+    EXPECT_EQ(DashCoinPeerManager::saturating_backoff_delay(60, 0, 3600), 60);
+    EXPECT_EQ(DashCoinPeerManager::saturating_backoff_delay(60, 1, 3600), 120);
+    EXPECT_EQ(DashCoinPeerManager::saturating_backoff_delay(60, 6, 3600), 3600);
+    EXPECT_EQ(DashCoinPeerManager::saturating_backoff_delay(1, 100000, 3600), 3600);
+    EXPECT_EQ(DashCoinPeerManager::saturating_backoff_delay(1, (1 << 30), 3600), 3600);
+    EXPECT_EQ(DashCoinPeerManager::saturating_backoff_delay(100, 0, 50), 50); // cap<base
+}
+
+// ── 2. RE-ENTRY GUARD: N arms between firings -> exactly ONE re-arm ───────────
+
+TEST(DashCoinPeerRearm, reentry_guard_collapses_many_ticks_to_one_rearm)
+{
+    boost::asio::io_context ioc;
+    DashCoinPeerManager pm(ioc, "DASH", rearm_tmp_dir(), rearm_cfg());
+    pm.start();   // sets m_running; no seeds -> nothing fires; ioc not run
+
+    ASSERT_EQ(pm.emergency_attempt_count(), 0);
+    ASSERT_FALSE(pm.emergency_active());
+
+    // Simulate MANY starved maintenance ticks before the pending timer fires.
+    for (int i = 0; i < 20; ++i)
+        pm.arm_emergency_fallbacks();
+
+    // Latch collapsed all 20 arms into ONE scheduled re-arm.
+    EXPECT_TRUE(pm.emergency_active());
+    EXPECT_EQ(pm.emergency_attempt_count(), 1);
+
+    // Timer fires: latch releases, cycle acts (no seeds -> refresh is a no-op).
+    pm.handle_emergency_timer({});
+    EXPECT_FALSE(pm.emergency_active());
+    EXPECT_EQ(pm.emergency_attempt_count(), 1);
+
+    // Still starved: the next tick arms the SECOND (longer) re-arm -> counter 2.
+    for (int i = 0; i < 20; ++i)
+        pm.arm_emergency_fallbacks();
+    EXPECT_TRUE(pm.emergency_active());
+    EXPECT_EQ(pm.emergency_attempt_count(), 2);
+
+    pm.stop();
+}
+
+// ── 3. RECOVERY RESET: connected>=min_peers zeroes counter, re-arm from base ──
+
+TEST(DashCoinPeerRearm, recovery_resets_counter_and_rearms_from_base)
+{
+    boost::asio::io_context ioc;
+    DashCoinPeerManager pm(ioc, "DASH", rearm_tmp_dir(), rearm_cfg());
+    pm.start();
+
+    // Escalate a few cycles: arm, fire, arm, fire ... -> counter climbs.
+    for (int cycle = 0; cycle < 4; ++cycle) {
+        pm.arm_emergency_fallbacks();
+        pm.handle_emergency_timer({});
+    }
+    EXPECT_EQ(pm.emergency_attempt_count(), 4);
+
+    // Recovery tick: connected >= min_peers.
+    pm.clear_emergency_state();
+    EXPECT_EQ(pm.emergency_attempt_count(), 0);
+    EXPECT_FALSE(pm.emergency_active());
+
+    // The next drop re-arms from BASE (attempt index 0 -> delay 60), not ceiling.
+    pm.arm_emergency_fallbacks();
+    EXPECT_EQ(pm.emergency_attempt_count(), 1);
+    EXPECT_EQ(pm.emergency_delay_sec(0), 60);   // fresh cycle starts at base
+
+    pm.stop();
+}
+
+// ── 4. FLOOR does NOT stop; SHUTDOWN cancels + handler early-returns ──────────
+
+TEST(DashCoinPeerRearm, never_permanently_gives_up_but_stop_terminates)
+{
+    boost::asio::io_context ioc;
+    DashCoinPeerManager pm(ioc, "DASH", rearm_tmp_dir(), rearm_cfg());
+    pm.start();
+
+    // Drive well past the ceiling: still starved -> keeps re-arming, saturated
+    // at max_backoff_sec (bounded ~1h heartbeat, not silence, not a storm).
+    for (int cycle = 0; cycle < 12; ++cycle) {
+        pm.arm_emergency_fallbacks();
+        pm.handle_emergency_timer({});
+    }
+    EXPECT_EQ(pm.emergency_attempt_count(), 12);
+    EXPECT_EQ(pm.emergency_delay_sec(pm.emergency_attempt_count()), 3600);
+
+    // SHUTDOWN: stop() cancels the emergency timer; a firing after shutdown
+    // releases the latch and early-returns (no refresh).
+    pm.arm_emergency_fallbacks();
+    EXPECT_TRUE(pm.emergency_active());
+    pm.stop();
+    pm.handle_emergency_timer(boost::asio::error::operation_aborted);
+    EXPECT_FALSE(pm.emergency_active());
+}
+
+} // namespace


### PR DESCRIPTION
## dash: re-arm coin-peer emergency seed fallback (never-re-arm fix)

Fixes the never-re-arm defect in the DASH-isolated `CoinPeerManager`: once the
emergency seed fallback fired it never re-armed, so a pool that lost all coin
peers after the first emergency dial stayed dark. Adds a saturating exponential
backoff schedule (floor + overflow-safe), a single-latch re-entry guard (N idle
ticks collapse to exactly one re-arm), and a recovery reset once a healthy peer
returns.

### Scope — DASH-tree only
- `src/impl/dash/coin/coin_peer_manager.hpp` (+224)
- `test/test_dash_coin_peer_rearm.cpp` (new, +181)
- `test/CMakeLists.txt` (+6 — sixth TU on the existing `test_dash_p2p_node`
  target, no new build.yml allowlist entry)

No `bitcoin_family/`, no `src/core/`, no other coin touched — per-coin isolation
holds, single-coin smoke suffices, no four-coin matrix.

### Base — reconciled AFTER #1082, real head (not a stale pin)
Cut fresh from **`932302a8`** — the `#1082` merge commit (`dash: hold a bounded
pool of concurrent coin-P2P peers`, merged 2026-08-04T10:36:48Z), which is the
current real `master` HEAD on GitHub.

Head of this branch: **`be142433`**.

This is a genuine post-#1082 reconciliation, not a textual rebase. #1082 and this
branch both edit `test/CMakeLists.txt` (same `test_dash_p2p_node` executable) —
resolved as a union: #1082's `test_dash_coin_p2p_pool.cpp` + `test_dash_qrinfo_wire.cpp`
TUs and the `DASH_FIXTURE_DIR` definition are preserved, and `test_dash_coin_peer_rearm.cpp`
is appended as the sixth TU. `coin_peer_manager.hpp` reconciles cleanly against
#1082's rewritten sibling `p2p_client.hpp` — proven by the target compiling and
linking against post-#1082 master (below), not just a clean `git rebase`.

(Trap noted for the record: the workstation's local `origin` mirror is stale and
lacks #1082 — reconciliation was done against the real `gh-ssh/master`.)

### Verification — real ctest counts from build_ci/ (not exit code)
Built via the CI DASH recipe (`-DCOIN_DGB=ON`, Release, conan `linux-gcc13`
toolchain, ccache) — target `test_dash_p2p_node` built + linked clean.

```
$ ctest -R "DashCoinPeerRearm\."     -> 100% tests passed, 0 tests failed out of 5
$ ctest -R "DashCoinPeerManager\."   -> 100% tests passed, 0 tests failed out of 8
```

Re-arm KAT: **5/5**. Coin-peer manager suite: **8/8** (full `test_dash_p2p_node`
binary: 90/90). Note: the coin-peer-manager suite is **8** tests, not the "30"
figure carried in an earlier held-status note — that file (`test_dash_coin_peer_manager.cpp`)
was last touched by #943 and is unaffected by #1082; 8/8 is the real current count.
