### PR TITLE
dash(dashboard): bind the sharechain WINDOW / DELTA / SHARE-DETAIL seams — the explorer grid and the individual share page were served by core's empty stub [do-not-merge]

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -109,6 +109,7 @@
 #include <core/uint256.hpp>                    // uint160 payout pubkey hash
 #include <core/target_utils.hpp>              // chain::target_to_difficulty (dashboard net-diff)
 #include <impl/dash/dashboard_found_block.hpp> // any-participant /recent_blocks feed (peer-found blocks)
+#include <impl/dash/dashboard_views.hpp>       // sharechain window / delta / share-detail read-models
 
 #include <core/stratum_server.hpp>             // core::StratumServer — miner-facing accept-loop (run-path caller)
 #include <impl/dash/stratum/work_source.hpp>   // dash::stratum::DASHWorkSource — concrete core::stratum::IWorkSource
@@ -1211,6 +1212,70 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 }
                 return out;
             });
+
+            // ── Sharechain WINDOW / DELTA / SHARE DETAIL (dashboard read-models) ─
+            //
+            // These three seams had exactly ONE caller each repo-wide —
+            // main_ltc.cpp:3730 / :3946 / :4077 — so on the DASH lane core fell
+            // through to its fallback STUBS (web_server.cpp:2907 / :3313 / :6768).
+            // A stub answers HTTP 200 with a well-formed EMPTY document, which is
+            // why this failed silently: no 404, no log line, and the front-end's
+            // `if (!data.shares) return` guard (dashboard.html:5011) sails through
+            // a truthy `[]`. Measured on the live DASH node before this change:
+            // /sharechain/window = 55 bytes, /sharechain/delta = 23 bytes,
+            // /web/share/<hash> = {"error":"share not found"} for a hash that IS
+            // in the tracker. The data was never missing — only the binding.
+            //
+            // The builders live in impl/dash/dashboard_views.hpp (ports of the LTC
+            // lambdas above) so they are KAT-able against a real ShareTracker; the
+            // work here is purely assembling the ViewContext and holding the
+            // tracker read guard.
+            {
+                auto view_ctx = [mi, owner_addr = node_owner_address]() {
+                    dash::dashboard::ViewContext ctx;
+                    ctx.testnet     = dash::SharechainConfig::is_testnet;
+                    ctx.window_size = dash::SharechainConfig::chain_length();
+                    // DASH has no node-level mining address (every miner
+                    // authorizes with its own address over stratum), so the
+                    // closest true "this node" identity is the configured
+                    // node-owner address. Left EMPTY when unset rather than
+                    // guessed — an empty my_address makes the dashboard render
+                    // "None (node not mining)", which is the honest answer.
+                    ctx.my_address  = owner_addr;
+                    if (mi) {
+                        ctx.fee_hash160 = mi->get_node_fee_hash160();
+                        for (const auto& fb : mi->get_found_blocks())
+                            if (!fb.share_hash.empty())
+                                ctx.found_block_short_hashes.push_back(
+                                    fb.share_hash.substr(0, 16));
+                    }
+                    return ctx;
+                };
+
+                mi->set_sharechain_window_fn(
+                    [node_ptr, view_ctx]() -> nlohmann::json {
+                        auto guard = node_ptr->read_tracker();
+                        if (!guard) return nlohmann::json::object();
+                        return dash::dashboard::build_window(*guard, view_ctx());
+                    });
+                // The grid IS the sharechain — refresh it on tip change, not on
+                // the 1 Hz periodic timer (main_ltc.cpp:3908).
+                mi->mark_last_cache_tip_driven();
+
+                mi->set_sharechain_delta_fn(
+                    [node_ptr, view_ctx](const std::string& since_hash) -> nlohmann::json {
+                        auto guard = node_ptr->read_tracker();
+                        if (!guard) return nlohmann::json::object();
+                        return dash::dashboard::build_delta(*guard, since_hash, view_ctx());
+                    });
+
+                mi->set_share_lookup_fn(
+                    [node_ptr, view_ctx](const std::string& hash_hex) -> nlohmann::json {
+                        auto guard = node_ptr->read_tracker();
+                        if (!guard) return nlohmann::json{{"error", "tracker busy"}};
+                        return dash::dashboard::build_share_detail(*guard, hash_hex, view_ctx());
+                    });
+            }
 
             // ── Signed transitional-message feed (DISPLAY + VERIFY) ────────────
             // Reuses the LTC crossing's exact signed-message component: read the

