### PR TITLE
dash(dashboard): bind the PPLNS payout views — /current_payouts returned {} on a node with a full window, and an individual share had no payout breakdown [do-not-merge]

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -110,6 +110,7 @@
 #include <core/target_utils.hpp>              // chain::target_to_difficulty (dashboard net-diff)
 #include <impl/dash/dashboard_found_block.hpp> // any-participant /recent_blocks feed (peer-found blocks)
 #include <impl/dash/dashboard_views.hpp>       // sharechain window / delta / share-detail read-models
+#include <impl/dash/dashboard_pplns.hpp>       // PPLNS payout read-model (pool-wide + per-share)
 
 #include <core/stratum_server.hpp>             // core::StratumServer — miner-facing accept-loop (run-path caller)
 #include <impl/dash/stratum/work_source.hpp>   // dash::stratum::DASHWorkSource — concrete core::stratum::IWorkSource
@@ -825,6 +826,14 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // processed (an empty pow_func fails every share_init_verify).
     const core::CoinParams mint_params = dash::make_coin_params(testnet);
     p2p_node.tracker().m_coin_params = mint_params;
+    // Live-template source for the dashboard PPLNS view. The WebServer seams
+    // are bound (and web_server->start() runs) well BEFORE DASHWorkSource
+    // exists, so the payout callbacks cannot capture the work source directly
+    // and a bare std::function assigned later would race the already-serving
+    // IO thread. TemplateSource publishes the peek under its own mutex and
+    // copies it out before calling. Until it is bound the PPLNS view answers
+    // an empty document — "no template yet", never a fabricated subsidy.
+    auto dash_tmpl = std::make_shared<dash::dashboard::TemplateSource>();
     // LevelDB sharechain store under the SAME per-net subdir as the rest of
     // the node state (bucket-1 isolation), loading any persisted shares.
     p2p_node.init_storage(net_subdir);
@@ -1317,11 +1326,50 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     return ctx;
                 };
 
-                mi->set_sharechain_window_fn(
-                    [node_ptr, view_ctx]() -> nlohmann::json {
+                // The pool-wide PPLNS split, shared by /current_payouts, the main
+                // dashboard treemap (via /current_merged_payouts) and the
+                // window's own `pplns_current` fallback. best_share_hash() is
+                // read BEFORE the guard: it takes its own try-shared-lock, and
+                // re-entering the same shared_mutex from a thread that already
+                // holds it is exactly the kind of nested acquire that stops
+                // being harmless the moment a writer queues up.
+                auto current_pplns =
+                    [node_ptr, dash_tmpl, mint_params]() -> nlohmann::json {
+                        const uint256 best = node_ptr->best_share_hash();
+                        if (best.IsNull()) return nlohmann::json::object();
                         auto guard = node_ptr->read_tracker();
                         if (!guard) return nlohmann::json::object();
-                        return dash::dashboard::build_window(*guard, view_ctx());
+                        auto v = dash::dashboard::pplns_payouts_current(
+                            guard->chain, mint_params, best, *dash_tmpl,
+                            dash::SharechainConfig::is_testnet);
+                        return v.ok ? v.payouts : nlohmann::json::object();
+                    };
+
+                // #939's direct-source seam. Its only callers repo-wide were in
+                // a unit test (core/test/web_server_current_payouts_test.cpp) —
+                // the seam shipped green and inert, which is why
+                // rest_current_payouts() kept returning {} on a DASH node with
+                // a full window and live balances (web_server.cpp:2375 takes
+                // this branch only when a coin actually wires it). This is that
+                // real, non-test caller.
+                //
+                // It also lights /current_merged_payouts, because
+                // compute_current_merged_payouts() (web_server.cpp:5964) starts
+                // from rest_current_payouts() — and /current_merged_payouts is
+                // what the MAIN dashboard PPLNS treemap fetches
+                // (dashboard.html loadMainPPLNS). /pplns/current's miners[]
+                // array comes off the same cache.
+                mi->set_current_payouts_fn(current_pplns);
+
+                mi->set_sharechain_window_fn(
+                    [node_ptr, view_ctx, current_pplns]() -> nlohmann::json {
+                        auto cur = current_pplns();          // takes + releases the guard
+                        auto guard = node_ptr->read_tracker();
+                        if (!guard) return nlohmann::json::object();
+                        auto w = dash::dashboard::build_window(*guard, view_ctx());
+                        if (cur.is_object() && !cur.empty())
+                            w["pplns_current"] = std::move(cur);
+                        return w;
                     });
                 // The grid IS the sharechain — refresh it on tip change, not on
                 // the 1 Hz periodic timer (main_ltc.cpp:3908).
@@ -1334,11 +1382,41 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                         return dash::dashboard::build_delta(*guard, since_hash, view_ctx());
                     });
 
