### PR TITLE
dash(#91): the MN-CKPT payee bridge RESUMES instead of replaying its window [do-not-merge]

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -229,6 +229,17 @@ const char* const kDashMnCheckpointTestnet =
 uint32_t g_mn_bridge_max_blocks =
     dash::coin::MnCheckpointLane::kDefaultMaxBridgeBlocks;
 
+// --embedded-mn-bridge-no-cursor (#91): DISABLE the bridge's resumable replay
+// cursor, so every process start replays the whole window from the pinned
+// anchor — exactly the behaviour before #91 existed.
+//
+// This is a CONTROL, and it is here because the claim #91 makes is a TIMING
+// claim ("a restart no longer costs ~26 minutes"), and a timing claim needs an
+// A/B on the same binary, same host, same peers. Same file-scope posture as
+// g_mn_bridge_max_blocks: written once during argument parsing, read once at
+// wiring.
+bool g_mn_bridge_no_cursor = false;
+
 // ── W2 FULL-HISTORY REPLAY bulk-fetch flags (replay_bulk_fetch.hpp) ─────────
 // Same file-scope posture (and the same rationale) as g_mn_bridge_max_blocks:
 // written once during argument parsing, read once at wiring. All default OFF —
@@ -369,6 +380,7 @@ void print_banner(const char* argv0)
         << "           [--web-port PORT] [--web-host ADDR] [--dashboard-dir PATH]\n"
         << "           [--external-ip ADDR]\n"
         << "           [--embedded-utxo] [--embedded-mainnet] [--embedded-mn-bridge-max N]\n"
+        << "           [--embedded-mn-bridge-no-cursor]\n"
         << "           [--embedded-utxo-immature-serve-empty] [--embedded-serve-mempool-txs]\n"
         << "           [--bestcl-policy freshness|consensus-exact]\n"
         << "           [--embedded-oracle-shadow]\n"
@@ -499,6 +511,18 @@ void print_banner(const char* argv0)
         << "        have_mn on a node with no dashd. Anything short of the full\n"
         << "        guard WITHHOLDS and names the blocking condition; the dashd\n"
         << "        seed and the checkpoint bridge are unchanged.\n"
+        << "        --embedded-mn-bridge-no-cursor DISABLES the MN-CKPT\n"
+        << "        bridge's persistent replay cursor, so every start replays\n"
+        << "        the whole window from the pinned anchor (the pre-#91\n"
+        << "        behaviour). Default ON: the bridge saves the set it has\n"
+        << "        actually folded, with the height and block hash it folded\n"
+        << "        to and the anchor it descends from, and a restart RESUMES\n"
+        << "        there instead of re-walking ~3900 blocks at one window per\n"
+        << "        tip change. A record that cannot be tied to this build's\n"
+        << "        anchor, to our own header chain at that height, and to a\n"
+        << "        contiguous span from the anchor is DISCARDED (cold start,\n"
+        << "        naming the rule) — it is never half-resumed. Use this flag\n"
+        << "        to measure cold-vs-warm on one binary.\n"
         << "        --embedded-no-dashd-mn-seed cuts the PAYEE axis off from a\n"
         << "        configured dashd (no `protx list` seed, no checkpoint\n"
         << "        bridge) while KEEPING the RPC for --embedded-shadow-compare:\n"
@@ -2814,6 +2838,11 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // node_coin_state / coin_state (declared earlier) they reference.
     std::unique_ptr<dash::coin::HeaderChain> header_chain;
     std::unique_ptr<dash::coin::CoinStateMaintainer> maintainer;
+    // #91: the MN-CKPT bridge's resumable replay cursor. Declared BEFORE the
+    // lane so it is destroyed AFTER it — the lane borrows a raw pointer and
+    // writes through it from on_block_connected/publish, so the store must
+    // outlive every path that can still call into the lane.
+    std::unique_ptr<dash::coin::MnBridgeCursorStore> mn_bridge_cursor;
     // E2d: the daemonless MN-set bridge. Constructed for the whole embedded
     // arm so the tip-changed driver below can pump it unconditionally, but
     // only ARMED on the no-RPC path (an available `protx list` is strictly
@@ -4635,6 +4664,40 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             const std::string net_name = testnet ? "testnet" : "mainnet";
             auto ckpt = dash::coin::parse_mn_checkpoint(payload, net_name);
 
+            // ── #91: THE RESUMABLE REPLAY CURSOR ──────────────────────────
+            //
+            // Wired BEFORE arm(), because arm() is where the persisted record
+            // is read. Rooted in the per-instance data dir alongside every
+            // other piece of DASH state, so --data-dir isolates it exactly
+            // like the header chain, the SML db and the credit pool.
+            //
+            // Without this the bridge threw away a COMPLETED replay on every
+            // process start: "[MN-CKPT] bridge START: replaying
+            // h=2513001..2516913 (3913 blocks)" after a restart that had
+            // already finished that work. The lane is EVENT-BOUND — it
+            // re-drives its window on tip changes, ~2.5 min apart — so that
+            // discard cost ~26 of the ~34 minutes of a pure-daemonless cold
+            // start, every time.
+            //
+            // The lane refuses to half-resume: see try_restore()'s R1..R7. A
+            // record it cannot tie to THIS build's anchor, to our own header
+            // chain at the persisted height, and to a contiguous span from the
+            // anchor is discarded and the bridge starts COLD, naming the rule.
+            if (!g_mn_bridge_no_cursor) {
+                mn_bridge_cursor =
+                    std::make_unique<dash::coin::MnBridgeCursorStore>(
+                        (core::filesystem::config_path() / net_subdir
+                         / "dash_mn_bridge_cursor.dat").string());
+                mn_ckpt_lane->set_cursor_store(mn_bridge_cursor.get());
+            } else {
+                std::cout << "[run] --embedded-mn-bridge-no-cursor: the"
+                             " MN-CKPT bridge will NOT persist or resume its"
+                             " replay cursor. Every start replays the whole"
+                             " window from the pinned anchor — the behaviour"
+                             " before task #91. This exists so a cold-vs-warm"
+                             " measurement has a control.\n";
+            }
+
             // Fail CLOSED and LOUDLY. A wrong payee is a coinbase the network
             // rejects — direct revenue loss — so an unusable anchor must be
             // impossible to mistake for a working one. arm() latches the lane
@@ -6016,6 +6079,18 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                         << (mn_ckpt_lane ? mn_ckpt_lane->state_name() : "none")
                         << " bridge_cursor="
                         << (mn_ckpt_lane ? mn_ckpt_lane->cursor_height() : 0)
+                        // #91: is this process finishing a previous one's
+                        // replay, or redoing it? It is the first thing worth
+                        // knowing when a restart is slow, and before this the
+                        // only way to tell was to time it.
+                        << " bridge_cursor_src="
+                        << (!mn_ckpt_lane
+                                ? std::string("none")
+                                : (mn_ckpt_lane->cursor_restored()
+                                       ? "resumed@h="
+                                             + std::to_string(
+                                                   mn_ckpt_lane->restored_at())
+                                       : std::string("cold")))
                         << " bridge_wait="
                         << (mn_ckpt_lane ? mn_ckpt_lane->waiting_for()
                                          : std::string("n/a"))
@@ -6472,6 +6547,9 @@ int main(int argc, char** argv)
                  && i + 1 < argc)
             g_mn_bridge_max_blocks = static_cast<uint32_t>(
                 std::strtoul(argv[++i], nullptr, 10));
+        // #91: the A/B control for the resumable replay cursor.
+        else if (std::strcmp(argv[i], "--embedded-mn-bridge-no-cursor") == 0)
+            g_mn_bridge_no_cursor = true;
         else if ((std::strcmp(argv[i], "--give-author") == 0 ||
                   std::strcmp(argv[i], "--dev-donation") == 0) && i + 1 < argc)
             dev_donation = std::strtod(argv[++i], nullptr);

