### PR TITLE
ci: heavy-leg reap-guard must not leak its lock holder

### DIFF
--- a/.github/actions/heavy-leg-lock/test.sh
+++ b/.github/actions/heavy-leg-lock/test.sh
@@ -4,28 +4,31 @@
 #
 # Extracts the ACTUAL "Acquire per-host heavy-leg lock (reap-guard)" run: script
 # out of build.yml (the shipped bytes, not a copy) and drives it in isolation
-# via the HEAVY_LEG_* env overrides, proving the reap is load-bearing:
+# via the HEAVY_LEG_* env overrides, proving the reap is load-bearing across ALL
+# HEAVY_LEG_SLOTS concurrent slots (not just one):
 #
-#   FIXED  (HEAVY_LEG_SWEEP=1): an orphaned holder whose owning job is already
-#          dead is REAPED at acquire -> the lock is acquired -> exit 0 (GREEN).
-#   LEAKED (HEAVY_LEG_SWEEP=0): the same orphan is NOT swept -> it blocks ->
-#          acquire times out at the -w budget -> exit 1 (RED).
+#   FIXED  (HEAVY_LEG_SWEEP=1): EVERY slot is saturated with an orphaned holder
+#          whose owning job is already dead -> all are REAPED at acquire -> a
+#          free slot opens -> the lock is acquired -> exit 0 (GREEN).
+#   LEAKED (HEAVY_LEG_SWEEP=0): the same orphans are NOT swept -> every slot
+#          stays busy -> acquire times out at the -w budget -> exit 1 (RED).
 #
 # If restoring the leak did NOT turn it red the test FAILS: that would mean the
-# guard acquired despite a live orphan -- a hollow (non-load-bearing) sweep.
-# Perturb -> green, restore leak -> red. No hollow pass.
+# guard acquired despite live orphans on every slot -- a hollow sweep. Saturating
+# all SLOTS is what keeps this load-bearing under the multi-slot semaphore: a
+# single free slot would let acquire pass without reaping anything.
 # ============================================================================
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
 WF="$ROOT/.github/workflows/build.yml"
 STEP="Acquire per-host heavy-leg lock (reap-guard)"
