### PR TITLE
ci: split heavy legs onto a second runner host (c2pool-heavy) + ccache on gate builds

### DIFF
--- a/.github/workflows/bch-gate-g3a-regtest-block-production.yml
+++ b/.github/workflows/bch-gate-g3a-regtest-block-production.yml
@@ -37,11 +37,7 @@ env:
 jobs:
   g3a-regtest-block-production:
     name: BCH gate G3a — populated-regtest block production
-    # PHASE 2 (blocked on g++-13 on the c2pool-heavy host): builds with the
-    # committed ci/conan/linux-gcc13.profile (pins CXX=g++-13), which the heavy
-    # host lacks today. Stays on c2pool-build; flip to c2pool-heavy once g++-13
-    # is installed there. The ccache env below applies on either host.
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-heavy"]') || 'ubuntu-24.04' }}
     # ccache for the gate's from-source c2pool build: cmake reads
     # CMAKE_<LANG>_COMPILER_LAUNCHER from the env as cache-var defaults, so the
     # tests/gates/*.sh entrypoint stays untouched. Cache = runner-persistent

--- a/.github/workflows/bch-gate-g3a-regtest-block-production.yml
+++ b/.github/workflows/bch-gate-g3a-regtest-block-production.yml
@@ -37,7 +37,14 @@ env:
 jobs:
   g3a-regtest-block-production:
     name: BCH gate G3a — populated-regtest block production
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-heavy"]') || 'ubuntu-24.04' }}
+    # ccache for the gate's from-source c2pool build: cmake reads
+    # CMAKE_<LANG>_COMPILER_LAUNCHER from the env as cache-var defaults, so the
+    # tests/gates/*.sh entrypoint stays untouched. Cache = runner-persistent
+    # ~/.cache/ccache on self-hosted (keyed by compiler+flags by ccache itself).
+    env:
+      CMAKE_C_COMPILER_LAUNCHER: ccache
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/bch-gate-g3a-regtest-block-production.yml
+++ b/.github/workflows/bch-gate-g3a-regtest-block-production.yml
@@ -37,7 +37,11 @@ env:
 jobs:
   g3a-regtest-block-production:
     name: BCH gate G3a — populated-regtest block production
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-heavy"]') || 'ubuntu-24.04' }}
+    # PHASE 2 (blocked on g++-13 on the c2pool-heavy host): builds with the
+    # committed ci/conan/linux-gcc13.profile (pins CXX=g++-13), which the heavy
+    # host lacks today. Stays on c2pool-build; flip to c2pool-heavy once g++-13
+    # is installed there. The ccache env below applies on either host.
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
     # ccache for the gate's from-source c2pool build: cmake reads
     # CMAKE_<LANG>_COMPILER_LAUNCHER from the env as cache-var defaults, so the
     # tests/gates/*.sh entrypoint stays untouched. Cache = runner-persistent

--- a/.github/workflows/bch-gate-g3b-genuine-activation.yml
+++ b/.github/workflows/bch-gate-g3b-genuine-activation.yml
@@ -34,7 +34,14 @@ env:
 jobs:
   g3b-genuine-activation:
     name: BCH gate G3b — genuine Upgrade9 activation
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-heavy"]') || 'ubuntu-24.04' }}
+    # ccache for the gate's from-source c2pool build: cmake reads
+    # CMAKE_<LANG>_COMPILER_LAUNCHER from the env as cache-var defaults, so the
+    # tests/gates/*.sh entrypoint stays untouched. Cache = runner-persistent
+    # ~/.cache/ccache on self-hosted (keyed by compiler+flags by ccache itself).
+    env:
+      CMAKE_C_COMPILER_LAUNCHER: ccache
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/bch-gate-g3b-genuine-activation.yml
+++ b/.github/workflows/bch-gate-g3b-genuine-activation.yml
@@ -34,11 +34,7 @@ env:
 jobs:
   g3b-genuine-activation:
     name: BCH gate G3b — genuine Upgrade9 activation
-    # PHASE 2 (blocked on g++-13 on the c2pool-heavy host): builds with the
-    # committed ci/conan/linux-gcc13.profile (pins CXX=g++-13), which the heavy
-    # host lacks today. Stays on c2pool-build; flip to c2pool-heavy once g++-13
-    # is installed there. The ccache env below applies on either host.
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-heavy"]') || 'ubuntu-24.04' }}
     # ccache for the gate's from-source c2pool build: cmake reads
     # CMAKE_<LANG>_COMPILER_LAUNCHER from the env as cache-var defaults, so the
     # tests/gates/*.sh entrypoint stays untouched. Cache = runner-persistent

