### PR TITLE
dash: --pin-local-tx-hex — zero-fee operator tx rides our own embedded template (donation-dust consolidation lane)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -384,6 +384,7 @@ void print_banner(const char* argv0)
         << "           [--embedded-utxo] [--embedded-mainnet] [--embedded-mn-bridge-max N]\n"
         << "           [--embedded-mn-bridge-no-cursor]\n"
         << "           [--embedded-utxo-immature-serve-empty] [--embedded-serve-mempool-txs]\n"
+        << "           [--pin-local-tx-hex FILE]  (zero-fee self-mined tx, e.g. donation consolidation)\n"
         << "           [--bestcl-policy freshness|consensus-exact]\n"
         << "           [--embedded-oracle-shadow]\n"
         << "           [--embedded-shadow-compare]\n"
@@ -755,7 +756,17 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              // itself put a single transaction into a served template — that
              // remains --embedded-serve-mempool-txs' decision, gated on the
              // [SHADOW-TXSET] coverage series.
-             bool embedded_mempool_ingest = false)
+             bool embedded_mempool_ingest = false,
+             // --pin-local-tx-hex <file>: PINNED LOCAL TX (donation-dust
+             // consolidation). File holds the hex of an externally-signed,
+             // ZERO-fee tx spending our own P2PKH outputs; it rides OUR OWN
+             // embedded template (relay rejects 0-fee, so self-mining is its
+             // only chain-ward path). Parsed once here; per-template admission
+             // (inputs unspent + coinbase-mature + fee exactly 0) is re-gated
+             // in the builder against the live UTXO view — a bad or already-
+             // mined pin is EXCLUDED, never a refused template, never a lost
+             // block. Empty (default) = no pin, byte-unchanged.
+             const std::string& pin_local_tx_hex_path = std::string())
 {
     namespace io = boost::asio;
 
@@ -1996,6 +2007,49 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                       : "OFF (default: coinbase-only body, cause="
                         "mempool-txs-disabled; fees forgone, values exact)")
               << "\n";
+
+    // ── Pinned local tx (--pin-local-tx-hex): parse + park in NodeCoinState.
+    if (!pin_local_tx_hex_path.empty()) {
+        std::ifstream pf(pin_local_tx_hex_path);
+        std::string pin_hex((std::istreambuf_iterator<char>(pf)),
+                            std::istreambuf_iterator<char>());
+        // strip whitespace/newlines
+        pin_hex.erase(std::remove_if(pin_hex.begin(), pin_hex.end(),
+                                     [](unsigned char c) { return std::isspace(c); }),
+                      pin_hex.end());
+        bool pin_ok = !pin_hex.empty() && pin_hex.size() % 2 == 0;
+        MutableTransaction pin_tx;
+        if (pin_ok) {
+            try {
+                auto raw = ParseHex(pin_hex);
+                PackStream ps(raw);
+                ps >> pin_tx;
+                // classic tx only: a special-type (extra_payload) pin would
+                // interact with the CbTx roots the template commits — refuse
+                // at load, loudly, rather than gate per template.
+                pin_ok = pin_tx.type == 0
+                         && !pin_tx.vin.empty() && !pin_tx.vout.empty();
+            } catch (const std::exception& e) {
+                std::cout << "[run] --pin-local-tx-hex PARSE FAILED (" << e.what()
+                          << ") — pin DISABLED\n";
+                pin_ok = false;
+            }
+        }
+        if (pin_ok) {
+            node_coin_state.set_pinned_local_tx(pin_tx);
+            std::cout << "[run] pinned local tx ARMED: "
+                      << dash::coin::dash_txid(pin_tx).GetHex()
+                      << " vin=" << pin_tx.vin.size()
+                      << " vout=" << pin_tx.vout.size()
+                      << " (admission re-gated per template: inputs unspent,"
+                      << " coinbase-mature, fee==0; excluded-not-refused on"
+                      << " failure; auto-retires once mined)\n";
+        } else {
+            std::cout << "[run] --pin-local-tx-hex: file empty/unreadable/"
+                      << "invalid (" << pin_local_tx_hex_path
+                      << ") — pin DISABLED\n";
+        }
+    }
 
     // ── E2b (#738): the embedded UTXO/fee lane -- OPT-IN via --embedded-utxo.
     // Transliterated from the PROVEN LTC wiring (main_ltc.cpp ~1750-1801 con-
