### PR TITLE
web(dashboard): the shared page read per-coin field names — Node Fee blank on DASH, and three computed values written to elements that do not exist [do-not-merge]

### DIFF
--- a/src/core/test/web_server_dashboard_data_test.cpp
+++ b/src/core/test/web_server_dashboard_data_test.cpp
@@ -391,3 +391,153 @@ TEST(DashboardData, PersistedBestShareNeverLowersALiveRecord)
     std::remove(log_path.c_str());
     std::remove((log_path + ".best.json").c_str());
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 7. The node-fee amount is readable WITHOUT knowing which coin this is
+// ═══════════════════════════════════════════════════════════════════════════
+
+// THE INCIDENT (live, 2026-08-06, DASH node 109.161.52.148:8081): the Node Fee
+// card showed "- DASH" — no amount. /local_stats on that node carried
+//     node_fee_dash = 0.004240003478694174
+//     node_fee_ltc  = ABSENT
+// and dashboard.html:3228 read `local_stats.node_fee_ltc` unconditionally.
+// d3.format('.4f')(undefined) renders nothing, so the card sat at "-" on a node
+// that had computed the number correctly.
+//
+// There is exactly ONE shared web-static/dashboard.html for every coin, so the
+// key it reads cannot be per-coin. This pins the coin-neutral `node_fee` on
+// EVERY blockchain — a fix that only added `node_fee_bch`, say, would leave the
+// next coin broken the same way.
+//
+// The coin-suffixed keys are pinned as UNCHANGED in the same test: they are the
+// p2pool-compat surface, and the dashboard falls back to them so a newer page
+// dropped on an older binary still renders.
+namespace {
+
+// Fee amount = miner_subsidy x fee% x (local hashrate / pool hashrate).
+// 4.0 coins of miner subsidy (no protocol-payment lane), 1% fee, and
+// 1000/4000 = a quarter of the pool -> 4.0 x 0.01 x 0.25 = 0.01 exactly, so
+// the number is checkable by eye rather than merely "greater than zero".
+constexpr double kExpectedNodeFee = 0.01;
+
+void wire_fee_node(MiningInterface& mi)
+{
+    mi.set_coin_work_fn([]() {
+        MiningInterface::CoinWorkInfo cw;
+        cw.valid              = true;
+        cw.coinbase_value_sat = 400000000;   // 4.0
+        cw.height             = 1000000;
+        return cw;
+    });
+    mi.set_pool_fee_percent(1.0);
+    mi.set_stratum_hashrate_fn([]() { return 1000.0; });
+    mi.set_pool_hashrate_fn([]()    { return 4000.0; });
+}
+
+} // namespace
+
+TEST(DashboardData, NodeFeeAmountIsExposedUnderACoinNeutralKey)
+{
+    struct Case { c2pool::address::Blockchain chain; const char* legacy; };
+    const Case cases[] = {
+        {c2pool::address::Blockchain::DASH,     "node_fee_dash"},
+        {c2pool::address::Blockchain::LITECOIN, "node_fee_ltc"},
+        {c2pool::address::Blockchain::DOGECOIN, "node_fee_doge"},
+        {c2pool::address::Blockchain::BITCOIN,  "node_fee_ltc"},
+        {c2pool::address::Blockchain::DIGIBYTE, "node_fee_ltc"},
+    };
+
+    for (const auto& c : cases) {
+        MiningInterface mi(/*testnet=*/false, /*node=*/nullptr, c.chain);
+        wire_fee_node(mi);
+        auto stats = mi.rest_local_stats();
+
+        // THE FIX: present on every coin, so the shared page needs no per-coin
+        // knowledge to render the card.
+        ASSERT_TRUE(stats.contains("node_fee"))
+            << "no coin-neutral node_fee — the shared dashboard cannot read"
+               " this coin's amount";
+        EXPECT_DOUBLE_EQ(stats["node_fee"].get<double>(), kExpectedNodeFee);
+
+        // The legacy key still carries the identical value (compat surface).
+        ASSERT_TRUE(stats.contains(c.legacy));
+        EXPECT_DOUBLE_EQ(stats[c.legacy].get<double>(),
+                         stats["node_fee"].get<double>());
+    }
+}
+
+// THE NEGATIVE CONTROL: this reproduces the shipped defect exactly. On DASH the
+// key the dashboard actually read is absent, and reading it yields the
+// undefined that formatted to nothing.
+TEST(DashboardData, TheKeyTheDashboardUsedToReadIsAbsentOnDash)
+{
+    MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                       c2pool::address::Blockchain::DASH);
+    wire_fee_node(mi);
+    auto stats = mi.rest_local_stats();
+
+    EXPECT_FALSE(stats.contains("node_fee_ltc"))
+        << "if DASH ever emits node_fee_ltc this test is stale — but the "
+           "dashboard must still not depend on it";
+    EXPECT_TRUE(stats.contains("node_fee_dash"));
+    EXPECT_TRUE(stats.contains("node_fee"));
+
+    // The dashboard's resolution order (node_fee -> node_fee_<symbol> ->
+    // node_fee_ltc) transcribed: step 1 alone already answers.
+    EXPECT_DOUBLE_EQ(stats["node_fee"].get<double>(),
+                     stats["node_fee_dash"].get<double>());
+}
+
+// A node with no local miners owes no fee — and must say 0, not omit the key,
+// so the card renders "0.0000" rather than falling back through the chain to
+// some other coin's number.
+TEST(DashboardData, NodeFeeIsZeroNotAbsentWhenNothingIsMiningLocally)
+{
+    MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                       c2pool::address::Blockchain::DASH);
+    mi.set_pool_fee_percent(1.0);
+    mi.set_stratum_hashrate_fn([]() { return 0.0; });
+    mi.set_pool_hashrate_fn([]()    { return 4000.0; });
+    auto stats = mi.rest_local_stats();
+    ASSERT_TRUE(stats.contains("node_fee"));
+    EXPECT_DOUBLE_EQ(stats["node_fee"].get<double>(), 0.0);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 8. block_value_payments only means "protocol outputs" where such a lane exists
+// ═══════════════════════════════════════════════════════════════════════════
+
+// The API sets block_value_payments == block_value on every non-DASH coin
+// (there is no masternode/superblock lane to deduct), so the dashboard must
+// gate the "− protocol" line on payments < block_value. Pinning the shape here
+// keeps that front-end gate honest: if a coin ever starts reporting a real
+// payments lane, the line appears on its own.
+TEST(DashboardData, PaymentsEqualBlockValueWhereThereIsNoProtocolLane)
+{
+    {
+        MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                           c2pool::address::Blockchain::DASH);
+        wire_dash_template(mi);
+        auto stats = mi.rest_local_stats();
+        // A genuine deduction: 1.77109977 total, 1.32832482 protocol outputs.
+        EXPECT_LT(stats["block_value_payments"].get<double>(),
+                  stats["block_value"].get<double>());
+        EXPECT_GT(stats["block_value_burn"].get<double>(), 0.0);
+    }
+    {
+        MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                           c2pool::address::Blockchain::LITECOIN);
+        mi.set_coin_work_fn([]() {
+            MiningInterface::CoinWorkInfo cw;
+            cw.valid              = true;
+            cw.coinbase_value_sat = 671473381;
+            cw.height             = 3000000;
+            return cw;
+        });
+        auto stats = mi.rest_local_stats();
+        EXPECT_DOUBLE_EQ(stats["block_value_payments"].get<double>(),
+                         stats["block_value"].get<double>())
+            << "the dashboard's protocol-lane gate keys on this equality";
+        EXPECT_FALSE(stats.contains("block_value_burn"));
+    }
+}

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -3980,8 +3980,26 @@ nlohmann::json MiningInterface::rest_local_stats()
         double local_hr = m_stratum_hashrate_fn ? m_stratum_hashrate_fn() : 0.0;
         double pool_hr = m_pool_hashrate_fn ? m_pool_hashrate_fn() : 0.0;
         double node_share = (pool_hr > 0 && local_hr > 0) ? local_hr / pool_hr : 0.0;
