### PR TITLE
web(#919): per-node local_hashps series in /local_stats, honest-absent when cold

### DIFF
--- a/src/core/test/CMakeLists.txt
+++ b/src/core/test/CMakeLists.txt
@@ -54,7 +54,7 @@ if (BUILD_TESTING AND (GTest_FOUND OR GTEST_FOUND))
     # carries a source KAT pinning the is_wire_advertisable() guard into all ten
     # per-coin getaddrs handlers. Same reasoning as above: FOLDED into the
     # EXISTING allowlisted core_test target, never a new add_executable.
-    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp core_merkle_branches_test.cpp version_gate_test.cpp filesystem_test.cpp web_server_submitblock_test.cpp web_server_current_payouts_test.cpp known_txs_eviction_test.cpp tx_advertiser_test.cpp socket_write_queue_test.cpp known_txs_backing_test.cpp random_choice_guard_test.cpp p2p_message_stats_test.cpp netaddress_resolution_test.cpp)
+    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp core_merkle_branches_test.cpp version_gate_test.cpp filesystem_test.cpp web_server_submitblock_test.cpp web_server_current_payouts_test.cpp web_server_local_hashps_test.cpp known_txs_eviction_test.cpp tx_advertiser_test.cpp socket_write_queue_test.cpp known_txs_backing_test.cpp random_choice_guard_test.cpp p2p_message_stats_test.cpp netaddress_resolution_test.cpp)
     target_compile_definitions(core_test PRIVATE C2POOL_SRC_ROOT="${CMAKE_SOURCE_DIR}/src")
     target_link_libraries(core_test PRIVATE GTest::gtest_main core c2pool_merged_mining GTest::gtest)
     target_link_libraries(core_test PRIVATE c2pool_payout c2pool_hashrate ltc_coin)  # OBJECT-lib SCC direct-naming (#22/#39)

--- a/src/core/test/web_server_local_hashps_test.cpp
+++ b/src/core/test/web_server_local_hashps_test.cpp
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#include <gtest/gtest.h>
+
+#include <nlohmann/json.hpp>
+
+#include <core/web_server.hpp>
+
+// ---------------------------------------------------------------------------
+// KATs for core::MiningInterface::rest_local_stats -> local_hashps (#919).
+//
+// The /local_stats endpoint surfaces this node's OWN work rate as a series a
+// local-hashrate graph polls over time. The rate is read from the real stratum
+// work-rate counter (set_stratum_hashrate_fn) -- the same live per-node source
+// the node-fee share at web_server.cpp trusts as local_hr -- never the empty
+// m_node stub that gave us the founding poolhashps=0 lie.
+//
+// The honesty rule these lock, in both directions:
+//   * COLD (no work-rate source wired): local_hashps is null -- an honest
+//     "unknown", NOT a flat 0 that would falsely claim this node mines nothing.
+//   * LIVE (source wired): local_hashps is the counter's real value. A wired
+//     source that reports 0.0 is a TRUE reading and stays 0, not null.
+//
+// Both FAIL WITHOUT THE FIX: before it, rest_local_stats emits no local_hashps
+// key at all, so the cold assertion (key present AND null) and the live
+// assertion (key present AND == counter) both fail on the missing field.
+// ---------------------------------------------------------------------------
+
+// COLD: no stratum work-rate source wired -> honest-absent null, never 0.
+TEST(LocalHashpsSeam, ColdCounterIsHonestNullNotZero) {
+    core::MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                             c2pool::address::Blockchain::LITECOIN);
+
+    auto r = mi.rest_local_stats();
+    ASSERT_TRUE(r.is_object());
+    ASSERT_TRUE(r.contains("local_hashps"))
+        << "local_hashps must be present so a cold node reads as unknown, not 0";
+    EXPECT_TRUE(r["local_hashps"].is_null())
+        << "cold local work-rate counter must be honest-absent (null), not flat 0";
+}
+
+// LIVE: wired counter surfaces its real value verbatim.
+TEST(LocalHashpsSeam, LiveCounterSurfacesRealValue) {
+    core::MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                             c2pool::address::Blockchain::LITECOIN);
+
+    const double kLocalHs = 1234567.0;  // ~1.23 MH/s of local stratum work
+    mi.set_stratum_hashrate_fn([kLocalHs]() { return kLocalHs; });
+
+    auto r = mi.rest_local_stats();
+    ASSERT_TRUE(r.is_object());
+    ASSERT_TRUE(r.contains("local_hashps"));
+    ASSERT_TRUE(r["local_hashps"].is_number());
+    EXPECT_DOUBLE_EQ(r["local_hashps"].get<double>(), kLocalHs)
+        << "live local_hashps must equal the real stratum work-rate counter";
+}

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -3695,6 +3695,21 @@ nlohmann::json MiningInterface::rest_local_stats()
     result["miner_hash_rates"] = miner_rates;
     result["miner_dead_hash_rates"] = miner_dead;
 
