### PR TITLE
dash(replay): W2 multi-peer archival BULK block-fetch lane (--replay-bulk, feature-flagged, OBSERVE-only)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -90,6 +90,7 @@
 #include <impl/dash/coin/mn_seed.hpp>            // E2c: RPC protx-list MN-set seed (parse_protx_list_seed)
 #include <impl/dash/coin/mn_checkpoint.hpp>      // E2d: pinned MN-set checkpoint format + fail-closed parser
 #include <impl/dash/coin/mn_checkpoint_lane.hpp> // E2d: checkpoint -> forward-replay bridge -> leg-4 publish
+#include <impl/dash/coin/replay_bulk_fetch.hpp>  // W2: full-history replay bulk block-fetch lane (--replay-bulk)
 #include <impl/dash/node.hpp>          // dash::Node — sharechain pool-node (NodeBridge<NodeImpl,Legacy,Actual>)
 #include <impl/dash/config.hpp>        // dash::Config (PoolConfig/CoinConfig)
 #include <impl/dash/config_pool.hpp>   // dash::SharechainConfig — P2P_PORT / PREFIX / min-proto SSOT
@@ -222,6 +223,15 @@ const char* const kDashMnCheckpointTestnet =
 uint32_t g_mn_bridge_max_blocks =
     dash::coin::MnCheckpointLane::kDefaultMaxBridgeBlocks;
 
+// ── W2 FULL-HISTORY REPLAY bulk-fetch flags (replay_bulk_fetch.hpp) ─────────
+// Same file-scope posture (and the same rationale) as g_mn_bridge_max_blocks:
+// written once during argument parsing, read once at wiring. All default OFF —
+// absent, no replay object is constructed, no CoinClient filter is registered,
+// and the serve path is byte-identical to the released posture.
+bool        g_replay_bulk = false;            // --replay-bulk: arm the lane
+std::string g_replay_bulk_capture_dir;        // --replay-bulk-capture DIR (implies --replay-bulk)
+uint32_t    g_replay_bulk_start = 0;          // --replay-bulk-start H (0 = network default: mainnet DIP3 1028160)
+
 // Report the requested sharechain peering topology at run-loop bring-up. Honest
 // about the deferred live bind: a won/seen share does NOT yet cross the wire
 // until the sharechain pool-node leaf lands.
@@ -266,6 +276,7 @@ void print_banner(const char* argv0)
         << "           [--bestcl-policy freshness|consensus-exact]\n"
         << "           [--embedded-oracle-shadow]\n"
         << "           [--embedded-shadow-compare]\n"
+        << "           [--replay-bulk] [--replay-bulk-capture DIR] [--replay-bulk-start H]\n"
         << "           [--oracle-graduation-blocks N] [--oracle-class-coverage K]\n"
         << "           [--give-author PCT] [-f|--fee PCT] [--node-owner-address ADDR]\n"
         << "           [--redistribute pplns|fee|boost|donate]\n"
@@ -357,6 +368,18 @@ void print_banner(const char* argv0)
         << "        are bound to the REAL DASH tracker; local hashrate comes from the\n"
         << "        DASH stratum acceptor. If stratum and web ports collide the web\n"
         << "        port moves to stratum+1.\n"
+        << "        --replay-bulk (needs --coin-p2p-connect/--coin-p2p-discover) arms\n"
+        << "        the FULL-HISTORY REPLAY bulk block-fetch lane (W2): full-genesis\n"
+        << "        header backfill join-checked against the fast-start anchor, then\n"
+        << "        pipelined multi-peer body fetch from DIP3 (h=1028160) forward,\n"
+        << "        merkle-verified, handed IN ORDER to the replay consumer and\n"
+        << "        PRUNED (bodies never persisted). Strictly lower priority than\n"
+        << "        the tip lane; resumable (high-water cursor); [BULK] telemetry.\n"
+        << "        OBSERVE-only in W2 (counting consumer stands in for the W1 fold);\n"
+        << "        NEVER changes serving. --replay-bulk-capture DIR additionally\n"
+        << "        caches raw bodies into append-only segment files (fleet re-fold\n"
+        << "        cache; implies --replay-bulk). --replay-bulk-start H overrides\n"
+        << "        the first fetched height (default: mainnet DIP3 1028160).\n"
         << "        --external-ip ADDR (alias --stratum-advertise / --public-host)\n"
         << "        overrides the miner-facing host shown in the dashboard Stratum\n"
         << "        URL -- for NAT / port-mapped nodes whose outbound IP is not the\n"
@@ -2609,6 +2632,16 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // subscriptions -> lane -> maintainer -> header_chain.
     std::unique_ptr<dash::coin::MnCheckpointLane> mn_ckpt_lane;
     std::vector<std::shared_ptr<EventDisposable>> coin_feed_subs;
+    // ── W2 replay bulk-fetch locals (--replay-bulk; replay_bulk_fetch.hpp) ──
+    // Declared AFTER header_chain (they read it) so they unwind FIRST at
+    // return; the timer is last so its callbacks stop before the lane dies.
+    // All null unless the flag armed them — zero construction otherwise.
+    std::unique_ptr<dash::coin::replay::HeaderBackfill>        replay_backfill;
+    std::unique_ptr<dash::coin::replay::CountingReplayConsumer> replay_counter;
+    std::unique_ptr<dash::coin::replay::CaptureReplayConsumer> replay_capture;
+    std::unique_ptr<dash::coin::replay::ReplayCursorStore>     replay_cursor;
+    std::unique_ptr<dash::coin::replay::BulkFetchLane>         replay_lane;
+    std::unique_ptr<core::Timer>                               replay_timer;
     if (coin_p2p) {
         const auto dash_params = testnet
             ? dash::coin::make_dash_chain_params_testnet()
@@ -4602,6 +4635,131 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             // the anchor from a previous run's persisted header DB.
             mn_ckpt_lane->pump();
         }
+
+        // ── W2: FULL-HISTORY REPLAY bulk block-fetch lane (--replay-bulk) ──
+        // OBSERVE-only transport slice: fetches DIP3→tip bodies across the
+        // peer pool, verifies, hands them IN ORDER to the (W2 counting stub)
+        // consumer and PRUNES them. Registers the two CoinClient demux
+        // filters + the notfound seam; nothing here touches serving, gating
+        // or the tip lane's request paths (priority invariants are in
+        // replay_bulk_fetch.hpp's header comment).
+        if (g_replay_bulk) {
+            namespace rp = dash::coin::replay;
+            const auto& rparams = header_chain->params();
+            if (rparams.fast_start_checkpoint.has_value()) {
+                // Extend the fast-start anchor to GENESIS: the backfill walks
+                // genesis→anchor and must JOIN the anchor hash exactly
+                // (fail-closed otherwise). Without a fast-start (testnet) the
+                // main header chain already syncs from genesis — no backfill.
+                const auto& cpk = rparams.fast_start_checkpoint.value();
+                replay_backfill = std::make_unique<rp::HeaderBackfill>(
+                    rparams.genesis_hash, cpk.height, cpk.hash,
+                    rparams.pow_limit,
+                    (core::filesystem::config_path() / net_subdir
+                        / "dash_replay_headers").string());
+            }
+            replay_counter = std::make_unique<rp::CountingReplayConsumer>();
+            rp::IReplayBlockConsumer* replay_consumer = replay_counter.get();
+            if (!g_replay_bulk_capture_dir.empty()) {
+                replay_capture = std::make_unique<rp::CaptureReplayConsumer>(
+                    g_replay_bulk_capture_dir, replay_counter.get());
+                replay_consumer = replay_capture.get();
+            }
+            replay_cursor = std::make_unique<rp::ReplayCursorStore>(
+                (core::filesystem::config_path() / net_subdir
+                    / "dash_replay_cursor").string());
+
+            rp::BulkFetchLane::Seams seams;
+            // Height→hash: pre-anchor from the (join-checked) backfill,
+            // anchor→tip from the main header chain.
+            seams.hash_at = [bf = replay_backfill.get(),
+                             hc = header_chain.get()]
+                (uint32_t h) -> std::optional<uint256> {
+                if (bf) { auto x = bf->hash_at(h); if (x) return x; }
+                auto e = hc->get_header_by_height(h);
+                if (!e) return std::nullopt;
+                return e->hash;
+            };
+            seams.chain_height = [hc = header_chain.get()] {
+                return hc->height();
+            };
+            // Priority invariant 1: the PRIMARY carries every stateful
+            // request/response leg — bulk loads it only when it is the sole
+            // handshaked peer.
+            seams.eligible_peers = [cp = coin_p2p.get()] {
+                auto keys = cp->handshaked_peer_keys();
+                const auto prim = cp->primary_peer_key();
+                if (keys.size() > 1 && !prim.empty())
+                    keys.erase(std::remove(keys.begin(), keys.end(), prim),
+                               keys.end());
+                return keys;
+            };
+            seams.send_getdata = [cp = coin_p2p.get()](
+                const std::string& peer, const std::vector<uint256>& hashes) {
+                cp->request_blocks_from(peer, hashes);
+            };
+            seams.send_getheaders = [cp = coin_p2p.get()](
+                const std::string& peer, const uint256& locator_hash,
+                const uint256& stop) {
+                cp->send_getheaders_to(peer, 70230, {locator_hash}, stop);
+            };
+            // Priority invariant 2: no new bulk getdata while a tracked tip
+            // body is outstanding.
+            seams.tip_busy = [cp = coin_p2p.get()] {
+                return cp->pending_body_count() > 0;
+            };
+
+            rp::BulkFetchLane::Config rcfg;
+            rcfg.start_height = g_replay_bulk_start != 0
+                ? g_replay_bulk_start
+                : (testnet ? 1 : rp::MAINNET_DIP3_HEIGHT);
+            replay_lane = std::make_unique<rp::BulkFetchLane>(
+                std::move(seams), rcfg, replay_backfill.get(),
+                replay_consumer, replay_cursor.get());
+
+            coin_p2p->set_headers_filter(
+                [ln = replay_lane.get()](const std::string& key,
+                                         const std::vector<dash::coin::BlockType>& b) {
+                    return ln->on_headers(key, b);
+                });
+            coin_p2p->set_block_body_filter(
+                [ln = replay_lane.get()](const uint256& h,
+                                         const dash::coin::BlockType& blk) {
+                    return ln->on_block_body(h, blk);
+                });
+            coin_p2p->set_on_block_notfound(
+                [ln = replay_lane.get()](const uint256& h) {
+                    ln->on_notfound(h);
+                });
+
+            replay_timer = std::make_unique<core::Timer>(&ioc, /*repeat=*/true);
+            replay_timer->start(1, [ln = replay_lane.get()] {
+                ln->tick(std::chrono::duration_cast<std::chrono::seconds>(
+                    std::chrono::steady_clock::now().time_since_epoch())
+                        .count());
+            });
+
+            std::cout << "[run] W2 REPLAY BULK lane ARMED: start_h="
+                      << rcfg.start_height
+                      << (replay_backfill
+                              ? " backfill=genesis->"
+                                + std::to_string(replay_backfill->anchor_height())
+                                + (replay_backfill->complete() ? " (joined)" : "")
+                              : " backfill=none")
+                      << (g_replay_bulk_capture_dir.empty()
+                              ? ""
+                              : " capture=" + g_replay_bulk_capture_dir)
+                      << " consumer=" << (g_replay_bulk_capture_dir.empty()
+                                              ? "counting-stub(W1 seam)"
+                                              : "capture+counting-stub")
+                      << " (OBSERVE-only; tip lane strictly prioritized)\n";
+        }
+    }
+    if (g_replay_bulk && !coin_p2p) {
+        // Name the unmet dependency instead of silently not arming.
+        std::cout << "[run] --replay-bulk given but no coin-P2P client "
+                     "(needs --coin-p2p-connect/--coin-p2p-discover) — "
+                     "replay bulk lane NOT armed\n";
     }
 
     // ── Fallback-arm event-driven tip refresh ────────────────────────────
@@ -5052,6 +5210,13 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         }
     }
 
+    // W2 replay lane: force-persist the delivered high-water cursor so a
+    // clean shutdown resumes exactly where it stopped (a crash costs at most
+    // cursor_persist_every blocks of re-fetch). Timer callbacks no longer
+    // fire — ioc.run() has returned.
+    if (replay_timer) replay_timer->stop();
+    if (replay_lane) replay_lane->flush();
+
     // Save stats on shutdown (main_ltc.cpp:7457 parity): flush the final
     // stat_log so the last window survives the restart. mi still valid here —
     // run() has returned but web_server/mining-interface teardown is below.
@@ -5394,6 +5559,16 @@ int main(int argc, char** argv)
             embedded_oracle_shadow = true;
         else if (std::strcmp(argv[i], "--embedded-shadow-compare") == 0)
             embedded_shadow_compare = true;
+        // W2 full-history replay bulk-fetch lane (replay_bulk_fetch.hpp).
+        else if (std::strcmp(argv[i], "--replay-bulk") == 0)
+            g_replay_bulk = true;
+        else if (std::strcmp(argv[i], "--replay-bulk-capture") == 0 && i + 1 < argc) {
+            g_replay_bulk_capture_dir = argv[++i];
+            g_replay_bulk = true;   // capture is a decoration of the lane
+        }
+        else if (std::strcmp(argv[i], "--replay-bulk-start") == 0 && i + 1 < argc)
+            g_replay_bulk_start = static_cast<uint32_t>(
+                std::strtoul(argv[++i], nullptr, 10));
         else if (std::strcmp(argv[i], "--oracle-graduation-blocks") == 0 && i + 1 < argc)
             oracle_grad_blocks = std::strtoull(argv[++i], nullptr, 10);
         else if (std::strcmp(argv[i], "--oracle-class-coverage") == 0 && i + 1 < argc)

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -732,6 +732,33 @@ private:
     using QrInfoConsumer = std::function<void(const vendor::CQuorumRotationInfo&)>;
     std::vector<QrInfoConsumer> m_qrinfo_consumers;
 
