### PR TITLE
dash(stratum): resolve the coin-state arm on the owning thread and hand the background re-source a VALUE — closes the SERVE-path sibling of the hotel heap corruption [do-not-merge]

### DIFF
--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -315,20 +315,52 @@ int64_t DASHWorkSource::peek_template_age_sec() const
 // IWorkSource: work generation -- Stage 4c (the template trio).
 // ─────────────────────────────────────────────────────────────────────────────
 
-void DASHWorkSource::resource_template_now() const
-{
-    // The blocking select_work()/dashd-GBT re-source + cache update. Runs either
-    // inline on the caller (legacy blocking path) OR on the background rpc_pool
-    // thread (io-thread-decouple, via refresh_executor_). select_work() is done
-    // OUTSIDE the lock (the fallback arm is a blocking dashd RPC); the cache is
-    // then updated under template_mutex_.
+// ─────────────────────────────────────────────────────────────────────────────
+// #1134 — OWNERSHIP SPLIT ON THE SERVE PATH.
+//
+// resource_template_now() used to read NodeCoinState itself, and it runs on the
+// background rpc_pool thread whenever refresh_executor_ is wired. NodeCoinState
+// has ZERO mutexes and select_work() hands RAW POINTERS into its live containers
+// (`&m_mnstates`, `&m_sml`) which build_embedded_workdata() then dereferences
+// for the WHOLE template assembly — the identical shape that took the hotel
+// primary down with glibc heap corruption on 2026-08-05 (PR #1135), except this
+// one is on the path that serves miners.
+//
+// It did not fire only because of ARM EXCLUSIVITY: the executor is installed
+// under `!coin_p2p` while every NodeCoinState mutator lives inside
+// `if (coin_p2p)`, so on the arm that has the worker the coin state happened to
+// be write-quiescent. Nothing in the code enforced that, and removing --coin-rpc
+// steers the process straight into the combination it depends on being
+// impossible.
+//
+// The split below is a LIFETIME/OWNERSHIP change only:
+//
+//   resolve_coin_state_arm()      OWNING THREAD. Every NodeCoinState read.
+//                                 Returns a self-contained value.
+//   resource_template_now(arm)    ANY THREAD. Every dashd RPC, the arm log,
+//                                 the journal, the cache update. Names no
+//                                 coin state at all.
+//
+// Same shape as EmbeddedOracleShadow::on_new_tip/process_tip (#1135) and
+// EmbeddedShadowCompare::on_serve. NOT a mutex on NodeCoinState — see the PR
+// body: this is the hot serve path (26 sessions per work-generation bump), a
+// lock across select_work() is a lock across a 12 s dashd RPC deadline, the
+// class exposes many reference-returning accessors so a partial lock only LOOKS
+// safe, and WorkSelection is already all-by-value so the copy is not new work.
+// ─────────────────────────────────────────────────────────────────────────────
 
-    // Captured BEFORE sourcing: a failed attempt negative-caches against THIS
-    // generation, so an event (work-generation bump) that lands while the
-    // blocking source runs still breaks through the retry throttle (soak0804e
-    // resume-quantization fix — see cached_work()).
-    const uint64_t gen_at_source =
-        work_generation_.load(std::memory_order_relaxed);
+DASHWorkSource::CoinStateArm DASHWorkSource::resolve_coin_state_arm() const
+{
+    CoinStateArm arm;
+
+    // Captured BEFORE sourcing — and the resolution IS the first step of
+    // sourcing. A failed attempt negative-caches against THIS generation, so an
+    // event (work-generation bump) that lands while the blocking source runs
+    // still breaks through the retry throttle (soak0804e resume-quantization
+    // fix — see cached_work()). Sampling it here rather than on the rpc_pool
+    // thread additionally covers the queueing delay, which can only ever make
+    // the cache MORE willing to re-source, never less.
+    arm.gen_at_source = work_generation_.load(std::memory_order_relaxed);
 
     // ── Mainnet embedded gate (v0.2.4 trigger) ──────────────────────────────
     // The SML/QuorumManager wiring emits a real DIP-0004 type-5 CCbTx, and its
@@ -341,65 +373,137 @@ void DASHWorkSource::resource_template_now() const
     // (SML+quorum fresh at the tip, non-superblock, credit-pool seed height at
     // tip, bestCL fresh) fails safe to the fallback, so no invalid template mines.
     const bool embedded_arm_enabled = is_testnet_ || embedded_mainnet_;
-    if (!embedded_arm_enabled && coin_state_.populated()) {
-        static std::once_flag mainnet_gate_logged;
-        std::call_once(mainnet_gate_logged, [] {
-            LOG_WARNING << "[DASH-STRATUM-GBT] embedded template arm disabled on "
-                           "mainnet (byte-parity proven; enable with --embedded-mainnet) "
-                           "— using dashd-RPC fallback";
-        });
+    try {
+        const bool populated = coin_state_.populated();
+        if (!embedded_arm_enabled && populated) {
+            static std::once_flag mainnet_gate_logged;
+            std::call_once(mainnet_gate_logged, [] {
+                LOG_WARNING << "[DASH-STRATUM-GBT] embedded template arm disabled on "
+                               "mainnet (byte-parity proven; enable with --embedded-mainnet) "
+                               "— using dashd-RPC fallback";
+            });
+        }
+        arm.try_embedded = embedded_arm_enabled && populated;
+
+        // Nothing to source at all (no embedded arm AND no dashd arm): leave the
+        // arm empty and do NOT consult the clause list. Byte-identical to the
+        // pre-split `if (try_embedded || dashd_fallback_)` guard.
+        if (!arm.try_embedded && !dashd_fallback_) return arm;
+
+        if (!arm.try_embedded) {
+            // The mainnet gate refused BEFORE viability was ever consulted;
+            // name that, or the operator reads "dashd-fallback" and starts
+            // hunting a coin-state fault that does not exist.
+            if (!embedded_arm_enabled) {
+                // The mainnet opt-in is off, so viability was never even
+                // consulted. Name the GATE, not the coin state -- an
+                // operator here must flip a flag, not chase a sync fault.
+                arm.decline.viable    = false;
+                arm.decline.cause     = "mainnet-gate-off";
+                arm.decline.value     = "embedded_mainnet=false";
+                arm.decline.threshold = "--embedded-mainnet";
+            } else {
+                // Armed but unpopulated. Ask THE clause list rather than
+                // restating a poorer version of it here; that duplication
+                // is precisely the drift this design exists to prevent.
+                arm.decline = coin_state_.describe_decline();
+            }
+            return arm;
+        }
+
+        // THE embedded-arm resolution. The fallback closure is a NO-OP: this may
+        // run on the io thread and the real fallback is a dashd getblocktemplate
+        // RPC. select_dash_work() only invokes the fallback on the non-viable
+        // branch, so binding it to an empty template here changes nothing except
+        // WHICH THREAD makes the RPC — resource_template_now() makes exactly the
+        // same one, exactly once, below.
+        coin::WorkSelection sel =
+            coin_state_.select_work([]() { return coin::DashWorkData{}; });
+        if (sel.source != coin::WorkSource::Embedded) {
+            arm.decline = std::move(sel.decline);
+            return arm;
+        }
+
+        // BLOCKER-3 pre-emit HARD GATE (PR #780): re-validate an EMBEDDED
+        // template's CbTx against consensus invariants (both roots recomputed,
+        // DKG/superblock/bestCL/credit-pool-height guards) before it can be
+        // served; on any failure DISCARD it for the reward-safe dashd arm.
+        // Evaluated HERE, beside the selection it judges, because it reads the
+        // same unguarded containers.
+        coin::DeclineReport emit_why;
+        if (!coin_state_.embedded_template_emit_ok(sel.work, &emit_why)) {
+            // Keep the height the embedded arm was refusing AT: on a daemonless
+            // node the fallback arm is UNARMED and returns an empty template
+            // (m_height == 0), and "h=0" told the operator nothing — it is the
+            // single most misleading field in the measured 08-03 fallback lines.
+            arm.declined_height = sel.work.m_height;
+            arm.decline         = std::move(emit_why);
+            return arm;
+        }
+
+        arm.is_embedded = true;
+        arm.work        = std::move(sel.work);   // DEEP COPY, owned by the value
+        arm.decline     = std::move(sel.decline);
+    } catch (const std::exception& e) {
+        // Reproduced verbatim by resource_template_now() so the log line and the
+        // empty-template outcome are byte-identical to the pre-split form.
+        arm.resolve_threw = true;
+        arm.resolve_error = e.what();
+    } catch (...) {
+        // NOTHING here throws a non-std exception today, but this resolution now
+        // runs on the io thread BETWEEN template_refresh_inflight_ being claimed
+        // and the job being posted. An escape there would strand the
+        // single-flight flag set forever and wedge every future re-source, so it
+        // fails closed into the same empty-template path instead.
+        arm.resolve_threw = true;
+        arm.resolve_error = "unknown exception";
     }
+    return arm;
+}
+
+void DASHWorkSource::resource_template_now() const
+{
+    // Inline (no-executor) path: resolve and source on this thread, exactly as
+    // the single pre-#1134 function did.
+    resource_template_now(resolve_coin_state_arm());
+}
+
+void DASHWorkSource::resource_template_now(CoinStateArm arm) const
+{
+    // The blocking dashd-GBT re-source + cache update. Runs either inline on the
+    // caller (legacy blocking path) OR on the background rpc_pool thread
+    // (io-thread-decouple, via refresh_executor_). The RPC is done OUTSIDE the
+    // lock; the cache is then updated under template_mutex_.
+    //
+    // THREAD CONTRACT (#1134): this function must NEVER name coin_state_.
+    // Everything it knows about the embedded arm arrived in `arm`, already
+    // resolved and deep-copied on the owning thread.
+    const uint64_t gen_at_source = arm.gen_at_source;
 
     coin::DashWorkData work;
     bool work_is_embedded = false;   // tracks the FINAL sourced arm for the cache tag
-    const bool try_embedded = embedded_arm_enabled && coin_state_.populated();
-    if (try_embedded || dashd_fallback_) {
+    if (arm.resolve_threw) {
+        LOG_WARNING << "[DASH-STRATUM] template sourcing threw: " << arm.resolve_error;
+        work = coin::DashWorkData{};
+    } else if (arm.try_embedded || dashd_fallback_) {
         try {
-            // Mainnet-gated: bypass select_work and source the reward-safe dashd
-            // fallback directly; testnet/regtest picks embedded-when-viable.
             coin::WorkSelection sel;
-            if (try_embedded) {
-                sel = coin_state_.select_work(dashd_fallback_);
+            if (arm.is_embedded) {
+                sel = coin::WorkSelection{ std::move(arm.work),
+                                           coin::WorkSource::Embedded,
+                                           arm.decline };
             } else {
-                // The mainnet gate refused BEFORE viability was ever consulted;
-                // name that, or the operator reads "dashd-fallback" and starts
-                // hunting a coin-state fault that does not exist.
-                coin::DeclineReport gated;
-                if (!embedded_arm_enabled) {
-                    // The mainnet opt-in is off, so viability was never even
-                    // consulted. Name the GATE, not the coin state -- an
-                    // operator here must flip a flag, not chase a sync fault.
-                    gated.viable    = false;
-                    gated.cause     = "mainnet-gate-off";
-                    gated.value     = "embedded_mainnet=false";
-                    gated.threshold = "--embedded-mainnet";
-                } else {
-                    // Armed but unpopulated. Ask THE clause list rather than
-                    // restating a poorer version of it here; that duplication
-                    // is precisely the drift this design exists to prevent.
-                    gated = coin_state_.describe_decline();
-                }
-                sel = coin::WorkSelection{
-                    dashd_fallback_ ? dashd_fallback_() : coin::DashWorkData{},
-                    coin::WorkSource::DashdFallback, std::move(gated) };
-            }
-            // BLOCKER-3 pre-emit HARD GATE (PR #780): re-validate an EMBEDDED
-            // template's CbTx against consensus invariants (both roots recomputed,
-            // DKG/superblock/bestCL/credit-pool-height guards) before it can be
-            // served; on any failure DISCARD it for the reward-safe dashd arm.
-            coin::DeclineReport emit_why;
-            if (sel.source == coin::WorkSource::Embedded
-                && !coin_state_.embedded_template_emit_ok(sel.work, &emit_why)) {
-                const uint32_t declined_h = sel.work.m_height;
-                sel = coin::WorkSelection{
-                    dashd_fallback_ ? dashd_fallback_() : coin::DashWorkData{},
-                    coin::WorkSource::DashdFallback, emit_why };
-                // On a daemonless node the fallback arm is UNARMED and returns
-                // an empty template (m_height == 0). Keep the height the
-                // embedded arm was refusing AT -- "h=0" told the operator
-                // nothing, and it is the single most misleading field in the
-                // measured 08-03 fallback lines.
-                if (sel.work.m_height == 0) sel.work.m_height = declined_h;
+                // The fallback arm: the blocking dashd getblocktemplate. This is
+                // the ONLY reason the io-decouple exists, and it stays here — on
+                // whichever thread the re-source runs — rather than moving onto
+                // the io thread with the coin-state resolution.
+                coin::DashWorkData fb =
+                    dashd_fallback_ ? dashd_fallback_() : coin::DashWorkData{};
+                if (fb.m_height == 0 && arm.declined_height != 0)
+                    fb.m_height = arm.declined_height;
+                sel = coin::WorkSelection{ std::move(fb),
+                                           coin::WorkSource::DashdFallback,
+                                           arm.decline };
             }
             // GBT-xcheck reward-safety BACKSTOP (soak): when enabled and a dashd
             // is reachable, cross-check the embedded CbTx creditPoolBalance
@@ -611,8 +715,18 @@ nlohmann::json DASHWorkSource::embedded_arm_status_json() const
 
 std::shared_ptr<const coin::DashWorkData> DASHWorkSource::cached_work() const
 {
+    // COIN-STATE-OWNING THREAD ONLY (#1134) — see the declaration. This body
+    // reads NodeCoinState (the serve-time embedded re-check below) and resolves
+    // the arm for the background job; NodeCoinState has no lock. Production
+    // reaches here only through core::StratumServer, which shares main_dash's
+    // single-threaded `ioc` and creates no thread, strand or pool of its own.
     const uint64_t gen = work_generation_.load(std::memory_order_relaxed);
     const auto now = std::chrono::steady_clock::now();
+    // Deferred to AFTER template_mutex_ is released: resolving the arm can build
+    // a full embedded template, and holding the template lock across that would
+    // stall peek_template() on the dashboard thread for no reason.
+    bool post_refresh = false;
+    std::shared_ptr<const coin::DashWorkData> executor_serve;
     {
         std::lock_guard<std::mutex> lk(template_mutex_);
         // FRESH cache (same generation, inside the TTL) -> serve it. The
@@ -640,9 +754,9 @@ std::shared_ptr<const coin::DashWorkData> DASHWorkSource::cached_work() const
 
         if (refresh_executor_) {
             // NON-BLOCKING scale path (the fix for 60+ sessions freezing on each
-            // re-source): the io thread NEVER runs the blocking select_work()/
-            // dashd-GBT. Hand it to the background rpc_pool as a SINGLE-FLIGHT
-            // job and serve the CURRENT cache (possibly stale, or null on a
+            // re-source): the io thread NEVER runs the blocking dashd-GBT. Hand
+            // it to the background rpc_pool as a SINGLE-FLIGHT job and serve the
+            // CURRENT cache (possibly stale, or null on a
             // set-gap) immediately. A minted share bumps the generation ~every
             // 15-30 s; before, that blocked the io thread on a full GBT -- now it
             // costs one background fetch, coalesced. A stale serve is bounded by
@@ -661,24 +775,48 @@ std::shared_ptr<const coin::DashWorkData> DASHWorkSource::cached_work() const
                 && template_last_fail_at_.time_since_epoch().count() != 0
                 && now - template_last_fail_at_ < kRetryAfter
                 && template_last_fail_gen_ == gen;
-            if (!recently_failed && !template_refresh_inflight_.exchange(true)) {
-                refresh_executor_([this]() {
-                    resource_template_now();
-                    template_refresh_inflight_.store(false);
-                });
-            }
-            return template_cache_;   // stale-or-null; null == honest set-gap
+            if (!recently_failed && !template_refresh_inflight_.exchange(true))
+                post_refresh = true;
+            // Snapshot the cache UNDER the lock, exactly as the pre-#1134 form
+            // returned it under the lock: the background job cannot have run
+            // yet (it is posted below and must take template_mutex_ to store),
+            // so this is the same stale-or-null value.
+            executor_serve = template_cache_;   // null == honest set-gap
+        } else {
+            // Legacy inline-blocking path (executor not wired: embedded/tests) --
+            // BYTE-IDENTICAL to the pre-decouple behaviour. Negative cache: a recent
+            // failed sourcing attempt -> don't re-poll yet — UNLESS the generation
+            // moved since the failure (an event changed the answer; same
+            // soak0804e break-through as the executor path above).
+            if (!template_cache_ && template_last_fail_at_.time_since_epoch().count() != 0
+                && now - template_last_fail_at_ < kRetryAfter
+                && template_last_fail_gen_ == gen)
+                return nullptr;
         }
+    }
 
-        // Legacy inline-blocking path (executor not wired: embedded/tests) --
-        // BYTE-IDENTICAL to the pre-decouple behaviour. Negative cache: a recent
-        // failed sourcing attempt -> don't re-poll yet — UNLESS the generation
-        // moved since the failure (an event changed the answer; same
-        // soak0804e break-through as the executor path above).
-        if (!template_cache_ && template_last_fail_at_.time_since_epoch().count() != 0
-            && now - template_last_fail_at_ < kRetryAfter
-            && template_last_fail_gen_ == gen)
-            return nullptr;
+    if (refresh_executor_) {
+        if (post_refresh) {
+            // ── #1134: THE OWNERSHIP HANDOFF ────────────────────────────────
+            // Resolve every NodeCoinState-dependent input HERE, on the thread
+            // that owns the coin state, and hand the background pool a
+            // self-contained VALUE. Before this, the posted job called
+            // resource_template_now() which read populated() / select_work() /
+            // describe_decline() / embedded_template_emit_ok() on the rpc_pool
+            // thread — select_work() hands raw pointers into m_mnstates/m_sml
+            // and the template assembly dereferences them for its whole
+            // duration, so a concurrent maintainer write was the 2026-08-05
+            // heap-corruption shape, on the serve path.
+            //
+            // The dashd getblocktemplate RPC — the ONLY reason the decouple
+            // exists — still runs inside the posted job, off this thread.
+            CoinStateArm arm = resolve_coin_state_arm();
+            refresh_executor_([this, arm = std::move(arm)]() mutable {
+                resource_template_now(std::move(arm));
+                template_refresh_inflight_.store(false);
+            });
+        }
+        return executor_serve;   // stale-or-null; null == honest set-gap
     }
 
     // Legacy path only: re-source inline (blocks the caller) then serve.

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -38,7 +38,15 @@
 //   - `workers_` is guarded by `workers_mutex_`
 //   - `best_share_hash_fn_` / `mint_share_fn_` guarded by their own mutexes
 //   - the template cache (stage 4c) is guarded by `template_mutex_`
-//   - `coin_state_` has its own internal locking; `dashd_fallback_` is const
+//   - `dashd_fallback_` is const
+//   - `coin_state_` has NO internal locking (#1134 — the line here used to
+//     claim it did, and that claim is what made the background re-source look
+//     safe). `coin::NodeCoinState` contains ZERO mutexes and hands RAW POINTERS
+//     into its live containers out of select_work(), so it may be read ONLY
+//     from the thread that mutates it. In this class that is: cached_work(),
+//     resolve_coin_state_arm() and get_work() — all reached from the single
+//     ioc.run() thread. Everything that runs elsewhere (the refresh_executor_
+//     job) takes a by-value CoinStateArm instead.
 //
 // What's deliberately MVP-incomplete in this 4a skeleton (mirrors
 // dgb::stratum::DGBWorkSource's own 4a landing): every work-generation /
@@ -416,11 +424,86 @@ private:
     /// template source armed / empty template) -- never a fabricated one.
     /// Bumps work_generation_ when a refresh observes a moved coin tip so
     /// stratum sessions re-push work on their next heartbeat.
+    ///
+    /// COIN-STATE-OWNING THREAD ONLY (#1134). This reads NodeCoinState directly
+    /// (the serve-time embedded re-check) and calls resolve_coin_state_arm();
+    /// NodeCoinState carries ZERO mutexes, so it may only be read from the
+    /// thread that mutates it. Every production caller reaches this through
+    /// core::StratumServer, which is constructed over main_dash's `ioc` and
+    /// creates no thread, strand or pool of its own -- so "the caller" is the
+    /// single ioc.run() thread by construction, not by configuration.
     std::shared_ptr<const coin::DashWorkData> cached_work() const;
-    // io-thread-decouple: the blocking select_work()/dashd-GBT re-source, factored
-    // out so it runs either inline (legacy blocking path, no executor wired) OR
-    // on the background rpc_pool thread (via refresh_executor_). Updates the
-    // template cache under template_mutex_.
+
+    /// Everything the template re-source needs to know from NodeCoinState,
+    /// RESOLVED BY VALUE. It deliberately carries no pointer, reference or
+    /// handle into the coin state -- see resolve_coin_state_arm().
+    ///
+    /// This is the DASHWorkSource sibling of EmbeddedOracleShadow::TipJob
+    /// (PR #1135) and of the queue element EmbeddedShadowCompare::on_serve
+    /// already used correctly: the owning thread resolves, the value crosses
+    /// the thread boundary, the reader owns every byte it reads.
+    struct CoinStateArm {
+        /// work_generation_ observed BEFORE any sourcing began (including the
+        /// resolution itself). The negative cache and the stored cache
+        /// generation key off this, so it must be sampled at the FIRST step of
+        /// the re-source, never after it -- see resource_template_now().
+        uint64_t            gen_at_source{0};
+        /// coin_state_.populated() AND the mainnet gate: the embedded arm was
+        /// actually consulted. false => a pure dashd-fallback re-source.
+        bool                try_embedded{false};
+        /// The embedded arm won AND passed the pre-emit hard gate. When false
+        /// the sourcing thread takes the dashd-RPC arm.
+        bool                is_embedded{false};
+        /// The embedded template, DEEP-COPIED out of the selector on the owning
+        /// thread. Meaningful only when is_embedded. DashWorkData is
+        /// all-by-value (coin/rpc_data.hpp) -- owning it is what makes the
+        /// off-thread read safe.
+        coin::DashWorkData  work;
+        /// WHY the fallback arm will be taken, carried out of the SAME branch
+        /// that chose it (never recomputed on the sourcing thread). viable{}
+        /// when is_embedded.
+        coin::DeclineReport decline;
+        /// Height the embedded arm was refusing AT, when the pre-emit gate
+        /// rejected its template. 0 otherwise. Used only to keep an UNARMED
+        /// fallback's h=0 from erasing the one number the operator needs.
+        uint32_t            declined_height{0};
+        /// The resolution itself threw. The sourcing thread reproduces the
+        /// pre-#1134 "template sourcing threw" log + empty-template outcome
+        /// rather than swallowing it.
+        bool                resolve_threw{false};
+        std::string         resolve_error;
+    };
+
+    /// COIN-STATE-OWNING THREAD ONLY (#1134). Reads NodeCoinState -- populated(),
+    /// select_work(), describe_decline(), embedded_template_emit_ok() -- and
+    /// returns a self-contained VALUE. NodeCoinState has ZERO mutexes and
+    /// select_work() hands RAW POINTERS into its live containers
+    /// (node_coin_state.hpp `&m_mnstates` / `&m_sml`) which the template
+    /// assembly then dereferences, so reading it from the rpc_pool thread while
+    /// the coin-P2P maintainer mutates it on the io thread is the 2026-08-05
+    /// hotel heap-corruption shape -- on the SERVE path this time. Everything
+    /// downstream of this call runs off a copy.
+    ///
+    /// The select_work() fallback arm is bound to a NO-OP here on purpose: the
+    /// real fallback is a dashd getblocktemplate behind NodeRPC::m_rpc_mutex
+    /// (12 s socket deadline) and this may run on the io thread. The dashd RPC
+    /// is taken by resource_template_now() instead -- same call, same count, on
+    /// whichever thread the re-source itself runs.
+    CoinStateArm resolve_coin_state_arm() const;
+
+    // io-thread-decouple: the blocking dashd-GBT re-source + cache update,
+    // factored out so it runs either inline (legacy blocking path, no executor
+    // wired) OR on the background rpc_pool thread (via refresh_executor_).
+    // Updates the template cache under template_mutex_.
+    //
+    // ANY THREAD (#1134). This overload must NEVER name coin_state_: everything
+    // it knows about the embedded arm arrives in `arm`, already resolved and
+    // copied by resolve_coin_state_arm() on the owning thread. The structural
+    // guard in test/test_dash_work_source_ownership.cpp pins that.
+    void resource_template_now(CoinStateArm arm) const;
+
+    // Convenience for the inline (no-executor) path: resolve on THIS thread and
+    // source immediately. Identical to the pre-#1134 single-function form.
     void resource_template_now() const;
 
 public:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -918,9 +918,13 @@ if (BUILD_TESTING AND GTest_FOUND)
     # source-structural guard over embedded_oracle_shadow.hpp + main_dash.cpp,
     # so it needs no link deps of its own; the compile definitions hand it the
     # paths to the SHIPPED sources.
+    # D-DASH.WORKSOURCE-OWNERSHIP (#1134) is its SERVE-path sibling and rides the
+    # same target for the same reason — it guards stratum/work_source.{cpp,hpp}
+    # by source text, so it adds no link deps either.
     add_executable(test_dash_node_coin_state
         test_dash_node_coin_state.cpp
-        test_dash_oracle_shadow_ownership.cpp)
+        test_dash_oracle_shadow_ownership.cpp
+        test_dash_work_source_ownership.cpp)
     target_link_libraries(test_dash_node_coin_state PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core
@@ -930,7 +934,9 @@ if (BUILD_TESTING AND GTest_FOUND)
     target_link_libraries(test_dash_node_coin_state PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
     target_compile_definitions(test_dash_node_coin_state PRIVATE
         DASH_ORACLE_SHADOW_SRC="${CMAKE_CURRENT_SOURCE_DIR}/../src/impl/dash/coin/embedded_oracle_shadow.hpp"
-        DASH_MAIN_SRC="${CMAKE_CURRENT_SOURCE_DIR}/../src/c2pool/main_dash.cpp")
+        DASH_MAIN_SRC="${CMAKE_CURRENT_SOURCE_DIR}/../src/c2pool/main_dash.cpp"
+        DASH_WORK_SOURCE_SRC="${CMAKE_CURRENT_SOURCE_DIR}/../src/impl/dash/stratum/work_source.cpp"
+        DASH_WORK_SOURCE_HDR="${CMAKE_CURRENT_SOURCE_DIR}/../src/impl/dash/stratum/work_source.hpp")
     gtest_add_tests(test_dash_node_coin_state "" AUTO)
 
     # bestCL template gate: dashcore's CheckCbTxBestChainlock rule (consensus-

--- a/test/test_dash_oracle_shadow_ownership.cpp
+++ b/test/test_dash_oracle_shadow_ownership.cpp
@@ -43,6 +43,11 @@
 #ifndef DASH_MAIN_SRC
 #error "DASH_MAIN_SRC must be defined by CMake to the path of src/c2pool/main_dash.cpp"
 #endif
+// #1134: the superseded arm-guard tripwire below now asserts the ownership split
+// in the work source itself, so it needs that source too.
+#ifndef DASH_WORK_SOURCE_SRC
+#error "DASH_WORK_SOURCE_SRC must be defined by CMake to the path of src/impl/dash/stratum/work_source.cpp"
+#endif
 
 namespace {
 
@@ -241,43 +246,62 @@ TEST(DashOracleShadowOwnership, PendingSlotHoldsTheJobByValue)
 }
 
 // ── The SIBLING exposure: DASHWorkSource::resource_template_now() ───────────
-// work_source.cpp:335/:346/:353/:371/:383 read NodeCoinState (populated(),
-// select_work(), describe_decline(), embedded_template_emit_ok()) and can run
-// on the rpc_pool worker (main_dash.cpp:5056) when refresh_executor_ is wired.
-// That is the SAME unguarded-read shape as the oracle-shadow bug — and today
-// the ONLY thing that makes it safe is ARM EXCLUSIVITY: the executor is
-// installed under `!coin_p2p`, while every NodeCoinState MUTATOR lives inside
-// the `if (coin_p2p)` block, so on the arm that has the worker the coin state
-// is write-quiescent. That is an accident of configuration, not an invariant,
-// and main_dash.cpp:4197-4204 explicitly anticipates extending io-decouple to
-// the coin_p2p arm. This test makes that day RED instead of silent.
+// SUPERSEDED BY #1134. This test was `RefreshExecutorStaysOffTheCoinP2PArm`.
 //
-// It deliberately does NOT change the serve path — the fix belongs in its own
-// PR (see the tracking issue referenced in the PR body).
-TEST(DashOracleShadowOwnership, RefreshExecutorStaysOffTheCoinP2PArm)
+// When #1135 landed, DASHWorkSource::resource_template_now() read NodeCoinState
+// (populated(), select_work(), describe_decline(), embedded_template_emit_ok())
+// and ran on the rpc_pool worker whenever refresh_executor_ was wired — the same
+// unguarded-read shape as the oracle-shadow bug, on the SERVE path. The ONLY
+// thing that made it safe was ARM EXCLUSIVITY: the executor was installed under
+// `!coin_p2p` while every NodeCoinState MUTATOR lived inside `if (coin_p2p)`, so
+// on the arm that had the worker the coin state happened to be write-quiescent.
+// This test asserted that configuration coincidence, because a tripwire was all
+// #1135 could offer without touching the serve path.
+//
+// #1134 replaced the coincidence with OWNERSHIP: resolve_coin_state_arm() makes
+// every NodeCoinState read on the owning thread and hands the background job a
+// by-value CoinStateArm. The `!coin_p2p` condition is therefore no longer
+// load-bearing for this shape, and continuing to assert it would pin the exact
+// configuration detail the dashd cut is going to relax.
+//
+// What this test pins INSTEAD: the executor may be installed on either arm,
+// PROVIDED the function that executor runs owns everything it reads. Revert the
+// split -> RED, with the arm-guard warning restated. The full serve-path guard
+// (every reader enumerated by name, the by-value handoff, the no-op fallback)
+// lives in test/test_dash_work_source_ownership.cpp.
+TEST(DashOracleShadowOwnership, RefreshExecutorArmGuardSupersededByCoinStateOwnership)
 {
     const std::string src = strip_comments(read_main_dash());
     ASSERT_EQ(count_of(src, "set_refresh_executor("), 1u)
         << "expected exactly one set_refresh_executor() install site in main_dash.cpp";
-    const size_t at = src.find("set_refresh_executor(");
-    ASSERT_NE(at, std::string::npos);
 
-    // Nearest enclosing top-level (4-space indent) `if (` before the install.
-    const std::string head = src.substr(0, at);
-    const size_t if_at = head.rfind("\n    if (");
-    ASSERT_NE(if_at, std::string::npos)
-        << "set_refresh_executor() is no longer inside a top-level if — the arm "
-           "guard cannot be verified.";
-    const size_t eol = src.find('\n', if_at + 1);
-    const std::string cond = src.substr(if_at + 1, eol - if_at - 1);
+    const std::string ws = strip_comments(read_text(DASH_WORK_SOURCE_SRC));
 
-    EXPECT_NE(cond.find("!coin_p2p"), std::string::npos)
-        << "The rpc_pool refresh executor is being installed WITHOUT the "
-           "!coin_p2p guard. DASHWorkSource::resource_template_now() then reads "
-           "NodeCoinState (select_work -> raw pointers into m_mnstates/m_sml) on "
-           "a worker thread while the coin-P2P maintainer mutates it on the io "
-           "thread — the 2026-08-05 heap-corruption shape, on the SERVE path "
-           "this time. Resolve on the io thread and hand the worker a value "
-           "(the on_new_tip pattern) before relaxing this. Condition was: "
-        << cond;
+    // (1) The ownership handoff exists: the executor-run overload takes the
+    //     already-resolved arm BY VALUE.
+    const size_t sig =
+        ws.find("void DASHWorkSource::resource_template_now(CoinStateArm arm)");
+    ASSERT_NE(sig, std::string::npos)
+        << "resource_template_now(CoinStateArm) is gone — the #1134 ownership "
+           "split has been reverted, so the rpc_pool job resolves the arm itself "
+           "again and the only thing between this node and the 2026-08-05 heap "
+           "corruption is the !coin_p2p install guard in main_dash.cpp. Restore "
+           "the split before relaxing that guard.";
+
+    // (2) The function the executor runs never names the coin state.
+    const size_t close = ws.find("\n}\n", sig);
+    ASSERT_NE(close, std::string::npos)
+        << "resource_template_now(CoinStateArm) has no terminator";
+    const std::string body = ws.substr(sig, close - sig);
+    EXPECT_EQ(body.find("coin_state_"), std::string::npos)
+        << "resource_template_now() reads NodeCoinState again. It runs on the "
+           "rpc_pool worker whenever refresh_executor_ is wired; NodeCoinState "
+           "has ZERO mutexes and select_work() hands raw pointers into "
+           "m_mnstates/m_sml. Resolve on the owning thread "
+           "(resolve_coin_state_arm) and pass a value.";
+
+    // (3) And the owning-thread resolver is where those reads went.
+    EXPECT_NE(ws.find("DASHWorkSource::resolve_coin_state_arm()"), std::string::npos)
+        << "resolve_coin_state_arm() is missing — there is no owning-thread "
+           "resolver for the background job to take its value from.";
 }

--- a/test/test_dash_work_source_ownership.cpp
+++ b/test/test_dash_work_source_ownership.cpp
@@ -1,0 +1,342 @@
+// D-DASH.WORKSOURCE-OWNERSHIP (#1134) — source-structural guard pinning WHICH
+// THREAD is allowed to read NodeCoinState from the SERVE path.
+//
+// THE DEFECT THIS PINS (the sibling of the 2026-08-05 hotel SIGABRT that PR
+// #1135 fixed, on the path that builds the templates our miners work on):
+//
+//   coin::NodeCoinState (impl/dash/coin/node_coin_state.hpp) has ZERO mutexes,
+//   and select_work() hands RAW POINTERS into its live containers out to the
+//   caller — `e.mnstates = &m_mnstates` (an MnStateMachine map) and
+//   `e.sml = &m_sml` (a CSimplifiedMNList vector). build_embedded_workdata()
+//   then dereferences them for the ENTIRE template assembly.
+//
+//   DASHWorkSource::resource_template_now() used to read that state itself —
+//   populated(), select_work(), describe_decline(), embedded_template_emit_ok()
+//   — and it runs on the rpc_pool worker thread whenever refresh_executor_ is
+//   wired (main_dash.cpp set_refresh_executor). Meanwhile cached_work() reads
+//   the same object on the io thread. Two threads, one unguarded object.
+//
+//   It never fired because of ARM EXCLUSIVITY and nothing else: the executor is
+//   installed under `!coin_p2p`, while every NodeCoinState MUTATOR lives inside
+//   the `if (coin_p2p)` block, so on the arm that has the worker the coin state
+//   happened to be write-quiescent after startup. That is an accident of
+//   configuration, not an invariant — and cutting dashd (removing --coin-rpc)
+//   changes exactly those flags.
+//
+// THE FIX: split the re-source in two. resolve_coin_state_arm() makes EVERY
+// NodeCoinState read on the thread that owns the state and returns a
+// self-contained by-value CoinStateArm; resource_template_now(CoinStateArm)
+// does the dashd RPCs, the arm log, the journal and the cache update off a
+// copy and never names the coin state. Same shape as
+// EmbeddedOracleShadow::on_new_tip/process_tip (#1135) and
+// EmbeddedShadowCompare::on_serve.
+//
+// WHY A STRUCTURAL TEST: a true data race is nondeterministic and was NOT
+// reproduced under a sanitizer. A guard that asserts the OWNERSHIP SHAPE is the
+// deterministic red/green this invariant admits, and it is the house pattern
+// for exactly this situation (src/impl/dgb/test/race913_lock_guard_test.cpp,
+// PR #1114; test/test_dash_oracle_shadow_ownership.cpp, PR #1135). Move any
+// coin_state_ read back into the executor-run function -> RED.
+#include <gtest/gtest.h>
+
+#include <cctype>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#ifndef DASH_WORK_SOURCE_SRC
+#error "DASH_WORK_SOURCE_SRC must be defined by CMake to the path of src/impl/dash/stratum/work_source.cpp"
+#endif
+#ifndef DASH_WORK_SOURCE_HDR
+#error "DASH_WORK_SOURCE_HDR must be defined by CMake to the path of src/impl/dash/stratum/work_source.hpp"
+#endif
+
+namespace {
+
+std::string read_text(const char* path)
+{
+    std::ifstream in(path);
+    EXPECT_TRUE(in.good()) << "cannot open " << path;
+    std::stringstream ss; ss << in.rdbuf();
+    return ss.str();
+}
+
+// Replace every comment with spaces, preserving byte offsets and line breaks.
+// Comments must not be able to satisfy (or break) an assertion about what the
+// CODE does — this file's own subject deliberately quotes the pre-fix
+// expressions in its doc blocks.
+std::string strip_comments(const std::string& s)
+{
+    std::string out = s;
+    enum { kCode, kLine, kBlock, kStr, kChr } st = kCode;
+    for (size_t i = 0; i < out.size(); ++i) {
+        const char c = out[i];
+        const char n = (i + 1 < out.size()) ? out[i + 1] : '\0';
+        switch (st) {
+        case kCode:
+            if (c == '/' && n == '/') { st = kLine;  out[i] = ' '; out[i + 1] = ' '; ++i; }
+            else if (c == '/' && n == '*') { st = kBlock; out[i] = ' '; out[i + 1] = ' '; ++i; }
+            else if (c == '"')  st = kStr;
+            else if (c == '\'') st = kChr;
+            break;
+        case kLine:
+            if (c == '\n') st = kCode; else out[i] = ' ';
+            break;
+        case kBlock:
+            if (c == '*' && n == '/') { out[i] = ' '; out[i + 1] = ' '; ++i; st = kCode; }
+            else if (c != '\n') out[i] = ' ';
+            break;
+        case kStr:
+            if (c == '\\') ++i; else if (c == '"') st = kCode;
+            break;
+        case kChr:
+            if (c == '\\') ++i; else if (c == '\'') st = kCode;
+            break;
+        }
+    }
+    return out;
+}
+
+struct Range { size_t begin{std::string::npos}; size_t end{std::string::npos}; };
+
+// Byte range [begin,end) of an out-of-line member definition in work_source.cpp.
+// Members here sit at column 0 and every nested block closes deeper, so the
+// closing "\n}\n" is unambiguous.
+Range member_range(const std::string& src, const std::string& signature)
+{
+    Range r;
+    r.begin = src.find(signature);
+    if (r.begin == std::string::npos) return r;
+    const size_t close = src.find("\n}\n", r.begin);
+    if (close == std::string::npos) { r.begin = std::string::npos; return r; }
+    r.end = close + 3;   // strlen("\n}\n")
+    return r;
+}
+
+std::string member_body(const std::string& src, const std::string& signature)
+{
+    const Range r = member_range(src, signature);
+    if (r.begin == std::string::npos) return "";
+    return src.substr(r.begin, r.end - r.begin);
+}
+
+size_t count_of(const std::string& hay, const std::string& needle)
+{
+    size_t n = 0, pos = 0;
+    while ((pos = hay.find(needle, pos)) != std::string::npos) { ++n; pos += needle.size(); }
+    return n;
+}
+
+// Every out-of-line member definition, as (offset of the "DASHWorkSource::"
+// token, member name). Used to name the function ENCLOSING an arbitrary offset
+// without hardcoding a signature list — a newly added reader is caught by name
+// instead of slipping past a stale allowlist.
+struct MemberMark { size_t at; std::string name; };
+
+std::vector<MemberMark> member_marks(const std::string& src)
+{
+    static const std::string kQual = "DASHWorkSource::";
+    std::vector<MemberMark> out;
+    size_t pos = 0;
+    while ((pos = src.find(kQual, pos)) != std::string::npos) {
+        size_t i = pos + kQual.size();
+        std::string name;
+        while (i < src.size()
+               && (std::isalnum(static_cast<unsigned char>(src[i])) || src[i] == '_'))
+            name.push_back(src[i++]);
+        if (!name.empty()) out.push_back({pos, name});
+        pos += kQual.size();
+    }
+    return out;
+}
+
+// The whole identifier occupying `at`, so a substring hit inside a LONGER name
+// (resolve_coin_state_arm contains "coin_state_") is not mistaken for a member
+// access.
+std::string identifier_at(const std::string& src, size_t at)
+{
+    auto is_id = [](char c) {
+        return std::isalnum(static_cast<unsigned char>(c)) || c == '_';
+    };
+    size_t b = at, e = at;
+    while (b > 0 && is_id(src[b - 1])) --b;
+    while (e < src.size() && is_id(src[e])) ++e;
+    return src.substr(b, e - b);
+}
+
+std::string enclosing_member(const std::vector<MemberMark>& marks, size_t at)
+{
+    std::string name = "(file scope)";
+    for (const auto& m : marks) {
+        if (m.at > at) break;
+        name = m.name;
+    }
+    return name;
+}
+
+const char* kResolveSig  = "DASHWorkSource::CoinStateArm DASHWorkSource::resolve_coin_state_arm()";
+const char* kSourceArgSig = "void DASHWorkSource::resource_template_now(CoinStateArm arm)";
+const char* kCachedSig   = "DASHWorkSource::cached_work() const";
+
+} // namespace
+
+// ── The thread that is NOT the owner must not be able to reach NodeCoinState ─
+// resource_template_now(CoinStateArm) is the body the refresh_executor_ job
+// runs — i.e. the rpc_pool thread. A single textual reference to coin_state_
+// inside it is the whole bug back.
+TEST(DashWorkSourceOwnership, SourcingFunctionNeverTouchesCoinState)
+{
+    const std::string src  = strip_comments(read_text(DASH_WORK_SOURCE_SRC));
+    const std::string body = member_body(src, kSourceArgSig);
+    ASSERT_FALSE(body.empty())
+        << "resource_template_now(CoinStateArm arm) not found in "
+        << DASH_WORK_SOURCE_SRC
+        << " — the ownership split (#1134) is absent, so the function the "
+           "refresh_executor_ job runs still resolves the arm itself.";
+    EXPECT_EQ(body.find("coin_state_"), std::string::npos)
+        << "resource_template_now() runs on the rpc_pool worker whenever "
+           "refresh_executor_ is wired and must never read NodeCoinState (no "
+           "mutex; select_work() hands out raw pointers into live containers -> "
+           "the 2026-08-05 heap corruption, on the SERVE path). Resolve on the "
+           "owning thread in resolve_coin_state_arm() and hand it a value.";
+}
+
+// ── Enumerate EVERY coin_state_ read and name the function it sits in ───────
+// The allowlist is the set of members that provably run on the coin-state
+// owning thread. A new reader anywhere else fails here BY NAME, without anyone
+// having to remember to extend a signature list.
+TEST(DashWorkSourceOwnership, EveryCoinStateReadSitsInAnOwningThreadMember)
+{
+    const std::string src = strip_comments(read_text(DASH_WORK_SOURCE_SRC));
+    const auto marks = member_marks(src);
+    ASSERT_FALSE(marks.empty()) << "no DASHWorkSource:: member definitions found";
+
+    // DASHWorkSource      -> the constructor's initialiser list (binds the ref)
+    // resolve_coin_state_arm -> THE owning-thread resolver (#1134)
+    // cached_work         -> serve-time embedded re-check; owning thread, see hpp
+    // get_work            -> IWorkSource seam, no production caller (tests only)
+    const std::vector<std::string> allowed = {
+        "DASHWorkSource", "resolve_coin_state_arm", "cached_work", "get_work"};
+
+    size_t pos = 0, seen = 0;
+    while ((pos = src.find("coin_state_", pos)) != std::string::npos) {
+        // Member accesses only — not resolve_coin_state_arm(), which merely
+        // contains the member's name.
+        if (identifier_at(src, pos) != "coin_state_") { pos += 11; continue; }
+        ++seen;
+        const std::string who = enclosing_member(marks, pos);
+        bool ok = false;
+        for (const auto& a : allowed) if (a == who) { ok = true; break; }
+        EXPECT_TRUE(ok)
+            << "NodeCoinState is read inside DASHWorkSource::" << who
+            << "(), which is not on the coin-state owning-thread allowlist. "
+               "NodeCoinState has ZERO mutexes and select_work() hands raw "
+               "pointers into m_mnstates/m_sml; reading it off the io thread is "
+               "the 2026-08-05 heap-corruption shape. Resolve on the owning "
+               "thread (resolve_coin_state_arm) and pass a by-value CoinStateArm.";
+        pos += 11;   // strlen("coin_state_")
+    }
+    EXPECT_GT(seen, 0u) << "no coin_state_ references at all — the guard has "
+                           "nothing to protect; did the member get renamed?";
+}
+
+// ── The owning thread must not take a dashd RPC ─────────────────────────────
+// select_work()'s fallback arm is a dashd getblocktemplate behind
+// NodeRPC::m_rpc_mutex (12 s socket deadline). Resolving on the io thread is
+// only correct because that arm is bound to a NO-OP here; binding the real
+// fallback would convert a rare crash into routine multi-second serve stalls —
+// exactly the trade PR #1135 rejected a NodeCoinState mutex for.
+TEST(DashWorkSourceOwnership, OwningThreadResolutionTakesNoDashdRpc)
+{
+    const std::string src = strip_comments(read_text(DASH_WORK_SOURCE_SRC));
+    EXPECT_EQ(src.find("coin_state_.select_work(dashd_fallback_)"), std::string::npos)
+        << "select_work() is being handed the REAL dashd fallback on the "
+           "coin-state owning (io) thread. That puts a 12 s getblocktemplate "
+           "deadline on the thread that serves 26 stratum sessions. The "
+           "fallback RPC belongs in resource_template_now(), which runs on the "
+           "rpc_pool when one is wired.";
+
+    const Range resolve = member_range(src, kResolveSig);
+    ASSERT_NE(resolve.begin, std::string::npos)
+        << "resolve_coin_state_arm() not found — the #1134 split is absent.";
+    EXPECT_EQ(count_of(src, "coin_state_.select_work("), 1u)
+        << "exactly one select_work() call site is expected, inside "
+           "resolve_coin_state_arm()";
+    const size_t at = src.find("coin_state_.select_work(");
+    ASSERT_NE(at, std::string::npos) << "select_work() call vanished entirely";
+    EXPECT_TRUE(at > resolve.begin && at < resolve.end)
+        << "select_work() is called from OUTSIDE resolve_coin_state_arm() — "
+           "only the coin-state owning thread may read NodeCoinState.";
+}
+
+// ── The handoff happens BEFORE the post, not inside the job ─────────────────
+TEST(DashWorkSourceOwnership, CachedWorkResolvesTheArmBeforePostingTheJob)
+{
+    const std::string src  = strip_comments(read_text(DASH_WORK_SOURCE_SRC));
+    const std::string body = member_body(src, kCachedSig);
+    ASSERT_FALSE(body.empty()) << "cached_work() not found";
+
+    const size_t resolved = body.find("resolve_coin_state_arm()");
+    ASSERT_NE(resolved, std::string::npos)
+        << "cached_work() does not resolve the arm at all — the background job "
+           "is still reading NodeCoinState on the rpc_pool thread.";
+    const size_t posted = body.find("refresh_executor_(");
+    ASSERT_NE(posted, std::string::npos)
+        << "the refresh_executor_ post site vanished from cached_work()";
+    EXPECT_LT(resolved, posted)
+        << "resolve_coin_state_arm() must run BEFORE the job is posted — "
+           "resolving inside the lambda would put the NodeCoinState read back "
+           "on the rpc_pool thread, which is the entire defect.";
+
+    // The posted lambda must carry the arm; capturing `this` alone and calling
+    // the no-arg overload is the pre-fix shape.
+    EXPECT_NE(body.find("resource_template_now(std::move(arm))"), std::string::npos)
+        << "the posted job must consume the by-value CoinStateArm resolved "
+           "above, not re-derive it.";
+}
+
+// ── The value that crosses the thread boundary must OWN what it carries ─────
+// A pointer/reference member would re-open the lifetime hole with none of the
+// textual evidence the tests above look for.
+TEST(DashWorkSourceOwnership, CoinStateArmIsAllByValue)
+{
+    const std::string hdr = strip_comments(read_text(DASH_WORK_SOURCE_HDR));
+    const size_t s = hdr.find("struct CoinStateArm {");
+    ASSERT_NE(s, std::string::npos)
+        << "struct CoinStateArm (the by-value ownership handoff) not found in "
+        << DASH_WORK_SOURCE_HDR;
+    const size_t e = hdr.find("\n    };\n", s);
+    ASSERT_NE(e, std::string::npos) << "CoinStateArm has no terminator";
+    const std::string body = hdr.substr(s, e - s);
+
+    EXPECT_NE(body.find("coin::DashWorkData  work;"), std::string::npos)
+        << "CoinStateArm must carry the embedded template BY VALUE (DashWorkData "
+           "is all-by-value; owning it is what makes the off-thread read safe)";
+    EXPECT_EQ(body.find("DashWorkData*"), std::string::npos)
+        << "CoinStateArm must not carry a POINTER to the template";
+    EXPECT_EQ(body.find("NodeCoinState"), std::string::npos)
+        << "CoinStateArm must not reference NodeCoinState in any form";
+    EXPECT_EQ(body.find("MnStateMachine"), std::string::npos)
+        << "CoinStateArm must not carry the MN state map (that is the live container)";
+    EXPECT_EQ(body.find("CSimplifiedMNList"), std::string::npos)
+        << "CoinStateArm must not carry the SML (that is the live container)";
+    EXPECT_EQ(body.find("&"), std::string::npos)
+        << "CoinStateArm must hold no reference member — the whole point is that "
+           "it outlives nothing.";
+}
+
+// ── The contract text must not re-assert the thing that made this look safe ──
+// The class header claimed `coin_state_` "has its own internal locking". It has
+// none (grep -c -i mutex node_coin_state.hpp -> 0). That sentence is why a
+// background re-source over it read as obviously fine for as long as it did.
+TEST(DashWorkSourceOwnership, HeaderDoesNotClaimCoinStateLocksItself)
+{
+    const std::string hdr = read_text(DASH_WORK_SOURCE_HDR);   // comments ARE the subject
+    EXPECT_EQ(hdr.find("`coin_state_` has its own internal locking"), std::string::npos)
+        << "the threading contract still claims NodeCoinState locks itself. It "
+           "contains ZERO mutexes. Say so, or the next reader repeats #1134.";
+    EXPECT_NE(hdr.find("NO internal locking"), std::string::npos)
+        << "the threading contract must state that coin_state_ has no internal "
+           "locking and name the threads allowed to read it.";
+}


### PR DESCRIPTION
Closes #1134. Step 1 of cutting dashd: this must land before anyone removes `--coin-rpc`.

## The exposure

`DASHWorkSource::resource_template_now()` read `NodeCoinState` directly — `populated()`, `select_work()`, `describe_decline()`, `embedded_template_emit_ok()` — and it runs on the **rpc_pool worker thread** whenever `refresh_executor_` is wired (`main_dash.cpp:5511`). Meanwhile `cached_work()` reads the same object on the io/stratum thread. Two threads, one object with **zero mutexes** (`grep -c -i mutex node_coin_state.hpp` -> 0).

`select_work()` hands **raw pointers into live containers** out to the caller — `e.mnstates = &m_mnstates` (an `MnStateMachine` map) and `e.sml = &m_sml` (a `CSimplifiedMNList` vector) — and `build_embedded_workdata()` dereferences them for the **entire** template assembly. `MNState` owns two heap vectors, so an overlapping maintainer write corrupts **allocator metadata**, not merely values. That is exactly the shape that killed the hotel primary with glibc `unaligned tcache chunk` / `double free` on 2026-08-05 and that #1135 fixed for `EmbeddedOracleShadow` — except this sibling is on the path that builds the templates our miners work on. A corrupted template here is a lost block, not a lost diagnostic sample.

It never fired because of **arm exclusivity and nothing else**: the executor is installed under `!coin_p2p` while every `NodeCoinState` mutator lives inside `if (coin_p2p)`, so on the arm that has the worker the coin state happened to be write-quiescent after startup. No assert, no comment, no invariant — a configuration coincidence. **Removing `--coin-rpc` changes exactly those flags.**

## The fix — lifetime/ownership only

Split the re-source at the thread boundary, mirroring #1135 and `EmbeddedShadowCompare::on_serve` rather than inventing a third form:

| | thread | does |
|---|---|---|
| `resolve_coin_state_arm()` | **owning** | every `NodeCoinState` read; returns a self-contained by-value `CoinStateArm` |
| `resource_template_now(CoinStateArm)` | **any** | every dashd RPC, the GBT-xcheck, the arm log, the serve-gate journal, the shadow-compare enqueue, the cache update. Names no coin state at all. |

`CoinStateArm` carries `gen_at_source`, `try_embedded`, `is_embedded`, a **deep-copied** `DashWorkData`, the `DeclineReport` and `declined_height` — no pointer, reference or handle into the coin state. `cached_work()` resolves **before** posting, outside `template_mutex_`, and the posted lambda carries the value.

`select_work()`'s fallback arm is bound to a **no-op** inside the resolution: the real fallback is a dashd `getblocktemplate` behind `NodeRPC::m_rpc_mutex` (12 s socket deadline) and the resolution may run on the io thread. `select_dash_work()` only invokes the fallback on the non-viable branch, so `resource_template_now()` makes exactly the same RPC, exactly once — only on the other side of the boundary. **Zero RPCs added, zero removed.**

### Why not a mutex on `NodeCoinState`

I evaluated it. The four reasons #1135 gave apply here with **more** force, because this is the serve path:

1. **It lands on the hot path.** `resource_template_now()` sources for 26 sessions per work-generation bump.
2. **The worst case is strictly worse than the bug.** A lock held across `select_work()` is a lock held across a 12 s dashd RPC deadline — converting a rare, restart-recoverable corruption into a **routine multi-second serve stall on a mining node**.
3. **A partial lock gives false confidence.** `mnstates()`, `sml()`, `mempool()`, `qmgr()` all return references into the internals; locking `select_work()` alone would leave them unprotected while making the class *look* thread-safe.
4. **The copy is not new work.** `WorkSelection` is already all-by-value and `DashWorkData` contains no pointers. Only the *location* of an existing copy moved.

## Behaviour deltas — the complete list

**No serve gate, arm decision, coinbase, payee, payout or consensus path is touched.** The arm that gets selected, the template bytes served, the `[EMBED-GATE]`/`[DASH-STRATUM-GBT]` text and the `no_work_reason` surface are all unchanged. Three deltas, all on the executor arm only, all in the conservative direction:

1. **`gen_at_source` is now sampled at resolve time instead of at rpc_pool run time** — i.e. it additionally covers the queueing delay. Both the negative cache (`template_last_fail_gen_`) and the stored `template_cache_gen_` key off it, and an *earlier* sample can only make the cache **more** willing to re-source, never less. Same discipline the soak0804e fix established, applied one step earlier.
2. **The local CPU-only embedded build moves onto the owning thread.** The dashd RPC — the only reason the decouple exists — stays on the pool. On the arm that has an executor today the embedded arm is not even armed, and on the `coin_p2p` arm this build already ran inline on io, so this is a no-op in both shipping configurations and the correct split for the combined one.
3. **The resolution catches `...` as well as `std::exception`,** failing closed into the same empty-template/negative-cache path. It runs between `template_refresh_inflight_` being claimed and the job being posted; an escape there would strand the single-flight flag and wedge every future re-source.

Also corrected: the class threading contract claimed `coin_state_` "has its own internal locking". **It has none.** That sentence is a large part of why a background re-source over it read as obviously fine.

## Off-io reader audit — re-confirmed on current master

Ground truth: `main_dash.cpp:6061` is the **single** `ioc.run()`, no `std::thread` wraps it, there is no `make_strand` anywhere in `src/impl/dash/`, and `core::StratumServer` (which is constructed over that same `ioc`) creates **no thread, strand or pool of its own** — so "the io thread" is the main thread, and every stratum handler, timer and socket callback is that one thread.

**Nothing new landed since #1135.** `git diff 41281884..f5588fd6 -- src/` adds **zero** `std::thread` / `thread_pool` / `make_strand` / `detach()`. The complete thread inventory of the DASH lane is byte-for-byte the one #1135 enumerated. #1126's new `[EMBED-STATUS]` diagnostic reads `node_coin_state` heavily but runs on an `io::steady_timer(ioc)` — the io thread. #1128's and #1126's `work_source.cpp` additions (`[BLOCK-LEDGER]`) read only `wd` and `serve_gate_mutex_`-guarded state.

**Off-io readers of `NodeCoinState`: now ZERO.**

1. `EmbeddedOracleShadow` worker — fixed in #1135.
2. `DASHWorkSource::resource_template_now()` on the rpc_pool worker — **fixed here**.

Cleared (off-io but provably no `NodeCoinState` path), re-verified: `EmbeddedShadowCompare` worker (holds no coin-state reference); ZMQ subscriber (`zmq_tip_notify.cpp:68` — posts to `ioc`); DNS-seed detached threads (`coin_peer_manager.hpp:1137`/`:1162`); `NodeImpl::m_verify_pool` / `m_think_pool` (`NodeImpl::select_work()`/`coin_state()` still have zero callers — dead seam); WebServer HTTP thread (the one lambda that captures the work source calls only `embedded_arm_status_json()`, `serve_gate_mutex_`-guarded; the dashboard seams go through `get_stratum_workers()` / `peek_template()`, both mutex-guarded snapshots); `run_mine_block`; `dash::stratum::get_work()` (still tests-only).

## Is the arm-exclusivity dependency GONE or narrowed?

**Gone, for this shape.** Every remaining `NodeCoinState` read in `DASHWorkSource` is in `resolve_coin_state_arm()`, `cached_work()` or `get_work()` (tests-only), and reaching any of them means going through `core::StratumServer`, which by construction runs on `ioc`. The residual condition is the ordinary "this object's `IWorkSource` surface is called from the stratum io thread" — enforced by the type of the constructor argument, not by a flag combination. `set_refresh_executor` can be installed on either arm without reopening this hole, which is precisely what the dashd cut needs.

Two honest caveats, neither arm-dependent:
- The `NodeCoinState` **class** is still lock-free, so a *future* off-io reader is still a hazard. The new guard enumerates every reader by name and fails on a new one, which is the strongest structural answer available short of locking the class.
- `cached_work()`'s serve-time embedded re-check still reads the coin state on the calling thread. That is *correct by definition* (it consults the CURRENT state) and it is the io thread — but it is a contract, now written down in the header and pinned by the allowlist test, rather than a proof.

## Tests — real red/green, both runs executed

`test/test_dash_work_source_ownership.cpp`, 6 tests. Rides the **existing allowlisted** `test_dash_node_coin_state` target (a new `add_executable` would be a NOT_BUILT sentinel, #143). **Not `#ifdef`-guarded** (#895) — the `#error` on a missing compile definition is a hard build failure, not a skip. A true UAF race is nondeterministic and was **not** reproduced under a sanitizer, so this is a source-structural ownership guard, the house pattern for exactly this situation (`src/impl/dgb/test/race913_lock_guard_test.cpp`, #1114; #1135's own suite). Comments are stripped before asserting, so the doc blocks that *quote* the pre-fix expressions cannot satisfy or break a check.

`EveryCoinStateReadSitsInAnOwningThreadMember` enumerates **every** `coin_state_` access in the file and names the enclosing member, so a newly added reader fails **by name** instead of slipping past a stale signature list.

### RED — same test source, sources from `master` (f5588fd6, unfixed)

```
[==========] Running 6 tests from 1 test suite.
[ RUN      ] DashWorkSourceOwnership.SourcingFunctionNeverTouchesCoinState
test_dash_work_source_ownership.cpp:178: Failure
Value of: body.empty()
  Actual: true
Expected: false
resource_template_now(CoinStateArm arm) not found in .../master_tree/src/impl/dash/stratum/work_source.cpp — the ownership split (#1134) is absent, so the function the refresh_executor_ job runs still resolves the arm itself.
[  FAILED  ] DashWorkSourceOwnership.SourcingFunctionNeverTouchesCoinState (1 ms)
[ RUN      ] DashWorkSourceOwnership.EveryCoinStateReadSitsInAnOwningThreadMember
test_dash_work_source_ownership.cpp:214: Failure
Value of: ok
  Actual: false
Expected: true
NodeCoinState is read inside DASHWorkSource::resource_template_now(), which is not on the coin-state owning-thread allowlist. NodeCoinState has ZERO mutexes and select_work() hands raw pointers into m_mnstates/m_sml; reading it off the io thread is the 2026-08-05 heap-corruption shape. Resolve on the owning thread (resolve_coin_state_arm) and pass a by-value CoinStateArm.
  ... (x5 — one per read: populated(), populated(), select_work(), describe_decline(), embedded_template_emit_ok())
[  FAILED  ] DashWorkSourceOwnership.EveryCoinStateReadSitsInAnOwningThreadMember (1 ms)
[ RUN      ] DashWorkSourceOwnership.OwningThreadResolutionTakesNoDashdRpc
test_dash_work_source_ownership.cpp:236: Failure
Expected equality of these values:
  src.find("coin_state_.select_work(dashd_fallback_)")
    Which is: 20387
  std::string::npos
select_work() is being handed the REAL dashd fallback on the coin-state owning (io) thread. That puts a 12 s getblocktemplate deadline on the thread that serves 26 stratum sessions. The fallback RPC belongs in resource_template_now(), which runs on the rpc_pool when one is wired.
test_dash_work_source_ownership.cpp:244: Failure
Expected: (resolve.begin) != (std::string::npos)
resolve_coin_state_arm() not found — the #1134 split is absent.
[  FAILED  ] DashWorkSourceOwnership.OwningThreadResolutionTakesNoDashdRpc (1 ms)
[ RUN      ] DashWorkSourceOwnership.CachedWorkResolvesTheArmBeforePostingTheJob
test_dash_work_source_ownership.cpp:264: Failure
Expected: (resolved) != (std::string::npos)
cached_work() does not resolve the arm at all — the background job is still reading NodeCoinState on the rpc_pool thread.
[  FAILED  ] DashWorkSourceOwnership.CachedWorkResolvesTheArmBeforePostingTheJob (1 ms)
[ RUN      ] DashWorkSourceOwnership.CoinStateArmIsAllByValue
test_dash_work_source_ownership.cpp:289: Failure
Expected: (s) != (std::string::npos)
struct CoinStateArm (the by-value ownership handoff) not found in .../master_tree/src/impl/dash/stratum/work_source.hpp
[  FAILED  ] DashWorkSourceOwnership.CoinStateArmIsAllByValue (0 ms)
[ RUN      ] DashWorkSourceOwnership.HeaderDoesNotClaimCoinStateLocksItself
test_dash_work_source_ownership.cpp:336: Failure
Expected equality of these values:
  hdr.find("`coin_state_` has its own internal locking")
    Which is: 2287
  std::string::npos
the threading contract still claims NodeCoinState locks itself. It contains ZERO mutexes. Say so, or the next reader repeats #1134.
test_dash_work_source_ownership.cpp:339: Failure
Expected: (hdr.find("NO internal locking")) != (std::string::npos)
the threading contract must state that coin_state_ has no internal locking and name the threads allowed to read it.
[  FAILED  ] DashWorkSourceOwnership.HeaderDoesNotClaimCoinStateLocksItself (0 ms)

[  PASSED  ] 0 tests.
[  FAILED  ] 6 tests
```

The superseded #1135 tripwire, same RED run:

```
[ RUN      ] DashOracleShadowOwnership.RefreshExecutorArmGuardSupersededByCoinStateOwnership
test_dash_oracle_shadow_ownership.cpp:284: Failure
Expected: (sig) != (std::string::npos)
resource_template_now(CoinStateArm) is gone — the #1134 ownership split has been reverted, so the rpc_pool job resolves the arm itself again and the only thing between this node and the 2026-08-05 heap corruption is the !coin_p2p install guard in main_dash.cpp. Restore the split before relaxing that guard.
[  FAILED  ] DashOracleShadowOwnership.RefreshExecutorArmGuardSupersededByCoinStateOwnership (7 ms)
```

### GREEN — same test source, this branch

```
[==========] Running 6 tests from 1 test suite.
[ RUN      ] DashWorkSourceOwnership.SourcingFunctionNeverTouchesCoinState
[       OK ] DashWorkSourceOwnership.SourcingFunctionNeverTouchesCoinState (1 ms)
[ RUN      ] DashWorkSourceOwnership.EveryCoinStateReadSitsInAnOwningThreadMember
[       OK ] DashWorkSourceOwnership.EveryCoinStateReadSitsInAnOwningThreadMember (1 ms)
[ RUN      ] DashWorkSourceOwnership.OwningThreadResolutionTakesNoDashdRpc
[       OK ] DashWorkSourceOwnership.OwningThreadResolutionTakesNoDashdRpc (1 ms)
[ RUN      ] DashWorkSourceOwnership.CachedWorkResolvesTheArmBeforePostingTheJob
[       OK ] DashWorkSourceOwnership.CachedWorkResolvesTheArmBeforePostingTheJob (1 ms)
[ RUN      ] DashWorkSourceOwnership.CoinStateArmIsAllByValue
[       OK ] DashWorkSourceOwnership.CoinStateArmIsAllByValue (0 ms)
[ RUN      ] DashWorkSourceOwnership.HeaderDoesNotClaimCoinStateLocksItself
[       OK ] DashWorkSourceOwnership.HeaderDoesNotClaimCoinStateLocksItself (0 ms)
[----------] 6 tests from DashWorkSourceOwnership (5 ms total)
[  PASSED  ] 6 tests.
```

Reproduce standalone:

```
g++ -std=c++17 -DDASH_WORK_SOURCE_SRC='"<tree>/src/impl/dash/stratum/work_source.cpp"' \
               -DDASH_WORK_SOURCE_HDR='"<tree>/src/impl/dash/stratum/work_source.hpp"' \
    test/test_dash_work_source_ownership.cpp -lgtest -lgtest_main -pthread -o t && ./t
```

Point the definitions at a `master` checkout for RED, at this branch for GREEN.

### In-tree, on the real allowlisted targets

```
$ ./test/test_dash_node_coin_state
[==========] 84 tests from 8 test suites ran. (5 ms total)
[  PASSED  ] 84 tests.

$ ./test/test_dash_stratum_work_source
[==========] 70 tests from 8 test suites ran. (257 ms total)
[  PASSED  ] 70 tests.
```

`test_dash_stratum_work_source` is the behavioural proof that this is ownership-only: it includes `IoThreadDecoupleServesCachedAndRefreshesOffThread` (asserts the fallback is **never** called on the caller thread, single-flight holds, and the refresh runs off-thread) and both `DashStratumCoinP2pTipInvalidate` tests, which drive `cached_work()` through a deferred executor exactly as the rpc_pool does. All still green, unmodified.

## The tripwire

#1135's `DashOracleShadowOwnership.RefreshExecutorStaysOffTheCoinP2PArm` asserted the `!coin_p2p` install guard. This change makes that guard **non-load-bearing**, and the dashd cut intends to relax it — so continuing to assert it would pin the exact configuration detail we are about to change. It is **superseded, not deleted**: renamed to `RefreshExecutorArmGuardSupersededByCoinStateOwnership`, kept in the same suite with the history written into the comment, and it now asserts the ownership that replaced the guard (the `CoinStateArm` overload exists, its body never names `coin_state_`, and `resolve_coin_state_arm()` is where the reads went). Revert the split -> RED, with the arm-guard warning restated in the failure message.

## Merge sequencing

**This PR does not touch `main_dash.cpp`** — no overlap with the PPLNS / sharechain-explorer work (#1144, #1145) or with the honest-RPC-refusal work. The only shared file with anything in flight is `test/CMakeLists.txt` (two lines) and `test/test_dash_oracle_shadow_ownership.cpp` (#1135's own file, no other PR should be in it).

## Deploy note

`do-not-merge` pending operator review. Header + one .cpp + tests; a hotel deploy needs the **binary + lib bundle**, not a lone binary swap. Read-only inspection only — no restarts, no deploys, no config changes on any node.
