### PR TITLE
web/dash: dashboard DATA defects — the numbers now mean what the cards say

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -1281,8 +1281,33 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         {
             core::WebServer* ws = web_server.get();
             p2p_node.tracker().m_on_share_difficulty =
-                [ws](double diff, const std::string& miner) {
-                    ws->get_mining_interface()->record_share_difficulty(diff, miner);
+                [ws, testnet](double diff, const std::string& miner,
+                              const uint256& share_hash) {
+                    // ── ENCODE THE MINER (hotel primary, 2026-08-05) ──────
+                    // The tracker reports the share's committed payout as a
+                    // RAW hash160 hex, and the best_share card rendered it
+                    // verbatim ("cfc7a034…3b8d") while the reserve — whose
+                    // record came via stratum usernames — showed a proper
+                    // address. Same entity, two spellings, read as a bug.
+                    // Encode here, where testnet-ness is known, with the
+                    // exact version bytes dashboard_found_block.hpp uses.
+                    std::string shown = miner;
+                    if (miner.size() == 40) {
+                        uint160 h160;
+                        h160.SetHex(miner);
+                        std::string addr = core::script_to_address(
+                            dash::pubkey_hash_to_script2(h160),
+                            /*bech32_hrp=*/"",
+                            testnet ? dash::dashboard::P2PKH_VERSION_TESTNET
+                                    : dash::dashboard::P2PKH_VERSION_MAINNET,
+                            testnet ? dash::dashboard::P2SH_VERSION_TESTNET
+                                    : dash::dashboard::P2SH_VERSION_MAINNET);
+                        if (!addr.empty()) shown = std::move(addr);
+                    }
+                    // The share hash rides through so best_share.hash names
+                    // the record share instead of rendering "".
+                    ws->get_mining_interface()->record_share_difficulty(
+                        diff, shown, share_hash.GetHex());
                 };
         }
 
@@ -1329,7 +1354,11 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                             row.chain, row.miner, row.share_hash,
                             mi->get_network_difficulty(),
                             row.share_difficulty,
-                            mi->get_local_hashrate(),
+                            // pool_hashrate_at_find: 0 routes the core to the
+                            // real POOL estimator (m_pool_hashrate_fn); this
+                            // site passed get_local_hashrate(), which is only
+                            // the pool rate when every rig sits on this node.
+                            /*pool_hashrate=*/0.0,
                             row.subsidy);
                         // Arm the post-broadcast confirm/orphan poller so this
                         // peer-found block flips off "pending" (main_ltc.cpp:6315
@@ -2109,10 +2138,16 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 [ws](uint32_t height, const uint256& block_hash,
                      const std::string& miner, bool reached_network) {
                     auto* mi = ws->get_mining_interface();
-                    // Enrich the recorded win with the block reward + real pool
-                    // hashrate so the dashboard shows a truthful value instead of
-                    // 0 (main_ltc.cpp:2988 parity). Display only.
-                    double pool_hr = mi->get_local_hashrate();
+                    // Subsidy: the WebServer-held template is empty on the
+                    // embedded arm (row 2516914 recorded subsidy=0 from it on
+                    // 2026-08-05); record_found_block now falls back to the
+                    // live coin template itself, so 0 here means "let the
+                    // core ask the template". Same for pool hashrate: this
+                    // site passed get_local_hashrate() into a field named
+                    // pool_hashrate_at_find — correct only while every rig
+                    // in the pool happens to sit on this node. 0 routes the
+                    // core to m_pool_hashrate_fn (the real pool estimator),
+                    // which is the rate expected_time/luck are defined over.
                     uint64_t subsidy = 0;
                     {
                         auto tmpl = mi->get_current_work_template();
@@ -2125,7 +2160,7 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                         "DASH", miner, block_hash.GetHex(),
                         mi->get_network_difficulty(),
                         /*share_difficulty=*/0.0,
-                        pool_hr,
+                        /*pool_hashrate=*/0.0,
                         subsidy);
                     // Arm the post-broadcast confirm/orphan poller so this local
                     // win flips off "pending" (main_ltc.cpp:4258 parity).
@@ -2579,6 +2614,30 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                         info.coinbase_value_sat = t->m_coinbase_value;
                         info.payment_amount_sat = t->m_payment_amount;
                         info.height             = t->m_height;
+                        info.template_age_sec   = wsrc->peek_template_age_sec();
+                        // ── EVERY non-miner output, not just the MN payee ─
+                        // m_payment_amount rides in share serialization and
+                        // on the embedded arm carries ONLY the projected MN
+                        // payment — it must keep that meaning. The dashboard
+                        // needs the ACCEPTED-coinbase truth: miner share =
+                        // coinbasevalue − ALL protocol outputs. Measured on
+                        // our own accepted h=2516911: MN 0.8304 + platform
+                        // burn 0.4979 leave miners 0.4428 (25%), while the
+                        // card computed 0.9404 (53%) by subtracting the MN
+                        // payee alone. Summing m_packed_payments — which
+                        // both the RPC and embedded builders fill in real
+                        // coinbase-output order — closes that gap. Display
+                        // only; no share/consensus field is touched.
+                        uint64_t total = 0, burn = 0;
+                        for (const auto& pp : t->m_packed_payments) {
+                            total += pp.amount;
+                            // "!6a" is the normalized OP_RETURN platform
+                            // burn (rpc.cpp / embedded_gbt.hpp both use it).
+                            if (pp.payee.rfind("!6a", 0) == 0)
+                                burn += pp.amount;
+                        }
+                        info.payments_total_sat = total;
+                        info.burn_sat           = burn;
                         if (t->m_bits != 0)
                             info.network_difficulty = chain::target_to_difficulty(
                                 dash::coin::target_from_nbits(t->m_bits));

--- a/src/core/test/CMakeLists.txt
+++ b/src/core/test/CMakeLists.txt
@@ -54,7 +54,11 @@ if (BUILD_TESTING AND (GTest_FOUND OR GTEST_FOUND))
     # carries a source KAT pinning the is_wire_advertisable() guard into all ten
     # per-coin getaddrs handlers. Same reasoning as above: FOLDED into the
     # EXISTING allowlisted core_test target, never a new add_executable.
-    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp core_merkle_branches_test.cpp version_gate_test.cpp filesystem_test.cpp web_server_submitblock_test.cpp web_server_current_payouts_test.cpp web_server_local_hashps_test.cpp web_server_relay_block_test.cpp known_txs_eviction_test.cpp tx_advertiser_test.cpp socket_write_queue_test.cpp known_txs_backing_test.cpp random_choice_guard_test.cpp p2p_message_stats_test.cpp netaddress_resolution_test.cpp)
+    # web_server_dashboard_data_test.cpp: the 2026-08-05 hotel-dashboard DATA
+    # honesty KATs (luck/netdiff-at-find, junk-row enrichment, block-value
+    # split vs the accepted coinbase, fee units, last_block, best-share
+    # persistence). Same fold-into-core_test reasoning as every TU here.
+    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp core_merkle_branches_test.cpp version_gate_test.cpp filesystem_test.cpp web_server_submitblock_test.cpp web_server_current_payouts_test.cpp web_server_local_hashps_test.cpp web_server_relay_block_test.cpp web_server_dashboard_data_test.cpp known_txs_eviction_test.cpp tx_advertiser_test.cpp socket_write_queue_test.cpp known_txs_backing_test.cpp random_choice_guard_test.cpp p2p_message_stats_test.cpp netaddress_resolution_test.cpp)
     target_compile_definitions(core_test PRIVATE C2POOL_SRC_ROOT="${CMAKE_SOURCE_DIR}/src")
     target_link_libraries(core_test PRIVATE GTest::gtest_main core c2pool_merged_mining GTest::gtest)
     target_link_libraries(core_test PRIVATE c2pool_payout c2pool_hashrate ltc_coin)  # OBJECT-lib SCC direct-naming (#22/#39)