--- a/src/impl/dash/dashboard_views.hpp
+++ b/src/impl/dash/dashboard_views.hpp
@@ -1,0 +1,412 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// DASH dashboard read-models: the sharechain WINDOW, the incremental DELTA and
+// the individual SHARE DETAIL document.
+//
+// These are the DASH ports of the three builders main_ltc.cpp wires inline:
+//   * window       -> main_ltc.cpp:3730 (MiningInterface::set_sharechain_window_fn)
+//   * delta        -> main_ltc.cpp:3946 (MiningInterface::set_sharechain_delta_fn)
+//   * share detail -> main_ltc.cpp:4077 (MiningInterface::set_share_lookup_fn)
+//
+// The three seams were never bound on the DASH lane, so core answered from the
+// FALLBACK STUBS (web_server.cpp:2907 window, :3313 delta, :6768 share) — a
+// well-formed HTTP 200 carrying `{"shares":[],"total":0,...}` / `{}`. That is
+// the whole defect: no 404, no log line, no error anywhere; the dashboard's
+// `if (!data.shares) return` guard (dashboard.html:5011) sails straight through
+// a truthy empty array and renders nothing. Every consumer of those three
+// endpoints — the defragmenter grid, Best Share / This Node / heads / tails
+// cells, share.html, /pplns/current's per-miner enrichment — is dark as a
+// result.
+//
+// Why a header instead of three more lambdas in main_dash.cpp: the builders are
+// pure functions of (tracker, view context) with no io_context, no socket and
+// no MiningInterface, which makes them directly KAT-able against a real
+// dash::ShareTracker. main_dash.cpp keeps only the binding.
+//
+// LOCKING CONTRACT: every entry point here takes an ALREADY-LOCKED tracker
+// (dash::Node::read_tracker() guard held by the caller) and only READS it.
+// Nothing in this header acquires a lock, mutates chain state, or touches
+// consensus.
+
+#include "share_chain.hpp"     // dash::ShareChain / ShareIndex / DashShare
+#include "share_check.hpp"     // dash::get_share_script, pubkey_hash_to_script2
+#include "config_pool.hpp"     // dash::SharechainConfig
+
+#include <core/address_utils.hpp>
+#include <core/target_utils.hpp>
+#include <core/uint256.hpp>
+
+#include <btclibs/util/strencodings.h>
+
+#include <nlohmann/json.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace dash {
+namespace dashboard {
+
+// ── View context ────────────────────────────────────────────────────────────
+// Everything the builders need that does NOT live on the tracker. Passed in by
+// the main_dash binding so this header never reaches into MiningInterface.
+struct ViewContext
+{
+    bool        testnet{false};
+    uint32_t    window_size{0};        ///< SharechainConfig::chain_length()
+    std::string my_address;            ///< local payout address ("mine" marking)
+    std::string fee_hash160;           ///< node-fee hash160 (fee-share marking)
+    /// 16-hex short hashes of shares known to have solved a DASH block, from
+    /// the found-block store (survives restart; the index flag does not).
+    std::vector<std::string> found_block_short_hashes;
+    /// Hard cap on the delta walk, matching main_ltc.cpp:4029.
+    int delta_max_shares{200};
+};
+
+// ── Address rendering ───────────────────────────────────────────────────────
+// DASH base58 version bytes (params.hpp: 76/'X' mainnet, 140/'y' testnet;
+// 16/'7' and 19 for P2SH). Identical to the resolver rest_current_payouts()
+// already uses for Blockchain::DASH (web_server.cpp:2384), so an address the
+// window renders and the same address in /current_payouts are byte-equal.
+inline std::string script_to_dash_address(const std::vector<unsigned char>& script,
+                                          bool testnet)
+{
+    return core::script_to_address(script, "",
+                                   testnet ? 140 : 76,
+                                   testnet ?  19 : 16);
+}
+
+// ── Coinbase tag extraction ─────────────────────────────────────────────────
+// Longest printable-ASCII run in the share's coinbase scriptSig, shown as the
+// miner's self-identification in the grid tooltip. Same rule as
+// main_ltc.cpp:3800 — >= 10 chars, must contain a letter, truncated at 48 —
+// so the two coins' grids read identically.
+inline std::string coinbase_tag(const std::vector<unsigned char>& data)
+{
+    std::string best_run;
+    std::string cur_run;
+    for (auto c : data) {
+        if (c >= 32 && c <= 126) {
+            cur_run += static_cast<char>(c);
+        } else {
+            if (cur_run.size() > best_run.size()) best_run = cur_run;
+            cur_run.clear();
+        }
+    }
+    if (cur_run.size() > best_run.size()) best_run = cur_run;
+
+    bool has_letter = false;
+    for (auto c : best_run) {
+        if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')) { has_letter = true; break; }
+    }
+    if (best_run.size() < 10 || !has_letter) return {};
+    if (best_run.size() > 48) best_run.resize(48);
+    return best_run;
+}
+
+// ── Tallest head ────────────────────────────────────────────────────────────
+// The grid follows the TALLEST RAW head rather than the verified best so it
+// keeps moving during sync (main_ltc.cpp:3740). This is display-only and never
+// feeds mint/payout election — those go through mint_runloop's
+// select_best_share(), which is work-weighted over the VERIFIED chain.
+template <typename ChainT>
+inline uint256 tallest_head(ChainT& chain, int32_t& height_out)
+{
+    uint256 best;
+    int32_t best_height = -1;
+    for (const auto& [head_hash, tail_hash] : chain.get_heads()) {
+        (void)tail_hash;
+        const int32_t h = chain.get_height(head_hash);
+        if (h > best_height) { best = head_hash; best_height = h; }
+    }
+    height_out = best_height;
+    return best;
+}
+
+// ── One grid cell ───────────────────────────────────────────────────────────
+// Key names are the SHARED wire contract the dashboard front-end already
+// speaks (dashboard.html defrag.getColor / showTooltip / makeShareCell):
+//   h  short hash (16 hex)     H  full hash          p  position in the walk
+//   v  verified (0/1)          blk block solution    t  share timestamp
+//   V  share wire version      s  stale_info         b  share nBits
+//   a  absheight               dv desired_version    m  miner address
+//   cb coinbase tag            fee node-fee share
+template <typename ChainT>
+inline nlohmann::json share_cell(ChainT& chain, ChainT& verified,
+                                 const uint256& hash, int pos,
+                                 const ViewContext& ctx)
+{
+    nlohmann::json s;
+    const std::string full = hash.GetHex();
+    s["h"] = full.substr(0, 16);
+    s["H"] = full;
+    s["p"] = pos;
+    s["v"] = verified.contains(hash) ? 1 : 0;
+
+    auto* idx = chain.get_index(hash);
+    if (idx && idx->is_block_solution)
+        s["blk"] = 1;
+
+    chain.get_share(hash).invoke([&](auto* obj) {
+        s["t"]  = obj->m_timestamp;
+        s["V"]  = std::remove_pointer_t<decltype(obj)>::version;
+        s["s"]  = static_cast<int>(obj->m_stale_info);
+        s["b"]  = obj->m_bits;
+        s["a"]  = obj->m_absheight;
+        s["dv"] = obj->m_desired_version;
+
+        const auto script = dash::get_share_script(obj);
+        const std::string addr = script_to_dash_address(script, ctx.testnet);
+        s["m"] = addr.empty() ? HexStr(script) : addr;
+
+        const std::string tag = coinbase_tag(obj->m_coinbase.m_data);
+        if (!tag.empty()) s["cb"] = tag;
+
+        // DASH sharechain payouts are P2PKH-keyed, so the fee test is a direct
+        // hash160 compare — no script-shape dispatch (LTC needs one because it
+        // carries P2PKH / P2WPKH / P2SH payout scripts; DASH is always-P2PKH,
+        // share_check.hpp pubkey_hash_to_script2).
+        if (!ctx.fee_hash160.empty() && obj->m_pubkey_hash.GetHex() == ctx.fee_hash160)
+            s["fee"] = 1;
+    });
+
+    return s;
+}
+
+// ── Heads array ─────────────────────────────────────────────────────────────
+template <typename ChainT>
+inline nlohmann::json heads_array(ChainT& chain)
+{
+    nlohmann::json arr = nlohmann::json::array();
+    for (const auto& [head_hash, tail_hash] : chain.get_heads()) {
+        (void)tail_hash;
+        arr.push_back(head_hash.GetHex().substr(0, 16));
+    }
+    return arr;
+}
+
+// ── Window ──────────────────────────────────────────────────────────────────
+// Full grid payload: up to chain_length() shares walked back from the tallest
+// head. Port of main_ltc.cpp:3730 minus the merged-mining (DOGE) legs, which
+// have no DASH equivalent — DASH is standalone X11 with no AuxPoW child, so
+// `doge_blocks` is intentionally ABSENT rather than an empty array pretending
+// a merged chain exists.
+template <typename TrackerT>
+inline nlohmann::json build_window(TrackerT& tracker, const ViewContext& ctx)
+{
+    auto& chain    = tracker.chain;
+    auto& verified = tracker.verified;
+
+    nlohmann::json result;
+
+    int32_t best_height = -1;
+    const uint256 best = tallest_head(chain, best_height);
+
+    result["best_hash"]    = best.IsNull() ? "" : best.GetHex();
+    result["chain_length"] = static_cast<int>(chain.size());
+    result["window_size"]  = static_cast<int>(ctx.window_size);
+    result["my_address"]   = ctx.my_address;
+    result["fee_hash160"]  = ctx.fee_hash160;
+
+    nlohmann::json shares_arr = nlohmann::json::array();
+    if (!best.IsNull()) {
+        const int height = chain.get_height(best);
+        const int walk   = std::min(height, static_cast<int>(ctx.window_size));
+        if (walk > 0) {
+            try {
+                int pos = 0;
+                for (auto [hash, data] : chain.get_chain(best, walk)) {
+                    (void)data;
+                    shares_arr.push_back(share_cell(chain, verified, hash, pos++, ctx));
+                }
+            } catch (...) {
+                // Partial results on chain inconsistency — same tolerance as
+                // main_ltc.cpp:3848. A truncated grid is honest; a thrown
+                // exception here would surface as the empty stub again.
+            }
+        }
+    }
+
+    nlohmann::json blocks_arr = nlohmann::json::array();
+    for (const auto& sh : ctx.found_block_short_hashes)
+        blocks_arr.push_back(sh);
+
+    result["shares"] = std::move(shares_arr);
+    result["heads"]  = heads_array(chain);
+    result["blocks"] = std::move(blocks_arr);
+    result["total"]  = static_cast<int>(chain.size());
+    return result;
+}
+
+// ── Delta ───────────────────────────────────────────────────────────────────
+// Only the shares NEWER than `since_hash` (which the client already holds),
+// capped at ctx.delta_max_shares. Port of main_ltc.cpp:3946.
+template <typename TrackerT>
+inline nlohmann::json build_delta(TrackerT& tracker, const std::string& since_hash,
+                                  const ViewContext& ctx)
+{
+    auto& chain    = tracker.chain;
+    auto& verified = tracker.verified;
+
+    nlohmann::json result;
+
+    int32_t best_height = -1;
+    const uint256 best = tallest_head(chain, best_height);
+
+    nlohmann::json shares_arr = nlohmann::json::array();
+    int count = 0;
+
+    if (!best.IsNull()) {
+        const int walk = std::min(static_cast<int>(chain.get_height(best)),
+                                  static_cast<int>(ctx.window_size));
+        try {
+            for (auto [hash, data] : chain.get_chain(best, walk)) {
+                (void)data;
+                const std::string full  = hash.GetHex();
+                const std::string short_h = full.substr(0, 16);
+                if (short_h == since_hash || full == since_hash)
+                    break;   // reached what the client already has
+                shares_arr.push_back(share_cell(chain, verified, hash, count, ctx));
+                if (++count >= ctx.delta_max_shares) break;
+            }
+        } catch (...) {
+            // partial delta — the client reconciles on the next full window
+        }
+    }
+
+    nlohmann::json blocks_arr = nlohmann::json::array();
+    for (const auto& sh : ctx.found_block_short_hashes)
+        blocks_arr.push_back(sh);
+
+    result["shares"] = std::move(shares_arr);
+    result["count"]  = count;
+    result["tip"]    = best.IsNull() ? "" : best.GetHex().substr(0, 16);
+    result["heads"]  = heads_array(chain);
+    result["blocks"] = std::move(blocks_arr);
+    return result;
+}
+
+// ── Individual share detail ─────────────────────────────────────────────────
+// The document behind /web/share/<hash> and web-static/share.html. Port of
+// main_ltc.cpp:4077; the merged-mining (DOGE block) legs are dropped for the
+// same reason as in build_window, and a DASH-specific `dash_metadata` block is
+// added for the masternode/DIP4 fields the DASH share carries and LTC has no
+// analogue for (share.hpp: m_payment_amount, m_packed_payments,
+// m_coinbase_payload).
+//
+// Returns {"error": ...} on a miss so core's rest_web_share() keeps its
+// existing not-found contract (web_server.cpp:6771 treats an "error" key as
+// "not answered" and falls back).
+template <typename TrackerT>
+inline nlohmann::json build_share_detail(TrackerT& tracker, const std::string& hash_hex,
+                                         const ViewContext& ctx)
+{
+    auto& chain    = tracker.chain;
+    auto& verified = tracker.verified;
+
+    uint256 hash;
+    hash.SetHex(hash_hex);
+    if (hash.IsNull() || !chain.contains(hash))
+        return nlohmann::json{{"error", "share not found"}};
+
+    nlohmann::json result;
+
+    auto* idx = chain.get_index(hash);
+    const bool is_block = idx && idx->is_block_solution;
+    result["is_block_solution"] = is_block;
+
+    chain.get_share(hash).invoke([&](auto* obj) {
+        using ShareT = std::remove_pointer_t<decltype(obj)>;
+
+        result["parent"]     = obj->m_prev_hash.GetHex();
+        result["far_parent"] = obj->m_far_share_hash.GetHex();
+        result["version"]    = ShareT::version;
+        result["type_name"]  = "V" + std::to_string(ShareT::version);
+
+        nlohmann::json local_j;
+        local_j["verified"]                 = verified.contains(hash);
+        local_j["time_first_seen"]          = idx ? idx->time_seen : 0;
+        local_j["peer_first_received_from"] = obj->peer_addr.to_string();
+        result["local"] = local_j;
+
+        const auto script = dash::get_share_script(obj);
+        const std::string addr = script_to_dash_address(script, ctx.testnet);
+
+        const double target_diff =
+            chain::target_to_difficulty(chain::bits_to_target(obj->m_bits));
+        const double max_target_diff =
+            chain::target_to_difficulty(chain::bits_to_target(obj->m_max_bits));
+
+        nlohmann::json sd;
+        sd["timestamp"]       = obj->m_timestamp;
+        sd["target"]          = obj->m_bits;
+        sd["max_target"]      = obj->m_max_bits;
+        sd["payout_address"]  = addr.empty() ? HexStr(script) : addr;
+        sd["pubkey_hash"]     = obj->m_pubkey_hash.GetHex();
+        // DASH encodes donation in 1/65536 units (share.hpp m_donation, and the
+        // 65535 divisor in pplns.hpp) — NOT LTC's percent-of-65536 reading.
+        sd["donation"]        = static_cast<double>(obj->m_donation) / 65536.0;
+        sd["stale_info"]      = static_cast<int>(obj->m_stale_info);
+        sd["nonce"]           = obj->m_nonce;
+        sd["desired_version"] = obj->m_desired_version;
+        sd["absheight"]       = obj->m_absheight;
+        sd["abswork"]         = obj->m_abswork.GetHex();
+        sd["difficulty"]      = target_diff;
+        sd["min_difficulty"]  = max_target_diff;
+        result["share_data"]  = sd;
+
+        auto& hdr = obj->m_min_header;
+        nlohmann::json hdr_j;
+        hdr_j["version"]        = hdr.m_version;
+        hdr_j["previous_block"] = hdr.m_previous_block.GetHex();
+        hdr_j["merkle_root"]    = "";
+        hdr_j["timestamp"]      = hdr.m_timestamp;
+        hdr_j["target"]         = hdr.m_bits;
+        hdr_j["nonce"]          = hdr.m_nonce;
+
+        nlohmann::json gentx_j;
+        gentx_j["hash"]              = "";
+        gentx_j["coinbase"]          = HexStr(obj->m_coinbase.m_data);
+        gentx_j["value"]             = static_cast<double>(obj->m_subsidy) / 1e8;
+        gentx_j["last_txout_nonce"]  = obj->m_last_txout_nonce;
+
+        nlohmann::json block_j;
+        block_j["hash"]                      = hash.GetHex();
+        block_j["header"]                    = hdr_j;
+        block_j["gentx"]                     = gentx_j;
+        block_j["other_transaction_hashes"]  = nlohmann::json::array();
+        result["block"] = block_j;
+
+        // No reverse (parent -> children) index on the shared ShareChain, so
+        // children stay empty rather than being faked — same position
+        // main_ltc.cpp:4193 takes.
+        result["children"] = nlohmann::json::array();
+
+        // ── DASH-specific: masternode / DIP4 coinbase payload ───────────────
+        nlohmann::json dash_j;
+        dash_j["payment_amount"] = static_cast<double>(obj->m_payment_amount) / 1e8;
+        nlohmann::json payments = nlohmann::json::array();
+        for (const auto& p : obj->m_packed_payments) {
+            nlohmann::json pj;
+            pj["amount"] = static_cast<double>(p.m_amount) / 1e8;
+            const auto pm_script = dash::decode_payee_script(
+                p.m_payee, ctx.testnet ? 140 : 76, ctx.testnet ? 19 : 16);
+            const std::string pm_addr = script_to_dash_address(pm_script, ctx.testnet);
+            // m_payee is already the oracle's text form (base58 address, or
+            // "!<hex script>") — surface it verbatim when it does not decode
+            // to a renderable address rather than inventing one.
+            pj["payee"] = pm_addr.empty() ? p.m_payee : pm_addr;
+            payments.push_back(std::move(pj));
+        }
+        dash_j["packed_payments"]        = std::move(payments);
+        dash_j["coinbase_payload_bytes"] = obj->m_coinbase_payload.m_data.size();
+        result["dash_metadata"] = std::move(dash_j);
+    });
+
+    return result;
+}
+
+} // namespace dashboard
+} // namespace dash

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -334,7 +334,13 @@ if (BUILD_TESTING AND GTest_FOUND)
     # standalone target would need a build.yml --target edit and trip CI's
     # NOT_BUILT sentinel until it had one. Needs exactly this link set (core
     # MiningInterface; the resolver is header-only).
