### PR TITLE
dash(serve-gate): carry the missing quorum identity to the refusal instead of "nullopt"

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -4393,7 +4393,8 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                  // by-value capture would freeze the null it holds today.
                  // Same lifetime class as &node_coin_state above.
                  &mined_commitment_index]
-                (uint32_t next_h) -> std::optional<dash::coin::QcBlockPlan> {
+                (uint32_t next_h, dash::coin::QcPlanGap* plan_gap)
+                    -> std::optional<dash::coin::QcBlockPlan> {
                     if (*qc_first_plan_h == 0u) *qc_first_plan_h = next_h;
                     // Observe the MINED set at the tip we are building on.
                     // D2 root memo: this lambda runs INSIDE emit_ok on the
@@ -4471,7 +4472,11 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                       uint8_t t, const uint256& qh) {
                                       return mi->has_mined_commitment(t, qh);
                                   })
-                            : std::function<bool(uint8_t, const uint256&)>());
+                            : std::function<bool(uint8_t, const uint256&)>(),
+                        // The identity of what was missing, handed straight to
+                        // the serve-gate refusal so its VALUE names a quorum
+                        // instead of the word "nullopt".
+                        plan_gap);
                     if (!plan && !gap.quorum_hash.IsNull()
                         && *qc_gap_logged_h != next_h) {
                         *qc_gap_logged_h = next_h;

--- a/src/impl/dash/coin/dkg_commitments.hpp
+++ b/src/impl/dash/coin/dkg_commitments.hpp
@@ -190,6 +190,7 @@
 #include <functional>
 #include <map>
 #include <optional>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -979,6 +980,88 @@ struct QcBlockPlan {
     uint256 merkle_root_quorums;
 };
 
+/// WHICH of build_daemonless_qc_plan's three structurally different refusals
+/// produced the std::nullopt. Before this existed the serve gate printed the
+/// SAME word — "nullopt" — for all three, which is a value that cannot
+/// disagree with anything: it satisfies the #1038/#1039 cause/value/threshold
+/// shape while naming nothing an operator can act on.
+enum class QcPlanStage : uint8_t {
+    None = 0,             // a plan WAS produced — no refusal to name
+    Unreported,           // provider does not report a reason (1-arg plan fn)
+    SlotSetUnderivable,   // compute_required_qc_slots said no: below the serve
+                          // floor inside a window, or a quorum base header the
+                          // slot list needs is not held locally
+    SlotUnsatisfied,      // the slot list derived, but one mandatory slot has
+                          // no BLS-verified real / attested-null commitment.
+                          // THIS is the case that carries a quorum identity.
+    RootFoldUnderivable,  // every slot satisfied, but merkleRootQuorums could
+                          // not be folded (a leaf's base height is unknown)
+};
+
+inline const char* qc_plan_stage_name(QcPlanStage s)
+{
+    switch (s) {
+        case QcPlanStage::None:                return "n/a";
+        case QcPlanStage::Unreported:          return "reason-unreported";
+        case QcPlanStage::SlotSetUnderivable:  return "slot-set-underivable";
+        case QcPlanStage::SlotUnsatisfied:     return "slot-unsatisfied";
+        case QcPlanStage::RootFoldUnderivable: return "root-fold-underivable";
+    }
+    return "n/a";
+}
+
+/// The identity of what the plan LACKED, carried from the producer to the
+/// refusal site so the decline's VALUE names a quorum instead of a monad.
+/// Observability only: nothing here is ever consulted by a serve decision.
+struct QcPlanGap {
+    QcPlanStage stage{QcPlanStage::None};
+    // Populated only for QcPlanStage::SlotUnsatisfied — the other stages have
+    // no single offending quorum, and inventing one would be worse than "n/a".
+    bool        slot_known{false};
+    uint8_t     llmq_type{0};
+    int16_t     quorum_index{-1};
+    uint256     quorum_hash;
+    QcSlotGap   slot_gap{QcSlotGap::Unevaluated};
+    int32_t     cached_signers{-1};   // -1 == not evaluated -> prints n/a
+
+    /// The decline VALUE. Never the literal "nullopt": either the offending
+    /// quorum's identity + why that slot failed, or the named stage that has
+    /// no quorum to point at.
+    std::string describe() const {
+        if (stage == QcPlanStage::None) return "n/a";
+        if (!slot_known) return qc_plan_stage_name(stage);
+        return "llmqType=" + std::to_string(static_cast<int>(llmq_type))
+             + ",quorumIndex=" + std::to_string(static_cast<int>(quorum_index))
+             + ",quorum=" + quorum_hash.GetHex().substr(0, 16)
+             + ",gap=" + qc_slot_gap_name(slot_gap)
+             + ",signers="
+             + (cached_signers >= 0 ? std::to_string(cached_signers)
+                                    : std::string("n/a"));
+    }
+};
+
+/// Fill a QcPlanGap from the slot the commitment sourcing failed on. A null
+/// quorum_hash IS the discriminator daemonless_qc_commitments documents for
+/// "the slot set itself was underivable" (it leaves `first_gap` untouched in
+/// that case), so it maps to the stage that has no quorum, not to a
+/// fabricated all-zero one.
+inline QcPlanGap qc_plan_gap_from_slot(const RequiredQcSlot& s)
+{
+    QcPlanGap g;
+    if (s.quorum_hash.IsNull()) {
+        g.stage = QcPlanStage::SlotSetUnderivable;
+        return g;
+    }
+    g.stage          = QcPlanStage::SlotUnsatisfied;
+    g.slot_known     = true;
+    g.llmq_type      = s.params.type;
+    g.quorum_index   = s.quorum_index;
+    g.quorum_hash    = s.quorum_hash;
+    g.slot_gap       = s.gap;
+    g.cached_signers = s.cached_signers;
+    return g;
+}
+
 /// Compose the full daemonless plan. std::nullopt => cannot be derived
 /// safely at this height — slot set underivable, root fold underivable, or
 /// ANY mandatory slot lacking a verified real / attested-null commitment
