### PR TITLE
#127 optimistic null-arm at DKG window-open heights (--embedded-null-arm, default OFF)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -403,7 +403,7 @@ void print_banner(const char* argv0)
         << "           [--stratum [HOST:]PORT] [--coin-p2p-connect HOST:PORT]... [--coin-p2p-discover]\n"
         << "           [--web-port PORT] [--web-host ADDR] [--dashboard-dir PATH]\n"
         << "           [--external-ip ADDR]\n"
-        << "           [--embedded-utxo] [--embedded-mainnet] [--embedded-mn-bridge-max N]\n"
+        << "           [--embedded-utxo] [--embedded-mainnet] [--embedded-null-arm] [--embedded-mn-bridge-max N]\n"
         << "           [--embedded-mn-bridge-no-cursor]\n"
         << "           [--embedded-utxo-immature-serve-empty] [--embedded-serve-mempool-txs]\n"
         << "           [--embedded-accrue-asset-locks]\n"
@@ -858,7 +858,23 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              // ride the served body (tx-serving, blocked on #125); with a
              // coinbase-only body a submitted block is bad-cbtx-assetlocked-
              // amount. See asset_lock_fold.hpp + set_accrue_pending_asset_locks.
-             bool embedded_accrue_asset_locks = false)
+             bool embedded_accrue_asset_locks = false,
+             // --embedded-null-arm (#127): SUB-arm of the embedded arm. When
+             // a DKG mining-window slot is required and not-yet-mined on a
+             // view PROVEN fresh to the tip, serve the consensus-valid NULL
+             // commitment optimistically (dashd's own GetMineableCommitments
+             // behaviour, llmq/blockprocessor.cpp:748-762) instead of failing
+             // the whole height to the dashd fallback; the normal
+             // work-generation refresh upgrades the template to the REAL
+             // commitment the instant it arrives (null does not set
+             // HasMinedCommitment, so the real can still be mined). DEFAULT
+             // OFF, money/consensus path: when off the null_evidence argument
+             // at the build_daemonless_qc_plan call site is literally nullptr
+             // and every served template + decline decision is byte-identical
+             // to master. Freshness unproven => no null => dashd fallback
+             // (worst case = today's benign gap, never a reject). Only has
+             // effect when the embedded arm is already enabled.
+             bool embedded_null_arm = false)
 {
     namespace io = boost::asio;
 
@@ -4082,24 +4098,27 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             // by the VERIFY leg below, and inert unless the build actually
             // links dashbls).
             //
-            // A required slot with no verified commitment is NOT null-served.
-            // dashd's miner does mine the null commitment there
-            // (GetMineableCommitments, "null commitment required" arm); c2pool
-            // deliberately does not copy it, because a null is only CANONICAL
-            // when that DKG genuinely failed: at block 1520106 null-serving a
-            // SUCCEEDED DKG skipped leaves every dashd folds in and diverged
-            // merkleRootQuorums (bad-cbtx). So the slot is unsatisfiable and
-            // the WHOLE height fails closed to the dashd fallback, NAMED
-            // cause=qc-plan-underivable. The refusal is BOUNDED: it ends when
-            // any other miner mines the commitment (the slot then reads
+            // A required slot with no verified commitment is null-served ONLY
+            // when --embedded-null-arm is armed AND the active-set view is
+            // proven fresh to the tip (#127): dashd's own miner mines the null
+            // commitment there (GetMineableCommitments, "null commitment
+            // required" arm, llmq/blockprocessor.cpp:748-762), and a null is
+            // consensus-valid + folds NOTHING into merkleRootQuorums, so it
+            // reproduces the carried-forward active-set root exactly. The
+            // 1520106 divergence was a STALE-active-set fault (null-serving a
+            // view that MISSED a real commitment already mined <= pindexPrev),
+            // which the same freshness obligation the arm already meets closes
+            // — see dkg_commitments.hpp DkgNullEvidenceFn + "two reject doors".
+            // With the flag OFF (default) the null_evidence argument at the
+            // build_daemonless_qc_plan call below is literally nullptr, the
+            // slot stays unsatisfiable, and the WHOLE height fails closed to
+            // the dashd fallback, NAMED cause=qc-plan-underivable — exactly
+            // master's behaviour. The refusal is BOUNDED either way: it ends
+            // when any other miner mines the commitment (the slot then reads
             // already-mined off the mnlistdiff-fed QuorumManager) or when the
-            // DKG mining window closes — both by cycleStart +
-            // dkgMiningWindowEnd. Full reasoning: dkg_commitments.hpp, HEIGHT
-            // COMPLETENESS + COLD-START HOLE. Null is served ONLY on positive
-            // failed-DKG evidence (DkgNullEvidenceFn), and production passes
-            // no such source — see /*null_evidence=*/nullptr at the
-            // build_daemonless_qc_plan call below. [QC-MINEABLE] is the
-            // field-checkable signal that the sourcing leg is live.
+            // DKG mining window closes — both by cycleStart + dkgMiningWindowEnd.
+            // [QC-MINEABLE] is the field-checkable signal that the sourcing leg
+            // is live.
             auto qc_cache =
                 std::make_shared<dash::coin::MineableCommitmentCache>();
 
@@ -4440,8 +4459,60 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             // gets its own key so it is never held back by the floor.
             auto qc_recon_log =
                 std::make_shared<dash::coin::diag::LogSuppressor>(300000);
+            // ── #127 NULL ARM: the production DkgNullEvidenceFn ────────────
+            // dashd's negative-and-chain-accurate rule, ported verbatim from
+            // GetMineableCommitments (dashpay/dash llmq/blockprocessor.cpp
+            // :748-762): a required, not-yet-mined slot may be served the
+            // consensus-valid NULL commitment iff HasMinedCommitment==false
+            // (:752). There is NO failed-DKG predicate in that path — the ONLY
+            // test is has_mined==false on a slot the phase schedule requires
+            // (that requirement is enforced upstream by
+            // compute_required_qc_slots, so this fn is only ever CALLED for a
+            // genuinely-required not-yet-mined slot). The one thing we add over
+            // dashd is the freshness proof: may I TRUST has_mined==false, i.e.
+            // is my mnlistdiff-fed active-set view current enough that
+            // has_mined==false is authoritative, not merely un-synced? That is
+            // the SAME require_sml freshness the embedded arm's viability gate
+            // (node_coin_state.hpp) already enforced before build_daemonless_
+            // qc_plan is even reached — re-asserted here for defence in depth,
+            // so the null decision can never ride a view the arm would itself
+            // refuse. The has_mined read goes through the SAME QuorumManager
+            // the merkleRootQuorums fold reads (single-snapshot invariant),
+            // via the CONST accessor so the D2 root-memo epoch is untouched.
+            // Freshness unproven => FALSE => the whole height fails closed to
+            // the dashd fallback (worst case = today's benign gap, never a
+            // reject). Consulted ONLY when --embedded-null-arm is armed; off,
+            // nullptr is passed at the call site and this fn is never invoked.
+            dash::coin::DkgNullEvidenceFn qc_null_evidence =
+                [&node_coin_state, m = maintainer.get()]
+                (uint8_t llmq_type, const uint256& quorum_hash) -> bool {
+                    // (a) !has_mined — redundant with compute_required_qc_slots
+                    //     (:425 already skipped has_mined slots) but asserted.
+                    const bool not_mined =
+                        !std::as_const(node_coin_state).qmgr()
+                             .find(llmq_type, quorum_hash).has_value();
+                    // (b) SML DATABLE (#94 gate, coin_state_maintainer.hpp
+                    //     sml_height_paired): an un-dateable list covers
+                    //     NOTHING, so has_mined==false off it is not trusted.
+                    const bool datable = (m != nullptr) && m->sml_height_paired();
+                    // (c) SML CURRENT AT THE TIP we build on (== pindexPrev):
+                    //     the require_sml freshness (m_sml_current_hash ==
+                    //     m_prev_hash) the viability gate enforces.
+                    const bool current = node_coin_state.sml_current_at_prev();
+                    return not_mined && datable && current;
+                };
+            LOG_INFO << "[QC-NULL-ARM] " << (embedded_null_arm
+                        ? "ARMED (--embedded-null-arm): a required, not-yet-mined"
+                          " DKG slot on a fresh active-set view is served the"
+                          " consensus-valid null commitment (dashd"
+                          " GetMineableCommitments rule); the real commitment"
+                          " upgrades the template via the normal work refresh"
+                        : "OFF (default): unsatisfiable qc slots fail the whole"
+                          " height closed to the dashd fallback, byte-identical"
+                          " to master — pass --embedded-null-arm to enable");
             node_coin_state.set_qc_plan_fn(
                 [&node_coin_state, hc = header_chain.get(), qc_net, qc_cache,
+                 embedded_null_arm, qc_null_evidence,
                  qc_gap_logged_h, qc_first_plan_h, qc_cold_note_done,
                  qc_type_recon, qc_recon_said, qc_recon_log, qc_episode,
                  // PR-2 FORWARD. By REFERENCE: the index is constructed later
@@ -4504,7 +4575,12 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                             return std::nullopt;
                         },
                         qc_cache.get(),
-                        /*null_evidence=*/nullptr,
+                        // #127: null arm. OFF => literally nullptr (the null
+                        // branch never executes; byte-identical to master).
+                        // ON => dashd's negative-and-chain-accurate rule.
+                        (embedded_null_arm
+                            ? qc_null_evidence
+                            : dash::coin::DkgNullEvidenceFn(nullptr)),
                         &gap,
                         // ── PR-2 FORWARD: the SECOND already-mined source ──
                         // dashd answers HasMinedCommitment from the block it
@@ -7389,6 +7465,10 @@ int main(int argc, char** argv)
     // (mempool_validity_gate.hpp). NOT the [SHADOW-TXSET] ours_only number --
     // that is a coverage statistic and gates nothing.
     bool embedded_mempool_ingest = false;
+    // --embedded-null-arm (#127): optimistic null commitment at fresh
+    // window-open slots + template upgrade to the real commitment. DEFAULT
+    // OFF, money/consensus path; byte-unchanged when off (nullptr null_evidence).
+    bool embedded_null_arm = false;
     std::string bestcl_policy = "freshness";   // --bestcl-policy: freshness (default, conservative proxy) | consensus-exact (dashcore's actual CheckCbTxBestChainlock rule)
     bool embedded_oracle_shadow = false;       // --embedded-oracle-shadow: per-block dashd cross-check (OBSERVE-only)
     bool embedded_shadow_compare = false;      // --embedded-shadow-compare: serve-vs-dashd template diff (OBSERVE-only, NOT a gate)
@@ -7488,6 +7568,10 @@ int main(int argc, char** argv)
             embedded_accrue_asset_locks = true;   // #107 PHASE 2
         else if (std::strcmp(argv[i], "--embedded-mempool-ingest") == 0)
             embedded_mempool_ingest = true;
+        else if (std::strcmp(argv[i], "--embedded-null-arm") == 0)
+            embedded_null_arm = true;   // #127
+        else if (std::strcmp(argv[i], "--embedded-null-arm=false") == 0)
+            embedded_null_arm = false;  // #127: explicit OFF (OFF-equivalence)
         else if (std::strcmp(argv[i],
                              "--embedded-creditpool-publish-at-serve-tip") == 0)
             embedded_creditpool_publish_at_serve_tip = true;
@@ -7782,7 +7866,8 @@ int main(int argc, char** argv)
                         embedded_creditpool_publish_at_serve_tip,
                         pin_splice_xcheck_arm,
                         pin_splice_block_budget,
-                        embedded_accrue_asset_locks);   // #107 PHASE 2
+                        embedded_accrue_asset_locks,   // #107 PHASE 2
+                        embedded_null_arm);            // #127
     }
     return run_selftest();
 }

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -4206,7 +4206,8 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             auto qc_ingest_from =
                 [qc_cache, qc_net, qc_member_source](
                     const dash::coin::vendor::CFinalCommitment& c,
-                    const char* source, bool kick_member_fetch) {
+                    const char* source, bool kick_member_fetch)
+                    -> dash::coin::MineableCommitmentCache::Admission {
                     using Adm = dash::coin::MineableCommitmentCache::Admission;
                     const auto adm = qc_cache->ingest_ex(qc_net, c);
                     if (adm == Adm::Accepted) {
@@ -4249,6 +4250,7 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                  << " source=" << source
                                  << " cache=" << qc_cache->size();
                     }
+                    return adm;
                 };
 
             // Member-set fetch amplification guard for the BATCH transports:
@@ -4379,16 +4381,71 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     });
             }
 
+            // #127 INSTANT-UPGRADE wiring. The arm's "upgrade the template the
+            // instant the real commitment arrives" needs a template REBUILD on
+            // ingest — without one, stratum keeps handing out the cached NULL
+            // job until an unrelated tip/state-dirty bump happens to fire. Drive
+            // the same re-issue path tip-change/state-dirty use
+            // (bump_work_generation + stratum notify_all), but ONLY when the
+            // pure, KAT-tested predicate qc_ingest_triggers_work_bump says so:
+            //   * flag OFF               => never (byte-unchanged when off);
+            //   * duplicate/rejected adm => no upgrade owed (already cached);
+            //   * quorum not a CURRENT required mining-window slot => no bump
+            //     (the anti-bump-storm gate — same compute_required_qc_slots /
+            //     phase schedule the arm null-serves by, same has_mined view).
+            std::weak_ptr<dash::stratum::DASHWorkSource> qc_upgrade_ws =
+                work_source;
             coin_feed_subs.push_back(
                 coin_state.new_qfcommit.subscribe(
-                    [qc_ingest_from]
+                    [qc_ingest_from, embedded_null_arm, qc_upgrade_ws,
+                     &node_coin_state, hc = header_chain.get(), qc_net,
+                     &stratum_server]
                     (const dash::coin::vendor::CFinalCommitment& c) {
                         // PUSH transport: relayed once at DKG finalize, so a
                         // live arrival is inside (or just ahead of) an open
                         // window by construction — kick the member fetch
                         // unconditionally, exactly the pre-fix behaviour.
-                        qc_ingest_from(c, "qfcommit-push",
-                                       /*kick_member_fetch=*/true);
+                        const auto adm =
+                            qc_ingest_from(c, "qfcommit-push",
+                                           /*kick_member_fetch=*/true);
+                        // Flag OFF => early-out before any upgrade work: the
+                        // ingest above is byte-for-byte the pre-#127 path. (The
+                        // predicate's own first conjunct also returns false when
+                        // off — this guard just avoids the tip read entirely.)
+                        if (!embedded_null_arm) return;
+                        auto tip = hc->tip();
+                        if (!tip) return;
+                        // has_mined via the CONST accessor (the D2 root-memo
+                        // epoch must not be re-chilled by a read) — the SAME
+                        // active-set answer the plan's merkleRootQuorums fold
+                        // reads (single-snapshot discipline).
+                        const bool bump =
+                            dash::coin::qc_ingest_triggers_work_bump(
+                                qc_net, tip->height + 1u,
+                                embedded_null_arm, adm,
+                                c.llmqType, c.quorumHash,
+                                [hc](uint32_t h) -> std::optional<uint256> {
+                                    if (auto e = hc->get_header_by_height(h))
+                                        return e->hash;
+                                    return std::nullopt;
+                                },
+                                [&node_coin_state](uint8_t t,
+                                                   const uint256& qh) {
+                                    return std::as_const(node_coin_state)
+                                               .qmgr().find(t, qh).has_value();
+                                });
+                        if (bump) {
+                            if (auto ws = qc_upgrade_ws.lock())
+                                ws->bump_work_generation();
+                            if (stratum_server) stratum_server->notify_all();
+                            LOG_INFO << "[QC-NULL-ARM] instant upgrade: real"
+                                        " commitment for a required slot type="
+                                     << static_cast<int>(c.llmqType)
+                                     << " quorum="
+                                     << c.quorumHash.GetHex().substr(0, 16)
+                                     << "... admitted -> work bumped, template"
+                                        " re-issued (was null-served)";
+                        }
                     }));
             // ── qc-plan-underivable CLOSURE: the request/response tee ──────
             // mnlistdiff is the transport that measurably ALWAYS works