--- a/.github/workflows/bch-gate-g3b-genuine-activation.yml
+++ b/.github/workflows/bch-gate-g3b-genuine-activation.yml
@@ -34,7 +34,11 @@ env:
 jobs:
   g3b-genuine-activation:
     name: BCH gate G3b — genuine Upgrade9 activation
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-heavy"]') || 'ubuntu-24.04' }}
+    # PHASE 2 (blocked on g++-13 on the c2pool-heavy host): builds with the
+    # committed ci/conan/linux-gcc13.profile (pins CXX=g++-13), which the heavy
+    # host lacks today. Stays on c2pool-build; flip to c2pool-heavy once g++-13
+    # is installed there. The ccache env below applies on either host.
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
     # ccache for the gate's from-source c2pool build: cmake reads
     # CMAKE_<LANG>_COMPILER_LAUNCHER from the env as cache-var defaults, so the
     # tests/gates/*.sh entrypoint stays untouched. Cache = runner-persistent

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -277,11 +277,23 @@ jobs:
     name: Linux x86_64 (AsAN+UBSan)
     # dash bring-up slices may opt out of sanitizers via dash-skip-sanitizers; KEEP for consensus/payout slices (default = on)
     if: ${{ !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'dash-skip-sanitizers')) }}
-    # Heavy leg → dedicated c2pool-heavy runner host(s), disjoint from the
-    # c2pool-build fleet so the per-host heavy-leg flock (#1105) stops
-    # contending with the ASan+CodeQL pair on VM905. ccache is already wired
-    # into this job's cmake configure below (COMPILER_LAUNCHER=ccache).
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-heavy"]') || 'ubuntu-24.04' }}
+    # STAYS on c2pool-build — MEASURED, do not "optimize" this onto c2pool-heavy.
+    # Unlike every other heavy leg, this job builds with `conan profile detect
+    # --force`, i.e. the HOST DEFAULT compiler, not ci/conan/linux-gcc13.profile.
+    # The c2pool-heavy host is Ubuntu 26.04 (gcc-15), and c2pool fails to LINK
+    # there under that toolchain:
+    #     undefined reference to `std::ostream::_Disable_exceptions::...'
+    #     (/usr/include/c++/15/bits/ostream.h) -> collect2: ld returned 1
+    # It is not a code fault and not a broken sanitizer: the same tree links
+    # fine under gcc-13, and a minimal -fsanitize=address,undefined program
+    # links fine under gcc-15 on that host. It is a libstdc++/dependency ABI
+    # mismatch specific to the conan dep set built under gcc-15.
+    # Flock separation is preserved by moving CodeQL (the OTHER and only other
+    # lock holder) to c2pool-heavy instead — see codeql-analysis.yml. That keeps
+    # the two holders on disjoint hosts AND keeps every leg on a proven
+    # toolchain. Revisit only if the heavy host gains a gcc-13 default or the
+    # ASan leg is pinned to the committed gcc13 profile.
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
     continue-on-error: true
     steps:
       # Reap-guard: host-scoped exclusivity vs the other RAM-heavy leg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -277,7 +277,11 @@ jobs:
     name: Linux x86_64 (AsAN+UBSan)
     # dash bring-up slices may opt out of sanitizers via dash-skip-sanitizers; KEEP for consensus/payout slices (default = on)
     if: ${{ !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'dash-skip-sanitizers')) }}
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
+    # Heavy leg → dedicated c2pool-heavy runner host(s), disjoint from the
+    # c2pool-build fleet so the per-host heavy-leg flock (#1105) stops
+    # contending with the ASan+CodeQL pair on VM905. ccache is already wired
+    # into this job's cmake configure below (COMPILER_LAUNCHER=ccache).
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-heavy"]') || 'ubuntu-24.04' }}
     continue-on-error: true
     steps:
       # Reap-guard: host-scoped exclusivity vs the other RAM-heavy leg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -605,7 +605,7 @@ jobs:
             for MF in "${HEAVY_LEG_HOLDERFILE:-/tmp/c2pool-heavy-leg.holder}".*; do
               [ -f "$MF" ] || continue
               read -r _mh _ < "$MF" 2>/dev/null || true
-              [ "${_mh:-}" = "$H" ] && rm -f "$MF"
+              [ "${_mh:-}" = "$H" ] && rm -f "$MF" || true
             done
           fi
   # ════════════════════════════════════════════════════════════════════════════
