### PR TITLE
funding: link BTC via DONATE.md (stop the crypto-clipper warning badge on the sponsor button)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,9 +1,11 @@
 # GitHub funding sidebar. Only the keys GitHub itself recognises take effect;
 # anything else must stay commented or the sidebar silently stops rendering.
-# FUNDING.yml has no native bitcoin key, so the BTC address is offered through
-# the `custom` list as a bitcoin: URI (opens a wallet with the address filled in).
-# A bare `btc:` key would silently break the whole sidebar and take the PayPal
-# link down with it, which is why it must never be uncommented.
+# The BTC address is offered via a linked DONATE.md page rather than a raw
+# `bitcoin:` URI: client-side crypto-clipper / security browser extensions scan
+# the sidebar for a standalone wallet address and drop a warning "stop sign"
+# badge on the button when they find one. Keeping the raw address off the button
+# and behind a link avoids that false flag. A bare `btc:` key would silently
+# break the whole sidebar (taking the PayPal link down too), so never uncomment one.
 custom:
   - https://www.paypal.com/donate/?hosted_button_id=9DF676HUWAHKY
-  - bitcoin:1Gd1bjFqCCrx9AkiHUcBuuEYUuVuvncBTc
+  - https://github.com/frstrtr/c2pool/blob/master/DONATE.md

--- a/DONATE.md
+++ b/DONATE.md
@@ -1,0 +1,17 @@
+# Support c2pool
+
+c2pool is free, open-source merged-mining pool software, licensed AGPL-3.0.
+Donations go toward development and the infrastructure that keeps the public
+nodes and sharechains running. Thank you for your support.
+
+## PayPal
+
+https://www.paypal.com/donate/?hosted_button_id=9DF676HUWAHKY
+
+## Bitcoin (BTC)
+
+```
+1Gd1bjFqCCrx9AkiHUcBuuEYUuVuvncBTc
+```
+
+<!-- DASH donation address: to be added (pending a confirmed address). -->

--- a/DONATE.md
+++ b/DONATE.md
@@ -14,4 +14,8 @@ https://www.paypal.com/donate/?hosted_button_id=9DF676HUWAHKY
 1Gd1bjFqCCrx9AkiHUcBuuEYUuVuvncBTc
 ```
 
-<!-- DASH donation address: to be added (pending a confirmed address). -->
+## Dash (DASH)
+
+```
+XdgF55wEHBRWwbuBniNYH4GvvaoYMgL84u
+```


### PR DESCRIPTION
The raw `bitcoin:` URI in the funding sidebar triggers client-side crypto-clipper / security browser extensions to drop a warning "stop sign" badge on the Sponsor button (they flag any standalone wallet address in page HTML). This moves the BTC address behind a linked DONATE.md page so the button no longer carries a raw address, while PayPal + BTC stay reachable. Adds DONATE.md; FUNDING.yml `custom` now links PayPal + the DONATE page.