### PR TITLE
dash: fix two false-positive modes in LlmqTypeReconciler MINED-BUT-NOT-REQUIRED

### DIFF
--- a/src/impl/dash/coin/llmq_type_reconciler.hpp
+++ b/src/impl/dash/coin/llmq_type_reconciler.hpp
@@ -27,7 +27,7 @@
 ///
 /// SO THIS CHECK IS BUILT TO BE ABLE TO FAIL. A check that cannot produce a
 /// negative is not evidence. `reconcile()` returns a verdict PER required
-/// type, and two of the four verdicts are defects:
+/// type, and two of the five verdicts are defects:
 ///
 ///   * NeverObserved — we require it, the observation window covers a full
 ///     DKG cycle of that type, other required types WERE observed mined in
@@ -39,12 +39,14 @@
 ///     re-enables one) and is the half a one-directional check would miss:
 ///     the symptom there is bad-qc-missing on a block we thought was complete.
 ///
-/// and two are not:
+/// and three are not:
 ///
 ///   * Observed — required and seen. The healthy state.
 ///   * Unevaluated — not enough observation yet. The HONEST value for a
 ///     bootstrap that has not run long enough. It is never silently rendered
 ///     as "fine"; `defects()` excludes it and `verdict_name()` prints it.
+///   * StaleSightings — a non-required type that WAS sighted but whose every
+///     sighting has aged out of its retention window. See mode 2 below.
 ///
 /// FALSE-POSITIVE DISCIPLINE. Slandering a type would be as bad as missing
 /// one, so promoting silence to NeverObserved requires POSITIVE proof that the
@@ -69,6 +71,40 @@
 /// enabled type. One sample would therefore be enough — except during our own
 /// SML bootstrap, when the set is legitimately partial. `kMinObservations`
 /// plus the corroboration rule buy that distinction cheaply.
+///
+/// TWO FALSE-POSITIVE MODES THE FIRST SHIP CARRIED (both on the
+/// MINED-BUT-NOT-REQUIRED side; both fixed here, both regression-pinned in
+/// test_dash_dkg_commitments.cpp):
+///
+///   1. ZERO-WIDTH WINDOW. observe() runs once per template build, which is
+///      MANY times per block, so kMinObservations calls accumulate at a
+///      single tip height and the UnexpectedType branch — which gated only on
+///      the observation COUNT, never the window WIDTH — could indict before
+///      any real observation window existed. The required-side verdicts
+///      always demanded a full DKG cycle of span; the unexpected side now
+///      demands the same (its own cycle when the type is in the known params
+///      table, the largest known cycle otherwise).
+///
+///   2. SELF-REFRESHING STALE ENTRY (measured 2026-08-04, two independent
+///      soaks): `[LLMQ-TYPE-RECONCILE] type=1 MINED-BUT-NOT-REQUIRED` rang
+///      continuously with sightings == observations EXACTLY (1408==1408,
+///      895==895) while ZERO type-1 qfcommits existed in ~12 h of chain —
+///      impossible for real evidence, guaranteed for a bookkeeping loop.
+///      observe() stamped every entry PRESENT in the local active set with
+///      the CURRENT TIP height, never the quorum's own height, so one stale
+///      local entry (type 1 — a set mainnet cannot even mine, see
+///      reference above) re-registered as a fresh sighting at every sample,
+///      forever. An alarm that cannot decay carries no information. Now each
+///      entry is dated by ITS OWN height — mining_height when the [QC-MINED]
+///      scanner has seen the qfcommit tx, else the height at which WE first
+///      saw that (type, quorumHash) — and an entry older than its type's
+///      active-quorum retention window (dkgInterval ×
+///      signingActiveQuorumCount, the span the chain itself keeps a quorum
+///      active) is NOT a sighting. A stale entry therefore ages OUT, the
+///      per-type last-sighting height freezes, and once it trails the tip by
+///      more than one DKG cycle the verdict decays to StaleSightings — a
+///      named non-defect — and the alarm CLEARS. A genuinely mined type
+///      keeps producing in-retention entries, so its alarm never decays.
 
 #include <impl/dash/coin/dkg_commitments.hpp>
 #include <impl/dash/coin/quorum_manager.hpp>