--- a/src/core/test/web_server_dashboard_data_test.cpp
+++ b/src/core/test/web_server_dashboard_data_test.cpp
@@ -1,0 +1,393 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Dashboard DATA honesty KATs — every case pins a defect measured on the two
+// hotel DASH dashboards on 2026-08-05 (primary :8080 / reserve :8081, both on
+// the same build):
+//
+//   * rows for OUR OWN accepted blocks h=2516911/2516914 rendered as junk on
+//     the primary (miner="" subsidy=0 network_difficulty=0.0 luck=null) —
+//     legacy-persisted rows blocked the attributed re-record forever;
+//   * the reserve's rows carried luck=0.0/expected_time=0.0 because network
+//     difficulty was read from a cache that only a dashboard poll refreshes,
+//     and the luck-trend chart DREW those zeros;
+//   * /local_stats said the miner share of a block was 53% when the ACCEPTED
+//     coinbase of h=2516911 paid miners 25% — the DIP-0027 platform burn was
+//     counted as miner money;
+//   * best_share.all_time reset on restart (all_time == session after 36 min
+//     of uptime);
+//   * /global_stats last_block was a hardcoded 0 with 107 ledger rows on disk.
+//
+// All display-path; no consensus surface is reachable from anything here.
+
+#include <gtest/gtest.h>
+
+#include <core/web_server.hpp>
+#include <core/uint256.hpp>
+
+#include <cstdio>
+#include <string>
+
+using core::MiningInterface;
+
+namespace {
+
+nlohmann::json find_block(const nlohmann::json& arr, const std::string& hash)
+{
+    for (const auto& b : arr)
+        if (b.contains("hash") && b["hash"].get<std::string>() == hash)
+            return b;
+    return nlohmann::json(nullptr);
+}
+
+// Wire a live coin template the way main_dash does: netdiff 1.0 and a pool
+// hashrate of exactly 2^32 H/s make expected_time == 1 s, so the luck
+// arithmetic is checkable by eye. (MiningInterface is neither movable nor
+// copyable — mutexes/atomics — so this configures in place.)
+void wire_dash_template(MiningInterface& mi)
+{
+    mi.set_coin_work_fn([]() {
+        MiningInterface::CoinWorkInfo cw;
+        cw.valid               = true;
+        cw.network_difficulty  = 1.0;
+        cw.coinbase_value_sat  = 177109977;   // the real h=2516911 total
+        cw.payment_amount_sat  = 83044903;    // MN payee alone (legacy field)
+        cw.payments_total_sat  = 132832482;   // MN payee + platform burn
+        cw.burn_sat            = 49787579;    // the OP_RETURN burn
+        cw.height              = 2516911;
+        cw.template_age_sec    = 7;
+        return cw;
+    });
+    mi.set_pool_hashrate_fn([]() { return 4294967296.0; });   // 2^32 H/s
+}
+
+} // namespace
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 1. Luck / expected-time math, with the netdiff-at-find fallback
+// ═══════════════════════════════════════════════════════════════════════════
+
+// THE INCIDENT: both record paths passed a cached network difficulty that is
+// only refreshed when somebody polls /local_stats, so blocks found before the
+// first dashboard hit recorded netdiff=0 -> expected_time=0 -> luck=0, and
+// the chart drew the zeros. The live template knows the real difficulty; the
+// record path must ask it before accepting a zero.
+TEST(DashboardData, LuckIsComputedFromTheLiveTemplateWhenTheCacheIsCold)
+{
+    MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                       c2pool::address::Blockchain::DASH);
+    wire_dash_template(mi);
+
+    const std::string h1 =
+        "3333333333333333333333333333333333333333333333333333333333333333";
+    const std::string h2 =
+        "4444444444444444444444444444444444444444444444444444444444444444";
+
+    // NO dashboard poll has happened: the netdiff cache is cold (0), and the
+    // caller passes 0 for both netdiff and pool hashrate — the exact call
+    // shape of the DASH record sites after this fix.
+    mi.record_found_block(2516911, uint256S(h1), /*ts=*/1785955172, "DASH",
+                          "XoZcEFbqwnty5secW7HYjdQEZYfubMkURu", h1,
+                          /*network_difficulty=*/0.0,
+                          /*share_difficulty=*/240228.0,
+                          /*pool_hashrate=*/0.0, /*subsidy=*/0);
+    // Second block 2 s later: expected_time = 1.0 * 2^32 / 2^32 = 1 s,
+    // time_to_find = 2 s, luck = 50%.
+    mi.record_found_block(2516914, uint256S(h2), /*ts=*/1785955174, "DASH",
+                          "XoZcEFbqwnty5secW7HYjdQEZYfubMkURu", h2,
+                          0.0, 240228.0, 0.0, 0);
+
+    auto blk = find_block(mi.rest_recent_blocks(), h2);
+    ASSERT_TRUE(blk.is_object());
+
+    ASSERT_TRUE(blk["network_difficulty"].is_number())
+        << "netdiff must be recovered from the live template, not stored as 0";
+    EXPECT_DOUBLE_EQ(blk["network_difficulty"].get<double>(), 1.0);
+    ASSERT_TRUE(blk["expected_time"].is_number())
+        << "expected_time = netdiff * 2^32 / pool_hashrate must be computable";
+    EXPECT_DOUBLE_EQ(blk["expected_time"].get<double>(), 1.0);
+    ASSERT_TRUE(blk["time_to_find"].is_number());
+    EXPECT_DOUBLE_EQ(blk["time_to_find"].get<double>(), 2.0);
+    ASSERT_TRUE(blk["luck"].is_number());
+    EXPECT_DOUBLE_EQ(blk["luck"].get<double>(), 50.0);
+    EXPECT_EQ(blk["luck_method"].get<std::string>(), "simple_avg");
+
+    // Subsidy fallback: the caller passed 0 on the node's own chain, so the
+    // template's coinbasevalue must have been recorded instead (row 2516914
+    // showed subsidy=0 on the hotel because the WebServer-held template is
+    // empty on the embedded arm).
+    EXPECT_EQ(blk["subsidy"].get<uint64_t>(), 177109977u);
+
+    // Pool hashrate: 0 from the caller routes to the pool estimator.
+    ASSERT_TRUE(blk["pool_hashrate_at_find"].is_number());
+    EXPECT_DOUBLE_EQ(blk["pool_hashrate_at_find"].get<double>(), 4294967296.0);
+}
+
+// The FIRST block of a ledger has no predecessor, hence no time_to_find and
+// no luck MEASUREMENT. That must surface as null ("not computed"), never as
+// a numeric 0 the chart will draw — 0% luck is a catastrophe claim, and the
+// hotel chart made exactly that claim out of unmeasured rows.
+TEST(DashboardData, UncomputedLuckIsNullNeverZero)
+{
+    MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                       c2pool::address::Blockchain::DASH);
+    wire_dash_template(mi);
+    const std::string h =
+        "5555555555555555555555555555555555555555555555555555555555555555";
+    mi.record_found_block(2516911, uint256S(h), 1785955172, "DASH",
+                          "XoZcEFbqwnty5secW7HYjdQEZYfubMkURu", h,
+                          0.0, 240228.0, 0.0, 0);
+
+    auto blk = find_block(mi.rest_recent_blocks(), h);
+    ASSERT_TRUE(blk.is_object());
+    EXPECT_TRUE(blk["luck"].is_null())
+        << "a first block has no luck measurement; 0 is a fabricated one";
+    EXPECT_TRUE(blk["time_to_find"].is_null());
+    EXPECT_EQ(blk["luck_method"].get<std::string>(), "first_block");
+
+    // /luck_stats feeds the trend chart: same rule there.
+    auto luck = mi.rest_luck_stats();
+    ASSERT_FALSE(luck["blocks"].empty());
+    EXPECT_TRUE(luck["blocks"][0]["luck"].is_null())
+        << "the trend chart must SKIP unmeasured rows, not draw them at 0";
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2. Junk-row honesty + ENRICHMENT
+// ═══════════════════════════════════════════════════════════════════════════
+
+// THE INCIDENT: the primary's rows for our own blocks were persisted by an
+// older binary as miner="" share="" subsidy=0, restored at startup, and the
+// dedup's plain early-return then blocked the attributed re-record (the
+// sharechain hook) forever. An attributed record must UPGRADE an
+// unattributed row; nothing may downgrade.
+TEST(DashboardData, AttributedRecordEnrichesAJunkRowInsteadOfBeingDropped)
+{
+    MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                       c2pool::address::Blockchain::DASH);
+    const std::string h =
+        "6666666666666666666666666666666666666666666666666666666666666666";
+
+    // The legacy junk row (what load_persisted restored on the primary).
+    mi.record_found_block(2516911, uint256S(h), 1785955172, "DASH",
+                          /*miner=*/"", /*share_hash=*/"",
+                          0.0, 0.0, 0.0, 0);
+    {
+        auto blk = find_block(mi.rest_recent_blocks(), h);
+        ASSERT_TRUE(blk.is_object());
+        EXPECT_FALSE(blk["found_locally"].get<bool>());
+        // Junk numerics are honest-absent, not zero-valued data.
+        EXPECT_TRUE(blk["network_difficulty"].is_null());
+        EXPECT_TRUE(blk["subsidy"].is_null());
+        EXPECT_TRUE(blk["share_difficulty"].is_null());
+        EXPECT_TRUE(blk["pool_hashrate_at_find"].is_null());
+    }
+
+    // The attributed record arrives (sharechain hook after restart).
+    mi.record_found_block(2516911, uint256S(h), 1785955172, "DASH",
+                          "XghFtkZ8W3vhEHejUBbD3n387hemVJ6Pt4", h,
+                          47674323.0, 240228.0, 48896352084867.0, 177109977);
+
+    auto arr = mi.rest_recent_blocks();
+    int copies = 0;
+    for (const auto& b : arr)
+        if (b["hash"].get<std::string>() == h) ++copies;
+    EXPECT_EQ(copies, 1) << "enrichment must upgrade in place, never duplicate";
+
+    auto blk = find_block(arr, h);
+    EXPECT_TRUE(blk["found_locally"].get<bool>())
+        << "the junk row must have been upgraded by the attributed record";
+    EXPECT_EQ(blk["miner"].get<std::string>(),
+              "XghFtkZ8W3vhEHejUBbD3n387hemVJ6Pt4");
+    EXPECT_DOUBLE_EQ(blk["network_difficulty"].get<double>(), 47674323.0);
+    EXPECT_EQ(blk["subsidy"].get<uint64_t>(), 177109977u);
+}
+
+TEST(DashboardData, AnAttributedRowIsNeverDowngraded)
+{
+    MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                       c2pool::address::Blockchain::DASH);
+    const std::string h =
+        "7777777777777777777777777777777777777777777777777777777777777777";
+    mi.record_found_block(2516911, uint256S(h), 1785955172, "DASH",
+                          "XghFtkZ8W3vhEHejUBbD3n387hemVJ6Pt4", h,
+                          47674323.0, 240228.0, 1.0, 177109977);
+    // A later unattributed record for the same block (relay echo).
+    mi.record_found_block(2516911, uint256S(h), 1785955999, "DASH",
+                          "", "", 0.0, 0.0, 0.0, 0);
+
+    auto blk = find_block(mi.rest_recent_blocks(), h);
+    EXPECT_EQ(blk["miner"].get<std::string>(),
+              "XghFtkZ8W3vhEHejUBbD3n387hemVJ6Pt4")
+        << "an unattributed echo must not clobber real attribution";
+    EXPECT_EQ(blk["ts"].get<uint64_t>(), 1785955172u);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 3. Block-value split — the ACCEPTED-coinbase truth
+// ═══════════════════════════════════════════════════════════════════════════
+
+// THE INCIDENT, in the exact numbers of our accepted h=2516911: coinbase
+// total 1.77109977, MN payee 0.83044903, platform burn 0.49787579 => miners
+// received 0.44277495 (25%). The card computed miner share as coinbasevalue
+// minus the MN payee ALONE — 0.94065074 (53%) — silently counting the burn
+// as miner money.
+TEST(DashboardData, MinerShareSubtractsEveryProtocolOutputNotJustTheMnPayee)
+{
+    MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                       c2pool::address::Blockchain::DASH);
+    wire_dash_template(mi);
+    auto stats = mi.rest_local_stats();
+
+    EXPECT_NEAR(stats["block_value"].get<double>(), 1.77109977, 1e-9);
+    // payments = MN payee + burn (payments_total_sat), NOT the MN payee alone.
+    EXPECT_NEAR(stats["block_value_payments"].get<double>(), 1.32832482, 1e-9);
+    EXPECT_NEAR(stats["block_value_burn"].get<double>(), 0.49787579, 1e-9);
+    // gross miner share = the 25% the chain actually paid, not 53%.
+    EXPECT_NEAR(stats["block_value_miner_gross"].get<double>(), 0.44277495, 1e-9);
+    // The reconciliation identity #948 documented still holds.
+    EXPECT_NEAR(stats["block_value_miner_gross"].get<double>()
+                    + stats["block_value_payments"].get<double>(),
+                stats["block_value"].get<double>(), 1e-9);
+    // WHICH template, and how old: staleness is now visible instead of a
+    // stale number rendering as current.
+    EXPECT_EQ(stats["block_value_height"].get<uint64_t>(), 2516911u);
+    EXPECT_EQ(stats["block_value_age_sec"].get<int64_t>(), 7);
+}
+
+// A producer that does NOT fill payments_total_sat (the LTC path) must keep
+// byte-identical legacy behaviour: payments falls back to payment_amount_sat.
+TEST(DashboardData, LegacyProducerWithoutPaymentsTotalIsUnchanged)
+{
+    MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                       c2pool::address::Blockchain::DASH);
+    mi.set_coin_work_fn([]() {
+        MiningInterface::CoinWorkInfo cw;
+        cw.valid              = true;
+        cw.coinbase_value_sat = 100000000;
+        cw.payment_amount_sat = 25000000;
+        // payments_total_sat / burn_sat left 0 — legacy producer.
+        return cw;
+    });
+    auto stats = mi.rest_local_stats();
+    EXPECT_NEAR(stats["block_value_payments"].get<double>(), 0.25, 1e-12);
+    EXPECT_NEAR(stats["block_value_miner_gross"].get<double>(), 0.75, 1e-12);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 4. Fee units say their own name
+// ═══════════════════════════════════════════════════════════════════════════
+
+// THE INCIDENT: /fee returned the bare string "1.0" and /local_stats carried
+// fee=1.0 alongside donation_proportion=0.01 — two spellings of the same 1%
+// in two different units, with nothing naming either unit.
+TEST(DashboardData, FeeFieldsDeclareTheirUnits)
+{
+    MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                       c2pool::address::Blockchain::DASH);
+    mi.set_pool_fee_percent(1.0);
+    auto stats = mi.rest_local_stats();
+    EXPECT_DOUBLE_EQ(stats["fee"].get<double>(), 1.0);            // legacy: percent
+    EXPECT_DOUBLE_EQ(stats["fee_percent"].get<double>(), 1.0);    // named unit
+    EXPECT_DOUBLE_EQ(stats["donation_percent"].get<double>(), 1.0);
+    EXPECT_DOUBLE_EQ(stats["donation_proportion"].get<double>(), 0.01);
+    EXPECT_EQ(stats["fee_units"].get<std::string>(), "percent");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 5. last_block comes from the ledger, not a hardcoded 0
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(DashboardData, GlobalStatsLastBlockReadsTheFoundBlockLedger)
+{
+    MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                       c2pool::address::Blockchain::DASH);
+    // Empty ledger: 0 is then the truth (no block ever found), ts is null.
+    {
+        auto gs = mi.rest_global_stats();
+        EXPECT_EQ(gs["last_block"].get<uint64_t>(), 0u);
+        EXPECT_TRUE(gs["last_block_ts"].is_null());
+    }
+    const std::string h =
+        "8888888888888888888888888888888888888888888888888888888888888888";
+    mi.record_found_block(2516911, uint256S(h), 1785955172, "DASH",
+                          "XoZcEFbqwnty5secW7HYjdQEZYfubMkURu", h,
+                          1.0, 1.0, 1.0, 1);
+    auto gs = mi.rest_global_stats();
+    EXPECT_EQ(gs["last_block"].get<uint64_t>(), 2516911u)
+        << "both hotel nodes showed last_block=0 with 100+ rows on disk";
+    EXPECT_EQ(gs["last_block_ts"].get<uint64_t>(), 1785955172u);
+    // And the miners-count scope is stated, so 5-vs-33-rigs cannot again be
+    // read as a bug: 5 counts pool-wide payout addresses, rigs are local
+    // stratum workers, published separately.
+    EXPECT_EQ(gs["unique_miners_scope"].get<std::string>(),
+              "sharechain-payout-addresses-pool-wide");
+    EXPECT_TRUE(gs.contains("local_workers"));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 6. All-time best share survives a restart
+// ═══════════════════════════════════════════════════════════════════════════
+
+TEST(DashboardData, AllTimeBestShareSurvivesARestart)
+{
+    const std::string log_path = "/tmp/c2pool_test_bestshare_statlog.json";
+    std::remove(log_path.c_str());
+    std::remove((log_path + ".best.json").c_str());
+
+    {
+        MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                           c2pool::address::Blockchain::DASH);
+        mi.set_stat_log_path(log_path);
+        mi.record_share_difficulty(268585.98,
+                                   "XudUrCvNXLRwyJqnpdEvZC8Hd6DRAW81TV",
+                                   "aa11");
+        mi.save_stat_log();   // the 100 s tick / clean shutdown path
+    }
+
+    // "Restart": a fresh interface loading the same stat-log path.
+    MiningInterface mi2(/*testnet=*/false, /*node=*/nullptr,
+                        c2pool::address::Blockchain::DASH);
+    mi2.set_stat_log_path(log_path);
+    mi2.load_stat_log();
+
+    auto stats = mi2.rest_local_stats();
+    const auto& best = stats["best_share"];
+    EXPECT_NEAR(best["all_time"]["difficulty"].get<double>(), 268585.98, 1e-6)
+        << "the hotel primary showed all_time == session after 36 min of"
+           " uptime: 'all time' reset on every restart";
+    EXPECT_EQ(best["all_time"]["miner"].get<std::string>(),
+              "XudUrCvNXLRwyJqnpdEvZC8Hd6DRAW81TV");
+    EXPECT_EQ(best["all_time"]["hash"].get<std::string>(), "aa11");
+    // Session is honestly per-process: the restarted node has seen nothing.
+    EXPECT_DOUBLE_EQ(best["session"]["difficulty"].get<double>(), 0.0);
+
+    std::remove(log_path.c_str());
+    std::remove((log_path + ".best.json").c_str());
+}
+
+// A persisted record must only ever RAISE the in-memory one.
+TEST(DashboardData, PersistedBestShareNeverLowersALiveRecord)
+{
+    const std::string log_path = "/tmp/c2pool_test_bestshare_statlog2.json";
+    std::remove(log_path.c_str());
+    std::remove((log_path + ".best.json").c_str());
+    {
+        MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                           c2pool::address::Blockchain::DASH);
+        mi.set_stat_log_path(log_path);
+        mi.record_share_difficulty(100.0, "Xlow", "bb22");
+        mi.save_stat_log();
+    }
+    MiningInterface mi2(/*testnet=*/false, /*node=*/nullptr,
+                        c2pool::address::Blockchain::DASH);
+    mi2.set_stat_log_path(log_path);
+    mi2.record_share_difficulty(500.0, "Xhigh", "cc33");   // before the load
+    mi2.load_stat_log();
+    auto stats = mi2.rest_local_stats();
+    EXPECT_DOUBLE_EQ(stats["best_share"]["all_time"]["difficulty"].get<double>(),
+                     500.0)
+        << "loading a 100-difficulty record over a live 500 would erase the"
+           " better share";
+    std::remove(log_path.c_str());
+    std::remove((log_path + ".best.json").c_str());
+}

