### PR TITLE
dash(mempool): phase 1 — pull MSG_TX so the mempool FILLS, and measure coverage against dashd [do-not-merge]

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -722,7 +722,15 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              // template field diff (diagnostic; NOT a serve gate). Off the hot
              // path (worker-thread dashd fetch). Default false; only meaningful
              // when a dashd RPC oracle is reachable — a strict no-op otherwise.
-             bool embedded_shadow_compare = false)
+             bool embedded_shadow_compare = false,
+             // --embedded-mempool-ingest: arm the coin-P2P MSG_TX pull so the
+             // mempool actually FILLS. Phase 1 of c2pool's own DASH mempool
+             // (the/docs/DASH-OWN-MEMPOOL-DESIGN.md). Default false: turning it
+             // on changes what this node asks its peers for. It does NOT by
+             // itself put a single transaction into a served template — that
+             // remains --embedded-serve-mempool-txs' decision, gated on the
+             // [SHADOW-TXSET] coverage series.
+             bool embedded_mempool_ingest = false)
 {
     namespace io = boost::asio;
 
@@ -2897,6 +2905,9 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     std::unique_ptr<dash::coin::replay::ReplayCursorStore>     replay_cursor;
     std::unique_ptr<dash::coin::replay::BulkFetchLane>         replay_lane;
     std::unique_ptr<core::Timer>                               replay_timer;
+    // Phase-1 mempool-ingest telemetry (30s); constructed only under
+    // --embedded-mempool-ingest.
+    std::unique_ptr<core::Timer>                               mempool_ingest_timer;
     // W5 integration: the fold engine the lane drives, and its consumer.
     std::unique_ptr<dash::coin::replay::DmlFoldEngine>         replay_fold_engine;
     std::unique_ptr<dash::coin::replay::FoldReplayConsumer>    replay_fold_consumer;
@@ -4466,6 +4477,48 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         // Peer's reported chain height -> header-chain sync-progress gauge.
         coin_p2p->set_on_peer_height(
             [hc = header_chain.get()](uint32_t h) { hc->set_peer_tip_height(h); });
+
+        // ── PHASE-1 MEMPOOL INGEST: arm the MSG_TX pull ──────────────────
+        // Every embedded template we build today is EMPTY, and the reason is
+        // one line of policy: inv_type_is_pulled() admits only
+        // quorum_final_commitment and clsig, so a peer's inv(MSG_TX) never
+        // earned a getdata and the tx handler that feeds
+        // Mempool::add_tx was unreachable from the network. Everything below
+        // that handler already shipped in #1110.
+        //
+        // send_mempool() below has ALWAYS asked peers to announce their pool —
+        // its own comment says "our inv handler currently only pulls block
+        // invs" — so before this the prime was answered with announcements we
+        // then threw away.
+        //
+        // OFF by default. Budgeted, and strictly lower priority than the tip
+        // body. See the/docs/DASH-OWN-MEMPOOL-DESIGN.md.
+        if (embedded_mempool_ingest) {
+            coin_p2p->set_tx_pull(true, /*cap=*/64);
+            // Say what the lane is doing on a cadence: what we were offered,
+            // what we asked for, what arrived, and what the pool now holds.
+            // received==0 with getdata>0 sustained is the signature of a peer
+            // set that will not serve us transactions — a diagnosis nobody can
+            // make from an empty template alone.
+            mempool_ingest_timer =
+                std::make_unique<core::Timer>(&ioc, /*repeat=*/true);
+            mempool_ingest_timer->start(30,
+                [cp = coin_p2p.get(), &node_coin_state]() {
+                    LOG_INFO << cp->tx_ingest_status()
+                             << " pool_txs=" << node_coin_state.mempool().size()
+                             << " pool_bytes=" << node_coin_state.mempool().byte_size()
+                             << " priced_fees="
+                             << node_coin_state.mempool().total_known_fees()
+                             << " duffs";
+                });
+            std::cout << "[run] --embedded-mempool-ingest: coin-P2P MSG_TX pull"
+                         " ARMED (budget 64 in flight, yields to the tip body)."
+                         " The mempool will now FILL from the DASH network.\n"
+                      << "      This does NOT put transactions into served"
+                         " templates: that stays --embedded-serve-mempool-txs"
+                         " (default OFF), gated on the [SHADOW-TXSET]"
+                         " coverage series.\n";
+        }
 
         // Kick the initial sync once the version/verack handshake completes:
         // getheaders off our current locator + a mempool prime.
@@ -6394,6 +6447,12 @@ int main(int argc, char** argv)
     // DASH_CONNECTBLOCK_REJECT_SURFACE_AUDIT.md) arms only on explicit
     // operator decision.
     bool embedded_serve_mempool_txs = false;
+    // --embedded-mempool-ingest: arm the coin-P2P MSG_TX pull (phase 1).
+    // SEPARATE from --embedded-serve-mempool-txs on purpose: this only makes
+    // the mempool FILL. Whether its contents ever reach a served template is
+    // still the other flag's decision, and that one stays default-OFF until
+    // the [SHADOW-TXSET] coverage series says it is safe.
+    bool embedded_mempool_ingest = false;
     std::string bestcl_policy = "freshness";   // --bestcl-policy: freshness (default, conservative proxy) | consensus-exact (dashcore's actual CheckCbTxBestChainlock rule)
     bool embedded_oracle_shadow = false;       // --embedded-oracle-shadow: per-block dashd cross-check (OBSERVE-only)
     bool embedded_shadow_compare = false;      // --embedded-shadow-compare: serve-vs-dashd template diff (OBSERVE-only, NOT a gate)
@@ -6485,6 +6544,8 @@ int main(int argc, char** argv)
             embedded_utxo_immature_serve_empty = true;
         else if (std::strcmp(argv[i], "--embedded-serve-mempool-txs") == 0)
             embedded_serve_mempool_txs = true;
+        else if (std::strcmp(argv[i], "--embedded-mempool-ingest") == 0)
+            embedded_mempool_ingest = true;
         else if (std::strcmp(argv[i], "--replay-utxo-db") == 0 && i + 1 < argc)
             replay_utxo_db = argv[++i];
         else if (std::strcmp(argv[i], "--replay-utxo-hash") == 0)
@@ -6746,7 +6807,8 @@ int main(int argc, char** argv)
                         oracle_class_coverage, coin_p2p_peers, bestcl_policy,
                         embedded_utxo_immature_serve_empty,
                         embedded_serve_mempool_txs,
-                        embedded_shadow_compare);
+                        embedded_shadow_compare,
+                        embedded_mempool_ingest);
     }
     return run_selftest();
 }

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -4529,7 +4529,28 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                             " getheaders + mempool + mnlistdiff(cold)"
                          << (discover ? " + getaddr (peer crawl)" : "");
                 cp->send_getheaders(70230, hc->get_locator(), uint256::ZERO);
-                cp->send_mempool();
+                // ── BIP35 AND THE SOLE-INGESTION-PATH INVARIANT ──────────
+                // mempool.hpp names "BIP35 sync drain" as one of the seams
+                // that turns two ConnectBlock reject rows (bad-txns-nonfinal,
+                // mandatory-script-verify-flag) from N/A into GAPs. Those rows
+                // are argued N/A because every tx was RELAY-admitted: a peer
+                // validated it against the current tip and chose to announce
+                // it. A BIP35 drain is different in kind — it dumps the peer's
+                // whole pool, including entries admitted long ago under
+                // policy we cannot date.
+                //
+                // Before the MSG_TX pull existed this call was harmless: the
+                // inv handler discarded the announcements, so the drain was a
+                // no-op (its own comment said so). Arming the pull would make
+                // it live, and would silently convert those two rows into gaps
+                // without the re-audit the invariant demands.
+                //
+                // So when ingest is armed we do NOT drain: the pool fills from
+                // relay only, exactly the path the invariant is written about.
+                // The cost is cold-start latency (we learn a transaction when
+                // it is next announced, not retroactively) — minutes on a
+                // 2.5-minute chain, and it buys the audit staying true.
+                if (!cp->tx_pull_enabled()) cp->send_mempool();
                 // Peer-crawl: getaddr feeds set_addr_callback -> the isolated
                 // peer manager (addr-crawl source, +50 scored) so the diverse
                 // independent peer set grows off live wire discovery.

--- a/src/impl/dash/coin/embedded_gbt.hpp
+++ b/src/impl/dash/coin/embedded_gbt.hpp
@@ -260,6 +260,36 @@ inline DashWorkData build_embedded_workdata(
         }
         selected.resize(kept);
     }