@@ -6626,6 +6680,7 @@ int main(int argc, char** argv)
     // DASH_CONNECTBLOCK_REJECT_SURFACE_AUDIT.md) arms only on explicit
     // operator decision.
     bool embedded_serve_mempool_txs = false;
+    std::string pin_local_tx_hex_path;
     // --embedded-mempool-ingest: arm the coin-P2P MSG_TX pull (phase 1).
     // SEPARATE from --embedded-serve-mempool-txs on purpose: this only makes
     // the mempool FILL. Whether its contents ever reach a served template is
@@ -6725,6 +6780,8 @@ int main(int argc, char** argv)
             embedded_serve_mempool_txs = true;
         else if (std::strcmp(argv[i], "--embedded-mempool-ingest") == 0)
             embedded_mempool_ingest = true;
+        else if (std::strcmp(argv[i], "--pin-local-tx-hex") == 0 && i + 1 < argc)
+            pin_local_tx_hex_path = argv[++i];
         else if (std::strcmp(argv[i], "--replay-utxo-db") == 0 && i + 1 < argc)
             replay_utxo_db = argv[++i];
         else if (std::strcmp(argv[i], "--replay-utxo-hash") == 0)
@@ -6990,7 +7047,8 @@ int main(int argc, char** argv)
                         embedded_utxo_immature_serve_empty,
                         embedded_serve_mempool_txs,
                         embedded_shadow_compare,
-                        embedded_mempool_ingest);
+                        embedded_mempool_ingest,
+                        pin_local_tx_hex_path);
     }
     return run_selftest();
 }

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -2018,7 +2018,7 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                      [](unsigned char c) { return std::isspace(c); }),
                       pin_hex.end());
         bool pin_ok = !pin_hex.empty() && pin_hex.size() % 2 == 0;