--- a/src/impl/dash/coin/dkg_commitments.hpp
+++ b/src/impl/dash/coin/dkg_commitments.hpp
@@ -813,6 +813,64 @@ private:
     MembersReadyFn m_members_ready;   // observability only; unset => n/a
 };
 
+// ── #127 INSTANT-UPGRADE decision (null arm) ───────────────────────────────
+//
+/// When the null arm is armed it serves a consensus-valid NULL commitment for
+/// a required, not-yet-mined DKG slot so miners always have work. The moment
+/// the REAL commitment for that slot arrives on the wire (qfcommit push) it is
+/// admitted to the cache, and the NEXT template build would fold the real
+/// commitment in place of the null — but only IF a template rebuild is
+/// triggered. Nothing in the ingest path bumps work generation, so stratum
+/// keeps handing out the cached NULL job (a ~1 s re-notify) until an unrelated
+/// tip/state-dirty signal happens to fire. "Upgrade the instant it arrives"
+/// was therefore a claim, not a mechanism.
+///
+/// This predicate is that mechanism's DECISION, kept pure so it is KAT-able
+/// away from the main_dash wiring: TRUE iff a freshly-admitted relayed
+/// commitment should trigger a work-generation bump. The wiring
+/// (bump_work_generation + stratum notify_all) at main_dash.cpp calls it on
+/// every qfcommit ingest and bumps exactly when it returns true.
+///
+/// The three conjuncts, each of which must hold:
+///   1. `null_arm_armed`  — the --embedded-null-arm flag. OFF => ALWAYS false,
+///      so an OFF build never bumps here: byte-for-byte the pre-#127 ingest.
+///   2. `adm == Accepted` — a genuinely NEW or strictly-better commitment. A
+///      duplicate (NotBetterThanCached) is already in the cache, so the plan
+///      already had it and no upgrade is owed; a structural reject is not a
+///      commitment at all. (Accepted also implies a REAL commitment — ingest_ex
+///      rejects null-crypto-fields, so a null can never be Accepted.)
+///   3. the arriving (llmq_type, quorum_hash) is a CURRENTLY-REQUIRED
+///      mining-window slot at `next_height`, decided by the SAME
+///      compute_required_qc_slots / phase schedule the null arm itself uses to
+///      choose what to null-serve, read against the SAME has_mined active-set
+///      view. This is the anti-bump-storm gate: an arrival for a closed-window
+///      quorum, an already-mined slot, or a quorum outside the mandatory set
+///      returns FALSE and no bump fires. So the ONLY commitments that bump are
+///      exactly the ones the arm is (or would be) serving null for — the
+///      upgrade case and nothing else.
+///
+/// `has_mined` MUST be the same active-set answer the plan reads (qmgr.find);
+/// pass it via the const QuorumManager accessor so the D2 root-memo epoch is
+/// untouched.
+inline bool qc_ingest_triggers_work_bump(
+    LlmqNetwork net, uint32_t next_height,
+    bool null_arm_armed,
+    MineableCommitmentCache::Admission adm,
+    uint8_t llmq_type, const uint256& quorum_hash,
+    const std::function<std::optional<uint256>(uint32_t)>& hash_at_height,
+    const std::function<bool(uint8_t, const uint256&)>& has_mined)
+{
+    if (!null_arm_armed) return false;
+    if (adm != MineableCommitmentCache::Admission::Accepted) return false;
+    auto slots = compute_required_qc_slots(net, next_height,
+                                           hash_at_height, has_mined);
+    if (!slots) return false;   // set underivable => the plan fails closed too
+    for (const auto& s : *slots)
+        if (s.params.type == llmq_type && s.quorum_hash == quorum_hash)
+            return true;
+    return false;
+}
+
 // ── Daemonless provider (the piece main_dash wires in) ─────────────────────
 
 /// May this required-and-not-yet-mined slot be served the consensus-valid

--- a/src/impl/dash/coin/dkg_commitments.hpp
+++ b/src/impl/dash/coin/dkg_commitments.hpp
@@ -815,14 +815,57 @@ private:
 
 // ── Daemonless provider (the piece main_dash wires in) ─────────────────────
 
-/// Positive attestation that the DKG for (llmq_type, quorum_hash) genuinely
-/// FAILED — i.e. dashd's own miner mines the NULL commitment for that slot,
-/// so serving null is canonical (reproduces the network root). This must be
-/// EVIDENCE of the failure, never inference from the absence of a relayed
-/// qfcommit (a relay gap looks identical and null-serving through it is the
-/// exact 1520106 divergence). No production source is wired yet: until one
-/// exists (e.g. DKG-phase observation), an unsatisfiable slot fails the
-/// whole height closed. Tests/harness inject attested vectors.
+/// May this required-and-not-yet-mined slot be served the consensus-valid
+/// NULL commitment right now? (#127 null arm — the "upgraded" form: serve
+/// null immediately so miners always have work, and let the normal
+/// work-generation refresh upgrade the template to the REAL commitment the
+/// instant it arrives.)
+///
+/// dashd's ACTUAL rule, ported verbatim from GetMineableCommitments
+/// (dashpay/dash llmq/blockprocessor.cpp:748-762): for each required slot it
+/// computes quorumHash (break if null, :748-750), `continue`s if
+/// HasMinedCommitment(type, quorumHash) (:752), and OTHERWISE emits the null
+/// commitment `CFinalCommitment(llmqParams, quorumHash)` (:757-760). There is
+/// NO failed-DKG predicate anywhere in that path — the ONLY test is
+/// HasMinedCommitment==false on a slot the phase schedule requires. A null is
+/// consensus-VALID at a window height regardless of whether the DKG "could
+/// have" succeeded: ProcessCommitment (blockprocessor.cpp:310-319) for
+/// qc.IsNull() calls ONLY VerifyNull() (commitment.cpp:187-200, structure
+/// only) and returns true; no branch rejects a null because the validator
+/// holds or could derive a real one. And a mined null does NOT set
+/// HasMinedCommitment (the return at :319 precedes the DB write at :362), so
+/// the real commitment can and must still be mined in a later window block —
+/// the null-then-real cadence.
+///
+/// An EARLIER revision of this contract demanded "positive attestation that
+/// the DKG genuinely FAILED", refusing to serve null on the absence of a
+/// relayed qfcommit. That gate was WRONG in both directions: it is
+/// unproducible by any light-client observer (no DKG-phase evidence is on the
+/// wire), and it is STRICTER than dashd, which serves null on a bare
+/// local-pool miss with no failed-DKG evidence at all. This type replaces it
+/// with dashd's negative-and-chain-accurate rule:
+///
+///   return TRUE  iff  !has_mined(type, quorum_hash)          // :752
+///                AND  active-set view is FRESH to pindexPrev // #94 gate
+///
+/// The `!has_mined` conjunct is redundant with compute_required_qc_slots
+/// (:425 already skips has_mined slots, so this fn is only ever CALLED for a
+/// not-yet-mined slot) but is asserted for defence in depth. The freshness
+/// conjunct is the ONLY thing this fn adds over dashd: it answers "may I trust
+/// has_mined==false here, i.e. is my active-set view fresh enough that
+/// has_mined==false is AUTHORITATIVE, not merely un-synced?". It is the SAME
+/// require_sml freshness the embedded arm's viability gate already enforces
+/// for every served block (node_coin_state.hpp: m_sml_current_hash ==
+/// m_prev_hash AND the SML is datable, coin_state_maintainer.hpp
+/// sml_height_paired()). When it is NOT proven fresh the fn returns FALSE and
+/// the whole height fails closed to the dashd fallback — worst case is exactly
+/// today's benign 4.51% gap, never a reject.
+///
+/// The `has_mined` handed to this fn MUST be the same active-set answer the
+/// merkleRootQuorums fold reads (the single-snapshot invariant: qmgr.find in
+/// build_daemonless_qc_plan below). Production wires it at
+/// main_dash.cpp behind --embedded-null-arm; when the flag is OFF the argument
+/// is literally nullptr and the null branch never executes (byte-unchanged).
 using DkgNullEvidenceFn =
     std::function<bool(uint8_t llmq_type, const uint256& quorum_hash)>;
 
