### PR TITLE
fix(#1131): borrow don't own on think-P1 verified.remove(bad) — latent double free (all 5 lanes)

### DIFF
--- a/src/impl/bch/share_tracker.hpp
+++ b/src/impl/bch/share_tracker.hpp
@@ -747,7 +747,17 @@ public:
 
                 try {
                     invalidate_weight_caches(bad);
-                    if (verified.contains(bad)) verified.remove(bad);
+                    // #1131 double-free guard: `verified` is a BORROWING view —
+                    // it holds the same raw share pointers `chain` OWNS (every
+                    // node.cpp removal already pairs verified.remove(h, false)
+                    // with chain.remove(h)). Removing from the borrowing view
+                    // must NOT destroy; only the owning chain.remove() below
+                    // may. Omitting owns_data defaults it to true, so if the
+                    // `verified.contains(bad) -> continue` guard 20 lines up is
+                    // ever loosened (e.g. wiring the mint path) this would
+                    // destroy() the share and chain.remove() would destroy() the
+                    // same pointer again -> the exact tcache/double-free abort.
+                    if (verified.contains(bad)) verified.remove(bad, /*owns_data=*/false);
                     if (chain.remove(bad)) ++removed_count;
                 } catch (...) {}
             }

--- a/src/impl/btc/share_tracker.hpp
+++ b/src/impl/btc/share_tracker.hpp
@@ -849,8 +849,18 @@ public:
                 // (equivalent to NotImplementedError).
                 try {
                     invalidate_weight_caches(bad);
+                    // #1131 double-free guard: `verified` is a BORROWING view —
+                    // it holds the same raw share pointers `chain` OWNS (every
+                    // node.cpp removal already pairs verified.remove(h, false)
+                    // with chain.remove(h)). Removing from the borrowing view
+                    // must NOT destroy; only the owning chain.remove() below
+                    // may. Omitting owns_data here defaults it to true, so if
+                    // the `verified.contains(bad) -> continue` guard 20 lines up
+                    // is ever loosened (e.g. wiring the mint path) this would
+                    // destroy() the share and chain.remove() would destroy() the
+                    // same pointer again -> the exact tcache/double-free abort.
                     if (verified.contains(bad))
-                        verified.remove(bad);
+                        verified.remove(bad, /*owns_data=*/false);
                     if (chain.remove(bad))
                         ++removed_count;
                 } catch (...) {}

--- a/src/impl/btc/test/CMakeLists.txt
+++ b/src/impl/btc/test/CMakeLists.txt
@@ -1,11 +1,15 @@
 if (BUILD_TESTING AND GTest_FOUND)
     # btc twin of ltc share_test — uniquely named to avoid the CMP0002 target
     # collision with src/impl/ltc/test (both subdirs build in the same tree).
-    add_executable(btc_share_test share_test.cpp f11_donation_invariance_test.cpp f10b_version_punish_removal_test.cpp g01_share_format_parity_test.cpp g0_share_wire_parity_test.cpp auto_ratchet_sim_test.cpp block_broadcast_guard_test.cpp block_broadcast_connect_test.cpp regtest_sharechain_isolation_test.cpp stratum_merkle_branch_test.cpp witness_commitment_merkle_test.cpp finder_fee_integer_exact_test.cpp rpc_conf_test.cpp genesis_check_test.cpp won_share_dualpath_test.cpp gentx_unpack_test.cpp block_assembly_test.cpp gentx_coinbase_test.cpp template_capture_test.cpp template_other_txs_test.cpp reconstruct_test.cpp known_txs_retention_test.cpp won_block_mints_share_test.cpp broadcast_gate_test.cpp broadcast_lock_discipline_test.cpp seed_bootstrapper_test.cpp idle_progress_gate_test.cpp reconstruct_merkle_backstop_test.cpp coin_peer_manager_test.cpp merged_spec_test.cpp merged_backend_test.cpp)
+    add_executable(btc_share_test share_test.cpp f11_donation_invariance_test.cpp f10b_version_punish_removal_test.cpp g01_share_format_parity_test.cpp g0_share_wire_parity_test.cpp auto_ratchet_sim_test.cpp block_broadcast_guard_test.cpp block_broadcast_connect_test.cpp regtest_sharechain_isolation_test.cpp stratum_merkle_branch_test.cpp witness_commitment_merkle_test.cpp finder_fee_integer_exact_test.cpp rpc_conf_test.cpp genesis_check_test.cpp won_share_dualpath_test.cpp gentx_unpack_test.cpp block_assembly_test.cpp gentx_coinbase_test.cpp template_capture_test.cpp template_other_txs_test.cpp reconstruct_test.cpp known_txs_retention_test.cpp won_block_mints_share_test.cpp broadcast_gate_test.cpp broadcast_lock_discipline_test.cpp seed_bootstrapper_test.cpp idle_progress_gate_test.cpp reconstruct_merkle_backstop_test.cpp coin_peer_manager_test.cpp merged_spec_test.cpp merged_backend_test.cpp share_remove_owns_data_test.cpp)
     target_link_libraries(btc_share_test PRIVATE
         GTest::gtest_main GTest::gtest
         core btc
     )