--- a/src/impl/dash/coin/mn_bridge_cursor.hpp
+++ b/src/impl/dash/coin/mn_bridge_cursor.hpp
@@ -1,0 +1,485 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// Task #91 step 2: the MN-CKPT payee bridge's RESUMABLE cursor.
+///
+/// ─────────────────────────────────────────────────────────────────────────
+/// THE DEFECT THIS CLOSES
+/// ─────────────────────────────────────────────────────────────────────────
+/// The bridge (mn_checkpoint_lane.hpp) replays every block from the pinned
+/// anchor to the header tip, and threw all of it away on exit. Verbatim from
+/// a 2026-08-04 restart that had ALREADY completed exactly that work:
+///
+///     [MN-CKPT] bridge START: replaying h=2513001..2516913 (3913 blocks)
+///
+/// The cost is not CPU. #1126's own measurement: the lane is EVENT-BOUND —
+/// it re-drives its request window only when the tip changes (~2.5 min per
+/// mainnet block) and bursts at ~375 blk/s when it does fire — so the wall
+/// clock is roughly "number of stalled windows x block interval". That is
+/// ~26 of the ~34 minutes of a pure-daemonless cold start, paid again on
+/// every process start.
+///
+/// ─────────────────────────────────────────────────────────────────────────
+/// WHY THIS IS ONE FILE, ONE RECORD, ONE RENAME
+/// ─────────────────────────────────────────────────────────────────────────
+/// "A cursor must be authoritative and must refuse to half-resume" is the
+/// W1/W2 lesson (project_replay_tier_a_proven_3851_blocks): the bulk lane's
+/// persistent cursor and the fold's anchor were once INDEPENDENT, so a
+/// restart resumed the lane at h=2513098 while the fold sat at h=2513000 —
+/// a silently skipped range, which on THIS lane means a wrong payee queue,
+/// which means a coinbase the network rejects.
+///
+/// The structural answer is to make a partial state UNREPRESENTABLE rather
+/// than to police it:
+///
+///   * ONE record holds the masternode set AND the height it is as-of AND
+///     the provenance it descends from. There is no "cursor only" record and
+///     no "entries only" record, so a cursor can never be paired with a set
+///     from a different height.
+///   * The record is written to `<path>.tmp` and moved into place with a
+///     single rename(2) — the same atomic-publish idiom ReplayCursorStore
+///     (replay_bulk_fetch.hpp) already uses in this tree. A torn write is
+///     never observable; the reader sees the old record or the new one.
+///   * A payload digest covers the whole record. Truncation, bit rot and a
+///     half-flushed file all read back as CORRUPT, which is a COLD start,
+///     not a half-resume.
+///   * A FORMAT VERSION is checked before anything is believed. The MnStateDb
+///     v1->v2 lesson: a schema change that deserialises entry-by-entry gets
+///     SILENTLY SKIPPED rows, i.e. a partial set under a believed cursor.
+///     Here a version mismatch discards the whole record and says so.
+///
+/// ─────────────────────────────────────────────────────────────────────────
+/// WHAT IS PERSISTED IS WHAT WAS DELIVERED
+/// ─────────────────────────────────────────────────────────────────────────
+/// #1128 hit the inverse and it destroyed derived state: a lane's floor taken
+/// from an aspirational CEILING (`max(delivered, target_end)`) instead of the
+/// DELIVERED high-water orphaned every height in between. So `cursor_height`
+/// here is the height of the last block `apply_block` ACTUALLY folded with no
+/// desync and no gap — never `m_requested_through`, never the replay target,
+/// never the tip. The store is written from exactly one site, after a
+/// successful apply, and `applied` rides along so the reader can check the
+/// arithmetic (see `contiguous()` below) instead of trusting the writer.
+///
+/// FENCED: src/impl/dash only. Read and written solely by MnCheckpointLane.
+
+#include <impl/dash/coin/mn_state_db.hpp>        // MNState + its pack methods
+
+#include <core/hash.hpp>
+#include <core/log.hpp>
+#include <core/pack.hpp>
+#include <core/uint256.hpp>
+
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+namespace dash {
+namespace coin {
+
+/// Everything the bridge needs to stand back up exactly where it stopped.
+///
+/// The fields are grouped by WHAT MAKES THEM SAFE, not by where they live in
+/// the lane, because that is the order a reviewer has to check them in.
+struct MnBridgeCursor
+{
+    // ── PROVENANCE. What lineage this state descends from. Every one of
+    // these is compared against the anchor the running binary carries, and
+    // any difference is a COLD start: a set derived from a different anchor
+    // is a set with a different trust root.
+    uint32_t    anchor_height{0};
+    uint256     anchor_hash;
+    std::string anchor_source;
+    uint32_t    anchor_count{0};
+    uint32_t    anchor_eligible{0};
+    uint32_t    anchor_ineligible{0};
+
+    // ── DELIVERED. The height actually folded, and the block that was folded
+    // at it. `cursor_hash` is what makes a resume refuse across a reorg: it
+    // is checked against OUR OWN PoW-validated header chain before a single
+    // entry is believed.
+    uint32_t    cursor_height{0};
+    uint256     cursor_hash;
+    uint32_t    applied{0};
+
+    // ── SPENT BUDGETS AND LATCHES. A resumed bridge must not be handed a
+    // fresh budget for work a previous process already spent: that would make
+    // a restart LOOSER than a continuous run, and every one of these caps
+    // exists to stop a runaway from hammering a peer or from overriding the
+    // projection wholesale. Carrying them forward keeps restart-equivalence
+    // (the KAT that pins it compares a continuous bridge against a restarted
+    // one field for field, so this list cannot silently drift).
+    uint32_t    folds{0};
+    uint32_t    first_fold_height{0};
+    uint32_t    last_fold_height{0};
+    uint32_t    sml_folded_at{0};
+    uint32_t    abandoned_folds{0};
+    uint32_t    ondemand_folds{0};
+    uint32_t    ondemand_excluded{0};
+    uint32_t    ondemand_abandoned{0};
+    uint32_t    revive_probes{0};
+    uint32_t    revive_unmeasured{0};
+    uint32_t    revive_declined{0};
+    uint32_t    sml_recovered{0};
+    uint32_t    pose_removed{0};
+    uint32_t    pose_reinstated{0};
+    uint32_t    tx_revived{0};
+    uint32_t    revive_dropped{0};
+    uint32_t    registered{0};
+    uint32_t    spent{0};
+
+    // ── THE SET ITSELF, as of `cursor_height`.
+    std::vector<std::pair<uint256, MNState>> entries;
+
+    /// THE ANTI-GAP ARITHMETIC, checkable by the READER from the record alone.
+    ///
+    /// The bridge folds exactly one block per height from anchor+1 up to the
+    /// cursor — apply_block is forward-CONTIGUOUS and refuses anything else —
+    /// so a truthful record always satisfies
+    ///
+    ///     applied == cursor_height - anchor_height
+    ///
+    /// A record that does not is describing a state that skipped heights.
+    /// That is the exact shape of the W1/W2 defect, and it is refused rather
+    /// than resumed. This is deliberately not an assert at the write site:
+    /// the point is that the READER does not have to trust the writer.
+    bool contiguous() const
+    {
+        if (cursor_height <= anchor_height) return false;
+        return applied == (cursor_height - anchor_height);
+    }
+};
+
+/// Atomic single-record store for MnBridgeCursor.
+///
+/// On-disk layout (all integers little-endian, no padding):
+///
+///     "c2pool-mn-bridge-cursor\n"   24 bytes, exact
+///     u32   format version
+///     u64   payload length
+///     ...   payload
+///     32B   CHash256(payload)
+///
+/// The digest is over the PAYLOAD ONLY so a length that disagrees with the
+/// file size is caught before any allocation is sized from it.
+class MnBridgeCursorStore
+{
+public:
+    /// Bump on ANY change to the payload encoding or to MNState's pack
+    /// methods. A stale-format record is discarded whole; it is never
+    /// partially interpreted (the MnStateDb v1->v2 lesson).
+    static constexpr uint32_t kFormatVersion = 1;
+
+    explicit MnBridgeCursorStore(std::string path) : m_path(std::move(path)) {}
+
+    const std::string& path() const { return m_path; }
+
+    /// nullopt = nothing usable on disk. `why` always names the reason, and
+    /// an absent file is NOT an error (it is a first run).
+    std::optional<MnBridgeCursor> load(std::string& why) const
+    {
+        std::error_code ec;
+        if (!std::filesystem::exists(m_path, ec)) {
+            why = "no persisted cursor at " + m_path + " (first run for this"
+                  " data directory)";
+            return std::nullopt;
+        }
+        std::ifstream in(m_path, std::ios::binary);
+        if (!in) { why = "cursor file " + m_path + " is unreadable"; return std::nullopt; }
+        std::vector<uint8_t> raw((std::istreambuf_iterator<char>(in)),
+                                  std::istreambuf_iterator<char>());
+        const size_t kHdr = kMagicLen + 4 + 8;
+        if (raw.size() < kHdr + 32) {
+            why = "cursor file is TRUNCATED (" + std::to_string(raw.size())
+                  + " bytes, header alone needs " + std::to_string(kHdr + 32)
+                  + ")";
+            return std::nullopt;
+        }
+        if (std::memcmp(raw.data(), kMagic, kMagicLen) != 0) {
+            why = "cursor file does not carry the expected magic — it is not"
+                  " an MN-CKPT bridge cursor";
+            return std::nullopt;
+        }
+        const uint32_t ver = rd_u32(raw.data() + kMagicLen);
+        if (ver != kFormatVersion) {
+            why = "cursor file is format v" + std::to_string(ver)
+                  + ", this build writes v" + std::to_string(kFormatVersion)
+                  + " — discarding the whole record rather than interpreting"
+                    " part of it";
+            return std::nullopt;
+        }
+        const uint64_t len = rd_u64(raw.data() + kMagicLen + 4);
+        if (len > raw.size() || raw.size() != kHdr + len + 32) {
+            why = "cursor file length field (" + std::to_string(len)
+                  + ") disagrees with the file size ("
+                  + std::to_string(raw.size()) + ") — TORN or truncated write";
+            return std::nullopt;
+        }
+        uint256 want;
+        std::memcpy(want.data(), raw.data() + kHdr + len, 32);
+        uint256 got;
+        CHash256()
+            .Write(std::span<const unsigned char>(raw.data() + kHdr,
+                                                  static_cast<size_t>(len)))
+            .Finalize(std::span<unsigned char>(got.data(), 32));
+        if (want != got) {
+            why = "cursor file digest MISMATCH (want " + want.GetHex().substr(0, 16)
+                  + ", got " + got.GetHex().substr(0, 16)
+                  + ") — the record is corrupt";
+            return std::nullopt;
+        }
+        MnBridgeCursor c;
+        try {
+            decode(raw.data() + kHdr, static_cast<size_t>(len), c);
+        } catch (const std::exception& e) {
+            why = std::string("cursor payload failed to decode: ") + e.what();
+            return std::nullopt;
+        }
+        why = "loaded a persisted cursor: h=" + std::to_string(c.cursor_height)
+              + " with " + std::to_string(c.entries.size()) + " masternodes,"
+                " anchor h=" + std::to_string(c.anchor_height);
+        return c;
+    }
+
+    /// Write-then-rename. Returns false on ANY failure, and the caller treats
+    /// that as "persistence is not working" rather than retrying silently:
+    /// a bridge that cannot save is still CORRECT, it is only slow again, and
+    /// the one thing it must never do is believe it saved when it did not.
+    bool store(const MnBridgeCursor& c) const
+    {
+        std::vector<uint8_t> payload;
+        encode(c, payload);
+
+        std::vector<uint8_t> out;
+        out.reserve(kMagicLen + 12 + payload.size() + 32);
+        out.insert(out.end(), kMagic, kMagic + kMagicLen);
+        wr_u32(out, kFormatVersion);
+        wr_u64(out, payload.size());
+        out.insert(out.end(), payload.begin(), payload.end());
+        uint256 digest;
+        CHash256()
+            .Write(std::span<const unsigned char>(payload.data(), payload.size()))
+            .Finalize(std::span<unsigned char>(digest.data(), 32));
+        out.insert(out.end(), digest.data(), digest.data() + 32);
+
+        const std::string tmp = m_path + ".tmp";
+        {
+            std::ofstream f(tmp, std::ios::binary | std::ios::trunc);
+            if (!f) return false;
+            f.write(reinterpret_cast<const char*>(out.data()),
+                    static_cast<std::streamsize>(out.size()));
+            if (!f) return false;
+            f.flush();
+            if (!f) return false;
+        }
+        std::error_code ec;
+        std::filesystem::rename(tmp, m_path, ec);
+        if (ec) {
+            std::filesystem::remove(tmp, ec);
+            return false;
+        }
+        return true;
+    }
+
+    /// Remove the record. Used when the state it describes must NEVER be
+    /// resumed into — a fail-closed bridge and a re-arm both qualify (see the
+    /// call sites in mn_checkpoint_lane.hpp).
+    bool erase() const
+    {
+        std::error_code ec;
+        std::filesystem::remove(m_path, ec);
+        std::error_code ec2;
+        std::filesystem::remove(m_path + ".tmp", ec2);
+        return !ec;
+    }
+
+private:
+    static constexpr char kMagic[] = "c2pool-mn-bridge-cursor\n";
+    static constexpr size_t kMagicLen = sizeof(kMagic) - 1;   // 24, no NUL
+
+    std::string m_path;
+
+    static void wr_u32(std::vector<uint8_t>& o, uint32_t v)
+    {
+        o.push_back(uint8_t( v        & 0xFF));
+        o.push_back(uint8_t((v >>  8) & 0xFF));
+        o.push_back(uint8_t((v >> 16) & 0xFF));
+        o.push_back(uint8_t((v >> 24) & 0xFF));
+    }
+    static void wr_u64(std::vector<uint8_t>& o, uint64_t v)
+    {
+        for (int i = 0; i < 8; ++i) o.push_back(uint8_t((v >> (8 * i)) & 0xFF));
+    }
+    static uint32_t rd_u32(const uint8_t* p)
+    {
+        return uint32_t(p[0]) | (uint32_t(p[1]) << 8)
+             | (uint32_t(p[2]) << 16) | (uint32_t(p[3]) << 24);
+    }
+    static uint64_t rd_u64(const uint8_t* p)
+    {
+        uint64_t v = 0;
+        for (int i = 0; i < 8; ++i) v |= uint64_t(p[i]) << (8 * i);
+        return v;
+    }
+    static void wr_hash(std::vector<uint8_t>& o, const uint256& h)
+    {
+        o.insert(o.end(), h.data(), h.data() + 32);
+    }
+    static void wr_str(std::vector<uint8_t>& o, const std::string& s)
+    {
+        wr_u32(o, static_cast<uint32_t>(s.size()));
+        o.insert(o.end(), s.begin(), s.end());
+    }
+
+    /// Bounds-checked reader. Every accessor throws rather than returning a
+    /// default, because a default here is exactly the "silently partial
+    /// record" this file exists to make impossible.
+    struct Reader
+    {
+        const uint8_t* p;
+        size_t         n;
+        size_t         at{0};
+
+        void need(size_t k) const
+        {
+            if (at + k > n) throw std::runtime_error("payload underrun");
+        }
+        uint32_t u32() { need(4); uint32_t v = rd_u32(p + at); at += 4; return v; }
+        uint64_t u64() { need(8); uint64_t v = rd_u64(p + at); at += 8; return v; }
+        uint256 hash()
+        {
+            need(32);
+            uint256 h;
+            std::memcpy(h.data(), p + at, 32);
+            at += 32;
+            return h;
+        }
+        std::string str()
+        {
+            const uint32_t k = u32();
+            if (k > (1u << 20)) throw std::runtime_error("string too long");
+            need(k);
+            std::string s(reinterpret_cast<const char*>(p + at), k);
+            at += k;
+            return s;
+        }
+        std::vector<uint8_t> blob()
+        {
+            const uint32_t k = u32();
+            if (k > (1u << 24)) throw std::runtime_error("blob too long");
+            need(k);
+            std::vector<uint8_t> b(p + at, p + at + k);
+            at += k;
+            return b;
+        }
+    };
+
+    static void encode(const MnBridgeCursor& c, std::vector<uint8_t>& o)
+    {
+        wr_u32(o, c.anchor_height);
+        wr_hash(o, c.anchor_hash);
+        wr_str(o, c.anchor_source);
+        wr_u32(o, c.anchor_count);
+        wr_u32(o, c.anchor_eligible);
+        wr_u32(o, c.anchor_ineligible);
+
+        wr_u32(o, c.cursor_height);
+        wr_hash(o, c.cursor_hash);
+        wr_u32(o, c.applied);
+
+        wr_u32(o, c.folds);
+        wr_u32(o, c.first_fold_height);
+        wr_u32(o, c.last_fold_height);
+        wr_u32(o, c.sml_folded_at);
+        wr_u32(o, c.abandoned_folds);
+        wr_u32(o, c.ondemand_folds);
+        wr_u32(o, c.ondemand_excluded);
+        wr_u32(o, c.ondemand_abandoned);
+        wr_u32(o, c.revive_probes);
+        wr_u32(o, c.revive_unmeasured);
+        wr_u32(o, c.revive_declined);
+        wr_u32(o, c.sml_recovered);
+        wr_u32(o, c.pose_removed);
+        wr_u32(o, c.pose_reinstated);
+        wr_u32(o, c.tx_revived);
+        wr_u32(o, c.revive_dropped);
+        wr_u32(o, c.registered);
+        wr_u32(o, c.spent);
+
+        wr_u64(o, c.entries.size());
+        for (const auto& [h, st] : c.entries) {
+            wr_hash(o, h);
+            // MNState rides its OWN pack methods, exactly as MnStateDb
+            // persists it. One encoder for the struct means a field added
+            // there cannot be forgotten here — it changes the byte length,
+            // the digest, and (because kFormatVersion must be bumped with it)
+            // the version gate.
+            auto stream = ::pack(st);
+            auto sp = stream.get_span();
+            wr_u32(o, static_cast<uint32_t>(sp.size()));
+            const auto* b = reinterpret_cast<const uint8_t*>(sp.data());
+            o.insert(o.end(), b, b + sp.size());
+        }
+    }
+
+    static void decode(const uint8_t* p, size_t n, MnBridgeCursor& c)
+    {
+        Reader r{p, n};
+        c.anchor_height     = r.u32();
+        c.anchor_hash       = r.hash();
+        c.anchor_source     = r.str();
+        c.anchor_count      = r.u32();
+        c.anchor_eligible   = r.u32();
+        c.anchor_ineligible  = r.u32();
+
+        c.cursor_height     = r.u32();
+        c.cursor_hash       = r.hash();
+        c.applied           = r.u32();
+
+        c.folds             = r.u32();
+        c.first_fold_height = r.u32();
+        c.last_fold_height  = r.u32();
+        c.sml_folded_at     = r.u32();
+        c.abandoned_folds   = r.u32();
+        c.ondemand_folds    = r.u32();
+        c.ondemand_excluded = r.u32();
+        c.ondemand_abandoned = r.u32();
+        c.revive_probes     = r.u32();
+        c.revive_unmeasured = r.u32();
+        c.revive_declined   = r.u32();
+        c.sml_recovered     = r.u32();
+        c.pose_removed      = r.u32();
+        c.pose_reinstated   = r.u32();
+        c.tx_revived        = r.u32();
+        c.revive_dropped    = r.u32();
+        c.registered        = r.u32();
+        c.spent             = r.u32();
+
+        const uint64_t count = r.u64();
+        if (count > 200000) throw std::runtime_error("entry count implausible");
+        c.entries.clear();
+        c.entries.reserve(static_cast<size_t>(count));
+        for (uint64_t i = 0; i < count; ++i) {
+            uint256 h = r.hash();
+            auto blob = r.blob();
+            MNState st;
+            ::PackStream ps(std::vector<unsigned char>(blob.begin(), blob.end()));
+            ps >> st;
+            c.entries.emplace_back(h, std::move(st));
+        }
+        // Trailing bytes mean the writer and the reader disagree about the
+        // shape of the record. Refuse: "it parsed a prefix" is precisely the
+        // half-resume this store must not permit.
+        if (r.at != n) throw std::runtime_error("payload has trailing bytes");
+    }
+};
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -206,6 +206,7 @@
 /// path in main_dash.cpp; the dashd-RPC fallback never touches this file.
 
 #include <impl/dash/coin/block.hpp>
+#include <impl/dash/coin/mn_bridge_cursor.hpp>   // #91: the resumable replay cursor
 #include <impl/dash/coin/mn_checkpoint.hpp>
 #include <impl/dash/coin/mn_state_machine.hpp>
 #include <impl/dash/coin/historical_sml.hpp>   // authenticate_historical_snapshot
@@ -383,6 +384,64 @@ public:
     uint32_t max_bridge_blocks() const     { return m_max_bridge; }
 
     // ─────────────────────────────────────────────────────────────────────
+    // #91: CURSOR PERSISTENCE — a restart RESUMES instead of replaying
+    // ─────────────────────────────────────────────────────────────────────
+    //
+    // WHAT WAS BROKEN, verbatim, on a restart that had ALREADY done the work:
+    //
+    //     [MN-CKPT] bridge START: replaying h=2513001..2516913 (3913 blocks)
+    //
+    // #1126 made that discard VISIBLE (the COLD/RESTORED line below) and
+    // measured its cost: the lane is EVENT-BOUND — it re-drives its request
+    // window only on a tip change, ~2.5 min per mainnet block, bursting at
+    // ~375 blk/s when it does fire — so the bill is ~26 of the ~34 minutes of
+    // a pure-daemonless cold start, paid on EVERY process start.
+    //
+    // ── THE RULE: AUTHORITATIVE, OR COLD. NEVER HALF-RESUMED ─────────────
+    //
+    // This lane's output is the payee queue that gates block templates. A
+    // wrong resume is a wrong payee is a rejected block, so the resume path is
+    // built to make a partial state UNREPRESENTABLE rather than to police one:
+    //
+    //   * ONE record carries the set AND its height AND its provenance
+    //     (mn_bridge_cursor.hpp), written by a single rename(2). There is no
+    //     cursor-without-a-set and no set-without-a-height to pair wrongly.
+    //     That is the direct lesson of the W1/W2 integration, where the bulk
+    //     lane's persistent cursor and the fold's anchor were INDEPENDENT and
+    //     a restart resumed the lane at h=2513098 with the fold at h=2513000.
+    //   * try_restore() enforces R1..R7 below and, if ANY of them cannot be
+    //     shown to hold against what is on disk and on our own header chain
+    //     RIGHT NOW, it discards the record and starts COLD, naming which one.
+    //     It never resumes into a gap and never resumes a lineage it cannot
+    //     tie to the anchor this binary carries.
+    //   * What is persisted is what was DELIVERED — the height apply_block
+    //     actually folded — never m_requested_through and never the replay
+    //     target. #1128's inverse (a floor taken from an aspirational ceiling)
+    //     destroyed derived state; the comment on note_persist() carries the
+    //     write-site argument.
+    //   * A RESTORED set may not publish until it has been FALSIFIED at least
+    //     once by evidence this process fetched itself — see
+    //     resume_verification_pending(). Fail-closed beats fast.
+
+    /// Borrowed, may be nullptr (KATs, and any embedding that does not want a
+    /// resumable bridge). Unwired the lane behaves EXACTLY as it did before
+    /// this seam existed: every start is COLD and nothing is written.
+    void set_cursor_store(const MnBridgeCursorStore* store)
+    {
+        m_cursor_store = store;
+    }
+    bool has_cursor_store() const { return m_cursor_store != nullptr; }
+
+    /// How many applied blocks between checkpoint writes. A record costs one
+    /// ~700 KB rename (≈3000 masternodes), so per-block would be absurd at the
+    /// measured 375 blk/s burst rate, and the WORST case a coarse interval can
+    /// cost is re-replaying fewer than `n` blocks — against the 3913 this
+    /// exists to avoid. Deliberately smaller than kDefaultFoldInterval so a
+    /// resumed cursor is never more than one fold interval from a fold point.
+    static constexpr uint32_t kDefaultPersistEvery = 250;
+    void set_persist_every(uint32_t n) { m_persist_every = n ? n : 1; }
+
+    // ─────────────────────────────────────────────────────────────────────
     // DIAGNOSTIC SEAMS (telemetry only — no serve/arm/consensus effect)
     // ─────────────────────────────────────────────────────────────────────
 
@@ -462,6 +521,9 @@ public:
     {
         if (m_state == State::FailedClosed) return "nothing(failed-closed)";
         if (m_state == State::Published)    return "nothing(published)";
+        // ORDER MATTERS, and it is measured rather than assumed: whatever is
+        // OUTSTANDING is always the more specific answer, so every outstanding
+        // -work case is tested BEFORE the resume debt below.
         if (m_snapshot_pending)
             return std::string(m_ondemand_pending ? "ondemand-mnlist-reply@h="
                                                   : "fold-mnlist-reply@h=")
@@ -472,6 +534,22 @@ public:
         if (m_requested_through >= m_next)
             return "block-bodies@h=" + std::to_string(m_next) + ".."
                    + std::to_string(m_requested_through);
+        // LAST, and that is the whole point. An unfalsified resume is a DEBT,
+        // not a blocker: while a fold reply or a block body is outstanding, the
+        // outstanding thing IS the cause, and this token would mask it.
+        // MEASURED both ways on contabo mainnet 2026-08-06 — placed above the
+        // checks it now sits below, it printed
+        //     waiting_for=resume-falsification@h=2517001
+        // for 330 s while the lane was in fact waiting on
+        // block-bodies@h=2517002..2517065: true, and useless, and it hid the
+        // real cause. Here it means what it says — nothing is outstanding, the
+        // cursor has caught the tip, and the ONLY reason this lane is not
+        // publishing is that this process has not yet falsified what it
+        // restored. Without the token that state prints "tip-advance" and reads
+        // exactly like a healthy idle lane, which is the silent-refusal shape
+        // this whole file is built against.
+        if (resume_verification_pending())
+            return "resume-falsification@h=" + std::to_string(m_restored_at);
         return "tip-advance";
     }
 
@@ -489,10 +567,56 @@ public:
     const char* state_name() const { return state_name(m_state); }
 
     /// Whether this lane's replay cursor was RESTORED from persisted work or is
-    /// starting COLD. Today it is ALWAYS cold — there is no cursor persistence
-    /// — and the point of surfacing it is that the log said nothing at all
-    /// about discarding a completed 3913-block replay on every process start.
+    /// starting COLD. #1126 added this field when the answer was ALWAYS cold,
+    /// so that discarding a completed 3913-block replay stopped being invisible;
+    /// #91 makes RESTORED reachable. COLD remains the answer whenever the
+    /// persisted record could not be shown consistent — see try_restore().
     bool cursor_restored() const { return m_cursor_restored; }
+    /// The height a restored cursor stood at (0 = cold start).
+    uint32_t restored_at() const { return m_restored_at; }
+    /// Why the last restore attempt landed where it did. Always populated once
+    /// the attempt has run — including on success — because "resumed" and
+    /// "refused, and here is which rule" are the same question to an operator.
+    const std::string& restore_verdict() const { return m_restore_verdict; }
+
+    /// TRUE while a RESTORED set is still unfalsified.
+    ///
+    /// A cold bridge earns trust block by block: apply_block projects the
+    /// DIP-3 payee from the set and compares it against that block's REAL
+    /// coinbase, so every replayed block is a live falsification test of the
+    /// anchored data (this file's header calls that "progressively
+    /// falsifiable"). A restored set has had NONE of those tests run in this
+    /// process — it is trusted bytes off a local disk.
+    ///
+    /// So a resume owes at least one piece of evidence THIS process fetched
+    /// over the network before it may publish, and either of these is one:
+    ///
+    ///   * an APPLIED BLOCK - apply_block projects the payee from the restored
+    ///     set and compares it against that block's real coinbase. This is the
+    ///     PAYMENT-ORDER axis (nLastPaidHeight, the key GetMNPayee sorts by),
+    ///     which nothing else here covers, and it costs NO extra round trip:
+    ///     the lane is fetching those bodies anyway. In the normal restart the
+    ///     tip has moved on, so it is paid within seconds of the first body.
+    ///   * an APPLIED PER-HEIGHT FOLD - a getmnlistd the lane requested for a
+    ///     block it names, DIP-4-authenticated against that block's own
+    ///     committed cbTx root. The VALIDITY axis. A resume does not FORCE
+    ///     one (see try_restore() for the measured reason), but if the
+    ///     ordinary fold schedule lands one first it counts.
+    ///
+    /// Worst case - restarted with the cursor already AT the tip - this costs
+    /// one block interval (~2.5 min) waiting for the next block, against the
+    /// hours of replay the resume saves.
+    ///
+    /// HONEST LIMIT, stated because it will be quoted: this is NOT #1128's G6.
+    /// That guard re-hashes the folded list to the block's committed
+    /// merkleRootMNList, and it cannot be run here — MNState is the payee
+    /// dialect and carries no confirmedHash, so the DIP-4 SML entry cannot be
+    /// reconstructed from it. The resume is falsifiable, not proven.
+    bool resume_verification_pending() const
+    {
+        if (!m_cursor_restored) return false;
+        return m_applied == 0 && m_folds == 0;
+    }
 
     /// Load a parsed checkpoint. A !ok checkpoint arms the lane in the
     /// terminal FailedClosed state so the refusal is visible in status()
@@ -508,6 +632,16 @@ public:
             return;
         }
         reset_for_arm(cp);
+        // ── #91. READ the persisted record here, but BELIEVE nothing yet.
+        //
+        // The decisive checks (R4: does our own PoW-validated header chain
+        // hold the block this record was folded at?) need a header chain that
+        // has reached the cursor height, and at arm() time it has usually
+        // reached nothing at all. Deciding early would mean deciding on less
+        // evidence than is about to be available — so the record is parked and
+        // try_restore() adjudicates it from pump(), at the same moment the
+        // anchor's own chain position is verified.
+        load_pending_cursor();
         m_status = "armed at h=" + std::to_string(cp.height) + " ("
                    + std::to_string(m_anchor_count) + " masternodes), waiting"
                      " for headers to reach the anchor";
@@ -726,6 +860,21 @@ public:
         m_last_rearm_at       = at;
         m_last_rearm_at_known = have_tip;
         reset_for_arm(cp);
+        // #91: a re-arm ABANDONS the lineage the persisted record belongs to —
+        // that state produced a payee queue the maintainer rejected, which is
+        // the whole reason we are here. fail_closed() has usually erased it
+        // already; do it again unconditionally rather than reason about which
+        // paths reach rearm() with a record still on disk. Two sources of
+        // truth for "where is this lane" is the defect this design exists to
+        // prevent, and the cheapest way to have one is to leave nothing behind.
+        if (m_cursor_store) m_cursor_store->erase();
+        // ...and settle the adjudication explicitly, so a re-arm that happened
+        // while a restore was still DEFERRING cannot later adopt a record that
+        // describes the lineage this re-arm is walking away from.
+        m_pending_restore.reset();
+        m_restore_settled = true;
+        m_restore_verdict = "COLD (re-arm): the persisted lineage produced the"
+                            " payee desync this re-arm is recovering from";
         m_status = "RE-ARMED " + std::to_string(m_rearms) + "/"
                    + std::to_string(kMaxRearms) + " at h="
                    + std::to_string(cp.height) + " ("
@@ -1198,11 +1347,41 @@ public:
                      << m_anchor_height << " matches our header chain";
         }
 