+SLOTS="${SLOTS:-2}"   # must match the guard's production HEAVY_LEG_SLOTS default
 
 TMP="$(mktemp -d)"
 cleanup() {
   [ "${BASHPID:-$$}" = "$$" ] || return 0   # never run inside a $(...) subshell
-  # reap anything we spawned that still holds a case lock
-  for lk in "$TMP"/case*.lock; do
+  for lk in "$TMP"/case*.lock.*; do
     [ -e "$lk" ] && fuser -k "$lk" 2>/dev/null || true
   done
   rm -rf "$TMP"
@@ -50,13 +53,12 @@ echo "===== acquire script under test (extracted from build.yml) ====="
 cat "$ACQ_SH"
 echo "================================================================"
 
-# Plant a holder whose owning job is already dead: a marker pointing at a
-# worker PID that no longer exists (exactly what a host-reaped job leaves).
-# Single process (exec sleep) holding the exclusive flock, so a kill of it
-# frees the lock at once -- same shape as the old `exec sleep 14400` holder.
-plant_orphan() {  # $1 lockpath  $2 holderpath
+# Plant a holder whose owning job is already dead on ONE slot: a marker pointing
+# at a worker PID that no longer exists (exactly what a host-reaped job leaves).
+# Single process (exec sleep) holding the exclusive flock, so a kill of it frees
+# the slot at once -- same shape as the old `exec sleep 14400` holder.
+plant_orphan() {  # $1 slot-lockpath  $2 slot-markerpath
   local lock="$1" marker="$2"
-  # a guaranteed-dead worker PID: a subshell that exits immediately, then reaped
   ( exit 0 ) & local deadworker=$!
   wait "$deadworker" 2>/dev/null || true
   setsid bash -c 'exec 9>"'"$lock"'"; flock -x 9 || exit 1; exec sleep 300' \
@@ -64,46 +66,56 @@ plant_orphan() {  # $1 lockpath  $2 holderpath
   local orphan=$!
   printf '%s %s\n' "$orphan" "$deadworker" > "$marker"
   local i
-  local i
   for ((i=0;i<100;i++)); do
     flock -n -x "$lock" -c true 2>/dev/null || return 0   # held -> orphan is up
     sleep 0.1
   done
-  echo "FATAL: orphan never took the lock"; return 1
+  echo "FATAL: orphan never took the lock $lock"; return 1
 }
 
-run_guard() {  # $1 sweep(0/1)  $2 wait(s)  $3 lockpath  $4 holderpath
+# Saturate every slot: ${base}.1 .. ${base}.SLOTS with a dead-owner orphan each.
+saturate() {  # $1 lock-base  $2 marker-base
+  local s
+  for ((s=1;s<=SLOTS;s++)); do
+    plant_orphan "$1.$s" "$2.$s" || return 1
+  done
+}
+
+run_guard() {  # $1 sweep(0/1)  $2 wait(s)  $3 lock-base  $4 marker-base
   HEAVY_LEG_LOCK="$3" HEAVY_LEG_HOLDERFILE="$4" \
-  HEAVY_LEG_WAIT="$2" HEAVY_LEG_TTL=3 HEAVY_LEG_SWEEP="$1" \
+  HEAVY_LEG_WAIT="$2" HEAVY_LEG_TTL=3 HEAVY_LEG_SWEEP="$1" HEAVY_LEG_SLOTS="$SLOTS" \
   RUNNER_NAME="honesty-test" GITHUB_ENV="$TMP/genv" \
   bash "$ACQ_SH"
 }
 
-reap() {
-  [ -f "$2" ] && awk '{print $1}' "$2" | xargs -r kill 2>/dev/null || true
-  fuser -k "$1" 2>/dev/null || true
+reap() {  # $1 lock-base  $2 marker-base
+  local s
+  for ((s=1;s<=SLOTS;s++)); do
+    [ -f "$2.$s" ] && awk '{print $1}' "$2.$s" | xargs -r kill 2>/dev/null || true
+    fuser -k "$1.$s" 2>/dev/null || true
+  done
   sleep 0.3 || true
 }
 
 fail=0
 
-echo; echo "### CASE 1  FIXED (sweep on): orphan must be reaped -> GREEN"
+echo; echo "### CASE 1  FIXED (sweep on): all $SLOTS slots saturated -> orphans reaped -> GREEN"
 L1="$TMP/case1.lock"; H1="$TMP/case1.holder"
-plant_orphan "$L1" "$H1" || exit 1
+saturate "$L1" "$H1" || exit 1
 if run_guard 1 20 "$L1" "$H1"; then
-  echo "-> PASS: guard reaped the stale holder and acquired the lock"
+  echo "-> PASS: guard reaped the stale holders on every slot and acquired the lock"
 else
-  echo "-> FAIL: guard did NOT recover from a reapable orphan"; fail=1
+  echo "-> FAIL: guard did NOT recover from reapable orphans saturating all slots"; fail=1
 fi
 reap "$L1" "$H1"
 
-echo; echo "### CASE 2  LEAKED (sweep off): same orphan must block -> RED"
+echo; echo "### CASE 2  LEAKED (sweep off): same saturation must block -> RED"
 L2="$TMP/case2.lock"; H2="$TMP/case2.holder"
-plant_orphan "$L2" "$H2" || exit 1
+saturate "$L2" "$H2" || exit 1
 if run_guard 0 5 "$L2" "$H2"; then
-  echo "-> FAIL: guard acquired despite a live orphan -- sweep is not load-bearing (hollow)"; fail=1
+  echo "-> FAIL: guard acquired despite live orphans on every slot -- sweep is not load-bearing (hollow)"; fail=1
 else
-  echo "-> PASS: orphan blocked acquire and it failed red, as it must without the sweep"
+  echo "-> PASS: orphans blocked every slot and acquire failed red, as it must without the sweep"
 fi
 reap "$L2" "$H2"
 

--- a/.github/actions/heavy-leg-lock/test.sh
+++ b/.github/actions/heavy-leg-lock/test.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Honesty gate for the per-host heavy-leg reap-guard.
+#
+# Extracts the ACTUAL "Acquire per-host heavy-leg lock (reap-guard)" run: script
+# out of build.yml (the shipped bytes, not a copy) and drives it in isolation
+# via the HEAVY_LEG_* env overrides, proving the reap is load-bearing:
+#
+#   FIXED  (HEAVY_LEG_SWEEP=1): an orphaned holder whose owning job is already
+#          dead is REAPED at acquire -> the lock is acquired -> exit 0 (GREEN).
+#   LEAKED (HEAVY_LEG_SWEEP=0): the same orphan is NOT swept -> it blocks ->
+#          acquire times out at the -w budget -> exit 1 (RED).
+#
+# If restoring the leak did NOT turn it red the test FAILS: that would mean the
+# guard acquired despite a live orphan -- a hollow (non-load-bearing) sweep.
+# Perturb -> green, restore leak -> red. No hollow pass.
+# ============================================================================
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+WF="$ROOT/.github/workflows/build.yml"
+STEP="Acquire per-host heavy-leg lock (reap-guard)"
+
+TMP="$(mktemp -d)"
+cleanup() {
+  [ "${BASHPID:-$$}" = "$$" ] || return 0   # never run inside a $(...) subshell
+  # reap anything we spawned that still holds a case lock
+  for lk in "$TMP"/case*.lock; do
+    [ -e "$lk" ] && fuser -k "$lk" 2>/dev/null || true
+  done
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+# --- extract the shipped acquire script (pyyaml; on gh-hosted + workstation) -
+ACQ_SH="$TMP/acquire.sh"
+python3 - "$WF" "$STEP" > "$ACQ_SH" <<'PY'
+import sys, yaml
+wf, step = sys.argv[1], sys.argv[2]
+doc = yaml.safe_load(open(wf))
+for job in (doc.get("jobs") or {}).values():
+    for s in (job.get("steps") or []):
+        if s.get("name") == step:
+            sys.stdout.write(s.get("run", ""))
+            raise SystemExit(0)
+raise SystemExit(3)
+PY
+[ -s "$ACQ_SH" ] || { echo "FATAL: could not extract '$STEP' run: from $WF"; exit 2; }
+echo "===== acquire script under test (extracted from build.yml) ====="
+cat "$ACQ_SH"
+echo "================================================================"
+
+# Plant a holder whose owning job is already dead: a marker pointing at a
+# worker PID that no longer exists (exactly what a host-reaped job leaves).
+# Single process (exec sleep) holding the exclusive flock, so a kill of it
+# frees the lock at once -- same shape as the old `exec sleep 14400` holder.
+plant_orphan() {  # $1 lockpath  $2 holderpath
+  local lock="$1" marker="$2"
+  # a guaranteed-dead worker PID: a subshell that exits immediately, then reaped
+  ( exit 0 ) & local deadworker=$!
+  wait "$deadworker" 2>/dev/null || true
+  setsid bash -c 'exec 9>"'"$lock"'"; flock -x 9 || exit 1; exec sleep 300' \
+    </dev/null >/dev/null 2>&1 &
+  local orphan=$!
+  printf '%s %s\n' "$orphan" "$deadworker" > "$marker"
+  local i
+  local i
+  for ((i=0;i<100;i++)); do
+    flock -n -x "$lock" -c true 2>/dev/null || return 0   # held -> orphan is up
+    sleep 0.1
+  done
+  echo "FATAL: orphan never took the lock"; return 1
+}
+
+run_guard() {  # $1 sweep(0/1)  $2 wait(s)  $3 lockpath  $4 holderpath
+  HEAVY_LEG_LOCK="$3" HEAVY_LEG_HOLDERFILE="$4" \
+  HEAVY_LEG_WAIT="$2" HEAVY_LEG_TTL=3 HEAVY_LEG_SWEEP="$1" \
+  RUNNER_NAME="honesty-test" GITHUB_ENV="$TMP/genv" \
+  bash "$ACQ_SH"
+}
+
+reap() {
+  [ -f "$2" ] && awk '{print $1}' "$2" | xargs -r kill 2>/dev/null || true
+  fuser -k "$1" 2>/dev/null || true
+  sleep 0.3 || true
+}
+
+fail=0
+
+echo; echo "### CASE 1  FIXED (sweep on): orphan must be reaped -> GREEN"
+L1="$TMP/case1.lock"; H1="$TMP/case1.holder"
+plant_orphan "$L1" "$H1" || exit 1
+if run_guard 1 20 "$L1" "$H1"; then
+  echo "-> PASS: guard reaped the stale holder and acquired the lock"
+else
+  echo "-> FAIL: guard did NOT recover from a reapable orphan"; fail=1
+fi
+reap "$L1" "$H1"
+
+echo; echo "### CASE 2  LEAKED (sweep off): same orphan must block -> RED"
+L2="$TMP/case2.lock"; H2="$TMP/case2.holder"
+plant_orphan "$L2" "$H2" || exit 1
+if run_guard 0 5 "$L2" "$H2"; then
+  echo "-> FAIL: guard acquired despite a live orphan -- sweep is not load-bearing (hollow)"; fail=1
+else
+  echo "-> PASS: orphan blocked acquire and it failed red, as it must without the sweep"
+fi
+reap "$L2" "$H2"
+
+echo
+if [ "$fail" = 0 ]; then
+  echo "HONESTY GATE PASSED: perturb -> reaped -> green ; restore leak -> red"
+else
+  echo "HONESTY GATE FAILED"
+fi
+exit "$fail"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -343,7 +343,7 @@ jobs:
             case "$(ps -o comm= -p "$_p" 2>/dev/null || true)" in
               Runner.Worker*) WORKER="$_p"; break ;;
             esac
-            _p="$(ps -o ppid= -p "$_p" 2>/dev/null | tr -d ' ')"
+            _p="$(ps -o ppid= -p "$_p" 2>/dev/null | tr -d ' ' || true)"
             [ -z "${_p:-}" ] && break
           done
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -293,47 +293,62 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Per-host heavy-leg lock (VM905: 8 runners, 1 heavy slot -> constant
-          # contention). Two defects this guard fixes vs. the old sleep-holder:
-          #  (1) the holder must die WITH the job. The old `exec sleep 14400`
-          #      outlived a reaped/cancelled job and wedged the host for up to the
-          #      TTL while every waiter hard-failed at its own 60 min -w. The holder
-          #      below waits on the runner-worker PID and exits (freeing the lock)
-          #      the instant that worker dies; the TTL is only a ceiling.
-          #  (2) a stale holder from an already-dead job is REAPED at acquire time,
-          #      not blocked on: a recorded holder whose worker is gone, or a
-          #      markerless PPID-1 legacy orphan, is by definition dead.
+          # Per-host heavy-leg semaphore (VM905: up to 8 runners on a 32-core/62 GB box).
+          # History: a single slot (1 heavy leg per host) became the #1 CI failure mode --
+          # 8 runners serialized behind one flock while ~2/3 of the box sat idle, and
+          # waiters hard-failed at the -w budget (integrator measurement 2026-08-05). This
+          # guard now offers HEAVY_LEG_SLOTS concurrent slots with first-free acquisition:
+          # a leg takes the first free slot, so up to SLOTS heavy legs (ASan/UBSan build +
+          # CodeQL c-cpp analyze) run concurrently on one host and the (SLOTS+1)th WAITS --
+          # nothing is ever cancelled. 2 ASan/CodeQL legs fit 32c/62G comfortably; do NOT
+          # raise SLOTS past 3 without first measuring an ASan leg's peak RSS.
+          # Two holder invariants preserved from #1112:
+          #  (1) the holder dies WITH the job -- it waits on the runner-worker PID and
+          #      frees its slot the instant that worker dies; TTL is only a ceiling.
+          #  (2) a stale holder from an already-dead job is REAPED at acquire, not blocked
+          #      on: a recorded holder whose worker is gone, or a markerless PPID-1 legacy
+          #      orphan, is by definition dead.
           # HEAVY_LEG_* env overrides exist ONLY for the honesty-gate test
           # (.github/actions/heavy-leg-lock/test.sh); production uses the defaults.
           LOCK="${HEAVY_LEG_LOCK:-/tmp/c2pool-heavy-leg.lock}"
           HOLDERFILE="${HEAVY_LEG_HOLDERFILE:-/tmp/c2pool-heavy-leg.holder}"
-          WAIT="${HEAVY_LEG_WAIT:-3600}"
+          WAIT="${HEAVY_LEG_WAIT:-5400}"
           TTL="${HEAVY_LEG_TTL:-14400}"
           SWEEP="${HEAVY_LEG_SWEEP:-1}"
+          SLOTS="${HEAVY_LEG_SLOTS:-2}"
           ACQ="$(mktemp -u /tmp/c2pool-heavy-acq.XXXXXX)"
 
-          # --- stale-holder sweep: reap the dead instead of blocking on them ---
+          # Slot files are ${LOCK}.1 .. ${LOCK}.SLOTS; each slot's live holder records a
+          # ${HOLDERFILE}.<slot> marker ("holderpid workerpid"). Both are per-slot so two
+          # concurrent holders never clobber each other's marker.
+
+          # --- stale-holder sweep: reap the dead on each slot instead of blocking ---
           if [ "$SWEEP" = 1 ]; then
-            if [ -f "$HOLDERFILE" ]; then
-              read -r MH MW _ < "$HOLDERFILE" 2>/dev/null || true
-              if [ -n "${MW:-}" ] && [ "${MW:-0}" != 0 ] && ! kill -0 "$MW" 2>/dev/null; then
-                echo "heavy-leg sweep: reaping holder pid ${MH:-?} (worker $MW dead)"
-                [ -n "${MH:-}" ] && kill "$MH" 2>/dev/null || true
-                rm -f "$HOLDERFILE"
-              fi
-            fi
-            # Markerless PPID-1 orphan = a pre-guard `sleep 14400` holder: our live
-            # holders always keep a marker, and a still-waiting new holder has a live
-            # parent (its acquire step), so PPID==1 + no marker is unambiguously dead.
-            if [ ! -f "$HOLDERFILE" ] && command -v fuser >/dev/null 2>&1; then
-              for _q in $(fuser "$LOCK" 2>/dev/null | tr -d ' '); do
-                _qp="$(ps -o ppid= -p "$_q" 2>/dev/null | tr -d ' ')"
-                if [ "${_qp:-0}" = 1 ]; then
-                  echo "heavy-leg sweep: reaping markerless PPID-1 orphan pid $_q"
-                  kill "$_q" 2>/dev/null || true
+            _s=1
+            while [ "$_s" -le "$SLOTS" ]; do
+              _mf="${HOLDERFILE}.${_s}"
+              if [ -f "$_mf" ]; then
+                read -r MH MW _ < "$_mf" 2>/dev/null || true
+                if [ -n "${MW:-}" ] && [ "${MW:-0}" != 0 ] && ! kill -0 "$MW" 2>/dev/null; then
+                  echo "heavy-leg sweep: reaping holder pid ${MH:-?} on slot $_s (worker $MW dead)"
+                  [ -n "${MH:-}" ] && kill "$MH" 2>/dev/null || true
+                  rm -f "$_mf"
                 fi
-              done
-            fi
+              fi
+              # Markerless PPID-1 orphan on this slot = a pre-guard `sleep` holder: our live
+              # holders always keep a marker, and a still-waiting new holder has a live
+              # parent, so PPID==1 + no marker is unambiguously dead.
+              if [ ! -f "$_mf" ] && command -v fuser >/dev/null 2>&1; then
+                for _q in $(fuser "${LOCK}.${_s}" 2>/dev/null | tr -d ' '); do
+                  _qp="$(ps -o ppid= -p "$_q" 2>/dev/null | tr -d ' ' || true)"
+                  if [ "${_qp:-0}" = 1 ]; then
+                    echo "heavy-leg sweep: reaping markerless PPID-1 orphan pid $_q on slot $_s"
+                    kill "$_q" 2>/dev/null || true
+                  fi
+                done
+              fi
+              _s=$((_s+1))
+            done
           fi
 
           # --- find the runner-worker so the holder can die with the job ---
@@ -347,43 +362,73 @@ jobs:
             [ -z "${_p:-}" ] && break
           done
 
-          # --- spawn the holder: holds fd 9 for the job's life ---
-          # Children get fd 9 closed (9>&-) so a kill of this bash frees the lock at
-          # once. It exits when the runner-worker dies, or at TTL, whichever is first;
-          # if the worker could not be found it falls back to a pure TTL ceiling.
-          env LOCK="$LOCK" HOLDERFILE="$HOLDERFILE" ACQ="$ACQ" WAIT="$WAIT" TTL="$TTL" WORKER="$WORKER" \
+          # --- spawn the holder: first-free across SLOTS, holds its fd for the job's life ---
+          # Each slot opens on fd (8+slot); slot 1 -> fd 9 (as before). The held fd is
+          # closed (N>&-) in the sleep child so a kill of this bash frees the slot at once.
+          # The holder exits when the runner-worker dies, or at TTL, whichever is first; if
+          # the worker could not be found it falls back to a pure TTL ceiling.
+          env LOCK="$LOCK" HOLDERFILE="$HOLDERFILE" ACQ="$ACQ" WAIT="$WAIT" TTL="$TTL" SLOTS="$SLOTS" WORKER="$WORKER" \
           bash -c '
-            exec 9>"$LOCK" || exit 1
-            flock -x -w "$WAIT" 9 || exit 1
-            printf "%s %s\n" "$$" "${WORKER:-0}" > "$HOLDERFILE"
-            touch "$ACQ"
+            _s=1
+            while [ "$_s" -le "$SLOTS" ]; do
+              _fd=$((8+_s))
+              eval "exec ${_fd}>\"\${LOCK}.\${_s}\"" || exit 1
+              _s=$((_s+1))
+            done
+            _held_fd=""
+            _deadline=$(( SECONDS + WAIT ))
+            while [ "$SECONDS" -lt "$_deadline" ]; do
+              _s=1
+              while [ "$_s" -le "$SLOTS" ]; do
+                _fd=$((8+_s))
+                if flock -n "$_fd"; then _held_fd="$_fd"; break; fi
+                _s=$((_s+1))
+              done
+              [ -n "$_held_fd" ] && break
+              sleep 3
+            done
+            [ -z "$_held_fd" ] && exit 1
+            _held_slot=$(( _held_fd - 8 ))
+            printf "%s %s\n" "$$" "${WORKER:-0}" > "${HOLDERFILE}.${_held_slot}"
+            echo "$_held_slot" > "$ACQ"
             _end=$(( SECONDS + TTL ))
             while [ "$SECONDS" -lt "$_end" ]; do
               if [ -n "$WORKER" ] && ! kill -0 "$WORKER" 2>/dev/null; then break; fi
-              sleep 15 9>&-
+              eval "sleep 15 ${_held_fd}>&-"
             done
-            rm -f "$HOLDERFILE"
+            rm -f "${HOLDERFILE}.${_held_slot}"
           ' </dev/null >/dev/null 2>&1 &
           HOLDER=$!
           disown "$HOLDER" 2>/dev/null || true
           echo "HEAVY_LEG_LOCK_HOLDER=$HOLDER" >> "${GITHUB_ENV:-/dev/null}"
 
           # --- wait for the acquire handshake ---
-          while kill -0 "$HOLDER" 2>/dev/null && [ ! -e "$ACQ" ]; do
+          while kill -0 "$HOLDER" 2>/dev/null && [ ! -s "$ACQ" ]; do
             sleep 2
           done
-          if [ ! -e "$ACQ" ]; then
-            echo "::error::per-host heavy-leg lock not acquired within $((WAIT/60)) min on ${RUNNER_NAME:-?} -- blocked by a stale holder, not this diff"
-            if command -v fuser >/dev/null 2>&1; then
-              for _q in $(fuser "$LOCK" 2>/dev/null | tr -d ' '); do
-                echo "  current holder: $(ps -o pid=,ppid=,etimes=,comm= -p "$_q" 2>/dev/null | tr -s ' ')"
-              done
-            fi
-            [ -f "$HOLDERFILE" ] && echo "  holder marker: $(cat "$HOLDERFILE" 2>/dev/null)"
+          if [ ! -s "$ACQ" ]; then
+            echo "::error::per-host heavy-leg lock: all $SLOTS slots busy for $((WAIT/60)) min on ${RUNNER_NAME:-?} -- blocked by live long holders, not this diff"
+            _s=1
+            while [ "$_s" -le "$SLOTS" ]; do
+              echo "  slot $_s (${LOCK}.${_s}):"
+              if command -v fuser >/dev/null 2>&1; then
+                for _q in $(fuser "${LOCK}.${_s}" 2>/dev/null | tr -d ' '); do
+                  # pid ppid age(etimes,s) comm -- names the live holder blocking this slot
+                  echo "    holder [pid ppid age_s comm]: $(ps -o pid=,ppid=,etimes=,comm= -p "$_q" 2>/dev/null | tr -s ' ')"
+                done
+              fi
+              if [ -f "${HOLDERFILE}.${_s}" ]; then
+                echo "    marker (holderpid workerpid): $(cat "${HOLDERFILE}.${_s}" 2>/dev/null)"
+              else
+                echo "    marker: (none)"
+              fi
+              _s=$((_s+1))
+            done
             exit 1
           fi
+          _got="$(cat "$ACQ" 2>/dev/null)"
           rm -f "$ACQ"
-          echo "heavy-leg lock acquired on ${RUNNER_NAME:-?} (holder pid $HOLDER, worker ${WORKER:-none})"
+          echo "heavy-leg lock acquired on ${RUNNER_NAME:-?} slot ${_got:-?}/$SLOTS (holder pid $HOLDER, worker ${WORKER:-none})"
       - uses: actions/checkout@v6
 
       # Per-job Conan home under $RUNNER_TEMP so concurrent jobs on the shared
@@ -537,11 +582,12 @@ jobs:
           H="${HEAVY_LEG_LOCK_HOLDER:-}"
           if [ -n "$H" ]; then
             kill "$H" 2>/dev/null || true
-            MF=/tmp/c2pool-heavy-leg.holder
-            if [ -f "$MF" ]; then
+            # drop whichever per-slot marker this holder owns
+            for MF in "${HEAVY_LEG_HOLDERFILE:-/tmp/c2pool-heavy-leg.holder}".*; do
+              [ -f "$MF" ] || continue
               read -r _mh _ < "$MF" 2>/dev/null || true
               [ "${_mh:-}" = "$H" ] && rm -f "$MF"
-            fi
+            done
           fi
   # ════════════════════════════════════════════════════════════════════════════
   # COIN_BCH leg — Bitcoin Cash (SHA256d standalone parent, V36)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -293,28 +293,97 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          LOCK=/tmp/c2pool-heavy-leg.lock
+          # Per-host heavy-leg lock (VM905: 8 runners, 1 heavy slot -> constant
+          # contention). Two defects this guard fixes vs. the old sleep-holder:
+          #  (1) the holder must die WITH the job. The old `exec sleep 14400`
+          #      outlived a reaped/cancelled job and wedged the host for up to the
+          #      TTL while every waiter hard-failed at its own 60 min -w. The holder
+          #      below waits on the runner-worker PID and exits (freeing the lock)
+          #      the instant that worker dies; the TTL is only a ceiling.
+          #  (2) a stale holder from an already-dead job is REAPED at acquire time,
+          #      not blocked on: a recorded holder whose worker is gone, or a
+          #      markerless PPID-1 legacy orphan, is by definition dead.
+          # HEAVY_LEG_* env overrides exist ONLY for the honesty-gate test
+          # (.github/actions/heavy-leg-lock/test.sh); production uses the defaults.
+          LOCK="${HEAVY_LEG_LOCK:-/tmp/c2pool-heavy-leg.lock}"
+          HOLDERFILE="${HEAVY_LEG_HOLDERFILE:-/tmp/c2pool-heavy-leg.holder}"
+          WAIT="${HEAVY_LEG_WAIT:-3600}"
+          TTL="${HEAVY_LEG_TTL:-14400}"
+          SWEEP="${HEAVY_LEG_SWEEP:-1}"
           ACQ="$(mktemp -u /tmp/c2pool-heavy-acq.XXXXXX)"
-          # Holder: waits up to 60 min for the lock, then holds it with a
-          # 4 h TTL (self-expires so a reaped job cannot wedge the host).
-          # fds redirected so the step does not hang on the open pipe;
-          # disowned so it survives this step's shell (NOT setsid: setsid
-          # forks, orphaning $!; and the runner's end-of-job cleanup
-          # SHOULD reap the holder if the release step never runs).
-          bash -c "exec 9>'$LOCK' && flock -x -w 3600 9 && touch '$ACQ' && exec sleep 14400" </dev/null >/dev/null 2>&1 &
+
+          # --- stale-holder sweep: reap the dead instead of blocking on them ---
+          if [ "$SWEEP" = 1 ]; then
+            if [ -f "$HOLDERFILE" ]; then
+              read -r MH MW _ < "$HOLDERFILE" 2>/dev/null || true
+              if [ -n "${MW:-}" ] && [ "${MW:-0}" != 0 ] && ! kill -0 "$MW" 2>/dev/null; then
+                echo "heavy-leg sweep: reaping holder pid ${MH:-?} (worker $MW dead)"
+                [ -n "${MH:-}" ] && kill "$MH" 2>/dev/null || true
+                rm -f "$HOLDERFILE"
+              fi
+            fi
+            # Markerless PPID-1 orphan = a pre-guard `sleep 14400` holder: our live
+            # holders always keep a marker, and a still-waiting new holder has a live
+            # parent (its acquire step), so PPID==1 + no marker is unambiguously dead.
+            if [ ! -f "$HOLDERFILE" ] && command -v fuser >/dev/null 2>&1; then
+              for _q in $(fuser "$LOCK" 2>/dev/null | tr -d ' '); do
+                _qp="$(ps -o ppid= -p "$_q" 2>/dev/null | tr -d ' ')"
+                if [ "${_qp:-0}" = 1 ]; then
+                  echo "heavy-leg sweep: reaping markerless PPID-1 orphan pid $_q"
+                  kill "$_q" 2>/dev/null || true
+                fi
+              done
+            fi
+          fi
+
+          # --- find the runner-worker so the holder can die with the job ---
+          WORKER=""
+          _p=$$
+          while [ "${_p:-1}" -gt 1 ]; do
+            case "$(ps -o comm= -p "$_p" 2>/dev/null || true)" in
+              Runner.Worker*) WORKER="$_p"; break ;;
+            esac
+            _p="$(ps -o ppid= -p "$_p" 2>/dev/null | tr -d ' ')"
+            [ -z "${_p:-}" ] && break
+          done
+
+          # --- spawn the holder: holds fd 9 for the job's life ---
+          # Children get fd 9 closed (9>&-) so a kill of this bash frees the lock at
+          # once. It exits when the runner-worker dies, or at TTL, whichever is first;
+          # if the worker could not be found it falls back to a pure TTL ceiling.
+          env LOCK="$LOCK" HOLDERFILE="$HOLDERFILE" ACQ="$ACQ" WAIT="$WAIT" TTL="$TTL" WORKER="$WORKER" \
+          bash -c '
+            exec 9>"$LOCK" || exit 1
+            flock -x -w "$WAIT" 9 || exit 1
+            printf "%s %s\n" "$$" "${WORKER:-0}" > "$HOLDERFILE"
+            touch "$ACQ"
+            _end=$(( SECONDS + TTL ))
+            while [ "$SECONDS" -lt "$_end" ]; do
+              if [ -n "$WORKER" ] && ! kill -0 "$WORKER" 2>/dev/null; then break; fi
+              sleep 15 9>&-
+            done
+            rm -f "$HOLDERFILE"
+          ' </dev/null >/dev/null 2>&1 &
           HOLDER=$!
-          disown "$HOLDER"
-          echo "HEAVY_LEG_LOCK_HOLDER=$HOLDER" >> "$GITHUB_ENV"
+          disown "$HOLDER" 2>/dev/null || true
+          echo "HEAVY_LEG_LOCK_HOLDER=$HOLDER" >> "${GITHUB_ENV:-/dev/null}"
+
+          # --- wait for the acquire handshake ---
           while kill -0 "$HOLDER" 2>/dev/null && [ ! -e "$ACQ" ]; do
             sleep 2
           done
           if [ ! -e "$ACQ" ]; then
-            echo "::error::per-host heavy-leg lock not acquired within 60 min on $RUNNER_NAME"
+            echo "::error::per-host heavy-leg lock not acquired within $((WAIT/60)) min on ${RUNNER_NAME:-?} -- blocked by a stale holder, not this diff"
+            if command -v fuser >/dev/null 2>&1; then
+              for _q in $(fuser "$LOCK" 2>/dev/null | tr -d ' '); do
+                echo "  current holder: $(ps -o pid=,ppid=,etimes=,comm= -p "$_q" 2>/dev/null | tr -s ' ')"
+              done
+            fi
+            [ -f "$HOLDERFILE" ] && echo "  holder marker: $(cat "$HOLDERFILE" 2>/dev/null)"
             exit 1
           fi
           rm -f "$ACQ"
-          echo "heavy-leg lock acquired on $RUNNER_NAME (holder pid $HOLDER)"
-
+          echo "heavy-leg lock acquired on ${RUNNER_NAME:-?} (holder pid $HOLDER, worker ${WORKER:-none})"
       - uses: actions/checkout@v6
 
       # Per-job Conan home under $RUNNER_TEMP so concurrent jobs on the shared
@@ -465,10 +534,15 @@ jobs:
         if: always() && runner.environment != 'github-hosted'
         shell: bash
         run: |
-          if [ -n "${HEAVY_LEG_LOCK_HOLDER:-}" ]; then
-            kill "$HEAVY_LEG_LOCK_HOLDER" 2>/dev/null || true
+          H="${HEAVY_LEG_LOCK_HOLDER:-}"
+          if [ -n "$H" ]; then
+            kill "$H" 2>/dev/null || true
+            MF=/tmp/c2pool-heavy-leg.holder
+            if [ -f "$MF" ]; then
+              read -r _mh _ < "$MF" 2>/dev/null || true
+              [ "${_mh:-}" = "$H" ] && rm -f "$MF"
+            fi
           fi
-
   # ════════════════════════════════════════════════════════════════════════════
   # COIN_BCH leg — Bitcoin Cash (SHA256d standalone parent, V36)
   #

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -133,7 +133,7 @@ jobs:
             case "$(ps -o comm= -p "$_p" 2>/dev/null || true)" in
               Runner.Worker*) WORKER="$_p"; break ;;
             esac
-            _p="$(ps -o ppid= -p "$_p" 2>/dev/null | tr -d ' ')"
+            _p="$(ps -o ppid= -p "$_p" 2>/dev/null | tr -d ' ' || true)"
             [ -z "${_p:-}" ] && break
           done
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -83,47 +83,62 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Per-host heavy-leg lock (VM905: 8 runners, 1 heavy slot -> constant
-          # contention). Two defects this guard fixes vs. the old sleep-holder:
-          #  (1) the holder must die WITH the job. The old `exec sleep 14400`
-          #      outlived a reaped/cancelled job and wedged the host for up to the
-          #      TTL while every waiter hard-failed at its own 60 min -w. The holder
-          #      below waits on the runner-worker PID and exits (freeing the lock)
-          #      the instant that worker dies; the TTL is only a ceiling.
-          #  (2) a stale holder from an already-dead job is REAPED at acquire time,
-          #      not blocked on: a recorded holder whose worker is gone, or a
-          #      markerless PPID-1 legacy orphan, is by definition dead.
+          # Per-host heavy-leg semaphore (VM905: up to 8 runners on a 32-core/62 GB box).
+          # History: a single slot (1 heavy leg per host) became the #1 CI failure mode --
+          # 8 runners serialized behind one flock while ~2/3 of the box sat idle, and
+          # waiters hard-failed at the -w budget (integrator measurement 2026-08-05). This
+          # guard now offers HEAVY_LEG_SLOTS concurrent slots with first-free acquisition:
+          # a leg takes the first free slot, so up to SLOTS heavy legs (ASan/UBSan build +
+          # CodeQL c-cpp analyze) run concurrently on one host and the (SLOTS+1)th WAITS --
+          # nothing is ever cancelled. 2 ASan/CodeQL legs fit 32c/62G comfortably; do NOT
+          # raise SLOTS past 3 without first measuring an ASan leg's peak RSS.
+          # Two holder invariants preserved from #1112:
+          #  (1) the holder dies WITH the job -- it waits on the runner-worker PID and
+          #      frees its slot the instant that worker dies; TTL is only a ceiling.
+          #  (2) a stale holder from an already-dead job is REAPED at acquire, not blocked
+          #      on: a recorded holder whose worker is gone, or a markerless PPID-1 legacy
+          #      orphan, is by definition dead.
           # HEAVY_LEG_* env overrides exist ONLY for the honesty-gate test
           # (.github/actions/heavy-leg-lock/test.sh); production uses the defaults.
           LOCK="${HEAVY_LEG_LOCK:-/tmp/c2pool-heavy-leg.lock}"
           HOLDERFILE="${HEAVY_LEG_HOLDERFILE:-/tmp/c2pool-heavy-leg.holder}"
-          WAIT="${HEAVY_LEG_WAIT:-3600}"
+          WAIT="${HEAVY_LEG_WAIT:-5400}"
           TTL="${HEAVY_LEG_TTL:-14400}"
           SWEEP="${HEAVY_LEG_SWEEP:-1}"
+          SLOTS="${HEAVY_LEG_SLOTS:-2}"
           ACQ="$(mktemp -u /tmp/c2pool-heavy-acq.XXXXXX)"
 
-          # --- stale-holder sweep: reap the dead instead of blocking on them ---
+          # Slot files are ${LOCK}.1 .. ${LOCK}.SLOTS; each slot's live holder records a
+          # ${HOLDERFILE}.<slot> marker ("holderpid workerpid"). Both are per-slot so two
+          # concurrent holders never clobber each other's marker.
+
+          # --- stale-holder sweep: reap the dead on each slot instead of blocking ---
           if [ "$SWEEP" = 1 ]; then
-            if [ -f "$HOLDERFILE" ]; then
-              read -r MH MW _ < "$HOLDERFILE" 2>/dev/null || true
-              if [ -n "${MW:-}" ] && [ "${MW:-0}" != 0 ] && ! kill -0 "$MW" 2>/dev/null; then
-                echo "heavy-leg sweep: reaping holder pid ${MH:-?} (worker $MW dead)"
-                [ -n "${MH:-}" ] && kill "$MH" 2>/dev/null || true
-                rm -f "$HOLDERFILE"
-              fi
-            fi
-            # Markerless PPID-1 orphan = a pre-guard `sleep 14400` holder: our live
-            # holders always keep a marker, and a still-waiting new holder has a live
-            # parent (its acquire step), so PPID==1 + no marker is unambiguously dead.
-            if [ ! -f "$HOLDERFILE" ] && command -v fuser >/dev/null 2>&1; then
-              for _q in $(fuser "$LOCK" 2>/dev/null | tr -d ' '); do
-                _qp="$(ps -o ppid= -p "$_q" 2>/dev/null | tr -d ' ')"
-                if [ "${_qp:-0}" = 1 ]; then
-                  echo "heavy-leg sweep: reaping markerless PPID-1 orphan pid $_q"
-                  kill "$_q" 2>/dev/null || true
+            _s=1
+            while [ "$_s" -le "$SLOTS" ]; do
+              _mf="${HOLDERFILE}.${_s}"
+              if [ -f "$_mf" ]; then
+                read -r MH MW _ < "$_mf" 2>/dev/null || true
+                if [ -n "${MW:-}" ] && [ "${MW:-0}" != 0 ] && ! kill -0 "$MW" 2>/dev/null; then
+                  echo "heavy-leg sweep: reaping holder pid ${MH:-?} on slot $_s (worker $MW dead)"
+                  [ -n "${MH:-}" ] && kill "$MH" 2>/dev/null || true
+                  rm -f "$_mf"
                 fi
-              done
-            fi
+              fi
+              # Markerless PPID-1 orphan on this slot = a pre-guard `sleep` holder: our live
+              # holders always keep a marker, and a still-waiting new holder has a live
+              # parent, so PPID==1 + no marker is unambiguously dead.
+              if [ ! -f "$_mf" ] && command -v fuser >/dev/null 2>&1; then
+                for _q in $(fuser "${LOCK}.${_s}" 2>/dev/null | tr -d ' '); do
+                  _qp="$(ps -o ppid= -p "$_q" 2>/dev/null | tr -d ' ' || true)"
+                  if [ "${_qp:-0}" = 1 ]; then
+                    echo "heavy-leg sweep: reaping markerless PPID-1 orphan pid $_q on slot $_s"
+                    kill "$_q" 2>/dev/null || true
+                  fi
+                done
+              fi
+              _s=$((_s+1))
+            done
           fi
 
           # --- find the runner-worker so the holder can die with the job ---
@@ -137,43 +152,73 @@ jobs:
             [ -z "${_p:-}" ] && break
           done
 
-          # --- spawn the holder: holds fd 9 for the job's life ---
-          # Children get fd 9 closed (9>&-) so a kill of this bash frees the lock at
-          # once. It exits when the runner-worker dies, or at TTL, whichever is first;
-          # if the worker could not be found it falls back to a pure TTL ceiling.
-          env LOCK="$LOCK" HOLDERFILE="$HOLDERFILE" ACQ="$ACQ" WAIT="$WAIT" TTL="$TTL" WORKER="$WORKER" \
+          # --- spawn the holder: first-free across SLOTS, holds its fd for the job's life ---
+          # Each slot opens on fd (8+slot); slot 1 -> fd 9 (as before). The held fd is
+          # closed (N>&-) in the sleep child so a kill of this bash frees the slot at once.
+          # The holder exits when the runner-worker dies, or at TTL, whichever is first; if
+          # the worker could not be found it falls back to a pure TTL ceiling.
+          env LOCK="$LOCK" HOLDERFILE="$HOLDERFILE" ACQ="$ACQ" WAIT="$WAIT" TTL="$TTL" SLOTS="$SLOTS" WORKER="$WORKER" \
           bash -c '
-            exec 9>"$LOCK" || exit 1
-            flock -x -w "$WAIT" 9 || exit 1
-            printf "%s %s\n" "$$" "${WORKER:-0}" > "$HOLDERFILE"
-            touch "$ACQ"
+            _s=1
+            while [ "$_s" -le "$SLOTS" ]; do
+              _fd=$((8+_s))
+              eval "exec ${_fd}>\"\${LOCK}.\${_s}\"" || exit 1
+              _s=$((_s+1))
+            done
+            _held_fd=""
+            _deadline=$(( SECONDS + WAIT ))
+            while [ "$SECONDS" -lt "$_deadline" ]; do
+              _s=1
+              while [ "$_s" -le "$SLOTS" ]; do
+                _fd=$((8+_s))
+                if flock -n "$_fd"; then _held_fd="$_fd"; break; fi
+                _s=$((_s+1))
+              done
+              [ -n "$_held_fd" ] && break
+              sleep 3
+            done
+            [ -z "$_held_fd" ] && exit 1
+            _held_slot=$(( _held_fd - 8 ))
+            printf "%s %s\n" "$$" "${WORKER:-0}" > "${HOLDERFILE}.${_held_slot}"
+            echo "$_held_slot" > "$ACQ"
             _end=$(( SECONDS + TTL ))
             while [ "$SECONDS" -lt "$_end" ]; do
               if [ -n "$WORKER" ] && ! kill -0 "$WORKER" 2>/dev/null; then break; fi
-              sleep 15 9>&-
+              eval "sleep 15 ${_held_fd}>&-"
             done
-            rm -f "$HOLDERFILE"
+            rm -f "${HOLDERFILE}.${_held_slot}"
           ' </dev/null >/dev/null 2>&1 &
           HOLDER=$!
           disown "$HOLDER" 2>/dev/null || true
           echo "HEAVY_LEG_LOCK_HOLDER=$HOLDER" >> "${GITHUB_ENV:-/dev/null}"
 
           # --- wait for the acquire handshake ---
-          while kill -0 "$HOLDER" 2>/dev/null && [ ! -e "$ACQ" ]; do
+          while kill -0 "$HOLDER" 2>/dev/null && [ ! -s "$ACQ" ]; do
             sleep 2
           done
-          if [ ! -e "$ACQ" ]; then
-            echo "::error::per-host heavy-leg lock not acquired within $((WAIT/60)) min on ${RUNNER_NAME:-?} -- blocked by a stale holder, not this diff"
-            if command -v fuser >/dev/null 2>&1; then
-              for _q in $(fuser "$LOCK" 2>/dev/null | tr -d ' '); do
-                echo "  current holder: $(ps -o pid=,ppid=,etimes=,comm= -p "$_q" 2>/dev/null | tr -s ' ')"
-              done
-            fi
-            [ -f "$HOLDERFILE" ] && echo "  holder marker: $(cat "$HOLDERFILE" 2>/dev/null)"
+          if [ ! -s "$ACQ" ]; then
+            echo "::error::per-host heavy-leg lock: all $SLOTS slots busy for $((WAIT/60)) min on ${RUNNER_NAME:-?} -- blocked by live long holders, not this diff"
+            _s=1
+            while [ "$_s" -le "$SLOTS" ]; do
+              echo "  slot $_s (${LOCK}.${_s}):"
+              if command -v fuser >/dev/null 2>&1; then
+                for _q in $(fuser "${LOCK}.${_s}" 2>/dev/null | tr -d ' '); do
+                  # pid ppid age(etimes,s) comm -- names the live holder blocking this slot
+                  echo "    holder [pid ppid age_s comm]: $(ps -o pid=,ppid=,etimes=,comm= -p "$_q" 2>/dev/null | tr -s ' ')"
+                done
+              fi
+              if [ -f "${HOLDERFILE}.${_s}" ]; then
+                echo "    marker (holderpid workerpid): $(cat "${HOLDERFILE}.${_s}" 2>/dev/null)"
+              else
+                echo "    marker: (none)"
+              fi
+              _s=$((_s+1))
+            done
             exit 1
           fi
+          _got="$(cat "$ACQ" 2>/dev/null)"
           rm -f "$ACQ"
-          echo "heavy-leg lock acquired on ${RUNNER_NAME:-?} (holder pid $HOLDER, worker ${WORKER:-none})"
+          echo "heavy-leg lock acquired on ${RUNNER_NAME:-?} slot ${_got:-?}/$SLOTS (holder pid $HOLDER, worker ${WORKER:-none})"
       - name: Checkout repository
         uses: actions/checkout@v6
 
@@ -357,9 +402,10 @@ jobs:
           H="${HEAVY_LEG_LOCK_HOLDER:-}"
           if [ -n "$H" ]; then
             kill "$H" 2>/dev/null || true
-            MF=/tmp/c2pool-heavy-leg.holder
-            if [ -f "$MF" ]; then
+            # drop whichever per-slot marker this holder owns
+            for MF in "${HEAVY_LEG_HOLDERFILE:-/tmp/c2pool-heavy-leg.holder}".*; do
+              [ -f "$MF" ] || continue
               read -r _mh _ < "$MF" 2>/dev/null || true
               [ "${_mh:-}" = "$H" ] && rm -f "$MF"
-            fi
+            done
           fi

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -83,28 +83,97 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          LOCK=/tmp/c2pool-heavy-leg.lock
+          # Per-host heavy-leg lock (VM905: 8 runners, 1 heavy slot -> constant
+          # contention). Two defects this guard fixes vs. the old sleep-holder:
+          #  (1) the holder must die WITH the job. The old `exec sleep 14400`
+          #      outlived a reaped/cancelled job and wedged the host for up to the
+          #      TTL while every waiter hard-failed at its own 60 min -w. The holder
+          #      below waits on the runner-worker PID and exits (freeing the lock)
+          #      the instant that worker dies; the TTL is only a ceiling.
+          #  (2) a stale holder from an already-dead job is REAPED at acquire time,
+          #      not blocked on: a recorded holder whose worker is gone, or a
+          #      markerless PPID-1 legacy orphan, is by definition dead.
+          # HEAVY_LEG_* env overrides exist ONLY for the honesty-gate test
+          # (.github/actions/heavy-leg-lock/test.sh); production uses the defaults.
+          LOCK="${HEAVY_LEG_LOCK:-/tmp/c2pool-heavy-leg.lock}"
+          HOLDERFILE="${HEAVY_LEG_HOLDERFILE:-/tmp/c2pool-heavy-leg.holder}"
+          WAIT="${HEAVY_LEG_WAIT:-3600}"
+          TTL="${HEAVY_LEG_TTL:-14400}"
+          SWEEP="${HEAVY_LEG_SWEEP:-1}"
           ACQ="$(mktemp -u /tmp/c2pool-heavy-acq.XXXXXX)"
-          # Holder: waits up to 60 min for the lock, then holds it with a
-          # 4 h TTL (self-expires so a reaped job cannot wedge the host).
-          # fds redirected so the step does not hang on the open pipe;
-          # disowned so it survives this step's shell (NOT setsid: setsid
-          # forks, orphaning $!; and the runner's end-of-job cleanup
-          # SHOULD reap the holder if the release step never runs).
-          bash -c "exec 9>'$LOCK' && flock -x -w 3600 9 && touch '$ACQ' && exec sleep 14400" </dev/null >/dev/null 2>&1 &
+
+          # --- stale-holder sweep: reap the dead instead of blocking on them ---
+          if [ "$SWEEP" = 1 ]; then
+            if [ -f "$HOLDERFILE" ]; then
+              read -r MH MW _ < "$HOLDERFILE" 2>/dev/null || true
+              if [ -n "${MW:-}" ] && [ "${MW:-0}" != 0 ] && ! kill -0 "$MW" 2>/dev/null; then
+                echo "heavy-leg sweep: reaping holder pid ${MH:-?} (worker $MW dead)"
+                [ -n "${MH:-}" ] && kill "$MH" 2>/dev/null || true
+                rm -f "$HOLDERFILE"
+              fi
+            fi
+            # Markerless PPID-1 orphan = a pre-guard `sleep 14400` holder: our live
+            # holders always keep a marker, and a still-waiting new holder has a live
+            # parent (its acquire step), so PPID==1 + no marker is unambiguously dead.
+            if [ ! -f "$HOLDERFILE" ] && command -v fuser >/dev/null 2>&1; then
+              for _q in $(fuser "$LOCK" 2>/dev/null | tr -d ' '); do
+                _qp="$(ps -o ppid= -p "$_q" 2>/dev/null | tr -d ' ')"
+                if [ "${_qp:-0}" = 1 ]; then
+                  echo "heavy-leg sweep: reaping markerless PPID-1 orphan pid $_q"
+                  kill "$_q" 2>/dev/null || true
+                fi
+              done
+            fi
+          fi
+
+          # --- find the runner-worker so the holder can die with the job ---
+          WORKER=""
+          _p=$$
+          while [ "${_p:-1}" -gt 1 ]; do
+            case "$(ps -o comm= -p "$_p" 2>/dev/null || true)" in
+              Runner.Worker*) WORKER="$_p"; break ;;
+            esac
+            _p="$(ps -o ppid= -p "$_p" 2>/dev/null | tr -d ' ')"
+            [ -z "${_p:-}" ] && break
+          done
+
+          # --- spawn the holder: holds fd 9 for the job's life ---
+          # Children get fd 9 closed (9>&-) so a kill of this bash frees the lock at
+          # once. It exits when the runner-worker dies, or at TTL, whichever is first;
+          # if the worker could not be found it falls back to a pure TTL ceiling.
+          env LOCK="$LOCK" HOLDERFILE="$HOLDERFILE" ACQ="$ACQ" WAIT="$WAIT" TTL="$TTL" WORKER="$WORKER" \
+          bash -c '
+            exec 9>"$LOCK" || exit 1
+            flock -x -w "$WAIT" 9 || exit 1
+            printf "%s %s\n" "$$" "${WORKER:-0}" > "$HOLDERFILE"
+            touch "$ACQ"
+            _end=$(( SECONDS + TTL ))
+            while [ "$SECONDS" -lt "$_end" ]; do
+              if [ -n "$WORKER" ] && ! kill -0 "$WORKER" 2>/dev/null; then break; fi
+              sleep 15 9>&-
+            done
+            rm -f "$HOLDERFILE"
+          ' </dev/null >/dev/null 2>&1 &
           HOLDER=$!
-          disown "$HOLDER"
-          echo "HEAVY_LEG_LOCK_HOLDER=$HOLDER" >> "$GITHUB_ENV"
+          disown "$HOLDER" 2>/dev/null || true
+          echo "HEAVY_LEG_LOCK_HOLDER=$HOLDER" >> "${GITHUB_ENV:-/dev/null}"
+
+          # --- wait for the acquire handshake ---
           while kill -0 "$HOLDER" 2>/dev/null && [ ! -e "$ACQ" ]; do
             sleep 2
           done
           if [ ! -e "$ACQ" ]; then
-            echo "::error::per-host heavy-leg lock not acquired within 60 min on $RUNNER_NAME"
+            echo "::error::per-host heavy-leg lock not acquired within $((WAIT/60)) min on ${RUNNER_NAME:-?} -- blocked by a stale holder, not this diff"
+            if command -v fuser >/dev/null 2>&1; then
+              for _q in $(fuser "$LOCK" 2>/dev/null | tr -d ' '); do
+                echo "  current holder: $(ps -o pid=,ppid=,etimes=,comm= -p "$_q" 2>/dev/null | tr -s ' ')"
+              done
+            fi
+            [ -f "$HOLDERFILE" ] && echo "  holder marker: $(cat "$HOLDERFILE" 2>/dev/null)"
             exit 1
           fi
           rm -f "$ACQ"
-          echo "heavy-leg lock acquired on $RUNNER_NAME (holder pid $HOLDER)"
-
+          echo "heavy-leg lock acquired on ${RUNNER_NAME:-?} (holder pid $HOLDER, worker ${WORKER:-none})"
       - name: Checkout repository
         uses: actions/checkout@v6
 
@@ -285,6 +354,12 @@ jobs:
         if: always() && matrix.build-mode == 'manual' && runner.environment != 'github-hosted'
         shell: bash
         run: |
-          if [ -n "${HEAVY_LEG_LOCK_HOLDER:-}" ]; then
-            kill "$HEAVY_LEG_LOCK_HOLDER" 2>/dev/null || true
+          H="${HEAVY_LEG_LOCK_HOLDER:-}"
+          if [ -n "$H" ]; then
+            kill "$H" 2>/dev/null || true
+            MF=/tmp/c2pool-heavy-leg.holder
+            if [ -f "$MF" ]; then
+              read -r _mh _ < "$MF" 2>/dev/null || true
+              [ "${_mh:-}" = "$H" ] && rm -f "$MF"
+            fi
           fi

--- a/.github/workflows/heavy-leg-lock-test.yml
+++ b/.github/workflows/heavy-leg-lock-test.yml
@@ -1,0 +1,35 @@
+# Honesty gate for the per-host heavy-leg reap-guard used by build.yml and
+# codeql-analysis.yml. Runs the ACTUAL acquire script (extracted from build.yml)
+# against a planted orphan and asserts: with the sweep it recovers (green),
+# without the sweep the orphan blocks (red). Pure shell on a gh-hosted runner --
+# no self-hosted host, no build. See .github/actions/heavy-leg-lock/test.sh.
+name: heavy-leg-lock-test
+
+on:
+  push:
+    branches: [master, v37-dev]
+    paths:
+      - .github/workflows/build.yml
+      - .github/workflows/codeql-analysis.yml
+      - .github/workflows/heavy-leg-lock-test.yml
+      - .github/actions/heavy-leg-lock/**
+  pull_request:
+    paths:
+      - .github/workflows/build.yml
+      - .github/workflows/codeql-analysis.yml
+      - .github/workflows/heavy-leg-lock-test.yml
+      - .github/actions/heavy-leg-lock/**
+
+permissions:
+  contents: read
+
+jobs:
+  reap-guard-honesty:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: Ensure fuser (psmisc) for the guard's diagnostics
+        run: command -v fuser >/dev/null || sudo apt-get install -y -q psmisc
+      - name: Run heavy-leg reap-guard honesty gate
+        run: bash .github/actions/heavy-leg-lock/test.sh


### PR DESCRIPTION
## The leak

The per-host heavy-leg lock holder was `exec sleep 14400`. When the owning job is reaped/cancelled, that `sleep` orphans to init (PPID 1) and keeps the **exclusive** lock for up to 4h, while every other heavy leg on the host waits only its 60 min `-w` and then hard-fails. On VM905 (8 runners, **1** heavy-leg slot) contention is constant, so one dead job poisons the host for up to 3 extra hours and turns clean PRs red — integrator observed exactly this on #1110's ASan job (the acquire step ran the full 3600s then failed, all 13 downstream steps skipped).

## The fix (`.github/` only)

1. **Holder dies with the job.** It now discovers the `Runner.Worker` PID up its process tree and exits the instant that worker dies — freeing the lock — instead of a blind 4h `sleep`. TTL is only a ceiling. Children get fd 9 closed (`9>&-`) so a `kill` of the holder releases the lock immediately.
2. **Stale-holder sweep at acquire.** A recorded holder whose worker PID is gone, or a markerless PPID-1 legacy `sleep 14400` orphan, is reaped rather than blocked on. This alone would have prevented today's incident.
3. **Legible failure.** On lock-wait timeout the guard prints the current holder PID/PPID/age + marker, so a red check reads `blocked by a stale holder, not this diff`.
4. **Honesty gate.** `.github/actions/heavy-leg-lock/test.sh` (run by `heavy-leg-lock-test.yml` on gh-hosted, pure shell) extracts the **actual** acquire script from `build.yml` and drives it: leave an orphan → guard reaps it → **green**; restore the leak (`HEAVY_LEG_SWEEP=0`) → same orphan blocks → **red**. Not a copy of the logic — the shipped bytes.

Applied identically to `build.yml` (linux-asan) and `codeql-analysis.yml` — the two heavy legs sharing the lock.

## Mutation evidence (workstation, 4 clean runs)

```
### CASE 1  FIXED (sweep on): orphan must be reaped -> GREEN
heavy-leg sweep: reaping holder pid 3620582 (worker 3620581 dead)
heavy-leg lock acquired on honesty-test (holder pid 3620629, worker none)
-> PASS: guard reaped the stale holder and acquired the lock

### CASE 2  LEAKED (sweep off): same orphan must block -> RED
::error::per-host heavy-leg lock not acquired within 0 min on honesty-test -- blocked by a stale holder, not this diff
  current holder: 3620642 3620575 6 sleep
  holder marker: 3620642 3620641
-> PASS: orphan blocked acquire and it failed red, as it must without the sweep

HONESTY GATE PASSED: perturb -> reaped -> green ; restore leak -> red
```
Ran 4×, deterministic (exit 0 each). CASE 2's `within 0 min` is only because the test drives `HEAVY_LEG_WAIT=5`; production is 3600 → `60 min`.

Held at the push/merge gate for operator approval.
