### PR TITLE
dash(sml): the tip getmnlistd had no retry and no log line — 586 of 940 fallback seconds. Instrument it, and land the bounded re-request policy [do-not-merge]

### DIFF
--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -1323,9 +1323,29 @@ public:
     uint64_t body_rerequests_exhausted() const { return m_body_rerequests_exhausted; }
 
     /// Send a getmnlistd (SML diff request) — E2/E3 masternode-list sync seam.
+    ///
+    /// OBSERVABILITY (2026-08-06). This used to return SILENTLY when there was
+    /// no primary peer, and logged nothing on the way out either. That made a
+    /// whole class of stall undiagnosable: when the hotel node's SML sat behind
+    /// the tip for 156 s there was no way to tell from the log whether the
+    /// request had been sent and gone unanswered, or had never been sent at
+    /// all. Those two have completely different fixes, and the absence of this
+    /// one line is what made the question unanswerable.
+    ///
+    /// Full hashes, not a prefix: at mainnet difficulty the leading ~14 nibbles
+    /// of a block hash are difficulty padding and carry no information, and
+    /// this line fires about once per tip so it can afford the bytes.
     void send_getmnlistd(const uint256& base_block_hash, const uint256& block_hash)
     {
-        if (!m_primary) return;
+        if (!m_primary) {
+            LOG_WARNING << "[COIN-P2P] getmnlistd DROPPED (no primary peer):"
+                        << " base=" << base_block_hash.GetHex()
+                        << " target=" << block_hash.GetHex()
+                        << " — the SML cannot advance until a peer is up";
+            return;
+        }
+        LOG_INFO << "[COIN-P2P] getmnlistd -> base=" << base_block_hash.GetHex()
+                 << " target=" << block_hash.GetHex();
         auto msg = message_getmnlistd::make_raw(base_block_hash, block_hash);
         m_primary->write(msg);
     }