-    add_executable(test_dash_node test_dash_node.cpp test_dash_dashboard_found_block.cpp test_dash_addrme.cpp test_dash_block_confirm_lane.cpp)
+    # test_dash_dashboard_views.cpp: the sharechain WINDOW / DELTA / SHARE-DETAIL
+    # read-model KATs (dashboard_views.hpp). FOLDED in as another TU for the same
+    # reason as the TUs above — a standalone target would need a build.yml
+    # --target edit and would trip CI's NOT_BUILT sentinel until it had one
+    # (#143/#883/#893). Needs exactly this link set: a real dash::NodeImpl +
+    # ShareTracker, and core's address_utils for the DASH base58 rendering.
+    add_executable(test_dash_node test_dash_node.cpp test_dash_dashboard_found_block.cpp test_dash_addrme.cpp test_dash_block_confirm_lane.cpp test_dash_dashboard_views.cpp)
     target_link_libraries(test_dash_node PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core

--- a/test/test_dash_dashboard_views.cpp
+++ b/test/test_dash_dashboard_views.cpp
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// ---------------------------------------------------------------------------
+// test_dash_dashboard_views — BINDING KATs for the DASH sharechain WINDOW /
+// DELTA / SHARE-DETAIL read-models.
+//
+// THE DEFECT. MiningInterface::set_sharechain_window_fn / _delta_fn /
+// set_share_lookup_fn had exactly ONE caller each in the whole repository —
+// main_ltc.cpp:3730 / :3946 / :4077. Nothing on the DASH lane bound them, so
+// core answered from its FALLBACK STUBS (web_server.cpp:2907 / :3313 / :6768).
+// A stub is not a 404: it is HTTP 200 carrying a well-formed EMPTY document
+// ({"shares":[],"total":0,...}), which is why three dashboard widgets went dark
+// with no error anywhere and the front-end guard `if (!data.shares) return`
+// (dashboard.html:5011) sailed straight through a truthy `[]`.
+//
+// WHY THESE KATs ARE NOT VACUOUS. Each positive KAT is paired with the
+// NEGATIVE CONTROL that reproduces the shipped defect: the same assertion run
+// against core's stub shape, which passes the front-end's null check and fails
+// its content check. A KAT that only asserted "the builder returns an object"
+// would have been green on the broken build too.
+//
+// Display-only surface: nothing here reaches mint, payout, target or block
+// submission. The builders take an ALREADY-READ-LOCKED tracker and only read.
+// ---------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/dashboard_views.hpp>
+#include <impl/dash/node.hpp>
+#include <impl/dash/share.hpp>
+#include <impl/dash/share_check.hpp>
+
+#include <core/address_utils.hpp>
+#include <core/uint256.hpp>
+
+#include <nlohmann/json.hpp>
+
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr uint32_t V_BLOCK_BITS = 0x1d00ffff;
+constexpr uint32_t V_SHARE_BITS = 0x1e0ffff0;
+constexpr uint32_t V_BASE_TIME  = 1753000000;
+constexpr uint64_t V_SUBSIDY    = 155000000;   // duffs
+
+uint256 view_hash(unsigned int n)
+{
+    static const char* digits = "0123456789abcdef";
+    std::string s = "7d";
+    s += digits[(n >> 12) & 0xf];
+    s += digits[(n >>  8) & 0xf];
+    s += digits[(n >>  4) & 0xf];
+    s += digits[ n        & 0xf];
+    s += std::string(64 - s.size(), '0');
+    uint256 h;
+    h.SetHex(s);
+    return h;
+}
+
+uint160 view_pkh(unsigned char b)
+{
+    static const char* digits = "0123456789abcdef";
+    std::string s;
+    s += digits[b >> 4];
+    s += digits[b & 0x0f];
+    s += std::string(40 - s.size(), '3');
+    uint160 h;
+    h.SetHex(s);
+    return h;
+}
+
+// A share carrying every field the grid cell reads, so a builder that silently
+// dropped one would show up as a missing key rather than as a plausible zero.
+dash::DashShare* make_view_share(unsigned int n, const uint256& prev, unsigned char pkh_byte)
+{
+    auto* s = new dash::DashShare();
+    s->m_hash      = view_hash(n);
+    s->m_prev_hash = prev;
+    s->m_min_header.m_bits      = V_BLOCK_BITS;
+    s->m_min_header.m_timestamp = V_BASE_TIME + n;
+    s->m_bits            = V_SHARE_BITS;
+    s->m_max_bits        = V_SHARE_BITS;
+    s->m_timestamp       = V_BASE_TIME + n;
+    s->m_absheight       = 2500000 + n;
+    s->m_desired_version = 36;
+    s->m_pubkey_hash     = view_pkh(pkh_byte);
+    s->m_subsidy         = V_SUBSIDY;
+    const std::string tag = "/P2Pool-DASH/c2pool/";
+    s->m_coinbase.m_data.assign(tag.begin(), tag.end());
+    return s;
+}
+
+// Real tracker (dash::NodeImpl's ctor is what wires verified.set_parent_chain),
+// loaded with a linear chain of `count` shares. Returned tip is the head.
+struct ChainHarness
+{
+    dash::NodeImpl node;
+    uint256        tip;
+    unsigned int   count{0};
+
+    explicit ChainHarness(unsigned int n)
+    {
+        uint256 prev = uint256::ZERO;
+        for (unsigned int i = 0; i < n; ++i) {
+            // Two distinct miners so the address column is demonstrably
+            // per-share and not a single constant.
+            auto* s = make_view_share(i, prev, static_cast<unsigned char>(0xa0 + (i % 2)));
+            node.tracker().chain.add(s);
+            prev = s->m_hash;
+            tip  = s->m_hash;
+        }
+        count = n;
+    }
+
+    dash::dashboard::ViewContext ctx() const
+    {
+        dash::dashboard::ViewContext c;
+        c.testnet     = false;
+        c.window_size = 4320;
+        return c;
+    }
+};
+
+// The exact shape core serves when the seam is UNBOUND (web_server.cpp:2907).
+nlohmann::json core_window_stub()
+{
+    nlohmann::json r;
+    r["shares"]       = nlohmann::json::array();
+    r["total"]        = 0;
+    r["best_hash"]    = "";
+    r["chain_length"] = 0;
+    return r;
+}
+
+// The front-end's own admission test, transcribed from dashboard.html:5011
+// (`if (!data || !data.shares) return;`) plus the render precondition that
+// actually puts cells on screen.
+bool front_end_would_render(const nlohmann::json& w)
+{
+    if (w.is_null() || !w.contains("shares")) return false;   // the null guard
+    if (!w["shares"].is_array())              return false;
+    return !w["shares"].empty();                              // the render precondition
+}
+
+} // namespace
+
+// ── KAT 1: the window carries the chain ─────────────────────────────────────
+TEST(DashDashboardViews, WindowCarriesEveryShareAndTheGridContract)
+{
+    ChainHarness h(12);
+    auto w = dash::dashboard::build_window(h.node.tracker(), h.ctx());
+
+    ASSERT_TRUE(w.contains("shares"));
+    ASSERT_EQ(w["shares"].size(), 12u);
+    EXPECT_EQ(w["total"].get<int>(), 12);
+    EXPECT_EQ(w["chain_length"].get<int>(), 12);
+    EXPECT_EQ(w["window_size"].get<int>(), 4320);
+    EXPECT_EQ(w["best_hash"].get<std::string>(), h.tip.GetHex());
+
+    // Walk order is tip-first (position 0 == tallest head), matching the LTC
+    // grid the front-end already renders.
+    const auto& first = w["shares"][0];
+    EXPECT_EQ(first["H"].get<std::string>(), h.tip.GetHex());
+    EXPECT_EQ(first["h"].get<std::string>(), h.tip.GetHex().substr(0, 16));
+    EXPECT_EQ(first["p"].get<int>(), 0);
+
+    // Every key the front-end reads must be present — a missing one renders as
+    // a blank/NaN cell rather than an error.
+    for (const char* k : {"h", "H", "p", "v", "t", "V", "s", "b", "a", "dv", "m"})
+        EXPECT_TRUE(first.contains(k)) << "missing grid key: " << k;
+
+    EXPECT_EQ(first["V"].get<int>(), 16);            // live DASH wire version
+    EXPECT_EQ(first["dv"].get<int>(), 36);           // the v16->v36 vote
+    EXPECT_EQ(first["b"].get<uint32_t>(), V_SHARE_BITS);
+    EXPECT_EQ(first["v"].get<int>(), 0);             // nothing verified in this fixture
+
+    // Miner column is a real DASH mainnet address ('X'), not a Bitcoin '1'.
+    const std::string addr = first["m"].get<std::string>();
+    ASSERT_FALSE(addr.empty());
+    EXPECT_EQ(addr[0], 'X');
+    EXPECT_EQ(addr, core::script_to_address(
+                        dash::pubkey_hash_to_script2(view_pkh(0xa1)), "", 76, 16));
+
+    // Coinbase tag survives the printable-run extraction.
+    ASSERT_TRUE(first.contains("cb"));
+    EXPECT_EQ(first["cb"].get<std::string>(), "/P2Pool-DASH/c2pool/");
+
+    // The two miners are actually distinguished.
+    EXPECT_NE(w["shares"][0]["m"].get<std::string>(),
+              w["shares"][1]["m"].get<std::string>());
+
+    // Heads are reported for fork marking.
+    ASSERT_TRUE(w.contains("heads"));
+    EXPECT_EQ(w["heads"].size(), 1u);
+
+    // POSITIVE: this payload renders. NEGATIVE CONTROL: the stub the DASH lane
+    // shipped passes the front-end null guard and still draws nothing — the
+    // exact silent failure being fixed.
+    EXPECT_TRUE(front_end_would_render(w));
+    EXPECT_FALSE(front_end_would_render(core_window_stub()));
+    EXPECT_TRUE(core_window_stub().contains("shares"));   // why it was silent
+}
+
+// ── KAT 2: the window is bounded by window_size ──────────────────────────────
+TEST(DashDashboardViews, WindowIsClampedToTheConfiguredWindowSize)
+{
+    ChainHarness h(30);
+    auto ctx = h.ctx();
+    ctx.window_size = 10;
+    auto w = dash::dashboard::build_window(h.node.tracker(), ctx);
+
+    EXPECT_EQ(w["shares"].size(), 10u);
+    EXPECT_EQ(w["total"].get<int>(), 30);          // total is the whole store
+    EXPECT_EQ(w["window_size"].get<int>(), 10);
+}
+
+// ── KAT 3: the empty chain degrades honestly ────────────────────────────────
+TEST(DashDashboardViews, EmptyChainYieldsAnHonestEmptyWindow)
+{
+    ChainHarness h(0);
+    auto w = dash::dashboard::build_window(h.node.tracker(), h.ctx());
+
+    EXPECT_TRUE(w["shares"].is_array());
+    EXPECT_TRUE(w["shares"].empty());
+    EXPECT_EQ(w["best_hash"].get<std::string>(), "");
+    EXPECT_FALSE(front_end_would_render(w));   // nothing to draw, and it says so
+}
+
+// ── KAT 4: the delta returns only what the client is missing ────────────────
+TEST(DashDashboardViews, DeltaStopsAtTheHashTheClientAlreadyHas)
+{
+    ChainHarness h(12);
+    auto ctx = h.ctx();
+
+    // Client already at the tip -> nothing new.
+    auto d0 = dash::dashboard::build_delta(h.node.tracker(),
+                                           h.tip.GetHex().substr(0, 16), ctx);
+    EXPECT_EQ(d0["count"].get<int>(), 0);
+    EXPECT_TRUE(d0["shares"].empty());
+    EXPECT_EQ(d0["tip"].get<std::string>(), h.tip.GetHex().substr(0, 16));
+
+    // Client three shares behind -> exactly three.
+    const std::string behind = view_hash(8).GetHex().substr(0, 16);   // 11,10,9 are newer
+    auto d3 = dash::dashboard::build_delta(h.node.tracker(), behind, ctx);
+    EXPECT_EQ(d3["count"].get<int>(), 3);
+    ASSERT_EQ(d3["shares"].size(), 3u);
+    EXPECT_EQ(d3["shares"][0]["H"].get<std::string>(), view_hash(11).GetHex());
+    EXPECT_EQ(d3["shares"][2]["H"].get<std::string>(), view_hash(9).GetHex());
+
+    // Cold client (no `since`) -> the full walk, capped.
+    auto dall = dash::dashboard::build_delta(h.node.tracker(), "", ctx);
+    EXPECT_EQ(dall["count"].get<int>(), 12);
+}
+
+TEST(DashDashboardViews, DeltaHonoursItsSafetyCap)
+{
+    ChainHarness h(40);
+    auto ctx = h.ctx();
+    ctx.delta_max_shares = 5;
+    auto d = dash::dashboard::build_delta(h.node.tracker(), "", ctx);
+    EXPECT_EQ(d["count"].get<int>(), 5);
+    EXPECT_EQ(d["shares"].size(), 5u);
+}
+
+// ── KAT 5: the individual share page ────────────────────────────────────────
+TEST(DashDashboardViews, ShareDetailAnswersForAShareInTheTracker)
+{
+    ChainHarness h(6);
+    auto s = dash::dashboard::build_share_detail(h.node.tracker(), h.tip.GetHex(), h.ctx());
+
+    // NEGATIVE CONTROL first: this is the document the unwired lane served for
+    // a hash that IS in the tracker (web_server.cpp:6773).
+    ASSERT_FALSE(s.contains("error"))
+        << "share lookup still falling through to the not-found stub";
+
+    EXPECT_EQ(s["version"].get<int>(), 16);
+    EXPECT_EQ(s["type_name"].get<std::string>(), "V16");
+    EXPECT_EQ(s["parent"].get<std::string>(), view_hash(4).GetHex());
+    EXPECT_FALSE(s["is_block_solution"].get<bool>());
+
+    ASSERT_TRUE(s.contains("share_data"));
+    const auto& sd = s["share_data"];
+    // share.html reads exactly these (share.html:545 payout_address, and the
+    // kv() rows below it) — a missing key renders as a blank field.
+    for (const char* k : {"timestamp", "target", "max_target", "payout_address",
+                          "stale_info", "nonce", "desired_version", "absheight",
+                          "difficulty"})
+        EXPECT_TRUE(sd.contains(k)) << "missing share_data key: " << k;
+
+    EXPECT_EQ(sd["payout_address"].get<std::string>()[0], 'X');
+    EXPECT_EQ(sd["absheight"].get<uint32_t>(), 2500005u);
+    EXPECT_GT(sd["difficulty"].get<double>(), 0.0);
+
+    ASSERT_TRUE(s.contains("block"));
+    EXPECT_EQ(s["block"]["hash"].get<std::string>(), h.tip.GetHex());
+    EXPECT_TRUE(s["block"].contains("header"));
+    EXPECT_TRUE(s["block"].contains("gentx"));
+
+    ASSERT_TRUE(s.contains("local"));
+    EXPECT_FALSE(s["local"]["verified"].get<bool>());
+
+    // DASH-specific block, present even when the fixture carries no payments —
+    // absent would be indistinguishable from "builder forgot it".
+    ASSERT_TRUE(s.contains("dash_metadata"));
+    EXPECT_TRUE(s["dash_metadata"]["packed_payments"].is_array());
+}
+
+TEST(DashDashboardViews, ShareDetailReportsAnHonestMiss)
+{
+    ChainHarness h(6);
+    auto s = dash::dashboard::build_share_detail(
+        h.node.tracker(), view_hash(999).GetHex(), h.ctx());
+    ASSERT_TRUE(s.contains("error"));
+    EXPECT_EQ(s["error"].get<std::string>(), "share not found");
+}
+
+// ── KAT 6: the node-fee marking ─────────────────────────────────────────────
+TEST(DashDashboardViews, FeeSharesAreMarkedByHash160)
+{
+    ChainHarness h(4);
+    auto ctx = h.ctx();
+    ctx.fee_hash160 = view_pkh(0xa1).GetHex();   // the odd-index miner
+
+    auto w = dash::dashboard::build_window(h.node.tracker(), ctx);
+    ASSERT_EQ(w["shares"].size(), 4u);
+    // Shares 3 and 1 carry pkh 0xa1; 2 and 0 carry 0xa0.
+    EXPECT_TRUE(w["shares"][0].contains("fee"));    // share 3
+    EXPECT_FALSE(w["shares"][1].contains("fee"));   // share 2
+    EXPECT_EQ(w["fee_hash160"].get<std::string>(), ctx.fee_hash160);
+}


