### PR TITLE
dash(oracle-shadow): resolve the embedded arm on the io thread and hand the worker a deep copy — root-cause fix for the 2026-08-05 hotel heap corruption [do-not-merge]

### DIFF
--- a/src/impl/dash/coin/embedded_oracle_shadow.hpp
+++ b/src/impl/dash/coin/embedded_oracle_shadow.hpp
@@ -637,16 +637,76 @@ public:
     EmbeddedOracleShadow(const EmbeddedOracleShadow&) = delete;
     EmbeddedOracleShadow& operator=(const EmbeddedOracleShadow&) = delete;
 
+    /// One queued tip sample. It is a VALUE — everything the worker needs is
+    /// COPIED into it on the tip thread. It deliberately carries no pointer,
+    /// reference or handle into NodeCoinState; see on_new_tip().
+    struct TipJob {
+        uint32_t     next_height{0};
+        uint256      next_prev_hash;
+        /// Which arm the embedded selector chose FOR THIS TIP, resolved on the
+        /// tip thread (see on_new_tip). false => fall-closed to dashd.
+        bool         is_embedded{false};
+        /// The embedded template, DEEP-COPIED out of the selector. Meaningful
+        /// only when is_embedded; DashWorkData is all-by-value (rpc_data.hpp),
+        /// so once it is here it owns every byte the worker reads.
+        DashWorkData emb;
+        /// Log-only decline diagnostic, sampled beside is_embedded. Empty when
+        /// is_embedded.
+        std::string  decline_reason;
+    };
+
     /// Tip-thread entry: ENQUEUE ONLY (never blocks the caller). The worker
     /// thread runs the compare so a hung dashd cannot perturb tip processing.
     /// Coalescing: if a tip is already pending unprocessed, it is replaced by
     /// the newest (a shadow samples tips; a skipped intermediate is a coverage
     /// gap, never a wrong count — and on the ~2.6 min interval the worker keeps
     /// up with room to spare).
+    ///
+    /// OWNERSHIP (heap-corruption fix, hotel SIGABRT 2026-08-05 21:52:38 MSK):
+    /// the embedded arm is resolved HERE, on the tip/io thread that exclusively
+    /// owns NodeCoinState, and the worker is handed a DEEP COPY. It used to be
+    /// resolved on the WORKER thread (process_tip called coin_state_.
+    /// select_work()), which dereferenced `&m_mnstates` / `&m_sml` — raw
+    /// pointers select_work() hands into live containers (node_coin_state.hpp
+    /// :1066/:1087) — while the io thread was concurrently rebalancing the
+    /// MnStateMachine RB-tree (coin_state_maintainer.hpp:1092), reallocating
+    /// the CSimplifiedMNList vector (:489) and clear()ing it (:482/:716).
+    /// NodeCoinState has ZERO mutexes, and MNState owns two heap vectors
+    /// (mn_state_db.hpp:60), so the overlap corrupted ALLOCATOR METADATA rather
+    /// than merely reading stale values — glibc "malloc(): unaligned tcache
+    /// chunk detected" / "double free or corruption (!prev)".
+    ///
+    /// This is the same shape EmbeddedShadowCompare::on_serve already uses
+    /// (embedded_shadow_compare.hpp:381-387): the io thread resolves, the queue
+    /// carries a value, the worker owns what it reads. It is a lifetime/
+    /// ownership change ONLY — no serve gate, no arm decision, no consensus
+    /// path is touched, and the shadow remains OBSERVE-only.
     void on_new_tip(uint32_t next_height, const uint256& next_prev_hash) {
+        TipJob job;
+        job.next_height    = next_height;
+        job.next_prev_hash = next_prev_hash;
+        // The fallback arm is a NO-OP HERE, deliberately. select_work()'s
+        // fallback is a dashd getblocktemplate RPC (NodeRPC::m_rpc_mutex,
+        // rpc.cpp:211, 12 s socket deadline) and this runs on the io thread,
+        // which must never block on an RPC. The shadow never read the fallback
+        // template anyway — process_tip() consumes sel.work ONLY on the
+        // is_embedded branch — so an empty DashWorkData is byte-equivalent for
+        // every consumer, and one wasted per-tip RPC disappears with it.
+        WorkSelection sel = coin_state_.select_work(
+            []() { return DashWorkData{}; });
+        job.is_embedded = (sel.source == WorkSource::Embedded);
+        if (job.is_embedded) {
+            job.emb = std::move(sel.work);
+        } else {
+            // decline-reason DIAGNOSTIC (log-only): captured on the SAME
+            // sample as is_embedded so it matches the selection decision
+            // exactly — and now on the same thread and in the same instant,
+            // instead of across a worker-side RPC round trip.
+            job.decline_reason = coin_state_.classify_decline();
+        }
         {
             std::lock_guard<std::mutex> lk(q_mu_);
-            pending_ = std::make_pair(next_height, next_prev_hash);
+            pending_ = std::move(job);
         }
         q_cv_.notify_one();
     }
@@ -654,19 +714,22 @@ public:
     /// The actual per-block shadow-compare (worker thread). OBSERVE-ONLY. All
     /// heavy RPCs run here BEFORE mu_ is taken, so /embedded_oracle (stats_json)
     /// never blocks on a dashd RPC.