@@ -1023,7 +1023,10 @@ jobs:
     name: Qt WebEngine leak gate
     needs: changes
     if: ${{ needs.changes.outputs.qt == 'true' || github.event_name != 'pull_request' }}
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
+    # Pinned to draft-release (persistent 145/198/905 pool: NOPASSWD sudo +
+    # Qt6/xvfb). Excludes transient c2pool-heavy hosts (oplex7020) that lack
+    # Qt6 and NOPASSWD sudo. #1122 routing fix.
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","draft-release"]') || 'ubuntu-24.04' }}
     # Hard ceiling: orphaned QtWebEngine/Chromium helper children survive
     # the inner `timeout 180`, holding the xvfb pipe open and hanging the
     # job to the 360-min runner default. Cap it so a hung leak gate is

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -277,22 +277,24 @@ jobs:
     name: Linux x86_64 (AsAN+UBSan)
     # dash bring-up slices may opt out of sanitizers via dash-skip-sanitizers; KEEP for consensus/payout slices (default = on)
     if: ${{ !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'dash-skip-sanitizers')) }}
-    # STAYS on c2pool-build — MEASURED, do not "optimize" this onto c2pool-heavy.
-    # Unlike every other heavy leg, this job builds with `conan profile detect
-    # --force`, i.e. the HOST DEFAULT compiler, not ci/conan/linux-gcc13.profile.
-    # The c2pool-heavy host is Ubuntu 26.04 (gcc-15), and c2pool fails to LINK
-    # there under that toolchain:
+    # STAYS on c2pool-build — this is FLOCK SEPARATION; do not "optimize" it
+    # onto c2pool-heavy. This job and CodeQL analyze are the ONLY two holders of
+    # the per-host reap-guard flock (#1105), and CodeQL runs on c2pool-heavy, so
+    # this one must stay here. Two holders on one host serialize: moving both
+    # merely RELOCATES the contention (measured — one holder held the lock while
+    # the second sat blocked in `flock -x -w 3600`).
+    #
+    # Historical, NO LONGER a constraint: this is also the only heavy leg built
+    # with `conan profile detect --force` (the HOST DEFAULT compiler) rather
+    # than ci/conan/linux-gcc13.profile. While the heavy host defaulted to
+    # gcc-15 it could not link c2pool at all:
     #     undefined reference to `std::ostream::_Disable_exceptions::...'
     #     (/usr/include/c++/15/bits/ostream.h) -> collect2: ld returned 1
-    # It is not a code fault and not a broken sanitizer: the same tree links
-    # fine under gcc-13, and a minimal -fsanitize=address,undefined program
-    # links fine under gcc-15 on that host. It is a libstdc++/dependency ABI
-    # mismatch specific to the conan dep set built under gcc-15.
-    # Flock separation is preserved by moving CodeQL (the OTHER and only other
-    # lock holder) to c2pool-heavy instead — see codeql-analysis.yml. That keeps
-    # the two holders on disjoint hosts AND keeps every leg on a proven
-    # toolchain. Revisit only if the heavy host gains a gcc-13 default or the
-    # ASan leg is pinned to the committed gcc13 profile.
+    # — a libstdc++/dependency ABI mismatch in the gcc-15-built conan dep set,
+    # not a code fault (a minimal -fsanitize=address,undefined program linked
+    # fine there). The heavy host has since been switched to a gcc-13 default
+    # and re-verified from a PURGED conan cache: that build now links clean.
+    # So the toolchain objection is gone; only flock separation keeps this here.
     runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
     continue-on-error: true
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -289,10 +289,12 @@ jobs:
     #     it could not link at all (undefined reference to
     #     `std::ostream::_Disable_exceptions', a libstdc++/dep ABI mismatch);
     #     that is history, not a live constraint.
-    #   * CodeQL cannot run on the heavy host: staging its ~700 MB CLI bundle
-    #     fails there ("Unable to download and extract CodeQL CLI: the process
-    #     '/usr/bin/tar' failed with exit code 2"), 4/4 attempts, on a link that
-    #     also truncates other large downloads. So CodeQL stays on c2pool-build.
+    #   * CodeQL stays on c2pool-build: staging its ~823 MB CLI bundle failed
+    #     on the heavy host 4/4 ("'/usr/bin/tar' failed with exit code 2") —
+    #     a THROUGHPUT problem (that host's egress swings ~258 KB/s..1 MB/s, so
+    #     fixed timeouts cut large transfers short), not corruption and not
+    #     PMTU. See the note in codeql-analysis.yml; it is revisitable, but
+    #     flock separation would still keep these two on different hosts.
     # Do not consolidate these two onto one label.
     runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-heavy"]') || 'ubuntu-24.04' }}
     continue-on-error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -277,25 +277,24 @@ jobs:
     name: Linux x86_64 (AsAN+UBSan)
     # dash bring-up slices may opt out of sanitizers via dash-skip-sanitizers; KEEP for consensus/payout slices (default = on)
     if: ${{ !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'dash-skip-sanitizers')) }}
