### PR TITLE
dash: derive already-mined quorum commitments from our own replay

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -65,6 +65,7 @@
 #include <impl/dash/coin/arm_resolution.hpp>   // dash::coin::resolve_embedded_arm (#738 arm decision, one place)
 #include <impl/dash/coin/dkg_window.hpp>       // dash::coin::is_dkg_commitment_window (BLOCKER-1 guard)
 #include <impl/dash/coin/dkg_commitments.hpp>  // E1: build_daemonless_qc_plan (serve DKG windows daemonlessly)
+#include <impl/dash/coin/mined_commitment_index.hpp>  // PR-2 FORWARD: dashd's mined-commitment store, from OUR replay
 #include <impl/dash/coin/qc_episode_classifier.hpp>  // [QC-EPISODE] terminal-event classifier (null-arm design §8)
 #include <impl/dash/coin/vendor/bls_verify.hpp>  // E1 Phase-L: make_commitment_bls_verifier (real qc verify seam)
 #include <impl/dash/coin/chainlock_verify.hpp>   // live-path ChainLock quorum selection + BLS verify gate
@@ -277,6 +278,22 @@ std::string g_replay_fold_worklists;          // --replay-fold-worklists FILE
 // serve are both fine WITHOUT proving the serve is daemonless.
 bool        g_no_dashd_mn_seed = false;       // --embedded-no-dashd-mn-seed
 
+// ── PR-2 FORWARD: --replay-mined-commitment-index ─────────────────────────
+// Arms the forward half of dashd's mined-commitment store
+// (mined_commitment_index.hpp, ported from v23.1.7 llmq/blockprocessor.cpp)
+// off the replay lane, and — ONLY once armed — offers it as a SECOND
+// "already mined" source to the daemonless qc plan, alongside the
+// mnlistdiff/qrinfo-fed QuorumManager.
+//
+// ⚠ MONEY PATH, default OFF. A slot that reads already-mined is a type-6 tx
+// the served template no longer carries, so this is byte-visible. The index
+// itself REFUSES TO ARM when the node's tip is live (dashd's UndoBlock half
+// is not ported; a reorg would leave a phantom mined record and the template
+// would be short one qfcommit => bad-qc-missing => lost block). The flag is
+// therefore two gates deep: the operator must ask for it AND the tip posture
+// must permit it.
+bool        g_mined_commitment_index = false; // --replay-mined-commitment-index
+
 // ───────────────────────────────────────────────────────────────────────────
 // [BLOCK-LEDGER] — our own block accounting, from PERSISTENT state
 // ───────────────────────────────────────────────────────────────────────────
@@ -391,6 +408,7 @@ void print_banner(const char* argv0)
         << "           [--replay-bulk] [--replay-bulk-capture DIR] [--replay-bulk-start H]\n"
         << "           [--replay-fold-prestate FILE] [--replay-fold-quorums]\n"
         << "           [--replay-fold-qsnapshot FILE] [--replay-fold-worklists FILE]\n"
+        << "           [--replay-mined-commitment-index]\n"
         << "           [--embedded-no-dashd-mn-seed]\n"
         << "           [--oracle-graduation-blocks N] [--oracle-class-coverage K]\n"
         << "           [--give-author PCT] [-f|--fee PCT] [--node-owner-address ADDR]\n"
@@ -3189,6 +3207,12 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // Constructed only alongside the fold engine.
     std::unique_ptr<dash::coin::replay::FoldLiveTail>          replay_live_tail;
     std::unique_ptr<dash::coin::replay::ReplayPayeePublisher>  replay_payee_pub;
+    // PR-2 FORWARD: dashd's mined-commitment store, fed from the same replayed
+    // bodies. shared_ptr because the qc-plan lambda (installed far above, on
+    // the serve path) captures it by value and must see it appear later — it
+    // stays null, and the lambda's guard stays false, when the flag is off or
+    // the arm is refused.
+    std::shared_ptr<dash::coin::MinedCommitmentIndex>          mined_commitment_index;
     if (coin_p2p) {
         const auto dash_params = testnet
             ? dash::coin::make_dash_chain_params_testnet()
@@ -4265,7 +4289,12 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             node_coin_state.set_qc_plan_fn(
                 [&node_coin_state, hc = header_chain.get(), qc_net, qc_cache,
                  qc_gap_logged_h, qc_first_plan_h, qc_cold_note_done,
-                 qc_type_recon, qc_recon_said, qc_recon_log, qc_episode]
+                 qc_type_recon, qc_recon_said, qc_recon_log, qc_episode,
+                 // PR-2 FORWARD. By REFERENCE: the index is constructed later
+                 // in this same function (alongside the replay lane), so a
+                 // by-value capture would freeze the null it holds today.
+                 // Same lifetime class as &node_coin_state above.
+                 &mined_commitment_index]
                 (uint32_t next_h) -> std::optional<dash::coin::QcBlockPlan> {
                     if (*qc_first_plan_h == 0u) *qc_first_plan_h = next_h;
                     // Observe the MINED set at the tip we are building on.
@@ -4315,7 +4344,30 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                         },
                         qc_cache.get(),
                         /*null_evidence=*/nullptr,
-                        &gap);
+                        &gap,
+                        // ── PR-2 FORWARD: the SECOND already-mined source ──
+                        // dashd answers HasMinedCommitment from the block it
+                        // connected (v23.1.7 llmq/blockprocessor.cpp:502 over
+                        // the DB_MINED_COMMITMENT record ProcessCommitment
+                        // wrote at :359). We answered it only from the
+                        // mnlistdiff/qrinfo-fed QuorumManager — a round trip
+                        // that lands AFTER the block did, which is what turned
+                        // "another miner already mined this slot" into
+                        // qc-plan-underivable episodes of 512/302/283/249 s.
+                        //
+                        // Two gates deep: null unless the operator passed
+                        // --replay-mined-commitment-index AND the index armed
+                        // (it REFUSES on a live tip — the undo half is not
+                        // ported). Both false => this is nullptr and the plan
+                        // is byte-identical to before.
+                        (mined_commitment_index
+                         && mined_commitment_index->armed())
+                            ? std::function<bool(uint8_t, const uint256&)>(
+                                  [mi = mined_commitment_index](
+                                      uint8_t t, const uint256& qh) {
+                                      return mi->has_mined_commitment(t, qh);
+                                  })
+                            : std::function<bool(uint8_t, const uint256&)>());
                     if (!plan && !gap.quorum_hash.IsNull()
                         && *qc_gap_logged_h != next_h) {
                         *qc_gap_logged_h = next_h;
@@ -5678,6 +5730,73 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 }
             }
 
