### PR TITLE
dash: nothing alarmed while a dead height was served for an hour

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -3326,8 +3326,14 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     // the SERVE path and carries the sentinel's standing
                     // verdict, so the page can state a fault instead of leaving
                     // it to a human to notice two numbers disagree.
-                    if (arm.contains("serve_staleness"))
-                        c["serve_staleness"] = arm["serve_staleness"];
+                    //
+                    // Read from serve_staleness_json() DIRECTLY, not out of
+                    // `arm`. embedded_arm_status_json also touches
+                    // serve_gate_mutex_ -- a lock the SERVE PATH holds -- so
+                    // sourcing the staleness block from its result would make
+                    // the one surface that reports serve-path saturation depend
+                    // on the serve path. This call takes no lock at all.
+                    c["serve_staleness"] = ws->serve_staleness_json();
                     return nlohmann::json{
                         {"node_symbol", "DASH"},
                         {"auto_detected", false},
@@ -6601,12 +6607,24 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // So the independent reference is the PEER-ADVERTISED height —
     // HeaderChain::peer_tip_height(), a relaxed atomic that already existed and
     // is already fed from the coin-p2p peer-height callback. It is genuinely
-    // from outside this process, which is the property that matters. Our own
-    // header tip is the documented second choice and is labelled `hdr` so a
-    // reader can tell the two apart. The honest consequence, recorded rather
-    // than hidden: BOTH mirrors are written on `ioc`, so in a full io freeze
-    // they stop advancing and D2 goes blind — D1 is the sub-check that would
-    // have fired in THIS incident, and D2 is the generalisation.
+    // from outside this process, which is the property that matters.
+    //
+    // AND IT IS THE ONLY ELIGIBLE SOURCE. There is deliberately NO fallback to
+    // our own header tip. set_peer_tip_height is wired only inside the coin_p2p
+    // block below, and header_chain is only constructed when coin_p2p exists —
+    // so on a node without coin-p2p there is no outside height at all, and an
+    // `hdr` fallback would have quietly turned D2 into the node comparing
+    // itself against itself. That is the exact class of check this lane's
+    // catalogue condemns in (b), (c) and (d): it would have read "served ==
+    // observed, healthy" for every minute of the incident. D2 REFUSES to run
+    // instead, and /api/node_topology publishes
+    // serve_staleness.d2 = "unavailable-no-independent-reference" so the refusal
+    // is visible rather than indistinguishable from a clean bill of health.
+    //
+    // The honest consequence, recorded rather than hidden: BOTH mirrors are
+    // written on `ioc`, so in a full io freeze they stop advancing and D2 goes
+    // blind — D1 is the sub-check that fires in THIS incident, D2 is the
+    // generalisation, and the status surface names which one raised.
     std::shared_ptr<std::atomic<int64_t>>  ss_beat;
     std::shared_ptr<std::atomic<uint32_t>> ss_obs_h;
     std::shared_ptr<std::atomic<int>>      ss_obs_src;
@@ -6634,18 +6652,24 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             ss_beat->store(ddiag::steady_now_ms(), std::memory_order_relaxed);
 
             // Mirrors, taken here because THIS is the thread on which reading
-            // them is safe. peer_tip_height() is preferred over our own tip
-            // precisely because it is the one height that did not come from
-            // inside this process.
+            // them is safe.
+            //
+            // THE ONLY ELIGIBLE SOURCE IS peer_tip_height() — a height that
+            // came from OUTSIDE this process. Our own header tip is NOT a
+            // fallback and must never be one: hc->peer_tip_height() is fed only
+            // from the coin-p2p peer-height callback (set_peer_tip_height,
+            // below in the coin_p2p block) and header_chain itself is only
+            // constructed when coin_p2p exists, so on a node without coin-p2p
+            // there is no outside height at all. Falling back to hc->height()
+            // there would have made D2 compare the node against ITSELF — the
+            // exact defect this lane's own header condemns, and it would have
+            // reported "served == observed, healthy" for the whole incident
+            // hour. 0/none means D2 does not run, and the surface says so.
             uint32_t obs = 0;
             int      src = 0;
             if (hc) {
                 const uint32_t peer = hc->peer_tip_height();
                 if (peer > 0) { obs = peer; src = 2; }          // "peer"
-                else {
-                    const uint32_t own = hc->height();
-                    if (own > 0) { obs = own; src = 3; }        // "hdr"
-                }
             }
             ss_obs_h->store(obs, std::memory_order_relaxed);
             ss_obs_src->store(src, std::memory_order_relaxed);
@@ -6673,6 +6697,13 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                         default: return "none";
                     }
                 };
+                // INDEPENDENT means "not from inside this process". Only the
+                // peer-advertised height qualifies today; "hdr" is our own tip
+                // and is listed here solely so that if a future source is
+                // wired it has to declare which side of this line it is on.
+                const auto src_independent = [](int i) {
+                    return i == 1 || i == 2;   // rpc (separate daemon) | peer
+                };
                 while (!ss_stop->load(std::memory_order_relaxed)) {
                     // ~15 s poll, slept in 100 ms slices so shutdown is prompt
                     // rather than up to a poll-period late.
@@ -6687,9 +6718,11 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     s.io_heartbeat_ms = ss_beat->load(std::memory_order_relaxed);
                     s.served_height   = ws->last_served_height();
                     s.served_at_ms    = ws->last_served_at_ms();
+                    const int obs_src_i =
+                        ss_obs_src->load(std::memory_order_relaxed);
                     s.observed_height = ss_obs_h->load(std::memory_order_relaxed);
-                    s.observed_src    =
-                        src_name(ss_obs_src->load(std::memory_order_relaxed));
+                    s.observed_src    = src_name(obs_src_i);
+                    s.observed_independent = src_independent(obs_src_i);
                     s.sessions        = ss_sessions->load(std::memory_order_relaxed);
 
                     const auto v = sen.poll(s);
@@ -6698,11 +6731,26 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     // status surface must be able to say "checked N seconds
                     // ago and it was fine", because "quiet" and "dead" looking
                     // identical is the defect this whole lane exists to close.
-                    ws->note_serve_observation(s.observed_height,
-                                               s.io_heartbeat_ms,
-                                               s.observed_src,
-                                               v.stale,
-                                               v.age_ms);
+                    //
+                    // And publish the STANDING verdict, not just D2's. In the
+                    // incident as it truly presented, the io thread was pegged,
+                    // so BOTH ioc-written mirrors froze and D2 went blind while
+                    // D1 raised correctly every minute. A surface carrying D2
+                    // alone reported `stale: false` for the entire hour that the
+                    // log was printing [STALE-SERVE] check=io-silence.
+                    dash::stratum::DASHWorkSource::ServeStalenessReport rep;
+                    rep.observed_height = s.observed_height;
+                    rep.observed_at_ms  = s.io_heartbeat_ms;
+                    rep.observed_src    = s.observed_src;
+                    rep.d2_armed        = v.d2_armed;
+                    rep.stale           = v.stale;
+                    rep.stale_check =
+                        dash::coin::stale_serve_check_name(v.stale_check);
+                    rep.stale_age_ms    = v.stale_age_ms;
+                    rep.io_silent_ms    = v.io_silent_ms;
+                    rep.skew_age_ms     = v.skew_age_ms;
+                    rep.serve_quiet_ms  = v.serve_quiet_ms;
+                    ws->note_serve_observation(rep);
                     if (v.fired) LOG_ERROR << v.line;
                 }
             });

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -123,6 +123,7 @@
 #include <impl/dash/enhanced_node.hpp>         // dash::EnhancedDashNode — core::IMiningNode the WebServer ctor takes
 #include <impl/dash/share_messages.hpp>        // dash::unpack_share_messages — signed transitional-blob DISPLAY+VERIFY feed
 #include <core/log.hpp>
+#include <impl/dash/coin/serve_staleness.hpp>  // REPORT-ONLY serve-staleness sentinel (2026-08-07 dead-height incident)
 
 #include <algorithm>    // std::copy (pool-share-cap pubkey_hash extract)
 #include <array>        // std::array<uint8_t,20> — AddrRateMap key
@@ -144,6 +145,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <thread>       // the serve-staleness sentinel's DEDICATED poller
 #include <vector>
 
 #ifndef C2POOL_VERSION
@@ -388,6 +390,7 @@ void print_banner(const char* argv0)
         << "           [--bestcl-policy freshness|consensus-exact]\n"
         << "           [--embedded-oracle-shadow]\n"
         << "           [--embedded-shadow-compare]\n"
+        << "           [--serve-staleness-sentinel=off]\n"
         << "           [--replay-bulk] [--replay-bulk-capture DIR] [--replay-bulk-start H]\n"
         << "           [--replay-fold-prestate FILE] [--replay-fold-quorums]\n"
         << "           [--replay-fold-qsnapshot FILE] [--replay-fold-worklists FILE]\n"
@@ -479,6 +482,14 @@ void print_banner(const char* argv0)
         << "        ledger + /embedded_oracle verdict signal when the embedded arm is\n"
         << "        proven equivalent (safe to disable dashd, served domain). Needs the\n"
         << "        dashd RPC arm; never changes serving. N/K tune the graduation gate.\n"
+        << "        --serve-staleness-sentinel=off DISABLES the report-only\n"
+        << "        serve-staleness detector, which is ON by default. It compares\n"
+        << "        the height actually handed to miners against an independently\n"
+        << "        observed one, from a DEDICATED thread (never the io loop), and\n"
+        << "        alarms with [STALE-SERVE]. It is report-only: a log line and a\n"
+        << "        node_topology field, never a serve decision. Turn it off only\n"
+        << "        if it is noisy -- with it off, a dead height served to miners\n"
+        << "        raises NOTHING, which is the 2026-08-07 failure it exists for.\n"
         << "        --embedded-shadow-compare is a SEPARATE, simpler OBSERVE-only\n"
         << "        diagnostic (NOT a serve gate, no graduation state): on every\n"
         << "        template SERVE it best-effort field-compares the served template\n"
@@ -766,7 +777,17 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              // in the builder against the live UTXO view — a bad or already-
              // mined pin is EXCLUDED, never a refused template, never a lost
              // block. Empty (default) = no pin, byte-unchanged.
-             const std::string& pin_local_tx_hex_path = std::string())
+             const std::string& pin_local_tx_hex_path = std::string(),
+             // --serve-staleness-sentinel=off: KILL SWITCH for the report-only
+             // serve-staleness sentinel (2026-08-07 dead-height incident). It
+             // is DEFAULT ON, which the money-path flag rule permits because it
+             // changes NOTHING about what is served: its only outputs are a log
+             // line and a JSON field. The flag exists for ops hygiene (a noisy
+             // detector must be silenceable without a redeploy), not for
+             // safety — there is no code path from an alarm to a serve
+             // decision. See coin/serve_staleness.hpp for why report-only was
+             // chosen over a detector that can stop serving.
+             bool serve_staleness_sentinel = true)
 {
     namespace io = boost::asio;
 
@@ -3298,6 +3319,15 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                         ? std::string()
                         : cause + " (value=" + c["no_work_value"].get<std::string>()
                                 + " threshold=" + c["no_work_threshold"].get<std::string>() + ")";
+                    // SERVE-STALENESS: the height we actually handed to a miner
+                    // versus an independently observed one. header_height and
+                    // target_height above are about the HEADER chain and are
+                    // recomputed only when a browser asks; this block is about
+                    // the SERVE path and carries the sentinel's standing
+                    // verdict, so the page can state a fault instead of leaving
+                    // it to a human to notice two numbers disagree.
+                    if (arm.contains("serve_staleness"))
+                        c["serve_staleness"] = arm["serve_staleness"];
                     return nlohmann::json{
                         {"node_symbol", "DASH"},
                         {"auto_detected", false},
@@ -6525,6 +6555,165 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         diag_timer->async_wait(*diag_tick);
     }
 
+    // ═════════════════════════════════════════════════════════════════════
+    // SERVE-STALENESS SENTINEL — REPORT-ONLY (2026-08-07 dead-height incident)
+    // ═════════════════════════════════════════════════════════════════════
+    //
+    // On 2026-08-07 this node handed h=2518006 to 26 rigs for ONE HOUR while
+    // dashd advanced to h=2518028, and nothing said so. The catalogue of why
+    // every existing signal was structurally unable to fire lives at the top of
+    // impl/dash/coin/serve_staleness.hpp; the short version is that all of them
+    // compare the node against ITSELF, and the [EMBED-STATUS] line that would
+    // have carried the news is a steady_timer on `ioc` — the very thread that
+    // pegged, so it stopped printing.
+    //
+    // Two pieces stand up here:
+    //
+    //   1. A 1 s heartbeat timer ON `ioc`. Its only job is to prove the io
+    //      thread can still write a number. It ALSO mirrors, from the io thread
+    //      where those reads are safe, the two values the sentinel would
+    //      otherwise have to race for: an independently observed height and the
+    //      attached-session count. The sentinel then dereferences NOTHING but
+    //      atomics.
+    //
+    //   2. A DEDICATED sentinel thread. Not an ioc timer, and this is the whole
+    //      point — diag::StallWatchdog's own contract (coin/lane_diag.hpp:
+    //      209-219) says a stall detector must not live on the path it watches,
+    //      and half of what this detects is that path dying.
+    //
+    // REPORT-ONLY: the outputs are a LOG_ERROR line and a JSON field on the
+    // existing /api/node_topology surface. There is no code path from an alarm
+    // to a serve decision, an arm flip, or a template byte. A false positive
+    // costs a page; a blocking detector's false positive would cost 26 rigs an
+    // outage, which is strictly worse than the failure it guards.
+    //
+    // HEIGHT SOURCE — a deliberate deviation from the approved plan, stated
+    // plainly. The plan called for `dashd getblockcount` on the sentinel's own
+    // dedicated NodeRPC connection. That is NOT wired here, because:
+    //   * reusing the SHARED NodeRPC is a data race, not merely contention:
+    //     NodeRPC::CallAPIMethod takes no lock at all, and blockcount_cached()
+    //     mutates the plain non-atomic members m_blockcount_cache /
+    //     m_blockcount_cache_at (impl/dash/coin/rpc.hpp:110-111). Adding a race
+    //     on the money path in order to detect a freeze is the wrong trade.
+    //   * a SECOND dashd connection was already an open question in the plan
+    //     (hotel auth / connection limits) and is not something to answer by
+    //     assumption on a production node.
+    // So the independent reference is the PEER-ADVERTISED height —
+    // HeaderChain::peer_tip_height(), a relaxed atomic that already existed and
+    // is already fed from the coin-p2p peer-height callback. It is genuinely
+    // from outside this process, which is the property that matters. Our own
+    // header tip is the documented second choice and is labelled `hdr` so a
+    // reader can tell the two apart. The honest consequence, recorded rather
+    // than hidden: BOTH mirrors are written on `ioc`, so in a full io freeze
+    // they stop advancing and D2 goes blind — D1 is the sub-check that would
+    // have fired in THIS incident, and D2 is the generalisation.
+    std::shared_ptr<std::atomic<int64_t>>  ss_beat;
+    std::shared_ptr<std::atomic<uint32_t>> ss_obs_h;
+    std::shared_ptr<std::atomic<int>>      ss_obs_src;
+    std::shared_ptr<std::atomic<uint32_t>> ss_sessions;
+    std::shared_ptr<std::atomic<bool>>     ss_stop;
+    std::thread                            ss_thread;
+    if (serve_staleness_sentinel && work_source) {
+        namespace ddiag = dash::coin::diag;
+        ss_beat     = std::make_shared<std::atomic<int64_t>>(ddiag::steady_now_ms());
+        ss_obs_h    = std::make_shared<std::atomic<uint32_t>>(0);
+        ss_obs_src  = std::make_shared<std::atomic<int>>(0);
+        ss_sessions = std::make_shared<std::atomic<uint32_t>>(0);
+        ss_stop     = std::make_shared<std::atomic<bool>>(false);
+
+        auto hb_timer = std::make_shared<io::steady_timer>(ioc);
+        auto hb_tick  =
+            std::make_shared<std::function<void(const boost::system::error_code&)>>();
+        *hb_tick = [hb_timer, hb_tick, ss_beat, ss_obs_h, ss_obs_src, ss_sessions,
+                    hc = header_chain.get(), ssrv = stratum_server.get()](
+                       const boost::system::error_code& ec) {
+            if (ec) return;   // cancelled at shutdown
+            // The liveness proof itself. Deliberately the FIRST thing the
+            // handler does: if the queue is drained late, the beat is late, and
+            // that lateness is exactly the measurement.
+            ss_beat->store(ddiag::steady_now_ms(), std::memory_order_relaxed);
+
+            // Mirrors, taken here because THIS is the thread on which reading
+            // them is safe. peer_tip_height() is preferred over our own tip
+            // precisely because it is the one height that did not come from
+            // inside this process.
+            uint32_t obs = 0;
+            int      src = 0;
+            if (hc) {
+                const uint32_t peer = hc->peer_tip_height();
+                if (peer > 0) { obs = peer; src = 2; }          // "peer"
+                else {
+                    const uint32_t own = hc->height();
+                    if (own > 0) { obs = own; src = 3; }        // "hdr"
+                }
+            }
+            ss_obs_h->store(obs, std::memory_order_relaxed);
+            ss_obs_src->store(src, std::memory_order_relaxed);
+            if (ssrv)
+                ss_sessions->store(
+                    static_cast<uint32_t>(ssrv->get_session_count()),
+                    std::memory_order_relaxed);
+
+            hb_timer->expires_after(std::chrono::seconds(1));
+            hb_timer->async_wait(*hb_tick);
+        };
+        hb_timer->expires_after(std::chrono::seconds(1));
+        hb_timer->async_wait(*hb_tick);
+
+        ss_thread = std::thread(
+            [ss_beat, ss_obs_h, ss_obs_src, ss_sessions, ss_stop,
+             ws = work_source]() {
+                dash::coin::ServeStalenessSentinel sen{
+                    dash::coin::ServeStalenessConfig{}};
+                const auto src_name = [](int i) {
+                    switch (i) {
+                        case 1:  return "rpc";
+                        case 2:  return "peer";
+                        case 3:  return "hdr";
+                        default: return "none";
+                    }
+                };
+                while (!ss_stop->load(std::memory_order_relaxed)) {
+                    // ~15 s poll, slept in 100 ms slices so shutdown is prompt
+                    // rather than up to a poll-period late.
+                    for (int i = 0;
+                         i < 150 && !ss_stop->load(std::memory_order_relaxed);
+                         ++i)
+                        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                    if (ss_stop->load(std::memory_order_relaxed)) break;
+
+                    dash::coin::ServeStalenessSample s;
+                    s.now_ms          = dash::coin::diag::steady_now_ms();
+                    s.io_heartbeat_ms = ss_beat->load(std::memory_order_relaxed);
+                    s.served_height   = ws->last_served_height();
+                    s.served_at_ms    = ws->last_served_at_ms();
+                    s.observed_height = ss_obs_h->load(std::memory_order_relaxed);
+                    s.observed_src    =
+                        src_name(ss_obs_src->load(std::memory_order_relaxed));
+                    s.sessions        = ss_sessions->load(std::memory_order_relaxed);
+
+                    const auto v = sen.poll(s);
+
+                    // Publish EVERY poll, not only the alarming ones: the
+                    // status surface must be able to say "checked N seconds
+                    // ago and it was fine", because "quiet" and "dead" looking
+                    // identical is the defect this whole lane exists to close.
+                    ws->note_serve_observation(s.observed_height,
+                                               s.io_heartbeat_ms,
+                                               s.observed_src,
+                                               v.stale,
+                                               v.age_ms);
+                    if (v.fired) LOG_ERROR << v.line;
+                }
+            });
+        std::cout << "[run] serve-staleness sentinel ARMED (report-only, "
+                     "dedicated poller, --serve-staleness-sentinel=off to "
+                     "disable)\n";
+    } else if (!serve_staleness_sentinel) {
+        std::cout << "[run] serve-staleness sentinel DISABLED by flag — a dead "
+                     "height served to miners will NOT be alarmed\n";
+    }
+
     std::cout << "[run] run-loop up (Ctrl-C to stop); won blocks relay DUAL-PATH:\n"
                  "[run]   ARM A embedded coin-P2P relay (primary, daemonless) = "
               << (p2p_relay ? "ARMED" : (no_p2p_relay ? "SUPPRESSED (--no-p2p-relay)"
@@ -6556,6 +6745,16 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // clean shutdown resumes exactly where it stopped (a crash costs at most
     // cursor_persist_every blocks of re-fetch). Timer callbacks no longer
     // fire — ioc.run() has returned.
+    // Serve-staleness sentinel: stop and JOIN its thread FIRST, before anything
+    // it can touch unwinds. It holds a shared_ptr to work_source (so the
+    // pointer cannot dangle) and otherwise reads only shared_ptr'd atomics, but
+    // joining here also guarantees no [STALE-SERVE] line is emitted after the
+    // log surface starts tearing down. The 100 ms sleep slices bound this wait
+    // at ~100 ms, not at a full 15 s poll period. Its ioc heartbeat timer is
+    // already dead: ioc.run() has returned.
+    if (ss_stop) ss_stop->store(true, std::memory_order_relaxed);
+    if (ss_thread.joinable()) ss_thread.join();
+
     if (replay_timer) replay_timer->stop();
     if (replay_lane) replay_lane->flush();
 
@@ -6820,6 +7019,10 @@ int main(int argc, char** argv)
     std::string bestcl_policy = "freshness";   // --bestcl-policy: freshness (default, conservative proxy) | consensus-exact (dashcore's actual CheckCbTxBestChainlock rule)
     bool embedded_oracle_shadow = false;       // --embedded-oracle-shadow: per-block dashd cross-check (OBSERVE-only)
     bool embedded_shadow_compare = false;      // --embedded-shadow-compare: serve-vs-dashd template diff (OBSERVE-only, NOT a gate)
+    // Serve-staleness sentinel (2026-08-07 dead-height incident): DEFAULT ON.
+    // Report-only -- log line + JSON field, no serve effect -- so the kill flag
+    // is ops hygiene, not a safety gate.
+    bool serve_staleness_sentinel = true;
     uint64_t oracle_grad_blocks = 5000;        // --oracle-graduation-blocks N (consecutive clean)
     uint64_t oracle_class_coverage = 20;       // --oracle-class-coverage K (per height class)
     double dev_donation = 0.1;                 // --give-author (donation_percentage; README default 0.1%)
@@ -6926,6 +7129,17 @@ int main(int argc, char** argv)
             embedded_oracle_shadow = true;
         else if (std::strcmp(argv[i], "--embedded-shadow-compare") == 0)
             embedded_shadow_compare = true;
+        // Serve-staleness sentinel kill switch. Accepts the bare flag (= on,
+        // already the default) and an explicit `=off` / `=on`, because an ops
+        // kill switch that needs the operator to remember which polarity the
+        // bare flag means is a kill switch that gets typed wrong at 04:00.
+        else if (std::strncmp(argv[i], "--serve-staleness-sentinel", 26) == 0) {
+            const char* eq = std::strchr(argv[i], '=');
+            serve_staleness_sentinel =
+                !(eq && (std::strcmp(eq + 1, "off") == 0 ||
+                         std::strcmp(eq + 1, "0")   == 0 ||
+                         std::strcmp(eq + 1, "false") == 0));
+        }
         // W2 full-history replay bulk-fetch lane (replay_bulk_fetch.hpp).
         else if (std::strcmp(argv[i], "--replay-bulk") == 0)
             g_replay_bulk = true;
@@ -7178,7 +7392,8 @@ int main(int argc, char** argv)
                         embedded_serve_mempool_txs,
                         embedded_shadow_compare,
                         embedded_mempool_ingest,
-                        pin_local_tx_hex_path);
+                        pin_local_tx_hex_path,
+                        serve_staleness_sentinel);
     }
     return run_selftest();
 }

