### PR TITLE
dash web: purge remaining merged-DOGE UI on standalone-coin pages (#896 follow-up)

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1469,7 +1469,10 @@ if (BUILD_TESTING AND GTest_FOUND)
     target_link_libraries(test_web_honesty_regression PRIVATE c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage ltc_coin pool)  # OBJECT-lib SCC direct-naming (#22/#39)
     gtest_add_tests(test_web_honesty_regression "" AUTO)
     target_compile_definitions(test_web_honesty_regression PRIVATE  # folded #912 static-HTML KAT
-        DASHBOARD_HTML_PATH="${CMAKE_SOURCE_DIR}/web-static/dashboard.html")
+        DASHBOARD_HTML_PATH="${CMAKE_SOURCE_DIR}/web-static/dashboard.html"
+        # WebStaticMergedGating KATs read the sibling web-static pages
+        # (miners/miner/loading) for standalone-coin merged-UI gating.
+        WEB_STATIC_DIR="${CMAKE_SOURCE_DIR}/web-static")
 
 endif()
 

--- a/test/test_web_honesty_regression.cpp
+++ b/test/test_web_honesty_regression.cpp
@@ -1743,3 +1743,130 @@ TEST(WebBlockValueReconcile, ZeroFeeStillPresentAndConsistent) {
                 r["block_value_payments"].get<double>(),
                 r["block_value"].get<double>(), 1e-8);
 }
