### PR TITLE
dash: memoize both committed roots at NodeCoinState level, epoch-invalidated

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -140,6 +140,7 @@
 #include <cstdint>
 #include <cctype>       // std::tolower (--replay-utxo-expect normalize)
 #include <cstdlib>      // std::getenv
+#include <utility>      // std::as_const (qc-plan lambda: read-only qmgr access)
 #include <cstring>
 #include <fstream>
 #include <iostream>
@@ -4372,9 +4373,15 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 (uint32_t next_h) -> std::optional<dash::coin::QcBlockPlan> {
                     if (*qc_first_plan_h == 0u) *qc_first_plan_h = next_h;
                     // Observe the MINED set at the tip we are building on.
+                    // D2 root memo: this lambda runs INSIDE emit_ok on the
+                    // serve path. Reads of qmgr() here must go through the
+                    // CONST accessor — the non-const one bumps the root-memo
+                    // epoch (it hands out a mutable reference) and would
+                    // re-chill the memo on every single gate evaluation,
+                    // silently reinstating the recompute the memo removes.
                     if (next_h > 0)
                         qc_type_recon->observe(next_h - 1u,
-                                               node_coin_state.qmgr());
+                                               std::as_const(node_coin_state).qmgr());
                     // Log when the DEFECT SHAPE changes — a new offending
                     // type must never be swallowed by dedup on an old one —
                     // and otherwise at most once per 5 minutes, carrying the
