### PR TITLE
dash(work-source): splice the pinned local tx into the SERVED dashd template — one admission gate for both arms

### DIFF
--- a/src/impl/dash/coin/embedded_gbt.hpp
+++ b/src/impl/dash/coin/embedded_gbt.hpp
@@ -100,6 +100,47 @@ inline std::vector<unsigned char> encode_cbtx(const vendor::CCbTx&);
 // Zero CLSIG default for the E2d best_cl_sig seam (no temporary-bound ref).
 inline const std::array<uint8_t, 96> k_zero_cl_sig{};
 
+/// PINNED LOCAL TX splice — the ONE admission-and-append used by BOTH serving
+/// arms (embedded builder and the served-dashd-template arm), so the gate can
+/// never drift between them. `arm` names the caller in the log lines
+/// ("GBT-EMB" / "dashd-splice") so soaks can tell which arm carried the pin.
+/// Exclusion is the only failure mode: gate re-checked on EVERY build (inputs
+/// unspent against OUR UTXO view, coinbase-mature at this height, fee exactly
+/// zero, no MN-collateral spend). A bad pin must never cost a block, and an
+/// unverifiable one (utxo-view-unset) must never be included.
+inline void splice_pinned_tx(DashWorkData& w,
+                             const MutableTransaction& pin,
+                             const Mempool& mempool,
+                             const MnStateMachine& mnstates,
+                             const char* arm)
+{
+    const auto gate = mempool.pinned_tx_admissible(pin, w.m_height);
+    uint256 protx;
+    if (gate != Mempool::PinnedTxGate::Ok) {
+        LOG_INFO << "[" << arm << "] pinned tx EXCLUDED h=" << w.m_height
+                 << " cause=" << Mempool::pinned_gate_name(gate)
+                 << " txid=" << dash::coin::dash_txid(pin).GetHex().substr(0, 16)
+                 << " (template built without it; re-checked next build)";
+        return;
+    }
+    if (tx_spends_mn_collateral(mnstates, pin, &protx)) {
+        LOG_WARNING << "[" << arm << "] pinned tx EXCLUDED h=" << w.m_height
+                    << " cause=spends-mn-collateral MN "
+                    << protx.GetHex().substr(0, 16);
+        return;
+    }
+    auto stream = ::pack(pin);
+    auto sp = stream.get_span();
+    w.m_txs.emplace_back(pin);
+    w.m_tx_hashes.push_back(dash::coin::dash_txid(pin));
+    w.m_tx_fees.push_back(0);
+    w.m_tx_data_hex.push_back(HexStr(std::span<const unsigned char>(
+        reinterpret_cast<const unsigned char*>(sp.data()), sp.size())));
+    LOG_INFO << "[" << arm << "] pinned tx INCLUDED h=" << w.m_height
+             << " txid=" << dash::coin::dash_txid(pin).GetHex().substr(0, 16)
+             << " vin=" << pin.vin.size() << " fee=0 (rides this template)";
+}
+
 inline DashWorkData build_embedded_workdata(
     uint32_t prev_height,
     const uint256& prev_hash,
@@ -363,33 +404,8 @@ inline DashWorkData build_embedded_workdata(
     // only failure mode (see the parameter note); the MN-collateral filter
     // applies here too — a pinned tx spending a collateral would poison the
     // committed merkleRootMNList exactly like a selected one.
-    if (pinned_local_tx != nullptr) {
-        const auto gate = mempool.pinned_tx_admissible(*pinned_local_tx,
-                                                       w.m_height);
-        uint256 protx;
-        if (gate != Mempool::PinnedTxGate::Ok) {
-            LOG_INFO << "[GBT-EMB] pinned tx EXCLUDED h=" << w.m_height
-                     << " cause=" << Mempool::pinned_gate_name(gate)
-                     << " txid=" << dash::coin::dash_txid(*pinned_local_tx)
-                            .GetHex().substr(0, 16)
-                     << " (template built without it; re-checked next build)";
-        } else if (tx_spends_mn_collateral(mnstates, *pinned_local_tx,
-                                           &protx)) {
-            LOG_WARNING << "[GBT-EMB] pinned tx EXCLUDED h=" << w.m_height
-                        << " cause=spends-mn-collateral MN "
-                        << protx.GetHex().substr(0, 16);
-        } else {
-            w.m_txs.emplace_back(*pinned_local_tx);
-            w.m_tx_hashes.push_back(dash::coin::dash_txid(*pinned_local_tx));
-            w.m_tx_fees.push_back(0);
-            w.m_tx_data_hex.push_back(tx_hex(*pinned_local_tx));
-            LOG_INFO << "[GBT-EMB] pinned tx INCLUDED h=" << w.m_height
-                     << " txid=" << dash::coin::dash_txid(*pinned_local_tx)
-                            .GetHex().substr(0, 16)
-                     << " vin=" << pinned_local_tx->vin.size()
-                     << " fee=0 (rides this template)";
-        }
-    }
+    if (pinned_local_tx != nullptr)
+        splice_pinned_tx(w, *pinned_local_tx, mempool, mnstates, "GBT-EMB");
     uint64_t selected_bytes = 0;  // wire bytes packed into this template (underfill guard)
     for (auto& s : selected) {
         selected_bytes += s.base_size;

--- a/src/impl/dash/coin/work_source.hpp
+++ b/src/impl/dash/coin/work_source.hpp
@@ -204,7 +204,28 @@ inline WorkSelection select_dash_work(
                       + "," + (emb.mempool ? "mempool=ok" : "mempool=null");
         why.threshold = "mnstates!=null,mempool!=null";
     }
-    return WorkSelection{dashd_fallback(), WorkSource::DashdFallback, std::move(why)};
+    WorkSelection out{dashd_fallback(), WorkSource::DashdFallback, std::move(why)};
+    // PINNED LOCAL TX on the SERVED-dashd arm (option B, donation lane): the
+    // dashd mempool cannot carry the >100KB zero-fee consolidation (policy
+    // standardness), so the pin rides OUR served copy of dashd's template
+    // instead. Same shared gate as the embedded arm (splice_pinned_tx);
+    // coinbase value untouched (fee 0) — stratum merkle branches and the
+    // submitblock body both derive from the appended tx vectors. Fail-closed:
+    // without the verify view (mempool+mnstates, i.e. --embedded-utxo) the
+    // pin is EXCLUDED with a named cause, never included unverified.
+    if (emb.pinned_local_tx != nullptr) {
+        if (emb.mempool == nullptr || emb.mnstates == nullptr) {
+            LOG_INFO << "[dashd-splice] pinned tx EXCLUDED h="
+                     << out.work.m_height << " cause=no-verify-view ("
+                     << (emb.mempool ? "mempool=ok" : "mempool=null") << ","
+                     << (emb.mnstates ? "mnstates=ok" : "mnstates=null")
+                     << ") — enable --embedded-utxo to verify the pin";
+        } else {
+            splice_pinned_tx(out.work, *emb.pinned_local_tx,
+                             *emb.mempool, *emb.mnstates, "dashd-splice");
+        }
+    }
+    return out;
 }
 
 /// Production entry point: builds the embedded template from `emb` when viable,

--- a/test/test_dash_work_source.cpp
+++ b/test/test_dash_work_source.cpp
@@ -16,6 +16,8 @@
 #include <impl/dash/coin/work_source.hpp>
 #include <impl/dash/coin/special_tx_pool_delta.hpp>
 #include <impl/dash/coin/rpc_data.hpp>
+#include <impl/dash/coin/utxo_adapter.hpp>
+#include <core/coin/utxo_view_cache.hpp>
 #include <core/pack.hpp>
 #include <c2pool/hashrate/tracker.hpp>
 
@@ -188,6 +190,57 @@ TEST(DashWorkSource, PinnedTxOnFallbackFailsClosedWithoutUtxoView)
     EXPECT_TRUE(sel.work.m_txs.empty());
     EXPECT_TRUE(sel.work.m_tx_data_hex.empty());
 }
+
+// POSITIVE PATH: verify view wired (mempool + UTXO + mnstates), pin admissible
+// (mature input, fee exactly 0) -> appended to ALL FOUR tx vectors on the
+// SERVED dashd template, fee recorded as 0, coinbase value untouched. This is
+// the donation-consolidation contract: >100KB standardness never applies here.
+TEST(DashWorkSource, PinnedTxSplicedOnFallbackWithVerifyView)
+{
+    using ::core::coin::UTXOViewCache;
+    using ::core::coin::Outpoint;
+    using ::core::coin::Coin;
+
+    uint256 prev;
+    prev.begin()[0] = 0x42;
+    UTXOViewCache utxo(nullptr);
+    utxo.add_coin(Outpoint(prev, 0), Coin(50'000, {}, /*height=*/1, /*cb=*/false));
+
+    dash::coin::Mempool mp;
+    mp.set_utxo(&utxo);
+    MnStateMachine mn;
+
+    dash::coin::MutableTransaction pin;
+    pin.vin.resize(1);
+    pin.vin[0].prevout.hash  = prev;
+    pin.vin[0].prevout.index = 0;
+    pin.vout.resize(1);
+    pin.vout[0].value = 50'000;   // sum(in) == sum(out): fee exactly zero
+
+    EmbeddedWorkInputs emb;       // has_state=false -> fallback arm
+    emb.mnstates        = &mn;
+    emb.mempool         = &mp;
+    emb.pinned_local_tx = &pin;
+
+    bool emb_ran = false, fb_ran = false;
+    WorkSelection sel = select_dash_work(
+        emb,
+        [&] { return embedded_stub(emb_ran); },
+        [&] { return dashd_stub(fb_ran); });
+
+    EXPECT_EQ(sel.source, WorkSource::DashdFallback);
+    EXPECT_TRUE(fb_ran);
+    ASSERT_EQ(sel.work.m_txs.size(), 1u);
+    ASSERT_EQ(sel.work.m_tx_hashes.size(), 1u);
+    ASSERT_EQ(sel.work.m_tx_fees.size(), 1u);
+    ASSERT_EQ(sel.work.m_tx_data_hex.size(), 1u);
+    EXPECT_EQ(sel.work.m_tx_fees[0], 0u);
+    EXPECT_EQ(sel.work.m_tx_hashes[0], dash::coin::dash_txid(pin));
+    EXPECT_FALSE(sel.work.m_tx_data_hex[0].empty());
+    // Coinbase value untouched by the splice (fee 0 adds nothing to claim).
+    EXPECT_EQ(sel.work.m_coinbase_value, 0u);
+}
+
 
 // ─── Firmware-grid vardiff quantization KAT (retention fix) ──────────────────
 // HashrateTracker::set_difficulty_from_hashrate must advertise ONLY power-of-two

--- a/test/test_dash_work_source.cpp
+++ b/test/test_dash_work_source.cpp
@@ -136,6 +136,59 @@ TEST(DashWorkSource, NullMempoolRoutesFallback)
     EXPECT_TRUE(fb_ran);
 }
 
+// ─── Option B: pinned-tx splice on the SERVED-dashd arm ──────────────────────
+// The donation consolidation (>100KB, fee 0) cannot enter dashd's mempool
+// (policy standardness), so when the dashd arm serves, the pin must ride OUR
+// copy of the template — gated by the SAME splice_pinned_tx the embedded arm
+// uses. Fail-closed contract: no verify view (mempool/mnstates null) → the
+// template is byte-identical to no-pin; never an unverified inclusion.
+TEST(DashWorkSource, PinnedTxExcludedOnFallbackWithoutVerifyView)
+{
+    EmbeddedWorkInputs emb;            // has_state=false → fallback arm
+    dash::coin::MutableTransaction pin;
+    pin.vin.resize(1);
+    emb.pinned_local_tx = &pin;        // pin present, but no mempool/mnstates
+
+    bool emb_ran = false, fb_ran = false;
+    WorkSelection sel = select_dash_work(
+        emb,
+        [&] { return embedded_stub(emb_ran); },
+        [&] { return dashd_stub(fb_ran); });
+
+    EXPECT_EQ(sel.source, WorkSource::DashdFallback);
+    EXPECT_TRUE(fb_ran);
+    // Byte-identical to the no-pin shape: nothing appended anywhere.
+    EXPECT_TRUE(sel.work.m_txs.empty());
+    EXPECT_TRUE(sel.work.m_tx_hashes.empty());
+    EXPECT_TRUE(sel.work.m_tx_fees.empty());
+    EXPECT_TRUE(sel.work.m_tx_data_hex.empty());
+}
+
+TEST(DashWorkSource, PinnedTxOnFallbackFailsClosedWithoutUtxoView)
+{
+    // Verify view POINTERS present but the mempool has no UTXO view wired:
+    // pinned_tx_admissible returns UtxoViewUnset and the pin must be EXCLUDED
+    // (the primary without --embedded-utxo lands exactly here).
+    MnStateMachine mn;
+    dash::coin::Mempool mp;
+    EmbeddedWorkInputs emb;            // has_state=false → fallback arm
+    emb.mnstates = &mn;
+    emb.mempool  = &mp;
+    dash::coin::MutableTransaction pin;
+    pin.vin.resize(1);
+    emb.pinned_local_tx = &pin;
+
+    bool emb_ran = false, fb_ran = false;
+    WorkSelection sel = select_dash_work(
+        emb,
+        [&] { return embedded_stub(emb_ran); },
+        [&] { return dashd_stub(fb_ran); });
+
+    EXPECT_EQ(sel.source, WorkSource::DashdFallback);
+    EXPECT_TRUE(sel.work.m_txs.empty());
+    EXPECT_TRUE(sel.work.m_tx_data_hex.empty());
+}
+
 // ─── Firmware-grid vardiff quantization KAT (retention fix) ──────────────────
 // HashrateTracker::set_difficulty_from_hashrate must advertise ONLY power-of-two
 // difficulties, rounded DOWN from the estimator's ideal D. Many ASIC firmwares


### PR DESCRIPTION
Follow-up to #1166 (pin hook, merged 1865c38e8), rebased onto current master.

## Why the embedded arm alone is not enough

The donation-dust consolidation is 1032 inputs, zero fee, 152 KB. dashd relay policy caps a standard transaction at 100 KB, so it can never propagate — the only route into a block is to mine it ourselves. #1166 gave the embedded builder that ability.

But the production primary is in oracle-shadow posture: it SERVES dashd's template while the embedded arm runs alongside as a shadow. A pin that only rides the embedded arm would never reach a miner there.

## What this does

`select_dash_work`'s fallback branch now splices the pin into the served copy of dashd's template. Both arms call ONE function, `splice_pinned_tx` (factored out of #1166's embedded block), so the admission gate cannot drift between them:

- every input must be an unspent coin in OUR OWN UTXO view,
- coinbase inputs must be mature at the template height,
- `Σ in − Σ out` must be exactly zero,
- the tx must not spend a masternode collateral.

Coinbase value is never touched (fee 0 adds nothing to claim); stratum merkle branches and the submitblock body both derive from the appended tx vectors, so no separate merkle plumbing is needed.

## Fail-closed

Without the verify view — `--embedded-utxo` absent so the UTXO view is unset, or mempool/mnstates null — the pin is EXCLUDED with a named cause and the template is **byte-identical to the no-pin shape**. An unverifiable pin is never included.

## Tests

Three KATs in the existing allowlisted `test_dash_work_source` target:
- no verify view → nothing appended anywhere (all four tx vectors empty),
- pointers present but UTXO view unset (exactly the primary's current posture) → excluded,
- verify view wired, mature input, fee exactly zero → appended to all four vectors, fee recorded 0, coinbase value untouched.

18/18 green on vm905 after the rebase onto master (which now carries #1169's delta KATs in the same file).

## Deploy note

Enabling this on the primary needs TWO flags in the drop-in: `--pin-local-tx-hex <blob>` and `--embedded-utxo` (the second is what makes the pin verifiable at all — without it the gate correctly refuses). The signed blob is already staged on the host: txid 9f2ad90a…6bce12, 0.90106451 DASH, sha256 81ab0d49…