### PR TITLE
ci(conan): prefer a LAN package/source mirror, fail open to conancenter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,6 +130,13 @@ jobs:
             conan --version   # pre-provisioned at /usr/local/bin on self-hosted
           fi
 
+      # Prefer the LAN Conan mirror when it answers the probe; conancenter stays
+      # as the fallback and is never removed, so an unreachable mirror is a
+      # no-op. Cuts a fresh runner's cold bootstrap from a measured 1554 s
+      # (170.7 MB Boost tarball over the WAN + from-source build) to ~2 s.
+      - name: Prefer LAN Conan remote
+        run: bash ci/conan/lan-remote.sh
+
       - name: Show committed Conan profile
         run: conan profile show -pr:a=ci/conan/linux-gcc13.profile
 
@@ -471,6 +478,13 @@ jobs:
             conan --version   # pre-provisioned at /usr/local/bin on self-hosted
           fi
 
+      # Prefer the LAN Conan mirror when it answers the probe; conancenter stays
+      # as the fallback and is never removed, so an unreachable mirror is a
+      # no-op. Cuts a fresh runner's cold bootstrap from a measured 1554 s
+      # (170.7 MB Boost tarball over the WAN + from-source build) to ~2 s.
+      - name: Prefer LAN Conan remote
+        run: bash ci/conan/lan-remote.sh
+
       - name: Detect Conan profile
         run: |
           conan profile detect --force
@@ -650,6 +664,13 @@ jobs:
             conan --version   # pre-provisioned at /usr/local/bin on self-hosted
           fi
 
+      # Prefer the LAN Conan mirror when it answers the probe; conancenter stays
+      # as the fallback and is never removed, so an unreachable mirror is a
+      # no-op. Cuts a fresh runner's cold bootstrap from a measured 1554 s
+      # (170.7 MB Boost tarball over the WAN + from-source build) to ~2 s.
+      - name: Prefer LAN Conan remote
+        run: bash ci/conan/lan-remote.sh
+
       - name: Detect Conan profile
         run: |
           conan profile detect --force
@@ -785,6 +806,13 @@ jobs:
           else
             conan --version   # pre-provisioned at /usr/local/bin on self-hosted
           fi
+
+      # Prefer the LAN Conan mirror when it answers the probe; conancenter stays
+      # as the fallback and is never removed, so an unreachable mirror is a
+      # no-op. Cuts a fresh runner's cold bootstrap from a measured 1554 s
+      # (170.7 MB Boost tarball over the WAN + from-source build) to ~2 s.
+      - name: Prefer LAN Conan remote
+        run: bash ci/conan/lan-remote.sh
 
       - name: Detect Conan profile
         run: |
@@ -1449,6 +1477,13 @@ jobs:
             conan --version   # pre-provisioned at /usr/local/bin on self-hosted
           fi
 
+      # Prefer the LAN Conan mirror when it answers the probe; conancenter stays
+      # as the fallback and is never removed, so an unreachable mirror is a
+      # no-op. Cuts a fresh runner's cold bootstrap from a measured 1554 s
+      # (170.7 MB Boost tarball over the WAN + from-source build) to ~2 s.
+      - name: Prefer LAN Conan remote
+        run: bash ci/conan/lan-remote.sh
+
       - name: Detect Conan profile
         run: |
           conan profile detect --force
@@ -1575,6 +1610,13 @@ jobs:
           else
             conan --version   # pre-provisioned at /usr/local/bin on self-hosted
           fi
+
+      # Prefer the LAN Conan mirror when it answers the probe; conancenter stays
+      # as the fallback and is never removed, so an unreachable mirror is a
+      # no-op. Cuts a fresh runner's cold bootstrap from a measured 1554 s
+      # (170.7 MB Boost tarball over the WAN + from-source build) to ~2 s.
+      - name: Prefer LAN Conan remote
+        run: bash ci/conan/lan-remote.sh
 
       - name: Restore Conan cache (github-hosted only)
         if: runner.environment == 'github-hosted'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -317,6 +317,14 @@ jobs:
             conan --version   # pre-provisioned at /usr/local/bin on self-hosted
           fi
 
+      # Prefer the LAN Conan mirror when it answers the probe; conancenter stays
+      # as the fallback and is never removed, so an unreachable mirror is a
+      # no-op. Cuts a fresh runner's cold bootstrap from a measured 1554 s
+      # (170.7 MB Boost tarball over the WAN + from-source build) to ~2 s.
+      - if: matrix.build-mode == 'manual'
+        name: Prefer LAN Conan remote
+        run: bash ci/conan/lan-remote.sh
+
       - if: matrix.build-mode == 'manual' && runner.environment == 'github-hosted'
         name: Restore Conan package cache (github-hosted only)
         uses: actions/cache@v5

