### PR TITLE
feat(dash): #107 phase 2 — accrue pending type-8 asset-lock term into embedded CbTx creditPool (flag default OFF)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -406,6 +406,7 @@ void print_banner(const char* argv0)
         << "           [--embedded-utxo] [--embedded-mainnet] [--embedded-mn-bridge-max N]\n"
         << "           [--embedded-mn-bridge-no-cursor]\n"
         << "           [--embedded-utxo-immature-serve-empty] [--embedded-serve-mempool-txs]\n"
+        << "           [--embedded-accrue-asset-locks]\n"
         << "           [--pin-local-tx-hex FILE]  (zero-fee self-mined tx, e.g. donation consolidation)\n"
         << "           [--pin-splice-xcheck-arm]  (let pins ride an xcheck-SWAPPED dashd template; default OFF)\n"
         << "           [--pin-splice-block-budget] (EXCLUDE a pin that pushes the template past the block size cap; default OFF)\n"
@@ -847,7 +848,17 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              // default on. OFF, the overflow is a WARNING and a recorded flag
              // on the template; ON, the pin is excluded with cause=block-budget
              // (block 2517855 was lost to bad-txns-oversize).
-             bool pin_splice_block_budget = false)
+             bool pin_splice_block_budget = false,
+             // --embedded-accrue-asset-locks (#107 PHASE 2): accrue the pending
+             // type-8 DIP-0027 asset-lock term into the embedded CbTx
+             // creditPoolBalance so it matches dashd's and the
+             // gbt-xcheck-modulo-special-explained swap stops firing on the
+             // type-8-only case. DEFAULT OFF — money/consensus path. A block
+             // committing this accrual is valid ONLY once the same type-8 txs
+             // ride the served body (tx-serving, blocked on #125); with a
+             // coinbase-only body a submitted block is bad-cbtx-assetlocked-
+             // amount. See asset_lock_fold.hpp + set_accrue_pending_asset_locks.
+             bool embedded_accrue_asset_locks = false)
 {
     namespace io = boost::asio;
 
@@ -2097,6 +2108,21 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // never coincide) and blind to a strict SUBSET that contains an invalid
     // transaction, which is exactly the case that costs a whole block.
     node_coin_state.set_serve_mempool_txs(embedded_serve_mempool_txs);
+    // #107 PHASE 2 (--embedded-accrue-asset-locks): DEFAULT OFF. When ON the
+    // embedded CbTx creditPoolBalance accrues the pending type-8 asset-lock term
+    // dashd commits, so the gbt-xcheck-modulo-special-explained swap stops
+    // firing on the type-8-only case (asset_lock_fold.hpp). CONSENSUS: a block
+    // committing this accrual is valid only once the same type-8 txs ride the
+    // served body (blocked on #125); otherwise a submitted coinbase-only block
+    // is bad-cbtx-assetlocked-amount. Hence OFF by default.
+    node_coin_state.set_accrue_pending_asset_locks(embedded_accrue_asset_locks);
+    std::cout << "[run] embedded #107 asset-lock accrual: "
+              << (embedded_accrue_asset_locks
+                      ? "ON (--embedded-accrue-asset-locks: CbTx creditPool "
+                        "accrues pending type-8 locks; VALID block needs those "
+                        "txs in the served body -- #125/tx-serving)"
+                      : "OFF (default: creditPool = seed + platform reward only)")
+              << "\n";
     std::cout << "[run] embedded mempool-tx serving: "
               << (embedded_serve_mempool_txs
                       ? "ON (--embedded-serve-mempool-txs: fee-carrying "
@@ -7344,6 +7370,7 @@ int main(int argc, char** argv)
     // (mempool_validity_gate.hpp) reports zero transactions refused by dashd's
     // testmempoolaccept over its sustained window.
     bool embedded_serve_mempool_txs = false;
+    bool embedded_accrue_asset_locks = false;  // #107 PHASE 2, default OFF
     // --embedded-creditpool-publish-at-serve-tip: publish the derived credit
     // pool AT THE SERVE TIP rather than at the folded body height (PR-5,
     // dashd GetCreditPool(pindexPrev) parity). MONEY PATH -> default OFF: it
@@ -7457,6 +7484,8 @@ int main(int argc, char** argv)
             embedded_utxo_immature_serve_empty = true;
         else if (std::strcmp(argv[i], "--embedded-serve-mempool-txs") == 0)
             embedded_serve_mempool_txs = true;
+        else if (std::strcmp(argv[i], "--embedded-accrue-asset-locks") == 0)
+            embedded_accrue_asset_locks = true;   // #107 PHASE 2
         else if (std::strcmp(argv[i], "--embedded-mempool-ingest") == 0)
             embedded_mempool_ingest = true;
         else if (std::strcmp(argv[i],
@@ -7752,7 +7781,8 @@ int main(int argc, char** argv)
                         serve_staleness_sentinel,
                         embedded_creditpool_publish_at_serve_tip,
                         pin_splice_xcheck_arm,
-                        pin_splice_block_budget);
+                        pin_splice_block_budget,
+                        embedded_accrue_asset_locks);   // #107 PHASE 2
     }
     return run_selftest();
 }

