### PR TITLE
ci: lane-keyed zero-test guard + fail-loud honesty demo (UID 5024)

### DIFF
--- a/.github/workflows/test-floor-guard-honesty.yml
+++ b/.github/workflows/test-floor-guard-honesty.yml
@@ -1,0 +1,85 @@
+name: test-floor-guard-honesty
+
+# Fail-loud demo for the zero-test guard (scripts/ci/test_floor_guard.sh).
+# It proves the guard actually catches an empty run: the guard is fed a
+# synthetic ctest --output-junit report with ZERO testcases and MUST reject it.
+# If "Guard must RED on an empty run" ever goes green, the zero-test guard has
+# stopped catching hollow-green lanes -- this workflow is the tripwire.
+
+on:
+  push:
+    branches:
+      - master
+      - v37-dev
+      - 'ci-steward/**'
+  pull_request:
+    branches:
+      - master
+      - v37-dev
+
+jobs:
+  honesty:
+    name: Test-floor guard honesty
+    runs-on: [self-hosted, X64, Linux]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Guard must RED on an empty run
+        shell: bash
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp)"
+          cat > "$tmp" <<'XML'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <testsuite name="ci" tests="0" failures="0" errors="0">
+          </testsuite>
+          XML
+          # Invert the exit: the guard MUST fail on an empty report.
+          if bash scripts/ci/test_floor_guard.sh linux "$tmp"; then
+            echo "::error::HONESTY FAILURE: guard accepted an empty (0-testcase) junit -- it would let a hollow green through." >&2
+            exit 1
+          fi
+          echo "OK: guard correctly REJECTED an empty run"
+
+      - name: Guard must RED on a missing report
+        shell: bash
+        run: |
+          set -euo pipefail
+          if bash scripts/ci/test_floor_guard.sh linux /nonexistent/junit.xml; then
+            echo "::error::HONESTY FAILURE: guard accepted a missing junit -- ctest producing no report at all would pass." >&2
+            exit 1
+          fi
+          echo "OK: guard correctly REJECTED a missing report"
+
+      - name: Guard must PASS a populated run at floor
+        shell: bash
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp)"
+          {
+            echo '<?xml version="1.0" encoding="UTF-8"?>'
+            echo '<testsuite name="ci" tests="5" failures="0">'
+            for i in 1 2 3 4 5; do echo "<testcase name=\"DashBlsVerify.case$i\"/>"; done
+            echo '</testsuite>'
+          } > "$tmp"
+          # linux-dash-bls floor is 5; a populated report at floor MUST pass,
+          # else the guard is a false-red generator on the scoped lanes.
+          bash scripts/ci/test_floor_guard.sh linux-dash-bls "$tmp"
+          echo "OK: guard correctly PASSED a populated run at floor"
+
+      - name: Guard must RED when skips mask an empty run
+        shell: bash
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp)"
+          {
+            echo '<?xml version="1.0" encoding="UTF-8"?>'
+            echo '<testsuite name="ci" tests="5" failures="0">'
+            for i in 1 2 3 4 5; do echo "<testcase name=\"skipped.case$i\" status=\"notrun\"/>"; done
+            echo '</testsuite>'
+          } > "$tmp"
+          if bash scripts/ci/test_floor_guard.sh linux-dash-bls "$tmp"; then
+            echo "::error::HONESTY FAILURE: guard let 5 skipped cases satisfy a floor of 5 -- skips must not count as run." >&2
+            exit 1
+          fi
+          echo "OK: guard correctly REJECTED a floor satisfied only by skips"