+        // ── #91. ADJUDICATE the persisted cursor, once, here.
+        //
+        // Here and nowhere else, because this is the first point at which all
+        // the evidence exists: the anchor is verified against our own header
+        // chain, the chain is known to cover at least the anchor height, and
+        // NOTHING has been applied yet — so a refusal costs only a COLD start
+        // and never a rollback. try_restore() may also DEFER (headers have not
+        // reached the persisted cursor yet); deferring re-runs on the next
+        // pump, which the tip-changed callback guarantees.
+        if (!m_restore_settled && !try_restore()) return;
+
         // ── Staleness bound ──────────────────────────────────────────────
-        const uint32_t distance = tip - m_anchor_height;
+        //
+        // Measured from THE CURSOR THIS BRIDGE WILL ACTUALLY START AT, which is
+        // the anchor on a cold arm (unchanged) and the restored cursor on a
+        // resume (#91).
+        //
+        // This bound is about REPLAY DURATION, not about anchor trust — its own
+        // rationale is "the replay would take longer than an operator would
+        // tolerate, and a silently-crawling bridge that never arms is the quiet
+        // degradation this lane exists to avoid". Anchor trust is carried by
+        // the digest and the chain-position check, neither of which this touches.
+        // Keeping it pinned to the anchor would therefore have made #91 a
+        // REGRESSION: a node that had already replayed 19,995 of 20,000 blocks
+        // and persisted them would fail closed on restart with "checkpoint is
+        // STALE" while having essentially no work left to do.
+        const uint32_t replay_from = m_cursor_restored ? m_restored_at
+                                                       : m_anchor_height;
+        const uint32_t distance = tip - replay_from;
         if (distance > m_max_bridge) {
             return fail_closed(
-                "checkpoint is STALE: anchor h=" + std::to_string(m_anchor_height)
+                "checkpoint is STALE: "
+                + std::string(m_cursor_restored ? "the resumed cursor h="
+                                                : "anchor h=")
+                + std::to_string(replay_from)
                 + " is " + std::to_string(distance) + " blocks behind the tip h="
                 + std::to_string(tip) + ", over the "
                 + std::to_string(m_max_bridge) + "-block bridge limit."
@@ -1274,30 +1453,39 @@ public:
                      << ".." << tip << " (" << (tip - m_next + 1)
                      << " blocks) onto the anchored set";
             // ── PERSISTENCE VISIBILITY ────────────────────────────────────
-            // This lane has NO cursor persistence: every process start throws
-            // away the previous run's completed replay and re-walks the whole
-            // window from the pinned anchor. That is a real cost (3913 blocks
-            // on 2026-08-04) and the log said NOTHING about it — "bridge
-            // START: replaying h=2513001..2516913" reads exactly the same
-            // whether prior work was resumed or discarded. Name it.
+            // #1126 added this line when the answer was ALWAYS COLD: every
+            // process start threw away the previous run's completed replay and
+            // re-walked the whole window from the pinned anchor (3913 blocks
+            // on 2026-08-04), and "bridge START: replaying h=2513001..2516913"
+            // read exactly the same whether prior work was resumed or
+            // discarded.
+            //
+            // #91 makes RESTORED reachable, and keeps the line honest in BOTH
+            // directions: a COLD start now says WHY it is cold — no record, a
+            // refused record and which rule refused it, or no store wired at
+            // all — because "cold" with no reason is the same silence in a
+            // different costume.
             m_replay_target = tip;
             m_replay_base   = m_next;
             m_replay_bytes  = 0;
             LOG_INFO << "[MN-CKPT] cursor "
                      << (m_cursor_restored ? "RESTORED" : "COLD")
                      << " lane=mn-ckpt from="
-                     << (m_cursor_restored ? "persisted-cursor"
-                                           : "pinned-anchor@h="
-                                                 + std::to_string(m_anchor_height))
+                     << (m_cursor_restored
+                             ? "persisted-cursor@h=" + std::to_string(m_restored_at)
+                             : "pinned-anchor@h="
+                                   + std::to_string(m_anchor_height))
                      << " cursor=" << m_next << " target=" << tip
                      << " to_replay=" << (tip - m_next + 1)
+                     << " skipped=" << (m_cursor_restored ? m_restored_applied : 0)
                      << " rearms=" << m_rearms
-                     << (m_cursor_restored
-                             ? ""
-                             : " — there is no replay-cursor persistence in"
-                               " this build, so ANY replay work done by a"
-                               " previous process was DISCARDED and this window"
-                               " is being walked from scratch");
+                     << " verdict=\""
+                     << (m_restore_verdict.empty()
+                             ? std::string("no cursor store is wired in this"
+                                           " build/run, so nothing could be"
+                                           " resumed")
+                             : m_restore_verdict)
+                     << "\"";
             m_progress.start(0, m_now());
             m_watchdog.arm(m_now());
         }
@@ -1321,6 +1509,12 @@ public:
         //     catch-up it does not. So the dispatch now REQUESTS the list as of
         //     the anchor rather than hoping the tip one is dated there, and the
         //     anchor fold fires every time instead of by coincidence.
+        //
+        //   • A RESUMED bridge (#91) never reaches this dispatch: its cursor is
+        //     the persisted one, not the anchor, and try_restore() closes the
+        //     latch explicitly. The argument for why a resume does not need its
+        //     own fold — and the measured 7-minute cost of giving it one — is
+        //     written out at that call site.
         if (!m_snapshot_pending && !m_anchor_fold_done
             && m_next == m_anchor_height + 1 && m_request_snapshot) {
             m_anchor_fold_done = true;
@@ -1415,6 +1609,10 @@ public:
         m_next = height + 1;
         ++m_applied;
         note_replay_advance(block);
+        // #91: DELIVERED, and only now. Every guard above had to pass — no
+        // gap, no payee desync, a non-empty set — before this height is a
+        // height a restart may resume from.
+        note_persist(/*force=*/false);
         // ── PER-HEIGHT PoSe fold. The cursor is now exactly `height`; if
         // this is a fold point, request the list AS OF it and pause.
         if (m_tip_height) {
@@ -1463,6 +1661,378 @@ public:
     }
 
 private:
+    // ─────────────────────────────────────────────────────────────────────
+    // #91: LOAD / ADJUDICATE / WRITE
+    // ─────────────────────────────────────────────────────────────────────
+
+    /// Parse whatever is on disk into m_pending_restore. Believes nothing.
+    void load_pending_cursor()
+    {
+        m_pending_restore.reset();
+        m_restore_settled = m_cursor_store == nullptr;
+        m_restore_defers  = 0;
+        m_restore_verdict.clear();
+        if (!m_cursor_store) return;
+        std::string why;
+        auto rec = m_cursor_store->load(why);
+        if (!rec) {
+            // Not an error: a first run has no record. It IS worth a line —
+            // "why did this start cold" was unanswerable before #1126.
+            m_restore_settled = true;
+            m_restore_verdict = "COLD: " + why;
+            LOG_INFO << "[MN-CKPT] cursor store: " << why;
+            return;
+        }
+        LOG_INFO << "[MN-CKPT] cursor store: " << why
+                 << " — held for adjudication against our own header chain";
+        m_pending_restore = std::move(rec);
+    }
+
+    /// Refuse to COLD, with a named rule. Never fails the lane: a record we
+    /// cannot vouch for costs a replay, not a refusal to serve.
+    void restore_cold(const std::string& rule, const std::string& detail)
+    {
+        m_pending_restore.reset();
+        m_restore_settled = true;
+        m_cursor_restored = false;
+        m_restored_at     = 0;
+        m_restore_verdict = "COLD (" + rule + "): " + detail;
+        LOG_WARNING << "[MN-CKPT] persisted cursor REFUSED [" << rule << "]: "
+                    << detail
+                    << " — starting COLD from the pinned anchor h="
+                    << m_anchor_height
+                    << ". This costs a full replay; it does NOT risk a wrong"
+                       " payee.";
+        // The record described a lineage this process will not continue.
+        // Leaving it would make the next start re-adjudicate and re-refuse the
+        // same bytes forever, and — worse — a record kept next to a set that
+        // has since been rebuilt from the anchor is exactly the two-sources-
+        // of-truth shape this design exists to avoid.
+        if (m_cursor_store) m_cursor_store->erase();
+    }
+
+    /// Bound on how many pumps a restore may DEFER before it gives up and goes
+    /// COLD. A deferral is a legitimate "the header index has not handed us
+    /// that height yet", but an unbounded one is a wedge with no symptom —
+    /// and the fallback (COLD) always works.
+    static constexpr uint32_t kMaxRestoreDefers = 20;
+
+    /// Returns TRUE when the lane may proceed this pump, FALSE to defer.
+    ///
+    /// R1  the record parses, magic + format version + digest all check out
+    ///     (enforced in MnBridgeCursorStore::load — a partial record cannot be
+    ///     handed to us)
+    /// R2  it descends from THE ANCHOR THIS BINARY CARRIES: height, hash,
+    ///     source string and entry count all identical. A release with a
+    ///     fresher anchor has a different trust root, and silently continuing
+    ///     someone else's lineage under it is the "anchor cut AFTER a
+    ///     divergence began" trap rearm() already refuses.
+    /// R3  the cursor is strictly above the anchor — a record at or below it
+    ///     buys nothing and a record below it is a different lineage.
+    /// R4  OUR OWN PoW-validated header chain holds, at cursor_height, exactly
+    ///     the block the record says was folded there. This is the reorg /
+    ///     fork guard, and it is the reason adjudication waits for the header
+    ///     chain instead of happening at arm().
+    /// R5  applied == cursor_height - anchor_height. THE ANTI-GAP ARITHMETIC:
+    ///     the bridge folds one block per height, contiguously, so a record
+    ///     that does not satisfy this is describing skipped heights — the
+    ///     exact W1/W2 defect. Refuse; never "resume and hope".
+    /// R6  the set is non-empty and has at least one payee-eligible entry —
+    ///     a set that cannot back a payee cannot shorten anything.
+    /// R7  the cursor is not beyond the replay this lane would do anyway
+    ///     (cursor <= tip), and the remaining distance is inside the bridge
+    ///     bound.
+    bool try_restore()
+    {
+        if (m_restore_settled) return true;
+        if (!m_pending_restore) { m_restore_settled = true; return true; }
+        // A COPY, not a reference. restore_cold() and the accept path BOTH
+        // reset m_pending_restore, so a reference into it would dangle the
+        // moment either ran — and every refusal message is built FROM this
+        // record, i.e. the dangling read would be inside the diagnostics that
+        // exist to explain the refusal. One ~700 KB copy, once per process,
+        // removes that hazard by construction rather than by call ordering.
+        const MnBridgeCursor rec = *m_pending_restore;
+
+        // R2 — lineage.
+        if (rec.anchor_height != m_anchor_height
+            || rec.anchor_hash != m_anchor_hash
+            || rec.anchor_source != m_anchor_source
+            || rec.anchor_count != m_anchor_count) {
+            restore_cold(
+                "R2 anchor-lineage",
+                "the record descends from anchor h="
+                    + std::to_string(rec.anchor_height) + " "
+                    + rec.anchor_hash.GetHex().substr(0, 16) + " source='"
+                    + rec.anchor_source + "' count="
+                    + std::to_string(rec.anchor_count)
+                    + ", but this build is armed from h="
+                    + std::to_string(m_anchor_height) + " "
+                    + m_anchor_hash.GetHex().substr(0, 16) + " source='"
+                    + m_anchor_source + "' count="
+                    + std::to_string(m_anchor_count));
+            return true;
+        }
+
+        // R3 / R5 — position and the anti-gap arithmetic, both readable from
+        // the record alone, so the reader never has to trust the writer.
+        if (!rec.contiguous()) {
+            restore_cold(
+                "R5 contiguity",
+                "the record claims cursor h=" + std::to_string(rec.cursor_height)
+                    + " after applying " + std::to_string(rec.applied)
+                    + " blocks from anchor h="
+                    + std::to_string(rec.anchor_height) + ", but a contiguous"
+                      " replay of that range is exactly "
+                    + std::to_string(rec.cursor_height > rec.anchor_height
+                                         ? rec.cursor_height - rec.anchor_height
+                                         : 0)
+                    + " blocks — this state SKIPPED heights and resuming into"
+                      " it would carry a stale payment queue forward");
+            return true;
+        }
+
+        // R6 — usability.
+        if (rec.entries.empty()) {
+            restore_cold("R6 empty-set",
+                         "the record carries no masternodes");
+            return true;
+        }
+
+        // R7 — is this record even about the replay we are here to do?
+        const uint32_t tip = m_tip_height ? m_tip_height() : 0;
+        if (rec.cursor_height > tip) {
+            restore_cold(
+                "R7 cursor-above-tip",
+                "the record's cursor h=" + std::to_string(rec.cursor_height)
+                    + " is ABOVE our own header tip h=" + std::to_string(tip)
+                    + " — we cannot verify at a height we do not have, and a"
+                      " chain that lost ground is not a chain to resume onto");
+            return true;
+        }
+
+        // R4 — the reorg / fork guard. Deferred, not refused, while the header
+        // index is still handing heights out.
+        if (!m_header_hash_at) {
+            restore_cold("R4 no-header-lookup",
+                         "no header-hash lookup is wired, so the record's"
+                         " chain position cannot be verified");
+            return true;
+        }
+        auto have = m_header_hash_at(rec.cursor_height);
+        if (!have) {
+            if (++m_restore_defers > kMaxRestoreDefers) {
+                restore_cold(
+                    "R4 header-unavailable",
+                    "our header chain never produced the block at h="
+                        + std::to_string(rec.cursor_height) + " across "
+                        + std::to_string(kMaxRestoreDefers) + " drive attempts");
+                return true;
+            }
+            LOG_INFO << "[MN-CKPT] persisted cursor h=" << rec.cursor_height
+                     << ": header not retrievable yet (attempt "
+                     << m_restore_defers << "/" << kMaxRestoreDefers
+                     << ") — deferring adjudication, not guessing";
+            return false;   // defer this pump
+        }
+        if (*have != rec.cursor_hash) {
+            restore_cold(
+                "R4 chain-position",
+                "the record was folded at h=" + std::to_string(rec.cursor_height)
+                    + " over block " + rec.cursor_hash.GetHex().substr(0, 16)
+                    + ", but our PoW-validated header chain holds "
+                    + have->GetHex().substr(0, 16)
+                    + " there — the chain REORGED past the persisted cursor and"
+                      " every payment attributed after the fork point is wrong");
+            return true;
+        }
+
+        // ── ACCEPTED. Adopt the record wholesale: the set, the height it is
+        // as-of, and every budget the previous process already spent.
+        //
+        // The budgets are not bookkeeping. Each cap bounds how far the lane
+        // may deviate from a pure replay — the demotion walk, the on-demand
+        // fold round trips, the revive probes. Handing a resumed bridge a
+        // FRESH budget would make a restart strictly LOOSER than a continuous
+        // run, i.e. a node could buy extra overrides by restarting. Carrying
+        // them makes restart-equivalence the default.
+        m_machine.load(rec.entries, rec.cursor_height);
+        m_machine.reset_sml_recovery_budget();
+        m_next              = rec.cursor_height + 1;
+        m_applied           = 0;   // blocks applied BY THIS PROCESS
+        m_restored_applied  = rec.applied;
+        m_folds             = 0;   // folds applied BY THIS PROCESS
+        m_restored_folds    = rec.folds;
+        m_first_fold_height = rec.first_fold_height;
+        m_last_fold_height  = rec.last_fold_height;
+        m_sml_folded        = rec.sml_folded_at != 0;
+        m_sml_folded_at     = rec.sml_folded_at;
+        m_abandoned_folds   = rec.abandoned_folds;
+        m_ondemand_folds    = rec.ondemand_folds;
+        m_ondemand_excluded = rec.ondemand_excluded;
+        m_ondemand_abandoned = rec.ondemand_abandoned;
+        m_revive_probes     = rec.revive_probes;
+        m_revive_unmeasured = rec.revive_unmeasured;
+        m_revive_declined   = rec.revive_declined;
+        m_sml_recovered     = rec.sml_recovered;
+        m_pose_removed      = rec.pose_removed;
+        m_pose_reinstated   = rec.pose_reinstated;
+        m_tx_revived        = rec.tx_revived;
+        m_revive_dropped    = rec.revive_dropped;
+        m_registered        = rec.registered;
+        m_spent             = rec.spent;
+        m_anchor_eligible   = rec.anchor_eligible;
+        m_anchor_ineligible = rec.anchor_ineligible;
+
+        // ── THE FALSIFICATION A RESUME OWES, AND WHY IT IS NOT A FOLD ─────
+        //
+        // The first design re-armed the anchor fold AT the restored cursor, so
+        // a resume proved its set against the list the chain committed there.
+        // MEASURED on contabo mainnet 2026-08-06 and removed for it: on a WARM
+        // restart the header chain loads from LevelDB instantly, so the first
+        // pump fires with ZERO handshaked coin-P2P peers — the getmnlistd goes
+        // nowhere, the replay is PAUSED behind it, and the lane sits on
+        //     [LANE-WATCHDOG] ... waiting_for=fold-mnlist-reply@h=2513251
+        //                         snapshot_pending=1 applied=0
+        // until the kFoldRetryPumps re-ask, which is three TIP CHANGES away —
+        // ~7 minutes of a resume spent not replaying. A cold start never pays
+        // this because its 90 s of header sync brings the peers up first.
+        //
+        // And it bought nothing. The two axes are already covered:
+        //   * PAYMENT ORDER — apply_block cross-checks the projected payee
+        //     against the real coinbase of the very next block, which is the
+        //     falsification publish() actually waits on
+        //     (resume_verification_pending), and it is FREE: no round trip,
+        //     and it happens as soon as one body arrives.
+        //   * VALIDITY / PoSe bans — every ban inside the resumed range was
+        //     already folded by the process that walked it, and R4 has just
+        //     proven the chain under that cursor is the same chain. Re-folding
+        //     the same height over the same set re-derives the same answer.
+        //     From here the ordinary fold schedule and the on-demand fold
+        //     carry it exactly as they do for a cold bridge between fold
+        //     points — which is the pre-existing, measured-good behaviour.
+        //
+        // So the latch is CLOSED, not re-opened: the anchor fold is not this
+        // bridge's job, because this bridge does not stand on the anchor.
+        m_anchor_fold_done = true;
+
+        m_cursor_restored = true;
+        m_restored_at     = rec.cursor_height;
+        m_restore_settled = true;
+        m_restore_verdict =
+            "RESTORED at h=" + std::to_string(rec.cursor_height) + " ("
+            + std::to_string(rec.entries.size()) + " masternodes, "
+            + std::to_string(rec.applied) + " blocks already replayed by a"
+              " previous process)";
+        LOG_INFO << "[MN-CKPT] persisted cursor ACCEPTED: h="
+                 << rec.cursor_height << " " << have->GetHex().substr(0, 16)
+                 << " entries=" << rec.entries.size()
+                 << " eligible=" << m_machine.eligible_size()
+                 << " prior_applied=" << rec.applied
+                 << " prior_folds=" << rec.folds
+                 << " — R2 lineage, R4 chain position and R5 contiguity all"
+                    " check out; skipping "
+                 << rec.applied << " blocks of replay this process would"
+                    " otherwise have redone";
+        // The parsed record has been fully absorbed; ~700 KB of it does not
+        // need to live for the rest of the process.
+        m_pending_restore.reset();
+        return true;
+    }
+
+    /// WRITE SITE. Called ONLY after apply_block has folded a block with no
+    /// gap and no desync, so `m_next - 1` is a height that was DELIVERED, not
+    /// one that was merely requested.
+    ///
+    /// This distinction is the whole of #1128's lesson: a lane's floor taken
+    /// from an aspirational ceiling (`max(delivered, target_end)`) instead of
+    /// the delivered high-water orphaned every height in between and destroyed
+    /// derived state. m_requested_through and m_replay_target are both in scope
+    /// here and neither may ever reach the record.
+    void note_persist(bool force)
+    {
+        if (!m_cursor_store) return;
+        if (m_state != State::Bridging && m_state != State::Published) return;
+        const uint32_t cursor = m_next ? m_next - 1 : 0;
+        if (cursor <= m_anchor_height) return;
+        if (!force && (cursor - m_last_persisted) < m_persist_every) return;
+        if (!m_header_hash_at) return;
+        auto hash = m_header_hash_at(cursor);
+        if (!hash) return;   // cannot name the block we folded; do not claim to
+
+        MnBridgeCursor rec;
+        rec.anchor_height      = m_anchor_height;
+        rec.anchor_hash        = m_anchor_hash;
+        rec.anchor_source      = m_anchor_source;
+        rec.anchor_count       = static_cast<uint32_t>(m_anchor_count);
+        rec.anchor_eligible    = static_cast<uint32_t>(m_anchor_eligible);
+        rec.anchor_ineligible  = static_cast<uint32_t>(m_anchor_ineligible);
+        rec.cursor_height      = cursor;
+        rec.cursor_hash        = *hash;
+        rec.applied            = m_restored_applied + m_applied;
+        rec.folds              = m_restored_folds + m_folds;
+        rec.first_fold_height  = m_first_fold_height;
+        rec.last_fold_height   = m_last_fold_height;
+        rec.sml_folded_at      = m_sml_folded_at;
+        rec.abandoned_folds    = m_abandoned_folds;
+        rec.ondemand_folds     = static_cast<uint32_t>(m_ondemand_folds);
+        rec.ondemand_excluded  = static_cast<uint32_t>(m_ondemand_excluded);
+        rec.ondemand_abandoned = static_cast<uint32_t>(m_ondemand_abandoned);
+        rec.revive_probes      = static_cast<uint32_t>(m_revive_probes);
+        rec.revive_unmeasured  = static_cast<uint32_t>(m_revive_unmeasured);
+        rec.revive_declined    = static_cast<uint32_t>(m_revive_declined);
+        rec.sml_recovered      = static_cast<uint32_t>(m_sml_recovered);
+        rec.pose_removed       = static_cast<uint32_t>(m_pose_removed);
+        rec.pose_reinstated    = static_cast<uint32_t>(m_pose_reinstated);
+        rec.tx_revived         = static_cast<uint32_t>(m_tx_revived);
+        rec.revive_dropped     = static_cast<uint32_t>(m_revive_dropped);
+        rec.registered         = static_cast<uint32_t>(m_registered);
+        rec.spent              = static_cast<uint32_t>(m_spent);
+        rec.entries.reserve(m_machine.entries().size());
+        for (const auto& [h, st] : m_machine.entries())
+            rec.entries.emplace_back(h, st);
+
+        // SELF-CHECK BEFORE PUBLISHING THE RECORD. R5 is the rule a reader
+        // enforces; checking it at the WRITER too means a lane that has
+        // somehow lost contiguity writes NOTHING rather than writing a record
+        // that a future reader will (correctly) refuse — and it turns a silent
+        // arithmetic drift into a line an operator can see today.
+        if (!rec.contiguous()) {
+            if (!m_persist_arith_warned) {
+                m_persist_arith_warned = true;
+                LOG_WARNING << "[MN-CKPT] cursor NOT persisted at h=" << cursor
+                            << ": applied=" << rec.applied
+                            << " does not equal the contiguous span from the"
+                               " anchor ("
+                            << (cursor - m_anchor_height)
+                            << "). Refusing to write a record no restart may"
+                               " resume; the bridge itself is unaffected.";
+            }
+            return;
+        }
+
+        if (!m_cursor_store->store(rec)) {
+            // Loud, once. A bridge that cannot save is CORRECT but slow again,
+            // and the failure mode this must never have is believing it saved.
+            if (!m_persist_io_warned) {
+                m_persist_io_warned = true;
+                LOG_WARNING << "[MN-CKPT] could NOT write the replay cursor to "
+                            << m_cursor_store->path()
+                            << " — the bridge is unaffected, but a restart will"
+                               " replay this window from the anchor again";
+            }
+            return;
+        }
+        m_last_persisted = cursor;
+        ++m_persist_writes;
+        LOG_INFO << "[MN-CKPT] cursor PERSISTED h=" << cursor << " "
+                 << hash->GetHex().substr(0, 16) << " entries="
+                 << rec.entries.size() << " applied=" << rec.applied
+                 << " writes=" << m_persist_writes
+                 << " — a restart resumes here instead of replaying "
+                 << (cursor - m_anchor_height) << " blocks";
+    }
+
     /// Push the SML's current height into the machine so the reactive
     /// demotion walk can refuse a STALE attestation. Cheap; called on every
     /// folded block because the mnlistdiff feed advances underneath us.
@@ -1949,6 +2519,17 @@ public:
 
     bool snapshot_pending() const { return m_snapshot_pending; }
     uint32_t folds_applied() const { return m_folds; }
+    /// LIFETIME totals across the whole span from the anchor, i.e. including
+    /// whatever a previous process contributed before a resume.
+    ///
+    /// The distinction matters in both directions and getting it backwards is
+    /// a report that LIES. Reporting must be lifetime — a resumed bridge whose
+    /// predecessor folded 8 times must not publish "NO per-height fold was
+    /// ever applied", and its "anchor + N replayed blocks" must describe the
+    /// range the set actually covers. The resume's own falsification test must
+    /// be THIS process — see resume_verification_pending().
+    uint32_t folds_lifetime()   const { return m_restored_folds + m_folds; }
+    uint32_t applied_lifetime() const { return m_restored_applied + m_applied; }
     uint32_t abandoned_folds() const { return m_abandoned_folds; }
 
     /// Pumps to wait before re-asking, and before giving up on a fold point.
@@ -2234,7 +2815,8 @@ public:
                  " alone — and the walk's per-bridge budget is sized for"
                  " ISOLATED bans, so a BURST can exhaust it.";
         } else {
-            s += " Per-height PoSe folds applied: " + std::to_string(m_folds)
+            s += " Per-height PoSe folds applied: "
+                 + std::to_string(folds_lifetime())
                  + " (first at h=" + std::to_string(m_first_fold_height)
                  + ", latest at h=" + std::to_string(m_sml_folded_at)
                  + "); each was DIP-4 client-verified and applied with the"
@@ -2393,6 +2975,36 @@ public:
             return fail_closed("no publish seam wired — the bridged masternode"
                                " set has nowhere to go");
         }
+        // ── #91. A RESTORED SET MAY NOT PUBLISH UNFALSIFIED ────────────────
+        //
+        // The bridge's claim on trust has always been "progressively
+        // falsifiable": every replayed block's coinbase is an answer key the
+        // network already agreed on, and a wrong set fails against it. A
+        // resumed set has had none of those tests run in this process — it is
+        // bytes off a local disk that passed a lineage check.
+        //
+        // So publishing waits for ONE piece of network evidence: an applied
+        // block (the payment-ORDER axis) or the fold this resume re-armed at
+        // its own cursor (the VALIDITY axis, DIP-4-authenticated against the
+        // block's committed root). This is a HOLD, not a refusal — pump() is
+        // re-driven on every tip change and the fold reply resumes it — so the
+        // worst case is one block interval (~2.5 min) against the ~26 minutes
+        // the resume saves. Fail-closed beats fast on the lane that decides
+        // what a block template pays.
+        if (resume_verification_pending()) {
+            if (m_restored_at != m_resume_hold_logged) {
+                m_resume_hold_logged = m_restored_at;
+                LOG_INFO << "[MN-CKPT] resume HOLD at h=" << m_restored_at
+                         << ": the restored masternode set has not been"
+                            " falsified by anything this process fetched yet"
+                            " (applied=0 folds=0). Waiting for the fold reply"
+                            " at the restored cursor, or for the next block."
+                            " NOT publishing an unfalsified set.";
+            }
+            m_status = "resume HOLD at h=" + std::to_string(m_restored_at)
+                       + ": restored set awaiting its first falsification";
+            return;
+        }
         // Last chance for the wholesale PoSe fold: this is the cursor ==
         // H_sml case when the SML is current at the bridge target (and the
         // only chance at all for a zero-block bridge). Same one-shot equality
@@ -2431,9 +3043,10 @@ public:
                    + " masternodes (" + std::to_string(m_sml_recovered)
                    + " SML-recovered exclusions) as-of h=" + std::to_string(as_of)
                    + " (anchor h=" + std::to_string(m_anchor_height)
-                   + " + " + std::to_string(m_applied) + " replayed blocks) "
+                   + " + " + std::to_string(applied_lifetime())
+                   + " replayed blocks) "
                    + delta
-                   + " PoSe folds: " + std::to_string(m_folds)
+                   + " PoSe folds: " + std::to_string(folds_lifetime())
                    + " (" + ondemand_report() + " "
                    + revive_probe_report() + ")";
         // A DEGRADED publish must say so. Publishing a set that was assembled
@@ -2447,7 +3060,7 @@ public:
                           " reply, so those intervals were carried by the"
                           " per-mismatch walk alone)";
         }