+
+// ===========================================================================
+// Standalone-coin merged-UI purge (follow-up to #896/#912): a coin with no
+// merged child (DASH/BTC/DGB) must not render ANY merged-mining card, column,
+// or SPV row anywhere in the web-static layer -- not just the Username line.
+// These KATs pin the topology gates added to dashboard.html (Merged Payout
+// column), miners.html / miner.html (Merged Mining Blocks sections), and
+// loading.html (SPV rows). Same charter: never imply revenue or a chain
+// topology that does not exist.
+// ===========================================================================
+#ifndef WEB_STATIC_DIR
+#error "WEB_STATIC_DIR must be defined by CMake"
+#endif
+
+namespace {
+std::string read_web_static(const std::string& name) {
+    std::ifstream f(std::string(WEB_STATIC_DIR) + "/" + name);
+    EXPECT_TRUE(f.good()) << "cannot open " << WEB_STATIC_DIR << "/" << name;
+    std::stringstream ss; ss << f.rdbuf();
+    return ss.str();
+}
+} // namespace
+
+// dashboard.html: the Active-Miners "Merged Payout" column (header AND the
+// dynamically appended cells) must carry the merged-child-hint gate. The cells
+// are appended on every table re-render, AFTER the one-shot d3 toggle ran, so
+// the gate must also exist as a CSS rule keyed off a body class the topology
+// handler stamps -- otherwise re-rendered rows resurrect the DOGE column.
+TEST(DashboardMergedGating, MinersTableMergedPayoutColumnIsGated) {
+    const auto html = read_dashboard();
+    for (const auto& line : lines_of(html)) {
+        if (line.find(">Merged Payout</th>") != std::string::npos) {
+            EXPECT_NE(line.find("merged-child-hint"), std::string::npos)
+                << "the Merged Payout column header is not topology-gated; a "
+                   "standalone coin renders a phantom DOGE payout column:\n"
+                << line;
+        }
+    }
+    // Body-class CSS gate covers dynamically appended cells.
+    EXPECT_NE(html.find("body.no-merged-child .merged-child-hint"),
+              std::string::npos)
+        << "missing the body-class CSS gate; merged cells appended after the "
+           "currency_info toggle ran (miner-table re-renders) stay visible on "
+           "a standalone coin.";
+    EXPECT_NE(html.find("classList.toggle('no-merged-child', !mergedChild)"),
+              std::string::npos)
+        << "the topology handler does not stamp the no-merged-child body "
+           "class; the CSS gate never engages.";
+    // The dynamically appended merged-payout cell must carry the gate class.
+    EXPECT_NE(html.find("minerRow.append('td').attr('class', 'merged-child-hint')"),
+              std::string::npos)
+        << "the per-miner merged-payout cell is appended without the gate "
+           "class; every miner row shows '0.0000 DOGE' on a standalone coin.";
+}
+
+// miners.html: the "Merged Mining Blocks" section must be hidden by default
+// and revealed only when currency_info advertises a merged child. Both failure
+// directions: standalone stays hidden, merged parent still shows it.
+TEST(WebStaticMergedGating, MinersPageMergedBlocksSectionIsTopologyGated) {
+    const auto html = read_web_static("miners.html");
+    for (const auto& line : lines_of(html)) {
+        if (line.find("id=\"merged_blocks_header\"") != std::string::npos) {
+            EXPECT_NE(line.find("display: none"), std::string::npos)
+                << "merged_blocks_header renders by default; a standalone coin "
+                   "shows a Merged Mining Blocks card:\n" << line;
+        }
+        if (line.find("id=\"merged_blocks_panel\"") != std::string::npos) {
+            EXPECT_NE(line.find("display: none"), std::string::npos)
+                << "merged_blocks_panel renders by default on a standalone "
+                   "coin:\n" << line;
+        }
+    }
+    EXPECT_NE(html.find("info.merged_child_symbol"), std::string::npos)
+        << "no topology reveal path: a merged parent (LTC) would lose its "
+           "Merged Mining Blocks section.";
+}
+
+// miner.html: same contract for the per-miner page (header + summary stat
+// cards + blocks table), which previously rendered zeroed merged cards
+// unconditionally.
+TEST(WebStaticMergedGating, MinerPageMergedBlocksSectionIsTopologyGated) {
+    const auto html = read_web_static("miner.html");
+    const std::vector<std::string> gated_ids = {
+        "merged_blocks_header", "merged_summary_grid", "merged_blocks_panel"};
+    for (const auto& id : gated_ids) {
+        bool declared = false, hidden = false;
+        for (const auto& line : lines_of(html)) {
+            if (line.find("id=\"" + id + "\"") != std::string::npos) {
+                declared = true;
+                if (line.find("display: none") != std::string::npos) hidden = true;
+            }
+        }
+        EXPECT_TRUE(declared) << "expected element '" << id << "' not found; "
+            "if it moved, re-point this KAT.";
+        EXPECT_TRUE(hidden) << "'" << id << "' renders by default; a "
+            "standalone coin shows zeroed merged-mining cards.";
+    }
+    EXPECT_NE(html.find("info.merged_child_symbol"), std::string::npos)
+        << "no topology reveal path: a merged parent (LTC) would lose its "
+           "merged blocks section on the miner page.";
+}
+
+// loading.html: the startup page must not hardcode LTC/DOGE SPV rows. The
+// parent row's label is currency_info-driven and both rows appear only when
+// the node reports SPV progress; the child row additionally requires a merged
+// child in the topology. A DASH node must show neither an LTC nor a DOGE row.
+TEST(WebStaticMergedGating, LoadingPageSpvRowsAreTopologyDriven) {
+    const auto html = read_web_static("loading.html");
+    EXPECT_EQ(html.find(">LTC SPV</span>"), std::string::npos)
+        << "loading.html hardcodes an LTC SPV row label; a standalone DASH "
+           "node presents itself as an LTC node while starting up.";
+    EXPECT_EQ(html.find(">DOGE SPV</span>"), std::string::npos)
+        << "loading.html hardcodes a DOGE SPV row label; a standalone coin "
+           "advertises a merged chain it does not have.";
+    for (const auto& line : lines_of(html)) {
+        if (line.find("id=\"row-parent-spv\"") != std::string::npos ||
+            line.find("id=\"row-child-spv\"") != std::string::npos) {
+            EXPECT_NE(line.find("display:none"), std::string::npos)
+                << "SPV row renders by default (before the node reports any "
+                   "SPV state):\n" << line;
+        }
+    }
+    EXPECT_NE(html.find("ci.merged_child_symbol"), std::string::npos)
+        << "the child SPV row is not keyed off the merged-child topology.";
+    EXPECT_NE(html.find("ci.symbol"), std::string::npos)
+        << "the parent SPV row label is not currency_info-driven.";
+}

--- a/web-static/dashboard.html
+++ b/web-static/dashboard.html
@@ -634,6 +634,11 @@
             color: var(--success);
         }
         
