### PR TITLE
dash: take the serve gate off the per-share-submit path (hotel freeze D1)

### DIFF
--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -830,6 +830,12 @@ public:
     void set_mn_needs_reseed(bool v) { m_mn_needs_reseed = v; }
     bool mn_needs_reseed() const { return m_mn_needs_reseed; }
 
+    /// Number of times embedded_template_emit_ok() has been evaluated on this
+    /// state (counted at the top of the gate, before any early return). Test
+    /// seam: pins that submit-path tip reads never evaluate the serve gate
+    /// (the 2026-08-07/08 hotel freeze amplifier).
+    uint64_t emit_ok_call_count() const { return m_emit_ok_calls; }
+
     /// BLOCKER-3 pre-emit HARD GATE. Before the embedded arm's template is
     /// served/mined, re-validate the BUILT CbTx against consensus invariants;
     /// any failure => the caller must fall back to the reward-safe dashd path.
@@ -850,6 +856,12 @@ public:
     /// existing caller and KAT source-compatible.
     bool embedded_template_emit_ok(const DashWorkData& w,
                                    DeclineReport* why = nullptr) const {
+        // Call counter FIRST, before any early return: the regression gate in
+        // test_dash_submit_gate_scaling.cpp pins that a submit-path tip READ
+        // (get_current_gbt_prevhash) never evaluates this gate -- the
+        // 2026-08-07/08 hotel freeze was this method's SML CalcMerkleRoot
+        // running per share submit on the io thread.
+        ++m_emit_ok_calls;
         auto reject = [why](const char* c, std::string v, std::string t) -> bool {
             if (why) {
                 why->viable    = false;
@@ -1560,6 +1572,12 @@ private:
     uint256  m_sml_current_hash;              // block hash the SML is current at (ZERO = cold/reorg)
     int64_t  m_sml_current_height{-1};        // DIAGNOSTIC ONLY, -1 = never reported; see set_sml_current_height
     bool     m_require_sml{false};            // gate viability on have_sml (embedded arm)
+    // How many times embedded_template_emit_ok() was EVALUATED (incremented at
+    // its top, before any early return). Test seam for the 2026-08-07/08 hotel
+    // freeze regression gate: the serve gate re-derives the full SML merkle
+    // root, so the count of evaluations per submit-path tip read must be ZERO
+    // (test_dash_submit_gate_scaling.cpp). mutable because the gate is const.
+    mutable uint64_t m_emit_ok_calls{0};
     std::function<bool()> m_utxo_ready_fn;   // optional UTXO maturity gate (E2b)
     // Default REFUSES the immature window (p2pool semantics: an unsynced node
     // does not serve templates) -- byte-identical to the pre-policy behaviour.

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -228,14 +228,29 @@ std::function<uint256()> DASHWorkSource::get_best_share_hash_fn() const
 
 std::string DASHWorkSource::get_current_gbt_prevhash() const
 {
-    // GBT-conventional BE display hex of the tip the pool mines on, drawn from
-    // the SAME cached DashWorkData get_current_work_template() serves -- one
-    // truthful source, so the dedicated getter and the assembled template can
-    // never silently diverge. Empty on a set-gap (no template source armed) --
-    // a truthful absence, never a fabricated tip id.
-    auto wd = cached_work();
-    if (!wd) return {};
-    return wd->m_previous_block.GetHex();
+    // GBT-conventional BE display hex of the tip the pool mines on -- a PURE
+    // template_mutex_-guarded PEEK of the cached snapshot, same shape as
+    // peek_template(). Empty on a set-gap (cache null) -- a truthful absence,
+    // never a fabricated tip id.
+    //
+    // 2026-08-07/08 hotel freeze fix (0 of 26 rigs, twice): this getter's only
+    // production caller is StratumSession::handle_submit's DOA statistics
+    // compare (stratum_server.cpp), which runs PER SHARE SUBMIT on the single
+    // io thread. Routing it through cached_work() ran the serve-time embedded
+    // re-check -- embedded_template_emit_ok -> CSimplifiedMNList::
+    // CalcMerkleRoot -- per submit: ~17 submits/s x ~2000 masternodes = ~68k
+    // SHA256d/s on the io thread; the stratum recvQ grew 7 -> 62 MB and the
+    // served tip froze. A submit-time tip READ must not evaluate the serve
+    // gate, must not reset or re-source the cache, and must not record a
+    // served height (note_served_height belongs to the getters through which
+    // a height actually LEAVES the node: get_current_work_template /
+    // build_connection_coinbase). The DOA compare is brace-scoped, guarded by
+    // !current_prevhash.empty(), and statistics-only by its own comment -- a
+    // stale peek costs at worst one wrong DOA counter tick, never a wrong
+    // share or block.
+    std::lock_guard<std::mutex> lk(template_mutex_);
+    if (!template_cache_) return {};
+    return template_cache_->m_previous_block.GetHex();
 }
 
 bool DASHWorkSource::has_merged_chain(uint32_t /*chain_id*/) const
@@ -922,6 +937,11 @@ nlohmann::json DASHWorkSource::embedded_arm_status_json() const
     nlohmann::json j;
     // BEFORE the lock, deliberately -- see serve_staleness_json().
     j["serve_staleness"] = serve_staleness_json();
+    // Atomic, lock-free: how many times the serve-time embedded re-check
+    // dropped a cached template. Published so the fire RATE is measurable
+    // from the operator surface, not inferred from log archaeology.
+    j["serve_recheck_fail_count"] =
+        serve_recheck_fail_count_.load(std::memory_order_relaxed);
 
     // TRY_LOCK, not lock_guard. serve_gate_mutex_ is taken by the SERVE PATH
     // (note_arm_decision, :759; the found-block ledger, :1478). Blocking here
@@ -993,8 +1013,16 @@ std::shared_ptr<const coin::DashWorkData> DASHWorkSource::cached_work() const
             if (!template_cache_is_embedded_
                 || coin_state_.embedded_template_emit_ok(*template_cache_))
                 return template_cache_;
+            // Monotonic fire counter: before this, the re-check failure path
+            // was LOG_WARNING-only, so its rate was unmeasurable and every
+            // claim about how often it fires was unfalsifiable. Relaxed
+            // atomic -- a counter, not a synchronization point.
+            serve_recheck_fail_count_.fetch_add(1, std::memory_order_relaxed);
             LOG_WARNING << "[DASH-STRATUM-GBT] cached EMBEDDED template failed "
-                           "serve-time re-check (stale creditPool/roots) — re-sourcing";
+                           "serve-time re-check (stale creditPool/roots) — re-sourcing"
+                           " (fail_count="
+                        << serve_recheck_fail_count_.load(std::memory_order_relaxed)
+                        << ")";
             template_cache_.reset();
         }
 

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -435,6 +435,14 @@ public:
     /// live template (display only; never drives coinbase or consensus).
     std::shared_ptr<const coin::DashWorkData> peek_template() const;
 
+    /// Monotonic count of serve-time embedded re-check FAILURES (cached
+    /// template dropped for stale creditPool/roots). Measurability seam:
+    /// the path was LOG_WARNING-only before, so its fire rate could not be
+    /// observed, which made every claim about it unfalsifiable.
+    uint64_t serve_recheck_fail_count() const {
+        return serve_recheck_fail_count_.load(std::memory_order_relaxed);
+    }
+
     /// Seconds since the cached template was sourced, -1 when none / unknown.
     /// Display only (the dashboard's block_value_age_sec): a template that is
     /// an hour old renders exactly like a live one without this, which is how
@@ -763,6 +771,12 @@ private:
     // the CURRENT coin-state before being served, so a template built with a
     // stale credit-pool seed cannot be served after the seed advances.
     mutable bool                template_cache_is_embedded_{false};
+    // Monotonic fire counter for the serve-time re-check FAILURE path (the
+    // "cached EMBEDDED template failed serve-time re-check" drop above).
+    // Formerly LOG_WARNING-only, so its rate was unmeasurable and any claim
+    // about it unfalsifiable. Read via serve_recheck_fail_count() and
+    // published in embedded_arm_status_json().
+    mutable std::atomic<uint64_t> serve_recheck_fail_count_{0};
     mutable std::chrono::steady_clock::time_point template_last_fail_at_{};
     // Generation the last FAILED sourcing attempt was made against (captured
     // BEFORE the blocking source ran). The negative cache only holds while the

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -984,6 +984,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     #                       mutation case.
     add_executable(test_dash_stratum_work_source
         test_dash_stratum_work_source.cpp
+        test_dash_submit_gate_scaling.cpp
         test_dash_serve_staleness_seam.cpp
         test_dash_serve_staleness_unit.cpp
         ${CMAKE_SOURCE_DIR}/src/impl/dash/coin/zmq_tip_notify.cpp)

--- a/test/test_dash_submit_gate_scaling.cpp
+++ b/test/test_dash_submit_gate_scaling.cpp
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// D1 regression gate — the 2026-08-07/08 hotel freeze (0 of 26 rigs, twice).
+//
+// Root cause (three identical gdb stacks 5 s apart on the live node):
+//   StratumSession::handle_submit -> DASHWorkSource::get_current_gbt_prevhash
+//   -> cached_work() -> NodeCoinState::embedded_template_emit_ok()
+//   -> CSimplifiedMNList::CalcMerkleRoot() -> CSHA256
+// ~17 submits/s x ~2000 masternodes = ~68k SHA256d/s on the single io thread;
+// the stratum recvQ grew 7 -> 62 MB and the served tip froze.
+//
+// THE PIN: a submit-path tip READ (get_current_gbt_prevhash) must be a pure
+// template_mutex_-guarded peek of the cached snapshot — it must NEVER evaluate
+// the serve gate (embedded_template_emit_ok), reset the cache, or re-source.
+// NodeCoinState counts gate EVALUATIONS at the top of emit_ok (before any
+// early return), so the pin holds regardless of whether the gate passes.
+//
+// Constructed RED on the pre-fix master: there, every get_current_gbt_prevhash
+// routed through cached_work()'s fresh-cache branch, which re-evaluates
+// emit_ok on an embedded cache hit — 100 reads == 100 gate evaluations.
+//
+// Builds into the test_dash_stratum_work_source executable (same harness /
+// legacy inline path — no refresh executor wired — as
+// test_dash_stratum_work_source.cpp).
+
+#include <impl/dash/stratum/work_source.hpp>
+
+#include <impl/dash/coin/mn_state_db.hpp>   // MNState (resolvable payee, #996 gate)
+
+#include <core/stratum_work_source.hpp>
+#include <core/uint256.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+// Mirrors the C1-gate fixtures in test_dash_stratum_work_source.cpp (those
+// helpers live in that TU's anonymous namespace, so they are re-stated here):
+// a populated coin-state whose embedded template serves on the testnet arm.
+const char* const kEmbPrevHashHex =
+    "0000000000000000abcdef0123456789abcdef0123456789abcdef0123456789";
+constexpr uint32_t kEmbPrevHeight = 500000u;   // embedded template -> +1
+constexpr uint32_t kCurtime       = 1751000000u;
+constexpr int32_t  kVersion       = 0x20000000;
+
+std::vector<unsigned char> p2pkh_script()
+{
+    std::vector<unsigned char> s = {0x76, 0xa9, 0x14};
+    s.insert(s.end(), 20, 0x11);
+    s.push_back(0x88);
+    s.push_back(0xac);
+    return s;
+}
+
+// #996 fail-closed guard: seed ONE live MN so the embedded arm is genuinely
+// viable (a payee is resolvable at the tip) and the arm under test is the
+// embedded one, not a masked refusal.
+void seed_resolvable_mn(dash::coin::NodeCoinState& cs)
+{
+    dash::coin::MNState mn;
+    mn.isValid           = true;              // eligible (nPoSeBanHeight == 0)
+    mn.nRegisteredHeight = 1;                 // a positive payment-queue slot
+    mn.collateralOutpoint.hash.SetHex(std::string(64, '9'));
+    mn.collateralOutpoint.index = 0;
+    mn.scriptPayout.m_data = p2pkh_script();
+    mn.payoutSplitProvenance = dash::coin::MNState::SPLIT_KNOWN;
+    uint256 protx;
+    protx.SetHex(std::string(64, 'a'));
+    cs.mnstates().load({{protx, mn}}, /*as_of_height=*/kEmbPrevHeight);
+}
+
+void seed_populated(dash::coin::NodeCoinState& cs)
+{
+    uint256 emb_prev;
+    emb_prev.SetHex(kEmbPrevHashHex);
+    cs.set_tip(kEmbPrevHeight, emb_prev, /*bits_for_next=*/0x1e0ffff0u,
+               /*mtp_at_tip=*/1'700'000'000u, /*addr_ver=*/76, /*p2sh_ver=*/16,
+               /*curtime=*/kCurtime, /*version=*/static_cast<uint32_t>(kVersion));
+    seed_resolvable_mn(cs);
+}
+
+}  // namespace
+
+TEST(DashSubmitGateScaling, SubmitPathTipReadNeverEvaluatesServeGate)
+{
+    dash::coin::NodeCoinState cs;
+    seed_populated(cs);
+    ASSERT_TRUE(cs.populated());
+
+    // Empty fallback: the embedded arm must carry the whole serve, and a
+    // silent flip to the dashd arm (where the re-check is exempt by design,
+    // :993) cannot fake a green.
+    auto fallback = []() -> dash::coin::DashWorkData { return {}; };
+    auto submit   = [](const std::vector<unsigned char>&, uint32_t, bool) { return true; };
+
+    // is_testnet=true => embedded arm enabled; no refresh executor wired =>
+    // the legacy inline cached_work() path, same as the rest of this harness.
+    dash::stratum::DASHWorkSource ws(cs, fallback, submit,
+                                     core::stratum::StratumConfig{},
+                                     /*is_testnet=*/true);
+
+    // Prime the cache ONCE through the notify-path getter (this getter is
+    // allowed — required, even — to run the build/serve gates).
+    ASSERT_FALSE(ws.get_current_work_template().empty());
+
+    // Arm sanity: the cached template really is the EMBEDDED one. If this
+    // pinned the fallback arm instead, the re-check would be exempt and the
+    // whole test vacuously green.
+    uint256 emb_prev;
+    emb_prev.SetHex(kEmbPrevHashHex);
+    ASSERT_EQ(ws.get_current_gbt_prevhash(), emb_prev.GetHex());
+
+    // THE PIN: 100 submit-path tip reads, zero serve-gate evaluations.
+    const auto baseline = cs.emit_ok_call_count();
+    for (int i = 0; i < 100; ++i)
+        (void) ws.get_current_gbt_prevhash();
+    EXPECT_EQ(cs.emit_ok_call_count() - baseline, 0u)
+        << "submit-path tip reads must not evaluate the serve gate";
+}


### PR DESCRIPTION
## What changed

`DASHWorkSource::get_current_gbt_prevhash()` (src/impl/dash/stratum/work_source.cpp) is now a **pure `template_mutex_`-guarded peek** of the cached template snapshot — the same shape as `peek_template()`. No serve gate, no `template_cache_.reset()`, no re-source, no `note_served_height` (that sentinel stays exclusively in the two getters through which a height actually leaves the node: `get_current_work_template` and `build_connection_coinbase`). Empty string on a null cache — a truthful set-gap, never a fabricated tip id.

Also in this PR:
- **Monotonic fire counter** on the serve-time re-check failure path (the "cached EMBEDDED template failed serve-time re-check" drop, formerly `LOG_WARNING`-only). Its rate was unmeasurable, which made any claim about it unfalsifiable. Exposed as `serve_recheck_fail_count()` and published as `serve_recheck_fail_count` in `embedded_arm_status_json()` (read lock-free, before the try_lock, so it degrades with the rest of that surface instead of hanging).
- **Regression test** `test/test_dash_submit_gate_scaling.cpp` (built into the existing `test_dash_stratum_work_source` binary, so it is inside the existing CI `--target` allowlist — no new NOT_BUILT sentinel surface). `NodeCoinState` gains `m_emit_ok_calls`, incremented at the very top of `embedded_template_emit_ok` (before any early return) plus an `emit_ok_call_count()` accessor, so the pin holds regardless of whether the gate passes.

## Why

Production freeze, twice (2026-08-07, 2026-08-08): the hotel node went to 0 of 26 rigs. Three gdb stacks 5 s apart on the live node, all identical:

```
StratumSession::handle_submit -> DASHWorkSource::get_current_gbt_prevhash ->
cached_work() -> NodeCoinState::embedded_template_emit_ok() ->
CSimplifiedMNList::CalcMerkleRoot() -> CSHA256
```

The gate re-derives the full SML merkle root: ~17 submits/s x ~2000 masternodes = ~68k SHA256d/s on the single io thread, main thread 100:1 userspace. The stratum recvQ grew 7 -> 62 MB and the served tip froze.

`handle_submit`'s only use of the prevhash is the DOA statistics compare (src/core/stratum_server.cpp, the brace-scoped block guarded by `!current_prevhash.empty()`); its own comment states the share is still created and broadcast regardless — DOA tracking is statistics/dashboard only. A stale peek costs at worst one wrong DOA counter tick, never a wrong share or block.

**Deliberately NOT implemented as "cached_work() minus the gate":** on the production coin-p2p arm `refresh_executor_` is NULL (it is installed only under `!coin_p2p && rpc && stratum_server`, src/c2pool/main_dash.cpp), so a gate-stripped `cached_work` would fall through to the legacy inline path and run `resource_template_now()` on the io thread per submit — recreating the freeze with full template-build cost.

**All four other `cached_work()` callers are untouched, gate intact:** `get_current_work_template`, `get_stratum_merkle_branches`, `build_connection_coinbase`, and the won-block branch of `mining_submit`. The won-block branch especially: its result feeds `check_submit_payee`, the reward-critical local reject of a won block before dispatch; it fires only when `pow_hash <= block_target`, so it contributes nothing to the submit storm.

## The invariant, stated with its real scope

The serve gate invariant is **EMBEDDED-SCOPED**, not universal. "No template enters the cache ungated" is FALSE as worded: the build gate runs ONLY on the embedded selection (the `embedded_template_emit_ok` check inside `resolve_coin_state_arm`); dashd-fallback and gbt-xcheck-swap templates enter the cache WITHOUT `emit_ok`, and the serve-time re-check exempts them by design (`!template_cache_is_embedded_ ||` short-circuit). What this PR preserves: every EMBEDDED template is gated at build, re-checked at serve on the notify/coinbase paths, and the submit-path peek serves only what one of those gated paths already cached.

## Landmine flag (for the coin-p2p executor wiring work)

The executor stale-serve branch of `cached_work()` (the `refresh_executor_` arm that returns `executor_serve` — the current cache, possibly stale — without running the embedded re-check) is **vacuous today**: the executor exists only on the `!coin_p2p` arm, and `CoinStateMaintainer` is constructed only under `if (coin_p2p)`, so an executor-armed node never holds an embedded cache. **Wiring `set_refresh_executor` onto the coin-p2p arm (the daemonless cut) turns that branch into a live ungated embedded-serve window.** Whoever does that wiring must add the embedded re-check (or an equivalent gate) to the executor serve branch first.

Also deliberately NOT done here: no caller introduced for the fused `DASHWorkSource::get_work(WorkJobTargetInputs)` — it has zero production callers and does not run the pre-emit gate on all branches.

## Mutation run and what went red

Test: `DashSubmitGateScaling.SubmitPathTipReadNeverEvaluatesServeGate` — primes the cache once via `get_current_work_template()` (embedded arm, testnet, legacy inline path; log line confirms `arm=EMBEDDED`), snapshots `emit_ok_call_count()`, calls `get_current_gbt_prevhash()` 100 times, requires delta == 0.

- **Mutation (master's behavior restored):** replaced the peek body with the pre-fix `auto wd = cached_work(); ...` routing, rebuilt, ran. **RED**, delta exactly 100:
  ```
  test/test_dash_submit_gate_scaling.cpp:120: Failure
  Expected equality of these values:
    cs.emit_ok_call_count() - baseline
      Which is: 100
      Which is: 0
  submit-path tip reads must not evaluate the serve gate
  [  FAILED  ] DashSubmitGateScaling.SubmitPathTipReadNeverEvaluatesServeGate
  ```
  100 reads -> 100 gate evaluations: exactly the per-submit amplifier from the gdb stacks.
- **Fix restored, rebuilt, ran:** GREEN, delta 0. Full binary: `100 tests from 11 test suites ran. [ PASSED ] 100 tests.` (gcc-13 Release, conan profile `ci/conan/linux-gcc13.profile`).

The test also pins arm identity (`ASSERT_EQ(prevhash, embedded_prev)`) with an EMPTY dashd fallback, so a silent flip to the fallback arm — where the re-check is exempt by design — cannot fake a green.

## Scope honesty

D1 removes the ~17/s per-submit amplifier only. It leaves up to ~3 `emit_ok` evaluations per session per notify — an ESTIMATE from the three `cached_work` calls reachable from `send_notify_work` (template + branches + coinbase), NOT a measurement. This PR does **not** claim to fix the freeze class on its own; the notify-path cost is the follow-up lane's problem (memoization / dead-copy removal).

## Not verified

- No live-node soak: the fix is proven by the unit gate and by code-path reasoning over the gdb stacks, not by re-running 26 rigs against this build.
- The "at worst one wrong DOA tick" claim rests on the DOA block being the only consumer of this getter on the DASH stratum path (verified by grep: `stratum_server.cpp` is the sole core caller; the `MiningInterface` implementation in web_server.cpp is a separate LTC-shaped override, untouched).
- The fire counter's usefulness is asserted, not demonstrated — nothing in this PR makes the re-check fail in production; the existing `EmbeddedCacheHitReValidatesCreditPoolAndReSources` test exercises the path (and stays green), but I did not add a dedicated assertion on the counter value.
