### PR TITLE
dash(embedded): pay the MN operator-reward split; fail closed when unprovable (h=2516595 bad-cb-payee)

### DIFF
--- a/src/impl/dash/coin/embedded_gbt.hpp
+++ b/src/impl/dash/coin/embedded_gbt.hpp
@@ -366,38 +366,63 @@ inline DashWorkData build_embedded_workdata(
         w.m_packed_payments.push_back(std::move(burn));
     }
 
-    // MN payee → packed_payment. dashcore GBT returns "payee" as a
+    // MN payee → packed_payment(s). dashcore GBT returns "payee" as a
     // base58 address. We use script_to_address() to produce the same
     // wire form for standard P2PKH/P2SH scripts. Unrecognized script
     // types fall back to the c2pool "!hex" raw-script convention from
     // share_check.hpp::decode_payee_script — preserves bytes for
     // share_check verification while keeping the GBT API clean.
+    auto script_to_payee_token = [&](const std::vector<unsigned char>& script) {
+        // Dash mainnet has no bech32 (P2WPKH/P2WSH inactive); pass
+        // empty hrp so script_to_address() falls through cleanly.
+        std::string addr = ::core::script_to_address(
+            script, /*bech32_hrp=*/"",
+            address_version, address_p2sh_version);
+        if (!addr.empty()) return addr;
+        // Non-standard script: fall back to !hex.
+        std::string hex_script;
+        hex_script.reserve(script.size() * 2 + 1);
+        hex_script.push_back('!');
+        static const char* digits = "0123456789abcdef";
+        for (uint8_t b : script) {
+            hex_script.push_back(digits[(b >> 4) & 0xF]);
+            hex_script.push_back(digits[b & 0xF]);
+        }
+        return hex_script;
+    };
     auto expected = mnstates.find_expected_payee();
     if (expected) {
         auto it = mnstates.entries().find(*expected);
         if (it != mnstates.entries().end() && mn_payment > 0) {
-            const auto& script = it->second.scriptPayout.m_data;
-            // Dash mainnet has no bech32 (P2WPKH/P2WSH inactive); pass
-            // empty hrp so script_to_address() falls through cleanly.
-            std::string addr = ::core::script_to_address(
-                script, /*bech32_hrp=*/"",
-                address_version, address_p2sh_version);
-            PackedPayment pp;
-            if (!addr.empty()) {
-                pp.payee = std::move(addr);
-            } else {
-                // Non-standard script: fall back to !hex.
-                std::string hex_script;
-                hex_script.reserve(script.size() * 2);
-                static const char* digits = "0123456789abcdef";
-                for (uint8_t b : script) {
-                    hex_script.push_back(digits[(b >> 4) & 0xF]);
-                    hex_script.push_back(digits[b & 0xF]);
-                }
-                pp.payee = "!" + hex_script;
+            const auto& st = it->second;
+            // ── Operator-reward split (incident h=2516595 bad-cb-payee) ──
+            // dashd masternode/payments.cpp GetBlockTxOuts pays the MN
+            // share as a SET: when the scheduled MN registered an operator
+            // share (nOperatorReward bps, ProRegTx) AND its operator set a
+            // payout script (ProUpServTx), the coinbase carries
+            //   owner   : mnShare - floor(mnShare * bps / 10000)
+            //   operator: floor(mnShare * bps / 10000)
+            // in that order, and CheckMasternodePayments validates scripts
+            // AND amounts. h=2516595 (mn 0037c2c5…, bps=800) was rejected
+            // bad-cb-payee precisely because this builder paid the whole
+            // share to the owner. The truncating division is dashd's own;
+            // do NOT "fix" the rounding.
+            const int64_t operator_payment = st.operator_payment_of(mn_payment);
+            const int64_t owner_payment    = mn_payment - operator_payment;
+            if (owner_payment > 0) {
+                PackedPayment pp;
+                pp.payee  = script_to_payee_token(st.scriptPayout.m_data);
+                pp.amount = static_cast<uint64_t>(owner_payment);
+                w.m_packed_payments.push_back(std::move(pp));
             }
-            pp.amount = static_cast<uint64_t>(mn_payment);
-            w.m_packed_payments.push_back(std::move(pp));
+            // dashd: `if (operatorReward > 0) emplace_back(...)` — a split
+            // whose floor rounds to zero emits NO operator output.
+            if (operator_payment > 0) {
+                PackedPayment pp;
+                pp.payee  = script_to_payee_token(st.scriptOperatorPayout.m_data);
+                pp.amount = static_cast<uint64_t>(operator_payment);
+                w.m_packed_payments.push_back(std::move(pp));
+            }
         }
     }
 

--- a/src/impl/dash/coin/embedded_oracle_shadow.hpp
+++ b/src/impl/dash/coin/embedded_oracle_shadow.hpp
@@ -220,6 +220,33 @@ inline uint64_t platform_burn_amount(const std::vector<PackedPayment>& pps) {
     for (const auto& p : pps) if (p.payee == "!6a") return p.amount;
     return 0;
 }
+/// Incident h=2516595 (bad-cb-payee): FEE-INVARIANT digest of the MN payout
+/// SET — owner payee, operator payee, and the operator-reward bps derived
+/// from this side's own amounts (bps = ceil(op*10000/(own+op)), emitted only
+/// when dashd's truncating recomputation floor((own+op)*bps/10000) == op
+/// reproduces the amount exactly; a non-split second output practically
+/// never passes that round-trip). Raw amounts differ across sides whenever
+/// the selected tx sets differ (that is why payee_amounts is Informational),
+/// but the SPLIT — payees and ratio — must be identical, so this field is
+/// counted Equality without fee flap. The owner-address-only compare this
+/// widens is exactly what let h=2516595's missing operator output through.
+inline std::string mn_payout_split_shape_str(const std::vector<PackedPayment>& pps) {
+    std::vector<const PackedPayment*> nb;
+    for (const auto& p : pps) if (p.payee != "!6a") nb.push_back(&p);
+    std::string s = "n=" + std::to_string(nb.size());
+    if (nb.empty()) return s + ";owner=-";
+    s += ";owner=" + nb[0]->payee + ";operator=";
+    if (nb.size() < 2) return s + "-;bps=-";
+    const int64_t own   = static_cast<int64_t>(nb[0]->amount);
+    const int64_t op    = static_cast<int64_t>(nb[1]->amount);
+    const int64_t total = own + op;
+    if (total > 0 && op > 0) {
+        const int64_t bps = (op * 10000 + total - 1) / total;   // ceil
+        if (bps >= 1 && bps <= 10000 && (total * bps) / 10000 == op)
+            return s + nb[1]->payee + ";bps=" + std::to_string(bps);
+    }
+    return s + "-;bps=-";   // 2nd output is not an operator split
+}
 inline uint64_t sum_fees(const std::vector<uint64_t>& fees) {
     uint64_t s = 0; for (auto f : fees) s += f; return s;
 }
@@ -267,6 +294,12 @@ inline std::vector<FieldResult> compare_templates(
     eq("mintime",  Regime::Equality, true, std::to_string(emb.m_mintime),std::to_string(dashd.m_mintime));
     eq("payee_identities", Regime::Equality, true,
        payee_identity_str(emb.m_packed_payments), payee_identity_str(dashd.m_packed_payments));
+    // Incident h=2516595: the FULL MN payout SET (owner + operator + ratio),
+    // not the owner address alone. Fee-invariant by construction, so it may
+    // count as Equality even when the two sides selected different tx sets.
+    eq("mn_payout_split_shape", Regime::Equality, true,
+       mn_payout_split_shape_str(emb.m_packed_payments),
+       mn_payout_split_shape_str(dashd.m_packed_payments));
     eq("platform_burn_amount", Regime::Equality, true,
        std::to_string(e.platform_reward), std::to_string(d.platform_reward));
     // Normalized subsidy core = coinbasevalue − own fees (fees stripped) — this

--- a/src/impl/dash/coin/mn_checkpoint.hpp
+++ b/src/impl/dash/coin/mn_checkpoint.hpp
@@ -507,6 +507,15 @@ inline MnCheckpoint parse_mn_checkpoint(const std::string& payload,
             // DERIVED, never stored — same projection mn_seed.hpp makes.
             mn.isValid = (mn.nPoSeBanHeight == 0);
 
+            // The checkpoint format is generated from `protx list registered
+            // true` and carries the payout split EXPLICITLY (field 11 = bps,
+            // field 13 = operator script, `-` = provably unset). A row that
+            // reaches here has both fields validated above — the payout SET
+            // is proven (incident h=2516595: this very anchor carried mn
+            // 0037c2c5… bps=800 + its operator script; the omission was in
+            // the consumer, not the data).
+            mn.payoutSplitProvenance = MNState::SPLIT_KNOWN;
+
             if (!seen_protx.insert(protx).second)
                 return fail("duplicate proTxHash " + protx.GetHex().substr(0, 16)
                             + " on line " + std::to_string(lineno));

--- a/src/impl/dash/coin/mn_seed.hpp
+++ b/src/impl/dash/coin/mn_seed.hpp
@@ -103,6 +103,20 @@ struct MnSeedStats {
     // ZERO here on mainnet means the source was `valid`-filtered, so no
     // ProUpServTx revive can ever find an entry to revive.
     size_t pose_banned{0};
+    // ── Payout-split provenance (incident h=2516595 bad-cb-payee) ────────
+    // Entries whose operator-reward split could NOT be proven from this
+    // seed. Each lands as SPLIT_UNKNOWN and the serve gate refuses the
+    // height it is scheduled at (cause=mn-payout-split-unprovable) until a
+    // canonical payment reveals the split (pass-3 adoption, ~one payment
+    // cycle worst case). dashd's protx ToJson ALWAYS emits operatorReward,
+    // so a nonzero split_unproven on a real `protx list` seed means the
+    // source was filtered/reshaped — a seed-quality defect made visible,
+    // not a statistic.
+    size_t split_unproven{0};      // operatorReward key absent
+    size_t operator_addr_undecodable{0};  // address present, decode failed
+    // MNs seeded with a >0 operator share (mainnet ~6.8%: 203 of 2974 at
+    // anchor 2513000) — the population the h=2516595 class lives in.
+    size_t with_operator_split{0};
 };
 
 namespace detail {
@@ -245,9 +259,23 @@ inline std::vector<std::pair<uint256, MNState>> parse_protx_list_seed(
         }
         // JSON reports operatorReward as a percentage double (dashd ToJson:
         // nOperatorReward / 100.0); recover the internal 0..10000 fixed-point.
-        if (e.contains("operatorReward") && e["operatorReward"].is_number())
+        //
+        // PROVENANCE (incident h=2516595): dashd's ToJson emits the
+        // operatorReward key unconditionally, so its ABSENCE means this seed
+        // was filtered/reshaped and the split cannot be proven from it. Such
+        // an entry is seeded SPLIT_UNKNOWN — present, payable in the queue
+        // projection, but the serve gate refuses the height it is scheduled
+        // at (cause=mn-payout-split-unprovable) rather than build a coinbase
+        // dashd deterministically rejects (bad-cb-payee).
+        if (e.contains("operatorReward") && e["operatorReward"].is_number()) {
             mn.nOperatorReward = static_cast<uint16_t>(
                 std::llround(e["operatorReward"].get<double>() * 100.0));
+            mn.payoutSplitProvenance = MNState::SPLIT_KNOWN;
+            if (mn.nOperatorReward > 0) ++st.with_operator_split;
+        } else {
+            mn.payoutSplitProvenance = MNState::SPLIT_UNKNOWN;
+            ++st.split_unproven;
+        }
         const std::string type_str = e.value("type", "Regular");
         mn.nType = (type_str == "Evo" || type_str == "HighPerformance")
                        ? vendor::MnType::EVO
@@ -290,13 +318,31 @@ inline std::vector<std::pair<uint256, MNState>> parse_protx_list_seed(
             if (stats) *stats = st;
             return {};
         }
-        // Operator payout (optional, best-effort — not payee-critical today;
-        // operator-payout coinbase matching is a documented non-goal of the
-        // state machine).
+        // Operator payout script. PAYEE-CRITICAL since incident h=2516595:
+        // when nOperatorReward > 0 and this script is set, dashd's coinbase
+        // pays TWO MN outputs (owner + floor(mnShare*bps/10000) to the
+        // operator) and CheckMasternodePayments validates the full set —
+        // an omitted operator output is a deterministically rejected block.
+        // Consensus (bad-protx-operator-payee) only admits P2PKH/P2SH here,
+        // so a present address that fails to decode is OUR defect, not an
+        // exotic script: fail the ENTRY closed (SPLIT_UNKNOWN, the serve
+        // gate refuses its heights) instead of silently seeding an empty
+        // script that would build a single-output coinbase.
         const std::string op_addr = s.value("operatorPayoutAddress", "");
-        if (!op_addr.empty())
+        if (!op_addr.empty()) {
             mn.scriptOperatorPayout.m_data = detail::payout_address_to_script(
                 op_addr, address_version, address_p2sh_version);
+            if (mn.scriptOperatorPayout.m_data.empty()) {
+                ++st.operator_addr_undecodable;
+                mn.payoutSplitProvenance = MNState::SPLIT_UNKNOWN;
+                LOG_WARNING << "[MN-SEED] undecodable operatorPayoutAddress '"
+                            << op_addr << "' for proTx "
+                            << proTxHash.GetHex().substr(0, 16)
+                            << " -- entry seeded SPLIT_UNKNOWN (serve gate"
+                               " refuses its scheduled heights;"
+                               " cause=mn-payout-split-unprovable)";
+            }
+        }
 
         // Governance keys (best-effort; not consumed by payee projection).
         mn.keyIDOwner  = detail::hash160_hex_to_uint160(

--- a/src/impl/dash/coin/mn_state_db.hpp
+++ b/src/impl/dash/coin/mn_state_db.hpp
@@ -88,6 +88,59 @@ struct MNState
     uint16_t                                       platformP2PPort{0};
     uint16_t                                       platformHTTPPort{0};
 
+    // ── Payout-split provenance (incident h=2516595 bad-cb-payee) ──────
+    // dashd's coinbase pays the MN share as a SET: owner scriptPayout plus,
+    // when nOperatorReward>0 AND scriptOperatorPayout is set, an operator
+    // output of floor(mnShare * nOperatorReward / 10000) duffs
+    // (masternode/payments.cpp GetBlockTxOuts). CheckMasternodePayments
+    // validates the FULL set — scripts AND amounts — so building from a
+    // state whose split fields are not PROVEN correct is a deterministic
+    // bad-cb-payee rejection of a WON block. The SML wire can never prove
+    // them (CSimplifiedMNListEntry keeps scriptPayout/scriptOperatorPayout
+    // "mem-only", evo/simplifiedmns.h), so provenance is tracked per entry:
+    //
+    //   SPLIT_UNKNOWN — no ingest path has proven the split fields. The
+    //       serve gate REFUSES to serve a height whose scheduled payee
+    //       carries this (cause=mn-payout-split-unprovable); fallback
+    //       serves. Entries land here only via a seed that omitted the
+    //       operator fields (filtered/legacy source) or an observed
+    //       canonical payout that CONTRADICTED our fields (demotion —
+    //       the chain is authoritative, our knowledge was stale).
+    //   SPLIT_KNOWN — fields are authoritative: checkpoint row (format
+    //       carries bps + operator script explicitly), dashd protx-list
+    //       seed row with the operatorReward key present, a ProRegTx we
+    //       parsed from a block body (bps is immutable after
+    //       registration; the operator script may only be set later by a
+    //       ProUpServTx, which we also parse), or an observed canonical
+    //       coinbase whose 2-output MN payment uniquely determines bps
+    //       (interval width 10000/mnShare << 1).
+    //
+    // NOTE: (nOperatorReward>0, scriptOperatorPayout empty, SPLIT_KNOWN)
+    // is a VALID single-output state — consensus (bad-protx-operator-payee)
+    // only admits setting the operator script when a reward share exists,
+    // and dashd pays a single owner output while it is unset.
+    static constexpr uint8_t SPLIT_UNKNOWN = 0;
+    static constexpr uint8_t SPLIT_KNOWN   = 1;
+    uint8_t                                        payoutSplitProvenance{SPLIT_UNKNOWN};
+
+    bool payout_split_provable() const
+    {
+        return payoutSplitProvenance == SPLIT_KNOWN;
+    }
+
+    /// dashd masternode/payments.cpp GetBlockTxOuts, bit-exact:
+    ///   operatorReward = (masternodeReward * nOperatorReward) / 10000
+    ///   masternodeReward -= operatorReward   (owner keeps the remainder)
+    /// gated on nOperatorReward != 0 && scriptOperatorPayout non-empty;
+    /// the operator output is only emitted when its amount > 0.
+    int64_t operator_payment_of(int64_t mn_payment) const
+    {
+        if (nOperatorReward == 0 || nOperatorReward > 10000) return 0;
+        if (scriptOperatorPayout.m_data.empty()) return 0;
+        if (mn_payment <= 0) return 0;
+        return (mn_payment * static_cast<int64_t>(nOperatorReward)) / 10000;
+    }
+
     C2POOL_SERIALIZE_METHODS(MNState)
     {
         READWRITE(obj.nVersion,
@@ -109,7 +162,8 @@ struct MNState
                   obj.isValid,
                   obj.platformNodeID,
                   obj.platformP2PPort,
-                  obj.platformHTTPPort);
+                  obj.platformHTTPPort,
+                  obj.payoutSplitProvenance);
     }
 
     bool operator==(const MNState& r) const
@@ -131,7 +185,8 @@ struct MNState
             && scriptOperatorPayout.m_data == r.scriptOperatorPayout.m_data
             && platformNodeID == r.platformNodeID
             && platformP2PPort == r.platformP2PPort
-            && platformHTTPPort == r.platformHTTPPort;
+            && platformHTTPPort == r.platformHTTPPort
+            && payoutSplitProvenance == r.payoutSplitProvenance;
     }
 };
 
@@ -142,9 +197,32 @@ public:
                        const ::core::LevelDBOptions& opts = {})
         : m_store(db_path, opts) {}
 
+    // Store format version. v2 appended MNState.payoutSplitProvenance
+    // (incident h=2516595 bad-cb-payee). A v1 store's entries would fail
+    // to deserialize one by one and be silently SKIPPED by load_all —
+    // leaving a partial set under a believed best_height cursor. Make the
+    // migration explicit instead: on format mismatch wipe the store and
+    // let the normal checkpoint/seed reseed rebuild it (the same
+    // fail-closed path a payee desync takes).
+    static constexpr uint32_t kFormatVersion = 2;
+
     bool open()
     {
         if (!m_store.open()) return false;
+        const uint32_t stored = load_format_version();
+        if (stored != kFormatVersion) {
+            const bool had_rows =
+                !m_store.list_keys(std::string(1, 'M'), /*limit=*/1).empty();
+            if (had_rows || stored != 0) {
+                LOG_INFO << "[MNS-DB] format v" << stored << " -> v"
+                         << kFormatVersion
+                         << " migration: clearing store (payout-split "
+                            "provenance added); the checkpoint/seed reseed "
+                            "rebuilds it";
+                if (!clear()) return false;
+            }
+            store_format_version();
+        }
         load_best_state();
         LOG_INFO << "[MNS-DB] opened best_height=" << m_best_height
                  << " best_hash=" << m_best_hash.GetHex().substr(0, 16);
@@ -273,6 +351,29 @@ private:
     }
 
     static std::string make_state_key() { return std::string(1, 'B'); }
+
+    static std::string make_format_key() { return std::string(1, 'F'); }
+
+    // 0 = no format key (a v1 store, or a fresh directory).
+    uint32_t load_format_version()
+    {
+        std::vector<uint8_t> data;
+        if (!m_store.get(make_format_key(), data) || data.size() < 4) return 0;
+        return uint32_t(data[0])
+             | (uint32_t(data[1]) <<  8)
+             | (uint32_t(data[2]) << 16)
+             | (uint32_t(data[3]) << 24);
+    }
+
+    void store_format_version()
+    {
+        std::vector<uint8_t> out(4);
+        out[0] = static_cast<uint8_t>( kFormatVersion        & 0xFF);
+        out[1] = static_cast<uint8_t>((kFormatVersion >>  8) & 0xFF);
+        out[2] = static_cast<uint8_t>((kFormatVersion >> 16) & 0xFF);
+        out[3] = static_cast<uint8_t>((kFormatVersion >> 24) & 0xFF);
+        m_store.put(make_format_key(), out);
+    }
 
     static std::vector<uint8_t> encode_best_state(const uint256& hash,
                                                   uint32_t height)

--- a/src/impl/dash/coin/mn_state_machine.hpp
+++ b/src/impl/dash/coin/mn_state_machine.hpp
@@ -243,6 +243,28 @@ public:
         // disagreed with the coinbase AND the SML proved the disagreement was
         // a post-anchor consensus PoSe ban rather than a real desync.
         size_t sml_recovered{0};
+        // ── Operator-reward split observation (incident h=2516595) ───────
+        // The canonical coinbase is the network's own attestation of the
+        // paid MN's CURRENT payout set. When the projected payee matched,
+        // pass 3 also reads the split it was paid with:
+        //
+        // split_adopted: this MN's split provenance was UNKNOWN (filtered/
+        //          legacy seed) and the observed payment proved it — a
+        //          2-output MN payment uniquely determines the bps
+        //          (interval width 10000/mnShare << 1: bps =
+        //          ceil(op*10000/(own+op)), floor-verified), a
+        //          single-output payment proves the operator script is
+        //          currently unset. The entry was promoted to SPLIT_KNOWN.
+        // split_desync: the observed payout set CONTRADICTED a SPLIT_KNOWN
+        //          entry (stale operator script / wrong bps — the exact
+        //          bad-cb-payee class of h=2516595). The entry was demoted
+        //          to SPLIT_UNKNOWN, so the serve gate refuses it
+        //          (cause=mn-payout-split-unprovable) until a fresh
+        //          observation or ProTx re-proves it. NON-ZERO MEANS THIS
+        //          MACHINE WOULD HAVE BUILT A REJECTED COINBASE — a
+        //          defect signature, not a statistic.
+        size_t split_adopted{0};
+        size_t split_desync{0};
     };
 
     /// ─────────────────────────────────────────────────────────────────────
