### PR TITLE
dash: publish the credit pool at the SERVE tip, not the body height

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -795,7 +795,17 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              // occupies and refuse the pin that would push the assembled
              // block past the 2 MB consensus limit, with a NAMED cause.
              // OFF reproduces the shipped arithmetic byte-for-byte.
-             bool pin_block_budget = false)
+             bool pin_block_budget = false,
+             // --embedded-creditpool-publish-at-serve-tip: publish the derived
+             // DIP-0027 credit pool AT THE SERVE TIP instead of at the folded
+             // body height (dashd derives the pool for the block you ask
+             // about -- creditpool.cpp:224 GetCreditPool(block_index), read at
+             // pindexPrev by both the template and validation paths). Removes
+             // the `creditpool-stale value=threshold+1` window that opens when
+             // the fourth-axis conjunct holds promotion. MONEY PATH: it makes
+             // the arm SERVE where it previously refused, so default false.
+             // Only meaningful on the body-first (coin-P2P daemonless) arm.
+             bool embedded_creditpool_publish_at_serve_tip = false)
 {
     namespace io = boost::asio;
 
@@ -4740,6 +4750,20 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         // advance. `creditpool-stale` then ceases to exist as a class in
         // normal operation; the ~1-2 s window is named `tip-body-pending`.
         maintainer->set_body_first_serve_tip(true);
+        // PR-5 publication height (default OFF; money path). With body-first
+        // on, the credit pool derived for a block ABOVE the serve tip is held
+        // and published atomically with the promotion that makes that block
+        // the serve tip -- so the pool the template is built from is the pool
+        // at the block it builds ON, which is what dashd does by construction
+        // (GetCreditPool(pindexPrev)).
+        maintainer->set_credit_pool_publish_at_serve_tip(
+            embedded_creditpool_publish_at_serve_tip);
+        std::cout << "[run] embedded credit-pool publication height: "
+                  << (embedded_creditpool_publish_at_serve_tip
+                          ? "SERVE TIP (--embedded-creditpool-publish-at-serve-tip)"
+                          : "body height (default; creditpool-stale windows "
+                            "possible while promotion is held)")
+                  << "\n";
         maintainer->set_full_block_buffer(true);
         maintainer->set_chain_hash_at_height_fn(
             [hc = header_chain.get()](uint32_t h) -> std::optional<uint256> {
@@ -7085,6 +7109,12 @@ int main(int argc, char** argv)
     // DASH_CONNECTBLOCK_REJECT_SURFACE_AUDIT.md) arms only on explicit
     // operator decision.
     bool embedded_serve_mempool_txs = false;
+    // --embedded-creditpool-publish-at-serve-tip: publish the derived credit
+    // pool AT THE SERVE TIP rather than at the folded body height (PR-5,
+    // dashd GetCreditPool(pindexPrev) parity). MONEY PATH -> default OFF: it
+    // makes the body-first arm SERVE serve-tip-based work in windows where it
+    // currently refuses with `creditpool-stale`.
+    bool embedded_creditpool_publish_at_serve_tip = false;
     std::string pin_local_tx_hex_path;
     // --embedded-mempool-ingest: arm the coin-P2P MSG_TX pull (phase 1).
     // SEPARATE from --embedded-serve-mempool-txs on purpose: this only makes
@@ -7192,6 +7222,9 @@ int main(int argc, char** argv)
             embedded_mempool_ingest = true;
         else if (std::strcmp(argv[i], "--dash-pin-block-budget") == 0)
             pin_block_budget = true;
+        else if (std::strcmp(argv[i],
+                             "--embedded-creditpool-publish-at-serve-tip") == 0)
+            embedded_creditpool_publish_at_serve_tip = true;
         else if (std::strcmp(argv[i], "--pin-local-tx-hex") == 0 && i + 1 < argc)
             pin_local_tx_hex_path = argv[++i];
         else if (std::strcmp(argv[i], "--replay-utxo-db") == 0 && i + 1 < argc)
@@ -7473,7 +7506,8 @@ int main(int argc, char** argv)
                         embedded_mempool_ingest,
                         pin_local_tx_hex_path,
                         serve_staleness_sentinel,
-                        pin_block_budget);
+                        pin_block_budget,
+                        embedded_creditpool_publish_at_serve_tip);
     }
     return run_selftest();
 }

--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -1831,9 +1831,18 @@ private:
             m_cp_publish_at_serve_tip
             && m_body_first_serve_tip
             // No serve tip yet (cold start / post-demote): there is no tip for
-            // the pool to run ahead OF, and holding here would deadlock the
-            // arm -- promotion is what publishes, and nothing would ever
-            // promote. Publish, exactly as today.
+            // the pool to run ahead OF, so publish, exactly as today.
+            // NO DEADLOCK IS CLAIMED. An earlier revision of this comment said
+            // holding here "would deadlock the arm"; that was not demonstrable
+            // and is retracted -- every pending slot reachable from a cold
+            // start is drained by the very next promotion, which matches it
+            // via credit_pool_derived_at and publishes it in the same step.
+            // What the conjunct actually buys is the INTERMEDIATE state: with
+            // no serve tip the pool lands in the PUBLISHED slot rather than a
+            // slot only a promotion can drain, so a node whose promotion is
+            // held on another axis still has a published pool. That, and only
+            // that, is what ColdStartPublishesImmediatelyWithPublicationHeightOn
+            // asserts -- and it is red without this line.
             && m_have_tip
             && at_height > static_cast<int32_t>(m_prev_height);
         m_cp_pending_valid   = hold;
