### PR TITLE
dash(creditpool): subtract type-9 AssetUnlockTx payload.fee from the pool (P0, mainnet 2166498 KAT)

### DIFF
--- a/src/impl/dash/coin/credit_pool.hpp
+++ b/src/impl/dash/coin/credit_pool.hpp
@@ -11,11 +11,19 @@
 ///     - Type 8 (TRANSACTION_ASSET_LOCK):
 ///         pool += sum(payload.creditOutputs.value)
 ///     - Type 9 (TRANSACTION_ASSET_UNLOCK):
-///         pool -= sum(tx.vout.value)   // gross withdrawal; the
-///                                      // payload.fee is paid to the
-///                                      // miner from the unlock total
-///                                      // and does NOT come back into
-///                                      // the pool
+///         pool -= payload.fee + sum(tx.vout.value)
+///                                      // dashd unlocks the GROSS amount:
+///                                      // the withdrawal vouts PLUS the
+///                                      // payload.fee. The fee is paid to
+///                                      // the miner via the coinbase, but
+///                                      // it still LEAVES the pool, so it
+///                                      // is part of the deduction.
+///                                      // Verified against mainnet
+///                                      // 2,166,498 (4 unlocks, fee=190
+///                                      // each): cbTx creditPoolBalance
+///                                      // steps by −(Σvout + Σfee), not
+///                                      // −Σvout. See the KAT in
+///                                      // test_dash_coin_state_maintainer.
 ///
 /// Bootstrap: seed from the first observed CCbTx.creditPoolBalance
 /// before applying any deltas (similar pattern to MnStateMachine
@@ -77,19 +85,32 @@ public:
                 }
                 // parse failures already log; skip the tx for accounting
             } else if (tx.type == vendor::CAssetUnlockPayload::SPECIALTX_TYPE) {
-                // For unlocks, the deduction is sum of vout values
-                // (gross withdrawal). Payload parse is informational —
-                // not strictly required for the balance math, but we
-                // do it to keep the [ASSETUNLOCK] log consistent and
-                // catch wire-format drift early.
+                // For unlocks, the deduction is payload.fee + sum of vout
+                // values: dashd's DiffFromBlock removes the GROSS unlock
+                // amount from the pool — the withdrawal vouts plus the
+                // miner fee carried in the payload (the fee reaches the
+                // miner through the coinbase, not back into the pool).
+                // The payload parse is therefore REQUIRED for the balance
+                // math, not just diagnostics: without the fee term the
+                // running balance drifts by Σfee at every unlock block
+                // (mainnet 2,166,498 KAT: 4 unlocks × fee 190 = 760).
                 int64_t out_sum = 0;
                 for (const auto& v : tx.vout) out_sum += v.value;
                 delta -= out_sum;
                 ++unlocks;
-                // Optional payload parse for diagnostics.
-                if (!tx.extra_payload.empty()) {
-                    vendor::CAssetUnlockPayload up;
-                    vendor::parse_assetunlock_payload(tx.extra_payload, up);
+                vendor::CAssetUnlockPayload up;
+                if (!tx.extra_payload.empty()
+                    && vendor::parse_assetunlock_payload(tx.extra_payload, up)) {
+                    delta -= static_cast<int64_t>(up.fee);
+                } else {
+                    // Fee unknown → our balance will run HIGH by that fee.
+                    // Log loudly; the maintainer's per-block cross-check
+                    // against the cbTx-committed balance (ACCRUAL DRIFT,
+                    // fail-closed re-seed) is the backstop.
+                    LOG_WARNING << "[CREDITPOOL] h=" << height
+                                << " type-9 unlock payload unparseable — "
+                                   "fee term missing from delta (balance "
+                                   "may drift high until re-seed)";
                 }
             }
         }