--- a/src/impl/dash/coin/header_chain.hpp
+++ b/src/impl/dash/coin/header_chain.hpp
@@ -493,6 +493,18 @@ public:
 
     void set_peer_tip_height(uint32_t height) { m_peer_tip_height.store(height); }
 
+    /// The PEER-ADVERTISED best height, lock-free. Distinct from height(),
+    /// which is OUR OWN tip behind m_mutex: this is the only height in the
+    /// class that comes from outside this process, which is what makes it
+    /// usable as an independent reference by the serve-staleness sentinel
+    /// (coin/serve_staleness.hpp). Read-only accessor over an atomic that
+    /// already existed and is already written on the io thread
+    /// (main_dash.cpp: the coin-p2p peer-height callback) — it adds no new
+    /// synchronisation and takes no lock the serve path holds. 0 = never
+    /// advertised, which is "unknown", NOT "we are current".
+    uint32_t peer_tip_height() const
+    { return m_peer_tip_height.load(std::memory_order_relaxed); }
+
     /// Backfill progress line throttle: at most one line per `headers` of
     /// forward progress OR per `ms` of wall clock, whichever comes first.
     /// Telemetry only; exposed so a KAT can prove the line fires without

--- a/src/impl/dash/coin/serve_staleness.hpp
+++ b/src/impl/dash/coin/serve_staleness.hpp
@@ -1,0 +1,354 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// dash::coin::ServeStalenessSentinel — REPORT-ONLY detector for "we are handing
+/// miners a height the network has already passed".
+///
+/// ─────────────────────────────────────────────────────────────────────────
+/// THE INCIDENT (hotel 109.161.52.148, DASH mainnet, 2026-08-07)
+/// ─────────────────────────────────────────────────────────────────────────
+///
+/// The node served h=2518006 to 26 rigs for ONE HOUR while dashd advanced to
+/// h=2518028. All of that work was unpayable. A plain restart recovered it
+/// (9.7 -> 43.9 TH/s), so nothing was corrupted — the io thread was pegged at
+/// 99.9% in userspace and every other thread was parked on a futex.
+///
+/// The part this header addresses is NOT the peg. It is that NOTHING SAID SO
+/// for an hour.
+///
+/// ─────────────────────────────────────────────────────────────────────────
+/// WHY EVERY EXISTING SIGNAL WAS STRUCTURALLY UNABLE TO FIRE
+/// ─────────────────────────────────────────────────────────────────────────
+///
+/// Staleness signals DO exist in this tree. Each one fails here for a reason
+/// that is a property of its design, not a bug:
+///
+///  (a) kStaleAfter = 30 s / kRetryAfter = 5 s (stratum/work_source.cpp:66,:69)
+///      are CACHE TTLs. Expiry schedules a re-source; it is never a verdict.
+///      The executor path deliberately keeps serving the stale cache while the
+///      refresh runs (work_source.cpp:864-889, :924) — a stale cache is the
+///      normal steady state under load, so alarming on it would fire on every
+///      benign refresh and train operators to ignore the tag.
+///
+///  (b) [EMBED-STATUS] (c2pool/main_dash.cpp:6400-6525) is the periodic health
+///      line, and it is doubly blind here. Every field it prints —
+///      describe_decline(), have_tip/have_mn, payee_cursor, hdr_tip, bestcl —
+///      is read out of our OWN NodeCoinState/header chain, which froze WITH the
+///      serve path; and its `diag_timer` is a steady_timer on the SAME `ioc`
+///      (main_dash.cpp:6399), so when that thread pegged, the line stopped
+///      being printed at all. A metric that cannot disagree with the thing it
+///      measures is not a check.
+///
+///  (c) SmlResyncWatchdog (coin/sml_resync_watchdog.hpp) is a real over-time
+///      staleness detector — of the SML against OUR tip. A frozen tip makes a
+///      frozen SML look perfectly current, so it is silent by construction in
+///      exactly this failure.
+///
+///  (d) The oracle shadow-compare VOIDs a sample on tip-skew by design
+///      (coin/embedded_oracle_shadow.hpp:786-791) and its samples arrive on the
+///      starved owning thread. It reported a=0 comparisons — accurate, and read
+///      by everyone as silence.
+///
+///  (e) node_topology ALREADY carries header_height, target_height and a
+///      `synced` flag (main_dash.cpp:3271-3286). So the claim "there is no
+///      wall-clock comparison anywhere" is FALSE and is not made here. What is
+///      missing is narrower and exact: those fields are (i) recomputed only
+///      when a browser asks, (ii) about the HEADER chain, never about the
+///      height actually handed to a miner, and (iii) compared by nobody. A
+///      detector that needs a human watching at 04:00 is not a detector.
+///
+/// The one signal that did not exist anywhere in the tree — verified by
+/// `grep -rn 'serve_staleness\|served_height\|STALE-SERVE' src/` returning
+/// nothing on master — is a SERVED height, recorded where the template is
+/// actually handed out, compared against an INDEPENDENTLY observed height.
+/// That is all this class is.
+///
+/// ─────────────────────────────────────────────────────────────────────────
+/// REPORT-ONLY, DELIBERATELY
+/// ─────────────────────────────────────────────────────────────────────────
+///
+/// This class's only output types are a bool + a formatted string. There is no
+/// path from an alarm to a serve decision, an arm flip, or a template byte.
+/// That is a choice, not an omission: on the production money path a detector
+/// that can stop serving turns a false positive (a reorg, a lying peer height,
+/// the sentinel's own RPC glitch) into a self-inflicted outage for 26 rigs —
+/// strictly worse than the hour of unpayable work it guards against. A false
+/// positive here costs a page.
+///
+/// ─────────────────────────────────────────────────────────────────────────
+/// WHERE IT MUST BE POLLED FROM
+/// ─────────────────────────────────────────────────────────────────────────
+///
+/// A DEDICATED THREAD. Not `ioc`. Half of what this detects is the death of
+/// the io thread, and diag::StallWatchdog's own contract (coin/lane_diag.hpp:
+/// 209-219) already states the rule: "A STALL DETECTOR MUST NOT LIVE ON THE
+/// PATH IT WATCHES." The existing diag_tick violates that for this failure
+/// because it lives on `ioc` (main_dash.cpp:6399), which is why the class is
+/// reused here but its poller is not.
+///
+/// The class itself owns no thread and no clock: `poll()` takes every input as
+/// a value, so the whole detector is exercisable in a unit test with a fake
+/// clock and injected heights — including the mutation case that proves the
+/// skew comparison is load-bearing.
+
+#include <impl/dash/coin/lane_diag.hpp>   // diag::StallWatchdog, diag::steady_now_ms
+
+#include <cstdint>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace dash {
+namespace coin {
+
+/// Which sub-check raised. Named so a log scraper can key on the cause and an
+/// operator does not have to parse prose.
+enum class StaleServeCheck {
+    None = 0,
+    IoSilence,     ///< D1: the io thread stopped ticking its heartbeat.
+    HeightSkew,    ///< D2: served height is behind an independently observed one.
+    ServeSilence,  ///< D3: no template handed out at all while miners are attached.
+};
+
+inline const char* stale_serve_check_name(StaleServeCheck c)
+{
+    switch (c) {
+        case StaleServeCheck::IoSilence:    return "io-silence";
+        case StaleServeCheck::HeightSkew:   return "height-skew";
+        case StaleServeCheck::ServeSilence: return "serve-silence";
+        default:                            return "none";
+    }
+}
+
+/// Thresholds. Every one is a field rather than a constant SO THAT A TEST CAN
+/// NEUTER IT: the unit suite runs the induced-skew case a second time with
+/// `height_skew_blocks` set to the deleted-guard value and asserts the alarm
+/// does NOT fire. A guard that cannot be shown to matter has not been tested.
+struct ServeStalenessConfig {
+    /// D1: silence of the io-thread heartbeat that counts as "the io thread is
+    /// gone". The incident measured 13.145 s of io handler-queue latency
+    /// against 0.1 ms before it, so 10 s separates the two by two orders of
+    /// magnitude and still fires inside the first minute.
+    int64_t io_silence_ms{10000};
+
+    /// D2: how many blocks behind an independently observed height the SERVED
+    /// height must be. 1 is the ordinary propagation race (we are mid-block, a
+    /// peer already has the next one); 2 is not.
+    uint32_t height_skew_blocks{2};
+
+    /// D2: and for how long it must stay that way. DASH targets 2.5-minute
+    /// blocks, so 120 s cannot be reached by one block's propagation. The
+    /// incident's 22-block/1-hour skew clears this in ~5 minutes.
+    int64_t height_skew_sustain_ms{120000};
+
+    /// D3: no template handed out at all, while sessions are attached.
+    int64_t serve_silence_ms{300000};
+
+    /// Re-alarm cadence for a condition that stays true. Loud, but not a flood.
+    int64_t repeat_ms{60000};
+};
+
+/// One poll's inputs. All by value — the sentinel thread must never dereference
+/// live coin state (that is the 2026-08-05 heap-corruption shape) and must never
+/// take a lock the serve path holds.
+struct ServeStalenessSample {
+    int64_t  now_ms{0};             ///< steady clock, from the SENTINEL's thread.
+    int64_t  io_heartbeat_ms{0};    ///< last value the 1 s ioc timer stored; 0 = never.
+    uint32_t served_height{0};      ///< last height actually handed to a miner; 0 = never.
+    int64_t  served_at_ms{0};       ///< when that happened (steady).
+    uint32_t observed_height{0};    ///< independently observed chain height; 0 = unknown.
+    std::string observed_src{"none"};  ///< "rpc" | "peer" | "hdr" — which source won.
+    uint32_t sessions{0};           ///< attached stratum sessions.
+};
+
+/// What a poll concluded. `fired` is true only on the polls that owe a line.
+struct ServeStalenessVerdict {
+    bool            fired{false};
+    StaleServeCheck check{StaleServeCheck::None};
+    std::string     line;        ///< the full "[STALE-SERVE] ..." payload.
+    bool            stale{false};///< D2 condition currently true (independent of rate policy).
+    int64_t         age_ms{0};   ///< how long the raised condition has been true.
+};
+
+class ServeStalenessSentinel
+{
+public:
+    ServeStalenessSentinel() = default;
+    explicit ServeStalenessSentinel(ServeStalenessConfig cfg) : m_cfg(cfg) {}
+
+    const ServeStalenessConfig& config() const { return m_cfg; }
+
+    /// Poll once. Pure function of (sample, accumulated state) — no clock read,
+    /// no I/O, no lock. Returns at most ONE verdict per poll, most-severe
+    /// first: a dead io thread explains the other two, so saying all three
+    /// would be three lines about one fault.
+    ServeStalenessVerdict poll(const ServeStalenessSample& s)
+    {
+        ServeStalenessVerdict v;
+
+        // ── D1: io-thread liveness ──────────────────────────────────────────
+        // The heartbeat is written by a 1 s timer ON ioc. We do not read the io
+        // thread's state; we read whether it is still able to write a number.
+        // A pegged thread stops writing while remaining perfectly "alive" to
+        // every self-reported metric — that is the whole point.
+        if (s.io_heartbeat_ms > m_last_io_beat) {
+            m_last_io_beat  = s.io_heartbeat_ms;
+            m_io_beat_seen_at = s.now_ms;
+            m_io_wd.progress(s.now_ms);
+        }
+        if (!m_io_wd.armed() && s.io_heartbeat_ms > 0) {
+            m_io_wd = diag::StallWatchdog(m_cfg.io_silence_ms, m_cfg.repeat_ms);
+            m_io_wd.arm(s.now_ms);
+            m_last_io_beat    = s.io_heartbeat_ms;
+            m_io_beat_seen_at = s.now_ms;
+        }
+
+        // ── D2: served-vs-observed skew (state kept regardless of who wins) ──
+        // Sustain window, so a single-block propagation race cannot raise it.
+        const bool skew_now =
+            s.observed_height > 0 && s.served_height > 0 &&
+            (static_cast<uint64_t>(s.served_height) + m_cfg.height_skew_blocks
+                 <= static_cast<uint64_t>(s.observed_height));
+        if (skew_now) {
+            if (m_skew_since == 0) m_skew_since = s.now_ms;
+        } else {
+            m_skew_since = 0;
+        }
+        const int64_t skew_age =
+            m_skew_since == 0 ? 0 : (s.now_ms - m_skew_since);
+        const bool skew_sustained =
+            skew_now && skew_age >= m_cfg.height_skew_sustain_ms;
+        v.stale  = skew_sustained;
+        v.age_ms = skew_age;
+
+        // ── D3: serve silence, only while miners are actually attached ──────
+        if (s.served_height > m_last_served_height ||
+            s.served_at_ms  > m_last_served_at) {
+            m_last_served_height = s.served_height;
+            m_last_served_at     = s.served_at_ms;
+            m_serve_wd.progress(s.now_ms);
+        }
+        if (s.sessions > 0) {
+            if (!m_serve_wd.armed()) {
+                m_serve_wd = diag::StallWatchdog(m_cfg.serve_silence_ms,
+                                                 m_cfg.repeat_ms);
+                m_serve_wd.arm(s.now_ms);
+            }
+        } else {
+            m_serve_wd.disarm();
+        }
+
+        // ── Rate policy + severity order ────────────────────────────────────
+        if (auto d = m_io_wd.due(s.now_ms)) {
+            v.fired  = true;
+            v.check  = StaleServeCheck::IoSilence;
+            v.age_ms = *d;
+            v.line   = format_io(s, *d);
+            return v;
+        }
+        if (skew_sustained && owes_skew_line(s.now_ms)) {
+            v.fired = true;
+            v.check = StaleServeCheck::HeightSkew;
+            v.line  = format_skew(s, skew_age);
+            return v;
+        }
+        if (auto d = m_serve_wd.due(s.now_ms)) {
+            v.fired  = true;
+            v.check  = StaleServeCheck::ServeSilence;
+            v.age_ms = *d;
+            v.line   = format_serve_silence(s, *d);
+            return v;
+        }
+        return v;
+    }
+
+    /// Total alarms raised, per check. Lets the status surface say "this has
+    /// fired N times" rather than only "it is quiet right now" — the two are
+    /// not the same claim, and conflating them is how the last silent hour was
+    /// read as health.
+    uint32_t io_alarms()    const { return m_io_wd.warnings(); }
+    uint32_t skew_alarms()  const { return m_skew_alarms; }
+    uint32_t serve_alarms() const { return m_serve_wd.warnings(); }
+
+private:
+    bool owes_skew_line(int64_t now)
+    {
+        if (m_skew_warned && (now - m_skew_last_warn) < m_cfg.repeat_ms)
+            return false;
+        m_skew_last_warn = now;
+        m_skew_warned    = true;
+        ++m_skew_alarms;
+        return true;
+    }
+
+    static std::string ms(int64_t v)
+    {
+        std::ostringstream os;
+        os << (static_cast<double>(v) / 1000.0);
+        return os.str();
+    }
+
+    std::string format_io(const ServeStalenessSample& s, int64_t elapsed) const
+    {
+        std::ostringstream os;
+        os << "[STALE-SERVE] check=io-silence"
+           << " served=" << s.served_height
+           << " obs=" << s.observed_height
+           << " src=" << s.observed_src
+           << " io_silent=" << ms(elapsed) << "s"
+           << " threshold=" << ms(m_cfg.io_silence_ms) << "s"
+           << " sessions=" << s.sessions
+           << " — the io thread has not ticked; served work may be dead";
+        return os.str();
+    }
+
+    std::string format_skew(const ServeStalenessSample& s, int64_t age) const
+    {
+        std::ostringstream os;
+        os << "[STALE-SERVE] check=height-skew"
+           << " served=" << s.served_height
+           << " obs=" << s.observed_height
+           << " src=" << s.observed_src
+           << " behind=" << (static_cast<uint64_t>(s.observed_height)
+                             - static_cast<uint64_t>(s.served_height))
+           << " threshold=" << m_cfg.height_skew_blocks
+           << " age=" << ms(age) << "s"
+           << " sustain=" << ms(m_cfg.height_skew_sustain_ms) << "s"
+           << " sessions=" << s.sessions
+           << " — miners are working a height the network has passed";
+        return os.str();
+    }
+
+    std::string format_serve_silence(const ServeStalenessSample& s,
+                                     int64_t elapsed) const
+    {
+        std::ostringstream os;
+        os << "[STALE-SERVE] check=serve-silence"
+           << " served=" << s.served_height
+           << " obs=" << s.observed_height
+           << " src=" << s.observed_src
+           << " quiet=" << ms(elapsed) << "s"
+           << " threshold=" << ms(m_cfg.serve_silence_ms) << "s"
+           << " sessions=" << s.sessions
+           << " — no template handed out while miners are attached";
+        return os.str();
+    }
+
+    ServeStalenessConfig m_cfg{};
+
+    diag::StallWatchdog  m_io_wd{};
+    int64_t              m_last_io_beat{0};
+    int64_t              m_io_beat_seen_at{0};
+
+    int64_t              m_skew_since{0};
+    int64_t              m_skew_last_warn{0};
+    bool                 m_skew_warned{false};
+    uint32_t             m_skew_alarms{0};
+
+    diag::StallWatchdog  m_serve_wd{};
+    uint32_t             m_last_served_height{0};
+    int64_t              m_last_served_at{0};
+};
+
+}  // namespace coin
+}  // namespace dash