@@ -1854,6 +1863,17 @@ private:
 
     /// Drop anything held (rollback paths: the branch it was derived on is
     /// gone, or the seed is being invalidated outright).
+    ///
+    /// NOT inert bookkeeping — MONEY PATH. The pending slot answers
+    /// credit_pool_derived_at(), which IS the credit-pool promotion
+    /// precondition, so a slot that survives a rollback lets the next
+    /// promotion at that same hash/height publish the ORPHANED branch's
+    /// balance. On the cold-wipe path (:942) that silently undoes the
+    /// deliberate fail-closed write of (0, ZERO, -1) one line later.
+    /// Covered red-on-mutation by ColdWipeDiscardsHeldPoolSoTheOrphanCannot-
+    /// BeRepublished and ReorgUndoDiscardsHeldPoolDerivedAboveTheForkPoint —
+    /// emptying this body turns both red (orphan pool republished at H, serve
+    /// tip promoted onto it).
     void discard_held_credit_pool() { m_cp_pending_valid = false; }
 
     /// Is the credit pool DERIVED at exactly this block — published already,

--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -663,8 +663,13 @@ public:
                     // the seed does not advance to the tip, the seed height stays
                     // behind m_prev_height and the freshness gate fails closed
                     // instead of committing a lagged creditPoolBalance (soak fix).
-                    m_state.set_credit_pool(observed.creditPoolBalance,
-                                            diff.blockHash, observed.nHeight);
+                    // PR-5: publication height. Same rule as the body fold —
+                    // a diff-derived pool ABOVE the serve tip is held for the
+                    // promotion below (maybe_promote_pending_tip) to publish.
+                    // Under the default-off flag this is m_state.set_credit_pool
+                    // verbatim.
+                    publish_credit_pool_at(observed.creditPoolBalance,
+                                           diff.blockHash, observed.nHeight);
                     // E2: re-anchor the independent running accrual to this
                     // authoritative snapshot value/height so the per-block advance
                     // (on_block_connected) continues contiguously from here, and
@@ -911,6 +916,10 @@ public:
                         && cb.nVersion >= vendor::CCbTx::VERSION_CLSIG_AND_BALANCE
                         && cb.nHeight == static_cast<int32_t>(*fork_h)) {
                         m_credit_pool_sm.seed(cb.creditPoolBalance, *fork_h);
+                        // Rollback: write straight through and drop anything
+                        // held — a held pool was derived on the branch that
+                        // just went away (PR-5).
+                        discard_held_credit_pool();
                         m_state.set_credit_pool(cb.creditPoolBalance, rb.hash,
                                                 static_cast<int32_t>(*fork_h));
                         cp_undone = true;
@@ -928,7 +937,9 @@ public:
         if (!cp_undone) {
             // Invalidate the credit-pool seed's freshness (height -1 != any
             // tip), so the arm fails closed on the credit-pool axis until a
-            // fresh re-seed.
+            // fresh re-seed. A HELD pool (PR-5) is dropped with it: it was
+            // derived on the orphaned branch and must never be published.
+            discard_held_credit_pool();
             m_state.set_credit_pool(0, uint256::ZERO, -1);
             // E2: wipe the independent running accrual as well — its balance
             // was built on the now-orphaned branch. It re-bootstraps from the
@@ -1351,6 +1362,32 @@ public:
     void set_body_first_serve_tip(bool on) { m_body_first_serve_tip = on; }
     bool body_first_serve_tip() const { return m_body_first_serve_tip; }
 
+    /// PUBLICATION HEIGHT (PR-5). When enabled (and body-first is on), the
+    /// derived credit pool is PUBLISHED at the SERVE tip instead of at the
+    /// body height: a pool derived for a block ABOVE the serve tip is held in
+    /// a pending slot and published atomically with the promotion that makes
+    /// that block the serve tip. See publish_credit_pool_at() for the dashd
+    /// mechanism this ports and why the current write is not merely
+    /// gate-tripping but reward-WRONG for the tip we are actually building on.
+    ///
+    /// MONEY PATH -> default OFF. Turning it on changes what the embedded arm
+    /// serves during a held window: it serves serve-tip-based work where it
+    /// previously refused with `creditpool-stale`. main_dash exposes it as
+    /// --embedded-creditpool-publish-at-serve-tip; nothing enables it
+    /// implicitly.
+    void set_credit_pool_publish_at_serve_tip(bool on) {
+        m_cp_publish_at_serve_tip = on;
+    }
+    bool credit_pool_publish_at_serve_tip() const {
+        return m_cp_publish_at_serve_tip;
+    }
+    /// Observability (STATE SAYS ITS OWN NAME): is a derived credit pool
+    /// currently HELD above the serve tip, awaiting promotion? -1 = nothing
+    /// held.
+    int32_t held_credit_pool_height() const {
+        return m_cp_pending_valid ? m_cp_pending_height : -1;
+    }
+
     /// Body-first observability (STATE SAYS ITS OWN NAME): is the maintainer
     /// currently holding the serve tip below a known header tip, awaiting the
     /// tip body? TRUE is the normal ~1-2 s propagation transient, never an
@@ -1656,11 +1693,18 @@ private:
             // referential — value AND height come straight off the wire.
             m_credit_pool_sm.seed(from_wire, height);
         }
-        // Advance the freshness seed to THIS block: height == the tip we build the
-        // next template on, so the credit-pool freshness gate passes at the right
-        // height without waiting for the next mnlistdiff.
-        m_state.set_credit_pool(from_wire, block_identity_hash(block),
-                                static_cast<int32_t>(height));
+        // Advance the freshness seed to THIS block. The comment that used to
+        // stand here asserted "height == the tip we build the next template
+        // on" — true in header-first mode, and true in body-first mode ONLY
+        // when this fold promotes the serve tip. When promotion is held (the
+        // fourth axis, maybe_promote_pending_tip:1820-1822), the serve tip
+        // stays at H-1 while this write moved the pool to H: the pool AHEAD of
+        // the tip, which is exactly the `creditpool-stale value=threshold+1`
+        // class. publish_credit_pool_at() makes the assertion true by
+        // construction under the flag — it publishes at the serve tip and
+        // holds anything above it for the promotion to publish.
+        publish_credit_pool_at(from_wire, block_identity_hash(block),
+                               static_cast<int32_t>(height));
     }
 
     // E-SUPERBLOCK (R4): derive the funding threshold from the CURRENT SML —
