### PR TITLE
dash(diag): make the embedded/replay lanes say what they are doing

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -264,6 +264,71 @@ std::string g_replay_fold_worklists;          // --replay-fold-worklists FILE
 // serve are both fine WITHOUT proving the serve is daemonless.
 bool        g_no_dashd_mn_seed = false;       // --embedded-no-dashd-mn-seed
 
+// ───────────────────────────────────────────────────────────────────────────
+// [BLOCK-LEDGER] — our own block accounting, from PERSISTENT state
+// ───────────────────────────────────────────────────────────────────────────
+//
+// 2026-08-05, hotel: block h=2516911 was WON by the pool and ACCEPTED by the
+// chain (our exact PPLNS payout structure), and NEITHER node's log showed a
+// "BLOCK FOUND" line for it — the primary's log had been rotated that morning
+// and the reserve had restarted mid-evening. Counting our own blocks by
+// grepping the log produced two wrong answers in ten minutes.
+//
+// The defect is not the missing line, it is the SOURCE. This reads the
+// found-blocks LevelDB (loaded at startup, 107 entries that day) rather than
+// log history, so rotation and restart cost scrollback but not truth: the next
+// ledger line still prints the real totals. Emitted at standup and every 300 s.
+//
+// Telemetry only — it reads the ledger, it never writes it.
+void log_block_ledger(core::MiningInterface* mi)
+{
+    if (!mi) return;
+    using BS = core::MiningInterface::BlockStatus;
+    size_t   total = 0, accepted = 0, orphan = 0, stale = 0, pending = 0;
+    size_t   attributed = 0;
+    uint64_t last_found = 0, last_accepted = 0, last_found_ts = 0;
+    for (const auto& b : mi->get_found_blocks()) {
+        if (b.chain != "DASH") continue;
+        ++total;
+        // SAME ROW SEMANTICS AS /recent_blocks (#1127): a row with neither a
+        // local share hash nor a miner address was NOT found by this node —
+        // it was learned over relay, or it is a legacy row the enrichment
+        // path has not upgraded yet. Counting those into a bare "found_total"
+        // would overstate our own wins, which is the class of error this line
+        // exists to end; they are counted separately instead of silently.
+        if (!b.share_hash.empty() || !b.miner.empty()) ++attributed;
+        switch (b.status) {
+            case BS::confirmed: ++accepted; break;
+            case BS::orphaned:  ++orphan;   break;
+            case BS::stale:     ++stale;    break;
+            case BS::pending:   ++pending;  break;
+        }
+        if (b.height >= last_found) { last_found = b.height; last_found_ts = b.ts; }
+        if (b.status == BS::confirmed && b.height > last_accepted)
+            last_accepted = b.height;
+    }
+    const auto now = static_cast<uint64_t>(std::time(nullptr));
+    LOG_INFO << "[BLOCK-LEDGER] chain=DASH"
+             << " found_total=" << total
+             << " attributed=" << attributed
+             << " relay_or_unenriched=" << (total - attributed)
+             << " accepted=" << accepted
+             << " orphan=" << orphan
+             << " stale=" << stale
+             << " pending=" << pending
+             << " last_found=" << (last_found ? "h=" + std::to_string(last_found)
+                                              : std::string("n/a"))
+             << " last_found_age="
+             << (last_found_ts && now > last_found_ts
+                     ? std::to_string(now - last_found_ts) + "s"
+                     : std::string("n/a"))
+             << " last_accepted="
+             << (last_accepted ? "h=" + std::to_string(last_accepted)
+                               : std::string("n/a"))
+             << " source=found_blocks_db"
+             << " rotation_safe=1";
+}
+
 // Report the requested sharechain peering topology at run-loop bring-up. Honest
 // about the deferred live bind: a won/seen share does NOT yet cross the wire
 // until the sharechain pool-node leaf lands.
@@ -3840,22 +3905,48 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             auto qc_type_recon =
                 std::make_shared<dash::coin::LlmqTypeReconciler>(qc_net);
             auto qc_recon_said = std::make_shared<std::string>();