--- a/src/core/test/web_server_relay_block_test.cpp
+++ b/src/core/test/web_server_relay_block_test.cpp
@@ -98,6 +98,13 @@ TEST(RelayBlockHonesty, LocallyFoundBlockKeepsRealTiming) {
     EXPECT_NE(blk["luck_method"].get<std::string>(), "relayed")
         << "a locally-found block must carry a real timing label, not 'relayed'";
 
-    EXPECT_TRUE(blk["luck"].is_number())
-        << "locally-found luck is a genuine measured number, not null";
+    // 2026-08-05 revision: this block is the FIRST in its ledger, so no
+    // time_to_find exists and no luck was ever computed. The original
+    // assertion pinned that fabricated 0.0 as "a genuine measured number" —
+    // and the hotel's luck-trend chart faithfully drew those zeros as a
+    // catastrophe. An uncomputed luck is honest-absent null on found blocks
+    // too; luck_method=first_block is the label that says why.
+    EXPECT_TRUE(blk["luck"].is_null())
+        << "a first block has no luck measurement; 0 would be a fabricated one";
+    EXPECT_EQ(blk["luck_method"].get<std::string>(), "first_block");
 }

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -26,6 +26,7 @@
 #include <iomanip>
 #include <sstream>
 #include <set>
+#include <cstdio>   // std::rename (best-share sidecar atomic replace)
 #include <ctime>
 #include <chrono>
 #include <limits>
