### PR TITLE
chore(funding): add BTC donation address

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,10 +1,9 @@
 # GitHub funding sidebar. Only the keys GitHub itself recognises take effect;
 # anything else must stay commented or the sidebar silently stops rendering.
-custom: https://www.paypal.com/donate/?hosted_button_id=9DF676HUWAHKY
-
-# Bitcoin — PLACEHOLDER, NOT AN ADDRESS. Do not uncomment until a real address
-# is pasted in. FUNDING.yml has no native crypto field, so this line is inert by
-# design: a syntactically valid but WRONG address would silently send donations
-# somewhere nobody controls, and nothing would report it.
-#
-# btc: REPLACE-WITH-REAL-BTC-ADDRESS
+# FUNDING.yml has no native bitcoin key, so the BTC address is offered through
+# the `custom` list as a bitcoin: URI (opens a wallet with the address filled in).
+# A bare `btc:` key would silently break the whole sidebar and take the PayPal
+# link down with it, which is why it must never be uncommented.
+custom:
+  - https://www.paypal.com/donate/?hosted_button_id=9DF676HUWAHKY
+  - bitcoin:1Gd1bjFqCCrx9AkiHUcBuuEYUuVuvncBTc


### PR DESCRIPTION
Adds the operator's BTC donation address to the GitHub funding sidebar.

FUNDING.yml has no native `btc:` key — GitHub only recognises a fixed set of keys, and an
unrecognised one silently stops the whole sidebar from rendering (taking the live PayPal link
down with it). So the address is offered through the `custom` list as a `bitcoin:` URI, which
opens a wallet with the address filled in, alongside the existing PayPal link.

Address checksum validated (Base58Check, version byte 0 = P2PKH mainnet, 34 chars).

Caveat: if GitHub does not render the `bitcoin:` URI as a clickable sidebar entry, the
one-line fallback is a blockchain-explorer https URL for the same address — the PayPal link is
unaffected either way.