+                // Individual share page + THE PPLNS VIEW FOR THAT SHARE.
+                //
+                // LTC serves per-share PPLNS out of a precomputed cache
+                // (start_pplns_precompute -> m_pplns_per_tip, read back by the
+                // window as `pplns[<short hash>]`). That machinery is gated on
+                // refresh_work() having populated m_cached_template
+                // (web_server.cpp:2947), and refresh_work() never runs on the
+                // DASH lane (:3902) — porting it would have wired green and
+                // stayed empty, which is the exact failure this changeset
+                // exists to remove. DASH computes the share's own window on
+                // demand instead: ONE tracker walk per page view, inside the
+                // guard already held, attached to the share document itself.
                 mi->set_share_lookup_fn(
-                    [node_ptr, view_ctx](const std::string& hash_hex) -> nlohmann::json {
+                    [node_ptr, view_ctx, mint_params](const std::string& hash_hex) -> nlohmann::json {
                         auto guard = node_ptr->read_tracker();
                         if (!guard) return nlohmann::json{{"error", "tracker busy"}};
-                        return dash::dashboard::build_share_detail(*guard, hash_hex, view_ctx());
+                        auto doc = dash::dashboard::build_share_detail(
+                            *guard, hash_hex, view_ctx());
+                        if (doc.contains("error")) return doc;
+
+                        uint256 h;
+                        h.SetHex(hash_hex);
+                        auto v = dash::dashboard::pplns_payouts_for_share(
+                            guard->chain, mint_params, h,
+                            dash::SharechainConfig::is_testnet);
+                        if (v.ok) {
+                            doc["pplns"] = v.payouts;
+                            doc["pplns_meta"] = {
+                                {"subsidy",        static_cast<double>(v.subsidy) / 1e8},
+                                {"payments_total", static_cast<double>(v.payments_total) / 1e8},
+                                {"worker_payout",  static_cast<double>(v.worker_payout) / 1e8},
+                                {"recipients",     v.recipients},
+                            };
+                        }
+                        return doc;
                     });
             }
 
@@ -2194,6 +2272,11 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // to real dashd (both merkle roots reproduced from the mnlistdiff wire); the
     // SML+quorum freshness + superblock viability gates keep it fail-safe.
     work_source->set_embedded_mainnet(embedded_mainnet);
+    // Publish the live template to the dashboard PPLNS view (declared far above,
+    // where the WebServer seams are bound). peek_template() is the SAME
+    // non-fetching peek the block-value card already uses — it never triggers a
+    // GBT fetch and never touches the coinbase the miners hash.
+    dash_tmpl->bind([wsrc = work_source.get()]() { return wsrc->peek_template(); });
     // Reward-safety backstop: when a dashd fallback is ARMED, cross-check the
     // embedded creditPool against dashd's GBT before serving (catches any seed
     // pool bug the daemonless self-checks miss).

