### PR TITLE
dash(stratum): close the tip-transition fallback leak — serve-tip promotion re-evaluates the arm on the very next template request

### DIFF
--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -364,11 +364,18 @@ public:
         // BODY-FIRST: an authoritative snapshot loaded as-of the pending tip
         // completes the payee axis — the last promotion precondition when the
         // credit-pool seed already reached the tip (diff-before-seed order).
-        maybe_promote_pending_tip();
+        const bool promoted = maybe_promote_pending_tip();
         if (!m_have_mn)
             demote();
         else
             republish();
+        // The promotion just closed a pending window during which the work
+        // source cached a fallback (or old-tip) decision. Re-issue work
+        // event-driven — same sink as the body-fold promotion — so the next
+        // template request re-evaluates the arm instead of riding the stale
+        // cache until an unrelated signal lands.
+        if (promoted)
+            notify_state_dirty();
     }
 
     /// Reception path (mnlistdiff, SML axis — DAEMONLESS CCbTx source): apply a
@@ -870,6 +877,14 @@ public:
         m_tip_overdue_latched = false;
         if (maybe_promote_pending_tip()) {
             republish();
+            // Promotion is a serve-arm transition, not just a state write: the
+            // work source may hold a fallback template cached during the (now
+            // closed) pending window. Fire the same event-driven re-issue path
+            // the body-fold promotion uses (bump + notify), so the very next
+            // template request re-evaluates the arm — without this the stale
+            // cached decision keeps serving dashd-fallback until the next
+            // unrelated work signal.
+            notify_state_dirty();
             return;
         }
         m_state.set_tip_body_pending_dbg(true);

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -493,10 +493,33 @@ void DASHWorkSource::resource_template_now() const
     }
     // Tip moved since the last snapshot? Bump work_generation_ so sessions
     // detect stale work between their timer firings and re-push.
-    if (template_cache_ && template_cache_->m_previous_block != work.m_previous_block)
+    uint64_t self_bumps = 0;
+    if (template_cache_ && template_cache_->m_previous_block != work.m_previous_block) {
         work_generation_.fetch_add(1, std::memory_order_relaxed);
+        self_bumps = 1;
+    }
     template_cache_ = std::make_shared<const coin::DashWorkData>(std::move(work));
-    template_cache_gen_ = work_generation_.load(std::memory_order_relaxed);
+    // ── Tip-transition fallback leak (serve-tip promotion) ──────────────────
+    // Stamp the snapshot with the generation observed BEFORE sourcing began
+    // (gen_at_source, same discipline the negative cache already uses), not a
+    // load() taken here at store time. The difference is exactly the events
+    // that landed WHILE this (blocking — the fallback arm is a dashd GBT RPC)
+    // source was in flight: on every new block the serve-tip promotion's
+    // state-dirty bump (body fold, ~0.1-0.4 s after the header tip) routinely
+    // races the pending-window re-source, and a store-time stamp swallowed it
+    // — the dashd-fallback template read as CURRENT for the full kStaleAfter
+    // (30 s) window and several fallback serves leaked per block after the
+    // embedded arm was already viable. With the pre-source stamp a racing
+    // bump leaves the stored snapshot one generation behind, so the very next
+    // template request re-evaluates the arm gates (event-driven resume, the
+    // same break-through semantics as the soak0804e negative-cache fix). The
+    // own tip-moved bump above is accounted for (self_bumps): when NOTHING
+    // external raced, the stamp equals today's load() and behaviour is
+    // byte-identical — no re-source storm on ordinary tip rotation.
+    const uint64_t gen_now = work_generation_.load(std::memory_order_relaxed);
+    template_cache_gen_ = (gen_now == gen_at_source + self_bumps)
+                              ? gen_now
+                              : gen_at_source;
     template_cache_at_  = now;
     template_cache_is_embedded_ = work_is_embedded;
     template_last_fail_at_ = {};

--- a/test/test_dash_coin_state_maintainer.cpp
+++ b/test/test_dash_coin_state_maintainer.cpp
@@ -1622,3 +1622,83 @@ TEST(DashCoinStateMaintainer, ReorgWithinBufferReplaysCreditPoolUndoFromRetained
         << "beyond the buffer the existing wipe + cold-resync path stays";
     EXPECT_EQ(st2.credit_pool(), 0);
 }
