### PR TITLE
dash(mn-ckpt): a re-arm must re-adjudicate the persisted cursor, not reuse the verdict

### DIFF
--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -631,8 +631,8 @@ public:
             LOG_ERROR << "[MN-CKPT] " << m_status;
             return;
         }
-        reset_for_arm(cp);
-        // ── #91. READ the persisted record here, but BELIEVE nothing yet.
+        // ── #91. reset_for_arm() READS the persisted record, but BELIEVES
+        // nothing yet.
         //
         // The decisive checks (R4: does our own PoW-validated header chain
         // hold the block this record was folded at?) need a header chain that
@@ -641,7 +641,11 @@ public:
         // evidence than is about to be available — so the record is parked and
         // try_restore() adjudicates it from pump(), at the same moment the
         // anchor's own chain position is verified.
-        load_pending_cursor();
+        //
+        // The read lives in reset_for_arm() rather than here because rearm()
+        // owes it too, and "two hand-maintained lists drift" is the argument
+        // that put every other field in there.
+        reset_for_arm(cp);
         m_status = "armed at h=" + std::to_string(cp.height) + " ("
                    + std::to_string(m_anchor_count) + " masternodes), waiting"
                      " for headers to reach the anchor";
@@ -859,22 +863,33 @@ public:
         ++m_rearms;
         m_last_rearm_at       = at;
         m_last_rearm_at_known = have_tip;
+        // #91: reset_for_arm() re-reads the persisted record and re-opens the
+        // adjudication. It deliberately does NOT erase it here, and it does not
+        // carry the previous arm's verdict either.
+        //
+        // WHAT THIS USED TO DO, AND WHY IT WAS WRONG. It erased the record
+        // unconditionally and latched m_restore_settled, on the argument that
+        // "a re-arm abandons the lineage the record belongs to". That argument
+        // is right about ONE shape and wrong as a blanket: the record is only
+        // implicated when it was folded THROUGH the divergence. A cursor
+        // strictly older than the earliest height we have evidence of
+        // divergence at describes a window we have no evidence against — and
+        // throwing it away costs the full anchor replay (mainnet 2026-08-08:
+        // 5743 blocks, 374 minutes) to buy nothing.
+        //
+        // The implicated shape is not dropped, it is DECIDED: rule R8 in
+        // try_restore() refuses a cursor at or after m_first_divergence — the
+        // same OLDEST-FIRST doctrine the anchor guard above applies, and the
+        // one thing the header chain cannot tell us, because a payee desync is
+        // not a reorg and R4 would pass straight over it. R8 refuses through
+        // restore_cold(), which erases the record, so "leave nothing behind"
+        // still holds exactly where it was earned.
+        //
+        // A re-arm that lands while a restore is still DEFERRING is safe for
+        // the same reason: the deferral counter is reset with everything else
+        // and the record is re-adjudicated from scratch against this arm's
+        // evidence, R8 included.
         reset_for_arm(cp);
-        // #91: a re-arm ABANDONS the lineage the persisted record belongs to —
-        // that state produced a payee queue the maintainer rejected, which is
-        // the whole reason we are here. fail_closed() has usually erased it
-        // already; do it again unconditionally rather than reason about which
-        // paths reach rearm() with a record still on disk. Two sources of
-        // truth for "where is this lane" is the defect this design exists to
-        // prevent, and the cheapest way to have one is to leave nothing behind.
-        if (m_cursor_store) m_cursor_store->erase();
-        // ...and settle the adjudication explicitly, so a re-arm that happened
-        // while a restore was still DEFERRING cannot later adopt a record that
-        // describes the lineage this re-arm is walking away from.
-        m_pending_restore.reset();
-        m_restore_settled = true;
-        m_restore_verdict = "COLD (re-arm): the persisted lineage produced the"
-                            " payee desync this re-arm is recovering from";
         m_status = "RE-ARMED " + std::to_string(m_rearms) + "/"
                    + std::to_string(kMaxRearms) + " at h="
                    + std::to_string(cp.height) + " ("
@@ -1756,6 +1771,16 @@ private:
     /// R7  the cursor is not beyond the replay this lane would do anyway
     ///     (cursor <= tip), and the remaining distance is inside the bridge
     ///     bound.
