### PR TITLE
dash(serve-gate): name and reduce tip-body-pending

### DIFF
--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -1016,6 +1016,53 @@ public:
     /// tip is. Between header and body the arm keeps serving prev=old-tip
     /// work — the same propagation-window behaviour every pool has — named
     /// `tip-body-pending`, which is a NORMAL TRANSIENT, not an error state.
+    ///
+    /// ── WHAT `tip-body-pending` ACTUALLY NAMES ──────────────────────────────
+    /// It is one state with two very different costs, and they must not be
+    /// confused (they were: see the guard in node_coin_state.hpp's decline
+    /// refinement).
+    ///
+    /// THE STATE: we hold the tip HEADER (h, hash) but at least one of the
+    /// three per-block derived axes is still at h-1, so
+    /// maybe_promote_pending_tip() has not run. The header commits to those
+    /// axes; it does not carry them:
+    ///   • credit-pool seed — the next block's DIP4 CbTx must carry
+    ///     creditPoolBalance derived AT the tip. That number moves with the
+    ///     tip block's asset-lock/unlock special txs, which live in the tip
+    ///     block's BODY. Outstanding fetch: getdata BLOCK <tip hash> on the
+    ///     coin-P2P leg (or a tip-targeted mnlistdiff whose cbTx carries it).
+    ///   • payee cursor — nLastPaidHeight advances by the tip block's own
+    ///     masternode payment, which is a coinbase output in the same BODY.
+    ///     Without it the next template pays the previous winner again:
+    ///     bad-cb-payee, a rejected block, a lost share.
+    ///   • SML currency — merkleRootMNList must be computed over the list AS
+    ///     OF the tip. A cbTx commits that ROOT; a root is not a list, so the
+    ///     body CANNOT supply it. Outstanding fetch: a separate getmnlistd
+    ///     round trip (base = serve tip, target = header tip).
+    /// So the template cannot be built not because we lack the header's
+    /// difficulty/time fields — we stashed those above — but because three
+    /// coinbase-committed values are functions of the tip BLOCK.
+    ///
+    /// COST A (steady state): a serve tip already exists, we keep serving
+    /// h-1 work, and no refusal is emitted at all. The window is the block's
+    /// propagation + parse latency and nothing else. MEASURED on the
+    /// instrumented daemonless soak (86406d07, 2026-08-09 14:39–16:05,
+    /// h=2519019..2519049): 31 windows opened, 31 closed BY PROMOTION, 0
+    /// overdue demotes; median 0.771 s, p90 2.909 s. 30 of the 31 cost ZERO
+    /// seconds off the embedded arm.
+    ///
+    /// COST B (cold start / post-demote): no serve tip exists yet, so the
+    /// pending window IS the refusal. One-time, and it shares its episode
+    /// with `not-populated` — on that same soak the whole cold start was a
+    /// single 126 s episode (not-populated 102 s → tip-body-pending 19 s →
+    /// not-populated 5 s → RESUMED), the 19 s being the sole window of the 31
+    /// that cost anything, and the MN seed, not the block body, being its
+    /// longest pole (the body folded 5 s before have_mn came up). It belongs
+    /// to the cold-start lane (#1162/#1151), not to a steady-state budget.
+    ///
+    /// SO: do NOT try to shorten this wait. Promotion already fires the
+    /// instant the inputs land; the residue is network. The defect this
+    /// state had was in its NAME, not its duration.
     void on_new_tip(uint32_t prev_height, const uint256& prev_hash,
                     uint32_t bits_for_next, uint32_t mtp_at_tip,
                     uint8_t address_version, uint8_t address_p2sh_version,
@@ -1314,6 +1361,7 @@ public:
         m_have_hdr_tip = false;
         m_tip_body_pending = false;
         m_state.set_tip_body_pending_dbg(false);
+        m_state.set_tip_body_pending_axis("");
         demote();
     }
 
