### PR TITLE
ci(v37-dev): add v37-dev to push allowlists so merged tip gets the build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master, btc-embedded, dash-spv-embedded, dgb/**, windows-build, service-update]
+    branches: [master, btc-embedded, dash-spv-embedded, dgb/**, windows-build, service-update, v37-dev]
     tags: ['v*']
   pull_request:
     branches: [master, btc-embedded, dash-spv-embedded, dgb/**, v37-dev]

--- a/.github/workflows/coin-matrix.yml
+++ b/.github/workflows/coin-matrix.yml
@@ -13,7 +13,7 @@ name: Coin matrix
 
 on:
   push:
-    branches: [master, btc-embedded, dash-spv-embedded, dgb/pool-pillars-port, windows-build, service-update]
+    branches: [master, btc-embedded, dash-spv-embedded, dgb/pool-pillars-port, windows-build, service-update, v37-dev]
   pull_request:
     branches: [master, btc-embedded, dash-spv-embedded, dgb/slice4-skeleton, dgb/pool-pillars-port, v37-dev]
 


### PR DESCRIPTION
pull_request allowlists (#1070) render the matrix on v37-dev PRs, but the push: branch lists in build.yml + coin-matrix.yml still omit v37-dev. The #1068 and #1070 merges therefore validated only CodeQL on the post-merge tip -- no build/coin-matrix run confirmed the merged v37-dev state. This closes that post-merge validation gap. Held at merge gate for operator push-approval.