-        if (m_folds == 0) {
+        if (folds_lifetime() == 0) {
             m_status += " — NO per-height fold was ever applied; this set is"
                         " the additions-only replay plus the walk";
         }
@@ -2460,12 +3073,37 @@ public:
                         + std::to_string(kMaxRearms) + " — this set is a"
                           " recovery from a payee desync, not a cold start]";
         }
+        // A publish that RESUMED must not read like one that walked the whole
+        // window. The saving IS the claim this feature makes, so it is stated
+        // where the claim can be checked, next to the numbers that back it.
+        if (m_cursor_restored) {
+            m_status += " [RESUMED at h=" + std::to_string(m_restored_at)
+                        + " — " + std::to_string(m_restored_applied)
+                        + " of those blocks came from a PREVIOUS process and "
+                        + std::to_string(m_applied) + " from this one;"
+                          " falsified by the coinbase payee cross-check of the"
+                          " blocks this process applied on top of it]";
+        }
         LOG_INFO << "[MN-CKPT] bridge COMPLETE: published " << out.size()
                  << " masternodes (" << m_sml_recovered
                  << " SML-recovered exclusions) as-of h=" << as_of
                  << " (anchor h=" << m_anchor_height << ", replayed "
-                 << m_applied << " blocks, tip h=" << bridged_to
+                 << applied_lifetime() << " blocks"
+                 << (m_cursor_restored
+                         ? " — " + std::to_string(m_restored_applied)
+                               + " RESUMED from the persisted cursor at h="
+                               + std::to_string(m_restored_at) + ", only "
+                               + std::to_string(m_applied)
+                               + " walked by this process"
+                         : std::string())
+                 << ", tip h=" << bridged_to
                  << ") " << delta << " -> publishing to the maintainer";
