### PR TITLE
dash(embed-gate): the decline diagnostic printed twelve zeros for both sides of an inequality — report heights, discriminating hash tails, and the episode duration that ranks the causes [do-not-merge]

### DIFF
--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -526,9 +526,15 @@ public:
         // be papered over by a later clean incremental. Reject + keep prior state.
         const uint256 have_at = m_state.sml_current_hash();
         if (!diff.baseBlockHash.IsNull() && diff.baseBlockHash != have_at) {
-            LOG_WARNING << "[SML] REJECT diff: base "
-                        << diff.baseBlockHash.GetHex().substr(0, 16)
-                        << " != SML-current " << have_at.GetHex().substr(0, 16)
+            // Discriminating TAILs: these two hashes are compared for
+            // INEQUALITY, so rendering the difficulty padding they share made
+            // the line unable to show the very difference it reports.
+            LOG_WARNING << "[SML] REJECT diff: base ..."
+                        << discriminating_hash_tail(diff.baseBlockHash)
+                        << " != SML-current ..." << discriminating_hash_tail(have_at)
+                        << " @ h=" << (m_sml_height_paired
+                                           ? std::to_string(m_sml_current_height)
+                                           : std::string("n/a"))
                         << " (base-continuity guard) — awaiting a full/base-matched diff";
             return;
         }
@@ -705,7 +711,24 @@ public:
         // (NodeCoinState::make_embedded_work_inputs) compares this to the tip
         // we build on, and the next incremental diff's base must match it.
         m_state.set_sml_current_hash(diff.blockHash);
-        LOG_INFO << "[SML] applied diff: SML +" << sml_r.added_or_updated
+        // Publish the HEIGHT beside the hash, from the same statement, so the
+        // freshness pair can never disagree about which block it describes.
+        // Diagnostic only — no gate reads it; it exists so a `dmn-stale`
+        // refusal can say HOW FAR behind the DML is instead of only THAT it
+        // differs (see NodeCoinState::set_sml_current_height).
+        m_state.set_sml_current_height(
+            m_sml_height_paired ? static_cast<int64_t>(m_sml_current_height)
+                                : static_cast<int64_t>(-1));
+        LOG_INFO << "[SML] applied diff @ h="
+                 << (m_sml_height_paired
+                         ? std::to_string(m_sml_current_height)
+                         : std::string("n/a"))
+                 // The discriminating TAIL, not the difficulty padding: this
+                 // line is the corroborating evidence for every dmn-stale
+                 // episode, and printing the leading nibbles of a PoW hash left
+                 // it unable to corroborate anything.
+                 << " ..." << discriminating_hash_tail(diff.blockHash)
+                 << ": SML +" << sml_r.added_or_updated
                  << " -" << sml_r.deleted << " => " << m_state.sml().size()
                  << " MNs; quorums +" << q_added << " -" << q_deleted
                  << " => " << m_state.qmgr().active_count()

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -93,6 +93,37 @@ enum class BestClPolicy { Off, Freshness, ConsensusExact };
 ///                      nothing can be overstated.
 enum class UtxoImmaturePolicy { ServeEmptyTxSet, Refuse };
 
+/// The DISCRIMINATING tail of a block-hash display hex, for log/diagnostic use.
+///
+/// WHY THIS EXISTS (measured, hotel node 109.161.52.148, 2026-08-06). Every
+/// `dmn-stale` refusal in a 5h33m window printed
+///
+///     cause=dmn-stale value=000000000000 threshold=000000000000
+///
+/// — 114 of 114 identical, and the two sides equal, on a refusal whose ENTIRE
+/// meaning is that the two sides DIFFER. The fields were not unpopulated: they
+/// were `uint256::GetHex().substr(0, 12)`, i.e. the twelve MOST-significant
+/// nibbles of a PROOF-OF-WORK hash, which are zero by construction. The live
+/// tip hashes in the same log confirm it directly: `000000000000000e`,
+/// `000000000000001c`, `0000000000000018` — at mainnet difficulty the first
+/// ~14 nibbles are the difficulty padding and carry no information at all.
+///
+/// So the operator contract established by #1039 ("every decline names cause,
+/// value and threshold") was honoured in SHAPE and empty in SUBSTANCE, and no
+/// one could tell a genuinely stale DML from a broken predicate. Taking the
+/// TAIL instead of the head is the whole fix: the low-order nibbles are the
+/// hash's entropy.
+///
+/// Deliberately NOT applied to ProTx / transaction hashes elsewhere in this
+/// file (`mn-confirm-rollover-pending`, `mn-payout-split-unprovable`): those
+/// are ordinary double-SHA256 tx ids with no difficulty padding, so their
+/// leading nibbles ARE discriminating and their existing rendering is correct.
+inline std::string discriminating_hash_tail(const uint256& h, size_t n = 12)
+{
+    const std::string hex = h.GetHex();
+    return hex.size() <= n ? hex : hex.substr(hex.size() - n);
+}
+
 /// In-process coin-state the running node maintains for LOCAL template
 /// assembly. Non-copyable: it owns a Mempool (itself non-copyable) and is
 /// node-owned, never duplicated. The maintainer mutates mnstates()/mempool()