+    /// R8  the cursor is strictly OLDER than the earliest height we have
+    ///     evidence of divergence at. Checked next to R2 because both ask the
+    ///     same question — "is this record's lineage one we may continue?" —
+    ///     and it is the ONE rule the header chain cannot answer: a payee
+    ///     desync is not a reorg, so R4 passes straight over it. See rearm().
+    ///
+    /// EVERY ONE OF THESE IS RE-RUN ON EVERY ARM. reset_for_arm() clears the
+    /// settled latch and re-parks the record precisely so that no arm inherits
+    /// another arm's verdict — the anchor, the header chain and
+    /// m_first_divergence are all different evidence by then.
     bool try_restore()
     {
         if (m_restore_settled) return true;
@@ -1785,6 +1810,34 @@ private:
                     + m_anchor_hash.GetHex().substr(0, 16) + " source='"
                     + m_anchor_source + "' count="
                     + std::to_string(m_anchor_count));
+            return true;
+        }
+
+        // R8 — DIVERGENCE lineage. m_first_divergence is 0 until a re-seed ask
+        // gives us positive evidence that our replayed queue disagreed with the
+        // chain, so this rule is INERT on a cold start and only speaks on a
+        // re-arm. When it does speak it applies rearm()'s own OLDEST-FIRST
+        // doctrine to the record rather than to the anchor: a cursor folded
+        // THROUGH the divergence carries the divergence, and resuming it would
+        // re-arm the wrong queue at speed. A cursor strictly older than the
+        // divergence describes a window we have no evidence against, and
+        // R2/R4/R5 above and below adjudicate it exactly as they would on a
+        // cold start. restore_cold() erases the refused record, so nothing is
+        // left behind for a later start to re-adopt.
+        if (m_first_divergence != 0
+            && rec.cursor_height >= m_first_divergence) {
+            restore_cold(
+                "R8 divergence-lineage",
+                "the record was folded through h="
+                    + std::to_string(rec.cursor_height)
+                    + ", at or after the earliest height we have evidence of"
+                      " divergence at (h="
+                    + std::to_string(m_first_divergence)
+                    + "). A cursor inside the diverged window resumes the very"
+                      " set that produced the desync — the same trap the"
+                      " anchor-selection guard refuses a newer anchor for, and"
+                      " one our own header chain cannot see: a payee desync is"
+                      " not a reorg, so R4 would pass");
             return true;
         }
 
@@ -3285,6 +3338,10 @@ public:
     /// m_last_rearm_reason). It MUST survive a re-arm or the cap can never
     /// fire. Nor the configured seams / m_max_bridge / m_fold_interval /
     /// m_has_sml_fn, which are wiring, not bridge state.