@@ -997,6 +1080,10 @@ struct QcBlockPlan {
 /// MinedCommitmentIndex refuses to arm on a live-tip node until dashd's
 /// UndoBlock half (v23.1.7 llmq/blockprocessor.cpp:383-408) is ported.
 /// Defaulted null: every pre-existing caller keeps byte-identical behaviour.
+/// `plan_gap`, when non-null, receives WHY the plan could not be built — the
+/// offending quorum's identity when there is one, otherwise the named stage.
+/// It is written ONLY on the nullopt paths; a successful plan leaves it at
+/// QcPlanStage::None.
 inline std::optional<QcBlockPlan> build_daemonless_qc_plan(
     LlmqNetwork net, uint32_t next_height,
     const QuorumManager& qmgr,
@@ -1005,19 +1092,34 @@ inline std::optional<QcBlockPlan> build_daemonless_qc_plan(
     const MineableCommitmentCache* cache = nullptr,
     const DkgNullEvidenceFn& null_evidence = nullptr,
     RequiredQcSlot* first_gap = nullptr,
-    const std::function<bool(uint8_t, const uint256&)>& also_has_mined = nullptr)
+    const std::function<bool(uint8_t, const uint256&)>& also_has_mined = nullptr,
+    QcPlanGap* plan_gap = nullptr)
 {
     auto has_mined = [&qmgr, &also_has_mined](uint8_t t, const uint256& qh) {
         if (qmgr.find(t, qh).has_value()) return true;
         return also_has_mined ? also_has_mined(t, qh) : false;
     };
+    // Sink the slot locally so `first_gap`'s documented contract is preserved
+    // verbatim (untouched when the slot set itself was underivable) while
+    // plan_gap still gets an answer with no caller opt-in.
+    RequiredQcSlot slot{};
     auto commitments = daemonless_qc_commitments(
         net, next_height, hash_at_height, has_mined, cache,
-        null_evidence, first_gap);
-    if (!commitments) return std::nullopt;
+        null_evidence, &slot);
+    if (first_gap != nullptr && !slot.quorum_hash.IsNull()) *first_gap = slot;
+    if (!commitments) {
+        if (plan_gap != nullptr) *plan_gap = qc_plan_gap_from_slot(slot);
+        return std::nullopt;
+    }
     auto root = compute_merkle_root_quorums_with_block(
         net, qmgr, *commitments, height_of_hash);
-    if (!root) return std::nullopt;
+    if (!root) {
+        if (plan_gap != nullptr) {
+            *plan_gap = QcPlanGap{};
+            plan_gap->stage = QcPlanStage::RootFoldUnderivable;
+        }
+        return std::nullopt;
+    }
     return QcBlockPlan{std::move(*commitments), *root};
 }
 

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -661,8 +661,30 @@ public:
     /// reward-safe outcome as the PHASE-1 refusal, but now only when
     /// genuinely unable instead of for the whole 9-block window. Unset
     /// (default) preserves the refusal posture exactly.
