### PR TITLE
dash(embedded): close the mempool-tx body-path gaps G1-G4; fee-carrying templates behind --embedded-serve-mempool-txs (default OFF)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -262,7 +262,7 @@ void print_banner(const char* argv0)
         << "           [--web-port PORT] [--web-host ADDR] [--dashboard-dir PATH]\n"
         << "           [--external-ip ADDR]\n"
         << "           [--embedded-utxo] [--embedded-mainnet] [--embedded-mn-bridge-max N]\n"
-        << "           [--embedded-utxo-immature-serve-empty]\n"
+        << "           [--embedded-utxo-immature-serve-empty] [--embedded-serve-mempool-txs]\n"
         << "           [--bestcl-policy freshness|consensus-exact]\n"
         << "           [--embedded-oracle-shadow]\n"
         << "           [--embedded-shadow-compare]\n"
@@ -557,6 +557,12 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              // semantics: an unsynced node does not serve templates; the dashd
              // fallback serves full ones where armed) -- the pre-policy behaviour.
              bool embedded_utxo_immature_serve_empty = false,
+             // --embedded-serve-mempool-txs: OPT-IN fee-carrying embedded
+             // templates. Default false = coinbase-only body even with a
+             // mature UTXO lane (cause "mempool-txs-disabled"); the mempool-tx
+             // body path (G1-G4 guards, mempool.hpp) only enters block
+             // production when the operator explicitly arms it.
+             bool embedded_serve_mempool_txs = false,
              // --embedded-shadow-compare: OBSERVE-only serve-vs-dashd block-
              // template field diff (diagnostic; NOT a serve gate). Off the hot
              // path (worker-thread dashd fetch). Default false; only meaningful
@@ -1614,6 +1620,24 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // references it (reverse destruction order at scope exit).
     dash::coin::UtxoLane utxo_lane;
     dash::coin::NodeCoinState node_coin_state;
+
+    // ── Mempool-tx serving switch (--embedded-serve-mempool-txs) ────────────
+    // DEFAULT OFF: embedded templates carry a coinbase-only body even once the
+    // UTXO lane matures (suppress cause "mempool-txs-disabled" on the template
+    // + log). The fee-carrying mempool-tx body path — topological selection
+    // (G1), sigop cap (G2), coinbase-maturity (G3), islock-conflict (G4)
+    // guards, mempool.hpp — is an explicit soak-gated operator opt-in, not an
+    // implicit consequence of UTXO maturity. Audit:
+    // DASH_CONNECTBLOCK_REJECT_SURFACE_AUDIT.md §1. The dashd fallback arm is
+    // unaffected (its GBT bodies come from dashd itself).
+    node_coin_state.set_serve_mempool_txs(embedded_serve_mempool_txs);
+    std::cout << "[run] embedded mempool-tx serving: "
+              << (embedded_serve_mempool_txs
+                      ? "ON (--embedded-serve-mempool-txs: fee-carrying "
+                        "templates once the UTXO lane matures)"
+                      : "OFF (default: coinbase-only body, cause="
+                        "mempool-txs-disabled; fees forgone, values exact)")
+              << "\n";
 
     // ── E2b (#738): the embedded UTXO/fee lane -- OPT-IN via --embedded-utxo.
     // Transliterated from the PROVEN LTC wiring (main_ltc.cpp ~1750-1801 con-
@@ -5273,6 +5297,12 @@ int main(int argc, char** argv)
     // body instead -- consensus-valid, fees exactly 0, nothing to overstate
     // (see NodeCoinState::set_utxo_immature_policy).
     bool embedded_utxo_immature_serve_empty = false;
+    // --embedded-serve-mempool-txs: OPT-IN fee-carrying embedded templates.
+    // Default OFF = coinbase-only serving (values exact, fees forgone); the
+    // mempool-tx body path with its G1-G4 guards (mempool.hpp; audit
+    // DASH_CONNECTBLOCK_REJECT_SURFACE_AUDIT.md) arms only on explicit
+    // operator decision.
+    bool embedded_serve_mempool_txs = false;
     std::string bestcl_policy = "freshness";   // --bestcl-policy: freshness (default, conservative proxy) | consensus-exact (dashcore's actual CheckCbTxBestChainlock rule)
     bool embedded_oracle_shadow = false;       // --embedded-oracle-shadow: per-block dashd cross-check (OBSERVE-only)
     bool embedded_shadow_compare = false;      // --embedded-shadow-compare: serve-vs-dashd template diff (OBSERVE-only, NOT a gate)
@@ -5354,6 +5384,8 @@ int main(int argc, char** argv)
             embedded_utxo = true;
         else if (std::strcmp(argv[i], "--embedded-utxo-immature-serve-empty") == 0)
             embedded_utxo_immature_serve_empty = true;
+        else if (std::strcmp(argv[i], "--embedded-serve-mempool-txs") == 0)
+            embedded_serve_mempool_txs = true;
         else if (std::strcmp(argv[i], "--bestcl-policy") == 0 && i + 1 < argc)
             bestcl_policy = argv[++i];
         else if (std::strcmp(argv[i], "--coinbase-text") == 0 && i + 1 < argc)
@@ -5513,6 +5545,7 @@ int main(int argc, char** argv)
                         embedded_oracle_shadow, oracle_grad_blocks,
                         oracle_class_coverage, coin_p2p_peers, bestcl_policy,
                         embedded_utxo_immature_serve_empty,
+                        embedded_serve_mempool_txs,
                         embedded_shadow_compare);
     }
     return run_selftest();

--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -813,12 +813,32 @@ public:
     /// mempool yields a valid coinbase-only template -- so this never gates
     /// publication; it only enriches the next assembled template. Returns the
     /// mempool's accept verdict (false = rejected: bad utxo ref / already in).
+    ///
+    /// ██ SOLE-INGESTION-PATH INVARIANT ██ This method (fed exclusively by
+    /// wire_mempool_ingest <- interfaces::Node::new_tx <- dashd-peer relay)
+    /// is the ONLY route into Mempool::add_tx. The audit's two
+    /// N-A-BY-SOURCE-INVARIANT rows (bad-txns-nonfinal, mandatory-script-
+    /// verify-flag; DASH_CONNECTBLOCK_REJECT_SURFACE_AUDIT.md §6) hold only
+    /// while that stays true -- see the invariant block atop mempool.hpp
+    /// before adding any other caller.
     bool on_mempool_tx(const MutableTransaction& tx) {
         // Mempool relay is the highest-cadence event through the maintainer,
         // so it doubles as the clock the tip-body-overdue bound is checked on
         // (the maintainer owns no timer; see check_tip_body_overdue).
         check_tip_body_overdue();
         return m_state.mempool().add_tx(tx);
+    }
+
+    /// G4 seam (audit conflict-tx-lock): fold a relayed InstantSend lock into
+    /// the mempool's islock-conflict tracking -- evicts a conflicting pool
+    /// entry immediately and keeps the outpoints excluded from template
+    /// selection (Mempool::add_islock, incl. the documented residual race).
+    /// FEED: the coin-P2P isdlock parse leg (dashd-peer relay, same source
+    /// invariant as on_mempool_tx); until that leg lands nothing calls this
+    /// in a live node and selection behaviour is unchanged (empty map).
+    void on_islock(const uint256& locked_txid,
+                   const std::vector<std::pair<uint256, uint32_t>>& inputs) {
+        m_state.mempool().add_islock(locked_txid, inputs);
     }
 
     /// Header / think path: the chain tip advanced. Stash the params the

