### PR TITLE
dash(serve-gate): per-cause episode duration and cumulative time roll-up

### DIFF
--- a/src/impl/dash/coin/serve_gate_journal.hpp
+++ b/src/impl/dash/coin/serve_gate_journal.hpp
@@ -36,8 +36,12 @@
 /// seconds), no coin state. Header-only so it folds into the already
 /// allowlisted dash test targets.
 
+#include <algorithm>
 #include <cstdint>
+#include <map>
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace dash {
 namespace coin {
@@ -143,6 +147,9 @@ public:
     Decision observe(Served served, const std::string& cause, int64_t now_sec) {
         Decision d;
         d.previous_cause = m_last_cause;
+        // The roll-up denominator starts at the very first observation, serving
+        // or not — it is wall clock OBSERVED, not wall clock declined.
+        if (m_first_observed_sec < 0) m_first_observed_sec = now_sec;
 
         if (served == Served::Embedded) {
             const bool was_declining = (m_arm == Arm::Declining);
@@ -161,6 +168,10 @@ public:
                 // duration to the cause it names (d.previous_cause).
                 d.prev_cause_sec = (m_cause_start_sec >= 0)
                                        ? now_sec - m_cause_start_sec : -1;
+                // The final segment closes; bank it in the cumulative roll-up
+                // under the cause that owned it (terminal=resumed).
+                if (d.prev_cause_sec >= 0 && !d.previous_cause.empty())
+                    m_cause_totals[d.previous_cause] += d.prev_cause_sec;
                 m_cause_start_sec   = -1;
                 m_episode_start_sec = -1;
                 m_suppressed = 0;
@@ -198,8 +209,14 @@ public:
         // at ZERO. This is what keeps a cause-change line from attributing the
         // whole episode to the cause it names (the h=2518004 trap).
         if (prev_arm == Arm::Declining && cause != m_last_cause &&
-            m_cause_start_sec >= 0)
+            m_cause_start_sec >= 0) {
             d.prev_cause_sec = now_sec - m_cause_start_sec;
+            // A cause segment closes at a cause change; bank it in the
+            // cumulative roll-up under the cause that owned it
+            // (terminal=cause-change). d.previous_cause is the OLD cause here.
+            if (d.prev_cause_sec >= 0 && !d.previous_cause.empty())
+                m_cause_totals[d.previous_cause] += d.prev_cause_sec;
+        }
         if (prev_arm != Arm::Declining || cause != m_last_cause)
             m_cause_start_sec = now_sec;
 
@@ -235,6 +252,76 @@ public:
             case Trigger::None:        break;
         }
         return "none";
+    }
+
+    /// The named outcome of the CAUSE SEGMENT a decision closes (qc-shape
+    /// `terminal=`), or nullptr when the decision closes no segment
+    /// (`prev_cause_sec < 0`). A serve-gate cause segment ends in exactly one of
+    /// two ways, the direct analogue of QcEpisodeClassifier::Terminal:
+    ///   * `resumed`      — the arm resumed the embedded template; the episode's
+    ///                      final segment ends here (Trigger::Resumed);
+    ///   * `cause-change` — a DIFFERENT first-unmet condition took over; this
+    ///                      cause's segment ends and the next one's clock starts
+    ///                      at zero (Trigger::CauseChange).
+    /// Copying qc's `cause=<name> dur=<n>s terminal=<named-outcome>` discipline
+    /// onto every serve-gate segment is what makes a per-cause TIME histogram
+    /// greppable without hand-pairing lines — the #119 follow-up.
+    static const char* seg_terminal_name(Trigger t) {
+        switch (t) {
+            case Trigger::Resumed:     return "resumed";
+            case Trigger::CauseChange: return "cause-change";
+            default:                   break;
+        }
+        return nullptr;
+    }
+
+    /// A cumulative, denominator-carrying view of where wall clock went, so a
+    /// soak can be read WITHOUT reconstructing episodes from raw lines.
+    ///
+    /// WHY THE DENOMINATOR RIDES HERE — a per-cause seconds figure with an
+    /// implicit denominator is exactly how the best-share percentage shipped:
+    /// `observed_sec` (the wall clock seen since the first observation) is the
+    /// ONLY honest base for "what fraction of wall clock did this cause cost",
+    /// and it is printed alongside the numerators so no reader has to supply it.
+    struct Rollup {
+        /// Denominator: monotonic seconds observed since the first observation.
+        int64_t observed_sec{0};
+        /// Sum of every per-cause numerator below (total seconds off the
+        /// embedded arm, closed segments + the currently-open one). <=
+        /// observed_sec; the remainder is time the embedded arm was serving.
+        int64_t off_embedded_sec{0};
+        /// Per-cause attributed seconds, closed segments PLUS the currently-open
+        /// segment's partial, sorted by seconds desc then name (deterministic).
+        /// Built by summing the per-cause segment clock — NEVER episode_sec —
+        /// so the histogram matches the seg lines and cannot invert the way a
+        /// count- or episode_sec-based one does.
+        std::vector<std::pair<std::string, int64_t>> per_cause;
+    };
+
+    /// Cumulative roll-up as of `now_sec` (monotonic). Includes the partial
+    /// duration of any segment currently in progress, so a roll-up read
+    /// mid-episode is accurate and never lags a long-running cause.
+    Rollup rollup(int64_t now_sec) const {
+        Rollup r;
+        r.observed_sec = (m_first_observed_sec >= 0) ? now_sec - m_first_observed_sec : 0;
+        std::map<std::string, int64_t> acc = m_cause_totals;  // closed segments
+        // Fold the currently-open segment's partial so nothing in-flight is
+        // undercounted; it is NOT in m_cause_totals until it closes, so there
+        // is no double count.
+        if (m_arm == Arm::Declining && m_cause_start_sec >= 0 && !m_last_cause.empty())
+            acc[m_last_cause] += now_sec - m_cause_start_sec;
+        r.per_cause.reserve(acc.size());
+        for (const auto& kv : acc) {
+            r.off_embedded_sec += kv.second;
+            r.per_cause.emplace_back(kv.first, kv.second);
+        }
+        std::sort(r.per_cause.begin(), r.per_cause.end(),
+                  [](const std::pair<std::string, int64_t>& a,
+                     const std::pair<std::string, int64_t>& b) {
+                      if (a.second != b.second) return a.second > b.second;
+                      return a.first < b.first;
+                  });
+        return r;
     }
 
     /// The cause of the most recent decline ("" while the arm is serving or
@@ -276,6 +363,13 @@ private:
     int64_t     m_cause_start_sec{-1};
     bool        m_have_emitted{false};
     uint64_t    m_suppressed{0};
+    /// Wall clock observed since the FIRST observation (serving or declining);
+    /// the roll-up denominator. -1 until the first observe() call.
+    int64_t     m_first_observed_sec{-1};
+    /// Cumulative attributed seconds per cause, summed from CLOSED segment
+    /// durations (the per-cause segment clock, never episode_sec). Ordered by
+    /// name for a deterministic roll-up before the by-seconds sort.
+    std::map<std::string, int64_t> m_cause_totals;
 };
 
 }  // namespace coin

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -55,6 +55,7 @@
 #include <ctime>
 #include <mutex>
 #include <span>
