### PR TITLE
dash(mn-ckpt): every fold pause re-arms the request window — cold bridge 34m12s -> 1m30s [do-not-merge]

### DIFF
--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -1717,6 +1717,35 @@ public:
         m_snapshot_hash    = *hash;
         m_snapshot_height  = height;
         m_snapshot_waits   = 0;
+        // ── EVERY pause drops its in-flight bodies, so EVERY resume must
+        // re-request from the cursor (task #103; found measuring #1151's
+        // baseline). on_block_connected() returns early while
+        // m_snapshot_pending is set, so whatever getdata was outstanding when
+        // this fold paused is answered into the void. The resume paths call
+        // request_window(), but with this flag clear that computes
+        // from = m_requested_through + 1 — PAST the end of the already-
+        // requested window — and issues ZERO getdata. The bridge then sits
+        // idle until the next tip change (~2.5 min mainnet), once per fold:
+        // measured 4m16s, 5m34s, then 16m25s of dead gap on a cold bridge —
+        // 26 of its first 28 minutes doing nothing, against a fetch lane that
+        // moves at ~190 blk/s.
+        //
+        // The BAN-STATE PROBE path already sets this flag for itself, with a
+        // comment naming this exact failure ("the bridge would sit on the
+        // stall probe until the next tip change"); it was the ONE pause path
+        // that did, because it uniquely re-consumes a block it already folded.
+        // But the dropped-getdata half applies to ALL pauses, so the flag
+        // belongs to the pause itself, not to one caller. One flag set per
+        // pause, consumed once by the next request_window() (which resets it),
+        // and re-requesting a body we already hold is harmless — apply_block
+        // skips heights != m_next. No storm: a pause re-arms exactly once.
+        //
+        // SET BEFORE m_request_snapshot below, for the same reason the probe
+        // sets its latch first: the request may be answered INLINE (ordered
+        // stream / same-thread demux), in which case on_historical_snapshot()
+        // resumes and calls request_window() before begin_fold() returns —
+        // and that resume must already see the flag.
+        m_rerequest_from_cursor = true;
         LOG_INFO << "[MN-CKPT] "
                  << (!why.empty()
                          ? why

--- a/test/test_dash_mn_checkpoint.cpp
+++ b/test/test_dash_mn_checkpoint.cpp
@@ -3364,6 +3364,108 @@ struct DirtyBridge {
 
 } // namespace
 
+// ═══════════════════════════════════════════════════════════════════════════
+// TASK #103 — EVERY pause must re-arm the request window, not just the probe
+//
+// MEASURED (cold MN-CKPT bridge, found while baselining #1151): the bulk
+// fetch runs at ~190 blk/s, but the bridge's wall clock was dead gaps AFTER
+// FOLDS — 4m16s, 5m34s, then 16m25s; 26 of the first 28 minutes doing
+// nothing. Mechanism: a fold pauses the replay, on_block_connected drops
+// every in-flight body while paused, and the resume's request_window()
+// computes from = m_requested_through + 1 — PAST end — so it issues ZERO
+// getdata and the bridge waits for the next tip change (~2.5 min), once per
+// fold. The BAN-STATE PROBE path already set m_rerequest_from_cursor for
+// itself, with a comment naming this exact failure; begin_fold() and
+// begin_ondemand_fold() did not, and they are the pauses a cold bridge
+// actually takes.
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashMnCheckpointPoseFold, ResumeAfterAFoldReRequestsTheDroppedWindow)
+{
+    constexpr uint32_t kAnchorH = 2513000;
+    constexpr uint32_t kTip     = 2513010;
+    const uint256 anchor_hash = uint256S(kAnchorHash);
+    const auto cp = synthetic_anchor(64, kAnchorH, anchor_hash);
+
+    // Nobody banned: this test is about scheduling, not adjudication.
+    std::vector<std::pair<uint256, bool>> attest;
+    for (const auto& e : cp.entries) attest.emplace_back(e.first, true);
+
+    SnapshotRig rig;
+    rig.attest = attest;
+    rig.install(kAnchorH, kTip, anchor_hash);
+    rig.by_height[kAnchorH] = make_snapshot(anchor_hash, kAnchorH, attest);
+    // The queue runs rank 0, 1, 2, ... — each block pays the next head.
+    for (uint32_t bh = kAnchorH + 1; bh <= kTip; ++bh)
+        rig.h.blocks[bh] = block_paying(
+            cp.entries[bh - (kAnchorH + 1)].second.scriptPayout.m_data);
+
+    // PRODUCTION SHAPE: bodies are requested but arrive ASYNCHRONOUSLY.
+    // auto_deliver=false records the getdata without answering, which is
+    // exactly the state a paused fold drops on the floor. Snapshot replies
+    // stay inline (rig.answer=true) — the ordered-stream case the flag's
+    // set-before-request ordering exists for.
+    rig.h.auto_deliver = false;
+    rig.h.lane.set_fold_interval(4);      // fold point at cursor 2513004
+
+    rig.h.lane.arm(cp);
+    rig.h.lane.pump();
+    ASSERT_EQ(rig.h.lane.state(), MnCheckpointLane::State::Bridging)
+        << rig.h.lane.status();
+    // The window was requested up front: anchor+1 .. tip (tip < kWindow away).
+    ASSERT_FALSE(rig.h.requested.empty());
+    ASSERT_EQ(rig.h.lane.requested_through(), kTip);
+
+    // Deliver bodies up to the fold point. At 2513004 the lane pauses,
+    // requests the list AS OF 2513004, is answered inline, folds, and
+    // RESUMES. The bodies for 2513005..kTip were requested before the pause
+    // and (auto_deliver=false) never arrived — in production they were
+    // dropped by the paused on_block_connected.
+    rig.h.requested.clear();
+    for (uint32_t bh = kAnchorH + 1; bh <= kAnchorH + 4; ++bh)
+        rig.h.lane.on_block_connected(rig.h.blocks[bh], bh);
+    ASSERT_FALSE(rig.h.lane.snapshot_pending())
+        << "the inline snapshot answer must have resolved the fold";
+    ASSERT_EQ(rig.h.lane.folds_applied(), 2u)   // anchor fold + h=2513004
+        << rig.h.lane.status();
+    ASSERT_EQ(rig.h.lane.cursor_height(), kAnchorH + 4)
+        << "cursor_height() is the LAST FOLDED height; the next block the"
+           " bridge needs is +5";
+
+    // ── THE DEFECT. On master the resume issues ZERO getdata (from =
+    // requested_through + 1 = kTip + 1 > end) and the bridge sits until the
+    // next tip change — ~2.5 minutes per fold, 26 of a cold bridge's first
+    // 28 minutes. Fixed, the resume re-requests from the cursor.
+    std::vector<uint32_t> rerequested = rig.h.requested;
+    ASSERT_FALSE(rerequested.empty())
+        << "resume after a fold issued no getdata: the in-flight bodies were"
+           " dropped by the pause and nothing will ever re-request them —"
+           " the bridge is dead until the next tip change";
+    EXPECT_EQ(rerequested.front(), kAnchorH + 5)
+        << "the re-request must start at the cursor, where the dropped"
+           " window began";
+    EXPECT_EQ(rerequested.back(), kTip);
+
+    // ── NO STORM. The flag is consumed by the ONE re-request pass of the
+    // resume. The next request_window on the ordinary post-apply path (the
+    // end of on_block_connected) must issue NOTHING new: from returns to
+    // requested_through+1, past end. (pump()'s stall detector re-arms per
+    // STALL at tip-change cadence — that is its pre-existing job and is not
+    // exercised here; this asserts the pause's own flag does not linger.)
+    rig.h.requested.clear();
+    rig.h.lane.on_block_connected(rig.h.blocks[kAnchorH + 5], kAnchorH + 5);
+    EXPECT_TRUE(rig.h.requested.empty())
+        << "the resume's re-arm must be one-shot: an ordinary block apply"
+           " after it must not re-request the window again";
+
+    // The bridge still completes: deliver the rest of the tail and publish.
+    for (uint32_t bh = kAnchorH + 6; bh <= kTip; ++bh)
+        rig.h.lane.on_block_connected(rig.h.blocks[bh], bh);
+    EXPECT_TRUE(rig.h.published)
+        << rig.h.lane.status();
+    EXPECT_EQ(rig.h.published_as_of, kTip);
+}
+
+
 TEST(DashMnCheckpointReseed, ReArmResetsEveryFieldArmSets)
 {
     DirtyBridge d;


### PR DESCRIPTION
## Every fold pause re-arms the request window — cold MN-CKPT bridge: 34m12s → 1m30s

Task #103. Found by the #1151 cursor-persistence agent while baselining, and
kept out of that PR because it is a different defect.

### The defect

The fetch lane moves at ~190 blk/s, but a cold bridge's wall clock was almost
entirely **dead gaps after folds** — measured 4m16s, 5m34s, then 16m25s: 26 of
its first 28 minutes doing nothing.

Mechanism: a fold pauses the replay (`m_snapshot_pending`), and while paused
`on_block_connected` drops every arriving body — including the whole in-flight
getdata window. On resume, `request_window()` computes
`from = m_requested_through + 1`, which is **past the end** of the
already-requested window, so it issues **zero getdata**. Nothing ever re-asks
for the dropped bodies. The bridge sits until the next tip change (~2.5 min
mainnet) delivers one tip's worth, folds again, and repeats — one dead gap per
fold.

### The fix is the ban-state probe's own mechanism, given to every pause

The BAN-STATE PROBE path already carried exactly this fix for itself —
`m_rerequest_from_cursor`, set before its `begin_fold`, with a comment naming
the failure verbatim (*"the bridge would sit on the stall probe until the next
tip change"*). It was the only pause path that set it, because it uniquely
re-consumes a block it already folded. But the dropped-getdata half of its
reasoning applies to **every** pause, so the flag now belongs to the pause
itself: `begin_fold()` sets it, covering the fold-point path and the on-demand
path (which calls `begin_fold`), and leaving the probe path identical.

Set **before** `m_request_snapshot`, for the same reason the probe sets its
latch first: an inline reply (ordered stream / same-thread demux) resumes and
calls `request_window()` before `begin_fold()` has returned — and that resume
must already see the flag.

### Measured, live — same host, same LAN peer, same shape as the baseline

Cold bridge (fresh data dir, `cursor COLD`, no dashd RPC, no replay flags —
the checkpoint bridge as the only payee lane), .211 against the LAN archival
node:

| | baseline (2026-08-05) | with fix (2026-08-06) | |
|---|---|---|---|
| bridge COMPLETE (published payee set) | **34m 12s** | **1m 29.5s** | **23×** |
| first `arm=EMBEDDED` template served | **39m 25s** | **1m 32s** | **26×** |

The fixed run replayed **4220 blocks** (anchor 2513000 → tip 2517220) and took
**23 PoSe folds** — each of which was a ~2.5-minute dead gap before —
publishing 2972 masternodes and pushing `mining.notify` to an attached stratum
client. 4220 blocks / 89.5 s ≈ 47 blk/s *including* all 23 pause/fold/resume
cycles, against ~2 blk/s before.

### No storm, and the honest cost

* The flag is consumed by exactly **one** `request_window()` pass (which
  resets it); an ordinary post-apply `request_window` issues nothing new —
  pinned by the KAT.
* Re-requesting a body already held is harmless: `apply_block` skips heights
  `!= m_next` (pre-existing property, relied on by the stall detector).
* The honest cost: bodies that arrived during a pause and were dropped are
  fetched **twice**. Worst case ≈ `kWindow(64) × folds(23)` ≈ 1.5k redundant
  bodies (~20 MB) per cold bridge — paid in bandwidth instead of in 23 × 2.5
  min of wall clock. This is the price of the drop-while-paused design, now
  visible instead of disguised as dead time. It does not add to the
  steady-state double-fetch the #1151 agent flagged (the bridge running beside
  the fold as a fallback), which is unchanged by this PR.

### KAT — red on master at the exact defect

`test_dash_mn_checkpoint.cpp`, in the existing allowlisted
`test_dash_node_reception_wire` target (no new target, #143; no `#ifdef`,
#895). Async-delivery rig (`auto_deliver=false` — bodies requested but not
answered, the production shape), fold point mid-window, inline snapshot reply:

* **RED on master**, failing with *"resume after a fold issued no getdata: the
  in-flight bodies were dropped by the pause and nothing will ever re-request
  them — the bridge is dead until the next tip change"*.
* **GREEN with the fix**: the resume re-requests exactly `cursor+1..end`; the
  one-shot consumption is asserted (an ordinary block apply after the resume
  issues nothing new); and the bridge completes and publishes.

140/140 green in the target.

### Scope

One header, one flag-set site plus its comment; +KAT. No change to what is
folded, what is served, or which payee is chosen — `request_window` itself is
untouched apart from being reached when it should be.

`do-not-merge` per current policy.