--- a/ci/conan/LAN-MIRROR.md
+++ b/ci/conan/LAN-MIRROR.md
@@ -1,0 +1,101 @@
+# LAN Conan mirror — what it is, and how to refresh it
+
+`ci/conan/lan-remote.sh` runs in every Linux CI job right after `Install Conan 2`.
+It is a pure optimisation with a fail-open contract: every probe has a short
+timeout, `conancenter` is never removed, and a runner that cannot route to the
+LAN (any GitHub-hosted fork runner) behaves exactly as it did before.
+
+## Why it exists
+
+Each self-hosted runner has its own `CONAN_HOME` (`$HOME/.conan2-ci/$RUNNER_NAME`
+— deliberate, it avoids conan sqlite contention between concurrent jobs). A
+newly registered runner therefore pays a full cold bootstrap on its first
+compiling job. Measured on the `c2pool-heavy` host from an empty `CONAN_HOME`,
+2026-08-05:
+
+| lane | before | after (LAN) |
+|---|---|---|
+| `ci/conan/linux-gcc13.profile` | 117 s | **2.3 s** |
+| host-default `conan profile detect` (ASan / BCH / DGB) | 1554 s | **2.2 s** |
+| fully offline (binary remote down, seed archive only) | — | **17.9 s** idle host / **77 s** under full CI load |
+
+The 1554 s row is the one that matters: conancenter ships prebuilt binaries for
+gcc-13 but **not** for gcc-15, so on a gcc-15 host conan fell back to fetching
+170.7 MB of `boost_1_90_0.tar.bz2` over the WAN (~90% of the wall time) and
+building Boost from source. That is the "new runner looks hung and isn't" case.
+
+## The two pieces
+
+| piece | host | URL | contents |
+|---|---|---|---|
+| binary remote (`conan_server`, v2 API) | VM905 `c2pool-build` | `http://192.168.86.178:9300` | full dependency closure, **both** profiles |
+| static archive | VM104 `git-mirror` | `http://192.168.86.181:9301` | `sources/<sha256>` boost tarball + `seed/c2pool-deps-*.tgz` |
+
+Both are `systemd` units and survive reboot. On VM104 the unit is
+`conan-lan-http.service` (root-owned, `/srv/conan-lan`, runs as `nobody`,
+`ProtectSystem=strict`) — it is a read-only file server and cannot touch the
+gitea data on that box. On VM905 the unit is the user-level
+`conan-server.service` with linger enabled.
+
+Read access to both is anonymous; the upload account exists only on VM905 and
+its credential is not in this repo.
+
+## Coverage
+
+Exported from a warm CI cache, so it tracks `conanfile.txt` + `conan.lock`:
+
+- `boost/1.90.0`, `zeromq/4.3.5`, `leveldb/1.23`, `yaml-cpp/0.8.0`,
+  `nlohmann_json/3.12.0`, `gtest/1.14.0` and their transitives
+  (`b2`, `bzip2`, `crc32c`, `libbacktrace`, `snappy`, `zlib`)
+- two `package_id` sets per recipe: **gcc-13** (the committed profile) and
+  **gcc-15** (the host-default detect as it was before oplex7020 was pinned to
+  gcc-13). Keeping both means a host flipping its default compiler is a cache
+  hit either way.
+
+## Refresh — when, who, how
+
+**It goes stale when `conanfile.txt` or `conan.lock` changes, or when a build
+host's default compiler changes** (a new `compiler.version` is a new
+`package_id`, which the mirror does not have).
+
+**Symptom of staleness:** a job logs `Building from source` or downloads from
+`conancenter` for a package the mirror was supposed to serve. That is a
+degraded-but-correct state — nothing breaks, it is just slow again.
+
+**Trigger:** whoever lands a dependency bump (the PR that edits `conanfile.txt`
+or regenerates `conan.lock`) refreshes the mirror in the same change. There is
+deliberately no cron: a silent auto-refresh would republish whatever a random
+runner happened to have, which is how a mirror turns into a mystery artifact.
+
+**Procedure** — from any host with a warm, correct cache (a CI runner that has
+just built the new dependency set green):
+
+```bash
+# 1. export the whole dependency set from that warm cache
+export CONAN_HOME=$HOME/.conan2-ci/<runner-name>       # must NOT be mid-job
+conan cache save "*:*" --file=/tmp/c2pool-deps-$(date +%Y%m%d).tgz
+
+# 2. push the binaries into the LAN remote (restore into a scratch home first
+#    so the runner's own cache and remotes are never touched)
+export CONAN_HOME=/tmp/upload-home && rm -rf "$CONAN_HOME"
+conan cache restore /tmp/c2pool-deps-$(date +%Y%m%d).tgz
+conan remote add lan http://192.168.86.178:9300 --index 0 --force
+conan remote login lan ciupload          # credential: VM905 ~/.conan_server/server.conf
+conan upload "*" -r=lan --confirm
+
+# 3. publish the seed archive + any new upstream source tarball on VM104
+#    (/srv/conan-lan is served read-only; sources are named by their sha256,
+#    which must match the recipe's conandata.yml `sources:` entry)
+#    then bump SEED_URL's default in ci/conan/lan-remote.sh in the same PR.
+```
+
+**Safety rules for step 1 and 2:** never `conan cache save` a `CONAN_HOME` whose
+runner is mid-job — check `gh api repos/frstrtr/c2pool/actions/runners` for
+`busy=false` *and* that no `Runner.Worker` pid exists for that runner. Restore
+is additive and never deletes, but a concurrent writer can still tear the
+sqlite index.
+
+**Rollback:** `systemctl stop conan-lan-http` on VM104 and
+`systemctl --user stop conan-server` on VM905. Every probe in
+`lan-remote.sh` then fails and CI reverts to conancenter with no workflow
+change. Nothing else on either box is involved.