@@ -2511,6 +2512,17 @@ nlohmann::json MiningInterface::rest_recent_blocks()
         if (!found_locally)                        method = "relayed";
         else if (b.time_to_find > 0 && b.luck > 0) method = "simple_avg";
         else                                       method = "first_block";
+        // #942 second slice, extended to EVERY unmeasured field (hotel,
+        // 2026-08-05): the primary's rows for our own blocks rendered
+        // network_difficulty=0.0, subsidy=0, pool_hashrate=0.0 as if they
+        // were data. A zero that was never measured is emitted as null — the
+        // same honesty rule the timing fields already follow — so the UI
+        // renders '-' instead of a fabricated measurement. A luck of 0 on a
+        // found_locally row means "not computed" (first block, or recorded
+        // with no difficulty), never "0% lucky": also null.
+        auto num_or_null = [](double v) {
+            return v > 0.0 ? nlohmann::json(v) : nlohmann::json(nullptr);
+        };
         arr.push_back({
             {"ts", b.ts},
             {"hash", b.hash},
@@ -2524,13 +2536,14 @@ nlohmann::json MiningInterface::rest_recent_blocks()
             {"miner", b.miner},
             {"share", b.share_hash},
             {"found_locally", found_locally},
-            {"network_difficulty", b.network_difficulty},
-            {"share_difficulty", b.share_difficulty},
-            {"pool_hashrate_at_find", b.pool_hashrate},
-            {"subsidy", b.subsidy},
-            {"expected_time", found_locally ? nlohmann::json(b.expected_time) : nlohmann::json(nullptr)},
-            {"time_to_find", found_locally ? nlohmann::json(b.time_to_find) : nlohmann::json(nullptr)},
-            {"luck", found_locally ? nlohmann::json(b.luck) : nlohmann::json(nullptr)},
+            {"network_difficulty", num_or_null(b.network_difficulty)},
+            {"share_difficulty", num_or_null(b.share_difficulty)},
+            {"pool_hashrate_at_find", num_or_null(b.pool_hashrate)},
+            {"subsidy", b.subsidy != 0 ? nlohmann::json(b.subsidy)
+                                       : nlohmann::json(nullptr)},
+            {"expected_time", found_locally ? num_or_null(b.expected_time) : nlohmann::json(nullptr)},
+            {"time_to_find", found_locally ? num_or_null(b.time_to_find) : nlohmann::json(nullptr)},
+            {"luck", found_locally ? num_or_null(b.luck) : nlohmann::json(nullptr)},
             {"luck_method", method}
         });
     }
