### PR TITLE
web(dashboard): emit actual_hash_difficulty for SHA256/X11 lanes — block trails were dead on every coin (#1137) [do-not-merge]

### DIFF
--- a/src/core/test/web_server_relay_block_test.cpp
+++ b/src/core/test/web_server_relay_block_test.cpp
@@ -108,3 +108,82 @@ TEST(RelayBlockHonesty, LocallyFoundBlockKeepsRealTiming) {
         << "a first block has no luck measurement; 0 would be a fabricated one";
     EXPECT_EQ(blk["luck_method"].get<std::string>(), "first_block");
 }
+
+// ─── actual_hash_difficulty: quality of the found hash (#1137) ───────────────
+//
+// = diff1 / block_hash (p2pool-dash web.py:1754). The dashboard reads it 12x
+// (drawDiffRatioBars, diamond elevation, the Hash Difficulty column, two
+// tooltip branches) and NO backend emitted it, so those visuals were dead on
+// every lane. It is only correct where the BLOCK HASH IS the PoW hash: DASH
+// (X11) and BTC (SHA256d). Scrypt lanes (LTC/DOGE) and multi-algo DGB must
+// emit null -- diff1/block_hash there describes the wrong hash.
+
+// diff1 target itself -> difficulty exactly 1.0.
+static const char* kDiff1Hash =
+    "00000000ffff0000000000000000000000000000000000000000000000000000";
+// A much smaller hash (more leading zeroes) -> a large difficulty.
+static const char* kDeepHash =
+    "000000000000000f000000000000000000000000000000000000000000000000";
+
+TEST(ActualHashDifficulty, DashLaneEmitsDiff1OverHash) {
+    core::MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                             c2pool::address::Blockchain::DASH);
+    mi.record_found_block(/*height=*/2500000, uint256S(kDiff1Hash),
+                          /*ts=*/1750000000, /*chain=*/"DASH",
+                          /*miner=*/"XhK2example", /*share_hash=*/"beef");
+
+    auto blk = find_block(mi.rest_recent_blocks(), kDiff1Hash);
+    ASSERT_TRUE(blk.is_object());
+    ASSERT_TRUE(blk.contains("actual_hash_difficulty"));
+    ASSERT_TRUE(blk["actual_hash_difficulty"].is_number())
+        << "DASH block hash IS the X11 PoW hash -- the field must be emitted";
+    // hash == diff1 target -> difficulty 1.0.
+    EXPECT_NEAR(blk["actual_hash_difficulty"].get<double>(), 1.0, 1e-6);
+}
+
+TEST(ActualHashDifficulty, DeeperHashGivesHigherDifficulty) {
+    core::MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                             c2pool::address::Blockchain::DASH);
+    mi.record_found_block(/*height=*/2500001, uint256S(kDeepHash),
+                          /*ts=*/1750000100, /*chain=*/"DASH",
+                          /*miner=*/"XhK2example", /*share_hash=*/"beef");
+
+    auto blk = find_block(mi.rest_recent_blocks(), kDeepHash);
+    ASSERT_TRUE(blk.is_object());
+    ASSERT_TRUE(blk["actual_hash_difficulty"].is_number());
+    // A hash far below the diff1 target is a much "better" (rarer) hash.
+    EXPECT_GT(blk["actual_hash_difficulty"].get<double>(), 1e6)
+        << "a hash with many more leading zeroes than target implies high diff";
+}
+
+TEST(ActualHashDifficulty, BtcLaneAlsoEmits) {
+    core::MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                             c2pool::address::Blockchain::BITCOIN);
+    mi.record_found_block(/*height=*/800000, uint256S(kDiff1Hash),
+                          /*ts=*/1750000000, /*chain=*/"BTC",
+                          /*miner=*/"1BtcExample", /*share_hash=*/"beef");
+
+    auto blk = find_block(mi.rest_recent_blocks(), kDiff1Hash);
+    ASSERT_TRUE(blk.is_object());
+    ASSERT_TRUE(blk["actual_hash_difficulty"].is_number())
+        << "BTC block hash IS the SHA256d PoW hash -- the field must be emitted";
+    EXPECT_NEAR(blk["actual_hash_difficulty"].get<double>(), 1.0, 1e-6);
+}
+
+TEST(ActualHashDifficulty, ScryptLaneEmitsNullNotAWrongNumber) {
+    // LTC: block identity hash is SHA256d, PoW is scrypt. diff1/block_hash
+    // would describe the SHA256d hash, which is NOT what won the block. That
+    // is a fabricated measurement, so the lane emits null until a pow_hash is
+    // captured at find time (scoped out -- FoundBlock field + mint plumbing).
+    core::MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                             c2pool::address::Blockchain::LITECOIN);
+    mi.record_found_block(/*height=*/2600000, uint256S(kDiff1Hash),
+                          /*ts=*/1750000000, /*chain=*/"LTC",
+                          /*miner=*/"LhK2example", /*share_hash=*/"beef");
+
+    auto blk = find_block(mi.rest_recent_blocks(), kDiff1Hash);
+    ASSERT_TRUE(blk.is_object());
+    ASSERT_TRUE(blk.contains("actual_hash_difficulty"));
+    EXPECT_TRUE(blk["actual_hash_difficulty"].is_null())
+        << "scrypt lane must NOT emit diff1/block_hash -- that is the wrong hash";
+}

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -2497,6 +2497,33 @@ nlohmann::json MiningInterface::rest_recent_blocks()
 {
     static const char* status_str[] = {"pending", "confirmed", "orphaned", "stale"};
     nlohmann::json arr = nlohmann::json::array();
+
+    // actual_hash_difficulty: how far below target the WINNING hash landed,
+    // = diff1 / block_hash (the p2pool-dash formula, web.py:1754). It is the
+    // "quality of the found hash" the dashboard's drawDiffRatioBars / diamond
+    // elevation / Hash Difficulty column all read, and which no backend has
+    // ever emitted (#1137) -- so those visuals have been dead on every lane.
+    //
+    // It is ONLY meaningful where the BLOCK HASH IS the PoW hash: DASH (X11)
+    // and BTC (SHA256d). On scrypt lanes (LTC/DOGE) and multi-algo DGB the
+    // block identity hash is SHA256d while the PoW is a different function, so
+    // diff1/block_hash would describe the WRONG hash. Those lanes emit null
+    // here until a pow_hash is captured at find time -- a larger change,
+    // deliberately scoped out (it needs a FoundBlock field + mint-path plumbing
+    // on every scrypt lane). Emitting a plausible-but-wrong number would be the
+    // exact fabricated-value defect the honest-null rule above exists to stop.
+    const bool block_hash_is_pow_hash =
+        (m_blockchain == Blockchain::DASH || m_blockchain == Blockchain::BITCOIN);
+    auto actual_hash_difficulty = [&](const std::string& hash_hex) -> nlohmann::json {
+        if (!block_hash_is_pow_hash || hash_hex.size() != 64)
+            return nlohmann::json(nullptr);
+        uint256 h;
+        h.SetHex(hash_hex);
+        if (h.IsNull()) return nlohmann::json(nullptr);
+        double d = chain::target_to_difficulty(h);   // diff1 / hash
+        return d > 0.0 ? nlohmann::json(d) : nlohmann::json(nullptr);
+    };
+
     std::lock_guard<std::mutex> lock(m_blocks_mutex);
     for (const auto& b : m_found_blocks) {
         // Node-role honesty (#942): a block with no local share_hash AND no
@@ -2537,6 +2564,7 @@ nlohmann::json MiningInterface::rest_recent_blocks()
             {"share", b.share_hash},
             {"found_locally", found_locally},
             {"network_difficulty", num_or_null(b.network_difficulty)},
+            {"actual_hash_difficulty", actual_hash_difficulty(b.hash)},
             {"share_difficulty", num_or_null(b.share_difficulty)},
             {"pool_hashrate_at_find", num_or_null(b.pool_hashrate)},
             {"subsidy", b.subsidy != 0 ? nlohmann::json(b.subsidy)


### PR DESCRIPTION
Item 3 of the dashboard batch. Closes #1137. Backend emit + KATs; the front-end already reads the field.

## The bug

`actual_hash_difficulty` is read **12 times** in `dashboard.html` — `drawDiffRatioBars` (the block trails), block-diamond elevation, the "Hash Difficulty" column, two tooltip branches — and **no C++ path ever emitted it**. So all of that has drawn nothing, on every lane, since the JS was ported from our p2pool-dash fork. p2pool-dash's backend *does* emit it (`web.py:1754`, `max_target/hash_int`); only the field was left behind in the rewrite. c2pool's `drawDiffRatioBars` is a byte-identical port of theirs.

## The fix

`rest_recent_blocks()` now emits it, computed identically: `diff1 / block_hash`, via the existing `chain::target_to_difficulty(uint256)` (`target_utils.hpp:92`, whose `max_target` is the `0x00000000ffff0000…` bdiff-1 target). It is the "quality of the found hash" — how far below target the winning hash landed.

**Retroactive** for the SHA256/X11 lanes: the value is a pure function of the stored block hash, so every row already in the found-block store lights up with no re-record.

## Lane-gated — this is the load-bearing decision

It is only correct where the **block hash IS the PoW hash**:

| lane | identity hash | PoW | emit? |
|---|---|---|---|
| **DASH** | X11 | X11 | **yes** |
| **BTC** | SHA256d | SHA256d | **yes** |
| LTC / DOGE | SHA256d | scrypt | **null** |
| DGB | SHA256d | multi-algo | **null** |

On a scrypt lane, `diff1/block_hash` would describe the SHA256d *identity* hash, not the scrypt hash that actually won the block — a fabricated measurement, exactly what the honest-null rule already in this function forbids. **Those lanes emit `null`, not a plausible-but-wrong number.**

## Scoped OUT (the expensive category — flagged up front)

The scrypt lanes need the real PoW hash captured **at find time**: a new `FoundBlock` field plus mint-path plumbing on every scrypt lane. That is data we do not currently collect, so it is a separate, larger change and is deliberately not in this PR. LTC/DOGE block trails stay dark until then — by design, showing `null` (`-`) rather than a wrong number.

## Verification

Formula checked numerically: `diff1/diff1 = 1.0`; a hash with many more leading zeroes (`0000…000f…`) → `2.86e8`.

**4 KATs in `core_test`** (already allowlisted; `src/core/test/web_server_relay_block_test.cpp`, which already builds a `MiningInterface` and records blocks):
- DASH emits `diff1/hash` — `hash == diff1 → 1.0`
- a deeper hash → higher difficulty (`> 1e6`)
- BTC also emits
- **LTC emits `null`, not a wrong number**

Header logic compiles clean in isolation; full build + gtest left to CI (`do-not-merge`). No `#ifdef` (#895). Does not touch #1141/#1144/#1145/#1149; no `dashboard.html` change so no overlap with #1159/#1160.
