### PR TITLE
doge(t4a): get_coin_p2p_port returns 22556 for testnet4alpha, not testnet3 44556

### DIFF
--- a/src/c2pool/main_ltc.cpp
+++ b/src/c2pool/main_ltc.cpp
@@ -733,9 +733,9 @@ int main(int argc, char* argv[]) {
     };
 
     // Well-known P2P ports for coin daemons (same machine as RPC by default)
-    auto get_coin_p2p_port = [](const std::string& symbol, bool testnet) -> int {
+    auto get_coin_p2p_port = [&doge_testnet4alpha](const std::string& symbol, bool testnet) -> int {
         if (symbol == "LTC"   || symbol == "ltc")   return testnet ? 19335 : 9333;
-        if (symbol == "DOGE"  || symbol == "doge")  return testnet ? 44556 : 22556;
+        if (symbol == "DOGE"  || symbol == "doge")  return (testnet && !doge_testnet4alpha) ? 44556 : 22556;  // t4a uses mainnet-style 22556
         if (symbol == "NMC"   || symbol == "nmc")   return testnet ? 18334 : 8334;   // SSOT: src/impl/nmc/coin/chain_seeds.hpp (namecoind addrman)
         if (symbol == "BTC"   || symbol == "btc")   return testnet ? 18333 : 8333;
         if (symbol == "DGB"   || symbol == "dgb")   return testnet ? 12026 : 12024;


### PR DESCRIPTION
Port autodetect was the last straggler ignoring the doge_testnet4alpha flag: get_coin_p2p_port now captures t4a and returns the mainnet-style 22556 instead of testnet3 44556. The prefix lambda was already t4a-aware and valid_ports already lists 22556. Last code half of the .157 embedded-DOGE wedge (accept-path half already resolved, tip byte-exact at 69621). Branch by ltc-doge lane @ 1aeba5080; opened by integrator on their request (lane does not self-merge).