### PR TITLE
fix(dash): #125 reject already-confirmed txs at mempool admission

### DIFF
--- a/src/impl/dash/coin/mempool.hpp
+++ b/src/impl/dash/coin/mempool.hpp
@@ -278,6 +278,69 @@ public:
         std::lock_guard<std::mutex> lock(m_mutex);
         if (m_pool.count(txid)) return false;
 
+        // #125 — REJECT ALREADY-CONFIRMED TRANSACTIONS AT ADMISSION.
+        //
+        // A peer can relay a transaction that is ALREADY MINED. The txid-dedup
+        // above only catches a tx already in OUR pool (the benign
+        // txn-already-in-mempool case); it does NOT catch one that is already
+        // in a block but never passed through our pool. Admitting such a tx and
+        // then packing it into a template produces an INVALID BLOCK (a lost
+        // block), so it must be refused here — upstream of the mempool validity
+        // gate, which is correct and untouched.
+        //
+        // Ported EXACTLY from dashd MemPoolAccept::PreChecks
+        // (/tmp/dashsrc/src/validation.cpp:851-857):
+        //     if (!m_view.HaveCoin(txin.prevout)) {
+        //         for (size_t out = 0; out < tx.vout.size(); out++)
+        //             if (coins_cache.HaveCoinInCache(COutPoint(hash, out)))
+        //                 return state.Invalid(TX_CONFLICT, "txn-already-known");
+        //         return state.Invalid(TX_MISSING_INPUTS, ...);
+        //     }
+        // The signal: when an input's coin is MISSING from the view but one of
+        // the tx's OWN outputs is already a coin in the view, that output can
+        // only exist because the identical tx (txid = Hash(tx)) is already in a
+        // block. A genuine unconfirmed tx has its inputs PRESENT and its own
+        // outputs ABSENT, so it never reaches the own-output scan.
+        //
+        // ORDERING IS LOAD-BEARING (dashd's !HaveCoin guard): we consult
+        // own-outputs ONLY when at least one input is missing. We must NEVER
+        // reject a tx whose inputs are all present (a normal unconfirmed tx),
+        // and — unlike dashd's else-branch — we do NOT reject on
+        // input-missing-alone: CPFP chains, coins older than the node's start
+        // height, and orphans are admitted today with fee_known=false and must
+        // stay admitted. The reject fires ONLY on own-output-present.
+        //
+        // FAIL-OPEN (false-negative-safe): the check runs only when a UTXO view
+        // is wired; if the forward-built view cannot tell (no view, or a
+        // confirmed tx whose outputs were since spent / predate our start
+        // height), we ADMIT and let the mempool validity gate / serve path
+        // decide. This is deliberate: a false REJECT of a genuinely-unconfirmed
+        // valid tx would silently DROP its fees once --embedded-serve-mempool-txs
+        // arms. A false positive is impossible here — for an own output
+        // (txid:n) to already be a coin, some tx must have produced the
+        // identical outpoint, and identical outpoint ⇒ identical txid ⇒
+        // identical tx, i.e. the already-confirmed instance, never a distinct
+        // unconfirmed tx.
+        if (utxo != nullptr) {
+            bool any_input_missing = false;
+            for (const auto& vin : tx.vin) {
+                ::core::coin::Outpoint op(vin.prevout.hash, vin.prevout.index);
+                if (!utxo->have_coin(op)) { any_input_missing = true; break; }
+            }
+            if (any_input_missing) {
+                for (size_t out = 0; out < tx.vout.size(); ++out) {
+                    ::core::coin::Outpoint own(txid, static_cast<uint32_t>(out));
+                    if (utxo->have_coin(own)) {
+                        LOG_INFO << "[MEMPOOL] reject txn-already-known txid="
+                                 << txid.GetHex().substr(0, 16)
+                                 << " (own output " << out
+                                 << " already a coin, an input is missing)";
+                        return false;
+                    }
+                }
+            }
+        }
+
         MempoolEntry entry;
         entry.tx         = tx;
         entry.txid       = txid;

--- a/test/test_dash_mempool.cpp
+++ b/test/test_dash_mempool.cpp
@@ -165,6 +165,85 @@ TEST(DashMempool, FeeComputedFromUtxo)
     EXPECT_EQ(mp.total_known_fees(), 10'000u);
 }
 
