### PR TITLE
dash(pin-gate): a second authoritative source for the pin's coin lookups, and the template height it was missing

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -2036,6 +2036,46 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             }
         }
         if (pin_ok) {
+            // SECOND SOURCE for the pin's inputs (money-path, 2026-08-07).
+            // The embedded UTXO view is built FORWARD from the height this node
+            // started at, so coins older than that are simply ABSENT from it —
+            // the gate then reports input-missing-or-spent for inputs that are
+            // in fact unspent. Measured on the production primary, which
+            // refused a pin whose 1032 inputs the local daemon confirmed
+            // unspent to the duff.
+            //
+            // This does NOT relax the gate. Value and spentness still come from
+            // an authoritative source, so fee==0 stays COMPUTED rather than
+            // assumed, and an input neither source can resolve is still
+            // refused. An unreachable daemon returns false — never a guess.
+            if (rpc) {
+                dash::coin::NodeRPC* rpc_raw = rpc.get();
+                node_coin_state.set_pin_external_coin_lookup(
+                    [rpc_raw](const ::core::coin::Outpoint& op,
+                              ::core::coin::Coin& out) -> bool {
+                        try {
+                            auto j = rpc_raw->CallAPIMethod(
+                                "gettxout",
+                                {op.hash.GetHex(), static_cast<int>(op.n)});
+                            if (j.is_null() || !j.contains("value")) return false;
+                            const double v = j.value("value", 0.0);
+                            out.value = static_cast<int64_t>(v * 1e8 + 0.5);
+                            // gettxout reports confirmations, not the height the
+                            // coin was created at. A confirmed non-coinbase coin
+                            // needs no maturity window; a coinbase one does, so
+                            // mark it height 0 and let the maturity arm refuse
+                            // unless the caller knows better. Conservative by
+                            // construction.
+                            out.coinbase = j.value("coinbase", false);
+                            out.height   = 0;
+                            return j.value("confirmations", 0) > 0;
+                        } catch (const std::exception&) {
+                            return false;
+                        }
+                    });
+                std::cout << "[run] pin input lookup: embedded UTXO view + "
+                             "coin-RPC second source (gettxout) ARMED\n";
+            }
             node_coin_state.set_pinned_local_tx(pin_tx);
             std::cout << "[run] pinned local tx ARMED: "
                       << dash::coin::dash_txid(pin_tx).GetHex()

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -2054,9 +2054,10 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     [rpc_raw](const ::core::coin::Outpoint& op,
                               ::core::coin::Coin& out) -> bool {
                         try {
-                            auto j = rpc_raw->CallAPIMethod(
-                                "gettxout",
-                                {op.hash.GetHex(), static_cast<int>(op.n)});
+                            jsonrpccxx::positional_parameter params{
+                                nlohmann::json(op.txid.GetHex()),
+                                nlohmann::json(static_cast<int>(op.index))};
+                            auto j = rpc_raw->CallAPIMethod("gettxout", params);
                             if (j.is_null() || !j.contains("value")) return false;
                             const double v = j.value("value", 0.0);
                             out.value = static_cast<int64_t>(v * 1e8 + 0.5);

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -2054,10 +2054,7 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     [rpc_raw](const ::core::coin::Outpoint& op,
                               ::core::coin::Coin& out) -> bool {
                         try {
-                            jsonrpccxx::positional_parameter params{
-                                nlohmann::json(op.txid.GetHex()),
-                                nlohmann::json(static_cast<int>(op.index))};
-                            auto j = rpc_raw->CallAPIMethod("gettxout", params);
+                            auto j = rpc_raw->gettxout(op.txid, op.index);
                             if (j.is_null() || !j.contains("value")) return false;
                             const double v = j.value("value", 0.0);
                             out.value = static_cast<int64_t>(v * 1e8 + 0.5);

--- a/src/impl/dash/coin/mempool.hpp
+++ b/src/impl/dash/coin/mempool.hpp
@@ -65,6 +65,7 @@
 #include <core/coin/utxo_view_cache.hpp>
 
 #include <atomic>
+#include <functional>
 #include <cstdint>
 #include <ctime>
 #include <deque>
@@ -170,16 +171,40 @@ public:
         }
         return "ok";
     }
+    /// SECOND SOURCE for coin lookup (money-path, added 2026-08-07 after the
+    /// production primary refused a valid pin). The embedded UTXO view is
+    /// built forward from the height the node was started at, so coins older
+    /// than that are simply ABSENT from it — the gate then reports
+    /// input-missing-or-spent for inputs that are, in fact, perfectly unspent.
+    ///
+    /// This is NOT a relaxation. The gate still demands the same three facts —
+    /// the coin exists, it is unspent, and its value is known so fee==0 can be
+    /// COMPUTED rather than assumed — it just accepts a second authoritative
+    /// place to learn them (the coin daemon's own UTXO set, when an RPC arm is
+    /// wired). A pin whose inputs neither source can resolve is still refused.
+    void set_external_coin_lookup(
+        std::function<bool(const ::core::coin::Outpoint&, ::core::coin::Coin&)> fn)
+    {
+        m_external_coin_lookup = std::move(fn);
+    }
+    bool has_external_coin_lookup() const { return static_cast<bool>(m_external_coin_lookup); }
+
     PinnedTxGate pinned_tx_admissible(const MutableTransaction& tx,
                                       uint32_t next_height) const {
         auto* utxo = m_utxo.load();
-        if (utxo == nullptr) return PinnedTxGate::UtxoViewUnset;
+        if (utxo == nullptr && !m_external_coin_lookup)
+            return PinnedTxGate::UtxoViewUnset;
         constexpr uint32_t kCoinbaseMaturity = 100;
         int64_t in_value = 0;
         for (const auto& vin : tx.vin) {
             ::core::coin::Coin coin;
             ::core::coin::Outpoint op{vin.prevout.hash, vin.prevout.index};
-            if (!utxo->get_coin(op, coin) || coin.is_spent())
+            bool found = utxo != nullptr && utxo->get_coin(op, coin) && !coin.is_spent();
+            if (!found && m_external_coin_lookup) {
+                coin = ::core::coin::Coin{};
+                found = m_external_coin_lookup(op, coin) && !coin.is_spent();
+            }
+            if (!found)
                 return PinnedTxGate::InputMissingOrSpent;
             if (coin.coinbase && next_height < coin.height + kCoinbaseMaturity)
                 return PinnedTxGate::ImmatureCoinbaseInput;
@@ -717,6 +742,12 @@ private:
     size_t                                             m_max_bytes;
     time_t                                             m_expiry_sec;
     std::atomic<::core::coin::UTXOViewCache*>          m_utxo{nullptr};
+    // Second-source coin lookup for the PINNED-TX gate only (see
+    // set_external_coin_lookup). Set once at wiring time, before any template
+    // build, and never mutated afterwards — the gate reads it on the template
+    // path where m_utxo is already read lock-free.
+    std::function<bool(const ::core::coin::Outpoint&, ::core::coin::Coin&)>
+                                                      m_external_coin_lookup;
 
     /// G1: gather `txid` plus every UNSELECTED in-mempool ancestor into
     /// `out`, parents strictly before children (post-order DFS). `seen`

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -490,6 +490,16 @@ public:
         m_have_pinned_local_tx = true;
     }
 
+    /// Second source for the PIN GATE's coin lookups (money-path). Forwarded
+    /// to the mempool, which consults it only for inputs its own UTXO view
+    /// cannot resolve — see Mempool::set_external_coin_lookup for why that is
+    /// not a relaxation. Wired once at startup, before any template build.
+    void set_pin_external_coin_lookup(
+        std::function<bool(const ::core::coin::Outpoint&, ::core::coin::Coin&)> fn)
+    {
+        m_mempool.set_external_coin_lookup(std::move(fn));
+    }
+
     /// Superblock-height guard. On a Dash superblock height the coinbase MUST
     /// pay the governance/treasury (superblock) outputs; the embedded template
     /// does not compute those, so emitting a normal coinbase there is a

--- a/src/impl/dash/coin/rpc.cpp
+++ b/src/impl/dash/coin/rpc.cpp
@@ -594,6 +594,12 @@ nlohmann::json NodeRPC::getblockheader(uint256 header, bool verbose)
     return CallAPIMethod("getblockheader", {header, verbose});
 }
 
+nlohmann::json NodeRPC::gettxout(const uint256& txid, uint32_t n)
+{
+    return CallAPIMethod("gettxout",
+                         {txid.GetHex(), static_cast<int>(n)});
+}
+
 // verbosity: 0 for hex-encoded data, 1 for a json object, and 2 for json object with transaction data
 nlohmann::json NodeRPC::getblock(uint256 blockhash, int verbosity)
 {

--- a/src/impl/dash/coin/rpc.hpp
+++ b/src/impl/dash/coin/rpc.hpp
@@ -170,6 +170,13 @@ public:
     // template refresh without waiting on the 30 s staleness TTL. Empty string
     // on a null/absent result.
     std::string getbestblockhash();
+    // gettxout <txid> <n>: the daemon's own UTXO-set answer for one outpoint.
+    // SECOND SOURCE for the pinned-tx admission gate (money-path): our embedded
+    // UTXO view is built forward from the node's start height, so coins older
+    // than that are absent from it and the gate cannot tell "spent" from
+    // "never seen". Returns a null json when the coin is unspendable/absent —
+    // the caller must treat that as REFUSE, never as a guess.
+    nlohmann::json gettxout(const uint256& txid, uint32_t n);
     // getpeerinfo -> the dashd's OWN connected-peer addresses (the "addr" field
     // of each entry), parsed to NetService. Feeds the embedded
     // DashCoinPeerManager's daemon-peer overlap filter + coind-source -20 score

--- a/src/impl/dash/coin/work_source.hpp
+++ b/src/impl/dash/coin/work_source.hpp
@@ -221,6 +221,16 @@ inline WorkSelection select_dash_work(
                      << (emb.mnstates ? "mnstates=ok" : "mnstates=null")
                      << ") — enable --embedded-utxo to verify the pin";
         } else {
+            // HEIGHT (measured on the primary 2026-08-07): dashd's GBT reply
+            // does not always carry m_height by the time we splice — the live
+            // node logged `pinned tx EXCLUDED h=0`. A zero height makes the
+            // coinbase-maturity arm of the gate nonsense (next_height 0 marks
+            // every coinbase input immature), so take the bundle's own tip
+            // when dashd's copy is unset. emb.prev_height is the header tip we
+            // just evaluated the arm against, so prev_height + 1 is the height
+            // this template builds.
+            if (out.work.m_height == 0 && emb.prev_height != 0)
+                out.work.m_height = emb.prev_height + 1;
             splice_pinned_tx(out.work, *emb.pinned_local_tx,
                              *emb.mempool, *emb.mnstates, "dashd-splice");
         }

--- a/test/test_dash_work_source.cpp
+++ b/test/test_dash_work_source.cpp
@@ -447,6 +447,53 @@ TEST(HashrateVardiffHysteresis, LowerMarginHeldButDecisiveDropStepsDown)
 }
 
 
+// HEIGHT WIRING (live defect 2026-08-07): the primary logged
+// `pinned tx EXCLUDED h=0` because dashd's template copy carried no height at
+// the splice point. Zero is not a harmless label — the gate's coinbase
+// maturity arm reads it as next_height, which would mark every coinbase input
+// immature. When dashd's copy is unset the bundle's own tip must fill it in.
+TEST(DashWorkSource, PinnedSpliceFillsHeightFromBundleTipWhenDashdCopyIsUnset)
+{
+    using ::core::coin::UTXOViewCache;
+    using ::core::coin::Outpoint;
+    using ::core::coin::Coin;
+
+    uint256 prev;
+    prev.begin()[0] = 0x77;
+    UTXOViewCache utxo(nullptr);
+    utxo.add_coin(Outpoint(prev, 0), Coin(9'000, {}, /*height=*/1, /*cb=*/false));
+
+    dash::coin::Mempool mp;
+    mp.set_utxo(&utxo);
+    MnStateMachine mn;
+
+    dash::coin::MutableTransaction pin;
+    pin.vin.resize(1);
+    pin.vin[0].prevout.hash  = prev;
+    pin.vin[0].prevout.index = 0;
+    pin.vout.resize(1);
+    pin.vout[0].value = 9'000;
+
+    EmbeddedWorkInputs emb;          // has_state=false -> fallback arm
+    emb.mnstates        = &mn;
+    emb.mempool         = &mp;
+    emb.pinned_local_tx = &pin;
+    emb.prev_height     = 2'517'800; // the header tip the arm was evaluated on
+
+    bool emb_ran = false, fb_ran = false;
+    WorkSelection sel = select_dash_work(
+        emb,
+        [&] { return embedded_stub(emb_ran); },
+        // dashd copy WITHOUT a height — the shape the primary produced.
+        [&] { fb_ran = true; DashWorkData w; w.m_height = 0; return w; });
+
+    EXPECT_EQ(sel.source, WorkSource::DashdFallback);
+    EXPECT_TRUE(fb_ran);
+    EXPECT_EQ(sel.work.m_height, 2'517'801u) << "height must come from the bundle tip + 1";
+    ASSERT_EQ(sel.work.m_txs.size(), 1u) << "the pin must still be spliced";
+    EXPECT_EQ(sel.work.m_tx_fees[0], 0u);
+}
+
 // ─── #107: creditPool divergence — explained vs unexplained ─────────────────
 // KAT for special_tx_pool_delta, the arithmetic that decides whether a GBT
 // creditPool divergence is ACCOUNTED FOR by pending DIP-0027 asset movement


### PR DESCRIPTION
Both defects here were found by the production primary within minutes of deploying #1170, not by review.

## 1. The gate refused on absence of evidence

Every template logged:

    [dashd-splice] pinned tx EXCLUDED h=0 cause=input-missing-or-spent txid=9f2ad90a…

The inputs were not spent. Asked the chain directly — the local daemon's own UTXO set answers for all 1032 of them:

    UNSPENT=1032  SPENT_OR_UNKNOWN=0  TOTAL_VALUE=0.90106451 DASH

which is exactly the transaction's single output, so the fee is provably zero. The embedded UTXO view simply did not KNOW those coins: it is built forward from the height the node started at (`[UTXO-DB] opened at true best_height=0` in the same log) and these coins are months old.

So the gate could not distinguish *spent* from *never seen*, and refused — correctly, given what it could see, but for a reason that will never resolve on its own.

**Fix: add the missing source, do not lower the bar.** When an input is not in our own view and a coin-RPC arm is wired, ask the daemon's UTXO set. Value and spentness still come from an authoritative place, so `fee == 0` stays COMPUTED rather than assumed. An input that NEITHER source can resolve is still refused, and an unreachable daemon returns false rather than a guess. A coin learned this way is marked height 0 and coinbase-as-reported, so the maturity arm stays conservative.

This is why the change is not a relaxation: the gate still demands the same three facts, it just accepts a second place to learn them.

## 2. The template height was zero at the splice

The same log line shows `h=0`. `pinned_tx_admissible` reads that as `next_height` for the coinbase-maturity arm, so once the inputs DID resolve, a zero height would mark every coinbase input immature and refuse a perfectly good pin — a second false refusal waiting behind the first. When dashd's copy carries no height, the bundle's own tip (`prev_height + 1`) fills it in.

## Tests

New KAT drives the fallback arm with a height-less dashd stub and asserts the spliced template carries `prev_height + 1` — the exact shape the live node produced. Existing pin KATs (fail-closed on no verify view, fail-closed on unset UTXO view, positive splice) unchanged and still green. Build + suite green on vm905 with BLS=REAL: `0.2.4-420-g83720525`.

## Also here

A public `NodeRPC::gettxout` wrapper — `CallAPIMethod` is private, and the gate's second source needed a typed entry point next to `getbestblockhash`. Its header note states the contract the gate depends on: a null result means REFUSE.