### PR TITLE
dash: event-driven resume for the creditpool-stale serve-gate window (soak0804e)

### DIFF
--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -768,6 +768,39 @@ public:
     /// template with a phantom payee. Returns apply_block's ApplyResult.
     MnStateMachine::ApplyResult
     on_block_connected(const dash::coin::BlockType& block, uint32_t height) {
+        // EVENT-DRIVEN RESUME (soak0804e, creditpool-stale ~3.3% wall-clock):
+        // between the header tip advance (on_new_tip) and this body fold the
+        // credit-pool seed is exactly one block behind the tip and the serve
+        // gate CORRECTLY refuses (value = threshold-1; consensus demands exact
+        // creditPoolBalance equality — dashd specialtxman.cpp:749-755). The
+        // ingest was already event-driven, but the RESUME was not: a successful
+        // tip-body fold ended in republish() without firing the state-dirty
+        // sink, so no work re-issue happened until the next unrelated signal
+        // (template request / mnlistdiff / next tip, up to minutes away).
+        // Detect the stale->fresh transition on the credit-pool axis — the
+        // seed becoming current AT the tip — and fire the same re-issue path
+        // every other async advance uses (H-6). Historical window fills advance
+        // the seed to heights BELOW the tip and can never fire this, so the
+        // E2b bootstrap causes no notify storm. The refusal between
+        // tip-advance and body-parse is untouched: this is latency work, the
+        // gate itself is not weakened.
+        const bool cp_was_current_at_tip =
+            m_have_tip
+            && m_state.credit_pool_height() == static_cast<int32_t>(m_prev_height);
+        auto r = on_block_connected_impl(block, height);
+        const bool cp_now_current_at_tip =
+            m_have_tip
+            && m_state.credit_pool_height() == static_cast<int32_t>(m_prev_height);
+        if (!cp_was_current_at_tip && cp_now_current_at_tip)
+            notify_state_dirty();
+        return r;
+    }
+
+private:
+    /// The body of on_block_connected. Reached ONLY through the public wrapper
+    /// above (which detects the credit-pool stale->fresh transition around it).
+    MnStateMachine::ApplyResult
+    on_block_connected_impl(const dash::coin::BlockType& block, uint32_t height) {
         // E2 finding A (reward-critical, defence-in-depth): this component EXTRACTS
         // the reward-critical creditPoolBalance from the block's coinbase, so it
         // validates its own input at the trust boundary. The body↔header binding is
@@ -935,6 +968,7 @@ public:
         return r;
     }
 
+public:
     /// Reorg / MN-list gap / mempool flush: invalidate the live bundle so the
     /// next get_work falls back to dashd until a fresh tip rebuilds it. The
     /// stashed tip params are dropped -- a reorg means the old prev_hash is no

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -314,6 +314,13 @@ void DASHWorkSource::resource_template_now() const
     // OUTSIDE the lock (the fallback arm is a blocking dashd RPC); the cache is
     // then updated under template_mutex_.
 
+    // Captured BEFORE sourcing: a failed attempt negative-caches against THIS
+    // generation, so an event (work-generation bump) that lands while the
+    // blocking source runs still breaks through the retry throttle (soak0804e
+    // resume-quantization fix — see cached_work()).
+    const uint64_t gen_at_source =
+        work_generation_.load(std::memory_order_relaxed);
+
     // ── Mainnet embedded gate (v0.2.4 trigger) ──────────────────────────────
     // The SML/QuorumManager wiring emits a real DIP-0004 type-5 CCbTx, and its
     // byte-parity against a real dashd getblocktemplate is PROVEN (from the raw
@@ -463,7 +470,8 @@ void DASHWorkSource::resource_template_now() const
         // on any chain): an honest absence. Keep any previous cache DROPPED --
         // serving a stale tip is worse than waiting.
         template_cache_.reset();
-        template_last_fail_at_ = now;
+        template_last_fail_at_  = now;
+        template_last_fail_gen_ = gen_at_source;
         return;
     }
     // Tip moved since the last snapshot? Bump work_generation_ so sessions
@@ -592,10 +600,18 @@ std::shared_ptr<const coin::DashWorkData> DASHWorkSource::cached_work() const
             // the bg refresh latency AND the 3 s tip-poll invalidation (which
             // RESETS the cache on a real tip change, so a rotated tip is served
             // as a set-gap until the fresh template lands, never as stale work).
