### PR TITLE
web: HTML shells must revalidate — stop caching the dashboard page for an hour

### DIFF
--- a/src/core/http_session.cpp
+++ b/src/core/http_session.cpp
@@ -951,7 +951,14 @@ void HttpSession::process_request()
                         // duplicate buttons on pages that had both mechanisms.
 
                         response.set(http::field::content_type, mime);
-                        response.set(http::field::cache_control, "public, max-age=3600");
+                        // HTML entry points must always revalidate. Caching the shell for an
+                        // hour meant a plain browser refresh kept serving a stale dashboard
+                        // after any update or redeploy. Static assets (js/css/img/map) keep
+                        // the long cache; only the .html/.htm shells get no-cache.
+                        if (ext == ".html" || ext == ".htm")
+                            response.set(http::field::cache_control, "no-cache");
+                        else
+                            response.set(http::field::cache_control, "public, max-age=3600");
                         response.body() = std::move(contents);
                         response.prepare_payload();
                         send_response(std::move(response));


### PR DESCRIPTION
The static file handler in `src/core/http_session.cpp` set `Cache-Control: public, max-age=3600` on **every** served file — including the HTML entry points (`dashboard.html`, `index.html`, `share.html`).

**Symptom:** a plain browser refresh serves the cached HTML shell for up to an hour, so after any dashboard update or node redeploy the user keeps seeing the *stale* page — which reads as "the graph / features are missing" until the cache happens to expire. Verified live: `GET /dashboard.html` returns `Cache-Control: public, max-age=3600` on both the hotel primary (:8080) and voidbind (via Caddy).

**Fix:** serve `.html`/`.htm` with `Cache-Control: no-cache` (always revalidate); static assets (`js`/`css`/`img`/`woff`/`map`) keep the long cache. Uses the same `ext`-based dispatch already present in the handler (mime block just above).

Frontend-only behavioural change to the served headers; no consensus/reward path touched. Coin-generic (LTC/DASH/etc all use this handler).