### PR TITLE
DASH: enforce the PoSe-fold emit gate (emit-qc-real-pose-unfolded) + [QC-EPISODE] terminal-event classifier

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -65,6 +65,7 @@
 #include <impl/dash/coin/arm_resolution.hpp>   // dash::coin::resolve_embedded_arm (#738 arm decision, one place)
 #include <impl/dash/coin/dkg_window.hpp>       // dash::coin::is_dkg_commitment_window (BLOCKER-1 guard)
 #include <impl/dash/coin/dkg_commitments.hpp>  // E1: build_daemonless_qc_plan (serve DKG windows daemonlessly)
+#include <impl/dash/coin/qc_episode_classifier.hpp>  // [QC-EPISODE] terminal-event classifier (null-arm design §8)
 #include <impl/dash/coin/vendor/bls_verify.hpp>  // E1 Phase-L: make_commitment_bls_verifier (real qc verify seam)
 #include <impl/dash/coin/chainlock_verify.hpp>   // live-path ChainLock quorum selection + BLS verify gate
 #include <impl/dash/coin/llmq_type_reconciler.hpp>  // negative-capable enabled_llmqs backstop
@@ -3445,6 +3446,32 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     return qc_member_source->lookup(t, qh).has_value();
                 });
 
+            // PoSe-fold gate (the #1083 landmine ENFORCED — see
+            // NodeCoinState::set_qc_pose_noop_fn and dkg_commitments.hpp
+            // qc_pose_pass_provably_noop). A REAL in-block commitment makes
+            // dashd's verifier PoSe-punish every member it marks invalid
+            // (specialtxman.cpp:159-174), which can flip that MN's validity
+            // in the SAME block's list — the template's committed
+            // merkleRootMNList is then wrong (bad-cbtx-mnmerkleroot, a
+            // silently lost block). No PoSe fold exists here, so the pre-emit
+            // gate refuses any real commitment whose PoSe pass is not
+            // PROVABLY a no-op: every listed member valid, judged against the
+            // SAME deterministic member list the BLS verifier already sourced
+            // (its size is the members.size() dashd's punish loop runs over).
+            // Member set gone from cache => nullopt => refuse (fail-closed).
+            // Null commitments are exempt (IsNull() guard, specialtxman.cpp
+            // :432) — today's all-null plans are byte-unchanged.
+            node_coin_state.set_qc_pose_noop_fn(
+                [qc_member_source](
+                    const dash::coin::vendor::CFinalCommitment& c)
+                    -> std::optional<bool> {
+                    auto members =
+                        qc_member_source->lookup(c.llmqType, c.quorumHash);
+                    if (!members) return std::nullopt;   // cannot prove
+                    return dash::coin::qc_pose_pass_provably_noop(
+                        c, members->size());
+                });
+
             // DEMUX: route the source's HISTORICAL getmnlistd replies away from
             // the tip-SML maintainer (a base=ZERO snapshot would overwrite it).
             // ADDITIVE, not a slot: the MN-checkpoint lane registers its own
@@ -3512,6 +3539,17 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             auto qc_gap_logged_h  = std::make_shared<uint32_t>(0u);
             auto qc_first_plan_h  = std::make_shared<uint32_t>(0u);
             auto qc_cold_note_done = std::make_shared<bool>(false);
+            // [QC-EPISODE] terminal-event classifier (null-arm design §8,
+            // recommendation 1 — the measurement that decides whether the
+            // null arm is ever worth building). Every qc-plan-underivable
+            // episode ends real-arrived (the flood delivered), real-mined
+            // (another miner mined it) or window-closed-null (the window
+            // closed with no real commitment ever seen — the ONLY case the
+            // null arm could ever help). One line per episode at RESUME,
+            // derived from facts the caches already hold; no new state
+            // machine, no new wire traffic.
+            auto qc_episode =
+                std::make_shared<dash::coin::QcEpisodeClassifier>();
             // NEGATIVE-CAPABLE BACKSTOP for the enabled-type table itself
             // (llmq_type_reconciler.hpp). The mainnet LLMQ_50_60 defect was
             // invisible because "required but NONEXISTENT" and "required but
@@ -3527,7 +3565,7 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             node_coin_state.set_qc_plan_fn(
                 [&node_coin_state, hc = header_chain.get(), qc_net, qc_cache,
                  qc_gap_logged_h, qc_first_plan_h, qc_cold_note_done,
-                 qc_type_recon, qc_recon_said]
+                 qc_type_recon, qc_recon_said, qc_episode]
                 (uint32_t next_h) -> std::optional<dash::coin::QcBlockPlan> {
                     if (*qc_first_plan_h == 0u) *qc_first_plan_h = next_h;
                     // Observe the MINED set at the tip we are building on.
@@ -3629,6 +3667,61 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                    " 1520106. The refusal clears when any miner"
                                    " mines the commitment or when the window"
                                    " above closes — whichever comes first.";
+                        }
+                    }
+                    // ── [QC-EPISODE] terminal-event classification ────────
+                    // A slot-shaped refusal starts (or re-slots) the episode;
+                    // the first derivable plan afterwards is the RESUME, and
+                    // the terminal class is read off facts the caches hold at
+                    // that instant: the commitment cache (did the flood
+                    // deliver it => real-arrived), the mnlistdiff-fed
+                    // QuorumManager (did another miner mine it => real-mined),
+                    // or neither past the window's last height
+                    // (window-closed-null — the only case dashd's null arm
+                    // would have recovered; its measured wall-clock is the
+                    // standing input to the null-arm defer/build decision).
+                    // Structural nullopts (header gap / below the serve
+                    // floor: gap.quorum_hash null) are not commitment waits
+                    // and neither start nor end an episode.
+                    {
+                        const int64_t ep_now_sec =
+                            std::chrono::duration_cast<std::chrono::seconds>(
+                                std::chrono::steady_clock::now()
+                                    .time_since_epoch())
+                                .count();
+                        if (!plan) {
+                            if (!gap.quorum_hash.IsNull()) {
+                                const auto ep_wb = dash::coin::qc_window_bound(
+                                    gap.params, next_h);
+                                qc_episode->observe_underivable(
+                                    next_h, gap.params.type, gap.quorum_index,
+                                    gap.quorum_hash, ep_wb.last_height,
+                                    ep_now_sec);
+                            }
+                        } else if (auto slot = qc_episode->pending()) {
+                            const bool ep_cache_has = qc_cache->has_commitment(
+                                slot->llmq_type, slot->quorum_hash);
+                            const bool ep_mined =
+                                node_coin_state.qmgr()
+                                    .find(slot->llmq_type, slot->quorum_hash)
+                                    .has_value();
+                            if (auto ended = qc_episode->observe_derivable(
+                                    next_h, ep_cache_has, ep_mined,
+                                    ep_now_sec)) {
+                                LOG_INFO
+                                    << "[QC-EPISODE] cause=qc-plan-underivable"
+                                    << " dur=" << ended->duration_sec << "s"
+                                    << " terminal="
+                                    << dash::coin::QcEpisodeClassifier
+                                           ::terminal_name(ended->terminal)
+                                    << " type="
+                                    << static_cast<int>(ended->llmq_type)
+                                    << " quorum="
+                                    << ended->quorum_hash.GetHex().substr(0, 16)
+                                    << "... qi=" << ended->quorum_index
+                                    << " h=[" << ended->first_height << ".."
+                                    << ended->resumed_height << "]";
+                            }
                         }
                     }
                     return plan;