+            // soak0804e resume-quantization fix: the negative cache shields a
+            // down dashd from every session's 1 s retry — but ONLY while
+            // nothing has changed. A work-generation bump is an EVENT (tip
+            // change / coin-state advance, e.g. the credit-pool seed catching
+            // up to the tip body) that changes the answer, so it breaks
+            // through; without this the event-driven resume was quantized to
+            // the kRetryAfter (5 s) window even after the gate turned viable.
             const bool recently_failed =
                 !template_cache_
                 && template_last_fail_at_.time_since_epoch().count() != 0
-                && now - template_last_fail_at_ < kRetryAfter;
+                && now - template_last_fail_at_ < kRetryAfter
+                && template_last_fail_gen_ == gen;
             if (!recently_failed && !template_refresh_inflight_.exchange(true)) {
                 refresh_executor_([this]() {
                     resource_template_now();
@@ -607,9 +623,12 @@ std::shared_ptr<const coin::DashWorkData> DASHWorkSource::cached_work() const
 
         // Legacy inline-blocking path (executor not wired: embedded/tests) --
         // BYTE-IDENTICAL to the pre-decouple behaviour. Negative cache: a recent
-        // failed sourcing attempt -> don't re-poll yet.
+        // failed sourcing attempt -> don't re-poll yet — UNLESS the generation
+        // moved since the failure (an event changed the answer; same
+        // soak0804e break-through as the executor path above).
         if (!template_cache_ && template_last_fail_at_.time_since_epoch().count() != 0
-            && now - template_last_fail_at_ < kRetryAfter)
+            && now - template_last_fail_at_ < kRetryAfter
+            && template_last_fail_gen_ == gen)
             return nullptr;
     }
 

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -511,6 +511,12 @@ private:
     // stale credit-pool seed cannot be served after the seed advances.
     mutable bool                template_cache_is_embedded_{false};
     mutable std::chrono::steady_clock::time_point template_last_fail_at_{};
+    // Generation the last FAILED sourcing attempt was made against (captured
+    // BEFORE the blocking source ran). The negative cache only holds while the
+    // generation is unchanged: a bump (tip change / coin-state advance) is an
+    // event that changes the answer and must re-source immediately instead of
+    // waiting out kRetryAfter (soak0804e resume-quantization fix).
+    mutable uint64_t            template_last_fail_gen_{0};
 
     // io-thread-decouple: background single-flight template refresh.
     // refresh_executor_ posts the blocking re-source onto the rpc_pool thread

--- a/test/test_dash_coin_state_maintainer.cpp
+++ b/test/test_dash_coin_state_maintainer.cpp
@@ -713,6 +713,106 @@ TEST(DashCoinStateMaintainer, SmlApplyAndReorgFireStateDirty) {
     EXPECT_EQ(dirty, 2) << "reorg wipe must re-issue work (drop orphaned-branch template)";
 }
 
+// ════════════════════════════════════════════════════════════════════════
+// soak0804e (creditpool-stale ~3.3% of wall-clock, every decline exactly
+// value = threshold-1): between the header tip-advance and the tip BODY parse
+// the credit-pool seed is one block behind and the serve gate correctly
+// refuses. Ingest was already event-driven end-to-end (inv -> getdata ->
+// full_block -> block_connected -> advance_credit_pool_on_block), but the
+// RESUME was not: the successful tip-body fold ended in republish() without
+// firing the state-dirty sink, so no work re-issue happened until the next
+// UNRELATED signal (template request / mnlistdiff / next tip). This KAT pins
+// the event-driven resume: the tip body arriving must (a) advance the
+// credit-pool seed to the tip, (b) turn the gate viable, and (c) fire
+// set_on_state_dirty — with NO template request in between. It also pins that
+// the gate still refuses BETWEEN tip-advance and body-parse: the consensus
+// gate is untouched (dashd demands exact creditPoolBalance equality,
+// bad-cbtx-assetlocked-amount); this is latency work, not gate work.
+// ════════════════════════════════════════════════════════════════════════
+static BlockType make_cbtx_block(uint32_t height, int64_t credit_pool,
+                                 const std::vector<unsigned char>& payee_script) {
+    dash::coin::vendor::CCbTx cb;
+    cb.nVersion = dash::coin::vendor::CCbTx::VERSION_CLSIG_AND_BALANCE;
+    cb.nHeight  = static_cast<int32_t>(height);
+    cb.creditPoolBalance = credit_pool;
+    BlockType blk;
+    blk.m_txs.push_back(make_spend(raw256(0x90), 0, 500000000, height));
+    blk.m_txs[0].type = 5;                                    // CbTx
+    blk.m_txs[0].extra_payload = dash::coin::encode_cbtx(cb);
+    blk.m_txs[0].vout[0].scriptPubKey.m_data = payee_script;  // pays projected MN
+    bind_block(blk);
+    return blk;
+}
+
+TEST(DashCoinStateMaintainer, TipBodyArrivalFiresStateDirtyWithoutTemplateRequest) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    int dirty = 0;
+    m.set_on_state_dirty([&] { ++dirty; });
+
+    m.on_mn_list_update(single_mn(p2pkh_script(0x30)));
+    st.set_require_fresh_credit_pool(true);
+
+    // Header tip advance to H: the credit-pool seed (never seeded, -1) is now
+    // behind the tip — the gate MUST refuse, and with the creditpool cause.
+    // This is the correct refusal that MUST be preserved.
+    m.on_new_tip(H, raw256(0xCD), BITS, MTP, DASH_PUBKEY_VER, DASH_P2SH_VER,
+                 CURTIME, VERSION);
+    auto before = st.describe_decline();
+    EXPECT_FALSE(before.viable);
+    EXPECT_EQ(before.cause, "creditpool-stale")
+        << "between tip-advance and body-parse the gate must refuse on the "
+           "credit-pool axis";
+
+    const int dirty_before = dirty;
+
+    // The tip BODY arrives (event-driven ingest): type-5 CbTx coinbase
+    // carrying the committed creditPoolBalance at its own nHeight == tip.
+    // This is the moment the decline condition ends.
+    m.on_block_connected(make_cbtx_block(H, 123'456'789LL, p2pkh_script(0x30)), H);
+
+    // (a) the seed advanced to the tip off the block's OWN committed value...
+    EXPECT_EQ(st.credit_pool_height(), static_cast<int32_t>(H));
+    EXPECT_EQ(st.credit_pool(), 123'456'789LL);
+    // ...(b) the gate now evaluates viable...
+    EXPECT_TRUE(st.describe_decline().viable)
+        << "credit-pool seed current at the tip must clear the refusal";
+    // ...(c) and the state-dirty sink fired — the event-driven resume. No
+    // select_work()/template request happened between tip-advance and here.
+    EXPECT_GT(dirty, dirty_before)
+        << "tip-body fold must re-issue work (bump + notify) instead of "
+           "waiting for the next template request / unrelated signal";
+}
+
+// Guard against a notify storm during the E2b historical window fill: a body
+// fold BELOW the tip advances the seed to a non-tip height — still stale at
+// the tip — and must NOT fire the re-issue sink.
+TEST(DashCoinStateMaintainer, HistoricalBodyFoldBelowTipDoesNotFireStateDirty) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    int dirty = 0;
+    m.set_on_state_dirty([&] { ++dirty; });
+
+    m.on_mn_list_update(single_mn(p2pkh_script(0x30)));
+    st.set_require_fresh_credit_pool(true);
+    m.on_new_tip(H, raw256(0xCD), BITS, MTP, DASH_PUBKEY_VER, DASH_P2SH_VER,
+                 CURTIME, VERSION);
+    const int dirty_before = dirty;
+
+    // A HISTORICAL body (H-3 < tip H) folds in during window fill.
+    m.on_block_connected(make_cbtx_block(H - 3, 111'000'000LL, p2pkh_script(0x30)),
+                         H - 3);
+
+    EXPECT_EQ(st.credit_pool_height(), static_cast<int32_t>(H - 3));
+    EXPECT_FALSE(st.describe_decline().viable)
+        << "a seed below the tip must still refuse (the correct refusal is "
+           "preserved)";
+    EXPECT_EQ(st.describe_decline().cause, "creditpool-stale");
+    EXPECT_EQ(dirty, dirty_before)
+        << "a historical fold must not fire the re-issue sink (no notify "
+           "storm during the bootstrap window fill)";
+}
+
 // ── #814 review R1 hardening: stale ZERO-base snapshots must not corrupt the
 // tip SML ─────────────────────────────────────────────────────────────────────
 //

