### PR TITLE
dash: the serve path pays the aggregate BLS verify once, not once per read

### DIFF
--- a/src/impl/dash/coin/dkg_commitments.hpp
+++ b/src/impl/dash/coin/dkg_commitments.hpp
@@ -541,7 +541,14 @@ public:
     /// the distinction is UNEVALUATED and prints n/a — it is never guessed.
     using MembersReadyFn = std::function<bool(uint8_t, const uint256&)>;
 
-    void set_bls_verify_fn(BlsVerifyFn fn) { m_bls_verify = std::move(fn); }
+    /// Installing (or swapping) the verifier RETIRES every memoised verdict:
+    /// a "verified" latch is only ever a proof UNDER THE VERIFIER THAT
+    /// PRODUCED IT, so a verdict must never outlive its prover.
+    void set_bls_verify_fn(BlsVerifyFn fn)
+    {
+        m_bls_verify = std::move(fn);
+        for (auto& e : m_cache) e.second.verified = false;
+    }
     bool has_bls_verifier() const { return static_cast<bool>(m_bls_verify); }
     void set_members_ready_fn(MembersReadyFn fn) { m_members_ready = std::move(fn); }
     bool has_members_ready_fn() const { return static_cast<bool>(m_members_ready); }
@@ -567,7 +574,7 @@ public:
     {
         auto it = m_cache.find(Key{llmq_type, quorum_hash});
         if (it == m_cache.end()) return -1;
-        return static_cast<int32_t>(it->second.CountSigners());
+        return static_cast<int32_t>(it->second.c.CountSigners());
     }
 
     /// Classify why `verified_for` withheld this slot. Callers MUST have just
@@ -659,22 +666,68 @@ public:
         const Key k{c.llmqType, c.quorumHash};
         auto it = m_cache.find(k);
         if (it != m_cache.end()
-            && it->second.CountSigners() >= c.CountSigners())
+            && it->second.c.CountSigners() >= c.CountSigners())
             return Admission::NotBetterThanCached;   // hold an equal-or-better one
-        m_cache[k] = c;
+        // Replacement builds a FRESH entry, so the incoming commitment is
+        // UNLATCHED by construction — a verdict proven for the superseded
+        // bytes can never be served for these ones.
+        Entry fresh;
+        fresh.c = c;
+        fresh.verified = false;
+        m_cache[k] = std::move(fresh);
         return Admission::Accepted;
     }
 
     /// The mineable commitment for a slot — ONLY once BLS-verified. The
     /// Phase-L blocker line: without a verifier this is always nullopt.
+    ///
+    /// THE AGGREGATE VERIFY IS PAID ONCE PER COMMITMENT, NOT ONCE PER READ.
+    /// This is a SERVE-PATH hot function: the pre-emit consensus gate re-runs
+    /// INLINE on the io thread for every read of a cached EMBEDDED template
+    /// (work_source.cpp:852-853), the gate re-derives the mandatory qc plan on
+    /// every call (node_coin_state.hpp:889-893), the plan walks
+    /// daemonless_qc_commitments (:741 below) into here, and notify_all fans
+    /// send_notify_work out SERIALLY per session (stratum_server.cpp:379-384).
+    /// Re-proving a 391-signer LLMQ_400_60 aggregate signature on each of
+    /// those was the 2026-08-07 tip freeze: one send_notify_work measured
+    /// 0.3 ms -> 733 ms, the io thread saturated in userspace, and the tip
+    /// stopped advancing — which is self-sustaining, because the expensive
+    /// slot only retires when the tip advances (:415/:425 below).
+    ///
+    /// The memo is a POSITIVE-ONLY latch carried ON the cache entry, so its
+    /// staleness argument is by construction, not by discipline:
+    ///   * the verifier's inputs are the commitment BYTES and the member set
+    ///     for (llmqType, quorumHash) (bls_verify.hpp);
+    ///   * the bytes cannot change under a live latch: entry replacement is
+    ///     the ONLY mutation (keep-best, ingest_ex above) and it builds a
+    ///     FRESH, unlatched entry;
+    ///   * quorumHash IS the quorum base block hash (:421-426 below), so a
+    ///     reorg gives a DIFFERENT key — never a same-key different member
+    ///     set;
+    ///   * FALSE is never latched, so every recovery path (member set
+    ///     arrives, better commitment lands, verifier installed) is unchanged,
+    ///     as is diagnose()'s classification;
+    ///   * set_bls_verify_fn retires every latch, so a verdict is never served
+    ///     under a verifier that did not produce it.
+    /// A latched TRUE is therefore a retained mathematical proof about
+    /// immutable bytes against a chain-determined member set: it cannot become
+    /// false, and nothing the pre-emit gate CHECKS is checked less often —
+    /// only this leaf predicate's pairing math is reused.
+    ///
+    /// THREADING: the latch is `mutable` under the cache's existing no-lock
+    /// discipline because the only production caller is the single
+    /// coin-state-owning thread (work_source.cpp:823-827).
     std::optional<vendor::CFinalCommitment>
     verified_for(uint8_t llmq_type, const uint256& quorum_hash) const
     {
         if (!m_bls_verify) return std::nullopt;
         auto it = m_cache.find(Key{llmq_type, quorum_hash});
         if (it == m_cache.end()) return std::nullopt;
-        if (!m_bls_verify(it->second)) return std::nullopt;
-        return it->second;
+        if (!it->second.verified) {
+            if (!m_bls_verify(it->second.c)) return std::nullopt;
+            it->second.verified = true;   // latched ONLY on success
+        }
+        return it->second.c;
     }
 
     size_t size() const { return m_cache.size(); }
@@ -690,7 +743,16 @@ private:
             return std::memcmp(quorumHash.data(), r.quorumHash.data(), 32) < 0;
         }
     };