--- a/src/impl/dash/coin/embedded_gbt.hpp
+++ b/src/impl/dash/coin/embedded_gbt.hpp
@@ -185,7 +185,15 @@ inline DashWorkData build_embedded_workdata(
     // one path that does not depend on it at all.
     //
     // Default false => every existing positional caller is byte-unchanged.
-    bool suppress_mempool_txs = false)
+    bool suppress_mempool_txs = false,
+    // NAME-THE-STATE seam for the suppressed body: WHY this template is
+    // coinbase-only. Two producers exist: the UTXO-immature serving window
+    // (the historical default, kept as the default string so every existing
+    // positional caller is byte-unchanged) and the --embedded-serve-mempool-txs
+    // default-OFF posture ("mempool-txs-disabled", node_coin_state.hpp). The
+    // cause rides the template (m_txset_empty_cause) + the log line, so soaks
+    // can tell the two coinbase-only modes apart.
+    const char* txset_empty_cause = "utxo-immature-serving")
 {
     DashWorkData w;
     w.m_height          = prev_height + 1;
@@ -211,11 +219,16 @@ inline DashWorkData build_embedded_workdata(
     // mempool is not even consulted for selection (only, below, for the forgone-
     // fee report), so no partially-warm UTXO view can price anything into this
     // template.
+    // next_height threads the G3 coinbase-maturity check into selection: a
+    // vin spending a UTXO coinbase younger than 100 confs AT THIS HEIGHT is
+    // refused (bad-txns-premature-spend-of-coinbase). Selection is also
+    // topological (G1) and sigop-capped (G2) — see mempool.hpp.
     auto [selected, total_fees] =
         suppress_mempool_txs
             ? std::pair<std::vector<Mempool::SelectedTx>, uint64_t>{{}, 0ull}
             : mempool.get_sorted_txs_with_fees(MAX_BLOCK_BYTES,
-                                               /*exclude_special=*/true);
+                                               /*exclude_special=*/true,
+                                               /*next_height=*/w.m_height);
     // MN-collateral spend filter (sml_projection.hpp, FINDING-2). The C-3
     // special-tx cut above is NOT sufficient: dashd's verifier removes a
     // masternode from the list when ANY block tx — special or not — spends
@@ -344,11 +357,11 @@ inline DashWorkData build_embedded_workdata(
         // log, with the price attached. A soak greps this to answer both "how
         // long did the node run coinbase-only" and "what did that cost".
         const uint64_t mempool_fees = mempool.total_known_fees();
-        w.m_txset_empty_cause  = "utxo-immature-serving";
+        w.m_txset_empty_cause  = txset_empty_cause;
         w.m_txset_forgone_fees = mempool_fees;
         if (underfill_tripped) *underfill_tripped = false;
         LOG_INFO << "[GBT-EMB] arm=EMBEDDED txset=empty"
-                 << " cause=utxo-immature-serving"
+                 << " cause=" << txset_empty_cause
                  << " h=" << w.m_height
                  << " mempool_tx=" << mempool.size()
                  << " forgone_fees<=" << mempool_fees

--- a/src/impl/dash/coin/mempool.hpp
+++ b/src/impl/dash/coin/mempool.hpp
@@ -35,10 +35,27 @@
 ///     us catching it via remove_for_block conflict path)
 ///   - Orphan-children removal after conflict eviction
 ///   - Lightweight summary API for the explorer/dashboard
+///
+/// ██ SOLE-INGESTION-PATH INVARIANT (audit N-A-BY-SOURCE-INVARIANT rows) ██
+/// The ONLY path that feeds add_tx() in a live node is dashd-peer relay:
+/// interfaces::Node::new_tx → wire_mempool_ingest (mempool_ingest.hpp) →
+/// CoinStateMaintainer::on_mempool_tx → add_tx. Two whole ConnectBlock
+/// reject classes are argued N-A on exactly this invariant
+/// (DASH_CONNECTBLOCK_REJECT_SURFACE_AUDIT.md §6):
+///   - bad-txns-nonfinal (BIP68/locktime): relay-admitted txs are final at
+///     admission and finality is monotonic in height/MTP;
+///   - mandatory-script-verify-flag (CheckInputScripts): relay-admitted txs
+///     passed full script checks at every relaying dashd, and we never
+///     mutate tx bytes.
+/// If ANY other ingestion seam is ever added (RPC sendrawtransaction, local
+/// wallet submission, cross-coin tx forward, BIP35 sync drain), those two
+/// rows become GAPs: re-audit and add local finality + script checks BEFORE
+/// wiring it. Do not silently add callers of add_tx().
 
 #include "block.hpp"
 #include "transaction.hpp"
 #include "utxo_adapter.hpp"
+#include "sigops.hpp"             // G2: bad-blk-sigops accounting during selection
 #include "vendor/assetlock.hpp"   // DIP-0027 CAssetUnlockPayload (type-9 fee source)
 
 #include <core/uint256.hpp>
@@ -50,6 +67,7 @@
 #include <atomic>
 #include <cstdint>
 #include <ctime>
+#include <deque>
 #include <map>
 #include <set>
 #include <mutex>
@@ -225,11 +243,82 @@ public:
             }
         }
 
+        // G4: an outpoint spent by a CONFIRMED tx is resolved — whatever
+        // islock claimed it is now enforced (or moot) by the chain itself, so
+        // the tracking entry has done its job. Prune it.
+        for (const auto& mtx : block.m_txs) {
+            for (const auto& vin : mtx.vin) {
+                m_islock_outpoints.erase(
+                    std::make_pair(vin.prevout.hash, vin.prevout.index));
+            }
+        }
+
         if (removed > 0 || conflicts > 0) {
             LOG_INFO << "[MEMPOOL] block cleanup removed=" << removed
                      << " conflicts=" << conflicts
                      << " remaining=" << m_pool.size();
         }
+    }
+
+    // ── G4 (audit): InstantSend-lock conflict tracking ──────────────────
+    /// Register an islock: `locked_txid` holds the exclusive InstantSend
+    /// right to spend each outpoint in `inputs`. dashd rejects a block
+    /// containing any tx that conflicts with a known islock
+    /// (validation.cpp:2622 `conflict-tx-lock`), so the template builder
+    /// must never pack such a tx. Two defences, mirroring dashd's own
+    /// CInstantSendManager::RemoveConflictingLock posture:
+    ///   1. eviction NOW: any pool entry already spending one of these
+    ///      outpoints under a DIFFERENT txid is removed immediately;
+    ///   2. selection guard: get_sorted_txs_with_fees() re-checks every
+    ///      candidate vin against this map (belt for txs admitted between
+    ///      islock arrival and eviction, and for re-added conflicts).
+    ///
+    /// RESIDUAL RACE (documented, not closable node-side): an islock that
+    /// FORMS (or reaches us) after a template was emitted can invalidate a
+    /// share won on that template — the islock-formation window. dashd's
+    /// validator itself waives conflict-tx-lock once the block is
+    /// chainlocked (validation.cpp:2612 has_chainlock override), so the
+    /// exposure is one islock-vs-block race per conflicting spend, the same
+    /// race dashd's own miner runs. There is no pre-emit oracle for "an
+    /// islock will form for the OTHER spend"; tracking known locks is the
+    /// full extent of what any miner can do.
+    ///
+    /// FEED: dashd-peer relay (the sole-ingestion-path invariant covers
+    /// islocks too — they arrive from the same relay peers as the txs).
+    /// Until the coin-P2P isdlock parse leg lands, this map stays empty and
+    /// selection behaves exactly as before (empty map = no exclusions).
+    void add_islock(const uint256& locked_txid,
+                    const std::vector<std::pair<uint256, uint32_t>>& inputs)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        for (const auto& in : inputs) {
+            // Bound the tracking map (relay is untrusted input): evict the
+            // oldest registration once over cap. 100k outpoints ≈ a few MB.
+            while (m_islock_order.size() >= MAX_ISLOCK_OUTPOINTS
+                   && !m_islock_order.empty()) {
+                m_islock_outpoints.erase(m_islock_order.front());
+                m_islock_order.pop_front();
+            }
+            auto [it, inserted] = m_islock_outpoints.insert_or_assign(
+                in, locked_txid);
+            if (inserted) m_islock_order.push_back(in);
+            // Defence 1: evict a conflicting pool entry right away.
+            auto sit = m_spent_outputs.find(in);
+            if (sit != m_spent_outputs.end() && sit->second != locked_txid
+                && m_pool.count(sit->second)) {
+                LOG_INFO << "[MEMPOOL] evicting islock-conflicting tx "
+                         << sit->second.GetHex().substr(0, 16)
+                         << " (outpoint locked to "
+                         << locked_txid.GetHex().substr(0, 16) << ")";
+                remove_tx_locked(sit->second);
+            }
+        }
+    }
+
+    size_t islock_outpoint_count() const
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_islock_outpoints.size();
     }
 
     void evict_expired()
@@ -256,6 +345,8 @@ public:
         m_time_index.clear();
         m_spent_outputs.clear();
         m_feerate_index.clear();
+        m_islock_outpoints.clear();
+        m_islock_order.clear();
         m_total_bytes = 0;
     }
 
@@ -347,14 +438,42 @@ public:
     }
 
     /// Phase C-TEMPLATE prerequisite — fee-aware tx selection.
-    /// Returns transactions sorted by feerate (highest first) up to
-    /// `max_bytes` of base-size budget. Transactions with unknown
-    /// fees are EXCLUDED — they'd poison the coinbasevalue if we
+    /// Returns transactions in TOPOLOGICALLY-VALID feerate order (see G1
+    /// below) up to `max_bytes` of base-size budget. Transactions with
+    /// unknown fees are EXCLUDED — they'd poison the coinbasevalue if we
     /// included them at fee=0 vs dashd's GBT (which always knows
     /// fees because it sees the full mempool with full UTXO).
     ///