-        MutableTransaction pin_tx;
+        dash::coin::MutableTransaction pin_tx;
         if (pin_ok) {
             try {
                 auto raw = ParseHex(pin_hex);

--- a/src/impl/dash/coin/embedded_gbt.hpp
+++ b/src/impl/dash/coin/embedded_gbt.hpp
@@ -193,7 +193,20 @@ inline DashWorkData build_embedded_workdata(
     // default-OFF posture ("mempool-txs-disabled", node_coin_state.hpp). The
     // cause rides the template (m_txset_empty_cause) + the log line, so soaks
     // can tell the two coinbase-only modes apart.
-    const char* txset_empty_cause = "utxo-immature-serving")
+    const char* txset_empty_cause = "utxo-immature-serving",
+    // ── PINNED LOCAL TX seam (donation-dust consolidation lane) ──────────
+    // An operator-supplied, externally-signed, ZERO-fee tx that can only
+    // reach the chain through OUR OWN block (relay rejects 0-fee). Included
+    // right after the mandatory type-6 commitments when — and only when —
+    // Mempool::pinned_tx_admissible() passes against the live UTXO view; on
+    // ANY failure the tx is EXCLUDED and the template is built exactly as if
+    // no pin existed (a bad pinned tx must never cost a block, and must
+    // never refuse a template). Fee is 0 by the gate's contract, so
+    // total_fees / block_value / mn_payment stay exact untouched. Rides
+    // regardless of suppress_mempool_txs — the coinbase-only posture is
+    // about MEMPOOL selection; the pin is not a mempool tx.
+    // Default nullptr => every existing positional caller byte-unchanged.
+    const MutableTransaction* pinned_local_tx = nullptr)
 {
     DashWorkData w;
     w.m_height          = prev_height + 1;
@@ -342,6 +355,39 @@ inline DashWorkData build_embedded_workdata(
             w.m_tx_hashes.push_back(dash::coin::dash_txid(qtx));
             w.m_tx_fees.push_back(0);
             w.m_tx_data_hex.push_back(tx_hex(qtx));
+        }
+    }
+    // ── PINNED LOCAL TX — after the consensus-required type-6 set, before
+    // mempool selection. Gate re-checked on EVERY build: inputs unspent,
+    // coinbase-mature at THIS height, fee exactly zero. Exclusion is the
+    // only failure mode (see the parameter note); the MN-collateral filter
+    // applies here too — a pinned tx spending a collateral would poison the
+    // committed merkleRootMNList exactly like a selected one.
+    if (pinned_local_tx != nullptr) {
+        const auto gate = mempool.pinned_tx_admissible(*pinned_local_tx,
+                                                       w.m_height);
+        uint256 protx;
+        if (gate != Mempool::PinnedTxGate::Ok) {
+            LOG_INFO << "[GBT-EMB] pinned tx EXCLUDED h=" << w.m_height
+                     << " cause=" << Mempool::pinned_gate_name(gate)
+                     << " txid=" << dash::coin::dash_txid(*pinned_local_tx)
+                            .GetHex().substr(0, 16)
+                     << " (template built without it; re-checked next build)";
+        } else if (tx_spends_mn_collateral(mnstates, *pinned_local_tx,
+                                           &protx)) {
+            LOG_WARNING << "[GBT-EMB] pinned tx EXCLUDED h=" << w.m_height
+                        << " cause=spends-mn-collateral MN "
+                        << protx.GetHex().substr(0, 16);
+        } else {
+            w.m_txs.emplace_back(*pinned_local_tx);
+            w.m_tx_hashes.push_back(dash::coin::dash_txid(*pinned_local_tx));
+            w.m_tx_fees.push_back(0);
+            w.m_tx_data_hex.push_back(tx_hex(*pinned_local_tx));
+            LOG_INFO << "[GBT-EMB] pinned tx INCLUDED h=" << w.m_height
+                     << " txid=" << dash::coin::dash_txid(*pinned_local_tx)
+                            .GetHex().substr(0, 16)
+                     << " vin=" << pinned_local_tx->vin.size()
+                     << " fee=0 (rides this template)";
         }
     }
     uint64_t selected_bytes = 0;  // wire bytes packed into this template (underfill guard)

--- a/src/impl/dash/coin/mempool.hpp
+++ b/src/impl/dash/coin/mempool.hpp
@@ -135,6 +135,62 @@ public:
 
     void set_utxo(::core::coin::UTXOViewCache* u) { m_utxo.store(u); }
 
+    /// ── PINNED-LOCAL-TX include gate (donation-dust consolidation lane) ────
+    /// A pinned tx is an operator-supplied, externally-signed, ZERO-fee
+    /// transaction that rides OUR OWN block template (relay rejects 0-fee, so
+    /// self-mining is its only chain-ward path). A bad pinned tx would make
+    /// the whole found block invalid — a lost block — so admission is checked
+    /// against the live UTXO view on EVERY template build and the tx is
+    /// EXCLUDED (never the template refused) on any failure:
+    ///   * every input must exist unspent in our UTXO view;
+    ///   * a coinbase-output input must be MATURE at the template height
+    ///     (100 confs — donation outputs ARE coinbase outputs, so the newest
+    ///     ones are immature for ~4.5 h after their block; the tx self-heals
+    ///     into templates once they mature);
+    ///   * inputs minus outputs must equal EXACTLY ZERO — this lane's
+    ///     contract. Nonzero means the snapshot the tx was built from has
+    ///     drifted (or the wrong tx was pinned); negative would be
+    ///     consensus-invalid (bad-txns-in-belowout) outright.
+    /// Once mined, the inputs leave the UTXO set and the gate excludes the tx
+    /// forever after — no explicit "done" state is needed.
+    enum class PinnedTxGate : uint8_t {
+        Ok = 0,
+        UtxoViewUnset,          // no UTXO view wired yet (cold start)
+        InputMissingOrSpent,    // an input is not an unspent coin we know
+        ImmatureCoinbaseInput,  // a coinbase-output input below 100 confs
+        FeeNotZero,             // sum(in) - sum(out) != 0: snapshot drift
+    };
+    static const char* pinned_gate_name(PinnedTxGate g) {
+        switch (g) {
+            case PinnedTxGate::Ok:                    return "ok";
+            case PinnedTxGate::UtxoViewUnset:         return "utxo-view-unset";
+            case PinnedTxGate::InputMissingOrSpent:   return "input-missing-or-spent";
+            case PinnedTxGate::ImmatureCoinbaseInput: return "immature-coinbase-input";
+            case PinnedTxGate::FeeNotZero:            return "fee-not-zero";
+        }
+        return "ok";
+    }
+    PinnedTxGate pinned_tx_admissible(const MutableTransaction& tx,
+                                      uint32_t next_height) const {
+        auto* utxo = m_utxo.load();
+        if (utxo == nullptr) return PinnedTxGate::UtxoViewUnset;
+        constexpr uint32_t kCoinbaseMaturity = 100;
+        int64_t in_value = 0;
+        for (const auto& vin : tx.vin) {
+            ::core::coin::Coin coin;
+            ::core::coin::Outpoint op{vin.prevout.hash, vin.prevout.index};
+            if (!utxo->get_coin(op, coin) || coin.is_spent())
+                return PinnedTxGate::InputMissingOrSpent;
+            if (coin.coinbase && next_height < coin.height + kCoinbaseMaturity)
+                return PinnedTxGate::ImmatureCoinbaseInput;
+            in_value += coin.value;
+        }
+        int64_t out_value = 0;
+        for (const auto& vout : tx.vout) out_value += vout.value;
+        if (in_value - out_value != 0) return PinnedTxGate::FeeNotZero;
+        return PinnedTxGate::Ok;
+    }
+
     // ── Mutation ────────────────────────────────────────────────────
 
     /// Add a transaction. Returns false if already known. When `utxo`

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -478,6 +478,18 @@ public:
     void set_serve_mempool_txs(bool on) { m_serve_mempool_txs = on; }
     bool serve_mempool_txs() const { return m_serve_mempool_txs; }
 
+    /// PINNED LOCAL TX (--pin-local-tx-hex, donation-dust consolidation): an
+    /// operator-supplied, externally-signed, zero-fee tx that can only reach
+    /// the chain through OUR OWN block. Stored by value; the work-inputs
+    /// bundle hands the builder a pointer, and the builder re-gates admission
+    /// against the live UTXO view on every template
+    /// (Mempool::pinned_tx_admissible) — exclusion-only failure, never a
+    /// template refusal. Call on the io thread before serving starts.
+    void set_pinned_local_tx(MutableTransaction tx) {
+        m_pinned_local_tx = std::move(tx);
+        m_have_pinned_local_tx = true;
+    }
+
     /// Superblock-height guard. On a Dash superblock height the coinbase MUST
     /// pay the governance/treasury (superblock) outputs; the embedded template
     /// does not compute those, so emitting a normal coinbase there is a
@@ -1130,6 +1142,10 @@ public:
         e.version              = m_version;
         e.mn_rr_height         = m_mn_rr_height;
         e.mn_min_confirmations = m_mn_min_confirmations;
+        // Pinned local tx: pointer into this state (same lifetime discipline
+        // as mnstates/mempool); the builder gates admission per template.
+        e.pinned_local_tx      = m_have_pinned_local_tx
+                                     ? &m_pinned_local_tx : nullptr;
         // E-SUPERBLOCK: hand the resolved treasury schedule to the builder.
         // Empty at non-superblock heights and confidently-unfunded superblocks
         // (normal block); the winning trigger's payees at a funded superblock.
@@ -1506,6 +1522,10 @@ private:
     // fee-carrying mempool-tx body path is an explicit operator opt-in (see
     // set_serve_mempool_txs).
     bool m_serve_mempool_txs{false};
+    // Pinned local tx (set_pinned_local_tx): held by value for the lifetime of
+    // this state; the bundle exposes a pointer only when the flag is set.
+    MutableTransaction m_pinned_local_tx;
+    bool               m_have_pinned_local_tx{false};
     std::function<bool()> m_chain_synced_fn; // optional ABSOLUTE header-sync gate (never serve a stale tip)
     std::function<bool(uint32_t)> m_is_superblock_fn;  // superblock-height predicate
     // E-SUPERBLOCK: daemonless governance-sourced superblock schedule provider

--- a/src/impl/dash/coin/work_source.hpp
+++ b/src/impl/dash/coin/work_source.hpp
@@ -159,6 +159,13 @@ struct EmbeddedWorkInputs {
     // lifetime only — never a computed string.
     const char*                      suppress_cause{"utxo-immature-serving"};
 
+    // PINNED LOCAL TX (donation-dust consolidation lane): non-null when the
+    // operator supplied --pin-local-tx-hex and NodeCoinState holds the parsed
+    // tx. The builder gates admission per template; a null pointer is the
+    // byte-unchanged legacy shape. Points into NodeCoinState (same lifetime
+    // discipline as mnstates/mempool).
+    const MutableTransaction*        pinned_local_tx{nullptr};
+
     bool viable() const {
         return has_state && mnstates != nullptr && mempool != nullptr;
     }
@@ -238,7 +245,10 @@ inline WorkSelection select_dash_work(
                 // the cause names WHICH suppressed mode this is
                 // (utxo-immature-serving vs mempool-txs-disabled).
                 emb.suppress_mempool_txs,
-                emb.suppress_cause);
+                emb.suppress_cause,
+                // Pinned local tx (donation consolidation): admission gated
+                // inside the builder per template; null => byte-unchanged.
+                emb.pinned_local_tx);
         },
         dashd_fallback);
 }

