### PR TITLE
dgb(#995): wire found-block record + chain-sourced confirm/orphan verdict [do-not-merge]

### DIFF
--- a/src/c2pool/main_dgb.cpp
+++ b/src/c2pool/main_dgb.cpp
@@ -66,6 +66,7 @@
 #include <boost/asio.hpp>
 
 #include <cstdint>
+#include <span>
 #include <cstring>
 #include <filesystem>
 #include <iostream>
@@ -533,6 +534,17 @@ int run_node(const core::CoinParams& params, bool testnet,
     };
     auto bcast_telem = std::make_shared<DgbBroadcasterTelemetry>();
 
+    // ── #995 DGB arm: found-block dashboard/verdict reporter slot ─────────
+    // m_on_block_found is bound here, BEFORE the WebServer/MiningInterface is
+    // stood up (below, under --http), so the record_found_block + schedule_
+    // block_verification producer is injected via this shared slot: the http
+    // block assigns the real lambda once `mi` exists; until then (or with the
+    // dashboard off) it stays empty and a won block still broadcasts, just
+    // unrecorded. TELEMETRY ONLY -- never on any broadcast/mint/payout path.
+    auto found_block_report = std::make_shared<
+        std::function<void(const uint256&, const std::vector<unsigned char>&,
+                           const std::string&)>>();
+
     auto dgb_on_block_found = dgb::coin::make_on_block_found(
         /*reconstruct=*/std::move(faithful_reconstruct),
         /*p2p_relay=*/[&ioc, &coin_p2p, no_p2p_relay](const std::vector<unsigned char>& block_bytes) {
@@ -558,7 +570,14 @@ int run_node(const core::CoinParams& params, bool testnet,
                 if (coin_p2p) coin_p2p->submit_block_p2p_raw(bytes);
             });
         },
-        /*seam=*/&coin_node);                     // external-digibyted submitblock fallback
+        /*seam=*/&coin_node,                       // external-digibyted submitblock fallback
+        /*on_found=*/[found_block_report](const uint256& sh,
+                                          const std::vector<unsigned char>& bytes,
+                                          const std::string& hex) {
+            // Forward to the dashboard/verdict producer once it is bound (below,
+            // under --http). No-op while unbound. Telemetry only.
+            if (*found_block_report) (*found_block_report)(sh, bytes, hex);
+        });
 
     // ARM A dispatch counter — wrap the closure so every won-block dispatch is
     // counted before it runs; a stalled P2P-relay arm shows dispatches==0.