+        // #91: force a final record at the published height. This is the one
+        // that matters most — it is the state a restart most wants, and
+        // without the force the last partial interval would be lost to the
+        // throttle and every restart would still redo up to kDefaultPersistEvery
+        // blocks for no reason.
+        note_persist(/*force=*/true);
         m_publish(std::move(out), as_of);
     }
 
@@ -2486,6 +3124,26 @@ public:
         // `target=0 done=0.0%` line would be a measurement of nothing.
         if (m_replay_base != 0)
             if (auto s = m_progress.flush(m_applied, m_now())) emit_progress(*s);
+        // ── #91. ERASE THE PERSISTED CURSOR. ──────────────────────────────
+        //
+        // The record sits at some height BELOW the failure, so resuming from
+        // it replays straight back into the same wall. In-process that is
+        // already handled: the re-arm ladder's deterministic-repeat block
+        // spots a second fail-close at the identical cursor and stops. But
+        // those counters are PER-PROCESS — a restart resets them — so a
+        // surviving record would turn a deterministic failure into a
+        // resume/fail/restart loop that the ladder can no longer see and that
+        // burns the shortened window every time.
+        //
+        // Erasing costs a cold replay on the next start, which is exactly the
+        // behaviour before this feature existed. Not regressing beats being
+        // fast into a known-bad state.
+        if (m_cursor_store && m_cursor_store->erase()) {
+            LOG_WARNING << "[MN-CKPT] persisted replay cursor ERASED: the state"
+                           " it describes leads into this failure, and a"
+                           " restart must not resume into it. The next start"
+                           " will replay COLD from the anchor.";
+        }
         // Deliberately ERROR, not WARNING: the operator's embedded arm will
         // not arm, and the only thing worse than saying so is not saying so.
         LOG_ERROR << "[MN-CKPT] FAIL-CLOSED: " << why;
