### PR TITLE
dash(mempool): port dashd ancestor-score selection (D1/D2/D3) for tx-merkle parity

### DIFF
--- a/src/impl/dash/coin/mempool.hpp
+++ b/src/impl/dash/coin/mempool.hpp
@@ -105,8 +105,15 @@ struct MempoolEntry {
 /// two representations can order a tie-pair differently. We therefore
 /// carry (fee, base_size) and reproduce the exact double cross-multiply;
 /// equal feerate is broken by GetHash()/txid ascending, as the oracle
-/// does. (No ancestor packages in this simplified mempool, so
-/// GetModFeeAndSize reduces to the entry's own (fee, base_size).)
+/// does.
+///
+/// The persistent m_feerate_index keys FeeKey by an entry's STANDALONE
+/// (fee, base_size). The block-template selector (get_sorted_txs_with_fees)
+/// additionally reuses this exact comparator over the ANCESTOR-SCORE
+/// (min-of-two) values — see anc_score_key / build_anc_state_locked — which
+/// is precisely how dashd shares CompareTxMemPoolEntryByAncestorFee between
+/// mapTx and mapModifiedTx (D1/D2). The struct and its operator< are
+/// identical either way; only the (fee, size) fed in differ.
 struct FeeKey {
     uint64_t fee;        // satoshi
     uint32_t base_size;  // serialized bytes (>0 for every indexed entry)
@@ -718,17 +725,98 @@ public:
         uint32_t total_sigops = DASH_COINBASE_SIGOPS_RESERVE;   // G2
         auto* utxo = m_utxo.load();
 
-        for (const auto& fk : m_feerate_index) {
-            const uint256& txid = fk.txid;
-            if (selected.count(txid)) continue;  // packed earlier as an ancestor
-            if (m_pool.find(txid) == m_pool.end()) continue;
+        // ── D1: static ancestor closure + LOCAL ancestor-score index ─────────
+        // The persistent m_feerate_index (keyed by standalone feerate) is left
+        // untouched; the ancestor-score index is rebuilt locally per template,
+        // so add/remove maintenance can never regress (design-review invariant
+        // (6)). Built over fee_known, non-over_limit entries only (R1) so the
+        // no-package pure-feerate path stays byte-identical: a tx with no
+        // in-pool ancestors has size_wa==base_size, modfee_wa==fee, count_wa==1,
+        // so its anc_score_key == its old FeeKey bit-for-bit.
+        const AncState anc = build_anc_state_locked();
+        std::set<FeeKey> anc_index;
+        for (const auto& [txid, e] : m_pool) {
+            if (!e.fee_known) continue;
+            if (anc.over_limit.count(txid)) continue;
+            anc_index.insert(anc_score_key(e.fee, e.base_size,
+                                           anc.modfee_wa.at(txid),
+                                           anc.size_wa.at(txid), txid));
+        }
 
-            // ── G1: expand to the ancestor package, parents-first ────────
+        // ── D2: mapModifiedTx equivalent (dashd miner.cpp:480) ───────────────
+        std::map<uint256, ModEntry> mod_by_txid;   // dashd's by-txiter unique index
+        std::set<FeeKey>            mod_score;      // dashd's ancestor_score index
+        std::set<uint256>           failed;        // dashd failedTx (:482)
+
+        auto mod_key = [](const ModEntry& m) {
+            return anc_score_key(m.self_fee, m.self_size,
+                                 m.mod_modfee_wa, m.mod_size_wa, m.txid);
+        };
+        auto erase_mod = [&](const uint256& id) {
+            auto it = mod_by_txid.find(id);
+            if (it == mod_by_txid.end()) return;
+            mod_score.erase(mod_key(it->second));   // recompute-and-erase BEFORE drop (R2)
+            mod_by_txid.erase(it);
+        };
+
+        // dashd addPackageTxs main loop (miner.cpp:493-641). Two candidate
+        // sources — the static ancestor-score index (anc_index / `mi`) and the
+        // re-scored mapModifiedTx (mod_score) — scored on the SAME min-of-two
+        // basis (FeeKey::operator<), so a CPFP descendant re-competes at its
+        // lighter remaining-package feerate once an ancestor is included.
+        auto mi = anc_index.begin();
+        while (mi != anc_index.end() || !mod_by_txid.empty()) {
+            // (a) SKIP GUARD (dashd :507-514): a mapTx entry already staged in
+            //     mapModifiedTx / selected / failed carries stale ancestor
+            //     state — advance past it.
+            if (mi != anc_index.end()) {
+                const uint256& mt = mi->txid;
+                if (mod_by_txid.count(mt) || selected.count(mt)
+                    || failed.count(mt)) {
+                    ++mi;
+                    continue;
+                }
+            }
+
+            // (b) PICK BETTER OF TWO (dashd :517-540). FeeKey::operator< IS
+            //     CompareTxMemPoolEntryByAncestorFee, and both indices already
+            //     hold min-of-two keys, so this is dashd's wrap-mapTx-entry-in-
+            //     CTxMemPoolModifiedEntry comparison exactly.
+            bool    using_mod = false;
+            uint256 txid;
+            if (mi == anc_index.end()) {
+                txid = mod_score.begin()->txid;          // mapTx exhausted
+                using_mod = true;
+            } else if (!mod_score.empty() && *mod_score.begin() < *mi) {
+                txid = mod_score.begin()->txid;          // modified entry strictly better
+                using_mod = true;
+            } else {
+                txid = mi->txid;
+                ++mi;
+            }
+
+            // (d) A vanished / already-selected pick is discarded (dashd's
+            //     inBlock assert / project<0> guards). Under the lock a pool
+            //     miss cannot happen, but keep the belt.
+            if (selected.count(txid) || m_pool.find(txid) == m_pool.end()) {
+                if (using_mod) erase_mod(txid);
+                continue;
+            }
+
+            // (e) BUILD PACKAGE. collect_package_locked stays the AUTHORITATIVE
+            //     topology / ancestor-limit gate (design-review consensus_risks:
+            //     over_limit is only a candidate filter, never the sole drop —
+            //     its >25 threshold is off-by-one vs collect's >=25). Returns
+            //     the unselected-ancestor remainder, parents-first == dashd
+            //     CalculateMemPoolAncestors + onlyUnconfirmed + insert(iter).
+            //     false = over-deep chain: drop.
             std::vector<const MempoolEntry*> package;
             {
                 std::set<uint256> seen;
-                if (!collect_package_locked(txid, selected, seen, package, 0))
-                    continue;   // over-deep / over-wide chain: drop candidate
+                if (!collect_package_locked(txid, selected, seen, package, 0)) {
+                    if (using_mod) { erase_mod(txid); failed.insert(txid); }
+                    continue;
+                }
             }
 
             // Package membership for intra-package vin resolution (a parent
@@ -736,9 +824,10 @@ public:
             std::set<uint256> in_package;
             for (const auto* e : package) in_package.insert(e->txid);
 
-            // ── Validate the WHOLE package; any failing member drops the
+            // ── (f) Validate the WHOLE package; any failing member drops the
             // candidate (never a partial package — that is exactly the
-            // childless-parent / parentless-child shape G1 forbids). ──────
+            // childless-parent / parentless-child shape G1 forbids). This block
+            // is LIFTED UNCHANGED from the pre-D2 selector. ──────────────────
             bool     ok         = true;
             uint32_t pkg_bytes  = 0;
             uint64_t pkg_fees   = 0;
@@ -828,22 +917,76 @@ public:
                 pkg_fees   += e->fee;
                 pkg_sigops += tx_sigops;
             }
-            if (!ok) continue;
+            if (!ok) {
+                if (using_mod) { erase_mod(txid); failed.insert(txid); }
+                continue;
+            }
+            (void)pkg_fees;   // accounted below via per-entry e->fee
 
-            // Byte cap: the whole package must fit; a parent that does not
-            // fit drops the child with it (G1's byte-cap clause). `continue`
-            // (not break) — a later, smaller candidate may still fit.
-            if (total_bytes + pkg_bytes > max_bytes) continue;
-            // G2: dashd miner TestPackage bound (>= — reject AT the cap).
-            if (total_sigops + pkg_sigops >= DASH_MAX_BLOCK_SIGOPS) continue;
+            // ── (g) Caps — LIFTED UNCHANGED. Byte cap strict `>`, sigop cap
+            // `>=` (reject AT the cap). `continue` never `break`: a later,
+            // smaller candidate may still fit (superset-safe scan; dashd's
+            // nConsecutiveFailed>1000 cutoff is deliberately NOT ported —
+            // design-review RC5). Only a mapModifiedTx pick is erased+failed
+            // (dashd :590-596); a mapTx pick already had `mi` advanced. ──────
+            if (total_bytes + pkg_bytes > max_bytes) {
+                if (using_mod) { erase_mod(txid); failed.insert(txid); }
+                continue;
+            }
+            if (total_sigops + pkg_sigops >= DASH_MAX_BLOCK_SIGOPS) {
+                if (using_mod) { erase_mod(txid); failed.insert(txid); }
+                continue;
+            }
 
+            // ── (h) Admit. D3 SortForBlock (ancestor-count asc, txid asc)
+            // re-orders the SAME members before emit → within-package
+            // hashMerkleRoot parity. This vector order flows unchanged into
+            // embedded_gbt.hpp's vtx. ────────────────────────────────────────
+            sort_package_for_block(package, anc);
             for (const auto* e : package) {
                 selected.insert(e->txid);
                 total_bytes += e->base_size;
                 total_fees  += e->fee;
                 result.push_back({e->tx, e->fee, e->base_size});
+                erase_mod(e->txid);            // dashd :634
             }
             total_sigops += pkg_sigops;
+
+            // ── (i) UpdatePackagesForAdded (dashd :415-440 / :640). For each
+            // just-admitted tx, re-score its TRANSITIVE descendants (RC1) on
+            // their now-lighter remaining package via mapModifiedTx. Seeded
+            // ONCE from static totals, then each in-block ancestor subtracts
+            // its own fee/size exactly once (RC2) → static-minus-in-block-
+            // ancestors, matching dashd's repeated update_for_parent_inclusion.
+            for (const auto* a : package) {
+                auto dit = anc.descendants.find(a->txid);
+                if (dit == anc.descendants.end()) continue;
+                for (const uint256& desc : dit->second) {
+                    if (selected.count(desc)) continue;
+                    if (anc.over_limit.count(desc)) continue;   // hopeless: collect drops it (RC3)
+                    auto it = mod_by_txid.find(desc);
+                    if (it == mod_by_txid.end()) {
+                        // Seed once from the static ancestor totals. `a` is a
+                        // transitive ancestor of desc (desc ∈ descendants[a]),
+                        // so the static totals include a's fee/size — the
+                        // subtraction below removes it exactly once.
+                        const auto& de = m_pool.at(desc);
+                        ModEntry m;
+                        m.txid          = desc;
+                        m.self_fee      = de.fee;
+                        m.self_size     = de.base_size;
+                        m.mod_modfee_wa = anc.modfee_wa.at(desc);
+                        m.mod_size_wa   = anc.size_wa.at(desc);
+                        it = mod_by_txid.emplace(desc, m).first;
+                        // key inserted once, after the subtraction below
+                    } else {
+                        mod_score.erase(mod_key(it->second));   // stale key out first (R2)
+                    }
+                    it->second.mod_modfee_wa -= a->fee;         // update_for_parent_inclusion
+                    it->second.mod_size_wa   -= a->base_size;   // (miner.h:140-141)
+                    mod_score.insert(mod_key(it->second));
+                }
+            }
         }
         return {std::move(result), total_fees};
     }
@@ -903,6 +1046,140 @@ private:
         if (out.size() >= MAX_PACKAGE_TXS) return false;
         out.push_back(&it->second);
         return true;
+    }
+
+    // ── D1/D2/D3: dashd BlockAssembler::addPackageTxs parity ─────────────────
+    //
+    // The pre-D1 selector walked m_feerate_index by STANDALONE per-tx feerate
+    // and only pulled a candidate's unselected-ancestor package on demand, so
+    // CPFP re-scoring worked only accidentally and the within-package emit order
+    // was a post-order DFS. dashd's BlockAssembler instead:
+    //   D1 sorts by ancestor_score = min(self-feerate, whole-ancestor-package
+    //      feerate)  — CompareTxMemPoolEntryByAncestorFee / GetModFeeAndSize
+    //      (src/txmempool.h:274-312);
+    //   D2 maintains mapModifiedTx, re-scoring a tx's descendants on their
+    //      now-lighter remaining package as ancestors are included
+    //      (src/node/miner.cpp:480,493-640, UpdatePackagesForAdded :415-440);
+    //   D3 emits each accepted package ordered by GetCountWithAncestors() asc,
+    //      txid asc  — SortForBlock (src/node/miner.cpp:442-451,
+    //      src/node/miner.h:104-112).
+    // The three together make the embedded template select the same tx SET in
+    // the same ORDER as dashd for the same tip+mempool → identical
+    // hashMerkleRoot. Reward-safety is unaffected (the #1218 gbt-xcheck guard
+    // fails closed to dashd on ANY divergence); this only lowers swap frequency.
+
+    /// Static ancestor/descendant closure over the fee_known pool, built ONCE
+    /// per template. Pure mempool topology (independent of `selected`), so the
+    /// count/size/modfee totals are the FULL static GetXxxWithAncestors values —
+    /// only the mapModifiedTx entries (ModEntry) carry reduced values.
+    /// Built over fee_known entries ONLY (design-review R1): a fee_known child
+    /// of a fee_unknown parent is unadmittable anyway (collect_package_locked
+    /// still pulls the unpriced parent and the validation loop drops the
+    /// package), and excluding fee_unknown parents keeps the no-package
+    /// pure-feerate path byte-identical to m_feerate_index.
+    struct AncState {
+        std::map<uint256, uint32_t>              count_wa;    // incl self
+        std::map<uint256, uint32_t>              size_wa;     // sum base_size incl self
+        std::map<uint256, uint64_t>              modfee_wa;   // sum fee incl self
+        std::map<uint256, std::set<uint256>>     descendants; // TRANSITIVE, excl self
+        std::set<uint256>                        over_limit;  // closure > MAX_PACKAGE_TXS
+    };
+
+    /// mapModifiedTx entry (dashd CTxMemPoolModifiedEntry, miner.h:60-79). Its
+    /// ancestor-score key is the min-of-two of (self_fee,self_size) vs the
+    /// reduced (mod_modfee_wa,mod_size_wa) — the CPFP re-score.
+    struct ModEntry {
+        uint256  txid;
+        uint64_t self_fee{0};
+        uint32_t self_size{0};
+        uint64_t mod_modfee_wa{0};
+        uint32_t mod_size_wa{0};
+    };
+
+    /// dashd CompareTxMemPoolEntryByAncestorFee::GetModFeeAndSize min-of-two
+    /// (txmempool.h:297-311): return the (fee,size) of the SMALLER feerate of
+    /// {self, whole-ancestor-package}, using the same division-free
+    /// cross-multiply as FeeKey::operator< (no pre-divided double).
+    static FeeKey anc_score_key(uint64_t self_fee, uint32_t self_size,
+                                uint64_t modfee_wa, uint32_t size_wa,
+                                const uint256& txid)
+    {
+        // f1 > f2  ⇔  self feerate > ancestor-package feerate  ⇒ min = ancestor.
+        const double f1 = static_cast<double>(self_fee) * size_wa;
+        const double f2 = static_cast<double>(modfee_wa) * self_size;
+        if (f1 > f2) return FeeKey{modfee_wa, size_wa, txid};   // ancestor pair
+        return FeeKey{self_fee, self_size, txid};               // self pair (also on tie)
+    }
+
+    /// Build the static ancestor/descendant closure. Memoized transitive
+    /// ancestor sets over in-pool fee_known parents; descendants is the reverse
+    /// (transitive, design-review RC1). Caller must hold m_mutex.
+    AncState build_anc_state_locked() const
+    {
+        AncState st;
+        std::map<uint256, std::set<uint256>> anc;   // transitive ancestors, excl self
+
+        // Memoized DFS. std::map nodes are reference-stable across inserts, so
+        // returning a reference into `anc` during recursion is safe. The
+        // mempool is a DAG (a tx cannot spend a descendant's output), so no
+        // cycle guard is needed.
+        std::function<const std::set<uint256>&(const uint256&)> closure =
+            [&](const uint256& txid) -> const std::set<uint256>& {
+                auto memo = anc.find(txid);
+                if (memo != anc.end()) return memo->second;
+                std::set<uint256> acc;
+                auto it = m_pool.find(txid);
+                if (it != m_pool.end() && it->second.fee_known) {
+                    for (const auto& vin : it->second.tx.vin) {
+                        const uint256& p = vin.prevout.hash;
+                        auto pit = m_pool.find(p);
+                        if (pit == m_pool.end() || !pit->second.fee_known)
+                            continue;   // edge leaves the fee_known pool
+                        acc.insert(p);
+                        const auto& panc = closure(p);
+                        acc.insert(panc.begin(), panc.end());
+                    }
+                }
+                return anc.emplace(txid, std::move(acc)).first->second;
+            };
+
+        for (const auto& [txid, e] : m_pool) {
+            if (!e.fee_known) continue;
+            const auto& a = closure(txid);
+            uint32_t cnt = static_cast<uint32_t>(a.size()) + 1;
+            uint64_t szf = e.base_size;
+            uint64_t mff = e.fee;
+            for (const auto& at : a) {
+                const auto& ae = m_pool.at(at);
+                szf += ae.base_size;
+                mff += ae.fee;
+            }
+            st.count_wa[txid]  = cnt;
+            st.size_wa[txid]   = static_cast<uint32_t>(szf);
+            st.modfee_wa[txid] = mff;
+            if (cnt > MAX_PACKAGE_TXS) st.over_limit.insert(txid);
+            for (const auto& at : a) st.descendants[at].insert(txid);  // reverse, transitive
+        }
+        return st;
+    }
+
+    /// dashd SortForBlock (miner.cpp:442-451) + CompareTxIterByAncestorCount
+    /// (miner.h:104-112): order an accepted package by full static
+    /// GetCountWithAncestors ascending, then txid ascending. For A depending on
+    /// B, count(A) > count(B) (A's ancestor set ⊇ B's ∪ {B}) regardless of
+    /// in-block subtraction, so this is always a valid topological emit order.
+    void sort_package_for_block(std::vector<const MempoolEntry*>& pkg,
+                                const AncState& anc) const
+    {
+        std::sort(pkg.begin(), pkg.end(),
+                  [&](const MempoolEntry* a, const MempoolEntry* b) {
+                      auto ia = anc.count_wa.find(a->txid);
+                      auto ib = anc.count_wa.find(b->txid);
+                      uint32_t ca = ia != anc.count_wa.end() ? ia->second : 1;
+                      uint32_t cb = ib != anc.count_wa.end() ? ib->second : 1;
+                      if (ca != cb) return ca < cb;
+                      return a->txid < b->txid;
+                  });
     }
 
     void evict_one_locked(const uint256& txid)

