### PR TITLE
dash(stratum): GBT-xcheck reward-safety swap on a divergent non-coinbase tx-merkleroot (tx-serving analog of #1216)

### DIFF
--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -1057,6 +1057,90 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
                                                std::move(xcheck) };
                     served_via_xcheck_swap = true;
                 }
+                // #130 tx-serving reward-safety — NON-COINBASE tx-merkleroot
+                // xcheck. The #1216 creditPool / quorum / MN branches above
+                // guard the CbTx (coinbase) axis; this guards the TRANSACTION-
+                // SELECTION axis, which lives entirely in the non-coinbase txid
+                // vector m_tx_hashes (mempool selection AND the type-6
+                // commitment order both fold into it). Once
+                // --embedded-serve-mempool-txs is armed, a divergent mempool tx
+                // SELECTION or commitment ORDER yields a different block body ->
+                // a different hashMerkleRoot -> the exact bad-txns- / orphan
+                // reject vector. The embedded selector is KNOWN to diverge from
+                // dashd's BlockAssembler (D1 ancestor-score primary key, D2
+                // mapModifiedTx CPFP re-scoring, D3 within-package emit order --
+                // see the PR body); this backstop makes that divergence
+                // reward-SAFE by swapping to dashd's template on ANY non-
+                // coinbase-body mismatch, exactly as the quorum branch does for
+                // the CbTx roots. The selection-fidelity port that CLOSES D1/D2/
+                // D3 in mempool.hpp is a separate follow-up; it only lowers the
+                // swap rate, it is not needed for safety once this guard is in.
+                //
+                // FIELD — the fold over the ORDERED non-coinbase body,
+                // coin::compute_merkle_root(m_tx_hashes), NOT the full-block
+                // hashMerkleRoot. The full-block root folds [coinbase_txid]+
+                // m_tx_hashes, and the embedded vs dashd-fallback coinbases
+                // differ BY CONSTRUCTION (extranonce / payload / timestamp), so
+                // a full-block-root compare would mismatch on EVERY template and
+                // swap-to-dashd always, defeating the daemonless mandate.
+                // Coinbase correctness is already covered by the #1216 CbTx
+                // branches above; the tx-selection axis lives entirely here.
+                // DashWorkData carries no hashMerkleRoot member, so the fold is
+                // recomputed on the fly exactly as the assembler commits it
+                // (block_producer.hpp compute_merkle_root).
+                //
+                // GATE — sel.work.m_mempool_tx_count > 0. When
+                // --embedded-serve-mempool-txs is OFF (the default) the embedded
+                // body is coinbase-only (m_tx_hashes empty, m_mempool_tx_count
+                // ==0) while dref (a real getblocktemplate) carries mempool txs;
+                // comparing the folds without this gate would mismatch on every
+                // template and collapse embedded serving to always-dashd. The
+                // gate is also SEMANTICALLY correct: a body with no mempool-
+                // selected txs can never orphan for a bad-txset reason, so it
+                // needs no tx-selection guard (pin-only bodies are owned by the
+                // pin-splice machinery below, not by this axis). This is NOT a
+                // feature-flag gate -- like #1216 it protects EVERY armed
+                // template unconditionally; m_mempool_tx_count>0 is the natural
+                // applicability precondition of a tx-selection guard, a body
+                // that actually carries mempool txs. Byte-neutral today: with
+                // the flag OFF the branch is skipped, so hotel behaviour is
+                // bit-identical. Deliberately NOT gated on emb_ok && dref_ok:
+                // the tx-merkle axis is a body/header axis independent of the
+                // CbTx, so requiring cbtx-parse-success would create a silent
+                // safety miss if a divergent-set template happened to fail cbtx
+                // parse. The sel.source==Embedded re-check skips this branch when
+                // a prior branch already swapped (and MOVED dref), so dref is
+                // never double-served -- and it is evaluated FIRST so the moved
+                // dref is never read.
+                if (sel.source == coin::WorkSource::Embedded
+                    && dref.m_height == sel.work.m_height
+                    && sel.work.m_mempool_tx_count > 0) {
+                    const uint256 emb_txroot =
+                        coin::compute_merkle_root(sel.work.m_tx_hashes);
+                    const uint256 dref_txroot =
+                        coin::compute_merkle_root(dref.m_tx_hashes);
+                    if (emb_txroot != dref_txroot) {
+                        LOG_WARNING << "[DASH-STRATUM-GBT] GBT-xcheck tx-merkleroot"
+                                    << " MISMATCH at h=" << sel.work.m_height
+                                    << " embedded txs=" << sel.work.m_tx_hashes.size()
+                                    << " root=" << emb_txroot.GetHex().substr(0, 16)
+                                    << " dashd txs=" << dref.m_tx_hashes.size()
+                                    << " root=" << dref_txroot.GetHex().substr(0, 16)
+                                    << " — serving dashd template (reward-safety"
+                                       " backstop: a divergent mempool tx selection"
+                                       " / commitment order is the bad-txns-"
+                                       "merkleroot orphan vector)";
+                        coin::DeclineReport xcheck;
+                        xcheck.viable    = false;
+                        xcheck.cause     = "gbt-xcheck-txmerkle-mismatch";
+                        xcheck.value     = emb_txroot.GetHex();
+                        xcheck.threshold = dref_txroot.GetHex();
+                        sel = coin::WorkSelection{ std::move(dref),
+                                                   coin::WorkSource::DashdFallback,
+                                                   std::move(xcheck) };
+                        served_via_xcheck_swap = true;
+                    }
+                }
             }
             // ── THE SINGLE PIN SPLICE POINT ─────────────────────────────────
             // The arm is FINAL here: every producer of a served dashd-fallback

