### PR TITLE
dash: LlmqTypeReconciler mode 3 — UnexpectedType requires a scanner-dated sighting; restart cannot resurrect an undated-entry alarm

### DIFF
--- a/src/impl/dash/coin/llmq_type_reconciler.hpp
+++ b/src/impl/dash/coin/llmq_type_reconciler.hpp
@@ -105,6 +105,21 @@
 ///      more than one DKG cycle the verdict decays to StaleSightings — a
 ///      named non-defect — and the alarm CLEARS. A genuinely mined type
 ///      keeps producing in-retention entries, so its alarm never decays.
+///
+///   3. RESTART RESURRECTION OF AN UNDATED ENTRY (measured 2026-08-06, hotel
+///      reserve node, issue #1164): mode 2's first-seen dating lives in
+///      memory, so a process restart re-dates every scanner-undated entry as
+///      fresh — and a bogus never-mined entry that mnlistdiff/qrinfo keeps
+///      delivering (a full-span chain sweep showed ZERO type-1 commitments
+///      on-chain while the alarm cited that exact span) rings for a whole
+///      retention window (576 blocks for type 1) after EVERY restart,
+///      indefinitely. The fix is evidentiary, not another timer: the
+///      UnexpectedType indictment now requires at least one sighting whose
+///      entry the [QC-MINED] scanner actually dated (mined_height known).
+///      DELIVERY IS NOT MINING. A genuinely upstream-added type is mined
+///      every cycle and gets scanner-dated within one, so the real defect
+///      still fires; an entry no one can date stays Unevaluated with reason
+///      "delivered-but-never-scanner-dated" — visible, never alarming.
 
 #include <impl/dash/coin/dkg_commitments.hpp>
 #include <impl/dash/coin/quorum_manager.hpp>
@@ -261,9 +276,11 @@ public:
         if (tip_height > m_last_height) m_last_height = tip_height;
 
         std::set<uint8_t> present;   // types with >=1 IN-RETENTION entry
+        std::set<uint8_t> confirmed; // ...of which >=1 is scanner-dated
         std::map<std::pair<uint8_t, uint256>, uint32_t> first_seen_next;
         for (const auto& e : entries) {
             uint32_t own_h = e.mined_height;
+            const bool scanner_dated = (own_h != 0);
             if (own_h == 0 && !e.quorum_hash.IsNull()) {
                 const auto key = std::make_pair(e.llmq_type, e.quorum_hash);
                 auto it = m_first_seen.find(key);
@@ -278,6 +295,7 @@ public:
                 && tip_height - own_h > retention_for(e.llmq_type))
                 continue;                          // aged out — NOT a sighting
             present.insert(e.llmq_type);
+            if (scanner_dated) confirmed.insert(e.llmq_type);
         }
         // Records for entries no longer served are dropped here, bounding the
         // map by the live active-set size. If such an entry ever reappears it
@@ -290,6 +308,11 @@ public:
             if (s.first_height == 0 || tip_height < s.first_height)
                 s.first_height = tip_height;
             if (tip_height > s.last_height) s.last_height = tip_height;
+            if (confirmed.count(t)) {
+                ++s.scanner_confirmed;
+                if (tip_height > s.last_confirmed_height)
+                    s.last_confirmed_height = tip_height;
+            }
         }
     }
 
@@ -412,6 +435,21 @@ public:
                 // current disagreement with the chain.
                 f.verdict = LlmqTypeVerdict::StaleSightings;
                 f.pending_reason = "n/a";