+    // ── W2 replay bulk-fetch demux seams (replay_bulk_fetch.hpp) ─────────
+    // Registered ONLY under --replay-bulk; unset (the default and every
+    // released posture) both are null and the handlers below behave
+    // byte-identically to before.
+    //
+    //   * headers filter: a `headers` batch CLAIMED by the genesis→anchor
+    //     backfill walker is consumed BEFORE the new_headers event — the main
+    //     HeaderChain must never see pre-anchor batches (they orphan-reject
+    //     and pollute the CP2 accepted==0 diagnostic), and the tip lane's
+    //     header ingest must never be re-pointed at 2012-era headers.
+    //   * block-body filter: a body the bulk scheduler has in flight is
+    //     consumed BEFORE the full_block event — bulk bodies must never
+    //     enter the live ingest legs (whose deferral buffers assume tip-rate
+    //     traffic), and tip bodies must never be swallowed by the bulk lane
+    //     (the filter only claims hashes it requested itself).
+    //   * block notfound callback: lets the bulk lane requeue an archival
+    //     gap on a different peer instead of waiting out its timeout.
+    using HeadersFilter =
+        std::function<bool(const std::string& peer_key,
+                           const std::vector<BlockType>&)>;
+    HeadersFilter m_headers_filter;
+    using BlockBodyFilter =
+        std::function<bool(const uint256&, const BlockType&)>;
+    BlockBodyFilter m_block_body_filter;
+    using BlockNotFoundCallback = std::function<void(const uint256&)>;
+    BlockNotFoundCallback m_on_block_notfound;
+
     // Commands already reported as dropped-unhandled, so the WARNING fires
     // once per distinct command instead of once per message. See handle().
     std::set<std::string> m_unhandled_seen;
@@ -1089,6 +1116,67 @@ public:
         m_qrinfo_consumers.push_back(std::move(c));
     }
     size_t qrinfo_consumer_count() const { return m_qrinfo_consumers.size(); }
+    // ── W2 replay bulk-fetch seams (see the member-block rationale) ──────
+    /// Register the backfill headers demux (single slot: exactly one bulk
+    /// lane exists per client; --replay-bulk wiring only).
+    void set_headers_filter(HeadersFilter f) { m_headers_filter = std::move(f); }
+    /// Register the bulk block-body demux (single slot, same rationale).
+    void set_block_body_filter(BlockBodyFilter f) { m_block_body_filter = std::move(f); }
+    /// Fired for every notfound(block) inv AFTER the reply matchers complete
+    /// (tip-lane semantics unchanged); the bulk lane requeues off this.
+    void set_on_block_notfound(BlockNotFoundCallback cb) { m_on_block_notfound = std::move(cb); }
+
+    /// Handshaked peer keys, pool order — the bulk scheduler's peer universe.
+    std::vector<std::string> handshaked_peer_keys() const
+    {
+        std::vector<std::string> out;
+        out.reserve(m_pool.size());
+        for (const auto& p : m_pool)
+            if (p->handshake.complete()) out.push_back(p->key);
+        return out;
+    }
+    /// The PRIMARY's key ("" when none) — the peer the bulk lane must NOT
+    /// load while any other handshaked peer exists (it carries every
+    /// request/response leg).
+    std::string primary_peer_key() const
+    {
+        return m_primary ? m_primary->key : std::string{};
+    }
+
+    /// getheaders to a NAMED peer (bulk header backfill: the walker rotates
+    /// its own peer cursor and must not disturb the primary-bound tip legs).
+    /// Returns false when the peer is unknown/not handshaked.
+    bool send_getheaders_to(const std::string& peer_key, uint32_t version,
+                            const std::vector<uint256>& locator,
+                            const uint256& stop)
+    {
+        PeerSession* p = find_peer(peer_key);
+        if (!p || !p->handshake.complete()) return false;
+        auto msg = message_getheaders::make_raw(version, locator, stop);
+        p->write(msg);
+        return true;
+    }
+
+    /// One getdata(MSG_BLOCK…) carrying `hashes` to a NAMED peer — the bulk
+    /// lane's pipelined batch pull. UNTRACKED by the tip-body watchdog by
+    /// design: bulk volume would defeat PENDING_BODY_CAP, and the bulk
+    /// scheduler owns its own timeout/re-request loop. Returns false when
+    /// the peer is unknown/not handshaked (the scheduler's service() pass
+    /// then requeues the batch off the live-peer set).
+    bool request_blocks_from(const std::string& peer_key,
+                             const std::vector<uint256>& hashes)
+    {
+        if (hashes.empty()) return true;
+        PeerSession* p = find_peer(peer_key);
+        if (!p || !p->handshake.complete()) return false;
+        std::vector<inventory_type> invs;
+        invs.reserve(hashes.size());
+        for (const auto& h : hashes)
+            invs.emplace_back(inventory_type::block, h);
+        auto msg = message_getdata::make_raw(invs);
+        p->write(msg);
+        return true;
+    }
     /// Fired on socket connect (before handshake) with the peer endpoint — the
     /// DashCoinPeerManager scores the connect + tracks anchors off this.
     void set_on_peer_connected(PeerLifecycleCallback cb) { m_on_peer_connected = std::move(cb); }
@@ -2118,6 +2206,21 @@ private:
         for (auto it = m_pending_bodies.begin();
              it != m_pending_bodies.end(); ++it)
             if (it->hash == blockhash) { m_pending_bodies.erase(it); break; }
+        // W2 bulk demux: a body the replay bulk lane has in flight is consumed
+        // HERE (verified + folded + pruned by the lane) and never fires
+        // full_block — the live ingest legs are tip-rate consumers and must
+        // not see 1.49M historical bodies. The filter claims ONLY hashes the
+        // bulk scheduler itself requested, so a tip body can never be
+        // swallowed. DEBUG, not INFO: bulk arrival rate would flood the
+        // journal (the [BULK] telemetry line is the throughput surface).
+        if (m_block_body_filter && m_block_body_filter(blockhash, msg->m_block))
+        {
+            LOG_DEBUG_COIND << "[" << m_chain_label << "] bulk body from "
+                            << p->key << ": "
+                            << blockhash.GetHex().substr(0, 16)
+                            << "... (consumed by replay bulk lane)";
+            return;
+        }
         LOG_INFO << "[" << m_chain_label << "] block received from " << p->key
                  << ": " << blockhash.GetHex().substr(0, 16) << "...";
         m_coin->full_block.happened(msg->m_block);
@@ -2138,6 +2241,19 @@ private:
         // the tip authority driving the embedded template's next-work/MTP.
         PeerSession* p = m_active;
         if (!p) return;
+        // W2 bulk demux: a batch extending the genesis→anchor backfill walk
+        // is consumed here — the main HeaderChain fast-starts at the anchor
+        // and would orphan-reject every pre-anchor header (CP2 accepted==0
+        // noise), and the tip-lane matchers below have nothing waiting on
+        // 2012-era headers. Unclaimed batches (the tip sync) fall through
+        // unchanged.
+        if (m_headers_filter && m_headers_filter(p->key, msg->m_headers))
+        {
+            LOG_DEBUG_COIND << "[" << m_chain_label << "] headers batch ("
+                            << msg->m_headers.size()
+                            << ") consumed by replay backfill";
+            return;
+        }
         std::vector<BlockHeaderType> vheaders;
         for (auto& block : msg->m_headers)
         {
@@ -2368,6 +2484,10 @@ private:
                 // cancel this peer's still-pending request.
                 try { p->conn->get_block(inv.m_hash, BlockType{}); } catch (...) {}
                 try { p->conn->get_header(inv.m_hash, BlockHeaderType{}); } catch (...) {}
+                // W2 bulk lane: an archival gap answered notfound is requeued
+                // on a DIFFERENT peer immediately instead of waiting out the
+                // scheduler timeout. No-op unless --replay-bulk registered it.
+                if (m_on_block_notfound) m_on_block_notfound(inv.m_hash);
             }
         }
     }

