### PR TITLE
dash: the fallback arm gets a block budget too — the other half of #1177

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -387,6 +387,7 @@ void print_banner(const char* argv0)
         << "           [--embedded-mn-bridge-no-cursor]\n"
         << "           [--embedded-utxo-immature-serve-empty] [--embedded-serve-mempool-txs]\n"
         << "           [--pin-local-tx-hex FILE]  (zero-fee self-mined tx, e.g. donation consolidation)\n"
+        << "           [--dash-pin-block-budget]  (refuse a pin that would push the served block over 2 MB)\n"
         << "           [--bestcl-policy freshness|consensus-exact]\n"
         << "           [--embedded-oracle-shadow]\n"
         << "           [--embedded-shadow-compare]\n"
@@ -787,7 +788,14 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              // safety — there is no code path from an alarm to a serve
              // decision. See coin/serve_staleness.hpp for why report-only was
              // chosen over a detector that can stop serving.
-             bool serve_staleness_sentinel = true)
+             bool serve_staleness_sentinel = true,
+             // --dash-pin-block-budget: MONEY PATH, DEFAULT OFF. Give the
+             // served-dashd splice the same block-level size budget #1177
+             // gave the embedded arm — measure what dashd's template already
+             // occupies and refuse the pin that would push the assembled
+             // block past the 2 MB consensus limit, with a NAMED cause.
+             // OFF reproduces the shipped arithmetic byte-for-byte.
+             bool pin_block_budget = false)
 {
     namespace io = boost::asio;
 
@@ -2503,6 +2511,26 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // consulted, i.e. during an actual embedded outage.
     const bool xcheck_wanted = (testnet || embedded_mainnet);
     work_source->set_gbt_xcheck(xcheck_wanted && static_cast<bool>(rpc));
+
+    // ── BLOCK-LEVEL PIN BUDGET on the served-dashd arm ──────────────────────
+    // MONEY PATH, DEFAULT OFF (--dash-pin-block-budget). #1177 unified the
+    // size budget on the EMBEDDED arm; the fallback arm splices up to 400000
+    // bytes of pins onto dashd's own template with no block-level accounting,
+    // and dashd fills that template to its own blockmaxsize. ON, the splice
+    // measures the real remaining headroom and refuses the overflowing pin
+    // with the named cause pin-over-block-headroom. It is off by default
+    // because a refusal CHANGES SERVED BYTES; say which posture is live so
+    // the journal never has to be guessed at.
+    work_source->set_pin_block_budget(pin_block_budget);
+    std::cout << "[DASH-STRATUM] served-dashd pin block budget: "
+              << (pin_block_budget
+                      ? "ON (--dash-pin-block-budget: a pin that would push "
+                        "the assembled block past 2000000 bytes is REFUSED "
+                        "with cause=pin-over-block-headroom)"
+                      : "OFF (default: pins capped only against 400000, NOT "
+                        "against what dashd's template already holds -- "
+                        "enable with --dash-pin-block-budget)")
+              << "\n";
     if (xcheck_wanted && !rpc) {
         std::cout << "[DASH-STRATUM-GBT] GBT cross-check DISABLED: dashd RPC "
                      "arm UNARMED (pure-daemonless) -- the embedded arm relies "
@@ -7064,6 +7092,7 @@ int main(int argc, char** argv)
     // still the other flag's decision, and that one stays default-OFF until
     // the [SHADOW-TXSET] coverage series says it is safe.
     bool embedded_mempool_ingest = false;
+    bool pin_block_budget = false;
     std::string bestcl_policy = "freshness";   // --bestcl-policy: freshness (default, conservative proxy) | consensus-exact (dashcore's actual CheckCbTxBestChainlock rule)
     bool embedded_oracle_shadow = false;       // --embedded-oracle-shadow: per-block dashd cross-check (OBSERVE-only)
     bool embedded_shadow_compare = false;      // --embedded-shadow-compare: serve-vs-dashd template diff (OBSERVE-only, NOT a gate)
@@ -7161,6 +7190,8 @@ int main(int argc, char** argv)
             embedded_serve_mempool_txs = true;
         else if (std::strcmp(argv[i], "--embedded-mempool-ingest") == 0)
             embedded_mempool_ingest = true;
+        else if (std::strcmp(argv[i], "--dash-pin-block-budget") == 0)
+            pin_block_budget = true;
         else if (std::strcmp(argv[i], "--pin-local-tx-hex") == 0 && i + 1 < argc)
             pin_local_tx_hex_path = argv[++i];
         else if (std::strcmp(argv[i], "--replay-utxo-db") == 0 && i + 1 < argc)
@@ -7441,7 +7472,8 @@ int main(int argc, char** argv)
                         embedded_shadow_compare,
                         embedded_mempool_ingest,
                         pin_local_tx_hex_path,
-                        serve_staleness_sentinel);
+                        serve_staleness_sentinel,
+                        pin_block_budget);
     }
     return run_selftest();
 }

--- a/src/impl/dash/coin/embedded_gbt.hpp
+++ b/src/impl/dash/coin/embedded_gbt.hpp
@@ -48,6 +48,7 @@
 #include <core/log.hpp>
 #include <core/address_utils.hpp>
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <ctime>
@@ -156,59 +157,195 @@ inline void pin_append(DashWorkData& w, const MutableTransaction& pin)
         reinterpret_cast<const unsigned char*>(sp.data()), sp.size())));
 }
 