@@ -1947,14 +1995,22 @@ private:
     /// Returns true iff promotion happened; caller republishes.
     bool maybe_promote_pending_tip() {
         if (!m_body_first_serve_tip || !m_tip_body_pending) return false;
-        if (!m_have_hdr_tip) return false;
+        // Every early return below records WHICH conjunct is the unmet one, so
+        // a `tip-body-pending` refusal can say what it is waiting FOR. Static
+        // literals only (NodeCoinState stores the pointer, never a copy).
+        if (!m_have_hdr_tip) {
+            m_state.set_tip_body_pending_axis("header-tip");
+            return false;
+        }
         // Credit-pool axis: the pool must be DERIVED at this exact block —
         // published already (flag off / at-or-below the serve tip), or HELD
         // pending publication (PR-5). Asking "do we have the pool for this
         // block" rather than "is the published slot at this block" is what
         // lets the publication ride the promotion instead of preceding it.
-        if (!credit_pool_derived_at(m_hdr_prev_hash, m_hdr_prev_height))
+        if (!credit_pool_derived_at(m_hdr_prev_hash, m_hdr_prev_height)) {
+            m_state.set_tip_body_pending_axis("credit-pool-seed");
             return false;
+        }
         // The PAYEE axis must be current at the tip too (its cursor advances
         // in the tip-body apply_block, or a snapshot loaded as-of the tip):
         // promoting off a tip-targeted mnlistdiff that outraced the body
@@ -1964,8 +2020,10 @@ private:
         // has no cursor to be stale and does not hold promotion back — the
         // MN-readiness half of populated() already gates serving there.
         if (!m_state.mnstates().entries().empty()
-            && m_state.mnstates().last_applied_height() != m_hdr_prev_height)
+            && m_state.mnstates().last_applied_height() != m_hdr_prev_height) {
+            m_state.set_tip_body_pending_axis("payee-cursor");
             return false;
+        }
         // ── FOURTH AXIS: the SML currency (dmn-stale, clause 12) ────────────
         // Folding the tip body we already hold cannot advance the SML — a cbTx
         // commits merkleRootMNList, and a root is not a list — so the currency
@@ -1985,8 +2043,10 @@ private:
         // first. Test: ColdSmlDoesNotBlockPromotion pins that a future reader
         // cannot "tighten" this into a cold-start deadlock.
         if (!m_state.sml_current_hash().IsNull()
-            && m_state.sml_current_hash() != m_hdr_prev_hash)
+            && m_state.sml_current_hash() != m_hdr_prev_hash) {
+            m_state.set_tip_body_pending_axis("sml-currency");
             return false;
+        }
         // PUBLISH-WITH-PROMOTION (PR-5): the held pool for this exact block
         // becomes the published pool in the same indivisible step that makes
         // the block the serve tip. No observer can see the pool at H with the
@@ -1995,6 +2055,7 @@ private:
         publish_held_credit_pool_at(m_hdr_prev_hash, m_hdr_prev_height);
         promote_serve_tip();
         m_state.set_tip_body_pending_dbg(false);
+        m_state.set_tip_body_pending_axis("");
         LOG_INFO << "[EMB-DASH] serve tip promoted h=" << m_prev_height << " "
                  << m_prev_hash.GetHex().substr(0, 16)
                  << "... (body-first: tip block inputs parsed, credit-pool"

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -393,6 +393,25 @@ public:
     void set_tip_body_pending_dbg(bool v) { m_tip_body_pending_dbg = v; }
     bool tip_body_pending_dbg() const { return m_tip_body_pending_dbg; }
 
+    /// WHICH promotion conjunct is the one still unmet, as a static string
+    /// literal ("credit-pool-seed" / "payee-cursor" / "sml-currency" /
+    /// "header-tip"). `tip-body-pending` names a WAIT; on its own it does NOT
+    /// name what is being waited FOR, and the three axes have different owners
+    /// and different repair paths — the credit-pool seed and the payee cursor
+    /// both come from the tip BLOCK BODY (one getdata BLOCK on the coin-P2P
+    /// leg), while the SML currency comes from a SEPARATE getmnlistd round
+    /// trip that the block body cannot supply (a cbTx commits
+    /// merkleRootMNList, and a root is not a list). An operator reading
+    /// `cause=tip-body-pending` alone cannot tell a slow body from a silently
+    /// dropped diff request; `awaiting=sml-currency` says it in one line.
+    ///
+    /// LIFETIME: the pointer must be a string literal (every call site passes
+    /// one). Diagnostic only; no serve or reward path reads it.
+    void set_tip_body_pending_axis(const char* axis) {
+        m_tip_body_pending_axis = axis ? axis : "";
+    }
+    const char* tip_body_pending_axis() const { return m_tip_body_pending_axis; }
+
     /// The same two bits, READABLE. They existed only inside the decline
     /// string, so the standing state ("why would this node not serve RIGHT
     /// NOW, before anyone asks it for work") could not be printed at all — an