--- a/src/impl/dash/coin/asset_lock_fold.hpp
+++ b/src/impl/dash/coin/asset_lock_fold.hpp
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// #107 PHASE 2 — ACCRUE the pending type-8 (asset-lock) DIP-0027 credit-pool
+/// term into OUR embedded CbTx, so the committed creditPoolBalance matches what
+/// dashd computes and the `gbt-xcheck-modulo-special-explained` swap
+/// (dash/stratum/work_source.cpp) stops firing on the EXPLAINED case.
+///
+/// PHASE 1 (special_tx_pool_delta.hpp) only EXPLAINED a divergence after the
+/// fact, over dashd's OWN already-validated tx list, using
+/// Σ payload.creditOutputs. This header ports the arithmetic dashd actually
+/// COMMITS a block with — which is NOT the same source, even though the two are
+/// numerically equal for a valid tx:
+///
+///   dashd's per-block credit-pool lock term is the value of the FIRST OP_RETURN
+///   output of the lock tx (evo/creditpool.cpp:262-276), NOT the sum of
+///   payload.creditOutputs. They are equal ONLY because CheckAssetLockTx
+///   (evo/assetlocktx.cpp:90-92) enforces
+///       Σ payload.creditOutputs == returnAmount (the OP_RETURN value).
+///   A value that COMMITS to a block must be byte-exact against the source
+///   validation re-derives from, not merely equal-by-invariant to another
+///   field, so this header reads the OP_RETURN output — dashd's source — and
+///   validates the invariant rather than assuming it.
+///
+/// WHERE THE COMMITTED VALUE LANDS AND IS CHECKED (a wrong fold = a rejected
+/// block, not a warning):
+///   - GetTotalLocked() = pool.locked + sessionLocked − sessionUnlocked
+///                        + platformReward           (evo/creditpool.h:98-100)
+///   - written into the CbTx at node/miner.cpp:314
+///   - re-derived from the block's OWN txs and compared by the validator at
+///     evo/specialtxman.cpp:749-755 → mismatch = bad-cbtx-assetlocked-amount
+///     = REJECTED BLOCK.
+///
+/// TYPE-8 SAFETY (no quorum signature needed): CheckAssetLockTx
+/// (evo/assetlocktx.cpp:44-95) is a PURE function of tx bytes — nType==8,
+/// exactly one OP_RETURN output whose value is in MoneyRange, payload parses,
+/// version in [1, CURRENT_VERSION], creditOutputs non-empty and each in
+/// MoneyRange, and Σ creditOutputs == OP_RETURN value. We reproduce it here so
+/// a lock is folded ONLY when it would be a valid block member. Type-9 (unlock)
+/// is DELIBERATELY OUT OF SCOPE: it needs the platform-LLMQ signature-verify +
+/// header index + global dedup CRangesSet + sliding withdrawal limit state
+/// machines that this daemonless build does not carry, so this header never
+/// accrues an unlock term.
+///
+/// Reuses the vendored payload parser (assetlock.hpp::parse_assetlock_payload)
+/// and the SPECIALTX_TYPE constant rather than re-deriving them.
+
+#include <impl/dash/coin/vendor/assetlock.hpp>
+
+#include <core/log.hpp>
+
+#include <cstdint>
+#include <vector>
+
+namespace dash {
+namespace coin {
+
+/// DASH MoneyRange upper bound: MAX_MONEY = 21e6 * COIN (dashcore
+/// consensus/amount.h; dashcore inherits Bitcoin's 21M cap). Same constant the
+/// governance-object and UTXO adapters use.
+inline constexpr int64_t k_dash_max_money = 21'000'000LL * 100'000'000LL;
+
+/// OP_RETURN opcode (0x6a). A type-8 lock encodes the locked amount as the
+/// value of a bare OP_RETURN output; the payload's creditOutputs describe how
+/// that amount is credited on the Platform side.
+inline constexpr unsigned char k_op_return = 0x6a;
+
+inline bool money_in_range(int64_t v) { return v >= 0 && v <= k_dash_max_money; }
+
+/// dashcore evo/creditpool.cpp:262-276 — the credit-pool contribution of a
+/// TRANSACTION_ASSET_LOCK is the value of the FIRST output whose scriptPubKey
+/// is OP_RETURN. Returns that value, or -1 when the tx carries no OP_RETURN
+/// output (which CheckAssetLockTx forbids for a valid lock; the caller must
+/// have validated first).
+template <typename Tx>
+inline int64_t asset_lock_first_op_return_value(const Tx& tx)
+{
+    for (const auto& out : tx.vout) {
+        const auto& script = out.scriptPubKey.m_data;
+        if (script.empty() || script[0] != k_op_return) continue;
+        return out.value;    // FIRST OP_RETURN only — matches dashd's `break`.
+    }
+    return -1;
+}
+
+/// Port of dashcore evo/assetlocktx.cpp:44-95 CheckAssetLockTx as a PURE
+/// function of tx bytes. A type-8 tx that passes this is a valid block member,
+/// so folding its credit term into our CbTx cannot desync our pool from what
+/// validation re-derives from the SAME tx in the block body.
+template <typename Tx>
+inline bool check_asset_lock_tx(const Tx& tx)
+{
+    if (tx.type != vendor::CAssetLockPayload::SPECIALTX_TYPE) return false;
+
+    vendor::CAssetLockPayload pl;
+    if (!vendor::parse_assetlock_payload(tx.extra_payload, pl)) return false;
+    // version in [1, CURRENT_VERSION] (dashd: nVersion == 0 || > CURRENT is bad)
+    if (pl.nVersion == 0 || pl.nVersion > vendor::CAssetLockPayload::CURRENT_VERSION)
+        return false;
+    if (pl.creditOutputs.empty()) return false;
+
+    int64_t credit_sum = 0;
+    for (const auto& o : pl.creditOutputs) {
+        if (!money_in_range(o.value)) return false;
+        credit_sum += o.value;
+        if (!money_in_range(credit_sum)) return false;   // overflow guard
+    }
+
+    // Exactly one OP_RETURN output; its value in MoneyRange.
+    unsigned return_count = 0;
+    int64_t   return_amount = 0;
+    for (const auto& out : tx.vout) {
+        const auto& script = out.scriptPubKey.m_data;
+        if (script.empty() || script[0] != k_op_return) continue;
+        // dashd requires the marker output to be a bare 2-byte OP_RETURN
+        // (OP_RETURN + a single push-count/opcode byte); a longer OP_RETURN
+        // script is rejected (assetlocktx.cpp "assetlocktx-non-empty-return").
+        if (script.size() != 2) return false;
+        if (!money_in_range(out.value)) return false;
+        return_amount += out.value;
+        ++return_count;
+    }
+    if (return_count != 1) return false;
+
+    // The invariant that makes first-OP_RETURN and Σ creditOutputs equal
+    // (assetlocktx.cpp:90-92). We do not assume it — we require it.
+    if (credit_sum != return_amount) return false;
+
+    return true;
+}
+
+/// Result of folding the pending type-8 locks a template would carry.
+struct AssetLockFold {
+    /// Signed pool accrual (always >= 0 here: locks only add; type-9 is out of
+    /// scope). This is Σ first-OP_RETURN value over the VALID locks.
+    int64_t  accrued{0};
+    /// How many type-8 locks were folded.
+    unsigned count{0};
+    /// How many type-8 candidates were REJECTED by check_asset_lock_tx (would
+    /// not be valid block members). A non-zero value means our fold is a strict
+    /// subset of the candidates — the xcheck stays fail-closed on any residual
+    /// pool disagreement, so this is diagnostic, not a correctness lever.
+    unsigned rejected{0};
+};
+
+/// Fold the pending type-8 asset-lock txs into a credit-pool accrual using
+/// dashd's EXACT first-OP_RETURN arithmetic. Non-type-8 txs are ignored; an
+/// invalid type-8 (fails CheckAssetLockTx) is skipped and counted in
+/// `rejected` (dashd's getblocktemplate would not include it either).
+template <typename TxRange>
+inline AssetLockFold pending_asset_lock_fold(const TxRange& txs)
+{
+    AssetLockFold out;
+    for (const auto& tx : txs) {
+        if (tx.type != vendor::CAssetLockPayload::SPECIALTX_TYPE) continue;
+        if (!check_asset_lock_tx(tx)) { ++out.rejected; continue; }
+        out.accrued += asset_lock_first_op_return_value(tx);
+        ++out.count;
+    }
+    return out;
+}
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/embedded_gbt.hpp
+++ b/src/impl/dash/coin/embedded_gbt.hpp
@@ -31,6 +31,7 @@
 #include <impl/dash/coin/mn_state_machine.hpp>
 #include <impl/dash/coin/sml_projection.hpp>    // confirmedHash rollover pass + collateral-spend predicate
 #include <impl/dash/coin/mempool.hpp>
+#include <impl/dash/coin/asset_lock_fold.hpp>   // #107 phase 2: DIP-0027 type-8 credit-pool fold
 #include <impl/dash/coin/subsidy.hpp>
 #include <impl/dash/coin/governance_object.hpp>   // SuperblockPayment (daemonless superblock outputs)
 #include <impl/dash/coin/utxo_adapter.hpp>
@@ -483,7 +484,26 @@ inline DashWorkData build_embedded_workdata(
     // regardless of suppress_mempool_txs — the coinbase-only posture is
     // about MEMPOOL selection; the pin is not a mempool tx.
     // Default nullptr => every existing positional caller byte-unchanged.
-    const std::vector<MutableTransaction>* pinned_local_txs = nullptr)
+    const std::vector<MutableTransaction>* pinned_local_txs = nullptr,
+    // ── #107 PHASE 2 seam: ACCRUE PENDING TYPE-8 ASSET LOCKS ──────────────
+    // --embedded-accrue-asset-locks (default OFF). When true, the CbTx
+    // creditPoolBalance below accrues the DIP-0027 asset-lock (type-8) term
+    // dashd would commit for this block — Σ first-OP_RETURN value over the
+    // pending type-8 locks in the mempool (asset_lock_fold.hpp, dashd
+    // creditpool.cpp:262-276). This makes our committed pool match dashd's so
+    // the gbt-xcheck-modulo-special-explained swap stops firing on the
+    // EXPLAINED (type-8-only) case. DEFAULT false => the accrual is exactly
+    // last_observed + platform_reward, byte-identical to today. Type-9
+    // (unlock) is OUT OF SCOPE and never accrued.
+    //
+    // CONSENSUS NOTE (why default OFF): the value committed here is re-derived
+    // and compared by the validator (specialtxman.cpp:749-755) against the
+    // block's OWN txs. A block that commits this accrual is VALID only if the
+    // SAME type-8 txs are in the served body (which requires tx-serving,
+    // --embedded-serve-mempool-txs, itself blocked on #125). Committing the
+    // accrual with a coinbase-only body would be a bad-cbtx-assetlocked-amount
+    // REJECTED block — see the PR body B1.
+    bool accrue_pending_asset_locks = false)
 {
     DashWorkData w;
     w.m_height          = prev_height + 1;
@@ -892,8 +912,38 @@ inline DashWorkData build_embedded_workdata(
         // exactly the platform reward (66966830 duff) each block — see
         // test_dash_embedded_cbtx_byte_parity.cpp. When platform_reward is 0
         // (pre-MN_RR) the balance carries forward unchanged, also correct.
+        //
+        // #107 PHASE 2: when --embedded-accrue-asset-locks is armed, ADD the
+        // DIP-0027 type-8 (asset-lock) term dashd commits for this block. dashd
+        // builds its template from the pending locks in its mempool and adds,
+        // for each, the value of the lock tx's FIRST OP_RETURN output
+        // (creditpool.cpp:262-276) to GetTotalLocked() (creditpool.h:98-100),
+        // written to the CbTx at miner.cpp:314. We fold the SAME source — the
+        // pending type-8 locks in OUR mempool — with the SAME arithmetic
+        // (asset_lock_fold.hpp), each validated by check_asset_lock_tx
+        // (assetlocktx.cpp:44-95) so only would-be-valid block members count.
+        // Off (default) the term is 0 and the accrual is byte-identical to the
+        // pre-phase-2 template. The emit gate (node_coin_state.hpp
+        // embedded_template_emit_ok) re-derives this SAME term over the SAME
+        // mempool snapshot, so a fresh build cannot trip emit-creditpool-value-
+        // drift (PR body B2).
+        int64_t asset_lock_accrual = 0;
+        if (accrue_pending_asset_locks) {
+            const AssetLockFold f =
+                pending_asset_lock_fold(mempool.pending_asset_lock_txs());
+            asset_lock_accrual = f.accrued;
+            if (f.count > 0 || f.rejected > 0) {
+                LOG_INFO << "[GBT-EMB] #107 asset-lock accrual h="
+                         << (prev_height + 1) << " folded=" << f.count
+                         << " rejected=" << f.rejected
+                         << " accrual=" << asset_lock_accrual
+                         << " duff (committed creditPoolBalance now INCLUDES the"
+                            " pending type-8 locks; block is valid ONLY if those"
+                            " same txs ride the served body -- #125/tx-serving)";
+            }
+        }
         const int64_t accrued_credit_pool =
-            last_observed_credit_pool + platform_reward;
+            last_observed_credit_pool + platform_reward + asset_lock_accrual;
         // confirmedHash rollover (sml_projection.hpp, FINDING-1): the tip SML
         // is the verifier's PREV list, not the list for the block being
         // templated — dashd's rebuild starts with a purely height-driven

--- a/src/impl/dash/coin/mempool.hpp
+++ b/src/impl/dash/coin/mempool.hpp
@@ -551,6 +551,25 @@ public:
         return out;
     }
 
+    /// #107 PHASE 2: the pending type-8 (TRANSACTION_ASSET_LOCK) txs currently
+    /// resident in the pool. The credit-pool fold (asset_lock_fold.hpp) accrues
+    /// these into the embedded CbTx creditPoolBalance so it matches dashd's,
+    /// which builds its template from the SAME pending locks. Returns the raw
+    /// txs (not entries) — the fold reads only tx.vout / tx.extra_payload, and
+    /// validity is re-checked by check_asset_lock_tx, so no fee/UTXO context is
+    /// needed here. Deterministic order (std::map is txid-ascending) so the
+    /// builder and the emit-gate re-derivation over the same snapshot agree.
+    std::vector<MutableTransaction> pending_asset_lock_txs() const
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        std::vector<MutableTransaction> out;
+        for (const auto& [_, e] : m_pool) {
+            if (e.tx.type == 8 /*CAssetLockPayload::SPECIALTX_TYPE*/)
+                out.push_back(e.tx);
+        }
+        return out;
+    }
+
     /// Snapshot of all transactions keyed by txid. Used (eventually)
     /// by BIP 152 compact-block reconstruction + by block-template
     /// builder in Phase C-TEMPLATE.

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -322,6 +322,22 @@ public:
     /// reward-safe dashd fallback. Default OFF preserves prior unit-test posture.
     void set_require_fresh_credit_pool(bool v) { m_require_fresh_credit_pool = v; }
 
+    /// #107 PHASE 2 (--embedded-accrue-asset-locks, default OFF). When ON, the
+    /// embedded CbTx creditPoolBalance accrues the pending type-8 DIP-0027
+    /// asset-lock term (Σ first-OP_RETURN value over the mempool's pending
+    /// locks, asset_lock_fold.hpp / dashd creditpool.cpp:262-276) so it matches
+    /// what dashd commits — the gbt-xcheck-modulo-special-explained swap then
+    /// stops firing on the type-8-only case. The SAME term is added to the
+    /// emit-gate's expected creditPool (embedded_template_emit_ok) so a fresh
+    /// build satisfies the freshness gate instead of tripping
+    /// emit-creditpool-value-drift (PR body B2). Consensus caveat (B1): a block
+    /// committing this accrual is valid ONLY once the same type-8 txs ride the
+    /// served body (tx-serving, blocked on #125); until then the accrual makes
+    /// the classification match but a submitted coinbase-only block would be
+    /// bad-cbtx-assetlocked-amount. Hence default OFF.
+    void set_accrue_pending_asset_locks(bool v) { m_accrue_pending_asset_locks = v; }
+    bool accrue_pending_asset_locks() const { return m_accrue_pending_asset_locks; }
+
     /// Network MN_RR activation height (dashcore Params().GetConsensus()
     /// .MN_RRHeight — per-chainparams). Gates the DIP-0027 platform-share
     /// credit-pool accrual in the template build, the pre-emit value re-check,
@@ -1215,10 +1231,21 @@ public:
         // Uses the SAME accrual build_embedded_workdata does, so it is a pure
         // seed-delta check (the platform reward cancels): built == current seed.
         if (m_require_fresh_credit_pool) {
-            const int64_t expected_credit_pool =
+            int64_t expected_credit_pool =
                 m_credit_pool
                 + compute_dash_platform_reward_post_v20_mn_rr(next_h,
                                                               m_mn_rr_height);
+            // #107 PHASE 2 (B2): when the asset-lock fold is armed the builder
+            // ADDED the pending type-8 term to the committed pool. Re-derive it
+            // here from the SAME source (m_mempool's pending type-8 locks) with
+            // the SAME arithmetic (asset_lock_fold.hpp) so the freshness gate
+            // EXPECTS the accrued value instead of rejecting it. Off (default)
+            // this term is 0 and the check is byte-identical to before.
+            if (m_accrue_pending_asset_locks) {
+                expected_credit_pool +=
+                    pending_asset_lock_fold(m_mempool.pending_asset_lock_txs())
+                        .accrued;
+            }
             if (cb.creditPoolBalance != expected_credit_pool)
                 return reject("emit-creditpool-value-drift",
                               std::to_string(cb.creditPoolBalance),
@@ -1319,6 +1346,8 @@ public:
         // as mnstates/mempool); the builder gates admission per template.
         e.pinned_local_txs     = m_have_pinned_local_tx
                                      ? &m_pinned_local_txs : nullptr;
+        // #107 phase 2: accrue pending type-8 asset locks into the CbTx pool.
+        e.accrue_pending_asset_locks = m_accrue_pending_asset_locks;
         // E-SUPERBLOCK: hand the resolved treasury schedule to the builder.
         // Empty at non-superblock heights and confidently-unfunded superblocks
         // (normal block); the winning trigger's payees at a funded superblock.
@@ -1758,6 +1787,11 @@ private:
     // fee-carrying mempool-tx body path is an explicit operator opt-in (see
     // set_serve_mempool_txs).
     bool m_serve_mempool_txs{false};
+    // #107 PHASE 2 (--embedded-accrue-asset-locks): DEFAULT OFF — accrue the
+    // pending type-8 asset-lock term into the CbTx creditPoolBalance. See
+    // set_accrue_pending_asset_locks. Consumed by make_embedded_work_inputs
+    // (builder) and embedded_template_emit_ok (matching emit-gate re-derivation).
+    bool m_accrue_pending_asset_locks{false};
     // Pinned local tx (set_pinned_local_tx): held by value for the lifetime of
     // this state; the bundle exposes a pointer only when the flag is set.
     // MULTIPLE pins: the donation consolidation had to be SPLIT after

--- a/src/impl/dash/coin/work_source.hpp
+++ b/src/impl/dash/coin/work_source.hpp
@@ -166,6 +166,13 @@ struct EmbeddedWorkInputs {
     // discipline as mnstates/mempool).
     const std::vector<MutableTransaction>* pinned_local_txs{nullptr};
 
+    // #107 PHASE 2 (--embedded-accrue-asset-locks): accrue the pending type-8
+    // DIP-0027 asset-lock term into the CbTx creditPoolBalance so it matches
+    // dashd's and the gbt-xcheck-modulo-special-explained swap stops firing on
+    // the type-8-only case. Default false => byte-unchanged accrual. Set by
+    // NodeCoinState::make_embedded_work_inputs from set_accrue_pending_asset_locks.
+    bool                             accrue_pending_asset_locks{false};
+
     bool viable() const {
         return has_state && mnstates != nullptr && mempool != nullptr;
     }
@@ -296,7 +303,10 @@ inline WorkSelection select_dash_work(
                 emb.suppress_cause,
                 // Pinned local tx (donation consolidation): admission gated
                 // inside the builder per template; null => byte-unchanged.
-                emb.pinned_local_txs);
+                emb.pinned_local_txs,
+                // #107 phase 2: accrue pending type-8 asset-lock term into the
+                // CbTx creditPoolBalance (default false => byte-unchanged).
+                emb.accrue_pending_asset_locks);
         },
         dashd_fallback);
 }