@@ -300,6 +322,22 @@ public:
     using SmlValidityFn = std::function<std::optional<bool>(const uint256&)>;
 
     void set_sml_validity_fn(SmlValidityFn fn) { m_sml_validity = std::move(fn); }
+
+    /// Optional superblock-height predicate (same cycle the serve path
+    /// uses). When set, pass-3 payout-split ADOPTION and the 2-output-shape
+    /// demotion are SKIPPED at superblock heights: a funded superblock with
+    /// exactly one treasury payee presents the same unambiguous-looking
+    /// 2-output coinbase shape as an operator split, and a lone treasury
+    /// amount CAN floor-verify against a plausible bps (observed in the
+    /// superblock KATs: a 50/50 payee adopts as bps=5000). The exact-pair
+    /// presence cross-check for KNOWN splits stays active at all heights
+    /// (extra treasury outputs cannot un-match a pair that is present).
+    /// NULL (default) keeps the shape guards only — correct for callers
+    /// that never fold superblock-height coinbases.
+    void set_superblock_height_fn(std::function<bool(uint32_t)> fn)
+    {
+        m_is_superblock_height = std::move(fn);
+    }
     bool has_sml_validity_fn() const { return static_cast<bool>(m_sml_validity); }
 
     /// Cumulative budget for SML-attested exclusions over the lifetime of
@@ -1135,6 +1173,11 @@ public:
                 st.nOperatorReward   = ptx.nOperatorReward;
                 st.scriptPayout.m_data = ptx.scriptPayout.m_data;
                 st.netInfo           = ptx.netInfo;