--- a/test/test_dash_stratum_work_source.cpp
+++ b/test/test_dash_stratum_work_source.cpp
@@ -1089,6 +1089,45 @@ TEST(DashStratumWorkSource, InvalidateTemplateCacheForcesRefetchAndBumpsGenerati
     EXPECT_EQ(fallback_calls, 2);
 }
 
+// soak0804e resume-quantization pin: a FAILED sourcing attempt (set-gap /
+// declined gate) is negative-cached for kRetryAfter (5 s) so a down dashd is
+// not hammered by every session's 1 s notify-retry — but a work-generation
+// bump is an EVENT (tip change / coin-state advance, e.g. the credit-pool
+// seed catching up to the tip body) that changes the answer, so it must break
+// THROUGH the negative cache. Before this fix the event-driven resume was
+// quantized to the retry window: the maintainer had already advanced the
+// credit pool and fired state-dirty (bump + notify), the gate was viable, yet
+// cached_work() refused to re-source for up to 5 more seconds — exactly the
+// [5,5,5,5,5] s creditpool-stale episode floor the soak measured.
+TEST(DashStratumWorkSource, GenerationBumpBreaksThroughNegativeTemplateCache)
+{
+    dash::coin::NodeCoinState cs;   // unpopulated -> fallback arm
+    int fallback_calls = 0;
+    auto ws = std::make_unique<dash::stratum::DASHWorkSource>(
+        cs,
+        [&fallback_calls]() {
+            ++fallback_calls;
+            return dash::coin::DashWorkData{};   // set-gap: every attempt FAILS
+        });
+
+    // First pull: sources once, fails, arms the negative cache.
+    EXPECT_TRUE(ws->get_current_work_template().empty());
+    EXPECT_EQ(fallback_calls, 1);
+
+    // Second pull inside kRetryAfter with NO event: the throttle must hold
+    // (the down-dashd protection is unchanged).
+    EXPECT_TRUE(ws->get_current_work_template().empty());
+    EXPECT_EQ(fallback_calls, 1) << "no event => the retry throttle must hold";
+
+    // An event fires (the state-dirty sink's bump_work_generation): the next
+    // pull must re-source IMMEDIATELY instead of waiting out kRetryAfter.
+    ws->bump_work_generation();
+    EXPECT_TRUE(ws->get_current_work_template().empty());
+    EXPECT_EQ(fallback_calls, 2)
+        << "a work-generation bump must break through the negative template "
+           "cache (event-driven resume, not the 5 s retry quantum)";
+}
+
 // Fallback-arm event-driven tip refresh pin: on the dashd-fallback arm the
 // template cache only re-sources on the 30 s staleness TTL, so a new DASH block
 // can leave miners hashing a stale tip for up to ~30 s (accepted pseudoshares