--- a/src/impl/dash/coin/dkg_commitments.hpp
+++ b/src/impl/dash/coin/dkg_commitments.hpp
@@ -473,6 +473,55 @@ inline MutableTransaction build_qc_tx(uint32_t height,
     return tx;
 }
 
+// ── PoSe interaction of REAL commitments (the #1083 landmine, enforced) ────
+
+/// dashcore's IsNull predicate over a commitment, exactly as the
+/// merkleRootQuorums fold applies it (CFinalCommitment::IsNull:
+/// CountSigners()==0 && CountValidMembers()==0). Null commitments take the
+/// IsNull() exempt path in dashd's verifier (specialtxman.cpp:427-432), so
+/// they can never trigger a PoSe punishment.
+inline bool qc_commitment_is_null(const vendor::CFinalCommitment& c)
+{
+    return c.CountSigners() == 0 && c.CountValidMembers() == 0;
+}
+
+/// Is the verifier's PoSe pass over this commitment PROVABLY a no-op?
+///
+/// dashd's verifier PoSe-punishes every quorum member the commitment marks
+/// invalid when a NON-NULL commitment is in a block — specialtxman.cpp:159-174
+/// HandleQuorumCommitment: for i over members.size(), `if (!qc.validMembers[i])
+/// ... mnList.PoSePunish(members[i]->proTxHash, mnList.CalcPenalty(66))` — and
+/// a punishment that crosses the ban threshold flips that MN's validity IN THE
+/// SAME BLOCK's MN list, changing the merkleRootMNList the same coinbase
+/// commits. c2pool does not fold that pass into its committed root (the full
+/// fold mirrors the confirmedHash rollover projection and is not built), and
+/// penalty-crossing cannot be computed daemonlessly at all: PoSe penalty state
+/// is not in the SML, so it must never be guessed.
+///
+/// The INTERIM serve predicate is therefore the provable no-op: every LISTED
+/// member — index < member_count, where member_count is the size of the
+/// deterministic member list dashd indexes validMembers with
+/// (GetAllQuorumMembers; daemonlessly the QuorumMemberSource set the BLS
+/// verify already required) — is marked valid, so the punish loop touches
+/// nothing and the committed MN root is exact. validMembers bits at
+/// index >= member_count are DKG padding up to params.size (dashcore's own
+/// Verify requires them unset) and prove nothing either way.
+///
+/// Fail-closed: a member_count of 0 or one exceeding the bitset cannot prove
+/// the no-op (nothing to index the bitset against), so the answer is false —
+/// the caller must refuse, never serve. Null commitments are exempt by the
+/// same IsNull predicate the fold and dashd's verifier use.
+inline bool qc_pose_pass_provably_noop(const vendor::CFinalCommitment& c,
+                                       size_t member_count)
+{
+    if (qc_commitment_is_null(c)) return true;   // IsNull() exempt path
+    if (member_count == 0 || member_count > c.validMembers.size())
+        return false;                            // cannot prove — fail closed
+    for (size_t i = 0; i < member_count; ++i)
+        if (!c.validMembers[i]) return false;    // dashd would PoSePunish members[i]
+    return true;
+}
+
 // ── Mineable-commitment cache (Phase-L seam) ───────────────────────────────
 
 /// Collects REAL finalized commitments off the coin-P2P `qfcommit` relay —

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -416,6 +416,30 @@ public:
         m_qc_plan_fn = std::move(fn);
     }
 
+    /// PoSe no-op proof for one REAL (non-null) type-6 commitment — the
+    /// enforcement of the #1083 landmine comment at the inclusion site
+    /// (embedded_gbt.hpp). dashd's verifier PoSe-punishes every member a
+    /// non-null in-block commitment marks invalid (specialtxman.cpp:159-174),
+    /// which can flip that MN's validity in the SAME block's list and change
+    /// the merkleRootMNList this coinbase commits — bad-cbtx-mnmerkleroot, a
+    /// silently lost block. c2pool does not fold that pass, so the pre-emit
+    /// gate refuses any real commitment whose PoSe pass is not PROVABLY a
+    /// no-op (qc_pose_pass_provably_noop: every listed member valid).
+    ///
+    /// The fn answers exactly that question for one commitment:
+    ///   true    => the PoSe pass provably touches nothing — servable;
+    ///   false   => at least one listed member would be punished — refuse;
+    ///   nullopt => cannot be established (member set not sourced) — refuse.
+    /// UNSET (default) => the capability is absent and every non-null
+    /// commitment is refused (fail-closed insurance until a real PoSe fold
+    /// into the committed MN root is built). Null commitments are exempt by
+    /// dashd's own IsNull() guard (specialtxman.cpp:427-432) and are never
+    /// consulted, so the all-null production plans are byte-unchanged.
+    void set_qc_pose_noop_fn(
+        std::function<std::optional<bool>(const vendor::CFinalCommitment&)> fn) {
+        m_qc_pose_noop_fn = std::move(fn);
+    }
+
     /// bestCL freshness guard (review PR #780 BLOCKER-2, HIGH). dashcore
     /// CheckCbTxBestChainlock rejects a block whose committed bestCLSignature is
     /// null or older than the previous block's committed ChainLock
@@ -667,6 +691,36 @@ public:
                 if (got[i] != expect.extra_payload)
                     return reject("emit-qc-payload-drift", "qc[" + std::to_string(i) + "]-bytes",
                                   "planned-qc[" + std::to_string(i) + "]-bytes");