@@ -1499,14 +1518,45 @@ private:
             d.cause     = "mn-needs-reseed";
             d.value     = "latched";
             d.threshold = "cleared-by-authoritative-reseed";
-        } else if (d.cause == "not-populated" && m_tip_body_pending_dbg) {
+        } else if (d.cause == "not-populated" && m_tip_body_pending_dbg
+                   && m_have_tip_dbg == 0 && m_have_mn_dbg == 1) {
             // Body-first serve tip: a header tip is known but its block
             // inputs have not been parsed yet (cold start before the first
             // promotion, or an overdue-demoted pending window). The named
             // transient — NOT a header-sync fault, NOT an error state; the
             // value keeps both populate halves visible.
+            //
+            // ONLY WHEN THE TIP HALF IS THE ONE UNMET (have_tip=0, have_mn=1).
+            // The pending flag says a header tip is awaiting its body; it does
+            // NOT say the body is what is holding serving back. Two states the
+            // unguarded rename got wrong, both measured on the instrumented
+            // daemonless soak (86406d07, 2026-08-09 14:39–15:53):
+            //
+            //   have_tip=0, have_mn=0 — cold start. At 14:40:55 the arm was
+            //   relabelled `tip-body-pending` while BOTH halves were unmet,
+            //   and the MN half was the LONGER pole: the body folded at
+            //   14:41:15 (have_tip 0→1) but the arm stayed down another 5 s
+            //   waiting on have_mn. 19 s were charged to the block body when
+            //   the MN seed owned the whole 126 s cold-start episode.
+            //
+            //   have_tip=1, have_mn=0 — a body-pending window opened while a
+            //   serve tip already exists (steady state: we keep serving H-1
+            //   work, which is correct and not a decline at all) and the MN
+            //   set is what went away. There the tip body is not blocking
+            //   ANYTHING and naming it sends the operator at the wrong lane.
+            //
+            // Both now keep `not-populated`, whose value already names the two
+            // halves. The rename survives exactly where it is true: no serve
+            // tip, MN set ready, the tip block's inputs the only thing missing.
             d.cause     = "tip-body-pending";
             d.threshold = "tip-body-folded";
+            // …and WHICH input. See set_tip_body_pending_axis: the credit-pool
+            // seed and the payee cursor arrive with the block body, the SML
+            // currency only with a getmnlistd reply, so the two point at
+            // different repair paths. Appended, never substituted — the
+            // populate halves stay visible.
+            if (m_tip_body_pending_axis && *m_tip_body_pending_axis)
+                d.value += std::string(",awaiting=") + m_tip_body_pending_axis;
         } else if (d.cause == "not-populated" && m_prev_hash.IsNull()
                    && m_have_tip_dbg < 0) {
             // ONLY when the maintainer has told us nothing (never reported).
@@ -1719,6 +1769,9 @@ private:
     // Body-first serve tip: header tip known, block inputs not yet parsed
     // (set_tip_body_pending_dbg). Diagnostic only, never gates anything.
     bool     m_tip_body_pending_dbg{false};
+    // Which promotion conjunct is unmet (set_tip_body_pending_axis). Always a
+    // string literal — never an owning pointer. Diagnostic only.
+    const char* m_tip_body_pending_axis{""};
     uint32_t m_prev_height{0};
     uint256  m_prev_hash;
     uint32_t m_bits_for_next{0};

--- a/test/test_dash_coin_state_maintainer.cpp
+++ b/test/test_dash_coin_state_maintainer.cpp
@@ -2090,6 +2090,84 @@ TEST(DashCoinStateMaintainer, BodyFirstOverduePendingDemotesThenBodyReArms) {
 }
 
 // ════════════════════════════════════════════════════════════════════════
+// `tip-body-pending` must name a WAIT WE ARE ACTUALLY IN, and name what it
+// is waiting FOR. Both pinned against the instrumented daemonless soak
+// (86406d07, 2026-08-09 14:39–15:53).
+// ════════════════════════════════════════════════════════════════════════
+
+// MEASURED MISATTRIBUTION. Soak line 14:40:55 read
+//   cause=tip-body-pending value=have_tip=0,have_mn=0 threshold=tip-body-folded
+// — the body-pending flag was set, but BOTH populate halves were unmet and
+// the MN half was the LONGER pole: the body folded at 14:41:15 (have_tip 0→1)
+// and the arm still stayed down 5 s more waiting on have_mn. 19 s of the
+// 126 s cold-start episode were charged to the block body; the MN seed owned
+// them. The threshold made it worse by dropping `have_mn=1` from the
+// requirement it printed.
+//
+// FAILS ON MASTER: the rename there is guarded only by the pending flag.
+TEST(DashCoinStateMaintainer, TipBodyPendingIsNotNamedWhileTheMnHalfIsAlsoMissing) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    m.set_body_first_serve_tip(true);
+    st.set_require_fresh_credit_pool(true);
+
+    // Make the maintainer REPORT both halves as unmet without seeding the MN
+    // set — the cold-start shape (have_tip=0, have_mn=0), and the reason the
+    // "no-tip" refinement below must not fire either (the halves were
+    // measured, not merely never reported).
+    m.on_invalidate();
+    ASSERT_EQ(st.have_tip_dbg(), 0);
+    ASSERT_EQ(st.have_mn_dbg(), 0);
+
+    auto b1 = make_cbtx_block(H - 1, 111'000'000LL, p2pkh_script(0x30));
+    m.on_new_tip(H - 1, block_hash_of(b1), BITS, MTP,
+                 DASH_PUBKEY_VER, DASH_P2SH_VER, CURTIME, VERSION);
+    ASSERT_TRUE(m.tip_body_pending()) << "the pending flag IS set here";
+
+    const auto d = st.describe_decline();
+    EXPECT_EQ(d.cause, "not-populated")
+        << "with the MN seed also missing, the block body is not the binding "
+           "constraint — naming it sends the operator at the wrong lane";
+    EXPECT_EQ(d.value, "have_tip=0,have_mn=0");
+    EXPECT_EQ(d.threshold, "have_tip=1,have_mn=1")
+        << "the threshold must keep requiring BOTH halves";
+}
+
+// The rename SURVIVES exactly where it is true: MN set ready, no serve tip,
+// the tip block's own inputs the only thing missing — and it now says WHICH
+// input. `awaiting=` is appended, never substituted, so the populate halves
+// stay readable on the same line.
+//
+// FAILS ON MASTER: no axis exists there, so the value is the bare pair.
+TEST(DashCoinStateMaintainer, TipBodyPendingNamesTheUnmetPromotionAxis) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    m.set_body_first_serve_tip(true);
+    st.set_require_fresh_credit_pool(true);
+    m.on_mn_list_update(single_mn(p2pkh_script(0x30)));
+    ASSERT_EQ(st.have_mn_dbg(), 1);
+
+    auto b1 = make_cbtx_block(H - 1, 111'000'000LL, p2pkh_script(0x30));
+    m.on_new_tip(H - 1, block_hash_of(b1), BITS, MTP,
+                 DASH_PUBKEY_VER, DASH_P2SH_VER, CURTIME, VERSION);
+    ASSERT_TRUE(m.tip_body_pending());
+
+    const auto d = st.describe_decline();
+    EXPECT_EQ(d.cause, "tip-body-pending");
+    EXPECT_EQ(d.threshold, "tip-body-folded");
+    // The credit-pool seed is the first unmet conjunct: it is derived from the
+    // tip block's BODY, which is exactly what has not arrived.
+    EXPECT_EQ(d.value, "have_tip=0,have_mn=1,awaiting=credit-pool-seed")
+        << "a wait must say what it is waiting FOR — the body and the "
+           "getmnlistd reply are different fetches with different repair paths";
+
+    // The body lands: promotion clears both the flag and the axis.
+    m.on_block_connected(b1, H - 1);
+    EXPECT_FALSE(m.tip_body_pending());
+    EXPECT_STREQ(st.tip_body_pending_axis(), "");
+}
+
+// ════════════════════════════════════════════════════════════════════════
 // Bounded full-block buffer (LTC-style retention): eviction proven at the
 // bound — cap 24 with no ChainLock, shrink-to-floor 6 with a fresh one.
 // FAILS-ON-MASTER: no retention exists there at all.