--- a/src/impl/dash/dashboard_pplns.hpp
+++ b/src/impl/dash/dashboard_pplns.hpp
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// DASH dashboard PPLNS read-model.
+//
+// Answers two questions with ONE code path:
+//   1. "who does the pool owe right now?"  -> /current_payouts,
+//      /current_merged_payouts (the main dashboard treemap) and the miners[]
+//      array of /pplns/current.
+//   2. "what did THIS share's window pay?" -> the per-share PPLNS treemap on
+//      web-static/share.html (which reads window["pplns"][<short hash>], with
+//      window["pplns_current"] as its fallback).
+//
+// Why DASH could not simply reuse the LTC route
+// ---------------------------------------------
+// LTC lights both from MiningInterface's own PPLNS cache:
+//   set_pplns_fn  -> refresh_work() (web_server.cpp:1360) stores
+//   m_cached_pplns_outputs, which rest_current_payouts() reads (:2401); and
+//   start_pplns_precompute() (:2921) walks the window in a background thread,
+//   calling m_pplns_fn once per share to fill m_pplns_per_tip.
+// BOTH depend on refresh_work() having run: the precompute loop refuses to
+// start until m_cached_template carries "bits" + "coinbasevalue" (:2947-2963).
+// refresh_work() NEVER runs on the DASH lane — MiningInterface's own stratum
+// acceptor is switched off (main_dash.cpp set_stratum_port(0)) and DASHWorkSource
+// owns the coinbase; web_server.cpp:3902 states the invariant outright. So the
+// LTC path would have wired green and stayed inert. That is the same class of
+// bug this whole change is fixing, so it is not repeated here.
+//
+// Instead the payouts are computed DIRECTLY from the two SSOTs the DASH
+// coinbase itself uses, which means the dashboard shows the same split a block
+// found now would actually pay:
+//   * dash::mint::pplns_weights_for  (mint_runloop.hpp:504) — the ORACLE window
+//     walk (start at the grandparent, max(0, min(height, RCL)-1) shares).
+//   * dash::coinbase::compute_dash_payouts (coinbase_builder.hpp:83) — the
+//     payout allocator, including the pre-v36 49/50 split and the donation
+//     remainder.
+// No payout arithmetic is re-implemented here.
+//
+// Finder fee: compute_dash_payouts credits the pre-v36 2% block-finder fee to
+// the caller-supplied pubkey hash. A pool-wide "current payouts" view has no
+// finder (the next block's winner is unknown), so it is computed with a ZERO
+// pubkey hash and that one output is then dropped. This matches LTC exactly —
+// share_tracker.hpp:2058 documents get_v35_expected_payouts as "amounts WITHOUT
+// finder fee — caller adds subsidy/200", and main_ltc.cpp's pplns_fn returns it
+// unmodified for the pre-v36 arm. The per-share view has a real finder (the
+// share's own miner) and passes it.
+
+#include "share_chain.hpp"
+#include "share_check.hpp"       // DONATION_SCRIPT, decode_payee_script
+#include "coinbase_builder.hpp"  // dash::coinbase::compute_dash_payouts
+#include "mint_runloop.hpp"      // dash::mint::pplns_weights_for
+#include "dashboard_views.hpp"   // script_to_dash_address
+#include "coin/rpc_data.hpp"     // dash::coin::PackedPayment
+
+#include <core/coin_params.hpp>
+#include <core/uint256.hpp>
+
+#include <nlohmann/json.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace dash {
+namespace dashboard {
+
+// ── Late-bound live template source ─────────────────────────────────────────
+// The dashboard seams are bound while the WebServer is stood up
+// (main_dash.cpp), which is BEFORE DASHWorkSource exists and before
+// web_server->start() — so the window/payout callbacks cannot capture the work
+// source directly, and a bare std::function assigned afterwards would be a data
+// race against the already-serving IO thread. This holder publishes the peek
+// under a mutex and COPIES IT OUT before calling, so the (tracker-locking)
+// callee never runs with this mutex held.
+//
+// Unbound is a first-class state: it means "no template yet", and every caller
+// answers an empty document rather than inventing a subsidy.
+class TemplateSource
+{
+public:
+    using PeekFn = std::function<std::shared_ptr<const dash::coin::DashWorkData>()>;
+
+    void bind(PeekFn fn)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_peek = std::move(fn);
+    }
+
+    std::shared_ptr<const dash::coin::DashWorkData> peek() const
+    {
+        PeekFn fn;
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            fn = m_peek;
+        }
+        if (!fn) return nullptr;
+        return fn();
+    }
+
+private:
+    mutable std::mutex m_mutex;
+    PeekFn             m_peek;
+};
+
+// ── Result ──────────────────────────────────────────────────────────────────
+struct PplnsView
+{
+    bool     ok{false};
+    /// {address: amount in DASH} — PPLNS workers plus the donation output.
+    /// Masternode / superblock / platform payments are EXCLUDED: they are
+    /// consensus-mandated block outputs, not pool payouts, and folding them in
+    /// would overstate what the pool distributes.
+    nlohmann::json payouts = nlohmann::json::object();
+    uint64_t subsidy{0};          ///< full block reward the split was taken from
+    uint64_t payments_total{0};   ///< masternode + superblock + platform, satoshi
+    uint64_t worker_payout{0};    ///< subsidy - payments_total
+    int      recipients{0};
+};
+
+// ── Core builder ────────────────────────────────────────────────────────────
+// `prev_share_hash` is the share the window is anchored on — i.e. the PARENT of
+// the (hypothetical or real) share being paid, exactly as
+// DASHWorkSource::build_connection_coinbase passes it.
+//
+// `block_bits` is the COIN block nBits for the difficulty epoch the payout
+// belongs to; the caller takes it from the same place the mint does.
+template <typename ChainT>
+inline PplnsView pplns_payouts_at(
+    ChainT& chain,
+    const core::CoinParams& params,
+    const uint256& prev_share_hash,
+    uint32_t block_bits,
+    uint64_t subsidy,
+    const std::vector<dash::coin::PackedPayment>& packed_payments,
+    const uint160& finder_pubkey_hash,
+    bool drop_finder_output,
+    bool testnet)
+{
+    PplnsView view;
+    if (subsidy == 0 || prev_share_hash.IsNull() || !chain.contains(prev_share_hash))
+        return view;
+
+    auto weights = dash::mint::pplns_weights_for(chain, params, prev_share_hash, block_bits);
+    if (!weights)
+        return view;   // cold / too-short chain — honest miss, never a fake row
+
+    std::vector<dash::coinbase::MinerPayout> outs;
+    try {
+        outs = dash::coinbase::compute_dash_payouts(
+            subsidy, packed_payments, finder_pubkey_hash,
+            weights->weights, weights->total_weight, params);
+    } catch (const std::exception&) {
+        return view;   // allocator sum-invariant tripped: report nothing, not a guess
+    }
+
+    // compute_dash_payouts emits, in this exact order (coinbase_builder.hpp:212):
+    //     worker_tx (sorted by script) || payments_tx (GBT order) || donation_tx
+    // so the masternode block is identified by COUNT, not by guessing which
+    // scripts "look like" a payee — a masternode that also mines would otherwise
+    // have its worker row misfiled. The count is step 1 of the same function:
+    // zero-amount and undecodable payees are dropped.
+    size_t n_payments = 0;
+    for (const auto& p : packed_payments) {
+        if (p.amount == 0) continue;
+        if (dash::decode_payee_script(p.payee, params.address_version,
+                                      params.address_p2sh_version).empty())
+            continue;
+        ++n_payments;
+        view.payments_total += p.amount;
+    }
+
+    view.subsidy       = subsidy;
+    view.worker_payout = (subsidy > view.payments_total)
+                       ? (subsidy - view.payments_total) : 0;
+
+    if (outs.size() < n_payments + 1)
+        return view;   // shape violated — do not slice blind
+    const size_t n_workers = outs.size() - n_payments - 1;
+
+    const std::vector<unsigned char> finder_script =
+        dash::pubkey_hash_to_script2(finder_pubkey_hash);
+
+    auto add = [&](const dash::coinbase::MinerPayout& o) {
+        if (o.amount == 0) return;
+        if (drop_finder_output && o.script == finder_script) return;
+        std::string addr = script_to_dash_address(o.script, testnet);
+        if (addr.empty()) addr = HexStr(o.script);
+        const double amt = static_cast<double>(o.amount) / 1e8;
+        if (view.payouts.contains(addr))
+            view.payouts[addr] = view.payouts[addr].get<double>() + amt;
+        else
+            view.payouts[addr] = amt;
+    };
+
+    for (size_t i = 0; i < n_workers; ++i)
+        add(outs[i]);
+    add(outs.back());   // donation
+
+    view.recipients = static_cast<int>(view.payouts.size());
+    view.ok = !view.payouts.empty();
+    return view;
+}
+
+// ── Per-share convenience wrapper ───────────────────────────────────────────
+// The PPLNS breakdown carried BY a share: its own recorded block reward
+// (m_subsidy), its own masternode payment set (m_packed_payments), its own
+// difficulty epoch (m_min_header.m_bits) and its own miner as the 2% finder —
+// i.e. the coinbase that share's gentx actually committed to. The window is
+// anchored on the share's PARENT, which is what
+// DASHWorkSource::build_connection_coinbase / mint_runloop's producer path pass
+// as prev_share_hash when building this very share (mint_runloop.hpp:181).
+template <typename ChainT>
+inline PplnsView pplns_payouts_for_share(ChainT& chain,
+                                         const core::CoinParams& params,
+                                         const uint256& share_hash,
+                                         bool testnet)
+{
+    if (share_hash.IsNull() || !chain.contains(share_hash))
+        return {};
+
+    uint256  parent;
+    uint32_t block_bits = 0;
+    uint64_t subsidy    = 0;
+    uint160  finder;
+    std::vector<dash::coin::PackedPayment> payments;
+
+    chain.get_share(share_hash).invoke([&](auto* obj) {
+        parent     = obj->m_prev_hash;
+        block_bits = obj->m_min_header.m_bits;
+        subsidy    = obj->m_subsidy;
+        finder     = obj->m_pubkey_hash;
+        payments.reserve(obj->m_packed_payments.size());
+        for (const auto& p : obj->m_packed_payments)
+            payments.push_back({p.m_payee, p.m_amount});
+    });
+
+    return pplns_payouts_at(chain, params, parent, block_bits, subsidy, payments,
+                            finder, /*drop_finder_output=*/false, testnet);
+}
+
+// ── Pool-wide convenience wrapper ───────────────────────────────────────────
+// "What would a block found RIGHT NOW pay?" — the live GBT template's reward
+// and masternode payment set, split over the window anchored on the node's
+// current best share. Finder fee omitted (see the header note).
+template <typename ChainT>
+inline PplnsView pplns_payouts_current(ChainT& chain,
+                                       const core::CoinParams& params,
+                                       const uint256& best_share_hash,
+                                       const TemplateSource& tmpl,
+                                       bool testnet)
+{
+    auto t = tmpl.peek();
+    if (!t || t->m_coinbase_value == 0)
+        return {};   // no template -> no claim about what is owed
+    return pplns_payouts_at(chain, params, best_share_hash, t->m_bits,
+                            t->m_coinbase_value, t->m_packed_payments,
+                            uint160(), /*drop_finder_output=*/true, testnet);
+}
+
+} // namespace dashboard
+} // namespace dash

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -340,7 +340,12 @@ if (BUILD_TESTING AND GTest_FOUND)
     # --target edit and would trip CI's NOT_BUILT sentinel until it had one
     # (#143/#883/#893). Needs exactly this link set: a real dash::NodeImpl +
     # ShareTracker, and core's address_utils for the DASH base58 rendering.