@@ -78,6 +114,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace dash {
@@ -87,7 +124,14 @@ enum class LlmqTypeVerdict : uint8_t {
     Unevaluated = 0,   // insufficient observation — the honest "don't know"
     Observed,          // required AND seen in mined commitments
     NeverObserved,     // required, span sufficient, corroborated, ZERO sightings
-    UnexpectedType,    // mined on-chain but NOT in our required set
+    UnexpectedType,    // mined on-chain but NOT in our required set — LIVE
+                       // evidence: sighted within the last DKG cycle
+    StaleSightings,    // NOT required, WAS sighted, but every sighting has
+                       // aged out: no in-retention entry for over one DKG
+                       // cycle. Either a stale local cache entry that aged
+                       // out (the measured 2026-08-04 mode) or a type the
+                       // chain genuinely stopped mining. NOT a defect —
+                       // stale evidence must not keep an alarm ringing.
 };
 
 inline const char* llmq_type_verdict_name(LlmqTypeVerdict v)
@@ -97,6 +141,7 @@ inline const char* llmq_type_verdict_name(LlmqTypeVerdict v)
         case LlmqTypeVerdict::Observed:       return "observed";
         case LlmqTypeVerdict::NeverObserved:  return "REQUIRED-BUT-NEVER-OBSERVED";
         case LlmqTypeVerdict::UnexpectedType: return "MINED-BUT-NOT-REQUIRED";
+        case LlmqTypeVerdict::StaleSightings: return "stale-sightings-aged-out";
     }
     return "unevaluated";
 }