+                // The ProRegTx IS the split's registration: nOperatorReward
+                // is immutable from here on and scriptOperatorPayout is
+                // provably unset until a ProUpServTx (which we also parse)
+                // sets it. The payout set is PROVEN by construction.
+                st.payoutSplitProvenance = MNState::SPLIT_KNOWN;
                 if (ptx.nType == vendor::MnType::EVO) {
                     st.platformNodeID    = ptx.platformNodeID;
                     st.platformP2PPort   = ptx.platformP2PPort;
@@ -1188,6 +1231,26 @@ public:
                 it->second.netInfo = ptx.netInfo;
                 it->second.scriptOperatorPayout.m_data =
                     ptx.scriptOperatorPayout.m_data;
+                // Consensus (bad-protx-operator-payee) only ACCEPTS a
+                // ProUpServTx carrying an operator payout script when the
+                // MN's registered nOperatorReward != 0. If we hold bps==0
+                // while the chain just proved bps>0, our bps is a
+                // filtered/legacy-seed zero — the split is UNPROVEN until
+                // the next canonical payment reveals it (pass-3 adoption).
+                if (!ptx.scriptOperatorPayout.m_data.empty()
+                    && it->second.nOperatorReward == 0
+                    && it->second.payoutSplitProvenance
+                           == MNState::SPLIT_KNOWN) {
+                    it->second.payoutSplitProvenance = MNState::SPLIT_UNKNOWN;
+                    LOG_WARNING
+                        << "[MNS-SM] ProUpServTx h=" << height << " mn="
+                        << ptx.proTxHash.GetHex().substr(0, 16)
+                        << " sets an operator payout script while this state"
+                           " holds nOperatorReward=0 — consensus proves the"
+                           " real bps>0. Split demoted to SPLIT_UNKNOWN"
+                           " (cause=mn-payout-split-unprovable when"
+                           " scheduled) until observed.";
+                }
                 if (ptx.nType == vendor::MnType::EVO) {
                     it->second.platformNodeID = ptx.platformNodeID;
                     if (ptx.nVersion < vendor::ProTxVersion::EXT_ADDR) {
@@ -1259,9 +1322,24 @@ public:
                 it->second.keyIDVoting      = ptx.keyIDVoting;
                 it->second.scriptPayout.m_data = ptx.scriptPayout.m_data;
                 if (key_changed) {
-                    // dashcore: ResetOperatorFields + BanIfNotBanned.
+                    // dashcore: ResetOperatorFields + BanIfNotBanned
+                    // (deterministicmns.cpp; dmnstate.h ResetOperatorFields
+                    // clears addr, scriptOperatorPayout, nRevocationReason,
+                    // platformNodeID — the new operator must ProUpServTx its
+                    // own service + payout script). The old code banned but
+                    // KEPT the previous operator's payout script; had the MN
+                    // been revalidated (SML fold) and scheduled, the builder
+                    // would have paid a script dashd no longer pays —
+                    // the h=2516595 bad-cb-payee class. The split itself
+                    // stays PROVEN: bps is immutable, and the operator
+                    // script is now provably unset.
                     it->second.nPoSeBanHeight = height;
                     it->second.isValid        = false;
+                    it->second.netInfo        = vendor::LegacyNetService{};
+                    it->second.scriptOperatorPayout.m_data.clear();
+                    it->second.nRevocationReason =
+                        vendor::CProUpRevTx::REASON_NOT_SPECIFIED;
+                    it->second.platformNodeID = uint160{};
                 }
                 ++r.updated;
                 break;
@@ -1277,9 +1355,15 @@ public:
                 it->second.nPoSeBanHeight   = height;
                 it->second.isValid          = false;
                 it->second.nRevocationReason = ptx.nReason;
-                // Operator key reset (until a future ProUpServTx
-                // provides a new operator key + revives).
+                // dashcore ResetOperatorFields (dmnstate.h): the revoked
+                // operator's service AND payout script go with the key —
+                // a revived MN's new operator sets its own via
+                // ProUpServTx. Keeping the stale script was the same
+                // pay-a-script-dashd-does-not class as the type-3 case.
                 it->second.pubKeyOperator.fill(0);
+                it->second.netInfo          = vendor::LegacyNetService{};
+                it->second.scriptOperatorPayout.m_data.clear();
+                it->second.platformNodeID   = uint160{};
                 ++r.revoked;
                 break;
               }
@@ -1339,6 +1423,10 @@ public:
             if (it != m_entries.end()) {
                 if (paid_in_cb(it->second.scriptPayout.m_data)) {
                     mark_paid(it);
+                    // The accepted coinbase also attests the paid MN's
+                    // CURRENT operator-reward split — cross-check a KNOWN
+                    // split / prove an UNKNOWN one (incident h=2516595).
+                    observe_payout_split(it, block, height, r);
                 } else if (!recover_from_sml_ban(ranked, height, paid_in_cb,
                                                  mark_paid, r)) {
                     r.payee_desync = true;
@@ -1364,6 +1452,159 @@ public:
     }
 
 private:
+    // ─────────────────────────────────────────────────────────────────────
+    // observe_payout_split — read the paid MN's split off the canonical
+    // coinbase (incident h=2516595 bad-cb-payee)
+    // ─────────────────────────────────────────────────────────────────────
+    //
+    // Precondition: pass 3 verified the coinbase pays `it`'s scriptPayout —
+    // the projection matched, so the coinbase's MN payment outputs describe
+    // THIS MN's current payout set as dashd computed it
+    // (masternode/payments.cpp GetBlockTxOuts: owner output, then — iff
+    // nOperatorReward != 0 and scriptOperatorPayout is set — an operator
+    // output of floor(mnShare * bps / 10000)).
+    //
+    // Superblock safety WITHOUT knowing the superblock cycle: the demotion
+    // checks are pure presence/consistency scans over ALL coinbase outputs
+    // (extra treasury outputs cannot un-match a pair that is present), and
+    // the adoption paths require an UNAMBIGUOUS output shape — exactly one
+    // (single-owner proof) or exactly two (split derivation, floor-verified:
+    // an unrelated output passes floor-consistency for a ceil-derived bps
+    // only with probability ~(own+op)/10000 per duff-exactness, ~1e-4) non-
+    // OP_RETURN outputs — which a funded superblock coinbase (many treasury
+    // outputs) never presents.
+    void observe_payout_split(Entries::iterator it, const BlockType& block,
+                              uint32_t height, ApplyResult& r)
+    {
+        MNState& st = it->second;
+        if (st.scriptPayout.m_data.empty()) return;
+        const auto& outs = block.m_txs[0].vout;
+
+        // Shape scan: non-OP_RETURN outputs; owner-script matches.
+        std::vector<size_t> owner_idx, other_idx;
+        for (size_t i = 0; i < outs.size(); ++i) {
+            const auto& sc = outs[i].scriptPubKey.m_data;
+            if (sc.empty() || sc[0] == 0x6a) continue;   // credit-pool burn / OP_RETURN
+            if (sc == st.scriptPayout.m_data) owner_idx.push_back(i);
+            else                              other_idx.push_back(i);
+        }
+        if (owner_idx.empty()) return;   // unreachable: paid_in_cb passed
+
+        const auto floor_split = [](int64_t total, uint16_t bps) -> int64_t {
+            return (total * static_cast<int64_t>(bps)) / 10000;
+        };
+
+        const bool expect_operator_out =
+            st.nOperatorReward > 0 && st.nOperatorReward <= 10000
+            && !st.scriptOperatorPayout.m_data.empty();
+
+        // Superblock heights: a lone treasury payee presents the same
+        // 2-output shape as an operator split and can floor-verify against
+        // a plausible bps — adoption/shape-demotion are ambiguous there.
+        const bool ambiguous_height =
+            m_is_superblock_height && m_is_superblock_height(height);
+
+        if (st.payoutSplitProvenance == MNState::SPLIT_KNOWN) {
+            if (expect_operator_out) {
+                // The exact (owner, operator) pair must be present and
+                // floor-consistent with OUR bps. Presence-scan is valid at
+                // any height class.
+                // NOTE the operator script MAY equal the owner script (an
+                // operator paid to the owner's address): scan ALL non-burn
+                // outputs as operator candidates, excluding only the output
+                // standing as owner in the current pairing.
+                bool consistent = false;
+                for (size_t oi : owner_idx) {
+                    for (size_t pj = 0; pj < outs.size() && !consistent; ++pj) {
+                        if (pj == oi) continue;
+                        if (outs[pj].scriptPubKey.m_data
+                            != st.scriptOperatorPayout.m_data) continue;
+                        const int64_t total = outs[oi].value + outs[pj].value;
+                        if (floor_split(total, st.nOperatorReward)
+                            == outs[pj].value) consistent = true;
+                    }
+                    if (consistent) break;
+                }
+                if (!consistent) {
+                    ++r.split_desync;
+                    st.payoutSplitProvenance = MNState::SPLIT_UNKNOWN;
+                    LOG_WARNING
+                        << "[MNS-SM] payout-split DESYNC h=" << height
+                        << " mn=" << it->first.GetHex().substr(0, 16)
+                        << ": coinbase does not pay the (owner,operator) set"
+                           " this state predicts (bps=" << st.nOperatorReward
+                        << ") — a template built from it is the h=2516595"
+                           " bad-cb-payee class. Demoted to"
+                           " SPLIT_UNKNOWN (serve gate refuses this payee"
+                           " until re-proven).";
+                }
+            } else if (st.nOperatorReward > 0 && !ambiguous_height
+                       && owner_idx.size() == 1 && other_idx.size() == 1) {
+                // We predict a SINGLE owner output (bps registered but no
+                // operator script known) yet the unambiguous 2-output shape
+                // floor-verifies against OUR bps: the network is paying an
+                // operator script we do not hold — stale knowledge.
+                const int64_t total =
+                    outs[owner_idx[0]].value + outs[other_idx[0]].value;
+                if (floor_split(total, st.nOperatorReward)
+                    == outs[other_idx[0]].value) {
+                    ++r.split_desync;
+                    st.payoutSplitProvenance = MNState::SPLIT_UNKNOWN;
+                    LOG_WARNING
+                        << "[MNS-SM] payout-split DESYNC h=" << height
+                        << " mn=" << it->first.GetHex().substr(0, 16)
+                        << ": coinbase pays an operator output (bps="
+                        << st.nOperatorReward << ") but this state holds no"
+                           " operator script. Demoted to SPLIT_UNKNOWN.";
+                }
+            }
+            return;
+        }
+
+        // SPLIT_UNKNOWN → adoption from the chain's own attestation.
+        if (ambiguous_height) return;   // never adopt off a superblock coinbase
+        if (owner_idx.size() == 1 && other_idx.empty()) {
+            // Exactly one non-burn output and it is the owner: the operator
+            // script is provably unset RIGHT NOW. bps stays as-held; if a
+            // later ProUpServTx sets a script while we hold bps==0, the
+            // type-2 handler re-demotes (consensus proves the real bps>0).
+            st.scriptOperatorPayout.m_data.clear();
+            st.payoutSplitProvenance = MNState::SPLIT_KNOWN;
+            ++r.split_adopted;
+            LOG_INFO << "[MNS-SM] payout-split ADOPTED h=" << height
+                     << " mn=" << it->first.GetHex().substr(0, 16)
+                     << " set=single-owner (observed canonical payout)";
+        } else if (owner_idx.size() == 1 && other_idx.size() == 1) {
+            // Unambiguous 2-output shape: derive bps. A 2-output MN payment
+            // uniquely determines it — bps = ceil(op*10000/total) and the
+            // truncating recomputation must reproduce the operator amount
+            // exactly (interval width 10000/total << 1).
+            const int64_t own   = outs[owner_idx[0]].value;
+            const int64_t op    = outs[other_idx[0]].value;
+            const int64_t total = own + op;
+            if (total > 0 && op > 0) {
+                const int64_t bps = (op * 10000 + total - 1) / total; // ceil
+                if (bps >= 1 && bps <= 10000
+                    && floor_split(total, static_cast<uint16_t>(bps)) == op) {
+                    st.nOperatorReward = static_cast<uint16_t>(bps);
+                    st.scriptOperatorPayout.m_data =
+                        outs[other_idx[0]].scriptPubKey.m_data;
+                    st.payoutSplitProvenance = MNState::SPLIT_KNOWN;
+                    ++r.split_adopted;
+                    LOG_INFO << "[MNS-SM] payout-split ADOPTED h=" << height
+                             << " mn=" << it->first.GetHex().substr(0, 16)
+                             << " bps=" << bps
+                             << " (derived from observed canonical payout,"
+                                " floor-verified)";
+                }
+                // floor-verify failed: the second output is not this MN's
+                // operator payment (e.g. lone treasury payee) — stay
+                // UNKNOWN, adopt nothing.
+            }
+        }
+        // >2-output shapes (funded superblock): ambiguous — stay UNKNOWN.
+    }
+
     // ─────────────────────────────────────────────────────────────────────
     // recover_from_sml_ban — the ONLY licensed alternative to payee_desync
     // ─────────────────────────────────────────────────────────────────────
@@ -1593,6 +1834,10 @@ private:
     }
 
     SmlValidityFn m_sml_validity;
+
+    // Optional superblock-height predicate (see set_superblock_height_fn).
+    // NULL by default: shape guards only.
+    std::function<bool(uint32_t)> m_is_superblock_height;
     uint32_t      m_sml_height{0};
     bool          m_sml_height_known{false};
     size_t        m_sml_recovery_cap{0};

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -240,6 +240,7 @@ public:
     /// template-SERVE refusal (free), never a block-SUBMIT refusal. Exposed
     /// for the negative-pass test.
     void set_require_resolvable_payee(bool v) { m_require_resolvable_payee = v; }
+    void set_require_provable_payout_split(bool v) { m_require_provable_payout_split = v; }
 
     /// creditPool freshness gate (soak fix). dashcore CheckCreditPoolDiffForBlock
     /// rejects a block whose committed creditPoolBalance is off by a block's
@@ -412,7 +413,13 @@ public:
     /// The predicate takes the NEXT block height (prev_height + 1). Unset
     /// (default) preserves prior behaviour exactly.
     void set_is_superblock_fn(std::function<bool(uint32_t)> fn) {
-        m_is_superblock_fn = std::move(fn);
+        m_is_superblock_fn = fn;
+        // Same cycle for the payee machine's pass-3 payout-split
+        // observation: a lone treasury payee at a superblock height
+        // presents the same 2-output shape as an operator split, so
+        // adoption there is ambiguous and must be skipped (h=2516595
+        // split-provenance lane).
+        m_mnstates.set_superblock_height_fn(std::move(fn));
     }
 
     /// Daemonless superblock provider (E-SUPERBLOCK). When enabled (see
@@ -824,6 +831,60 @@ public:
                               ? std::to_string(m_mnstates.last_applied_height())
                               : std::string("n/a"),
                           std::to_string(m_prev_height));
+        // Incident h=2516595 (bad-cb-payee) mirror of the viability clause:
+        // a template whose scheduled MN has an UNPROVEN operator-reward
+        // split must never reach a miner, even via a cached template or a
+        // viability bypass.
+        if (m_require_provable_payout_split) {
+            if (auto protx = mn_payout_split_unprovable_at_tip())
+                return reject("emit-mn-payout-split-unprovable",
+                              "protx=" + protx->GetHex().substr(0, 12),
+                              "payout-set-known");
+            // Structural re-derivation (defence in depth against a builder
+            // that ignores the split — the exact h=2516595 defect): the
+            // BUILT template's MN payment amounts must be dashd's
+            // GetBlockTxOuts split of ITS OWN m_payment_amount —
+            //   operator = floor(mn_payment * bps / 10000), owner = rest —
+            // whenever the scheduled entry says a split is due. Amount
+            // presence is checked (not scripts: the packed payee is an
+            // address token; the builder KATs pin script identity).
+            const auto expected = m_mnstates.find_expected_payee();
+            if (expected && w.m_payment_amount > 0) {
+                const auto it = m_mnstates.entries().find(*expected);
+                if (it != m_mnstates.entries().end()) {
+                    const int64_t mn_payment =
+                        static_cast<int64_t>(w.m_payment_amount);
+                    const int64_t op_due =
+                        it->second.operator_payment_of(mn_payment);
+                    if (op_due > 0) {
+                        // Occurrence-counted so a 50/50 split (owner amount
+                        // == operator amount) needs TWO outputs, not one
+                        // double-matched.
+                        const uint64_t own_amt =
+                            static_cast<uint64_t>(mn_payment - op_due);
+                        const uint64_t op_amt = static_cast<uint64_t>(op_due);
+                        size_t own_n = 0, op_n = 0;
+                        for (const auto& p : w.m_packed_payments) {
+                            if (p.payee == "!6a") continue;
+                            if (p.amount == own_amt) ++own_n;
+                            if (p.amount == op_amt)  ++op_n;
+                        }
+                        const bool owner_ok =
+                            own_amt == op_amt ? own_n >= 2 : own_n >= 1;
+                        const bool op_ok =
+                            own_amt == op_amt ? op_n >= 2 : op_n >= 1;
+                        if (!owner_ok || !op_ok)
+                            return reject(
+                                "emit-mn-payout-split-drift",
+                                "owner=" + std::to_string(mn_payment - op_due)
+                                    + (owner_ok ? "-present" : "-MISSING")
+                                    + ",operator=" + std::to_string(op_due)
+                                    + (op_ok ? "-present" : "-MISSING"),
+                                "both-split-amounts-in-template");
+                    }
+                }
+            }
+        }
         // FINDING-2 defence in depth: no template tx may spend a known MN
         // collateral outpoint. dashd's verifier removes that MN from the list
         // for THIS block (specialtxman.cpp:457-464, ALL txs, no special-tx
@@ -1166,6 +1227,18 @@ private:
                        std::to_string(m_mnstates.entries().size())
                            + "-entries-none-payable",
                        "expected-payee-in-SML@h=" + std::to_string(next_h));
