### PR TITLE
dash: wire post-broadcast found-block confirm/orphan lane

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -72,6 +72,7 @@
 #include <impl/dash/coin/quorum_member_source.hpp>  // E1 Phase-L: daemonless member-set sourcing (the provider)
 #include <impl/dash/coin/utxo_lane.hpp>    // dash::coin::UtxoLane — embedded UTXO/fee lane (E2b, #738)
 #include <impl/dash/coin/header_chain.hpp>       // dash::coin::HeaderChain — SPV header/tip authority (E2a)
+#include <impl/dash/coin/block_confirm.hpp>      // dash::coin::block_confirm — post-broadcast confirm/orphan verdict
 #include <impl/dash/coin/chain_rpc.hpp>          // dash::coin::chain_rpc — daemonless getbestblockhash/getblockhash/getblockchaininfo
 #include <impl/dash/coin/coin_state_maintainer.hpp>  // dash::coin::CoinStateMaintainer — populate ordering gate (E2a)
 #include <impl/dash/coin/sml_quorum_db.hpp>      // dash::coin::SMLDb / QuorumDb — SML+quorum persistence (incremental restart)
@@ -1278,6 +1279,10 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                             row.share_difficulty,
                             mi->get_local_hashrate(),
                             row.subsidy);
+                        // Arm the post-broadcast confirm/orphan poller so this
+                        // peer-found block flips off "pending" (main_ltc.cpp:6315
+                        // parity). Telemetry only; never gates a broadcast.
+                        mi->schedule_block_verification(row.block_hash.GetHex());
                     });
         }
 
@@ -2018,6 +2023,10 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                         /*share_difficulty=*/0.0,
                         pool_hr,
                         subsidy);
+                    // Arm the post-broadcast confirm/orphan poller so this local
+                    // win flips off "pending" (main_ltc.cpp:4258 parity).
+                    // Telemetry only; runs after dispatch, never gates it.
+                    mi->schedule_block_verification(block_hash.GetHex());
                     if (!reached_network)
                         LOG_WARNING << "[DASH] recorded found block height="
                                     << height << " that reached NO network sink";
@@ -4855,6 +4864,87 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         };
         stats_timer->expires_after(std::chrono::seconds(100));
         stats_timer->async_wait(*stats_tick);