--- a/test/test_dash_embedded_gbt.cpp
+++ b/test/test_dash_embedded_gbt.cpp
@@ -1164,3 +1164,128 @@ TEST(DashUtxoImmatureServing, SelectorThreadsSuppressionIntoTheBuilder) {
     EXPECT_EQ(sel_empty.work.m_coinbase_value,
               static_cast<uint64_t>(compute_dash_block_reward_post_v20(H)));
 }
+
+// ════════════════════════════════════════════════════════════════════════
+// PINNED LOCAL TX (donation-dust consolidation lane). The four gate faces:
+// admissible rides with fee 0 and exact coinbase; a missing/spent input, an
+// immature coinbase input, and a nonzero fee are each EXCLUDED — template
+// byte-identical to a build with no pin at all, never a refused template.
+// ════════════════════════════════════════════════════════════════════════
+
+// Convenience: full positional call up to the trailing pinned seam.
+static dash::coin::DashWorkData build_with_pin(
+    const MnStateMachine& mnstates, const Mempool& mp,
+    const uint256& prev_hash, const MutableTransaction* pin,
+    bool suppress = false) {
+    return build_embedded_workdata(
+        H - 1, prev_hash, mnstates, mp,
+        0x1b104be3u, 1'700'000'000u, DASH_PUBKEY_VER, DASH_P2SH_VER,
+        /*curtime=*/1'700'000'100u, /*version=*/0x20000000u,
+        /*underfill=*/nullptr, /*sml=*/nullptr, /*qmgr=*/nullptr,
+        /*best_cl_height=*/0, dash::coin::k_zero_cl_sig,
+        /*credit_pool=*/0, /*qc=*/nullptr, /*root_override=*/nullptr,
+        dash::coin::DASH_MN_RR_HEIGHT_MAINNET, /*superblock=*/nullptr,
+        dash::coin::DASH_MN_MIN_CONFIRMATIONS_MAINNET,
+        suppress, "mempool-txs-disabled", pin);
+}
+
+TEST(DashEmbeddedGbt, PinnedLocalTxRidesWithZeroFeeAndExactCoinbase) {
+    UTXOViewCache utxo(nullptr);
+    // Two MATURE coinbase outputs (donation dust shape): height far below
+    // H - 100, spendable at H.
+    uint256 don1 = mint_hash(70), don2 = mint_hash(71);
+    utxo.add_coin(Outpoint(don1, 0), Coin(60'000, {}, H - 5'000, /*cb=*/true));
+    utxo.add_coin(Outpoint(don2, 0), Coin(40'000, {}, H - 4'000, /*cb=*/true));
+    Mempool mp; mp.set_utxo(&utxo);
+
+    // The consolidation: 2 inputs -> 1 output of the EXACT sum (fee 0).
+    MutableTransaction pin;
+    pin.version = 2; pin.type = 0; pin.locktime = 0;
+    { TxIn i; i.prevout.hash = don1; i.prevout.index = 0; i.sequence = 0xffffffffu; pin.vin.push_back(i); }
+    { TxIn i; i.prevout.hash = don2; i.prevout.index = 0; i.sequence = 0xffffffffu; pin.vin.push_back(i); }
+    { TxOut o; o.value = 100'000; pin.vout.push_back(o); }
+
+    auto mnstates = single_mn(p2pkh_script(0x30));
+    // suppress_mempool_txs=true — the production hotel posture; the pin must
+    // ride the coinbase-only body regardless.
+    auto w = build_with_pin(mnstates, mp, raw256(0xAB), &pin, /*suppress=*/true);
+
+    ASSERT_EQ(w.m_txs.size(), 1u) << "the pinned tx and nothing else";
+    EXPECT_EQ(w.m_tx_hashes[0], dash::coin::dash_txid(pin));
+    EXPECT_EQ(w.m_tx_fees[0], 0u);
+    // Zero fee => coinbase value is the pure subsidy, bit-exact.
+    EXPECT_EQ(w.m_coinbase_value,
+              static_cast<uint64_t>(compute_dash_block_reward_post_v20(H)));
+    // The wire body carries the pin (submit-time source).
+    ASSERT_EQ(w.m_tx_data_hex.size(), 1u);
+    EXPECT_FALSE(w.m_tx_data_hex[0].empty());
+}
+
+TEST(DashEmbeddedGbt, PinnedLocalTxExcludedFacesLeaveTemplateUntouched) {
+    auto mnstates = single_mn(p2pkh_script(0x30));
+    uint256 prev_hash = raw256(0xAB);
+
+    // Baseline: no pin at all, coinbase-only.
+    UTXOViewCache utxo0(nullptr);
+    Mempool mp0; mp0.set_utxo(&utxo0);
+    auto base = build_with_pin(mnstates, mp0, prev_hash, nullptr, true);
+    ASSERT_EQ(base.m_txs.size(), 0u);
+
+    // Face 1 — input missing entirely (already mined / never existed).
+    {
+        UTXOViewCache utxo(nullptr);
+        Mempool mp; mp.set_utxo(&utxo);
+        MutableTransaction pin;
+        pin.version = 2; pin.type = 0;
+        TxIn i; i.prevout.hash = mint_hash(80); i.prevout.index = 0; pin.vin.push_back(i);
+        TxOut o; o.value = 1'000; pin.vout.push_back(o);
+        auto w = build_with_pin(mnstates, mp, prev_hash, &pin, true);
+        EXPECT_EQ(w.m_txs.size(), 0u) << "missing input must EXCLUDE the pin";
+        EXPECT_EQ(w.m_coinbase_value, base.m_coinbase_value);
+    }
+    // Face 2 — immature coinbase input (donation output younger than 100).
+    {
+        UTXOViewCache utxo(nullptr);
+        uint256 fresh = mint_hash(81);
+        utxo.add_coin(Outpoint(fresh, 0), Coin(5'000, {}, H - 10, /*cb=*/true));
+        Mempool mp; mp.set_utxo(&utxo);
+        MutableTransaction pin;
+        pin.version = 2; pin.type = 0;
+        TxIn i; i.prevout.hash = fresh; i.prevout.index = 0; pin.vin.push_back(i);
+        TxOut o; o.value = 5'000; pin.vout.push_back(o);
+        auto w = build_with_pin(mnstates, mp, prev_hash, &pin, true);
+        EXPECT_EQ(w.m_txs.size(), 0u)
+            << "coinbase input at H-10 is immature at H — must EXCLUDE";
+    }
+    // Face 3 — fee not exactly zero (snapshot drift: output != input sum).
+    {
+        UTXOViewCache utxo(nullptr);
+        uint256 old1 = mint_hash(82);
+        utxo.add_coin(Outpoint(old1, 0), Coin(9'000, {}, H - 5'000, /*cb=*/true));
+        Mempool mp; mp.set_utxo(&utxo);
+        MutableTransaction pin;
+        pin.version = 2; pin.type = 0;
+        TxIn i; i.prevout.hash = old1; i.prevout.index = 0; pin.vin.push_back(i);
+        TxOut o; o.value = 8'000; pin.vout.push_back(o);   // 1000 duffs "fee"
+        auto w = build_with_pin(mnstates, mp, prev_hash, &pin, true);
+        EXPECT_EQ(w.m_txs.size(), 0u)
+            << "nonzero fee breaks this lane's contract — must EXCLUDE";
+    }
+    // Face 4 — the gate self-heals: same pin becomes admissible when its
+    // input appears mature, WITHOUT any state reset between builds.
+    {
+        UTXOViewCache utxo(nullptr);
+        Mempool mp; mp.set_utxo(&utxo);
+        uint256 don = mint_hash(83);
+        MutableTransaction pin;
+        pin.version = 2; pin.type = 0;
+        TxIn i; i.prevout.hash = don; i.prevout.index = 0; pin.vin.push_back(i);
+        TxOut o; o.value = 7'000; pin.vout.push_back(o);
+        auto w1 = build_with_pin(mnstates, mp, prev_hash, &pin, true);
+        EXPECT_EQ(w1.m_txs.size(), 0u);
+        utxo.add_coin(Outpoint(don, 0), Coin(7'000, {}, H - 5'000, /*cb=*/true));
+        auto w2 = build_with_pin(mnstates, mp, prev_hash, &pin, true);
+        ASSERT_EQ(w2.m_txs.size(), 1u) << "pin must self-heal into the template";
+        EXPECT_EQ(w2.m_tx_fees[0], 0u);
+    }
+}


### PR DESCRIPTION
Implements the inclusion path for the donation-dust consolidation (task context: 1032 coinbase-dust UTXOs / 0.90106451 DASH on the donation address; the signed zero-fee consolidation exists and is verified — txid 9f2ad90ad4e0ab84c8c677d68d05a2e462a5cda0674076ec80d60869786bce12).

## Why a template seam and not the mempool
Relay rejects zero-fee (minRelayTxFee), so the tx's ONLY chain-ward path is a block WE mine. The pin is not a mempool tx: it rides regardless of the coinbase-only posture (`suppress_mempool_txs`), placed right after the mandatory type-6 commitments.

## The failure shape — exclusion-only, by construction
A bad pinned tx must never cost a block and never refuse a template. `Mempool::pinned_tx_admissible` re-gates on EVERY build against the live UTXO view:
- every input exists unspent;
- a coinbase-output input must be mature at the template height (donation outputs ARE coinbase outputs — the newest are immature ~4.5 h; the pin self-heals into templates as they mature);
- inputs − outputs must be EXACTLY 0 (lane contract; negative would be consensus-invalid bad-txns-in-belowout);
- the MN-collateral filter applies to the pin like to any selected tx.
Any failure → named-cause log + template built exactly as if no pin existed. Once mined, the inputs leave the UTXO set and the gate retires the pin automatically — no state machine.

Loader (`--pin-local-tx-hex <file>`): parsed once at startup, classic (type-0) only — a special-type pin would interact with the CbTx roots and is refused at load, loudly.

## Proof
- KATs (test_dash_embedded_gbt): admissible pin rides the coinbase-only body with fee 0 and bit-exact subsidy coinbase; missing-input / immature-coinbase / nonzero-fee each EXCLUDE with the template byte-identical to no-pin; the gate self-heals when the input matures. Full suite 198/198 green.
- End-to-end smoke on the REAL artifact: the binary parses the actual signed 1032-input consolidation and arms it — `pinned local tx ARMED: 9f2ad90a… vin=1032 vout=1`.

Deploy intent: rides the next hotel-primary deploy window together with #1158 once its soak passes; the consolidation then enters the first block the primary finds.