--- a/src/impl/dash/coin/vendor/assetlock.hpp
+++ b/src/impl/dash/coin/vendor/assetlock.hpp
@@ -17,12 +17,17 @@
 //                         Mints UTXO from the credit pool. The tx has
 //                         NO regular inputs (treasury-class spend
 //                         secured by the LLMQ signature in payload).
-//                         Pool balance changes by -sum(tx.vouts.value).
+//                         Pool balance changes by
+//                         -(payload.fee + sum(tx.vouts.value)).
 //                         (The 'fee' field in the payload is the
 //                         miner fee deducted from the unlock total —
-//                         it goes to the miner's coinbase, NOT into
-//                         the credit pool, so it doesn't appear in
-//                         the credit-pool delta.)
+//                         it goes to the miner's coinbase, not back
+//                         into the pool, so it IS part of the amount
+//                         that leaves the pool and MUST be included
+//                         in the credit-pool delta. Verified against
+//                         mainnet block 2,166,498: the committed
+//                         cbTx creditPoolBalance steps by
+//                         −(Σvout + Σfee).)
 //
 // Adaptations from upstream:
 //   1. CBLSSignature (96-byte BLS sig) → std::array<uint8_t, 96>.

--- a/test/test_dash_coin_state_maintainer.cpp
+++ b/test/test_dash_coin_state_maintainer.cpp
@@ -1706,3 +1706,126 @@ TEST(DashCoinStateMaintainer, BodyFirstSnapshotPromotionFiresStateDirty) {
     EXPECT_GT(dirty, dirty_before)
         << "snapshot promotion must fire the re-issue sink (bump + notify)";
 }