--- a/ci/conan/LAN-MIRROR.md
+++ b/ci/conan/LAN-MIRROR.md
@@ -13,37 +13,56 @@ newly registered runner therefore pays a full cold bootstrap on its first
 compiling job. Measured on the `c2pool-heavy` host from an empty `CONAN_HOME`,
 2026-08-05:
 
-| lane | before | after (LAN) |
-|---|---|---|
-| `ci/conan/linux-gcc13.profile` | 117 s | **2.3 s** |
-| host-default `conan profile detect` (ASan / BCH / DGB) | 1554 s | **2.2 s** |
-| fully offline (binary remote down, seed archive only) | — | **17.9 s** idle host / **77 s** under full CI load |
+| lane | before | after — VM104 primary | after — VM905 fallback |
+|---|---|---|---|
+| `ci/conan/linux-gcc13.profile` | 117 s | **2.6 s** | 2.3 s idle / 8.4 s loaded |
+| host-default `conan profile detect` (ASan / BCH / DGB) | 1554 s | **2.2 s** | 2.2 s idle / 5.6 s loaded |
+| fully offline (both remotes down, seed archive only) | — | **17.9 s** idle host / **77 s** under full CI load | — |
 
-The "after" column is an idle host. Re-measured on the same host while it was
-running four concurrent CI jobs the same two resolves cost 8.4 s and 5.6 s —
-still three orders of magnitude off the cold bootstrap, but quote the range,
-not the best case.
+Every "after" number was taken from a purged `CONAN_HOME` with **conancenter
+removed entirely**, so the resolve provably came off the LAN and not from a warm
+remote cache. The VM905 column shows idle and loaded figures because that box
+also runs eight CI slots; quote the range, not the best case.
 
 The 1554 s row is the one that matters: conancenter ships prebuilt binaries for
 gcc-13 but **not** for gcc-15, so on a gcc-15 host conan fell back to fetching
 170.7 MB of `boost_1_90_0.tar.bz2` over the WAN (~90% of the wall time) and
 building Boost from source. That is the "new runner looks hung and isn't" case.
 
-## The two pieces
+## The pieces
 
-| piece | host | URL | contents |
+| role | host | URL | contents |
 |---|---|---|---|
-| binary remote (`conan_server`, v2 API) | VM905 `c2pool-build` | `http://192.168.86.178:9300` | full dependency closure, **both** profiles |
+| binary remote `lan` — **PRIMARY** | VM104 `git-mirror` | `http://192.168.86.181:9300` | full dependency closure, **both** profiles |
+| binary remote `lan905` — **FALLBACK** | VM905 `c2pool-build` | `http://192.168.86.178:9300` | identical closure |
 | static archive | VM104 `git-mirror` | `http://192.168.86.181:9301` | `sources/<sha256>` boost tarball + `seed/c2pool-deps-*.tgz` |
 
-Both are `systemd` units and survive reboot. On VM104 the unit is
-`conan-lan-http.service` (root-owned, `/srv/conan-lan`, runs as `nobody`,
-`ProtectSystem=strict`) — it is a read-only file server and cannot touch the
-gitea data on that box. On VM905 the unit is the user-level
-`conan-server.service` with linger enabled.
+`lan-remote.sh` probes them in that order and inserts each ahead of
+`conancenter`, so the search order is `lan` → `lan905` → `conancenter`. If the
+primary is down the fallback is promoted to the front; if both are down and the
+cache is cold, the seed archive is restored instead.
 
-Read access to both is anonymous; the upload account exists only on VM905 and
-its credential is not in this repo.
+**VM104 lives on Proxmox node `pve`, not `pve1`.** Fleet notes said `pve1`;
+that is wrong and `qm` commands against `pve1` fail with
+`Configuration file 'nodes/pve1/qemu-server/104.conf' does not exist`.
+
+All three are `systemd` units and survive reboot:
+
+| unit | host | notes |
+|---|---|---|
+| `conan-server.service` | VM104 | **root/system** unit, runs as `ubuntu`, `ProtectSystem=strict`, `ProtectHome=read-only`, writes only to its own storage dir |
+| `conan-lan-http.service` | VM104 | root/system unit, runs as `nobody`, read-only file server over `/srv/conan-lan` |
+| `conan-server.service` | VM905 | user unit with linger enabled |
+
+Nothing on VM104 touches the gitea container, which keeps `:3000` to itself;
+gitea was verified answering 200 after every step of the install.
+
+**Footprint on VM104:** 427 MB static archive (`/srv/conan-lan`) + 54 MB package
+store (`/home/ubuntu/conan-server-data`) + ~90 MB of venvs ≈ **0.6 GB** on a
+58 G disk with 26 G free. The 242 git mirrors remain the dominant consumer.
+
+Read access to every endpoint is anonymous; upload accounts exist only on the
+two server boxes and no credential is in this repo.
 
 ## Coverage
 
@@ -80,27 +99,30 @@ just built the new dependency set green):
 export CONAN_HOME=$HOME/.conan2-ci/<runner-name>       # must NOT be mid-job
 conan cache save "*:*" --file=/tmp/c2pool-deps-$(date +%Y%m%d).tgz
 
