### PR TITLE
dash: DONATION-DROPPED must not fire on a pin that IS in the served template

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -405,6 +405,7 @@ void print_banner(const char* argv0)
         << "           [--embedded-utxo-immature-serve-empty] [--embedded-serve-mempool-txs]\n"
         << "           [--pin-local-tx-hex FILE]  (zero-fee self-mined tx, e.g. donation consolidation)\n"
         << "           [--pin-splice-xcheck-arm]  (let pins ride an xcheck-SWAPPED dashd template; default OFF)\n"
+        << "           [--pin-splice-block-budget] (EXCLUDE a pin that pushes the template past the block size cap; default OFF)\n"
         << "           [--bestcl-policy freshness|consensus-exact]\n"
         << "           [--embedded-oracle-shadow]\n"
         << "           [--embedded-shadow-compare]\n"
@@ -829,7 +830,19 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              // unchanged; ON, the pins ride it too, through the same unchanged
              // admission gate plus a height check and a block-size budget that
              // can only EXCLUDE.
-             bool pin_splice_xcheck_arm = false)
+             bool pin_splice_xcheck_arm = false,
+             // --pin-splice-block-budget: ENFORCE the block-level size budget
+             // in the pin splice. DEFAULT OFF -- money path.
+             //
+             // The budget caps a pin against what the template already holds
+             // (2 MB minus a named reserve). Enforcing it turns an inclusion
+             // into an exclusion on the declined-embedded arm, which has been
+             // splicing pins onto served templates in production since before
+             // this flag existed -- so it CHANGES SERVED BYTES and may not
+             // default on. OFF, the overflow is a WARNING and a recorded flag
+             // on the template; ON, the pin is excluded with cause=block-budget
+             // (block 2517855 was lost to bad-txns-oversize).
+             bool pin_splice_block_budget = false)
 {
     namespace io = boost::asio;
 
@@ -2553,6 +2566,20 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
               << (pin_splice_xcheck_arm ? "ON (--pin-splice-xcheck-arm)"
                                         : "OFF (default; misses are named, "
                                           "not spliced)")
+              << "\n";
+    // Block-size budget for the pin splice (default OFF). It is a flag because
+    // ENFORCING it removes a pin from a template the declined-embedded arm is
+    // already serving -- that changes served bytes, which is exactly what a
+    // money-path change may not do unannounced. OFF it still SAYS the budget
+    // was blown; it just does not act.
+    work_source->set_pin_splice_block_budget(pin_splice_block_budget);
+    std::cout << "[DASH-STRATUM-GBT] pin splice block-size budget: "
+              << (pin_splice_block_budget
+                      ? "ENFORCED (--pin-splice-block-budget; an over-budget "
+                        "pin is EXCLUDED)"
+                      : "OFF (default; an over-budget pin still rides and the "
+                        "overflow is logged BLOCK-BUDGET EXCEEDED, NOT "
+                        "ENFORCED)")
               << "\n";
     if (xcheck_wanted && !rpc) {
         std::cout << "[DASH-STRATUM-GBT] GBT cross-check DISABLED: dashd RPC "
@@ -7261,6 +7288,7 @@ int main(int argc, char** argv)
     bool embedded_creditpool_publish_at_serve_tip = false;
     std::string pin_local_tx_hex_path;
     bool pin_splice_xcheck_arm = false;
+    bool pin_splice_block_budget = false;
     // --embedded-mempool-ingest: arm the coin-P2P MSG_TX pull (phase 1).
     // SEPARATE from --embedded-serve-mempool-txs on purpose: this only makes
     // the mempool FILL. Whether its contents ever reach a served template is
@@ -7371,6 +7399,8 @@ int main(int argc, char** argv)
             pin_local_tx_hex_path = argv[++i];
         else if (std::strcmp(argv[i], "--pin-splice-xcheck-arm") == 0)
             pin_splice_xcheck_arm = true;
+        else if (std::strcmp(argv[i], "--pin-splice-block-budget") == 0)
+            pin_splice_block_budget = true;
         else if (std::strcmp(argv[i], "--replay-utxo-db") == 0 && i + 1 < argc)
             replay_utxo_db = argv[++i];
         else if (std::strcmp(argv[i], "--replay-utxo-hash") == 0)
@@ -7654,7 +7684,8 @@ int main(int argc, char** argv)
                         pin_local_tx_hex_path,
                         serve_staleness_sentinel,
                         embedded_creditpool_publish_at_serve_tip,
-                        pin_splice_xcheck_arm);
+                        pin_splice_xcheck_arm,
+                        pin_splice_block_budget);
     }
     return run_selftest();
 }

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -404,7 +404,7 @@ void print_banner(const char* argv0)
         << "           [--embedded-mn-bridge-no-cursor]\n"
         << "           [--embedded-utxo-immature-serve-empty] [--embedded-serve-mempool-txs]\n"
         << "           [--pin-local-tx-hex FILE]  (zero-fee self-mined tx, e.g. donation consolidation)\n"
-        << "           [--dash-pin-block-budget]  (refuse a pin that would push the served block over 2 MB)\n"
+        << "           [--pin-splice-xcheck-arm]  (let pins ride an xcheck-SWAPPED dashd template; default OFF)\n"
         << "           [--bestcl-policy freshness|consensus-exact]\n"
         << "           [--embedded-oracle-shadow]\n"
         << "           [--embedded-shadow-compare]\n"
@@ -807,14 +807,7 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              // decision. See coin/serve_staleness.hpp for why report-only was
              // chosen over a detector that can stop serving.
              bool serve_staleness_sentinel = true,
-             // --dash-pin-block-budget: MONEY PATH, DEFAULT OFF. Give the
-             // served-dashd splice the same block-level size budget #1177
-             // gave the embedded arm — measure what dashd's template already
-             // occupies and refuse the pin that would push the assembled
-             // block past the 2 MB consensus limit, with a NAMED cause.
-             // OFF reproduces the shipped arithmetic byte-for-byte.
-             bool pin_block_budget = false,
-             // --embedded-creditpool-publish-at-serve-tip: publish the derived
+// --embedded-creditpool-publish-at-serve-tip: publish the derived
              // DIP-0027 credit pool AT THE SERVE TIP instead of at the folded
              // body height (dashd derives the pool for the block you ask
              // about -- creditpool.cpp:224 GetCreditPool(block_index), read at
@@ -823,7 +816,20 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              // the fourth-axis conjunct holds promotion. MONEY PATH: it makes
              // the arm SERVE where it previously refused, so default false.
              // Only meaningful on the body-first (coin-P2P daemonless) arm.
-             bool embedded_creditpool_publish_at_serve_tip = false)
+             bool embedded_creditpool_publish_at_serve_tip = false,
+             // --pin-splice-xcheck-arm: let the pinned txs ride a template the
+             // GBT cross-check SWAPPED IN. DEFAULT OFF -- money path.
+             //
+             // The cross-check discards an embedded template that already
+             // carries the pins and serves a fresh dashd one; that replacement
+             // has never run the splice. Measured on the primary 2026-08-07,
+             // 66 of 197 served fallback templates came from that swap and one
+             // of them won h=2518044 without the donation. OFF, the miss is now
+             // NAMED (cause=xcheck-swap-pin-gate-off) and served bytes are
+             // unchanged; ON, the pins ride it too, through the same unchanged
+             // admission gate plus a height check and a block-size budget that
+             // can only EXCLUDE.
+             bool pin_splice_xcheck_arm = false)
 {
     namespace io = boost::asio;
 
@@ -2539,25 +2545,14 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // consulted, i.e. during an actual embedded outage.
     const bool xcheck_wanted = (testnet || embedded_mainnet);
     work_source->set_gbt_xcheck(xcheck_wanted && static_cast<bool>(rpc));
-
-    // ── BLOCK-LEVEL PIN BUDGET on the served-dashd arm ──────────────────────
-    // MONEY PATH, DEFAULT OFF (--dash-pin-block-budget). #1177 unified the
-    // size budget on the EMBEDDED arm; the fallback arm splices up to 400000
-    // bytes of pins onto dashd's own template with no block-level accounting,
-    // and dashd fills that template to its own blockmaxsize. ON, the splice
-    // measures the real remaining headroom and refuses the overflowing pin
-    // with the named cause pin-over-block-headroom. It is off by default
-    // because a refusal CHANGES SERVED BYTES; say which posture is live so
-    // the journal never has to be guessed at.
-    work_source->set_pin_block_budget(pin_block_budget);
-    std::cout << "[DASH-STRATUM] served-dashd pin block budget: "
-              << (pin_block_budget
-                      ? "ON (--dash-pin-block-budget: a pin that would push "
-                        "the assembled block past 2000000 bytes is REFUSED "
-                        "with cause=pin-over-block-headroom)"
-                      : "OFF (default: pins capped only against 400000, NOT "
-                        "against what dashd's template already holds -- "
-                        "enable with --dash-pin-block-budget)")
+    // Pin splice on the xcheck-SWAPPED arm (default OFF). Announce the state
+    // either way: with it off the donation still misses every swapped
+    // template -- it just no longer does so silently.
+    work_source->set_pin_splice_xcheck_arm(pin_splice_xcheck_arm);
+    std::cout << "[DASH-STRATUM-GBT] pin splice on xcheck-swapped arm: "
+              << (pin_splice_xcheck_arm ? "ON (--pin-splice-xcheck-arm)"
+                                        : "OFF (default; misses are named, "
+                                          "not spliced)")
               << "\n";
     if (xcheck_wanted && !rpc) {
         std::cout << "[DASH-STRATUM-GBT] GBT cross-check DISABLED: dashd RPC "
@@ -7265,13 +7260,13 @@ int main(int argc, char** argv)
     // currently refuses with `creditpool-stale`.
     bool embedded_creditpool_publish_at_serve_tip = false;
     std::string pin_local_tx_hex_path;
+    bool pin_splice_xcheck_arm = false;
     // --embedded-mempool-ingest: arm the coin-P2P MSG_TX pull (phase 1).
     // SEPARATE from --embedded-serve-mempool-txs on purpose: this only makes
     // the mempool FILL. Whether its contents ever reach a served template is
     // still the other flag's decision, and that one stays default-OFF until
     // the [SHADOW-TXSET] coverage series says it is safe.
     bool embedded_mempool_ingest = false;
-    bool pin_block_budget = false;
     std::string bestcl_policy = "freshness";   // --bestcl-policy: freshness (default, conservative proxy) | consensus-exact (dashcore's actual CheckCbTxBestChainlock rule)
     bool embedded_oracle_shadow = false;       // --embedded-oracle-shadow: per-block dashd cross-check (OBSERVE-only)
     bool embedded_shadow_compare = false;      // --embedded-shadow-compare: serve-vs-dashd template diff (OBSERVE-only, NOT a gate)
@@ -7369,13 +7364,13 @@ int main(int argc, char** argv)
             embedded_serve_mempool_txs = true;
         else if (std::strcmp(argv[i], "--embedded-mempool-ingest") == 0)
             embedded_mempool_ingest = true;
-        else if (std::strcmp(argv[i], "--dash-pin-block-budget") == 0)
-            pin_block_budget = true;
         else if (std::strcmp(argv[i],
                              "--embedded-creditpool-publish-at-serve-tip") == 0)
             embedded_creditpool_publish_at_serve_tip = true;
         else if (std::strcmp(argv[i], "--pin-local-tx-hex") == 0 && i + 1 < argc)
             pin_local_tx_hex_path = argv[++i];
+        else if (std::strcmp(argv[i], "--pin-splice-xcheck-arm") == 0)
+            pin_splice_xcheck_arm = true;
         else if (std::strcmp(argv[i], "--replay-utxo-db") == 0 && i + 1 < argc)
             replay_utxo_db = argv[++i];
         else if (std::strcmp(argv[i], "--replay-utxo-hash") == 0)
@@ -7658,8 +7653,8 @@ int main(int argc, char** argv)
                         embedded_mempool_ingest,
                         pin_local_tx_hex_path,
                         serve_staleness_sentinel,
-                        pin_block_budget,
-                        embedded_creditpool_publish_at_serve_tip);
+                        embedded_creditpool_publish_at_serve_tip,
+                        pin_splice_xcheck_arm);
     }
     return run_selftest();
 }

--- a/src/impl/dash/coin/mempool.hpp
+++ b/src/impl/dash/coin/mempool.hpp
@@ -182,6 +182,22 @@ public:
     /// 2 MB block limit, because the pins are not the only thing in the block
     /// and a template we cannot mine is worth nothing.
     static constexpr size_t kMaxPinnedTotalBytes = 400000;