+    // ── CANDIDATE-SET RECORDING (observe-without-arming) ────────────────
+    // When the body is deliberately coinbase-only, run the SAME selection the
+    // serving path would run and record only its identities and fees. Nothing
+    // here can reach the served template: `selected` and `total_fees` above
+    // are untouched, so the coinbase value, the tx vectors and the merkle are
+    // byte-identical to a build with this block deleted.
+    //
+    // The property the original comment asserts — "no partially-warm UTXO view
+    // can price anything into this template" — is preserved exactly: a
+    // candidate priced from a partial UTXO view lands in m_txset_candidates,
+    // which no consensus path reads.
+    if (suppress_mempool_txs) {
+        auto [cand, cand_fees] =
+            mempool.get_sorted_txs_with_fees(MAX_BLOCK_BYTES,
+                                             /*exclude_special=*/true,
+                                             /*next_height=*/w.m_height);
+        (void)cand_fees;
+        w.m_txset_candidates.reserve(cand.size());
+        w.m_txset_candidate_fees.reserve(cand.size());
+        for (const auto& c : cand) {
+            // The SAME MN-collateral exclusion the served path applies: a
+            // candidate set that included them would overstate what we could
+            // actually have served and make the coverage gate too generous.
+            uint256 protx;
+            if (tx_spends_mn_collateral(mnstates, c.tx, &protx)) continue;
+            w.m_txset_candidates.push_back(dash::coin::dash_txid(c.tx));
+            w.m_txset_candidate_fees.push_back(c.fee);
+        }
+    }
+
     int64_t block_value      = reward + static_cast<int64_t>(total_fees);
     int64_t platform_reward  = compute_dash_platform_reward_post_v20_mn_rr(
         w.m_height, mn_rr_height);

--- a/src/impl/dash/coin/embedded_shadow_compare.hpp
+++ b/src/impl/dash/coin/embedded_shadow_compare.hpp
@@ -110,6 +110,24 @@ struct ShadowFieldDiff {
     bool        commitment{false};
     bool        modulo_mempool_protx{false};
 };
+/// Which set on OUR side the measurement used.
+///   Served    — the transactions actually in the template.
+///   Candidate — what selection WOULD have chosen, recorded while the served
+///               body is deliberately coinbase-only. This is the mode the
+///               enable-the-flag gate must be evaluated in, because a
+///               measurement over the served set reads 0% by construction
+///               while the flag is off.
+enum class ShadowTxSetMode { Served, Candidate, None };
+
+inline const char* shadow_txset_mode_name(ShadowTxSetMode m)
+{
+    switch (m) {
+        case ShadowTxSetMode::Served:    return "served";
+        case ShadowTxSetMode::Candidate: return "candidate";
+        default:                         return "none";
+    }
+}
+
 /// ── THE MEMPOOL COVERAGE MEASUREMENT (phase-1 mempool ingest) ────────────
 ///
 /// While dashd is still present, its template's tx set is a free, per-block
