### PR TITLE
core: the found-block log says WHO found it

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -1667,7 +1667,12 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                             // site passed get_local_hashrate(), which is only
                             // the pool rate when every rig sits on this node.
                             /*pool_hashrate=*/0.0,
-                            row.subsidy);
+                            row.subsidy,
+                            // Sharechain peer path: another node built the
+                            // template that won. Our pins and our tx selection
+                            // are not in it, and our address may still be in
+                            // the coinbase as our share of the pool payout.
+                            /*found_locally=*/false);
                         // Arm the post-broadcast confirm/orphan poller so this
                         // peer-found block flips off "pending" (main_ltc.cpp:6315
                         // parity). Telemetry only; never gates a broadcast.
@@ -2609,7 +2614,10 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                         mi->get_network_difficulty(),
                         /*share_difficulty=*/0.0,
                         /*pool_hashrate=*/0.0,
-                        subsidy);
+                        subsidy,
+                        // Local dispatch: THIS node built the template and
+                        // sent the block. Whatever we pinned rode it.
+                        /*found_locally=*/true);
                     // Arm the post-broadcast confirm/orphan poller so this local
                     // win flips off "pending" (main_ltc.cpp:4258 parity).
                     // Telemetry only; runs after dispatch, never gates it.

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -1672,7 +1672,10 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                             // template that won. Our pins and our tx selection
                             // are not in it, and our address may still be in
                             // the coinbase as our share of the pool payout.
-                            /*found_locally=*/false);
+                            // row.miner is that peer's own payout address,
+                            // derived from the winning share's pubkey hash.
+                            core::MiningInterface::BlockAuthorship
+                                ::sharechain_peer);
                         // Arm the post-broadcast confirm/orphan poller so this
                         // peer-found block flips off "pending" (main_ltc.cpp:6315
                         // parity). Telemetry only; never gates a broadcast.
@@ -2617,7 +2620,7 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                         subsidy,
                         // Local dispatch: THIS node built the template and
                         // sent the block. Whatever we pinned rode it.
-                        /*found_locally=*/true);
+                        core::MiningInterface::BlockAuthorship::this_node);
                     // Arm the post-broadcast confirm/orphan poller so this local
                     // win flips off "pending" (main_ltc.cpp:4258 parity).
                     // Telemetry only; runs after dispatch, never gates it.

--- a/src/core/test/web_server_dashboard_data_test.cpp
+++ b/src/core/test/web_server_dashboard_data_test.cpp
@@ -541,3 +541,90 @@ TEST(DashboardData, PaymentsEqualBlockValueWhereThereIsNoProtocolLane)
         EXPECT_FALSE(stats.contains("block_value_burn"));
     }
 }