+    /// Dash's consensus maximum serialized block size (DIP-0001, 2 MB).
+    static constexpr size_t kMaxBlockBytes = 2000000;
+    /// Headroom the pin splice refuses to touch: the 80-byte header, the
+    /// tx-count varint, and a coinbase that carries the DIP-0004 payload plus
+    /// every masternode/superblock/platform output. 100 KB is far more than any
+    /// of those need; the point is that the number is CONSERVATIVE and named,
+    /// not that it is tight.
+    static constexpr size_t kBlockBytesReserve = 100000;
+    /// THE BLOCK-LEVEL BUDGET. kMaxPinnedTotalBytes caps the pins against each
+    /// OTHER; this caps them against what the template they are being appended
+    /// to ALREADY holds. Without it a 400 KB pin set is admitted onto a dashd
+    /// template that is already near 2 MB and the block is unmineable
+    /// (bad-blk-length) -- the same class of loss as the 152258-byte pin that
+    /// cost block 2517855, one level up.
+    static constexpr size_t kMaxPinnedBlockBytes =
+        kMaxBlockBytes - kBlockBytesReserve;
     static const char* pinned_gate_name(PinnedTxGate g) {
         switch (g) {
             case PinnedTxGate::Ok:                    return "ok";

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -518,6 +518,11 @@ public:
         return out;
     }
 
+    /// Is ANY pin configured? Read by the legacy get_work() adapter, which has
+    /// no splice, so it can NAME the omission instead of shipping a template
+    /// that silently lacks the donation.
+    bool has_pinned_local_txs() const { return m_have_pinned_local_tx; }
+
     void set_pinned_local_tx(MutableTransaction tx) {
         m_pinned_local_txs.clear();
         m_pinned_local_txs.push_back(std::move(tx));

--- a/src/impl/dash/coin/rpc_data.hpp
+++ b/src/impl/dash/coin/rpc_data.hpp
@@ -74,6 +74,31 @@ inline bool submitblock_result_accepted(const nlohmann::json& result)
     return already_have && code.find("invalid") == std::string::npos;
 }
 
+// ── NON-CONSENSUS: what happened to each configured pinned local tx on THIS
+// template. One entry per configured pin, in file order, written by the splice
+// that judges it.
+//
+// It exists because a pin that is simply ABSENT is indistinguishable from a pin
+// that was never considered, and that ambiguity cost the donation on block
+// 2518044 (2026-08-07): the embedded builder logged four `pinned tx INCLUDED`
+// lines, the GBT-xcheck backstop swapped in dashd's template 57 ms later, and
+// the served template carried neither the pins nor one word about them.
+//
+// Never serialized, never hashed, never read by any consensus path -- the block
+// assembler reads m_txs / m_tx_data_hex only. It is the ANSWER a test can assert
+// on without scraping a log line.
+struct PinOutcome {
+    uint256     txid;
+    bool        included{false};
+    /// Named refusal reason when !included; empty when included.
+    std::string cause;
+    /// The height the pin GATE judged at (our tip + 1), and the height of the
+    /// template the pin was offered to. They are separate numbers because the
+    /// gate runs beside the coin state and the template may come from dashd.
+    uint32_t    gate_height{0};
+    uint32_t    template_height{0};
+};
+
 struct DashWorkData {
     // Raw getblocktemplate JSON response (kept for fallback access to fields
     // we haven't promoted to members yet).
@@ -143,6 +168,12 @@ struct DashWorkData {
     // what makes the fee lane completable at all.
     std::vector<uint256>  m_txset_candidates;
     std::vector<uint64_t> m_txset_candidate_fees;
+
+    // ── PIN OUTCOMES (see PinOutcome above) ───────────────────────────────
+    // One entry per configured pinned local tx, written by the splice on the
+    // SERVED dashd-fallback arm. Empty on the embedded arm (which splices in
+    // its own builder and logs there) and empty when no pin is configured.
+    std::vector<PinOutcome> m_pin_outcomes;
 };
 
 } // namespace coin

--- a/src/impl/dash/coin/rpc_data.hpp
+++ b/src/impl/dash/coin/rpc_data.hpp
@@ -97,6 +97,11 @@ struct PinOutcome {
     /// gate runs beside the coin state and the template may come from dashd.
     uint32_t    gate_height{0};
     uint32_t    template_height{0};
+    /// Sum of the pin's outputs, in satoshi. This is WHAT IS LOST when the pin
+    /// does not ride a template that then wins: the donation is a zero-fee
+    /// self-spend, so its output total is the whole amount at stake. Recorded
+    /// so the drop alarm can name a number instead of a count.
+    int64_t     value{0};
 };
 
 struct DashWorkData {
@@ -174,6 +179,26 @@ struct DashWorkData {
     // SERVED dashd-fallback arm. Empty on the embedded arm (which splices in
     // its own builder and logs there) and empty when no pin is configured.
     std::vector<PinOutcome> m_pin_outcomes;
+
+    // ── THE DROP ALARM (non-consensus) ────────────────────────────────────
+    // Non-empty when this SERVED template is missing at least one configured
+    // pin. It names the count, the height, the satoshi value at stake and the
+    // cause(s), because "pins=0/4" on its own does not tell an operator that
+    // money is going missing or why.
+    //
+    // The flag-off xcheck-swap arm is the case this exists for: with
+    // --pin-splice-xcheck-arm at its default the donation is DELIBERATELY not
+    // spliced, and a deliberate loss that is only visible as an INFO line is
+    // operationally identical to the silent loss that cost h=2518044.
+    std::string m_pin_drop_alarm;
+
+    // ── BLOCK-BUDGET NOT ENFORCED (non-consensus) ─────────────────────────
+    // True when a pin was appended even though it pushed the template past
+    // kMaxPinnedBlockBytes, because --pin-splice-block-budget is OFF (the
+    // default: enforcing it CHANGES SERVED BYTES on the already-live
+    // declined-embedded arm, so it may not be on by default). The block may be
+    // rejected as bad-blk-length if it wins. Always accompanied by a WARNING.
+    bool m_pin_block_budget_unenforced{false};
 };
 
 } // namespace coin

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -207,6 +207,23 @@ GetWork DASHWorkSource::get_work(const WorkJobTargetInputs& job_in) const
     if (!is_testnet_ && !embedded_mainnet_) {
         coin::DashWorkData w =
             dashd_fallback_ ? dashd_fallback_() : coin::DashWorkData{};
+        // THE THIRD FALLBACK PRODUCER, and the last silent one. This legacy
+        // adapter builds a dashd template without ever consulting the pin gate.
+        // It is believed unreachable on the serve path (serving goes through
+        // cached_work()/resource_template_now), but "believed unreachable" is
+        // exactly the assumption that cost block h=2518044 -- so if it ever
+        // does serve with pins configured, it says so instead of quietly
+        // shipping a template without them.
+        if (coin_state_.has_pinned_local_txs()) {
+            static std::once_flag legacy_pin_path_logged;
+            std::call_once(legacy_pin_path_logged, [] {
+                LOG_WARNING << "[dashd-splice] pinned tx EXCLUDED "
+                               "cause=legacy-get-work-path txid=(all) "
+                               "-- DASHWorkSource::get_work() sourced a dashd "
+                               "template directly; this adapter runs no pin "
+                               "gate and no splice";
+            });
+        }
         return GetWork{ coin::WorkSource::DashdFallback, std::move(w),
                         assemble_work_job_targets(job_in) };
     }
@@ -331,6 +348,190 @@ int64_t DASHWorkSource::peek_template_age_sec() const
 // ─────────────────────────────────────────────────────────────────────────────
 // IWorkSource: work generation -- Stage 4c (the template trio).
 // ─────────────────────────────────────────────────────────────────────────────
+
+namespace {
+
+// ─────────────────────────────────────────────────────────────────────────────
+// THE ONE PLACE a pinned donation tx meets a SERVED dashd-fallback template.
+//
+// resource_template_now() has TWO producers of a served dashd-fallback
+// template, and before this only one of them spliced:
+//
+//   (1) the declined-embedded branch  -- the fallback GBT, spliced inline;
+//   (2) the GBT-xcheck swap           -- replaces an EMBEDDED selection that
+//       ALREADY carries the pins with a fresh dashd_fallback_() template, and
+//       ran no splice and logged no refusal.
+//
+// Measured on the production primary 2026-08-07 22:33:35 -> 23:32:45: of 197
+// distinct served dashd-fallback templates, 131 came from (1) and 66 from (2).
+// One of the 66 won block h=2518044 and the four pinned donation transactions
+// were not in it -- 57 ms after the embedded builder had logged all four as
+// INCLUDED on the template that was then thrown away.
+//
+// Running here, on the FINAL selection, means every producer passes through
+// one gate. Two rules make the outcome legible:
+//   * A pin either RIDES or leaves a NAMED cause. "Absent, no record" is the
+//     defect itself -- it is indistinguishable from code that never ran.
+//   * Every new decision FAILS TOWARD EXCLUSION. Dropping a zero-fee donation
+//     pin costs the donation; a bad or oversize pin costs the whole block.
+void splice_pins_onto_served_fallback(
+    coin::DashWorkData& w,
+    const std::vector<coin::MutableTransaction>* pins,
+    const std::vector<coin::PinVerdict>& verdicts,
+    bool from_xcheck_swap,
+    bool xcheck_arm_enabled)
+{
+    if (pins == nullptr || pins->empty()) return;   // nothing configured
+
+    const char* const kArm = "dashd-splice";
+    const std::string site = from_xcheck_swap ? " site=xcheck-swap" : "";
+
+    auto record = [&](const coin::MutableTransaction& pin, bool included,
+                      const char* cause, uint32_t gate_h) {
+        coin::PinOutcome o;
+        o.txid            = coin::dash_txid(pin);
+        o.included        = included;
+        o.cause           = included ? std::string() : std::string(cause);
+        o.gate_height     = gate_h;
+        o.template_height = w.m_height;
+        w.m_pin_outcomes.push_back(std::move(o));
+    };
+
+    // The verdict vector is produced one-per-pin beside the coin state. A
+    // length disagreement means the two crossed a thread boundary out of step:
+    // refuse everything BY NAME rather than index into a guess.
+    if (verdicts.size() != pins->size()) {
+        for (const auto& pin : *pins) {
+            LOG_WARNING << "[" << kArm << "] pinned tx EXCLUDED h=" << w.m_height
+                        << " cause=pin-verdict-count-mismatch txid="
+                        << coin::dash_txid(pin).GetHex().substr(0, 16)
+                        << " (" << verdicts.size() << " verdicts for "
+                        << pins->size() << " pins)" << site;
+            record(pin, false, "pin-verdict-count-mismatch", 0);
+        }
+        return;
+    }
+
+    // What the template ALREADY holds, in serialized bytes. Prefer the GBT's
+    // own "data" hex (exactly what will be written into the block) and fall
+    // back to re-packing only when a producer left it empty.
+    size_t existing_bytes = 0;
+    for (size_t i = 0; i < w.m_txs.size(); ++i) {
+        if (i < w.m_tx_data_hex.size() && !w.m_tx_data_hex[i].empty())
+            existing_bytes += w.m_tx_data_hex[i].size() / 2;
+        else
+            existing_bytes +=
+                ::pack(coin::MutableTransaction(w.m_txs[i])).get_span().size();
+    }
+
+    size_t spliced_bytes = 0;
+    for (size_t i = 0; i < pins->size(); ++i) {
+        const auto& pin  = (*pins)[i];
+        const auto& v    = verdicts[i];
+        const auto  txid = coin::dash_txid(pin).GetHex().substr(0, 16);
+
+        // (a) The pin's OWN verdict, judged beside the coin state. Reported
+        // first because it is a fact about the pin, not about this site.
+        if (!v.ok) {
+            LOG_INFO << "[" << kArm << "] pinned tx EXCLUDED h="
+                     << v.at_height << " cause=" << v.cause
+                     << " txid=" << txid
+                     << " (template built without it; re-checked next build)"
+                     << site;
+            record(pin, false, v.cause, v.at_height);
+            continue;
+        }
+
+        // (b) MONEY-PATH FLAG. Appending to an xcheck-swapped template changes
+        // served bytes on a path that has never carried pins, so it ships OFF.
+        // With the flag off this arm behaves exactly as before -- except that
+        // the miss is now NAMED instead of silent.
+        if (from_xcheck_swap && !xcheck_arm_enabled) {
+            LOG_INFO << "[" << kArm << "] pinned tx EXCLUDED h=" << v.at_height
+                     << " cause=xcheck-swap-pin-gate-off txid=" << txid
+                     << " (enable with --pin-splice-xcheck-arm)" << site;
+            record(pin, false, "xcheck-swap-pin-gate-off", v.at_height);
+            continue;
+        }
+
+        // (c) HEIGHT AGREEMENT, xcheck-swap arm only. The verdict was judged at
+        // OUR tip+1; dref's height is dashd's. Coinbase maturity is a function
+        // of height, so a disagreement means the verdict does not apply to this
+        // template. Confined to the new arm on purpose: the declined-embedded
+        // branch has always spliced regardless (its fallback template can
+        // legitimately arrive with m_height==0, filled in from the bundle tip
+        // -- see the h=0 fix), and widening the rule there would change bytes
+        // this change is required not to touch.
+        if (from_xcheck_swap && w.m_height != 0 && v.at_height != w.m_height) {
+            LOG_WARNING << "[" << kArm << "] pinned tx EXCLUDED h=" << v.at_height
+                        << " cause=xcheck-swap-height-mismatch txid=" << txid
+                        << " (gate judged at " << v.at_height
+                        << ", template is at " << w.m_height << ")" << site;
+            record(pin, false, "xcheck-swap-height-mismatch", v.at_height);
+            continue;
+        }
+
+        const size_t sz = ::pack(pin).get_span().size();
+
+        // (d) Pins vs each other (pre-existing cap).
+        if (spliced_bytes + sz > coin::Mempool::kMaxPinnedTotalBytes) {
+            LOG_INFO << "[" << kArm << "] pinned tx EXCLUDED h=" << v.at_height
+                     << " cause=pin-total-too-large txid=" << txid
+                     << " (" << spliced_bytes << "+" << sz << " > "
+                     << coin::Mempool::kMaxPinnedTotalBytes << ")" << site;
+            record(pin, false, "pin-total-too-large", v.at_height);
+            continue;
+        }
+
+        // (e) Pins vs THE BLOCK. Strictly work-removing: it can only ever turn
+        // an inclusion into an exclusion, and an unmineable block is worth
+        // less than a missed donation.
+        if (existing_bytes + spliced_bytes + sz
+            > coin::Mempool::kMaxPinnedBlockBytes) {
+            LOG_WARNING << "[" << kArm << "] pinned tx EXCLUDED h=" << v.at_height
+                        << " cause=block-budget txid=" << txid
+                        << " (" << existing_bytes << "+" << spliced_bytes << "+"
+                        << sz << " > " << coin::Mempool::kMaxPinnedBlockBytes
+                        << ")" << site;
+            record(pin, false, "block-budget", v.at_height);
+            continue;
+        }
+
+        coin::pin_append(w, pin);
+        spliced_bytes += sz;
+        record(pin, true, "", v.at_height);
+        LOG_INFO << "[" << kArm << "] pinned tx INCLUDED h=" << v.at_height
+                 << " txid=" << txid << " vin=" << pin.vin.size()
+                 << " fee=0 (rides this template)" << site;
+    }
+}
+
+// The NEGATIVE SPACE on the arm line. Counted by txid PRESENCE in the served
+// template, so it is truthful for both arms and cannot drift from a splice
+// that did or did not run. A silent miss becomes structurally unreportable:
+// the line either says pins=N/N or it says which cause held them back.
+std::string served_pins_field(const coin::DashWorkData& w,
+                              const std::vector<coin::MutableTransaction>* pins)
+{
+    if (pins == nullptr || pins->empty()) return {};
+    size_t k = 0;
+    for (const auto& p : *pins) {
+        const auto id = coin::dash_txid(p);
+        if (std::find(w.m_tx_hashes.begin(), w.m_tx_hashes.end(), id)
+            != w.m_tx_hashes.end())
+            ++k;
+    }
+    std::string out = " pins=" + std::to_string(k) + "/"
+                    + std::to_string(pins->size());
+    for (const auto& o : w.m_pin_outcomes)
+        if (!o.included && !o.cause.empty()) {
+            out += " pin_cause=" + o.cause;
+            break;
+        }
+    return out;
+}
+
+}  // namespace
 
 // ─────────────────────────────────────────────────────────────────────────────
 // #1134 — OWNERSHIP SPLIT ON THE SERVE PATH.
@@ -524,38 +725,14 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
                     dashd_fallback_ ? dashd_fallback_() : coin::DashWorkData{};
                 if (fb.m_height == 0 && arm.declined_height != 0)
                     fb.m_height = arm.declined_height;
-                // PINNED LOCAL TX on the REAL served template. The gate already
-                // ran beside the coin state (resolve_coin_state_arm); all that
-                // happens here is the append, so this touches no coin-state
-                // container. The height in the log is the one the gate JUDGED
-                // at, not fb.m_height, so the line can never claim a check it
-                // did not make.
-                if (arm.pin_txs != nullptr
-                    && arm.pin_verdicts.size() == arm.pin_txs->size()) {
-                    // Each pin is judged and reported INDEPENDENTLY: one bad
-                    // pin excludes itself and the rest still ride. The height
-                    // logged is the one the gate JUDGED at, never fb.m_height,
-                    // so a line can never claim a check it did not make.
-                    //
-                    // THE SHARED SPLICE (embedded_gbt.hpp). This loop used to
-                    // be an inline copy of it, and the copy had NO block-level
-                    // size accounting at all: it capped pins against a fixed
-                    // 400000 and never against what dashd's template already
-                    // held. dashd fills its own template to its own
-                    // blockmaxsize; near 2000000 that reproduces the
-                    // bad-blk-length overshoot #1177 removed from the embedded
-                    // arm — here, on the always-reachable safety path. Block
-                    // 2518186 was won on THIS arm carrying 154 KB of pin.
-                    //
-                    // pin_block_budget_ is the money-path flag: OFF (default)
-                    // is byte-for-byte the pre-fix arithmetic; ON measures
-                    // dashd's real template and refuses the overflowing pin
-                    // with a NAMED cause (pin-over-block-headroom).
-                    coin::splice_verdicted_pins(fb, *arm.pin_txs,
-                                                arm.pin_verdicts,
-                                                "dashd-splice",
-                                                pin_block_budget_);
-                }
+                // PINNED LOCAL TX: the splice used to run HERE, which is why
+                // the GBT-xcheck swap below could replace the whole selection
+                // and lose the pins without a word. It now runs ONCE on the
+                // FINAL selection (splice_pins_onto_served_fallback, after the
+                // xcheck block), so every producer of a served fallback goes
+                // through the same gate. For THIS branch the move is pure:
+                // nothing between here and there touches sel.work when the
+                // source is already DashdFallback.
                 sel = coin::WorkSelection{ std::move(fb),
                                            coin::WorkSource::DashdFallback,
                                            arm.decline };
@@ -579,6 +756,12 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
             // EMBEDDED is served either way; the defect was purely in what the
             // log said, and it stole the one line that should mean a REAL
             // fallback.
+            // Set when the xcheck REPLACED an embedded selection with a fresh
+            // dashd template. The pins were inside the discarded one; the
+            // replacement has never seen the splice. This is the flag that
+            // tells the single splice point below which producer it is
+            // serving -- and the 66-of-197 silent-miss class it closes.
+            bool served_via_xcheck_swap = false;
             if (sel.source == coin::WorkSource::Embedded && gbt_xcheck_ && dashd_fallback_) {
                 coin::DashWorkData dref = dashd_fallback_();
                 coin::vendor::CCbTx emb_cb, dref_cb;
@@ -620,6 +803,7 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
                         sel = coin::WorkSelection{ std::move(dref),
                                                    coin::WorkSource::DashdFallback,
                                                    std::move(xok) };
+                        served_via_xcheck_swap = true;
                     } else {
                     LOG_WARNING << "[DASH-STRATUM-GBT] GBT-xcheck MISMATCH at h="
                                 << sel.work.m_height << " embedded creditPool="
@@ -640,9 +824,21 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
                     sel = coin::WorkSelection{ std::move(dref),
                                                coin::WorkSource::DashdFallback,
                                                std::move(xcheck) };
+                    served_via_xcheck_swap = true;
                     }
                 }
             }
