### PR TITLE
dash(stratum): name the third arm state and the serve disposition

### DIFF
--- a/src/impl/dash/coin/serve_gate_journal.hpp
+++ b/src/impl/dash/coin/serve_gate_journal.hpp
@@ -55,6 +55,15 @@ public:
         Resumed      ///< fallback -> EMBEDDED: the arm is serving again
     };
 
+    /// The THREE serve dispositions, so the journal stops collapsing the third
+    /// (neither arm produced a mineable template) into the dashd-fallback arm.
+    ///   Embedded  -- the embedded arm served a mineable template;
+    ///   Fallback  -- a real dashd getblocktemplate was served instead;
+    ///   NoWork    -- SET-GAP: m_bits==0 || previous_block.IsNull(); an honest
+    ///                absence, nothing was served (the caller drops the cache).
+    /// Fallback and NoWork are both "off embedded" and time IDENTICALLY.
+    enum class Served { Embedded, Fallback, NoWork };
+
     struct Decision {
         Trigger  trigger{Trigger::None};
         /// Declines suppressed since the previous emitted line (0 on the
@@ -114,15 +123,31 @@ public:
     explicit ServeGateJournal(int64_t heartbeat_sec = 300)
         : m_heartbeat_sec(heartbeat_sec) {}
 
-    /// Feed ONE arm-selection outcome. `cause` is ignored when
+    /// Feed ONE arm-selection outcome (LEGACY bool). Retained verbatim for the
+    /// existing serve-path caller and the four timing KATs. false maps to
+    /// Served::Fallback: Fallback and NoWork are BOTH "off the embedded arm"
+    /// and share identical episode/partition timing, so every invariant and
+    /// every existing test stays green. `cause` is ignored when
     /// `served_embedded` is true. `now_sec` is monotonic seconds.
     Decision observe(bool served_embedded, const std::string& cause, int64_t now_sec) {
+        return observe(served_embedded ? Served::Embedded : Served::Fallback,
+                       cause, now_sec);
+    }
+
+    /// Feed ONE arm-selection outcome, THREE-VALUED. Served::Embedded takes the
+    /// serving path; Served::Fallback and Served::NoWork take the SAME decline
+    /// path (identical timing) but record a distinct disposition so the arm can
+    /// name the third state -- neither arm produced a mineable template
+    /// (set-gap / no-work) -- instead of mis-reporting it as a dashd-fallback
+    /// serve. `cause` is ignored for Served::Embedded. `now_sec` is monotonic.
+    Decision observe(Served served, const std::string& cause, int64_t now_sec) {
         Decision d;
         d.previous_cause = m_last_cause;
 
-        if (served_embedded) {
+        if (served == Served::Embedded) {
             const bool was_declining = (m_arm == Arm::Declining);
             m_arm = Arm::Embedded;
+            m_disposition = Disposition::Serving;
             m_last_cause.clear();
             if (was_declining) {
                 d.trigger    = Trigger::Resumed;
@@ -147,6 +172,12 @@ public:
 
         const Arm prev_arm = m_arm;
         m_arm = Arm::Declining;
+        // The third arm state rides HERE: Fallback vs NoWork share this decline
+        // path's timing exactly, and differ only in the disposition the arm
+        // name renders. Recorded every decline so a cause-stable set-gap is
+        // never mis-named a dashd-fallback serve on a later heartbeat.
+        m_disposition = (served == Served::NoWork) ? Disposition::NoWork
+                                                   : Disposition::Fallback;
         // Episode clock starts at the first decline after serving (or at the
         // very first observation) and survives cause changes.
         if (m_episode_start_sec < 0) m_episode_start_sec = now_sec;
@@ -214,11 +245,28 @@ public:
     bool observed() const { return m_arm != Arm::Unknown; }
     uint64_t suppressed_since_emit() const { return m_suppressed; }
 
+    /// True iff the arm is off the embedded template because NEITHER arm
+    /// produced a mineable template (set-gap / no-work) -- the third state,
+    /// distinct from a genuine dashd-fallback serve. False while serving.
+    bool no_work() const { return m_disposition == Disposition::NoWork; }
+
+    /// Three-valued arm name for the serve journal and the operator surface.
+    const char* arm_name() const {
+        if (m_arm == Arm::Unknown)  return "unknown";
+        if (m_arm == Arm::Embedded) return "embedded";
+        return m_disposition == Disposition::NoWork ? "none(set-gap/no-work)"
+                                                    : "dashd-fallback";
+    }
+
 private:
     enum class Arm { Unknown, Embedded, Declining };
+    /// Which off-embedded disposition the current decline is (Serving while the
+    /// embedded arm is up). This is the state that makes arm_name() three-valued.
+    enum class Disposition { Serving, Fallback, NoWork };
 
     int64_t     m_heartbeat_sec;
     Arm         m_arm{Arm::Unknown};
+    Disposition m_disposition{Disposition::Serving};
     std::string m_last_cause;
     int64_t     m_last_emit_sec{0};
     /// Start of the CURRENT continuous off-embedded episode; -1 = arm serving.

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -1029,9 +1029,20 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
             std::string mn_payee = "(none)";
             for (const auto& pp : sel.work.m_packed_payments)
                 if (pp.payee != "!6a") { mn_payee = pp.payee; break; }
+            // THE THIRD ARM STATE. `sel` is FINAL here (every arm producer has
+            // written it above), so this is where the set-gap disposition is
+            // known: a zeroed bits or a null prev-block is not mineable work on
+            // ANY chain, so NEITHER arm produced a template -- that is not a
+            // dashd-fallback serve, and the arm line must not say it is. Same
+            // predicate the serve disposition at the store below (m_bits==0 ||
+            // previous_block.IsNull()) uses, computed once on the pre-move sel.
+            const bool no_work =
+                (sel.work.m_bits == 0 || sel.work.m_previous_block.IsNull());
             LOG_INFO << "[DASH-STRATUM-GBT] template sourced: arm="
-                     << (sel.source == coin::WorkSource::Embedded
-                             ? "EMBEDDED" : "dashd-fallback")
+                     << (no_work
+                             ? "none(set-gap/no-work)"
+                             : (sel.source == coin::WorkSource::Embedded
+                                    ? "EMBEDDED" : "dashd-fallback"))
                      << " h=" << sel.work.m_height
                      << " mn_payee=" << mn_payee
                      // A deliberately coinbase-only template says so ON THE ARM
@@ -1056,14 +1067,30 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
             // decision the way a reason recomputed here would. Rate policy:
             // the EMBEDDED->fallback transition and any change of cause emit
             // immediately; an unchanged cause emits on a slow heartbeat.
-            note_arm_decision(work_is_embedded, sel.decline, sel.work.m_height);
+            //
+            // THREE-VALUED: a set-gap template is neither an embedded serve nor
+            // a dashd-fallback serve -- it is the NoWork third state, and it is
+            // the FINAL disposition (the store below drops the cache and returns
+            // without serving anything). Record THAT, so the journal's last word
+            // is not the two-valued mis-report the daemonless soak surfaced.
+            const coin::ServeGateJournal::Served served =
+                no_work ? coin::ServeGateJournal::Served::NoWork
+                        : (work_is_embedded
+                               ? coin::ServeGateJournal::Served::Embedded
+                               : coin::ServeGateJournal::Served::Fallback);
+            note_arm_decision(served, sel.decline, sel.work.m_height);
             // OBSERVE-only serve-vs-dashd SHADOW-COMPARE (--embedded-shadow-compare).
             // Hand the JUST-RESOLVED template (by const-ref; on_serve copies) to
             // the diagnostic probe. This is ENQUEUE-ONLY: the dashd oracle fetch +
             // field-compare + [SHADOW] log all run on the probe's WORKER THREAD, so
             // nothing here waits on dashd and the served bytes below are untouched.
             // No-op when the probe is unset (default / pure-daemonless).
-            if (shadow_compare_)
+            // on_serve treats `sel.work` as a SERVED template; a set-gap NoWork
+            // template is NOT served (the store below drops the cache and
+            // returns), so the shadow-compare must not fire for it -- consistent
+            // with the :1077 disposition. Genuine embedded/fallback serves are
+            // unchanged.
+            if (shadow_compare_ && !no_work)
                 shadow_compare_->on_serve(sel.source, sel.work);
             work = std::move(sel.work);
         } catch (const std::exception& e) {
@@ -1132,17 +1159,19 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
 // This is the one place the answer is emitted, and it emits the report the
 // selecting branch RETURNED, so it cannot drift from the decision.
 // ─────────────────────────────────────────────────────────────────────────────
-void DASHWorkSource::note_arm_decision(bool served_embedded,
+void DASHWorkSource::note_arm_decision(coin::ServeGateJournal::Served served,
                                        const coin::DeclineReport& why,
                                        uint32_t height) const
 {
+    const bool served_embedded =
+        (served == coin::ServeGateJournal::Served::Embedded);
     const auto now_sec = std::chrono::duration_cast<std::chrono::seconds>(
                              std::chrono::steady_clock::now().time_since_epoch())
                              .count();
     coin::ServeGateJournal::Decision d;
     {
         std::lock_guard<std::mutex> lk(serve_gate_mutex_);
-        d = serve_gate_journal_.observe(served_embedded, why.cause, now_sec);
+        d = serve_gate_journal_.observe(served, why.cause, now_sec);
         last_decline_      = served_embedded ? coin::DeclineReport{} : why;
         last_arm_embedded_ = served_embedded;
         arm_ever_observed_ = true;
@@ -1167,9 +1196,13 @@ void DASHWorkSource::note_arm_decision(bool served_embedded,
         return;
     }
     // ONE named cause with its measured value and threshold -- never a list of
-    // maybes, and never "declined" alone.
+    // maybes, and never "declined" alone. THREE-VALUED arm: a set-gap decline
+    // names the NoWork third state, not a dashd-fallback serve it never made.
     LOG_WARNING << "[EMBED-GATE] h=" << height
-                << " arm=dashd-fallback DECLINED " << why.one_line()
+                << " arm="
+                << (served == coin::ServeGateJournal::Served::NoWork
+                        ? "none(set-gap/no-work)" : "dashd-fallback")
+                << " DECLINED " << why.one_line()
                 << " trigger=" << coin::ServeGateJournal::trigger_name(d.trigger)
                 << dur
                 << " suppressed=" << d.suppressed;

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -700,7 +700,7 @@ private:
     /// Record ONE arm-selection outcome and, if the rate policy says so, emit
     /// the single named line. `why` MUST be the report the selecting branch
     /// returned -- never one recomputed here.
-    void note_arm_decision(bool served_embedded,
+    void note_arm_decision(coin::ServeGateJournal::Served served,
                            const coin::DeclineReport& why,
                            uint32_t height) const;
 

--- a/test/test_dash_serve_gate_journal.cpp
+++ b/test/test_dash_serve_gate_journal.cpp
@@ -149,4 +149,60 @@ TEST(DashServeGateJournal, ServingLinesCarryNoCauseClock) {
     EXPECT_EQ(d.episode_sec, -1);
 }
 
+/// THE THIRD-ARM DEFECT THIS PINS (daemonless soak, reconstructing the
+/// integrator's 2026-08-09 three-edit spec): the serve gate knew only two arm
+/// states, EMBEDDED and dashd-fallback, and recorded the THIRD real state --
+/// SET-GAP / NO-WORK, where NEITHER arm produced a mineable template (the
+/// disposition predicate m_bits==0 || previous_block.IsNull(), nothing is
+/// served) -- as a plain "dashd-fallback DECLINED". A fallback serve and an
+/// honest absence read IDENTICALLY, so an operator could not tell a node that
+/// was serving real dashd templates from one serving nothing at all.
+///
+/// The fix is the three-valued observe(Served): NoWork shares the decline
+/// path's timing with Fallback EXACTLY (both are off the embedded arm) but
+/// carries a distinct disposition, so arm_name()/no_work() separate them while
+/// every episode/partition invariant above is preserved.
+///
+/// RED ON MASTER: master's ServeGateJournal has no Served enum, so this TU does
+/// not COMPILE there -- the intended failure this branch turns green.
+TEST(DashServeGateJournal, NoWorkIsTheDistinctThirdArmState) {
+    using Served = ServeGateJournal::Served;
+    ServeGateJournal j(300);
+    const int64_t t0 = 2000;
+
+    // A genuine dashd-fallback serve: off the embedded arm, but a template WAS
+    // served. The arm names the fallback, and it is NOT the no-work state.
+    auto fb = j.observe(Served::Fallback, "qc-plan-underivable", t0);
+    EXPECT_EQ(fb.trigger, Trigger::First);
+    EXPECT_FALSE(j.no_work());
+    EXPECT_STREQ(j.arm_name(), "dashd-fallback");
+
+    // The arm flips to SET-GAP: neither arm produced mineable work. The
+    // DISPOSITION changed, and that is the third state the journal must now
+    // name distinctly from the fallback above.
+    auto ng = j.observe(Served::NoWork, "set-gap", t0 + 5);
+    EXPECT_TRUE(ng.emit());
+    EXPECT_TRUE(j.no_work());
+    EXPECT_STREQ(j.arm_name(), "none(set-gap/no-work)");
+    EXPECT_STRNE(j.arm_name(), "dashd-fallback");
+
+    // Timing STILL partitions: NoWork rides the identical decline path, so the
+    // episode survives the disposition change (whole-episode semantics) and the
+    // fallback segment it closes is attributed to the previous cause.
+    ASSERT_EQ(ng.trigger, Trigger::CauseChange);
+    EXPECT_EQ(ng.episode_sec, 5);
+    EXPECT_EQ(ng.previous_cause, "qc-plan-underivable");
+    EXPECT_EQ(ng.prev_cause_sec, 5);
+    EXPECT_EQ(ng.cause_sec, 0);
+
+    // Resuming onto the embedded arm clears the third state.
+    auto up = j.observe(Served::Embedded, "", t0 + 12);
+    ASSERT_EQ(up.trigger, Trigger::Resumed);
+    EXPECT_FALSE(j.no_work());
+    EXPECT_STREQ(j.arm_name(), "embedded");
+    EXPECT_EQ(up.episode_sec, 12);
+    EXPECT_EQ(up.previous_cause, "set-gap");
+    EXPECT_EQ(up.prev_cause_sec, 7);
+}
+
 }  // namespace


### PR DESCRIPTION
## What

Make the DASH stratum serve-gate journal **three-valued**. It currently knows only two arm states — embedded vs dashd-fallback — and mis-records the third real state (**NO-WORK / set-gap**: `m_bits == 0 || previous_block.IsNull()`, i.e. *neither* arm produced a mineable template and nothing is served) as `dashd-fallback DECLINED`. A genuine fallback serve and an honest absence then read identically, so an operator cannot tell a node serving real dashd templates from one serving nothing.

## The three serve-path edits (`src/impl/dash/stratum/work_source.cpp`)

1. **Arm log third label.** At the point `sel` is final (right before the `[DASH-STRATUM-GBT] template sourced:` line), compute `const bool no_work = (sel.work.m_bits == 0 || sel.work.m_previous_block.IsNull());` — the same predicate the store disposition uses — and render `arm=none(set-gap/no-work)` instead of EMBEDDED/dashd-fallback. Every other field on the line is preserved.
2. **`on_serve` ordering.** The `--embedded-shadow-compare` `on_serve` treats its template as *served*; a set-gap NoWork template is **not** served (the store below drops the cache and returns). Guard it `if (shadow_compare_ && !no_work)` so the probe does not fire for an unserved template, consistent with the set-gap disposition.
3. **Set-gap disposition records NoWork.** The journal now records the **final** three-valued disposition: `no_work ? NoWork : (embedded ? Embedded : Fallback)`, so the journal's last word is not the two-valued mis-report. `note_arm_decision` takes `ServeGateJournal::Served`, and the `[EMBED-GATE] … DECLINED` line names `arm=none(set-gap/no-work)` for the third state.

## Journal tri-state extension (`src/impl/dash/coin/serve_gate_journal.hpp`) — additive

- New `enum class Served { Embedded, Fallback, NoWork };` and an `observe(Served, cause, now_sec)` overload. `Embedded` → the serving path; **`Fallback` and `NoWork` share the SAME decline path with identical timing** (both are "off embedded"), differing only in a recorded `m_disposition`.
- The legacy `observe(bool served_embedded, …)` is retained and delegates (`false → Served::Fallback`), so every existing caller and all four timing KATs stay green.
- New queries `no_work()` and three-valued `arm_name()` ("embedded" / "dashd-fallback" / "none(set-gap/no-work)").
- Still header-only, pure policy, no I/O or clock.

## KAT (`test/test_dash_serve_gate_journal.cpp`)

Adds `NoWorkIsTheDistinctThirdArmState`, driving `observe(Served::NoWork, …)` and asserting the journal distinguishes it from `Served::Fallback` (distinct `arm_name()`, `no_work() == true`) **and** that timing still partitions (episode survives the disposition change; the prior segment is attributed to `previous_cause`). **Red on master:** master's journal has no `Served` enum, so that TU does not compile there — the failure this branch turns green. The four pre-existing timing tests are unchanged and still pass.

## Verify

Built `test_dash_serve_gate_journal` and `test_dash_stratum_work_source` (the latter compiles the edited `work_source.cpp`) on the workstation (`-j4`); journal suite: **6 tests passed / 6**. dashd RPC fallback path is untouched — never removed.

---

This DRAFT reconstructs the integrator's 14:05 three-edit spec (which had not synced to the inbox); please reconcile against the diff.