@@ -128,6 +146,7 @@ struct ShadowFieldDiff {
 /// Diagnostic only — nothing in the served decision reads this.
 struct ShadowTxSetDiff
 {
+    ShadowTxSetMode mode{ShadowTxSetMode::None};
     size_t ours{0};
     size_t theirs{0};
     size_t both{0};
@@ -184,9 +203,26 @@ inline ShadowTxSetDiff shadow_tx_set_diff(const DashWorkData& embedded,
         }
         return out;
     };
-    const auto e = index(embedded);
+    // OUR side: the served set when there is one, otherwise the candidate set.
+    // Preference order matters — a template that actually served transactions
+    // must be measured on what it served, never on what it might have chosen.
+    auto our_index = [&index](const DashWorkData& w) {
+        auto served = index(w);
+        if (!served.empty()) return std::make_pair(served, ShadowTxSetMode::Served);
+        std::map<std::string, std::optional<uint64_t>> cand;
+        for (size_t i = 0; i < w.m_txset_candidates.size(); ++i) {
+            std::optional<uint64_t> fee;
+            if (i < w.m_txset_candidate_fees.size())
+                fee = w.m_txset_candidate_fees[i];
+            cand.emplace(w.m_txset_candidates[i].GetHex(), fee);
+        }
+        return std::make_pair(cand, cand.empty() ? ShadowTxSetMode::None
+                                                 : ShadowTxSetMode::Candidate);
+    };
+    const auto [e, e_mode] = our_index(embedded);
     const auto d = index(dashd);
     ShadowTxSetDiff r;
+    r.mode = e_mode;
     r.ours = e.size();
     r.theirs = d.size();
     for (const auto& [txid, our_fee] : e) {
@@ -362,6 +398,7 @@ inline ShadowOutcome shadow_evaluate(WorkSource source,
     o.tx_set = shadow_tx_set_diff(embedded, dashd);
     {
         std::string l = "[SHADOW-TXSET] h=" + std::to_string(o.height)
+                      + " mode=" + shadow_txset_mode_name(o.tx_set.mode)
                       + " ours=" + std::to_string(o.tx_set.ours)
                       + " dashd=" + std::to_string(o.tx_set.theirs)
                       + " both=" + std::to_string(o.tx_set.both)

--- a/src/impl/dash/coin/embedded_shadow_compare.hpp
+++ b/src/impl/dash/coin/embedded_shadow_compare.hpp
@@ -110,6 +110,66 @@ struct ShadowFieldDiff {
     bool        commitment{false};
     bool        modulo_mempool_protx{false};
 };
+/// ── THE MEMPOOL COVERAGE MEASUREMENT (phase-1 mempool ingest) ────────────
+///
+/// While dashd is still present, its template's tx set is a free, per-block
+/// answer key for our own mempool. This is the cheapest possible proof that
+/// our ingest is working and, more importantly, the gate for ever turning
+/// --embedded-serve-mempool-txs on: a wrong tx set costs a whole block, and a
+/// shadow run costs nothing.
+///
+/// The two directions are NOT symmetric:
+///   * dashd-only  — transactions dashd had and we did not. Pure REVENUE loss;
+///     the coverage number the whole mempool project is trying to move.
+///   * ours-only   — transactions WE selected and dashd did not. The dangerous
+///     direction: it means we would have built a block on something dashd's
+///     mempool rejected, did not know about, or had already seen conflict. Any
+///     sustained non-zero here BLOCKS enabling the serve flag.
+/// Diagnostic only — nothing in the served decision reads this.
+struct ShadowTxSetDiff
+{
+    size_t ours{0};
+    size_t theirs{0};
+    size_t both{0};
+    size_t dashd_only{0};   // revenue we are leaving on the table
+    size_t ours_only{0};    // the dangerous direction
+    /// theirs == 0 means dashd's own template was coinbase-only: there was no
+    /// fee to capture at this height, so the coverage ratio is undefined
+    /// rather than 0% (counting it as a miss would slander the ingest lane).
+    bool coverage_defined() const { return theirs != 0; }
+    double coverage_pct() const
+    {
+        return coverage_defined() ? (100.0 * static_cast<double>(both)
+                                     / static_cast<double>(theirs)) : 0.0;
+    }
+};
+
+inline ShadowTxSetDiff shadow_tx_set_diff(const DashWorkData& embedded,
+                                          const DashWorkData& dashd)
+{
+    auto ids = [](const DashWorkData& w) {
+        std::set<std::string> out;
+        // Identify by txid when the parallel hash vector is aligned. When it is
+        // not, report EMPTY rather than guessing: an unaligned WorkData would
+        // otherwise manufacture a coverage number out of nothing, and a
+        // fabricated measurement is worse than a missing one.
+        if (w.m_tx_hashes.size() != w.m_txs.size()) return out;
+        for (const auto& h : w.m_tx_hashes) out.insert(h.GetHex());
+        return out;
+    };
+    const auto e = ids(embedded);
+    const auto d = ids(dashd);
+    ShadowTxSetDiff r;
+    r.ours = e.size();
+    r.theirs = d.size();
+    for (const auto& t : e) {
+        if (d.count(t)) ++r.both; else ++r.ours_only;
+    }
+    r.dashd_only = r.theirs - r.both;
+    return r;
+}
+
+
 
 /// The verdict for one served height. MatchModuloMempoolProTx is the benign
 /// verdict for "every divergence is the tx-set-dependent merkleRootMNList case"
@@ -124,6 +184,9 @@ struct ShadowOutcome {
     std::string                 no_oracle_reason;
     std::vector<ShadowFieldDiff> diffs;          // diverging fields only
     bool                        served_mismatch{false}; // served && a commitment field diverged
+    /// Mempool coverage vs dashd for this height (phase-1 ingest measurement).
+    /// Zeroed on the no-oracle paths, where there is nothing to compare.
+    ShadowTxSetDiff             tx_set;
     std::vector<std::string>    log_lines;        // the [SHADOW] lines, ready to emit
 };
 
@@ -233,6 +296,27 @@ inline ShadowOutcome shadow_evaluate(WorkSource source,
         o.log_lines.push_back("[SHADOW] h=" + std::to_string(o.height)
                               + " no-oracle reason=" + o.no_oracle_reason);
         return o;
+    }
+
+    // ── MEMPOOL COVERAGE, measured against dashd's own set ───────────────
+    // Emitted for every compared height, whether or not anything diverges:
+    // the number only means something as a series.
+    o.tx_set = shadow_tx_set_diff(embedded, dashd);
+    {
+        std::string l = "[SHADOW-TXSET] h=" + std::to_string(o.height)
+                      + " ours=" + std::to_string(o.tx_set.ours)
+                      + " dashd=" + std::to_string(o.tx_set.theirs)
+                      + " both=" + std::to_string(o.tx_set.both)
+                      + " dashd_only=" + std::to_string(o.tx_set.dashd_only)
+                      + " ours_only=" + std::to_string(o.tx_set.ours_only);
+        l += o.tx_set.coverage_defined()
+                 ? " coverage=" + std::to_string(
+                       static_cast<int>(o.tx_set.coverage_pct() + 0.5)) + "%"
+                 : " coverage=n/a(dashd-template-was-coinbase-only)";
+        if (o.tx_set.ours_only)
+            l += " ⚠ OURS-ONLY txs present — do NOT enable"
+                 " --embedded-serve-mempool-txs until this is zero";
+        o.log_lines.push_back(std::move(l));
     }
 
     auto add = [&](const char* field, bool commitment,

--- a/src/impl/dash/coin/embedded_shadow_compare.hpp
+++ b/src/impl/dash/coin/embedded_shadow_compare.hpp
@@ -340,6 +340,25 @@ inline ShadowOutcome shadow_evaluate(WorkSource source,
     // ── MEMPOOL COVERAGE, measured against dashd's own set ───────────────
     // Emitted for every compared height, whether or not anything diverges:
     // the number only means something as a series.
+    //
+    // ⚠ THE "ours" SIDE IS ONLY OURS WHEN THE EMBEDDED ARM PRODUCED IT.
+    // `embedded` here is the SERVED template. When the gate declined and the
+    // node served the dashd-fallback arm, that argument IS dashd's template,
+    // and diffing it against a fresh dashd template compares dashd with
+    // itself — which reports a flawless ours=11 dashd=11 coverage=100%
+    // fee_agree=11 while our own mempool holds one transaction. Live-observed
+    // on the first soak run (h=2517157, gate cause=utxo-immature), and it is
+    // exactly the kind of self-confirming number that gets quoted as evidence.
+    // Membership and fee agreement are therefore measured ONLY when the
+    // embedded arm actually built the thing being measured; otherwise the line
+    // says why there is no measurement, and the counters stay zero.
+    if (!o.served) {
+        o.log_lines.push_back(
+            "[SHADOW-TXSET] h=" + std::to_string(o.height)
+            + " no-measurement reason=served-by-dashd-fallback"
+              " (the 'ours' side would be dashd's own template — comparing it"
+              " with dashd would report a fabricated 100%)");
+    } else {
     o.tx_set = shadow_tx_set_diff(embedded, dashd);
     {
         std::string l = "[SHADOW-TXSET] h=" + std::to_string(o.height)
@@ -370,6 +389,7 @@ inline ShadowOutcome shadow_evaluate(WorkSource source,
                  " bad-cb-amount and the block is REJECTED; do NOT enable"
                  " --embedded-serve-mempool-txs";
         o.log_lines.push_back(std::move(l));
+    }
     }
 
     auto add = [&](const char* field, bool commitment,

--- a/src/impl/dash/coin/embedded_shadow_compare.hpp
+++ b/src/impl/dash/coin/embedded_shadow_compare.hpp
@@ -133,6 +133,25 @@ struct ShadowTxSetDiff
     size_t both{0};
     size_t dashd_only{0};   // revenue we are leaving on the table
     size_t ours_only{0};    // the dangerous direction
+
+    // ── PER-TX FEE AGREEMENT — the VALUATION half ────────────────────────
+    // Membership (above) proves we HAVE the transaction. It says nothing
+    // about whether we priced it correctly, and valuation is the half that
+    // can cost a block: the coinbase may claim at most subsidy + fees, so
+    // OVERSTATING a fee is `bad-cb-amount` and the whole block is rejected,
+    // while understating merely forfeits the difference.
+    //
+    // For every tx in BOTH sets we compare our fee against dashd's. That is a
+    // direct, free, per-height proof that the prevout VALUES our UTXO view
+    // holds are right for exactly the coins a template actually spends —
+    // which is strictly less than, and much cheaper than, proving the whole
+    // chainstate with hash_serialized_2.
+    size_t fee_agree{0};
+    size_t fee_understated{0};   // ours < dashd's: forfeits money, block valid
+    size_t fee_overstated{0};    // ours > dashd's: BLOCK-LOSING. must stay 0.
+    size_t fee_unknown{0};       // a side did not report a fee for a shared tx
+    int64_t worst_overstatement{0};   // duffs, max(ours - theirs)
+    std::string worst_overstated_txid;
     /// theirs == 0 means dashd's own template was coinbase-only: there was no
     /// fee to capture at this height, so the coverage ratio is undefined
     /// rather than 0% (counting it as a miss would slander the ingest lane).
@@ -147,23 +166,43 @@ struct ShadowTxSetDiff
 inline ShadowTxSetDiff shadow_tx_set_diff(const DashWorkData& embedded,
                                           const DashWorkData& dashd)
 {
-    auto ids = [](const DashWorkData& w) {
-        std::set<std::string> out;
-        // Identify by txid when the parallel hash vector is aligned. When it is
-        // not, report EMPTY rather than guessing: an unaligned WorkData would
-        // otherwise manufacture a coverage number out of nothing, and a
-        // fabricated measurement is worse than a missing one.
+    // txid -> fee, but ONLY when the parallel vectors are aligned. When they
+    // are not, report EMPTY rather than guessing: an unaligned WorkData would
+    // otherwise manufacture a coverage number out of nothing, and a fabricated
+    // measurement is worse than a missing one. A fee is carried as optional
+    // separately from membership, because m_tx_fees may legitimately be
+    // shorter (e.g. a builder that pushed hashes but no fee for a class it
+    // does not price) and a MISSING fee must never read as a fee of zero —
+    // zero would silently look like perfect agreement on a free transaction.
+    auto index = [](const DashWorkData& w) {
+        std::map<std::string, std::optional<uint64_t>> out;
         if (w.m_tx_hashes.size() != w.m_txs.size()) return out;
-        for (const auto& h : w.m_tx_hashes) out.insert(h.GetHex());
+        for (size_t i = 0; i < w.m_tx_hashes.size(); ++i) {
+            std::optional<uint64_t> fee;
+            if (i < w.m_tx_fees.size()) fee = w.m_tx_fees[i];
+            out.emplace(w.m_tx_hashes[i].GetHex(), fee);
+        }
         return out;
     };
-    const auto e = ids(embedded);
-    const auto d = ids(dashd);
+    const auto e = index(embedded);
+    const auto d = index(dashd);
     ShadowTxSetDiff r;
     r.ours = e.size();
     r.theirs = d.size();
-    for (const auto& t : e) {
-        if (d.count(t)) ++r.both; else ++r.ours_only;
+    for (const auto& [txid, our_fee] : e) {
+        auto it = d.find(txid);
+        if (it == d.end()) { ++r.ours_only; continue; }
+        ++r.both;
+        if (!our_fee || !it->second) { ++r.fee_unknown; continue; }
+        const uint64_t ours_f = *our_fee, theirs_f = *it->second;
+        if (ours_f == theirs_f) { ++r.fee_agree; continue; }
+        if (ours_f < theirs_f) { ++r.fee_understated; continue; }
+        ++r.fee_overstated;
+        const int64_t over = static_cast<int64_t>(ours_f - theirs_f);
+        if (over > r.worst_overstatement) {
+            r.worst_overstatement    = over;
+            r.worst_overstated_txid  = txid;
+        }
     }
     r.dashd_only = r.theirs - r.both;
     return r;
@@ -313,9 +352,23 @@ inline ShadowOutcome shadow_evaluate(WorkSource source,
                  ? " coverage=" + std::to_string(
                        static_cast<int>(o.tx_set.coverage_pct() + 0.5)) + "%"
                  : " coverage=n/a(dashd-template-was-coinbase-only)";
+        // The VALUATION half, always reported alongside membership: a soak
+        // that compares only tx SETS proves membership, not pricing, and
+        // pricing is the half that can cost a block.
+        l += " fee_agree=" + std::to_string(o.tx_set.fee_agree)
+           + " fee_under=" + std::to_string(o.tx_set.fee_understated)
+           + " fee_over=" + std::to_string(o.tx_set.fee_overstated)
+           + " fee_unknown=" + std::to_string(o.tx_set.fee_unknown);
         if (o.tx_set.ours_only)
             l += " ⚠ OURS-ONLY txs present — do NOT enable"
                  " --embedded-serve-mempool-txs until this is zero";
+        if (o.tx_set.fee_overstated)
+            l += " ⚠⚠ FEE OVERSTATED on " + std::to_string(o.tx_set.fee_overstated)
+               + " tx (worst +" + std::to_string(o.tx_set.worst_overstatement)
+               + " duffs, " + o.tx_set.worst_overstated_txid.substr(0, 16)
+               + ") — a coinbase claiming more than subsidy+fees is"
+                 " bad-cb-amount and the block is REJECTED; do NOT enable"
+                 " --embedded-serve-mempool-txs";
         o.log_lines.push_back(std::move(l));
     }
 

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -630,6 +630,48 @@ private:
     // Collapses the N-peer inv fan-in to one getdata. Bounded + expiring.
     InvDedup m_inv_dedup;
 
+    /// Reclaim tx-pull slots whose getdata was never answered. Without this a
+    /// peer that goes quiet after announcing permanently consumes the budget.
+    void expire_tx_pulls(int64_t now)
+    {
+        for (auto it = m_tx_pull_inflight.begin(); it != m_tx_pull_inflight.end(); ) {
+            if (now - it->second > TX_PULL_TIMEOUT_SEC) {
+                it = m_tx_pull_inflight.erase(it);
+                ++m_tx_pull_expired;
+            } else {
+                ++it;
+            }
+        }
+    }
+
+    // ── MEMPOOL INGEST (phase 1): the MSG_TX pull ────────────────────────
+    // The whole reason every embedded template is EMPTY. inv_type_is_pulled()
+    // admits quorum_final_commitment and clsig only, so a peer's inv(MSG_TX)
+    // was dropped without a getdata, the `tx` handler below never fired, and
+    // Mempool::add_tx was unreachable FROM THE NETWORK. Everything downstream
+    // of that handler already exists (#1110).
+    //
+    // Not simply added to inv_type_is_pulled: tx invs arrive orders of
+    // magnitude more often than blocks or clsigs, so an unbudgeted pull lets
+    // a peer make us getdata-flood ourselves. This lane is therefore:
+    //   * OPT-IN                (m_tx_pull_enabled, --embedded-mempool-ingest)
+    //   * BUDGETED              (m_tx_pull_inflight_cap outstanding at once)
+    //   * STRICTLY LOWER PRIORITY than the tip body — no tx getdata is issued
+    //     while a tracked block body is outstanding, the same invariant the
+    //     bulk-fetch lane observes.
+    // In-flight slots expire on their own (TX_PULL_TIMEOUT_SEC) so a peer that
+    // answers a getdata with silence cannot wedge the budget.
+    static constexpr int64_t TX_PULL_TIMEOUT_SEC = 60;
+    bool     m_tx_pull_enabled{false};
+    size_t   m_tx_pull_inflight_cap{64};
+    std::map<uint256, int64_t> m_tx_pull_inflight;   // txid -> requested-at
+    uint64_t m_tx_inv_seen{0};       // inv(MSG_TX) admitted by the dedup
+    uint64_t m_tx_pull_sent{0};      // getdata(MSG_TX) issued
+    uint64_t m_tx_pull_skipped_budget{0};
+    uint64_t m_tx_pull_skipped_busy{0};
+    uint64_t m_tx_received{0};       // tx bodies that arrived
+    uint64_t m_tx_pull_expired{0};   // getdata that never got an answer
+
     // ── SPORK listener (state + telemetry ONLY — nothing gates on it) ────
     // Seeded with the assume-active mainnet defaults (7/7 active, matching
     // dashd's hardened mainnet spork values), refined by VERIFIED spork
@@ -1279,6 +1321,36 @@ public:
         auto msg = message_mempool::make_raw();
         m_primary->write(msg);
     }
+
+    /// Arm the MSG_TX pull (phase-1 mempool ingest). OFF by default: turning it
+    /// on changes what this node asks its peers for, so it is an explicit
+    /// operator decision (--embedded-mempool-ingest), not a side effect of
+    /// running a newer build. `cap` bounds outstanding tx getdata.
+    void set_tx_pull(bool on, size_t cap = 64)
+    {
+        m_tx_pull_enabled      = on;
+        m_tx_pull_inflight_cap = cap ? cap : 1;
+        if (!on) m_tx_pull_inflight.clear();
+    }
+    bool tx_pull_enabled() const { return m_tx_pull_enabled; }
+
+    /// One greppable line: what the ingest lane asked for and what it got.
+    /// received < pull_sent is normal (notfound, races, peers that drop);
+    /// received == 0 with pull_sent > 0 for a sustained period is the
+    /// signature of a peer set that will not serve us transactions.
+    std::string tx_ingest_status() const
+    {
+        return "[MEMPOOL-INGEST] tx_inv=" + std::to_string(m_tx_inv_seen)
+             + " getdata=" + std::to_string(m_tx_pull_sent)
+             + " received=" + std::to_string(m_tx_received)
+             + " inflight=" + std::to_string(m_tx_pull_inflight.size())
+             + "/" + std::to_string(m_tx_pull_inflight_cap)
+             + " skipped(budget)=" + std::to_string(m_tx_pull_skipped_budget)
+             + " skipped(tip-body-busy)=" + std::to_string(m_tx_pull_skipped_busy)
+             + " expired=" + std::to_string(m_tx_pull_expired);
+    }
+    uint64_t tx_received_count() const { return m_tx_received; }
+    size_t   tx_pull_inflight()  const { return m_tx_pull_inflight.size(); }
 
     /// Request a full block via plain MSG_BLOCK getdata (E2 pull seam).
     /// Routed to the peer that ANNOUNCED this block (block_source), which holds
@@ -2164,7 +2236,9 @@ private:
         {
             const bool pulled = inv_type_is_pulled(inv.m_type);
             const bool is_block = (inv.base_type() == inventory_type::block);
-            if (!pulled && !is_block)
+            const bool is_tx = (inv.base_type() == inventory_type::tx)
+                            && m_tx_pull_enabled;
+            if (!pulled && !is_block && !is_tx)
                 continue;   // not actionable — do not spend a dedup slot on it
             if (!m_inv_dedup.admit(static_cast<uint32_t>(inv.m_type), inv.m_hash, now))
             {
@@ -2201,6 +2275,29 @@ private:
                 p->write(getdata_msg);
                 continue;
             }
+            if (is_tx)
+            {
+                ++m_tx_inv_seen;
+                expire_tx_pulls(now);
+                // STRICT PRIORITY: the tip body always wins. A transaction is
+                // worth a fraction of a block's fees; a late tip body is a
+                // stale template on every attached rig.
+                if (!m_pending_bodies.empty()) {
+                    ++m_tx_pull_skipped_busy;
+                    continue;
+                }
+                if (m_tx_pull_inflight.size() >= m_tx_pull_inflight_cap) {
+                    ++m_tx_pull_skipped_budget;
+                    continue;
+                }
+                if (m_tx_pull_inflight.count(inv.m_hash)) continue;
+                m_tx_pull_inflight.emplace(inv.m_hash, now);
+                ++m_tx_pull_sent;
+                auto getdata_msg = message_getdata::make_raw(
+                    {inventory_type(inventory_type::tx, inv.m_hash)});
+                p->write(getdata_msg);
+                continue;
+            }
             LOG_INFO << "[" << m_chain_label << "] block inv "
                      << inv.m_hash.GetHex().substr(0, 16) << "... from " << p->key;
             // Remember WHO announced it: the body/headers pull the new_block
@@ -2213,6 +2310,22 @@ private:
 
     ADD_P2P_HANDLER(tx)
     {
+        ++m_tx_received;
+        // Release the budget slot. The txid is the SHA256d of the serialized
+        // body; computing it here (rather than trusting the announcement we
+        // asked for) means an unsolicited or substituted body cannot free a
+        // slot it never occupied.
+        {
+            ::PackStream ps;
+            ps << msg->m_tx;
+            auto sp = ps.get_span();
+            uint256 txid;
+            CHash256()
+                .Write(std::span<const unsigned char>(
+                    reinterpret_cast<const unsigned char*>(sp.data()), sp.size()))
+                .Finalize(std::span<unsigned char>(txid.data(), 32));
+            m_tx_pull_inflight.erase(txid);
+        }
         m_coin->new_tx.happened(Transaction(msg->m_tx));
     }
 

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -665,6 +665,7 @@ private:
     bool     m_tx_pull_enabled{false};
     size_t   m_tx_pull_inflight_cap{64};
     std::map<uint256, int64_t> m_tx_pull_inflight;   // txid -> requested-at
+    uint64_t m_tx_inv_offered{0};    // inv(MSG_TX) SEEN on the wire, pre-dedup
     uint64_t m_tx_inv_seen{0};       // inv(MSG_TX) admitted by the dedup
     uint64_t m_tx_pull_sent{0};      // getdata(MSG_TX) issued
     uint64_t m_tx_pull_skipped_budget{0};
@@ -1340,7 +1341,8 @@ public:
     /// signature of a peer set that will not serve us transactions.
     std::string tx_ingest_status() const
     {
-        return "[MEMPOOL-INGEST] tx_inv=" + std::to_string(m_tx_inv_seen)
+        return "[MEMPOOL-INGEST] tx_inv_offered=" + std::to_string(m_tx_inv_offered)
+             + " tx_inv=" + std::to_string(m_tx_inv_seen)
              + " getdata=" + std::to_string(m_tx_pull_sent)
              + " received=" + std::to_string(m_tx_received)
              + " inflight=" + std::to_string(m_tx_pull_inflight.size())
@@ -2238,6 +2240,11 @@ private:
             const bool is_block = (inv.base_type() == inventory_type::block);
             const bool is_tx = (inv.base_type() == inventory_type::tx)
                             && m_tx_pull_enabled;
+            // Offered-vs-admitted (diagnosis, not policy): counted BEFORE the
+            // dedup so "peers are not announcing" can be told apart from "we
+            // are filtering". Same announcement from N peers = N offered, 1
+            // admitted — that gap is the fan-in the pool exists to produce.
+            if (inv.base_type() == inventory_type::tx) ++m_tx_inv_offered;
             if (!pulled && !is_block && !is_tx)
                 continue;   // not actionable — do not spend a dedup slot on it
             if (!m_inv_dedup.admit(static_cast<uint32_t>(inv.m_type), inv.m_hash, now))

--- a/src/impl/dash/coin/rpc_data.hpp
+++ b/src/impl/dash/coin/rpc_data.hpp
@@ -127,6 +127,22 @@ struct DashWorkData {
     // special, and MN-collateral-spending txs), so read it as "at most this much".
     std::string m_txset_empty_cause;
     uint64_t    m_txset_forgone_fees{0};
+
+    // ── THE CANDIDATE SET (observe-without-arming) ────────────────────────
+    // What selection WOULD have chosen, recorded when the served body is
+    // deliberately coinbase-only. NEVER served: these ids/fees are not in
+    // m_txs, m_tx_hashes, m_tx_fees or m_tx_data_hex, contribute nothing to
+    // m_coinbase_value, and no consensus path reads them.
+    //
+    // They exist because the gate that must pass BEFORE fee-carrying
+    // templates are enabled cannot be evaluated from templates built while
+    // that flag is OFF: the served set is empty by construction, so a
+    // coverage measurement over it reads 0% forever and the only ways left to
+    // evaluate the gate are to arm the money path first (exactly what the
+    // gate prevents) or to enable on faith. Measuring the candidate set is
+    // what makes the fee lane completable at all.
+    std::vector<uint256>  m_txset_candidates;
+    std::vector<uint64_t> m_txset_candidate_fees;
 };
 
 } // namespace coin

--- a/test/test_dash_embedded_shadow_compare.cpp
+++ b/test/test_dash_embedded_shadow_compare.cpp
@@ -352,3 +352,112 @@ TEST(DashShadowCompare, MatchingRootsWithDifferentTxSetsIsStillMatch) {
     EXPECT_EQ(o.kind, ShadowOutcome::Kind::Match);
     EXPECT_FALSE(o.served_mismatch);
 }
+
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PHASE-1 MEMPOOL INGEST — the coverage measurement
+//
+// While dashd is present its template's tx set is a free, per-block answer key
+// for our own mempool. This is the gate for ever enabling
+// --embedded-serve-mempool-txs: a wrong tx set costs a whole block, a shadow
+// run costs nothing. The two directions are not symmetric — dashd-only is
+// revenue we are forfeiting, ours-only is a block we might lose.
+// ═══════════════════════════════════════════════════════════════════════════
+namespace {
+// Attach a tx set to a WorkData the way the builder does: m_txs and
+// m_tx_hashes are PARALLEL, and shadow_tx_set_diff refuses to measure when
+// they are not (see the KAT below).
+void with_txs(DashWorkData& w, const std::vector<uint8_t>& seeds) {
+    w.m_txs.clear();
+    w.m_tx_hashes.clear();
+    for (uint8_t sd : seeds) {
+        MutableTransaction t;
+        t.version = 2;
+        w.m_txs.emplace_back(t);
+        w.m_tx_hashes.push_back(hashn(sd));
+    }
+}
+} // namespace
+
+TEST(DashShadowCompare, TxSetCoverageIsMeasuredAgainstDashd) {
+    auto cb = make_cbtx(2500000, 11, 22);
+    auto emb  = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    auto dref = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    // dashd has five; we ingested three of them.
+    with_txs(emb,  {1, 2, 3});
+    with_txs(dref, {1, 2, 3, 4, 5});
+
+    const auto d = shadow_tx_set_diff(emb, dref);
+    EXPECT_EQ(d.ours, 3u);
+    EXPECT_EQ(d.theirs, 5u);
+    EXPECT_EQ(d.both, 3u);
+    EXPECT_EQ(d.dashd_only, 2u);      // the fees we are still forfeiting
+    EXPECT_EQ(d.ours_only, 0u);       // the safe direction
+    EXPECT_TRUE(d.coverage_defined());
+    EXPECT_NEAR(d.coverage_pct(), 60.0, 1e-9);
+
+    const auto o = shadow_evaluate(WorkSource::Embedded, emb,
+                                   std::optional<DashWorkData>(dref));
+    EXPECT_TRUE(has_line_with(o.log_lines, "[SHADOW-TXSET]"));
+    EXPECT_TRUE(has_line_with(o.log_lines, "coverage=60%"));
+    EXPECT_TRUE(has_line_with(o.log_lines, "dashd_only=2"));
+    // The measurement is a DIAGNOSTIC: a coverage shortfall is not a mismatch.
+    EXPECT_FALSE(o.served_mismatch);
+}
+
+// The dangerous direction is called out in the line itself, because the
+// operator reads the line, not the struct.
+TEST(DashShadowCompare, TxWeHaveThatDashdDoesNotIsFlaggedLoudly) {
+    auto cb = make_cbtx(2500000, 11, 22);
+    auto emb  = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    auto dref = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    with_txs(emb,  {1, 2, 9});        // 9 is ours alone
+    with_txs(dref, {1, 2, 3});
+
+    const auto d = shadow_tx_set_diff(emb, dref);
+    EXPECT_EQ(d.ours_only, 1u);
+    EXPECT_EQ(d.dashd_only, 1u);
+
+    const auto o = shadow_evaluate(WorkSource::Embedded, emb,
+                                   std::optional<DashWorkData>(dref));
+    EXPECT_TRUE(has_line_with(o.log_lines, "ours_only=1"));
+    EXPECT_TRUE(has_line_with(o.log_lines, "OURS-ONLY"));
+    EXPECT_TRUE(has_line_with(o.log_lines,
+                              "do NOT enable --embedded-serve-mempool-txs"));
+}
+
+// A coinbase-only dashd template means there was no fee to capture at this
+// height. Reporting that as 0% coverage would slander a working ingest lane,
+// so coverage is UNDEFINED, and the line says so.
+TEST(DashShadowCompare, CoverageIsUndefinedWhenDashdHadNoTxsEither) {
+    auto cb = make_cbtx(2500000, 11, 22);
+    auto emb  = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    auto dref = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+
+    const auto d = shadow_tx_set_diff(emb, dref);
+    EXPECT_EQ(d.theirs, 0u);
+    EXPECT_FALSE(d.coverage_defined());
+    EXPECT_EQ(d.dashd_only, 0u);
+
+    const auto o = shadow_evaluate(WorkSource::Embedded, emb,
+                                   std::optional<DashWorkData>(dref));
+    EXPECT_TRUE(has_line_with(o.log_lines, "coverage=n/a"));
+}
+
+// An unaligned WorkData must produce NO measurement rather than a fabricated
+// one. A wrong number here would be read as evidence and acted on.
+TEST(DashShadowCompare, UnalignedTxHashesMeasureNothingRatherThanGuess) {
+    auto cb = make_cbtx(2500000, 11, 22);
+    auto emb  = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    auto dref = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    with_txs(dref, {1, 2, 3});
+    with_txs(emb,  {1, 2, 3});
+    emb.m_tx_hashes.pop_back();       // parallel vectors no longer aligned
+
+    const auto d = shadow_tx_set_diff(emb, dref);
+    EXPECT_EQ(d.ours, 0u) << "an unaligned tx set must not be measured";
+    EXPECT_EQ(d.ours_only, 0u)
+        << "and must never manufacture the dangerous direction";
+    EXPECT_EQ(d.theirs, 3u);
+    EXPECT_EQ(d.dashd_only, 3u);
+}

--- a/test/test_dash_embedded_shadow_compare.cpp
+++ b/test/test_dash_embedded_shadow_compare.cpp
@@ -370,12 +370,19 @@ namespace {
 void with_txs(DashWorkData& w, const std::vector<uint8_t>& seeds) {
     w.m_txs.clear();
     w.m_tx_hashes.clear();
+    w.m_tx_fees.clear();
     for (uint8_t sd : seeds) {
         MutableTransaction t;
         t.version = 2;
         w.m_txs.emplace_back(t);
         w.m_tx_hashes.push_back(hashn(sd));
+        w.m_tx_fees.push_back(1000ull * sd);      // deterministic per-txid fee
     }
+}
+// Same set, but our side prices one tx differently from dashd.
+void reprice(DashWorkData& w, uint8_t seed, uint64_t fee) {
+    for (size_t i = 0; i < w.m_tx_hashes.size(); ++i)
+        if (w.m_tx_hashes[i] == hashn(seed)) w.m_tx_fees[i] = fee;
 }
 } // namespace
 
@@ -460,4 +467,100 @@ TEST(DashShadowCompare, UnalignedTxHashesMeasureNothingRatherThanGuess) {
         << "and must never manufacture the dangerous direction";
     EXPECT_EQ(d.theirs, 3u);
     EXPECT_EQ(d.dashd_only, 3u);
+}
+
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PER-TX FEE AGREEMENT — the VALUATION half of the gate
+//
+// Membership proves we HAVE the transaction. It says nothing about whether we
+// priced it right, and pricing is the half that can cost a block: a coinbase
+// may claim at most subsidy + fees, so OVERSTATING is bad-cb-amount and the
+// block is rejected, while understating merely forfeits the difference.
+//
+// This is also the cheap maturity proof for the UTXO lane: agreement on the
+// coins a template actually spends is strictly less than, and far cheaper
+// than, proving the whole chainstate with hash_serialized_2.
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashShadowCompare, PerTxFeeAgreementIsCountedForSharedTxs) {
+    auto cb = make_cbtx(2500000, 11, 22);
+    auto emb  = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    auto dref = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    with_txs(emb,  {1, 2, 3});
+    with_txs(dref, {1, 2, 3, 4});
+
+    const auto d = shadow_tx_set_diff(emb, dref);
+    EXPECT_EQ(d.both, 3u);
+    EXPECT_EQ(d.fee_agree, 3u);         // identical pricing on all shared txs
+    EXPECT_EQ(d.fee_overstated, 0u);
+    EXPECT_EQ(d.fee_understated, 0u);
+
+    const auto o = shadow_evaluate(WorkSource::Embedded, emb,
+                                   std::optional<DashWorkData>(dref));
+    EXPECT_TRUE(has_line_with(o.log_lines, "fee_agree=3"));
+    EXPECT_TRUE(has_line_with(o.log_lines, "fee_over=0"));
+}
+
+// UNDERSTATING forfeits money and keeps the block valid — counted, not alarmed.
+TEST(DashShadowCompare, UnderstatedFeeIsCountedButNotAlarmed) {
+    auto cb = make_cbtx(2500000, 11, 22);
+    auto emb  = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    auto dref = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    with_txs(emb,  {1, 2});
+    with_txs(dref, {1, 2});
+    reprice(emb, 2, 500);               // dashd says 2000, we say 500
+
+    const auto d = shadow_tx_set_diff(emb, dref);
+    EXPECT_EQ(d.fee_understated, 1u);
+    EXPECT_EQ(d.fee_overstated, 0u);
+
+    const auto o = shadow_evaluate(WorkSource::Embedded, emb,
+                                   std::optional<DashWorkData>(dref));
+    EXPECT_TRUE(has_line_with(o.log_lines, "fee_under=1"));
+    EXPECT_FALSE(has_line_with(o.log_lines, "FEE OVERSTATED"))
+        << "understating is a revenue loss, not a block loss — do not cry wolf";
+}
+
+// OVERSTATING is the block-losing direction and the line must say so, with the
+// txid and the magnitude, because that is what an operator acts on.
+TEST(DashShadowCompare, OverstatedFeeIsTheBlockLosingDirectionAndSaysSo) {
+    auto cb = make_cbtx(2500000, 11, 22);
+    auto emb  = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    auto dref = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    with_txs(emb,  {1, 2});
+    with_txs(dref, {1, 2});
+    reprice(emb, 2, 9000);              // dashd says 2000, we claim 9000
+
+    const auto d = shadow_tx_set_diff(emb, dref);
+    EXPECT_EQ(d.fee_overstated, 1u);
+    EXPECT_EQ(d.worst_overstatement, 7000);
+    EXPECT_EQ(d.worst_overstated_txid, hashn(2).GetHex());
+
+    const auto o = shadow_evaluate(WorkSource::Embedded, emb,
+                                   std::optional<DashWorkData>(dref));
+    EXPECT_TRUE(has_line_with(o.log_lines, "fee_over=1"));
+    EXPECT_TRUE(has_line_with(o.log_lines, "FEE OVERSTATED"));
+    EXPECT_TRUE(has_line_with(o.log_lines, "+7000 duffs"));
+    EXPECT_TRUE(has_line_with(o.log_lines, "bad-cb-amount"));
+    EXPECT_TRUE(has_line_with(o.log_lines,
+                              "do NOT enable --embedded-serve-mempool-txs"));
+}
+
+// A MISSING fee must never read as a fee of zero — zero would look like
+// perfect agreement on a free transaction and hide the very gap we are
+// measuring.
+TEST(DashShadowCompare, MissingFeeIsUnknownNotZero) {
+    auto cb = make_cbtx(2500000, 11, 22);
+    auto emb  = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    auto dref = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    with_txs(emb,  {1, 2});
+    with_txs(dref, {1, 2});
+    emb.m_tx_fees.pop_back();           // we have the tx but priced nothing
+
+    const auto d = shadow_tx_set_diff(emb, dref);
+    EXPECT_EQ(d.both, 2u);
+    EXPECT_EQ(d.fee_unknown, 1u);
+    EXPECT_EQ(d.fee_agree, 1u);
+    EXPECT_EQ(d.fee_overstated, 0u)
+        << "an absent fee must not be scored as agreement OR as overstatement";
 }

--- a/test/test_dash_embedded_shadow_compare.cpp
+++ b/test/test_dash_embedded_shadow_compare.cpp
@@ -564,3 +564,40 @@ TEST(DashShadowCompare, MissingFeeIsUnknownNotZero) {
     EXPECT_EQ(d.fee_overstated, 0u)
         << "an absent fee must not be scored as agreement OR as overstatement";
 }
+
+
+// ═══════════════════════════════════════════════════════════════════════════
+// THE SELF-CONFIRMING MEASUREMENT — caught on the first live soak
+//
+// shadow_evaluate's `embedded` argument is the SERVED template. When the gate
+// declines and the node serves the dashd-fallback arm, that argument IS
+// dashd's template, and diffing it against a fresh dashd template compares
+// dashd with itself. Live at h=2517157 (gate cause=utxo-immature) it reported
+//     ours=11 dashd=11 both=11 coverage=100% fee_agree=11
+// while our own mempool held ONE transaction. A number like that gets quoted.
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashShadowCompare, NoCoverageMeasurementWhenServedByTheFallbackArm) {
+    auto cb = make_cbtx(2500000, 11, 22);
+    auto served = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    auto dref   = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    // The fallback case: the served template IS dashd's, so both sides match
+    // perfectly — which is precisely why it must not be reported as coverage.
+    with_txs(served, {1, 2, 3, 4, 5});
+    with_txs(dref,   {1, 2, 3, 4, 5});
+
+    const auto o = shadow_evaluate(WorkSource::DashdFallback, served,
+                                   std::optional<DashWorkData>(dref));
+    EXPECT_TRUE(has_line_with(o.log_lines, "no-measurement"));
+    EXPECT_TRUE(has_line_with(o.log_lines, "served-by-dashd-fallback"));
+    EXPECT_FALSE(has_line_with(o.log_lines, "coverage=100%"))
+        << "dashd compared with itself must never be reported as coverage";
+    EXPECT_EQ(o.tx_set.both, 0u)   << "counters must stay zero, not flattering";
+    EXPECT_EQ(o.tx_set.fee_agree, 0u);
+
+    // ... and the SAME inputs, when the embedded arm really did build it, ARE
+    // measured. The guard keys on provenance, not on the numbers.
+    const auto o2 = shadow_evaluate(WorkSource::Embedded, served,
+                                    std::optional<DashWorkData>(dref));
+    EXPECT_TRUE(has_line_with(o2.log_lines, "coverage=100%"));
+    EXPECT_EQ(o2.tx_set.fee_agree, 5u);
+}

--- a/test/test_dash_embedded_shadow_compare.cpp
+++ b/test/test_dash_embedded_shadow_compare.cpp
@@ -601,3 +601,101 @@ TEST(DashShadowCompare, NoCoverageMeasurementWhenServedByTheFallbackArm) {
     EXPECT_TRUE(has_line_with(o2.log_lines, "coverage=100%"));
     EXPECT_EQ(o2.tx_set.fee_agree, 5u);
 }
+
+
+// ═══════════════════════════════════════════════════════════════════════════
+// THE CANDIDATE SET — measuring the gate from the correct side of it
+//
+// The third trap: a measurement built over the SERVED tx set cannot evaluate
+// the gate that decides whether to serve. With --embedded-serve-mempool-txs
+// OFF the served set is empty BY CONSTRUCTION, so coverage reads 0% forever
+// however full the mempool is, and the only remaining ways to evaluate the
+// gate are to arm the money path first (what the gate exists to prevent) or to
+// enable on faith. Measuring what selection WOULD have chosen fixes that
+// without putting a single byte into a served template.
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashShadowCompare, CandidateSetIsMeasuredWhenTheServedBodyIsCoinbaseOnly) {
+    auto cb = make_cbtx(2500000, 11, 22);
+    auto emb  = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    auto dref = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    with_txs(dref, {1, 2, 3, 4});
+    // Served body is coinbase-only (the flag is off) but selection recorded
+    // what it would have taken.
+    emb.m_txset_candidates      = {hashn(1), hashn(2), hashn(3)};
+    emb.m_txset_candidate_fees  = {1000, 2000, 3000};
+    ASSERT_TRUE(emb.m_txs.empty());
+
+    const auto d = shadow_tx_set_diff(emb, dref);
+    EXPECT_EQ(d.mode, ShadowTxSetMode::Candidate);
+    EXPECT_EQ(d.ours, 3u);
+    EXPECT_EQ(d.both, 3u);
+    EXPECT_EQ(d.dashd_only, 1u);
+    EXPECT_EQ(d.ours_only, 0u);
+    EXPECT_EQ(d.fee_agree, 3u);           // priced identically to dashd
+    EXPECT_NEAR(d.coverage_pct(), 75.0, 1e-9);
+
+    const auto o = shadow_evaluate(WorkSource::Embedded, emb,
+                                   std::optional<DashWorkData>(dref));
+    EXPECT_TRUE(has_line_with(o.log_lines, "mode=candidate"));
+    EXPECT_TRUE(has_line_with(o.log_lines, "coverage=75%"));
+}
+
+// A template that ACTUALLY served transactions is measured on what it served,
+// never on what it might have chosen — otherwise a stale candidate list could
+// flatter a template whose real contents were worse.
+TEST(DashShadowCompare, ServedSetWinsOverCandidatesWhenBothArePresent) {
+    auto cb = make_cbtx(2500000, 11, 22);
+    auto emb  = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    auto dref = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    with_txs(emb,  {1});                  // we actually served ONE
+    with_txs(dref, {1, 2, 3, 4});
+    emb.m_txset_candidates     = {hashn(1), hashn(2), hashn(3)};  // flattering
+    emb.m_txset_candidate_fees = {1000, 2000, 3000};
+
+    const auto d = shadow_tx_set_diff(emb, dref);
+    EXPECT_EQ(d.mode, ShadowTxSetMode::Served);
+    EXPECT_EQ(d.ours, 1u) << "the served set is the truth about a served template";
+    EXPECT_EQ(d.dashd_only, 3u);
+
+    const auto o = shadow_evaluate(WorkSource::Embedded, emb,
+                                   std::optional<DashWorkData>(dref));
+    EXPECT_TRUE(has_line_with(o.log_lines, "mode=served"));
+}
+
+// Nothing on either side: mode=none, and no fabricated coverage.
+TEST(DashShadowCompare, NoServedAndNoCandidatesIsModeNone) {
+    auto cb = make_cbtx(2500000, 11, 22);
+    auto emb  = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    auto dref = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    with_txs(dref, {1, 2});
+
+    const auto d = shadow_tx_set_diff(emb, dref);
+    EXPECT_EQ(d.mode, ShadowTxSetMode::None);
+    EXPECT_EQ(d.ours, 0u);
+    EXPECT_EQ(d.dashd_only, 2u);
+    const auto o = shadow_evaluate(WorkSource::Embedded, emb,
+                                   std::optional<DashWorkData>(dref));
+    EXPECT_TRUE(has_line_with(o.log_lines, "mode=none"));
+}
+
+// The candidate path must still refuse the dangerous direction: a candidate we
+// hold that dashd does not is exactly as disqualifying as a served one, because
+// it is what we WOULD have put in a block.
+TEST(DashShadowCompare, CandidateOursOnlyIsStillFlagged) {
+    auto cb = make_cbtx(2500000, 11, 22);
+    auto emb  = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    auto dref = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    with_txs(dref, {1, 2});
+    emb.m_txset_candidates     = {hashn(1), hashn(9)};   // 9 is ours alone
+    emb.m_txset_candidate_fees = {1000, 9000};
+
+    const auto d = shadow_tx_set_diff(emb, dref);
+    EXPECT_EQ(d.mode, ShadowTxSetMode::Candidate);
+    EXPECT_EQ(d.ours_only, 1u);
+
+    const auto o = shadow_evaluate(WorkSource::Embedded, emb,
+                                   std::optional<DashWorkData>(dref));
+    EXPECT_TRUE(has_line_with(o.log_lines, "OURS-ONLY"));
+    EXPECT_TRUE(has_line_with(o.log_lines,
+                              "do NOT enable --embedded-serve-mempool-txs"));
+}


### PR DESCRIPTION
## Phase 1 of c2pool's own DASH mempool — make it FILL, and measure what it costs us

Design note: **`the/docs/DASH-OWN-MEMPOOL-DESIGN.md`** (pushed to `frstrtr/the`).

Operator's framing: *"we need our own mempool fully functional and not
dependant to dashd — this is a money path — without mempool we are loosing now
small but in the future significant amount of fees!"*

Live on production right now, every template:

```
[GBT-EMB] arm=EMBEDDED txset=empty cause=mempool-txs-disabled h=… mempool_tx=0 forgone_fees<=0 sat
```

### The cause is one line of policy, not missing machinery

**#1110 already did ~70 % of this job.** `Mempool` is bounded, feerate-indexed,
topologically package-selecting, sigop-accounting, coinbase-maturity-guarded,
InstantSend-conflict-aware, and prices fees from UTXO / CPFP / DIP-0027 payload.
The ingest leg is wired end to end (`wire_mempool_ingest` → `on_mempool_tx` →
`add_tx`). The DASH coin-P2P client already has a `tx` handler that fires
`new_tx`.

But `inv_type_is_pulled()` (`p2p_messages.hpp:173`) admits exactly two
inventory types — `quorum_final_commitment` and `clsig`. A peer's
`inv(MSG_TX, …)` was dropped without a `getdata`, so that handler was
**unreachable from the network**. `send_mempool()` has always asked peers to
announce their pool — its own comment reads *"our inv handler currently only
pulls block invs"* — so we primed the feed and threw the announcements away.

### What this PR adds

**1. A budgeted `MSG_TX` pull.** Deliberately *not* just added to
`inv_type_is_pulled`: tx invs arrive orders of magnitude more often than blocks
or clsigs, so an unbudgeted pull lets a peer make us `getdata`-flood ourselves.
The lane is:

* **opt-in** — `--embedded-mempool-ingest`, default OFF;
* **budgeted** — 64 outstanding `getdata`, slots expiring after 60 s so a peer
  that goes quiet cannot wedge the budget;
* **strictly lower priority than the tip body** — no tx `getdata` while a
  tracked block body is outstanding, the same invariant the bulk-fetch lane
  observes. A transaction is worth a fraction of a block's fees; a late tip body
  is a stale template on every attached rig.
* the slot is released by **recomputing the txid from the delivered body**, so
  an unsolicited or substituted tx cannot free a slot it never occupied.

**2. Telemetry that can diagnose an empty pool.**

```
[MEMPOOL-INGEST] tx_inv=… getdata=… received=… inflight=…/64
                 skipped(budget)=… skipped(tip-body-busy)=… expired=…
                 pool_txs=… pool_bytes=… priced_fees=… duffs
```

`received == 0` with `getdata > 0` sustained is the signature of a peer set that
will not serve us transactions — a diagnosis nobody can make from an empty
template alone.

**3. The correctness gate — `[SHADOW-TXSET]`.** While dashd is present, its
template's tx set is a free per-block answer key, and `--embedded-shadow-compare`
already runs on the hotel. Every compared height now reports:

```
[SHADOW-TXSET] h=… ours=3 dashd=5 both=3 dashd_only=2 ours_only=0 coverage=60%
```

The two directions are **not symmetric**, and the line says so:

* `dashd_only` — revenue we are still forfeiting. The number this project
  exists to move.
* `ours_only` — we would have built a block on something dashd's mempool did
  not have. **Any sustained non-zero blocks enabling the serve flag**, and the
  line prints that instruction inline.

Coverage is reported **undefined, not 0 %**, when dashd's own template was
coinbase-only — calling that a miss would slander a working ingest lane. An
unaligned `WorkData` measures **nothing** rather than fabricating a number.

### No money-path change

This makes the mempool **fill**. Whether its contents ever reach a served
template remains `--embedded-serve-mempool-txs` (default OFF, untouched), gated
on the `[SHADOW-TXSET]` series. With `--embedded-mempool-ingest` absent, not one
byte of behaviour differs — and it is deliberately a *separate* flag from #1110's
so that ingest can be soaked on a test rig without arming block production
anywhere.

### The measurements behind the phasing

**Revenue** — 1 001 consecutive mainnet blocks (2516134–2517134):

| | DASH |
|---|---|
| mean fee/block | **0.00164575** |
| median | 0.00035735 |
| p90 | 0.00194443 |
| max in sample | 0.32280427 |
| mean subsidy | 1.77022505 |
| **fees as % of block reward** | **0.0930 %** |

22.2 non-coinbase txs/block; 941/1 001 blocks carried at least one tx.

**THE UTXO ANSWER** (full argument in the design note): template-time fee
pricing *does* need prevout values — a transaction does not carry them — but
that is weaker than a consensus UTXO set, and the error is **one-sided**.
Understating a fee forfeits money; overstating loses the block; #1110 already
fails closed on the safe side by excluding `fee_known == false`. Full script
validation is **not** needed in phase 1: relay-inherited validity plus conflict
tracking (double-spend, InstantSend, confirmation) is the same posture dashd's
own miner takes, and shadow-compare measures the residual for free.

**Coverage ramp** — measured, 60 blocks, 383 txs with resolvable inputs:

| UTXO view depth | txs priceable | time to reach |
|---|---|---|
| 288 blocks (**today's `--embedded-utxo` bootstrap**) | **79.4 %** | 12 h |
| 1 000 | 87.5 % | 1.7 d |
| 10 000 | 91.4 % | 17 d |
| 100 000 | 97.4 % | 6 mo |
| full (genesis, W3 Tier-B fold #1118) | 100 % | phase 3 |

median oldest-input age 38 blocks. **This is why the existing lane is good
enough to start and the genesis fold is not a blocker.**

Phase-1 recovery estimate: ~0.065–0.075 % of block reward (~0.0012–0.0013 DASH
per won block). The `[SHADOW-TXSET]` series replaces that estimate with a
measurement within a day of running.

### Scale, stated plainly

**Weeks to "fully functional", days for phase 1.** Phasing in §8 of the design
note: phase 1 fills + measures; phase 2 serves ordinary txs behind the shadow
gate; phase 3 closes the coverage gap (genesis UTXO fold), script validation and
special-tx inclusion.

### KATs

4 new in `test_dash_embedded_shadow_compare.cpp` — the coverage math, the
ours-only warning text, undefined-vs-zero coverage, and the refusal to measure
an unaligned set. Existing allowlisted target `test_dash_embedded_gbt`, no new
target, drift-guard passes. **15 green** in that suite.

### Overlaps to sequence

* `main_dash.cpp` — #1134, #1144, #1145 are live here. My footprint is small and
  localised (one flag, the arm block next to `set_on_handshake_complete`, one
  timer declaration).
* `p2p_client.hpp` / `embedded_shadow_compare.hpp` — the real surface; no
  in-flight PR I can see touches them.
* `node_coin_state.hpp` — **not touched** (#1134 owns it).

---

## Three traps that look like success — read this before changing the ingest path

Every one of these produced, or would have produced, a result that looked like
progress. They are recorded here because the next person to touch this code will
meet them again.

### 1. The BIP35 drain that was safe only by accident

`mempool.hpp`'s SOLE-INGESTION-PATH INVARIANT argues two whole ConnectBlock
reject classes — `bad-txns-nonfinal` and `mandatory-script-verify-flag` — are
N/A **because every transaction was relay-admitted**: a peer validated it against
the current tip and chose to announce it. The invariant explicitly names
*"BIP35 sync drain"* as one of the seams that turns both rows into GAPs.

`send_mempool()` has been called at every handshake since E2a. It was harmless
**only because the inv handler discarded the replies** — its own comment says so.
Arming the `MSG_TX` pull would have made that drain live and silently converted
both rows into gaps with no re-audit.

**So with `--embedded-mempool-ingest` armed we do not drain at all.** The pool
fills from relay only, which is the path the audit is written about. The cost is
cold-start latency — we learn a transaction when it is next announced rather
than retroactively — which on a 2.5-minute chain is minutes. Do not "improve"
this by re-enabling the drain without redoing the audit.

### 2. The measurement that compared dashd with itself

`shadow_evaluate`'s `embedded` argument is the **served** template. When the gate
declines and the node serves the dashd-fallback arm, that argument **is** dashd's
template. Diffing it against a fresh dashd template compares dashd with itself.

Live at h=2517157, with the gate declining on `cause=utxo-immature`:

```
[SHADOW-TXSET] h=2517157 ours=11 dashd=11 both=11 dashd_only=0 ours_only=0
               coverage=100% fee_agree=11 fee_under=0 fee_over=0
```

A flawless score on every gate condition — produced while our own mempool held
**one** transaction of 666 bytes. Every condition for enabling fee-carrying
templates is trivially satisfied by dashd-vs-dashd, which means the gate itself
was untested, not just the instrumentation.

**The measurement now keys on PROVENANCE, not on the numbers.** When the embedded
arm did not build the template, the line reads `no-measurement
reason=served-by-dashd-fallback` and the counters stay zero rather than
flattering. The KAT feeds identical inputs both ways and asserts the same data
is REFUSED under `DashdFallback` and MEASURED under `Embedded`.

### 3. The `coverage=0%` that means "serving is switched off"

Once the arm is genuinely EMBEDDED the line reads:

```
[SHADOW-TXSET] h=2517160 ours=0 dashd=6 both=0 dashd_only=6 ours_only=0 coverage=0%
```

`ours=0` is **not** an ingest failure. `--embedded-serve-mempool-txs` is OFF by
design, so the embedded template is coinbase-only by construction and the served
set is empty *whatever the mempool holds*. Read naively this says "ingest is
broken"; it actually says "serving is correctly disabled".

This is a measurement positioned on the **wrong side of the gate it exists to
open**. The consequence is worse than a bad number: it leaves no path to
enabling fees responsibly at all — the only remaining options would be to arm
the money path in order to measure it (what the gate prevents) or to enable on
faith.

**Fixed by measuring the CANDIDATE set.** When the served body is deliberately
coinbase-only, the builder runs the *same* selection and records only identities
and fees into `m_txset_candidates` / `m_txset_candidate_fees`. `selected` and
`total_fees` are untouched, so `m_txs`, `m_tx_hashes`, `m_tx_fees`,
`m_tx_data_hex`, `m_coinbase_value` and the merkle are **byte-identical to a
build with that block deleted**, and no consensus path reads the new fields.
Observe-without-arming, the same shape as shadow-compare itself.

The line names which set it used — `mode=served | candidate | none` — and
precedence is explicit and tested: a template that *actually served*
transactions is measured on what it served, never on what it might have chosen,
so a stale candidate list can never flatter a template whose real contents were
worse. The MN-collateral exclusion the served path applies is applied to
candidates too, so the gate cannot be flattered by counting transactions we
could never have served. `ours_only` is still flagged in candidate mode: a
transaction we *would* have put in a block is exactly as disqualifying as one we
did.

### What these three share

All three were defined in terms of **what the system does** rather than **what
the decision needs to know** — a metric comparing a thing to itself, a
measurement that could not distinguish provenance, and a measurement on the
wrong side of its own gate. That is the failure mode to watch for, not the three
specific bugs.

### A note on the denominator

An early reading of "5 transactions in 35 minutes" was called a 1 % shortfall
against ~3.5 tx/min derived from 22 transactions per 2.5-minute block. **That
denominator is wrong**: a block accumulates over its whole interval from the
whole network. Measured directly, dashd's own mempool holds **2–16 transactions**
in steady state (`getmempoolinfo`, both hosts), draining to 2 right after a
block. Offered-vs-admitted confirms the pull path is clean: `tx_inv_offered=32
tx_inv=4` with an 8-peer pool is every peer announcing the same four
transactions. There is no relay shortfall. DASH is simply a quiet chain, which
also caps what fee recovery can ever be worth.

`do-not-merge`: phase 1 wants a live ingest soak on a test rig before it lands.
