### PR TITLE
dash(embed-gate): fourth-axis SML-currency conjunct — dmn-stale structurally unsatisfiable in steady state, with the bounded getmnlistd re-request that keeps it from opening a silent doomed-tip window

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -4325,6 +4325,18 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 if (cp) cp->send_getmnlistd(uint256::ZERO, tip);
             });
 
+        // Fourth-axis conjunct companion (#1153 policy wired to the ordering
+        // fix): when the serve-tip promotion is held because the SML currency
+        // is stuck behind the header tip, re-drive the INCREMENTAL getmnlistd
+        // the tip-change path already sends (base = where the SML is, target =
+        // the header tip). This is what keeps the conjunct from turning a
+        // dropped/lost diff into a silent doomed-tip window. Bounded inside the
+        // maintainer's SmlResyncWatchdog; this closure only forwards.
+        maintainer->set_on_sml_rerequest(
+            [cp = coin_p2p.get()](const uint256& base, const uint256& target) {
+                if (cp) cp->send_getmnlistd(base, target);
+            });
+
         // ChainLock verifier: BLS-verify a relayed clsig against the quorum
         // dashcore's SelectQuorumForSigning says must have signed it, before
         // the maintainer may adopt its height as the CCbTx bestCL*. Candidate

--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -28,6 +28,7 @@
 /// safety path and the [GBT-XCHECK] cross-check whenever the bundle is not live.
 
 #include <impl/dash/coin/node_coin_state.hpp>    // NodeCoinState
+#include <impl/dash/coin/sml_resync_watchdog.hpp> // SmlResyncWatchdog (bounded getmnlistd re-request)
 #include <impl/dash/coin/governance_store.hpp>   // GovernanceStore (daemonless superblock)
 #include <impl/dash/coin/govsync_status.hpp>     // GovSyncStatus (R5 completeness determination)
 #include <impl/dash/coin/governance_object.hpp>  // parse_superblock_trigger, govvote_signature_hash
@@ -1495,6 +1496,19 @@ public:
         m_on_sml_clear = std::move(fn);
     }
 
+    /// Wire the bounded getmnlistd re-request (main_dash points this at
+    /// coin_p2p->send_getmnlistd). Fired from check_tip_body_overdue's diff-
+    /// phase sub-threshold when the SML currency is stuck behind the header tip
+    /// — the companion that keeps the fourth-axis conjunct from converting a
+    /// diff outage into a silent doomed-tip window (see check_tip_body_overdue).
+    /// Optional: unset in KATs = no re-request wired, so the conjunct's blocking
+    /// behaviour is testable without a live peer. `base` is the SML's current
+    /// block, `target` the header tip to advance it to.
+    void set_on_sml_rerequest(
+        std::function<void(const uint256& base, const uint256& target)> fn) {
+        m_on_sml_rerequest = std::move(fn);
+    }
+
     /// Wire the credit-pool PERSISTENCE sink (main_dash points this at
     /// CreditPoolDb::write_state). Invoked from on_mnlistdiff after an accepted
     /// diff re-anchors the pool, with the same (blockHash, height) the SML persist
@@ -1746,13 +1760,28 @@ private:
         m_tip_overdue_latched  = false;
     }
 
-    /// Promote the pending header tip to the serve tip iff the credit-pool
-    /// seed is current AT that exact block (hash AND height — the hash match
+    /// Promote the pending header tip to the serve tip iff ALL FOUR derived
+    /// axes are current AT that exact block (hash AND height — the hash match
     /// is what keeps a same-height competing block's body from promoting the