-    std::map<Key, vendor::CFinalCommitment> m_cache;
+    /// The admitted commitment plus its memoised BLS verdict. `verified` is
+    /// the POSITIVE-ONLY latch verified_for() sets (see there for why it can
+    /// never go stale); it is `mutable` so the const serve-path read can
+    /// record the proof it just paid for, and it dies with the entry — a
+    /// replacement commitment is unlatched by construction.
+    struct Entry {
+        vendor::CFinalCommitment c;
+        mutable bool verified{false};
+    };
+    std::map<Key, Entry> m_cache;
     BlsVerifyFn m_bls_verify;   // unset until Phase L lands a BLS12-381 lib
     MembersReadyFn m_members_ready;   // observability only; unset => n/a
 };

--- a/src/impl/dash/coin/dkg_commitments.hpp
+++ b/src/impl/dash/coin/dkg_commitments.hpp
@@ -184,6 +184,7 @@
 #include <core/pack.hpp>
 
 #include <algorithm>
+#include <atomic>
 #include <cstdint>
 #include <cstring>
 #include <functional>
@@ -547,7 +548,8 @@ public:
     void set_bls_verify_fn(BlsVerifyFn fn)
     {
         m_bls_verify = std::move(fn);
-        for (auto& e : m_cache) e.second.verified = false;
+        for (auto& e : m_cache)
+            e.second.verified.store(false, std::memory_order_relaxed);
     }
     bool has_bls_verifier() const { return static_cast<bool>(m_bls_verify); }
     void set_members_ready_fn(MembersReadyFn fn) { m_members_ready = std::move(fn); }
@@ -670,11 +672,12 @@ public:
             return Admission::NotBetterThanCached;   // hold an equal-or-better one
         // Replacement builds a FRESH entry, so the incoming commitment is
         // UNLATCHED by construction — a verdict proven for the superseded
-        // bytes can never be served for these ones.
-        Entry fresh;
-        fresh.c = c;
-        fresh.verified = false;
-        m_cache[k] = std::move(fresh);
+        // bytes can never be served for these ones. ERASE-then-default-
+        // construct rather than assign: Entry holds a std::atomic latch and is
+        // therefore neither copyable nor movable, and that is deliberate — the
+        // only way to obtain an entry is to build a fresh, unlatched one.
+        m_cache.erase(k);
+        m_cache[k].c = c;
         return Admission::Accepted;
     }
 
@@ -714,18 +717,47 @@ public:
     /// false, and nothing the pre-emit gate CHECKS is checked less often —
     /// only this leaf predicate's pairing math is reused.
     ///