### PR DESCRIPTION
## What this is

soak0804e (N=1, 3 h, master 932302a88) measured `creditpool-stale` at ~3.3% of wall-clock across 9 episodes (durations [5,5,5,5,5,60,63,64,208] s), every decline exactly `value = threshold-1`. This PR answers the two questions the finding posed and fixes the resume path. **The consensus gate is untouched** — dashd demands exact `creditPoolBalance` equality (`bad-cbtx-assetlocked-amount`, specialtxman.cpp:749-755) and the refusal between tip-advance and body-parse is correct and pinned by a KAT as preserved.

## Q1 — is the credit-pool advance event-driven or poll-driven? (MEASURED, call chain)

The **ingest is fully event-driven**; no periodic tick anywhere in the chain:

1. block inv -> `new_block` fired (`src/impl/dash/coin/p2p_client.hpp` inv handler, ~:1901-1904)
2. `new_block` subscriber sends `getheaders` + `request_block(hash)` **immediately**, same ordered TCP stream, headers land first (`src/c2pool/main_dash.cpp` ~:3792-3806)
3. headers -> `HeaderChain::add_headers` -> tip-changed callback -> `on_new_tip` (tip advances; gate now correctly stale) + `invalidate_template_cache` + bump + `notify_all` (`main_dash.cpp` ~:3835-3894)
4. block body arrives -> `full_block` (`p2p_client.hpp` block handler ~:1912-1931) -> merkle-bound -> `block_connected` (`src/impl/dash/coin/live_feed.hpp` :104-136) -> `CoinStateMaintainer::on_block_connected` (`src/impl/dash/coin/block_connect_ingest.hpp` :54-58) -> `advance_credit_pool_on_block` (`coin_state_maintainer.hpp`)