@@ -141,6 +172,23 @@ public:
     /// dashd fallback until the SML catches up to the new tip).
     void set_sml_current_hash(const uint256& h) { m_sml_current_hash = h; }
     const uint256& sml_current_hash() const { return m_sml_current_hash; }
+
+    /// The HEIGHT that same applied SML is current at, authoritative off the
+    /// accepted diff's own cbTx.nHeight (CoinStateMaintainer::m_sml_current_height).
+    /// -1 = never reported.
+    ///
+    /// DIAGNOSTIC-ONLY — nothing in the viability decision reads it. It exists
+    /// because the `dmn-stale` refusal below compares two BLOCK HASHES, and a
+    /// hash can only ever say "different", never "how far behind". Every long
+    /// dmn-stale episode measured on the hotel node (2026-08-06: 5 episodes,
+    /// 586 s of the 592 s total) was closed by the NEXT BLOCK arriving rather
+    /// than by the SML catching up at the same tip — a distinction the hash
+    /// alone cannot express, and the height makes obvious at a glance.
+    ///
+    /// Published from the SAME statement that publishes the hash, so the pair
+    /// can never disagree about which block it describes.
+    void set_sml_current_height(int64_t h) { m_sml_current_height = h; }
+    int64_t sml_current_height_dbg() const { return m_sml_current_height; }
 
     /// Seed the version-appropriate CCbTx fields the SML/quorum roots do not
     /// carry: the best-ChainLock height+signature and the DIP-0027 credit-pool
@@ -1241,11 +1289,25 @@ private:
             d = refuse("quorum-unhealthy", "quorum-tail-parse-failed", "parsed-ok");
         else if (m_require_sml && m_sml_current_hash != m_prev_hash)
             // A ZERO sml hash is "cold / wiped by reorg", not a block hash.
+            //
+            // Report the HEIGHT first and the discriminating hash TAIL second.
+            // Both halves are load-bearing:
+            //   * the height answers the only question an operator can act on —
+            //     HOW FAR behind is the DML? one block (the ordinary tip-change
+            //     round trip, ~54 ms measured) or many (a lost diff that will
+            //     not self-heal until the next block)?
+            //   * the hash tail still distinguishes a same-height fork from a
+            //     lag, which the height alone cannot.
+            // Before this, both fields rendered as twelve zeros — see
+            // discriminating_hash_tail() for the measurement.
             d = refuse("dmn-stale",
                        m_sml_current_hash.IsNull()
-                           ? std::string("n/a")
-                           : m_sml_current_hash.GetHex().substr(0, 12),
-                       m_prev_hash.GetHex().substr(0, 12));
+                           ? std::string("cold/wiped")
+                           : "h=" + (m_sml_current_height >= 0
+                                         ? std::to_string(m_sml_current_height)
+                                         : std::string("n/a"))
+                                 + ",..." + discriminating_hash_tail(m_sml_current_hash),
+                       "h=" + tip + ",..." + discriminating_hash_tail(m_prev_hash));
         else if (m_require_sml && find_unprojectable_confirmation(m_sml, m_mnstates))
             // FINDING-1 fail-closed fallback: an SML entry awaits its
             // height-driven confirmedHash rollover (specialtxman.cpp:206-215)
@@ -1432,6 +1494,7 @@ private:
     int64_t  m_credit_pool{0};                // DIP-0027 credit-pool balance (seeded from cbTx)
     bool     m_have_sml{false};               // a non-empty SML has been applied
     uint256  m_sml_current_hash;              // block hash the SML is current at (ZERO = cold/reorg)
+    int64_t  m_sml_current_height{-1};        // DIAGNOSTIC ONLY, -1 = never reported; see set_sml_current_height
     bool     m_require_sml{false};            // gate viability on have_sml (embedded arm)
     std::function<bool()> m_utxo_ready_fn;   // optional UTXO maturity gate (E2b)
     // Default REFUSES the immature window (p2pool semantics: an unsynced node

--- a/src/impl/dash/coin/serve_gate_journal.hpp
+++ b/src/impl/dash/coin/serve_gate_journal.hpp
@@ -63,6 +63,24 @@ public:
         /// The cause the previous emitted decline named ("" if none). Lets the
         /// Resumed / CauseChange lines say what they replaced.
         std::string previous_cause;
+        /// Seconds the arm has been continuously OFF the embedded template, as
+        /// of this decision. -1 when not applicable (the arm was already
+        /// serving) or not yet measurable.
+        ///
+        /// WHY THIS FIELD EXISTS — the COUNT of decline lines is the wrong
+        /// metric and it actively misleads. Measured on the hotel node over
+        /// 5h33m (2026-08-06): 109 `dmn-stale` episodes vs 3
+        /// `qc-plan-underivable`, so BY COUNT dmn-stale looks like 97% of the
+        /// problem. BY TIME ACTUALLY SPENT ON THE FALLBACK ARM, 104 of those
+        /// 109 dmn-stale episodes lasted under one second (~54 ms each — the
+        /// ordinary tip-change -> getmnlistd round trip, 5.6 s in total) while
+        /// the 3 qc-plan episodes cost 351 s. Eight episodes out of 116 carried
+        /// 99.4% of the loss, and the prioritisation flips completely depending
+        /// on which number you read.
+        ///
+        /// A journal that emits only counts cannot express that, so the episode
+        /// duration rides the line that closes the episode.
+        int64_t episode_sec{-1};
 
         bool emit() const { return trigger != Trigger::None; }
     };
