### PR TITLE
dash: body-first serve tip, lost-body watchdog, bounded full-block buffer (stacked on #1089)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -3802,7 +3802,12 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             coin_state.new_block.subscribe(
                 [cp = coin_p2p.get(), hc = header_chain.get()](const uint256& hash) {
                     cp->send_getheaders(70230, hc->get_locator(), uint256::ZERO);
-                    cp->request_block(hash);
+                    // TRACKED: this is the tip-body pull, the one request the
+                    // serve tip now waits on (body-first). The lost-body
+                    // watchdog re-requests it from a rotated peer after 10 s
+                    // (`cause=body-rerequest` in the log) instead of waiting
+                    // out the 600 s inv-dedup TTL — the #1089 208 s tail.
+                    cp->request_block_tracked(hash);
                 }));
 
         // new_chainlock -> record into the best-chainlock tracker (finalization
@@ -3824,6 +3829,27 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     if (batch.empty()) return;
                     cp->send_getheaders(70230, hc->get_locator(), uint256::ZERO);
                 }));
+
+        // ── BODY-FIRST SERVE TIP + bounded full-block buffer (operator
+        // direction off soak0804e; the follow-up the #1089 thread scopes).
+        // Enabled ONLY here, on the coin-P2P daemonless arm, where full
+        // bodies demonstrably flow (the dashd-RPC/ZMQ tip posture has no body
+        // feed and stays header-first). From here on the header-chain tip
+        // callback below keeps driving stale-work invalidation / job rebuild
+        // / the mnlistdiff pull EXACTLY as before (header-tip consumers are
+        // not delayed), while the maintainer's serve tip — the template
+        // height and every freshness-gate threshold — advances only when the
+        // tip block's inputs are parsed, atomically with the credit-pool
+        // advance. `creditpool-stale` then ceases to exist as a class in
+        // normal operation; the ~1-2 s window is named `tip-body-pending`.
+        maintainer->set_body_first_serve_tip(true);
+        maintainer->set_full_block_buffer(true);
+        maintainer->set_chain_hash_at_height_fn(
+            [hc = header_chain.get()](uint32_t h) -> std::optional<uint256> {
+                auto e = hc->get_header_by_height(h);
+                if (!e) return std::nullopt;
+                return e->hash;
+            });
 
         // Tip-changed callback: (a) fire Node::new_tip (leg 2 arms tip-readiness
         // -> the maintainer republishes once the MN list is ALSO seeded ->

--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -52,6 +52,8 @@
 #include <cstdint>
 #include <ctime>
 #include <functional>
+#include <iterator>
+#include <map>
 #include <optional>
 #include <string>
 #include <utility>
@@ -359,6 +361,10 @@ public:
                          << vr.flipped_to_invalid << " banned +"
                          << vr.flipped_to_valid << " revived @ h=" << vh;
         }
+        // BODY-FIRST: an authoritative snapshot loaded as-of the pending tip
+        // completes the payee axis — the last promotion precondition when the
+        // credit-pool seed already reached the tip (diff-before-seed order).
+        maybe_promote_pending_tip();
         if (!m_have_mn)
             demote();
         else
