### PR TITLE
dash(#950): seed peers a STANDING remembered set on handle_version

### DIFF
--- a/src/impl/dash/known_txs_retention.hpp
+++ b/src/impl/dash/known_txs_retention.hpp
@@ -105,4 +105,32 @@ inline void retain_template_txs(std::deque<std::set<uint256>>& recent_sets,
     }
 }
 
+// #950 STANDING remembered-set seed. Canonical p2pool keeps a per-peer standing
+// remembered set — its dashboard "txpool" for us (web.py:673 remembered_txs_size)
+// is fed ONLY by remember_tx BODIES, never by have_tx adverts — and seeds a
+// freshly connected peer with the WHOLE current mining-tx set (p2p.py:269). It is
+// bounded by max_remembered_txs_size = 2 500 000 bytes (p2p.py:30): a canonical
+// peer DISCONNECTS if an inbound remember_tx pushes its remembered_txs_size over
+// that bound (p2p.py:488), so the cap here is an interop-safety limit, not a
+// nicety. c2pool held NO standing set — remember_tx went out only as a transient
+// bracket inside sendShares (canonical-faithful, p2p.py:388) — so peers saw
+// txpool == 0 (#950). This selects, from the txs we already hold, the prefix that
+// fits under `cap` bytes to seed the peer. size_of(tx) MUST mirror canonical's
+// `100 + packed_size(tx)` accounting so the running sum never overshoots the cap.
+template <typename TxMap, typename SizeFn>
+inline std::vector<typename TxMap::key_type>
+select_standing_remember(const TxMap& known_txs, std::size_t cap, SizeFn size_of)
+{
+    std::vector<typename TxMap::key_type> chosen;
+    std::size_t acc = 0;
+    for (const auto& kv : known_txs) {
+        const std::size_t sz = size_of(kv.second);
+        if (acc + sz > cap)
+            break;   // stop BEFORE the peer's cap — overshoot => it disconnects us
+        acc += sz;
+        chosen.push_back(kv.first);
+    }
+    return chosen;
+}
+
 } // namespace dash

--- a/src/impl/dash/node.cpp
+++ b/src/impl/dash/node.cpp
@@ -3,6 +3,7 @@
 #include "share.hpp"
 #include "mint_runloop.hpp"   // dash::mint::elect_best_share (election policy SSOT)
 #include "known_txs_retention.hpp"  // dash::retain_template_txs / all_txs_backable (F1/F3)
+#include "coin/transaction.hpp"  // coin::TX_WITH_WITNESS (remembered_tx_size, #950)
 #include "think_gate.hpp"     // dash::think:: think-slot protocol + clean-cycle tip decision (#854)
 
 #include <cassert>
@@ -1502,6 +1503,40 @@ uint256 NodeImpl::add_local_share(ShareType share, bool block_winning)
     broadcast_share(hash);
     run_think();
     return hash;
