### PR TITLE
btc: save graph_db stat log on clean shutdown (LTC-parity site 3/3)

### DIFF
--- a/src/c2pool/main_btc.cpp
+++ b/src/c2pool/main_btc.cpp
@@ -1777,6 +1777,18 @@ int main(int argc, char* argv[])
         }
     }
 
+    // LTC-parity site 3/3 (the TRUE third, missing until now): save the stat
+    // log on clean shutdown. load-on-start (:1722) + periodic-100s (:1735) only
+    // persist at tick boundaries, so without this every restart drops whatever
+    // accumulated since the last 100s tick. Mirrors main_ltc.cpp:7456-7457
+    // ("Save stats on shutdown"). web_server (and thus its MiningInterface) is
+    // still alive here — the reset()s below run after. Display-only stat log;
+    // p2pool-merged-v36 surface: NONE.
+    if (web_server) {
+        if (auto* mi = web_server->get_mining_interface())
+            mi->save_stat_log();
+    }
+
     // ── Graceful shutdown — explicit teardown order ──────────────────────
     //
     // ioc.run() returned because the signal handler called ioc.stop(). Now


### PR DESCRIPTION
## What

`src/c2pool/main_btc.cpp` stands up the graph_db stat-log with only 2 of LTC's 3 persistence sites:

- **Site 1 — load-on-start:** `main_btc.cpp:1722` `mi->load_stat_log();`
- **Site 2 — periodic-100s:** `main_btc.cpp:1735` `mi->save_stat_log();`
- **Site 3 — save-on-shutdown:** **absent** (LTC has it at `main_ltc.cpp:7456-7457`).

Effect: everything accumulated in the final sub-100s window is dropped on every clean restart. The dashboard series only survives when a periodic tick happens to land before shutdown. Same 2/3 gap DGB fixed in #1097.

## Change

One null-guarded call added after the run loop returns (the `while (!shutdown_initiated)` run_for-slice loop), while `web_server` and its `MiningInterface` are still alive, before the graceful-teardown resets:

```cpp
if (web_server) {
    if (auto* mi = web_server->get_mining_interface())
        mi->save_stat_log();
}
```

Mirrors #1097 / dgb `822eaa347` exactly, adapted to BTC line numbers.

## Isolation

`src/c2pool/main_btc.cpp` only — BTC's own entrypoint. Zero `src/core`, zero cross-coin (no `main_ltc.cpp` / `main_dgb.cpp` touched). p2pool-merged-v36 surface: NONE (operator dashboard stat log, not share/PPLNS/coinbase bytes).

## Evidence

_(live restart-persist proof captured below — tick lands, clean restart, series survives the shutdown boundary)_