+
+// ════════════════════════════════════════════════════════════════════════
+// Tip-transition fallback leak: EVERY serve-tip promotion site must fire the
+// state-dirty re-issue sink (bump + notify), not only the body-fold one —
+// otherwise the work source rides a fallback decision cached during the (now
+// closed) pending window until the next unrelated signal, and fallback serves
+// leak for seconds after the fold. Latency only: no gate is weakened.
+// ════════════════════════════════════════════════════════════════════════
+
+// Body raced AHEAD of the header event (block message processed before the
+// header-chain tip callback): on_new_tip promotes immediately — and must
+// re-issue work. FAILS-ON-MASTER: that branch republished and returned
+// without firing the sink.
+TEST(DashCoinStateMaintainer, BodyFirstRacedBodyPromotionOnHeaderFiresStateDirty) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    m.set_body_first_serve_tip(true);
+    st.set_require_fresh_credit_pool(true);
+    int dirty = 0;
+    m.set_on_state_dirty([&] { ++dirty; });
+    m.on_mn_list_update(single_mn(p2pkh_script(0x30)));
+
+    auto b1 = make_cbtx_block(H - 1, 111'000'000LL, p2pkh_script(0x30));
+    m.on_new_tip(H - 1, block_hash_of(b1), BITS, MTP,
+                 DASH_PUBKEY_VER, DASH_P2SH_VER, CURTIME, VERSION);
+    m.on_block_connected(b1, H - 1);
+    ASSERT_TRUE(m.live());
+
+    // The BODY of H arrives first: the seed advances to H, but no pending
+    // window is open, so the serve tip holds at the parsed H-1.
+    auto b2 = make_cbtx_block(H, next_balance(st, 111'000'000LL, H),
+                              p2pkh_script(0x30));
+    m.on_block_connected(b2, H);
+    ASSERT_EQ(st.credit_pool_height(), static_cast<int32_t>(H));
+    ASSERT_EQ(m.serve_tip_height(), H - 1);
+
+    // The header event lands: promotion is immediate (inputs already parsed)
+    // and MUST re-issue work event-driven.
+    const int dirty_before = dirty;
+    m.on_new_tip(H, block_hash_of(b2), BITS, MTP,
+                 DASH_PUBKEY_VER, DASH_P2SH_VER, CURTIME, VERSION);
+    EXPECT_EQ(m.serve_tip_height(), H)
+        << "body raced ahead: the header event must promote immediately";
+    EXPECT_FALSE(m.tip_body_pending());
+    EXPECT_GT(dirty, dirty_before)
+        << "immediate promotion must fire the re-issue sink (bump + notify)";
+}
+
+// Cold-start diff-before-seed order: the authoritative snapshot as-of the
+// pending tip completes the payee axis — the LAST promotion precondition —
+// and that promotion must re-issue work too. FAILS-ON-MASTER: the
+// on_mn_list_update promotion ended in republish() with no sink fire.
+TEST(DashCoinStateMaintainer, BodyFirstSnapshotPromotionFiresStateDirty) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    m.set_body_first_serve_tip(true);
+    st.set_require_fresh_credit_pool(true);
+    int dirty = 0;
+    m.set_on_state_dirty([&] { ++dirty; });
+    // Payee cursor one behind the pending tip: the tip-targeted diff may NOT
+    // promote (payee-stale hold, pinned elsewhere)...
+    m.on_mn_list_update(single_mn(p2pkh_script(0x30)), /*as_of_height=*/H - 1);
+    const uint256 tip_hash = raw256(0x54);
+    m.on_new_tip(H, tip_hash, BITS, MTP, DASH_PUBKEY_VER, DASH_P2SH_VER,
+                 CURTIME, VERSION);
+    m.on_mnlistdiff(diff_with_seed(uint256::ZERO, tip_hash, H,
+                                   111'000'000LL, sml_entry(0x40)));
+    ASSERT_TRUE(m.tip_body_pending());
+    ASSERT_EQ(m.serve_tip_height(), 0u);
+
+    // ...then the authoritative snapshot as-of the tip lands: promotion — and
+    // the event-driven re-issue with it.
+    const int dirty_before = dirty;
+    m.on_mn_list_update(single_mn(p2pkh_script(0x30)), /*as_of_height=*/H);
+    EXPECT_EQ(m.serve_tip_height(), H)
+        << "snapshot as-of the tip completes the payee axis and promotes";
+    EXPECT_FALSE(m.tip_body_pending());
+    EXPECT_GT(dirty, dirty_before)
+        << "snapshot promotion must fire the re-issue sink (bump + notify)";
+}