@@ -381,6 +387,7 @@ public:
     /// SML at exactly the state dashd commits for TIP+1 is the #1 item the live
     /// byte-parity KAT against a running dashd must confirm; do not assume.
     void on_mnlistdiff(const vendor::CSimplifiedMNListDiff& diff) {
+        check_tip_body_overdue();
         // E2 credit-pool persist locals: set when the diff's cbTx re-anchors the
         // pool, flushed (aligned with the SML persist) at the bottom so a restart
         // resumes the credit pool at the SAME tip as SMLDb/QuorumDb.
@@ -628,6 +635,13 @@ public:
         // recomputes nAbsVoteReq per tally; a one-shot seed would freeze a
         // cold-start 0 forever or drift as the list grows).
         reseed_funding_threshold();
+        // BODY-FIRST: a diff whose authoritative cbTx re-anchored the
+        // credit-pool seed AT the pending header tip carries the same block
+        // inputs a tip-body fold does — promote the serve tip off it (this is
+        // the cold-start path: the initial header sync ends at a tip whose
+        // body is never inv'd, and the tip-targeted mnlistdiff is what makes
+        // it servable).
+        maybe_promote_pending_tip();
         if (!m_have_mn_sml)
             demote();
         else
@@ -705,13 +719,79 @@ public:
         // full-snapshot resync must not be blocked by the stale-guard.
         m_sml_current_height = 0;
         m_sml_height_paired  = false;
-        // Invalidate the credit-pool seed's freshness too (height -1 != any tip),
-        // so the arm fails closed on the credit-pool axis until a fresh re-seed.
-        m_state.set_credit_pool(0, uint256::ZERO, -1);
-        // E2: wipe the independent running accrual as well — its balance was built
-        // on the now-orphaned branch. It re-bootstraps from the first post-reorg
-        // block's / full-snapshot's authoritative cbTx (never a stale carry-over).
-        m_credit_pool_sm.clear();
+        // ── Credit-pool axis: REORG UNDO from the retained full-block buffer ──
+        // A reorg whose fork point is still inside the bounded full-block
+        // buffer does not need the cold wipe on this axis: the retained
+        // fork-point body's OWN coinbase CCbTx carries the creditPoolBalance
+        // the chain committed AT that height (an independent, network-accepted
+        // value — the same non-self-referential source the per-block advance
+        // verifies against). Rolling the pool back to the fork point from that
+        // retained body lets the new branch's bodies advance CONTIGUOUSLY and
+        // verify, instead of the seed sitting at -1 until the next mnlistdiff
+        // re-anchor. The fork point is found by comparing retained body hashes
+        // against the NEW branch's height index (the header chain has already
+        // switched when this runs). Beyond the buffer — or with the buffer /
+        // lookup unwired (KAT posture, dashd-RPC posture) — the existing
+        // wipe + cold-resync path below is UNCHANGED.
+        // NOTE the deliberate asymmetry: the SML/quorum axis above is still
+        // wiped even inside the buffer. Bodies cannot reconstruct the DMN
+        // list — a cbTx commits merkleRootMNList, and a root is not a list —
+        // so the mnlistdiff cold-resync (one request/response round-trip,
+        // re-issued by main_dash's reorg wiring) remains the only sound
+        // MN-root recovery.
+        bool cp_undone = false;
+        if (m_block_buffer_enabled && m_chain_hash_at_height_fn
+            && !m_block_buffer.empty()) {
+            std::optional<uint32_t> fork_h;
+            for (auto it = m_block_buffer.rbegin();
+                 it != m_block_buffer.rend(); ++it) {
+                auto on_chain = m_chain_hash_at_height_fn(it->first);
+                if (on_chain && *on_chain == it->second.hash) {
+                    fork_h = it->first;
+                    break;
+                }
+            }
+            if (fork_h) {
+                // Retained bodies ABOVE the fork point are orphan-branch
+                // bodies — drop them (they must never re-seed anything).
+                while (!m_block_buffer.empty()
+                       && m_block_buffer.rbegin()->first > *fork_h) {
+                    m_block_buffer.erase(std::prev(m_block_buffer.end()));
+                    ++m_block_buffer_evictions;
+                }
+                const auto& rb = m_block_buffer.rbegin()->second;
+                if (!rb.block.m_txs.empty() && rb.block.m_txs[0].type == 5
+                    && !rb.block.m_txs[0].extra_payload.empty()) {
+                    vendor::CCbTx cb;
+                    if (vendor::parse_cbtx(rb.block.m_txs[0].extra_payload, cb)
+                        && cb.nVersion >= vendor::CCbTx::VERSION_CLSIG_AND_BALANCE
+                        && cb.nHeight == static_cast<int32_t>(*fork_h)) {
+                        m_credit_pool_sm.seed(cb.creditPoolBalance, *fork_h);
+                        m_state.set_credit_pool(cb.creditPoolBalance, rb.hash,
+                                                static_cast<int32_t>(*fork_h));
+                        cp_undone = true;
+                        LOG_INFO << "[EMB-DASH] reorg undo: credit pool rolled"
+                                    " back to fork point h=" << *fork_h
+                                 << " balance=" << cb.creditPoolBalance
+                                 << " from retained body (buffer depth="
+                                 << m_block_buffer.size()
+                                 << ") — no cold credit-pool wipe inside the"
+                                    " buffer";
+                    }
+                }
+            }
+        }
+        if (!cp_undone) {
+            // Invalidate the credit-pool seed's freshness (height -1 != any
+            // tip), so the arm fails closed on the credit-pool axis until a
+            // fresh re-seed.
+            m_state.set_credit_pool(0, uint256::ZERO, -1);
+            // E2: wipe the independent running accrual as well — its balance
+            // was built on the now-orphaned branch. It re-bootstraps from the
+            // first post-reorg block's / full-snapshot's authoritative cbTx
+            // (never a stale carry-over).
+            m_credit_pool_sm.clear();
+        }
         // Wipe the PERSISTED SML/quorum stores too. The on-disk state is now for
         // an orphaned branch; it is self-consistent so the root-verify on the
         // next restart WOULD pass and serve a wrong-branch template. Clearing it
@@ -734,6 +814,10 @@ public:
     /// publication; it only enriches the next assembled template. Returns the
     /// mempool's accept verdict (false = rejected: bad utxo ref / already in).
     bool on_mempool_tx(const MutableTransaction& tx) {
+        // Mempool relay is the highest-cadence event through the maintainer,
+        // so it doubles as the clock the tip-body-overdue bound is checked on
+        // (the maintainer owns no timer; see check_tip_body_overdue).
+        check_tip_body_overdue();
         return m_state.mempool().add_tx(tx);
     }
 
@@ -741,20 +825,61 @@ public:
     /// embedded template needs and mark tip-readiness, then republish if the
     /// MN list is also ready. curtime/version left 0 defer to
     /// build_embedded_workdata()'s own SAFE-ADDITIVE defaults.
+    ///
+    /// BODY-FIRST SERVE TIP (operator direction off soak0804e / #1089): under
+    /// set_body_first_serve_tip(true) this records the HEADER tip only. The
+    /// SERVE tip (m_prev_* — the template height and the threshold every
+    /// freshness gate compares against) advances ONLY once the block inputs
+    /// for this exact tip block have been parsed: the tip body's coinbase
+    /// CCbTx folded (on_block_connected) or an authoritative mnlistdiff cbTx
+    /// at the tip (on_mnlistdiff). That is dashd's own ordering — its tip
+    /// advances after full-block processing — and it removes the
+    /// creditpool-stale window as a class: we never DECLARE a tip we cannot
+    /// yet serve. Header-tip consumers (stale-work invalidation, job rebuild,
+    /// won-block detection, mnlistdiff pull — all wired in main_dash off the
+    /// header chain's tip-changed callback) are NOT delayed; only the serve
+    /// tip is. Between header and body the arm keeps serving prev=old-tip
+    /// work — the same propagation-window behaviour every pool has — named
+    /// `tip-body-pending`, which is a NORMAL TRANSIENT, not an error state.
     void on_new_tip(uint32_t prev_height, const uint256& prev_hash,
                     uint32_t bits_for_next, uint32_t mtp_at_tip,
                     uint8_t address_version, uint8_t address_p2sh_version,
                     uint32_t curtime = 0, uint32_t version = 0) {
-        m_prev_height          = prev_height;
-        m_prev_hash            = prev_hash;
-        m_bits_for_next        = bits_for_next;
-        m_mtp_at_tip           = mtp_at_tip;
-        m_address_version      = address_version;
-        m_address_p2sh_version = address_p2sh_version;
-        m_curtime              = curtime;
-        m_version              = version;
-        m_have_tip             = true;
-        republish();
+        m_hdr_prev_height          = prev_height;
+        m_hdr_prev_hash            = prev_hash;
+        m_hdr_bits_for_next        = bits_for_next;
+        m_hdr_mtp_at_tip           = mtp_at_tip;
+        m_hdr_address_version      = address_version;
+        m_hdr_address_p2sh_version = address_p2sh_version;
+        m_hdr_curtime              = curtime;
+        m_hdr_version              = version;
+        m_have_hdr_tip             = true;
+        if (!m_body_first_serve_tip) {
+            // Header-first (legacy, DEFAULT): promote immediately —
+            // byte-identical to the pre-split behaviour.
+            promote_serve_tip();
+            republish();
+            return;
+        }
+        // Body-first: a new header tip opens (or re-opens) the body-pending
+        // window. A body/diff that already made the credit-pool seed current
+        // AT this exact block (body raced ahead of the header event) promotes
+        // immediately.
+        m_tip_body_pending  = true;
+        m_tip_pending_since = m_now_fn();
+        m_tip_overdue_latched = false;
+        if (maybe_promote_pending_tip()) {
+            republish();
+            return;
+        }
+        m_state.set_tip_body_pending_dbg(true);
+        LOG_INFO << "[EMB-DASH] tip-body-pending h=" << prev_height << " "
+                 << prev_hash.GetHex().substr(0, 16)
+                 << "... — serve tip holds at "
+                 << (m_have_tip ? ("h=" + std::to_string(m_prev_height))
+                                : std::string("none"))
+                 << " until the tip body folds (normal transient,"
+                    " dashd-equivalent propagation window)";
     }
 
     /// Header / think path (block connect): fold a newly-connected block's
@@ -784,10 +909,23 @@ public:
         // E2b bootstrap causes no notify storm. The refusal between
         // tip-advance and body-parse is untouched: this is latency work, the
         // gate itself is not weakened.
+        check_tip_body_overdue();
         const bool cp_was_current_at_tip =
             m_have_tip
             && m_state.credit_pool_height() == static_cast<int32_t>(m_prev_height);
         auto r = on_block_connected_impl(block, height);
+        // BODY-FIRST serve-tip promotion: if this fold made the credit-pool
+        // seed current AT the pending header tip, the serve tip advances NOW —
+        // atomically with the credit-pool/MN-root input advance that just
+        // happened inside the impl (single-threaded event path; nothing can
+        // observe the state between the fold and this promotion). The
+        // atomicity invariant this pins: the serve height never exceeds the
+        // height whose body has been parsed.
+        if (maybe_promote_pending_tip()) {
+            republish();
+            notify_state_dirty();
+            return r;
+        }
         const bool cp_now_current_at_tip =
             m_have_tip
             && m_state.credit_pool_height() == static_cast<int32_t>(m_prev_height);
@@ -826,6 +964,11 @@ private:
         // Runs BEFORE the MN snapshot fence: the credit pool is a distinct axis
         // (asset-lock/unlock + platform-reward), independent of the payee set.
         advance_credit_pool_on_block(block, height);
+
+        // Bounded full-block retention (LTC-style "highest sufficient number
+        // of full blocks"): the body is merkle-bound (checked above), so it is
+        // eligible for the reorg-undo buffer. No-op unless enabled.
+        buffer_insert(block, height);
 
         // E-SUPERBLOCK (R6): superblock desync cross-check + store pruning —
         // the superblock analogue of the MN payee-desync latch below (#807,
@@ -977,6 +1120,11 @@ public:
     /// reorg) is left in place.
     void on_invalidate() {
         m_have_tip = false;
+        // Body-first bookkeeping: the header tip we were awaiting a body for
+        // is invalidated with everything else; a fresh on_new_tip re-arms.
+        m_have_hdr_tip = false;
+        m_tip_body_pending = false;
+        m_state.set_tip_body_pending_dbg(false);
         demote();
     }
 
@@ -1008,6 +1156,71 @@ public:
     /// turns it on for the whole embedded arm.
     void set_require_seeded_mn_set(bool on) { m_require_seeded_mn = on; }
     bool require_seeded_mn_set() const { return m_require_seeded_mn; }
+
+    /// BODY-FIRST SERVE TIP (operator direction, soak0804e follow-up to
+    /// #1089). When enabled, on_new_tip records the HEADER tip only; the
+    /// SERVE tip (what m_prev_height / every freshness gate sees) advances
+    /// exactly when the block inputs for that tip have been parsed — the tip
+    /// body's coinbase folded, or an authoritative mnlistdiff cbTx at the tip
+    /// — atomically with the credit-pool advance. Default OFF: every existing
+    /// construction site (KATs, the dashd-RPC/ZMQ tip posture, whose tip feed
+    /// has NO body feed and would otherwise never promote) keeps byte-
+    /// identical header-first behaviour. main_dash enables it for the
+    /// coin-P2P daemonless arm, where full bodies demonstrably flow.
+    /// REQUIRES the v20+ CCbTx posture (promotion is keyed on the credit-pool
+    /// seed becoming current at the tip) — exactly the posture the daemonless
+    /// arm already requires for the creditpool freshness gate.
+    void set_body_first_serve_tip(bool on) { m_body_first_serve_tip = on; }
+    bool body_first_serve_tip() const { return m_body_first_serve_tip; }
+
+    /// Body-first observability (STATE SAYS ITS OWN NAME): is the maintainer
+    /// currently holding the serve tip below a known header tip, awaiting the
+    /// tip body? TRUE is the normal ~1-2 s propagation transient, never an
+    /// error state.
+    bool tip_body_pending() const { return m_tip_body_pending; }
+    /// The header tip (advances on headers exactly as before) and the serve
+    /// tip (advances body-first when enabled). serve <= header always under
+    /// body-first — the atomicity invariant.
+    uint32_t header_tip_height() const { return m_have_hdr_tip ? m_hdr_prev_height : 0; }
+    uint32_t serve_tip_height()  const { return m_have_tip ? m_prev_height : 0; }
+
+    /// How long a body-pending window may last before the serve tip is
+    /// DEMOTED instead of continuing to serve old-tip work (the doomed-tip
+    /// bound the operator direction names for the lost-body tail: past the
+    /// propagation window, prev=old-height work is knowingly doomed and
+    /// refusing is safer than serving it). The p2p body-rerequest watchdog
+    /// (10 s, up to 4 rotated peers) should resolve a lost body well inside
+    /// this. Checked opportunistically on maintainer events (mempool relay is
+    /// the high-cadence clock). Overridable for tests.
+    void set_tip_body_overdue_secs(int64_t s) { m_tip_body_overdue_secs = s; }
+
+    /// Bounded full-block buffer (LTC-style retention, operator direction):
+    /// retain merkle-bound bodies above the last ChainLocked height + margin,
+    /// floor 6, cap 24 (~1 h of DASH blocks). ChainLock depth is the
+    /// principled reachability cap — nothing at or below a ChainLocked block
+    /// can reorg — and DASH ChainLocks normally land within seconds, so the
+    /// steady-state depth is the floor. Purpose: reorg undo for the
+    /// credit-pool axis without a wipe + cold-resync inside the buffer depth
+    /// (see on_sml_reorg); beyond it the existing wipe + reseed path stays.
+    /// Default OFF (no retention, no memory cost) — main_dash enables it for
+    /// the daemonless arm alongside body-first.
+    void set_full_block_buffer(bool on) { m_block_buffer_enabled = on; }
+    /// Height -> hash lookup on the CURRENT chain (main_dash wires the header
+    /// chain's height index). The reorg-undo fork-point search compares
+    /// retained body hashes against it. Unset => undo never fires (existing
+    /// wipe path, KAT posture).
+    void set_chain_hash_at_height_fn(
+        std::function<std::optional<uint256>(uint32_t)> fn) {
+        m_chain_hash_at_height_fn = std::move(fn);
+    }
+    size_t   block_buffer_depth()     const { return m_block_buffer.size(); }
+    uint64_t block_buffer_evictions() const { return m_block_buffer_evictions; }
+    uint32_t block_buffer_lowest_height() const {
+        return m_block_buffer.empty() ? 0 : m_block_buffer.begin()->first;
+    }
+    uint32_t block_buffer_highest_height() const {
+        return m_block_buffer.empty() ? 0 : m_block_buffer.rbegin()->first;
+    }
 
     /// The unseeded-payee-fold guard's own witnesses: how many blocks it
     /// refused to fold because no height-stamped masternode snapshot was in
@@ -1331,6 +1544,121 @@ private:
         m_gov_store.prune_executed(static_cast<int32_t>(height));
     }
 
