### PR TITLE
dash(shadow-compare): serve-vs-dashd block-template diff DIAGNOSTIC (NOT a serve gate)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -81,6 +81,7 @@
 #include <impl/dash/coin/mempool_ingest.hpp>     // wire_mempool_ingest (leg 1)
 #include <impl/dash/coin/tip_ingest.hpp>         // wire_tip_ingest (leg 2)
 #include <impl/dash/coin/embedded_oracle_shadow.hpp> // dash::coin::EmbeddedOracleShadow — per-block dashd cross-check (OBSERVE-only)
+#include <impl/dash/coin/embedded_shadow_compare.hpp> // dash::coin::EmbeddedShadowCompare — serve-vs-dashd template diff (OBSERVE-only, NOT a gate)
 #include <impl/dash/coin/block_connect_ingest.hpp>   // wire_block_connect_ingest (leg 3)
 #include <impl/dash/coin/mn_list_ingest.hpp>     // wire_mn_list_ingest (leg 4)
 #include <impl/dash/coin/govsync_ingest.hpp>     // wire_govobject_ingest / wire_govvote_ingest (E-SUPERBLOCK)
@@ -264,6 +265,7 @@ void print_banner(const char* argv0)
         << "           [--embedded-utxo-immature-serve-empty]\n"
         << "           [--bestcl-policy freshness|consensus-exact]\n"
         << "           [--embedded-oracle-shadow]\n"
+        << "           [--embedded-shadow-compare]\n"
         << "           [--oracle-graduation-blocks N] [--oracle-class-coverage K]\n"
         << "           [--give-author PCT] [-f|--fee PCT] [--node-owner-address ADDR]\n"
         << "           [--redistribute pplns|fee|boost|donate]\n"
@@ -344,6 +346,13 @@ void print_banner(const char* argv0)
         << "        ledger + /embedded_oracle verdict signal when the embedded arm is\n"
         << "        proven equivalent (safe to disable dashd, served domain). Needs the\n"
         << "        dashd RPC arm; never changes serving. N/K tune the graduation gate.\n"
+        << "        --embedded-shadow-compare is a SEPARATE, simpler OBSERVE-only\n"
+        << "        diagnostic (NOT a serve gate, no graduation state): on every\n"
+        << "        template SERVE it best-effort field-compares the served template\n"
+        << "        against dashd getblocktemplate at the same height on a WORKER\n"
+        << "        thread (off the miner hot path) and logs one [SHADOW] line\n"
+        << "        (MATCH / MISMATCH / SERVED-MISMATCH / no-oracle) + counters. Needs\n"
+        << "        a reachable dashd RPC arm; a strict no-op in pure-daemonless mode.\n"
         << "        Live sharechain tip/stats, pool hashrate and per-share difficulty\n"
         << "        are bound to the REAL DASH tracker; local hashrate comes from the\n"
         << "        DASH stratum acceptor. If stratum and web ports collide the web\n"
@@ -547,7 +556,12 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              // nothing to overstate. Default false = REFUSE the window (p2pool
              // semantics: an unsynced node does not serve templates; the dashd
              // fallback serves full ones where armed) -- the pre-policy behaviour.
-             bool embedded_utxo_immature_serve_empty = false)
+             bool embedded_utxo_immature_serve_empty = false,
+             // --embedded-shadow-compare: OBSERVE-only serve-vs-dashd block-
+             // template field diff (diagnostic; NOT a serve gate). Off the hot
+             // path (worker-thread dashd fetch). Default false; only meaningful
+             // when a dashd RPC oracle is reachable — a strict no-op otherwise.
+             bool embedded_shadow_compare = false)
 {
     namespace io = boost::asio;
 
@@ -1931,6 +1945,40 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         std::cout << "[DASH-STRATUM-GBT] GBT cross-check DISABLED: dashd RPC "
                      "arm UNARMED (pure-daemonless) -- the embedded arm relies "
                      "on the independent seed-height + pre-emit gates\n";
+    }
+
+    // ── Embedded-vs-dashd SHADOW-COMPARE DIAGNOSTIC (--embedded-shadow-compare) ──
+    // A pure OBSERVABILITY probe, DISTINCT from set_gbt_xcheck above: gbt_xcheck
+    // is a reward-safety GATE that can SWAP the served arm on a creditPool
+    // mismatch; this probe can NEVER change what is served. On every template
+    // re-source it hands the just-resolved template (by copy) to a WORKER THREAD
+    // that best-effort fetches dashd's getblocktemplate for the SAME height,
+    // field-compares (payee / merkleRootMNList / merkleRootQuorums / cbTx
+    // height+version / scriptSig height) and logs one [SHADOW] line. The oracle
+    // fetch is entirely off the miner-facing path; a slow/absent dashd just logs
+    // `no-oracle`. Only meaningful when a dashd RPC arm is ARMED — pure-daemonless
+    // (no rpc) leaves it a strict no-op.
+    if (embedded_shadow_compare) {
+        if (rpc) {
+            auto shadow = std::make_shared<dash::coin::EmbeddedShadowCompare>(
+                // OracleFn: dashd getblocktemplate -> DashWorkData, or nullopt on
+                // any failure/absence (so the probe degrades to `no-oracle`,
+                // never a stall). rp is valid for the probe's lifetime: work_source
+                // (which owns this probe) is destroyed before rpc at scope exit,
+                // and the probe's dtor joins the worker before returning.
+                [rp = rpc.get()]() -> std::optional<dash::coin::DashWorkData> {
+                    try { return rp->getwork(); }
+                    catch (...) { return std::nullopt; }
+                });
+            work_source->set_shadow_compare(std::move(shadow));
+            std::cout << "[run] --embedded-shadow-compare ARMED: OBSERVE-only "
+                         "serve-vs-dashd template diff (worker-thread dashd fetch; "
+                         "NOT a serve gate; [SHADOW] log lines + counters)\n";
+        } else {
+            std::cout << "[run] --embedded-shadow-compare given but no dashd RPC "
+                         "arm is armed (pure-daemonless) -- no oracle to compare "
+                         "against; probe NOT armed (no-op)\n";
+        }
     }
 
     // ── Mint slice 3/3: run-loop share minting wiring ─────────────────────