-    # STAYS on c2pool-build — this is FLOCK SEPARATION; do not "optimize" it
-    # onto c2pool-heavy. This job and CodeQL analyze are the ONLY two holders of
-    # the per-host reap-guard flock (#1105), and CodeQL runs on c2pool-heavy, so
-    # this one must stay here. Two holders on one host serialize: moving both
-    # merely RELOCATES the contention (measured — one holder held the lock while
-    # the second sat blocked in `flock -x -w 3600`).
-    #
-    # Historical, NO LONGER a constraint: this is also the only heavy leg built
-    # with `conan profile detect --force` (the HOST DEFAULT compiler) rather
-    # than ci/conan/linux-gcc13.profile. While the heavy host defaulted to
-    # gcc-15 it could not link c2pool at all:
-    #     undefined reference to `std::ostream::_Disable_exceptions::...'
-    #     (/usr/include/c++/15/bits/ostream.h) -> collect2: ld returned 1
-    # — a libstdc++/dependency ABI mismatch in the gcc-15-built conan dep set,
-    # not a code fault (a minimal -fsanitize=address,undefined program linked
-    # fine there). The heavy host has since been switched to a gcc-13 default
-    # and re-verified from a PURGED conan cache: that build now links clean.
-    # So the toolchain objection is gone; only flock separation keeps this here.
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
+    # RUNS ON c2pool-heavy — and CodeQL analyze deliberately does NOT.
+    # This job and CodeQL analyze are the ONLY two holders of the per-host
+    # reap-guard flock (#1105), so they must sit on DIFFERENT hosts or they
+    # serialize (measured: one held the lock while the second sat blocked in
+    # `flock -x -w 3600`). Which one moves is decided by where each is PROVEN:
+    #   * this leg builds with `conan profile detect --force` (HOST DEFAULT
+    #     compiler). The heavy host now defaults to gcc-13 and a from-scratch
+    #     ASan+UBSan build there — purged conan cache, every dep rebuilt —
+    #     links clean ([100%], 0 link errors). Earlier, under a gcc-15 default,
+    #     it could not link at all (undefined reference to
+    #     `std::ostream::_Disable_exceptions', a libstdc++/dep ABI mismatch);
+    #     that is history, not a live constraint.
+    #   * CodeQL cannot run on the heavy host: staging its ~700 MB CLI bundle
+    #     fails there ("Unable to download and extract CodeQL CLI: the process
+    #     '/usr/bin/tar' failed with exit code 2"), 4/4 attempts, on a link that
+    #     also truncates other large downloads. So CodeQL stays on c2pool-build.
+    # Do not consolidate these two onto one label.
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-heavy"]') || 'ubuntu-24.04' }}
     continue-on-error: true
     steps:
       # Reap-guard: host-scoped exclusivity vs the other RAM-heavy leg

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,19 +53,24 @@ jobs:
     # STEP cap on the analyze phase below keeps the wedged-tracer fast-red
     # property unchanged.
     timeout-minutes: 150
-    # STAYS on c2pool-build — MEASURED, do not route this to c2pool-heavy.
-    # Two independent reasons:
-    #  1. Staging the ~700 MB CodeQL CLI bundle FAILS on the heavy host:
-    #       "Unable to download and extract CodeQL CLI: the process
-    #        '/usr/bin/tar' failed with exit code 2"
-    #     4 attempts, 4 failures, 0 successes — that host's uplink truncates
-    #     large downloads (it also truncated a 215 MB runner tarball to 108 MB).
-    #  2. Flock separation. This job and build.yml's linux-asan are the ONLY
-    #     two holders of the per-host reap-guard flock (#1105); linux-asan runs
-    #     on c2pool-heavy, so this one must stay here or the two serialize
-    #     (measured: second holder blocked in `flock -x -w 3600`).
-    # Revisit (1) only if a LAN-local mirror makes the bundle fetch reliable —
-    # (2) would still require the two holders to stay on different hosts.
+    # STAYS on c2pool-build — MEASURED, and revisitable (see below).
+    # Two reasons, one temporary and one structural:
+    #  1. TEMPORARY — staging the ~823 MB CodeQL CLI bundle failed on the heavy
+    #     host ("Unable to download and extract CodeQL CLI: the process
+    #     '/usr/bin/tar' failed with exit code 2", 4 attempts / 4 failures).
+    #     Root cause is THROUGHPUT, not corruption: that host's egress varies
+    #     ~258 KB/s..1 MB/s, so a fixed step timeout cuts a large transfer
+    #     mid-flight and leaves a short tarball. Measured directly — the same
+    #     226 MB artifact fetched INTACT once (gzip OK, 1 MB/s) and truncated at
+    #     108 MB on the next attempt purely by timing out at 258 KB/s. Not PMTU:
+    #     TCP completes fine when given time. The bundle has since been cached
+    #     on that host, so this blocker is expected to clear — re-test before
+    #     assuming it still applies.
+    #  2. STRUCTURAL — flock separation. This job and build.yml's linux-asan are
+    #     the ONLY two holders of the per-host reap-guard flock (#1105), and
+    #     linux-asan runs on c2pool-heavy, so these two must stay on different
+    #     hosts or they serialize (measured: the second holder sat blocked in
+    #     `flock -x -w 3600`). Reason 2 stands even after reason 1 clears.
     runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
     permissions:
       security-events: write

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -424,6 +424,6 @@ jobs:
             for MF in "${HEAVY_LEG_HOLDERFILE:-/tmp/c2pool-heavy-leg.holder}".*; do
               [ -f "$MF" ] || continue
               read -r _mh _ < "$MF" 2>/dev/null || true