+            // ── THE SINGLE PIN SPLICE POINT ─────────────────────────────────
+            // The arm is FINAL here: every producer of a served dashd-fallback
+            // template -- the declined-embedded branch and both xcheck-swap
+            // branches -- reaches this line, so a pin cannot go missing on a
+            // path nobody remembered to wire. The embedded arm is untouched
+            // (it splices in its own builder, embedded_gbt.hpp).
+            if (sel.source == coin::WorkSource::DashdFallback)
+                splice_pins_onto_served_fallback(sel.work, arm.pin_txs,
+                                                 arm.pin_verdicts,
+                                                 served_via_xcheck_swap,
+                                                 pin_splice_xcheck_arm_);
             // E2c observability: WHICH arm served this template + the MN payee
             // it carries (the payee-correctness axis of the embedded arm). One
             // line per re-source (cache-TTL cadence), INFO -- the field-
@@ -664,7 +860,13 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
                              ? std::string()
                              : " txset=empty cause=" + sel.work.m_txset_empty_cause
                                    + " forgone_fees<="
-                                   + std::to_string(sel.work.m_txset_forgone_fees));
+                                   + std::to_string(sel.work.m_txset_forgone_fees))
+                     // THE NEGATIVE SPACE. Before this the arm line said which
+                     // arm served and nothing about the donation, so a template
+                     // that quietly dropped every pin read exactly like one
+                     // that carried them all. Counted by txid presence in what
+                     // is ACTUALLY served, on BOTH arms.
+                     << served_pins_field(sel.work, arm.pin_txs);
             work_is_embedded = (sel.source == coin::WorkSource::Embedded);
             // ── DEFECT-3: the gate must SAY WHY it refused ──────────────────
             // sel.decline came out of the branch that chose the arm (dashd's

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -349,7 +349,7 @@ int64_t DASHWorkSource::peek_template_age_sec() const
 // IWorkSource: work generation -- Stage 4c (the template trio).
 // ─────────────────────────────────────────────────────────────────────────────
 
-namespace {
+namespace detail {
 
 // ─────────────────────────────────────────────────────────────────────────────
 // THE ONE PLACE a pinned donation tx meets a SERVED dashd-fallback template.
@@ -379,12 +379,20 @@ void splice_pins_onto_served_fallback(
     const std::vector<coin::MutableTransaction>* pins,
     const std::vector<coin::PinVerdict>& verdicts,
     bool from_xcheck_swap,
-    bool xcheck_arm_enabled)
+    bool xcheck_arm_enabled,
+    bool block_budget_enabled)
 {
     if (pins == nullptr || pins->empty()) return;   // nothing configured
 
     const char* const kArm = "dashd-splice";
-    const std::string site = from_xcheck_swap ? " site=xcheck-swap" : "";
+    const std::string site = from_xcheck_swap ? " site=xcheck-swap"
+                                              : " site=declined-embedded";
+
+    auto pin_value = [](const coin::MutableTransaction& pin) {
+        int64_t v = 0;
+        for (const auto& o : pin.vout) v += o.value;
+        return v;
+    };
 
     auto record = [&](const coin::MutableTransaction& pin, bool included,
                       const char* cause, uint32_t gate_h) {
@@ -394,7 +402,48 @@ void splice_pins_onto_served_fallback(
         o.cause           = included ? std::string() : std::string(cause);
         o.gate_height     = gate_h;
         o.template_height = w.m_height;
+        o.value           = pin_value(pin);
         w.m_pin_outcomes.push_back(std::move(o));
+    };
+
+    // ── THE DROP ALARM ────────────────────────────────────────────────────
+    // Emitted once per SERVED template that is missing at least one pin, at
+    // WARNING, naming the count, the height, the satoshi value at stake and
+    // every distinct cause. Runs on every exit path below (including the
+    // count-mismatch early return), which is why it is a named lambda and not
+    // a tail block.
+    //
+    // It exists because C1 of the review verdict is correct: with
+    // --pin-splice-xcheck-arm at its default OFF the h=2518044 loss shape is
+    // unchanged in BYTES -- the four pins are still absent from every swapped
+    // template. What changes is that the loss is now stated, per template,
+    // with the cause named and the money counted. An operator reading
+    // "pins=0/4" learns nothing; an operator reading
+    // "DONATION-DROPPED 4/4 pins h=2518044 value=... cause=xcheck-swap-pin-gate-off"
+    // knows exactly what is being given up and which flag buys it back.
+    auto raise_drop_alarm = [&]() {
+        size_t      dropped = 0;
+        int64_t     lost    = 0;
+        std::string causes;
+        for (const auto& o : w.m_pin_outcomes) {
+            if (o.included) continue;
+            ++dropped;
+            lost += o.value;
+            if (causes.find(o.cause) == std::string::npos)
+                causes += (causes.empty() ? "" : ",") + o.cause;
+        }
+        if (dropped == 0) return;
+        w.m_pin_drop_alarm =
+            "DONATION-DROPPED " + std::to_string(dropped) + "/"
+            + std::to_string(pins->size()) + " pins h="
+            + std::to_string(w.m_height) + " value=" + std::to_string(lost)
+            + "sat cause=" + causes + site;
+        LOG_WARNING << "[" << kArm << "] " << w.m_pin_drop_alarm
+                    << " -- this template IS SERVED to miners without the "
+                       "donation; if it wins, that value does not land"
+                    << (from_xcheck_swap && !xcheck_arm_enabled
+                            ? " (carry it with --pin-splice-xcheck-arm)"
+                            : "");
     };
 
     // The verdict vector is produced one-per-pin beside the coin state. A
@@ -409,6 +458,7 @@ void splice_pins_onto_served_fallback(
                         << pins->size() << " pins)" << site;
             record(pin, false, "pin-verdict-count-mismatch", 0);
         }
+        raise_drop_alarm();
         return;
     }
 
@@ -447,9 +497,11 @@ void splice_pins_onto_served_fallback(
         // With the flag off this arm behaves exactly as before -- except that
         // the miss is now NAMED instead of silent.
         if (from_xcheck_swap && !xcheck_arm_enabled) {
-            LOG_INFO << "[" << kArm << "] pinned tx EXCLUDED h=" << v.at_height
+            LOG_WARNING << "[" << kArm << "] pinned tx EXCLUDED h=" << v.at_height
                      << " cause=xcheck-swap-pin-gate-off txid=" << txid
-                     << " (enable with --pin-splice-xcheck-arm)" << site;
+                     << " value=" << pin_value(pin) << "sat"
+                     << " (admissible; DROPPED BY POLICY -- enable with"
+                        " --pin-splice-xcheck-arm)" << site;
             record(pin, false, "xcheck-swap-pin-gate-off", v.at_height);
             continue;
         }
@@ -483,18 +535,99 @@ void splice_pins_onto_served_fallback(
             continue;
         }
 
-        // (e) Pins vs THE BLOCK. Strictly work-removing: it can only ever turn
-        // an inclusion into an exclusion, and an unmineable block is worth
-        // less than a missed donation.
+        // (e) Pins vs THE BLOCK. FLAG-GATED (--pin-splice-block-budget),
+        // DEFAULT OFF, because it is NOT byte-neutral: on the declined-embedded
+        // arm -- which has spliced pins in production since before this branch
+        // -- turning an inclusion into an exclusion changes the transaction set
+        // of a template that is already being served. "Only ever removes work"
+        // is not the exemption; the exemption is "does not change served
+        // template bytes", and this changes them. The reviewer was right to
+        // call it a rule breach, so it ships off.
+        //
+        // Removing it is not an option either: the cap exists because block
+        // 2517855 was lost to bad-txns-oversize. So with the flag OFF the
+        // overflow is not silently ignored -- it is a WARNING plus a recorded
+        // flag on the template, and the operator can turn the exclusion on.
         if (existing_bytes + spliced_bytes + sz
             > coin::Mempool::kMaxPinnedBlockBytes) {
-            LOG_WARNING << "[" << kArm << "] pinned tx EXCLUDED h=" << v.at_height
-                        << " cause=block-budget txid=" << txid
+            if (block_budget_enabled) {
+                LOG_WARNING << "[" << kArm << "] pinned tx EXCLUDED h=" << v.at_height
+                            << " cause=block-budget txid=" << txid
+                            << " (" << existing_bytes << "+" << spliced_bytes << "+"
+                            << sz << " > " << coin::Mempool::kMaxPinnedBlockBytes
+                            << ")" << site;
+                record(pin, false, "block-budget", v.at_height);
+                continue;
+            }
+            w.m_pin_block_budget_unenforced = true;
+            LOG_WARNING << "[" << kArm << "] BLOCK-BUDGET EXCEEDED, NOT ENFORCED"
+                        << " h=" << v.at_height << " txid=" << txid
                         << " (" << existing_bytes << "+" << spliced_bytes << "+"
                         << sz << " > " << coin::Mempool::kMaxPinnedBlockBytes
-                        << ")" << site;
-            record(pin, false, "block-budget", v.at_height);
-            continue;
+                        << ") -- serving this template ANYWAY because"
+                           " --pin-splice-block-budget is off; if it wins the"
+                           " block may be rejected bad-blk-length, the loss"
+                           " that cost block 2517855" << site;
+        }
+
+        // (f) DUPLICATE / CONFLICT vs THE HOST TEMPLATE. The splice appends
+        // blind: it never asked whether the template it is appending to already
+        // carries this transaction, or already spends one of its inputs. Either
+        // one produces a block that CANNOT be mined -- bad-txns-duplicate /
+        // bad-txns-inputs-missingorspent -- so it costs the whole block, not
+        // just the donation. The presence scan four functions down
+        // (served_pins_field) already walks m_tx_hashes for exactly this txid;
+        // it just ran AFTER the append, where it could only report.
+        //
+        // The scan also covers pins spliced EARLIER in this same loop, because
+        // pin_append writes into the very containers it reads.
+        //
+        // WHY THIS ONE IS NOT FLAG-GATED AND (e) IS. Both remove a pin from a
+        // template the declined-embedded arm already serves, so both change
+        // served bytes -- but only one of them can change a template that was
+        // MINEABLE. (e)'s threshold is a HEURISTIC with a 100 KB reserve: a
+        // 1.95 MB template plus an 85-byte pin trips it while being 49915 bytes
+        // inside the real 2 MB consensus limit, so enforcing it would drop the
+        // donation from blocks that would have been accepted. This one is
+        // CONSENSUS-EXACT: a block containing the same txid twice, or two
+        // inputs spending one outpoint, is invalid unconditionally, at every
+        // size, on every node. The only templates it changes are templates that
+        // could never have produced a block. That is the exemption -- it does
+        // not change what we can serve, only what we can never mine.
+        {
+            const auto id = coin::dash_txid(pin);
+            if (std::find(w.m_tx_hashes.begin(), w.m_tx_hashes.end(), id)
+                != w.m_tx_hashes.end()) {
+                LOG_WARNING << "[" << kArm << "] pinned tx EXCLUDED h=" << v.at_height
+                            << " cause=already-in-template txid=" << txid
+                            << " (the served template already carries this txid;"
+                               " appending it again is bad-txns-duplicate)" << site;
+                record(pin, false, "already-in-template", v.at_height);
+                continue;
+            }
+            const char* conflict = nullptr;
+            for (const auto& pin_in : pin.vin) {
+                for (const auto& host : w.m_txs) {
+                    for (const auto& host_in : host.vin) {
+                        if (host_in.prevout.index == pin_in.prevout.index
+                            && host_in.prevout.hash == pin_in.prevout.hash) {
+                            conflict = "input-spent-by-template";
+                            break;
+                        }
+                    }
+                    if (conflict) break;
+                }
+                if (conflict) break;
+            }
+            if (conflict) {
+                LOG_WARNING << "[" << kArm << "] pinned tx EXCLUDED h=" << v.at_height
+                            << " cause=" << conflict << " txid=" << txid
+                            << " (an input of this pin is already spent by the"
+                               " served template; the block would be rejected"
+                               " bad-txns-inputs-missingorspent)" << site;
+                record(pin, false, conflict, v.at_height);
+                continue;
+            }
         }
 
         coin::pin_append(w, pin);
@@ -504,6 +637,8 @@ void splice_pins_onto_served_fallback(
                  << " txid=" << txid << " vin=" << pin.vin.size()
                  << " fee=0 (rides this template)" << site;
     }
+
+    raise_drop_alarm();
 }
 
 // The NEGATIVE SPACE on the arm line. Counted by txid PRESENCE in the served
@@ -528,10 +663,16 @@ std::string served_pins_field(const coin::DashWorkData& w,
             out += " pin_cause=" + o.cause;
             break;
         }
+    // The alarm rides the arm line too, so the ONE line an operator greps for
+    // template provenance also carries "money went missing here, this much,
+    // for this reason" instead of a bare ratio.
+    if (!w.m_pin_drop_alarm.empty()) out += " " + w.m_pin_drop_alarm;
+    if (w.m_pin_block_budget_unenforced)
+        out += " BLOCK-BUDGET-UNENFORCED";
     return out;
 }
 
-}  // namespace
+}  // namespace detail
 
 // ─────────────────────────────────────────────────────────────────────────────
 // #1134 — OWNERSHIP SPLIT ON THE SERVE PATH.
@@ -835,10 +976,10 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
             // path nobody remembered to wire. The embedded arm is untouched
             // (it splices in its own builder, embedded_gbt.hpp).
             if (sel.source == coin::WorkSource::DashdFallback)
-                splice_pins_onto_served_fallback(sel.work, arm.pin_txs,
-                                                 arm.pin_verdicts,
-                                                 served_via_xcheck_swap,
-                                                 pin_splice_xcheck_arm_);
+                detail::splice_pins_onto_served_fallback(
+                    sel.work, arm.pin_txs, arm.pin_verdicts,
+                    served_via_xcheck_swap, pin_splice_xcheck_arm_,
+                    pin_splice_block_budget_);
             // E2c observability: WHICH arm served this template + the MN payee
             // it carries (the payee-correctness axis of the embedded arm). One
             // line per re-source (cache-TTL cadence), INFO -- the field-
@@ -866,7 +1007,7 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
                      // that quietly dropped every pin read exactly like one
                      // that carried them all. Counted by txid presence in what
                      // is ACTUALLY served, on BOTH arms.