So blocks are getdata'd promptly on inv (no lazy body fetch). **But the RESUME was not event-driven, twice over:**

- `on_block_connected`'s success path ended in `republish()` **without** firing the state-dirty sink — unlike every other async advance (mnlistdiff apply, ChainLock adopt, reorg wipe, all of which call `notify_state_dirty()`). The gate turning viable re-issued no work until the next unrelated signal.
- Even when a bump did land, `DASHWorkSource`'s negative template cache (`kRetryAfter` = 5 s, `work_source.cpp:68`) refused to re-source after a failed attempt regardless of events — quantizing any resume to the 5 s retry window.

## Q2 — the fix (latency-only)

- **Maintainer** (`coin_state_maintainer.hpp`): wrap the block-connect fold and fire `notify_state_dirty()` exactly on the credit-pool seed's stale->fresh transition (seed becoming current AT the tip). Historical E2b window fills advance the seed to below-tip heights and can never fire it — no bootstrap notify storm (pinned by KAT).
- **Work source** (`work_source.{hpp,cpp}`): a failed sourcing attempt negative-caches against the generation it was made at (captured before the blocking source, so a bump landing mid-source still counts); a generation bump breaks through and re-sources immediately. With no event, the down-dashd 5 s throttle is byte-identical.

Post-fix resume: body parse -> `notify_state_dirty` -> bump + `notify_all` -> session re-pull re-sources immediately -> EMBEDDED resumes. The residual window is the genuine header-arrival -> body-parse network latency — the same block-boundary physics dashd itself has.

## Evaluation-quantization report (measure-and-report, no fix needed beyond the above)

- MEASURED (code): decline/resume edges are only *observed* at sourcing attempts (`ServeGateJournal::observe` runs inside `resource_template_now` only). During a decline, sourcing cadence is floored by `kRetryAfter` = 5 s and ceilinged by whoever asks (sessions' 1 s notify retry; the soak probe at 60 s).
- The five 5 s episodes are the **retry-quantum floor**, not body latency: true condition duration <= 5 s each, likely sub-second-to-~2 s (one getdata response after the headers response on an already-open stream). INFERRED from the transport ordering.
- The 60/63/64 s episodes carry the **60 s probe-cadence signature** (resume edge only observable at the next probe). Their true durations may be the same few seconds; they cannot be distinguished from a genuinely slow body fetch without the maintainer-side timestamps, which the journal did not record per-episode. INFERRED.
- The single 208 s episode fits neither quantum and is likely real: `request_block` goes to the primary peer with no timeout/re-request, and `InvDedup` (TTL 600 s) suppresses acting on the same block inv from other peers — an unanswered getdata can stall the body until a later headers-driven re-request. INFERRED, N=1; separate lane if it recurs.
- Net: of the measured 3.3%, the majority is probe/retry-cadence artifact. True steady-state unavailability was plausibly ~0.15% excluding the 208 s tail (~2% including it). A production miner polling continuously would have seen roughly body-latency + up-to-5 s per block pre-fix (~2-4%/episode-block), and sees body-latency only (~1 s-class) post-fix.

## Tests (both behaviour KATs verified to FAIL on pre-fix master)

- `DashCoinStateMaintainer.TipBodyArrivalFiresStateDirtyWithoutTemplateRequest` — body arrival advances the pool + fires the re-issue sink with **no template request in between**; also pins the correct refusal (`creditpool-stale`) between tip-advance and body-parse. FAILS on master.
- `DashCoinStateMaintainer.HistoricalBodyFoldBelowTipDoesNotFireStateDirty` — below-tip folds still refuse and do not notify (guard; passes pre-fix too, by design).
- `DashStratumWorkSource.GenerationBumpBreaksThroughNegativeTemplateCache` — the 5 s retry quantum yields to an event; holds with no event. FAILS on master.

Both suites fully green with the fix (25/25 maintainer, 68/68 work source). Targets fold into the already-allowlisted `test_dash_coin_state_maintainer` / `test_dash_stratum_work_source`; `tools/ci/check_test_target_allowlist.py` green (230 targets).

DASH lane only. No consensus-gate change. Non-destructive.