+    # #1131 source-structural KAT: verified.remove(bad) must borrow (owns_data=false),
+    # not own — folded into this EXISTING allowlisted target (no new executable).
+    target_compile_definitions(btc_share_test PRIVATE
+        BTC_SHARE_TRACKER_SRC="${CMAKE_CURRENT_SOURCE_DIR}/../share_tracker.hpp")
     # btc_stratum: won_block_mints_share_test.cpp (#887) constructs a live
     # BTCWorkSource and drives mining_submit. FOLDED into this EXISTING
     # allowlisted target rather than a new add_executable -- a new one would

--- a/src/impl/btc/test/share_remove_owns_data_test.cpp
+++ b/src/impl/btc/test/share_remove_owns_data_test.cpp
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// D-BTC.SHARE-REMOVE-OWNS-DATA — source-structural guard pinning that the
+// think-P1 bad-share removal borrows (owns_data=false) from `verified` and lets
+// only the owning `chain` destroy the share.
+//
+// THE DEFECT THIS PINS (#1131, latent double free):
+//   In ShareTracker::think() the bad-share removal does, per share `bad`:
+//       if (verified.contains(bad)) verified.remove(bad);   // owns_data=TRUE (default)
+//       if (chain.remove(bad))      ++removed_count;         // owns_data=TRUE (default)
+//   `verified` is a BORROWING view — it holds the SAME raw share pointers that
+//   `chain` OWNS (every removal in node.cpp already pairs
+//   verified.remove(h, /*owns_data=*/false) with chain.remove(h)). With the
+//   default owns_data=true, verified.remove() calls share.destroy() -> delete,
+//   then chain.remove() calls destroy() on the SAME pointer again: a double
+//   free / "unaligned tcache chunk" abort, exactly the hotel-primary signature.
+//
+//   It is UNREACHABLE TODAY only because of the `if (verified.contains(bad))
+//   continue;` guard ~20 lines earlier, which makes the inner
+//   `verified.contains(bad)` always false. The moment that guard is loosened
+//   (e.g. wiring the mint path) the landmine arms. The fix pre-arms it: pass
+//   owns_data=false so the borrowing view can never destroy.
+//
+// WHY A STRUCTURAL TEST: the buggy statement is dead code today, so a runtime
+// repro cannot reach it without first perturbing unrelated control flow — the
+// same situation as the sibling latent-UAF race913 (PR #1114) and the #1134
+// oracle-ownership guard (PR #1150). A guard that asserts the OWNERSHIP SHAPE
+// in the shipped source is the deterministic red/green this invariant admits.
+// Restore the bare `verified.remove(bad);` form -> RED; keep the borrowing
+// owns_data=false form -> GREEN.
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#ifndef BTC_SHARE_TRACKER_SRC
+#error "BTC_SHARE_TRACKER_SRC must be defined by CMake to the path of src/impl/btc/share_tracker.hpp"
+#endif
+
+namespace {
+
+std::string read_text(const char* path)
+{
+    std::ifstream in(path);
+    EXPECT_TRUE(in.good()) << "cannot open " << path;
+    std::stringstream ss; ss << in.rdbuf();
+    return ss.str();
+}
+
+// Replace every comment with spaces, preserving byte offsets and line breaks.
+// The fix's own doc comment deliberately quotes the pre-fix `verified.remove(bad)`
+// expression, so the assertions below MUST run over comment-free code or they
+// would pass against the buggy form for the wrong reason.
+std::string strip_comments(const std::string& s)
+{
+    std::string out = s;
+    enum { kCode, kLine, kBlock, kStr, kChr } st = kCode;
+    for (size_t i = 0; i < out.size(); ++i) {
+        const char c = out[i];
+        const char n = (i + 1 < out.size()) ? out[i + 1] : '\0';
+        switch (st) {
+        case kCode:
+            if (c == '/' && n == '/') { st = kLine;  out[i] = ' '; out[i + 1] = ' '; ++i; }
+            else if (c == '/' && n == '*') { st = kBlock; out[i] = ' '; out[i + 1] = ' '; ++i; }
+            else if (c == '"')  st = kStr;
+            else if (c == '\'') st = kChr;
+            break;
+        case kLine:
+            if (c == '\n') st = kCode; else out[i] = ' ';
+            break;
+        case kBlock:
+            if (c == '*' && n == '/') { out[i] = ' '; out[i + 1] = ' '; ++i; st = kCode; }
+            else if (c != '\n') out[i] = ' ';
+            break;
+        case kStr:
+            if (c == '\\') ++i; else if (c == '"') st = kCode;
+            break;
+        case kChr:
+            if (c == '\\') ++i; else if (c == '\'') st = kCode;
+            break;
+        }
+    }
+    return out;
+}
+
+size_t count_of(const std::string& hay, const std::string& needle)
+{
+    size_t n = 0, pos = 0;
+    while ((pos = hay.find(needle, pos)) != std::string::npos) { ++n; pos += needle.size(); }
+    return n;
+}
+
+// The argument text of a `verified.remove(bad<...>)` call: everything between
+// the first '(' after the match and its matching ')'.
+std::string remove_call_args(const std::string& code)
+{
+    const std::string key = "verified.remove(bad";
+    const size_t k = code.find(key);
+    if (k == std::string::npos) return "";
+    const size_t open = code.find('(', k);
+    if (open == std::string::npos) return "";
+    int depth = 0;
+    for (size_t i = open; i < code.size(); ++i) {
+        if (code[i] == '(') ++depth;
+        else if (code[i] == ')') { if (--depth == 0) return code.substr(open + 1, i - open - 1); }
+    }
+    return "";
+}
+
+} // namespace
+
+// The think-P1 removal block must exist — anchor the assertions to real code.
+TEST(BtcShareRemoveOwnsData, RemovalBlockPresent)
+{
+    const std::string code = strip_comments(read_text(BTC_SHARE_TRACKER_SRC));
+    EXPECT_NE(code.find("if (chain.remove(bad))"), std::string::npos)
+        << "think-P1 bad-share removal block not found — test anchor is stale";
+    EXPECT_GE(count_of(code, "verified.remove(bad"), 1u)
+        << "expected a verified.remove(bad ...) in the removal block";
+}
+
+// #1131: the borrowing view must NEVER be removed-from with the default
+// owns_data=true. The bare `verified.remove(bad)` form (no second argument)
+// destroys a share `chain` also owns -> double free.
+TEST(BtcShareRemoveOwnsData, VerifiedRemoveDoesNotOwnData)
+{
+    const std::string code = strip_comments(read_text(BTC_SHARE_TRACKER_SRC));
+
+    // RED against the shipped bug: exactly the bare, owns_data-defaulted form.
+    EXPECT_EQ(count_of(code, "verified.remove(bad)"), 0u)
+        << "verified.remove(bad) defaults owns_data=true and destroy()s a share "
+           "chain.remove(bad) also owns -> #1131 double free; pass "
+           "/*owns_data=*/false so the borrowing view cannot destroy";
+
+    // GREEN shape: the call carries an explicit second argument, and it is false.
+    const std::string args = remove_call_args(code);
+    ASSERT_FALSE(args.empty()) << "no verified.remove(bad ...) call found";
+    EXPECT_NE(args.find(','), std::string::npos)
+        << "verified.remove(bad ...) must pass an explicit owns_data argument";
+    EXPECT_NE(args.find("false"), std::string::npos)
+        << "verified is a borrowing view — owns_data must be false";
+    EXPECT_EQ(args.find("true"), std::string::npos)
+        << "owns_data=true on a borrowing view double-frees with chain.remove()";
+}