+    /// ── ConnectBlock reject-surface audit gaps closed here ─────────────
+    /// (frstrtr/the docs/DASH_CONNECTBLOCK_REJECT_SURFACE_AUDIT.md §1)
+    ///
+    /// G1 `bad-txns-inputs-missingorspent` — TOPOLOGICAL selection. The
+    ///   pre-fix selector walked the feerate index strictly descending, so a
+    ///   CPFP child that out-feed its parent was packed BEFORE (or without)
+    ///   the parent — a consensus-invalid block on a winning share. Now every
+    ///   candidate is expanded to its ancestor PACKAGE (all unselected
+    ///   in-mempool ancestors, parents-first); the whole package is admitted
+    ///   atomically or the child is dropped. A vin is satisfied only by a
+    ///   live UTXO coin or by a parent ALREADY IN THE SELECTED SET /
+    ///   earlier in this package — never by bare mempool membership.
+    ///
+    /// G2 `bad-blk-sigops` — sigop accounting (sigops.hpp). Running
+    ///   legacy+P2SH sigop count, seeded with dashd's 100-sigop coinbase
+    ///   reserve; a package that would reach MaxBlockSigOps (40k) is
+    ///   skipped, mirroring dashd miner TestPackage.
+    ///
+    /// G3 `bad-txns-premature-spend-of-coinbase` — coinbase maturity. When
+    ///   the caller supplies `next_height`, a vin resolved from the UTXO
+    ///   view must be mature at that height (Coin::is_mature, DASH_LIMITS
+    ///   coinbase_maturity=100) or the package is dropped. `next_height==0`
+    ///   (legacy callers) skips the check.
+    ///
+    /// G4 `conflict-tx-lock` — islock conflicts. A vin spending an outpoint
+    ///   that a known islock assigns to a DIFFERENT txid drops the package
+    ///   (see add_islock for the tracking + the documented residual race).
+    ///
     /// Stale-input guard: re-checks each candidate's inputs against
-    /// the live UTXO + parent-mempool chain before including. Catches
+    /// the live UTXO + selected-set parents before including. Catches
     /// the brief window between tip-change and full_block arrival
     /// where remove_for_block hasn't yet evicted now-double-spent
     /// txs.
@@ -366,6 +485,11 @@ public:
         uint32_t           base_size{0};
     };
 
+    /// dashd policy DEFAULT_ANCESTOR_LIMIT: a candidate whose in-mempool
+    /// ancestor package exceeds this is dropped (unminable by dashd's own
+    /// miner too — its mempool never admits deeper chains).
+    static constexpr size_t MAX_PACKAGE_TXS = 25;
+
     // exclude_special (C-3): when true, drop every Dash special tx (tx.type != 0
     // — ProRegTx/ProUpServTx/asset-lock/asset-unlock) from the selection. dashd
     // recomputes the coinbase CbTx roots (merkleRootMNList/Quorums) and the
@@ -376,51 +500,152 @@ public:
     // reward term only). Default false preserves the mempool's general pricing +
     // selection capability (including the asset-unlock fee path) unchanged.
     std::pair<std::vector<SelectedTx>, uint64_t>