### PR DESCRIPTION
`tip-body-pending` got a duration for the first time under #1202 and has no owner and no plan. This is its diagnosis.

**The headline finding is that the premise that sent me here is wrong, and the same log refutes it.** `tip-body-pending` is not a steady-state cause at 19 s/hour. It is ONE cold-start window, sharing an episode with `not-populated`, and its steady-state cost is measured ZERO. There is nothing to reduce. What was defective was the NAME, and that is what this PR fixes.

---

## 1. Where it is raised, and exactly what state it describes

Raised at `coin_state_maintainer.hpp` `on_new_tip()` (body-first serve tip), surfaced as a decline cause by the refinement in `node_coin_state.hpp` `describe_decline()`.

The state: **we hold the tip HEADER `(h, hash)` but at least one of three per-block derived axes is still at `h-1`**, so `maybe_promote_pending_tip()` has not run and the SERVE tip still points at `h-1`.

The header *commits to* those axes; it does not *carry* them. That is why the template cannot be built, and it is not about the header's difficulty/time fields (those are stashed at header arrival):

| axis | why the template needs it | outstanding fetch |
|---|---|---|
| **credit-pool seed** | the next block's DIP4 CbTx must carry `creditPoolBalance` derived AT the tip; that number moves with the tip block's asset-lock/unlock special txs, which live in the tip block's **body** | `getdata BLOCK <tip hash>` on the coin-P2P leg (or a tip-targeted `mnlistdiff` whose cbTx carries it) |
| **payee cursor** | `nLastPaidHeight` advances by the tip block's own masternode payment — a coinbase output in the same **body**. Without it the next template pays the previous winner again: `bad-cb-payee`, block rejected, share lost | same `getdata BLOCK` |
| **SML currency** | `merkleRootMNList` must be computed over the list **as of** the tip. A cbTx commits that ROOT, and a root is not a list — the body **cannot** supply it | a **separate** `getmnlistd` round trip (base = serve tip, target = header tip) |

