### PR TITLE
dash(daemonless): serve every block query the header chain owns, REFUSE the body-backed ones with a named reason and HTTP 501 (#99 a+b) [do-not-merge]

### DIFF
--- a/src/core/http_session.cpp
+++ b/src/core/http_session.cpp
@@ -750,22 +750,80 @@ void HttpSession::process_request()
                     // backend can answer from its own validated state (DASH's
                     // header chain), its answer — including a refusal that
                     // names the blocking condition — is served verbatim.
-                    if ((ep == "getblockchaininfo" || ep == "getbestblockhash" || ep == "getblockhash")
-                        && mining_interface_->has_coin_chain_query_fn()) {
+                    //
+                    // Methods a coin backend may answer from its own validated
+                    // state. getblock/getblockheader/getrawtransaction joined the
+                    // list when the daemonless block-data policy landed: the
+                    // header chain answers getblockheader in full and getblock
+                    // partially, and REFUSES the body-backed shapes with a named
+                    // reason rather than letting the request fall through to a
+                    // branch that would answer {} (#99).
+                    const bool coin_owned_query =
+                        (ep == "getblockchaininfo" || ep == "getbestblockhash"
+                         || ep == "getblockhash"   || ep == "getblockheader"
+                         || ep == "getblock"       || ep == "getrawtransaction");
+                    if (coin_owned_query && mining_interface_->has_coin_chain_query_fn()) {
                         rest_result = [&]() -> nlohmann::json {
                             nlohmann::json qp = nlohmann::json::array();
-                            if (ep == "getblockhash") {
+                            if (ep == "getblockheader" || ep == "getblock") {
+                                // hash, or height resolved through the same hook.
+                                std::string hash = getQueryParam("hash");
+                                if (hash.empty()) {
+                                    std::string h_str = getQueryParam("height");
+                                    if (!h_str.empty()) {
+                                        nlohmann::json hp = nlohmann::json::array();
+                                        try { hp.push_back(static_cast<uint32_t>(std::stoul(h_str))); }
+                                        catch (...) {
+                                            return nlohmann::json{
+                                                {"error", ep + " withheld: height parameter '"
+                                                          + h_str + "' is not a number "
+                                                          "(threshold: decimal height)"},
+                                                {"code", "BAD_PARAMS"},
+                                                {"method", ep}};
+                                        }
+                                        auto hj = mining_interface_->call_coin_chain_query(
+                                            "getblockhash", hp, chain);
+                                        if (hj.is_string()) hash = hj.get<std::string>();
+                                        else return hj;   // propagate the refusal verbatim
+                                    }
+                                }
+                                if (hash.empty())
+                                    return nlohmann::json{
+                                        {"error", ep + " withheld: neither ?hash= nor ?height= "
+                                                  "was supplied (threshold: one of them)"},
+                                        {"code", "BAD_PARAMS"},
+                                        {"method", ep}};
+                                qp.push_back(hash);
+                                if (ep == "getblock") {
+                                    auto vs = getQueryParam("verbosity");
+                                    if (vs.empty()) vs = getQueryParam("verbose");
+                                    if (!vs.empty()) {
+                                        if (vs == "true")       qp.push_back(1);
+                                        else if (vs == "false") qp.push_back(0);
+                                        else { try { qp.push_back(std::stoi(vs)); } catch (...) {} }
+                                    }
+                                } else {
+                                    auto vs = getQueryParam("verbose");
+                                    if (vs == "false") qp.push_back(false);
+                                }
+                            } else if (ep == "getrawtransaction") {
+                                qp.push_back(getQueryParam("txid"));
+                            } else if (ep == "getblockhash") {
                                 std::string height_str = getQueryParam("height");
                                 if (height_str.empty())
                                     return nlohmann::json{
                                         {"error", "getblockhash withheld: missing height "
-                                                  "parameter (threshold: ?height=<n> required)"}};
+                                                  "parameter (threshold: ?height=<n> required)"},
+                                        {"code", "BAD_PARAMS"},
+                                        {"method", ep}};
                                 try { qp.push_back(static_cast<uint32_t>(std::stoul(height_str))); }
                                 catch (...) {
                                     return nlohmann::json{
                                         {"error", "getblockhash withheld: height parameter '"
                                                   + height_str + "' is not a number "
-                                                  "(threshold: decimal height)"}};
+                                                  "(threshold: decimal height)"},
+                                        {"code", "BAD_PARAMS"},
+                                        {"method", ep}};
                                 }
                             }
                             return mining_interface_->call_coin_chain_query(ep, qp, chain);
@@ -917,8 +975,27 @@ void HttpSession::process_request()
                 }  // end static file serving else
             }  // end explorer/static dispatch
 
