### PR TITLE
web(#942): honest node-role labels for relay-learned found blocks

### DIFF
--- a/src/core/test/CMakeLists.txt
+++ b/src/core/test/CMakeLists.txt
@@ -54,7 +54,7 @@ if (BUILD_TESTING AND (GTest_FOUND OR GTEST_FOUND))
     # carries a source KAT pinning the is_wire_advertisable() guard into all ten
     # per-coin getaddrs handlers. Same reasoning as above: FOLDED into the
     # EXISTING allowlisted core_test target, never a new add_executable.
-    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp core_merkle_branches_test.cpp version_gate_test.cpp filesystem_test.cpp web_server_submitblock_test.cpp web_server_current_payouts_test.cpp web_server_local_hashps_test.cpp known_txs_eviction_test.cpp tx_advertiser_test.cpp socket_write_queue_test.cpp known_txs_backing_test.cpp random_choice_guard_test.cpp p2p_message_stats_test.cpp netaddress_resolution_test.cpp)
+    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp core_merkle_branches_test.cpp version_gate_test.cpp filesystem_test.cpp web_server_submitblock_test.cpp web_server_current_payouts_test.cpp web_server_local_hashps_test.cpp web_server_relay_block_test.cpp known_txs_eviction_test.cpp tx_advertiser_test.cpp socket_write_queue_test.cpp known_txs_backing_test.cpp random_choice_guard_test.cpp p2p_message_stats_test.cpp netaddress_resolution_test.cpp)
     target_compile_definitions(core_test PRIVATE C2POOL_SRC_ROOT="${CMAKE_SOURCE_DIR}/src")
     target_link_libraries(core_test PRIVATE GTest::gtest_main core c2pool_merged_mining GTest::gtest)
     target_link_libraries(core_test PRIVATE c2pool_payout c2pool_hashrate ltc_coin)  # OBJECT-lib SCC direct-naming (#22/#39)