--- a/src/impl/dash/coin/replay_bulk_fetch.hpp
+++ b/src/impl/dash/coin/replay_bulk_fetch.hpp
@@ -1,0 +1,1293 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// DASH FULL-HISTORY REPLAY — W2: the multi-peer archival BULK block-fetch lane.
+//
+// Design source: docs/DASH_FULL_HISTORY_REPLAY_MODE.md (frstrtr/the), §4.1/§4.3
+// and WP table §6 (W2). This work package supplies the TRANSPORT for the replay
+// fold (W1): it walks the header chain back to GENESIS (extending the existing
+// 2400000 fast-start anchor), then getdata's full block bodies in large
+// pipelined batches ACROSS the coin-P2P peer pool, verifies each body against
+// its PoW header, hands it to the fold consumer strictly in height order, and
+// PRUNES it — bodies are never persisted (fetch → fold → prune; ~30-40 GB
+// total stream, bounded work-ahead buffer, nothing retained).
+//
+// ── What lives here (all io-thread confined, KAT-able pieces pure) ─────────
+//
+//   * HeaderBackfill    — genesis→anchor header walker. The main HeaderChain
+//     fast-starts at 2400000 (header_chain.hpp:92) and its height index only
+//     covers anchor→tip; replay needs per-height hashes from genesis. The
+//     backfill walks FORWARD from the known genesis hash, X11-PoW-checking and
+//     prev-linking every header, and MUST terminate by producing exactly the
+//     fast-start anchor hash at the anchor height (the JOIN CHECK). Because
+//     every header commits its predecessor, a matching anchor hash pins the
+//     entire pre-anchor segment byte-for-byte down to genesis — the same
+//     induction the spec's §4.2 layer-2 argument rides. Join mismatch is
+//     fail-closed and LOUD: it means a hostile peer or a wrong chain, and the
+//     lane refuses to fetch a single body off an unpinned index.
+//
+//   * BulkBlockScheduler — pure request planner. Range-partitions the wanted
+//     height span into contiguous per-peer batches, caps in-flight requests
+//     per peer, re-requests on timeout / notfound / peer loss (rotating away
+//     from the peer that failed), and tallies per-peer throughput for the
+//     [BULK] telemetry line. No sockets, no clocks of its own — every decision
+//     is a function of (now, peers, cursor) so the KATs drive it directly.
+//
+//   * BulkFetchLane      — the driver glue. Owns the work-ahead body buffer,
+//     the in-order delivery loop into IReplayBlockConsumer, the resumable
+//     high-water cursor (ReplayCursorStore), the optional capture writer, and
+//     the telemetry. Wired to the CoinClient via narrow seams (function
+//     injections + the headers/body demux filters) so it can be stood up in a
+//     test with no network at all.
+//
+//   * IReplayBlockConsumer — the W1 fold seam. W2 ships the interface plus a
+//     counting stub (CountingReplayConsumer) and the capture consumer; the W1
+//     fold engine implements the same interface and simply replaces the stub.
+//
+//   * BulkCaptureWriter / --replay-bulk-capture — OPTIONAL side utility: cache
+//     the raw bodies into append-only segment files on a fleet host so test
+//     re-folds do not re-pull 30-40 GB from the network. Capture is a
+//     CONSUMER decoration, never a requirement — the production flow stays
+//     fetch → fold → prune.
+//
+// ── PRIORITY INVARIANT: bulk NEVER starves the tip lane ────────────────────
+//
+// The tip lane (new-block inv → getheaders + tracked body pull, p2p_client.hpp
+// BODY_REREQUEST_*) is the money path; bulk is strictly lower priority:
+//
+//   1. bulk bodies are never requested from the PRIMARY peer while any other
+//      handshaked peer exists (the primary carries every request/response leg
+//      — mnlistdiff/qrinfo/govsync — and the tip-follow getheaders default);
+//   2. NO new bulk getdata is issued while a tracked tip body is outstanding
+//      (tip_busy seam = pending_body_count() > 0) — in-flight bulk requests
+//      complete, fresh ones wait;
+//   3. bulk never requests within TIP_EXCLUSION blocks of the header tip: the
+//      live edge belongs to the tip lane, and a bulk-consumed body demuxed
+//      away from the full_block event must never be one the live ingest legs
+//      were waiting for;
+//   4. per-peer in-flight caps keep every socket's reply queue short, so a
+//      tip-lane request issued to a bulk-serving peer is answered within a
+//      bounded backlog (~cap × avg body size), not behind a megabatch.
+//
+// ── Verification per body (spec §4.1: "nothing else in the body is read") ──
+//
+// A body is accepted only if (a) X11(its 80-byte header) equals the hash the
+// scheduler requested — which the backfill/header-chain index pinned under
+// PoW + the anchor join — and (b) the tx set folds to the header's committed
+// hashMerkleRoot via the CVE-2012-2459-guarded fold the serve path already
+// uses (block_producer.hpp block_body_binds_to_header). A body failing (b) is
+// counted corrupt and re-requested from a different peer. No script
+// execution, no UTXO reads — acceptance-predicate skipping per spec §4.2.
+//
+// Feature-flagged (--replay-bulk / --replay-bulk-capture): absent, nothing
+// here is constructed and no CoinClient filter is registered — the serve path
+// is byte-identical. DASH-lane only; header-only to match the sibling leaves.
+
+#include "block.hpp"
+#include "block_producer.hpp"   // block_body_binds_to_header (body↔header bind)
+#include "header_chain.hpp"     // check_pow / x11_hash / DashChainParams
+
+#include <core/leveldb_store.hpp>
+#include <core/log.hpp>
+#include <core/pack.hpp>
+#include <core/uint256.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <deque>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <map>
+#include <memory>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace dash {
+namespace coin {
+namespace replay {
+
+// DIP0003 activation on mainnet — the first height whose body the fold
+// consumes (spec §4.1: "Replay from DIP3 activation (h=1028160) forward").
+static constexpr uint32_t MAINNET_DIP3_HEIGHT = 1028160;
+
+// ── W1 fold seam ───────────────────────────────────────────────────────────
+//
+// The bulk lane hands every verified body to exactly ONE consumer, strictly
+// in ascending height order with no gaps (the fold is a strict left fold over
+// the chain). Returning false REFUSES the block: the lane fails closed with a
+// named cause and stops fetching — a fold that cannot proceed must never be
+// silently skipped past (a gap would desync every subsequent root check).
+class IReplayBlockConsumer
+{
+public:
+    virtual ~IReplayBlockConsumer() = default;
+    /// `height`/`hash` are pinned by the PoW header index; `block` has passed
+    /// the merkle body↔header bind. The reference is only valid for the call —
+    /// the lane PRUNES the body immediately after (consumers must copy what
+    /// they keep, which for the W1 fold is derived state, never the body).
+    virtual bool on_replay_block(uint32_t height, const uint256& hash,
+                                 const BlockType& block) = 0;
+};
+
+// Counting stub consumer: the W2 stand-in for the W1 fold. Counts blocks and
+// bytes, asserts the in-order/no-gap contract, and can be armed to refuse at
+// a given height (fail-closed KAT). Also the production default under
+// --replay-bulk until W1 lands — throughput soaks measure the transport with
+// exactly this consumer.
+class CountingReplayConsumer : public IReplayBlockConsumer
+{
+    uint64_t m_blocks{0};
+    uint64_t m_bytes{0};
+    uint64_t m_txs{0};
+    uint32_t m_last_height{0};
+    bool     m_have_last{false};
+    bool     m_order_violated{false};
+    uint32_t m_refuse_at{0};        // 0 = never refuse
+
+public:
+    void set_refuse_at(uint32_t h) { m_refuse_at = h; }
+
+    bool on_replay_block(uint32_t height, const uint256& /*hash*/,
+                         const BlockType& block) override
+    {
+        if (m_refuse_at != 0 && height >= m_refuse_at)
+            return false;
+        if (m_have_last && height != m_last_height + 1)
+            m_order_violated = true;
+        m_last_height = height;
+        m_have_last = true;
+        ++m_blocks;
+        m_txs += block.m_txs.size();
+        auto packed = ::pack(block);
+        m_bytes += packed.size();
+        return true;
+    }
+
+    uint64_t blocks() const { return m_blocks; }
+    uint64_t bytes() const { return m_bytes; }
+    uint64_t txs() const { return m_txs; }
+    uint32_t last_height() const { return m_last_height; }
+    bool order_violated() const { return m_order_violated; }
+};
+
+// ── Resumable high-water cursor ────────────────────────────────────────────
+//
+// One tiny versioned file: the highest height DELIVERED to the consumer plus
+// its hash. Written atomically (tmp + rename) so a crash can never leave a
+// torn cursor; a stale-but-consistent cursor only costs re-fetching the tail
+// since the last write. The HASH is stored alongside the height so a resumed
+// lane can prove it is still on the same chain before trusting the cursor
+// (mismatch ⇒ refuse with a named cause, never silently re-fold a different
+// branch — the standing "version it so an old binary fails loud" trap).
+class ReplayCursorStore
+{
+public:
+    struct Cursor
+    {
+        uint32_t height{0};
+        uint256  hash;
+    };
+
+private:
+    std::string m_path;
+
+public:
+    explicit ReplayCursorStore(std::string path) : m_path(std::move(path)) {}
+
+    const std::string& path() const { return m_path; }
+
+    std::optional<Cursor> load() const
+    {
+        std::ifstream in(m_path);
+        if (!in) return std::nullopt;
+        std::string magic, version, hash_hex;
+        uint32_t height = 0;
+        in >> magic >> version >> height >> hash_hex;
+        if (!in || magic != "c2pool-replay-cursor" || version != "v1" ||
+            hash_hex.size() != 64)
+        {
+            LOG_WARNING << "[BULK] cursor file " << m_path
+                        << " unreadable or wrong version — ignoring (restart "
+                           "from configured start height)";
+            return std::nullopt;
+        }
+        Cursor c;
+        c.height = height;
+        c.hash.SetHex(hash_hex);
+        return c;
+    }
+
+    bool store(const Cursor& c) const
+    {
+        const std::string tmp = m_path + ".tmp";
+        {
+            std::ofstream out(tmp, std::ios::trunc);
+            if (!out) return false;
+            out << "c2pool-replay-cursor v1 " << c.height << " "
+                << c.hash.GetHex() << "\n";
+            if (!out) return false;
+        }
+        std::error_code ec;
+        std::filesystem::rename(tmp, m_path, ec);
+        return !ec;
+    }
+};
+
+// ── Capture side-channel (--replay-bulk-capture DIR) ───────────────────────
+//
+// Append-only segment files, SEGMENT_SPAN blocks each, one length-prefixed
+// record per block: [u32 magic][u32 height][32B hash][u32 size][size bytes].
+// One file per 10k blocks keeps the fleet cache to ~150 files/1.49M blocks
+// instead of 1.49M inodes, and a torn tail record (crash mid-append) is
+// detected by the magic/size framing on read and simply truncates that
+// segment's usable prefix. This is a TEST-REFOLD cache, not consensus state.
+class BulkCaptureWriter
+{
+public:
+    static constexpr uint32_t RECORD_MAGIC = 0x43325242;   // "C2RB"
+    static constexpr uint32_t SEGMENT_SPAN = 10000;
+
+    struct Record
+    {
+        uint32_t height{0};
+        uint256  hash;
+        std::vector<uint8_t> bytes;
+    };
+
+private:
+    std::string m_dir;
+    std::ofstream m_out;
+    uint32_t m_open_segment{UINT32_MAX};
+    uint64_t m_records{0};
+    uint64_t m_bytes{0};
+    bool     m_failed{false};
+
+    static void put_u32(std::ofstream& out, uint32_t v)
+    {
+        unsigned char b[4] = {
+            static_cast<unsigned char>(v & 0xFF),
+            static_cast<unsigned char>((v >> 8) & 0xFF),
+            static_cast<unsigned char>((v >> 16) & 0xFF),
+            static_cast<unsigned char>((v >> 24) & 0xFF)};
+        out.write(reinterpret_cast<const char*>(b), 4);
+    }
+
+    static bool get_u32(std::ifstream& in, uint32_t& v)
+    {
+        unsigned char b[4];
+        if (!in.read(reinterpret_cast<char*>(b), 4)) return false;
+        v = static_cast<uint32_t>(b[0]) | (static_cast<uint32_t>(b[1]) << 8) |
+            (static_cast<uint32_t>(b[2]) << 16) |
+            (static_cast<uint32_t>(b[3]) << 24);
+        return true;
+    }
+
+public:
+    explicit BulkCaptureWriter(std::string dir) : m_dir(std::move(dir))
+    {
+        std::error_code ec;
+        std::filesystem::create_directories(m_dir, ec);
+        if (ec)
+        {
+            LOG_ERROR << "[BULK] capture dir " << m_dir
+                      << " cannot be created: " << ec.message()
+                      << " — capture DISABLED (fetch/fold unaffected)";
+            m_failed = true;
+        }
+    }
+
+    static std::string segment_name(uint32_t segment_base)
+    {
+        char buf[32];
+        std::snprintf(buf, sizeof(buf), "blocks_%09u.seg", segment_base);
+        return buf;
+    }
+
+    bool failed() const { return m_failed; }
+    uint64_t records() const { return m_records; }
+    uint64_t bytes_written() const { return m_bytes; }
+    const std::string& dir() const { return m_dir; }
+
+    bool append(uint32_t height, const uint256& hash,
+                const std::vector<uint8_t>& raw)
+    {
+        if (m_failed) return false;
+        const uint32_t segment = (height / SEGMENT_SPAN) * SEGMENT_SPAN;
+        if (segment != m_open_segment || !m_out.is_open())
+        {
+            if (m_out.is_open()) m_out.close();
+            const std::string path =
+                (std::filesystem::path(m_dir) / segment_name(segment)).string();
+            m_out.open(path, std::ios::binary | std::ios::app);
+            if (!m_out)
+            {
+                LOG_ERROR << "[BULK] capture segment " << path
+                          << " cannot be opened — capture DISABLED";
+                m_failed = true;
+                return false;
+            }
+            m_open_segment = segment;
+        }
+        put_u32(m_out, RECORD_MAGIC);
+        put_u32(m_out, height);
+        m_out.write(reinterpret_cast<const char*>(hash.data()), 32);
+        put_u32(m_out, static_cast<uint32_t>(raw.size()));
+        m_out.write(reinterpret_cast<const char*>(raw.data()),
+                    static_cast<std::streamsize>(raw.size()));
+        if (!m_out)
+        {
+            LOG_ERROR << "[BULK] capture write failed (disk full?) — "
+                         "capture DISABLED (fetch/fold unaffected)";
+            m_failed = true;
+            return false;
+        }
+        m_out.flush();
+        ++m_records;
+        m_bytes += 44 + raw.size();
+        return true;
+    }
+
+    /// Read every intact record of one segment file. A torn tail (magic or
+    /// framing mismatch) ends the read at the last intact record — the
+    /// re-fold utility then re-fetches from there.
+    static std::vector<Record> read_segment(const std::string& path)
+    {
+        std::vector<Record> out;
+        std::ifstream in(path, std::ios::binary);
+        if (!in) return out;
+        while (true)
+        {
+            uint32_t magic = 0, height = 0, size = 0;
+            if (!get_u32(in, magic) || magic != RECORD_MAGIC) break;
+            if (!get_u32(in, height)) break;
+            Record rec;
+            rec.height = height;
+            unsigned char hb[32];
+            if (!in.read(reinterpret_cast<char*>(hb), 32)) break;
+            std::memcpy(rec.hash.data(), hb, 32);
+            if (!get_u32(in, size)) break;
+            rec.bytes.resize(size);
+            if (size > 0 &&
+                !in.read(reinterpret_cast<char*>(rec.bytes.data()), size))
+                break;
+            out.push_back(std::move(rec));
+        }
+        return out;
+    }
+};
+
+// Capture consumer decoration: append the raw body to the fleet cache, then
+// forward to the inner consumer (the fold / the counting stub). A capture
+// failure never fails the fold — the cache is an optimization, the fold is
+// the product — so append errors log, disable capture, and the inner verdict
+// alone decides.
+class CaptureReplayConsumer : public IReplayBlockConsumer
+{
+    BulkCaptureWriter m_writer;
+    IReplayBlockConsumer* m_inner;   // borrowed, never owned
+
+public:
+    CaptureReplayConsumer(const std::string& dir, IReplayBlockConsumer* inner)
+        : m_writer(dir), m_inner(inner) {}
+
+    BulkCaptureWriter& writer() { return m_writer; }
+
+    bool on_replay_block(uint32_t height, const uint256& hash,
+                         const BlockType& block) override
+    {
+        if (!m_writer.failed())
+        {
+            auto packed = ::pack(block);
+            std::vector<uint8_t> raw(
+                reinterpret_cast<const uint8_t*>(packed.data()),
+                reinterpret_cast<const uint8_t*>(packed.data()) + packed.size());
+            m_writer.append(height, hash, raw);
+        }
+        return m_inner ? m_inner->on_replay_block(height, hash, block) : true;
+    }
+};
+
+// ── Genesis→anchor header backfill ─────────────────────────────────────────
+//
+// Forward walker over `headers` batches. Holds ONLY the per-height hash
+// (32 B × 2.4M ≈ 77 MB — the body-fetch index) plus a rolling claim window;
+// full IndexEntry storage stays the main HeaderChain's job for anchor→tip.
+//
+// Validation per header: prev-hash must equal the current walker tip, and
+// X11(header) must satisfy the header's own nBits under the network pow_limit
+// (check_pow — the anti-DoS floor). Target-CORRECTNESS (DGW) is not re-derived
+// here: the JOIN CHECK subsumes it — a segment that terminates in the exact
+// fast-start anchor hash is prev-hash-pinned all the way down, so a forged
+// mid-segment header would need the entire suffix re-mined onto the real
+// anchor. (The main chain's own DGW check is log-only for the same reason,
+// header_chain.hpp:616.) Genesis is additionally pinned to the known
+// params.genesis_hash, and the walk FAILS CLOSED, loudly, on a join mismatch.
+//
+// Persistence: hashes are flushed to LevelDB in full CHUNK_SPAN chunks (one
+// 320 KB value per 10k heights), so a restart reloads ~240 values instead of
+// re-syncing 2.4M headers; at most the partial tail chunk is re-fetched.
+class HeaderBackfill
+{
+public:
+    static constexpr uint32_t CHUNK_SPAN = 10000;
+    static constexpr size_t   CLAIM_WINDOW = 4096;
+
+private:
+    uint256  m_genesis_hash;
+    uint32_t m_anchor_height{0};
+    uint256  m_anchor_hash;
+    uint256  m_pow_limit;
+    bool     m_check_pow{true};
+
+    // heights [0, m_hashes.size()) — m_hashes[0] is the genesis hash.
+    std::vector<uint256> m_hashes;
+    bool m_complete{false};
+    bool m_failed{false};
+    std::string m_fail_cause;
+
+    // Rolling recent-hash window: batch claim + duplicate suppression. Old
+    // entries expire FIFO; a stale batch older than the window falls through
+    // to the main chain, orphan-rejects there, and is re-served next kick.
+    std::map<uint256, uint32_t> m_recent;
+    std::deque<uint256> m_recent_order;
+
+    std::unique_ptr<core::LevelDBStore> m_db;
+    uint32_t m_persisted_chunks{0};
+
+    uint64_t m_headers_accepted{0};
+    uint64_t m_headers_rejected{0};
+
+    void note_recent(const uint256& h, uint32_t height)
+    {
+        m_recent.emplace(h, height);
+        m_recent_order.push_back(h);
+        while (m_recent_order.size() > CLAIM_WINDOW)
+        {
+            m_recent.erase(m_recent_order.front());
+            m_recent_order.pop_front();
+        }
+    }
+
+    void fail(const std::string& cause)
+    {
+        m_failed = true;
+        m_fail_cause = cause;
+        LOG_ERROR << "[BULK] header backfill FAILED CLOSED cause=" << cause
+                  << " walker_height=" << (m_hashes.empty() ? 0 : m_hashes.size() - 1)
+                  << " — replay bulk lane refuses to fetch bodies off an "
+                     "unpinned header index";
+    }
+
+    static std::string chunk_key(uint32_t chunk_index)
+    {
+        char buf[16];
+        std::snprintf(buf, sizeof(buf), "rc%08u", chunk_index);
+        return buf;
+    }
+
+    void persist_full_chunks()
+    {
+        if (!m_db || !m_db->is_open()) return;
+        const uint32_t full_chunks =
+            static_cast<uint32_t>(m_hashes.size() / CHUNK_SPAN);
+        if (full_chunks <= m_persisted_chunks) return;
+        auto batch = m_db->create_batch();
+        for (uint32_t c = m_persisted_chunks; c < full_chunks; ++c)
+        {
+            std::vector<uint8_t> blob;
+            blob.reserve(CHUNK_SPAN * 32);
+            for (uint32_t i = 0; i < CHUNK_SPAN; ++i)
+            {
+                const uint256& h = m_hashes[static_cast<size_t>(c) * CHUNK_SPAN + i];
+                blob.insert(blob.end(), h.data(), h.data() + 32);
+            }
+            batch.put(chunk_key(c), blob);
+        }
+        std::vector<uint8_t> count(4);
+        count[0] = full_chunks & 0xFF;
+        count[1] = (full_chunks >> 8) & 0xFF;
+        count[2] = (full_chunks >> 16) & 0xFF;
+        count[3] = (full_chunks >> 24) & 0xFF;
+        batch.put("rc_count", count);
+        if (batch.commit_sync())
+            m_persisted_chunks = full_chunks;
+        else
+            LOG_WARNING << "[BULK] header-backfill chunk persist FAILED "
+                           "(progress kept in memory; resume will re-sync)";
+    }
+
+    void load_persisted()
+    {
+        if (!m_db || !m_db->is_open()) return;
+        std::vector<uint8_t> count;
+        if (!m_db->get("rc_count", count) || count.size() != 4) return;
+        const uint32_t chunks = static_cast<uint32_t>(count[0]) |
+                                (static_cast<uint32_t>(count[1]) << 8) |
+                                (static_cast<uint32_t>(count[2]) << 16) |
+                                (static_cast<uint32_t>(count[3]) << 24);
+        m_hashes.reserve(static_cast<size_t>(chunks) * CHUNK_SPAN);
+        for (uint32_t c = 0; c < chunks; ++c)
+        {
+            std::vector<uint8_t> blob;
+            if (!m_db->get(chunk_key(c), blob) || blob.size() != CHUNK_SPAN * 32)
+            {
+                LOG_WARNING << "[BULK] header-backfill chunk " << c
+                            << " missing/torn — resuming from chunk boundary "
+                            << m_hashes.size();
+                break;
+            }
+            for (uint32_t i = 0; i < CHUNK_SPAN; ++i)
+            {
+                uint256 h;
+                std::memcpy(h.data(), blob.data() + static_cast<size_t>(i) * 32, 32);
+                m_hashes.push_back(h);
+            }
+            m_persisted_chunks = c + 1;
+        }
+        if (!m_hashes.empty())
+        {
+            // The stored chain must still start at OUR genesis — a store from
+            // a different network fails loud, not silent.
+            if (m_hashes[0] != m_genesis_hash)
+            {
+                LOG_WARNING << "[BULK] header-backfill store genesis mismatch "
+                               "— discarding persisted walk";
+                m_hashes.clear();
+                m_persisted_chunks = 0;
+                return;
+            }
+            for (size_t i = m_hashes.size() > CLAIM_WINDOW
+                     ? m_hashes.size() - CLAIM_WINDOW : 0;
+                 i < m_hashes.size(); ++i)
+                note_recent(m_hashes[i], static_cast<uint32_t>(i));
+            LOG_INFO << "[BULK] header backfill resumed at height "
+                     << (m_hashes.size() - 1) << "/" << m_anchor_height
+                     << " (" << m_persisted_chunks << " persisted chunk[s])";
+            check_join();
+        }
+    }
+
+    void check_join()
+    {
+        if (m_failed || m_complete) return;
+        if (m_hashes.size() <= m_anchor_height) return;
+        // Walker reached the anchor height: the JOIN CHECK.
+        if (m_hashes[m_anchor_height] == m_anchor_hash)
+        {
+            m_complete = true;
+            LOG_INFO << "[BULK] header backfill COMPLETE: genesis→"
+                     << m_anchor_height << " JOINED the fast-start anchor ("
+                     << m_anchor_hash.GetHex().substr(0, 16)
+                     << "…) — pre-anchor chain is anchor-pinned to genesis";
+        }
+        else
+        {
+            fail("anchor-join-mismatch walker=" +
+                 m_hashes[m_anchor_height].GetHex().substr(0, 16) +
+                 " expected=" + m_anchor_hash.GetHex().substr(0, 16));
+        }
+    }
+
+public:
+    /// `db_path` empty ⇒ in-memory only (tests). `check_pow=false` is a
+    /// TEST-ONLY relaxation for synthetic header chains.
+    HeaderBackfill(const uint256& genesis_hash,
+                   uint32_t anchor_height, const uint256& anchor_hash,
+                   const uint256& pow_limit,
+                   const std::string& db_path = "",
+                   bool check_pow_flag = true)
+        : m_genesis_hash(genesis_hash)
+        , m_anchor_height(anchor_height)
+        , m_anchor_hash(anchor_hash)
+        , m_pow_limit(pow_limit)
+        , m_check_pow(check_pow_flag)
+    {
+        m_hashes.push_back(genesis_hash);
+        note_recent(genesis_hash, 0);
+        if (!db_path.empty())
+        {
+            core::LevelDBOptions opts;
+            opts.write_buffer_size = 2 * 1024 * 1024;
+            opts.block_cache_size = 2 * 1024 * 1024;
+            m_db = std::make_unique<core::LevelDBStore>(db_path, opts);
+            if (!m_db->open())
+            {
+                LOG_WARNING << "[BULK] header-backfill LevelDB open FAILED at "
+                            << db_path << " — walking without persistence";
+                m_db.reset();
+            }
+            else
+            {
+                load_persisted();
+            }
+        }
+    }
+
+    bool complete() const { return m_complete; }
+    bool failed() const { return m_failed; }
+    const std::string& fail_cause() const { return m_fail_cause; }
+    uint32_t anchor_height() const { return m_anchor_height; }
+    /// Height of the highest linked header (the walker tip).
+    uint32_t tip_height() const
+    {
+        return static_cast<uint32_t>(m_hashes.size() - 1);
+    }
+    const uint256& tip_hash() const { return m_hashes.back(); }
+    uint64_t headers_accepted() const { return m_headers_accepted; }
+    uint64_t headers_rejected() const { return m_headers_rejected; }
+
+    std::optional<uint256> hash_at(uint32_t height) const
+    {
+        if (height >= m_hashes.size()) return std::nullopt;
+        // Pre-anchor hashes are only trustworthy once the join has pinned the
+        // segment; before that they are a walk in progress, not an index.
+        if (!m_complete && height > 0) return std::nullopt;
+        return m_hashes[height];
+    }
+
+    /// Would this `headers` batch extend the backfill walk? The demux
+    /// predicate: a batch whose first prev-hash lands in our recent window is
+    /// OURS (consumed before the tip-lane's new_headers event); anything else
+    /// falls through to the main HeaderChain untouched.
+    bool claims(const std::vector<BlockType>& batch) const
+    {
+        if (m_complete || m_failed || batch.empty()) return false;
+        return m_recent.find(batch.front().m_previous_block) != m_recent.end();
+    }
+
+    /// Fold a claimed batch into the walk. Returns headers accepted.
+    int add_headers(const std::vector<BlockType>& batch)
+    {
+        if (m_complete || m_failed) return 0;
+        int accepted = 0;
+        for (const auto& b : batch)
+        {
+            if (m_complete) break;
+            if (b.m_previous_block != m_hashes.back())
+            {
+                // Duplicate/overlap (re-served after a re-kick) or out-of-order
+                // garbage — count and skip; the walk only ever extends its tip.
+                ++m_headers_rejected;
+                continue;
+            }
+            const auto header = static_cast<BlockHeaderType>(b);
+            auto packed = ::pack(header);
+            const uint256 bhash = dash::crypto::hash_x11(packed.get_span());
+            if (m_check_pow && !check_pow(bhash, header.m_bits, m_pow_limit))
+            {
+                ++m_headers_rejected;
+                LOG_WARNING << "[BULK] backfill header PoW FAIL at height "
+                            << m_hashes.size() << " — batch dropped";
+                break;   // a bad link poisons the rest of the batch
+            }
+            const uint32_t new_height = static_cast<uint32_t>(m_hashes.size());
+            if (new_height > m_anchor_height)
+            {
+                // Peer served past the anchor despite the stop hash; the walk
+                // ends at the anchor by definition.
+                break;
+            }
+            m_hashes.push_back(bhash);
+            note_recent(bhash, new_height);
+            ++m_headers_accepted;
+            ++accepted;
+            if (new_height == m_anchor_height)
+                check_join();
+        }
+        if (accepted > 0)
+        {
+            persist_full_chunks();
+            if ((m_hashes.size() % 100000) < static_cast<size_t>(accepted))
+                LOG_INFO << "[BULK] header backfill: " << tip_height() << "/"
+                         << m_anchor_height << " ("
+                         << (100.0 * tip_height() / m_anchor_height) << "%)";
+        }
+        return accepted;
+    }
+};
+
+// ── Pure bulk-request planner ──────────────────────────────────────────────
+//
+// Owns WHICH heights are asked of WHICH peer and when to ask again; owns no
+// sockets, no clock, no bodies. All state transitions are driven by the lane:
+//   pump()        → new (peer, batch-of-hashes) assignments to issue
+//   on_body()     → a requested body arrived (from whichever peer)
+//   on_notfound() → the asked peer does not have it (archival gap) — requeue,
+//                   avoid that peer on the retry
+//   service()     → timeouts + requests stranded on departed peers → requeue
+//   requeue()     → lane-detected corruption (merkle bind fail) → refetch
+class BulkBlockScheduler
+{
+public:
+    struct Config
+    {
+        uint32_t window{2000};            // max heights ahead of the delivered cursor (spec §4.3 bounded work-ahead)
+        uint32_t per_peer_inflight{32};   // outstanding bodies per peer (keeps reply queues short — priority inv. 4)
+        uint32_t batch{16};               // invs per getdata message
+        int64_t  request_timeout_sec{30}; // unanswered this long ⇒ re-request elsewhere
+    };
+
+    struct PeerTally
+    {
+        uint64_t blocks{0};
+        uint64_t bytes{0};
+        uint32_t inflight{0};
+    };
+
+    struct Assignment
+    {
+        std::string peer;
+        std::vector<std::pair<uint32_t, uint256>> blocks;   // (height, hash)
+    };
+
+private:
+    struct Req
+    {
+        uint32_t    height{0};
+        std::string peer;
+        int64_t     at{0};
+        int         attempts{0};
+    };
+
+    Config m_cfg;
+    uint32_t m_start{0};
+    uint32_t m_next{0};           // next never-requested height
+    uint32_t m_delivered{0};      // high-water: all ≤ this handed to consumer
+    uint32_t m_target_end{0};     // inclusive fetch ceiling (tip − exclusion)
+
+    std::map<uint256, Req> m_inflight;                       // by hash
+    std::deque<std::pair<uint32_t, std::string>> m_retry;    // (height, avoid-peer)
+    std::map<std::string, PeerTally> m_tallies;
+    std::size_t m_rr{0};                                     // round-robin cursor
+
+    uint64_t m_rerequests{0};
+    uint64_t m_notfound{0};
+    uint64_t m_timeouts{0};
+
+public:
+    void configure(const Config& cfg) { m_cfg = cfg; }
+    const Config& cfg() const { return m_cfg; }
+
+    /// Begin (or resume) at `start` — the first height to fetch. `delivered`
+    /// is start−1 by construction: nothing below start is wanted.
+    void reset(uint32_t start)
+    {
+        m_start = start;
+        m_next = start;
+        m_delivered = start > 0 ? start - 1 : 0;
+        m_inflight.clear();
+        m_retry.clear();
+    }
+
+    void set_target_end(uint32_t end_inclusive) { m_target_end = end_inclusive; }
+    uint32_t target_end() const { return m_target_end; }
+    void note_delivered(uint32_t height)
+    {
+        if (height > m_delivered) m_delivered = height;
+    }
+    uint32_t delivered() const { return m_delivered; }
+    uint32_t next_height() const { return m_next; }
+
+    std::size_t inflight_count() const { return m_inflight.size(); }
+    std::size_t retry_count() const { return m_retry.size(); }
+    uint64_t rerequests() const { return m_rerequests; }
+    uint64_t notfound_count() const { return m_notfound; }
+    uint64_t timeout_count() const { return m_timeouts; }
+    const std::map<std::string, PeerTally>& tallies() const { return m_tallies; }
+
+    bool is_inflight(const uint256& hash) const
+    {
+        return m_inflight.find(hash) != m_inflight.end();
+    }
+
+    /// A requested body arrived (identified by the hash the block handler
+    /// computed from its own header — arrival hash == requested hash is what
+    /// pins the header). Returns its height, or nullopt for a body we never
+    /// asked for (NOT ours — the caller lets it fall through to the tip lane).
+    std::optional<uint32_t> on_body(const uint256& hash, std::size_t raw_size)
+    {
+        auto it = m_inflight.find(hash);
+        if (it == m_inflight.end()) return std::nullopt;
+        const uint32_t height = it->second.height;
+        auto& t = m_tallies[it->second.peer];
+        ++t.blocks;
+        t.bytes += raw_size;
+        if (t.inflight > 0) --t.inflight;
+        m_inflight.erase(it);
+        return height;
+    }
+
+    /// The asked peer answered notfound (pruned/archival gap): requeue at the
+    /// FRONT (oldest heights gate the in-order delivery cursor) avoiding that
+    /// peer, so the retry lands on a neighbour that may hold it.
+    bool on_notfound(const uint256& hash)
+    {
+        auto it = m_inflight.find(hash);
+        if (it == m_inflight.end()) return false;
+        ++m_notfound;
+        auto& t = m_tallies[it->second.peer];
+        if (t.inflight > 0) --t.inflight;
+        m_retry.emplace_front(it->second.height, it->second.peer);
+        m_inflight.erase(it);
+        return true;
+    }
+
+    /// Lane-side refusal (merkle bind failure): fetch the height again from
+    /// anyone but the peer that served the corrupt body.
+    void requeue(uint32_t height, const std::string& avoid_peer)
+    {
+        ++m_rerequests;
+        m_retry.emplace_front(height, avoid_peer);
+    }
+
+    /// Timeouts + stranded requests. `live_peers` is the CURRENT eligible set;
+    /// a request whose peer churned out of the pool is requeued immediately
+    /// rather than waiting out its timeout.
+    void service(int64_t now, const std::vector<std::string>& live_peers)
+    {
+        for (auto it = m_inflight.begin(); it != m_inflight.end();)
+        {
+            const bool peer_gone =
+                std::find(live_peers.begin(), live_peers.end(),
+                          it->second.peer) == live_peers.end();
+            const bool timed_out =
+                (now - it->second.at) >= m_cfg.request_timeout_sec;
+            if (!peer_gone && !timed_out) { ++it; continue; }
+            if (timed_out) ++m_timeouts;
+            auto& t = m_tallies[it->second.peer];
+            if (t.inflight > 0) --t.inflight;
+            m_retry.emplace_front(it->second.height, it->second.peer);
+            it = m_inflight.erase(it);
+        }
+    }
+
+    /// Plan new assignments. `hash_at` resolves a height to its pinned hash
+    /// (nullopt ⇒ the header index does not cover it yet — stop there).
+    /// `buffered` is the lane's current work-ahead buffer occupancy; combined
+    /// with the window it bounds total residency (spec §4.3: bounded buffer,
+    /// nothing retained). Fresh heights are handed out as CONTIGUOUS runs per
+    /// peer (range partitioning), retries go first.
+    std::vector<Assignment> pump(
+        int64_t now,
+        const std::vector<std::string>& peers,
+        const std::function<std::optional<uint256>(uint32_t)>& hash_at,
+        std::size_t buffered)
+    {
+        std::vector<Assignment> out;
+        if (peers.empty()) return out;
+
+        // Drop tallies' inflight for peers that vanished (service() already
+        // requeued their requests); keep their historical block/byte tallies.
+        for (auto& [key, t] : m_tallies)
+            if (std::find(peers.begin(), peers.end(), key) == peers.end())
+                t.inflight = 0;
+
+        const uint64_t budget_total =
+            static_cast<uint64_t>(m_delivered) + m_cfg.window;
+
+        for (std::size_t pi = 0; pi < peers.size(); ++pi)
+        {
+            const std::string& peer = peers[(m_rr + pi) % peers.size()];
+            auto& tally = m_tallies[peer];
+            if (tally.inflight >= m_cfg.per_peer_inflight) continue;
+            uint32_t capacity = std::min<uint32_t>(
+                m_cfg.batch, m_cfg.per_peer_inflight - tally.inflight);
+
+            Assignment a;
+            a.peer = peer;
+
+            // Retries first: oldest missing heights gate the delivery cursor.
+            while (capacity > 0 && !m_retry.empty())
+            {
+                auto [height, avoid] = m_retry.front();
+                if (avoid == peer && peers.size() > 1)
+                    break;   // let another peer's slot take this one
+                m_retry.pop_front();
+                auto h = hash_at(height);
+                if (!h) continue;   // index shrank (should not happen) — drop
+                m_inflight[*h] = Req{height, peer, now,
+                                     /*attempts=*/1};
+                a.blocks.emplace_back(height, *h);
+                ++tally.inflight;
+                --capacity;
+            }
+
+            // Then a fresh CONTIGUOUS range for this peer.
+            while (capacity > 0 && m_next <= m_target_end &&
+                   static_cast<uint64_t>(m_next) <= budget_total &&
+                   (static_cast<uint64_t>(m_inflight.size()) + buffered) <
+                       m_cfg.window)
+            {
+                auto h = hash_at(m_next);
+                if (!h) break;   // header index ends here for now
+                m_inflight[*h] = Req{m_next, peer, now, 0};
+                a.blocks.emplace_back(m_next, *h);
+                ++tally.inflight;
+                --capacity;
+                ++m_next;
+            }
+
+            if (!a.blocks.empty()) out.push_back(std::move(a));
+        }
+        if (!peers.empty()) m_rr = (m_rr + 1) % peers.size();
+        return out;
+    }
+};
+
+// ── The lane: glue between scheduler, backfill, consumer and the client ────
+//
+// Constructed only under --replay-bulk. All seams are injected functions so
+// the KATs stand the whole lane up with no CoinClient and no io_context; in
+// production main_dash wires them to the client's named-peer sends and demux
+// filters and pumps tick() from a 1 s core::Timer on the io thread.
+class BulkFetchLane
+{
+public:
+    struct Seams
+    {
+        // Height → pinned hash: backfill for pre-anchor, HeaderChain above.
+        std::function<std::optional<uint256>(uint32_t)> hash_at;
+        // Current main header-chain tip height.
+        std::function<uint32_t()> chain_height;
+        // Handshaked peers ELIGIBLE for bulk (primary excluded unless alone).
+        std::function<std::vector<std::string>()> eligible_peers;
+        // One getdata(block…) with the given hashes to the named peer.
+        std::function<void(const std::string&, const std::vector<uint256>&)>
+            send_getdata;
+        // getheaders(locator=[backfill tip], stop=anchor) to the named peer.
+        std::function<void(const std::string&, const uint256& locator_hash,
+                           const uint256& stop)> send_getheaders;
+        // Tip lane busy right now? (pending tracked tip body) — priority inv. 2.
+        std::function<bool()> tip_busy;
+    };
+
+    struct Config
+    {
+        uint32_t start_height{MAINNET_DIP3_HEIGHT};
+        uint32_t tip_exclusion{12};          // live edge belongs to the tip lane
+        int64_t  telemetry_interval_sec{30};
+        int64_t  backfill_rekick_sec{15};    // headers stall re-kick
+        uint32_t cursor_persist_every{512};  // delivered blocks between cursor writes
+    };
+
+private:
+    Seams  m_seams;
+    Config m_cfg;
+    BulkBlockScheduler m_sched;
+    HeaderBackfill*    m_backfill;   // borrowed; nullptr ⇒ no pre-anchor span (testnet / no fast-start)
+    IReplayBlockConsumer* m_consumer;
+    ReplayCursorStore* m_cursor;     // borrowed; nullptr ⇒ no persistence (tests)
+
+    std::map<uint32_t, BlockType> m_buffer;   // received, awaiting in-order delivery
+    uint32_t m_delivered{0};
+    bool m_cursor_checked{false};
+    std::optional<ReplayCursorStore::Cursor> m_resume;
+
+    bool m_failed{false};
+    std::string m_fail_cause;
+
+    // Telemetry window.
+    int64_t  m_last_telemetry{0};
+    uint64_t m_window_blocks{0};
+    uint64_t m_window_bytes{0};
+    uint64_t m_total_blocks{0};
+    uint64_t m_total_bytes{0};
+    uint64_t m_corrupt_bodies{0};
+    uint32_t m_delivered_since_persist{0};
+
+    int64_t m_last_backfill_kick{0};
+    std::size_t m_backfill_rr{0};
+
+    void fail(const std::string& cause)
+    {
+        if (m_failed) return;
+        m_failed = true;
+        m_fail_cause = cause;
+        LOG_ERROR << "[BULK] lane FAILED CLOSED cause=" << cause
+                  << " delivered=" << m_delivered
+                  << " — bulk fetching stopped (tip lane unaffected)";
+    }
+
+    void persist_cursor(bool force)
+    {
+        if (!m_cursor || m_delivered < m_cfg.start_height) return;
+        if (!force && m_delivered_since_persist < m_cfg.cursor_persist_every)
+            return;
+        auto h = m_seams.hash_at(m_delivered);
+        if (!h) return;
+        ReplayCursorStore::Cursor c;
+        c.height = m_delivered;
+        c.hash = *h;
+        if (m_cursor->store(c))
+            m_delivered_since_persist = 0;
+    }
+
+    /// Deliver the contiguous prefix of the buffer to the consumer, PRUNE it.
+    void drain_buffer()
+    {
+        while (!m_failed)
+        {
+            auto it = m_buffer.find(m_delivered + 1);
+            if (it == m_buffer.end()) break;
+            const uint32_t height = it->first;
+            auto h = m_seams.hash_at(height);
+            if (!h) break;   // cannot name the hash (index regressed) — hold
+            if (!m_consumer->on_replay_block(height, *h, it->second))
+            {
+                fail("consumer-refused height=" + std::to_string(height));
+                break;
+            }
+            m_buffer.erase(it);   // PRUNE — the body is gone the moment it folds
+            m_delivered = height;
+            m_sched.note_delivered(height);
+            ++m_delivered_since_persist;
+            persist_cursor(false);
+        }
+    }
+
+    void maybe_kick_backfill(int64_t now)
+    {
+        if (!m_backfill || m_backfill->complete() || m_backfill->failed())
+            return;
+        if ((now - m_last_backfill_kick) < m_cfg.backfill_rekick_sec) return;
+        auto peers = m_seams.eligible_peers();
+        if (peers.empty()) return;
+        const std::string& peer = peers[m_backfill_rr++ % peers.size()];
+        m_seams.send_getheaders(peer, m_backfill->tip_hash(),
+                                uint256::ZERO /* stop: serve max batches; the
+                                walker itself stops at the anchor */);
+        m_last_backfill_kick = now;
+    }
+
+    void maybe_log_telemetry(int64_t now)
+    {
+        if (m_last_telemetry != 0 &&
+            (now - m_last_telemetry) < m_cfg.telemetry_interval_sec)
+            return;
+        const int64_t span = m_last_telemetry == 0
+            ? m_cfg.telemetry_interval_sec : (now - m_last_telemetry);
+        m_last_telemetry = now;
+        const double blk_s = span > 0 ? double(m_window_blocks) / span : 0.0;
+        const double mb_s  = span > 0
+            ? double(m_window_bytes) / (1024.0 * 1024.0) / span : 0.0;
+        std::ostringstream peers;
+        for (const auto& [key, t] : m_sched.tallies())
+        {
+            if (t.blocks == 0 && t.inflight == 0) continue;
+            peers << " " << key << "=" << t.blocks << "blk/"
+                  << (t.bytes / (1024 * 1024)) << "MB"
+                  << (t.inflight ? ("(+" + std::to_string(t.inflight) + ")")
+                                 : "");
+        }
+        LOG_INFO << "[BULK] delivered=" << m_delivered << "/"
+                 << m_sched.target_end()
+                 << " rate=" << blk_s << "blk/s " << mb_s << "MB/s"
+                 << " total=" << m_total_blocks << "blk/"
+                 << (m_total_bytes / (1024 * 1024)) << "MB"
+                 << " inflight=" << m_sched.inflight_count()
+                 << " buffer=" << m_buffer.size()
+                 << " retry=" << m_sched.retry_count()
+                 << " hdr="
+                 << (m_backfill
+                         ? (m_backfill->complete()
+                                ? std::string("joined")
+                                : (m_backfill->failed()
+                                       ? std::string("FAILED")
+                                       : std::to_string(m_backfill->tip_height())
+                                         + "/"
+                                         + std::to_string(
+                                               m_backfill->anchor_height())))
+                         : std::string("n/a"))
+                 << " rereq=" << m_sched.rerequests()
+                 << " timeout=" << m_sched.timeout_count()
+                 << " notfound=" << m_sched.notfound_count()
+                 << " corrupt=" << m_corrupt_bodies
+                 << " peers[" << peers.str() << " ]";
+        m_window_blocks = 0;
+        m_window_bytes = 0;
+    }
+
+    /// Cursor resume: trust the persisted high-water only after proving its
+    /// hash still names OUR chain at that height (lazy — the backfill may not
+    /// cover the height yet). Mismatch ⇒ fail closed with a named cause.
+    void maybe_check_cursor()
+    {
+        if (m_cursor_checked || !m_resume) return;
+        auto h = m_seams.hash_at(m_resume->height);
+        if (!h) return;   // index not there yet — check again next tick
+        if (*h != m_resume->hash)
+        {
+            fail("resume-cursor-hash-mismatch height=" +
+                 std::to_string(m_resume->height) +
+                 " stored=" + m_resume->hash.GetHex().substr(0, 16) +
+                 " chain=" + h->GetHex().substr(0, 16));
+            return;
+        }
+        m_cursor_checked = true;
+        LOG_INFO << "[BULK] resume cursor VERIFIED at height "
+                 << m_resume->height << " — resuming fetch from "
+                 << (m_resume->height + 1);
+    }
+
+public:
+    BulkFetchLane(Seams seams, Config cfg,
+                  HeaderBackfill* backfill,
+                  IReplayBlockConsumer* consumer,
+                  ReplayCursorStore* cursor)
+        : m_seams(std::move(seams))
+        , m_cfg(cfg)
+        , m_backfill(backfill)
+        , m_consumer(consumer)
+        , m_cursor(cursor)
+    {
+        uint32_t start = m_cfg.start_height;
+        if (m_cursor)
+        {
+            m_resume = m_cursor->load();
+            if (m_resume && m_resume->height >= start)
+            {
+                start = m_resume->height + 1;
+                LOG_INFO << "[BULK] cursor found: delivered high-water "
+                         << m_resume->height
+                         << " (hash check deferred until the header index "
+                            "covers it)";
+            }
+            else
+            {
+                m_resume.reset();
+                m_cursor_checked = true;   // nothing to verify
+            }
+        }
+        else
+        {
+            m_cursor_checked = true;
+        }
+        m_sched.reset(start);
+        m_delivered = start > 0 ? start - 1 : 0;
+    }
+
+    BulkBlockScheduler& scheduler() { return m_sched; }
+    uint32_t delivered() const { return m_delivered; }
+    std::size_t buffer_size() const { return m_buffer.size(); }
+    bool failed() const { return m_failed; }
+    const std::string& fail_cause() const { return m_fail_cause; }
+    uint64_t total_blocks() const { return m_total_blocks; }
+    uint64_t total_bytes() const { return m_total_bytes; }
+    uint64_t corrupt_bodies() const { return m_corrupt_bodies; }
+
+    /// Headers demux filter body (registered on the CoinClient): claim and
+    /// fold backfill batches; everything else falls through to new_headers.
+    bool on_headers(const std::string& /*peer_key*/,
+                    const std::vector<BlockType>& batch)
+    {
+        if (!m_backfill || !m_backfill->claims(batch)) return false;
+        const int accepted = m_backfill->add_headers(batch);
+        if (accepted > 0 && !m_backfill->complete() && !m_backfill->failed())
+        {
+            // Self-propel: immediately ask for the next span. The stall
+            // re-kick in tick() is only the backstop.
+            auto peers = m_seams.eligible_peers();
+            if (!peers.empty())
+            {
+                const std::string& peer =
+                    peers[m_backfill_rr++ % peers.size()];
+                m_seams.send_getheaders(peer, m_backfill->tip_hash(),
+                                        uint256::ZERO);
+            }
+        }
+        return true;   // claimed — never reaches the tip-lane header ingest
+    }
+
+    /// Block-body demux filter body (registered on the CoinClient). `hash` is
+    /// X11 of the body's own header — equality with the scheduled hash pins
+    /// the header; the merkle bind then pins the tx set to that header.
+    /// Returns true when the body was OURS (consumed; skip full_block event).
+    bool on_block_body(const uint256& hash, const BlockType& block)
+    {
+        if (m_failed)
+        {
+            // Still consume stragglers we asked for, so they don't leak into
+            // the tip lane's full_block ingest; just don't fold them.
+            return m_sched.on_body(hash, 0).has_value();
+        }
+        if (!m_sched.is_inflight(hash)) return false;   // not ours — tip lane's body
+        const std::size_t raw_size = ::pack(block).size();
+        auto height = m_sched.on_body(hash, raw_size);
+        if (!height) return false;   // unreachable (checked above); belt+braces
+
+        if (!block_body_binds_to_header(block))
+        {
+            ++m_corrupt_bodies;
+            LOG_WARNING << "[BULK] body MERKLE-BIND FAIL height=" << *height
+                        << " hash=" << hash.GetHex().substr(0, 16)
+                        << "… — re-requesting from a different peer";
+            // The tally already credited the serving peer; requeue avoids it.
+            m_sched.requeue(*height, std::string{});
+            return true;   // consumed (and rejected) — never fold, never leak
+        }
+
+        ++m_total_blocks;
+        ++m_window_blocks;
+        m_total_bytes += raw_size;
+        m_window_bytes += raw_size;
+        if (*height <= m_delivered)
+            return true;   // duplicate (double-answered re-request) — pruned
+        m_buffer[*height] = block;
+        drain_buffer();
+        return true;
+    }
+
+    /// notfound(block) callback body.
+    void on_notfound(const uint256& hash) { m_sched.on_notfound(hash); }
+
+    /// One pump: drive the backfill, service timeouts, plan + issue bulk
+    /// getdata (unless the tip lane is busy), telemetry. Call ~1/s.
+    void tick(int64_t now)
+    {
+        maybe_check_cursor();
+        if (m_failed)
+        {
+            maybe_log_telemetry(now);
+            return;
+        }
+        maybe_kick_backfill(now);
+
+        const auto peers = m_seams.eligible_peers();
+        m_sched.service(now, peers);
+
+        // Fetch ceiling: stay clear of the live edge (priority invariant 3).
+        const uint32_t tip = m_seams.chain_height();
+        m_sched.set_target_end(tip > m_cfg.tip_exclusion
+                                   ? tip - m_cfg.tip_exclusion : 0);
+
+        // STRICT PRIORITY: no new bulk requests while a tracked tip body is
+        // outstanding (invariant 2). In-flight bulk completes on its own.
+        if (!peers.empty() && m_cursor_checked &&
+            !(m_seams.tip_busy && m_seams.tip_busy()))
+        {
+            auto assignments = m_sched.pump(
+                now, peers, m_seams.hash_at, m_buffer.size());
+            for (const auto& a : assignments)
+            {
+                std::vector<uint256> hashes;
+                hashes.reserve(a.blocks.size());
+                for (const auto& [h, hash] : a.blocks) hashes.push_back(hash);
+                m_seams.send_getdata(a.peer, hashes);
+            }
+        }
+        maybe_log_telemetry(now);
+    }
+
+    /// Clean-shutdown hook: force-persist the cursor.
+    void flush() { persist_cursor(true); }
+};
+
+} // namespace replay
+} // namespace coin
+} // namespace dash

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1050,8 +1050,15 @@ if (BUILD_TESTING AND GTest_FOUND)
     # (never-re-arm defect fix): saturating exponential backoff schedule/floor/
     # overflow, the single-latch re-entry guard (N ticks -> one re-arm), and the
     # recovery reset. Same target, no new allowlist entry.