@@ -1742,6 +1786,105 @@ private:
 
     // ── BODY-FIRST serve-tip machinery ───────────────────────────────────
 
+    // ── PR-5: PUBLICATION HEIGHT of the credit pool ──────────────────────
+    //
+    // THE MECHANISM, from dashd v23.1.7. dashd has no single "current" credit
+    // pool at all. CCreditPoolManager::GetCreditPool(block_index)
+    // (src/evo/creditpool.cpp:224-239) DERIVES the pool FOR THE BLOCK YOU ASK
+    // ABOUT, walking back to the nearest cached ancestor, and caches the
+    // result keyed by that block's own hash+height
+    // (creditpool.cpp:218 AddToCache(block_index->GetBlockHash(),
+    // block_index->nHeight, pool), store at creditpool.h:115). Deriving the
+    // pool at H therefore leaves the pool at H-1 exactly as available as it
+    // was. Every consumer asks for the pool AT THE BLOCK IT IS BUILDING OR
+    // VALIDATING ON, never "the newest one":
+    //   * template  : CChainstateHelper::GetCreditPool passthrough
+    //                 (evo/chainhelper.cpp:48-51), called with pindexPrev;
+    //   * validation: GetCreditPoolDiffForBlock ->
+    //                 cpoolman.GetCreditPool(pindexPrev)
+    //                 (creditpool.cpp:325-333), and the connect-time path
+    //                 CSpecialTxProcessor (evo/specialtxman.cpp:565)
+    //                 GetCreditPool(pindex->pprev).
+    // The committed balance of a block at height X is the pool at X-1 plus
+    // that block's own deltas (specialtxman.cpp:745-755).
+    //
+    // WE have ONE published slot, and node_coin_state.hpp:1334-1340 measures
+    // its height against the SERVE tip while node_coin_state.hpp:1096-1103
+    // builds the next CbTx's creditPoolBalance from its VALUE. Writing that
+    // slot at the BODY height while the serve tip is still H-1 (promotion
+    // held on the fourth axis, :1820-1822) is therefore wrong twice over:
+    //   1. the freshness gate reports `creditpool-stale` with value =
+    //      threshold+1 -- the pool is AHEAD of the tip, never behind, which is
+    //      why every one of the 48 measured episodes carried exactly +1;
+    //   2. had the gate not refused, the template built on H-1 would have
+    //      committed the pool at H -- the wrong base, a bad-cbtx block.
+    // Publishing at the serve tip fixes both: the pool the arm serves from is
+    // the pool at the block it builds on, which is what dashd does by
+    // construction.
+    //
+    // Every credit-pool ADVANCE routes through here. The rollback paths
+    // (reorg undo / cold wipe) write m_state directly and clear the pending
+    // slot -- they move the seed to or below the tip, never above it.
+    void publish_credit_pool_at(int64_t balance, const uint256& at_hash,
+                                int32_t at_height) {
+        const bool hold =
+            m_cp_publish_at_serve_tip
+            && m_body_first_serve_tip
+            // No serve tip yet (cold start / post-demote): there is no tip for
+            // the pool to run ahead OF, and holding here would deadlock the
+            // arm -- promotion is what publishes, and nothing would ever
+            // promote. Publish, exactly as today.
+            && m_have_tip
+            && at_height > static_cast<int32_t>(m_prev_height);
+        m_cp_pending_valid   = hold;
+        m_cp_pending_balance = balance;
+        m_cp_pending_hash    = at_hash;
+        m_cp_pending_height  = at_height;
+        if (hold) {
+            LOG_INFO
+                << "[CREDITPOOL] derived h=" << at_height
+                << " HELD above the serve tip h=" << m_prev_height
+                << " — publishing at the serve tip (dashd derives the pool at"
+                   " pindexPrev; the template building on h=" << m_prev_height
+                << " must commit the pool at h=" << m_prev_height << ")";
+            return;
+        }
+        m_state.set_credit_pool(balance, at_hash, at_height);
+    }
+
+    /// Drop anything held (rollback paths: the branch it was derived on is
+    /// gone, or the seed is being invalidated outright).
+    void discard_held_credit_pool() { m_cp_pending_valid = false; }
+
+    /// Is the credit pool DERIVED at exactly this block — published already,
+    /// or held pending publication? This is the promotion precondition: what
+    /// matters is that we HAVE the pool for that block, not which slot it is
+    /// sitting in.
+    bool credit_pool_derived_at(const uint256& at_hash, uint32_t at_height) const {
+        if (m_cp_pending_valid
+            && m_cp_pending_hash == at_hash
+            && m_cp_pending_height == static_cast<int32_t>(at_height))
+            return true;
+        return m_state.credit_pool_current_hash() == at_hash
+               && m_state.credit_pool_height() == static_cast<int32_t>(at_height);
+    }
+
+    /// Publish a HELD pool at the moment the serve tip becomes its block.
+    /// Called from maybe_promote_pending_tip immediately before
+    /// promote_serve_tip, so the publication and the serve-tip advance are one
+    /// indivisible step on the single io thread — the same atomicity the whole
+    /// body-first design rests on. A pending slot for a DIFFERENT block is
+    /// left alone (it is not this tip's pool).
+    void publish_held_credit_pool_at(const uint256& at_hash, uint32_t at_height) {
+        if (!m_cp_pending_valid) return;
+        if (m_cp_pending_hash != at_hash
+            || m_cp_pending_height != static_cast<int32_t>(at_height))
+            return;
+        m_state.set_credit_pool(m_cp_pending_balance, m_cp_pending_hash,
+                                m_cp_pending_height);
+        m_cp_pending_valid = false;
+    }
+
     /// Copy the stashed header-tip params into the SERVE slots. In
     /// header-first (legacy) mode this runs inside on_new_tip, byte-identical
     /// to the old direct assignment; in body-first mode it runs only from