+}
+
+// #950: standing remembered-set seed (canonical p2p.py:269). Declared in
+// node.hpp. IO-thread only. Sizes each tx with canonical's 100 + packed_size
+// accounting (p2p.py:379) so the seed never overshoots the peer's cap (p2p.py:488).
+static std::size_t remembered_tx_size(const coin::Transaction& tx)
+{
+    coin::MutableTransaction mtx(tx);
+    return 100 + pack(coin::TX_WITH_WITNESS(mtx)).get_span().size();
+}
+
+void NodeImpl::send_standing_remember(const peer_ptr& peer)
+{
+    if (!peer)
+        return;
+    std::vector<coin::MutableTransaction> full_txs;
+    {
+        // try_to_lock, never block: mirrors advertise_known_txs — if the compute
+        // thread is mid-cycle we skip; the next inbound handshake reseeds.
+        std::shared_lock<std::shared_mutex> lk(m_tracker_mutex, std::try_to_lock);
+        if (!lk.owns_lock())
+            return;
+        auto chosen = dash::select_standing_remember(
+            m_known_txs, MAX_REMEMBERED_TXS_SIZE, &remembered_tx_size);
+        full_txs.reserve(chosen.size());
+        for (const auto& h : chosen)
+            if (auto it = m_known_txs.find(h); it != m_known_txs.end())
+                full_txs.emplace_back(it->second);
+    }
+    if (full_txs.empty())
+        return;
+    // Canonical p2p.py:269 sends tx_hashes=[] (all as bodies): at handshake we do
+    // not yet know the peer's remote_tx_hashes.
+    peer->write(dash::message_remember_tx::make_raw({}, full_txs));
 }
 
 void NodeImpl::register_template_txs(const std::vector<coin::Transaction>& txs,

--- a/src/impl/dash/node.hpp
+++ b/src/impl/dash/node.hpp
@@ -377,6 +377,10 @@ protected:
     // on any recent job stays fully backable; a tx leaves m_known_txs only once it
     // has fallen out of EVERY retained set (peer-remembered txs are separate).
     static constexpr size_t RETAINED_TEMPLATE_TX_SETS = 8;
+    // #950: canonical p2pool's max_remembered_txs_size (p2p.py:30). A peer
+    // disconnects if an inbound remember_tx pushes its remembered_txs_size
+    // over this (p2p.py:488), so the standing-remember seed stays under it.
+    static constexpr std::size_t MAX_REMEMBERED_TXS_SIZE = 2500000;
     std::deque<std::set<uint256>> m_recent_template_tx_sets;
     // Fired on the IO thread when run_think() elects a new best share
     // (p2pool: new_work_event) — main_dash binds the stratum work refresh.
@@ -812,6 +816,18 @@ public:
         // landing on top of it. See core/tx_advertiser.hpp.
         advertise_known_txs(peer);
 
+        // #950: seed this freshly-connected peer's STANDING remembered set
+        // (canonical p2p.py:269). A peer's "txpool" for us (web.py:673
+        // remembered_txs_size) is fed ONLY by remember_tx bodies; c2pool
+        // emitted none outside the transient sendShares bracket, so every
+        // peer showed txpool == 0 (#950). Post-#863 the socket write queue
+        // drains composed writes in strict submission order
+        // (core/socket.cpp:110-145), so this no longer risks the mid-message
+        // interleave the comment above warns of — it is safely queued after
+        // the have_tx advert. Bounded by MAX_REMEMBERED_TXS_SIZE so a
+        // canonical peer never disconnects us on overflow (p2p.py:488).
+        send_standing_remember(peer);
+
         // #754 join trigger (oracle p2p.py handle_version → node.py
         // handle_share_hashes): a peer advertising a best share we don't have
         // is THE download entry point for an empty node joining an
@@ -1126,6 +1142,14 @@ public:
         for (auto& entry : m_peers)
             advertise_one(entry.second);
     }
+
+    /// #950: seed a freshly-connected peer's STANDING remembered set with the
+    /// txs we already hold, bounded by MAX_REMEMBERED_TXS_SIZE (canonical
+    /// p2p.py:269, :30/:488). IO-THREAD ONLY (handle_version handler): reads
+    /// IO-confined m_known_txs, same discipline as advertise_known_txs.
+    /// Defined in node.cpp because it serializes tx bytes (pack /
+    /// TX_WITH_WITNESS) to size the per-peer cap.
+    void send_standing_remember(const peer_ptr& peer);
 
     /// Broadcast a new best-block notification to every connected pool peer.
     /// Straight port of the LTC reference (src/impl/ltc/node.hpp:316-320; same

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1009,6 +1009,13 @@ if (BUILD_TESTING AND GTest_FOUND)
         ${Boost_LIBRARIES}
     )
     target_link_libraries(test_dash_node_embedded_wire PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining c2pool_storage pool)  # OBJECT-lib SCC direct-naming (#22/#39)
+    # #950: handle_version() in node.hpp now calls NodeImpl::send_standing_remember,
+    # whose definition lives in node.cpp — the same shape as #889 on
+    # test_dash_node above. A target that includes node.hpp and instantiates the
+    # handler must link the `dash` OBJECT lib or the reference is undefined at
+    # link time. `dash`'s own deps are already on this line or arrive
+    # transitively; nothing outside src/impl/dash is added.
+    target_link_libraries(test_dash_node_embedded_wire PRIVATE dash sharechain)
     gtest_add_tests(test_dash_node_embedded_wire "" AUTO)
     # get_work() consumer capstone: fuses NodeCoinState::select_work() (embedded
     # template source) with assemble_work_job_targets(); same OBJECT-lib SCC.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1027,6 +1027,11 @@ if (BUILD_TESTING AND GTest_FOUND)
         ${Boost_LIBRARIES}
     )
     target_link_libraries(test_dash_get_work PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining c2pool_storage pool)  # OBJECT-lib SCC direct-naming (#22/#39)
+    # #950: every target that includes node.hpp and instantiates handle_version
+    # links NodeImpl::send_standing_remember, defined in node.cpp — see the
+    # test_dash_node_embedded_wire note above and the #889 precedent. Targets
+    # that only type-check against the header do not need this; these do.
+    target_link_libraries(test_dash_get_work PRIVATE dash sharechain)
     gtest_add_tests(test_dash_get_work "" AUTO)
 
     # Reception wire (legs 1-3): interfaces::Node reception Events ->
@@ -1213,7 +1218,12 @@ if (BUILD_TESTING AND GTest_FOUND)
         nlohmann_json::nlohmann_json
         ${Boost_LIBRARIES}
     )