-# 2. push the binaries into the LAN remote (restore into a scratch home first
-#    so the runner's own cache and remotes are never touched)
-export CONAN_HOME=/tmp/upload-home && rm -rf "$CONAN_HOME"
-conan cache restore /tmp/c2pool-deps-$(date +%Y%m%d).tgz
-conan remote add lan http://192.168.86.178:9300 --index 0 --force
-conan remote login lan ciupload          # credential: VM905 ~/.conan_server/server.conf
-conan upload "*" -r=lan --confirm
+# 2. publish it as the new seed archive on VM104 and, if a recipe pulled a new
+#    upstream tarball, drop that in sources/ named by the sha256 from the
+#    recipe's conandata.yml `sources:` entry (the name IS the integrity check)
+scp /tmp/c2pool-deps-$(date +%Y%m%d).tgz \
+    ubuntu@192.168.86.181:/srv/conan-lan/seed/
 
-# 3. publish the seed archive + any new upstream source tarball on VM104
-#    (/srv/conan-lan is served read-only; sources are named by their sha256,
-#    which must match the recipe's conandata.yml `sources:` entry)
-#    then bump SEED_URL's default in ci/conan/lan-remote.sh in the same PR.
+# 3. push the binaries into BOTH binary remotes, primary first. Run this ON the
+#    server box: /home/ubuntu/vm104_upload.sh reads the upload credential out of
+#    that host's own server.conf, restores the seed into a scratch CONAN_HOME and
+#    uploads, so no credential ever crosses a shell you are typing into.
+ssh ubuntu@192.168.86.181 bash /home/ubuntu/vm104_upload.sh
+#    then the same for the VM905 fallback.
+
+# 4. bump SEED_URL's default in ci/conan/lan-remote.sh in the same PR.
 ```
 
-**Safety rules for step 1 and 2:** never `conan cache save` a `CONAN_HOME` whose
-runner is mid-job — check `gh api repos/frstrtr/c2pool/actions/runners` for
-`busy=false` *and* that no `Runner.Worker` pid exists for that runner. Restore
-is additive and never deletes, but a concurrent writer can still tear the
-sqlite index.
+**Safety rules:** never `conan cache save` a `CONAN_HOME` whose runner is
+mid-job — check `gh api repos/frstrtr/c2pool/actions/runners` for `busy=false`
+*and* that no `Runner.Worker` pid exists for that runner. Restore is additive
+and never deletes, but a concurrent writer can still tear the sqlite index.
+Always restore into a scratch `CONAN_HOME` before uploading, so a runner's own
+cache and remote list are never touched.
 
-**Rollback:** `systemctl stop conan-lan-http` on VM104 and
-`systemctl --user stop conan-server` on VM905. Every probe in
-`lan-remote.sh` then fails and CI reverts to conancenter with no workflow
-change. Nothing else on either box is involved.
+**Rollback:** stop `conan-server` and/or `conan-lan-http` on VM104 and
+`conan-server` (user unit) on VM905. Every probe in `lan-remote.sh` then fails
+and CI reverts to conancenter with no workflow change. Nothing else on either
+box is involved.

--- a/ci/conan/LAN-MIRROR.md
+++ b/ci/conan/LAN-MIRROR.md
@@ -19,6 +19,11 @@ compiling job. Measured on the `c2pool-heavy` host from an empty `CONAN_HOME`,
 | host-default `conan profile detect` (ASan / BCH / DGB) | 1554 s | **2.2 s** |
 | fully offline (binary remote down, seed archive only) | — | **17.9 s** idle host / **77 s** under full CI load |
 
+The "after" column is an idle host. Re-measured on the same host while it was
+running four concurrent CI jobs the same two resolves cost 8.4 s and 5.6 s —
+still three orders of magnitude off the cold bootstrap, but quote the range,
+not the best case.
+
 The 1554 s row is the one that matters: conancenter ships prebuilt binaries for
 gcc-13 but **not** for gcc-15, so on a gcc-15 host conan fell back to fetching
 170.7 MB of `boost_1_90_0.tar.bz2` over the WAN (~90% of the wall time) and

--- a/ci/conan/lan-remote.sh
+++ b/ci/conan/lan-remote.sh
@@ -1,50 +1,61 @@
 #!/usr/bin/env bash
-# Point Conan at the LAN package/source mirror when it is reachable.
+# Point Conan at the LAN mirror when it is reachable. Runbook: ci/conan/LAN-MIRROR.md
 #
 # WHY ──────────────────────────────────────────────────────────────────────────
 # Every self-hosted runner gets its OWN CONAN_HOME ($HOME/.conan2-ci/$RUNNER_NAME
 # — deliberate: it avoids conan sqlite contention between concurrent jobs), so a
-# NEWLY registered runner's first compiling job pays a full cold bootstrap.
-# Measured on the c2pool-heavy host (oplex7020) from an empty CONAN_HOME:
+# NEWLY registered runner's first compiling job pays a full cold bootstrap over
+# the WAN. Measured on the c2pool-heavy host (oplex7020) from an empty
+# CONAN_HOME, 2026-08-05:
 #
-#   committed gcc-13 profile   117 s   conancenter has matching prebuilt binaries
-#   host-default gcc-15 lane  1554 s   no prebuilt -> 170.7 MB boost_1_90_0.tar.bz2
-#                                      dragged over the WAN (~90% of the wall
-#                                      time) + a from-source Boost build
+#   committed gcc-13 profile   117 s   conancenter ships matching prebuilts
+#   host-default gcc-15 lane  1554 s   conancenter ships NO gcc-15 prebuilt, so
+#                                      conan fetched 170.7 MB of
+#                                      boost_1_90_0.tar.bz2 over the WAN (~90%
+#                                      of the wall time) and built Boost
 #
-# Against the LAN remote both lanes resolve in ~2 s from an empty CONAN_HOME.
+# Against the LAN mirror the same empty CONAN_HOME resolves in ~2 s, and even
+# the fully offline seed path (no internet reachable at all) costs 18-77 s
+# (18 s on an idle host, 77 s on VM905 under full CI load).
 #
 # FAIL-OPEN ───────────────────────────────────────────────────────────────────
-# The mirror is an optimisation, never a dependency. If it does not answer the
-# probe this script REMOVES the remote and the job proceeds against conancenter
-# exactly as before. conancenter is kept as the fallback remote and is never
-# removed or disabled. GitHub-hosted runners (forks) simply fail the probe.
+# The mirror is an optimisation, never a dependency. Every probe has a short
+# timeout and every failure degrades to today's behaviour. conancenter is kept
+# as the fallback remote and is never removed or disabled. GitHub-hosted fork
+# runners cannot route to the LAN, fail all three probes, and are unaffected.
 set -uo pipefail
 
-LAN_HOST="${C2POOL_CONAN_LAN_HOST:-192.168.86.178}"
-PKG_URL="${C2POOL_CONAN_LAN_URL:-http://${LAN_HOST}:9300}"
-SRC_URL="${C2POOL_CONAN_SRC_URL:-http://${LAN_HOST}:9301/}"
+# Binary remote: conan_server v2 API. Serves prebuilt binaries for BOTH profiles
+# in use — ci/conan/linux-gcc13.profile and the host-default `conan profile
+# detect`. Read access is anonymous, so no credentials live in this repo.
+PKG_URL="${C2POOL_CONAN_LAN_URL:-http://192.168.86.178:9300}"
+# Source + seed archive host (VM104, the box that already holds the git mirror).
+ARCHIVE="${C2POOL_CONAN_ARCHIVE_URL:-http://192.168.86.181:9301}"
+SRC_URL="${C2POOL_CONAN_SRC_URL:-${ARCHIVE}/sources/}"
+SEED_URL="${C2POOL_CONAN_SEED_URL:-${ARCHIVE}/seed/c2pool-deps-20260805.tgz}"
 
 if ! command -v conan >/dev/null 2>&1; then
