### PR TITLE
dashboard: plot this node's LOCAL hashrate on the main chart (#919) — front-end only, backend has served the data all along [do-not-merge]

### DIFF
--- a/web-static/dashboard.html
+++ b/web-static/dashboard.html
@@ -1888,6 +1888,8 @@
                         <div class="legend-item" data-series="connected" onclick="toggleSeries('connected', this)" title="Click to toggle connected miners (all connections)"><span class="legend-color" style="background: #e91e63;"></span><span>Connected</span></div>
                         <div class="legend-item" data-series="lucktrend" onclick="toggleSeries('lucktrend', this)" title="Click to toggle luck trend line"><span class="legend-color" style="background: #ffc107;"></span><span>Luck</span></div>
                         <div class="legend-item disabled" data-series="netdiff" onclick="toggleSeries('netdiff', this)" title="Click to toggle network difficulty"><span class="legend-color" style="background: #8b5cf6;"></span><span>Net Diff</span></div>
+                        <div class="legend-item" data-series="local" onclick="toggleSeries('local', this)" title="Click to toggle THIS node's own hashrate (as distinct from the pool total)"><span class="legend-color" style="background: #00d4ff;"></span><span>Local</span></div>
+                        <div class="legend-item disabled" data-series="localdoa" onclick="toggleSeries('localdoa', this)" title="Click to toggle this node's dead-on-arrival hashrate"><span class="legend-color" style="background: #ff8800;"></span><span>Local DOA</span></div>
                     </div>
                     <div class="graph-container compact" id="hashrate-graph"></div>
                     <div class="graph-stats compact">
@@ -1919,6 +1921,8 @@
                     <div class="legend-item" data-series="miners" onclick="toggleSeries('miners', this)" title="Click to toggle unique miner addresses" style="font-size: 14px; padding: 6px 12px;"><span class="legend-color" style="background: #673ab7; width: 14px; height: 14px;"></span><span>Miners</span></div>
                     <div class="legend-item" data-series="lucktrend" onclick="toggleSeries('lucktrend', this)" title="Click to toggle luck trend line" style="font-size: 14px; padding: 6px 12px;"><span class="legend-color" style="background: #ffc107; width: 14px; height: 14px;"></span><span>Luck</span></div>
                     <div class="legend-item disabled" data-series="netdiff" onclick="toggleSeries('netdiff', this)" title="Click to toggle network difficulty" style="font-size: 14px; padding: 6px 12px;"><span class="legend-color" style="background: #8b5cf6; width: 14px; height: 14px;"></span><span>Net Diff</span></div>
+                    <div class="legend-item" data-series="local" onclick="toggleSeries('local', this)" title="Click to toggle THIS node's own hashrate (as distinct from the pool total)" style="font-size: 14px; padding: 6px 12px;"><span class="legend-color" style="background: #00d4ff; width: 14px; height: 14px;"></span><span>Local</span></div>
+                    <div class="legend-item disabled" data-series="localdoa" onclick="toggleSeries('localdoa', this)" title="Click to toggle this node's dead-on-arrival hashrate" style="font-size: 14px; padding: 6px 12px;"><span class="legend-color" style="background: #ff8800; width: 14px; height: 14px;"></span><span>Local DOA</span></div>
                 </div>
                 <button class="fullscreen-close" onclick="toggleGraphFullscreen()">✕ Close</button>
             </div>
@@ -6793,9 +6797,11 @@
         var graphUniqueMinersData = [];
         var graphBlocks = [];
         var graphNetworkDiffData = [];
+        var graphLocalData = [];
+        var graphLocalDeadData = [];
         var isFullscreen = false;
         var fullscreenChart = null;
-        var seriesVisibility = { good: true, doa: true, blocks: true, workers: false, miners: true, connected: true, lucktrend: true, netdiff: false };
+        var seriesVisibility = { good: true, doa: true, blocks: true, workers: false, miners: true, connected: true, lucktrend: true, netdiff: false, local: true, localdoa: false };
         
         function toggleSeries(seriesName, element) {
             seriesVisibility[seriesName] = !seriesVisibility[seriesName];
@@ -6809,8 +6815,8 @@
                 }
             });
             