-    target_link_libraries(test_dash_auto_ratchet PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
+    target_link_libraries(test_dash_auto_ratchet PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining c2pool_storage pool)  # OBJECT-lib SCC direct-naming (#22/#39)
+    # #950: every target that includes node.hpp and instantiates handle_version
+    # links NodeImpl::send_standing_remember, defined in node.cpp — see the
+    # test_dash_node_embedded_wire note above and the #889 precedent. Targets
+    # that only type-check against the header do not need this; these do.
+    target_link_libraries(test_dash_auto_ratchet PRIVATE dash sharechain)
     gtest_add_tests(test_dash_auto_ratchet "" AUTO)
 
     add_executable(test_dash_peer test_dash_peer.cpp)

--- a/test/test_dash_node.cpp
+++ b/test/test_dash_node.cpp
@@ -22,6 +22,7 @@
 
 #include <impl/dash/node.hpp>
 #include <core/uint256.hpp>
+#include <impl/dash/known_txs_retention.hpp>  // dash::select_standing_remember (#950)
 
 #include <memory>
 #include <type_traits>
@@ -455,4 +456,50 @@ TEST(DashBlockWinningMint, AcquirePrimitiveContract)
                            std::chrono::milliseconds(50));
         EXPECT_FALSE(a.owns_lock());
     }
+}
+
+
+// ── #950 standing remembered-set selector ──────────────────────────────────
+// Canonical p2pool seeds a freshly-connected peer with its whole mining-tx set
+// (p2p.py:269), bounded by max_remembered_txs_size (p2p.py:30) because a peer
+// DISCONNECTS if an inbound remember_tx overflows that bound (p2p.py:488).
+// c2pool emitted NO standing remember, so peers showed txpool == 0 (#950).
+// dash::select_standing_remember is what send_standing_remember(peer) (node.cpp,
+// wired into handle_version at node.hpp) uses to pick the seed. REAL uint256
+// keys; tx bytes stand in as ints exactly as test_dash_known_txs_retention.cpp
+// does — the production call binds the SAME template to coin::Transaction + the
+// pack() byte-sizer. These pin the two properties the fix must hold and pre-#950
+// code did not: a non-empty pool yields a non-empty seed (vs the empty standing
+// set that caused txpool==0), and the seed never overshoots the peer cap (vs an
+// unbounded seed that trips p2p.py:488). Selector+cap KAT on real types, NOT a
+// live-socket capture — the wire proof is the hotel #879 remember_tx-out / peer
+// remembered_txs_size read after merge.
+namespace {
+std::size_t as_bytes(int b) { return static_cast<std::size_t>(b); }
+}
+
+TEST(DashStandingRemember, PopulatedPoolYieldsNonEmptySeed)
+{
+    std::map<uint256, int> known;
+    known[uint256(1)] = 500;
+    known[uint256(2)] = 500;
+    known[uint256(3)] = 500;
+    auto chosen = dash::select_standing_remember(known, 2500000u, as_bytes);
+    EXPECT_EQ(chosen.size(), 3u);
+}
+
+TEST(DashStandingRemember, StopsBeforeExceedingPeerCap)
+{
+    std::map<uint256, int> known;
+    for (uint64_t i = 0; i < 10; ++i)
+        known[uint256(i)] = 400;
+    auto chosen = dash::select_standing_remember(known, 1000u, as_bytes);
+    EXPECT_EQ(chosen.size(), 2u);
+}
+
+TEST(DashStandingRemember, EmptyPoolSeedsNothing)
+{
+    std::map<uint256, int> known;
+    auto chosen = dash::select_standing_remember(known, 2500000u, as_bytes);
+    EXPECT_TRUE(chosen.empty());
 }


### PR DESCRIPTION
dash(#950): seed peers a STANDING remembered set on handle_version

Canonical p2pool keeps a per-peer standing remembered set and seeds a
freshly-connected peer with the whole current mining-tx set (p2p.py:269).
A peer dashboard txpool for us (web.py:673 remembered_txs_size) is fed
ONLY by remember_tx BODIES, never by have_tx adverts. c2pool held no
standing set -- remember_tx went out only as a transient bracket inside
sendShares -- so every peer showed txpool == 0 (#950).

send_standing_remember(peer), wired into handle_version (node.hpp:816),
selects via dash::select_standing_remember the prefix of held txs that fits
under max_remembered_txs_size = 2500000 bytes (p2p.py:30); a canonical
peer disconnects on overflow (p2p.py:488), so the cap is interop safety.
Post-#863 the socket write queue drains composed writes in submission
order, so the seed is safely queued after the have_tx advert.

Test folded into test_dash_node (allowlisted): DashStandingRemember pins
the two properties pre-#950 code violated -- a populated pool yields a
non-empty seed, and the seed stops before the peer cap. Selector KAT on
real uint256 keys; wire proof is the hotel #879 remember_tx-out read
after merge.