-        // Use blockchain-appropriate key for backward compatibility
         double primary_fee = miner_subsidy * fee_ratio * node_share;
+
+        // COIN-NEUTRAL key. There is exactly ONE shared web-static/dashboard
+        // .html for every coin, so a per-coin key name is something the page
+        // cannot read without knowing which coin it is serving. The Node Fee
+        // card read `node_fee_ltc` unconditionally, which is absent on DASH —
+        // d3.format('.4f')(undefined) renders nothing, so the card sat at "-"
+        // on a node that had computed the number correctly (measured live:
+        // node_fee_dash = 0.00424, node_fee_ltc absent). This is the key the
+        // dashboard reads first, on every coin.
+        result["node_fee"] = primary_fee;
+        // Merged-child equivalent, likewise coin-neutral. Absent (not zero)
+        // when nothing is merged, so the page can tell "no merged chain" from
+        // "merged chain owes zero".
+        //
+        // The coin-SUFFIXED keys below stay byte-unchanged: they are the
+        // p2pool-compat surface external tooling reads, and the same
+        // keep-the-legacy-key rule #1127 followed for the fee fields. The
+        // dashboard falls back to them so a NEW page dropped on an OLD binary
+        // (e.g. --dashboard-dir pointed at a newer web-static) still renders.
         switch (m_blockchain) {
         case Blockchain::DASH:
             result["node_fee_dash"] = primary_fee; break;
@@ -3993,11 +4011,18 @@ nlohmann::json MiningInterface::rest_local_stats()
         }
         if (m_mm_manager) {
             auto chain_infos = m_mm_manager->get_chain_infos();
+            bool first_merged = true;
             for (const auto& ci : chain_infos) {
                 double merged_bv = ci.coinbase_value / 1e8;
                 std::string sym = ci.symbol;
                 for (auto& c : sym) c = std::tolower(c);
-                result["node_fee_" + sym] = merged_bv * fee_ratio * node_share;
+                double merged_fee = merged_bv * fee_ratio * node_share;
+                result["node_fee_" + sym] = merged_fee;
+                if (first_merged) {
+                    result["node_fee_merged"]        = merged_fee;
+                    result["node_fee_merged_symbol"] = ci.symbol;
+                    first_merged = false;
+                }
             }
         }
     }