@@ -1785,9 +1928,13 @@ private:
     bool maybe_promote_pending_tip() {
         if (!m_body_first_serve_tip || !m_tip_body_pending) return false;
         if (!m_have_hdr_tip) return false;
-        if (m_state.credit_pool_current_hash() != m_hdr_prev_hash) return false;
-        if (m_state.credit_pool_height()
-            != static_cast<int32_t>(m_hdr_prev_height)) return false;
+        // Credit-pool axis: the pool must be DERIVED at this exact block —
+        // published already (flag off / at-or-below the serve tip), or HELD
+        // pending publication (PR-5). Asking "do we have the pool for this
+        // block" rather than "is the published slot at this block" is what
+        // lets the publication ride the promotion instead of preceding it.
+        if (!credit_pool_derived_at(m_hdr_prev_hash, m_hdr_prev_height))
+            return false;
         // The PAYEE axis must be current at the tip too (its cursor advances
         // in the tip-body apply_block, or a snapshot loaded as-of the tip):
         // promoting off a tip-targeted mnlistdiff that outraced the body
@@ -1820,6 +1967,12 @@ private:
         if (!m_state.sml_current_hash().IsNull()
             && m_state.sml_current_hash() != m_hdr_prev_hash)
             return false;
+        // PUBLISH-WITH-PROMOTION (PR-5): the held pool for this exact block
+        // becomes the published pool in the same indivisible step that makes
+        // the block the serve tip. No observer can see the pool at H with the
+        // serve tip at H-1 — the creditpool-stale window is not shortened, it
+        // ceases to have a state to exist in.
+        publish_held_credit_pool_at(m_hdr_prev_hash, m_hdr_prev_height);
         promote_serve_tip();
         m_state.set_tip_body_pending_dbg(false);
         LOG_INFO << "[EMB-DASH] serve tip promoted h=" << m_prev_height << " "
@@ -2056,6 +2209,15 @@ private:
     // Body-first mode + pending-window state. Defaults keep every existing
     // construction site byte-identical (header-first).
     bool    m_body_first_serve_tip{false};
+    // PR-5 publication height. m_cp_pending_* holds a credit pool DERIVED for
+    // a block above the serve tip until promotion publishes it (see
+    // publish_credit_pool_at). Default OFF => the pending slot is never used
+    // and every write goes straight through, byte-identical to header-first.
+    bool    m_cp_publish_at_serve_tip{false};
+    bool    m_cp_pending_valid{false};
+    int64_t m_cp_pending_balance{0};
+    uint256 m_cp_pending_hash;
+    int32_t m_cp_pending_height{-1};
     bool    m_tip_body_pending{false};
     bool    m_tip_overdue_latched{false};
     int64_t m_tip_pending_since{0};

--- a/test/test_dash_coin_state_maintainer.cpp
+++ b/test/test_dash_coin_state_maintainer.cpp
@@ -1820,10 +1820,26 @@ TEST(DashCoinStateMaintainer, CreditPoolPublishesAtServeTipWhilePromotionHeld) {
     }
 }
 