--- a/src/impl/dash/share_tracker.hpp
+++ b/src/impl/dash/share_tracker.hpp
@@ -896,8 +896,18 @@ public:
                 // (equivalent to NotImplementedError).
                 try {
                     invalidate_weight_caches(bad);
+                    // #1131 double-free guard: `verified` is a BORROWING view —
+                    // it holds the same raw share pointers `chain` OWNS (every
+                    // node.cpp removal already pairs verified.remove(h, false)
+                    // with chain.remove(h)). Removing from the borrowing view
+                    // must NOT destroy; only the owning chain.remove() below
+                    // may. Omitting owns_data here defaults it to true, so if
+                    // the `verified.contains(bad) -> continue` guard 20 lines up
+                    // is ever loosened (e.g. wiring the mint path) this would
+                    // destroy() the share and chain.remove() would destroy() the
+                    // same pointer again -> the exact tcache/double-free abort.
                     if (verified.contains(bad))
-                        verified.remove(bad);
+                        verified.remove(bad, /*owns_data=*/false);
                     if (chain.remove(bad))
                         ++removed_count;
                 } catch (...) {}

--- a/src/impl/dgb/share_tracker.hpp
+++ b/src/impl/dgb/share_tracker.hpp
@@ -856,8 +856,18 @@ public:
                 // (equivalent to NotImplementedError).
                 try {
                     invalidate_weight_caches(bad);
+                    // #1131 double-free guard: `verified` is a BORROWING view —
+                    // it holds the same raw share pointers `chain` OWNS (every
+                    // node.cpp removal already pairs verified.remove(h, false)
+                    // with chain.remove(h)). Removing from the borrowing view
+                    // must NOT destroy; only the owning chain.remove() below
+                    // may. Omitting owns_data here defaults it to true, so if
+                    // the `verified.contains(bad) -> continue` guard 20 lines up
+                    // is ever loosened (e.g. wiring the mint path) this would
+                    // destroy() the share and chain.remove() would destroy() the
+                    // same pointer again -> the exact tcache/double-free abort.
                     if (verified.contains(bad))
-                        verified.remove(bad);
+                        verified.remove(bad, /*owns_data=*/false);
                     if (chain.remove(bad))
                         ++removed_count;
                 } catch (...) {}