-            // Map series names to indices (order: good, doa, blocks, workers, miners, connected, lucktrend, netdiff)
-            var seriesIndexMap = { good: 0, doa: 1, blocks: 2, workers: 3, miners: 4, connected: 5, lucktrend: 6, netdiff: 7 };
+            // Map series names to indices (order: good, doa, blocks, workers, miners, connected, lucktrend, netdiff, local, localdoa)
+            var seriesIndexMap = { good: 0, doa: 1, blocks: 2, workers: 3, miners: 4, connected: 5, lucktrend: 6, netdiff: 7, local: 8, localdoa: 9 };
             var seriesIndex = seriesIndexMap[seriesName];
             
             if (hashrateChart && hashrateChart.series[seriesIndex]) {
@@ -6838,7 +6844,7 @@
                 overlay.classList.add('active');
                 document.body.style.overflow = 'hidden';
                 // Render fullscreen chart
-                renderFullscreenGraph(graphData, graphMinerData, graphUniqueMinersData, graphConnectedMinersData, graphBlocks, graphNetworkDiffData);
+                renderFullscreenGraph(graphData, graphMinerData, graphUniqueMinersData, graphConnectedMinersData, graphBlocks, graphNetworkDiffData, graphLocalData, graphLocalDeadData);
                 // Update button states
                 updatePeriodButtons();
             } else {
@@ -6882,17 +6888,21 @@
             var connectedMinersData = null;
             var blocksData = [];
             var networkDiffData = [];
+            var localData = [];
+            var localDeadData = [];
             
             function tryRender() {
                 loadCount++;
-                if (loadCount === 6) {  // Loading 6 resources: hashrate, worker_count, unique_miner_count, connected_miners, blocks, network_difficulty
+                if (loadCount === 8) {  // hashrate, worker_count, unique_miner_count, connected_miners, blocks, network_difficulty, local_hash_rate, local_dead_hash_rate
                     graphData = hashrateData;
                     graphMinerData = minerCountData;
                     graphUniqueMinersData = uniqueMinerCountData;
                     graphConnectedMinersData = connectedMinersData;
                     graphBlocks = blocksData;
                     graphNetworkDiffData = networkDiffData;
-                    renderHashrateGraph(hashrateData, minerCountData, uniqueMinerCountData, connectedMinersData, blocksData, networkDiffData);
+                    graphLocalData = localData;
+                    graphLocalDeadData = localDeadData;
+                    renderHashrateGraph(hashrateData, minerCountData, uniqueMinerCountData, connectedMinersData, blocksData, networkDiffData, localData, localDeadData);
                 }
             }
             
@@ -6953,6 +6963,36 @@
             
             d3.json('../network_difficulty?period=' + currentGraphPeriod, function(data) {
                 networkDiffData = data || [];
+                tryRender();
+            });
+            
+            // This node's OWN hashrate, as distinct from the pool total.
+            // Both sources are already served by rest_web_graph_data() and are
+            // populated on every coin -- see web-static/graphs.html, which has
+            // plotted them on a separate legacy page since the p2pool port.
+            var localEndpoints = {
+                'hour': '../web/graph_data/local_hash_rate/last_hour',
+                'day': '../web/graph_data/local_hash_rate/last_day',
+                'week': '../web/graph_data/local_hash_rate/last_week',
+                'month': '../web/graph_data/local_hash_rate/last_month',
+                'year': '../web/graph_data/local_hash_rate/last_year'
+            };
+            
+            var localDeadEndpoints = {
+                'hour': '../web/graph_data/local_dead_hash_rate/last_hour',
+                'day': '../web/graph_data/local_dead_hash_rate/last_day',
+                'week': '../web/graph_data/local_dead_hash_rate/last_week',
+                'month': '../web/graph_data/local_dead_hash_rate/last_month',
+                'year': '../web/graph_data/local_dead_hash_rate/last_year'
+            };
+            
+            d3.json(localEndpoints[currentGraphPeriod], function(data) {
+                localData = data || [];
+                tryRender();
+            });
+            
+            d3.json(localDeadEndpoints[currentGraphPeriod], function(data) {
+                localDeadData = data || [];
                 tryRender();
             });
         }
@@ -7045,7 +7085,7 @@
             });
         }
 
-        function renderHashrateGraph(data, minerData, uniqueMinersData, connectedData, blocks, networkDiffSamples) {
+        function renderHashrateGraph(data, minerData, uniqueMinersData, connectedData, blocks, networkDiffSamples, localSamples, localDeadSamples) {
             var container = document.getElementById('hashrate-graph');
             blocks = blocks || [];
             minerData = minerData || [];
@@ -7122,6 +7162,26 @@
                 if (timestamp >= minTime && timestamp <= maxTime) {
                     var count = d[1] || 0;
                     connectedCount.push([timestamp, count]);
+                }
+            });
+            
+            // Parse this node's OWN hashrate. Scalar H/s, the same unit as the
+            // pool series, so it shares yAxis 0 -- a node contributing a small
+            // slice of the pool legitimately draws a low line. Both sources are
+            // already served by rest_web_graph_data() on every coin; only the
+            // main chart never asked for them (#919).
+            var localRate = [];
+            var localDeadRate = [];
+            (localSamples || []).forEach(function(d) {
+                var timestamp = d[0] * 1000;
+                if (timestamp >= minTime && timestamp <= maxTime) {
+                    localRate.push([timestamp, d[1] || 0]);
+                }
+            });
+            (localDeadSamples || []).forEach(function(d) {
+                var timestamp = d[0] * 1000;
+                if (timestamp >= minTime && timestamp <= maxTime) {
+                    localDeadRate.push([timestamp, d[1] || 0]);
                 }
             });
             