-    /// THREADING: the latch is `mutable` under the cache's existing no-lock
-    /// discipline because the only production caller is the single
-    /// coin-state-owning thread (work_source.cpp:823-827).
+    /// THREADING: the latch is `mutable std::atomic<bool>` read/written
+    /// RELAXED under the cache's existing no-lock discipline. The only
+    /// production caller is the single coin-state-owning thread
+    /// (work_source.cpp:823-827), so the atomic is not load-bearing TODAY —
+    /// it is there so that the safety of this line stops depending on that
+    /// staying true. Relaxed is the right (and sufficient) order: the latch
+    /// publishes nothing — the bytes it guards are immutable for the entry's
+    /// lifetime — so the only race a second reader can lose is a redundant
+    /// re-verify of the same commitment to the same verdict.
+    ///
+    /// BEHAVIOUR CHANGE, ON RECORD (the one thing this is not free): a latched
+    /// slot no longer calls the BLS verifier, and the verifier is what sources
+    /// the member key set (bls_verify.hpp make_commitment_bls_verifier). If
+    /// the member set is EVICTED after a successful verify, the refusal MOVES
+    /// DOWNSTREAM: it used to surface here as nullopt -> underivable plan ->
+    /// cause=qc-plan-underivable (node_coin_state.hpp:892), and now surfaces
+    /// at the PoSe-noop gate, which sources the SAME member set
+    /// (main_dash.cpp:4160-4169) -> cause=emit-qc-real-pose-unfolded
+    /// (node_coin_state.hpp:930). SAME OUTCOME — fail closed, no template
+    /// served, no bytes changed — but a DIFFERENT decline cause string, which
+    /// this project ranks serve-gate episodes by (ServeGateJournal,
+    /// work_source.cpp:749-789). Pinned by
+    /// DashQcVerifyMemoDeclineCause.EvictedMemberSetDeclinesAsPoseUnfolded
+    /// (test_dash_node_coin_state.cpp).
     std::optional<vendor::CFinalCommitment>
     verified_for(uint8_t llmq_type, const uint256& quorum_hash) const
     {
         if (!m_bls_verify) return std::nullopt;
         auto it = m_cache.find(Key{llmq_type, quorum_hash});
         if (it == m_cache.end()) return std::nullopt;
-        if (!it->second.verified) {
+        if (!it->second.verified.load(std::memory_order_relaxed)) {
             if (!m_bls_verify(it->second.c)) return std::nullopt;
-            it->second.verified = true;   // latched ONLY on success
+            // Latched ONLY on success. RELAXED is sufficient and is the WHOLE
+            // safety argument: the latch publishes no data — the commitment
+            // bytes it guards are immutable for the entry's whole lifetime
+            // (replacement builds a fresh entry), so there is nothing for an
+            // acquire/release pair to order. A relaxed atomic gives the one
+            // property a plain `bool` did not: reads and writes cannot tear or
+            // race (no UB), so the worst case of a concurrent reader is a
+            // REDUNDANT re-verify of the same bytes to the same verdict.
+            it->second.verified.store(true, std::memory_order_relaxed);
         }
         return it->second.c;
     }
@@ -748,9 +780,24 @@ private:
     /// never go stale); it is `mutable` so the const serve-path read can
     /// record the proof it just paid for, and it dies with the entry — a
     /// replacement commitment is unlatched by construction.
+    ///
+    /// The latch is std::atomic<bool>, accessed RELAXED, not a plain bool. The
+    /// production caller is the single coin-state-owning thread
+    /// (work_source.cpp:823-827), so a plain bool would be provably safe BY
+    /// READING THE CODE — which is exactly the argument that preceded the
+    /// 2026-08-05 heap corruption on this same money path
+    /// (oracle_shadow_worker racing lockless coin state). A relaxed atomic
+    /// costs nothing on x86-64 (a plain mov either way) and converts "no
+    /// second thread reaches this today" from an invariant someone must keep
+    /// into one the type enforces: a future off-io reader gets a redundant
+    /// re-verify, never a data race.
+    ///
+    /// Consequence, and it is deliberate: Entry is neither copyable nor
+    /// movable, so an entry can only ever be DEFAULT-CONSTRUCTED (unlatched)
+    /// and then filled — a latched verdict cannot be copied onto other bytes.
     struct Entry {
         vendor::CFinalCommitment c;
-        mutable bool verified{false};
+        mutable std::atomic<bool> verified{false};
     };
     std::map<Key, Entry> m_cache;
     BlsVerifyFn m_bls_verify;   // unset until Phase L lands a BLS12-381 lib

--- a/test/test_dash_dkg_commitments.cpp
+++ b/test/test_dash_dkg_commitments.cpp
@@ -36,6 +36,7 @@
 #include <core/uint256.hpp>
 
 #include <algorithm>
+#include <atomic>
 #include <cstddef>
 #include <cstring>
 #include <fstream>
@@ -44,6 +45,7 @@
 #include <set>
 #include <span>
 #include <string>
+#include <thread>
 #include <vector>
 
 using namespace dash::coin;
@@ -2008,4 +2010,84 @@ TEST(DashQcVerifyMemo, ServePathPlanDerivationPaysTheVerifyOncePerCommitment)
         << "plan re-derivation re-proved the aggregate signatures: " << calls
         << " verifies for " << kReads << " reads of " << n_slots
         << " unchanged commitments — the io-thread cost the incident measured";
+}
+
+// ── C1: the latch is std::atomic<bool>, not a plain bool ───────────────────
+//
+// The memo's thread-safety was, as first written, an argument you had to READ
+// THE CODE to believe: `mutable bool`, no lock, justified by "the only
+// production caller is the single coin-state-owning thread"
+// (work_source.cpp:823-827). That is the same shape of assumption that
+// produced the 2026-08-05 heap corruption on this same money path (the
+// oracle-shadow worker racing lockless coin state), so the latch is now a
+// relaxed std::atomic<bool> (dkg_commitments.hpp:800). Relaxed is the right
+// order and the whole safety argument fits in one line: the latch publishes
+// NO data — the commitment bytes it guards are immutable for the entry's
+// lifetime, since replacement builds a fresh entry — so there is nothing for
+// an acquire/release pair to order, and the worst a concurrent reader can
+// suffer is a REDUNDANT re-verify of the same bytes to the same verdict.
+//
+// HOW THIS TEST IS DEMONSTRATED RED (it is a race-detector test, so it is
+// honest to say so: in an ordinary build it passes with a plain bool too —
+// a benign-in-practice race is still UB, and the tool that sees UB is TSan):
+//
+//   g++ -std=c++20 -O1 -g -fsanitize=thread \
+//       -I<repo>/include -I<repo>/src ... test/tools/tsan_qc_verify_latch.cpp \
+//       -o /tmp/tsan_latch
+//   setarch $(uname -m) -R /tmp/tsan_latch
+//
+//   with `mutable std::atomic<bool> verified` : served=16000/16000
+//                                               verifies=4, NO TSan report
+//   with `mutable bool verified`              : WARNING: ThreadSanitizer:
+//                                               data race — "Write of size 1"
+//                                               in verified_for at
+//                                               dkg_commitments.hpp:760, two
+//                                               reader threads
+//
+// test/tools/tsan_qc_verify_latch.cpp is that harness, committed alongside so
+// the demonstration is reproducible rather than reported. What the gtest below
+// pins WITHOUT a sanitizer is the behavioural contract the atomic must keep:
+// concurrency must never cost a reader its commitment, and the latch must
+// still converge (verifies bounded by the reader count, not by the read
+// count).
+
+TEST(DashQcVerifyMemo, ConcurrentServeReadsAlwaysGetTheirCommitmentAndConverge)
+{
+    MineableCommitmentCache cache;
+    const uint256 qh = h256(0x76);
+    ASSERT_TRUE(cache.ingest(LlmqNetwork::Testnet,
+                             real_commitment(kLlmq50_60, qh, 0, 0x11)));
+    std::atomic<int> calls{0};
+    cache.set_bls_verify_fn([&calls](const CFinalCommitment&) {
+        calls.fetch_add(1, std::memory_order_relaxed);
+        return true;
+    });
+
+    constexpr int kThreads = 8;
+    constexpr int kReads   = 2000;
+    std::atomic<bool> go{false};
+    std::atomic<int> served{0};
+    std::vector<std::thread> readers;
+    readers.reserve(kThreads);
+    for (int t = 0; t < kThreads; ++t) {
+        readers.emplace_back([&] {
+            while (!go.load(std::memory_order_acquire)) { }
+            for (int i = 0; i < kReads; ++i)
+                if (cache.verified_for(1, qh).has_value())
+                    served.fetch_add(1, std::memory_order_relaxed);
+        });
+    }
+    go.store(true, std::memory_order_release);
+    for (auto& t : readers) t.join();
+
+    EXPECT_EQ(served.load(), kThreads * kReads)
+        << "a concurrent read WITHHELD a verified commitment — the latch is "
+           "positive-only, so no interleaving may ever turn a verified slot "
+           "into a refusal";
+    EXPECT_GE(calls.load(), 1);
+    EXPECT_LE(calls.load(), kThreads)
+        << "the verify ran " << calls.load() << " times for "
+        << (kThreads * kReads)
+        << " reads: the only tolerable duplication is one racing re-verify "
+           "per reader thread at the moment of latching, never per read";
 }

--- a/test/test_dash_dkg_commitments.cpp
+++ b/test/test_dash_dkg_commitments.cpp
@@ -1772,3 +1772,240 @@ TEST(DashQcPoseNoopPredicate, UnprovableMemberCountsFailClosed)
     EXPECT_FALSE(qc_pose_pass_provably_noop(c, 0));
     EXPECT_FALSE(qc_pose_pass_provably_noop(c, 51));
 }