-            if (!rest_result.is_null())
+            if (!rest_result.is_null()) {
+                // ── CAPABILITY REFUSALS DO NOT SHIP AS 200 ────────────────────
+                // A refusal from a coin backend carries a stable `code` (see
+                // dash/coin/chain_rpc.hpp). Serving it as 200 would put it in
+                // the same status class as a real answer, which is precisely
+                // how an empty stub passed for data on this lane for months.
+                // 501 Not Implemented is a statement about THIS NODE ("we do
+                // not implement that"), as distinct from 404 ("that block does
+                // not exist"), which is a statement about the CHAIN. Callers
+                // act on those differently, so they must not share a status.
+                //
+                // The status is carried in the payload by the producer, so the
+                // transport can never disagree with the contract; a payload
+                // that omits it defaults to 501 whenever `code` is present.
+                if (rest_result.is_object() && rest_result.contains("code")) {
+                    int st = rest_result.value("http_status", 501);
+                    if (st < 400 || st > 599) st = 501;
+                    response.result(static_cast<http::status>(st));
+                }
                 response_body = rest_result.dump();
+            }
         }
         else if (request_.method() == http::verb::post) {
             // Handle JSON-RPC POST request.

--- a/src/impl/dash/coin/chain_rpc.hpp
+++ b/src/impl/dash/coin/chain_rpc.hpp
@@ -54,6 +54,7 @@
 #include <ctime>
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace dash {
 namespace coin {
@@ -166,6 +167,102 @@ struct Answer {
 /// The daemonless answer source, echoed on every response so a consumer can
 /// never confuse it with a real dashd reply.
 inline constexpr const char* SOURCE_TAG = "c2pool-embedded-header-chain";
+
+/// ── THE REFUSAL CONTRACT ────────────────────────────────────────────────────
+///
+/// An unwired seam in this tree used to answer with a well-formed EMPTY
+/// document under HTTP 200 (core's fallback stubs: web_server.cpp:2907 window,
+/// :3313 delta). That is why the DASH dashboard drew blank panels for months
+/// with no error in the UI, no line in the log and nothing red in CI. The
+/// lesson generalises:
+///
+///     ABSENCE OF DATA AND ABSENCE OF CAPABILITY ARE DIFFERENT ANSWERS
+///     AND MUST NEVER SHARE A REPRESENTATION.
+///
+/// "This block has no transactions we can show you" (empty) and "this node
+/// cannot show transactions at all" (incapable) look identical if both are
+/// `{"tx":[]}` with status 200. So a refusal here is built to be impossible to
+/// mistake for emptiness, by a machine AND by a human:
+///
+///   machine — HTTP 501 Not Implemented, plus a `code` field naming the
+///             missing capability as a stable enum. No successful answer in
+///             this file ever carries `code`, and no empty collection can
+///             synthesise one. A caller's whole check is:
+///                 if (status === 501 || body.code) -> capability refusal
+///             501 is chosen deliberately over 404: 404 means "that block does
+///             not exist", which is a statement about the CHAIN. 501 means
+///             "this node does not implement that", which is a statement about
+///             THIS NODE. Those are different facts and callers act on them
+///             differently.
+///
+///   human   — `error` is a sentence naming the blocking condition, what we DO
+///             retain, and the two concrete remedies. Never a bare "failed".
+///
+/// A partially-answerable query (getblock verbosity 1: we own every header
+/// field but not the transaction list) is NOT a refusal. It answers 200 with
+/// `partial: true` and lists each withheld field under `unavailable` with its
+/// reason — the same shape getblockchaininfo has always used. Critically the
+/// withheld fields are ABSENT, never emitted as `[]` or `0`: a consumer that
+/// blindly reads `result.tx.length` must throw, not silently render an empty
+/// transaction table. Emitting `tx: []` there would recreate the exact bug
+/// this contract exists to prevent.
+
+/// Stable machine-readable refusal codes. Additive only — callers match on
+/// these strings.
+inline constexpr const char* CODE_REQUIRES_BLOCK_BODIES = "REQUIRES_BLOCK_BODIES";
+inline constexpr const char* CODE_REQUIRES_TX_INDEX     = "REQUIRES_TX_INDEX";
+inline constexpr const char* CODE_UNKNOWN_METHOD        = "UNKNOWN_METHOD";
+inline constexpr const char* CODE_BAD_PARAMS            = "BAD_PARAMS";
+inline constexpr const char* CODE_CHAIN_STATE           = "CHAIN_STATE";
+
+/// What this node retains today. Emitted on every refusal so the answer is
+/// self-describing without the caller consulting docs.
+inline constexpr const char* RETAINED_HEADERS_ONLY = "headers-only";
+
+/// HTTP status a refusal must be served with. Kept here, next to the codes, so
+/// the transport cannot drift from the contract.
+inline constexpr int REFUSAL_HTTP_STATUS = 501;
+
+/// Build the refusal envelope. `remedies` names what would make the query
+/// answerable — the operator's product choice is explicit in the payload
+/// itself, not buried in documentation.
+inline nlohmann::json refusal(const std::string& method,
+                              const char*        code,
+                              const std::string& reason,
+                              std::vector<std::string> remedies = {})
+{
+    nlohmann::json r;
+    r["error"]              = reason;
+    // Retained for the callers of the original three queries, which already
+    // read this key.
+    r["unavailable_reason"] = reason;
+    r["code"]               = code;
+    r["method"]             = method;
+    r["source"]             = SOURCE_TAG;
+    r["retained"]           = RETAINED_HEADERS_ONLY;
+    r["http_status"]        = REFUSAL_HTTP_STATUS;
+    if (!remedies.empty()) r["requires"] = remedies;
+    return r;
+}
+
+/// The two ways an operator can make body-backed queries work. Symmetric by
+/// design: one costs an external process, the other costs disk.
+inline std::vector<std::string> body_remedies()
+{
+    return {"external-daemon-rpc", "archive-mode"};
+}
+
+/// Reason text shared by every body-requiring query, so the wording cannot
+/// drift between endpoints.
+inline std::string body_reason(const std::string& what)
+{
+    return what + " requires transaction bodies; this node retains block "
+                  "HEADERS ONLY (X11+DGW validated, genesis..tip). Replay "
+                  "streams every block body through the fold and prunes it "
+                  "immediately, so no body store exists. Remedies: connect an "
+                  "external daemon RPC, or enable archive mode to retain "
+                  "bodies (materially larger disk footprint).";
+}
 
 /// getbestblockhash. Answerable only while the chain is synced: the tip of a
 /// chain we know is behind is not the network best block, and returning it
@@ -325,6 +422,187 @@ inline nlohmann::json getblockchaininfo(const HeaderChain& hc,
     return r;
 }
 
+/// Header-level fields for one indexed entry, in dashd's getblockheader shape.
+/// Every field here is owned: it comes out of the stored IndexEntry, which was
+/// X11-PoW and DGW-validated before it was indexed.
+inline nlohmann::json header_fields(const HeaderChain& hc, const IndexEntry& e,
+                                    const SyncStatus& s)
+{
+    const auto& p = hc.params();
+    nlohmann::json r;
+    r["hash"]              = e.hash.GetHex();
+    r["height"]            = e.height;
+    r["version"]           = e.header.m_version;
+    r["versionHex"]        = hex8(static_cast<uint32_t>(e.header.m_version));
+    r["merkleroot"]        = e.header.m_merkle_root.GetHex();
+    r["time"]              = e.header.m_timestamp;
+    r["bits"]              = hex8(e.header.m_bits);
+    r["nonce"]             = e.header.m_nonce;
+    r["source"]            = SOURCE_TAG;
+    // confirmations counts against OUR tip, which is only the network tip when
+    // synced. Under a stale tip the number would overstate finality, so it is
+    // withheld rather than quietly computed from a tip we know is behind.
+    if (s.synced)
+        r["confirmations"] = static_cast<int64_t>(s.tip_height) - static_cast<int64_t>(e.height) + 1;
+
+    // Genesis has no predecessor; every other entry carries one.
+    if (!e.prev_hash.IsNull())
+        r["previousblockhash"] = e.prev_hash.GetHex();
+
+    // nextblockhash exists only if we hold the successor on the active branch.
+    if (auto nxt = hc.get_header_by_height(e.height + 1))
+        r["nextblockhash"] = nxt->hash.GetHex();
+
+    uint256 target = target_from_bits(e.header.m_bits);
+    if (!target.IsNull())
+        r["difficulty"] = p.pow_limit.getdouble() / target.getdouble();
+
+    return r;
+}
+
+/// Locate an entry by hash, with a refusal that distinguishes "we do not hold
+/// that height" from "no such block". Returns nullopt on failure and fills
+/// `out_refusal`.
+inline std::optional<IndexEntry> lookup_by_hash(const HeaderChain& hc,
+                                                const std::string& method,
+                                                const std::string& hash_hex,
+                                                nlohmann::json&    out_refusal)
+{
+    uint256 h;
+    if (hash_hex.size() != 64) {
+        out_refusal = refusal(method, CODE_BAD_PARAMS,
+                              method + " withheld: block hash '" + hash_hex
+                              + "' is not 64 hex characters (threshold: a "
+                                "64-char block hash)");
+        return std::nullopt;
+    }
+    h.SetHex(hash_hex);
+    auto e = hc.get_header(h);
+    if (e) return e;
+
+    // Not indexed. Say WHICH of the two reasons applies — an operator asking
+    // for a pre-anchor block needs a different action than one asking for a
+    // hash that is not on our chain at all.
+    auto anchor = first_indexed_height(hc);
+    out_refusal = refusal(
+        method, CODE_CHAIN_STATE,
+        method + " withheld: block " + hash_hex + " is not in our header index. "
+        "We index the active branch from height "
+        + (anchor ? std::to_string(*anchor) : std::string("n/a"))
+        + " to the tip; the hash is either below that anchor, on a branch we "
+          "did not follow, or not a Dash block.");
+    return std::nullopt;
+}
+
+/// getblockheader <hash>. FULLY answerable — a header chain is exactly the
+/// state this query names. verbose=false returns the serialised header hex.
+inline nlohmann::json getblockheader(const HeaderChain& hc,
+                                     const std::string& hash_hex,
+                                     bool verbose = true,
+                                     uint32_t now = now_unix())
+{
+    nlohmann::json ref;
+    auto e = lookup_by_hash(hc, "getblockheader", hash_hex, ref);
+    if (!e) return ref;
+
+    if (is_synthetic_anchor(*e))
+        return refusal("getblockheader", CODE_CHAIN_STATE,
+                       "getblockheader withheld: height " + std::to_string(e->height)
+                       + " is the synthetic anchor entry (bits=0, timestamp=0; no "
+                         "real header was ever connected there), so every field "
+                         "would be a fabricated zero (threshold: a real header)");
+
+    auto s = sync_status(hc, now);
+    if (!verbose) {
+        auto packed = pack(e->header);
+        auto span   = packed.get_span();   // std::span<const std::byte>
+        std::string out;
+        out.reserve(span.size() * 2);
+        static const char* HEX = "0123456789abcdef";
+        for (auto sb : span) {
+            const auto b = static_cast<unsigned char>(sb);
+            out += HEX[b >> 4];
+            out += HEX[b & 0x0f];
+        }
+        return nlohmann::json(out);
+    }
+    return header_fields(hc, *e, s);
+}
+
+/// getblock <hash> [verbosity].
+///
+///   verbosity 0 — the raw serialised BLOCK. Needs the body. REFUSED.
+///   verbosity 1 — header fields + the txid list. We own every header field
+///                 and none of the txid list, so this answers PARTIAL: owned
+///                 fields present, `tx`/`nTx`/`size`/`strippedsize` ABSENT and
+///                 named under `unavailable`. Never `tx: []`.
+///   verbosity 2 — header + fully decoded transactions. Needs bodies. REFUSED.
+///
+/// The merkle root commits to the transaction set but does not reveal it: no
+/// amount of header data can reconstruct a txid list, which is why verbosity 1
+/// cannot be completed rather than merely being unimplemented.
+inline nlohmann::json getblock(const HeaderChain& hc,
+                               const std::string& hash_hex,
+                               int verbosity = 1,
+                               uint32_t now = now_unix())
+{
+    if (verbosity <= 0)
+        return refusal("getblock", CODE_REQUIRES_BLOCK_BODIES,
+                       body_reason("getblock verbosity 0 (raw serialised block)"),
+                       body_remedies());
+    if (verbosity >= 2)
+        return refusal("getblock", CODE_REQUIRES_BLOCK_BODIES,
+                       body_reason("getblock verbosity 2 (decoded transactions)"),
+                       body_remedies());
+
+    nlohmann::json ref;
+    auto e = lookup_by_hash(hc, "getblock", hash_hex, ref);
+    if (!e) return ref;
+
+    if (is_synthetic_anchor(*e))
+        return refusal("getblock", CODE_CHAIN_STATE,
+                       "getblock withheld: height " + std::to_string(e->height)
+                       + " is the synthetic anchor entry (bits=0, timestamp=0); "
+                         "every header field would be a fabricated zero "
+                         "(threshold: a real header)");
+
+    auto s = sync_status(hc, now);
+    nlohmann::json r = header_fields(hc, *e, s);
+
+    // The honest half. These are ABSENT above, not zeroed, and each says why.
+    const std::string why = body_reason("the transaction list");
+    nlohmann::json unavailable = nlohmann::json::object();
+    for (const char* f : {"tx", "nTx", "size", "strippedsize", "weight"})
+        unavailable[f] = why;
+    r["unavailable"] = unavailable;
+    // The one flag a consumer must branch on before treating this like a
+    // daemon's getblock. Present ONLY when fields were withheld.
+    r["partial"] = true;
+    r["requires"] = body_remedies();
+    if (!s.synced) r["sync_blocked_by"] = s.blocked_by;
+    return r;
+}
+
+/// getrawtransaction <txid>. Doubly unanswerable: it needs the block body the
+/// transaction lives in AND a txid->block index to find which body that is.
+/// Both are named, because archive mode alone does not fix this one.
+inline nlohmann::json getrawtransaction(const std::string& txid)
+{
+    auto r = refusal(
+        "getrawtransaction", CODE_REQUIRES_BLOCK_BODIES,
+        "getrawtransaction withheld for txid '" + txid + "': this node retains "
+        "block HEADERS ONLY. Serving a transaction needs (1) the block body it "
+        "is in, which replay prunes immediately after folding, and (2) a "
+        "txid->block index, which is not built even in archive mode unless "
+        "transaction indexing is also enabled. Remedies: connect an external "
+        "daemon RPC, or enable archive mode WITH transaction indexing.",
+        {"external-daemon-rpc", "archive-mode+txindex"});
+    // Second code so a caller can tell this apart from a plain body refusal:
+    // enabling archive mode alone will NOT make this succeed.
+    r["also_requires"] = CODE_REQUIRES_TX_INDEX;
+    return r;
+}
+
 /// Single dispatch entry point for the three queries, shaped for the web
 /// server's coin-chain-query hook. Returns the bare dashd-compatible result on
 /// success; on refusal an object carrying the named blocking condition.
@@ -362,12 +640,42 @@ inline nlohmann::json chain_query(const HeaderChain& hc,
         return a.available ? a.value : refuse(a);
     }
 
-    return nlohmann::json{
-        {"error", std::string("method '") + method +
-                  "' is not answerable from the header chain (owned: "
-                  "getbestblockhash, getblockhash, getblockchaininfo)"},
-        {"method", method},
-        {"source", SOURCE_TAG}};
+    if (method == "getblockheader") {
+        if (!params.is_array() || params.empty() || !params[0].is_string())
+            return refusal(method, CODE_BAD_PARAMS,
+                           "getblockheader withheld: missing or non-string block "
+                           "hash (threshold: params[0] must be a 64-char hash)");
+        bool verbose = true;
+        if (params.size() > 1 && params[1].is_boolean()) verbose = params[1].get<bool>();
+        return getblockheader(hc, params[0].get<std::string>(), verbose, now);
+    }
+
+    if (method == "getblock") {
+        if (!params.is_array() || params.empty() || !params[0].is_string())
+            return refusal(method, CODE_BAD_PARAMS,
+                           "getblock withheld: missing or non-string block hash "
+                           "(threshold: params[0] must be a 64-char hash)");
+        int verbosity = 1;
+        if (params.size() > 1) {
+            if (params[1].is_number())       verbosity = params[1].get<int>();
+            else if (params[1].is_boolean()) verbosity = params[1].get<bool>() ? 1 : 0;
+        }
+        return getblock(hc, params[0].get<std::string>(), verbosity, now);
+    }
+
+    if (method == "getrawtransaction") {
+        std::string txid;
+        if (params.is_array() && !params.empty() && params[0].is_string())
+            txid = params[0].get<std::string>();
+        return getrawtransaction(txid);
+    }
+
+    return refusal(method, CODE_UNKNOWN_METHOD,
+                   std::string("method '") + method +
+                   "' is not answerable from the header chain (owned: "
+                   "getbestblockhash, getblockhash, getblockchaininfo, "
+                   "getblockheader, getblock[verbosity=1, partial]; refused with "
+                   "a named reason: getblock[verbosity 0|2], getrawtransaction)");
 }
 
 } // namespace chain_rpc

--- a/test/test_dash_header_chain.cpp
+++ b/test/test_dash_header_chain.cpp
@@ -21,6 +21,7 @@
 //   T/3 -> 0x104c8b/3 = 0x056ed9 -> 0x1b056ed9
 //   3*T -> 0x104c8b*3 = 0x30e5a1 -> 0x1b30e5a1
 
+#include <algorithm>   // std::find over the refusal `requires` array
 #include <gtest/gtest.h>
 
 #include <impl/dash/coin/header_chain.hpp>
@@ -660,4 +661,218 @@ TEST(DashHeaderChainDiag, BackfillProgressBaselinesThenReports) {
     auto b2 = mine_batch(3);
     EXPECT_EQ(hc.add_headers(b2), 3);
     EXPECT_EQ(hc.height(), 6u);
+}
+
+// ─── DAEMONLESS BLOCK-DATA POLICY (#99) ─────────────────────────────────────
+//
+// Three behaviours, one contract:
+//   (a) SERVE what the header chain owns  — getblockheader in full, getblock
+//       verbosity 1 partially.
+//   (b) REFUSE what needs bodies, NAMING the reason and the remedies, in a
+//       shape no empty answer can imitate.
+//   (c) archive mode is the remedy the refusal itself advertises.
+//
+// The regression these pin is the one that motivated the whole task: an
+// unwired seam answered HTTP 200 with a well-formed EMPTY document, so a dead
+// view was indistinguishable from an empty one. Every assertion below exists
+// to keep "no data" and "no capability" in different representations.
+
+namespace {
+
+// A refusal must be recognisable by a machine with ONE predicate and by a
+// human from the prose. Both halves are asserted together so neither can rot.
+void expect_is_refusal(const nlohmann::json& r, const char* expect_code) {
+    ASSERT_TRUE(r.is_object()) << r.dump(2);
+    ASSERT_TRUE(r.contains("code")) << "the machine discriminator is missing; a "
+                                       "caller cannot tell this from data: " << r.dump(2);
+    EXPECT_EQ(r["code"].get<std::string>(), expect_code) << r.dump(2);
+    EXPECT_EQ(r.value("http_status", 0), chain_rpc::REFUSAL_HTTP_STATUS)
+        << "a refusal must carry the non-2xx status the transport will serve";
+    EXPECT_EQ(r.value("source", std::string()), chain_rpc::SOURCE_TAG);
+    EXPECT_EQ(r.value("retained", std::string()), chain_rpc::RETAINED_HEADERS_ONLY);
+    const std::string err = r.value("error", std::string());
+    EXPECT_FALSE(err.empty()) << "a refusal must name the blocking condition";
+    EXPECT_GT(err.size(), 40u) << "refusal prose must be a sentence, not a token: " << err;
+    // Back-compat with the callers of the original three queries.
+    EXPECT_EQ(r.value("unavailable_reason", std::string()), err);
+}
+
+} // namespace
+
+TEST(DashDaemonlessBlockData, GetBlockHeaderIsFullyAnsweredFromOwnedState) {
+    auto mc = build_mined_chain(5, /*tip_time=*/1'800'000'000u);
+    const uint32_t now = mc.tip_time + 60;
+    auto r = chain_rpc::getblockheader(*mc.hc, mc.hashes[3].GetHex(), true, now);
+
+    ASSERT_FALSE(r.contains("code")) << "this query is fully owned: " << r.dump(2);
+    EXPECT_EQ(r["hash"].get<std::string>(), mc.hashes[3].GetHex());
+    EXPECT_EQ(r["height"].get<uint32_t>(), 3u);
+    EXPECT_EQ(r["previousblockhash"].get<std::string>(), mc.hashes[2].GetHex());
+    EXPECT_EQ(r["nextblockhash"].get<std::string>(), mc.hashes[4].GetHex());
+    // 5 - 3 + 1
+    EXPECT_EQ(r["confirmations"].get<int64_t>(), 3);
+    EXPECT_TRUE(r.contains("merkleroot"));
+    EXPECT_TRUE(r.contains("time"));
+    EXPECT_TRUE(r.contains("bits"));
+    EXPECT_TRUE(r.contains("nonce"));
+    EXPECT_TRUE(r.contains("difficulty"));
+    // A fully-owned answer carries NO partial marker and NO unavailable list.
+    EXPECT_FALSE(r.contains("partial")) << r.dump(2);
+    EXPECT_FALSE(r.contains("unavailable")) << r.dump(2);
+}
+
+TEST(DashDaemonlessBlockData, GetBlockHeaderTipHasNoNextBlockHash) {
+    auto mc = build_mined_chain(4, /*tip_time=*/1'800'000'000u);
+    auto r = chain_rpc::getblockheader(*mc.hc, mc.hashes.back().GetHex(), true,
+                                       mc.tip_time + 60);
+    // Absent, never an empty string — the successor does not exist yet.
+    EXPECT_FALSE(r.contains("nextblockhash")) << r.dump(2);
+}
+
+TEST(DashDaemonlessBlockData, GetBlockHeaderNonVerboseReturnsSerialisedHex) {
+    auto mc = build_mined_chain(3, /*tip_time=*/1'800'000'000u);
+    auto r = chain_rpc::getblockheader(*mc.hc, mc.hashes[2].GetHex(), false,
+                                       mc.tip_time + 60);
+    ASSERT_TRUE(r.is_string()) << r.dump(2);
+    // A Dash header is 80 bytes on the wire.
+    EXPECT_EQ(r.get<std::string>().size(), 160u);
+}
+
+TEST(DashDaemonlessBlockData, GetBlockVerbosity1IsPartialAndNeverFakesATxList) {
+    auto mc = build_mined_chain(5, /*tip_time=*/1'800'000'000u);
+    auto r = chain_rpc::getblock(*mc.hc, mc.hashes[3].GetHex(), 1, mc.tip_time + 60);
+
+    // Not a refusal — we own most of it.
+    ASSERT_FALSE(r.contains("code")) << r.dump(2);
+    EXPECT_EQ(r["height"].get<uint32_t>(), 3u);
+    EXPECT_TRUE(r.contains("merkleroot"));
+
+    // ...but it MUST announce that it is incomplete.
+    ASSERT_TRUE(r.value("partial", false)) << r.dump(2);
+    ASSERT_TRUE(r.contains("requires")) << r.dump(2);
+
+    // THE CENTRAL ASSERTION. The withheld fields are ABSENT, not empty. If `tx`
+    // were emitted as [], a consumer reading result.tx.length would render an
+    // empty transaction table and call it data — the exact class of bug this
+    // policy exists to remove. Absent makes that consumer throw instead.
+    for (const char* f : {"tx", "nTx", "size", "strippedsize", "weight"}) {
+        EXPECT_FALSE(r.contains(f))
+            << "field '" << f << "' must be ABSENT, never a plausible empty/zero: "
+            << r.dump(2);
+        ASSERT_TRUE(r["unavailable"].contains(f)) << r.dump(2);
+        EXPECT_NE(r["unavailable"][f].get<std::string>().find("HEADERS ONLY"),
+                  std::string::npos)
+            << "each withheld field must name what we retain: " << r.dump(2);
+    }
+}
+
+TEST(DashDaemonlessBlockData, GetBlockRawAndDecodedShapesAreRefusedWithRemedies) {
+    auto mc = build_mined_chain(3, /*tip_time=*/1'800'000'000u);
+    const std::string h = mc.hashes[2].GetHex();
+
+    for (int verbosity : {0, 2}) {
+        auto r = chain_rpc::getblock(*mc.hc, h, verbosity, mc.tip_time + 60);
+        expect_is_refusal(r, chain_rpc::CODE_REQUIRES_BLOCK_BODIES);
+        // Both product choices are advertised in the payload itself, so the
+        // operator never has to consult docs to learn the way out.
+        ASSERT_TRUE(r.contains("requires")) << r.dump(2);
+        auto req = r["requires"];
+        EXPECT_NE(std::find(req.begin(), req.end(), "external-daemon-rpc"), req.end())
+            << r.dump(2);
+        EXPECT_NE(std::find(req.begin(), req.end(), "archive-mode"), req.end())
+            << r.dump(2);
+    }
+}
+
+TEST(DashDaemonlessBlockData, GetRawTransactionNamesBOTHMissingCapabilities) {
+    auto r = chain_rpc::getrawtransaction(
+        "0000000000000000000000000000000000000000000000000000000000000001");
+    expect_is_refusal(r, chain_rpc::CODE_REQUIRES_BLOCK_BODIES);
+    // Archive mode ALONE does not fix this one: without a txid->block index we
+    // still cannot find which body to open. Saying so prevents an operator
+    // paying the archive disk cost and finding the query still refuses.
+    EXPECT_EQ(r.value("also_requires", std::string()), chain_rpc::CODE_REQUIRES_TX_INDEX);
+    auto req = r["requires"];
+    EXPECT_NE(std::find(req.begin(), req.end(), "archive-mode+txindex"), req.end())
+        << r.dump(2);
+    EXPECT_EQ(std::find(req.begin(), req.end(), "archive-mode"), req.end())
+        << "plain archive-mode must NOT be offered as a sufficient remedy here: "
+        << r.dump(2);
+}
+
+TEST(DashDaemonlessBlockData, UnknownBlockHashIsChainStateNotACapabilityRefusal) {
+    auto mc = build_mined_chain(3, /*tip_time=*/1'800'000'000u);
+    auto r = chain_rpc::getblock(
+        *mc.hc,
+        "00000000000000000000000000000000000000000000000000000000deadbeef",
+        1, mc.tip_time + 60);
+    // "we do not have that block" is a fact about the CHAIN; "we cannot serve
+    // bodies" is a fact about THIS NODE. Different codes, so a caller can tell
+    // a typo from a missing feature.
+    expect_is_refusal(r, chain_rpc::CODE_CHAIN_STATE);
+    EXPECT_NE(r["error"].get<std::string>().find("not in our header index"),
+              std::string::npos) << r.dump(2);
+}
+
+TEST(DashDaemonlessBlockData, MalformedHashIsRejectedBeforeAnyLookup) {
+    auto mc = build_mined_chain(2, /*tip_time=*/1'800'000'000u);
+    auto r = chain_rpc::getblockheader(*mc.hc, "not-a-hash", true, mc.tip_time + 60);
+    expect_is_refusal(r, chain_rpc::CODE_BAD_PARAMS);
+}
+
+TEST(DashDaemonlessBlockData, StaleTipWithholdsConfirmationsRatherThanOverstateFinality) {
+    auto mc = build_mined_chain(5, /*tip_time=*/1'800'000'000u);
+    const uint32_t stale_now = mc.tip_time + 90'000u;   // > TIP_MAX_AGE_SECONDS
+    auto r = chain_rpc::getblockheader(*mc.hc, mc.hashes[2].GetHex(), true, stale_now);
+
+    // Header fields are still ours to serve — PoW does not go stale.
+    EXPECT_EQ(r["height"].get<uint32_t>(), 2u);
+    EXPECT_TRUE(r.contains("merkleroot"));
+    // But confirmations counted against a tip we know is behind would overstate
+    // burial, so it is withheld rather than computed.
+    EXPECT_FALSE(r.contains("confirmations")) << r.dump(2);
+}
+
+TEST(DashDaemonlessBlockData, DispatchRoutesEveryOwnedAndRefusedMethod) {
+    auto mc = build_mined_chain(4, /*tip_time=*/1'800'000'000u);
+    const uint32_t now = mc.tip_time + 60;
+    const std::string h = mc.hashes[3].GetHex();
+
+    auto q = [&](const char* m, nlohmann::json p) {
+        return chain_rpc::chain_query(*mc.hc, m, p, now);
+    };
+
+    // Owned.
+    EXPECT_FALSE(q("getblockheader", {h}).contains("code"));
+    EXPECT_FALSE(q("getblock", {h, 1}).contains("code"));
+    // getblock defaults to verbosity 1 when the caller omits it.
+    EXPECT_TRUE(q("getblock", {h}).value("partial", false));
+
+    // Refused, each with its own code.
+    expect_is_refusal(q("getblock", {h, 0}), chain_rpc::CODE_REQUIRES_BLOCK_BODIES);
+    expect_is_refusal(q("getblock", {h, 2}), chain_rpc::CODE_REQUIRES_BLOCK_BODIES);
+    expect_is_refusal(q("getrawtransaction", {h}), chain_rpc::CODE_REQUIRES_BLOCK_BODIES);
+    expect_is_refusal(q("getblockheader", nlohmann::json::array()), chain_rpc::CODE_BAD_PARAMS);
+    expect_is_refusal(q("getpeerinfo", nlohmann::json::array()), chain_rpc::CODE_UNKNOWN_METHOD);
+}
+
+TEST(DashDaemonlessBlockData, NoSuccessfulAnswerCarriesTheRefusalDiscriminator) {
+    // The one-predicate contract: `code` present <=> refusal. If any owned
+    // answer ever grew a `code` field the caller's check would misfire, so this
+    // sweeps every success path at once.
+    auto mc = build_mined_chain(4, /*tip_time=*/1'800'000'000u);
+    const uint32_t now = mc.tip_time + 60;
+    const std::string h = mc.hashes[2].GetHex();
+
+    for (const auto& r : {
+             chain_rpc::chain_query(*mc.hc, "getblockchaininfo", nlohmann::json::array(), now),
+             chain_rpc::chain_query(*mc.hc, "getbestblockhash", nlohmann::json::array(), now),
+             chain_rpc::chain_query(*mc.hc, "getblockhash", nlohmann::json::array({2}), now),
+             chain_rpc::chain_query(*mc.hc, "getblockheader", nlohmann::json::array({h}), now),
+             chain_rpc::chain_query(*mc.hc, "getblock", nlohmann::json::array({h, 1}), now),
+         }) {
+        if (r.is_object())
+            EXPECT_FALSE(r.contains("code"))
+                << "an ANSWER must never carry the refusal discriminator: " << r.dump(2);
+    }
 }


### PR DESCRIPTION
Task #99, parts **(a) serve** and **(b) refuse honestly**. Part **(c) archive mode** is deliberately NOT here — it is a separate change with its own disk-cost decision; design + measured estimate in the companion issue.

**Stacked on #1145** (which is stacked on #1144). Base shown as master for review convenience; the actual parent is `dash/dashboard-pplns-views`. **Sequence: #1144 → #1145 → this.** Overlap is small and additive — those two touch `main_dash.cpp` + new `dashboard_views.hpp`/`dashboard_pplns.hpp`; this touches `coin/chain_rpc.hpp`, `core/http_session.cpp` and `test/test_dash_header_chain.cpp`. No shared hunks.

## The rule

> **Absence of DATA and absence of CAPABILITY are different answers and must never share a representation.**

That is the generalisation of the bug this lane just spent a week on. Three unwired seams answered **HTTP 200 with a well-formed empty document**, so a dead view and a genuinely-empty one were byte-identical. Nothing was red — not the status, not the log, not CI. The dashboard drew blank panels for months.

So the refusal shape here is designed so a caller cannot make that mistake again.

## Classification — decided per endpoint, not lumped

| endpoint | class | source / reason |
|---|---|---|
| `getbestblockhash` | **(a) answered** | header chain tip. *Already shipped* |
| `getblockhash <h>` | **(a) answered** | height index. *Already shipped* |
| `getblockchaininfo` | **(a) answered** | header chain + honest `unavailable` list. *Already shipped* |
| `getblockheader <hash>` | **(a) answered — NEW, in full** | a header chain is exactly this query's state |
| `getblock <hash> 1` | **(a) PARTIAL — NEW** | every header field owned; txid list is not |
| `getblock <hash> 0` | **(b) refuses** | raw block = body. `REQUIRES_BLOCK_BODIES` |
| `getblock <hash> 2` | **(b) refuses** | decoded txs = bodies. `REQUIRES_BLOCK_BODIES` |
| `getrawtransaction <txid>` | **(b) refuses — needs (c)+txindex** | body **and** txid→block index |
| explorer block-detail | **(a) partial** | rides `getblock` v=1 |
| explorer tx-detail | **(b) refuses** | rides `getrawtransaction` |
| `getpeerinfo` / `getnetworkinfo` / `getmininginfo` | (a)-derivable, **not implemented here** | cheap but out of the block-data scope; `UNKNOWN_METHOD` for now |
| mempool endpoints | **not mine** | owned by #98 |

`getblock` verbosity 1 is the interesting cell, and it is why the task said *do not lump*. The merkle root **commits to** the transaction set without **revealing** it — no amount of header data reconstructs a txid list. So this is not "unimplemented", it is "completable only with bodies", and it answers 200 with the owned half plus a named account of the withheld half.

## How a caller distinguishes refusal from genuine emptiness

**Machine — one predicate:**

```js
if (status === 501 || body.code) { /* capability refusal */ }
```

`code` is present on every refusal and on **no** successful answer — pinned by a KAT that sweeps all five success paths (`NoSuccessfulAnswerCarriesTheRefusalDiscriminator`). An empty collection cannot synthesise it.

**501 over 404, deliberately:** 404 means *"that block does not exist"* — a fact about the **chain**. 501 means *"this node does not implement that"* — a fact about **this node**. Callers act on those differently, so they must not share a status. An unknown block hash therefore returns `CODE_CHAIN_STATE`, not a capability code, so a typo stays distinguishable from a missing feature.

**Human:**

```json
{
  "error": "getblock verbosity 0 (raw serialised block) requires transaction bodies;
            this node retains block HEADERS ONLY (X11+DGW validated, genesis..tip).
            Replay streams every block body through the fold and prunes it immediately,
            so no body store exists. Remedies: connect an external daemon RPC, or enable
            archive mode to retain bodies (materially larger disk footprint).",
  "code": "REQUIRES_BLOCK_BODIES",
  "requires": ["external-daemon-rpc", "archive-mode"],
  "retained": "headers-only",
  "http_status": 501,
  "method": "getblock",
  "source": "c2pool-embedded-header-chain"
}
```

The remedies are **in the payload**, so the operator never consults docs to learn the way out. `unavailable_reason` duplicates `error` for back-compat with the existing three queries' callers.

## The absent-vs-empty rule, concretely

`getblock` v=1 emits `tx`, `nTx`, `size`, `strippedsize`, `weight` as **absent** — never `[]`, never `0` — each listed under `unavailable` with its reason, with `partial: true` alongside.

Emitting `tx: []` would have recreated the exact defect this policy exists to remove: a consumer reading `result.tx.length` renders an empty transaction table and calls it data. **Absent makes that consumer throw.** That is the single most important line in the diff and it has its own KAT.

## `getrawtransaction` is refused twice over

It carries `code: REQUIRES_BLOCK_BODIES` **and** `also_requires: REQUIRES_TX_INDEX`, and its `requires` offers `archive-mode+txindex` — **not** plain `archive-mode`. Archive mode alone does not fix it: without a txid→block index we still cannot find which body to open. Offering the plain remedy would have an operator pay archive-scale disk and find the query still refusing. A KAT asserts plain `archive-mode` is *absent* from that list.

## Transport

`http_session` maps any coin-backend result carrying `code` to the status the payload names (default 501), so the wire status cannot drift from the contract. `getblock`/`getblockheader`/`getrawtransaction` now **reach** the coin hook at all — previously they fell through to daemon-proxy branches that no-op on a daemonless node, i.e. the failure mode was itself an empty answer. Both pre-existing `getblockhash` parameter errors gained the same discriminator so the surface is uniform.

## Tests

11 KATs folded into **`test_dash_header_chain`**, already an allowlisted target in `build.yml` — no `--target` edit, no `NOT_BUILT` sentinel risk (#143/#883/#893). No `#ifdef` guards (#895).

Verified locally: header is `-fsyntax-only` clean under C++20, and a standalone runner exercises the envelope (`getrawtransaction`, `refusal`, `body_remedies`) — all assertions pass. Full gtest run left to CI; `do-not-merge` until it is green and someone curls a live node.

## What is NOT in this PR

Body retention. Nothing here downloads, stores or prunes a block body — this is entirely about answering honestly with what the node already has on disk. Archive mode is the companion change, and it is what turns several of these `(b)` rows into `(a)`.