That third row is the operationally important one: two of the three arrive with the block, the third does not. `cause=tip-body-pending` on its own cannot distinguish "the block is slow" from "our diff request was silently dropped" — two different lanes with two different repairs.

## 2. Its shape, measured

Instrumented daemonless soak, master `86406d07`, `--embedded-mainnet --embedded-utxo --embedded-mempool-ingest --embedded-serve-mempool-txs`, **no `--coin-rpc`**, 2026-08-09 14:39–16:05, `h=2519019..2519049`.

Every window paired `[EMB-DASH] tip-body-pending h=N` with its `serve tip promoted h=N`:

```
windows paired: 31        promotions: 31        overdue demotes: 0
min 0.376 s   median 0.771 s   p90 2.909 s   max 19.198 s
longest 5: 2519019=19.198  2519040=8.399  2519023=3.901  2519027=2.909  2519045=2.753
```

- **Perfectly correlated with tip changes**: exactly one window per tip advance, 31 for 31. It is not a fault mode; it is the propagation window.
- **Every window closed by promotion**, none by the 30 s doomed-tip demote. The bound never had to fire.
- **30 of the 31 cost ZERO seconds off the embedded arm.** In steady state a serve tip already exists, `h-1` work keeps being served, and no refusal is emitted at all — that is the propagation behaviour every pool has.
- **The 31st is the cold start**, `h=2519019` at 19.198 s, and it is the *entire* 19 s in the rollup.

The rollup's own episode lines say the same thing — the whole cold start is **one 126 s episode** whose cause label changed three times:

```
14:39:14  DECLINED cause=not-populated      value=have_tip=0,have_mn=0   trigger=first
14:40:55  SEG cause=not-populated      dur=102s terminal=cause-change
14:40:55  DECLINED cause=tip-body-pending   value=have_tip=0,have_mn=0
14:41:15  SEG cause=tip-body-pending  dur=19s  terminal=cause-change
14:41:15  DECLINED cause=not-populated      value=have_tip=1,have_mn=0
14:41:20  SEG cause=not-populated      dur=5s   terminal=resumed
14:41:20  RESUMED (was declining: not-populated; dur=126s)
```