+    ///
+    /// This function ENDS by re-reading the persisted cursor, so arm() and
+    /// rearm() get one reset list rather than two — see the #91 block below
+    /// for why the adjudication latch in particular may not be inherited.
     void reset_for_arm(const MnCheckpoint& cp)
     {
         // The lane KEEPS its own anchor. poll_rearm() has no caller to hand it
@@ -3386,9 +3443,9 @@ public:
         // legitimate publish behind a debt that was already paid block by block.
         //
         // Note what is deliberately NOT done here: the record on disk is not
-        // erased. arm() reads it immediately after this call, and a re-arm
-        // erases it at ITS own call site, where the reason (the previous
-        // lineage is being abandoned) is local and legible.
+        // erased. It is RE-READ instead (below), and a verdict of COLD erases
+        // it at the rule that reached that verdict, where the reason is local
+        // and legible.
         m_cursor_restored  = false;
         m_restored_at      = 0;
         m_restored_applied = 0;
@@ -3399,6 +3456,34 @@ public:
         m_persist_arith_warned = false;
         m_resume_hold_logged   = 0;
         m_restore_defers       = 0;
+        // ── THE ADJUDICATION ITSELF, not merely its result. ───────────────
+        //
+        // m_restore_settled is the LATCH that says "this process no longer
+        // owes an adjudication". It was the one #91 field this list forgot,
+        // and forgetting it is not a cosmetic omission: pump()'s
+        //     if (!m_restore_settled && !try_restore()) return;
+        // is the ONLY call site of try_restore(), so a latch left standing
+        // makes the guard unfireable for the rest of the process. Every later
+        // arm then walks with WHATEVER verdict the first one reached —
+        // adjudicated against a header chain, an anchor and a divergence
+        // record that have all since moved on.
+        //
+        // Both directions of that reuse are wrong, and the fast one is worse:
+        //   * a preserved REFUSAL pins every re-arm to m_anchor_height, which
+        //     on mainnet 2026-08-08 was 5743 blocks / 374 minutes of replay
+        //     the persisted cursor could have skipped;
+        //   * a preserved ACCEPTANCE resumes at a height adjudicated for a
+        //     DIFFERENT arm, never re-checked against the current chain — it
+        //     silently skips R4, the reorg refusal. A fast wrong start is
+        //     harder to notice than a slow right one.
+        //
+        // So the verdict is not carried in EITHER direction. The record is
+        // re-loaded and re-parked, and try_restore() decides again from the
+        // evidence that exists NOW — which may legitimately say COLD.
+        m_pending_restore.reset();
+        m_restore_verdict.clear();
+        m_restore_settled = true;    // the declared default: nothing owed…
+        load_pending_cursor();       // …re-opened here iff a record exists
         m_progress.start(0, m_now());
         m_watchdog.disarm();         // re-armed at the Waiting->Bridging edge
         m_anchor_eligible   = m_machine.eligible_size();

--- a/test/test_dash_mn_checkpoint.cpp
+++ b/test/test_dash_mn_checkpoint.cpp
@@ -5503,3 +5503,147 @@ TEST(DashMnBridgeCursor, RecordRoundTripsEveryFieldAndRejectsTrailingBytes)
     EXPECT_FALSE(cs.store.load(why2).has_value());
     EXPECT_NE(why2.find("trailing"), std::string::npos) << why2;
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 11-13. A RE-ARM RE-ADJUDICATES. IT DOES NOT REUSE THE VERDICT.
+//
+// pump() has exactly one call site for try_restore():
+//     if (!m_restore_settled && !try_restore()) return;
+// and m_restore_settled was the one #91 field reset_for_arm() forgot. With it
+// latched, a second arm in the same process walks with whatever verdict the
+// FIRST one reached — against an anchor, a header chain and a divergence record
+// that have all since moved on. Both directions of that reuse are defects:
+//
+//   * a preserved REFUSAL pins every re-arm to the anchor. MEASURED on mainnet
+//     2026-08-08: 5743 blocks, 374 minutes of replay the persisted cursor could
+//     have skipped, on the cold-start/re-arm line that is the single largest
+//     entry in the serve-gate roll-up.
+//   * a preserved ACCEPTANCE resumes at a height adjudicated for a DIFFERENT
+//     arm, skipping the reorg refusal (R4) that adjudication exists to run. A
+//     fast wrong start is harder to notice than a slow right one.
+//
+// So the tests below assert the ADJUDICATION, not an outcome: the same record
+// must be re-decided on every arm, and it must be allowed to come out ACCEPT
+// (11), REFUSE-on-reorg (12) or REFUSE-on-divergence (13) purely from the
+// evidence that exists at that arm.
+// ═══════════════════════════════════════════════════════════════════════════
+
+// ── 11. The re-arm re-runs the adjudication and resumes when the chain says so
+TEST(DashMnBridgeCursor, ReArmReAdjudicatesTheCursorInsteadOfWalkingFromTheAnchor)
+{
+    TempCursorStore cs("rearm-readjudicate");
+
+    // Process 1 replays 1519544..1519545 and persists a cursor there.
+    { CursorRun a(&cs.store, 1519545); a.run(); ASSERT_TRUE(a.h.published); }
+    ASSERT_TRUE(cs.exists());
+
+    // Process 2 arms at that same tip. The cursor is adjudicated and ACCEPTED;
+    // nothing is applied (cursor == tip), so the record on disk is untouched.
+    CursorRun r(&cs.store, 1519545);
+    r.run();
+    ASSERT_TRUE(r.h.lane.cursor_restored()) << r.h.lane.restore_verdict();
+    ASSERT_EQ(r.h.lane.restored_at(), 1519545u);
+
+    // The chain moves on and the maintainer asks for a re-seed.
+    r.h.requested.clear();
+    r.h.tip = 1519546;
+    ASSERT_EQ(r.h.lane.rearm(good_checkpoint(), "unit test: payee desync"),
+              MnCheckpointLane::RearmOutcome::Armed)
+        << r.h.lane.last_rearm_reason();
+
+    // The re-arm carries NO verdict forward — not even the favourable one.
+    EXPECT_FALSE(r.h.lane.cursor_restored())
+        << "a re-arm that starts out already 'restored' is standing on a"
+           " verdict reached for a different arm, and has skipped R4";
+    EXPECT_EQ(r.h.lane.restored_at(), 0u);
+
+    // It re-runs the rules, and on this chain they say ACCEPT.
+    r.h.lane.pump();
+    ASSERT_TRUE(r.h.lane.cursor_restored())
+        << "the re-arm never called try_restore() again; verdict: "
+        << r.h.lane.restore_verdict();
+    EXPECT_EQ(r.h.lane.restored_at(), 1519545u);
+
+    for (uint32_t asked : r.h.requested) {
+        EXPECT_GT(asked, 1519545u)
+            << "h=" << asked << ": the re-armed bridge walked from the anchor"
+               " across heights a previous process had already folded AND"
+               " persisted. On mainnet that walk measured 5743 blocks / 374"
+               " minutes while the embedded arm stayed demoted";
+    }
+    EXPECT_EQ(r.h.lane.cursor_height(), 1519546u) << r.h.lane.status();
+}
+
+// ── 12. ...and it RE-VALIDATES: a reorg under the cursor is caught by R4
+TEST(DashMnBridgeCursor, ReArmReValidatesTheCursorAgainstTheChainItNowRunsOn)
+{
+    TempCursorStore cs("rearm-revalidate");
+    { CursorRun a(&cs.store, 1519545); a.run(); ASSERT_TRUE(a.h.published); }
+
+    CursorRun r(&cs.store, 1519545);
+    r.run();
+    ASSERT_TRUE(r.h.lane.cursor_restored()) << r.h.lane.restore_verdict();
+    ASSERT_EQ(r.h.lane.restored_at(), 1519545u);
+
+    // The chain REORGS past the persisted cursor. The record's bytes have not
+    // changed; the chain underneath them has — which is exactly the state a
+    // reused verdict cannot see, because R4 only runs during adjudication.
+    r.h.headers[1519545] = synth_block_hash(0xdead);
+    r.h.requested.clear();
+    r.h.tip = 1519546;
+    // Bodies stop arriving here, so the COLD walk this refusal starts cannot
+    // persist a fresh record over the erased one. Without that, "the file
+    // exists" would be a measurement of the replay, not of the erasure.
+    r.h.auto_deliver = false;
+    ASSERT_EQ(r.h.lane.rearm(good_checkpoint(), "unit test: payee desync"),
+              MnCheckpointLane::RearmOutcome::Armed)
+        << r.h.lane.last_rearm_reason();
+    r.h.lane.pump();
+
+    EXPECT_FALSE(r.h.lane.cursor_restored());
+    EXPECT_EQ(r.h.lane.restored_at(), 0u);
+    EXPECT_NE(r.h.lane.restore_verdict().find("R4"), std::string::npos)
+        << "R4 is the reorg refusal and it can only have fired if this arm"
+           " re-ran the adjudication; verdict: " << r.h.lane.restore_verdict();
+    EXPECT_FALSE(cs.exists())
+        << "a REFUSED record must be erased, not left for a later start to"
+           " re-adopt";
+    ASSERT_FALSE(r.h.requested.empty());
+    EXPECT_EQ(r.h.requested.front(), kAnchorHeight + 1)
+        << "a refused cursor means a COLD walk from the anchor — a legitimate"
+           " verdict, and the one this chain gives";
+}
+
+// ── 13. R8: the one rule the header chain cannot supply
+TEST(DashMnBridgeCursor, ReArmRefusesACursorFoldedThroughTheDivergence)
+{
+    TempCursorStore cs("rearm-diverged");
+    { CursorRun a(&cs.store, 1519546); a.run(); ASSERT_TRUE(a.h.published); }
+
+    // The SAME record, adjudicated with no divergence evidence: ACCEPTED.
+    CursorRun r(&cs.store, 1519546);
+    r.run();
+    ASSERT_TRUE(r.h.lane.cursor_restored()) << r.h.lane.restore_verdict();
+    ASSERT_EQ(r.h.lane.restored_at(), 1519546u);
+
+    // Now the maintainer reports a desync at that very tip. The cursor was
+    // folded THROUGH the diverged height, so resuming it would re-arm the queue
+    // that produced the desync — fast, and wrong. Nothing about the header
+    // chain changed, so R4 still passes: R8 is the rule that has to catch this.
+    r.h.requested.clear();
+    r.h.auto_deliver = false;   // same reason as case 12: keep the erasure visible
+    ASSERT_EQ(r.h.lane.rearm(good_checkpoint(), "unit test: payee desync"),
+              MnCheckpointLane::RearmOutcome::Armed)
+        << r.h.lane.last_rearm_reason();
+    r.h.lane.pump();
+
+    EXPECT_FALSE(r.h.lane.cursor_restored());
+    EXPECT_NE(r.h.lane.restore_verdict().find("R8"), std::string::npos)
+        << r.h.lane.restore_verdict();
+    EXPECT_FALSE(cs.exists())
+        << "the implicated record must be erased where the rule refused it";
+    ASSERT_FALSE(r.h.requested.empty());
+    EXPECT_EQ(r.h.requested.front(), kAnchorHeight + 1)
+        << "the anchor IS the right answer here; the point is that it was"
+           " REACHED by a rule, not inherited from a latch";
+}


### PR DESCRIPTION
## The defect

`pump()` has exactly one call site for `try_restore()`:

```cpp
if (!m_restore_settled && !try_restore()) return;
```

`reset_for_arm()` resets `m_cursor_restored` and `m_restored_at` — the RESULT of an
adjudication — but not `m_restore_settled`, the latch that says *this process no longer
owes one*. With that latch standing the guard cannot fire twice in a process, so every
arm after the first walks on a verdict reached against a header chain, an anchor and a
divergence record that have all since moved on.

`rearm()` then made it permanent on purpose: it erased the persisted record and set
`m_restore_settled = true`, on the argument that a re-arm abandons the lineage the record
belongs to.

**Measured, mainnet 2026-08-08:** `cursor RESTORED` appeared exactly once per process —
the cold start. Both re-arms in that run walked from the static anchor h=2513000: **5743
blocks, 374 minutes** with the embedded arm demoted to the dashd fallback the whole time.
`not-populated` (the cold-start / re-arm class) is **107s of 3600s** in the serve-gate
roll-up — the largest single line in it.

Both directions of reuse are wrong, and the fast one is worse:

* a preserved **REFUSAL** pins every re-arm to the anchor (the 374 minutes above);
* a preserved **ACCEPTANCE** resumes at a height adjudicated for a *different* arm, never
  re-checked against the current chain — it silently skips **R4**, the reorg refusal. A
  fast wrong start is harder to notice than a slow right one.

## The fix

Not "clear the latch and resume" — that would treat the persisted cursor as trustworthy.
A re-arm **re-adjudicates** and takes whatever verdict the current evidence gives, which
may legitimately be the anchor.

* `reset_for_arm()` clears `m_restore_settled`, `m_pending_restore` and
  `m_restore_verdict` alongside the two it already cleared, then re-reads the record.
  `arm()`'s `load_pending_cursor()` call moves in with it, so the two arming paths share
  **one** reset list instead of two that can drift — the same argument that put every
  other field in there.
* `rearm()` no longer erases the record or pre-settles the verdict. The record is
  **decided**, not dropped.
* New rule **R8**: refuse a cursor at or after `m_first_divergence`. This is `rearm()`'s
  own OLDEST-FIRST doctrine — already applied to the *anchor* two guards above — applied
  to the *record*, and it is the one thing our header chain cannot supply: a payee desync
  is not a reorg, so R4 passes straight over it. R8 refuses through `restore_cold()`,
  which erases the record, so "leave nothing behind" still holds exactly where it is
  earned. R8 is inert until a re-seed ask has produced positive evidence, so the
  cold-start path is byte-unchanged.

### Net behaviour

| situation at a re-arm | verdict |
|---|---|
| cursor strictly older than the earliest observed divergence, chain still holds it | **RESUME** — re-validated by R2/R4/R5 against the chain running *now* |
| cursor folded through the divergence | **COLD** by R8, record erased |
| chain reorged out from under the cursor | **COLD** by R4, record erased |

Neither outcome is inherited from a previous arm.

## Tests

Three cases in `test_dash_mn_checkpoint.cpp`, **verified red on master, green after**
(the source fix stashed, target rebuilt, all three fail; restored, all three pass):

1. `ReArmReAdjudicatesTheCursorInsteadOfWalkingFromTheAnchor` — a re-arm calls
   `try_restore()` again and requests no height a previous process already folded and
   persisted.
2. `ReArmReValidatesTheCursorAgainstTheChainItNowRunsOn` — a reorg under the cursor is
   refused by **R4**, which can only have fired if the adjudication actually re-ran.
   (On master the verdict is the `COLD (re-arm)` boilerplate — no rule ever ran.)
3. `ReArmRefusesACursorFoldedThroughTheDivergence` — the *same* record, ACCEPTED with no
   divergence evidence, is refused by **R8** once a desync at that height is reported.

Cases 2 and 3 stop delivering block bodies after the re-arm so the cold walk cannot
persist a fresh record over the erased one; otherwise "the file exists" would be a
measurement of the replay, not of the erasure.

## Verification

* Full build green (`conan install` + `cmake --build`, Release, gcc).
* `test_dash_node_reception_wire`: **153/153**, including all 13 `DashMnBridgeCursor` cases.
* `ctest`: **1325 passed, 0 failed**. The `Not Run` entries are targets outside the
  default build in this configuration and are unrelated to this change.

## Scope

`src/impl/dash/coin/mn_checkpoint_lane.hpp` and its test only. No other lane, no wire
format, no serving path. The persisted record's encoding is untouched.