@@ -2824,10 +2837,39 @@ nlohmann::json MiningInterface::rest_global_stats()
     result["network_hashrate"] = net_hashrate;
     result["shares_in_chain"] = total_shares;
     result["unique_miners"] = unique_miners;
+    // WHAT unique_miners COUNTS, stated so the card can label it (hotel,
+    // 2026-08-05: the operator read 5 against ~33 connected rigs and called
+    // it wrong — it was counting something else). It is the number of
+    // DISTINCT PAYOUT ADDRESSES holding shares in the sharechain window,
+    // POOL-WIDE (every node's miners, workers collapsed per address); the
+    // rigs number the operator expected is local stratum sessions, published
+    // separately here so the two can never be conflated again.
+    result["unique_miners_scope"] = "sharechain-payout-addresses-pool-wide";
+    {
+        int local_workers = 0;
+        auto workers = effective_stratum_workers();
+        local_workers = static_cast<int>(workers.size());
+        result["local_workers"] = local_workers;
+    }
     result["current_height"] = chain_height;
     result["uptime_seconds"] = rest_uptime();
     result["status"] = "operational";
-    result["last_block"] = 0;
+    // last_block: was a hardcoded 0 since the field's introduction — never
+    // set on any chain (both hotel nodes showed 0 with 100+ ledger rows).
+    // Sourced from the found-block ledger (persistent, so a restart does not
+    // zero it): the newest row for THIS node's primary chain.
+    {
+        uint64_t last_h = 0, last_ts = 0;
+        const std::string primary = node_symbol();
+        std::lock_guard<std::mutex> lock(m_blocks_mutex);
+        for (const auto& b : m_found_blocks) {
+            if (!primary.empty() && b.chain != primary) continue;
+            if (b.height > last_h) { last_h = b.height; last_ts = b.ts; }
+        }
+        result["last_block"] = last_h;
+        result["last_block_ts"] =
+            last_ts ? nlohmann::json(last_ts) : nlohmann::json(nullptr);
+    }
 
     return result;
 }
@@ -3356,12 +3398,70 @@ void MiningInterface::record_found_block(uint64_t height, const uint256& hash, u
     if (ts == 0) ts = static_cast<uint64_t>(std::time(nullptr));
     std::string hash_hex = hash.GetHex();
 
-    // Runtime dedup: skip if this hash+chain combo already exists
+    // ── MEASUREMENT FALLBACKS (hotel, 2026-08-05) ────────────────────────
+    // Both record paths passed mi->get_network_difficulty(), which reads a
+    // cache that is only refreshed when somebody polls /local_stats — so a
+    // block found before the first dashboard hit was recorded with
+    // network_difficulty=0, which zeroed expected_time, which zeroed luck,
+    // which the chart then DREW as 0% luck (the operator's wrong-luck-trend
+    // complaint, rows h=2516911/2516914). The live template knows the real
+    // difficulty at find time; ask it before accepting a zero. Same for a
+    // zero subsidy on the primary chain (row 2516914 recorded subsidy=0
+    // because the embedded arm leaves get_current_work_template() empty).
+    if (network_difficulty <= 0.0 || subsidy == 0) {
+        CoinWorkInfo cw;
+        if (m_coin_work_fn) cw = m_coin_work_fn();
+        if (cw.valid) {
+            if (network_difficulty <= 0.0 && cw.network_difficulty > 0.0)
+                network_difficulty = cw.network_difficulty;
+            if (subsidy == 0 && chain == node_symbol())
+                subsidy = cw.coinbase_value_sat;
+        }
+        if (network_difficulty <= 0.0)
+            network_difficulty =
+                m_network_difficulty.load(std::memory_order_relaxed);
+    }
+
+    // Runtime dedup — with ENRICHMENT. Measured (hotel primary): rows for
+    // OUR OWN blocks h=2516911/2516914 sat as miner="" share="" subsidy=0
+    // junk forever, because they were persisted by an older binary before
+    // attribution existed, restored at startup, and the plain early-return
+    // here then blocked the attributed re-record (sharechain hook) for the
+    // rest of time. An ATTRIBUTED record now upgrades an unattributed row in
+    // place; nothing ever downgrades, and a second attributed record for the
+    // same (hash, chain) still dedups exactly as before.
     {
         std::lock_guard<std::mutex> lock(m_blocks_mutex);
-        for (const auto& existing : m_found_blocks) {
-            if (existing.hash == hash_hex && existing.chain == chain)
-                return;  // already recorded
+        for (auto& existing : m_found_blocks) {
+            if (existing.hash != hash_hex || existing.chain != chain)
+                continue;
+            const bool existing_unattributed =
+                existing.share_hash.empty() && existing.miner.empty();
+            const bool incoming_attributed =
+                !share_hash.empty() || !miner.empty();
+            if (existing_unattributed && incoming_attributed) {
+                existing.miner      = miner;
+                existing.share_hash = share_hash;
+                if (existing.share_difficulty <= 0.0)
+                    existing.share_difficulty = share_difficulty;
+                if (existing.network_difficulty <= 0.0)
+                    existing.network_difficulty = network_difficulty;
+                if (existing.pool_hashrate <= 0.0)
+                    existing.pool_hashrate = pool_hashrate;
+                if (existing.subsidy == 0) existing.subsidy = subsidy;
+                LOG_INFO << "[Pool] found-block row ENRICHED (was recorded"
+                            " unattributed): h=" << existing.height
+                         << " hash=" << hash_hex.substr(0, 16)
+                         << " miner=" << miner;
+                if (m_persist_block_fn) {
+                    try { m_persist_block_fn(existing); }
+                    catch (const std::exception& e) {
+                        LOG_WARNING << "[Pool] Failed to persist enriched"
+                                       " found block: " << e.what();
+                    }
+                }
+            }
+            return;  // already recorded (possibly just enriched)
         }
     }
 
@@ -3818,11 +3918,37 @@ nlohmann::json MiningInterface::rest_local_stats()
         }
     }
     // Fall back to the coin target's live template when WebServer has none.
+    double burn_amount = 0.0;
     if (block_value == 0.0 && coin_work.valid) {
         block_value    = static_cast<double>(coin_work.coinbase_value_sat) / 1e8;
-        payment_amount = static_cast<double>(coin_work.payment_amount_sat) / 1e8;
+        // MEASURED WRONG SPLIT (hotel, 2026-08-05, DASH mainnet). The
+        // dashboard said miner_gross=0.9404 (53% of the block) while the
+        // ACCEPTED coinbase of our own h=2516911 paid miners 0.4428 (25%):
+        // payment_amount_sat carries only the projected MN payee — it rides
+        // in share serialization and MUST keep that meaning — so the 0.4979
+        // DIP-0027 platform OP_RETURN burn was silently counted as miner
+        // money. payments_total_sat is the display-side truth: the sum of
+        // EVERY non-miner coinbase output (MN payee + operator split +
+        // superblock + burn). Fall back to the legacy field only when the
+        // producer did not fill it (LTC path: both 0, byte-identical).
+        payment_amount = static_cast<double>(
+            coin_work.payments_total_sat != 0 ? coin_work.payments_total_sat
+                                              : coin_work.payment_amount_sat) / 1e8;
+        burn_amount    = static_cast<double>(coin_work.burn_sat) / 1e8;
     }
     result["block_value"] = block_value;
+    // WHICH template the number describes, and how old it is. block_value
+    // renders identically whether the template is live or was last sourced
+    // an hour ago (hotel primary: 0 local miners => nothing refreshes it) —
+    // the height + age let the dashboard say so instead of presenting a
+    // stale number as current.
+    if (coin_work.valid) {
+        result["block_value_height"] = coin_work.height;
+        result["block_value_age_sec"] =
+            coin_work.template_age_sec >= 0
+                ? nlohmann::json(coin_work.template_age_sec)
+                : nlohmann::json(nullptr);
+    }
     // #948 gross-vs-net honesty. block_value_miner has always been NET of the
     // pool fee while block_value_payments is GROSS: two sibling fields sharing
     // the block_value_ prefix carry different conventions, and nothing in the