### PR DESCRIPTION
dash(dashboard): bind the sharechain WINDOW / DELTA / SHARE-DETAIL seams — the explorer grid and the individual share page were served by core's empty stub

Three MiningInterface seams had exactly ONE caller each repo-wide, all of them
in main_ltc.cpp:

  set_sharechain_window_fn  -> main_ltc.cpp:3730
  set_sharechain_delta_fn   -> main_ltc.cpp:3946
  set_share_lookup_fn       -> main_ltc.cpp:4077

Nothing on the DASH lane bound them, so core answered from its FALLBACK STUBS
(web_server.cpp:2907 window, :3313 delta, :6768 share). A stub is not a 404 —
it is HTTP 200 carrying a well-formed EMPTY document. That is why this failed
in total silence: no error status, no log line, and the dashboard's own guard
`if (!data || !data.shares) return` (dashboard.html:5011) sails straight
through a truthy `[]` and renders nothing.

Measured on the live DASH node (127.0.0.1:8081) before this change:

  /sharechain/window        55 bytes  {"best_hash":"","chain_length":0,"shares":[],"total":0}
  /sharechain/delta         23 bytes  {"count":0,"shares":[]}
  /web/share/<tip hash>               {"error":"share not found"}

...while /sharechain/stats on the SAME node reported chain_height 9078,
chain_tip_hash 00000000000010e8..., 4320-share window. The data was never
missing. Only the binding was.