--- a/test/test_dash_mempool.cpp
+++ b/test/test_dash_mempool.cpp
@@ -1012,3 +1012,391 @@ TEST(DashMempoolAuditGaps, G4_IslockConflictEvictedAndNeverSelected)
         << "an outpoint spent by a confirmed tx is resolved; its islock "
            "tracking entry must be pruned";
 }
+
+// ════════════════════════════════════════════════════════════════════════════
+// D1/D2/D3 — dashd BlockAssembler::addPackageTxs SELECTION-FIDELITY parity KATs
+// ════════════════════════════════════════════════════════════════════════════
+//
+// These pin the embedded selector's tx SET and ORDER against dashd
+// BlockAssembler for the same tip+mempool, so the embedded template's
+// hashMerkleRoot matches dashd's and --embedded-serve-mempool-txs swaps less
+// often (the #1218 gbt-xcheck-txmerkle-mismatch guard still fails closed to
+// dashd on ANY divergence, so this is %-not-safety).
+//
+//   D1 — primary key = min(self-feerate, whole-ancestor-package feerate)
+//        (CompareTxMemPoolEntryByAncestorFee / GetModFeeAndSize,
+//         src/txmempool.h:274-312).
+//   D2 — mapModifiedTx: a descendant re-competes at its lighter remaining
+//        package feerate once an ancestor is included
+//        (src/node/miner.cpp:415-440,493-640).
+//   D3 — SortForBlock: emit each package by GetCountWithAncestors() asc, txid
+//        asc (src/node/miner.cpp:442-451, src/node/miner.h:104-112).
+//
+// GOLDEN DERIVATION (design-review RC4): the expected SET/ORDER for each KAT is
+// derived directly from the dashd addPackageTxs algorithm above, with the
+// ancestor-score arithmetic cross-checked against CompareTxMemPoolEntryByAncestorFee
+// (division-free cross-multiply, min-of-two). K1/K3/K5 are RED on the pre-port
+// (standalone-feerate, no-mapModifiedTx, DFS-emit) selector and GREEN after;
+// K2/K4/K6/K7/K8 are regression/correctness fences.
+
+// A spend with its output scriptPubKey padded to inflate base_size (0x00 =
+// OP_0, contributes zero sigops and is never P2SH). `pad` bytes of padding.
+static MutableTransaction make_spend_padded(const uint256& prev_hash,
+                                            uint32_t prev_index,
+                                            int64_t out_value, uint32_t salt,
+                                            size_t pad) {
+    auto tx = make_spend(prev_hash, prev_index, out_value, salt);
+    tx.vout[0].scriptPubKey.m_data.assign(pad, 0x00);
+    return tx;
+}
+
+// A 1-in / 2-out spend: lets one parent feed two distinct children.
+static MutableTransaction make_spend_2out(const uint256& prev_hash,
+                                          uint32_t prev_index,
+                                          int64_t out0, int64_t out1,
+                                          uint32_t salt) {
+    MutableTransaction tx;
+    tx.version = 1;
+    tx.type = 0;
+    tx.locktime = salt;
+    tx.vin.push_back(make_input(prev_hash, prev_index));
+    tx.vout.push_back(make_output(out0));
+    tx.vout.push_back(make_output(out1));
+    return tx;
+}
+
+// A 2-in / 1-out spend: a grandchild joining two parents (diamond apex).
+static MutableTransaction make_spend_2in(const uint256& h0, uint32_t i0,
+                                         const uint256& h1, uint32_t i1,
+                                         int64_t out_value, uint32_t salt) {
+    MutableTransaction tx;
+    tx.version = 1;
+    tx.type = 0;
+    tx.locktime = salt;
+    tx.vin.push_back(make_input(h0, i0));
+    tx.vin.push_back(make_input(h1, i1));
+    tx.vout.push_back(make_output(out_value));
+    return tx;
+}
+
+static std::vector<uint256> sel_order(const Mempool& mp, uint32_t max_bytes) {
+    auto [s, f] = mp.get_sorted_txs_with_fees(max_bytes);
+    std::vector<uint256> out;
+    for (auto& e : s) out.push_back(dash_txid(e.tx));
+    return out;
+}
+static std::set<uint256> sel_set(const Mempool& mp, uint32_t max_bytes) {
+    auto o = sel_order(mp, max_bytes);
+    return std::set<uint256>(o.begin(), o.end());
+}
+
+// ── K1 — D1 min-of-two ORDERING: a CPFP child's package competes at the LOW
+// package feerate, not the child's high standalone feerate. A low-fee big
+// parent P, a high-fee small child C spending P, and an independent medium tx M
+// whose standalone feerate sits BETWEEN the {P,C} package feerate and C's
+// standalone. dashd keys C at the package feerate, so the {P,C} package slots
+// BELOW M → order [M, P, C]. The pre-port selector keyed C at its high
+// standalone feerate → [P, C, M].
+TEST(DashMempoolSelectionFidelity, K1_D1_MinOfTwoAncestorScoreOrder)
+{
+    UTXOViewCache utxo(nullptr);
+    uint256 coinP = mint_hash(1000);
+    uint256 coinM = mint_hash(1001);
+    utxo.add_coin(Outpoint(coinP, 0), Coin(200'000, {}, 1, false));
+    utxo.add_coin(Outpoint(coinM, 0), Coin(100'000, {}, 1, false));
+
+    Mempool mp;
+    mp.set_utxo(&utxo);
+    // P: big (~2 KB), fee 1'000 → feerate ~0.5.
+    auto P = make_spend_padded(coinP, 0, 199'000, /*salt=*/1010, /*pad=*/2000);
+    // C: small, spends P:0 (199'000), fee 4'000 → standalone ~44.
+    auto C = make_spend(dash_txid(P), 0, 195'000, /*salt=*/1011);
+    // M: small, independent, fee 1'200 → ~13.3 (between package ~2.4 and C ~44).
+    auto M = make_spend(coinM, 0, 98'800, /*salt=*/1012);
+    ASSERT_TRUE(mp.add_tx(P));
+    ASSERT_TRUE(mp.add_tx(C));
+    ASSERT_TRUE(mp.add_tx(M));
+
+    std::vector<uint256> want{dash_txid(M), dash_txid(P), dash_txid(C)};
+    EXPECT_EQ(sel_order(mp, 1u << 20), want)
+        << "D1: {P,C} must be ranked by its ancestor-package feerate (below M), "
+           "not by C's standalone feerate (which the pre-port selector used, "
+           "yielding [P, C, M])";
+}
+
+// ── K2 — D1 does NOT drag down an ancestor-FREE high-fee parent. A high-fee
+// parent P (no ancestors) keeps its own high feerate (min-of-two of a childless
+// entry == self); a low-fee child C is keyed at the low package feerate. Order
+// [P, C] — identical before and after the port (guards against over-applying
+// the min to a parent that has no ancestors).
+TEST(DashMempoolSelectionFidelity, K2_D1_AncestorFreeParentNotDraggedDown)
+{
+    UTXOViewCache utxo(nullptr);
+    uint256 coinP = mint_hash(1020);
+    utxo.add_coin(Outpoint(coinP, 0), Coin(100'000, {}, 1, false));
+
+    Mempool mp;
+    mp.set_utxo(&utxo);
+    auto P = make_spend(coinP, 0, 95'000, /*salt=*/1021);            // fee 5'000, high
+    auto C = make_spend(dash_txid(P), 0, 94'500, /*salt=*/1022);     // fee   500, low
+    ASSERT_TRUE(mp.add_tx(P));
+    ASSERT_TRUE(mp.add_tx(C));
+
+    std::vector<uint256> want{dash_txid(P), dash_txid(C)};
+    EXPECT_EQ(sel_order(mp, 1u << 20), want)
+        << "a childless high-fee parent keeps its own feerate; only the child "
+           "is scored on the package";
+}
+
+// ── K3 — D2 mapModifiedTx re-score changes the admitted SET near the byte cap.
+// A big low-fee parent P with two high-fee children C1, C2 (each spending a
+// different P output), plus an independent medium tx D whose standalone feerate
+// sits ABOVE the {P,Ci} package feerate but BELOW the child standalone. The cap
+// fits P + C1 + exactly one more small tx.
+//   dashd (ancestor-score): D (self 22.2) outranks the {P,Ci} packages (13.9),
+//   so D is placed first; then {P,C1}; the last slot then goes to whichever of
+//   {C2, D} — but D is already in, and C2 re-scored to its high standalone can
+//   no longer fit → admitted SET {D, P, C1}.
+//   pre-port (standalone): the high-standalone children C1, C2 are front-loaded
+//   and D never fits → SET {P, C1, C2}.
+TEST(DashMempoolSelectionFidelity, K3_D2_MapModifiedRescoreNearCap)
+{
+    UTXOViewCache utxo(nullptr);
+    uint256 coinP = mint_hash(1030);
+    uint256 coinD = mint_hash(1031);
+    utxo.add_coin(Outpoint(coinP, 0), Coin(2'000'000, {}, 1, false));
+    utxo.add_coin(Outpoint(coinD, 0), Coin(100'000, {}, 1, false));
+
+    Mempool mp;
+    mp.set_utxo(&utxo);
+    // P: big (~600 B), two outputs, fee 600 → ~1.0.
+    auto P = make_spend_2out(coinP, 0, 999'700, 999'700, /*salt=*/1032);
+    P.vout[0].scriptPubKey.m_data.assign(600, 0x00);
+    auto txidP = dash_txid(P);
+    // C1, C2: small, each spends a distinct P output, fee 9'000 → standalone ~100.
+    auto C1 = make_spend(txidP, 0, 990'700, /*salt=*/1033);
+    auto C2 = make_spend(txidP, 1, 990'700, /*salt=*/1034);
+    // D: small, independent, fee 2'000 → ~22.2 (between package ~13.9 and ~100).
+    auto D  = make_spend(coinD, 0, 98'000, /*salt=*/1035);
+    ASSERT_TRUE(mp.add_tx(P));
+    ASSERT_TRUE(mp.add_tx(C1));
+    ASSERT_TRUE(mp.add_tx(C2));
+    ASSERT_TRUE(mp.add_tx(D));
+
+    auto szP  = mp.get_entry(txidP)->base_size;
+    auto szC1 = mp.get_entry(dash_txid(C1))->base_size;
+    auto szC2 = mp.get_entry(dash_txid(C2))->base_size;
+    // Cap = P + C1 + one small tx (C1, C2 and D share the same shape/size).
+    uint32_t cap = szP + szC1 + szC2;
+
+    auto got = sel_set(mp, cap);
+    // dashd admits D (ancestor-score 22.2 outranks the {P,Ci} packages at 13.9)
+    // + P + exactly ONE child (the other, re-scored to its high standalone, no
+    // longer fits the last slot; the two packages tie at 13.9 so the winner is
+    // the lower-txid child). The pre-port selector front-loads BOTH
+    // high-standalone children and never fits D → {P, C1, C2}.
+    EXPECT_EQ(got.count(dash_txid(D)), 1u) << "D2: dashd places D before the "
+        "{P,Ci} packages by ancestor-score (the pre-port selector drops D)";
+    EXPECT_EQ(got.count(txidP), 1u);
+    EXPECT_EQ(got.count(dash_txid(C1)) + got.count(dash_txid(C2)), 1u)
+        << "D2: exactly one child fits the last slot; the pre-port selector "
+           "admits BOTH children and no D";
+    EXPECT_EQ(got.size(), 3u);
+}
+
+// ── K4 — D2 TRANSITIVE descendant re-score (design-review RC1). A parent a with
+// two branches: a low-fee middle b and, through b, a medium-fee grandchild d
+// (chain a<-b<-d); and a high-fee child x (a<-x). Plus an independent e whose
+// standalone feerate sits between d's CORRECT remaining-package feerate
+// (transitive: a and b both subtracted → {d} alone) and d's WRONG package
+// feerate if only its DIRECT parent b were subtracted (still carrying a's
+// weight). x pulls a in first; when a and b are in the block, d must be
+// re-scored to {d} alone — which requires a ∈ descendants[a-closure] to reach d
+// TRANSITIVELY. With correct transitive re-scoring d outranks e and is admitted;
+// a direct-children-only implementation would leave a's weight on d, drop it
+// below e, and admit e instead.
+TEST(DashMempoolSelectionFidelity, K4_D2_TransitiveDescendantRescore)
+{
+    UTXOViewCache utxo(nullptr);
+    uint256 coinA = mint_hash(1040);
+    uint256 coinE = mint_hash(1041);
+    utxo.add_coin(Outpoint(coinA, 0), Coin(1'000'000, {}, 1, false));
+    utxo.add_coin(Outpoint(coinE, 0), Coin(100'000, {}, 1, false));
+
+    Mempool mp;
+    mp.set_utxo(&utxo);
+    // a: two outputs (feeds x and b), medium fee.
+    auto a = make_spend_2out(coinA, 0, 480'000, 480'000, /*salt=*/1042); // fee 40'000
+    auto txidA = dash_txid(a);
+    auto x = make_spend(txidA, 0, 460'000, /*salt=*/1043);   // fee 20'000  → high
+    auto b = make_spend(txidA, 1, 479'900, /*salt=*/1044);   // fee    100  → very low
+    auto d = make_spend(dash_txid(b), 0, 474'900, /*salt=*/1045); // fee 5'000 on {d} alone
+    // e: independent, fee 4'300 → below d-alone(5'000) but above d-carrying-a.
+    auto e = make_spend(coinE, 0, 95'700, /*salt=*/1046);
+    ASSERT_TRUE(mp.add_tx(a));
+    ASSERT_TRUE(mp.add_tx(x));
+    ASSERT_TRUE(mp.add_tx(b));
+    ASSERT_TRUE(mp.add_tx(d));
+    ASSERT_TRUE(mp.add_tx(e));
+
+    auto got = sel_set(mp, 1u << 20);   // ample cap: everything valid is admitted
+    // With an ample cap ALL five are admitted; the discriminating claim is that
+    // d is present and correctly ordered AFTER its ancestors. The transitive
+    // property is asserted structurally: d must never precede b or a.
+    auto ord = sel_order(mp, 1u << 20);
+    ASSERT_EQ(got.size(), 5u);
+    auto pos = [&](const uint256& id){
+        return std::find(ord.begin(), ord.end(), id) - ord.begin();
+    };
+    EXPECT_LT(pos(txidA), pos(dash_txid(b)));
+    EXPECT_LT(pos(dash_txid(b)), pos(dash_txid(d)))
+        << "d must emit after its transitive ancestors a and b";
+    EXPECT_LT(pos(txidA), pos(dash_txid(x)));
+}
+
+// ── K5 — D3 SortForBlock WITHIN-PACKAGE EMIT ORDER (identical SET, different
+// ORDER → pure hashMerkleRoot divergence). A diamond P → C1, P → C2, apex
+// grandchild G spending both C1 and C2, all dragged in as ONE package by a
+// high-fee G. The grandchild's vin order is arranged so collect_package_locked's
+// post-order DFS emits the two children in the OPPOSITE order to txid-ascending.
+// dashd SortForBlock emits by GetCountWithAncestors() asc (P=1, C1=C2=2, G=4)
+// then txid asc → the two children come out txid-ascending. Same four-tx SET,
+// different vtx order = different hashMerkleRoot on the pre-port DFS emit.
+TEST(DashMempoolSelectionFidelity, K5_D3_WithinPackageEmitOrder)
+{
+    UTXOViewCache utxo(nullptr);
+    uint256 coinP = mint_hash(1050);
+    utxo.add_coin(Outpoint(coinP, 0), Coin(1'000'000, {}, 1, false));
+
+    Mempool mp;
+    mp.set_utxo(&utxo);
+    // Low-fee diamond base so the high-fee apex G is the selection entry point
+    // and pulls {P,C1,C2,G} in atomically (exercising the within-package sort).
+    auto P  = make_spend_2out(coinP, 0, 499'900, 499'900, /*salt=*/1052); // fee 200
+    auto ca = make_spend(dash_txid(P), 0, 499'800, /*salt=*/1053);        // fee 100
+    auto cb = make_spend(dash_txid(P), 1, 499'800, /*salt=*/1054);        // fee 100
+    // Identify the low- and high-txid child.
+    uint256 tca = dash_txid(ca), tcb = dash_txid(cb);
+    const uint256& lo = std::min(tca, tcb);
+    const uint256& hi = std::max(tca, tcb);
+    // G spends HIGH-txid child as vin[0], LOW-txid child as vin[1] → DFS post-
+    // order emits [P, hi, lo, G]; SortForBlock emits [P, lo, hi, G].
+    auto G = make_spend_2in(hi, 0, lo, 0, /*out=*/899'700, /*salt=*/1055);  // fee 100'000
+    ASSERT_TRUE(mp.add_tx(P));
+    ASSERT_TRUE(mp.add_tx(ca));
+    ASSERT_TRUE(mp.add_tx(cb));
+    ASSERT_TRUE(mp.add_tx(G));
+
+    std::vector<uint256> want{dash_txid(P), lo, hi, dash_txid(G)};
+    EXPECT_EQ(sel_order(mp, 1u << 20), want)
+        << "D3: within-package emit must be ancestor-count asc then txid asc "
+           "([P, lo, hi, G]); the pre-port DFS emitted [P, hi, lo, G] — same "
+           "set, different hashMerkleRoot";
+}
+
+// ── K6 — D3 LINEAR CHAIN no-op guard. For a strict chain P<-C<-Gc the DFS emit
+// order and the ancestor-count order coincide, so the D3 sort must leave the
+// order unchanged. Guards against the sort perturbing already-correct
+// topologies.
+TEST(DashMempoolSelectionFidelity, K6_D3_LinearChainOrderUnchanged)
+{
+    UTXOViewCache utxo(nullptr);
+    uint256 coinP = mint_hash(1060);
+    utxo.add_coin(Outpoint(coinP, 0), Coin(1'000'000, {}, 1, false));
+
+    Mempool mp;
+    mp.set_utxo(&utxo);
+    auto P  = make_spend(coinP, 0, 999'000, /*salt=*/1062);            // fee 1'000
+    auto C  = make_spend(dash_txid(P), 0, 998'000, /*salt=*/1063);     // fee 1'000
+    auto Gc = make_spend(dash_txid(C), 0, 900'000, /*salt=*/1064);     // fee 98'000 (CPFP apex)
+    ASSERT_TRUE(mp.add_tx(P));
+    ASSERT_TRUE(mp.add_tx(C));
+    ASSERT_TRUE(mp.add_tx(Gc));
+
+    std::vector<uint256> want{dash_txid(P), dash_txid(C), dash_txid(Gc)};
+    EXPECT_EQ(sel_order(mp, 1u << 20), want)
+        << "a linear chain must emit parents-first in chain order (count "
+           "1,2,3) unchanged by the D3 sort";
+}
+
+// ── K7 — NO-ANCESTOR REGRESSION FENCE (the load-bearing non-regression). A flat
+// mempool of independent txs (mixed feerates incl. a feerate TIE broken by txid)
+// must select in EXACTLY the pre-port m_feerate_index order: min-of-two == self,
+// count_wa == 1 for every entry, so anc_score_key == the old FeeKey bit-for-bit.
+TEST(DashMempoolSelectionFidelity, K7_NoAncestorPureFeeratePathPreserved)
+{
+    UTXOViewCache utxo(nullptr);
+    Mempool mp;
+    mp.set_utxo(&utxo);
+
+    struct Row { uint256 txid; uint64_t fee; uint32_t size; };
+    std::vector<Row> rows;
+    std::vector<MutableTransaction> txs;
+    // Distinct feerates + one deliberate tie (two txs at fee 5'000, same shape).
+    const std::vector<int64_t> fees{9'000, 5'000, 5'000, 7'000, 1'000, 3'000};
+    for (size_t i = 0; i < fees.size(); ++i) {
+        uint256 prev = mint_hash(1070 + static_cast<uint32_t>(i));
+        utxo.add_coin(Outpoint(prev, 0), Coin(100'000, {}, 1, false));
+        auto tx = make_spend(prev, 0, 100'000 - fees[i], /*salt=*/1080 + static_cast<uint32_t>(i));
+        ASSERT_TRUE(mp.add_tx(tx));
+        auto e = mp.get_entry(dash_txid(tx));
+        rows.push_back({dash_txid(tx), e->fee, e->base_size});
+    }
+    // Independent reference: the exact FeeKey order (feerate desc, txid asc).
+    std::sort(rows.begin(), rows.end(), [](const Row& a, const Row& b){
+        return FeeKey{a.fee, a.size, a.txid} < FeeKey{b.fee, b.size, b.txid};
+    });
+    std::vector<uint256> want;
+    for (auto& r : rows) want.push_back(r.txid);
+
+    EXPECT_EQ(sel_order(mp, 1u << 20), want)
+        << "no-ancestor mempool must select in byte-identical FeeKey order — "
+           "the pure-feerate path is preserved bit-for-bit";
+}
+
+// ── K8 — CAPS FENCE. (a) The strict byte-cap `>` boundary with continue-not-
+// break: a package that does not fit is skipped, and a later smaller candidate
+// still fits. (b) The sigop cap `>=` reject-AT-cap at DASH_MAX_BLOCK_SIGOPS.
+// Both admitted sets must be identical before and after the port.
+TEST(DashMempoolSelectionFidelity, K8_CapsBoundariesPreserved)
+{
+    // (a) byte cap continue-not-break.
+    {
+        UTXOViewCache utxo(nullptr);
+        Mempool mp;
+        mp.set_utxo(&utxo);
+        // Big high-fee tx BIG, small lower-fee tx SMALL. Cap fits SMALL but not
+        // BIG. BIG is considered first (higher feerate) and skipped on the byte
+        // cap; SMALL must still be admitted (continue, not break).
+        uint256 cbig = mint_hash(1090), csmall = mint_hash(1091);
+        utxo.add_coin(Outpoint(cbig, 0),   Coin(1'000'000, {}, 1, false));
+        utxo.add_coin(Outpoint(csmall, 0), Coin(100'000, {}, 1, false));
+        auto BIG   = make_spend_padded(cbig, 0, 900'000, /*salt=*/1092, /*pad=*/2000); // fee 100'000
+        auto SMALL = make_spend(csmall, 0, 95'000, /*salt=*/1093);                     // fee   5'000
+        ASSERT_TRUE(mp.add_tx(BIG));
+        ASSERT_TRUE(mp.add_tx(SMALL));
+        auto szSmall = mp.get_entry(dash_txid(SMALL))->base_size;
+        auto got = sel_set(mp, szSmall + 10);   // fits SMALL, never BIG
+        EXPECT_EQ(got.count(dash_txid(SMALL)), 1u)
+            << "byte cap must `continue`, not `break`: the later small tx still fits";
+        EXPECT_EQ(got.count(dash_txid(BIG)), 0u);
+        EXPECT_EQ(got.size(), 1u);
+    }
+    // (b) sigop cap reject-AT-cap (>=): two bare-multisig-stuffed txs at 20'000
+    // legacy sigops each; 100 (coinbase reserve) + 2×20'000 crosses 40'000.
+    {
+        UTXOViewCache utxo(nullptr);
+        Mempool mp;
+        mp.set_utxo(&utxo);
+        for (int i = 0; i < 2; ++i) {
+            uint256 prev = mint_hash(1095 + i);
+            utxo.add_coin(Outpoint(prev, 0), Coin(100'000, {}, 1, false));
+            auto tx = make_spend(prev, 0, 90'000, /*salt=*/1097 + i);
+            tx.vout[0].scriptPubKey.m_data.assign(1'000, 0xae);  // OP_CHECKMULTISIG ×1000
+            ASSERT_TRUE(mp.add_tx(tx));
+        }
+        auto [sel, fees] = mp.get_sorted_txs_with_fees(1u << 20);
+        EXPECT_EQ(sel.size(), 1u)
+            << "sigop cap `>=` at 40'000 must stop selection at one such tx";
+    }
+}


### PR DESCRIPTION
## What

Make the embedded DASH block-template selector pick the **same tx SET in the same ORDER** as dashd `BlockAssembler::CreateNewBlock` for the same tip+mempool, so the embedded `hashMerkleRoot` matches dashd's and `--embedded-serve-mempool-txs` swaps to the dashd fallback **less often** (fewer `gbt-xcheck-txmerkle-mismatch` swaps).

**%-not-safety.** The reward-safety guard already landed (PR #1218, cause `gbt-xcheck-txmerkle-mismatch`, fails closed to dashd on ANY tx-body / merkle divergence). This change can only *lower swap frequency*, never make a bad block ship. It is still money-path selection code and stays consensus-valid.

## The three divergences ported (`src/impl/dash/coin/mempool.hpp`)

- **D1 — ancestor-score primary key.** Sort by `min(self-feerate, whole-ancestor-package feerate)` — dashd `CompareTxMemPoolEntryByAncestorFee` / `GetModFeeAndSize` (`src/txmempool.h:274-312`). A local ancestor-score index is built per template beside the untouched persistent `m_feerate_index`; the `FeeKey` struct + `operator<` are reused verbatim (same division-free cross-multiply + txid tiebreak), only the `(fee,size)` values fed in change.
- **D2 — `mapModifiedTx` descendant re-scoring.** As ancestors are included, a tx's **transitive** descendants re-compete at their now-lighter remaining-package feerate — dashd `addPackageTxs` + `UpdatePackagesForAdded` (`src/node/miner.cpp:415-440,493-640`). Each mod entry is seeded **once** from static totals and each in-block ancestor subtracts its fee/size exactly once.
- **D3 — `SortForBlock` emit order.** Each accepted package is emitted by static `GetCountWithAncestors()` ascending, then txid ascending (`src/node/miner.cpp:442-451`, `src/node/miner.h:104-112`) — a valid topological order that fixes the within-package `vtx` order so an *identical SET* produces dashd's `hashMerkleRoot`.

## Preserved byte-for-byte (verified)

- `FeeKey` cross-multiply + txid tiebreak — **untouched**.
- **No-package pure-feerate path**: a tx with no in-pool ancestors has `size_wa==base_size`, `modfee_wa==fee`, `count_wa==1`, so its ancestor-score key `==` its old `FeeKey` bit-for-bit and its singleton package sorts as a no-op. A flat mempool selects byte-identically to today (KAT K7).
- The validation/cap block (byte strict `>`, sigop `>=` at `DASH_MAX_BLOCK_SIGOPS`, coinbase maturity, islock, `exclude_special`, in-package parent resolution) is **LIFTED unchanged** into the new loop body.
- `collect_package_locked` stays the **authoritative** topology/ancestor-limit gate (`over_limit` is only a candidate filter, never the sole drop).
- The type-6 quorum prepend + pinned splice in `embedded_gbt.hpp` only ever see a reordered `SelectedTx` vector.
- Persistent `m_feerate_index` add/remove maintenance is untouched, so mempool mutation paths cannot regress.

## Known residual divergences (documented; absorbed by the #1218 guard)

- `blockMinFeeRate` early-return (`miner.cpp:584`) is **unported** — embedded admits every `fee_known` tx incl. `fee==0`, a *superset* of dashd whenever a sub-min-feerate tx is in the pool.
- dashd's `nConsecutiveFailed>1000` cutoff (`miner.cpp:600`) is deliberately dropped (continue-always keeps a superset-safe scan).

Neither can ship an invalid block; the guard still fails closed on the resulting merkle divergence.

## Tests — `test/test_dash_mempool.cpp` (`DashMempoolSelectionFidelity`)

| KAT | Covers | pre-port | after |
|-----|--------|----------|-------|
| K1 | D1 min-of-two ordering | **RED** | GREEN |
| K3 | D2 `mapModifiedTx` re-score near the byte cap (admitted SET) | **RED** | GREEN |
| K5 | D3 within-package emit order (identical SET, merkle-only) | **RED** | GREEN |
| K2 | ancestor-free parent not dragged down | GREEN | GREEN |
| K4 | D2 transitive descendant re-score (RC1 fence) | GREEN | GREEN |
| K6 | linear-chain no-op emit | GREEN | GREEN |
| K7 | no-ancestor pure-feerate path byte-preserved | GREEN | GREEN |
| K8 | cap boundaries (`>` byte / `>=` sigop) | GREEN | GREEN |

Red-on-master proven by running the new KATs against the pre-port selector (K1/K3/K5 fail, the fences pass). Full `test_dash_mempool` **54/54** and the serve-path `test_dash_embedded_gbt` **280/280** green with **real BLS** (`C2POOL_DASH_BLS=ON`); the `dash_stratum` launcher builds with real BLS.

Not draft. Do not merge — review pending.