### PR TITLE
dash(gbt-xcheck): explain the creditPool delta before alarming on it — pending asset movement is not drift (#107 phase 1)

### DIFF
--- a/src/impl/dash/coin/special_tx_pool_delta.hpp
+++ b/src/impl/dash/coin/special_tx_pool_delta.hpp
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// #107 — EXPLAIN a creditPool divergence instead of alarming on it.
+///
+/// Our template builder excludes every Dash special tx by design (C-3, see
+/// mempool.hpp): the builder does not yet apply DIP-0027 asset movement to the
+/// credit pool, so including such a tx while leaving the pool untouched would
+/// commit a wrong CbTx. Excluding it keeps our template INTERNALLY CONSISTENT
+/// and therefore consensus-valid.
+///
+/// The consequence is that whenever dashd's template carries pending asset
+/// locks/unlocks, its CbTx creditPoolBalance differs from ours by EXACTLY the
+/// summed effect of those txs:
+///
+///   lock   (type 8): pool += sum(payload.creditOutputs[].value)
+///   unlock (type 9): pool -= (payload.fee + sum(tx.vout[].value))
+///
+/// dashd hands us its tx list along with the template, so this is an equation
+/// and not a guess: if embedded_pool + delta == dashd_pool the divergence is
+/// FULLY ACCOUNTED FOR by a by-design exclusion, and the graduation statistics
+/// must not count it as drift. Anything else stays an unexplained mismatch.
+///
+/// Kept as a free function over a tx range so the KATs can pin the arithmetic
+/// without a live daemon, a stratum session, or a populated coin state.
+
+#include <impl/dash/coin/vendor/assetlock.hpp>
+
+#include <cstdint>
+#include <vector>
+
+namespace dash {
+namespace coin {
+
+struct SpecialPoolDelta {
+    /// Summed DIP-0027 effect of the special txs seen (signed: locks add,
+    /// unlocks subtract). Meaningless when `unparsable` is true.
+    int64_t  delta{0};
+    /// How many special txs contributed. Zero means the divergence has
+    /// nothing to do with asset movement.
+    unsigned count{0};
+    /// A special tx was present but its payload did not parse. We then know
+    /// NOTHING about the true delta, so nothing may be explained by it.
+    bool     unparsable{false};
+
+    /// The equation: does our pool plus this movement land exactly on dashd's?
+    /// Requires at least one special tx and a clean parse — an accidental
+    /// zero-tx "match" is never an explanation.
+    bool explains(int64_t embedded_pool, int64_t dashd_pool) const {
+        return !unparsable && count > 0 && embedded_pool + delta == dashd_pool;
+    }
+};
+
+/// Compute the pending asset movement carried by `txs` (dashd's template tx
+/// list). Non-special txs are ignored; the first unparsable special payload
+/// aborts with unparsable=true (a partial sum would be worse than no sum).
+template <typename TxRange>
+inline SpecialPoolDelta special_tx_pool_delta(const TxRange& txs)
+{
+    SpecialPoolDelta out;
+    for (const auto& t : txs) {
+        if (t.type == vendor::CAssetLockPayload::SPECIALTX_TYPE) {
+            vendor::CAssetLockPayload pl;
+            if (!vendor::parse_assetlock_payload(t.extra_payload, pl)) {
+                out.unparsable = true;
+                return out;
+            }
+            int64_t sum = 0;
+            for (const auto& o : pl.creditOutputs) sum += o.value;
+            out.delta += sum;
+            ++out.count;
+        } else if (t.type == vendor::CAssetUnlockPayload::SPECIALTX_TYPE) {
+            vendor::CAssetUnlockPayload pl;
+            if (!vendor::parse_assetunlock_payload(t.extra_payload, pl)) {
+                out.unparsable = true;
+                return out;
+            }
+            int64_t vout_sum = 0;
+            for (const auto& o : t.vout) vout_sum += o.value;
+            out.delta -= (static_cast<int64_t>(pl.fee) + vout_sum);
+            ++out.count;
+        }
+    }
+    return out;
+}
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -41,7 +41,7 @@
 #include <impl/dash/crypto/hash_x11.hpp>      // dash::crypto::hash_x11 (X11 PoW SSOT)
 #include <impl/dash/params.hpp>               // dash::make_coin_params
 #include <impl/dash/coin/vendor/cbtx.hpp>     // vendor::parse_cbtx (GBT-xcheck creditPool)
-#include <impl/dash/coin/vendor/assetlock.hpp> // #107: explain pool delta via type-8/9 payloads
+#include <impl/dash/coin/special_tx_pool_delta.hpp> // #107: explain the pool delta
 
 #include <core/address_utils.hpp>             // core::address_to_script (mint payout from username)
 #include <core/log.hpp>
@@ -543,32 +543,12 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
                     // Serving behaviour is UNCHANGED either way (dashd wins);
                     // only the classification differs, so the graduation-gate
                     // statistics stop counting a by-design exclusion as drift.
-                    int64_t special_delta = 0;
-                    unsigned special_n = 0;
-                    bool payload_unparsable = false;
-                    for (const auto& t : dref.m_txs) {
-                        if (t.type == coin::vendor::CAssetLockPayload::SPECIALTX_TYPE) {
-                            coin::vendor::CAssetLockPayload pl;
-                            if (!coin::vendor::parse_assetlock_payload(t.extra_payload, pl)) {
-                                payload_unparsable = true; break;
-                            }
-                            int64_t sum = 0;
-                            for (const auto& o : pl.creditOutputs) sum += o.value;
-                            special_delta += sum; ++special_n;
-                        } else if (t.type == coin::vendor::CAssetUnlockPayload::SPECIALTX_TYPE) {
-                            coin::vendor::CAssetUnlockPayload pl;
-                            if (!coin::vendor::parse_assetunlock_payload(t.extra_payload, pl)) {
-                                payload_unparsable = true; break;
-                            }
-                            int64_t vout_sum = 0;
-                            for (const auto& o : t.vout) vout_sum += o.value;
-                            special_delta -= (static_cast<int64_t>(pl.fee) + vout_sum);
-                            ++special_n;
-                        }
-                    }
-                    const bool explained = !payload_unparsable && special_n > 0
-                        && emb_cb.creditPoolBalance + special_delta
-                               == dref_cb.creditPoolBalance;
+                    const coin::SpecialPoolDelta sp =
+                        coin::special_tx_pool_delta(dref.m_txs);
+                    const int64_t special_delta = sp.delta;
+                    const unsigned special_n = sp.count;
+                    const bool explained = sp.explains(emb_cb.creditPoolBalance,
+                                                      dref_cb.creditPoolBalance);
                     if (explained) {
                         LOG_INFO << "[DASH-STRATUM-GBT] GBT-xcheck MATCH-MODULO-SPECIAL at h="
                                  << sel.work.m_height << " embedded creditPool="

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -41,6 +41,7 @@
 #include <impl/dash/crypto/hash_x11.hpp>      // dash::crypto::hash_x11 (X11 PoW SSOT)
 #include <impl/dash/params.hpp>               // dash::make_coin_params
 #include <impl/dash/coin/vendor/cbtx.hpp>     // vendor::parse_cbtx (GBT-xcheck creditPool)
+#include <impl/dash/coin/vendor/assetlock.hpp> // #107: explain pool delta via type-8/9 payloads
 
 #include <core/address_utils.hpp>             // core::address_to_script (mint payout from username)
 #include <core/log.hpp>
@@ -532,11 +533,71 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
                 if (emb_ok && dref_ok
                     && dref.m_height == sel.work.m_height
                     && emb_cb.creditPoolBalance != dref_cb.creditPoolBalance) {
+                    // #107 phase 1 — EXPLAIN the delta before alarming on it.
+                    // Our builder excludes every special tx BY DESIGN (C-3,
+                    // mempool.hpp), so when dashd's template carries pending
+                    // asset locks/unlocks its CbTx pool differs by EXACTLY
+                    // their summed effect (DIP-0027: lock +sum(creditOutputs);
+                    // unlock −(payload.fee + Σvout)). dashd's template hands us
+                    // the exact tx list, so this is an equation, not a guess.
+                    // Serving behaviour is UNCHANGED either way (dashd wins);
+                    // only the classification differs, so the graduation-gate
+                    // statistics stop counting a by-design exclusion as drift.
+                    int64_t special_delta = 0;
+                    unsigned special_n = 0;
+                    bool payload_unparsable = false;
+                    for (const auto& t : dref.m_txs) {
+                        if (t.type == coin::vendor::CAssetLockPayload::SPECIALTX_TYPE) {
+                            coin::vendor::CAssetLockPayload pl;
+                            if (!coin::vendor::parse_assetlock_payload(t.extra_payload, pl)) {
+                                payload_unparsable = true; break;
+                            }
+                            int64_t sum = 0;
+                            for (const auto& o : pl.creditOutputs) sum += o.value;
+                            special_delta += sum; ++special_n;
+                        } else if (t.type == coin::vendor::CAssetUnlockPayload::SPECIALTX_TYPE) {
+                            coin::vendor::CAssetUnlockPayload pl;
+                            if (!coin::vendor::parse_assetunlock_payload(t.extra_payload, pl)) {
+                                payload_unparsable = true; break;
+                            }
+                            int64_t vout_sum = 0;
+                            for (const auto& o : t.vout) vout_sum += o.value;
+                            special_delta -= (static_cast<int64_t>(pl.fee) + vout_sum);
+                            ++special_n;
+                        }
+                    }
+                    const bool explained = !payload_unparsable && special_n > 0
+                        && emb_cb.creditPoolBalance + special_delta
+                               == dref_cb.creditPoolBalance;
+                    if (explained) {
+                        LOG_INFO << "[DASH-STRATUM-GBT] GBT-xcheck MATCH-MODULO-SPECIAL at h="
+                                 << sel.work.m_height << " embedded creditPool="
+                                 << emb_cb.creditPoolBalance << " dashd="
+                                 << dref_cb.creditPoolBalance << " — delta "
+                                 << special_delta << " fully explained by "
+                                 << special_n << " pending asset lock/unlock tx(s)"
+                                 << " dashd includes and we exclude by design"
+                                 << " (serving dashd template; classification only)";
+                        coin::DeclineReport xok;
+                        xok.viable    = false;
+                        xok.cause     = "gbt-xcheck-modulo-special-explained";
+                        xok.value     = std::to_string(special_delta);
+                        xok.threshold = std::to_string(special_n) + "-special-txs";
+                        sel = coin::WorkSelection{ std::move(dref),
+                                                   coin::WorkSource::DashdFallback,
+                                                   std::move(xok) };
+                    } else {
                     LOG_WARNING << "[DASH-STRATUM-GBT] GBT-xcheck MISMATCH at h="
                                 << sel.work.m_height << " embedded creditPool="
                                 << emb_cb.creditPoolBalance << " dashd="
                                 << dref_cb.creditPoolBalance
-                                << " — serving dashd template (reward-safety backstop)";
+                                << " — serving dashd template (reward-safety backstop)"
+                                << (special_n
+                                        ? " [" + std::to_string(special_n)
+                                              + " special txs seen but they do NOT"
+                                                " explain the delta ("
+                                              + std::to_string(special_delta) + ")]"
+                                        : "");
                     coin::DeclineReport xcheck;
                     xcheck.viable    = false;
                     xcheck.cause     = "gbt-xcheck-creditpool-mismatch";
@@ -545,6 +606,7 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
                     sel = coin::WorkSelection{ std::move(dref),
                                                coin::WorkSource::DashdFallback,
                                                std::move(xcheck) };
+                    }
                 }
             }
             // E2c observability: WHICH arm served this template + the MN payee

--- a/test/test_dash_work_source.cpp
+++ b/test/test_dash_work_source.cpp
@@ -14,6 +14,7 @@
 ///   4. viable but null mempool  -> fallback (defensive null-guard).
 
 #include <impl/dash/coin/work_source.hpp>
+#include <impl/dash/coin/special_tx_pool_delta.hpp>
 #include <c2pool/hashrate/tracker.hpp>
 
 #include <cmath>
@@ -335,4 +336,160 @@ TEST(HashrateVardiffHysteresis, LowerMarginHeldButDecisiveDropStepsDown)
             << "decisive drop did not step the advertised bucket (D4=" << D4 << ")";
         EXPECT_LE(t.get_current_difficulty(), D4);   // never advertise above ideal D
     }
+}
+
+
+// ─── #107: creditPool divergence — explained vs unexplained ─────────────────
+// KAT for special_tx_pool_delta, the arithmetic that decides whether a GBT
+// creditPool divergence is ACCOUNTED FOR by pending DIP-0027 asset movement
+// (dashd includes those txs, we exclude them by design, C-3) or is genuine
+// drift the reward-safety backstop must keep shouting about. Numbers are the
+// ones measured live on mainnet the night of 2026-08-06/07, so a regression
+// here is a regression against reality:
+//   h=2517494 lock   +0.02689906 DASH ; h=2517504 unlock -72.0000019 with a
+//   190-duff payload fee tail.
+// Folded into this EXISTING allowlisted target on purpose: a fresh
+// add_executable absent from the build.yml --target allowlist would be a
+// silently-passing NOT_BUILT sentinel (#143).
+namespace {
+
+template <typename Payload>
+std::vector<unsigned char> pack_payload(const Payload& pl) {
+    auto ps = ::pack(pl);
+    auto span = ps.get_span();
+    return std::vector<unsigned char>(
+        reinterpret_cast<const unsigned char*>(span.data()),
+        reinterpret_cast<const unsigned char*>(span.data()) + span.size());
+}
+
+TxOut out_of(int64_t v) { TxOut o; o.value = v; return o; }
+
+/// Type-8: pool GAINS sum(payload.creditOutputs).
+MutableTransaction make_lock(int64_t credit_value) {
+    CAssetLockPayload pl;
+    pl.creditOutputs.push_back(out_of(credit_value));
+    MutableTransaction tx;
+    tx.version = 3;
+    tx.type    = CAssetLockPayload::SPECIALTX_TYPE;   // 8
+    tx.extra_payload = pack_payload(pl);
+    return tx;
+}
+
+/// Type-9: pool LOSES (payload.fee + sum(vout)); no inputs, outputs are minted.
+MutableTransaction make_unlock(int64_t out_value, uint32_t fee) {
+    CAssetUnlockPayload pl;
+    pl.index           = 1;
+    pl.fee             = fee;
+    pl.requestedHeight = 1000;
+    MutableTransaction tx;
+    tx.version = 3;
+    tx.type    = CAssetUnlockPayload::SPECIALTX_TYPE; // 9
+    tx.vout.push_back(out_of(out_value));
+    tx.extra_payload = pack_payload(pl);
+    return tx;
+}
+
+MutableTransaction make_plain() {
+    MutableTransaction tx;
+    tx.version = 2;
+    tx.type    = 0;
+    tx.vout.push_back(out_of(50'000));
+    return tx;
+}
+
+} // namespace
+
+// 1) The mainnet h=2517494 shape: one pending lock of 0.02689906 DASH.
+TEST(DashSpecialPoolDelta, PendingLockExplainsThePositiveDivergence)
+{
+    const int64_t kLock = 2'689'906;                 // measured on mainnet
+    const int64_t ours  = 3'028'884'293'639;         // our CbTx creditPool
+    const int64_t dashd = ours + kLock;              // dashd's, with the lock
+
+    std::vector<MutableTransaction> txs{ make_plain(), make_lock(kLock) };
+    const auto sp = special_tx_pool_delta(txs);
+
+    EXPECT_EQ(sp.count, 1u);
+    EXPECT_FALSE(sp.unparsable);
+    EXPECT_EQ(sp.delta, kLock);
+    EXPECT_TRUE(sp.explains(ours, dashd));
+}
+
+// 2) The h=2517504 shape: an unlock, whose miner fee lives in the payload.
+TEST(DashSpecialPoolDelta, PendingUnlockSubtractsOutputsPlusPayloadFee)
+{
+    const int64_t kOut = 7'200'000'000;              // 72 DASH
+    const uint32_t kFee = 190;                       // the measured fee tail
+    const int64_t ours  = 3'029'419'859'335;
+    const int64_t dashd = ours - (kOut + kFee);
+
+    std::vector<MutableTransaction> txs{ make_unlock(kOut, kFee) };
+    const auto sp = special_tx_pool_delta(txs);
+
+    EXPECT_EQ(sp.count, 1u);
+    EXPECT_EQ(sp.delta, -(kOut + static_cast<int64_t>(kFee)));
+    EXPECT_TRUE(sp.explains(ours, dashd));
+}
+
+// 3) Both directions in one template — the signs must not cancel by accident.
+TEST(DashSpecialPoolDelta, MixedLockAndUnlockSumSigned)
+{
+    const int64_t kLock = 35'000'000;
+    const int64_t kOut  = 2'108'300'000;
+    const uint32_t kFee = 190;
+    const int64_t expected = kLock - (kOut + static_cast<int64_t>(kFee));
+    const int64_t ours  = 3'023'215'610'725;
+    const int64_t dashd = ours + expected;
+
+    std::vector<MutableTransaction> txs{
+        make_lock(kLock), make_plain(), make_unlock(kOut, kFee) };
+    const auto sp = special_tx_pool_delta(txs);
+
+    EXPECT_EQ(sp.count, 2u);
+    EXPECT_EQ(sp.delta, expected);
+    EXPECT_TRUE(sp.explains(ours, dashd));
+}
+
+// 4) A divergence the pending special txs do NOT account for stays a mismatch.
+//    This is the whole reason the check is an equation and not a heuristic.
+TEST(DashSpecialPoolDelta, UnrelatedDivergenceIsNotExplained)
+{
+    const int64_t kLock = 2'689'906;
+    const int64_t ours  = 3'028'884'293'639;
+    const int64_t dashd = ours + kLock + 1;          // one duff off
+
+    std::vector<MutableTransaction> txs{ make_lock(kLock) };
+    const auto sp = special_tx_pool_delta(txs);
+
+    EXPECT_EQ(sp.delta, kLock);
+    EXPECT_FALSE(sp.explains(ours, dashd));
+}
+
+// 5) No special txs: even an exactly-equal pool must not be reported as
+//    "explained by special movement" — there was nothing to explain it with.
+TEST(DashSpecialPoolDelta, NoSpecialTxsNeverExplains)
+{
+    std::vector<MutableTransaction> txs{ make_plain(), make_plain() };
+    const auto sp = special_tx_pool_delta(txs);
+
+    EXPECT_EQ(sp.count, 0u);
+    EXPECT_EQ(sp.delta, 0);
+    EXPECT_FALSE(sp.explains(1'000, 1'000));
+}
+
+// 6) Fail-closed: a special tx whose payload does not parse leaves us knowing
+//    NOTHING about the true movement, so nothing may be explained by it.
+TEST(DashSpecialPoolDelta, UnparsablePayloadExplainsNothing)
+{
+    MutableTransaction broken;
+    broken.version = 3;
+    broken.type    = CAssetLockPayload::SPECIALTX_TYPE;
+    broken.extra_payload = { 0xff, 0xff, 0xff };     // not a valid payload
+
+    std::vector<MutableTransaction> txs{ make_lock(1'000), broken };
+    const auto sp = special_tx_pool_delta(txs);
+
+    EXPECT_TRUE(sp.unparsable);
+    EXPECT_FALSE(sp.explains(0, 0));
+    EXPECT_FALSE(sp.explains(0, 1'000));
 }

--- a/test/test_dash_work_source.cpp
+++ b/test/test_dash_work_source.cpp
@@ -15,6 +15,8 @@
 
 #include <impl/dash/coin/work_source.hpp>
 #include <impl/dash/coin/special_tx_pool_delta.hpp>
+#include <impl/dash/coin/rpc_data.hpp>
+#include <core/pack.hpp>
 #include <c2pool/hashrate/tracker.hpp>
 
 #include <cmath>
@@ -362,35 +364,35 @@ std::vector<unsigned char> pack_payload(const Payload& pl) {
         reinterpret_cast<const unsigned char*>(span.data()) + span.size());
 }
 
-TxOut out_of(int64_t v) { TxOut o; o.value = v; return o; }
+::bitcoin_family::coin::TxOut out_of(int64_t v) { ::bitcoin_family::coin::TxOut o; o.value = v; return o; }
 
 /// Type-8: pool GAINS sum(payload.creditOutputs).
-MutableTransaction make_lock(int64_t credit_value) {
-    CAssetLockPayload pl;
+dash::coin::MutableTransaction make_lock(int64_t credit_value) {
+    dash::coin::vendor::CAssetLockPayload pl;
     pl.creditOutputs.push_back(out_of(credit_value));
-    MutableTransaction tx;
+    dash::coin::MutableTransaction tx;
     tx.version = 3;
-    tx.type    = CAssetLockPayload::SPECIALTX_TYPE;   // 8
+    tx.type    = dash::coin::vendor::CAssetLockPayload::SPECIALTX_TYPE;   // 8
     tx.extra_payload = pack_payload(pl);
     return tx;
 }
 
 /// Type-9: pool LOSES (payload.fee + sum(vout)); no inputs, outputs are minted.
-MutableTransaction make_unlock(int64_t out_value, uint32_t fee) {
-    CAssetUnlockPayload pl;
+dash::coin::MutableTransaction make_unlock(int64_t out_value, uint32_t fee) {
+    dash::coin::vendor::CAssetUnlockPayload pl;
     pl.index           = 1;
     pl.fee             = fee;
     pl.requestedHeight = 1000;
-    MutableTransaction tx;
+    dash::coin::MutableTransaction tx;
     tx.version = 3;
-    tx.type    = CAssetUnlockPayload::SPECIALTX_TYPE; // 9
+    tx.type    = dash::coin::vendor::CAssetUnlockPayload::SPECIALTX_TYPE; // 9
     tx.vout.push_back(out_of(out_value));
     tx.extra_payload = pack_payload(pl);
     return tx;
 }
 
-MutableTransaction make_plain() {
-    MutableTransaction tx;
+dash::coin::MutableTransaction make_plain() {
+    dash::coin::MutableTransaction tx;
     tx.version = 2;
     tx.type    = 0;
     tx.vout.push_back(out_of(50'000));
@@ -406,8 +408,8 @@ TEST(DashSpecialPoolDelta, PendingLockExplainsThePositiveDivergence)
     const int64_t ours  = 3'028'884'293'639;         // our CbTx creditPool
     const int64_t dashd = ours + kLock;              // dashd's, with the lock
 
-    std::vector<MutableTransaction> txs{ make_plain(), make_lock(kLock) };
-    const auto sp = special_tx_pool_delta(txs);
+    std::vector<dash::coin::MutableTransaction> txs{ make_plain(), make_lock(kLock) };
+    const auto sp = dash::coin::special_tx_pool_delta(txs);
 
     EXPECT_EQ(sp.count, 1u);
     EXPECT_FALSE(sp.unparsable);
@@ -423,8 +425,8 @@ TEST(DashSpecialPoolDelta, PendingUnlockSubtractsOutputsPlusPayloadFee)
     const int64_t ours  = 3'029'419'859'335;
     const int64_t dashd = ours - (kOut + kFee);
 
-    std::vector<MutableTransaction> txs{ make_unlock(kOut, kFee) };
-    const auto sp = special_tx_pool_delta(txs);
+    std::vector<dash::coin::MutableTransaction> txs{ make_unlock(kOut, kFee) };
+    const auto sp = dash::coin::special_tx_pool_delta(txs);
 
     EXPECT_EQ(sp.count, 1u);
     EXPECT_EQ(sp.delta, -(kOut + static_cast<int64_t>(kFee)));
@@ -441,9 +443,9 @@ TEST(DashSpecialPoolDelta, MixedLockAndUnlockSumSigned)
     const int64_t ours  = 3'023'215'610'725;
     const int64_t dashd = ours + expected;
 
-    std::vector<MutableTransaction> txs{
+    std::vector<dash::coin::MutableTransaction> txs{
         make_lock(kLock), make_plain(), make_unlock(kOut, kFee) };
-    const auto sp = special_tx_pool_delta(txs);
+    const auto sp = dash::coin::special_tx_pool_delta(txs);
 
     EXPECT_EQ(sp.count, 2u);
     EXPECT_EQ(sp.delta, expected);
@@ -458,8 +460,8 @@ TEST(DashSpecialPoolDelta, UnrelatedDivergenceIsNotExplained)
     const int64_t ours  = 3'028'884'293'639;
     const int64_t dashd = ours + kLock + 1;          // one duff off
 
-    std::vector<MutableTransaction> txs{ make_lock(kLock) };
-    const auto sp = special_tx_pool_delta(txs);
+    std::vector<dash::coin::MutableTransaction> txs{ make_lock(kLock) };
+    const auto sp = dash::coin::special_tx_pool_delta(txs);
 
     EXPECT_EQ(sp.delta, kLock);
     EXPECT_FALSE(sp.explains(ours, dashd));
@@ -469,8 +471,8 @@ TEST(DashSpecialPoolDelta, UnrelatedDivergenceIsNotExplained)
 //    "explained by special movement" — there was nothing to explain it with.
 TEST(DashSpecialPoolDelta, NoSpecialTxsNeverExplains)
 {
-    std::vector<MutableTransaction> txs{ make_plain(), make_plain() };
-    const auto sp = special_tx_pool_delta(txs);
+    std::vector<dash::coin::MutableTransaction> txs{ make_plain(), make_plain() };
+    const auto sp = dash::coin::special_tx_pool_delta(txs);
 
     EXPECT_EQ(sp.count, 0u);
     EXPECT_EQ(sp.delta, 0);
@@ -481,13 +483,13 @@ TEST(DashSpecialPoolDelta, NoSpecialTxsNeverExplains)
 //    NOTHING about the true movement, so nothing may be explained by it.
 TEST(DashSpecialPoolDelta, UnparsablePayloadExplainsNothing)
 {
-    MutableTransaction broken;
+    dash::coin::MutableTransaction broken;
     broken.version = 3;
-    broken.type    = CAssetLockPayload::SPECIALTX_TYPE;
+    broken.type    = dash::coin::vendor::CAssetLockPayload::SPECIALTX_TYPE;
     broken.extra_payload = { 0xff, 0xff, 0xff };     // not a valid payload
 
-    std::vector<MutableTransaction> txs{ make_lock(1'000), broken };
-    const auto sp = special_tx_pool_delta(txs);
+    std::vector<dash::coin::MutableTransaction> txs{ make_lock(1'000), broken };
+    const auto sp = dash::coin::special_tx_pool_delta(txs);
 
     EXPECT_TRUE(sp.unparsable);
     EXPECT_FALSE(sp.explains(0, 0));


### PR DESCRIPTION
## What this changes

Nothing about what gets served. A GBT creditPool divergence still hands the height to dashd. What changes is whether we call that divergence **drift**.

## Why

Our template builder excludes every Dash special tx by design (C-3, mempool.hpp): the builder does not yet apply DIP-0027 asset movement to the credit pool, so including such a tx while leaving the pool untouched would commit a wrong CbTx. Excluding it keeps our template internally consistent and therefore consensus-valid.

The consequence is that whenever dashd's template carries pending asset locks/unlocks, its CbTx creditPoolBalance differs from ours by exactly the summed effect of those txs. dashd hands us its tx list along with the template, so this is an **equation**, not a guess:

    lock   (type 8): pool += sum(payload.creditOutputs[].value)
    unlock (type 9): pool -= (payload.fee + sum(tx.vout[].value))

When `embedded_pool + delta == dashd_pool`, the event is now classified MATCH-MODULO-SPECIAL (INFO, cause=`gbt-xcheck-modulo-special-explained`) instead of MISMATCH (WARNING). Anything else stays a MISMATCH, now annotated with what was seen.

## Measured, not theorised

Overnight 2026-08-06/07 on the shadow soak: **22 distinct heights** diverged, every one a pending lock or unlock:

| height | delta | class |
|---|---|---|
| 2517494 | +0.02689906 | lock |
| 2517501 | +0.35 | lock |
| 2517504 | −72.0000019 | unlock (190-duff payload fee tail) |
| 2517524 | −21.083 | unlock |
| … 18 more, same two shapes | | |

That is ~10–20% of tips. Until they are classified correctly the embedded arm can never graduate the shadow gate — a by-design exclusion was being counted as divergence.

## Safety

- Serving behaviour byte-unchanged: dashd's template still wins the height either way.
- Fail-closed preserved: an unparsable payload sets `unparsable` and explains nothing; zero special txs never explain anything, even at an exactly equal pool.
- The arithmetic moved out of the stratum call site into `coin/special_tx_pool_delta.hpp` so it can be pinned without a daemon, a stratum session or a populated coin state.

## Tests

6 KATs on the measured mainnet shapes, folded into the **existing allowlisted** `test_dash_work_source` target (a fresh add_executable absent from the build.yml --target allowlist would be a silently-passing NOT_BUILT sentinel, #143). Local run on vm905: 15/15 PASSED, including the one-duff-off case that must stay unexplained.

## Not in this PR

Phase 2 — actually including type-8 locks in our own template and applying their effect to the CbTx pool, behind a default-OFF flag plus a shadow soak. Type-9 unlocks stay excluded until quorum-signature verification of the withdrawal is wired: an invalid unlock is an invalid block.