-    void process_tip(uint32_t next_height, const uint256& next_prev_hash) {
+    ///
+    /// THREAD CONTRACT: this function must NEVER touch coin_state_. Everything
+    /// it needs about the embedded arm arrives in `job`, already copied by
+    /// on_new_tip() on the owning thread. The structural guard in
+    /// test/test_dash_oracle_shadow_ownership.cpp pins that.
+    void process_tip(const TipJob& job) {
+        const uint32_t  next_height    = job.next_height;
+        const uint256&  next_prev_hash = job.next_prev_hash;
         if (!dashd_gbt_) { LOG_WARNING << "[EMB-ORACLE] no dashd oracle bound"; return; }
 
         // ── Phase 1: ALL heavy RPCs, NO lock ────────────────────────────────
         // Runs on the worker thread; taking mu_ here would make /embedded_oracle
         // (stats_json) block on a dashd RPC. So gather everything unlocked, then
         // take mu_ only for the fast analysis + ledger phase.
-        WorkSelection sel = coin_state_.select_work(dashd_gbt_);
-        const bool is_embedded = (sel.source == WorkSource::Embedded);
-        // decline-reason DIAGNOSTIC (log-only): captured on the SAME
-        // sample as is_embedded so it matches the selection decision exactly.
-        const std::string decline_reason =
-            is_embedded ? std::string() : coin_state_.classify_decline();
+        const bool is_embedded = job.is_embedded;
+        const std::string& decline_reason = job.decline_reason;
         DashWorkData emb, dashd;
         bool dashd_rpc_ok = false, aligned = false;
         std::optional<int64_t> base_cp;   // creditPool(N-1) from the CONNECTED block
@@ -674,7 +737,7 @@ public:
         ProposalResult pr;
 
         if (is_embedded) {
-            emb = std::move(sel.work);
+            emb = job.emb;   // deep copy already owned by this job
             try { dashd = dashd_gbt_(); dashd_rpc_ok = true; }
             catch (const std::exception& ex) {
                 LOG_WARNING << "[EMB-ORACLE] dashd oracle threw: " << ex.what() << " — void";
@@ -840,15 +903,17 @@ private:
     // RPCs + file writes) never runs on the tip-dispatch thread.
     void worker_loop() {
         for (;;) {
-            std::pair<uint32_t, uint256> job;
+            TipJob job;
             {
                 std::unique_lock<std::mutex> lk(q_mu_);
                 q_cv_.wait(lk, [this] { return stop_ || pending_.has_value(); });
                 if (stop_ && !pending_.has_value()) return;
-                job = *pending_;
+                job = std::move(*pending_);
                 pending_.reset();
             }
-            try { process_tip(job.first, job.second); }
+            // `job` is a self-contained VALUE: from here on the worker reads
+            // nothing that the io thread can concurrently mutate.
+            try { process_tip(job); }
             catch (const std::exception& e) {
                 LOG_WARNING << "[EMB-ORACLE] worker exception: " << e.what();
             }
@@ -944,6 +1009,11 @@ private:
         }
     }
 
+    // TIP-THREAD ONLY. NodeCoinState carries no mutex and hands raw pointers
+    // into its live containers out of select_work(); it may be read ONLY from
+    // the thread that mutates it (the io/tip thread). The single legal use of
+    // this reference is inside on_new_tip(). The worker thread must never
+    // reach it — that was the 2026-08-05 hotel heap corruption.
     const NodeCoinState&          coin_state_;
     std::function<DashWorkData()> dashd_gbt_;
     ProposalFn                    proposal_fn_;
@@ -958,7 +1028,7 @@ private:
     std::thread             worker_;
     std::mutex              q_mu_;
     std::condition_variable q_cv_;
-    std::optional<std::pair<uint32_t, uint256>> pending_;
+    std::optional<TipJob>   pending_;
     bool                    stop_{false};
 
     // Trackers below are WORKER-THREAD-EXCLUSIVE (process_tip only) — no lock.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -899,7 +899,15 @@ if (BUILD_TESTING AND GTest_FOUND)
     # NodeCoinState: node-held embedded coin-state holder over the
     # work_source selector link set (mn_state_machine + mempool header-only);
     # no ltc/pool SCC dependency. Mirrors the test_dash_work_source link set.
-    add_executable(test_dash_node_coin_state test_dash_node_coin_state.cpp)
+    # D-DASH.ORACLE-OWNERSHIP rides this EXISTING allowlisted target rather than
+    # a new add_executable — a fresh target absent from the build.yml --target
+    # allowlist becomes the silently-passing NOT_BUILT sentinel (#143). It is a
+    # source-structural guard over embedded_oracle_shadow.hpp + main_dash.cpp,
+    # so it needs no link deps of its own; the compile definitions hand it the
+    # paths to the SHIPPED sources.
+    add_executable(test_dash_node_coin_state
+        test_dash_node_coin_state.cpp
+        test_dash_oracle_shadow_ownership.cpp)
     target_link_libraries(test_dash_node_coin_state PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core
@@ -907,6 +915,9 @@ if (BUILD_TESTING AND GTest_FOUND)
         ${Boost_LIBRARIES}
     )
     target_link_libraries(test_dash_node_coin_state PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
+    target_compile_definitions(test_dash_node_coin_state PRIVATE
+        DASH_ORACLE_SHADOW_SRC="${CMAKE_CURRENT_SOURCE_DIR}/../src/impl/dash/coin/embedded_oracle_shadow.hpp"
+        DASH_MAIN_SRC="${CMAKE_CURRENT_SOURCE_DIR}/../src/c2pool/main_dash.cpp")
     gtest_add_tests(test_dash_node_coin_state "" AUTO)
 
     # bestCL template gate: dashcore's CheckCbTxBestChainlock rule (consensus-

--- a/test/test_dash_oracle_shadow_ownership.cpp
+++ b/test/test_dash_oracle_shadow_ownership.cpp
@@ -1,0 +1,283 @@
+// D-DASH.ORACLE-OWNERSHIP — source-structural guard pinning WHICH THREAD is
+// allowed to read NodeCoinState from the --embedded-oracle-shadow lane.
+//
+// THE DEFECT THIS PINS (hotel primary c2pool-dash, SIGABRT 2026-08-05
+// 21:52:38 MSK, glibc "malloc(): unaligned tcache chunk detected" +
+// "double free or corruption (!prev)", 25 min after deploying cdd908ce):
+//
+//   NodeCoinState (impl/dash/coin/node_coin_state.hpp) has ZERO mutexes, and
+//   select_work() hands RAW POINTERS into its live containers out to the
+//   caller — `e.mnstates = &m_mnstates` (:1066, an MnStateMachine map) and
+//   `e.sml = &m_sml` (:1087, a CSimplifiedMNList vector). The embedded
+//   template is then assembled by DEREFERENCING those pointers.
+//
+//   EmbeddedOracleShadow::process_tip() used to call
+//   `coin_state_.select_work(...)` on its own WORKER THREAD while the io
+//   thread concurrently mutated the very same containers — apply_diff vector
+//   realloc (coin_state_maintainer.hpp:489), mnList.clear() (:482, :716),
+//   apply_block RB-tree rebalance (:1092). MNState owns two heap vectors
+//   (mn_state_db.hpp:60), so the overlap corrupted ALLOCATOR METADATA rather
+//   than merely returning stale values — which is exactly why glibc reported
+//   tcache/double-free rather than a wrong template.
+//
+// THE FIX: resolve the embedded arm on the tip/io thread inside on_new_tip()
+// and enqueue a DEEP COPY (TipJob, all-by-value). This is the shape
+// EmbeddedShadowCompare::on_serve already uses correctly
+// (embedded_shadow_compare.hpp:381-387).
+//
+// WHY A STRUCTURAL TEST: a true data race is nondeterministic and was NOT
+// reproduced under a sanitizer — the diagnosis is convergent static + timing
+// evidence. A guard that asserts the OWNERSHIP SHAPE is the deterministic
+// red/green this invariant admits, and it is the house pattern for exactly
+// this situation (src/impl/dgb/test/race913_lock_guard_test.cpp, PR #1114).
+// Move select_work() back into process_tip()/worker_loop() -> RED.
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#ifndef DASH_ORACLE_SHADOW_SRC
+#error "DASH_ORACLE_SHADOW_SRC must be defined by CMake to the path of src/impl/dash/coin/embedded_oracle_shadow.hpp"
+#endif
+#ifndef DASH_MAIN_SRC
+#error "DASH_MAIN_SRC must be defined by CMake to the path of src/c2pool/main_dash.cpp"
+#endif
+
+namespace {
+
+std::string read_text(const char* path)
+{
+    std::ifstream in(path);
+    EXPECT_TRUE(in.good()) << "cannot open " << path;
+    std::stringstream ss; ss << in.rdbuf();
+    return ss.str();
+}
+
+std::string read_shadow_header() { return read_text(DASH_ORACLE_SHADOW_SRC); }
+std::string read_main_dash()     { return read_text(DASH_MAIN_SRC); }
+
+// Replace every comment with spaces, preserving byte offsets and line breaks so
+// the "\n    }\n" member-end anchor below still lines up. Comments must not be
+// able to satisfy (or break) an assertion about what the CODE does — the doc
+// blocks in this header deliberately quote the pre-fix expressions.
+std::string strip_comments(const std::string& s)
+{
+    std::string out = s;
+    enum { kCode, kLine, kBlock, kStr, kChr } st = kCode;
+    for (size_t i = 0; i < out.size(); ++i) {
+        const char c = out[i];
+        const char n = (i + 1 < out.size()) ? out[i + 1] : '\0';
+        switch (st) {
+        case kCode:
+            if (c == '/' && n == '/') { st = kLine;  out[i] = ' '; out[i + 1] = ' '; ++i; }
+            else if (c == '/' && n == '*') { st = kBlock; out[i] = ' '; out[i + 1] = ' '; ++i; }
+            else if (c == '"')  st = kStr;
+            else if (c == '\'') st = kChr;
+            break;
+        case kLine:
+            if (c == '\n') st = kCode; else out[i] = ' ';
+            break;
+        case kBlock:
+            if (c == '*' && n == '/') { out[i] = ' '; out[i + 1] = ' '; ++i; st = kCode; }
+            else if (c != '\n') out[i] = ' ';
+            break;
+        case kStr:
+            if (c == '\\') ++i; else if (c == '"') st = kCode;
+            break;
+        case kChr:
+            if (c == '\\') ++i; else if (c == '\'') st = kCode;
+            break;
+        }
+    }
+    return out;
+}
+
+// Byte range [begin,end) of a 4-space-indented member function body, from its
+// signature line to the closing "\n    }\n" that ends it. Class members in this
+// header sit at 4-space indent and every nested block closes deeper, so the
+// anchor is unambiguous (verified against the shipped file by the tests below,
+// which fail loudly if a signature or its terminator is missing).
+struct Range { size_t begin{std::string::npos}; size_t end{std::string::npos}; };
+
+Range member_range(const std::string& src, const std::string& signature)
+{
+    Range r;
+    r.begin = src.find(signature);
+    if (r.begin == std::string::npos) return r;
+    const size_t close = src.find("\n    }\n", r.begin);
+    if (close == std::string::npos) { r.begin = std::string::npos; return r; }
+    r.end = close + 7;   // strlen("\n    }\n")
+    return r;
+}
+
+std::string member_body(const std::string& src, const std::string& signature)
+{
+    const Range r = member_range(src, signature);
+    if (r.begin == std::string::npos) return "";
+    return src.substr(r.begin, r.end - r.begin);
+}
+
+size_t count_of(const std::string& hay, const std::string& needle)
+{
+    size_t n = 0, pos = 0;
+    while ((pos = hay.find(needle, pos)) != std::string::npos) { ++n; pos += needle.size(); }
+    return n;
+}
+
+const char* kProcessTipSig = "void process_tip(";
+const char* kWorkerLoopSig = "void worker_loop()";
+const char* kOnNewTipSig   = "void on_new_tip(";
+
+} // namespace
+
+// ── The worker thread must not be able to reach NodeCoinState at all ────────
+// process_tip() runs on worker_, started in the ctor. NodeCoinState is owned
+// and mutated by the io thread and carries no lock, so a single textual
+// reference to coin_state_ inside this body is the whole bug back.
+TEST(DashOracleShadowOwnership, ProcessTipNeverTouchesCoinState)
+{
+    const std::string src  = strip_comments(read_shadow_header());
+    const std::string body = member_body(src, kProcessTipSig);
+    ASSERT_FALSE(body.empty()) << "process_tip(...) not found in "
+                               << DASH_ORACLE_SHADOW_SRC;
+    EXPECT_EQ(body.find("coin_state_"), std::string::npos)
+        << "process_tip() runs on the WORKER thread and must never read "
+           "NodeCoinState (no mutex; select_work() hands out raw pointers into "
+           "live containers -> the 2026-08-05 heap corruption). Resolve on the "
+           "tip thread in on_new_tip() and enqueue a deep copy instead.";
+}
+
+TEST(DashOracleShadowOwnership, WorkerLoopNeverTouchesCoinState)
+{
+    const std::string src  = strip_comments(read_shadow_header());
+    const std::string body = member_body(src, kWorkerLoopSig);
+    ASSERT_FALSE(body.empty()) << "worker_loop() not found";
+    EXPECT_EQ(body.find("coin_state_"), std::string::npos)
+        << "worker_loop() runs on the WORKER thread and must never read "
+           "NodeCoinState.";
+}
+
+// ── The tip (io) thread is the ONLY legal reader ────────────────────────────
+TEST(DashOracleShadowOwnership, OnNewTipResolvesTheArmOnTheTipThread)
+{
+    const std::string src  = strip_comments(read_shadow_header());
+    const std::string body = member_body(src, kOnNewTipSig);
+    ASSERT_FALSE(body.empty()) << "on_new_tip(...) not found";
+    EXPECT_NE(body.find("coin_state_.select_work("), std::string::npos)
+        << "on_new_tip() runs on the tip/io thread that owns NodeCoinState and "
+           "is where the embedded arm must be resolved.";
+}
+
+// Exactly one select_work() call in the whole file, and it sits inside
+// on_new_tip(). Catches a re-introduced second call site anywhere else
+// (a new accessor, a stats path, a future compare leg).
+TEST(DashOracleShadowOwnership, SelectWorkCalledOnlyFromOnNewTip)
+{
+    const std::string src = strip_comments(read_shadow_header());
+    EXPECT_EQ(count_of(src, "select_work("), 1u)
+        << "exactly one select_work() call site is expected, inside on_new_tip()";
+    const Range on_tip = member_range(src, kOnNewTipSig);
+    ASSERT_NE(on_tip.begin, std::string::npos) << "on_new_tip(...) not found";
+    const size_t at = src.find("select_work(");
+    ASSERT_NE(at, std::string::npos) << "select_work() call vanished entirely";
+    EXPECT_TRUE(at > on_tip.begin && at < on_tip.end)
+        << "select_work() is called from OUTSIDE on_new_tip() — only the "
+           "tip/io thread may read NodeCoinState.";
+}
+
+// classify_decline() re-runs make_embedded_work_inputs() and therefore reads
+// the same unguarded containers; it is the same exposure and must be sampled
+// on the same thread.
+TEST(DashOracleShadowOwnership, ClassifyDeclineSampledOnTheTipThread)
+{
+    const std::string src = strip_comments(read_shadow_header());
+    ASSERT_EQ(count_of(src, "classify_decline("), 1u)
+        << "expected exactly one classify_decline() sample";
+    const Range on_tip = member_range(src, kOnNewTipSig);
+    ASSERT_NE(on_tip.begin, std::string::npos);
+    const size_t at = src.find("classify_decline(");
+    EXPECT_TRUE(at > on_tip.begin && at < on_tip.end)
+        << "classify_decline() re-reads m_mnstates/m_sml — it must be sampled "
+           "on the tip thread beside select_work(), never on the worker.";
+}
+
+// ── The queued job must OWN what the worker reads ───────────────────────────
+// A pointer/reference member would re-open the lifetime hole with none of the
+// textual evidence the tests above look for.
+TEST(DashOracleShadowOwnership, QueuedJobCarriesTheTemplateByValue)
+{
+    const std::string src = strip_comments(read_shadow_header());
+    const size_t s = src.find("struct TipJob {");
+    ASSERT_NE(s, std::string::npos) << "TipJob (the by-value queue element) not found";
+    const size_t e = src.find("\n    };\n", s);
+    ASSERT_NE(e, std::string::npos) << "TipJob has no terminator";
+    const std::string body = src.substr(s, e - s);
+
+    EXPECT_NE(body.find("DashWorkData emb;"), std::string::npos)
+        << "TipJob must carry the embedded template BY VALUE (DashWorkData is "
+           "all-by-value; owning it is what makes the worker read safe)";
+    EXPECT_EQ(body.find("DashWorkData*"), std::string::npos)
+        << "TipJob must not carry a POINTER to the template";
+    EXPECT_EQ(body.find("NodeCoinState"), std::string::npos)
+        << "TipJob must not reference NodeCoinState in any form";
+    EXPECT_EQ(body.find("MnStateMachine"), std::string::npos)
+        << "TipJob must not carry the MN state map (that is the live container)";
+    EXPECT_EQ(body.find("CSimplifiedMNList"), std::string::npos)
+        << "TipJob must not carry the SML (that is the live container)";
+}
+
+// The coalescing queue slot holds the job BY VALUE too — a pointer here would
+// mean the tip thread still owns storage the worker dereferences.
+TEST(DashOracleShadowOwnership, PendingSlotHoldsTheJobByValue)
+{
+    const std::string src = strip_comments(read_shadow_header());
+    EXPECT_NE(src.find("std::optional<TipJob>"), std::string::npos)
+        << "the coalescing queue slot must be std::optional<TipJob> (by value)";
+    EXPECT_EQ(src.find("std::optional<std::pair<uint32_t, uint256>> pending_"),
+              std::string::npos)
+        << "the pre-fix queue element is back: it carried only (height, hash), "
+           "which forced the worker to re-read NodeCoinState for the template.";
+}
+
+// ── The SIBLING exposure: DASHWorkSource::resource_template_now() ───────────
+// work_source.cpp:335/:346/:353/:371/:383 read NodeCoinState (populated(),
+// select_work(), describe_decline(), embedded_template_emit_ok()) and can run
+// on the rpc_pool worker (main_dash.cpp:5056) when refresh_executor_ is wired.
+// That is the SAME unguarded-read shape as the oracle-shadow bug — and today
+// the ONLY thing that makes it safe is ARM EXCLUSIVITY: the executor is
+// installed under `!coin_p2p`, while every NodeCoinState MUTATOR lives inside
+// the `if (coin_p2p)` block, so on the arm that has the worker the coin state
+// is write-quiescent. That is an accident of configuration, not an invariant,
+// and main_dash.cpp:4197-4204 explicitly anticipates extending io-decouple to
+// the coin_p2p arm. This test makes that day RED instead of silent.
+//
+// It deliberately does NOT change the serve path — the fix belongs in its own
+// PR (see the tracking issue referenced in the PR body).
+TEST(DashOracleShadowOwnership, RefreshExecutorStaysOffTheCoinP2PArm)
+{
+    const std::string src = strip_comments(read_main_dash());
+    ASSERT_EQ(count_of(src, "set_refresh_executor("), 1u)
+        << "expected exactly one set_refresh_executor() install site in main_dash.cpp";
+    const size_t at = src.find("set_refresh_executor(");
+    ASSERT_NE(at, std::string::npos);
+
+    // Nearest enclosing top-level (4-space indent) `if (` before the install.
+    const std::string head = src.substr(0, at);
+    const size_t if_at = head.rfind("\n    if (");
+    ASSERT_NE(if_at, std::string::npos)
+        << "set_refresh_executor() is no longer inside a top-level if — the arm "
+           "guard cannot be verified.";
+    const size_t eol = src.find('\n', if_at + 1);
+    const std::string cond = src.substr(if_at + 1, eol - if_at - 1);
+
+    EXPECT_NE(cond.find("!coin_p2p"), std::string::npos)
+        << "The rpc_pool refresh executor is being installed WITHOUT the "
+           "!coin_p2p guard. DASHWorkSource::resource_template_now() then reads "
+           "NodeCoinState (select_work -> raw pointers into m_mnstates/m_sml) on "
+           "a worker thread while the coin-P2P maintainer mutates it on the io "
+           "thread — the 2026-08-05 heap-corruption shape, on the SERVE path "
+           "this time. Resolve on the io thread and hand the worker a value "
+           "(the on_new_tip pattern) before relaxing this. Condition was: "
+        << cond;
+}


### PR DESCRIPTION
## What broke

Hotel primary `c2pool-dash` died **SIGABRT at 21:52:38 MSK on 2026-08-05**, 25 min after deploying `cdd908ce` (`0.2.4-366-gb0299a5b`):

```
malloc(): unaligned tcache chunk detected
double free or corruption (!prev)
```

systemd restarted it 16 s later. **No damage, no shares lost, no block affected.**

## Mechanism

`NodeCoinState` (`src/impl/dash/coin/node_coin_state.hpp`) has **zero mutexes** (`grep -c -i mutex` -> 0), and `select_work()` hands **raw pointers into its live containers** out to the caller:

```cpp
node_coin_state.hpp:1066   e.mnstates = &m_mnstates;   // MnStateMachine map
node_coin_state.hpp:1087   e.sml      = &m_sml;        // vendor::CSimplifiedMNList
```

`build_embedded_workdata()` then dereferences all four (`coin/work_source.hpp:214`, `:225`) for the **entire duration** of the template assembly — mempool selection plus both merkle roots over the full MN list.

`EmbeddedOracleShadow::process_tip()` called `select_work()` on its **own worker thread** (`embedded_oracle_shadow.hpp:664`, worker started `:628`, holding a `const NodeCoinState&` at `:947`) while the io thread mutated the very same containers through `CoinStateMaintainer`:

| writer | what it does |
|---|---|
| `coin_state_maintainer.hpp:489` | `apply_diff` -> `CSimplifiedMNList` vector realloc |
| `coin_state_maintainer.hpp:482` | `mnList.clear()` (null baseBlockHash resync) |
| `coin_state_maintainer.hpp:716` | `mnList.clear()` (`on_sml_reorg`) |
| `coin_state_maintainer.hpp:1092` | `apply_block` -> `MnStateMachine` RB-tree rebalance |

`MNState` (`mn_state_db.hpp:60`) owns two heap vectors, so the overlap corrupts **allocator metadata** rather than merely returning stale values — which is exactly why glibc reported tcache/double-free instead of a wrong template.

### Trigger chain (`main_dash.cpp:4165-4211`)

1. `coin_state.new_tip.happened()` wakes the shadow worker (subscription at `:2941-2943`).
2. ~17 us later the io thread runs `invalidate_template_cache()` -> `bump_work_generation()` -> `notify_all()`.
3. 26 sessions hit a null cache, and `resource_template_now()` runs **inline on the io thread** — the coin-P2P arm has no `refresh_executor_` (`main_dash.cpp:5055`, and `:4197-4204` says so explicitly).
4. => a **second concurrent `select_work()`** while the worker is still inside its own.

The worker exists **only** under `--embedded-oracle-shadow` (gate `main_dash.cpp:2854`, ctor `:2933`). `--embedded-shadow-compare` widens the window by adding a second worker contending for `NodeRPC::m_rpc_mutex` (`rpc.cpp:211`, 12 s socket deadline), stretching the oracle worker's residency inside `select_work()`.

### Confidence — stated plainly

**This was NOT reproduced under a sanitizer.** The diagnosis is convergent **static + timing** evidence: the unguarded-read shape is unambiguous in the source, the writer set is enumerated above, and the trigger interleaving matches the crash timestamp. It is not a captured ASAN trace, and this PR does not claim one.

## The fix

Resolve the embedded arm **inside `on_new_tip()`, on the tip/io thread that exclusively owns `NodeCoinState`**, and enqueue a by-value `TipJob` carrying a deep-copied `DashWorkData`. `process_tip()` and `worker_loop()` no longer name `coin_state_` at all.

This is not a new idea — `EmbeddedShadowCompare::on_serve` already does exactly this (`embedded_shadow_compare.hpp:381-387`: io thread resolves, queue carries a value, worker owns what it reads). This PR copies that established shape rather than inventing a third form.

`classify_decline()` re-runs `make_embedded_work_inputs()` over the **same** unguarded containers, so it is the same exposure and is now sampled on the tip thread too, beside the selection it explains.

### Why deep copy and not a mutex on `NodeCoinState`

I evaluated the lock and rejected it:

1. **The lock would sit on the hot serve path.** `resource_template_now()` reads `NodeCoinState` inline on the io thread for **26 sessions per work-generation bump**. Every one of those would now take a lock that the shadow worker also wants.
2. **The worst case is strictly worse than the bug.** `select_work()`'s fallback arm is a dashd `getblocktemplate` RPC behind `NodeRPC::m_rpc_mutex` (12 s socket deadline). A lock held across `select_work()` is a lock held across that RPC — converting a rare, restart-recoverable corruption into a **routine multi-second serve stall**. That is a bad trade on a mining node.
3. **A partial lock gives false confidence.** `NodeCoinState` exposes many accessors that return references into its internals (`mnstates()`, `sml()`, `mempool()`, `qmgr()`). Locking `select_work()` alone would leave those unprotected while making the class *look* thread-safe.
4. **The copy is not new work.** `WorkSelection` is already **all by value** — `DashWorkData` (`rpc_data.hpp:77`) contains no pointers. We are not adding a copy; we are moving *where* an existing one is produced. It happens once per tip (~2.6 min on mainnet) on a thread that already runs the identical build many times per tip.

If the shadow lane were on the money path this trade would deserve more argument. It is observe-only, so ownership is the right axis.

### Behaviour deltas — the complete list

This is a **lifetime/ownership** change. **No serve gate, arm decision, coinbase, payee, payout or consensus path is touched**, and the shadow stays OBSERVE-only. Two observable deltas, both in the shadow's own diagnostics:

1. **`select_work()`'s fallback arm here is now a no-op lambda.** It must be: the fallback is a dashd RPC and this now runs on the io thread. The shadow never read the fallback template anyway — `process_tip()` consumes `sel.work` **only** on the `is_embedded` branch; the fall-closed branch uses a literal `{}` (`note_fall_closed(next_height, classify(next_height, {}, ...))`). So this is byte-equivalent for every consumer, and one wasted per-tip `getblocktemplate` disappears with it.
2. **A dashd blip on the fall-closed path no longer drops the sample.** Previously a throwing `dashd_gbt_()` inside `select_work()` propagated out of `process_tip()` into `worker_loop()`'s catch, and the tip was silently lost (no `note_fall_closed`, no `remember_tip`). Now the fall-closed sample is always recorded. This makes the graduation ledger **more** conservative (fall-closed counts against the clean streak), never less.

## Other off-io-thread readers of `NodeCoinState` — full enumeration

I traced every reader rather than fixing one and leaving a sibling. Ground truth for "the io thread": `main_dash.cpp:5454` is the **single** `ioc.run()` call, no `std::thread` wraps it, and there is no `make_strand` anywhere in `src/impl/dash/` — so io thread == main thread, and every `subscribe` / timer / socket handler is that one thread.

**Off-io readers: exactly two.**

1. **`EmbeddedOracleShadow` worker** — fixed here.
2. **`DASHWorkSource::resource_template_now()`** on the `rpc_pool` worker (`main_dash.cpp:5056`): reads `coin_state_.populated()` (`work_source.cpp:335`, `:346`), `select_work()` (`:353`), `describe_decline()` (`:371`), `embedded_template_emit_ok()` (`:383`) — while `cached_work()` reads the same state on the io thread at `:625`. **Not fixed here** — it is on the serve path and wants its own PR and soak. It is safe *today* only by **arm exclusivity**: `set_refresh_executor` is installed under `!coin_p2p` (`main_dash.cpp:5055`) while every `NodeCoinState` mutator lives inside `if (coin_p2p)`. Filed as **#1134**, and this PR adds a tripwire test (below) that goes red the day that guard is relaxed.

**Cleared** (off-io but provably no `NodeCoinState` path): `EmbeddedShadowCompare` worker (`embedded_shadow_compare.hpp:364` — holds no coin-state reference at all); ZMQ subscriber (`zmq_tip_notify.cpp:68` — posts to `ioc`); DNS-seed detached threads (`coin_peer_manager.hpp:1137`, `:1162`); `NodeImpl::m_verify_pool` / `m_think_pool` (`node.hpp:165`/`:175` — `NodeImpl::select_work()` and `coin_state()` have **zero callers**, dead seam; `main_dash` uses a standalone `node_coin_state` at `:1690`); WebServer HTTP thread and its precompute/submit threads (dashboard seams go through `get_stratum_workers()` / `peek_template()`, both mutex-guarded snapshots at `work_source.cpp:292`/`:301`); `run_mine_block` (`main_dash.cpp:5589`, stack-local empty bundle); `dash::stratum::get_work()` (`get_work.hpp:61` — no production callers, tests only).

## Test — real red/green, both runs executed

`test/test_dash_oracle_shadow_ownership.cpp`, 8 tests.

- Rides the **existing allowlisted** `test_dash_node_coin_state` target (a new `add_executable` would be a NOT_BUILT sentinel, #143).
- **Not `#ifdef`-guarded** (#895). The `#error` on a missing compile definition is a hard build failure, not a skip — same as the house pattern.
- A true UAF race is nondeterministic and was not reproduced under a sanitizer, so this is a **source-structural ownership guard** — the deterministic red/green this invariant admits. House pattern: `src/impl/dgb/test/race913_lock_guard_test.cpp` (PR #1114).

It strips comments before asserting, so the doc blocks that *quote* the pre-fix expressions cannot satisfy or break a check.

### RED — same test binary, sources from current `master` (unfixed)

```
[==========] Running 8 tests from 1 test suite.
[ RUN      ] DashOracleShadowOwnership.ProcessTipNeverTouchesCoinState
test_dash_oracle_shadow_ownership.cpp:144: Failure
Expected equality of these values:
  body.find("coin_state_")
    Which is: 566
  std::string::npos
process_tip() runs on the WORKER thread and must never read NodeCoinState (no mutex;
select_work() hands out raw pointers into live containers -> the 2026-08-05 heap
corruption). Resolve on the tip thread in on_new_tip() and enqueue a deep copy instead.
[  FAILED  ] DashOracleShadowOwnership.ProcessTipNeverTouchesCoinState
[ RUN      ] DashOracleShadowOwnership.WorkerLoopNeverTouchesCoinState
[       OK ] DashOracleShadowOwnership.WorkerLoopNeverTouchesCoinState
[ RUN      ] DashOracleShadowOwnership.OnNewTipResolvesTheArmOnTheTipThread
test_dash_oracle_shadow_ownership.cpp:167: Failure
Expected: (body.find("coin_state_.select_work(")) != (std::string::npos)
on_new_tip() runs on the tip/io thread that owns NodeCoinState and is where the
embedded arm must be resolved.
[  FAILED  ] DashOracleShadowOwnership.OnNewTipResolvesTheArmOnTheTipThread
[ RUN      ] DashOracleShadowOwnership.SelectWorkCalledOnlyFromOnNewTip
test_dash_oracle_shadow_ownership.cpp:184: Failure
Value of: at > on_tip.begin && at < on_tip.end
  Actual: false
select_work() is called from OUTSIDE on_new_tip() — only the tip/io thread may read
NodeCoinState.
[  FAILED  ] DashOracleShadowOwnership.SelectWorkCalledOnlyFromOnNewTip
[ RUN      ] DashOracleShadowOwnership.ClassifyDeclineSampledOnTheTipThread
test_dash_oracle_shadow_ownership.cpp:200: Failure
Value of: at > on_tip.begin && at < on_tip.end
  Actual: false
classify_decline() re-reads m_mnstates/m_sml — it must be sampled on the tip thread
beside select_work(), never on the worker.
[  FAILED  ] DashOracleShadowOwnership.ClassifyDeclineSampledOnTheTipThread
[ RUN      ] DashOracleShadowOwnership.QueuedJobCarriesTheTemplateByValue
test_dash_oracle_shadow_ownership.cpp:212: Failure
TipJob (the by-value queue element) not found
[  FAILED  ] DashOracleShadowOwnership.QueuedJobCarriesTheTemplateByValue
[ RUN      ] DashOracleShadowOwnership.PendingSlotHoldsTheJobByValue
test_dash_oracle_shadow_ownership.cpp:235: Failure
Expected: (src.find("std::optional<TipJob>")) != (std::string::npos)
the coalescing queue slot must be std::optional<TipJob> (by value)
test_dash_oracle_shadow_ownership.cpp:237: Failure
Expected equality of these values:
  src.find("std::optional<std::pair<uint32_t, uint256>> pending_")
    Which is: 53334
  std::string::npos
the pre-fix queue element is back: it carried only (height, hash), which forced the
worker to re-read NodeCoinState for the template.
[  FAILED  ] DashOracleShadowOwnership.PendingSlotHoldsTheJobByValue
[ RUN      ] DashOracleShadowOwnership.RefreshExecutorStaysOffTheCoinP2PArm
[       OK ] DashOracleShadowOwnership.RefreshExecutorStaysOffTheCoinP2PArm

[  PASSED  ] 2 tests.
[  FAILED  ] 6 tests
```

### GREEN — same binary, this branch

```
[==========] Running 8 tests from 1 test suite.
[ RUN      ] DashOracleShadowOwnership.ProcessTipNeverTouchesCoinState
[       OK ] DashOracleShadowOwnership.ProcessTipNeverTouchesCoinState (0 ms)
[ RUN      ] DashOracleShadowOwnership.WorkerLoopNeverTouchesCoinState
[       OK ] DashOracleShadowOwnership.WorkerLoopNeverTouchesCoinState (0 ms)
[ RUN      ] DashOracleShadowOwnership.OnNewTipResolvesTheArmOnTheTipThread
[       OK ] DashOracleShadowOwnership.OnNewTipResolvesTheArmOnTheTipThread (0 ms)
[ RUN      ] DashOracleShadowOwnership.SelectWorkCalledOnlyFromOnNewTip
[       OK ] DashOracleShadowOwnership.SelectWorkCalledOnlyFromOnNewTip (0 ms)
[ RUN      ] DashOracleShadowOwnership.ClassifyDeclineSampledOnTheTipThread
[       OK ] DashOracleShadowOwnership.ClassifyDeclineSampledOnTheTipThread (0 ms)
[ RUN      ] DashOracleShadowOwnership.QueuedJobCarriesTheTemplateByValue
[       OK ] DashOracleShadowOwnership.QueuedJobCarriesTheTemplateByValue (0 ms)
[ RUN      ] DashOracleShadowOwnership.PendingSlotHoldsTheJobByValue
[       OK ] DashOracleShadowOwnership.PendingSlotHoldsTheJobByValue (0 ms)
[ RUN      ] DashOracleShadowOwnership.RefreshExecutorStaysOffTheCoinP2PArm
[       OK ] DashOracleShadowOwnership.RefreshExecutorStaysOffTheCoinP2PArm (6 ms)
[----------] 8 tests from DashOracleShadowOwnership (12 ms total)
[  PASSED  ] 8 tests.
```

The two that pass in both are correct: `WorkerLoopNeverTouchesCoinState` (pre-fix `worker_loop` reached the coin state *through* `process_tip`, so it never named it textually — the guard exists to stop a future direct read) and `RefreshExecutorStaysOffTheCoinP2PArm` (a forward-looking tripwire for #1134, not part of this fix).

Reproduce:

```
g++ -std=c++17 -DDASH_ORACLE_SHADOW_SRC='"<tree>/src/impl/dash/coin/embedded_oracle_shadow.hpp"' \
               -DDASH_MAIN_SRC='"<tree>/src/c2pool/main_dash.cpp"' \
    test/test_dash_oracle_shadow_ownership.cpp -lgtest -lgtest_main -pthread -o t && ./t
```
Point the two definitions at a `master` checkout for RED, at this branch for GREEN.

## Companion issues filed from the same audit

| # | severity | what |
|---|---|---|
| #1129 | security-relevant | `size_t` underflow in `ShareMessage::unpack()` on peer-supplied bytes, all 5 lanes. **Honest caveat in the issue:** I could not construct a live path today — the sole caller maintains `offset <= len` — so it is latent hardening, not a live remote crash. Filed with the one-token fix. |
| #1130 | severe | `handle_get_share` returns borrowed `ShareType` handles that outlive the tracker lock (`node.cpp:205-251`). **Measured NOT to be this crash** — zero `[Pool] Sending`, `[CLEAN]` and `handle_get_share` lines in the crash window. Recorded in the issue so nobody re-litigates it. |
| #1131 | latent double free | `verified.remove(bad)` omits `owns_data=false` (`share_tracker.hpp:889` + btc `:853` + ltc `:875`); every other call site in the tree passes it. Unreachable only because of a `continue` 20 lines earlier. |
| #1132 | leak | `add_verified_shares` leaks every skipped share — both `continue` paths bypass the only owner transfer (`node.cpp:130-136`). The `dup_count` branch is the *normal* path. |
| #1133 | shutdown only | `m_tracker_mutex` (`node.hpp:190`) destroyed before `m_think_pool` (`:175`) joins; `~Node` (`main_dash.cpp:733`) runs after `web_server`/`oracle_shadow` (`:826`/`:824`). |
| #1134 | latent, serve path | The sibling reader enumerated above. |

## Verification done

- `g++ -fsyntax-only` on a TU including the modified header — clean.
- Standalone gtest compile + both runs of the new guard, output above.
- Read-only inspection on the hotel nodes; **no restarts, no deploys, no config changes** were made anywhere.

## Deploy note

`do-not-merge` is on this PR pending operator review. The fix is header-only plus a test; the hotel deploy needs the **binary + lib bundle**, not a lone binary swap.