+
+        // ── Post-broadcast found-block confirmation / orphan lane ──────────
+        // WHY: DASH wired NONE of set_block_verify_fn / schedule_block_
+        // verification (LTC wires both, main_ltc.cpp:2105/3013/4258/6315), so a
+        // DASH found block sat "pending" on the dashboard forever and orphans
+        // (e.g. hotel 2508008) were found by humans, not the board. This arms
+        // the poller: verify_found_block fires the verdict fn at +30/+150/… s
+        // and flips the row to confirmed/orphaned.
+        //
+        // TELEMETRY ONLY. Runs strictly AFTER submission; touches no submit,
+        // mint, target or payout path. The pre-broadcast payee guard
+        // (work_source.cpp) remains the sole consensus gate — a wrong verdict
+        // here can only mislabel a dashboard row, never a broadcast.
+        //
+        // DAEMONLESS-FIRST (rule 4): the embedded X11+DGW header chain answers
+        // "which block won height h" from its own best branch, so orphan/confirm
+        // resolve with NO dashd. dashd getblockheader is used only as a fallback
+        // when the header chain is absent (pure --coin-rpc arm). The found block
+        // height comes from our own record (get_found_blocks) — authoritative
+        // even for an orphan whose header peers never relayed to us.
+        cache_mi->set_block_verify_fn(
+            [hc = header_chain.get(), rp = rpc.get(), mi = cache_mi](
+                const std::string& hash_hex) -> int {
+                uint256 h;
+                h.SetHex(hash_hex);
+
+                // Recorded mint height for this hash (authoritative for orphans).
+                uint32_t found_height = 0;
+                bool have_height = false;
+                for (const auto& b : mi->get_found_blocks()) {
+                    if (b.hash == hash_hex) {
+                        found_height = static_cast<uint32_t>(b.height);
+                        have_height = true;
+                        break;
+                    }
+                }
+
+                // Daemonless arm: resolve against the embedded header chain.
+                if (hc) {
+                    if (!have_height) {
+                        if (auto e = hc->get_header(h)) {
+                            found_height = e->height;
+                            have_height = true;
+                        }
+                    }
+                    if (have_height) {
+                        auto winner_at =
+                            [hc](uint32_t hh) -> std::optional<uint256> {
+                                if (auto e = hc->get_header_by_height(hh))
+                                    return e->hash;
+                                return std::nullopt;
+                            };
+                        return dash::coin::block_confirm::resolve_status(
+                            winner_at, hc->height(), h, found_height);
+                    }
+                    // header chain present but height unknown → still pending
+                    return 0;
+                }
+
+                // Fallback arm (no embedded chain): dashd getblockheader.
+                // dashd reports confirmations = -1 for a block off the active
+                // chain (orphaned), >=1 while it is on the best chain.
+                if (rp) {
+                    try {
+                        auto j = rp->getblockheader(h, /*verbose=*/true);
+                        if (j.contains("confirmations") &&
+                            j["confirmations"].is_number()) {
+                            int c = j["confirmations"].get<int>();
+                            if (c < 0) return -1;   // off active chain → orphaned
+                            if (c >= static_cast<int>(
+                                    dash::coin::block_confirm::kDefaultConfirmDepth))
+                                return c;           // buried enough → confirmed
+                        }
+                    } catch (...) { /* unreachable/unknown → pending */ }
+                }
+                return 0;
+            });
+        std::cout << "[run] found-block confirmation/orphan lane ARMED "
+                     "(daemonless header-chain verdict"
+                  << (rpc ? " + dashd getblockheader fallback" : "")
+                  << ")\n";
     }
 
     std::cout << "[run] run-loop up (Ctrl-C to stop); won blocks relay DUAL-PATH:\n"

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -28,6 +28,7 @@
 #include <set>
 #include <ctime>
 #include <chrono>
+#include <limits>
 #include <cmath>
 #include <fstream>
 #ifndef _WIN32
@@ -3565,6 +3566,32 @@ void MiningInterface::verify_found_block(size_t index)
     {
         try { m_persist_block_fn(blk); }
         catch (...) {}
+    }
+}
+
+int MiningInterface::run_block_verification_now(const std::string& block_hash)
+{
+    size_t idx = SIZE_MAX;
+    {
+        std::lock_guard<std::mutex> lock(m_blocks_mutex);
+        for (size_t i = 0; i < m_found_blocks.size(); ++i) {
+            if (m_found_blocks[i].hash == block_hash) { idx = i; break; }
+        }
+    }
+    if (idx == SIZE_MAX) return std::numeric_limits<int>::min();
+
+    // verify_found_block() takes m_blocks_mutex itself — must not hold it here.
+    verify_found_block(idx);
+
+    std::lock_guard<std::mutex> lock(m_blocks_mutex);
+    if (idx >= m_found_blocks.size()) return std::numeric_limits<int>::min();
+    switch (m_found_blocks[idx].status) {
+        case BlockStatus::confirmed:
+            return static_cast<int>(m_found_blocks[idx].confirmations);
+        case BlockStatus::orphaned:
+            return -1;
+        default:
+            return 0;
     }
 }
 

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -891,6 +891,16 @@ public:
     // Per-chain verify function: register additional verifiers for merged chains
     void add_chain_verify_fn(const std::string& chain, block_verify_fn_t fn);
 