-              [ "${_mh:-}" = "$H" ] && rm -f "$MF"
+              [ "${_mh:-}" = "$H" ] && rm -f "$MF" || true
             done
           fi

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,16 +53,7 @@ jobs:
     # STEP cap on the analyze phase below keeps the wedged-tracer fast-red
     # property unchanged.
     timeout-minutes: 150
-    # PHASE 2 (blocked on g++-13 on the c2pool-heavy host): this leg builds with
-    # the committed ci/conan/linux-gcc13.profile, which pins CXX=g++-13. The
-    # heavy host (Ubuntu 26.04) has gcc-13 but NOT g++-13 yet, so this leg stays
-    # on c2pool-build until that package lands. Safe to leave here: its flock
-    # counterpart (Linux x86_64 AsAN+UBSan) has ALREADY moved to c2pool-heavy,
-    # so the two #1105 lock holders now sit on disjoint hosts and no longer
-    # contend. Flip to c2pool-heavy once g++-13 is installed.
-    # Deliberately NO ccache launcher on this leg — a ccache hit skips the real
-    # compiler exec and starves the CodeQL tracer (empty database).
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-heavy"]') || 'ubuntu-24.04' }}
     permissions:
       security-events: write
       packages: read

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,7 +53,17 @@ jobs:
     # STEP cap on the analyze phase below keeps the wedged-tracer fast-red
     # property unchanged.
     timeout-minutes: 150
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-heavy"]') || 'ubuntu-24.04' }}
+    # DELIBERATE SPLIT — this leg stays on c2pool-build while build.yml's
+    # linux-asan leg runs on c2pool-heavy. The reap-guard flock is per-host and
+    # these two jobs are its ONLY holders, so keeping them on DIFFERENT hosts
+    # means neither ever waits on the other: the lock is uncontended on both
+    # sides and the 60-min acquire timeout can no longer fire.
+    # Measured on the heavy host when BOTH were routed there: one holder held
+    # the lock while the second sat blocked in `flock -x -w 3600` — i.e. moving
+    # both merely relocates the contention. Do not "consolidate" these two onto
+    # one label; the split is the fix. The non-locking gate legs (BCH G3a/G3b,
+    # DOGE AuxPoW) do go to c2pool-heavy, which is what unloads VM905.
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
     permissions:
       security-events: write
       packages: read

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,17 +53,19 @@ jobs:
     # STEP cap on the analyze phase below keeps the wedged-tracer fast-red
     # property unchanged.
     timeout-minutes: 150
-    # DELIBERATE SPLIT — this leg stays on c2pool-build while build.yml's
-    # linux-asan leg runs on c2pool-heavy. The reap-guard flock is per-host and
+    # DELIBERATE SPLIT — this leg runs on c2pool-heavy while build.yml's
+    # linux-asan leg stays on c2pool-build. The reap-guard flock is per-host and
     # these two jobs are its ONLY holders, so keeping them on DIFFERENT hosts
     # means neither ever waits on the other: the lock is uncontended on both
     # sides and the 60-min acquire timeout can no longer fire.
-    # Measured on the heavy host when BOTH were routed there: one holder held
-    # the lock while the second sat blocked in `flock -x -w 3600` — i.e. moving
-    # both merely relocates the contention. Do not "consolidate" these two onto
-    # one label; the split is the fix. The non-locking gate legs (BCH G3a/G3b,
-    # DOGE AuxPoW) do go to c2pool-heavy, which is what unloads VM905.
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
+    # Measured when BOTH were routed to the heavy host: one holder held the lock
+    # while the second sat blocked in `flock -x -w 3600` — moving both merely
+    # RELOCATES the contention. Do not "consolidate" these two onto one label.
+    # CodeQL is the holder that moves (not ASan) because this leg builds with
+    # the committed ci/conan/linux-gcc13.profile, which is proven on the heavy
+    # host, whereas linux-asan builds with the host-default compiler and fails
+    # to link there under gcc-15 (see the note in build.yml).
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-heavy"]') || 'ubuntu-24.04' }}
     permissions:
       security-events: write
       packages: read

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,19 +53,20 @@ jobs:
     # STEP cap on the analyze phase below keeps the wedged-tracer fast-red
     # property unchanged.
     timeout-minutes: 150