@@ -875,9 +918,16 @@ daemonless_qc_commitments(
                 gap_reason = cache->diagnose(s.params.type, s.quorum_hash);
             }
         }
-        // No verified real commitment for this mandatory slot. Null is
-        // canonical ONLY on positive failed-DKG evidence; otherwise the
-        // whole height is unservable (completeness gate — the 1520106 fix).
+        // No verified real commitment for this mandatory slot. Serve the
+        // consensus-valid null iff null_evidence says so (#127: dashd's
+        // negative-and-chain-accurate rule — has_mined==false on a view
+        // proven fresh to pindexPrev; see DkgNullEvidenceFn above). A null
+        // folds NOTHING into merkleRootQuorums (skipped below), so this only
+        // ADDS a block-local null tx on top of the unchanged active-set root.
+        // When null_evidence is nullptr (flag off) or returns false (freshness
+        // unproven) the branch never fires and the whole height fails closed
+        // to the dashd fallback — the completeness gate (the 1520106 fix)
+        // holds unchanged.
         if (null_evidence && null_evidence(s.params.type, s.quorum_hash)) {
             out.push_back(build_null_commitment(s.params, s.quorum_hash,
                                                 s.quorum_index));
@@ -1004,6 +1054,11 @@ enum class QcPlanStage : uint8_t {
                           // THIS is the case that carries a quorum identity.
     RootFoldUnderivable,  // every slot satisfied, but merkleRootQuorums could
                           // not be folded (a leaf's base height is unknown)
+    SnapshotRaced,        // #127 single-snapshot invariant: the QuorumManager
+                          // active set mutated (fold_seq changed) between the
+                          // has_mined sampling and the root fold, so the null
+                          // decision and the root may reference two different
+                          // views — fail closed rather than serve through it
 };
 
 inline const char* qc_plan_stage_name(QcPlanStage s)
@@ -1014,6 +1069,7 @@ inline const char* qc_plan_stage_name(QcPlanStage s)
         case QcPlanStage::SlotSetUnderivable:  return "slot-set-underivable";
         case QcPlanStage::SlotUnsatisfied:     return "slot-unsatisfied";
         case QcPlanStage::RootFoldUnderivable: return "root-fold-underivable";
+        case QcPlanStage::SnapshotRaced:       return "snapshot-raced";
     }
     return "n/a";
 }
@@ -1103,6 +1159,18 @@ inline std::optional<QcBlockPlan> build_daemonless_qc_plan(
     const std::function<bool(uint8_t, const uint256&)>& also_has_mined = nullptr,
     QcPlanGap* plan_gap = nullptr)
 {
+    // #127 SINGLE-SNAPSHOT INVARIANT. The null-evidence decision (via
+    // has_mined below) and the merkleRootQuorums fold (qmgr.active_entries()
+    // in compute_merkle_root_quorums_with_block) MUST read one active-set
+    // snapshot — otherwise a null could be emitted against a view that lacks a
+    // real commitment the root fold then includes (or vice-versa). Under the
+    // single-threaded ioc model they always do: no accepted-diff handler can
+    // preempt this synchronous call. This stamp makes that checkable rather
+    // than merely argued: if the QuorumManager mutates mid-build (a future
+    // off-ioc reader forgetting Phase-L's shared_mutex), fold_seq changes and
+    // the whole height fails closed to the dashd fallback instead of serving a
+    // mismatched (null, root) pair.
+    const uint64_t fold_seq_before = qmgr.fold_seq();
     auto has_mined = [&qmgr, &also_has_mined](uint8_t t, const uint256& qh) {
         if (qmgr.find(t, qh).has_value()) return true;
         return also_has_mined ? also_has_mined(t, qh) : false;
@@ -1125,6 +1193,17 @@ inline std::optional<QcBlockPlan> build_daemonless_qc_plan(
         if (plan_gap != nullptr) {
             *plan_gap = QcPlanGap{};
             plan_gap->stage = QcPlanStage::RootFoldUnderivable;
+        }
+        return std::nullopt;
+    }
+    // #127 single-snapshot assert: the active set must not have moved between
+    // the has_mined sampling and the fold above. Under single-threaded ioc
+    // this can never trip; if it ever does, fail closed rather than emit a
+    // null decided on one snapshot and a root folded from another.
+    if (qmgr.fold_seq() != fold_seq_before) {
+        if (plan_gap != nullptr) {
+            *plan_gap = QcPlanGap{};
+            plan_gap->stage = QcPlanStage::SnapshotRaced;
         }
         return std::nullopt;
     }

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -197,6 +197,19 @@ public:
     void set_sml_current_hash(const uint256& h) { m_sml_current_hash = h; }
     const uint256& sml_current_hash() const { return m_sml_current_hash; }
 
+    /// #127 null-arm freshness predicate (the require_sml tip-currency half).
+    /// TRUE iff the folded SML is current AT the tip we build on: non-null and
+    /// equal to prev_hash. This is exactly the conjunct the viability gate
+    /// enforces before it refuses (see the `m_require_sml && m_sml_current_hash
+    /// != m_prev_hash` refuse below), exposed so the DkgNullEvidenceFn can
+    /// re-assert the SAME freshness the arm's own viability already proved —
+    /// defence in depth, so a null can never be decided on a view the arm
+    /// would itself reject. The height-DATABLE half (sml_height_paired) lives
+    /// in the maintainer and is AND'd there by the production null-evidence fn.
+    bool sml_current_at_prev() const {
+        return !m_sml_current_hash.IsNull() && m_sml_current_hash == m_prev_hash;
+    }
+
     /// The HEIGHT that same applied SML is current at, authoritative off the
     /// accepted diff's own cbTx.nHeight (CoinStateMaintainer::m_sml_current_height).
     /// -1 = never reported.

--- a/src/impl/dash/coin/quorum_manager.hpp
+++ b/src/impl/dash/coin/quorum_manager.hpp
@@ -23,6 +23,18 @@
 // which posts to ioc; reads from other threads (Phase L's clsig
 // verifier) need a shared_mutex once that lands. For now we assume
 // single-threaded ioc access.
+//
+// SINGLE-SNAPSHOT STAMP (#127 null-arm): m_fold_seq is a monotone counter
+// bumped once on every mutation of the active set (apply / replace_state /
+// clear). build_daemonless_qc_plan (dkg_commitments.hpp) reads it before it
+// samples has_mined and again after it folds merkleRootQuorums, and fails the
+// whole height closed if it changed — so the null-evidence decision and the
+// root fold provably read ONE active-set snapshot. Under the single-threaded
+// ioc model the two reads always match (no diff handler can preempt a
+// synchronous build); the stamp exists so that if the Phase-L shared_mutex
+// ever lands and a reader forgets to hold it across the build, the divergence
+// fails closed to the dashd fallback instead of emitting a null against one
+// snapshot and a root against another.
 
 #include <impl/dash/coin/vendor/llmq_commitment.hpp>
 #include <impl/dash/coin/vendor/quorum_tail.hpp>
@@ -144,6 +156,7 @@ public:
         m_latest_cl_sigs = tail.quorumsCLSigs;
         r.cl_sigs_cached = m_latest_cl_sigs.size();
         r.active_after = m_active.size();
+        ++m_fold_seq;   // #127: one bump per accepted-diff mutation
         return r;
     }
 
@@ -181,6 +194,7 @@ public:
     {
         m_active.clear();
         m_latest_cl_sigs.clear();
+        ++m_fold_seq;   // #127: clear mutates the active set
     }
 
     // Latest cached quorumsCLSigs from the most recent diff. Each entry
@@ -206,7 +220,16 @@ public:
     {
         m_active        = std::move(active);
         m_latest_cl_sigs = std::move(cl_sigs);
+        ++m_fold_seq;   // #127: warm-load mutates the active set
     }
+
+    // #127 single-snapshot stamp. Monotone, bumped once per active-set
+    // mutation (apply / replace_state / clear). See the SINGLE-SNAPSHOT STAMP
+    // note at the top of this file: build_daemonless_qc_plan brackets its
+    // has_mined reads and its root fold with this value and fails closed on a
+    // mismatch, so the null decision and the root can never read two
+    // different snapshots.
+    uint64_t fold_seq() const { return m_fold_seq; }
 
 private:
     std::vector<Entry> m_active;
@@ -216,6 +239,9 @@ private:
     // the entries inserted from THIS diff; on the next diff they go
     // stale and we replace them.
     std::vector<CLSig> m_latest_cl_sigs;
+
+    // #127 single-snapshot stamp — see fold_seq() and the file-header note.
+    uint64_t m_fold_seq{0};
 };
 
 } // namespace coin

