### PR TITLE
dash(#1103): explicit chase-log for the mn-ckpt tail-chase (diagnostic-only)

### DIFF
--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -418,6 +418,20 @@ public:
         if (!m_tip_height) return;
         const uint32_t tip = m_tip_height();
         if (m_next > tip) { publish(tip); return; }
+        // #1103 chase-log. The cursor is advancing but has not yet reached the
+        // LIVE tip: this is a CHASE across the header/body-availability gap
+        // (the header tip leads what block bodies are locally available), NOT a
+        // wedge. The lane watchdog resets on every cursor move, so a healthy
+        // tail-chase and a genuine stall are indistinguishable from outside —
+        // "33 min no publish" on contabo 2026-08-09 was in fact this chase
+        // creeping the last handful of bodies to the tip. Emit the lag
+        // explicitly for the tail (lag<=8), where the coarse 500-block progress
+        // line does not fire, so the silent window becomes greppable.
+        if ((tip - m_next + 1) <= 8) {
+            LOG_INFO << "[MN-CKPT] chase: cursor h=" << (m_next - 1)
+                     << " live-tip h=" << tip << " lag=" << (tip - m_next + 1)
+                     << " block(s) — chasing block-bodies to tip, not wedged";
+        }
         request_window(tip);
     }
 


### PR DESCRIPTION
Diagnostic-only slice of the #1103 cold-daemonless "33-min no-publish" chase (NOT a wedge).

The mn-ckpt lane publishes only once its cursor passes the LIVE (header) tip. While the header tip leads locally-available block bodies, the cursor chases the body tail and advances on every apply — which resets the lane watchdog, so a healthy tail-chase and a genuine stall are indistinguishable from outside. On contabo mainnet 2026-08-09 this surfaced as a silent 33-min no-publish window (published 04:02:39 @h=2518773) that self-healed once the last bodies arrived; smoking gun bridge_wait=block-bodies@h=2518769..2518772.

This emits the lag explicitly for the tail (lag<=8), where the coarse 500-block progress line does not fire, so the previously-silent window is greppable as chase progress. No serve/payee path change.

Follow-ups (this campaign): publish-at-body-tip semantic (needs KAT + oracle conform), then #1151 re-arm-cursor ignores persistent cursor (374min->minutes).