--- a/web-static/dashboard.html
+++ b/web-static/dashboard.html
@@ -1832,6 +1832,10 @@
                         <div class="stat-value success" id="local_rate">-</div>
                         <div class="stat-sub" title="Dead-on-arrival = local dead_hashrate / local hashrate -- the true lost-work / unrewarded fraction. Sourced from live hashrate, not share counts.">DOA: <span id="local_doa">-</span></div>
                         <div class="stat-detail">Expected Share: <span id="time_to_share">-</span></div>
+                        <!-- #expected_payout_amount was written by renderGlobalStats
+                             but had NO element in this page: c2pool computed the
+                             24h expectation and threw it away. -->
+                        <div class="stat-detail" id="expected_payout_line" style="display: none;" title="This node's expected 24h payout = (local share of pool hashrate) x miner block value x (1 - donation) x blocks expected in 24h">Est. 24h: <span id="expected_payout_amount">-</span> <small class="symbol-small">-</small></div>
                     </div>
                     
                     <div class="stat-card" id="shares_card">
@@ -1856,6 +1860,13 @@
                     <div class="stat-value warning"><span id="block_value_miner">-</span> <small class="symbol-small" id="block_value_symbol">-</small></div>
                     <div class="stat-sub merged-child-hint" style="color: #c3a634; font-size: 1.1em; margin-top: -4px;">+<span id="merged_block_value">-</span> <span class="merged-child-symbol-hint">DOGE</span></div>
                     <div class="stat-detail" style="white-space: nowrap;" title="#948: this card shows the GROSS miner share; the pool fee is deducted to give the NET amount the API reports as block_value_miner">Fee: <span id="block_value_fee">-</span> &rarr; net <span id="block_value_miner_net">-</span></div>
+                    <!-- #block_value and #block_value_payments were both written
+                         by renderLocalStats but had NO elements in this page. The
+                         card showed the miner slice with nothing to compare it
+                         against, so on DASH there was no way to see that 1.7702
+                         total minus 1.3277 of protocol outputs is what leaves
+                         miners 0.4426. -->
+                    <div class="stat-detail" style="white-space: nowrap;" title="Full coinbase value of the block being worked on, and the protocol-mandated outputs deducted from it before the miner split (masternode / superblock / platform burn). Shown only on coins that have such a lane.">Block: <span id="block_value">-</span><span id="block_value_payments_part" style="display: none;"> &minus; protocol <span id="block_value_payments">-</span><span id="block_value_burn_part" style="display: none;"> (burn <span id="block_value_burn">-</span>)</span></span></div>
                     <div class="stat-detail" style="white-space: nowrap;">Expected: <span id="time_to_block">-</span> <span class="merged-child-hint"><span style="color: #c3a634;">|</span> <span style="color: #c3a634;"><span id="time_to_merged_block">-</span></span></span></div>
                 </div>
                 