-// The held pool must never be published on its own timeline: a cold-start /
-// post-demote state (no serve tip) has no tip for the pool to run ahead of,
-// and holding there would DEADLOCK the arm (promotion is what publishes, and
-// promotion needs the pool). Pins the carve-out in publish_credit_pool_at.
+// ── The no-serve-tip carve-out (`&& m_have_tip`, publish_credit_pool_at) ──
+// The carve-out has ONE observable effect, and it is an INTERMEDIATE state:
+// with no serve tip the derived pool goes to the PUBLISHED slot instead of the
+// pending slot. Assert exactly that, and nothing more.
+//
+// The earlier version of this test asserted only the settled state after a
+// cold fold that promotes in the same step — and could not fail, because a
+// pending slot is drained by that very promotion (credit_pool_derived_at
+// matches it, publish_held_credit_pool_at publishes it) so the settled state
+// is byte-identical with or without the carve-out. Deleting `&& m_have_tip`
+// left the whole suite green. The scenario below fixes that by holding
+// promotion on the SML axis, so no promotion can launder the difference away:
+// the SML currency is set to a NON-cold hash that does not name the incoming
+// tip, which the fourth-axis ZERO carve-out therefore does not wave through.
+//
+// NOTE what is NOT claimed: this pins the carve-out's BEHAVIOUR, not a
+// deadlock. No deadlock was demonstrated for the cold-start path — every
+// pending slot reachable there is drained by the next promotion — so the
+// former "pins the carve-out against a future tightening into a deadlock"
+// claim is retracted.
 TEST(DashCoinStateMaintainer, ColdStartPublishesImmediatelyWithPublicationHeightOn) {
     NodeCoinState st;
     CoinStateMaintainer m(st);
@@ -1831,17 +1847,113 @@ TEST(DashCoinStateMaintainer, ColdStartPublishesImmediatelyWithPublicationHeight
     m.set_credit_pool_publish_at_serve_tip(true);
     st.set_require_fresh_credit_pool(true);
     m.on_mn_list_update(single_mn(p2pkh_script(0x30)));
+    // Non-cold SML currency naming SOME OTHER block => the fourth axis holds
+    // promotion through the fold below.
+    st.set_sml_current_hash(raw256(0xA7));
 
     auto b1 = make_cbtx_block(H - 1, 111'000'000LL, p2pkh_script(0x30));
     const uint256 h1 = block_hash_of(b1);
     m.on_new_tip(H - 1, h1, BITS, MTP, DASH_PUBKEY_VER, DASH_P2SH_VER,
                  CURTIME, VERSION);
     ASSERT_EQ(m.serve_tip_height(), 0u) << "no serve tip yet";
+    ASSERT_FALSE(m.have_tip()) << "the carve-out's precondition";
     m.on_block_connected(b1, H - 1);
+
+    // Promotion is genuinely held, so nothing here can drain a pending slot.
+    ASSERT_EQ(m.serve_tip_height(), 0u) << "SML axis holds promotion";
+    ASSERT_TRUE(m.tip_body_pending());
+
+    // THE CARVE-OUT, and the only thing it does: with no serve tip the pool is
+    // PUBLISHED, not parked in a slot only a promotion can drain.
+    EXPECT_EQ(st.credit_pool_height(), static_cast<int32_t>(H - 1))
+        << "no serve tip => publish immediately, do not hold";
+    EXPECT_EQ(st.credit_pool(), 111'000'000LL);
+    EXPECT_EQ(m.held_credit_pool_height(), -1) << "nothing may be held here";
+
+    // Settled state (identical either way — asserted for completeness, NOT as
+    // the discriminating assertion): the SML lands and the tip promotes.
+    st.set_sml_current_hash(h1);
+    m.on_new_tip(H - 1, h1, BITS, MTP, DASH_PUBKEY_VER, DASH_P2SH_VER,
+                 CURTIME, VERSION);
     EXPECT_EQ(m.serve_tip_height(), H - 1) << "cold start must still promote";
     EXPECT_EQ(st.credit_pool_height(), static_cast<int32_t>(H - 1));
-    EXPECT_EQ(m.held_credit_pool_height(), -1);
     EXPECT_TRUE(m.live());
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// ROLLBACK: discard_held_credit_pool() on both call sites.
+//
+// The pending slot answers credit_pool_derived_at() — the promotion
+// precondition — so a slot that SURVIVES a rollback is not inert: the next
+// promotion attempt at that same block hash/height finds the pool "derived",
+// promotes, and publish_held_credit_pool_at writes the ORPHANED branch's
+// balance into the published slot. On the cold-wipe path that silently
+// defeats the deliberate fail-closed write of (0, ZERO, -1).
+// ════════════════════════════════════════════════════════════════════════
+
+// COLD WIPE (on_sml_reorg, no retained body on the new branch).
+TEST(DashCoinStateMaintainer, ColdWipeDiscardsHeldPoolSoTheOrphanCannotBeRepublished) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    m.set_credit_pool_publish_at_serve_tip(true);
+    auto s = drive_held_promotion(st, m);
+    ASSERT_EQ(m.held_credit_pool_height(), static_cast<int32_t>(H))
+        << "precondition: a pool derived at H is HELD above the serve tip";
+    ASSERT_EQ(st.credit_pool_height(), static_cast<int32_t>(H - 1));
+
+    // Reorg with the block buffer unwired => the cold wipe path, which
+    // deliberately writes (0, ZERO, -1) to fail closed on this axis.
+    m.on_sml_reorg();
+    EXPECT_EQ(st.credit_pool_height(), -1) << "cold wipe must fail closed";
+    EXPECT_EQ(m.held_credit_pool_height(), -1)
+        << "a pool derived on the orphaned branch must be dropped with the seed";
+
+    // THE MONEY PATH. The orphaned block is re-announced as the header tip
+    // (reorg-back, or a competing announcement). If the slot survived, it
+    // satisfies credit_pool_derived_at(h2, H) and promotion republishes the
+    // orphan's balance over the fail-closed -1 — and serves off it.
+    m.on_new_tip(H, s.h2, BITS, MTP, DASH_PUBKEY_VER, DASH_P2SH_VER,
+                 CURTIME, VERSION);
+    EXPECT_EQ(st.credit_pool_height(), -1)
+        << "promotion must not resurrect the orphaned branch's credit pool";
+    EXPECT_NE(st.credit_pool(), s.bal2)
+        << "the orphaned balance must never reach the published slot";
+    EXPECT_EQ(m.serve_tip_height(), H - 1)
+        << "no serve tip may be promoted off an orphan-derived pool";
+}
+
+// REORG UNDO from the retained fork-point body (the other call site): the pool
+// is rolled back to the fork point, and the held pool — derived ABOVE it, on
+// the branch that just went away — must go with it.
+TEST(DashCoinStateMaintainer, ReorgUndoDiscardsHeldPoolDerivedAboveTheForkPoint) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    m.set_full_block_buffer(true);
+    m.set_credit_pool_publish_at_serve_tip(true);
+    auto s = drive_held_promotion(st, m);
+    ASSERT_EQ(m.held_credit_pool_height(), static_cast<int32_t>(H));
+    ASSERT_EQ(m.block_buffer_depth(), 2u);
+
+    // New branch: H-1 is still ours (fork point), H is a different block.
+    m.set_chain_hash_at_height_fn(
+        [&](uint32_t h) -> std::optional<uint256> {
+            if (h == H - 1) return s.h1;
+            if (h == H) return raw256(0xEE);
+            return std::nullopt;
+        });
+    m.on_sml_reorg();
+    EXPECT_EQ(st.credit_pool_height(), static_cast<int32_t>(H - 1))
+        << "rolled back to the fork point from the retained body";
+    EXPECT_EQ(st.credit_pool(), s.bal1);
+    EXPECT_EQ(m.held_credit_pool_height(), -1)
+        << "the held pool was derived above the fork point, on the dead branch";
+
+    m.on_new_tip(H, s.h2, BITS, MTP, DASH_PUBKEY_VER, DASH_P2SH_VER,
+                 CURTIME, VERSION);
+    EXPECT_EQ(st.credit_pool_height(), static_cast<int32_t>(H - 1))
+        << "promotion must not resurrect the orphaned branch's credit pool";
+    EXPECT_EQ(st.credit_pool(), s.bal1);
+    EXPECT_EQ(m.serve_tip_height(), H - 1);
 }
 
 // Legacy default pinned: with body-first NOT enabled, on_new_tip promotes the