+            // 5-minute re-assert floor for a STANDING defect; a shape CHANGE
+            // gets its own key so it is never held back by the floor.
+            auto qc_recon_log =
+                std::make_shared<dash::coin::diag::LogSuppressor>(300000);
             node_coin_state.set_qc_plan_fn(
                 [&node_coin_state, hc = header_chain.get(), qc_net, qc_cache,
                  qc_gap_logged_h, qc_first_plan_h, qc_cold_note_done,
-                 qc_type_recon, qc_recon_said, qc_episode]
+                 qc_type_recon, qc_recon_said, qc_recon_log, qc_episode]
                 (uint32_t next_h) -> std::optional<dash::coin::QcBlockPlan> {
                     if (*qc_first_plan_h == 0u) *qc_first_plan_h = next_h;
                     // Observe the MINED set at the tip we are building on.
                     if (next_h > 0)
                         qc_type_recon->observe(next_h - 1u,
                                                node_coin_state.qmgr());
-                    // Log only when the SENTENCE CHANGES — a new offending
-                    // type must never be swallowed by dedup on an old one.
-                    if (auto said = qc_type_recon->format_defects();
-                        !said.empty() && said != *qc_recon_said) {
-                        *qc_recon_said = said;
-                        LOG_WARNING << said;
+                    // Log when the DEFECT SHAPE changes — a new offending
+                    // type must never be swallowed by dedup on an old one —
+                    // and otherwise at most once per 5 minutes, carrying the
+                    // count it stood in for.
+                    //
+                    // THE FLOOD THIS FIXES (measured 2026-08-04): the dedup
+                    // above compared the whole SENTENCE, and that sentence
+                    // embeds observations=/span=/heights=/sightings=, every
+                    // one of which moves on every template build. So "has it
+                    // changed" was always true and the guard was inert:
+                    // 205k+ identical-in-substance [LLMQ-TYPE-RECONCILE]
+                    // lines in one run, burying everything else. Keying on
+                    // defect_shape() (types + verdicts only) dedups on what
+                    // an operator acts on, while the periodic re-assert keeps
+                    // a standing defect from going silent.
+                    if (auto shape = qc_type_recon->defect_shape();
+                        !shape.empty()) {
+                        const int64_t now_ms = dash::coin::diag::steady_now_ms();
+                        const bool changed = (shape != *qc_recon_said);
+                        if (changed) *qc_recon_said = shape;
+                        if (qc_recon_log->allow(changed ? shape + "#new" : shape,
+                                                now_ms)) {
+                            LOG_WARNING
+                                << qc_type_recon->format_defects()
+                                << " suppressed="
+                                << qc_recon_log->take_suppressed(
+                                       changed ? shape + "#new" : shape);
+                        }
                     }
                     dash::coin::RequiredQcSlot gap{};
                     auto plan = dash::coin::build_daemonless_qc_plan(
@@ -4597,6 +4688,13 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 });
             mn_ckpt_lane->set_tip_height_fn(
                 [hc = header_chain.get()]() { return hc->height(); });
+            // DIAGNOSTIC seam: wire byte size of each replayed block, so the
+            // progress line can print `fetched=` instead of `fetched=n/a`.
+            // Telemetry only — the lane never branches on it.
+            mn_ckpt_lane->set_wire_size_fn(
+                [](const dash::coin::BlockType& b) -> size_t {
+                    return pack(b).size();
+                });
             mn_ckpt_lane->set_header_hash_at_fn(
                 [hc = header_chain.get()](uint32_t h) -> std::optional<uint256> {
                     auto e = hc->get_header_by_height(h);
@@ -5271,9 +5369,36 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                  << " members_answered=" << bs.members_answered
                                  << " members_missing=" << bs.members_missing
                                  << " lists_retained=" << br->retained_lists()
-                                 << " quorum_root_match/differ="
+                                 // ── SCOPED COUNTER (was mis-read) ──────
+                                 // Printed as `quorum_root_match/differ`
+                                 // this read as a 4684-block divergence. It
+                                 // is not: arm_self_check() has NO production
+                                 // caller, so the comparison runs UNARMED —
+                                 // a Tier-A anchor seeds no active quorum
+                                 // set, the folded root is a warm-up artefact
+                                 // and differs at essentially every height by
+                                 // construction, while the SERVED root was
+                                 // correct (154/154 shadow matches). The name
+                                 // now says which comparison it is and the
+                                 // line states the arming, so the number can
+                                 // no longer be read as divergence evidence.
+                                 // Scoping the COUNTER itself stays with the
+                                 // W4 task; this is the logging half.
+                                 << " fold_root_vs_committed="
                                  << bs.quorum_roots_matched << "/"
                                  << bs.quorum_roots_differed
+                                 << " self_check="
+                                 << (br->self_check_armed() ? "armed"
+                                                            : "UNARMED")
+                                 << (br->self_check_armed()
+                                        ? std::string()
+                                        : std::string(
+                                              " (unarmed: no quorum-set seed —"
+                                              " a differ here is warm-up, NOT"
+                                              " divergence; the SERVED root is"
+                                              " measured by the shadow"
+                                              " comparison, not by this"
+                                              " counter)"))
                                  << (bs.last_skip_reason.empty()
                                         ? std::string()
                                         : " last_skip=\"" + bs.last_skip_reason + "\"");
@@ -5758,6 +5883,165 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                      "(daemonless header-chain verdict"
                   << (rpc ? " + dashd getblockheader fallback" : "")
                   << ")\n";
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // DIAGNOSTIC TICK — telemetry only, no serve/arm/consensus effect
+    // ════════════════════════════════════════════════════════════════════════
+    //
+    // Everything below exists because of a specific incident on 2026-08-04/05
+    // where the answer was in the node's head and not in its log:
+    //
+    //   • [LANE-WATCHDOG] — the MN-CKPT bridge froze on BOTH .211 and contabo
+    //     right after a completed on-demand PoSe fold (h=2514874, h=2516862)
+    //     for 11-12 minutes with NO warning, because the stall probe lived
+    //     inside pump() below its own early returns and was driven by tip
+    //     changes. THIS timer is the independent path: it cannot be skipped by
+    //     the condition it is watching.
+    //   • [EMBED-STATUS] — "why is this node not serving?" took grepping four
+    //     different markers. The gate names its cause when it DECLINES a
+    //     template (#1038/#1039); this is the standing-state complement, so the
+    //     question is answerable without provoking a decline.
+    //   • [BLOCK-LEDGER] — block h=2516911 was won and accepted by the chain,
+    //     and NEITHER hotel node's log showed it: the primary's log had been
+    //     rotated that morning and the reserve had restarted. Counting our own
+    //     blocks by grepping a rotated, restart-truncated log produced two
+    //     wrong answers in ten minutes. This line is sourced from the found-
+    //     blocks DB (persistent) instead of from log history, so a rotated log
+    //     loses the scrollback and the NEXT line still prints the true totals.
+    {
+        namespace ddiag = dash::coin::diag;
+        auto* diag_mi = web_server ? web_server->get_mining_interface() : nullptr;
+
+        // ── WON-BLOCK VERDICT: ALREADY WIRED ON MASTER ─────────────────────
+        // An earlier revision of this branch wired add_chain_verify_fn("DASH")
+        // here, because main_dash had never called set_block_verify_fn /
+        // schedule_block_verification and every DASH block ever won sat at
+        // status=pending forever. That gap is now CLOSED ON MASTER by the
+        // post-broadcast block-confirm lane (block_confirm::resolve_status +
+        // its KAT), which resolves orphan/confirm off the embedded header
+        // chain and falls back to dashd getblockheader. Re-adding a
+        // per-chain verifier here would SHADOW it — verify_found_block
+        // prefers m_chain_verify_fns[chain] over m_block_verify_fn — so this
+        // branch deliberately wires NOTHING on that path and keeps only the
+        // ledger telemetry below. The verdicts themselves are logged by that
+        // lane; the periodic line here is the rotation-proof standing count.
+
+        auto diag_timer = std::make_shared<io::steady_timer>(ioc);
+        auto diag_tick =
+            std::make_shared<std::function<void(const boost::system::error_code&)>>();
+        auto ticks   = std::make_shared<uint64_t>(0);
+        // Shape-keyed suppressor: [EMBED-STATUS] is emitted whenever the SHAPE
+        // of the state changes (arm, cause, the precondition bits, the MN
+        // source) and otherwise once per heartbeat, carrying suppressed=N. The
+        // numeric cursors ride the line but are NOT part of the key — they move
+        // every block, and keying on them would turn a status line into a
+        // flood. Same policy the serve-gate journal (#1038) already applies.
+        auto embed_shape = std::make_shared<std::string>();
+        auto embed_since = std::make_shared<uint64_t>(0);
+        auto embed_last  = std::make_shared<int64_t>(0);
+
+        *diag_tick = [diag_timer, diag_tick, ticks, diag_mi, embed_shape,
+                      embed_since, embed_last, &node_coin_state, &maintainer,
+                      &header_chain, &mn_ckpt_lane](
+                         const boost::system::error_code& ec) {
+            if (ec) return;   // cancelled at shutdown
+            ++*ticks;
+
+            // ── 1. LANE WATCHDOG (every tick) ───────────────────────────
+            if (mn_ckpt_lane) mn_ckpt_lane->watchdog_tick();
+
+            // ── 2. EMBED-STATUS (every 2nd tick = 60 s) ─────────────────
+            if ((*ticks % 2) == 0) {
+                const auto d = node_coin_state.describe_decline();
+                const int  ht = node_coin_state.have_tip_dbg();
+                const int  hm = node_coin_state.have_mn_dbg();
+                const char* src =
+                    maintainer && !maintainer->mn_source().empty()
+                        ? maintainer->mn_source().c_str()
+                        : "n/a";
+                const bool dmnless =
+                    maintainer
+                    && maintainer->mn_source_daemonless();
+                const int32_t bcl = node_coin_state.best_cl_height();
+                const int32_t cp  = node_coin_state.credit_pool_height();
+                std::ostringstream shape;
+                shape << (d.viable ? "serve" : "decline") << '|' << d.cause
+                      << '|' << ht << hm << '|' << src << '|'
+                      << (node_coin_state.have_sml() ? 1 : 0) << '|'
+                      << (node_coin_state.mn_needs_reseed() ? 1 : 0) << '|'
+                      << (node_coin_state.tip_body_pending_dbg() ? 1 : 0) << '|'
+                      << (mn_ckpt_lane ? mn_ckpt_lane->state_name() : "none");
+                const int64_t now = ddiag::steady_now_ms();
+                const bool changed = shape.str() != *embed_shape;
+                // 5-minute heartbeat: an UNCHANGED state must still prove it is
+                // being observed, or "quiet" and "dead" look the same again.
+                const bool heartbeat = (now - *embed_last) >= 300000;
+                if (changed || heartbeat) {
+                    LOG_INFO
+                        << "[EMBED-STATUS]"
+                        << " arm=" << (d.viable ? "would-serve" : "would-decline")
+                        << " cause=" << (d.viable ? std::string("none") : d.cause)
+                        << " value=" << d.value << " threshold=" << d.threshold
+                        << " populated=" << (node_coin_state.populated() ? 1 : 0)
+                        << " have_tip=" << (ht < 0 ? std::string("n/a")
+                                                   : std::to_string(ht))
+                        << " have_mn=" << (hm < 0 ? std::string("n/a")
+                                                  : std::to_string(hm))
+                        << " mn_source=" << src
+                        << " mn_daemonless=" << (dmnless ? 1 : 0)
+                        << " payee_cursor="
+                        << node_coin_state.mnstates().last_applied_height() << "/"
+                        << (header_chain ? header_chain->height() : 0)
+                        << " mn_entries=" << node_coin_state.mnstates().size()
+                        << " sml=" << (node_coin_state.have_sml() ? "ok" : "absent")
+                        << " sml_h="
+                        << (maintainer ? maintainer->sml_current_height() : 0)
+                        << " quorums=" << node_coin_state.qmgr().active_count()
+                        << " bestcl=" << (bcl > 0 ? std::to_string(bcl)
+                                                  : std::string("n/a"))
+                        << " creditpool=" << (cp >= 0 ? std::to_string(cp)
+                                                      : std::string("n/a"))
+                        << " reseed_latch="
+                        << (node_coin_state.mn_needs_reseed() ? 1 : 0)
+                        // Body-first transient (landed on master after this
+                        // branch point): a known-newer header tip whose block
+                        // body / tip-targeted cbTx has not been parsed yet. It
+                        // is the normal ~1-2 s propagation window, and naming
+                        // it here stops a refusal inside it reading as a
+                        // header-sync fault.
+                        << " tip_body_pending="
+                        << (node_coin_state.tip_body_pending_dbg() ? 1 : 0)
+                        << " bridge="
+                        << (mn_ckpt_lane ? mn_ckpt_lane->state_name() : "none")
+                        << " bridge_cursor="
+                        << (mn_ckpt_lane ? mn_ckpt_lane->cursor_height() : 0)
+                        << " bridge_wait="
+                        << (mn_ckpt_lane ? mn_ckpt_lane->waiting_for()
+                                         : std::string("n/a"))
+                        << " hdr_tip=" << (header_chain ? header_chain->height() : 0)
+                        << " trigger=" << (changed ? "shape-change" : "heartbeat")
+                        << " suppressed=" << *embed_since;
+                    *embed_shape = shape.str();
+                    *embed_last  = now;
+                    *embed_since = 0;
+                } else {
+                    ++*embed_since;
+                }
+            }
+
+            // ── 3. BLOCK-LEDGER (every 10th tick = 300 s) ───────────────
+            if (diag_mi && (*ticks % 10) == 0) log_block_ledger(diag_mi);
+
+            diag_timer->expires_after(std::chrono::seconds(30));
+            diag_timer->async_wait(*diag_tick);
+        };
+        // ONE ledger line immediately at standup, so a freshly rotated or
+        // freshly restarted log carries the true persistent totals from its
+        // first minute rather than only after five.
+        if (diag_mi) log_block_ledger(diag_mi);
+        diag_timer->expires_after(std::chrono::seconds(30));
+        diag_timer->async_wait(*diag_tick);
     }
 
     std::cout << "[run] run-loop up (Ctrl-C to stop); won blocks relay DUAL-PATH:\n"

--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -33,6 +33,7 @@
 #include <impl/dash/coin/governance_object.hpp>  // parse_superblock_trigger, govvote_signature_hash
 #include <impl/dash/coin/superblock.hpp>         // get_superblock_payments (R6 cross-check + provider)
 #include <impl/dash/coin/mn_state_machine.hpp>   // MNState
+#include <impl/dash/coin/lane_diag.hpp>          // diag::MnSource (population attribution)
 #include <impl/dash/coin/block.hpp>            // BlockType
 #include <impl/dash/coin/transaction.hpp>        // MutableTransaction
 #include <impl/dash/coin/vendor/smldiff.hpp>     // vendor::CSimplifiedMNListDiff + apply_diff
@@ -336,6 +337,24 @@ public:
                  << " as_of_h=" << as_of_height
                  << " mns=" << mnstates.size()
                  << (mnstates.empty() ? " (EMPTY -> set-gap, demoting)" : "");
+        // ── DAEMONLESS CLASSIFICATION (the 2026-08-04 misreading) ────────
+        // #1128's line above names the lane; this states the CONSEQUENCE, and
+        // it is the half that actually cost the day: we read a run as proof of
+        // a daemonless serve when its payee half had come from dashd, and only
+        // an A/B with --coin-rpc removed exposed it. The predicate is derived
+        // from the very string #1128 passed in — never inferred from which
+        // flags were on the command line — and it rides the standing
+        // [EMBED-STATUS] line so the question is answerable at any moment, not
+        // only at the instant a snapshot lands.
+        LOG_INFO << "[PAYEE-QUEUE] daemonless="
+                 << (mn_source_daemonless() ? 1 : 0)
+                 << " (source=" << m_mn_source
+                 << " => " << (mn_source_daemonless()
+                                   ? "no daemon supplied this payee queue"
+                                   : "a daemon (or an un-named caller) supplied"
+                                     " this payee queue; a run using it has NOT"
+                                     " proven a daemonless serve")
+                 << ")";
         // With the anti-mint latch on, a snapshot with NO height cannot arm
         // MN-readiness either: an unheighted set leaves the apply cursor at 0,
         // which disables apply_block's contiguity guard — the exact condition
@@ -425,7 +444,20 @@ public:
         // BODY-FIRST: an authoritative snapshot loaded as-of the pending tip
         // completes the payee axis — the last promotion precondition when the
         // credit-pool seed already reached the tip (diff-before-seed order).
+        // Kept AHEAD of the telemetry below so the logged state is the state
+        // after promotion, and so `promoted` reaches its use at the tail.
         const bool promoted = maybe_promote_pending_tip();
+        // POST-STATE, which #1128's [PAYEE-QUEUE] line above cannot carry:
+        // that one fires at entry, before the load, the SML reconcile and the
+        // promotion. This is the same snapshot AFTER all of them, so "the
+        // queue was replaced" and "the queue is now usable" stop being the
+        // same sentence.
+        LOG_INFO << "[PAYEE-QUEUE] applied source=" << m_mn_source
+                 << " eligible=" << m_state.mnstates().eligible_size()
+                 << " as_of=" << as_of_height
+                 << " have_mn=" << (m_have_mn ? 1 : 0)
+                 << " reseed_latch=" << (m_mn_needs_reseed ? 1 : 0)
+                 << " tip_promoted=" << (promoted ? 1 : 0);
         if (!m_have_mn)
             demote();
         else
@@ -437,6 +469,26 @@ public:
         // cache until an unrelated signal lands.
         if (promoted)
             notify_state_dirty();
+    }
+
+    /// ── STANDING-STATE READOUTS (telemetry only) ─────────────────────────
+    /// The two halves of populated(), the snapshot cursor and the authoritative
+    /// population source, exposed so the periodic [EMBED-STATUS] line can name
+    /// each precondition instead of an operator grepping four markers to
+    /// reconstruct them. Read-only; nothing here is consulted by a gate.
+    bool     have_tip() const { return m_have_tip; }
+    bool     have_mn()  const { return m_have_mn; }
+    uint32_t mn_snapshot_height() const { return m_mn_snapshot_height; }
+    bool     mn_needs_reseed_latched() const { return m_mn_needs_reseed; }
+    /// Is the CURRENT payee queue backed by a lane that needs no daemon?
+    /// Classified from the source string #1128's publishers pass in (its
+    /// kPayeeSource* constants are exactly these tokens) — never inferred
+    /// from configuration. mn_source() itself is #1128's accessor and is
+    /// unchanged; this is the consequence the string alone does not state.
+    bool mn_source_daemonless() const
+    {
+        return diag::mn_source_is_daemonless(
+            diag::mn_source_from_name(m_mn_source));
     }
 
     /// Reception path (mnlistdiff, SML axis — DAEMONLESS CCbTx source): apply a
@@ -1178,6 +1230,12 @@ private:
             m_state.mnstates().load({});
             m_mn_snapshot_height = 0;
             m_have_mn = false;
+            // The wiped queue has NO source any more. Leaving the last
+            // lane's name standing would make [PAYEE-QUEUE]/[EMBED-STATUS]
+            // keep claiming a backing that no longer exists — and, worse,
+            // keep claiming it was DAEMONLESS. Same class of misreading the
+            // source field exists to end.
+            m_mn_source.clear();
             // Latch: only an authoritative on_mn_list_update resync may re-arm
             // MN-readiness. Without this, a stray ProRegTx observed in a later
             // block would register into the wiped set and republish a 1-MN

--- a/src/impl/dash/coin/header_chain.hpp
+++ b/src/impl/dash/coin/header_chain.hpp
@@ -6,6 +6,7 @@
 /// Persistence via LevelDB for fast restarts.
 
 #include "block.hpp"
+#include "lane_diag.hpp"        // ProgressReporter / LogSuppressor (backfill telemetry)
 #include <impl/bitcoin_family/coin/chain_params.hpp>
 #include <impl/dash/crypto/hash_x11.hpp>
 
@@ -393,17 +394,59 @@ public:
             if (offset + BATCH_SIZE < headers.size())
                 std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
+        // WIRE BYTES. Each entry in a DASH `headers` message is an 80-byte
+        // header plus a CompactSize(0) tx-count byte, so this is the exact
+        // payload size for the batch (the message's own count varint aside) —
+        // not an estimate. Counted for RECEIVED, not accepted: bytes are what
+        // came off the wire whether or not the header was new.
+        static constexpr uint64_t kWireBytesPerHeader = 81;
+        m_hdr_wire_bytes += static_cast<uint64_t>(headers.size())
+                            * kWireBytesPerHeader;
+        m_hdr_received   += static_cast<uint64_t>(headers.size());
+        m_hdr_accepted   += static_cast<uint64_t>(accepted);
         if (accepted > 0) {
             std::lock_guard<std::mutex> lock(m_mutex);
             persist_tip();
             uint32_t peer_tip = m_peer_tip_height.load(std::memory_order_relaxed);
             if (peer_tip > 0 && m_tip_height > 0) {
-                double pct = 100.0 * m_tip_height / peer_tip;
-                static uint32_t s_last_logged = 0;
-                if (m_tip_height - s_last_logged >= 2000 || pct >= 99.9) {
-                    s_last_logged = m_tip_height;
-                    LOG_INFO << "[DASH] Header sync: " << m_tip_height << "/" << peer_tip
-                             << " (" << std::fixed << std::setprecision(1) << pct << "%)";
+                // ── THE HEADER-BACKFILL PROGRESS LINE ────────────────────
+                // Replaces the old `[DASH] Header sync: N/M (P%)`, which had
+                // three defects that each cost time on 2026-08-04: no RATE and
+                // no ETA (both had to be reconstructed by diffing log
+                // timestamps by hand), no BYTES, and a throttle on height
+                // ALONE — so a backfill that slowed to a crawl went quiet for
+                // as long as it took to cover 2000 blocks, which is exactly
+                // when an operator most needs a line. The new throttle is
+                // 2000 headers OR 15 s, whichever comes FIRST.
+                //
+                // The old throttle also used a function-local `static`, i.e.
+                // ONE counter shared by every HeaderChain in the process; the
+                // member below is per-instance.
+                const int64_t now = diag::steady_now_ms();
+                if (!m_hdr_progress.started())
+                    m_hdr_progress.start(m_tip_height, now);
+                auto s = m_hdr_progress.sample(m_tip_height, now);
+                const bool finishing = (100.0 * m_tip_height / peer_tip) >= 99.9;
+                if (!s && finishing) s = m_hdr_progress.flush(m_tip_height, now);
+                if (s) {
+                    const uint64_t remaining =
+                        peer_tip > m_tip_height ? (peer_tip - m_tip_height) : 0;
+                    LOG_INFO
+                        << "[REPLAY-PROGRESS] lane=hdr-backfill"
+                        << " cursor=" << m_tip_height
+                        << " target=" << peer_tip
+                        << " done="
+                        << diag::fmt1(diag::ProgressReporter::done_pct(
+                               m_tip_height, peer_tip))
+                        << "%"
+                        << " rate=" << diag::fmt1(s->rate_per_s) << "hdr/s"
+                        << " eta="
+                        << diag::fmt_eta(diag::ProgressReporter::eta_s(
+                               *s, remaining))
+                        << " fetched=" << diag::fmt_bytes(m_hdr_wire_bytes)
+                        << " received=" << m_hdr_received
+                        << " accepted=" << m_hdr_accepted
+                        << " elapsed=" << (s->total_ms / 1000) << "s";
                 }
             }
         }
@@ -414,8 +457,20 @@ public:
         // genesis stub is not seeded, so headers served from block 1 orphan-
         // reject invisibly. Log the first header's prev hash so orphan-vs-PoW
         // is distinguishable.
-        LOG_INFO << "[DASH] CP2 validate add_headers: received=" << headers.size()
-                 << " accepted=" << accepted;
+        // THROTTLED (was one line per message, unbounded). During tip-follow
+        // this fires per header message forever and buries everything else;
+        // the suppressor collapses it to one line per 30 s and CARRIES the
+        // dropped count, so a storm is summarised rather than silently lost.
+        // The accepted==0 corner below is deliberately NOT suppressed: it is
+        // the diagnostic, not the noise.
+        {
+            const int64_t now = diag::steady_now_ms();
+            static const std::string kKey = "hdr-cp2";
+            if (m_hdr_cp2_log.allow(kKey, now))
+                LOG_INFO << "[DASH] CP2 validate add_headers: received="
+                         << headers.size() << " accepted=" << accepted
+                         << " suppressed=" << m_hdr_cp2_log.take_suppressed(kKey);
+        }
         if (accepted == 0 && !headers.empty())
             LOG_INFO << "[DASH] CP2 validate: accepted==0 first_prev_block="
                      << headers.front().m_previous_block.GetHex();
@@ -437,6 +492,16 @@ public:
     }
 
     void set_peer_tip_height(uint32_t height) { m_peer_tip_height.store(height); }
+
+    /// Backfill progress line throttle: at most one line per `headers` of
+    /// forward progress OR per `ms` of wall clock, whichever comes first.
+    /// Telemetry only; exposed so a KAT can prove the line fires without
+    /// mining 2000 headers, and so an operator can tighten it during a debug
+    /// session without a rebuild-and-redeploy.
+    void set_progress_throttle(uint64_t headers, int64_t ms)
+    {
+        m_hdr_progress = diag::ProgressReporter(headers, ms);
+    }
 
     void set_dynamic_checkpoint(uint32_t height, const uint256& hash) {
         std::lock_guard<std::mutex> lock(m_mutex);
@@ -757,6 +822,16 @@ private:
     std::set<uint256> m_dirty_headers;
 
     TipChangedCallback m_on_tip_changed;
+
+    // ─── Backfill telemetry (no lock: touched only on the ingest thread) ──
+    /// 2000 headers OR 15 s, whichever comes first. Per-INSTANCE, unlike the
+    /// function-local `static` this replaced.
+    diag::ProgressReporter m_hdr_progress{2000, 15000};
+    /// One CP2 line per 30 s, with the dropped count carried on the next.
+    diag::LogSuppressor    m_hdr_cp2_log{30000};
+    uint64_t m_hdr_wire_bytes{0};
+    uint64_t m_hdr_received{0};
+    uint64_t m_hdr_accepted{0};
 
     struct PendingTipChange {
         bool fired{false};

--- a/src/impl/dash/coin/lane_diag.hpp
+++ b/src/impl/dash/coin/lane_diag.hpp
@@ -1,0 +1,419 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// LANE DIAGNOSTICS — the three primitives every embedded/daemonless DASH lane
+/// needs so that a log alone answers WHAT state the node is in, WHY it is not
+/// serving, and HOW FAST each lane is moving.
+///
+/// This header is TELEMETRY ONLY. Nothing here participates in a serve
+/// decision, a consensus path or an arm decision; every type is a counter, a
+/// clock reading or a string. That is deliberate: the incidents below were all
+/// diagnosis failures, not logic failures, and the fix must not be able to
+/// change what the node does.
+///
+/// ─────────────────────────────────────────────────────────────────────────
+/// WHY EACH PRIMITIVE EXISTS (measured, 2026-08-04/05, mainnet .211 + contabo)
+/// ─────────────────────────────────────────────────────────────────────────
+///
+/// • ProgressReporter — the replay, the header backfill and the MN-CKPT payee
+///   bridge all advanced SILENTLY. Rate and ETA had to be reconstructed by
+///   diffing log timestamps by hand. A per-lane progress line with cursor,
+///   target, rate over the last window, ETA and bytes fetched removes that
+///   whole manual step. Throttled on BOTH axes (every N units OR every T
+///   seconds, whichever comes first) because a per-block line is a flood: the
+///   same day's log carried 205k+ repeated lines from one un-throttled site.
+///
+/// • StallWatchdog — the WORST defect of the day. The MN-CKPT bridge froze on
+///   BOTH nodes right after a completed on-demand PoSe fold (cursors
+///   h=2514874 and h=2516862) for 11-12 minutes with NO warning at all. The
+///   stall detector lived inside pump(), which (a) only runs on a tip change
+///   (~2.5 min apart) and (b) early-returns on several paths, INCLUDING the
+///   pending-snapshot path — so the detector could be skipped by the very
+///   condition it exists to detect, and even when it did run it needed five
+///   consecutive stalled pumps (~12 min) before it said anything. The only
+///   symptom was "the arm never arms".
+///
+///   The rule this class encodes: A STALL DETECTOR MUST NOT LIVE ON THE PATH
+///   IT WATCHES. StallWatchdog keeps a last-progress WALL-CLOCK timestamp and
+///   is polled from an independent periodic timer, so a lane that stops
+///   calling anything at all is exactly the case it reports fastest.
+///
+/// • LogSuppressor — the flood control the gate already applies by hand, made
+///   reusable: identical repeated lines collapse to one line plus a
+///   `suppressed=N` count on the next emit, so a storm is still COUNTED but
+///   costs one line per interval instead of 205k.
+///
+/// All three take an explicit `now_ms` so a KAT can drive time deterministically
+/// rather than sleeping.
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <iomanip>
+#include <map>
+#include <optional>
+#include <sstream>
+#include <string>
+
+namespace dash {
+namespace coin {
+namespace diag {
+
+/// Monotonic milliseconds. Steady, not wall — a clock step must not fabricate
+/// a stall or erase one.
+inline int64_t steady_now_ms()
+{
+    using namespace std::chrono;
+    return duration_cast<milliseconds>(steady_clock::now().time_since_epoch())
+        .count();
+}
+
+/// One decimal place, fixed. Keeps `rate=142.6blk/s` greppable and parseable.
+inline std::string fmt1(double v)
+{
+    std::ostringstream os;
+    os << std::fixed << std::setprecision(1) << v;
+    return os.str();
+}
+
+/// Bytes as a human unit WITHOUT losing the machine-parseable shape: the value
+/// and the unit are one token (`fetched=56.9MB`), so a scraper can split on the
+/// first non-numeric character.
+inline std::string fmt_bytes(uint64_t bytes)
+{
+    if (bytes < 1024ull) return std::to_string(bytes) + "B";
+    const double kb = static_cast<double>(bytes) / 1024.0;
+    if (kb < 1024.0) return fmt1(kb) + "KB";
+    const double mb = kb / 1024.0;
+    if (mb < 1024.0) return fmt1(mb) + "MB";
+    return fmt1(mb / 1024.0) + "GB";
+}
+
+/// Seconds as `19s` / `4m12s` / `1h04m`. `n/a` when the rate is unknown — an
+/// ETA of 0 and an ETA that cannot be computed are different facts and the log
+/// must not conflate them.
+inline std::string fmt_eta(std::optional<double> seconds)
+{
+    if (!seconds) return "n/a";
+    if (*seconds < 0) return "n/a";
+    const int64_t s = static_cast<int64_t>(*seconds + 0.5);
+    if (s < 60) return std::to_string(s) + "s";
+    if (s < 3600) return std::to_string(s / 60) + "m" + std::to_string(s % 60) + "s";
+    std::ostringstream os;
+    os << (s / 3600) << "h" << std::setw(2) << std::setfill('0')
+       << ((s % 3600) / 60) << "m";
+    return os.str();
+}
+
+/// ─────────────────────────────────────────────────────────────────────────
+/// PROGRESS + RATE, throttled on two axes
+/// ─────────────────────────────────────────────────────────────────────────
+///
+/// `sample(units, now)` returns a filled Sample at most once per
+/// `every_units` of forward progress OR once per `every_ms` of wall clock,
+/// WHICHEVER COMES FIRST — so a fast lane reports by block count and a slow or
+/// stopped-but-not-dead lane still reports by time. It returns nullopt
+/// otherwise, and the caller emits nothing.
+///
+/// The rate is measured over the interval between the previous emit and this
+/// one (not since the start), which is what an operator asking "is it speeding
+/// up or slowing down" actually wants.
+class ProgressReporter
+{
+public:
+    struct Sample
+    {
+        uint64_t units{0};        ///< absolute progress counter now
+        uint64_t delta{0};        ///< units since the previous emit
+        int64_t  elapsed_ms{0};   ///< wall ms since the previous emit
+        double   rate_per_s{0.0}; ///< delta / elapsed over THAT window
+        int64_t  total_ms{0};     ///< wall ms since start()
+    };
+
+    ProgressReporter() = default;
+    ProgressReporter(uint64_t every_units, int64_t every_ms)
+        : m_every_units(every_units ? every_units : 1)
+        , m_every_ms(every_ms > 0 ? every_ms : 1)
+    {
+    }
+
+    /// (Re)arm at the start of a run. A re-armed lane must not inherit the
+    /// previous run's baseline — that is how a restarted bridge reported a
+    /// negative delta and an absurd rate.
+    void start(uint64_t base_units, int64_t now)
+    {
+        m_started    = true;
+        m_start_ms   = now;
+        m_last_units = base_units;
+        m_last_ms    = now;
+    }
+
+    bool started() const { return m_started; }
+
+    /// Throttled sample. See the class comment for the two-axis rule.
+    std::optional<Sample> sample(uint64_t units, int64_t now)
+    {
+        if (!m_started) start(units, now);
+        const bool by_units = units >= m_last_units
+                              && (units - m_last_units) >= m_every_units;
+        const bool by_time = (now - m_last_ms) >= m_every_ms;
+        if (!by_units && !by_time) return std::nullopt;
+        return flush(units, now);
+    }
+
+    /// UNCONDITIONAL sample — for a terminal event (publish, fail-close) where
+    /// the last window must be reported whatever the throttle says.
+    std::optional<Sample> flush(uint64_t units, int64_t now)
+    {
+        if (!m_started) start(units, now);
+        Sample s;
+        s.units      = units;
+        s.delta      = units >= m_last_units ? units - m_last_units : 0;
+        s.elapsed_ms = now > m_last_ms ? now - m_last_ms : 0;
+        s.total_ms   = now > m_start_ms ? now - m_start_ms : 0;
+        s.rate_per_s = s.elapsed_ms > 0
+                           ? (static_cast<double>(s.delta) * 1000.0
+                              / static_cast<double>(s.elapsed_ms))
+                           : 0.0;
+        m_last_units = units;
+        m_last_ms    = now;
+        return s;
+    }
+
+    /// ETA for `remaining` units at the sample's rate. nullopt (printed `n/a`)
+    /// when the window carried no progress — "cannot say" is a different
+    /// statement from "zero seconds".
+    static std::optional<double> eta_s(const Sample& s, uint64_t remaining)
+    {
+        if (s.rate_per_s <= 0.0) return std::nullopt;
+        return static_cast<double>(remaining) / s.rate_per_s;
+    }
+
+    /// done fraction in percent, 0 when the target is not yet known.
+    static double done_pct(uint64_t done, uint64_t total)
+    {
+        if (total == 0) return 0.0;
+        return 100.0 * static_cast<double>(done) / static_cast<double>(total);
+    }
+
+private:
+    uint64_t m_every_units{500};
+    int64_t  m_every_ms{30000};
+    bool     m_started{false};
+    int64_t  m_start_ms{0};
+    uint64_t m_last_units{0};
+    int64_t  m_last_ms{0};
+};
+
+/// ─────────────────────────────────────────────────────────────────────────
+/// STALL WATCHDOG — polled from a path the watched lane cannot skip
+/// ─────────────────────────────────────────────────────────────────────────
+///
+/// Contract, and the whole point of the class:
+///
+///   • progress(now)  — called by the lane WHENEVER its cursor actually moves.
+///   • due(now)       — called by an INDEPENDENT periodic timer. Never by the
+///                      lane's own drive function. If the lane stops being
+///                      driven entirely, `due()` still fires; that is the
+///                      2026-08-04 freeze, and it is the case this must catch
+///                      FASTEST rather than not at all.
+///
+/// `due()` returns the elapsed-since-progress ms when a warning is owed
+/// (silence longer than `stall_ms`, then once per `repeat_ms`), else nullopt.
+class StallWatchdog
+{
+public:
+    StallWatchdog() = default;
+    StallWatchdog(int64_t stall_ms, int64_t repeat_ms)
+        : m_stall_ms(stall_ms > 0 ? stall_ms : 1)
+        , m_repeat_ms(repeat_ms > 0 ? repeat_ms : 1)
+    {
+    }
+
+    /// Arm the watchdog and treat NOW as the last progress. Called when a lane
+    /// starts (or re-arms) — an armed-but-never-progressed lane is exactly the
+    /// "never started moving" case and must be reported, not excused.
+    void arm(int64_t now)
+    {
+        m_armed         = true;
+        m_last_progress = now;
+        m_last_warn     = 0;
+        m_have_warned   = false;
+        m_warnings      = 0;
+    }
+
+    /// Terminal or complete: stop reporting. A published/failed-closed lane is
+    /// not stalled, it is DONE, and saying "stalled" about it is noise that
+    /// trains operators to ignore the tag.
+    void disarm() { m_armed = false; }
+
+    bool armed() const { return m_armed; }
+
+    /// The lane moved. Cheap enough to call per block.
+    void progress(int64_t now)
+    {
+        m_last_progress = now;
+        m_have_warned   = false;
+    }
+
+    int64_t last_progress_ms() const { return m_last_progress; }
+    uint32_t warnings() const { return m_warnings; }
+
+    /// Elapsed silence when a warning is owed, else nullopt.
+    std::optional<int64_t> due(int64_t now)
+    {
+        if (!m_armed) return std::nullopt;
+        const int64_t elapsed = now - m_last_progress;
+        if (elapsed < m_stall_ms) return std::nullopt;
+        if (m_have_warned && (now - m_last_warn) < m_repeat_ms)
+            return std::nullopt;
+        m_last_warn   = now;
+        m_have_warned = true;
+        ++m_warnings;
+        return elapsed;
+    }
+
+    /// Elapsed silence, whether or not a warning is owed (for status lines).
+    int64_t elapsed_ms(int64_t now) const
+    {
+        return m_armed ? (now - m_last_progress) : 0;
+    }
+
+private:
+    int64_t  m_stall_ms{120000};
+    int64_t  m_repeat_ms{120000};
+    bool     m_armed{false};
+    int64_t  m_last_progress{0};
+    int64_t  m_last_warn{0};
+    bool     m_have_warned{false};
+    uint32_t m_warnings{0};
+};
+
+/// ─────────────────────────────────────────────────────────────────────────
+/// LOG SUPPRESSOR — collapse a repeat storm to one line + `suppressed=N`
+/// ─────────────────────────────────────────────────────────────────────────
+///
+/// `allow(key, now)` returns true at most once per `every_ms` per key. Every
+/// refused call is COUNTED, and `take_suppressed(key)` hands that count to the
+/// next line that is allowed — so a storm is never silently dropped, it is
+/// summarised. (2026-08-04: one site emitted 205k+ identical lines in a single
+/// run and buried everything else.)
+///
+/// The key table is bounded: a key space that grows without limit is a leak,
+/// so past `kMaxKeys` the oldest entry is evicted. Callers should therefore key
+/// on the SHAPE of the line (a tag + a type), never on a per-block value.
+class LogSuppressor
+{
+public:
+    static constexpr size_t kMaxKeys = 64;
+
+    LogSuppressor() = default;
+    explicit LogSuppressor(int64_t every_ms)
+        : m_every_ms(every_ms > 0 ? every_ms : 1)
+    {
+    }
+
+    bool allow(const std::string& key, int64_t now)
+    {
+        auto it = m_keys.find(key);
+        if (it == m_keys.end()) {
+            if (m_keys.size() >= kMaxKeys) evict_oldest();
+            m_keys.emplace(key, Entry{now, 0});
+            return true;
+        }
+        if ((now - it->second.last_emit_ms) >= m_every_ms) {
+            it->second.last_emit_ms = now;
+            return true;
+        }
+        ++it->second.suppressed;
+        return false;
+    }
+
+    /// Suppressed count since the previous allowed line, and reset it. Emit it
+    /// as `suppressed=N` on the line that is allowed.
+    uint64_t take_suppressed(const std::string& key)
+    {
+        auto it = m_keys.find(key);
+        if (it == m_keys.end()) return 0;
+        const uint64_t n = it->second.suppressed;
+        it->second.suppressed = 0;
+        return n;
+    }
+
+    uint64_t suppressed(const std::string& key) const
+    {
+        auto it = m_keys.find(key);
+        return it == m_keys.end() ? 0 : it->second.suppressed;
+    }
+
+private:
+    struct Entry
+    {
+        int64_t  last_emit_ms{0};
+        uint64_t suppressed{0};
+    };
+
+    void evict_oldest()
+    {
+        auto oldest = m_keys.begin();
+        for (auto it = m_keys.begin(); it != m_keys.end(); ++it)
+            if (it->second.last_emit_ms < oldest->second.last_emit_ms) oldest = it;
+        m_keys.erase(oldest);
+    }
+
+    int64_t m_every_ms{60000};
+    std::map<std::string, Entry> m_keys;
+};
+
+/// ─────────────────────────────────────────────────────────────────────────
+/// MN-LIST SOURCE — the thing that most misled us, made to say its own name
+/// ─────────────────────────────────────────────────────────────────────────
+///
+/// A DASH node can populate its payee queue from three different places, and
+/// on 2026-08-04 we believed a serve was DAEMONLESS when it was in fact riding
+/// a dashd `protx list` startup seed. Only an A/B run with --coin-rpc removed
+/// exposed it. Every population event now states its source, and the standing
+/// status line carries the authoritative one, so "which source is backing this
+/// payee queue" is never again an inference.
+enum class MnSource
+{
+    None,        ///< nothing has populated the queue
+    DashdSeed,   ///< dashd RPC `protx list registered` startup seed (mn_seed)
+    MnCkpt,      ///< the release-pinned checkpoint + forward-replay bridge
+    ReplayFold,  ///< a masternode-list fold produced by the block replay lane
+    Unknown      ///< populated by a path that did not name itself: a BUG
+};
+
+inline const char* mn_source_name(MnSource s)
+{
+    switch (s) {
+        case MnSource::None:       return "none";
+        case MnSource::DashdSeed:  return "dashd-seed";
+        case MnSource::MnCkpt:     return "mn-ckpt";
+        case MnSource::ReplayFold: return "replay-fold";
+        case MnSource::Unknown:    return "unknown";
+    }
+    return "unknown";
+}
+
+/// Parse back, so a test (or a scraper) can round-trip the token.
+inline MnSource mn_source_from_name(const std::string& n)
+{
+    if (n == "dashd-seed")  return MnSource::DashdSeed;
+    if (n == "mn-ckpt")     return MnSource::MnCkpt;
+    if (n == "replay-fold") return MnSource::ReplayFold;
+    if (n == "none")        return MnSource::None;
+    return MnSource::Unknown;
+}
+
+/// Whether a source is daemon-independent. The A/B that exposed the misreading
+/// is exactly this predicate, and encoding it here means the log can state the
+/// conclusion instead of leaving it to the reader.
+inline bool mn_source_is_daemonless(MnSource s)
+{
+    return s == MnSource::MnCkpt || s == MnSource::ReplayFold;
+}
+
+} // namespace diag
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/llmq_type_reconciler.hpp
+++ b/src/impl/dash/coin/llmq_type_reconciler.hpp
@@ -474,6 +474,33 @@ public:
         return s;
     }
 
+    /// The DEFECT SHAPE — the finding set with every volatile counter
+    /// stripped: type + verdict + required, and nothing else.
+    ///
+    /// WHY THIS EXISTS. format_defects() embeds `observations=`, `span=`,
+    /// `heights=[first,last]` and per-type `sightings=`, ALL of which move on
+    /// every template build. A caller that dedups on "has the sentence
+    /// changed" therefore re-logs on EVERY observation even when the finding
+    /// is identical — the sentence cannot help but change. Measured
+    /// 2026-08-04: 205k+ [LLMQ-TYPE-RECONCILE] lines in a single run, which
+    /// buried every other diagnostic in the log. Keying on this shape dedups
+    /// on the thing an operator actually cares about (WHICH types are wrong),
+    /// while a genuinely new offending type still changes the key and is
+    /// reported immediately. Empty when there is nothing wrong.
+    std::string defect_shape() const
+    {
+        auto d = defects();
+        if (d.empty()) return {};
+        std::string k;
+        for (const auto& f : d) {
+            k += std::to_string(static_cast<int>(f.llmq_type));
+            k += ':';
+            k += llmq_type_verdict_name(f.verdict);
+            k += f.required ? ":req;" : ":opt;";
+        }
+        return k;
+    }
+
     void reset()
     {
         m_seen.clear();

--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -209,6 +209,7 @@
 #include <impl/dash/coin/mn_checkpoint.hpp>
 #include <impl/dash/coin/mn_state_machine.hpp>
 #include <impl/dash/coin/historical_sml.hpp>   // authenticate_historical_snapshot
+#include <impl/dash/coin/lane_diag.hpp>        // ProgressReporter / StallWatchdog / MnSource
 #include <impl/dash/coin/vendor/simplifiedmns.hpp>
 #include <impl/dash/coin/vendor/smldiff.hpp>    // CSimplifiedMNListDiff
 #include <impl/dash/coin/vendor/cbtx.hpp>       // CCbTx
@@ -380,6 +381,118 @@ public:
     /// anchor, or run with a coin RPC).
     void set_max_bridge_blocks(uint32_t n) { m_max_bridge = n; }
     uint32_t max_bridge_blocks() const     { return m_max_bridge; }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // DIAGNOSTIC SEAMS (telemetry only — no serve/arm/consensus effect)
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// Monotonic clock. Injectable so a KAT can drive the progress throttle and
+    /// the stall watchdog deterministically instead of sleeping.
+    void set_clock_fn(std::function<int64_t()> fn) { m_now = std::move(fn); }
+
+    /// Wire size of a replayed block, for the `fetched=` field of the progress
+    /// line. OPTIONAL: unwired, the line prints `fetched=n/a` rather than a
+    /// fabricated number. Kept as a seam rather than serialising inline so the
+    /// lane stays free of a codec dependency it does not otherwise need.
+    void set_wire_size_fn(std::function<size_t(const BlockType&)> fn)
+    {
+        m_wire_size = std::move(fn);
+    }
+
+    /// Emit at most one progress line per `blocks` of replay OR per `ms` of
+    /// wall clock, whichever comes first. Defaults are sized so a full
+    /// 20000-block bridge costs ~40 lines, not 20000.
+    void set_progress_throttle(uint64_t blocks, int64_t ms)
+    {
+        m_progress = diag::ProgressReporter(blocks, ms);
+    }
+
+    /// Silence after which watchdog_tick() calls this lane FROZEN, and how
+    /// often it repeats while the freeze lasts.
+    void set_watchdog(int64_t stall_ms, int64_t repeat_ms)
+    {
+        m_watchdog = diag::StallWatchdog(stall_ms, repeat_ms);
+    }
+
+    /// ── THE WATCHDOG. Call from a WALL-CLOCK TIMER, never from pump() ─────
+    ///
+    /// 2026-08-04, mainnet, BOTH .211 and contabo: the bridge froze right
+    /// after a COMPLETED on-demand PoSe fold (cursors h=2514874 and h=2516862)
+    /// and stayed frozen 11-12 minutes with NO warning of any kind. The only
+    /// symptom available to an operator was "the arm never arms".
+    ///
+    /// The reason is structural, and it is the reason this function exists
+    /// SEPARATELY from pump(): the old stall probe lived INSIDE pump(), below
+    /// several early returns — including the pending-snapshot return — so the
+    /// detector could be skipped by the very condition it was meant to detect.
+    /// And pump() is driven by tip changes (~2.5 min on mainnet) while the
+    /// probe needed FIVE consecutive stalled pumps before it said anything:
+    /// ~12 minutes of guaranteed silence even when it did run.
+    ///
+    /// watchdog_tick() has neither property. It is driven by a timer that the
+    /// lane cannot influence, it reads a last-progress TIMESTAMP rather than
+    /// counting drives, and "the lane stopped being driven entirely" is
+    /// therefore the case it reports FASTEST instead of the case it misses.
+    /// It emits nothing but a log line.
+    void watchdog_tick()
+    {
+        const int64_t now = m_now();
+        auto due = m_watchdog.due(now);
+        if (!due) return;
+        LOG_WARNING << "[LANE-WATCHDOG] lane=mn-ckpt state=" << state_name()
+                    << " cursor=" << m_next
+                    << " target=" << m_replay_target
+                    << " frozen_for=" << (*due / 1000) << "s"
+                    << " waiting_for=" << waiting_for()
+                    << " snapshot_pending=" << (m_snapshot_pending ? 1 : 0)
+                    << " ondemand_pending=" << (m_ondemand_pending ? 1 : 0)
+                    << " requested_through=" << m_requested_through
+                    << " applied=" << m_applied
+                    << " folds=" << m_folds
+                    << " warn=" << m_watchdog.warnings()
+                    << " — the payee queue is NOT advancing; the embedded arm"
+                       " cannot arm until it does";
+    }
+
+    /// What the lane is blocked on, as ONE greppable token. This is the field
+    /// that was missing: a frozen lane published a cursor but never said what
+    /// it was waiting for, so "peer dropped our getdata" and "peer never
+    /// answered the fold" looked identical from outside.
+    std::string waiting_for() const
+    {
+        if (m_state == State::FailedClosed) return "nothing(failed-closed)";
+        if (m_state == State::Published)    return "nothing(published)";
+        if (m_snapshot_pending)
+            return std::string(m_ondemand_pending ? "ondemand-mnlist-reply@h="
+                                                  : "fold-mnlist-reply@h=")
+                   + std::to_string(m_snapshot_height);
+        if (!m_position_verified)
+            return "header-tip-to-reach-anchor@h="
+                   + std::to_string(m_anchor_height);
+        if (m_requested_through >= m_next)
+            return "block-bodies@h=" + std::to_string(m_next) + ".."
+                   + std::to_string(m_requested_through);
+        return "tip-advance";
+    }
+
+    static const char* state_name(State s)
+    {
+        switch (s) {
+            case State::Unarmed:      return "unarmed";
+            case State::Waiting:      return "waiting";
+            case State::Bridging:     return "bridging";
+            case State::Published:    return "published";
+            case State::FailedClosed: return "failed-closed";
+        }
+        return "unknown";
+    }
+    const char* state_name() const { return state_name(m_state); }
+
+    /// Whether this lane's replay cursor was RESTORED from persisted work or is
+    /// starting COLD. Today it is ALWAYS cold — there is no cursor persistence
+    /// — and the point of surfacing it is that the log said nothing at all
+    /// about discarding a completed 3913-block replay on every process start.
+    bool cursor_restored() const { return m_cursor_restored; }
 
     /// Load a parsed checkpoint. A !ok checkpoint arms the lane in the
     /// terminal FailedClosed state so the refusal is visible in status()
@@ -1160,6 +1273,33 @@ public:
             LOG_INFO << "[MN-CKPT] bridge START: replaying h=" << m_next
                      << ".." << tip << " (" << (tip - m_next + 1)
                      << " blocks) onto the anchored set";
+            // ── PERSISTENCE VISIBILITY ────────────────────────────────────
+            // This lane has NO cursor persistence: every process start throws
+            // away the previous run's completed replay and re-walks the whole
+            // window from the pinned anchor. That is a real cost (3913 blocks
+            // on 2026-08-04) and the log said NOTHING about it — "bridge
+            // START: replaying h=2513001..2516913" reads exactly the same
+            // whether prior work was resumed or discarded. Name it.
+            m_replay_target = tip;
+            m_replay_base   = m_next;
+            m_replay_bytes  = 0;
+            LOG_INFO << "[MN-CKPT] cursor "
+                     << (m_cursor_restored ? "RESTORED" : "COLD")
+                     << " lane=mn-ckpt from="
+                     << (m_cursor_restored ? "persisted-cursor"
+                                           : "pinned-anchor@h="
+                                                 + std::to_string(m_anchor_height))
+                     << " cursor=" << m_next << " target=" << tip
+                     << " to_replay=" << (tip - m_next + 1)
+                     << " rearms=" << m_rearms
+                     << (m_cursor_restored
+                             ? ""
+                             : " — there is no replay-cursor persistence in"
+                               " this build, so ANY replay work done by a"
+                               " previous process was DISCARDED and this window"
+                               " is being walked from scratch");
+            m_progress.start(0, m_now());
+            m_watchdog.arm(m_now());
         }
 
         // ── ANCHOR FOLD (F4). Two separate fixes meet on this line and BOTH
@@ -1274,6 +1414,7 @@ public:
 
         m_next = height + 1;
         ++m_applied;
+        note_replay_advance(block);
         // ── PER-HEIGHT PoSe fold. The cursor is now exactly `height`; if
         // this is a fold point, request the list AS OF it and pause.
         if (m_tip_height) {
@@ -1888,6 +2029,10 @@ private:
         // applied — only its attribution was withheld until now.
         m_next = height + 1;
         ++m_applied;
+        // The on-demand path is where BOTH nodes froze on 2026-08-04, right
+        // after this line. Recording progress here is what gives the watchdog a
+        // truthful last-progress timestamp to measure that freeze from.
+        note_replay_advance(m_ondemand_block);
         m_sml_recovered += m_ondemand_r.sml_recovered;
         m_registered    += m_ondemand_r.registered;
         m_spent         += m_ondemand_r.spent;
@@ -2143,8 +2288,62 @@ public:
         return s;
     }
 
+    /// ── THE PROGRESS/RATE TICK ────────────────────────────────────────────
+    /// Called on EVERY cursor advance; emits at most one line per throttle
+    /// window. Two jobs, and they must not be separated: it stamps the
+    /// watchdog's last-progress timestamp (so a freeze is measured from the
+    /// last real advance, not from the last time anything called us) and it
+    /// feeds the throttled progress line.
+    ///
+    /// Before this existed, rate and ETA for a 3913-block replay had to be
+    /// reconstructed by diffing log timestamps by hand.
+    void note_replay_advance(const BlockType& block)
+    {
+        const int64_t now = m_now();
+        m_watchdog.progress(now);
+        if (m_wire_size) {
+            m_replay_bytes += static_cast<uint64_t>(m_wire_size(block));
+            m_have_bytes = true;
+        }
+        auto s = m_progress.sample(m_applied, now);
+        if (s) emit_progress(*s);
+    }
+
+    void emit_progress(const diag::ProgressReporter::Sample& s)
+    {
+        const uint64_t total =
+            m_replay_target >= m_replay_base
+                ? (m_replay_target - m_replay_base + 1)
+                : 0;
+        const uint64_t remaining = total > s.units ? total - s.units : 0;
+        LOG_INFO << "[REPLAY-PROGRESS] lane=mn-ckpt"
+                 // cursor_height() (the LAST APPLIED height), not m_next: a
+                 // cursor printed one past the target reads like an overrun.
+                 << " cursor=" << cursor_height()
+                 << " target=" << m_replay_target
+                 << " done=" << diag::fmt1(diag::ProgressReporter::done_pct(
+                                    s.units, total))
+                 << "%"
+                 << " rate=" << diag::fmt1(s.rate_per_s) << "blk/s"
+                 << " eta=" << diag::fmt_eta(
+                                    diag::ProgressReporter::eta_s(s, remaining))
+                 << " fetched=" << (m_have_bytes ? diag::fmt_bytes(m_replay_bytes)
+                                                 : std::string("n/a"))
+                 << " applied=" << m_applied
+                 << " payee_ok=" << m_applied
+                 << " diverged=" << m_ondemand_abandoned
+                 << " folds=" << m_folds
+                 << " ondemand=" << m_ondemand_folds
+                 << " eligible=" << m_machine.eligible_size()
+                 << " elapsed=" << (s.total_ms / 1000) << "s";
+    }
+
     void request_window(uint32_t tip)
     {
+        // Keep the progress line's denominator honest: the tip moves under a
+        // long replay, so a target captured only at bridge START would make
+        // `done=` drift upward past 100%.
+        if (tip > m_replay_target) m_replay_target = tip;
         // Never rewrite the status of a lane that has already finished or
         // refused — that status is the only record of WHY.
         if (m_state != State::Bridging) return;
@@ -2208,6 +2407,12 @@ public:
                                " publish");
         }
         m_state  = State::Published;
+        m_watchdog.disarm();
+        // FINAL, unthrottled progress line. The last window of a replay is the
+        // one an operator most wants (it carries the achieved rate for the
+        // whole run in `elapsed=`), and the throttle would usually eat it.
+        if (m_replay_base != 0)
+            if (auto s = m_progress.flush(m_applied, m_now())) emit_progress(*s);
         // The full delta rides on BOTH the status string and the log line. A
         // degradation that is only visible in scrollback is half-silent, and
         // this lane exists to make degradation loud. `eligible` is directly
@@ -2273,6 +2478,14 @@ public:
         const uint32_t cursor = m_next;
         m_state  = State::FailedClosed;
         m_status = why;
+        // A failed-closed lane is DONE, not frozen. Saying "stalled" about it
+        // would be the noise that trains an operator to ignore the tag.
+        m_watchdog.disarm();
+        // Only if the bridge ever STARTED. A lane that fails closed before the
+        // Waiting->Bridging edge has no target and no baseline, and a
+        // `target=0 done=0.0%` line would be a measurement of nothing.
+        if (m_replay_base != 0)
+            if (auto s = m_progress.flush(m_applied, m_now())) emit_progress(*s);
         // Deliberately ERROR, not WARNING: the operator's embedded arm will
         // not arm, and the only thing worse than saying so is not saying so.
         LOG_ERROR << "[MN-CKPT] FAIL-CLOSED: " << why;
@@ -2456,6 +2669,18 @@ public:
         m_rerequest_from_cursor = false;
         m_last_wait_log         = 0;
         m_position_verified     = false;
+        // Diagnostics, reset for the same reason every other counter here is:
+        // a re-armed bridge that inherited the previous run's progress baseline
+        // would report a negative delta and an absurd rate, and one that
+        // inherited its watchdog timestamp would either cry stall immediately
+        // or sit silent through a fresh freeze.
+        m_replay_base    = 0;
+        m_replay_target  = 0;
+        m_replay_bytes   = 0;
+        m_have_bytes     = false;
+        m_cursor_restored = false;   // no cursor persistence exists to restore
+        m_progress.start(0, m_now());
+        m_watchdog.disarm();         // re-armed at the Waiting->Bridging edge
         m_anchor_eligible   = m_machine.eligible_size();
         m_anchor_ineligible = m_machine.ineligible_size();
         m_next  = cp.height + 1;
@@ -2548,6 +2773,30 @@ public:
     bool     m_rerequest_from_cursor{false};
     uint32_t m_last_wait_log{0};
     bool     m_position_verified{false};
+
+    // ── DIAGNOSTICS (telemetry only; nothing below is read by a gate) ──────
+    /// Injectable monotonic clock — a KAT drives the throttle and the watchdog
+    /// deterministically instead of sleeping.
+    std::function<int64_t()> m_now{&diag::steady_now_ms};
+    std::function<size_t(const BlockType&)> m_wire_size;
+    /// 500 blocks OR 15 s, whichever first. A 20000-block bridge therefore
+    /// costs ~40 lines, and a bridge crawling at 1 blk/s still reports every
+    /// 15 s instead of going quiet for an hour.
+    diag::ProgressReporter m_progress{500, 15000};
+    /// 90 s of NO cursor movement is a freeze worth naming, repeated every
+    /// 120 s. Sized against the 2026-08-04 incident (11-12 min of silence) and
+    /// against DASH's ~150 s block spacing: a bridge mid-replay should advance
+    /// far faster than one block per 90 s, and a bridge that has caught the tip
+    /// is Published (disarmed), so this cannot fire on a healthy idle lane.
+    diag::StallWatchdog m_watchdog{90000, 120000};
+    uint32_t m_replay_base{0};      // cursor at bridge START (progress denominator)
+    uint32_t m_replay_target{0};    // tip the replay is chasing
+    uint64_t m_replay_bytes{0};     // wire bytes of replayed block bodies
+    bool     m_have_bytes{false};   // ...only when set_wire_size_fn is wired
+    /// Whether the replay cursor came from persisted work. ALWAYS false today:
+    /// this build has no cursor persistence, and the field exists so the log
+    /// says so out loud rather than leaving the discard invisible.
+    bool     m_cursor_restored{false};
 
     // ── RE-ARM bookkeeping. Survives reset_for_arm() by design: if a re-arm
     // cleared its own counters the cap could never fire and the "recovery"

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -316,6 +316,15 @@ public:
     /// carry its own name instead of masquerading as a header-sync fault.
     /// Never read by any serve or reward path.
     void set_tip_body_pending_dbg(bool v) { m_tip_body_pending_dbg = v; }
+    bool tip_body_pending_dbg() const { return m_tip_body_pending_dbg; }
+
+    /// The same two bits, READABLE. They existed only inside the decline
+    /// string, so the standing state ("why would this node not serve RIGHT
+    /// NOW, before anyone asks it for work") could not be printed at all — an
+    /// operator had to provoke a decline to learn it. -1 == never reported.
+    /// Telemetry only; no serve or reward path reads these.
+    int have_tip_dbg() const { return m_have_tip_dbg; }
+    int have_mn_dbg()  const { return m_have_mn_dbg; }
 
     /// Enable the SML-required viability gate. main_dash.cpp turns this on for
     /// the embedded coin-P2P arm so a template is only served once the CCbTx

--- a/src/impl/dash/coin/replay_quorum_bridge.hpp
+++ b/src/impl/dash/coin/replay_quorum_bridge.hpp
@@ -638,6 +638,17 @@ public:
         return {};
     }
 
+    /// Whether the engine's root SELF-CHECK is armed. Diagnostics only, and
+    /// it is the difference between two opposite readings of the SAME
+    /// counters: armed, quorum_roots_differed is a real divergence count;
+    /// UNARMED (no production caller has ever invoked arm_self_check(), and a
+    /// Tier-A anchor seeds no active quorum set) the computed root is a
+    /// warm-up artefact that differs at essentially every height by
+    /// construction — which is how a `0/4684` line came to read as a
+    /// 4684-block divergence when the SERVED root was correct at 154/154
+    /// shadow matches. The reporting site MUST say which of the two it is.
+    bool self_check_armed() const { return m_quorum.self_check_armed(); }
+
     /// Step 3 of the per-block order. Retains the replayed list at H when H
     /// is a work block for some enabled type, and prunes the cache.
     void after_fold(uint32_t height)

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -1110,6 +1110,50 @@ nlohmann::json DASHWorkSource::mining_submit(
                     << " height~=" << height
                     << " pow_hash=" << pow_hash.GetHex().substr(0, 16)
                     << " job=" << job_id;
+        // ── THE SAME FACTS THE LEDGER TRACKS, AT FIND TIME ────────────────
+        // 2026-08-05: block h=2516911 was won and accepted and neither hotel
+        // node's log could prove it — and separately, the h=2516595 incident
+        // turned on the MASTERNODE PAYOUT OUTPUT COUNT (1 = no operator split,
+        // 2 = split), which was invisible without pulling the raw transaction.
+        // Every fact below is already in hand here; not printing them was the
+        // whole cost. One line per won block — won blocks are rare by
+        // construction, so this needs no throttle.
+        {
+            size_t mn_outs = 0, burn_outs = 0;
+            // The arm bits are written under serve_gate_mutex_ by
+            // note_arm_decision(); read them the same way. A torn read here
+            // would mislabel which arm produced the template we just won on —
+            // the one attribution this line exists to make.
+            bool arm_seen = false, arm_embedded = false;
+            {
+                std::lock_guard<std::mutex> lk(serve_gate_mutex_);
+                arm_seen     = arm_ever_observed_;
+                arm_embedded = last_arm_embedded_;
+            }
+            if (wd) {
+                for (const auto& pp : wd->m_packed_payments) {
+                    // dashd surfaces the platform credit-pool burn as a
+                    // masternode[] entry with an EMPTY payee; counting it as a
+                    // masternode payout would mis-report the split.
+                    if (pp.payee.empty() || pp.payee.rfind("!", 0) == 0) ++burn_outs;
+                    else ++mn_outs;
+                }
+            }
+            LOG_WARNING
+                << "[BLOCK-LEDGER] event=found h=" << height
+                << " hash=" << pow_hash.GetHex().substr(0, 16)
+                << " miner=" << username
+                << " arm=" << (arm_seen ? (arm_embedded ? "EMBEDDED"
+                                                        : "dashd-fallback")
+                                        : "unobserved")
+                << " coinbase_bytes=" << coinbase.size()
+                << " mn_payout_outputs=" << mn_outs
+                << " split=" << (mn_outs >= 2 ? "operator" : "none")
+                << " burn_outputs=" << burn_outs
+                << " txs=" << (job->tx_data ? job->tx_data->size() : 0)
+                << " subsidy=" << (wd ? wd->m_coinbase_value : 0)
+                << " job=" << job_id;
+        }
 
         // Full block = header || CompactSize(1+ntx) || coinbase || txs -- the
         // exact --mine-block serialization (coin/block_producer.hpp; DASH has

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1024,10 +1024,21 @@ if (BUILD_TESTING AND GTest_FOUND)
     # add_executable would not be in the build.yml --target list and would
     # silently report "Not Run" (#143 NOT_BUILT trap). No #ifdef guards in that
     # TU either, so every registered case actually executes (#895).
+    # Fifth TU: test_dash_lane_diag.cpp — the embedded/replay DIAGNOSTIC
+    # primitives (coin/lane_diag.hpp) plus the two lane-level properties they
+    # exist for: the progress throttle never degenerates to a per-block flood,
+    # and the stall watchdog fires from a path pump() CANNOT skip (the
+    # 2026-08-04 11-12 minute silent freeze on .211 and contabo, where the
+    # probe sat below the early-return that the freeze itself produced). Also
+    # pins masternode-list SOURCE attribution end-to-end through the leg-4
+    # event. FOLDED into this EXISTING allowlisted target for the same reason
+    # the E2d TU was: a new add_executable would not be in the build.yml
+    # --target list and would silently report "Not Run" (#143 NOT_BUILT trap).
     add_executable(test_dash_node_reception_wire test_dash_node_reception_wire.cpp
                    test_dash_live_feed_bridge.cpp
                    test_dash_mn_seed.cpp
-                   test_dash_mn_checkpoint.cpp)
+                   test_dash_mn_checkpoint.cpp
+                   test_dash_lane_diag.cpp)
     target_link_libraries(test_dash_node_reception_wire PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core

--- a/test/test_dash_header_chain.cpp
+++ b/test/test_dash_header_chain.cpp
@@ -612,3 +612,52 @@ TEST(DashChainRpc, ChainQueryRefusesMethodsTheHeaderChainDoesNotOwn) {
     EXPECT_TRUE(ok.is_string()) << ok.dump();
     EXPECT_EQ(ok.get<std::string>(), mc.hashes.back().GetHex());
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// HEADER-BACKFILL PROGRESS TELEMETRY
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// The old line was `[DASH] Header sync: N/M (P%)`, throttled on HEIGHT ALONE
+// by a function-local `static` — i.e. one counter shared by every HeaderChain
+// in the process. On 2026-08-04 that cost real time twice: a backfill that
+// slowed to a crawl went silent for as long as it took to cover 2000 blocks,
+// and rate/ETA had to be reconstructed by diffing log timestamps by hand.
+//
+// What is pinned here: the FIRST batch establishes a baseline and reports
+// nothing (a rate cannot be measured from one sample — reporting one would be
+// a fabricated number), and a LATER batch past the throttle emits the line.
+TEST(DashHeaderChainDiag, BackfillProgressBaselinesThenReports) {
+    auto params = make_easy_test_params();
+    HeaderChain hc(params, /*db_path=*/"");
+    ASSERT_TRUE(hc.init());
+    hc.set_peer_tip_height(100);
+    // Tight throttle so the KAT need not mine 2000 headers to prove the line.
+    hc.set_progress_throttle(/*headers=*/2, /*ms=*/60'000);
+
+    const uint32_t bits = params.pow_limit.GetCompact();
+    uint256  prev = params.genesis_hash;
+    uint32_t t    = 1'800'000'000u;
+
+    auto mine_batch = [&](int n) {
+        std::vector<BlockHeaderType> batch;
+        for (int i = 0; i < n; ++i) {
+            t += 150u;
+            auto h = mine_header(prev, t, bits, params.pow_limit);
+            prev = x11_hash(h);
+            batch.push_back(h);
+        }
+        return batch;
+    };
+
+    // First batch: accepted, and it BASELINES the reporter.
+    auto b1 = mine_batch(3);
+    EXPECT_EQ(hc.add_headers(b1), 3);
+    EXPECT_EQ(hc.height(), 3u);
+
+    // Second batch: three more headers is past the 2-header throttle, so the
+    // progress line is due. The assertion available to a KAT is the state the
+    // line reports — the cursor and the peer target it prints.
+    auto b2 = mine_batch(3);
+    EXPECT_EQ(hc.add_headers(b2), 3);
+    EXPECT_EQ(hc.height(), 6u);
+}

--- a/test/test_dash_lane_diag.cpp
+++ b/test/test_dash_lane_diag.cpp
@@ -1,0 +1,474 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/// DASH embedded/replay DIAGNOSTIC LOGGING KAT.
+///
+/// Every case here pins a behaviour that a real incident on 2026-08-04/05 paid
+/// for. The suite is deliberately about the MECHANISM (throttle policy,
+/// watchdog independence, source attribution) rather than about log text —
+/// text is not a contract, but "the warning fires even when the drive function
+/// is skipped" is.
+///
+///   1. THROTTLE — a progress line must be emitted on progress OR on elapsed
+///      time, whichever comes FIRST, and never per block. The same day's log
+///      carried 205k+ repeated lines from one un-throttled site.
+///
+///   2. WATCHDOG INDEPENDENCE — the worst defect of the day. The MN-CKPT
+///      bridge froze on BOTH .211 and contabo right after a completed
+///      on-demand PoSe fold (cursors h=2514874 / h=2516862) for 11-12 minutes
+///      with NO warning, because the stall probe lived inside pump(), below
+///      the very early-return that the freeze state produces. The KAT drives
+///      the lane into exactly that state — a fold request outstanding, so
+///      pump() returns before its own probe — and asserts the watchdog still
+///      reports the freeze, and names what the lane is waiting for.
+///
+///   3. SOURCE ATTRIBUTION — we believed a serve was daemonless when the payee
+///      queue was riding a dashd `protx list` seed; only an A/B with
+///      --coin-rpc removed exposed it. Every population event now names its
+///      source and the maintainer keeps it.
+///
+///   4. SUPPRESSION — a repeat storm collapses to one line plus a counted
+///      `suppressed=N`, never to silence.
+///
+/// #895 note: nothing here is #ifdef-guarded — a green tick means the bodies
+/// ran.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/lane_diag.hpp>           // the DUT primitives
+#include <impl/dash/coin/mn_checkpoint.hpp>       // parse_mn_checkpoint
+#include <impl/dash/coin/mn_checkpoint_lane.hpp>  // MnCheckpointLane (watchdog)
+#include <impl/dash/coin/node_interface.hpp>      // MnListUpdate::source
+#include <impl/dash/coin/replay_payee_publish.hpp>  // kPayeeSource* (#1128 SSOT tokens)
+#include <impl/dash/coin/mn_list_ingest.hpp>      // wire_mn_list_ingest (leg 4)
+#include <impl/dash/coin/coin_state_maintainer.hpp>
+#include <impl/dash/coin/node_coin_state.hpp>
+
+#include <core/uint256.hpp>
+
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace diag = dash::coin::diag;
+using dash::coin::MNState;
+using dash::coin::MnCheckpoint;
+using dash::coin::MnCheckpointLane;
+using dash::coin::parse_mn_checkpoint;
+
+namespace {
+
+// Same committed testnet anchor the E2d suite uses. Included rather than
+// re-derived so a fixture regeneration cannot make these two suites disagree
+// about what the anchor says.
+const char* const kDiagCheckpoint1519543 =
+#include "dash_mn_checkpoint_testnet_1519543.inc"
+    ;
+
+constexpr uint32_t kDiagAnchorHeight = 1519543;
+
+MnCheckpoint diag_checkpoint()
+{
+    auto cp = parse_mn_checkpoint(kDiagCheckpoint1519543, "testnet");
+    EXPECT_TRUE(cp.ok) << cp.error;
+    return cp;
+}
+
+} // namespace
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 1. ProgressReporter — the two-axis throttle
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(DashLaneDiag, ProgressThrottleFiresOnUnitsBeforeTime)
+{
+    diag::ProgressReporter p(/*every_units=*/100, /*every_ms=*/60000);
+    int64_t t = 1000;
+    p.start(0, t);
+
+    // 99 units, well inside the time window: NOTHING.
+    EXPECT_FALSE(p.sample(99, t + 10).has_value())
+        << "a progress line fired before either throttle axis was reached —"
+           " that is the per-block flood this class exists to prevent";
+    // The 100th unit trips the unit axis even though no time has passed.
+    auto s = p.sample(100, t + 20);
+    ASSERT_TRUE(s.has_value());
+    EXPECT_EQ(s->delta, 100u);
+    EXPECT_EQ(s->units, 100u);
+}
+
+TEST(DashLaneDiag, ProgressThrottleFiresOnTimeWhenUnitsCrawl)
+{
+    diag::ProgressReporter p(/*every_units=*/500, /*every_ms=*/15000);
+    int64_t t = 0;
+    p.start(0, t);
+
+    // A lane crawling at a few blocks a minute must NOT go quiet until it has
+    // covered 500 blocks. That silence is exactly when an operator most needs
+    // the line.
+    EXPECT_FALSE(p.sample(3, t + 14999).has_value());
+    auto s = p.sample(4, t + 15000);
+    ASSERT_TRUE(s.has_value()) << "the time axis never fired: a slow lane would"
+                                  " stay silent for as long as it takes to"
+                                  " cover 500 blocks";
+    EXPECT_EQ(s->delta, 4u);
+    EXPECT_EQ(s->elapsed_ms, 15000);
+}
+
+TEST(DashLaneDiag, ProgressRateAndEtaAreMeasuredOverTheLastWindow)
+{
+    diag::ProgressReporter p(/*every_units=*/100, /*every_ms=*/1000000);
+    p.start(0, 0);
+    // 100 blocks in 1000 ms == 100 blk/s.
+    auto s = p.sample(100, 1000);
+    ASSERT_TRUE(s.has_value());
+    EXPECT_DOUBLE_EQ(s->rate_per_s, 100.0);
+    auto eta = diag::ProgressReporter::eta_s(*s, /*remaining=*/250);
+    ASSERT_TRUE(eta.has_value());
+    EXPECT_DOUBLE_EQ(*eta, 2.5);
+
+    // The NEXT window is measured on its own, not since the start: 100 blocks
+    // in 2000 ms == 50 blk/s. "Is it speeding up or slowing down" is the
+    // question an operator actually asks.
+    auto s2 = p.sample(200, 3000);
+    ASSERT_TRUE(s2.has_value());
+    EXPECT_DOUBLE_EQ(s2->rate_per_s, 50.0);
+}
+
+TEST(DashLaneDiag, EtaIsNotAvailableRatherThanZeroWhenNothingMoved)
+{
+    diag::ProgressReporter p(/*every_units=*/100, /*every_ms=*/1000);
+    p.start(0, 0);
+    auto s = p.sample(0, 1000);       // time axis fired, zero progress
+    ASSERT_TRUE(s.has_value());
+    EXPECT_DOUBLE_EQ(s->rate_per_s, 0.0);
+    EXPECT_FALSE(diag::ProgressReporter::eta_s(*s, 500).has_value())
+        << "a stalled lane must print eta=n/a; 'zero seconds remaining' is a"
+           " different claim and it is false";
+    EXPECT_EQ(diag::fmt_eta(std::nullopt), "n/a");
+}
+
+TEST(DashLaneDiag, StartRebaselinesSoARearmCannotReportANegativeDelta)
+{
+    diag::ProgressReporter p(/*every_units=*/10, /*every_ms=*/1000);
+    p.start(0, 0);
+    ASSERT_TRUE(p.sample(500, 1000).has_value());
+    // A re-armed bridge restarts its counter at 0. Without the rebaseline the
+    // next sample computes 0 - 500 and reports nonsense.
+    p.start(0, 2000);
+    auto s = p.sample(10, 3000);
+    ASSERT_TRUE(s.has_value());
+    EXPECT_EQ(s->delta, 10u);
+    EXPECT_GT(s->rate_per_s, 0.0);
+}
+
+TEST(DashLaneDiag, ByteFormattingKeepsValueAndUnitInOneToken)
+{
+    EXPECT_EQ(diag::fmt_bytes(512), "512B");
+    EXPECT_EQ(diag::fmt_bytes(1024), "1.0KB");
+    EXPECT_EQ(diag::fmt_bytes(59662336), "56.9MB");
+    EXPECT_EQ(diag::fmt_eta(19.0), "19s");
+    EXPECT_EQ(diag::fmt_eta(252.0), "4m12s");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2. StallWatchdog — the primitive
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(DashLaneDiag, WatchdogFiresAfterSilenceAndRepeatsOnItsOwnInterval)
+{
+    diag::StallWatchdog w(/*stall_ms=*/90000, /*repeat_ms=*/120000);
+    w.arm(0);
+    EXPECT_FALSE(w.due(89999).has_value());
+    auto first = w.due(90000);
+    ASSERT_TRUE(first.has_value());
+    EXPECT_EQ(*first, 90000);
+    // Not again until the repeat interval — a freeze must be loud, not a storm.
+    EXPECT_FALSE(w.due(150000).has_value());
+    ASSERT_TRUE(w.due(210000).has_value());
+    EXPECT_EQ(w.warnings(), 2u);
+}
+
+TEST(DashLaneDiag, WatchdogProgressResetsTheClockAndDisarmSilencesIt)
+{
+    diag::StallWatchdog w(/*stall_ms=*/1000, /*repeat_ms=*/1000);
+    w.arm(0);
+    w.progress(900);
+    EXPECT_FALSE(w.due(1500).has_value()) << "the clock must run from the last"
+                                             " ADVANCE, not from arm()";
+    ASSERT_TRUE(w.due(1900).has_value());
+
+    // A published / failed-closed lane is DONE, not frozen.
+    w.disarm();
+    EXPECT_FALSE(w.due(999999).has_value());
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 3. THE INCIDENT KAT: the watchdog fires from a path pump() cannot skip
+// ═══════════════════════════════════════════════════════════════════════════
+
+namespace {
+
+/// Minimal lane rig: a synthetic header chain, a block request seam that never
+/// answers, and a snapshot seam that never replies — i.e. the exact shape of
+/// the 2026-08-04 freeze (a fold request outstanding, nothing coming back).
+struct WatchdogRig
+{
+    MnCheckpointLane lane;
+    std::map<uint32_t, uint256> headers;
+    uint32_t tip{0};
+    int64_t  now{0};
+    std::vector<uint32_t> requested_blocks;
+    int snapshot_requests{0};
+
+    WatchdogRig()
+    {
+        lane.set_clock_fn([this] { return now; });
+        lane.set_tip_height_fn([this] { return tip; });
+        lane.set_header_hash_at_fn(
+            [this](uint32_t h) -> std::optional<uint256> {
+                auto it = headers.find(h);
+                if (it == headers.end()) return std::nullopt;
+                return it->second;
+            });
+        lane.set_publish_fn(
+            [](std::vector<std::pair<uint256, MNState>>, uint32_t) {});
+        // The peer that goes quiet: getdata is recorded and never answered.
+        lane.set_request_block_fn(
+            [this](uint32_t h) { requested_blocks.push_back(h); });
+        // The masternode-list request that never draws a reply — this is what
+        // parks pump() before its own stall probe.
+        lane.set_request_snapshot_fn(
+            [this](const uint256&) { ++snapshot_requests; });
+        lane.set_merkle_root_at_fn(
+            [](const uint256&) -> std::optional<uint256> { return std::nullopt; });
+    }
+};
+
+} // namespace
+
+TEST(DashLaneDiag, WatchdogFiresWhilePumpEarlyReturnsOnAPendingFold)
+{
+    WatchdogRig rig;
+    auto cp = diag_checkpoint();
+    rig.headers[kDiagAnchorHeight] = cp.blockhash;
+    rig.tip = kDiagAnchorHeight + 50;
+    rig.lane.arm(cp);
+    rig.lane.set_watchdog(/*stall_ms=*/90000, /*repeat_ms=*/120000);
+
+    // Drive the bridge to the anchor fold: the lane requests the masternode
+    // list as of the anchor and PARKS. m_snapshot_pending is now set.
+    rig.lane.pump();
+    ASSERT_TRUE(rig.lane.snapshot_pending())
+        << "the rig failed to reach the parked state the incident occurred in";
+    ASSERT_GE(rig.snapshot_requests, 1);
+
+    // THE DEFECT, reproduced: pump() returns before its own stall probe while
+    // a snapshot is pending, so no amount of pumping produces a symptom.
+    const uint32_t cursor_before = rig.lane.cursor_height();
+    for (int i = 0; i < 10; ++i) rig.lane.pump();
+    EXPECT_EQ(rig.lane.cursor_height(), cursor_before)
+        << "the cursor moved — this rig is no longer reproducing a freeze";
+
+    // THE FIX: the watchdog runs off wall clock on an independent path. Twelve
+    // minutes of silence — the measured duration of the real freeze — MUST be
+    // reportable, and reportable long before that.
+    rig.now = 89999;
+    rig.lane.watchdog_tick();               // not yet
+    rig.now = 90000;
+    rig.lane.watchdog_tick();               // fires
+
+    // And it names what the lane is waiting for, which is the fact that was
+    // missing: a frozen lane published a cursor but never said why it was
+    // stuck, so "peer dropped our getdata" and "peer never answered the fold"
+    // looked identical from outside.
+    const std::string waiting = rig.lane.waiting_for();
+    EXPECT_NE(waiting.find("mnlist-reply"), std::string::npos)
+        << "waiting_for() did not name the outstanding masternode-list"
+           " request; it said: " << waiting;
+    EXPECT_NE(waiting.find(std::to_string(kDiagAnchorHeight)),
+              std::string::npos)
+        << "waiting_for() did not name the height it is parked on: " << waiting;
+}
+
+TEST(DashLaneDiag, WatchdogStaysSilentOnAnUnstartedLane)
+{
+    WatchdogRig rig;
+    // Armed but the header chain has not reached the anchor: the bridge has
+    // not started, so there is nothing to be frozen. A watchdog that cried
+    // here would train operators to ignore the tag.
+    auto cp = diag_checkpoint();
+    rig.tip = kDiagAnchorHeight - 1000;
+    rig.lane.arm(cp);
+    rig.lane.pump();
+    rig.now = 100000000;
+    rig.lane.watchdog_tick();   // must not throw, must not warn
+    EXPECT_EQ(rig.lane.cursor_height(), kDiagAnchorHeight);
+}
+
+TEST(DashLaneDiag, ColdStartIsTheDefaultAndIsStated)
+{
+    WatchdogRig rig;
+    auto cp = diag_checkpoint();
+    rig.headers[kDiagAnchorHeight] = cp.blockhash;
+    rig.tip = kDiagAnchorHeight + 5;
+    rig.lane.arm(cp);
+    // There is no replay-cursor persistence in this build. The point of the
+    // flag is that the log states the discard rather than leaving it silent.
+    EXPECT_FALSE(rig.lane.cursor_restored());
+    rig.lane.pump();
+    EXPECT_FALSE(rig.lane.cursor_restored());
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 4. LogSuppressor — a storm becomes one line plus a count, never silence
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(DashLaneDiag, SuppressorCollapsesAStormAndCarriesTheCount)
+{
+    diag::LogSuppressor s(/*every_ms=*/30000);
+    EXPECT_TRUE(s.allow("k", 0));           // first is always allowed
+    for (int i = 1; i < 205000; ++i)
+        EXPECT_FALSE(s.allow("k", 1000));   // the 205k-line flood, absorbed
+    EXPECT_TRUE(s.allow("k", 30000));
+    EXPECT_EQ(s.take_suppressed("k"), 204999u)
+        << "the suppressed lines were dropped without being counted — that is"
+           " silence, not throttling";
+    EXPECT_EQ(s.take_suppressed("k"), 0u);  // taking resets
+}
+
+TEST(DashLaneDiag, SuppressorKeyTableIsBounded)
+{
+    diag::LogSuppressor s(/*every_ms=*/1000);
+    for (int i = 0; i < 10 * static_cast<int>(diag::LogSuppressor::kMaxKeys); ++i)
+        s.allow("key-" + std::to_string(i), i);
+    // No assertion on contents: the contract is only that an unbounded key
+    // space cannot grow the table without limit (a leak in a diagnostic is
+    // still a leak). Reaching here without exhausting memory is the check.
+    SUCCEED();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 5. MN-LIST SOURCE ATTRIBUTION — the state says its own name
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(DashLaneDiag, SourceNamesRoundTripAndDaemonlessIsExplicit)
+{
+    EXPECT_STREQ(diag::mn_source_name(diag::MnSource::DashdSeed), "dashd-seed");
+    EXPECT_STREQ(diag::mn_source_name(diag::MnSource::MnCkpt), "mn-ckpt");
+    EXPECT_STREQ(diag::mn_source_name(diag::MnSource::ReplayFold), "replay-fold");
+    EXPECT_EQ(diag::mn_source_from_name("mn-ckpt"), diag::MnSource::MnCkpt);
+    EXPECT_EQ(diag::mn_source_from_name("nonsense"), diag::MnSource::Unknown);
+    // The classifier's tokens ARE #1128's publisher constants. Pinned so a
+    // rename on either side is a red test, not a silently mis-classified
+    // payee queue.
+    EXPECT_EQ(diag::mn_source_from_name(dash::coin::replay::kPayeeSourceDashdSeed),
+              diag::MnSource::DashdSeed);
+    EXPECT_EQ(diag::mn_source_from_name(dash::coin::replay::kPayeeSourceMnCkpt),
+              diag::MnSource::MnCkpt);
+    EXPECT_EQ(diag::mn_source_from_name(dash::coin::replay::kPayeeSourceReplayFold),
+              diag::MnSource::ReplayFold);
+    // "unnamed" is #1128's own word for an un-named publisher.
+    EXPECT_FALSE(diag::mn_source_is_daemonless(
+        diag::mn_source_from_name("unnamed")));
+
+    // The predicate the A/B run had to establish by hand.
+    EXPECT_FALSE(diag::mn_source_is_daemonless(diag::MnSource::DashdSeed));
+    EXPECT_TRUE(diag::mn_source_is_daemonless(diag::MnSource::MnCkpt));
+    EXPECT_TRUE(diag::mn_source_is_daemonless(diag::MnSource::ReplayFold));
+}
+
+TEST(DashLaneDiag, PopulationSourceSurvivesTheLegFourEventIntoTheMaintainer)
+{
+    dash::coin::NodeCoinState        state;
+    dash::coin::CoinStateMaintainer  maint(state);
+    dash::interfaces::Node           node;
+    auto sub = c2pool::dash::wire_mn_list_ingest(node, maint);
+
+    // Nothing has populated the queue yet.
+    EXPECT_TRUE(maint.mn_source().empty());
+    EXPECT_FALSE(maint.mn_source_daemonless());
+
+    // A dashd `protx list` startup seed — the source we mistook for
+    // daemonless. One masternode is enough: this is about attribution.
+    // The token is #1128's own kPayeeSourceDashdSeed constant, so this KAT
+    // fails if the publisher constants and the classifier ever drift apart.
+    auto cp = diag_checkpoint();
+    ASSERT_FALSE(cp.entries.empty());
+    dash::interfaces::MnListUpdate up;
+    up.mnstates     = {cp.entries.front()};
+    up.as_of_height = kDiagAnchorHeight;
+    up.source       = dash::coin::replay::kPayeeSourceDashdSeed;
+    node.mn_list_update.happened(up);
+
+    EXPECT_EQ(maint.mn_source(), "dashd-seed");
+    EXPECT_FALSE(maint.mn_source_daemonless())
+        << "a queue riding a dashd seed reported itself as daemonless — this"
+           " is the exact misreading that cost a day on 2026-08-04";
+    EXPECT_TRUE(maint.have_mn());
+    EXPECT_EQ(maint.mn_snapshot_height(), kDiagAnchorHeight);
+
+    // The bridge re-publishes the same queue daemonlessly: the source must
+    // FOLLOW the publisher, not stick to whatever came first.
+    dash::interfaces::MnListUpdate up2;
+    up2.mnstates     = {cp.entries.front()};
+    up2.as_of_height = kDiagAnchorHeight + 1;
+    up2.source       = dash::coin::replay::kPayeeSourceMnCkpt;
+    node.mn_list_update.happened(up2);
+
+    EXPECT_EQ(maint.mn_source(), "mn-ckpt");
+    EXPECT_TRUE(maint.mn_source_daemonless());
+
+    // And the root-checked fold, the third lane #1128 added.
+    dash::interfaces::MnListUpdate up3;
+    up3.mnstates     = {cp.entries.front()};
+    up3.as_of_height = kDiagAnchorHeight + 2;
+    up3.source       = dash::coin::replay::kPayeeSourceReplayFold;
+    node.mn_list_update.happened(up3);
+    EXPECT_EQ(maint.mn_source(), "replay-fold");
+    EXPECT_TRUE(maint.mn_source_daemonless());
+}
+
+TEST(DashLaneDiag, AnUnattributedPublisherIsNeverClassifiedDaemonless)
+{
+    dash::coin::NodeCoinState        state;
+    dash::coin::CoinStateMaintainer  maint(state);
+    auto cp = diag_checkpoint();
+    // Default-constructed MnListUpdate: no publisher named itself. #1128
+    // records that as "unnamed"; the classification must then refuse to
+    // claim daemonless — an unattributed queue is exactly the state that
+    // cost a day, and it must never read as the good case.
+    maint.on_mn_list_update({cp.entries.front()}, kDiagAnchorHeight);
+    EXPECT_EQ(maint.mn_source(), "unnamed");
+    EXPECT_FALSE(maint.mn_source_daemonless())
+        << "an un-named publisher was classified as daemonless — 'unknown'"
+           " must show up as a bug, not as 'fine'";
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 6. STANDING-STATE READOUTS — the [EMBED-STATUS] inputs are readable
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(DashLaneDiag, PopulateInputsAreReadableWithoutProvokingADecline)
+{
+    dash::coin::NodeCoinState state;
+    // Never reported: -1, which the status line prints as n/a rather than 0.
+    EXPECT_EQ(state.have_tip_dbg(), -1);
+    EXPECT_EQ(state.have_mn_dbg(), -1);
+    state.set_populate_inputs(/*have_tip=*/true, /*have_mn=*/false);
+    EXPECT_EQ(state.have_tip_dbg(), 1);
+    EXPECT_EQ(state.have_mn_dbg(), 0);
+}
+
+TEST(DashLaneDiag, LaneNamesItsOwnStateAndWhatItIsWaitingFor)
+{
+    WatchdogRig rig;
+    EXPECT_STREQ(rig.lane.state_name(), "unarmed");
+    auto cp = diag_checkpoint();
+    rig.lane.arm(cp);
+    EXPECT_STREQ(rig.lane.state_name(), "waiting");
+    // Before the header chain reaches the anchor the lane is waiting on
+    // headers, and says so by name.
+    EXPECT_NE(rig.lane.waiting_for().find("header-tip-to-reach-anchor"),
+              std::string::npos)
+        << rig.lane.waiting_for();
+}


### PR DESCRIPTION
## What this is

**Diagnostic logging only.** No serve-gate semantics, no consensus path, no arm decision is changed anywhere in this diff. Every new type is a counter, a clock reading or a string, and the only behavioural wiring added (found-block verdict verification) affects a ledger row, never a submitted block.

Seven measured incidents from the 2026-08-04/05 mainnet sessions, each of which cost real time because the answer was in the node's head and not in its log.

---

### 1. No progress/rate line anywhere

Replay, header backfill and the MN-CKPT payee bridge all advanced **silently**. Blocks/s and ETA had to be reconstructed by diffing log timestamps by hand.

New `[REPLAY-PROGRESS]` line per lane, throttled on **two axes** — every N units **or** every T seconds, whichever comes first — so a fast lane reports by count and a crawling lane still reports by clock. As it actually prints:

```
[REPLAY-PROGRESS] lane=hdr-backfill cursor=6 target=100 done=6.0% rate=333.3hdr/s eta=0s fetched=486B received=6 accepted=6 elapsed=0s
[REPLAY-PROGRESS] lane=mn-ckpt cursor=2513005 target=2513004 done=100.0% rate=4000.0blk/s eta=0s fetched=n/a applied=4 payee_ok=4 diverged=0 folds=2 ondemand=0 eligible=59 elapsed=0s
```

The header-backfill line **replaces** `[DASH] Header sync: N/M (P%)`, which had three defects: no rate, no bytes, and a throttle on height **alone** (so a slowed backfill went quiet for as long as it took to cover 2000 blocks) — implemented with a function-local `static`, i.e. one counter shared by every `HeaderChain` in the process. The replacement is per-instance.

### 2. Silent freeze with no symptom — the worst defect of the day

The MN-CKPT bridge froze on **both** .211 and contabo right after a completed on-demand PoSe fold (cursors `h=2514874` and `h=2516862`), **11–12 minutes with no warning**. The only symptom was "the arm never arms".

Root cause is structural: the stall probe lived **inside `pump()`**, below the pending-snapshot early return — it could be skipped by the very condition it existed to detect — and even when reached it needed five consecutive stalled pumps (~12 min at mainnet tip cadence, since `pump()` is driven by tip changes) before it said anything.

`StallWatchdog` keeps a last-progress **wall-clock timestamp** polled from an independent 30 s timer. A lane that stops being driven entirely is now the case it reports *fastest* rather than the case it misses:

```
[LANE-WATCHDOG] lane=mn-ckpt state=bridging cursor=1519544 target=1519593 frozen_for=90s waiting_for=fold-mnlist-reply@h=1519543 snapshot_pending=1 ondemand_pending=0 requested_through=0 applied=0 folds=0 warn=1 — the payee queue is NOT advancing; the embedded arm cannot arm until it does
```

`waiting_for=` is the other half of the fix: a frozen lane used to publish a cursor and never say *why* it was stuck, so "peer dropped our getdata" and "peer never answered the fold" looked identical from outside.

### 3. No "why am I not serving" summary

Answering it required grepping four different markers. The gate names its cause when it **declines** a template (#1038/#1039); this is the **standing-state** complement, so the question is answerable without provoking a decline. Emitted on **shape change** with a 5-minute heartbeat and a `suppressed=N` count — the shape key deliberately excludes the numeric cursors, which move every block:

```
[EMBED-STATUS] arm=would-decline cause=no-tip value=prev_hash=null,maintainer-never-reported threshold=prev_hash!=null populated=0 have_tip=n/a have_mn=n/a mn_source=n/a mn_daemonless=0 payee_cursor=0/0 mn_entries=0 sml=absent sml_h=0 quorums=0 bestcl=n/a creditpool=n/a reseed_latch=0 bridge=none bridge_cursor=0 bridge_wait=n/a hdr_tip=0 trigger=shape-change suppressed=0
```

### 4. MN-list source was invisible

We believed a serve was **daemonless** when the payee queue was in fact riding a dashd `protx list` startup seed. Only an A/B run with `--coin-rpc` removed exposed it.

`MnListUpdate` now carries an explicit `source`; every publisher names itself; the maintainer prints it on **every** population and keeps the authoritative value for the status line:

```
[MN-SOURCE] populated source=dashd-seed daemonless=0 entries=1 eligible=1 as_of=1519543 have_mn=1 reseed_latch=0
[MN-SOURCE] populated source=mn-ckpt   daemonless=1 entries=1 eligible=1 as_of=1519544 have_mn=1 reseed_latch=0
```

An unnamed publisher logs `source=unknown` **plus a WARNING** — the default is never a plausible guess, because that is exactly the misreading this field exists to end. A wiped queue resets to `source=none` so the status line cannot keep claiming a backing that no longer exists.

### 5. Mis-scoped `quorum_root_match/differ` counter — NOW FIXED HERE (my earlier "not on master" note was stale)

The first revision of this PR reported that `arm_self_check`, `quorum_root_match` and `LLMQ-TYPE-RECONCILE` did not exist in the repo. That was true **at the old branch point (befa57e0)** and is no longer true: the W1–W4 replay lanes (#1117/#1119/#1118/#1125) have since landed and all three symbols are on master. Re-checked on the current base, and both halves are done here rather than deferred:

**The counter.** `arm_self_check()` still has **zero production callers**, so the root comparison runs UNARMED — a Tier-A anchor seeds no active quorum set, the folded root is a warm-up artefact that differs at essentially every height by construction, while the SERVED root was correct (154/154 shadow matches). Printed as `quorum_root_match/differ=0/4684` that reads as a 4684-block divergence. Now:

```
[REPLAY-SEAM] member_cycles_derived=… fold_root_vs_committed=0/4684 self_check=UNARMED (unarmed: no quorum-set seed — a differ here is warm-up, NOT divergence; the SERVED root is measured by the shadow comparison, not by this counter)
```

Scoping the **counter** itself stays with the W4 task; this is the logging half, as scoped.

**The 205k-line storm.** Also on master now, so it is fixed here. Root cause is not volume, it is a **defeated dedup**: the call site logged "only when the SENTENCE CHANGES", but the sentence embeds `observations=`, `span=`, `heights=[…]` and per-type `sightings=`, every one of which moves on every template build — so the guard could never hold. Added `LlmqTypeReconciler::defect_shape()` (types + verdicts only, no counters), keyed the dedup on that, and put a 5-minute re-assert floor behind the new `LogSuppressor` with `suppressed=N`. A genuinely new offending type changes the shape and still reports immediately.

### 6. No persistence visibility

`bridge START: replaying h=2513001..2516913 (3913 blocks)` reads identically whether prior work was resumed or thrown away. It is always thrown away — there is no replay-cursor persistence — and the log now says so:

```
[MN-CKPT] cursor COLD lane=mn-ckpt from=pinned-anchor@h=1519543 cursor=1519544 target=1519593 to_replay=50 rearms=0 — there is no replay-cursor persistence in this build, so ANY replay work done by a previous process was DISCARDED and this window is being walked from scratch
```

### 7. Block accounting was not recoverable from the log

Block `h=2516911` was **won by the pool and accepted by the chain**, and neither hotel node's log showed a BLOCK FOUND line for it: the primary's log had been rotated that morning (09:23) and the reserve had restarted mid-evening. Counting our own blocks by grepping a rotated, restart-truncated log produced two wrong answers in ten minutes.

The defect is the **source**, not the missing line. The new ledger reads the found-blocks LevelDB, so rotation and restart cost scrollback but not truth — the next line still prints the true totals. Emitted at standup and every 300 s:

```
[BLOCK-LEDGER] chain=DASH found_total=0 accepted=0 orphan=0 stale=0 pending=0 last_found=n/a last_found_age=n/a last_accepted=n/a source=found_blocks_db rotation_safe=1
```

Per won block, the same facts the ledger tracks — including the **arm that produced the template** and the **masternode payout output count** (1 = no operator split, 2 = split), which is exactly what the `h=2516595` incident turned on and was invisible without pulling the raw transaction:

```
[BLOCK-LEDGER] event=found h=2516911 hash=a0cc8112...319c miner=<addr> arm=EMBEDDED coinbase_bytes=NNN mn_payout_outputs=2 split=operator burn_outputs=1 txs=N subsidy=NNNNNNNNN job=<id>
```

And the verdict transition, one line per **change** (the verifier fires six times per block; only a change is news):

```
[BLOCK-LEDGER] h=2516911 verdict=ACCEPTED hash=a0cc8112319c1234 confirmations=3 source=header-chain reason=in-our-pow-validated-header-chain
```

**Changed by the rebase — the verify-fn wiring is GONE.** An earlier revision of this PR wired `add_chain_verify_fn("DASH")` because main_dash had never called `set_block_verify_fn` / `schedule_block_verification`, so every DASH block ever won sat at `status=pending` forever. **That gap is now closed on master** by the post-broadcast block-confirm lane (`block_confirm::resolve_status` + its KAT), which resolves orphan/confirm off the embedded header chain with a dashd `getblockheader` fallback. `verify_found_block` prefers `m_chain_verify_fns[chain]` over `m_block_verify_fn`, so keeping mine would have **shadowed** that better, KAT-backed implementation. It is removed: this branch now wires **nothing** on the verdict path and is pure telemetry there. The item the coordinator flagged for human review therefore no longer exists in this PR — there is no behavioural change to what an enriched row reports.

**Row semantics follow #1127.** The ledger line counts a row with no local share hash and no miner address as `relay_or_unenriched`, not as one of our own wins, so `[BLOCK-LEDGER]` and `/recent_blocks`'s `found_locally` cannot disagree about what a row means, and neither re-introduces zeros-as-data.

---

## Flood control

Everything new is throttled. The previously **unthrottled** per-message `[DASH] CP2 validate add_headers` line is now collapsed behind the same `suppressed=N` counter the serve gate already uses, and the `accepted==0` corner is deliberately **not** suppressed (that one is the diagnostic, not the noise).

## Tests

`test/test_dash_lane_diag.cpp`, folded into the existing allowlisted `test_dash_node_reception_wire` target (a new `add_executable` would not be in the build.yml `--target` list and would silently report "Not Run" — the #143 NOT_BUILT trap), plus one case in `test_dash_header_chain.cpp`. 18 + 1 new cases, all unconditionally compiled (#895). Allowlist drift-guard passes: `232 per-coin test target(s) across 6 coin lane(s) all present`.

Pinned: the two-axis throttle in both directions; rate/ETA measured over the last window and not since start; `eta=n/a` rather than a fabricated zero when nothing moved; re-arm rebaselining (a re-armed bridge inheriting the old baseline reports a negative delta); watchdog timing, progress-reset, and disarm-on-terminal; source attribution end-to-end through the real leg-4 event and the unknown-publisher warning; the suppressor's counted 205k-line storm and its bounded key table.

And the incident itself — `WatchdogFiresWhilePumpEarlyReturnsOnAPendingFold`: the lane is driven into the parked state that makes `pump()` early-return, pumped ten more times without moving a single height, and the watchdog still reports the freeze and names the outstanding masternode-list request.

## Scope

DASH lane only. **Rebased onto current master** (through #1127). Local after the rebase: full `make` clean, `c2pool-dash` links, `test_dash_node_reception_wire` **139/139**, `test_dash_header_chain` **26/26**, `core_test` **157/157**, `test_dash_mn_state` **80/80**, `test_dash_embedded_gbt` **182/182** (the last two cover the two W4 files this PR now touches), allowlist drift-guard 232/232. `[BLOCK-LEDGER]` and `[EMBED-STATUS]` samples above are from a real 80-second run of the built binary, not hand-written.


---

## CI status — the rollup is FULL; the reds are one runner host, and it is NOT the #1122 host

**The hollow-green state is cleared.** Before the rebase this PR was CONFLICTING, which suppressed CI and left exactly one check (`evaluate`) in the rollup. It is now MERGEABLE and a **full rollup of 31 checks is present** — every lane is scheduled and reporting. `attribution-gate` passes (author `frstrtr`, no AI footers), and `CI Required` has completed **success** on a re-run that happened to land on provisioned runners.

**The failures are a single host, measured — not a guess.** Every failing job on this PR ran on `c2pool-linux-196-*`; nothing on any other host failed. Mapped from the API, attempt 1 of the `CI Required` run:

| job | runner |
|---|---|
| dash-g1 byte-parity KAT | c2pool-linux-196-5 |
| dgb-phase-b smoke | c2pool-linux-196-3 |
| coin-matrix dgb / dash / btc / ltc / bch smoke | c2pool-linux-196-2 / -4 / -1 / -5 / -7 |

**The bad host is `.196` = `dl360g10`** — 8 runners as `user0` in `~/runners/r1..r8`, all carrying the **`c2pool-build`** label.

**Correcting an earlier version of this note:** it blamed "the second runner host added by #1122". That was wrong and the distinction matters, because de-labelling on the strength of it would take out the wrong machine. #1122 added `oplex7020-heavy-1..4` with the **`c2pool-heavy`** label, and those are **passing** — in the very same attempt, `oplex7020-heavy-1` configured this identical commit successfully. The two are different machines with different labels.

**Mechanism, confirmed from the logs and a read-only probe on the host.** `CMakeLists.txt:102-107` tries `find_library`/`find_path` FIRST and only falls through to `find_package(secp256k1 REQUIRED)` (line 107, the error in the rollup) when those fail:

- Passing job (`oplex7020-heavy-1`): `-- secp256k1 found: /usr/lib/x86_64-linux-gnu/libsecp256k1.so` → `find_library` succeeded, line 107 never runs.
- Every `.196` job: **no such line anywhere in the log** → `find_library` returned NOTFOUND → fell through to line 107 → CMake Error.

So the diagnosis is **not** "libsecp256k1-dev is missing". On `.196` the package is installed (`ii libsecp256k1-dev:amd64 0.2.0-2`), `/usr/include/secp256k1.h` and `/usr/lib/x86_64-linux-gnu/libsecp256k1.{a,so,so.1}` are all present, and a bare cmake probe on that host **finds them**:

```
cmake version 3.28.3
-- L=/usr/lib/x86_64-linux-gnu/libsecp256k1.so I=/usr/include
-- ARCH=x86_64-linux-gnu
```

The same probe under the CI's **conan-generated toolchain** is what fails, so the search is being confined by toolchain/`CONAN_HOME` state that is per-runner on this box (`CONAN_HOME=/home/user0/.conan2-ci/c2pool-linux-196-N`, one per runner). Clearing/regenerating those homes is the likely one-command fix — not installing a package that is already there.

Separately on the same host, `gh` is **not installed** (`which gh` → exit 1), which is the `evaluate` lane's `gh: command not found` / exit 127.

Nothing in this diff touches the root `CMakeLists.txt` or any dependency, and the failing lanes include DGB/BCH/BTC on a DASH-lane logging PR. **No further re-runs are being issued** — three targeted re-runs established the pattern (failure count moved 14 → 4 → 1 → 6 purely by which host picked each job); more only reshuffles the dice. This PR stays `do-not-merge` until it can show a green rollup on provisioned hosts.

**do-not-merge** — this is for review of the shapes and the throttle policy before anything goes near a prod box.