@@ -5011,6 +5059,12 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // otherwise outlive it. ioc.run() has returned, so no further new_tip fires.
     if (oracle_shadow) oracle_shadow.reset();
 
+    // Join the shadow-compare worker BEFORE rpc unwinds: its worker thread
+    // dereferences rpc (getwork oracle). Dropping work_source's ref here runs the
+    // probe's dtor (which joins the worker) while rpc is still alive. ioc.run()
+    // has returned, so no further template re-source can enqueue a new job.
+    if (work_source) work_source->set_shadow_compare(nullptr);
+
     // Stop the dashboard BEFORE p2p_node unwinds: its callbacks hold a raw
     // dash::Node* and the HTTP thread must be joined while that is still valid.
     if (web_server) {
@@ -5215,6 +5269,7 @@ int main(int argc, char** argv)
     bool embedded_utxo_immature_serve_empty = false;
     std::string bestcl_policy = "freshness";   // --bestcl-policy: freshness (default, conservative proxy) | consensus-exact (dashcore's actual CheckCbTxBestChainlock rule)
     bool embedded_oracle_shadow = false;       // --embedded-oracle-shadow: per-block dashd cross-check (OBSERVE-only)
+    bool embedded_shadow_compare = false;      // --embedded-shadow-compare: serve-vs-dashd template diff (OBSERVE-only, NOT a gate)
     uint64_t oracle_grad_blocks = 5000;        // --oracle-graduation-blocks N (consecutive clean)
     uint64_t oracle_class_coverage = 20;       // --oracle-class-coverage K (per height class)
     double dev_donation = 0.1;                 // --give-author (donation_percentage; README default 0.1%)
@@ -5299,6 +5354,8 @@ int main(int argc, char** argv)
             coinbase_text = argv[++i];
         else if (std::strcmp(argv[i], "--embedded-oracle-shadow") == 0)
             embedded_oracle_shadow = true;
+        else if (std::strcmp(argv[i], "--embedded-shadow-compare") == 0)
+            embedded_shadow_compare = true;
         else if (std::strcmp(argv[i], "--oracle-graduation-blocks") == 0 && i + 1 < argc)
             oracle_grad_blocks = std::strtoull(argv[++i], nullptr, 10);
         else if (std::strcmp(argv[i], "--oracle-class-coverage") == 0 && i + 1 < argc)
@@ -5449,7 +5506,8 @@ int main(int argc, char** argv)
                         operator_message_blob_hex, embedded_superblock,
                         embedded_oracle_shadow, oracle_grad_blocks,
                         oracle_class_coverage, coin_p2p_peers, bestcl_policy,
-                        embedded_utxo_immature_serve_empty);
+                        embedded_utxo_immature_serve_empty,
+                        embedded_shadow_compare);
     }
     return run_selftest();
 }