-    get_sorted_txs_with_fees(uint32_t max_bytes, bool exclude_special = false) const
+    get_sorted_txs_with_fees(uint32_t max_bytes, bool exclude_special = false,
+                             uint32_t next_height = 0) const
     {
         std::lock_guard<std::mutex> lock(m_mutex);
         std::vector<SelectedTx> result;
-        uint64_t total_fees = 0;
-        uint32_t total_bytes = 0;
+        std::set<uint256> selected;   // G1: the parent-in-selected-set check
+        uint64_t total_fees   = 0;
+        uint32_t total_bytes  = 0;
+        uint32_t total_sigops = DASH_COINBASE_SIGOPS_RESERVE;   // G2
         auto* utxo = m_utxo.load();
 
         for (const auto& fk : m_feerate_index) {
             const uint256& txid = fk.txid;
-            auto pit = m_pool.find(txid);
-            if (pit == m_pool.end()) continue;
-            const auto& entry = pit->second;
-            if (!entry.fee_known) continue;
-            if (exclude_special && entry.tx.type != 0) continue;
-            if (total_bytes + entry.base_size > max_bytes) continue;
+            if (selected.count(txid)) continue;  // packed earlier as an ancestor
+            if (m_pool.find(txid) == m_pool.end()) continue;
 
-            // Stale-input guard.
-            if (utxo) {
-                bool ok = true;
-                for (const auto& vin : entry.tx.vin) {
-                    ::core::coin::Outpoint op(
-                        vin.prevout.hash, vin.prevout.index);
-                    ::core::coin::Coin coin;
-                    if (utxo->get_coin(op, coin)) continue;
-                    // Parent-mempool chain (CPFP).
-                    auto parent = m_pool.find(vin.prevout.hash);
-                    if (parent != m_pool.end()
-                        && vin.prevout.index < parent->second.tx.vout.size()) {
-                        continue;
-                    }
-                    ok = false;
-                    break;
-                }
-                if (!ok) continue;
+            // ── G1: expand to the ancestor package, parents-first ────────
+            std::vector<const MempoolEntry*> package;
+            {
+                std::set<uint256> seen;
+                if (!collect_package_locked(txid, selected, seen, package, 0))
+                    continue;   // over-deep / over-wide chain: drop candidate
             }
 
-            total_bytes += entry.base_size;
-            total_fees  += entry.fee;
-            result.push_back({entry.tx, entry.fee, entry.base_size});
+            // Package membership for intra-package vin resolution (a parent
+            // earlier in `package` is as good as one already selected).
+            std::set<uint256> in_package;
+            for (const auto* e : package) in_package.insert(e->txid);
+
+            // ── Validate the WHOLE package; any failing member drops the
+            // candidate (never a partial package — that is exactly the
+            // childless-parent / parentless-child shape G1 forbids). ──────
+            bool     ok         = true;
+            uint32_t pkg_bytes  = 0;
+            uint64_t pkg_fees   = 0;
+            uint32_t pkg_sigops = 0;
+            for (const auto* e : package) {
+                if (!e->fee_known) { ok = false; break; }
+                if (exclude_special && e->tx.type != 0) { ok = false; break; }
+
+                // G2: legacy sigops (every scriptSig + every scriptPubKey,
+                // multisig = 20), exactly dashd GetLegacySigOpCount.
+                uint32_t tx_sigops = 0;
+                for (const auto& vout : e->tx.vout) {
+                    tx_sigops += count_script_sigops(
+                        vout.scriptPubKey.m_data, /*accurate=*/false);
+                }
+
+                for (const auto& vin : e->tx.vin) {
+                    tx_sigops += count_script_sigops(
+                        vin.scriptSig.m_data, /*accurate=*/false);
+
+                    auto opkey = std::make_pair(vin.prevout.hash,
+                                                vin.prevout.index);
+
+                    // G4: islock conflict — the outpoint is locked to a
+                    // different txid; packing this tx is conflict-tx-lock.
+                    auto lk = m_islock_outpoints.find(opkey);
+                    if (lk != m_islock_outpoints.end()
+                        && lk->second != e->txid) {
+                        ok = false;
+                        break;
+                    }
+
+                    // Resolve the prevout: in-package/selected parent first
+                    // (an in-mempool parent output can never be a coinbase,
+                    // so no maturity question), then the live UTXO view.
+                    auto parent = m_pool.find(vin.prevout.hash);
+                    if (parent != m_pool.end()
+                        && (in_package.count(vin.prevout.hash)
+                            || selected.count(vin.prevout.hash))) {
+                        if (vin.prevout.index
+                                >= parent->second.tx.vout.size()) {
+                            ok = false;
+                            break;
+                        }
+                        const auto& pscript = parent->second.tx
+                            .vout[vin.prevout.index].scriptPubKey.m_data;
+                        if (is_p2sh_script(pscript)) {
+                            tx_sigops += count_p2sh_sigops(
+                                vin.scriptSig.m_data);
+                        }
+                        continue;
+                    }
+                    if (utxo) {
+                        ::core::coin::Outpoint op(vin.prevout.hash,
+                                                  vin.prevout.index);
+                        ::core::coin::Coin coin;
+                        if (!utxo->get_coin(op, coin)) {
+                            // Stale input: neither selected-parent nor UTXO.
+                            ok = false;
+                            break;
+                        }
+                        // G3: coinbase maturity. dashd CheckTxInputs rejects
+                        // a spend of a coinbase younger than 100 confs
+                        // (bad-txns-premature-spend-of-coinbase); the Coin
+                        // carries is_coinbase+height, so refuse here instead
+                        // of shipping the reject. next_height==0 = legacy
+                        // caller, check skipped.
+                        if (next_height != 0
+                            && !coin.is_mature(next_height, DASH_LIMITS)) {
+                            ok = false;
+                            break;
+                        }
+                        if (is_p2sh_script(coin.scriptPubKey.m_data)) {
+                            tx_sigops += count_p2sh_sigops(
+                                vin.scriptSig.m_data);
+                        }
+                        continue;
+                    }
+                    // No UTXO view attached (unit-test / cold-start): the
+                    // pre-fix selector accepted the vin unchecked; keep that
+                    // behaviour for non-mempool prevouts (topological order
+                    // and sigop caps above still apply).
+                }
+                if (!ok) break;
+
+                pkg_bytes  += e->base_size;
+                pkg_fees   += e->fee;
+                pkg_sigops += tx_sigops;
+            }
+            if (!ok) continue;
+
+            // Byte cap: the whole package must fit; a parent that does not
+            // fit drops the child with it (G1's byte-cap clause). `continue`
+            // (not break) — a later, smaller candidate may still fit.
+            if (total_bytes + pkg_bytes > max_bytes) continue;
+            // G2: dashd miner TestPackage bound (>= — reject AT the cap).
+            if (total_sigops + pkg_sigops >= DASH_MAX_BLOCK_SIGOPS) continue;
+
+            for (const auto* e : package) {
+                selected.insert(e->txid);
+                total_bytes += e->base_size;
+                total_fees  += e->fee;
+                result.push_back({e->tx, e->fee, e->base_size});
+            }
+            total_sigops += pkg_sigops;
         }
         return {std::move(result), total_fees};
     }
 
 private:
+    // G4: bound on tracked islock outpoints (relay-fed, so untrusted input;
+    // FIFO eviction beyond this — see add_islock).
+    static constexpr size_t MAX_ISLOCK_OUTPOINTS = 100'000;
+
     mutable std::mutex                                 m_mutex;
     std::map<uint256, MempoolEntry>                    m_pool;
     std::multimap<time_t, uint256>                     m_time_index;
@@ -428,10 +653,44 @@ private:
     // Step 2: feerate-sorted index. greater<double> means begin() =
     // highest feerate, so iteration is best-first.
     std::set<FeeKey>                                   m_feerate_index;
+    // G4: outpoint → txid holding the InstantSend lock on it, plus FIFO
+    // insertion order for bounded eviction.
+    std::map<std::pair<uint256, uint32_t>, uint256>    m_islock_outpoints;
+    std::deque<std::pair<uint256, uint32_t>>           m_islock_order;
     size_t                                             m_total_bytes{0};
     size_t                                             m_max_bytes;
     time_t                                             m_expiry_sec;
     std::atomic<::core::coin::UTXOViewCache*>          m_utxo{nullptr};
+
+    /// G1: gather `txid` plus every UNSELECTED in-mempool ancestor into
+    /// `out`, parents strictly before children (post-order DFS). `seen`
+    /// de-duplicates diamond dependencies within one package. Returns false
+    /// when the package exceeds MAX_PACKAGE_TXS (drop the candidate; such a
+    /// chain is deeper than dashd's own mempool would admit). Caller must
+    /// hold m_mutex. Recursion depth is bounded by MAX_PACKAGE_TXS.
+    bool collect_package_locked(const uint256& txid,
+                                const std::set<uint256>& already_selected,
+                                std::set<uint256>& seen,
+                                std::vector<const MempoolEntry*>& out,
+                                size_t depth) const
+    {
+        if (depth > MAX_PACKAGE_TXS || out.size() >= MAX_PACKAGE_TXS)
+            return false;
+        auto it = m_pool.find(txid);
+        if (it == m_pool.end()) return false;
+        if (!seen.insert(txid).second) return true;  // already scheduled
+        for (const auto& vin : it->second.tx.vin) {
+            if (already_selected.count(vin.prevout.hash)) continue;
+            if (m_pool.find(vin.prevout.hash) == m_pool.end()) continue;
+            if (!collect_package_locked(vin.prevout.hash, already_selected,
+                                        seen, out, depth + 1)) {
+                return false;
+            }
+        }
+        if (out.size() >= MAX_PACKAGE_TXS) return false;
+        out.push_back(&it->second);
+        return true;
+    }
 
     void evict_one_locked(const uint256& txid)
     {

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -403,6 +403,24 @@ public:
         return m_utxo_immature_policy;
     }
 
+    /// ── Mempool-tx serving switch (--embedded-serve-mempool-txs) ─────────
+    /// DEFAULT OFF: the embedded arm serves a COINBASE-ONLY body even with a
+    /// mature UTXO lane (suppress_mempool_txs=true, cause
+    /// "mempool-txs-disabled"). Consensus never requires a mempool tx, and
+    /// with zero txs every committed value (subsidy, MN payment, creditPool)
+    /// is exact — the same argument as the utxo-immature serving mode.
+    ///
+    /// Turning it ON puts the whole mempool-tx body path in the block
+    /// production lane: topological selection (G1), sigop caps (G2),
+    /// coinbase-maturity (G3) and islock-conflict (G4) guards all live in
+    /// Mempool::get_sorted_txs_with_fees (see
+    /// DASH_CONNECTBLOCK_REJECT_SURFACE_AUDIT.md). Fees ride the coinbase.
+    /// The switch exists so the fee-carrying path is an explicit operator
+    /// decision, soak-gated like every other production posture — not an
+    /// implicit consequence of the UTXO lane maturing.
+    void set_serve_mempool_txs(bool on) { m_serve_mempool_txs = on; }
+    bool serve_mempool_txs() const { return m_serve_mempool_txs; }
+
     /// Superblock-height guard. On a Dash superblock height the coinbase MUST
     /// pay the governance/treasury (superblock) outputs; the embedded template
     /// does not compute those, so emitting a normal coinbase there is a
@@ -1022,9 +1040,19 @@ public:
         // serving policy we DO serve, but only a coinbase-only body. The
         // builder marks the template (m_txset_empty_cause) and logs the
         // forgone fees, so this degraded-but-valid mode is never silent.
+        // Two suppressed-body producers, most-specific cause first: the
+        // utxo-immature serving window names itself; otherwise the default-OFF
+        // --embedded-serve-mempool-txs posture does. Fee-carrying templates
+        // require BOTH a mature UTXO lane AND the explicit operator opt-in.
         e.suppress_mempool_txs =
-            utxo_immature
-            && m_utxo_immature_policy == UtxoImmaturePolicy::ServeEmptyTxSet;
+            (utxo_immature
+             && m_utxo_immature_policy == UtxoImmaturePolicy::ServeEmptyTxSet)
+            || !m_serve_mempool_txs;
+        e.suppress_cause =
+            (utxo_immature
+             && m_utxo_immature_policy == UtxoImmaturePolicy::ServeEmptyTxSet)
+                ? "utxo-immature-serving"
+                : "mempool-txs-disabled";
         if (m_require_resolvable_payee && !payee_resolvable) {
             LOG_WARNING << "[EMBED-GATE] h=" << (m_prev_height + 1)
                         << " REFUSE embedded template: MN payment due but payee"
@@ -1402,6 +1430,10 @@ private:
     // ServeEmptyTxSet is the pure-daemonless opt-in (subsidy-only block beats
     // no block when there is no fallback). See set_utxo_immature_policy().
     UtxoImmaturePolicy m_utxo_immature_policy{UtxoImmaturePolicy::Refuse};
+    // --embedded-serve-mempool-txs: DEFAULT OFF — coinbase-only serving; the
+    // fee-carrying mempool-tx body path is an explicit operator opt-in (see
+    // set_serve_mempool_txs).
+    bool m_serve_mempool_txs{false};
     std::function<bool()> m_chain_synced_fn; // optional ABSOLUTE header-sync gate (never serve a stale tip)
     std::function<bool(uint32_t)> m_is_superblock_fn;  // superblock-height predicate
     // E-SUPERBLOCK: daemonless governance-sourced superblock schedule provider

--- a/src/impl/dash/coin/sigops.hpp
+++ b/src/impl/dash/coin/sigops.hpp
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// Sigop accounting for the embedded DASH template builder — G2 of the
+/// ConnectBlock reject-surface audit
+/// (frstrtr/the docs/DASH_CONNECTBLOCK_REJECT_SURFACE_AUDIT.md).
+///
+/// dashd rejects a block whose accumulated legacy+P2SH sigop count exceeds
+/// MaxBlockSigOps (validation.cpp:2535 `bad-blk-sigops`; consensus/consensus.h
+/// MAX_BLOCK_SIGOPS_PER_MB * 2 = 40'000 at the DIP-0001 2 MB size). dashd's
+/// own miner enforces the cap per selected package (node/miner.cpp
+/// TestPackage); before this file the embedded selection bounded bytes only,
+/// so bare-multisig-stuffed standard txs (20 sigops per OP_CHECKMULTISIG
+/// output) could exceed 40k inside the 1.99 MB byte cap.
+///
+/// This is a standalone header-only port of dashd's counting rules
+/// (script/script.cpp CScript::GetSigOpCount + tx_verify.cpp
+/// GetLegacySigOpCount / GetP2SHSigOpCount) over raw script bytes, so
+/// mempool.hpp does not grow a btclibs CScript link dependency (the
+/// btclibs-SCC trap — see mempool_ingest.hpp).
+///
+/// Counting rules mirrored EXACTLY:
+///  - legacy count (fAccurate=false): every scriptSig and every scriptPubKey
+///    in the tx; OP_CHECKSIG(VERIFY) = 1, OP_CHECKMULTISIG(VERIFY) = 20
+///    (MAX_PUBKEYS_PER_MULTISIG) regardless of the preceding OP_N.
+///  - P2SH count (fAccurate=true): when the PREVOUT scriptPubKey is P2SH
+///    (OP_HASH160 <20> OP_EQUAL) and the scriptSig is push-only, the LAST
+///    pushed datum is the redeemScript; count it with OP_N-aware multisig
+///    (OP_N CHECKMULTISIG = N). A non-push scriptSig contributes 0, exactly
+///    as CScript::GetSigOpCount(scriptSig) returns 0 there.
+///  - malformed script tails (truncated pushdata) stop the scan, exactly as
+///    CScript::GetOp fails out of the loop.
+
+#include <cstdint>
+#include <cstddef>
+#include <vector>
+
+namespace dash {
+namespace coin {
+
+/// dashd consensus/consensus.h: MaxBlockSigOps(fDIP0001Active=true)
+/// = MAX_BLOCK_SIGOPS_PER_MB(20'000) * MaxBlockSize(2 MB)/1MB = 40'000.
+/// DIP-0001 activated on mainnet in 2017; every height this builder can
+/// serve is fDIP0001Active.
+inline constexpr uint32_t DASH_MAX_BLOCK_SIGOPS = 40'000;
+
+/// dashd node/miner.cpp BlockAssembler::resetBlock(): nBlockSigOps = 100 —
+/// the reserve for the coinbase (whose payee/superblock outputs are appended
+/// after tx selection). We mirror the same reserve so the selection bound is
+/// never looser than the oracle miner's.
+inline constexpr uint32_t DASH_COINBASE_SIGOPS_RESERVE = 100;
+
+/// dashd script/script.h MAX_PUBKEYS_PER_MULTISIG.
+inline constexpr uint32_t DASH_MAX_PUBKEYS_PER_MULTISIG = 20;
+
+namespace detail {
+// Opcode bytes (script/script.h). Only the ones the counter needs.
+inline constexpr uint8_t OP_PUSHDATA1          = 0x4c;
+inline constexpr uint8_t OP_PUSHDATA2          = 0x4d;
+inline constexpr uint8_t OP_PUSHDATA4          = 0x4e;
+inline constexpr uint8_t OP_RESERVED           = 0x50;
+inline constexpr uint8_t OP_1                  = 0x51;
+inline constexpr uint8_t OP_16                 = 0x60;
+inline constexpr uint8_t OP_CHECKSIG           = 0xac;
+inline constexpr uint8_t OP_CHECKSIGVERIFY     = 0xad;
+inline constexpr uint8_t OP_CHECKMULTISIG      = 0xae;
+inline constexpr uint8_t OP_CHECKMULTISIGVERIFY= 0xaf;
+inline constexpr uint8_t OP_HASH160            = 0xa9;
+inline constexpr uint8_t OP_EQUAL              = 0x87;
+
+/// One CScript::GetOp step over raw bytes. Advances `pc`; fills `opcode` and,
+/// for pushes, [data_begin, data_end). Returns false on a truncated push
+/// (scan must stop, mirroring GetOp's failure).
+inline bool get_op(const std::vector<unsigned char>& s, size_t& pc,
+                   uint8_t& opcode, size_t& data_begin, size_t& data_end)
+{
+    data_begin = data_end = 0;
+    if (pc >= s.size()) return false;
+    opcode = s[pc++];
+    if (opcode <= OP_PUSHDATA4) {
+        size_t n = 0;
+        if (opcode < OP_PUSHDATA1) {
+            n = opcode;
+        } else if (opcode == OP_PUSHDATA1) {
+            if (pc + 1 > s.size()) return false;
+            n = s[pc];
+            pc += 1;
+        } else if (opcode == OP_PUSHDATA2) {
+            if (pc + 2 > s.size()) return false;
+            n = static_cast<size_t>(s[pc]) | (static_cast<size_t>(s[pc + 1]) << 8);
+            pc += 2;
+        } else { // OP_PUSHDATA4
+            if (pc + 4 > s.size()) return false;
+            n = static_cast<size_t>(s[pc])
+              | (static_cast<size_t>(s[pc + 1]) << 8)
+              | (static_cast<size_t>(s[pc + 2]) << 16)
+              | (static_cast<size_t>(s[pc + 3]) << 24);
+            pc += 4;
+        }
+        if (pc + n > s.size()) return false;
+        data_begin = pc;
+        data_end   = pc + n;
+        pc += n;
+    }
+    return true;
+}
+} // namespace detail
+
+/// CScript::GetSigOpCount(fAccurate) over raw script bytes.
+inline uint32_t count_script_sigops(const std::vector<unsigned char>& script,
+                                    bool accurate)
+{
+    using namespace detail;
+    uint32_t n = 0;
+    size_t pc = 0, db = 0, de = 0;
+    uint8_t opcode = 0;
+    uint8_t last_opcode = 0xff; // OP_INVALIDOPCODE
+    while (pc < script.size()) {
+        if (!get_op(script, pc, opcode, db, de)) break;
+        if (opcode == OP_CHECKSIG || opcode == OP_CHECKSIGVERIFY) {
+            ++n;
+        } else if (opcode == OP_CHECKMULTISIG || opcode == OP_CHECKMULTISIGVERIFY) {
+            if (accurate && last_opcode >= OP_1 && last_opcode <= OP_16)
+                n += static_cast<uint32_t>(last_opcode) - (OP_1 - 1); // DecodeOP_N
+            else
+                n += DASH_MAX_PUBKEYS_PER_MULTISIG;
+        }
+        last_opcode = opcode;
+    }
+    return n;
+}
+
+/// CScript::IsPayToScriptHash(): exactly OP_HASH160 <20 bytes> OP_EQUAL.
+inline bool is_p2sh_script(const std::vector<unsigned char>& script)
+{
+    return script.size() == 23
+        && script[0]  == detail::OP_HASH160
+        && script[1]  == 0x14
+        && script[22] == detail::OP_EQUAL;
+}
+
+/// CScript::GetSigOpCount(scriptSig) P2SH branch: sigops of the redeemScript
+/// (the LAST datum a push-only scriptSig pushes), counted fAccurate=true.
+/// Returns 0 when the scriptSig contains any non-push opcode or is malformed
+/// — byte-exact with dashd (such an input cannot pass P2SH evaluation anyway).
+inline uint32_t count_p2sh_sigops(const std::vector<unsigned char>& script_sig)
+{
+    using namespace detail;
+    size_t pc = 0, db = 0, de = 0;
+    uint8_t opcode = 0;
+    size_t last_db = 0, last_de = 0;
+    while (pc < script_sig.size()) {
+        if (!get_op(script_sig, pc, opcode, db, de)) return 0;
+        if (opcode > OP_16) return 0;
+        last_db = db;
+        last_de = de;
+    }
+    std::vector<unsigned char> redeem(script_sig.begin() + last_db,
+                                      script_sig.begin() + last_de);
+    return count_script_sigops(redeem, /*accurate=*/true);
+}
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/work_source.hpp
+++ b/src/impl/dash/coin/work_source.hpp
@@ -152,6 +152,13 @@ struct EmbeddedWorkInputs {
     // a statement about WHAT is served.
     bool                             suppress_mempool_txs{false};
 
+    // NAME-THE-STATE for the suppressed body: WHY it is coinbase-only.
+    // "utxo-immature-serving" (the historical producer) or
+    // "mempool-txs-disabled" (--embedded-serve-mempool-txs default-OFF
+    // posture; see NodeCoinState::set_serve_mempool_txs). String literal
+    // lifetime only — never a computed string.
+    const char*                      suppress_cause{"utxo-immature-serving"};
+
     bool viable() const {
         return has_state && mnstates != nullptr && mempool != nullptr;
     }
@@ -227,8 +234,11 @@ inline WorkSelection select_dash_work(
                                                 : &emb.superblock_payments,
                 // confirmedHash rollover projection threshold (sml_projection.hpp).
                 emb.mn_min_confirmations,
-                // UTXO-immature serving: coinbase-only body, fees exactly 0.
-                emb.suppress_mempool_txs);
+                // Coinbase-only serving: body suppressed, fees exactly 0;
+                // the cause names WHICH suppressed mode this is
+                // (utxo-immature-serving vs mempool-txs-disabled).
+                emb.suppress_mempool_txs,
+                emb.suppress_cause);
         },
         dashd_fallback);
 }

--- a/test/test_dash_coin_state_maintainer.cpp
+++ b/test/test_dash_coin_state_maintainer.cpp
@@ -171,6 +171,10 @@ TEST(DashCoinStateMaintainer, MnThenTipPublishesByteEqualToDirectBuild) {
 
     NodeCoinState st;
     st.mempool().set_utxo(&utxo);
+    // This KAT pins the FEE-CARRYING flow — the --embedded-serve-mempool-txs
+    // OPT-IN (default OFF = coinbase-only; pinned in test_dash_node_coin_state
+    // DashMempoolTxServing).
+    st.set_serve_mempool_txs(true);
     CoinStateMaintainer m(st);
 
     m.on_mn_list_update(single_mn(p2pkh_script(0x30)));

--- a/test/test_dash_get_work.cpp
+++ b/test/test_dash_get_work.cpp
@@ -177,6 +177,10 @@ TEST(DashGetWork, PopulatedRoutesEmbeddedNoDashdPoll) {
 
     dash::NodeImpl node;
     node.coin_state().mempool().set_utxo(&utxo);
+    // This KAT pins the FEE-CARRYING flow — the --embedded-serve-mempool-txs
+    // OPT-IN (default OFF = coinbase-only; pinned in test_dash_node_coin_state
+    // DashMempoolTxServing).
+    node.coin_state().set_serve_mempool_txs(true);
 
     node.coin_state_maintainer().on_mn_list_update(single_mn(payout));
     ASSERT_TRUE(node.coin_state_maintainer().on_mempool_tx(

--- a/test/test_dash_mempool.cpp
+++ b/test/test_dash_mempool.cpp
@@ -735,3 +735,201 @@ TEST(DashUtxoLane, MiningMaturityGateAt106)
     EXPECT_TRUE(lane.mining_utxo_ready())
         << "gate must open at exactly " << DASH_MINING_GATE_DEPTH;
 }
+
+// ═══ ConnectBlock reject-surface audit — mempool-TX body-path gap KATs ═══════
+//
+// One KAT (at least) per GAP row of §1 of
+// frstrtr/the docs/DASH_CONNECTBLOCK_REJECT_SURFACE_AUDIT.md. Every behaviour
+// pinned here FAILS against the pre-fix selector (feerate-descending walk with
+// bare parent-in-mempool acceptance, no sigop/maturity/islock accounting):
+//   G1 bad-txns-inputs-missingorspent  → topological (package) selection
+//   G2 bad-blk-sigops                  → 40k cap, 100-sigop coinbase reserve
+//   G3 bad-txns-premature-spend-of-coinbase → maturity vs next_height
+//   G4 conflict-tx-lock                → islock tracking + selection guard
+
+TEST(DashMempoolAuditGaps, G1_CpfpChildNeverPrecedesParent)
+{
+    UTXOViewCache utxo(nullptr);
+    uint256 prev = mint_hash(600);
+    utxo.add_coin(Outpoint(prev, 0), Coin(100'000, {}, 1, false));
+
+    Mempool mp;
+    mp.set_utxo(&utxo);
+    // Parent fee 1'000; the CPFP child spends the parent's output at fee
+    // 49'000 (same 1-in/1-out shape => same size => ~49x the feerate). The
+    // pre-fix selector emitted the child FIRST — dashd validates inputs in
+    // tx order, so that block is bad-txns-inputs-missingorspent.
+    auto parent = make_spend(prev, 0, 99'000, /*salt=*/601);
+    auto child  = make_spend(dash_txid(parent), 0, 50'000, /*salt=*/602);
+    ASSERT_TRUE(mp.add_tx(parent));
+    ASSERT_TRUE(mp.add_tx(child));
+
+    auto [sel, fees] = mp.get_sorted_txs_with_fees(1u << 20);
+    ASSERT_EQ(sel.size(), 2u);
+    EXPECT_EQ(dash_txid(sel[0].tx), dash_txid(parent))
+        << "G1: the parent MUST precede its CPFP child in the selection";
+    EXPECT_EQ(dash_txid(sel[1].tx), dash_txid(child));
+    EXPECT_EQ(fees, 50'000u);
+}
+
+TEST(DashMempoolAuditGaps, G1_ByteCapDropsChildWhenParentDoesNotFit)
+{
+    UTXOViewCache utxo(nullptr);
+    uint256 prev = mint_hash(605);
+    utxo.add_coin(Outpoint(prev, 0), Coin(100'000, {}, 1, false));
+
+    Mempool mp;
+    mp.set_utxo(&utxo);
+    auto parent = make_spend(prev, 0, 99'000, /*salt=*/606);            // fee  1'000
+    auto child  = make_spend(dash_txid(parent), 0, 50'000, /*salt=*/607); // fee 49'000
+    ASSERT_TRUE(mp.add_tx(parent));
+    ASSERT_TRUE(mp.add_tx(child));
+
+    // Byte cap fits exactly ONE tx (both have the same shape/size). The
+    // pre-fix selector packed the higher-feerate CHILD alone — parentless,
+    // consensus-invalid. The fix drops the child with its unfitting parent
+    // and falls through to the parent as the only valid single-tx fill.
+    auto one_tx = mp.get_entry(dash_txid(child))->base_size;
+    auto [sel, fees] = mp.get_sorted_txs_with_fees(one_tx + 1);
+    ASSERT_EQ(sel.size(), 1u);
+    EXPECT_EQ(dash_txid(sel[0].tx), dash_txid(parent))
+        << "G1: a child whose parent does not fit the byte cap must be "
+           "dropped with it";
+    EXPECT_EQ(fees, 1'000u);
+}
+
+TEST(DashMempoolAuditGaps, G1_FeeUnknownParentExcludesPricedChild)
+{
+    UTXOViewCache utxo(nullptr);   // parent's prevout deliberately NOT in UTXO
+    Mempool mp;
+    mp.set_utxo(&utxo);
+    auto parent = make_spend(mint_hash(610), 0, 80'000, /*salt=*/611);
+    ASSERT_TRUE(mp.add_tx(parent));
+    ASSERT_FALSE(mp.get_entry(dash_txid(parent))->fee_known);
+    // The child prices off the parent's in-mempool output — the CPFP fee
+    // path the audit cites (mempool.hpp compute_fee parent branch), so
+    // fee-KNOWN children of fee-UNKNOWN parents are selectable candidates.
+    auto child = make_spend(dash_txid(parent), 0, 40'000, /*salt=*/612);
+    ASSERT_TRUE(mp.add_tx(child));
+    ASSERT_TRUE(mp.get_entry(dash_txid(child))->fee_known);
+
+    auto [sel, fees] = mp.get_sorted_txs_with_fees(1u << 20);
+    EXPECT_TRUE(sel.empty())
+        << "G1: a priced child of an unpriced (unselectable) parent must "
+           "not enter the block without it";
+    EXPECT_EQ(fees, 0u);
+}
+
+TEST(DashMempoolAuditGaps, G2_SigopCapStopsSelectionBeforeBadBlkSigops)
+{
+    UTXOViewCache utxo(nullptr);
+    Mempool mp;
+    mp.set_utxo(&utxo);
+    // Three standard-shaped txs, each carrying 20'000 legacy sigops in one
+    // output (1'000 bare OP_CHECKMULTISIG bytes × 20 sigops each — the
+    // audit's bare-multisig-stuffed shape), all well inside the byte cap.
+    for (int i = 0; i < 3; ++i) {
+        uint256 prev = mint_hash(620 + i);
+        utxo.add_coin(Outpoint(prev, 0), Coin(100'000, {}, 1, false));
+        auto tx = make_spend(prev, 0, 90'000, /*salt=*/625 + i);
+        tx.vout[0].scriptPubKey.m_data.assign(1'000, 0xae); // OP_CHECKMULTISIG
+        ASSERT_TRUE(mp.add_tx(tx));
+    }
+    auto [sel, fees] = mp.get_sorted_txs_with_fees(1u << 20);
+    EXPECT_EQ(sel.size(), 1u)
+        << "G2: 100 (coinbase reserve) + 2×20'000 sigops crosses the 40k "
+           "bad-blk-sigops cap — selection must stop at one such tx";
+}
+
+TEST(DashMempoolAuditGaps, G2_SigopCountingMatchesDashdRules)
+{
+    using dash::coin::count_script_sigops;
+    using dash::coin::count_p2sh_sigops;
+    using dash::coin::is_p2sh_script;
+    // OP_CHECKSIG counts 1 in either mode.
+    EXPECT_EQ(count_script_sigops({0xac}, false), 1u);
+    EXPECT_EQ(count_script_sigops({0xac}, true), 1u);
+    // OP_2 OP_CHECKMULTISIG: 20 legacy (MAX_PUBKEYS_PER_MULTISIG), 2 accurate.
+    EXPECT_EQ(count_script_sigops({0x52, 0xae}, false), 20u);
+    EXPECT_EQ(count_script_sigops({0x52, 0xae}, true), 2u);
+    // Push data is skipped, not misread as opcodes (0xac INSIDE a push).
+    EXPECT_EQ(count_script_sigops({0x02, 0xac, 0xac}, false), 0u);
+    // Truncated push stops the scan (CScript::GetOp failure semantics).
+    EXPECT_EQ(count_script_sigops({0x4c}, false), 0u);
+    // P2SH: redeemScript = OP_3 OP_CHECKMULTISIG pushed as the scriptSig's
+    // last datum; counted fAccurate ⇒ 3.
+    std::vector<unsigned char> spk{0xa9, 0x14};
+    spk.resize(22, 0x11);
+    spk.push_back(0x87);
+    ASSERT_TRUE(is_p2sh_script(spk));
+    EXPECT_EQ(count_p2sh_sigops({0x02, 0x53, 0xae}), 3u);
+    // A non-push scriptSig contributes 0 P2SH sigops (dashd returns 0 there).
+    EXPECT_EQ(count_p2sh_sigops({0xac}), 0u);
+}
+
+TEST(DashMempoolAuditGaps, G3_ImmatureCoinbaseSpendRefused)
+{
+    UTXOViewCache utxo(nullptr);
+    uint256 cb = mint_hash(640);
+    // A coinbase-flagged coin minted at height 950 (the metadata the pre-fix
+    // stale-input guard fetched and never read).
+    utxo.add_coin(Outpoint(cb, 0),
+                  Coin(100'000, {}, /*height=*/950, /*coinbase=*/true));
+    Mempool mp;
+    mp.set_utxo(&utxo);
+    auto spend = make_spend(cb, 0, 90'000, /*salt=*/641);
+    ASSERT_TRUE(mp.add_tx(spend));   // pricing is not the gate; selection is
+
+    // 99 confirmations at next_height 1049: premature-spend-of-coinbase.
+    EXPECT_TRUE(mp.get_sorted_txs_with_fees(1u << 20, false, 1049).first.empty())
+        << "G3: coinbase spend at 99 confs must be refused";
+    // 100 confirmations at 1050: mature (dashd COINBASE_MATURITY boundary).
+    auto [sel, fees] = mp.get_sorted_txs_with_fees(1u << 20, false, 1050);
+    ASSERT_EQ(sel.size(), 1u);
+    EXPECT_EQ(fees, 10'000u);
+    // Legacy callers (next_height omitted) keep the prior no-check shape.
+    EXPECT_EQ(mp.get_sorted_txs_with_fees(1u << 20).first.size(), 1u);
+}
+
+TEST(DashMempoolAuditGaps, G4_IslockConflictEvictedAndNeverSelected)
+{
+    UTXOViewCache utxo(nullptr);
+    uint256 prev = mint_hash(650);
+    utxo.add_coin(Outpoint(prev, 0), Coin(100'000, {}, 1, false));
+    Mempool mp;
+    mp.set_utxo(&utxo);
+    auto loser = make_spend(prev, 0, 90'000, /*salt=*/651);
+    ASSERT_TRUE(mp.add_tx(loser));
+    ASSERT_EQ(mp.get_sorted_txs_with_fees(1u << 20).first.size(), 1u);
+
+    // An islock forms for the OTHER spend of the same outpoint.
+    uint256 winner_txid = mint_hash(652);
+    mp.add_islock(winner_txid, {{prev, 0}});
+    // Defence 1: the conflicting pool entry is evicted immediately.
+    EXPECT_FALSE(mp.contains(dash_txid(loser)));
+    // Defence 2: even re-admitted (relay race), it must never be selected —
+    // packing it is conflict-tx-lock (validation.cpp:2622).
+    ASSERT_TRUE(mp.add_tx(loser));
+    EXPECT_TRUE(mp.get_sorted_txs_with_fees(1u << 20).first.empty())
+        << "G4: a tx spending an outpoint islocked to a different txid "
+           "must not enter a template";
+
+    // The islock HOLDER itself is not a conflict.
+    uint256 prev2 = mint_hash(655);
+    utxo.add_coin(Outpoint(prev2, 0), Coin(100'000, {}, 1, false));
+    auto holder = make_spend(prev2, 0, 90'000, /*salt=*/656);
+    ASSERT_TRUE(mp.add_tx(holder));
+    mp.add_islock(dash_txid(holder), {{prev2, 0}});
+    EXPECT_TRUE(mp.contains(dash_txid(holder)));
+    auto [sel2, fees2] = mp.get_sorted_txs_with_fees(1u << 20);
+    ASSERT_EQ(sel2.size(), 1u);
+    EXPECT_EQ(dash_txid(sel2[0].tx), dash_txid(holder));
+
+    // Block-confirm resolves a lock: the tracking entry is pruned.
+    ASSERT_EQ(mp.islock_outpoint_count(), 2u);
+    auto winner = make_spend(prev, 0, 95'000, /*salt=*/657);
+    mp.remove_for_block(make_block({make_coinbase({10'000}, 658), winner}, 658));
+    EXPECT_EQ(mp.islock_outpoint_count(), 1u)
+        << "an outpoint spent by a confirmed tx is resolved; its islock "
+           "tracking entry must be pruned";
+}

--- a/test/test_dash_node_coin_state.cpp
+++ b/test/test_dash_node_coin_state.cpp
@@ -141,6 +141,10 @@ TEST(DashNodeCoinState, PopulatedRoutesEmbeddedByteEqualToDirectBuild) {
     st.mempool().set_utxo(&utxo);
     ASSERT_TRUE(st.mempool().add_tx(make_spend(prev, 0, 90'000, /*salt=*/1)));  // fee 10'000
     st.set_tip(H - 1, prev_hash, bits, mtp, DASH_PUBKEY_VER, DASH_P2SH_VER, curtime, version);
+    // This KAT pins the FEE-CARRYING flow; tx-carrying templates are the
+    // --embedded-serve-mempool-txs OPT-IN (default OFF = coinbase-only; the
+    // default posture is pinned by the DashMempoolTxServing suite below).
+    st.set_serve_mempool_txs(true);
 
     ASSERT_TRUE(st.populated());
     ASSERT_TRUE(st.make_embedded_work_inputs().viable());
@@ -1030,7 +1034,10 @@ TEST(DashUtxoImmatureServing, DefaultRefusesTheImmatureWindowExactlyAsBefore) {
     EXPECT_EQ(e.decline.value, "utxo_ready=false");
     EXPECT_EQ(e.decline.threshold, "utxo_ready=true");
     EXPECT_EQ(st.classify_decline(), "utxo-immature");
-    EXPECT_FALSE(e.suppress_mempool_txs)
+    // (With mempool-tx serving armed, the refusing arm suppresses nothing —
+    // the suppress bit belongs to WHAT is served, and nothing is.)
+    st.set_serve_mempool_txs(true);
+    EXPECT_FALSE(st.make_embedded_work_inputs().suppress_mempool_txs)
         << "a refusing arm serves nothing, so it suppresses nothing";
 }
 
@@ -1066,6 +1073,9 @@ TEST(DashUtxoImmatureServing, MatureLaneNeverSuppresses) {     // negative twin
     NodeCoinState st;
     seed_healthy_armed(st);
     st.set_utxo_ready_fn([] { return true; });
+    // Mempool-tx serving armed (--embedded-serve-mempool-txs; without it the
+    // default-OFF posture suppresses regardless — DashMempoolTxServing suite).
+    st.set_serve_mempool_txs(true);
     // Even WITH the opt-in policy, a mature lane builds normal templates.
     st.set_utxo_immature_policy(
         dash::coin::UtxoImmaturePolicy::ServeEmptyTxSet);
@@ -1076,7 +1086,52 @@ TEST(DashUtxoImmatureServing, MatureLaneNeverSuppresses) {     // negative twin
     // …and neither does a bundle with no UTXO lane armed at all.
     NodeCoinState unarmed;
     seed_healthy_armed(unarmed);
+    unarmed.set_serve_mempool_txs(true);
     EXPECT_FALSE(unarmed.make_embedded_work_inputs().suppress_mempool_txs);
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// --embedded-serve-mempool-txs (default OFF): fee-carrying templates are an
+// explicit operator opt-in; the shipped default serves coinbase-only bodies
+// with the cause named on the template. Audit:
+// DASH_CONNECTBLOCK_REJECT_SURFACE_AUDIT.md (mempool-tx body path G1-G4).
+// ════════════════════════════════════════════════════════════════════════
+TEST(DashMempoolTxServing, DefaultOffSuppressesBodyWithNamedCause) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_utxo_ready_fn([] { return true; });   // even a MATURE lane
+    EXPECT_FALSE(st.serve_mempool_txs()) << "the shipped default is OFF";
+    const auto e = st.make_embedded_work_inputs();
+    EXPECT_TRUE(e.has_state) << "coinbase-only serving is not a refusal";
+    EXPECT_TRUE(e.suppress_mempool_txs)
+        << "default OFF: the body must be coinbase-only";
+    EXPECT_STREQ(e.suppress_cause, "mempool-txs-disabled")
+        << "the state must say its own name";
+}
+
+TEST(DashMempoolTxServing, OptInCarriesMempoolTxs) {           // negative twin
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_utxo_ready_fn([] { return true; });
+    st.set_serve_mempool_txs(true);
+    const auto e = st.make_embedded_work_inputs();
+    EXPECT_TRUE(e.has_state);
+    EXPECT_FALSE(e.suppress_mempool_txs)
+        << "the opt-in with a mature lane serves fee-carrying templates";
+}
+
+TEST(DashMempoolTxServing, UtxoImmatureCauseWinsOverDisabled) {
+    // Both suppressed-body producers active: the more specific state name
+    // (utxo-immature-serving) must win so soak greps attribute the window
+    // correctly.
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_utxo_ready_fn([] { return false; });
+    st.set_utxo_immature_policy(
+        dash::coin::UtxoImmaturePolicy::ServeEmptyTxSet);
+    const auto e = st.make_embedded_work_inputs();
+    EXPECT_TRUE(e.suppress_mempool_txs);
+    EXPECT_STREQ(e.suppress_cause, "utxo-immature-serving");
 }
 
 // The opt-in relaxes ONLY this clause. Every other gate must still refuse —

--- a/test/test_dash_node_embedded_wire.cpp
+++ b/test/test_dash_node_embedded_wire.cpp
@@ -155,6 +155,10 @@ TEST(DashNodeEmbeddedWire, MaintainerPublishesNodeBundleRoutesEmbeddedByteEqual)
 
     dash::NodeImpl node;
     node.coin_state().mempool().set_utxo(&utxo);
+    // This KAT pins the FEE-CARRYING flow — the --embedded-serve-mempool-txs
+    // OPT-IN (default OFF = coinbase-only; pinned in test_dash_node_coin_state
+    // DashMempoolTxServing).
+    node.coin_state().set_serve_mempool_txs(true);
 
     // Drive the bundle purely through the node's maintainer accessor -- the exact
     // surface the reception/think slices call. MN then tip; readiness gate flips

--- a/test/test_dash_node_reception_wire.cpp
+++ b/test/test_dash_node_reception_wire.cpp
@@ -205,6 +205,10 @@ TEST(DashReceptionWire, RelayedTxReachesEmbeddedTemplateThenInvalidateDemotes) {
     dash::interfaces::Node node;
     NodeCoinState st;
     st.mempool().set_utxo(&utxo);
+    // This KAT pins the FEE-CARRYING flow — the --embedded-serve-mempool-txs
+    // OPT-IN (default OFF = coinbase-only; pinned in test_dash_node_coin_state
+    // DashMempoolTxServing).
+    st.set_serve_mempool_txs(true);
     CoinStateMaintainer m(st);
     auto sub = wire_mempool_ingest(node, m);
 


### PR DESCRIPTION
## What

Closes all four GAP rows of the ConnectBlock reject-surface audit (`frstrtr/the` `docs/DASH_CONNECTBLOCK_REJECT_SURFACE_AUDIT.md` §1) — every one of them in the mempool-tx body path of the embedded DASH template builder — so embedded templates can safely carry mempool transactions (fees). DASH lane only; the dashd fallback arm is untouched.

## Gap-by-gap

| gap | dashd reject | fix |
|---|---|---|
| **G1** (primary) | `bad-txns-inputs-missingorspent` | **Topological selection** in `Mempool::get_sorted_txs_with_fees` (`src/impl/dash/coin/mempool.hpp`): every candidate expands to its ancestor **package** (unselected in-mempool ancestors, parents-first, dashd `DEFAULT_ANCESTOR_LIMIT=25` bound), admitted atomically or the child is dropped (byte cap, fee-unknown parent, any failing member). A vin is satisfied only by a live UTXO coin or a parent **already in the selected set / earlier in the package** — never by bare mempool membership (the pre-fix stale-input-guard hole behind the CPFP child-precedes-parent shape). |
| **G2** | `bad-blk-sigops` (40k) | Sigop accounting during selection: new `src/impl/dash/coin/sigops.hpp`, a standalone header-only port of dashd `GetLegacySigOpCount`/`GetP2SHSigOpCount` over raw script bytes (no btclibs `CScript` link dependency). Running total seeded with dashd's 100-sigop coinbase reserve; a package reaching `MaxBlockSigOps` is skipped (`>=` at the cap, miner `TestPackage` semantics). |
| **G3** | `bad-txns-premature-spend-of-coinbase` | The selection guard now reads the `Coin`'s `is_coinbase`+`height` (previously fetched and never read) and refuses spends of coinbase < 100 confs at the template height (`next_height` seam threaded from `build_embedded_workdata`; `0` = legacy callers unchanged). |
| **G4** | `conflict-tx-lock` | Islock-conflict tracking (`Mempool::add_islock` + `CoinStateMaintainer::on_islock` seam): registration evicts a conflicting pool entry immediately AND selection re-checks every vin (outpoint locked to a different txid ⇒ package dropped); confirm-time pruning, 100k FIFO bound. **Residual race documented at the API**: an islock forming after emit can still invalidate a won share — the same islock-formation window dashd's own miner runs, and dashd waives the check once the block is chainlocked (`validation.cpp:2612`). Feed = the coin-P2P `isdlock` parse leg (follow-up); until it lands the map is empty and selection behaves exactly as before. |

## Serving posture — coinbase-only stays the default

Fee-carrying templates are now behind **`--embedded-serve-mempool-txs` (default OFF)**. No such switch existed: tx-carrying was an implicit consequence of the UTXO lane maturing. Default OFF serves a coinbase-only body with the cause **named on the template and in the log** (`mempool-txs-disabled`; the utxo-immature window keeps its own `utxo-immature-serving` name — `DashMempoolTxServing.UtxoImmatureCauseWinsOverDisabled` pins the precedence).

## Source invariant (the audit's two N-A-BY-SOURCE-INVARIANT rows)

`bad-txns-nonfinal` and `mandatory-script-verify-flag` are argued N-A **only** because dashd-peer relay is the sole tx ingestion path (`new_tx` → `wire_mempool_ingest` → `on_mempool_tx` → `add_tx`, the only caller). That invariant is now asserted in writing at both ends (`mempool.hpp` header block, `CoinStateMaintainer::on_mempool_tx`): any new ingestion seam must re-audit those rows before wiring.

## KATs — fails-on-master, folded into allowlisted targets

- `test_dash_mempool` (allowlisted): `DashMempoolAuditGaps` — `G1_CpfpChildNeverPrecedesParent`, `G1_ByteCapDropsChildWhenParentDoesNotFit`, `G1_FeeUnknownParentExcludesPricedChild`, `G2_SigopCapStopsSelectionBeforeBadBlkSigops`, `G2_SigopCountingMatchesDashdRules`, `G3_ImmatureCoinbaseSpendRefused`, `G4_IslockConflictEvictedAndNeverSelected`.
- `test_dash_node_coin_state` (allowlisted): `DashMempoolTxServing` — default-OFF suppression with named cause, opt-in carries txs, cause precedence.
- **Fails-on-master verified** by rebuilding the KATs against master's `mempool.hpp`: the four old-API KATs (G1 ×3, G2 cap) FAIL against the pre-fix selector; the G3/G4 KATs pin seams that do not exist on master (do not compile there).
- `tools/ci/check_test_target_allowlist.py`: **OK** (231 targets, no new executable).

Five existing KATs that pin the fee-carrying flow (`PopulatedRoutesEmbeddedByteEqualToDirectBuild`, `PopulatedRoutesEmbeddedNoDashdPoll`, `MnThenTipPublishesByteEqualToDirectBuild`, `MaintainerPublishesNodeBundleRoutesEmbeddedByteEqual`, `RelayedTxReachesEmbeddedTemplateThenInvalidateDemotes`) now arm it explicitly via `set_serve_mempool_txs(true)` — commented at each site.

## Verification

Full dash-lane sweep green locally (Release, gcc13): `test_dash_mempool` 26, `test_dash_node_coin_state` 70, `test_dash_embedded_gbt` 159, `test_dash_node_reception_wire` 121, plus `get_work` / `coin_state_maintainer` / `node_embedded_wire` / `work_source` / `stratum_work_source` / `conformance` / `oracle_byte_parity` / `cb_payee` / `coinbase_parity` / `superblock` / `bestcl_gate` / `underfill_guard` / `block_producer` / `g3_assembled` / `work_target` / `work_job_targets` / `embedded_relay_e2e`. `c2pool-dash` binary builds.

**do-not-merge**: fee-carrying serving is soak-gated; this PR ships the guards + the default-OFF switch and awaits the operator's soak/cutover decision.