+    // #919 per-node LOCAL hashrate (local_hashps) -- the series a local-hashrate
+    // graph polls over time. This is THIS node's own work rate, read from the
+    // real stratum work-rate counter (m_stratum_hashrate_fn, the same live
+    // per-node source the node-fee "local_hr" leg below trusts), NOT the empty
+    // m_node stub that produced the founding poolhashps=0 lie. Distinct from
+    // poolhashps, which is the pool-wide attempts/s the "Pool: X GH/s" print
+    // reports. Honest-absent: with no work-rate source wired the counter is
+    // COLD and we emit null, never a flat 0 that would falsely claim this node
+    // mines nothing. A wired source reporting 0.0 is a TRUE reading (no active
+    // local miners) and is surfaced as 0, not null.
+    if (m_stratum_hashrate_fn)
+        result["local_hashps"] = m_stratum_hashrate_fn();
+    else
+        result["local_hashps"] = nullptr;
+
     // shares — {total, orphan, dead}
     // Sharechain stats now use O(log n) StatsSkipList — no caching needed.
     nlohmann::json cached_sc;


### PR DESCRIPTION
## #919 — per-node local hashrate series in /local_stats (honest-absent)

### Problem
`/api/local_stats` exposed no per-node **local** hashrate. The only hashrate field was `poolhashps` (pool-wide attempts/s — the "Pool: X GH/s" figure). A local-hashrate graph therefore had no real series of *this node's own* work rate to poll.

### Fix (additive)
Add `local_hashps` to `MiningInterface::rest_local_stats` (`src/core/web_server.cpp`), sourced from the real stratum work-rate counter `m_stratum_hashrate_fn` — the same live per-node source the node-fee `local_hr` leg already trusts, **not** the empty `m_node` stub that produced the founding `poolhashps=0` lie.

**Honest-absent, not flat zero:** with no work-rate source wired the counter is **cold** and the field is `null` — an honest "unknown", never a `0` that would falsely claim the node mines nothing. A wired source reporting `0.0` is a *true* reading (no active local miners) and stays `0`.

Every existing field is byte-identical; only the new key is added.

### Source note for the merge gate
`local_hashps` is this node's **local** work rate (stratum counter), deliberately distinct from `poolhashps` (pool-wide). If the intent was instead to mirror the pool counter per-node, say so and I will repoint the source — the seam is one line.

### Tests
`src/core/test/web_server_local_hashps_test.cpp` — 2 additive KATs, folded into the existing `core_test` target:
- `ColdCounterIsHonestNullNotZero` — no source wired → `local_hashps` present and `null` (not `0`).
- `LiveCounterSurfacesRealValue` — source wired → `local_hashps` equals the real counter value.

**Both FAIL without the source change** (key absent → `contains("local_hashps")` is false), verified by reverting only `web_server.cpp` and rebuilding. With the fix: `core_test` **145/145 green**.
