### PR TITLE
web: source local-hashrate graph series from RateMonitor (fix flat/zero history)

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -7171,13 +7171,28 @@ void MiningInterface::update_stat_log()
         entry.connected_count = static_cast<int>(workers.size());  // raw TCP connections
         std::set<std::string> worker_combos;
         for (const auto& [sid, w] : workers) {
-            double existing = entry.local_hash_rates.value(w.username, 0.0);
-            entry.local_hash_rates[w.username] = existing + w.hashrate;
-            double existing_dead = entry.local_dead_hash_rates.value(w.username, 0.0);
-            entry.local_dead_hash_rates[w.username] = existing_dead + w.dead_hashrate;
             std::string combo = w.username;
             if (!w.worker_name.empty()) combo += "." + w.worker_name;
             worker_combos.insert(combo);
+        }
+        // Hash-rate series: source from the RateMonitor (windowed, p2pool-correct
+        // get_local_rates), NOT the per-session WorkerInfo.hashrate estimate. The
+        // per-session field is updated only on pseudoshare-accept and always
+        // carries dead=0, which rendered the local-hashrate history graph flat/zero
+        // on live prod. Fall back to the per-session sum only if the seam is unset.
+        if (m_local_rates_fn) {
+            auto [rates, dead_rates] = m_local_rates_fn();
+            for (const auto& [user, hr] : rates)
+                entry.local_hash_rates[user] = hr;
+            for (const auto& [user, dhr] : dead_rates)
+                entry.local_dead_hash_rates[user] = dhr;
+        } else {
+            for (const auto& [sid, w] : workers) {
+                double existing = entry.local_hash_rates.value(w.username, 0.0);
+                entry.local_hash_rates[w.username] = existing + w.hashrate;
+                double existing_dead = entry.local_dead_hash_rates.value(w.username, 0.0);
+                entry.local_dead_hash_rates[w.username] = existing_dead + w.dead_hashrate;
+            }
         }
         entry.miner_count = static_cast<int>(entry.local_hash_rates.size());
         entry.worker_count = static_cast<int>(worker_combos.size());
@@ -8714,6 +8729,12 @@ bool WebServer::start_stratum_server()
             mining_interface_->set_stratum_rate_stats_fn([ss]() -> MiningInterface::RateStats {
                 auto s = ss->get_rate_stats();
                 return {s.hashrate, s.effective_dt, s.total_datums, s.dead_datums};
+            });
+            // Feed the stat-log graph series from the RateMonitor per-user rates
+            // (get_local_rates), so the local-hashrate history graph reflects live
+            // windowed hashrate instead of the flat per-session estimate.
+            mining_interface_->set_local_rates_fn([ss]() {
+                return ss->get_local_rates();
             });
         }
         return started;

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -625,6 +625,16 @@ public:
     void set_stratum_rate_stats_fn(std::function<RateStats()> fn) { m_stratum_rate_stats_fn = thread_safe_wrap(std::move(fn)); }
     RateStats get_stratum_rate_stats() const { return m_stratum_rate_stats_fn ? m_stratum_rate_stats_fn() : RateStats{}; }
 
+    // Per-user hashrate + dead-hashrate from the stratum RateMonitor (p2pool
+    // get_local_rates, work.py:1965-1973). The stat-log graph series reads from
+    // THIS, not per-session WorkerInfo.hashrate: the latter is refreshed only on
+    // pseudoshare-accept and always carries dead=0, which flattened the local
+    // hashrate history graph to zero on live prod (founding-bug class).
+    using local_rates_fn_t = std::function<std::pair<
+        std::unordered_map<std::string, double>,
+        std::unordered_map<std::string, double>>()>;
+    void set_local_rates_fn(local_rates_fn_t fn) { m_local_rates_fn = std::move(fn); }
+
     // Per-worker stratum registry provider (display only). On the LTC path the
     // dashboard's OWN core::StratumServer registers workers straight into
     // m_stratum_workers (register_stratum_worker). Coin targets that run their
@@ -1257,6 +1267,7 @@ private:
     std::vector<unsigned char> m_donation_script;   // protocol donation scriptPubKey
     std::function<double()> m_stratum_hashrate_fn;  // callback to get stratum total hashrate
     std::function<RateStats()> m_stratum_rate_stats_fn;  // callback to get rate monitor stats
+    local_rates_fn_t m_local_rates_fn;  // RateMonitor per-user rates for stat-log graph series
 
     // Cached network difficulty (computed from bits in refresh_work)
     std::atomic<double> m_network_difficulty{0.0};


### PR DESCRIPTION
## Defect
The stat-log graph series (`MiningInterface::update_stat_log`) built `local_hash_rates` by summing per-session `WorkerInfo.hashrate`. That field is refreshed only on pseudoshare-accept and is passed `dead=0` unconditionally by the stratum acceptor (`update_stratum_worker` callsite). On live prod master (`d30b6989`: 26 miners, `accepted=16882/1h`) the local-hashrate **history graph rendered flat/zero** — a repeat of the founding 0-stub bug this lane exists to prevent. The live `/local_rate` read is already correct (RateMonitor); only the graph series was on the dead path.

## Fix
Re-source the series from the stratum RateMonitor via a new `local_rates` seam:
- `MiningInterface::set_local_rates_fn` wired in `start_stratum_server` to `StratumServer::get_local_rates()` (p2pool `work.py:1965-1973`), the same windowed per-user source `/local_rate` uses.
- `update_stat_log` populates `local_hash_rates` / `local_dead_hash_rates` from that seam (real dead rates too), keeping `effective_stratum_workers()` for connection/worker/combo counts.
- Falls back to the legacy per-session sum only if the seam is unset (coin targets without the wiring keep prior behaviour).

Web-layer only; no consensus change. Non-consensus → normal merge, but surfacing for operator awareness (web on prod).

## Verification
- Type-exact: `get_local_rates()` returns the `local_rates_fn_t` pair type; structured-binding consumption matches existing patterns.
- Live acceptance path: on a node with mining traffic the graph series should now track the RateMonitor windowed rate (nonzero, with real dead%), matching `/local_rate`, instead of flat/zero.
- No MiningInterface unit fixture exists yet; requesting designated-reviewer confirmation and relying on CI for the build. A follow-up fixture slice can lock this with a KAT (seam-set worker with hashrate=0 but nonzero windowed rate → series nonzero).