--- a/test/test_dash_coin_state_maintainer.cpp
+++ b/test/test_dash_coin_state_maintainer.cpp
@@ -1678,6 +1678,172 @@ TEST(DashCoinStateMaintainer, BodyFirstServeTipNeverExceedsParsedBodyHeight) {
     }
 }
 
+// ════════════════════════════════════════════════════════════════════════
+// PR-5: CREDIT-POOL PUBLICATION HEIGHT
+//
+// The test above asserts "no creditpool-stale window may exist after the
+// atomic advance" and passes only because it never exercises the SML axis:
+// its sml_current_hash is the cold ZERO sentinel, which the fourth-axis
+// carve-out (coin_state_maintainer.hpp:1820-1822) deliberately lets through,
+// so the body fold always promotes and the pool write always lands AT the
+// serve tip.
+//
+// The steady state is different: the SML is current at the serve tip H-1, and
+// it advances only on its own getmnlistd round trip. Between the tip body
+// fold and that round trip, promotion is HELD (by design — promoting first
+// would trade a creditpool-stale window for a dmn-stale one) while
+// advance_credit_pool_on_block writes the pool at the BODY height H. The pool
+// is then ONE BLOCK AHEAD of the serve tip — which is precisely what the soak
+// measured: all 48 creditpool-stale episodes carried value = threshold + 1,
+// exactly, never behind.
+//
+// The scenario below is the one the maintainer actually runs; the two tests
+// differ ONLY in the publication-height flag.
+// ════════════════════════════════════════════════════════════════════════
+namespace {
+// Drives: serve tip established at H-1 (header+body), SML current AT H-1,
+// then header H + body H with the SML still at H-1 (promotion held).
+// Returns the H-block so the caller can address it.
+struct HeldPromotionScenario {
+    BlockType b1;
+    BlockType b2;
+    uint256   h1;
+    uint256   h2;
+    int64_t   bal1{111'000'000LL};
+    int64_t   bal2{0};
+};
+HeldPromotionScenario drive_held_promotion(NodeCoinState& st,
+                                           CoinStateMaintainer& m) {
+    HeldPromotionScenario s;
+    m.set_body_first_serve_tip(true);
+    st.set_require_fresh_credit_pool(true);
+    m.on_mn_list_update(single_mn(p2pkh_script(0x30)));
+
+    s.b1 = make_cbtx_block(H - 1, s.bal1, p2pkh_script(0x30));
+    s.h1 = block_hash_of(s.b1);
+    m.on_new_tip(H - 1, s.h1, BITS, MTP, DASH_PUBKEY_VER, DASH_P2SH_VER,
+                 CURTIME, VERSION);
+    m.on_block_connected(s.b1, H - 1);
+    EXPECT_EQ(m.serve_tip_height(), H - 1);
+
+    // STEADY STATE (what the test above never sets): the SML is current AT
+    // the serve tip. A live node is here between every pair of blocks.
+    st.set_sml_current_hash(s.h1);
+
+    s.bal2 = next_balance(st, s.bal1, H);
+    s.b2 = make_cbtx_block(H, s.bal2, p2pkh_script(0x30));
+    s.h2 = block_hash_of(s.b2);
+    m.on_new_tip(H, s.h2, BITS, MTP, DASH_PUBKEY_VER, DASH_P2SH_VER,
+                 CURTIME, VERSION);
+    // The tip BODY lands before the tip-targeted mnlistdiff (the ordinary
+    // order: the body is pushed, the SML must be asked for).
+    m.on_block_connected(s.b2, H);
+    return s;
+}
+}  // namespace
+
+// CHARACTERIZATION of the DEFAULT (flag off) — this is master's behaviour and
+// must stay master's behaviour until an operator arms the flag. It documents
+// the defect rather than asserting it is desirable.
+TEST(DashCoinStateMaintainer, CreditPoolPublishesAtBodyHeightByDefault) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    ASSERT_FALSE(m.credit_pool_publish_at_serve_tip()) << "money path: OFF by default";
+    auto s = drive_held_promotion(st, m);
+
+    // Promotion is held on the SML axis — correct, and unchanged by PR-5.
+    EXPECT_EQ(m.serve_tip_height(), H - 1);
+    EXPECT_TRUE(m.tip_body_pending());
+    // ...but the pool was published at the BODY height: ONE BLOCK AHEAD.
+    EXPECT_EQ(st.credit_pool_height(), static_cast<int32_t>(H));
+    EXPECT_EQ(st.credit_pool(), s.bal2);
+    auto d = st.describe_decline();
+    EXPECT_FALSE(d.viable);
+    EXPECT_EQ(d.cause, "creditpool-stale");
+    EXPECT_EQ(d.value, std::to_string(H)) << "value = threshold + 1, always";
+    EXPECT_EQ(m.held_credit_pool_height(), -1) << "nothing is held when the flag is off";
+}
+
+// THE FIX. Same scenario, publication height armed: the pool is published AT
+// THE SERVE TIP, so no creditpool-stale window can exist while promotion is
+// held — and, the reason this is a correctness fix and not a gate relaxation,
+// the value the template would build from is the pool at the block it is
+// building ON (dashd: GetCreditPool(pindexPrev), creditpool.cpp:224 / :325-333
+// / specialtxman.cpp:565). Publishing H while building on H-1 would commit the
+// wrong creditPoolBalance; today only the refusal prevents that.
+TEST(DashCoinStateMaintainer, CreditPoolPublishesAtServeTipWhilePromotionHeld) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    m.set_credit_pool_publish_at_serve_tip(true);
+    auto s = drive_held_promotion(st, m);
+
+    // Promotion still held on the SML axis — PR-5 does NOT relax the conjunct.
+    EXPECT_EQ(m.serve_tip_height(), H - 1);
+    EXPECT_TRUE(m.tip_body_pending());
+
+    // The published pool is the pool AT THE SERVE TIP.
+    EXPECT_EQ(st.credit_pool_height(), static_cast<int32_t>(H - 1))
+        << "publication height must follow the SERVE tip, not the body height";
+    EXPECT_EQ(st.credit_pool(), s.bal1)
+        << "the VALUE too: a template building on H-1 must commit the pool at H-1";
+    // The derived-but-unpublished pool says its own name.
+    EXPECT_EQ(m.held_credit_pool_height(), static_cast<int32_t>(H));
+
+    // No creditpool-stale window exists — the state it needs is unreachable.
+    auto d = st.describe_decline();
+    EXPECT_TRUE(d.viable)
+        << "creditpool-stale while promotion is held (cause=" << d.cause
+        << " value=" << d.value << " threshold=" << d.threshold << ")";
+    EXPECT_NE(d.cause, "creditpool-stale");
+    {
+        WorkSelection sel = st.select_work([]() { return DashWorkData{}; });
+        EXPECT_EQ(sel.source, WorkSource::Embedded);
+        EXPECT_EQ(sel.work.m_height, H) << "keeps serving H-1-based work, as designed";
+    }
+
+    // ── The SML catches up: promotion + publication are ONE step. ──
+    // In production the SML advances inside on_mnlistdiff, which calls
+    // maybe_promote_pending_tip itself (coin_state_maintainer.hpp:793); here
+    // the currency is set directly and the next maintainer event drives the
+    // promotion, which is the same code path.
+    st.set_sml_current_hash(s.h2);
+    m.on_new_tip(H, s.h2, BITS, MTP, DASH_PUBKEY_VER, DASH_P2SH_VER,
+                 CURTIME, VERSION);
+    EXPECT_EQ(m.serve_tip_height(), H);
+    EXPECT_EQ(st.credit_pool_height(), static_cast<int32_t>(H));
+    EXPECT_EQ(st.credit_pool(), s.bal2);
+    EXPECT_EQ(m.held_credit_pool_height(), -1) << "nothing left held after publication";
+    EXPECT_TRUE(st.describe_decline().viable);
+    {
+        WorkSelection sel = st.select_work([]() { return DashWorkData{}; });
+        EXPECT_EQ(sel.work.m_height, H + 1);
+    }
+}
+
+// The held pool must never be published on its own timeline: a cold-start /
+// post-demote state (no serve tip) has no tip for the pool to run ahead of,
+// and holding there would DEADLOCK the arm (promotion is what publishes, and
+// promotion needs the pool). Pins the carve-out in publish_credit_pool_at.
+TEST(DashCoinStateMaintainer, ColdStartPublishesImmediatelyWithPublicationHeightOn) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    m.set_body_first_serve_tip(true);
+    m.set_credit_pool_publish_at_serve_tip(true);
+    st.set_require_fresh_credit_pool(true);
+    m.on_mn_list_update(single_mn(p2pkh_script(0x30)));
+
+    auto b1 = make_cbtx_block(H - 1, 111'000'000LL, p2pkh_script(0x30));
+    const uint256 h1 = block_hash_of(b1);
+    m.on_new_tip(H - 1, h1, BITS, MTP, DASH_PUBKEY_VER, DASH_P2SH_VER,
+                 CURTIME, VERSION);
+    ASSERT_EQ(m.serve_tip_height(), 0u) << "no serve tip yet";
+    m.on_block_connected(b1, H - 1);
+    EXPECT_EQ(m.serve_tip_height(), H - 1) << "cold start must still promote";
+    EXPECT_EQ(st.credit_pool_height(), static_cast<int32_t>(H - 1));
+    EXPECT_EQ(m.held_credit_pool_height(), -1);
+    EXPECT_TRUE(m.live());
+}
+
 // Legacy default pinned: with body-first NOT enabled, on_new_tip promotes the
 // serve tip immediately (header-first) — byte-identical pre-split behaviour
 // for every existing posture (KATs, dashd-RPC/ZMQ tip feed with no body feed).