@@ -83,6 +101,12 @@ public:
             if (was_declining) {
                 d.trigger    = Trigger::Resumed;
                 d.suppressed = m_suppressed;
+                // How long this episode actually cost us. Measured from the
+                // FIRST decline of the episode, not from the last emitted line,
+                // so a cause-change mid-episode cannot shorten the number.
+                d.episode_sec = (m_episode_start_sec >= 0)
+                                    ? now_sec - m_episode_start_sec : -1;
+                m_episode_start_sec = -1;
                 m_suppressed = 0;
                 m_last_emit_sec = now_sec;
                 m_have_emitted  = true;
@@ -92,6 +116,9 @@ public:
 
         const Arm prev_arm = m_arm;
         m_arm = Arm::Declining;
+        // Episode clock starts at the first decline after serving (or at the
+        // very first observation) and survives cause changes.
+        if (m_episode_start_sec < 0) m_episode_start_sec = now_sec;
 
         if (prev_arm == Arm::Embedded)
             d.trigger = Trigger::Transition;
@@ -109,6 +136,12 @@ public:
             return d;
         }
         d.suppressed    = m_suppressed;
+        // Also carried on the DECLINE lines: a heartbeat that says how long the
+        // arm has already been down is the difference between "the usual
+        // sub-second round trip" and "we have been off the embedded arm for
+        // four minutes", which read identically before.
+        d.episode_sec   = (m_episode_start_sec >= 0)
+                              ? now_sec - m_episode_start_sec : -1;
         m_suppressed    = 0;
         m_last_emit_sec = now_sec;
         m_have_emitted  = true;
@@ -143,6 +176,8 @@ private:
     Arm         m_arm{Arm::Unknown};
     std::string m_last_cause;
     int64_t     m_last_emit_sec{0};
+    /// Start of the CURRENT continuous off-embedded episode; -1 = arm serving.
+    int64_t     m_episode_start_sec{-1};
     bool        m_have_emitted{false};
     uint64_t    m_suppressed{0};
 };

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -669,11 +669,21 @@ void DASHWorkSource::note_arm_decision(bool served_embedded,
     }
     if (!d.emit()) return;
 
+    // The COST of the episode, in seconds off the embedded arm. This is the
+    // metric that RANKS the causes; the decline COUNT does not (measured
+    // 2026-08-06: 109 dmn-stale episodes vs 3 qc-plan-underivable, but 5.6 s vs
+    // 351 s of actual fallback serving). Emitting it here means nobody has to
+    // reconstruct it by hand-pairing DECLINED/RESUMED lines again.
+    const std::string dur =
+        d.episode_sec >= 0 ? " dur=" + std::to_string(d.episode_sec) + "s"
+                           : std::string();
+
     if (d.trigger == coin::ServeGateJournal::Trigger::Resumed) {
         LOG_WARNING << "[EMBED-GATE] h=" << height
                     << " arm=EMBEDDED RESUMED (was declining: "
                     << (d.previous_cause.empty() ? "unknown" : d.previous_cause)
-                    << "; " << d.suppressed << " decline(s) suppressed)";
+                    << ";" << dur
+                    << " " << d.suppressed << " decline(s) suppressed)";
         return;
     }
     // ONE named cause with its measured value and threshold -- never a list of
@@ -681,6 +691,7 @@ void DASHWorkSource::note_arm_decision(bool served_embedded,
     LOG_WARNING << "[EMBED-GATE] h=" << height
                 << " arm=dashd-fallback DECLINED " << why.one_line()
                 << " trigger=" << coin::ServeGateJournal::trigger_name(d.trigger)
+                << dur
                 << " suppressed=" << d.suppressed;
 }
 

--- a/test/test_dash_node_coin_state.cpp
+++ b/test/test_dash_node_coin_state.cpp
@@ -907,14 +907,121 @@ TEST(DashServeGateNamesRefusal, PayeeFreshIsViable) {        // negative twin
     EXPECT_TRUE(st.describe_decline().viable);
 }
 