For comparison the LTC node serves 16 MB from /sharechain/window and 359 KB
from /sharechain/delta off the same shared front-end and the same shared route
table (src/core/http_session.cpp). Nothing is missing at markup or routing
level for DASH either.

WHAT THIS ADDS

  src/impl/dash/dashboard_views.hpp — build_window / build_delta /
  build_share_detail, ports of the three LTC lambdas onto the DASH tracker.
  They are pure functions of (already-read-locked tracker, ViewContext): no
  io_context, no socket, no MiningInterface, so they are directly KAT-able
  against a real dash::ShareTracker. main_dash.cpp keeps only the binding.

  Divergences from the LTC source, each forced by DASH and none of them a stub:
    * merged-mining (DOGE) legs dropped. DASH is standalone X11 with no AuxPoW
      child, so `doge_blocks` is ABSENT rather than an empty array pretending a
      merged chain exists.
    * miner script is dash::get_share_script (always-P2PKH,
      pubkey_hash_to_script2) instead of LTC's P2PKH/P2WPKH/P2SH dispatch, and
      the node-fee test is therefore a direct hash160 compare.
    * addresses render through the DASH base58 version bytes (76/'X' mainnet,
      140/'y' testnet) — the same resolver rest_current_payouts() already uses
      for Blockchain::DASH, so an address in the grid and the same address in
      /current_payouts are byte-equal.
    * share detail carries a DASH-specific `dash_metadata` block
      (payment_amount, packed_payments with decoded payees, coinbase_payload
      size) for the masternode/DIP4 fields LTC has no analogue for.

  my_address: DASH has no node-level mining address — every miner authorizes
  with its own address over stratum — so the closest true "this node" identity
  is --node-owner-address, and it is left EMPTY when unset rather than guessed.
  An empty my_address makes the dashboard render "None (node not mining)",
  which is the honest answer.

