### PR TITLE
dash(coin-p2p): fetch tip block body from the ANNOUNCING peer (warm-node embedded serve fix)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -3930,7 +3930,13 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         coin_feed_subs.push_back(
             coin_state.new_block.subscribe(
                 [cp = coin_p2p.get(), hc = header_chain.get()](const uint256& hash) {
-                    cp->send_getheaders(70230, hc->get_locator(), uint256::ZERO);
+                    // Route BOTH the header pull and the body pull to the peer
+                    // that ANNOUNCED this block (#1082 pool: announcer != the
+                    // primary). Sending them to an arbitrary primary that is
+                    // behind/wedged is why a WARM node's tip-body never folded
+                    // and body-first serve-tip stayed at have_tip=0.
+                    cp->send_getheaders_from_block_source(
+                        hash, 70230, hc->get_locator(), uint256::ZERO);
                     // TRACKED: this is the tip-body pull, the one request the
                     // serve tip now waits on (body-first). The lost-body
                     // watchdog re-requests it from a rotated peer after 10 s

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -644,6 +644,18 @@ private:
     uint64_t m_body_rerequests_total{0};
     uint64_t m_body_rerequests_exhausted{0};
 
+    // ── tip-body announcer routing (#1082 pool + #1094 body-first) ───────
+    // A block `inv` names a peer that HOLDS the block. The tip-body getdata
+    // (and the getheaders that must precede its connect) is fetched from THAT
+    // peer — not from an arbitrary primary that, on a WARM node, may be behind
+    // or wedged and silently never delivers (no notfound, so the watchdog just
+    // exhausts). This mirrors the qfcommit/clsig pull, which already asks the
+    // announcer. Bounded FIFO; the announcer is resolved LIVE (never a cached
+    // pointer), so pool churn just falls back to the primary.
+    struct BlockAnnouncer { uint256 hash; std::string key; };
+    std::vector<BlockAnnouncer> m_block_announcers;
+    static constexpr std::size_t ANNOUNCER_CAP = 64;
+
     std::unique_ptr<core::Timer> m_reconnect_timer;
     // ONE repeating tick for the whole pool (liveness, handshake deadlines,
     // dial-slot reclamation, status log). Per-peer STATE stays per-peer.
@@ -1112,6 +1124,23 @@ public:
         m_primary->write(msg);
     }
 
+    /// getheaders targeted at the peer that announced `block_hash`. The
+    /// tip-follow header pull must reach the peer that HAS the new tip — the
+    /// same #1082 announcer!=primary hazard as the body pull: routing it to an
+    /// arbitrary (possibly behind/wedged) primary is exactly why the warm-node
+    /// header tip could stall while a neighbour was announcing past it. Falls
+    /// back to the primary via block_source().
+    void send_getheaders_from_block_source(const uint256& block_hash,
+                                           uint32_t version,
+                                           const std::vector<uint256>& locator,
+                                           const uint256& stop)
+    {
+        PeerSession* p = block_source(block_hash);
+        if (!p) return;
+        auto msg = message_getheaders::make_raw(version, locator, stop);
+        p->write(msg);
+    }
+
     /// Send getaddr to request peer addresses (feeds set_addr_callback).
     ///
     /// BROADCAST, deliberately: an addr reply carries no per-peer matching
@@ -1142,12 +1171,16 @@ public:
     }
 
     /// Request a full block via plain MSG_BLOCK getdata (E2 pull seam).
+    /// Routed to the peer that ANNOUNCED this block (block_source), which holds
+    /// it by definition; falls back to the primary when the announcer is
+    /// unknown (bulk/historical legs) or has churned out.
     void request_block(const uint256& block_hash)
     {
-        if (!m_primary) return;
+        PeerSession* p = block_source(block_hash);
+        if (!p) return;
         auto msg = message_getdata::make_raw(
             {inventory_type(inventory_type::block, block_hash)});
-        m_primary->write(msg);
+        p->write(msg);
     }
 
     /// Request a full block AND arm the lost-body watchdog for it (tip-follow
@@ -1167,7 +1200,10 @@ public:
         pb.hash      = block_hash;
         pb.first_req = now;
         pb.last_req  = now;
-        pb.last_peer = m_primary ? m_primary->key : std::string{};
+        // The announcer just got the initial getdata; record it so the watchdog
+        // rotates AWAY from it (to a neighbour) if it does not answer in time.
+        PeerSession* src = block_source(block_hash);
+        pb.last_peer = src ? src->key : std::string{};
         m_pending_bodies.push_back(std::move(pb));
     }
 