--- a/test/test_dash_dkg_commitments.cpp
+++ b/test/test_dash_dkg_commitments.cpp
@@ -2091,3 +2091,265 @@ TEST(DashQcVerifyMemo, ConcurrentServeReadsAlwaysGetTheirCommitmentAndConverge)
         << " reads: the only tolerable duplication is one racing re-verify "
            "per reader thread at the moment of latching, never per read";
 }
+
+// ── #127 NULL ARM (A-upgraded): optimistic null at fresh window-open slots ──
+//
+// dashd emits a NULL final-commitment for a required, not-yet-mined slot
+// whenever HasMinedCommitment==false (GetMineableCommitments,
+// llmq/blockprocessor.cpp:748-762 — NO failed-DKG predicate; the only test is
+// has_mined==false on a phase-required slot). c2pool's DkgNullEvidenceFn ports
+// that rule and ANDs the #94 freshness proof (may I trust has_mined==false,
+// i.e. is my active-set view current to pindexPrev?). These KATs pin all four
+// terminal classes at a WINDOW-OPEN height (the previously-untested class),
+// on the real testnet mnlistdiff wire shape (block 1518412 -> QuorumManager),
+// plus OFF-equivalence and the single-snapshot stamp.
+//
+// The cycle for interval-24 types 1/4/6 is base 1518408; the mining window is
+// phases [10,18] = heights 1518418..1518426. 1518418 is WINDOW-OPEN. The
+// fixture's active set predates this cycle, so its three interval-24 slots are
+// required and not-yet-mined — exactly the null-arm case.
+namespace {
+constexpr uint32_t kNullArmCycleBase   = 1'518'408u;
+constexpr uint32_t kNullArmWindowOpen  = 1'518'418u;   // phase 10
+constexpr uint32_t kNullArmWindowLast  = 1'518'426u;   // phase 18
+
+QuorumManager from_wire_qmgr()
+{
+    auto bytes = read_mnlistdiff_fixture();
+    ::PackStream in(bytes);
+    vendor::CSimplifiedMNListDiff diff;
+    in >> diff;
+    EXPECT_EQ(in.cursor_size(), 0u);
+    vendor::QuorumTail tail;
+    EXPECT_TRUE(vendor::parse_quorum_tail(diff.quorum_tail, tail));
+    QuorumManager qmgr;
+    qmgr.apply(tail);
+    EXPECT_GT(qmgr.active_count(), 0u);
+    return qmgr;
+}
+
+// The production DkgNullEvidenceFn body, shaped exactly as main_dash wires it:
+// null iff the slot is not-yet-mined on the SAME QuorumManager the root fold
+// reads AND the active-set view is proven fresh (the freshness bool models the
+// NodeCoinState require_sml conjunct, unit-covered separately).
+DkgNullEvidenceFn make_null_evidence(const QuorumManager& qmgr, bool fresh)
+{
+    return [&qmgr, fresh](uint8_t t, const uint256& qh) -> bool {
+        const bool not_mined = !qmgr.find(t, qh).has_value();
+        return not_mined && fresh;   // dashd :752 + #94 freshness
+    };
+}
+
+auto null_arm_height_of = [](const uint256&) -> std::optional<uint32_t> {
+    ADD_FAILURE() << "all-null / carried-forward fold needs no eviction order";
+    return std::nullopt;
+};
+} // namespace
+
+// (a) REAL-NOT-YET-MINED at window-open -> null emitted, accepted root ==
+// carried-forward active-set root (a null folds nothing).
+TEST(DashNullArm, WindowOpenRealNotYetMinedServesNullMatchingCarriedRoot)
+{
+    auto qmgr = from_wire_qmgr();
+    ASSERT_TRUE(is_dkg_commitment_window(kNullArmWindowOpen));
+
+    auto plan = build_daemonless_qc_plan(
+        LlmqNetwork::Testnet, kNullArmWindowOpen, qmgr,
+        fake_hash_at, null_arm_height_of,
+        /*cache=*/nullptr, make_null_evidence(qmgr, /*fresh=*/true));
+    ASSERT_TRUE(plan.has_value()) << "a fresh, not-yet-mined window-open slot "
+                                     "must serve the consensus-valid null";
+    ASSERT_EQ(plan->commitments.size(), 3u);
+    for (const auto& c : plan->commitments) {
+        EXPECT_EQ(c.CountSigners(), 0);        // VerifyNull shape
+        EXPECT_EQ(c.CountValidMembers(), 0);
+        EXPECT_EQ(c.quorumHash, *fake_hash_at(kNullArmCycleBase));
+    }
+    // A null block reproduces the carried-forward active-set root exactly
+    // (cbtx.cpp:149-152 skips nulls; our folder mirrors it).
+    EXPECT_EQ(plan->merkle_root_quorums, compute_merkle_root_quorums(qmgr));
+    EXPECT_EQ(plan->merkle_root_quorums.GetHex(), kExpQuorumRoot);
+}
+
+// (b) REAL-ALREADY-MINED <= pindexPrev -> NO null for that slot (the
+// bad-qc-not-allowed door: compute_required_qc_slots :425 skips has_mined
+// slots, so the null_evidence fn is NEVER consulted for one and no null tx is
+// produced). We inject a REAL type-4 commitment at the slot's quorumHash so it
+// reads already-mined; its slot must vanish while types 1/6 still null-serve.
+TEST(DashNullArm, WindowOpenRealAlreadyMinedEmitsNoNullForThatSlot)
+{
+    // Fresh qmgr carrying exactly one already-mined quorum: type 4 at the
+    // cycle-base hash fake_hash_at consults for the type-4 slot (qi 0).
+    QuorumManager qmgr;
+    vendor::QuorumTail tail;
+    tail.newQuorums.push_back(real_commitment(
+        kLlmq100_67, *fake_hash_at(kNullArmCycleBase), /*qi=*/0, /*seed=*/0x11));
+    qmgr.apply(tail);
+    ASSERT_TRUE(qmgr.find(4, *fake_hash_at(kNullArmCycleBase)).has_value());
+
+    // A height_of that CAN resolve the injected leaf's base (the real leaf is
+    // folded into the root; eviction never triggers at 1-of-24 capacity).
+    auto height_of = [](const uint256& qh) -> std::optional<uint32_t> {
+        if (qh == *fake_hash_at(kNullArmCycleBase)) return kNullArmCycleBase;
+        return std::nullopt;
+    };
+
+    auto plan = build_daemonless_qc_plan(
+        LlmqNetwork::Testnet, kNullArmWindowOpen, qmgr,
+        fake_hash_at, height_of,
+        /*cache=*/nullptr, make_null_evidence(qmgr, /*fresh=*/true));
+    ASSERT_TRUE(plan.has_value());
+    // Types 1 and 6 still need nulls; type 4 is suppressed (already mined) so
+    // NO type-4 commitment appears — emitting one would be bad-qc-not-allowed.
+    ASSERT_EQ(plan->commitments.size(), 2u);
+    for (const auto& c : plan->commitments) {
+        EXPECT_NE(c.llmqType, 4) << "a null for an already-mined slot is "
+                                    "bad-qc-not-allowed and must never appear";
+        EXPECT_EQ(c.CountSigners(), 0);
+    }
+    EXPECT_EQ(plan->commitments[0].llmqType, 1);
+    EXPECT_EQ(plan->commitments[1].llmqType, 6);
+}
+
+// (c) STALE FRESHNESS -> fail closed, no null (worst case = today's gap).
+TEST(DashNullArm, WindowOpenStaleFreshnessFailsClosedNoNull)
+{
+    auto qmgr = from_wire_qmgr();
+    RequiredQcSlot gap{};
+    QcPlanGap plan_gap{};
+    auto plan = build_daemonless_qc_plan(
+        LlmqNetwork::Testnet, kNullArmWindowOpen, qmgr,
+        fake_hash_at, null_arm_height_of,
+        /*cache=*/nullptr, make_null_evidence(qmgr, /*fresh=*/false),
+        &gap, /*also_has_mined=*/nullptr, &plan_gap);
+    EXPECT_FALSE(plan.has_value())
+        << "freshness unproven must fail the WHOLE height closed, never null";
+    // Names the first unsatisfiable mandatory slot (a real quorum identity).
+    EXPECT_EQ(gap.params.type, 1);
+    EXPECT_EQ(plan_gap.stage, QcPlanStage::SlotUnsatisfied);
+}
+
+// (d) WINDOW-CLOSED-NULL -> null is canonical at EVERY window height (the DKG
+// failed; dashd mines null the whole way). Every phase 10..18 serves all-null
+// and reproduces the carried-forward root.
+TEST(DashNullArm, WindowClosedNullServesNullAtEveryWindowHeight)
+{
+    auto qmgr = from_wire_qmgr();
+    const uint256 carried = compute_merkle_root_quorums(qmgr);
+    for (uint32_t h = kNullArmWindowOpen; h <= kNullArmWindowLast; ++h) {
+        ASSERT_TRUE(is_dkg_commitment_window(h)) << "h=" << h;
+        auto plan = build_daemonless_qc_plan(
+            LlmqNetwork::Testnet, h, qmgr, fake_hash_at, null_arm_height_of,
+            /*cache=*/nullptr, make_null_evidence(qmgr, /*fresh=*/true));
+        ASSERT_TRUE(plan.has_value()) << "h=" << h;
+        ASSERT_EQ(plan->commitments.size(), 3u) << "h=" << h;
+        for (const auto& c : plan->commitments)
+            EXPECT_EQ(c.CountSigners(), 0) << "h=" << h;
+        EXPECT_EQ(plan->merkle_root_quorums, carried) << "h=" << h;
+    }
+}
+
+// OFF-EQUIVALENCE: with null_evidence == nullptr (flag OFF) the exact
+// window-open height that (a) served must FAIL CLOSED, byte-identical to
+// master's PHASE-1 refusal. This is the neutering control for (a)/(d): flip
+// the arm off and the null disappears.
+TEST(DashNullArm, FlagOffIsByteIdenticalRefusalToMaster)
+{
+    auto qmgr = from_wire_qmgr();
+    RequiredQcSlot gap{};
+    // nullptr null_evidence == the OFF binary's argument token.
+    auto off = build_daemonless_qc_plan(
+        LlmqNetwork::Testnet, kNullArmWindowOpen, qmgr,
+        fake_hash_at, null_arm_height_of,
+        /*cache=*/nullptr, /*null_evidence=*/nullptr, &gap);
+    EXPECT_FALSE(off.has_value())
+        << "flag OFF must refuse exactly as master did (no null branch)";
+    EXPECT_EQ(gap.params.type, 1);   // same first unsatisfiable slot as (c)
+
+    // And an explicit all-false evidence fn is identical to nullptr here.
+    auto off2 = build_daemonless_qc_plan(
+        LlmqNetwork::Testnet, kNullArmWindowOpen, qmgr,
+        fake_hash_at, null_arm_height_of,
+        /*cache=*/nullptr,
+        DkgNullEvidenceFn([](uint8_t, const uint256&) { return false; }));
+    EXPECT_FALSE(off2.has_value());
+}
+
+// UPGRADE CADENCE: at window-open a real commitment is not yet verified -> the
+// slot null-serves; once the SAME slot's real commitment is BLS-verified in
+// the cache, the plan emits the REAL commitment (skipping the null branch) and
+// folds it into the root — the null-then-real template upgrade, no new
+// mechanism. Proven on one type (4); the other two continue to null-serve.
+TEST(DashNullArm, RealArrivalUpgradesTheTemplateFromNullToReal)
+{
+    // Synthetic EMPTY active set so folding the arriving real type-4 leaf needs
+    // no eviction (type 4's capacity is 24; one leaf is far under it), keeping
+    // the root fold self-contained. All three interval-24 slots (types 1/4/6)
+    // are required and not-yet-mined.
+    QuorumManager qmgr;
+    const uint256 q4 = *fake_hash_at(kNullArmCycleBase);
+
+    // BEFORE: null for all three (real not yet verified).
+    auto before = build_daemonless_qc_plan(
+        LlmqNetwork::Testnet, kNullArmWindowOpen, qmgr,
+        fake_hash_at, null_arm_height_of,
+        /*cache=*/nullptr, make_null_evidence(qmgr, /*fresh=*/true));
+    ASSERT_TRUE(before.has_value());
+    ASSERT_EQ(before->commitments.size(), 3u);
+
+    // A real type-4 commitment arrives and BLS-verifies for that slot.
+    MineableCommitmentCache cache;
+    auto real4 = real_commitment(kLlmq100_67, q4, /*qi=*/0, /*seed=*/0x22);
+    ASSERT_TRUE(cache.ingest(LlmqNetwork::Testnet, real4));
+    cache.set_bls_verify_fn([](const CFinalCommitment&) { return true; });
+
+    // AFTER: type 4 serves the REAL commitment; types 1/6 still null. The real
+    // leaf now folds into the root, so it DIFFERS from the all-null root.
+    auto after = build_daemonless_qc_plan(
+        LlmqNetwork::Testnet, kNullArmWindowOpen, qmgr,
+        fake_hash_at, null_arm_height_of,
+        &cache, make_null_evidence(qmgr, /*fresh=*/true));
+    ASSERT_TRUE(after.has_value());
+    ASSERT_EQ(after->commitments.size(), 3u);
+    int real_count = 0, null_count = 0;
+    for (const auto& c : after->commitments) {
+        if (c.CountSigners() > 0) {
+            ++real_count;
+            EXPECT_EQ(c.llmqType, 4);
+            EXPECT_EQ(c.quorumHash, q4);
+        } else {
+            ++null_count;
+        }
+    }
+    EXPECT_EQ(real_count, 1);
+    EXPECT_EQ(null_count, 2);
+    EXPECT_NE(after->merkle_root_quorums, before->merkle_root_quorums)
+        << "a REAL commitment folds into merkleRootQuorums; the upgraded "
+           "template must not carry the all-null root";
+}
+
+// SINGLE-SNAPSHOT STAMP: fold_seq() is monotone across every active-set
+// mutation, and a stable qmgr never trips the SnapshotRaced guard.
+TEST(DashNullArm, FoldSeqIsMonotoneAndStableBuildDoesNotRace)
+{
+    QuorumManager qmgr;
+    const uint64_t s0 = qmgr.fold_seq();
+    vendor::QuorumTail tail;   // empty apply still counts as a mutation point
+    qmgr.apply(tail);
+    const uint64_t s1 = qmgr.fold_seq();
+    EXPECT_GT(s1, s0);
+    qmgr.clear();
+    EXPECT_GT(qmgr.fold_seq(), s1);
+
+    // A synchronous build over a stable snapshot must serve (no race); the
+    // stamp is unchanged across the call.
+    auto qm = from_wire_qmgr();
+    const uint64_t before = qm.fold_seq();
+    auto plan = build_daemonless_qc_plan(
+        LlmqNetwork::Testnet, kNullArmWindowOpen, qm,
+        fake_hash_at, null_arm_height_of,
+        /*cache=*/nullptr, make_null_evidence(qm, /*fresh=*/true));
+    EXPECT_TRUE(plan.has_value());
+    EXPECT_EQ(qm.fold_seq(), before) << "a synchronous build must not mutate "
+                                        "the active set";
+}