+    // ── BODY-FIRST serve-tip machinery ───────────────────────────────────
+
+    /// Copy the stashed header-tip params into the SERVE slots. In
+    /// header-first (legacy) mode this runs inside on_new_tip, byte-identical
+    /// to the old direct assignment; in body-first mode it runs only from
+    /// maybe_promote_pending_tip().
+    void promote_serve_tip() {
+        m_prev_height          = m_hdr_prev_height;
+        m_prev_hash            = m_hdr_prev_hash;
+        m_bits_for_next        = m_hdr_bits_for_next;
+        m_mtp_at_tip           = m_hdr_mtp_at_tip;
+        m_address_version      = m_hdr_address_version;
+        m_address_p2sh_version = m_hdr_address_p2sh_version;
+        m_curtime              = m_hdr_curtime;
+        m_version              = m_hdr_version;
+        m_have_tip             = true;
+        m_tip_body_pending     = false;
+        m_tip_overdue_latched  = false;
+    }
+
+    /// Promote the pending header tip to the serve tip iff the credit-pool
+    /// seed is current AT that exact block (hash AND height — the hash match
+    /// is what keeps a same-height competing block's body from promoting the
+    /// wrong tip's params). The seed is the witness that the tip block's
+    /// inputs were parsed: the body fold and the mnlistdiff cbTx re-anchor
+    /// both stamp it with the block's own identity. Returns true iff
+    /// promotion happened; caller republishes.
+    bool maybe_promote_pending_tip() {
+        if (!m_body_first_serve_tip || !m_tip_body_pending) return false;
+        if (!m_have_hdr_tip) return false;
+        if (m_state.credit_pool_current_hash() != m_hdr_prev_hash) return false;
+        if (m_state.credit_pool_height()
+            != static_cast<int32_t>(m_hdr_prev_height)) return false;
+        // The PAYEE axis must be current at the tip too (its cursor advances
+        // in the tip-body apply_block, or a snapshot loaded as-of the tip):
+        // promoting off a tip-targeted mnlistdiff that outraced the body
+        // would advance the serve tip into a payee-stale refusal — trading
+        // the removed creditpool-stale window for an identical one on the
+        // payee axis. An EMPTY payee machine (pre-seed cold start, post-wipe)
+        // has no cursor to be stale and does not hold promotion back — the
+        // MN-readiness half of populated() already gates serving there.
+        if (!m_state.mnstates().entries().empty()
+            && m_state.mnstates().last_applied_height() != m_hdr_prev_height)
+            return false;
+        promote_serve_tip();
+        m_state.set_tip_body_pending_dbg(false);
+        LOG_INFO << "[EMB-DASH] serve tip promoted h=" << m_prev_height << " "
+                 << m_prev_hash.GetHex().substr(0, 16)
+                 << "... (body-first: tip block inputs parsed, credit-pool"
+                    " seed current at tip)";
+        return true;
+    }
+
+    /// Doomed-tip bound: a body-pending window that outlives
+    /// m_tip_body_overdue_secs (lost body the p2p watchdog could not recover,
+    /// or a credit-pool ACCRUAL DRIFT that blocks the seed) must stop serving
+    /// old-tip work — past the propagation window that work is knowingly
+    /// doomed, and refusing (dashd fallback / not-populated) is the safe
+    /// state. Promotion re-arms the serve tip when the inputs finally land.
+    /// The maintainer owns no timer, so this is checked opportunistically on
+    /// every maintainer event (mempool relay being the high-cadence clock).
+    void check_tip_body_overdue() {
+        if (!m_body_first_serve_tip || !m_tip_body_pending) return;
+        if (m_tip_overdue_latched) return;
+        if (m_now_fn() - m_tip_pending_since < m_tip_body_overdue_secs) return;
+        m_tip_overdue_latched = true;
+        LOG_WARNING << "[EMB-DASH] tip-body-overdue h=" << m_hdr_prev_height
+                    << " pending for "
+                    << (m_now_fn() - m_tip_pending_since)
+                    << "s (> " << m_tip_body_overdue_secs
+                    << "s) — demoting the serve tip: serving h="
+                    << m_prev_height << "-based work past the propagation"
+                       " window is doomed-tip work; failing closed until the"
+                       " tip block's inputs land";
+        if (!m_have_tip) return;   // nothing was being served anyway
+        m_have_tip = false;
+        demote();
+        notify_state_dirty();
+    }
+
+    /// Bounded full-block retention (see set_full_block_buffer). Called from
+    /// on_block_connected_impl AFTER the merkle bind check — only bound
+    /// bodies are retained. Retention depth: heights above the last
+    /// ChainLocked height + a 2-block margin, clamped to [floor 6, cap 24];
+    /// no ChainLock observed => the cap alone bounds it (a ChainLock outage
+    /// of ~1 h exhausts the buffer and the wipe path takes over, by design).
+    void buffer_insert(const dash::coin::BlockType& block, uint32_t height) {
+        if (!m_block_buffer_enabled) return;
+        m_block_buffer[height] =
+            RetainedBlock{block_identity_hash(block), block};
+        ++m_block_buffer_inserts;
+        const uint32_t hi = m_block_buffer.rbegin()->first;
+        const int32_t  cl = m_state.best_cl_height();
+        uint64_t depth_target = kBlockBufferCap;
+        if (cl > 0 && static_cast<uint32_t>(cl) <= hi)
+            depth_target = static_cast<uint64_t>(hi - static_cast<uint32_t>(cl))
+                           + kBlockBufferClMargin;
+        depth_target = std::min<uint64_t>(
+            std::max<uint64_t>(depth_target, kBlockBufferFloor),
+            kBlockBufferCap);
+        while (!m_block_buffer.empty()
+               && m_block_buffer.begin()->first + depth_target <= hi) {
+            m_block_buffer.erase(m_block_buffer.begin());
+            ++m_block_buffer_evictions;
+        }
+        // Periodic depth line (soak-greppable measurement, ~once per cap's
+        // worth of inserts ≈ 1 h at steady state).
+        if ((m_block_buffer_inserts % kBlockBufferCap) == 1)
+            LOG_INFO << "[EMB-DASH] full-block buffer depth="
+                     << m_block_buffer.size() << " span=["
+                     << m_block_buffer.begin()->first << ".." << hi
+                     << "] target=" << depth_target << " cl_h=" << cl
+                     << " evictions=" << m_block_buffer_evictions;
+    }
+
     // Publish only when both prerequisites are present; otherwise leave the
     // holder in whatever (un)published state it is in -- callers reach demote()
     // explicitly for the invalidating transitions.
@@ -1419,7 +1747,9 @@ private:
     uint32_t m_unseeded_payee_first_h{0};
     uint32_t m_unseeded_payee_last_h{0};
 
-    // Last observed tip params, applied on republish().
+    // SERVE-TIP params, applied on republish(). Under body-first these lag
+    // the header tip by the body-pending window; header-first (default)
+    // they are assigned directly in on_new_tip via promote_serve_tip().
     uint32_t m_prev_height{0};
     uint256  m_prev_hash;
     uint32_t m_bits_for_next{0};
@@ -1428,6 +1758,42 @@ private:
     uint8_t  m_address_p2sh_version{0};
     uint32_t m_curtime{0};
     uint32_t m_version{0};