+#include <sstream>
 #include <utility>
 
 namespace dash::stratum {
@@ -1169,13 +1170,66 @@ void DASHWorkSource::note_arm_decision(coin::ServeGateJournal::Served served,
                              std::chrono::steady_clock::now().time_since_epoch())
                              .count();
     coin::ServeGateJournal::Decision d;
+    coin::ServeGateJournal::Rollup rollup;
+    bool emit_rollup = false;
     {
         std::lock_guard<std::mutex> lk(serve_gate_mutex_);
         d = serve_gate_journal_.observe(served, why.cause, now_sec);
         last_decline_      = served_embedded ? coin::DeclineReport{} : why;
         last_arm_embedded_ = served_embedded;
         arm_ever_observed_ = true;
+        // Cumulative roll-up on its own slow cadence, INDEPENDENT of whether
+        // this decision emits a per-line entry: it must fire during a long
+        // healthy (serving) stretch too, so the denominator keeps growing and a
+        // soak is readable from the roll-up alone. Seed the cadence on the first
+        // decision so the very first observation never prints an empty summary.
+        if (last_rollup_sec_ < 0) {
+            last_rollup_sec_ = now_sec;
+        } else if (now_sec - last_rollup_sec_ >= kRollupHeartbeatSec) {
+            last_rollup_sec_ = now_sec;
+            rollup           = serve_gate_journal_.rollup(now_sec);
+            emit_rollup      = true;
+        }
     }
+
+    if (emit_rollup) {
+        // DENOMINATOR FIRST, then the numerators it divides — a percentage
+        // whose denominator is implicit is how the best-share bug shipped, so
+        // observed= is never omitted and each cause carries its own share.
+        std::ostringstream os;
+        os << "[EMBED-GATE-ROLLUP] observed=" << rollup.observed_sec << "s"
+           << " off_embedded=" << rollup.off_embedded_sec << "s";
+        if (rollup.observed_sec > 0)
+            os << " (" << (rollup.off_embedded_sec * 100 / rollup.observed_sec)
+               << "% of wall clock)";
+        os << " causes:";
+        if (rollup.per_cause.empty()) {
+            os << " (none)";
+        } else {
+            for (const auto& c : rollup.per_cause) {
+                os << " " << c.first << "=" << c.second << "s";
+                if (rollup.observed_sec > 0)
+                    os << "(" << (c.second * 100 / rollup.observed_sec) << "%)";
+            }
+        }
+        LOG_WARNING << os.str();
+    }
+
+    // A CAUSE SEGMENT closed on THIS decision (a cause change or a resume):
+    // emit it in qc's exact shape so a `grep 'cause=... dur='` sums to the
+    // CORRECT per-cause histogram. This is deliberately a SEPARATE line from the
+    // episode line below — its dur= is the per-cause segment clock, never the
+    // whole-episode dur=, so counts and seconds are never mixed on one line.
+    if (d.emit() && d.prev_cause_sec >= 0 && !d.previous_cause.empty()) {
+        if (const char* term =
+                coin::ServeGateJournal::seg_terminal_name(d.trigger)) {
+            LOG_WARNING << "[EMBED-GATE-SEG] h=" << height
+                        << " cause=" << d.previous_cause
+                        << " dur=" << d.prev_cause_sec << "s"
+                        << " terminal=" << term;
+        }
+    }
+
     if (!d.emit()) return;
 
     // The COST of the episode, in seconds off the embedded arm. This is the
@@ -1186,6 +1240,13 @@ void DASHWorkSource::note_arm_decision(coin::ServeGateJournal::Served served,
     const std::string dur =
         d.episode_sec >= 0 ? " dur=" + std::to_string(d.episode_sec) + "s"
                            : std::string();
+    // The CURRENT cause's own clock, distinct from the whole-episode dur= above:
+    // on a heartbeat this separates "the arm has been down 4 min" (episode) from
+    // "this particular cause has held for 20 s" (segment), which read identically
+    // when only episode_sec was printed (the h=2518004 attribution trap).
+    const std::string cause_dur =
+        d.cause_sec >= 0 ? " cause_dur=" + std::to_string(d.cause_sec) + "s"
+                         : std::string();
 
     if (d.trigger == coin::ServeGateJournal::Trigger::Resumed) {
         LOG_WARNING << "[EMBED-GATE] h=" << height
@@ -1205,6 +1266,7 @@ void DASHWorkSource::note_arm_decision(coin::ServeGateJournal::Served served,
                 << " DECLINED " << why.one_line()
                 << " trigger=" << coin::ServeGateJournal::trigger_name(d.trigger)
                 << dur
+                << cause_dur
                 << " suppressed=" << d.suppressed;
 }
 

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -741,6 +741,13 @@ private:
     // answers "why is the arm not serving".
     static constexpr int64_t kDeclineHeartbeatSec = 300;
 
+    // Cadence of the cumulative [EMBED-GATE-ROLLUP] line: seconds-per-cause
+    // since start with the wall-clock DENOMINATOR printed alongside, so a soak
+    // is readable without hand-reconstructing episodes (the #119 follow-up).
+    // Hourly is far below the decline heartbeat's flood risk and dense enough
+    // that any soak window carries at least one denominator-bearing summary.
+    static constexpr int64_t kRollupHeartbeatSec = 3600;
+
     // DEFECT-3: the serve gate must NAME its refusal. `serve_gate_journal_` is
     // the rate policy (transition / cause-change / heartbeat); `last_decline_`
     // is the most recent DeclineReport as returned BY the arm-selection branch
@@ -751,6 +758,10 @@ private:
     mutable coin::DeclineReport     last_decline_;
     mutable bool                    last_arm_embedded_{false};
     mutable bool                    arm_ever_observed_{false};
+    // Monotonic second of the last emitted cumulative roll-up; -1 until the
+    // first arm decision, so the first observation seeds the cadence without
+    // emitting an empty summary. Guarded by serve_gate_mutex_.
+    mutable int64_t                 last_rollup_sec_{-1};
 
     // ── Serve-staleness observation (lock-free by requirement) ─────────────
     // Written on the serve path (get_current_work_template /

--- a/test/test_dash_serve_gate_journal.cpp
+++ b/test/test_dash_serve_gate_journal.cpp
@@ -205,4 +205,135 @@ TEST(DashServeGateJournal, NoWorkIsTheDistinctThirdArmState) {
     EXPECT_EQ(up.prev_cause_sec, 7);
 }
 
+// ── #119 FOLLOW-UP: cumulative per-cause TIME roll-up with a denominator ─────
+//
+// THE DEFECT THIS PINS (soak-dl-master, 2026-08-09, 36,854 s window): the
+// serve-gate log carried a duration for ONLY qc-plan-underivable; the cause
+// with 10x the episodes (creditpool-stale, 107 episodes) carried NONE, so
+// "what fraction of wall clock did each cause cost" was unanswerable and every
+// serving-percentage claim rested on episode COUNTS. counts and seconds are not
+// commensurable. The fix is a cumulative roll-up that (1) attributes seconds to
+// EVERY cause and (2) prints the DENOMINATOR (wall clock observed) so a share
+// is never implicit.
+
+using Rollup = ServeGateJournal::Rollup;
+
+// A short, high-count cause and a long, low-count cause — the brief's shape.
+// By count creditpool-stale dominates (many episodes); by TIME qc-plan owns the
+// loss. The roll-up must attribute NON-ZERO seconds to the high-count cause AND
+// rank by time, not count.
+TEST(DashServeGateJournal, RollupAttributesTimePerCauseNotCount) {
+    ServeGateJournal j(1000000);  // heartbeat off; segments still bank on close
+    int64_t t = 0;
+
+    // 20 creditpool-stale episodes, ~1 s each (the "107 episodes, 0 s" cause):
+    // each is decline -> resume, so each segment closes and banks ~1 s.
+    for (int i = 0; i < 20; ++i) {
+        j.observe(false, "creditpool-stale", t);
+        j.observe(true, "", t + 1);
+        t += 60;  // 59 s of serving between episodes
+    }
+    // ONE qc-plan-underivable episode of 500 s (few episodes, most of the loss).
+    j.observe(false, "qc-plan-underivable", t);
+    j.observe(true, "", t + 500);
+    t += 500;
+
+    const int64_t now = t + 10;  // arm serving now
+    Rollup r = j.rollup(now);
+
+    // Denominator present and is the WHOLE observed window, not just decline time.
+    EXPECT_EQ(r.observed_sec, now);           // first observation was at t=0
+    EXPECT_GT(r.observed_sec, r.off_embedded_sec);  // most of it was serving
+
+    // BOTH causes carry seconds — the high-count cause is no longer 0 s.
+    ASSERT_EQ(r.per_cause.size(), 2u);
+    int64_t credit = 0, qc = 0;
+    for (const auto& c : r.per_cause) {
+        if (c.first == "creditpool-stale")    credit = c.second;
+        if (c.first == "qc-plan-underivable") qc     = c.second;
+    }
+    EXPECT_EQ(credit, 20);   // 20 episodes x ~1 s
+    EXPECT_EQ(qc, 500);
+
+    // Ranked by TIME: qc-plan first despite having 1/20th the episode count.
+    EXPECT_EQ(r.per_cause.front().first, "qc-plan-underivable");
+    // Numerators sum to off_embedded (no time lost or double-counted).
+    EXPECT_EQ(credit + qc, r.off_embedded_sec);
+    EXPECT_EQ(r.off_embedded_sec, 520);
+}
+
+// A roll-up read MID-EPISODE includes the in-progress segment's partial, so a
+// long-running cause is never undercounted until it happens to close.
+TEST(DashServeGateJournal, RollupIncludesOpenSegmentPartial) {
+    ServeGateJournal j(1000000);
+    j.observe(false, "cause-a", 100);          // segment opens at 100, still open
+    Rollup r = j.rollup(250);                   // 150 s into the open segment
+    ASSERT_EQ(r.per_cause.size(), 1u);
+    EXPECT_EQ(r.per_cause.front().first, "cause-a");
+    EXPECT_EQ(r.per_cause.front().second, 150);
+    EXPECT_EQ(r.off_embedded_sec, 150);
+    EXPECT_EQ(r.observed_sec, 150);             // denominator = 250 - first obs (100)
+
+    // The same cause re-observed across a cause change accumulates, and the open
+    // partial does not double-count what already closed.
+    j.observe(false, "cause-b", 260);           // closes cause-a segment (160 s)
+    Rollup r2 = j.rollup(300);                   // cause-b open 40 s
+    int64_t a = 0, b = 0;
+    for (const auto& c : r2.per_cause) {
+        if (c.first == "cause-a") a = c.second;
+        if (c.first == "cause-b") b = c.second;
+    }
+    EXPECT_EQ(a, 160);   // closed segment, banked once
+    EXPECT_EQ(b, 40);    // open partial
+    EXPECT_EQ(r2.off_embedded_sec, 200);
+}
+
+// The denominator is wall clock since the FIRST observation, serving included.
+TEST(DashServeGateJournal, RollupDenominatorIsObservedWallClock) {
+    ServeGateJournal j(300);
+    j.observe(true, "", 1000);                  // first observation: serving
+    j.observe(false, "cause-a", 1010);          // 10 s of serving, then decline
+    j.observe(true, "", 1015);                  // 5 s declining
+    Rollup r = j.rollup(1020);
+    EXPECT_EQ(r.observed_sec, 20);              // 1020 - 1000
+    EXPECT_EQ(r.off_embedded_sec, 5);           // only the 5 s decline segment
+    ASSERT_EQ(r.per_cause.size(), 1u);
+    EXPECT_EQ(r.per_cause.front().second, 5);
+}
+
+// An empty journal names no cause and invents no denominator.
+TEST(DashServeGateJournal, RollupEmptyBeforeAnyObservation) {
+    ServeGateJournal j(300);
+    Rollup r = j.rollup(500);
+    EXPECT_EQ(r.observed_sec, 0);
+    EXPECT_EQ(r.off_embedded_sec, 0);
+    EXPECT_TRUE(r.per_cause.empty());
+}
+
+// seg_terminal_name gives every CLOSING decision a qc-shaped terminal, and
+// nullptr for decisions that close no segment.
+TEST(DashServeGateJournal, SegTerminalNamesCoverClosuresOnly) {
+    using Trig = ServeGateJournal::Trigger;
+    EXPECT_STREQ(ServeGateJournal::seg_terminal_name(Trig::Resumed), "resumed");
+    EXPECT_STREQ(ServeGateJournal::seg_terminal_name(Trig::CauseChange),
+                 "cause-change");
+    EXPECT_EQ(ServeGateJournal::seg_terminal_name(Trig::Heartbeat), nullptr);
+    EXPECT_EQ(ServeGateJournal::seg_terminal_name(Trig::First), nullptr);
+    EXPECT_EQ(ServeGateJournal::seg_terminal_name(Trig::Transition), nullptr);
+    EXPECT_EQ(ServeGateJournal::seg_terminal_name(Trig::None), nullptr);
+
+    // The closing decisions the consumer emits a [EMBED-GATE-SEG] line for carry
+    // BOTH a non-null terminal and a prev_cause_sec — they always co-occur.
+    ServeGateJournal j(300);
+    j.observe(false, "cause-a", 0);
+    auto change = j.observe(false, "cause-b", 10);
+    EXPECT_STREQ(ServeGateJournal::seg_terminal_name(change.trigger),
+                 "cause-change");
+    EXPECT_EQ(change.prev_cause_sec, 10);
+    auto resumed = j.observe(true, "", 25);
+    EXPECT_STREQ(ServeGateJournal::seg_terminal_name(resumed.trigger),
+                 "resumed");
+    EXPECT_EQ(resumed.prev_cause_sec, 15);
+}
+
 }  // namespace


### PR DESCRIPTION
## What

`creditpool-stale` had 107 episodes and zero attributed duration; serving loss could not be attributed to a cause. `ServeGateJournal` already computed the per-cause segment clock (`cause_sec`/`prev_cause_sec`) but the consumer only ever printed the whole-episode `dur=`, and there was no cumulative summary — so every serving-percentage claim on this programme rested on episode COUNTS, which are not commensurable with seconds. Closes the #119 follow-up ("add per-cause TIME to ServeGateJournal").

Measured on soak-dl-master, daemonless, 36,854 s window (2026-08-09 03:26:23 → 13:40:37 UTC): only `qc-plan-underivable` carried a duration (5,526 s / 10 episodes); `creditpool-stale` (107 episodes), `emit-bestcl-null-committed` (2), `mn-needs-reseed` (1), `bestcl-stale` (1), `not-populated` (1) were count-only.

## Change (instrument only — no behaviour change)

- `ServeGateJournal::rollup(now)` returns per-cause attributed seconds (closed segments + the currently-open segment's partial, summed from the per-cause segment clock — never `episode_sec`) plus the wall-clock DENOMINATOR observed since the first observation.
- `seg_terminal_name()` names every closing segment in the qc classifier's shape (`resumed` / `cause-change`).
- `work_source` emits `[EMBED-GATE-SEG] cause=<name> dur=<n>s terminal=<...>` on every segment close — a SEPARATE line from the episode line, so per-cause seconds and whole-episode seconds are never mixed and `grep 'cause=... dur='` sums to the correct per-cause histogram. Adds `cause_dur=` to the decline line, and a periodic `[EMBED-GATE-ROLLUP]` that prints the denominator alongside the numerators (a percentage with an implicit denominator is how the best-share bug shipped).

## Tests

New KATs in `test_dash_serve_gate_journal`: per-cause time attributed by TIME not count (the brief's high-count/low-time shape), open-segment partial, observed-wall-clock denominator, terminal naming. The six existing segment-model KATs are unchanged and still pass. Header-only suite verified locally (11/11); `work_source.cpp` syntax-checks clean against the project include set.

## Not a gate

PR-1 and PR-2 touch different files and can merge in any order; what waits on this is the CLAIM about what they bought, not their merge. HEAD asserted against origin/master (2a051f5f); no literal commit pins.
