### PR TITLE
test(#1131): DGB mirror KAT — verified.remove(bad) must borrow, not own

### DIFF
--- a/src/impl/dgb/test/CMakeLists.txt
+++ b/src/impl/dgb/test/CMakeLists.txt
@@ -7,7 +7,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     # F1 retention + F2/F3 broadcast-gate KATs are actually compiled and run;
     # a fresh target would need a build.yml entry and would otherwise report
     # the silently-passing NOT_BUILT sentinel.
-    add_executable(dgb_share_test share_test.cpp known_txs_retention_test.cpp broadcast_gate_test.cpp race913_lock_guard_test.cpp)
+    add_executable(dgb_share_test share_test.cpp known_txs_retention_test.cpp broadcast_gate_test.cpp race913_lock_guard_test.cpp share_remove_owns_data_test.cpp)
     target_link_libraries(dgb_share_test PRIVATE
         GTest::gtest_main GTest::gtest
         core dgb
@@ -24,6 +24,12 @@ if (BUILD_TESTING AND GTest_FOUND)
     # D-DGB.RACE913 lock-scope guard reads the shipped node.cpp source.
     target_compile_definitions(dgb_share_test PRIVATE
         DGB_NODE_SRC="${CMAKE_CURRENT_SOURCE_DIR}/../node.cpp")
+
+    # #1131 source-structural KAT: verified.remove(bad) must borrow
+    # (owns_data=false), not own -- folded into this EXISTING allowlisted target
+    # (no new executable). Mirror of the dash/btc/ltc guards landed with #1163.
+    target_compile_definitions(dgb_share_test PRIVATE
+        DGB_SHARE_TRACKER_SRC="${CMAKE_CURRENT_SOURCE_DIR}/../share_tracker.hpp")
 
     # --- #905 tx-relay dead-probe regression (port of btc #880) ------------
     # Pins coin/share_tx_relay_refs.hpp: append_share_tx_refs, the SSOT

--- a/src/impl/dgb/test/share_remove_owns_data_test.cpp
+++ b/src/impl/dgb/test/share_remove_owns_data_test.cpp
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// D-DGB.SHARE-REMOVE-OWNS-DATA — source-structural guard pinning that the
+// think-P1 bad-share removal borrows (owns_data=false) from `verified` and lets
+// only the owning `chain` destroy the share.
+//
+// THE DEFECT THIS PINS (#1131, latent double free):
+//   In ShareTracker::think() the bad-share removal does, per share `bad`:
+//       if (verified.contains(bad)) verified.remove(bad);   // owns_data=TRUE (default)
+//       if (chain.remove(bad))      ++removed_count;         // owns_data=TRUE (default)
+//   `verified` is a BORROWING view — it holds the SAME raw share pointers that
+//   `chain` OWNS (every removal in node.cpp already pairs
+//   verified.remove(h, /*owns_data=*/false) with chain.remove(h)). With the
+//   default owns_data=true, verified.remove() calls share.destroy() -> delete,
+//   then chain.remove() calls destroy() on the SAME pointer again: a double
+//   free / "unaligned tcache chunk" abort, exactly the hotel-primary signature.
+//
+//   It is UNREACHABLE TODAY only because of the `if (verified.contains(bad))
+//   continue;` guard ~20 lines earlier, which makes the inner
+//   `verified.contains(bad)` always false. The moment that guard is loosened
+//   (e.g. wiring the mint path) the landmine arms. The fix pre-arms it: pass
+//   owns_data=false so the borrowing view can never destroy.
+//
+// WHY A STRUCTURAL TEST: the buggy statement is dead code today, so a runtime
+// repro cannot reach it without first perturbing unrelated control flow — the
+// same situation as the sibling latent-UAF race913 (PR #1114) and the #1134
+// oracle-ownership guard (PR #1150). A guard that asserts the OWNERSHIP SHAPE
+// in the shipped source is the deterministic red/green this invariant admits.
+// Restore the bare `verified.remove(bad);` form -> RED; keep the borrowing
+// owns_data=false form -> GREEN.
+//
+// This is a deliberate MIRROR of the dash/btc/ltc KATs landed with #1163 — the
+// source fix touched all five lanes; this asserts the DGB copy stays fixed and
+// fails specifically if the owning form is re-introduced on the DGB lane.
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#ifndef DGB_SHARE_TRACKER_SRC
+#error "DGB_SHARE_TRACKER_SRC must be defined by CMake to the path of src/impl/dgb/share_tracker.hpp"
+#endif
+
+namespace {
+
+std::string read_text(const char* path)
+{
+    std::ifstream in(path);
+    EXPECT_TRUE(in.good()) << "cannot open " << path;
+    std::stringstream ss; ss << in.rdbuf();
+    return ss.str();
+}
+
+// Replace every comment with spaces, preserving byte offsets and line breaks.
+// The fix's own doc comment deliberately quotes the pre-fix `verified.remove(bad)`
+// expression, so the assertions below MUST run over comment-free code or they
+// would pass against the buggy form for the wrong reason.
+std::string strip_comments(const std::string& s)
+{
+    std::string out = s;
+    enum { kCode, kLine, kBlock, kStr, kChr } st = kCode;
+    for (size_t i = 0; i < out.size(); ++i) {
+        const char c = out[i];
+        const char n = (i + 1 < out.size()) ? out[i + 1] : '\0';
+        switch (st) {
+        case kCode:
+            if (c == '/' && n == '/') { st = kLine;  out[i] = ' '; out[i + 1] = ' '; ++i; }
+            else if (c == '/' && n == '*') { st = kBlock; out[i] = ' '; out[i + 1] = ' '; ++i; }
+            else if (c == '"')  st = kStr;
+            else if (c == '\'') st = kChr;
+            break;
+        case kLine:
+            if (c == '\n') st = kCode; else out[i] = ' ';
+            break;
+        case kBlock:
+            if (c == '*' && n == '/') { out[i] = ' '; out[i + 1] = ' '; ++i; st = kCode; }
+            else if (c != '\n') out[i] = ' ';
+            break;
+        case kStr:
+            if (c == '\\') ++i; else if (c == '"') st = kCode;
+            break;
+        case kChr:
+            if (c == '\\') ++i; else if (c == '\'') st = kCode;
+            break;
+        }
+    }
+    return out;
+}
+
+size_t count_of(const std::string& hay, const std::string& needle)
+{
+    size_t n = 0, pos = 0;
+    while ((pos = hay.find(needle, pos)) != std::string::npos) { ++n; pos += needle.size(); }
+    return n;
+}
+
+// The argument text of a `verified.remove(bad<...>)` call: everything between
+// the first '(' after the match and its matching ')'.
+std::string remove_call_args(const std::string& code)
+{
+    const std::string key = "verified.remove(bad";
+    const size_t k = code.find(key);
+    if (k == std::string::npos) return "";
+    const size_t open = code.find('(', k);
+    if (open == std::string::npos) return "";
+    int depth = 0;
+    for (size_t i = open; i < code.size(); ++i) {
+        if (code[i] == '(') ++depth;
+        else if (code[i] == ')') { if (--depth == 0) return code.substr(open + 1, i - open - 1); }
+    }
+    return "";
+}
+
+} // namespace
+
+// The think-P1 removal block must exist — anchor the assertions to real code.
+TEST(DgbShareRemoveOwnsData, RemovalBlockPresent)
+{
+    const std::string code = strip_comments(read_text(DGB_SHARE_TRACKER_SRC));
+    EXPECT_NE(code.find("if (chain.remove(bad))"), std::string::npos)
+        << "think-P1 bad-share removal block not found — test anchor is stale";
+    EXPECT_GE(count_of(code, "verified.remove(bad"), 1u)
+        << "expected a verified.remove(bad ...) in the removal block";
+}
+
+// #1131: the borrowing view must NEVER be removed-from with the default
+// owns_data=true. The bare `verified.remove(bad)` form (no second argument)
+// destroys a share `chain` also owns -> double free.
+TEST(DgbShareRemoveOwnsData, VerifiedRemoveDoesNotOwnData)
+{
+    const std::string code = strip_comments(read_text(DGB_SHARE_TRACKER_SRC));
+
+    // RED against the shipped bug: exactly the bare, owns_data-defaulted form.
+    EXPECT_EQ(count_of(code, "verified.remove(bad)"), 0u)
+        << "verified.remove(bad) defaults owns_data=true and destroy()s a share "
+           "chain.remove(bad) also owns -> #1131 double free; pass "
+           "/*owns_data=*/false so the borrowing view cannot destroy";
+
+    // GREEN shape: the call carries an explicit second argument, and it is false.
+    const std::string args = remove_call_args(code);
+    ASSERT_FALSE(args.empty()) << "no verified.remove(bad ...) call found";
+    EXPECT_NE(args.find(','), std::string::npos)
+        << "verified.remove(bad ...) must pass an explicit owns_data argument";
+    EXPECT_NE(args.find("false"), std::string::npos)
+        << "verified is a borrowing view — owns_data must be false";
+    EXPECT_EQ(args.find("true"), std::string::npos)
+        << "owns_data=true on a borrowing view double-frees with chain.remove()";
+}


### PR DESCRIPTION
## What

Adds the missing DGB-lane regression pin for the #1131 latent double free. #1163 fixed the defect at the source on all five lanes (dash/btc/ltc/dgb/bch), but the source-structural KATs only cover dash, btc and ltc. The DGB lane has the fixed source and no test asserting it stays fixed — this closes that gap.

Deliberately a **mirror** of the dash/btc/ltc `share_remove_owns_data` KATs (same strip_comments / remove_call_args / count_of shape). Its value is that it fails specifically if the owning `verified.remove(bad)` form is re-introduced on the DGB lane.

## The invariant it pins

In `ShareTracker::think()` the think-P1 bad-share removal must remove from the **borrowing** `verified` view with `owns_data=false` — `verified` holds the same raw share pointers `chain` owns, so a default `owns_data=true` would `destroy()` a pointer `chain.remove(bad)` then destroys again (double free / tcache abort). Unreachable today only because of the `verified.contains(bad) -> continue` guard; the fix pre-arms it. The KAT strips comments from `src/impl/dgb/share_tracker.hpp` and asserts the call carries an explicit `owns_data=false`.

## Red/green demonstrated (the point of the task)

- **RED against pre-#1163 source**: reverting `share_tracker.hpp` line 870 to the bare `verified.remove(bad);` form -> `DgbShareRemoveOwnsData.VerifiedRemoveDoesNotOwnData` FAILS.
- **GREEN against current master**: 2/2 pass.

```
[  FAILED  ] DgbShareRemoveOwnsData.VerifiedRemoveDoesNotOwnData   # bare form
[  PASSED  ] 2 tests.                                              # restored
```

## Scope

- **DGB lane only.** No behaviour change; no change to the other four lanes.
- **Test-only.** `src/impl/dgb/test/share_remove_owns_data_test.cpp` + a two-line wiring in `src/impl/dgb/test/CMakeLists.txt` (folded into the already-allowlisted `dgb_share_test` target via a `DGB_SHARE_TRACKER_SRC` compile-def, same style as the race913 `DGB_NODE_SRC` guard). No new executable, no build.yml allowlist change.
- Commit GPG-signed. No self-merge — integrator gate-verifies the rollup.