### PR TITLE
dash(mempool): gate serving on tx validity instead of set membership

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -84,6 +84,7 @@
 #include <impl/dash/coin/tip_ingest.hpp>         // wire_tip_ingest (leg 2)
 #include <impl/dash/coin/embedded_oracle_shadow.hpp> // dash::coin::EmbeddedOracleShadow — per-block dashd cross-check (OBSERVE-only)
 #include <impl/dash/coin/embedded_shadow_compare.hpp> // dash::coin::EmbeddedShadowCompare — serve-vs-dashd template diff (OBSERVE-only, NOT a gate)
+#include <impl/dash/coin/mempool_validity_gate.hpp>   // dash::coin::MempoolValidityGate — THE --embedded-serve-mempool-txs arming condition
 #include <impl/dash/coin/block_connect_ingest.hpp>   // wire_block_connect_ingest (leg 3)
 #include <impl/dash/coin/mn_list_ingest.hpp>     // wire_mn_list_ingest (leg 4)
 #include <impl/dash/coin/govsync_ingest.hpp>     // wire_govobject_ingest / wire_govvote_ingest (E-SUPERBLOCK)
@@ -788,7 +789,9 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              // on changes what this node asks its peers for. It does NOT by
              // itself put a single transaction into a served template — that
              // remains --embedded-serve-mempool-txs' decision, gated on the
-             // [SHADOW-TXSET] coverage series.
+             // [MEMPOOL-VALIDITY] testmempoolaccept series
+             // (mempool_validity_gate.hpp) -- NOT on the [SHADOW-TXSET]
+             // ours_only coverage number, which is informational.
              bool embedded_mempool_ingest = false,
              // --pin-local-tx-hex <file>: PINNED LOCAL TX (donation-dust
              // consolidation). File holds the hex of an externally-signed,
@@ -2085,6 +2088,14 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // implicit consequence of UTXO maturity. Audit:
     // DASH_CONNECTBLOCK_REJECT_SURFACE_AUDIT.md §1. The dashd fallback arm is
     // unaffected (its GBT bodies come from dashd itself).
+    //
+    // THE CONDITION for that opt-in is the MEMPOOL VALIDITY GATE
+    // (mempool_validity_gate.hpp): zero transactions refused by dashd's
+    // testmempoolaccept over a sustained window of consecutive
+    // evidence-bearing heights. It is NOT `ours_only == 0` -- that
+    // set-membership test is unreachable (two independently-connected mempools
+    // never coincide) and blind to a strict SUBSET that contains an invalid
+    // transaction, which is exactly the case that costs a whole block.
     node_coin_state.set_serve_mempool_txs(embedded_serve_mempool_txs);
     std::cout << "[run] embedded mempool-tx serving: "
               << (embedded_serve_mempool_txs
@@ -2611,11 +2622,28 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 [rp = rpc.get()]() -> std::optional<dash::coin::DashWorkData> {
                     try { return rp->getwork(); }
                     catch (...) { return std::nullopt; }
+                },
+                // AcceptFn: dashd testmempoolaccept for ONE transaction we hold
+                // and would serve. THE condition that decides when
+                // --embedded-serve-mempool-txs may be armed, replacing the
+                // unreachable-and-blind `ours_only == 0` set-membership test.
+                // Runs on the SAME worker thread as the oracle fetch, so it is
+                // off the miner-facing path; a null answer counts UNPROBED,
+                // never as a pass. It arms NOTHING -- the flag stays OFF.
+                [rp = rpc.get()](const std::string& raw_tx_hex) -> nlohmann::json {
+                    return rp->test_mempool_accept(raw_tx_hex);
                 });
             work_source->set_shadow_compare(std::move(shadow));
             std::cout << "[run] --embedded-shadow-compare ARMED: OBSERVE-only "
                          "serve-vs-dashd template diff (worker-thread dashd fetch; "
-                         "NOT a serve gate; [SHADOW] log lines + counters)\n";
+                         "NOT a serve gate; [SHADOW] log lines + counters)\n"
+                      << "      [MEMPOOL-VALIDITY] gate ARMED with it: every tx we "
+                         "would serve goes to dashd testmempoolaccept. Condition "
+                         "for arming --embedded-serve-mempool-txs = ZERO INVALID "
+                         "over "
+                      << dash::coin::MempoolValidityGate::kCleanHeightsRequired
+                      << " consecutive evidence-bearing heights. ours_only is "
+                         "INFORMATIONAL and gates nothing.\n";
         } else {
             std::cout << "[run] --embedded-shadow-compare given but no dashd RPC "
                          "arm is armed (pure-daemonless) -- no oracle to compare "
@@ -4982,8 +5010,10 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                          " The mempool will now FILL from the DASH network.\n"
                       << "      This does NOT put transactions into served"
                          " templates: that stays --embedded-serve-mempool-txs"
-                         " (default OFF), gated on the [SHADOW-TXSET]"
-                         " coverage series.\n";
+                         " (default OFF), gated on the [MEMPOOL-VALIDITY]"
+                         " testmempoolaccept series -- zero INVALID over "
+                      << dash::coin::MempoolValidityGate::kCleanHeightsRequired
+                      << " consecutive evidence-bearing heights.\n";
         }
 
         // Kick the initial sync once the version/verack handshake completes:
@@ -7303,7 +7333,9 @@ int main(int argc, char** argv)
     // Default OFF = coinbase-only serving (values exact, fees forgone); the
     // mempool-tx body path with its G1-G4 guards (mempool.hpp; audit
     // DASH_CONNECTBLOCK_REJECT_SURFACE_AUDIT.md) arms only on explicit
-    // operator decision.
+    // operator decision, and only once the MEMPOOL VALIDITY GATE
+    // (mempool_validity_gate.hpp) reports zero transactions refused by dashd's
+    // testmempoolaccept over its sustained window.
     bool embedded_serve_mempool_txs = false;
     // --embedded-creditpool-publish-at-serve-tip: publish the derived credit
     // pool AT THE SERVE TIP rather than at the folded body height (PR-5,
@@ -7318,7 +7350,10 @@ int main(int argc, char** argv)
     // SEPARATE from --embedded-serve-mempool-txs on purpose: this only makes
     // the mempool FILL. Whether its contents ever reach a served template is
     // still the other flag's decision, and that one stays default-OFF until
-    // the [SHADOW-TXSET] coverage series says it is safe.
+    // the [MEMPOOL-VALIDITY] series says it is safe: ZERO transactions that
+    // dashd's testmempoolaccept refuses, over a sustained window
+    // (mempool_validity_gate.hpp). NOT the [SHADOW-TXSET] ours_only number --
+    // that is a coverage statistic and gates nothing.
     bool embedded_mempool_ingest = false;
     std::string bestcl_policy = "freshness";   // --bestcl-policy: freshness (default, conservative proxy) | consensus-exact (dashcore's actual CheckCbTxBestChainlock rule)
     bool embedded_oracle_shadow = false;       // --embedded-oracle-shadow: per-block dashd cross-check (OBSERVE-only)

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -2642,7 +2642,9 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                          "for arming --embedded-serve-mempool-txs = ZERO INVALID "
                          "over "
                       << dash::coin::MempoolValidityGate::kCleanHeightsRequired
-                      << " consecutive evidence-bearing heights. ours_only is "
+                      << " consecutive evidence-bearing DISTINCT heights (the "
+                         "probe fires ~5-6x per block; repeats do not advance "
+                         "the window). ours_only is "
                          "INFORMATIONAL and gates nothing.\n";
         } else {
             std::cout << "[run] --embedded-shadow-compare given but no dashd RPC "
@@ -5013,7 +5015,7 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                          " (default OFF), gated on the [MEMPOOL-VALIDITY]"
                          " testmempoolaccept series -- zero INVALID over "
                       << dash::coin::MempoolValidityGate::kCleanHeightsRequired
-                      << " consecutive evidence-bearing heights.\n";
+                      << " consecutive evidence-bearing DISTINCT heights.\n";
         }
 
         // Kick the initial sync once the version/verack handshake completes:

--- a/src/impl/dash/coin/embedded_gbt.hpp
+++ b/src/impl/dash/coin/embedded_gbt.hpp
@@ -52,6 +52,7 @@
 #include <array>
 #include <cstdint>
 #include <ctime>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -143,6 +144,34 @@ inline PinVerdict pin_gate_verdict(const MutableTransaction& pin,
     }
     v.ok = true;
     return v;
+}
+
+/// Wire-form hex of one transaction — the shape dashd's testmempoolaccept and
+/// submitblock both take.
+inline std::string embedded_tx_hex(const MutableTransaction& mtx)
+{
+    auto stream = ::pack(mtx);
+    auto sp = stream.get_span();
+    return HexStr(std::span<const unsigned char>(
+        reinterpret_cast<const unsigned char*>(sp.data()), sp.size()));
+}
+
+/// TRUE when `tx` spends an output of a transaction ALREADY in `in_set`.
+///
+/// The MEMPOOL VALIDITY GATE (mempool_validity_gate.hpp) probes one
+/// transaction at a time, because that is the only shape Dash Core's
+/// testmempoolaccept takes. A child probed alone answers `missing-inputs`
+/// whenever its parent rides the same template but is not (yet) in dashd's own
+/// mempool — an artefact of the probe, not a defect of the transaction, since
+/// selection is topological (mempool.hpp G1) and the parent IS in the block.
+/// Recording the dependency HERE, from the real vins, is what lets the gate
+/// excuse exactly that case without excusing a genuine missing input.
+inline bool spends_earlier_in_set(const MutableTransaction& tx,
+                                  const std::set<uint256>& in_set)
+{
+    for (const auto& vin : tx.vin)
+        if (in_set.count(vin.prevout.hash)) return true;
+    return false;
 }
 
 /// Append only — the caller must already hold an ok PinVerdict for THIS height.
@@ -583,14 +612,29 @@ inline DashWorkData build_embedded_workdata(
         (void)cand_fees;
         w.m_txset_candidates.reserve(cand.size());
         w.m_txset_candidate_fees.reserve(cand.size());
+        w.m_txset_candidate_data_hex.reserve(cand.size());
+        w.m_mempool_probe_depends_in_set.reserve(cand.size());
+        // In-set parents, accumulated in SELECTION order: selection is
+        // topological (mempool.hpp G1), so a parent that rides this template
+        // has already been pushed when its child is considered.
+        std::set<uint256> candidate_ids;
         for (const auto& c : cand) {
             // The SAME MN-collateral exclusion the served path applies: a
             // candidate set that included them would overstate what we could
             // actually have served and make the coverage gate too generous.
             uint256 protx;
             if (tx_spends_mn_collateral(mnstates, c.tx, &protx)) continue;
-            w.m_txset_candidates.push_back(dash::coin::dash_txid(c.tx));
+            const uint256 cid = dash::coin::dash_txid(c.tx);
+            w.m_mempool_probe_depends_in_set.push_back(
+                spends_earlier_in_set(c.tx, candidate_ids) ? 1u : 0u);
+            w.m_txset_candidates.push_back(cid);
             w.m_txset_candidate_fees.push_back(c.fee);
+            // Wire hex for the MEMPOOL VALIDITY GATE's testmempoolaccept
+            // probe. Still NEVER served: this vector is not m_tx_data_hex, no
+            // consensus path reads it, and the coinbase value and merkle are
+            // byte-identical to a build with this line deleted.
+            w.m_txset_candidate_data_hex.push_back(embedded_tx_hex(c.tx));
+            candidate_ids.insert(cid);
         }
     }
 