@@ -1865,8 +1876,12 @@
                     <div class="stat-value success"><span id="payout_totamount">-</span> <small class="symbol-small" id="node_payout_symbol">-</small></div>
                     <div class="stat-sub merged-child-hint" id="node_merged_payout" style="color: #c3a634; font-size: 1.1em; margin-top: -4px;">+<span id="node_merged_amount">0</span> <span id="node_merged_symbol" class="merged-child-symbol-hint">DOGE</span></div>
                     <div class="stat-detail">Per block found now</div>
+                    <!-- The operator's TOTAL entitlement in the current PPLNS
+                         window (mining payout + fee). Distinct from the fee
+                         above; it used to overwrite it. -->
+                    <div class="stat-detail" id="node_pplns_total_line" style="display: none;" title="Sum of this node's own addresses (/payout_addrs) in the current PPLNS window — the operator's mining payout AND fee, not the fee alone">PPLNS total: <span id="node_pplns_totamount">-</span> <small class="symbol-small">-</small></div>
                 </div>
-                
+
                 <div class="graph-section compact">
                     <div class="graph-header">
                         <h2>📈 Pool Hashrate</h2>
@@ -3188,7 +3203,16 @@
             var blocks_in_24h = (24 * 3600) / time_to_block;
             var payout_per_block = (local / global_stats.pool_hash_rate) * local_stats.block_value_miner * (1 - local_stats.donation_proportion);
             var expected_24h_payout = payout_per_block * blocks_in_24h;