@@ -4406,7 +4413,7 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     }
                     dash::coin::RequiredQcSlot gap{};
                     auto plan = dash::coin::build_daemonless_qc_plan(
-                        qc_net, next_h, node_coin_state.qmgr(),
+                        qc_net, next_h, std::as_const(node_coin_state).qmgr(),
                         [hc](uint32_t h) -> std::optional<uint256> {
                             if (auto e = hc->get_header_by_height(h))
                                 return e->hash;
@@ -4550,7 +4557,7 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                             const bool ep_cache_has = qc_cache->has_commitment(
                                 slot->llmq_type, slot->quorum_hash);
                             const bool ep_mined =
-                                node_coin_state.qmgr()
+                                std::as_const(node_coin_state).qmgr()
                                     .find(slot->llmq_type, slot->quorum_hash)
                                     .has_value();
                             if (auto ended = qc_episode->observe_derivable(

--- a/src/impl/dash/coin/embedded_gbt.hpp
+++ b/src/impl/dash/coin/embedded_gbt.hpp
@@ -985,12 +985,16 @@ inline vendor::CCbTx build_embedded_cbtx(
     vendor::CCbTx c;
     c.nVersion           = vendor::CCbTx::VERSION_CLSIG_AND_BALANCE;
     c.nHeight            = static_cast<int32_t>(prev_height + 1);
-    // CalcMerkleRoot() caches upstream; take a mutable copy to call
-    // into it without breaking const-correctness of the caller. The
-    // cost is one ~450 KB SML vector copy per 5s shadow tick — within
-    // budget for log-only validation.
-    auto sml_mut = sml;
-    c.merkleRootMNList   = sml_mut.CalcMerkleRoot();
+    // CalcMerkleRoot() is const and does NOT cache — every call hashes the
+    // full list (~2000 x SHA256d on mainnet). A prior comment here claimed
+    // "CalcMerkleRoot() caches upstream" and budgeted the ~450 KB copy it
+    // took to call it "per 5s shadow tick"; BOTH clauses were false — this
+    // builder runs on the live serve path, and that assumed-cheap root
+    // recompute is the class behind the 2026-08-07/08 hotel freeze (26
+    // rigs -> 0, twice). The serve-time re-derivations are memoized at
+    // NodeCoinState level (root-memo epoch); this build-time call runs once
+    // per template build, directly on the caller's list, no copy.
+    c.merkleRootMNList   = sml.CalcMerkleRoot();
     c.merkleRootQuorums  = quorum_root_override
         ? *quorum_root_override
         : compute_merkle_root_quorums(qmgr);

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -137,7 +137,22 @@ public:
 
     // Mutable accessors for the maintainer (the reception / think slices seed
     // these from mnlistdiff + relayed mempool txs).
-    MnStateMachine& mnstates() { return m_mnstates; }
+    //
+    // D2 (2026-08-07/08 hotel freeze, remaining half of the class): handing
+    // out a MUTABLE reference to any input of the two committed-root
+    // computations bumps the root-memo epoch — the caller MAY mutate, and a
+    // memoized root that survives a mutation is a WRONG BLOCK
+    // (bad-cbtx-mnmerkleroot / bad-cbtx-quorummerkleroot, silently lost).
+    // Over-invalidation on a read-through-non-const access only costs one
+    // recompute; under-invalidation costs a block — so the bump rides the
+    // accessor, not the callers' discipline. Read-only callers on the
+    // emit-ok hot path must use the const accessors (std::as_const at the
+    // main_dash qc-plan sites) or they re-chill the memo every evaluation.
+    // mnstates() bumps too: the confirmation-pass projection reads MN
+    // registration heights from it (sml_projection.hpp).
+    MnStateMachine& mnstates() { bump_root_memo_epoch(); return m_mnstates; }
+    // Mempool contents feed the template TX SET, not either committed root —
+    // no epoch bump (a per-tx bump would chill the memo for nothing).
     Mempool&        mempool()  { return m_mempool; }
 
     // ── SML / quorum consensus-commitment state (daemonless CCbTx) ────────
@@ -150,10 +165,19 @@ public:
     // from the last root-verified state and requests an INCREMENTAL
     // mnlistdiff(persisted-tip, tip) rather than a cold mnlistdiff(zero, tip);
     // a corrupt/stale store fails closed to the cold path.
-    vendor::CSimplifiedMNList& sml() { return m_sml; }
-    QuorumManager&             qmgr() { return m_qmgr; }
+    // Non-const access == possible mutation == root-memo epoch bump (see the
+    // mnstates() note above; same rule, same failure mode).
+    vendor::CSimplifiedMNList& sml() { bump_root_memo_epoch(); return m_sml; }
+    QuorumManager&             qmgr() { bump_root_memo_epoch(); return m_qmgr; }
     const vendor::CSimplifiedMNList& sml() const { return m_sml; }
     const QuorumManager&             qmgr() const { return m_qmgr; }
+
+    /// Root-memo mutation epoch (D2). Bumped by every non-const accessor /
+    /// setter whose target feeds the projected-SML root or the quorum root; a
+    /// cached root is valid only while its epoch matches. All mutators run on
+    /// the single-threaded ioc, so a plain uint64 needs no lock — do not add
+    /// one. Exposed read-only as a test seam.
+    uint64_t root_memo_epoch() const { return m_root_memo_epoch; }
 
     /// Mark whether a valid SML is present (set by the maintainer after the
     /// first accepted mnlistdiff yields a non-empty list). When require_sml
@@ -316,7 +340,10 @@ public:
     /// pre-emit root re-check. main_dash sets the testnet value next to
     /// set_mn_rr_height; the mainnet default keeps every existing caller
     /// byte-unchanged.
-    void set_mn_min_confirmations(int c) { m_mn_min_confirmations = c; }
+    void set_mn_min_confirmations(int c) {
+        bump_root_memo_epoch();   // D2: projection threshold input
+        m_mn_min_confirmations = c;
+    }
     int mn_min_confirmations() const { return m_mn_min_confirmations; }
 
     /// HEADER-SYNC gate (the DASH half of a cross-lane asymmetry: bch 13, ltc
@@ -388,6 +415,10 @@ public:
                  uint32_t bits_for_next, uint32_t mtp_at_tip,
                  uint8_t address_version, uint8_t address_p2sh_version,
                  uint32_t curtime = 0, uint32_t version = 0) {
+        // D2: prev_height/prev_hash are inputs of the confirmation-pass
+        // projection (confirmations = prev_height - reg_height; confirmedHash
+        // = prev_hash), so a tip move invalidates the memoized projected root.
+        bump_root_memo_epoch();
         m_prev_height          = prev_height;
         m_prev_hash            = prev_hash;
         m_bits_for_next        = bits_for_next;
@@ -1062,24 +1093,56 @@ public:
         // is unprojectable (a null-confirmedHash entry with no known
         // registration height — at most ~nMasternodeMinimumConfirmations
         // blocks per unknown registration).
-        auto proj = project_sml_confirmations(m_sml, m_prev_height, m_prev_hash,
-                                              m_mnstates,
-                                              m_mn_min_confirmations);
-        if (!proj.ok)
-            return reject("emit-mn-confirm-rollover-pending",
-                          "protx=" + proj.unprojectable_protx.GetHex().substr(0, 12),
-                          "known-registration-height");
-        if (cb.merkleRootMNList != proj.sml.CalcMerkleRoot())
+        //
+        // D2 (2026-08-07/08 hotel freeze, remaining half of the class): the
+        // projection returns a FRESH ~450 KB copy of the SML by value and its
+        // root was re-hashed (~2000 x SHA256d) on EVERY evaluation — ~3 per
+        // session per notify on the single io thread even after D1 removed
+        // the per-share amplifier. Both the projected root and the quorum
+        // root below are memoized at THIS level (per-NodeCoinState, epoch-
+        // invalidated), because a memo on the per-call projection object is
+        // cold by construction — that dead-end is what the deleted
+        // "CalcMerkleRoot() caches upstream" comment in embedded_gbt.hpp
+        // wrongly assumed. On an epoch match the projection copy itself is
+        // skipped, not just the hashing. WHERE-and-HOW-OFTEN only: the
+        // memoized value is byte-identical to the fresh computation
+        // (test_dash_root_memo.cpp T3), and any epoch bump forces a full
+        // recompute (T2 — a memo that never invalidates serves a stale root,
+        // which is a silently LOST BLOCK, strictly worse than the freeze).
+        if (!(m_sml_root_memo_valid
+              && m_sml_root_memo_epoch == m_root_memo_epoch)) {
+            auto proj = project_sml_confirmations(m_sml, m_prev_height,
+                                                  m_prev_hash, m_mnstates,
+                                                  m_mn_min_confirmations);
+            if (!proj.ok)   // NOT memoized: fail-closed stays re-evaluated
+                return reject("emit-mn-confirm-rollover-pending",
+                              "protx=" + proj.unprojectable_protx.GetHex().substr(0, 12),
+                              "known-registration-height");
+            m_sml_root_memo       = proj.sml.CalcMerkleRoot();
+            m_sml_root_memo_epoch = m_root_memo_epoch;
+            m_sml_root_memo_valid = true;
+        }
+        if (cb.merkleRootMNList != m_sml_root_memo)
             return reject("emit-mnlist-root-drift",
                           cb.merkleRootMNList.GetHex().substr(0, 12),
-                          proj.sml.CalcMerkleRoot().GetHex().substr(0, 12));
+                          m_sml_root_memo.GetHex().substr(0, 12));
         // E1: under a qc plan the committed root must be the WITH-BLOCK root
         // (fold of the plan's commitments over the active set — equal to the
         // plain root while the plan is all-null, diverging only once Phase L
-        // serves real commitments). Without a plan, the plain PROVEN root.
+        // serves real commitments). Without a plan, the plain PROVEN root —
+        // memoized on the same epoch (D2: compute_merkle_root_quorums
+        // re-serializes and SHA256d's every active commitment per call, the
+        // second unmemoized root on this same path).
+        if (!qc_plan
+            && !(m_quorum_root_memo_valid
+                 && m_quorum_root_memo_epoch == m_root_memo_epoch)) {
+            m_quorum_root_memo       = compute_merkle_root_quorums(m_qmgr);
+            m_quorum_root_memo_epoch = m_root_memo_epoch;
+            m_quorum_root_memo_valid = true;
+        }
         const uint256 expected_quorum_root = qc_plan
             ? qc_plan->merkle_root_quorums
-            : compute_merkle_root_quorums(m_qmgr);
+            : m_quorum_root_memo;
         if (cb.merkleRootQuorums != expected_quorum_root)
             return reject("emit-quorum-root-drift",
                           cb.merkleRootQuorums.GetHex().substr(0, 12),
@@ -1554,6 +1617,23 @@ private:
         if (!sched) return SuperblockDisposition{false, {}};
         return SuperblockDisposition{true, std::move(*sched)};
     }
+
+    // D2 root memo (2026-08-07/08 hotel freeze, remaining half of the class).
+    // The epoch is bumped by every non-const accessor / setter whose target
+    // feeds either committed root (sml()/qmgr()/mnstates()/set_tip()/
+    // set_mn_min_confirmations()); the cached roots are valid only while
+    // their captured epoch matches. Single-threaded ioc => plain uint64, no
+    // lock (same discipline as every other member here). The cached values
+    // are mutable because embedded_template_emit_ok() is const — same
+    // pattern as m_emit_ok_calls below.
+    void bump_root_memo_epoch() { ++m_root_memo_epoch; }
+    uint64_t m_root_memo_epoch{0};
+    mutable bool     m_sml_root_memo_valid{false};
+    mutable uint64_t m_sml_root_memo_epoch{0};
+    mutable uint256  m_sml_root_memo;         // projected-SML merkle root
+    mutable bool     m_quorum_root_memo_valid{false};
+    mutable uint64_t m_quorum_root_memo_epoch{0};
+    mutable uint256  m_quorum_root_memo;      // plain active-set quorum root
 
     MnStateMachine m_mnstates;
     Mempool        m_mempool;

--- a/src/impl/dash/coin/quorum_root.hpp
+++ b/src/impl/dash/coin/quorum_root.hpp
@@ -49,6 +49,18 @@
 namespace dash {
 namespace coin {
 
+/// TEST SEAM (D2 root-memo regression gates, the 2026-08-07/08 hotel freeze
+/// class): process-wide count of FULL quorum-root computations (each one
+/// re-serializes + SHA256d's every active commitment). Mirrors
+/// vendor::sml_calc_merkle_root_count() — the memo tests count the actual
+/// hashing work, not calls to a wrapper. Single io-thread discipline:
+/// plain uint64, no atomics.
+inline uint64_t& quorum_root_compute_count()
+{
+    static uint64_t n = 0;
+    return n;
+}
+
 inline bool llmq_uses_rotation(uint8_t llmqType)
 {
     // Mainnet rotation flags: types 5 (LLMQ_60_75) and 6 (LLMQ_25_67).
@@ -114,6 +126,7 @@ inline uint256 compute_merkle_root_quorums(const QuorumManager& qmgr)
     // members), this yields dashd's committed merkleRootQuorums
     // (test_dash_mnlistdiff_root_parity.cpp). The earlier per-index dedup of
     // rotated types dropped ring-member leaves and diverged (bad-cbtx).
+    ++quorum_root_compute_count();   // D2 test seam
     std::vector<uint256> vec_hashes_final;
     vec_hashes_final.reserve(qmgr.active_entries().size());
     for (const auto& e : qmgr.active_entries()) {

--- a/src/impl/dash/coin/vendor/simplifiedmns.hpp
+++ b/src/impl/dash/coin/vendor/simplifiedmns.hpp
@@ -227,6 +227,19 @@ struct CSimplifiedMNListEntry
     }
 };
 
+// TEST SEAM (D2 root-memo regression gates, the 2026-08-07/08 hotel freeze
+// class): process-wide count of FULL SML merkle-root computations. The memo
+// tests count the actual hashing work — not calls to some wrapper a future
+// refactor could bypass — so a memo defeated by hashing a fresh per-call
+// object (the exact defect that made the first CalcMerkleRoot-level memo
+// worthless) still shows up as a scaling hash count. Single io-thread
+// discipline (same as NodeCoinState): plain uint64, no atomics.
+inline uint64_t& sml_calc_merkle_root_count()
+{
+    static uint64_t n = 0;
+    return n;
+}
+
 // Holds the CURRENT SML at a given block. Entries are kept sorted by
 // proRegTxHash ascending — required for both equality comparisons and
 // for the merkle-root calculation to match dashcore bit-for-bit.
@@ -267,6 +280,8 @@ public:
 
     uint256 CalcMerkleRoot() const
     {
+        ++sml_calc_merkle_root_count();   // D2 test seam — counted even for
+                                          // the empty case: a call is a call
         if (mnList.empty()) return uint256::ZERO;
         std::vector<uint256> leaves;
         leaves.reserve(mnList.size());

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -805,6 +805,13 @@ if (BUILD_TESTING AND GTest_FOUND)
         test_dash_embedded_shadow_compare.cpp
         test_dash_mn_confirm_rollover.cpp
         test_dash_collateral_spend_filter.cpp
+        # test_dash_root_memo.cpp: D2 of the 2026-08-07/08 hotel freeze —
+        # NodeCoinState-level memo of the projected-SML root + quorum root
+        # (epoch-invalidated). Pins: warm emit_ok does no hashing (T1),
+        # any SML/quorum mutation invalidates (T2 — the stale-root/lost-
+        # block pin), memoized == fresh byte-for-byte (T3). Folded here per
+        # the same #769 rule as the rollover suite above.
+        test_dash_root_memo.cpp
         # test_dash_operator_split.cpp: incident h=2516595 bad-cb-payee — the
         # MN operator-reward split KATs (builder dual-output + serve-gate
         # cause=mn-payout-split-unprovable + ResetOperatorFields mirror +

--- a/test/test_dash_root_memo.cpp
+++ b/test/test_dash_root_memo.cpp
@@ -1,0 +1,387 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/// D2 root memo — the REMAINING half of the 2026-08-07/08 hotel freeze class
+/// (26 rigs -> 0, twice). D1 (test_dash_submit_gate_scaling.cpp) took the
+/// serve gate off the per-share submit path; this suite pins that the gate
+/// itself no longer re-hashes the world on every evaluation that remains
+/// (~3 emit_ok per session per notify: ~78 per notify_all at 26 sessions).
+///
+/// WHY THE MEMO LIVES ON NodeCoinState AND NOT ON CalcMerkleRoot: emit_ok
+/// does not hash the STORED SML. project_sml_confirmations returns a fresh
+/// ~450 KB CSimplifiedMNList BY VALUE and the root was computed on THAT
+/// per-call object — so a per-object cache is cold on every call by
+/// construction. The memo must sit one level up, keyed by a mutation epoch
+/// on the owning NodeCoinState, and on a hit it skips the projection copy
+/// itself, not just the hashing.
+///
+/// THE THREE PINS, in order of what they cost when wrong:
+///   T2 (stale serve = LOST BLOCK): a mutation of the SML or the quorum set
+///      must invalidate the memo — a memo that never invalidates passes T1
+///      forever while silently serving a bad-cbtx root on a winning share.
+///   T3 (byte identity): the memoized root is byte-identical to the freshly
+///      computed one — WHERE-and-HOW-OFTEN only, never WHAT.
+///   T1 (the freeze): repeated emit_ok at a fixed epoch must not scale the
+///      hash work with the call count.
+///
+/// The counters are on the ACTUAL hashing (vendor CalcMerkleRoot entry /
+/// compute_merkle_root_quorums entry), not on a wrapper — so a memo defeated
+/// by hashing a fresh per-call object (the exact dead-end above) still shows
+/// up as a scaling count.
+///
+/// Constructed RED on pre-memo master: there, 100 warm emit_ok evaluations
+/// cost 100 full SML-root computations + 100 full quorum-root computations
+/// (measured by these counters); with the memo both deltas are 0.
+///
+/// Fixture mirrors test_dash_mn_confirm_rollover.cpp (helpers live in that
+/// TU's anonymous namespace, so they are re-stated here) and the quorum
+/// entries mirror test_dash_quorum_root.cpp's make_entry.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/embedded_gbt.hpp>
+#include <impl/dash/coin/sml_projection.hpp>
+#include <impl/dash/coin/mn_state_machine.hpp>
+#include <impl/dash/coin/mn_state_db.hpp>
+#include <impl/dash/coin/mempool.hpp>
+#include <impl/dash/coin/node_coin_state.hpp>
+#include <impl/dash/coin/quorum_manager.hpp>
+#include <impl/dash/coin/quorum_root.hpp>
+#include <impl/dash/coin/vendor/cbtx.hpp>
+#include <impl/dash/coin/vendor/llmq_commitment.hpp>
+#include <impl/dash/coin/vendor/simplifiedmns.hpp>
+
+#include <core/uint256.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <utility>
+#include <vector>
+
+using dash::coin::DashWorkData;
+using dash::coin::DeclineReport;
+using dash::coin::MNState;
+using dash::coin::NodeCoinState;
+using dash::coin::QuorumManager;
+using dash::coin::build_embedded_cbtx;
+using dash::coin::compute_merkle_root_local;
+using dash::coin::compute_merkle_root_quorums;
+using dash::coin::encode_cbtx;
+using dash::coin::hash_commitment;
+using dash::coin::quorum_root_compute_count;
+using dash::coin::DASH_MN_MIN_CONFIRMATIONS_MAINNET;
+using dash::coin::vendor::CCbTx;
+using dash::coin::vendor::CFinalCommitment;
+using dash::coin::vendor::CSimplifiedMNList;
+using dash::coin::vendor::CSimplifiedMNListEntry;
+using dash::coin::vendor::parse_cbtx;
+using dash::coin::vendor::sml_calc_merkle_root_count;
+
+namespace {
+
+// Dash mainnet base58 version bytes (chainparams.cpp PUBKEY_ADDRESS=76,
+// SCRIPT_ADDRESS=16) — same constants the rollover suite uses.
+constexpr uint8_t DASH_PUBKEY_VER = 76;
+constexpr uint8_t DASH_P2SH_VER   = 16;
+
+// Template height well past V20 + MN_RR, matching mainnet steady state
+// (same H as the rollover suite: proven outside every height-class refusal).
+constexpr uint32_t H = 2'400'000;
+
+uint256 raw256(uint8_t base) {
+    uint256 h;
+    for (size_t i = 0; i < 32; ++i)
+        h.data()[i] = static_cast<uint8_t>(base + i);
+    return h;
+}
+
+std::vector<unsigned char> p2pkh_script(uint8_t hashseed) {
+    std::vector<unsigned char> s;
+    s.push_back(0x76); s.push_back(0xa9); s.push_back(0x14);
+    for (int i = 0; i < 20; ++i)
+        s.push_back(static_cast<unsigned char>(hashseed + i));
+    s.push_back(0x88); s.push_back(0xac);
+    return s;
+}
+
+CSimplifiedMNListEntry sml_entry(const uint256& protx,
+                                 const uint256& confirmed) {
+    CSimplifiedMNListEntry e;
+    e.nVersion      = CSimplifiedMNListEntry::VER_BASIC_BLS;
+    e.proRegTxHash  = protx;
+    e.confirmedHash = confirmed;
+    e.netPort       = 9999;
+    e.isValid       = true;
+    return e;
+}
+
+MNState mn_state(uint32_t reg_height,
+                 const std::vector<unsigned char>& payout) {
+    MNState s;
+    s.isValid             = true;
+    s.nRegisteredHeight   = reg_height;
+    s.nLastPaidHeight     = 0;
+    s.scriptPayout.m_data = payout;
+    s.payoutSplitProvenance = MNState::SPLIT_KNOWN;
+    return s;
+}
+
+// A fully-specified non-indexed (v1) commitment, distinguishable by its
+// serialized bytes (mirror of test_dash_quorum_root.cpp::make_commitment).
+CFinalCommitment make_commitment(uint8_t llmqType, unsigned char hash_seed,
+                                 int16_t quorumIndex) {
+    CFinalCommitment c;
+    c.nVersion = CFinalCommitment::LEGACY_BLS_NON_INDEXED_QUORUM_VERSION;
+    c.llmqType = llmqType;
+    for (int i = 0; i < 32; ++i) c.quorumHash.data()[i] = hash_seed;
+    c.quorumIndex = quorumIndex;
+    c.signers.assign(8, false);
+    c.validMembers.assign(8, true);
+    return c;
+}
+
+QuorumManager::Entry make_entry(uint8_t llmqType, unsigned char hash_seed,
+                                int16_t quorumIndex, uint32_t mining_height) {
+    QuorumManager::Entry e;
+    e.commitment = make_commitment(llmqType, hash_seed, quorumIndex);
+    e.key = QuorumManager::ActiveKey{llmqType, e.commitment.quorumHash};
+    e.mining_height = mining_height;
+    return e;
+}
+
+// The shared fixture: two MNs (MN2's registration height parameterized so a
+// test can choose a below-threshold or crossing shape), a non-empty quorum
+// set, and a NodeCoinState wired exactly as the rollover suite's passing
+// emit-gate test wires it.
+struct Rig {
+    uint256 protx1 = raw256(0x01);
+    uint256 protx2 = raw256(0x02);
+    uint256 prev_hash = raw256(0xAB);
+    uint32_t prev_height = H - 1;
+    CSimplifiedMNList sml;
+    NodeCoinState st;
+
+    explicit Rig(uint32_t mn2_reg_height) {
+        std::vector<CSimplifiedMNListEntry> entries;
+        entries.push_back(sml_entry(protx1, raw256(0x77)));  // long confirmed
+        entries.push_back(sml_entry(protx2, uint256()));     // awaiting rollover
+        sml = CSimplifiedMNList(std::move(entries));
+
+        st.set_require_sml(true);
+        st.sml() = sml;
+        st.set_have_sml(true);
+        st.set_sml_current_hash(prev_hash);
+        st.mnstates().load(
+            {{protx1, mn_state(2'300'000, p2pkh_script(0x30))},
+             {protx2, mn_state(mn2_reg_height, p2pkh_script(0x44))}},
+            prev_height);
+        std::vector<QuorumManager::Entry> active;
+        active.push_back(make_entry(CFinalCommitment::LLMQ_400_60, 0x22, 0, 90));
+        active.push_back(make_entry(CFinalCommitment::LLMQ_100_67, 0x33, 0, 95));
+        st.qmgr().replace_state(std::move(active), {});
+        st.set_tip(prev_height, prev_hash, 0x1b104be3u, 1'700'000'000u,
+                   DASH_PUBKEY_VER, DASH_P2SH_VER);
+    }
+
+    // A template committing the CURRENT expected values: root of `list`
+    // (caller passes the projected list where projection is non-identity)
+    // + the plain quorum root over the CURRENT active set.
+    DashWorkData template_committing(const CSimplifiedMNList& list) {
+        DashWorkData w;
+        CCbTx cb = build_embedded_cbtx(prev_height, list,
+                                       std::as_const(st).qmgr(),
+                                       0, std::array<uint8_t, 96>{}, 0,
+                                       nullptr);
+        w.m_coinbase_payload = encode_cbtx(cb);
+        return w;
+    }
+
+    // INDEPENDENT quorum-root reference (mirror of the rollover suite's
+    // oracle discipline): re-derive the leaf set + sort + merkle by hand,
+    // never through the emit gate under test.
+    uint256 reference_quorum_root() const {
+        std::vector<uint256> leaves;
+        for (const auto& e : std::as_const(st).qmgr().active_entries())
+            leaves.push_back(hash_commitment(e.commitment));
+        std::sort(leaves.begin(), leaves.end(),
+                  [](const uint256& a, const uint256& b) {
+                      return std::memcmp(a.data(), b.data(), 32) < 0;
+                  });
+        return compute_merkle_root_local(std::move(leaves));
+    }
+};
+
+// Below-threshold registration: the confirmation-pass projection is the
+// identity, so the raw tip SML is exactly what a valid template commits.
+constexpr uint32_t BELOW_THRESHOLD_REG = H - DASH_MN_MIN_CONFIRMATIONS_MAINNET;
+// Crossing registration: the projection flips MN2's confirmedHash, so the
+// committed root differs from the raw tip root (projection non-identity).
+constexpr uint32_t CROSSING_REG = H - 1 - DASH_MN_MIN_CONFIRMATIONS_MAINNET;
+
+}  // namespace
+
+// ── T1 — the freeze pin: hash work must not scale with emit_ok calls ─────
+//
+// RED on pre-memo master by construction: every evaluation re-projected the
+// SML (fresh ~450 KB copy), re-hashed its ~full-list merkle root AND
+// re-serialized + re-hashed every active quorum commitment. 100 warm calls
+// == 100 + 100 full root computations there; == 0 + 0 here.
+TEST(DashRootMemo, WarmEmitOkDoesNotScaleHashWorkWithCallCount)
+{
+    Rig rig(BELOW_THRESHOLD_REG);
+    auto w = rig.template_committing(rig.sml);
+
+    DeclineReport why;
+    ASSERT_TRUE(rig.st.embedded_template_emit_ok(w, &why))
+        << "fixture must PASS the gate or the scaling loop below never "
+        << "reaches the root checks (cause=" << why.cause
+        << " value=" << why.value << ")";
+
+    const uint64_t sml_before    = sml_calc_merkle_root_count();
+    const uint64_t quorum_before = quorum_root_compute_count();
+    constexpr int N = 100;
+    for (int i = 0; i < N; ++i)
+        ASSERT_TRUE(rig.st.embedded_template_emit_ok(w, nullptr));
+    const uint64_t sml_delta    = sml_calc_merkle_root_count() - sml_before;
+    const uint64_t quorum_delta = quorum_root_compute_count() - quorum_before;
+
+    EXPECT_EQ(sml_delta, 0u)
+        << N << " warm emit_ok evaluations performed " << sml_delta
+        << " full SML merkle-root computations — the memo is cold or "
+        << "defeated (pre-memo master measures " << N << " here)";
+    EXPECT_EQ(quorum_delta, 0u)
+        << N << " warm emit_ok evaluations performed " << quorum_delta
+        << " full quorum-root computations — the memo is cold or defeated "
+        << "(pre-memo master measures " << N << " here)";
+}
+
+// ── T2 — the pin that matters MORE than the freeze: invalidation ─────────
+//
+// A memo that never invalidates passes T1 and silently approves a STALE
+// root after the state moves — on a winning share that is a consensus-
+// invalid block (bad-cbtx-mnmerkleroot / -quorummerkleroot), silently lost.
+// Proven red by removing the epoch bump from the non-const accessors.
+TEST(DashRootMemo, SmlMutationInvalidatesMemoizedRoot)
+{
+    Rig rig(BELOW_THRESHOLD_REG);
+    auto stale = rig.template_committing(rig.sml);
+
+    // Warm the memo on the pre-mutation state.
+    DeclineReport why;
+    ASSERT_TRUE(rig.st.embedded_template_emit_ok(stale, &why))
+        << "cause=" << why.cause << " value=" << why.value;
+
+    // Mutate the SML through the SAME mutable accessor every production
+    // writer uses (apply_diff, warm-restart load, reorg wipe). netPort is an
+    // SML-hashed field: the true committed root changes.
+    const uint64_t epoch_before = rig.st.root_memo_epoch();
+    rig.st.sml().mnList[0].netPort = 12345;
+    EXPECT_GT(rig.st.root_memo_epoch(), epoch_before)
+        << "handing out a mutable SML reference must bump the memo epoch";
+
+    // The template committing the PRE-mutation root must now be REJECTED —
+    // a stale memo would keep approving it.
+    EXPECT_FALSE(rig.st.embedded_template_emit_ok(stale, &why))
+        << "emit_ok approved the PRE-mutation root after an SML mutation: "
+        << "the memo served a stale root (this is a silently lost block)";
+    EXPECT_EQ(why.cause, std::string("emit-mnlist-root-drift"));
+
+    // And the template committing the POST-mutation root must PASS —
+    // proving the gate recomputed the real new value, not just "something
+    // changed".
+    CSimplifiedMNList mutated = rig.sml;
+    mutated.mnList[0].netPort = 12345;
+    auto fresh = rig.template_committing(mutated);
+    EXPECT_TRUE(rig.st.embedded_template_emit_ok(fresh, &why))
+        << "cause=" << why.cause << " value=" << why.value;
+}
+
+TEST(DashRootMemo, QuorumMutationInvalidatesMemoizedRoot)
+{
+    Rig rig(BELOW_THRESHOLD_REG);
+    auto stale = rig.template_committing(rig.sml);
+
+    DeclineReport why;
+    ASSERT_TRUE(rig.st.embedded_template_emit_ok(stale, &why))
+        << "cause=" << why.cause << " value=" << why.value;
+
+    // Mutate the quorum set through the same mutable accessor the
+    // maintainer's diff-apply path uses.
+    const uint64_t epoch_before = rig.st.root_memo_epoch();
+    std::vector<QuorumManager::Entry> active;
+    active.push_back(make_entry(CFinalCommitment::LLMQ_400_60, 0x22, 0, 90));
+    active.push_back(make_entry(CFinalCommitment::LLMQ_100_67, 0x33, 0, 95));
+    active.push_back(make_entry(CFinalCommitment::LLMQ_400_85, 0x55, 0, 99));
+    rig.st.qmgr().replace_state(std::move(active), {});
+    EXPECT_GT(rig.st.root_memo_epoch(), epoch_before)
+        << "handing out a mutable QuorumManager reference must bump the "
+        << "memo epoch";
+
+    EXPECT_FALSE(rig.st.embedded_template_emit_ok(stale, &why))
+        << "emit_ok approved the PRE-mutation quorum root after the active "
+        << "set changed: the memo served a stale root";
+    EXPECT_EQ(why.cause, std::string("emit-quorum-root-drift"));
+
+    auto fresh = rig.template_committing(rig.sml);
+    EXPECT_TRUE(rig.st.embedded_template_emit_ok(fresh, &why))
+        << "cause=" << why.cause << " value=" << why.value;
+}
+
+// ── T3 — byte identity: the memo changes WHERE/HOW OFTEN, never WHAT ─────
+//
+// Uses the CROSSING shape so the memoized value is the non-trivial
+// PROJECTED root (the projection actually flips a confirmedHash) and both
+// references are re-derived independently of the gate (rollover-suite
+// oracle discipline: hand-copied list, hand-derived quorum leaves).
+TEST(DashRootMemo, MemoizedRootsAreByteIdenticalToIndependentReference)
+{
+    Rig rig(CROSSING_REG);
+
+    // Independent references.
+    CSimplifiedMNList projected_ref = rig.sml;
+    for (auto& e : projected_ref.mnList)
+        if (e.proRegTxHash == rig.protx2) e.confirmedHash = rig.prev_hash;
+    const uint256 ref_sml_root    = projected_ref.CalcMerkleRoot();
+    const uint256 ref_quorum_root = rig.reference_quorum_root();
+    ASSERT_NE(ref_sml_root, CSimplifiedMNList(rig.sml).CalcMerkleRoot())
+        << "fixture defect: the projection must be non-identity here or the "
+        << "test cannot tell the projected root from the tip root";
+
+    // A template committing exactly the references must pass COLD...
+    auto good = rig.template_committing(projected_ref);
+    {
+        CCbTx cb;
+        ASSERT_TRUE(parse_cbtx(good.m_coinbase_payload, cb));
+        ASSERT_EQ(cb.merkleRootMNList, ref_sml_root);
+        ASSERT_EQ(cb.merkleRootQuorums, ref_quorum_root);
+    }
+    DeclineReport why;
+    EXPECT_TRUE(rig.st.embedded_template_emit_ok(good, &why))
+        << "cold: cause=" << why.cause << " value=" << why.value;
+    // ...and WARM (the memoized compare against the same reference bytes),
+    // without any further hashing.
+    const uint64_t sml_before    = sml_calc_merkle_root_count();
+    const uint64_t quorum_before = quorum_root_compute_count();
+    EXPECT_TRUE(rig.st.embedded_template_emit_ok(good, &why))
+        << "warm: cause=" << why.cause << " value=" << why.value;
+    EXPECT_EQ(sml_calc_merkle_root_count() - sml_before, 0u);
+    EXPECT_EQ(quorum_root_compute_count() - quorum_before, 0u);
+
+    // A template with a flipped SML root must be rejected ON THE WARM PATH,
+    // and the gate's own expected value (why.threshold) must name the
+    // reference root — byte-for-byte the same first 12 hex digits the
+    // decline report carries. If the memo changed WHAT we serve, this is
+    // where it shows.
+    DashWorkData bad = good;
+    {
+        CCbTx cb;
+        ASSERT_TRUE(parse_cbtx(bad.m_coinbase_payload, cb));
+        cb.merkleRootMNList.data()[0] ^= 0x01;
+        bad.m_coinbase_payload = encode_cbtx(cb);
+    }
+    EXPECT_FALSE(rig.st.embedded_template_emit_ok(bad, &why));
+    EXPECT_EQ(why.cause, std::string("emit-mnlist-root-drift"));
+    EXPECT_EQ(why.threshold, ref_sml_root.GetHex().substr(0, 12))
+        << "the memoized expected root drifted from the independently "
+        << "computed reference";
+}


### PR DESCRIPTION
Remaining half of the 2026-08-07/08 hotel freeze fix (0 of 26 rigs, twice). #1188 took the serve gate off the per-share submit path; this closes the class itself.

## What was still burning after #1188

~3 `emit_ok` evaluations per session per notify remain (~78 per `notify_all` at 26 sessions), and each one:

1. re-projected the SML — `project_sml_confirmations` returns a fresh ~450 KB `CSimplifiedMNList` **by value**;
2. re-hashed that fresh copy's full ~2000-entry merkle root (`node_coin_state.hpp` pre-emit gate);
3. re-serialized + SHA256d'd **every** active quorum commitment — `compute_merkle_root_quorums` had no cache either, the second unmemoized root on the same path.

A memo on `CalcMerkleRoot` itself is worthless here: the gate hashes a fresh per-call object, so a per-object cache is cold on every call by construction.

## The fix

Both roots memoized at **NodeCoinState** level, invalidated by a **mutation epoch**:

- every non-const accessor/setter whose target feeds either root bumps the epoch: `sml()`, `qmgr()`, `mnstates()` (projection reads MN registration heights), `set_tip()` (projection reads prev_height/prev_hash), `set_mn_min_confirmations()`;
- a cached root is valid only while its captured epoch matches; on a hit the projection copy itself is skipped, not just the hashing;
- all mutators run on the single-threaded ioc — the epoch is a plain `uint64`, no lock added;
- the qc-plan lambda in `main_dash.cpp` runs **inside** the gate and read `qmgr()` through the non-const accessor; those three read-only sites now use `std::as_const` so they cannot re-chill the memo on every evaluation. Over-invalidation elsewhere (startup/persistence/status-log non-const reads) only costs a recompute at block cadence — under-invalidation would cost a block, so the bump rides the accessor, not caller discipline.

Also deleted the dead ~450 KB SML copy in `build_embedded_cbtx` (taken only to call the const `CalcMerkleRoot`) and corrected the comment above it — it claimed "CalcMerkleRoot() caches upstream" and budgeted the copy "per 5s shadow tick"; both clauses were false, and that comment is the origin of the incident. The other dead copy of this class (the emit gate's `sml_copy`) was already removed by bdfd3222.

## Measured gain (counters on the hashing functions themselves)

| | 100 warm emit_ok evaluations |
|---|---|
| before (memo defeated — pre-memo shape) | **100** full SML-root + **100** full quorum-root computations |
| after | **0 + 0** (1 + 1 cold, then flat) |

At the freeze's measured shape (~2000 MNs) each avoided pair is ~2000 `CalcHash` leaf hashes + a ~450 KB list copy + a full commitment re-serialization pass, per evaluation, on the io thread.

## Serving is byte-identical (WHERE-and-HOW-OFTEN, never WHAT)

New suite `test_dash_root_memo.cpp` (folded into `test_dash_embedded_gbt` per the #769 allowlist rule), each test mutation-verified red:

- **T1** warm scaling: 100 warm evaluations → 0 further root computations. Red with the memo hit disabled: exactly 100 + 100.
- **T2** invalidation (the pin that matters most — a memo that never invalidates passes T1 forever while serving a stale root = silently lost block): SML mutation and quorum-set mutation each force a REJECT of the pre-mutation root and an ACCEPT of the recomputed one. Red with the epoch bumps removed: both tests catch the stale accept.
- **T3** byte identity on the crossing shape (projection non-identity): memoized root == independently re-derived reference, cold and warm, including the decline report's expected value. Red with a warm-path byte flip.

## Runs (real counts, this branch, Release)

- `test_dash_embedded_gbt`: **243/243** (includes the CbTx byte-parity KATs covering the deleted copy)
- `test_dash_stratum_work_source`: **100/100** (the #1188 submit-path pin intact)
- `test_dash_node_coin_state`: **99/99**
- `test_dash_quorum_root`: **11/11**
- `c2pool-dash` builds (the `std::as_const` sites compile against the real signatures)