@@ -113,13 +158,32 @@ struct LlmqTypeFinding {
     uint8_t         llmq_type{0};
     LlmqTypeVerdict verdict{LlmqTypeVerdict::Unevaluated};
     bool            required{false};      // present in enabled_llmqs(net)
-    uint64_t        sightings{0};         // observations in which it appeared
+    /// Observations in which the type appeared via at least one entry INSIDE
+    /// its retention window. An entry whose quorum aged out of retention is
+    /// NOT a sighting — that is the whole difference between evidence and a
+    /// stale cache echo (see header, mode 2).
+    uint64_t        sightings{0};
     uint32_t        first_height{0};      // 0 == never observed anything
     uint32_t        last_height{0};
     uint32_t        span_heights{0};      // last - first
     uint32_t        dkg_interval{0};      // 0 for a non-required type
     /// Why a verdict stayed Unevaluated — never guessed, never blank.
     const char*     pending_reason{"n/a"};
+};
+
+/// One active-set entry as the reconciler consumes it. The quorum's OWN
+/// height is the load-bearing field: stamping sightings with the current tip
+/// instead of it is exactly the self-refreshing-stale-entry defect (header,
+/// mode 2).
+struct LlmqEntryObservation {
+    uint8_t  llmq_type{0};
+    /// Identity for first-seen dating. Null == no identity: the caller is
+    /// asserting the type is mined as of the observed tip (test feeds).
+    uint256  quorum_hash{};
+    /// The quorum's own mined height. 0 == unknown (mnlistdiff delivered the
+    /// entry but the [QC-MINED] scanner has not seen its qfcommit tx) — the
+    /// entry is then dated by when WE first saw this (type, quorumHash).
+    uint32_t mined_height{0};
 };
 
 class LlmqTypeReconciler {
@@ -135,21 +199,92 @@ public:
     /// ...and only if at least one OTHER required type was observed, proving
     /// the channel was live. See FALSE-POSITIVE DISCIPLINE above.
     static constexpr bool kCorroborationRequired = true;
+    /// DKG cycle assumed for a type ABSENT from the known params table (an
+    /// upstream-added type we have no row for): the largest known interval
+    /// (llmq_400_85, 576), so the unexpected-side span gate errs toward
+    /// waiting, never toward a premature indictment.
+    static constexpr uint32_t kFallbackDkgInterval = 576;
+    /// Retention assumed for a type absent from the table: the largest
+    /// dkgInterval x signingActiveQuorumCount product among known types
+    /// (llmq_60_75, 288 x 32). Overestimating retention only delays aging —
+    /// it can never fabricate a sighting.
+    static constexpr uint32_t kFallbackRetention = 9216;
+
+    /// Full params row for ANY type dashcore defines at this pin — including
+    /// types the runtime predicate disables (enabled_llmqs() would not have
+    /// them; the 2026-08-04 stale entry was exactly such a type).
+    static const LlmqParamsView* known_llmq_params(uint8_t t)
+    {
+        static const LlmqParamsView kAll[] = {
+            kLlmq50_60, kLlmq60_75, kLlmq400_60, kLlmq400_85,
+            kLlmq100_67, kLlmq25_67};
+        for (const auto& p : kAll)
+            if (p.type == t) return &p;
+        return nullptr;
+    }
+
+    static uint32_t dkg_interval_for(uint8_t t)
+    {
+        const auto* p = known_llmq_params(t);
+        return p ? p->dkg_interval : kFallbackDkgInterval;
+    }
+
+    /// The chain's own active-quorum retention window for a type: a mined
+    /// quorum stays in the active set for signingActiveQuorumCount DKG cycles
+    /// before newer quorums push it out. An entry older than this cannot be
+    /// a currently-active quorum — it is a stale local cache echo.
+    static uint32_t retention_for(uint8_t t)
+    {
+        const auto* p = known_llmq_params(t);
+        return p ? p->dkg_interval * p->signing_active_quorum_count
+                 : kFallbackRetention;
+    }
 
     explicit LlmqTypeReconciler(LlmqNetwork net) : m_net(net) {}
 
-    /// Record the set of llmqTypes present in MINED commitments as of `tip`.
-    /// Duplicate types within one call count once (this is a set observation,
-    /// not a count of quorums).
-    void observe(uint32_t tip_height, const std::vector<uint8_t>& mined_types)
+    /// Record the active-set entries as of `tip`. A type registers ONE
+    /// sighting per call (set semantics, not a quorum count) and ONLY via
+    /// entries whose own height is inside the type's retention window —
+    /// an entry the chain would already have aged out is a stale local echo,
+    /// not evidence (header, mode 2). Entry dating, most-truthful-first:
+    ///   1. mined_height when known (the [QC-MINED] scanner saw the qfcommit);
+    ///   2. else the tip at which WE first saw this (type, quorumHash) — a
+    ///      stale leftover dates from our first sample and can only age;
+    ///   3. else (no identity at all) the observed tip — the caller asserts
+    ///      freshness, which is what the types-only test feed means.
+    void observe(uint32_t tip_height,
+                 const std::vector<LlmqEntryObservation>& entries)
     {
         ++m_observations;
         if (m_first_height == 0 || tip_height < m_first_height)
             m_first_height = tip_height;
         if (tip_height > m_last_height) m_last_height = tip_height;
 
-        std::set<uint8_t> uniq(mined_types.begin(), mined_types.end());
-        for (uint8_t t : uniq) {
+        std::set<uint8_t> present;   // types with >=1 IN-RETENTION entry
+        std::map<std::pair<uint8_t, uint256>, uint32_t> first_seen_next;
+        for (const auto& e : entries) {
+            uint32_t own_h = e.mined_height;
+            if (own_h == 0 && !e.quorum_hash.IsNull()) {
+                const auto key = std::make_pair(e.llmq_type, e.quorum_hash);
+                auto it = m_first_seen.find(key);
+                own_h = (it != m_first_seen.end()) ? it->second : tip_height;
+                // Keep the record even for an aged-out entry — dropping it
+                // while the entry is still served would re-date the entry
+                // as fresh and resurrect the self-refresh loop cyclically.
+                first_seen_next.emplace(key, own_h);
+            }
+            if (own_h == 0) own_h = tip_height;   // no identity: asserted fresh
+            if (tip_height > own_h
+                && tip_height - own_h > retention_for(e.llmq_type))
+                continue;                          // aged out — NOT a sighting
+            present.insert(e.llmq_type);
+        }
+        // Records for entries no longer served are dropped here, bounding the
+        // map by the live active-set size. If such an entry ever reappears it
+        // is a NEW mnlistdiff insertion and fresh dating is the honest read.
+        m_first_seen.swap(first_seen_next);
+
+        for (uint8_t t : present) {
             auto& s = m_seen[t];
             ++s.sightings;
             if (s.first_height == 0 || tip_height < s.first_height)
@@ -158,15 +293,31 @@ public:
         }
     }
 
+    /// Types-only feed (tests, hand-built streams). No entry identity, so
+    /// each listed type is asserted mined as of `tip` — staleness cannot be
+    /// judged and is not: that is the CALLER'S claim to get right.
+    void observe(uint32_t tip_height, const std::vector<uint8_t>& mined_types)
+    {
+        std::vector<LlmqEntryObservation> es;
+        es.reserve(mined_types.size());
+        for (uint8_t t : mined_types)
+            es.push_back(LlmqEntryObservation{t, uint256{}, tip_height});
+        observe(tip_height, es);
+    }
+
     /// The production overload: the mnlistdiff-fed active set IS dashd's
     /// mined-and-active commitment set (dkg_commitments.hpp header note).
+    /// Each entry carries its own (type, quorumHash, mining_height) so the
+    /// core observe() can date it — passing types alone is what let a stale
+    /// entry re-register forever (header, mode 2).
     void observe(uint32_t tip_height, const QuorumManager& qmgr)
     {
-        std::vector<uint8_t> types;
-        types.reserve(qmgr.active_entries().size());
+        std::vector<LlmqEntryObservation> es;
+        es.reserve(qmgr.active_entries().size());
         for (const auto& e : qmgr.active_entries())
-            types.push_back(e.key.llmqType);
-        observe(tip_height, types);
+            es.push_back(LlmqEntryObservation{
+                e.key.llmqType, e.key.quorumHash, e.mining_height});
+        observe(tip_height, es);
     }
 
     uint32_t observations() const { return m_observations; }
@@ -231,6 +382,12 @@ public:
         }
 
         // The other direction: a type the chain mines that we do not require.
+        // The indictment discipline mirrors the required side: enough
+        // observations AND a real window at least one DKG cycle wide (a
+        // zero-width window — many samples at one tip — proves nothing,
+        // header mode 1) AND the evidence must be LIVE — sighted within the
+        // last cycle. Sightings that all aged out decay to StaleSightings
+        // and the alarm clears (header, mode 2).
         for (const auto& [t, s] : m_seen) {
             if (out.count(t) != 0) continue;   // required, already handled
             LlmqTypeFinding f;
@@ -240,9 +397,21 @@ public:
             f.first_height = s.first_height;
             f.last_height  = s.last_height;
             f.span_heights = span_heights();
+            const uint32_t cycle = dkg_interval_for(t);
             if (m_observations < kMinObservations) {
                 f.verdict = LlmqTypeVerdict::Unevaluated;
                 f.pending_reason = "too-few-observations";
+            } else if (f.span_heights < cycle * kMinCyclesCovered) {
+                f.verdict = LlmqTypeVerdict::Unevaluated;
+                f.pending_reason = "span-shorter-than-one-dkg-cycle";
+            } else if (m_last_height - s.last_height > cycle) {
+                // A genuinely mined type has in-retention entries at EVERY
+                // sample, so its last sighting rides the tip. A last
+                // sighting more than one full cycle behind means every
+                // entry aged out of retention: stale evidence, not a
+                // current disagreement with the chain.
+                f.verdict = LlmqTypeVerdict::StaleSightings;
+                f.pending_reason = "n/a";
             } else {
                 f.verdict = LlmqTypeVerdict::UnexpectedType;
                 f.pending_reason = "n/a";
@@ -308,6 +477,7 @@ public:
     void reset()
     {
         m_seen.clear();
+        m_first_seen.clear();
         m_observations = 0;
         m_first_height = 0;
         m_last_height  = 0;
@@ -322,6 +492,10 @@ private:
 
     LlmqNetwork m_net;
     std::map<uint8_t, Sighting> m_seen;
+    /// First tip at which each identity-bearing, mined_height-unknown entry
+    /// was observed — the dating proxy for entries the [QC-MINED] scanner has
+    /// not dated. Pruned every observe() to the entries currently served.
+    std::map<std::pair<uint8_t, uint256>, uint32_t> m_first_seen;
     uint32_t m_observations{0};
     uint32_t m_first_height{0};
     uint32_t m_last_height{0};

--- a/test/test_dash_dkg_commitments.cpp
+++ b/test/test_dash_dkg_commitments.cpp
@@ -1460,6 +1460,200 @@ TEST(DashLlmqTypeReconciler, ReadsTheProductionQuorumManagerSource)
     EXPECT_EQ(d[0].verdict, LlmqTypeVerdict::NeverObserved);
 }
 
+namespace {
+
+// One entry per required mainnet type, so every reconciler test below is
+// corroborated and no REQUIRED-type finding contaminates the axis under
+// test (the MINED-BUT-NOT-REQUIRED side).
+void add_required_mainnet_entries(QuorumManager& qmgr, uint8_t seed)
+{
+    vendor::QuorumTail tail;
+    tail.newQuorums.push_back(
+        real_commitment(kLlmq60_75,  h256(seed + 0), 0, seed + 0));
+    tail.newQuorums.push_back(
+        real_commitment(kLlmq400_60, h256(seed + 1), 0, seed + 1));
+    tail.newQuorums.push_back(
+        real_commitment(kLlmq400_85, h256(seed + 2), 0, seed + 2));
+    tail.newQuorums.push_back(
+        real_commitment(kLlmq100_67, h256(seed + 3), 0, seed + 3));
+    qmgr.apply(tail);
+}
+
+} // namespace
+
+TEST(DashLlmqTypeReconciler, ZeroWidthWindowCannotIndictAMinedButNotRequiredType)
+{
+    // kMinObservations observe() calls accumulate at a SINGLE tip in
+    // production (one call per template build, many builds per block), so the
+    // observation-count gate alone is satisfiable before any observation
+    // window exists. A zero-width window proves nothing about any type: the
+    // unexpected side must demand the same thing the required side always
+    // has — a window at least one DKG cycle wide — before it indicts.
+    LlmqTypeReconciler r(LlmqNetwork::Mainnet);
+    auto stream = healthy_types(LlmqNetwork::Mainnet);
+    stream.push_back(7);            // a type we do not require
+    for (uint32_t i = 0; i < LlmqTypeReconciler::kMinObservations + 4u; ++i)
+        r.observe(1'950'000u, stream);          // SAME tip every time: span 0
+
+    EXPECT_EQ(r.span_heights(), 0u);
+    EXPECT_TRUE(r.defects().empty())
+        << "zero-width window must not indict: " << r.format_defects();
+    auto f = finding_for(r.reconcile(), 7);
+    ASSERT_TRUE(f.has_value());
+    EXPECT_EQ(f->verdict, LlmqTypeVerdict::Unevaluated);
+    EXPECT_STREQ(f->pending_reason, "span-shorter-than-one-dkg-cycle");
+    EXPECT_EQ(r.format_defects().find("MINED-BUT-NOT-REQUIRED"),
+              std::string::npos);
+
+    // The gate DELAYS the verdict, it does not destroy it: once a real
+    // window exists (>= one cycle; type 7 is unknown to the params table so
+    // the conservative largest-known cycle, 576, applies) the same evidence
+    // convicts.
+    for (uint32_t h = 1'950'001u; h <= 1'950'000u + 600u; ++h)
+        r.observe(h, stream);
+    auto d = r.defects();
+    ASSERT_EQ(d.size(), 1u);
+    EXPECT_EQ(d[0].llmq_type, 7);
+    EXPECT_EQ(d[0].verdict, LlmqTypeVerdict::UnexpectedType);
+}
+
+TEST(DashLlmqTypeReconciler, StaleDatedEntryIsNeverSightedAtAll)
+{
+    // The 2026-08-04 soak defect, DATABLE variant. A local active-set entry
+    // whose quorum was mined far outside its type's retention window
+    // (dkgInterval x signingActiveQuorumCount — the span the chain itself
+    // keeps a quorum active) cannot be a currently-active quorum. Observing
+    // it must register NOTHING: the defect was stamping such an entry with
+    // the CURRENT TIP at every sample, which made one stale entry ring
+    // MINED-BUT-NOT-REQUIRED forever with sightings == observations.
+    constexpr uint32_t kT0 = 1'950'000u;
+    QuorumManager qmgr;
+    add_required_mainnet_entries(qmgr, 0x40);
+    qmgr.find_mutable(5, h256(0x40))->mining_height = kT0;   // llmq_60_75
+    qmgr.find_mutable(2, h256(0x41))->mining_height = kT0;   // llmq_400_60
+    qmgr.find_mutable(3, h256(0x42))->mining_height = kT0;   // llmq_400_85
+    qmgr.find_mutable(4, h256(0x43))->mining_height = kT0;   // llmq_100_67
+    // The stale entry: type 1 (LLMQ_50_60 — mainnet cannot even mine it),
+    // dated 2000 blocks before our window; retention for type 1 is
+    // 24 x 24 = 576.
+    vendor::QuorumTail tail;
+    tail.newQuorums.push_back(real_commitment(kLlmq50_60, h256(0x51), 0, 0x51));
+    qmgr.apply(tail);
+    qmgr.find_mutable(1, h256(0x51))->mining_height = kT0 - 2'000u;
+
+    LlmqTypeReconciler r(LlmqNetwork::Mainnet);
+    for (uint32_t h = kT0; h <= kT0 + 700u; ++h) r.observe(h, qmgr);
+
+    // The stale entry never registers a sighting, so type 1 produces no
+    // finding at all — and in particular no defect.
+    EXPECT_TRUE(r.defects().empty()) << r.format_defects();
+    auto f = finding_for(r.reconcile(), 1);
+    EXPECT_FALSE(f.has_value())
+        << "a stale entry must not manufacture sightings; got sightings="
+        << (f ? f->sightings : 0u) << " of " << r.observations()
+        << " observations";
+}
+
+TEST(DashLlmqTypeReconciler, UndatableStaleEntryAgesOutAndTheAlarmClears)
+{
+    // The 2026-08-04 soak defect, EXACT measured shape. The stale type-1
+    // entry has mining_height 0 (the [QC-MINED] scanner never saw a type-1
+    // qfcommit — none exists), so it cannot be dated better than "when WE
+    // first saw it". Both soaks measured sightings == observations EXACTLY
+    // (1408==1408, 895==895) over ~12 h with zero type-1 qfcommits on chain:
+    // the entry re-registered as fresh at every sample, so the alarm could
+    // never decay and carried no information. Post-fix the entry dates from
+    // first sight, ages out of retention (576 blocks for type 1), sightings
+    // FREEZE, and one DKG cycle later the verdict decays to the named
+    // non-defect StaleSightings — the alarm CLEARS.
+    constexpr uint32_t kT0 = 1'950'000u;
+    QuorumManager qmgr;
+    add_required_mainnet_entries(qmgr, 0x60);   // mining_height 0: undatable
+    vendor::QuorumTail tail;
+    tail.newQuorums.push_back(real_commitment(kLlmq50_60, h256(0x71), 0, 0x71));
+    qmgr.apply(tail);                            // mining_height stays 0
+
+    LlmqTypeReconciler r(LlmqNetwork::Mainnet);
+    for (uint32_t h = kT0; h <= kT0 + 300u; ++h) r.observe(h, qmgr);
+
+    // While the undatable entry is inside the retention window measured from
+    // first sight it is INDISTINGUISHABLE from a freshly mined quorum, and
+    // the honest verdict is the alarm. This is not a regression — it is the
+    // backstop refusing to be blinded by a missing datum.
+    {
+        auto f = finding_for(r.reconcile(), 1);
+        ASSERT_TRUE(f.has_value());
+        EXPECT_EQ(f->verdict, LlmqTypeVerdict::UnexpectedType);
+    }
+
+    // ...but past first-sight + retention the entry ages out: sightings stop.
+    for (uint32_t h = kT0 + 301u; h <= kT0 + 601u; ++h) r.observe(h, qmgr);
+    auto f = finding_for(r.reconcile(), 1);
+    ASSERT_TRUE(f.has_value());
+    EXPECT_EQ(f->verdict, LlmqTypeVerdict::StaleSightings);
+    EXPECT_STREQ(llmq_type_verdict_name(f->verdict),
+                 "stale-sightings-aged-out");
+    EXPECT_FALSE(is_llmq_type_defect(f->verdict));
+    EXPECT_TRUE(r.defects().empty())
+        << "the alarm must CLEAR once every sighting aged out: "
+        << r.format_defects();
+    // The measured self-refresh signature — sightings == observations — is
+    // structurally impossible now: sightings froze at first-sight+retention.
+    EXPECT_LT(f->sightings, r.observations());
+    EXPECT_EQ(f->sightings, 577u);              // kT0 .. kT0+576 inclusive
+    EXPECT_EQ(f->last_height, kT0 + 576u);
+}
+
+TEST(DashLlmqTypeReconciler, GenuinelyMinedUnexpectedTypeStillAlarms)
+{
+    // THE BACKSTOP MUST KEEP WORKING — a fix that silences the stale echo by
+    // silencing the alarm would trade a false positive for a false negative,
+    // and the false negative is worse (bad-qc-missing loses blocks). A type
+    // upstream genuinely mines keeps producing NEW quorums with current
+    // mined heights; those entries are always inside retention, sightings
+    // ride the tip, and the indictment must stand. Same zero-width
+    // discipline applies first: no verdict from a one-tip pileup.
+    constexpr uint32_t kT0 = 1'950'000u;
+    QuorumManager qmgr;
+    add_required_mainnet_entries(qmgr, 0x20);
+    const LlmqParamsView fake7{7, 50, 40, 30, 24, 10, 18, 24, false};
+
+    LlmqTypeReconciler r(LlmqNetwork::Mainnet);
+    // A template-build pileup at one tip: enough CALLS, zero-width WINDOW.
+    {
+        vendor::QuorumTail tail;
+        tail.newQuorums.push_back(real_commitment(fake7, h256(0x80), 0, 0x80));
+        qmgr.apply(tail);
+        qmgr.find_mutable(7, h256(0x80))->mining_height = kT0;
+    }
+    for (uint32_t i = 0; i < LlmqTypeReconciler::kMinObservations + 4u; ++i)
+        r.observe(kT0, qmgr);
+    EXPECT_TRUE(r.defects().empty()) << r.format_defects();
+
+    // The chain keeps mining the type: a new quorum every 24 blocks, each
+    // stamped with ITS OWN mined height.
+    uint8_t fill = 0x81;
+    for (uint32_t h = kT0 + 1u; h <= kT0 + 600u; ++h) {
+        if (h % 24u == 0u) {
+            vendor::QuorumTail tail;
+            tail.newQuorums.push_back(
+                real_commitment(fake7, h256(fill), 0, fill));
+            qmgr.apply(tail);
+            qmgr.find_mutable(7, h256(fill))->mining_height = h;
+            ++fill;
+        }
+        r.observe(h, qmgr);
+    }
+
+    auto d = r.defects();
+    ASSERT_EQ(d.size(), 1u);
+    EXPECT_EQ(d[0].llmq_type, 7);
+    EXPECT_EQ(d[0].verdict, LlmqTypeVerdict::UnexpectedType);
+    const auto said = r.format_defects();
+    EXPECT_NE(said.find("type=7"), std::string::npos) << said;
+    EXPECT_NE(said.find("MINED-BUT-NOT-REQUIRED"), std::string::npos) << said;
+}
+
 // ── qc_pose_pass_provably_noop: the interim PoSe serve predicate ───────────
 //
 // dashd PoSe-punishes every member a NON-NULL in-block commitment marks


### PR DESCRIPTION
## What

The DASH `LlmqTypeReconciler` (negative-capable backstop for `enabled_llmqs()`) carried two defects, both on the **MINED-BUT-NOT-REQUIRED** (`UnexpectedType`) axis, that made it fire falsely. Both are fixed here; the backstop's true signal is preserved.

### DEFECT 1 — zero-width observation window (DEF10, task-tracked)
`observe()` runs once per template build (many times per block), so `kMinObservations` calls pile up at a **single tip height**. The unexpected-type branch gated only on the observation *count*, never the window *width*, so it could indict a not-required type before any real observation window existed (`span == 0`). The required-side verdicts always demanded a full DKG cycle of span; the unexpected side now demands the same — its own `dkgInterval` when the type is in the known params table, the largest known interval (576) otherwise.

### DEFECT 2 — self-refreshing stale entry (MEASURED 2026-08-04, two soaks)
Both soaks rang `type=1 MINED-BUT-NOT-REQUIRED` continuously with `sightings == observations` **exactly** (1408==1408, 895==895) and **zero** type-1 qfcommits in ~12 h — a signature impossible for real evidence, guaranteed for a bookkeeping loop. `observe()` read `qmgr.active_entries()` and stamped every *present* type with the **current tip** height, never the quorum's own mined height, so one stale local entry (type 1 / LLMQ_50_60 — a set mainnet cannot even mine) re-registered a fresh sighting at every sample, forever.

**Fix:** each entry is dated by *its own* height — `mining_height` when the `[QC-MINED]` scanner has seen the qfcommit tx, else the tip at which we first saw that `(type, quorumHash)`. An entry older than its type's active-quorum **retention window** (`dkgInterval × signingActiveQuorumCount`) is not counted as a sighting, so a genuinely stale entry ages **out**. Once a non-required type's last in-retention sighting trails the tip by more than one DKG cycle the verdict decays to the named non-defect `StaleSightings` and the alarm **clears** — while a type the chain keeps mining produces in-retention entries every sample, so its alarm never decays.

## Why it matters
If MINED-BUT-NOT-REQUIRED were *true* it would mean our blocks omit a mandatory commitment (`bad-qc-missing`) and lose blocks. A backstop that cries wolf permanently carries no information — this restores its signal.

## Tests — each fails on master
Folded into `test_dash_embedded_gbt` (already in the `build.yml` `--target` allowlist; `tools/ci/check_test_target_allowlist.py` passes):
- `ZeroWidthWindowCannotIndictAMinedButNotRequiredType` — behavioral fail on master (span=0 indictment, `sightings==observations`).
- `StaleDatedEntryIsNeverSightedAtAll` / `UndatableStaleEntryAgesOutAndTheAlarmClears` — the 2026-08-04 shape; alarm clears post-fix.
- `GenuinelyMinedUnexpectedTypeStillAlarms` — the backstop must keep working (fabricated type with live per-cycle mined heights still alarms).

Verified locally: all 3 new tests fail on master (2 behaviorally, 2 via the new `StaleSightings` verdict), all 10 reconciler tests + full 139-test `test_dash_embedded_gbt` suite green on the fix.

## Scope
DASH lane only. Two files: `src/impl/dash/coin/llmq_type_reconciler.hpp`, `test/test_dash_dkg_commitments.cpp`.

MEASURED: the 2026-08-04 `sightings==observations` soak signature (DEFECT 2). INFERRED: DEFECT 1 reachability from the once-per-template-build call cadence.

**do-not-merge** — leaving merge to the coordinator after full CI rollup verification.