### PR TITLE
docs(funding): FUNDING.yml — PayPal link, plus an inert BTC placeholder

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,10 @@
+# GitHub funding sidebar. Only the keys GitHub itself recognises take effect;
+# anything else must stay commented or the sidebar silently stops rendering.
+custom: https://www.paypal.com/donate/?hosted_button_id=9DF676HUWAHKY
+
+# Bitcoin — PLACEHOLDER, NOT AN ADDRESS. Do not uncomment until a real address
+# is pasted in. FUNDING.yml has no native crypto field, so this line is inert by
+# design: a syntactically valid but WRONG address would silently send donations
+# somewhere nobody controls, and nothing would report it.
+#
+# btc: REPLACE-WITH-REAL-BTC-ADDRESS


### PR DESCRIPTION
Picks up the work stranded on \`frstrtr-patch-1\` (commit 9bb10537, 4 behind master, never had a PR) and adds the Bitcoin line the operator asked for.

**The BTC entry is deliberately commented out and is not an address.**

\`FUNDING.yml\` has no native crypto field, so a Bitcoin address can only ride as a comment or inside \`custom:\`. Leaving a syntactically plausible placeholder live would be worse than useless: donations would go somewhere nobody controls, and **nothing in the system would report it** — no error, no bounce, no log line. An inert comment cannot do that.

Replace \`REPLACE-WITH-REAL-BTC-ADDRESS\` and uncomment once the real address is to hand.

The header comment also records why unknown keys must stay commented: GitHub silently stops rendering the sidebar rather than reporting a bad key.

\`frstrtr-patch-1\` is left untouched.