@@ -2678,7 +3336,26 @@ public:
         m_replay_target  = 0;
         m_replay_bytes   = 0;
         m_have_bytes     = false;
-        m_cursor_restored = false;   // no cursor persistence exists to restore
+        // ── #91 cursor-persistence state. A fresh arm is by definition a walk
+        // from the anchor, so every "restored" fact must go — m_cursor_restored
+        // above all, because publish() reads it to decide whether this set still
+        // owes a falsification, and a stale `true` on a cold walk would hold a
+        // legitimate publish behind a debt that was already paid block by block.
+        //
+        // Note what is deliberately NOT done here: the record on disk is not
+        // erased. arm() reads it immediately after this call, and a re-arm
+        // erases it at ITS own call site, where the reason (the previous
+        // lineage is being abandoned) is local and legible.
+        m_cursor_restored  = false;
+        m_restored_at      = 0;
+        m_restored_applied = 0;
+        m_restored_folds   = 0;
+        m_last_persisted   = 0;
+        m_persist_writes   = 0;
+        m_persist_io_warned    = false;
+        m_persist_arith_warned = false;
+        m_resume_hold_logged   = 0;
+        m_restore_defers       = 0;
         m_progress.start(0, m_now());
         m_watchdog.disarm();         // re-armed at the Waiting->Bridging edge
         m_anchor_eligible   = m_machine.eligible_size();
@@ -2793,10 +3470,38 @@ public:
     uint32_t m_replay_target{0};    // tip the replay is chasing
     uint64_t m_replay_bytes{0};     // wire bytes of replayed block bodies
     bool     m_have_bytes{false};   // ...only when set_wire_size_fn is wired
-    /// Whether the replay cursor came from persisted work. ALWAYS false today:
-    /// this build has no cursor persistence, and the field exists so the log
-    /// says so out loud rather than leaving the discard invisible.
+    /// Whether the replay cursor came from persisted work.
     bool     m_cursor_restored{false};
+
+    // ── #91 CURSOR PERSISTENCE STATE ──────────────────────────────────────
+    /// Borrowed; nullptr means no persistence at all (KATs, and the
+    /// --embedded-mn-bridge-no-cursor A/B). Never owned: the store is a path
+    /// wrapper with no state of its own, and giving the lane ownership would
+    /// make the KATs' "no persistence" case a special case instead of the
+    /// default.
+    const MnBridgeCursorStore* m_cursor_store{nullptr};
+    /// Parsed at arm(), adjudicated at the first pump that can see the header
+    /// chain. Holding it across that gap is deliberate — see try_restore().
+    std::optional<MnBridgeCursor> m_pending_restore;
+    bool     m_restore_settled{true};    // true when no adjudication is owed
+    uint32_t m_restore_defers{0};
+    std::string m_restore_verdict;
+    uint32_t m_restored_at{0};           // height a restore resumed from
+    /// Blocks / folds a PREVIOUS process contributed. Kept separate from
+    /// m_applied and m_folds, which count THIS process's work, because the two
+    /// answer different questions: the record needs the lifetime total (R5's
+    /// arithmetic is about the whole span from the anchor) and
+    /// resume_verification_pending() needs "has this process proved anything
+    /// yet". Merging them would make a resumed set look self-verified the
+    /// instant it loaded.
+    uint32_t m_restored_applied{0};
+    uint32_t m_restored_folds{0};
+    uint32_t m_persist_every{kDefaultPersistEvery};
+    uint32_t m_last_persisted{0};
+    uint32_t m_persist_writes{0};
+    bool     m_persist_io_warned{false};
+    bool     m_persist_arith_warned{false};
+    uint32_t m_resume_hold_logged{0};
 
     // ── RE-ARM bookkeeping. Survives reset_for_arm() by design: if a re-arm
     // cleared its own counters the cap could never fire and the "recovery"

--- a/test/test_dash_mn_checkpoint.cpp
+++ b/test/test_dash_mn_checkpoint.cpp
@@ -40,6 +40,7 @@
 
 #include <impl/dash/coin/mn_checkpoint.hpp>       // parse_mn_checkpoint (DUT)
 #include <impl/dash/coin/mn_checkpoint_lane.hpp>  // MnCheckpointLane (DUT)
+#include <impl/dash/coin/mn_bridge_cursor.hpp>    // MnBridgeCursorStore (DUT, #91)
 #include <impl/dash/coin/vendor/providertx.hpp>   // CProUpServTx (revival leg)
 #include <impl/dash/coin/vendor/simplifiedmns.hpp>// CSimplifiedMNList (attestation source)
 #include <impl/dash/coin/mn_seed.hpp>             // parse_protx_list_seed (E2c cross-check)
@@ -56,7 +57,10 @@
 #include <nlohmann/json.hpp>
 
 #include <algorithm>
+#include <cstdint>
 #include <cstring>
+#include <filesystem>
+#include <fstream>
 #include <functional>
 #include <map>
 #include <span>
@@ -64,6 +68,8 @@
 #include <string>
 #include <utility>
 #include <vector>
+
+#include <unistd.h>   // getpid — unique temp paths for the #91 cursor KATs
 
 using dash::coin::MNState;
 using dash::coin::MnCheckpoint;