+// ─── #125 — reject already-confirmed transactions at admission ───────────────
+//
+// Ported from dashd validation.cpp:851-857: when an input's coin is MISSING
+// from the view but one of the tx's OWN outputs is already a coin, the tx is
+// already in a block → reject "txn-already-known". The three cases pin the
+// full behaviour: (a) confirmed tx is REJECTED; (b) a normal unconfirmed tx
+// (inputs present, outputs absent) is still ADMITTED — proves no false
+// positive; (c) an input-missing/output-absent tx (CPFP/old-coin/orphan) is
+// still ADMITTED — proves dashd's else-branch reject was NOT adopted.
+
+TEST(DashMempool, AlreadyConfirmedTxRejected)
+{
+    // Model a confirmed tx: its OWN output is a coin in the view, and its
+    // input is ABSENT (a confirmed tx has had its input spent/removed).
+    uint256 prevA = mint_hash(60);
+    auto tx = make_spend(prevA, 0, 90'000, /*salt=*/1);
+    uint256 txid = dash_txid(tx);
+
+    UTXOViewCache utxo(nullptr);
+    // Own output present as a coin (tx already mined) …
+    utxo.add_coin(Outpoint(txid, 0), Coin(90'000, {}, /*height=*/5, false));
+    // … and DELIBERATELY do NOT add the input prevA — input missing = the
+    // already-confirmed state.
+
+    Mempool mp;
+    mp.set_utxo(&utxo);
+
+    EXPECT_FALSE(mp.add_tx(tx))
+        << "a tx whose own output is already a coin and whose input is "
+           "missing is already confirmed — must be rejected (txn-already-known)";
+    EXPECT_EQ(mp.size(), 0u) << "the already-confirmed tx must not enter the pool";
+}
+
+TEST(DashMempool, NormalUnconfirmedTxStillAdmitted)
+{
+    // Genuine unconfirmed tx: input PRESENT (unspent coin), own output ABSENT.
+    // The input-present guard must stop the own-output scan from ever running,
+    // so this admits exactly as before the #125 check existed.
+    uint256 prevB = mint_hash(61);
+    auto tx = make_spend(prevB, 0, 90'000, /*salt=*/2);
+
+    UTXOViewCache utxo(nullptr);
+    utxo.add_coin(Outpoint(prevB, 0), Coin(100'000, {}, 1, false));  // input present
+    // own output (txid:0) intentionally ABSENT
+
+    Mempool mp;
+    mp.set_utxo(&utxo);
+
+    EXPECT_TRUE(mp.add_tx(tx))
+        << "a normal unconfirmed tx (inputs present) must NEVER be rejected";
+    auto entry = mp.get_entry(dash_txid(tx));
+    ASSERT_TRUE(entry.has_value());
+    EXPECT_TRUE(entry->fee_known);
+    EXPECT_EQ(entry->fee, 10'000u);
+}
+
+TEST(DashMempool, InputMissingOutputAbsentStillAdmitted)
+{
+    // CPFP / coin-older-than-start-height / orphan: input ABSENT and own
+    // output ABSENT. dashd's else-branch would reject this
+    // (bad-txns-inputs-missingorspent); we must NOT adopt that — today's
+    // admission keeps it with fee_known=false.
+    uint256 prevC = mint_hash(62);
+    auto tx = make_spend(prevC, 0, 90'000, /*salt=*/3);
+
+    UTXOViewCache utxo(nullptr);   // empty view: neither input nor own output present
+
+    Mempool mp;
+    mp.set_utxo(&utxo);
+
+    EXPECT_TRUE(mp.add_tx(tx))
+        << "input-missing with own-output-absent must still be admitted "
+           "(the else-branch reject must NOT be adopted)";
+    auto entry = mp.get_entry(dash_txid(tx));
+    ASSERT_TRUE(entry.has_value());
+    EXPECT_FALSE(entry->fee_known)
+        << "unresolvable input → fee unknown, but still admitted";
+}
+
 TEST(DashMempool, RecomputeUnknownFeesAfterUtxoArrives)
 {
     Mempool mp;


### PR DESCRIPTION
## #125 — ingest admits already-confirmed transactions

### Root cause (measured, established)
The mempool validity gate reports `clean_run=0/576` on the hotel — it has
never passed. 83 refusals joined against block-landed times: 95.2% are
steady state (>60 s from any block), not a post-block transient. 97
distinct txids behind them; sampled 12 against the local daemon — all on
chain (confirmations 2–18). Our own eviction works. The defect is
**ingest**, not eviction: a peer relays a transaction that is **already
confirmed**, we admit it, and dashd's `testmempoolaccept` then correctly
answers `txn-already-known`.

The `add_tx` txid-dedup (`mempool.hpp:279`) only catches a tx already in
**our** pool (the benign `txn-already-in-mempool` case). It does not catch
a tx already in a **block** that never passed through our pool.

Why it matters: contained today only because production templates are
coinbase-only. A template carrying an already-mined tx is an **invalid
block** (a lost block), so this is the hard blocker before
`--embedded-serve-mempool-txs` can arm. Zero money risk right now.

### Fix — dashd's check, ported exactly
Ported from dashd `MemPoolAccept::PreChecks`,
`src/validation.cpp:851-857`:

```cpp
if (!m_view.HaveCoin(txin.prevout)) {
    for (size_t out = 0; out < tx.vout.size(); out++)
        if (coins_cache.HaveCoinInCache(COutPoint(hash, out)))
            return state.Invalid(TX_CONFLICT, "txn-already-known");
    return state.Invalid(TX_MISSING_INPUTS, "bad-txns-inputs-missingorspent");
}
```

Added in `add_tx` (`src/impl/dash/coin/mempool.hpp`), immediately after the
txid-dedup and before the entry is built — so it runs on every relayed
admission, and the benign `txn-already-in-mempool` case is already consumed
by the `m_pool.count()` line above it. When an input's coin is **missing**
from our UTXO view **and** one of the tx's **own** outputs is already a
coin in the view, the tx is already confirmed in a block → reject
`txn-already-known` (name matched to dashd so the existing gate and logs
line up). Reuses `utxo->have_coin` on the view we already hold
(`--embedded-utxo`) — no new coins store.

### Ordering preserved (load-bearing)
Own-outputs are consulted **only when an input is missing**, mirroring
dashd's `!HaveCoin` guard. A tx with all inputs present is a normal
unconfirmed tx and is **never** rejected. Critically, unlike dashd's
else-branch (`bad-txns-inputs-missingorspent` on input-missing-alone), we
do **not** adopt that reject: CPFP chains, coins older than the node's
start height, and orphans are admitted today with `fee_known=false` and
stay admitted. The reject fires **only** on own-output-present.

### False-positive consequence and why it cannot occur
The one unacceptable outcome is a **false reject of a genuinely-unconfirmed
valid tx**, which would **silently drop its fees** once
`--embedded-serve-mempool-txs` arms. This is stated in the code and cannot
occur here: for an own output `(txid:n)` to already be a coin, some tx must
have produced the identical outpoint — and since `txid = Hash(tx)`, an
identical outpoint means the identical txid means the identical tx, i.e.
the already-confirmed instance, never a distinct unconfirmed tx. The
input-missing guard precedes the own-output test, so a normal unconfirmed
tx (inputs present) never reaches it.

### Fail-open (false-negative-safe)
The check runs only when a UTXO view is wired. If the forward-built view
cannot tell — no view, a confirmed tx whose outputs were since spent, or a
tx predating the node's start height — we **admit** and let the existing
mempool validity gate / serve path decide. Misses fall through to the gate;
they are never false rejects. The mempool validity gate and its exemption
set are **not touched** — this is strictly upstream of it.

### KATs (`test/test_dash_mempool.cpp`)
- `AlreadyConfirmedTxRejected` — own output a coin, input missing →
  `add_tx` returns false, pool stays empty.
- `NormalUnconfirmedTxStillAdmitted` — input present, own output absent →
  admitted, fee computed (proves no false positive).
- `InputMissingOutputAbsentStillAdmitted` — input absent, own output absent
  (CPFP/old-coin/orphan) → admitted, `fee_known=false` (proves dashd's
  else-branch reject was **not** adopted).

**RED proof:** neutering the reject (commenting the `return false`) and
rebuilding flips `AlreadyConfirmedTxRejected` — `add_tx` returns true
(admitted) and `mp.size()` becomes 1, failing both `EXPECT_FALSE(add_tx)`
and `EXPECT_EQ(mp.size(), 0u)`. Full suite: 46/46 green with the check in.

Unblocks #125 → `--embedded-serve-mempool-txs`.