+
+    // HEADER-TIP stash (body-first split). Always written by on_new_tip;
+    // promoted into the serve slots immediately (header-first) or on the tip
+    // block's inputs being parsed (body-first).
+    bool     m_have_hdr_tip{false};
+    uint32_t m_hdr_prev_height{0};
+    uint256  m_hdr_prev_hash;
+    uint32_t m_hdr_bits_for_next{0};
+    uint32_t m_hdr_mtp_at_tip{0};
+    uint8_t  m_hdr_address_version{0};
+    uint8_t  m_hdr_address_p2sh_version{0};
+    uint32_t m_hdr_curtime{0};
+    uint32_t m_hdr_version{0};
+
+    // Body-first mode + pending-window state. Defaults keep every existing
+    // construction site byte-identical (header-first).
+    bool    m_body_first_serve_tip{false};
+    bool    m_tip_body_pending{false};
+    bool    m_tip_overdue_latched{false};
+    int64_t m_tip_pending_since{0};
+    int64_t m_tip_body_overdue_secs{30};
+
+    // Bounded full-block buffer (reorg undo). Keyed by height; hash is the
+    // block's own X11 identity, used by the fork-point search.
+    struct RetainedBlock {
+        uint256 hash;
+        dash::coin::BlockType block;
+    };
+    static constexpr size_t   kBlockBufferFloor    = 6;
+    static constexpr size_t   kBlockBufferCap      = 24;   // ~1 h of DASH blocks
+    static constexpr uint32_t kBlockBufferClMargin = 2;
+    bool m_block_buffer_enabled{false};
+    std::map<uint32_t, RetainedBlock> m_block_buffer;
+    uint64_t m_block_buffer_inserts{0};
+    uint64_t m_block_buffer_evictions{0};
+    std::function<std::optional<uint256>(uint32_t)> m_chain_hash_at_height_fn;
 };
 
 } // namespace coin

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -289,6 +289,15 @@ public:
         m_have_mn_dbg  = have_mn ? 1 : 0;
     }
 
+    /// DIAGNOSTIC (body-first serve tip): the maintainer knows a newer header
+    /// tip whose block inputs (body / tip-targeted mnlistdiff cbTx) have not
+    /// been parsed yet. This is the NORMAL ~1-2 s propagation transient of
+    /// the body-first split, not an error state; publishing it here lets a
+    /// not-populated refusal during that window (cold start / overdue demote)
+    /// carry its own name instead of masquerading as a header-sync fault.
+    /// Never read by any serve or reward path.
+    void set_tip_body_pending_dbg(bool v) { m_tip_body_pending_dbg = v; }
+
     /// Enable the SML-required viability gate. main_dash.cpp turns this on for
     /// the embedded coin-P2P arm so a template is only served once the CCbTx
     /// commitment inputs are present (review finding H3: no mid-sync half-built block).
@@ -1037,6 +1046,14 @@ private:
             d.cause     = "mn-needs-reseed";
             d.value     = "latched";
             d.threshold = "cleared-by-authoritative-reseed";
+        } else if (d.cause == "not-populated" && m_tip_body_pending_dbg) {
+            // Body-first serve tip: a header tip is known but its block
+            // inputs have not been parsed yet (cold start before the first
+            // promotion, or an overdue-demoted pending window). The named
+            // transient — NOT a header-sync fault, NOT an error state; the
+            // value keeps both populate halves visible.
+            d.cause     = "tip-body-pending";
+            d.threshold = "tip-body-folded";
         } else if (d.cause == "not-populated" && m_prev_hash.IsNull()
                    && m_have_tip_dbg < 0) {
             // ONLY when the maintainer has told us nothing (never reported).
@@ -1173,6 +1190,9 @@ private:
     // Publish-precondition mirror (-1 = the maintainer has never reported).
     int8_t   m_have_tip_dbg{-1};
     int8_t   m_have_mn_dbg{-1};
+    // Body-first serve tip: header tip known, block inputs not yet parsed
+    // (set_tip_body_pending_dbg). Diagnostic only, never gates anything.
+    bool     m_tip_body_pending_dbg{false};
     uint32_t m_prev_height{0};
     uint256  m_prev_hash;
     uint32_t m_bits_for_next{0};

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -562,6 +562,23 @@ private:
     // second.
     static constexpr time_t POOL_TICK_SEC = 1;
     static constexpr time_t RECONNECT_INTERVAL_SEC = 30;
+    // ── Lost-body watchdog (#1089 208 s tail; same defect class as the
+    // #1077 rotated-pending wedge: a request with no timeout). A tracked
+    // getdata(block) answered by nothing has NO protocol-level retry, and
+    // InvDedup (TTL 600 s) suppresses the same block's inv from every other
+    // peer — so a single lost body request can stall the tip body for up to
+    // 10 minutes (the 208 s episode measured on soak0804e sits squarely in
+    // this class). T = 10 s: ~5x the worst normal same-stream headers→block
+    // gap (~1-2 s), far below the 157.5 s block interval, and a false
+    // positive costs one duplicate block-sized response — cheap. Re-requests
+    // rotate through the pool's OTHER handshaked peers (post-#1082 up to 8),
+    // capped at 4 (~50 s total), after which the headers-driven re-request /
+    // inv-TTL expiry remains the backstop.
+    static constexpr time_t BODY_REREQUEST_SEC = 10;
+    static constexpr int    BODY_REREQUEST_MAX = 4;
+    // Tracked slots are bounded by design: the tip body plus a short burst
+    // of near-tip blocks; oldest evicted beyond this.
+    static constexpr size_t PENDING_BODY_CAP  = 8;
     // Pool-status log cadence (the soak's direct read on peer count + durability).
     static constexpr time_t POOL_STATUS_INTERVAL_SEC = 60;
     // A dial that never calls back (no connected(), no connect_failed()) must not
@@ -611,6 +628,21 @@ private:
     std::map<std::string, int64_t> m_dialing;
     // Collapses the N-peer inv fan-in to one getdata. Bounded + expiring.
     InvDedup m_inv_dedup;
+
+    // ── Lost-body watchdog state (see BODY_REREQUEST_* above) ────────────
+    // One slot per tracked outstanding getdata(block); disarmed by the block
+    // handler on receipt (from ANY peer), serviced by the pool tick.
+    struct PendingBody
+    {
+        uint256     hash;
+        int64_t     first_req{0};
+        int64_t     last_req{0};
+        int         rerequests{0};
+        std::string last_peer;    // don't re-ask the peer that just failed us
+    };
+    std::vector<PendingBody> m_pending_bodies;
+    uint64_t m_body_rerequests_total{0};
+    uint64_t m_body_rerequests_exhausted{0};
 
     std::unique_ptr<core::Timer> m_reconnect_timer;
     // ONE repeating tick for the whole pool (liveness, handshake deadlines,
@@ -1117,6 +1149,32 @@ public:
             {inventory_type(inventory_type::block, block_hash)});
         m_primary->write(msg);
     }
+
+    /// Request a full block AND arm the lost-body watchdog for it (tip-follow
+    /// path — see the BODY_REREQUEST_* rationale above). Plain
+    /// request_block() stays untracked for the bulk/historical legs (UTXO
+    /// window refill, checkpoint-lane windows), whose volume would defeat the
+    /// bound and whose own re-request loops already exist.
+    void request_block_tracked(const uint256& block_hash)
+    {
+        request_block(block_hash);
+        const int64_t now = now_sec();
+        for (auto& pb : m_pending_bodies)
+            if (pb.hash == block_hash) { pb.last_req = now; return; }
+        if (m_pending_bodies.size() >= PENDING_BODY_CAP)
+            m_pending_bodies.erase(m_pending_bodies.begin());   // oldest slot
+        PendingBody pb;
+        pb.hash      = block_hash;
+        pb.first_req = now;
+        pb.last_req  = now;
+        pb.last_peer = m_primary ? m_primary->key : std::string{};
+        m_pending_bodies.push_back(std::move(pb));
+    }
+
+    /// Watchdog observability (KATs + POOL-STATUS).
+    std::size_t pending_body_count()    const { return m_pending_bodies.size(); }
+    uint64_t body_rerequests_total()    const { return m_body_rerequests_total; }
+    uint64_t body_rerequests_exhausted() const { return m_body_rerequests_exhausted; }
 
     /// Send a getmnlistd (SML diff request) — E2/E3 masternode-list sync seam.
     void send_getmnlistd(const uint256& base_block_hash, const uint256& block_hash)
@@ -1679,8 +1737,61 @@ private:
             remove_peer(p, why);
         }
 
+        service_pending_bodies(now);
         prune_stale_dials(now);
         maybe_log_pool_status(now);