-    add_executable(test_dash_node test_dash_node.cpp test_dash_dashboard_found_block.cpp test_dash_addrme.cpp test_dash_block_confirm_lane.cpp test_dash_dashboard_views.cpp)
+    # test_dash_dashboard_pplns.cpp: the PPLNS payout read-model KATs
+    # (dashboard_pplns.hpp) — the pool-wide split behind /current_payouts and
+    # the per-share split on an individual share's page. FOLDED in for the same
+    # reason; needs the same link set plus the header-only mint/producer weight
+    # walk and coinbase allocator, both already reachable from `dash`.
+    add_executable(test_dash_node test_dash_node.cpp test_dash_dashboard_found_block.cpp test_dash_addrme.cpp test_dash_block_confirm_lane.cpp test_dash_dashboard_views.cpp test_dash_dashboard_pplns.cpp)
     target_link_libraries(test_dash_node PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core

--- a/test/test_dash_dashboard_pplns.cpp
+++ b/test/test_dash_dashboard_pplns.cpp
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// ---------------------------------------------------------------------------
+// test_dash_dashboard_pplns — BINDING KATs for the DASH PPLNS dashboard views:
+// the pool-wide split behind /current_payouts (and therefore
+// /current_merged_payouts and the main dashboard treemap), and the PER-SHARE
+// split attached to an individual share's page.
+//
+// THE DEFECT. rest_current_payouts() has three sources (web_server.cpp:2365):
+// the #939 direct seam m_current_payouts_fn, the coinbase-builder cache
+// m_cached_pplns_outputs, and a fallback. On DASH the first was never bound —
+// its only callers repo-wide were in core/test/web_server_current_payouts_test
+// .cpp, i.e. the seam shipped green and inert — and the second is filled by
+// refresh_work(), which never runs on the DASH lane (web_server.cpp:3902).
+// So the endpoint returned `{}` on a node with a full 4320-share window, which
+// then propagated: compute_current_merged_payouts() starts from it (:5964), so
+// /current_merged_payouts was {} too, so renderMainPPLNS({}) drew zero cells.
+//
+// WHY THESE KATs ARE NOT VACUOUS. The assertions pin the split against the
+// SAME allocator the DASH coinbase uses — dash::coinbase::compute_dash_payouts
+// over dash::mint::pplns_weights_for — rather than against a re-implementation
+// here, and each positive case is paired with the honest-miss case that the
+// unwired lane produced. A KAT asserting only "returns an object" would have
+// passed on `{}`.
+//
+// Display-only surface: nothing here reaches mint, submission or the served
+// coinbase. Both entry points take an already-read-locked chain and only read.
+// ---------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/dashboard_pplns.hpp>
+#include <impl/dash/node.hpp>
+#include <impl/dash/params.hpp>
+#include <impl/dash/share.hpp>
+#include <impl/dash/share_check.hpp>
+
+#include <core/address_utils.hpp>
+#include <core/uint256.hpp>
+
+#include <nlohmann/json.hpp>
+
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr uint32_t P_BLOCK_BITS = 0x1d00ffff;
+constexpr uint32_t P_SHARE_BITS = 0x1e0ffff0;
+constexpr uint32_t P_BASE_TIME  = 1753000000;
+// A real-shaped DASH block reward split: 5.00000000 DASH total, with the
+// masternode taking 0.83 and the platform burn 0.49 (the proportions measured
+// on our own accepted h=2516911).
+constexpr uint64_t P_SUBSIDY    = 500000000;
+constexpr uint64_t P_MN_PAY     =  83040000;
+constexpr uint64_t P_BURN_PAY   =  49790000;
+
+uint256 p_hash(unsigned int n)
+{
+    static const char* digits = "0123456789abcdef";
+    std::string s = "5c";
+    s += digits[(n >> 12) & 0xf];
+    s += digits[(n >>  8) & 0xf];
+    s += digits[(n >>  4) & 0xf];
+    s += digits[ n        & 0xf];
+    s += std::string(64 - s.size(), '0');
+    uint256 h;
+    h.SetHex(s);
+    return h;
+}
+
+uint160 p_pkh(unsigned char b)
+{
+    static const char* digits = "0123456789abcdef";
+    std::string s;
+    s += digits[b >> 4];
+    s += digits[b & 0x0f];
+    s += std::string(40 - s.size(), '5');
+    uint160 h;
+    h.SetHex(s);
+    return h;
+}
+
+std::string p_addr(unsigned char b)
+{
+    return core::script_to_address(dash::pubkey_hash_to_script2(p_pkh(b)), "", 76, 16);
+}
+
+dash::DashShare* make_pplns_share(unsigned int n, const uint256& prev,
+                                  unsigned char pkh_byte, bool with_payments)
+{
+    auto* s = new dash::DashShare();
+    s->m_hash      = p_hash(n);
+    s->m_prev_hash = prev;
+    s->m_min_header.m_bits      = P_BLOCK_BITS;
+    s->m_min_header.m_timestamp = P_BASE_TIME + n;
+    s->m_bits        = P_SHARE_BITS;
+    s->m_max_bits    = P_SHARE_BITS;
+    s->m_timestamp   = P_BASE_TIME + n;
+    s->m_absheight   = 2500000 + n;
+    s->m_pubkey_hash = p_pkh(pkh_byte);
+    s->m_subsidy     = P_SUBSIDY;
+    s->m_donation    = 0;
+    if (with_payments) {
+        // A base58 masternode payee plus the normalized OP_RETURN platform
+        // burn ("!6a..."), i.e. both forms decode_payee_script handles.
+        dash::PackedPayment mn;
+        mn.m_payee  = p_addr(0xc0);
+        mn.m_amount = P_MN_PAY;
+        dash::PackedPayment burn;
+        burn.m_payee  = "!6a0101";
+        burn.m_amount = P_BURN_PAY;
+        s->m_packed_payments = {mn, burn};
+        s->m_payment_amount  = P_MN_PAY + P_BURN_PAY;
+    }
+    return s;
+}
+
+struct PplnsHarness
+{
+    dash::NodeImpl   node;
+    core::CoinParams params = dash::make_coin_params(/*testnet=*/false);
+    uint256          tip;
+
+    // `n` shares alternating between three miners, so the split is
+    // demonstrably proportional and not a single-recipient degenerate.
+    explicit PplnsHarness(unsigned int n, bool with_payments = true)
+    {
+        uint256 prev = uint256::ZERO;
+        for (unsigned int i = 0; i < n; ++i) {
+            auto* s = make_pplns_share(i, prev,
+                                       static_cast<unsigned char>(0xa0 + (i % 3)),
+                                       with_payments);
+            node.tracker().chain.add(s);
+            prev = s->m_hash;
+            tip  = s->m_hash;
+        }
+    }
+};
+
+double sum_values(const nlohmann::json& j)
+{
+    double t = 0;
+    for (const auto& [k, v] : j.items()) { (void)k; t += v.get<double>(); }
+    return t;
+}
+
+} // namespace
+
+// ── KAT 1: the per-share PPLNS view ─────────────────────────────────────────
+TEST(DashDashboardPplns, PerShareViewSplitsTheShareOwnWorkerPayout)
+{
+    PplnsHarness h(40);
+    auto v = dash::dashboard::pplns_payouts_for_share(
+        h.node.tracker().chain, h.params, h.tip, /*testnet=*/false);
+
+    ASSERT_TRUE(v.ok) << "per-share PPLNS came back empty — this is the "
+                         "unwired-seam symptom, not a valid answer";
+
+    // The reward decomposition is the share's OWN recorded numbers.
+    EXPECT_EQ(v.subsidy,        P_SUBSIDY);
+    EXPECT_EQ(v.payments_total, P_MN_PAY + P_BURN_PAY);
+    EXPECT_EQ(v.worker_payout,  P_SUBSIDY - P_MN_PAY - P_BURN_PAY);
+
+    // Masternode / platform outputs are consensus-mandated block outputs, not
+    // pool payouts — folding them in would overstate what the pool distributes.
+    EXPECT_FALSE(v.payouts.contains(p_addr(0xc0)))
+        << "masternode payee leaked into the PPLNS view";
+
+    // Three miners contributed; the donation line is always emitted.
+    EXPECT_GE(v.recipients, 3);
+    for (unsigned char b : {0xa0, 0xa1, 0xa2})
+        EXPECT_TRUE(v.payouts.contains(p_addr(static_cast<unsigned char>(b))))
+            << "missing miner " << p_addr(static_cast<unsigned char>(b));
+
+    // Every rendered key is a DASH mainnet address ('X'), never a Bitcoin '1'.
+    for (const auto& [addr, amt] : v.payouts.items()) {
+        (void)amt;
+        EXPECT_FALSE(addr.empty());
+        EXPECT_TRUE(addr[0] == 'X' || addr[0] == '7')
+            << "non-DASH address rendering: " << addr;
+    }
+
+    // The pre-v36 arm reserves 1/50 of worker_payout for the block finder,
+    // which IS this share's own miner — so the view sums to the full
+    // worker_payout, and the finder's own row is the largest.
+    EXPECT_NEAR(sum_values(v.payouts),
+                static_cast<double>(v.worker_payout) / 1e8, 1e-6);
+}
+
+// ── KAT 2: honest miss on a cold / unknown chain ────────────────────────────
+TEST(DashDashboardPplns, PerShareViewMissesHonestly)
+{
+    PplnsHarness h(40);
+
+    // Unknown share.
+    auto miss = dash::dashboard::pplns_payouts_for_share(
+        h.node.tracker().chain, h.params, p_hash(9999), false);
+    EXPECT_FALSE(miss.ok);
+    EXPECT_TRUE(miss.payouts.empty());
+
+    // Chain too short for a window (the genesis share has no grandparent).
+    PplnsHarness cold(1);
+    auto c = dash::dashboard::pplns_payouts_for_share(
+        cold.node.tracker().chain, cold.params, cold.tip, false);
+    EXPECT_FALSE(c.ok);
+    EXPECT_TRUE(c.payouts.empty())
+        << "a cold chain must yield NOTHING, never a fabricated row";
+}
+
+// ── KAT 3: no masternode payments -> the whole subsidy is the worker payout ─
+TEST(DashDashboardPplns, WithoutPaymentsTheWholeSubsidyIsSplit)
+{
+    PplnsHarness h(40, /*with_payments=*/false);
+    auto v = dash::dashboard::pplns_payouts_for_share(
+        h.node.tracker().chain, h.params, h.tip, false);
+
+    ASSERT_TRUE(v.ok);
+    EXPECT_EQ(v.payments_total, 0u);
+    EXPECT_EQ(v.worker_payout, P_SUBSIDY);
+    EXPECT_NEAR(sum_values(v.payouts), static_cast<double>(P_SUBSIDY) / 1e8, 1e-6);
+}
+
+// ── KAT 4: the pool-wide view, and its finder-fee omission ──────────────────
+TEST(DashDashboardPplns, PoolWideViewOmitsTheFinderFeeLikeLtcDoes)
+{
+    PplnsHarness h(40);
+
+    std::vector<dash::coin::PackedPayment> tmpl_payments = {
+        {p_addr(0xc0), P_MN_PAY},
+        {"!6a0101",    P_BURN_PAY},
+    };
+
+    // Same call the pool-wide binding makes: zero finder pubkey hash, and that
+    // one output dropped. This matches LTC, where get_v35_expected_payouts is
+    // documented as "amounts WITHOUT finder fee — caller adds subsidy/200"
+    // (share_tracker.hpp:2058) and main_ltc's pplns_fn returns it unmodified.
+    auto pool = dash::dashboard::pplns_payouts_at(
+        h.node.tracker().chain, h.params, h.tip, P_BLOCK_BITS, P_SUBSIDY,
+        tmpl_payments, uint160(), /*drop_finder_output=*/true, /*testnet=*/false);
+
+    ASSERT_TRUE(pool.ok);
+    EXPECT_FALSE(pool.payouts.contains(p_addr(0xc0)));   // no masternode row
+    // The zero-pubkey-hash placeholder must never be rendered as a payee.
+    EXPECT_FALSE(pool.payouts.contains(
+        core::script_to_address(dash::pubkey_hash_to_script2(uint160()), "", 76, 16)));
+
+    // 2% of worker_payout is reserved for the (as-yet unknown) block finder, so
+    // the pool-wide view sums to ~98% of it — a definite, checkable number
+    // rather than "some subset".
+    const double worker = static_cast<double>(pool.worker_payout) / 1e8;
+    EXPECT_NEAR(sum_values(pool.payouts), worker * 0.98, worker * 0.001);
+
+    // The per-share view of the same anchor DOES carry a finder, so it sums to
+    // the full worker payout — the two views differ exactly by that 2%.
+    auto with_finder = dash::dashboard::pplns_payouts_at(
+        h.node.tracker().chain, h.params, h.tip, P_BLOCK_BITS, P_SUBSIDY,
+        tmpl_payments, p_pkh(0xa0), /*drop_finder_output=*/false, false);
+    ASSERT_TRUE(with_finder.ok);
+    EXPECT_NEAR(sum_values(with_finder.payouts), worker, 1e-6);
+    EXPECT_GT(sum_values(with_finder.payouts), sum_values(pool.payouts));
+}
+
+// ── KAT 5: an unbound template source yields nothing, not a guess ───────────
+TEST(DashDashboardPplns, UnboundTemplateSourceYieldsAnHonestEmpty)
+{
+    PplnsHarness h(40);
+    dash::dashboard::TemplateSource tmpl;   // never bound
+
+    EXPECT_EQ(tmpl.peek(), nullptr);
+    auto v = dash::dashboard::pplns_payouts_current(
+        h.node.tracker().chain, h.params, h.tip, tmpl, /*testnet=*/false);
+    EXPECT_FALSE(v.ok);
+    EXPECT_TRUE(v.payouts.empty())
+        << "no template must mean no claim about what is owed";
+
+    // Bound -> answers. This is the whole difference between the shipped
+    // behaviour and this change.
+    auto wd = std::make_shared<dash::coin::DashWorkData>();
+    wd->m_coinbase_value = P_SUBSIDY;
+    wd->m_bits           = P_BLOCK_BITS;
+    wd->m_packed_payments = {{p_addr(0xc0), P_MN_PAY}};
+    tmpl.bind([wd]() -> std::shared_ptr<const dash::coin::DashWorkData> { return wd; });
+
+    auto v2 = dash::dashboard::pplns_payouts_current(
+        h.node.tracker().chain, h.params, h.tip, tmpl, false);
+    ASSERT_TRUE(v2.ok);
+    EXPECT_EQ(v2.worker_payout, P_SUBSIDY - P_MN_PAY);
+    EXPECT_GE(v2.recipients, 3);
+
+    // NEGATIVE CONTROL: this is what /current_payouts served before — an
+    // object that passes every "is it valid JSON" check and renders nothing.
+    const nlohmann::json shipped = nlohmann::json::object();
+    EXPECT_TRUE(shipped.is_object());
+    EXPECT_TRUE(shipped.empty());
+    EXPECT_FALSE(v2.payouts.empty());
+}