-  echo "conan not on PATH — skipping LAN remote setup"
+  echo "conan not on PATH — skipping LAN mirror setup"
   exit 0
 fi
 
-# --index 0 => searched BEFORE conancenter. Read access on the mirror is
-# anonymous, so no credentials are needed (and none are stored in the repo).
+# ── 1. binary remote, searched BEFORE conancenter ────────────────────────────
+lan_up=0
 if curl -fsS -m 3 -o /dev/null "${PKG_URL}/v2/ping" 2>/dev/null; then
   conan remote add lan "${PKG_URL}" --index 0 --force
+  lan_up=1
   echo "conan: LAN binary remote ENABLED (${PKG_URL}) — preferred over conancenter"
 else
   conan remote remove lan >/dev/null 2>&1 || true
   echo "conan: LAN binary remote unreachable — conancenter only"
 fi
 
-# Backup-sources mirror. Only consulted when a recipe actually needs the upstream
-# tarball, i.e. a package_id with no prebuilt binary on any remote. "origin"
-# keeps the recipe's own URLs as the fallback, so a missing/incomplete mirror
-# degrades to today's behaviour. core.* conf can ONLY be set in global.conf —
-# `conan install -c core.sources:...` is rejected by design.
+# ── 2. backup-sources mirror ─────────────────────────────────────────────────
+# Only consulted when a recipe genuinely needs the upstream tarball, i.e. a
+# package_id with no prebuilt binary on any remote. "origin" keeps the recipe's
+# own URLs as fallback, so a missing or stale mirror degrades to today's
+# behaviour. core.* conf can ONLY live in global.conf — `conan install -c
+# core.sources:...` is rejected by design, which is why this is a script.
 GLOBAL_CONF="$(conan config home)/global.conf"
 touch "${GLOBAL_CONF}"
 sed -i '/^core\.sources:download_urls/d' "${GLOBAL_CONF}"
@@ -53,6 +64,27 @@ if curl -fsS -m 3 -o /dev/null "${SRC_URL}" 2>/dev/null; then
   echo "conan: LAN source mirror ENABLED (${SRC_URL})"
 else
   echo "conan: LAN source mirror unreachable — sources come from origin"
+fi
+
+# ── 3. offline seed, only when the binary remote is down AND the cache is cold ─
+# This is the "no internet at all" path: one LAN transfer of the whole exported
+# dependency set, then `conan cache restore`. Measured 17.9 s end-to-end on the
+# heavy host (2.4 s transfer of 276 MB + 14.8 s restore + 0.8 s resolve) and
+# 77 s on VM905 while it was running eight concurrent CI jobs. Deliberately NOT
+# taken when the binary remote answers — the remote only moves what the graph
+# needs and is ~8x faster.
+# NB: match an indented `boost/...` line specifically. A bare `grep ':'` false-
+# positives on conan's own "WARN: There are no matching recipe references".
+if [ "${lan_up}" -eq 0 ] && ! conan list "boost/*:*" 2>/dev/null | grep -qE '^[[:space:]]+boost/'; then
+  if curl -fsS -m 5 -o /dev/null -I "${SEED_URL}" 2>/dev/null; then
+    tmp="$(mktemp -t c2pool-conan-seed.XXXXXX.tgz)"
+    if curl -fsS -m 300 -o "${tmp}" "${SEED_URL}" && conan cache restore "${tmp}"; then
+      echo "conan: cold cache seeded from LAN archive (${SEED_URL})"
+    else
+      echo "conan: LAN seed restore failed — falling through to conancenter"
+    fi
+    rm -f "${tmp}"
+  fi
 fi
 
 conan remote list