+        /* Standalone-parent topology (no merged child, e.g. DASH/BTC/DGB):
+           hide every merged-mining UI element, including ones appended after
+           the currency_info gate ran (dynamic table cells). The body class is
+           set from currency_info.merged_child_symbol — never hardcoded. */
+        body.no-merged-child .merged-child-hint { display: none !important; }
         /* Merged payout sub-rows */
         .merged-payout-row td {
             font-size: 0.72rem;
@@ -1952,7 +1957,7 @@
                                 <th title="Last pseudoshare received">Last Seen</th>
                                 <th title="Dead on Arrival rate">DOA Rate</th>
                                 <th title="Predicted payout if block found now">Predicted Payout</th>
-                                <th title="Predicted merged mining payout if block found now">Merged Payout</th>
+                                <th class="merged-child-hint" title="Predicted merged mining payout if block found now">Merged Payout</th>
                             </tr>
                         </thead>
                         <tbody></tbody>
@@ -2774,9 +2779,11 @@
                     var payoutSymbol = (currency_info && currency_info.symbol) || 'COIN';
                     minerRow.append('td').text(d3.format('.4f')(payout) + ' ' + payoutSymbol);
                     
-                    // Merged payout
+                    // Merged payout — cell carries merged-child-hint so the
+                    // topology CSS gate (body.no-merged-child) hides it on
+                    // standalone parents together with its column header.
                     var mergedEntry = mergedPayouts[miner.address];
-                    var mergedPayoutCell = minerRow.append('td');
+                    var mergedPayoutCell = minerRow.append('td').attr('class', 'merged-child-hint');
                     if (mergedEntry && mergedEntry.merged && mergedEntry.merged.length > 0) {
                         var mp = mergedEntry.merged[0];
                         mergedPayoutCell
@@ -2839,7 +2846,9 @@
                         var doaPercent = worker.hashrate > 0 ? worker.doa_hashrate / worker.hashrate : 0;
                         workerRow.append('td').text(d3.format('.2%')(doaPercent));
                         workerRow.append('td').text('-');
-                        workerRow.append('td').text('-');
+                        // Merged-payout filler cell — hidden with its column on
+                        // standalone parents (body.no-merged-child).
+                        workerRow.append('td').attr('class', 'merged-child-hint').text('-');
                     });
                 });
                 });
@@ -2874,6 +2883,10 @@
             // (DASH/BTC/DGB) shows just PARENT_ADDR.WORKER. Never serve merged-
             // mining worker instructions on a coin with no merged child.
             var mergedChild = info && info.merged_child_symbol;