--- a/web-static/dashboard.html
+++ b/web-static/dashboard.html
@@ -6480,6 +6480,11 @@
         var _cachedPPLNSPayouts = null;
         function renderMainPPLNS(payouts) {
                 if (!payouts || typeof payouts !== 'object') return;
+                // Coin label from currency_info (per-node truthful). This
+                // treemap hardcoded 'LTC', so on a DASH node every cell and
+                // tooltip read "% LTC".
+                var _pplnsSym = ((typeof currency_info !== 'undefined'
+                                  && currency_info.symbol) || 'COIN').toUpperCase();
                 var pl = document.getElementById('pplns-loading');
                 if (pl) pl.style.display = 'none';
                 var grid = document.getElementById('pplns-main-grid');
@@ -6574,7 +6579,7 @@
                         var el = document.createElement('div');
                         el.className = 'pm-pct';
                         el.style.fontSize = fitPct + 'px';
-                        el.textContent = (r.pct * 100).toFixed(1) + (r.w > 60 ? '% LTC' : '%');
+                        el.textContent = (r.pct * 100).toFixed(1) + (r.w > 60 ? '% ' + _pplnsSym : '%');
                         cell.appendChild(el);
                     }
                     // DOGE %
@@ -6686,7 +6691,7 @@
                             if (mHr > 0) hrLine = '<div style="color:var(--text-secondary)">' + format_hashrate(mHr) + '</div>';
                             tooltip.innerHTML =
                                 '<div style="color:var(--primary);font-weight:700;margin-bottom:4px">' + r.addr + '</div>' +