+
+// ── The BLS aggregate verify is paid ONCE per commitment, not per read ─────
+//
+// THE INCIDENT (2026-08-07, DASH mainnet): the node served a DEAD height to 26
+// rigs for an hour with the main thread pegged at 99.9% in USERSPACE. Every
+// read of the cached template on the EMBEDDED arm re-runs the full pre-emit
+// consensus gate INLINE on the io thread — work_source.cpp:852-853
+//   `if (!template_cache_is_embedded_
+//        || coin_state_.embedded_template_emit_ok(*template_cache_))`
+// — and the dashd-fallback arm short-circuits it, which is why only the
+// embedded arm saturated. That gate re-derives the mandatory qc plan on every
+// call (node_coin_state.hpp:889-893 m_qc_plan_fn), which walks
+// daemonless_qc_commitments (dkg_commitments.hpp:741) into
+// MineableCommitmentCache::verified_for (dkg_commitments.hpp:676), and
+// verified_for invoked the installed BLS verifier UNCONDITIONALLY on every
+// hit, caching nothing. On mainnet that is a 391-signer LLMQ_400_60 aggregate
+// verification re-proved from scratch per call; StratumServer::notify_all
+// fans send_notify_work out SERIALLY per session (stratum_server.cpp:379-384),
+// so one share arrival cost N x that. One send_notify_work was measured going
+// 0.3 ms -> 733 ms at the arm flip.
+//
+// THE MEMO IS POSITIVE-ONLY AND LATCHED ON THE CACHE ENTRY ITSELF, which is
+// what makes its staleness argument by-construction rather than by-discipline:
+//   * the verifier's inputs are the commitment bytes and the member set for
+//     (llmqType, quorumHash); the bytes cannot change under a live latch,
+//     because entry replacement is the ONLY mutation (keep-best,
+//     dkg_commitments.hpp:659-665) and it constructs a FRESH entry;
+//   * quorumHash IS the quorum base block hash (dkg_commitments.hpp:421-426),
+//     so a reorg yields a different key, never a same-key different member
+//     set;
+//   * FALSE is never latched, so every recovery path (member set arrives, a
+//     better commitment lands, a verifier is installed) behaves as before;
+//   * set_bls_verify_fn clears every latch, so a verdict proven under one
+//     verifier is never served under another.
+// Nothing the gate CHECKS is checked less often — only the pairing math
+// inside one leaf predicate is reused.
+//
+// RED ON MASTER: the invocation counters below grow linearly with the number
+// of reads (100 and 50 x slots respectively) instead of standing at 1 / one
+// per commitment.
+
+namespace {
+
+// A structurally admissible real commitment with a chosen signer count, so a
+// strictly BETTER commitment for the same slot can be ingested (keep-best is
+// by CountSigners, dkg_commitments.hpp:661-663).
+CFinalCommitment real_commitment_signers(const LlmqParamsView& p,
+                                         const uint256& qh, int16_t qi,
+                                         uint8_t seed, size_t n_signers)
+{
+    auto c = real_commitment(p, qh, qi, seed);
+    c.signers.assign(p.size, false);
+    for (size_t i = 0; i < n_signers && i < p.size; ++i) c.signers[i] = true;
+    return c;
+}
+
+} // namespace
+
+TEST(DashQcVerifyMemo, AggregateVerifyIsPaidOnceAcrossManyServeReads)
+{
+    // Testnet: LLMQ_50_60 (type 1) is enabled there forever, so the 50/40/30
+    // shape is real (same reason as MineableCacheStructuralAdmissionAndBlsGate).
+    int calls = 0;
+    MineableCommitmentCache cache;
+    const uint256 qh = h256(0x71);
+    ASSERT_TRUE(cache.ingest(LlmqNetwork::Testnet,
+                             real_commitment(kLlmq50_60, qh, 0, 0x11)));
+    cache.set_bls_verify_fn([&calls](const CFinalCommitment&) {
+        ++calls;
+        return true;
+    });
+
+    // THE SERVE LOOP, abstracted: N reads, inputs unchanged.
+    constexpr int kReads = 100;
+    for (int i = 0; i < kReads; ++i) {
+        auto served = cache.verified_for(1, qh);
+        ASSERT_TRUE(served.has_value()) << "read " << i << " withheld a verified commitment";
+        EXPECT_EQ(served->quorumHash, qh);
+    }
+    EXPECT_EQ(calls, 1)
+        << "the BLS aggregate verify was re-run on the io thread " << calls
+        << " times for " << kReads << " reads of an UNCHANGED commitment "
+           "(dkg_commitments.hpp:676) — this is the tip-freeze hot loop";
+}
+
+TEST(DashQcVerifyMemo, BetterCommitmentForTheSameSlotReprovesFromScratch)
+{
+    // The guard against OVER-caching: the latch must die with the entry it was
+    // proven for. ingest_ex replaces the entry on keep-best
+    // (dkg_commitments.hpp:664), so the replacement is unlatched by
+    // construction and the next read must pay a fresh verify — for the NEW
+    // bytes.
+    int calls = 0;
+    MineableCommitmentCache cache;
+    const uint256 qh = h256(0x72);
+    ASSERT_TRUE(cache.ingest(
+        LlmqNetwork::Testnet,
+        real_commitment_signers(kLlmq50_60, qh, 0, 0x11, /*n_signers=*/45)));
+    cache.set_bls_verify_fn([&calls](const CFinalCommitment&) {
+        ++calls;
+        return true;
+    });
+
+    for (int i = 0; i < 10; ++i) ASSERT_TRUE(cache.verified_for(1, qh).has_value());
+    ASSERT_EQ(calls, 1) << "verify not memoised (see the once-across-N case)";
+    EXPECT_EQ(cache.cached_signers(1, qh), 45);
+
+    // A strictly better commitment for the SAME slot key.
+    ASSERT_TRUE(cache.ingest(
+        LlmqNetwork::Testnet,
+        real_commitment_signers(kLlmq50_60, qh, 0, 0x11, /*n_signers=*/50)));
+    EXPECT_EQ(cache.cached_signers(1, qh), 50);
+
+    auto after = cache.verified_for(1, qh);
+    ASSERT_TRUE(after.has_value());
+    EXPECT_EQ(after->CountSigners(), 50)
+        << "served the SUPERSEDED commitment — the memo returned stale bytes";
+    EXPECT_EQ(calls, 2)
+        << "the replacement commitment was served on a verdict proven for the "
+           "PREVIOUS bytes";
+    // ...and the new verdict latches in turn.
+    for (int i = 0; i < 10; ++i) ASSERT_TRUE(cache.verified_for(1, qh).has_value());
+    EXPECT_EQ(calls, 2);
+}
+
+TEST(DashQcVerifyMemo, FailedVerdictIsNeverLatched)
+{
+    // The opposite failure mode of memoising: latching FALSE would make a
+    // transient member-set gap permanent. A refusal must stay re-evaluated on
+    // every read, exactly as today (dkg_commitments.hpp:673-677 nullopt
+    // semantics), so the recovery paths keep working.
+    int calls = 0;
+    MineableCommitmentCache cache;
+    const uint256 qh = h256(0x73);
+    ASSERT_TRUE(cache.ingest(LlmqNetwork::Testnet,
+                             real_commitment(kLlmq50_60, qh, 0, 0x11)));
+    cache.set_bls_verify_fn([&calls](const CFinalCommitment&) {
+        ++calls;
+        return false;
+    });
+
+    constexpr int kReads = 20;
+    for (int i = 0; i < kReads; ++i)
+        EXPECT_FALSE(cache.verified_for(1, qh).has_value()) << "read " << i;
+    EXPECT_EQ(calls, kReads)
+        << "a FAILED verdict was latched — a transient refusal would become "
+           "permanent";
+    EXPECT_EQ(cache.diagnose(1, qh), QcSlotGap::BlsVerifyFailed);
+
+    // Recovery: the same commitment verifies once the verifier says so, and
+    // only THEN does the positive verdict latch.
+    int good_calls = 0;
+    cache.set_bls_verify_fn([&good_calls](const CFinalCommitment&) {
+        ++good_calls;
+        return true;
+    });
+    ASSERT_TRUE(cache.verified_for(1, qh).has_value());
+    EXPECT_EQ(good_calls, 1);
+    for (int i = 0; i < 10; ++i) ASSERT_TRUE(cache.verified_for(1, qh).has_value());
+    EXPECT_EQ(good_calls, 1) << "positive verdict not latched after recovery";
+    EXPECT_EQ(calls, kReads) << "the RETIRED verifier was called again";
+}
+
+TEST(DashQcVerifyMemo, InstallingAVerifierClearsEveryLatch)
+{
+    // A verdict is only ever a proof UNDER THE VERIFIER THAT PRODUCED IT.
+    // Swapping the verifier (set_bls_verify_fn, dkg_commitments.hpp:544 — the
+    // Phase-L seam main_dash.cpp:4124 installs the real BLS12-381 one through)
+    // must invalidate every latch, or a stub's verdict could outlive it.
+    int first_calls = 0, second_calls = 0;
+    MineableCommitmentCache cache;
+    const uint256 qh_a = h256(0x74);
+    const uint256 qh_b = h256(0x75);
+    ASSERT_TRUE(cache.ingest(LlmqNetwork::Testnet,
+                             real_commitment(kLlmq50_60, qh_a, 0, 0x11)));
+    ASSERT_TRUE(cache.ingest(LlmqNetwork::Testnet,
+                             real_commitment(kLlmq50_60, qh_b, 0, 0x12)));
+    cache.set_bls_verify_fn([&first_calls](const CFinalCommitment&) {
+        ++first_calls;
+        return true;
+    });
+    for (int i = 0; i < 5; ++i) {
+        ASSERT_TRUE(cache.verified_for(1, qh_a).has_value());
+        ASSERT_TRUE(cache.verified_for(1, qh_b).has_value());
+    }
+    ASSERT_EQ(first_calls, 2) << "verify not memoised (see the once-across-N case)";
+
+    cache.set_bls_verify_fn([&second_calls](const CFinalCommitment&) {
+        ++second_calls;
+        return true;
+    });
+    ASSERT_TRUE(cache.verified_for(1, qh_a).has_value());
+    ASSERT_TRUE(cache.verified_for(1, qh_b).has_value());
+    EXPECT_EQ(second_calls, 2)
+        << "a latch survived a verifier swap — a verdict proven under the OLD "
+           "verifier was served under the new one";
+    EXPECT_EQ(first_calls, 2) << "the RETIRED verifier was called again";
+}
+
+TEST(DashQcVerifyMemo, ServePathPlanDerivationPaysTheVerifyOncePerCommitment)
+{
+    // THE SERVE PATH ITSELF, one level up: daemonless_qc_commitments is what
+    // the pre-emit gate's m_qc_plan_fn walks on EVERY cached-template read
+    // (node_coin_state.hpp:889-893 <- work_source.cpp:852-853). Re-deriving
+    // the plan N times must cost ONE verify per distinct commitment, not N.
+    constexpr uint32_t kH = 1'900'812u;   // testnet, inside a mining window
+    auto slots = compute_required_qc_slots(LlmqNetwork::Testnet, kH,
+                                           fake_hash_at, never_mined);
+    ASSERT_TRUE(slots.has_value());
+    ASSERT_FALSE(slots->empty());
+
+    int calls = 0;
+    MineableCommitmentCache cache;
+    for (const auto& s : *slots)
+        ASSERT_TRUE(cache.ingest(
+            LlmqNetwork::Testnet,
+            real_commitment(s.params, s.quorum_hash, s.quorum_index, 0x11)))
+            << "fixture commitment not admissible for type "
+            << static_cast<int>(s.params.type);
+    cache.set_bls_verify_fn([&calls](const CFinalCommitment&) {
+        ++calls;
+        return true;
+    });
+
+    const size_t n_slots = slots->size();
+    constexpr int kReads = 50;
+    for (int i = 0; i < kReads; ++i) {
+        auto plan = daemonless_qc_commitments(LlmqNetwork::Testnet, kH,
+                                              fake_hash_at, never_mined, &cache);
+        ASSERT_TRUE(plan.has_value()) << "read " << i << " failed the height closed";
+        ASSERT_EQ(plan->size(), n_slots);
+    }
+    EXPECT_EQ(static_cast<size_t>(calls), n_slots)
+        << "plan re-derivation re-proved the aggregate signatures: " << calls
+        << " verifies for " << kReads << " reads of " << n_slots
+        << " unchanged commitments — the io-thread cost the incident measured";
+}