### PR DESCRIPTION
**This is a correctness fix that happens to remove a decline, not a throughput fix.**

The `creditpool-stale` decline is not a stale pool. In all 48 measured daemonless episodes it carried `value = threshold + 1`, exactly: the pool is one block **ahead** of the serve tip, never behind. Seeding a pool that is behind closes none of them.

**Mechanism.** `advance_credit_pool_on_block()` wrote `set_credit_pool(from_wire, hash, height)` unconditionally at the *body* height, under a comment asserting "height == the tip we build the next template on". That holds only when the fold also promotes the serve tip. When `maybe_promote_pending_tip()` holds promotion on the fourth axis (SML currency hash != header tip), the serve tip stays at H-1 while the pool moves to H, and the freshness clause refuses.

**dashd has no single "current" pool to get ahead of anything.** `CCreditPoolManager::GetCreditPool(block_index)` (v23.1.7 `evo/creditpool.cpp:224-239`) *derives* the pool for the block you ask about, cached by that block's own hash+height. Every consumer asks at the block it builds or validates **on**: the template via `CChainstateHelper::GetCreditPool` with `pindexPrev` (`evo/chainhelper.cpp:48-51`), validation via `GetCreditPoolDiffForBlock -> GetCreditPool(pindexPrev)` (`creditpool.cpp:325-333`), and `CSpecialTxProcessor` (`evo/specialtxman.cpp:565`). A block at height X commits pool(X-1) plus its own deltas.