+
+// ════════════════════════════════════════════════════════════════════════
+// DIP-0027 asset-unlock FEE term — KAT from real mainnet block 2,166,498.
+//
+// dashd (evo/creditpool.cpp) removes the GROSS unlock amount from the credit
+// pool for every type-9 tx: payload.fee + Σ(tx.vout.value). The fee reaches
+// the miner through the coinbase, but it still LEAVES the pool. An accrual
+// that subtracts only Σvout runs HIGH by Σfee at every unlock block, so the
+// per-block cross-check against the committed cbTx creditPoolBalance trips
+// ACCRUAL DRIFT (fail-closed: freshness seed not advanced) at each of the
+// ~5k historical unlock blocks — and an embedded template built from the
+// drifted balance commits a wrong cbTx creditPool field (bad-cbtx class).
+//
+// Known answers, re-verified against a mainnet dashd (dash-cli getblock ×2,
+// 2026-08-05):
+//   cbTx(2,166,497).creditPoolBalance = 1,366,727,881,775
+//   block 2,166,498: 4 type-9 unlocks (indexes 156..159), each fee = 190;
+//                    Σvout = 100e6 + 100e6 + 1000e6 + 100e6 = 1,300,000,000
+//   platform reward at 2,166,498 (mainnet MN_RR active)   =    53,617,393
+//   cbTx(2,166,498).creditPoolBalance = 1,365,481,498,408
+//     = 1,366,727,881,775 + 53,617,393 − 1,300,000,000 − 760
+// Omitting the fee computes 1,365,481,499,168 — exactly 760 high.
+// ════════════════════════════════════════════════════════════════════════
+
+static std::vector<unsigned char> encode_unlock_payload(
+    const dash::coin::vendor::CAssetUnlockPayload& p)
+{
+    auto stream = ::pack(p);
+    auto sp = stream.get_span();
+    return std::vector<unsigned char>(
+        reinterpret_cast<const unsigned char*>(sp.data()),
+        reinterpret_cast<const unsigned char*>(sp.data()) + sp.size());
+}
+
+// A structurally-real type-9 asset-unlock tx: no vin (credit-pool mint),
+// withdrawal vout, and a well-formed CAssetUnlockPayload carrying the fee.
+static MutableTransaction make_asset_unlock(uint64_t index, uint32_t fee,
+                                            uint32_t requested_height,
+                                            int64_t out_value, uint8_t salt)
+{
+    MutableTransaction tx;
+    tx.version  = 3;
+    tx.type     = dash::coin::vendor::CAssetUnlockPayload::SPECIALTX_TYPE;
+    tx.locktime = 0;
+    TxOut o;
+    o.value = out_value;
+    o.scriptPubKey.m_data = p2pkh_script(salt);
+    tx.vout.push_back(o);
+    dash::coin::vendor::CAssetUnlockPayload p;
+    p.nVersion        = dash::coin::vendor::CAssetUnlockPayload::CURRENT_VERSION;
+    p.index           = index;
+    p.fee             = fee;
+    p.requestedHeight = requested_height;
+    p.quorumHash      = raw256(salt);   // structural only — not verified here
+    tx.extra_payload  = encode_unlock_payload(p);
+    return tx;
+}
+
+// The four unlocks of mainnet 2,166,498, appended to a type-5 CbTx coinbase
+// committing `committed_balance` at the block's own height.
+static BlockType make_unlock_block_2166498(int64_t committed_balance)
+{
+    BlockType blk = make_cbtx_block(2'166'498u, committed_balance,
+                                    p2pkh_script(0x30));
+    blk.m_txs.push_back(make_asset_unlock(156, 190, 2'166'497u,
+                                          1'000'000'000LL, 0x10));
+    blk.m_txs.push_back(make_asset_unlock(157, 190, 2'166'497u,
+                                          100'000'000LL, 0x20));
+    blk.m_txs.push_back(make_asset_unlock(158, 190, 2'166'497u,
+                                          100'000'000LL, 0x21));
+    blk.m_txs.push_back(make_asset_unlock(159, 190, 2'166'497u,
+                                          100'000'000LL, 0x22));
+    bind_block(blk);   // re-bind: the tx set changed after make_cbtx_block
+    return blk;
+}
+
+// Pure state-machine KAT. FAILS-ON-MASTER: apply_block subtracted only Σvout,
+// yielding 1,365,481,499,168 (760 high) instead of the committed
+// 1,365,481,498,408.
+TEST(DashCreditPool, MainnetBlock2166498UnlockFeeKAT) {
+    // Independent pin of the platform-reward term used below (mainnet MN_RR).
+    const int64_t reward =
+        dash::coin::compute_dash_platform_reward_post_v20_mn_rr(2'166'498u);
+    ASSERT_EQ(reward, 53'617'393LL);
+
+    dash::coin::CreditPool sm;
+    sm.seed(1'366'727'881'775LL, 2'166'497u);
+
+    auto blk = make_unlock_block_2166498(1'365'481'498'408LL);
+    auto delta = sm.apply_block(blk, 2'166'498u, reward);
+    ASSERT_TRUE(delta.has_value());
+    EXPECT_EQ(*delta, 53'617'393LL - 1'300'000'000LL - 760LL)
+        << "unlock delta must be −(Σvout + Σfee) + platform reward";
+    EXPECT_EQ(sm.balance(), 1'365'481'498'408LL)
+        << "credit-pool balance must match the committed cbTx value "
+           "(off-by-Σfee = the omitted payload.fee term)";
+    EXPECT_EQ(sm.height(), 2'166'498u);
+}
+
+// Maintainer wire-path KAT: a CONTIGUOUS advance through the real unlock
+// block must verify against the committed balance and advance the freshness
+// seed. FAILS-ON-MASTER: the fee-less accrual disagreed with the wire value,
+// tripping ACCRUAL DRIFT — fail-closed, seed held at 2,166,497.
+TEST(DashCoinStateMaintainer, UnlockBlockContiguousAdvanceNoAccrualDrift) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+
+    // Cold bootstrap at 2,166,497 off the block's own committed balance.
+    m.on_block_connected(make_cbtx_block(2'166'497u, 1'366'727'881'775LL,
+                                         p2pkh_script(0x30)),
+                         2'166'497u);
+    ASSERT_EQ(st.credit_pool_height(), 2'166'497);
+    ASSERT_EQ(st.credit_pool(), 1'366'727'881'775LL);
+
+    // Contiguous next block: the independent accrual (platform reward
+    // + Σlocks − Σunlocks-incl-fee) must equal the committed balance.
+    m.on_block_connected(make_unlock_block_2166498(1'365'481'498'408LL),
+                         2'166'498u);
+    EXPECT_EQ(st.credit_pool_height(), 2'166'498)
+        << "ACCRUAL DRIFT fired on a correct block: the unlock fee term is "
+           "missing from the credit-pool delta";
+    EXPECT_EQ(st.credit_pool(), 1'365'481'498'408LL);
+}


### PR DESCRIPTION
## P0 fix: type-9 AssetUnlockTx `payload.fee` omitted from the DIP-0027 credit-pool accrual

**Found by the replay-sizing research on current `master`** — a real bug in shipped code, not a hypothetical.

### The bug
`CreditPool::apply_block` (`src/impl/dash/coin/credit_pool.hpp`) deducted only `Σ(tx.vout.value)` for each type-9 asset-unlock, **omitting `payload.fee`**. dashd's `evo/creditpool.cpp` `DiffFromBlock` removes the **gross** unlock amount from the pool — the withdrawal vouts **plus** the miner fee. The fee reaches the miner through the coinbase, not back into the pool, so it still *leaves* the pool and is part of the deduction. The old comments (here and in `vendor/assetlock.hpp`) explicitly — and wrongly — claimed the fee does not appear in the delta.

### Impact
- Our `creditPoolBalance` ran **high by `Σfee`** at every unlock block — **5,082 such blocks historically**.
- The maintainer's per-block cross-check against the committed `cbTx.creditPoolBalance` then trips **ACCRUAL DRIFT** and fails closed (freshness seed not advanced), demoting to the dashd fallback at each unlock event.
- Any embedded template built from the drifted balance commits a **wrong `cbTx` creditPool field** → the **bad-cbtx rejection class** on embedded templates after unlock events.

### Fix
- `credit_pool.hpp`: `delta -= payload.fee` in addition to `Σvout`. The payload parse is now **required** for the balance math (was diagnostics-only), with a loud warning + fail-closed backstop if a type-9 payload is unparseable.
- Corrected the misleading comments in `credit_pool.hpp` and `vendor/assetlock.hpp`.

### KAT — real mainnet block 2,166,498 (verified against a mainnet dash-cli, 2 `getblock` calls)
4 type-9 unlocks (indexes 156–159), each `fee = 190`:

```
prev  (cbTx 2,166,497) = 1,366,727,881,775
  + platform reward    =        53,617,393   (mainnet MN_RR active)
  − Σvout              =     1,300,000,000   (1000e6 + 100e6 + 100e6 + 100e6)
  − Σfee               =               760   (4 × 190)  ← the omitted term
  = committed balance  = 1,365,481,498,408   == cbTx(2,166,498).creditPoolBalance
```

Master computes `1,365,481,499,168` — exactly **760 high**. Two new KATs in `test_dash_coin_state_maintainer.cpp` (allowlisted DASH target, `check_test_target_allowlist.py` passes) — the pure state-machine `DashCreditPool.MainnetBlock2166498UnlockFeeKAT` and the maintainer contiguous-advance `DashCoinStateMaintainer.UnlockBlockContiguousAdvanceNoAccrualDrift` — both **fail on master, pass with the fix** (verified locally: stash the source fix → RED, restore → GREEN).

### Scope
DASH-lane only. No other creditPool arithmetic path carries the same omission (the maintainer/emit paths route through `apply_block`; the mempool type-9 fee path at `mempool.hpp` prices the miner fee correctly and is unrelated to the pool deduction).

Labeled `do-not-merge` — integrator merges only after gate/re-soak.