--- a/src/impl/dash/coin/serve_staleness.hpp
+++ b/src/impl/dash/coin/serve_staleness.hpp
@@ -126,10 +126,39 @@ inline const char* stale_serve_check_name(StaleServeCheck c)
 /// does NOT fire. A guard that cannot be shown to matter has not been tested.
 struct ServeStalenessConfig {
     /// D1: silence of the io-thread heartbeat that counts as "the io thread is
-    /// gone". The incident measured 13.145 s of io handler-queue latency
-    /// against 0.1 ms before it, so 10 s separates the two by two orders of
-    /// magnitude and still fires inside the first minute.
-    int64_t io_silence_ms{10000};
+    /// gone".
+    ///
+    /// THIS DEFAULT WAS 10 s AND WOULD HAVE CRIED WOLF ON A HEALTHY NODE. The
+    /// arithmetic that retired it, with every input measured rather than
+    /// assumed:
+    ///
+    ///   * one send_notify_work costs ~733 ms on the hotel node — the pre-emit
+    ///     gate held across it (stratum/work_source.cpp:853 records the same
+    ///     733 ms figure from the incident capture);
+    ///   * notify_all runs those SERIALLY over the session snapshot, on the io
+    ///     thread, with no yield between them (core/stratum_server.cpp:379-385);
+    ///   * 26 attached rigs is therefore 26 x 733 ms = 19.06 s in ONE notify
+    ///     round, during which the 1 s heartbeat timer CANNOT run — on a node
+    ///     that is perfectly healthy and simply busy;
+    ///   * a tip change landing inside a round makes two rounds back to back:
+    ///     38.1 s.
+    ///
+    /// 10 s sat BELOW one round. It would have fired on every tip change with
+    /// 14+ rigs attached, and a detector that fires on a healthy node is worth
+    /// less than nothing: it trains the operator to skip the tag, which is how
+    /// [EMBED-STATUS] became unreadable.
+    ///
+    /// 60 s sits above two full rounds and far below the fault. The incident's
+    /// io handler-queue latency was 13.145 s SUSTAINED for 3600 s — a peg does
+    /// not recover, so a 60 s threshold still raises 60 s in and once per
+    /// repeat_ms thereafter, i.e. ~59 lines inside the hour that produced zero.
+    ///
+    /// THE CEILING, STATED SO IT IS FALSIFIABLE: this holds while
+    ///     io_silence_ms >= 2 * sessions * 733 ms,
+    /// i.e. up to 40 attached sessions at 60 s. A pool above ~40 rigs MUST
+    /// raise this or D1 will false-positive on it. The value is a config field
+    /// for exactly that reason.
+    int64_t io_silence_ms{60000};
 
     /// D2: how many blocks behind an independently observed height the SERVED
     /// height must be. 1 is the ordinary propagation race (we are mid-block, a
@@ -158,16 +187,57 @@ struct ServeStalenessSample {
     int64_t  served_at_ms{0};       ///< when that happened (steady).
     uint32_t observed_height{0};    ///< independently observed chain height; 0 = unknown.
     std::string observed_src{"none"};  ///< "rpc" | "peer" | "hdr" — which source won.
+    /// TRUE only when `observed_height` came from OUTSIDE this process.
+    ///
+    /// D2 REFUSES TO RUN WHEN THIS IS FALSE, and that refusal is the whole
+    /// point of the sub-check. Our own header tip is not an independent
+    /// reference: comparing served-height against it is the node measuring
+    /// itself, which is precisely the failure mode this file's catalogue
+    /// condemns in (b), (c) and (d) above. A D2 that silently degrades to
+    /// self-comparison is not a weaker detector, it is a FALSE ONE — it would
+    /// have reported "served == observed, all good" for the whole incident
+    /// hour. Unknown must render as unknown.
+    bool     observed_independent{false};
     uint32_t sessions{0};           ///< attached stratum sessions.
 };
 
-/// What a poll concluded. `fired` is true only on the polls that owe a line.
+/// What a poll concluded.
+///
+/// `fired` is true only on the polls that OWE A LINE (rate policy). The
+/// standing-condition fields below are true whenever the condition holds,
+/// whether or not a line was owed — that split exists because the surface and
+/// the log must not be able to disagree: during the incident the log knew and
+/// the JSON did not.
+///
+/// EVERY AGE IS ITS OWN FIELD. A single `age_ms` that meant io-silence on one
+/// poll and skew-age on the next is how an operator reads a number that is
+/// true and concludes something false; the 2026-08-07 confusion started
+/// exactly there. `stale_age_ms` is the age of the condition named by
+/// `stale_check` AND NOTHING ELSE.
 struct ServeStalenessVerdict {
     bool            fired{false};
-    StaleServeCheck check{StaleServeCheck::None};
+    StaleServeCheck check{StaleServeCheck::None};  ///< which check emitted `line`.
     std::string     line;        ///< the full "[STALE-SERVE] ..." payload.
-    bool            stale{false};///< D2 condition currently true (independent of rate policy).
-    int64_t         age_ms{0};   ///< how long the raised condition has been true.
+
+    /// ANY sub-check condition currently true — D1, D2 or D3. Not D2 alone:
+    /// in the incident as it truly presented, D1 was the only one that could
+    /// see anything, and a `stale` that ignored it left the status surface
+    /// reporting health for an hour while the log printed 60 alarms.
+    bool            stale{false};
+    /// Which condition `stale` refers to, most-severe first (D1 > D2 > D3).
+    StaleServeCheck stale_check{StaleServeCheck::None};
+    /// Age of the condition named by `stale_check`. 0 when none is raised.
+    int64_t         stale_age_ms{0};
+
+    /// Per-check ages, always populated, never overwritten by each other.
+    int64_t         io_silent_ms{0};    ///< D1: since the io heartbeat last moved.
+    int64_t         skew_age_ms{0};     ///< D2: since served fell behind observed.
+    int64_t         serve_quiet_ms{0};  ///< D3: since a template was last handed out.
+
+    /// D2 had an INDEPENDENT reference this poll and therefore actually ran.
+    /// False means D2 said nothing — which is not the same claim as "no skew"
+    /// and must never be rendered as one.
+    bool            d2_armed{false};
 };
 
 class ServeStalenessSentinel
@@ -205,8 +275,16 @@ public:
 
         // ── D2: served-vs-observed skew (state kept regardless of who wins) ──
         // Sustain window, so a single-block propagation race cannot raise it.
+        //
+        // REFUSE-TO-SELF-COMPARE. `observed_independent` is a hard precondition,
+        // not a hint. Without an outside height the honest answer is "D2 did not
+        // run"; comparing against our own header tip would make the detector
+        // agree with the freeze, which is the exact defect this file exists to
+        // close. m_skew_since is cleared on refusal so a later real observation
+        // starts a fresh sustain window rather than inheriting a stale one.
+        v.d2_armed = s.observed_independent && s.observed_height > 0;
         const bool skew_now =
-            s.observed_height > 0 && s.served_height > 0 &&
+            v.d2_armed && s.served_height > 0 &&
             (static_cast<uint64_t>(s.served_height) + m_cfg.height_skew_blocks
                  <= static_cast<uint64_t>(s.observed_height));
         if (skew_now) {
@@ -218,8 +296,6 @@ public:
             m_skew_since == 0 ? 0 : (s.now_ms - m_skew_since);
         const bool skew_sustained =
             skew_now && skew_age >= m_cfg.height_skew_sustain_ms;
-        v.stale  = skew_sustained;
-        v.age_ms = skew_age;
 
         // ── D3: serve silence, only while miners are actually attached ──────
         if (s.served_height > m_last_served_height ||
@@ -238,12 +314,50 @@ public:
             m_serve_wd.disarm();
         }
 
+        // ── STANDING CONDITIONS — computed BEFORE the rate policy ───────────
+        //
+        // This block is the C1 fix. Previously `stale` carried D2 only, so the
+        // incident as it TRULY presented — io thread pegged, therefore BOTH
+        // ioc-written mirrors frozen, therefore observed == served and D2 blind,
+        // while the serve path still trickled the dead height to 26 rigs —
+        // produced 60 correct [STALE-SERVE] check=io-silence LOG lines and a
+        // status surface that said `stale: false` for the whole hour. An
+        // operator reading /api/node_topology during the real event saw nothing
+        // wrong. The log and the surface must not be able to disagree.
+        //
+        // `due()` mutates (it is the rate policy), so the standing state is read
+        // with the non-mutating elapsed_ms() and is independent of whether a
+        // line is owed this poll.
+        v.io_silent_ms   = m_io_wd.elapsed_ms(s.now_ms);
+        v.skew_age_ms    = skew_age;
+        v.serve_quiet_ms = m_serve_wd.elapsed_ms(s.now_ms);
+
+        const bool io_cond =
+            m_io_wd.armed() && v.io_silent_ms >= m_cfg.io_silence_ms;
+        const bool serve_cond =
+            m_serve_wd.armed() && v.serve_quiet_ms >= m_cfg.serve_silence_ms;
+
+        // Same severity order as the lines: a dead io thread explains the other
+        // two, so it is what the surface names.
+        if (io_cond) {
+            v.stale        = true;
+            v.stale_check  = StaleServeCheck::IoSilence;
+            v.stale_age_ms = v.io_silent_ms;
+        } else if (skew_sustained) {
+            v.stale        = true;
+            v.stale_check  = StaleServeCheck::HeightSkew;
+            v.stale_age_ms = v.skew_age_ms;
+        } else if (serve_cond) {
+            v.stale        = true;
+            v.stale_check  = StaleServeCheck::ServeSilence;
+            v.stale_age_ms = v.serve_quiet_ms;
+        }
+
         // ── Rate policy + severity order ────────────────────────────────────
         if (auto d = m_io_wd.due(s.now_ms)) {
-            v.fired  = true;
-            v.check  = StaleServeCheck::IoSilence;
-            v.age_ms = *d;
-            v.line   = format_io(s, *d);
+            v.fired = true;
+            v.check = StaleServeCheck::IoSilence;
+            v.line  = format_io(s, *d);
             return v;
         }
         if (skew_sustained && owes_skew_line(s.now_ms)) {
@@ -253,10 +367,9 @@ public:
             return v;
         }
         if (auto d = m_serve_wd.due(s.now_ms)) {
-            v.fired  = true;
-            v.check  = StaleServeCheck::ServeSilence;
-            v.age_ms = *d;
-            v.line   = format_serve_silence(s, *d);
+            v.fired = true;
+            v.check = StaleServeCheck::ServeSilence;
+            v.line  = format_serve_silence(s, *d);
             return v;
         }
         return v;

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -42,6 +42,7 @@
 #include <impl/dash/params.hpp>               // dash::make_coin_params
 #include <impl/dash/coin/vendor/cbtx.hpp>     // vendor::parse_cbtx (GBT-xcheck creditPool)
 #include <impl/dash/coin/special_tx_pool_delta.hpp> // #107: explain the pool delta
+#include <impl/dash/coin/serve_staleness.hpp> // serve-staleness sentinel (steady_now_ms + the incident catalogue)
 
 #include <core/address_utils.hpp>             // core::address_to_script (mint payout from username)
 #include <core/log.hpp>
@@ -793,10 +794,102 @@ void DASHWorkSource::note_arm_decision(bool served_embedded,
 // SAME DeclineReport the journal logged, so the page and the log cannot
 // disagree; "unknown" before the first template is sourced, never a fabricated
 // "ok".
+// ── SERVE-STALENESS: the served height, recorded WHERE IT IS SERVED ─────────
+//
+// Two relaxed stores. That is the entire serve-path cost of this detector, and
+// it is why the safety argument is short: it adds an observation and touches
+// nothing else. Cited by the 2026-08-07 incident — the node had no record
+// anywhere of the height it had actually handed out, only of what its own
+// (frozen) coin state believed, so every check that existed was comparing the
+// node against itself.
+void DASHWorkSource::note_served_height(uint32_t h) const
+{
+    if (h == 0) return;   // no template -> nothing was served; do not fabricate
+    last_served_height_.store(h, std::memory_order_relaxed);
+    last_served_at_ms_.store(coin::diag::steady_now_ms(),
+                             std::memory_order_relaxed);
+}
+
+namespace {
+// Index <-> name for the observed-height source. An index keeps the whole
+// staleness block lock-free (a std::string cannot be an atomic), and naming the
+// source matters: "we are 22 blocks behind according to a peer's advertised
+// height" and "...according to our own dashd" are different claims and must not
+// render identically.
+const char* serve_src_name(int i)
+{
+    switch (i) {
+        case 1:  return "rpc";
+        case 2:  return "peer";
+        case 3:  return "hdr";
+        case 4:  return "other";
+        default: return "none";
+    }
+}
+int serve_src_index(const std::string& s)
+{
+    if (s == "rpc")  return 1;
+    if (s == "peer") return 2;
+    if (s == "hdr")  return 3;
+    if (s == "none" || s.empty()) return 0;
+    return 4;
+}
+}  // namespace
+
+void DASHWorkSource::note_serve_observation(uint32_t observed_height,
+                                            int64_t observed_at_ms,
+                                            const std::string& source,
+                                            bool stale,
+                                            int64_t stale_age_ms) const
+{
+    observed_height_.store(observed_height, std::memory_order_relaxed);
+    observed_at_ms_.store(observed_at_ms, std::memory_order_relaxed);
+    observed_src_.store(serve_src_index(source), std::memory_order_relaxed);
+    serve_stale_.store(stale, std::memory_order_relaxed);
+    serve_stale_age_ms_.store(stale_age_ms, std::memory_order_relaxed);
+}
+
+// Composed from atomics ONLY. During the incident the io thread held
+// template_mutex_ across the ~733 ms pre-emit gate (see the serve-time re-check
+// below, and the gate call it wraps), so a status surface that waits on any
+// lock the serve path holds goes dark exactly when an operator needs it. This
+// function therefore runs BEFORE embedded_arm_status_json takes
+// serve_gate_mutex_, and takes nothing itself.
+nlohmann::json DASHWorkSource::serve_staleness_json() const
+{
+    const int64_t  now      = coin::diag::steady_now_ms();
+    const uint32_t served   = last_served_height_.load(std::memory_order_relaxed);
+    const int64_t  served_at= last_served_at_ms_.load(std::memory_order_relaxed);
+    const uint32_t observed = observed_height_.load(std::memory_order_relaxed);
+    const int64_t  obs_at   = observed_at_ms_.load(std::memory_order_relaxed);
+    const int      src      = observed_src_.load(std::memory_order_relaxed);
+
+    nlohmann::json s;
+    s["served_height"]   = served;
+    s["observed_height"] = observed;
+    s["observed_src"]    = serve_src_name(src);
+    s["stale"]           = serve_stale_.load(std::memory_order_relaxed);
+    s["stale_age_s"]     =
+        serve_stale_age_ms_.load(std::memory_order_relaxed) / 1000;
+    // Ages, not timestamps: "served 3 s ago" survives a log paste, an absolute
+    // steady-clock reading does not.
+    s["served_age_s"]    = served_at > 0 ? (now - served_at) / 1000 : -1;
+    s["observed_age_s"]  = obs_at    > 0 ? (now - obs_at)    / 1000 : -1;
+    // behind is ABSENT, not 0, when either side is unknown. A missing
+    // observation is not a claim of health, and rendering it as 0 is exactly
+    // how the shadow oracle's honest a=0 got read as "fine".
+    if (served > 0 && observed > 0 && observed > served)
+        s["behind"] = observed - served;
+    return s;
+}
+
 nlohmann::json DASHWorkSource::embedded_arm_status_json() const
 {
-    std::lock_guard<std::mutex> lk(serve_gate_mutex_);
     nlohmann::json j;
+    // BEFORE the lock, deliberately -- see serve_staleness_json().
+    j["serve_staleness"] = serve_staleness_json();
+
+    std::lock_guard<std::mutex> lk(serve_gate_mutex_);
     if (!arm_ever_observed_) {
         j["arm"]               = "unknown";
         j["no_work_reason"]    = "no-template-sourced-yet";
@@ -939,6 +1032,13 @@ nlohmann::json DASHWorkSource::get_current_work_template() const
     auto wd = cached_work();
     if (!wd) return nlohmann::json::object();
 
+    // Serve-staleness sentinel: this is the moment a HEIGHT LEAVES THE NODE.
+    // Recorded here rather than anywhere upstream because upstream is coin
+    // state, and coin state is what froze on 2026-08-07 — a detector reading it
+    // would have agreed with the freeze all hour. Two relaxed stores; no lock,
+    // no allocation, no effect on the returned template.
+    note_served_height(wd->m_height);
+
     nlohmann::json tmpl;
     tmpl["previousblockhash"] = wd->m_previous_block.GetHex();
     tmpl["version"]           = wd->m_version;
@@ -1000,6 +1100,12 @@ core::stratum::CoinbaseResult DASHWorkSource::build_connection_coinbase(
     // GBT-mandated masternode/superblock outputs and the donation tail.
     auto wd = cached_work();
     if (!wd) return {};   // no template -> no job (session retries)
+
+    // Serve-staleness sentinel: the per-connection coinbase path is the OTHER
+    // way a height reaches a miner (get_current_work_template is the first).
+    // Recording both means the detector's served_height cannot be stale merely
+    // because the notify path happened to be quiet. Two relaxed stores.
+    note_served_height(wd->m_height);
 
     // Shared frozen-snapshot tail: branches + tx set from the SAME wd the
     // coinbase was built over, so the session's job merkle always matches the

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -834,27 +834,62 @@ int serve_src_index(const std::string& s)
     if (s == "none" || s.empty()) return 0;
     return 4;
 }
+
+// Which sub-check the standing `stale` verdict refers to. Same ordering as
+// coin::StaleServeCheck; kept as an index for the same reason as the source --
+// a std::string cannot be an atomic and this block must stay lock-free.
+const char* serve_check_name(int i)
+{
+    switch (i) {
+        case 1:  return "io-silence";
+        case 2:  return "height-skew";
+        case 3:  return "serve-silence";
+        default: return "none";
+    }
+}
+int serve_check_index(const std::string& s)
+{
+    if (s == "io-silence")    return 1;
+    if (s == "height-skew")   return 2;
+    if (s == "serve-silence") return 3;
+    return 0;
+}
 }  // namespace
 
-void DASHWorkSource::note_serve_observation(uint32_t observed_height,
-                                            int64_t observed_at_ms,
-                                            const std::string& source,
-                                            bool stale,
-                                            int64_t stale_age_ms) const
+void DASHWorkSource::note_serve_observation(
+    const DASHWorkSource::ServeStalenessReport& r) const
 {
-    observed_height_.store(observed_height, std::memory_order_relaxed);
-    observed_at_ms_.store(observed_at_ms, std::memory_order_relaxed);
-    observed_src_.store(serve_src_index(source), std::memory_order_relaxed);
-    serve_stale_.store(stale, std::memory_order_relaxed);
-    serve_stale_age_ms_.store(stale_age_ms, std::memory_order_relaxed);
+    observed_height_.store(r.observed_height, std::memory_order_relaxed);
+    observed_at_ms_.store(r.observed_at_ms, std::memory_order_relaxed);
+    observed_src_.store(serve_src_index(r.observed_src),
+                        std::memory_order_relaxed);
+    serve_d2_armed_.store(r.d2_armed, std::memory_order_relaxed);
+    serve_stale_.store(r.stale, std::memory_order_relaxed);
+    serve_stale_check_.store(serve_check_index(r.stale_check),
+                             std::memory_order_relaxed);
+    serve_stale_age_ms_.store(r.stale_age_ms, std::memory_order_relaxed);
+    serve_io_silent_ms_.store(r.io_silent_ms, std::memory_order_relaxed);
+    serve_skew_age_ms_.store(r.skew_age_ms, std::memory_order_relaxed);
+    serve_quiet_ms_.store(r.serve_quiet_ms, std::memory_order_relaxed);
 }
 
-// Composed from atomics ONLY. During the incident the io thread held
-// template_mutex_ across the ~733 ms pre-emit gate (see the serve-time re-check
-// below, and the gate call it wraps), so a status surface that waits on any
-// lock the serve path holds goes dark exactly when an operator needs it. This
-// function therefore runs BEFORE embedded_arm_status_json takes
-// serve_gate_mutex_, and takes nothing itself.
+// Composed from RELAXED ATOMICS ONLY -- this function takes no mutex of any
+// kind, and /api/node_topology calls it DIRECTLY rather than digging it out of
+// embedded_arm_status_json's result (main_dash.cpp).
+//
+// That directness is the point. embedded_arm_status_json additionally reads the
+// arm bits behind serve_gate_mutex_, and serve_gate_mutex_ is held by the SERVE
+// PATH (note_arm_decision, :759 above). During the incident the io thread held
+// template_mutex_ across the ~733 ms pre-emit gate; a status block reachable
+// only THROUGH a lock the failing path holds is dark exactly when an operator
+// needs it. Composing this block before that lock is not enough on its own --
+// the caller still blocked on the lock a line later -- so the block is public
+// and the topology surface reads it on its own.
+//
+// EVERY AGE IS ITS OWN FIELD, and `stale_check` names which condition
+// `stale`/`stale_age_s` are about. The previous shape reused one age field for
+// whichever sub-check happened to fire, so the same operator number meant
+// io-silence on one poll and height-skew on the next.
 nlohmann::json DASHWorkSource::serve_staleness_json() const
 {
     const int64_t  now      = coin::diag::steady_now_ms();
@@ -863,14 +898,27 @@ nlohmann::json DASHWorkSource::serve_staleness_json() const
     const uint32_t observed = observed_height_.load(std::memory_order_relaxed);
     const int64_t  obs_at   = observed_at_ms_.load(std::memory_order_relaxed);
     const int      src      = observed_src_.load(std::memory_order_relaxed);
+    const bool     d2_armed = serve_d2_armed_.load(std::memory_order_relaxed);
 
     nlohmann::json s;
     s["served_height"]   = served;
     s["observed_height"] = observed;
     s["observed_src"]    = serve_src_name(src);
     s["stale"]           = serve_stale_.load(std::memory_order_relaxed);
+    s["stale_check"]     =
+        serve_check_name(serve_stale_check_.load(std::memory_order_relaxed));
     s["stale_age_s"]     =
         serve_stale_age_ms_.load(std::memory_order_relaxed) / 1000;
+    // Per-check ages, always present, never standing in for one another.
+    s["io_silent_s"]     =
+        serve_io_silent_ms_.load(std::memory_order_relaxed) / 1000;
+    s["skew_age_s"]      =
+        serve_skew_age_ms_.load(std::memory_order_relaxed) / 1000;
+    s["serve_quiet_s"]   = serve_quiet_ms_.load(std::memory_order_relaxed) / 1000;
+    // D2 needs a height from OUTSIDE this process. Without one it does not run,
+    // and the surface says so instead of publishing a silent self-comparison --
+    // a node vouching for its own tip is exactly what stayed quiet for an hour.
+    s["d2"] = d2_armed ? "armed" : "unavailable-no-independent-reference";
     // Ages, not timestamps: "served 3 s ago" survives a log paste, an absolute
     // steady-clock reading does not.
     s["served_age_s"]    = served_at > 0 ? (now - served_at) / 1000 : -1;
@@ -889,7 +937,21 @@ nlohmann::json DASHWorkSource::embedded_arm_status_json() const
     // BEFORE the lock, deliberately -- see serve_staleness_json().
     j["serve_staleness"] = serve_staleness_json();
 
-    std::lock_guard<std::mutex> lk(serve_gate_mutex_);
+    // TRY_LOCK, not lock_guard. serve_gate_mutex_ is taken by the SERVE PATH
+    // (note_arm_decision, :759; the found-block ledger, :1478). Blocking here
+    // meant the whole status response waited on the very path this lane exists
+    // to report on -- during the exact saturation the sentinel detects, the
+    // endpoint hung with it. A status surface must degrade with a NAMED reason,
+    // never hang: the staleness block above is already composed and is returned
+    // regardless, and the arm block says which condition denied it.
+    std::unique_lock<std::mutex> lk(serve_gate_mutex_, std::try_to_lock);
+    if (!lk.owns_lock()) {
+        j["arm"]               = "unknown";
+        j["no_work_reason"]    = "status-serve-gate-busy";
+        j["no_work_value"]     = "n/a";
+        j["no_work_threshold"] = "n/a";
+        return j;
+    }
     if (!arm_ever_observed_) {
         j["arm"]               = "unknown";
         j["no_work_reason"]    = "no-template-sourced-yet";

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -539,6 +539,45 @@ public:
     /// first template has been sourced -- never a fabricated "ok".
     nlohmann::json embedded_arm_status_json() const;
 
+    // ── SERVE-STALENESS SENTINEL (2026-08-07 dead-height incident) ──────────
+    //
+    // For one hour this node handed h=2518006 to 26 rigs while the chain was at
+    // h=2518028, and nothing said so. The reason no existing signal could fire
+    // is that every one of them compares the node against ITSELF — see the
+    // catalogue in coin/serve_staleness.hpp. The missing datum is exactly this
+    // pair: the height we ACTUALLY handed out, and an INDEPENDENTLY observed
+    // height to compare it against.
+    //
+    // Both halves are plain relaxed atomics on purpose. The reader is an
+    // off-`ioc` sentinel thread and the HTTP status surface, and during the
+    // incident the io thread held template_mutex_ across the ~733 ms pre-emit
+    // gate — so a status path that takes ANY lock the serve path holds is dark
+    // at precisely the moment it is needed. Relaxed is sufficient: these feed a
+    // >=120 s sustain window, not a decision, and a torn read would at worst
+    // delay one poll.
+    //
+    // REPORT-ONLY. Nothing reads these back into a serve decision, an arm
+    // choice, or a template byte; the stores are pure observation.
+
+    /// Height of the last template actually handed to a miner (0 = none yet).
+    uint32_t last_served_height() const
+    { return last_served_height_.load(std::memory_order_relaxed); }
+
+    /// Steady-clock ms at which that happened (0 = none yet).
+    int64_t last_served_at_ms() const
+    { return last_served_at_ms_.load(std::memory_order_relaxed); }
+
+    /// Sentinel -> status surface. Publishes what an INDEPENDENT source said
+    /// the chain height was, when it said it, which source answered, and the
+    /// sentinel's own verdict. Called only from the sentinel thread; takes no
+    /// lock. `observed_height == 0` means "no source answered", which is NOT
+    /// the same claim as "we are current" and must never be rendered as one.
+    void note_serve_observation(uint32_t observed_height,
+                                int64_t observed_at_ms,
+                                const std::string& source,
+                                bool stale,
+                                int64_t stale_age_ms) const;
+
 private:
     /// Record ONE arm-selection outcome and, if the rate policy says so, emit
     /// the single named line. `why` MUST be the report the selecting branch
@@ -546,6 +585,16 @@ private:
     void note_arm_decision(bool served_embedded,
                            const coin::DeclineReport& why,
                            uint32_t height) const;
+
+    /// Record that height `h` was just handed to a miner. Two relaxed stores;
+    /// no allocation, no lock, no branch on coin state. This is the ONLY
+    /// addition to the serve path and it strictly adds observation — it cannot
+    /// change which template is chosen or a single byte of it.
+    void note_served_height(uint32_t h) const;
+
+    /// The lock-free half of the operator surface, composed before
+    /// embedded_arm_status_json takes serve_gate_mutex_.
+    nlohmann::json serve_staleness_json() const;
 
     // External dependencies (non-owning references) -- see Lifetime note.
     const coin::NodeCoinState&  coin_state_;    ///< embedded work arm (populated -> Embedded)
@@ -586,6 +635,20 @@ private:
     mutable coin::DeclineReport     last_decline_;
     mutable bool                    last_arm_embedded_{false};
     mutable bool                    arm_ever_observed_{false};
+
+    // ── Serve-staleness observation (lock-free by requirement) ─────────────
+    // Written on the serve path (get_current_work_template /
+    // build_connection_coinbase) and by the sentinel thread; read by the
+    // sentinel and by embedded_arm_status_json BEFORE it takes any lock.
+    // `observed_src_` is an index rather than a string precisely so the whole
+    // block stays atomic: 0=none 1=rpc 2=peer 3=hdr 4=other (serve_src_name).
+    mutable std::atomic<uint32_t> last_served_height_{0};
+    mutable std::atomic<int64_t>  last_served_at_ms_{0};
+    mutable std::atomic<uint32_t> observed_height_{0};
+    mutable std::atomic<int64_t>  observed_at_ms_{0};
+    mutable std::atomic<int>      observed_src_{0};
+    mutable std::atomic<bool>     serve_stale_{false};
+    mutable std::atomic<int64_t>  serve_stale_age_ms_{0};
 
     // Atomic state. work_generation_ is mutable: the const template-cache
     // resolve (cached_work) bumps it when a refresh observes a moved tip.

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -567,16 +567,51 @@ public:
     int64_t last_served_at_ms() const
     { return last_served_at_ms_.load(std::memory_order_relaxed); }
 
+    /// One sentinel poll, as published to the operator surface.
+    ///
+    /// EVERY AGE IS ITS OWN FIELD. The previous shape carried a single
+    /// `stale_age_ms` that the sentinel overwrote with whichever sub-check had
+    /// fired, so the same operator field meant io-silence on one poll and
+    /// height-skew on the next. An operator field whose meaning depends on
+    /// which branch fired is how the 2026-08-07 confusion started.
+    /// `stale_age_ms` here is the age of the condition named by `stale_check`,
+    /// and nothing else.
+    struct ServeStalenessReport {
+        uint32_t    observed_height{0};
+        int64_t     observed_at_ms{0};
+        std::string observed_src{"none"};
+        /// D2 had an INDEPENDENT height this poll and therefore ran at all.
+        /// False is published as an explicit "unavailable" on the surface —
+        /// never as "no skew", which would be the node vouching for itself.
+        bool        d2_armed{false};
+        bool        stale{false};
+        std::string stale_check{"none"};   ///< names which condition `stale` is.
+        int64_t     stale_age_ms{0};       ///< age of THAT condition only.
+        int64_t     io_silent_ms{0};       ///< D1, always populated.
+        int64_t     skew_age_ms{0};        ///< D2, always populated.
+        int64_t     serve_quiet_ms{0};     ///< D3, always populated.
+    };
+
     /// Sentinel -> status surface. Publishes what an INDEPENDENT source said
     /// the chain height was, when it said it, which source answered, and the
-    /// sentinel's own verdict. Called only from the sentinel thread; takes no
-    /// lock. `observed_height == 0` means "no source answered", which is NOT
-    /// the same claim as "we are current" and must never be rendered as one.
-    void note_serve_observation(uint32_t observed_height,
-                                int64_t observed_at_ms,
-                                const std::string& source,
-                                bool stale,
-                                int64_t stale_age_ms) const;
+    /// sentinel's own standing verdict. Called only from the sentinel thread;
+    /// takes no lock. `observed_height == 0` means "no source answered", which
+    /// is NOT the same claim as "we are current" and must never be rendered as
+    /// one.
+    void note_serve_observation(const ServeStalenessReport& r) const;
+
+    /// The served-vs-observed staleness block, composed from RELAXED ATOMICS
+    /// ONLY — no mutex is taken anywhere on this path.
+    ///
+    /// PUBLIC on purpose. embedded_arm_status_json() also embeds it, but that
+    /// function additionally reads the arm bits behind serve_gate_mutex_, a
+    /// lock the SERVE PATH holds (note_arm_decision, work_source.cpp:759). A
+    /// status surface reachable only through a lock the failing path holds goes
+    /// dark exactly when it is needed, which is the failure this whole lane is
+    /// about. /api/node_topology calls THIS directly (main_dash.cpp), so the
+    /// staleness block is reachable with zero locks even if the arm block is
+    /// contended.
+    nlohmann::json serve_staleness_json() const;
 
 private:
     /// Record ONE arm-selection outcome and, if the rate policy says so, emit
@@ -591,10 +626,6 @@ private:
     /// addition to the serve path and it strictly adds observation — it cannot
     /// change which template is chosen or a single byte of it.
     void note_served_height(uint32_t h) const;
-
-    /// The lock-free half of the operator surface, composed before
-    /// embedded_arm_status_json takes serve_gate_mutex_.
-    nlohmann::json serve_staleness_json() const;
 
     // External dependencies (non-owning references) -- see Lifetime note.
     const coin::NodeCoinState&  coin_state_;    ///< embedded work arm (populated -> Embedded)
@@ -647,8 +678,16 @@ private:
     mutable std::atomic<uint32_t> observed_height_{0};
     mutable std::atomic<int64_t>  observed_at_ms_{0};
     mutable std::atomic<int>      observed_src_{0};
+    mutable std::atomic<bool>     serve_d2_armed_{false};
     mutable std::atomic<bool>     serve_stale_{false};
+    // Index of the check `serve_stale_` refers to (StaleServeCheck ordering:
+    // 0=none 1=io-silence 2=height-skew 3=serve-silence). A NAMED check plus a
+    // per-check age, rather than one age field that silently changed meaning.
+    mutable std::atomic<int>      serve_stale_check_{0};
     mutable std::atomic<int64_t>  serve_stale_age_ms_{0};
+    mutable std::atomic<int64_t>  serve_io_silent_ms_{0};
+    mutable std::atomic<int64_t>  serve_skew_age_ms_{0};
+    mutable std::atomic<int64_t>  serve_quiet_ms_{0};
 
     // Atomic state. work_generation_ is mutable: the const template-cache
     // resolve (cached_work) bumps it when a refresh observes a moved tip.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -973,8 +973,19 @@ if (BUILD_TESTING AND GTest_FOUND)
     # Includes coin/zmq_tip_notify.cpp directly (NOT the C2POOL_ZMQ-guarded
     # subscriber — only the pure TipHashDedup / frame-decode helpers) so the
     # ZMQ hashblock instant-tip-notify KAT links without libzmq.
+    # SERVE-STALENESS SENTINEL rides this EXISTING allowlisted target rather
+    # than adding two of its own: a fresh add_executable absent from the
+    # build.yml --target allowlist is the #143 NOT_BUILT sentinel that "passes"
+    # by never being built (same reasoning as test_dash_node_coin_state above).
+    #   * ..._seam.cpp   -- the RED witness: compiles on master, fails there,
+    #                       because nothing publishes a serve_staleness block.
+    #   * ..._unit.cpp   -- the detector itself, driven off injected clock and
+    #                       height providers, including the deleted-guard
+    #                       mutation case.
     add_executable(test_dash_stratum_work_source
         test_dash_stratum_work_source.cpp
+        test_dash_serve_staleness_seam.cpp
+        test_dash_serve_staleness_unit.cpp
         ${CMAKE_SOURCE_DIR}/src/impl/dash/coin/zmq_tip_notify.cpp)
     target_link_libraries(test_dash_stratum_work_source PRIVATE
         GTest::gtest_main GTest::gtest
@@ -983,6 +994,9 @@ if (BUILD_TESTING AND GTest_FOUND)
         ${Boost_LIBRARIES}
     )
     target_link_libraries(test_dash_stratum_work_source PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
+    target_compile_definitions(test_dash_stratum_work_source PRIVATE
+        DASH_WORK_SOURCE_SRC="${CMAKE_CURRENT_SOURCE_DIR}/../src/impl/dash/stratum/work_source.cpp"
+        DASH_MAIN_SRC="${CMAKE_CURRENT_SOURCE_DIR}/../src/c2pool/main_dash.cpp")
     gtest_add_tests(test_dash_stratum_work_source "" AUTO)
 
     # CoinStateMaintainer: drives NodeCoinState off async tip/MN/mempool update

--- a/test/test_dash_serve_staleness_seam.cpp
+++ b/test/test_dash_serve_staleness_seam.cpp
@@ -54,6 +54,7 @@
 #include <gtest/gtest.h>
 
 #include <cstdio>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -310,6 +311,75 @@ TEST(DashServeStalenessSeam, NodeTopologyReadsTheLockFreeAccessorDirectly)
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// A HEIGHT OF ZERO IS NOT A SERVE — note_served_height's do-not-fabricate rule
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// work_source.cpp:807 refuses to record h == 0. Round-2 mutation: deleting that
+// line left the whole suite green, even though the comment beside it calls it
+// load-bearing. It is the SAME do-not-fabricate rule this branch enforces for
+// `behind` (absent, never 0, when either side is unknown) and for D2 (declines
+// rather than self-comparing): a number nobody actually observed must not be
+// published as if it had been.
+//
+// Zero is reachable. DashWorkData default-constructs m_height to 0, and both
+// serve paths hand cached_work()'s snapshot straight to note_served_height —
+// so a degenerate or not-yet-filled template walks into it. If it were
+// recorded, the detector this whole lane exists for would be fed a fabricated
+// pair: served_height=0 with a served_at of NOW. That is worse than no data,
+// because served_age_s would read "we served a template a moment ago" about a
+// node that served nothing, and it would OVERWRITE the record of the last real
+// height — the one number the 2026-08-07 incident proved nothing else has.
+TEST(DashServeStalenessSeam, ZeroHeightIsNeitherFabricatedNorAllowedToClobber)
+{
+    dash::coin::NodeCoinState cs;
+    auto height = std::make_shared<uint32_t>(0u);
+    auto fallback = [height]() -> dash::coin::DashWorkData {
+        return seam_work(*height);
+    };
+    auto submit = [](const std::vector<unsigned char>&, uint32_t, bool) {
+        return true;
+    };
+    dash::stratum::DASHWorkSource ws(cs, fallback, submit,
+                                     core::stratum::StratumConfig{},
+                                     /*is_testnet=*/false);
+
+    // ── (a) NOT FABRICATED. A zero-height template goes out; nothing about it
+    // may be recorded as a serve. served_age_s is the falsifiable half: with
+    // the guard the record is untouched and the age renders -1 ("never"); with
+    // the guard deleted, last_served_at_ms_ is stamped with now and the surface
+    // claims a serve that did not happen.
+    ws.get_current_work_template();
+    ws.build_connection_coinbase(uint256::ZERO, "", {}, {});
+    {
+        const nlohmann::json ss = ws.serve_staleness_json();
+        EXPECT_EQ(ss.value("served_height", 99u), 0u)   << ss.dump();
+        EXPECT_EQ(ss.value("served_age_s", 0), -1)
+            << "a template with no height was recorded as a serve, so the "
+               "surface says we handed work out moments ago when we handed out "
+               "nothing: " << ss.dump();
+    }
+
+    // ── (b) NOT ALLOWED TO CLOBBER. A real height is served, and then the
+    // template degenerates back to zero. The record of the last height that
+    // ACTUALLY reached a miner must survive — it is the only such record in the
+    // process, which is the entire premise of this lane.
+    *height = 2518006u;
+    ws.invalidate_template_cache("test");
+    ASSERT_EQ(ws.get_current_work_template().value("height", 0u), 2518006u);
+    ASSERT_EQ(ws.serve_staleness_json().value("served_height", 0u), 2518006u);
+
+    *height = 0u;
+    ws.invalidate_template_cache("test");
+    ws.get_current_work_template();
+    ws.build_connection_coinbase(uint256::ZERO, "", {}, {});
+
+    const nlohmann::json ss = ws.serve_staleness_json();
+    EXPECT_EQ(ss.value("served_height", 0u), 2518006u)
+        << "a zero-height template ERASED the record of the last height a miner "
+           "actually got: " << ss.dump();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 // C1 / C3 / C6 ON THE SURFACE — the sentinel's standing verdict, as published
 // ═══════════════════════════════════════════════════════════════════════════
 //
@@ -354,7 +424,12 @@ TEST(DashServeStalenessSeam, PublishedBlockNamesTheCheckAndKeepsAgesApart)
     r.stale_age_ms    = 3600000;
     r.io_silent_ms    = 3600000;
     r.skew_age_ms     = 0;
-    r.serve_quiet_ms  = 900;
+    // 7 s, NOT the 900 ms this test used to carry. 900 integer-divides to a
+    // published 0, which is indistinguishable from note_serve_observation
+    // never storing the field at all -- and the round-2 mutation
+    // (serve_quiet_ms_.store(0)) proved it: the suite stayed green. Every
+    // published age needs a value whose plumbing can be seen end to end.
+    r.serve_quiet_ms  = 7000;
     ws.note_serve_observation(r);
 
     const nlohmann::json ss = ws.serve_staleness_json();
@@ -364,7 +439,7 @@ TEST(DashServeStalenessSeam, PublishedBlockNamesTheCheckAndKeepsAgesApart)
     EXPECT_EQ(ss.value("stale_age_s", 0), 3600)      << ss.dump();
     EXPECT_EQ(ss.value("io_silent_s", 0), 3600)      << ss.dump();
     EXPECT_EQ(ss.value("skew_age_s", -1), 0)         << ss.dump();
-    EXPECT_EQ(ss.value("serve_quiet_s", -1), 0)      << ss.dump();
+    EXPECT_EQ(ss.value("serve_quiet_s", -1), 7)      << ss.dump();
     EXPECT_EQ(ss.value("d2", std::string()),
               "unavailable-no-independent-reference")
         << "D2 was blind and the surface must SAY so; rendering it as 'no skew' "
@@ -385,5 +460,15 @@ TEST(DashServeStalenessSeam, PublishedBlockNamesTheCheckAndKeepsAgesApart)
     EXPECT_EQ(ss2.value("stale_check", std::string()), "height-skew") << ss2.dump();
     EXPECT_EQ(ss2.value("stale_age_s", 0), 480)               << ss2.dump();
     EXPECT_EQ(ss2.value("io_silent_s", -1), 1)                << ss2.dump();
+    // ALL FOUR ages are asserted on a report where all four DIFFER. The round-2
+    // mutation hardwired serve_skew_age_ms_.store(0) and skew_age_s was still
+    // green, because the only assertion on it was against a report whose skew
+    // age was genuinely 0 -- an assertion that cannot disagree with the code it
+    // checks. This block sets skew_age_ms=480000 and serve_quiet_ms=7000 and
+    // now says so.
+    EXPECT_EQ(ss2.value("skew_age_s", -1), 480)               << ss2.dump();
+    EXPECT_EQ(ss2.value("serve_quiet_s", -1), 7)
+        << "a field not set by THIS report was not carried forward from the "
+           "last one -- the publisher is dropping it: " << ss2.dump();
     EXPECT_EQ(ss2.value("behind", 0u), 22u)                   << ss2.dump();
 }

--- a/test/test_dash_serve_staleness_seam.cpp
+++ b/test/test_dash_serve_staleness_seam.cpp
@@ -152,3 +152,238 @@ TEST(DashServeStalenessSeam, StalenessBlockIsBuiltBeforeAnyLockIsTaken)
            "the io thread is wedged inside the serve gate";
 #endif
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// C2 — THE PER-CONNECTION COINBASE PATH IS THE OTHER WAY A HEIGHT ESCAPES
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// A reviewer DELETED note_served_height(wd->m_height) from
+// build_connection_coinbase (work_source.cpp:1108) and the whole target stayed
+// 86/86 green — while the comment at that very site called it load-bearing.
+// A guard nothing can fail is not a guard.
+//
+// This test touches ONLY that path: it never calls get_current_work_template,
+// so the recorded served height can have come from nowhere else. Delete the
+// call and this reds.
+TEST(DashServeStalenessSeam, PerConnectionCoinbasePathRecordsTheServedHeight)
+{
+    dash::coin::NodeCoinState cs;
+    auto fallback = []() -> dash::coin::DashWorkData {
+        return seam_work(2518006u);
+    };
+    auto submit = [](const std::vector<unsigned char>&, uint32_t, bool) {
+        return true;
+    };
+
+    dash::stratum::DASHWorkSource ws(cs, fallback, submit,
+                                     core::stratum::StratumConfig{},
+                                     /*is_testnet=*/false);
+
+    // Nothing has been handed out yet.
+    ASSERT_EQ(ws.last_served_height(), 0u)
+        << "a fresh work source claimed to have already served a height";
+
+    // The per-connection path, and ONLY it. This is what StratumSession calls
+    // when a miner subscribes; on a node whose notify loop happens to be quiet
+    // it is the only way a height reaches a rig.
+    const uint256 prev_share = uint256::ZERO;
+    const std::vector<unsigned char> payout_script = {
+        0x76, 0xa9, 0x14,
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
+        0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14,
+        0x88, 0xac};
+    const auto cb = ws.build_connection_coinbase(prev_share, "00000000",
+                                                 payout_script, {});
+    ASSERT_TRUE(cb.snapshot.has_header)
+        << "the per-connection coinbase path did not produce a job at all, so "
+           "this test cannot say anything about what it recorded";
+    ASSERT_EQ(cb.snapshot.height, 2518006u);
+
+    EXPECT_EQ(ws.last_served_height(), 2518006u)
+        << "build_connection_coinbase handed h=2518006 to a miner and left NO "
+           "record of it — exactly the blindness that let 26 rigs sit on a dead "
+           "height for an hour";
+    EXPECT_GT(ws.last_served_at_ms(), 0);
+
+    // And it must reach the operator surface, not just the accessor.
+    const nlohmann::json ss = ws.serve_staleness_json();
+    EXPECT_EQ(ss.value("served_height", 0u), 2518006u) << ss.dump();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// C4 — THE STALENESS BLOCK IS REACHABLE WITHOUT THE SERVE-GATE LOCK
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// The first cut COMPOSED the block before the lock and then blocked
+// unconditionally on serve_gate_mutex_ one line later, so during the exact
+// saturation this detects the status endpoint hung with it. Composing early is
+// worthless if the only way to reach the result is through the lock.
+TEST(DashServeStalenessSeam, StalenessBlockHasItsOwnLockFreeAccessor)
+{
+    dash::coin::NodeCoinState cs;
+    auto fallback = []() -> dash::coin::DashWorkData {
+        return seam_work(2518006u);
+    };
+    auto submit = [](const std::vector<unsigned char>&, uint32_t, bool) {
+        return true;
+    };
+    dash::stratum::DASHWorkSource ws(cs, fallback, submit,
+                                     core::stratum::StratumConfig{},
+                                     /*is_testnet=*/false);
+    ws.get_current_work_template();
+
+    // Reached WITHOUT going through embedded_arm_status_json at all.
+    const nlohmann::json ss = ws.serve_staleness_json();
+    ASSERT_TRUE(ss.is_object()) << ss.dump();
+    EXPECT_EQ(ss.value("served_height", 0u), 2518006u) << ss.dump();
+    EXPECT_TRUE(ss.contains("stale"))       << ss.dump();
+    EXPECT_TRUE(ss.contains("stale_check")) << ss.dump();
+    EXPECT_TRUE(ss.contains("d2"))          << ss.dump();
+}
+
+// The lock-free property itself, pinned by source text — a lock ORDER cannot be
+// observed from outside the class, so it is read off the body that has it.
+TEST(DashServeStalenessSeam, StalenessJsonBodyTakesNoLockAtAll)
+{
+#ifndef DASH_WORK_SOURCE_SRC
+    GTEST_SKIP() << "DASH_WORK_SOURCE_SRC not defined";
+#else
+    FILE* f = std::fopen(DASH_WORK_SOURCE_SRC, "rb");
+    ASSERT_NE(f, nullptr) << DASH_WORK_SOURCE_SRC;
+    std::string src;
+    char buf[65536];
+    size_t n;
+    while ((n = std::fread(buf, 1, sizeof(buf), f)) > 0) src.append(buf, n);
+    std::fclose(f);
+
+    const size_t body = src.find("DASHWorkSource::serve_staleness_json");
+    ASSERT_NE(body, std::string::npos);
+    const size_t end = src.find("\n}", body);
+    ASSERT_NE(end, std::string::npos);
+    const std::string fn = src.substr(body, end - body);
+    EXPECT_EQ(fn.find("lock_guard"),        std::string::npos) << fn;
+    EXPECT_EQ(fn.find("unique_lock"),       std::string::npos) << fn;
+    EXPECT_EQ(fn.find("serve_gate_mutex_"), std::string::npos) << fn;
+    EXPECT_EQ(fn.find("template_mutex_"),   std::string::npos) << fn;
+
+    // And embedded_arm_status_json must not BLOCK on the serve gate either: it
+    // degrades with a named reason instead of hanging the whole response.
+    const size_t arm = src.find("DASHWorkSource::embedded_arm_status_json");
+    ASSERT_NE(arm, std::string::npos);
+    const size_t arm_end = src.find("\n}", arm);
+    ASSERT_NE(arm_end, std::string::npos);
+    const std::string armfn = src.substr(arm, arm_end - arm);
+    EXPECT_NE(armfn.find("try_to_lock"), std::string::npos)
+        << "embedded_arm_status_json blocks unconditionally on a lock the SERVE "
+           "PATH holds, so the status surface goes dark during exactly the "
+           "saturation the sentinel exists to report: " << armfn;
+    EXPECT_EQ(armfn.find("std::lock_guard<std::mutex> lk(serve_gate_mutex_)"),
+              std::string::npos)
+        << armfn;
+#endif
+}
+
+// The topology surface must read the staleness block from the LOCK-FREE
+// accessor, not dig it out of embedded_arm_status_json's result — otherwise the
+// one surface that reports serve-path saturation depends on the serve path.
+TEST(DashServeStalenessSeam, NodeTopologyReadsTheLockFreeAccessorDirectly)
+{
+#ifndef DASH_MAIN_SRC
+    GTEST_SKIP() << "DASH_MAIN_SRC not defined";
+#else
+    FILE* f = std::fopen(DASH_MAIN_SRC, "rb");
+    ASSERT_NE(f, nullptr) << DASH_MAIN_SRC;
+    std::string src;
+    char buf[65536];
+    size_t n;
+    while ((n = std::fread(buf, 1, sizeof(buf), f)) > 0) src.append(buf, n);
+    std::fclose(f);
+
+    EXPECT_NE(src.find("c[\"serve_staleness\"] = ws->serve_staleness_json();"),
+              std::string::npos)
+        << "/api/node_topology does not call the lock-free accessor";
+    EXPECT_EQ(src.find("if (arm.contains(\"serve_staleness\"))"),
+              std::string::npos)
+        << "the topology surface still sources the staleness block from the "
+           "arm status, which is gated behind serve_gate_mutex_";
+#endif
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// C1 / C3 / C6 ON THE SURFACE — the sentinel's standing verdict, as published
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// The detector-side proof lives in test_dash_serve_staleness_unit.cpp. This is
+// the other half: what the sentinel concluded has to survive the trip to JSON
+// with its per-check ages intact and D2's refusal stated rather than implied.
+TEST(DashServeStalenessSeam, PublishedBlockNamesTheCheckAndKeepsAgesApart)
+{
+    dash::coin::NodeCoinState cs;
+    auto fallback = []() -> dash::coin::DashWorkData {
+        return seam_work(2518006u);
+    };
+    auto submit = [](const std::vector<unsigned char>&, uint32_t, bool) {
+        return true;
+    };
+    dash::stratum::DASHWorkSource ws(cs, fallback, submit,
+                                     core::stratum::StratumConfig{},
+                                     /*is_testnet=*/false);
+    ws.get_current_work_template();
+
+    // Before any sentinel poll: no verdict, and D2 explicitly unavailable
+    // rather than silently "not stale".
+    {
+        const nlohmann::json ss = ws.serve_staleness_json();
+        EXPECT_EQ(ss.value("stale", true), false)         << ss.dump();
+        EXPECT_EQ(ss.value("stale_check", std::string()), "none") << ss.dump();
+        EXPECT_EQ(ss.value("d2", std::string()),
+                  "unavailable-no-independent-reference") << ss.dump();
+        EXPECT_FALSE(ss.contains("behind")) << ss.dump();
+    }
+
+    // The incident as it presented: D1 standing for an hour, D2 blind because
+    // its mirror froze with the io thread, D3 quiet because templates were
+    // still going out.
+    dash::stratum::DASHWorkSource::ServeStalenessReport r;
+    r.observed_height = 2518006u;      // frozen mirror == the dead height
+    r.observed_at_ms  = 1000;
+    r.observed_src    = "peer";
+    r.d2_armed        = false;         // no independent reference this poll
+    r.stale           = true;
+    r.stale_check     = "io-silence";
+    r.stale_age_ms    = 3600000;
+    r.io_silent_ms    = 3600000;
+    r.skew_age_ms     = 0;
+    r.serve_quiet_ms  = 900;
+    ws.note_serve_observation(r);
+
+    const nlohmann::json ss = ws.serve_staleness_json();
+    EXPECT_EQ(ss.value("stale", false), true)
+        << "the surface reported health while the log alarmed: " << ss.dump();
+    EXPECT_EQ(ss.value("stale_check", std::string()), "io-silence") << ss.dump();
+    EXPECT_EQ(ss.value("stale_age_s", 0), 3600)      << ss.dump();
+    EXPECT_EQ(ss.value("io_silent_s", 0), 3600)      << ss.dump();
+    EXPECT_EQ(ss.value("skew_age_s", -1), 0)         << ss.dump();
+    EXPECT_EQ(ss.value("serve_quiet_s", -1), 0)      << ss.dump();
+    EXPECT_EQ(ss.value("d2", std::string()),
+              "unavailable-no-independent-reference")
+        << "D2 was blind and the surface must SAY so; rendering it as 'no skew' "
+           "is the node vouching for itself: " << ss.dump();
+
+    // A later poll with a real outside reference flips D2 to armed, and the two
+    // ages stay separate.
+    r.d2_armed        = true;
+    r.observed_height = 2518028u;
+    r.stale_check     = "height-skew";
+    r.stale_age_ms    = 480000;
+    r.skew_age_ms     = 480000;
+    r.io_silent_ms    = 1000;
+    ws.note_serve_observation(r);
+
+    const nlohmann::json ss2 = ws.serve_staleness_json();
+    EXPECT_EQ(ss2.value("d2", std::string()), "armed")        << ss2.dump();
+    EXPECT_EQ(ss2.value("stale_check", std::string()), "height-skew") << ss2.dump();
+    EXPECT_EQ(ss2.value("stale_age_s", 0), 480)               << ss2.dump();
+    EXPECT_EQ(ss2.value("io_silent_s", -1), 1)                << ss2.dump();
+    EXPECT_EQ(ss2.value("behind", 0u), 22u)                   << ss2.dump();
+}

--- a/test/test_dash_serve_staleness_seam.cpp
+++ b/test/test_dash_serve_staleness_seam.cpp
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SEAM red witness — the operator surface must carry a SERVED-vs-OBSERVED
+// staleness block.
+//
+// ── THE DEFECT THIS PINS (hotel 109.161.52.148, 2026-08-07 mainnet) ─────────
+//
+// For one hour the node handed h=2518006 to 26 rigs while the network was at
+// h=2518028. Every share those rigs produced was unpayable, and NOTHING in the
+// process said so. The reason is structural, not an oversight: every staleness
+// signal that exists compares the node against ITSELF.
+//
+//   * kStaleAfter / kRetryAfter (work_source.cpp:66, :69) are cache TTLs. They
+//     schedule a RE-SOURCE; they never emit a verdict, and the executor path
+//     deliberately serves the stale cache while the refresh is in flight
+//     (work_source.cpp:864-889, :924). "Stale" there is a routine state, not a
+//     fault, so it cannot be alarmed on without misfiring on every refresh.
+//   * [EMBED-STATUS] (main_dash.cpp:6400-6525) is the periodic health line. It
+//     reports describe_decline() / have_tip / payee_cursor / hdr_tip — all read
+//     out of our OWN NodeCoinState and header chain. When the io thread froze,
+//     that state froze with it AND the timer that prints the line lives on the
+//     same `ioc`, so the line simply stopped.
+//   * SmlResyncWatchdog (coin/sml_resync_watchdog.hpp) does compare two things
+//     over time — but they are the SML and OUR tip. A frozen tip makes the SML
+//     look perfectly current.
+//   * The shadow oracle VOIDs a sample on tip-skew by design
+//     (coin/embedded_oracle_shadow.hpp:788-791), so the exact condition here is
+//     the one it refuses to score.
+//   * node_topology already carries header_height / target_height / synced
+//     (main_dash.cpp:3271-3286) — but only as fields recomputed when a browser
+//     asks. Nothing compares them and nothing raises anything.
+//
+// So the missing thing is precisely one thing: a SERVED height, recorded where
+// the template is actually handed out, compared against an INDEPENDENTLY
+// observed height, with an age. This test pins that field's existence on the
+// one surface every operator path already reads (embedded_arm_status_json ->
+// node_topology_fn, main_dash.cpp:3286-3288).
+//
+// RED ON MASTER: `grep -rn serve_staleness src/` returns nothing on master;
+// embedded_arm_status_json publishes only arm / no_work_reason / no_work_value
+// / no_work_threshold (work_source.cpp:796-819). This file compiles against
+// master and FAILS there. That failing run is the witness.
+//
+// This rides the EXISTING allowlisted test_dash_stratum_work_source target on
+// purpose: a new add_executable absent from the build.yml --target allowlist is
+// the #143 NOT_BUILT sentinel that passes by never being built (see the note at
+// test/CMakeLists.txt:922-925).
+
+#include <impl/dash/stratum/work_source.hpp>
+#include <impl/dash/coin/node_coin_state.hpp>
+
+#include <core/stratum_work_source.hpp>
+#include <core/uint256.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+namespace {
+
+// A minimal dashd-fallback template. Nothing here needs to be consensus-real:
+// the surface under test is a REPORTING field, and the point is that it exists
+// and carries the served height at all.
+dash::coin::DashWorkData seam_work(uint32_t height)
+{
+    dash::coin::DashWorkData w;
+    w.m_version = 0x20000000;
+    w.m_previous_block.SetHex(
+        "0000000000000000abcdef0123456789abcdef0123456789abcdef0123456789");
+    w.m_height         = height;
+    w.m_coinbase_value = 100000000ull;
+    w.m_bits           = 0x1e0ffff0u;
+    w.m_curtime        = 1700000000u;
+    return w;
+}
+
+}  // namespace
+
+// The incident height, verbatim. A served template must leave a RECORD of the
+// height it served, on a surface that is readable without the io thread.
+TEST(DashServeStalenessSeam, StatusJsonCarriesServedHeightAndObservedSkew)
+{
+    dash::coin::NodeCoinState cs;                 // unpopulated -> dashd arm
+    auto fallback = []() -> dash::coin::DashWorkData {
+        return seam_work(2518006u);               // the DEAD height, as served
+    };
+    auto submit = [](const std::vector<unsigned char>&, uint32_t, bool) {
+        return true;
+    };
+
+    dash::stratum::DASHWorkSource ws(cs, fallback, submit,
+                                     core::stratum::StratumConfig{},
+                                     /*is_testnet=*/false);
+
+    // Serve one template, exactly as StratumSession::send_notify_work does.
+    auto tmpl = ws.get_current_work_template();
+    ASSERT_FALSE(tmpl.empty());
+    ASSERT_EQ(tmpl.value("height", 0u), 2518006u);
+
+    // The operator surface. On master this object does not exist.
+    const nlohmann::json st = ws.embedded_arm_status_json();
+    ASSERT_TRUE(st.contains("serve_staleness"))
+        << "embedded_arm_status_json publishes NO served-vs-observed block, so "
+           "an hour of dead-height serving is invisible to every reader of "
+           "/api/node_topology. Status was: " << st.dump();
+
+    const nlohmann::json& ss = st["serve_staleness"];
+    ASSERT_TRUE(ss.is_object()) << ss.dump();
+
+    // The three fields that make the claim falsifiable: what we served, what
+    // the world says, and whether that pair is a fault.
+    EXPECT_TRUE(ss.contains("served_height"))   << ss.dump();
+    EXPECT_TRUE(ss.contains("observed_height")) << ss.dump();
+    EXPECT_TRUE(ss.contains("stale"))           << ss.dump();
+
+    // And served_height must be the height we ACTUALLY handed out -- not a
+    // re-read of coin state (which is exactly what froze), and not zero.
+    EXPECT_EQ(ss.value("served_height", 0u), 2518006u)
+        << "served_height must be recorded ON the serve path, from the template "
+           "that was handed out: " << ss.dump();
+}
+
+// The surface must be readable WITHOUT the template lock. During the freeze the
+// io thread held template_mutex_ across the 733 ms pre-emit gate
+// (work_source.cpp:836-853); a status reader that waits on that lock is dark at
+// exactly the moment it is needed. Pinned by source text because a lock
+// ordering cannot be observed from outside.
+TEST(DashServeStalenessSeam, StalenessBlockIsBuiltBeforeAnyLockIsTaken)
+{
+#ifndef DASH_WORK_SOURCE_SRC
+    GTEST_SKIP() << "DASH_WORK_SOURCE_SRC not defined";
+#else
+    FILE* f = std::fopen(DASH_WORK_SOURCE_SRC, "rb");
+    ASSERT_NE(f, nullptr) << DASH_WORK_SOURCE_SRC;
+    std::string src;
+    char buf[65536];
+    size_t n;
+    while ((n = std::fread(buf, 1, sizeof(buf), f)) > 0) src.append(buf, n);
+    std::fclose(f);
+
+    const size_t body = src.find("DASHWorkSource::embedded_arm_status_json");
+    ASSERT_NE(body, std::string::npos);
+    const size_t pub  = src.find("serve_staleness", body);
+    ASSERT_NE(pub, std::string::npos)
+        << "embedded_arm_status_json never publishes a serve_staleness block";
+    const size_t lock = src.find("serve_gate_mutex_", body);
+    ASSERT_NE(lock, std::string::npos);
+    EXPECT_LT(pub, lock)
+        << "the staleness block must be composed from lock-free atomics BEFORE "
+           "serve_gate_mutex_ is taken, so the status surface stays live while "
+           "the io thread is wedged inside the serve gate";
+#endif
+}

--- a/test/test_dash_serve_staleness_unit.cpp
+++ b/test/test_dash_serve_staleness_unit.cpp
@@ -291,7 +291,8 @@ TEST(DashServeStaleness, IoHeartbeatSilenceIsSilentWhenTheGuardIsNeutered)
 TEST(DashServeStaleness, ServeSilenceAlarmsOnlyWhileSessionsAreAttached)
 {
     FakeClock c;
-    ServeStalenessSentinel sen{ServeStalenessConfig{}};
+    const ServeStalenessConfig cfg{};          // serve_silence_ms = 300 s
+    ServeStalenessSentinel sen{cfg};
 
     for (int i = 0; i < 4; ++i) {
         c.advance(15000);
@@ -311,15 +312,24 @@ TEST(DashServeStaleness, ServeSilenceAlarmsOnlyWhileSessionsAreAttached)
         s.observed_src    = "rpc";
         s.observed_independent = true;
         s.sessions        = 0;
-        ASSERT_FALSE(sen.poll(s).fired) << "alarmed on an idle pool";
+        const auto v = sen.poll(s);
+        ASSERT_FALSE(v.fired)  << "alarmed on an idle pool";
+        // The SURFACE must agree with the log here too: an idle pool is not a
+        // stale one, and the D3 watchdog is disarmed so its age is not running.
+        ASSERT_FALSE(v.stale)  << "an idle pool was published as stale";
+        ASSERT_EQ(v.serve_quiet_ms, 0)
+            << "the D3 age ran while the check was disarmed";
     }
     EXPECT_EQ(sen.serve_alarms(), 0u);
 
     // Miners attach and STILL nothing is served -> that is a fault.
     bool fired = false;
     std::string line;
+    dash::coin::ServeStalenessVerdict at_fire{};
+    int polls_after_attach = 0;
     for (int i = 0; i < 60 && !fired; ++i) {
         c.advance(15000);
+        ++polls_after_attach;
         ServeStalenessSample s;
         s.now_ms          = c.now();
         s.io_heartbeat_ms = c.now();
@@ -330,14 +340,44 @@ TEST(DashServeStaleness, ServeSilenceAlarmsOnlyWhileSessionsAreAttached)
         s.observed_independent = true;
         s.sessions        = 26;
         const auto v = sen.poll(s);
+        // ── D3 CARRIES A REAL AGE, POLL BY POLL ─────────────────────────────
+        // Round-2 mutation: hardwiring `v.serve_quiet_ms = 0`
+        // (serve_staleness.hpp:333) left the suite green, because the only
+        // assertion on this field anywhere was EXPECT_LT(..., 20000) — which 0
+        // satisfies. One of the three "every check gets its own field" fields
+        // was never shown to carry a value at all. It is the watchdog's own
+        // elapsed clock, so it must equal the time since attach exactly.
+        EXPECT_EQ(v.serve_quiet_ms,
+                  static_cast<int64_t>(polls_after_attach - 1) * 15000)
+            << "D3 age at poll " << polls_after_attach;
         if (v.fired) {
-            fired = true;
-            line  = v.line;
+            fired   = true;
+            line    = v.line;
+            at_fire = v;
             EXPECT_EQ(v.check, StaleServeCheck::ServeSilence) << v.line;
         }
     }
     ASSERT_TRUE(fired) << "26 rigs attached, no template for 15 minutes, silence";
     EXPECT_NE(line.find("check=serve-silence"), std::string::npos) << line;
+
+    // ── THE SURFACE, NOT ONLY THE LOG ───────────────────────────────────────
+    // Round-2 mutation: `} else if (serve_cond) {` -> `} else if (false) {`
+    // (serve_staleness.hpp:350) left the suite green. This test asserted only
+    // v.fired — the LOG — so the D3 arm of the operator-visible verdict was
+    // entirely uncovered and could be deleted silently. Exactly the C1 defect
+    // (log knows, surface says healthy) reintroduced one sub-check at a time.
+    EXPECT_TRUE(at_fire.stale)
+        << "26 rigs attached, nothing served for 5 minutes, and the status "
+           "surface still reported health";
+    EXPECT_EQ(at_fire.stale_check, StaleServeCheck::ServeSilence);
+    EXPECT_EQ(at_fire.stale_age_ms, at_fire.serve_quiet_ms)
+        << "stale_age_ms must be the age of the check stale_check NAMES";
+    EXPECT_GE(at_fire.serve_quiet_ms, cfg.serve_silence_ms)
+        << "D3 raised before its own threshold";
+    // D1 and D2 stayed quiet the whole time, so their ages must NOT have been
+    // borrowed to satisfy the above.
+    EXPECT_EQ(at_fire.io_silent_ms, 0) << "io heartbeat was ticking every poll";
+    EXPECT_EQ(at_fire.skew_age_ms, 0)  << "served == observed the whole time";
 }
 
 // ── The detector must not go permanently loud once raised. A condition that
@@ -679,6 +719,7 @@ TEST(DashServeStaleness, DTwoRunsAndAlarmsOnceTheReferenceIsIndependent)
 
     bool fired = false;
     bool armed_seen = false;
+    dash::coin::ServeStalenessVerdict at_fire{};
     for (int i = 0; i < 240 && !fired; ++i) {
         c.advance(15000);
         ServeStalenessSample s;
@@ -693,7 +734,8 @@ TEST(DashServeStaleness, DTwoRunsAndAlarmsOnceTheReferenceIsIndependent)
         const auto v = sen.poll(s);
         if (v.d2_armed) armed_seen = true;
         if (v.fired) {
-            fired = true;
+            fired   = true;
+            at_fire = v;
             EXPECT_EQ(v.check, StaleServeCheck::HeightSkew) << v.line;
         }
     }
@@ -701,6 +743,31 @@ TEST(DashServeStaleness, DTwoRunsAndAlarmsOnceTheReferenceIsIndependent)
     ASSERT_TRUE(fired)
         << "with a genuinely independent reference the 22-block skew raised "
            "nothing — the refusal test proves only that dead code is dead";
+
+    // ── THE SURFACE, NOT ONLY THE LOG ───────────────────────────────────────
+    // Round-2 mutation: `} else if (skew_sustained) {` -> `} else if (false) {`
+    // in the standing-conditions block (serve_staleness.hpp:346) left the whole
+    // suite green, because every D2 test asserted `fired` (the LOG) and the one
+    // test that touched `stale` asserted it FALSE — which a hardwired-false arm
+    // satisfies vacuously. D2 is the sub-check for this lane's entire reason to
+    // exist: a dead height being served while the io thread is alive and
+    // answering. Its contribution to the operator-visible verdict must be
+    // asserted POSITIVELY, or it can be deleted and nothing notices.
+    //
+    // The refusal test (DTwoRefusesToRunWithoutAnIndependentReference) asserts
+    // ASSERT_FALSE(v.stale) on the same drive with observed_independent=false.
+    // These two together are the pair: same 22-block skew, opposite verdict,
+    // and the ONLY difference is where the reference came from.
+    EXPECT_TRUE(at_fire.stale)
+        << "the log alarmed on a 22-block sustained skew and the STATUS SURFACE "
+           "still said healthy — that exact disagreement is what left "
+           "/api/node_topology clean for the whole incident hour";
+    EXPECT_EQ(at_fire.stale_check, StaleServeCheck::HeightSkew)
+        << "stale is standing but names the wrong check";
+    EXPECT_EQ(at_fire.stale_age_ms, at_fire.skew_age_ms)
+        << "stale_age_ms must be the age of the check stale_check NAMES";
+    EXPECT_GE(at_fire.skew_age_ms, 120000)
+        << "the sustain window is 120 s; a shorter age means D2 raised early";
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -766,6 +833,44 @@ TEST(DashServeStaleness, EachCheckCarriesItsOwnAgeAndTheVerdictNamesWhichOne)
         << " vs " << v.io_silent_ms << "), which is the whole point";
     EXPECT_GE(v.skew_age_ms, 600000);
     EXPECT_LE(v.io_silent_ms, 130000);
-    // D3 never raised: templates kept going out the whole time.
-    EXPECT_LT(v.serve_quiet_ms, 20000);
+    // D3 never raised: templates kept going out the whole time, so its age is
+    // EXACTLY zero rather than merely small.
+    EXPECT_EQ(v.serve_quiet_ms, 0);
+
+    // ── PHASE 3: ALL THREE AGES RUNNING AT ONCE, AND ALL THREE DIFFERENT ────
+    // The two phases above leave serve_quiet_ms pinned at 0, which is why the
+    // round-2 mutation `v.serve_quiet_ms = 0` (serve_staleness.hpp:333) went
+    // unnoticed: a field that is only ever asserted to be small is not
+    // demonstrated to carry anything. Templates now stop going out as well —
+    // 90 s of it, deliberately BELOW D3's 300 s threshold, so D3 does not fire
+    // and the only thing under test is whether its age is real and its own.
+    const int64_t frozen_serve = c.now();
+    for (int i = 0; i < 6; ++i) {
+        c.advance(15000);
+        ServeStalenessSample s;
+        s.now_ms          = c.now();
+        s.io_heartbeat_ms = frozen_beat;    // io still pegged
+        s.served_height   = kServedDead;
+        s.served_at_ms    = frozen_serve;   // and now nothing is served either
+        s.observed_height = kNetwork;
+        s.observed_src    = "peer";
+        s.observed_independent = true;
+        s.sessions        = 26;
+        v = sen.poll(s);
+    }
+
+    // Three conditions, three ages, three DIFFERENT numbers, from one poll.
+    EXPECT_EQ(v.serve_quiet_ms, 90000)  << "D3 age is not the time since the "
+                                           "last template left";
+    EXPECT_EQ(v.io_silent_ms,  210000)  << "D1 age is not the time since the "
+                                           "heartbeat froze";
+    EXPECT_GE(v.skew_age_ms,   690000);
+    EXPECT_NE(v.serve_quiet_ms, v.io_silent_ms);
+    EXPECT_NE(v.serve_quiet_ms, v.skew_age_ms);
+    EXPECT_NE(v.io_silent_ms,   v.skew_age_ms);
+    // D1 still outranks, and stale_age_ms still tracks the check it names --
+    // NOT the largest age, and not the one that happens to be newest.
+    ASSERT_TRUE(v.stale);
+    EXPECT_EQ(v.stale_check, StaleServeCheck::IoSilence);
+    EXPECT_EQ(v.stale_age_ms, v.io_silent_ms);
 }

--- a/test/test_dash_serve_staleness_unit.cpp
+++ b/test/test_dash_serve_staleness_unit.cpp
@@ -57,6 +57,8 @@ ServeStalenessSample healthy(const FakeClock& c, uint32_t h)
     s.served_at_ms    = c.now();
     s.observed_height = h;
     s.observed_src    = "rpc";
+    s.observed_independent = true;
+    s.observed_independent = true;   // a real outside source answered
     s.sessions        = 26;
     return s;
 }
@@ -140,6 +142,7 @@ TEST(DashServeStaleness, InducedSkewAlarms)
         s.served_at_ms    = c.now();   // still SERVING -- just a dead height
         s.observed_height = obs;
         s.observed_src    = "rpc";
+        s.observed_independent = true;
         s.sessions        = 26;
 
         const auto v = sen.poll(s);
@@ -195,6 +198,7 @@ TEST(DashServeStaleness, InducedSkewIsSilentWhenTheGuardIsNeutered)
         s.served_at_ms    = c.now();   // still SERVING -- just a dead height
         s.observed_height = obs;
         s.observed_src    = "rpc";
+        s.observed_independent = true;
         s.sessions        = 26;
 
         const auto v = sen.poll(s);
@@ -237,6 +241,7 @@ TEST(DashServeStaleness, IoHeartbeatSilenceAlarms)
         s.served_at_ms    = frozen_beat;
         s.observed_height = kNetwork;
         s.observed_src    = "peer";
+        s.observed_independent = true;
         s.sessions        = 26;
         const auto v = sen.poll(s);
         if (v.fired) {
@@ -273,6 +278,7 @@ TEST(DashServeStaleness, IoHeartbeatSilenceIsSilentWhenTheGuardIsNeutered)
         s.served_at_ms    = frozen_beat;
         s.observed_height = kNetwork;
         s.observed_src    = "peer";
+        s.observed_independent = true;
         s.sessions        = 26;
         ASSERT_FALSE(sen.poll(s).fired);
     }
@@ -303,6 +309,7 @@ TEST(DashServeStaleness, ServeSilenceAlarmsOnlyWhileSessionsAreAttached)
         s.served_at_ms    = frozen_serve;
         s.observed_height = kNetwork;
         s.observed_src    = "rpc";
+        s.observed_independent = true;
         s.sessions        = 0;
         ASSERT_FALSE(sen.poll(s).fired) << "alarmed on an idle pool";
     }
@@ -320,6 +327,7 @@ TEST(DashServeStaleness, ServeSilenceAlarmsOnlyWhileSessionsAreAttached)
         s.served_at_ms    = frozen_serve;
         s.observed_height = kNetwork;
         s.observed_src    = "rpc";
+        s.observed_independent = true;
         s.sessions        = 26;
         const auto v = sen.poll(s);
         if (v.fired) {
@@ -357,6 +365,7 @@ TEST(DashServeStaleness, SustainedSkewIsRateLimitedNotFlooded)
         s.served_at_ms    = c.now();   // still SERVING -- just a dead height
         s.observed_height = kNetwork;
         s.observed_src    = "rpc";
+        s.observed_independent = true;
         s.sessions        = 26;
         if (sen.poll(s).fired) ++fires;
     }
@@ -387,6 +396,7 @@ TEST(DashServeStaleness, AlarmClearsWhenTheServedHeightCatchesUp)
         s.served_at_ms    = c.now();   // still SERVING -- just a dead height
         s.observed_height = kNetwork;
         s.observed_src    = "rpc";
+        s.observed_independent = true;
         s.sessions        = 26;
         if (sen.poll(s).fired) ever_fired = true;
     }
@@ -424,4 +434,338 @@ TEST(DashServeStaleness, UnknownObservedHeightDoesNotAlarmAndDoesNotClaimHealth)
         EXPECT_FALSE(v.stale) << "claimed a skew verdict with no observation";
     }
     EXPECT_EQ(sen.skew_alarms(), 0u);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// C1 — THE INCIDENT AS IT TRULY PRESENTED, AND WHAT THE SURFACE SAID
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// The first cut of this detector reproduced the incident with the SERVED height
+// frozen and an INDEPENDENTLY MOVING observed height (InducedSkewAlarms above).
+// That is not what happened. What happened is:
+//
+//   * the io thread pegged at 99.9% userspace, so EVERY value mirrored by an
+//     `ioc` timer froze — including the observed-height mirror the sentinel
+//     reads. observed_height therefore stayed EQUAL to the dead served height
+//     for the whole hour and D2 could not see anything;
+//   * the serve path still trickled h=2518006 out to 26 rigs, so served_at_ms
+//     kept advancing and D3 could not see anything either;
+//   * only D1 — "the io thread has stopped being able to write a number" —
+//     could see it, and it did: 60 correct [STALE-SERVE] check=io-silence lines
+//     across the hour.
+//
+// And the operator surface said `stale: false` for all sixty of them, because
+// `stale` carried D2 alone. An operator refreshing /api/node_topology during the
+// real event saw nothing wrong. The log and the surface must not be able to
+// disagree; this test is that claim.
+TEST(DashServeStaleness, IncidentAsItPresentedIsVisibleOnTheStatusSurface)
+{
+    FakeClock c;
+    ServeStalenessSentinel sen{ServeStalenessConfig{}};
+
+    for (int i = 0; i < 4; ++i) {
+        c.advance(15000);
+        ASSERT_FALSE(sen.poll(healthy(c, kServedDead)).fired);
+    }
+
+    // The peg. Both ioc-written mirrors freeze together — that is not two
+    // faults, it is one fault seen twice.
+    const int64_t frozen_beat = c.now();
+    int  lines = 0, stale_polls = 0;
+    dash::coin::ServeStalenessVerdict last{};
+    for (int i = 0; i < 240; ++i) {          // one hour at a 15 s poll
+        c.advance(15000);
+        ServeStalenessSample s;
+        s.now_ms          = c.now();
+        s.io_heartbeat_ms = frozen_beat;     // io thread cannot write a number
+        s.served_height   = kServedDead;     // dead height, still going out
+        s.served_at_ms    = c.now();         // 26 rigs are still being served
+        s.observed_height = kServedDead;     // mirror froze WITH the io thread
+        s.observed_src    = "peer";
+        s.observed_independent = true;       // the source is real, just stale
+        s.sessions        = 26;
+
+        last = sen.poll(s);
+        if (last.fired) {
+            ++lines;
+            EXPECT_EQ(last.check, StaleServeCheck::IoSilence) << last.line;
+        }
+        if (last.stale) ++stale_polls;
+    }
+
+    // The log half — this already worked, and is asserted so the test fails
+    // loudly if the fix breaks it.
+    EXPECT_GT(lines, 30) << "the log went quiet on the incident it exists for";
+
+    // THE SURFACE HALF — this is the C1 fix. Without it stale_polls is 0.
+    // 237 of 240: the first three polls are inside the 60 s D1 threshold.
+    EXPECT_GE(stale_polls, 236)
+        << "the status surface reported HEALTH while the log printed " << lines
+        << " [STALE-SERVE] lines about the same hour";
+    EXPECT_TRUE(last.stale);
+    EXPECT_EQ(last.stale_check, StaleServeCheck::IoSilence);
+    EXPECT_GE(last.stale_age_ms, 3600000)
+        << "the surface must carry HOW LONG, not just that something is wrong";
+
+    // And D2 must say it was blind rather than say nothing was wrong: the
+    // observed height equalled the served height only because the mirror died.
+    EXPECT_EQ(last.skew_age_ms, 0);
+}
+
+// C1, mutation: if `stale` were still D2-only, the surface would stay silent for
+// the whole hour. Driving the same incident with the height comparison as the
+// ONLY thing that could set `stale` — by handing D2 nothing to work with —
+// leaves stale false, which is precisely the state the fix removed.
+TEST(DashServeStaleness, IncidentSurfaceClaimDependsOnDOneNotOnTheSkew)
+{
+    FakeClock c;
+    ServeStalenessConfig cfg;
+    cfg.io_silence_ms = std::numeric_limits<int32_t>::max();  // D1 neutered
+    ServeStalenessSentinel sen{cfg};
+
+    for (int i = 0; i < 4; ++i) {
+        c.advance(15000);
+        ASSERT_FALSE(sen.poll(healthy(c, kServedDead)).fired);
+    }
+    const int64_t frozen_beat = c.now();
+    for (int i = 0; i < 240; ++i) {
+        c.advance(15000);
+        ServeStalenessSample s;
+        s.now_ms          = c.now();
+        s.io_heartbeat_ms = frozen_beat;
+        s.served_height   = kServedDead;
+        s.served_at_ms    = c.now();
+        s.observed_height = kServedDead;
+        s.observed_src    = "peer";
+        s.observed_independent = true;
+        s.sessions        = 26;
+        const auto v = sen.poll(s);
+        ASSERT_FALSE(v.stale)
+            << "with D1 neutered nothing in this drive can see the fault — if "
+               "the surface still claims staleness, the C1 assertion above is "
+               "not testing D1: " << v.line;
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// C5 — A HEALTHY BUSY NODE MUST NOT TRIP D1
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// notify_all() walks the session snapshot SERIALLY on the io thread
+// (core/stratum_server.cpp:379-385) and one send_notify_work measured ~733 ms.
+// 26 rigs is 19.06 s in a single round with the heartbeat timer unable to run,
+// and a tip change landing mid-round makes that two rounds: 38.1 s. The
+// original 10 s default sat BELOW one round, so it would have paged on a
+// perfectly healthy pool of 14+ rigs.
+TEST(DashServeStaleness, BusyHealthyNodeSerialNotifyRoundDoesNotTripIoSilence)
+{
+    constexpr int64_t kPerNotifyMs = 733;
+    constexpr int64_t kSessions    = 26;
+    constexpr int64_t kRoundMs     = kPerNotifyMs * kSessions;   // 19058
+    static_assert(kRoundMs == 19058, "the measured round is 26 x 733 ms");
+
+    FakeClock c;
+    ServeStalenessConfig cfg;   // the shipped default
+    ASSERT_GE(cfg.io_silence_ms, 2 * kRoundMs)
+        << "io_silence_ms must clear TWO serial notify rounds (" << (2 * kRoundMs)
+        << " ms); at " << cfg.io_silence_ms << " ms it fires on a healthy node";
+    ServeStalenessSentinel sen{cfg};
+
+    for (int i = 0; i < 4; ++i) {
+        c.advance(15000);
+        ASSERT_FALSE(sen.poll(healthy(c, kNetwork)).fired);
+    }
+
+    // An hour of a busy-but-healthy node: back-to-back double rounds (a tip
+    // change landing inside a round), the heartbeat catching up between them.
+    int64_t beat = c.now();
+    for (int round = 0; round < 90; ++round) {
+        c.advance(2 * kRoundMs);        // io thread is inside notify_all
+        {
+            ServeStalenessSample s = healthy(c, kNetwork);
+            s.io_heartbeat_ms = beat;   // still the pre-round beat
+            const auto v = sen.poll(s);
+            ASSERT_FALSE(v.fired)
+                << "round " << round << ": a healthy 26-rig notify round paged: "
+                << v.line;
+            ASSERT_FALSE(v.stale) << "round " << round;
+        }
+        beat = c.now();                 // round done, the 1 s timer runs again
+        c.advance(1000);
+        ASSERT_FALSE(sen.poll(healthy(c, kNetwork)).fired);
+    }
+    EXPECT_EQ(sen.io_alarms(), 0u)
+        << "D1 cried wolf on a healthy node; an ignored detector is worth less "
+           "than no detector";
+}
+
+// C5, mutation: the SAME healthy drive against the retired 10 s default must
+// alarm. If it did not, the test above would be passing for a reason that has
+// nothing to do with the threshold.
+TEST(DashServeStaleness, BusyHealthyNodeWouldHaveTrippedTheOldTenSecondDefault)
+{
+    FakeClock c;
+    ServeStalenessConfig cfg;
+    cfg.io_silence_ms = 10000;          // the value this condition retired
+    ServeStalenessSentinel sen{cfg};
+
+    for (int i = 0; i < 4; ++i) {
+        c.advance(15000);
+        ASSERT_FALSE(sen.poll(healthy(c, kNetwork)).fired);
+    }
+    int64_t beat = c.now();
+    bool fired = false;
+    for (int round = 0; round < 90 && !fired; ++round) {
+        c.advance(2 * 733 * 26);
+        ServeStalenessSample s = healthy(c, kNetwork);
+        s.io_heartbeat_ms = beat;
+        if (sen.poll(s).fired) fired = true;
+        beat = c.now();
+        c.advance(1000);
+        if (sen.poll(healthy(c, kNetwork)).fired) fired = true;
+    }
+    ASSERT_TRUE(fired)
+        << "the 10 s default did NOT false-positive on the busy-node drive, so "
+           "the raised default is unjustified by this test";
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// C6 — D2 REFUSES TO COMPARE THE NODE AGAINST ITSELF
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// peer_tip_height() is fed only from the coin-p2p peer-height callback, and
+// header_chain exists only when coin_p2p does. Without coin-p2p there is no
+// outside height, and the only number to hand is our own tip. Comparing the
+// served height against our own tip is the node vouching for itself — the exact
+// property that made every pre-existing signal blind. D2 must decline.
+TEST(DashServeStaleness, DTwoRefusesToRunWithoutAnIndependentReference)
+{
+    FakeClock c;
+    ServeStalenessSentinel sen{ServeStalenessConfig{}};
+
+    // Drive a skew that is UNMISTAKABLE — 22 blocks, the incident's own gap,
+    // sustained far past the window. The only thing wrong with it is that the
+    // observed height did not come from outside this process.
+    for (int i = 0; i < 240; ++i) {
+        c.advance(15000);
+        ServeStalenessSample s;
+        s.now_ms          = c.now();
+        s.io_heartbeat_ms = c.now();
+        s.served_height   = kServedDead;
+        s.served_at_ms    = c.now();
+        s.observed_height = kNetwork;       // 22 ahead
+        s.observed_src    = "hdr";          // OUR OWN header tip
+        s.observed_independent = false;     // ...so it proves nothing
+        s.sessions        = 26;
+
+        const auto v = sen.poll(s);
+        ASSERT_FALSE(v.d2_armed)
+            << "D2 claimed to be armed on a self-sourced height";
+        ASSERT_FALSE(v.stale)
+            << "D2 compared the node against ITSELF and called the result a "
+               "verdict: " << v.line;
+        ASSERT_EQ(v.skew_age_ms, 0);
+    }
+    EXPECT_EQ(sen.skew_alarms(), 0u);
+}
+
+// C6, mutation: the SAME drive with the reference marked independent MUST
+// alarm. Without this the refusal test would pass on a detector whose skew
+// comparison was simply dead.
+TEST(DashServeStaleness, DTwoRunsAndAlarmsOnceTheReferenceIsIndependent)
+{
+    FakeClock c;
+    ServeStalenessSentinel sen{ServeStalenessConfig{}};
+
+    bool fired = false;
+    bool armed_seen = false;
+    for (int i = 0; i < 240 && !fired; ++i) {
+        c.advance(15000);
+        ServeStalenessSample s;
+        s.now_ms          = c.now();
+        s.io_heartbeat_ms = c.now();
+        s.served_height   = kServedDead;
+        s.served_at_ms    = c.now();
+        s.observed_height = kNetwork;
+        s.observed_src    = "peer";         // from OUTSIDE this process
+        s.observed_independent = true;
+        s.sessions        = 26;
+        const auto v = sen.poll(s);
+        if (v.d2_armed) armed_seen = true;
+        if (v.fired) {
+            fired = true;
+            EXPECT_EQ(v.check, StaleServeCheck::HeightSkew) << v.line;
+        }
+    }
+    EXPECT_TRUE(armed_seen);
+    ASSERT_TRUE(fired)
+        << "with a genuinely independent reference the 22-block skew raised "
+           "nothing — the refusal test proves only that dead code is dead";
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// C3 — EVERY AGE IS ITS OWN FIELD
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// The first cut set v.age_ms to the skew age and then OVERWROTE it with
+// whichever check fired, and main_dash passed that same number on as the
+// operator-visible stale_age. One field that means io-silence on one poll and
+// height-skew on the next is how a true number produces a false conclusion.
+// Drive a state where D1 and D2 are BOTH standing and their ages DIFFER, and
+// require the surface to keep them apart.
+TEST(DashServeStaleness, EachCheckCarriesItsOwnAgeAndTheVerdictNamesWhichOne)
+{
+    FakeClock c;
+    ServeStalenessSentinel sen{ServeStalenessConfig{}};
+
+    for (int i = 0; i < 4; ++i) {
+        c.advance(15000);
+        ASSERT_FALSE(sen.poll(healthy(c, kServedDead)).fired);
+    }
+
+    // Phase 1: skew ONLY. io keeps ticking, so the skew age runs ahead alone.
+    for (int i = 0; i < 40; ++i) {
+        c.advance(15000);
+        ServeStalenessSample s;
+        s.now_ms          = c.now();
+        s.io_heartbeat_ms = c.now();
+        s.served_height   = kServedDead;
+        s.served_at_ms    = c.now();
+        s.observed_height = kNetwork;
+        s.observed_src    = "peer";
+        s.observed_independent = true;
+        s.sessions        = 26;
+        sen.poll(s);
+    }
+
+    // Phase 2: the io thread now pegs too. Skew is ~600 s old; io-silence is
+    // seconds old. A single shared field cannot express both.
+    const int64_t frozen_beat = c.now();
+    dash::coin::ServeStalenessVerdict v{};
+    for (int i = 0; i < 8; ++i) {
+        c.advance(15000);
+        ServeStalenessSample s;
+        s.now_ms          = c.now();
+        s.io_heartbeat_ms = frozen_beat;
+        s.served_height   = kServedDead;
+        s.served_at_ms    = c.now();
+        s.observed_height = kNetwork;
+        s.observed_src    = "peer";
+        s.observed_independent = true;
+        s.sessions        = 26;
+        v = sen.poll(s);
+    }
+
+    ASSERT_TRUE(v.stale);
+    EXPECT_EQ(v.stale_check, StaleServeCheck::IoSilence)
+        << "a dead io thread outranks the skew it causes";
+    EXPECT_EQ(v.stale_age_ms, v.io_silent_ms)
+        << "stale_age_ms must be the age of the check stale_check NAMES";
+    EXPECT_GT(v.skew_age_ms, v.io_silent_ms)
+        << "the two ages are genuinely different here (" << v.skew_age_ms
+        << " vs " << v.io_silent_ms << "), which is the whole point";
+    EXPECT_GE(v.skew_age_ms, 600000);
+    EXPECT_LE(v.io_silent_ms, 130000);
+    // D3 never raised: templates kept going out the whole time.
+    EXPECT_LT(v.serve_quiet_ms, 20000);
 }

--- a/test/test_dash_serve_staleness_unit.cpp
+++ b/test/test_dash_serve_staleness_unit.cpp
@@ -1,0 +1,427 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// dash::coin::ServeStalenessSentinel — the detector itself, driven off a FAKE
+// clock and INJECTED heights.
+//
+// The brief this ships under is explicit that a compile-and-run RED of a class
+// that does not exist on master is impossible, and says to say so rather than
+// fake one. So the red witness for this change is the SEAM test
+// (test_dash_serve_staleness_seam.cpp), which compiles against master and fails
+// there. This file carries the OTHER half of the same obligation: proving the
+// detector can FAIL — i.e. that the assertions here depend on the guard and not
+// on the shape of the test.
+//
+// That is not a hypothetical concern on this repo. This week a KAT shipped that
+// still passed with the guard it "tested" deleted. So the induced-skew case is
+// run TWICE: once with the real threshold (must alarm) and once with the
+// threshold neutered to the deleted-guard value (must NOT alarm). If the
+// comparison were dead code, the second run would alarm too and this file would
+// red.
+//
+// Numbers are the incident's, verbatim: served h=2518006, network h=2518028.
+
+#include <impl/dash/coin/serve_staleness.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <limits>
+#include <string>
+
+namespace {
+
+using dash::coin::ServeStalenessConfig;
+using dash::coin::ServeStalenessSample;
+using dash::coin::ServeStalenessSentinel;
+using dash::coin::StaleServeCheck;
+
+constexpr uint32_t kServedDead = 2518006u;   // what 26 rigs were given
+constexpr uint32_t kNetwork    = 2518028u;   // where dashd actually was
+
+// A fake clock. Nothing in the sentinel reads a real one — every input arrives
+// through poll(), which is the property that makes an hour-long incident
+// reproducible in microseconds.
+struct FakeClock {
+    int64_t t{1'000'000};
+    int64_t advance(int64_t ms) { t += ms; return t; }
+    int64_t now() const { return t; }
+};
+
+// A HEALTHY node: io ticking every second, template handed out every second at
+// the network's own height, miners attached.
+ServeStalenessSample healthy(const FakeClock& c, uint32_t h)
+{
+    ServeStalenessSample s;
+    s.now_ms          = c.now();
+    s.io_heartbeat_ms = c.now();
+    s.served_height   = h;
+    s.served_at_ms    = c.now();
+    s.observed_height = h;
+    s.observed_src    = "rpc";
+    s.sessions        = 26;
+    return s;
+}
+
+}  // namespace
+
+// ── HEALTHY: the detector must be SILENT. A detector that fires on a good node
+// is worse than none — it is how [EMBED-STATUS] noise trained operators to
+// stop reading the log in the first place.
+TEST(DashServeStaleness, HealthyNodeNeverAlarms)
+{
+    FakeClock c;
+    ServeStalenessSentinel sen{ServeStalenessConfig{}};
+
+    uint32_t h = kNetwork;
+    // 30 minutes at a 15 s poll, tip advancing every 2.5 min like mainnet.
+    for (int i = 0; i < 120; ++i) {
+        c.advance(15000);
+        if (i % 10 == 0) ++h;
+        const auto v = sen.poll(healthy(c, h));
+        ASSERT_FALSE(v.fired)
+            << "healthy poll " << i << " raised " << v.line;
+        ASSERT_FALSE(v.stale);
+    }
+    EXPECT_EQ(sen.io_alarms(), 0u);
+    EXPECT_EQ(sen.skew_alarms(), 0u);
+    EXPECT_EQ(sen.serve_alarms(), 0u);
+}
+
+// ── ONE BLOCK BEHIND is NOT an alarm. This is the ordinary propagation race:
+// a peer already has the block we are mid-way through hearing about. If the
+// detector fired here it would fire several times an hour forever.
+TEST(DashServeStaleness, OneBlockBehindIsNotAnAlarm)
+{
+    FakeClock c;
+    ServeStalenessSentinel sen{ServeStalenessConfig{}};
+
+    for (int i = 0; i < 60; ++i) {   // 15 minutes of being one block behind
+        c.advance(15000);
+        auto s = healthy(c, kNetwork - 1);
+        s.observed_height = kNetwork;
+        const auto v = sen.poll(s);
+        ASSERT_FALSE(v.fired) << v.line;
+        ASSERT_FALSE(v.stale);
+    }
+    EXPECT_EQ(sen.skew_alarms(), 0u);
+}
+
+// ── THE INCIDENT, D2. Served height frozen at the dead height while the
+// observed height walks away. Must alarm — and must NOT alarm before the
+// sustain window, or a reorg becomes a page.
+TEST(DashServeStaleness, InducedSkewAlarms)
+{
+    FakeClock c;
+    ServeStalenessConfig cfg;         // defaults: 2 blocks, 120 s sustain
+    ServeStalenessSentinel sen{cfg};
+
+    // Warm up healthy so the watchdogs are armed and the served cursor is real.
+    for (int i = 0; i < 4; ++i) {
+        c.advance(15000);
+        ASSERT_FALSE(sen.poll(healthy(c, kServedDead)).fired);
+    }
+
+    // Now freeze the served height and let the network move. The io heartbeat
+    // KEEPS TICKING on purpose: this case must stand on the height comparison
+    // alone, so D1 cannot be what raises it.
+    uint32_t obs   = kServedDead;
+    bool     fired = false;
+    std::string line;
+    int64_t  fired_at = 0;
+    const int64_t skew_started = c.now();
+
+    for (int i = 0; i < 40 && !fired; ++i) {   // 10 minutes at 15 s
+        c.advance(15000);
+        if (i % 10 == 0) obs += 6;             // network pulls ahead
+
+        ServeStalenessSample s;
+        s.now_ms          = c.now();
+        s.io_heartbeat_ms = c.now();           // io alive
+        s.served_height   = kServedDead;       // FROZEN
+        s.served_at_ms    = c.now();   // still SERVING -- just a dead height
+        s.observed_height = obs;
+        s.observed_src    = "rpc";
+        s.sessions        = 26;
+
+        const auto v = sen.poll(s);
+        if (v.fired) {
+            fired    = true;
+            line     = v.line;
+            fired_at = c.now();
+            EXPECT_EQ(v.check, StaleServeCheck::HeightSkew)
+                << "the height comparison must be what raised this, not D1/D3: "
+                << v.line;
+        }
+    }
+
+    ASSERT_TRUE(fired)
+        << "the exact 2026-08-07 condition — 26 rigs on a dead height while the "
+           "chain advanced — produced NO alarm";
+    EXPECT_NE(line.find("[STALE-SERVE]"), std::string::npos)   << line;
+    EXPECT_NE(line.find("check=height-skew"), std::string::npos) << line;
+    EXPECT_NE(line.find("served=2518006"), std::string::npos)  << line;
+
+    // Not before the sustain window: a 2.5-minute-block chain cannot get two
+    // blocks ahead of us inside 120 s by propagation alone.
+    EXPECT_GE(fired_at - skew_started, cfg.height_skew_sustain_ms)
+        << "alarm raised before the sustain window — a reorg would page someone";
+    EXPECT_EQ(sen.skew_alarms(), 1u);
+    EXPECT_EQ(sen.io_alarms(), 0u);
+}
+
+// ── THE MUTATION CASE. Identical drive, guard neutered. If the skew comparison
+// were dead code, this would alarm exactly like the case above and the test
+// above would be proving nothing. It must be SILENT.
+TEST(DashServeStaleness, InducedSkewIsSilentWhenTheGuardIsNeutered)
+{
+    FakeClock c;
+    ServeStalenessConfig cfg;
+    cfg.height_skew_blocks = std::numeric_limits<uint32_t>::max();  // guard deleted
+    ServeStalenessSentinel sen{cfg};
+
+    for (int i = 0; i < 4; ++i) {
+        c.advance(15000);
+        ASSERT_FALSE(sen.poll(healthy(c, kServedDead)).fired);
+    }
+
+    uint32_t obs = kServedDead;
+    for (int i = 0; i < 40; ++i) {
+        c.advance(15000);
+        if (i % 10 == 0) obs += 6;
+
+        ServeStalenessSample s;
+        s.now_ms          = c.now();
+        s.io_heartbeat_ms = c.now();
+        s.served_height   = kServedDead;
+        s.served_at_ms    = c.now();   // still SERVING -- just a dead height
+        s.observed_height = obs;
+        s.observed_src    = "rpc";
+        s.sessions        = 26;
+
+        const auto v = sen.poll(s);
+        ASSERT_FALSE(v.fired)
+            << "alarm fired with the skew threshold neutered — the assertion in "
+               "InducedSkewAlarms does not depend on the guard: " << v.line;
+        ASSERT_FALSE(v.stale);
+    }
+    EXPECT_EQ(sen.skew_alarms(), 0u);
+}
+
+// ── D1: the io thread stops ticking. This is the sub-check that would have
+// fired FIRST in the incident — measured io handler-queue latency 13.145 s
+// against 0.1 ms before — and it is the one that does not depend on any height
+// source being available at all.
+TEST(DashServeStaleness, IoHeartbeatSilenceAlarms)
+{
+    FakeClock c;
+    ServeStalenessConfig cfg;
+    ServeStalenessSentinel sen{cfg};
+
+    for (int i = 0; i < 4; ++i) {
+        c.advance(15000);
+        ASSERT_FALSE(sen.poll(healthy(c, kNetwork)).fired);
+    }
+
+    // The io thread pegs: the heartbeat value stops advancing. EVERYTHING else
+    // still looks perfect — served height equals observed height, sessions
+    // attached — which is exactly how the incident presented to every
+    // self-reported metric.
+    const int64_t frozen_beat = c.now();
+    bool fired = false;
+    std::string line;
+    for (int i = 0; i < 10 && !fired; ++i) {
+        c.advance(15000);
+        ServeStalenessSample s;
+        s.now_ms          = c.now();
+        s.io_heartbeat_ms = frozen_beat;   // FROZEN
+        s.served_height   = kNetwork;
+        s.served_at_ms    = frozen_beat;
+        s.observed_height = kNetwork;
+        s.observed_src    = "peer";
+        s.sessions        = 26;
+        const auto v = sen.poll(s);
+        if (v.fired) {
+            fired = true;
+            line  = v.line;
+            EXPECT_EQ(v.check, StaleServeCheck::IoSilence) << v.line;
+        }
+    }
+    ASSERT_TRUE(fired) << "a wedged io thread raised nothing";
+    EXPECT_NE(line.find("check=io-silence"), std::string::npos) << line;
+    EXPECT_GE(sen.io_alarms(), 1u);
+}
+
+// D1 mutation: with the silence threshold pushed past the whole run, the same
+// frozen heartbeat must NOT alarm.
+TEST(DashServeStaleness, IoHeartbeatSilenceIsSilentWhenTheGuardIsNeutered)
+{
+    FakeClock c;
+    ServeStalenessConfig cfg;
+    cfg.io_silence_ms = std::numeric_limits<int32_t>::max();   // guard deleted
+    ServeStalenessSentinel sen{cfg};
+
+    for (int i = 0; i < 4; ++i) {
+        c.advance(15000);
+        ASSERT_FALSE(sen.poll(healthy(c, kNetwork)).fired);
+    }
+    const int64_t frozen_beat = c.now();
+    for (int i = 0; i < 10; ++i) {
+        c.advance(15000);
+        ServeStalenessSample s;
+        s.now_ms          = c.now();
+        s.io_heartbeat_ms = frozen_beat;
+        s.served_height   = kNetwork;
+        s.served_at_ms    = frozen_beat;
+        s.observed_height = kNetwork;
+        s.observed_src    = "peer";
+        s.sessions        = 26;
+        ASSERT_FALSE(sen.poll(s).fired);
+    }
+    EXPECT_EQ(sen.io_alarms(), 0u);
+}
+
+// ── D3: nothing handed out at all while miners are attached. Distinct from D2:
+// D2 needs an observed height to compare against, and a node whose only height
+// source is its own frozen state has none. D3 needs nothing but a clock.
+TEST(DashServeStaleness, ServeSilenceAlarmsOnlyWhileSessionsAreAttached)
+{
+    FakeClock c;
+    ServeStalenessSentinel sen{ServeStalenessConfig{}};
+
+    for (int i = 0; i < 4; ++i) {
+        c.advance(15000);
+        ASSERT_FALSE(sen.poll(healthy(c, kNetwork)).fired);
+    }
+
+    // No miners: silence is not a fault, it is an idle pool.
+    const int64_t frozen_serve = c.now();
+    for (int i = 0; i < 60; ++i) {   // 15 min of nothing served, 0 sessions
+        c.advance(15000);
+        ServeStalenessSample s;
+        s.now_ms          = c.now();
+        s.io_heartbeat_ms = c.now();
+        s.served_height   = kNetwork;
+        s.served_at_ms    = frozen_serve;
+        s.observed_height = kNetwork;
+        s.observed_src    = "rpc";
+        s.sessions        = 0;
+        ASSERT_FALSE(sen.poll(s).fired) << "alarmed on an idle pool";
+    }
+    EXPECT_EQ(sen.serve_alarms(), 0u);
+
+    // Miners attach and STILL nothing is served -> that is a fault.
+    bool fired = false;
+    std::string line;
+    for (int i = 0; i < 60 && !fired; ++i) {
+        c.advance(15000);
+        ServeStalenessSample s;
+        s.now_ms          = c.now();
+        s.io_heartbeat_ms = c.now();
+        s.served_height   = kNetwork;
+        s.served_at_ms    = frozen_serve;
+        s.observed_height = kNetwork;
+        s.observed_src    = "rpc";
+        s.sessions        = 26;
+        const auto v = sen.poll(s);
+        if (v.fired) {
+            fired = true;
+            line  = v.line;
+            EXPECT_EQ(v.check, StaleServeCheck::ServeSilence) << v.line;
+        }
+    }
+    ASSERT_TRUE(fired) << "26 rigs attached, no template for 15 minutes, silence";
+    EXPECT_NE(line.find("check=serve-silence"), std::string::npos) << line;
+}
+
+// ── The detector must not go permanently loud once raised. A condition that
+// stays true is re-stated on the repeat cadence, not on every poll.
+TEST(DashServeStaleness, SustainedSkewIsRateLimitedNotFlooded)
+{
+    FakeClock c;
+    ServeStalenessConfig cfg;
+    cfg.repeat_ms = 60000;
+    ServeStalenessSentinel sen{cfg};
+
+    for (int i = 0; i < 4; ++i) {
+        c.advance(15000);
+        ASSERT_FALSE(sen.poll(healthy(c, kServedDead)).fired);
+    }
+
+    int fires = 0;
+    // 60 minutes at 15 s = 240 polls, the incident's own duration.
+    for (int i = 0; i < 240; ++i) {
+        c.advance(15000);
+        ServeStalenessSample s;
+        s.now_ms          = c.now();
+        s.io_heartbeat_ms = c.now();
+        s.served_height   = kServedDead;
+        s.served_at_ms    = c.now();   // still SERVING -- just a dead height
+        s.observed_height = kNetwork;
+        s.observed_src    = "rpc";
+        s.sessions        = 26;
+        if (sen.poll(s).fired) ++fires;
+    }
+    // ~1/min over ~58 alarming minutes, never 240.
+    EXPECT_GT(fires, 30);
+    EXPECT_LT(fires, 80) << "the alarm floods; " << fires << " lines in an hour";
+}
+
+// ── Recovery: once the served height catches up, the alarm must STOP. The
+// incident recovered on a restart; a detector that keeps shouting afterwards is
+// the same silence problem wearing the opposite mask.
+TEST(DashServeStaleness, AlarmClearsWhenTheServedHeightCatchesUp)
+{
+    FakeClock c;
+    ServeStalenessSentinel sen{ServeStalenessConfig{}};
+
+    for (int i = 0; i < 4; ++i) {
+        c.advance(15000);
+        ASSERT_FALSE(sen.poll(healthy(c, kServedDead)).fired);
+    }
+    bool ever_fired = false;
+    for (int i = 0; i < 40; ++i) {
+        c.advance(15000);
+        ServeStalenessSample s;
+        s.now_ms          = c.now();
+        s.io_heartbeat_ms = c.now();
+        s.served_height   = kServedDead;
+        s.served_at_ms    = c.now();   // still SERVING -- just a dead height
+        s.observed_height = kNetwork;
+        s.observed_src    = "rpc";
+        s.sessions        = 26;
+        if (sen.poll(s).fired) ever_fired = true;
+    }
+    ASSERT_TRUE(ever_fired);
+
+    // Restart / recovery: we serve the current height again.
+    for (int i = 0; i < 40; ++i) {
+        c.advance(15000);
+        const auto v = sen.poll(healthy(c, kNetwork));
+        ASSERT_FALSE(v.fired) << "still alarming after recovery: " << v.line;
+        ASSERT_FALSE(v.stale);
+    }
+}
+
+// ── Unknown observed height must NOT be read as "we are current". A sentinel
+// whose only height source is down knows nothing, and saying nothing is the
+// honest answer for D2 specifically — D1/D3 still cover the case.
+TEST(DashServeStaleness, UnknownObservedHeightDoesNotAlarmAndDoesNotClaimHealth)
+{
+    FakeClock c;
+    ServeStalenessSentinel sen{ServeStalenessConfig{}};
+
+    for (int i = 0; i < 40; ++i) {
+        c.advance(15000);
+        ServeStalenessSample s;
+        s.now_ms          = c.now();
+        s.io_heartbeat_ms = c.now();
+        s.served_height   = kServedDead;
+        s.served_at_ms    = c.now();   // still SERVING -- just a dead height
+        s.observed_height = 0;             // no source answered
+        s.observed_src    = "none";
+        s.sessions        = 26;
+        const auto v = sen.poll(s);
+        EXPECT_EQ(v.check, StaleServeCheck::None) << v.line;
+        EXPECT_FALSE(v.stale) << "claimed a skew verdict with no observation";
+    }
+    EXPECT_EQ(sen.skew_alarms(), 0u);
+}


### PR DESCRIPTION
## The gap this closes

On 2026-08-07 a DASH mainnet node served a **dead height** — h=2518006 — to 26 rigs for an hour while the chain advanced to 2518028. Their work was unpayable. It surfaced because the operator looked at a hashrate graph.

Nothing in the node said anything. Not the serve gate: every internal axis had frozen together and stayed mutually consistent. Not the dashboard. Not the shadow oracle, which was in fact doing its job perfectly — it declined to compare on `tip-skew` and therefore reported `a=0` samples every two hours, which everyone, including me, read as silence rather than as the symptom it was.

This adds the check that would have spoken.

## What it is, and what it deliberately is not

**Report-only.** A sentinel thread, three independent checks, a `serve_staleness` block on `/api/node_topology`, and a log line. It cannot stop the node serving, cannot refuse a template, cannot touch a consensus decision. That restraint is deliberate: a detector empowered to halt production is a larger risk than the condition it detects.

The three checks and, more usefully, **what makes each one able to fail** — this project has shipped several checks that could only ever pass:

| check | fires on | can it false-positive? |
|---|---|---|
| **D1** io-silence | the io thread stops writing its mirrors | yes above ~40 sessions — see the ceiling below |
| **D2** height-skew | served height falls behind an **independent** reference | refuses to run rather than compare the node against itself |
| **D3** serve-silence | no template served while sessions are attached | only while rigs are actually attached |

D2 is the one that matches the incident, and it is the one with the trap: its reference must be independent. `set_peer_tip_height` is wired only inside the coin-p2p block, so without coin-p2p there is no independent source — and rather than quietly degrading to comparing the node against its own state, D2 **refuses to run** and publishes `d2="unavailable-no-independent-reference"`. A check that can only agree with itself is not a check.

## Two rounds of adversarial review, and what the second one found

Round 1 was returned **unsound**. The reviewer rebuilt it and mutation-tested it, and found the detector was **silent on the very incident it ships for**: driven with the real shape (io thread pegged, so both io-written mirrors freeze while the serve path still trickles h=2518006 out to 26 rigs), the log produced 60 correct `[STALE-SERVE]` lines while `serve_staleness.stale` stayed **false for the entire simulated hour**. An operator reading the endpoint during the real event would have seen nothing wrong.

Round 2 fixed that and then the reviewer mutation-tested **the fix itself**, finding four more surviving mutants — assertions that tested the log line but never the operator-visible surface. Each is now closed, and the round-2 change is **test-only**: `git diff --stat -- src/` against the round-1 head is empty.

## Known limits, stated rather than discovered later

- **The D1 threshold has a ceiling.** 60 s covers roughly 40 sessions, from `2 x sessions x 733 ms` — `notify_all` fans `send_notify_work` out **serially**, and 733 ms is the measured per-session cost from the incident. The hotel has 26 rigs, so it is safe there. **A pool above ~40 rigs will get D1 false positives on a healthy node.** The 733 ms is inherited from the incident capture, not re-measured.
- **D2 is unavailable on daemon-backed deployments** without coin-p2p, by the refusal above.
- **No runtime proof** that the status endpoint answers while the serve gate is held. The lock-free path is structural and mutation-proven — restoring the unconditional `lock_guard` reds the test — but nobody has watched the endpoint respond during real saturation.
- **The kill switch is not the whole footprint.** `--serve-staleness-sentinel=off` removes the poller thread and the status publication, but two relaxed atomic stores on the serve path remain. They sit after the early return, take no lock, allocate nothing, and touch neither the work data nor the returned template — served bytes and serve decisions are byte-identical — but the flag does not remove them.

## Tests

99 in the target, up from 98 (the +1 is a new do-not-fabricate case; the other four round-2 fixes are new assertions inside existing tests, so a reader diffing counts should expect the discrepancy). Every guard was demonstrated red by making its own mutation and watching the test fail, then restoring.
