### PR TITLE
dash(node): free skipped shares in add_verified_shares — plug heap leak (Fixes #1132)

### DIFF
--- a/src/impl/dash/node.cpp
+++ b/src/impl/dash/node.cpp
@@ -129,11 +129,20 @@ void NodeImpl::add_verified_shares(HandleSharesData& data, NetService addr)
         {
             // Skip shares that failed phase-1 verification (hash still null).
             if (share.hash().IsNull())
+            {
+                // ShareVariants owns a heap Args* with no destructor; a share
+                // that is never handed to m_tracker.add() must be freed here or
+                // it leaks when HandleSharesData is destroyed.
+                share.destroy();
                 continue;
+            }
 
             if (m_chain->contains(share.hash()))
             {
                 ++dup_count;
+                // Duplicate of a share the chain already owns: this incoming
+                // copy is a distinct heap Args* that never reaches the tracker.
+                share.destroy();
                 continue;
             }
 


### PR DESCRIPTION
## Fixes #1132

`ShareVariants` (`src/sharechain/share.hpp:67`) is `std::variant<Args*...>` holding a raw `new Args()` with **no destructor** — freeing is manual via `.destroy()`. `HandleSharesData` (`node.hpp:66`) has no destructor either.

In `NodeImpl::add_verified_shares` (`src/impl/dash/node.cpp`) the two early-`continue` paths bypass `m_tracker.add(share)`, the only owner transfer:
- phase-1 null hash (share never verified)
- duplicate already in the chain

Those variants are never handed to the tracker and never freed → the heap `Args*` leaks every time a batch carries a null-hash or duplicate share.

### Fix
Call `share.destroy()` before each `continue`.

### Why no double-free
Skipped shares are never handed to the chain; successfully-added shares transfer ownership to the chain and are untouched. `grep` confirms nothing else in `node.cpp` calls `.destroy()` on `m_items`.

### Out of scope (noted, not bundled)
The startup DB-reload loop at `node.cpp:~322` (`load_share` → `m_chain->contains` → `++skipped; continue;`) leaks the same way on the freshly-loaded local `share`. Same class, different function — flag for a follow-up rather than widen this PR.

Acceptance = CI + reviewer (not my own local green). Draft to run the matrix and show the diff.