-inline void splice_pinned_tx(DashWorkData& w,
-                             const MutableTransaction& pin,
-                             const Mempool& mempool,
-                             const MnStateMachine& mnstates,
-                             const char* arm)
+// ── BLOCK-LEVEL PIN BUDGET ──────────────────────────────────────────────
+// #1177 unified the size budget on the EMBEDDED arm: the consensus-required
+// set is measured BEFORE mempool selection and deducted, with an explicit
+// zero floor. The SERVED-DASHD arm never got that discipline. Its only cap
+// was pins-vs-kMaxPinnedTotalBytes — never pins-vs-what-dashd's-template-
+// ALREADY-HOLDS. dashd fills its own template to its own blockmaxsize
+// (node/miner.cpp:212 clamps to MaxBlockSize()-1000, DEFAULT_BLOCK_MAX_SIZE
+// is 2000000, policy/policy.h:23); splicing 400000 bytes of pins onto a
+// template already near that reproduces EXACTLY the bad-blk-length overshoot
+// #1177 removed — on the arm we describe as the always-reachable safety path.
+//
+// This is not hypothetical: block 2518186 was won on arm=dashd-fallback
+// carrying 154 KB of pinned donation. One large dashd template away.
+//
+// ORDER, mirrored from dashd node/miner.cpp deliberately, because the order
+// encodes which component may be dropped:
+//   1. coinbase reserve   (miner.cpp:115, resetBlock: nBlockSize = 1000)
+//   2. consensus-required (miner.cpp:235, nBlockSize += qcTx->GetTotalSize())
+//   3. mempool selection  (miner.cpp:361, TestPackage against nBlockMaxSize)
+// On the served-dashd arm steps 1-3 have ALREADY happened inside dashd and
+// arrive as a finished template. The only component left that may yield is
+// the pin set — pins are policy, everything already in dashd's template is
+// either required for validity or paid for with fees we would be throwing
+// away. So the pins yield, and they yield by being REFUSED WITH A NAME.
+
+/// dashd consensus.h:10 — MAX_DIP0001_BLOCK_SIZE. A block over this is
+/// INVALID (bad-blk-length), not merely large.
+inline constexpr uint64_t kDashMaxBlockBytes = 2'000'000;
+
+/// dashd node/miner.cpp:115 — resetBlock() starts nBlockSize at 1000 for a
+/// coinbase it has not built yet. We reserve the same, for the same reason:
+/// at splice time our coinbase does not exist either.
+inline constexpr uint64_t kCoinbaseReserveBytes = 1'000;
+
+/// serialize_full_block (block_producer.hpp:207-217) emits an 80-byte header
+/// plus a CompactSize tx count before the coinbase. 9 is the WIDEST
+/// CompactSize, so this over-reserves by at most 8 bytes — in the safe
+/// direction, which is the only direction a budget may err.
+inline constexpr uint64_t kBlockOverheadBytes = 80 + 9;
+
+/// Bytes the template body ALREADY occupies, measured from the exact field
+/// serialize_full_block() emits verbatim (block_producer.hpp:220). Not an
+/// estimate and not a re-derivation: these ARE the bytes that go on the wire.
+inline uint64_t template_body_bytes(const DashWorkData& w)
 {
-    const auto v = pin_gate_verdict(pin, mempool, mnstates, w.m_height);
-    if (!v.ok) {
-        LOG_INFO << "[" << arm << "] pinned tx EXCLUDED h=" << w.m_height
-                 << " cause=" << v.cause
-                 << " txid=" << dash::coin::dash_txid(pin).GetHex().substr(0, 16)
-                 << " (template built without it; re-checked next build)";
-        return;
-    }
-    pin_append(w, pin);
-    LOG_INFO << "[" << arm << "] pinned tx INCLUDED h=" << w.m_height
-             << " txid=" << dash::coin::dash_txid(pin).GetHex().substr(0, 16)
-             << " vin=" << pin.vin.size() << " fee=0 (rides this template)";
+    uint64_t n = 0;
+    for (const auto& h : w.m_tx_data_hex) n += h.size() / 2;
+    return n;
 }
 