+            } else if (s.scanner_confirmed == 0) {
+                // MODE 3 (measured 2026-08-06, hotel reserve node): the entry
+                // is SERVED (mnlistdiff/qrinfo delivered it) but the
+                // [QC-MINED] scanner has never dated its qfcommit, and a
+                // full-span chain sweep showed ZERO commitments of the type
+                // on-chain. Delivery is not mining. Without one scanner-dated
+                // entry the "MINED"-but-not-required indictment has no mined
+                // evidence at all — and because this reconciler is in-memory,
+                // every restart re-dated the undated entry as fresh and the
+                // alarm resurrected for a whole retention window (576 blocks
+                // for type 1), surviving restarts indefinitely. A genuinely
+                // upstream-added type is mined every cycle, so the scanner
+                // dates it within one cycle and the indictment still fires.
+                f.verdict = LlmqTypeVerdict::Unevaluated;
+                f.pending_reason = "delivered-but-never-scanner-dated";
             } else {
                 f.verdict = LlmqTypeVerdict::UnexpectedType;
                 f.pending_reason = "n/a";
@@ -515,6 +553,11 @@ private:
         uint64_t sightings{0};
         uint32_t first_height{0};
         uint32_t last_height{0};
+        /// Sightings backed by an entry whose qfcommit the [QC-MINED] scanner
+        /// actually dated (mined_height known). Only these can indict an
+        /// UnexpectedType — see mode 3 in the header.
+        uint64_t scanner_confirmed{0};
+        uint32_t last_confirmed_height{0};
     };
 
     LlmqNetwork m_net;

--- a/test/test_dash_dkg_commitments.cpp
+++ b/test/test_dash_dkg_commitments.cpp
@@ -1576,14 +1576,19 @@ TEST(DashLlmqTypeReconciler, UndatableStaleEntryAgesOutAndTheAlarmClears)
     LlmqTypeReconciler r(LlmqNetwork::Mainnet);
     for (uint32_t h = kT0; h <= kT0 + 300u; ++h) r.observe(h, qmgr);
 
-    // While the undatable entry is inside the retention window measured from
-    // first sight it is INDISTINGUISHABLE from a freshly mined quorum, and
-    // the honest verdict is the alarm. This is not a regression — it is the
-    // backstop refusing to be blinded by a missing datum.
+    // SEMANTICS SHARPENED for issue #1164 (mode 3): while the undatable entry
+    // is inside the retention window it is served but the [QC-MINED] scanner
+    // has never dated ANY commitment of its type — delivery is not mining, so
+    // the honest verdict is now Unevaluated with the reason named, NOT the
+    // alarm. (The old in-retention alarm survived every RESTART indefinitely
+    // in production, because first-seen dating is in-memory — see the
+    // RestartCannotResurrect test below.)
     {
         auto f = finding_for(r.reconcile(), 1);
         ASSERT_TRUE(f.has_value());
-        EXPECT_EQ(f->verdict, LlmqTypeVerdict::UnexpectedType);
+        EXPECT_EQ(f->verdict, LlmqTypeVerdict::Unevaluated);
+        EXPECT_STREQ(f->pending_reason, "delivered-but-never-scanner-dated");
+        EXPECT_TRUE(r.defects().empty()) << r.format_defects();
     }
 
     // ...but past first-sight + retention the entry ages out: sightings stop.
@@ -1602,6 +1607,47 @@ TEST(DashLlmqTypeReconciler, UndatableStaleEntryAgesOutAndTheAlarmClears)
     EXPECT_LT(f->sightings, r.observations());
     EXPECT_EQ(f->sightings, 577u);              // kT0 .. kT0+576 inclusive
     EXPECT_EQ(f->last_height, kT0 + 576u);