-            d3.select('#expected_payout_amount').text(isFinite(expected_24h_payout) ? d3.format('.4f')(expected_24h_payout) : '0');
+            // The element for this now exists (Local Hash Rate card). Reveal it
+            // only when the number is real: with no local miners, or before the
+            // first pool-hashrate sample, the expression is NaN/Infinity and a
+            // formatted '0' would read as a genuine "you will earn nothing".
+            if (isFinite(expected_24h_payout)) {
+                d3.select('#expected_payout_amount').text(d3.format('.4f')(expected_24h_payout));
+                d3.select('#expected_payout_line').style('display', null);
+            } else {
+                d3.select('#expected_payout_line').style('display', 'none');
+            }
         }
 
         function renderLocalStats(local_stats) {
@@ -3208,7 +3232,31 @@
                 d3.select('#efficiency').text(local_stats.efficiency != null ? d3.format('.2p')(local_stats.efficiency) : '???');
                 d3.select('#uptime').text(format_dt(local_stats.uptime));
                 d3.select('#block_value').text(d3.format('.4f')(local_stats.block_value));
-                d3.select('#block_value_payments').text(d3.format('.4f')(local_stats.block_value_payments || 0));
+                // block_value_payments is the protocol-mandated output lane
+                // (masternode / superblock / platform burn). The API sets it
+                // EQUAL to block_value on coins that have no such lane
+                // (web_server.cpp: `(DASH) ? payment_amount : block_value`), so
+                // showing it unconditionally would tell an LTC operator the
+                // whole block is "protocol payments". Show it only when it is a
+                // genuine deduction.
+                var _bvp = local_stats.block_value_payments;
+                var _hasProtocolLane = (_bvp != null && _bvp > 0
+                                        && _bvp < local_stats.block_value - 1e-12);
+                var _burn = local_stats.block_value_burn;
+                // Both visibilities are set on EVERY pass, never only inside the
+                // positive branch: these cards re-render in place, so a branch
+                // that can turn a line on but not off leaves a stale line behind
+                // the moment the shape changes (a coin whose payments lane goes
+                // away, or a template that arrives before the burn field does).
+                var _hasBurn = _hasProtocolLane && (_burn != null && _burn > 0);
+                d3.select('#block_value_payments_part')
+                    .style('display', _hasProtocolLane ? null : 'none');
+                d3.select('#block_value_burn_part')
+                    .style('display', _hasBurn ? null : 'none');
+                if (_hasProtocolLane)
+                    d3.select('#block_value_payments').text(d3.format('.4f')(_bvp));
+                if (_hasBurn)
+                    d3.select('#block_value_burn').text(d3.format('.4f')(_burn));
                 // #948: the card headline is the GROSS (pre-fee) miner share so it
                 // matches the API block_value_miner_gross field and the label says so;
                 // the fee and the resulting NET (legacy block_value_miner) are shown below.
@@ -3223,14 +3271,58 @@
                 // Node fee percentage and computed amounts
                 var nodeFee = local_stats.fee != null ? local_stats.fee : 0;
                 d3.select('#node_fee_percent').text(d3.format('.1f')(nodeFee));
-                // Display computed node fee amounts per block
-                if (local_stats.node_fee_ltc != null) {
-                    d3.select('#payout_totamount').text(d3.format('.4f')(local_stats.node_fee_ltc));
-                    d3.select('#node_payout_symbol').text('LTC');
+                // Display computed node fee amounts per block.
+                //
+                // There is ONE shared dashboard.html for every coin, so the
+                // amount can NEVER be read from a hardcoded per-coin key. This
+                // read `local_stats.node_fee_ltc`, which is absent on DASH:
+                // d3.format('.4f')(undefined) renders nothing, so the card sat
+                // at "-" while the backend had the number
+                // (node_fee_dash = 0.00424). The symbol looked right only by
+                // accident — the .symbol-small sweep from currency_info had
+                // already written "DASH", and line :3229's hardcoded 'LTC'
+                // would have stomped it the moment node_fee_ltc appeared.
+                //
+                // Resolution order, most-general first:
+                //   1. node_fee                     coin-neutral, every coin
+                //   2. node_fee_<currency_info.symbol>   old binary, new page
+                //   3. node_fee_ltc                 the original legacy key
+                // (2) is what lets a newer web-static dropped on an already-
+                // running node render without a restart, and it is why LTC/
+                // DOGE/DASH keep working against binaries that predate (1).
+                var localStatsCoinFee = function(stats, sym, legacyKey) {
+                    if (stats.node_fee != null) return stats.node_fee;
+                    if (sym) {
+                        var k = 'node_fee_' + String(sym).toLowerCase();
+                        if (stats[k] != null) return stats[k];
+                    }
+                    if (legacyKey && stats[legacyKey] != null) return stats[legacyKey];
+                    return null;
+                };
+                var _ci = (typeof currency_info !== 'undefined') ? currency_info : {};
+                var _sym = _ci.symbol || '';
+                var nodeFeeAmount = localStatsCoinFee(local_stats, _sym, 'node_fee_ltc');
+                if (nodeFeeAmount != null) {
+                    d3.select('#payout_totamount').text(d3.format('.4f')(nodeFeeAmount));
+                    // Symbol from currency_info, never a literal — same source
+                    // the .symbol-small sweep uses, so the two agree. When
+                    // currency_info has not landed we leave whatever the sweep
+                    // put there rather than stomping it with a placeholder;
+                    // the old code wrote 'LTC' here unconditionally.
+                    if (_sym) d3.select('#node_payout_symbol').text(_sym.toUpperCase());
                 }
-                if (local_stats.node_fee_doge != null) {
-                    d3.select('#node_merged_amount').text(d3.format(',.2f')(local_stats.node_fee_doge));
-                    d3.select('#node_merged_symbol').text((typeof currency_info!=="undefined"&&currency_info.merged_child_symbol)||'DOGE');
+                // Merged-child fee: coin-neutral node_fee_merged first, then
+                // node_fee_<merged_child_symbol>, then the legacy DOGE key.
+                var mergedSym = _ci.merged_child_symbol || '';
+                var mergedFee = (local_stats.node_fee_merged != null)
+                    ? local_stats.node_fee_merged
+                    : (mergedSym && local_stats['node_fee_' + mergedSym.toLowerCase()] != null
+                        ? local_stats['node_fee_' + mergedSym.toLowerCase()]
+                        : (local_stats.node_fee_doge != null ? local_stats.node_fee_doge : null));
+                if (mergedFee != null) {
+                    d3.select('#node_merged_amount').text(d3.format(',.2f')(mergedFee));
+                    d3.select('#node_merged_symbol').text(
+                        local_stats.node_fee_merged_symbol || mergedSym || 'DOGE');
                 }
 
                 // Warnings
@@ -4492,9 +4584,20 @@
                             }
                         }
                     }