So publishing at H while the serve tip is H-1 is wrong twice: it manufactures the refusal, **and** — had the gate not refused — the template built on H-1 would have committed the pool at H.

**Change.** Every credit-pool advance now routes through `publish_credit_pool_at()`: a pool derived for a block above the serve tip is held in a pending slot and published atomically with the promotion that makes that block the serve tip. Single io thread, no lock added.

Contains an `amend!` commit — squash-merge, or autosquash before merging.


---

## ⛔ MERGE HAZARD — do NOT plain squash-merge this PR

HEAD is an **`amend!`** commit, not a plain `fixup!`. `amend!` replaces the target's message **only** under `git rebase --autosquash`. A plain GitHub squash-merge **concatenates both bodies**, which would re-admit into master's history the exact false claim this fixup exists to retract — e189c746's *"holding there would DEADLOCK the arm"* and *"pins the carve-out against a future tightening into a deadlock"*.

**Before merging:** run a local `git rebase -i --autosquash`, **or** paste the `amend!` body as the squash-commit message. Do not accept the default.

## Verified-by-mutation coverage gaps (both inert today — flag `m_cp_publish_at_serve_tip` defaults OFF)

| # | site | mutation | result |
|---|---|---|---|
| M7 | `coin_state_maintainer.hpp:1900-1902` — block-identity match in `publish_held_credit_pool_at` | `if (false && m_cp_pending_hash != at_hash` | **50 passed, zero red** |
| M8 | `coin_state_maintainer.hpp:1847` — `at_height > m_prev_height`, the central predicate of the feature | replaced with `&& true` | **50 passed, zero red** |

M8 is the feature's own condition: with it gone and the flag armed, **every** advance is held — including the mnlistdiff-path publish at `:671` whose `at_height` can equal the serve tip, giving a pool never drained by a promotion that already happened. No concrete money loss traced (the stuck slot fails *closed* on the freshness gate rather than serving a wrong value), so severity is low — but the coverage is literally zero.

Only non-test source change on the fixup is **comments**: the retracted deadlock claim at `:1833-1841` and the money-path note at `:1856-1866`. Zero behavioural change, zero served-bytes change.