--- a/test/test_dash_stratum_work_source.cpp
+++ b/test/test_dash_stratum_work_source.cpp
@@ -2091,6 +2091,218 @@ TEST(DashStratumC1MainnetGate, GbtXcheckQuorumRootMatchServesEmbeddedUnchanged)
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// GBT-xcheck reward-safety BACKSTOP — NON-COINBASE tx-merkleroot axis (#130,
+// tx-serving analog of #1216). The #1216 branches guard the CbTx (coinbase)
+// roots; this one guards the TRANSACTION-SELECTION axis, which lives entirely in
+// the non-coinbase txid vector m_tx_hashes. Once --embedded-serve-mempool-txs is
+// armed the embedded selector — KNOWN to diverge from dashd's BlockAssembler
+// (ancestor-score key, mapModifiedTx CPFP, within-package emit order) — can pick
+// a different tx SET/ORDER at the same tip, folding to a different block body
+// hashMerkleRoot: the exact bad-txns-merkleroot orphan vector. A served embedded
+// template whose non-coinbase fold disagrees with dashd's GBT for the same
+// height MUST swap to dashd's template with cause=gbt-xcheck-txmerkle-mismatch.
+// Neuter the new compare in work_source.cpp (`if (false && ...)`) and the swap
+// KAT goes RED while the byte-neutral KAT stays GREEN — the load-bearing proof.
+namespace {
+// The mempool spend the embedded arm SELECTS: a positive-fee spend of a mature
+// non-coinbase coin the fixture funds. Deterministic id.
+dash::coin::MutableTransaction txmerkle_mempool_spend(const uint256& funding)
+{
+    dash::coin::MutableTransaction tx;
+    tx.vin.resize(1);
+    tx.vin[0].prevout.hash  = funding;
+    tx.vin[0].prevout.index = 0;
+    tx.vout.resize(1);
+    tx.vout[0].value = 90'000;   // 100k funded − 90k = 10k fee (>0 → selected)
+    tx.vout[0].scriptPubKey.m_data = fixture_miner_script();
+    return tx;
+}
+// make_quorumroot_xcheck_cs() + a served mempool tx: with --embedded-serve-
+// mempool-txs ON and a funded UTXO the embedded template comes back with
+// m_mempool_tx_count==1 and m_tx_hashes carrying the spend's txid, so the tx-
+// merkle axis is LIVE (the m_mempool_tx_count>0 gate is satisfied). The caller
+// OWNS `utxo`; it must outlive the returned coin state / any DASHWorkSource
+// built over it.
+std::unique_ptr<dash::coin::NodeCoinState>
+make_txmerkle_xcheck_cs(::core::coin::UTXOViewCache& utxo, const uint256& funding)
+{
+    utxo.add_coin(::core::coin::Outpoint(funding, 0),
+                  ::core::coin::Coin(100'000, {}, /*height=*/1, /*cb=*/false));
+    auto cs = make_quorumroot_xcheck_cs();
+    cs->mempool().set_utxo(&utxo);
+    EXPECT_TRUE(cs->mempool().add_tx(txmerkle_mempool_spend(funding)))
+        << "fixture: the mempool spend must price against the funded UTXO";
+    cs->set_serve_mempool_txs(true);
+    return cs;
+}
+}  // namespace
+
+TEST(DashStratumC1MainnetGate, GbtXcheckServesDashdOnTxMerkleMismatch)
+{
+    uint256 emb_prev; emb_prev.SetHex(kEmbeddedPrevHashHex);
+    uint256 funding;  funding.begin()[0] = 0x51;
+
+    // (0) Capture the EMBEDDED template with the xcheck OFF: its CbTx roots
+    // become the values dashd must MATCH (so ONLY the tx axis is under test),
+    // and its non-empty served tx set proves the fixture actually carries
+    // mempool txs (so the m_mempool_tx_count>0 gate does not make the assertion
+    // below vacuous).
+    dash::coin::vendor::CCbTx emb_cb;
+    std::vector<uint256> emb_txids;
+    uint32_t emb_mempool_n = 0;
+    {
+        ::core::coin::UTXOViewCache utxo(nullptr);
+        auto cs = make_txmerkle_xcheck_cs(utxo, funding);
+        auto never = []() -> dash::coin::DashWorkData { return {}; };
+        dash::stratum::DASHWorkSource ws(*cs, never, xcheck_submit,
+                                         core::stratum::StratumConfig{},
+                                         /*is_testnet=*/true);
+        ASSERT_FALSE(ws.get_current_work_template().empty());
+        auto t = ws.peek_template();
+        ASSERT_TRUE(t && !t->m_coinbase_payload.empty());
+        ASSERT_TRUE(dash::coin::vendor::parse_cbtx(t->m_coinbase_payload, emb_cb));
+        emb_txids     = t->m_tx_hashes;
+        emb_mempool_n = t->m_mempool_tx_count;
+    }
+    ASSERT_GT(emb_mempool_n, 0u)
+        << "fixture broken: the embedded arm served no mempool txs, so the "
+           "m_mempool_tx_count>0 gate would skip the branch and this KAT would "
+           "be vacuous";
+    ASSERT_FALSE(emb_txids.empty());
+    const uint256 emb_txroot = dash::coin::compute_merkle_root(emb_txids);
+
+    // dashd fallback: SAME height, SAME creditPool / merkleRootMNList /
+    // merkleRootQuorums (so the #1216 CbTx branches do NOT fire), but a
+    // DIFFERENT non-coinbase tx set → ONLY the tx-merkle axis diverges.
+    std::vector<uint256> dref_txids(1);
+    dref_txids[0].SetHex(std::string(64, 'e'));
+    const uint256 dref_txroot = dash::coin::compute_merkle_root(dref_txids);
+    ASSERT_NE(emb_txroot, dref_txroot)
+        << "fixture: the dashd tx set must actually fold to a different root";
+
+    auto fallback = [&]() -> dash::coin::DashWorkData {
+        dash::coin::DashWorkData w;
+        w.m_height         = kEmbeddedPrevHeight + 1;
+        w.m_previous_block = emb_prev;
+        w.m_bits           = 0x1e0ffff0u;
+        w.m_version        = static_cast<uint32_t>(kVersion);
+        w.m_curtime        = kCurtime;
+        dash::coin::vendor::CCbTx cb;
+        cb.nVersion           = dash::coin::vendor::CCbTx::VERSION_CLSIG_AND_BALANCE;
+        cb.nHeight            = static_cast<int32_t>(kEmbeddedPrevHeight + 1);
+        cb.merkleRootMNList   = emb_cb.merkleRootMNList;   // MATCH → not the mn axis
+        cb.merkleRootQuorums  = emb_cb.merkleRootQuorums;  // MATCH → not the quorum axis
+        cb.creditPoolBalance  = emb_cb.creditPoolBalance;  // MATCH → not the creditPool axis
+        w.m_coinbase_payload  = dash::coin::encode_cbtx(cb);
+        w.m_tx_hashes         = dref_txids;                // DIFFER → the axis under test
+        w.m_mempool_tx_count  = 1;
+        return w;
+    };
+
+    ::core::coin::UTXOViewCache utxo(nullptr);
+    auto cs = make_txmerkle_xcheck_cs(utxo, funding);
+    dash::stratum::DASHWorkSource ws(*cs, fallback, xcheck_submit,
+                                     core::stratum::StratumConfig{},
+                                     /*is_testnet=*/true);
+    ws.set_gbt_xcheck(true);
+
+    ASSERT_FALSE(ws.get_current_work_template().empty());
+    auto t = ws.peek_template();
+    ASSERT_TRUE(t && !t->m_coinbase_payload.empty());
+    // The served body is now dashd's: its non-coinbase set folds to dashd's
+    // root, NOT the embedded one.
+    EXPECT_EQ(dash::coin::compute_merkle_root(t->m_tx_hashes), dref_txroot)
+        << "on a tx-merkleroot mismatch the backstop must serve dashd's body";
+    EXPECT_NE(dash::coin::compute_merkle_root(t->m_tx_hashes), emb_txroot);
+    dash::coin::vendor::CCbTx served;
+    ASSERT_TRUE(dash::coin::vendor::parse_cbtx(t->m_coinbase_payload, served));
+    EXPECT_EQ(served.creditPoolBalance, emb_cb.creditPoolBalance)
+        << "the swap is on the tx axis: the CbTx roots MATCHED, proving the "
+           "#1216 branches did not fire and this is the tx-merkle branch";
+    const auto st = ws.embedded_arm_status_json();
+    EXPECT_EQ(st.value("arm", std::string{}), "dashd-fallback")
+        << "the swap must leave the served arm as the dashd fallback";
+    EXPECT_EQ(st.value("no_work_reason", std::string{}), "gbt-xcheck-txmerkle-mismatch")
+        << "the swap must be recorded with the distinct tx-merkleroot cause";
+}
+
+// Byte-neutral proof: when the embedded non-coinbase fold already MATCHES dashd's
+// (and the CbTx roots match too) the unconditional xcheck adds NO swap and the
+// served bytes ARE the embedded template's, unchanged — coinbase and body. This
+// is why arming the guard changes nothing on a template whose selection already
+// agrees with dashd.
+TEST(DashStratumC1MainnetGate, GbtXcheckTxMerkleMatchServesEmbeddedUnchanged)
+{
+    uint256 emb_prev; emb_prev.SetHex(kEmbeddedPrevHashHex);
+    uint256 funding;  funding.begin()[0] = 0x51;
+
+    // Capture the embedded template (xcheck OFF): CbTx roots, the served tx set,
+    // and the raw served CbTx bytes.
+    dash::coin::vendor::CCbTx emb_cb;
+    std::vector<uint256> emb_txids;
+    std::vector<unsigned char> emb_raw;
+    {
+        ::core::coin::UTXOViewCache utxo(nullptr);
+        auto cs = make_txmerkle_xcheck_cs(utxo, funding);
+        auto never = []() -> dash::coin::DashWorkData { return {}; };
+        dash::stratum::DASHWorkSource ws(*cs, never, xcheck_submit,
+                                         core::stratum::StratumConfig{},
+                                         /*is_testnet=*/true);
+        ASSERT_FALSE(ws.get_current_work_template().empty());
+        auto t = ws.peek_template();
+        ASSERT_TRUE(t && !t->m_coinbase_payload.empty());
+        ASSERT_TRUE(dash::coin::vendor::parse_cbtx(t->m_coinbase_payload, emb_cb));
+        ASSERT_GT(t->m_mempool_tx_count, 0u)
+            << "fixture broken: no mempool txs served, byte-neutral claim vacuous";
+        emb_txids = t->m_tx_hashes;
+        emb_raw   = t->m_coinbase_payload;
+    }
+    ASSERT_FALSE(emb_raw.empty());
+
+    // dashd fallback: SAME height, SAME CbTx roots, AND the SAME non-coinbase tx
+    // set → every axis matches, so the unconditional xcheck adds no swap.
+    auto fallback = [&]() -> dash::coin::DashWorkData {
+        dash::coin::DashWorkData w;
+        w.m_height         = kEmbeddedPrevHeight + 1;
+        w.m_previous_block = emb_prev;
+        w.m_bits           = 0x1e0ffff0u;
+        w.m_version        = static_cast<uint32_t>(kVersion);
+        w.m_curtime        = kCurtime;
+        dash::coin::vendor::CCbTx cb;
+        cb.nVersion           = dash::coin::vendor::CCbTx::VERSION_CLSIG_AND_BALANCE;
+        cb.nHeight            = static_cast<int32_t>(kEmbeddedPrevHeight + 1);
+        cb.merkleRootMNList   = emb_cb.merkleRootMNList;
+        cb.merkleRootQuorums  = emb_cb.merkleRootQuorums;
+        cb.creditPoolBalance  = emb_cb.creditPoolBalance;
+        w.m_coinbase_payload  = dash::coin::encode_cbtx(cb);
+        w.m_tx_hashes         = emb_txids;                              // MATCH → byte-neutral
+        w.m_mempool_tx_count  = static_cast<uint32_t>(emb_txids.size());
+        return w;
+    };
+
+    ::core::coin::UTXOViewCache utxo(nullptr);
+    auto cs = make_txmerkle_xcheck_cs(utxo, funding);
+    dash::stratum::DASHWorkSource ws(*cs, fallback, xcheck_submit,
+                                     core::stratum::StratumConfig{},
+                                     /*is_testnet=*/true);
+    ws.set_gbt_xcheck(true);
+
+    ASSERT_FALSE(ws.get_current_work_template().empty());
+    auto t = ws.peek_template();
+    ASSERT_TRUE(t && !t->m_coinbase_payload.empty());
+    EXPECT_EQ(t->m_coinbase_payload, emb_raw)
+        << "tx roots match → byte-neutral: the embedded template is served "
+           "unchanged, coinbase and all";
+    EXPECT_EQ(t->m_tx_hashes, emb_txids)
+        << "the served non-coinbase body is the embedded one, untouched";
+    const auto st = ws.embedded_arm_status_json();
+    EXPECT_EQ(st.value("arm", std::string{}), "EMBEDDED")
+        << "a matching tx-merkleroot must leave the embedded arm serving, not swap";
+    EXPECT_NE(st.value("no_work_reason", std::string{}), "gbt-xcheck-txmerkle-mismatch")
+        << "a matching tx-merkleroot must NOT record a swap";
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Tip-transition fallback leak: on every new block the serve path re-sources
 // during the body-pending window and (correctly) gets the dashd fallback; the
 // serve-tip promotion then lands ~0.1-0.4 s later — routinely WHILE that


### PR DESCRIPTION
## What

Extends the GBT-xcheck reward-safety backstop in `resource_template_now()`
(`src/impl/dash/stratum/work_source.cpp`) to also guard the **transaction-selection
axis**. The existing branches cover the CbTx (coinbase) axis only:
`creditPoolBalance` (#107) and `merkleRootQuorums` / `merkleRootMNList` (#1216).
Neither covers the non-coinbase txid vector `m_tx_hashes` — so once
`--embedded-serve-mempool-txs` is armed, a divergent mempool tx selection could
ship a bad/orphan block **unguarded**.

This PR adds one additive branch (mirroring #1216 exactly), plus two KATs.

## The still-present divergence this makes safe

The embedded selector (`mempool.hpp`) diverges from dashd's `BlockAssembler`
(`node/miner.cpp` + `txmempool.h`) in three real ways, verified against source:

- **D1 — primary ordering key.** Embedded sorts by *standalone* per-tx feerate
  (`mempool.hpp:112-122`; the code comment at 108-110 concedes it reduces to the
  entry's own fee/size). dashd sorts by ancestor-score = MIN(self, ancestor-package)
  via `CompareTxMemPoolEntryByAncestorFee` (`txmempool.h:274-312`).
- **D2 — no `mapModifiedTx` / CPFP re-scoring.** dashd progressively re-scores
  descendants as ancestors are included (`miner.cpp:415-440,480,528-529`); embedded
  only pulls a candidate's unselected ancestor package topologically, so CPFP works
  only accidentally and the admitted set diverges near the byte/sigop cap.
- **D3 — within-package emit order.** dashd `SortForBlock` orders an accepted
  package by ascending ancestor-count, txid tiebreak (`miner.cpp:442-451`); embedded
  emits parents-first by DFS (`mempool.hpp:884-905`) — different vtx order → different
  `hashMerkleRoot` even for an identical SET.

Same tip, same mempool, the two selectors can pick a different tx SET/ORDER → a
different non-coinbase body → a different block `hashMerkleRoot` → the exact
bad-txns-merkleroot / orphan reject vector.

**Scope decision:** the selection-fidelity port that closes D1/D2/D3 in `mempool.hpp`
is real but **not small** (a new ancestor-score index + a `mapModifiedTx` re-scoring
state machine + `SortForBlock` ancestor-count ordering). It is a separate follow-up.
Guard-first is the established daemonless pattern (#1216): backstop the axis, then
narrow the divergence. This PR is the guard alone; it does not touch `mempool.hpp`.

## The guard

Inside the same `sel.source==Embedded && gbt_xcheck_ && dashd_fallback_` block,
**after** the #1216 quorum/MN branch and **before** the single pin-splice point:

- **Field:** the fold over the ordered non-coinbase body,
  `coin::compute_merkle_root(m_tx_hashes)` — **not** the full-block `hashMerkleRoot`.
  The full-block root folds `[coinbase_txid]+m_tx_hashes`, and the embedded vs dashd
  coinbases differ by construction (extranonce/payload/timestamp), so a full-block
  compare would mismatch on *every* template and swap-to-dashd always, defeating the
  daemonless mandate. Coinbase correctness is already covered by #107/#1216.
- **Gate:** `sel.work.m_mempool_tx_count > 0`. With the flag OFF (default) the embedded
  body is coinbase-only (empty `m_tx_hashes`) while the dashd fallback carries mempool
  txs; an ungated compare would mismatch on every template and collapse embedded
  serving to always-dashd. The gate is also semantically correct — a body with no
  mempool-selected txs can never orphan for a bad-txset reason. It is **not** a
  feature-flag gate: like #1216 it protects every armed template unconditionally.
- **Swap:** on any difference, swap to the dashd template with a distinct cause
  `gbt-xcheck-txmerkle-mismatch`; the swapped body flows through the single pin-splice
  point with zero extra wiring (`served_via_xcheck_swap=true`).
- `sel.source==Embedded` re-checked first, so the branch is skipped (and `dref` never
  read after move) when a prior branch already swapped.

## Properties

- **Byte-neutral** when the txid vectors fold equal, and **skipped entirely** while
  `--embedded-serve-mempool-txs` is OFF — current hotel behaviour is bit-identical.
- **Additive-only**; #107/#1216 and the pin-splice point are untouched.

## Tests — RED-proven by neutering (mirroring #1216)

- `GbtXcheckServesDashdOnTxMerkleMismatch` — same height / creditPool / quorum / MN
  roots, different non-coinbase set → served body carries dashd's tx-merkle,
  `arm=dashd-fallback`, `no_work_reason=gbt-xcheck-txmerkle-mismatch`.
- `GbtXcheckTxMerkleMatchServesEmbeddedUnchanged` — all axes match → no swap, served
  bytes identical to the embedded template, `arm=EMBEDDED`.

Neutering the compare to `if (false && ...)` makes the swap KAT **fail to swap**
(arm stays EMBEDDED, cause empty) while the byte-neutral KAT stays green — the branch
is load-bearing. Built with **real dashbls**; the full `test_dash_stratum_work_source`
binary is green (**115/115**).