--- a/test/test_dash_node_coin_state.cpp
+++ b/test/test_dash_node_coin_state.cpp
@@ -1724,3 +1724,145 @@ TEST(DashQcPoseGate, NullCommitmentPlanIsExemptWithoutCapability) {
     EXPECT_TRUE(st.embedded_template_emit_ok(sel.work, &why))
         << "cause=" << why.cause << " value=" << why.value;
 }
+
+// ════════════════════════════════════════════════════════════════════════
+// C2 — THE ONE REAL BEHAVIOUR CHANGE OF THE verified_for MEMO, PINNED.
+//
+// MineableCommitmentCache::verified_for now memoises its BLS verdict on the
+// cache entry (dkg_commitments.hpp:750-761). Once a slot is latched it no
+// longer calls the BLS verifier — and the verifier is what SOURCES THE MEMBER
+// KEY SET (bls_verify.hpp make_commitment_bls_verifier: provider nullopt =>
+// fail closed). Production feeds that same member source to the PoSe-noop
+// prover as well (main_dash.cpp:4160-4169
+// qc_member_source->lookup(...) -> nullopt => cannot prove).
+//
+// So if the member set is EVICTED after a successful verify, the refusal MOVES
+// DOWNSTREAM by one gate:
+//
+//   before: verified_for -> nullopt -> the whole height is underivable
+//           (dkg_commitments.hpp:869-878) -> cause=emit-qc-plan-underivable
+//           (node_coin_state.hpp:892)
+//   after:  verified_for -> LATCHED commitment -> plan derives -> the PoSe
+//           gate cannot source the member set -> pose_noop=n/a
+//           -> cause=emit-qc-real-pose-unfolded (node_coin_state.hpp:930)
+//
+// SAME OUTCOME — fail closed, nothing served, template bytes unchanged. But a
+// DIFFERENT DECLINE CAUSE STRING, and this project ranks serve-gate episodes
+// by exactly that string (ServeGateJournal, work_source.cpp:749-789), so the
+// change would otherwise show up as an unexplained shift in a soak histogram.
+// These two tests make it a decision on record.
+//
+// RED WITHOUT THE MEMO: revert verified_for to re-verify unconditionally (or
+// mutate the latch read to `if (true)`) and the first test fails at
+// EXPECT_EQ(cause, "emit-qc-real-pose-unfolded") — it gets
+// "emit-qc-plan-underivable", which is precisely the control case below.
+// ════════════════════════════════════════════════════════════════════════
+
+namespace {
+
+// A cache-backed plan fn with the shape daemonless_qc_commitments has for a
+// single mandatory slot (dkg_commitments.hpp:849-878): no BLS-verified
+// commitment for a mandatory slot => the WHOLE height is underivable.
+std::function<std::optional<dash::coin::QcBlockPlan>(uint32_t)>
+cache_backed_qc_plan_fn(const dash::coin::MineableCommitmentCache& cache,
+                        uint8_t llmq_type, const uint256& quorum_hash)
+{
+    return [&cache, llmq_type, quorum_hash](uint32_t)
+               -> std::optional<dash::coin::QcBlockPlan> {
+        auto real = cache.verified_for(llmq_type, quorum_hash);
+        if (!real) return std::nullopt;   // fail closed for the whole height
+        dash::coin::QcBlockPlan plan;
+        plan.commitments = {*real};
+        plan.merkle_root_quorums = raw256(0x77);
+        return plan;
+    };
+}
+
+}  // namespace
+
+TEST(DashQcVerifyMemoDeclineCause, EvictedMemberSetDeclinesAsPoseUnfolded) {
+    // ONE flag stands for the member source, exactly as production wires it:
+    // the SAME lookup backs the BLS verifier and the PoSe-noop prover.
+    bool member_set_cached = true;
+
+    const auto qc = make_real_qc(/*punish_listed_member=*/false);
+    dash::coin::MineableCommitmentCache cache;
+    ASSERT_TRUE(cache.ingest(dash::coin::LlmqNetwork::Testnet, qc));
+    cache.set_bls_verify_fn(
+        [&member_set_cached](const dash::coin::vendor::CFinalCommitment&) {
+            return member_set_cached;   // no member keys => fail closed
+        });
+
+    NodeCoinState st;
+    seed_real_qc_serving(st, qc);        // healthy DKG-window serving posture
+    st.set_qc_plan_fn(cache_backed_qc_plan_fn(cache, qc.llmqType, qc.quorumHash));
+    st.set_qc_pose_noop_fn(
+        [&member_set_cached](const dash::coin::vendor::CFinalCommitment& c)
+            -> std::optional<bool> {
+            if (!member_set_cached) return std::nullopt;   // cannot prove
+            return dash::coin::qc_pose_pass_provably_noop(c, 50);
+        });
+
+    // 1) Member set present: the slot verifies (and LATCHES), and the height
+    //    serves exactly as before the memo.
+    WorkSelection sel = st.select_work([] { return DashWorkData{}; });
+    ASSERT_EQ(sel.source, WorkSource::Embedded);
+    ASSERT_EQ(sel.work.m_txs.size(), 1u);
+    ASSERT_EQ(sel.work.m_txs[0].type, 6);
+    DeclineReport ok_why;
+    ASSERT_TRUE(st.embedded_template_emit_ok(sel.work, &ok_why))
+        << "cause=" << ok_why.cause << " value=" << ok_why.value;
+
+    // 2) The member set is EVICTED. Both the verifier and the PoSe prover go
+    //    blind — but the latch survives, so the plan still derives and the
+    //    refusal lands one gate downstream.
+    member_set_cached = false;
+
+    DeclineReport why;
+    EXPECT_FALSE(st.embedded_template_emit_ok(sel.work, &why))
+        << "an unprovable PoSe pass was SERVED";
+    EXPECT_EQ(why.cause, "emit-qc-real-pose-unfolded")
+        << "THE behaviour change this test exists for: with the verdict "
+           "latched, the member-set eviction is no longer caught at "
+           "verified_for (cause=emit-qc-plan-underivable) but at the PoSe "
+           "gate. Got cause=" << why.cause << " value=" << why.value;
+    EXPECT_NE(why.value.find("pose_noop=n/a"), std::string::npos)
+        << "the refusal must say the capability could not answer, not "
+           "fabricate a verdict: " << why.value;
+    EXPECT_EQ(why.threshold, "pose-pass-provably-noop(all-listed-members-valid)");
+}
+
+// The CONTROL, and the reason the test above is a change and not a bug: with
+// NO latch in play (a cache never read while the member set was present) the
+// old cause is still exactly what it was. The two tests together say the
+// cause string moved, and moved only for latched slots.
+TEST(DashQcVerifyMemoDeclineCause, UnlatchedSlotStillDeclinesAsPlanUnderivable) {
+    const auto qc = make_real_qc(/*punish_listed_member=*/false);
+
+    NodeCoinState st;
+    seed_real_qc_serving(st, qc);   // fixed plan fn => builds the template
+    st.set_qc_pose_noop_fn(
+        [](const dash::coin::vendor::CFinalCommitment& c)
+            -> std::optional<bool> {
+            return dash::coin::qc_pose_pass_provably_noop(c, 50);
+        });
+    WorkSelection sel = st.select_work([] { return DashWorkData{}; });
+    ASSERT_EQ(sel.source, WorkSource::Embedded);
+    ASSERT_EQ(sel.work.m_txs.size(), 1u);
+
+    // Now swap in a cache-backed plan whose commitment was NEVER verified
+    // while the member set existed — nothing is latched, so verified_for pays
+    // (and fails) the verify, and the whole height is underivable.
+    dash::coin::MineableCommitmentCache cold;
+    ASSERT_TRUE(cold.ingest(dash::coin::LlmqNetwork::Testnet, qc));
+    cold.set_bls_verify_fn(
+        [](const dash::coin::vendor::CFinalCommitment&) { return false; });
+    st.set_qc_plan_fn(cache_backed_qc_plan_fn(cold, qc.llmqType, qc.quorumHash));
+
+    DeclineReport why;
+    EXPECT_FALSE(st.embedded_template_emit_ok(sel.work, &why));
+    EXPECT_EQ(why.cause, "emit-qc-plan-underivable")
+        << "the PRE-memo cause must remain reachable for an unlatched slot: "
+        << "cause=" << why.cause << " value=" << why.value;
+    EXPECT_EQ(why.value, "nullopt");
+}