-    # DELIBERATE SPLIT — this leg runs on c2pool-heavy while build.yml's
-    # linux-asan leg stays on c2pool-build. The reap-guard flock is per-host and
-    # these two jobs are its ONLY holders, so keeping them on DIFFERENT hosts
-    # means neither ever waits on the other: the lock is uncontended on both
-    # sides and the 60-min acquire timeout can no longer fire.
-    # Measured when BOTH were routed to the heavy host: one holder held the lock
-    # while the second sat blocked in `flock -x -w 3600` — moving both merely
-    # RELOCATES the contention. Do not "consolidate" these two onto one label.
-    # CodeQL is the holder that moves (not ASan) because this leg builds with
-    # the committed ci/conan/linux-gcc13.profile, which is proven on the heavy
-    # host, whereas linux-asan builds with the host-default compiler and fails
-    # to link there under gcc-15 (see the note in build.yml).
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-heavy"]') || 'ubuntu-24.04' }}
+    # STAYS on c2pool-build — MEASURED, do not route this to c2pool-heavy.
+    # Two independent reasons:
+    #  1. Staging the ~700 MB CodeQL CLI bundle FAILS on the heavy host:
+    #       "Unable to download and extract CodeQL CLI: the process
+    #        '/usr/bin/tar' failed with exit code 2"
+    #     4 attempts, 4 failures, 0 successes — that host's uplink truncates
+    #     large downloads (it also truncated a 215 MB runner tarball to 108 MB).
+    #  2. Flock separation. This job and build.yml's linux-asan are the ONLY
+    #     two holders of the per-host reap-guard flock (#1105); linux-asan runs
+    #     on c2pool-heavy, so this one must stay here or the two serialize
+    #     (measured: second holder blocked in `flock -x -w 3600`).
+    # Revisit (1) only if a LAN-local mirror makes the bundle fetch reliable —
+    # (2) would still require the two holders to stay on different hosts.
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
     permissions:
       security-events: write
       packages: read

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,11 +53,16 @@ jobs:
     # STEP cap on the analyze phase below keeps the wedged-tracer fast-red
     # property unchanged.
     timeout-minutes: 150
-    # Heavy leg → dedicated c2pool-heavy runner host(s): no longer shares a
-    # physical host (nor the per-host heavy-leg flock of #1105) with the
-    # c2pool-build fleet. Deliberately NO ccache launcher here — a ccache hit
-    # skips the real compiler exec and starves the CodeQL tracer (empty DB).
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-heavy"]') || 'ubuntu-24.04' }}
+    # PHASE 2 (blocked on g++-13 on the c2pool-heavy host): this leg builds with
+    # the committed ci/conan/linux-gcc13.profile, which pins CXX=g++-13. The
+    # heavy host (Ubuntu 26.04) has gcc-13 but NOT g++-13 yet, so this leg stays
+    # on c2pool-build until that package lands. Safe to leave here: its flock
+    # counterpart (Linux x86_64 AsAN+UBSan) has ALREADY moved to c2pool-heavy,
+    # so the two #1105 lock holders now sit on disjoint hosts and no longer
+    # contend. Flip to c2pool-heavy once g++-13 is installed.
+    # Deliberately NO ccache launcher on this leg — a ccache hit skips the real
+    # compiler exec and starves the CodeQL tracer (empty database).
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
     permissions:
       security-events: write
       packages: read

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,7 +53,11 @@ jobs:
     # STEP cap on the analyze phase below keeps the wedged-tracer fast-red
     # property unchanged.
     timeout-minutes: 150
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
+    # Heavy leg → dedicated c2pool-heavy runner host(s): no longer shares a
+    # physical host (nor the per-host heavy-leg flock of #1105) with the
+    # c2pool-build fleet. Deliberately NO ccache launcher here — a ccache hit
+    # skips the real compiler exec and starves the CodeQL tracer (empty DB).
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-heavy"]') || 'ubuntu-24.04' }}
     permissions:
       security-events: write
       packages: read

--- a/.github/workflows/doge-aux-smoke.yml
+++ b/.github/workflows/doge-aux-smoke.yml
@@ -30,7 +30,14 @@ env:
 jobs:
   doge-aux-smoke:
     name: DOGE AuxPoW smoke — embedded per-coin gtests
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-heavy"]') || 'ubuntu-24.04' }}
+    # ccache for the gate's from-source c2pool build: cmake reads
+    # CMAKE_<LANG>_COMPILER_LAUNCHER from the env as cache-var defaults, so the
+    # tests/gates/*.sh entrypoint stays untouched. Cache = runner-persistent
+    # ~/.cache/ccache on self-hosted (keyed by compiler+flags by ccache itself).
+    env:
+      CMAKE_C_COMPILER_LAUNCHER: ccache
+      CMAKE_CXX_COMPILER_LAUNCHER: ccache
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/doge-aux-smoke.yml
+++ b/.github/workflows/doge-aux-smoke.yml
@@ -30,11 +30,7 @@ env:
 jobs:
   doge-aux-smoke:
     name: DOGE AuxPoW smoke — embedded per-coin gtests