+}
+
+TEST(DashLlmqTypeReconciler, RestartCannotResurrectAnUndatedEntryAlarm)
+{
+    // MODE 3 — the shape MEASURED on the hotel reserve node (issue #1164).
+    // The reconciler is in-memory: a restart empties first-seen dating, so a
+    // never-mined entry that mnlistdiff keeps delivering was re-dated fresh
+    // by every NEW process and rang MINED-BUT-NOT-REQUIRED for a whole
+    // retention window after EVERY restart — the alarm survived restarts
+    // indefinitely while a full-span chain sweep showed ZERO commitments of
+    // the type on-chain. With the scanner-confirmation gate the indictment
+    // needs at least one scanner-dated entry, which a never-mined type can
+    // never produce — in the first process, or any process after it.
+    constexpr uint32_t kT0 = 1'950'000u;
+    QuorumManager qmgr;
+    add_required_mainnet_entries(qmgr, 0x60);   // undated (mining_height 0)
+    vendor::QuorumTail tail;
+    tail.newQuorums.push_back(real_commitment(kLlmq50_60, h256(0x91), 0, 0x91));
+    qmgr.apply(tail);                            // type 1, never scanner-dated
+
+    // Process 1: a full retention window of observation. No defect, and the
+    // reason is named rather than silently fine.
+    {
+        LlmqTypeReconciler r(LlmqNetwork::Mainnet);
+        for (uint32_t h = kT0; h <= kT0 + 600u; ++h) r.observe(h, qmgr);
+        EXPECT_TRUE(r.defects().empty()) << r.format_defects();
+    }
+
+    // "Restart": a fresh reconciler over the SAME still-served entry, at the
+    // heights where the next process would resume. Pre-fix this rang for
+    // another 576 blocks; now it must stay silent, with the same named
+    // reason, for as many restarts as ever happen.
+    LlmqTypeReconciler r2(LlmqNetwork::Mainnet);
+    for (uint32_t h = kT0 + 601u; h <= kT0 + 1'200u; ++h) r2.observe(h, qmgr);
+    EXPECT_TRUE(r2.defects().empty())
+        << "restart resurrected the undated-entry alarm: "
+        << r2.format_defects();
+    auto f = finding_for(r2.reconcile(), 1);
+    ASSERT_TRUE(f.has_value());
+    EXPECT_EQ(f->verdict, LlmqTypeVerdict::Unevaluated);
+    EXPECT_STREQ(f->pending_reason, "delivered-but-never-scanner-dated");
 }
 
 TEST(DashLlmqTypeReconciler, GenuinelyMinedUnexpectedTypeStillAlarms)


### PR DESCRIPTION
Fixes the live half of #1164.

## The measured defect (hotel reserve node, 2026-08-06)
`[LLMQ-TYPE-RECONCILE] type=1 MINED-BUT-NOT-REQUIRED` rang continuously ACROSS process restarts (first 2026-08-05 12:44; still ringing after the 06:41 restart; observations=119k over span=90b) — while a full dashd sweep of the exact cited span 2517120–2517210 shows the chain mined types 5(x40)/4(x9)/3(x2)/2(x2) and **zero type-1 commitments**.

The #1103 mode-2 fix WAS in the running binary. Its first-seen dating is in-memory: every restart re-dates a still-served, never-mined entry as fresh, and the alarm resurrects for a full retention window (576 blocks for type 1) — indefinitely, since mnlistdiff keeps delivering the entry.

## The fix — evidentiary, not another timer
Delivery is not mining. The `UnexpectedType` indictment now requires at least one sighting whose entry the [QC-MINED] scanner actually dated (`mined_height` known). A genuinely upstream-added type is mined every DKG cycle and gets scanner-dated within one — the real bad-qc-missing backstop still fires (pinned by `GenuinelyMinedUnexpectedTypeStillAlarms`, unchanged). An entry no scanner can date stays `Unevaluated` with `pending_reason=delivered-but-never-scanner-dated` — visible, never alarming.

## Red/green
- RED on master's engine: the new `RestartCannotResurrectAnUndatedEntryAlarm` fails with the exact production alarm text ("type=1 MINED-BUT-NOT-REQUIRED ... sightings=577").
- GREEN with the fix: all 11 `DashLlmqTypeReconciler` tests pass, including the unchanged genuine-mined backstop and both #1103 regression pins. `UndatableStaleEntryAgesOutAndTheAlarmClears` is sharpened: the in-retention verdict for a scanner-undated entry is now the named Unevaluated instead of the alarm (its aging-out tail and sightings-freeze assertions are unchanged).

## What this PR does NOT do
- The per-submit log flood on the hotel is ALREADY fixed on master (defect_shape dedup + 5-min re-assert, f5588fd6) — the hotel binary just predates it; the next deploy carries it.
- The remaining open question of #1164 — WHICH source (mnlistdiff vs qrinfo, and which peer/daemon) keeps delivering a never-mined type-1 entry — is not answered here; the reconciler now refuses to be fooled by it either way. Left open in the issue.