-    void set_qc_plan_fn(std::function<std::optional<QcBlockPlan>(uint32_t)> fn) {
+    ///
+    /// TWO shapes, and the two-argument one is what production wires. A bare
+    /// `std::optional<QcBlockPlan>` throws away the identity of what was
+    /// missing, and the refusal downstream then had nothing to print but the
+    /// literal "nullopt" — a value that cannot disagree with anything. The
+    /// QcPlanGap out-parameter carries the offending quorum (llmqType,
+    /// quorumIndex, quorumHash, per-slot gap reason) to the decline's VALUE
+    /// field. The one-argument overload stays for providers that genuinely
+    /// have no reason to report; it names ITSELF ("reason-unreported") rather
+    /// than pretending the gap was measured.
+    void set_qc_plan_fn(
+        std::function<std::optional<QcBlockPlan>(uint32_t, QcPlanGap*)> fn) {
         m_qc_plan_fn = std::move(fn);
+    }
+    void set_qc_plan_fn(std::function<std::optional<QcBlockPlan>(uint32_t)> fn) {
+        m_qc_plan_fn = [f = std::move(fn)](uint32_t h, QcPlanGap* gap)
+            -> std::optional<QcBlockPlan> {
+            auto plan = f(h);
+            if (!plan && gap != nullptr) {
+                *gap = QcPlanGap{};
+                gap->stage = QcPlanStage::Unreported;
+            }
+            return plan;
+        };
     }
 
     /// PoSe no-op proof for one REAL (non-null) type-6 commitment — the
@@ -935,9 +957,10 @@ public:
         // a plan fn the PHASE-1 refusal stays.
         std::optional<QcBlockPlan> qc_plan;
         if (m_qc_plan_fn) {
-            qc_plan = m_qc_plan_fn(next_h);
-            if (!qc_plan)   // underivable — fail closed
-                return reject("emit-qc-plan-underivable", "nullopt",
+            QcPlanGap qc_gap;
+            qc_plan = m_qc_plan_fn(next_h, &qc_gap);
+            if (!qc_plan)   // underivable — fail closed, NAMING what was missing
+                return reject("emit-qc-plan-underivable", qc_gap.describe(),
                               "derivable-qc-plan@h=" + std::to_string(next_h));
             // Collect the type-6 payloads actually in the template.
             std::vector<std::vector<unsigned char>> got;
@@ -1197,9 +1220,12 @@ public:
         // serve floor) refuses exactly like the PHASE-1 posture. Without a
         // plan fn the BLOCKER-1 window refusal below stays authoritative.
         std::optional<QcBlockPlan> qc_plan;
+        // The gap is the qc clause's VALUE. It travels WITH the bool, because
+        // a bare bool is exactly what left the refusal with nothing to print.
+        QcPlanGap qc_gap;
         bool qc_ok = true;
         if (m_qc_plan_fn && m_populated) {
-            qc_plan = m_qc_plan_fn(m_prev_height + 1);
+            qc_plan = m_qc_plan_fn(m_prev_height + 1, &qc_gap);
             qc_ok = qc_plan.has_value();
         }
         // Resolve the superblock disposition ONCE (fail-closed unless the
@@ -1230,7 +1256,7 @@ public:
         // logging — and the two had already drifted (classify_decline never
         // checked payee_resolvable, so a #996 money-path refusal surfaced as
         // "viable-race"). There is now exactly one list.
-        e.decline   = evaluate_viability(qc_ok, sb.ok, payee_resolvable,
+        e.decline   = evaluate_viability(qc_ok, qc_gap, sb.ok, payee_resolvable,
                                          utxo_immature);
         e.has_state = e.decline.viable;
         // NAME THE STATE: while the UTXO lane is immature under the OPT-IN
@@ -1356,7 +1382,12 @@ private:
     /// the builder regardless); re-invoking those predicates here would double
     /// the cost on a per-template path and, worse, could observe a different
     /// answer than the one the bundle was built from.
-    DeclineReport evaluate_viability(bool qc_ok, bool sb_ok,
+    /// `qc_gap` rides alongside `qc_ok` for the same reason the other inputs
+    /// are passed in: it was measured at the one place that CAN measure it —
+    /// the plan call — and re-deriving it here would mean a second plan build
+    /// that could answer differently. It is meaningful only when !qc_ok.
+    DeclineReport evaluate_viability(bool qc_ok, const QcPlanGap& qc_gap,
+                                     bool sb_ok,
                                      bool payee_resolvable,
                                      bool utxo_immature) const {
         const uint32_t next_h = m_prev_height + 1;
@@ -1391,7 +1422,11 @@ private:
             d = refuse("chain-not-synced", "tip=" + tip + ",synced=false",
                        "header-tip-current");
         else if (!qc_ok)
-            d = refuse("qc-plan-underivable", "nullopt",
+            // NAME THE MISSING QUORUM. "nullopt" satisfied the #1038/#1039
+            // cause/value/threshold shape and defeated its purpose: it is a
+            // value that cannot disagree with anything, so the largest
+            // addressable refusal class was unactionable from the log alone.
+            d = refuse("qc-plan-underivable", qc_gap.describe(),
                        "derivable-qc-plan@h=" + std::to_string(next_h));
         else if (utxo_immature
                  && m_utxo_immature_policy == UtxoImmaturePolicy::Refuse)
@@ -1691,7 +1726,9 @@ private:
     // heights refuse the embedded arm even when the provider is confident.
     std::function<bool()> m_superblock_sync_complete_fn;
     std::function<bool(uint32_t)> m_commitment_window_fn;  // refuse embedded on DKG commitment heights
-    std::function<std::optional<QcBlockPlan>(uint32_t)> m_qc_plan_fn;  // E1: serve DKG windows daemonlessly
+    // E1: serve DKG windows daemonlessly. The QcPlanGap out-param is how a
+    // refusal learns WHICH quorum it lacked (see set_qc_plan_fn).
+    std::function<std::optional<QcBlockPlan>(uint32_t, QcPlanGap*)> m_qc_plan_fn;
     // PoSe no-op proof for a REAL commitment (emit-qc-real-pose-unfolded gate);
     // unset => capability absent => every non-null commitment refused.
     std::function<std::optional<bool>(const vendor::CFinalCommitment&)> m_qc_pose_noop_fn;

--- a/test/test_dash_node_coin_state.cpp
+++ b/test/test_dash_node_coin_state.cpp
@@ -1274,6 +1274,191 @@ TEST(DashServeGateNamesRefusal, QcPlanDerivableIsViable) {     // negative twin
     EXPECT_TRUE(st.describe_decline().viable);
 }
 
+// ════════════════════════════════════════════════════════════════════════
+// THE REFUSAL MUST NAME THE MISSING QUORUM
+//
+// #1038/#1039 established that every serve-gate decline carries cause, VALUE
+// and threshold. qc-plan-underivable satisfied the shape with the literal
+// string "nullopt" — a value that cannot disagree with anything. The identity
+// of the missing quorum was known at the producer (main_dash's plan closure
+// already logs it as [QC-COMPLETENESS]) and thrown away at the std::function
+// boundary, which returned a bare std::optional.
+//
+// RED WITHOUT THE FIX: revert m_qc_plan_fn to the one-argument shape and both
+// tests below fail on the value — the first gets "nullopt" where it demands a
+// quorum hash, the second gets "nullopt" where it demands a named stage.
+// ════════════════════════════════════════════════════════════════════════
+
+namespace {
+
+// A synthetic header chain: the hash is a pure function of the height, and the
+// height lands in the bytes GetHex() prints FIRST, so the 16-char prefix the
+// refusal carries actually discriminates one quorum base height from another.
+std::optional<uint256> synth_hash_at_height(uint32_t h)
+{
+    uint256 u;
+    std::memset(u.data(), 0xCD, 32);
+    std::memcpy(u.data() + 28, &h, 4);
+    return u;
+}
+
+}  // namespace
+
+TEST(DashServeGateNamesRefusal, QcPlanUnderivableNamesTheMissingQuorum) {
+    NodeCoinState st;
+    seed_single_mn(st, p2pkh_script(0x30));
+    seed_sml(st);
+    st.set_require_sml(true);
+    st.set_sml_current_hash(raw256(0xAB));
+
+    // The REAL producer, with no commitment cache and no failed-DKG evidence:
+    // the slot list derives, and the first mandatory slot is unsatisfiable.
+    // `first_gap` is captured independently so the expected identity comes from
+    // the sourcing layer, not from a constant transcribed into the assertion.
+    dash::coin::RequiredQcSlot observed{};
+    st.set_qc_plan_fn(
+        [&st, &observed](uint32_t next_h, dash::coin::QcPlanGap* gap)
+            -> std::optional<dash::coin::QcBlockPlan> {
+            return dash::coin::build_daemonless_qc_plan(
+                dash::coin::LlmqNetwork::Testnet, next_h, st.qmgr(),
+                synth_hash_at_height,
+                [](const uint256&) -> std::optional<uint32_t> {
+                    return std::nullopt;
+                },
+                /*cache=*/nullptr, /*null_evidence=*/nullptr, &observed,
+                /*also_has_mined=*/nullptr, gap);
+        });
+
+    // Phase 10 of a testnet interval-24 cycle: mandatory slots exist here.
+    st.set_tip(1518417, raw256(0xAB), 0x1b104be3u, 1'700'000'000u,
+               DASH_PUBKEY_VER, DASH_P2SH_VER, 1'700'000'123u, 0x20000000u);
+
+    const DeclineReport d = st.describe_decline();
+    ASSERT_FALSE(d.viable);
+    ASSERT_EQ(d.cause, "qc-plan-underivable");
+    ASSERT_FALSE(observed.quorum_hash.IsNull())
+        << "fixture check: this height must have a mandatory slot to miss";
+
+    EXPECT_NE(d.value, "nullopt")
+        << "THE defect: the refusal named nothing an operator could act on";
+    EXPECT_NE(d.value.find("llmqType="
+                           + std::to_string(
+                                 static_cast<int>(observed.params.type))),
+              std::string::npos)
+        << "the refusal must name the llmqType it lacked: " << d.value;
+    EXPECT_NE(d.value.find("quorumIndex="
+                           + std::to_string(
+                                 static_cast<int>(observed.quorum_index))),
+              std::string::npos)
+        << "the refusal must name the quorum slot index: " << d.value;
+    EXPECT_NE(d.value.find(observed.quorum_hash.GetHex().substr(0, 16)),
+              std::string::npos)
+        << "the refusal must name the quorum HASH -- that is the identity a "
+           "[QC-COMPLETENESS] line can be joined on: " << d.value;
+    EXPECT_NE(d.value.find("gap=no-commitment-cached"), std::string::npos)
+        << "and WHY that slot was unsatisfiable: " << d.value;
+    EXPECT_EQ(d.threshold, "derivable-qc-plan@h=1518418");
+}
+
+// The structural nullopts have no single offending quorum. They must still
+// name themselves rather than fall back to a word that means nothing.
+TEST(DashServeGateNamesRefusal, QcPlanUnderivableNamesTheStageWhenNoQuorumExists) {
+    NodeCoinState st;
+    seed_single_mn(st, p2pkh_script(0x30));
+    seed_sml(st);
+    st.set_require_sml(true);
+    st.set_sml_current_hash(raw256(0xAB));
+
+    // No header for the quorum base height => compute_required_qc_slots cannot
+    // even build the slot list, so there is no quorum to point at.
+    st.set_qc_plan_fn(
+        [&st](uint32_t next_h, dash::coin::QcPlanGap* gap)
+            -> std::optional<dash::coin::QcBlockPlan> {
+            return dash::coin::build_daemonless_qc_plan(
+                dash::coin::LlmqNetwork::Testnet, next_h, st.qmgr(),
+                [](uint32_t) -> std::optional<uint256> {
+                    return std::nullopt;   // header gap
+                },
+                [](const uint256&) -> std::optional<uint32_t> {
+                    return std::nullopt;
+                },
+                /*cache=*/nullptr, /*null_evidence=*/nullptr,
+                /*first_gap=*/nullptr, /*also_has_mined=*/nullptr, gap);
+        });
+    st.set_tip(1518417, raw256(0xAB), 0x1b104be3u, 1'700'000'000u,
+               DASH_PUBKEY_VER, DASH_P2SH_VER, 1'700'000'123u, 0x20000000u);
+
+    const DeclineReport d = st.describe_decline();
+    ASSERT_FALSE(d.viable);
+    ASSERT_EQ(d.cause, "qc-plan-underivable");
+    EXPECT_EQ(d.value, "slot-set-underivable")
+        << "a header gap is a DIFFERENT operator response from a missing "
+           "commitment; collapsing both into \"nullopt\" hid that: " << d.value;
+    EXPECT_NE(d.value, "nullopt");
+}
+
+// A provider that reports no reason says SO. It must not borrow the shape of a
+// measurement it never took.
+TEST(DashServeGateNamesRefusal, QcPlanUnderivableWithoutAReasonSaysUnreported) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_qc_plan_fn([](uint32_t) {
+        return std::optional<dash::coin::QcBlockPlan>{};
+    });
+    const DeclineReport d = st.describe_decline();
+    ASSERT_EQ(d.cause, "qc-plan-underivable");
+    EXPECT_EQ(d.value, "reason-unreported");
+    EXPECT_NE(d.value, "nullopt");
+}
+
+// Same carriage on the PRE-EMIT gate: that refusal discards a BUILT template,
+// so it is the one an operator reads when a block was nearly served.
+TEST(DashServeGateNamesRefusal, EmitQcPlanRefusalCarriesTheQuorumIdentity) {
+    NodeCoinState st;
+    seed_single_mn(st, p2pkh_script(0x30));
+    seed_sml(st);
+    st.set_require_sml(true);
+    st.set_sml_current_hash(raw256(0xAB));
+
+    // Serve once with a derivable plan so there IS a template to re-check.
+    dash::coin::QcBlockPlan plan;
+    plan.merkle_root_quorums = uint256::ZERO;
+    st.set_qc_plan_fn([plan](uint32_t, dash::coin::QcPlanGap*) {
+        return std::optional<dash::coin::QcBlockPlan>{plan};
+    });
+    st.set_tip(1518417, raw256(0xAB), 0x1b104be3u, 1'700'000'000u,
+               DASH_PUBKEY_VER, DASH_P2SH_VER, 1'700'000'123u, 0x20000000u);
+    WorkSelection sel = st.select_work([] { return DashWorkData{}; });
+    ASSERT_EQ(sel.source, WorkSource::Embedded);
+
+    // Now the slot's commitment goes missing between build and emit.
+    const uint256 missing = raw256(0x9E);
+    st.set_qc_plan_fn(
+        [missing](uint32_t, dash::coin::QcPlanGap* gap)
+            -> std::optional<dash::coin::QcBlockPlan> {
+            if (gap != nullptr) {
+                gap->stage        = dash::coin::QcPlanStage::SlotUnsatisfied;
+                gap->slot_known   = true;
+                gap->llmq_type    = 4;
+                gap->quorum_index = 0;
+                gap->quorum_hash  = missing;
+                gap->slot_gap     = dash::coin::QcSlotGap::BlsVerifyFailed;
+            }
+            return std::nullopt;
+        });
+
+    DeclineReport why;
+    EXPECT_FALSE(st.embedded_template_emit_ok(sel.work, &why));
+    EXPECT_EQ(why.cause, "emit-qc-plan-underivable");
+    EXPECT_NE(why.value, "nullopt");
+    EXPECT_NE(why.value.find("llmqType=4"), std::string::npos) << why.value;
+    EXPECT_NE(why.value.find(missing.GetHex().substr(0, 16)), std::string::npos)
+        << why.value;
+    EXPECT_NE(why.value.find("gap=bls-verify-failed"), std::string::npos)
+        << "a hostile/corrupt signature and a cold-start relay hole are not "
+           "the same incident: " << why.value;
+}
+
 TEST(DashServeGateNamesRefusal, NotPopulatedIsNamed) {
     NodeCoinState st;
     seed_healthy_armed(st);
@@ -1864,5 +2049,8 @@ TEST(DashQcVerifyMemoDeclineCause, UnlatchedSlotStillDeclinesAsPlanUnderivable) 
     EXPECT_EQ(why.cause, "emit-qc-plan-underivable")
         << "the PRE-memo cause must remain reachable for an unlatched slot: "
         << "cause=" << why.cause << " value=" << why.value;
-    EXPECT_EQ(why.value, "nullopt");
+    // This fixture's plan fn is the ONE-argument shape, which reports no
+    // reason — and now says exactly that instead of "nullopt", a word that
+    // could not disagree with anything.
+    EXPECT_EQ(why.value, "reason-unreported");
 }


### PR DESCRIPTION
## The defect

`node_coin_state.hpp:1393` wrote the qc-plan refusal like this:

```cpp
else if (!qc_ok)
    d = refuse("qc-plan-underivable", "nullopt",
               "derivable-qc-plan@h=" + std::to_string(next_h));
```

`qc_ok` was a bare `bool`, computed from `qc_plan.has_value()` and passed by value into `evaluate_viability`. By the time the refusal was written, the identity of the missing quorum was gone and the observed VALUE in the log was the literal string `"nullopt"`.

That satisfies the cause / value / threshold shape #1038/#1039 established for this gate and **defeats its purpose**. `"nullopt"` is a value that cannot disagree with anything — it is identical for a cold-start relay hole, a failed BLS signature, an unsourced member set, a header gap and an underivable root fold, which are five different operator responses. The largest addressable refusal class on the daemonless soak (37s of 3600s, ~1% of wall clock) was unactionable from the decline alone.

The identity was never unavailable — it was **discarded at the seam**. The production plan closure in `main_dash.cpp` already holds the offending slot and logs it as `[QC-COMPLETENESS]`; `m_qc_plan_fn` returned a bare `std::optional<QcBlockPlan>`, so only a bool crossed the `std::function` boundary.

## What changed

**`dkg_commitments.hpp`** — `QcPlanStage` + `QcPlanGap`. `build_daemonless_qc_plan` gains an optional `QcPlanGap*` out-param and fills it on **every** nullopt path, so each of the three structurally different refusals names itself:

| stage | when | carries a quorum? |
|---|---|---|
| `slot-unsatisfied` | a mandatory slot has no verified-real / attested-null commitment | yes — llmqType, quorumIndex, quorumHash, per-slot gap reason, cached signers |
| `slot-set-underivable` | below the serve floor in-window, or a quorum base header is not held | no — there is no single offending quorum, and inventing one would be worse than `n/a` |
| `root-fold-underivable` | slots all satisfied, merkleRootQuorums could not be folded | no |

The pre-existing `first_gap` contract is preserved verbatim: it is still left untouched when the slot set itself was underivable, which is the discriminator the `[QC-COMPLETENESS]` logger keys on.

**`node_coin_state.hpp`** — `m_qc_plan_fn` takes the out-param; the gap travels **beside** `qc_ok` into `evaluate_viability`, so the decision and its value come from ONE plan call and cannot observe different answers. Both refusal sites now print it: viability (`qc-plan-underivable`, :1393) and pre-emit (`emit-qc-plan-underivable`, :940). A one-argument overload remains for providers that genuinely report no reason; it names **itself** (`reason-unreported`) rather than borrowing the shape of a measurement never taken.

**`main_dash.cpp`** — the production closure hands its gap straight through.

## Measured shape of the new value

```
cause=qc-plan-underivable
value=llmqType=1,quorumIndex=0,quorum=cdcdcdcdcdcdcdcd,gap=no-commitment-cached,signers=n/a
threshold=derivable-qc-plan@h=1518418
```

(hash is the test fixture's synthetic header chain). The 16-char quorum prefix matches the `[QC-COMPLETENESS]` convention, so a decline and its explainer line join on the same key.

## What this is NOT

**No null-commitment fallback is added.** dashd mints a null `CFinalCommitment` on a cache miss (`llmq/blockprocessor.cpp` `GetMineableCommitments`, the "null commitment required" arm); we deliberately do not, because null-serving a SUCCEEDED DKG diverged `merkleRootQuorums` at block 1520106 — see `quorum_member_source.hpp:41-44`. This PR is about **naming** what is missing, not about filling it.

Serving behaviour and template bytes are unchanged. Every refusal that fired before fires now, on the same condition; only the VALUE string differs.

## Tests

Four new cases in `test_dash_node_coin_state.cpp`:

- `QcPlanUnderivableNamesTheMissingQuorum` — drives the **real** producer (`build_daemonless_qc_plan`, no cache, no failed-DKG evidence) at a testnet DKG-window height and asserts the decline value is not `"nullopt"` and carries the llmqType, quorumIndex, quorum hash prefix and gap reason. The expected identity is captured independently via `first_gap`, not transcribed as a constant.
- `QcPlanUnderivableNamesTheStageWhenNoQuorumExists` — header gap ⇒ `slot-set-underivable`, because a header gap and a missing commitment are different incidents.
- `QcPlanUnderivableWithoutAReasonSaysUnreported` — the one-argument provider names itself.
- `EmitQcPlanRefusalCarriesTheQuorumIdentity` — the same carriage on the PRE-EMIT gate, the refusal an operator reads when a block was nearly served.

The pre-existing assertion that pinned the literal `"nullopt"` (`UnlatchedSlotStillDeclinesAsPlanUnderivable`) is updated to `reason-unreported`.

**RED without the fix**: revert `m_qc_plan_fn` to the one-argument shape and the first two fail on the value — one gets `"nullopt"` where it demands a quorum hash, the other where it demands a named stage.

Built and run locally on the branch head: `c2pool-dash` links, and **866 tests across 30 dash test binaries pass**, zero failures.