@@ -7706,16 +7766,36 @@
                     },
                     visible: seriesVisibility.netdiff,
                     yAxis: 0
+                }, {
+                    type: 'spline',
+                    name: 'Local',
+                    data: localRate,
+                    color: '#00d4ff',
+                    lineWidth: 2,
+                    dashStyle: 'ShortDot',
+                    marker: { enabled: false },
+                    visible: seriesVisibility.local,
+                    yAxis: 0
+                }, {
+                    type: 'spline',
+                    name: 'Local DOA',
+                    data: localDeadRate,
+                    color: '#ff8800',
+                    lineWidth: 1,
+                    dashStyle: 'ShortDot',
+                    marker: { enabled: false },
+                    visible: seriesVisibility.localdoa,
+                    yAxis: 0
                 }]
             });
             
             // Also update fullscreen if open
             if (isFullscreen) {
-                renderFullscreenGraph(data, minerData, uniqueMinersData, connectedData, blocks, networkDiffSamples);
+                renderFullscreenGraph(data, minerData, uniqueMinersData, connectedData, blocks, networkDiffSamples, localSamples, localDeadSamples);
             }
         }
         
-        function renderFullscreenGraph(data, minerData, uniqueMinersData, connectedData, blocks, networkDiffSamples) {
+        function renderFullscreenGraph(data, minerData, uniqueMinersData, connectedData, blocks, networkDiffSamples, localSamples, localDeadSamples) {
             var container = document.getElementById('fullscreen-graph');
             blocks = blocks || graphBlocks || [];
             minerData = minerData || [];
@@ -7781,6 +7861,26 @@
                 var timestamp = d[0] * 1000;
                 var count = d[1] || 0;
                 connectedCount.push([timestamp, count]);
+            });
+            
+            // Parse this node's OWN hashrate. Scalar H/s, the same unit as the
+            // pool series, so it shares yAxis 0 -- a node contributing a small
+            // slice of the pool legitimately draws a low line. Both sources are
+            // already served by rest_web_graph_data() on every coin; only the
+            // main chart never asked for them (#919).
+            var localRate = [];
+            var localDeadRate = [];
+            (localSamples || []).forEach(function(d) {
+                var timestamp = d[0] * 1000;
+                if (timestamp >= minTime && timestamp <= maxTime) {
+                    localRate.push([timestamp, d[1] || 0]);
+                }
+            });
+            (localDeadSamples || []).forEach(function(d) {
+                var timestamp = d[0] * 1000;
+                if (timestamp >= minTime && timestamp <= maxTime) {
+                    localDeadRate.push([timestamp, d[1] || 0]);
+                }
             });
             
             // Process blocks - filter to exact time range for proper data alignment
@@ -8328,6 +8428,26 @@
                         symbol: 'circle'
                     },
                     visible: seriesVisibility.netdiff,
+                    yAxis: 0
+                }, {
+                    type: 'spline',
+                    name: 'Local',
+                    data: localRate,
+                    color: '#00d4ff',
+                    lineWidth: 2,
+                    dashStyle: 'ShortDot',
+                    marker: { enabled: false },
+                    visible: seriesVisibility.local,
+                    yAxis: 0
+                }, {
+                    type: 'spline',
+                    name: 'Local DOA',
+                    data: localDeadRate,
+                    color: '#ff8800',
+                    lineWidth: 1,
+                    dashStyle: 'ShortDot',
+                    marker: { enabled: false },
+                    visible: seriesVisibility.localdoa,
                     yAxis: 0
                 }]
             });


### PR DESCRIPTION
Closes #919.

## What was missing

The main dashboard hashrate chart has only ever fetched `pool_rates`. A node operator could not see **their own** contribution anywhere on the dashboard — on any coin.

## What it did NOT need

**No backend change. No new data collection. No retention work.**

`rest_web_graph_data()` has served `local_hash_rate` and `local_dead_hash_rate` all along (`src/core/web_server.cpp:6845-6858`), alongside 19 other sources. Verified live, read-only, on both deployed nodes today:

| endpoint | DASH hotel `0.2.4-366-gb0299a5b` | LTC contabo `0.2.4-235-g52e8e051b` |
|---|---|---|
| `local_hash_rate/last_hour` | 200, 2468 B | 200, 2435 B |
| `local_hash_rate/last_day` | 200, 59401 B | 200, 57499 B |
| `local_dead_hash_rate/last_hour` | 200, 1621 B | 200, 1594 B |
| `miner_hash_rates/last_day` | 200, 115480 B | 200, 111904 B |

Real values, correct p2pool 4-tuple shape, on both lanes, for every one of the five views.

`web-static/graphs.html` has in fact been plotting these on a separate legacy d3 page since the p2pool port — `graphs.html:76` *"Local rate"*, `:515-516`, `:539` — and that page is reachable and working on both nodes right now (`/graphs.html`, 200). The feature was never absent from the codebase; it was absent from the **main dashboard**, which is where the operator looks. The Highcharts chart simply never asked for the data.

## What this adds

Two series on both the compact and fullscreen charts, fetched through the same `endpoints[currentGraphPeriod]` pattern as every other overlay, so they follow the existing 1H/1D/1W/1M/1Y selector with no extra plumbing:

- **Local** — this node's own hashrate. Visible by default.
- **Local DOA** — this node's dead-on-arrival hashrate. Off by default (usually zero; clutter otherwise).

Both are H/s, the same unit as the pool series, so they share `yAxis: 0`. A node contributing a small slice of the pool draws a low line — that is the truth, not a scaling bug. On the DASH hotel local ≈ 46.4 TH/s against a 52 TH/s pool, so the two lines sit together; on contabo LTC local is 4.2 MH/s against 340 GH/s and the line correctly hugs the floor.

Contrast **Net Diff**, which is a *different* unit (difficulty, ~1e8) and is nonetheless on `yAxis: 0` today next to hashrate (~5e13) — that one is a genuine scaling bug and is tracked separately, not touched here.

## Why it is safe

- Series appended at indices **8 / 9**, so no existing `seriesIndexMap` entry moves.
- The shared-tooltip formatter needs no change: its `else` branch already formats unrecognised series with `format_hashrate()` (`dashboard.html:7593-7596`, `:8244-8247`), which is exactly right for both new series.
- `loadCount` gate raised 6 → 8 to match the two added fetches.
- Both new parsers are `(localSamples || []).forEach` and filter to the chart's existing `minTime`/`maxTime`, so a lane that somehow serves nothing renders an empty series rather than throwing.
- `node --check` clean on the extracted inline script.

## Coin-generic

There is one shared `web-static/dashboard.html` and one shared route table (`src/core/http_session.cpp`), so this lights up on every lane at once — DASH, LTC, BTC, DGB, BCH — with no per-coin wiring. That is why it is deliberately not a DASH-only change.

## Not tested in a browser

Static verification only: endpoint shape confirmed against both live nodes, JS syntax checked, series indices and selector wiring reviewed by hand. `do-not-merge` until someone loads it against a running node and confirms the two lines draw.

## Retention model, for the record

The operator asked for p2pool classic's bucketing scheme. c2pool does **not** use it, and that is worth knowing before anyone extends this.

p2pool classic (`p2pool-dash/p2pool/web.py:2309-2314`, `p2pool/util/graph.py:9-63`) keeps a fixed-size ring per view — `DataViewDescription(bin_count, total_width)`:

| view | bins | bin width |
|---|---|---|
| `last_hour` | 150 | 24 s |
| `last_day` | 300 | 288 s |
| `last_week` | 300 | 2016 s |
| `last_month` | 300 | 8640 s |
| `last_year` | 300 | 105408 s |

Every datum is added to all five views at once; `_shift_bins_so_t_is_not_past_end()` rotates the ring. Storage is bounded at 1350 bins per stream forever, and resolution degrades gracefully with age.

c2pool instead filters one flat `m_stat_log` by time window and emits a **hardcoded `bin_width = 300.0`** regardless of view (`web_server.cpp:6812-6830`). Two consequences worth a separate issue rather than scope creep here:

1. The `bin_width` in the payload is not the real spacing — live samples are ~60 s apart while the tuple claims 300 s.
2. There is no downsampling, so `last_week` / `last_month` / `last_year` return every retained sample rather than a fixed number of bins. Whether those views are usable at all depends on the `m_stat_log` cap, not on the requested resolution.

This PR does not touch any of that — it consumes the endpoints exactly as they already behave.
