### PR TITLE
bch(test): mirror #1131 verified.remove owns_data=false KAT onto the BCH lane

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -770,6 +770,7 @@ jobs:
                     bch_cashtokens_transparency_test \
                     bch_cashaddr_kat_test \
                     bch_share_tx_refs_kat_test \
+                    bch_share_remove_owns_data_test \
                     bch_block_connector_test bch_block_ordering_test \
                     bch_utxo_connect_test bch_reorg_connect_test bch_reorg_rerequest_test \
                     bch_compact_block_connector_test \
@@ -921,6 +922,7 @@ jobs:
                     bch_cashtokens_transparency_test \
                     bch_cashaddr_kat_test \
                     bch_share_tx_refs_kat_test \
+                    bch_share_remove_owns_data_test \
                     bch_block_connector_test bch_block_ordering_test \
                     bch_utxo_connect_test bch_reorg_connect_test bch_reorg_rerequest_test \
                     bch_compact_block_connector_test \

--- a/src/impl/bch/test/CMakeLists.txt
+++ b/src/impl/bch/test/CMakeLists.txt
@@ -45,6 +45,16 @@ if(BUILD_TESTING)
         add_test(NAME bch_${t} COMMAND bch_${t})
     endforeach()
 
+    # #1131 source-structural KAT (BCH-lane mirror of dash/btc/ltc): the think-P1
+    # bad-share removal must borrow from `verified` (owns_data=false) so only the
+    # owning `chain` destroys the share. Its own executable (BCH tree is plain
+    # main()+CHECK, no GTest to fold into); needs the share_tracker.hpp path.
+    add_executable(bch_share_remove_owns_data_test share_remove_owns_data_test.cpp)
+    target_include_directories(bch_share_remove_owns_data_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
+    target_compile_definitions(bch_share_remove_owns_data_test PRIVATE
+        BCH_SHARE_TRACKER_SRC="${CMAKE_CURRENT_SOURCE_DIR}/../share_tracker.hpp")
+    add_test(NAME bch_share_remove_owns_data_test COMMAND bch_share_remove_owns_data_test)
+
     # block_connector_test exercises the full-block -> mempool reconciliation
     # path, so it constructs MutableTransaction objects whose ctors are out-of-line
     # in coin/transaction.cpp. Add that single TU to this test only; the link set

--- a/src/impl/bch/test/share_remove_owns_data_test.cpp
+++ b/src/impl/bch/test/share_remove_owns_data_test.cpp
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// B-BCH.SHARE-REMOVE-OWNS-DATA — source-structural guard pinning that the
+// think-P1 bad-share removal borrows (owns_data=false) from `verified` and lets
+// only the owning `chain` destroy the share. This is the BCH-lane mirror of the
+// dash/btc/ltc KATs shipped with the #1131 fix (#1163): the source was fixed on
+// all five lanes, but only three carried the regression pin. This file adds the
+// missing pin on the BCH lane so a re-introduction of the owning form HERE fails.
+//
+// THE DEFECT THIS PINS (#1131, latent double free):
+//   In ShareTracker::think() the bad-share removal does, per share `bad`:
+//       if (verified.contains(bad)) verified.remove(bad);   // owns_data=TRUE (default)
+//       if (chain.remove(bad))      ++removed_count;         // owns_data=TRUE (default)
+//   `verified` is a BORROWING view — it holds the SAME raw share pointers that
+//   `chain` OWNS (every removal in node.cpp already pairs
+//   verified.remove(h, /*owns_data=*/false) with chain.remove(h)). With the
+//   default owns_data=true, verified.remove() calls share.destroy() -> delete,
+//   then chain.remove() calls destroy() on the SAME pointer again: a double
+//   free / "unaligned tcache chunk" abort, exactly the hotel-primary signature.
+//
+//   It is UNREACHABLE TODAY only because of the `if (verified.contains(bad))
+//   continue;` guard ~20 lines earlier, which makes the inner
+//   `verified.contains(bad)` always false. The moment that guard is loosened
+//   (e.g. wiring the mint path) the landmine arms. The fix pre-arms it: pass
+//   owns_data=false so the borrowing view can never destroy.
+//
+// WHY A STRUCTURAL TEST: the buggy statement is dead code today, so a runtime
+// repro cannot reach it without first perturbing unrelated control flow — the
+// same situation as the sibling latent-UAF race913 (PR #1114) and the #1134
+// oracle-ownership guard (PR #1150). A guard that asserts the OWNERSHIP SHAPE
+// in the shipped source is the deterministic red/green this invariant admits.
+// Restore the bare `verified.remove(bad);` form -> RED; keep the borrowing
+// owns_data=false form -> GREEN.
+//
+// Harness: plain int main() + CHECK (the BCH test tree has no GTest dependency);
+// the ASSERTION LOGIC is a faithful copy of the dash/btc/ltc KATs — same
+// strip_comments / remove_call_args / count_of shape.
+#include <cstddef>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#ifndef BCH_SHARE_TRACKER_SRC
+#error "BCH_SHARE_TRACKER_SRC must be defined by CMake to the path of src/impl/bch/share_tracker.hpp"
+#endif
+
+namespace {
+
+int failures = 0;
+#define CHECK(cond) do { if (!(cond)) { \
+    std::cerr << "FAIL: " #cond " @ line " << __LINE__ << "\n"; ++failures; } } while (0)
+
+std::string read_text(const char* path)
+{
+    std::ifstream in(path);
+    CHECK(in.good());
+    std::stringstream ss; ss << in.rdbuf();
+    return ss.str();
+}
+
+// Replace every comment with spaces, preserving byte offsets and line breaks.
+// The fix's own doc comment deliberately quotes the pre-fix `verified.remove(bad)`
+// expression, so the assertions below MUST run over comment-free code or they
+// would pass against the buggy form for the wrong reason.
+std::string strip_comments(const std::string& s)
+{
+    std::string out = s;
+    enum { kCode, kLine, kBlock, kStr, kChr } st = kCode;
+    for (size_t i = 0; i < out.size(); ++i) {
+        const char c = out[i];
+        const char n = (i + 1 < out.size()) ? out[i + 1] : '\0';
+        switch (st) {
+        case kCode:
+            if (c == '/' && n == '/') { st = kLine;  out[i] = ' '; out[i + 1] = ' '; ++i; }
+            else if (c == '/' && n == '*') { st = kBlock; out[i] = ' '; out[i + 1] = ' '; ++i; }
+            else if (c == '"')  st = kStr;
+            else if (c == '\'') st = kChr;
+            break;
+        case kLine:
+            if (c == '\n') st = kCode; else out[i] = ' ';
+            break;
+        case kBlock:
+            if (c == '*' && n == '/') { out[i] = ' '; out[i + 1] = ' '; ++i; st = kCode; }
+            else if (c != '\n') out[i] = ' ';
+            break;
+        case kStr:
+            if (c == '\\') ++i; else if (c == '"') st = kCode;
+            break;
+        case kChr:
+            if (c == '\\') ++i; else if (c == '\'') st = kCode;
+            break;
+        }
+    }
+    return out;
+}
+
+size_t count_of(const std::string& hay, const std::string& needle)
+{
+    size_t n = 0, pos = 0;
+    while ((pos = hay.find(needle, pos)) != std::string::npos) { ++n; pos += needle.size(); }
+    return n;
+}
+
+// The argument text of a `verified.remove(bad<...>)` call: everything between
+// the first '(' after the match and its matching ')'.
+std::string remove_call_args(const std::string& code)
+{
+    const std::string key = "verified.remove(bad";
+    const size_t k = code.find(key);
+    if (k == std::string::npos) return "";
+    const size_t open = code.find('(', k);
+    if (open == std::string::npos) return "";
+    int depth = 0;
+    for (size_t i = open; i < code.size(); ++i) {
+        if (code[i] == '(') ++depth;
+        else if (code[i] == ')') { if (--depth == 0) return code.substr(open + 1, i - open - 1); }
+    }
+    return "";
+}
+
+} // namespace
+
+int main()
+{
+    const std::string code = strip_comments(read_text(BCH_SHARE_TRACKER_SRC));
+
+    // The think-P1 removal block must exist — anchor the assertions to real code.
+    CHECK(code.find("if (chain.remove(bad))") != std::string::npos);   // removal block present
+    CHECK(count_of(code, "verified.remove(bad") >= 1u);                 // a verified.remove(bad ...) exists
+
+    // #1131: the borrowing view must NEVER be removed-from with the default
+    // owns_data=true. The bare `verified.remove(bad)` form (no second argument)
+    // destroys a share `chain` also owns -> double free.
+    // RED against the shipped bug: exactly the bare, owns_data-defaulted form.
+    CHECK(count_of(code, "verified.remove(bad)") == 0u);
+
+    // GREEN shape: the call carries an explicit second argument, and it is false.
+    const std::string args = remove_call_args(code);
+    CHECK(!args.empty());                              // a verified.remove(bad ...) call was found
+    CHECK(args.find(',') != std::string::npos);        // explicit owns_data argument passed
+    CHECK(args.find("false") != std::string::npos);    // borrowing view -> owns_data=false
+    CHECK(args.find("true") == std::string::npos);     // owns_data=true would double-free
+
+    if (failures == 0) std::cout << "bch_share_remove_owns_data_test: OK\n";
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## What

BCH-lane mirror of the #1131 `verified.remove` `owns_data=false` KAT. #1163 fixed the latent double free at the source on all five lanes (dash/btc/ltc/dgb/bch), but only dash/btc/ltc shipped the source-structural regression pin. BCH had the fixed source and **no test asserting it stays fixed**. This adds the missing pin on the BCH lane specifically.

## The defect this pins (#1131)

In `ShareTracker::think()` the think-P1 bad-share removal does, per bad share:

```
if (verified.contains(bad)) verified.remove(bad);   // owns_data=TRUE (default)
if (chain.remove(bad))      ++removed_count;          // owns_data=TRUE (default)
```

`verified` is a **borrowing view** over the same raw share pointers `chain` **owns**. With the default `owns_data=true`, `verified.remove()` destroys the share and `chain.remove()` destroys the same pointer again — a double free. Unreachable today only because of the `verified.contains(bad) -> continue` guard ~20 lines up; the fix pre-arms it with `owns_data=false`.

## Why a structural KAT

The buggy statement is dead code today, so a runtime repro cannot reach it without perturbing unrelated control flow (same situation as race913 / the #1134 oracle-ownership guard). The test strips comments from `share_tracker.hpp` and asserts the `verified.remove(bad ...)` call carries an explicit `owns_data=false`, rejecting the bare defaulted form. Assertion logic is a faithful copy of the dash/btc/ltc KATs; harness is plain `main()`+`CHECK` because the BCH test tree has no GTest to fold into.

## Acceptance — RED demonstrated, not just green

Compiled the KAT against a copy of `share_tracker.hpp` with the line reverted to the pre-#1163 bare `verified.remove(bad);` form:

```
=== GREEN (current master, fixed source) ===
bch_share_remove_owns_data_test: OK
exit=0
=== RED (pre-#1163 bare form) ===
FAIL: count_of(code, "verified.remove(bad)") == 0u @ line 135
FAIL: args.find(,) != std::string::npos @ line 140
FAIL: args.find("false") != std::string::npos @ line 141
exit=1
```

## Scope

- BCH lane only. No behaviour change on any other lane.
- Test-only: `share_remove_owns_data_test.cpp` (new) + its wiring in `src/impl/bch/test/CMakeLists.txt` (own executable, `BCH_SHARE_TRACKER_SRC` compile def) + both `build.yml` COIN_BCH allowlists. No source edited — the #1163 fix already fully landed on the BCH lane (confirmed: `share_tracker.hpp` line 760 already passes `/*owns_data=*/false`).
- The two stale BCH comments flagged in the brief (reconstruct returns nullopt / test unregistered) are in the reconstruct path, not touched by this KAT — left untouched.

Do not merge; CI-gate + rollup owned by integrator.