@@ -3843,6 +3969,10 @@ nlohmann::json MiningInterface::rest_local_stats()
     result["block_value_miner_gross"] = miner_subsidy; // explicit pre-fee miner share (dashboard displays this)
     result["block_value_fee"]         = miner_fee;     // visible pool-fee deduction, so the parts reconcile
     result["block_value_payments"] = (m_blockchain == Blockchain::DASH) ? payment_amount : block_value;
+    // The burn split out of payments, so the card's arithmetic is auditable
+    // against the real coinbase: payments == masternode-lane outputs + burn.
+    if (m_blockchain == Blockchain::DASH)
+        result["block_value_burn"] = burn_amount;
 
     // Node fee amounts per block: fee% × (local_hashrate / pool_hashrate) × block_value
     // Matches p2pool: operator gets fee% of THIS node's contribution, not the whole block.
@@ -3955,6 +4085,15 @@ nlohmann::json MiningInterface::rest_local_stats()
     }
     result["donation_proportion"] = m_pool_fee_percent / 100.0;
     result["fee"] = m_pool_fee_percent;  // percentage (e.g. 1.0)
+    // UNITS, stated (hotel, 2026-08-05: the operator could not tell from the
+    // payload whether fee=1.0 meant 1% or a proportion of 1.0 = 100%, because
+    // the sibling donation_proportion IS a proportion where 1.0 would mean
+    // 100%). `fee` and /fee stay p2pool-compat percent; these two name their
+    // unit in the key so no consumer has to guess again. Same value, no
+    // semantic change.
+    result["fee_percent"]      = m_pool_fee_percent;          // 1.0 == 1%
+    result["donation_percent"] = m_pool_fee_percent;          // same 1% restated
+    result["fee_units"]        = "percent";
 
     // attempts_to_{share,block} — estimate from difficulty
     double net_diff = m_network_difficulty.load(std::memory_order_relaxed);
@@ -4824,7 +4963,14 @@ nlohmann::json MiningInterface::rest_luck_stats()
 
     nlohmann::json blocks = nlohmann::json::array();
     for (const auto& b : m_found_blocks) {
-        blocks.push_back({{"ts", b.ts}, {"hash", b.hash}, {"luck", b.luck}});
+        // luck==0 is "never computed" (relay-learned row, or recorded with
+        // no network difficulty), not "0% lucky". The chart previously drew
+        // those as 0-value points, which is exactly the wrong-luck-trend the
+        // hotel dashboards showed on 2026-08-05: emit null so the trend
+        // SKIPS them instead of plotting a fabricated catastrophe.
+        blocks.push_back({{"ts", b.ts}, {"hash", b.hash},
+                          {"luck", b.luck > 0.0 ? nlohmann::json(b.luck)
+                                                : nlohmann::json(nullptr)}});
     }
     result["blocks"] = blocks;
 
@@ -7105,6 +7251,9 @@ void MiningInterface::update_stat_log()
 void MiningInterface::save_stat_log()
 {
     if (m_stat_log_path.empty()) return;
+    // Piggyback on the existing 100 s stat-log cadence (plus the clean-
+    // shutdown save): the all-time best share rides to disk with it.
+    save_best_share_all_time();
     try {
         // Snapshot under brief lock — copies a compact std::vector of structs.
         // The expensive part is the JSON expansion + serialization, which we
@@ -7199,6 +7348,64 @@ void MiningInterface::load_stat_log()
         LOG_INFO << "[StatLog] Loaded " << m_stat_log.size() << " entries from " << m_stat_log_path;
     } catch (const std::exception& ex) {
         LOG_WARNING << "[StatLog] Load failed: " << ex.what();
+    }
+    load_best_share_all_time();
+}
+
+// ── ALL-TIME best share: survives restarts ──────────────────────────────
+// Measured (hotel primary, 2026-08-05, uptime 36 min): /local_stats
+// best_share reported all_time == session == round because the all-time leg
+// lived only in memory — every restart re-founded "all time", and the card
+// silently redefined the word. Only the all-time leg is persisted: session
+// and round are honestly per-process / per-round and must reset.
+void MiningInterface::save_best_share_all_time()
+{
+    const std::string path = best_share_db_path();
+    if (path.empty()) return;
+    nlohmann::json j;
+    {
+        std::lock_guard<std::mutex> lock(m_best_diff_mutex);
+        if (m_best_difficulty.all_time <= 0.0) return;   // nothing measured
+        j = {{"difficulty", m_best_difficulty.all_time},
+             {"miner", m_best_difficulty.all_time_miner},
+             {"hash", m_best_difficulty.all_time_hash},
+             {"ts", m_best_difficulty.all_time_ts}};
+    }
+    try {
+        const std::string tmp = path + ".new";
+        { std::ofstream f(tmp, std::ios::trunc); f << j.dump(); }
+        std::rename(tmp.c_str(), path.c_str());
+    } catch (const std::exception& ex) {
+        LOG_WARNING << "[BestShare] Save failed: " << ex.what();
+    }
+}
+
+void MiningInterface::load_best_share_all_time()
+{
+    const std::string path = best_share_db_path();
+    if (path.empty()) return;
+    try {
+        std::ifstream f(path);
+        if (!f) return;
+        auto j = nlohmann::json::parse(std::string(
+            (std::istreambuf_iterator<char>(f)),
+            std::istreambuf_iterator<char>()));
+        const double d = j.value("difficulty", 0.0);
+        if (d <= 0.0) return;
+        std::lock_guard<std::mutex> lock(m_best_diff_mutex);
+        // Only ever RAISE: a persisted record must never overwrite a better
+        // share found before the load ran.
+        if (d > m_best_difficulty.all_time) {
+            m_best_difficulty.all_time       = d;
+            m_best_difficulty.all_time_miner = j.value("miner", std::string());
+            m_best_difficulty.all_time_hash  = j.value("hash", std::string());
+            m_best_difficulty.all_time_ts    = j.value("ts", uint64_t(0));
+            LOG_INFO << "[BestShare] all-time best RESTORED: difficulty=" << d
+                     << " miner=" << m_best_difficulty.all_time_miner
+                     << " — the card's 'all time' now actually spans restarts";
+        }
+    } catch (const std::exception& ex) {
+        LOG_WARNING << "[BestShare] Load failed: " << ex.what();
     }
 }
 

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -628,6 +628,22 @@ public:
         uint64_t coinbase_value_sat = 0;      // "coinbasevalue"
         uint64_t payment_amount_sat = 0;      // masternode+treasury share
         uint64_t height = 0;                  // template height
+        // TOTAL of every coinbase output that does NOT go to miners, in
+        // template order: masternode payee + operator split + superblock +
+        // the DIP-0027 platform OP_RETURN burn. Measured on the hotel
+        // (2026-08-05, DASH mainnet h=2516911): payment_amount_sat carried
+        // only the MN payee (0.8298), so the dashboard's "miner" share read
+        // 53% of the block when the ACCEPTED coinbase paid miners 25% -- the
+        // 0.4979 platform burn was silently counted as miner money. 0 =
+        // producer did not fill it; consumers then fall back to
+        // payment_amount_sat (pre-existing behaviour, LTC unchanged).
+        uint64_t payments_total_sat = 0;
+        // Of payments_total_sat, the OP_RETURN burn portion (display split).
+        uint64_t burn_sat = 0;
+        // Wall-clock seconds since this template was sourced (0 = unknown).
+        // A stale template renders as a legitimate-looking block_value; the
+        // age is what lets the dashboard say "this number is N minutes old".
+        int64_t  template_age_sec = -1;
     };
     void set_coin_work_fn(std::function<CoinWorkInfo()> fn) { m_coin_work_fn = thread_safe_wrap(std::move(fn)); }
 