--- a/test/tools/tsan_qc_verify_latch.cpp
+++ b/test/tools/tsan_qc_verify_latch.cpp
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// ThreadSanitizer harness for MineableCommitmentCache::verified_for's memo
+// latch (dkg_commitments.hpp). NOT part of the CMake build and NOT a gtest:
+// it is the reproducible demonstration behind the latch being
+// `mutable std::atomic<bool>` rather than `mutable bool`.
+//
+// The gtest twin
+// (DashQcVerifyMemo.ConcurrentServeReadsAlwaysGetTheirCommitmentAndConverge,
+// test_dash_dkg_commitments.cpp) pins the BEHAVIOUR under concurrency, but a
+// benign-in-practice data race is still UB and an ordinary build cannot see
+// it. This one can:
+//
+//   g++ -std=c++20 -O1 -g -fsanitize=thread \
+//       -I<repo>/include -I<repo>/src -I<repo>/src/btclibs \
+//       -I<repo>/src/btclibs/util -I<repo>/src/btclibs/crypto \
+//       -I<repo>/src/btclibs/compat \
+//       test/tools/tsan_qc_verify_latch.cpp -o /tmp/tsan_latch
+//   setarch $(uname -m) -R /tmp/tsan_latch     # -R: TSan needs ASLR off
+//
+// Measured on this tree (gcc 13, 8 readers x 2000 reads):
+//   mutable std::atomic<bool> verified -> served=16000/16000 verifies=4,
+//                                         no TSan report, exit 0
+//   mutable bool verified              -> WARNING: ThreadSanitizer: data race
+//                                         "Write of size 1" in verified_for
+//                                         at dkg_commitments.hpp:760
+//
+// `verifies` being >1 is not a defect: it is exactly the tolerated worst case
+// — a redundant re-verify of the SAME bytes to the SAME verdict when readers
+// race the latching store. The latch is positive-only, so no interleaving can
+// turn a verified slot into a refusal, which is what `served` checks.
+
+#include <impl/dash/coin/dkg_commitments.hpp>
+
+#include <atomic>
+#include <cstdio>
+#include <cstring>
+#include <thread>
+#include <vector>
+
+using namespace dash::coin;
+
+namespace {
+
+uint256 fill256(uint8_t b)
+{
+    uint256 u;
+    std::vector<unsigned char> v(32, b);
+    std::memcpy(u.data(), v.data(), 32);
+    return u;
+}
+
+}  // namespace
+
+int main()
+{
+    MineableCommitmentCache cache;
+    const uint256 qh = fill256(0x91);
+
+    // A structurally admissible real testnet LLMQ_50_60 commitment (the same
+    // shape test_dash_dkg_commitments.cpp's real_commitment() builds).
+    vendor::CFinalCommitment c;
+    c.nVersion = vendor::CFinalCommitment::BASIC_BLS_NON_INDEXED_QUORUM_VERSION;
+    c.llmqType = kLlmq50_60.type;
+    c.quorumHash = qh;
+    c.quorumIndex = 0;
+    c.signers.assign(kLlmq50_60.size, true);
+    c.validMembers.assign(kLlmq50_60.size, true);
+    c.quorumPublicKey.fill(0x11);
+    c.quorumVvecHash = fill256(0x22);
+    c.quorumSig.fill(0x33);
+    c.membersSig.fill(0x44);
+    if (!cache.ingest(LlmqNetwork::Testnet, c)) {
+        std::puts("FAIL: fixture commitment was not admitted");
+        return 2;
+    }
+
+    std::atomic<int> calls{0};
+    cache.set_bls_verify_fn([&calls](const vendor::CFinalCommitment&) {
+        calls.fetch_add(1, std::memory_order_relaxed);
+        return true;
+    });
+
+    constexpr int kThreads = 8;
+    constexpr int kReads = 2000;
+    std::atomic<bool> go{false};
+    std::atomic<int> served{0};
+    std::vector<std::thread> readers;
+    readers.reserve(kThreads);
+    for (int t = 0; t < kThreads; ++t) {
+        readers.emplace_back([&] {
+            while (!go.load(std::memory_order_acquire)) { }
+            for (int i = 0; i < kReads; ++i)
+                if (cache.verified_for(kLlmq50_60.type, qh).has_value())
+                    served.fetch_add(1, std::memory_order_relaxed);
+        });
+    }
+    go.store(true, std::memory_order_release);
+    for (auto& t : readers) t.join();
+
+    std::printf("served=%d/%d verifies=%d\n", served.load(),
+                kThreads * kReads, calls.load());
+    if (served.load() != kThreads * kReads) {
+        std::puts("FAIL: a concurrent read withheld a verified commitment");
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## What the 2026-08-07 freeze actually was

A DASH mainnet node served a **dead height** to 26 rigs for an hour. Their work was unpayable. The main thread sat at 99.9% CPU **in userspace** (utime 4959 s against stime 28 s), every other thread parked on a futex, and the stratum receive queues grew to 16.66 MB. A plain restart recovered it completely — nothing on disk was wrong.

Four independent RCA angles ran, then each hypothesis was attacked by a skeptic. Five were refuted. One survived:

> Every read of the cached template on the serve path re-runs the **full pre-emit consensus gate inline on the io thread** — and only when the cached template came from the EMBEDDED arm, because the dashd arm short-circuits at `work_source.cpp:852` via `!template_cache_is_embedded_`.

The dominant term inside that gate is an **un-memoised BLS aggregate verification of a 391-signer LLMQ_400_60 commitment**, re-proven from scratch on every call. Measured from the log: one `send_notify_work` went **0.3 ms → 733 ms** at the arm flip, and `notify_all` fans those out **serially** per session. Duty accounting over the window: **292.6 s of 296.0 s = 98.9% of one core**, re-derived twice from different directions.

And it is self-sustaining: the expensive slot only retires when the tip advances, and the saturation is exactly what stops the tip advancing.

## The change

One production file. The memo is a **positive-only latch carried on the cache entry**, so its staleness argument is by construction rather than by discipline:

- the latch is set **only** on a successful verify — a failed verdict is never cached;
- `set_bls_verify_fn` **retires every latch**, because a verdict is only a proof under the verifier that produced it;
- replacement **erases and default-constructs** rather than assigning. `Entry` holds a `std::atomic` latch and is therefore neither copyable nor movable — deliberately, so the only way to obtain an entry is to build a fresh, unlatched one.

**No consensus check runs less often.** `embedded_template_emit_ok` still executes end to end per serve read, the qc plan is still re-derived per call, and the type-6 payload bytes are still byte-compared against it. A served template byte cannot move.

## What a skeptic did to it

Rebuilt and mutation-tested four ways, and **every mutant was killed by exactly the case that exists to catch it**:

| mutation | dies on |
|---|---|
| memo removed | all 5 |
| latch set regardless of verdict (latching FALSE — the dangerous direction) | `FailedVerdictIsNeverLatched` |
| `set_bls_verify_fn` no longer clearing | `InstallingAVerifierClearsEveryLatch` |
| replacement keeps the old latch | `BetterCommitmentForTheSameSlotReprovesFromScratch` |

## Disclosure — what this does NOT prove

**One real behaviour change, and it is tested rather than asserted away.** Once a slot is latched, `verified_for` no longer calls the member-key provider. If the member set is evicted after a successful verify, master declines with `cause=qc-plan-underivable`; here the refusal moves downstream to `cause=emit-qc-real-pose-unfolded`. Same outcome — fail closed, no template served — but a **different decline cause string**, and this project ranks serve-gate episodes by exactly that string. Two tests pin the new cause so it is a decision on record, not a surprise in a soak histogram.

**The performance claim is unmeasured.** There is no before/after timing of `embedded_template_emit_ok`, on the hotel or in a bench. The residual per-read cost — projected SML root, quorum root, qc-tx rebuild and byte compare, PoSe gate — times the serial per-session fan-out is unquantified. This removes the term the RCA called dominant and breaks the self-sustaining loop. **It does not prove the freeze cannot recur from the residue.** Do not close the incident class on this merge; measure on the next soak.

**CI cannot see a regression of the atomic.** `test/tools/tsan_qc_verify_latch.cpp` is the only red-on-mutation demonstration for the atomic latch, and it is deliberately not in CMakeLists — it needs `-fsanitize=thread`. Its gtest twin stays green with a plain `bool`, which is stated here rather than papered over. A TSan job is worth having as a separate change; this PR should not block on it.

## Tests

Three new cases plus the TSan harness. 216/216 and 45/45 green on the two binaries that reference the cache; `c2pool-dash` relinks clean. Full-repo build was **not** completed — the host OOM-killed it under concurrent load, and that is reported rather than claimed away.
