### PR TITLE
dash(qc-prefetch): ask for a DKG cycle's member sets before the commitments need them (#108)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -3785,6 +3785,12 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         // which also covers --regtest chains riding the testnet flag), exactly
         // the old refusal. The emit gate re-derives this same plan and
         // hard-rejects any template whose type-6 set drifts from it.
+        // #108: the member source is created inside the embedded-arm block
+        // below, but the tip-advance callback that must PREFETCH from it is
+        // installed further down at outer scope. Hold a handle out here so the
+        // callback can reach it; stays null when the embedded arm is off, and
+        // the callback checks.
+        std::shared_ptr<dash::coin::QuorumMemberSource> qc_ms_prefetch_handle;
         if (run_arm.embedded_arm_enabled) {
             const auto qc_net = testnet ? dash::coin::LlmqNetwork::Testnet
                                         : dash::coin::LlmqNetwork::Mainnet;
@@ -3982,6 +3988,8 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             // closed to the dashd fallback (NOT null-served — dkg_commitments.hpp
             // HEIGHT COMPLETENESS). That is the pre-item-4 posture.
             if (coin_p2p) {
+                // #108: publish the handle for the tip-advance prefetch.
+                qc_ms_prefetch_handle = qc_member_source;
                 qc_member_source->set_send_getqrinfo(
                     [cp = coin_p2p.get()](const std::vector<uint256>& bases,
                                           const uint256& req, bool extra) {
@@ -4582,7 +4590,7 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             [&coin_state, &stratum_server, hc = header_chain.get(),
              addr_ver, p2sh_ver, ws = work_source.get(),
              cp = coin_p2p.get(), sml_base, m = maintainer.get(),
-             mnl = mn_ckpt_lane.get()]
+             mnl = mn_ckpt_lane.get(), qcms = qc_ms_prefetch_handle]
             (const uint256&, uint32_t, const uint256& new_tip, uint32_t new_height,
              bool was_reorg) {
                 // E2d bridge driver. Safe + REACHABLE here: HeaderChain fires
@@ -4594,6 +4602,13 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 // relies on exactly that property and is proven live.
                 // No-op unless the lane was armed on the daemonless path.
                 if (mnl) mnl->pump();
+                // #108 QC-PREFETCH: ask for the member sets this DKG cycle
+                // will need while the tip is still ~10 blocks short of the
+                // mining window, instead of at the first qfcommit that needs
+                // them. Same request paths, same authentication, same dedupe —
+                // only the timing changes. Measured cost of asking late: 48
+                // qc-plan-underivable declines on the daemonless soak.
+                if (qcms) qcms->prefetch_cycle(new_height);
                 auto ta = dash::coin::tip_advance_from_chain(
                     *hc, addr_ver, p2sh_ver);
                 if (ta) {

--- a/src/impl/dash/coin/quorum_member_source.hpp
+++ b/src/impl/dash/coin/quorum_member_source.hpp
@@ -270,6 +270,21 @@ public:
     void prefetch_cycle(uint32_t tip_height)
     {
         if (tip_height == 0) return;
+        // CATCH-UP GATE. The tip callback fires once per headers MESSAGE, and
+        // add_headers coalesces up to 2000 headers into one — so during a cold
+        // start or a long resync each call arrives ~2000 blocks above the last.
+        // Every such call is a memo miss for every type (2000 > any mainnet
+        // dkgInterval), and each miss asks for a cycle whose mining window is
+        // long past: measured shape is ~215 requests / ~100 MB of full MN
+        // snapshots from a checkpointed cold start, all of it riding the ONE
+        // ordered stream to the primary coin-P2P peer that the cold-start path
+        // (#1162/#1151) just spent effort making fast. Prefetch is an
+        // optimisation for the LIVE tip; while we are catching up the qfcommit
+        // kick remains the correct and sufficient mechanism.
+        const uint32_t prev = m_last_prefetch_tip;
+        m_last_prefetch_tip = tip_height;
+        if (prev != 0 && tip_height > prev + kMaxDkgInterval)
+            return;   // jumped a whole cycle or more => still catching up
         for (const auto& p : enabled_llmqs(m_net)) {
             if (p.dkg_interval == 0) continue;
             // The cycle whose mining window this tip is approaching: the most
@@ -306,17 +321,30 @@ public:
             }
             // Only act once per (type, cycle) — repeated tips inside the same
             // cycle must not re-walk the request path.
+            // Resolve the header BEFORE memoising. A header gap is a
+            // "not yet", not a "done": memoising it would spend the cycle's
+            // only prefetch on a lookup that failed.
+            auto base_hash = m_hash_at_height(cycle_base);
+            if (!base_hash || base_hash->IsNull()) continue;  // retry next tip
             const uint64_t seen_key =
                 (static_cast<uint64_t>(p.type) << 32) | cycle_base;
             if (!m_prefetched_cycles.insert(seen_key).second) continue;
-            auto base_hash = m_hash_at_height(cycle_base);
-            if (!base_hash || base_hash->IsNull()) continue;  // header gap: skip
+            // Lead time is measured from the tip we are ON, not from the
+            // window offset: a rotated type waits for its slot headers, so it
+            // asks LATER than a non-rotated one and the honest number is the
+            // difference. (An earlier version printed mining_window_start,
+            // which overstated the rotated lane by 4x.)
+            const uint32_t window_open_h = cycle_base + p.mining_window_start;
+            const long lead = static_cast<long>(window_open_h)
+                            - static_cast<long>(tip_height);
             LOG_INFO << "[QC-PREFETCH] cycle_base=" << cycle_base
                      << " type=" << static_cast<int>(p.type)
                      << " hash=" << base_hash->GetHex().substr(0, 8)
                      << " tip=" << tip_height
-                     << " (asking " << (p.mining_window_start)
-                     << " blocks before the mining window opens)";
+                     << " rotated=" << (p.use_rotation ? 1 : 0)
+                     << " lead=" << lead
+                     << " blocks before the mining window opens at h="
+                     << window_open_h;
             request(p.type, *base_hash);
         }
         // Bound the memo: a cycle far behind the tip can never be asked for
@@ -884,7 +912,11 @@ private:
     // wholesale when it grows past the bound — re-walking a live cycle costs
     // one deduped request(), which the pending/ready maps then absorb.
     static constexpr size_t kPrefetchMemoMax = 4096;
+    // Largest mainnet dkgInterval (LLMQ_400_85 = 576). A tip advance larger
+    // than this cannot be live-chain progress; it is a headers batch.
+    static constexpr uint32_t kMaxDkgInterval = 576;
     std::set<uint64_t> m_prefetched_cycles;
+    uint32_t           m_last_prefetch_tip{0};
 
     const LlmqParamsView* params_for(uint8_t type) const
     {

--- a/src/impl/dash/coin/quorum_member_source.hpp
+++ b/src/impl/dash/coin/quorum_member_source.hpp
@@ -276,6 +276,34 @@ public:
             // recent boundary at or below the tip.
             const uint32_t cycle_base = tip_height - (tip_height % p.dkg_interval);
             if (cycle_base == 0) continue;
+            // ROTATED TYPES (DIP-24): DO NOT ask at the cycle boundary.
+            //
+            // A rotated reply publishes one member set per slot, keyed by the
+            // header at cycleBase + quorumIndex (finalize_rotated). At the tip
+            // that CROSSES the boundary only cycleBase itself exists, so 31 of
+            // 32 slots are skipped for want of a header — and the one slot that
+            // does publish is index 0, whose key IS the cycle key. From then on
+            // request_rotated short-circuits on "cycle already ready" and the
+            // qfcommit kick can never re-ask: the cycle is permanently stuck at
+            // 1/32 sourced. That would REGRESS the rotated lane proven live by
+            // #1077, which works precisely because the qfcommit kick fires
+            // inside the mining window, when every slot header exists.
+            //
+            // So wait until the last slot's base header is in the chain. With
+            // signing_active_quorum_count=32 and mining_window_start=42 the
+            // prefetch still lands ~10 blocks (~25 min) before the window
+            // opens, which is the entire point of this change.
+            //
+            // The memo is inserted AFTER this check on purpose: memoising a
+            // cycle we deliberately skipped would burn the only chance to
+            // prefetch it at all.
+            if (p.use_rotation) {
+                const uint32_t last_slot_h =
+                    cycle_base + (p.signing_active_quorum_count > 0
+                                      ? p.signing_active_quorum_count - 1
+                                      : 0);
+                if (tip_height < last_slot_h) continue;   // retry on a later tip
+            }
             // Only act once per (type, cycle) — repeated tips inside the same
             // cycle must not re-walk the request path.
             const uint64_t seen_key =

--- a/src/impl/dash/coin/quorum_member_source.hpp
+++ b/src/impl/dash/coin/quorum_member_source.hpp
@@ -128,6 +128,7 @@
 #include <deque>
 #include <functional>
 #include <map>
+#include <set>
 #include <optional>
 #include <string>
 #include <vector>
@@ -239,6 +240,63 @@ public:
 
     /// Kick sourcing for a quorum (idempotent). Called when a qfcommit for the
     /// quorum is admitted, so the member set is ready by the DKG-window height.
+    /// #108 — PREFETCH the member sets a DKG cycle will need, BEFORE the
+    /// commitments that need them arrive.
+    ///
+    /// MEASURED (fully-daemonless soak, 2026-08-06/07): 48 of the embedded
+    /// arm's decline events were cause=qc-plan-underivable, and they are not
+    /// scattered — every one sits at a height h where (h % dkgInterval) equals
+    /// the type's mining_window_start, and each clears in 1-7 minutes. That is
+    /// one getmnlistd/getqrinfo round trip, paid at the exact moment the plan
+    /// first needs the answer.
+    ///
+    /// The inputs, however, are available much earlier: a non-rotated quorum's
+    /// member set derives from the WORK block (quorumBase - 8), and the cycle
+    /// base is known the moment the tip crosses it — typically ten blocks and
+    /// ~25 minutes before the mining window opens. So the round trip is not
+    /// unavoidable latency; it is latency we chose by asking late.
+    ///
+    /// This asks early. It calls the SAME request paths with the SAME key, so
+    /// every invariant they carry is untouched: DIP-4 authentication of the
+    /// snapshot, dedupe-by-block-hash, one outstanding request per base, FIFO
+    /// reaping, and the demux that keeps historical replies away from the tip
+    /// SML. The qfcommit kick stays exactly as it was — this only changes WHEN
+    /// the first attempt happens, never whether the answer is trusted.
+    ///
+    /// Silent no-ops are deliberate: a header we do not hold yet, a pre-V20
+    /// height, a type whose params we do not know. Prefetch is an optimisation
+    /// and must never fail a template; the qfcommit kick remains the fallback
+    /// for every case this skips.
+    void prefetch_cycle(uint32_t tip_height)
+    {
+        if (tip_height == 0) return;
+        for (const auto& p : enabled_llmqs(m_net)) {
+            if (p.dkg_interval == 0) continue;
+            // The cycle whose mining window this tip is approaching: the most
+            // recent boundary at or below the tip.
+            const uint32_t cycle_base = tip_height - (tip_height % p.dkg_interval);
+            if (cycle_base == 0) continue;
+            // Only act once per (type, cycle) — repeated tips inside the same
+            // cycle must not re-walk the request path.
+            const uint64_t seen_key =
+                (static_cast<uint64_t>(p.type) << 32) | cycle_base;
+            if (!m_prefetched_cycles.insert(seen_key).second) continue;
+            auto base_hash = m_hash_at_height(cycle_base);
+            if (!base_hash || base_hash->IsNull()) continue;  // header gap: skip
+            LOG_INFO << "[QC-PREFETCH] cycle_base=" << cycle_base
+                     << " type=" << static_cast<int>(p.type)
+                     << " hash=" << base_hash->GetHex().substr(0, 8)
+                     << " tip=" << tip_height
+                     << " (asking " << (p.mining_window_start)
+                     << " blocks before the mining window opens)";
+            request(p.type, *base_hash);
+        }
+        // Bound the memo: a cycle far behind the tip can never be asked for
+        // again, and an unbounded set would grow for the life of the node.
+        if (m_prefetched_cycles.size() > kPrefetchMemoMax)
+            m_prefetched_cycles.clear();
+    }
+
     void request(uint8_t llmq_type, const uint256& quorum_hash)
     {
         // request() is kicked on every admitted qfcommit, which makes it the
@@ -793,6 +851,12 @@ private:
         uint32_t cycle_base_height{0};
         int64_t  sent_at{0};
     };
+
+    // #108 prefetch memo: (type<<32 | cycle_base) already walked. Cleared
+    // wholesale when it grows past the bound — re-walking a live cycle costs
+    // one deduped request(), which the pending/ready maps then absorb.
+    static constexpr size_t kPrefetchMemoMax = 4096;
+    std::set<uint64_t> m_prefetched_cycles;
 
     const LlmqParamsView* params_for(uint8_t type) const
     {

--- a/test/test_dash_qrinfo.cpp
+++ b/test/test_dash_qrinfo.cpp
@@ -464,7 +464,11 @@ TEST(DashQcPrefetch, RotatedCycleIsNotAskedBeforeItsSlotHeadersExist)
 {
     PrefetchHarness h;
     // LLMQ_60_75 on mainnet: dkg_interval 288, 32 signing-active slots.
-    const uint32_t cycle_base = 2517504;      // 2517504 % 288 == 0
+    // 2517408 = 288 * 8741, so it IS a cycle base. (An unaligned height would
+    // make prefetch_cycle derive a DIFFERENT base whose header we never added,
+    // and the test would pass for the wrong reason — it did, once.)
+    const uint32_t cycle_base = 2517408;
+    static_assert(2517408u % 288u == 0u, "cycle_base must be dkgInterval-aligned");
     h.add_range(cycle_base - 8, cycle_base);  // ONLY the base exists
 
     h.src->prefetch_cycle(cycle_base);

--- a/test/test_dash_qrinfo.cpp
+++ b/test/test_dash_qrinfo.cpp
@@ -362,6 +362,125 @@ struct Harness {
 
 } // namespace
 
+// ── #108 QC-PREFETCH: ask early, but never before the slot headers exist ────
+//
+// The prefetch asks for a DKG cycle's member sets at the cycle boundary rather
+// than at the first qfcommit that needs them — 48 qc-plan-underivable declines
+// on the daemonless soak were exactly that round trip, paid late.
+//
+// The ROTATED lane must NOT be asked at the boundary. A rotated reply keys one
+// member set per slot on the header at cycleBase + quorumIndex; at the boundary
+// only cycleBase exists, so 31 of 32 slots would be skipped for want of a
+// header — and the one slot that publishes is index 0, whose key IS the cycle
+// key, after which request_rotated short-circuits "already ready" forever.
+// These KATs pin BOTH halves of that contract.
+namespace {
+
+struct PrefetchHarness {
+    std::map<uint32_t, uint256> by_height;
+    std::map<uint256, uint32_t> by_hash;
+    std::vector<std::pair<uint256, uint256>> sends;      // non-rotated getmnlistd
+    int qrinfo_sends{0};                                  // rotated getqrinfo
+
+    std::unique_ptr<QuorumMemberSource> src;
+
+    explicit PrefetchHarness(LlmqNetwork net = LlmqNetwork::Mainnet)
+    {
+        src = std::make_unique<QuorumMemberSource>(
+            net,
+            [this](uint32_t h) -> std::optional<uint256> {
+                auto it = by_height.find(h);
+                if (it == by_height.end()) return std::nullopt;
+                return it->second;
+            },
+            [this](const uint256& bh) -> std::optional<uint32_t> {
+                auto it = by_hash.find(bh);
+                if (it == by_hash.end()) return std::nullopt;
+                return it->second;
+            },
+            [](const uint256&) -> std::optional<uint256> { return std::nullopt; },
+            [this](const uint256& base, const uint256& tgt) {
+                sends.emplace_back(base, tgt);
+            });
+        src->set_send_getqrinfo(
+            [this](const std::vector<uint256>&, const uint256&, bool) {
+                ++qrinfo_sends;
+            });
+    }
+
+    void add(uint32_t h)
+    {
+        uint256 hash;
+        hash.begin()[0] = static_cast<unsigned char>(h & 0xff);
+        hash.begin()[1] = static_cast<unsigned char>((h >> 8) & 0xff);
+        hash.begin()[2] = static_cast<unsigned char>((h >> 16) & 0xff);
+        by_height[h] = hash;
+        by_hash[hash] = h;
+    }
+    void add_range(uint32_t from, uint32_t to) { for (uint32_t h = from; h <= to; ++h) add(h); }
+};
+
+} // namespace
+
+// A tip that CROSSES a cycle boundary asks for the non-rotated cycle
+// immediately — before any qfcommit for that cycle can have arrived.
+TEST(DashQcPrefetch, BoundaryTipAsksForTheNonRotatedCycle)
+{
+    PrefetchHarness h;
+    // LLMQ_100_67 on mainnet: dkg_interval 24. Give the chain the cycle base
+    // and its work block (base - 8).
+    const uint32_t cycle_base = 2517600;      // 2517600 % 24 == 0
+    h.add_range(cycle_base - 8, cycle_base);
+
+    EXPECT_TRUE(h.sends.empty()) << "nothing asked before the tip advances";
+    h.src->prefetch_cycle(cycle_base);
+    EXPECT_FALSE(h.sends.empty())
+        << "the boundary tip must have asked for at least one non-rotated cycle";
+}
+
+// The SAME cycle asked twice must not draw a second request — the memo and the
+// pending/ready dedupe both have to hold.
+TEST(DashQcPrefetch, RepeatedTipsInsideOneCycleDoNotReAsk)
+{
+    PrefetchHarness h;
+    const uint32_t cycle_base = 2517600;
+    h.add_range(cycle_base - 8, cycle_base + 5);
+
+    h.src->prefetch_cycle(cycle_base);
+    const size_t after_first = h.sends.size();
+    ASSERT_GT(after_first, 0u);
+
+    h.src->prefetch_cycle(cycle_base + 1);
+    h.src->prefetch_cycle(cycle_base + 2);
+    EXPECT_EQ(h.sends.size(), after_first)
+        << "tips inside the same cycle must not re-walk the request path";
+}
+
+// THE REGRESSION GUARD. At the cycle boundary the rotated slot headers
+// (cycleBase+1 .. cycleBase+31) do not exist yet. Asking then would publish
+// 1/32 slots and latch the cycle ready forever, so the prefetch must stay
+// silent on the rotated lane until the last slot header is in the chain.
+TEST(DashQcPrefetch, RotatedCycleIsNotAskedBeforeItsSlotHeadersExist)
+{
+    PrefetchHarness h;
+    // LLMQ_60_75 on mainnet: dkg_interval 288, 32 signing-active slots.
+    const uint32_t cycle_base = 2517504;      // 2517504 % 288 == 0
+    h.add_range(cycle_base - 8, cycle_base);  // ONLY the base exists
+
+    h.src->prefetch_cycle(cycle_base);
+    EXPECT_EQ(h.qrinfo_sends, 0)
+        << "a rotated cycle must not be requested while 31 of its 32 slot "
+           "headers are missing — that publishes 1/32 and latches the cycle";
+
+    // Once the whole slot range is in the chain the same cycle IS asked: the
+    // skip must be a deferral, not a permanent memo burn.
+    h.add_range(cycle_base + 1, cycle_base + 31);
+    h.src->prefetch_cycle(cycle_base + 31);
+    EXPECT_GT(h.qrinfo_sends, 0)
+        << "after the slot headers arrive the rotated cycle must be prefetched";
+}
+
+
 TEST(DashQrInfo, RequestRotatedEmitsAnEmptyBaseFullSnapshotRequest)
 {
     Harness h;

--- a/test/test_dash_qrinfo.cpp
+++ b/test/test_dash_qrinfo.cpp
@@ -485,6 +485,55 @@ TEST(DashQcPrefetch, RotatedCycleIsNotAskedBeforeItsSlotHeadersExist)
 }
 
 
+// CATCH-UP GATE (Fable review, 2026-08-07): the tip callback fires once per
+// headers MESSAGE and add_headers coalesces up to 2000 headers, so a cold
+// start delivers tips ~2000 apart. Every such call would be a memo miss for
+// every type and would ask for cycles whose mining windows are long past —
+// measured shape ~215 requests / ~100 MB of full MN snapshots down the single
+// ordered stream the cold-start path depends on. Prefetch is for the LIVE tip.
+TEST(DashQcPrefetch, CatchUpTipJumpsAskNothing)
+{
+    PrefetchHarness h;
+    const uint32_t base = 2517600;                 // 2517600 % 24 == 0
+    h.add_range(base - 8, base + 4100);            // headers present either way
+
+    h.src->prefetch_cycle(base);                   // first call primes the tip
+    const size_t after_first = h.sends.size();
+    ASSERT_GT(after_first, 0u) << "a live tip must still prefetch";
+
+    // Two coalesced headers batches: +2000 each. Both must be refused.
+    h.src->prefetch_cycle(base + 2000);
+    h.src->prefetch_cycle(base + 4000);
+    EXPECT_EQ(h.sends.size(), after_first)
+        << "a tip jump larger than the biggest dkgInterval means we are still "
+           "catching up — prefetch must stay silent";
+
+    // Back to live cadence (+1): asking resumes.
+    h.src->prefetch_cycle(base + 4001);
+    EXPECT_GT(h.sends.size(), after_first)
+        << "the gate must be a deferral for catch-up, not a permanent stop";
+}
+
+// A header gap must NOT burn the cycle's single prefetch: the lookup happens
+// BEFORE the memo insert, so the next tip retries.
+TEST(DashQcPrefetch, HeaderGapDoesNotBurnTheMemo)
+{
+    PrefetchHarness h;
+    const uint32_t base = 2517600;
+    // Deliberately withhold the cycle base header; give only the work block.
+    h.add_range(base - 8, base - 1);
+
+    h.src->prefetch_cycle(base);
+    EXPECT_TRUE(h.sends.empty()) << "no header, nothing to ask with";
+
+    // Header arrives; the SAME cycle must now be asked for.
+    h.add(base);
+    h.src->prefetch_cycle(base);
+    EXPECT_FALSE(h.sends.empty())
+        << "a header gap is a 'not yet', not a spent prefetch";
+}
+
+
 TEST(DashQrInfo, RequestRotatedEmitsAnEmptyBaseFullSnapshotRequest)
 {
     Harness h;


### PR DESCRIPTION
The single largest remaining eater of embedded serving, measured rather than guessed — and the first cut of this change contained a regression that an adversarial review caught before it shipped. Both are documented below.

## The measurement

On the fully-daemonless conjunct soak (no `--coin-rpc` at all): would-serve 238 / would-decline 33, and **48 of the decline events are `cause=qc-plan-underivable`**. They are not scattered — every one sits where `h % dkgInterval` equals that type's `mining_window_start`, and each clears in 1–7 minutes. That is one getmnlistd/getqrinfo round trip, paid at the exact moment the plan first needs the answer.

The inputs are available much earlier. A non-rotated quorum's member set derives from the WORK block (`quorumBase - 8`), and the cycle base is known the moment the tip crosses it — typically ten blocks and ~25 minutes before the mining window opens. The round trip was never unavoidable latency; it was latency we chose by asking late.

## The change

`prefetch_cycle(tip_height)` walks the enabled LLMQ types, derives each type's current cycle base, and calls the **same** `request()` path with the **same** key. Every invariant that path carries is untouched: DIP-4 authentication of the snapshot, dedupe-by-block-hash, one outstanding request per base, FIFO reaping, and the demux that keeps historical replies away from the tip SML. The qfcommit kick stays exactly as it was, so anything prefetch skips still resolves the old way. Skips are silent and deliberate (header not held, pre-V20 height, unknown type) — a prefetch must never fail a template.

Wired from the header-chain tip-advance callback, which already drives the MN-checkpoint pump on the same thread.

## The regression the first cut had

A rotated (DIP-24) reply publishes one member set per slot, keyed by the header at `cycleBase + quorumIndex`. Prefetching at the cycle boundary asks while **only `cycleBase` exists**, so `finalize_rotated` skips 31 of 32 slots for want of a header — and the single slot that does publish is index 0, **whose key IS the cycle key**. `request_rotated` then short-circuits on "cycle already ready" for the rest of that cycle, so the qfcommit kick can never re-ask: the cycle is stuck at 1/32 sourced, and `published != 0` keeps the no-slot-headers warning silent.

That would have regressed the rotated lane proven live by #1077, which works precisely because the qfcommit kick fires **inside** the mining window, when every slot header exists.

Rotated types now wait until `cycleBase + signing_active_quorum_count - 1` is in the chain. With 32 slots and `mining_window_start = 42` the prefetch still lands ~10 blocks before the window opens, so the change keeps its entire benefit. The memo insert moved **after** the guard — memoising a cycle we deliberately skipped would burn the only chance to prefetch it.

## Tests

Three KATs in `test_dash_qrinfo.cpp`, which is folded into a **CI-built** target. (`test_dash_quorum_member_source.cpp` is BLS-gated and allowlist-exempt, so a KAT there would never run in CI — the silently-passing NOT_BUILT trap of #143.)

- a boundary tip asks for the non-rotated cycle,
- further tips inside the same cycle do not re-ask,
- **the rotated cycle is NOT asked while its slot headers are missing, and IS asked once they arrive** — the regression guard.

One honest note on the third KAT: its first version used a height that was not `dkgInterval`-aligned, so `prefetch_cycle` derived a different base whose header the harness never added. It passed for the wrong reason (silence from a header gap, not from the guard) while the second half failed. Fixed to a real cycle base with a `static_assert` pinning the property.

201/201 green on the full target on vm905, BLS=REAL.