### PR TITLE
dash: one size budget for the whole block, not one per component

### DIFF
--- a/src/impl/dash/coin/embedded_gbt.hpp
+++ b/src/impl/dash/coin/embedded_gbt.hpp
@@ -333,7 +333,47 @@ inline DashWorkData build_embedded_workdata(
 
     // Subsidy + tx selection.
     int64_t reward = compute_dash_block_reward_post_v20(w.m_height);
-    constexpr uint32_t MAX_BLOCK_BYTES = 1'990'000;  // leave headroom for cb
+
+    // ── UNIFIED SIZE BUDGET (block 2517855) ────────────────────────────────
+    // Every component of the block competes for ONE budget. Before this, the
+    // mempool selection was handed the WHOLE cap as if it were alone, and the
+    // consensus-required qc set plus any pinned transactions were appended on
+    // top of it. Worst case that overshoots the 2 MB block limit outright, and
+    // an oversize block is INVALID, not merely large — dashd rejects it with
+    // bad-blk-length and the height goes to another miner.
+    //
+    // dashd does the same accounting in the other direction: node/miner.cpp
+    // starts nBlockSize at a 1000-byte coinbase reserve, adds each qcTx's
+    // GetTotalSize(), and packages the rest against nBlockMaxSize minus that
+    // reserve. We mirror the ORDER — reserve, then consensus-required qc, then
+    // pins, then selection gets the remainder — so the component that can be
+    // dropped safely (mempool txs, worth fees) yields to the ones that cannot
+    // (coinbase and qc, required for validity).
+    //
+    // We size qc and pins BEFORE selection rather than after, because a budget
+    // discovered after the fact is not a budget. The pin figure here is an
+    // UPPER BOUND (every configured pin, before the admission gate runs); the
+    // gate can only shrink it, so deducting the bound is conservative and can
+    // never let the block exceed the cap.
+    constexpr uint32_t MAX_BLOCK_BYTES   = 1'990'000;  // leave headroom for cb
+    constexpr uint32_t kCoinbaseReserve  = 1'000;      // dashd node/miner.cpp:115
+    uint64_t reserved_bytes = kCoinbaseReserve;
+    if (qc_commitments != nullptr) {
+        for (const auto& c : *qc_commitments)
+            reserved_bytes += ::pack(build_qc_tx(w.m_height, c)).get_span().size();
+    }
+    if (pinned_local_txs != nullptr) {
+        for (const auto& t : *pinned_local_txs)
+            reserved_bytes += ::pack(t).get_span().size();
+    }
+    // Selection gets what is left. If the required set alone has eaten the
+    // budget, selection gets ZERO rather than a negative number wrapping to a
+    // huge unsigned cap — the underflow face is the one that would silently
+    // restore the old behaviour.
+    const uint32_t selection_budget =
+        reserved_bytes >= MAX_BLOCK_BYTES
+            ? 0u
+            : static_cast<uint32_t>(MAX_BLOCK_BYTES - reserved_bytes);
     // C-3: exclude Dash special txs (tx.type != 0) from the embedded template.
     // dashd recomputes the CbTx roots + creditPool by applying the block's own
     // special txs; including one without accounting for it yields bad-cbtx. The
@@ -350,7 +390,7 @@ inline DashWorkData build_embedded_workdata(
     auto [selected, total_fees] =
         suppress_mempool_txs
             ? std::pair<std::vector<Mempool::SelectedTx>, uint64_t>{{}, 0ull}
-            : mempool.get_sorted_txs_with_fees(MAX_BLOCK_BYTES,
+            : mempool.get_sorted_txs_with_fees(selection_budget,
                                                /*exclude_special=*/true,
                                                /*next_height=*/w.m_height);
     // MN-collateral spend filter (sml_projection.hpp, FINDING-2). The C-3
@@ -397,7 +437,10 @@ inline DashWorkData build_embedded_workdata(
     // which no consensus path reads.
     if (suppress_mempool_txs) {
         auto [cand, cand_fees] =
-            mempool.get_sorted_txs_with_fees(MAX_BLOCK_BYTES,
+            // Same budget as the served path. Reporting the forgone set
+            // against the FULL cap would overstate it — we could not have
+            // served more than selection_budget even with serving enabled.
+            mempool.get_sorted_txs_with_fees(selection_budget,
                                              /*exclude_special=*/true,
                                              /*next_height=*/w.m_height);
         (void)cand_fees;

--- a/test/test_dash_embedded_gbt.cpp
+++ b/test/test_dash_embedded_gbt.cpp
@@ -1477,3 +1477,102 @@ TEST(DashPinGate, OversizeIsNamedEvenWithNoUtxoViewWired) {
               dash::coin::Mempool::PinnedTxGate::TooLarge)
         << "size is decidable without chain state; say so";
 }
+
+// ════════════════════════════════════════════════════════════════════════
+// UNIFIED SIZE BUDGET — every component competes for ONE block.
+//
+// Before this, mempool selection was handed the WHOLE cap as if it were alone
+// in the block, and the consensus-required qc set plus any pinned transactions
+// were appended ON TOP. The arithmetic overshoots the 2 MB consensus limit,
+// and an oversize block is INVALID — dashd rejects it bad-blk-length and the
+// height goes to another miner. We lost block 2517855 to the same class of
+// error one level down (a single oversize TRANSACTION); this is the same
+// mistake at block scale.
+//
+// dashd accounts the other way round on purpose (node/miner.cpp): nBlockSize
+// starts at a 1000-byte coinbase reserve, each qcTx GetTotalSize() is added,
+// and packages are fitted into what remains. The component that can be dropped
+// safely — mempool txs, worth only fees — yields to the ones that cannot.
+// ════════════════════════════════════════════════════════════════════════
+
+TEST(DashSizeBudget, SelectionBudgetShrinksByTheRequiredSet) {
+    // The arithmetic that was wrong. Selection cap 1'990'000 while the pin set
+    // may hold kMaxPinnedTotalBytes (400'000) and the qc plan adds more — the
+    // sum exceeded the 2'000'000 consensus limit with no accounting anywhere.
+    constexpr uint64_t kConsensusBlockLimit = 2'000'000;
+    constexpr uint64_t kOldSelectionCap     = 1'990'000;
+    constexpr uint64_t kPinBudget = dash::coin::Mempool::kMaxPinnedTotalBytes;
+
+    // Worst case under the OLD scheme: selection fills its cap, pins fill
+    // theirs, qc rides on top. Even ignoring qc entirely this is already over.
+    const uint64_t old_worst = kOldSelectionCap + kPinBudget;
+    EXPECT_GT(old_worst, kConsensusBlockLimit)
+        << "the pre-fix arithmetic must actually overshoot, or this KAT is "
+           "asserting nothing: " << old_worst << " vs " << kConsensusBlockLimit;
+
+    // Under the unified budget the deduction is subtraction, so the total is
+    // bounded by construction no matter how the parts are sized.
+    constexpr uint64_t kCoinbaseReserve = 1'000;
+    const uint64_t qc_bytes  = 12'000;   // a fat rotated-boundary qc plan
+    const uint64_t reserved  = kCoinbaseReserve + qc_bytes + kPinBudget;
+    const uint64_t selection = reserved >= kOldSelectionCap
+                                   ? 0 : kOldSelectionCap - reserved;
+    EXPECT_LE(selection + reserved, kConsensusBlockLimit)
+        << "the unified budget must bound the whole block";
+}
+
+TEST(DashSizeBudget, RequiredSetLargerThanCapYieldsZeroNotUnderflow) {
+    // The face that would silently restore the old behaviour: if the required
+    // set exceeds the cap and the remainder is computed as an unsigned
+    // subtraction, it wraps to ~4 GB and selection fills the block again.
+    constexpr uint32_t MAX_BLOCK_BYTES = 1'990'000;
+    const uint64_t reserved = 2'500'000;   // required set alone over the cap
+
+    const uint32_t budget = reserved >= MAX_BLOCK_BYTES
+                                ? 0u
+                                : static_cast<uint32_t>(MAX_BLOCK_BYTES - reserved);
+    EXPECT_EQ(budget, 0u)
+        << "an over-budget required set must starve selection, never wrap";
+
+    // Demonstrate what the unguarded form would have produced, so the guard's
+    // value is visible rather than asserted.
+    const uint32_t unguarded =
+        static_cast<uint32_t>(MAX_BLOCK_BYTES - reserved);
+    EXPECT_GT(unguarded, MAX_BLOCK_BYTES)
+        << "unguarded subtraction wraps — this is the defect being prevented";
+}
+
+TEST(DashSizeBudget, BuilderDeductsPinsFromSelectionBudget) {
+    // End-to-end through the builder: with a pin configured, the template must
+    // not exceed the limit. The pin is admissible on the merits so it really
+    // does ride, and its bytes really do have to come from somewhere.
+    UTXOViewCache utxo(nullptr);
+    uint256 don = mint_hash(120);
+    utxo.add_coin(Outpoint(don, 0), Coin(50'000, {}, H - 5'000, /*cb=*/true));
+    Mempool mp; mp.set_utxo(&utxo);
+
+    MutableTransaction pin;
+    pin.version = 2; pin.type = 0; pin.locktime = 0;
+    { TxIn i; i.prevout.hash = don; i.prevout.index = 0;
+      i.sequence = 0xffffffffu; pin.vin.push_back(i); }
+    { TxOut o; o.value = 50'000; pin.vout.push_back(o); }
+    std::vector<MutableTransaction> pins{pin};
+
+    auto mnstates = single_mn(p2pkh_script(0x30));
+    auto w = build_embedded_workdata(
+        H - 1, raw256(0xAB), mnstates, mp,
+        0x1b104be3u, 1'700'000'000u, DASH_PUBKEY_VER, DASH_P2SH_VER,
+        /*curtime=*/1'700'000'100u, /*version=*/0x20000000u,
+        /*underfill=*/nullptr, /*sml=*/nullptr, /*qmgr=*/nullptr,
+        /*best_cl_height=*/0, dash::coin::k_zero_cl_sig,
+        /*credit_pool=*/0, /*qc=*/nullptr, /*root_override=*/nullptr,
+        dash::coin::DASH_MN_RR_HEIGHT_MAINNET, /*superblock=*/nullptr,
+        dash::coin::DASH_MN_MIN_CONFIRMATIONS_MAINNET,
+        /*suppress=*/true, "mempool-txs-disabled", &pins);
+
+    ASSERT_EQ(w.m_txs.size(), 1u) << "the pin rides";
+    uint64_t body = 0;
+    for (const auto& h : w.m_tx_data_hex) body += h.size() / 2;
+    EXPECT_LT(body, 2'000'000u)
+        << "template body must stay under the consensus block limit";
+}


### PR DESCRIPTION
## The arithmetic

Mempool selection was handed `MAX_BLOCK_BYTES` as if it were alone in the block. The consensus-required qc set and any pinned transactions were then appended **on top of** a full selection. Nothing added the parts up.

```
selection cap                    1,990,000
+ pin budget (kMaxPinnedTotalBytes)  400,000
                                 ─────────
                                 2,390,000   vs consensus limit 2,000,000
```

That is before a single qc transaction is counted. An oversize block is **invalid**, not merely large — dashd rejects it `bad-blk-length` and the height goes to whoever else found one.

This is the same mistake that cost us block **2517855** today, one level up. There it was a single oversize *transaction* and the gate had no size face. Here it is the *block*, and the budget had no owner.

## The fix mirrors dashd's ordering, deliberately

dashd accounts the other way round (`node/miner.cpp`): `nBlockSize` starts at a 1000-byte coinbase reserve, each `qcTx GetTotalSize()` is added, and packages are fitted into what remains.

We mirror that **order**, because the order encodes which component may be dropped:

| component | may be dropped? |
|---|---|
| coinbase reserve | no — required |
| qc set | no — consensus-required |
| pins | policy, sized as an upper bound |
| **mempool selection** | **yes — worth only fees, so fees yield** |

## Two details that are the actual content

**qc and pins are sized BEFORE selection runs, not after.** A budget discovered after the fact is not a budget. The pin figure is an upper bound — every configured pin, before the admission gate narrows it — so deducting it is conservative and cannot let the block exceed the cap.

**The remainder has an explicit zero floor.** Unsigned subtraction of an over-cap required set wraps to ~4 GB and hands selection an unbounded budget — silently restoring exactly the behaviour being fixed. That face gets its own KAT which *demonstrates* the wrap rather than asserting around it.

The forgone-fee report moves onto the same budget: measuring it against the full cap would overstate what we could have served.

## Tests

- **`SelectionBudgetShrinksByTheRequiredSet`** — asserts the pre-fix arithmetic actually overshoots, so the KAT fails on its own premise if that ever stops being true, rather than passing vacuously.
- **`RequiredSetLargerThanCapYieldsZeroNotUnderflow`** — the wrap face, shown side by side with the guarded form.
- **`BuilderDeductsPinsFromSelectionBudget`** — end-to-end through the builder with a pin that really rides.

**211/211 green** on vm905 with `BLS=REAL`.

## Provenance

PR-1 of the six-PR dashd-parity series, derived from a direct read of the
dashd v23.1.7 sources rather than from our own prior assumptions about them.
The series order is dependency-mandated: this PR gates the first byte the
later null-commitment arm would add.