@@ -1348,6 +1367,73 @@ int run_node(const core::CoinParams& params, bool testnet,
         //     surface: NONE (dashboard reporting, not share/PPLNS bytes).
         mi->set_peer_info_fn([&p2p_node]() { return p2p_node.get_peer_info_json(); });
 
+        // ── #995 DGB arm: found-block record + chain-sourced confirm/orphan ──
+        // Wire the won-block reporter slot (declared above, fired by
+        // m_on_block_found after a successful reconstruct) to record_found_block
+        // + schedule_block_verification, and install the verdict fn that resolves
+        // a recorded block against the live chain. Mirrors the DASH shape
+        // (main_dash.cpp record sites + set_block_verify_fn) -- SHAPE reference
+        // only, no DASH code copied. Isolation: constructs core classes / calls
+        // core MI methods, ZERO src/core edits. p2pool-merged-v36 surface: NONE
+        // (dashboard telemetry, not share/PPLNS/coinbase bytes).
+        //
+        // PRODUCER. The reconstructed parent block bytes carry the 80-byte header
+        // first; the coin block IDENTITY hash is params.block_hash_func over that
+        // header (sha256d) -- distinct from the scrypt PoW digest AND from the
+        // share hash, and it is the key digibyted getblockheader answers on.
+        // Runs strictly AFTER both broadcast arms; never gates a broadcast.
+        *found_block_report =
+            [mi, &header_chain, block_id = params.block_hash_func](
+                const uint256& /*share_hash*/,
+                const std::vector<unsigned char>& block_bytes,
+                const std::string& /*block_hex*/) {
+                if (block_bytes.size() < 80) return;   // no header -> nothing to key on
+                uint256 block_hash = block_id(
+                    std::span<const unsigned char>(block_bytes.data(), 80));
+                // Height of the block we just won == the pool tip + 1. header_chain
+                // is not yet fed (M3), so this is base (0) until the embedded
+                // header-ingest lands -- display only; the RPC verdict keys on the
+                // hash, not the height.
+                uint64_t height = header_chain.next_block_height();
+                mi->record_found_block(
+                    height, block_hash, static_cast<uint64_t>(std::time(nullptr)),
+                    /*chain=*/"DGB", /*miner=*/"", /*share_hash=*/block_hash.GetHex(),
+                    mi->get_network_difficulty(), /*share_difficulty=*/0.0,
+                    mi->get_local_hashrate(), /*subsidy=*/0);
+                // Arm the post-broadcast confirm/orphan poller. Telemetry only.
+                mi->schedule_block_verification(block_hash.GetHex());
+                std::cout << "[DGB] recorded found block hash="
+                          << block_hash.GetHex().substr(0, 16)
+                          << " -- confirm/orphan poller armed" << std::endl;
+            };
+
+        // VERDICT. Resolve a recorded found block against the chain: >0 accepted
+        // (best-chain depth / confirmations), <0 orphaned (off the active chain),
+        // 0 pending (not yet buried, or the chain cannot answer). DAEMONLESS-first
+        // (embedded HeaderChain) is DEFERRED to M3: header_chain is not yet fed
+        // (block_hash stays 0, tip_hash()==nullopt), so a header-chain arm could
+        // only ever return pending today and would be inert-until-fed -- it lands
+        // with the header-ingest slice, not as dead code now. The LIVE verdict
+        // source is the external digibyted getblockheader RPC (rpc.cpp).
+        mi->set_block_verify_fn(
+            [rp = rpc.get()](const std::string& hash_hex) -> int {
+                if (!rp) return 0;   // no digibyted RPC -> cannot ask the chain -> pending
+                uint256 h; h.SetHex(hash_hex);
+                try {
+                    auto j = rp->getblockheader(h, /*verbose=*/true);
+                    if (j.contains("confirmations") && j["confirmations"].is_number()) {
+                        int c = j["confirmations"].get<int>();
+                        if (c < 0) return -1;      // off the active chain -> orphaned
+                        if (c >= 1) return c;      // on the best chain -> accepted
+                    }
+                } catch (...) { /* unknown to daemon / transport error -> pending */ }
+                return 0;
+            });
+        std::cout << "[DGB] found-block confirm/orphan lane ARMED "
+                  << (rpc ? "(digibyted getblockheader verdict)"
+                          : "(no digibyted RPC -> verdicts stay pending until --coin-rpc)")
+                  << std::endl;
+
         // graph_db stats persistence — survives restarts (LTC-parity site 2/3).
         // DGB-namespaced sub-dir isolates the per-coin stat log under config_path().
         {
@@ -1414,6 +1500,7 @@ int run_node(const core::CoinParams& params, bool testnet,
     // objects it references (header_chain / mempool / coin_node) are still
     // alive — explicit reset keeps destruction order safe (stratum_server was
     // declared first, so it would otherwise outlive them).
+    if (found_block_report) *found_block_report = nullptr;  // #995: unbind before mi dies
     stratum_server.reset();
     web_server.reset();
 

--- a/src/impl/dgb/coin/won_block_dispatch.hpp
+++ b/src/impl/dgb/coin/won_block_dispatch.hpp
@@ -59,17 +59,31 @@ namespace coin
 using WonBlockReconstructor =
     std::function<std::optional<std::pair<std::vector<unsigned char>, std::string>>(const uint256&)>;
 
+// Optional post-broadcast telemetry hook (#995 DGB found-block arm). Fired AFTER
+// a won block is reconstructed + dispatched down both broadcast arms, carrying
+// the winning share hash, the serialized parent block, and its hex. main_dgb
+// binds it to MiningInterface::record_found_block + schedule_block_verification
+// so a pool-won DGB block lands on /recent_blocks and enters the confirm/orphan
+// poller. Empty by default (dashboard off / --http absent): a won block still
+// broadcasts, it is simply not recorded. TELEMETRY ONLY -- it runs strictly
+// after both broadcast arms and never gates, delays, or alters a broadcast.
+using FoundBlockReporter =
+    std::function<void(const uint256& share_hash,
+                       const std::vector<unsigned char>& block_bytes,
+                       const std::string& block_hex)>;
+
 // Build the m_on_block_found handler. The run-loop assigns the returned closure
 // to tracker.m_on_block_found; `p2p_relay` may be empty (no embedded sink yet)
 // and `seam` may be null / RPC-less -- broadcast_won_block guards each leg.
 inline std::function<void(const uint256&)>
 make_on_block_found(WonBlockReconstructor reconstruct,
                     P2pRelaySink p2p_relay,
-                    core::coin::ICoinNode* seam)
+                    core::coin::ICoinNode* seam,
+                    FoundBlockReporter on_found = {})
 {
     return [reconstruct = std::move(reconstruct),
             p2p_relay = std::move(p2p_relay),
-            seam](const uint256& share_hash)
+            seam, on_found = std::move(on_found)](const uint256& share_hash)
     {
         if (!reconstruct) {
             LOG_ERROR << "[EMB-DGB] won-block " << share_hash.GetHex().substr(0, 16)
@@ -88,6 +102,12 @@ make_on_block_found(WonBlockReconstructor reconstruct,
                  << " reconstructed " << blk->first.size()
                  << " bytes -- dispatching dual-path.";
         broadcast_won_block(p2p_relay, seam, blk->first, blk->second);
+
+        // #995 DGB found-block arm: surface the reconstructed win to the
+        // dashboard + confirm/orphan verdict lane (record_found_block +
+        // schedule_block_verification), strictly AFTER both broadcast arms.
+        // Telemetry only -- an empty hook (no dashboard) changes nothing here.
+        if (on_found) on_found(share_hash, blk->first, blk->second);
     };
 }
 


### PR DESCRIPTION
DO-NOT-MERGE / no self-merge -- integrator cards the merge once legs are green.

## #995 DGB arm
DGB called neither `record_found_block` nor `set_block_verify_fn` (grep-confirmed) -- a pool-won DGB block was broadcast (dual-path #82) but never checked against the chain. Same class as the DASH 2508008 orphan.

## What lands (src/impl/dgb + main_dgb only; zero src/core; p2pool-merged-v36 surface NONE)
- **Producer**: `make_on_block_found` gains an optional `FoundBlockReporter`, fired after both broadcast arms dispatch. Run-loop binds it (under `--http`) to `record_found_block` + `schedule_block_verification`, keyed by the block IDENTITY hash (`params.block_hash_func` over the 80-byte header) -- distinct from the scrypt PoW digest and the share hash.
- **Real production caller**: `ShareTracker` fires `m_on_block_found` on a won share -> dispatch -> reporter. NOT a test-only caller.
- **Verdict**: `set_block_verify_fn` resolves against the live chain via digibyted `getblockheader` -- confirmations>=1 accepted, <0 orphaned, absent/error pending.
- Daemonless embedded-HeaderChain arm DEFERRED to M3 (chain not yet fed) rather than shipped inert.

## Legs
Build GREEN: `[100%] Built target c2pool-dgb`, 0 errors; binary loads. Telemetry only -- runs strictly after both broadcast arms, touches no submit/mint/target/payout path.