--- a/test/test_dash_work_source.cpp
+++ b/test/test_dash_work_source.cpp
@@ -15,6 +15,8 @@
 
 #include <impl/dash/coin/work_source.hpp>
 #include <impl/dash/coin/special_tx_pool_delta.hpp>
+#include <impl/dash/coin/asset_lock_fold.hpp>      // #107 PHASE 2 fold-under-test
+#include <impl/dash/coin/mempool.hpp>              // #107 PHASE 2 mempool accessor
 #include <impl/dash/coin/rpc_data.hpp>
 #include <impl/dash/coin/utxo_adapter.hpp>
 #include <core/coin/utxo_view_cache.hpp>
@@ -718,4 +720,179 @@ TEST(DashSpecialPoolDelta, UnparsablePayloadExplainsNothing)
     EXPECT_TRUE(sp.unparsable);
     EXPECT_FALSE(sp.explains(0, 0));
     EXPECT_FALSE(sp.explains(0, 1'000));
+}
+
+// ─── #107 PHASE 2: ACCRUE the pending type-8 asset-lock term into OUR CbTx ────
+// These KATs pin asset_lock_fold.hpp — the arithmetic that lets our embedded
+// template COMMIT the same creditPoolBalance dashd does, so the
+// gbt-xcheck-modulo-special-explained swap stops firing on the type-8-only
+// case. Unlike special_tx_pool_delta (phase 1, which EXPLAINS dashd's list
+// after the fact via Σ creditOutputs), the fold reads the value dashd actually
+// commits with: the FIRST OP_RETURN output of the lock tx
+// (dashd creditpool.cpp:262-276), validated by a CheckAssetLockTx port
+// (assetlocktx.cpp:44-95). Shapes are the ones measured live on mainnet the
+// night of 2026-08-06/07 (same night as the phase-1 numbers).
+//
+// NEUTER PROOF (executed, not asserted from a comment): with
+// asset_lock_first_op_return_value() forced to `return 0;` — a fold that
+// accrues nothing — DashAssetLockFold.RealMainnetLockAccruesFirstOpReturn
+// FAILS at `EXPECT_EQ(f.accrued, kLock)` (0 != 2689906) and
+// PoolMatchesDashdAfterFold FAILS at `EXPECT_EQ(ours + f.accrued, dashd)`.
+// With check_asset_lock_tx() forced to `return true;` (skip validation),
+// InvalidLockCreditMismatchIsRejected FAILS at `EXPECT_EQ(f.rejected, 1u)`.
+namespace {
+
+using ::bitcoin_family::coin::TxOut;
+
+// A bare 2-byte OP_RETURN marker output carrying `v` duffs — the shape a real
+// asset-lock uses to encode the locked amount (dashd scans vout for the first
+// OP_RETURN and takes its value).
+TxOut op_return_out(int64_t v) {
+    TxOut o;
+    o.value = v;
+    o.scriptPubKey.m_data = { 0x6a, 0x00 };   // OP_RETURN OP_0 (2 bytes)
+    return o;
+}
+
+// A VALID mainnet-shaped type-8: exactly one 2-byte OP_RETURN output of value
+// `amount`, and payload.creditOutputs summing to the SAME amount (the
+// CheckAssetLockTx invariant, assetlocktx.cpp:90-92). Splits the credit across
+// `n_credit_outputs` outputs to exercise the sum, defaulting to one.
+dash::coin::MutableTransaction make_valid_lock(int64_t amount,
+                                               unsigned n_credit_outputs = 1) {
+    dash::coin::vendor::CAssetLockPayload pl;
+    int64_t remaining = amount;
+    for (unsigned i = 0; i + 1 < n_credit_outputs; ++i) {
+        pl.creditOutputs.push_back(out_of(1));
+        --remaining;
+    }
+    pl.creditOutputs.push_back(out_of(remaining));   // last carries the rest
+
+    dash::coin::MutableTransaction tx;
+    tx.version = 3;
+    tx.type    = dash::coin::vendor::CAssetLockPayload::SPECIALTX_TYPE;  // 8
+    tx.vout.push_back(op_return_out(amount));
+    tx.extra_payload = pack_payload(pl);
+    return tx;
+}
+
+} // namespace
+
+// 1) The h=2517494 lock (0.02689906 DASH): the fold's accrual is the value of
+//    the tx's FIRST OP_RETURN output — dashd's exact source.
+TEST(DashAssetLockFold, RealMainnetLockAccruesFirstOpReturn)
+{
+    const int64_t kLock = 2'689'906;                 // measured on mainnet
+    std::vector<dash::coin::MutableTransaction> txs{ make_valid_lock(kLock) };
+
+    const auto f = dash::coin::pending_asset_lock_fold(txs);
+
+    EXPECT_EQ(f.count, 1u);
+    EXPECT_EQ(f.rejected, 0u);
+    EXPECT_EQ(f.accrued, kLock);
+    // The raw dashd-source reader agrees with the fold.
+    EXPECT_EQ(dash::coin::asset_lock_first_op_return_value(txs[0]), kLock);
+}
+
+// 2) THE GOAL: our seed + fold lands exactly on dashd's committed pool, so the
+//    xcheck swap stops firing. Mirror of the phase-1 explain test, but in the
+//    COMMIT direction — our template now MATCHES instead of being swapped.
+TEST(DashAssetLockFold, PoolMatchesDashdAfterFold)
+{
+    const int64_t kLock = 2'689'906;
+    const int64_t ours  = 3'028'884'293'639;         // our seed+reward pool
+    const int64_t dashd = ours + kLock;              // dashd, with the lock
+
+    const auto f = dash::coin::pending_asset_lock_fold(
+        std::vector<dash::coin::MutableTransaction>{ make_valid_lock(kLock) });
+
+    EXPECT_EQ(ours + f.accrued, dashd);
+}
+
+// 3) Multiple pending locks sum; multi-output credit payloads still balance.
+TEST(DashAssetLockFold, MultipleLocksSumFirstOpReturns)
+{
+    const int64_t a = 35'000'000;
+    const int64_t b =  2'689'906;
+    std::vector<dash::coin::MutableTransaction> txs{
+        make_valid_lock(a, /*n_credit_outputs=*/3),
+        make_plain(),
+        make_valid_lock(b) };
+
+    const auto f = dash::coin::pending_asset_lock_fold(txs);
+
+    EXPECT_EQ(f.count, 2u);
+    EXPECT_EQ(f.rejected, 0u);
+    EXPECT_EQ(f.accrued, a + b);
+}
+
+// 4) VALIDATION, not assumption: a lock whose creditOutputs do NOT equal its
+//    OP_RETURN value is not a valid block member (CheckAssetLockTx fails,
+//    assetlocktx.cpp:90-92). It is REJECTED and contributes nothing — dashd
+//    would not include it, and neither may our accrual.
+TEST(DashAssetLockFold, InvalidLockCreditMismatchIsRejected)
+{
+    auto bad = make_valid_lock(2'689'906);
+    // Break the invariant: OP_RETURN now says one duff more than the credits.
+    bad.vout[0].value += 1;
+
+    const auto f = dash::coin::pending_asset_lock_fold(
+        std::vector<dash::coin::MutableTransaction>{ bad });
+
+    EXPECT_EQ(f.count, 0u);
+    EXPECT_EQ(f.rejected, 1u);
+    EXPECT_EQ(f.accrued, 0);
+    EXPECT_FALSE(dash::coin::check_asset_lock_tx(bad));
+}
+
+// 5) A type-8 with NO OP_RETURN output is invalid (returnCount != 1) and is
+//    rejected; the raw reader reports -1 (no source to commit).
+TEST(DashAssetLockFold, LockWithoutOpReturnIsRejected)
+{
+    // Reuse the phase-1 make_lock(): it sets creditOutputs but NO vout, so it
+    // has no OP_RETURN marker — exactly the missing-source case.
+    auto no_marker = make_lock(1'000);
+
+    EXPECT_FALSE(dash::coin::check_asset_lock_tx(no_marker));
+    EXPECT_EQ(dash::coin::asset_lock_first_op_return_value(no_marker), -1);
+
+    const auto f = dash::coin::pending_asset_lock_fold(
+        std::vector<dash::coin::MutableTransaction>{ no_marker });
+    EXPECT_EQ(f.count, 0u);
+    EXPECT_EQ(f.rejected, 1u);
+    EXPECT_EQ(f.accrued, 0);
+}
+
+// 6) Type-9 (unlock) is OUT OF SCOPE and never folded; type-0 is ignored. Only
+//    valid type-8 locks accrue.
+TEST(DashAssetLockFold, UnlockAndPlainNeverAccrue)
+{
+    std::vector<dash::coin::MutableTransaction> txs{
+        make_unlock(7'200'000'000, 190), make_plain() };
+
+    const auto f = dash::coin::pending_asset_lock_fold(txs);
+
+    EXPECT_EQ(f.count, 0u);
+    EXPECT_EQ(f.rejected, 0u);   // type-9/type-0 are not even candidates
+    EXPECT_EQ(f.accrued, 0);
+}
+
+// 7) THE WIRED PATH: the exact source-accessor the builder and the emit gate
+//    call — Mempool::pending_asset_lock_txs() — returns the resident type-8
+//    locks, and folding them reproduces the accrual. This is the seam that
+//    keeps build_embedded_workdata and embedded_template_emit_ok in agreement.
+TEST(DashAssetLockFold, MempoolAccessorFeedsTheFold)
+{
+    const int64_t kLock = 2'689'906;
+    dash::coin::Mempool pool;
+    pool.add_tx(make_valid_lock(kLock));
+    pool.add_tx(make_plain());                       // type-0, ignored
+    pool.add_tx(make_unlock(1'000, 5));              // type-9, out of scope
+
+    const auto pending = pool.pending_asset_lock_txs();
+    ASSERT_EQ(pending.size(), 1u);                   // only the type-8 lock
+
+    const auto f = dash::coin::pending_asset_lock_fold(pending);
+    EXPECT_EQ(f.count, 1u);
+    EXPECT_EQ(f.accrued, kLock);
 }


### PR DESCRIPTION
## #107 PHASE 2 — accrue the pending type-8 asset-lock term into our embedded CbTx creditPool

**Flag: `--embedded-accrue-asset-locks`, default OFF.** Off ⇒ every template and every gate is byte-identical to today.

### What phase 1 left open
Phase 1 (PR #1169) made a creditPool divergence *EXPLAINED* instead of *ALARMED*: over dashd's own tx list it computed `lock +ΣcreditOutputs / unlock −(fee+Σvout)` and, when `embedded_pool + delta == dashd_pool`, labelled the swap `gbt-xcheck-modulo-special-explained`. But it **still swapped** our proven-correct template for dashd's on every pending lock — the divergence was named, not removed.

### What phase 2 does
Makes our committed `CbTx.creditPoolBalance` **accrue** the DIP-0027 type-8 (asset-lock) term dashd commits, so `embedded_pool == dashd_pool` for the type-8-only case and the swap stops firing on it. Because creditPool is a CbTx field, this is correct to compute even while the tx body is coinbase-only today — see **B1** for the block-validity relationship.

### dashd arithmetic — ported, not approximated
`src/impl/dash/coin/asset_lock_fold.hpp` ports dashd's **exact** source:

- The credit-pool contribution of a lock is the value of its **FIRST `OP_RETURN` output** (`evo/creditpool.cpp:262-276`) — **not** `Σ payload.creditOutputs`. The two are equal *only* because `CheckAssetLockTx` (`evo/assetlocktx.cpp:90-92`) enforces `Σ creditOutputs == returnAmount`. A value that **commits to a block** must be byte-exact against the source validation re-derives from, so the fold reads the `OP_RETURN` output (dashd's source) and *validates* the invariant rather than assuming it.
- Each candidate is run through a `check_asset_lock_tx` port of `CheckAssetLockTx` (`evo/assetlocktx.cpp:44-95`) — a **pure function of tx bytes** (nType==8, exactly one 2-byte `OP_RETURN` in MoneyRange, payload parses, version≤1, non-empty creditOutputs each in range, `Σ creditOutputs == OP_RETURN value`). **No quorum signature is needed**, which is why type-8 is safe to fold and type-9 is not.
- The committed value lands via `GetTotalLocked()` (`evo/creditpool.h:98-100`), is written at `node/miner.cpp:314`, and is re-derived + compared by the validator at `evo/specialtxman.cpp:749-755`.

Reuses the vendored `parse_assetlock_payload` (assetlock.hpp) and the phase-1/`credit_pool.hpp` model rather than re-deriving the payload plumbing.

**Type-9 (unlock) is OUT OF SCOPE** and never accrued — it needs 4 unported state machines (platform-LLMQ scan, header index by quorum hash, global dedup `CRangesSet`, sliding withdrawal limit).

### Wiring (all gated by the flag)
- `build_embedded_workdata` folds `mempool.pending_asset_lock_txs()` into the accrual: `last_observed + platform_reward + Σ first-OP_RETURN(valid locks)`.
- `embedded_template_emit_ok` re-derives the **same** term over the **same** mempool snapshot, so the credit-pool freshness gate **expects** the accrued value instead of rejecting it as `emit-creditpool-value-drift` (this is **B2**).
- `Mempool::pending_asset_lock_txs()` exposes the resident type-8 locks.
- The fail-closed xcheck swap in `dash/stratum/work_source.cpp` is **untouched**: if our pool still disagrees for any reason (type-9, a lock dashd selected but we didn't, a mempool skew between build and emit) the swap still fires to dashd. This PR makes the *explained* case stop needing the swap; it does not disable the swap.

### Consensus consequence of a wrong fold with the flag ON
The committed `creditPoolBalance` is re-derived from the block's **own** txs and compared by `specialtxman.cpp:749-755`. A creditPool that disagrees with what validation computes is **`bad-cbtx-assetlocked-amount` — a REJECTED block.** That is why the flag is default OFF and this PR is "ready", not "fixes production today".

### Tests — KATs on real mainnet type-8 shapes, proven RED
7 KATs in `test_dash_work_source.cpp` (an already-allowlisted target — no green-by-absence NOT_BUILT sentinel), on the shapes measured live on mainnet the night of 2026-08-06/07 (`h=2517494` lock 0.02689906 DASH, etc). **27/27 green** in that target; dependent targets green too (`test_dash_node_coin_state` 103, `test_dash_embedded_gbt` 272, `test_dash_coin_state_maintainer` 52, `test_dash_mempool` 43). `c2pool-dash` binary builds and carries the flag.

**RED proof — executed, not asserted from a comment:**
- Neuter `asset_lock_first_op_return_value` → `return 0;`, rebuild: **5 KATs FAIL** — `RealMainnetLockAccruesFirstOpReturn` at `EXPECT_EQ(f.accrued, kLock)` (`0 != 2689906`), `PoolMatchesDashdAfterFold` at `EXPECT_EQ(ours + f.accrued, dashd)` (`3028884293639 != 3028886983545`), `MultipleLocksSumFirstOpReturns` (`0 != 37689906`), `LockWithoutOpReturnIsRejected` (raw reader `0` not `-1`), `MempoolAccessorFeedsTheFold` (`0 != 2689906`).
- Neuter `check_asset_lock_tx` → `return true;` (skip validation), rebuild: `InvalidLockCreditMismatchIsRejected` and `LockWithoutOpReturnIsRejected` **FAIL** at `EXPECT_EQ(f.rejected, 1u)` (`0 != 1`) — an invalid lock gets folded.

Both neuters were reverted; final tree is green.

---

## NOT COVERED / DEPENDENCIES (stated verbatim)

**B1:** production template is coinbase-only until `--embedded-serve-mempool-txs` is enabled (default OFF), which is itself blocked on task #125 (ingest admits already-confirmed txids). So including a type-8 body changes nothing on production until #125 lands.

**B2:** our own emit gate `set_require_fresh_credit_pool` (`node_coin_state.hpp:1217-1226`) would reject a template whose credit pool differs from tip+1; the fold must satisfy it, not trip it.

### The precise B1 relationship (block validity vs classification)
This PR makes the CbTx creditPool **match dashd's for the xcheck classification**. It does **not** by itself make a *submittable* block. A block that commits this accrual is consensus-valid **only if the same type-8 txs are IN the served body** — validation re-derives the pool from the block's own txs. With a coinbase-only body (the default, and the only posture available until `--embedded-serve-mempool-txs` + #125), a *submitted* block that committed the accrual would be `bad-cbtx-assetlocked-amount`. Therefore the safe enable order is: **land #125 → arm `--embedded-serve-mempool-txs` (type-8 rides the body) → arm `--embedded-accrue-asset-locks`.** Arming this flag alone, ahead of tx-serving, is itself unsafe for block submission (not merely "unsafe if the fold is wrong"), which is exactly why it defaults OFF.

Base: master `8d122b76`.