--- a/src/impl/dash/coin/sml_resync_watchdog.hpp
+++ b/src/impl/dash/coin/sml_resync_watchdog.hpp
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// dash::coin::SmlResyncWatchdog — re-ask for the tip mnlistdiff when the one we
+// asked for never came back.
+//
+// ── THE GAP THIS CLOSES (measured, hotel node 109.161.52.148, 2026-08-06) ────
+//
+// The SML advances on exactly one trigger: a tip change fires
+// `send_getmnlistd(sml_base, new_tip)` (main_dash.cpp) and the reply moves
+// `sml_current_hash` forward. There is NO retry anywhere — the only other
+// getmnlistd call sites are the handshake, the RPC seed, and the historical
+// work-block snapshot requests. So a single request that is never sent or never
+// answered leaves the SML behind the tip until the NEXT block fires the trigger
+// again, roughly one block interval (~2.6 min on mainnet) of serving from the
+// dashd fallback instead of the embedded arm.
+//
+// That is not a hypothesis. Over a 5h33m window the embedded arm spent 943 s on
+// the fallback, and 586 s of it — 62% of the total, and 99% of all `dmn-stale`
+// time — sat in just FIVE episodes of 275/156/103/51/1 s. Every one was closed
+// by `[EMB-DASH] tip advanced`, i.e. by the chain moving, never by the SML
+// catching up at the tip it was already on. Traced at h=2517141:
+//
+//     07:34:37.559  [EMBED-GATE] DECLINED cause=dmn-stale
+//        ... 156 s of dashd-fallback serving, no [SML] line at all ...
+//     07:37:12.924  [EMB-DASH] tip advanced h=2517141      <-- the NEXT BLOCK
+//     07:37:13.471  [COIN-P2P] mnlistdiff: base=...1f tip=...11 +1mn
+//     07:37:13.491  [EMBED-GATE] RESUMED
+//
+// The two other explanations were eliminated rather than assumed:
+//   * NOT the base-continuity guard — zero `[SML] REJECT` lines in the window.
+//   * NOT the historical demux stealing the reply — QuorumMemberSource::
+//     on_mnlistdiff matches STRICTLY on (baseBlockHash.IsNull() AND blockHash
+//     in the await set), so a tip INCREMENTAL can never be claimed by it.
+//
+// ── WHAT THIS IS NOT ────────────────────────────────────────────────────────
+//
+// It is NOT a relaxation of anything. The `dmn-stale` predicate, the serve
+// gate, the base-continuity guard and every consensus check are untouched: this
+// only re-sends a request that was already supposed to have been answered, so
+// the state the gate reads becomes ready SOONER. A gate that is satisfied
+// earlier because its input arrived is categorically different from a gate that
+// is satisfied because it was lowered. Nothing here can cause a template to be
+// served that would not have been served one block later anyway.
+//
+// It is also NOT for the ordinary per-tip window. 104 of 109 `dmn-stale`
+// episodes in the same window were sub-second (~54 ms — the normal tip-change
+// round trip) and are the irreducible floor. `min_quiet` exists precisely so
+// this never fires on those: a retry at 54 ms would be pure duplicate traffic.
+//
+// ── POLICY ──────────────────────────────────────────────────────────────────
+//
+// Fail-QUIET and strictly bounded, because the failure mode of a retry is
+// hammering a peer that is already struggling:
+//   * only while the SML is actually behind the tip;
+//   * only after `min_quiet` seconds of no SML progress (well above a normal
+//     round trip, well below a block interval);
+//   * geometric backoff between attempts;
+//   * at most `max_attempts` per stuck (tip, sml) pair — after that we wait for
+//     the next block exactly as today, so a genuinely unreachable peer sees the
+//     same traffic it sees now plus a bounded constant;
+//   * any observed SML progress, or a tip change, resets everything.
+
+#include <cstdint>
+#include <optional>
+
+#include <core/uint256.hpp>
+
+namespace dash {
+namespace coin {
+
+class SmlResyncWatchdog {
+public:
+    struct Config {
+        /// Seconds of no SML progress before the FIRST re-request. Must sit
+        /// well above a healthy round trip (measured ~54 ms) so the ordinary
+        /// per-tip window never triggers it, and well below a block interval
+        /// (~156 s measured) so a stuck SML is recovered inside the same block
+        /// rather than by the next one.
+        int64_t  min_quiet_sec{20};
+        /// Multiplier applied to the wait after each attempt.
+        int64_t  backoff_mult{2};
+        /// Hard cap per stuck (tip, sml) pair. After this we go quiet and let
+        /// the next tip change do what it does today.
+        uint32_t max_attempts{3};
+    };
+
+    /// What the caller should send: getmnlistd(base = sml_at, target = tip).
+    struct Request {
+        uint256  base;
+        uint256  target;
+        uint32_t attempt{0};   ///< 1-based, for the log line
+    };
+
+    SmlResyncWatchdog() = default;
+    explicit SmlResyncWatchdog(Config c) : m_cfg(c) {}
+
+    /// Feed the CURRENT observation. Returns a request when one is due.
+    ///
+    /// `sml_at` is the block the SML is current at (ZERO = cold/wiped);
+    /// `tip` is the block we are building on. Call it on any convenient
+    /// cadence — the decision is time-based, not call-count-based, so a slow
+    /// or jittery timer changes when a retry happens but never whether the
+    /// bounds hold.
+    std::optional<Request> observe(const uint256& tip, const uint256& sml_at,
+                                   int64_t now_sec)
+    {
+        // Cold SML: a ZERO base is a FULL-snapshot re-seed, which is a
+        // different (and much heavier) request than a tip incremental, and the
+        // cold path already has its own drivers. Never our business.
+        if (sml_at.IsNull()) { reset(now_sec); return std::nullopt; }
+
+        // In sync: nothing to do, and this is the state we return to after
+        // every successful recovery.
+        if (sml_at == tip) { reset(now_sec); return std::nullopt; }
+
+        // A NEW stuck pair (either axis moved) restarts the whole policy: the
+        // SML made progress, or we are now chasing a different tip, and in both
+        // cases the previous attempt budget describes a situation that no
+        // longer exists.
+        if (tip != m_tip || sml_at != m_sml_at) {
+            m_tip        = tip;
+            m_sml_at     = sml_at;
+            m_since_sec  = now_sec;
+            m_attempts   = 0;
+            m_last_try   = -1;
+            return std::nullopt;   // never retry on the FIRST sighting
+        }
+
+        if (m_attempts >= m_cfg.max_attempts) return std::nullopt;
+
+        // Wait: min_quiet before the first attempt, then geometric backoff.
+        int64_t wait = m_cfg.min_quiet_sec;
+        for (uint32_t i = 0; i < m_attempts; ++i) wait *= m_cfg.backoff_mult;
+        const int64_t since = (m_last_try >= 0) ? m_last_try : m_since_sec;
+        if (now_sec - since < wait) return std::nullopt;
+
+        m_last_try = now_sec;
+        ++m_attempts;
+        return Request{sml_at, tip, m_attempts};
+    }
+
+    /// Attempts spent against the current stuck pair (0 when in sync).
+    uint32_t attempts() const { return m_attempts; }
+
+private:
+    void reset(int64_t now_sec)
+    {
+        m_tip.SetNull();
+        m_sml_at.SetNull();
+        m_since_sec = now_sec;
+        m_attempts  = 0;
+        m_last_try  = -1;
+    }
+
+    Config   m_cfg;
+    uint256  m_tip;
+    uint256  m_sml_at;
+    int64_t  m_since_sec{0};
+    int64_t  m_last_try{-1};
+    uint32_t m_attempts{0};
+};
+
+}  // namespace coin
+}  // namespace dash

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -926,10 +926,13 @@ if (BUILD_TESTING AND GTest_FOUND)
     # D-DASH.WORKSOURCE-OWNERSHIP (#1134) is its SERVE-path sibling and rides the
     # same target for the same reason — it guards stratum/work_source.{cpp,hpp}
     # by source text, so it adds no link deps either.
