### PR TITLE
dash: give the pin gate a SIZE face — the one that cost us block 2517855

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -2010,31 +2010,59 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
 
     // ── Pinned local tx (--pin-local-tx-hex): parse + park in NodeCoinState.
     if (!pin_local_tx_hex_path.empty()) {
+        // ONE TRANSACTION PER LINE. The donation consolidation had to be SPLIT
+        // after a single 152258-byte pin was rejected as bad-txns-oversize and
+        // cost block 2517855; four quarter-sized transactions now ride ONE
+        // template. Multiple lines rather than a repeatable flag on purpose:
+        // the systemd drop-in stays byte-identical and only the FILE changes,
+        // so re-arming the lane cannot silently drop a transaction by editing
+        // the wrong place. A single-line file behaves exactly as before.
         std::ifstream pf(pin_local_tx_hex_path);
-        std::string pin_hex((std::istreambuf_iterator<char>(pf)),
-                            std::istreambuf_iterator<char>());
-        // strip whitespace/newlines
-        pin_hex.erase(std::remove_if(pin_hex.begin(), pin_hex.end(),
-                                     [](unsigned char c) { return std::isspace(c); }),
-                      pin_hex.end());
-        bool pin_ok = !pin_hex.empty() && pin_hex.size() % 2 == 0;
-        dash::coin::MutableTransaction pin_tx;
-        if (pin_ok) {
+        std::vector<dash::coin::MutableTransaction> pin_txs;
+        bool pin_ok = false;
+        std::string line;
+        unsigned lineno = 0;
+        while (std::getline(pf, line)) {
+            ++lineno;
+            line.erase(std::remove_if(line.begin(), line.end(),
+                                      [](unsigned char c) { return std::isspace(c); }),
+                       line.end());
+            if (line.empty()) continue;
+            if (line.size() % 2 != 0) {
+                std::cout << "[run] --pin-local-tx-hex line " << lineno
+                          << ": odd hex length — pin DISABLED\n";
+                pin_txs.clear();
+                break;
+            }
             try {
-                auto raw = ParseHex(pin_hex);
+                auto raw = ParseHex(line);
                 PackStream ps(raw);
-                ps >> pin_tx;
+                dash::coin::MutableTransaction tx;
+                ps >> tx;
                 // classic tx only: a special-type (extra_payload) pin would
                 // interact with the CbTx roots the template commits — refuse
                 // at load, loudly, rather than gate per template.
-                pin_ok = pin_tx.type == 0
-                         && !pin_tx.vin.empty() && !pin_tx.vout.empty();
+                if (tx.type != 0 || tx.vin.empty() || tx.vout.empty()) {
+                    std::cout << "[run] --pin-local-tx-hex line " << lineno
+                              << ": not a classic non-empty tx — pin DISABLED\n";
+                    pin_txs.clear();
+                    break;
+                }
+                pin_txs.push_back(std::move(tx));
             } catch (const std::exception& e) {
-                std::cout << "[run] --pin-local-tx-hex PARSE FAILED (" << e.what()
-                          << ") — pin DISABLED\n";
-                pin_ok = false;
+                std::cout << "[run] --pin-local-tx-hex line " << lineno
+                          << " PARSE FAILED (" << e.what() << ") — pin DISABLED\n";
+                pin_txs.clear();
+                break;
             }
         }
+        // ALL-OR-NOTHING at load. A partially-loaded set would mine some of a
+        // split consolidation and silently strand the rest, which is worse
+        // than not arming: the operator would see money move and assume the
+        // whole of it did.
+        pin_ok = !pin_txs.empty();
+        dash::coin::MutableTransaction pin_tx;
+        if (pin_ok) pin_tx = pin_txs.front();   // for the existing log/lookup
         if (pin_ok) {
             // SECOND SOURCE for the pin's inputs (money-path, 2026-08-07).
             // The embedded UTXO view is built FORWARD from the height this node
@@ -2095,11 +2123,16 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 std::cout << "[run] pin input lookup: embedded UTXO view + "
                              "coin-RPC second source (gettxout) ARMED\n";
             }
-            node_coin_state.set_pinned_local_tx(pin_tx);
-            std::cout << "[run] pinned local tx ARMED: "
-                      << dash::coin::dash_txid(pin_tx).GetHex()
-                      << " vin=" << pin_tx.vin.size()
-                      << " vout=" << pin_tx.vout.size()
+            node_coin_state.set_pinned_local_txs(pin_txs);
+            size_t total_bytes = 0;
+            for (const auto& t : pin_txs) total_bytes += ::pack(t).get_span().size();
+            std::cout << "[run] pinned local tx ARMED: " << pin_txs.size()
+                      << " transaction(s), " << total_bytes << " bytes total";
+            for (const auto& t : pin_txs)
+                std::cout << "\n[run]   " << dash::coin::dash_txid(t).GetHex()
+                          << " vin=" << t.vin.size()
+                          << " bytes=" << ::pack(t).get_span().size();
+            std::cout
                       << " (admission re-gated per template: inputs unspent,"
                       << " coinbase-mature, fee==0; excluded-not-refused on"
                       << " failure; auto-retires once mined)\n";

--- a/src/impl/dash/coin/embedded_gbt.hpp
+++ b/src/impl/dash/coin/embedded_gbt.hpp
@@ -176,6 +176,41 @@ inline void splice_pinned_tx(DashWorkData& w,
              << " vin=" << pin.vin.size() << " fee=0 (rides this template)";
 }
 
+/// Splice EVERY admissible pin, in file order, under a CUMULATIVE byte cap.
+///
+/// The donation consolidation had to be split into four transactions after a
+/// single 152258-byte pin was rejected as bad-txns-oversize and cost block
+/// 2517855. Four quarter-sized transactions ride ONE template, so the money
+/// lands in one block instead of four.
+///
+/// Each pin is gated INDEPENDENTLY: one bad pin excludes itself and the others
+/// still ride. The cumulative cap is checked against what has ALREADY been
+/// accepted, so the answer never depends on the order the caller happened to
+/// pass them in beyond file order itself.
+inline void splice_pinned_txs(DashWorkData& w,
+                              const std::vector<MutableTransaction>& pins,
+                              const Mempool& mempool,
+                              const MnStateMachine& mnstates,
+                              const char* arm)
+{
+    size_t spliced_bytes = 0;
+    for (const auto& pin : pins) {
+        const size_t sz = ::pack(pin).get_span().size();
+        if (spliced_bytes + sz > Mempool::kMaxPinnedTotalBytes) {
+            LOG_INFO << "[" << arm << "] pinned tx EXCLUDED h=" << w.m_height
+                     << " cause=pin-total-too-large txid="
+                     << dash::coin::dash_txid(pin).GetHex().substr(0, 16)
+                     << " (" << spliced_bytes << "+" << sz << " > "
+                     << Mempool::kMaxPinnedTotalBytes
+                     << "; earlier pins keep their places)";
+            continue;
+        }
+        const size_t before = w.m_txs.size();
+        splice_pinned_tx(w, pin, mempool, mnstates, arm);
+        if (w.m_txs.size() != before) spliced_bytes += sz;
+    }
+}
+
 inline DashWorkData build_embedded_workdata(
     uint32_t prev_height,
     const uint256& prev_hash,
@@ -282,7 +317,7 @@ inline DashWorkData build_embedded_workdata(
     // regardless of suppress_mempool_txs — the coinbase-only posture is
     // about MEMPOOL selection; the pin is not a mempool tx.
     // Default nullptr => every existing positional caller byte-unchanged.
-    const MutableTransaction* pinned_local_tx = nullptr)
+    const std::vector<MutableTransaction>* pinned_local_txs = nullptr)
 {
     DashWorkData w;
     w.m_height          = prev_height + 1;
@@ -439,8 +474,8 @@ inline DashWorkData build_embedded_workdata(
     // only failure mode (see the parameter note); the MN-collateral filter
     // applies here too — a pinned tx spending a collateral would poison the
     // committed merkleRootMNList exactly like a selected one.
-    if (pinned_local_tx != nullptr)
-        splice_pinned_tx(w, *pinned_local_tx, mempool, mnstates, "GBT-EMB");
+    if (pinned_local_txs != nullptr && !pinned_local_txs->empty())
+        splice_pinned_txs(w, *pinned_local_txs, mempool, mnstates, "GBT-EMB");
     uint64_t selected_bytes = 0;  // wire bytes packed into this template (underfill guard)
     for (auto& s : selected) {
         selected_bytes += s.base_size;

--- a/src/impl/dash/coin/mempool.hpp
+++ b/src/impl/dash/coin/mempool.hpp
@@ -160,13 +160,35 @@ public:
         InputMissingOrSpent,    // an input is not an unspent coin we know
         ImmatureCoinbaseInput,  // a coinbase-output input below 100 confs
         FeeNotZero,             // sum(in) - sum(out) != 0: snapshot drift
+        TooLarge,               // serialized size exceeds the consensus cap
     };
+    /// Dash rejects an oversize transaction at CONSENSUS, not merely policy —
+    /// CheckTransaction() returns "bad-txns-oversize", so a block carrying one
+    /// is INVALID, not just non-standard. That distinction cost a real block:
+    ///
+    ///   2026-08-07 14:33:45  won block height=2517855 bytes=152889
+    ///   2026-08-07 14:33:45  submit_block_hex result: "bad-txns-oversize"
+    ///
+    /// height 2517855 went to another miner. The pinned tx was 152258 bytes
+    /// (1032 inputs). Every gate face we had — inputs unspent, coinbase
+    /// maturity, fee exactly zero, no MN-collateral spend — PASSED. The tx was
+    /// admissible by every rule we had thought to write, and unmineable.
+    /// Confirmed independently against the daemon:
+    ///   testmempoolaccept -> allowed=false reject-reason="bad-txns-oversize"
+    ///
+    /// A pin costs the WHOLE BLOCK when it is wrong, not just its own value.
+    static constexpr size_t kMaxPinnedTxBytes = 100000;
+    /// Cumulative cap across ALL pins in one template. Well under Dash's
+    /// 2 MB block limit, because the pins are not the only thing in the block
+    /// and a template we cannot mine is worth nothing.
+    static constexpr size_t kMaxPinnedTotalBytes = 400000;
     static const char* pinned_gate_name(PinnedTxGate g) {
         switch (g) {
             case PinnedTxGate::Ok:                    return "ok";
             case PinnedTxGate::UtxoViewUnset:         return "utxo-view-unset";
             case PinnedTxGate::InputMissingOrSpent:   return "input-missing-or-spent";
             case PinnedTxGate::ImmatureCoinbaseInput: return "immature-coinbase-input";
+            case PinnedTxGate::TooLarge:              return "tx-too-large";
             case PinnedTxGate::FeeNotZero:            return "fee-not-zero";
         }
         return "ok";
@@ -191,6 +213,12 @@ public:
 
     PinnedTxGate pinned_tx_admissible(const MutableTransaction& tx,
                                       uint32_t next_height) const {
+        // SIZE FIRST. It is the cheapest check and the only one whose failure
+        // is certain regardless of chain state — an oversize tx is invalid at
+        // every height, against every UTXO view. Checking it before the 1032
+        // coin lookups also stops us paying for a verdict we already know.
+        if (::pack(tx).get_span().size() > kMaxPinnedTxBytes)
+            return PinnedTxGate::TooLarge;
         auto* utxo = m_utxo.load();
         if (utxo == nullptr && !m_external_coin_lookup)
             return PinnedTxGate::UtxoViewUnset;

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -498,21 +498,34 @@ public:
     /// dashd template can reach the splice with height 0, and a zero height
     /// makes the coinbase-maturity arm read every coinbase-sourced input as
     /// immature. An unknown tip is REFUSED by name rather than guessed at.
-    PinVerdict evaluate_pinned_tx(const MutableTransaction** out_tx) const {
-        if (!m_have_pinned_local_tx) return PinVerdict{};
-        if (out_tx) *out_tx = &m_pinned_local_tx;
-        if (m_prev_height == 0) {
-            PinVerdict v;
-            v.cause = "tip-unknown";
-            return v;
+    /// One verdict PER PIN, in file order. The vector is empty when no pin is
+    /// configured. Judged at OUR tip; an unknown tip refuses by name rather
+    /// than guessing (a zero height marks every coinbase input immature).
+    std::vector<PinVerdict> evaluate_pinned_txs(
+        const std::vector<MutableTransaction>** out_txs) const {
+        std::vector<PinVerdict> out;
+        if (!m_have_pinned_local_tx) return out;
+        if (out_txs) *out_txs = &m_pinned_local_txs;
+        out.reserve(m_pinned_local_txs.size());
+        for (const auto& tx : m_pinned_local_txs) {
+            if (m_prev_height == 0) {
+                PinVerdict v; v.cause = "tip-unknown"; out.push_back(v);
+                continue;
+            }
+            out.push_back(pin_gate_verdict(tx, m_mempool, m_mnstates,
+                                           m_prev_height + 1));
         }
-        return pin_gate_verdict(m_pinned_local_tx, m_mempool, m_mnstates,
-                                m_prev_height + 1);
+        return out;
     }
 
     void set_pinned_local_tx(MutableTransaction tx) {
-        m_pinned_local_tx = std::move(tx);
+        m_pinned_local_txs.clear();
+        m_pinned_local_txs.push_back(std::move(tx));
         m_have_pinned_local_tx = true;
+    }
+    void set_pinned_local_txs(std::vector<MutableTransaction> txs) {
+        m_pinned_local_txs = std::move(txs);
+        m_have_pinned_local_tx = !m_pinned_local_txs.empty();
     }
 
     /// Second source for the PIN GATE's coin lookups (money-path). Forwarded
@@ -1179,8 +1192,8 @@ public:
         e.mn_min_confirmations = m_mn_min_confirmations;
         // Pinned local tx: pointer into this state (same lifetime discipline
         // as mnstates/mempool); the builder gates admission per template.
-        e.pinned_local_tx      = m_have_pinned_local_tx
-                                     ? &m_pinned_local_tx : nullptr;
+        e.pinned_local_txs     = m_have_pinned_local_tx
+                                     ? &m_pinned_local_txs : nullptr;
         // E-SUPERBLOCK: hand the resolved treasury schedule to the builder.
         // Empty at non-superblock heights and confidently-unfunded superblocks
         // (normal block); the winning trigger's payees at a funded superblock.
@@ -1559,7 +1572,10 @@ private:
     bool m_serve_mempool_txs{false};
     // Pinned local tx (set_pinned_local_tx): held by value for the lifetime of
     // this state; the bundle exposes a pointer only when the flag is set.
-    MutableTransaction m_pinned_local_tx;
+    // MULTIPLE pins: the donation consolidation had to be SPLIT after
+    // 152258 bytes was rejected as bad-txns-oversize and cost block
+    // 2517855. Four quarter-sized transactions ride ONE template.
+    std::vector<MutableTransaction> m_pinned_local_txs;
     bool               m_have_pinned_local_tx{false};
     std::function<bool()> m_chain_synced_fn; // optional ABSOLUTE header-sync gate (never serve a stale tip)
     std::function<bool(uint32_t)> m_is_superblock_fn;  // superblock-height predicate

--- a/src/impl/dash/coin/work_source.hpp
+++ b/src/impl/dash/coin/work_source.hpp
@@ -164,7 +164,7 @@ struct EmbeddedWorkInputs {
     // tx. The builder gates admission per template; a null pointer is the
     // byte-unchanged legacy shape. Points into NodeCoinState (same lifetime
     // discipline as mnstates/mempool).
-    const MutableTransaction*        pinned_local_tx{nullptr};
+    const std::vector<MutableTransaction>* pinned_local_txs{nullptr};
 
     bool viable() const {
         return has_state && mnstates != nullptr && mempool != nullptr;
@@ -229,7 +229,8 @@ inline WorkSelection select_dash_work(
     const bool fallback_is_placeholder =
         out.work.m_height == 0 && out.work.m_previous_block.IsNull()
         && out.work.m_txs.empty();
-    if (emb.pinned_local_tx != nullptr && !fallback_is_placeholder) {
+    if (emb.pinned_local_txs != nullptr && !emb.pinned_local_txs->empty()
+        && !fallback_is_placeholder) {
         if (emb.mempool == nullptr || emb.mnstates == nullptr) {
             LOG_INFO << "[dashd-splice] pinned tx EXCLUDED h="
                      << out.work.m_height << " cause=no-verify-view ("
@@ -247,8 +248,8 @@ inline WorkSelection select_dash_work(
             // this template builds.
             if (out.work.m_height == 0 && emb.prev_height != 0)
                 out.work.m_height = emb.prev_height + 1;
-            splice_pinned_tx(out.work, *emb.pinned_local_tx,
-                             *emb.mempool, *emb.mnstates, "dashd-splice");
+            splice_pinned_txs(out.work, *emb.pinned_local_txs,
+                              *emb.mempool, *emb.mnstates, "dashd-splice");
         }
     }
     return out;
@@ -295,7 +296,7 @@ inline WorkSelection select_dash_work(
                 emb.suppress_cause,
                 // Pinned local tx (donation consolidation): admission gated
                 // inside the builder per template; null => byte-unchanged.
-                emb.pinned_local_tx);
+                emb.pinned_local_txs);
         },
         dashd_fallback);
 }

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -367,7 +367,7 @@ DASHWorkSource::CoinStateArm DASHWorkSource::resolve_coin_state_arm() const
     // served-dashd arm to append later. Unconditional because the verdict does
     // not depend on which arm wins: the embedded builder gates the pin itself,
     // and this copy is simply unused when it does.
-    arm.pin_verdict = coin_state_.evaluate_pinned_tx(&arm.pin_tx);
+    arm.pin_verdicts = coin_state_.evaluate_pinned_txs(&arm.pin_txs);
 
     // ── Mainnet embedded gate (v0.2.4 trigger) ──────────────────────────────
     // The SML/QuorumManager wiring emits a real DIP-0004 type-5 CCbTx, and its
@@ -514,23 +514,44 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
                 // container. The height in the log is the one the gate JUDGED
                 // at, not fb.m_height, so the line can never claim a check it
                 // did not make.
-                if (arm.pin_tx != nullptr) {
-                    const auto txid = coin::dash_txid(*arm.pin_tx)
-                                          .GetHex().substr(0, 16);
-                    if (arm.pin_verdict.ok) {
-                        coin::pin_append(fb, *arm.pin_tx);
+                if (arm.pin_txs != nullptr
+                    && arm.pin_verdicts.size() == arm.pin_txs->size()) {
+                    // Each pin is judged and reported INDEPENDENTLY: one bad
+                    // pin excludes itself and the rest still ride. The height
+                    // logged is the one the gate JUDGED at, never fb.m_height,
+                    // so a line can never claim a check it did not make.
+                    size_t spliced_bytes = 0;
+                    for (size_t i = 0; i < arm.pin_txs->size(); ++i) {
+                        const auto& pin = (*arm.pin_txs)[i];
+                        const auto& v   = arm.pin_verdicts[i];
+                        const auto txid = coin::dash_txid(pin)
+                                              .GetHex().substr(0, 16);
+                        if (!v.ok) {
+                            LOG_INFO << "[dashd-splice] pinned tx EXCLUDED h="
+                                     << v.at_height << " cause=" << v.cause
+                                     << " txid=" << txid
+                                     << " (template built without it; "
+                                        "re-checked next build)";
+                            continue;
+                        }
+                        const size_t sz = ::pack(pin).get_span().size();
+                        if (spliced_bytes + sz
+                            > coin::Mempool::kMaxPinnedTotalBytes) {
+                            LOG_INFO << "[dashd-splice] pinned tx EXCLUDED h="
+                                     << v.at_height
+                                     << " cause=pin-total-too-large txid="
+                                     << txid << " (" << spliced_bytes << "+"
+                                     << sz << " > "
+                                     << coin::Mempool::kMaxPinnedTotalBytes
+                                     << ")";
+                            continue;
+                        }
+                        coin::pin_append(fb, pin);
+                        spliced_bytes += sz;
                         LOG_INFO << "[dashd-splice] pinned tx INCLUDED h="
-                                 << arm.pin_verdict.at_height
-                                 << " txid=" << txid
-                                 << " vin=" << arm.pin_tx->vin.size()
+                                 << v.at_height << " txid=" << txid
+                                 << " vin=" << pin.vin.size()
                                  << " fee=0 (rides this template)";
-                    } else {
-                        LOG_INFO << "[dashd-splice] pinned tx EXCLUDED h="
-                                 << arm.pin_verdict.at_height
-                                 << " cause=" << arm.pin_verdict.cause
-                                 << " txid=" << txid
-                                 << " (template built without it; re-checked "
-                                    "next build)";
                     }
                 }
                 sel = coin::WorkSelection{ std::move(fb),

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -482,11 +482,11 @@ private:
         /// what the production primary logged on 2026-08-07
         /// (`pinned tx EXCLUDED h=0`) -- an honest report about the wrong
         /// object.
-        coin::PinVerdict            pin_verdict;
+        std::vector<coin::PinVerdict> pin_verdicts;
         /// Points at load-time-immutable storage (set once before serving,
         /// never mutated), which is why a pointer may cross where a container
         /// reference may not. nullptr when no pin is configured.
-        const coin::MutableTransaction* pin_tx{nullptr};
+        const std::vector<coin::MutableTransaction>* pin_txs{nullptr};
     };
 
     /// COIN-STATE-OWNING THREAD ONLY (#1134). Reads NodeCoinState -- populated(),

--- a/test/test_dash_embedded_gbt.cpp
+++ b/test/test_dash_embedded_gbt.cpp
@@ -1177,6 +1177,12 @@ static dash::coin::DashWorkData build_with_pin(
     const MnStateMachine& mnstates, const Mempool& mp,
     const uint256& prev_hash, const MutableTransaction* pin,
     bool suppress = false) {
+    // The builder now takes a VECTOR of pins (the consolidation had to be
+    // split); these KATs each exercise one, so wrap it.
+    static thread_local std::vector<MutableTransaction> pins;
+    pins.clear();
+    if (pin != nullptr) pins.push_back(*pin);
+    const std::vector<MutableTransaction>* pins_arg = pin ? &pins : nullptr;
     return build_embedded_workdata(
         H - 1, prev_hash, mnstates, mp,
         0x1b104be3u, 1'700'000'000u, DASH_PUBKEY_VER, DASH_P2SH_VER,
@@ -1186,7 +1192,7 @@ static dash::coin::DashWorkData build_with_pin(
         /*credit_pool=*/0, /*qc=*/nullptr, /*root_override=*/nullptr,
         dash::coin::DASH_MN_RR_HEIGHT_MAINNET, /*superblock=*/nullptr,
         dash::coin::DASH_MN_MIN_CONFIRMATIONS_MAINNET,
-        suppress, "mempool-txs-disabled", pin);
+        suppress, "mempool-txs-disabled", pins_arg);
 }
 
 TEST(DashEmbeddedGbt, PinnedLocalTxRidesWithZeroFeeAndExactCoinbase) {
@@ -1355,7 +1361,8 @@ TEST(DashPinGate, PlaceholderFallbackIsNeverSpliced) {
     e.prev_height      = 0;            // exactly the production shape
     e.mnstates         = &mnstates;
     e.mempool          = &mp;
-    e.pinned_local_tx  = &pin;
+    std::vector<dash::coin::MutableTransaction> pins{pin};
+    e.pinned_local_txs = &pins;
 
     auto placeholder = []() -> dash::coin::DashWorkData { return {}; };
     auto sel = dash::coin::select_dash_work(e, placeholder);

--- a/test/test_dash_embedded_gbt.cpp
+++ b/test/test_dash_embedded_gbt.cpp
@@ -1377,3 +1377,96 @@ TEST(DashPinGate, PlaceholderFallbackIsNeverSpliced) {
     EXPECT_EQ(sel_real.work.m_txs.size(), 1u)
         << "a genuine fallback template still carries the pin";
 }
+
+// ════════════════════════════════════════════════════════════════════════
+// SIZE — the gate face that did not exist, and the block it cost.
+//
+//   2026-08-07 14:33:45  won block height=2517855 bytes=152889
+//   2026-08-07 14:33:45  submit_block_hex result: "bad-txns-oversize"
+//
+// Height 2517855 went to another miner. The pinned consolidation was 152258
+// bytes (1032 inputs) and EVERY face the gate had — inputs unspent, coinbase
+// maturity, fee exactly zero, no MN-collateral spend — passed it. The tx was
+// admissible by every rule anyone had thought to write, and unmineable by
+// consensus. dashd agreed independently:
+//   testmempoolaccept -> allowed=false reject-reason="bad-txns-oversize"
+//
+// A pin is not worth its own value when it is wrong. It is worth the block.
+// ════════════════════════════════════════════════════════════════════════
+
+// Build a pin with `n` inputs, all mature and unspent, fee exactly zero — so
+// the ONLY thing that can refuse it is size.
+static MutableTransaction make_admissible_pin(UTXOViewCache& utxo, unsigned n,
+                                              unsigned seed_base) {
+    MutableTransaction pin;
+    pin.version = 2; pin.type = 0; pin.locktime = 0;
+    int64_t total = 0;
+    for (unsigned i = 0; i < n; ++i) {
+        uint256 h = mint_hash(seed_base + i);
+        const int64_t v = 1'000 + i;
+        utxo.add_coin(Outpoint(h, 0), Coin(v, {}, H - 5'000, /*cb=*/true));
+        TxIn in; in.prevout.hash = h; in.prevout.index = 0;
+        // A real signed input carries a ~107-byte scriptSig (DER sig +
+        // compressed pubkey). Without it the KAT would measure a shape that
+        // never reaches a block, and the size face would be tested against
+        // fiction.
+        std::vector<unsigned char> sig(107, 0x51);
+        in.scriptSig = OPScript(sig.data(), sig.data() + sig.size());
+        in.sequence = 0xffffffffu;
+        pin.vin.push_back(in);
+        total += v;
+    }
+    TxOut o; o.value = total; pin.vout.push_back(o);   // fee exactly zero
+    return pin;
+}
+
+TEST(DashPinGate, OversizePinIsRefusedByNameNotDiscoveredAtSubmit) {
+    UTXOViewCache utxo(nullptr);
+    Mempool mp; mp.set_utxo(&utxo);
+
+    // 1032 inputs — the production shape, byte-for-byte in spirit.
+    auto pin = make_admissible_pin(utxo, 1032, 5'000);
+    const size_t bytes = ::pack(pin).get_span().size();
+    EXPECT_GT(bytes, dash::coin::Mempool::kMaxPinnedTxBytes)
+        << "the KAT must reproduce an OVERSIZE tx or it proves nothing; got "
+        << bytes << " bytes";
+
+    EXPECT_EQ(mp.pinned_tx_admissible(pin, H),
+              dash::coin::Mempool::PinnedTxGate::TooLarge)
+        << "an oversize pin must be refused BY NAME at gate time — the "
+           "alternative is discovering it from dashd after the block is gone";
+    EXPECT_STREQ(dash::coin::Mempool::pinned_gate_name(
+                     dash::coin::Mempool::PinnedTxGate::TooLarge),
+                 "tx-too-large");
+}
+
+TEST(DashPinGate, SplitPinUnderTheCapIsAdmissible) {
+    UTXOViewCache utxo(nullptr);
+    Mempool mp; mp.set_utxo(&utxo);
+
+    // 258 inputs = the 1032 consolidation split four ways. Same coins, same
+    // zero fee, same maturity — the ONLY change is size.
+    auto pin = make_admissible_pin(utxo, 258, 9'000);
+    const size_t bytes = ::pack(pin).get_span().size();
+    EXPECT_LT(bytes, dash::coin::Mempool::kMaxPinnedTxBytes)
+        << "a quarter-split must fit under the cap; got " << bytes;
+
+    EXPECT_EQ(mp.pinned_tx_admissible(pin, H),
+              dash::coin::Mempool::PinnedTxGate::Ok)
+        << "splitting is the fix, so the split must actually pass";
+}
+
+// The size face runs BEFORE the coin lookups. With no UTXO view wired at all,
+// an oversize tx must still be named TooLarge rather than utxo-view-unset:
+// the verdict is certain without consulting any chain state, and reporting the
+// weaker cause would send the operator hunting a view that is not the problem.
+TEST(DashPinGate, OversizeIsNamedEvenWithNoUtxoViewWired) {
+    UTXOViewCache utxo(nullptr);
+    Mempool sizing; sizing.set_utxo(&utxo);
+    auto pin = make_admissible_pin(utxo, 1032, 13'000);
+
+    Mempool bare;   // no view, no external lookup
+    EXPECT_EQ(bare.pinned_tx_admissible(pin, H),
+              dash::coin::Mempool::PinnedTxGate::TooLarge)
+        << "size is decidable without chain state; say so";
+}

--- a/test/test_dash_work_source.cpp
+++ b/test/test_dash_work_source.cpp
@@ -149,7 +149,8 @@ TEST(DashWorkSource, PinnedTxExcludedOnFallbackWithoutVerifyView)
     EmbeddedWorkInputs emb;            // has_state=false → fallback arm
     dash::coin::MutableTransaction pin;
     pin.vin.resize(1);
-    emb.pinned_local_tx = &pin;        // pin present, but no mempool/mnstates
+    std::vector<dash::coin::MutableTransaction> pins{pin};
+    emb.pinned_local_txs = &pins;        // pin present, but no mempool/mnstates
 
     bool emb_ran = false, fb_ran = false;
     WorkSelection sel = select_dash_work(
@@ -178,7 +179,8 @@ TEST(DashWorkSource, PinnedTxOnFallbackFailsClosedWithoutUtxoView)
     emb.mempool  = &mp;
     dash::coin::MutableTransaction pin;
     pin.vin.resize(1);
-    emb.pinned_local_tx = &pin;
+    std::vector<dash::coin::MutableTransaction> pins{pin};
+    emb.pinned_local_txs = &pins;
 
     bool emb_ran = false, fb_ran = false;
     WorkSelection sel = select_dash_work(
@@ -220,7 +222,8 @@ TEST(DashWorkSource, PinnedTxSplicedOnFallbackWithVerifyView)
     EmbeddedWorkInputs emb;       // has_state=false -> fallback arm
     emb.mnstates        = &mn;
     emb.mempool         = &mp;
-    emb.pinned_local_tx = &pin;
+    std::vector<dash::coin::MutableTransaction> pins{pin};
+    emb.pinned_local_txs = &pins;
 
     bool emb_ran = false, fb_ran = false;
     WorkSelection sel = select_dash_work(
@@ -498,7 +501,8 @@ TEST(DashWorkSource, PlaceholderFallbackLeavesThePinAlone)
     EmbeddedWorkInputs emb;          // has_state=false -> fallback arm
     emb.mnstates        = &mn;
     emb.mempool         = &mp;
-    emb.pinned_local_tx = &pin;
+    std::vector<dash::coin::MutableTransaction> pins{pin};
+    emb.pinned_local_txs = &pins;
     emb.prev_height     = 2'517'800; // a tip IS known — still not a template
 
     bool emb_ran = false, fb_ran = false;
@@ -544,7 +548,8 @@ TEST(DashWorkSource, FallbackCarryingAHeightIsATemplateAndTakesThePin)
     EmbeddedWorkInputs emb;
     emb.mnstates        = &mn;
     emb.mempool         = &mp;
-    emb.pinned_local_tx = &pin;
+    std::vector<dash::coin::MutableTransaction> pins{pin};
+    emb.pinned_local_txs = &pins;
     emb.prev_height     = 2'517'800;
 
     bool emb_ran = false, fb_ran = false;


### PR DESCRIPTION
## What happened

```
2026-08-07 14:33:45  won block height=2517855 bytes=152889
2026-08-07 14:33:45  submit_block_hex result: "bad-txns-oversize"
```

We found block 2517855 and could not keep it. It went to another miner.

The pinned donation consolidation was **152258 bytes** across 1032 inputs. Every face the gate had **passed** it:

| gate face | verdict |
|---|---|
| inputs unspent (authoritative source) | ✅ pass |
| coinbase maturity | ✅ pass |
| fee exactly zero | ✅ pass |
| no MN-collateral spend | ✅ pass |
| **size** | **face did not exist** |

The transaction was admissible by every rule anyone had thought to write, and invalid by consensus. Confirmed independently against the daemon:

```
testmempoolaccept -> allowed=false  reject-reason="bad-txns-oversize"
```

Dash rejects an oversize transaction in `CheckTransaction`, so this is a **consensus** failure, not policy: the block carrying it is *invalid*, not merely non-standard. A wrong pin costs **the whole block** (~1.77 DASH), not its own value. That was written down as the reason not to weaken the gate — and it happened anyway, through a face the gate did not have.

## The fix

`PinnedTxGate::TooLarge` + `kMaxPinnedTxBytes`, checked **first**, before the 1032 coin lookups. Size is the only verdict certain without any chain state: an oversize tx is invalid at every height against every UTXO view. Reporting `utxo-view-unset` for one would send the operator hunting a view that is not the problem.

Also adds `kMaxPinnedTotalBytes` for the cumulative cap the multi-pin lane will need to put several split transactions in one block.

## Tests — three KATs, all red before this commit

- **`OversizePinIsRefusedByNameNotDiscoveredAtSubmit`** — 1032 inputs, each carrying a realistic 107-byte scriptSig (DER sig + compressed pubkey) so the shape measured is one that could actually reach a block. Without the scriptSig the KAT would measure a fiction that happens to be small, and would pass while proving nothing.
- **`SplitPinUnderTheCapIsAdmissible`** — the same coins split four ways (258 inputs) pass. Splitting is the remedy, so the remedy is tested, not assumed.
- **`OversizeIsNamedEvenWithNoUtxoViewWired`** — size is decidable without chain state and the gate says so, rather than blaming the view.

208/208 green on vm905 with `BLS=REAL`.

## Blast radius

Serving is byte-unchanged for every node without a pin configured.