@@ -615,10 +659,7 @@ inline DashWorkData build_embedded_workdata(
     // ids were already folded into the job merkle — fill it here for every
     // template tx (E1; additive, the dashd fallback path is untouched).
     auto tx_hex = [](const MutableTransaction& mtx) {
-        auto stream = ::pack(mtx);
-        auto sp = stream.get_span();
-        return HexStr(std::span<const unsigned char>(
-            reinterpret_cast<const unsigned char*>(sp.data()), sp.size()));
+        return embedded_tx_hex(mtx);
     };
     // E1: mandatory type-6 quorum-commitment txs FIRST — dashd's miner
     // places them immediately after the coinbase, before mempool txs
@@ -657,13 +698,25 @@ inline DashWorkData build_embedded_workdata(
     if (pinned_local_txs != nullptr && !pinned_local_txs->empty())
         splice_pinned_txs(w, *pinned_local_txs, mempool, mnstates, "GBT-EMB");
     uint64_t selected_bytes = 0;  // wire bytes packed into this template (underfill guard)
+    // ── THE MEMPOOL-SOURCED RANGE (validity-gate probe set) ─────────────
+    // Everything appended from here on is mempool-sourced; the type-6
+    // commitments and the pinned local txs are already in. Recorded as a
+    // RANGE so the gate probes exactly these and does not have to guess which
+    // entries relay policy is entitled to refuse.
+    w.m_mempool_tx_first_index = static_cast<uint32_t>(w.m_txs.size());
+    std::set<uint256> selected_ids;
     for (auto& s : selected) {
         selected_bytes += s.base_size;
+        const uint256 sid = dash::coin::dash_txid(s.tx);
+        w.m_mempool_probe_depends_in_set.push_back(
+            spends_earlier_in_set(s.tx, selected_ids) ? 1u : 0u);
+        selected_ids.insert(sid);
         w.m_txs.emplace_back(s.tx);
-        w.m_tx_hashes.push_back(dash::coin::dash_txid(s.tx));
+        w.m_tx_hashes.push_back(sid);
         w.m_tx_fees.push_back(s.fee);
         w.m_tx_data_hex.push_back(tx_hex(s.tx));
     }
+    w.m_mempool_tx_count = static_cast<uint32_t>(selected.size());
 
     // ── Underfill guard ─────────────────────────────────────────────
     // Do not silently treat a near-empty DASH template as healthy when the

--- a/src/impl/dash/coin/embedded_shadow_compare.hpp
+++ b/src/impl/dash/coin/embedded_shadow_compare.hpp
@@ -70,6 +70,7 @@
 
 #include <impl/dash/coin/work_source.hpp>       // WorkSource
 #include <impl/dash/coin/rpc_data.hpp>          // DashWorkData, PackedPayment
+#include <impl/dash/coin/mempool_validity_gate.hpp>  // THE serve-flag gate (testmempoolaccept)
 #include <impl/dash/coin/vendor/cbtx.hpp>       // vendor::CCbTx, vendor::parse_cbtx
 
 #include <core/log.hpp>
@@ -132,17 +133,30 @@ inline const char* shadow_txset_mode_name(ShadowTxSetMode m)
 ///
 /// While dashd is still present, its template's tx set is a free, per-block
 /// answer key for our own mempool. This is the cheapest possible proof that
-/// our ingest is working and, more importantly, the gate for ever turning
-/// --embedded-serve-mempool-txs on: a wrong tx set costs a whole block, and a
-/// shadow run costs nothing.
+/// our ingest is working.
 ///
-/// The two directions are NOT symmetric:
+/// ⚠ THIS IS A COVERAGE MEASUREMENT, NOT THE SERVE-FLAG GATE. It used to be
+/// both: `ours_only == 0` was the stated condition for ever turning
+/// --embedded-serve-mempool-txs on. Set membership is the wrong question in
+/// two directions at once —
+///   * UNREACHABLE: two independently-connected nodes never hold identical
+///     mempools. MEASURED on the production hotel over 6056 samples,
+///     ours_only == 0 in 91.2% and > 0 in 8.8%, mean 65.3 when non-zero, max
+///     287; over the LAST 200 samples it was zero only 37% of the time.
+///   * BLIND to the case that costs money: FEWER transactions than dashd but
+///     INVALID ones. A strict subset passes `ours_only == 0` and can still
+///     mint a rejected block.
+/// The gate is now TRANSACTION VALIDITY, asked of dashd directly with
+/// testmempoolaccept — see mempool_validity_gate.hpp. `ours_only` keeps being
+/// measured and printed as an INFORMATIONAL coverage statistic and blocks
+/// nothing.
+///
+/// The two directions are still not symmetric, as INFORMATION:
 ///   * dashd-only  — transactions dashd had and we did not. Pure REVENUE loss;
 ///     the coverage number the whole mempool project is trying to move.
-///   * ours-only   — transactions WE selected and dashd did not. The dangerous
-///     direction: it means we would have built a block on something dashd's
-///     mempool rejected, did not know about, or had already seen conflict. Any
-///     sustained non-zero here BLOCKS enabling the serve flag.
+///   * ours-only   — transactions WE selected and dashd's template did not
+///     carry. Reads as "our view is ahead of, or simply different from, this
+///     one dashd's" — worth watching as a trend, never a pass/fail.
 /// Diagnostic only — nothing in the served decision reads this.
 struct ShadowTxSetDiff
 {
@@ -151,7 +165,7 @@ struct ShadowTxSetDiff
     size_t theirs{0};
     size_t both{0};
     size_t dashd_only{0};   // revenue we are leaving on the table
-    size_t ours_only{0};    // the dangerous direction
+    size_t ours_only{0};    // INFORMATIONAL coverage statistic — NOT a gate
 
     // ── PER-TX FEE AGREEMENT — the VALUATION half ────────────────────────
     // Membership (above) proves we HAVE the transaction. It says nothing
@@ -416,8 +430,10 @@ inline ShadowOutcome shadow_evaluate(WorkSource source,
            + " fee_over=" + std::to_string(o.tx_set.fee_overstated)
            + " fee_unknown=" + std::to_string(o.tx_set.fee_unknown);
         if (o.tx_set.ours_only)
-            l += " ⚠ OURS-ONLY txs present — do NOT enable"
-                 " --embedded-serve-mempool-txs until this is zero";
+            l += " ours_only_note=INFORMATIONAL (coverage statistic, NOT a"
+                 " gate: two independently-connected mempools never coincide,"
+                 " and a strict subset can still be invalid — serving is gated"
+                 " on dashd testmempoolaccept validity, see [MEMPOOL-VALIDITY])";
         if (o.tx_set.fee_overstated)
             l += " ⚠⚠ FEE OVERSTATED on " + std::to_string(o.tx_set.fee_overstated)
                + " tx (worst +" + std::to_string(o.tx_set.worst_overstatement)
@@ -551,10 +567,26 @@ public:
     /// to a `no-oracle` log line, never a stall). Bound in main_dash.cpp.
     using OracleFn = std::function<std::optional<DashWorkData>()>;
 
-    explicit EmbeddedShadowCompare(OracleFn oracle)
-        : oracle_(std::move(oracle)) {
+    /// dashd `testmempoolaccept` for ONE raw transaction hex -> the single
+    /// result object, or a null json on any failure/absence. Optional: unbound
+    /// leaves the MEMPOOL VALIDITY GATE unevaluated (and therefore CLOSED),
+    /// which is the correct reading of "we could not ask".
+    using AcceptFn = std::function<nlohmann::json(const std::string& raw_tx_hex)>;
+
+    explicit EmbeddedShadowCompare(OracleFn oracle, AcceptFn accept = nullptr)
+        : oracle_(std::move(oracle)), accept_(std::move(accept)) {
         LOG_INFO << "[SHADOW] embedded-vs-dashd shadow-compare ARMED (diagnostic "
                     "only; NOT a serve gate; oracle fetch off the hot path)";
+        if (accept_)
+            LOG_INFO << "[MEMPOOL-VALIDITY] gate ARMED: every transaction we"
+                        " would serve is put to dashd testmempoolaccept."
+                        " Condition to arm --embedded-serve-mempool-txs = ZERO"
+                        " INVALID over "
+                     << MempoolValidityGate::kCleanHeightsRequired
+                     << " consecutive evidence-bearing heights (~25h at DASH's"
+                        " 2.625 min/block). ours_only is INFORMATIONAL and"
+                        " gates nothing. This gate arms NOTHING by itself --"
+                        " the flag stays an operator decision";
         worker_ = std::thread([this] { worker_loop(); });
     }
 
@@ -585,6 +617,13 @@ public:
         nlohmann::json j = counters_.to_json();
         j["mode"] = "embedded-shadow-compare";
         j["note"] = "diagnostic only — NOT a serve gate";
+        // The serve-FLAG readiness verdict. Still not a serve gate: it decides
+        // whether --embedded-serve-mempool-txs MAY be armed, never what is
+        // served at this instant.
+        j["mempool-validity-gate"] = accept_
+            ? validity_.to_json()
+            : nlohmann::json{{"gate", "CLOSED"},
+                             {"reason", "no dashd testmempoolaccept oracle bound"}};
         return j;
     }
 
@@ -629,14 +668,54 @@ private:
             if (o.served_mismatch) LOG_WARNING << line;   // the real-problem signal
             else                   LOG_INFO    << line;
         }
+        {
+            std::lock_guard<std::mutex> lk(mu_);
+            counters_.apply(o);
+        }
+        probe_validity(served);
+    }
+
+    /// THE MEMPOOL VALIDITY GATE, on the SAME worker thread as the oracle
+    /// fetch — off the miner-facing path by construction. One
+    /// testmempoolaccept per transaction we would serve (Dash Core's
+    /// testmempoolaccept takes exactly one raw transaction per call), three-
+    /// valued classification, then the sustained-window verdict.
+    ///
+    /// This CANNOT change what is served. Its only outputs are log lines, the
+    /// counters, and a readiness verdict on a DEFAULT-OFF flag.
+    void probe_validity(const DashWorkData& w) {
+        if (!accept_) return;
+        const auto set = mempool_probe_set(w);
+
+        std::vector<nlohmann::json> answers;
+        answers.reserve(set.size());
+        for (const auto& t : set) {
+            nlohmann::json a;
+            try { a = accept_(t.raw_hex); }
+            catch (const std::exception& e) {
+                LOG_WARNING << "[MEMPOOL-VALIDITY] testmempoolaccept threw for"
+                               " txid=" << t.txid << ": " << e.what()
+                            << " — counted UNPROBED, never VALID";
+                a = nlohmann::json();
+            }
+            answers.push_back(std::move(a));
+        }
+
+        const auto sample = mempool_validity_sample(w.m_height, set, answers);
         std::lock_guard<std::mutex> lk(mu_);
-        counters_.apply(o);
+        validity_.apply(sample);
+        for (const auto& line : mempool_validity_log_lines(sample, validity_)) {
+            if (sample.invalid > 0) LOG_WARNING << line;   // the refusal
+            else                    LOG_INFO    << line;
+        }
     }
 
     OracleFn oracle_;
+    AcceptFn accept_;
 
-    mutable std::mutex mu_;          // guards counters_
+    mutable std::mutex mu_;          // guards counters_ + validity_
     ShadowCounters     counters_;
+    MempoolValidityGate validity_;
 
     std::thread             worker_;
     std::mutex              q_mu_;

--- a/src/impl/dash/coin/embedded_shadow_compare.hpp
+++ b/src/impl/dash/coin/embedded_shadow_compare.hpp
@@ -583,8 +583,10 @@ public:
                         " Condition to arm --embedded-serve-mempool-txs = ZERO"
                         " INVALID over "
                      << MempoolValidityGate::kCleanHeightsRequired
-                     << " consecutive evidence-bearing heights (~25h at DASH's"
-                        " 2.625 min/block). ours_only is INFORMATIONAL and"
+                     << " consecutive evidence-bearing DISTINCT heights (>=25h"
+                        " at DASH's 2.625 min/block; this probe fires ~5-6x per"
+                        " block and repeats do NOT advance the window)."
+                        " ours_only is INFORMATIONAL and"
                         " gates nothing. This gate arms NOTHING by itself --"
                         " the flag stays an operator decision";
         worker_ = std::thread([this] { worker_loop(); });

--- a/src/impl/dash/coin/mempool_validity_gate.hpp
+++ b/src/impl/dash/coin/mempool_validity_gate.hpp
@@ -45,19 +45,52 @@
 ///
 /// ══ HARD GATE ══════════════════════════════════════════════════════════════
 /// ZERO INVALID over a SUSTAINED window of kCleanHeightsRequired consecutive
-/// EVIDENCE-BEARING heights (see below). One INVALID anywhere in the run resets
-/// the run to zero. The gate is a READINESS verdict on a FLAG, not a serve
-/// decision: nothing in this header can change, delay, or re-order a served
-/// template. --embedded-serve-mempool-txs remains DEFAULT-OFF; this file
-/// changes the condition under which it may be armed.
+/// EVIDENCE-BEARING, DISTINCT heights (see both qualifiers below). One INVALID
+/// anywhere in the run resets the run to zero. The gate is a READINESS verdict
+/// on a FLAG, not a serve decision: nothing in this header can change, delay,
+/// or re-order a served template. --embedded-serve-mempool-txs remains
+/// DEFAULT-OFF; this file changes the condition under which it may be armed.
 ///
 /// ══ EVIDENCE-BEARING, and why a height with no transactions does not count ══
 /// A height where our probe set was empty (empty mempool, coinbase-only
 /// candidate set) produced NO observation of validity. Counting it as "clean"
 /// would let 576 empty heights open the gate on zero evidence — the same
 /// unreachable/vacuous failure the old condition had, with the sign flipped.
-/// Such heights therefore neither ADVANCE the clean run nor RESET it: they are
-/// counted separately as `heights_without_evidence` and are visible in the log.
+/// Such samples therefore neither ADVANCE the clean run nor RESET it: they are
+/// counted separately as `samples_without_evidence` and are visible in the log.
+///
+/// ══ DISTINCT, and why a SAMPLE is not a HEIGHT ══════════════════════════════
+/// apply() is fed ONE SAMPLE PER PROBE RUN, and a probe run is NOT a block.
+/// probe_validity() runs from process(), process() runs from on_serve, and
+/// on_serve fires on EVERY template re-source: every work-generation bump plus
+/// a 30 s staleness re-poll (stratum/work_source.cpp kStaleAfter). DASH targets
+/// 157.5 s/block, so roughly FIVE TO SIX samples land on ONE height.
+///
+/// Counting samples would therefore have made 576 counter ticks mean ~110 real
+/// heights — about 4.8 hours, not the ~25.2 hours the threshold is argued
+/// from — and a node parked on a FROZEN TIP could tick the counter to 576
+/// without ever advancing a block. That is precisely the "a shorter window can
+/// be passed by a quiet night" failure the threshold exists to exclude, so the
+/// window counts DISTINCT heights and the cursor is MONOTONE.
+///
+/// The rule is DELIBERATELY ASYMMETRIC, and the asymmetry is the point:
+///
+///   * A sample at a height that does NOT advance the cursor (a repeat of the
+///     last counted height, or a rollback below it) contributes NO new
+///     evidence: it cannot advance `consecutive_clean`, cannot raise
+///     `heights_with_evidence`, and its transactions are not added to the
+///     independent-trial totals. It is counted as `samples_repeat_height`.
+///   * That same sample CAN STILL KILL THE RUN. An INVALID is an OBSERVED
+///     DEFECT whenever it is observed — the mempool at one height is not
+///     constant, and a conflicting spend that arrives between two probes of
+///     the same height is exactly the event that costs a block. Ignoring it
+///     because "we already counted this height" would trade over-counting
+///     clean evidence for under-counting defects: one blindness for another.
+///
+/// So a repeat can only ever HURT the run, never help it. Everything the
+/// non-advancing samples DID see stays visible in `samples_seen`,
+/// `samples_repeat_height` and `repeat_txs_probed` — dropped from the window
+/// arithmetic, never dropped from the record.
 ///
 /// ══ ours_only IS NOW INFORMATIONAL ══════════════════════════════════════════
 /// It keeps being measured and keeps being printed — as a COVERAGE STATISTIC.
@@ -94,13 +127,20 @@ namespace coin {
 /// "txn-already-in-mempool"). The ONE exempted reason. Compared for EQUALITY.
 inline constexpr const char* kAlreadyInMempoolReason = "txn-already-in-mempool";
 
-/// The reject-reason family a SINGLE-transaction probe produces for a child
-/// whose parent is in the same template but not in dashd's mempool. Only ever
-/// consulted together with a build-time `depends_on_in_set_parent` fact.
-inline bool is_missing_inputs_reason(const std::string& reason)
+/// The ONE reject-reason that can mean ONLY "I do not know this input" — the
+/// answer a SINGLE-transaction probe gets for a child whose parent rides the
+/// same template but has not reached dashd's mempool. Only ever consulted
+/// together with a build-time `depends_on_in_set_parent` fact.
+inline bool is_unknown_input_only_reason(const std::string& reason)
 {
-    return reason == "missing-inputs"
-        || reason == "bad-txns-inputs-missingorspent";
+    return reason == "missing-inputs";
+}
+
+/// The reject-reason that CONFLATES a missing input with a SPENT one, and says
+/// so in its own name. NEVER exempted — see the note on the exemption below.
+inline bool is_missing_or_spent_reason(const std::string& reason)
+{
+    return reason == "bad-txns-inputs-missingorspent";
 }
 
 /// Three-valued logic, plus the honest fourth state for "no answer".
@@ -175,8 +215,35 @@ inline MempoolAcceptResult classify_mempool_accept(const MempoolProbeTx& tx,
     }
 
     // The ONLY excused rejection beyond the named one: a child probed alone
-    // whose parent rides the SAME template. Requires the build-time fact.
-    if (tx.depends_on_in_set_parent && is_missing_inputs_reason(r.reason)) {
+    // whose parent rides the SAME template. Requires the build-time fact AND a
+    // reason that can mean nothing else.
+    //
+    // WHY `bad-txns-inputs-missingorspent` IS **NOT** IN HERE.
+    // `depends_on_in_set_parent` is a fact about the TRANSACTION, not about the
+    // INPUT that failed, and testmempoolaccept never names WHICH outpoint it
+    // refused. So a recorded dependency does not imply the failing input was
+    // the in-set parent: a transaction spending ONE in-set parent output AND
+    // ONE genuinely double-spent output carries the flag and is a real defect —
+    // the exact loss this gate exists to prevent, classified as UNPROBED and
+    // waved through.
+    //
+    // A per-INPUT fix is NOT AVAILABLE from the data dashd gives us. Even with
+    // the full per-input in-set map on our side, the answer is a bare reason
+    // string with no outpoint, so nothing can attribute the failure to a
+    // specific input. The exemption is therefore NARROWED instead, to the one
+    // reason whose meaning is unambiguous: "missing-inputs" = "this input is
+    // not known to me". `bad-txns-inputs-missingorspent` conflates unknown with
+    // SPENT in its own name and is now INVALID even with the flag set.
+    //
+    // The cost is stated rather than hidden: an in-set-parent child that dashd
+    // answers with the conflating reason will now RESET the clean run. That
+    // fails toward a CLOSED gate on ambiguous evidence, which is the direction
+    // a gate is allowed to be wrong in. The residual the narrow exemption still
+    // carries is likewise per-transaction: a tx spending an in-set parent AND
+    // an input dashd does not know for an unrelated reason. That case is not a
+    // double-spend, and our selection is topological (mempool.hpp G1), so every
+    // in-our-mempool ancestor rides the same template.
+    if (tx.depends_on_in_set_parent && is_unknown_input_only_reason(r.reason)) {
         r.verdict        = MempoolAcceptVerdict::Unprobed;
         r.unprobed_cause = "in-set-parent(single-tx-probe-cannot-see-it)";
         return r;
@@ -241,20 +308,35 @@ mempool_validity_sample(uint32_t height,
 /// INVALID. Justification, in full, because a threshold without one is a
 /// number somebody made up:
 ///
-///   * DURATION. DASH mainnet targets 2.625 min/block, so 576 blocks is
-///     ~25.2 hours — one full day plus a margin. That is the shortest window
+///   * DURATION. DASH mainnet targets 2.625 min/block, so 576 DISTINCT heights
+///     is AT LEAST ~25.2 hours — one full day plus a margin, and longer
+///     whenever heights go by without evidence. That is the shortest window
 ///     that contains every DAILY period in mempool composition: the fee/traffic
 ///     diurnal cycle, at least one full DKG mining window for each active LLMQ
 ///     type, and at least one ChainLock-less stretch. A shorter window can be
-///     passed by a quiet night.
-///   * STATISTICAL POWER. Evidence-bearing heights on the hotel carry a mean of
-///     ~30 selectable transactions, so 576 of them is ~1.7e4 transaction
-///     probes. Zero events in n trials bounds the true per-transaction invalid
-///     rate at 3/n (rule of three, 95%) = ~1.7e-4. At ~30 transactions per
-///     template that is a <=0.5% chance that any given template we build
-///     carries a rejectable transaction — roughly one at-risk block per 190
-///     mined. THAT IS THE RESIDUAL, stated rather than implied; it is not zero,
-///     and the number is why the window is 576 and not 100.
+///     passed by a quiet night. This bound holds ONLY because the counter
+///     advances per distinct height; counting samples would have made the same
+///     576 mean ~110 heights (~4.8 h), because the probe fires ~5-6 times per
+///     block — see "DISTINCT" at the top of this file.
+///   * STATISTICAL POWER, stated at the unit the window actually counts. Zero
+///     INVALID heights in 576 evidence-bearing heights bounds the per-HEIGHT
+///     rate at 3/576 (rule of three, 95%) = 5.2e-3: at most a ~0.52% chance
+///     that any given template we build carries a rejectable transaction,
+///     roughly ONE AT-RISK BLOCK PER 192 MINED. THAT IS THE RESIDUAL, stated
+///     rather than implied; it is not zero, and it is why the window is 576 and
+///     not 100.
+///
+///     The per-HEIGHT rate is the honest form of this claim, and the per-
+///     TRANSACTION form is deliberately NOT made. Evidence-bearing heights on
+///     the hotel carry a mean of ~30 selectable transactions, so the window
+///     does accumulate ~1.7e4 probes — but they are not 1.7e4 INDEPENDENT
+///     trials: a transaction that sits in the mempool for several blocks is
+///     re-probed at each of them. Only the HEIGHTS are separated by a fresh
+///     tip, a fresh selection and a fresh mempool, so only the height-level
+///     bound is claimed. (Before the distinct-height fix the counter's true
+///     unit was ~110 heights, which bounds the per-template rate at 3/110 =
+///     2.7% — one at-risk block per 37, 5.2x worse than the number the
+///     threshold was argued from.)
 ///   * REACHABILITY. Unlike `ours_only == 0`, this condition is satisfiable by
 ///     a correct node: it asks dashd whether OUR transactions are acceptable,
 ///     not whether dashd's mempool coincides with ours.
@@ -264,23 +346,65 @@ mempool_validity_sample(uint32_t height,
 struct MempoolValidityGate {
     static constexpr uint64_t kCleanHeightsRequired = 576;
 
+    /// What the LAST applied sample did to the window. Named so a log reader
+    /// never has to infer it from two counters moving.
+    enum class SampleDisposition : uint8_t {
+        None,           // nothing applied yet
+        Counted,        // new height, evidence-bearing: the window moved
+        RepeatHeight,   // at/below the counted cursor: no new evidence
+        NoEvidence      // nothing to probe, or every answer was Unprobed
+    };
+
+    static const char* disposition_name(SampleDisposition d)
+    {
+        switch (d) {
+            case SampleDisposition::Counted:      return "COUNTED";
+            case SampleDisposition::RepeatHeight: return "REPEAT-HEIGHT(no-advance)";
+            case SampleDisposition::NoEvidence:   return "NO-EVIDENCE(no-advance)";
+            default:                              return "NONE";
+        }
+    }
+
     uint64_t required{kCleanHeightsRequired};
 
-    uint64_t heights_seen{0};
+    /// THE MONOTONE HEIGHT CURSOR. Only a sample ABOVE it can advance the
+    /// window, and only an evidence-bearing sample moves it — so a height whose
+    /// first probe found nothing is not burned, and a rollback cannot make the
+    /// window count the same block twice.
+    uint32_t last_counted_height{0};
+    bool     has_counted_height{false};
+
+    /// Every apply() call: the PROBE cadence, ~5-6 per block. NOT a height.
+    uint64_t samples_seen{0};
+    /// ... of which landed at/below the cursor and so advanced nothing.
+    uint64_t samples_repeat_height{0};
+    /// ... of which observed no validity at all.
+    uint64_t samples_without_evidence{0};
+
+    /// THE WINDOW'S UNIT: distinct evidence-bearing heights.
     uint64_t heights_with_evidence{0};
-    uint64_t heights_without_evidence{0};
     uint64_t consecutive_clean{0};
     uint64_t best_consecutive_clean{0};
 
+    /// Transaction totals over the COUNTED samples only — one observation per
+    /// transaction per height, which is what the power argument is entitled to
+    /// read. Re-probes are kept apart in `repeat_txs_probed` so nothing is
+    /// hidden, only kept out of the arithmetic.
     uint64_t txs_probed{0};
     uint64_t txs_valid{0};
     uint64_t txs_already_in_mempool{0};
-    uint64_t txs_invalid{0};
     uint64_t txs_unprobed{0};
+    uint64_t repeat_txs_probed{0};
+
+    /// DEFECTS ARE COUNTED WHEREVER THEY ARE OBSERVED — counted sample or
+    /// repeat. See the asymmetry note at the top of this file.
+    uint64_t txs_invalid{0};
 
     uint32_t    last_invalid_height{0};
     std::string last_invalid_txid;
     std::string last_invalid_reason;
+
+    SampleDisposition last_disposition{SampleDisposition::None};
 
     /// TRUE == the condition for arming --embedded-serve-mempool-txs is met.
     /// It does NOT arm anything; the flag stays an operator decision.
@@ -288,30 +412,54 @@ struct MempoolValidityGate {
 
     void apply(const MempoolValiditySample& s)
     {
-        ++heights_seen;
-        txs_probed             += s.probed;
-        txs_valid              += s.valid;
-        txs_already_in_mempool += s.already_in_mempool;
-        txs_invalid            += s.invalid;
-        txs_unprobed           += s.unprobed;
+        ++samples_seen;
 
         if (!s.evidence_bearing()) {
             // Neither advances nor resets — it is not evidence in either
             // direction. Said out loud so a long quiet stretch cannot be
-            // mistaken for progress toward the threshold.
-            ++heights_without_evidence;
+            // mistaken for progress toward the threshold. The cursor is NOT
+            // moved: a later probe of this same height that DOES find
+            // transactions is the first evidence there, and must count.
+            ++samples_without_evidence;
+            txs_unprobed     += s.unprobed;
+            last_disposition  = SampleDisposition::NoEvidence;
             return;
         }
-        ++heights_with_evidence;
 
+        // A DEFECT KILLS THE RUN WHEREVER IT IS SEEN — before the distinct-
+        // height test, deliberately. The mempool at one height is not constant;
+        // a conflicting spend arriving between two probes of the same height is
+        // exactly the event that costs a block. A repeat may only ever HURT.
         if (s.invalid > 0) {
-            const auto& first = s.invalids.front();
+            txs_invalid        += s.invalid;
+            const auto& first   = s.invalids.front();
             last_invalid_height = s.height;
             last_invalid_txid   = first.txid;
             last_invalid_reason = first.reason;
             consecutive_clean   = 0;      // the run dies on ONE defect
+        }
+
+        const bool advances = !has_counted_height || s.height > last_counted_height;
+        if (!advances) {
+            // No new evidence: the window has already banked this height. The
+            // reset above (if any) still stands.
+            ++samples_repeat_height;
+            repeat_txs_probed += s.probed;
+            last_disposition   = SampleDisposition::RepeatHeight;
             return;
         }
+
+        last_counted_height = s.height;
+        has_counted_height  = true;
+        ++heights_with_evidence;
+        txs_probed             += s.probed;
+        txs_valid              += s.valid;
+        txs_already_in_mempool += s.already_in_mempool;
+        txs_unprobed           += s.unprobed;
+        last_disposition        = SampleDisposition::Counted;
+
+        if (s.invalid > 0) return;        // already reset above
+
         ++consecutive_clean;
         if (consecutive_clean > best_consecutive_clean)
             best_consecutive_clean = consecutive_clean;
@@ -324,10 +472,17 @@ struct MempoolValidityGate {
         j["clean-heights-required"]    = required;
         j["consecutive-clean-heights"] = consecutive_clean;
         j["best-consecutive-clean-heights"] = best_consecutive_clean;
-        j["heights-seen"]              = heights_seen;
         j["heights-with-evidence"]     = heights_with_evidence;
-        j["heights-without-evidence"]  = heights_without_evidence;
+        j["last-counted-height"]       = last_counted_height;
+        // The window's unit is a HEIGHT; these three say how many PROBES it
+        // took and how many of them the window was entitled to count, so a
+        // reader can never mistake probe cadence for progress.
+        j["samples-seen"]              = samples_seen;
+        j["samples-repeat-height"]     = samples_repeat_height;
+        j["samples-without-evidence"]  = samples_without_evidence;
+        j["last-sample-disposition"]   = disposition_name(last_disposition);
         j["txs-probed"]                = txs_probed;
+        j["txs-probed-repeat-height"]  = repeat_txs_probed;
         j["txs-valid"]                 = txs_valid;
         j["txs-already-in-mempool"]    = txs_already_in_mempool;
         j["txs-invalid"]               = txs_invalid;
@@ -373,10 +528,17 @@ mempool_validity_log_lines(const MempoolValiditySample& s,
         + " unprobed="  + std::to_string(s.unprobed)
         + " clean_run=" + std::to_string(g.consecutive_clean) + "/"
         + std::to_string(g.required)
+        + " heights_with_evidence=" + std::to_string(g.heights_with_evidence)
+        + " sample=" + MempoolValidityGate::disposition_name(g.last_disposition)
         + " gate=" + (g.open() ? "OPEN" : "CLOSED");
     if (!s.evidence_bearing())
         l += " (no-evidence: nothing to probe at this height — the run neither"
              " advances nor resets)";
+    else if (g.last_disposition == MempoolValidityGate::SampleDisposition::RepeatHeight)
+        l += " (repeat-height: h<=" + std::to_string(g.last_counted_height)
+           + " is already banked — the probe fires ~5-6x per block, so this"
+             " sample is NOT new evidence and does NOT advance the window;"
+             " an INVALID on it would still RESET the run)";
     out.push_back(std::move(l));
     return out;
 }

--- a/src/impl/dash/coin/mempool_validity_gate.hpp
+++ b/src/impl/dash/coin/mempool_validity_gate.hpp
@@ -1,0 +1,436 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// DASH MEMPOOL **VALIDITY** GATE — the condition that decides when
+/// --embedded-serve-mempool-txs may be turned on.
+///
+/// ══ WHAT THIS REPLACES, AND WHY ═════════════════════════════════════════════
+/// The previous condition was a SET-MEMBERSHIP test: `ours_only == 0` in the
+/// [SHADOW-TXSET] comparison against dashd's template (embedded_shadow_compare.
+/// hpp). It is wrong in two directions at once.
+///
+///   (1) UNREACHABLE. `ours_only` is "transactions in OUR selection that are
+///       absent from dashd's template". Two independently-connected nodes never
+///       hold identical mempools: relay is gossip, admission is per-node policy
+///       over a per-node UTXO view, and each side's template is a snapshot taken
+///       at a different instant. MEASURED on the production hotel over 6056
+///       samples: ours_only == 0 in 91.2% of them, > 0 in 8.8%, and when
+///       non-zero its MEAN is 65.3 with a max of 287. Over the LAST 200 samples
+///       it was zero only 37% of the time. A gate whose passing condition is a
+///       coincidence is not a gate.
+///
+///   (2) BLIND TO THE CASE THAT COSTS MONEY. `ours_only == 0` says our set is a
+///       SUBSET of dashd's. It does NOT say the members are acceptable: a
+///       strict subset can still contain a transaction dashd would refuse
+///       (double-spend of a coin our partial UTXO view still shows unspent, a
+///       non-final tx, a policy-rejected script), and mining it costs the whole
+///       block. The set-membership test passes and the block is still rejected.
+///       The "strict subset, therefore safe" shortcut does not even hold on the
+///       measurements above.
+///
+/// ══ THE CONDITION IMPLEMENTED HERE ══════════════════════════════════════════
+/// For every transaction we hold AND WOULD SERVE, ask dashd's
+/// `testmempoolaccept` and apply THREE-VALUED logic:
+///
+///     allowed == true                                        -> VALID
+///     allowed == false && reason == "txn-already-in-mempool"  -> ALSO VALID
+///     allowed == false && any other reason                    -> INVALID,
+///                                                                and a defect
+///
+/// "already in mempool" is dashd telling us it ALREADY HOLDS this transaction —
+/// the strongest possible statement that the transaction is acceptable to it.
+/// It is exempted by NAME, verbatim, and nothing else is: no reason-prefix
+/// matching, no "looks benign" family. A widening of the exemption set is a
+/// widening of the gate and must be argued on its own.
+///
+/// ══ HARD GATE ══════════════════════════════════════════════════════════════
+/// ZERO INVALID over a SUSTAINED window of kCleanHeightsRequired consecutive
+/// EVIDENCE-BEARING heights (see below). One INVALID anywhere in the run resets
+/// the run to zero. The gate is a READINESS verdict on a FLAG, not a serve
+/// decision: nothing in this header can change, delay, or re-order a served
+/// template. --embedded-serve-mempool-txs remains DEFAULT-OFF; this file
+/// changes the condition under which it may be armed.
+///
+/// ══ EVIDENCE-BEARING, and why a height with no transactions does not count ══
+/// A height where our probe set was empty (empty mempool, coinbase-only
+/// candidate set) produced NO observation of validity. Counting it as "clean"
+/// would let 576 empty heights open the gate on zero evidence — the same
+/// unreachable/vacuous failure the old condition had, with the sign flipped.
+/// Such heights therefore neither ADVANCE the clean run nor RESET it: they are
+/// counted separately as `heights_without_evidence` and are visible in the log.
+///
+/// ══ ours_only IS NOW INFORMATIONAL ══════════════════════════════════════════
+/// It keeps being measured and keeps being printed — as a COVERAGE STATISTIC.
+/// It no longer blocks anything. See embedded_shadow_compare.hpp.
+///
+/// ══ WHY testmempoolaccept IS PROBED ONE TRANSACTION AT A TIME ═══════════════
+/// Dash Core's `testmempoolaccept` takes an array that must contain exactly one
+/// raw transaction (the pre-package-relay shape). A single-transaction probe
+/// cannot see a parent that is in OUR probe set but not yet in dashd's mempool,
+/// so such a child answers `missing-inputs` — an artefact of the probe, not a
+/// defect of the transaction: a block carrying parent AND child together is
+/// perfectly valid, and our selection is topological (mempool.hpp G1) so the
+/// parent IS in the same template. Those, and ONLY those, are classified
+/// Unprobed: the caller supplies a per-entry `depends_on_in_set_parent` flag
+/// computed at build time from the actual vins, so the exemption is a FACT
+/// about the set, never an inference from the reason string alone.
+///
+/// STRICTLY single-coin: src/impl/dash/coin/ only. Header-only so the pure
+/// classify/aggregate logic is KAT-pinnable without a live node or a daemon.
+
+#include <impl/dash/coin/rpc_data.hpp>       // DashWorkData
+
+#include <nlohmann/json.hpp>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace dash {
+namespace coin {
+
+/// dashd's reject-reason for "I already hold this transaction", verbatim
+/// (Dash Core validation.cpp: TxValidationResult TX_CONFLICT,
+/// "txn-already-in-mempool"). The ONE exempted reason. Compared for EQUALITY.
+inline constexpr const char* kAlreadyInMempoolReason = "txn-already-in-mempool";
+
+/// The reject-reason family a SINGLE-transaction probe produces for a child
+/// whose parent is in the same template but not in dashd's mempool. Only ever
+/// consulted together with a build-time `depends_on_in_set_parent` fact.
+inline bool is_missing_inputs_reason(const std::string& reason)
+{
+    return reason == "missing-inputs"
+        || reason == "bad-txns-inputs-missingorspent";
+}
+
+/// Three-valued logic, plus the honest fourth state for "no answer".
+/// Unprobed is NEVER counted as valid and NEVER counted as a defect: it is the
+/// absence of a measurement, and it advances nothing.
+enum class MempoolAcceptVerdict : uint8_t {
+    Valid,              // allowed == true
+    AlreadyInMempool,   // allowed == false, reason == txn-already-in-mempool
+    Invalid,            // allowed == false, any other reason -> A DEFECT
+    Unprobed            // no answer, or an in-set-parent probe artefact
+};
+
+inline const char* mempool_accept_verdict_name(MempoolAcceptVerdict v)
+{
+    switch (v) {
+        case MempoolAcceptVerdict::Valid:            return "VALID";
+        case MempoolAcceptVerdict::AlreadyInMempool: return "ALSO-VALID(already-in-mempool)";
+        case MempoolAcceptVerdict::Invalid:          return "INVALID";
+        default:                                     return "UNPROBED";
+    }
+}
+
+struct MempoolAcceptResult {
+    std::string          txid;
+    MempoolAcceptVerdict verdict{MempoolAcceptVerdict::Unprobed};
+    /// dashd's reject-reason VERBATIM (empty when allowed). Never paraphrased:
+    /// the operator has to be able to grep dashd's own string.
+    std::string          reason;
+    /// Why an Unprobed is unprobed, when it is not simply "no answer".
+    std::string          unprobed_cause;
+};
+
+/// One transaction of the probe set: what we would serve, in selection
+/// (topological) order.
+struct MempoolProbeTx {
+    std::string txid;
+    std::string raw_hex;
+    /// TRUE when this transaction spends an output of an EARLIER member of the
+    /// same probe set. Computed at template-build time from the real vins, not
+    /// guessed from a reject string.
+    bool        depends_on_in_set_parent{false};
+};
+
+/// PURE. dashd's testmempoolaccept answer for ONE transaction -> the verdict.
+/// `entry` is the single result object (`{"txid":..,"allowed":..,
+/// "reject-reason":..}`); a null/non-object entry means the probe produced no
+/// answer (RPC blip, daemon absent) and yields Unprobed.
+inline MempoolAcceptResult classify_mempool_accept(const MempoolProbeTx& tx,
+                                                   const nlohmann::json& entry)
+{
+    MempoolAcceptResult r;
+    r.txid = tx.txid;
+
+    if (!entry.is_object() || !entry.contains("allowed")
+        || !entry["allowed"].is_boolean()) {
+        r.verdict        = MempoolAcceptVerdict::Unprobed;
+        r.unprobed_cause = "no-answer";
+        return r;
+    }
+
+    if (entry["allowed"].get<bool>()) {
+        r.verdict = MempoolAcceptVerdict::Valid;
+        return r;
+    }
+
+    if (entry.contains("reject-reason") && entry["reject-reason"].is_string())
+        r.reason = entry["reject-reason"].get<std::string>();
+
+    if (r.reason == kAlreadyInMempoolReason) {
+        r.verdict = MempoolAcceptVerdict::AlreadyInMempool;
+        return r;
+    }
+
+    // The ONLY excused rejection beyond the named one: a child probed alone
+    // whose parent rides the SAME template. Requires the build-time fact.
+    if (tx.depends_on_in_set_parent && is_missing_inputs_reason(r.reason)) {
+        r.verdict        = MempoolAcceptVerdict::Unprobed;
+        r.unprobed_cause = "in-set-parent(single-tx-probe-cannot-see-it)";
+        return r;
+    }
+
+    r.verdict = MempoolAcceptVerdict::Invalid;
+    return r;
+}
+
+/// One height's worth of probing.
+struct MempoolValiditySample {
+    uint32_t height{0};
+    size_t   probed{0};
+    size_t   valid{0};
+    size_t   already_in_mempool{0};
+    size_t   invalid{0};
+    size_t   unprobed{0};
+    /// The defects, verbatim — txid + dashd's reason. These are what the
+    /// refusal line prints.
+    std::vector<MempoolAcceptResult> invalids;
+
+    /// A height that actually OBSERVED validity. A height whose probe set was
+    /// empty, or whose every entry came back Unprobed, observed nothing.
+    bool evidence_bearing() const
+    {
+        return (valid + already_in_mempool + invalid) > 0;
+    }
+    bool clean() const { return evidence_bearing() && invalid == 0; }
+};
+
+/// PURE. Classify a whole probe set against the per-transaction answers.
+/// `answers[i]` is dashd's result object for `set[i]`; a shorter answers vector
+/// means the remaining entries got no answer (Unprobed), never a pass.
+inline MempoolValiditySample
+mempool_validity_sample(uint32_t height,
+                        const std::vector<MempoolProbeTx>& set,
+                        const std::vector<nlohmann::json>& answers)
+{
+    MempoolValiditySample s;
+    s.height = height;
+    s.probed = set.size();
+    for (size_t i = 0; i < set.size(); ++i) {
+        const nlohmann::json& a = (i < answers.size()) ? answers[i]
+                                                       : nlohmann::json();
+        const MempoolAcceptResult r = classify_mempool_accept(set[i], a);
+        switch (r.verdict) {
+            case MempoolAcceptVerdict::Valid:            ++s.valid; break;
+            case MempoolAcceptVerdict::AlreadyInMempool: ++s.already_in_mempool; break;
+            case MempoolAcceptVerdict::Invalid:
+                ++s.invalid;
+                s.invalids.push_back(r);
+                break;
+            default:                                     ++s.unprobed; break;
+        }
+    }
+    return s;
+}
+
+/// THE HARD GATE.
+///
+/// kCleanHeightsRequired = 576 CONSECUTIVE EVIDENCE-BEARING heights with ZERO
+/// INVALID. Justification, in full, because a threshold without one is a
+/// number somebody made up:
+///
+///   * DURATION. DASH mainnet targets 2.625 min/block, so 576 blocks is
+///     ~25.2 hours — one full day plus a margin. That is the shortest window
+///     that contains every DAILY period in mempool composition: the fee/traffic
+///     diurnal cycle, at least one full DKG mining window for each active LLMQ
+///     type, and at least one ChainLock-less stretch. A shorter window can be
+///     passed by a quiet night.
+///   * STATISTICAL POWER. Evidence-bearing heights on the hotel carry a mean of
+///     ~30 selectable transactions, so 576 of them is ~1.7e4 transaction
+///     probes. Zero events in n trials bounds the true per-transaction invalid
+///     rate at 3/n (rule of three, 95%) = ~1.7e-4. At ~30 transactions per
+///     template that is a <=0.5% chance that any given template we build
+///     carries a rejectable transaction — roughly one at-risk block per 190
+///     mined. THAT IS THE RESIDUAL, stated rather than implied; it is not zero,
+///     and the number is why the window is 576 and not 100.
+///   * REACHABILITY. Unlike `ours_only == 0`, this condition is satisfiable by
+///     a correct node: it asks dashd whether OUR transactions are acceptable,
+///     not whether dashd's mempool coincides with ours.
+///
+/// The window is stated in BLOCKS, not hours, because the evidence is per
+/// TEMPLATE HEIGHT; hours are the derived reading.
+struct MempoolValidityGate {
+    static constexpr uint64_t kCleanHeightsRequired = 576;
+
+    uint64_t required{kCleanHeightsRequired};
+
+    uint64_t heights_seen{0};
+    uint64_t heights_with_evidence{0};
+    uint64_t heights_without_evidence{0};
+    uint64_t consecutive_clean{0};
+    uint64_t best_consecutive_clean{0};
+
+    uint64_t txs_probed{0};
+    uint64_t txs_valid{0};
+    uint64_t txs_already_in_mempool{0};
+    uint64_t txs_invalid{0};
+    uint64_t txs_unprobed{0};
+
+    uint32_t    last_invalid_height{0};
+    std::string last_invalid_txid;
+    std::string last_invalid_reason;
+
+    /// TRUE == the condition for arming --embedded-serve-mempool-txs is met.
+    /// It does NOT arm anything; the flag stays an operator decision.
+    bool open() const { return consecutive_clean >= required; }
+
+    void apply(const MempoolValiditySample& s)
+    {
+        ++heights_seen;
+        txs_probed             += s.probed;
+        txs_valid              += s.valid;
+        txs_already_in_mempool += s.already_in_mempool;
+        txs_invalid            += s.invalid;
+        txs_unprobed           += s.unprobed;
+
+        if (!s.evidence_bearing()) {
+            // Neither advances nor resets — it is not evidence in either
+            // direction. Said out loud so a long quiet stretch cannot be
+            // mistaken for progress toward the threshold.
+            ++heights_without_evidence;
+            return;
+        }
+        ++heights_with_evidence;
+
+        if (s.invalid > 0) {
+            const auto& first = s.invalids.front();
+            last_invalid_height = s.height;
+            last_invalid_txid   = first.txid;
+            last_invalid_reason = first.reason;
+            consecutive_clean   = 0;      // the run dies on ONE defect
+            return;
+        }
+        ++consecutive_clean;
+        if (consecutive_clean > best_consecutive_clean)
+            best_consecutive_clean = consecutive_clean;
+    }
+
+    nlohmann::json to_json() const
+    {
+        nlohmann::json j;
+        j["gate"]                      = open() ? "OPEN" : "CLOSED";
+        j["clean-heights-required"]    = required;
+        j["consecutive-clean-heights"] = consecutive_clean;
+        j["best-consecutive-clean-heights"] = best_consecutive_clean;
+        j["heights-seen"]              = heights_seen;
+        j["heights-with-evidence"]     = heights_with_evidence;
+        j["heights-without-evidence"]  = heights_without_evidence;
+        j["txs-probed"]                = txs_probed;
+        j["txs-valid"]                 = txs_valid;
+        j["txs-already-in-mempool"]    = txs_already_in_mempool;
+        j["txs-invalid"]               = txs_invalid;
+        j["txs-unprobed"]              = txs_unprobed;
+        j["last-invalid-height"]       = last_invalid_height;
+        j["last-invalid-txid"]         = last_invalid_txid;
+        j["last-invalid-reason"]       = last_invalid_reason;
+        j["ours-only"] = "INFORMATIONAL — coverage statistic, not a gate";
+        return j;
+    }
+};
+
+/// PURE. The lines this sample emits. The REFUSAL lines carry, per #1038/#1039
+/// serve-gate discipline, the TXID, dashd's REASON STRING, and the THRESHOLD —
+/// a decline that does not name its own cause and bound is a silent decline.
+inline std::vector<std::string>
+mempool_validity_log_lines(const MempoolValiditySample& s,
+                           const MempoolValidityGate& g)
+{
+    std::vector<std::string> out;
+    const std::string h = std::to_string(s.height);
+
+    for (const auto& d : s.invalids) {
+        out.push_back(
+            "[MEMPOOL-VALIDITY] h=" + h + " REFUSED cause=tx-invalid"
+            " txid=" + d.txid
+            + " reason=" + (d.reason.empty() ? std::string("(none-given)") : d.reason)
+            + " threshold=" + std::to_string(g.required)
+            + "-consecutive-clean-heights"
+              " clean_run=" + std::to_string(g.consecutive_clean) + "/"
+            + std::to_string(g.required)
+            + " — dashd's testmempoolaccept says this transaction is NOT"
+              " acceptable; serving it can cost a whole block."
+              " --embedded-serve-mempool-txs stays OFF and the clean run"
+              " RESETS to 0");
+    }
+
+    std::string l = "[MEMPOOL-VALIDITY] h=" + h
+        + " probed="    + std::to_string(s.probed)
+        + " valid="     + std::to_string(s.valid)
+        + " already_in_mempool=" + std::to_string(s.already_in_mempool)
+        + " invalid="   + std::to_string(s.invalid)
+        + " unprobed="  + std::to_string(s.unprobed)
+        + " clean_run=" + std::to_string(g.consecutive_clean) + "/"
+        + std::to_string(g.required)
+        + " gate=" + (g.open() ? "OPEN" : "CLOSED");
+    if (!s.evidence_bearing())
+        l += " (no-evidence: nothing to probe at this height — the run neither"
+             " advances nor resets)";
+    out.push_back(std::move(l));
+    return out;
+}
+
+/// The MEMPOOL-SOURCED transactions this template would serve, assembled from
+/// whichever half of the template carries them:
+///
+///   * SERVING (--embedded-serve-mempool-txs ON): the contiguous mempool range
+///     of the served body, [m_mempool_tx_first_index, +m_mempool_tx_count).
+///     Referenced by index rather than copied — the money path must not grow a
+///     second copy of the block body for a diagnostic.
+///   * NOT SERVING (the default, and the case the gate exists to decide): the
+///     CANDIDATE set — what selection WOULD have chosen — with its own wire hex.
+///
+/// Consensus-mandatory type-6 quorum-commitment txs and pinned local txs are
+/// EXCLUDED by construction: neither is mempool-sourced, and both are rejected
+/// by relay policy on purpose (a zero-fee pin especially), so probing them
+/// would manufacture INVALID verdicts out of correct behaviour.
+inline std::vector<MempoolProbeTx> mempool_probe_set(const DashWorkData& w)
+{
+    std::vector<MempoolProbeTx> out;
+
+    if (w.m_mempool_tx_count > 0) {
+        const size_t first = w.m_mempool_tx_first_index;
+        const size_t n     = w.m_mempool_tx_count;
+        if (first + n > w.m_tx_hashes.size() || first + n > w.m_tx_data_hex.size())
+            return out;   // mis-populated WorkData: report NOTHING, never guess
+        out.reserve(n);
+        for (size_t i = 0; i < n; ++i) {
+            MempoolProbeTx t;
+            t.txid    = w.m_tx_hashes[first + i].GetHex();
+            t.raw_hex = w.m_tx_data_hex[first + i];
+            t.depends_on_in_set_parent =
+                (i < w.m_mempool_probe_depends_in_set.size())
+                && (w.m_mempool_probe_depends_in_set[i] != 0);
+            out.push_back(std::move(t));
+        }
+        return out;
+    }
+
+    if (w.m_txset_candidates.size() != w.m_txset_candidate_data_hex.size())
+        return out;       // unaligned: a fabricated probe set is worse than none
+    out.reserve(w.m_txset_candidates.size());
+    for (size_t i = 0; i < w.m_txset_candidates.size(); ++i) {
+        MempoolProbeTx t;
+        t.txid    = w.m_txset_candidates[i].GetHex();
+        t.raw_hex = w.m_txset_candidate_data_hex[i];
+        t.depends_on_in_set_parent =
+            (i < w.m_mempool_probe_depends_in_set.size())
+            && (w.m_mempool_probe_depends_in_set[i] != 0);
+        out.push_back(std::move(t));
+    }
+    return out;
+}
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/rpc.cpp
+++ b/src/impl/dash/coin/rpc.cpp
@@ -527,6 +527,28 @@ std::string NodeRPC::propose_block_hex(const std::string& block_hex)
     }
 }
 
+nlohmann::json NodeRPC::test_mempool_accept(const std::string& raw_tx_hex)
+{
+    // THE MEMPOOL VALIDITY GATE's only question to dashd: would you accept
+    // THIS transaction? The answer array carries exactly one result object for
+    // a one-element request.
+    //
+    // A transport error, a daemon that is down, or a malformed answer all
+    // return a NULL json — the caller classifies that as UNPROBED. Returning
+    // anything that could be read as `allowed` would turn "we could not ask"
+    // into "dashd said yes", which is the failure mode this whole gate exists
+    // to remove.
+    try {
+        nlohmann::json arr = nlohmann::json::array();
+        arr.push_back(raw_tx_hex);
+        auto res = CallAPIMethod("testmempoolaccept", {arr});
+        if (res.is_array() && !res.empty() && res[0].is_object()) return res[0];
+        return nlohmann::json();
+    } catch (const std::exception&) {
+        return nlohmann::json();
+    }
+}
+
 nlohmann::json NodeRPC::getnetworkinfo()
 {
     return CallAPIMethod("getnetworkinfo");

--- a/src/impl/dash/coin/rpc.hpp
+++ b/src/impl/dash/coin/rpc.hpp
@@ -167,6 +167,17 @@ public:
     // assembled block. Returns "" on ACCEPT (dashd TestBlockValidity passed) or
     // the reject reason. Mempool-independent; never throws (RPC blip -> reason).
     std::string propose_block_hex(const std::string& block_hex);
+    // MEMPOOL VALIDITY GATE (mempool_validity_gate.hpp): dashd's own verdict on
+    // ONE transaction we hold and would serve. Returns the single result object
+    // -- {"txid":..,"allowed":..,"reject-reason":..} -- or a NULL json when the
+    // daemon could not be asked. Never throws, and a failure is deliberately
+    // indistinguishable from "no answer" rather than from "allowed": the gate
+    // counts a missing answer as UNPROBED, never as a pass.
+    //
+    // ONE transaction per call, because that is the only shape Dash Core's
+    // testmempoolaccept takes ("Array must contain exactly one raw
+    // transaction"). Always called off the miner-facing path.
+    nlohmann::json test_mempool_accept(const std::string& raw_tx_hex);
     nlohmann::json getnetworkinfo();
     nlohmann::json getblockchaininfo();
     nlohmann::json getmininginfo();

--- a/src/impl/dash/coin/rpc_data.hpp
+++ b/src/impl/dash/coin/rpc_data.hpp
@@ -173,6 +173,39 @@ struct DashWorkData {
     // what makes the fee lane completable at all.
     std::vector<uint256>  m_txset_candidates;
     std::vector<uint64_t> m_txset_candidate_fees;
+    // Wire-form hex of each candidate, parallel to m_txset_candidates. The
+    // MEMPOOL VALIDITY GATE (mempool_validity_gate.hpp) feeds these to dashd's
+    // testmempoolaccept: the condition that decides whether
+    // --embedded-serve-mempool-txs may be armed cannot be evaluated from ids
+    // alone, and while the flag is OFF the candidate set is the ONLY place the
+    // transactions we would serve exist. Diagnostic: no consensus path reads it.
+    std::vector<std::string> m_txset_candidate_data_hex;
+
+    // ── THE MEMPOOL-SOURCED RANGE OF THE SERVED BODY ──────────────────────
+    // When the template DOES carry mempool transactions they are appended
+    // LAST, after the consensus-mandatory type-6 quorum commitments and any
+    // pinned local tx, so they occupy the contiguous range
+    // [m_mempool_tx_first_index, m_mempool_tx_first_index + m_mempool_tx_count)
+    // of m_txs / m_tx_hashes / m_tx_fees / m_tx_data_hex.
+    //
+    // The validity gate must probe EXACTLY that range and nothing else: a
+    // type-6 commitment and a zero-fee pinned tx are both refused by relay
+    // policy BY DESIGN, so probing them would manufacture INVALID verdicts out
+    // of correct behaviour. Carried as a RANGE rather than a second copy of
+    // the hex so the money path does not grow a duplicate block body for a
+    // diagnostic. count == 0 means "no mempool-sourced tx in this body".
+    uint32_t m_mempool_tx_first_index{0};
+    uint32_t m_mempool_tx_count{0};
+
+    // Per-entry "this tx spends an output of an EARLIER entry of the same
+    // probe set" flag, parallel to whichever probe set is populated (the
+    // served range above, or the candidate set). dashd's testmempoolaccept
+    // takes ONE transaction, so a child probed alone answers `missing-inputs`
+    // when its parent is only in OUR template — an artefact of the probe, not
+    // a defect of the transaction. The flag is computed at build time from the
+    // real vins, so the exemption is a FACT about the set rather than an
+    // inference from a reject string. Diagnostic: no consensus path reads it.
+    std::vector<uint8_t>  m_mempool_probe_depends_in_set;
 
     // ── PIN OUTCOMES (see PinOutcome above) ───────────────────────────────
     // One entry per configured pinned local tx, written by the splice on the

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -849,7 +849,18 @@ if (BUILD_TESTING AND GTest_FOUND)
         # dash_mainnet_quorum_scan_* / _active_quorums_ fixtures as the W4
         # suite above, and is folded into this target for the same #769
         # reason (the push bot cannot add a build.yml --target).
-        test_dash_mined_commitment_index.cpp)
+        test_dash_mined_commitment_index.cpp
+        # test_dash_mempool_validity_gate.cpp: THE condition that decides when
+        # --embedded-serve-mempool-txs may be armed
+        # (mempool_validity_gate.hpp). Pins the three-valued
+        # testmempoolaccept logic, the exact-name "txn-already-in-mempool"
+        # exemption, "a missing answer is never a pass", the refusal line's
+        # txid/reason/threshold (#1038/#1039 discipline), the sustained-window
+        # arithmetic, and the two directions the retired `ours_only == 0`
+        # set-membership test got wrong. Folded into this target per the same
+        # #769 rule as the leaves above (the push bot cannot add a build.yml
+        # --target, so a standalone executable would be a NOT_BUILT sentinel).
+        test_dash_mempool_validity_gate.cpp)
     target_compile_definitions(test_dash_embedded_gbt PRIVATE
         DASH_FIXTURE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/fixtures")
     target_link_libraries(test_dash_embedded_gbt PRIVATE

--- a/test/test_dash_embedded_gbt.cpp
+++ b/test/test_dash_embedded_gbt.cpp
@@ -48,6 +48,7 @@
 #include <impl/dash/coin/mn_state_machine.hpp>
 #include <impl/dash/coin/mn_state_db.hpp>
 #include <impl/dash/coin/mempool.hpp>
+#include <impl/dash/coin/mempool_validity_gate.hpp>    // probe-set assembly (the serve-flag gate)
 #include <impl/dash/coin/subsidy.hpp>
 #include <impl/dash/coin/utxo_adapter.hpp>
 #include <impl/dash/coin/quorum_manager.hpp>
@@ -1059,6 +1060,90 @@ TEST(DashUtxoImmatureServing, SuppressedTemplateNamesItselfAndReportsThePrice) {
     EXPECT_EQ(empty.m_txset_forgone_fees, f.mp.total_known_fees());
     EXPECT_EQ(empty.m_txset_forgone_fees,
               static_cast<uint64_t>(ImmatureFixture::FEE));
+}
+
+// ── THE MEMPOOL VALIDITY GATE's PROBE SET (mempool_validity_gate.hpp) ───────
+// The condition that decides when --embedded-serve-mempool-txs may be armed
+// needs the WIRE BYTES of every transaction we would serve, so each one can be
+// put to dashd's testmempoolaccept. These pin that the builder hands the gate
+// exactly those transactions and no others, in both postures.
+
+TEST(DashMempoolProbeSet, SuppressedTemplateCarriesCandidateWireHexForTheGate) {
+    ImmatureFixture f;
+    auto empty = f.build(/*suppress=*/true);
+
+    // Nothing served, but the candidate set — what selection WOULD have chosen
+    // — now carries its wire hex: ids alone cannot be put to
+    // testmempoolaccept, and while the flag is OFF the candidate set is the
+    // only place the transactions we would serve exist.
+    ASSERT_TRUE(empty.m_txs.empty());
+    ASSERT_EQ(empty.m_txset_candidates.size(), 1u);
+    ASSERT_EQ(empty.m_txset_candidate_data_hex.size(),
+              empty.m_txset_candidates.size());
+    EXPECT_FALSE(empty.m_txset_candidate_data_hex[0].empty());
+    ASSERT_EQ(empty.m_mempool_probe_depends_in_set.size(), 1u);
+    EXPECT_EQ(empty.m_mempool_probe_depends_in_set[0], 0u)
+        << "a single independent tx has no in-set parent";
+
+    const auto set = dash::coin::mempool_probe_set(empty);
+    ASSERT_EQ(set.size(), 1u);
+    EXPECT_EQ(set[0].txid, dash::coin::dash_txid(f.tx).GetHex());
+    EXPECT_EQ(set[0].raw_hex, empty.m_txset_candidate_data_hex[0]);
+}
+
+TEST(DashMempoolProbeSet, ServedTemplateRangeNamesTheMempoolTxsWithoutDuplicatingThem) {
+    ImmatureFixture f;
+    auto normal = f.build(/*suppress=*/false);
+
+    // The served body here is exactly the one selected mempool tx: no type-6
+    // commitments, no pins. The range must name it and nothing else.
+    ASSERT_EQ(normal.m_txs.size(), 1u);
+    EXPECT_EQ(normal.m_mempool_tx_first_index, 0u);
+    EXPECT_EQ(normal.m_mempool_tx_count, 1u);
+
+    const auto set = dash::coin::mempool_probe_set(normal);
+    ASSERT_EQ(set.size(), 1u);
+    EXPECT_EQ(set[0].txid, dash::coin::dash_txid(f.tx).GetHex());
+    EXPECT_EQ(set[0].raw_hex, normal.m_tx_data_hex[0]);
+
+    // The probe set is a VIEW of the served body, not a second copy of it —
+    // the money path must not grow a duplicate block body for a diagnostic.
+    EXPECT_TRUE(normal.m_txset_candidate_data_hex.empty());
+}
+
+TEST(DashMempoolProbeSet, ProbeRangeSkipsTheMandatoryQuorumCommitmentPrefix) {
+    // A type-6 quorum commitment is consensus-REQUIRED and is not a mempool
+    // transaction: relay refuses it by design. Probing it would manufacture an
+    // INVALID verdict out of correct behaviour, so the range must start AFTER
+    // the commitments.
+    ImmatureFixture f;
+    std::vector<dash::coin::vendor::CFinalCommitment> qcs(1);
+    qcs[0].llmqType   = 1;
+    qcs[0].quorumHash = raw256(0x77);
+
+    auto w = build_embedded_workdata(
+        /*prev_height=*/H - 1, f.prev_hash, f.mnstates, f.mp,
+        ImmatureFixture::BITS, ImmatureFixture::MTP,
+        DASH_PUBKEY_VER, DASH_P2SH_VER,
+        /*curtime=*/1'700'000'123u, /*version=*/0x20000000u,
+        /*underfill_tripped=*/nullptr,
+        /*sml=*/nullptr, /*qmgr=*/nullptr,
+        /*best_cl_height=*/0, dash::coin::k_zero_cl_sig, /*credit_pool=*/0,
+        &qcs, /*quorum_root_override=*/nullptr,
+        dash::coin::DASH_MN_RR_HEIGHT_MAINNET,
+        /*superblock_payments=*/nullptr,
+        dash::coin::DASH_MN_MIN_CONFIRMATIONS_MAINNET,
+        /*suppress_mempool_txs=*/false);
+
+    ASSERT_EQ(w.m_txs.size(), 2u) << "one qc tx + one mempool tx";
+    EXPECT_EQ(w.m_txs[0].type, 6);
+    EXPECT_EQ(w.m_mempool_tx_first_index, 1u);
+    EXPECT_EQ(w.m_mempool_tx_count, 1u);
+
+    const auto set = dash::coin::mempool_probe_set(w);
+    ASSERT_EQ(set.size(), 1u);
+    EXPECT_EQ(set[0].txid, dash::coin::dash_txid(f.tx).GetHex())
+        << "the quorum commitment must never be put to testmempoolaccept";
 }
 
 TEST(DashUtxoImmatureServing, SuppressedTemplateCbTxIsByteIdenticalToNormal) {

--- a/test/test_dash_embedded_shadow_compare.cpp
+++ b/test/test_dash_embedded_shadow_compare.cpp
@@ -412,9 +412,14 @@ TEST(DashShadowCompare, TxSetCoverageIsMeasuredAgainstDashd) {
     EXPECT_FALSE(o.served_mismatch);
 }
 
-// The dangerous direction is called out in the line itself, because the
-// operator reads the line, not the struct.
-TEST(DashShadowCompare, TxWeHaveThatDashdDoesNotIsFlaggedLoudly) {
+// ours_only is INFORMATIONAL. It is still measured and still printed — as a
+// COVERAGE STATISTIC — and it no longer tells the operator not to arm the serve
+// flag. `ours_only == 0` was unreachable (two independently-connected mempools
+// never coincide: MEASURED non-zero in 8.8% of 6056 hotel samples, mean 65.3,
+// max 287) AND blind to the case that costs money (a strict SUBSET of dashd's
+// set can still contain a transaction dashd would refuse). The serve flag is
+// now gated on transaction VALIDITY — mempool_validity_gate.hpp.
+TEST(DashShadowCompare, OursOnlyIsReportedButNoLongerBlocksTheServeFlag) {
     auto cb = make_cbtx(2500000, 11, 22);
     auto emb  = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
     auto dref = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
@@ -427,10 +432,15 @@ TEST(DashShadowCompare, TxWeHaveThatDashdDoesNotIsFlaggedLoudly) {
 
     const auto o = shadow_evaluate(WorkSource::Embedded, emb,
                                    std::optional<DashWorkData>(dref));
+    // Still MEASURED and still PRINTED — a coverage statistic nobody stops
+    // watching just because it stopped being a gate.
     EXPECT_TRUE(has_line_with(o.log_lines, "ours_only=1"));
-    EXPECT_TRUE(has_line_with(o.log_lines, "OURS-ONLY"));
-    EXPECT_TRUE(has_line_with(o.log_lines,
-                              "do NOT enable --embedded-serve-mempool-txs"));
+    EXPECT_TRUE(has_line_with(o.log_lines, "INFORMATIONAL"));
+    // ... and it no longer issues the blocking instruction.
+    EXPECT_FALSE(has_line_with(o.log_lines,
+                               "do NOT enable --embedded-serve-mempool-txs"));
+    // A tx-set divergence is not, and never was, a served mismatch.
+    EXPECT_FALSE(o.served_mismatch);
 }
 
 // A coinbase-only dashd template means there was no fee to capture at this
@@ -678,10 +688,11 @@ TEST(DashShadowCompare, NoServedAndNoCandidatesIsModeNone) {
     EXPECT_TRUE(has_line_with(o.log_lines, "mode=none"));
 }
 
-// The candidate path must still refuse the dangerous direction: a candidate we
-// hold that dashd does not is exactly as disqualifying as a served one, because
-// it is what we WOULD have put in a block.
-TEST(DashShadowCompare, CandidateOursOnlyIsStillFlagged) {
+// The candidate path measures ours_only the same way the served path does —
+// and, like the served path, reports it as INFORMATION. What disqualifies a
+// candidate is dashd REFUSING it (mempool_validity_gate.hpp), not dashd's
+// template happening not to carry it.
+TEST(DashShadowCompare, CandidateOursOnlyIsMeasuredAndReportedInformational) {
     auto cb = make_cbtx(2500000, 11, 22);
     auto emb  = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
     auto dref = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
@@ -695,7 +706,8 @@ TEST(DashShadowCompare, CandidateOursOnlyIsStillFlagged) {
 
     const auto o = shadow_evaluate(WorkSource::Embedded, emb,
                                    std::optional<DashWorkData>(dref));
-    EXPECT_TRUE(has_line_with(o.log_lines, "OURS-ONLY"));
-    EXPECT_TRUE(has_line_with(o.log_lines,
-                              "do NOT enable --embedded-serve-mempool-txs"));
+    EXPECT_TRUE(has_line_with(o.log_lines, "ours_only=1"));
+    EXPECT_TRUE(has_line_with(o.log_lines, "INFORMATIONAL"));
+    EXPECT_FALSE(has_line_with(o.log_lines,
+                               "do NOT enable --embedded-serve-mempool-txs"));
 }

--- a/test/test_dash_mempool_validity_gate.cpp
+++ b/test/test_dash_mempool_validity_gate.cpp
@@ -1,0 +1,369 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// DASH MEMPOOL VALIDITY GATE — KATs for the condition that decides when
+// --embedded-serve-mempool-txs may be armed (mempool_validity_gate.hpp).
+//
+// What these pin, in order of what they are worth:
+//   1. The three-valued logic itself: allowed -> VALID; allowed==false with
+//      reason "txn-already-in-mempool" -> ALSO VALID; ANY other reason ->
+//      INVALID, and a defect.
+//   2. That the exemption is by EXACT NAME. A near-miss reason string
+//      ("txn-already-known") is INVALID, because widening the exemption set
+//      widens the gate.
+//   3. That a missing answer is UNPROBED, never a pass — "we could not ask" is
+//      the failure mode the whole gate exists to remove.
+//   4. That the REFUSAL line names the txid, dashd's reason string, and the
+//      threshold (#1038/#1039 serve-gate discipline).
+//   5. That the sustained window is what it says: a clean run advances only on
+//      EVIDENCE-BEARING heights, dies on one INVALID, and empty heights neither
+//      advance nor reset (576 empty heights must not open the gate).
+//   6. That ours_only is nowhere in the gate: a set-membership divergence, of
+//      any size, cannot close it, and a strict SUBSET containing an invalid
+//      transaction DOES close it — the two directions the old condition got
+//      wrong.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/mempool_validity_gate.hpp>
+
+#include <nlohmann/json.hpp>
+
+#include <string>
+#include <vector>
+
+using namespace dash::coin;
+
+namespace {
+
+MempoolProbeTx tx(const std::string& id, bool depends = false)
+{
+    MempoolProbeTx t;
+    t.txid    = id;
+    t.raw_hex = "0100000000";   // shape only; the daemon is the oracle here
+    t.depends_on_in_set_parent = depends;
+    return t;
+}
+
+nlohmann::json allowed_true(const std::string& id)
+{
+    return nlohmann::json{{"txid", id}, {"allowed", true}};
+}
+
+nlohmann::json refused(const std::string& id, const std::string& reason)
+{
+    return nlohmann::json{{"txid", id}, {"allowed", false},
+                          {"reject-reason", reason}};
+}
+
+bool has_line_with(const std::vector<std::string>& lines, const std::string& needle)
+{
+    for (const auto& l : lines)
+        if (l.find(needle) != std::string::npos) return true;
+    return false;
+}
+
+// A run of `n` clean, evidence-bearing heights.
+void feed_clean(MempoolValidityGate& g, uint64_t n, uint32_t from_height = 1000)
+{
+    for (uint64_t i = 0; i < n; ++i) {
+        const auto set = std::vector<MempoolProbeTx>{tx("aa")};
+        const auto ans = std::vector<nlohmann::json>{allowed_true("aa")};
+        g.apply(mempool_validity_sample(
+            static_cast<uint32_t>(from_height + i), set, ans));
+    }
+}
+
+} // namespace
+
+// ── 1. THE THREE-VALUED LOGIC ───────────────────────────────────────────────
+
+TEST(DashMempoolValidityGate, AllowedIsValid) {
+    const auto r = classify_mempool_accept(tx("aa"), allowed_true("aa"));
+    EXPECT_EQ(r.verdict, MempoolAcceptVerdict::Valid);
+    EXPECT_TRUE(r.reason.empty());
+}
+
+TEST(DashMempoolValidityGate, AlreadyInMempoolIsAlsoValid) {
+    // dashd saying "I already hold this" is the STRONGEST statement that the
+    // transaction is acceptable to it.
+    const auto r = classify_mempool_accept(
+        tx("bb"), refused("bb", "txn-already-in-mempool"));
+    EXPECT_EQ(r.verdict, MempoolAcceptVerdict::AlreadyInMempool);
+    EXPECT_EQ(r.reason, "txn-already-in-mempool");
+}
+
+TEST(DashMempoolValidityGate, AnyOtherReasonIsInvalidAndCarriesItVerbatim) {
+    const auto r = classify_mempool_accept(
+        tx("cc"), refused("cc", "bad-txns-inputs-spent"));
+    EXPECT_EQ(r.verdict, MempoolAcceptVerdict::Invalid);
+    EXPECT_EQ(r.reason, "bad-txns-inputs-spent");   // verbatim, not paraphrased
+}
+
+// ── 2. THE EXEMPTION IS BY EXACT NAME ───────────────────────────────────────
+
+TEST(DashMempoolValidityGate, NearMissReasonIsNotExempted) {
+    // "txn-already-known" is a DIFFERENT dashd reason (the transaction is in a
+    // block / recently rejected, not in the mempool). Excusing it would widen
+    // the gate by prefix-matching, and a tx we would serve that dashd has
+    // already MINED is a staleness defect worth stopping on.
+    for (const char* reason : {"txn-already-known",
+                               "txn-already-in-mempool-ish",
+                               "already-in-mempool"}) {
+        const auto r = classify_mempool_accept(tx("dd"), refused("dd", reason));
+        EXPECT_EQ(r.verdict, MempoolAcceptVerdict::Invalid)
+            << "reason=" << reason << " must NOT be exempted";
+    }
+}
+
+// ── 3. A MISSING ANSWER IS NEVER A PASS ─────────────────────────────────────
+
+TEST(DashMempoolValidityGate, NoAnswerIsUnprobedNotValid) {
+    const auto r = classify_mempool_accept(tx("ee"), nlohmann::json());
+    EXPECT_EQ(r.verdict, MempoolAcceptVerdict::Unprobed);
+    EXPECT_EQ(r.unprobed_cause, "no-answer");
+
+    // And a short answers vector leaves the tail UNPROBED, never VALID.
+    const std::vector<MempoolProbeTx> set{tx("e1"), tx("e2"), tx("e3")};
+    const std::vector<nlohmann::json> ans{allowed_true("e1")};
+    const auto s = mempool_validity_sample(2500000, set, ans);
+    EXPECT_EQ(s.probed,   3u);
+    EXPECT_EQ(s.valid,    1u);
+    EXPECT_EQ(s.unprobed, 2u);
+    EXPECT_EQ(s.invalid,  0u);
+}
+
+TEST(DashMempoolValidityGate, InSetParentMissingInputsIsUnprobedOnlyWithTheBuildTimeFact) {
+    // A child probed ALONE cannot show dashd a parent that only rides our
+    // template. That is an artefact of the one-tx probe shape, so it is
+    // UNPROBED — but ONLY because the builder recorded the dependency.
+    const auto excused = classify_mempool_accept(
+        tx("ff", /*depends=*/true), refused("ff", "missing-inputs"));
+    EXPECT_EQ(excused.verdict, MempoolAcceptVerdict::Unprobed);
+    EXPECT_EQ(excused.reason, "missing-inputs");   // still reported verbatim
+
+    // Same reason, NO recorded dependency: a genuine missing input. INVALID.
+    const auto real = classify_mempool_accept(
+        tx("ff", /*depends=*/false), refused("ff", "missing-inputs"));
+    EXPECT_EQ(real.verdict, MempoolAcceptVerdict::Invalid);
+
+    // The excuse does not generalise to other reasons just because the tx has
+    // an in-set parent.
+    const auto other = classify_mempool_accept(
+        tx("ff", /*depends=*/true), refused("ff", "bad-txns-inputs-spent"));
+    EXPECT_EQ(other.verdict, MempoolAcceptVerdict::Invalid);
+}
+
+// ── 4. THE REFUSAL LINE NAMES CAUSE, TXID, REASON AND THRESHOLD ─────────────
+
+TEST(DashMempoolValidityGate, RefusalLineCarriesTxidReasonAndThreshold) {
+    MempoolValidityGate g;
+    const std::vector<MempoolProbeTx> set{tx("aa"), tx("deadbeefcafe")};
+    const std::vector<nlohmann::json> ans{
+        allowed_true("aa"),
+        refused("deadbeefcafe", "bad-txns-inputs-spent")};
+    const auto s = mempool_validity_sample(2518789, set, ans);
+    g.apply(s);
+
+    const auto lines = mempool_validity_log_lines(s, g);
+    EXPECT_TRUE(has_line_with(lines, "REFUSED"));
+    EXPECT_TRUE(has_line_with(lines, "txid=deadbeefcafe"));
+    EXPECT_TRUE(has_line_with(lines, "reason=bad-txns-inputs-spent"));
+    EXPECT_TRUE(has_line_with(
+        lines, "threshold=" + std::to_string(g.required)));
+    EXPECT_TRUE(has_line_with(lines, "h=2518789"));
+    // The summary line is always emitted too, so a soak can read the series.
+    EXPECT_TRUE(has_line_with(lines, "probed=2"));
+    EXPECT_TRUE(has_line_with(lines, "gate=CLOSED"));
+}
+
+// ── 5. THE SUSTAINED WINDOW ─────────────────────────────────────────────────
+
+TEST(DashMempoolValidityGate, GateOpensOnlyAfterTheFullCleanRun) {
+    MempoolValidityGate g;
+    ASSERT_EQ(g.required, MempoolValidityGate::kCleanHeightsRequired);
+    EXPECT_FALSE(g.open());
+
+    feed_clean(g, g.required - 1);
+    EXPECT_EQ(g.consecutive_clean, g.required - 1);
+    EXPECT_FALSE(g.open()) << "one height short must still be CLOSED";
+
+    feed_clean(g, 1, 9000);
+    EXPECT_TRUE(g.open());
+    EXPECT_EQ(g.txs_invalid, 0u);
+}
+
+TEST(DashMempoolValidityGate, OneInvalidKillsTheWholeRun) {
+    MempoolValidityGate g;
+    feed_clean(g, g.required - 1);
+    ASSERT_EQ(g.consecutive_clean, g.required - 1);
+
+    const std::vector<MempoolProbeTx> set{tx("aa"), tx("bad")};
+    const std::vector<nlohmann::json> ans{allowed_true("aa"),
+                                          refused("bad", "bad-txns-inputs-spent")};
+    g.apply(mempool_validity_sample(9999, set, ans));
+
+    EXPECT_EQ(g.consecutive_clean, 0u);
+    EXPECT_FALSE(g.open());
+    EXPECT_EQ(g.txs_invalid, 1u);
+    EXPECT_EQ(g.last_invalid_txid, "bad");
+    EXPECT_EQ(g.last_invalid_reason, "bad-txns-inputs-spent");
+    EXPECT_EQ(g.last_invalid_height, 9999u);
+    // The high-water mark survives, so the reset is visible as a reset rather
+    // than as "we never got anywhere".
+    EXPECT_EQ(g.best_consecutive_clean, g.required - 1);
+}
+
+TEST(DashMempoolValidityGate, EmptyHeightsNeitherAdvanceNorResetTheRun) {
+    MempoolValidityGate g;
+    // A whole window of heights with nothing to probe proves NOTHING; letting
+    // it open the gate would be the same vacuous pass the old condition had.
+    for (uint64_t i = 0; i < g.required + 10; ++i)
+        g.apply(mempool_validity_sample(static_cast<uint32_t>(1000 + i), {}, {}));
+    EXPECT_FALSE(g.open());
+    EXPECT_EQ(g.consecutive_clean, 0u);
+    EXPECT_EQ(g.heights_with_evidence, 0u);
+    EXPECT_EQ(g.heights_without_evidence, g.required + 10);
+
+    // Nor do they RESET a run in progress.
+    feed_clean(g, 5, 20000);
+    ASSERT_EQ(g.consecutive_clean, 5u);
+    g.apply(mempool_validity_sample(30000, {}, {}));
+    EXPECT_EQ(g.consecutive_clean, 5u);
+}
+
+TEST(DashMempoolValidityGate, AnAllUnprobedHeightIsNotEvidence) {
+    // Probing 40 transactions and getting 40 non-answers is not a clean height:
+    // it is no measurement at all.
+    MempoolValidityGate g;
+    std::vector<MempoolProbeTx> set;
+    std::vector<nlohmann::json> ans;
+    for (int i = 0; i < 40; ++i) {
+        set.push_back(tx("t" + std::to_string(i)));
+        ans.push_back(nlohmann::json());
+    }
+    const auto s = mempool_validity_sample(2500001, set, ans);
+    EXPECT_FALSE(s.evidence_bearing());
+    EXPECT_FALSE(s.clean());
+    g.apply(s);
+    EXPECT_EQ(g.consecutive_clean, 0u);
+    EXPECT_EQ(g.txs_unprobed, 40u);
+}
+
+TEST(DashMempoolValidityGate, AlreadyInMempoolAloneIsEnoughEvidenceToAdvance) {
+    // A height whose every transaction dashd already holds IS a measurement of
+    // validity — the strongest one available.
+    MempoolValidityGate g;
+    const std::vector<MempoolProbeTx> set{tx("aa"), tx("bb")};
+    const std::vector<nlohmann::json> ans{
+        refused("aa", "txn-already-in-mempool"),
+        refused("bb", "txn-already-in-mempool")};
+    const auto s = mempool_validity_sample(2500002, set, ans);
+    EXPECT_TRUE(s.clean());
+    g.apply(s);
+    EXPECT_EQ(g.consecutive_clean, 1u);
+    EXPECT_EQ(g.txs_already_in_mempool, 2u);
+}
+
+// ── 6. THE TWO DIRECTIONS THE OLD CONDITION GOT WRONG ───────────────────────
+
+TEST(DashMempoolValidityGate, SetDivergenceOfAnySizeCannotCloseTheGate) {
+    // Reproduces the hotel's worst measured sample: 287 transactions we hold
+    // that dashd's template did not carry. Under `ours_only == 0` that is a
+    // hard block. Under VALIDITY, if dashd accepts all of them, it is a clean
+    // height — because the question is whether the transactions are
+    // acceptable, not whether the two mempools coincide.
+    MempoolValidityGate g;
+    std::vector<MempoolProbeTx> set;
+    std::vector<nlohmann::json> ans;
+    for (int i = 0; i < 287; ++i) {
+        const std::string id = "ours" + std::to_string(i);
+        set.push_back(tx(id));
+        ans.push_back(allowed_true(id));
+    }
+    const auto s = mempool_validity_sample(2518000, set, ans);
+    EXPECT_TRUE(s.clean());
+    EXPECT_EQ(s.valid, 287u);
+    g.apply(s);
+    EXPECT_EQ(g.consecutive_clean, 1u);
+    EXPECT_EQ(g.txs_invalid, 0u);
+}
+
+TEST(DashMempoolValidityGate, AStrictSubsetWithOneInvalidTxStillClosesTheGate) {
+    // The case the set-membership test is BLIND to: FEWER transactions than
+    // dashd (a strict subset, ours_only == 0, the old gate PASSES) with one
+    // that dashd would refuse. Serving it costs a whole block.
+    MempoolValidityGate g;
+    const std::vector<MempoolProbeTx> set{tx("a"), tx("b")};   // dashd has a,b,c
+    const std::vector<nlohmann::json> ans{
+        allowed_true("a"),
+        refused("b", "bad-txns-inputs-missingorspent")};       // no in-set parent
+    const auto s = mempool_validity_sample(2518001, set, ans);
+    EXPECT_FALSE(s.clean());
+    EXPECT_EQ(s.invalid, 1u);
+    g.apply(s);
+    EXPECT_FALSE(g.open());
+    EXPECT_EQ(g.last_invalid_txid, "b");
+}
+
+// ── PROBE-SET ASSEMBLY off a DashWorkData ───────────────────────────────────
+
+TEST(DashMempoolValidityGate, ProbeSetIsTheCandidateSetWhenNothingIsServed) {
+    DashWorkData w;
+    w.m_height = 2518002;
+    w.m_txset_candidates.push_back(uint256::ONE);
+    w.m_txset_candidate_data_hex.push_back("0100");
+    w.m_mempool_probe_depends_in_set.push_back(0);
+
+    const auto set = mempool_probe_set(w);
+    ASSERT_EQ(set.size(), 1u);
+    EXPECT_EQ(set[0].txid, uint256::ONE.GetHex());
+    EXPECT_EQ(set[0].raw_hex, "0100");
+    EXPECT_FALSE(set[0].depends_on_in_set_parent);
+}
+
+TEST(DashMempoolValidityGate, ProbeSetSkipsTheNonMempoolPrefixOfAServedBody) {
+    // A served body is [type-6 commitments][pinned local txs][mempool txs].
+    // Only the last range is mempool-sourced; the others are refused by relay
+    // policy BY DESIGN and probing them would manufacture INVALID verdicts out
+    // of correct behaviour.
+    DashWorkData w;
+    w.m_height = 2518003;
+    w.m_tx_hashes = {uint256::ONE, uint256::ZERO, uint256::ONE};
+    w.m_tx_data_hex = {"qc", "pin", "mempool"};
+    w.m_mempool_tx_first_index = 2;
+    w.m_mempool_tx_count       = 1;
+    w.m_mempool_probe_depends_in_set = {0};
+
+    const auto set = mempool_probe_set(w);
+    ASSERT_EQ(set.size(), 1u);
+    EXPECT_EQ(set[0].raw_hex, "mempool");
+}
+
+TEST(DashMempoolValidityGate, AMisPopulatedWorkDataProbesNothingRatherThanGuessing) {
+    DashWorkData w;
+    w.m_height = 2518004;
+    // Range points past the end of the parallel vectors.
+    w.m_tx_hashes   = {uint256::ONE};
+    w.m_tx_data_hex = {"aa"};
+    w.m_mempool_tx_first_index = 0;
+    w.m_mempool_tx_count       = 5;
+    EXPECT_TRUE(mempool_probe_set(w).empty());
+
+    // Unaligned candidate vectors: also nothing.
+    DashWorkData v;
+    v.m_txset_candidates = {uint256::ONE, uint256::ZERO};
+    v.m_txset_candidate_data_hex = {"aa"};
+    EXPECT_TRUE(mempool_probe_set(v).empty());
+}
+
+// The gate reports itself, including that ours_only is informational — a soak
+// reads JSON, not comments.
+TEST(DashMempoolValidityGate, JsonNamesTheThresholdAndTheInformationalStatus) {
+    MempoolValidityGate g;
+    feed_clean(g, 3);
+    const auto j = g.to_json();
+    EXPECT_EQ(j["gate"], "CLOSED");
+    EXPECT_EQ(j["clean-heights-required"], MempoolValidityGate::kCleanHeightsRequired);
+    EXPECT_EQ(j["consecutive-clean-heights"], 3u);
+    EXPECT_NE(std::string(j["ours-only"]).find("INFORMATIONAL"), std::string::npos);
+}

--- a/test/test_dash_mempool_validity_gate.cpp
+++ b/test/test_dash_mempool_validity_gate.cpp
@@ -62,15 +62,28 @@ bool has_line_with(const std::vector<std::string>& lines, const std::string& nee
     return false;
 }
 
-// A run of `n` clean, evidence-bearing heights.
+// ONE clean, evidence-bearing sample AT a given height.
+void feed_clean_sample_at(MempoolValidityGate& g, uint32_t height)
+{
+    const auto set = std::vector<MempoolProbeTx>{tx("aa")};
+    const auto ans = std::vector<nlohmann::json>{allowed_true("aa")};
+    g.apply(mempool_validity_sample(height, set, ans));
+}
+
+// A run of `n` clean, evidence-bearing heights — one sample each, ADVANCING.
 void feed_clean(MempoolValidityGate& g, uint64_t n, uint32_t from_height = 1000)
 {
-    for (uint64_t i = 0; i < n; ++i) {
-        const auto set = std::vector<MempoolProbeTx>{tx("aa")};
-        const auto ans = std::vector<nlohmann::json>{allowed_true("aa")};
-        g.apply(mempool_validity_sample(
-            static_cast<uint32_t>(from_height + i), set, ans));
-    }
+    for (uint64_t i = 0; i < n; ++i)
+        feed_clean_sample_at(g, static_cast<uint32_t>(from_height + i));
+}
+
+// `n` clean samples that all land on THE SAME height — the shape the probe
+// cadence actually produces (on_serve fires per template re-source: every
+// work-generation bump and every 30 s staleness re-poll, ~5-6 times inside one
+// 157.5 s DASH block).
+void feed_clean_repeats_at(MempoolValidityGate& g, uint64_t n, uint32_t height)
+{
+    for (uint64_t i = 0; i < n; ++i) feed_clean_sample_at(g, height);
 }
 
 } // namespace
@@ -222,7 +235,7 @@ TEST(DashMempoolValidityGate, EmptyHeightsNeitherAdvanceNorResetTheRun) {
     EXPECT_FALSE(g.open());
     EXPECT_EQ(g.consecutive_clean, 0u);
     EXPECT_EQ(g.heights_with_evidence, 0u);
-    EXPECT_EQ(g.heights_without_evidence, g.required + 10);
+    EXPECT_EQ(g.samples_without_evidence, g.required + 10);
 
     // Nor do they RESET a run in progress.
     feed_clean(g, 5, 20000);
@@ -262,6 +275,148 @@ TEST(DashMempoolValidityGate, AlreadyInMempoolAloneIsEnoughEvidenceToAdvance) {
     g.apply(s);
     EXPECT_EQ(g.consecutive_clean, 1u);
     EXPECT_EQ(g.txs_already_in_mempool, 2u);
+}
+
+// ── 5b. THE WINDOW COUNTS DISTINCT HEIGHTS, NOT SAMPLES ─────────────────────
+//
+// apply() is called ONCE PER SAMPLE, and a sample is one probe run — not one
+// block. probe_validity() runs from process(), process() runs from on_serve,
+// and on_serve fires on EVERY template re-source: every work-generation bump
+// plus a 30 s staleness re-poll (work_source.cpp kStaleAfter). DASH targets
+// 157.5 s/block, so ~5-6 samples land on ONE height. If a repeated sample
+// advanced the window, 576 counter ticks would be ~110 real heights (~4.8 h),
+// not the 576 heights (~25.2 h) the threshold is argued from — and the
+// "rule of three" power argument would be counting the same transaction, at
+// the same height, five times over as five independent trials.
+//
+// These KATs feed the input the rest of the suite never presents: REPEATS.
+
+TEST(DashMempoolValidityGate, RepeatedSamplesAtOneHeightAdvanceTheWindowOnce) {
+    MempoolValidityGate g;
+    feed_clean_repeats_at(g, 5, 2518500);
+
+    EXPECT_EQ(g.consecutive_clean, 1u)
+        << "five probes of one height are ONE height of evidence";
+    EXPECT_EQ(g.heights_with_evidence, 1u);
+
+    // The four that advanced nothing are not erased — they are RECORDED as
+    // what they were, so probe cadence can never be read as progress.
+    EXPECT_EQ(g.samples_seen,          5u);
+    EXPECT_EQ(g.samples_repeat_height, 4u);
+    EXPECT_EQ(g.txs_probed,            1u) << "one observation per tx per height";
+    EXPECT_EQ(g.repeat_txs_probed,     4u);
+    EXPECT_EQ(g.last_disposition,
+              MempoolValidityGate::SampleDisposition::RepeatHeight);
+
+    // And the log line SAYS SO rather than leaving it to be inferred.
+    const auto set = std::vector<MempoolProbeTx>{tx("aa")};
+    const auto ans = std::vector<nlohmann::json>{allowed_true("aa")};
+    const auto s   = mempool_validity_sample(2518500, set, ans);
+    const auto lines = mempool_validity_log_lines(s, g);
+    EXPECT_TRUE(has_line_with(lines, "sample=REPEAT-HEIGHT(no-advance)"));
+    EXPECT_TRUE(has_line_with(lines, "heights_with_evidence=1"));
+}
+
+TEST(DashMempoolValidityGate, AWholeWindowOfSamplesAtOneHeightCannotOpenTheGate) {
+    // The failure this whole fix exists to stop: a node parked on ONE height
+    // (frozen tip, stalled bridge) re-probing the same transactions for hours
+    // and calling it a full day of evidence.
+    MempoolValidityGate g;
+    feed_clean_repeats_at(g, g.required + 50, 2518501);
+
+    EXPECT_FALSE(g.open()) << "one height, however often probed, is one height";
+    EXPECT_EQ(g.consecutive_clean, 1u);
+    EXPECT_EQ(g.heights_with_evidence, 1u);
+    EXPECT_EQ(g.samples_seen, g.required + 50);
+    EXPECT_EQ(g.to_json()["gate"], "CLOSED");
+}
+
+TEST(DashMempoolValidityGate, ARepeatedHeightIsNotEvidenceButAnInvalidOnItStillKillsTheRun) {
+    // The ASYMMETRY, stated as a test: a repeat cannot ADVANCE the run (it is
+    // not new evidence) but it CAN kill it (a defect is a defect whenever it is
+    // observed). Trading "over-counts clean" for "under-counts invalid" would
+    // be swapping one blindness for another.
+    MempoolValidityGate g;
+    feed_clean(g, 4, 2518600);                 // heights 2518600..2518603
+    ASSERT_EQ(g.consecutive_clean, 4u);
+
+    // A LATER probe of the height already counted clean — this time dashd
+    // refuses one of the transactions (a conflicting spend arrived).
+    const std::vector<MempoolProbeTx> set{tx("aa"), tx("bad")};
+    const std::vector<nlohmann::json> ans{allowed_true("aa"),
+                                          refused("bad", "bad-txns-inputs-spent")};
+    g.apply(mempool_validity_sample(2518603, set, ans));
+
+    EXPECT_EQ(g.consecutive_clean, 0u) << "a repeat must still be able to RESET";
+    EXPECT_EQ(g.last_invalid_txid, "bad");
+    EXPECT_EQ(g.last_invalid_height, 2518603u);
+    EXPECT_EQ(g.txs_invalid, 1u);
+
+    // The defect was seen on a REPEAT, so the height is not re-banked...
+    EXPECT_EQ(g.heights_with_evidence, 4u);
+    // ...but it IS counted, because a defect counts wherever it is observed.
+    EXPECT_EQ(g.last_disposition,
+              MempoolValidityGate::SampleDisposition::RepeatHeight);
+
+    // And a clean re-probe of that same height does NOT resurrect the run.
+    feed_clean_sample_at(g, 2518603);
+    EXPECT_EQ(g.consecutive_clean, 0u);
+
+    // Only a genuinely NEW height restarts it, from one.
+    feed_clean_sample_at(g, 2518604);
+    EXPECT_EQ(g.consecutive_clean, 1u);
+}
+
+TEST(DashMempoolValidityGate, AHeightThatDoesNotADVANCEContributesNoEvidence) {
+    // Reorg / rollback: the cursor is MONOTONE. A template height at or below
+    // the last counted one carries no evidence the window has not already
+    // banked, and alternating H, H-1, H must not be read as three heights.
+    MempoolValidityGate g;
+    feed_clean_sample_at(g, 2518700);
+    feed_clean_sample_at(g, 2518699);   // rolled back
+    feed_clean_sample_at(g, 2518700);   // and forward again — same height
+    EXPECT_EQ(g.consecutive_clean, 1u);
+    EXPECT_EQ(g.heights_with_evidence, 1u);
+
+    feed_clean_sample_at(g, 2518701);   // a genuinely NEW height does advance
+    EXPECT_EQ(g.consecutive_clean, 2u);
+    EXPECT_EQ(g.heights_with_evidence, 2u);
+}
+
+TEST(DashMempoolValidityGate, AnEmptyProbeAtAHeightDoesNotBurnThatHeight) {
+    // A height whose first probe found nothing has NOT been measured. When a
+    // later probe of the SAME height does find transactions, that is the first
+    // evidence at that height and it must count.
+    MempoolValidityGate g;
+    g.apply(mempool_validity_sample(2518800, {}, {}));
+    EXPECT_EQ(g.consecutive_clean, 0u);
+    feed_clean_sample_at(g, 2518800);
+    EXPECT_EQ(g.consecutive_clean, 1u);
+    EXPECT_EQ(g.heights_with_evidence, 1u);
+}
+
+// ── 5c. THE IN-SET-PARENT EXEMPTION IS PER-TRANSACTION, SO IT MUST BE NARROW ─
+
+TEST(DashMempoolValidityGate, MissingOrSpentIsNeverExemptedEvenWithAnInSetParent) {
+    // `bad-txns-inputs-missingorspent` says in its own NAME that it cannot
+    // tell a missing input from a SPENT one, and testmempoolaccept never names
+    // WHICH outpoint failed. `depends_on_in_set_parent` is a fact about the
+    // TRANSACTION, not about the failing INPUT: a tx spending one in-set parent
+    // output AND one genuinely double-spent output has the flag set and is a
+    // real defect. Excusing it would let exactly the loss this gate exists to
+    // prevent through as UNPROBED.
+    const auto r = classify_mempool_accept(
+        tx("gg", /*depends=*/true),
+        refused("gg", "bad-txns-inputs-missingorspent"));
+    EXPECT_EQ(r.verdict, MempoolAcceptVerdict::Invalid);
+    EXPECT_EQ(r.reason, "bad-txns-inputs-missingorspent");
+
+    // The narrow reason — dashd saying only "I do not know this input" — stays
+    // excused, because that IS what a one-tx probe of a child does to a parent
+    // dashd has not seen.
+    const auto narrow = classify_mempool_accept(
+        tx("gg", /*depends=*/true), refused("gg", "missing-inputs"));
+    EXPECT_EQ(narrow.verdict, MempoolAcceptVerdict::Unprobed);
 }
 
 // ── 6. THE TWO DIRECTIONS THE OLD CONDITION GOT WRONG ───────────────────────


### PR DESCRIPTION
## The defect

The condition blocking `--embedded-serve-mempool-txs` was a **set-membership test**: `ours_only == 0` in the `[SHADOW-TXSET]` comparison against dashd's template. It is wrong in two directions at once.

**1. UNREACHABLE.** `ours_only` counts transactions in *our* selection that are absent from *dashd's template*. Two independently-connected nodes never hold identical mempools — relay is gossip, admission is per-node policy over a per-node UTXO view, and the two templates are snapshots taken at different instants.

Measured on the production hotel, **6056 samples**:

| | |
|---|---|
| `ours_only == 0` | 91.2% |
| `ours_only > 0` | 8.8% |
| mean when non-zero | 65.3 |
| max | 287 |
| zero rate over the **last 200** samples | **37%** |

A gate whose passing condition is a coincidence is not a gate. And the "it's usually zero, so it's nearly satisfied" reading dies on that last row.

**2. BLIND to the case that costs money.** `ours_only == 0` says our set is a *subset* of dashd's. It says nothing about whether the members are **acceptable**. A strict subset can still contain a transaction dashd would refuse — a double-spend of a coin our partial UTXO view still shows unspent, a non-final tx, a policy-rejected script — and mining it costs the whole block. The membership test **passes** and the block is **still rejected**. The "strict subset, therefore safe" shortcut does not even hold empirically on the numbers above.

## The condition implemented

For every transaction we hold **and would serve**, ask dashd's `testmempoolaccept` and apply three-valued logic:

```
allowed == true                                         -> VALID
allowed == false && reason == "txn-already-in-mempool"   -> ALSO VALID
allowed == false && any other reason                     -> INVALID, and a defect
```

"Already in mempool" is dashd telling us it *already holds* this transaction — the strongest possible statement that it is acceptable to it. It is exempted **by exact name**, and nothing else is: no reason-prefix matching, no "looks benign" family. `txn-already-known` is a *different* dashd reason (transaction in a block / recently rejected) and is **INVALID** — a tx we would serve that dashd has already mined is a staleness defect worth stopping on. There is a KAT for that, because widening the exemption set is widening the gate.

## The hard gate, and the window

**ZERO INVALID over 576 consecutive EVIDENCE-BEARING heights.** One INVALID anywhere in the run resets it to zero.

Why 576, stated rather than assumed:

* **Duration.** DASH mainnet targets 2.625 min/block, so 576 **distinct** heights is **at least ~25.2 hours** — one full day plus margin, and longer whenever heights go by without evidence. That is the shortest window containing every *daily* period in mempool composition: the fee/traffic diurnal cycle, at least one full DKG mining window per active LLMQ type, at least one ChainLock-less stretch. A shorter window can be passed by a quiet night. **This bound holds only because the counter advances per distinct height** — see "One height counts once" below.
* **Statistical power, stated at the unit the window actually counts.** Zero INVALID heights in 576 evidence-bearing heights bounds the per-**height** rate at 3/576 (rule of three, 95%) = **5.2e-3**: at most a **≤0.52% chance that any given template we build carries a rejectable transaction — roughly one at-risk block per 192 mined.** That is the **residual**, and it is not zero. It is why the number is 576 and not 100.

  The per-**transaction** form of this claim is deliberately *not* made. The window does accumulate ~1.7e4 probes (~30 selectable tx per evidence-bearing height on the hotel), but those are not 1.7e4 *independent* trials: a transaction that sits in the mempool for several blocks is re-probed at each of them. Only the heights are separated by a fresh tip, a fresh selection and a fresh mempool, so only the height-level bound is claimed.
* **Reachability.** Unlike `ours_only == 0`, a correct node can actually satisfy this: it asks whether *our* transactions are acceptable, not whether two mempools coincide.

The window is stated in **blocks** because the evidence is per template height; hours are the derived reading.

### One height counts once

`apply()` is fed **one sample per probe run, and a probe run is not a block.** `probe_validity()` runs from `process()`, `process()` runs from `on_serve`, and `on_serve` fires on *every template re-source*: every work-generation bump plus a 30 s staleness re-poll (`work_source.cpp` `kStaleAfter`). At 157.5 s/block that is roughly **five to six samples on one height**.

Counting samples would therefore have made 576 counter ticks mean **~110 real heights — about 4.8 hours, not 25.2** — and a node parked on a frozen tip could tick the counter to 576 without ever advancing a block. That is precisely the "a shorter window can be passed by a quiet night" failure the threshold exists to exclude. Measured at its true unit, the sample-counting window bounded the per-template rate at 3/110 = **2.7%, one at-risk block per 37 — 5.2x worse than the number the threshold was argued from.**

So the window counts **distinct heights**, over a **monotone cursor**, and the rule is deliberately **asymmetric**:

* A sample at a height that does not advance the cursor (a repeat of the last counted height, or a rollback below it) contributes **no new evidence**: it cannot advance `consecutive_clean`, cannot raise `heights_with_evidence`, and its transactions are kept out of the independent-trial totals.
* That same sample **can still kill the run**. An INVALID is an *observed defect* whenever it is observed — the mempool at one height is not constant, and a conflicting spend arriving between two probes of the same height is exactly the event that costs a block. Ignoring it because "we already counted this height" would trade over-counting clean evidence for under-counting defects: one blindness for another.

A repeat can therefore only ever **hurt** the run, never help it. Nothing is erased: `samples_seen`, `samples_repeat_height`, `repeat_txs_probed` and a per-line `sample=COUNTED | REPEAT-HEIGHT(no-advance) | NO-EVIDENCE(no-advance)` disposition keep every probe on the record — dropped from the window arithmetic, never dropped from the log.

A height whose *first* probe found nothing is **not** burned: the cursor only moves on evidence, so a later probe of that same height that does find transactions is the first evidence there and counts.

**Evidence-bearing** is load-bearing. A height where the probe set was empty — or where every entry came back with no answer — observed *nothing*. Counting it clean would let 576 empty heights open the gate on zero evidence: the same vacuous pass the old condition had, sign-flipped. Such heights neither advance nor reset the run; they are counted and logged separately.

## ours_only is now INFORMATIONAL

Still measured, still printed on every `[SHADOW-TXSET]` line, as a coverage statistic. It blocks nothing. The line now says so, in place of the old "do NOT enable --embedded-serve-mempool-txs until this is zero".

## Refusals name themselves

Per the #1038/#1039 serve-gate discipline, a decline that does not name its cause and bound is a silent decline:

```
[MEMPOOL-VALIDITY] h=2518789 REFUSED cause=tx-invalid txid=<64 hex>
  reason=<dashd's string, verbatim> threshold=576-consecutive-clean-heights
  clean_run=0/576 — dashd's testmempoolaccept says this transaction is NOT
  acceptable; serving it can cost a whole block. --embedded-serve-mempool-txs
  stays OFF and the clean run RESETS to 0
```

Plus a per-height summary line so a soak can read the series, and a `mempool-validity-gate` object in the shadow-compare stats JSON.

## The flag stays DEFAULT-OFF

This PR changes the **condition** that decides when `--embedded-serve-mempool-txs` may be turned on. It does not turn it on, and nothing in it can change, delay, or re-order a served template. The probe runs on `EmbeddedShadowCompare`'s existing worker thread — off the miner-facing path, exactly like the oracle fetch. With no dashd RPC arm bound the gate is unevaluated and therefore **CLOSED**, which is the correct reading of "we could not ask".

## Mechanics worth reviewing

* **`mempool_validity_gate.hpp`** — pure classify / aggregate / window logic + probe-set assembly + log lines. Header-only so it is KAT-pinnable without a node or a daemon.
* **`NodeRPC::test_mempool_accept`** — **one transaction per call**, because that is the only shape Dash Core's `testmempoolaccept` takes ("Array must contain exactly one raw transaction"). Never throws; a transport error, a down daemon, or a malformed answer all return a **null** answer, which classifies **UNPROBED**. Returning anything readable as `allowed` would turn "we could not ask" into "dashd said yes" — the exact failure this gate exists to remove.
* **What gets probed.** Only the **mempool-sourced** transactions. A served body is `[type-6 quorum commitments][pinned local txs][mempool txs]`; the builder records that last range as a *range* (`m_mempool_tx_first_index` / `_count`) rather than duplicating the block body for a diagnostic. Commitments and pins are refused by relay policy **by design** (a zero-fee pin especially) — probing them would manufacture INVALID verdicts out of correct behaviour.
* **Evaluable while the flag is OFF.** With serving disabled the served set is empty by construction, so the candidate set — what selection *would* have chosen — now carries its wire hex. Still never served: no consensus path reads it, and the coinbase value and merkle are byte-identical to a build with that line deleted.
* **The package artefact, handled honestly — and narrowly.** A child probed alone answers `missing-inputs` when its parent rides the same template but is not yet in dashd's mempool. That is an artefact of the one-tx probe shape — a block carrying parent *and* child is perfectly valid, and selection is topological (mempool.hpp G1) so the parent *is* in the template. Those are classified UNPROBED, but **only** when the builder recorded the dependency from the real vins. The same reason string with no recorded dependency is a genuine missing input and is **INVALID**.

  **`bad-txns-inputs-missingorspent` is not in the exemption.** `depends_on_in_set_parent` is a fact about the *transaction*, not about the *input that failed*, and `testmempoolaccept` never names which outpoint it refused — so a recorded dependency does not imply the failing input was that one. A transaction spending one in-set parent output **and** one genuinely double-spent output carries the flag and is a real defect: the exact loss this gate exists to prevent, classified UNPROBED and waved through.

  A per-**input** fix is not available from the data dashd returns: even with the full per-input in-set map on our side, the answer is a bare reason string with no outpoint, so nothing can attribute the failure to a specific input. The exemption is therefore **narrowed** to the one reason whose meaning is unambiguous — `missing-inputs` = "this input is not known to me". `bad-txns-inputs-missingorspent` conflates unknown with **spent** in its own name and is now **INVALID even with the flag set**. The cost is stated rather than hidden: an in-set-parent child that dashd answers with the conflating reason will reset the clean run. That fails toward a **closed** gate on ambiguous evidence, which is the direction a gate is allowed to be wrong in.

## Testing

`test_dash_embedded_gbt`: **270/270 green**, including

* **24 gate KATs** (`test_dash_mempool_validity_gate.cpp`): the three-valued logic; the exact-name exemption and three near-miss strings that must *not* be exempted; no-answer and short-answer-vector both UNPROBED; the in-set-parent excuse and its negative cases; the refusal line's txid/reason/threshold; the full clean run and the one-short case; one INVALID killing the run with the high-water mark surviving; empty heights neither advancing nor resetting; an all-UNPROBED height not counting as evidence; probe-set assembly from both template shapes and the mis-populated-WorkData case that reports nothing rather than guessing.
* **6 of those 24 are new, and were written to fail first.** The pre-existing suite could not have caught the sample-vs-height defect: its `feed_clean()` helper always advances `from_height + i`, so it never presented the input that breaks the counter. The new KATs feed **repeats**: five probes of one height advancing the window once; a whole window (`required + 50`) of samples at **one** height leaving the gate CLOSED; an INVALID on an already-counted height still killing the run while a clean re-probe does not resurrect it; a rollback/alternation not counting a height twice; an empty first probe not burning its height; and `bad-txns-inputs-missingorspent` staying INVALID with an in-set parent while the narrow `missing-inputs` stays excused.

  **Verified red before the fix, not asserted red.** Built against the unfixed header, 5 of the 6 fail — the headline being `AWholeWindowOfSamplesAtOneHeightCannotOpenTheGate`, where **626 counter ticks at a single height opened the gate**:

  ```
  [ RUN      ] DashMempoolValidityGate.AWholeWindowOfSamplesAtOneHeightCannotOpenTheGate
  Value of: g.open()
    Actual: true
  Expected: false
  one height, however often probed, is one height
  Expected equality of these values:
    g.consecutive_clean
      Which is: 626
    1u
  Expected equality of these values:
    g.heights_with_evidence
      Which is: 626
    1u
  [  FAILED  ] DashMempoolValidityGate.AWholeWindowOfSamplesAtOneHeightCannotOpenTheGate
  ...
   5 FAILED TESTS
  ```

  (The sixth, `AnEmptyProbeAtAHeightDoesNotBurnThatHeight`, passes both before and after: it is a guard against the fix over-correcting, not a defect witness.) With the fix applied the same six are green.
* **Both directions the old condition got wrong, as explicit KATs**: 287 ours-only transactions that dashd accepts is a **clean** height; a strict subset (`ours_only == 0`, old gate passes) containing one refused transaction **closes** the gate.
* **3 new builder KATs** in `test_dash_embedded_gbt.cpp`: candidate wire hex present when suppressed; served range naming the mempool txs without duplicating them; the range skipping a mandatory type-6 commitment prefix.
* The two shadow-compare tests that asserted the old blocking text now assert the informational reframe.

Also built and linked clean: `c2pool-dash`.

## What this does NOT do

It does not arm the flag, and it does not claim the gate is *satisfied*. The gate has not yet run for a single window; it starts CLOSED and stays CLOSED until 576 consecutive evidence-bearing **distinct** heights say otherwise. Arming remains an operator decision on top of that.