-    /// wrong tip's params). The seed is the witness that the tip block's
-    /// inputs were parsed: the body fold and the mnlistdiff cbTx re-anchor
-    /// both stamp it with the block's own identity. Returns true iff
-    /// promotion happened; caller republishes.
+    /// wrong tip's params). This is the PUBLISH-LAST invariant that makes the
+    /// serve tip atomic in the way dashcore's ConnectBlock is: dashd advances
+    /// DML, quorums, credit pool and ChainLocks together inside one block-
+    /// connect, so its getblocktemplate never sees the tip at height N with a
+    /// derived axis at N-1. We advance each axis on its own network round trip
+    /// (getmnlistd, qrinfo) or local fold, so they CAN momentarily disagree —
+    /// and the gate exists to refuse rather than serve a wrong payee. Gating
+    /// promotion on all four here means the serve tip is only ever published
+    /// once they agree, which makes those refusals structurally unreachable in
+    /// steady state instead of merely rare. The single io thread is the
+    /// atomicity primitive — no lock, no event, no thread is added.
+    ///
+    /// The four axes, each a witness that the tip block's inputs were parsed:
+    ///   1. credit-pool seed  (hash + height)   — body fold / mnlistdiff cbTx
+    ///   2. payee cursor       (height)          — tip-body apply_block
+    ///   3. SML currency       (hash)            — on_mnlistdiff (fourth axis,
+    ///      added here; makes node_coin_state.hpp clause 12 `dmn-stale`
+    ///      structurally unsatisfiable in steady state WITHOUT relaxing it)
+    /// Returns true iff promotion happened; caller republishes.
     bool maybe_promote_pending_tip() {
         if (!m_body_first_serve_tip || !m_tip_body_pending) return false;
         if (!m_have_hdr_tip) return false;
@@ -1769,6 +1798,27 @@ private:
         // MN-readiness half of populated() already gates serving there.
         if (!m_state.mnstates().entries().empty()
             && m_state.mnstates().last_applied_height() != m_hdr_prev_height)
+            return false;
+        // ── FOURTH AXIS: the SML currency (dmn-stale, clause 12) ────────────
+        // Folding the tip body we already hold cannot advance the SML — a cbTx
+        // commits merkleRootMNList, and a root is not a list — so the currency
+        // hash advances ONLY via on_mnlistdiff, on its own getmnlistd round
+        // trip. Promoting before that lands would advance the serve tip into a
+        // dmn-stale refusal, the exact window this conjunct removes.
+        //
+        // ZERO carve-out (cold start AND post-reorg-wipe, which the step-1
+        // audit proved land the IDENTICAL uint256::ZERO sentinel, so they
+        // collapse to one case — mirroring the empty-payee-machine carve-out
+        // above). A ZERO currency hash is "the SML covers nothing", which the
+        // require_sml half of populated() (surfacing as clause 10 no-dmn-set,
+        // evaluated BEFORE clause 12) already gates. It must NOT hold promotion
+        // back, or a cold node would DEADLOCK: the currency hash cannot become
+        // the tip until a full snapshot lands, and nothing drives that if
+        // promotion — and therefore the whole embedded arm — waited on it
+        // first. Test: ColdSmlDoesNotBlockPromotion pins that a future reader
+        // cannot "tighten" this into a cold-start deadlock.
+        if (!m_state.sml_current_hash().IsNull()
+            && m_state.sml_current_hash() != m_hdr_prev_hash)
             return false;
         promote_serve_tip();
         m_state.set_tip_body_pending_dbg(false);
@@ -1789,6 +1839,44 @@ private:
     /// every maintainer event (mempool relay being the high-cadence clock).
     void check_tip_body_overdue() {
         if (!m_body_first_serve_tip || !m_tip_body_pending) return;
+
+        // ── DIFF-PHASE SUB-THRESHOLD (#1153 policy, wired here) ─────────────
+        // LOAD-BEARING COMPANION to the fourth-axis conjunct, NOT an optional
+        // extra: the conjunct now holds the tip body-pending whenever the SML
+        // currency is behind the header tip. If that is because a getmnlistd
+        // was never sent or never answered — p2p_client.hpp drops it SILENTLY
+        // with no primary peer — then without a re-request the tip stays
+        // pending until the 30 s hard demote below, and the conjunct will have
+        // converted what used to be a LOUD instant dmn-stale refusal into up
+        // to 30 s of QUIET H-1 serving. H-1 work solved past the propagation
+        // window orphans, so the conjunct ALONE is a regression in the diff-
+        // outage case; the conjunct + this re-request is the fix.
+        //
+        // Bounded by SmlResyncWatchdog (min_quiet ~4 s « the 30 s demote, so it
+        // fires inside the silent window; geometric backoff; hard cap, after
+        // which the demote takes over exactly as today). Target is the HEADER
+        // tip, base is where the SML actually is — byte-identical to the
+        // getmnlistd main_dash's tip-change path already sends, so the base-
+        // continuity guard accepts the reply. (Deliberately the header tip, not
+        // the serve tip m_prev_hash: we are DRIVING the SML forward to enable
+        // promotion, not gating the current serve — the two diverge during a
+        // body-pending window and only the header tip converges the conjunct.)
+        if (m_on_sml_rerequest && m_have_hdr_tip
+            && !m_state.sml_current_hash().IsNull()
+            && m_state.sml_current_hash() != m_hdr_prev_hash) {
+            if (auto req = m_sml_resync.observe(m_hdr_prev_hash,
+                                                m_state.sml_current_hash(),
+                                                m_now_fn())) {
+                LOG_WARNING << "[EMB-DASH] SML behind tip h=" << m_hdr_prev_height
+                            << " (currency ..."
+                            << discriminating_hash_tail(m_state.sml_current_hash())
+                            << " != tip ..." << discriminating_hash_tail(m_hdr_prev_hash)
+                            << ") — re-requesting getmnlistd (attempt "
+                            << req->attempt << "/3) before the doomed-tip demote";
+                m_on_sml_rerequest(req->base, req->target);
+            }
+        }
+
         if (m_tip_overdue_latched) return;
         if (m_now_fn() - m_tip_pending_since < m_tip_body_overdue_secs) return;
         m_tip_overdue_latched = true;
@@ -1881,6 +1969,12 @@ private:
     std::function<void()> m_on_state_dirty;  // SML/bestCL/reorg -> re-issue work
     std::function<void()> m_on_mn_reseed;    // payee desync -> authoritative protx re-seed
     std::function<void()> m_on_full_resync;  // H-1 heal -> reset sml_base + full re-sync
+    std::function<void(const uint256&, const uint256&)> m_on_sml_rerequest;  // SML-behind-tip -> bounded getmnlistd(base,target)
+    // #1153 policy: bounds the getmnlistd re-request to at most a few attempts
+    // per stuck (tip, sml) pair. min_quiet 4 s « the 30 s doomed-tip demote, so
+    // it fires INSIDE the silent window the conjunct would otherwise open.
+    SmlResyncWatchdog m_sml_resync{SmlResyncWatchdog::Config{
+        /*min_quiet_sec=*/4, /*backoff_mult=*/2, /*max_attempts=*/3}};
     std::function<void(const uint256&)> m_on_sml_persist;  // accepted diff -> SMLDb/QuorumDb write
     std::function<void()> m_on_sml_clear;    // reorg/heal -> SMLDb/QuorumDb wipe (extended to CreditPoolDb)
     // qc-plan-underivable tee: accepted diff's full tail.newQuorums ->

--- a/test/test_dash_coin_state_maintainer.cpp
+++ b/test/test_dash_coin_state_maintainer.cpp
@@ -463,6 +463,293 @@ static CSimplifiedMNListEntry sml_entry(uint8_t seed) {
     return e;
 }
 
+// A cold/incremental mnlistdiff carrying a type-5 cbTx seed (creditPool +
+// nHeight @ cb_height), so on_mnlistdiff advances BOTH the currency hash and
+// the paired height. Defined here (moved up from below) because the step-1
+// wipe-audit KATs need it.
+static CSimplifiedMNListDiff diff_with_seed(const uint256& base, const uint256& block,
+                                            int32_t cb_height, int64_t credit_pool,
+                                            CSimplifiedMNListEntry mn) {
+    CSimplifiedMNListDiff d;
+    d.baseBlockHash = base;
+    d.blockHash     = block;
+    d.mnList = {mn};
+    dash::coin::vendor::CCbTx cb;
+    cb.nVersion = dash::coin::vendor::CCbTx::VERSION_CLSIG_AND_BALANCE;
+    cb.nHeight  = cb_height;
+    cb.creditPoolBalance = credit_pool;
+    d.cbTx.version = 3;
+    d.cbTx.type    = 5;
+    d.cbTx.extra_payload = dash::coin::encode_cbtx(cb);
+    return d;
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// STEP-1 SML-CURRENCY WIPE AUDIT (gate for the "fourth-axis conjunct" that
+// makes dmn-stale structurally unsatisfiable in steady state). The conjunct
+// blocks tip promotion until sml_current_hash() == the header prev-hash and
+// advances it back to a real value only via on_mnlistdiff. If ANY wipe path
+// could leave m_sml_current_hash STALE-NONZERO, the base-continuity guard
+// (on_mnlistdiff) would then reject every incremental whose base != that
+// stale value, sml_current_hash could never re-reach the tip, and the
+// conjunct would deadlock into an indefinite QUIET stall (no loud refusal,
+// just work that never promotes). So the invariant the conjunct depends on
+// is: every SML wipe leaves the currency hash EXACTLY ZERO, and ZERO is the
+// cold sentinel on_mnlistdiff treats as "accept a full snapshot".
+//
+// The four (and only four) writers of m_sml_current_hash are:
+//   1. on_mnlistdiff        -> diff.blockHash  (advance; paired with the list)
+//   2. on_sml_reorg         -> uint256::ZERO   (wipe)
+//   3. warm restart restore -> get_best_hash() (only inside the root-verified
+//                              `warm` guard, main_dash.cpp; cold leaves ZERO)
+//   4. the setter itself     (plumbing)
+// The SML-LIST wipes are exactly two: the full-snapshot clear inside
+// on_mnlistdiff (:595, which always falls through to writer #1 and lands a
+// REAL hash) and on_sml_reorg (:829, which lands writer #2 = ZERO).
+//
+// FINDING (premise correction): the payee-desync / apply-gap wipe the design
+// note flagged as a suspect (coin_state_maintainer.hpp ~:1224) is NOT an SML
+// wipe at all — it wipes mnstates() (the PAYEE axis) and never touches the
+// SML or its currency hash. So it correctly leaves sml_current_hash intact,
+// and the two KATs below pin BOTH facts: the reorg wipe zeroes it, the payee
+// desync leaves it untouched. No path can leave it stale-nonzero.
+// ════════════════════════════════════════════════════════════════════════
+
+// on_sml_reorg is the header-chain reorg entry (main_dash's reorg hook calls
+// it directly; the malformed-quorum-tail heal reaches the SAME function via
+// on_mnlistdiff, already covered above). It must land the currency hash at
+// EXACTLY ZERO and the paired height at 0 — never a stale block hash.
+TEST(DashCoinStateMaintainer, ReorgWipeZerosSmlCurrencyHashAndHeight) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+
+    // Sync the SML to a real, NON-ZERO currency hash (cold full snapshot
+    // carrying a type-5 cbTx so the paired height advances too).
+    m.on_mnlistdiff(diff_with_seed(uint256::ZERO, raw256(0x54), 1518654,
+                                   111'000'000LL, sml_entry(0x40)));
+    ASSERT_TRUE(st.have_sml());
+    ASSERT_EQ(st.sml_current_hash(), raw256(0x54));
+    ASSERT_NE(st.sml_current_hash(), uint256::ZERO);
+    ASSERT_EQ(m.sml_current_height(), 1518654u);
+    ASSERT_TRUE(m.sml_height_paired());
+
+    m.on_sml_reorg();
+
+    EXPECT_EQ(st.sml_current_hash(), uint256::ZERO)
+        << "an SML wipe MUST leave the currency hash EXACTLY ZERO, never a "
+           "stale block hash — a stale-nonzero value would make on_mnlistdiff "
+           "reject every incremental off it (base != stale), so the currency "
+           "hash could never re-reach the tip and the fourth-axis conjunct "
+           "would deadlock into an indefinite quiet stall";
+    EXPECT_FALSE(st.have_sml());
+    EXPECT_EQ(m.sml_current_height(), 0u)
+        << "the paired height must reset with the hash (R1 freshness tracker)";
+    EXPECT_FALSE(m.sml_height_paired());
+
+    // And ZERO must actually behave as the cold sentinel: only a FULL
+    // snapshot (base=ZERO) is accepted; a clean incremental off the old tip
+    // is refused. This is the property that lets the conjunct recover rather
+    // than wedge — a fresh full diff re-establishes currency.
+    m.on_mnlistdiff(diff_with_seed(raw256(0x54), raw256(0x55), 1518655,
+                                   111'066'966'830LL, sml_entry(0x41)));
+    EXPECT_FALSE(st.have_sml())
+        << "post-wipe, an incremental off the old tip must STILL refuse";
+    EXPECT_EQ(st.sml_current_hash(), uint256::ZERO);
+}
+
+// The payee-desync / apply-gap path (on_block_connected -> wipe) is a PAYEE
+// wipe, not an SML wipe. It must leave the SML currency hash UNTOUCHED — the
+// SML axis stays valid and its hash keeps describing it accurately, so the
+// conjunct is neither falsely satisfied (the SML really is at that block) nor
+// deadlocked (the hash is not corrupted). This KAT pins the premise
+// correction: the path the design note suspected does not move the hash.
+TEST(DashCoinStateMaintainer, PayeeDesyncLeavesSmlCurrencyHashIntact) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+
+    // SML current at a real block; payee queue armed and live at the tip.
+    m.on_mnlistdiff(diff_with_seed(uint256::ZERO, PREV_HASH, H - 1,
+                                   111'000'000LL, sml_entry(0x40)));
+    ASSERT_EQ(st.sml_current_hash(), PREV_HASH);
+    m.on_mn_list_update(single_mn(p2pkh_script(0x30)));
+    m.on_new_tip(H - 1, PREV_HASH, BITS, MTP, DASH_PUBKEY_VER, DASH_P2SH_VER,
+                 CURTIME, VERSION);
+
+    // Force a payee desync: the connected block's coinbase pays a script the
+    // projected MN does not.
+    BlockType blk;
+    blk.m_txs.push_back(make_spend(raw256(0x90), 0, 500000000, 1));
+    blk.m_txs[0].vout[0].scriptPubKey.m_data = p2pkh_script(0x77);  // NOT the MN
+    bind_block(blk);
+    auto r = m.on_block_connected(blk, H);
+
+    ASSERT_TRUE(r.payee_desync) << "precondition: the desync path must fire";
+    EXPECT_EQ(st.mnstates().size(), 0u) << "the PAYEE set is wiped...";
+    EXPECT_EQ(st.sml_current_hash(), PREV_HASH)
+        << "...but the SML currency hash is UNTOUCHED — a payee-axis wipe is "
+           "not an SML wipe. Zeroing it here would needlessly force a full "
+           "SML re-sync on every payee desync; leaving it stale-WRONG would "
+           "deadlock the conjunct. It must stay EXACTLY what the SML is at.";
+    EXPECT_TRUE(st.have_sml()) << "the SML list itself survives a payee wipe";
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// STEP 2 — THE FOURTH-AXIS CONJUNCT (SML currency) in maybe_promote_pending_tip.
+//
+// Publish-last: the body-first serve tip is promoted only once ALL FOUR
+// derived axes agree on the block — credit-pool, payee cursor, AND now the SML
+// currency hash. This makes node_coin_state.hpp clause 12 (dmn-stale)
+// structurally unsatisfiable in steady state WITHOUT relaxing the gate: the
+// serve tip m_prev_hash is never advanced to a block the SML is not at.
+//
+// Helper: arm credit-pool + payee current AT `tip`/`height` directly on the
+// NodeCoinState (each axis has its own public setter), leaving SML to the
+// individual test. Promotion reads these axes plus the maintainer's stashed
+// header tip; the require_* serve flags gate SERVING, not promotion.
+static void arm_cp_and_payee_at(NodeCoinState& st, const uint256& tip,
+                                uint32_t height) {
+    st.set_credit_pool(111'000'000LL, tip, static_cast<int32_t>(height));
+    MNState s;
+    s.isValid = true;
+    s.nRegisteredHeight = 2'300'000;
+    s.scriptPayout.m_data = p2pkh_script(0x30);
+    s.payoutSplitProvenance = MNState::SPLIT_KNOWN;
+    st.mnstates().load(
+        std::vector<std::pair<uint256, MNState>>{{raw256(0x01), s}}, height);
+}
+
+// SML behind the tip (nonzero, mismatched) MUST block promotion — the tip
+// stays body-pending rather than advancing into a dmn-stale refusal.
+TEST(DashCoinStateMaintainer, FourthAxisSmlBehindTipBlocksPromotion) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    m.set_body_first_serve_tip(true);
+
+    arm_cp_and_payee_at(st, PREV_HASH, H - 1);
+    st.set_have_sml(true);
+    st.set_sml_current_hash(raw256(0xCD));   // SML at a DIFFERENT nonzero block
+
+    m.on_new_tip(H - 1, PREV_HASH, BITS, MTP, DASH_PUBKEY_VER, DASH_P2SH_VER,
+                 CURTIME, VERSION);
+
+    EXPECT_TRUE(m.tip_body_pending())
+        << "credit-pool and payee are current at the tip but the SML is not — "
+           "promoting here would advance the serve tip straight into a "
+           "dmn-stale refusal (clause 12). The fourth-axis conjunct must hold "
+           "the tip body-pending until the SML currency reaches it.";
+}
+
+// SML current at the tip (all four axes agree) MUST promote.
+TEST(DashCoinStateMaintainer, FourthAxisSmlCurrentAtTipPromotes) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    m.set_body_first_serve_tip(true);
+
+    arm_cp_and_payee_at(st, PREV_HASH, H - 1);
+    st.set_have_sml(true);
+    st.set_sml_current_hash(PREV_HASH);      // SML current AT the tip
+
+    m.on_new_tip(H - 1, PREV_HASH, BITS, MTP, DASH_PUBKEY_VER, DASH_P2SH_VER,
+                 CURTIME, VERSION);
+
+    // tip_body_pending() flipping to false IS the promotion (the conjunct
+    // released). m.live()/populated() additionally needs the MN-readiness
+    // snapshot plumbing, which this unit does not arm — the promotion axis is
+    // exactly tip_body_pending here.
+    EXPECT_FALSE(m.tip_body_pending())
+        << "all four axes current at the tip — promotion must proceed";
+}
+
+// THE CARVE-OUT (coordinator-mandated, test-visible so a future reader cannot
+// "tighten" it into a cold-start deadlock). A ZERO SML currency hash is
+// cold-start OR post-reorg-wipe (step-1 audit: both land the identical ZERO
+// sentinel). It must NOT block promotion — serving is still gated by the
+// require_sml half of populated(), which surfaces as clause 10 (no-dmn-set),
+// evaluated before clause 12. If the ZERO case blocked promotion, a cold node
+// would deadlock: the currency hash can only reach the tip once a full
+// snapshot lands, and nothing drives that if the whole arm waited on it first.
+TEST(DashCoinStateMaintainer, FourthAxisColdSmlDoesNotBlockPromotion) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    m.set_body_first_serve_tip(true);
+
+    arm_cp_and_payee_at(st, PREV_HASH, H - 1);
+    st.set_sml_current_hash(uint256::ZERO);  // cold / post-wipe sentinel
+
+    m.on_new_tip(H - 1, PREV_HASH, BITS, MTP, DASH_PUBKEY_VER, DASH_P2SH_VER,
+                 CURTIME, VERSION);
+
+    EXPECT_FALSE(m.tip_body_pending())
+        << "a ZERO (cold/wiped) SML currency must NOT hold promotion back — "
+           "that is the carve-out; blocking here would deadlock cold start. "
+           "Serving is still gated by require_sml/no-dmn-set downstream.";
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// STEP 3 — the LOAD-BEARING companion: the diff-phase sub-threshold re-request.
+// Without it the conjunct turns a dropped/lost getmnlistd into up to 30 s of
+// silent H-1 serving (which orphans past propagation). check_tip_body_overdue,
+// driven opportunistically (on_mempool_tx is the clock), fires ONE bounded
+// getmnlistd(base=sml, target=hdr-tip) after ~min_quiet, capped, before the
+// unchanged 30 s hard demote.
+// ════════════════════════════════════════════════════════════════════════
+TEST(DashCoinStateMaintainer, DiffPhaseReRequestFiresBoundedThenDefersToDemote) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    m.set_body_first_serve_tip(true);
+    m.set_tip_body_overdue_secs(30);
+
+    int64_t now = 1000;
+    m.set_now_fn([&now]() { return now; });
+
+    std::vector<std::pair<uint256, uint256>> reqs;
+    m.set_on_sml_rerequest(
+        [&reqs](const uint256& base, const uint256& target) {
+            reqs.emplace_back(base, target);
+        });
+
+    // Tip body-pending with the SML stuck one behind the tip.
+    arm_cp_and_payee_at(st, PREV_HASH, H - 1);
+    st.set_have_sml(true);
+    st.set_sml_current_hash(raw256(0xCD));
+    m.on_new_tip(H - 1, PREV_HASH, BITS, MTP, DASH_PUBKEY_VER, DASH_P2SH_VER,
+                 CURTIME, VERSION);
+    ASSERT_TRUE(m.tip_body_pending()) << "conjunct holds it pending";
+
+    auto tick = [&](int64_t at) {
+        now = at;
+        m.on_mempool_tx(make_spend(raw256(0x90), 0, 90'000, /*salt=*/int(at)));
+    };
+
+    // First sighting of the stuck (tip, sml) pair starts the quiet clock and
+    // NEVER retries — this is what keeps the ordinary sub-second per-tip window
+    // (104 of 109 measured episodes) from ever generating traffic.
+    tick(1001);
+    EXPECT_TRUE(reqs.empty()) << "first sighting must not re-request";
+
+    // Still inside the quiet period (2 s < 4 s).
+    tick(1003);
+    EXPECT_TRUE(reqs.empty()) << "must not re-request inside the quiet period";
+
+    // Past min_quiet (5 s ≥ 4 s): exactly ONE re-request, byte-identical to the
+    // tip-change getmnlistd (base = where the SML is, target = the header tip).
+    tick(1006);
+    ASSERT_EQ(reqs.size(), 1u) << "one bounded re-request after ~min_quiet";
+    EXPECT_EQ(reqs[0].first,  raw256(0xCD)) << "base = where the SML is";
+    EXPECT_EQ(reqs[0].second, PREV_HASH)    << "target = the header tip";
+
+    // Geometric backoff + hard cap at 3: keep ticking well past any wait; the
+    // count must stop at 3, never grow unbounded (never hammer a struggling peer).
+    for (int64_t t = 1010; t <= 1200; t += 5) tick(t);
+    EXPECT_EQ(reqs.size(), 3u)
+        << "re-request must cap at max_attempts (3), then go quiet and let the "
+           "unchanged 30 s hard demote take over exactly as today";
+
+    // Throughout, the SML never reached the tip, so the conjunct kept the tip
+    // body-pending the entire time — it never promoted into a dmn-stale serve.
+    EXPECT_TRUE(m.tip_body_pending());
+}
+
 // H-7 base-continuity: once the SML is current at block A, an INCREMENTAL diff
 // whose base is NOT A is rejected — the SML and its current-at marker are left
 // untouched (no ghost-MN corruption from applying a diff off the wrong base).
@@ -633,23 +920,6 @@ TEST(DashCoinStateMaintainer, MalformedQuorumTailHealsViaFullResyncNotIncrementa
 }
 
 // Build a diff carrying a type-5 cbTx seed (creditPool @ cb_height).
-static CSimplifiedMNListDiff diff_with_seed(const uint256& base, const uint256& block,
-                                            int32_t cb_height, int64_t credit_pool,
-                                            CSimplifiedMNListEntry mn) {
-    CSimplifiedMNListDiff d;
-    d.baseBlockHash = base;
-    d.blockHash     = block;
-    d.mnList = {mn};
-    dash::coin::vendor::CCbTx cb;
-    cb.nVersion = dash::coin::vendor::CCbTx::VERSION_CLSIG_AND_BALANCE;
-    cb.nHeight  = cb_height;
-    cb.creditPoolBalance = credit_pool;
-    d.cbTx.version = 3;
-    d.cbTx.type    = 5;
-    d.cbTx.extra_payload = dash::coin::encode_cbtx(cb);
-    return d;
-}
-
 // SOAK FIX v3 — POST-RESTART: after a cold snapshot the credit-pool seed MUST
 // advance off the snapshot on the first incremental (the re-soak #2 defect was
 // it staying put). And a non-advancing seed (a diff whose cbTx does not carry a


### PR DESCRIPTION
The ordering fix that makes `dmn-stale` structurally unreachable in steady state — **without touching the gate**. Design 1, build phase 1 (steps 1-3), soak-gated (step 4).

## Why this is an ordering fix, not a lane bug

#1154 established that the ~1-per-tip `dmn-stale` decline is not staleness in any one lane — it is the **cost of asynchrony**. dashd's `ConnectBlock` advances DML, quorums, credit pool and ChainLocks together inside one block-connect, so its `getblocktemplate` never sees the tip at height N with a derived axis at N-1. We advance each axis on its own network round trip (`getmnlistd`, `qrinfo`) or local fold, so they *can* momentarily disagree, and the gate correctly refuses rather than serve a wrong payee. The replay measurement (#1154) proved the DML **tail** (lost-diff outages, 586s of 940) is removable but the ~50ms per-tip window is an intra-node **ordering** gap.

`maybe_promote_pending_tip` already gates the body-first serve tip on the credit-pool seed **and** the payee cursor being current *at* the tip. This adds the **SML currency hash** as the fourth axis of that same publish-last conjunct: the serve tip `m_prev_hash` is never advanced to a block the SML is not current at. That makes `node_coin_state.hpp` clause 12 (`dmn-stale` = SML present but at the wrong block) **structurally unsatisfiable in steady state** — the clause, the gate, `on_mnlistdiff` and the header lane are all unchanged. The single io thread is the atomicity primitive; no lock, event or thread is added.

## Step 1 — the blocking wipe audit (gate for everything)

A wipe that left `m_sml_current_hash` **stale-nonzero** would make `on_mnlistdiff`'s base-continuity guard reject every incremental off it, so the currency hash could never re-reach the tip and the conjunct would **deadlock into an indefinite quiet stall**. I enumerated **all four** writers of the hash and **both** SML-list wipes and proved no path can leave it stale-nonzero:

| path | post-state |
|---|---|
| `on_mnlistdiff` :707 | `diff.blockHash` (real, paired with the list just applied) |
| `on_sml_reorg` :836 | **ZERO** + height 0 + `have_sml=false` |
| full-snapshot clear :595 | always falls through to `on_mnlistdiff` → real hash |
| warm-restart restore, main_dash:3252 | `get_best_hash()` only inside the root-verified `warm` guard; cold leaves ZERO |

**Premise correction:** the payee-desync / apply-gap path (~:1224) the design flagged is **not an SML wipe** — it wipes `mnstates()` (the payee axis) and correctly leaves the SML currency untouched. Zeroing it there would force a needless full re-sync on every payee desync. Nothing to fix.

KATs: `ReorgWipeZerosSmlCurrencyHashAndHeight` (also proves ZERO behaves as the cold sentinel — an incremental off the old tip is refused, so recovery needs a full snapshot), `PayeeDesyncLeavesSmlCurrencyHashIntact`.

## Step 2 — the conjunct, with a test-visible carve-out

```cpp
if (!m_state.sml_current_hash().IsNull()
    && m_state.sml_current_hash() != m_hdr_prev_hash)
    return false;
```

**ZERO carve-out** (cold start AND post-reorg-wipe, which step 1 proved land the *identical* `uint256::ZERO` sentinel — they collapse to one case, mirroring the empty-payee carve-out above it). A ZERO currency hash is "the SML covers nothing", already gated by `require_sml`/`populated()` as clause 10 (`no-dmn-set`, evaluated **before** clause 12). It must **not** block promotion or a cold node deadlocks: the currency hash can only reach the tip once a full snapshot lands, and nothing drives that if the whole arm waited on it first. `FourthAxisColdSmlDoesNotBlockPromotion` pins this so a future reader cannot tighten it into a cold-start hang — the same class as the #1152 fixture that couldn't reproduce the padding bug.

## Step 3 — the load-bearing companion (ships here, not a follow-up)

The conjunct holds the tip body-pending while the SML is behind. If that is because a `getmnlistd` was **dropped** (`p2p_client.hpp` returns silently with no primary) or lost, the conjunct would convert a loud instant `dmn-stale` refusal into up to 30s of **quiet H-1 serving** — and H-1 work solved past the propagation window **orphans**. So `check_tip_body_overdue` gains a diff-phase sub-threshold: when the SML is stuck behind the header tip, fire **one bounded** `getmnlistd(base=sml, target=hdr-tip)` via the #1153 `SmlResyncWatchdog` — `min_quiet` 4s « the **unchanged** 30s hard demote, geometric backoff, hard cap 3, then defer to the demote. This is the retry #1153 built, now wired to the ordering fix.

The conjunct **alone** is a regression in the diff-outage case; the conjunct + this re-request is the fix. They ship together.

The target is deliberately the **header** tip, not the serve tip `m_prev_hash` — the trap I flagged in #1153. During a body-pending window the two diverge, and only the header tip is the value the conjunct needs the SML to reach.

## Ceiling — stated honestly

This reaches **100% of steady-state tips** (0 structural declines), **not 100% wall-clock**. Reorg wipes, cold start and genuine faults stay fail-closed refusals by design — realistic ~99.99%. And even with the conjunct the **47-80ms fresh-work latency per tip remains**: it converts a refusal into H-1 serving during that window rather than eliminating the window. Removing that is **phase 2** (local SML fold-stamping), which is **design-only** and untouched here — a fold bug there would become a serving-correctness bug.

## Tests — real red/green, both executed

Allowlisted `test_dash_coin_state_maintainer` (no new target #143, no `#ifdef` #895).

**RED** (master source + the conjunct tests, which use only existing API):
```
[  FAILED  ] DashCoinStateMaintainer.FourthAxisSmlBehindTipBlocksPromotion
[       OK ] DashCoinStateMaintainer.FourthAxisSmlCurrentAtTipPromotes
[       OK ] DashCoinStateMaintainer.FourthAxisColdSmlDoesNotBlockPromotion
```
Against master the SML-behind case **promotes** (the exact clause-12 window). The all-agree and cold-carve-out tests pass in both — correct, since the conjunct only *adds* blocking.

**GREEN** (this branch):
```
[       OK ] FourthAxisSmlBehindTipBlocksPromotion
[       OK ] FourthAxisSmlCurrentAtTipPromotes
[       OK ] FourthAxisColdSmlDoesNotBlockPromotion
[       OK ] DiffPhaseReRequestFiresBoundedThenDefersToDemote
[       OK ] ReorgWipeZerosSmlCurrencyHashAndHeight        (step-1 audit)
[       OK ] PayeeDesyncLeavesSmlCurrencyHashIntact        (step-1 audit)
```
Full suite **45/45**, pre-existing tests unchanged. Full `c2pool-dash` binary builds clean.

*(The Step-3 `DiffPhaseReRequest` test uses the new `set_on_sml_rerequest` API, so against master it does not compile rather than fail — there is no runnable RED for a hook that does not exist. The behavioral RED that matters is the conjunct, shown above.)*

## Merge gate — the soak, authoritative over review

**Do not merge on green CI alone.** CI proves it builds and the KATs hold; only the soak proves the window actually closed and nothing surfaced under the now-unmasked clauses. Step 4, starting next: A/B on a **multi-peer** replay rig (single-peer `.211` could not attribute bestcl/DKG — #1154), ≥100 tips per arm, #1152 `dur=` instrument. Pass criteria include a **masking tally** — clause 12 currently masks clauses 13-15 (mn-confirm-rollover, payee-unresolvable, payout-split-unprovable); if any of their counts *rise* once clause 12 stops firing, I stop and report, because that means closing this window exposed a real per-tip problem the old metric could never see.

## Sequencing

Touches `coin_state_maintainer.hpp`, `main_dash.cpp` (one hook-wiring block, mirroring `set_on_full_resync`), and the maintainer test. No `work_source.cpp`, no `node_coin_state.hpp` gate clause, no `on_mnlistdiff`. Base `daab1987` (16 PRs landed today incl #1150/#1152/#1153). `do-not-merge`.