-                     << served_pins_field(sel.work, arm.pin_txs);
+                     << detail::served_pins_field(sel.work, arm.pin_txs);
             work_is_embedded = (sel.source == coin::WorkSource::Embedded);
             // ── DEFECT-3: the gate must SAY WHY it refused ──────────────────
             // sel.decline came out of the branch that chose the arm (dashd's

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -421,12 +421,34 @@ void splice_pins_onto_served_fallback(
     // "pins=0/4" learns nothing; an operator reading
     // "DONATION-DROPPED 4/4 pins h=2518044 value=... cause=xcheck-swap-pin-gate-off"
     // knows exactly what is being given up and which flag buys it back.
+    //
+    // WHAT THE ALARM ASSERTS, and therefore what it may NOT fire on. The WARNING
+    // says "this template IS SERVED without the donation; if it wins, that value
+    // does not land". `included` is a fact about THE SPLICE (did this call
+    // append?), not about the SERVED TEMPLATE (is the txid in it?), and for one
+    // cause the two disagree: `already-in-template` refuses precisely BECAUSE
+    // w.m_tx_hashes already carries the pin's txid, so the money is on the
+    // template and does land. It produced lines that contradicted themselves
+    // inside one string --
+    //   pins=1/1 pin_cause=already-in-template DONATION-DROPPED 1/1 pins h=500001
+    // -- pins=1/1 counted by txid PRESENCE (served_pins_field, below) against a
+    // DONATION-DROPPED counted by splice outcome. It is the only one of the
+    // seven causes that can false-fire: every other one (pin-verdict-count-
+    // mismatch, xcheck-swap-pin-gate-off, xcheck-swap-height-mismatch,
+    // pin-total-too-large, block-budget, input-spent-by-template) leaves the
+    // txid absent from the served template, which is a real loss.
+    //
+    // An alarm that also fires where the money DID land is worth less than
+    // nothing: block 2518044 dropped four pins and block 2518186 landed all
+    // four, same node, same arm, same pin set -- the next operator reading a
+    // DONATION-DROPPED line has to be able to believe it.
     auto raise_drop_alarm = [&]() {
         size_t      dropped = 0;
         int64_t     lost    = 0;
         std::string causes;
         for (const auto& o : w.m_pin_outcomes) {
             if (o.included) continue;
+            if (o.cause == "already-in-template") continue;  // it IS served
             ++dropped;
             lost += o.value;
             if (causes.find(o.cause) == std::string::npos)

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -424,19 +424,35 @@ void splice_pins_onto_served_fallback(
     //
     // WHAT THE ALARM ASSERTS, and therefore what it may NOT fire on. The WARNING
     // says "this template IS SERVED without the donation; if it wins, that value
-    // does not land". `included` is a fact about THE SPLICE (did this call
-    // append?), not about the SERVED TEMPLATE (is the txid in it?), and for one
-    // cause the two disagree: `already-in-template` refuses precisely BECAUSE
-    // w.m_tx_hashes already carries the pin's txid, so the money is on the
-    // template and does land. It produced lines that contradicted themselves
-    // inside one string --
-    //   pins=1/1 pin_cause=already-in-template DONATION-DROPPED 1/1 pins h=500001
+    // does not land". That sentence is a claim about ONE fact: is the txid in
+    // w.m_tx_hashes or not. `included` does not answer it -- `included` records
+    // what THE SPLICE did (did this call append?), and a pin can be refused by
+    // this function while sitting in the template anyway, because the template
+    // we splice ONTO is not ours. The dashd fallback arm serves a template dashd
+    // built from ITS mempool, which can already carry the donation.
+    //
+    // So the alarm keys on PRESENCE, not on the refusal cause. Keying on the
+    // cause string is what shipped first and it was one refusal shape short:
+    // `already-in-template` is only reached by guard (f) below, and FIVE guards
+    // run before it and `continue` with a different cause -- the verdict-count
+    // early return, (a) !v.ok, (b) xcheck-swap-pin-gate-off, (c) height
+    // mismatch, (d)/(e) the size caps. Any of those on a pin dashd already
+    // included reproduces the self-contradicting line this branch exists to
+    // kill --
+    //   pins=1/1 pin_cause=input-missing-or-spent DONATION-DROPPED 1/1 pins h=…
     // -- pins=1/1 counted by txid PRESENCE (served_pins_field, below) against a
-    // DONATION-DROPPED counted by splice outcome. It is the only one of the
-    // seven causes that can false-fire: every other one (pin-verdict-count-
-    // mismatch, xcheck-swap-pin-gate-off, xcheck-swap-height-mismatch,
-    // pin-total-too-large, block-budget, input-spent-by-template) leaves the
-    // txid absent from the served template, which is a real loss.
+    // DONATION-DROPPED counted by splice outcome, in one string.
+    //
+    // (a) is not a hypothetical: the embedded UTXO view is built forward from
+    // the height we started at, so a coin older than that reads back
+    // input-missing-or-spent (mempool.hpp:205 and the SECOND SOURCE note at
+    // :212, added after the production primary refused a valid pin exactly so).
+    //
+    // The presence test subsumes the cause-string skip, which is therefore GONE
+    // rather than kept beside it: two keys for one condition would leave this
+    // one un-mutable -- delete the presence test and the already-in-template
+    // shapes would still pass on the string, and a guard that cannot be made to
+    // fail is not a guard.
     //
     // An alarm that also fires where the money DID land is worth less than
     // nothing: block 2518044 dropped four pins and block 2518186 landed all
@@ -448,7 +464,10 @@ void splice_pins_onto_served_fallback(
         std::string causes;
         for (const auto& o : w.m_pin_outcomes) {
             if (o.included) continue;
-            if (o.cause == "already-in-template") continue;  // it IS served
+            // THE TRUTH CONDITION: is it in the template we are about to serve?
+            if (std::find(w.m_tx_hashes.begin(), w.m_tx_hashes.end(), o.txid)
+                != w.m_tx_hashes.end())
+                continue;  // refused by the splice, SERVED by the template
             ++dropped;
             lost += o.value;
             if (causes.find(o.cause) == std::string::npos)

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -83,6 +83,42 @@ class Mempool;
 
 namespace dash::stratum {
 
+// ─────────────────────────────────────────────────────────────────────────────
+// INTERNAL, EXPOSED FOR TESTING ONLY.
+//
+// The pin splice lived in an anonymous namespace inside work_source.cpp, which
+// made three of its guards unreachable from any test: the pipeline that calls
+// it cannot produce a verdict/pin count disagreement (both come from one
+// evaluate_pinned_txs call), cannot produce a height disagreement on the
+// xcheck-swap arm (the swap only fires when dashd's height EQUALS ours), and
+// cannot hand it a template that already carries the pin. An adversarial review
+// proved exactly that by replacing two of the guards with `if (false)`,
+// rebuilding, and watching every test still pass.
+//
+// A guard on the money path that no test can reach is not a guard. The function
+// is pure -- it takes a DashWorkData and mutates only that -- so it is named,
+// declared here, and driven directly.
+namespace detail {
+
+/// Splice the configured pinned local txs onto a SERVED dashd-fallback
+/// template. `verdicts` is one-per-pin, resolved beside the coin state.
+/// `from_xcheck_swap` marks the arm the GBT cross-check swapped in;
+/// `xcheck_arm_enabled` / `block_budget_enabled` are the two money-path flags,
+/// both DEFAULT OFF (see set_pin_splice_xcheck_arm / set_pin_splice_block_budget).
+void splice_pins_onto_served_fallback(
+    coin::DashWorkData& w,
+    const std::vector<coin::MutableTransaction>* pins,
+    const std::vector<coin::PinVerdict>& verdicts,
+    bool from_xcheck_swap,
+    bool xcheck_arm_enabled,
+    bool block_budget_enabled);
+
+/// " pins=K/N [pin_cause=…] [DONATION-DROPPED …]" for the arm-sourced log line.
+std::string served_pins_field(const coin::DashWorkData& w,
+                              const std::vector<coin::MutableTransaction>* pins);
+
+}  // namespace detail
+
 class DASHWorkSource : public core::stratum::IWorkSource
 {
 public:
@@ -344,6 +380,27 @@ public:
     /// gate (verdicts resolved beside the coin state), plus a height-agreement
     /// check and the block-size budget -- both of which can only EXCLUDE.
     void set_pin_splice_xcheck_arm(bool v) { pin_splice_xcheck_arm_ = v; }
+
+    /// BLOCK-SIZE BUDGET FOR THE PIN SPLICE (--pin-splice-block-budget).
+    /// DEFAULT OFF -- this is the money path, and the reason it is a flag is
+    /// that the reviewer was right: it is NOT byte-neutral.
+    ///
+    /// The budget caps a pin against what the template it is being appended to
+    /// ALREADY holds (kMaxPinnedBlockBytes = 2 MB minus a named reserve), and
+    /// the declined-embedded arm has been splicing pins onto served templates
+    /// in production since before this branch. Turning an inclusion there into
+    /// an exclusion CHANGES THE SERVED TRANSACTION SET. "It only removes work"
+    /// is not the exemption -- the exemption is "does not change served bytes"
+    /// -- so it ships off and the operator arms it.
+    ///
+    /// OFF (default): an over-budget pin still rides, exactly as today, but the
+    /// template records m_pin_block_budget_unenforced and the log says
+    /// BLOCK-BUDGET EXCEEDED, NOT ENFORCED. Never silent.
+    /// ON: the over-budget pin is EXCLUDED with cause=block-budget -- the
+    /// 152258-byte lesson of block 2517855 (bad-txns-oversize), one level up:
+    /// a bad or oversize pin costs the whole block, a missed pin costs only the
+    /// donation.
+    void set_pin_splice_block_budget(bool v) { pin_splice_block_budget_ = v; }
 
     /// Embedded-vs-dashd SHADOW-COMPARE DIAGNOSTIC (--embedded-shadow-compare).
     /// OBSERVE-ONLY: on every template re-source the just-resolved template is
@@ -668,6 +725,7 @@ private:
     bool embedded_mainnet_{false};   // gate-lift opt-in: daemonless embedded arm on mainnet
     bool gbt_xcheck_{false};         // reward-safety backstop: cross-check embedded creditPool vs dashd
     bool pin_splice_xcheck_arm_{false};  // money path: splice pins onto an xcheck-SWAPPED template (default OFF)
+    bool pin_splice_block_budget_{false};  // money path: ENFORCE the block-size budget (changes served bytes; default OFF)
 
     // OBSERVE-only serve-vs-dashd shadow-compare (--embedded-shadow-compare).
     // Unset (default / pure-daemonless) => strict no-op. Never on the hot path:

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -327,31 +327,23 @@ public:
     /// independent seed-height + pre-emit gates.
     void set_gbt_xcheck(bool v) { gbt_xcheck_ = v; }
 
-    /// BLOCK-LEVEL PIN BUDGET on the served-dashd arm
-    /// (--dash-pin-block-budget). MONEY PATH, DEFAULT OFF.
+    /// PIN SPLICE ON THE XCHECK-SWAPPED ARM (--pin-splice-xcheck-arm).
+    /// DEFAULT OFF -- this is the money path.
     ///
-    /// #1177 unified the size budget on the EMBEDDED arm. The fallback arm
-    /// never got it: it splices up to kMaxPinnedTotalBytes (400000) onto
-    /// dashd's OWN template with no block-level accounting, and dashd fills
-    /// that template to its own blockmaxsize (node/miner.cpp:212 clamps to
-    /// MaxBlockSize()-1000; DEFAULT_BLOCK_MAX_SIZE is 2000000). Near the cap,
-    /// +400 KB is the bad-blk-length overshoot that cost block 2517855 — on
-    /// the arm we call the always-reachable safety path. Block 2518186 was
-    /// won on this arm carrying 154 KB of pinned donation, so the shape is
-    /// live, not hypothetical.
+    /// When set_gbt_xcheck's backstop swaps the served arm it throws away an
+    /// EMBEDDED template that already carries the pinned donation transactions
+    /// and serves a fresh dashd one instead. Until 2026-08-07 that replacement
+    /// never met the pin splice and never said so: 66 of 197 served fallback
+    /// templates in one measured hour carried no pin and no reason, and one of
+    /// them won block h=2518044 without the donation.
     ///
-    /// ON, the splice measures what dashd's template already occupies and
-    /// refuses the pin that would not fit, with the NAMED cause
-    /// pin-over-block-headroom. OFF, the arithmetic is byte-for-byte what
-    /// shipped: headroom collapses to the pin cap and the block-headroom arm
-    /// of the check is unreachable.
-    ///
-    /// It is OFF by default because it CHANGES SERVED BYTES in exactly the
-    /// case it fires — refusing a pin that today would ride. That is the
-    /// money-path rule, not a judgement that OFF is the better posture: a
-    /// refused pin costs one template's donation, an oversize block costs the
-    /// whole height.
-    void set_pin_block_budget(bool v) { pin_block_budget_ = v; }
+    /// OFF (default): the miss is NAMED -- each pin gets an outcome with
+    /// cause=xcheck-swap-pin-gate-off and the arm line reports pins=0/N. Served
+    /// bytes are IDENTICAL to before.
+    /// ON: the pins ride that arm too, through the same unchanged admission
+    /// gate (verdicts resolved beside the coin state), plus a height-agreement
+    /// check and the block-size budget -- both of which can only EXCLUDE.
+    void set_pin_splice_xcheck_arm(bool v) { pin_splice_xcheck_arm_ = v; }
 
     /// Embedded-vs-dashd SHADOW-COMPARE DIAGNOSTIC (--embedded-shadow-compare).
     /// OBSERVE-ONLY: on every template re-source the just-resolved template is
@@ -675,7 +667,7 @@ private:
     bool is_testnet_{false};
     bool embedded_mainnet_{false};   // gate-lift opt-in: daemonless embedded arm on mainnet
     bool gbt_xcheck_{false};         // reward-safety backstop: cross-check embedded creditPool vs dashd
-    bool pin_block_budget_{false};   // --dash-pin-block-budget: block-level pin budget on the served-dashd arm
+    bool pin_splice_xcheck_arm_{false};  // money path: splice pins onto an xcheck-SWAPPED template (default OFF)
 
     // OBSERVE-only serve-vs-dashd shadow-compare (--embedded-shadow-compare).
     // Unset (default / pure-daemonless) => strict no-op. Never on the hot path:

--- a/test/test_dash_stratum_work_source.cpp
+++ b/test/test_dash_stratum_work_source.cpp
@@ -2788,6 +2788,11 @@ TEST(DashStratumPinSplice, FallbackSpliceRespectsTheBlockSizeBudget)
     dash::stratum::DASHWorkSource ws(cs, fallback, submit,
                                      core::stratum::StratumConfig{},
                                      /*is_testnet=*/false);
+    // The budget is FLAG-GATED and OFF by default, because enforcing it removes
+    // a pin from a template this arm is already serving in production -- a
+    // served-bytes change, which may not default on. Arm it here; the companion
+    // test below pins the DEFAULT (off) shape.
+    ws.set_pin_splice_block_budget(true);
 
     ASSERT_FALSE(ws.get_current_work_template().empty());
     auto t = ws.peek_template();
@@ -2854,4 +2859,407 @@ TEST(DashStratumPinSplice, DeclinedEmbeddedFallbackStillCarriesThePin)
     EXPECT_TRUE(outcome->included);
     ASSERT_FALSE(t->m_tx_fees.empty());
     EXPECT_EQ(t->m_tx_fees.back(), 0u);
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// THE SPLICE GUARDS, DRIVEN DIRECTLY.
+//
+// An adversarial rebuild of this branch replaced two money-path guards with
+// `if (false)`, rebuilt, and every test above still passed. They were
+// unreachable from the pipeline by construction:
+//
+//   * pin-verdict-count-mismatch  -- pins and verdicts both come out of ONE
+//     evaluate_pinned_txs() call, so the pipeline cannot make them disagree;
+//   * xcheck-swap-height-mismatch -- the xcheck backstop only swaps when dashd's
+//     height EQUALS ours, so the pipeline cannot make them disagree either;
+//   * already-in-template / input-spent-by-template -- no fixture hands the
+//     splice a host template that already carries the pin.
+//
+// A guard on the money path that no test can reach is not a guard. The splice
+// is pure (it takes a DashWorkData and mutates only that), so these KATs call
+// dash::stratum::detail::splice_pins_onto_served_fallback directly. Each one is
+// proven red by making exactly the `if (false)` mutation on its own guard.
+// ═════════════════════════════════════════════════════════════════════════════
+namespace {
+
+constexpr uint32_t kSpliceHeight = 500001;
+
+// An ok verdict at a chosen height -- what the gate hands the splice when the
+// pin is admissible beside the coin state.
+dash::coin::PinVerdict ok_verdict(uint32_t at_height)
+{
+    dash::coin::PinVerdict v;
+    v.ok        = true;
+    v.at_height = at_height;
+    return v;
+}
+
+// A served dashd-fallback template at kSpliceHeight carrying `hosts`, with the
+// four parallel vectors kept in step exactly as pin_append keeps them.
+dash::coin::DashWorkData host_template(
+    const std::vector<dash::coin::MutableTransaction>& hosts = {})
+{
+    dash::coin::DashWorkData w;
+    w.m_height = kSpliceHeight;
+    w.m_previous_block.SetHex(kEmbeddedPrevHashHex);
+    for (const auto& h : hosts) {
+        auto sp = ::pack(h).get_span();
+        w.m_txs.emplace_back(h);
+        w.m_tx_hashes.push_back(dash::coin::dash_txid(h));
+        w.m_tx_fees.push_back(0);
+        w.m_tx_data_hex.push_back(HexStr(std::span<const unsigned char>(
+            reinterpret_cast<const unsigned char*>(sp.data()), sp.size())));
+    }
+    return w;
+}
+
+}  // namespace
+
+// GUARD (verdict/pin count). The verdict vector is indexed BY POSITION against
+// the pin vector. A length disagreement means the two crossed the thread
+// boundary out of step, and indexing into a guess on the money path is how a
+// pin gets spliced under someone else's admission decision.
+//
+// RED WITHOUT THE GUARD: with `if (verdicts.size() != pins->size())` replaced by
+// `if (false)`, the extra-verdict case below indexes verdicts[0] -- which is ok
+// -- and the pin RIDES, so the ASSERT_TRUE(w.m_txs.empty()) fails.
+TEST(DashStratumSpliceGuards, VerdictCountMismatchRefusesEveryPinByName)
+{
+    uint256 f1; f1.begin()[0] = 0x61;
+    const auto pin  = admissible_pin(f1);
+    const auto txid = dash::coin::dash_txid(pin);
+    const std::vector<dash::coin::MutableTransaction> pins{pin};
+
+    // MORE verdicts than pins. Chosen as the load-bearing case on purpose: with
+    // the guard mutated out every index is still in range, so the mutation's
+    // effect is a DETERMINISTIC inclusion rather than an out-of-range read.
+    {
+        auto w = host_template();
+        const std::vector<dash::coin::PinVerdict> verdicts{
+            ok_verdict(kSpliceHeight), ok_verdict(kSpliceHeight)};
+        dash::stratum::detail::splice_pins_onto_served_fallback(
+            w, &pins, verdicts, /*from_xcheck_swap=*/false,
+            /*xcheck_arm_enabled=*/false, /*block_budget_enabled=*/false);
+
+        ASSERT_TRUE(w.m_txs.empty())
+            << "2 verdicts for 1 pin: the splice indexed into a mismatched "
+               "vector and appended anyway";
+        ASSERT_FALSE(template_carries(w, txid));
+        ASSERT_EQ(w.m_pin_outcomes.size(), 1u);
+        ASSERT_FALSE(w.m_pin_outcomes[0].included);
+        ASSERT_EQ(w.m_pin_outcomes[0].cause, "pin-verdict-count-mismatch");
+        // The refusal must also reach the operator as a DROP, not just a code.
+        ASSERT_NE(w.m_pin_drop_alarm.find("DONATION-DROPPED 1/1"),
+                  std::string::npos);
+        ASSERT_NE(w.m_pin_drop_alarm.find("pin-verdict-count-mismatch"),
+                  std::string::npos);
+    }
+
+    // FEWER verdicts than pins -- the direction that would be an out-of-range
+    // read. Reached only when the case above already held.
+    {
+        auto w = host_template();
+        const std::vector<dash::coin::PinVerdict> none;
+        dash::stratum::detail::splice_pins_onto_served_fallback(
+            w, &pins, none, false, false, false);
+        EXPECT_TRUE(w.m_txs.empty());
+        ASSERT_EQ(w.m_pin_outcomes.size(), 1u);
+        EXPECT_EQ(w.m_pin_outcomes[0].cause, "pin-verdict-count-mismatch");
+    }
+
+    // NON-VACUITY: the same pin, the same height, verdicts in step -> it rides.
+    // Without this the two assertions above would pass on a splice that never
+    // includes anything.
+    {
+        auto w = host_template();
+        const std::vector<dash::coin::PinVerdict> matched{ok_verdict(kSpliceHeight)};
+        dash::stratum::detail::splice_pins_onto_served_fallback(
+            w, &pins, matched, false, false, false);
+        EXPECT_TRUE(template_carries(w, txid))
+            << "fixture broken: this pin never rides, so the refusals above "
+               "prove nothing";
+        EXPECT_TRUE(w.m_pin_drop_alarm.empty())
+            << "no pin was dropped -- the alarm must stay silent";
+    }
+}
+
+// GUARD (xcheck-swap height). The verdict is judged at OUR tip+1; the swapped
+// template's height is dashd's. Coinbase maturity is a function of height, so a
+// disagreement means the admission decision does not apply to this template.
+//
+// RED WITHOUT THE GUARD: with the `if (from_xcheck_swap && w.m_height != 0 &&
+// v.at_height != w.m_height)` line replaced by `if (false)`, the mismatched pin
+// rides and EXPECT_FALSE(template_carries(...)) fails.
+TEST(DashStratumSpliceGuards, XcheckSwapHeightMismatchExcludesByName)
+{
+    uint256 f1; f1.begin()[0] = 0x62;
+    const auto pin  = admissible_pin(f1);
+    const auto txid = dash::coin::dash_txid(pin);
+    const std::vector<dash::coin::MutableTransaction> pins{pin};
+
+    // (a) THE GUARD. Arm flag ON (so gate (b) cannot shadow this), swapped arm,
+    // verdict judged one height BELOW the template.
+    {
+        auto w = host_template();
+        const std::vector<dash::coin::PinVerdict> verdicts{
+            ok_verdict(kSpliceHeight - 1)};
+        dash::stratum::detail::splice_pins_onto_served_fallback(
+            w, &pins, verdicts, /*from_xcheck_swap=*/true,
+            /*xcheck_arm_enabled=*/true, /*block_budget_enabled=*/false);
+
+        EXPECT_FALSE(template_carries(w, txid))
+            << "the verdict was judged at h=" << (kSpliceHeight - 1)
+            << " and the template is at h=" << kSpliceHeight
+            << " -- maturity is a function of height";
+        ASSERT_EQ(w.m_pin_outcomes.size(), 1u);
+        EXPECT_FALSE(w.m_pin_outcomes[0].included);
+        EXPECT_EQ(w.m_pin_outcomes[0].cause, "xcheck-swap-height-mismatch");
+        EXPECT_EQ(w.m_pin_outcomes[0].gate_height, kSpliceHeight - 1);
+        EXPECT_EQ(w.m_pin_outcomes[0].template_height, kSpliceHeight);
+        EXPECT_NE(w.m_pin_drop_alarm.find("xcheck-swap-height-mismatch"),
+                  std::string::npos);
+    }
+
+    // (b) NON-VACUITY: heights AGREE on the same armed swap -> it rides.
+    {
+        auto w = host_template();
+        const std::vector<dash::coin::PinVerdict> verdicts{ok_verdict(kSpliceHeight)};
+        dash::stratum::detail::splice_pins_onto_served_fallback(
+            w, &pins, verdicts, true, true, false);
+        EXPECT_TRUE(template_carries(w, txid))
+            << "fixture broken: the armed swap never carries this pin, so (a) "
+               "proves nothing";
+    }
+
+    // (c) CONFINEMENT. The rule is deliberately xcheck-swap-only: the
+    // declined-embedded branch has always spliced regardless of the height it
+    // was judged at, and widening it there would change bytes this branch is
+    // required not to touch. Same mismatch, same pin, non-swapped arm -> RIDES.
+    {
+        auto w = host_template();
+        const std::vector<dash::coin::PinVerdict> verdicts{
+            ok_verdict(kSpliceHeight - 1)};
+        dash::stratum::detail::splice_pins_onto_served_fallback(
+            w, &pins, verdicts, /*from_xcheck_swap=*/false, false, false);
+        EXPECT_TRUE(template_carries(w, txid))
+            << "the height rule leaked onto the declined-embedded arm and "
+               "changed what that arm serves";
+    }
+}
+
+// GUARD (duplicate / conflict vs the host template). The splice appended blind.
+// Splicing a txid the served template already carries is bad-txns-duplicate;
+// splicing a tx whose input the template already spends is
+// bad-txns-inputs-missingorspent. Either one costs the WHOLE block, not the
+// donation -- and unlike the size budget these are consensus-exact, so
+// excluding can only ever change a template that could never have been mined.
+//
+// RED WITHOUT THE GUARD: `if (std::find(...) != w.m_tx_hashes.end())` -> `if
+// (false)` makes case (a) append a second copy (m_txs.size() == 2); nulling the
+// conflict scan makes case (b) append the double-spend.
+TEST(DashStratumSpliceGuards, SpliceRefusesDuplicateAndConflictingPins)
+{
+    uint256 funding; funding.begin()[0] = 0x63;
+    const auto pin  = admissible_pin(funding);
+    const auto txid = dash::coin::dash_txid(pin);
+    const std::vector<dash::coin::MutableTransaction> pins{pin};
+    const std::vector<dash::coin::PinVerdict> verdicts{ok_verdict(kSpliceHeight)};
+
+    // (a) THE TEMPLATE ALREADY CARRIES THIS EXACT TXID.
+    {
+        auto w = host_template({pin});
+        ASSERT_EQ(w.m_txs.size(), 1u);
+        dash::stratum::detail::splice_pins_onto_served_fallback(
+            w, &pins, verdicts, false, false, false);
+        EXPECT_EQ(w.m_txs.size(), 1u)
+            << "the same transaction is in the block twice -- bad-txns-duplicate";
+        EXPECT_EQ(w.m_tx_hashes.size(), 1u);
+        ASSERT_EQ(w.m_pin_outcomes.size(), 1u);
+        EXPECT_FALSE(w.m_pin_outcomes[0].included);
+        EXPECT_EQ(w.m_pin_outcomes[0].cause, "already-in-template");
+    }
+
+    // (b) A DIFFERENT TRANSACTION ALREADY SPENDS THE PIN'S INPUT. Same outpoint,
+    // different txid (different output value), so the txid scan cannot catch it.
+    {
+        auto conflicting = admissible_pin(funding);
+        conflicting.vout[0].value = 49'000;    // -> different txid, same input
+        ASSERT_NE(dash::coin::dash_txid(conflicting), txid);
+        auto w = host_template({conflicting});
+        dash::stratum::detail::splice_pins_onto_served_fallback(
+            w, &pins, verdicts, false, false, false);
+        EXPECT_EQ(w.m_txs.size(), 1u)
+            << "two transactions in one block spend outpoint " << funding.GetHex()
+            << ":0 -- bad-txns-inputs-missingorspent";
+        EXPECT_FALSE(template_carries(w, txid));
+        ASSERT_EQ(w.m_pin_outcomes.size(), 1u);
+        EXPECT_EQ(w.m_pin_outcomes[0].cause, "input-spent-by-template");
+    }
+
+    // (c) THE SAME PIN CONFIGURED TWICE. The scan reads the containers
+    // pin_append writes, so the second copy is caught inside one call: the
+    // first rides, the second is named.
+    {
+        auto w = host_template();
+        const std::vector<dash::coin::MutableTransaction> twice{pin, pin};
+        const std::vector<dash::coin::PinVerdict> two{ok_verdict(kSpliceHeight),
+                                                     ok_verdict(kSpliceHeight)};
+        dash::stratum::detail::splice_pins_onto_served_fallback(
+            w, &twice, two, false, false, false);
+        EXPECT_EQ(w.m_txs.size(), 1u);
+        ASSERT_EQ(w.m_pin_outcomes.size(), 2u);
+        EXPECT_TRUE(w.m_pin_outcomes[0].included);
+        EXPECT_FALSE(w.m_pin_outcomes[1].included);
+        EXPECT_EQ(w.m_pin_outcomes[1].cause, "already-in-template");
+    }
+
+    // (d) NON-VACUITY: a clean host template with an unrelated tx -> it rides.
+    {
+        uint256 other; other.begin()[0] = 0x64;
+        auto w = host_template({admissible_pin(other)});
+        dash::stratum::detail::splice_pins_onto_served_fallback(
+            w, &pins, verdicts, false, false, false);
+        EXPECT_TRUE(template_carries(w, txid))
+            << "fixture broken: this pin never rides a populated template";
+        EXPECT_EQ(w.m_txs.size(), 2u);
+    }
+}
+
+// THE BLOCK-SIZE BUDGET IS FLAG-GATED, AND ITS DEFAULT IS BYTE-FOR-BYTE THE
+// BEHAVIOUR THAT WAS ALREADY LIVE. The declined-embedded arm has been splicing
+// pins onto served templates since #1170; turning an inclusion there into an
+// exclusion changes the served transaction set, which a money-path change may
+// not do by default. So the default still SERVES the over-budget pin and SAYS
+// the budget was blown; only --pin-splice-block-budget acts on it.
+//
+// RED WITHOUT THE GATE: `if (block_budget_enabled)` -> `if (true)` makes the
+// default arm exclude the pin, and EXPECT_TRUE(template_carries(...)) fails.
+TEST(DashStratumSpliceGuards, BlockBudgetIsGatedOffAndTheDefaultStillServes)
+{
+    uint256 funding; funding.begin()[0] = 0x65;
+    const auto pin  = admissible_pin(funding);
+    const auto txid = dash::coin::dash_txid(pin);
+    const std::vector<dash::coin::MutableTransaction> pins{pin};
+    const std::vector<dash::coin::PinVerdict> verdicts{ok_verdict(kSpliceHeight)};
+
+    // A host template already holding ~1.95 MB of transaction payload: over the
+    // 1.9 MB pin budget, still 49915 bytes INSIDE the 2 MB consensus limit.
+    constexpr size_t kFatBytes = 1'950'000;
+    static_assert(kFatBytes > dash::coin::Mempool::kMaxPinnedBlockBytes,
+                  "fixture must exceed the budget");
+    static_assert(kFatBytes + 1000 < dash::coin::Mempool::kMaxBlockBytes,
+                  "and must stay inside the consensus limit -- that gap is "
+                  "exactly why the budget may not default on");
+    auto fat_template = [&]() {
+        auto w = host_template();
+        dash::coin::MutableTransaction fat;   // identity only; the BYTES are the hex
+        fat.vin.resize(1);
+        fat.vin[0].prevout.hash.begin()[0] = 0x77;
+        w.m_txs.emplace_back(fat);
+        w.m_tx_hashes.push_back(dash::coin::dash_txid(fat));
+        w.m_tx_fees.push_back(0);
+        w.m_tx_data_hex.push_back(std::string(kFatBytes * 2, 'a'));
+        return w;
+    };
+
+    // (a) DEFAULT (flag OFF): the pin RIDES -- served bytes unchanged from what
+    // this arm already produces -- and the template SAYS the budget was blown.
+    {
+        auto w = fat_template();
+        dash::stratum::detail::splice_pins_onto_served_fallback(
+            w, &pins, verdicts, false, false, /*block_budget_enabled=*/false);
+        EXPECT_TRUE(template_carries(w, txid))
+            << "the budget acted at its default and removed a pin the "
+               "declined-embedded arm is already serving";
+        EXPECT_TRUE(w.m_pin_block_budget_unenforced)
+            << "over budget and silent about it -- the operator cannot see the "
+               "bad-blk-length exposure that cost block 2517855";
+        EXPECT_NE(dash::stratum::detail::served_pins_field(w, &pins)
+                      .find("BLOCK-BUDGET-UNENFORCED"),
+                  std::string::npos);
+        ASSERT_EQ(w.m_pin_outcomes.size(), 1u);
+        EXPECT_TRUE(w.m_pin_outcomes[0].included);
+    }
+
+    // (b) ARMED: the same template, the same pin, now EXCLUDED by name.
+    {
+        auto w = fat_template();
+        dash::stratum::detail::splice_pins_onto_served_fallback(
+            w, &pins, verdicts, false, false, /*block_budget_enabled=*/true);
+        EXPECT_FALSE(template_carries(w, txid));
+        EXPECT_FALSE(w.m_pin_block_budget_unenforced)
+            << "the budget was ENFORCED, so nothing rode unenforced";
+        ASSERT_EQ(w.m_pin_outcomes.size(), 1u);
+        EXPECT_EQ(w.m_pin_outcomes[0].cause, "block-budget");
+    }
+
+    // (c) The gate is about the BUDGET, not about pins in general: an
+    // under-budget pin rides on both settings.
+    {
+        auto w = host_template();
+        dash::stratum::detail::splice_pins_onto_served_fallback(
+            w, &pins, verdicts, false, false, true);
+        EXPECT_TRUE(template_carries(w, txid));
+        EXPECT_FALSE(w.m_pin_block_budget_unenforced);
+    }
+}
+
+// THE DROP ALARM -- what the flag-OFF xcheck-swap arm buys instead of bytes.
+//
+// With --pin-splice-xcheck-arm at its default the h=2518044 loss shape is
+// unchanged in BYTES: the pins are still absent from every swapped template.
+// What changes is that the loss is STATED, per template, with the money counted
+// and the flag that buys it back named. A ratio ("pins=0/4") does not tell an
+// operator that a donation is being given up.
+//
+// RED WITHOUT THE ALARM: `if (dropped == 0) return;` -> `if (true) return;`
+// leaves m_pin_drop_alarm empty and every ASSERT_NE below fails.
+TEST(DashStratumSpliceGuards, DropAlarmNamesTheCountValueAndCause)
+{
+    uint256 f1; f1.begin()[0] = 0x66;
+    uint256 f2; f2.begin()[0] = 0x67;
+    auto p1 = admissible_pin(f1);
+    auto p2 = admissible_pin(f2);
+    p2.vout[0].value = 30'000;
+    const std::vector<dash::coin::MutableTransaction> pins{p1, p2};
+    const std::vector<dash::coin::PinVerdict> verdicts{ok_verdict(kSpliceHeight),
+                                                      ok_verdict(kSpliceHeight)};
+
+    // The shipped default on the swapped arm: both pins dropped by policy.
+    auto w = host_template();
+    dash::stratum::detail::splice_pins_onto_served_fallback(
+        w, &pins, verdicts, /*from_xcheck_swap=*/true,
+        /*xcheck_arm_enabled=*/false, false);
+
+    EXPECT_TRUE(w.m_txs.empty());
+    ASSERT_FALSE(w.m_pin_drop_alarm.empty())
+        << "the donation is being dropped from a SERVED template and the "
+           "template does not say so";
+    // COUNT, HEIGHT, MONEY, CAUSE, SITE -- each one load-bearing for the
+    // operator: without the value it is a ratio, without the cause it is a
+    // mystery, without the site it is the wrong arm.
+    EXPECT_NE(w.m_pin_drop_alarm.find("DONATION-DROPPED 2/2"), std::string::npos)
+        << w.m_pin_drop_alarm;
+    EXPECT_NE(w.m_pin_drop_alarm.find("h=" + std::to_string(kSpliceHeight)),
+              std::string::npos) << w.m_pin_drop_alarm;
+    EXPECT_NE(w.m_pin_drop_alarm.find("value=80000sat"), std::string::npos)
+        << "50000 + 30000 -- the whole amount at stake, not a count: "
+        << w.m_pin_drop_alarm;
+    EXPECT_NE(w.m_pin_drop_alarm.find("cause=xcheck-swap-pin-gate-off"),
+              std::string::npos) << w.m_pin_drop_alarm;
+    EXPECT_NE(w.m_pin_drop_alarm.find("site=xcheck-swap"), std::string::npos)
+        << w.m_pin_drop_alarm;
+    // And it must reach the ONE line an operator greps for arm provenance.
+    EXPECT_NE(dash::stratum::detail::served_pins_field(w, &pins)
+                  .find("DONATION-DROPPED 2/2"),
+              std::string::npos);
+
+    // NO FALSE ALARM: the same two pins on the armed swap ride, and the field
+    // stays a clean pins=2/2 with nothing shouted.
+    auto clean = host_template();
+    dash::stratum::detail::splice_pins_onto_served_fallback(
+        clean, &pins, verdicts, true, /*xcheck_arm_enabled=*/true, false);
+    EXPECT_EQ(clean.m_txs.size(), 2u);
+    EXPECT_TRUE(clean.m_pin_drop_alarm.empty());
+    EXPECT_EQ(dash::stratum::detail::served_pins_field(clean, &pins), " pins=2/2");
 }

--- a/test/test_dash_stratum_work_source.cpp
+++ b/test/test_dash_stratum_work_source.cpp
@@ -2903,7 +2903,8 @@ dash::coin::DashWorkData host_template(
     w.m_height = kSpliceHeight;
     w.m_previous_block.SetHex(kEmbeddedPrevHashHex);
     for (const auto& h : hosts) {
-        auto sp = ::pack(h).get_span();
+        auto packed = ::pack(h);       // keep the packed buffer alive across the HexStr read below
+        auto sp = packed.get_span();
         w.m_txs.emplace_back(h);
         w.m_tx_hashes.push_back(dash::coin::dash_txid(h));
         w.m_tx_fees.push_back(0);

--- a/test/test_dash_stratum_work_source.cpp
+++ b/test/test_dash_stratum_work_source.cpp
@@ -3279,10 +3279,16 @@ TEST(DashStratumSpliceGuards, DropAlarmNamesTheCountValueAndCause)
 // outcome. An alarm that fires where the money DID land is the alarm the next
 // operator learns to ignore, and then block 2518044 happens again unseen.
 //
-// RED WITHOUT THE FIX: delete `if (o.cause == "already-in-template") continue;`
-// from raise_drop_alarm (work_source.cpp) and arms (a), (b) and (c) all fail --
-// (a) and (b) on a non-empty m_pin_drop_alarm, (c) on the count/value/cause of
-// a real loss being inflated by a pin that is being served.
+// RED WITHOUT THE FIX: delete the presence test from raise_drop_alarm
+// (work_source.cpp -- the std::find over w.m_tx_hashes) and arms (a), (b) and
+// (c) all fail -- (a) and (b) on a non-empty m_pin_drop_alarm, (c) on the
+// count/value/cause of a real loss being inflated by a pin that is being served.
+//
+// This test originally rode a skip on the cause STRING. It does not any more:
+// the string skip was one refusal shape short (see
+// DropAlarmKeysOnPresenceNotOnTheCauseString below) and is gone, so this test
+// and that one now both hang on the same single statement, which is the point --
+// one mutation must be able to take them both down.
 TEST(DashStratumSpliceGuards, DropAlarmIsSilentWhenTheDuplicatePinIsActuallyServed)
 {
     uint256 funding; funding.begin()[0] = 0x68;
@@ -3373,6 +3379,170 @@ TEST(DashStratumSpliceGuards, DropAlarmIsSilentWhenTheDuplicatePinIsActuallyServ
         EXPECT_EQ(w.m_pin_drop_alarm.find("already-in-template"),
                   std::string::npos)
             << "a cause that describes a SERVED pin is in a loss report: "
+            << w.m_pin_drop_alarm;
+    }
+}
+
+// THE ALARM KEYS ON PRESENCE, NOT ON A CAUSE STRING.
+//
+// The first cut of this fix skipped outcomes whose cause == "already-in-template",
+// and that was one refusal shape short of the truth condition. `already-in-template`
+// is only ever REACHED by the duplicate scan (work_source.cpp guard (f)), and FIVE
+// guards run BEFORE it and `continue` with a different cause:
+//
+//   the verdict-count-mismatch early return  (cause=pin-verdict-count-mismatch)
+//   (a) the pin's own verdict !v.ok          (cause=<whatever the gate said>)
+//   (b) xcheck-swap-pin-gate-off
+//   (c) xcheck-swap-height-mismatch
+//   (d)/(e) pin-total-too-large / block-budget
+//
+// A pin that IS on the served template but trips any of those records that
+// cause instead, and the cause-string skip never sees it -- so the alarm still
+// says the donation was lost while the donation is sitting in the block.
+//
+// This is not hypothetical shape-hunting. (a) is the PRODUCTION shape: the
+// embedded UTXO view is built forward from the height we started at, so a coin
+// older than that reads back input-missing-or-spent (mempool.hpp:205, and the
+// SECOND SOURCE comment at :212 exists because the production primary refused a
+// perfectly valid pin exactly this way). The dashd fallback template we splice
+// onto was built from dashd's OWN mempool, which can already carry that same
+// donation. Our gate refuses; dashd already included it; the money lands; the
+// alarm shouts that it did not.
+//
+// The truth condition the WARNING asserts is "the txid is NOT in the served
+// template". So that is what the alarm must test. The cause string is a
+// description of a decision; presence is the fact.
+//
+// RED WITHOUT THE FIX: with the presence test removed from raise_drop_alarm
+// (work_source.cpp) -- or replaced by the old cause-string skip, which is what
+// shipped -- arms (a) through (d) all fail on a non-empty m_pin_drop_alarm, and
+// arm (f) fails on a real loss whose count/value is inflated by a served pin.
+TEST(DashStratumSpliceGuards, DropAlarmKeysOnPresenceNotOnTheCauseString)
+{
+    uint256 funding; funding.begin()[0] = 0x6a;
+    const auto pin  = admissible_pin(funding);          // 50'000 sat
+    const auto txid = dash::coin::dash_txid(pin);
+    const std::vector<dash::coin::MutableTransaction> pins{pin};
+
+    // A refusal from the pin's own gate, at the template's height, with a cause
+    // that is NOT "already-in-template" -- the reviewer's scratch KAT.
+    auto bad_verdict = [](const char* cause) {
+        dash::coin::PinVerdict v;
+        v.ok        = false;
+        v.cause     = cause;
+        v.at_height = kSpliceHeight;
+        return v;
+    };
+
+    // Every arm below serves a template that ALREADY CARRIES the pin. Whatever
+    // the splice decided, the donation is in the block. Nothing may claim a loss.
+    auto expect_no_alarm = [&](const dash::coin::DashWorkData& w,
+                               const char* which, const char* expected_cause) {
+        ASSERT_EQ(w.m_pin_outcomes.size(), 1u) << which;
+        ASSERT_FALSE(w.m_pin_outcomes[0].included) << which;
+        // If this ever reads already-in-template the arm has stopped testing
+        // what it was written to test and the cause-string skip covers it.
+        ASSERT_EQ(w.m_pin_outcomes[0].cause, expected_cause)
+            << which << ": fixture no longer reaches the guard it targets";
+        ASSERT_TRUE(template_carries(w, txid))
+            << which << ": fixture broken, the alarm would be telling the truth";
+        EXPECT_TRUE(w.m_pin_drop_alarm.empty())
+            << which << ": DONATION-DROPPED on a template that IS carrying the "
+                        "donation: " << w.m_pin_drop_alarm;
+        const auto field = dash::stratum::detail::served_pins_field(w, &pins);
+        EXPECT_EQ(field.find("DONATION-DROPPED"), std::string::npos)
+            << which << ": the arm line claims a loss and a full pin count at "
+                        "once: " << field;
+        EXPECT_NE(field.find("pins=1/1"), std::string::npos) << which << field;
+    };
+
+    // (a) THE REVIEWER'S KAT. Guard (a) fires on the pin's own verdict and
+    // `continue`s long before the duplicate scan can name it.
+    {
+        auto w = host_template({pin});
+        dash::stratum::detail::splice_pins_onto_served_fallback(
+            w, &pins, {bad_verdict("input-missing-or-spent")},
+            /*from_xcheck_swap=*/false, /*xcheck_arm_enabled=*/false,
+            /*block_budget_enabled=*/false);
+        expect_no_alarm(w, "(a) !v.ok", "input-missing-or-spent");
+    }
+
+    // (b) The xcheck-swap money-path flag, default OFF. The swapped template
+    // came from dashd and can already carry the donation.
+    {
+        auto w = host_template({pin});
+        dash::stratum::detail::splice_pins_onto_served_fallback(
+            w, &pins, {ok_verdict(kSpliceHeight)},
+            /*from_xcheck_swap=*/true, /*xcheck_arm_enabled=*/false, false);
+        expect_no_alarm(w, "(b) xcheck-swap-pin-gate-off",
+                        "xcheck-swap-pin-gate-off");
+    }
+
+    // (c) Height disagreement on the xcheck arm.
+    {
+        auto w = host_template({pin});
+        dash::stratum::detail::splice_pins_onto_served_fallback(
+            w, &pins, {ok_verdict(kSpliceHeight - 1)},
+            /*from_xcheck_swap=*/true, /*xcheck_arm_enabled=*/true, false);
+        expect_no_alarm(w, "(c) xcheck-swap-height-mismatch",
+                        "xcheck-swap-height-mismatch");
+    }
+
+    // (d) The count-mismatch EARLY RETURN, which raises the alarm from its own
+    // exit path. Refusing everything by name is right; calling it a loss is not.
+    {
+        auto w = host_template({pin});
+        dash::stratum::detail::splice_pins_onto_served_fallback(
+            w, &pins, /*verdicts=*/{}, false, false, false);
+        expect_no_alarm(w, "(d) pin-verdict-count-mismatch",
+                        "pin-verdict-count-mismatch");
+    }
+
+    // (e) THE CONTROL, and the reason this is not "silence the alarm": the SAME
+    // refusal cause on a pin that is genuinely ABSENT must still shout, with the
+    // money and the cause named.
+    {
+        auto w = host_template();                       // carries nothing
+        dash::stratum::detail::splice_pins_onto_served_fallback(
+            w, &pins, {bad_verdict("input-missing-or-spent")}, false, false,
+            false);
+        ASSERT_FALSE(template_carries(w, txid));
+        ASSERT_FALSE(w.m_pin_drop_alarm.empty())
+            << "a pin that is genuinely absent stopped raising the alarm";
+        EXPECT_NE(w.m_pin_drop_alarm.find("DONATION-DROPPED 1/1"),
+                  std::string::npos) << w.m_pin_drop_alarm;
+        EXPECT_NE(w.m_pin_drop_alarm.find("value=50000sat"), std::string::npos)
+            << w.m_pin_drop_alarm;
+        EXPECT_NE(w.m_pin_drop_alarm.find("cause=input-missing-or-spent"),
+                  std::string::npos) << w.m_pin_drop_alarm;
+    }
+
+    // (f) MIXED, the arm that stops presence-keying from swallowing a real loss:
+    // one pin served-but-refused beside one genuinely absent, same cause on
+    // both. The alarm must read 1/2 and 30000sat, not 2/2 and 80000sat.
+    {
+        uint256 other; other.begin()[0] = 0x6b;
+        auto lost_pin = admissible_pin(other);
+        lost_pin.vout[0].value = 30'000;
+        const auto lost_txid = dash::coin::dash_txid(lost_pin);
+
+        auto w = host_template({pin});                  // carries `pin` only
+        const std::vector<dash::coin::MutableTransaction> both{pin, lost_pin};
+        dash::stratum::detail::splice_pins_onto_served_fallback(
+            w, &both,
+            {bad_verdict("input-missing-or-spent"),
+             bad_verdict("input-missing-or-spent")},
+            false, false, false);
+
+        ASSERT_TRUE(template_carries(w, txid));
+        ASSERT_FALSE(template_carries(w, lost_txid));
+        ASSERT_FALSE(w.m_pin_drop_alarm.empty())
+            << "the genuinely absent pin stopped raising the alarm";
+        EXPECT_NE(w.m_pin_drop_alarm.find("DONATION-DROPPED 1/2"),
+                  std::string::npos)
+            << "the served pin was counted as lost: " << w.m_pin_drop_alarm;
+        EXPECT_NE(w.m_pin_drop_alarm.find("value=30000sat"), std::string::npos)
+            << "the served pin's 50000 sat was added to the loss: "
             << w.m_pin_drop_alarm;
     }
 }

--- a/test/test_dash_stratum_work_source.cpp
+++ b/test/test_dash_stratum_work_source.cpp
@@ -3263,3 +3263,116 @@ TEST(DashStratumSpliceGuards, DropAlarmNamesTheCountValueAndCause)
     EXPECT_TRUE(clean.m_pin_drop_alarm.empty());
     EXPECT_EQ(dash::stratum::detail::served_pins_field(clean, &pins), " pins=2/2");
 }
+
+// THE ALARM MUST BE TRUTHFUL -- `already-in-template` is NOT a dropped donation.
+//
+// The alarm's WARNING asserts "this template IS SERVED to miners without the
+// donation; if it wins, that value does not land". `included` records what THE
+// SPLICE did, not what the SERVED TEMPLATE holds, and exactly one of the seven
+// causes makes those disagree: `already-in-template` refuses BECAUSE
+// w.m_tx_hashes already carries the txid. The money is on the template. It
+// lands. The shipped line contradicted itself inside one string --
+//
+//   pins=1/1 pin_cause=already-in-template DONATION-DROPPED 1/1 pins h=500001 value=50000sat
+//
+// -- pins=1/1 counted by PRESENCE against DONATION-DROPPED 1/1 counted by
+// outcome. An alarm that fires where the money DID land is the alarm the next
+// operator learns to ignore, and then block 2518044 happens again unseen.
+//
+// RED WITHOUT THE FIX: delete `if (o.cause == "already-in-template") continue;`
+// from raise_drop_alarm (work_source.cpp) and arms (a), (b) and (c) all fail --
+// (a) and (b) on a non-empty m_pin_drop_alarm, (c) on the count/value/cause of
+// a real loss being inflated by a pin that is being served.
+TEST(DashStratumSpliceGuards, DropAlarmIsSilentWhenTheDuplicatePinIsActuallyServed)
+{
+    uint256 funding; funding.begin()[0] = 0x68;
+    const auto pin  = admissible_pin(funding);          // 50'000 sat
+    const auto txid = dash::coin::dash_txid(pin);
+    const std::vector<dash::coin::MutableTransaction> pins{pin};
+    const std::vector<dash::coin::PinVerdict> verdicts{ok_verdict(kSpliceHeight)};
+
+    // (a) THE REPORTED LINE. The served template already carries the pin, so the
+    // splice refuses -- and the donation is ON THE TEMPLATE.
+    {
+        auto w = host_template({pin});
+        dash::stratum::detail::splice_pins_onto_served_fallback(
+            w, &pins, verdicts, /*from_xcheck_swap=*/false,
+            /*xcheck_arm_enabled=*/false, /*block_budget_enabled=*/false);
+
+        // The refusal itself is unchanged -- this KAT is about the ALARM, not
+        // about relaxing the duplicate guard.
+        ASSERT_EQ(w.m_pin_outcomes.size(), 1u);
+        ASSERT_FALSE(w.m_pin_outcomes[0].included);
+        ASSERT_EQ(w.m_pin_outcomes[0].cause, "already-in-template");
+        ASSERT_EQ(w.m_txs.size(), 1u) << "the duplicate guard stopped guarding";
+
+        // THE POINT: the value is in the block that gets served.
+        ASSERT_TRUE(template_carries(w, txid))
+            << "fixture broken: the alarm would be telling the truth";
+        EXPECT_TRUE(w.m_pin_drop_alarm.empty())
+            << "DONATION-DROPPED on a template that IS carrying the donation: "
+            << w.m_pin_drop_alarm;
+        const auto field = dash::stratum::detail::served_pins_field(w, &pins);
+        EXPECT_EQ(field.find("DONATION-DROPPED"), std::string::npos)
+            << "the arm line claims a loss and a full pin count at once: " << field;
+        EXPECT_NE(field.find("pins=1/1"), std::string::npos) << field;
+    }
+
+    // (b) THE SAME PIN CONFIGURED TWICE. The first copy rides, the second is
+    // refused as already-in-template by the scan reading what pin_append just
+    // wrote. One donation, served once, correctly: nothing was lost.
+    {
+        auto w = host_template();
+        const std::vector<dash::coin::MutableTransaction> twice{pin, pin};
+        const std::vector<dash::coin::PinVerdict> two{ok_verdict(kSpliceHeight),
+                                                      ok_verdict(kSpliceHeight)};
+        dash::stratum::detail::splice_pins_onto_served_fallback(
+            w, &twice, two, false, false, false);
+        ASSERT_EQ(w.m_pin_outcomes.size(), 2u);
+        ASSERT_TRUE(w.m_pin_outcomes[0].included);
+        ASSERT_EQ(w.m_pin_outcomes[1].cause, "already-in-template");
+        EXPECT_TRUE(w.m_pin_drop_alarm.empty())
+            << "configuring one donation twice is not losing it: "
+            << w.m_pin_drop_alarm;
+    }
+
+    // (c) MIXED, AND THE REAL LOSS STILL SHOUTS -- with the served duplicate out
+    // of the count, out of the money, and out of the cause list. This arm is
+    // what stops the fix from being "silence the alarm": a genuine drop beside a
+    // served duplicate must still name itself, at 1/2 and 30000sat, not 2/2 and
+    // 80000sat.
+    {
+        uint256 other; other.begin()[0] = 0x69;
+        auto lost_pin = admissible_pin(other);
+        lost_pin.vout[0].value = 30'000;
+        const auto lost_txid = dash::coin::dash_txid(lost_pin);
+
+        auto w = host_template({pin});                  // already carries `pin`
+        const std::vector<dash::coin::MutableTransaction> both{pin, lost_pin};
+        dash::coin::PinVerdict refused;                 // a REAL refusal
+        refused.ok        = false;
+        refused.cause     = "pin-input-unspendable";
+        refused.at_height = kSpliceHeight;
+        const std::vector<dash::coin::PinVerdict> two{ok_verdict(kSpliceHeight),
+                                                      refused};
+        dash::stratum::detail::splice_pins_onto_served_fallback(
+            w, &both, two, false, false, false);
+
+        ASSERT_FALSE(template_carries(w, lost_txid));
+        ASSERT_TRUE(template_carries(w, txid));
+        ASSERT_FALSE(w.m_pin_drop_alarm.empty())
+            << "a pin that is genuinely absent stopped raising the alarm";
+        EXPECT_NE(w.m_pin_drop_alarm.find("DONATION-DROPPED 1/2"),
+                  std::string::npos)
+            << "the served duplicate was counted as lost: " << w.m_pin_drop_alarm;
+        EXPECT_NE(w.m_pin_drop_alarm.find("value=30000sat"), std::string::npos)
+            << "the served duplicate's 50000 sat was added to the loss: "
+            << w.m_pin_drop_alarm;
+        EXPECT_NE(w.m_pin_drop_alarm.find("cause=pin-input-unspendable"),
+                  std::string::npos) << w.m_pin_drop_alarm;
+        EXPECT_EQ(w.m_pin_drop_alarm.find("already-in-template"),
+                  std::string::npos)
+            << "a cause that describes a SERVED pin is in a loss report: "
+            << w.m_pin_drop_alarm;
+    }
+}

--- a/test/test_dash_stratum_work_source.cpp
+++ b/test/test_dash_stratum_work_source.cpp
@@ -2499,3 +2499,359 @@ TEST(DashServeGateJournal, TwoTransitionsBothEmitEvenWithOneCause) {
         << "expected: first decline (transition), resume, second decline "
            "(transition) -- three edges, none swallowed by the same-cause rule";
 }
+
+// ═════════════════════════════════════════════════════════════════════════════
+// PINNED DONATION TX vs THE SERVED FALLBACK TEMPLATE
+//
+// Measured on the production primary, 2026-08-07 (log c2pool-dash-v024.log.1,
+// window 22:33:35 -> 23:32:45, 197 distinct served dashd-fallback templates):
+//
+//     131  produced by the DECLINED-EMBEDDED branch  -> the splice ran
+//                                                        (28 INCLUDED, 103
+//                                                         EXCLUDED cause=tip-unknown)
+//      66  produced by the GBT-XCHECK SWAP           -> the splice NEVER ran,
+//                                                        and NOTHING was logged
+//
+// The 66 are the defect. The swap replaces the embedded selection -- which
+// already carries the pins -- with a fresh dashd template that no pin splice
+// ever touches, so the donation silently falls off a third of everything we
+// serve. Block h=2518044 was won from one of them:
+//
+//     23:12:31.660-.711  [GBT-EMB] pinned tx INCLUDED x4  h=2518044
+//     23:12:31.768       GBT-xcheck MATCH-MODULO-SPECIAL  h=2518044
+//     23:12:31.768       template sourced: arm=dashd-fallback
+//     23:12:39           won block 2518044                (0 of 4 pins on chain)
+//
+// 57 ms between "the pins are on this template" and serving a different one.
+// ═════════════════════════════════════════════════════════════════════════════
+namespace {
+
+// A pinned tx that the gate ADMITS: one mature non-coinbase input, one output
+// of exactly the input value (fee == 0), well under kMaxPinnedTxBytes.
+dash::coin::MutableTransaction admissible_pin(const uint256& funding)
+{
+    dash::coin::MutableTransaction pin;
+    pin.vin.resize(1);
+    pin.vin[0].prevout.hash  = funding;
+    pin.vin[0].prevout.index = 0;
+    pin.vout.resize(1);
+    pin.vout[0].value  = 50'000;
+    pin.vout[0].scriptPubKey.m_data = fixture_miner_script();
+    return pin;
+}
+
+bool template_carries(const dash::coin::DashWorkData& w, const uint256& txid)
+{
+    return std::find(w.m_tx_hashes.begin(), w.m_tx_hashes.end(), txid)
+        != w.m_tx_hashes.end();
+}
+
+const dash::coin::PinOutcome* find_pin_outcome(const dash::coin::DashWorkData& w,
+                                               const uint256& txid)
+{
+    for (const auto& o : w.m_pin_outcomes)
+        if (o.txid == txid) return &o;
+    return nullptr;
+}
+
+// The xcheck fixture: populated + SML-fresh + credit-pool-fresh coin state whose
+// embedded template is viable, plus a dashd fallback that disagrees on
+// creditPool at the SAME height so the backstop swaps the served arm.
+void seed_xcheck_ready(dash::coin::NodeCoinState& cs, const uint256& emb_prev,
+                       int64_t seed)
+{
+    dash::coin::vendor::CSimplifiedMNListEntry e1;
+    e1.proRegTxHash.SetHex(std::string(64, '4'));
+    e1.confirmedHash.SetHex(std::string(64, '5'));
+    e1.isValid = true;
+    cs.sml().mnList = {e1};
+    cs.sml().sort();
+    cs.set_have_sml(true);
+    cs.set_sml_current_hash(emb_prev);
+    cs.set_require_sml(true);
+    cs.set_require_fresh_credit_pool(true);
+    cs.set_credit_pool(seed, emb_prev, static_cast<int32_t>(kEmbeddedPrevHeight));
+    cs.set_tip(kEmbeddedPrevHeight, emb_prev, 0x1e0ffff0u, 1'700'000'000u,
+               76, 16, kCurtime, static_cast<uint32_t>(kVersion));
+    seed_resolvable_mn(cs);
+}
+
+}  // namespace
+
+// THE DEFECT. An admissible pin rides the EMBEDDED template (proved first, so
+// this test cannot pass vacuously on an inadmissible pin), and then the
+// GBT-xcheck swap serves a dashd template that carries neither the pin nor any
+// record of why it is missing.
+TEST(DashStratumPinSplice, XcheckSwapDropsThePinnedDonationSilently)
+{
+    using ::core::coin::UTXOViewCache;
+    using ::core::coin::Outpoint;
+    using ::core::coin::Coin;
+
+    uint256 emb_prev; emb_prev.SetHex(kEmbeddedPrevHashHex);
+    uint256 funding;  funding.begin()[0] = 0x42;
+    const int64_t seed = 500'000'000LL;
+
+    UTXOViewCache utxo(nullptr);
+    utxo.add_coin(Outpoint(funding, 0), Coin(50'000, {}, /*height=*/1, /*cb=*/false));
+    const auto pin  = admissible_pin(funding);
+    const auto txid = dash::coin::dash_txid(pin);
+
+    auto submit = [](const std::vector<unsigned char>&, uint32_t, bool) { return true; };
+
+    // ── (a) NON-VACUITY: the same pin, the same gate, xcheck OFF -> the served
+    // EMBEDDED template carries it. If this fails the fixture is wrong, not the
+    // code under test.
+    {
+        dash::coin::NodeCoinState cs;
+        seed_xcheck_ready(cs, emb_prev, seed);
+        cs.mempool().set_utxo(&utxo);
+        cs.set_pinned_local_txs({pin});
+
+        auto fallback = []() -> dash::coin::DashWorkData { return dash::coin::DashWorkData{}; };
+        dash::stratum::DASHWorkSource ws(cs, fallback, submit,
+                                         core::stratum::StratumConfig{},
+                                         /*is_testnet=*/true);
+        ASSERT_FALSE(ws.get_current_work_template().empty());
+        auto t = ws.peek_template();
+        ASSERT_TRUE(t);
+        ASSERT_TRUE(template_carries(*t, txid))
+            << "fixture broken: the pin is not admissible on the embedded arm, "
+               "so the xcheck assertion below would be vacuous";
+    }
+
+    // ── (b) THE DEFECT: same coin state, xcheck ARMED, dashd disagrees on
+    // creditPool at the same height -> the backstop serves dashd's template.
+    dash::coin::NodeCoinState cs;
+    seed_xcheck_ready(cs, emb_prev, seed);
+    cs.mempool().set_utxo(&utxo);
+    cs.set_pinned_local_txs({pin});
+
+    const int64_t dashd_credit = seed + 424242LL;
+    auto fallback = [&]() -> dash::coin::DashWorkData {
+        dash::coin::DashWorkData w;
+        w.m_height         = kEmbeddedPrevHeight + 1;
+        w.m_previous_block = emb_prev;
+        w.m_bits           = 0x1e0ffff0u;
+        w.m_version        = static_cast<uint32_t>(kVersion);
+        w.m_curtime        = kCurtime;
+        dash::coin::vendor::CCbTx cb;
+        cb.nVersion           = dash::coin::vendor::CCbTx::VERSION_CLSIG_AND_BALANCE;
+        cb.nHeight            = static_cast<int32_t>(kEmbeddedPrevHeight + 1);
+        cb.creditPoolBalance  = dashd_credit;
+        w.m_coinbase_payload  = dash::coin::encode_cbtx(cb);
+        return w;
+    };
+    dash::stratum::DASHWorkSource ws(cs, fallback, submit,
+                                     core::stratum::StratumConfig{},
+                                     /*is_testnet=*/true);
+    ws.set_gbt_xcheck(true);
+
+    ASSERT_FALSE(ws.get_current_work_template().empty());
+    auto t = ws.peek_template();
+    ASSERT_TRUE(t && !t->m_coinbase_payload.empty());
+    dash::coin::vendor::CCbTx served;
+    ASSERT_TRUE(dash::coin::vendor::parse_cbtx(t->m_coinbase_payload, served));
+    ASSERT_EQ(served.creditPoolBalance, dashd_credit)
+        << "precondition: the xcheck backstop must have swapped in dashd's template";
+
+    // THE CONTRACT: ride, or say why. Never both absent.
+    const bool rides = template_carries(*t, txid);
+    const auto* outcome = find_pin_outcome(*t, dash::coin::dash_txid(pin));
+    EXPECT_TRUE(rides || (outcome != nullptr && !outcome->cause.empty()))
+        << "h=2518044 shape: the served dashd template dropped the pinned "
+           "donation and recorded no reason at all";
+
+    // With the arm flag at its DEFAULT (off) the served bytes are unchanged --
+    // so the resolution must be the NAMED cause, not an inclusion.
+    EXPECT_FALSE(rides)
+        << "--pin-splice-xcheck-arm defaults OFF: no new bytes may be served";
+    ASSERT_NE(outcome, nullptr);
+    EXPECT_EQ(outcome->cause, "xcheck-swap-pin-gate-off");
+    EXPECT_EQ(outcome->gate_height, kEmbeddedPrevHeight + 1);
+    EXPECT_EQ(outcome->template_height, kEmbeddedPrevHeight + 1);
+}
+
+// FLAG ON: the same swap, the same pin, and now it RIDES -- the served dashd
+// template carries the donation and the outcome says so. This is the arm the
+// operator turns on once the flag-off shape has been read in production.
+TEST(DashStratumPinSplice, XcheckSwapCarriesThePinWhenTheArmIsEnabled)
+{
+    using ::core::coin::UTXOViewCache;
+    using ::core::coin::Outpoint;
+    using ::core::coin::Coin;
+
+    uint256 emb_prev; emb_prev.SetHex(kEmbeddedPrevHashHex);
+    uint256 funding;  funding.begin()[0] = 0x44;
+    const int64_t seed = 500'000'000LL;
+
+    UTXOViewCache utxo(nullptr);
+    utxo.add_coin(Outpoint(funding, 0), Coin(50'000, {}, /*height=*/1, /*cb=*/false));
+    const auto pin  = admissible_pin(funding);
+    const auto txid = dash::coin::dash_txid(pin);
+
+    dash::coin::NodeCoinState cs;
+    seed_xcheck_ready(cs, emb_prev, seed);
+    cs.mempool().set_utxo(&utxo);
+    cs.set_pinned_local_txs({pin});
+
+    const int64_t dashd_credit = seed + 424242LL;
+    auto fallback = [&]() -> dash::coin::DashWorkData {
+        dash::coin::DashWorkData w;
+        w.m_height         = kEmbeddedPrevHeight + 1;
+        w.m_previous_block = emb_prev;
+        w.m_bits           = 0x1e0ffff0u;
+        w.m_version        = static_cast<uint32_t>(kVersion);
+        w.m_curtime        = kCurtime;
+        dash::coin::vendor::CCbTx cb;
+        cb.nVersion          = dash::coin::vendor::CCbTx::VERSION_CLSIG_AND_BALANCE;
+        cb.nHeight           = static_cast<int32_t>(kEmbeddedPrevHeight + 1);
+        cb.creditPoolBalance = dashd_credit;
+        w.m_coinbase_payload = dash::coin::encode_cbtx(cb);
+        return w;
+    };
+    auto submit = [](const std::vector<unsigned char>&, uint32_t, bool) { return true; };
+    dash::stratum::DASHWorkSource ws(cs, fallback, submit,
+                                     core::stratum::StratumConfig{},
+                                     /*is_testnet=*/true);
+    ws.set_gbt_xcheck(true);
+    ws.set_pin_splice_xcheck_arm(true);
+
+    ASSERT_FALSE(ws.get_current_work_template().empty());
+    auto t = ws.peek_template();
+    ASSERT_TRUE(t && !t->m_coinbase_payload.empty());
+    dash::coin::vendor::CCbTx served;
+    ASSERT_TRUE(dash::coin::vendor::parse_cbtx(t->m_coinbase_payload, served));
+    ASSERT_EQ(served.creditPoolBalance, dashd_credit)
+        << "precondition: the xcheck backstop must have swapped in dashd's template";
+
+    EXPECT_TRUE(template_carries(*t, txid))
+        << "--pin-splice-xcheck-arm is ON: the pin must ride the swapped template";
+    const auto* outcome = find_pin_outcome(*t, txid);
+    ASSERT_NE(outcome, nullptr);
+    EXPECT_TRUE(outcome->included);
+    EXPECT_TRUE(outcome->cause.empty());
+    // The append must be COMPLETE -- all four parallel vectors, fee recorded as
+    // zero, coinbase claim untouched. A half-spliced tx is an unmineable block.
+    ASSERT_EQ(t->m_txs.size(), t->m_tx_hashes.size());
+    ASSERT_EQ(t->m_txs.size(), t->m_tx_fees.size());
+    ASSERT_EQ(t->m_txs.size(), t->m_tx_data_hex.size());
+    EXPECT_EQ(t->m_tx_fees.back(), 0u);
+    EXPECT_FALSE(t->m_tx_data_hex.back().empty());
+}
+
+// THE BUDGET. The fallback splice caps pins against 400 KB of PINS and nothing
+// else -- never against what the template it is appending to already holds. A
+// dashd template that is already near the 2 MB block limit therefore accepts
+// the pin and produces a block that cannot be mined (bad-blk-length).
+TEST(DashStratumPinSplice, FallbackSpliceRespectsTheBlockSizeBudget)
+{
+    using ::core::coin::UTXOViewCache;
+    using ::core::coin::Outpoint;
+    using ::core::coin::Coin;
+
+    uint256 emb_prev; emb_prev.SetHex(kEmbeddedPrevHashHex);
+    uint256 funding;  funding.begin()[0] = 0x43;
+
+    UTXOViewCache utxo(nullptr);
+    utxo.add_coin(Outpoint(funding, 0), Coin(50'000, {}, /*height=*/1, /*cb=*/false));
+    const auto pin  = admissible_pin(funding);
+    const auto txid = dash::coin::dash_txid(pin);
+
+    // Mainnet with --embedded-mainnet OFF: the arm declines by the gate, the
+    // tip is still known (so the pin gate judges at a real height), and the
+    // served template is the dashd fallback that the splice runs on today.
+    dash::coin::NodeCoinState cs;
+    seed_populated(cs);
+    cs.mempool().set_utxo(&utxo);
+    cs.set_pinned_local_txs({pin});
+
+    // A dashd template already holding ~1.95 MB of transaction payload.
+    constexpr size_t kFatBytes = 1'950'000;
+    auto fallback = [&]() -> dash::coin::DashWorkData {
+        dash::coin::DashWorkData w;
+        w.m_height         = kEmbeddedPrevHeight + 1;
+        w.m_previous_block = emb_prev;
+        w.m_bits           = 0x1e0ffff0u;
+        w.m_version        = static_cast<uint32_t>(kVersion);
+        w.m_curtime        = kCurtime;
+        dash::coin::MutableTransaction fat;   // identity only; the BYTES are the hex
+        fat.vin.resize(1);
+        fat.vin[0].prevout.hash.begin()[0] = 0x77;
+        w.m_txs.emplace_back(fat);
+        w.m_tx_hashes.push_back(dash::coin::dash_txid(fat));
+        w.m_tx_fees.push_back(0);
+        w.m_tx_data_hex.push_back(std::string(kFatBytes * 2, 'a'));
+        return w;
+    };
+    auto submit = [](const std::vector<unsigned char>&, uint32_t, bool) { return true; };
+    dash::stratum::DASHWorkSource ws(cs, fallback, submit,
+                                     core::stratum::StratumConfig{},
+                                     /*is_testnet=*/false);
+
+    ASSERT_FALSE(ws.get_current_work_template().empty());
+    auto t = ws.peek_template();
+    ASSERT_TRUE(t);
+    ASSERT_EQ(t->m_height, kEmbeddedPrevHeight + 1)
+        << "precondition: the dashd fallback template is the one being served";
+
+    EXPECT_FALSE(template_carries(*t, txid))
+        << "the pin was appended to a template already at " << kFatBytes
+        << " bytes -- the only cap that ran was pins-vs-400KB";
+    const auto* outcome = find_pin_outcome(*t, txid);
+    ASSERT_NE(outcome, nullptr) << "an exclusion without a record is the defect";
+    EXPECT_EQ(outcome->cause, "block-budget");
+}
+
+// THE HOIST MUST NOT REGRESS THE PATH THAT ALREADY WORKED. Same declined-
+// embedded producer as the budget KAT above, but a normal-sized dashd template:
+// the pin still rides, still with fee 0, still recorded as INCLUDED. Moving the
+// splice from inside the fallback branch to the final selection is a pure move
+// only if this stays green.
+TEST(DashStratumPinSplice, DeclinedEmbeddedFallbackStillCarriesThePin)
+{
+    using ::core::coin::UTXOViewCache;
+    using ::core::coin::Outpoint;
+    using ::core::coin::Coin;
+
+    uint256 emb_prev; emb_prev.SetHex(kEmbeddedPrevHashHex);
+    uint256 funding;  funding.begin()[0] = 0x45;
+
+    UTXOViewCache utxo(nullptr);
+    utxo.add_coin(Outpoint(funding, 0), Coin(50'000, {}, /*height=*/1, /*cb=*/false));
+    const auto pin  = admissible_pin(funding);
+    const auto txid = dash::coin::dash_txid(pin);
+
+    dash::coin::NodeCoinState cs;
+    seed_populated(cs);
+    cs.mempool().set_utxo(&utxo);
+    cs.set_pinned_local_txs({pin});
+
+    auto fallback = [&]() -> dash::coin::DashWorkData {
+        dash::coin::DashWorkData w;
+        w.m_height         = kEmbeddedPrevHeight + 1;
+        w.m_previous_block = emb_prev;
+        w.m_bits           = 0x1e0ffff0u;
+        w.m_version        = static_cast<uint32_t>(kVersion);
+        w.m_curtime        = kCurtime;
+        return w;
+    };
+    auto submit = [](const std::vector<unsigned char>&, uint32_t, bool) { return true; };
+    // mainnet, --embedded-mainnet OFF => the arm declines by the gate and the
+    // dashd fallback is what gets served.
+    dash::stratum::DASHWorkSource ws(cs, fallback, submit,
+                                     core::stratum::StratumConfig{},
+                                     /*is_testnet=*/false);
+
+    ASSERT_FALSE(ws.get_current_work_template().empty());
+    auto t = ws.peek_template();
+    ASSERT_TRUE(t);
+    EXPECT_TRUE(template_carries(*t, txid))
+        << "the declined-embedded fallback has spliced the pin since #1170; "
+           "the hoist must not have taken that away";
+    const auto* outcome = find_pin_outcome(*t, txid);
+    ASSERT_NE(outcome, nullptr);
+    EXPECT_TRUE(outcome->included);
+    ASSERT_FALSE(t->m_tx_fees.empty());
+    EXPECT_EQ(t->m_tx_fees.back(), 0u);
+}


### PR DESCRIPTION
> **Carries the full `dash/tipfreeze-pin-miss` stack** (4 commits from master), not just the alarm fix — `raise_drop_alarm` / `m_pin_drop_alarm` / the `DONATION-DROPPED` string arrive in f93d8bbc and 1b603d7a. Review as one unit.

> **✅ C4 DECIDED — operator, 2026-08-08: ACCEPT UNFLAGGED.** The pin-splice duplicate/double-spend check (`work_source.cpp:557-616`) ships without a flag, as an explicit exception to the no-unflagged-served-bytes rule.
>
> **Rationale on record:** both comparisons are consensus-exact — txid equality and prevout (hash+index) equality — so neither can false-positive. The only templates altered are ones that could never have produced a valid block (`bad-txns-duplicate` / `bad-txns-inputs-missingorspent`). It can only turn an unmineable template into a mineable one. This is what distinguishes it from C2, the block budget, which IS flag-gated because it is a *heuristic* with a 100 KB reserve that would drop donations from templates 49,915 bytes inside the real 2 MB limit.
>
> Both halves mutation-proven red: `txid-presence find → if(false)` and `outpoint-equality → if(false)` each fail `SpliceRefusesDuplicateAndConflictingPins`.
>
> **Scope of the exception:** pinned transactions only. Any future extension of this check to non-pin transactions requires a flag.
>
> **This PR is no longer blocked on an operator decision.** It remains blocked on being CONFLICTING (zero CI) and on the branch-shape question below.

The alarm fix: `DONATION-DROPPED` must not fire on a pin that IS in the served template.

**The shipped version was one statement short.** It skipped outcomes whose *cause string* was `already-in-template`. That string is only ever written by guard (f), the duplicate scan. Five refusals run before it and `continue` with a different cause:

| site | cause |
|---|---|
| `work_source.cpp:477` | `pin-verdict-count-mismatch` |
| `work_source.cpp:510` | the pin's own verdict `!v.ok` |
| `work_source.cpp:524` | `xcheck-swap-pin-gate-off` |
| `work_source.cpp:542` | `xcheck-swap-height-mismatch` |
| `:554` / `:576` | the two size caps |

A pin that IS on the served template but trips any of those records that other cause, the string skip never sees it, and the alarm claims the donation was lost while it sits in the block:

```
pins=1/1 pin_cause=input-missing-or-spent DONATION-DROPPED 1/1 pins h=500001 ...
```

**This is the production shape, not a hunted-for test case.** The embedded UTXO view is built forward from the height we started at, so a coin older than that reads back `input-missing-or-spent` — the production primary refused a perfectly valid pin exactly this way on 2026-08-07. The dashd fallback template we splice onto was built from dashd's own mempool, which can already carry that donation: our gate refuses, dashd already included it, the money lands, and the alarm shouts that it did not.

**Fix — key the alarm on PRESENCE:**

```cpp
if (std::find(w.m_tx_hashes.begin(), w.m_tx_hashes.end(), o.txid)
    != w.m_tx_hashes.end())
    continue;  // refused by the splice, SERVED by the template
```

`included` is a fact about *the splice* (did this call append?). The warning makes a claim about *the served template* (is the txid in it?). Different questions; the alarm was asking the wrong one.

**The cause-string skip is removed, not kept alongside.** Presence subsumes it, and keeping both would make the presence test unmutable — delete it and the `already-in-template` shapes would still pass on the string. A guard that cannot be made to fail is not a guard, and this lane has already shipped four of those.

Contains a `fixup!` commit — squash-merge, or autosquash before merging.


---

## ⛔ BRANCH SHAPE — this should probably NOT be a PR to master

`origin/master..a345abc3` is **four** commits (f93d8bbc, 1b603d7a, ce6e1e00, a345abc3), because `raise_drop_alarm` / `m_pin_drop_alarm` / `DONATION-DROPPED` do not exist on master (`git grep` on `origin/master` confirms absent) — they arrive with `dash/tipfreeze-pin-miss`, **which has never had a PR**.

So this PR carries **two unreviewed pin-miss commits under an alarm-fix title**.

**Recommended: FOLD rather than merge as-is.** 1b603d7a is a strict ancestor of a345abc3, so no rebase is needed — squash a345abc3 into ce6e1e00, fast-forward `dash/tipfreeze-pin-miss`, and open **one** PR from there. This PR can then be closed in favour of it.

⚠️ **Do not merge `dash/tipfreeze-pin-miss` alone either** — that would land a `raise_drop_alarm` that **false-fires in production**. The alarm and its fix must land together.

Also unsquashed: a345abc3 is still a literal `fixup!` on top of ce6e1e00.

**Still DO NOT MERGE pending the C4 operator decision** regardless of how the branch shape is resolved.