+
+// ── AUTHORSHIP: three states, and "unknown" is one of them ───────────────
+//
+// Block 2517979 (2026-08-07) read as ours by every check the log offered --
+// our address in the coinbase, BLOCK CONFIRMED printed, confirmations=1 --
+// and was found by another node on the sharechain. The coinbase cannot
+// answer authorship on a p2pool sharechain: it pays every participant.
+//
+// The first cut of the fix used a bool defaulting to false. That is a
+// two-valued answer to a three-valued question, and its default reads as a
+// CLAIM -- every LTC/DGB/BTC/BCH block, whose call sites do not label, would
+// have announced a sharechain peer as its finder. These tests pin the third
+// state and the direction of the merge.
+TEST(FoundBlockAuthorship, UnlabelledCallSiteStaysUnknownAndClaimsNothing)
+{
+    MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                       c2pool::address::Blockchain::LITECOIN);
+    const std::string h =
+        "5555555555555555555555555555555555555555555555555555555555555555";
+    // The LTC/DGB/BTC/BCH call shape: no authorship argument at all.
+    mi.record_found_block(2500000, uint256S(h), /*ts=*/1785955172, "LTC",
+                          "LhY4example", h, 1000.0, 1.0, 0.0, 0);
+    auto blk = find_block(mi.rest_recent_blocks(), h);
+    ASSERT_TRUE(blk.is_object());
+    EXPECT_EQ(blk["found_by"].get<std::string>(), "unknown")
+        << "a lane that does not label must say unknown, never name a finder";
+}
+
+TEST(FoundBlockAuthorship, LabelledSitesReportTheFinderTheyKnow)
+{
+    MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                       c2pool::address::Blockchain::LITECOIN);
+    const std::string hp =
+        "6666666666666666666666666666666666666666666666666666666666666666";
+    const std::string hl =
+        "7777777777777777777777777777777777777777777777777777777777777777";
+    mi.record_found_block(2517979, uint256S(hp), 1785955172, "DASH",
+                          "XoZcEFbqwnty5secW7HYjdQEZYfubMkURu", hp,
+                          1000.0, 1.0, 0.0, 0,
+                          MiningInterface::BlockAuthorship::sharechain_peer);
+    mi.record_found_block(2517980, uint256S(hl), 1785955174, "DASH",
+                          "XoZcEFbqwnty5secW7HYjdQEZYfubMkURu", hl,
+                          1000.0, 1.0, 0.0, 0,
+                          MiningInterface::BlockAuthorship::this_node);
+    auto blocks = mi.rest_recent_blocks();
+    EXPECT_EQ(find_block(blocks, hp)["found_by"].get<std::string>(),
+              "sharechain_peer");
+    EXPECT_EQ(find_block(blocks, hl)["found_by"].get<std::string>(),
+              "this_node");
+}
+
+TEST(FoundBlockAuthorship, EnrichmentRaisesAuthorshipAndNeverLowersIt)
+{
+    MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                       c2pool::address::Blockchain::LITECOIN);
+    const std::string h =
+        "8888888888888888888888888888888888888888888888888888888888888888";
+    // The real ordering on DASH: the peer path sees the block on the
+    // sharechain first, and our own dispatch enriches the SAME row after.
+    // That second call is the one that knows we built it.
+    mi.record_found_block(2517981, uint256S(h), 1785955172, "DASH",
+                          "XoZcEFbqwnty5secW7HYjdQEZYfubMkURu", h,
+                          1000.0, 1.0, 0.0, 0,
+                          MiningInterface::BlockAuthorship::sharechain_peer);
+    mi.record_found_block(2517981, uint256S(h), 1785955172, "DASH",
+                          "XoZcEFbqwnty5secW7HYjdQEZYfubMkURu", h,
+                          1000.0, 1.0, 0.0, 0,
+                          MiningInterface::BlockAuthorship::this_node);
+    EXPECT_EQ(find_block(mi.rest_recent_blocks(), h)["found_by"].get<std::string>(),
+              "this_node");
+
+    // And the reverse order must NOT demote it. An assignment-style merge
+    // would; taking the max is why it cannot.
+    const std::string h2 =
+        "9999999999999999999999999999999999999999999999999999999999999999";
+    mi.record_found_block(2517982, uint256S(h2), 1785955174, "DASH",
+                          "XoZcEFbqwnty5secW7HYjdQEZYfubMkURu", h2,
+                          1000.0, 1.0, 0.0, 0,
+                          MiningInterface::BlockAuthorship::this_node);
+    mi.record_found_block(2517982, uint256S(h2), 1785955174, "DASH",
+                          "XoZcEFbqwnty5secW7HYjdQEZYfubMkURu", h2,
+                          1000.0, 1.0, 0.0, 0,
+                          MiningInterface::BlockAuthorship::sharechain_peer);
+    EXPECT_EQ(find_block(mi.rest_recent_blocks(), h2)["found_by"].get<std::string>(),
+              "this_node")
+        << "a later, less informed call must not downgrade a known finder";
+}

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -3421,7 +3421,8 @@ void MiningInterface::record_found_block(uint64_t height, const uint256& hash, u
                                           double network_difficulty,
                                           double share_difficulty,
                                           double pool_hashrate,
-                                          uint64_t subsidy)
+                                          uint64_t subsidy,
+                                          bool found_locally)
 {
     if (ts == 0) ts = static_cast<uint64_t>(std::time(nullptr));
     std::string hash_hex = hash.GetHex();
@@ -3477,6 +3478,12 @@ void MiningInterface::record_found_block(uint64_t height, const uint256& hash, u
                 if (existing.pool_hashrate <= 0.0)
                     existing.pool_hashrate = pool_hashrate;
                 if (existing.subsidy == 0) existing.subsidy = subsidy;
+                // Authorship only ever turns ON. The peer path records first
+                // (we see the block on the sharechain), and our own dispatch
+                // may enrich the same row afterwards — that second call is the
+                // one that knows we built it. The reverse never happens, so an
+                // OR is correct and an assignment would be a downgrade.
+                existing.found_locally = existing.found_locally || found_locally;
                 LOG_INFO << "[Pool] found-block row ENRICHED (was recorded"
                             " unattributed): h=" << existing.height
                          << " hash=" << hash_hex.substr(0, 16)
@@ -3495,7 +3502,7 @@ void MiningInterface::record_found_block(uint64_t height, const uint256& hash, u
 
     FoundBlock blk{height, hash_hex, ts, BlockStatus::pending, 0, chain, 0,
                    miner, share_hash, network_difficulty, share_difficulty,
-                   pool_hashrate, subsidy, 0, 0, 0};
+                   pool_hashrate, subsidy, 0, 0, 0, found_locally};
 
     // Compute time_to_find from previous block, then derive expected_time and luck
     {
@@ -3672,14 +3679,45 @@ void MiningInterface::verify_found_block(size_t index)
         if (blk.status == BlockStatus::pending) {
             blk.status = BlockStatus::confirmed;
             auto age_sec = static_cast<uint64_t>(std::time(nullptr)) - blk.ts;
+            // WHO FOUND IT, in words. On a p2pool sharechain the coinbase
+            // pays every participant proportionally, so our payout address in
+            // a block's coinbase means we earned a SHARE — never that we found
+            // it. That ambiguity cost real debugging time on 2026-08-07, when
+            // block 2517979 read as "ours" by its coinbase and was in fact
+            // found by another sharechain node, which is also why none of this
+            // node's pinned transactions were in it.
             LOG_INFO << "\n"
-                     << "  +++  BLOCK CONFIRMED — " << cn << " height " << blk.height << "  +++\n"
+                     << (blk.found_locally
+                            ? "  +++  BLOCK CONFIRMED — FOUND BY THIS NODE  +++\n"
+                            : "  +++  POOL BLOCK CONFIRMED — found by ANOTHER "
+                              "sharechain node  +++\n")
                      << "  Chain:      " << cn << "\n"
                      << "  Height:     " << blk.height << "\n"
                      << "  Block hash: " << blk.hash << "\n"
+                     << "  Found by:   "
+                     << (blk.found_locally ? "THIS NODE (we built the template"
+                                             " and dispatched it)"
+                                           : "ANOTHER NODE on the sharechain"
+                                             " — its template, not ours")
+                     << "\n"
+                     << "  Payout to:  " << (blk.miner.empty() ? "(unattributed)"
+                                                               : blk.miner)
+                     << (blk.found_locally ? ""
+                                           : "   [our address may still appear"
+                                             " in the coinbase as our SHARE of"
+                                             " the pool payout]")
+                     << "\n"
+                     << "  Share hash: " << (blk.share_hash.empty()
+                                                 ? "(none)" : blk.share_hash)
+                     << "\n"
                      << "  Verified:   check #" << (int)blk.check_count
                      << " (" << age_sec << "s after submission)"
-                     << " confirmations=" << blk.confirmations;
+                     << " confirmations=" << blk.confirmations
+                     << (blk.found_locally
+                            ? ""
+                            : "\n  Note:       transactions this node pins or"
+                              " serves are NOT in this block — the finder built"
+                              " its own template.");
         }
         // Already confirmed — just update confirmation count silently
     } else if (result < 0) {

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 #include "web_server.hpp"
 #include "stratum_server.hpp"
+#include <algorithm>   // std::max — authorship only ever climbs, never downgrades
 #include <memory>
 #include "address_utils.hpp"
 #include "socket.hpp"
@@ -2532,11 +2533,18 @@ nlohmann::json MiningInterface::rest_recent_blocks()
         // it, so luck_method must not fabricate a computed-luck label
         // ("first_block" wrongly implied a luck computation was attempted), and
         // the timing-derived fields are honest-absent (null) rather than a
-        // real-looking 0. found_locally is the explicit node-role signal the
-        // dashboard reads to render relay-learned blocks as such.
-        const bool found_locally = !(b.share_hash.empty() && b.miner.empty());
+        // real-looking 0.
+        //
+        // NAMING (2026-08-07): this predicate asks "do we hold a local record
+        // of the block", NOT "did we find it" — a sharechain peer's block
+        // satisfies it, because the gossiped share carries both fields. The
+        // two questions were conflated under one name; authorship now has its
+        // own field (b.authorship, emitted as found_by) set at the call site
+        // that knows. The wire key `found_locally` keeps its existing meaning
+        // and its existing consumers; read `found_by` for authorship.
+        const bool have_local_record = !(b.share_hash.empty() && b.miner.empty());
         std::string method;
-        if (!found_locally)                        method = "relayed";
+        if (!have_local_record)                    method = "relayed";
         else if (b.time_to_find > 0 && b.luck > 0) method = "simple_avg";
         else                                       method = "first_block";
         // #942 second slice, extended to EVERY unmeasured field (hotel,
@@ -2562,16 +2570,24 @@ nlohmann::json MiningInterface::rest_recent_blocks()
             {"confirmations", b.confirmations},
             {"miner", b.miner},
             {"share", b.share_hash},
-            {"found_locally", found_locally},
+            {"found_locally", have_local_record},
+            // Authorship, set at the call site that knows. "unknown" is a real
+            // answer -- a coin lane that has not labelled its sites -- and the
+            // UI must render it as unknown rather than folding it into either
+            // claim.
+            {"found_by", b.authorship == BlockAuthorship::this_node
+                             ? "this_node"
+                             : b.authorship == BlockAuthorship::sharechain_peer
+                                   ? "sharechain_peer" : "unknown"},
             {"network_difficulty", num_or_null(b.network_difficulty)},
             {"actual_hash_difficulty", actual_hash_difficulty(b.hash)},
             {"share_difficulty", num_or_null(b.share_difficulty)},
             {"pool_hashrate_at_find", num_or_null(b.pool_hashrate)},
             {"subsidy", b.subsidy != 0 ? nlohmann::json(b.subsidy)
                                        : nlohmann::json(nullptr)},
-            {"expected_time", found_locally ? num_or_null(b.expected_time) : nlohmann::json(nullptr)},
-            {"time_to_find", found_locally ? num_or_null(b.time_to_find) : nlohmann::json(nullptr)},
-            {"luck", found_locally ? num_or_null(b.luck) : nlohmann::json(nullptr)},
+            {"expected_time", have_local_record ? num_or_null(b.expected_time) : nlohmann::json(nullptr)},
+            {"time_to_find", have_local_record ? num_or_null(b.time_to_find) : nlohmann::json(nullptr)},
+            {"luck", have_local_record ? num_or_null(b.luck) : nlohmann::json(nullptr)},
             {"luck_method", method}
         });
     }