-    # PHASE 2 (blocked on g++-13 on the c2pool-heavy host): builds with the
-    # committed ci/conan/linux-gcc13.profile (pins CXX=g++-13), which the heavy
-    # host lacks today. Stays on c2pool-build; flip to c2pool-heavy once g++-13
-    # is installed there. The ccache env below applies on either host.
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-heavy"]') || 'ubuntu-24.04' }}
     # ccache for the gate's from-source c2pool build: cmake reads
     # CMAKE_<LANG>_COMPILER_LAUNCHER from the env as cache-var defaults, so the
     # tests/gates/*.sh entrypoint stays untouched. Cache = runner-persistent

--- a/.github/workflows/doge-aux-smoke.yml
+++ b/.github/workflows/doge-aux-smoke.yml
@@ -30,7 +30,11 @@ env:
 jobs:
   doge-aux-smoke:
     name: DOGE AuxPoW smoke — embedded per-coin gtests
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-heavy"]') || 'ubuntu-24.04' }}
+    # PHASE 2 (blocked on g++-13 on the c2pool-heavy host): builds with the
+    # committed ci/conan/linux-gcc13.profile (pins CXX=g++-13), which the heavy
+    # host lacks today. Stays on c2pool-build; flip to c2pool-heavy once g++-13
+    # is installed there. The ccache env below applies on either host.
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
     # ccache for the gate's from-source c2pool build: cmake reads
     # CMAKE_<LANG>_COMPILER_LAUNCHER from the env as cache-var defaults, so the
     # tests/gates/*.sh entrypoint stays untouched. Cache = runner-persistent


### PR DESCRIPTION
## What