-                    // Only overwrite computed estimates if PPLNS has real data
+                    // This sums the operator's own entries in the CURRENT PPLNS
+                    // window (/payout_addrs intersected with
+                    // /current_merged_payouts). That is the operator's total
+                    // entitlement — their mining payout AND the fee — which is
+                    // NOT the node fee the card above is labelled with. It used
+                    // to overwrite #payout_totamount, silently relabelling one
+                    // quantity as the other; it only escaped notice because
+                    // /current_merged_payouts answered {} wherever the seam was
+                    // unbound, so `totamount > 0` was never true. It gets its
+                    // own, correctly-labelled line instead.
+                    d3.select('#node_pplns_total_line')
+                        .style('display', totamount > 0 ? null : 'none');
                     if (totamount > 0)
-                        d3.select('#payout_totamount').text(d3.format('.4f')(totamount));
+                        d3.select('#node_pplns_totamount').text(d3.format('.4f')(totamount));
 
                     // Show merged payout (always show when merged mining is active)
                     if (window.payoutsMergedSymbol && totMergedAmount > 0) {


### PR DESCRIPTION
web(dashboard): the shared page read per-coin field names — Node Fee blank on DASH, and three computed values written to elements that do not exist

There is exactly ONE web-static/dashboard.html for every coin. Two failure
shapes follow from that, and both are in this changeset:

  A. the page reads a HARDCODED per-coin key, so it reads nothing on the
     coins whose key differs;
  B. the page writes a computed value to a selector with NO matching element,
     so it computes the number and throws it away.

Neither raises an error. d3.format('.4f')(undefined) returns '' and
d3.select('#nothing').text(x) is a silent no-op on an empty selection, so
every one of these renders as a card that simply sits at "-".

── A. Node Fee card (the operator-visible one) ─────────────────────────────

    dashboard.html:3228  d3.select('#payout_totamount')
                             .text(d3.format('.4f')(local_stats.node_fee_ltc));
    dashboard.html:3229  d3.select('#node_payout_symbol').text('LTC');

  /local_stats on the live DASH node 109.161.52.148:8081:

      node_fee_dash   0.004240003478694174     <- computed, correct
      node_fee_ltc    ABSENT

  so the amount rendered as nothing and the card read

      Node Fee: 1.0 %
      -  DASH
      Per block found now

  The symbol looked right only by ACCIDENT: the `.symbol-small` sweep
  (dashboard.html:2878, sourced from currency_info) had already written
  "DASH", and :3229's hardcoded 'LTC' sits inside `if (node_fee_ltc != null)`
  which is false on DASH. The moment DASH emitted that key the symbol would
  have flipped to LTC. Both are fixed.

  FIX — chosen after weighing the two options:

    backend  rest_local_stats() now also emits a COIN-NEUTRAL `node_fee`
             (plus `node_fee_merged` / `node_fee_merged_symbol`). The
             coin-suffixed keys are byte-unchanged — they are the
             p2pool-compat surface, kept the way #1127 kept the legacy fee
             keys.

    frontend resolves most-general-first:
               1. node_fee                            every coin, new binary
               2. node_fee_<currency_info.symbol>     old binary, new page
               3. node_fee_ltc                        the original legacy key

  Why BOTH and not either alone:
    * backend-only would leave a newer web-static dropped on an already
      running node (--dashboard-dir) broken until that node restarts. Step 2
      fixes both live nodes with the PAGE ALONE, no redeploy.
    * frontend-only would leave BCH and DGB broken: the backend's `default:`
      arm emits `node_fee_ltc`, so a symbol-derived `node_fee_bch` misses.
      Step 1 covers them.
    * step 3 guarantees LTC cannot regress.

  The symbol is now taken from currency_info and only written when
  currency_info has landed, so it never stomps the sweep with a placeholder.

── B. Three selectors with no element ──────────────────────────────────────

  A mechanical sweep of every d3.select('#id') / getElementById in the page
  against every id="" in the markup found exactly five orphans; two are false
  positives (`merged_peers_show_more_` is a dynamic id prefix, `nav-explorer`
  is created at runtime). The other three were all live writes:

    #expected_payout_amount   (:3191)  the node's expected 24h payout
    #block_value              (:3210)  the full block coinbase value
    #block_value_payments     (:3211)  the protocol-mandated output lane

  So on DASH there was no way to see that 1.7702 total, minus 1.3277 of
  masternode + platform-burn outputs, is what leaves miners 0.4426 — the card
  showed the miner slice with nothing to compare it to. All three now have
  elements:

    * "Est. 24h: <n> <SYM>" on the Local Hash Rate card, revealed only when
      the expression is finite (no local miners => NaN, and a formatted '0'
      would read as a real "you will earn nothing").
    * "Block: <n> − protocol <n> (burn <n>)" on the Miners Block Value card.
      The protocol part is gated on payments < block_value, because the API
      sets block_value_payments EQUAL to block_value on coins with no such
      lane — printing it unconditionally would tell an LTC operator the whole
      block is protocol payments. Both visibilities are set on every pass, so
      a stale line cannot survive a shape change.
    * #block_value_burn was computed by the backend and had neither an element
      NOR a JS reader; it is now the burn sub-line.

── C. A mislabel this change would otherwise have activated ────────────────

  dashboard.html:4497 also wrote #payout_totamount, from /payout_addrs
  intersected with /current_merged_payouts — i.e. the operator's TOTAL PPLNS
  entitlement (their mining payout AND the fee), overwriting the card labelled
  "Node Fee: 1.0% / Per block found now" with a different quantity. It escaped
  notice only because /current_merged_payouts answers {} wherever that seam is
  unbound, so `totamount > 0` was never true. It now has its own correctly
  labelled "PPLNS total:" line. (Flagged here because #1145 makes that endpoint
  non-empty on DASH, which would have activated the mislabel.)

── LIVE VERIFICATION ───────────────────────────────────────────────────────

  Both real /local_stats payloads were replayed through the page's own card
  code (extracted verbatim from dashboard.html, not re-typed):

    LIVE payloads — binaries WITHOUT the new node_fee key (page-only upgrade)
      DASH 109.161.52.148:8081   Node Fee  BEFORE "-"        AFTER "0.0043 DASH"
                                 Block line              "Block: 1.7702 − protocol 1.3277 (burn 0.4979)"
      LTC  contabo:8080          Node Fee  BEFORE "0.0000"  AFTER "0.0000 LTC"   (unchanged)
                                 merged                  "0.00 DOGE"            (unchanged)
                                 Block line              "Block: 6.7147", protocol part HIDDEN

    Same payloads + the new backend keys: identical output on both coins.

    BCH/DGB shape (symbol-derived key absent, legacy key present): resolves
    via step 3 on an old binary and via step 1 on a new one.

  contabo's LTC node reports node_fee_ltc = 0.0 because it runs --fee 0; the
  point of that row is that the value and the symbol are unchanged, i.e. no
  regression on the coin that worked.

── TESTS ───────────────────────────────────────────────────────────────────

  Four KATs appended to src/core/test/web_server_dashboard_data_test.cpp,
  which already rides the allowlisted core_test target — no new
  add_executable (#143), no #ifdef guard (#895):

    * node_fee present and equal to the legacy key on DASH / LTC / DOGE /
      BTC / DGB, pinned to an exact 0.01 (4.0 subsidy x 1% x a quarter of the
      pool) rather than "> 0";
    * the NEGATIVE CONTROL: node_fee_ltc is absent on DASH, which is precisely
      what the shipped page read;
    * an idle node reports node_fee = 0 rather than omitting the key, so the
      resolver cannot fall through to another coin's number;
    * block_value_payments == block_value where there is no protocol lane,
      which is the equality the front-end gate keys on.

  161/161 core_test green. Page JS syntax-checked; the orphan-selector sweep
  now reports only the two known false positives.

Display-path only: rest_local_stats() is a read-only stats endpoint and no
consensus, payout or submission surface is reachable from anything here.