--- a/src/impl/dash/coin/embedded_shadow_compare.hpp
+++ b/src/impl/dash/coin/embedded_shadow_compare.hpp
@@ -1,0 +1,344 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// DASH Embedded-vs-dashd block-template SHADOW-COMPARE DIAGNOSTIC
+/// (--embedded-shadow-compare).
+///
+/// ══ WHAT THIS IS (and, emphatically, WHAT IT IS NOT) ════════════════════════
+/// A pure OBSERVABILITY probe. On every block-template SERVE resolution (the
+/// same trigger that produces the template a miner mines) it best-effort obtains
+/// dashd's getblocktemplate for the SAME height and field-compares the two, then
+/// LOGS one self-describing [SHADOW] line and bumps a counter. That is the whole
+/// contract.
+///
+/// THIS IS NOT A SERVE GATE. It never selects, blocks, delays, re-orders, or
+/// alters the template that gets served. It is deliberately SEPARATE from the
+/// EmbeddedOracleShadow graduation gate (embedded_oracle_shadow.hpp): that one is
+/// tip-triggered and drives a revocable "safe to disable dashd" verdict; THIS one
+/// is serve-triggered, keeps no graduation state, and makes no claim beyond "at
+/// height H, the field-by-field diff between what we served and what dashd would
+/// have served looks like <X>". A [SHADOW] MISMATCH is DIAGNOSTIC EVIDENCE, not
+/// proof of a bad served block (see the SEMANTIC note below).
+///
+/// ══ HOT-PATH DISCIPLINE (hard invariant) ════════════════════════════════════
+/// The dashd oracle fetch is ALWAYS off the miner-facing path. on_serve() only
+/// ENQUEUES a copy of the just-resolved template (coalescing to the newest) and
+/// returns; a dedicated worker thread runs the dashd RPC + compare + log. The
+/// serve path therefore NEVER waits on the oracle: if dashd is slow, hung, or
+/// absent the miner-facing response is completely unaffected and the worker
+/// simply logs `no-oracle` for that sample. Nothing this class does can add
+/// latency to, or change the bytes of, the served template.
+///
+/// ══ DEFAULT OFF / DAEMONLESS ════════════════════════════════════════════════
+/// Only meaningful when a dashd RPC oracle is reachable (the getblocktemplate
+/// closure is bound). In pure-daemonless production no oracle is bound, so the
+/// probe is never constructed and this is a strict no-op. Flag-gated
+/// (--embedded-shadow-compare), default false.
+///
+/// ══ SEMANTIC — why a MISMATCH is not a served-block bug ══════════════════════
+/// Two legitimate ways the compare can diverge WITHOUT anything wrong being
+/// served:
+///   (1) The fail-closed serve gate may have REFUSED the embedded arm at this
+///       height (source == DashdFallback). Then the embedded fields we log are a
+///       template that was NEVER served — a divergence here proves the gate did
+///       its job, not that a bad block went out.
+///   (2) dashd's template can legitimately differ in TX SELECTION (separate
+///       mempool), which perturbs fee-dependent amounts and the tx-set. Those are
+///       NOT validity-bearing for the coinbase-commitment fields.
+/// The single high-value signal — the ONLY combination that would indicate a real
+/// validity problem — is: the embedded arm was SERVED (not refused) at height H
+/// AND a CONSENSUS-COMMITMENT field (coinbase payee, merkleRootMNList, or
+/// merkleRootQuorums) diverged from dashd. That combination is surfaced
+/// distinctly as `[SHADOW] h=H SERVED-MISMATCH ...` so it stands out from the
+/// benign mismatch noise.
+///
+/// STRICTLY single-coin: src/impl/dash/coin/ only. Header-only so the pure
+/// evaluate()/diff logic is KAT-pinnable without a live node or a thread.
+
+#include <impl/dash/coin/work_source.hpp>       // WorkSource
+#include <impl/dash/coin/rpc_data.hpp>          // DashWorkData, PackedPayment
+#include <impl/dash/coin/vendor/cbtx.hpp>       // vendor::CCbTx, vendor::parse_cbtx
+
+#include <core/log.hpp>
+
+#include <nlohmann/json.hpp>
+
+#include <condition_variable>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace dash {
+namespace coin {
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure comparison layer (no thread, no RPC, no node) — KAT-pinnable.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// One diverging field. `commitment` marks the consensus-commitment trio
+/// (payee / merkleRootMNList / merkleRootQuorums) whose divergence — when the
+/// embedded arm was SERVED — is the real-validity-problem signal.
+struct ShadowFieldDiff {
+    std::string field;
+    std::string embedded;
+    std::string dashd;
+    bool        commitment{false};
+};
+
+/// The verdict for one served height.
+struct ShadowOutcome {
+    enum class Kind { NoOracle, Match, Mismatch };
+    Kind                        kind{Kind::NoOracle};
+    uint32_t                    height{0};
+    bool                        served{false};   // source == WorkSource::Embedded
+    std::string                 no_oracle_reason;
+    std::vector<ShadowFieldDiff> diffs;          // diverging fields only
+    bool                        served_mismatch{false}; // served && a commitment field diverged
+    std::vector<std::string>    log_lines;        // the [SHADOW] lines, ready to emit
+};
+
+/// Counters, surfaced the way the existing gate markers surface: named tallies a
+/// monitor/dashboard can read, plus a per-field breakdown keyed
+/// "shadow-mismatch-<field>".
+struct ShadowCounters {
+    uint64_t shadow_match{0};
+    uint64_t shadow_no_oracle{0};
+    uint64_t shadow_served_mismatch{0};
+    std::map<std::string, uint64_t> shadow_mismatch_by_field;   // field -> count
+
+    void apply(const ShadowOutcome& o) {
+        switch (o.kind) {
+        case ShadowOutcome::Kind::NoOracle: shadow_no_oracle++; break;
+        case ShadowOutcome::Kind::Match:    shadow_match++;     break;
+        case ShadowOutcome::Kind::Mismatch:
+            for (const auto& d : o.diffs) shadow_mismatch_by_field[d.field]++;
+            if (o.served_mismatch) shadow_served_mismatch++;
+            break;
+        }
+    }
+    nlohmann::json to_json() const {
+        nlohmann::json j;
+        j["shadow-match"]           = shadow_match;
+        j["shadow-no-oracle"]       = shadow_no_oracle;
+        j["shadow-served-mismatch"] = shadow_served_mismatch;
+        nlohmann::json byf = nlohmann::json::object();
+        for (const auto& kv : shadow_mismatch_by_field)
+            byf["shadow-mismatch-" + kv.first] = kv.second;
+        j["shadow-mismatch-by-field"] = byf;
+        return j;
+    }
+};
+
+/// First non-platform-burn payee ("!6a" is the DASH platform credit-pool
+/// OP_RETURN burn, not a real payee) — the masternode payee identity.
+inline std::string shadow_mn_payee(const std::vector<PackedPayment>& pps) {
+    for (const auto& p : pps)
+        if (p.payee != "!6a") return p.payee;
+    return "(none)";
+}
+
+/// Pure evaluate: given the SERVED template, whether the embedded arm produced it
+/// (source), and dashd's template for the SAME height (nullopt == oracle
+/// unavailable / did not arrive in time / tip-skew), produce the outcome + the
+/// exact [SHADOW] log lines. No side effects: does not read or mutate anything
+/// beyond its arguments, so a reviewer can see the served template is untouched.
+inline ShadowOutcome shadow_evaluate(WorkSource source,
+                                     const DashWorkData& embedded,
+                                     const std::optional<DashWorkData>& dashd_opt) {
+    ShadowOutcome o;
+    o.height = embedded.m_height;
+    o.served = (source == WorkSource::Embedded);
+
+    if (!dashd_opt) {
+        o.kind = ShadowOutcome::Kind::NoOracle;
+        o.log_lines.push_back("[SHADOW] h=" + std::to_string(o.height) + " no-oracle");
+        return o;
+    }
+    const DashWorkData& dashd = *dashd_opt;
+
+    // Same-height alignment is a precondition to compare at all: a template for a
+    // DIFFERENT height is not the oracle for THIS one. Treat tip-skew as
+    // "no oracle for this height" rather than false-flagging every field.
+    if (dashd.m_height != embedded.m_height) {
+        o.kind = ShadowOutcome::Kind::NoOracle;
+        o.no_oracle_reason = "tip-skew(dashd_h=" + std::to_string(dashd.m_height) + ")";
+        o.log_lines.push_back("[SHADOW] h=" + std::to_string(o.height)
+                              + " no-oracle reason=" + o.no_oracle_reason);
+        return o;
+    }
+
+    auto add = [&](const char* field, bool commitment,
+                   const std::string& e, const std::string& d) {
+        if (e != d) o.diffs.push_back({field, e, d, commitment});
+    };
+
+    // ── Consensus-commitment trio (validity-bearing for the SERVED signal) ────
+    add("payee", /*commitment=*/true,
+        shadow_mn_payee(embedded.m_packed_payments),
+        shadow_mn_payee(dashd.m_packed_payments));
+
+    vendor::CCbTx ecb, dcb;
+    const bool eok = vendor::parse_cbtx(embedded.m_coinbase_payload, ecb);
+    const bool dok = vendor::parse_cbtx(dashd.m_coinbase_payload, dcb);
+    if (eok && dok) {
+        add("merkleRootMNList",  /*commitment=*/true,
+            ecb.merkleRootMNList.GetHex(),  dcb.merkleRootMNList.GetHex());
+        add("merkleRootQuorums", /*commitment=*/true,
+            ecb.merkleRootQuorums.GetHex(), dcb.merkleRootQuorums.GetHex());
+        add("cbtx_version", /*commitment=*/false,
+            std::to_string(ecb.nVersion), std::to_string(dcb.nVersion));
+        add("cbtx_height",  /*commitment=*/false,
+            std::to_string(ecb.nHeight),  std::to_string(dcb.nHeight));
+    } else {
+        // A CbTx we cannot parse is itself a divergence worth logging (but not a
+        // commitment-trio member: we cannot read the roots to judge them).
+        add("cbtx_parse", /*commitment=*/false,
+            eok ? "ok" : "fail", dok ? "ok" : "fail");
+    }
+
+    // Coinbase scriptSig height (BIP34). At serve-resolution the assembled
+    // coinbase input is not yet materialized in DashWorkData — the coinbase
+    // builder BIP34-encodes the block height (m_height) into the scriptSig. So we
+    // compare the height VALUE that will be encoded, which is exactly the
+    // validity-bearing quantity a scriptSig-height check would catch.
+    add("scriptsig_height", /*commitment=*/false,
+        std::to_string(embedded.m_height), std::to_string(dashd.m_height));
+
+    if (o.diffs.empty()) {
+        o.kind = ShadowOutcome::Kind::Match;
+        o.log_lines.push_back("[SHADOW] h=" + std::to_string(o.height) + " MATCH");
+        return o;
+    }
+
+    o.kind = ShadowOutcome::Kind::Mismatch;
+    for (const auto& d : o.diffs)
+        if (d.commitment && o.served) o.served_mismatch = true;
+
+    // One line per diverging field. The served + commitment combination is the
+    // ONLY real-validity-problem signal, so it gets the distinct SERVED-MISMATCH
+    // marker; every other divergence is benign-until-proven and gets MISMATCH.
+    for (const auto& d : o.diffs) {
+        const bool served_bad = o.served && d.commitment;
+        o.log_lines.push_back(
+            std::string("[SHADOW] h=") + std::to_string(o.height)
+            + (served_bad ? " SERVED-MISMATCH" : " MISMATCH")
+            + " field=" + d.field
+            + " embedded=" + d.embedded
+            + " dashd=" + d.dashd);
+    }
+    return o;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Runtime driver. Enqueue-only on the serve path; a worker thread does the RPC +
+// compare + log so the miner-facing response never waits on dashd.
+// ─────────────────────────────────────────────────────────────────────────────
+class EmbeddedShadowCompare {
+public:
+    /// Returns dashd's getblocktemplate as a DashWorkData for the current tip,
+    /// or nullopt on any failure/absence (so a slow/hung/missing dashd degrades
+    /// to a `no-oracle` log line, never a stall). Bound in main_dash.cpp.
+    using OracleFn = std::function<std::optional<DashWorkData>()>;
+
+    explicit EmbeddedShadowCompare(OracleFn oracle)
+        : oracle_(std::move(oracle)) {
+        LOG_INFO << "[SHADOW] embedded-vs-dashd shadow-compare ARMED (diagnostic "
+                    "only; NOT a serve gate; oracle fetch off the hot path)";
+        worker_ = std::thread([this] { worker_loop(); });
+    }
+
+    ~EmbeddedShadowCompare() {
+        { std::lock_guard<std::mutex> lk(q_mu_); stop_ = true; }
+        q_cv_.notify_all();
+        if (worker_.joinable()) worker_.join();
+    }
+
+    EmbeddedShadowCompare(const EmbeddedShadowCompare&) = delete;
+    EmbeddedShadowCompare& operator=(const EmbeddedShadowCompare&) = delete;
+
+    /// SERVE-PATH ENTRY. ENQUEUE ONLY — copies the just-resolved template + the
+    /// arm that produced it and returns immediately. NEVER blocks the caller and
+    /// NEVER touches `served`. Coalesces to the newest pending job (a shadow
+    /// samples serves; a skipped intermediate is a coverage gap, never a wrong
+    /// count). Safe to call whether the resolved arm was Embedded or fallback.
+    void on_serve(WorkSource source, const DashWorkData& served) {
+        {
+            std::lock_guard<std::mutex> lk(q_mu_);
+            pending_ = std::make_pair(source, served);   // copy
+        }
+        q_cv_.notify_one();
+    }
+
+    nlohmann::json stats_json() const {
+        std::lock_guard<std::mutex> lk(mu_);
+        nlohmann::json j = counters_.to_json();
+        j["mode"] = "embedded-shadow-compare";
+        j["note"] = "diagnostic only — NOT a serve gate";
+        return j;
+    }
+
+private:
+    void worker_loop() {
+        for (;;) {
+            std::pair<WorkSource, DashWorkData> job;
+            {
+                std::unique_lock<std::mutex> lk(q_mu_);
+                q_cv_.wait(lk, [this] { return stop_ || pending_.has_value(); });
+                if (stop_ && !pending_.has_value()) return;
+                job = std::move(*pending_);
+                pending_.reset();
+            }
+            try { process(job.first, job.second); }
+            catch (const std::exception& e) {
+                LOG_WARNING << "[SHADOW] worker exception: " << e.what();
+            }
+        }
+    }
+
+    void process(WorkSource source, const DashWorkData& served) {
+        // The dashd oracle RPC runs HERE, on the worker thread — off the hot
+        // path. A throw/absence maps to nullopt -> a `no-oracle` sample.
+        std::optional<DashWorkData> dashd;
+        if (oracle_) {
+            try { dashd = oracle_(); }
+            catch (const std::exception& e) {
+                LOG_WARNING << "[SHADOW] oracle threw: " << e.what() << " — no-oracle";
+                dashd.reset();
+            }
+        }
+        // If the oracle returned an empty set-gap template (unarmed fallback:
+        // m_height==0 / null prev), treat it as no-oracle rather than diffing
+        // every field against zeros.
+        if (dashd && (dashd->m_bits == 0 || dashd->m_previous_block.IsNull()))
+            dashd.reset();
+
+        const ShadowOutcome o = shadow_evaluate(source, served, dashd);
+
+        for (const auto& line : o.log_lines) {
+            if (o.served_mismatch) LOG_WARNING << line;   // the real-problem signal
+            else                   LOG_INFO    << line;
+        }
+        std::lock_guard<std::mutex> lk(mu_);
+        counters_.apply(o);
+    }
+
+    OracleFn oracle_;
+
+    mutable std::mutex mu_;          // guards counters_
+    ShadowCounters     counters_;
+
+    std::thread             worker_;
+    std::mutex              q_mu_;
+    std::condition_variable q_cv_;
+    std::optional<std::pair<WorkSource, DashWorkData>> pending_;
+    bool                    stop_{false};
+};
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -464,6 +464,14 @@ void DASHWorkSource::resource_template_now() const
             // the EMBEDDED->fallback transition and any change of cause emit
             // immediately; an unchanged cause emits on a slow heartbeat.
             note_arm_decision(work_is_embedded, sel.decline, sel.work.m_height);
+            // OBSERVE-only serve-vs-dashd SHADOW-COMPARE (--embedded-shadow-compare).
+            // Hand the JUST-RESOLVED template (by const-ref; on_serve copies) to
+            // the diagnostic probe. This is ENQUEUE-ONLY: the dashd oracle fetch +
+            // field-compare + [SHADOW] log all run on the probe's WORKER THREAD, so
+            // nothing here waits on dashd and the served bytes below are untouched.
+            // No-op when the probe is unset (default / pure-daemonless).
+            if (shadow_compare_)
+                shadow_compare_->on_serve(sel.source, sel.work);
             work = std::move(sel.work);
         } catch (const std::exception& e) {
             LOG_WARNING << "[DASH-STRATUM] template sourcing threw: " << e.what();

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -52,6 +52,7 @@
 
 #include <impl/dash/coin/node_coin_state.hpp>   // coin::NodeCoinState, coin::DashWorkData seam
 #include <impl/dash/coin/serve_gate_journal.hpp> // coin::ServeGateJournal — decline rate policy (DEFECT-3)
+#include <impl/dash/coin/embedded_shadow_compare.hpp> // coin::EmbeddedShadowCompare — OBSERVE-only serve-vs-dashd diff
 #include <impl/dash/stratum/get_work.hpp>       // dash::stratum::get_work() fused capstone
 
 #include <atomic>
@@ -318,6 +319,18 @@ public:
     /// independent seed-height + pre-emit gates.
     void set_gbt_xcheck(bool v) { gbt_xcheck_ = v; }
 
+    /// Embedded-vs-dashd SHADOW-COMPARE DIAGNOSTIC (--embedded-shadow-compare).
+    /// OBSERVE-ONLY: on every template re-source the just-resolved template is
+    /// handed (by copy) to this probe, which best-effort field-compares it against
+    /// dashd's getblocktemplate on a WORKER THREAD and logs a [SHADOW] line. It
+    /// NEVER selects, blocks, delays, or alters the served template — the serve
+    /// path only ENQUEUES and returns. Unset (default) => strict no-op. Distinct
+    /// from set_gbt_xcheck (a reward-safety GATE that can swap the served arm);
+    /// this one can never change what is served.
+    void set_shadow_compare(std::shared_ptr<coin::EmbeddedShadowCompare> s) {
+        shadow_compare_ = std::move(s);
+    }
+
     /// Set the current share-target bits (compact-target encoding).
     /// `max_bits` is the easiest the share target can be. Both atomically
     /// visible to stratum sessions.
@@ -443,6 +456,12 @@ private:
     bool is_testnet_{false};
     bool embedded_mainnet_{false};   // gate-lift opt-in: daemonless embedded arm on mainnet
     bool gbt_xcheck_{false};         // reward-safety backstop: cross-check embedded creditPool vs dashd
+
+    // OBSERVE-only serve-vs-dashd shadow-compare (--embedded-shadow-compare).
+    // Unset (default / pure-daemonless) => strict no-op. Never on the hot path:
+    // on_serve() only enqueues a copy for a worker thread. Held by shared_ptr so
+    // the driver's worker thread outlives no dangling reference at teardown.
+    std::shared_ptr<coin::EmbeddedShadowCompare> shadow_compare_;
 
     // Slow heartbeat for an UNCHANGED decline cause. The transition and any
     // change of cause are emitted immediately regardless; this only bounds how

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -741,6 +741,7 @@ if (BUILD_TESTING AND GTest_FOUND)
         test_dash_qc_episode_classifier.cpp
         test_dash_sml_quorum_db.cpp
         test_dash_embedded_oracle_shadow.cpp
+        test_dash_embedded_shadow_compare.cpp
         test_dash_mn_confirm_rollover.cpp
         test_dash_collateral_spend_filter.cpp)
     target_compile_definitions(test_dash_embedded_gbt PRIVATE

--- a/test/test_dash_embedded_shadow_compare.cpp
+++ b/test/test_dash_embedded_shadow_compare.cpp
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/// DASH embedded-vs-dashd SHADOW-COMPARE DIAGNOSTIC — hermetic KATs
+/// (embedded_shadow_compare.hpp).
+///
+/// This is a DIAGNOSTIC TOOL, explicitly NOT a serve gate. These KATs pin the
+/// two properties the operator directive requires:
+///
+///   (a) FLAG-OFF / ZERO BEHAVIOR CHANGE: the compare never mutates the served
+///       template — the bytes handed in are byte-identical afterward, and a
+///       driver with no oracle/served input changes nothing. (shadow_evaluate
+///       takes const refs; on_serve copies.)
+///   (b) FLAG-ON + MISMATCHING ORACLE: when the EMBEDDED arm was SERVED and a
+///       consensus-commitment field (payee / merkleRootMNList / merkleRootQuorums)
+///       diverges from dashd, the distinct SERVED-MISMATCH line + the
+///       shadow-served-mismatch counter fire — while the served template stays
+///       byte-identical to what it would serve without the flag.
+///
+/// Plus the surrounding semantics: a MATCH agrees on all fields; a fallback
+/// (gate-refused) divergence is MISMATCH but NOT served-mismatch (the fail-closed
+/// gate did its job); an absent / tip-skewed oracle logs no-oracle. The async
+/// runtime driver (worker thread + counters via stats_json) is exercised
+/// end-to-end with a synthetic in-process oracle — no live node needed.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/embedded_shadow_compare.hpp>
+#include <impl/dash/coin/rpc_data.hpp>
+#include <impl/dash/coin/vendor/cbtx.hpp>
+
+#include <core/uint256.hpp>
+#include <core/pack.hpp>
+
+#include <chrono>
+#include <optional>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace dash::coin;
+
+namespace {
+
+std::vector<uint8_t> encode(const vendor::CCbTx& c) {
+    auto stream = ::pack(c);
+    auto sp = stream.get_span();
+    return std::vector<uint8_t>(
+        reinterpret_cast<const uint8_t*>(sp.data()),
+        reinterpret_cast<const uint8_t*>(sp.data()) + sp.size());
+}
+uint256 hashn(uint8_t seed) {
+    uint256 h;
+    auto* b = reinterpret_cast<unsigned char*>(h.begin());
+    for (int i = 0; i < 32; ++i) b[i] = static_cast<uint8_t>(seed + i);
+    return h;
+}
+vendor::CCbTx make_cbtx(uint32_t height, uint8_t mn_seed = 1, uint8_t q_seed = 100) {
+    vendor::CCbTx c;
+    c.nVersion = vendor::CCbTx::VERSION_CLSIG_AND_BALANCE;
+    c.nHeight = static_cast<int32_t>(height);
+    c.merkleRootMNList = hashn(mn_seed);
+    c.merkleRootQuorums = hashn(q_seed);
+    c.creditPoolBalance = 1000;
+    return c;
+}
+DashWorkData make_wd(uint32_t height, const vendor::CCbTx& cbtx,
+                     const std::string& mn_payee) {
+    DashWorkData w;
+    w.m_height = height;
+    w.m_previous_block = hashn(200);   // non-null: not a set-gap
+    w.m_bits = 0x1e0ffff0u;            // non-zero: not a set-gap
+    w.m_coinbase_value = 5'0000'0000ull;
+    w.m_packed_payments = { {"!6a", 1234}, {mn_payee, 100000} };
+    w.m_coinbase_payload = encode(cbtx);
+    return w;
+}
+
+bool has_line_with(const std::vector<std::string>& lines, const std::string& needle) {
+    for (const auto& l : lines)
+        if (l.find(needle) != std::string::npos) return true;
+    return false;
+}
+
+} // namespace
+
+// (a) Pure identical templates -> MATCH, no served-mismatch, one MATCH line.
+TEST(DashShadowCompare, MatchWhenIdentical) {
+    auto cb = make_cbtx(2500000);
+    auto emb = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    auto dref = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+
+    auto o = shadow_evaluate(WorkSource::Embedded, emb, dref);
+    EXPECT_EQ(o.kind, ShadowOutcome::Kind::Match);
+    EXPECT_FALSE(o.served_mismatch);
+    EXPECT_TRUE(has_line_with(o.log_lines, "[SHADOW] h=2500000 MATCH"));
+
+    ShadowCounters c;
+    c.apply(o);
+    EXPECT_EQ(c.shadow_match, 1u);
+    EXPECT_EQ(c.shadow_served_mismatch, 0u);
+}
+
+// (b) EMBEDDED SERVED + commitment-field divergence -> SERVED-MISMATCH line +
+// counter, and the served template bytes are UNTOUCHED by the compare.
+TEST(DashShadowCompare, ServedMismatchOnCommitmentDivergence) {
+    auto emb_cb  = make_cbtx(2500000, /*mn_seed=*/1,  /*q_seed=*/100);
+    auto dref_cb = make_cbtx(2500000, /*mn_seed=*/9,  /*q_seed=*/100); // mnlist differs
+    auto emb  = make_wd(2500000, emb_cb,  "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    auto dref = make_wd(2500000, dref_cb, "yMNaddrBBBBBBBBBBBBBBBBBBBBB");     // payee differs
+
+    // Snapshot the served template BEFORE the compare (zero-behavior-change proof).
+    const auto payload_before = emb.m_coinbase_payload;
+    const auto payments_before = emb.m_packed_payments;
+
+    auto o = shadow_evaluate(WorkSource::Embedded, emb, dref);
+
+    // Served bytes untouched — the diagnostic never alters what gets served.
+    EXPECT_EQ(emb.m_coinbase_payload, payload_before);
+    ASSERT_EQ(emb.m_packed_payments.size(), payments_before.size());
+    EXPECT_EQ(emb.m_packed_payments[1].payee, payments_before[1].payee);
+
+    EXPECT_EQ(o.kind, ShadowOutcome::Kind::Mismatch);
+    EXPECT_TRUE(o.served_mismatch);
+    EXPECT_TRUE(has_line_with(o.log_lines, "SERVED-MISMATCH field=payee"));
+    EXPECT_TRUE(has_line_with(o.log_lines, "SERVED-MISMATCH field=merkleRootMNList"));
+
+    ShadowCounters c;
+    c.apply(o);
+    EXPECT_EQ(c.shadow_served_mismatch, 1u);
+    EXPECT_EQ(c.shadow_mismatch_by_field["payee"], 1u);
+    EXPECT_EQ(c.shadow_mismatch_by_field["merkleRootMNList"], 1u);
+    // merkleRootQuorums matched -> no counter for it.
+    EXPECT_EQ(c.shadow_mismatch_by_field.count("merkleRootQuorums"), 0u);
+}
+
+// A gate-REFUSED height (source == DashdFallback) with the SAME divergence is a
+// plain MISMATCH, NOT a SERVED-MISMATCH: nothing wrong was served.
+TEST(DashShadowCompare, FallbackDivergenceIsNotServedMismatch) {
+    auto emb_cb  = make_cbtx(2500000, /*mn_seed=*/1);
+    auto dref_cb = make_cbtx(2500000, /*mn_seed=*/9);
+    auto emb  = make_wd(2500000, emb_cb,  "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    auto dref = make_wd(2500000, dref_cb, "yMNaddrBBBBBBBBBBBBBBBBBBBBB");
+
+    auto o = shadow_evaluate(WorkSource::DashdFallback, emb, dref);
+    EXPECT_EQ(o.kind, ShadowOutcome::Kind::Mismatch);
+    EXPECT_FALSE(o.served_mismatch);
+    EXPECT_TRUE(has_line_with(o.log_lines, "MISMATCH field=payee"));
+    EXPECT_FALSE(has_line_with(o.log_lines, "SERVED-MISMATCH"));
+
+    ShadowCounters c;
+    c.apply(o);
+    EXPECT_EQ(c.shadow_served_mismatch, 0u);
+    EXPECT_EQ(c.shadow_mismatch_by_field["payee"], 1u);
+}
+
+// Absent oracle -> no-oracle line + counter.
+TEST(DashShadowCompare, NoOracleWhenAbsent) {
+    auto cb = make_cbtx(2500000);
+    auto emb = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+
+    auto o = shadow_evaluate(WorkSource::Embedded, emb, std::nullopt);
+    EXPECT_EQ(o.kind, ShadowOutcome::Kind::NoOracle);
+    EXPECT_TRUE(has_line_with(o.log_lines, "[SHADOW] h=2500000 no-oracle"));
+
+    ShadowCounters c;
+    c.apply(o);
+    EXPECT_EQ(c.shadow_no_oracle, 1u);
+}
+
+// Tip-skew (dashd template at a different height) -> no-oracle for THIS height,
+// never a false all-fields divergence.
+TEST(DashShadowCompare, TipSkewIsNoOracle) {
+    auto emb_cb  = make_cbtx(2500000);
+    auto dref_cb = make_cbtx(2500001);
+    auto emb  = make_wd(2500000, emb_cb,  "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    auto dref = make_wd(2500001, dref_cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+
+    auto o = shadow_evaluate(WorkSource::Embedded, emb, dref);
+    EXPECT_EQ(o.kind, ShadowOutcome::Kind::NoOracle);
+    EXPECT_TRUE(has_line_with(o.log_lines, "no-oracle reason=tip-skew"));
+}
+
+// End-to-end async DRIVER: on_serve enqueues and returns immediately (off the
+// hot path); a worker thread fetches the (synthetic) oracle, compares, and the
+// counter surfaces via stats_json — the monitor/dashboard read path.
+TEST(DashShadowCompare, DriverAsyncServedMismatchSurfacesCounter) {
+    auto emb_cb  = make_cbtx(2500000, /*mn_seed=*/1);
+    auto dref_cb = make_cbtx(2500000, /*mn_seed=*/9);
+    auto served  = make_wd(2500000, emb_cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    // A synthetic dashd oracle that diverges on the payee (commitment field).
+    auto dref    = make_wd(2500000, dref_cb, "yMNaddrBBBBBBBBBBBBBBBBBBBBB");
+
+    EmbeddedShadowCompare probe(
+        [dref]() -> std::optional<DashWorkData> { return dref; });
+
+    const auto payload_before = served.m_coinbase_payload;
+    probe.on_serve(WorkSource::Embedded, served);   // enqueue-only, never blocks
+    // The served template we still hold is unchanged (const-ref contract).
+    EXPECT_EQ(served.m_coinbase_payload, payload_before);
+
+    // Poll the counter surface until the worker processes the sample.
+    bool fired = false;
+    for (int i = 0; i < 200 && !fired; ++i) {
+        auto j = probe.stats_json();
+        if (j.value("shadow-served-mismatch", 0u) == 1u) fired = true;
+        else std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    EXPECT_TRUE(fired);
+    auto j = probe.stats_json();
+    EXPECT_EQ(j["shadow-served-mismatch"], 1u);
+    EXPECT_EQ(j["mode"], "embedded-shadow-compare");
+}


### PR DESCRIPTION
## What

Adds `--embedded-shadow-compare`: a LIVE embedded-vs-dashd block-template **shadow-compare DIAGNOSTIC** for the DASH lane. On every block-template SERVE resolution it best-effort obtains dashd's `getblocktemplate` for the **same height**, field-compares it against the served template, and logs one self-describing `[SHADOW]` line plus counters.

**This is a diagnostic tool, explicitly NOT a serve gate.** It is separate from the existing `EmbeddedOracleShadow` graduation gate (`--embedded-oracle-shadow`): that one is tip-triggered and drives a revocable "safe to disable dashd" verdict; this one is serve-triggered, keeps no graduation state, and can never change what is served.

## Hard constraints (all met)

1. **ZERO behavior change to the serve path.** The probe only ENQUEUES a copy of the just-resolved template and returns; it never selects, blocks, delays, or alters the served bytes. `shadow_evaluate()` takes const refs. The hook sits in `DASHWorkSource::resource_template_now()` right after the arm decision and **before** the served template is moved out, so the served bytes are visibly untouched.
2. **Never adds latency to the miner-facing response.** The dashd oracle fetch runs on a dedicated **worker thread**, entirely off the hot path (coalescing to the newest pending serve). A slow/hung/absent dashd logs `no-oracle`; the miner response never waits.
3. **Flag-gated, default OFF.** Only meaningful when a dashd RPC oracle is reachable; a strict no-op in pure-daemonless mode (probe not even constructed).
4. **DASH lane only.** New logic lives in `src/impl/dash/coin/embedded_shadow_compare.hpp`. No cross-coin files; no `core/` changes (counters surface via `[SHADOW]` log lines + `stats_json()`).

## What it compares & emits

Validity-bearing fields: coinbase **payee**, **merkleRootMNList**, **merkleRootQuorums**, cbTx **height** + **version**, and the (BIP34) coinbase **scriptSig height**.

- `[SHADOW] h=H MATCH`
- `[SHADOW] h=H MISMATCH field=<name> embedded=<val> dashd=<val>` (one line per diverging field)
- `[SHADOW] h=H no-oracle` (dashd unavailable / tip-skew)
- `[SHADOW] h=H SERVED-MISMATCH field=...` — the distinct high-value signal for the **only** combination that would indicate a real validity problem: the embedded arm was **SERVED** (not gate-refused) AND a consensus-commitment field (payee / merkleRootMNList / merkleRootQuorums) diverged.

Counters `shadow-match`, `shadow-no-oracle`, `shadow-served-mismatch`, `shadow-mismatch-<field>`.

A MISMATCH is DIAGNOSTIC EVIDENCE, not proof of a bad served block — the fail-closed gate may have refused the height (nothing wrong was served) and dashd's template can legitimately differ in tx selection. Documented in code.

## Tests

Hermetic KATs folded into the already-allowlisted `test_dash_embedded_gbt` target (`test_dash_embedded_shadow_compare.cpp`): MATCH on identical templates; **SERVED-MISMATCH line + counter fire on a served commitment-field divergence while the served template stays byte-identical**; a gate-refused (fallback) divergence is MISMATCH but NOT served-mismatch; absent / tip-skewed oracle logs `no-oracle`; and the async driver surfaces the counter via `stats_json()`. Fails to compile on master (the class does not exist there). Allowlist guard passes.

## Scope note

Separate from #1102 (body-fetch fix): does not touch `p2p_client.hpp`; the `main_dash.cpp` edits are confined to flag plumbing + serve/template wiring + teardown, in distinct regions.