-TEST(DashServeGateNamesRefusal, DmnStaleNamesSmlHashAndTipHash) {
+// A REALISTIC DASH mainnet block hash. raw256() above is NOT one: its bytes are
+// base+i, so its display hex has no leading zeros and any rendering of it looks
+// discriminating. A real block hash carries the DIFFICULTY PADDING — at mainnet
+// difficulty the display hex opens with ~14 zero nibbles (measured on the hotel
+// node 2026-08-06: 000000000000000e, 000000000000001c, 0000000000000018).
+// Zeroing the top 7 bytes reproduces exactly that shape.
+//
+// This helper exists because THE FIXTURE IS WHAT HID THE DEFECT: the old
+// DmnStaleNamesSmlHashAndTipHash asserted GetHex().substr(0, 12) and passed,
+// while in production both sides of that comparison rendered as twelve zeros
+// on 114 of 114 refusals.
+static uint256 pow256(uint8_t entropy) {
+    uint256 h;
+    std::array<uint8_t, 32> p{};
+    for (size_t i = 0; i < 25; ++i) p[i] = static_cast<uint8_t>(entropy + i);
+    // p[25..31] left ZERO -> 14 leading zero nibbles in GetHex().
+    std::memcpy(h.data(), p.data(), 32);
+    return h;
+}
+
+// Guard the helper itself: if it ever stops producing a padded hash, the tests
+// below would silently stop testing anything.
+TEST(DashServeGateNamesRefusal, PowFixtureActuallyCarriesDifficultyPadding) {
+    EXPECT_EQ(pow256(0x11).GetHex().substr(0, 12), std::string(12, '0'));
+    EXPECT_EQ(pow256(0x22).GetHex().substr(0, 12), std::string(12, '0'))
+        << "two DIFFERENT mainnet-shaped hashes must share their leading "
+           "nibbles — that is the whole reason the old rendering was blind";
+}
+
+TEST(DashServeGateNamesRefusal, DmnStaleNamesSmlHeightAndTipHeight) {
     NodeCoinState st;
     seed_healthy_armed(st);
     st.set_sml_current_hash(raw256(0xCD));   // SML current at a DIFFERENT block
+    st.set_sml_current_height(static_cast<int64_t>(H - 4));
     const DeclineReport d = st.describe_decline();
     EXPECT_EQ(d.cause, "dmn-stale");
-    EXPECT_EQ(d.value, raw256(0xCD).GetHex().substr(0, 12));
-    EXPECT_EQ(d.threshold, raw256(0xAB).GetHex().substr(0, 12));
+    // HEIGHT first (how far behind), discriminating hash TAIL second (which
+    // block — and same-height forks, which the height alone cannot express).
+    EXPECT_EQ(d.value, "h=" + std::to_string(H - 4) + ",..."
+                           + dash::coin::discriminating_hash_tail(raw256(0xCD)));
+    EXPECT_EQ(d.threshold, "h=" + std::to_string(H - 1) + ",..."
+                               + dash::coin::discriminating_hash_tail(raw256(0xAB)));
+}
+
+// THE DEFECT, as production actually presents it. Both hashes are mainnet-
+// shaped, so the pre-fix rendering collapses them onto the same twelve zeros
+// and the refusal reports value == threshold — on a refusal whose entire
+// meaning is that the two DIFFER.
+TEST(DashServeGateNamesRefusal, DmnStaleDistinguishesTwoMainnetPowHashes) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    // Re-stamp the tip with a mainnet-SHAPED hash. set_tip is the last thing
+    // seed_healthy_armed does, so this simply replaces it; the height is
+    // unchanged, so every height-keyed clause above dmn-stale stays satisfied.
+    st.set_tip(H - 1, pow256(0x11), 0x1b104be3u, 1'700'000'000u,
+               DASH_PUBKEY_VER, DASH_P2SH_VER, 1'700'000'123u, 0x20000000u);
+    st.set_sml_current_hash(pow256(0x22));
+
+    const DeclineReport d = st.describe_decline();
+    ASSERT_EQ(d.cause, "dmn-stale");
+    EXPECT_NE(d.value, d.threshold)
+        << "dmn-stale refuses BECAUSE the SML hash differs from the tip hash, "
+           "so a report whose value EQUALS its threshold cannot be read at all. "
+           "Measured on the hotel node 2026-08-06: 114 of 114 refusals printed "
+           "value=000000000000 threshold=000000000000, because both sides were "
+           "GetHex().substr(0, 12) of a PROOF-OF-WORK hash and those nibbles "
+           "are the difficulty padding. Report the discriminating TAIL.";
+    EXPECT_EQ(d.value.find(std::string(12, '0')), std::string::npos)
+        << "the reported value is still (or contains) the all-zero difficulty "
+           "padding — it carries no information about which block the SML is at";
+}
+
+// The height half, which is what turns "different" into "how far behind".
+// Uses the diagnostic height seam the maintainer publishes beside the hash.
+TEST(DashServeGateNamesRefusal, DmnStaleNamesHowFarBehindTheDmlIs) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_tip(H - 1, pow256(0x11), 0x1b104be3u, 1'700'000'000u,
+               DASH_PUBKEY_VER, DASH_P2SH_VER, 1'700'000'123u, 0x20000000u);
+    st.set_sml_current_hash(pow256(0x22));
+    st.set_sml_current_height(static_cast<int64_t>(H - 3));
+
+    const DeclineReport d = st.describe_decline();
+    ASSERT_EQ(d.cause, "dmn-stale");
+    EXPECT_NE(d.value.find("h=" + std::to_string(H - 3)), std::string::npos)
+        << "the report must say HOW FAR BEHIND the DML is — the only quantity "
+           "an operator can act on. A hash says THAT it differs, never by how "
+           "much, and every long dmn-stale episode measured in production was "
+           "closed by the next block arriving rather than by the SML catching "
+           "up at the same tip.";
+    EXPECT_NE(d.threshold.find("h=" + std::to_string(H - 1)), std::string::npos);
+}
+
+// Never reported (cold maintainer) must read as n/a, not as height 0 — the
+// #1039 discipline: do not print a measurement that was never taken.
+TEST(DashServeGateNamesRefusal, DmnStaleUnreportedHeightIsNotZero) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_sml_current_hash(raw256(0xCD));   // height never published
+    const DeclineReport d = st.describe_decline();
+    ASSERT_EQ(d.cause, "dmn-stale");
+    EXPECT_NE(d.value.find("h=n/a"), std::string::npos);
+    EXPECT_EQ(d.value.find("h=0,"), std::string::npos)
+        << "0 would read as 'we measured the SML height and it was genesis'";
+}
+
+// A cold / reorg-wiped SML is a DIFFERENT operator situation from a lagging
+// one, and "000000000000" could express neither.
+TEST(DashServeGateNamesRefusal, DmnStaleColdSmlSaysColdNotZeros) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_sml_current_hash(uint256::ZERO);
+    const DeclineReport d = st.describe_decline();
+    ASSERT_EQ(d.cause, "dmn-stale");
+    EXPECT_EQ(d.value, "cold/wiped");
 }
 
 TEST(DashServeGateNamesRefusal, DmnCurrentAtTipIsViable) {   // negative twin

--- a/test/test_dash_stratum_work_source.cpp
+++ b/test/test_dash_stratum_work_source.cpp
@@ -2339,6 +2339,67 @@ TEST(DashRunArmResolution, NoMainnetCombinationWithoutOptInEverEnablesTheArm)
 using dash::coin::ServeGateJournal;
 using Trig = dash::coin::ServeGateJournal::Trigger;
 
+// ── Episode DURATION: the metric that actually ranks the causes ─────────────
+// Measured on the hotel node over 5h33m (2026-08-06): 109 `dmn-stale` episodes
+// vs 3 `qc-plan-underivable`. BY COUNT dmn-stale is 97% of the problem. BY TIME
+// OFF THE EMBEDDED ARM, 104 of those 109 lasted under a second (~54 ms each,
+// 5.6 s in total — the ordinary tip-change -> getmnlistd round trip) while the
+// 3 qc-plan episodes cost 351 s. The two readings rank the work in OPPOSITE
+// orders, and the journal could only ever emit the misleading one.
+TEST(DashServeGateJournal, ResumeReportsHowLongTheArmWasDown) {
+    ServeGateJournal j(300);
+    j.observe(true,  "", 1000);                    // serving
+    j.observe(false, "dmn-stale", 1010);           // episode starts
+    auto d = j.observe(true, "", 1130);            // resumes 120 s later
+    ASSERT_EQ(d.trigger, Trig::Resumed);
+    EXPECT_EQ(d.episode_sec, 120)
+        << "the RESUMED line must carry the cost of the episode in seconds; a "
+           "decline COUNT cannot distinguish a 54 ms tip-change round trip from "
+           "a four-minute outage, and those need opposite responses";
+}
+
+// A cause change mid-episode must NOT restart the clock: the arm never came
+// back, so "how long have we been off?" is answered from the FIRST decline,
+// not from the last relabelling.
+TEST(DashServeGateJournal, CauseChangeDoesNotRestartTheEpisodeClock) {
+    ServeGateJournal j(300);
+    j.observe(true,  "", 1000);
+    j.observe(false, "qc-plan-underivable", 1010); // episode starts here
+    j.observe(false, "dmn-stale", 1100);           // cause changes, still down
+    auto d = j.observe(true, "", 1160);
+    ASSERT_EQ(d.trigger, Trig::Resumed);
+    EXPECT_EQ(d.episode_sec, 150)
+        << "measured from the FIRST decline (1010), not the cause change "
+           "(1100) — otherwise every long episode that changes cause reports "
+           "only its final segment and the true loss is understated";
+}
+
+// The decline lines carry it too, so an episode still in flight is readable
+// without waiting for it to end.
+TEST(DashServeGateJournal, DeclineLinesCarryTheRunningEpisodeAge) {
+    ServeGateJournal j(10);
+    j.observe(true,  "", 1000);
+    auto first = j.observe(false, "dmn-stale", 1005);
+    ASSERT_EQ(first.trigger, Trig::Transition);
+    EXPECT_EQ(first.episode_sec, 0);
+    auto beat = j.observe(false, "dmn-stale", 1065);   // heartbeat
+    ASSERT_EQ(beat.trigger, Trig::Heartbeat);
+    EXPECT_EQ(beat.episode_sec, 60)
+        << "a heartbeat that cannot say how long the arm has already been down "
+           "reads identically at 1 s and at 4 min";
+}
+
+// While the arm is serving there is no episode; the field must stay absent
+// rather than report a stale or zero duration.
+TEST(DashServeGateJournal, ServingArmHasNoEpisodeDuration) {
+    ServeGateJournal j(300);
+    j.observe(false, "dmn-stale", 1000);
+    j.observe(true,  "", 1030);
+    auto d = j.observe(true, "", 1090);   // still serving, nothing emitted
+    EXPECT_FALSE(d.emit());
+    EXPECT_EQ(d.episode_sec, -1);
+}
+
 TEST(DashServeGateJournal, FirstObservationEverIsAlwaysEmitted) {
     ServeGateJournal j(300);
     auto d = j.observe(false, "dmn-stale", 1000);


### PR DESCRIPTION
Step 1 of "100% embedded template serving": **the instrument, before any behaviour.** No gate, threshold or predicate is touched.

## The diagnostic was blind

Measured on the hotel node (`109.161.52.148`, `a73da8ec`) over **5h33m**, 2026-08-06 02:27:09–08:00:02: **2971 EMBEDDED vs 536 dashd-fallback** template serves. Every `dmn-stale` refusal in that window read:

```
[EMBED-GATE] h=2517151 arm=dashd-fallback DECLINED cause=dmn-stale \
    value=000000000000 threshold=000000000000 trigger=cause-change suppressed=5
```

**114 of 114 identical, and the two sides equal** — on a refusal whose entire meaning is that they *differ*.

The fields were not unpopulated. They were `uint256::GetHex().substr(0, 12)`: the twelve **most-significant** nibbles of a **proof-of-work** hash, which are the difficulty padding and are zero by construction. The same log proves it directly — real tip hashes, printed elsewhere at `substr(0,16)`:

```
[EMB-DASH] tip advanced h=2517152 000000000000000e
[EMB-DASH] tip advanced h=2517153 000000000000001c
[EMB-DASH] tip advanced h=2517154 0000000000000018
```

So #1039's contract ("every decline names cause, value and threshold") was honoured in **shape** and empty in **substance**. From the log it was impossible to tell a genuinely stale DML from a broken predicate — which is exactly the question the task asked.

### Why the tests did not catch it

`DmnStaleNamesSmlHashAndTipHash` asserted precisely that `substr(0, 12)` rendering — and passed. Its fixture, `raw256()`, builds a hash whose bytes are `base + i`: **no difficulty padding**, so in the test the leading nibbles are discriminating and in production they never are. The fixture could not exhibit the defect it was guarding. This PR keeps that test (updated to the new contract) and adds `pow256()` plus a guard test on the fixture itself.

## The second, larger finding: the decline COUNT is the wrong metric

Pairing every `DECLINED` with its following `RESUMED` across the same window:

| cause | n | total_s | mean_s | max_s | n<1s | n>=1s | long_s |
|---|---:|---:|---:|---:|---:|---:|---:|
| `dmn-stale` | 109 | 591.77 | 5.429 | 275.30 | **104** | 5 | **586.18** |
| `qc-plan-underivable` | 3 | 351.24 | 117.081 | 168.69 | 0 | 3 | 351.24 |
| `bestcl-stale` | 1 | 0.23 | 0.234 | 0.23 | 1 | 0 | 0.00 |
| `creditpool-stale` | 3 | 0.12 | 0.040 | 0.10 | 3 | 0 | 0.00 |

**By count**, `dmn-stale` is 97% of the problem. **By time actually spent on the fallback arm**, 104 of those 109 `dmn-stale` episodes are **sub-second** (~54 ms each, 5.6 s in total — the ordinary tip-change → `getmnlistd` round trip, not a defect at all), while 3 `qc-plan-underivable` episodes cost **351 s**.

**Eight episodes out of 116 carry 99.4% of the loss.** The two readings rank the work in opposite orders, and the journal could only ever emit the misleading one. That is why `episode_sec` is in this PR and not deferred: without it the next person repeats the same mis-prioritisation I nearly did.

*(These totals are a lower bound: the pairing measures from the last cause-change to the resume, so multi-cause episodes are undercounted. `episode_sec` measures from the first decline and fixes that at the source.)*

## What this changes — diagnostic only

- **`discriminating_hash_tail()`** — render the **low-order** nibbles, where a PoW hash keeps its entropy. Applied to the `dmn-stale` report and to the `[SML] applied` / `[SML] REJECT` lines that corroborate it. Deliberately **not** applied to ProTx hashes (`mn-confirm-rollover-pending`, `mn-payout-split-unprovable`): those are ordinary tx ids with no padding, so their existing rendering is already correct.
- **`NodeCoinState::set_sml_current_height()`** — the height the SML is current at, published by `CoinStateMaintainer` from the **same statement** that publishes the hash, so the pair can never disagree about which block it describes. A hash can only say *that* it differs; the height says **how far behind**. `dmn-stale` now reports `value=h=2517139,...a1c3f0 threshold=h=2517140,...9e77b2`, and `cold/wiped` for a reorg-wiped SML instead of a zero hash.
- **`ServeGateJournal::Decision::episode_sec`** — seconds continuously off the embedded arm, measured from the **first** decline of the episode so a mid-episode cause change cannot understate it. Emitted as `dur=` on both the `DECLINED` and `RESUMED` lines, so an episode still in flight is readable without waiting for it to end.

**No gate, threshold or predicate is touched.** Not one condition for serving an embedded template changes; the arm decides exactly what it decided before. The gate guards payee selection, and a wrong payee is the `bad-cb-payee` rejection that cost h=2516595 — so the measurement lands first, alone, before any behaviour does.

## Per-cause verdicts (from this window — carried in the issue, not fixed here)

| cause | measuring correctly? | genuine? | avoidable? |
|---|---|---|---|
| `dmn-stale` (sub-second, 104×) | **no** — fixed here | yes, but **not a staleness problem** — a per-tip ORDERING window, ~54 ms each (see reframing below) | **no** — this is the irreducible floor |
| `dmn-stale` (long, 5×) | **no** — fixed here | yes | **likely yes** — see below |
| `qc-plan-underivable` (3×, 351 s) | weak (`value=nullopt`) but **not blind** — adjacent `[QC-COMPLETENESS] reason=no-commitment-cached` and `[QC-EPISODE] dur=124s terminal=real-arrived` already name it | **yes, and correct** — waiting on a mandatory type-4 DKG commitment; serving without it commits a wrong `merkleRootQuorums` = lost block. **Must not be relaxed.** | possibly — the commitment arrived by unsolicited `qfcommit` push at the *next* block; an explicit request may pre-empt it |
| `bestcl-stale`, `creditpool-stale`, `not-populated`, `tip-body-pending` | **yes** — real heights / real populate halves | yes | transient; 0.35 s combined across the window. Noise. |

**The long `dmn-stale` lead.** Traced at h=2517141 (155.9 s):

```
07:34:37.559  DECLINED cause=dmn-stale
   ... 156 s of dashd-fallback serving, no SML update at the current tip ...
07:37:12.924  [EMB-DASH] tip advanced h=2517141   <-- the NEXT BLOCK
07:37:13.471  [COIN-P2P] mnlistdiff: base=...1f tip=...11 +1mn
07:37:13.491  RESUMED
```

The window was **not** closed by the SML catching up — it was closed by the chain advancing. `send_getmnlistd` is issued only on tip-change (`main_dash.cpp:4436`) and at handshake (`:4490`); **there is no retry**. One lost or unusable reply therefore costs a full block interval, which is exactly the shape of the five long windows (275/156/103/51/1 s). Zero `[SML] REJECT` lines fired in the window, so the base-continuity guard is not the cause. A bounded re-request inside the block interval is a **readiness** fix — making the state ready sooner, never lowering the bar — and it is the next PR, with before/after decline counts. I am **not** changing it here.

I cannot yet state definitively whether any individual long `dmn-stale` was a genuine lag or a same-height fork: the log truncates away the discriminating nibbles. **That is the finding, and it is why this PR exists first.**

## Reframing: `dmn-stale` is a cadence question, not a staleness one

Independently confirmed on **.211** — a separate node, own data dir, own ports, no relation to the hotel — where it cleared unaided:

```
[EMBED-GATE] h=2517160 arm=EMBEDDED RESUMED (was declining: dmn-stale; 0 decline(s) suppressed)
```

It resolved **within a single tip advance, with no intervention**, immediately after the UTXO lane warmed and the payee queue populated — the window between the payee snapshot landing and the DMN axis being considered current for the new tip.

That is the same conclusion this PR's duration analysis reached from the opposite direction: 104 of 109 episodes are sub-second at ~54 ms, i.e. the ordinary tip-change round trip. **Two independent nodes, two independent methods, one answer.**

So the right question for the hotel's dominant `dmn-stale` is **not** "why is the masternode set stale" but "is this the same per-tip transient recurring at every tip". Those point at completely different fixes — "the DML is stale 109 times" points at sync correctness, "there is a per-tip ordering window" points at cadence and ordering — and only the second is what the measurement supports. The blind report is exactly what kept the wrong reading available.

The **five long** `dmn-stale` episodes are a genuinely different phenomenon wearing the same cause label (the missing-retry trace above) — another thing `dur=` surfaces at a glance instead of by hand-pairing.

## The natural successor: measure where the DECISION is, not where the SERVING is

`dur=` instruments the **serve** path, so it can only observe what happens while the gate is refusing. It answers "we declined for 275 s"; it cannot answer "did we need to".

The instrument that would is **`--embedded-oracle-shadow`**: it builds the embedded template **regardless of what is served**, so it keeps producing one *through* a decline window — precisely when the serve path is on dashd-fallback and has nothing to measure. Comparing that shadow template against dashd's during the decline turns "we declined for 275 seconds" into "we declined for 275 seconds **and here is whether the embedded arm would have been correct anyway**". That is the difference between measuring the symptom and measuring the decision, and the only way to separate a *necessary* decline from a merely *explicable* one.

Credit: this framing comes from the mempool lane, which hit the same wall from the other side — a candidate-set measurement that could not fire live because the gate was declining and the provenance guard correctly refused to measure. Third time this lesson has come round, so it is recorded here rather than rediscovered a fourth time.

Not built in this PR: the readiness fixes come first, and this is the instrument that tells us when to stop.

## Separate defect found (filing, not fixing here)

`[LLMQ-TYPE-RECONCILE] ENABLED-SET DISAGREES WITH THE CHAIN` is **162,329 of 400,013 log lines = 40.6%**, firing several times per second with a monotonically climbing `observations=` counter (25226 → 25282 in 10 s). It is why the log is 600 MB and it actively obscures the serve-gate signal — every timeline in this PR had to be `grep -v`'d past it. Not touched here.

## Tests — real red/green, both runs executed

On the **existing allowlisted** targets `test_dash_node_coin_state` and `test_dash_stratum_work_source`. No new `add_executable` (#143), no `#ifdef` guards (#895), **no CMake change at all**.

### RED — new tests, unfixed sources (master `011b104d`)

```
[ RUN      ] DashServeGateNamesRefusal.PowFixtureActuallyCarriesDifficultyPadding
[       OK ] DashServeGateNamesRefusal.PowFixtureActuallyCarriesDifficultyPadding (0 ms)
[ RUN      ] DashServeGateNamesRefusal.DmnStaleDistinguishesTwoMainnetPowHashes
test_dash_node_coin_state.cpp:956: Failure
Expected: (d.value) != (d.threshold), actual: "000000000000" vs "000000000000"
dmn-stale refuses BECAUSE the SML hash differs from the tip hash, so a report whose value EQUALS its threshold cannot be read at all. Measured on the hotel node 2026-08-06: 114 of 114 refusals printed value=000000000000 threshold=000000000000, because both sides were GetHex().substr(0, 12) of a PROOF-OF-WORK hash and those nibbles are the difficulty padding. Report the discriminating TAIL.

test_dash_node_coin_state.cpp:963: Failure
Expected equality of these values:
  d.value.find(std::string(12, '0'))
    Which is: 0
  std::string::npos
the reported value is still (or contains) the all-zero difficulty padding — it carries no information about which block the SML is at

[  FAILED  ] DashServeGateNamesRefusal.DmnStaleDistinguishesTwoMainnetPowHashes (0 ms)
[  PASSED  ] 1 test.
[  FAILED  ] 1 test
```

The failure text is byte-for-byte the production symptom. `PowFixtureActuallyCarriesDifficultyPadding` passes in both trees by design — it guards the fixture, so this test can never silently stop testing anything the way its predecessor did.

### GREEN — this branch

```
[       OK ] DashServeGateNamesRefusal.PowFixtureActuallyCarriesDifficultyPadding (0 ms)
[       OK ] DashServeGateNamesRefusal.DmnStaleNamesSmlHeightAndTipHeight (0 ms)
[       OK ] DashServeGateNamesRefusal.DmnStaleDistinguishesTwoMainnetPowHashes (0 ms)
[       OK ] DashServeGateNamesRefusal.DmnStaleNamesHowFarBehindTheDmlIs (0 ms)
[       OK ] DashServeGateNamesRefusal.DmnStaleUnreportedHeightIsNotZero (0 ms)
[       OK ] DashServeGateNamesRefusal.DmnStaleColdSmlSaysColdNotZeros (0 ms)
[       OK ] DashServeGateNamesRefusal.DmnCurrentAtTipIsViable (0 ms)
[  PASSED  ] 7 tests.

[       OK ] DashServeGateJournal.ResumeReportsHowLongTheArmWasDown (0 ms)
[       OK ] DashServeGateJournal.CauseChangeDoesNotRestartTheEpisodeClock (0 ms)
[       OK ] DashServeGateJournal.DeclineLinesCarryTheRunningEpisodeAge (0 ms)
[       OK ] DashServeGateJournal.ServingArmHasNoEpisodeDuration (0 ms)
[       OK ] DashServeGateJournal.FirstObservationEverIsAlwaysEmitted (0 ms)
[       OK ] DashServeGateJournal.EmbeddedToFallbackTransitionAlwaysEmits (0 ms)
[       OK ] DashServeGateJournal.RepeatOfSameCauseInsideHeartbeatIsSuppressed (0 ms)
[       OK ] DashServeGateJournal.ChangeOfCauseEmitsImmediately (0 ms)
[       OK ] DashServeGateJournal.HeartbeatEmitsOnlyAfterTheIntervalElapses (0 ms)
[       OK ] DashServeGateJournal.SuppressedCountRidesTheNextEmittedLine (0 ms)
[       OK ] DashServeGateJournal.ResumeEmitsAndNamesWhatItReplaced (0 ms)
[       OK ] DashServeGateJournal.SteadyServingNeverEmits (0 ms)
[       OK ] DashServeGateJournal.TwoTransitionsBothEmitEvenWithOneCause (0 ms)
[  PASSED  ] 13 tests.
```

The 9 pre-existing `DashServeGateJournal` tests are unmodified and still green — `episode_sec` is additive.

**Honest scope note on the red/green:** the four `episode_sec` tests are green-only. `Decision::episode_sec` is a new field, so against master they do not compile rather than fail — there is no meaningful RED for a field that does not exist, and I am not dressing one up. The defect this PR is actually about (`dmn-stale` blindness) has a genuine runnable RED, shown above.

## Merge sequencing

Touches `src/impl/dash/coin/{node_coin_state,coin_state_maintainer,serve_gate_journal}.hpp`, `src/impl/dash/stratum/work_source.cpp`, and two existing test files. **No `main_dash.cpp`** — no overlap with #1145.

Shares `work_source.cpp` with my open #1150, in a **different function** (`note_arm_decision`; #1150 changes `resource_template_now` and `cached_work`, which sit either side of it). No textual overlap; either order merges. If #1150 lands first I will rebase this on top.

## Deploy note

`do-not-merge` pending operator review. Read-only inspection on `109.161.52.148` throughout — no restarts, no deploys, no config changes. Heavy builds on VM905.