+            // ── PR-2 FORWARD: the mined-commitment store ──────────────────
+            // Placed HERE, after replay_live_tail is (or is not) constructed,
+            // because that pointer is the STRUCTURAL answer to "is this
+            // node's tip live?". FoldLiveTail subscribes block_connected and
+            // hands LIVE TIP blocks to the same fold consumer this index
+            // rides — so its existence means a disconnect can reach us, and
+            // the missing UndoBlock half would matter. The posture is read
+            // off the wiring, never guessed from how old the tip looks.
+            if (g_mined_commitment_index && replay_fold_consumer
+                && replay_fold_engine) {
+                dash::coin::MinedCommitmentIndexConfig micfg;
+                micfg.enabled = true;   // the operator asked for it by name
+                micfg.network = testnet ? dash::coin::LlmqNetwork::Testnet
+                                        : dash::coin::LlmqNetwork::Mainnet;
+                auto mi = std::make_shared<dash::coin::MinedCommitmentIndex>(
+                    micfg);
+                mi->seed_cursor(replay_fold_engine->height());
+                dash::coin::TipPosture posture;
+                posture.live = (replay_live_tail != nullptr);
+                posture.declared_by =
+                    replay_live_tail
+                        ? "FoldLiveTail is wired (live tip blocks are folded "
+                          "into this same consumer)"
+                        : "no FoldLiveTail: this consumer sees only replayed "
+                          "historical bodies";
+                const auto verdict = mi->arm(posture);
+                std::cout << "[run] " << verdict.reason << "\n";
+                LOG_INFO << "[QC-MINED-INDEX] " << verdict.reason;
+                if (verdict.armed) {
+                    mined_commitment_index = mi;
+                    // Chain onto whatever pre_fold the quorum seam installed:
+                    // the index observes the block FIRST (it needs no folded
+                    // state), then the quorum lane, then the DML fold. A
+                    // refusal here is reported through the same channel the
+                    // quorum lane uses and never stops the fold.
+                    auto prev = replay_fold_consumer->take_pre_fold();
+                    replay_fold_consumer->set_pre_fold(
+                        [mi, prev, hc = header_chain.get()](
+                            uint32_t h, const uint256& bh,
+                            const dash::coin::BlockType& blk) -> std::string {
+                            std::string err;
+                            const auto r = mi->process_block(
+                                h, bh, blk,
+                                [hc](uint32_t q) -> std::optional<uint256> {
+                                    if (auto e = hc->get_header_by_height(q))
+                                        return e->hash;
+                                    return std::nullopt;
+                                },
+                                &err);
+                            std::string out;
+                            if (r != dash::coin::MinedIngestResult::Applied)
+                                out = "mined-commitment index refused: " + err;
+                            if (prev) {
+                                const std::string q = prev(h, bh, blk);
+                                if (!q.empty())
+                                    out = out.empty() ? q : (out + "; " + q);
+                            }
+                            return out;
+                        });
+                }
+            } else if (g_mined_commitment_index) {
+                std::cout << "[run] --replay-mined-commitment-index given but "
+                             "no replay fold consumer (needs "
+                             "--replay-fold-prestate) — mined-commitment "
+                             "index NOT armed\n";
+            }
+
             if (!g_replay_bulk_capture_dir.empty()) {
                 replay_capture = std::make_unique<rp::CaptureReplayConsumer>(
                     g_replay_bulk_capture_dir, replay_consumer);
@@ -5811,6 +5930,7 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                     br = replay_quorum_bridge.get(),
                                     pp = replay_payee_pub.get(),
                                     lt = replay_live_tail.get(),
+                                    mi = mined_commitment_index,
                                     tick = std::make_shared<uint64_t>(0)] {
                 ln->tick(std::chrono::duration_cast<std::chrono::seconds>(
                     std::chrono::steady_clock::now().time_since_epoch())
@@ -5830,6 +5950,10 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 // watched from another terminal still reports what it proved.
                 if (fc && ++*tick % 30 == 0) {
                     LOG_INFO << fc->summary();
+                    // PR-2 FORWARD: the mined-commitment store's own line —
+                    // cursor, how many mined records it holds, and (issue #90)
+                    // which llmq type is still short of the full active quota.
+                    if (mi) LOG_INFO << mi->summary();
                     if (br) {
                         const auto& bs = br->stats();
                         LOG_INFO << "[REPLAY-SEAM] member_cycles_derived="
@@ -5857,17 +5981,36 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                  << bs.quorum_roots_matched << "/"
                                  << bs.quorum_roots_differed
                                  << " self_check="
-                                 << (br->self_check_armed() ? "armed"
-                                                            : "UNARMED")
+                                 << (br->self_check_armed()
+                                        ? "armed@h="
+                                              + std::to_string(
+                                                    bs.self_check_armed_at)
+                                        : std::string("UNARMED"))
+                                 // ── ISSUE #90 ─────────────────────────
+                                 // The counter now either MEASURES (armed:
+                                 // the reconstructed active set IS dashd's,
+                                 // a differ poisons) or NAMES ITS BLOCKING
+                                 // CONDITION (unarmed: which llmq type is
+                                 // short and by how many). It can no longer
+                                 // read `0/N` with nothing to say.
                                  << (br->self_check_armed()
                                         ? std::string()
                                         : std::string(
-                                              " (unarmed: no quorum-set seed —"
-                                              " a differ here is warm-up, NOT"
-                                              " divergence; the SERVED root is"
-                                              " measured by the shadow"
-                                              " comparison, not by this"
-                                              " counter)"))
+                                              " (unarmed: active set "
+                                              "incomplete — ")
+                                              + br->active_set_shortfall_text()
+                                              + "; on mainnet type1"
+                                                " (LLMQ_50_60) is short"
+                                                " FOREVER: its last 24"
+                                                " commitments were mined"
+                                                " before DIP0024 (~h1738698)"
+                                                " and no forward replay from"
+                                                " a modern anchor can observe"
+                                                " them — they must be SEEDED"
+                                                " or reached by a genesis"
+                                                " replay. Until then a differ"
+                                                " here is warm-up, NOT"
+                                                " divergence)")
                                  << (bs.last_skip_reason.empty()
                                         ? std::string()
                                         : " last_skip=\"" + bs.last_skip_reason + "\"");
@@ -6948,6 +7091,9 @@ int main(int argc, char** argv)
             g_replay_fold_qsnapshot = argv[++i];
         else if (std::strcmp(argv[i], "--replay-fold-worklists") == 0 && i + 1 < argc)
             g_replay_fold_worklists = argv[++i];
+        // PR-2 FORWARD: the mined-commitment store, fed from our own replay.
+        else if (std::strcmp(argv[i], "--replay-mined-commitment-index") == 0)
+            g_mined_commitment_index = true;
         // THE PROOF POSTURE: keep the dashd RPC (shadow-compare) but cut the
         // PAYEE axis off from it — see g_no_dashd_mn_seed.
         else if (std::strcmp(argv[i], "--embedded-no-dashd-mn-seed") == 0)

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -5982,17 +5982,23 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                  << bs.quorum_roots_differed
                                  << " self_check="
                                  << (br->self_check_armed()
-                                        ? "armed@h="
-                                              + std::to_string(
-                                                    bs.self_check_armed_at)
+                                        ? std::string("armed")
                                         : std::string("UNARMED"))
                                  // ── ISSUE #90 ─────────────────────────
-                                 // The counter now either MEASURES (armed:
-                                 // the reconstructed active set IS dashd's,
-                                 // a differ poisons) or NAMES ITS BLOCKING
-                                 // CONDITION (unarmed: which llmq type is
-                                 // short and by how many). It can no longer
-                                 // read `0/N` with nothing to say.
+                                 // The counter now NAMES ITS BLOCKING
+                                 // CONDITION — which llmq type is short and
+                                 // by how many — instead of reading `0/N`
+                                 // with nothing to say. NOTHING IN THIS
+                                 // BINARY ARMS THE SELF-CHECK: the arming
+                                 // half of #90 is deliberately not in this
+                                 // PR (see the ISSUE #90 note in
+                                 // ReplayQuorumBridge::observe — armed, a
+                                 // root differ is a hard stop that can stop
+                                 // SERVING, so it needs its own default-OFF
+                                 // flag and its own KAT). The armed branch
+                                 // below reads the real state rather than
+                                 // asserting a constant, so the line stays
+                                 // truthful when #90 lands.
                                  << (br->self_check_armed()
                                         ? std::string()
                                         : std::string(

--- a/src/impl/dash/coin/dkg_commitments.hpp
+++ b/src/impl/dash/coin/dkg_commitments.hpp
@@ -876,6 +876,18 @@ struct QcBlockPlan {
 /// (per-height all-or-nothing) — and the embedded arm must fail closed to
 /// the dashd fallback (exactly the PHASE-1 refusal, but now only when
 /// genuinely unable rather than for the whole window).
+/// `also_has_mined` is the PR-2 forward seam (mined_commitment_index.hpp): a
+/// SECOND source for "this quorum's commitment is already on the chain",
+/// derived from our own block replay instead of from an mnlistdiff/qrinfo
+/// round trip. It is OR'd into the QuorumManager answer, so it can only ever
+/// make FEWER slots mandatory — never more, and never a different commitment.
+///
+/// ⚠ MONEY PATH. A slot dropped from the mandatory set is a type-6 tx the
+/// served template no longer carries. That is byte-visible, so the source must
+/// be a mined record that a reorg cannot invalidate — which is exactly why
+/// MinedCommitmentIndex refuses to arm on a live-tip node until dashd's
+/// UndoBlock half (v23.1.7 llmq/blockprocessor.cpp:383-408) is ported.
+/// Defaulted null: every pre-existing caller keeps byte-identical behaviour.
 inline std::optional<QcBlockPlan> build_daemonless_qc_plan(
     LlmqNetwork net, uint32_t next_height,
     const QuorumManager& qmgr,
@@ -883,10 +895,12 @@ inline std::optional<QcBlockPlan> build_daemonless_qc_plan(
     const std::function<std::optional<uint32_t>(const uint256&)>& height_of_hash,
     const MineableCommitmentCache* cache = nullptr,
     const DkgNullEvidenceFn& null_evidence = nullptr,
-    RequiredQcSlot* first_gap = nullptr)
+    RequiredQcSlot* first_gap = nullptr,
+    const std::function<bool(uint8_t, const uint256&)>& also_has_mined = nullptr)
 {
-    auto has_mined = [&qmgr](uint8_t t, const uint256& qh) {
-        return qmgr.find(t, qh).has_value();
+    auto has_mined = [&qmgr, &also_has_mined](uint8_t t, const uint256& qh) {
+        if (qmgr.find(t, qh).has_value()) return true;
+        return also_has_mined ? also_has_mined(t, qh) : false;
     };
     auto commitments = daemonless_qc_commitments(
         net, next_height, hash_at_height, has_mined, cache,

--- a/src/impl/dash/coin/mined_commitment_index.hpp
+++ b/src/impl/dash/coin/mined_commitment_index.hpp
@@ -1,0 +1,862 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// ───────────────────────────────────────────────────────────────────────────
+/// PR-2 FORWARD — the MINED-COMMITMENT store, ported from dashd v23.1.7.
+/// ───────────────────────────────────────────────────────────────────────────
+///
+/// WHAT DASHD DOES THAT WE DID NOT
+///
+/// dashd learns that an LLMQ commitment has been MINED at the instant it
+/// CONNECTS the block that carries the qfcommit tx. `CQuorumBlockProcessor::
+/// ProcessBlock` (llmq/blockprocessor.cpp:165) pulls the block's type-6
+/// payloads via `GetCommitmentsFromBlock` (:423) and `ProcessCommitment`
+/// (:267) writes two records per non-null commitment (:359-368):
+///
+///     DB_MINED_COMMITMENT                   (llmqType, quorumHash) -> (qc, blockHash)
+///     DB_MINED_COMMITMENT_BY_INVERSED_HEIGHT(llmqType, minedHeight) -> quorumBaseHeight
+///     …_Q_INDEXED                           (llmqType, qIdx, minedHeight) -> quorumBaseHeight
+///
+/// Those three are read by `HasMinedCommitment` (:502), `GetMinedCommitment`
+/// (:517), `GetMinedCommitmentsUntilBlock` (:529),
+/// `GetLastMinedCommitmentsByQuorumIndexUntilBlock` (:571) and
+/// `GetMinedAndActiveCommitmentsUntilBlock` (:660) — and, through
+/// `GetNumCommitmentsRequired` (:455), they are what decides WHICH type-6
+/// commitments a block MUST carry.
+///
+/// c2pool had no equivalent. `compute_required_qc_slots`
+/// (dkg_commitments.hpp:407) answers `has_mined` from the QuorumManager, and
+/// the QuorumManager is fed ONLY from mnlistdiff `newQuorums` / qrinfo
+/// `lastCommitmentPerIndex` (quorum_manager.hpp:6-21) — a REQUEST/RESPONSE
+/// round trip that lands some time after the block did. Until it lands, a
+/// slot another miner has already filled still reads "not mined", the slot
+/// stays mandatory, we have no verified commitment for it, and the WHOLE
+/// height refuses with cause=qc-plan-underivable (node_coin_state.hpp:1314).
+///
+/// That refusal was 84.3% of the steady-state non-serves on the 12-hour
+/// daemonless soak and the only cause with a fat tail (episodes of 512, 302,
+/// 283, 249, 194 s). The block that ended each of those episodes had ALREADY
+/// been folded by this node — the fact just never reached the gate.
+///
+/// This file is the missing store. It is fed from OUR OWN block replay: the
+/// same parsed bodies the DML fold, the credit pool and the payee queue
+/// already consume.
+///
+/// ───────────────────────────────────────────────────────────────────────────
+/// FORWARD HALF ONLY — AND THE CODE ENFORCES IT
+/// ───────────────────────────────────────────────────────────────────────────
+///
+/// `UndoBlock` (llmq/blockprocessor.cpp:383-408) is NOT ported. It erases the
+/// same three records and re-offers the commitment as mineable when a block is
+/// DISCONNECTED. Without it a reorg leaves a phantom mined record, `has_mined`
+/// answers true for a commitment the new chain never mined, the slot drops out
+/// of the mandatory set, and the template we serve is short one type-6 tx —
+/// `bad-qc-missing` (blockprocessor.cpp:198), i.e. a LOST BLOCK. This is not
+/// hypothetical on this fleet: the hotel primary lost 2508008 to a stale payee
+/// and orphaned 2517855.
+///
+/// So the index REFUSES TO ARM on a node whose tip is live (`arm()` below).
+/// The refusal is a code path, not a paragraph in a design doc: whoever turns
+/// the flag on next month gets a named refusal instead of a silent gamble.
+/// A second, independent guard runs per block — `process_block()` refuses any
+/// height it did not expect next, so the store can only ever be built by a
+/// strictly forward, contiguous walk.
+///
+/// ───────────────────────────────────────────────────────────────────────────
+/// TRUST BOUNDARY
+/// ───────────────────────────────────────────────────────────────────────────
+///
+/// dashd processes commitments from blocks that have already passed full
+/// consensus validation, including `CFinalCommitment::Verify` with the real
+/// member sets. We are an SPV-shaped node: the equivalent available proof is
+/// that the body folds to the PoW-verified header's committed merkle root.
+/// `process_block()` re-asserts that itself (`block_body_binds_to_header`,
+/// block_producer.hpp:95) instead of trusting its caller — the same
+/// defence-in-depth `on_block_connected_impl` applies
+/// (coin_state_maintainer.hpp:1120-1129). What this store therefore asserts is
+/// "the chain we followed mined this commitment at this height", which is
+/// exactly the question `GetNumCommitmentsRequired` asks. It does NOT assert
+/// that the commitment's BLS signatures verify: that is
+/// `MineableCommitmentCache::verified_for`'s job and it is unchanged, because
+/// a commitment we SERVE must be verified, while a commitment that merely
+/// makes a slot non-mandatory need only have been mined.
+
+#include <impl/dash/coin/block.hpp>
+#include <impl/dash/coin/block_producer.hpp>   // block_body_binds_to_header
+#include <impl/dash/coin/dkg_commitments.hpp>  // LlmqParamsView, is_mining_phase
+#include <impl/dash/coin/quorum_root.hpp>      // hash_commitment
+#include <impl/dash/coin/vendor/llmq_commitment.hpp>
+
+#include <core/log.hpp>
+#include <core/uint256.hpp>
+
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <map>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace dash {
+namespace coin {
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Configuration + the arm guard
+// ═══════════════════════════════════════════════════════════════════════════
+
+struct MinedCommitmentIndexConfig {
+    /// THE FLAG. Default OFF. A default-constructed config refuses to arm, so
+    /// nothing reaches this store unless an operator asked for it by name.
+    bool        enabled{false};
+    LlmqNetwork network{LlmqNetwork::Mainnet};
+    /// Retention for the inversed-height indices, in MULTIPLES OF THE ACTIVE
+    /// QUOTA per key — never in blocks. dashd keeps them forever in evoDB; we
+    /// are in-memory, and every reader takes at most signingActiveQuorumCount
+    /// entries per type (per quorumIndex for rotated types), so keeping a few
+    /// multiples of that is lossless and bounded. See prune() for why a
+    /// height window is the wrong shape here: mainnet's LLMQ_50_60 active
+    /// commitments are 775k blocks old and never leave the active set.
+    uint16_t    keep_cycles{4};
+};
+
+/// What the caller declares about the chain position it is feeding from.
+/// `live` means: this node follows the network tip, so a DISCONNECT can
+/// happen and the missing `UndoBlock` half would matter.
+///
+/// The field is a DECLARATION, not a guess. Production derives it from
+/// structure (is a live-tip lane feeding this consumer?), never from a
+/// heuristic like "the tip looks old".
+struct TipPosture {
+    bool        live{true};
+    /// Names WHO declared it. Reproduced verbatim in the refusal so the
+    /// operator can see which wiring decided, not just that something did.
+    std::string declared_by{"unspecified"};
+};
+
+struct MinedIndexArmVerdict {
+    bool        armed{false};
+    std::string reason;   // always populated, on success too
+};
+
+/// Per-block outcome. Every non-Applied value NAMES a dashd rejection code
+/// where one exists, so a refusal here reads the same as the one the daemon
+/// would have produced.
+enum class MinedIngestResult : uint8_t {
+    Applied = 0,
+    NotArmed,            // arm() was never called, or refused
+    NonContiguous,       // forward-only walk violated
+    BodyNotBound,        // body merkle root != header commitment
+    BadQcPayload,        // dashd "bad-qc-payload"          (:434)
+    BadQcCommitmentType, // dashd "bad-qc-commitment-type"  (:440)
+    BadQcDupInBlock,     // dashd "bad-qc-dup"              (:448)
+    BadQcDupMined,       // dashd "bad-qc-dup"              (:322)
+    BadQcHeight,         // dashd "bad-qc-height"           (:327)
+    BadQcBlock,          // dashd "bad-qc-block"            (:303/:311)
+    BaseUnresolvable,    // LookupBlockIndex(qc.quorumHash) == nullptr (:333)
+};
+
+inline const char* mined_ingest_result_name(MinedIngestResult r)
+{
+    switch (r) {
+        case MinedIngestResult::Applied:             return "applied";
+        case MinedIngestResult::NotArmed:            return "not-armed";
+        case MinedIngestResult::NonContiguous:       return "non-contiguous";
+        case MinedIngestResult::BodyNotBound:        return "body-not-bound";
+        case MinedIngestResult::BadQcPayload:        return "bad-qc-payload";
+        case MinedIngestResult::BadQcCommitmentType: return "bad-qc-commitment-type";
+        case MinedIngestResult::BadQcDupInBlock:     return "bad-qc-dup";
+        case MinedIngestResult::BadQcDupMined:       return "bad-qc-dup";
+        case MinedIngestResult::BadQcHeight:         return "bad-qc-height";
+        case MinedIngestResult::BadQcBlock:          return "bad-qc-block";
+        case MinedIngestResult::BaseUnresolvable:    return "quorum-base-unresolvable";
+    }
+    return "n/a";
+}
+
+/// One DB_MINED_COMMITMENT record + the two inversed-height values.
+struct MinedCommitmentRecord {
+    vendor::CFinalCommitment commitment;
+    uint256  mined_block_hash;      // dashd DB value .second
+    uint32_t mined_height{0};
+    uint32_t quorum_base_height{0}; // dashd inversed-height value
+    int16_t  quorum_index{0};
+};
+
+/// Parsed per-block input — the same shape QuorumReplayEngine's
+/// QuorumBlockInput has, and for the same reason: KATs and lanes that have
+/// ALREADY bound the body to its header feed the parsed form, while
+/// `process_block()` is the BODY entry point that does the binding check
+/// itself. Whoever calls `process_input()` owns that proof.
+struct MinedBlockInput {
+    uint32_t height{0};
+    uint256  block_hash;
+    /// The block's type-6 payloads in tx order, nulls INCLUDED — the store
+    /// applies dashd's IsNull skip itself, because "the DKG failed here" and
+    /// "nothing was mined here" must not be conflated.
+    std::vector<vendor::CFinalCommitment> commitments;
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// The store
+// ═══════════════════════════════════════════════════════════════════════════
+
+class MinedCommitmentIndex
+{
+public:
+    /// height -> block hash of OUR chain (the `GetBlockHash(active_chain, …)`
+    /// GetQuorumBlockHash reads, blockprocessor.cpp:487).
+    using HashAtHeightFn = std::function<std::optional<uint256>(uint32_t)>;
+
+    explicit MinedCommitmentIndex(MinedCommitmentIndexConfig cfg)
+        : m_cfg(std::move(cfg)) {}
+
+    // ── Arming ───────────────────────────────────────────────────────────
+
+    /// THE GUARD. Refuses when the flag is off, and refuses when the node's
+    /// tip is LIVE — because the forward half alone is only self-consistent
+    /// on a chain that never disconnects a block.
+    MinedIndexArmVerdict arm(const TipPosture& posture)
+    {
+        MinedIndexArmVerdict v;
+        if (!m_cfg.enabled) {
+            v.reason =
+                "mined-commitment index NOT armed: the feature flag is off "
+                "(MinedCommitmentIndexConfig.enabled). Default-OFF is the "
+                "money-path posture — arming it changes which type-6 "
+                "commitments a served template is required to carry.";
+            m_armed = false;
+            m_arm_reason = v.reason;
+            return v;
+        }
+        if (posture.live) {
+            v.reason =
+                "mined-commitment index REFUSED TO ARM: the node's tip is "
+                "LIVE (declared by " + posture.declared_by + "). This is the "
+                "FORWARD half only — dashd's UndoBlock "
+                "(v23.1.7 llmq/blockprocessor.cpp:383-408) is NOT ported, so "
+                "a disconnected block would leave a phantom mined record; "
+                "has_mined_commitment() would then answer true for a "
+                "commitment the new chain never mined, the slot would drop "
+                "out of the mandatory set, and the served template would be "
+                "short one qfcommit => bad-qc-missing "
+                "(blockprocessor.cpp:198) => LOST BLOCK. Arm this only on a "
+                "replay/backfill consumer, or land the undo half first.";
+            m_armed = false;
+            m_arm_reason = v.reason;
+            return v;
+        }
+        v.armed  = true;
+        v.reason = "mined-commitment index ARMED (forward-only; tip declared "
+                   "NOT live by " + posture.declared_by + ")";
+        m_armed = true;
+        m_arm_reason = v.reason;
+        return v;
+    }
+
+    bool               armed() const      { return m_armed; }
+    const std::string& arm_reason() const { return m_arm_reason; }
+
+    /// Declare the cursor: the store is AT `height`; the next observable
+    /// block is height+1. Mirrors the replay engines' seed_cursor().
+    void seed_cursor(uint32_t height)
+    {
+        m_height = height;
+        m_seeded = true;
+    }
+
+    uint32_t height() const { return m_height; }
+    bool     seeded() const { return m_seeded; }
+
+    // ── ProcessBlock — the forward port ──────────────────────────────────
+
+    /// Port of `CQuorumBlockProcessor::ProcessBlock`'s STORE half
+    /// (blockprocessor.cpp:165) — `GetCommitmentsFromBlock` (:423) followed by
+    /// `ProcessCommitment`'s DB writes (:359-368) — with dashd's own
+    /// rejections in dashd's own order. NOT ported here, deliberately:
+    ///   * the BLS aggregate `qc.Verify` (:339) — see the TRUST BOUNDARY note;
+    ///   * the `GetNumCommitmentsRequired` completeness checks (:194-201),
+    ///     which are the VALIDATOR's job and are already modelled on the serve
+    ///     side by compute_required_qc_slots;
+    ///   * `PreComputeQuorumMembers` (:175), a cache warm-up with no store
+    ///     effect.
+    ///
+    /// `err`, when non-null, receives a sentence naming the height, the
+    /// offending commitment and the dashd code — a refusal that leaves no
+    /// trace is indistinguishable from a block that carried nothing.
+    MinedIngestResult process_block(uint32_t height, const uint256& block_hash,
+                                    const BlockType& block,
+                                    const HashAtHeightFn& hash_at_height,
+                                    std::string* err = nullptr)
+    {
+        auto fail = [&](MinedIngestResult r, const std::string& why) {
+            if (err)
+                *err = "h=" + std::to_string(height) + " "
+                     + mined_ingest_result_name(r) + ": " + why;
+            ++m_stats.blocks_refused;
+            return r;
+        };
+        // Trust boundary (see header note): the BODY entry point asserts the
+        // binding itself rather than trusting its caller.
+        if (!block_body_binds_to_header(block))
+            return fail(MinedIngestResult::BodyNotBound,
+                        "body merkle root != header commitment — a forged or "
+                        "mutated body must never write a mined record");
+
+        // ── GetCommitmentsFromBlock (blockprocessor.cpp:423-459) ─────────
+        MinedBlockInput in;
+        in.height     = height;
+        in.block_hash = block_hash;
+        std::map<uint8_t, size_t> per_type_count;
+        for (size_t i = 0; i < block.m_txs.size(); ++i) {
+            const auto& tx = block.m_txs[i];
+            if (tx.type != vendor::CFinalCommitmentTxPayload::SPECIALTX_TYPE)
+                continue;   // upstream: `tx->nType == TRANSACTION_QUORUM_COMMITMENT`
+            vendor::CFinalCommitmentTxPayload payload;
+            if (!vendor::parse_qfcommit_payload(tx.extra_payload, payload))
+                return fail(MinedIngestResult::BadQcPayload,
+                            "tx[" + std::to_string(i) + "] type-6 payload is "
+                            "unparseable (upstream GetTxPayload failure)");
+            const LlmqParamsView* p =
+                params_for(payload.commitment.llmqType);
+            if (p == nullptr)
+                return fail(MinedIngestResult::BadQcCommitmentType,
+                            "tx[" + std::to_string(i) + "] names llmqType "
+                            + std::to_string(int(payload.commitment.llmqType))
+                            + ", which is not in this network's chainparams "
+                              "llmq list");
+            // "only allow one commitment per type and per block (This was
+            // changed with rotation)" — blockprocessor.cpp:445-450.
+            if (!p->use_rotation && ++per_type_count[p->type] > 1)
+                return fail(MinedIngestResult::BadQcDupInBlock,
+                            "a second non-rotated type-"
+                            + std::to_string(int(p->type))
+                            + " commitment in one block");
+            in.commitments.push_back(std::move(payload.commitment));
+        }
+        return process_input(in, hash_at_height, err);
+    }
+
+    /// The PARSED entry point. Same store writes, same dashd rejections; the
+    /// body↔header binding is the CALLER's proof here (see MinedBlockInput).
+    MinedIngestResult process_input(const MinedBlockInput& in,
+                                    const HashAtHeightFn& hash_at_height,
+                                    std::string* err = nullptr)
+    {
+        const uint32_t height = in.height;
+        auto fail = [&](MinedIngestResult r, const std::string& why) {
+            if (err)
+                *err = "h=" + std::to_string(height) + " "
+                     + mined_ingest_result_name(r) + ": " + why;
+            ++m_stats.blocks_refused;
+            return r;
+        };
+        if (!m_armed)
+            return fail(MinedIngestResult::NotArmed, m_arm_reason);
+        if (!m_seeded || height != m_height + 1)
+            return fail(MinedIngestResult::NonContiguous,
+                        "the store is at h=" + std::to_string(m_height)
+                        + (m_seeded ? "" : " (NO seeded cursor)")
+                        + " and this port is forward-only — only h="
+                        + std::to_string(m_height + 1) + " is ingestible. "
+                        "UndoBlock is not ported, so a gap can never be "
+                        "closed by re-walking.");
+        // Re-assert the per-block dup rule on the parsed path too: a caller
+        // that assembled the input itself must not be able to smuggle two
+        // non-rotated commitments of one type past bad-qc-dup.
+        {
+            std::map<uint8_t, size_t> per_type_count;
+            for (const auto& qc : in.commitments) {
+                const LlmqParamsView* p = params_for(qc.llmqType);
+                if (p == nullptr)
+                    return fail(MinedIngestResult::BadQcCommitmentType,
+                                "llmqType " + std::to_string(int(qc.llmqType))
+                                + " is not in this network's chainparams llmq"
+                                  " list");
+                if (!p->use_rotation && ++per_type_count[p->type] > 1)
+                    return fail(MinedIngestResult::BadQcDupInBlock,
+                                "a second non-rotated type-"
+                                + std::to_string(int(p->type))
+                                + " commitment in one block");
+            }
+        }
+        const auto& qcs = in.commitments;
+        const uint256& block_hash = in.block_hash;
+
+        // ── ProcessCommitment, per commitment (blockprocessor.cpp:267) ────
+        // Staged: nothing is written until EVERY commitment in the block has
+        // passed. dashd gets atomicity from the evoDB transaction that
+        // ConnectBlock rolls back on failure; a half-written block here would
+        // be exactly the phantom record the missing undo half cannot repair.
+        std::vector<MinedCommitmentRecord> staged;
+        for (const auto& qc : qcs) {
+            const LlmqParamsView* p = params_for(qc.llmqType);
+            // GetQuorumBlockHash (:487): base = nHeight − nHeight%dkgInterval
+            //                                    + quorumIndex
+            const uint32_t base_h = height - (height % p->dkg_interval)
+                                  + static_cast<uint32_t>(qc.quorumIndex);
+            auto base_hash = hash_at_height ? hash_at_height(base_h)
+                                            : std::nullopt;
+            if (!base_hash || base_hash->IsNull())
+                // Upstream returns uint256() here and ProcessCommitment then
+                // rejects bad-qc-block (:303).
+                return fail(MinedIngestResult::BadQcBlock,
+                            "quorum base height " + std::to_string(base_h)
+                            + " has no known block hash on our chain");
+            if (*base_hash != qc.quorumHash)
+                // blockprocessor.cpp:311 — quorumHash != qc.quorumHash.
+                return fail(MinedIngestResult::BadQcBlock,
+                            "commitment names quorumHash "
+                            + qc.quorumHash.GetHex().substr(0, 16)
+                            + "... but our chain has "
+                            + base_hash->GetHex().substr(0, 16)
+                            + "... at base height " + std::to_string(base_h));
+            // blockprocessor.cpp:310-320: a NULL commitment is accepted and
+            // written NOWHERE. Not folding it is the whole reason
+            // has_mined_commitment() can be trusted: a null means the DKG
+            // failed, the quorum does NOT exist, and the slot must stay
+            // mandatory for whoever mines next.
+            if (is_null_commitment(qc)) {
+                ++m_stats.commitments_null;
+                continue;
+            }
+            // blockprocessor.cpp:322 — bad-qc-dup.
+            if (has_mined_commitment(qc.llmqType, qc.quorumHash))
+                return fail(MinedIngestResult::BadQcDupMined,
+                            "type=" + std::to_string(int(qc.llmqType))
+                            + " quorum "
+                            + qc.quorumHash.GetHex().substr(0, 16)
+                            + "... is already recorded as mined at h="
+                            + std::to_string(
+                                  m_mined.at(key_of(qc.llmqType, qc.quorumHash))
+                                      .mined_height));
+            // blockprocessor.cpp:327 — bad-qc-height.
+            if (!is_mining_phase(*p, height))
+                return fail(MinedIngestResult::BadQcHeight,
+                            "h=" + std::to_string(height) + " is outside the "
+                            "type-" + std::to_string(int(p->type))
+                            + " DKG mining window ["
+                            + std::to_string(p->mining_window_start) + ","
+                            + std::to_string(p->mining_window_end)
+                            + "] of interval "
+                            + std::to_string(p->dkg_interval));
+
+            MinedCommitmentRecord rec;
+            rec.commitment        = qc;
+            rec.mined_block_hash  = block_hash;
+            rec.mined_height      = height;
+            rec.quorum_base_height = base_h;
+            rec.quorum_index      = qc.quorumIndex;
+            staged.push_back(std::move(rec));
+        }
+
+        // ── The two writes (blockprocessor.cpp:359-368) ──────────────────
+        for (auto& rec : staged) {
+            const LlmqParamsView* p = params_for(rec.commitment.llmqType);
+            const uint8_t t = rec.commitment.llmqType;
+            const IndexValue v{rec.quorum_base_height,
+                               rec.commitment.quorumHash};
+            if (p->use_rotation)
+                m_by_height_indexed[t][rec.quorum_index][rec.mined_height] = v;
+            else
+                m_by_height[t][rec.mined_height] = v;
+            m_mined[key_of(t, rec.commitment.quorumHash)] = rec;
+            ++m_stats.commitments_mined;
+        }
+
+        m_height = height;
+        ++m_stats.blocks_ingested;
+        prune(height);
+        if (err) err->clear();
+        return MinedIngestResult::Applied;
+    }
+
+    // ── Readers ──────────────────────────────────────────────────────────
+
+    /// `CQuorumBlockProcessor::HasMinedCommitment` (blockprocessor.cpp:502).
+    bool has_mined_commitment(uint8_t llmq_type, const uint256& quorum_hash) const
+    {
+        return m_mined.count(key_of(llmq_type, quorum_hash)) != 0;
+    }
+
+    /// `CQuorumBlockProcessor::GetMinedCommitment` (blockprocessor.cpp:517).
+    /// nullopt where upstream returns the default-constructed pair.
+    std::optional<MinedCommitmentRecord>
+    get_mined_commitment(uint8_t llmq_type, const uint256& quorum_hash) const
+    {
+        auto it = m_mined.find(key_of(llmq_type, quorum_hash));
+        if (it == m_mined.end()) return std::nullopt;
+        return it->second;
+    }
+
+    /// `CQuorumBlockProcessor::GetMinedCommitmentsUntilBlock`
+    /// (blockprocessor.cpp:529). Upstream seeks the INVERSED-height key so a
+    /// forward LevelDB scan walks mined heights DESCENDING; an ordered map
+    /// walked in reverse is the same traversal. Returns QUORUM BASE HEIGHTS,
+    /// most-recently-mined first — upstream returns the CBlockIndex* of that
+    /// base, which we have no equivalent of.
+    std::vector<uint32_t> mined_commitments_until_block(uint8_t llmq_type,
+                                                        uint32_t height,
+                                                        size_t max_count) const
+    {
+        std::vector<uint32_t> ret;
+        for (const auto* r : mined_records_until_block(llmq_type, height,
+                                                       max_count))
+            ret.push_back(r->quorum_base_height);
+        return ret;
+    }
+
+    /// The same walk, returning the RECORDS. Upstream hands back
+    /// CBlockIndex* and lets the caller re-read the commitment from evoDB;
+    /// we have no block index, and every consumer that wants the base height
+    /// also wants the commitment (merkleRootQuorums is a fold over
+    /// commitments), so the walk yields records and
+    /// mined_commitments_until_block projects the base height out of them.
+    std::vector<const MinedCommitmentRecord*>
+    mined_records_until_block(uint8_t llmq_type, uint32_t height,
+                              size_t max_count) const
+    {
+        std::vector<const MinedCommitmentRecord*> ret;
+        auto tit = m_by_height.find(llmq_type);
+        if (tit == m_by_height.end()) return ret;
+        ret.reserve(max_count);
+        const auto& by_h = tit->second;
+        // upper_bound(height) then walk backwards == "the greatest mined
+        // height <= height, descending" == upstream's inversed-key forward
+        // scan.
+        for (auto it = by_h.upper_bound(height);
+             it != by_h.begin() && ret.size() < max_count;) {
+            --it;
+            if (const auto* r = record_for(llmq_type, it->second.quorum_hash))
+                ret.push_back(r);
+        }
+        return ret;
+    }
+
+    /// `CQuorumBlockProcessor::GetLastMinedCommitmentsByQuorumIndexUntilBlock`
+    /// (blockprocessor.cpp:571). `cycle` counts backwards from the most
+    /// recently mined commitment for that quorumIndex (0 = the latest).
+    std::optional<uint32_t> last_mined_commitment_by_quorum_index_until_block(
+        uint8_t llmq_type, uint32_t height, int16_t quorum_index,
+        size_t cycle) const
+    {
+        if (const auto* r = last_mined_record_by_quorum_index_until_block(
+                llmq_type, height, quorum_index, cycle))
+            return r->quorum_base_height;
+        return std::nullopt;
+    }
+
+    const MinedCommitmentRecord* last_mined_record_by_quorum_index_until_block(
+        uint8_t llmq_type, uint32_t height, int16_t quorum_index,
+        size_t cycle) const
+    {
+        auto tit = m_by_height_indexed.find(llmq_type);
+        if (tit == m_by_height_indexed.end()) return nullptr;
+        auto iit = tit->second.find(quorum_index);
+        if (iit == tit->second.end()) return nullptr;
+        const auto& by_h = iit->second;
+        size_t current = 0;
+        for (auto it = by_h.upper_bound(height); it != by_h.begin();) {
+            --it;
+            if (current == cycle)
+                return record_for(llmq_type, it->second.quorum_hash);
+            ++current;
+        }
+        return nullptr;
+    }
+
+    /// `CQuorumBlockProcessor::GetLastMinedCommitmentsPerQuorumIndexUntilBlock`
+    /// (blockprocessor.cpp:620). Upstream SKIPS indices with no commitment
+    /// (`if (q.has_value())`), so the result can be shorter than
+    /// signingActiveQuorumCount — reproduced, because a shorter active set is
+    /// exactly what a partially-mined cycle looks like.
+    std::vector<uint32_t> last_mined_commitments_per_quorum_index_until_block(
+        uint8_t llmq_type, uint32_t height, size_t cycle) const
+    {
+        std::vector<uint32_t> ret;
+        for (const auto* r : last_mined_records_per_quorum_index_until_block(
+                 llmq_type, height, cycle))
+            ret.push_back(r->quorum_base_height);
+        return ret;
+    }
+
+    std::vector<const MinedCommitmentRecord*>
+    last_mined_records_per_quorum_index_until_block(uint8_t llmq_type,
+                                                    uint32_t height,
+                                                    size_t cycle) const
+    {
+        std::vector<const MinedCommitmentRecord*> ret;
+        const LlmqParamsView* p = params_for(llmq_type);
+        if (p == nullptr) return ret;
+        for (uint16_t qi = 0; qi < p->signing_active_quorum_count; ++qi) {
+            if (const auto* r = last_mined_record_by_quorum_index_until_block(
+                    llmq_type, height, static_cast<int16_t>(qi), cycle))
+                ret.push_back(r);
+        }
+        return ret;
+    }
+
+    /// `CQuorumBlockProcessor::GetMinedAndActiveCommitmentsUntilBlock`
+    /// (blockprocessor.cpp:660) — THE ACTIVE SET, per chainparams llmq type.
+    /// Rotated types take the latest commitment PER quorumIndex (cycle 0),
+    /// non-rotated types the last `signingActiveQuorumCount` mined. Values are
+    /// quorum base heights.
+    std::map<uint8_t, std::vector<uint32_t>>
+    mined_and_active_commitments_until_block(uint32_t height) const
+    {
+        std::map<uint8_t, std::vector<uint32_t>> ret;
+        for (const auto& p : chainparams_llmqs()) {
+            ret[p.type] = p.use_rotation
+                ? last_mined_commitments_per_quorum_index_until_block(
+                      p.type, height, /*cycle=*/0)
+                : mined_commitments_until_block(
+                      p.type, height, p.signing_active_quorum_count);
+        }
+        return ret;
+    }
+
+    /// The same active set as RECORDS, flattened across types. This is what
+    /// evo/cbtx.cpp CalcCbTxMerkleRootQuorums folds: every active
+    /// commitment's SerializeHash, sorted, SHA256d-merkled. The KATs use it
+    /// to re-derive real mainnet blocks' committed merkleRootQuorums from
+    /// this store alone.
+    std::vector<const MinedCommitmentRecord*>
+    active_records_until_block(uint32_t height) const
+    {
+        std::vector<const MinedCommitmentRecord*> ret;
+        for (const auto& p : chainparams_llmqs()) {
+            auto part = p.use_rotation
+                ? last_mined_records_per_quorum_index_until_block(
+                      p.type, height, /*cycle=*/0)
+                : mined_records_until_block(p.type, height,
+                                            p.signing_active_quorum_count);
+            ret.insert(ret.end(), part.begin(), part.end());
+        }
+        return ret;
+    }
+
+    /// Anchor seed for the PRE-replay active set (the Phase-1 trust class the
+    /// replay design already defines). A forward replay starting at a modern
+    /// anchor cannot observe commitments mined before it — on mainnet that
+    /// includes LLMQ_50_60's last 24, frozen since DIP0024 and still in
+    /// dashd's active set forever. Ordering among seeded entries uses the
+    /// QUORUM BASE height as the mined-height proxy: within one llmq type a
+    /// cycle's mining window closes before the next cycle starts, so mined
+    /// order is monotone in base height (the same argument
+    /// dkg_commitments.hpp's oldest-leaf eviction rests on). Seeded entries
+    /// are given mined heights BELOW the cursor so any genuinely replayed
+    /// commitment always outranks them.
+    ///
+    /// Returns false (and touches nothing) when the type is not in this
+    /// network's chainparams list, or the commitment is null — a null was
+    /// never a mined quorum and must not become one by way of a seed.
+    bool seed_mined_commitment(uint32_t quorum_base_height,
+                               const vendor::CFinalCommitment& c,
+                               std::string& err)
+    {
+        const LlmqParamsView* p = params_for(c.llmqType);
+        if (p == nullptr) {
+            err = "seed names llmqType " + std::to_string(int(c.llmqType))
+                + ", not in this network's chainparams llmq list";
+            return false;
+        }
+        if (is_null_commitment(c)) {
+            err = "seed is a NULL commitment — a failed DKG is not a mined "
+                  "quorum";
+            return false;
+        }
+        MinedCommitmentRecord rec;
+        rec.commitment         = c;
+        rec.quorum_base_height = quorum_base_height;
+        rec.quorum_index       = c.quorumIndex;
+        // Below every replayable height, order-preserving in base height.
+        rec.mined_height       = quorum_base_height;
+        const IndexValue v{quorum_base_height, c.quorumHash};
+        if (p->use_rotation)
+            m_by_height_indexed[c.llmqType][c.quorumIndex][rec.mined_height] = v;
+        else
+            m_by_height[c.llmqType][rec.mined_height] = v;
+        m_mined[key_of(c.llmqType, c.quorumHash)] = std::move(rec);
+        ++m_stats.commitments_seeded;
+        return true;
+    }
+
+    // ── Observability ────────────────────────────────────────────────────
+
+    struct Stats {
+        uint64_t blocks_ingested{0};
+        uint64_t blocks_refused{0};
+        uint64_t commitments_mined{0};
+        uint64_t commitments_null{0};
+        uint64_t commitments_seeded{0};
+    };
+    const Stats& stats() const { return m_stats; }
+    size_t       size() const  { return m_mined.size(); }
+
+    /// How far each chainparams type is from the FULL active quota at
+    /// `height` — the criterion that decides whether a set reconstructed by a
+    /// forward scan IS dashd's set. Empty => complete.
+    ///
+    /// This is the honest half of issue #90: on mainnet LLMQ_50_60 stopped
+    /// being mined at DIP0024 (~h 1738698) yet its last 24 commitments stay in
+    /// dashd's active set FOREVER (upstream walks the CHAINPARAMS list, not
+    /// the enabled one — replay_quorum_engine.hpp SCOPE GATES). A forward
+    /// replay seeded at a modern anchor can NEVER observe them from blocks, so
+    /// this method will report type 1 short by 24 forever unless those
+    /// commitments are seeded from elsewhere. A counter that cannot become
+    /// complete must SAY it cannot, not read zero in silence.
+    std::vector<std::pair<uint8_t, size_t>>
+    active_set_shortfall(uint32_t height) const
+    {
+        std::vector<std::pair<uint8_t, size_t>> out;
+        const auto active = mined_and_active_commitments_until_block(height);
+        for (const auto& p : chainparams_llmqs()) {
+            const size_t have = active.at(p.type).size();
+            if (have < p.signing_active_quorum_count)
+                out.emplace_back(p.type,
+                                 p.signing_active_quorum_count - have);
+        }
+        return out;
+    }
+
+    /// One sentence an operator can read: armed?, cursor, store size, and the
+    /// per-type shortfall by name.
+    std::string summary() const
+    {
+        std::string s = "[QC-MINED-INDEX] armed="
+                      + std::string(m_armed ? "1" : "0")
+                      + " cursor_h=" + std::to_string(m_height)
+                      + " mined=" + std::to_string(m_mined.size())
+                      + " blocks=" + std::to_string(m_stats.blocks_ingested)
+                      + " refused=" + std::to_string(m_stats.blocks_refused)
+                      + " nulls=" + std::to_string(m_stats.commitments_null);
+        if (!m_armed) return s + " reason=\"" + m_arm_reason + "\"";
+        const auto miss = active_set_shortfall(m_height);
+        if (miss.empty()) return s + " active_set=COMPLETE";
+        s += " active_set=INCOMPLETE short=";
+        for (size_t i = 0; i < miss.size(); ++i) {
+            if (i) s += ",";
+            s += "type" + std::to_string(int(miss[i].first)) + ":"
+               + std::to_string(miss[i].second);
+        }
+        return s;
+    }
+
+    /// dashd `CFinalCommitment::IsNull` (llmq/commitment.cpp): no signers and
+    /// no valid members. Exposed because the same predicate decides whether a
+    /// commitment is folded into merkleRootQuorums
+    /// (dkg_commitments.hpp compute_merkle_root_quorums_with_block).
+    static bool is_null_commitment(const vendor::CFinalCommitment& c)
+    {
+        return c.CountSigners() == 0 && c.CountValidMembers() == 0;
+    }
+
+private:
+    const std::vector<LlmqParamsView>& chainparams_llmqs() const
+    {
+        // The CHAINPARAMS list, not the runtime-enabled one: upstream's
+        // GetMinedAndActiveCommitmentsUntilBlock iterates
+        // Params().GetConsensus().llmqs (blockprocessor.cpp:664). Mainnet
+        // therefore includes LLMQ_50_60 even though it is no longer mineable.
+        static const std::vector<LlmqParamsView> kMainnet{
+            kLlmq50_60, kLlmq60_75, kLlmq400_60, kLlmq400_85, kLlmq100_67};
+        static const std::vector<LlmqParamsView> kTestnet{
+            kLlmq50_60, kLlmq60_75, kLlmq400_60, kLlmq400_85, kLlmq100_67,
+            kLlmq25_67};
+        return m_cfg.network == LlmqNetwork::Mainnet ? kMainnet : kTestnet;
+    }
+
+    const LlmqParamsView* params_for(uint8_t type) const
+    {
+        for (const auto& p : chainparams_llmqs())
+            if (p.type == type) return &p;
+        return nullptr;
+    }
+
+    static std::string key_of(uint8_t type, const uint256& qh)
+    {
+        std::string k;
+        k.push_back(static_cast<char>(type));
+        k.append(reinterpret_cast<const char*>(qh.data()), 32);
+        return k;
+    }
+
+    const MinedCommitmentRecord* record_for(uint8_t type,
+                                            const uint256& qh) const
+    {
+        auto it = m_mined.find(key_of(type, qh));
+        return it == m_mined.end() ? nullptr : &it->second;
+    }
+
+    /// Bound the in-memory inversed-height indices BY COUNT, never by height.
+    ///
+    /// This was a height-based window first, and it was WRONG in a way the
+    /// 3101-block mainnet KAT caught immediately: mainnet's LLMQ_50_60 active
+    /// commitments were mined around h≈1738xxx and are STILL in dashd's active
+    /// set at h≈2513686 — 775k blocks later, forever, because the type stopped
+    /// being mined at DIP0024 but GetMinedAndActiveCommitmentsUntilBlock keeps
+    /// walking the chainparams list (blockprocessor.cpp:664). Any height window
+    /// short enough to be worth having drops them, and the derived
+    /// merkleRootQuorums silently loses 24 leaves.
+    ///
+    /// Age is not the bound; RANK is. Every reader takes at most
+    /// signingActiveQuorumCount entries per type (per quorumIndex for rotated
+    /// types), so keeping a multiple of that per key is lossless for them and
+    /// still bounded — a few hundred entries on mainnet.
+    ///
+    /// The DB_MINED_COMMITMENT map itself is NEVER pruned: has_mined_commitment
+    /// must stay true for the life of the run (dashd erases it only in
+    /// UndoBlock), and it is bounded by the number of quorums the chain mines.
+    void prune(uint32_t)
+    {
+        auto trim = [](std::map<uint32_t, IndexValue>& by_h, size_t keep) {
+            while (by_h.size() > keep) by_h.erase(by_h.begin());
+        };
+        for (auto& [t, by_h] : m_by_height) {
+            const LlmqParamsView* p = params_for(t);
+            if (p == nullptr) continue;
+            trim(by_h, keep_per_key(p->signing_active_quorum_count));
+        }
+        for (auto& [t, by_idx] : m_by_height_indexed) {
+            const LlmqParamsView* p = params_for(t);
+            if (p == nullptr) continue;
+            for (auto& [qi, by_h] : by_idx)
+                trim(by_h, keep_per_key(1));
+        }
+    }
+
+    size_t keep_per_key(size_t quota) const
+    {
+        const size_t k = static_cast<size_t>(m_cfg.keep_cycles) * quota;
+        return k < quota ? quota : k;
+    }
+
+    /// The inversed-height index VALUE. dashd stores just the quorum base
+    /// height (blockprocessor.cpp:363-367) and re-reads the commitment from
+    /// DB_MINED_COMMITMENT via the block index; we have no block index, so
+    /// the quorumHash rides along as the key back into m_mined. The base
+    /// height is still the value every ported reader returns.
+    struct IndexValue {
+        uint32_t base_height{0};
+        uint256  quorum_hash;
+    };
+
+    MinedCommitmentIndexConfig m_cfg;
+    bool        m_armed{false};
+    std::string m_arm_reason{"arm() has not been called"};
+    bool        m_seeded{false};
+    uint32_t    m_height{0};
+    Stats       m_stats;
+
+    // DB_MINED_COMMITMENT: (llmqType, quorumHash) -> record
+    std::map<std::string, MinedCommitmentRecord> m_mined;
+    // DB_MINED_COMMITMENT_BY_INVERSED_HEIGHT: type -> minedHeight -> value
+    std::map<uint8_t, std::map<uint32_t, IndexValue>> m_by_height;
+    // …_Q_INDEXED: type -> quorumIndex -> minedHeight -> value
+    std::map<uint8_t, std::map<int16_t, std::map<uint32_t, IndexValue>>>
+        m_by_height_indexed;
+};
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/replay_fold_consumer.hpp
+++ b/src/impl/dash/coin/replay_fold_consumer.hpp
@@ -55,6 +55,7 @@
 #include <map>
 #include <optional>
 #include <string>
+#include <utility>
 
 namespace dash {
 namespace coin {
@@ -141,6 +142,12 @@ public:
     using BlockHook = std::function<std::string(uint32_t, const uint256&,
                                                 const BlockType&)>;
     void set_pre_fold(BlockHook h)  { m_pre_fold = std::move(h); }
+    /// Hand the installed pre_fold hook back so a LATER wiring can CHAIN onto
+    /// it instead of silently replacing it (PR-2 forward: the mined-commitment
+    /// index is armed after the quorum seam and must not evict it). Leaves the
+    /// consumer with no hook — the caller is expected to install the chained
+    /// one immediately.
+    BlockHook take_pre_fold() { return std::exchange(m_pre_fold, BlockHook{}); }
     void set_post_fold(std::function<void(uint32_t)> h)
     {
         m_post_fold = std::move(h);

--- a/src/impl/dash/coin/replay_quorum_bridge.hpp
+++ b/src/impl/dash/coin/replay_quorum_bridge.hpp
@@ -471,20 +471,31 @@ public:
         uint64_t lists_retained{0};
         uint64_t quorum_roots_matched{0}; // informational: folded == committed
         uint64_t quorum_roots_differed{0};
-        /// Height at which the root self-check ARMED (0 = never). Issue #90:
-        /// while this is 0 the matched/differed pair is a warm-up artefact and
-        /// must not be read as divergence; from this height on it is a real
-        /// consensus comparison and a differ POISONS the lane.
-        uint32_t self_check_armed_at{0};
         std::string last_skip_reason;
         std::string first_member_miss;    // the named first miss, verbatim
     };
     const Stats& stats() const { return m_stats; }
 
-    /// Issue #90, the reporting half: WHY the self-check is still unarmed.
-    /// Never a bare bool — the counter that gates it reads 0/N forever on
-    /// mainnet and the reason (24 frozen LLMQ_50_60 commitments no forward
-    /// replay can observe) is not inferable from the number.
+    /// Issue #90, the REPORTING half — and the only half this PR ships.
+    /// WHY the self-check is still unarmed. Never a bare bool: the counter it
+    /// gates reads 0/N forever on mainnet and the reason (24 frozen
+    /// LLMQ_50_60 commitments no forward replay can observe) is not inferable
+    /// from the number. Pure text; it changes no serving decision.
+    ///
+    /// THE ARMING HALF IS DELIBERATELY ABSENT. An earlier revision of this
+    /// file armed the root self-check from inside observe() the moment
+    /// active_sets_complete() went true. That path was NOT behind
+    /// --replay-mined-commitment-index — it was reachable with the
+    /// PRE-EXISTING --replay-fold-quorums — and once armed, a
+    /// merkleRootQuorums differ is a HARD STOP (replay_quorum_engine.hpp
+    /// observe_block, the m_self_check branch) that poisons the engine. A
+    /// poisoned engine hands the fold no member sets, the replay payee
+    /// publisher stops publishing, and the node stops SERVING. Fail-closed,
+    /// but a stop. It was inert on mainnet only because type 1 is short by 24
+    /// forever — a fact about the chain, not a property of this code.
+    /// Arming stays with issue #90, behind its own flag and its own KAT.
+    /// DashReplayQuorumSeam.BridgeNeverArmsTheRootSelfCheckByItself holds
+    /// the line: a complete active set must not arm anything by itself.
     std::string active_set_shortfall_text() const
     {
         return m_quorum.active_set_shortfall_text();
@@ -645,38 +656,34 @@ public:
             else
                 ++m_stats.quorum_roots_differed;
         }
-        // ── ISSUE #90: the arming criterion finally has a caller ──────────
-        // replay_quorum_engine.hpp documented "callers arm it once the
-        // commitment store is complete (… a warm-from-scan harness — once
-        // every type has reached its active quota)". Nothing ever did, so
-        // fold_root_vs_committed ran UNARMED for the life of every run and
-        // reported 0/N — a counter that could not disagree with anything.
+        // ── ISSUE #90: NO AUTO-ARM HERE, ON PURPOSE ──────────────────────
+        // The obvious move at this point is
+        //     if (!m_quorum.self_check_armed() && m_quorum.active_sets_complete())
+        //         m_quorum.arm_self_check();
+        // and this file shipped exactly that for one revision. It is removed.
         //
-        // Arm it the moment the reconstructed active set IS dashd's set. From
-        // that block on the comparison is a real consensus check and a
-        // mismatch poisons the lane, which is the whole point.
-        //
-        // On MAINNET this will not fire, and that is a FACT about the chain,
-        // not a bug here: LLMQ_50_60's last 24 commitments were mined before
-        // DIP0024 and stay in dashd's active set forever, so a forward replay
-        // from a modern anchor is permanently short by 24. The shortfall is
-        // now NAMED (active_set_shortfall_text()) instead of being an
-        // unexplained zero.
-        if (!m_quorum.self_check_armed() && m_quorum.active_sets_complete()) {
-            m_quorum.arm_self_check();
-            m_stats.self_check_armed_at = height;
-            LOG_INFO << "[REPLAY-SEAM] quorum-root SELF-CHECK ARMED at h="
-                     << height
-                     << ": every chainparams llmq type has reached its full"
-                        " active quota, so the reconstructed active set IS"
-                        " dashd's set. fold_root_vs_committed is a consensus"
-                        " comparison from here on; a differ now POISONS the"
-                        " lane. Warm-up counts before this height: matched="
-                     << m_stats.quorum_roots_matched << " differed="
-                     << m_stats.quorum_roots_differed;
-            m_stats.quorum_roots_matched  = 0;
-            m_stats.quorum_roots_differed = 0;
-        }
+        // Reasons, in order of how much they cost:
+        //   1. It is not behind --replay-mined-commitment-index. It rides the
+        //      PRE-EXISTING --replay-fold-quorums, so it would change what a
+        //      node already running that flag does — an unflagged change to a
+        //      lane that feeds serving.
+        //   2. Once armed, a merkleRootQuorums differ is a HARD STOP: it
+        //      poisons the engine (see the m_self_check branch of
+        //      QuorumReplayEngine::observe_block). A poisoned engine answers
+        //      no member sets, the fold stops, the replay payee publisher
+        //      stops publishing, and the node stops SERVING. It cannot mint a
+        //      WRONG payee — but "fail-closed" is still "stopped".
+        //   3. This very site runs BEFORE `if (!r.ok) return r.error;`, so it
+        //      armed even on an observation the engine REFUSED.
+        //   4. Its safety argument was "inert on mainnet, because type 1 is
+        //      short by 24 forever". That is a fact about the chain, not
+        //      about this code, and premises of that shape have inverted on
+        //      this fleet before.
+        // The REPORTING half of #90 stays (active_set_shortfall_text() names
+        // the blocking type instead of printing an unexplained 0/N); it is
+        // text and gates nothing. Arming belongs to #90's own PR, with its own
+        // default-OFF flag and a KAT that drives a complete active set through
+        // and asserts it arms — and does NOT arm one commitment short.
         if (m_cfg.debug_logs && r.member_cycles_derived > 0)
             LOG_INFO << "[REPLAY-SEAM] h=" << height << " derived "
                      << r.member_cycles_derived << " member cycle(s)";

--- a/src/impl/dash/coin/replay_quorum_bridge.hpp
+++ b/src/impl/dash/coin/replay_quorum_bridge.hpp
@@ -471,10 +471,24 @@ public:
         uint64_t lists_retained{0};
         uint64_t quorum_roots_matched{0}; // informational: folded == committed
         uint64_t quorum_roots_differed{0};
+        /// Height at which the root self-check ARMED (0 = never). Issue #90:
+        /// while this is 0 the matched/differed pair is a warm-up artefact and
+        /// must not be read as divergence; from this height on it is a real
+        /// consensus comparison and a differ POISONS the lane.
+        uint32_t self_check_armed_at{0};
         std::string last_skip_reason;
         std::string first_member_miss;    // the named first miss, verbatim
     };
     const Stats& stats() const { return m_stats; }
+
+    /// Issue #90, the reporting half: WHY the self-check is still unarmed.
+    /// Never a bare bool — the counter that gates it reads 0/N forever on
+    /// mainnet and the reason (24 frozen LLMQ_50_60 commitments no forward
+    /// replay can observe) is not inferable from the number.
+    std::string active_set_shortfall_text() const
+    {
+        return m_quorum.active_set_shortfall_text();
+    }
 
     /// Seed per-cycle rotated snapshots (Phase-1 only).
     ///
@@ -630,6 +644,38 @@ public:
                 ++m_stats.quorum_roots_matched;
             else
                 ++m_stats.quorum_roots_differed;
+        }
+        // ── ISSUE #90: the arming criterion finally has a caller ──────────
+        // replay_quorum_engine.hpp documented "callers arm it once the
+        // commitment store is complete (… a warm-from-scan harness — once
+        // every type has reached its active quota)". Nothing ever did, so
+        // fold_root_vs_committed ran UNARMED for the life of every run and
+        // reported 0/N — a counter that could not disagree with anything.
+        //
+        // Arm it the moment the reconstructed active set IS dashd's set. From
+        // that block on the comparison is a real consensus check and a
+        // mismatch poisons the lane, which is the whole point.
+        //
+        // On MAINNET this will not fire, and that is a FACT about the chain,
+        // not a bug here: LLMQ_50_60's last 24 commitments were mined before
+        // DIP0024 and stay in dashd's active set forever, so a forward replay
+        // from a modern anchor is permanently short by 24. The shortfall is
+        // now NAMED (active_set_shortfall_text()) instead of being an
+        // unexplained zero.
+        if (!m_quorum.self_check_armed() && m_quorum.active_sets_complete()) {
+            m_quorum.arm_self_check();
+            m_stats.self_check_armed_at = height;
+            LOG_INFO << "[REPLAY-SEAM] quorum-root SELF-CHECK ARMED at h="
+                     << height
+                     << ": every chainparams llmq type has reached its full"
+                        " active quota, so the reconstructed active set IS"
+                        " dashd's set. fold_root_vs_committed is a consensus"
+                        " comparison from here on; a differ now POISONS the"
+                        " lane. Warm-up counts before this height: matched="
+                     << m_stats.quorum_roots_matched << " differed="
+                     << m_stats.quorum_roots_differed;
+            m_stats.quorum_roots_matched  = 0;
+            m_stats.quorum_roots_differed = 0;
         }
         if (m_cfg.debug_logs && r.member_cycles_derived > 0)
             LOG_INFO << "[REPLAY-SEAM] h=" << height << " derived "

--- a/src/impl/dash/coin/replay_quorum_engine.hpp
+++ b/src/impl/dash/coin/replay_quorum_engine.hpp
@@ -841,6 +841,51 @@ public:
         return true;
     }
 
+    /// WHICH types are short, and by how many — issue #90's missing half.
+    ///
+    /// `active_sets_complete()` is a bare bool, so a run that never completes
+    /// cannot say WHY, and the fold_root_vs_committed counter it gates reads
+    /// `0/N` forever with no blocking condition named. It has a NAME:
+    ///
+    ///   * MAINNET, LLMQ_50_60 (type 1) short by 24, PERMANENTLY. The type
+    ///     stopped being MINED at DIP0024 (~h 1738698) but its last 24
+    ///     commitments stay in dashd's active set forever, because
+    ///     GetMinedAndActiveCommitmentsUntilBlock walks the CHAINPARAMS list
+    ///     (v23.1.7 llmq/blockprocessor.cpp:664), not the runtime-enabled one.
+    ///     A forward replay seeded at a modern anchor can NEVER observe them
+    ///     from blocks. They must be SEEDED (seed_commitment(), 24 records) or
+    ///     reached by a genesis replay (Phase 2).
+    ///   * Any other type short: warm-up. It closes on its own within
+    ///     signingActiveQuorumCount × dkgInterval blocks of the anchor —
+    ///     576 blocks for the rotated type-5 ring, 96 for type 2/3.
+    ///
+    /// Empty => complete => the reconstructed set IS dashd's set and the root
+    /// self-check may be armed.
+    std::vector<std::pair<uint8_t, size_t>> active_set_shortfall() const
+    {
+        std::vector<std::pair<uint8_t, size_t>> out;
+        for (const auto& p : replay_chainparams_llmqs(m_cfg.network)) {
+            const size_t have = active_count(p.type);
+            if (have < p.signing_active_quorum_count)
+                out.emplace_back(p.type, p.signing_active_quorum_count - have);
+        }
+        return out;
+    }
+
+    /// Human-readable form of the above; "complete" when nothing is short.
+    std::string active_set_shortfall_text() const
+    {
+        const auto miss = active_set_shortfall();
+        if (miss.empty()) return "complete";
+        std::string s;
+        for (size_t i = 0; i < miss.size(); ++i) {
+            if (i) s += ",";
+            s += "type" + std::to_string(int(miss[i].first)) + ":short"
+               + std::to_string(miss[i].second);
+        }
+        return s;
+    }
+
     /// The W1 DmlFoldEngine::MembersFn contract: ORDERED member proTxHashes
     /// of the quorum (llmqType, quorumHash), or nullopt (caller fails
     /// closed). Resolution: quorumHash → observed/seeded height → the

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -812,7 +812,18 @@ if (BUILD_TESTING AND GTest_FOUND)
         # qrinfo (dash_mainnet_qrinfo_2516785.bin) and dashd's own `quorum
         # info` member lists. Folded here per the same #769 rule; reads
         # DASH_FIXTURE_DIR.
-        test_dash_replay_quorum_engine.cpp)
+        test_dash_replay_quorum_engine.cpp
+        # test_dash_mined_commitment_index.cpp: PR-2 FORWARD
+        # (mined_commitment_index.hpp) — dashd's mined-commitment store
+        # (v23.1.7 llmq/blockprocessor.cpp ProcessBlock/ProcessCommitment/
+        # HasMinedCommitment/GetMinedCommitmentsUntilBlock) rebuilt from OUR
+        # OWN block replay: 3101-block mainnet merkleRootQuorums byte-parity
+        # over the DERIVED active set, plus the arm/contiguity/null-skip
+        # guards and the money-path has_mined seam. Reuses the same
+        # dash_mainnet_quorum_scan_* / _active_quorums_ fixtures as the W4
+        # suite above, and is folded into this target for the same #769
+        # reason (the push bot cannot add a build.yml --target).
+        test_dash_mined_commitment_index.cpp)
     target_compile_definitions(test_dash_embedded_gbt PRIVATE
         DASH_FIXTURE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/fixtures")
     target_link_libraries(test_dash_embedded_gbt PRIVATE

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -752,6 +752,12 @@ if (BUILD_TESTING AND GTest_FOUND)
         ${Boost_LIBRARIES}
     )
     target_link_libraries(test_dash_mn_state PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
+    # The seam TU's issue-#90 arming KAT seeds the mainnet anchor's full
+    # 88-commitment active set from dash_mainnet_active_quorums_2513685.txt —
+    # the same fixture the W4 engine suite uses. Test-only define; no source
+    # in this target reads it otherwise.
+    target_compile_definitions(test_dash_mn_state PRIVATE
+        DASH_FIXTURE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/fixtures")
     gtest_add_tests(test_dash_mn_state "" AUTO)
 
     # DASH embedded getblocktemplate bit-parity capstone (S7 main): fuses the

--- a/test/test_dash_mined_commitment_index.cpp
+++ b/test/test_dash_mined_commitment_index.cpp
@@ -1,0 +1,719 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// PR-2 FORWARD — src/impl/dash/coin/mined_commitment_index.hpp
+//
+// dashd's mined-commitment store, ported from v23.1.7 llmq/blockprocessor.cpp
+// and fed from OUR OWN block replay instead of an mnlistdiff round trip.
+//
+// WHY THESE KATS EXIST
+// --------------------
+// The measured 12-hour daemonless soak declined 84.3% of its steady-state
+// non-serves with cause=qc-plan-underivable, and only that cause had a fat
+// tail (512, 302, 283, 249, 194 s). The slot each of those waits was blocked
+// on had, in most cases, already been mined by another miner — in a block this
+// node had ALREADY folded. `compute_required_qc_slots` just could not see it,
+// because `has_mined` read only the QuorumManager and the QuorumManager is
+// fed by request/response.
+//
+// THE KATS
+//   A  REAL MAINNET, 3101 blocks: seed the h=2513685 active set (88
+//      commitments, from a genesis-based mnlistdiff off a mainnet dashd),
+//      replay 2513686..2516786 through the index, and at EVERY block re-derive
+//      merkleRootQuorums from the index's own active set
+//      (GetMinedAndActiveCommitmentsUntilBlock, blockprocessor.cpp:660) and
+//      byte-match the block's committed cbTx root. 3101 consecutive equalities
+//      exercise the non-rotated last-K-mined walk, the rotated
+//      latest-per-quorumIndex walk, and the null skip, against chain truth.
+//   B  the SAME replay answers has_mined_commitment() for every non-null
+//      commitment it saw, and NEVER for a null one.
+//   C  arm() REFUSES on a live tip and names UndoBlock.
+//   D  unarmed => nothing is ingested.
+//   E  forward contiguity: a skipped height is refused, not silently absorbed.
+//   F  the money-path seam: build_daemonless_qc_plan's `also_has_mined` drops
+//      an already-mined slot from the mandatory set — and does NOT when the
+//      seam is absent (the default every existing caller keeps).
+//   G  issue #90: active_set_shortfall names WHICH type is short.
+//
+// Every one of C, D, E, F is red-provable by deleting the guard it names; the
+// comment on each says exactly which line to break.
+//
+// Fixture provenance: identical files to test_dash_replay_quorum_engine.cpp
+// (captured 2026-08-05 from a read-only mainnet Dash Core v23 node).
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/mined_commitment_index.hpp>
+#include <impl/dash/coin/dkg_commitments.hpp>
+#include <impl/dash/coin/quorum_root.hpp>
+#include <impl/dash/coin/vendor/llmq_commitment.hpp>
+
+#include <core/pack.hpp>
+#include <core/uint256.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <fstream>
+#include <map>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using dash::coin::LlmqNetwork;
+using dash::coin::MinedCommitmentIndex;
+using dash::coin::MinedCommitmentIndexConfig;
+using dash::coin::MinedBlockInput;
+using dash::coin::MinedIngestResult;
+using dash::coin::TipPosture;
+using dash::coin::vendor::CFinalCommitment;
+using dash::coin::vendor::CFinalCommitmentTxPayload;
+
+namespace {
+
+std::vector<unsigned char> from_hex(const std::string& hex)
+{
+    std::vector<unsigned char> out;
+    if (hex.size() % 2) return out;
+    out.reserve(hex.size() / 2);
+    for (size_t i = 0; i < hex.size(); i += 2) {
+        auto nib = [](char c) -> int {
+            if (c >= '0' && c <= '9') return c - '0';
+            if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+            if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+            return -1;
+        };
+        const int hi = nib(hex[i]), lo = nib(hex[i + 1]);
+        if (hi < 0 || lo < 0) return {};
+        out.push_back(static_cast<unsigned char>((hi << 4) | lo));
+    }
+    return out;
+}
+
+std::vector<std::string> read_lines(const std::string& name)
+{
+    const std::string path = std::string(DASH_FIXTURE_DIR) + "/" + name;
+    std::ifstream f(path);
+    EXPECT_TRUE(f.good()) << "cannot open fixture: " << path;
+    std::vector<std::string> lines;
+    std::string l;
+    while (std::getline(f, l))
+        if (!l.empty() && l[0] != '#') lines.push_back(l);
+    return lines;
+}
+
+std::vector<std::string> split_ws(const std::string& l)
+{
+    std::istringstream ss(l);
+    std::vector<std::string> f;
+    std::string t;
+    while (ss >> t) f.push_back(t);
+    return f;
+}
+
+std::optional<CFinalCommitment> parse_commitment_hex(const std::string& hex)
+{
+    auto bytes = from_hex(hex);
+    if (bytes.empty()) return std::nullopt;
+    CFinalCommitment c;
+    try {
+        ::PackStream s(bytes);
+        s >> c;
+        if (s.cursor_size() != 0) return std::nullopt;
+    } catch (const std::exception&) {
+        return std::nullopt;
+    }
+    return c;
+}
+
+std::optional<CFinalCommitmentTxPayload> parse_qc_payload_hex(
+    const std::string& hex)
+{
+    auto bytes = from_hex(hex);
+    if (bytes.empty()) return std::nullopt;
+    CFinalCommitmentTxPayload qc;
+    std::vector<unsigned char> b(bytes.begin(), bytes.end());
+    if (!dash::coin::vendor::parse_qfcommit_payload(b, qc))
+        return std::nullopt;
+    return qc;
+}
+
+struct ScanBlock {
+    uint32_t height{0};
+    uint256  block_hash;
+    uint256  mrq;                       // committed cbTx merkleRootQuorums
+    std::vector<std::string> qc_hex;    // type-6 payloads, in tx order
+};
+
+std::vector<ScanBlock> load_scan()
+{
+    std::vector<ScanBlock> out;
+    for (const auto& l :
+         read_lines("dash_mainnet_quorum_scan_2513685_2516786.txt")) {
+        auto f = split_ws(l);
+        EXPECT_EQ(f.size(), 5u) << l.substr(0, 80);
+        if (f.size() != 5) continue;
+        ScanBlock b;
+        b.height = static_cast<uint32_t>(std::stoul(f[0]));
+        b.block_hash.SetHex(f[1]);
+        b.mrq.SetHex(f[2]);
+        if (f[4] != "-") {
+            std::stringstream ss(f[4]);
+            std::string item;
+            while (std::getline(ss, item, ',')) b.qc_hex.push_back(item);
+        }
+        out.push_back(std::move(b));
+    }
+    return out;
+}
+
+/// height -> hash for everything the KAT can resolve: the 21 pre-window
+/// blocks (2513664..2513684, the surrounding cycle base run) plus every
+/// scanned block. This stands in for the PoW-verified header chain that
+/// production passes as `hash_at_height`.
+std::map<uint32_t, uint256> build_hash_map(const std::vector<ScanBlock>& scan)
+{
+    std::map<uint32_t, uint256> m;
+    for (const auto& l :
+         read_lines("dash_mainnet_block_hashes_2513664_2513684.txt")) {
+        auto f = split_ws(l);
+        EXPECT_EQ(f.size(), 2u);
+        if (f.size() != 2) continue;
+        uint256 h;
+        h.SetHex(f[1]);
+        m[static_cast<uint32_t>(std::stoul(f[0]))] = h;
+    }
+    for (const auto& b : scan) m[b.height] = b.block_hash;
+    return m;
+}
+
+MinedCommitmentIndex::HashAtHeightFn hash_fn(
+    const std::map<uint32_t, uint256>& m)
+{
+    return [&m](uint32_t h) -> std::optional<uint256> {
+        auto it = m.find(h);
+        if (it == m.end()) return std::nullopt;
+        return it->second;
+    };
+}
+
+MinedCommitmentIndex make_armed(LlmqNetwork net = LlmqNetwork::Mainnet)
+{
+    MinedCommitmentIndexConfig cfg;
+    cfg.enabled = true;
+    cfg.network = net;
+    MinedCommitmentIndex idx(cfg);
+    TipPosture posture;
+    posture.live = false;
+    posture.declared_by = "KAT: no live-tip lane feeds this index";
+    const auto v = idx.arm(posture);
+    EXPECT_TRUE(v.armed) << v.reason;
+    return idx;
+}
+
+/// Seed the anchor's 88-commitment active set. Columns:
+/// type qidx base_height quorumHash commitment_hex.
+size_t seed_anchor(MinedCommitmentIndex& idx)
+{
+    size_t n = 0;
+    for (const auto& l :
+         read_lines("dash_mainnet_active_quorums_2513685.txt")) {
+        auto f = split_ws(l);
+        EXPECT_EQ(f.size(), 5u) << l.substr(0, 80);
+        if (f.size() != 5) continue;
+        auto c = parse_commitment_hex(f[4]);
+        if (!c) {
+            ADD_FAILURE() << "commitment slice must parse byte-exact: "
+                          << l.substr(0, 80);
+            continue;
+        }
+        std::string err;
+        EXPECT_TRUE(idx.seed_mined_commitment(
+            static_cast<uint32_t>(std::stoul(f[2])), *c, err)) << err;
+        ++n;
+    }
+    return n;
+}
+
+/// evo/cbtx.cpp CalcCbTxMerkleRootQuorums over whatever the index says is
+/// ACTIVE at `height`: SerializeHash each commitment, sort the leaves, merkle.
+uint256 root_from_index(const MinedCommitmentIndex& idx, uint32_t height)
+{
+    std::vector<uint256> leaves;
+    for (const auto* r : idx.active_records_until_block(height))
+        leaves.push_back(dash::coin::hash_commitment(r->commitment));
+    std::sort(leaves.begin(), leaves.end(),
+              [](const uint256& a, const uint256& b) {
+                  return std::memcmp(a.data(), b.data(), 32) < 0;
+              });
+    return dash::coin::compute_merkle_root_local(std::move(leaves));
+}
+
+} // namespace
+
+// ═══════════════════════════════════════════════════════════════════════════
+// KAT-A — 3101 real mainnet blocks: the ACTIVE SET the port derives
+//         reproduces every block's committed merkleRootQuorums.
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashMinedCommitmentIndex, MainnetActiveSetReproducesCommittedQuorumRoot)
+{
+    const auto scan = load_scan();
+    ASSERT_GE(scan.size(), 3000u) << "scan fixture truncated";
+    const auto hashes = build_hash_map(scan);
+
+    auto idx = make_armed();
+    const size_t seeded = seed_anchor(idx);
+    // The mainnet chainparams quotas are 24+32+4+4+24 = 88.
+    EXPECT_EQ(seeded, 88u)
+        << "the anchor's active set IS dashd's GetMinedAndActiveCommitments"
+           "UntilBlock at h=2513685";
+    EXPECT_TRUE(idx.active_set_shortfall(2513685).empty())
+        << "a full anchor seed leaves no type short — this is the seed issue"
+           " #90 asks for";
+
+    idx.seed_cursor(2513685);
+    auto at_h = hash_fn(hashes);
+
+    size_t checked = 0, with_qc = 0, payloads = 0;
+    for (const auto& b : scan) {
+        if (b.height == 2513685) continue;   // the cursor block itself
+        MinedBlockInput in;
+        in.height     = b.height;
+        in.block_hash = b.block_hash;
+        for (const auto& hex : b.qc_hex) {
+            auto p = parse_qc_payload_hex(hex);
+            ASSERT_TRUE(p.has_value())
+                << "qfcommit payload must parse byte-exact at h=" << b.height;
+            in.commitments.push_back(p->commitment);
+            ++payloads;
+        }
+        if (!in.commitments.empty()) ++with_qc;
+        std::string err;
+        const auto r = idx.process_input(in, at_h, &err);
+        ASSERT_EQ(r, MinedIngestResult::Applied)
+            << "h=" << b.height << ": " << err;
+
+        // THE PROOF: the root over the index's own active set, byte-matched
+        // against the block's committed cbTx root.
+        EXPECT_EQ(root_from_index(idx, b.height).GetHex(), b.mrq.GetHex())
+            << "merkleRootQuorums mismatch at h=" << b.height;
+        ++checked;
+    }
+    EXPECT_GE(checked, 3000u);
+    EXPECT_GT(with_qc, 100u) << "the window must actually carry commitments";
+    EXPECT_GT(payloads, 500u);
+    // The port's own bookkeeping must add up: every payload was either mined
+    // into the store or skipped as a null.
+    EXPECT_EQ(idx.stats().commitments_mined + idx.stats().commitments_null,
+              static_cast<uint64_t>(payloads));
+    EXPECT_EQ(idx.stats().blocks_refused, 0u);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// KAT-B — has_mined_commitment() is true for every non-null commitment the
+//         replay saw, and NEVER for a null one.
+//
+// RED: delete the `if (is_null_commitment(qc)) { ++…; continue; }` arm in
+// process_input (mined_commitment_index.hpp) — a null then writes a mined
+// record and the null half of this test fails. That arm is the whole reason
+// the store can be trusted: dashd's ProcessCommitment returns at
+// blockprocessor.cpp:310-320 WITHOUT writing DB_MINED_COMMITMENT, because a
+// null means the DKG failed and the slot must stay mandatory for whoever
+// mines next.
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashMinedCommitmentIndex, MinedIsTrueForRealCommitmentsAndFalseForNulls)
+{
+    const auto scan = load_scan();
+    const auto hashes = build_hash_map(scan);
+    auto idx = make_armed();
+    seed_anchor(idx);
+    idx.seed_cursor(2513685);
+    auto at_h = hash_fn(hashes);
+
+    std::vector<std::pair<uint8_t, uint256>> real_seen, null_seen;
+    for (const auto& b : scan) {
+        if (b.height == 2513685) continue;
+        MinedBlockInput in;
+        in.height     = b.height;
+        in.block_hash = b.block_hash;
+        for (const auto& hex : b.qc_hex) {
+            auto p = parse_qc_payload_hex(hex);
+            ASSERT_TRUE(p.has_value());
+            if (MinedCommitmentIndex::is_null_commitment(p->commitment))
+                null_seen.emplace_back(p->commitment.llmqType,
+                                       p->commitment.quorumHash);
+            else
+                real_seen.emplace_back(p->commitment.llmqType,
+                                       p->commitment.quorumHash);
+            in.commitments.push_back(p->commitment);
+        }
+        std::string err;
+        ASSERT_EQ(idx.process_input(in, at_h, &err),
+                  MinedIngestResult::Applied) << err;
+    }
+
+    ASSERT_FALSE(real_seen.empty());
+    for (const auto& [t, qh] : real_seen)
+        EXPECT_TRUE(idx.has_mined_commitment(t, qh))
+            << "type=" << int(t) << " quorum=" << qh.GetHex()
+            << " was mined on mainnet and the store must say so";
+
+    // Nulls are not quorums. A null does NOT close the slot — dashd writes no
+    // DB_MINED_COMMITMENT for it (blockprocessor.cpp:310-320), so the slot
+    // stays mandatory and a REAL commitment for the SAME quorumHash may be
+    // mined later in the same window. That happens on this window, so the
+    // assertion is over the nulls that were never superseded: those, and only
+    // those, must still read not-mined.
+    size_t null_only = 0;
+    for (const auto& [t, qh] : null_seen) {
+        const bool superseded =
+            std::any_of(real_seen.begin(), real_seen.end(),
+                        [&](const auto& r) {
+                            return r.first == t && r.second == qh;
+                        });
+        if (superseded) continue;
+        ++null_only;
+        EXPECT_FALSE(idx.has_mined_commitment(t, qh))
+            << "a NULL commitment that was never superseded must NEVER read "
+               "as mined (dashd writes no DB_MINED_COMMITMENT for it, "
+               "blockprocessor.cpp:310-320)";
+    }
+    EXPECT_GT(null_only, 0u)
+        << "this window must contain at least one never-superseded null, or "
+           "the null-skip arm is untested here";
+    EXPECT_EQ(idx.stats().commitments_null,
+              static_cast<uint64_t>(null_seen.size()));
+
+    // And a quorum hash the chain never committed to is not mined.
+    uint256 fake;
+    fake.SetHex("dead00000000000000000000000000000000000000000000000000000000beef");
+    EXPECT_FALSE(idx.has_mined_commitment(2, fake));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// KAT-C — the arm guard: REFUSES on a live tip, and says why.
+//
+// RED: change `if (posture.live)` in MinedCommitmentIndex::arm() to
+// `if (false)`. This test then fails on the first EXPECT_FALSE. That guard is
+// the whole safety story of the forward half: dashd's UndoBlock
+// (v23.1.7 llmq/blockprocessor.cpp:383-408) is not ported, so on a reorging
+// node a phantom mined record would drop a mandatory qfcommit out of the
+// served template => bad-qc-missing => lost block.
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashMinedCommitmentIndex, RefusesToArmOnALiveTip)
+{
+    MinedCommitmentIndexConfig cfg;
+    cfg.enabled = true;
+    MinedCommitmentIndex idx(cfg);
+
+    TipPosture live;
+    live.live = true;
+    live.declared_by = "FoldLiveTail is wired";
+    const auto refused = idx.arm(live);
+    EXPECT_FALSE(refused.armed);
+    EXPECT_FALSE(idx.armed());
+    EXPECT_NE(refused.reason.find("UndoBlock"), std::string::npos)
+        << "the refusal must name the missing half: " << refused.reason;
+    EXPECT_NE(refused.reason.find("bad-qc-missing"), std::string::npos)
+        << "and the consequence: " << refused.reason;
+    EXPECT_NE(refused.reason.find("FoldLiveTail is wired"), std::string::npos)
+        << "and WHO declared the posture: " << refused.reason;
+
+    TipPosture frozen;
+    frozen.live = false;
+    frozen.declared_by = "replay-only consumer";
+    EXPECT_TRUE(idx.arm(frozen).armed);
+    EXPECT_TRUE(idx.armed());
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// KAT-C2 — the flag itself: a default-constructed config never arms.
+//
+// RED: default MinedCommitmentIndexConfig::enabled to true.
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashMinedCommitmentIndex, DefaultConfigIsOffAndNeverArms)
+{
+    MinedCommitmentIndex idx{MinedCommitmentIndexConfig{}};
+    TipPosture frozen;
+    frozen.live = false;
+    const auto v = idx.arm(frozen);
+    EXPECT_FALSE(v.armed);
+    EXPECT_NE(v.reason.find("feature flag is off"), std::string::npos)
+        << v.reason;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// KAT-D — an UNARMED store ingests nothing.
+//
+// RED: delete the `if (!m_armed) return fail(NotArmed, …)` line in
+// process_input.
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashMinedCommitmentIndex, UnarmedStoreIngestsNothing)
+{
+    const auto scan = load_scan();
+    const auto hashes = build_hash_map(scan);
+    MinedCommitmentIndexConfig cfg;
+    cfg.enabled = true;
+    MinedCommitmentIndex idx(cfg);   // arm() never called
+    idx.seed_cursor(2513685);
+
+    // Find the first scanned block that actually carries a commitment.
+    const ScanBlock* carrier = nullptr;
+    for (const auto& b : scan)
+        if (b.height > 2513685 && !b.qc_hex.empty()) { carrier = &b; break; }
+    ASSERT_NE(carrier, nullptr);
+
+    MinedBlockInput in;
+    in.height     = 2513686;
+    in.block_hash = scan[1].block_hash;
+    auto p = parse_qc_payload_hex(carrier->qc_hex.front());
+    ASSERT_TRUE(p.has_value());
+    in.commitments.push_back(p->commitment);
+
+    std::string err;
+    EXPECT_EQ(idx.process_input(in, hash_fn(hashes), &err),
+              MinedIngestResult::NotArmed);
+    EXPECT_EQ(idx.size(), 0u);
+    EXPECT_FALSE(idx.has_mined_commitment(p->commitment.llmqType,
+                                          p->commitment.quorumHash));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// KAT-E — forward contiguity. A skipped height is REFUSED, never absorbed.
+//
+// RED: delete the `height != m_height + 1` clause in process_input. The store
+// then swallows a gap, and — with no UndoBlock — a gap can never be repaired
+// by re-walking, so every later has_mined answer is unfalsifiable.
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashMinedCommitmentIndex, ForwardContiguityIsEnforced)
+{
+    const auto scan = load_scan();
+    const auto hashes = build_hash_map(scan);
+    auto idx = make_armed();
+    seed_anchor(idx);
+    idx.seed_cursor(2513685);
+    auto at_h = hash_fn(hashes);
+
+    // Skip 2513686 entirely and offer 2513687.
+    const ScanBlock* skipped = nullptr;
+    for (const auto& b : scan) if (b.height == 2513687) skipped = &b;
+    ASSERT_NE(skipped, nullptr);
+
+    MinedBlockInput in;
+    in.height     = skipped->height;
+    in.block_hash = skipped->block_hash;
+    std::string err;
+    EXPECT_EQ(idx.process_input(in, at_h, &err),
+              MinedIngestResult::NonContiguous);
+    EXPECT_NE(err.find("forward-only"), std::string::npos) << err;
+    EXPECT_EQ(idx.height(), 2513685u) << "a refused block must not move the cursor";
+
+    // The same block IS accepted once the gap is closed.
+    for (const auto& b : scan) {
+        if (b.height != 2513686) continue;
+        MinedBlockInput ok;
+        ok.height     = b.height;
+        ok.block_hash = b.block_hash;
+        for (const auto& hex : b.qc_hex) {
+            auto p = parse_qc_payload_hex(hex);
+            ASSERT_TRUE(p.has_value());
+            ok.commitments.push_back(p->commitment);
+        }
+        EXPECT_EQ(idx.process_input(ok, at_h, &err),
+                  MinedIngestResult::Applied) << err;
+    }
+    EXPECT_EQ(idx.process_input(in, at_h, &err), MinedIngestResult::Applied)
+        << err;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// KAT-F — THE MONEY PATH. build_daemonless_qc_plan's `also_has_mined` seam:
+//         a slot the chain already mined stops being mandatory, and WITHOUT
+//         the seam it does not.
+//
+// RED: replace the `also_has_mined ? also_has_mined(t, qh) : false` in
+// dkg_commitments.hpp build_daemonless_qc_plan with `false`. The
+// "with the index" half then reports the same gap as the "without" half and
+// this test fails. That expression is the ONLY byte-visible change this PR
+// makes to a served template.
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashMinedCommitmentIndex, AlreadyMinedSlotLeavesTheMandatorySet)
+{
+    const auto scan = load_scan();
+    const auto hashes = build_hash_map(scan);
+
+    // Pick a REAL mainnet non-rotated type-4 (LLMQ_100_67, dkgInterval 24)
+    // commitment out of the window, and a template height at which type 4 is
+    // the ONLY enabled type in its DKG mining window. That isolation matters:
+    // the plan is per-height ALL-OR-NOTHING, so if any other type also had an
+    // unsatisfiable slot at that height the comparison would be about the
+    // wrong slot (the first attempt at this KAT blocked on type 3 and proved
+    // nothing).
+    auto only_type4_in_window = [](uint32_t h) {
+        for (const auto& p : dash::coin::enabled_llmqs(LlmqNetwork::Mainnet)) {
+            const bool in = dash::coin::is_mining_phase(p, h);
+            if (p.type == 4 ? !in : in) return false;
+        }
+        return true;
+    };
+
+    std::optional<CFinalCommitment> subject;
+    uint32_t subject_mined_h = 0, next_h = 0;
+    for (const auto& b : scan) {
+        for (const auto& hex : b.qc_hex) {
+            auto p = parse_qc_payload_hex(hex);
+            if (!p) continue;
+            const auto& c = p->commitment;
+            if (MinedCommitmentIndex::is_null_commitment(c)) continue;
+            if (c.llmqType != 4) continue;
+            const uint32_t cycle_start = b.height - (b.height % 24u);
+            for (uint32_t k = 10; k <= 18; ++k) {
+                if (!only_type4_in_window(cycle_start + k)) continue;
+                subject         = c;
+                subject_mined_h = b.height;
+                next_h          = cycle_start + k;
+                break;
+            }
+            if (subject) break;
+        }
+        if (subject) break;
+    }
+    ASSERT_TRUE(subject.has_value())
+        << "the fixture window must contain a real type-4 commitment whose "
+           "cycle has a height where only type 4 is in its mining window";
+
+    auto at_height = [&hashes](uint32_t h) -> std::optional<uint256> {
+        auto it = hashes.find(h);
+        if (it == hashes.end()) return std::nullopt;
+        return it->second;
+    };
+    auto height_of = [&hashes](const uint256& qh) -> std::optional<uint32_t> {
+        for (const auto& [h, hash] : hashes) if (hash == qh) return h;
+        return std::nullopt;
+    };
+
+    dash::coin::QuorumManager empty_qmgr;   // nothing learned from mnlistdiff
+
+    // WITHOUT the seam: the slot is mandatory, nothing satisfies it, the whole
+    // height fails closed — exactly today's cause=qc-plan-underivable.
+    dash::coin::RequiredQcSlot gap_without{};
+    auto plan_without = dash::coin::build_daemonless_qc_plan(
+        LlmqNetwork::Mainnet, next_h, empty_qmgr, at_height, height_of,
+        /*cache=*/nullptr, /*null_evidence=*/nullptr, &gap_without);
+    ASSERT_FALSE(plan_without.has_value());
+    EXPECT_FALSE(gap_without.quorum_hash.IsNull())
+        << "the refusal must be a SLOT gap, not a structural one";
+
+    // WITH the seam, fed by an index that replayed the block that mined it.
+    auto idx = make_armed();
+    seed_anchor(idx);
+    idx.seed_cursor(2513685);
+    auto at_h = hash_fn(hashes);
+    for (const auto& b : scan) {
+        if (b.height <= 2513685) continue;
+        MinedBlockInput in;
+        in.height     = b.height;
+        in.block_hash = b.block_hash;
+        for (const auto& hex : b.qc_hex) {
+            auto p = parse_qc_payload_hex(hex);
+            ASSERT_TRUE(p.has_value());
+            in.commitments.push_back(p->commitment);
+        }
+        std::string err;
+        ASSERT_EQ(idx.process_input(in, at_h, &err),
+                  MinedIngestResult::Applied) << err;
+        if (b.height >= subject_mined_h) break;
+    }
+    ASSERT_TRUE(idx.has_mined_commitment(subject->llmqType,
+                                         subject->quorumHash));
+
+    dash::coin::RequiredQcSlot gap_with{};
+    auto plan_with = dash::coin::build_daemonless_qc_plan(
+        LlmqNetwork::Mainnet, next_h, empty_qmgr, at_height, height_of,
+        /*cache=*/nullptr, /*null_evidence=*/nullptr, &gap_with,
+        [&idx](uint8_t t, const uint256& qh) {
+            return idx.has_mined_commitment(t, qh);
+        });
+
+    // The control arm must actually have blocked on THIS slot, or the
+    // comparison below is vacuous.
+    ASSERT_TRUE(gap_without.quorum_hash == subject->quorumHash
+                && gap_without.params.type == subject->llmqType)
+        << "control arm must block on the subject slot; it blocked on type="
+        << int(gap_without.params.type)
+        << " quorum=" << gap_without.quorum_hash.GetHex();
+
+    // WITH the seam the slot is no longer mandatory, nothing else is in its
+    // window, and the height PLANS — the whole refusal disappears.
+    EXPECT_TRUE(plan_with.has_value())
+        << "the chain mined this commitment at h=" << subject_mined_h
+        << " and h=" << next_h << " has no other type in a DKG window; with "
+           "the mined-commitment index wired the slot must stop being "
+           "mandatory (dashd GetNumCommitmentsRequired, "
+           "llmq/blockprocessor.cpp:455, skips a slot HasMinedCommitment "
+           "answers true for). Blocking gap was type="
+        << int(gap_with.params.type)
+        << " quorum=" << gap_with.quorum_hash.GetHex();
+    if (plan_with)
+        EXPECT_TRUE(plan_with->commitments.empty())
+            << "an already-mined slot is DROPPED, not served: the template "
+               "must carry no type-6 tx at this height";
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// KAT-G — issue #90: the active-set shortfall NAMES the type that is short.
+//
+// A forward replay from a modern anchor with NO active-set seed can never
+// complete on mainnet, because LLMQ_50_60's last 24 commitments were mined
+// before DIP0024 (~h 1738698) and stay in dashd's active set forever
+// (GetMinedAndActiveCommitmentsUntilBlock walks the CHAINPARAMS list,
+// blockprocessor.cpp:664). That is the whole reason the replay quorum-root
+// counter read 0/4684 and could not disagree with anything.
+//
+// RED: make active_set_shortfall() return {} unconditionally.
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashMinedCommitmentIndex, ShortfallNamesTheTypeThatBlocksSelfCheckArming)
+{
+    const auto scan = load_scan();
+    const auto hashes = build_hash_map(scan);
+
+    // UNSEEDED: replay alone, exactly the production posture that produced
+    // the 0/4684 line.
+    auto cold = make_armed();
+    cold.seed_cursor(2513685);
+    auto at_h = hash_fn(hashes);
+    for (const auto& b : scan) {
+        if (b.height <= 2513685) continue;
+        MinedBlockInput in;
+        in.height     = b.height;
+        in.block_hash = b.block_hash;
+        for (const auto& hex : b.qc_hex) {
+            auto p = parse_qc_payload_hex(hex);
+            ASSERT_TRUE(p.has_value());
+            in.commitments.push_back(p->commitment);
+        }
+        std::string err;
+        ASSERT_EQ(cold.process_input(in, at_h, &err),
+                  MinedIngestResult::Applied) << err;
+    }
+    const auto miss = cold.active_set_shortfall(cold.height());
+    ASSERT_FALSE(miss.empty())
+        << "3101 blocks of forward replay cannot complete the mainnet active "
+           "set — if this passes, the premise of issue #90 has changed";
+    bool names_50_60 = false;
+    for (const auto& [t, n] : miss)
+        if (t == 1) { names_50_60 = true; EXPECT_EQ(n, 24u); }
+    EXPECT_TRUE(names_50_60)
+        << "type 1 (LLMQ_50_60) is the permanent shortfall: no forward replay "
+           "from a modern anchor can observe its 24 frozen commitments";
+    EXPECT_NE(cold.summary().find("active_set=INCOMPLETE"), std::string::npos)
+        << cold.summary();
+
+    // SEEDED: the same 88-commitment mnlistdiff seed the KAT-A anchor uses
+    // closes it — so the counter CAN be made to measure something.
+    auto warm = make_armed();
+    EXPECT_EQ(seed_anchor(warm), 88u);
+    EXPECT_TRUE(warm.active_set_shortfall(2513685).empty());
+    warm.seed_cursor(2513685);
+    EXPECT_NE(warm.summary().find("active_set=COMPLETE"), std::string::npos)
+        << warm.summary();
+}

--- a/test/test_dash_mined_commitment_index.cpp
+++ b/test/test_dash_mined_commitment_index.cpp
@@ -33,9 +33,18 @@
 //      an already-mined slot from the mandatory set — and does NOT when the
 //      seam is absent (the default every existing caller keeps).
 //   G  issue #90: active_set_shortfall names WHICH type is short.
+//   H  bad-qc-block: a commitment whose quorumHash is not our chain's block
+//      hash at the derived base height is REFUSED (:407).
+//   I  bad-qc-height: a commitment mined outside its type's DKG mining window
+//      is REFUSED (:435).
+//   J  bad-qc-dup: two non-rotated commitments of one type in one block are
+//      REFUSED on the parsed entry point too (:377).
 //
-// Every one of C, D, E, F is red-provable by deleting the guard it names; the
-// comment on each says exactly which line to break.
+// Every one of C, D, E, F, H, I, J is red-provable by deleting the guard it
+// names; the comment on each says exactly which line to break. H/I/J each
+// carry a CONTROL that differs from the subject in exactly one property, so
+// the rejection is attributable to the arm under test and not to some other
+// refusal upstream of it.
 //
 // Fixture provenance: identical files to test_dash_replay_quorum_engine.cpp
 // (captured 2026-08-05 from a read-only mainnet Dash Core v23 node).
@@ -716,4 +725,244 @@ TEST(DashMinedCommitmentIndex, ShortfallNamesTheTypeThatBlocksSelfCheckArming)
     warm.seed_cursor(2513685);
     EXPECT_NE(warm.summary().find("active_set=COMPLETE"), std::string::npos)
         << warm.summary();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// KAT-H / KAT-I / KAT-J — THE THREE PORTED REJECTION ARMS, each with a
+// CONTROL that differs in exactly one property.
+//
+// The 3101-block KAT-A only ever feeds VALID mainnet blocks, so it exercises
+// none of dashd's rejections: all three of these arms could be replaced with
+// `if (false)` and the suite stayed green. None of them can produce a false
+// TRUE has_mined_commitment (a rejected block writes nothing either way), so
+// this was a COVERAGE hole rather than a serving hole — but an arm nothing
+// constrains is an arm that can be deleted by accident, and then the store
+// starts accepting commitments dashd's ConnectBlock would have rejected.
+//
+// Each KAT below runs the SAME real mainnet commitment twice: once in the
+// shape the chain actually had (CONTROL → Applied) and once with exactly one
+// property broken (SUBJECT → the named dashd rejection). Delete the arm and
+// the subject becomes Applied too, which is the red.
+// ═══════════════════════════════════════════════════════════════════════════
+
+namespace {
+
+struct SubjectQc {
+    dash::coin::vendor::CFinalCommitment commitment;
+    uint32_t mined_height{0};
+};
+
+/// The first real non-null NON-ROTATED (type 4, LLMQ_100_67, dkgInterval 24,
+/// mining window [10,18]) commitment in the scan window, with the height the
+/// chain mined it at.
+std::optional<SubjectQc> first_type4_commitment(const std::vector<ScanBlock>& scan)
+{
+    for (const auto& b : scan) {
+        for (const auto& hex : b.qc_hex) {
+            auto p = parse_qc_payload_hex(hex);
+            if (!p) continue;
+            const auto& c = p->commitment;
+            if (c.llmqType != 4) continue;
+            if (MinedCommitmentIndex::is_null_commitment(c)) continue;
+            SubjectQc s;
+            s.commitment   = c;
+            s.mined_height = b.height;
+            return s;
+        }
+    }
+    return std::nullopt;
+}
+
+} // namespace
+
+// ── KAT-H — bad-qc-block: the commitment's quorumHash must BE our chain's
+//    block hash at the derived quorum base height.
+//    Upstream: llmq/blockprocessor.cpp:300-307 (GetQuorumBlockHash, :487) and
+//    the `quorumHash != qc.quorumHash` reject at :311.
+//    Port: mined_commitment_index.hpp:407.
+//
+//    Without it, a commitment naming ANY quorumHash — including one from
+//    another chain or one a peer invented — gets recorded as mined, and
+//    has_mined_commitment() then answers true for a quorum that does not
+//    exist on our chain, dropping a MANDATORY qfcommit slot out of the
+//    served template (dashd bad-qc-missing, a lost block).
+//
+//    RED: replace `if (*base_hash != qc.quorumHash)` with `if (false)`.
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashMinedCommitmentIndex, BadQcBlockRejectsACommitmentNotBoundToOurChain)
+{
+    const auto scan   = load_scan();
+    const auto hashes = build_hash_map(scan);
+    auto at_h = hash_fn(hashes);
+
+    const auto subj = first_type4_commitment(scan);
+    ASSERT_TRUE(subj.has_value())
+        << "the fixture window must contain a real non-null type-4 commitment";
+
+    MinedBlockInput in;
+    in.height     = subj->mined_height;
+    for (const auto& b : scan)
+        if (b.height == subj->mined_height) in.block_hash = b.block_hash;
+    ASSERT_FALSE(in.block_hash.IsNull());
+
+    // ── CONTROL: the commitment exactly as the chain mined it.
+    {
+        auto idx = make_armed();
+        idx.seed_cursor(subj->mined_height - 1);
+        MinedBlockInput ok = in;
+        ok.commitments.push_back(subj->commitment);
+        std::string err;
+        ASSERT_EQ(idx.process_input(ok, at_h, &err), MinedIngestResult::Applied)
+            << err;
+        EXPECT_TRUE(idx.has_mined_commitment(subj->commitment.llmqType,
+                                             subj->commitment.quorumHash));
+    }
+
+    // ── SUBJECT: one byte of quorumHash flipped. Everything else — height,
+    //    type, mining window, contents — is identical.
+    {
+        auto idx = make_armed();
+        idx.seed_cursor(subj->mined_height - 1);
+        MinedBlockInput bad = in;
+        auto tampered = subj->commitment;
+        tampered.quorumHash.data()[0] ^= 0xff;
+        bad.commitments.push_back(tampered);
+        std::string err;
+        EXPECT_EQ(idx.process_input(bad, at_h, &err),
+                  MinedIngestResult::BadQcBlock)
+            << "a commitment whose quorumHash is not our chain's block hash at "
+               "the derived base height must be rejected bad-qc-block "
+               "(blockprocessor.cpp:311); got err=" << err;
+        EXPECT_NE(err.find("bad-qc-block"), std::string::npos) << err;
+        // Nothing may be written by a refused block.
+        EXPECT_FALSE(idx.has_mined_commitment(tampered.llmqType,
+                                              tampered.quorumHash));
+        EXPECT_EQ(idx.height(), subj->mined_height - 1)
+            << "a refused block must not advance the cursor";
+        EXPECT_EQ(idx.stats().commitments_mined, 0u);
+    }
+}
+
+// ── KAT-I — bad-qc-height: a commitment may only be mined INSIDE its type's
+//    DKG mining window.
+//    Upstream: llmq/blockprocessor.cpp:327 (`!IsMiningPhase` → bad-qc-height).
+//    Port: mined_commitment_index.hpp:435.
+//
+//    Type 4 is dkgInterval 24, window [10,18]. Control and subject use the
+//    SAME commitment and the SAME quorum base (same cycle), so the only
+//    difference between Applied and rejected is the block height's phase.
+//
+//    RED: replace `if (!is_mining_phase(*p, height))` with `if (false)`.
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashMinedCommitmentIndex, BadQcHeightRejectsMiningOutsideTheDkgWindow)
+{
+    const auto scan   = load_scan();
+    const auto hashes = build_hash_map(scan);
+    auto at_h = hash_fn(hashes);
+
+    const auto subj = first_type4_commitment(scan);
+    ASSERT_TRUE(subj.has_value());
+
+    // A whole type-4 cycle that lies inside the scanned window.
+    const uint32_t cycle = (subj->mined_height / 24u) * 24u;
+    const uint32_t h_in  = cycle + 12;   // phase 12 ∈ [10,18]
+    const uint32_t h_out = cycle + 20;   // phase 20 ∉ [10,18]
+    ASSERT_EQ(dash::coin::is_mining_phase(dash::coin::kLlmq100_67, h_in), true);
+    ASSERT_EQ(dash::coin::is_mining_phase(dash::coin::kLlmq100_67, h_out), false);
+
+    // Bind the commitment honestly to OUR chain at the cycle's quorum base,
+    // so the bad-qc-block arm cannot be what answers here.
+    const uint32_t base_h =
+        cycle + static_cast<uint32_t>(subj->commitment.quorumIndex);
+    auto base_hash = at_h(base_h);
+    ASSERT_TRUE(base_hash.has_value()) << "base h=" << base_h;
+    auto qc = subj->commitment;
+    qc.quorumHash = *base_hash;
+
+    auto run_at = [&](uint32_t height, std::string& err) {
+        auto idx = make_armed();
+        idx.seed_cursor(height - 1);
+        MinedBlockInput in;
+        in.height = height;
+        auto it = hashes.find(height);
+        EXPECT_NE(it, hashes.end());
+        if (it != hashes.end()) in.block_hash = it->second;
+        in.commitments.push_back(qc);
+        return idx.process_input(in, at_h, &err);
+    };
+
+    // ── CONTROL: inside the window.
+    std::string err_in;
+    ASSERT_EQ(run_at(h_in, err_in), MinedIngestResult::Applied) << err_in;
+
+    // ── SUBJECT: same commitment, same quorum base, 8 blocks later.
+    std::string err_out;
+    EXPECT_EQ(run_at(h_out, err_out), MinedIngestResult::BadQcHeight)
+        << "h=" << h_out << " is phase " << (h_out % 24)
+        << ", outside the type-4 DKG mining window [10,18]; dashd rejects "
+           "bad-qc-height (blockprocessor.cpp:327). err=" << err_out;
+    EXPECT_NE(err_out.find("bad-qc-height"), std::string::npos) << err_out;
+}
+
+// ── KAT-J — bad-qc-dup (the PER-BLOCK arm): at most one commitment per
+//    NON-ROTATED type per block.
+//    Upstream: llmq/blockprocessor.cpp:445-450 ("only allow one commitment
+//    per type and per block (This was changed with rotation)").
+//    Port: mined_commitment_index.hpp:377 — the re-assert on the PARSED entry
+//    point, which is the one a caller that assembled MinedBlockInput itself
+//    reaches (the body path's copy is at :332).
+//
+//    Without it a caller can smuggle two type-4 commitments into one block;
+//    both stage, both write, and the store's last-K-mined walk now holds a
+//    history no dashd would have accepted.
+//
+//    RED: replace `if (!p->use_rotation && ++per_type_count[p->type] > 1)`
+//         at :377 with `if (false)`.
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashMinedCommitmentIndex, BadQcDupRejectsTwoNonRotatedOfOneTypeInABlock)
+{
+    const auto scan   = load_scan();
+    const auto hashes = build_hash_map(scan);
+    auto at_h = hash_fn(hashes);
+
+    const auto subj = first_type4_commitment(scan);
+    ASSERT_TRUE(subj.has_value());
+
+    MinedBlockInput base;
+    base.height = subj->mined_height;
+    for (const auto& b : scan)
+        if (b.height == subj->mined_height) base.block_hash = b.block_hash;
+    ASSERT_FALSE(base.block_hash.IsNull());
+
+    // ── CONTROL: one type-4 commitment — the chain's own shape.
+    {
+        auto idx = make_armed();
+        idx.seed_cursor(subj->mined_height - 1);
+        MinedBlockInput one = base;
+        one.commitments.push_back(subj->commitment);
+        std::string err;
+        ASSERT_EQ(idx.process_input(one, at_h, &err),
+                  MinedIngestResult::Applied) << err;
+        EXPECT_EQ(idx.stats().commitments_mined, 1u);
+    }
+
+    // ── SUBJECT: the SAME commitment twice in one block.
+    {
+        auto idx = make_armed();
+        idx.seed_cursor(subj->mined_height - 1);
+        MinedBlockInput two = base;
+        two.commitments.push_back(subj->commitment);
+        two.commitments.push_back(subj->commitment);
+        std::string err;
+        EXPECT_EQ(idx.process_input(two, at_h, &err),
+                  MinedIngestResult::BadQcDupInBlock)
+            << "two non-rotated type-4 commitments in one block is dashd's "
+               "bad-qc-dup (blockprocessor.cpp:448); got err=" << err;
+        EXPECT_NE(err.find("bad-qc-dup"), std::string::npos) << err;
+        EXPECT_FALSE(idx.has_mined_commitment(subj->commitment.llmqType,
+                                              subj->commitment.quorumHash))
+            << "a refused block must write NOTHING — the staging rule";
+        EXPECT_EQ(idx.height(), subj->mined_height - 1);
+        EXPECT_EQ(idx.stats().commitments_mined, 0u);
+    }
 }

--- a/test/test_dash_mined_commitment_index.cpp
+++ b/test/test_dash_mined_commitment_index.cpp
@@ -39,8 +39,12 @@
 //      is REFUSED (:435).
 //   J  bad-qc-dup: two non-rotated commitments of one type in one block are
 //      REFUSED on the parsed entry point too (:377).
+//   K  body-not-bound: process_block — the BODY entry point production wires
+//      into the pre_fold hook — itself refuses a body that does not fold to
+//      the header's committed merkle root (:302), writes nothing, and does
+//      not advance the cursor.
 //
-// Every one of C, D, E, F, H, I, J is red-provable by deleting the guard it
+// Every one of C, D, E, F, H, I, J, K is red-provable by deleting the guard it
 // names; the comment on each says exactly which line to break. H/I/J each
 // carry a CONTROL that differs from the subject in exactly one property, so
 // the rejection is attributable to the arm under test and not to some other
@@ -964,5 +968,138 @@ TEST(DashMinedCommitmentIndex, BadQcDupRejectsTwoNonRotatedOfOneTypeInABlock)
             << "a refused block must write NOTHING — the staging rule";
         EXPECT_EQ(idx.height(), subj->mined_height - 1);
         EXPECT_EQ(idx.stats().commitments_mined, 0u);
+    }
+}
+
+// ── KAT-K — process_block: the BODY entry point must ITSELF refuse a body
+//    that does not bind to its header.
+//    Port: mined_commitment_index.hpp:302 (`block_body_binds_to_header`).
+//
+//    Every other KAT in this file drives process_input — the PARSED entry
+//    point, where the body↔header binding is the CALLER's proof. Production
+//    wires process_block into the pre_fold hook (main_dash.cpp), and
+//    process_block is where the store asserts the binding for itself (the
+//    TRUST BOUNDARY note in the header). Without this test the suite is green
+//    around the one function production actually calls.
+//
+//    Consequence if the guard is absent — the same chain KAT-H proves for
+//    :407: a forged/mutated body writes mined records, has_mined_commitment()
+//    answers true for a quorum not on our chain, a MANDATORY qfcommit slot
+//    leaves the served template, and dashd rejects the found block
+//    bad-qc-missing (blockprocessor.cpp:198) — a LOST BLOCK.
+//
+//    CONTROL and SUBJECT share one body: the real type-6 payload set the
+//    chain mined at the subject height, byte-exact from the mainnet capture,
+//    behind a coinbase-shaped tx 0. The header commits the merkle root over
+//    exactly that tx set (the same fold block_body_binds_to_header applies),
+//    so the control is Applied. The subject mutates ONE transaction — the
+//    coinbase — while the header keeps committing the ORIGINAL tx set: the
+//    delivered body no longer folds to the committed root, and nothing else
+//    about it changed. That is the real-PoW-header + forged-body attack the
+//    E2 finding-A guard exists for.
+//
+//    RED: replace `if (!block_body_binds_to_header(block))` at :302 with
+//    `if (false)`. The subject then parses cleanly (the mutated tx is the
+//    type-0 coinbase, which the type-6 walk skips), every downstream arm
+//    passes, and the forged body is Applied: records written, cursor
+//    advanced — all five subject expectations fail.
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashMinedCommitmentIndex, ProcessBlockRefusesABodyNotBoundToItsHeader)
+{
+    const auto scan   = load_scan();
+    const auto hashes = build_hash_map(scan);
+    auto at_h = hash_fn(hashes);
+
+    const auto subj = first_type4_commitment(scan);
+    ASSERT_TRUE(subj.has_value())
+        << "the fixture window must contain a real non-null type-4 commitment";
+
+    const ScanBlock* sb = nullptr;
+    for (const auto& b : scan)
+        if (b.height == subj->mined_height) sb = &b;
+    ASSERT_NE(sb, nullptr);
+    ASSERT_FALSE(sb->qc_hex.empty());
+
+    // Assemble the BODY the entry point sees: coinbase-shaped tx 0, then
+    // every type-6 tx the chain mined at this height, extra_payload
+    // byte-exact from the capture.
+    dash::coin::BlockType blk;
+    blk.m_bits = 0x19158dc7u;   // non-null header
+    {
+        dash::coin::MutableTransaction coinbase;
+        coinbase.version = 3;
+        coinbase.type    = 0;
+        dash::coin::TxIn cin;
+        cin.prevout.hash  = uint256::ZERO;
+        cin.prevout.index = 0xffffffffu;
+        coinbase.vin.push_back(cin);
+        blk.m_txs.push_back(std::move(coinbase));
+    }
+    for (const auto& hex : sb->qc_hex) {
+        dash::coin::MutableTransaction tx;
+        tx.version       = 3;
+        tx.type          = CFinalCommitmentTxPayload::SPECIALTX_TYPE;   // 6
+        tx.extra_payload = from_hex(hex);
+        ASSERT_FALSE(tx.extra_payload.empty());
+        blk.m_txs.push_back(std::move(tx));
+    }
+    ASSERT_GE(blk.m_txs.size(), 2u);
+
+    // Bind body to header: commit the root over the actual tx set — the same
+    // fold block_body_binds_to_header applies (compute_merkle_root over
+    // sha256d(canonical tx bytes)).
+    {
+        std::vector<uint256> txids;
+        for (const auto& tx : blk.m_txs) {
+            auto packed = ::pack(tx);
+            txids.push_back(::Hash(packed.get_span()));
+        }
+        blk.m_merkle_root = dash::coin::compute_merkle_root(txids);
+    }
+    ASSERT_TRUE(dash::coin::block_body_binds_to_header(blk));
+
+    // ── CONTROL: the bound body at its real height → Applied, records
+    //    written, cursor advanced.
+    {
+        auto idx = make_armed();
+        idx.seed_cursor(subj->mined_height - 1);
+        std::string err;
+        ASSERT_EQ(idx.process_block(subj->mined_height, sb->block_hash, blk,
+                                    at_h, &err),
+                  MinedIngestResult::Applied) << err;
+        EXPECT_TRUE(idx.has_mined_commitment(subj->commitment.llmqType,
+                                             subj->commitment.quorumHash))
+            << "the real block's type-4 commitment must be recorded as mined";
+        EXPECT_EQ(idx.height(), subj->mined_height);
+        EXPECT_EQ(idx.stats().blocks_ingested, 1u);
+        // Every payload the body carried was either mined or a null skip.
+        EXPECT_EQ(idx.stats().commitments_mined + idx.stats().commitments_null,
+                  static_cast<uint64_t>(sb->qc_hex.size()));
+    }
+
+    // ── SUBJECT: ONE transaction mutated (the coinbase), header unchanged —
+    //    the delivered body no longer folds to the committed root.
+    {
+        auto idx = make_armed();
+        idx.seed_cursor(subj->mined_height - 1);
+        dash::coin::BlockType forged = blk;
+        forged.m_txs[0].locktime ^= 1u;         // m_merkle_root NOT updated
+        ASSERT_FALSE(dash::coin::block_body_binds_to_header(forged));
+        std::string err;
+        EXPECT_EQ(idx.process_block(subj->mined_height, sb->block_hash,
+                                    forged, at_h, &err),
+                  MinedIngestResult::BodyNotBound)
+            << "a body that does not fold to the header's committed merkle "
+               "root must be refused body-not-bound at the entry point "
+               "(mined_commitment_index.hpp:302); got err=" << err;
+        EXPECT_NE(err.find("body-not-bound"), std::string::npos) << err;
+        // Nothing may be written by a refused body — the staging rule.
+        EXPECT_FALSE(idx.has_mined_commitment(subj->commitment.llmqType,
+                                              subj->commitment.quorumHash));
+        EXPECT_EQ(idx.height(), subj->mined_height - 1)
+            << "a refused body must not advance the cursor";
+        EXPECT_EQ(idx.stats().commitments_mined, 0u);
+        EXPECT_EQ(idx.stats().blocks_ingested, 0u);
+        EXPECT_EQ(idx.stats().blocks_refused, 1u);
     }
 }

--- a/test/test_dash_replay_quorum_engine.cpp
+++ b/test/test_dash_replay_quorum_engine.cpp
@@ -60,6 +60,7 @@
 #include <array>
 #include <fstream>
 #include <iterator>
+#include <map>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -1092,4 +1093,97 @@ TEST(DashReplayQuorumEngine, MembersForResolvesAfterACycleBaseObservation)
     unknown.SetHex(
         "00000000000000000000000000000000000000000000000000000000000ffff1");
     EXPECT_FALSE(eng.members_for(1, unknown).has_value());
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ISSUE #90 — active_set_shortfall() NAMES the blocking type, exactly, and
+// closes only when the last missing commitment arrives.
+//
+// active_sets_complete() is the criterion any future self-check arming will
+// key on (the arming itself is NOT in this PR — see
+// DashReplayQuorumSeam.BridgeNeverArmsTheRootSelfCheckByItself and the
+// ISSUE #90 note in ReplayQuorumBridge::observe). A bare bool cannot say WHY
+// a run never completes, which is how the fold_root_vs_committed line came to
+// print `0/4684` with no blocking condition named. The shortfall is the
+// missing half and it must be EXACT: the right type, the right count, and
+// "complete" only when nothing is short.
+//
+// This engine-level KAT is what the MinedCommitmentIndex KAT-G does NOT
+// cover: MinedCommitmentIndex::active_set_shortfall and
+// QuorumReplayEngine::active_set_shortfall are two different functions on two
+// different stores, and only the latter feeds the bridge's reporting surface.
+//
+// RED: make QuorumReplayEngine::active_set_shortfall() return {}, or make
+//      active_set_shortfall_text() return "complete".
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashReplayQuorumEngine, ActiveSetShortfallNamesTheTypeAndClosesExactly)
+{
+    // Seed the anchor fixture MINUS one llmq type / minus one row, so the
+    // shortfall has a known, checkable value.
+    auto seed_except = [](QuorumReplayEngine& eng, int skip_type,
+                          int skip_nth_of_type) {
+        size_t seeded = 0, skipped = 0;
+        std::map<int, int> seen_of_type;
+        for (const auto& l :
+             read_lines("dash_mainnet_active_quorums_2513685.txt")) {
+            auto f = split_ws(l);
+            EXPECT_EQ(f.size(), 5u);
+            if (f.size() != 5) continue;
+            const int type = std::stoi(f[0]);
+            const int nth  = seen_of_type[type]++;
+            if (type == skip_type
+                && (skip_nth_of_type < 0 || nth == skip_nth_of_type)) {
+                ++skipped;
+                continue;
+            }
+            auto c = parse_commitment_hex(f[4]);
+            EXPECT_TRUE(c.has_value());
+            if (!c) continue;
+            std::string err;
+            EXPECT_TRUE(eng.seed_commitment(
+                static_cast<uint32_t>(std::stoul(f[2])), *c, err)) << err;
+            ++seeded;
+        }
+        EXPECT_GT(skipped, 0u) << "the skip must actually skip something";
+        return seeded;
+    };
+
+    // ── (1) The mainnet reality: type 1 (LLMQ_50_60) entirely absent, which
+    //        is what a forward replay from a modern anchor produces — its 24
+    //        commitments were mined before DIP0024 and can never be observed.
+    {
+        QuorumReplayEngine eng(mainnet_cfg());
+        seed_except(eng, /*skip_type=*/1, /*skip_nth_of_type=*/-1);
+        EXPECT_FALSE(eng.active_sets_complete());
+        const auto miss = eng.active_set_shortfall();
+        ASSERT_EQ(miss.size(), 1u) << eng.active_set_shortfall_text();
+        EXPECT_EQ(int(miss[0].first), 1);
+        EXPECT_EQ(miss[0].second, 24u);
+        EXPECT_EQ(eng.active_set_shortfall_text(), "type1:short24");
+    }
+
+    // ── (2) ONE commitment short of complete is still SHORT, and says so by
+    //        name. This is the precision an arming criterion needs: it must
+    //        not round 3-of-4 up to "the reconstructed set IS dashd's set".
+    {
+        QuorumReplayEngine eng(mainnet_cfg());
+        seed_except(eng, /*skip_type=*/2, /*skip_nth_of_type=*/0);
+        EXPECT_FALSE(eng.active_sets_complete())
+            << "one type-2 commitment short must NOT read as complete";
+        const auto miss = eng.active_set_shortfall();
+        ASSERT_EQ(miss.size(), 1u) << eng.active_set_shortfall_text();
+        EXPECT_EQ(int(miss[0].first), 2);
+        EXPECT_EQ(miss[0].second, 1u);
+        EXPECT_EQ(eng.active_set_shortfall_text(), "type2:short1");
+    }
+
+    // ── (3) The full 88-commitment anchor closes it, and the text says so —
+    //        so "complete" is a reachable value, not a branch nothing hits.
+    {
+        QuorumReplayEngine eng(mainnet_cfg());
+        ASSERT_EQ(seed_engine_from_anchor(eng), 88u);
+        EXPECT_TRUE(eng.active_sets_complete());
+        EXPECT_TRUE(eng.active_set_shortfall().empty());
+        EXPECT_EQ(eng.active_set_shortfall_text(), "complete");
+    }
 }

--- a/test/test_dash_replay_quorum_seam.cpp
+++ b/test/test_dash_replay_quorum_seam.cpp
@@ -72,6 +72,7 @@
 #include <cstring>
 #include <map>
 #include <optional>
+#include <fstream>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -175,6 +176,38 @@ BlockType parse_block(const char* hex_text)
     s >> b;
     EXPECT_TRUE(s.empty()) << "trailing bytes after block";
     return b;
+}
+
+/// Seed the mainnet anchor's FULL active set (h=2513685, 88 commitments —
+/// 24+32+4+4+24) into a quorum engine. Same fixture the W4 engine KAT uses;
+/// columns are `type qidx base_height quorumHash commitment_hex`. This is the
+/// state that makes active_sets_complete() true, i.e. the exact precondition
+/// the removed auto-arm keyed on.
+size_t seed_anchor_active_set(QuorumReplayEngine& eng)
+{
+    const std::string path = std::string(DASH_FIXTURE_DIR)
+                           + "/dash_mainnet_active_quorums_2513685.txt";
+    std::ifstream f(path);
+    EXPECT_TRUE(f.good()) << "cannot open fixture: " << path;
+    std::string line;
+    size_t n = 0;
+    while (std::getline(f, line)) {
+        if (line.empty() || line[0] == '#') continue;
+        auto fl = split_ws(line);
+        EXPECT_EQ(fl.size(), 5u) << line.substr(0, 80);
+        if (fl.size() != 5) continue;
+        std::vector<uint8_t> bytes;
+        EXPECT_TRUE(hex_to_bytes(fl[4], bytes));
+        dash::coin::vendor::CFinalCommitment c;
+        ::PackStream s(bytes);
+        s >> c;
+        EXPECT_EQ(s.cursor_size(), 0u) << "commitment slice must parse exact";
+        std::string err;
+        EXPECT_TRUE(eng.seed_commitment(
+            static_cast<uint32_t>(std::stoul(fl[2])), c, err)) << err;
+        ++n;
+    }
+    return n;
 }
 
 /// dashd `quorum info` member order IS the DKG order the validMembers bitset
@@ -662,4 +695,84 @@ TEST(DashReplayQuorumSeam, BridgeInstallsTheResolverAndNamesAMiss)
     for (const auto& e : *list)
         if (!e.confirmedHash.IsNull()) { any_confirmed = true; break; }
     EXPECT_TRUE(any_confirmed);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// KAT-7 — ISSUE #90: the bridge NEVER arms the root self-check by itself.
+//
+// One revision of replay_quorum_bridge.hpp armed QuorumReplayEngine's root
+// self-check from inside observe(), the moment active_sets_complete() went
+// true. That was the only change in PR-2 not behind
+// --replay-mined-commitment-index: it rides the PRE-EXISTING
+// --replay-fold-quorums. And arming is not a diagnostic — once armed, a
+// merkleRootQuorums differ POISONS the engine (observe_block's m_self_check
+// branch), a poisoned engine answers no member sets, the fold stops, the
+// replay payee publisher stops publishing and the node STOPS SERVING. It was
+// argued inert on mainnet because type 1 is short by 24 forever, which is a
+// fact about the chain, not about this code.
+//
+// So the arming half now belongs to #90's own PR, behind its own default-OFF
+// flag. THIS KAT holds the line: a COMPLETE active set — the trigger — must
+// not arm anything, and neither must an observation the engine refused (the
+// removed code sat BEFORE `if (!r.ok) return r.error;`, so it armed on a
+// refusal too).
+//
+// RED: put back
+//     if (!m_quorum.self_check_armed() && m_quorum.active_sets_complete())
+//         m_quorum.arm_self_check();
+// anywhere in ReplayQuorumBridge::observe.
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashReplayQuorumSeam, BridgeNeverArmsTheRootSelfCheckByItself)
+{
+    FoldConfig fcfg; fcfg.enabled = true;
+    DmlFoldEngine dml(fcfg);
+    auto ps = parse_prestate_text(kDashReplayPrestate2513129);
+    ASSERT_TRUE(ps.ok) << ps.error;
+    ASSERT_TRUE(seed_engine_from_prestate(dml, ps).empty());
+
+    QuorumReplayConfig qcfg;
+    qcfg.enabled = true;
+    qcfg.network = LlmqNetwork::Mainnet;
+    QuorumReplayEngine quorum(qcfg);
+    QuorumBridgeConfig bcfg;
+    bcfg.network = LlmqNetwork::Mainnet;
+    ReplayQuorumBridge bridge(dml, quorum, bcfg);
+
+    // THE TRIGGER, present and true: every chainparams type at its full
+    // active quota. Nothing weaker than this ever armed the old code.
+    ASSERT_EQ(seed_anchor_active_set(quorum), 88u);
+    ASSERT_TRUE(quorum.active_sets_complete())
+        << "shortfall: " << quorum.active_set_shortfall_text();
+    EXPECT_EQ(bridge.active_set_shortfall_text(), "complete");
+    ASSERT_FALSE(bridge.self_check_armed());
+
+    const auto blk = parse_block(kDashReplayBlock2513130);
+    // Window key only; nothing under test reads it.
+    const uint256 observed_hash =
+        from_display("0000000000000000000000000000000000000000000000000000000000513130");
+
+    // ── Arm 1: an observation the ENGINE REFUSES (no seeded cursor). The
+    //    removed auto-arm ran before the !r.ok return, so this refused block
+    //    armed the consensus check anyway.
+    const std::string refused = bridge.observe(kSeamHeight, observed_hash, blk);
+    ASSERT_FALSE(refused.empty())
+        << "precondition: an unseeded engine must refuse this observation";
+    EXPECT_FALSE(bridge.self_check_armed())
+        << "a REFUSED observation must not arm the root self-check: " << refused;
+
+    // ── Arm 2: a real observation, cursor seeded, the fold actually runs.
+    quorum.seed_cursor(kAnchor, from_display(ps.blockhash_display.c_str()));
+    bridge.observe(kSeamHeight, observed_hash, blk);
+    EXPECT_FALSE(bridge.self_check_armed())
+        << "observing a block with a COMPLETE active set must not arm the "
+           "root self-check — arming can stop serving and belongs behind its "
+           "own flag (issue #90)";
+    EXPECT_FALSE(quorum.self_check_armed());
+
+    // ── Anti-vacuity: the flag IS reachable, and only an explicit caller
+    //    reaches it. Without this the EXPECT_FALSEs above could be measuring
+    //    an observable that is never true for unrelated reasons.
+    quorum.arm_self_check();
+    EXPECT_TRUE(bridge.self_check_armed())
+        << "arm_self_check() is the ONLY door, and it must still work";
 }


### PR DESCRIPTION
Ports dashd's already-mined quorum-commitment derivation onto our own replay, so the embedded node derives from data it already stores instead of asking dashd.

Follow-up commit drops the issue-#90 auto-arm and gives the three ported rejection arms red tests.

**Why the auto-arm is dropped rather than flag-gated:** it rode the pre-existing `--replay-fold-quorums`, so it changed behaviour for an already-running node. Armed, a `merkleRootQuorums` mismatch poisons the engine, a poisoned engine answers no member sets, the fold stops, the payee publisher stops, and **the node stops serving** — fail-closed, but stopped. It also sat before `if (!r.ok) return r.error;`, so it armed on observations the engine had refused. Shipping a serving-risk path behind a new default-OFF flag for a diagnostic counter, inside a money-path port, is not worth it. #90's arming gets its own PR, its own flag, and the KAT the reviewer specified.

The reporting half of #90 stays: `active_set_shortfall_text()` names the blocking llmq type instead of printing an unexplained 0/N. It is text and gates nothing.

**Tests:** shortfall now has red — `ActiveSetShortfallNamesTheTypeAndClosesExactly` seeds the anchor fixture minus type 1 (exactly `type1:short24`) and minus one type-2 row (exactly `type2:short1`).

Contains `fixup!` commits — squash-merge, or autosquash before merging.


---

## ⛔ BLOCKER — an untested guard on the PRODUCTION entry point

`block_body_binds_to_header` in **`process_block`** (`src/impl/dash/coin/mined_commitment_index.hpp:302`) **survives `if (false)` at 223/223 green** — verified by running the mutation, not by inspection.

Every test in `test_dash_mined_commitment_index.cpp` calls `process_input` (lines 300/359/482/514/530/533/631/704/815/831/891/944/957). **Nothing calls `process_block`** — which is the entry point `main_dash.cpp:5762` wires into the `pre_fold` hook. The suite is green around the function production actually uses.

**Consequence chain** — the same one this branch's own KAT-H already proved for `:407`:

> a body that does not bind to its header writes mined records → `has_mined_commitment` answers TRUE for a quorum not on our chain → a mandatory `qfcommit` slot leaves the served template → dashd `bad-qc-missing` → **lost block**.

Flag-gated, so not live today. But this branch's own stated standard was *"closed or stated, not left implied by a green suite"*, and this is neither.

**Close it with one KAT, not a redesign** — same shape as the three KATs already written here: feed one real mainnet block body through `process_block` (CONTROL → `Applied`), then mutate one tx so the body no longer binds (SUBJECT → `BodyNotBound`, nothing written, cursor not advanced), and prove it red with `if (false)` at `:302`.

## Stated, not silently kept

- `DashMinedCommitmentIndex.ShortfallNamesTheTypeThatBlocksSelfCheckArming` keeps its name although this PR ships no arming. The condition it names is still exactly what will block arming when #90 lands; renaming costs a rebuild cycle for zero behavioural change. One-line rename if the reviewer prefers the name not advertise an absent feature.
- **#90's arming half is now UNIMPLEMENTED by choice.** Nothing in this binary calls `arm_self_check()`, so `fold_root_vs_committed` still reports a warm-up counter — it now *names* its blocking condition instead of printing a bare 0/N. **Do not read "UNARMED" in the log as "the check passed."**