@@ -1524,6 +1540,19 @@ private:
     };
     BestDifficulty m_best_difficulty;
     mutable std::mutex m_best_diff_mutex;
+    // ── ALL-TIME best-share persistence ─────────────────────────────────
+    // Measured (hotel primary, 2026-08-05, uptime 36 min): /local_stats
+    // best_share showed all_time == session == round — the "all-time" leg
+    // reset on every restart because it lived only in memory, so the card
+    // was quietly lying about what "all time" means. Persisted as a small
+    // sidecar JSON next to the stat log (all_time leg ONLY: session and
+    // round are honestly per-process/per-round). Display only.
+    std::string best_share_db_path() const {
+        return m_stat_log_path.empty() ? std::string()
+                                       : m_stat_log_path + ".best.json";
+    }
+    void save_best_share_all_time();
+    void load_best_share_all_time();
 
     // Per-miner rolling hashrate ring populated by
     // record_share_difficulty; consumed by rest_pplns_current

--- a/src/impl/dash/share_tracker.hpp
+++ b/src/impl/dash/share_tracker.hpp
@@ -371,7 +371,11 @@ public:
     std::function<void(const uint256&, const uint256&)> m_on_merged_block_check;
     // Callback fired for every verified share with its difficulty + miner script.
     // Used to track best share difficulty for dashboard display.
-    std::function<void(double difficulty, const std::string& miner)> m_on_share_difficulty;
+    /// (difficulty, miner-as-pubkey-hash-hex, share hash). DASH-only shape:
+    /// the hash parameter lets the dashboard attribute its best-share record
+    /// to a concrete share instead of an empty string. Display hook only.
+    std::function<void(double difficulty, const std::string& miner,
+                       const uint256& share_hash)> m_on_share_difficulty;
 
     // Scan the verified best chain for block solutions after startup.
     // Uses cached pow_hash from index (stored during original attempt_verify).
@@ -578,7 +582,14 @@ public:
             m_on_block_found(share_hash);
         }
 
-        // Report share difficulty for best-share dashboard tracking
+        // Report share difficulty for best-share dashboard tracking.
+        // The SHARE HASH rides along (display fix, 2026-08-05): the hotel's
+        // best_share card showed hash="" because this hook never carried the
+        // identity of the very share it was reporting — the dashboard had a
+        // record difficulty with no way to say WHICH share set it. The miner
+        // string stays the raw pubkey-hash hex here (this header does not
+        // know the address version bytes); the main_dash binding encodes it
+        // to a presentable address, where testnet-ness is known.
         if (m_on_share_difficulty) {
             share_var.invoke([&](auto* s) {
                 double diff = chain::target_to_difficulty(chain::bits_to_target(s->m_bits));
@@ -587,7 +598,7 @@ public:
                     miner = s->m_pubkey_hash.GetHex();
                 else if constexpr (requires { s->m_address; })
                     miner = HexStr(s->m_address.m_data);
-                m_on_share_difficulty(diff, miner);
+                m_on_share_difficulty(diff, miner, share_hash);
             });
         }
 

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -302,6 +302,15 @@ std::shared_ptr<const coin::DashWorkData> DASHWorkSource::peek_template() const
     return template_cache_;   // last-sourced snapshot; no refresh triggered
 }
 
+int64_t DASHWorkSource::peek_template_age_sec() const
+{
+    std::lock_guard<std::mutex> lk(template_mutex_);
+    if (!template_cache_) return -1;
+    return std::chrono::duration_cast<std::chrono::seconds>(
+               std::chrono::steady_clock::now() - template_cache_at_)
+        .count();
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // IWorkSource: work generation -- Stage 4c (the template trio).
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -401,6 +401,13 @@ public:
     /// live template (display only; never drives coinbase or consensus).
     std::shared_ptr<const coin::DashWorkData> peek_template() const;
 
+    /// Seconds since the cached template was sourced, -1 when none / unknown.
+    /// Display only (the dashboard's block_value_age_sec): a template that is
+    /// an hour old renders exactly like a live one without this, which is how
+    /// the hotel primary (0 local miners, nothing refreshing the cache)
+    /// presented a stale block_value as current on 2026-08-05.
+    int64_t peek_template_age_sec() const;
+
 private:
     /// Template cache resolve: return the cached DashWorkData snapshot when it
     /// is still fresh (same work_generation AND younger than the staleness

--- a/test/test_dash_dashboard_found_block.cpp
+++ b/test/test_dash_dashboard_found_block.cpp
@@ -335,3 +335,41 @@ TEST(DashDashboardFoundBlock, RecordFoundBlockDedupsOnBlockHash)
                           "Xminer", block_b.GetHex(), 1.0, 2.0, 3.0, SUBSIDY);
     EXPECT_EQ(mi.rest_recent_blocks().size(), 2u);
 }
+
+// 6) FINDER ATTRIBUTION IS THE SHARE'S OWN COMMITTED PAYOUT — pinned against
+//    the 2026-08-05 h=2516911 incident. The reserve dashboard showed
+//    miner=XghFtkZ8W3vhEHejUBbD3n387hemVJ6Pt4 for our pool's block and the
+//    operator read it as a wrong pick of a coinbase output (the MN payee or
+//    the operator split). It is neither: row_from_share() reads
+//    s.m_pubkey_hash — the payout identity the winning share itself commits
+//    to, i.e. the FINDER, who can be any pool participant on any node — and
+//    never inspects a coinbase output. The accepted coinbase paying that
+//    same address a small PPLNS slice (output 1, 0.0407 DASH) is what
+//    CONFIRMS the finder was a genuine (small) participant. This KAT builds
+//    a share committing to XghF…'s real hash160 while the coinbase
+//    scriptSig-side data carries a DIFFERENT (miner_pubkey_hash) identity
+//    everywhere else in this file, and pins that the row encodes exactly the
+//    share's committed payout.
+TEST(DashDashboardFoundBlock, MinerIsTheSharesCommittedPayoutNotACoinbaseOutput)
+{
+    dash::DashShare s;
+    s.m_hash      = hash_from_byte(0x66);
+    s.m_min_header.m_timestamp = HEADER_TIME;
+    s.m_bits      = SHARE_BITS;
+    s.m_subsidy   = 177109977;   // the real h=2516911 coinbase total
+    s.m_coinbase.m_data = bip34_scriptsig();
+    // XghFtkZ8W3vhEHejUBbD3n387hemVJ6Pt4 == P2PKH(version 76) over hash160
+    // 41e4d6d8971a735946494cdbc5e8602c5209b98e (decoded from the address;
+    // the accepted block's output 1 pays the same script). SetHex parses a
+    // big-endian NUMBER into little-endian storage, and the P2PKH script is
+    // built from the INTERNAL bytes — so the hex is fed reversed to land the
+    // script bytes in wire order.
+    s.m_pubkey_hash.SetHex("8eb909522c60e8c5db4c494659731a97d8d6e441");
+
+    const auto row = dash::dashboard::row_from_share(
+        s.m_hash, s, /*testnet=*/false);
+
+    EXPECT_EQ(row.miner, "XghFtkZ8W3vhEHejUBbD3n387hemVJ6Pt4")
+        << "the row's miner must be the share's committed payout address";
+    EXPECT_EQ(row.subsidy, 177109977u);
+}