-                                '<div style="font-weight:600">' + (r.pct*100).toFixed(2) + '% \u2014 ' + r.amt.toFixed(8) + ' LTC</div>' +
+                                '<div style="font-weight:600">' + (r.pct*100).toFixed(2) + '% \u2014 ' + r.amt.toFixed(8) + ' ' + _pplnsSym + '</div>' +
                                 dogeLine + hrLine + verLine +
                                 '<div style="color:var(--text-muted);font-size:0.75em;margin-top:4px">Click to view on Blockchair</div>';
                             tooltip.style.display = 'block';

--- a/web-static/share.html
+++ b/web-static/share.html
@@ -699,7 +699,15 @@
                 // Use per-share PPLNS from server cache (exact for this share's position)
                 var shortHash = share_hash.substr(0, 16);
                 var sharePplns = null;
-                if (winData.pplns && winData.pplns[shortHash]) {
+                // Preferred source: the PPLNS breakdown carried BY this share's
+                // own document (/web/share/<hash>.pplns), computed on demand
+                // from the share's own window position, subsidy and payment set.
+                // It is exact and needs no server-side per-share precompute
+                // cache — which is what a coin whose work pipeline does not run
+                // core's refresh_work() (i.e. DASH) can never populate.
+                if (share && share.pplns && Object.keys(share.pplns).length > 0) {
+                    sharePplns = share.pplns;
+                } else if (winData.pplns && winData.pplns[shortHash]) {
                     sharePplns = winData.pplns[shortHash];
                 } else if (winData.pplns_current) {
                     sharePplns = winData.pplns_current;
@@ -798,7 +806,11 @@
                             var pctEl = document.createElement('div');
                             pctEl.className = 'pplns-pct';
                             pctEl.style.fontSize = fitPct + 'px';
-                            pctEl.textContent = (r.pct * 100).toFixed(1) + (r.w > 60 ? '% LTC' : '%');
+                            // Coin label from currency_info (per-node truthful),
+                            // never the hardcoded 'LTC' this treemap shipped
+                            // with — on a DASH node it read "% LTC".
+                            pctEl.textContent = (r.pct * 100).toFixed(1)
+                                + (r.w > 60 ? '% ' + symbol.toUpperCase() : '%');
                             cell.appendChild(pctEl);
                         }
 


### PR DESCRIPTION
dash(dashboard): bind the PPLNS payout views — /current_payouts returned {} on a node with a full window, and an individual share had no payout breakdown at all

Stacked on dash/dashboard-sharechain-views (the window/delta/share-detail
binding); the per-share PPLNS view is a widget INSIDE the share page that PR
creates, so it cannot land first.

TWO WIDGETS, ONE ROOT CAUSE

  1. The main dashboard PPLNS treemap was empty on DASH.
     rest_current_payouts() (web_server.cpp:2365) has two live sources. The
     #939 direct seam m_current_payouts_fn was never bound by any coin — its
     only callers repo-wide were in core/test/web_server_current_payouts_test
     .cpp, i.e. it shipped green and INERT. The other source,
     m_cached_pplns_outputs, is filled by refresh_work(), which never runs on
     the DASH lane (web_server.cpp:3902 states it outright: MiningInterface's
     own stratum acceptor is off and DASHWorkSource owns the coinbase).
     So /current_payouts answered {} — and that propagated:
     compute_current_merged_payouts() starts from it (:5964), so
     /current_merged_payouts was {} too, and /current_merged_payouts is
     exactly what the main treemap fetches (dashboard.html loadMainPPLNS).
     renderMainPPLNS({}) draws zero cells. /pplns/current's miners[] came off
     the same cache and was likewise [].

  2. An individual share had no PPLNS view at all.
     share.html has had a per-share PPLNS treemap for a long time; it reads
     window["pplns"][<short hash>], falling back to window["pplns_current"].
     LTC fills those from start_pplns_precompute() -> m_pplns_per_tip. That
     precompute REFUSES TO START until m_cached_template carries "bits" +
     "coinbasevalue" (web_server.cpp:2947-2963) — which, again, only
     refresh_work() ever sets. Porting the LTC route would have wired green
     and stayed empty: the same failure mode this whole changeset exists to
     remove. It is deliberately not repeated.

WHAT THIS ADDS

  src/impl/dash/dashboard_pplns.hpp — payouts computed DIRECTLY from the two
  SSOTs the DASH coinbase itself uses, so the dashboard shows the split a block
  found now would actually pay:
    * dash::mint::pplns_weights_for (mint_runloop.hpp:504) — the ORACLE window
      walk (grandparent start, max(0, min(height, RCL)-1) shares).
    * dash::coinbase::compute_dash_payouts (coinbase_builder.hpp:83) — the
      allocator, including the pre-v36 49/50 split and the donation remainder.
  No payout arithmetic is re-implemented. Masternode / superblock / platform
  outputs are excluded from the payout map by COUNT, not by guessing which
  scripts look like a payee (the allocator's output order is worker_tx ||
  payments_tx || donation_tx, and the payment count is step 1 of the same
  function) — so a masternode that also mines still gets its worker row.

  Finder fee: the pool-wide view has no finder (the next block's winner is
  unknown), so it is computed with a ZERO pubkey hash and that one output is
  dropped. This is LTC's own convention — share_tracker.hpp:2058 documents
  get_v35_expected_payouts as "amounts WITHOUT finder fee — caller adds
  subsidy/200", and main_ltc's pplns_fn returns it unmodified for the pre-v36
  arm. The PER-SHARE view has a real finder (the share's own miner) and passes
  it, so that view sums to the full worker payout.

  TemplateSource: the WebServer seams are bound, and web_server->start() runs,
  well BEFORE DASHWorkSource exists (main_dash.cpp:1549 vs :2124), so the
  payout callback cannot capture the work source and a bare std::function
  assigned later would race the already-serving IO thread. TemplateSource
  publishes the peek under its own mutex and copies it out before calling, so
  the tracker-locking callee never runs holding it. Unbound is a first-class
  state meaning "no template yet" — every caller answers an empty document
  rather than inventing a subsidy. It is bound to peek_template(), the same
  NON-FETCHING peek the block-value card already uses.

  Per-share PPLNS is attached to the SHARE DOCUMENT and computed on demand:
  one tracker walk per page view, inside the guard already held. It uses the
  share's OWN recorded numbers — m_subsidy, m_packed_payments,
  m_min_header.m_bits, m_pubkey_hash as finder — anchored on the share's
  PARENT, which is exactly what build_connection_coinbase / the producer path
  pass as prev_share_hash when building that very share (mint_runloop.hpp:181).

FRONT-END

  * share.html now prefers share.pplns (the share's own document) over the
    window cache, then falls back to the existing two sources unchanged. LTC
    behaviour is untouched: it has no share.pplns, so it takes the same branch
    it always did.
  * The PPLNS treemaps hardcoded 'LTC' in three places, so on a DASH node
    every cell and tooltip read "% LTC". Now sourced from currency_info.symbol
    (the per-node-truthful mechanism the rest of the dashboard already uses).

LIVE EVIDENCE

  Built binary run READ-ONLY against a copy of the production DASH node's
  sharechain store (8845 shares, tip 000000000000428a, chain_height 8837).
  Individual share 0000000000000991...:

    "dash_metadata": {"payment_amount":0.82979299,
       "packed_payments":[{"amount":0.49787579,"payee":"!6a"},
                          {"amount":0.82979299,"payee":"Xi7ukT4BsF4yMm63yD7aN2EekkP8vRAZD8"}]}
    "pplns_meta":  {"subsidy":1.77022505, "payments_total":1.32766878,
                    "worker_payout":0.44255627, "recipients":6}
    "pplns":       XoZcEFbqwnty5secW7HYjdQEZYfubMkURu 0.38206776
                   XghFtkZ8W3vhEHejUBbD3n387hemVJ6Pt4 0.03468994
                   XqFqj77kbPQ5HZqnz7YKG5Ku25XpPTjdQ9 0.01317866
                   Xc68hkJyUhStiNNnpDjk9J5R6SXM1jWXAp 0.01197685
                   XdgF55wEHBRWwbuBniNYH4GvvaoYMgL84u 0.00035042
                   XhSrhUp7VDZsjVRmzNVCgQUpoJaTLpNzQP 0.00029264
                   ---------------------------------- ----------
                                                      0.44255627  == worker_payout

  The masternode payee is in dash_metadata and NOT in the payout map, and the
  six rows sum to the worker payout exactly. Independently corroborated by the
  production node's own /local_stats at the same time: block_value 1.77022505,
  block_value_payments 1.32766878, block_value_miner_gross 0.44255627.

TESTS

  test/test_dash_dashboard_pplns.cpp — 5 KATs FOLDED into the already
  allowlisted test_dash_node target (no new add_executable, #143/#883/#893;
  not #ifdef-guarded, #895). Pins: the per-share split against the real
  allocator, masternode exclusion, honest miss on unknown/cold chain, the
  no-payments case, the pool-wide finder-fee omission as a checkable 98%-of-
  worker-payout figure with the zero-pubkey-hash placeholder proven absent,
  and the unbound-TemplateSource honest empty with the shipped `{}` as the
  explicit negative control.

  19/19 green across the three DASH dashboard suites. c2pool-dash builds clean.

Display-only surface: nothing here reaches mint, submission or the served
coinbase; peek_template() never triggers a fetch. Per-coin isolation:
src/impl/dash/ + the DASH main; the two web-static edits are coin-agnostic and
leave the LTC path byte-identical.


---
Depends on #1144 (base is that branch, not master).