@@ -3422,7 +3438,7 @@ void MiningInterface::record_found_block(uint64_t height, const uint256& hash, u
                                           double share_difficulty,
                                           double pool_hashrate,
                                           uint64_t subsidy,
-                                          bool found_locally)
+                                          BlockAuthorship authorship)
 {
     if (ts == 0) ts = static_cast<uint64_t>(std::time(nullptr));
     std::string hash_hex = hash.GetHex();
@@ -3464,6 +3480,27 @@ void MiningInterface::record_found_block(uint64_t height, const uint256& hash, u
         for (auto& existing : m_found_blocks) {
             if (existing.hash != hash_hex || existing.chain != chain)
                 continue;
+            // AUTHORSHIP CLIMBS FIRST, and OUTSIDE the enrichment branch.
+            // It was inside it, gated on the existing row being unattributed
+            // -- which made the raise unreachable on the path it exists for.
+            // Both DASH sites record miner+share_hash, so the second call for
+            // a block always meets an ALREADY-ATTRIBUTED row, hit the plain
+            // early return, and left authorship at whatever the first caller
+            // happened to know. Attribution and authorship are independent
+            // facts: a fully attributed row can still be wrong about WHO
+            // found the block, and that is exactly the row this field exists
+            // to correct. EnrichmentRaisesAuthorshipAndNeverLowersIt proved
+            // this red before the fix.
+            const bool authorship_raised = authorship > existing.authorship;
+            if (authorship_raised) {
+                existing.authorship = authorship;
+                LOG_INFO << "[Pool] found-block AUTHORSHIP raised: h="
+                         << existing.height << " hash="
+                         << hash_hex.substr(0, 16) << " -> "
+                         << (authorship == BlockAuthorship::this_node
+                                 ? "THIS NODE" : "sharechain peer");
+            }
+
             const bool existing_unattributed =
                 existing.share_hash.empty() && existing.miner.empty();
             const bool incoming_attributed =
@@ -3478,12 +3515,6 @@ void MiningInterface::record_found_block(uint64_t height, const uint256& hash, u
                 if (existing.pool_hashrate <= 0.0)
                     existing.pool_hashrate = pool_hashrate;
                 if (existing.subsidy == 0) existing.subsidy = subsidy;
-                // Authorship only ever turns ON. The peer path records first
-                // (we see the block on the sharechain), and our own dispatch
-                // may enrich the same row afterwards — that second call is the
-                // one that knows we built it. The reverse never happens, so an
-                // OR is correct and an assignment would be a downgrade.
-                existing.found_locally = existing.found_locally || found_locally;
                 LOG_INFO << "[Pool] found-block row ENRICHED (was recorded"
                             " unattributed): h=" << existing.height
                          << " hash=" << hash_hex.substr(0, 16)
@@ -3495,6 +3526,15 @@ void MiningInterface::record_found_block(uint64_t height, const uint256& hash, u
                                        " found block: " << e.what();
                     }
                 }
+            } else if (authorship_raised && m_persist_block_fn) {
+                // Authorship changed on a row that needed no other enrichment.
+                // Without this the raise lives only in memory and the restored
+                // row reasserts the wrong finder after every restart.
+                try { m_persist_block_fn(existing); }
+                catch (const std::exception& e) {
+                    LOG_WARNING << "[Pool] Failed to persist raised"
+                                   " authorship: " << e.what();
+                }
             }
             return;  // already recorded (possibly just enriched)
         }
@@ -3502,7 +3542,7 @@ void MiningInterface::record_found_block(uint64_t height, const uint256& hash, u
 
     FoundBlock blk{height, hash_hex, ts, BlockStatus::pending, 0, chain, 0,
                    miner, share_hash, network_difficulty, share_difficulty,
-                   pool_hashrate, subsidy, 0, 0, 0, found_locally};
+                   pool_hashrate, subsidy, 0, 0, 0, authorship};
 
     // Compute time_to_find from previous block, then derive expected_time and luck
     {
@@ -3686,26 +3726,34 @@ void MiningInterface::verify_found_block(size_t index)
             // block 2517979 read as "ours" by its coinbase and was in fact
             // found by another sharechain node, which is also why none of this
             // node's pinned transactions were in it.
+            const bool ours  = blk.authorship == BlockAuthorship::this_node;
+            const bool peers = blk.authorship == BlockAuthorship::sharechain_peer;
             LOG_INFO << "\n"
-                     << (blk.found_locally
-                            ? "  +++  BLOCK CONFIRMED — FOUND BY THIS NODE  +++\n"
-                            : "  +++  POOL BLOCK CONFIRMED — found by ANOTHER "
-                              "sharechain node  +++\n")
+                     << (ours  ? "  +++  BLOCK CONFIRMED — FOUND BY THIS NODE  +++\n"
+                       : peers ? "  +++  POOL BLOCK CONFIRMED — found by ANOTHER "
+                                 "sharechain node  +++\n"
+                               : "  +++  POOL BLOCK CONFIRMED  +++\n")
                      << "  Chain:      " << cn << "\n"
                      << "  Height:     " << blk.height << "\n"
                      << "  Block hash: " << blk.hash << "\n"
                      << "  Found by:   "
-                     << (blk.found_locally ? "THIS NODE (we built the template"
-                                             " and dispatched it)"
-                                           : "ANOTHER NODE on the sharechain"
-                                             " — its template, not ours")
+                     << (ours  ? "THIS NODE (we built the template and"
+                                 " dispatched it)"
+                       : peers ? "ANOTHER NODE on the sharechain — its"
+                                 " template, not ours"
+                               : "UNKNOWN — this coin lane does not record"
+                                 " which node found the block")
                      << "\n"
+                     // The miner address is the payout of the WINNING SHARE,
+                     // i.e. the finder's own address, not the pool's and not
+                     // ours. It is meaningful on all three branches: on a
+                     // peer-found block it names the peer who found it.
                      << "  Payout to:  " << (blk.miner.empty() ? "(unattributed)"
                                                                : blk.miner)
-                     << (blk.found_locally ? ""
-                                           : "   [our address may still appear"
-                                             " in the coinbase as our SHARE of"
-                                             " the pool payout]")
+                     << (ours ? ""
+                              : "   [payout of the winning share — the finder."
+                                " Our address may ALSO appear in the coinbase"
+                                " as our SHARE of the pool payout]")
                      << "\n"
                      << "  Share hash: " << (blk.share_hash.empty()
                                                  ? "(none)" : blk.share_hash)
@@ -3713,11 +3761,11 @@ void MiningInterface::verify_found_block(size_t index)
                      << "  Verified:   check #" << (int)blk.check_count
                      << " (" << age_sec << "s after submission)"
                      << " confirmations=" << blk.confirmations
-                     << (blk.found_locally
-                            ? ""
-                            : "\n  Note:       transactions this node pins or"
+                     << (peers
+                            ? "\n  Note:       transactions this node pins or"
                               " serves are NOT in this block — the finder built"
-                              " its own template.");
+                              " its own template."
+                            : "");
         }
         // Already confirmed — just update confirmation count silently
     } else if (result < 0) {

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -280,7 +280,12 @@ public:
                             double network_difficulty = 0,
                             double share_difficulty = 0,
                             double pool_hashrate = 0,
-                            uint64_t subsidy = 0);
+                            uint64_t subsidy = 0,
+                            // TRUE only from the local won-block dispatch. The
+                            // sharechain-peer path passes false: that block was
+                            // built by ANOTHER node's template, so nothing this
+                            // node pins or serves is in it.
+                            bool found_locally = false);
     
     // Boundary types hoisted to core::stratum (see core/stratum_types.hpp).
     // Aliases kept here so existing references like `MiningInterface::JobSnapshot`