--- a/src/core/test/web_server_relay_block_test.cpp
+++ b/src/core/test/web_server_relay_block_test.cpp
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+#include <core/web_server.hpp>
+#include <core/uint256.hpp>
+
+// ---------------------------------------------------------------------------
+// KATs for core::MiningInterface::rest_recent_blocks -> node-role honesty (#942).
+//
+// A relay-only node learns some blocks over P2P from peers rather than finding
+// them itself. Those relay-learned records carry NO local share_hash and NO
+// miner address, and no local timing was ever computed for them. Before this
+// fix the endpoint labelled every timing-less block luck_method="first_block"
+// -- fabricating a computed-luck claim for blocks this node never found -- and
+// surfaced the timing fields as a real-looking 0.0, so the dashboard rendered
+// ten empty-but-numeric fields as if they were measured.
+//
+// The honesty rule these lock, in both directions:
+//   * RELAY-LEARNED (no share_hash, no miner): found_locally is false,
+//     luck_method is "relayed", and the timing-derived fields (luck,
+//     time_to_find, expected_time) are honest-absent null, never 0.
+//   * LOCALLY-FOUND (share_hash + miner present): found_locally is true,
+//     luck_method is a real timing label, and luck is a genuine number.
+//
+// Both FAIL WITHOUT THE FIX: before it there is no found_locally key at all,
+// the relay block reports luck_method=="first_block" not "relayed", and its
+// luck is 0.0 rather than null.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// Locate a recorded block by hash in the /recent_blocks array.
+nlohmann::json find_block(const nlohmann::json& arr, const std::string& hash) {
+    for (const auto& b : arr)
+        if (b.contains("hash") && b["hash"].get<std::string>() == hash)
+            return b;
+    return nlohmann::json(nullptr);
+}
+
+} // namespace
+
+// RELAY-LEARNED: no local share/miner -> found_locally false, luck_method
+// "relayed", timing fields honest-absent null (never a fabricated 0).
+TEST(RelayBlockHonesty, RelayLearnedBlockIsHonestlyLabelled) {
+    core::MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                             c2pool::address::Blockchain::LITECOIN);
+
+    const std::string h =
+        "1111111111111111111111111111111111111111111111111111111111111111";
+    // Relay path: empty miner + empty share_hash (this node did not find it).
+    mi.record_found_block(/*height=*/900000, uint256S(h), /*ts=*/1750000000,
+                          /*chain=*/"LTC", /*miner=*/"", /*share_hash=*/"");
+
+    auto blk = find_block(mi.rest_recent_blocks(), h);
+    ASSERT_TRUE(blk.is_object()) << "relay-learned block must be recorded";
+
+    ASSERT_TRUE(blk.contains("found_locally"))
+        << "found_locally is the node-role signal the dashboard reads";
+    EXPECT_FALSE(blk["found_locally"].get<bool>())
+        << "a block with no local share/miner was not found by this node";
+
+    EXPECT_EQ(blk["luck_method"].get<std::string>(), "relayed")
+        << "must not fabricate a computed-luck label for a relay-learned block";
+
+    EXPECT_TRUE(blk["luck"].is_null())
+        << "relay-learned luck is unknown -- honest-absent null, not 0";
+    EXPECT_TRUE(blk["time_to_find"].is_null())
+        << "relay-learned time_to_find is unknown -- honest-absent null, not 0";
+    EXPECT_TRUE(blk["expected_time"].is_null())
+        << "relay-learned expected_time is unknown -- honest-absent null, not 0";
+}
+
+// LOCALLY-FOUND: real share + miner -> found_locally true, real timing label,
+// luck surfaced as a genuine number.
+TEST(RelayBlockHonesty, LocallyFoundBlockKeepsRealTiming) {
+    core::MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                             c2pool::address::Blockchain::LITECOIN);
+
+    const std::string h =
+        "2222222222222222222222222222222222222222222222222222222222222222";
+    // Found locally: real payout address + real share hash.
+    mi.record_found_block(/*height=*/900001, uint256S(h), /*ts=*/1750000100,
+                          /*chain=*/"LTC",
+                          /*miner=*/"LhK2b7hQ8example",
+                          /*share_hash=*/"deadbeef");
+
+    auto blk = find_block(mi.rest_recent_blocks(), h);
+    ASSERT_TRUE(blk.is_object()) << "locally-found block must be recorded";
+
+    ASSERT_TRUE(blk.contains("found_locally"));
+    EXPECT_TRUE(blk["found_locally"].get<bool>())
+        << "a block with a real local share/miner was found by this node";
+
+    EXPECT_NE(blk["luck_method"].get<std::string>(), "relayed")
+        << "a locally-found block must carry a real timing label, not 'relayed'";
+
+    EXPECT_TRUE(blk["luck"].is_number())
+        << "locally-found luck is a genuine measured number, not null";
+}

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -2498,7 +2498,19 @@ nlohmann::json MiningInterface::rest_recent_blocks()
     nlohmann::json arr = nlohmann::json::array();
     std::lock_guard<std::mutex> lock(m_blocks_mutex);
     for (const auto& b : m_found_blocks) {
-        std::string method = (b.time_to_find > 0 && b.luck > 0) ? "simple_avg" : "first_block";
+        // Node-role honesty (#942): a block with no local share_hash AND no
+        // miner address is one this node did NOT find -- it was learned from a
+        // peer over P2P relay. A relay node therefore has no local timing for
+        // it, so luck_method must not fabricate a computed-luck label
+        // ("first_block" wrongly implied a luck computation was attempted), and
+        // the timing-derived fields are honest-absent (null) rather than a
+        // real-looking 0. found_locally is the explicit node-role signal the
+        // dashboard reads to render relay-learned blocks as such.
+        const bool found_locally = !(b.share_hash.empty() && b.miner.empty());
+        std::string method;
+        if (!found_locally)                        method = "relayed";
+        else if (b.time_to_find > 0 && b.luck > 0) method = "simple_avg";
+        else                                       method = "first_block";
         arr.push_back({
             {"ts", b.ts},
             {"hash", b.hash},
@@ -2511,13 +2523,14 @@ nlohmann::json MiningInterface::rest_recent_blocks()
             {"confirmations", b.confirmations},
             {"miner", b.miner},
             {"share", b.share_hash},
+            {"found_locally", found_locally},
             {"network_difficulty", b.network_difficulty},
             {"share_difficulty", b.share_difficulty},
             {"pool_hashrate_at_find", b.pool_hashrate},
             {"subsidy", b.subsidy},
-            {"expected_time", b.expected_time},
-            {"time_to_find", b.time_to_find},
-            {"luck", b.luck},
+            {"expected_time", found_locally ? nlohmann::json(b.expected_time) : nlohmann::json(nullptr)},
+            {"time_to_find", found_locally ? nlohmann::json(b.time_to_find) : nlohmann::json(nullptr)},
+            {"luck", found_locally ? nlohmann::json(b.luck) : nlohmann::json(nullptr)},
             {"luck_method", method}
         });
     }


### PR DESCRIPTION
## #942 slice 1 — honest node-role labels for relay-learned found blocks

**Charter:** a dashboard must never lie about prod health. On a relay-only
node, some blocks in `/recent_blocks` were learned over P2P from peers, not
found locally — yet every one was labelled `luck_method="first_block"`
(a fabricated computed-luck claim) with ten timing fields showing a
real-looking `0.0`. The operator saw measured-looking data that was never measured.

**Fix (web layer only, non-consensus):**
- `found_locally` node-role signal on each block: `share_hash` **and** `miner`
  both empty ⇒ this node did not find it.
- relay-learned blocks get `luck_method="relayed"` (no fabricated luck label).
- their timing-derived fields (`luck`, `time_to_find`, `expected_time`) are
  honest-absent `null`, not `0`.
- locally-found blocks are unchanged (real timing preserved).

**Source choice flagged:** node-role is inferred from the block record
(empty local share+miner) rather than a first-class node config flag — kept
deliberately narrow for this slice. The follow-ups (last_day graph x-range so
relay-learned blocks fall inside the plotted window, and a node-role page
header) are separate and will build on `found_locally`.

**Tests:** 2 KATs, both **proven fail-without-fix** (revert source ⇒ 2 failed:
missing `found_locally`, `luck_method==first_block`, `luck==0.0` not null).
core_test **147/147**. GPG-signed.

Frontend consumes `found_locally` in the follow-up slice; awaiting designated
reviewer, then integrator merge (web = operator merge-tap awareness).