+    }
+
+    /// Lost-body watchdog service (one pass per pool tick). A tracked
+    /// getdata(block) unanswered for BODY_REREQUEST_SEC is re-issued — from a
+    /// DIFFERENT handshaked peer when the pool holds one (the announcing peer
+    /// may be slow/wedged; its neighbours demonstrably hold the block they
+    /// all announced), rotating through the pool on successive attempts —
+    /// bounded at BODY_REREQUEST_MAX, every re-request named in the log.
+    void service_pending_bodies(int64_t now)
+    {
+        for (auto it = m_pending_bodies.begin(); it != m_pending_bodies.end();)
+        {
+            PendingBody& pb = *it;
+            if (now - pb.last_req < BODY_REREQUEST_SEC) { ++it; continue; }
+            if (pb.rerequests >= BODY_REREQUEST_MAX)
+            {
+                ++m_body_rerequests_exhausted;
+                LOG_WARNING << "[" << m_chain_label
+                            << "] body-rerequest EXHAUSTED hash="
+                            << pb.hash.GetHex().substr(0, 16) << "... after "
+                            << pb.rerequests << " re-request(s) over "
+                            << (now - pb.first_req)
+                            << "s — leaving recovery to the headers-driven"
+                               " re-request / inv-TTL backstop";
+                it = m_pending_bodies.erase(it);
+                continue;
+            }
+            // Rotate through the handshaked peers, preferring one we did not
+            // just ask; a single-peer pool re-asks the same peer (still
+            // strictly better than the 600 s inv-TTL wait).
+            std::vector<PeerSession*> cands;
+            for (auto& up : m_pool)
+                if (up->handshake.complete()) cands.push_back(up.get());
+            if (cands.empty()) { ++it; continue; }   // retry when the pool refills
+            PeerSession* target =
+                cands[static_cast<size_t>(pb.rerequests) % cands.size()];
+            if (target->key == pb.last_peer && cands.size() > 1)
+                target = cands[(static_cast<size_t>(pb.rerequests) + 1)
+                               % cands.size()];
+            auto msg = message_getdata::make_raw(
+                {inventory_type(inventory_type::block, pb.hash)});
+            target->write(msg);
+            ++pb.rerequests;
+            ++m_body_rerequests_total;
+            pb.last_req  = now;
+            pb.last_peer = target->key;
+            LOG_INFO << "[" << m_chain_label << "] cause=body-rerequest attempt="
+                     << pb.rerequests << " peer=" << target->key << " hash="
+                     << pb.hash.GetHex().substr(0, 16) << "... unanswered_for="
+                     << (now - pb.first_req) << "s";
+            ++it;
+        }
     }
 
     /// THE MEASUREMENT. One line, every POOL_STATUS_INTERVAL_SEC, naming the
@@ -1722,7 +1833,10 @@ private:
                  << m_inv_dedup.capacity()
                  << " admitted=" << st.admitted
                  << " suppressed=" << st.suppressed
-                 << " evicted(cap/ttl)=" << st.evicted_capacity << "/" << st.evicted_ttl;
+                 << " evicted(cap/ttl)=" << st.evicted_capacity << "/" << st.evicted_ttl
+                 << " pending_bodies=" << m_pending_bodies.size()
+                 << " body_rerequests=" << m_body_rerequests_total
+                 << "/" << m_body_rerequests_exhausted;
     }
 
     // ── handshake ────────────────────────────────────────────────────────
@@ -1925,6 +2039,11 @@ private:
         // on its socket, and its deferral state is the one waiting.
         try { p->conn->get_block(blockhash, msg->m_block); } catch (...) {}
         try { p->conn->get_header(blockhash, header); } catch (...) {}
+        // Lost-body watchdog: the body has arrived (from whichever peer
+        // answered first) — disarm its slot.
+        for (auto it = m_pending_bodies.begin();
+             it != m_pending_bodies.end(); ++it)
+            if (it->hash == blockhash) { m_pending_bodies.erase(it); break; }
         LOG_INFO << "[" << m_chain_label << "] block received from " << p->key
                  << ": " << blockhash.GetHex().substr(0, 16) << "...";
         m_coin->full_block.happened(msg->m_block);

--- a/test/test_dash_coin_p2p_pool.cpp
+++ b/test/test_dash_coin_p2p_pool.cpp
@@ -925,4 +925,94 @@ TEST(DashCoinP2PPool, a_throwing_subscriber_costs_one_message_not_the_pool)
         << "inbound dispatch stopped after a handler threw";
 }
 
+// ══════════════════════════════════════════════════════════════════════════
+// LOST-BODY WATCHDOG (#1089 208 s tail; same defect class as the #1077
+// rotated-pending wedge: a request with no timeout). request_block_tracked's
+// getdata unanswered for BODY_REREQUEST_SEC=10 is re-issued from a DIFFERENT
+// handshaked peer, rotating on successive attempts, capped at
+// BODY_REREQUEST_MAX=4, each re-request named (`cause=body-rerequest`) —
+// killing the 208 s / 600 s inv-TTL tail. FAILS-ON-MASTER: request_block has
+// no tracking, no timeout, no re-request at all.
+// ══════════════════════════════════════════════════════════════════════════
+
+TEST(DashCoinP2PPool, lost_tip_body_is_rerequested_from_a_rotated_peer_at_T)
+{
+    PoolRig rig;
+    rig.use_fake_clock();
+    for (int i = 1; i <= 3; ++i) rig.handshake(i);
+
+    const uint256 h = hash_n(0xB0D7);
+    const uint64_t p1_before = rig.session(1)->msgs_sent;
+    const uint64_t p2_before = rig.session(2)->msgs_sent;
+    const uint64_t p3_before = rig.session(3)->msgs_sent;
+
+    rig.client.request_block_tracked(h);
+    EXPECT_EQ(rig.client.pending_body_count(), 1u);
+    // The initial getdata goes to the primary (peer 1), like request_block.
+    EXPECT_EQ(rig.session(1)->msgs_sent, p1_before + 1);
+
+    // T-1 seconds of silence: no re-request yet.
+    rig.run_seconds(9);
+    EXPECT_EQ(rig.client.body_rerequests_total(), 0u)
+        << "re-requested before the 10 s timeout";
+
+    // Crossing T: exactly one re-request, and NOT to the peer that failed us.
+    rig.run_seconds(1);
+    EXPECT_EQ(rig.client.body_rerequests_total(), 1u)
+        << "an unanswered tracked body request must be re-requested at T=10 s";
+    EXPECT_EQ(rig.session(1)->msgs_sent, p1_before + 1)
+        << "the re-request must rotate OFF the peer that did not answer";
+    EXPECT_EQ((rig.session(2)->msgs_sent - p2_before)
+                  + (rig.session(3)->msgs_sent - p3_before),
+              1u)
+        << "exactly one re-request, to one other peer";
+    EXPECT_EQ(rig.client.pending_body_count(), 1u) << "still unanswered";
+}
+
+TEST(DashCoinP2PPool, body_rerequest_is_capped_then_backstop_owns_it)
+{
+    PoolRig rig;
+    rig.use_fake_clock();
+    for (int i = 1; i <= 2; ++i) rig.handshake(i);
+
+    rig.client.request_block_tracked(hash_n(0xDEAD));
+    // Nothing ever answers: attempts must stop at the cap and the slot must
+    // be released to the headers-driven / inv-TTL backstop (bounded by
+    // design — not a forever-retry loop).
+    rig.run_seconds(120);
+    EXPECT_EQ(rig.client.body_rerequests_total(), 4u)
+        << "re-requests must be capped at BODY_REREQUEST_MAX";
+    EXPECT_EQ(rig.client.body_rerequests_exhausted(), 1u);
+    EXPECT_EQ(rig.client.pending_body_count(), 0u)
+        << "an exhausted slot must be released, not retried forever";
+}
+
+TEST(DashCoinP2PPool, body_arrival_disarms_the_watchdog)
+{
+    PoolRig rig;
+    rig.use_fake_clock();
+    for (int i = 1; i <= 2; ++i) rig.handshake(i);
+
+    // A real (if empty-bodied) block whose X11 header hash the handler will
+    // compute — track exactly that hash.
+    dash::coin::BlockType blk;
+    blk.m_version = 0x20000000;
+    blk.m_timestamp = 1'700'000'000u;
+    auto packed_hdr =
+        pack(static_cast<const dash::coin::BlockHeaderType&>(blk));
+    const uint256 bh = dash::crypto::hash_x11(packed_hdr.get_span());
+
+    rig.client.request_block_tracked(bh);
+    EXPECT_EQ(rig.client.pending_body_count(), 1u);
+
+    // The body arrives — from the OTHER peer, which must disarm it too.
+    rig.deliver(2, p2p::message_block::make_raw(blk));
+    EXPECT_EQ(rig.client.pending_body_count(), 0u)
+        << "receipt from any peer must disarm the watchdog";
+
+    // And no re-request ever fires afterwards.
+    rig.run_seconds(60);
+    EXPECT_EQ(rig.client.body_rerequests_total(), 0u);
+}
+
 } // namespace

--- a/test/test_dash_coin_state_maintainer.cpp
+++ b/test/test_dash_coin_state_maintainer.cpp
@@ -1297,3 +1297,326 @@ TEST(DashCoinStateMaintainer, DuplicateAcrossTransportsIsNoOpNeverDowngrades) {
         EXPECT_EQ(served->CountSigners(), 50);
     }
 }