@@ -755,6 +760,13 @@ public:
         double      expected_time{0};      // expected seconds to find at current rate
         double      time_to_find{0};       // actual seconds since previous block
         double      luck{0};              // expected_time / time_to_find * 100
+        // WHO FOUND IT. On a p2pool sharechain the coinbase pays EVERY
+        // participant proportionally, so our payout address appearing in a
+        // block's coinbase means we earned a SHARE of it — never that we found
+        // it. Reading the coinbase for authorship is the mistake this field
+        // exists to make impossible: it is set at the call site that knows,
+        // and the log states it in words.
+        bool        found_locally{false};
     };
 
     // Block acceptance verification: schedule async checks at +10s, +30s, +120s.

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -271,6 +271,20 @@ public:
     std::string rest_web_log();
     std::string rest_logs_export(const std::string& scope, int64_t from_ts, int64_t to_ts, const std::string& format);
 
+    // WHO FOUND THE BLOCK. Three states, not two: a coin lane that has not
+    // been taught to label its call sites must say so, not inherit a default
+    // that reads as a claim. A two-valued bool defaulting to "not us" would
+    // make every LTC/DGB/BTC/BCH block announce a sharechain peer as its
+    // finder — the same false certainty this whole field exists to retire.
+    // Ordering is deliberate: the values increase with how much is known, so
+    // an enrichment pass can only ever raise the record (see the merge in
+    // record_found_block), never quietly downgrade a known finder.
+    enum class BlockAuthorship : uint8_t {
+        unknown         = 0,  // this coin lane does not label its call sites
+        sharechain_peer = 1,  // another node's template won
+        this_node       = 2,  // we built the template and dispatched it
+    };
+
     // Track a found block for the /recent_blocks endpoint.
     // Extended overload captures dashboard-enriched fields at record time.
     void record_found_block(uint64_t height, const uint256& hash, uint64_t ts = 0,
@@ -281,11 +295,15 @@ public:
                             double share_difficulty = 0,
                             double pool_hashrate = 0,
                             uint64_t subsidy = 0,
-                            // TRUE only from the local won-block dispatch. The
-                            // sharechain-peer path passes false: that block was
-                            // built by ANOTHER node's template, so nothing this
-                            // node pins or serves is in it.
-                            bool found_locally = false);
+                            // WHO FOUND IT — set at the call site that knows.
+                            // `this_node` from the local won-block dispatch;
+                            // `sharechain_peer` from the gossiped-share path
+                            // (another node's template won, so nothing this
+                            // node pins or serves is in it). A coin lane that
+                            // has not labelled its sites leaves `unknown`,
+                            // which reports as unknown and never as a claim.
+                            BlockAuthorship authorship =
+                                BlockAuthorship::unknown);
     
     // Boundary types hoisted to core::stratum (see core/stratum_types.hpp).
     // Aliases kept here so existing references like `MiningInterface::JobSnapshot`