+        else if (m_require_provable_payout_split) {
+            // Incident h=2516595 (bad-cb-payee): serving a height whose
+            // scheduled MN carries an UNPROVEN operator-reward split builds
+            // a coinbase dashd deterministically rejects — the won block is
+            // lost. The value names the masternode so the operator can see
+            // WHICH entry is starving the arm (a fresh checkpoint reseed or
+            // one canonical payment of that MN clears it).
+            if (auto protx = mn_payout_split_unprovable_at_tip())
+                d = refuse("mn-payout-split-unprovable",
+                           "protx=" + protx->GetHex().substr(0, 12),
+                           "payout-set-known");
+        }
 
         if (d.viable) return d;
 
@@ -1248,6 +1321,35 @@ private:
         return m_mnstates.entries().find(*expected) != m_mnstates.entries().end();
     }
 
+    // Incident h=2516595 (bad-cb-payee): the scheduled payee's operator-
+    // reward split must be PROVEN before the embedded arm may build the
+    // height. dashd pays the MN share as a SET (owner + optional operator
+    // output, masternode/payments.cpp GetBlockTxOuts) and validates scripts
+    // AND amounts; the SML wire can never prove the split
+    // (CSimplifiedMNListEntry keeps the payout scripts mem-only), so
+    // provenance comes from checkpoint/seed rows, ProTx replay, or observed
+    // canonical payouts — see MNState::payoutSplitProvenance. Returns the
+    // scheduled proRegTxHash when the height must be REFUSED
+    // (cause=mn-payout-split-unprovable), nullopt when serving is safe.
+    // Follows mn_payee_resolvable_at_tip()'s no-payment-due carve-outs so
+    // it can never over-refuse a height with no MN payment.
+    std::optional<uint256> mn_payout_split_unprovable_at_tip() const {
+        if (m_mnstates.entries().empty()) return std::nullopt;
+        const uint32_t next_h = m_prev_height + 1;
+        const int64_t reward = compute_dash_block_reward_post_v20(next_h);
+        const int64_t platform_reward =
+            compute_dash_platform_reward_post_v20_mn_rr(next_h, m_mn_rr_height);
+        const int64_t mn_payment_floor =
+            compute_dash_mn_payment_post_v20(reward) - platform_reward;
+        if (mn_payment_floor <= 0) return std::nullopt;
+        const auto expected = m_mnstates.find_expected_payee();
+        if (!expected) return std::nullopt;   // payee-unresolvable owns this
+        const auto it = m_mnstates.entries().find(*expected);
+        if (it == m_mnstates.entries().end()) return std::nullopt; // ditto
+        if (it->second.payout_split_provable()) return std::nullopt;
+        return *expected;
+    }
+
     /// Superblock disposition for a candidate next height. ok=false => refuse
     /// (fail closed). payments empty+ok => normal block; non-empty+ok => emit.
     struct SuperblockDisposition {
@@ -1323,6 +1425,7 @@ private:
     // no external freshness wiring, and guards a money path, so unlike the
     // freshness gates above it defaults ON.
     bool     m_require_resolvable_payee{true};   // refuse embedded when a due MN payee is unresolvable (#996)
+    bool     m_require_provable_payout_split{true}; // refuse embedded when the scheduled MN's operator-reward split is unproven (h=2516595 bad-cb-payee)
     int      m_mn_rr_height{DASH_MN_RR_HEIGHT_MAINNET}; // network MN_RR activation height (platform-share gate)
     int      m_mn_min_confirmations{DASH_MN_MIN_CONFIRMATIONS_MAINNET}; // network nMasternodeMinimumConfirmations (rollover projection)
     uint256  m_credit_pool_current_hash;     // block hash the credit-pool seed is current at

--- a/src/impl/dash/coin/won_block_dispatch.hpp
+++ b/src/impl/dash/coin/won_block_dispatch.hpp
@@ -171,8 +171,8 @@ inline BlockBroadcast broadcast_won_block(const P2pRelaySink& p2p_relay,
                          "block NOT relayed!";
         else
             LOG_INFO << "[EMB-DASH] height-race won-block broadcast: rpc="
-                     << (r.rpc_ok ? "ok" : "off") << " p2p="
-                     << (r.p2p_sent ? "sent" : "off")
+                     << (r.rpc_ok ? "ok" : (rpc_submit ? "no-ack" : "unarmed"))
+                     << " p2p=" << (r.p2p_sent ? "sent" : "off")
                      << " landed_first=" << r.landed_first << ".";
         return r;
     }
@@ -236,8 +236,13 @@ inline BlockBroadcast broadcast_won_block(const P2pRelaySink& p2p_relay,
     if (!r.any())
         LOG_ERROR << "[EMB-DASH] won-block reached NEITHER sink -- block NOT relayed!";
     else
+        // rpc= is a TRI-state: "off" used to mean both "arm never wired"
+        // and "arm fired, dashd did NOT ack" — on the h=2516595 incident
+        // (bad-cb-payee) the summary read rpc=off while ARM B had in fact
+        // fired and carried the rejection verdict. Name the two states
+        // apart so a no-ack is read as the consensus verdict it is.
         LOG_INFO << "[EMB-DASH] won-block broadcast: p2p=" << (r.p2p_sent ? "sent" : "off")
-                 << " rpc=" << (r.rpc_ok ? "ok" : "off")
+                 << " rpc=" << (r.rpc_ok ? "ok" : (rpc_submit ? "no-ack" : "unarmed"))
                  << " landed_first=" << r.landed_first << ".";
     return r;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -742,7 +742,12 @@ if (BUILD_TESTING AND GTest_FOUND)
         test_dash_sml_quorum_db.cpp
         test_dash_embedded_oracle_shadow.cpp
         test_dash_mn_confirm_rollover.cpp
-        test_dash_collateral_spend_filter.cpp)
+        test_dash_collateral_spend_filter.cpp
+        # test_dash_operator_split.cpp: incident h=2516595 bad-cb-payee — the
+        # MN operator-reward split KATs (builder dual-output + serve-gate
+        # cause=mn-payout-split-unprovable + ResetOperatorFields mirror +
+        # pass-3 split observation). Folded here per the same #769 rule.
+        test_dash_operator_split.cpp)
     target_compile_definitions(test_dash_embedded_gbt PRIVATE
         DASH_FIXTURE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/fixtures")
     target_link_libraries(test_dash_embedded_gbt PRIVATE

--- a/test/test_dash_bestcl_gate.cpp
+++ b/test/test_dash_bestcl_gate.cpp
@@ -107,6 +107,7 @@ void make_state(NodeCoinState& st) {
     s.nRegisteredHeight = 2'300'000;
     s.nLastPaidHeight   = 0;
     s.scriptPayout.m_data = p2pkh_script(0x30);
+    s.payoutSplitProvenance = MNState::SPLIT_KNOWN;   // fixture: proven zero split (h=2516595 gate)
     st.mnstates().load(std::vector<std::pair<uint256, MNState>>{{raw256(0x01), s}});
 
     st.sml().mnList = {sml_entry(0x40), sml_entry(0x60)};

--- a/test/test_dash_coin_state_maintainer.cpp
+++ b/test/test_dash_coin_state_maintainer.cpp
@@ -104,6 +104,7 @@ static std::vector<std::pair<uint256, MNState>> single_mn(const std::vector<unsi
     s.nRegisteredHeight = 2'300'000;
     s.nLastPaidHeight = 0;
     s.scriptPayout.m_data = payout;
+    s.payoutSplitProvenance = MNState::SPLIT_KNOWN;   // fixture: proven zero split (h=2516595 gate)
     return std::vector<std::pair<uint256, MNState>>{{raw256(0x01), s}};
 }
 
@@ -254,6 +255,7 @@ single_mn_coll(const std::vector<unsigned char>& payout,
     s.nRegisteredHeight = 2300000;
     s.nLastPaidHeight = 0;
     s.scriptPayout.m_data = payout;
+    s.payoutSplitProvenance = MNState::SPLIT_KNOWN;   // fixture: proven zero split (h=2516595 gate)
     s.collateralOutpoint.hash  = coll_hash;
     s.collateralOutpoint.index = coll_idx;
     return std::vector<std::pair<uint256, MNState>>{{raw256(0x01), s}};

--- a/test/test_dash_collateral_spend_filter.cpp
+++ b/test/test_dash_collateral_spend_filter.cpp
@@ -114,6 +114,9 @@ static MnStateMachine mn_set_with_collateral(const uint256& collat_hash,
     payee.isValid = true;
     payee.nRegisteredHeight = 2'300'000;
     payee.scriptPayout.m_data = p2pkh_script(0x30);
+    // Hand-seeded fixture: zero operator split, declared PROVEN as every
+    // real ingest path does (h=2516595 serve gate).
+    payee.payoutSplitProvenance = MNState::SPLIT_KNOWN;
     payee.collateralOutpoint.hash  = raw256(0xE0);  // unrelated outpoint
     payee.collateralOutpoint.index = 0;
 
@@ -121,6 +124,7 @@ static MnStateMachine mn_set_with_collateral(const uint256& collat_hash,
     victim.isValid = true;
     victim.nRegisteredHeight = 2'310'000;
     victim.scriptPayout.m_data = p2pkh_script(0x40);
+    victim.payoutSplitProvenance = MNState::SPLIT_KNOWN;   // h=2516595 serve gate
     victim.collateralOutpoint.hash  = collat_hash;
     victim.collateralOutpoint.index = collat_index;
 

--- a/test/test_dash_embedded_gbt.cpp
+++ b/test/test_dash_embedded_gbt.cpp
@@ -172,6 +172,9 @@ static MnStateMachine single_mn(const std::vector<unsigned char>& payout) {
     s.nRegisteredHeight = 2'300'000;
     s.nLastPaidHeight = 0;
     s.scriptPayout.m_data = payout;
+    // Hand-seeded fixtures declare their (zero) operator split PROVEN, as
+    // every real ingest path does (h=2516595 serve gate).
+    s.payoutSplitProvenance = MNState::SPLIT_KNOWN;
     MnStateMachine m;
     m.load(std::vector<std::pair<uint256, MNState>>{{raw256(0x01), s}});
     return m;
@@ -713,6 +716,7 @@ e2_mn_pairs(const std::vector<unsigned char>& payout) {
     s.nRegisteredHeight = 2'300'000;
     s.nLastPaidHeight = 0;
     s.scriptPayout.m_data = payout;
+    s.payoutSplitProvenance = MNState::SPLIT_KNOWN;   // h=2516595 serve gate
     return std::vector<std::pair<uint256, MNState>>{{raw256(0x01), s}};
 }
 

--- a/test/test_dash_get_work.cpp
+++ b/test/test_dash_get_work.cpp
@@ -96,6 +96,7 @@ static std::vector<std::pair<uint256, MNState>> single_mn(const std::vector<unsi
     s.nRegisteredHeight = 2'300'000;
     s.nLastPaidHeight = 0;
     s.scriptPayout.m_data = payout;
+    s.payoutSplitProvenance = MNState::SPLIT_KNOWN;   // fixture: proven zero split (h=2516595 gate)
     return {{raw256(0x01), s}};
 }
 

--- a/test/test_dash_govvote_bls.cpp
+++ b/test/test_dash_govvote_bls.cpp
@@ -412,6 +412,8 @@ TEST(DashGovVoteBLS, BannedMnVoteCountsAtWeightThresholdUsesValidSet) {
     banned_evo.isValid = false;                             // PoSe-banned
     banned_evo.nType   = dash::coin::vendor::MnType::EVO;
 
+    valid_mn.payoutSplitProvenance = dash::coin::MNState::SPLIT_KNOWN;   // fixture (h=2516595 gate)
+    banned_evo.payoutSplitProvenance = dash::coin::MNState::SPLIT_KNOWN;
     ncs.mnstates().load({{h(0x11), valid_mn}, {h(0x12), banned_evo}});
 
     const std::string valid_key =

--- a/test/test_dash_mn_confirm_rollover.cpp
+++ b/test/test_dash_mn_confirm_rollover.cpp
@@ -106,6 +106,9 @@ static MNState mn_state(uint32_t reg_height,
     s.nRegisteredHeight  = reg_height;
     s.nLastPaidHeight    = 0;
     s.scriptPayout.m_data = payout;
+    // Hand-seeded fixture: zero operator split, declared PROVEN as every
+    // real ingest path does (h=2516595 serve gate).
+    s.payoutSplitProvenance = MNState::SPLIT_KNOWN;
     return s;
 }
 

--- a/test/test_dash_node_coin_state.cpp
+++ b/test/test_dash_node_coin_state.cpp
@@ -103,6 +103,7 @@ static void seed_single_mn(NodeCoinState& st, const std::vector<unsigned char>& 
     s.nRegisteredHeight = 2'300'000;
     s.nLastPaidHeight = 0;
     s.scriptPayout.m_data = payout;
+    s.payoutSplitProvenance = MNState::SPLIT_KNOWN;   // fixture: proven zero split (h=2516595 gate)
     st.mnstates().load(std::vector<std::pair<uint256, MNState>>{{raw256(0x01), s}});
 }
 
@@ -398,6 +399,7 @@ TEST(DashNodeCoinState, UnresolvablePayeeFailsClosedToDashd) {
     banned.isValid          = false;
     banned.nRegisteredHeight = 2'300'000;
     banned.scriptPayout.m_data = p2pkh_script(0x30);
+    banned.payoutSplitProvenance = MNState::SPLIT_KNOWN;   // fixture: proven zero split (h=2516595 gate)
     st.mnstates().load(std::vector<std::pair<uint256, MNState>>{
         {raw256(0x01), banned}});
     st.set_tip(H - 1, raw256(0xAB), 0x1b104be3u, 1'700'000'000u,
@@ -742,6 +744,7 @@ TEST(DashNodeCoinState, MaintainerOnMnlistdiffPopulatesSmlAndEmitsPayload) {
     // (leg 1), then the SML diff (new leg), then the tip (leg 2).
     MNState pm; pm.isValid = true; pm.nRegisteredHeight = 2'300'000;
     pm.nLastPaidHeight = 0; pm.scriptPayout.m_data = p2pkh_script(0x30);
+    pm.payoutSplitProvenance = MNState::SPLIT_KNOWN;   // fixture: proven zero split (h=2516595 gate)
     maint.on_mn_list_update(
         std::vector<std::pair<uint256, MNState>>{{raw256(0x01), pm}}, 0);
     st.mempool().set_utxo(&utxo);
@@ -821,6 +824,7 @@ static void seed_healthy_armed(NodeCoinState& st) {
         s.nRegisteredHeight = 2'300'000;
         s.nLastPaidHeight = 0;
         s.scriptPayout.m_data = p2pkh_script(0x30);
+        s.payoutSplitProvenance = MNState::SPLIT_KNOWN;   // fixture: proven zero split (h=2516595 gate)
         st.mnstates().load(
             std::vector<std::pair<uint256, MNState>>{{raw256(0x01), s}}, H - 1);
     }
@@ -884,6 +888,7 @@ TEST(DashServeGateNamesRefusal, PayeeStaleNamesValueAndThreshold) {
     s.isValid = true;
     s.nRegisteredHeight = 2'300'000;
     s.scriptPayout.m_data = p2pkh_script(0x30);
+    s.payoutSplitProvenance = MNState::SPLIT_KNOWN;   // fixture: proven zero split (h=2516595 gate)
     st.mnstates().load(
         std::vector<std::pair<uint256, MNState>>{{raw256(0x01), s}}, H - 3);
     const DeclineReport d = st.describe_decline();
@@ -1277,6 +1282,7 @@ TEST(DashServeGateNamesRefusal, SelfConsistentStaleTipPassesEveryRelativeGate) {
         s.isValid = true;
         s.nRegisteredHeight = 1'000'000;
         s.scriptPayout.m_data = p2pkh_script(0x30);
+        s.payoutSplitProvenance = MNState::SPLIT_KNOWN;   // fixture: proven zero split (h=2516595 gate)
         st.mnstates().load(
             std::vector<std::pair<uint256, MNState>>{{raw256(0x01), s}}, ancient);
     }

--- a/test/test_dash_node_embedded_wire.cpp
+++ b/test/test_dash_node_embedded_wire.cpp
@@ -96,6 +96,7 @@ static std::vector<std::pair<uint256, MNState>> single_mn(const std::vector<unsi
     s.nRegisteredHeight = 2'300'000;
     s.nLastPaidHeight = 0;
     s.scriptPayout.m_data = payout;
+    s.payoutSplitProvenance = MNState::SPLIT_KNOWN;   // fixture: proven zero split (h=2516595 gate)
     return {{raw256(0x01), s}};
 }
 

--- a/test/test_dash_node_reception_wire.cpp
+++ b/test/test_dash_node_reception_wire.cpp
@@ -118,6 +118,7 @@ static std::vector<std::pair<uint256, MNState>> single_mn(const std::vector<unsi
     s.nRegisteredHeight = 2'300'000;
     s.nLastPaidHeight = 0;
     s.scriptPayout.m_data = payout;
+    s.payoutSplitProvenance = MNState::SPLIT_KNOWN;   // fixture: proven zero split (h=2516595 gate)
     return std::vector<std::pair<uint256, MNState>>{{raw256(0x01), s}};
 }
 
@@ -131,6 +132,7 @@ single_mn_coll(const std::vector<unsigned char>& payout,
     s.nRegisteredHeight = 2'300'000;
     s.nLastPaidHeight = 0;
     s.scriptPayout.m_data = payout;
+    s.payoutSplitProvenance = MNState::SPLIT_KNOWN;   // fixture: proven zero split (h=2516595 gate)
     s.collateralOutpoint.hash  = coll_hash;
     s.collateralOutpoint.index = coll_idx;
     return std::vector<std::pair<uint256, MNState>>{{raw256(0x01), s}};

--- a/test/test_dash_operator_split.cpp
+++ b/test/test_dash_operator_split.cpp
@@ -1,0 +1,566 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// ═══════════════════════════════════════════════════════════════════════════
+// DASH masternode operator-reward split — incident h=2516595 KATs
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// INCIDENT (2026-08-05, production, binary ca5c9469): the FIRST block ever
+// mined on an embedded daemonless template (h=2516595, pow 0…0d08e71b…) was
+// REJECTED by dashd with bad-cb-payee. The scheduled masternode
+// (proRegTxHash 0037c2c5…) has an 8% operator-reward split registered via
+// ProTx; dashd's canonical coinbase pays TWO MN outputs
+//     0.76413304 → XoDo3w4ZUqn93uL3FeRNb9fgfXvgg7BvDC   (owner)
+//     0.06644635 → Xnem6ejaXAfKDTh5PFGSa9ozMQNMY6bvs7   (operator)
+// while the embedded builder paid the ENTIRE share to the owner script.
+// CheckMasternodePayments validates the full payout set (scripts AND
+// amounts) → deterministic rejection → a lost won block.
+//
+// The split data was IN the shipped daemonless state the whole time: the
+// mainnet checkpoint anchor (2513000) carries mn 0037c2c5… with bps=800 and
+// both scripts; the omission was in the consumer (the builder), not the
+// data. These KATs pin, against dashd masternode/payments.cpp
+// GetBlockTxOuts (verbatim, v20.1.1):
+//
+//     CAmount operatorReward = 0;
+//     if (dmnPayee->nOperatorReward != 0
+//         && dmnPayee->pdmnState->scriptOperatorPayout != CScript()) {
+//         operatorReward = (masternodeReward * dmnPayee->nOperatorReward) / 10000;
+//         masternodeReward -= operatorReward;
+//     }
+//     if (masternodeReward > 0) emplace_back(masternodeReward, scriptPayout);
+//     if (operatorReward > 0)   emplace_back(operatorReward, scriptOperatorPayout);
+//
+// (a) the builder emits BOTH outputs with dashd-exact amounts (truncating
+//     division, owner-first order) — KAT'd with the real h=2516595 values;
+// (b) an UNPROVEN split refuses the embedded serve with its own named
+//     cause (cause=mn-payout-split-unprovable value=protx=… threshold=
+//     payout-set-known) at BOTH the viability gate and the pre-emit gate;
+// (c) a proven zero split builds the single owner output exactly as before;
+// (d) the state machine mirrors dashd ResetOperatorFields on operator-key
+//     change (ProUpRegTx) and revocation (ProUpRevTx) — the stale operator
+//     payout script must go with the key.
+//
+// All hermetic: no live node, amounts recomputed from the same closed-form
+// integer arithmetic dashd uses.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/embedded_gbt.hpp>
+#include <impl/dash/coin/node_coin_state.hpp>
+#include <impl/dash/coin/mn_state_db.hpp>
+#include <impl/dash/coin/mn_state_machine.hpp>
+#include <impl/dash/coin/vendor/providertx.hpp>
+#include <impl/dash/coin/embedded_oracle_shadow.hpp>
+
+#include <core/uint256.hpp>
+#include <core/pack.hpp>
+
+#include <array>
+#include <cstring>
+#include <vector>
+
+using dash::coin::MNState;
+using dash::coin::MnStateMachine;
+using dash::coin::Mempool;
+using dash::coin::MutableTransaction;
+using dash::coin::NodeCoinState;
+using dash::coin::DashWorkData;
+using dash::coin::PackedPayment;
+using dash::coin::build_embedded_workdata;
+using dash::coin::compute_dash_block_reward_post_v20;
+using dash::coin::compute_dash_mn_payment_post_v20;
+using dash::coin::compute_dash_platform_reward_post_v20_mn_rr;
+using ::core::coin::UTXOViewCache;
+
+// Dash mainnet base58 version bytes (chainparams.cpp PUBKEY_ADDRESS=76,
+// SCRIPT_ADDRESS=16) — same constants the sibling embedded_gbt KATs use.
+static constexpr uint8_t DASH_PUBKEY_VER = 76;
+static constexpr uint8_t DASH_P2SH_VER   = 16;
+
+// Past V20 + MN_RR, matching the mainnet steady state (and the incident).
+static constexpr uint32_t H = 2'400'000;
+
+// ─── incident h=2516595 ground truth (canonical, dashd-accepted) ──────────
+// Canonical MN share = owner + operator output values of the accepted block.
+static constexpr int64_t K_MN_SHARE   = 83'057'939;  // duffs
+static constexpr int64_t K_OWNER_OUT  = 76'413'304;  // → XoDo3w4…
+static constexpr int64_t K_OPER_OUT   =  6'644'635;  // → Xnem6ej…
+static constexpr uint16_t K_BPS       = 800;         // 8.00% (ProRegTx)
+// scriptPubKeys, base58check-decoded from the two canonical payout
+// addresses (and byte-identical to checkpoint-anchor row 0037c2c5…).
+static const std::vector<unsigned char> K_OWNER_SCRIPT = {
+    0x76, 0xa9, 0x14, 0x89, 0x7c, 0x15, 0x1a, 0x6a, 0xa2, 0x35, 0xb7, 0x88,
+    0x0f, 0xb7, 0xd3, 0x4d, 0xac, 0xac, 0xa1, 0x78, 0xca, 0x03, 0x95, 0x88,
+    0xac};
+static const std::vector<unsigned char> K_OPER_SCRIPT = {
+    0x76, 0xa9, 0x14, 0x83, 0x3c, 0xb9, 0xad, 0x96, 0x45, 0x55, 0xc7, 0x80,
+    0x50, 0xae, 0x92, 0xb6, 0x85, 0xde, 0x5c, 0x32, 0x20, 0x0f, 0xc9, 0x88,
+    0xac};
+
+static uint256 raw256(uint8_t base) {
+    uint256 h;
+    std::array<uint8_t, 32> p{};
+    for (size_t i = 0; i < 32; ++i) p[i] = static_cast<uint8_t>(base + i);
+    std::memcpy(h.data(), p.data(), 32);
+    return h;
+}
+
+static MNState split_mn(uint16_t bps,
+                        const std::vector<unsigned char>& owner,
+                        const std::vector<unsigned char>& oper,
+                        uint8_t provenance = MNState::SPLIT_KNOWN) {
+    MNState s;
+    s.isValid = true;
+    s.nRegisteredHeight = 2'300'000;
+    s.nLastPaidHeight = 0;
+    s.scriptPayout.m_data = owner;
+    s.nOperatorReward = bps;
+    s.scriptOperatorPayout.m_data = oper;
+    s.payoutSplitProvenance = provenance;
+    return s;
+}
+
+static MnStateMachine machine_with(const MNState& s) {
+    MnStateMachine m;
+    m.load(std::vector<std::pair<uint256, MNState>>{{raw256(0x01), s}});
+    return m;
+}
+
+// The non-burn packed payments (the "!6a" OP_RETURN is the platform
+// credit-pool burn, not an MN payment).
+static std::vector<PackedPayment> mn_payments(const DashWorkData& w) {
+    std::vector<PackedPayment> out;
+    for (const auto& p : w.m_packed_payments)
+        if (p.payee != "!6a") out.push_back(p);
+    return out;
+}
+
+// Arm the SML posture the emit gate requires (it is a no-op while
+// require_sml is off) — same minimal fixture the collateral-spend emit KAT
+// uses: a fully-confirmed 1-entry SML current at the tip, so the ONLY
+// defect the gate can find is the one under test.
+static void arm_emit_gate(NodeCoinState& st, const uint256& prev_hash) {
+    using dash::coin::vendor::CSimplifiedMNList;
+    using dash::coin::vendor::CSimplifiedMNListEntry;
+    std::vector<CSimplifiedMNListEntry> entries;
+    CSimplifiedMNListEntry e;
+    e.nVersion = CSimplifiedMNListEntry::VER_BASIC_BLS;
+    e.proRegTxHash = raw256(0x01);
+    e.confirmedHash = raw256(0x77);
+    e.isValid = true;
+    entries.push_back(e);
+    st.set_require_sml(true);
+    st.sml() = CSimplifiedMNList(std::move(entries));
+    st.set_have_sml(true);
+    st.set_sml_current_hash(prev_hash);
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// The split arithmetic itself — dashd GetBlockTxOuts, bit-exact
+// ════════════════════════════════════════════════════════════════════════
+
+TEST(DashOperatorSplit, SplitMathKatH2516595) {
+    MNState s = split_mn(K_BPS, K_OWNER_SCRIPT, K_OPER_SCRIPT);
+    // floor(83'057'939 * 800 / 10000) = floor(6'644'635.12) = 6'644'635 —
+    // the canonical operator output of the dashd-accepted block, truncating
+    // division, NOT round-half-up (llround would give the same here; the
+    // truncation edge is pinned separately below).
+    EXPECT_EQ(s.operator_payment_of(K_MN_SHARE), K_OPER_OUT);
+    EXPECT_EQ(K_MN_SHARE - s.operator_payment_of(K_MN_SHARE), K_OWNER_OUT);
+}
+
+TEST(DashOperatorSplit, SplitMathTruncatesLikeDashd) {
+    MNState s = split_mn(1, K_OWNER_SCRIPT, K_OPER_SCRIPT);
+    // 9'999 * 1 / 10000 = 0.9999 → 0 (dashd's own comment: "might turn out
+    // to result in 0"). No operator output may be emitted for it.
+    EXPECT_EQ(s.operator_payment_of(9'999), 0);
+    // One duff more crosses the boundary.
+    EXPECT_EQ(s.operator_payment_of(10'000), 1);
+}
+
+TEST(DashOperatorSplit, SplitZeroWhenNoScriptOrNoBps) {
+    // bps registered, operator script unset → dashd pays a single owner
+    // output (the `scriptOperatorPayout != CScript()` guard).
+    MNState no_script = split_mn(K_BPS, K_OWNER_SCRIPT, {});
+    EXPECT_EQ(no_script.operator_payment_of(K_MN_SHARE), 0);
+    // script set, bps == 0 → likewise single-output (the `nOperatorReward
+    // != 0` guard; consensus additionally forbids this state on-chain).
+    MNState no_bps = split_mn(0, K_OWNER_SCRIPT, K_OPER_SCRIPT);
+    EXPECT_EQ(no_bps.operator_payment_of(K_MN_SHARE), 0);
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// (a) the BUILDER emits both outputs, dashd-exact, owner first
+// ════════════════════════════════════════════════════════════════════════
+
+TEST(DashOperatorSplit, BuilderEmitsOwnerAndOperatorOutputs) {
+    UTXOViewCache utxo(nullptr);
+    Mempool mp;
+    mp.set_utxo(&utxo);   // empty template: subsidy-exact arithmetic
+
+    auto mnstates = machine_with(split_mn(K_BPS, K_OWNER_SCRIPT, K_OPER_SCRIPT));
+
+    auto w = build_embedded_workdata(
+        /*prev_height=*/H - 1, raw256(0xAB), mnstates, mp,
+        /*bits=*/0x1b104be3u, /*mtp=*/1'700'000'000u,
+        DASH_PUBKEY_VER, DASH_P2SH_VER);
+
+    // Independent re-derivation of THIS height's MN share.
+    const int64_t reward          = compute_dash_block_reward_post_v20(H);
+    const int64_t platform_reward = compute_dash_platform_reward_post_v20_mn_rr(H);
+    const int64_t mn_payment      = compute_dash_mn_payment_post_v20(reward)
+                                    - platform_reward;
+    ASSERT_GT(mn_payment, 0);
+    const int64_t op_due  = (mn_payment * K_BPS) / 10000;   // dashd formula
+    const int64_t own_due = mn_payment - op_due;
+    ASSERT_GT(op_due, 0);
+
+    const auto mn_outs = mn_payments(w);
+    ASSERT_EQ(mn_outs.size(), 2u)
+        << "h=2516595 defect: the builder must emit the operator output, "
+           "not fold the whole share into the owner's";
+    // dashd GetBlockTxOuts order: owner first, operator second.
+    EXPECT_EQ(mn_outs[0].amount, static_cast<uint64_t>(own_due));
+    EXPECT_EQ(mn_outs[1].amount, static_cast<uint64_t>(op_due));
+    // Set-level conservation: split, not duplicated.
+    EXPECT_EQ(mn_outs[0].amount + mn_outs[1].amount,
+              static_cast<uint64_t>(mn_payment));
+    EXPECT_EQ(w.m_payment_amount, static_cast<uint64_t>(mn_payment));
+    // The canonical incident addresses, re-encoded from the scripts.
+    EXPECT_EQ(mn_outs[0].payee, "XoDo3w4ZUqn93uL3FeRNb9fgfXvgg7BvDC");
+    EXPECT_EQ(mn_outs[1].payee, "Xnem6ejaXAfKDTh5PFGSa9ozMQNMY6bvs7");
+}
+
+// (c) proven zero split → the single owner output, exactly as before.
+TEST(DashOperatorSplit, BuilderSingleOutputWhenSplitKnownZero) {
+    UTXOViewCache utxo(nullptr);
+    Mempool mp;
+    mp.set_utxo(&utxo);
+
+    auto mnstates = machine_with(split_mn(0, K_OWNER_SCRIPT, {}));
+    auto w = build_embedded_workdata(
+        H - 1, raw256(0xAB), mnstates, mp,
+        0x1b104be3u, 1'700'000'000u, DASH_PUBKEY_VER, DASH_P2SH_VER);
+
+    const auto mn_outs = mn_payments(w);
+    ASSERT_EQ(mn_outs.size(), 1u);
+    EXPECT_EQ(mn_outs[0].amount, w.m_payment_amount);
+    EXPECT_EQ(mn_outs[0].payee, "XoDo3w4ZUqn93uL3FeRNb9fgfXvgg7BvDC");
+}
+
+// bps=10000 (a full-operator MN — one exists on mainnet at the checkpoint
+// anchor): owner share is 0 → dashd's `if (masternodeReward > 0)` emits NO
+// owner output; the single output is the operator's.
+TEST(DashOperatorSplit, BuilderFullOperatorSplitOmitsZeroOwnerOutput) {
+    UTXOViewCache utxo(nullptr);
+    Mempool mp;
+    mp.set_utxo(&utxo);
+
+    auto mnstates = machine_with(split_mn(10000, K_OWNER_SCRIPT, K_OPER_SCRIPT));
+    auto w = build_embedded_workdata(
+        H - 1, raw256(0xAB), mnstates, mp,
+        0x1b104be3u, 1'700'000'000u, DASH_PUBKEY_VER, DASH_P2SH_VER);
+
+    const auto mn_outs = mn_payments(w);
+    ASSERT_EQ(mn_outs.size(), 1u);
+    EXPECT_EQ(mn_outs[0].amount, w.m_payment_amount);
+    EXPECT_EQ(mn_outs[0].payee, "Xnem6ejaXAfKDTh5PFGSa9ozMQNMY6bvs7");
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// (b) UNPROVEN split → REFUSED, with its own named cause
+// ════════════════════════════════════════════════════════════════════════
+
+TEST(DashOperatorSplit, UnprovableSplitRefusesServeWithNamedCause) {
+    NodeCoinState st;
+    st.mnstates().load(std::vector<std::pair<uint256, MNState>>{
+        {raw256(0x01),
+         split_mn(0, K_OWNER_SCRIPT, {}, MNState::SPLIT_UNKNOWN)}});
+    st.set_tip(H - 1, raw256(0xAB), 0x1b104be3u, 1'700'000'000u,
+               DASH_PUBKEY_VER, DASH_P2SH_VER);
+    ASSERT_TRUE(st.populated());
+
+    // Guard ON (default posture): refuse, and say the cause's own name.
+    auto e = st.make_embedded_work_inputs();
+    ASSERT_FALSE(e.viable())
+        << "an unproven payout split must refuse the embedded arm "
+           "(h=2516595: serving it loses the won block to bad-cb-payee)";
+    EXPECT_EQ(e.decline.cause, std::string("mn-payout-split-unprovable"));
+    EXPECT_EQ(e.decline.value,
+              "protx=" + raw256(0x01).GetHex().substr(0, 12));
+    EXPECT_EQ(e.decline.threshold, std::string("payout-set-known"));
+    // The greppable one-line marker discipline shared with the other gates.
+    EXPECT_EQ(e.decline.one_line(),
+              "cause=mn-payout-split-unprovable value=protx="
+                  + raw256(0x01).GetHex().substr(0, 12)
+                  + " threshold=payout-set-known");
+
+    // NEGATIVE PASS — guard off reproduces the pre-fix fail-open.
+    st.set_require_provable_payout_split(false);
+    EXPECT_TRUE(st.make_embedded_work_inputs().viable())
+        << "guard-off must reproduce the incident posture (fail-open)";
+    st.set_require_provable_payout_split(true);
+
+    // CONTROL — same tip, same MN, split PROVEN → viable again.
+    st.mnstates().load(std::vector<std::pair<uint256, MNState>>{
+        {raw256(0x01), split_mn(0, K_OWNER_SCRIPT, {})}});
+    EXPECT_TRUE(st.make_embedded_work_inputs().viable())
+        << "the gate must be provenance-specific, not a blanket refuse";
+}
+
+TEST(DashOperatorSplit, EmitGateMirrorsUnprovableSplit) {
+    NodeCoinState st;
+    st.mnstates().load(std::vector<std::pair<uint256, MNState>>{
+        {raw256(0x01),
+         split_mn(K_BPS, K_OWNER_SCRIPT, K_OPER_SCRIPT,
+                  MNState::SPLIT_UNKNOWN)}});
+    arm_emit_gate(st, raw256(0xAB));
+    st.set_tip(H - 1, raw256(0xAB), 0x1b104be3u, 1'700'000'000u,
+               DASH_PUBKEY_VER, DASH_P2SH_VER);
+
+    UTXOViewCache utxo(nullptr);
+    Mempool mp;
+    mp.set_utxo(&utxo);
+    auto w = build_embedded_workdata(
+        H - 1, raw256(0xAB), st.mnstates(), mp,
+        0x1b104be3u, 1'700'000'000u, DASH_PUBKEY_VER, DASH_P2SH_VER);
+
+    dash::coin::DeclineReport why;
+    EXPECT_FALSE(st.embedded_template_emit_ok(w, &why))
+        << "a cached/bypassed template must be stopped at emit too";
+    EXPECT_EQ(why.cause, std::string("emit-mn-payout-split-unprovable"));
+    EXPECT_EQ(why.threshold, std::string("payout-set-known"));
+}
+
+// Defence in depth: a template whose MN payment IGNORES a proven split (the
+// exact h=2516595 builder defect, resurrected via any future regression)
+// must be rejected at emit by amount re-derivation.
+TEST(DashOperatorSplit, EmitGateRejectsSplitDriftTemplate) {
+    NodeCoinState st;
+    st.mnstates().load(std::vector<std::pair<uint256, MNState>>{
+        {raw256(0x01), split_mn(K_BPS, K_OWNER_SCRIPT, K_OPER_SCRIPT)}});
+    arm_emit_gate(st, raw256(0xAB));
+    st.set_tip(H - 1, raw256(0xAB), 0x1b104be3u, 1'700'000'000u,
+               DASH_PUBKEY_VER, DASH_P2SH_VER);
+
+    UTXOViewCache utxo(nullptr);
+    Mempool mp;
+    mp.set_utxo(&utxo);
+    auto w = build_embedded_workdata(
+        H - 1, raw256(0xAB), st.mnstates(), mp,
+        0x1b104be3u, 1'700'000'000u, DASH_PUBKEY_VER, DASH_P2SH_VER);
+
+    // Sanity: the fixed builder passes the emit re-derivation…
+    dash::coin::DeclineReport why;
+    // (viability preconditions like SML/qc are not armed in this bare
+    // fixture; probe ONLY the split re-derivation by reproducing the
+    // incident template: fold the operator output back into the owner's.)
+    std::vector<PackedPayment> broken;
+    uint64_t mn_total = 0;
+    for (const auto& p : w.m_packed_payments) {
+        if (p.payee == "!6a") { broken.push_back(p); continue; }
+        mn_total += p.amount;
+    }
+    PackedPayment all_to_owner;
+    all_to_owner.payee  = "XoDo3w4ZUqn93uL3FeRNb9fgfXvgg7BvDC";
+    all_to_owner.amount = mn_total;                  // the h=2516595 coinbase
+    broken.push_back(all_to_owner);
+    DashWorkData incident = w;
+    incident.m_packed_payments = broken;
+
+    EXPECT_FALSE(st.embedded_template_emit_ok(incident, &why));
+    EXPECT_EQ(why.cause, std::string("emit-mn-payout-split-drift"));
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// (d) ResetOperatorFields mirror — the stale operator script goes with the key
+// ════════════════════════════════════════════════════════════════════════
+
+static MutableTransaction protx_tx(uint16_t type,
+                                   const std::vector<unsigned char>& payload) {
+    MutableTransaction tx;
+    tx.version = 3;
+    tx.type = type;
+    tx.extra_payload = payload;
+    // A non-empty vin/vout so the tx is structurally a spend, not a
+    // coinbase (pass 1 walks i>=1; the test block provides a coinbase).
+    ::bitcoin_family::coin::TxIn in;
+    in.prevout.hash = raw256(0x77);
+    in.prevout.index = 0;
+    in.sequence = 0xffffffffu;
+    tx.vin.push_back(in);
+    return tx;
+}
+
+static dash::coin::BlockType block_with(uint32_t /*height*/,
+                                        std::vector<MutableTransaction> txs,
+                                        const std::vector<unsigned char>& cb_payee,
+                                        int64_t cb_value) {
+    dash::coin::BlockType b;
+    MutableTransaction cb;
+    cb.version = 3;
+    cb.type = 5;   // CbTx
+    ::bitcoin_family::coin::TxOut o;
+    o.value = cb_value;
+    o.scriptPubKey.m_data = cb_payee;
+    cb.vout.push_back(o);
+    b.m_txs.push_back(cb);
+    for (auto& t : txs) b.m_txs.push_back(std::move(t));
+    return b;
+}
+
+TEST(DashOperatorSplit, ProUpRegTxOperatorKeyChangeClearsOperatorPayout) {
+    // Seed one MN with a proven split, cursor at 999.
+    MNState s = split_mn(K_BPS, K_OWNER_SCRIPT, K_OPER_SCRIPT);
+    MnStateMachine m;
+    m.load(std::vector<std::pair<uint256, MNState>>{{raw256(0x01), s}},
+           /*as_of_height=*/999);
+
+    // ProUpRegTx changing the operator BLS key.
+    dash::coin::vendor::CProUpRegTx up;
+    up.proTxHash = raw256(0x01);
+    for (size_t i = 0; i < up.pubKeyOperator.size(); ++i)
+        up.pubKeyOperator[i] = static_cast<uint8_t>(0xC0 + i);   // != seeded
+    up.scriptPayout.m_data = K_OWNER_SCRIPT;
+    auto ps = ::pack(up);
+    auto sp = ps.get_span();
+    std::vector<unsigned char> payload(
+        reinterpret_cast<const unsigned char*>(sp.data()),
+        reinterpret_cast<const unsigned char*>(sp.data()) + sp.size());
+
+    auto blk = block_with(1000, {protx_tx(3, payload)}, K_OWNER_SCRIPT,
+                          /*cb_value=*/100'000'000);
+    auto r = m.apply_block(blk, 1000);
+    ASSERT_FALSE(r.skipped_out_of_order);
+
+    const auto& st2 = m.entries().at(raw256(0x01));
+    // dashcore dmnstate.h ResetOperatorFields: scriptOperatorPayout,
+    // addr(netInfo), platformNodeID cleared; MN PoSe-banned until the new
+    // operator revives it. bps itself is immutable → split stays PROVEN.
+    EXPECT_TRUE(st2.scriptOperatorPayout.m_data.empty())
+        << "the OLD operator's payout script must go with the old key — "
+           "keeping it pays a script dashd no longer pays (bad-cb-payee)";
+    EXPECT_FALSE(st2.isValid);
+    EXPECT_EQ(st2.payoutSplitProvenance, MNState::SPLIT_KNOWN);
+    EXPECT_EQ(st2.operator_payment_of(K_MN_SHARE), 0)
+        << "post-reset the payout set is single-owner";
+}
+
+TEST(DashOperatorSplit, ProUpRevTxClearsOperatorPayout) {
+    MNState s = split_mn(K_BPS, K_OWNER_SCRIPT, K_OPER_SCRIPT);
+    MnStateMachine m;
+    m.load(std::vector<std::pair<uint256, MNState>>{{raw256(0x01), s}},
+           /*as_of_height=*/999);
+
+    dash::coin::vendor::CProUpRevTx rev;
+    rev.proTxHash = raw256(0x01);
+    rev.nReason = 1;   // termination of service
+    auto ps = ::pack(rev);
+    auto sp = ps.get_span();
+    std::vector<unsigned char> payload(
+        reinterpret_cast<const unsigned char*>(sp.data()),
+        reinterpret_cast<const unsigned char*>(sp.data()) + sp.size());
+
+    auto blk = block_with(1000, {protx_tx(4, payload)}, K_OWNER_SCRIPT,
+                          100'000'000);
+    auto r = m.apply_block(blk, 1000);
+    ASSERT_FALSE(r.skipped_out_of_order);
+
+    const auto& st2 = m.entries().at(raw256(0x01));
+    EXPECT_TRUE(st2.scriptOperatorPayout.m_data.empty());
+    EXPECT_FALSE(st2.isValid);
+    EXPECT_EQ(st2.operator_payment_of(K_MN_SHARE), 0);
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Pass-3 observation: the canonical coinbase proves / falsifies the split
+// ════════════════════════════════════════════════════════════════════════
+
+static dash::coin::BlockType coinbase_only_block(
+    std::vector<std::pair<std::vector<unsigned char>, int64_t>> outs) {
+    dash::coin::BlockType b;
+    MutableTransaction cb;
+    cb.version = 3;
+    cb.type = 5;
+    for (auto& [script, value] : outs) {
+        ::bitcoin_family::coin::TxOut o;
+        o.value = value;
+        o.scriptPubKey.m_data = script;
+        cb.vout.push_back(o);
+    }
+    b.m_txs.push_back(cb);
+    return b;
+}
+
+TEST(DashOperatorSplit, Pass3AdoptsSplitFromObservedCanonicalPayout) {
+    // Provenance UNKNOWN (filtered-seed shape: bps absent → 0).
+    MNState s = split_mn(0, K_OWNER_SCRIPT, {}, MNState::SPLIT_UNKNOWN);
+    MnStateMachine m;
+    m.load(std::vector<std::pair<uint256, MNState>>{{raw256(0x01), s}},
+           /*as_of_height=*/999);
+
+    // The canonical h=2516595 payout shape: owner + operator outputs.
+    auto blk = coinbase_only_block({{K_OWNER_SCRIPT, K_OWNER_OUT},
+                                    {K_OPER_SCRIPT, K_OPER_OUT}});
+    auto r = m.apply_block(blk, 1000);
+    ASSERT_EQ(r.paid, 1u);
+    EXPECT_EQ(r.split_adopted, 1u);
+
+    const auto& st2 = m.entries().at(raw256(0x01));
+    EXPECT_EQ(st2.payoutSplitProvenance, MNState::SPLIT_KNOWN);
+    // bps uniquely determined: ceil(6'644'635 * 10000 / 83'057'939) = 800,
+    // floor-verified against dashd's truncating recomputation.
+    EXPECT_EQ(st2.nOperatorReward, K_BPS);
+    EXPECT_EQ(st2.scriptOperatorPayout.m_data, K_OPER_SCRIPT);
+    EXPECT_EQ(st2.operator_payment_of(K_MN_SHARE), K_OPER_OUT);
+}
+
+TEST(DashOperatorSplit, Pass3DemotesContradictedSplit) {
+    // Proven split... that the network no longer pays (stale knowledge —
+    // e.g. a pre-anchor ProUpServTx we never saw). Single-owner coinbase.
+    MNState s = split_mn(K_BPS, K_OWNER_SCRIPT, K_OPER_SCRIPT);
+    MnStateMachine m;
+    m.load(std::vector<std::pair<uint256, MNState>>{{raw256(0x01), s}},
+           /*as_of_height=*/999);
+
+    auto blk = coinbase_only_block({{K_OWNER_SCRIPT, K_MN_SHARE}});
+    auto r = m.apply_block(blk, 1000);
+    ASSERT_EQ(r.paid, 1u);
+    EXPECT_EQ(r.split_desync, 1u);
+    EXPECT_EQ(m.entries().at(raw256(0x01)).payoutSplitProvenance,
+              MNState::SPLIT_UNKNOWN)
+        << "a contradicted split must fail closed (refused when scheduled) "
+           "until re-proven";
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Parity surface: the shadow field digests the full payout SET, fee-invariant
+// ════════════════════════════════════════════════════════════════════════
+
+TEST(DashOperatorSplit, ShadowSplitShapeIsFeeInvariant) {
+    using dash::coin::mn_payout_split_shape_str;
+    // Same MN, same split, DIFFERENT fee totals on the two sides (embedded
+    // vs dashd selected different tx sets) — the shape must be EQUAL.
+    auto side = [](int64_t mn_share) {
+        std::vector<PackedPayment> pps;
+        PackedPayment burn;  burn.payee = "!6a"; burn.amount = 1'000;
+        PackedPayment owner; owner.payee = "Xowner";
+        PackedPayment oper;  oper.payee = "Xoper";
+        const int64_t op = (mn_share * K_BPS) / 10000;
+        owner.amount = static_cast<uint64_t>(mn_share - op);
+        oper.amount  = static_cast<uint64_t>(op);
+        pps.push_back(burn); pps.push_back(owner); pps.push_back(oper);
+        return pps;
+    };
+    const auto a = mn_payout_split_shape_str(side(K_MN_SHARE));       // canonical fees
+    const auto b = mn_payout_split_shape_str(side(82'979'299));       // OUR fees (incident)
+    EXPECT_EQ(a, b);
+    EXPECT_EQ(a, "n=2;owner=Xowner;operator=Xoper;bps=800");
+    // And the h=2516595 defect shape (owner-only) is DIFFERENT — the
+    // owner-address-only compare could never see this.
+    std::vector<PackedPayment> defect;
+    PackedPayment owner_all; owner_all.payee = "Xowner";
+    owner_all.amount = static_cast<uint64_t>(K_MN_SHARE);
+    defect.push_back(owner_all);
+    EXPECT_NE(mn_payout_split_shape_str(defect), a);
+}

--- a/test/test_dash_stratum_work_source.cpp
+++ b/test/test_dash_stratum_work_source.cpp
@@ -1734,6 +1734,7 @@ void seed_resolvable_mn(dash::coin::NodeCoinState& cs)
     mn.collateralOutpoint.hash.SetHex(std::string(64, '9'));
     mn.collateralOutpoint.index = 0;
     mn.scriptPayout.m_data = fixture_miner_script();   // standard P2PKH payout
+    mn.payoutSplitProvenance = dash::coin::MNState::SPLIT_KNOWN;   // fixture: proven zero split (h=2516595 gate)
     uint256 protx;
     protx.SetHex(std::string(64, 'a'));
     cs.mnstates().load({{protx, mn}}, /*as_of_height=*/kEmbeddedPrevHeight);

--- a/test/test_dash_superblock.cpp
+++ b/test/test_dash_superblock.cpp
@@ -686,6 +686,9 @@ std::vector<std::pair<uint256, MNState>> single_mn(
     s.nRegisteredHeight = 1'519'000;
     s.nLastPaidHeight = 0;
     s.scriptPayout.m_data = payout;
+    // Hand-seeded fixture: zero operator split, declared PROVEN as every
+    // real ingest path does (h=2516595 serve gate).
+    s.payoutSplitProvenance = MNState::SPLIT_KNOWN;
     return {{raw256(0x01), s}};
 }
 


### PR DESCRIPTION
## Incident

2026-08-05, production, binary ca5c9469 (master df849795b): the FIRST block ever mined on an embedded daemonless template — **h=2516595**, pow `000000000000000d08e71b238e476fc9322a7cd5303dfb7f26eedacb2be390ce` — was **REJECTED by dashd: `ConnectBlock failed, bad-cb-payee`** (getchaintips status=invalid). A won mainnet block was lost.

Coinbase comparison:

| | outputs |
|---|---|
| ours (invalid) | `0.82979299 → XoDo3w4ZUqn93uL3FeRNb9fgfXvgg7BvDC` (owner, full share) |
| canonical (valid) | `0.76413304 → XoDo3w4…` (owner) + `0.06644635 → Xnem6ejaXAfKDTh5PFGSa9ozMQNMY6bvs7` (operator) |

The scheduled MN (`proRegTxHash 0037c2c5…`) has an **8% operator-reward split** registered via ProRegTx. dashd pays the MN share as a SET — `masternode/payments.cpp GetBlockTxOuts`:

```cpp
if (dmnPayee->nOperatorReward != 0 && dmnPayee->pdmnState->scriptOperatorPayout != CScript()) {
    operatorReward = (masternodeReward * dmnPayee->nOperatorReward) / 10000;
    masternodeReward -= operatorReward;
}
if (masternodeReward > 0) voutMasternodePaymentsRet.emplace_back(masternodeReward, scriptPayout);
if (operatorReward > 0)   voutMasternodePaymentsRet.emplace_back(operatorReward, scriptOperatorPayout);
```

and `CheckMasternodePayments` validates scripts AND amounts. Check against the incident: `floor(83'057'939 × 800 / 10000) = 6'644'635` operator + `76'413'304` owner — exact match to the canonical block. The embedded builder paid the entire share to the owner script; the hotel log has zero mentions of operator reward.

## Wire verdict (decides the strategy)

**The split is NOT on the mnlistdiff/qrinfo wire.** `CSimplifiedMNListEntry` (dashd `src/evo/simplifiedmns.h`, verified at v20.1.1 and develop/v23.x) declares `scriptPayout`, `scriptOperatorPayout` (and v23's `payouts`) as **mem-only**; the `SERIALIZE_METHODS` body carries only `nVersion, proRegTxHash, confirmedHash, service/netInfo, pubKeyOperator, keyIDVoting, isValid [, nType, platform fields]`. `nOperatorReward` is not even a member — it lives in `CDeterministicMNState`, sourced from ProRegTx. So the SML can never prove the split, and the fix is **fail-closed serving + daemonless split provenance**, not wire plumbing.

## Can we know the split daemonlessly? YES — and we already did

The shipped state pipeline carries the split end to end; only the consumer ignored it:

- **Checkpoint anchor** (`checkpoints/dash_mn_checkpoint_mainnet.inc`, format field 11/13): carries bps + operator script explicitly. The 2513000 mainnet anchor holds **2974 MNs, 203 with a split (6.8%)**, including incident MN `0037c2c5…` with `800` bps and both scripts — byte-identical to the canonical coinbase outputs.
- **`protx list` seed** (`mn_seed.hpp`): parses `operatorReward` + `operatorPayoutAddress` (consensus `bad-protx-operator-payee` restricts the operator script to P2PKH/P2SH, so the address form is lossless).
- **Block-body replay** (`mn_state_machine.hpp`): ProRegTx carries `nOperatorReward` (immutable thereafter); ProUpServTx carries `scriptOperatorPayout`; both already folded into `MNState`.
- **Observed canonical coinbases** (new): a 2-output MN payment uniquely determines the bps — `bps = ceil(op·10000/(own+op))`, floor-verified; interval width `10000/mnShare ≪ 1`.

## The fix

1. **Builder** (`embedded_gbt.hpp`): emits the payout SET — owner then operator, `floor(mnShare·bps/10000)` truncating division, both `> 0`-guarded — dashd-exact including the bps=10000 no-owner-output edge (one such MN exists on mainnet).
2. **Provenance** (`MNState.payoutSplitProvenance`, mn_state_db format v2 with explicit migration wipe+reseed): SPLIT_KNOWN is set by the checkpoint parser, seed rows that carry the `operatorReward` key, and ProRegTx replay; SPLIT_UNKNOWN by filtered/legacy seeds, undecodable operator addresses (previously a SILENT empty script), observation contradictions, and a ProUpServTx setting a script while we hold bps=0 (consensus proves the real bps>0).
3. **Serve gate** (`node_coin_state.hpp`): new cause, marker-disciplined like the other gates and wall-clock accounted by the cause-agnostic `ServeGateJournal`:
   `cause=mn-payout-split-unprovable value=protx=<12hex> threshold=payout-set-known`
   plus the pre-emit mirrors `emit-mn-payout-split-unprovable` and `emit-mn-payout-split-drift` (amount re-derivation — the defence that would have caught this exact builder defect).
4. **ResetOperatorFields mirror** (`mn_state_machine.hpp`): ProUpRegTx operator-key change and ProUpRevTx now clear `scriptOperatorPayout`/`netInfo`/`platformNodeID` per dashd `dmnstate.h` — the handlers' own doc comment claimed this but the code kept the stale script (pay-a-script-dashd-does-not class).
5. **Pass-3 observation** (`mn_state_machine.hpp`): the accepted coinbase attests the paid MN's current split — cross-checks KNOWN entries (contradiction ⇒ demote + `split_desync`, fail closed), proves UNKNOWN ones (`split_adopted`), superblock-safe without knowing the cycle (unambiguous-shape + floor-verify guards).
6. **Parity surface** (`embedded_oracle_shadow.hpp`): new Equality field `mn_payout_split_shape` — the FULL MN payout set (owner payee, operator payee, derived bps), fee-invariant by construction so it can count as Equality while raw `payee_amounts` stays Informational.
7. **Won-block dispatch log** (`won_block_dispatch.hpp`): `rpc=` is now the tri-state `ok|no-ack|unarmed`. On the incident the summary printed `rpc=off` while ARM B had actually FIRED and carried dashd's rejection — "off" conflated "unarmed" with "consensus no-ack".

## Refusal-rate impact

Steady state ≈ **0%**: every current ingest path proves the split (checkpoint rows explicit, `protx list` always emits `operatorReward`, ProRegTx replay exact). The gate is a regression tripwire, not a tax. Counterfactuals, measured against the 2513000 anchor:

- Filtered/legacy seed (no operator fields): 203/2974 MNs (6.8%) start UNKNOWN → ~6.8% of heights refused, decaying as payments are observed. Observation-only warm-up is anti-correlated with scheduling (the next payee is the LEAST-recently-paid MN), so coverage stays ~0% for the first payment cycle (~2974 blocks ≈ 5 days) — but the checkpoint-lane body replay (anchor→tip, 3595+ blocks > one full cycle) already spans it, so even that posture converges at startup.
- New registrations: proven exactly from their ProRegTx; never refused.
- Residual refusals: an MN whose ProUpServTx sets a script while its bps is unproven — refused for at most one scheduling (~1 height) until its payment is observed. ≪1% of heights.

## Tests (fails-on-master KATs, allowlisted target)

`test/test_dash_operator_split.cpp`, folded into the allowlisted `test_dash_embedded_gbt` target (`check_test_target_allowlist.py` passes):

- (a) builder emits BOTH outputs with dashd-exact amounts — KAT'd with the real h=2516595 values (83'057'939 → 76'413'304 + 6'644'635 @ 800 bps, canonical addresses re-encoded from the scripts) — **fails on master** (single output);
- (b) unproven split → REFUSED with the named cause at viability AND emit, negative-pass with the guard off reproduces the incident posture — **fails on master** (no such cause);
- (c) proven zero split → single owner output exactly as before;
- plus: truncation edges (bps=1 → 0-duff operator output omitted; bps=10000 → owner output omitted), ResetOperatorFields mirror (type 3 + 4) — **fails on master** (stale script kept), pass-3 adoption/demotion with the incident's canonical amounts, emit-gate drift rejection of the exact incident template shape, and fee-invariance of the shadow split field.

## Class sweep: the full dashd payment neighborhood

The original dashd miner audit swept `BlockAssembler`/`CreateNewBlock` but missed `CMasternodePayments::GetBlockTxOuts` one call deeper. This table closes the CLASS: every output-semantics in dashd's coinbase payment neighborhood (`masternode/payments.cpp` `FillBlockPayments → GetMasternodeTxOuts → GetBlockTxOuts` + `CSuperblockManager::GetSuperblockPayments`, v20.1.1), each either (a) already modeled (site cited), (b) fixed in this PR, or (c) a named fail-closed refusal.

| dashd output semantics | disposition |
|---|---|
| **MN owner output** — script from ProRegTx/ProUpRegTx (consensus `bad-protx-payee`: P2PKH/P2SH only), amount = mnShare − operatorReward, emplaced first, `if (masternodeReward > 0)` guarded | **(b) FIXED** — `embedded_gbt.hpp` split emission; `>0` guard mirrored (bps=10000 → owner output omitted, KAT'd; one such MN exists at the anchor); P2PKH/P2SH + `!hex` fallback conversion already handled |
| **MN operator output** — `floor(mnShare·bps/10000)`, iff `nOperatorReward != 0 && scriptOperatorPayout != CScript()`, `if (operatorReward > 0)` guarded, emplaced after owner | **(b) FIXED** — the incident defect; truncating division verbatim, KAT vs real h=2516595 amounts |
| **Rounding & order** — truncating integer division; owner→operator; platform burn emplaced before both | (a)+(b): split order/rounding (b); burn-first ordering already modeled (`embedded_gbt.hpp` platform-burn block, byte-proven by the oracle-shadow `platform_burn_amount`/cbtx byte parity) |
| **MN share amount** — `GetMasternodePayment(h, blockSubsidy + feeReward, v20)` = 75% post-v20; historical realloc brackets below V20 | (a) `subsidy.hpp compute_dash_mn_payment_post_v20` (`embedded_gbt.hpp` block-value seam); pre-V20 brackets unreachable (anchor 2513000 ≫ V20 1987776) |
| **MN_RR platform share** — `PlatformShare(masternodeSubsidyReward)`: computed on the SUBSIDY-only MN share (fees excluded), OP_RETURN credit-pool burn, unconditional once `DEPLOYMENT_MN_RR` is active | (a) `subsidy.hpp compute_dash_platform_reward_post_v20_mn_rr` is height-only (fees excluded — matches `masternodeSubsidyReward`); burn emitted as `"!6a"`; live byte-parity-proven; creditPool interaction gated (`emit-creditpool-*` causes) |
| **No payee resolvable** (`GetBlockTxOuts` error branch) | (c) existing named refusal `cause=payee-unresolvable` (#996, `node_coin_state.hpp`) |
| **Payee resolvable but split unprovable daemonlessly** | **(c) NEW** named refusal `cause=mn-payout-split-unprovable` + `emit-` mirror + `emit-mn-payout-split-drift` amount re-derivation |
| **Superblock payments** — `AreSuperblocksEnabled(spork 9) && IsSuperblockTriggered`; trigger schedule, budget-capped; appended after MN outputs; coinbasevalue augmented | (a)+(c): schedule via `superblock.hpp::get_superblock_payments` (budget cap, all amounts>0); serve gated on govsync completeness + trigger-confidence, every non-confident branch refuses (`superblock-refused` / `emit-superblock-refused`); ordering + coinbasevalue augmentation modeled (`embedded_gbt.hpp` E-SUPERBLOCK seam); connect-time cross-check (`cross_check_superblock_on_block`). **Named residual**: `SPORK_9_SUPERBLOCKS_ENABLED` is not observable daemonlessly — a spork-off emergency while trigger-confident would over-pay treasury at a superblock height (1/16616 heights, spork has been on for years); permanently refusing every superblock height was judged the worse trade. Documented, not silently assumed. |
| **CbTx** (type-5 extra payload, not a vout) | (a) `build_embedded_cbtx` + emit gates (`emit-cbtx-unparseable/-height-drift`, `emit-mnlist-root-drift`, `emit-quorum-root-drift`, `emit-creditpool-value-drift`) |
| **Credit-pool withdrawals** | (a)-N/A: asset-unlocks are separate type-9 txs, never coinbase vouts; balance effects in `credit_pool.hpp` |
| **Miner payout outputs** | (a) c2pool's own PPLNS outputs (`coinbase_builder.hpp compute_dash_payouts`); miner share = block value − MN set − burn |
| **`IsBlockValueValid` cap** (coinbasevalue = subsidy+fees [+superblock]) | (a) `m_coinbase_value` arithmetic, KAT'd (`WorkdataHeaderFieldsAndSubsidyArithmetic`) |
| **EvoNode consecutive-payment scheduling** | (a) selection-side, not vout semantics — `nConsecutivePayments` modeled in the payee queue |

## Coordination

- **#1104** (shadow-compare, open): untouched here — no edits to `embedded_shadow_compare.hpp` / `work_source.*` / `main_dash.cpp`. Both PRs append a source to the `test_dash_embedded_gbt` fold in `test/CMakeLists.txt` (trivial adjacent-line merge). Once both land, `shadow_mn_payee()` (first non-burn payee) should switch to the reusable `mn_payout_split_shape_str()` digest so the shadow compares the full payout set too.
- **ARM B finding** (reported, log-only fix included): the submitblock RPC backup DID fire on the incident — `"no-ack"` at `won_block_dispatch.hpp:222` is only reachable when the sink is wired; dashd rejected the (invalid) block and `submit_block_hex(..., ignore_failure=false)` correctly returned false. The `rpc=off` summary label was the misleading part; disambiguated above. No wiring defect.

Label: do-not-merge (DASH lane). Base: master (includes #1102 df849795b, #1103 96892428f).