-/// Splice EVERY admissible pin, in file order, under a CUMULATIVE byte cap.
+/// How many MORE bytes the pin set may add before the ASSEMBLED block
+/// exceeds the consensus limit, capped by the pin policy budget.
+///
+/// The subtraction has an explicit zero floor. An unsigned subtraction of an
+/// over-cap occupancy wraps to ~18 EB and hands the splice an unbounded
+/// budget, silently restoring the very behaviour this removes — the same
+/// underflow face #1177 called out on the embedded arm.
+inline uint64_t pin_headroom_bytes(const DashWorkData& w)
+{
+    const uint64_t occupied =
+        kBlockOverheadBytes + kCoinbaseReserveBytes + template_body_bytes(w);
+    const uint64_t left =
+        occupied >= kDashMaxBlockBytes ? 0ull : kDashMaxBlockBytes - occupied;
+    return std::min<uint64_t>(left, Mempool::kMaxPinnedTotalBytes);
+}
+
+/// The NAMED answer to "may this pin ride?" at BLOCK scale. nullptr == yes.
+///
+/// Two distinct refusals, kept distinct on purpose. "tx-too-large" (the
+/// gate's own TooLarge face) blames the TRANSACTION; neither of these is a
+/// property of the transaction — one is the pin set's own policy budget, the
+/// other is a property of the TEMPLATE this pin happened to meet. A cause
+/// name is the operator's only handle on a refusal, so it must say which.
+inline const char* pin_budget_refusal(uint64_t spliced_bytes,
+                                      uint64_t pin_bytes,
+                                      uint64_t pin_cap,
+                                      uint64_t headroom)
+{
+    if (spliced_bytes + pin_bytes > pin_cap)  return "pin-total-too-large";
+    if (spliced_bytes + pin_bytes > headroom) return "pin-over-block-headroom";
+    return nullptr;
+}
+
+/// What a splice DID, as a value — so a test can assert the NAMED refusal
+/// without scraping a log line, and a caller can report it.
+struct PinSpliceReport {
+    size_t   included{0};
+    size_t   excluded{0};
+    uint64_t spliced_bytes{0};   ///< bytes actually appended
+    uint64_t headroom{0};        ///< the budget this splice ran against
+    /// Per-pin outcome in file order: "" when included, else the named cause.
+    std::vector<const char*> causes;
+};
+
+/// THE splice, in file order, under a CUMULATIVE byte cap AND the block
+/// budget. Both serving arms land here so neither can drift from the other.
 ///
 /// The donation consolidation had to be split into four transactions after a
 /// single 152258-byte pin was rejected as bad-txns-oversize and cost block
 /// 2517855. Four quarter-sized transactions ride ONE template, so the money
 /// lands in one block instead of four.
 ///
-/// Each pin is gated INDEPENDENTLY: one bad pin excludes itself and the others
-/// still ride. The cumulative cap is checked against what has ALREADY been
+/// Each pin is judged INDEPENDENTLY: one bad pin excludes itself and the
+/// others still ride. Both caps are checked against what has ALREADY been
 /// accepted, so the answer never depends on the order the caller happened to
 /// pass them in beyond file order itself.