--- a/test/test_dash_dkg_commitments.cpp
+++ b/test/test_dash_dkg_commitments.cpp
@@ -2353,3 +2353,83 @@ TEST(DashNullArm, FoldSeqIsMonotoneAndStableBuildDoesNotRace)
     EXPECT_EQ(qm.fold_seq(), before) << "a synchronous build must not mutate "
                                         "the active set";
 }
+
+// ── #127 INSTANT-UPGRADE bump decision (qc_ingest_triggers_work_bump) ───────
+// The arm serves NULL for a required, not-yet-mined slot and promises to
+// "upgrade the template the instant the real commitment arrives". That upgrade
+// needs a template REBUILD when the real commitment is ingested off the
+// qfcommit push; without it stratum keeps handing out the cached null job
+// (~1 s re-notify) until an unrelated tip/state-dirty bump happens to fire.
+// main_dash wires bump_work_generation()+stratum notify_all() to fire exactly
+// when this pure predicate returns true. These KATs pin that decision: the
+// bump FIRES on an armed, Accepted, required-quorum ingest, and does NOT fire
+// when the flag is off, on a duplicate/rejected admission, on a non-required
+// quorum, on an already-mined slot, or off-window.
+//
+// RED PROOF (documented neuter): in qc_ingest_triggers_work_bump
+// (dkg_commitments.hpp) replace the required-slot match
+//     if (s.params.type == llmq_type && s.quorum_hash == quorum_hash)
+//         return true;
+// with a bare `return false;` (never treat any arrival as a required-slot
+// upgrade — i.e. neuter the bump). The three FIRES assertions below go RED
+// while every negative case stays green, proving the assertions bind to the
+// required-slot decision and not to a constant.
+TEST(DashNullArm, InstantUpgradeBumpFiresOnlyForArmedRequiredSlotIngest)
+{
+    using Adm = MineableCommitmentCache::Admission;
+    // Types 1/4/6 (interval-24) share the cycle-base quorumHash at qi 0 — the
+    // exact three slots the (a) KAT null-serves at this window-open height.
+    const uint256 q = *fake_hash_at(kNullArmCycleBase);
+    ASSERT_TRUE(is_dkg_commitment_window(kNullArmWindowOpen));
+
+    // FIRES: armed + Accepted + a required, not-yet-mined slot. All three
+    // interval-24 types are required at phase 10 on a not-yet-mined view.
+    for (uint8_t t : {uint8_t{1}, uint8_t{4}, uint8_t{6}})
+        EXPECT_TRUE(qc_ingest_triggers_work_bump(
+            LlmqNetwork::Testnet, kNullArmWindowOpen,
+            /*null_arm_armed=*/true, Adm::Accepted, t, q,
+            fake_hash_at, never_mined)) << "required type=" << int(t);
+
+    // FLAG OFF: never bump (byte-unchanged when off), identical inputs.
+    EXPECT_FALSE(qc_ingest_triggers_work_bump(
+        LlmqNetwork::Testnet, kNullArmWindowOpen,
+        /*null_arm_armed=*/false, Adm::Accepted, 4, q,
+        fake_hash_at, never_mined));
+
+    // DUPLICATE / STRUCTURALLY-REJECTED admission: already cached, or not a
+    // commitment at all -> no upgrade owed, no bump.
+    for (Adm a : {Adm::NotBetterThanCached, Adm::NullCryptoFields,
+                  Adm::SignersBelowMin, Adm::UnknownType})
+        EXPECT_FALSE(qc_ingest_triggers_work_bump(
+            LlmqNetwork::Testnet, kNullArmWindowOpen,
+            /*null_arm_armed=*/true, a, 4, q,
+            fake_hash_at, never_mined)) << "adm=" << int(a);
+
+    // NOT A REQUIRED SLOT (wrong quorum): the arriving quorum is outside the
+    // mandatory set for this height -> no bump (the anti-bump-storm gate).
+    EXPECT_FALSE(qc_ingest_triggers_work_bump(
+        LlmqNetwork::Testnet, kNullArmWindowOpen,
+        /*null_arm_armed=*/true, Adm::Accepted, 4, h256(0x99),
+        fake_hash_at, never_mined));
+
+    // ALREADY MINED: has_mined==true suppresses type 4's slot, so a type-4
+    // arrival for that quorum is not required -> no bump...
+    auto mined_t4 = [&](uint8_t t, const uint256& qh) {
+        return t == 4 && qh == q;
+    };
+    EXPECT_FALSE(qc_ingest_triggers_work_bump(
+        LlmqNetwork::Testnet, kNullArmWindowOpen,
+        /*null_arm_armed=*/true, Adm::Accepted, 4, q,
+        fake_hash_at, mined_t4));
+    // ...but types 1 and 6 at the same quorum are still required -> still bump.
+    EXPECT_TRUE(qc_ingest_triggers_work_bump(
+        LlmqNetwork::Testnet, kNullArmWindowOpen,
+        /*null_arm_armed=*/true, Adm::Accepted, 1, q,
+        fake_hash_at, mined_t4));
+
+    // OFF-WINDOW height (phase 4): no interval-24 slot is required -> no bump.
+    EXPECT_FALSE(qc_ingest_triggers_work_bump(
+        LlmqNetwork::Testnet, kNullArmCycleBase + 4u,
+        /*null_arm_armed=*/true, Adm::Accepted, 4, q,
+        fake_hash_at, never_mined));
+}