@@ -1419,6 +1455,33 @@ private:
     {
         for (auto& p : m_pool) if (p->key == key) return p.get();
         return nullptr;
+    }
+
+    /// Record which peer announced a block, so its body/headers pull can be
+    /// routed back to it. Bounded FIFO (block invs arrive ~1 / 2.5 min).
+    void record_block_announcer(const uint256& hash, const std::string& key)
+    {
+        for (auto& a : m_block_announcers)
+            if (a.hash == hash) { a.key = key; return; }
+        if (m_block_announcers.size() >= ANNOUNCER_CAP)
+            m_block_announcers.erase(m_block_announcers.begin());
+        m_block_announcers.push_back(BlockAnnouncer{hash, key});
+    }
+
+    /// The peer to fetch a block from: the one that ANNOUNCED it (it holds it
+    /// by definition and its reply routes back to its own session), falling
+    /// back to the primary when the announcer is unknown or has since churned
+    /// out of the pool. Never returns a stale pointer — resolved live.
+    PeerSession* block_source(const uint256& hash)
+    {
+        for (auto& a : m_block_announcers)
+            if (a.hash == hash)
+            {
+                PeerSession* p = find_peer(a.key);
+                if (p && p->handshake.complete()) return p;
+                break;
+            }
+        return m_primary;
     }
 
     bool holds_key(const std::string& key) const
@@ -1769,10 +1832,17 @@ private:
             }
             // Rotate through the handshaked peers, preferring one we did not
             // just ask; a single-peer pool re-asks the same peer (still
-            // strictly better than the 600 s inv-TTL wait).
+            // strictly better than the 600 s inv-TTL wait). The ANNOUNCER goes
+            // first — it holds the block by definition — so a re-request tries
+            // it before any neighbour that may not have it yet (the fixed-
+            // subset-that-never-has-it rotation was the #1082 warm-node bug).
             std::vector<PeerSession*> cands;
+            if (PeerSession* src = block_source(pb.hash))
+                if (src->handshake.complete()) cands.push_back(src);
             for (auto& up : m_pool)
-                if (up->handshake.complete()) cands.push_back(up.get());
+                if (up->handshake.complete() &&
+                    (cands.empty() || up.get() != cands.front()))
+                    cands.push_back(up.get());
             if (cands.empty()) { ++it; continue; }   // retry when the pool refills
             PeerSession* target =
                 cands[static_cast<size_t>(pb.rerequests) % cands.size()];
@@ -2014,6 +2084,10 @@ private:
             }
             LOG_INFO << "[" << m_chain_label << "] block inv "
                      << inv.m_hash.GetHex().substr(0, 16) << "... from " << p->key;
+            // Remember WHO announced it: the body/headers pull the new_block
+            // subscriber fires next must be routed back to this peer, which
+            // holds the block, not to an arbitrary primary (block_source).
+            record_block_announcer(inv.m_hash, p->key);
             m_coin->new_block.happened(inv.m_hash);
         }
     }

--- a/test/test_dash_coin_p2p_pool.cpp
+++ b/test/test_dash_coin_p2p_pool.cpp
@@ -1015,4 +1015,47 @@ TEST(DashCoinP2PPool, body_arrival_disarms_the_watchdog)
     EXPECT_EQ(rig.client.body_rerequests_total(), 0u);
 }
 
+// ══════════════════════════════════════════════════════════════════════════
+// (H) TIP-BODY ROUTING — the body-fetch getdata goes to the peer that
+// ANNOUNCED the block, which holds it by definition, NOT to an arbitrary
+// primary. On a WARM node (pool of 8, announcer usually != primary) the block
+// body announced by peer B was fetched from primary A; when A was behind or
+// wedged it silently never delivered (no notfound), the watchdog rotated
+// through a fixed subset that also lacked the block, and body-first serve-tip
+// stayed at have_tip=0 forever — the embedded arm never served. The fresh
+// soak's sequential catch-up (getheaders->getdata to the primary it was
+// syncing from) never exercised the inv-driven announcer!=primary path, which
+// is why only the warm hotel node surfaced it.
+//
+// FAILS-ON-MASTER: request_block writes unconditionally to m_primary, so the
+// getdata lands on peer 1 (primary), never on the announcing peer 3.
+// ══════════════════════════════════════════════════════════════════════════
+
+TEST(DashCoinP2PPool, tip_body_getdata_targets_the_announcing_peer_not_the_primary)
+{
+    PoolRig rig;
+    for (int i = 1; i <= 3; ++i) rig.handshake(i);   // peer 1 handshakes first
+    ASSERT_TRUE(rig.session(1) && rig.session(1)->primary)
+        << "peer 1 must be the primary for this test to isolate the routing";
+
+    const uint256 h = hash_n(0xB0D9);
+
+    // Peer 3 — NOT the primary — announces the new block via inv.
+    rig.deliver(3, PoolRig::block_inv(h));
+
+    const uint64_t p1_before = rig.session(1)->msgs_sent;
+    const uint64_t p3_before = rig.session(3)->msgs_sent;
+
+    // The tip-follow body pull for that block (what the new_block subscriber
+    // fires in production).
+    rig.client.request_block_tracked(h);
+
+    EXPECT_EQ(rig.session(3)->msgs_sent, p3_before + 1)
+        << "the body getdata must go to the peer that ANNOUNCED the block "
+           "(it holds it by definition)";
+    EXPECT_EQ(rig.session(1)->msgs_sent, p1_before)
+        << "the body getdata must NOT be routed to an arbitrary primary that, "
+           "on a warm node, may be behind/wedged and never deliver";
+}
+
 } // namespace