102 + 19 + 5 = 126 s, one episode. So the brief's framing — "`not-populated` is cold start, one-time; `tip-body-pending` is the second-largest **steady-state** cause" — separates two labels that are two segments of the same one-time episode. `tip-body-pending` is not 19 s/hour; it is 19 s **once**, and 0 s in the 64 minutes of steady state that followed. It belongs to the cold-start lane (#1162/#1151), not to a steady-state serving budget.

## 3. Verdict: DO NOT shorten the wait

The refusal is correct and the wait is already minimal. Promotion fires the instant the inputs land — median 0.771 s is a block body crossing the network and being parsed. There is no queue to drain, no timer to tune, no round trip to remove. Nothing in this PR touches the serve gate, and no refusal changes from taken to not-taken.

But two things about the NAME were wrong, and both are fixed here.

### Defect 1 — the rename fired on the pending flag alone

`m_tip_body_pending_dbg` says a header tip is awaiting its body. It does **not** say the body is what is holding serving back. Unguarded, the rename also claimed two states where it isn't:

- **`have_tip=0, have_mn=0`** — the soak's 14:40:55 line, verbatim: `cause=tip-body-pending value=have_tip=0,have_mn=0`. Both halves unmet, and **the MN half was the longer pole**: the body folded at 14:41:15 (`have_tip` 0→1) and the arm stayed down another 5 s waiting on `have_mn`. 19 seconds were charged to the block body when the MN seed owned the whole 126 s episode. The threshold made it worse by rewriting `have_tip=1,have_mn=1` to `tip-body-folded` — so the value printed `have_mn=0` while the threshold no longer said `have_mn=1` was required.
- **`have_tip=1, have_mn=0`** — a body-pending window that opens while a serve tip already exists is the normal case and is not a decline at all; if a refusal happens there it is because the MN set went away. The tip body is blocking nothing, and naming it points at the wrong lane.

The rename now requires `have_tip=0 && have_mn=1` — precisely the state the doc comment describes: no serve tip, MN set ready, the tip block's own inputs the only thing missing. Both other states keep `not-populated`, whose value already names both halves and whose threshold keeps requiring both.

This *reduces the number the rollup reports*, but by re-attributing it to the cause that owns it, not by relaxing anything. The 19 s moves to the MN seed, which is where the measurement says it belongs.

### Defect 2 — a wait that did not say what it was waiting for

`maybe_promote_pending_tip()` now records which conjunct is unmet (`credit-pool-seed` / `payee-cursor` / `sml-currency` / `header-tip`, static literals only) and the decline value carries it:

```
cause=tip-body-pending value=have_tip=0,have_mn=1,awaiting=sml-currency threshold=tip-body-folded
```

Appended, never substituted — the populate halves stay readable on the same line. `awaiting=sml-currency` vs `awaiting=credit-pool-seed` is the difference between "chase the diff leg" and "chase the block leg" in one glance, without correlating logs.

The `on_new_tip` doc comment now states the three axes, the outstanding fetch for each, the two very different costs (steady state = zero, cold start = one-time), and an explicit instruction not to try to shorten the wait — so the next reader does not re-derive this from the rollup.

## Scope / safety

- `m_tip_body_pending_dbg` and the new axis are **diagnostic only** — no serve or reward path reads either. The serve gate, the promotion conjuncts and the doomed-tip bound are byte-unchanged.
- The axis is a `const char*` holding string literals exclusively (documented at both the setter and the member); no allocation on any path, no ownership.

## Verification

- `test_dash_coin_state_maintainer`: **52/52 green**, including 2 new tests.
- Both new tests **verified RED** by mutating the guard back to master's unguarded form and rebuilding: `TipBodyPendingIsNotNamedWhileTheMnHalfIsAlsoMissing` gets `"tip-body-pending"`/`"tip-body-folded"` where it expects `"not-populated"`/`"have_tip=1,have_mn=1"`, and `TipBodyPendingNamesTheUnmetPromotionAxis` gets the bare `have_tip=0,have_mn=1` with no `awaiting=`. Guard restored, green again.
- `c2pool-dash` builds and links (gcc-13, Release, `C2POOL_DASH_BLS=ON`).
