### PR TITLE
dgb: save graph_db stat log on clean shutdown (D-DGB.LIVEADAPTER leg 2, LTC-parity site 3/3)

### DIFF
--- a/src/c2pool/main_dgb.cpp
+++ b/src/c2pool/main_dgb.cpp
@@ -1398,6 +1398,18 @@ int run_node(const core::CoinParams& params, bool testnet,
 
     ioc.run();
 
+    // LTC-parity site 3/3 (the TRUE third, missing until now): save the stat
+    // log on clean shutdown. load-on-start (L1367) + periodic-100s (L1379) only
+    // persist at tick boundaries, so without this every restart drops whatever
+    // accumulated since the last 100s tick. Mirrors main_ltc.cpp:7456-7457
+    // ("Save stats on shutdown"). web_server (and thus its MiningInterface)
+    // is still alive here — the reset()s below run after. Display-only stat
+    // log; p2pool-merged-v36 surface: NONE.
+    if (web_server) {
+        if (auto* mi = web_server->get_mining_interface())
+            mi->save_stat_log();
+    }
+
     // Tear the acceptor + sessions down while the work source and the coin
     // objects it references (header_chain / mempool / coin_node) are still
     // alive — explicit reset keeps destruction order safe (stratum_server was


### PR DESCRIPTION
## What
Adds the missing **save-on-shutdown** stat-log call site in `src/c2pool/main_dgb.cpp`, closing D-DGB.LIVEADAPTER leg 2.

DGB stood up two of LTC's three graph_db persistence sites:
- load-on-start (main_dgb.cpp:1367)
- periodic save every 100s (main_dgb.cpp:1379)

but omitted the third — save-on-shutdown — which LTC has at `main_ltc.cpp:7456-7457`. Without it, a clean restart drops everything accumulated in the graph_db stat log since the last 100s tick. The leg-2 restart-persist acceptance only held when a periodic tick happened to land before shutdown.

## Fix
One call site after `ioc.run()` returns, while `web_server` (and its `MiningInterface`) is still alive, before the teardown `reset()`s. Null-guarded exactly as the two existing sites.

## Isolation / compat
- `src/c2pool/main_dgb.cpp` only — zero src/core, zero cross-coin.
- p2pool-merged-v36 surface: NONE (operator dashboard stat log, not share/PPLNS/coinbase bytes).

## Verification
Mirrors verified BTC/LTC shape. Restart-persist acceptance re-run pending build; will attach evidence.

No self-merge.