### PR DESCRIPTION
## Warm-node embedded arm never serves — tip block BODY is fetched from the wrong peer

**Symptom (MEASURED on the hotel money node, edcc27624, `--embedded-oracle-shadow` — READ-ONLY, money safe on dashd-fallback throughout):** a node already at chain tip never completes a new block BODY over coin-P2P, so body-first serve-tip (#1094) never promotes (`have_tip=0`), every embedded template DECLINES `cause=tip-body-pending`, and the arm falls back to dashd. Peers announce blocks and `mnlistdiff`/`qfcommit`/ChainLock all flow fine — only the block BODY path is broken, and it gates the entire embedded arm.

### Root cause (source-confirmed at edcc27624 = the running hotel binary)

A block `inv` fires `new_block(hash)`; the `main_dash` subscriber issues `getheaders` + `request_block_tracked`. Both `request_block()` and `send_getheaders()` write **unconditionally to `m_primary`** — the announcing peer's identity (p2p_client.hpp block-inv handler) is discarded.

- Pre-#1082 (single-peer client), primary == the only peer == announcer, so "ask the primary" WAS "ask the announcer".
- After the #1082 8-peer pool, the announcer is usually **not** the primary. A block announced by peer B is fetched from primary A; when A is behind/wedged it silently never delivers (**MEASURED: no `block`, no `notfound`**), and the lost-body watchdog rotates through a fixed `cands[1..4]` subset (`rerequests % size`, bounded 4, structurally skipping the primary/announcer) that also lacks the just-announced block → `body-rerequest EXHAUSTED`. The peers that HELD the block are never asked.

Hotel evidence: block invs from `151.244.85.209` (the pool `primary=`) and `151.244.85.121` were EXHAUSTED during the single-primary warmup; once the pool filled and the primary happened to be responsive, `serve tip promoted` fired in <1s. `qfcommit`/`clsig` invs already `getdata` the **announcer** and work on the same node — the block path is the sole outlier.

The fresh soak never surfaced this: catch-up sync is sequential `getheaders`→`getdata` to the primary it is syncing from, which never exercises the inv-driven announcer!=primary path. This is precisely the warm-node bug the hotel test exists to catch.

### Fix (mirrors the existing qfcommit/clsig "ask the announcer" pattern)

- `record_block_announcer(hash, peer)` in the block-inv handler.
- `block_source(hash)` resolves the announcer **live** (never a cached pointer, so pool churn just falls back to the primary — this also closes the stale-target hazard).
- `request_block()` and a new `send_getheaders_from_block_source()` route the body + header pull to the announcer; the `new_block` subscriber uses the latter.
- The lost-body watchdog puts the announcer first in the rotation.

Bulk/historical legs (UTXO window, checkpoint lane) call `request_block` with no recorded announcer → fall back to `m_primary` exactly as before. Existing watchdog KATs (direct `request_block_tracked`, no inv) are unchanged.

### Test — FAILS ON MASTER

`DashCoinP2PPool.tip_body_getdata_targets_the_announcing_peer_not_the_primary`: a block announced by a non-primary peer must route its body `getdata` to the announcer, not the primary. On master `request_block` writes to `m_primary`, so the getdata lands on the primary and the assertion fails. Registered target `test_dash_p2p_node`; `check_test_target_allowlist.py` passes.

---
**Review only — do not merge, do not deploy.** Non-destructive, DASH lane only. The embedded arm's downstream pieces (bridge, quorum-ready, embedded serve) are already proven working on the warm hotel node, so this one routing fix is expected to unblock the whole arm.