+    // Test/introspection seam: run ONE verification pass for a recorded found
+    // block synchronously (no io_context timer) and return the resulting
+    // verdict — >0 confirmations (confirmed), <0 orphaned, 0 pending,
+    // INT_MIN if the hash is not a recorded found block. This drives the exact
+    // production status-transition code (verify_found_block); the async
+    // schedule_block_verification() above is the live driver. Added for the
+    // DASH orphan-lane tests so the pending→confirmed / pending→orphaned flips
+    // can be asserted deterministically without waiting on real timers.
+    int run_block_verification_now(const std::string& block_hash);
+
     /// Read-only access to found blocks (for sharechain window grid).
     std::vector<FoundBlock> get_found_blocks() const {
         std::lock_guard<std::mutex> lock(m_blocks_mutex);

--- a/src/impl/dash/coin/block_confirm.hpp
+++ b/src/impl/dash/coin/block_confirm.hpp
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// DASH post-broadcast block confirmation / orphan verdict.
+///
+/// This is the daemonless resolver behind the dashboard found-block status
+/// lane. It answers ONE question about a block we already broadcast: is it
+/// still on the best chain at its height (confirmed), did a different block
+/// win that height (orphaned), or is the chain not deep enough to tell yet
+/// (pending)?
+///
+/// TELEMETRY ONLY. It runs AFTER submission and can never affect a broadcast
+/// — the pre-broadcast payee guard (work_source.cpp) is the consensus gate.
+/// Its sole effect is to flip a dashboard row out of "pending".
+///
+/// It is genuinely daemonless: the only primitive it needs is "which hash is
+/// on the best chain at height h" plus the current tip height. The embedded
+/// DASH HeaderChain answers both from its X11+DGW-validated, height-indexed
+/// on-disk chain (get_header_by_height() reflects the current best branch,
+/// rebuilt from the tip via prev_hash on every reorg), so orphan detection
+/// does NOT depend on our own orphaned header ever being delivered by peers —
+/// we compare the *winner* at our recorded height against our block hash.
+
+#include <core/uint256.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <optional>
+
+namespace dash::coin::block_confirm {
+
+// Minimum confirmations (best-chain depth) before a found block is flipped to
+// "confirmed". 1 == "accepted into the best chain" (block-acceptance, NOT
+// coinbase maturity), matching the LTC embedded verifier's semantics.
+inline constexpr uint32_t kDefaultConfirmDepth = 1;
+
+/// Resolve a found block's dashboard status from a best-chain-at-height view.
+///
+///   best_hash_at_height(h): the hash currently on the BEST chain at height h,
+///                           or std::nullopt if the chain has not yet reached
+///                           height h (or does not index it).
+///   tip_height:   current best-chain tip height.
+///   found_hash:   the block we broadcast and are tracking.
+///   found_height: the height that block was mined at (from our found-block
+///                 record — authoritative even when the block was orphaned and
+///                 its header never entered our chain).
+///   confirm_depth: min best-chain depth before declaring confirmed (>=1).
+///
+/// Returns  >0  → confirmed, value == confirmation count (tip - height + 1)
+///          <0  → orphaned (a different block occupies found_height)
+///           0  → pending (chain not deep enough yet, or on-chain but shallow)
+inline int resolve_status(
+    const std::function<std::optional<uint256>(uint32_t)>& best_hash_at_height,
+    uint32_t tip_height,
+    const uint256& found_hash,
+    uint32_t found_height,
+    uint32_t confirm_depth = kDefaultConfirmDepth)
+{
+    if (confirm_depth < 1) confirm_depth = 1;
+
+    auto winner = best_hash_at_height(found_height);
+    if (!winner.has_value())
+        return 0;                       // chain has not reached this height → pending
+
+    if (*winner != found_hash)
+        return -1;                      // a different block won this height → orphaned
+
+    // Our block IS the best-chain block at found_height.
+    if (tip_height < found_height)
+        return 0;                       // inconsistent view (race) → pending
+
+    uint32_t confs = tip_height - found_height + 1;
+    if (confs < confirm_depth)
+        return 0;                       // on chain but not buried enough yet → pending
+
+    if (confs > static_cast<uint32_t>(std::numeric_limits<int>::max()))
+        confs = static_cast<uint32_t>(std::numeric_limits<int>::max());
+    return static_cast<int>(confs);
+}
+
+}  // namespace dash::coin::block_confirm

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -327,7 +327,14 @@ if (BUILD_TESTING AND GTest_FOUND)
     # same reason as the second: a standalone target would need a build.yml
     # --target edit and would trip CI's NOT_BUILT sentinel until it had one
     # (#769/#883/#893).
-    add_executable(test_dash_node test_dash_node.cpp test_dash_dashboard_found_block.cpp test_dash_addrme.cpp)
+    # test_dash_block_confirm_lane.cpp: the post-broadcast found-block
+    # confirmation / orphan lane (daemonless resolve_status verdict + the
+    # MiningInterface pending→confirmed / pending→orphaned status flip). FOLDED
+    # in as another TU for the same reason as the found-block TU above — a
+    # standalone target would need a build.yml --target edit and trip CI's
+    # NOT_BUILT sentinel until it had one. Needs exactly this link set (core
+    # MiningInterface; the resolver is header-only).
+    add_executable(test_dash_node test_dash_node.cpp test_dash_dashboard_found_block.cpp test_dash_addrme.cpp test_dash_block_confirm_lane.cpp)
     target_link_libraries(test_dash_node PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core

--- a/test/test_dash_block_confirm_lane.cpp
+++ b/test/test_dash_block_confirm_lane.cpp
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// DASH post-broadcast found-block confirmation / orphan lane.
+//
+// THE GAP (on master). DASH wired NONE of the confirmation seam —
+// main_dash.cpp calls neither set_block_verify_fn nor
+// schedule_block_verification (LTC wires both). So a DASH found block sat
+// "pending" on the dashboard forever and orphans (e.g. hotel block 2508008)
+// were discovered by humans, not the board. NoVerifierLeavesPending below is
+// the master baseline: with no verifier armed, a recorded block never leaves
+// pending no matter how many verification passes run.
+//
+// THE FIX. main_dash arms set_block_verify_fn with the daemonless verdict
+// dash::coin::block_confirm::resolve_status (embedded X11+DGW header chain:
+// "which hash won height h?" vs our recorded block), plus a dashd
+// getblockheader fallback, and calls schedule_block_verification on both
+// found-block record paths. These tests exercise:
+//   1. resolve_status — the pure daemonless verdict (confirmed / orphaned /
+//      pending), including a reorg that flips a competitor back to our block.
+//   2. The MiningInterface status flip driven by that exact resolver through
+//      the REAL verify_found_block transition code (via the synchronous
+//      run_block_verification_now seam) — pending→confirmed, pending→orphaned.
+//
+// TELEMETRY ONLY. Nothing here touches submit / mint / target / payout.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/block_confirm.hpp>
+#include <core/web_server.hpp>
+#include <core/uint256.hpp>
+#include <core/address_validator.hpp>   // Blockchain
+
+#include <cstdint>
+#include <limits>
+#include <map>
+#include <optional>
+#include <string>
+
+namespace {
+
+// Distinct, deterministic block identities (SetHex like the sibling TU).
+uint256 blk_hash(unsigned char b)
+{
+    static const char* digits = "0123456789abcdef";
+    std::string s = "22";
+    s += digits[b >> 4];
+    s += digits[b & 0x0f];
+    s += std::string(64 - s.size(), '0');
+    uint256 h;
+    h.SetHex(s);
+    return h;
+}
+
+constexpr uint32_t kHeight   = 2508008;      // the real hotel orphan height
+constexpr uint32_t kTime     = 1753000000;
+constexpr uint64_t kSubsidy  = 155000000;
+
+// A fake best-chain view: hash on the best chain at each height, plus a tip.
+struct FakeChain {
+    std::map<uint32_t, uint256> best;   // height -> winning hash
+    uint32_t tip_height{0};
+
+    std::optional<uint256> winner_at(uint32_t h) const {
+        auto it = best.find(h);
+        if (it == best.end()) return std::nullopt;
+        return it->second;
+    }
+};
+
+// ── 1. Pure daemonless verdict ──────────────────────────────────────────────
+
+TEST(DashBlockConfirmLane, PendingWhenChainHasNotReachedHeight)
+{
+    FakeChain c;                         // empty — chain has not reached kHeight
+    c.tip_height = kHeight - 3;
+    const uint256 ours = blk_hash(0x01);
+    EXPECT_EQ(0, dash::coin::block_confirm::resolve_status(
+                     [&](uint32_t h){ return c.winner_at(h); },
+                     c.tip_height, ours, kHeight));
+}
+
+TEST(DashBlockConfirmLane, ConfirmedWhenOnBestChainAtDepth)
+{
+    FakeChain c;
+    const uint256 ours = blk_hash(0x01);
+    c.best[kHeight] = ours;              // our block won its height
+    c.tip_height    = kHeight + 4;       // 5 blocks deep
+    int v = dash::coin::block_confirm::resolve_status(
+                [&](uint32_t h){ return c.winner_at(h); },
+                c.tip_height, ours, kHeight);
+    EXPECT_GT(v, 0);
+    EXPECT_EQ(5, v);                     // tip - height + 1
+}
+
+TEST(DashBlockConfirmLane, OrphanedWhenCompetitorWonHeight)
+{
+    FakeChain c;
+    const uint256 ours       = blk_hash(0x01);
+    const uint256 competitor = blk_hash(0x02);
+    c.best[kHeight] = competitor;        // a DIFFERENT block occupies our height
+    c.tip_height    = kHeight + 2;
+    EXPECT_EQ(-1, dash::coin::block_confirm::resolve_status(
+                      [&](uint32_t h){ return c.winner_at(h); },
+                      c.tip_height, ours, kHeight));
+}
+
+TEST(DashBlockConfirmLane, HigherConfirmDepthHoldsPendingUntilBuried)
+{
+    FakeChain c;
+    const uint256 ours = blk_hash(0x01);
+    c.best[kHeight] = ours;
+    c.tip_height    = kHeight;           // only 1 confirmation
+    // depth 3 required → still pending at 1 conf
+    EXPECT_EQ(0, dash::coin::block_confirm::resolve_status(
+                     [&](uint32_t h){ return c.winner_at(h); },
+                     c.tip_height, ours, kHeight, /*confirm_depth=*/3));
+    c.tip_height = kHeight + 2;          // now 3 confirmations
+    EXPECT_EQ(3, dash::coin::block_confirm::resolve_status(
+                     [&](uint32_t h){ return c.winner_at(h); },
+                     c.tip_height, ours, kHeight, /*confirm_depth=*/3));
+}
+
+TEST(DashBlockConfirmLane, ReorgRestoresOurBlockToConfirmed)
+{
+    FakeChain c;
+    const uint256 ours       = blk_hash(0x01);
+    const uint256 competitor = blk_hash(0x02);
+    // First a competitor is seen at our height → orphaned verdict.
+    c.best[kHeight] = competitor;
+    c.tip_height    = kHeight;
+    EXPECT_EQ(-1, dash::coin::block_confirm::resolve_status(
+                      [&](uint32_t h){ return c.winner_at(h); },
+                      c.tip_height, ours, kHeight));
+    // A deeper reorg puts OUR block back on the best chain.
+    c.best[kHeight] = ours;
+    c.tip_height    = kHeight + 1;
+    EXPECT_GT(dash::coin::block_confirm::resolve_status(
+                  [&](uint32_t h){ return c.winner_at(h); },
+                  c.tip_height, ours, kHeight), 0);
+}
+
+// ── 2. MiningInterface status flip through the REAL transition code ─────────
+
+// Wire a verify fn that resolves against a FakeChain using the SAME resolver
+// main_dash arms, then flip status synchronously via run_block_verification_now.
+static void arm_verifier(core::MiningInterface& mi, const FakeChain& c)
+{
+    mi.set_block_verify_fn([&mi, &c](const std::string& hash_hex) -> int {
+        uint256 h; h.SetHex(hash_hex);
+        uint32_t found_height = 0; bool have = false;
+        for (const auto& b : mi.get_found_blocks()) {
+            if (b.hash == hash_hex) {
+                found_height = static_cast<uint32_t>(b.height);
+                have = true; break;
+            }
+        }
+        if (!have) return 0;
+        return dash::coin::block_confirm::resolve_status(
+            [&c](uint32_t hh){ return c.winner_at(hh); },
+            c.tip_height, h, found_height);
+    });
+}
+
+TEST(DashBlockConfirmLane, NoVerifierLeavesPending)
+{
+    // MASTER BASELINE: DASH main never armed a verifier, so a recorded found
+    // block stays pending across every verification pass.
+    core::MiningInterface mi(/*testnet=*/false, nullptr, Blockchain::DASH);
+    const uint256 ours = blk_hash(0x01);
+    mi.record_found_block(kHeight, ours, kTime, "DASH", "Xminer",
+                          ours.GetHex(), 1.0, 0.0, 3.0, kSubsidy);
+
+    EXPECT_EQ(0, mi.run_block_verification_now(ours.GetHex()));
+    ASSERT_EQ(mi.get_found_blocks().size(), 1u);
+    EXPECT_EQ(mi.get_found_blocks()[0].status,
+              core::MiningInterface::BlockStatus::pending)
+        << "with no verifier a DASH found block must stay pending (the defect)";
+}
+
+TEST(DashBlockConfirmLane, FoundBlockFlipsPendingToConfirmed)
+{
+    core::MiningInterface mi(/*testnet=*/false, nullptr, Blockchain::DASH);
+    const uint256 ours = blk_hash(0x01);
+    mi.record_found_block(kHeight, ours, kTime, "DASH", "Xminer",
+                          ours.GetHex(), 1.0, 0.0, 3.0, kSubsidy);
+    ASSERT_EQ(mi.get_found_blocks()[0].status,
+              core::MiningInterface::BlockStatus::pending);
+
+    FakeChain c;
+    c.best[kHeight] = ours;              // our block is on the best chain
+    c.tip_height    = kHeight + 5;
+    arm_verifier(mi, c);
+
+    int v = mi.run_block_verification_now(ours.GetHex());
+    EXPECT_GT(v, 0);
+    EXPECT_EQ(mi.get_found_blocks()[0].status,
+              core::MiningInterface::BlockStatus::confirmed);
+    EXPECT_EQ(mi.get_found_blocks()[0].confirmations, 6u);   // tip - h + 1
+}
+
+TEST(DashBlockConfirmLane, FoundBlockFlipsPendingToOrphaned)
+{
+    core::MiningInterface mi(/*testnet=*/false, nullptr, Blockchain::DASH);
+    const uint256 ours       = blk_hash(0x01);
+    const uint256 competitor = blk_hash(0x02);
+    mi.record_found_block(kHeight, ours, kTime, "DASH", "Xminer",
+                          ours.GetHex(), 1.0, 0.0, 3.0, kSubsidy);
+    ASSERT_EQ(mi.get_found_blocks()[0].status,
+              core::MiningInterface::BlockStatus::pending);
+
+    FakeChain c;
+    c.best[kHeight] = competitor;        // a different block won our height
+    c.tip_height    = kHeight + 2;
+    arm_verifier(mi, c);
+
+    int v = mi.run_block_verification_now(ours.GetHex());
+    EXPECT_LT(v, 0);
+    EXPECT_EQ(mi.get_found_blocks()[0].status,
+              core::MiningInterface::BlockStatus::orphaned)
+        << "a DASH block replaced at its height must flip to orphaned, not "
+           "linger pending as on master";
+}
+
+TEST(DashBlockConfirmLane, UnknownHashReportsSentinel)
+{
+    core::MiningInterface mi(/*testnet=*/false, nullptr, Blockchain::DASH);
+    EXPECT_EQ(std::numeric_limits<int>::min(),
+              mi.run_block_verification_now(blk_hash(0x09).GetHex()));
+}
+
+}  // namespace


### PR DESCRIPTION
## What & why

DASH found blocks stayed **\"pending\" on the dashboard forever**, and orphans (e.g. hotel block 2508008) were discovered by humans, not the board. Root cause: `main_dash.cpp` wired **none** of the post-broadcast confirmation seam — `grep set_block_verify_fn|add_chain_verify_fn|schedule_block_verification main_dash.cpp` returns 0 — while LTC wires both (`main_ltc.cpp:2105`/`:3013`/`:4258`/`:6315`). This PR arms that lane for DASH.

Premise re-verified on base `edcc2762`: DASH had zero calls to the three functions; the two found-block record paths are `main_dash.cpp` peer-found feed (the `make_on_block_found` handler) and the local solo win (`set_on_found_block_fn`).

## Scope: telemetry only

Runs **strictly after submission**; touches no submit / mint / target / payout path. The pre-broadcast payee guard (`work_source.cpp`) remains the sole consensus gate. A wrong verdict here can only mislabel a dashboard row, never a broadcast.

## Change

- **New header-only resolver** `dash::coin::block_confirm::resolve_status` (`src/impl/dash/coin/block_confirm.hpp`) — the daemonless confirm/orphan verdict. Given \"which hash won height h\", the tip height, and our recorded block, it returns `>0` confirmations (confirmed), `<0` orphaned, `0` pending.
- **Daemonless-first wiring** in `main_dash.cpp`: `set_block_verify_fn` resolves against the embedded X11+DGW `HeaderChain` (`get_header_by_height()` reflects the current best branch, rebuilt from the tip via `prev_hash` on every reorg), so **orphan detection needs no dashd** and does not depend on our own orphaned header ever being relayed to us — it compares the *winner* at our recorded height against our hash. `dashd getblockheader` (confirmations `== -1` ⇒ orphaned) is used **only** on the fallback arm when there is no embedded chain. The block height comes from our own found-block record — authoritative even for an orphan.
- `schedule_block_verification` called on **both** DASH found-block record paths so the poller arms at the standard cadence, exactly as LTC does.
- `MiningInterface::run_block_verification_now` — a small, chain-neutral synchronous test/introspection seam driving the real `verify_found_block` transition (the async `schedule_block_verification` remains the live driver).

## Daemonless resolution — confirmed possible, no new protocol work

The embedded header chain already answers \"is this hash on the best chain at depth N\" via `get_header_by_height`, so no `dash-orphan-flag-daemonless-todo` is needed. The dashd arm is a pure fallback.

## Tests

`test/test_dash_block_confirm_lane.cpp` (folded into the allowlisted `test_dash_node` target; `tools/ci/check_test_target_allowlist.py` passes):

- `resolve_status` confirmed / orphaned / pending, depth gating, and a reorg that restores our block to confirmed.
- MiningInterface flips **pending→confirmed** and **pending→orphaned** through the real transition code (logs emit the actual `BLOCK CONFIRMED` / `BLOCK ORPHANED` lines).
- `NoVerifierLeavesPending` pins the **master baseline**: with no verifier armed a DASH found block stays pending forever (the defect).

Locally: `test_dash_node` builds and all 9 `DashBlockConfirmLane.*` pass; the `c2pool-dash` binary (main_dash.cpp) builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxfnL8QaD6DHtwD5UgXHwn