+    # D-DASH.SML-RESYNC rides it too (#143): the watchdog is header-only over
+    # core/uint256.hpp, so it adds no link deps either.
     add_executable(test_dash_node_coin_state
         test_dash_node_coin_state.cpp
         test_dash_oracle_shadow_ownership.cpp
-        test_dash_work_source_ownership.cpp)
+        test_dash_work_source_ownership.cpp
+        test_dash_sml_resync_watchdog.cpp)
     target_link_libraries(test_dash_node_coin_state PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core

--- a/test/test_dash_sml_resync_watchdog.cpp
+++ b/test/test_dash_sml_resync_watchdog.cpp
@@ -1,0 +1,189 @@
+// D-DASH.SML-RESYNC — the tip mnlistdiff request had no retry, and one lost
+// reply cost a full block interval of embedded serving.
+//
+// MEASURED (hotel node 109.161.52.148, 2026-08-06, 5h33m window). The embedded
+// arm spent 943 s on the dashd fallback. 586 s of that — 62% of the total and
+// 99% of all `dmn-stale` time — sat in FIVE episodes of 275/156/103/51/1 s, and
+// every one was closed by `[EMB-DASH] tip advanced`, i.e. by the chain moving
+// on, never by the SML catching up at the tip it was already on. The SML
+// advances on exactly one trigger (a tip change fires getmnlistd) and there is
+// no retry anywhere, so a request that is never sent or never answered strands
+// the embedded arm until the next block fires the trigger again.
+//
+// The two competing explanations were ELIMINATED, not assumed:
+//   * not the base-continuity guard — zero `[SML] REJECT` lines in the window;
+//   * not the historical demux stealing the tip reply — QuorumMemberSource::
+//     on_mnlistdiff matches STRICTLY on (baseBlockHash.IsNull() AND blockHash
+//     in the await set), so a tip incremental can never be claimed by it.
+//
+// These tests pin the POLICY, which is where the risk is. A retry that is too
+// eager hammers a peer that is already struggling; one that is too lazy is the
+// bug. So the bounds are the contract: never on the ordinary sub-second per-tip
+// window, never unbounded, always reset by real progress.
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstring>
+
+#include <impl/dash/coin/sml_resync_watchdog.hpp>
+
+using dash::coin::SmlResyncWatchdog;
+
+namespace {
+
+uint256 blk(uint8_t seed)
+{
+    uint256 h;
+    // Mainnet-SHAPED: top bytes zero (difficulty padding), entropy low down.
+    std::array<uint8_t, 32> p{};
+    for (size_t i = 0; i < 25; ++i) p[i] = static_cast<uint8_t>(seed + i);
+    std::memcpy(h.data(), p.data(), 32);
+    return h;
+}
+
+SmlResyncWatchdog::Config fast()
+{
+    SmlResyncWatchdog::Config c;
+    c.min_quiet_sec = 20;
+    c.backoff_mult  = 2;
+    c.max_attempts  = 3;
+    return c;
+}
+
+}  // namespace
+
+// ── THE DEFECT: a stuck SML must eventually be re-asked ─────────────────────
+// Without a retry this is the 156 s hole at h=2517141: the SML sits behind the
+// tip and nothing asks again until the next block.
+TEST(DashSmlResyncWatchdog, StuckSmlIsReRequestedAfterTheQuietPeriod)
+{
+    SmlResyncWatchdog w(fast());
+    const uint256 tip = blk(0x11), sml = blk(0x22);
+
+    EXPECT_FALSE(w.observe(tip, sml, 1000).has_value())
+        << "the FIRST sighting of a lag must never retry — that is the ordinary "
+           "tip-change round trip, measured at ~54 ms";
+    EXPECT_FALSE(w.observe(tip, sml, 1019).has_value())
+        << "still inside the quiet period";
+
+    auto r = w.observe(tip, sml, 1020);
+    ASSERT_TRUE(r.has_value())
+        << "after min_quiet with NO SML progress the request must be re-sent; "
+           "without this the arm waits for the next block (~156 s measured)";
+    EXPECT_EQ(r->base, sml)   << "re-ask from where the SML actually is";
+    EXPECT_EQ(r->target, tip) << "...up to the tip we are trying to build on";
+    EXPECT_EQ(r->attempt, 1u);
+}
+
+// ── The ordinary per-tip window must NEVER trigger it ───────────────────────
+// 104 of the 109 measured dmn-stale episodes were sub-second. A retry there is
+// pure duplicate traffic against a peer that is answering perfectly well.
+TEST(DashSmlResyncWatchdog, OrdinaryPerTipWindowNeverRetries)
+{
+    SmlResyncWatchdog w(fast());
+    const uint256 tip = blk(0x11);
+    EXPECT_FALSE(w.observe(tip, blk(0x22), 1000).has_value());
+    // The real diff lands ~54 ms later; the watchdog is polled either side.
+    EXPECT_FALSE(w.observe(tip, tip, 1001).has_value());
+    EXPECT_EQ(w.attempts(), 0u)
+        << "a healthy tip-change round trip must cost ZERO retries";
+}
+
+// ── Progress resets the policy ──────────────────────────────────────────────
+TEST(DashSmlResyncWatchdog, SmlProgressResetsAttempts)
+{
+    SmlResyncWatchdog w(fast());
+    const uint256 tip = blk(0x11);
+    w.observe(tip, blk(0x22), 1000);
+    ASSERT_TRUE(w.observe(tip, blk(0x22), 1020).has_value());
+    EXPECT_EQ(w.attempts(), 1u);
+
+    // The SML moved (to an intermediate block, still not the tip): that is
+    // progress, so the budget starts over rather than expiring mid-recovery.
+    EXPECT_FALSE(w.observe(tip, blk(0x33), 1021).has_value());
+    EXPECT_EQ(w.attempts(), 0u);
+}
+
+TEST(DashSmlResyncWatchdog, ReachingTheTipClearsEverything)
+{
+    SmlResyncWatchdog w(fast());
+    const uint256 tip = blk(0x11);
+    w.observe(tip, blk(0x22), 1000);
+    ASSERT_TRUE(w.observe(tip, blk(0x22), 1020).has_value());
+    EXPECT_FALSE(w.observe(tip, tip, 1030).has_value());
+    EXPECT_EQ(w.attempts(), 0u);
+}
+
+// ── Bounded: backoff, then silence ──────────────────────────────────────────
+// The failure mode of a retry is hammering a peer that is already struggling,
+// so the cap is the safety property, not a nicety.
+TEST(DashSmlResyncWatchdog, BacksOffGeometricallyThenStopsAtTheCap)
+{
+    SmlResyncWatchdog w(fast());
+    const uint256 tip = blk(0x11), sml = blk(0x22);
+    w.observe(tip, sml, 1000);
+
+    ASSERT_TRUE(w.observe(tip, sml, 1020).has_value());          // +20
+    EXPECT_FALSE(w.observe(tip, sml, 1059).has_value());         // needs +40
+    ASSERT_TRUE(w.observe(tip, sml, 1060).has_value());          // attempt 2
+    EXPECT_FALSE(w.observe(tip, sml, 1139).has_value());         // needs +80
+    auto third = w.observe(tip, sml, 1140);
+    ASSERT_TRUE(third.has_value());
+    EXPECT_EQ(third->attempt, 3u);
+
+    // Cap reached: from here we are silent and the next block does what it
+    // does today. A stuck peer therefore sees today's traffic plus at most
+    // max_attempts extra requests, ever.
+    EXPECT_FALSE(w.observe(tip, sml, 5000).has_value());
+    EXPECT_FALSE(w.observe(tip, sml, 99999).has_value());
+    EXPECT_EQ(w.attempts(), 3u);
+}
+
+// A new tip is a new situation: the previous budget described a lag that no
+// longer exists, so it must not carry over and silence the new one.
+TEST(DashSmlResyncWatchdog, NewTipRestartsTheBudget)
+{
+    SmlResyncWatchdog w(fast());
+    const uint256 sml = blk(0x22);
+    w.observe(blk(0x11), sml, 1000);
+    w.observe(blk(0x11), sml, 1020);
+    w.observe(blk(0x11), sml, 1060);
+    ASSERT_TRUE(w.observe(blk(0x11), sml, 1140).has_value());
+    EXPECT_FALSE(w.observe(blk(0x11), sml, 9000).has_value());   // capped
+
+    EXPECT_FALSE(w.observe(blk(0x44), sml, 9001).has_value());   // new tip: first sighting
+    EXPECT_EQ(w.attempts(), 0u);
+    EXPECT_TRUE(w.observe(blk(0x44), sml, 9021).has_value())
+        << "a fresh tip must get its own retry budget — otherwise one exhausted "
+           "episode silences the watchdog for every block after it";
+}
+
+// ── A cold / reorg-wiped SML is NOT this watchdog's business ────────────────
+// ZERO base means a FULL-snapshot re-seed, a different and much heavier
+// request with its own drivers (handshake, on_sml_reorg -> m_on_full_resync).
+// Re-asking for one here would duplicate a ~32 kB snapshot fetch.
+TEST(DashSmlResyncWatchdog, ColdOrWipedSmlIsNeverReRequestedHere)
+{
+    SmlResyncWatchdog w(fast());
+    const uint256 tip = blk(0x11);
+    EXPECT_FALSE(w.observe(tip, uint256::ZERO, 1000).has_value());
+    EXPECT_FALSE(w.observe(tip, uint256::ZERO, 5000).has_value());
+    EXPECT_EQ(w.attempts(), 0u);
+}
+
+// ── The watchdog cannot widen what is served ────────────────────────────────
+// It emits a REQUEST and nothing else: no gate, no threshold, no predicate. The
+// only thing it can do is make the state the gate reads arrive sooner. This
+// test pins that the request is exactly the one the tip-change path would have
+// sent, so a retry can never ask for something the normal path would not.
+TEST(DashSmlResyncWatchdog, RequestIsIdenticalToTheOneTheTipChangeWouldSend)
+{
+    SmlResyncWatchdog w(fast());
+    const uint256 tip = blk(0x11), sml = blk(0x22);
+    w.observe(tip, sml, 1000);
+    auto r = w.observe(tip, sml, 1020);
+    ASSERT_TRUE(r.has_value());
+    // main_dash's tip-change path sends send_getmnlistd(*sml_base, new_tip).
+    EXPECT_EQ(r->base, sml);
+    EXPECT_EQ(r->target, tip);
+}


### PR DESCRIPTION
The single highest-value item in the serving lane by measured time — **586 of the 940 seconds** the embedded arm spent on the dashd fallback. This PR lands the **instrument** and the **tested policy**; the wiring waits on one more measurement, for a reason given below.

## What is broken

The SML advances on exactly **one** trigger: a tip change fires `send_getmnlistd(sml_base, new_tip)` and the reply moves `sml_current_hash` forward. **There is no retry anywhere** — the only other `getmnlistd` call sites are the handshake, the RPC seed, and the historical work-block snapshot requests. A single request that is never sent, or sent and never answered, strands the embedded arm until the *next block* fires the trigger again.

Measured on the hotel node (`109.161.52.148`, `a73da8ec`), 5h33m window: the arm spent **943 s** on the fallback, and **586 s of it — 62% of the total and 99% of all `dmn-stale` time — sat in five episodes of 275/156/103/51/1 s.** Every one was closed by `tip advanced`, i.e. by the chain moving on, never by the SML catching up at the tip it was already on:

```
07:34:37.559  [EMBED-GATE] DECLINED cause=dmn-stale
   ... 156 s of dashd-fallback serving, no [SML] line at all ...
07:37:12.924  [EMB-DASH] tip advanced h=2517141      <-- the NEXT BLOCK
07:37:13.471  [COIN-P2P] mnlistdiff: base=...1f tip=...11 +1mn
07:37:13.491  [EMBED-GATE] RESUMED
```

The two competing explanations were **eliminated, not assumed**:
- **Not the base-continuity guard** — zero `[SML] REJECT` lines in the window.
- **Not the historical demux stealing the tip reply** — `QuorumMemberSource::on_mnlistdiff` matches **strictly** on `baseBlockHash.IsNull() && blockHash ∈ await set`, so a tip *incremental* can never be claimed by it.

## Why the retry is not wired yet

Because one question is still open, and the two answers need **different fixes**.

`send_getmnlistd()` returned **silently** when there was no primary peer, and logged nothing on success either. So from the log it is impossible to tell whether the stalled request was **sent and unanswered** (a retry fixes it) or **never sent at all** (a retry sends nothing either, and the peer-availability path is the bug). Wiring the retry now would be tuning against an unmeasured mechanism — the same mistake this lane has spent the week correcting. The instrument ships first; the next stall window will say which case it is, and the wiring follows it.

## What lands

1. **`send_getmnlistd()` observability** — one INFO line per request with full base/target hashes, and a WARNING on the previously silent no-primary drop. Full hashes deliberately: at mainnet difficulty the leading ~14 nibbles are difficulty padding and carry no information, and this fires ~once per tip so it can afford the bytes.

2. **`SmlResyncWatchdog`** — the re-request policy as a testable unit, not yet on a timer. Fail-quiet and strictly bounded, because the failure mode of a retry is hammering a peer that is already struggling:
   - only while the SML is behind the tip;
   - only after `min_quiet` (20 s — well above the measured ~54 ms healthy round trip, well below a block interval);
   - geometric backoff between attempts;
   - at most `max_attempts` (3) per stuck `(tip, sml)` pair, after which it goes **silent** and the next block does exactly what it does today;
   - any SML progress or tip change resets everything;
   - a ZERO/cold SML is never its business (that is a full-snapshot re-seed, a much heavier request with its own drivers).

## Nothing is relaxed

No gate, threshold or predicate is touched. The watchdog emits a **request** and nothing else, and that request is **byte-identical to the one the tip-change path already sends** — so it can only make the state the gate reads arrive *sooner*. A gate satisfied earlier because its input arrived is categorically different from a gate satisfied because it was lowered, and nothing here can serve a template that would not have been served one block later anyway. `RequestIsIdenticalToTheOneTheTipChangeWouldSend` pins that equivalence.

## Tests

`test/test_dash_sml_resync_watchdog.cpp`, 8 tests, on the **existing allowlisted** `test_dash_node_coin_state` target (a new `add_executable` would be a NOT_BUILT sentinel, #143); not `#ifdef`-guarded (#895). They pin the **bounds**, which is where the risk is.

```
[       OK ] DashSmlResyncWatchdog.StuckSmlIsReRequestedAfterTheQuietPeriod (0 ms)
[       OK ] DashSmlResyncWatchdog.OrdinaryPerTipWindowNeverRetries (0 ms)
[       OK ] DashSmlResyncWatchdog.SmlProgressResetsAttempts (0 ms)
[       OK ] DashSmlResyncWatchdog.ReachingTheTipClearsEverything (0 ms)
[       OK ] DashSmlResyncWatchdog.BacksOffGeometricallyThenStopsAtTheCap (0 ms)
[       OK ] DashSmlResyncWatchdog.NewTipRestartsTheBudget (0 ms)
[       OK ] DashSmlResyncWatchdog.ColdOrWipedSmlIsNeverReRequestedHere (0 ms)
[       OK ] DashSmlResyncWatchdog.RequestIsIdenticalToTheOneTheTipChangeWouldSend (0 ms)
[  PASSED  ] 8 tests.
```

Whole target green (86/86) and the full `c2pool-dash` binary builds clean with the `p2p_client.hpp` change.

**Honest note on red/green:** these are green-only. `SmlResyncWatchdog` is a new class, so there is no unfixed version to fail against — a RED here would be manufactured and I am not dressing one up. The defect it addresses is evidenced by production measurement (above) rather than by a failing assertion, and `OrdinaryPerTipWindowNeverRetries` is the test that would catch the way this change could plausibly go wrong.

## When it is wired — the one design trap found

The watchdog must be fed the **same** tip hash the gate compares against (`NodeCoinState::m_prev_hash`), **not** the header-chain tip. They differ during `tip-body-pending`, and feeding the header tip would let the SML run *ahead* of the serve tip — producing `dmn-stale` from the other direction. That needs a `prev_hash()` accessor and belongs with the wiring, so it is not in this PR.

## Sequencing

Touches `src/impl/dash/coin/p2p_client.hpp`, one new header, one new test, and `test/CMakeLists.txt`. **No `main_dash.cpp`**, **no `work_source.cpp`**, **no `node_coin_state.hpp`** — so no collision with #1150, #1152, #1145 or #1148. #1148 also touches `p2p_client.hpp`; my change there is confined to the body of `send_getmnlistd()`.

`do-not-merge`. Read-only on the node throughout; builds on VM905.