@@ -4898,4 +4904,500 @@ TEST(DashMnPayeeLatch, SeededMaintainerStillFoldsAndStillReportsDivergence)
     EXPECT_TRUE(st.mn_needs_reseed());
     EXPECT_EQ(m.unseeded_payee_folds_skipped(), 0u)
         << "a seeded fold must never be counted as an unseeded skip";
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// #91 — THE RESUMABLE REPLAY CURSOR
+//
+// THE DEFECT, verbatim from a 2026-08-04 restart that had ALREADY finished
+// exactly this work:
+//
+//     [MN-CKPT] bridge START: replaying h=2513001..2516913 (3913 blocks)
+//
+// The lane is EVENT-BOUND — it re-drives its request window on tip changes,
+// ~2.5 min apart on mainnet — so that discard cost ~26 of the ~34 minutes of
+// a pure-daemonless cold start, on EVERY process start.
+//
+// What is pinned below is not "a file appears on disk". It is the two claims
+// that make the file safe to believe:
+//
+//   1. RESTART-EQUIVALENCE. A bridge interrupted and resumed publishes the
+//      SAME masternode set, at the SAME as-of height, with the SAME lifetime
+//      counters, as one that ran straight through. This is the test that does
+//      not rot: it compares OUTCOMES, so a field added to the lane and
+//      forgotten in the record fails here without anyone maintaining a list.
+//      (mn_checkpoint_lane.hpp's own reset_for_arm() comment names that exact
+//      drift risk for the two reset lists it already has.)
+//   2. REFUSE-TO-HALF-RESUME. Every one of R1..R7 is exercised as a REFUSAL
+//      that lands on a COLD replay and still publishes the right answer —
+//      never on a partial resume, and never on a lane that fails to serve
+//      because its cache was stale.
+//
+// #895: nothing here is #ifdef-guarded.
+// ═══════════════════════════════════════════════════════════════════════════
+
+namespace {
+
+using dash::coin::MnBridgeCursor;
+using dash::coin::MnBridgeCursorStore;
+
+/// A deterministic, height-distinct stand-in for a header-chain block hash.
+uint256 synth_block_hash(uint32_t height)
+{
+    uint256 h;
+    for (int i = 0; i < 4; ++i)
+        h.data()[i] = static_cast<unsigned char>((height >> (8 * i)) & 0xFF);
+    h.data()[31] = 0x91;
+    return h;
+}
+
+/// A store rooted in a unique temp path, removed on destruction. Tests that
+/// share a path would resume each other's state, which is exactly the class of
+/// bug this feature must not introduce, so each rig gets its own.
+struct TempCursorStore {
+    std::filesystem::path dir;
+    MnBridgeCursorStore   store;
+
+    explicit TempCursorStore(const std::string& tag)
+        : dir(std::filesystem::temp_directory_path()
+              / ("c2pool-t91-" + tag + "-"
+                 + std::to_string(::getpid()) + "-"
+                 + std::to_string(reinterpret_cast<uintptr_t>(this))))
+        , store((dir / "dash_mn_bridge_cursor.dat").string())
+    {
+        std::error_code ec;
+        std::filesystem::create_directories(dir, ec);
+    }
+    ~TempCursorStore()
+    {
+        std::error_code ec;
+        std::filesystem::remove_all(dir, ec);
+    }
+    bool exists() const
+    {
+        std::error_code ec;
+        return std::filesystem::exists(store.path(), ec);
+    }
+    std::vector<uint8_t> raw() const
+    {
+        std::ifstream in(store.path(), std::ios::binary);
+        return std::vector<uint8_t>((std::istreambuf_iterator<char>(in)),
+                                     std::istreambuf_iterator<char>());
+    }
+    void write_raw(const std::vector<uint8_t>& b) const
+    {
+        std::ofstream out(store.path(),
+                          std::ios::binary | std::ios::trunc);
+        out.write(reinterpret_cast<const char*>(b.data()),
+                  static_cast<std::streamsize>(b.size()));
+    }
+};
+
+/// One process's run of the bridge, over a persistent store.
+///
+/// Every height's header is published, because the real header chain holds
+/// them: the write site names the block it folded (it will not claim a height
+/// it cannot name) and R4 checks that name against the chain on the way back
+/// in.
+struct CursorRun {
+    BridgeHarness h;
+
+    CursorRun(const MnBridgeCursorStore* store, uint32_t tip)
+    {
+        h.headers[kAnchorHeight] = uint256S(kAnchorHash);
+        h.blocks[1519544] = block_from_hex(kBlockHex1519544);
+        h.blocks[1519545] = block_from_hex(kBlockHex1519545);
+        h.blocks[1519546] = block_from_hex(kBlockHex1519546);
+        // The lane names the block it folded at each height and checks that
+        // name against the header chain on the way back in (R4). It never
+        // compares that name to the body, so a DISTINCT deterministic hash per
+        // height is exactly as strong here as a real one — and it makes the
+        // reorg test's "the chain now holds something else at h" explicit
+        // rather than a re-derivation.
+        for (const auto& [ht, blk] : h.blocks) h.headers[ht] = synth_block_hash(ht);
+        h.tip = tip;
+        if (store) h.lane.set_cursor_store(store);
+        // Per-block writes: the KATs replay three blocks, and the shipped
+        // 250-block interval would make every one of them a no-op.
+        h.lane.set_persist_every(1);
+    }
+    void run() { h.lane.arm(good_checkpoint()); h.lane.pump(); }
+};
+
+std::map<uint256, MNState> as_map(
+    const std::vector<std::pair<uint256, MNState>>& v)
+{
+    return std::map<uint256, MNState>(v.begin(), v.end());
+}
+
+} // namespace
+
+// ── 1. THE CLAIM: a restart RESUMES ────────────────────────────────────────
+TEST(DashMnBridgeCursor, RestartResumesInsteadOfReplayingTheWindow)
+{
+    TempCursorStore cs("resume");
+
+    // Process 1: replay 1519544..1519545 and publish at that tip.
+    {
+        CursorRun r1(&cs.store, 1519545);
+        r1.run();
+        ASSERT_TRUE(r1.h.published) << r1.h.lane.status();
+        EXPECT_FALSE(r1.h.lane.cursor_restored())
+            << "a first run has nothing to resume from";
+        EXPECT_EQ(r1.h.lane.restored_at(), 0u);
+    }
+    ASSERT_TRUE(cs.exists())
+        << "a completed bridge must leave a record, or the next start pays the"
+           " whole replay again";
+
+    // Process 2: same anchor, same store, one more block on the chain.
+    CursorRun r2(&cs.store, 1519546);
+    r2.run();
+
+    ASSERT_TRUE(r2.h.lane.cursor_restored())
+        << "verdict: " << r2.h.lane.restore_verdict();
+    EXPECT_EQ(r2.h.lane.restored_at(), 1519545u);
+    ASSERT_TRUE(r2.h.published) << r2.h.lane.status();
+    EXPECT_EQ(r2.h.published_as_of, 1519546u);
+
+    // THE SAVING, measured the only way that means anything here: the work
+    // NOT redone. The resumed process must never ask for a block a previous
+    // process already folded.
+    for (uint32_t asked : r2.h.requested) {
+        EXPECT_GT(asked, 1519545u)
+            << "h=" << asked << " was already replayed and persisted; asking"
+               " for it again IS the defect #91 exists to remove";
+    }
+    EXPECT_EQ(r2.h.lane.replay_applied(), 1u)
+        << "only the one new block should have been applied by this process";
+    EXPECT_EQ(r2.h.lane.applied_lifetime(), 3u)
+        << "the LIFETIME span from the anchor is still all three blocks — a"
+           " resumed publish that under-reports its own coverage is a report"
+           " that lies";
+}
+
+// ── 2. THE DRIFT-PROOF TEST: outcome equality ──────────────────────────────
+TEST(DashMnBridgeCursor, ResumedBridgePublishesExactlyWhatAContinuousOneDoes)
+{
+    // Continuous control: no store at all, straight through to the tip.
+    CursorRun cont(nullptr, 1519546);
+    cont.run();
+    ASSERT_TRUE(cont.h.published) << cont.h.lane.status();
+
+    // Interrupted + resumed, same chain, same anchor.
+    TempCursorStore cs("equiv");
+    { CursorRun a(&cs.store, 1519545); a.run(); ASSERT_TRUE(a.h.published); }
+    CursorRun b(&cs.store, 1519546);
+    b.run();
+    ASSERT_TRUE(b.h.lane.cursor_restored()) << b.h.lane.restore_verdict();
+    ASSERT_TRUE(b.h.published) << b.h.lane.status();
+
+    // The published SET must be identical field for field. MNState::operator==
+    // covers every payout-relevant field including nLastPaidHeight — the one
+    // GetMNPayee orders the payment queue by, and the one a wrong resume would
+    // corrupt without changing the set's membership at all.
+    EXPECT_EQ(b.h.published_as_of, cont.h.published_as_of);
+    ASSERT_EQ(b.h.published_set.size(), cont.h.published_set.size());
+    const auto want = as_map(cont.h.published_set);
+    const auto got  = as_map(b.h.published_set);
+    ASSERT_EQ(got.size(), want.size());
+    for (const auto& [hash, st] : want) {
+        ASSERT_TRUE(got.count(hash))
+            << "resumed set is missing " << hash.GetHex().substr(0, 16);
+        EXPECT_TRUE(got.at(hash) == st)
+            << "resumed state differs for " << hash.GetHex().substr(0, 16)
+            << " — nLastPaidHeight " << got.at(hash).nLastPaidHeight
+            << " vs " << st.nLastPaidHeight;
+    }
+
+    // ...and so must the LIFETIME accounting. This is the half that catches a
+    // field added to the lane and forgotten in the record: nobody has to
+    // remember to extend a list, the outcome simply stops matching.
+    EXPECT_EQ(b.h.lane.applied_lifetime(), cont.h.lane.applied_lifetime());
+    EXPECT_EQ(b.h.lane.folds_lifetime(),   cont.h.lane.folds_lifetime());
+    EXPECT_EQ(b.h.lane.replay_registered(), cont.h.lane.replay_registered());
+    EXPECT_EQ(b.h.lane.replay_spent(),      cont.h.lane.replay_spent());
+    EXPECT_EQ(b.h.lane.eligible_size(),     cont.h.lane.eligible_size());
+}
+
+// ── 3. R2: a record from a DIFFERENT anchor is refused ─────────────────────
+TEST(DashMnBridgeCursor, RecordFromADifferentAnchorIsRefusedAndReplayedCold)
+{
+    TempCursorStore cs("lineage");
+    { CursorRun a(&cs.store, 1519545); a.run(); ASSERT_TRUE(a.h.published); }
+    ASSERT_TRUE(cs.exists());
+
+    // Rewrite the record's anchor hash: a release cut from a different anchor,
+    // or a data dir carried across builds. Its SET may be perfectly good — and
+    // that is the point: we cannot TIE it to the trust root this binary
+    // carries, so we do not build a payee queue on it.
+    std::string why;
+    auto rec = cs.store.load(why);
+    ASSERT_TRUE(rec.has_value()) << why;
+    rec->anchor_hash = uint256S(
+        "00000000000000000000000000000000000000000000000000000000deadbeef");
+    ASSERT_TRUE(cs.store.store(*rec));
+
+    CursorRun r(&cs.store, 1519546);
+    r.run();
+    EXPECT_FALSE(r.h.lane.cursor_restored());
+    EXPECT_NE(r.h.lane.restore_verdict().find("R2"), std::string::npos)
+        << r.h.lane.restore_verdict();
+    // COLD is not FAILED: the lane must still do its job, just slowly.
+    ASSERT_TRUE(r.h.published) << r.h.lane.status();
+    EXPECT_EQ(r.h.published_as_of, 1519546u);
+    EXPECT_EQ(r.h.lane.replay_applied(), 3u)
+        << "a refused record must produce a FULL cold replay, not a partial one";
+}
+
+// ── 4. R4: the chain REORGED past the persisted cursor ─────────────────────
+TEST(DashMnBridgeCursor, ReorgPastThePersistedCursorIsRefusedAndReplayedCold)
+{
+    TempCursorStore cs("reorg");
+    { CursorRun a(&cs.store, 1519545); a.run(); ASSERT_TRUE(a.h.published); }
+
+    // Our own PoW-validated header chain now holds a DIFFERENT block at the
+    // persisted height. Every payment attributed after the fork point is
+    // wrong, and resuming would carry that wrongness into a coinbase.
+    // auto_deliver OFF so the cold replay that follows the refusal cannot
+    // immediately write a NEW record: the property under test is that the
+    // STALE one is gone, and a rewrite would mask its removal.
+    CursorRun r(&cs.store, 1519546);
+    r.h.auto_deliver = false;
+    r.h.headers[1519545] = uint256S(
+        "00000000000000000000000000000000000000000000000000000000feedface");
+    r.run();
+
+    EXPECT_FALSE(r.h.lane.cursor_restored());
+    EXPECT_NE(r.h.lane.restore_verdict().find("R4"), std::string::npos)
+        << r.h.lane.restore_verdict();
+    EXPECT_EQ(r.h.lane.state(), MnCheckpointLane::State::Bridging)
+        << "a refused record costs a replay, never the lane: " << r.h.lane.status();
+    EXPECT_EQ(r.h.lane.cursor_height(), kAnchorHeight)
+        << "the cold replay must restart at the ANCHOR, not somewhere in the"
+           " middle of the refused record's range";
+    EXPECT_FALSE(cs.exists())
+        << "a refused record must be REMOVED, not left to be re-adjudicated and"
+           " re-refused on every subsequent start";
+
+    // And the cold replay, once the blocks arrive, still lands on the right
+    // answer over the chain we ACTUALLY hold.
+    r.h.auto_deliver = true;
+    for (uint32_t ht = 1519544; ht <= 1519546; ++ht)
+        r.h.lane.on_block_connected(r.h.blocks.at(ht), ht);
+    ASSERT_TRUE(r.h.published) << r.h.lane.status();
+    EXPECT_EQ(r.h.published_as_of, 1519546u);
+    EXPECT_EQ(r.h.lane.replay_applied(), 3u);
+}
+
+// ── 5. R5: the anti-gap arithmetic ─────────────────────────────────────────
+TEST(DashMnBridgeCursor, ARecordThatSkippedHeightsIsRefusedNotResumed)
+{
+    // THE W1/W2 DEFECT, reproduced deliberately: a cursor that claims a height
+    // it did not contiguously reach. There the bulk lane resumed at h=2513098
+    // while the fold sat at h=2513000; here the record says "I am at 1519545"
+    // while its own applied count proves it folded only one block from an
+    // anchor two below. Resuming would silently skip a height's payments.
+    TempCursorStore cs("gap");
+    { CursorRun a(&cs.store, 1519545); a.run(); ASSERT_TRUE(a.h.published); }
+
+    std::string why;
+    auto rec = cs.store.load(why);
+    ASSERT_TRUE(rec.has_value()) << why;
+    ASSERT_TRUE(rec->contiguous()) << "the writer must only ever emit"
+                                      " contiguous records";
+    rec->applied = rec->applied - 1;          // one height unaccounted for
+    ASSERT_FALSE(rec->contiguous());
+    ASSERT_TRUE(cs.store.store(*rec));
+
+    CursorRun r(&cs.store, 1519546);
+    r.run();
+    EXPECT_FALSE(r.h.lane.cursor_restored());
+    EXPECT_NE(r.h.lane.restore_verdict().find("R5"), std::string::npos)
+        << r.h.lane.restore_verdict();
+    ASSERT_TRUE(r.h.published) << r.h.lane.status();
+    EXPECT_EQ(r.h.lane.replay_applied(), 3u);
+}
+
+// ── 6. R1: a torn, truncated or foreign file is never half-read ────────────
+TEST(DashMnBridgeCursor, CorruptTruncatedAndForeignRecordsAllRefuse)
+{
+    // (a) a flipped byte inside the payload
+    {
+        TempCursorStore cs("bitrot");
+        { CursorRun a(&cs.store, 1519545); a.run(); ASSERT_TRUE(a.h.published); }
+        auto b = cs.raw();
+        ASSERT_GT(b.size(), 100u);
+        b[b.size() / 2] ^= 0xFF;
+        cs.write_raw(b);
+        std::string why;
+        EXPECT_FALSE(cs.store.load(why).has_value());
+        EXPECT_NE(why.find("digest"), std::string::npos) << why;
+    }
+    // (b) a truncated tail — the classic half-flushed write. The rename(2)
+    //     publish makes this unreachable in practice; it is pinned anyway,
+    //     because "unreachable" is a property of today's write path.
+    {
+        TempCursorStore cs("trunc");
+        { CursorRun a(&cs.store, 1519545); a.run(); ASSERT_TRUE(a.h.published); }
+        auto b = cs.raw();
+        b.resize(b.size() - 40);
+        cs.write_raw(b);
+        std::string why;
+        EXPECT_FALSE(cs.store.load(why).has_value()) << why;
+    }
+    // (c) something else entirely at that path
+    {
+        TempCursorStore cs("foreign");
+        cs.write_raw(std::vector<uint8_t>(200, 0x41));
+        std::string why;
+        EXPECT_FALSE(cs.store.load(why).has_value());
+        EXPECT_NE(why.find("magic"), std::string::npos) << why;
+    }
+    // (d) a future format version. Discarded WHOLE — the MnStateDb v1->v2
+    //     lesson was that entry-by-entry deserialisation silently SKIPS rows
+    //     and leaves a partial set under a believed cursor.
+    {
+        TempCursorStore cs("version");
+        { CursorRun a(&cs.store, 1519545); a.run(); ASSERT_TRUE(a.h.published); }
+        auto b = cs.raw();
+        b[24] = static_cast<uint8_t>(MnBridgeCursorStore::kFormatVersion + 7);
+        cs.write_raw(b);
+        std::string why;
+        EXPECT_FALSE(cs.store.load(why).has_value());
+        EXPECT_NE(why.find("format"), std::string::npos) << why;
+    }
+}
+
+// ── 7. A fail-closed bridge must not be resumable ──────────────────────────
+TEST(DashMnBridgeCursor, FailClosedErasesTheRecordSoARestartCannotResumeIntoIt)
+{
+    TempCursorStore cs("failclosed");
+
+    // Replay one good block (which persists), then feed a block whose coinbase
+    // pays nobody the anchored set projects: a terminal payee desync.
+    CursorRun r(&cs.store, 1519546);
+    r.h.auto_deliver = false;
+    r.h.lane.arm(good_checkpoint());
+    r.h.lane.pump();
+    ASSERT_EQ(r.h.lane.state(), MnCheckpointLane::State::Bridging);
+    r.h.lane.on_block_connected(block_from_hex(kBlockHex1519544), 1519544);
+    ASSERT_EQ(r.h.lane.cursor_height(), 1519544u);
+    ASSERT_TRUE(cs.exists()) << "a delivered block must have been persisted";
+
+    auto cp  = good_checkpoint();
+    auto bad = repay_coinbase(block_from_hex(kBlockHex1519545),
+                              payout_of(cp, kQ2), synth_script(0x5a));
+    r.h.lane.on_block_connected(bad, 1519545);
+    ASSERT_EQ(r.h.lane.state(), MnCheckpointLane::State::FailedClosed)
+        << r.h.lane.status();
+
+    EXPECT_FALSE(cs.exists())
+        << "the persisted state leads INTO this failure. The re-arm ladder's"
+           " deterministic-repeat block is per-PROCESS, so a surviving record"
+           " would turn a deterministic failure into a resume/fail/restart loop"
+           " that nothing is left to see";
+}
+
+// ── 8. A restored set may not publish unfalsified ──────────────────────────
+TEST(DashMnBridgeCursor, RestoredSetIsNotPublishedUntilThisProcessFalsifiesIt)
+{
+    TempCursorStore cs("falsify");
+    { CursorRun a(&cs.store, 1519545); a.run(); ASSERT_TRUE(a.h.published); }
+
+    // Restart with the cursor EXACTLY at the tip and no fold seam wired: there
+    // is nothing this process has verified for itself yet. The set is bytes off
+    // a local disk that passed a lineage check, and this lane's whole claim on
+    // trust is that its data is falsified against real coinbases.
+    CursorRun r(&cs.store, 1519545);
+    r.run();
+    ASSERT_TRUE(r.h.lane.cursor_restored()) << r.h.lane.restore_verdict();
+    EXPECT_TRUE(r.h.lane.resume_verification_pending());
+    EXPECT_FALSE(r.h.published)
+        << "publishing here would hand the maintainer an authoritative payee"
+           " queue on the strength of a local file alone";
+    EXPECT_NE(r.h.lane.waiting_for().find("resume-falsification"),
+              std::string::npos)
+        << "a HOLD that prints 'tip-advance' is indistinguishable from a"
+           " healthy idle lane: " << r.h.lane.waiting_for();
+
+    // The chain moves on. The first applied block runs the coinbase payee
+    // cross-check — the falsification the resume owed — and the hold clears.
+    r.h.tip = 1519546;
+    r.h.lane.pump();
+    EXPECT_FALSE(r.h.lane.resume_verification_pending());
+    ASSERT_TRUE(r.h.published) << r.h.lane.status();
+    EXPECT_EQ(r.h.published_as_of, 1519546u);
+}
+
+// ── 9. Unwired, nothing changes (the --embedded-mn-bridge-no-cursor posture) ─
+TEST(DashMnBridgeCursor, WithNoStoreWiredTheLaneWritesNothingAndAlwaysStartsCold)
+{
+    TempCursorStore cs("nostore");   // path exists; the lane is never told
+    CursorRun a(nullptr, 1519546);
+    a.run();
+    ASSERT_TRUE(a.h.published);
+    EXPECT_FALSE(a.h.lane.has_cursor_store());
+    EXPECT_FALSE(a.h.lane.cursor_restored());
+    EXPECT_FALSE(cs.exists())
+        << "an unwired lane must not touch the filesystem at all";
+
+    CursorRun b(nullptr, 1519546);
+    b.run();
+    EXPECT_FALSE(b.h.lane.cursor_restored());
+    EXPECT_EQ(b.h.lane.replay_applied(), 3u)
+        << "the pre-#91 behaviour, byte for byte: every start replays the whole"
+           " window";
+}
+
+// ── 10. The record's own encoding ──────────────────────────────────────────
+TEST(DashMnBridgeCursor, RecordRoundTripsEveryFieldAndRejectsTrailingBytes)
+{
+    TempCursorStore cs("roundtrip");
+    { CursorRun a(&cs.store, 1519546); a.run(); ASSERT_TRUE(a.h.published); }
+
+    std::string why;
+    auto rec = cs.store.load(why);
+    ASSERT_TRUE(rec.has_value()) << why;
+    EXPECT_EQ(rec->anchor_height, kAnchorHeight);
+    EXPECT_EQ(rec->anchor_hash, uint256S(kAnchorHash));
+    EXPECT_EQ(rec->cursor_height, 1519546u);
+    EXPECT_EQ(rec->applied, 3u);
+    EXPECT_EQ(rec->entries.size(), 6u);
+    EXPECT_TRUE(rec->contiguous());
+
+    // The set survives the round trip field for field — including the payment
+    // ordering key, which is the field a lossy codec would silently flatten.
+    auto by_hash = as_map(rec->entries);
+    EXPECT_EQ(by_hash.at(uint256S(kQ1)).nLastPaidHeight, 1519544u);
+    EXPECT_EQ(by_hash.at(uint256S(kQ2)).nLastPaidHeight, 1519545u);
+    EXPECT_EQ(by_hash.at(uint256S(kQ3)).nLastPaidHeight, 1519546u);
+    for (const auto& [h, st] : by_hash) {
+        EXPECT_FALSE(st.scriptPayout.m_data.empty())
+            << h.GetHex().substr(0, 16) << " lost its payout script";
+    }
+
+    // A payload that decodes a PREFIX and leaves bytes over is a writer and a
+    // reader that disagree about the record's shape. "It parsed" is not the
+    // bar; "it parsed exactly" is.
+    auto b = cs.raw();
+    b.insert(b.end() - 32, 8, 0x00);              // 8 stray bytes in the payload
+    const size_t len_at = 24 + 4;
+    const uint64_t newlen =
+        b.size() - (24 + 4 + 8) - 32;
+    for (int i = 0; i < 8; ++i)
+        b[len_at + i] = static_cast<uint8_t>((newlen >> (8 * i)) & 0xFF);
+    // Re-seal the digest so this probes the SHAPE check and not the checksum.
+    {
+        uint256 d;
+        CHash256()
+            .Write(std::span<const unsigned char>(b.data() + 24 + 4 + 8,
+                                                  static_cast<size_t>(newlen)))
+            .Finalize(std::span<unsigned char>(d.data(), 32));
+        std::memcpy(b.data() + b.size() - 32, d.data(), 32);
+    }
+    cs.write_raw(b);
+    std::string why2;
+    EXPECT_FALSE(cs.store.load(why2).has_value());
+    EXPECT_NE(why2.find("trailing"), std::string::npos) << why2;
 }


