### PR TITLE
dash: pin the donation tx into the template that is actually SERVED

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -2065,8 +2065,29 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                             // unless the caller knows better. Conservative by
                             // construction.
                             out.coinbase = j.value("coinbase", false);
-                            out.height   = 0;
-                            return j.value("confirmations", 0) > 0;
+                            const int confs = j.value("confirmations", 0);
+                            if (confs <= 0) return false;   // unconfirmed => refuse
+                            // HEIGHT, not a placeholder. Measured on the
+                            // production primary: an earlier version set
+                            // height 0 "conservatively", which made the
+                            // maturity arm read every coinbase-sourced coin as
+                            // immature and refuse it forever — and the donation
+                            // inputs ARE coinbase outputs (they are mining
+                            // payouts), so that conservatism refused exactly
+                            // the transaction it was meant to protect:
+                            //   pinned tx EXCLUDED cause=immature-coinbase-input
+                            // gettxout reports confirmations, and the coin's
+                            // height is the chain tip minus (confirmations-1).
+                            // We take the tip from the daemon's own answer
+                            // rather than a local view, so the number and the
+                            // coin come from the same source.
+                            const int tip = rpc_raw->blockcount_cached();
+                            if (tip <= 0) return false;     // no tip => refuse
+                            const long h = static_cast<long>(tip)
+                                         - static_cast<long>(confs) + 1;
+                            if (h < 0) return false;
+                            out.height = static_cast<uint32_t>(h);
+                            return true;
                         } catch (const std::exception&) {
                             return false;
                         }

--- a/src/impl/dash/coin/embedded_gbt.hpp
+++ b/src/impl/dash/coin/embedded_gbt.hpp
@@ -108,27 +108,45 @@ inline const std::array<uint8_t, 96> k_zero_cl_sig{};
 /// unspent against OUR UTXO view, coinbase-mature at this height, fee exactly
 /// zero, no MN-collateral spend). A bad pin must never cost a block, and an
 /// unverifiable one (utxo-view-unset) must never be included.