--- a/test/test_dash_stratum_work_source.cpp
+++ b/test/test_dash_stratum_work_source.cpp
@@ -1942,6 +1942,94 @@ TEST(DashStratumC1MainnetGate, GbtXcheckServesDashdOnCreditPoolMismatch)
         << "on a creditPool mismatch the backstop must serve dashd's template";
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Tip-transition fallback leak: on every new block the serve path re-sources
+// during the body-pending window and (correctly) gets the dashd fallback; the
+// serve-tip promotion then lands ~0.1-0.4 s later — routinely WHILE that
+// blocking fallback GBT source is still in flight. The promotion fires the
+// state-dirty sink (bump_work_generation + notify_all), but master stamped the
+// stored snapshot with a work_generation_.load() taken AT STORE TIME, which
+// swallows the racing bump: the fallback template reads as current for the
+// full kStaleAfter (30 s) window and several fallback serves leak per block
+// after the embedded arm is already viable.
+//
+// THE MEASUREMENT (fails on master): after the promotion's bump, the very
+// next template request must re-evaluate the arm gates and serve EMBEDDED —
+// not the stale cached fallback decision. Gate semantics are untouched; only
+// the re-evaluation latency is.
+TEST(DashStratumC1MainnetGate, PromotionBumpDuringInFlightSourceMakesNextTemplateEmbedded)
+{
+    dash::coin::NodeCoinState cs;   // NOT populated yet: the pending window
+    dash::stratum::DASHWorkSource* wsp = nullptr;
+    int fallback_calls = 0;
+    auto fallback = [&]() -> dash::coin::DashWorkData {
+        if (++fallback_calls == 1) {
+            // The serve-tip promotion lands while this (in prod: blocking
+            // dashd GBT RPC) source is in flight: the maintainer publishes
+            // the now-viable embedded bundle and fires the state-dirty sink.
+            seed_populated(cs);
+            if (wsp) wsp->bump_work_generation();
+        }
+        return rich_work();
+    };
+    auto submit = [](const std::vector<unsigned char>&, uint32_t, bool) { return true; };
+    dash::stratum::DASHWorkSource ws(cs, fallback, submit,
+                                     core::stratum::StratumConfig{},
+                                     /*is_testnet=*/true);
+    wsp = &ws;
+
+    // Serve 1: sourced during the pending window -> dashd fallback (the
+    // normal propagation-window serve; the promotion lands mid-flight).
+    auto t1 = ws.get_current_work_template();
+    ASSERT_FALSE(t1.empty());
+    EXPECT_EQ(t1.value("previousblockhash", ""), std::string(kPrevHashHex))
+        << "the in-flight serve itself is the fallback — that part is normal";
+
+    // Serve 2 — the very next template request after the promotion: must be
+    // EMBEDDED. On master the fallback snapshot was stamped with the
+    // post-bump generation, so it reads as fresh and this serves fallback.
+    uint256 emb_prev; emb_prev.SetHex(kEmbeddedPrevHashHex);
+    auto t2 = ws.get_current_work_template();
+    ASSERT_FALSE(t2.empty());
+    EXPECT_EQ(t2.value("previousblockhash", ""), emb_prev.GetHex())
+        << "stale cached arm decision leaked a dashd-fallback serve after "
+           "the serve-tip promotion";
+    EXPECT_EQ(t2.value("height", 0u), kEmbeddedPrevHeight + 1u);
+
+    dash::stratum::WorkJobTargetInputs job_in;
+    job_in.sane_target_min.SetHex(
+        "0000000000000000000000000000000000000000000000000000000000000001");
+    job_in.sane_target_max.SetHex(
+        "00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    job_in.share_info_bits_target.SetHex(
+        "0000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    auto gw = ws.get_work(job_in);
+    EXPECT_EQ(gw.source, dash::coin::WorkSource::Embedded);
+}
+
+// Negative twin: an ORDINARY re-source with no racing event must keep today's
+// exact caching behaviour — stored fresh, served from cache, ONE sourcing —
+// so the promotion fix cannot regress into a re-source storm.
+TEST(DashStratumC1MainnetGate, UnracedSourceStaysCachedWithoutReSourceStorm)
+{
+    dash::coin::NodeCoinState cs;   // unpopulated: fallback arm throughout
+    int fallback_calls = 0;
+    auto fallback = [&]() -> dash::coin::DashWorkData {
+        ++fallback_calls;
+        return rich_work();
+    };
+    auto submit = [](const std::vector<unsigned char>&, uint32_t, bool) { return true; };
+    dash::stratum::DASHWorkSource ws(cs, fallback, submit,
+                                     core::stratum::StratumConfig{},
+                                     /*is_testnet=*/true);
+
+    ASSERT_FALSE(ws.get_current_work_template().empty());
+    const int calls_after_first = fallback_calls;
+    ASSERT_FALSE(ws.get_current_work_template().empty());
+    EXPECT_EQ(fallback_calls, calls_after_first)
+        << "no event fired between serves: the second must be a cache hit";
+}
+
 TEST(DashDashboardWiring, LocalStatsIdleWarningWhenNoWorkers)
 {
     // No provider wired and an empty local registry -> the honest idle warning


### PR DESCRIPTION
## Defect (DASH lane, daemonless/embedded serve path)

On every new block the serve path re-sources during the tip-body-pending window and (correctly) gets the dashd fallback. The serve-tip promotion (`[EMB-DASH] serve tip promoted`) then lands ~0.1–0.4 s later — routinely **while that blocking fallback GBT source is still in flight**. `resource_template_now()` stamped the stored snapshot with `work_generation_.load()` taken **at store time**, which swallows the promotion's state-dirty bump: the fallback template reads as current for the full `kStaleAfter` (30 s) window, and several fallback serves leak per block after the embedded arm is already viable. Two maintainer promotion sites additionally never fired the state-dirty sink at all.

## Fix — re-evaluation latency only, no gate semantics change

1. **`src/impl/dash/stratum/work_source.cpp`** — stamp the stored template with the generation observed *before* sourcing began (`gen_at_source`, the same discipline the soak0804e negative cache already uses), accounting for the own tip-moved bump. A bump that raced the in-flight source leaves the snapshot one generation behind, so the **very next template request re-evaluates the arm gates** (event-driven, PR #770 lineage break-through semantics). When nothing raced, the stamp equals the old `load()` — byte-identical, no re-source storm.
2. **`src/impl/dash/coin/coin_state_maintainer.hpp`** — every serve-tip promotion now fires the state-dirty sink (bump + notify_all): adds it to the body-raced-ahead promote in `on_new_tip` and the authoritative-snapshot promote in `on_mn_list_update`; the body-fold and mnlistdiff sites already had it.

## Measurement (KATs fail on master; folded into allowlisted targets)

- `DashStratumC1MainnetGate.PromotionBumpDuringInFlightSourceMakesNextTemplateEmbedded` — after the promotion's bump, the next template must be **EMBEDDED**; on master the stale cached decision serves fallback. **FAILS on master.**
- `DashStratumC1MainnetGate.UnracedSourceStaysCachedWithoutReSourceStorm` — negative twin (passes on both): ordinary re-source stays a single sourcing + cache hit.
- `DashCoinStateMaintainer.BodyFirstRacedBodyPromotionOnHeaderFiresStateDirty`, `DashCoinStateMaintainer.BodyFirstSnapshotPromotionFiresStateDirty` — **FAIL on master** (those promotion sites republished silently).

Verified locally (Release, gcc13/conan profile): `test_dash_stratum_work_source` 70/70, `test_dash_coin_state_maintainer` 35/35 with the fix; the three KATs red when the two src files are reverted to master. `tools/ci/check_test_target_allowlist.py` passes — no new test targets, tests folded into `test_dash_stratum_work_source` and `test_dash_coin_state_maintainer` (both in the build.yml `--target` allowlist).

DASH-lane only; no hotel deploy in this PR.