### PR DESCRIPTION
## The defect

The MN-CKPT payee bridge threw away a **completed** replay on every process start. Verbatim, from a 2026-08-04 restart that had already finished exactly that work:

```
[MN-CKPT] bridge START: replaying h=2513001..2516913 (3913 blocks)
```

The cost is not CPU. #1126 measured the shape: the lane is **event-bound** — it re-drives its request window only when the tip changes (~2.5 min per mainnet block) and bursts at ~375 blk/s when it does fire — so the wall clock is roughly *number of stalled windows x block interval*. On the lane that decides whether the embedded arm may serve a template at all.

#1126 made that discard visible (the `COLD`/`RESTORED` line, which until now always said `COLD` and honestly admitted *"there is no replay-cursor persistence in this build"*). This makes `RESTORED` reachable.

## The design, and the rule it refuses to break

`mn_bridge_cursor.hpp` — **one record**, holding the masternode set, the height it is as-of, the block hash at that height, the anchor it descends from, and every per-bridge budget the previous process already spent. Written to `<path>.tmp` and moved into place with a single `rename(2)` — the `ReplayCursorStore` idiom already in this tree — with a format version and a payload digest.

There is deliberately **no cursor-without-a-set and no set-without-a-height**. That is the W1/W2 lesson made structural: there, the bulk lane's persistent cursor and the fold's anchor were *independent*, and a restart resumed the lane at h=2513098 while the fold sat at h=2513000. On this lane a skipped range is a stale payment queue, which is a coinbase the network rejects.

`try_restore()` adopts a record only if all of these hold, and it **names the one that did not**:

| | rule |
|---|---|
| R1 | parses; magic + format version + digest all check out |
| R2 | descends from **the anchor this binary carries** — height, hash, source and count all identical |
| R3 | the cursor is strictly above the anchor |
| R4 | **our own PoW-validated header chain** holds, at the persisted height, exactly the block the record says was folded there |
| R5 | `applied == cursor_height - anchor_height` — the anti-gap arithmetic, checked by the **reader** so it never has to trust the writer |
| R6 | the set is non-empty |
| R7 | the cursor is not above our own tip |

Any refusal discards and erases the record and replays **COLD** from the anchor. A refusal costs a replay; it never costs a refusal to serve.

## What is persisted is what was DELIVERED

#1128 hit the inverse and it destroyed derived state: a lane floor taken from an aspirational *ceiling* instead of the delivered high-water orphaned every height in between. The write site here is one place, after `apply_block` has folded a block with no gap and no desync. `m_requested_through` and `m_replay_target` are both in scope there and neither may reach the record.

## A restored set may not publish unfalsified

A cold bridge earns trust block by block — every replayed block's real coinbase falsifies the projected payee. A restored set has had none of those tests run in this process. So publishing waits for one piece of evidence **this** process fetched: an applied block (the payment-*order* axis), or the fold — re-armed at the restored cursor rather than at the anchor — whose reply is DIP-4 authenticated against that block's own committed root (the *validity* axis). Normally both are available immediately; worst case is one block interval.

Stated plainly, because it will be quoted: **this is not #1128's G6.** `MNState` is the payee dialect and carries no `confirmedHash`, so the DIP-4 SML entry cannot be reconstructed from it and the list cannot be re-hashed to `merkleRootMNList` here. The resume is *falsifiable*, not *proven*.

## Erased where resuming would be wrong

`fail_closed()` erases the record: it sits below the failure, so resuming replays into the same wall — and the re-arm ladder's deterministic-repeat block is **per-process**, so a surviving record would turn a deterministic failure into a resume/fail/restart loop that nothing is left to see. `rearm()` erases it too.

## One behaviour change outside the new path

The staleness bound is now measured from the cursor the bridge will actually start at (the anchor on a cold arm — unchanged; the restored cursor on a resume). That bound is about *replay duration*, not anchor trust, and leaving it pinned to the anchor would have made this a regression: a node that had already replayed and persisted 19,995 of 20,000 blocks would fail closed on restart with "checkpoint is STALE" while having no work left.

## Tests

10 cases folded into the **existing allowlisted** target `test_dash_node_reception_wire` (#143 NOT_BUILT trap), nothing `#ifdef`-guarded (#895). **149/149 green.**

The load-bearing one is *outcome equality*: an interrupted-and-resumed bridge publishes the same set field for field (including `nLastPaidHeight`, the key `GetMNPayee` orders by), the same as-of height, and the same lifetime counters as one that ran straight through. It compares **outcomes**, so a field added to the lane and forgotten in the record fails it without anyone maintaining a list — the exact drift risk `reset_for_arm()` already names for the two reset lists it has.

Plus: every R-rule as a refusal that still lands on a correct cold replay; bit rot / truncation / foreign file / future format; fail-closed erasure; the unfalsified-publish hold; and the unwired case being byte-identical to today.

`--embedded-mn-bridge-no-cursor` restores the pre-#91 behaviour exactly, and exists because the claim here is a **timing** claim that needs an A/B on one binary.

---

## Measured on mainnet — contabo, pure daemonless, no dashd, one binary

Anchor h=2513000, tip ~2517185, **no `--replay-fold-*` flags**, so the MN-CKPT bridge is the only payee source and it is what is being timed.

| | COLD (pre-#91: no record existed) | RESUMED (#91) |
|---|---|---|
| process start | 07:35:19 | 08:41:51 |
| header backfill | 1m44s | **0s** (persisted) |
| cursor at h=2517001 (4001 blocks) | **08:11:44 — 34m41s of bridge replay** | **08:41:53 — restored in the same second it armed** |
| blocks this process had to walk | 4001 | **187** |
| published payee set | never — still tail-chasing a moving tip when stopped at 64m35s | **08:53:33 — 707 s (11m47s) total** |
| serve gate | — | `arm=would-serve populated=1 have_mn=1 mn_source=mn-ckpt mn_daemonless=1` |

```
[MN-CKPT] persisted cursor ACCEPTED: h=2517001 entries=2971 eligible=2071
          prior_applied=4001 prior_folds=22 — R2 lineage, R4 chain position and
          R5 contiguity all check out; skipping 4001 blocks of replay this
          process would otherwise have redone
[MN-CKPT] cursor RESTORED lane=mn-ckpt from=persisted-cursor@h=2517001
          cursor=2517002 target=2517185 to_replay=184 skipped=4001
[MN-CKPT] bridge COMPLETE: published 2971 masternodes as-of h=2517188
          (anchor h=2513000, replayed 4188 blocks — 4001 RESUMED from the
          persisted cursor at h=2517001, only 187 walked by this process)
          eligible 2068 -> 2071 (+15 reg, -11 spent, -47 PoSe-removed,
          +42 reinstated)
```

**95.5% of the replay (4001 of 4188 blocks) was skipped**, and the delta the resumed bridge publishes matches the shape a continuous cold bridge produces over the same range.

## Where the time ACTUALLY goes — and it is not the replay

The cold run's own timeline says the replay is not the cost:

```
07:37:04 → 07:37:12    751 blocks applied      (~190 blocks/second)
07:37:12 → 07:41:28    DEAD 4m16s   after the fold at h=2513489
07:41:30 → 07:47:04    DEAD 5m34s   after the fold at h=2513860
07:47:07 → 08:03:32    DEAD 16m25s  after the fold at h=2514150
08:03:32 → 08:03:36    750 blocks applied      (~190 blocks/second)
```

**26 of the first 28 minutes were dead gaps.** 22 folds ran in that bridge.

The mechanism is visible in the code. When a fold pauses the replay, `on_block_connected` drops the block bodies already in flight. On resume, `request_window()` computes `from = m_requested_through + 1`, which is **past** `end = m_next + kWindow - 1` — so it issues **zero** getdata and simply waits. Nothing re-asks until the stall probe in `pump()` sets `m_rerequest_from_cursor`, and `pump()` only runs on a tip change (~2.5 min).

The BAN-STATE PROBE path already fixes exactly this for itself, and its comment names the failure verbatim:

> *"THIS block was already requested and has just been dropped on the floor. request_window() asks only for heights above m_requested_through, so without this the resume would ask for height+1 — which on_block_connected ignores — and the bridge would sit on the stall probe until the next tip change."*

`begin_fold()` (scheduled) and `begin_ondemand_fold()` do **not** set that flag. Setting it in those two paths is the same one-line fix, and it looks worth far more wall clock than this PR does. **Deliberately not folded in here** — it is a different defect, it would change perf characteristics inside a fail-closed-critical change, and it would have invalidated the baseline above mid-flight.