-inline void splice_pinned_txs(DashWorkData& w,
-                              const std::vector<MutableTransaction>& pins,
-                              const Mempool& mempool,
-                              const MnStateMachine& mnstates,
-                              const char* arm)
+///
+/// The served-dashd arm cannot run the gate where it appends (the gate reads
+/// coin state the io thread mutates — the #1134 heap-corruption shape), so it
+/// arrives with verdicts already decided beside that state. The embedded arm
+/// gates in place and hands the verdicts straight through. Either way the
+/// SIZE arithmetic below is one implementation.
+///
+/// `enforce_block_budget` is the money-path flag. OFF (default) reproduces
+/// the pre-fix arithmetic byte-for-byte: headroom == the pin policy cap, so
+/// the block-headroom arm of pin_budget_refusal is unreachable and every
+/// splice decision is identical to what shipped. ON measures dashd's real
+/// template and refuses against the REAL remaining room.
+inline PinSpliceReport splice_verdicted_pins(
+    DashWorkData& w,
+    const std::vector<MutableTransaction>& pins,
+    const std::vector<PinVerdict>& verdicts,
+    const char* arm,
+    bool enforce_block_budget)
 {
-    size_t spliced_bytes = 0;
-    for (const auto& pin : pins) {
-        const size_t sz = ::pack(pin).get_span().size();
-        if (spliced_bytes + sz > Mempool::kMaxPinnedTotalBytes) {
-            LOG_INFO << "[" << arm << "] pinned tx EXCLUDED h=" << w.m_height
-                     << " cause=pin-total-too-large txid="
-                     << dash::coin::dash_txid(pin).GetHex().substr(0, 16)
-                     << " (" << spliced_bytes << "+" << sz << " > "
-                     << Mempool::kMaxPinnedTotalBytes
+    PinSpliceReport rep;
+    rep.causes.assign(pins.size(), "");
+    if (verdicts.size() != pins.size()) return rep;
+
+    constexpr uint64_t pin_cap = Mempool::kMaxPinnedTotalBytes;
+    // Measured ONCE, from the template as dashd handed it over — before a
+    // single pin is appended. `spliced_bytes` then tracks what we add, so the
+    // two together are exactly "occupied now". Re-measuring inside the loop
+    // would double-count the pins already appended.
+    rep.headroom = enforce_block_budget ? pin_headroom_bytes(w) : pin_cap;
+
+    for (size_t i = 0; i < pins.size(); ++i) {
+        const auto& pin = pins[i];
+        const auto& v   = verdicts[i];
+        const auto txid = dash::coin::dash_txid(pin).GetHex().substr(0, 16);
+
+        if (!v.ok) {
+            rep.causes[i] = v.cause;
+            ++rep.excluded;
+            LOG_INFO << "[" << arm << "] pinned tx EXCLUDED h=" << v.at_height
+                     << " cause=" << v.cause << " txid=" << txid
+                     << " (template built without it; re-checked next build)";
+            continue;
+        }
+
+        const uint64_t sz = ::pack(pin).get_span().size();
+        if (const char* why = pin_budget_refusal(rep.spliced_bytes, sz,
+                                                 pin_cap, rep.headroom)) {
+            rep.causes[i] = why;
+            ++rep.excluded;
+            LOG_INFO << "[" << arm << "] pinned tx EXCLUDED h=" << v.at_height
+                     << " cause=" << why << " txid=" << txid
+                     << " (" << rep.spliced_bytes << "+" << sz
+                     << " > pin_cap=" << pin_cap
+                     << " headroom=" << rep.headroom
+                     << " body=" << template_body_bytes(w)
                      << "; earlier pins keep their places)";
             continue;
         }
-        const size_t before = w.m_txs.size();
-        splice_pinned_tx(w, pin, mempool, mnstates, arm);
-        if (w.m_txs.size() != before) spliced_bytes += sz;
+
+        pin_append(w, pin);
+        rep.spliced_bytes += sz;
+        ++rep.included;
+        LOG_INFO << "[" << arm << "] pinned tx INCLUDED h=" << v.at_height
+                 << " txid=" << txid << " vin=" << pin.vin.size()
+                 << " fee=0 (rides this template)";
     }
+    return rep;
+}
+
+/// Splice EVERY admissible pin, in file order, gating each one HERE. The
+/// embedded arm's entry point; the size arithmetic is the shared one above.
+inline PinSpliceReport splice_pinned_txs(DashWorkData& w,
+                                         const std::vector<MutableTransaction>& pins,
+                                         const Mempool& mempool,
+                                         const MnStateMachine& mnstates,
+                                         const char* arm,
+                                         bool enforce_block_budget = false)
+{
+    std::vector<PinVerdict> verdicts;
+    verdicts.reserve(pins.size());
+    for (const auto& pin : pins)
+        verdicts.push_back(pin_gate_verdict(pin, mempool, mnstates, w.m_height));
+    return splice_verdicted_pins(w, pins, verdicts, arm, enforce_block_budget);
 }
 
 inline DashWorkData build_embedded_workdata(

--- a/src/impl/dash/coin/work_source.hpp
+++ b/src/impl/dash/coin/work_source.hpp
@@ -208,7 +208,7 @@ inline WorkSelection select_dash_work(
     // PINNED LOCAL TX on the SERVED-dashd arm (option B, donation lane): the
     // dashd mempool cannot carry the >100KB zero-fee consolidation (policy
     // standardness), so the pin rides OUR served copy of dashd's template
-    // instead. Same shared gate as the embedded arm (splice_pinned_tx);
+    // instead. Same shared gate as the embedded arm (splice_pinned_txs);
     // coinbase value untouched (fee 0) — stratum merkle branches and the
     // submitblock body both derive from the appended tx vectors. Fail-closed:
     // without the verify view (mempool+mnstates, i.e. --embedded-utxo) the

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -521,39 +521,25 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
                     // pin excludes itself and the rest still ride. The height
                     // logged is the one the gate JUDGED at, never fb.m_height,
                     // so a line can never claim a check it did not make.
-                    size_t spliced_bytes = 0;
-                    for (size_t i = 0; i < arm.pin_txs->size(); ++i) {
-                        const auto& pin = (*arm.pin_txs)[i];
-                        const auto& v   = arm.pin_verdicts[i];
-                        const auto txid = coin::dash_txid(pin)
-                                              .GetHex().substr(0, 16);
-                        if (!v.ok) {
-                            LOG_INFO << "[dashd-splice] pinned tx EXCLUDED h="
-                                     << v.at_height << " cause=" << v.cause
-                                     << " txid=" << txid
-                                     << " (template built without it; "
-                                        "re-checked next build)";
-                            continue;
-                        }
-                        const size_t sz = ::pack(pin).get_span().size();
-                        if (spliced_bytes + sz
-                            > coin::Mempool::kMaxPinnedTotalBytes) {
-                            LOG_INFO << "[dashd-splice] pinned tx EXCLUDED h="
-                                     << v.at_height
-                                     << " cause=pin-total-too-large txid="
-                                     << txid << " (" << spliced_bytes << "+"
-                                     << sz << " > "
-                                     << coin::Mempool::kMaxPinnedTotalBytes
-                                     << ")";
-                            continue;
-                        }
-                        coin::pin_append(fb, pin);
-                        spliced_bytes += sz;
-                        LOG_INFO << "[dashd-splice] pinned tx INCLUDED h="
-                                 << v.at_height << " txid=" << txid
-                                 << " vin=" << pin.vin.size()
-                                 << " fee=0 (rides this template)";
-                    }
+                    //
+                    // THE SHARED SPLICE (embedded_gbt.hpp). This loop used to
+                    // be an inline copy of it, and the copy had NO block-level
+                    // size accounting at all: it capped pins against a fixed
+                    // 400000 and never against what dashd's template already
+                    // held. dashd fills its own template to its own
+                    // blockmaxsize; near 2000000 that reproduces the
+                    // bad-blk-length overshoot #1177 removed from the embedded
+                    // arm — here, on the always-reachable safety path. Block
+                    // 2518186 was won on THIS arm carrying 154 KB of pin.
+                    //
+                    // pin_block_budget_ is the money-path flag: OFF (default)
+                    // is byte-for-byte the pre-fix arithmetic; ON measures
+                    // dashd's real template and refuses the overflowing pin
+                    // with a NAMED cause (pin-over-block-headroom).
+                    coin::splice_verdicted_pins(fb, *arm.pin_txs,
+                                                arm.pin_verdicts,
+                                                "dashd-splice",
+                                                pin_block_budget_);
                 }
                 sel = coin::WorkSelection{ std::move(fb),
                                            coin::WorkSource::DashdFallback,

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -327,6 +327,32 @@ public:
     /// independent seed-height + pre-emit gates.
     void set_gbt_xcheck(bool v) { gbt_xcheck_ = v; }
 
+    /// BLOCK-LEVEL PIN BUDGET on the served-dashd arm
+    /// (--dash-pin-block-budget). MONEY PATH, DEFAULT OFF.
+    ///
+    /// #1177 unified the size budget on the EMBEDDED arm. The fallback arm
+    /// never got it: it splices up to kMaxPinnedTotalBytes (400000) onto
+    /// dashd's OWN template with no block-level accounting, and dashd fills
+    /// that template to its own blockmaxsize (node/miner.cpp:212 clamps to
+    /// MaxBlockSize()-1000; DEFAULT_BLOCK_MAX_SIZE is 2000000). Near the cap,
+    /// +400 KB is the bad-blk-length overshoot that cost block 2517855 — on
+    /// the arm we call the always-reachable safety path. Block 2518186 was
+    /// won on this arm carrying 154 KB of pinned donation, so the shape is
+    /// live, not hypothetical.
+    ///
+    /// ON, the splice measures what dashd's template already occupies and
+    /// refuses the pin that would not fit, with the NAMED cause
+    /// pin-over-block-headroom. OFF, the arithmetic is byte-for-byte what
+    /// shipped: headroom collapses to the pin cap and the block-headroom arm
+    /// of the check is unreachable.
+    ///
+    /// It is OFF by default because it CHANGES SERVED BYTES in exactly the
+    /// case it fires — refusing a pin that today would ride. That is the
+    /// money-path rule, not a judgement that OFF is the better posture: a
+    /// refused pin costs one template's donation, an oversize block costs the
+    /// whole height.
+    void set_pin_block_budget(bool v) { pin_block_budget_ = v; }
+
     /// Embedded-vs-dashd SHADOW-COMPARE DIAGNOSTIC (--embedded-shadow-compare).
     /// OBSERVE-ONLY: on every template re-source the just-resolved template is
     /// handed (by copy) to this probe, which best-effort field-compares it against
@@ -641,6 +667,7 @@ private:
     bool is_testnet_{false};
     bool embedded_mainnet_{false};   // gate-lift opt-in: daemonless embedded arm on mainnet
     bool gbt_xcheck_{false};         // reward-safety backstop: cross-check embedded creditPool vs dashd
+    bool pin_block_budget_{false};   // --dash-pin-block-budget: block-level pin budget on the served-dashd arm
 
     // OBSERVE-only serve-vs-dashd shadow-compare (--embedded-shadow-compare).
     // Unset (default / pure-daemonless) => strict no-op. Never on the hot path:

--- a/test/test_dash_embedded_gbt.cpp
+++ b/test/test_dash_embedded_gbt.cpp
@@ -1576,3 +1576,256 @@ TEST(DashSizeBudget, BuilderDeductsPinsFromSelectionBudget) {
     EXPECT_LT(body, 2'000'000u)
         << "template body must stay under the consensus block limit";
 }
+
+// ════════════════════════════════════════════════════════════════════════
+// F1 — BLOCK-LEVEL SIZE BUDGET ON THE SERVED-DASHD FALLBACK ARM
+//
+// #1177 unified the size budget on the EMBEDDED arm: the consensus-required
+// set is measured BEFORE mempool selection and deducted, with an explicit
+// zero floor. The FALLBACK arm never got that discipline. It spliced up to
+// kMaxPinnedTotalBytes (400000) of pins onto dashd's OWN template with NO
+// block-level accounting — the only cap was pins-vs-400000, never
+// pins-vs-what-the-template-already-holds.
+//
+// dashd fills its template to its own blockmaxsize (node/miner.cpp:212
+// clamps to MaxBlockSize()-1000; policy/policy.h:23 DEFAULT_BLOCK_MAX_SIZE
+// is 2000000). Near that ceiling, +400 KB of pins reproduces EXACTLY the
+// bad-blk-length overshoot that cost block 2517855 — on the arm we describe
+// as the always-reachable safety path. And this arm carries pins in
+// production: block 2518186 was won on arm=dashd-fallback carrying 154 KB of
+// pinned donation.
+//
+// The ORDER is dashd's, deliberately (node/miner.cpp): coinbase reserve
+// (miner.cpp:115, nBlockSize = 1000) and the consensus-required set
+// (miner.cpp:235) may not be dropped; mempool selection is fitted into what
+// is left (miner.cpp:361). On the served-dashd arm all three have already
+// happened INSIDE dashd and arrive as a finished template, so the only
+// component left that may yield is the pin set — and it yields by being
+// REFUSED WITH A NAME, never silently.
+// ════════════════════════════════════════════════════════════════════════
+
+// A dashd template whose BODY is `body_bytes` on the wire. Only the raw hex
+// matters here: template_body_bytes() and serialize_full_block() both read
+// m_tx_data_hex, and those ARE the bytes that go on the wire
+// (block_producer.hpp:220).
+static DashWorkData dashd_template_with_body(uint64_t body_bytes) {
+    DashWorkData fb;
+    fb.m_height = H;
+    fb.m_tx_data_hex.push_back(std::string(body_bytes * 2, '0'));
+    return fb;
+}
+
+static std::vector<dash::coin::PinVerdict> all_ok_verdicts(size_t n) {
+    std::vector<dash::coin::PinVerdict> v(n);
+    for (auto& e : v) { e.ok = true; e.at_height = H; }
+    return v;
+}
+
+// The bytes the ASSEMBLED block would occupy: the same three terms
+// pin_headroom_bytes() budgets against, so the two cannot disagree.
+static uint64_t assembled_block_bytes(const DashWorkData& w) {
+    return dash::coin::kBlockOverheadBytes
+         + dash::coin::kCoinbaseReserveBytes
+         + dash::coin::template_body_bytes(w);
+}
+
+// ── THE RED ONE ─────────────────────────────────────────────────────────
+// A dashd template near blockmaxsize, spliced with a pin that is admissible
+// on every OTHER axis (inside kMaxPinnedTxBytes, inside kMaxPinnedTotalBytes,
+// gate verdict ok). The block-level budget is the ONLY thing that can refuse
+// it. It must be refused, and the refusal must be NAMED.
+TEST(DashFallbackPinBudget, PinOverBlockHeadroomIsRefusedByName) {
+    UTXOViewCache utxo(nullptr);
+    auto pin = make_admissible_pin(utxo, 600, 21'000);
+    const uint64_t pin_bytes = ::pack(pin).get_span().size();
+
+    // The pin must be inside EVERY pre-existing cap, or one of them would
+    // have refused it and this KAT would be proving someone else's guard.
+    ASSERT_LT(pin_bytes, Mempool::kMaxPinnedTxBytes)
+        << "pin must pass the per-tx size face; got " << pin_bytes;
+    ASSERT_LT(pin_bytes, Mempool::kMaxPinnedTotalBytes)
+        << "pin must pass the cumulative pin cap; got " << pin_bytes;
+
+    auto fb = dashd_template_with_body(1'950'000);
+    std::vector<MutableTransaction> pins{pin};
+
+    const uint64_t headroom = dash::coin::pin_headroom_bytes(fb);
+    ASSERT_LT(headroom, pin_bytes)
+        << "the fixture must actually leave too little room (" << headroom
+        << " for a " << pin_bytes << "-byte pin) or nothing is being tested";
+
+    auto rep = dash::coin::splice_verdicted_pins(
+        fb, pins, all_ok_verdicts(1), "dashd-splice",
+        /*enforce_block_budget=*/true);
+
+    EXPECT_EQ(rep.included, 0u) << "the pin must NOT ride a full template";
+    ASSERT_EQ(rep.causes.size(), 1u);
+    EXPECT_STREQ(rep.causes[0], "pin-over-block-headroom")
+        << "a refusal the operator cannot name is a silent drop";
+    EXPECT_LE(assembled_block_bytes(fb), dash::coin::kDashMaxBlockBytes)
+        << "the served block must stay inside the consensus limit; got "
+        << assembled_block_bytes(fb);
+}
+
+// The DEFECT, demonstrated rather than asserted around: with the budget off
+// (today's shipped arithmetic) the identical splice produces an OVERSIZE
+// block. If this ever stops overshooting, the fix above is guarding nothing
+// and this KAT says so by failing.
+TEST(DashFallbackPinBudget, WithoutTheBudgetTheSpliceGoesOversize) {
+    UTXOViewCache utxo(nullptr);
+    auto pin = make_admissible_pin(utxo, 600, 31'000);
+    auto fb = dashd_template_with_body(1'950'000);
+    std::vector<MutableTransaction> pins{pin};
+
+    auto rep = dash::coin::splice_verdicted_pins(
+        fb, pins, all_ok_verdicts(1), "dashd-splice",
+        /*enforce_block_budget=*/false);
+
+    EXPECT_EQ(rep.included, 1u)
+        << "flag OFF must be byte-for-byte the shipped behaviour: the pin "
+           "rides, cap-checked only against " << Mempool::kMaxPinnedTotalBytes;
+    EXPECT_GT(assembled_block_bytes(fb), dash::coin::kDashMaxBlockBytes)
+        << "the pre-fix arithmetic must ACTUALLY overshoot the 2 MB consensus "
+           "limit, or there is no defect here to fix; got "
+        << assembled_block_bytes(fb);
+}
+
+// The normal case must be untouched: a small dashd template with the budget
+// ON still carries the pin. A guard that refuses everything is not a guard.
+TEST(DashFallbackPinBudget, RoomyTemplateStillCarriesThePinWithBudgetOn) {
+    UTXOViewCache utxo(nullptr);
+    auto pin = make_admissible_pin(utxo, 600, 41'000);
+    auto fb = dashd_template_with_body(120'000);   // a typical live body
+    std::vector<MutableTransaction> pins{pin};
+
+    auto rep = dash::coin::splice_verdicted_pins(
+        fb, pins, all_ok_verdicts(1), "dashd-splice",
+        /*enforce_block_budget=*/true);
+
+    EXPECT_EQ(rep.included, 1u) << "a pin that fits must still ride";
+    EXPECT_STREQ(rep.causes[0], "");
+    EXPECT_LE(assembled_block_bytes(fb), dash::coin::kDashMaxBlockBytes);
+}
+
+// Earlier pins keep their places. The donation had to be SPLIT into four
+// transactions; a partial fit must land what fits rather than refuse the set.
+TEST(DashFallbackPinBudget, EarlierPinsKeepTheirPlacesWhenALaterOneOverflows) {
+    UTXOViewCache utxo(nullptr);
+    auto small = make_admissible_pin(utxo, 60,  51'000);   // ~9 KB
+    auto big   = make_admissible_pin(utxo, 600, 52'000);   // ~89 KB
+    const uint64_t small_bytes = ::pack(small).get_span().size();
+
+    // Room for the small pin and not the big one.
+    auto fb = dashd_template_with_body(1'950'000);
+    const uint64_t headroom = dash::coin::pin_headroom_bytes(fb);
+    ASSERT_GT(headroom, small_bytes);
+    ASSERT_LT(headroom, ::pack(big).get_span().size());
+
+    std::vector<MutableTransaction> pins{small, big};
+    auto rep = dash::coin::splice_verdicted_pins(
+        fb, pins, all_ok_verdicts(2), "dashd-splice",
+        /*enforce_block_budget=*/true);
+
+    EXPECT_EQ(rep.included, 1u);
+    EXPECT_STREQ(rep.causes[0], "") << "the pin that fits must ride";
+    EXPECT_STREQ(rep.causes[1], "pin-over-block-headroom");
+    EXPECT_LE(assembled_block_bytes(fb), dash::coin::kDashMaxBlockBytes);
+}
+
+// The underflow face — the one that would SILENTLY restore the old
+// behaviour. An over-cap template must starve the pin set, never wrap to a
+// budget of ~18 EB. Demonstrated against the unguarded form so the guard's
+// value is visible rather than asserted.
+TEST(DashFallbackPinBudget, OverCapTemplateYieldsZeroHeadroomNotAWrap) {
+    auto fb = dashd_template_with_body(2'500'000);   // already over the limit
+    EXPECT_EQ(dash::coin::pin_headroom_bytes(fb), 0u)
+        << "an over-cap template must leave NO room for pins";
+
+    const uint64_t occupied = assembled_block_bytes(fb);
+    const uint64_t unguarded = dash::coin::kDashMaxBlockBytes - occupied;
+    EXPECT_GT(unguarded, dash::coin::kDashMaxBlockBytes)
+        << "unguarded subtraction wraps — this is the defect being prevented";
+
+    UTXOViewCache utxo(nullptr);
+    auto pin = make_admissible_pin(utxo, 60, 61'000);
+    std::vector<MutableTransaction> pins{pin};
+    auto rep = dash::coin::splice_verdicted_pins(
+        fb, pins, all_ok_verdicts(1), "dashd-splice",
+        /*enforce_block_budget=*/true);
+    EXPECT_EQ(rep.included, 0u);
+    EXPECT_STREQ(rep.causes[0], "pin-over-block-headroom");
+}
+
+// The budget may only ever SHRINK the pin allowance, never raise it. An empty
+// template has ~2 MB free, but the pin policy cap still governs.
+TEST(DashFallbackPinBudget, HeadroomNeverExceedsThePinPolicyCap) {
+    DashWorkData empty;
+    EXPECT_EQ(dash::coin::pin_headroom_bytes(empty),
+              Mempool::kMaxPinnedTotalBytes)
+        << "the block budget must never RAISE the pin allowance";
+}
+
+// The two refusals stay distinguishable. "pin-total-too-large" is a property
+// of the pin SET; "pin-over-block-headroom" is a property of the TEMPLATE the
+// pin happened to meet. Neither is "tx-too-large", which blames the
+// transaction for something that is not its fault — and a cause name is the
+// operator's only handle on a refusal.
+TEST(DashFallbackPinBudget, TheTwoRefusalsAreNamedApart) {
+    // Over the pin-set cap, with all the block room in the world.
+    EXPECT_STREQ(dash::coin::pin_budget_refusal(
+                     /*spliced=*/Mempool::kMaxPinnedTotalBytes - 10,
+                     /*pin=*/100, Mempool::kMaxPinnedTotalBytes,
+                     /*headroom=*/1'000'000),
+                 "pin-total-too-large");
+    // Inside the pin-set cap, but the template has no room.
+    EXPECT_STREQ(dash::coin::pin_budget_refusal(
+                     /*spliced=*/0, /*pin=*/50'000,
+                     Mempool::kMaxPinnedTotalBytes, /*headroom=*/1'000),
+                 "pin-over-block-headroom");
+    // Fits both.
+    EXPECT_EQ(dash::coin::pin_budget_refusal(
+                  0, 1'000, Mempool::kMaxPinnedTotalBytes, 400'000),
+              nullptr);
+}
+
+// The occupancy figure is the SERVED one, not a re-derivation: it is read
+// from the same m_tx_data_hex that serialize_full_block() emits verbatim
+// (block_producer.hpp:220). A pin that is appended must be counted.
+TEST(DashFallbackPinBudget, BodyBytesTrackWhatIsActuallyAppended) {
+    UTXOViewCache utxo(nullptr);
+    auto pin = make_admissible_pin(utxo, 60, 71'000);
+    const uint64_t pin_bytes = ::pack(pin).get_span().size();
+
+    auto fb = dashd_template_with_body(100'000);
+    const uint64_t before = dash::coin::template_body_bytes(fb);
+    EXPECT_EQ(before, 100'000u);
+
+    std::vector<MutableTransaction> pins{pin};
+    auto rep = dash::coin::splice_verdicted_pins(
+        fb, pins, all_ok_verdicts(1), "dashd-splice", true);
+    ASSERT_EQ(rep.included, 1u);
+    EXPECT_EQ(dash::coin::template_body_bytes(fb), before + pin_bytes)
+        << "the budget must measure the bytes that actually go on the wire";
+    EXPECT_EQ(rep.spliced_bytes, pin_bytes);
+}
+
+// A gate refusal still reports the GATE's cause, not a size cause — the
+// verdicts arrive already decided (the served-dashd arm cannot run the gate
+// where it appends, #1134) and the splice must not overwrite them.
+TEST(DashFallbackPinBudget, GateRefusalKeepsItsOwnCause) {
+    UTXOViewCache utxo(nullptr);
+    auto pin = make_admissible_pin(utxo, 60, 81'000);
+    auto fb = dashd_template_with_body(1'999'000);   // no room at all
+
+    std::vector<MutableTransaction> pins{pin};
+    std::vector<dash::coin::PinVerdict> verdicts(1);
+    verdicts[0].ok = false;
+    verdicts[0].cause = "input-missing-or-spent";
+    verdicts[0].at_height = H;
+
+    auto rep = dash::coin::splice_verdicted_pins(
+        fb, pins, verdicts, "dashd-splice", /*enforce_block_budget=*/true);
+    EXPECT_EQ(rep.included, 0u);
+    EXPECT_STREQ(rep.causes[0], "input-missing-or-spent")
+        << "the size budget must not relabel a gate refusal";
+}

--- a/test/test_dash_work_source.cpp
+++ b/test/test_dash_work_source.cpp
@@ -141,7 +141,7 @@ TEST(DashWorkSource, NullMempoolRoutesFallback)
 // ─── Option B: pinned-tx splice on the SERVED-dashd arm ──────────────────────
 // The donation consolidation (>100KB, fee 0) cannot enter dashd's mempool
 // (policy standardness), so when the dashd arm serves, the pin must ride OUR
-// copy of the template — gated by the SAME splice_pinned_tx the embedded arm
+// copy of the template — gated by the SAME splice_pinned_txs the embedded arm
 // uses. Fail-closed contract: no verify view (mempool/mnstates null) → the
 // template is byte-identical to no-pin; never an unverified inclusion.
 TEST(DashWorkSource, PinnedTxExcludedOnFallbackWithoutVerifyView)


### PR DESCRIPTION
## The exposure

PR #1177 unified the block size budget on the **embedded** arm: the consensus-required set is measured before mempool selection and deducted, with an explicit zero floor. That fix was complete for the arm it covered — and left the other one open.

The served-**dashd** fallback arm splices up to `kMaxPinnedTotalBytes` (400,000) of pinned transactions onto dashd's own template with **no block-level accounting at all**. The only cap is pins-vs-400KB. Never pins-vs-what-the-template-already-holds.

dashd fills its template to its own `blockmaxsize`. If that sits near 2,000,000, adding 400 KB reproduces exactly the `bad-blk-length` overshoot that cost us block **2517855** — on the arm we describe as the always-reachable safety path.

**This is not hypothetical.** Block 2518186 was won on `arm=dashd-fallback` while carrying 154 KB of pinned donation. We are one large dashd template away from losing a block to a class we have already paid for once.

## The fix

The fallback splice now gets the same discipline as the embedded arm: measure what dashd's template already occupies, and refuse or trim the pin set against the **real remaining headroom** rather than a fixed 400 KB.

The ordering mirrors dashd's `node/miner.cpp` deliberately, because the order encodes what may be dropped:

| component | may be dropped? |
|---|---|
| coinbase reserve | no — required |
| consensus-required set | no |
| pins | policy, sized as an upper bound |
| mempool selection | yes — worth only fees, so fees yield |

**A refusal is named, never silent.** The gate already has a `TooLarge` face; an over-headroom pin is refused with `pin-over-block-headroom` rather than dropped quietly. Refusing a pin is correct and cheap. Losing a block is not.

## Flag

`--dash-pin-block-budget`, **default OFF**.

The author gated it without being asked, and stated the reason plainly: this is **not byte-neutral**, so it must be gated — it changes served bytes in exactly the case it fires, by refusing a pin that would otherwise ride. That is the correct reading of the money-path rule, applied by the person who would have benefited from reading it the other way.

## What a skeptic did to it

The reviewer rebuilt from scratch in the author's worktree, ran both binaries, and ran **ten independent mutations**. **Zero of the nine new tests survived its own mutation.**

The load-bearing one, quoted from the run:

```
replace the guard with:  if (false) return "pin-over-block-headroom";
rebuild (BUILD_EXIT=0), rerun

4 of 9 new KATs FAIL:
  Expected: (assembled_block_bytes(fb)) <= (dash::coin::kDashMaxBlock...)
```

The assertion is on the **assembled block size**, not on a transcription of the budget expression — so it fails on the property, not on the arithmetic. That distinction matters here: a KAT in #1177 was later found to pass with its guard deleted, because it re-stated the formula instead of driving the builder.

No consensus check runs less often. No per-coin isolation breach. No replay schema change — every input is already in hand at splice time: dashd's template body arrives as `DashWorkData::m_tx_data_hex`, and the consensus limit is a ported constant.

## Known gap

**No end-to-end test through `DASHWorkSource`.** The KATs exercise `splice_verdicted_pins` directly. The live fallback arm now calls that exact function — the hand-copy it used to carry was deleted — so coverage is by construction, but a reviewer who wants the seam exercised from the work-source entry point will not find that test here. Stated rather than implied.