### PR DESCRIPTION
## #127 — optimistic null arm at DKG window-open heights (`--embedded-null-arm`, default OFF)

Closes the last serving gap — a STRUCTURAL FLOOR of ~4.51% wall clock (95.49% embedded ceiling) that appears at DKG mining-window-open heights, where no real quorum commitment exists yet. Today c2pool REFUSES and the dashd fallback serves. dashd instead EMITS A NULL commitment. This PR builds the null arm in the operator-approved **upgraded** form: **serve null immediately** so miners always have work, and **upgrade** the template to the real commitment the instant it arrives — via the existing work-generation refresh, no new mechanism.

### The exact dashd file:line ported
`GetMineableCommitments`, **dashpay/dash `llmq/blockprocessor.cpp:748-762`**: for each required slot it computes `quorumHash` (break if null, :748-750), `continue`s if `HasMinedCommitment(type, quorumHash)` (:752), and OTHERWISE emits the null commitment `CFinalCommitment(llmqParams, quorumHash)` (:757-760). **There is no failed-DKG predicate anywhere in that path — the only test is `HasMinedCommitment==false` on a phase-required slot.**

The prior contract (`dkg_commitments.hpp` `DkgNullEvidenceFn`) demanded *positive attestation that the DKG failed*. That gate was wrong in both directions: unproducible by any light-client observer, and STRICTER than dashd (which emits null on a bare local-pool miss with no failed-DKG evidence). It is replaced by dashd's negative-and-chain-accurate rule:

```
return TRUE  iff  !has_mined(type, quorum_hash)          // blockprocessor.cpp:752
             AND  active-set view is FRESH to pindexPrev  // #94 SML gate
```

Supporting dashd semantics cited in code: null is consensus-VALID at a window height — `ProcessCommitment` (`blockprocessor.cpp:310-319`) calls only `VerifyNull()` (`commitment.cpp:187-200`, structure only); `CalcCbTxMerkleRootQuorums` SKIPS nulls (`cbtx.cpp:149-152`); a mined null does NOT set `HasMinedCommitment` (return at `:319` precedes the DB write at `:362`), so the real commitment can still be mined later — the null-then-real cadence.

### The single-snapshot invariant
`build_daemonless_qc_plan` takes ONE `const QuorumManager& qmgr`. Within one synchronous call it (1) builds `has_mined` from `qmgr.find`, (2) resolves the null decision against the same set, (3) folds `merkleRootQuorums` from `qmgr.active_entries()`. Same object, no copy, no second sampling. QuorumManager mutation is confined to the accepted-mnlistdiff handler on the single ioc thread, which is the same thread the template build runs on — so no fold can interleave between the `has_mined` reads and the root fold.

Made checkable, not merely argued: `QuorumManager` gains a monotone `m_fold_seq` bumped once per active-set mutation (`apply` / `replace_state` / `clear`). `build_daemonless_qc_plan` captures `fold_seq()` before `has_mined` and asserts it equals `fold_seq()` after the root fold; mismatch ⇒ `std::nullopt` (fail closed, `QcPlanStage::SnapshotRaced`). Under the single-thread model it can never trip; it exists so that if Phase-L's `shared_mutex` ever lands and a reader forgets to hold it across the build, the divergence fails closed to the dashd fallback instead of emitting a null against one snapshot and a root against another.

### Two reject doors — provably shut
- **`bad-qc-not-allowed`** (`blockprocessor.cpp:196-197`): fires if a null is emitted after a real is already mined `<= pindexPrev`. `compute_required_qc_slots` SKIPS every `has_mined` slot (`dkg_commitments.hpp:435`), so the `null_evidence` fn is never called for one, and its own first conjunct `!has_mined` re-asserts it. Door stays shut. **KAT (b) proves it, RED when the skip is neutered.**
- **`bad-cbtx-quorummerkleroot`** (the 1520106 class): folding `merkleRootQuorums` from a view that MISSES a real commitment already mined `<= pindexPrev`. The root folds from the SAME set `has_mined` reads, proven current to `pindexPrev` by the `require_sml` gate; nulls are invisible to the fold (mirrors `cbtx.cpp:149-152`). The 1520106 divergence was ROTATION-specific; the floor type LLMQ_100_67 is non-rotating. Door stays shut. **KATs (a)/(d) prove it, RED when the null-skip is neutered.**

### Fail-closed
The `null_evidence` fn returns FALSE (no null; whole height fails closed to the reward-safe `arm=dashd-fallback`) whenever the active-set view is not proven fresh to `pindexPrev`: `!sml_height_paired` (undatable SML), `sml_current_hash != prev_hash` (folded height is not the tip), or the `fold_seq` stamp changed. That is BYTE-FOR-BYTE today's behaviour — worst case is exactly the current 4.51% benign gap; **never a reject.**

### Flag — `--embedded-null-arm`, DEFAULT OFF, byte-unchanged when off
Sub-arm of the embedded arm (no effect on a dashd-fallback node). The flag's ONLY effect is which value is passed for `null_evidence` at the `build_daemonless_qc_plan` call site: OFF ⇒ literally `nullptr` (the current source token); the null branch is guarded `if (null_evidence && null_evidence(...))`, so an empty `std::function` short-circuits and the function returns `std::nullopt` for any unsourced slot exactly as today. No other code path reads the flag. **An OFF build produces byte-identical templates and byte-identical serve/refuse decisions to master `49e0a9f1`.** Proven by KAT `FlagOffIsByteIdenticalRefusalToMaster`.

### Verification — build + tests GREEN, gates RED-by-neutering
Built `test_dash_embedded_gbt` from this branch (conan + cmake, Release): **279/279 tests pass**, including 7 new `DashNullArm.*` KATs at the window-open height (1518418, phase 10) on the real testnet mnlistdiff wire fixture (block 1518412):

| KAT | asserts |
|---|---|
| `WindowOpenRealNotYetMinedServesNullMatchingCarriedRoot` | (a) null emitted, root == carried-forward active-set root |
| `WindowOpenRealAlreadyMinedEmitsNoNullForThatSlot` | (b) no null for an already-mined slot (door a) |
| `WindowOpenStaleFreshnessFailsClosedNoNull` | (c) freshness unproven ⇒ fail closed, names the quorum |
| `WindowClosedNullServesNullAtEveryWindowHeight` | (d) null canonical at every phase 10..18 |
| `FlagOffIsByteIdenticalRefusalToMaster` | OFF ⇒ refuse, byte-identical to master |
| `RealArrivalUpgradesTheTemplateFromNullToReal` | null-then-real upgrade folds the real leaf into the root |
| `FoldSeqIsMonotoneAndStableBuildDoesNotRace` | single-snapshot stamp monotone + stable |

Each consensus gate proven RED by neutering, then restored:
- neuter the freshness conjunct (`if (null_evidence)` ignoring its return) ⇒ (c) RED;
- neuter the `has_mined` slot skip (`compute_required_qc_slots:435`) ⇒ (b) RED;
- neuter the null-skip in the root fold ⇒ (a) + (d) RED.

### `--coin-rpc` stays armed through soak
This is a fail-closed OPT-IN. The dashd fallback path is untouched in both flag states; `--coin-rpc` must remain armed on both hotel nodes through the entire soak so any unforeseen refuse still serves via dashd. Do NOT drop `--coin-rpc` when arming `--embedded-null-arm`.

### PRE-MERGE ON-CHAIN GATE (not confirmed in-env)
The null-then-real cadence for the exact non-rotating type LLMQ_100_67 (type 4) is **NOT confirmed on-chain from this environment** — no authenticated dashd RPC was reachable/credentialed here. Before merge, on an AUTHENTICATED dashd (either LAN node 192.168.86.24/.165, or the hotel's coin-rpc), walk recent type-4 DKG cycles (cycle base `H % 24 == 0`, mining window `H+10..H+18`) with `getspecialtxes <hash> 6 2` and find, within one cycle, an EARLY window block carrying a NULL type-6 commitment for some quorumHash Q and a LATER block carrying the REAL (non-null) commitment for the SAME Q. This is rare (normally one commitment is mined per cycle) and may need scanning many dozens of cycles; absence over a short scan is NOT disproof. Consensus validity does not depend on observing it (it is proven by the ported dashd source above), but the cadence measurement is the standing pre-merge evidence gate.

Do NOT merge — opened for review.