--- a/src/impl/ltc/share_tracker.hpp
+++ b/src/impl/ltc/share_tracker.hpp
@@ -871,8 +871,18 @@ public:
                 // (equivalent to NotImplementedError).
                 try {
                     invalidate_weight_caches(bad);
+                    // #1131 double-free guard: `verified` is a BORROWING view —
+                    // it holds the same raw share pointers `chain` OWNS (every
+                    // node.cpp removal already pairs verified.remove(h, false)
+                    // with chain.remove(h)). Removing from the borrowing view
+                    // must NOT destroy; only the owning chain.remove() below
+                    // may. Omitting owns_data here defaults it to true, so if
+                    // the `verified.contains(bad) -> continue` guard 20 lines up
+                    // is ever loosened (e.g. wiring the mint path) this would
+                    // destroy() the share and chain.remove() would destroy() the
+                    // same pointer again -> the exact tcache/double-free abort.
                     if (verified.contains(bad))
-                        verified.remove(bad);
+                        verified.remove(bad, /*owns_data=*/false);
                     if (chain.remove(bad))
                         ++removed_count;
                 } catch (...) {}

--- a/src/impl/ltc/test/CMakeLists.txt
+++ b/src/impl/ltc/test/CMakeLists.txt
@@ -18,12 +18,16 @@ if (BUILD_TESTING AND GTest_FOUND)
     # measurement that justifies it, and that an all-pass window logs no blocked
     # line and actually activates. Same folding rule: into the existing
     # allowlisted target.
-    add_executable(share_test share_test.cpp f11_donation_invariance_test.cpp emergency_decay_overflow_test.cpp wirecompat_runtime_test.cpp desired_version_tally_test.cpp auto_ratchet_sim_test.cpp auto_ratchet_tail_guard_test.cpp auto_ratchet_blocked_by_test.cpp chain_walk_window_test.cpp doge_template_underfill_test.cpp broadcast_tx_completeness_test.cpp broadcast_lock_discipline_test.cpp compact_block_merkle_test.cpp)
+    add_executable(share_test share_test.cpp f11_donation_invariance_test.cpp emergency_decay_overflow_test.cpp wirecompat_runtime_test.cpp desired_version_tally_test.cpp auto_ratchet_sim_test.cpp auto_ratchet_tail_guard_test.cpp auto_ratchet_blocked_by_test.cpp chain_walk_window_test.cpp doge_template_underfill_test.cpp broadcast_tx_completeness_test.cpp broadcast_lock_discipline_test.cpp compact_block_merkle_test.cpp share_remove_owns_data_test.cpp)
     target_link_libraries(share_test PRIVATE
         GTest::gtest_main GTest::gtest
         core ltc
     )
     target_link_libraries(share_test PRIVATE c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage ltc_coin pool)  # OBJECT-lib SCC direct-naming (#22/#39)
+    # #1131 source-structural KAT: verified.remove(bad) must borrow (owns_data=false),
+    # not own — folded into this EXISTING allowlisted target (no new executable).
+    target_compile_definitions(share_test PRIVATE
+        LTC_SHARE_TRACKER_SRC="${CMAKE_CURRENT_SOURCE_DIR}/../share_tracker.hpp")
 
     include(GoogleTest)
     include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})