-inline void splice_pinned_tx(DashWorkData& w,
-                             const MutableTransaction& pin,
-                             const Mempool& mempool,
-                             const MnStateMachine& mnstates,
-                             const char* arm)
+/// The pin gate's ANSWER as a self-contained VALUE.
+///
+/// The served-dashd arm cannot run the gate where it appends. The gate reads
+/// the mempool UTXO view and the MN state machine, which the coin-P2P
+/// maintainer mutates on the io thread — reading them from the re-source
+/// thread is the #1134 heap-corruption shape on the serve path. So the gate
+/// runs beside the coin state and only this value crosses.
+struct PinVerdict {
+    bool        ok{false};
+    const char* cause{""};     ///< named refusal reason when !ok
+    uint32_t    at_height{0};  ///< the height the gate judged AT
+};
+
+/// Gate only — no template touched. Same checks, same order, same names as the
+/// splice below, because it IS the splice's gate.
+inline PinVerdict pin_gate_verdict(const MutableTransaction& pin,
+                                   const Mempool& mempool,
+                                   const MnStateMachine& mnstates,
+                                   uint32_t next_height)
 {
-    const auto gate = mempool.pinned_tx_admissible(pin, w.m_height);
-    uint256 protx;
+    PinVerdict v;
+    v.at_height = next_height;
+    const auto gate = mempool.pinned_tx_admissible(pin, next_height);
     if (gate != Mempool::PinnedTxGate::Ok) {
-        LOG_INFO << "[" << arm << "] pinned tx EXCLUDED h=" << w.m_height
-                 << " cause=" << Mempool::pinned_gate_name(gate)
-                 << " txid=" << dash::coin::dash_txid(pin).GetHex().substr(0, 16)
-                 << " (template built without it; re-checked next build)";
-        return;
+        v.cause = Mempool::pinned_gate_name(gate);
+        return v;
     }
+    uint256 protx;
     if (tx_spends_mn_collateral(mnstates, pin, &protx)) {
-        LOG_WARNING << "[" << arm << "] pinned tx EXCLUDED h=" << w.m_height
-                    << " cause=spends-mn-collateral MN "
-                    << protx.GetHex().substr(0, 16);
-        return;
+        v.cause = "spends-mn-collateral";
+        return v;
     }
+    v.ok = true;
+    return v;
+}
+
+/// Append only — the caller must already hold an ok PinVerdict for THIS height.
+inline void pin_append(DashWorkData& w, const MutableTransaction& pin)
+{
     auto stream = ::pack(pin);
     auto sp = stream.get_span();
     w.m_txs.emplace_back(pin);
@@ -136,6 +154,23 @@ inline void splice_pinned_tx(DashWorkData& w,
     w.m_tx_fees.push_back(0);
     w.m_tx_data_hex.push_back(HexStr(std::span<const unsigned char>(
         reinterpret_cast<const unsigned char*>(sp.data()), sp.size())));
+}
+
+inline void splice_pinned_tx(DashWorkData& w,
+                             const MutableTransaction& pin,
+                             const Mempool& mempool,
+                             const MnStateMachine& mnstates,
+                             const char* arm)
+{
+    const auto v = pin_gate_verdict(pin, mempool, mnstates, w.m_height);
+    if (!v.ok) {
+        LOG_INFO << "[" << arm << "] pinned tx EXCLUDED h=" << w.m_height
+                 << " cause=" << v.cause
+                 << " txid=" << dash::coin::dash_txid(pin).GetHex().substr(0, 16)
+                 << " (template built without it; re-checked next build)";
+        return;
+    }
+    pin_append(w, pin);
     LOG_INFO << "[" << arm << "] pinned tx INCLUDED h=" << w.m_height
              << " txid=" << dash::coin::dash_txid(pin).GetHex().substr(0, 16)
              << " vin=" << pin.vin.size() << " fee=0 (rides this template)";

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -485,6 +485,31 @@ public:
     /// against the live UTXO view on every template
     /// (Mempool::pinned_tx_admissible) — exclusion-only failure, never a
     /// template refusal. Call on the io thread before serving starts.
+    /// PIN GATE for the SERVED-DASHD arm, as a VALUE (#1134).
+    ///
+    /// The embedded builder gates and appends in one place because both happen
+    /// beside the coin state. The served-dashd arm cannot: it appends on the
+    /// re-source thread, where touching m_mempool/m_mnstates is the serve-path
+    /// heap-corruption shape. So the gate runs HERE and only the verdict
+    /// crosses. `out_tx` receives a pointer to the pin, which is safe to hand
+    /// out because it is written once before serving and never mutated.
+    ///
+    /// The height is OURS (m_prev_height + 1), not the template's: a served
+    /// dashd template can reach the splice with height 0, and a zero height
+    /// makes the coinbase-maturity arm read every coinbase-sourced input as
+    /// immature. An unknown tip is REFUSED by name rather than guessed at.
+    PinVerdict evaluate_pinned_tx(const MutableTransaction** out_tx) const {
+        if (!m_have_pinned_local_tx) return PinVerdict{};
+        if (out_tx) *out_tx = &m_pinned_local_tx;
+        if (m_prev_height == 0) {
+            PinVerdict v;
+            v.cause = "tip-unknown";
+            return v;
+        }
+        return pin_gate_verdict(m_pinned_local_tx, m_mempool, m_mnstates,
+                                m_prev_height + 1);
+    }
+
     void set_pinned_local_tx(MutableTransaction tx) {
         m_pinned_local_tx = std::move(tx);
         m_have_pinned_local_tx = true;

--- a/src/impl/dash/coin/rpc.cpp
+++ b/src/impl/dash/coin/rpc.cpp
@@ -594,6 +594,24 @@ nlohmann::json NodeRPC::getblockheader(uint256 header, bool verbose)
     return CallAPIMethod("getblockheader", {header, verbose});
 }
 
+int NodeRPC::blockcount_cached()
+{
+    constexpr int kBlockCountCacheSecs = 20;
+    const auto now = std::time(nullptr);
+    if (m_blockcount_cache > 0
+        && now - m_blockcount_cache_at < kBlockCountCacheSecs)
+        return m_blockcount_cache;
+    try {
+        auto j = CallAPIMethod("getblockcount", {});
+        if (!j.is_number_integer()) return 0;
+        m_blockcount_cache    = j.get<int>();
+        m_blockcount_cache_at = now;
+        return m_blockcount_cache;
+    } catch (const std::exception&) {
+        return 0;   // unreachable => the caller refuses; never a stale guess
+    }
+}
+
 nlohmann::json NodeRPC::gettxout(const uint256& txid, uint32_t n)
 {
     return CallAPIMethod("gettxout",

--- a/src/impl/dash/coin/rpc.hpp
+++ b/src/impl/dash/coin/rpc.hpp
@@ -40,6 +40,7 @@
 #include "rpc_data.hpp"
 #include "node_interface.hpp"
 
+#include <ctime>
 #include <functional>
 #include <iostream>
 #include <mutex>
@@ -104,6 +105,10 @@ private:
     // payee cached from BEFORE the churn window. Assigned once at startup,
     // before the io loop runs.
     std::function<void()> m_on_reconnect;
+
+    // blockcount_cached() memo — see its declaration below.
+    int          m_blockcount_cache{0};
+    std::time_t  m_blockcount_cache_at{0};
 
     std::string Send(const std::string &request) override;
     nlohmann::json CallAPIMethod(const std::string& method, const jsonrpccxx::positional_parameter& params = {});
@@ -177,6 +182,13 @@ public:
     // "never seen". Returns a null json when the coin is unspendable/absent —
     // the caller must treat that as REFUSE, never as a guess.
     nlohmann::json gettxout(const uint256& txid, uint32_t n);
+    // Chain height with a short cache. The pin gate calls gettxout once per
+    // input (1032 for the donation consolidation) and each answer needs the
+    // tip to turn `confirmations` into a coin height; asking the daemon 1032
+    // times for a number that changes every ~2.6 minutes would be waste. The
+    // cache is refreshed at most once every kBlockCountCacheSecs. Returns 0
+    // when the daemon cannot be reached, which callers must treat as REFUSE.
+    int blockcount_cached();
     // getpeerinfo -> the dashd's OWN connected-peer addresses (the "addr" field
     // of each entry), parsed to NetService. Feeds the embedded
     // DashCoinPeerManager's daemon-peer overlap filter + coind-source -20 score

--- a/src/impl/dash/coin/work_source.hpp
+++ b/src/impl/dash/coin/work_source.hpp
@@ -213,7 +213,17 @@ inline WorkSelection select_dash_work(
     // submitblock body both derive from the appended tx vectors. Fail-closed:
     // without the verify view (mempool+mnstates, i.e. --embedded-utxo) the
     // pin is EXCLUDED with a named cause, never included unverified.
-    if (emb.pinned_local_tx != nullptr) {
+    // A PLACEHOLDER fallback is not a template. The serve path binds this arm
+    // to a no-op closure returning DashWorkData{} (#1134: the real dashd RPC
+    // must not run on the io thread), so splicing here judged a throwaway —
+    // that is what produced `pinned tx EXCLUDED h=0` on the production primary
+    // on 2026-08-07 while the REAL served template went unspliced. The serve
+    // path now gates beside the coin state and appends at the real template
+    // (DASHWorkSource::resolve_coin_state_arm + the re-source site); callers
+    // that pass a genuine fallback still splice here.
+    const bool fallback_is_placeholder =
+        out.work.m_previous_block.IsNull() && out.work.m_txs.empty();
+    if (emb.pinned_local_tx != nullptr && !fallback_is_placeholder) {
         if (emb.mempool == nullptr || emb.mnstates == nullptr) {
             LOG_INFO << "[dashd-splice] pinned tx EXCLUDED h="
                      << out.work.m_height << " cause=no-verify-view ("

--- a/src/impl/dash/coin/work_source.hpp
+++ b/src/impl/dash/coin/work_source.hpp
@@ -221,8 +221,14 @@ inline WorkSelection select_dash_work(
     // path now gates beside the coin state and appends at the real template
     // (DASHWorkSource::resolve_coin_state_arm + the re-source site); callers
     // that pass a genuine fallback still splice here.
+    // The test is deliberately narrow: ONLY a value indistinguishable from a
+    // default-constructed DashWorkData counts as a placeholder. Anything
+    // carrying a height, a previous block, or transactions is a template that
+    // told us something, and we splice into it. Refusing on any single missing
+    // field would silently drop the pin from real templates.
     const bool fallback_is_placeholder =
-        out.work.m_previous_block.IsNull() && out.work.m_txs.empty();
+        out.work.m_height == 0 && out.work.m_previous_block.IsNull()
+        && out.work.m_txs.empty();
     if (emb.pinned_local_tx != nullptr && !fallback_is_placeholder) {
         if (emb.mempool == nullptr || emb.mnstates == nullptr) {
             LOG_INFO << "[dashd-splice] pinned tx EXCLUDED h="

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -363,6 +363,12 @@ DASHWorkSource::CoinStateArm DASHWorkSource::resolve_coin_state_arm() const
     // the cache MORE willing to re-source, never less.
     arm.gen_at_source = work_generation_.load(std::memory_order_relaxed);
 
+    // PIN GATE (donation lane) — evaluated HERE, beside the coin state, for the
+    // served-dashd arm to append later. Unconditional because the verdict does
+    // not depend on which arm wins: the embedded builder gates the pin itself,
+    // and this copy is simply unused when it does.
+    arm.pin_verdict = coin_state_.evaluate_pinned_tx(&arm.pin_tx);
+
     // ── Mainnet embedded gate (v0.2.4 trigger) ──────────────────────────────
     // The SML/QuorumManager wiring emits a real DIP-0004 type-5 CCbTx, and its
     // byte-parity against a real dashd getblocktemplate is PROVEN (from the raw
@@ -502,6 +508,31 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
                     dashd_fallback_ ? dashd_fallback_() : coin::DashWorkData{};
                 if (fb.m_height == 0 && arm.declined_height != 0)
                     fb.m_height = arm.declined_height;
+                // PINNED LOCAL TX on the REAL served template. The gate already
+                // ran beside the coin state (resolve_coin_state_arm); all that
+                // happens here is the append, so this touches no coin-state
+                // container. The height in the log is the one the gate JUDGED
+                // at, not fb.m_height, so the line can never claim a check it
+                // did not make.
+                if (arm.pin_tx != nullptr) {
+                    const auto txid = coin::dash_txid(*arm.pin_tx)
+                                          .GetHex().substr(0, 16);
+                    if (arm.pin_verdict.ok) {
+                        coin::pin_append(fb, *arm.pin_tx);
+                        LOG_INFO << "[dashd-splice] pinned tx INCLUDED h="
+                                 << arm.pin_verdict.at_height
+                                 << " txid=" << txid
+                                 << " vin=" << arm.pin_tx->vin.size()
+                                 << " fee=0 (rides this template)";
+                    } else {
+                        LOG_INFO << "[dashd-splice] pinned tx EXCLUDED h="
+                                 << arm.pin_verdict.at_height
+                                 << " cause=" << arm.pin_verdict.cause
+                                 << " txid=" << txid
+                                 << " (template built without it; re-checked "
+                                    "next build)";
+                    }
+                }
                 sel = coin::WorkSelection{ std::move(fb),
                                            coin::WorkSource::DashdFallback,
                                            arm.decline };

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -472,6 +472,21 @@ private:
         /// rather than swallowing it.
         bool                resolve_threw{false};
         std::string         resolve_error;
+        /// PINNED LOCAL TX, served-dashd arm (donation lane). The gate runs
+        /// beside the coin state -- it reads the UTXO view and the MN state
+        /// machine, which the io thread mutates -- and only this VALUE crosses
+        /// to the sourcing thread, which appends. Before this, the splice ran
+        /// inside select_work()'s fallback arm, and on the serve path that arm
+        /// is bound to a NO-OP empty template: the gate judged a throwaway at
+        /// h=0 and the real dashd template was never spliced at all. That is
+        /// what the production primary logged on 2026-08-07
+        /// (`pinned tx EXCLUDED h=0`) -- an honest report about the wrong
+        /// object.
+        coin::PinVerdict            pin_verdict;
+        /// Points at load-time-immutable storage (set once before serving,
+        /// never mutated), which is why a pointer may cross where a container
+        /// reference may not. nullptr when no pin is configured.
+        const coin::MutableTransaction* pin_tx{nullptr};
     };
 
     /// COIN-STATE-OWNING THREAD ONLY (#1134). Reads NodeCoinState -- populated(),

--- a/test/test_dash_embedded_gbt.cpp
+++ b/test/test_dash_embedded_gbt.cpp
@@ -1289,3 +1289,91 @@ TEST(DashEmbeddedGbt, PinnedLocalTxExcludedFacesLeaveTemplateUntouched) {
         EXPECT_EQ(w2.m_tx_fees[0], 0u);
     }
 }
+
+// ════════════════════════════════════════════════════════════════════════
+// PIN GATE vs the SERVED-DASHD arm. Both KATs below are red on the code that
+// ran on the production primary on 2026-08-07, which logged
+//     [dashd-splice] pinned tx EXCLUDED h=0 cause=immature-coinbase-input
+// and told the operator nothing true: the height was not the template's, and
+// the template was not the one being served.
+// ════════════════════════════════════════════════════════════════════════
+
+// DEFECT 1 — a zero height marks a MATURE coinbase input immature. The gate is
+// correct; feeding it a height nobody established is what is wrong, so the
+// serve path must judge at a height it OWNS (coin-state tip + 1) and refuse by
+// name when it has none.
+TEST(DashPinGate, ZeroHeightWouldRefuseAMatureCoinbaseInput) {
+    UTXOViewCache utxo(nullptr);
+    uint256 don = mint_hash(90);
+    // Mined 5000 blocks ago: mature by any reading, 50x the 100-block rule.
+    utxo.add_coin(Outpoint(don, 0), Coin(100'000, {}, H - 5'000, /*cb=*/true));
+    Mempool mp; mp.set_utxo(&utxo);
+
+    MutableTransaction pin;
+    pin.version = 2; pin.type = 0; pin.locktime = 0;
+    { TxIn i; i.prevout.hash = don; i.prevout.index = 0;
+      i.sequence = 0xffffffffu; pin.vin.push_back(i); }
+    { TxOut o; o.value = 100'000; pin.vout.push_back(o); }
+
+    auto mnstates = single_mn(p2pkh_script(0x30));
+
+    const auto at_tip = dash::coin::pin_gate_verdict(pin, mp, mnstates, H);
+    EXPECT_TRUE(at_tip.ok) << "mature at the real height, cause=" << at_tip.cause;
+    EXPECT_EQ(at_tip.at_height, H) << "the verdict must carry the height it judged at";
+
+    const auto at_zero = dash::coin::pin_gate_verdict(pin, mp, mnstates, 0);
+    EXPECT_FALSE(at_zero.ok)
+        << "height 0 must not silently admit — it cannot evaluate maturity";
+    EXPECT_STREQ(at_zero.cause, "immature-coinbase-input")
+        << "and this is exactly the production line: the SAME coin, refused "
+           "only because the height was never established";
+}
+
+// DEFECT 2 — the serve path binds the fallback arm to a no-op returning an
+// EMPTY template (#1134). Splicing into that judged a throwaway while the real
+// served template went unspliced, so the pin could never ride a block no matter
+// what the log said. A placeholder must be left alone.
+TEST(DashPinGate, PlaceholderFallbackIsNeverSpliced) {
+    UTXOViewCache utxo(nullptr);
+    uint256 don = mint_hash(91);
+    utxo.add_coin(Outpoint(don, 0), Coin(100'000, {}, H - 5'000, /*cb=*/true));
+    Mempool mp; mp.set_utxo(&utxo);
+
+    MutableTransaction pin;
+    pin.version = 2; pin.type = 0; pin.locktime = 0;
+    { TxIn i; i.prevout.hash = don; i.prevout.index = 0;
+      i.sequence = 0xffffffffu; pin.vin.push_back(i); }
+    { TxOut o; o.value = 100'000; pin.vout.push_back(o); }
+
+    auto mnstates = single_mn(p2pkh_script(0x30));
+
+    // NON-VIABLE bundle => the selector takes the fallback arm. The pin is
+    // admissible on the merits, so anything appended here is appended to the
+    // placeholder.
+    dash::coin::EmbeddedWorkInputs e;
+    e.has_state        = false;        // forces the fallback arm
+    e.prev_height      = 0;            // exactly the production shape
+    e.mnstates         = &mnstates;
+    e.mempool          = &mp;
+    e.pinned_local_tx  = &pin;
+
+    auto placeholder = []() -> dash::coin::DashWorkData { return {}; };
+    auto sel = dash::coin::select_dash_work(e, placeholder);
+    ASSERT_EQ(sel.source, dash::coin::WorkSource::DashdFallback);
+    EXPECT_TRUE(sel.work.m_txs.empty())
+        << "a placeholder is not a template — the pin must not be spliced into it";
+    EXPECT_TRUE(sel.work.m_tx_data_hex.empty());
+
+    // A REAL fallback (it has a previous block) still splices here, so the
+    // guard discriminates on placeholder-ness, not on the arm.
+    auto real_fb = []() -> dash::coin::DashWorkData {
+        dash::coin::DashWorkData w;
+        w.m_previous_block = raw256(0xAB);
+        w.m_height         = H;
+        return w;
+    };
+    auto sel_real = dash::coin::select_dash_work(e, real_fb);
+    ASSERT_EQ(sel_real.source, dash::coin::WorkSource::DashdFallback);
+    EXPECT_EQ(sel_real.work.m_txs.size(), 1u)
+        << "a genuine fallback template still carries the pin";
+}

--- a/test/test_dash_work_source.cpp
+++ b/test/test_dash_work_source.cpp
@@ -452,7 +452,26 @@ TEST(HashrateVardiffHysteresis, LowerMarginHeldButDecisiveDropStepsDown)
 // the splice point. Zero is not a harmless label — the gate's coinbase
 // maturity arm reads it as next_height, which would mark every coinbase input
 // immature. When dashd's copy is unset the bundle's own tip must fill it in.
-TEST(DashWorkSource, PinnedSpliceFillsHeightFromBundleTipWhenDashdCopyIsUnset)
+// ─── The PLACEHOLDER fallback (corrected 2026-08-07) ───────────────────────
+//
+// This test previously asserted the OPPOSITE: that a fallback arriving with no
+// height still gets the pin spliced, with the height filled from the bundle
+// tip. It was written from the production log line
+//
+//     [dashd-splice] pinned tx EXCLUDED h=0 cause=input-missing-or-spent
+//
+// on the belief that "the shape the primary produced" was a real dashd
+// template missing its height. It was not. The serve path binds this arm to a
+// NO-OP closure returning DashWorkData{} (#1134 — the real dashd
+// getblocktemplate must not run on the io thread), so that h=0 was a
+// PLACEHOLDER, and every splice into it landed on a value nobody serves while
+// the real template went unspliced.
+//
+// The corrected contract: a value indistinguishable from a default-constructed
+// DashWorkData is not a template and is left alone. The serve path gates
+// beside the coin state and appends at the real template instead
+// (DASHWorkSource::resolve_coin_state_arm).
+TEST(DashWorkSource, PlaceholderFallbackLeavesThePinAlone)
 {
     using ::core::coin::UTXOViewCache;
     using ::core::coin::Outpoint;
@@ -467,6 +486,8 @@ TEST(DashWorkSource, PinnedSpliceFillsHeightFromBundleTipWhenDashdCopyIsUnset)
     mp.set_utxo(&utxo);
     MnStateMachine mn;
 
+    // Admissible on the merits: input unspent, fee exactly zero. So anything
+    // that DOES get spliced here is spliced into the placeholder.
     dash::coin::MutableTransaction pin;
     pin.vin.resize(1);
     pin.vin[0].prevout.hash  = prev;
@@ -478,20 +499,65 @@ TEST(DashWorkSource, PinnedSpliceFillsHeightFromBundleTipWhenDashdCopyIsUnset)
     emb.mnstates        = &mn;
     emb.mempool         = &mp;
     emb.pinned_local_tx = &pin;
-    emb.prev_height     = 2'517'800; // the header tip the arm was evaluated on
+    emb.prev_height     = 2'517'800; // a tip IS known — still not a template
 
     bool emb_ran = false, fb_ran = false;
     WorkSelection sel = select_dash_work(
         emb,
         [&] { return embedded_stub(emb_ran); },
-        // dashd copy WITHOUT a height — the shape the primary produced.
-        [&] { fb_ran = true; DashWorkData w; w.m_height = 0; return w; });
+        // EXACTLY what the serve path's no-op closure returns.
+        [&] { fb_ran = true; return DashWorkData{}; });
 
     EXPECT_EQ(sel.source, WorkSource::DashdFallback);
     EXPECT_TRUE(fb_ran);
-    EXPECT_EQ(sel.work.m_height, 2'517'801u) << "height must come from the bundle tip + 1";
-    ASSERT_EQ(sel.work.m_txs.size(), 1u) << "the pin must still be spliced";
+    EXPECT_TRUE(sel.work.m_txs.empty())
+        << "a placeholder is not a template — splicing it is a no-op that "
+           "reads as success in the log";
+    EXPECT_TRUE(sel.work.m_tx_data_hex.empty());
+}
+
+// A fallback that carries ANY information is a real template, and the pin
+// still rides it here. This is the discriminator the guard turns on, so it is
+// asserted rather than assumed.
+TEST(DashWorkSource, FallbackCarryingAHeightIsATemplateAndTakesThePin)
+{
+    using ::core::coin::UTXOViewCache;
+    using ::core::coin::Outpoint;
+    using ::core::coin::Coin;
+
+    uint256 prev;
+    prev.begin()[0] = 0x78;
+    UTXOViewCache utxo(nullptr);
+    utxo.add_coin(Outpoint(prev, 0), Coin(9'000, {}, /*height=*/1, /*cb=*/false));
+
+    dash::coin::Mempool mp;
+    mp.set_utxo(&utxo);
+    MnStateMachine mn;
+
+    dash::coin::MutableTransaction pin;
+    pin.vin.resize(1);
+    pin.vin[0].prevout.hash  = prev;
+    pin.vin[0].prevout.index = 0;
+    pin.vout.resize(1);
+    pin.vout[0].value = 9'000;
+
+    EmbeddedWorkInputs emb;
+    emb.mnstates        = &mn;
+    emb.mempool         = &mp;
+    emb.pinned_local_tx = &pin;
+    emb.prev_height     = 2'517'800;
+
+    bool emb_ran = false, fb_ran = false;
+    WorkSelection sel = select_dash_work(
+        emb,
+        [&] { return embedded_stub(emb_ran); },
+        [&] { fb_ran = true; DashWorkData w; w.m_height = 2'517'801; return w; });
+
+    EXPECT_EQ(sel.source, WorkSource::DashdFallback);
+    EXPECT_TRUE(fb_ran);
+    ASSERT_EQ(sel.work.m_txs.size(), 1u) << "a real template still carries the pin";
     EXPECT_EQ(sel.work.m_tx_fees[0], 0u);
+    EXPECT_EQ(sel.work.m_height, 2'517'801u);
 }
 
 // ─── #107: creditPool divergence — explained vs unexplained ─────────────────


### PR DESCRIPTION
## What the production primary was telling us

Every template, for hours, on the hotel primary:

```
[dashd-splice] pinned tx EXCLUDED h=0 cause=immature-coinbase-input txid=9f2ad90ad4e0ab84
```

Two defects. Both made that line an honest report about the wrong object.

### 1. The splice ran on a throwaway template

The serve path binds `select_dash_work()`'s fallback arm to a **no-op closure returning an empty `DashWorkData`** — the real dashd `getblocktemplate` must not run on the io thread (#1134). The pin splice lived inside that arm, so it gated and appended into a placeholder, while the template we actually serve was never spliced at all. **The pin could not have ridden a block whatever the gate said.**

Fix: `splice_pinned_tx` is split into `pin_gate_verdict` + `pin_append`, so both arms still share exactly one gate and it cannot drift. The gate now runs in `resolve_coin_state_arm()`, beside the coin state, where reading the UTXO view and the MN state machine is safe; only a `PinVerdict` **value** crosses to the re-source thread, which appends into the real template. A placeholder fallback is left alone.

### 2. Height 0 makes every coinbase input immature

The gate was asked to judge at height 0, and at height 0 the maturity arm reads every coinbase-sourced coin as immature. The donation inputs **are** coinbase outputs — they are mining payouts — so the check refused exactly the transaction it exists to protect.

The verdict now carries the height it judged **at**, taken from the coin state's own tip (`m_prev_height + 1`), and an unknown tip is refused by name (`tip-unknown`) rather than guessed.

### Also

The coin-RPC second source (#1171) returned a placeholder height 0 for every coin it resolved. It now derives the real coin height from `gettxout`'s `confirmations` via a short-cached `getblockcount` — one call per ~20 s, not one per input (the consolidation has 1032 of them). An unreachable daemon still returns `false`; never a guess.

## Tests

Two KATs, both **red on the old code**:

- `DashPinGate.ZeroHeightWouldRefuseAMatureCoinbaseInput` — the same coin, mined 5000 blocks ago, is `ok` at the real height and `immature-coinbase-input` at height 0. That is the production line, reproduced from first principles.
- `DashPinGate.PlaceholderFallbackIsNeverSpliced` — a placeholder fallback comes back with an empty tx set even though the pin is admissible on the merits; a genuine fallback (it has a previous block) still carries it.

`test_dash_embedded_gbt`: **200/200 green** on vm905 with `BLS=REAL`. `c2pool-dash` builds.

## Blast radius

Serving is byte-unchanged for every node without a pin configured — `pin_tx` is null and nothing on the path is entered.