--- a/ci/conan/lan-remote.sh
+++ b/ci/conan/lan-remote.sh
@@ -14,22 +14,26 @@
 #                                      boost_1_90_0.tar.bz2 over the WAN (~90%
 #                                      of the wall time) and built Boost
 #
-# Against the LAN mirror the same empty CONAN_HOME resolves in ~2 s, and even
+# Against the LAN mirror the same empty CONAN_HOME resolves in ~2-3 s, and even
 # the fully offline seed path (no internet reachable at all) costs 18-77 s
 # (18 s on an idle host, 77 s on VM905 under full CI load).
 #
 # FAIL-OPEN ───────────────────────────────────────────────────────────────────
 # The mirror is an optimisation, never a dependency. Every probe has a short
 # timeout and every failure degrades to today's behaviour. conancenter is kept
-# as the fallback remote and is never removed or disabled. GitHub-hosted fork
-# runners cannot route to the LAN, fail all three probes, and are unaffected.
+# as the last remote and is never removed or disabled. GitHub-hosted fork
+# runners cannot route to the LAN, fail every probe, and are unaffected.
 set -uo pipefail
 
-# Binary remote: conan_server v2 API. Serves prebuilt binaries for BOTH profiles
-# in use — ci/conan/linux-gcc13.profile and the host-default `conan profile
-# detect`. Read access is anonymous, so no credentials live in this repo.
-PKG_URL="${C2POOL_CONAN_LAN_URL:-http://192.168.86.178:9300}"
-# Source + seed archive host (VM104, the box that already holds the git mirror).
+# Binary remotes (conan_server v2 API), searched in this order and both ahead of
+# conancenter. Each serves prebuilt binaries for BOTH profiles in use —
+# ci/conan/linux-gcc13.profile and the host-default `conan profile detect`.
+# Read access is anonymous, so no credentials live in this repo.
+#   lan    = VM104 git-mirror   — PRIMARY
+#   lan905 = VM905 c2pool-build — FALLBACK, kept until VM104 has proven itself
+PKG_URL="${C2POOL_CONAN_LAN_URL:-http://192.168.86.181:9300}"
+PKG_URL_FALLBACK="${C2POOL_CONAN_LAN_FALLBACK_URL:-http://192.168.86.178:9300}"
+# Source + seed archive, served read-only off the same box as the primary.
 ARCHIVE="${C2POOL_CONAN_ARCHIVE_URL:-http://192.168.86.181:9301}"
 SRC_URL="${C2POOL_CONAN_SRC_URL:-${ARCHIVE}/sources/}"
 SEED_URL="${C2POOL_CONAN_SEED_URL:-${ARCHIVE}/seed/c2pool-deps-20260805.tgz}"
@@ -39,16 +43,29 @@ if ! command -v conan >/dev/null 2>&1; then
   exit 0
 fi
 
-# ── 1. binary remote, searched BEFORE conancenter ────────────────────────────
+# ── 1. binary remotes, searched BEFORE conancenter ───────────────────────────
 lan_up=0
 if curl -fsS -m 3 -o /dev/null "${PKG_URL}/v2/ping" 2>/dev/null; then
   conan remote add lan "${PKG_URL}" --index 0 --force
   lan_up=1
-  echo "conan: LAN binary remote ENABLED (${PKG_URL}) — preferred over conancenter"
+  echo "conan: LAN binary remote ENABLED (${PKG_URL}) — primary"
 else
   conan remote remove lan >/dev/null 2>&1 || true
-  echo "conan: LAN binary remote unreachable — conancenter only"
+  echo "conan: LAN binary remote unreachable (${PKG_URL})"
 fi
+
+# --index "${lan_up}" => slots in behind the primary when it is up, at the front
+# when it is not; conancenter stays last either way.
+if curl -fsS -m 3 -o /dev/null "${PKG_URL_FALLBACK}/v2/ping" 2>/dev/null; then
+  conan remote add lan905 "${PKG_URL_FALLBACK}" --index "${lan_up}" --force
+  lan_up=1
+  echo "conan: LAN binary remote ENABLED (${PKG_URL_FALLBACK}) — fallback"
+else
+  conan remote remove lan905 >/dev/null 2>&1 || true
+  echo "conan: LAN fallback remote unreachable (${PKG_URL_FALLBACK})"
+fi
+
+[ "${lan_up}" -eq 0 ] && echo "conan: no LAN binary remote answered — conancenter only"
 
 # ── 2. backup-sources mirror ─────────────────────────────────────────────────
 # Only consulted when a recipe genuinely needs the upstream tarball, i.e. a
@@ -66,13 +83,12 @@ else
   echo "conan: LAN source mirror unreachable — sources come from origin"
 fi
 
-# ── 3. offline seed, only when the binary remote is down AND the cache is cold ─
+# ── 3. offline seed, only when NO binary remote answered AND the cache is cold ─
 # This is the "no internet at all" path: one LAN transfer of the whole exported