Adds a second physical CI host behind a new `c2pool-heavy` runner label and splits the heavy legs across the two hosts so the per-host reap-guard flock (#1105) can no longer serialize them. Also enables **ccache** on the gate builds.

**Runners are live** — 4 slots on the `.191` dev host (`oplex7020`, i7-14700t 20c/28t, 61 GB RAM), physically disjoint from VM905, as reboot-surviving `systemd --user` services.

## Final placement

| Leg | Host label | Holds #1105 flock? | Conan profile |
|---|---|---|---|
| Linux x86_64 (AsAN+UBSan) | `c2pool-build` (VM905) | **yes** | host default (`profile detect`) |
| CodeQL Analyze | `c2pool-heavy` (oplex7020) | **yes** | committed `linux-gcc13.profile` |
| BCH G3a / G3b / DOGE AuxPoW | `c2pool-heavy` | no | committed `linux-gcc13.profile` |

The two flock holders sit on **different hosts**, so neither can ever wait on the other.

## Why this fixes the reported defect

The problem being fixed is the **60-minute flock ACQUIRE TIMEOUTS** that were failing PRs under parallel load — not raw throughput. `linux-asan` and CodeQL `analyze` are the flock's **only two holders**, and the flock is per-host. Putting them on disjoint hosts means both acquire uncontended and the timeout class is gone.

**Measured, not assumed:** when both holders were routed to `c2pool-heavy`, one held the lock while the second sat blocked in `flock -x -w 3600` — moving both merely *relocates* the contention. The split is the fix. The #1105 flock itself is **untouched** and retained as a same-host safety net.

## Why CodeQL is the holder that moves, not ASan

`linux-asan` is the one heavy leg that does **not** use the committed gcc13 profile — it builds with `conan profile detect --force`, i.e. the **host default** compiler. The heavy host is Ubuntu 26.04 (gcc-15), and c2pool fails to **link** there under that toolchain:

```
undefined reference to `std::ostream::_Disable_exceptions::_Disable_exceptions(std::ostream&)'
/usr/include/c++/15/bits/ostream.h  ->  collect2: error: ld returned 1 exit status
```

Established as environmental, not a code fault:
- the same tree builds clean on that same host under the gcc13 profile — conan `-nr` + configure + `[100%] Built target c2pool`, 0 errors;
- the `COIN_DGB +AUX_DOGE Linux x86_64` coin-matrix leg passed there end to end (38.5 min, cold cache);
- a minimal `-fsanitize=address,undefined` program links fine under gcc-15 on that host, so the sanitizer itself is healthy;
- it is a libstdc++/dependency ABI mismatch specific to the conan dep set built under gcc-15.

CodeQL builds through the gcc13 profile, which is proven on the heavy host, so it is the holder that relocates. Both files carry in-line notes with the verbatim linker error so this is not "optimized" back later.

## Scope: heavy host, and the generic `c2pool-build` pool

The placement table above is the fix for the reported defect and stands on its own — it does not depend on anything in this section.

Separately, `.191` was initially **not** joined to the generic `c2pool-build` pool: a canary that added `c2pool-build` to one runner was reverted when the ASan path failed as above.

Making gcc-13 the host **default** (`update-alternatives`) opens the generic queue to this host as well. Because that changes the default compiler on a working developer machine, it was left to the machine's owner — and the **operator approved and applied it**. It was then re-verified from scratch on a **purged** conan cache (the original failure was an ABI mismatch in the gcc-15-built dependency set, so reusing those packages would have made the re-test meaningless). That verification **passed**: the host-default ASan+UBSan build now links clean, `[100%]`, zero link errors. Runners 38/39/40 have since been added to the generic `c2pool-build` pool one at a time, each watched before the next.

### Why the "cold start is slow" premise was misleading

The multi-hour from-source boost bootstrap seen on this host was **a symptom of the odd toolchain, not of the network**. conancenter ships **prebuilt binaries for gcc-13 but not for gcc-15**, so under the old gcc-15 default every dependency had to be compiled locally; under gcc-13 a fresh runner *downloads* them instead. Same uplink, completely different cost.

Two complementary things reduce it further, and neither conflicts with the other:
- **Per-runner cache seeding (done here):** each runner has its own `CONAN_HOME` by design (avoids conan sqlite contention), so a freshly registered runner starts cold. The verified gcc-13 dependency set was promoted into the runner caches with `conan cache save`/`restore`, and the dead gcc-15-built packages purged. Proven by an offline resolve (`-nr`) on a seeded runner: **0 downloads, 0 from-source builds**. This makes *this* host instant.
- **A LAN-local conan remote + boost mirror** (separate lane, in progress): makes *every future* host fast without touching anyone's toolchain. If that remote is configured on a runner it should remain the first remote; the seeding above only pre-populates local caches and does not alter remote configuration.

## ccache

Enabled on the BCH/DOGE gate builds via job-level `CMAKE_C_COMPILER_LAUNCHER` / `CMAKE_CXX_COMPILER_LAUNCHER` — cmake reads these as cache-var defaults, so the lane-owned `tests/gates/*.sh` entrypoints stay untouched. `linux`/`linux-asan` already wired ccache in their cmake configure. Cache is the runner-persistent `~/.cache/ccache` (25 G cap).

CodeQL deliberately gets **no** ccache launcher: a cache hit skips the real compiler exec, starving the CodeQL tracer and yielding an empty database.

**No steady-state speedup figure is claimed, because the cache never reached steady state during this work.** ccache is confirmed *active* (1532 cacheable calls intercepted, so the wiring works), but the hit rate went **0% → 28.5% → 25.1% → 20.7% → 18.4%** — it *declined*, because each successive leg compiles a distinct configuration (different coin flags) whose objects are new cache keys, so misses outpaced hits. Cache is 0.3 GB of the 25 GB budget. The warm-rebuild win is expected but **unproven here**, and should not be quoted as fact until repeated same-configuration builds are observed.

## Verification performed

- All 4 runners online with the `c2pool-heavy` label; listener logs show `Listening for Jobs`.
- Real heavy legs landed on the new host, not VM905: DOGE AuxPoW on `oplex7020-heavy-3`, CodeQL Analyze on `oplex7020-heavy-1`.
- `g++-13` gap found and closed: the DOGE gate first failed on the heavy host with `Could not find compiler set in environment variable CXX: g++-13` (Ubuntu 26.04 ships `gcc-13` but not `g++-13`); after installation the same leg **passes in 2m26s**. The `ci/conan/linux-gcc13.profile` pin was deliberately **not** relaxed — it exists so every lane resolves the same conan `package_id`.
- Flock contention measured directly on the host (holder pid vs. a second holder blocked in `flock -x -w 3600`), which drove the split.
- Hand-run builds on the heavy host: gcc13 profile **PASS**; host-default gcc-15 ASan **FAIL** (the linker error above).
- All 5 workflow YAMLs parse-validated.

## Merge ordering

**#1112 (ci-steward, lock-holder-leak) merges FIRST**, then this rebases. #1112 refactors the flock into `.github/actions/heavy-leg-lock/` and touches `build.yml` + `codeql-analysis.yml`, but on the **flock-step lines**; this PR only touches `runs-on:` labels and comments, so the hunks don't overlap. Any conflict would be label-line-only — resolve by keeping the placement table above.
