### PR TITLE
[do-not-merge] dgb: RACE913 — fold notify_local_share chain.contains() under tracker lock

### DIFF
--- a/src/impl/dgb/node.cpp
+++ b/src/impl/dgb/node.cpp
@@ -910,14 +910,19 @@ void NodeImpl::notify_local_share(const uint256& share_hash)
 {
     // p2pool: set_best_share() → think() synchronously on the reactor thread.
     // Use think() for ALL best_share decisions, as p2pool does.
-    if (share_hash.IsNull() || !m_tracker.chain.contains(share_hash))
+    if (share_hash.IsNull())
         return;
 
-    // Try inline verify — if think() holds the mutex, defer to next think() cycle.
-    // The share is already in the chain; think() will verify + score it.
+    // Both the chain.contains() read AND attempt_verify() run UNDER the tracker
+    // lock (BTC origin btc/node.cpp:1054; LTC mirrored f445db8e). A bare
+    // m_tracker.chain.contains() here (the prior code) raced the compute-thread
+    // clean_tracker() exclusive prune freeing chain nodes -> SIGSEGV (kr1z1s
+    // LTC/DGB). try_to_lock keeps the IO thread non-blocking; if think()/clean
+    // holds the lock we skip the inline verify — the share is already in-chain
+    // and run_think() below will score it next cycle.
     {
         std::unique_lock lock(m_tracker_mutex, std::try_to_lock);
-        if (lock.owns_lock())
+        if (lock.owns_lock() && m_tracker.chain.contains(share_hash))
             m_tracker.attempt_verify(share_hash);
     }
 

--- a/src/impl/dgb/test/CMakeLists.txt
+++ b/src/impl/dgb/test/CMakeLists.txt
@@ -7,7 +7,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     # F1 retention + F2/F3 broadcast-gate KATs are actually compiled and run;
     # a fresh target would need a build.yml entry and would otherwise report
     # the silently-passing NOT_BUILT sentinel.
-    add_executable(dgb_share_test share_test.cpp known_txs_retention_test.cpp broadcast_gate_test.cpp)
+    add_executable(dgb_share_test share_test.cpp known_txs_retention_test.cpp broadcast_gate_test.cpp race913_lock_guard_test.cpp)
     target_link_libraries(dgb_share_test PRIVATE
         GTest::gtest_main GTest::gtest
         core dgb
@@ -20,6 +20,10 @@ if (BUILD_TESTING AND GTest_FOUND)
     include(GoogleTest)
     include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
     gtest_add_tests(dgb_share_test "" AUTO)
+
+    # D-DGB.RACE913 lock-scope guard reads the shipped node.cpp source.
+    target_compile_definitions(dgb_share_test PRIVATE
+        DGB_NODE_SRC="${CMAKE_CURRENT_SOURCE_DIR}/../node.cpp")
 
     # --- #905 tx-relay dead-probe regression (port of btc #880) ------------
     # Pins coin/share_tx_relay_refs.hpp: append_share_tx_refs, the SSOT

--- a/src/impl/dgb/test/race913_lock_guard_test.cpp
+++ b/src/impl/dgb/test/race913_lock_guard_test.cpp
@@ -1,0 +1,85 @@
+// D-DGB.RACE913 — source-structural guard pinning notify_local_share`s lock scope.
+//
+// The fix folds the racy chain.contains() read INSIDE the try_to_lock scope so
+// contains + attempt_verify hold one continuous lock, gated on owns_lock() —
+// the BTC reference shape (btc/node.cpp:1054-1058; LTC mirror f445db8e). The
+// prior code read m_tracker.chain.contains() UNLOCKED in the early-return guard,
+// racing clean_tracker()`s exclusive prune -> UAF/SIGSEGV once an M3/#82 caller
+// wires notify_local_share (today zero callers -> latent).
+//
+// A true data-race repro is nondeterministic; this guard is the deterministic
+// red/green the invariant admits: it parses the shipped node.cpp and asserts the
+// contains() read sits under owns_lock(), NOT in the unlocked early-return.
+// Perturb node.cpp back to the unlocked form -> RED; restore -> GREEN.
+#include <gtest/gtest.h>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#ifndef DGB_NODE_SRC
+#error "DGB_NODE_SRC must be defined by CMake to the path of src/impl/dgb/node.cpp"
+#endif
+
+namespace {
+
+// Return the body text of NodeImpl::notify_local_share(...) from node.cpp.
+std::string read_notify_local_share_body()
+{
+    std::ifstream in(DGB_NODE_SRC);
+    EXPECT_TRUE(in.good()) << "cannot open " << DGB_NODE_SRC;
+    std::stringstream ss; ss << in.rdbuf();
+    const std::string src = ss.str();
+
+    const std::string sig = "void NodeImpl::notify_local_share";
+    auto start = src.find(sig);
+    EXPECT_NE(start, std::string::npos) << "notify_local_share not found";
+    // Stop at the next top-level NodeImpl member definition.
+    auto end = src.find("\nvoid NodeImpl::", start + sig.size());
+    if (end == std::string::npos) end = src.size();
+    return src.substr(start, end - start);
+}
+
+std::string line_containing(const std::string& body, const std::string& needle)
+{
+    auto pos = body.find(needle);
+    if (pos == std::string::npos) return "";
+    auto ls = body.rfind(char(10), pos);
+    auto le = body.find(char(10), pos);
+    ls = (ls == std::string::npos) ? 0 : ls + 1;
+    le = (le == std::string::npos) ? body.size() : le;
+    return body.substr(ls, le - ls);
+}
+
+} // namespace
+
+// The chain read must be reachable ONLY through owns_lock() short-circuit.
+TEST(Race913LockGuard, ContainsReadIsGatedOnOwnsLock)
+{
+    const std::string body = read_notify_local_share_body();
+    const std::string owns_line = line_containing(body, "owns_lock()");
+    ASSERT_FALSE(owns_line.empty()) << "owns_lock() guard missing entirely";
+    EXPECT_NE(owns_line.find("chain.contains(share_hash)"), std::string::npos)
+        << "chain.contains(share_hash) must sit on the owns_lock() conditional "
+           "(BTC btc/node.cpp:1054 shape). Line was: " << owns_line;
+}
+
+// The unlocked early-return must NOT touch the tracker chain.
+TEST(Race913LockGuard, EarlyReturnDoesNotReadChain)
+{
+    const std::string body = read_notify_local_share_body();
+    const std::string null_line = line_containing(body, "IsNull()");
+    ASSERT_FALSE(null_line.empty()) << "IsNull() early-return missing";
+    EXPECT_EQ(null_line.find("contains"), std::string::npos)
+        << "early-return reads the chain UNLOCKED (the pre-fix UAF shape). "
+           "Line was: " << null_line;
+}
+
+// Exactly one chain.contains(share_hash) read in the function (no stray copy).
+TEST(Race913LockGuard, SingleGatedContainsRead)
+{
+    const std::string body = read_notify_local_share_body();
+    size_t n = 0, pos = 0;
+    const std::string needle = "chain.contains(share_hash)";
+    while ((pos = body.find(needle, pos)) != std::string::npos) { ++n; pos += needle.size(); }
+    EXPECT_EQ(n, 1u) << "expected exactly one gated chain.contains(share_hash)";
+}


### PR DESCRIPTION
TASK D-DGB.RACE913. Head SHA 8931bbfee.

## What
Move the `chain.contains(share_hash)` read in `src/impl/dgb/node.cpp` `notify_local_share` from the unlocked early-return INTO the `try_to_lock` scope, gated on `owns_lock()`, so contains + `attempt_verify` hold one continuous lock. This is the BTC reference shape (btc/node.cpp:1054-1058; LTC mirror f445db8e) copied verbatim — no third form invented. If the lock is not owned, the inline verify is skipped and run_think() re-scores next cycle (no block, no busy-wait).

## Why now (not M3)
The prior bare read raced the compute-thread `clean_tracker()` exclusive prune freeing chain nodes -> UAF/SIGSEGV. `notify_local_share` has ZERO callers today, so it is latent — but flips to a live crash the instant the M3 mint / #82 broadcaster seam wires a caller. Landing the fix ahead of the caller is strictly cheaper than a SIGSEGV found in a soak.

## Honesty gate — red/green pair (real re-exec)
New `race913_lock_guard_test.cpp` (rides `dgb_share_test`, already in the build.yml --target allowlist — no NOT_BUILT sentinel). Deterministic source-structural guard, since a true UAF race is nondeterministic:
- Fixed source: 3/3 GREEN.
- Perturbed back to the unlocked form: 2/3 RED (ContainsReadIsGatedOnOwnsLock + EarlyReturnDoesNotReadChain).
- Restored: 3/3 GREEN.
- Full `dgb_share_test`: 49/49.

## Isolation
DGB tree only: node.cpp + test/{race913_lock_guard_test.cpp,CMakeLists.txt}. No bitcoin_family, no src/core, no other coin tree.

DO NOT MERGE — integrator cards + merges on operator push approved. No self-merge.