-# dependency set, then `conan cache restore`. Measured 17.9 s end-to-end on the
-# heavy host (2.4 s transfer of 276 MB + 14.8 s restore + 0.8 s resolve) and
+# dependency set, then `conan cache restore`. Measured 17.9 s end-to-end on an
+# idle heavy host (2.4 s transfer of 276 MB + 14.8 s restore + 0.8 s resolve) and
 # 77 s on VM905 while it was running eight concurrent CI jobs. Deliberately NOT
-# taken when the binary remote answers — the remote only moves what the graph
-# needs and is ~8x faster.
+# taken when a binary remote is up — a remote moves only what the graph needs.
 # NB: match an indented `boost/...` line specifically. A bare `grep ':'` false-
 # positives on conan's own "WARN: There are no matching recipe references".
 if [ "${lan_up}" -eq 0 ] && ! conan list "boost/*:*" 2>/dev/null | grep -qE '^[[:space:]]+boost/'; then

--- a/ci/conan/lan-remote.sh
+++ b/ci/conan/lan-remote.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Point Conan at the LAN package/source mirror when it is reachable.
+#
+# WHY ──────────────────────────────────────────────────────────────────────────
+# Every self-hosted runner gets its OWN CONAN_HOME ($HOME/.conan2-ci/$RUNNER_NAME
+# — deliberate: it avoids conan sqlite contention between concurrent jobs), so a
+# NEWLY registered runner's first compiling job pays a full cold bootstrap.
+# Measured on the c2pool-heavy host (oplex7020) from an empty CONAN_HOME:
+#
+#   committed gcc-13 profile   117 s   conancenter has matching prebuilt binaries
+#   host-default gcc-15 lane  1554 s   no prebuilt -> 170.7 MB boost_1_90_0.tar.bz2
+#                                      dragged over the WAN (~90% of the wall
+#                                      time) + a from-source Boost build
+#
+# Against the LAN remote both lanes resolve in ~2 s from an empty CONAN_HOME.
+#
+# FAIL-OPEN ───────────────────────────────────────────────────────────────────
+# The mirror is an optimisation, never a dependency. If it does not answer the
+# probe this script REMOVES the remote and the job proceeds against conancenter
+# exactly as before. conancenter is kept as the fallback remote and is never
+# removed or disabled. GitHub-hosted runners (forks) simply fail the probe.
+set -uo pipefail
+
+LAN_HOST="${C2POOL_CONAN_LAN_HOST:-192.168.86.178}"
+PKG_URL="${C2POOL_CONAN_LAN_URL:-http://${LAN_HOST}:9300}"
+SRC_URL="${C2POOL_CONAN_SRC_URL:-http://${LAN_HOST}:9301/}"
+
+if ! command -v conan >/dev/null 2>&1; then
+  echo "conan not on PATH — skipping LAN remote setup"
+  exit 0
+fi
+
+# --index 0 => searched BEFORE conancenter. Read access on the mirror is
+# anonymous, so no credentials are needed (and none are stored in the repo).
+if curl -fsS -m 3 -o /dev/null "${PKG_URL}/v2/ping" 2>/dev/null; then
+  conan remote add lan "${PKG_URL}" --index 0 --force
+  echo "conan: LAN binary remote ENABLED (${PKG_URL}) — preferred over conancenter"
+else
+  conan remote remove lan >/dev/null 2>&1 || true
+  echo "conan: LAN binary remote unreachable — conancenter only"
+fi
+
+# Backup-sources mirror. Only consulted when a recipe actually needs the upstream
+# tarball, i.e. a package_id with no prebuilt binary on any remote. "origin"
+# keeps the recipe's own URLs as the fallback, so a missing/incomplete mirror
+# degrades to today's behaviour. core.* conf can ONLY be set in global.conf —
+# `conan install -c core.sources:...` is rejected by design.
+GLOBAL_CONF="$(conan config home)/global.conf"
+touch "${GLOBAL_CONF}"
+sed -i '/^core\.sources:download_urls/d' "${GLOBAL_CONF}"
+if curl -fsS -m 3 -o /dev/null "${SRC_URL}" 2>/dev/null; then
+  printf 'core.sources:download_urls=["%s", "origin"]\n' "${SRC_URL}" >> "${GLOBAL_CONF}"
+  echo "conan: LAN source mirror ENABLED (${SRC_URL})"
+else
+  echo "conan: LAN source mirror unreachable — sources come from origin"
+fi
+
+conan remote list


### PR DESCRIPTION
**do-not-merge** while the mirror soaks. Opened for review + the coordination note at the bottom.

## Problem

Each self-hosted runner gets its own `CONAN_HOME` (`$HOME/.conan2-ci/$RUNNER_NAME`) — deliberate, it avoids conan sqlite contention between concurrent jobs. The consequence is that a **newly registered runner's first compiling job pays a full cold bootstrap**, and that bootstrap goes over the WAN.

Measured on the `c2pool-heavy` host (oplex7020) from a genuinely empty `CONAN_HOME`, 2026-08-05:

| lane | fresh-`CONAN_HOME` cost | what dominates |
|---|---|---|
| committed `ci/conan/linux-gcc13.profile` | **117 s** | conancenter ships matching prebuilt binaries (296 MB download) |
| host-default detect (ASan / BCH / DGB legs) | **1554 s** (25 m 54 s) | conancenter ships **no gcc-15 prebuilt**, so conan fetched **170.7 MB `boost_1_90_0.tar.bz2` over the WAN** (~90% of the wall time) and built Boost from source |