--- a/web-static/dashboard.html
+++ b/web-static/dashboard.html
@@ -7150,8 +7150,11 @@
                 
                 // Check if block is within selected time window (exact range for alignment)
                 if (blockTime >= minTime && blockTime <= maxTime) {
-                    // For luck trend, collect blocks with luck data within time window
-                    if (b.luck !== undefined && b.luck !== null) {
+                    // For luck trend, collect blocks with luck data within time window.
+                    // luck <= 0 means "never computed" (relay-learned row, or a row
+                    // recorded before the netdiff-at-find fix), NOT 0% luck -- plotting
+                    // it drew the 2026-08-05 hotel chart down to zero. Skip, don't draw.
+                    if (b.luck !== undefined && b.luck !== null && b.luck > 0) {
                         luckTrendData.push([blockTime, b.luck]);
                         validLucks.push(b.luck);
                     }
@@ -7803,8 +7806,11 @@
                 
                 // Check if block is within selected time window (exact range for alignment)
                 if (blockTime >= minTime && blockTime <= maxTime) {
-                    // For luck trend, collect blocks with luck data within time window
-                    if (b.luck !== undefined && b.luck !== null) {
+                    // For luck trend, collect blocks with luck data within time window.
+                    // luck <= 0 means "never computed" (relay-learned row, or a row
+                    // recorded before the netdiff-at-find fix), NOT 0% luck -- plotting
+                    // it drew the 2026-08-05 hotel chart down to zero. Skip, don't draw.
+                    if (b.luck !== undefined && b.luck !== null && b.luck > 0) {
                         luckTrendData.push([blockTime, b.luck]);
                         validLucks.push(b.luck);
                     }


### PR DESCRIPTION
## What this is

Task #92: the two hotel DASH dashboards (primary :8080, reserve :8081, same build) were showing wrong **best share**, **miners block value**, **node fee**, and a wrong **luck-trend chart**. Every defect below was measured live on 2026-08-05 and reconciled against **chain truth** (`dash-cli getblock <h=2516911> 2` — the actual accepted coinbase of our own block), then fixed at its source.

**Display/web layer only.** No serve gate, consensus, share, target or payout path is touched. `m_payment_amount` (which rides in share serialization) keeps its exact meaning.

## Chain truth used throughout

The accepted coinbase of our block h=2516911 (total **1.77109977**):

| output | value | what |
|---|---|---|
| 0,1,2,3,4,7 | 0.44277495 total | PPLNS miner payouts (0.374 to XoZ…, **0.0407 to XghF…**, …) |
| 5 | 0.49787579 | DIP-0027 platform burn (OP_RETURN) |
| 6 | 0.83044903 | masternode payee |

Miners received **25%** of the block. The dashboard claimed **53%**.

## Per-defect verdicts

**1. Primary `/recent_blocks` junk rows for our own blocks — FIXED (needs-deploy).** Rows persisted *unattributed* by an older binary are restored at startup, and `record_found_block`'s dedup early-return blocked the attributed re-record forever. An attributed record now **enriches** an unattributed row in place (never the reverse), and unmeasured numerics (`network_difficulty=0`, `subsidy=0`, …) are emitted as honest-absent `null` instead of real-looking zeros (#942 second slice). After deploy, the sharechain hook re-fires on tracker rescans and upgrades the existing junk rows; until then the nulls stop the zeros rendering as data.

**2. Reserve says 2516911 miner=XghF… — NOT A BUG (works as designed; verified).** Attribution reads the winning **share's own committed payout** (`m_pubkey_hash`), never a coinbase output. Chain check: the accepted coinbase's output 1 pays that exact address a proportional PPLNS slice (0.0407 DASH) — XghF… is a genuine small pool participant (one of the 5 `unique_miners`) whose share won the block. The "miner" of a pool-found block is the **finder**, who need not be a local rig. Pinned by a new KAT using the real h=2516911 identities (`MinerIsTheSharesCommittedPayoutNotACoinbaseOutput`).

**3. best_share: raw hash160, empty hash, all_time==round==session — FIXED (needs-deploy).** Three sub-defects: (a) the dash tracker hook reported the miner as raw pubkey-hash hex (`cfc7a034…` decodes to XudUrCvNXLRwyJqnpdEvZC8Hd6DRAW81TV — a third pool participant, which is why the reserve, fed by stratum usernames, looked "right" while the primary, fed by sharechain shares, looked broken) — main_dash now encodes it testnet-aware with the same version bytes the found-block feed uses; (b) the hook never carried the share hash — the DASH hook signature now does, so `best_share.hash` names the record share; (c) the all-time leg lived only in memory — now persisted in a sidecar next to the stat log (load only ever raises), so "all time" stops meaning "since the last restart".

**4. block_value / miner share / payments — FIXED (needs-deploy), definitions below.** The card computed miner = coinbasevalue − **MN payee alone**, counting the platform burn as miner money. `CoinWorkInfo` gains `payments_total_sat`/`burn_sat` summed from the template's real packed payments (both the RPC and embedded builders fill them in coinbase-output order); `/local_stats` now subtracts **every** protocol output.
**Definitions (now true in the payload):** `block_value` = coinbasevalue of the current template (subsidy+fees) · `block_value_payments` = ALL non-miner outputs (MN payee + operator split + superblock + burn) · `block_value_burn` = the OP_RETURN part of that · `block_value_miner_gross` = miner residual incl. fees, **pre**-fee/donation · `block_value_miner`/`_net` = the same **after** the node's 1% · identity `gross + payments == block_value` holds and is KAT-pinned with the real h=2516911 numbers (0.4428 + 1.3283 = 1.7711).
**"Stale" half:** the template can legitimately differ from dashd's GBT by mempool selection; the real defect was that a stale template renders identically to a live one. Added `block_value_height` + `block_value_age_sec` so staleness is visible (the primary, with 0 local miners, refreshes nothing).

**5. fee ambiguity — FIXED (needs-deploy).** `fee=1.0` (percent) sat next to `donation_proportion=0.01` (proportion) with nothing naming either unit. Added `fee_percent` / `donation_percent` / `fee_units:"percent"`; `/fee` and legacy keys stay p2pool-compat byte-identical. The dashboard's fee card reads `.fee` as percent, which is correct; the "Node fee share" amount card was wrong only because it multiplied the inflated miner share from defect 4 — fixed by 4.

**6. global_stats — FIXED (needs-deploy).** `last_block` was a **hardcoded 0** since the field's introduction; now read from the persistent found-block ledger (+ `last_block_ts`). `unique_miners=5` vs ~33 rigs — **not a bug, relabelled**: it counts pool-wide sharechain payout addresses (XoZ…'s 27 workers collapse to one; XghF… and XudU… are two of the others). The scope is now stated in the payload (`unique_miners_scope`) and `local_workers` (stratum sessions) is published beside it.

**7. luck trend — FIXED (needs-deploy).** Two root causes: (a) both record paths passed a netdiff **cache that only a dashboard poll refreshes** → blocks found before the first poll recorded netdiff=0 → expected_time=0 → luck=0; (b) `pool_hashrate_at_find` was fed `get_local_hashrate()`, which equals the pool rate only while every rig sits on one node. `record_found_block` now falls back to the **live coin template** for netdiff/subsidy and to the **pool estimator** for hashrate; `expected_time = netdiff·2³²/pool_hashrate`, `luck = expected/actual·100` (KAT-pinned with round numbers). Uncomputed luck (0) is emitted as `null` on `/recent_blocks` **and** `/luck_stats`, and the chart JS skips non-positive luck instead of drawing it — existing junk DB rows stop dragging the trend to zero even before enrichment upgrades them.

**8. zero-hashrate posture — COVERED.** The idle-primary degradations were exactly the junk-row/stale-value modes above; the null-honesty emitters and the template-age field keep an idle node's cards truthful. `expected_payout` etc. already guard with `isFinite`.

## Tests

10 new cases in `core_test` (`web_server_dashboard_data_test.cpp`, folded into the existing allowlisted target), 1 updated in `web_server_relay_block_test.cpp` — it pinned the fabricated first-block `luck=0.0` as "a genuine measured number", which is precisely what the chart then drew — and 1 new dash-lane KAT in `test_dash_dashboard_found_block.cpp`. Local: core_test **157/157**, test_dash_node **34/34**, test_dash_node_reception_wire **121/121**, full `make` clean, allowlist drift-guard 232/232.

## Deploy note

Everything here is **needs-deploy** (hotel deploys are operator-tap only, and the hotel needs the binary + lib bundle, not a lone binary swap). No data migration: the enrichment path heals the existing junk DB rows in place at runtime, and the best-share sidecar appears on the first stat-log save.

**do-not-merge** — for review of the field semantics before anything ships.