+
+// ════════════════════════════════════════════════════════════════════════
+// BODY-FIRST SERVE TIP (operator direction off soak0804e; the follow-up the
+// #1089 thread scoped). The serve tip — m_prev_height, the template height
+// and the threshold of every freshness gate — advances ONLY when the tip
+// block's inputs have been parsed (tip body fold, or the tip-targeted
+// mnlistdiff cbTx), atomically with the credit-pool advance. The header tip
+// keeps advancing on headers exactly as before and stays visible to its
+// consumers (stale-work invalidation / job rebuild / won-block detection are
+// wired off the header chain in main_dash and are untouched).
+//
+// FAILS-ON-MASTER: on header-first master m_prev_height is written directly
+// in on_new_tip — the serve height exceeds the parsed-body height by design
+// for the whole body window, so the invariant assertions below cannot hold
+// there. (Default-off legacy mode is pinned separately below.)
+// ════════════════════════════════════════════════════════════════════════
+
+#include <impl/dash/crypto/hash_x11.hpp>
+
+
+// Accrual-consistent balance for a CONTIGUOUS next block: the independent
+// credit-pool advance verifies computed == from-wire (prev + platform reward,
+// no asset locks/unlocks in these fabricated blocks); an inconsistent value
+// trips the ACCRUAL DRIFT fail-closed path and blocks the seed advance.
+static int64_t next_balance(const NodeCoinState& st, int64_t prev_balance,
+                            uint32_t height) {
+    return prev_balance
+           + dash::coin::compute_dash_platform_reward_post_v20_mn_rr(
+                 height, st.mn_rr_height());
+}
+
+static uint256 block_hash_of(const BlockType& b) {
+    auto packed = ::pack(static_cast<const dash::coin::BlockHeaderType&>(b));
+    return dash::crypto::hash_x11(packed.get_span());
+}
+
+// THE CENTREPIECE: "serve height never exceeds the height whose body has
+// been parsed." Header arrival must not advance the serve tip; the body fold
+// must — atomically with the credit-pool advance.
+TEST(DashCoinStateMaintainer, BodyFirstServeTipNeverExceedsParsedBodyHeight) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    m.set_body_first_serve_tip(true);
+    st.set_require_fresh_credit_pool(true);
+    m.on_mn_list_update(single_mn(p2pkh_script(0x30)));
+
+    // ── Establish the serve tip at H-1: header first, then its body. ──
+    auto b1 = make_cbtx_block(H - 1, 111'000'000LL, p2pkh_script(0x30));
+    m.on_new_tip(H - 1, block_hash_of(b1), BITS, MTP,
+                 DASH_PUBKEY_VER, DASH_P2SH_VER, CURTIME, VERSION);
+    // Header alone: the serve tip must NOT exist yet (cold start).
+    EXPECT_TRUE(m.tip_body_pending());
+    EXPECT_EQ(m.header_tip_height(), H - 1);
+    EXPECT_EQ(m.serve_tip_height(), 0u)
+        << "INVARIANT: no body parsed yet, no serve tip may exist";
+    EXPECT_FALSE(m.live());
+    // The refusal names itself: tip-body-pending, not a header-sync fault.
+    EXPECT_EQ(st.describe_decline().cause, "tip-body-pending");
+
+    m.on_block_connected(b1, H - 1);
+    EXPECT_FALSE(m.tip_body_pending());
+    EXPECT_EQ(m.serve_tip_height(), H - 1) << "body parsed => serve tip promoted";
+    ASSERT_TRUE(m.live());
+    {
+        WorkSelection sel = st.select_work([]() { return DashWorkData{}; });
+        EXPECT_EQ(sel.source, WorkSource::Embedded);
+        EXPECT_EQ(sel.work.m_height, H) << "serving next-height H over parsed H-1";
+    }
+
+    // ── Header H arrives, body DELAYED. ──
+    const int64_t bal2 = next_balance(st, 111'000'000LL, H);
+    auto b2 = make_cbtx_block(H, bal2, p2pkh_script(0x30));
+    m.on_new_tip(H, block_hash_of(b2), BITS, MTP,
+                 DASH_PUBKEY_VER, DASH_P2SH_VER, CURTIME, VERSION);
+    // Header-tip consumers see the new header immediately...
+    EXPECT_EQ(m.header_tip_height(), H);
+    EXPECT_TRUE(m.tip_body_pending());
+    // ...but the INVARIANT holds: serve height stays at the parsed height.
+    EXPECT_EQ(m.serve_tip_height(), H - 1)
+        << "INVARIANT VIOLATED: serve height exceeds the height whose body "
+           "has been parsed (this is exactly header-first master's behaviour)";
+    // The serve gates hold VIABLE at the old height — the body window is a
+    // normal transient (every pool serves prev-tip work during propagation),
+    // NOT an error/decline state.
+    EXPECT_TRUE(st.describe_decline().viable)
+        << "tip-body-pending must not be treated as an error state";
+    {
+        WorkSelection sel = st.select_work([]() { return DashWorkData{}; });
+        EXPECT_EQ(sel.source, WorkSource::Embedded);
+        EXPECT_EQ(sel.work.m_height, H) << "still building on parsed H-1";
+    }
+
+    // ── Body H arrives: serve tip + credit pool advance ATOMICALLY. ──
+    m.on_block_connected(b2, H);
+    EXPECT_EQ(m.serve_tip_height(), H);
+    EXPECT_EQ(st.credit_pool_height(), static_cast<int32_t>(H));
+    EXPECT_EQ(st.credit_pool(), bal2);
+    EXPECT_TRUE(st.describe_decline().viable)
+        << "no creditpool-stale window may exist after the atomic advance";
+    {
+        WorkSelection sel = st.select_work([]() { return DashWorkData{}; });
+        EXPECT_EQ(sel.work.m_height, H + 1);
+    }
+}
+
+// Legacy default pinned: with body-first NOT enabled, on_new_tip promotes the
+// serve tip immediately (header-first) — byte-identical pre-split behaviour
+// for every existing posture (KATs, dashd-RPC/ZMQ tip feed with no body feed).
+TEST(DashCoinStateMaintainer, HeaderFirstDefaultPromotesServeTipOnHeader) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    m.on_mn_list_update(single_mn(p2pkh_script(0x30)));
+    m.on_new_tip(H, raw256(0xCD), BITS, MTP, DASH_PUBKEY_VER, DASH_P2SH_VER,
+                 CURTIME, VERSION);
+    EXPECT_EQ(m.serve_tip_height(), H);
+    EXPECT_FALSE(m.tip_body_pending());
+    EXPECT_TRUE(m.live());
+}
+
+// The body fold's promotion must fire the state-dirty re-issue sink (builds
+// on #1089's event-driven resume) — serve tip + credit pool advance, gate
+// resumes, with NO template request in between.
+TEST(DashCoinStateMaintainer, BodyFirstPromotionFiresStateDirtyWithoutTemplateRequest) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    m.set_body_first_serve_tip(true);
+    st.set_require_fresh_credit_pool(true);
+    int dirty = 0;
+    m.set_on_state_dirty([&] { ++dirty; });
+    m.on_mn_list_update(single_mn(p2pkh_script(0x30)));
+
+    auto b1 = make_cbtx_block(H - 1, 111'000'000LL, p2pkh_script(0x30));
+    m.on_new_tip(H - 1, block_hash_of(b1), BITS, MTP,
+                 DASH_PUBKEY_VER, DASH_P2SH_VER, CURTIME, VERSION);
+    m.on_block_connected(b1, H - 1);
+    ASSERT_TRUE(m.live());
+
+    auto b2 = make_cbtx_block(H, next_balance(st, 111'000'000LL, H),
+                              p2pkh_script(0x30));
+    m.on_new_tip(H, block_hash_of(b2), BITS, MTP,
+                 DASH_PUBKEY_VER, DASH_P2SH_VER, CURTIME, VERSION);
+    const int dirty_before = dirty;
+    // No select_work()/template request happens between here and the fold.
+    m.on_block_connected(b2, H);
+    EXPECT_EQ(m.serve_tip_height(), H);
+    EXPECT_GT(dirty, dirty_before)
+        << "promotion must re-issue work (bump + notify) event-driven";
+}
+
+// Cold-start path: the initial header sync ends at a tip whose body is never
+// inv'd — the tip-targeted mnlistdiff's authoritative cbTx carries the same
+// block inputs and must promote the pending serve tip.
+TEST(DashCoinStateMaintainer, BodyFirstMnlistdiffAtTipPromotesPendingServeTip) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    m.set_body_first_serve_tip(true);
+    st.set_require_fresh_credit_pool(true);
+    // Payee axis current at the tip via the snapshot's as_of height.
+    m.on_mn_list_update(single_mn(p2pkh_script(0x30)), /*as_of_height=*/H);
+
+    const uint256 tip_hash = raw256(0x54);
+    m.on_new_tip(H, tip_hash, BITS, MTP, DASH_PUBKEY_VER, DASH_P2SH_VER,
+                 CURTIME, VERSION);
+    EXPECT_TRUE(m.tip_body_pending());
+    EXPECT_EQ(m.serve_tip_height(), 0u);
+
+    m.on_mnlistdiff(diff_with_seed(uint256::ZERO, tip_hash, H,
+                                   111'000'000LL, sml_entry(0x40)));
+    EXPECT_FALSE(m.tip_body_pending());
+    EXPECT_EQ(m.serve_tip_height(), H)
+        << "a tip-targeted diff cbTx is a body-equivalent input advance";
+    EXPECT_TRUE(m.live());
+}
+
+// A diff at the tip must NOT promote while the payee cursor lags the tip —
+// that would trade the removed creditpool-stale window for an identical
+// payee-stale one.
+TEST(DashCoinStateMaintainer, BodyFirstDiffDoesNotPromoteOverLaggingPayeeCursor) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    m.set_body_first_serve_tip(true);
+    st.set_require_fresh_credit_pool(true);
+    // Snapshot as-of H-1: payee cursor is one behind the pending tip H.
+    m.on_mn_list_update(single_mn(p2pkh_script(0x30)), /*as_of_height=*/H - 1);
+
+    const uint256 tip_hash = raw256(0x54);
+    m.on_new_tip(H, tip_hash, BITS, MTP, DASH_PUBKEY_VER, DASH_P2SH_VER,
+                 CURTIME, VERSION);
+    m.on_mnlistdiff(diff_with_seed(uint256::ZERO, tip_hash, H,
+                                   111'000'000LL, sml_entry(0x40)));
+    EXPECT_TRUE(m.tip_body_pending())
+        << "promotion must wait for the payee axis to reach the tip";
+    EXPECT_EQ(m.serve_tip_height(), 0u);
+}
+
+// Doomed-tip bound: a pending window that outlives the overdue budget (lost
+// body the p2p watchdog could not recover / credit-pool drift) demotes the
+// serve tip instead of serving knowingly-doomed old-tip work; the eventual
+// body re-arms it.
+TEST(DashCoinStateMaintainer, BodyFirstOverduePendingDemotesThenBodyReArms) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    m.set_body_first_serve_tip(true);
+    st.set_require_fresh_credit_pool(true);
+    int64_t now = 1'000'000;
+    m.set_now_fn([&] { return now; });
+    m.set_tip_body_overdue_secs(30);
+    m.on_mn_list_update(single_mn(p2pkh_script(0x30)));
+
+    auto b1 = make_cbtx_block(H - 1, 111'000'000LL, p2pkh_script(0x30));
+    m.on_new_tip(H - 1, block_hash_of(b1), BITS, MTP,
+                 DASH_PUBKEY_VER, DASH_P2SH_VER, CURTIME, VERSION);
+    m.on_block_connected(b1, H - 1);
+    ASSERT_TRUE(m.live());
+
+    auto b2 = make_cbtx_block(H, next_balance(st, 111'000'000LL, H),
+                              p2pkh_script(0x30));
+    m.on_new_tip(H, block_hash_of(b2), BITS, MTP,
+                 DASH_PUBKEY_VER, DASH_P2SH_VER, CURTIME, VERSION);
+    // Inside the budget: still serving old-height work.
+    now += 29;
+    m.on_mempool_tx(make_spend(raw256(0x91), 0, 1'000, 7));
+    EXPECT_TRUE(m.live());
+
+    // Budget exceeded: demote — refusing beats serving doomed-tip work.
+    now += 2;
+    m.on_mempool_tx(make_spend(raw256(0x92), 0, 1'000, 8));
+    EXPECT_FALSE(m.live())
+        << "overdue pending window must stop serving old-tip work";
+    EXPECT_EQ(st.describe_decline().cause, "tip-body-pending")
+        << "the overdue refusal must carry the named transient";
+
+    // The body finally lands: promotion re-arms the serve tip.
+    m.on_block_connected(b2, H);
+    EXPECT_TRUE(m.live());
+    EXPECT_EQ(m.serve_tip_height(), H);
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Bounded full-block buffer (LTC-style retention): eviction proven at the
+// bound — cap 24 with no ChainLock, shrink-to-floor 6 with a fresh one.
+// FAILS-ON-MASTER: no retention exists there at all.
+// ════════════════════════════════════════════════════════════════════════
+TEST(DashCoinStateMaintainer, FullBlockBufferEvictsAtBound) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    m.set_full_block_buffer(true);
+
+    const uint32_t H0 = H;
+    for (uint32_t i = 0; i < 30; ++i)
+        m.on_block_connected(
+            make_cbtx_block(H0 + i, 1'000LL + i, p2pkh_script(0x30)), H0 + i);
+    // No ChainLock observed => the cap alone bounds retention.
+    EXPECT_EQ(m.block_buffer_depth(), 24u) << "cap must bound the buffer";
+    EXPECT_EQ(m.block_buffer_lowest_height(), H0 + 6);
+    EXPECT_EQ(m.block_buffer_highest_height(), H0 + 29);
+    EXPECT_GE(m.block_buffer_evictions(), 6u) << "eviction must be OBSERVED";
+
+    // A fresh ChainLock near the tip shrinks retention to the floor: nothing
+    // at or below a ChainLocked height can reorg.
+    std::array<uint8_t, 96> sig{};
+    sig[0] = 1;
+    st.set_best_cl(static_cast<int32_t>(H0 + 29),
+                   sig, dash::coin::ClProvenance::ChainCommitted);
+    m.on_block_connected(
+        make_cbtx_block(H0 + 30, 2'000LL, p2pkh_script(0x30)), H0 + 30);
+    EXPECT_EQ(m.block_buffer_depth(), 6u)
+        << "with a tip-fresh ChainLock the floor governs";
+    EXPECT_EQ(m.block_buffer_highest_height(), H0 + 30);
+}
+
+// Reorg WITHIN the buffer depth: the credit pool is rolled back to the fork
+// point from the RETAINED fork-point body's own committed CCbTx balance — no
+// cold wipe on the credit-pool axis. Beyond the buffer (no retained body
+// still on the new branch) the existing wipe path is unchanged.
+// FAILS-ON-MASTER: on_sml_reorg unconditionally wipes the seed to -1.
+TEST(DashCoinStateMaintainer, ReorgWithinBufferReplaysCreditPoolUndoFromRetainedBodies) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    m.set_full_block_buffer(true);
+
+    const uint32_t H0 = H;
+    const int64_t bal_a = 1'000LL;
+    const int64_t bal_b = next_balance(st, bal_a, H0 + 1);
+    const int64_t bal_c = next_balance(st, bal_b, H0 + 2);
+    auto a = make_cbtx_block(H0,     bal_a, p2pkh_script(0x30));
+    auto b = make_cbtx_block(H0 + 1, bal_b, p2pkh_script(0x30));
+    auto c = make_cbtx_block(H0 + 2, bal_c, p2pkh_script(0x30));
+    m.on_block_connected(a, H0);
+    m.on_block_connected(b, H0 + 1);
+    m.on_block_connected(c, H0 + 2);
+    ASSERT_EQ(st.credit_pool_height(), static_cast<int32_t>(H0 + 2));
+    ASSERT_EQ(m.block_buffer_depth(), 3u);
+
+    // New branch after the reorg: H0 is still ours (fork point), H0+1 is a
+    // DIFFERENT block, H0+2 not present.
+    const uint256 a_hash = block_hash_of(a);
+    m.set_chain_hash_at_height_fn(
+        [&](uint32_t h) -> std::optional<uint256> {
+            if (h == H0) return a_hash;
+            if (h == H0 + 1) return raw256(0xEE);   // new-branch block != b
+            return std::nullopt;
+        });
+    m.on_sml_reorg();
+    EXPECT_EQ(st.credit_pool_height(), static_cast<int32_t>(H0))
+        << "credit pool must roll back to the fork point, not wipe to -1";
+    EXPECT_EQ(st.credit_pool(), bal_a)
+        << "the rolled-back balance is the retained body's own committed value";
+    EXPECT_EQ(m.block_buffer_highest_height(), H0)
+        << "orphan-branch bodies above the fork point must be dropped";
+
+    // ── Beyond the buffer: no retained body on the new branch => wipe. ──
+    NodeCoinState st2;
+    CoinStateMaintainer m2(st2);
+    m2.set_full_block_buffer(true);
+    m2.on_block_connected(make_cbtx_block(H0, 1'000LL, p2pkh_script(0x30)), H0);
+    m2.set_chain_hash_at_height_fn(
+        [](uint32_t) -> std::optional<uint256> { return std::nullopt; });
+    m2.on_sml_reorg();
+    EXPECT_EQ(st2.credit_pool_height(), -1)
+        << "beyond the buffer the existing wipe + cold-resync path stays";
+    EXPECT_EQ(st2.credit_pool(), 0);
+}


### PR DESCRIPTION
## What this is

The operator-directed architecture change scoped in the #1089 comment thread: LTC-style **body-first serve tip**, a **bounded full-block buffer**, and a **lost-body re-request watchdog** for the DASH daemonless lane. #1089 measured the substrate facts this builds on; this PR removes the `creditpool-stale` window **as a class** instead of shrinking it.

**STACKED ON #1089** (`dash/creditpool-eventdriven-resume` is this PR's base branch). The split, stated: #1089 is the event-driven-resume substrate (body-connect fold fires `notify_state_dirty()`, work source honors generation bumps immediately); this PR is the ordering/retention change that defers the serve-tip advance to that same, now-notifying, fold. Merge #1089 first; this PR then retargets to master clean. No consensus gate is touched by either — ordering and retention only.

## Piece 1 — `header_tip` / `serve_tip` split (body-first serve tip)

**MEASURED on master (per #1089):** the serve tip is header-first — `m_prev_height` is written only via `set_tip` (`node_coin_state.hpp`) <- `republish()` <- `on_new_tip` (`coin_state_maintainer.hpp`) <- the header-chain tip-changed callback (`main_dash.cpp`). Bodies never advance it, so we declare tip=H off the header and then correctly refuse (`creditpool-stale`, value = threshold-1) until body H parses. The window is self-inflicted by the ordering; dashd never exhibits it because its tip only advances after full-block processing.

**The change (`coin_state_maintainer.hpp`):**
- `on_new_tip` now stashes the **header tip**. Header-tip consumers are untouched: stale-work invalidation, template-cache invalidate + generation bump + `notify_all`, the mnlistdiff pull, the checkpoint-lane pump, and won-block detection all stay wired to the header-chain callback in `main_dash.cpp` exactly as before — none of them waits for a body.
- The **serve tip** (`m_prev_*` -> `set_tip` -> every freshness-gate threshold) is **promoted** only when the tip block's inputs are parsed, atomically with the credit-pool advance. Promotion predicate: the credit-pool seed current at the pending tip's **hash and height** (the hash match keeps a same-height competing block's body from promoting the wrong tip's params), plus the payee cursor at the tip (otherwise a tip-targeted mnlistdiff outracing the body would trade the removed `creditpool-stale` window for an identical `payee-stale` one — pinned by KAT).
- Promotion sources: the tip **body fold** (steady state) or the tip-targeted **mnlistdiff cbTx** (cold start — the initial header sync ends at a tip whose body is never inv'd; the diff carries the same authoritative block inputs).
- The 1-2 s window between header and body is the **named normal transient**: `tip-body-pending` (maintainer getter + log line + `describe_decline` rename when a refusal surfaces during it, e.g. cold start). No code path treats `serve_tip < header_tip` as an error; during the window the arm keeps serving prev=old-tip work — the same propagation-window behaviour every pool has; stratum keeps miners on the last job.
- **Doomed-tip bound:** a pending window outliving 30 s (lost body the watchdog could not recover, or a credit-pool accrual drift blocking the seed) demotes the serve tip — `tip-body-overdue` WARNING — because past the propagation window old-tip work is knowingly doomed and refusing is safer than serving it. The eventual body/diff re-arms it. This is the pairing the #1089 thread named as mandatory for the policy flip.
- **Opt-in, DASH lane only:** `set_body_first_serve_tip(true)` is called exactly once, in `main_dash.cpp`'s coin-P2P daemonless wiring. Default OFF keeps every other posture byte-identical — including the dashd-RPC/ZMQ tip posture, whose tip feed has **no body feed** and would never promote.

**The load-bearing invariant + fails-on-master proof:** *serve height never exceeds the height whose body has been parsed.* `DashCoinStateMaintainer.BodyFirstServeTipNeverExceedsParsedBodyHeight` pins it end-to-end (header alone must not create/advance the serve tip; the body fold must, atomically with the credit-pool advance, viable at the old height throughout). On header-first master this fails **by design** — `on_new_tip` writes `m_prev_height` directly, before any body exists. The default header-first behaviour is separately pinned (`HeaderFirstDefaultPromotesServeTipOnHeader`), so the suite states both sides of the split.

## Piece 2 — lost-body re-request watchdog (`p2p_client.hpp`)

Same defect class as the #1077 rotated-pending wedge: a request with no timeout. A `request_block` getdata answered by nothing has no retry, and `InvDedup` (TTL 600 s) suppresses the same block's inv from every other peer — the #1089 208 s episode sits squarely in this class, with a 600 s worst case.

- `request_block_tracked(hash)` — used by the tip-body pull in `main_dash.cpp` (the one request the serve tip now waits on). The bulk/historical legs (UTXO window refill, checkpoint-lane windows) stay on untracked `request_block`: their volume would defeat the bound and they have their own re-request loops.
- Unanswered for **T = 10 s** -> re-request from a **different handshaked peer** (post-#1082 the pool holds up to 8; the announcing peer may be slow or wedged, its neighbours demonstrably hold what they all announced), rotating on successive attempts; a single-peer pool re-asks the same peer. T justification: ~5x the worst normal same-stream headers->block gap (~1-2 s), far below the 157.5 s block interval; a false positive costs one duplicate block-sized response.
- **Bounded:** 4 re-requests per hash (~50 s), 8 tracked slots, then the slot is released to the headers-driven / inv-TTL backstop. Every re-request is named: `cause=body-rerequest attempt=N peer=<key> hash=<h> unanswered_for=<s>s`; exhaustion is a named WARNING. `POOL-STATUS` now carries `pending_bodies=` and `body_rerequests=<total>/<exhausted>`.
- Receipt from **any** peer disarms the slot.

## Piece 3 — bounded full-block buffer + reorg undo (`coin_state_maintainer.hpp`)

Operator: "highest sufficient number of full blocks, like daemonless LTC." Retention: merkle-bound bodies only (inserted after the E2-finding-A bind check), keyed by height, **above the last ChainLocked height + 2-block margin, floor 6, cap 24 (~1 h of DASH blocks)** — ChainLock depth is the principled reachability cap (nothing at or below a ChainLocked block can reorg), and DASH ChainLocks normally land within seconds, so steady-state depth is the floor. A ChainLock outage of ~1 h exhausts the cap and the existing wipe path takes over, by design. Depth/evictions are logged periodically (`full-block buffer depth=... span=[...] target=... cl_h=... evictions=...`) and exposed as counters — bounded and **measured**, not asserted.

**Reorg undo, and its honest scope:** a reorg whose fork point is still inside the buffer re-seeds the credit pool from the **retained fork-point body's own committed CCbTx balance** (the same independent, network-accepted source the per-block advance verifies against) instead of wiping the seed to -1 — the new branch's bodies then advance contiguously and verify. Orphan-branch bodies above the fork point are dropped. Beyond the buffer, or with the buffer/height-lookup unwired, the existing wipe + cold-resync path is byte-unchanged. **Deliberate asymmetry, stated loudly:** the SML/quorum (MN-root) axis is still wiped even inside the buffer — bodies cannot reconstruct the DMN list (a cbTx commits `merkleRootMNList`; a root is not a list), so the mnlistdiff cold-resync (one request/response round-trip, already re-issued by the reorg wiring) remains the only sound MN-root recovery. On the LTC idiom: I found no separate bounded body-retention structure in the LTC embedded lane to transfer directly; what transfers is the posture — the tip only advances off processed full blocks (LTC `template_builder`'s sync-proof-before-serve is the in-tree reference already cited by `set_chain_synced_fn`) — and the bound/eviction idiom here follows the DASH lane's own `InvDedup` pattern (bounded, expiring, counters proven by test).

## Tests (folded into two already-allowlisted targets; `tools/ci/check_test_target_allowlist.py` green, 230 targets)

`test_dash_coin_state_maintainer` (+8):
- `BodyFirstServeTipNeverExceedsParsedBodyHeight` — the atomicity centrepiece (fails on header-first master by design).
- `HeaderFirstDefaultPromotesServeTipOnHeader` — default OFF pinned byte-identical.
- `BodyFirstPromotionFiresStateDirtyWithoutTemplateRequest` — serve tip + credit pool advance atomically, gate resumes with NO template request in between (builds on #1089's notify).
- `BodyFirstMnlistdiffAtTipPromotesPendingServeTip` / `BodyFirstDiffDoesNotPromoteOverLaggingPayeeCursor` — cold-start promotion, and the payee-axis guard that keeps the split from re-opening the window under a new name.
- `BodyFirstOverduePendingDemotesThenBodyReArms` — the doomed-tip bound, fake clock, named refusal.
- `FullBlockBufferEvictsAtBound` — eviction proven at the cap (24) and at the ChainLock-driven floor (6).
- `ReorgWithinBufferReplaysCreditPoolUndoFromRetainedBodies` — undo from retained bodies inside the buffer; wipe path preserved beyond it (fails on master: `on_sml_reorg` wipes unconditionally).

`test_dash_p2p_node` (pool TU, +3):
- `lost_tip_body_is_rerequested_from_a_rotated_peer_at_T` — re-request at exactly T=10 s, to a different peer, named (fails on master: no tracking exists).
- `body_rerequest_is_capped_then_backstop_owns_it` — cap 4, slot released, exhaustion counted.
- `body_arrival_disarms_the_watchdog` — receipt from any peer disarms; no re-request ever fires after.

## MEASURED vs INFERRED vs PROJECTED

- MEASURED: everything cited from #1089's soak (window sizes, decline causes, call chain); the KAT results here; the buffer bound/eviction behaviour (pinned by test, counters logged at runtime).
- INFERRED: the 208 s episode being a lost getdata (N=1, #1089's analysis) — the watchdog kills that class regardless of whether that specific episode was one.
- PROJECTED: the serve-share gain from removing the creditpool-stale class is **projected until the follow-up soak measures it** (a contabo soak of the merged result is the planned next pipeline step). Markers a soak should grep: `tip-body-pending`, `tip-body-overdue`, `serve tip promoted`, `cause=body-rerequest`, `body-rerequest EXHAUSTED`, `full-block buffer depth=`, `reorg undo: credit pool rolled back`, and `POOL-STATUS ... pending_bodies=... body_rerequests=...`.

DASH lane only (`src/impl/dash/coin/`, `src/c2pool/main_dash.cpp`, DASH test TUs). No consensus gate weakened — the exact-equality creditpool gate, the bestCL gates, and every fail-closed path are untouched; this changes WHEN the serve tip advances and WHAT is retained, never what is accepted. Non-destructive.