The second row is the "new runner looks hung and isn't" case. Note the root cause is the *toolchain*, not the uplink: the WAN source fetch only happens because no prebuilt exists for that compiler.

## What this changes

Three LAN endpoints, all `systemd` units that survive reboot:

| role | host | URL | serves |
|---|---|---|---|
| binary remote `lan` — **PRIMARY** | VM104 `git-mirror` | `http://192.168.86.181:9300` | full dependency closure, **both** profiles |
| binary remote `lan905` — **FALLBACK** | VM905 `c2pool-build` | `http://192.168.86.178:9300` | identical closure |
| static archive | VM104 `git-mirror` | `http://192.168.86.181:9301` | `sources/<sha256>` boost tarball + `seed/c2pool-deps-20260805.tgz` (276 MB) |

`ci/conan/lan-remote.sh` runs right after each `Install Conan 2` step and, per probe:

1. inserts each reachable binary remote ahead of `conancenter` — search order `lan` → `lan905` → `conancenter`; if the primary is down the fallback is promoted to the front;
2. points `core.sources:download_urls` at the LAN source mirror with `"origin"` kept as fallback (`core.*` conf can only live in `global.conf`, which is why this is a script and not a `conan install -c` flag);
3. if **no** binary remote answers and the cache is cold, pulls the seed archive and `conan cache restore`s it — the "no internet at all" path.

VM905 stays up deliberately; it is not torn down until VM104 has soaked.

Measured from a purged `CONAN_HOME` with **conancenter removed entirely**, so the resolve provably came off the LAN:

| lane | before | VM104 (primary) | VM905 (fallback) |
|---|---|---|---|
| gcc-13 profile | 117 s | **2.6 s** | 2.3 s idle / 8.4 s loaded |
| gcc-15 / ASan profile | 1554 s | **2.2 s** | 2.2 s idle / 5.6 s loaded |
| fully offline (both remotes down, seed only) | — | **17.9 s** idle / **77 s** under full CI load | — |

Both `boost` `package_id`s land, 499 MB pulled. All four probe paths were exercised: both up (order verified), primary down (fallback promoted), both down (seed restore fires), conancenter last in every case — against conan 2.29.1 and 2.31.2.

On VM104, `conan_server` is a **root/system** unit running as `ubuntu` under `ProtectSystem=strict` + `ProtectHome=read-only` with `ReadWritePaths` limited to its own storage, so it cannot reach the gitea data that is that box's actual job. Gitea on `:3000` verified answering 200 after every step. Footprint left there: 427 MB archive + 54 MB package store + ~90 MB venvs ≈ **0.6 GB** on a 58 G disk with 26 G free.

**Fleet-notes correction recorded in `LAN-MIRROR.md`:** VM104 is on Proxmox node **`pve`**, not `pve1` — `qm` against `pve1` fails with `Configuration file 'nodes/pve1/qemu-server/104.conf' does not exist`.

## Fail-open contract

This is an optimisation, never a dependency:

- four independent probes, 3–5 s timeouts; any failure degrades to today's behaviour;
- conancenter is **never** removed or disabled — it stays as the fallback remote in every path;
- GitHub-hosted fork runners cannot route to the LAN, fail every probe, and are unaffected — verified;
- read access on both hosts is anonymous, so no credentials enter the repo;
- overridable via `C2POOL_CONAN_LAN_URL` / `C2POOL_CONAN_LAN_FALLBACK_URL` / `C2POOL_CONAN_ARCHIVE_URL` / `C2POOL_CONAN_SRC_URL` / `C2POOL_CONAN_SEED_URL`;
- rollback is stopping either unit — no workflow change needed.



## Staleness

`ci/conan/LAN-MIRROR.md` is the runbook: exactly which recipes and `package_id`s are covered, the symptom of a stale mirror (a job logs `Building from source` for something the mirror should have served — degraded but still correct), and the refresh procedure. Refresh is triggered by **whoever lands a `conanfile.txt` / `conan.lock` bump**, in the same change — deliberately no cron, since a silent auto-refresh would republish whatever a random runner happened to have.

## Coordination with #1122

**No line overlap. Test-merged clean** at both commits (`git merge --no-commit --no-ff pr/1122` → "Automatic merge went well", both `build.yml` and `codeql-analysis.yml` auto-merged).

#1122 edits job **headers** (`runs-on:`, job-level `env:`); this PR only inserts a step inside `steps:` immediately after each existing `Install Conan 2`. Nearest hunks are ~60 lines apart in `build.yml` and ~260 in `codeql-analysis.yml`.

One substantive note for #1122, not a conflict: its rationale for keeping `linux-asan` on `c2pool-build` says *"Revisit only if the heavy host gains a gcc-13 default…"*. That precondition became true on 2026-08-05 — `g++-13` was installed on oplex7020 at 18:21 +04, and `update-alternatives --set gcc /usr/bin/gcc-13` pinned the default (manual mode) at 19:36 +04. `conan profile detect` there now yields `compiler.version=13`, not 15, which also removes the gcc-15 link failure that placement was working around. Worth a re-read of that decision; the mirror carries both `package_id`s either way, so this PR is agnostic to the outcome.