+            }
+            // ── PoSe-fold gate on REAL commitments (the #1083 landmine, now
+            // ENFORCED — a comment refuses nothing). A verified real
+            // commitment carrying !validMembers[i] for a listed member makes
+            // dashd's verifier PoSePunish that MN (specialtxman.cpp:159-174),
+            // and a punishment crossing the ban threshold flips the MN's
+            // validity in THIS block's list — the committed merkleRootMNList
+            // above is then wrong: bad-cbtx-mnmerkleroot, a silently lost
+            // block. c2pool folds no PoSe pass, so serve a real commitment
+            // ONLY when its PoSe pass is PROVABLY a no-op (every listed
+            // member valid — the common case, so real-commitment serving
+            // stays unblocked). Absent capability / unprovable => refuse:
+            // fail-closed insurance until a real PoSe fold (mirror of the
+            // confirmedHash rollover projection) is built. Null commitments
+            // are exempt by dashd's own IsNull() guard (specialtxman.cpp:432)
+            // — all-null plans are byte-unchanged through here.
+            for (size_t i = 0; i < qc_plan->commitments.size(); ++i) {
+                const auto& c = qc_plan->commitments[i];
+                if (qc_commitment_is_null(c)) continue;   // IsNull() exempt
+                const std::optional<bool> noop =
+                    m_qc_pose_noop_fn ? m_qc_pose_noop_fn(c) : std::nullopt;
+                if (!noop.has_value() || !*noop)
+                    return reject(
+                        "emit-qc-real-pose-unfolded",
+                        "qc[" + std::to_string(i) + "]:type="
+                            + std::to_string(static_cast<int>(c.llmqType))
+                            + ",quorum=" + c.quorumHash.GetHex().substr(0, 12)
+                            + ",pose_noop="
+                            + (noop.has_value() ? "unproven" : "n/a"),
+                        "pose-pass-provably-noop(all-listed-members-valid)");
             }
         } else if (m_commitment_window_fn && m_commitment_window_fn(next_h)) {
             return reject("emit-dkg-commitment-window",
@@ -1153,6 +1207,9 @@ private:
     std::function<bool()> m_superblock_sync_complete_fn;
     std::function<bool(uint32_t)> m_commitment_window_fn;  // refuse embedded on DKG commitment heights
     std::function<std::optional<QcBlockPlan>(uint32_t)> m_qc_plan_fn;  // E1: serve DKG windows daemonlessly
+    // PoSe no-op proof for a REAL commitment (emit-qc-real-pose-unfolded gate);
+    // unset => capability absent => every non-null commitment refused.
+    std::function<std::optional<bool>(const vendor::CFinalCommitment&)> m_qc_pose_noop_fn;
     bool     m_require_fresh_bestcl{false};  // refuse embedded on a stale/absent bestCL
     BestClPolicy m_bestcl_policy{BestClPolicy::Off};  // Freshness stays the default when enabled
     bool     m_require_fresh_credit_pool{false}; // refuse embedded on a lagged credit-pool seed

--- a/src/impl/dash/coin/qc_episode_classifier.hpp
+++ b/src/impl/dash/coin/qc_episode_classifier.hpp
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// [QC-EPISODE] — terminal-event classifier for `qc-plan-underivable`
+/// episodes (docs/DASH_NULL_COMMITMENT_ARM_DESIGN.md §8, recommendation 1).
+///
+/// Every qc-plan-underivable episode — a contiguous run of DKG-window heights
+/// refused because a mandatory type-6 slot has no BLS-verified real
+/// commitment — ends in exactly one of three ways:
+///
+///   * `real-arrived`      — the qfcommit flood delivered the real commitment
+///                           (the MineableCommitmentCache gained it and the
+///                           slot is served real);
+///   * `real-mined`        — another miner mined it (`has_mined` flipped: the
+///                           mnlistdiff-fed QuorumManager now holds the
+///                           quorum, so the slot left the mandatory set);
+///   * `window-closed-null`— the DKG mining window closed with NO real
+///                           commitment ever seen — the network mined null to
+///                           the end. This is the ONLY case dashd's
+///                           null-commitment arm would have recovered.
+///
+/// The class-3 wall-clock total is the standing measurement that decides
+/// whether the null arm (deferred by the design's §8 benefit accounting:
+/// measured benefit today is zero) is ever worth building. Pure logging
+/// policy: no I/O, no clock of its own (the caller passes monotonic
+/// seconds), no coin state — the terminal class is derived from facts the
+/// caches already hold at RESUME time, queried by the caller. Header-only so
+/// it folds into the already-allowlisted dash test targets.
+///
+/// SCOPE: only slot-shaped refusals (a named gap slot) start an episode.
+/// A plan that is underivable for structural reasons — header gap, below the
+/// serve floor — is not a commitment wait and neither starts nor ends one.
+/// An episode may progress across slots (slot A resolves, slot B still
+/// blocks): the blocking slot is updated on every underivable observation
+/// and the terminal event is classified against the LAST blocker — the slot
+/// whose fact-flip actually ended the episode.
+
+#include <core/uint256.hpp>
+
+#include <cstdint>
+#include <optional>
+
+namespace dash {
+namespace coin {
+
+class QcEpisodeClassifier {
+public:
+    enum class Terminal : uint8_t {
+        RealArrived,       ///< flood delivered: the cache gained the commitment
+        RealMined,         ///< another miner mined it: has_mined flipped
+        WindowClosedNull,  ///< window closed, no real commitment ever seen
+        /// The honest name for a resolution none of the three facts explains
+        /// (e.g. a reorg re-keyed the slot's base hash mid-window). Never
+        /// silently mapped onto a real class — state says its own name.
+        Unclassified,
+    };
+
+    static const char* terminal_name(Terminal t)
+    {
+        switch (t) {
+            case Terminal::RealArrived:      return "real-arrived";
+            case Terminal::RealMined:        return "real-mined";
+            case Terminal::WindowClosedNull: return "window-closed-null";
+            case Terminal::Unclassified:     return "unclassified";
+        }
+        return "unclassified";
+    }
+
+    /// The slot currently blocking the active episode — what the caller must
+    /// query its caches about before calling observe_derivable().
+    struct PendingSlot {
+        uint8_t  llmq_type{0};
+        int16_t  quorum_index{0};
+        uint256  quorum_hash;
+        uint32_t window_last_height{0};  ///< cycleStart + dkgMiningWindowEnd
+    };
+
+    /// One finished episode — everything the [QC-EPISODE] line prints.
+    struct Ended {
+        Terminal terminal{Terminal::Unclassified};
+        int64_t  duration_sec{0};
+        uint8_t  llmq_type{0};
+        int16_t  quorum_index{0};
+        uint256  quorum_hash;
+        uint32_t first_height{0};    ///< first refused height of the episode
+        uint32_t resumed_height{0};  ///< the height whose plan derived
+    };
+
+    /// Feed one underivable observation with its classified gap slot. Starts
+    /// an episode if none is active; otherwise updates the blocking slot to
+    /// the CURRENT one (see SCOPE note above). Cheap enough for the
+    /// per-template plan path.
+    void observe_underivable(uint32_t next_h, uint8_t llmq_type,
+                             int16_t quorum_index, const uint256& quorum_hash,
+                             uint32_t window_last_height, int64_t now_sec)
+    {
+        if (!m_active) {
+            m_active       = true;
+            m_started_sec  = now_sec;
+            m_first_height = next_h;
+        }
+        m_slot.llmq_type          = llmq_type;
+        m_slot.quorum_index       = quorum_index;
+        m_slot.quorum_hash        = quorum_hash;
+        m_slot.window_last_height = window_last_height;
+    }
+
+    bool active() const { return m_active; }
+
+    /// The slot to interrogate the caches about, or std::nullopt when no
+    /// episode is active.
+    std::optional<PendingSlot> pending() const
+    {
+        if (!m_active) return std::nullopt;
+        return m_slot;
+    }
+
+    /// Feed one derivable observation (the plan derived — the episode, if
+    /// any, RESUMEs here). The two facts are queried BY THE CALLER for the
+    /// pending() slot at resume time:
+    ///   cache_has_commitment : MineableCommitmentCache holds a commitment
+    ///                          for the slot (the flood delivered it);
+    ///   has_mined            : the QuorumManager holds the quorum (another
+    ///                          miner mined the commitment).
+    /// Classification, in order: cache_has_commitment => real-arrived (the
+    /// arrival lane worked, even if the network also mined it meanwhile —
+    /// the split between the first two classes is diagnostic; only
+    /// window-closed-null argues FOR the null arm); else has_mined =>
+    /// real-mined; else past the window's last height => window-closed-null;
+    /// else the honest `unclassified`. Returns the finished episode exactly
+    /// once; std::nullopt when no episode was active.
+    std::optional<Ended> observe_derivable(uint32_t next_h,
+                                           bool cache_has_commitment,
+                                           bool has_mined, int64_t now_sec)
+    {
+        if (!m_active) return std::nullopt;
+        Ended e;
+        if (cache_has_commitment)
+            e.terminal = Terminal::RealArrived;
+        else if (has_mined)
+            e.terminal = Terminal::RealMined;
+        else if (next_h > m_slot.window_last_height)
+            e.terminal = Terminal::WindowClosedNull;
+        else
+            e.terminal = Terminal::Unclassified;
+        e.duration_sec   = now_sec - m_started_sec;
+        e.llmq_type      = m_slot.llmq_type;
+        e.quorum_index   = m_slot.quorum_index;
+        e.quorum_hash    = m_slot.quorum_hash;
+        e.first_height   = m_first_height;
+        e.resumed_height = next_h;
+        m_active = false;
+        m_slot   = PendingSlot{};
+        return e;
+    }
+
+private:
+    bool        m_active{false};
+    PendingSlot m_slot;
+    int64_t     m_started_sec{0};
+    uint32_t    m_first_height{0};
+};
+
+}  // namespace coin
+}  // namespace dash

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -731,6 +731,7 @@ if (BUILD_TESTING AND GTest_FOUND)
         test_dash_qrinfo.cpp
         test_dash_rotated_quorum_members.cpp
         test_dash_dkg_commitments.cpp
+        test_dash_qc_episode_classifier.cpp
         test_dash_sml_quorum_db.cpp
         test_dash_embedded_oracle_shadow.cpp
         test_dash_mn_confirm_rollover.cpp

--- a/test/test_dash_dkg_commitments.cpp
+++ b/test/test_dash_dkg_commitments.cpp
@@ -1459,3 +1459,76 @@ TEST(DashLlmqTypeReconciler, ReadsTheProductionQuorumManagerSource)
     EXPECT_EQ(d[0].llmq_type, 5);
     EXPECT_EQ(d[0].verdict, LlmqTypeVerdict::NeverObserved);
 }
+
+// ── qc_pose_pass_provably_noop: the interim PoSe serve predicate ───────────
+//
+// dashd PoSe-punishes every member a NON-NULL in-block commitment marks
+// invalid (specialtxman.cpp:159-174 HandleQuorumCommitment ->
+// PoSePunish(CalcPenalty(66))), mutating the SAME block's merkleRootMNList
+// when a punishment crosses the ban threshold; null commitments are exempt
+// (specialtxman.cpp:427-432 IsNull() guard). c2pool folds no PoSe pass, so a
+// real commitment is servable ONLY when that pass is provably a no-op: every
+// LISTED member (index < member_count of the deterministic member list dashd
+// indexes validMembers with) marked valid. These KATs pin the predicate's
+// fail-closed edges.
+
+TEST(DashQcPoseNoopPredicate, NullCommitmentIsExemptByConstruction)
+{
+    // The arm-synthesized null (all-false bitsets, zero crypto) takes the
+    // IsNull() exempt path in every verifier — provably a no-op regardless
+    // of member count, even an unknowable one (0).
+    const auto null_c = build_null_commitment(kLlmq50_60, h256(0x31), 0);
+    EXPECT_TRUE(qc_commitment_is_null(null_c));
+    EXPECT_TRUE(qc_pose_pass_provably_noop(null_c, 0));
+    EXPECT_TRUE(qc_pose_pass_provably_noop(null_c, 50));
+}
+
+TEST(DashQcPoseNoopPredicate, AllListedMembersValidIsProvableNoop)
+{
+    // The common case: a full quorum, every listed member valid — the PoSe
+    // punish loop touches nothing, serving stays unblocked.
+    const auto c = real_commitment(kLlmq50_60, h256(0x32), 0, 0x01);
+    EXPECT_FALSE(qc_commitment_is_null(c));
+    EXPECT_TRUE(qc_pose_pass_provably_noop(c, 50));
+}
+
+TEST(DashQcPoseNoopPredicate, PaddingBitsBeyondMemberCountProveNothingBad)
+{
+    // A NON-FULL quorum: 40 members on a size-50 type. dashcore's own Verify
+    // requires bits at index >= members.size() unset, so a fully-valid
+    // commitment there has false bits [40,50) — DKG padding, not punished
+    // members. The predicate must NOT read padding as a punishment (that
+    // would refuse every non-full quorum forever).
+    auto c = real_commitment(kLlmq50_60, h256(0x33), 0, 0x02);
+    for (size_t i = 40; i < 50; ++i) {
+        c.signers[i]      = false;
+        c.validMembers[i] = false;
+    }
+    EXPECT_TRUE(qc_pose_pass_provably_noop(c, 40));
+    // The SAME bitset judged against a 50-member list reads indices [40,50)
+    // as punished listed members — refused. member_count is load-bearing.
+    EXPECT_FALSE(qc_pose_pass_provably_noop(c, 50));
+}
+
+TEST(DashQcPoseNoopPredicate, OnePunishedListedMemberRefuses)
+{
+    // THE LANDMINE INPUT: a verified real commitment carrying
+    // !validMembers[i] for a listed member — dashd would PoSePunish
+    // members[7] in the block's own MN list. Never provably a no-op.
+    auto c = real_commitment(kLlmq50_60, h256(0x34), 0, 0x03);
+    c.validMembers[7] = false;
+    EXPECT_FALSE(qc_pose_pass_provably_noop(c, 50));
+    // Punished member visible even at the smallest count that lists it.
+    EXPECT_FALSE(qc_pose_pass_provably_noop(c, 8));
+    // A count that does NOT list index 7 cannot see a punishment there.
+    EXPECT_TRUE(qc_pose_pass_provably_noop(c, 7));
+}
+
+TEST(DashQcPoseNoopPredicate, UnprovableMemberCountsFailClosed)
+{
+    // No member list (count 0) or a count exceeding the bitset: the punish
+    // loop cannot be modeled, so the answer is REFUSE, never a guess.
+    const auto c = real_commitment(kLlmq50_60, h256(0x35), 0, 0x04);
+    EXPECT_FALSE(qc_pose_pass_provably_noop(c, 0));
+    EXPECT_FALSE(qc_pose_pass_provably_noop(c, 51));
+}

--- a/test/test_dash_node_coin_state.cpp
+++ b/test/test_dash_node_coin_state.cpp
@@ -1278,3 +1278,182 @@ TEST(DashServeGateNamesRefusal, NoTipOnlyWhenTheMaintainerNeverReported) {
     EXPECT_EQ(d.value, "prev_hash=null,maintainer-never-reported")
         << "and it must say that it is inferring, not measuring";
 }
+
+// ════════════════════════════════════════════════════════════════════════
+// The #1083 PoSe landmine, ENFORCED (emit-qc-real-pose-unfolded).
+//
+// dashd's verifier PoSe-punishes every quorum member a NON-NULL in-block
+// commitment marks invalid (specialtxman.cpp:159-174 HandleQuorumCommitment
+// -> PoSePunish(CalcPenalty(66))), and a punishment crossing the ban
+// threshold flips that MN's validity IN THE SAME BLOCK's MN list — changing
+// the merkleRootMNList the same coinbase commits. Null commitments are
+// exempt (specialtxman.cpp:427-432, IsNull() guard). c2pool folds no PoSe
+// pass into its committed root; since #1077 wired rotated member sourcing
+// the real-commitment lane is LIVE, so a verified real commitment carrying
+// !validMembers[i] for a listed member is a servable bad-cbtx-mnmerkleroot —
+// a silently losable block. The pre-emit gate must refuse it; the ONLY thing
+// standing there before this gate was a comment (embedded_gbt.hpp), and a
+// comment refuses nothing.
+//
+// Shared fixture: the QcPlanServesDkgWindowHeightAndEmitGateEnforcesIt
+// posture (tip 1518417 => next 1518418), with the plan fn returning ONE
+// commitment — the same closure shape production installs, minus sourcing.
+// ════════════════════════════════════════════════════════════════════════
+
+namespace {
+
+dash::coin::vendor::CFinalCommitment make_real_qc(bool punish_listed_member)
+{
+    // A structurally real (non-null) testnet LLMQ_50_60 commitment: full
+    // 50-member quorum, non-zero crypto fields. punish_listed_member marks
+    // ONE listed member invalid — the exact landmine input.
+    dash::coin::vendor::CFinalCommitment c;
+    c.nVersion = dash::coin::vendor::CFinalCommitment
+                     ::BASIC_BLS_NON_INDEXED_QUORUM_VERSION;
+    c.llmqType    = 1;                    // LLMQ_50_60 (testnet-enabled)
+    c.quorumHash  = raw256(0x50);
+    c.quorumIndex = 0;
+    c.signers.assign(50, true);
+    c.validMembers.assign(50, true);
+    if (punish_listed_member) c.validMembers[7] = false;
+    c.quorumPublicKey.fill(0x11);
+    c.quorumVvecHash = raw256(0x22);
+    c.quorumSig.fill(0x33);
+    c.membersSig.fill(0x44);
+    return c;
+}
+
+// Seed the same healthy DKG-window serving posture the E1 qc-plan test uses,
+// with a plan fn returning exactly `qc` + a fixed with-block root override.
+void seed_real_qc_serving(NodeCoinState& st,
+                          const dash::coin::vendor::CFinalCommitment& qc)
+{
+    seed_single_mn(st, p2pkh_script(0x30));
+    seed_sml(st);
+    st.set_require_sml(true);
+    st.set_sml_current_hash(raw256(0xAB));
+    dash::coin::QcBlockPlan plan;
+    plan.commitments = {qc};
+    plan.merkle_root_quorums = raw256(0x77);
+    st.set_qc_plan_fn([plan](uint32_t) {
+        return std::optional<dash::coin::QcBlockPlan>{plan};
+    });
+    st.set_tip(1518417, raw256(0xAB), 0x1b104be3u, 1'700'000'000u,
+               DASH_PUBKEY_VER, DASH_P2SH_VER, 1'700'000'123u, 0x20000000u);
+}
+
+} // namespace
+
+// THE MASTER DEFECT, pinned. On pre-gate master this test FAILS at the
+// EXPECT_FALSE: the punishing real commitment sails through the pre-emit
+// gate (count/payload/root all self-consistent) and the template SERVES —
+// the silently losable block. No PoSe-noop capability is wired here, which
+// is exactly the state production shipped in: the gate must fail CLOSED on
+// capability absence, not only on a proven punishment.
+TEST(DashQcPoseGate, RealCommitmentPunishingListedMemberIsRefusedAtEmit) {
+    NodeCoinState st;
+    seed_real_qc_serving(st, make_real_qc(/*punish_listed_member=*/true));
+
+    // The template BUILDS and carries the real qc tx — viability alone does
+    // not (and cannot cheaply) prove the PoSe no-op; the emit gate is the
+    // enforcement point, exactly like the other emit re-derivations.
+    WorkSelection sel = st.select_work([] { return DashWorkData{}; });
+    ASSERT_EQ(sel.source, WorkSource::Embedded);
+    ASSERT_EQ(sel.work.m_txs.size(), 1u);
+    ASSERT_EQ(sel.work.m_txs[0].type, 6);
+
+    DeclineReport why;
+    EXPECT_FALSE(st.embedded_template_emit_ok(sel.work, &why))
+        << "a REAL commitment that PoSe-punishes a listed member reached the "
+           "miner: dashd's verifier flips that MN in THIS block's list and "
+           "the committed merkleRootMNList is wrong (bad-cbtx-mnmerkleroot = "
+           "a silently lost block)";
+    EXPECT_EQ(why.cause, "emit-qc-real-pose-unfolded");
+    EXPECT_EQ(why.threshold, "pose-pass-provably-noop(all-listed-members-valid)");
+    EXPECT_NE(why.value.find("pose_noop=n/a"), std::string::npos)
+        << "capability ABSENT must print n/a, not a fabricated verdict: "
+        << why.value;
+}
+
+// Negative twin: with the PoSe-noop capability wired and every listed member
+// valid (the common case), the SAME posture serves exactly as before — the
+// gate is punishment-specific, not a blanket real-commitment refuse.
+TEST(DashQcPoseGate, AllListedMembersValidServesExactlyAsBefore) {
+    NodeCoinState st;
+    seed_real_qc_serving(st, make_real_qc(/*punish_listed_member=*/false));
+    st.set_qc_pose_noop_fn(
+        [](const dash::coin::vendor::CFinalCommitment& c)
+            -> std::optional<bool> {
+            // The production shape: judge against the deterministic member
+            // list's size (full 50-member quorum here).
+            return dash::coin::qc_pose_pass_provably_noop(c, 50);
+        });
+
+    WorkSelection sel = st.select_work([] { return DashWorkData{}; });
+    ASSERT_EQ(sel.source, WorkSource::Embedded);
+    DeclineReport why;
+    EXPECT_TRUE(st.embedded_template_emit_ok(sel.work, &why))
+        << "cause=" << why.cause << " value=" << why.value;
+
+    // And the pre-existing drift enforcement is untouched: dropping the
+    // mandatory commitment still discards the template (bad-qc-missing).
+    DashWorkData tampered = sel.work;
+    tampered.m_txs.clear();
+    EXPECT_FALSE(st.embedded_template_emit_ok(tampered));
+}
+
+// With the capability WIRED, a proven punishment refuses with the measured
+// value naming the offending commitment — cause/value/threshold discipline.
+TEST(DashQcPoseGate, PunishingCommitmentRefusedEvenWithCapabilityWired) {
+    NodeCoinState st;
+    seed_real_qc_serving(st, make_real_qc(/*punish_listed_member=*/true));
+    st.set_qc_pose_noop_fn(
+        [](const dash::coin::vendor::CFinalCommitment& c)
+            -> std::optional<bool> {
+            return dash::coin::qc_pose_pass_provably_noop(c, 50);
+        });
+
+    WorkSelection sel = st.select_work([] { return DashWorkData{}; });
+    ASSERT_EQ(sel.source, WorkSource::Embedded);
+    DeclineReport why;
+    EXPECT_FALSE(st.embedded_template_emit_ok(sel.work, &why));
+    EXPECT_EQ(why.cause, "emit-qc-real-pose-unfolded");
+    EXPECT_NE(why.value.find("pose_noop=unproven"), std::string::npos)
+        << "a MEASURED failed proof must say 'unproven', not 'n/a': "
+        << why.value;
+    EXPECT_NE(why.value.find("type=1"), std::string::npos) << why.value;
+}
+
+// A wired capability that CANNOT answer (member set no longer cached) must
+// refuse — nullopt is "cannot prove", and unprovable serves nothing.
+TEST(DashQcPoseGate, UnprovableMemberSetFailsClosed) {
+    NodeCoinState st;
+    seed_real_qc_serving(st, make_real_qc(/*punish_listed_member=*/false));
+    st.set_qc_pose_noop_fn(
+        [](const dash::coin::vendor::CFinalCommitment&)
+            -> std::optional<bool> { return std::nullopt; });
+
+    WorkSelection sel = st.select_work([] { return DashWorkData{}; });
+    ASSERT_EQ(sel.source, WorkSource::Embedded);
+    DeclineReport why;
+    EXPECT_FALSE(st.embedded_template_emit_ok(sel.work, &why));
+    EXPECT_EQ(why.cause, "emit-qc-real-pose-unfolded");
+    EXPECT_NE(why.value.find("pose_noop=n/a"), std::string::npos) << why.value;
+}
+
+// Null commitments are exempt by dashd's own IsNull() guard — an all-null
+// plan serves with NO capability wired, byte-unchanged. (The E1 qc-plan test
+// above already proves this through the full daemonless plan; this twin pins
+// it against the gate directly so the exemption cannot silently narrow.)
+TEST(DashQcPoseGate, NullCommitmentPlanIsExemptWithoutCapability) {
+    NodeCoinState st;
+    const auto null_qc = dash::coin::build_null_commitment(
+        dash::coin::kLlmq50_60, raw256(0x50), 0);
+    seed_real_qc_serving(st, null_qc);
+    // No set_qc_pose_noop_fn on purpose.
+    WorkSelection sel = st.select_work([] { return DashWorkData{}; });
+    ASSERT_EQ(sel.source, WorkSource::Embedded);
+    DeclineReport why;
+    EXPECT_TRUE(st.embedded_template_emit_ok(sel.work, &why))
+        << "cause=" << why.cause << " value=" << why.value;
+}

--- a/test/test_dash_qc_episode_classifier.cpp
+++ b/test/test_dash_qc_episode_classifier.cpp
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/// [QC-EPISODE] terminal-event classifier KATs (qc_episode_classifier.hpp).
+/// Compiled into the CI-allowlisted test_dash_embedded_gbt executable.
+///
+/// Every `qc-plan-underivable` episode ends exactly one of three ways —
+/// `real-arrived` (the qfcommit flood delivered the commitment),
+/// `real-mined` (another miner mined it, has_mined flipped), or
+/// `window-closed-null` (the DKG window closed with NO real commitment ever
+/// seen — the ONLY case dashd's null-commitment arm would have recovered).
+/// The class-3 wall-clock total is the standing measurement the null-arm
+/// design (docs/DASH_NULL_COMMITMENT_ARM_DESIGN.md §8) defers its build
+/// decision to, so the classifier must be exact: each synthetic episode
+/// below ends one way and must be named that way, once, with the measured
+/// duration — and a resolution none of the three facts explains must say
+/// `unclassified`, never borrow a real class.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/qc_episode_classifier.hpp>
+
+#include <core/uint256.hpp>
+
+#include <cstring>
+
+using dash::coin::QcEpisodeClassifier;
+using Terminal = QcEpisodeClassifier::Terminal;
+
+namespace {
+
+uint256 qh256(uint8_t fill)
+{
+    uint256 u;
+    std::memset(u.data(), fill, 32);
+    return u;
+}
+
+// The incident-shaped window: testnet interval-24 window [1518418,1518426]
+// (cycle 1518408, dkgMiningWindowEnd offset 18).
+constexpr uint32_t kFirstH = 1'518'418u;
+constexpr uint32_t kLastH  = 1'518'426u;
+
+} // namespace
+
+TEST(DashQcEpisodeClassifier, FloodDeliveryClassifiesRealArrived)
+{
+    QcEpisodeClassifier ep;
+    EXPECT_FALSE(ep.active());
+    ep.observe_underivable(kFirstH, 1, 0, qh256(0x50), kLastH, /*now=*/100);
+    ep.observe_underivable(kFirstH, 1, 0, qh256(0x50), kLastH, /*now=*/160);
+    ASSERT_TRUE(ep.active());
+
+    // The cache gained the commitment (the flood delivered it): RESUME.
+    auto ended = ep.observe_derivable(kFirstH, /*cache_has=*/true,
+                                      /*mined=*/false, /*now=*/245);
+    ASSERT_TRUE(ended.has_value());
+    EXPECT_EQ(ended->terminal, Terminal::RealArrived);
+    EXPECT_STREQ(QcEpisodeClassifier::terminal_name(ended->terminal),
+                 "real-arrived");
+    EXPECT_EQ(ended->duration_sec, 145)
+        << "duration must span the WHOLE episode (first refusal to resume), "
+           "not the last observation";
+    EXPECT_EQ(ended->llmq_type, 1);
+    EXPECT_EQ(ended->quorum_hash, qh256(0x50));
+    EXPECT_EQ(ended->first_height, kFirstH);
+    EXPECT_EQ(ended->resumed_height, kFirstH);
+    EXPECT_FALSE(ep.active());
+}
+
+TEST(DashQcEpisodeClassifier, AnotherMinerMiningClassifiesRealMined)
+{
+    QcEpisodeClassifier ep;
+    ep.observe_underivable(kFirstH, 4, 0, qh256(0x51), kLastH, 1000);
+    // has_mined flipped (mnlistdiff-fed QuorumManager gained the quorum);
+    // the slot left the mandatory set two heights later.
+    auto ended = ep.observe_derivable(kFirstH + 2, /*cache_has=*/false,
+                                      /*mined=*/true, 1300);
+    ASSERT_TRUE(ended.has_value());
+    EXPECT_EQ(ended->terminal, Terminal::RealMined);
+    EXPECT_STREQ(QcEpisodeClassifier::terminal_name(ended->terminal),
+                 "real-mined");
+    EXPECT_EQ(ended->duration_sec, 300);
+    EXPECT_EQ(ended->resumed_height, kFirstH + 2);
+}
+
+TEST(DashQcEpisodeClassifier, WindowCloseWithNothingSeenClassifiesNull)
+{
+    // The one class that argues FOR the null arm: the whole window passed
+    // with the commitment neither delivered nor mined — the network mined
+    // null to the end, and only a null arm could have served those heights.
+    QcEpisodeClassifier ep;
+    ep.observe_underivable(kFirstH, 1, 0, qh256(0x52), kLastH, 0);
+    auto ended = ep.observe_derivable(kLastH + 1, /*cache_has=*/false,
+                                      /*mined=*/false, 1380);
+    ASSERT_TRUE(ended.has_value());
+    EXPECT_EQ(ended->terminal, Terminal::WindowClosedNull);
+    EXPECT_STREQ(QcEpisodeClassifier::terminal_name(ended->terminal),
+                 "window-closed-null");
+    EXPECT_EQ(ended->duration_sec, 1380)
+        << "~23 min — the whole-window outage shape the design doc predicts "
+           "for a genuine failed DKG";
+}
+
+TEST(DashQcEpisodeClassifier, InexplicableResolutionSaysUnclassified)
+{
+    // Window still open, commitment neither cached nor mined, yet the plan
+    // derived (e.g. a reorg re-keyed the slot's base hash). The honest name
+    // is `unclassified` — mapping it onto a real class would corrupt the
+    // very measurement the classifier exists to take.
+    QcEpisodeClassifier ep;
+    ep.observe_underivable(kFirstH, 1, 0, qh256(0x53), kLastH, 0);
+    auto ended = ep.observe_derivable(kFirstH + 1, /*cache_has=*/false,
+                                      /*mined=*/false, 60);
+    ASSERT_TRUE(ended.has_value());
+    EXPECT_EQ(ended->terminal, Terminal::Unclassified);
+    EXPECT_STREQ(QcEpisodeClassifier::terminal_name(ended->terminal),
+                 "unclassified");
+}
+
+TEST(DashQcEpisodeClassifier, EpisodeReSlotsToTheLastBlocker)
+{
+    // An episode can progress across slots: slot A (type 1) resolves while
+    // slot B (type 4) still blocks. The terminal event is classified against
+    // the LAST blocker — the slot whose fact-flip actually ended the episode
+    // — while the duration still spans from the FIRST refusal.
+    QcEpisodeClassifier ep;
+    ep.observe_underivable(kFirstH, 1, 0, qh256(0x54), kLastH, 100);
+    ep.observe_underivable(kFirstH + 1, 4, 0, qh256(0x55), kLastH, 400);
+    ASSERT_TRUE(ep.pending().has_value());
+    EXPECT_EQ(ep.pending()->llmq_type, 4);
+    EXPECT_EQ(ep.pending()->quorum_hash, qh256(0x55));
+
+    auto ended = ep.observe_derivable(kFirstH + 1, /*cache_has=*/true,
+                                      /*mined=*/false, 500);
+    ASSERT_TRUE(ended.has_value());
+    EXPECT_EQ(ended->llmq_type, 4);
+    EXPECT_EQ(ended->quorum_hash, qh256(0x55));
+    EXPECT_EQ(ended->duration_sec, 400)
+        << "re-slotting must not restart the episode clock";
+    EXPECT_EQ(ended->first_height, kFirstH);
+}
+
+TEST(DashQcEpisodeClassifier, OneLinePerEpisodeAndNoLineWithoutOne)
+{
+    QcEpisodeClassifier ep;
+    // Derivable observations with NO active episode (the steady-state
+    // serving path, hit on every template re-source) must return nothing.
+    EXPECT_FALSE(ep.observe_derivable(kFirstH, true, true, 10).has_value());
+    EXPECT_FALSE(ep.pending().has_value());
+
+    ep.observe_underivable(kFirstH, 1, 0, qh256(0x56), kLastH, 20);
+    EXPECT_TRUE(ep.observe_derivable(kFirstH, true, false, 30).has_value());
+    // The episode is spent: exactly one terminal line, never two.
+    EXPECT_FALSE(ep.observe_derivable(kFirstH, true, false, 40).has_value());
+    EXPECT_FALSE(ep.active());
+}
+
+TEST(DashQcEpisodeClassifier, ArrivalOutranksMinedInTheTieBreak)
+{
+    // Both facts true at resume (the flood delivered it AND the network
+    // mined it before we won a block): classified real-arrived — the
+    // arrival-lane evidence is the diagnostic split; only
+    // window-closed-null feeds the null-arm decision, and it is unaffected.
+    QcEpisodeClassifier ep;
+    ep.observe_underivable(kFirstH, 1, 0, qh256(0x57), kLastH, 0);
+    auto ended = ep.observe_derivable(kFirstH + 1, /*cache_has=*/true,
+                                      /*mined=*/true, 90);
+    ASSERT_TRUE(ended.has_value());
+    EXPECT_EQ(ended->terminal, Terminal::RealArrived);
+}


### PR DESCRIPTION
Two small, zero-consensus-risk changes to the DASH daemonless lane, both specified by the accepted design doc `docs/DASH_NULL_COMMITMENT_ARM_DESIGN.md` (frstrtr/the) — its §9 PoSe-interaction precondition and its §8 recommendation 1. Nothing here builds or arms the null-commitment arm itself; that stays DEFERRED per the design's benefit accounting.

## 1. PoSe-fold gate enforced: `emit-qc-real-pose-unfolded`

Since #1077 wired rotated member sourcing, the real-commitment lane is LIVE (`real-commitment serving ENABLED`). dashd's verifier PoSe-punishes every quorum member a NON-NULL in-block commitment marks invalid (`evo/specialtxman.cpp:159-174`, `HandleQuorumCommitment` → `PoSePunish(CalcPenalty(66))`), and a punishment that crosses the ban threshold flips that MN's validity in the SAME block's MN list — changing the `merkleRootMNList` the same coinbase commits. Null commitments are exempt (`specialtxman.cpp:427-432`, the `IsNull()` guard). c2pool folds no PoSe pass into its committed root; the only thing standing at the inclusion site was the #1083 landmine comment (`embedded_gbt.hpp`), and a comment refuses nothing. **MEASURED (by the new test, on current master): a verified real commitment carrying `!validMembers[i]` for a listed member sails through the pre-emit gate and SERVES** — `bad-cbtx-mnmerkleroot` on a winning share, a silently lost block. **INFERRED / honestly unknown: the FREQUENCY of that input** (a real commitment with a failed listed member) has never been measured; the risk is real but unquantified — which is exactly why the fix is fail-closed insurance, not a fold.

The gate, per the design:

* The pre-emit gate (`NodeCoinState::embedded_template_emit_ok`, next to the other qc re-derivations) refuses any REAL (non-null) commitment in the plan whose PoSe pass is not **provably a no-op**, with the named cause `emit-qc-real-pose-unfolded` and cause/value/threshold discipline (`value` names the offending commitment and whether the proof was `unproven` or `n/a`; `threshold=pose-pass-provably-noop(all-listed-members-valid)`).
* The serve predicate passes when every LISTED member is valid in the commitment — judged against the size of the SAME deterministic member list the BLS verifier already sourced (`QuorumMemberSource::lookup`, a pure cache hit; its size is the `members.size()` dashd's punish loop runs over). That is the common case, so real-commitment serving stays unblocked. `validMembers` bits beyond the member count are DKG padding (dashd's own `Verify` requires them unset) and are not read as punishments — a non-full quorum is not refused.
* Capability absent (fn unset) or unprovable (member set not cached) ⇒ refuse. This is fail-closed **insurance until a real PoSe fold into the committed MN root is built** (mirror of the confirmedHash rollover projection); penalty-crossing cannot be computed daemonlessly (PoSe penalty state is not in the SML) and is never guessed. The comment at the inclusion site is now an enforced gate.
* Null commitments are exempt by the same `IsNull` predicate the root fold uses — today's all-null production plans are byte-unchanged through the gate (pinned by test).

## 2. `[QC-EPISODE]` terminal-event classifier (pure observability)

Every `qc-plan-underivable` episode ends one of three ways, and the split is the measurement the null-arm decision waits on:

* `real-arrived` — the qfcommit flood delivered the commitment (cache gained it);
* `real-mined` — another miner mined it (`has_mined` flipped off the mnlistdiff-fed QuorumManager);
* `window-closed-null` — the DKG window closed with NO real commitment ever seen — **the only case the null arm could ever help**.

One `LOG_INFO` line per episode at RESUME:

```
[QC-EPISODE] cause=qc-plan-underivable dur=Ns terminal=<class> type=N quorum=<hash16>... qi=N h=[first..resumed]
```

Implementation: `qc_episode_classifier.hpp`, a pure header-only policy in the `ServeGateJournal` mold — no I/O, no clock of its own, no new state machine; the terminal class is derived from facts the caches already hold at RESUME time (commitment cache, QuorumManager, window bound). Wired inside the existing `qc_plan_fn` closure in `main_dash.cpp`. Structural nullopts (header gap / below the serve floor) are not commitment waits and neither start nor end an episode; a resolution none of the three facts explains logs the honest `unclassified`, never a borrowed class. The design's benefit accounting is MEASURED at ~1.24% wall-clock for the whole cause, with the `window-closed-null` share INFERRED to be ~0 of it (zero whole-window-shaped episodes observed) — **this classifier converts that inference into a standing measurement**, the same way the frequency unknown in change 1 would need its own counter.

## Tests

* `DashQcPoseGate.RealCommitmentPunishingListedMemberIsRefusedAtEmit` — **fails on current master, verified by building master + this test in a separate worktree**: on `932302a8`, the punishing real commitment is served (`embedded_template_emit_ok` returns true); with this change it is refused with `cause=emit-qc-real-pose-unfolded`, `pose_noop=n/a` (capability absent — the exact state production shipped in).
* `DashQcPoseGate.AllListedMembersValidServesExactlyAsBefore` — capability wired, all listed members valid ⇒ serves; the pre-existing count-drift enforcement is untouched.
* `DashQcPoseGate.PunishingCommitmentRefusedEvenWithCapabilityWired` / `UnprovableMemberSetFailsClosed` / `NullCommitmentPlanIsExemptWithoutCapability` — the measured `unproven` vs `n/a` distinction, nullopt fail-closed, and the IsNull exemption (all-null plans byte-unchanged).
* `DashQcPoseNoopPredicate.*` (5 KATs, `test_dash_dkg_commitments.cpp`) — predicate edges: null exempt, full-valid passes, non-full-quorum padding is not a punishment (member_count is load-bearing), one punished listed member refuses, count 0 / oversized fail closed.
* `DashQcEpisodeClassifier.*` (7 KATs, new `test_dash_qc_episode_classifier.cpp`) — synthetic episodes ending each of the three ways produce the right terminal class; plus `unclassified` honesty, episode re-slotting to the last blocker without restarting the clock, one-line-per-episode, and the arrival-outranks-mined tie-break.

Test registration: everything is folded into the already-allowlisted `test_dash_node_coin_state` and `test_dash_embedded_gbt` targets (the new classifier KAT file is a new SOURCE in the existing `test_dash_embedded_gbt` executable, not a new target); `python3 tools/ci/check_test_target_allowlist.py` is green. No test here needs `C2POOL_DASH_BLS` — commitments are fabricated structurally and the plan/pose seams are injected, so no BLS-job registration or must-report-as-run additions apply.

## Notes

* Block **1520106 was a TESTNET height** (the definitive-soak bad-cbtx incident; the design doc corrected an earlier "mainnet" mislabel — do not propagate it).
* MEASURED vs INFERRED, restated: the master-serves-the-punishing-commitment behaviour is MEASURED (failing test on master); the block-loss risk's real-world frequency is UNKNOWN (no counter exists for punishing commitments — analogous to the `window-closed-null` unknown the new classifier now measures for the null arm).
* Scope: DASH lane only; no consensus behaviour changes on any serve path that was correct before (all-null plans byte-unchanged; real commitments with clean PoSe passes serve exactly as before).