+            // Body class drives a CSS rule so merged-mining cells appended
+            // later (miner-table re-renders) are hidden too, not only the
+            // elements that existed when this callback ran.
+            document.body.classList.toggle('no-merged-child', !mergedChild);
             if (mergedChild) {
                 d3.selectAll('.merged-child-symbol-hint').text(mergedChild);
                 d3.selectAll('.merged-child-hint').style('display', null);

--- a/web-static/loading.html
+++ b/web-static/loading.html
@@ -37,8 +37,12 @@ h1 { font-size: 2rem; margin-bottom: 8px; color: #58a6ff; }
         <div class="row"><span class="label">Sharechain</span><span class="val" id="d-shares">...</span></div>
         <div class="row"><span class="label">Verified</span><span class="val" id="d-verified">...</span></div>
         <div class="row"><span class="label">Best share</span><span class="val" id="d-best">...</span></div>
-        <div class="row"><span class="label">LTC SPV</span><span class="val" id="d-ltc-spv">...</span></div>
-        <div class="row"><span class="label">DOGE SPV</span><span class="val" id="d-doge-spv">...</span></div>
+        <!-- SPV rows are topology-driven: parent label comes from
+             currency_info.symbol; the merged-child row appears only when the
+             node advertises a merged child (or reports child SPV progress).
+             A standalone coin (DASH/BTC/DGB) must not show LTC/DOGE rows. -->
+        <div class="row" id="row-parent-spv" style="display:none"><span class="label" id="l-parent-spv">SPV</span><span class="val" id="d-ltc-spv">...</span></div>
+        <div class="row" id="row-child-spv" style="display:none"><span class="label" id="l-child-spv">SPV</span><span class="val" id="d-doge-spv">...</span></div>
         <div class="row"><span class="label">Uptime</span><span class="val" id="d-uptime">...</span></div>
     </div>
     <div class="note">This page auto-refreshes. You will be redirected to the dashboard when ready.</div>
@@ -62,8 +66,23 @@ function poll() {
         // In embedded mode, currency_info doesn't have block_value/pool_hash_rate
         // (those come from getwork which requires stratum), so use the ready flag.
         var dashReady = d.ready && d.verified_size > 0 && d.has_work;
-        // SPV progress with ETA
+        // SPV progress with ETA — rows are shown only when the node actually
+        // reports SPV sync state; labels are topology-driven, never hardcoded.
         if (d.spv) {
+            // Each row appears only when the node reports THAT chain's SPV
+            // fields (e.g. DGB reports dgb_* keys: neither row applies).
+            var hasParentSpv = (d.spv.ltc_need !== undefined);
+            var childSym = ci && ci.merged_child_symbol;
+            var hasChildSpv = (d.spv.doge_need !== undefined) && (childSym || d.spv.doge_need > 0);
+            if (hasParentSpv) {
+                document.getElementById('row-parent-spv').style.display = '';
+                document.getElementById('l-parent-spv').textContent = ((ci && ci.symbol) || 'LTC') + ' SPV';
+            }
+            if (hasChildSpv) {
+                document.getElementById('row-child-spv').style.display = '';
+                document.getElementById('l-child-spv').textContent = (childSym || 'DOGE') + ' SPV';
+            }
+            if (hasParentSpv) {
             var ltcDone = d.spv.ltc_blocks >= d.spv.ltc_need;
             var ltcTxt = ltcDone ? 'ready' : d.spv.ltc_blocks + '/' + d.spv.ltc_need;
             if (!ltcDone && d.spv.ltc_blocks > 1 && d.uptime_seconds > 10) {
@@ -73,15 +92,18 @@ function poll() {
             }
             document.getElementById('d-ltc-spv').textContent = ltcTxt;
             document.getElementById('d-ltc-spv').className = 'val ' + (ltcDone ? 'ok' : 'wait');
-            var dogeDone = d.spv.doge_blocks >= d.spv.doge_need;
-            var dogeTxt = dogeDone ? 'ready' : d.spv.doge_blocks + '/' + d.spv.doge_need;
-            if (!dogeDone && d.spv.doge_blocks > 1 && d.uptime_seconds > 10) {
-                var dr = d.spv.doge_blocks / d.uptime_seconds;
-                var drem = Math.ceil((d.spv.doge_need - d.spv.doge_blocks) / Math.max(dr, 0.01));
-                dogeTxt += ' (~' + (drem > 60 ? Math.ceil(drem/60) + 'min' : drem + 's') + ')';
             }
-            document.getElementById('d-doge-spv').textContent = dogeTxt;
-            document.getElementById('d-doge-spv').className = 'val ' + (dogeDone ? 'ok' : 'wait');
+            if (hasChildSpv) {
+                var dogeDone = d.spv.doge_blocks >= d.spv.doge_need;
+                var dogeTxt = dogeDone ? 'ready' : d.spv.doge_blocks + '/' + d.spv.doge_need;
+                if (!dogeDone && d.spv.doge_blocks > 1 && d.uptime_seconds > 10) {
+                    var dr = d.spv.doge_blocks / d.uptime_seconds;
+                    var drem = Math.ceil((d.spv.doge_need - d.spv.doge_blocks) / Math.max(dr, 0.01));
+                    dogeTxt += ' (~' + (drem > 60 ? Math.ceil(drem/60) + 'min' : drem + 's') + ')';
+                }
+                document.getElementById('d-doge-spv').textContent = dogeTxt;
+                document.getElementById('d-doge-spv').className = 'val ' + (dogeDone ? 'ok' : 'wait');
+            }
         }
         var m = Math.floor((d.uptime_seconds || 0) / 60);
         var s = (d.uptime_seconds || 0) % 60;

--- a/web-static/miner.html
+++ b/web-static/miner.html
@@ -637,13 +637,15 @@
                 </div>
             </div>
             
-            <!-- Merged Mining Blocks Table -->
-            <div class="section-header" id="merged_blocks_header">
+            <!-- Merged Mining Blocks Table — hidden by default; revealed only
+                 when currency_info advertises a merged child (topology-driven,
+                 #896). Standalone parents (DASH/BTC/DGB) never show it. -->
+            <div class="section-header" id="merged_blocks_header" style="display: none;">
                 <h2>🔗 Merged Mining Blocks Found</h2>
             </div>
-            
+
             <!-- Merged Payout Summary Stats -->
-            <div class="stats-grid" style="margin-bottom: 20px;">
+            <div class="stats-grid" id="merged_summary_grid" style="display: none; margin-bottom: 20px;">
                 <div class="stat-card">
                     <h3>Merged Blocks Found</h3>
                     <div class="stat-value success" id="merged_blocks_found">0</div>
@@ -666,7 +668,7 @@
                 </div>
             </div>
             
-            <div class="chart-container">
+            <div class="chart-container" id="merged_blocks_panel" style="display: none;">
                 <div id="merged_blocks_loading" class="loading" style="padding: 20px;">
                     <div class="loading-spinner"></div>
                     <div>Loading merged blocks data...</div>
@@ -1524,6 +1526,14 @@
             var symbol = currency_info.symbol || 'COIN';
             document.getElementById('currency_symbol').textContent = symbol;
             document.getElementById('payout_label').textContent = symbol + ' on next block';
+            // Merged-mining cards are topology-driven: only a merged parent
+            // (currency_info.merged_child_symbol present) shows them. A
+            // standalone coin (DASH/BTC/DGB) keeps them hidden.
+            if (info && info.merged_child_symbol) {
+                document.getElementById('merged_blocks_header').style.display = '';
+                document.getElementById('merged_summary_grid').style.display = '';
+                document.getElementById('merged_blocks_panel').style.display = '';
+            }
             if (info && info.explorer_enabled && info.explorer_url) {
                 var nav = document.querySelector('nav');
                 var _old = document.getElementById('nav-explorer'); if (_old) _old.remove();

--- a/web-static/miners.html
+++ b/web-static/miners.html
@@ -566,11 +566,13 @@
             </div>
         </div>
         
-        <!-- Merged Mining Blocks -->
-        <div class="section-header" id="merged_blocks_header">
+        <!-- Merged Mining Blocks — hidden by default; revealed only when
+             currency_info advertises a merged child (topology-driven, #896).
+             Standalone parents (DASH/BTC/DGB) must never show merged cards. -->
+        <div class="section-header" id="merged_blocks_header" style="display: none;">
             <h2>🔗 Merged Mining Blocks <span class="badge" id="merged_blocks_count" style="background: #6f42c1;">0</span></h2>
         </div>
-        <div class="chart-container" style="background: var(--card-bg); border-radius: 12px; padding: 20px; border: 1px solid var(--border); margin-bottom: 20px;">
+        <div class="chart-container" id="merged_blocks_panel" style="display: none; background: var(--card-bg); border-radius: 12px; padding: 20px; border: 1px solid var(--border); margin-bottom: 20px;">
             <div id="merged_blocks_loading" class="loading" style="padding: 20px;">
                 <div class="loading-spinner"></div>
                 <div>Loading merged blocks data...</div>
@@ -644,6 +646,13 @@
         d3.json('../web/currency_info', function(info) {
             currency_info = info || {};
             d3.selectAll('.symbol-small').text((info && info.symbol) || 'DASH');
+            // Merged-mining cards are topology-driven: only a merged parent
+            // (currency_info.merged_child_symbol present) shows them. A
+            // standalone coin (DASH/BTC/DGB) keeps them hidden.
+            if (info && info.merged_child_symbol) {
+                document.getElementById('merged_blocks_header').style.display = '';
+                document.getElementById('merged_blocks_panel').style.display = '';
+            }
             if (info && info.explorer_enabled && info.explorer_url) {
                 var nav = document.querySelector('nav');
                 var _old = document.getElementById('nav-explorer'); if (_old) _old.remove();


### PR DESCRIPTION
## Standalone-coin web layer: purge the remaining merged-DOGE artifacts (#896 follow-up)

#896 gated only the **Username** connection-instruction line. The rest of the
web-static layer still rendered merged-mining UI unconditionally, so a
standalone DASH node (not merge-mined) served stale/wrong LTC+DOGE cards.

### MEASURED scope (branch base `edcc27624`)

Raw grep `merged|doge|auxpow` (case-insensitive) across the DASH-served web
layer + `src/impl/dash/**`: **1109 hits**. Classification:

| Class | Count | Disposition |
|---|---|---|
| (a) genuinely wrong for DASH — rendered merged UI with no topology gate | **4 defect sites (10 ungated DOM elements + 2 ungated JS cell-append sites)** | fixed here, topology-gated |
| (b) correctly inert on DASH (data-gated, `.merged-child-hint`-gated, unreachable render paths, shared explorer/test scaffolding, protocol-level structs) | ~1090 | untouched |
| (c) ambiguous | hardcoded blockchair litecoin/dogecoin fallback URLs inside merged-only render paths (`dashboard.html` ~3998/4050/4142/4165/6539, `miners.html` 893/904, `miner.html`, `share.html`) | untouched — only reachable when merged data exists (never on DASH); already tracked as the (a)-residual follow-up in `p2pool-dash/DASH_DASHBOARD_PLAN.md` |

The bulk of the raw hits are class (b): the merged blocks / discovered-merged /
broadcaster sections and best-share merged parts are data-gated and the DASH
backend returns empty for them (`rest_recent_merged_blocks` etc. bail without
`m_mm_manager`); the `.merged-child-hint` spans were already gated by #896.

### Class (a) defects fixed — each was visible on a live DASH node

1. **`dashboard.html` Active Miners table** — ungated **"Merged Payout"**
   column: header + a **`0.0000 DOGE`** cell per miner + `-` filler per worker
   row. Gated with the #896 topology signal; because the cells are re-appended
   on every table re-render (after the one-shot d3 toggle), the gate is a CSS
   rule keyed off a `no-merged-child` body class stamped from
   `currency_info.merged_child_symbol`.
2. **`miners.html`** — ungated "🔗 Merged Mining Blocks" section ("No merged
   mining blocks found yet"). Hidden by default, revealed only when
   `currency_info.merged_child_symbol` is present.
3. **`miner.html`** — ungated "🔗 Merged Mining Blocks Found" header + 4 zeroed
   merged stat cards + merged blocks table. Same topology reveal.
4. **`loading.html`** — hardcoded **"LTC SPV"** and **"DOGE SPV"** rows on the
   startup page of every coin. Rows now appear only when the node reports that
   chain's SPV fields; labels are `currency_info`-driven. On DASH (no
   `spv_progress_fn` wired) both rows stay hidden. Bonus: DGB (which reports
   `dgb_*` SPV keys) no longer renders `undefined/undefined` LTC/DOGE rows.

### LTC/DOGE merged lane — verified unchanged

Every edit is capability-gated on `currency_info.merged_child_symbol`, which
`rest_web_currency_info()` emits for the LTC parent (web_server.cpp:4071) and
omits for standalone coins. `main_ltc` always emits `ltc_*`/`doge_*` SPV keys,
so the loading rows and all merged cards render exactly as before on LTC.
No backend behavior changed; the diff is web-static + tests only.

### MEASURED after

- Ungated merged-mining DOM elements in DASH-served pages: **10 → 0** (plus
  2 ungated JS cell-append sites → 0).
- Hardcoded `LTC SPV` / `DOGE SPV` labels in `loading.html`: **2 → 0**.
- Raw grep counts per file go **up** slightly (gating comments mention
  "merged") — raw token count is the wrong metric for a gating fix; no inert
  class-(b) code was edited to inflate the diff.

### Tests

The layer is pure templating, so coverage is the static-HTML KAT pattern
already folded into the allowlisted `test_web_honesty_regression` target
(#912): 4 new KATs pin the gates —

- `DashboardMergedGating.MinersTableMergedPayoutColumnIsGated`
- `WebStaticMergedGating.MinersPageMergedBlocksSectionIsTopologyGated`
- `WebStaticMergedGating.MinerPageMergedBlocksSectionIsTopologyGated`
- `WebStaticMergedGating.LoadingPageSpvRowsAreTopologyDriven`

Each asserts both failure directions: standalone hides, merged parent still
shows. CMake adds a `WEB_STATIC_DIR` define next to the existing
`DASHBOARD_HTML_PATH`. No new test target (nothing to allowlist);
`tools/ci/check_test_target_allowlist.py` passes: 231 targets OK.

Full `test_web_honesty_regression` suite: 63/63 green locally (RUN→OK, not
skipped). `loading.html` script block passes `node --check`.