--- a/scripts/ci/test_floor_guard.sh
+++ b/scripts/ci/test_floor_guard.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Zero-test guard: fail loud when a ctest lane runs fewer cases than its floor.
+#
+# WHY: a ctest lane reports GREEN over an EMPTY set. That happens when a -R
+# subset stops matching (a case renamed, a gtest_discover_tests race dropping
+# the discovered set, or the cases compiled out of existence inside #ifdef on a
+# stub build). The lane goes green having asserted nothing -- a hollow green.
+#
+# A single FLAT floor would false-red the legitimately-small scoped lanes
+# (^bch_, the 5 DASH-BLS KATs, the lone boost_sentinel), so the floor is
+# LANE-KEYED via test-floors.json. This is a collapse detector, not an exact
+# expectation: it catches a lane falling to (near-)zero, and pairs with
+# `ctest --no-tests=error` on the ctest side as belt-and-suspenders.
+#
+# Usage: test_floor_guard.sh <lane-key> <junit-xml>
+#   <lane-key>   key into test-floors.json (.lanes.<key>)
+#   <junit-xml>  path to a `ctest --output-junit <file>` report
+#
+# Exit: 0 pass; 1 floor breached / no report produced; 2 misconfiguration.
+set -euo pipefail
+
+lane="${1:?lane key required}"
+junit="${2:?junit xml path required}"
+floors="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/test-floors.json"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "::error::test-floor-guard: jq not found on PATH" >&2
+  exit 2
+fi
+if [[ ! -f "$floors" ]]; then
+  echo "::error::test-floor-guard: floors file not found: $floors" >&2
+  exit 2
+fi
+# A missing junit is itself the failure mode we exist to catch: ctest produced
+# no report at all. Treat it as a breach, not a config error.
+if [[ ! -f "$junit" ]]; then
+  echo "::error::test-floor-guard[$lane]: junit not found ($junit) -- ctest wrote no report; the run asserted nothing." >&2
+  exit 1
+fi
+
+floor="$(jq -r --arg k "$lane" '.lanes[$k] // "MISSING"' "$floors")"
+if [[ "$floor" == "MISSING" ]]; then
+  echo "::error::test-floor-guard: no floor defined for lane '$lane' in $floors" >&2
+  exit 2
+fi
+
+# Count actual <testcase> elements rather than trusting the <testsuite tests=>
+# attribute, and subtract cases marked skipped/notrun so a lane cannot satisfy
+# its floor with skips. ctest --output-junit emits one <testcase ...> per line.
+ran="$(grep -c '<testcase ' "$junit" 2>/dev/null || true)"
+skipped="$(grep -Ec '<skipped|status="notrun"|status="disabled"' "$junit" 2>/dev/null || true)"
+ran="${ran:-0}"; skipped="${skipped:-0}"
+effective=$(( ran - skipped ))
+(( effective < 0 )) && effective=0
+
+echo "test-floor-guard[$lane]: floor=$floor ran=$ran skipped=$skipped effective=$effective"
+
+if (( effective < floor )); then
+  echo "::error::test-floor-guard[$lane]: only $effective effective test(s) ran, floor is $floor -- the lane collapsed to a (near-)empty set and would otherwise report a hollow green." >&2
+  exit 1
+fi
+echo "test-floor-guard[$lane]: OK ($effective >= $floor)"

--- a/test-floors.json
+++ b/test-floors.json
@@ -1,0 +1,11 @@
+{
+  "_comment": "Lane-keyed minimum test-case floors for the zero-test guard. A ctest lane whose -R subset stops matching (a renamed case, a gtest_discover_tests race dropping cases, or #ifdef'd-out cases on a stub build) reports GREEN over an empty set. A FLAT floor would false-red the scoped lanes (^bch_, the DASH-BLS 5, boost_sentinel), so the floor is lane-keyed. These are COLLAPSE detectors set safely below each lane's true count, NOT exact expectations; raise a lane's floor only after capturing a green-baseline junit for it. Enforced by scripts/ci/test_floor_guard.sh against `ctest --output-junit`.",
+  "lanes": {
+    "linux": 10,
+    "linux-asan": 10,
+    "coin-bch": 1,
+    "coin-bch-asan": 1,
+    "linux-dash-bls": 5,
+    "boost-sentinel": 1
+  }
+}


### PR DESCRIPTION
Closes the zero-test item integrator signed off (UID 5024): CI is structurally unable to red a ZERO-test run. A ctest lane greens over an empty set when its `-R` subset stops matching (renamed case, gtest_discover_tests race, or #ifdef-d-out cases on a stub build) — a hollow green.

**Design (lane-keyed, not flat).** A flat floor false-reds the legitimately-small scoped lanes (`^bch_`, the 5 DASH-BLS KATs, `boost_sentinel`), so the floor is keyed per lane in `test-floors.json`. Floors are collapse detectors set safely below true counts — raise a lane only after capturing a green-baseline junit.

**Parts**
- `test-floors.json` — per-lane minimum effective-testcase floors.
- `scripts/ci/test_floor_guard.sh` — parses `ctest --output-junit`, counts effective (run − skipped/notrun) cases, fails loud below floor; a missing report is itself a breach. Pairs with `ctest --no-tests=error`.
- `.github/workflows/test-floor-guard-honesty.yml` — **fail-loud demo**: feeds the guard empty / missing / skip-masked reports and asserts each REDs, plus a populated-at-floor report and asserts it GREENs. If the empty case ever goes green, the guard has stopped working — this workflow is the tripwire.

**Verified locally** (workstation, pre-push): all four assertions behave — empty→red, missing→red, skip-masked→red, populated-at-floor→green.

**Follow-up slice (not here):** wire `--output-junit` + `--no-tests=error` + the guard call into each live ctest step (linux, linux-asan, coin-bch, coin-bch-asan, linux-dash-bls). This PR lands the mechanism and its honesty proof.

Held at merge gate — awaiting operator push-approval.