--- a/src/impl/ltc/test/share_remove_owns_data_test.cpp
+++ b/src/impl/ltc/test/share_remove_owns_data_test.cpp
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// D-LTC.SHARE-REMOVE-OWNS-DATA — source-structural guard pinning that the
+// think-P1 bad-share removal borrows (owns_data=false) from `verified` and lets
+// only the owning `chain` destroy the share.
+//
+// THE DEFECT THIS PINS (#1131, latent double free):
+//   In ShareTracker::think() the bad-share removal does, per share `bad`:
+//       if (verified.contains(bad)) verified.remove(bad);   // owns_data=TRUE (default)
+//       if (chain.remove(bad))      ++removed_count;         // owns_data=TRUE (default)
+//   `verified` is a BORROWING view — it holds the SAME raw share pointers that
+//   `chain` OWNS (every removal in node.cpp already pairs
+//   verified.remove(h, /*owns_data=*/false) with chain.remove(h)). With the
+//   default owns_data=true, verified.remove() calls share.destroy() -> delete,
+//   then chain.remove() calls destroy() on the SAME pointer again: a double
+//   free / "unaligned tcache chunk" abort, exactly the hotel-primary signature.
+//
+//   It is UNREACHABLE TODAY only because of the `if (verified.contains(bad))
+//   continue;` guard ~20 lines earlier, which makes the inner
+//   `verified.contains(bad)` always false. The moment that guard is loosened
+//   (e.g. wiring the mint path) the landmine arms. The fix pre-arms it: pass
+//   owns_data=false so the borrowing view can never destroy.
+//
+// WHY A STRUCTURAL TEST: the buggy statement is dead code today, so a runtime
+// repro cannot reach it without first perturbing unrelated control flow — the
+// same situation as the sibling latent-UAF race913 (PR #1114) and the #1134
+// oracle-ownership guard (PR #1150). A guard that asserts the OWNERSHIP SHAPE
+// in the shipped source is the deterministic red/green this invariant admits.
+// Restore the bare `verified.remove(bad);` form -> RED; keep the borrowing
+// owns_data=false form -> GREEN.
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#ifndef LTC_SHARE_TRACKER_SRC
+#error "LTC_SHARE_TRACKER_SRC must be defined by CMake to the path of src/impl/ltc/share_tracker.hpp"
+#endif
+
+namespace {
+
+std::string read_text(const char* path)
+{
+    std::ifstream in(path);
+    EXPECT_TRUE(in.good()) << "cannot open " << path;
+    std::stringstream ss; ss << in.rdbuf();
+    return ss.str();
+}
+
+// Replace every comment with spaces, preserving byte offsets and line breaks.
+// The fix's own doc comment deliberately quotes the pre-fix `verified.remove(bad)`
+// expression, so the assertions below MUST run over comment-free code or they
+// would pass against the buggy form for the wrong reason.
+std::string strip_comments(const std::string& s)
+{
+    std::string out = s;
+    enum { kCode, kLine, kBlock, kStr, kChr } st = kCode;
+    for (size_t i = 0; i < out.size(); ++i) {
+        const char c = out[i];
+        const char n = (i + 1 < out.size()) ? out[i + 1] : '\0';
+        switch (st) {
+        case kCode:
+            if (c == '/' && n == '/') { st = kLine;  out[i] = ' '; out[i + 1] = ' '; ++i; }
+            else if (c == '/' && n == '*') { st = kBlock; out[i] = ' '; out[i + 1] = ' '; ++i; }
+            else if (c == '"')  st = kStr;
+            else if (c == '\'') st = kChr;
+            break;
+        case kLine:
+            if (c == '\n') st = kCode; else out[i] = ' ';
+            break;
+        case kBlock:
+            if (c == '*' && n == '/') { out[i] = ' '; out[i + 1] = ' '; ++i; st = kCode; }
+            else if (c != '\n') out[i] = ' ';
+            break;
+        case kStr:
+            if (c == '\\') ++i; else if (c == '"') st = kCode;
+            break;
+        case kChr:
+            if (c == '\\') ++i; else if (c == '\'') st = kCode;
+            break;
+        }
+    }
+    return out;
+}
+
+size_t count_of(const std::string& hay, const std::string& needle)
+{
+    size_t n = 0, pos = 0;
+    while ((pos = hay.find(needle, pos)) != std::string::npos) { ++n; pos += needle.size(); }
+    return n;
+}
+
+// The argument text of a `verified.remove(bad<...>)` call: everything between
+// the first '(' after the match and its matching ')'.
+std::string remove_call_args(const std::string& code)
+{
+    const std::string key = "verified.remove(bad";
+    const size_t k = code.find(key);
+    if (k == std::string::npos) return "";
+    const size_t open = code.find('(', k);
+    if (open == std::string::npos) return "";
+    int depth = 0;
+    for (size_t i = open; i < code.size(); ++i) {
+        if (code[i] == '(') ++depth;
+        else if (code[i] == ')') { if (--depth == 0) return code.substr(open + 1, i - open - 1); }
+    }
+    return "";
+}
+
+} // namespace
+
+// The think-P1 removal block must exist — anchor the assertions to real code.
+TEST(LtcShareRemoveOwnsData, RemovalBlockPresent)
+{
+    const std::string code = strip_comments(read_text(LTC_SHARE_TRACKER_SRC));
+    EXPECT_NE(code.find("if (chain.remove(bad))"), std::string::npos)
+        << "think-P1 bad-share removal block not found — test anchor is stale";
+    EXPECT_GE(count_of(code, "verified.remove(bad"), 1u)
+        << "expected a verified.remove(bad ...) in the removal block";
+}
+
+// #1131: the borrowing view must NEVER be removed-from with the default
+// owns_data=true. The bare `verified.remove(bad)` form (no second argument)
+// destroys a share `chain` also owns -> double free.
+TEST(LtcShareRemoveOwnsData, VerifiedRemoveDoesNotOwnData)
+{
+    const std::string code = strip_comments(read_text(LTC_SHARE_TRACKER_SRC));
+
+    // RED against the shipped bug: exactly the bare, owns_data-defaulted form.
+    EXPECT_EQ(count_of(code, "verified.remove(bad)"), 0u)
+        << "verified.remove(bad) defaults owns_data=true and destroy()s a share "
+           "chain.remove(bad) also owns -> #1131 double free; pass "
+           "/*owns_data=*/false so the borrowing view cannot destroy";
+
+    // GREEN shape: the call carries an explicit second argument, and it is false.
+    const std::string args = remove_call_args(code);
+    ASSERT_FALSE(args.empty()) << "no verified.remove(bad ...) call found";
+    EXPECT_NE(args.find(','), std::string::npos)
+        << "verified.remove(bad ...) must pass an explicit owns_data argument";
+    EXPECT_NE(args.find("false"), std::string::npos)
+        << "verified is a borrowing view — owns_data must be false";
+    EXPECT_EQ(args.find("true"), std::string::npos)
+        << "owns_data=true on a borrowing view double-frees with chain.remove()";
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -299,7 +299,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     # weight ring buffer (compute_v36_weights), decay table, donation split,
     # window slides. PoW-independent consensus core; socket-free, chain-free.
     # Mirrors the test_dash_conformance link set.
-    add_executable(test_dash_share_tracker test_dash_share_tracker.cpp)
+    add_executable(test_dash_share_tracker test_dash_share_tracker.cpp test_dash_share_remove_owns_data.cpp)
     target_link_libraries(test_dash_share_tracker PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core
@@ -307,6 +307,8 @@ if (BUILD_TESTING AND GTest_FOUND)
         ${Boost_LIBRARIES}
     )
     target_link_libraries(test_dash_share_tracker PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39): core stratum/web_server TUs
+    target_compile_definitions(test_dash_share_tracker PRIVATE  # #1131 source-structural KAT: borrow, don't own, on verified.remove(bad)
+        DASH_SHARE_TRACKER_SRC="${CMAKE_CURRENT_SOURCE_DIR}/../src/impl/dash/share_tracker.hpp")
     gtest_add_tests(test_dash_share_tracker "" AUTO)
 
     # DASH S8 pool-node leaf 5 (FINAL) slice A — node.hpp skeleton KAT: NodeImpl

--- a/test/test_dash_share_remove_owns_data.cpp
+++ b/test/test_dash_share_remove_owns_data.cpp
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// D-DASH.SHARE-REMOVE-OWNS-DATA — source-structural guard pinning that the
+// think-P1 bad-share removal borrows (owns_data=false) from `verified` and lets
+// only the owning `chain` destroy the share.
+//
+// THE DEFECT THIS PINS (#1131, latent double free):
+//   In ShareTracker::think() the bad-share removal does, per share `bad`:
+//       if (verified.contains(bad)) verified.remove(bad);   // owns_data=TRUE (default)
+//       if (chain.remove(bad))      ++removed_count;         // owns_data=TRUE (default)
+//   `verified` is a BORROWING view — it holds the SAME raw share pointers that
+//   `chain` OWNS (every removal in node.cpp already pairs
+//   verified.remove(h, /*owns_data=*/false) with chain.remove(h)). With the
+//   default owns_data=true, verified.remove() calls share.destroy() -> delete,
+//   then chain.remove() calls destroy() on the SAME pointer again: a double
+//   free / "unaligned tcache chunk" abort, exactly the hotel-primary signature.
+//
+//   It is UNREACHABLE TODAY only because of the `if (verified.contains(bad))
+//   continue;` guard ~20 lines earlier, which makes the inner
+//   `verified.contains(bad)` always false. The moment that guard is loosened
+//   (e.g. wiring the mint path) the landmine arms. The fix pre-arms it: pass
+//   owns_data=false so the borrowing view can never destroy.
+//
+// WHY A STRUCTURAL TEST: the buggy statement is dead code today, so a runtime
+// repro cannot reach it without first perturbing unrelated control flow — the
+// same situation as the sibling latent-UAF race913 (PR #1114) and the #1134
+// oracle-ownership guard (PR #1150). A guard that asserts the OWNERSHIP SHAPE
+// in the shipped source is the deterministic red/green this invariant admits.
+// Restore the bare `verified.remove(bad);` form -> RED; keep the borrowing
+// owns_data=false form -> GREEN.
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#ifndef DASH_SHARE_TRACKER_SRC
+#error "DASH_SHARE_TRACKER_SRC must be defined by CMake to the path of src/impl/dash/share_tracker.hpp"
+#endif
+
+namespace {
+
+std::string read_text(const char* path)
+{
+    std::ifstream in(path);
+    EXPECT_TRUE(in.good()) << "cannot open " << path;
+    std::stringstream ss; ss << in.rdbuf();
+    return ss.str();
+}
+
+// Replace every comment with spaces, preserving byte offsets and line breaks.
+// The fix's own doc comment deliberately quotes the pre-fix `verified.remove(bad)`
+// expression, so the assertions below MUST run over comment-free code or they
+// would pass against the buggy form for the wrong reason.
+std::string strip_comments(const std::string& s)
+{
+    std::string out = s;
+    enum { kCode, kLine, kBlock, kStr, kChr } st = kCode;
+    for (size_t i = 0; i < out.size(); ++i) {
+        const char c = out[i];
+        const char n = (i + 1 < out.size()) ? out[i + 1] : '\0';
+        switch (st) {
+        case kCode:
+            if (c == '/' && n == '/') { st = kLine;  out[i] = ' '; out[i + 1] = ' '; ++i; }
+            else if (c == '/' && n == '*') { st = kBlock; out[i] = ' '; out[i + 1] = ' '; ++i; }
+            else if (c == '"')  st = kStr;
+            else if (c == '\'') st = kChr;
+            break;
+        case kLine:
+            if (c == '\n') st = kCode; else out[i] = ' ';
+            break;
+        case kBlock:
+            if (c == '*' && n == '/') { out[i] = ' '; out[i + 1] = ' '; ++i; st = kCode; }
+            else if (c != '\n') out[i] = ' ';
+            break;
+        case kStr:
+            if (c == '\\') ++i; else if (c == '"') st = kCode;
+            break;
+        case kChr:
+            if (c == '\\') ++i; else if (c == '\'') st = kCode;
+            break;
+        }
+    }
+    return out;
+}
+
+size_t count_of(const std::string& hay, const std::string& needle)
+{
+    size_t n = 0, pos = 0;
+    while ((pos = hay.find(needle, pos)) != std::string::npos) { ++n; pos += needle.size(); }
+    return n;
+}
+
+// The argument text of a `verified.remove(bad<...>)` call: everything between
+// the first '(' after the match and its matching ')'.
+std::string remove_call_args(const std::string& code)
+{
+    const std::string key = "verified.remove(bad";
+    const size_t k = code.find(key);
+    if (k == std::string::npos) return "";
+    const size_t open = code.find('(', k);
+    if (open == std::string::npos) return "";
+    int depth = 0;
+    for (size_t i = open; i < code.size(); ++i) {
+        if (code[i] == '(') ++depth;
+        else if (code[i] == ')') { if (--depth == 0) return code.substr(open + 1, i - open - 1); }
+    }
+    return "";
+}
+
+} // namespace
+
+// The think-P1 removal block must exist — anchor the assertions to real code.
+TEST(DashShareRemoveOwnsData, RemovalBlockPresent)
+{
+    const std::string code = strip_comments(read_text(DASH_SHARE_TRACKER_SRC));
+    EXPECT_NE(code.find("if (chain.remove(bad))"), std::string::npos)
+        << "think-P1 bad-share removal block not found — test anchor is stale";
+    EXPECT_GE(count_of(code, "verified.remove(bad"), 1u)
+        << "expected a verified.remove(bad ...) in the removal block";
+}
+
+// #1131: the borrowing view must NEVER be removed-from with the default
+// owns_data=true. The bare `verified.remove(bad)` form (no second argument)
+// destroys a share `chain` also owns -> double free.
+TEST(DashShareRemoveOwnsData, VerifiedRemoveDoesNotOwnData)
+{
+    const std::string code = strip_comments(read_text(DASH_SHARE_TRACKER_SRC));
+
+    // RED against the shipped bug: exactly the bare, owns_data-defaulted form.
+    EXPECT_EQ(count_of(code, "verified.remove(bad)"), 0u)
+        << "verified.remove(bad) defaults owns_data=true and destroy()s a share "
+           "chain.remove(bad) also owns -> #1131 double free; pass "
+           "/*owns_data=*/false so the borrowing view cannot destroy";
+
+    // GREEN shape: the call carries an explicit second argument, and it is false.
+    const std::string args = remove_call_args(code);
+    ASSERT_FALSE(args.empty()) << "no verified.remove(bad ...) call found";
+    EXPECT_NE(args.find(','), std::string::npos)
+        << "verified.remove(bad ...) must pass an explicit owns_data argument";
+    EXPECT_NE(args.find("false"), std::string::npos)
+        << "verified is a borrowing view — owns_data must be false";
+    EXPECT_EQ(args.find("true"), std::string::npos)
+        << "owns_data=true on a borrowing view double-frees with chain.remove()";
+}


### PR DESCRIPTION
Fixes #1131 (latent double free). Base `master`. **do-not-merge** until reviewed.

## The defect
`ShareTracker::think()`'s bad-share removal removed each share from the borrowing `verified` view with the default `owns_data=true`:

```cpp
if (verified.contains(bad)) verified.remove(bad);   // destroy() -> delete
if (chain.remove(bad))      ++removed_count;         // destroy() the SAME ptr again
```

`verified` is a **borrowing** view holding the same raw share pointers `chain` **owns** — every removal in `node.cpp` already pairs `verified.remove(h, /*owns_data=*/false)` with `chain.remove(h)`. Only these in-tracker copies omitted it. With `owns_data` defaulting to `true`, `verified.remove()` calls `share.destroy()` → `delete`, then `chain.remove()` `destroy()`s the same pointer again: a double free / "unaligned tcache chunk" abort.

Unreachable **today** only because the `if (verified.contains(bad)) continue;` guard ~20 lines earlier makes the inner `verified.contains(bad)` always false — so `verified.remove()` is dead code. The moment that guard is loosened (e.g. wiring the mint path, the #941/#1129 cluster) the landmine arms. This pre-arms it.

## Scope correction
The issue reported **three** omitting copies; there are in fact **five** — dash, btc, ltc, **dgb, bch** all carry the identical loop (`grep -n "verified.remove(bad)"`). Each lane's `node.cpp` already establishes the borrow/own contract with explicit `owns_data=false` on its `verified.remove`, confirming the intended ownership. The one-token fix is applied to **all five** source sites; leaving dgb/bch would keep the same landmine.

## Fix
`verified.remove(bad, /*owns_data=*/false)` at all five sites, matching every `node.cpp` caller.

## Test — source-structural red/green KAT
The buggy statement is dead code today, so a runtime repro cannot reach it without perturbing unrelated control flow. This is the same situation as the sibling latent-UAF `race913_lock_guard_test.cpp` (#1114) and the #1134 oracle-ownership guard (#1150); the deterministic red/green the invariant admits is a source-structural guard. It reads the shipped `share_tracker.hpp`, **strips comments** (the fix's own doc comment quotes the pre-fix expression, so raw grep would be fooled), and asserts `verified.remove(bad ...)` carries an explicit `owns_data=false`.

- Verified locally against the pre-fix source → **RED** (`bare_count=1`, args `"bad"`), and post-fix → **GREEN** (args `"bad, /*owns_data=*/false"`), on all five lanes.
- Wired into the **already-allowlisted** targets `test_dash_share_tracker` / `btc_share_test` / `share_test` (ltc) — added as source files to existing executables, so **no new target and no `build.yml` `--target` change** (avoids the #143 NOT_BUILT trap). Test-allowlist drift-guard passes locally. No `#ifdef` (#895).

KATs cover dash/btc/ltc as scoped; dgb/bch received the source fix and warrant mirror KATs in follow-up (their `dgb_share_test` target is equally allowlisted).

## What this is NOT
Not the root cause of the 2026-08-05 hotel crash (that is #1134, the `EmbeddedOracleShadow` cross-thread `NodeCoinState` read, fixed in #1150). This is a separate latent landmine surfaced during the same investigation.