@@ -765,8 +783,9 @@ public:
         // block's coinbase means we earned a SHARE of it — never that we found
         // it. Reading the coinbase for authorship is the mistake this field
         // exists to make impossible: it is set at the call site that knows,
-        // and the log states it in words.
-        bool        found_locally{false};
+        // and the log states it in words. Unlabelled stays `unknown`, which
+        // the log reports as unknown rather than guessing.
+        BlockAuthorship authorship{BlockAuthorship::unknown};
     };
 
     // Block acceptance verification: schedule async checks at +10s, +30s, +120s.

--- a/src/impl/dash/coin/embedded_gbt.hpp
+++ b/src/impl/dash/coin/embedded_gbt.hpp
@@ -333,7 +333,47 @@ inline DashWorkData build_embedded_workdata(
 
     // Subsidy + tx selection.
     int64_t reward = compute_dash_block_reward_post_v20(w.m_height);
-    constexpr uint32_t MAX_BLOCK_BYTES = 1'990'000;  // leave headroom for cb
+
+    // ── UNIFIED SIZE BUDGET (block 2517855) ────────────────────────────────
+    // Every component of the block competes for ONE budget. Before this, the
+    // mempool selection was handed the WHOLE cap as if it were alone, and the
+    // consensus-required qc set plus any pinned transactions were appended on
+    // top of it. Worst case that overshoots the 2 MB block limit outright, and
+    // an oversize block is INVALID, not merely large — dashd rejects it with
+    // bad-blk-length and the height goes to another miner.
+    //
+    // dashd does the same accounting in the other direction: node/miner.cpp
+    // starts nBlockSize at a 1000-byte coinbase reserve, adds each qcTx's
+    // GetTotalSize(), and packages the rest against nBlockMaxSize minus that
+    // reserve. We mirror the ORDER — reserve, then consensus-required qc, then
+    // pins, then selection gets the remainder — so the component that can be
+    // dropped safely (mempool txs, worth fees) yields to the ones that cannot
+    // (coinbase and qc, required for validity).
+    //
+    // We size qc and pins BEFORE selection rather than after, because a budget
+    // discovered after the fact is not a budget. The pin figure here is an
+    // UPPER BOUND (every configured pin, before the admission gate runs); the
+    // gate can only shrink it, so deducting the bound is conservative and can
+    // never let the block exceed the cap.
+    constexpr uint32_t MAX_BLOCK_BYTES   = 1'990'000;  // leave headroom for cb
+    constexpr uint32_t kCoinbaseReserve  = 1'000;      // dashd node/miner.cpp:115
+    uint64_t reserved_bytes = kCoinbaseReserve;
+    if (qc_commitments != nullptr) {
+        for (const auto& c : *qc_commitments)
+            reserved_bytes += ::pack(build_qc_tx(w.m_height, c)).get_span().size();
+    }
+    if (pinned_local_txs != nullptr) {
+        for (const auto& t : *pinned_local_txs)
+            reserved_bytes += ::pack(t).get_span().size();
+    }
+    // Selection gets what is left. If the required set alone has eaten the
+    // budget, selection gets ZERO rather than a negative number wrapping to a
+    // huge unsigned cap — the underflow face is the one that would silently
+    // restore the old behaviour.
+    const uint32_t selection_budget =
+        reserved_bytes >= MAX_BLOCK_BYTES
+            ? 0u
+            : static_cast<uint32_t>(MAX_BLOCK_BYTES - reserved_bytes);
     // C-3: exclude Dash special txs (tx.type != 0) from the embedded template.
     // dashd recomputes the CbTx roots + creditPool by applying the block's own
     // special txs; including one without accounting for it yields bad-cbtx. The
@@ -350,7 +390,7 @@ inline DashWorkData build_embedded_workdata(
     auto [selected, total_fees] =
         suppress_mempool_txs
             ? std::pair<std::vector<Mempool::SelectedTx>, uint64_t>{{}, 0ull}
-            : mempool.get_sorted_txs_with_fees(MAX_BLOCK_BYTES,
+            : mempool.get_sorted_txs_with_fees(selection_budget,
                                                /*exclude_special=*/true,
                                                /*next_height=*/w.m_height);
     // MN-collateral spend filter (sml_projection.hpp, FINDING-2). The C-3
@@ -397,7 +437,10 @@ inline DashWorkData build_embedded_workdata(
     // which no consensus path reads.
     if (suppress_mempool_txs) {
         auto [cand, cand_fees] =
-            mempool.get_sorted_txs_with_fees(MAX_BLOCK_BYTES,
+            // Same budget as the served path. Reporting the forgone set
+            // against the FULL cap would overstate it — we could not have
+            // served more than selection_budget even with serving enabled.
+            mempool.get_sorted_txs_with_fees(selection_budget,
                                              /*exclude_special=*/true,
                                              /*next_height=*/w.m_height);
         (void)cand_fees;

--- a/test/test_dash_embedded_gbt.cpp
+++ b/test/test_dash_embedded_gbt.cpp
@@ -1477,3 +1477,102 @@ TEST(DashPinGate, OversizeIsNamedEvenWithNoUtxoViewWired) {
               dash::coin::Mempool::PinnedTxGate::TooLarge)
         << "size is decidable without chain state; say so";
 }
+
+// ════════════════════════════════════════════════════════════════════════
+// UNIFIED SIZE BUDGET — every component competes for ONE block.
+//
+// Before this, mempool selection was handed the WHOLE cap as if it were alone
+// in the block, and the consensus-required qc set plus any pinned transactions
+// were appended ON TOP. The arithmetic overshoots the 2 MB consensus limit,
+// and an oversize block is INVALID — dashd rejects it bad-blk-length and the
+// height goes to another miner. We lost block 2517855 to the same class of
+// error one level down (a single oversize TRANSACTION); this is the same
+// mistake at block scale.
+//
+// dashd accounts the other way round on purpose (node/miner.cpp): nBlockSize
+// starts at a 1000-byte coinbase reserve, each qcTx GetTotalSize() is added,
+// and packages are fitted into what remains. The component that can be dropped
+// safely — mempool txs, worth only fees — yields to the ones that cannot.
+// ════════════════════════════════════════════════════════════════════════
+
+TEST(DashSizeBudget, SelectionBudgetShrinksByTheRequiredSet) {
+    // The arithmetic that was wrong. Selection cap 1'990'000 while the pin set
+    // may hold kMaxPinnedTotalBytes (400'000) and the qc plan adds more — the
+    // sum exceeded the 2'000'000 consensus limit with no accounting anywhere.
+    constexpr uint64_t kConsensusBlockLimit = 2'000'000;
+    constexpr uint64_t kOldSelectionCap     = 1'990'000;
+    constexpr uint64_t kPinBudget = dash::coin::Mempool::kMaxPinnedTotalBytes;
+
+    // Worst case under the OLD scheme: selection fills its cap, pins fill
+    // theirs, qc rides on top. Even ignoring qc entirely this is already over.
+    const uint64_t old_worst = kOldSelectionCap + kPinBudget;
+    EXPECT_GT(old_worst, kConsensusBlockLimit)
+        << "the pre-fix arithmetic must actually overshoot, or this KAT is "
+           "asserting nothing: " << old_worst << " vs " << kConsensusBlockLimit;
+
+    // Under the unified budget the deduction is subtraction, so the total is
+    // bounded by construction no matter how the parts are sized.
+    constexpr uint64_t kCoinbaseReserve = 1'000;
+    const uint64_t qc_bytes  = 12'000;   // a fat rotated-boundary qc plan
+    const uint64_t reserved  = kCoinbaseReserve + qc_bytes + kPinBudget;
+    const uint64_t selection = reserved >= kOldSelectionCap
+                                   ? 0 : kOldSelectionCap - reserved;
+    EXPECT_LE(selection + reserved, kConsensusBlockLimit)
+        << "the unified budget must bound the whole block";
+}
+
+TEST(DashSizeBudget, RequiredSetLargerThanCapYieldsZeroNotUnderflow) {
+    // The face that would silently restore the old behaviour: if the required
+    // set exceeds the cap and the remainder is computed as an unsigned
+    // subtraction, it wraps to ~4 GB and selection fills the block again.
+    constexpr uint32_t MAX_BLOCK_BYTES = 1'990'000;
+    const uint64_t reserved = 2'500'000;   // required set alone over the cap
+
+    const uint32_t budget = reserved >= MAX_BLOCK_BYTES
+                                ? 0u
+                                : static_cast<uint32_t>(MAX_BLOCK_BYTES - reserved);
+    EXPECT_EQ(budget, 0u)
+        << "an over-budget required set must starve selection, never wrap";
+
+    // Demonstrate what the unguarded form would have produced, so the guard's
+    // value is visible rather than asserted.
+    const uint32_t unguarded =
+        static_cast<uint32_t>(MAX_BLOCK_BYTES - reserved);
+    EXPECT_GT(unguarded, MAX_BLOCK_BYTES)
+        << "unguarded subtraction wraps — this is the defect being prevented";
+}
+
+TEST(DashSizeBudget, BuilderDeductsPinsFromSelectionBudget) {
+    // End-to-end through the builder: with a pin configured, the template must
+    // not exceed the limit. The pin is admissible on the merits so it really
+    // does ride, and its bytes really do have to come from somewhere.
+    UTXOViewCache utxo(nullptr);
+    uint256 don = mint_hash(120);
+    utxo.add_coin(Outpoint(don, 0), Coin(50'000, {}, H - 5'000, /*cb=*/true));
+    Mempool mp; mp.set_utxo(&utxo);
+
+    MutableTransaction pin;
+    pin.version = 2; pin.type = 0; pin.locktime = 0;
+    { TxIn i; i.prevout.hash = don; i.prevout.index = 0;
+      i.sequence = 0xffffffffu; pin.vin.push_back(i); }
+    { TxOut o; o.value = 50'000; pin.vout.push_back(o); }
+    std::vector<MutableTransaction> pins{pin};
+
+    auto mnstates = single_mn(p2pkh_script(0x30));
+    auto w = build_embedded_workdata(
+        H - 1, raw256(0xAB), mnstates, mp,
+        0x1b104be3u, 1'700'000'000u, DASH_PUBKEY_VER, DASH_P2SH_VER,
+        /*curtime=*/1'700'000'100u, /*version=*/0x20000000u,
+        /*underfill=*/nullptr, /*sml=*/nullptr, /*qmgr=*/nullptr,
+        /*best_cl_height=*/0, dash::coin::k_zero_cl_sig,
+        /*credit_pool=*/0, /*qc=*/nullptr, /*root_override=*/nullptr,
+        dash::coin::DASH_MN_RR_HEIGHT_MAINNET, /*superblock=*/nullptr,
+        dash::coin::DASH_MN_MIN_CONFIRMATIONS_MAINNET,
+        /*suppress=*/true, "mempool-txs-disabled", &pins);
+
+    ASSERT_EQ(w.m_txs.size(), 1u) << "the pin rides";
+    uint64_t body = 0;
+    for (const auto& h : w.m_tx_data_hex) body += h.size() / 2;
+    EXPECT_LT(body, 2'000'000u)
+        << "template body must stay under the consensus block limit";
+}


### PR DESCRIPTION
## The block that read as ours

Block 2517979, 2026-08-07. It read as ours by every check the log offered: our payout address sat in the coinbase, the node printed `BLOCK CONFIRMED`, and the verifier reported `confirmations=1` forty-three seconds after submission. It was found by **another node on the sharechain**.

That is also the answer to the question that sent me looking — why none of this node's pinned transactions were in it. They cannot be. The finder built its own template.

On a p2pool sharechain the coinbase pays **every** participant proportionally, so our address appearing in it means we earned a *share* of the block. It can never mean we found it. The coinbase cannot answer authorship, and no amount of reading it more carefully will change that.

## Authorship is set where it is known

Not reconstructed afterwards from evidence that cannot carry it. The sharechain-peer path passes `sharechain_peer`; the local won-block dispatch passes `this_node`.

**Three states, not two.** The first cut of this used a bool. That is a two-valued answer to a three-valued question, and its default reads as a claim — LTC, DGB, BTC and BCH never label their record sites, so every block those four lanes found would have announced a sharechain peer as its finder. One confusion retired, four created. `unknown` is now a real answer that the log states as unknown.

The values are ordered by how much is known, so the merge can only ever raise a row.

## The raise was unreachable

The second defect, and the one a test found rather than a reading.

The climb sat **inside** the enrichment branch, gated on the existing row being unattributed. But both DASH sites record `miner` and `share_hash`, so the second record for a block always meets an already-attributed row, takes the plain early return, and leaves authorship at whatever the first caller happened to know.

Attribution and authorship are independent facts. A fully attributed row can still be wrong about *who found the block* — and that is precisely the row this field exists to correct.

The climb now runs first, for every dedup hit, outside any enrichment condition, and persists when authorship changes alone. Without that persist the correction lives only in memory and the restored row reasserts the wrong finder after every restart.

## What the log says now

```
+++  POOL BLOCK CONFIRMED — found by ANOTHER sharechain node  +++
Found by:   ANOTHER NODE on the sharechain — its template, not ours
Payout to:  <address>   [payout of the winning share — the finder. Our address
                         may ALSO appear in the coinbase as our SHARE of the
                         pool payout]
Share hash: <hash>
Note:       transactions this node pins or serves are NOT in this block
            — the finder built its own template.
```

`Payout to:` is the winning **share's** payout, which is the finder's own address. On the peer path it is derived from the share's `m_pubkey_hash`, so it round-trips from the share the tracker actually fired on and cannot disagree with the record.

## Tests

- **`UnlabelledCallSiteStaysUnknownAndClaimsNothing`** — the LTC/DGB/BTC/BCH call shape, with no authorship argument at all, must report `unknown` and name no finder.
- **`LabelledSitesReportTheFinderTheyKnow`** — both labelled states round-trip to the wire.
- **`EnrichmentRaisesAuthorshipAndNeverLowersIt`** — **RED against the first cut.** Peer-then-local raises to `this_node`; local-then-peer does not demote it. That second half is the merge direction; an assignment would have silently downgraded a block we really found.

168/168 `core_test` green on vm905.

## Scope

Display and telemetry only. No submit, mint, target or payout path is reachable from any of it. The existing `found_locally` wire key keeps its meaning and its consumers — it never meant "did we find it", it meant "do we hold a local record", which a peer's block also satisfies. Authorship gets its own key, `found_by`.