+    # Seventh TU: test_dash_replay_bulk_fetch.cpp — the W2 FULL-HISTORY REPLAY
+    # bulk block-fetch lane (coin/replay_bulk_fetch.hpp): multi-peer range
+    # partitioning, timeout/notfound/peer-loss re-request, in-order
+    # deliver-then-PRUNE into the W1 consumer seam, merkle-bind rejection,
+    # tip-lane strict priority, resumable cursor (verified hash, fail-closed
+    # mismatch), genesis→anchor header-backfill join, capture segment cache.
+    # Same target, no new allowlist entry.
     # DASH_FIXTURE_DIR: the wire suite replays the real 602'189-byte testnet capture.
-    add_executable(test_dash_p2p_node test_dash_p2p_node.cpp test_dash_coin_p2p_client.cpp test_dash_coin_peer_manager.cpp test_dash_coin_p2p_pool.cpp test_dash_qrinfo_wire.cpp test_dash_coin_peer_rearm.cpp)
+    add_executable(test_dash_p2p_node test_dash_p2p_node.cpp test_dash_coin_p2p_client.cpp test_dash_coin_peer_manager.cpp test_dash_coin_p2p_pool.cpp test_dash_qrinfo_wire.cpp test_dash_coin_peer_rearm.cpp test_dash_replay_bulk_fetch.cpp)
     target_compile_definitions(test_dash_p2p_node PRIVATE
         DASH_FIXTURE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/fixtures")
     target_link_libraries(test_dash_p2p_node PRIVATE

--- a/test/test_dash_replay_bulk_fetch.cpp
+++ b/test/test_dash_replay_bulk_fetch.cpp
@@ -1,0 +1,757 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/// DASH FULL-HISTORY REPLAY — W2 bulk block-fetch lane KATs.
+///
+/// Pins the properties the replay transport promises
+/// (src/impl/dash/coin/replay_bulk_fetch.hpp; design
+/// docs/DASH_FULL_HISTORY_REPLAY_MODE.md §4.1/§4.3, WP W2):
+///
+///   (A) RANGE PARTITIONING — the wanted height span is handed out as
+///       contiguous per-peer batches across the pool, per-peer in-flight
+///       capped, window-bounded (the §4.3 bounded work-ahead buffer).
+///   (B) RE-REQUEST — a timed-out request, a notfound answer, and a departed
+///       peer each requeue their heights; the retry rotates AWAY from the
+///       peer that failed.
+///   (C) IN-ORDER DELIVERY + PRUNE — bodies arriving out of order are
+///       delivered to the consumer strictly in height order with no gaps and
+///       PRUNED immediately (never persisted); a consumer refusal fails the
+///       lane closed.
+///   (D) VERIFICATION — a body whose tx set does not fold to its header's
+///       committed merkle root is rejected, counted and re-fetched, never
+///       delivered.
+///   (E) TIP PRIORITY — while a tracked tip body is outstanding (tip_busy),
+///       the lane issues NO new bulk getdata.
+///   (F) RESUMABILITY — the delivered high-water cursor round-trips its
+///       versioned file; a resumed lane verifies the cursor hash against the
+///       chain and FAILS CLOSED on mismatch instead of folding a different
+///       branch.
+///   (G) HEADER BACKFILL — the genesis→anchor walk links+claims batches,
+///       joins the fast-start anchor exactly, and fails closed on a join
+///       mismatch (the wrong-chain / hostile-peer case).
+///   (H) CAPTURE — the optional segment-file cache round-trips records and a
+///       torn tail truncates instead of corrupting.
+///
+/// Everything here is KAT-able without mainnet: the scheduler and lane are
+/// pure/seam-injected, and synthetic chains use check_pow=false (X11 PoW on
+/// real headers is exercised by the existing header-chain KATs; a live bulk
+/// throughput smoke is a soak item, not a unit test — see the PR notes).
+///
+/// This TU compiles into the EXISTING allowlisted test_dash_p2p_node target
+/// (no new test target, no workflow edit — the drift-guard stays green).
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/replay_bulk_fetch.hpp>
+#include <impl/dash/coin/header_chain.hpp>   // x11_hash
+
+#include <core/pack.hpp>
+#include <core/hash.hpp>
+#include <core/uint256.hpp>
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <memory>
+#include <optional>
+#include <random>
+#include <set>
+#include <string>
+#include <vector>
+
+using dash::coin::BlockType;
+using dash::coin::BlockHeaderType;
+using dash::coin::MutableTransaction;
+namespace rp = dash::coin::replay;
+
+namespace {
+
+// ── synthetic chain ───────────────────────────────────────────────────────
+//
+// Bodies are REAL BlockType objects whose tx set folds to the header's
+// committed merkle root (single unique tx per height), so the lane's
+// merkle-bind check runs the real code. PoW is not mined — the lane never
+// checks PoW itself (the header INDEX it fetches against is PoW-checked by
+// HeaderChain/HeaderBackfill, which have their own KATs).
+struct SyntheticChain
+{
+    std::vector<BlockType> blocks;   // index = height
+    std::vector<uint256>   hashes;
+
+    explicit SyntheticChain(uint32_t n_heights)
+    {
+        uint256 prev;   // null
+        for (uint32_t h = 0; h < n_heights; ++h)
+        {
+            BlockType b;
+            b.m_version = 1;
+            b.m_previous_block = prev;
+            b.m_timestamp = 1700000000u + h;
+            b.m_bits = 0x1e0fffff;
+            b.m_nonce = h;
+            MutableTransaction tx;
+            tx.locktime = h;              // unique tx per height
+            b.m_txs.push_back(tx);
+            auto packed_tx = ::pack(b.m_txs[0]);
+            b.m_merkle_root = ::Hash(packed_tx.get_span());
+            const auto header = static_cast<BlockHeaderType>(b);
+            auto packed = ::pack(header);
+            const uint256 hash = dash::crypto::hash_x11(packed.get_span());
+            blocks.push_back(b);
+            hashes.push_back(hash);
+            prev = hash;
+        }
+    }
+
+    std::optional<uint256> hash_at(uint32_t h) const
+    {
+        if (h >= hashes.size()) return std::nullopt;
+        return hashes[h];
+    }
+};
+
+// ── lane rig: all seams captured, no sockets, no io_context ───────────────
+struct LaneRig
+{
+    SyntheticChain chain;
+    rp::CountingReplayConsumer counter;
+    std::vector<std::string> peers{"p1:9999", "p2:9999", "p3:9999"};
+    bool tip_busy{false};
+    uint32_t chain_height;
+
+    struct SentBatch
+    {
+        std::string peer;
+        std::vector<uint256> hashes;
+    };
+    std::vector<SentBatch> sent;
+    std::vector<std::pair<std::string, uint256>> getheaders_sent;
+
+    std::unique_ptr<rp::BulkFetchLane> lane;
+
+    explicit LaneRig(uint32_t heights, rp::BulkFetchLane::Config cfg,
+                     rp::HeaderBackfill* backfill = nullptr,
+                     rp::ReplayCursorStore* cursor = nullptr,
+                     rp::IReplayBlockConsumer* consumer_override = nullptr)
+        : chain(heights), chain_height(heights - 1)
+    {
+        rp::BulkFetchLane::Seams seams;
+        seams.hash_at = [this](uint32_t h) { return chain.hash_at(h); };
+        seams.chain_height = [this] { return chain_height; };
+        seams.eligible_peers = [this] { return peers; };
+        seams.send_getdata = [this](const std::string& peer,
+                                    const std::vector<uint256>& hashes) {
+            sent.push_back({peer, hashes});
+        };
+        seams.send_getheaders = [this](const std::string& peer,
+                                       const uint256& loc, const uint256&) {
+            getheaders_sent.emplace_back(peer, loc);
+        };
+        seams.tip_busy = [this] { return tip_busy; };
+        lane = std::make_unique<rp::BulkFetchLane>(
+            std::move(seams), cfg, backfill,
+            consumer_override ? consumer_override
+                              : static_cast<rp::IReplayBlockConsumer*>(&counter),
+            cursor);
+    }
+
+    /// Answer every outstanding sent batch with its real bodies, in the given
+    /// (possibly shuffled) order. Returns bodies answered.
+    std::size_t answer_all(std::mt19937* shuffle_rng = nullptr)
+    {
+        std::vector<std::pair<uint256, const BlockType*>> pending;
+        for (auto& b : sent)
+            for (auto& h : b.hashes)
+            {
+                auto it = std::find(chain.hashes.begin(), chain.hashes.end(), h);
+                if (it == chain.hashes.end())
+                {
+                    ADD_FAILURE() << "lane requested an unknown hash";
+                    continue;
+                }
+                const auto idx = static_cast<std::size_t>(
+                    std::distance(chain.hashes.begin(), it));
+                pending.emplace_back(h, &chain.blocks[idx]);
+            }
+        sent.clear();
+        if (shuffle_rng)
+            std::shuffle(pending.begin(), pending.end(), *shuffle_rng);
+        for (auto& [h, blk] : pending)
+            lane->on_block_body(h, *blk);
+        return pending.size();
+    }
+};
+
+std::string temp_path(const char* stem)
+{
+    static std::mt19937_64 rng{std::random_device{}()};
+    return (std::filesystem::temp_directory_path() /
+            (std::string(stem) + "-" + std::to_string(rng()))).string();
+}
+
+// ═══ (A) range partitioning ═══════════════════════════════════════════════
+
+TEST(DashReplayBulkScheduler, RangePartitionsContiguousRunsAcrossPeers)
+{
+    SyntheticChain chain(200);
+    rp::BulkBlockScheduler s;
+    rp::BulkBlockScheduler::Config cfg;
+    cfg.window = 1000;
+    cfg.per_peer_inflight = 32;
+    cfg.batch = 8;
+    s.configure(cfg);
+    s.reset(10);
+    s.set_target_end(199);
+
+    const std::vector<std::string> peers{"a", "b", "c"};
+    auto plan = s.pump(1000, peers,
+                       [&](uint32_t h) { return chain.hash_at(h); }, 0);
+    ASSERT_EQ(plan.size(), 3u);
+
+    uint32_t expect = 10;
+    std::set<std::string> seen_peers;
+    for (const auto& a : plan)
+    {
+        seen_peers.insert(a.peer);
+        // Each peer gets a CONTIGUOUS run of `batch` heights, and the runs
+        // tile the span with no gap and no overlap.
+        ASSERT_EQ(a.blocks.size(), cfg.batch);
+        for (const auto& [h, hash] : a.blocks)
+        {
+            EXPECT_EQ(h, expect);
+            EXPECT_EQ(hash, chain.hashes[h]);
+            ++expect;
+        }
+    }
+    EXPECT_EQ(seen_peers.size(), 3u);          // all peers loaded
+    EXPECT_EQ(s.inflight_count(), 24u);        // 3 × batch
+    EXPECT_EQ(s.next_height(), 34u);
+
+    // Second pump keeps loading up to the per-peer cap, never beyond.
+    for (int i = 0; i < 10; ++i)
+        s.pump(1001 + i, peers,
+               [&](uint32_t h) { return chain.hash_at(h); }, 0);
+    for (const auto& [key, t] : s.tallies())
+        EXPECT_LE(t.inflight, cfg.per_peer_inflight) << key;
+    EXPECT_LE(s.inflight_count(), 3u * cfg.per_peer_inflight);
+}
+
+TEST(DashReplayBulkScheduler, WindowBoundsWorkAhead)
+{
+    SyntheticChain chain(5000);
+    rp::BulkBlockScheduler s;
+    rp::BulkBlockScheduler::Config cfg;
+    cfg.window = 100;              // small window
+    cfg.per_peer_inflight = 64;
+    cfg.batch = 32;
+    s.configure(cfg);
+    s.reset(0);
+    s.set_target_end(4999);
+
+    const std::vector<std::string> peers{"a", "b", "c", "d", "e", "f"};
+    for (int i = 0; i < 50; ++i)
+        s.pump(1000 + i, peers,
+               [&](uint32_t h) { return chain.hash_at(h); }, /*buffered=*/0);
+    // Nothing may be requested past delivered + window, regardless of pumps
+    // and peer capacity (bounded residency — spec §4.3).
+    EXPECT_LE(s.next_height(), 0u + cfg.window + 1);
+    EXPECT_LE(s.inflight_count(), cfg.window);
+}
+
+// ═══ (B) re-request paths ═════════════════════════════════════════════════
+
+TEST(DashReplayBulkScheduler, TimeoutRequeuesAndRotatesPeer)
+{
+    SyntheticChain chain(50);
+    rp::BulkBlockScheduler s;
+    rp::BulkBlockScheduler::Config cfg;
+    cfg.batch = 4;
+    cfg.request_timeout_sec = 30;
+    s.configure(cfg);
+    s.reset(0);
+    s.set_target_end(3);
+
+    auto plan = s.pump(1000, {"a", "b"},
+                       [&](uint32_t h) { return chain.hash_at(h); }, 0);
+    ASSERT_EQ(plan.size(), 1u);               // 4 heights fit one batch
+    const std::string first_peer = plan[0].peer;
+    EXPECT_EQ(s.inflight_count(), 4u);
+
+    // Not yet: 29 s.
+    s.service(1029, {"a", "b"});
+    EXPECT_EQ(s.inflight_count(), 4u);
+    EXPECT_EQ(s.timeout_count(), 0u);
+
+    // At 30 s: all four requeued.
+    s.service(1030, {"a", "b"});
+    EXPECT_EQ(s.inflight_count(), 0u);
+    EXPECT_EQ(s.retry_count(), 4u);
+    EXPECT_EQ(s.timeout_count(), 4u);
+
+    // The retry avoids the peer that just failed: with two peers the whole
+    // batch lands on the OTHER one.
+    auto retry_plan = s.pump(1031, {"a", "b"},
+                             [&](uint32_t h) { return chain.hash_at(h); }, 0);
+    ASSERT_FALSE(retry_plan.empty());
+    for (const auto& a : retry_plan)
+        for ([[maybe_unused]] const auto& blk : a.blocks)
+            EXPECT_NE(a.peer, first_peer);
+}
+
+TEST(DashReplayBulkScheduler, NotfoundRequeuesFrontAvoidingPeer)
+{
+    SyntheticChain chain(50);
+    rp::BulkBlockScheduler s;
+    rp::BulkBlockScheduler::Config cfg;
+    cfg.batch = 2;
+    s.configure(cfg);
+    s.reset(0);
+    s.set_target_end(1);
+
+    auto plan = s.pump(1000, {"a", "b"},
+                       [&](uint32_t h) { return chain.hash_at(h); }, 0);
+    ASSERT_EQ(plan.size(), 1u);
+    const std::string asked = plan[0].peer;
+    ASSERT_EQ(plan[0].blocks.size(), 2u);
+
+    EXPECT_TRUE(s.on_notfound(plan[0].blocks[0].second));
+    EXPECT_EQ(s.notfound_count(), 1u);
+    EXPECT_EQ(s.retry_count(), 1u);
+    // Unknown hash: not ours.
+    EXPECT_FALSE(s.on_notfound(uint256::ONE));
+
+    auto retry = s.pump(1001, {"a", "b"},
+                        [&](uint32_t h) { return chain.hash_at(h); }, 0);
+    ASSERT_FALSE(retry.empty());
+    EXPECT_NE(retry[0].peer, asked);
+    EXPECT_EQ(retry[0].blocks[0].first, plan[0].blocks[0].first);
+}
+
+TEST(DashReplayBulkScheduler, DepartedPeerRequestsRequeueImmediately)
+{
+    SyntheticChain chain(50);
+    rp::BulkBlockScheduler s;
+    rp::BulkBlockScheduler::Config cfg;
+    cfg.batch = 4;
+    cfg.request_timeout_sec = 30;
+    s.configure(cfg);
+    s.reset(0);
+    s.set_target_end(7);
+
+    auto plan = s.pump(1000, {"a", "b"},
+                       [&](uint32_t h) { return chain.hash_at(h); }, 0);
+    ASSERT_EQ(plan.size(), 2u);
+    // Peer "a" churns out ONE second later — its requests must not wait out
+    // the 30 s timeout.
+    s.service(1001, {"b"});
+    EXPECT_EQ(s.retry_count(), 4u);
+    EXPECT_EQ(s.inflight_count(), 4u);   // b's requests untouched
+}
+
+// ═══ (C) in-order delivery + prune ════════════════════════════════════════
+
+TEST(DashReplayBulkLane, DeliversInOrderAndPrunes)
+{
+    rp::BulkFetchLane::Config cfg;
+    cfg.start_height = 10;
+    cfg.tip_exclusion = 12;
+    LaneRig rig(200, cfg);
+    rig.lane->scheduler().configure({/*window*/ 1000, /*per_peer*/ 64,
+                                     /*batch*/ 16, /*timeout*/ 30});
+
+    // Pump until every wanted height [10, 187] is requested, answering each
+    // round SHUFFLED — out-of-order arrival is the normal multi-peer case.
+    std::mt19937 rng(1234);
+    int64_t now = 1000;
+    for (int round = 0; round < 64; ++round)
+    {
+        rig.lane->tick(now++);
+        rig.answer_all(&rng);
+        if (rig.lane->delivered() == 187) break;
+    }
+
+    EXPECT_EQ(rig.lane->delivered(), 187u);            // tip(199) − exclusion(12)
+    EXPECT_EQ(rig.counter.blocks(), 187u - 10u + 1u);
+    EXPECT_FALSE(rig.counter.order_violated());        // strict in-order, no gaps
+    EXPECT_EQ(rig.counter.last_height(), 187u);
+    EXPECT_EQ(rig.lane->buffer_size(), 0u);            // PRUNED — nothing retained
+    EXPECT_FALSE(rig.lane->failed());
+    EXPECT_GT(rig.lane->total_bytes(), 0u);
+}
+
+TEST(DashReplayBulkLane, ConsumerRefusalFailsClosed)
+{
+    rp::BulkFetchLane::Config cfg;
+    cfg.start_height = 10;
+    cfg.tip_exclusion = 12;
+    LaneRig rig(100, cfg);
+    rig.counter.set_refuse_at(20);   // the W1-fold-refused stand-in
+
+    int64_t now = 1000;
+    for (int round = 0; round < 32 && !rig.lane->failed(); ++round)
+    {
+        rig.lane->tick(now++);
+        rig.answer_all();
+    }
+
+    EXPECT_TRUE(rig.lane->failed());
+    EXPECT_NE(rig.lane->fail_cause().find("consumer-refused"),
+              std::string::npos);
+    EXPECT_EQ(rig.counter.last_height(), 19u);   // delivered up to the refusal
+    // Failed lane issues no further requests.
+    rig.sent.clear();
+    rig.lane->tick(now + 100);
+    EXPECT_TRUE(rig.sent.empty());
+}
+
+// ═══ (D) body verification ════════════════════════════════════════════════
+
+TEST(DashReplayBulkLane, CorruptBodyRejectedAndRefetched)
+{
+    rp::BulkFetchLane::Config cfg;
+    cfg.start_height = 10;
+    cfg.tip_exclusion = 12;
+    LaneRig rig(100, cfg);
+    rig.lane->scheduler().configure({1000, 64, 16, 30});
+
+    rig.lane->tick(1000);
+    ASSERT_FALSE(rig.sent.empty());
+    // Answer the FIRST requested body with a TAMPERED tx set under the same
+    // header (same hash — the header is pinned; the body is not, until the
+    // merkle bind runs).
+    const uint256 victim = rig.sent[0].hashes[0];
+    const auto idx = static_cast<std::size_t>(std::distance(
+        rig.chain.hashes.begin(),
+        std::find(rig.chain.hashes.begin(), rig.chain.hashes.end(), victim)));
+    BlockType tampered = rig.chain.blocks[idx];
+    tampered.m_txs.push_back(tampered.m_txs[0]);   // duplicate-tx mutation
+
+    EXPECT_TRUE(rig.lane->on_block_body(victim, tampered));   // consumed…
+    EXPECT_EQ(rig.lane->corrupt_bodies(), 1u);                // …and rejected
+    EXPECT_EQ(rig.counter.blocks(), 0u);                      // never delivered
+    EXPECT_EQ(rig.lane->scheduler().rerequests(), 1u);        // refetch queued
+
+    // The honest body then arrives on the retry and delivery proceeds.
+    std::mt19937 rng(7);
+    int64_t now = 1001;
+    for (int round = 0; round < 64; ++round)
+    {
+        rig.lane->tick(now++);
+        rig.answer_all(&rng);
+        if (rig.lane->delivered() == 87) break;
+    }
+    EXPECT_EQ(rig.lane->delivered(), 87u);
+    EXPECT_FALSE(rig.counter.order_violated());
+    EXPECT_FALSE(rig.lane->failed());
+}
+
+TEST(DashReplayBulkLane, ForeignBodyFallsThroughToTipLane)
+{
+    rp::BulkFetchLane::Config cfg;
+    cfg.start_height = 10;
+    LaneRig rig(100, cfg);
+    rig.lane->tick(1000);
+    // A body the bulk lane never requested (the tip lane's) must NOT be
+    // consumed — false means the client fires full_block as before.
+    BlockType foreign;
+    foreign.m_version = 1;
+    foreign.m_nonce = 0xDEAD1234u;
+    MutableTransaction tx;
+    tx.locktime = 0xDEAD1234u;
+    foreign.m_txs.push_back(tx);
+    auto packed_tx = ::pack(foreign.m_txs[0]);
+    foreign.m_merkle_root = ::Hash(packed_tx.get_span());
+    const auto header = static_cast<BlockHeaderType>(foreign);
+    auto packed = ::pack(header);
+    const uint256 fhash = dash::crypto::hash_x11(packed.get_span());
+    EXPECT_FALSE(rig.lane->on_block_body(fhash, foreign));
+}
+
+// ═══ (E) tip priority ═════════════════════════════════════════════════════
+
+TEST(DashReplayBulkLane, TipBusyIssuesNoNewRequests)
+{
+    rp::BulkFetchLane::Config cfg;
+    cfg.start_height = 10;
+    LaneRig rig(100, cfg);
+
+    rig.tip_busy = true;
+    rig.lane->tick(1000);
+    EXPECT_TRUE(rig.sent.empty());   // STRICT priority: not one bulk getdata
+
+    rig.tip_busy = false;
+    rig.lane->tick(1001);
+    EXPECT_FALSE(rig.sent.empty());  // released — bulk resumes
+}
+
+// ═══ (F) resumability ═════════════════════════════════════════════════════
+
+TEST(DashReplayCursorStore, RoundTripAndGarbageRejection)
+{
+    const std::string path = temp_path("c2pool-replay-cursor-kat");
+    rp::ReplayCursorStore store(path);
+    EXPECT_FALSE(store.load().has_value());   // absent file: no cursor
+
+    rp::ReplayCursorStore::Cursor c;
+    c.height = 1234567;
+    c.hash.SetHex("00000000000000112233445566778899aabbccddeeff00112233445566778899");
+    ASSERT_TRUE(store.store(c));
+    auto back = store.load();
+    ASSERT_TRUE(back.has_value());
+    EXPECT_EQ(back->height, c.height);
+    EXPECT_EQ(back->hash, c.hash);
+
+    // Garbage / wrong version fails LOUD-ignore (nullopt), never a bogus cursor.
+    {
+        std::ofstream out(path, std::ios::trunc);
+        out << "c2pool-replay-cursor v9 1 deadbeef\n";
+    }
+    EXPECT_FALSE(store.load().has_value());
+    std::filesystem::remove(path);
+}
+
+TEST(DashReplayBulkLane, ResumesFromVerifiedCursor)
+{
+    const std::string path = temp_path("c2pool-replay-resume-kat");
+    SyntheticChain probe(100);
+    {
+        rp::ReplayCursorStore store(path);
+        rp::ReplayCursorStore::Cursor c;
+        c.height = 50;
+        c.hash = probe.hashes[50];
+        ASSERT_TRUE(store.store(c));
+    }
+    rp::ReplayCursorStore store(path);
+    rp::BulkFetchLane::Config cfg;
+    cfg.start_height = 10;
+    cfg.tip_exclusion = 12;
+    LaneRig rig(100, cfg, nullptr, &store);
+    // Same synthetic chain (seed-deterministic), so the cursor hash matches.
+    ASSERT_EQ(rig.chain.hashes[50], probe.hashes[50]);
+
+    EXPECT_EQ(rig.lane->delivered(), 50u);   // resumed, not restarted
+    rig.lane->tick(1000);
+    ASSERT_FALSE(rig.sent.empty());
+    // First fetched height is cursor+1 — nothing below is re-fetched.
+    uint32_t min_h = UINT32_MAX;
+    for (auto& b : rig.sent)
+        for (auto& h : b.hashes)
+        {
+            auto it = std::find(rig.chain.hashes.begin(),
+                                rig.chain.hashes.end(), h);
+            min_h = std::min<uint32_t>(min_h, static_cast<uint32_t>(
+                std::distance(rig.chain.hashes.begin(), it)));
+        }
+    EXPECT_EQ(min_h, 51u);
+    EXPECT_FALSE(rig.lane->failed());
+    std::filesystem::remove(path);
+}
+
+TEST(DashReplayBulkLane, CursorHashMismatchFailsClosed)
+{
+    const std::string path = temp_path("c2pool-replay-mismatch-kat");
+    {
+        rp::ReplayCursorStore store(path);
+        rp::ReplayCursorStore::Cursor c;
+        c.height = 50;
+        c.hash = uint256::ONE;   // NOT this chain's hash at 50
+        ASSERT_TRUE(store.store(c));
+    }
+    rp::ReplayCursorStore store(path);
+    rp::BulkFetchLane::Config cfg;
+    cfg.start_height = 10;
+    LaneRig rig(100, cfg, nullptr, &store);
+
+    rig.lane->tick(1000);
+    EXPECT_TRUE(rig.lane->failed());
+    EXPECT_NE(rig.lane->fail_cause().find("resume-cursor-hash-mismatch"),
+              std::string::npos);
+    EXPECT_TRUE(rig.sent.empty());   // refused before ONE body was requested
+    std::filesystem::remove(path);
+}
+
+// ═══ (G) header backfill ══════════════════════════════════════════════════
+
+// Synthetic pre-anchor header chain: linkage is real, PoW checking is
+// disabled (check_pow=false — mining X11 in a unit test is not a thing; the
+// PoW predicate itself is pinned by the header-chain KATs).
+struct BackfillChain
+{
+    uint256 genesis;
+    std::vector<BlockType> headers;   // heights 1..N
+    std::vector<uint256> hashes;      // heights 0..N (0 = genesis)
+
+    explicit BackfillChain(uint32_t anchor_height, uint32_t salt = 0)
+    {
+        genesis.SetHex("000007deadbeef00112233445566778899aabbccddeeff001122334455667788");
+        // A salted chain diverges from genesis onward (distinct-chain rigs).
+        if (salt != 0)
+        {
+            unsigned char* gd = genesis.data();
+            gd[31] ^= static_cast<unsigned char>(salt);
+        }
+        hashes.push_back(genesis);
+        uint256 prev = genesis;
+        for (uint32_t h = 1; h <= anchor_height; ++h)
+        {
+            BlockType b;
+            b.m_version = 2;
+            b.m_previous_block = prev;
+            b.m_timestamp = 1400000000u + h;
+            b.m_bits = 0x1e0fffff;
+            b.m_nonce = h * 7u + salt;
+            const auto header = static_cast<BlockHeaderType>(b);
+            auto packed = ::pack(header);
+            const uint256 hash = dash::crypto::hash_x11(packed.get_span());
+            headers.push_back(b);
+            hashes.push_back(hash);
+            prev = hash;
+        }
+    }
+
+    std::vector<BlockType> batch(uint32_t from_height, uint32_t count) const
+    {
+        std::vector<BlockType> out;
+        for (uint32_t i = 0; i < count && (from_height - 1 + i) < headers.size(); ++i)
+            out.push_back(headers[from_height - 1 + i]);
+        return out;
+    }
+};
+
+TEST(DashReplayHeaderBackfill, WalksToAnchorAndJoins)
+{
+    const uint32_t ANCHOR = 25;
+    BackfillChain bc(ANCHOR);
+    uint256 pow_limit;
+    pow_limit.SetHex("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    rp::HeaderBackfill bf(bc.genesis, ANCHOR, bc.hashes[ANCHOR], pow_limit,
+                          /*db_path=*/"", /*check_pow=*/false);
+
+    EXPECT_FALSE(bf.complete());
+    EXPECT_EQ(bf.tip_height(), 0u);
+    // Pre-join, pre-anchor hashes are NOT an index (a walk in progress is not
+    // trustworthy) — only genesis is known.
+    EXPECT_FALSE(bf.hash_at(10).has_value());
+
+    // Batches in getheaders-sized chunks; claims() is the demux predicate.
+    auto b1 = bc.batch(1, 10);
+    EXPECT_TRUE(bf.claims(b1));
+    EXPECT_EQ(bf.add_headers(b1), 10);
+    EXPECT_EQ(bf.tip_height(), 10u);
+
+    // A batch that does NOT link (the tip lane's) is not claimed.
+    BackfillChain other(5, /*salt=*/0x5A);
+    EXPECT_FALSE(bf.claims(other.batch(1, 5)));
+
+    // Duplicate re-served batch: claimed (prev is in the recent window) but
+    // folds zero headers — no double-count, no corruption.
+    EXPECT_TRUE(bf.claims(b1));
+    EXPECT_EQ(bf.add_headers(b1), 0);
+    EXPECT_EQ(bf.tip_height(), 10u);
+
+    EXPECT_EQ(bf.add_headers(bc.batch(11, 100)), static_cast<int>(ANCHOR - 10));
+    EXPECT_TRUE(bf.complete());       // JOINED the anchor
+    EXPECT_FALSE(bf.failed());
+    // Post-join the whole pre-anchor index is served.
+    ASSERT_TRUE(bf.hash_at(10).has_value());
+    EXPECT_EQ(*bf.hash_at(10), bc.hashes[10]);
+    EXPECT_EQ(*bf.hash_at(ANCHOR), bc.hashes[ANCHOR]);
+    EXPECT_FALSE(bf.hash_at(ANCHOR + 1).has_value());
+    // A complete walk claims nothing further.
+    EXPECT_FALSE(bf.claims(b1));
+}
+
+TEST(DashReplayHeaderBackfill, AnchorJoinMismatchFailsClosed)
+{
+    const uint32_t ANCHOR = 12;
+    BackfillChain bc(ANCHOR);
+    uint256 pow_limit;
+    pow_limit.SetHex("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    // Anchor hash is NOT what this chain produces at the anchor height: the
+    // wrong-chain / hostile-peer case.
+    rp::HeaderBackfill bf(bc.genesis, ANCHOR, uint256::ONE, pow_limit,
+                          "", false);
+    bf.add_headers(bc.batch(1, ANCHOR));
+    EXPECT_TRUE(bf.failed());
+    EXPECT_FALSE(bf.complete());
+    EXPECT_NE(bf.fail_cause().find("anchor-join-mismatch"), std::string::npos);
+    // A failed walk serves NO index — the lane cannot fetch off it.
+    EXPECT_FALSE(bf.hash_at(5).has_value());
+}
+
+// ═══ (H) capture cache ════════════════════════════════════════════════════
+
+TEST(DashReplayBulkCapture, SegmentRoundTripAndTornTail)
+{
+    const std::string dir = temp_path("c2pool-replay-capture-kat");
+    SyntheticChain chain(4);
+    {
+        rp::BulkCaptureWriter w(dir);
+        ASSERT_FALSE(w.failed());
+        for (uint32_t h = 1; h < 4; ++h)
+        {
+            auto packed = ::pack(chain.blocks[h]);
+            std::vector<uint8_t> raw(
+                reinterpret_cast<const uint8_t*>(packed.data()),
+                reinterpret_cast<const uint8_t*>(packed.data()) + packed.size());
+            ASSERT_TRUE(w.append(h, chain.hashes[h], raw));
+        }
+        EXPECT_EQ(w.records(), 3u);
+    }
+    const std::string seg =
+        (std::filesystem::path(dir) / rp::BulkCaptureWriter::segment_name(0))
+            .string();
+    auto recs = rp::BulkCaptureWriter::read_segment(seg);
+    ASSERT_EQ(recs.size(), 3u);
+    for (uint32_t h = 1; h < 4; ++h)
+    {
+        EXPECT_EQ(recs[h - 1].height, h);
+        EXPECT_EQ(recs[h - 1].hash, chain.hashes[h]);
+        // Byte-exact body round trip: re-fold input == fetched input.
+        auto packed = ::pack(chain.blocks[h]);
+        ASSERT_EQ(recs[h - 1].bytes.size(), packed.size());
+        EXPECT_EQ(0, std::memcmp(recs[h - 1].bytes.data(), packed.data(),
+                                 packed.size()));
+    }
+
+    // Torn tail (crash mid-append): truncate the last record's payload — the
+    // reader returns the intact prefix, never garbage.
+    {
+        const auto full = std::filesystem::file_size(seg);
+        std::filesystem::resize_file(seg, full - 5);
+    }
+    auto truncated = rp::BulkCaptureWriter::read_segment(seg);
+    EXPECT_EQ(truncated.size(), 2u);
+
+    std::filesystem::remove_all(dir);
+}
+
+TEST(DashReplayBulkLane, CaptureConsumerDecoratesWithoutChangingDelivery)
+{
+    const std::string dir = temp_path("c2pool-replay-capture-lane-kat");
+    rp::BulkFetchLane::Config cfg;
+    cfg.start_height = 10;
+    cfg.tip_exclusion = 12;
+
+    rp::CountingReplayConsumer inner;
+    rp::CaptureReplayConsumer capture(dir, &inner);
+    LaneRig rig(60, cfg, nullptr, nullptr, &capture);
+
+    std::mt19937 rng(99);
+    int64_t now = 1000;
+    for (int round = 0; round < 32; ++round)
+    {
+        rig.lane->tick(now++);
+        rig.answer_all(&rng);
+        if (rig.lane->delivered() == 47) break;
+    }
+    EXPECT_EQ(rig.lane->delivered(), 47u);
+    EXPECT_EQ(inner.blocks(), 47u - 10u + 1u);      // inner verdict untouched
+    EXPECT_FALSE(inner.order_violated());
+    EXPECT_EQ(capture.writer().records(), inner.blocks());   // every body cached
+
+    std::filesystem::remove_all(dir);
+}
+
+} // namespace


### PR DESCRIPTION
## W2 — multi-peer archival BULK block-fetch lane (full-history replay)

Work package **W2** of `DASH_FULL_HISTORY_REPLAY_MODE.md` (§4.1 scope, §4.3 cost model, §6 WP table): the transport that feeds the W1 fold. **Feature-flagged (`--replay-bulk`), OBSERVE-only, default OFF — no serve-path changes.** DASH lane only.

### What it does

The current `MSG_BLOCK` path is tip-oriented (tracked getdata, `PENDING_BODY_CAP = 8`, primary/announcer-routed) — right for the live edge, wrong for a 1.49M-block, 30–40 GB historical stream. This adds `src/impl/dash/coin/replay_bulk_fetch.hpp`:

1. **Full-genesis header index** — `HeaderBackfill` extends the 2400000 fast-start to genesis: forward walk from the known genesis hash, X11-PoW + prev-linkage per header, and a **JOIN CHECK**: the walk must produce exactly the fast-start anchor hash at the anchor height, which prev-hash-pins the entire pre-anchor segment down to genesis (spec §4.2 layer 2). Join mismatch ⇒ fail-closed, loud; the lane refuses to fetch a single body off an unpinned index. Chunked LevelDB persistence (restart reloads ~240 values, not 2.4M headers).
2. **Bulk body pipeline** — `BulkBlockScheduler` (pure, KAT-driven) range-partitions the span into contiguous per-peer batches across the 8-peer pool, caps per-peer in-flight, bounds total work-ahead (default 2000 blocks), and re-requests on **timeout / notfound / peer loss**, rotating away from the peer that failed.
3. **fetch → verify → hand-to-consumer → PRUNE** — every body is accepted only if X11(its header) equals the scheduled (PoW-pinned) hash **and** its tx set folds to the header's committed merkle root (`block_body_binds_to_header`, CVE-2012-2459-guarded). Verified bodies go to `IReplayBlockConsumer` **strictly in height order, no gaps** and are pruned immediately — bodies are never persisted. W2 ships the interface + a counting stub; the W1 fold engine implements the same interface and replaces the stub (single seam).
4. **Resumability** — versioned high-water cursor file (atomic rename); on resume the stored hash is verified against the chain before one body is fetched; mismatch ⇒ `resume-cursor-hash-mismatch` fail-closed.
5. **Telemetry** — one `[BULK]` line per 30 s: `delivered/target`, `blk/s`, `MB/s`, per-peer split, in-flight/buffer/retry, backfill progress, re-request/notfound/corrupt counters.
6. **Capture utility** — `--replay-bulk-capture DIR` (implies `--replay-bulk`) additionally appends raw bodies into 10k-block segment files (torn-tail-safe framing) so fleet hosts can re-fold tests without re-pulling 30–40 GB. A consumer decoration; capture failure never gates the fold.

### Tip lane is strictly prioritized (never starved)

* The **primary** peer is excluded from bulk while any other handshaked peer exists (it carries every stateful request/response leg).
* **No new bulk getdata while a tracked tip body is outstanding** (`pending_body_count() > 0`); in-flight bulk merely completes.
* Bulk stays `tip_exclusion` (12) blocks behind the header tip — the live edge belongs to the tip lane.
* Per-peer in-flight caps keep every socket's reply backlog short.

### CoinClient changes (feature-inert)

Three null-by-default seams — a headers demux filter (backfill batches must not reach the fast-started `HeaderChain` as orphan noise), a block-body demux filter (bulk bodies must not enter the tip-rate `full_block` ingest; the filter claims only hashes the bulk scheduler itself requested, so a tip body can never be swallowed), a block-notfound callback — plus named-peer sends (`send_getheaders_to`, `request_blocks_from`) and peer-key accessors. With `--replay-bulk` absent, none is registered and the client is behavior-identical.

### Tests

17 KATs (`test/test_dash_replay_bulk_fetch.cpp`, folded into the already-allowlisted `test_dash_p2p_node` target — no workflow edit, drift-guard green): range partitioning, window bound, timeout/notfound/peer-loss re-request with peer rotation, in-order deliver+prune, consumer-refusal fail-closed, merkle-bind rejection + refetch, foreign-body fall-through, tip-busy starvation guard, cursor round-trip/garbage/verified-resume/mismatch-fail-closed, backfill walk+join / join-mismatch / claims demux / duplicate-batch, capture segment round-trip + torn-tail truncation. Full `test_dash_p2p_node` suite: **111/111 green** locally; `c2pool-dash` builds and renders the new flags.

### Live smoke (not unit-testable; soak item)

What KATs cannot pin without mainnet, to be read off a fleet host (not the hotel):

```
c2pool-dash --run --testnet=OFF --coin-p2p-discover --coin-p2p-peers 8 \
    --replay-bulk [--replay-bulk-capture /tank/dash-bodies]
```

* backfill: `[BULK] header backfill: N/2400000 (…%)` climbing, ending in `header backfill COMPLETE … JOINED the fast-start anchor` (~200 MB, minutes-class on X11);
* throughput: `[BULK] … rate=… blk/s … MB/s peers[…]` with the split spread across ≥2 non-primary peers (spec §4.3 expects 1–4 MB/s aggregate ⇒ ~3–11 h for the body stream);
* priority: `POOL-STATUS … pending_bodies>0` intervals must show no interleaved bulk getdata bursts, and tip-follow `block received` latency unchanged vs a control node;
* NODE_NETWORK coverage: peers answering deep heights without `notfound` floods (archival peers; pruned peers will show in the `notfound=` counter and rotate out naturally);
* restart mid-stream: `resume cursor VERIFIED at height H — resuming fetch from H+1`.

### Flags

`--replay-bulk` · `--replay-bulk-capture DIR` · `--replay-bulk-start H` (default mainnet DIP3 1028160). Needs `--coin-p2p-connect`/`--coin-p2p-discover`; without a coin-P2P client the lane names the unmet dependency and does not arm.

**do-not-merge:** W2 lands behind the W1 fold review; this PR is the transport slice only (counting-stub consumer), staged for the replay lane assembly.