WHAT LIGHTS UP

  /sharechain/window   the defragmenter grid (dashboard.html defrag.load),
                       Best Share / This Node / verified heads / tails cells
                       (loadShareLinks), per-miner hashrate derivation, and the
                       enrichment table behind /pplns/current's miners[]
  /sharechain/delta    the RealTime incremental refresh path (_rtFetchDelta)
  /web/share/<hash>    web-static/share.html — the individual share page, which
                       until now could not be reached with a real document for
                       ANY DASH share

TESTS

  test/test_dash_dashboard_views.cpp — 8 KATs, FOLDED into the already
  allowlisted test_dash_node target (no new add_executable, so no NOT_BUILT
  sentinel, #143/#883/#893) and not #ifdef-guarded (#895).

  Every positive KAT is paired with the negative control that reproduces the
  shipped defect: core's stub shape passes the front-end's null guard
  (`contains("shares")` is true) and fails its render precondition (the array
  is empty). A KAT that only asserted "the builder returns an object" would
  have been green on the broken build too.

  Coverage: full grid contract (every key the front-end reads), tip-first walk
  order, window_size clamping, honest empty chain, delta stop-at-since-hash /
  cold client / safety cap, share detail present-and-absent, DASH 'X' address
  rendering pinned against core::script_to_address(script, "", 76, 16), and
  node-fee marking by hash160.

  8/8 pass. c2pool-dash builds clean.

Display-only surface: nothing here reaches mint, payout, target or block
submission. Every entry point takes an already-read-locked tracker and only
reads it. Per-coin isolation: src/impl/dash/ + the DASH main only.

