### PR TITLE
release.yml(windows): self-install Inno Setup 6 so setup.exe ships every run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -672,11 +672,27 @@ jobs:
           name: pkg-windows-${{ matrix.coin }}
           path: c2pool-*-windows-x86_64.zip
 
-      # Installer is a NICE-TO-HAVE: the portable .zip (uploaded above) is the
-      # must-have deliverable. If Inno Setup is unavailable on the runner (e.g.
-      # VM217 where choco cannot write C:\ProgramData\chocolatey\lib-bad), warn
-      # and skip so the job still succeeds and the .zip ships. Durable fix is a
-      # persistent Inno Setup 6 install on the runner (ISCC on PATH).
+      # Ensure Inno Setup 6 is present. choco is broken on VM217 (cannot write
+      # C:\ProgramData\chocolatey\lib-bad), so install directly from jrsoftware
+      # via the official silent installer. The self-hosted runner persists it
+      # across jobs, so after the first run this is a fast no-op.
+      - name: Ensure Inno Setup 6 (for setup.exe installer)
+        if: steps.presence.outputs.exists == '1'
+        shell: pwsh
+        run: |
+          $iscc = "C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
+          if (Test-Path $iscc) { Write-Host "Inno Setup already installed: $iscc"; exit 0 }
+          Write-Host "Inno Setup not found; installing from jrsoftware.org ..."
+          $out = Join-Path $env:RUNNER_TEMP "innosetup-6.exe"
+          Invoke-WebRequest -Uri "https://jrsoftware.org/download.php/is.exe" -OutFile $out -UseBasicParsing
+          Start-Process -FilePath $out -ArgumentList '/VERYSILENT','/SUPPRESSMSGBOXES','/NORESTART','/SP-','/NOICONS' -Wait -NoNewWindow
+          if (-not (Test-Path $iscc)) { throw "Inno Setup install failed: ISCC.exe not found at $iscc" }
+          Write-Host "Inno Setup installed: $iscc"
+
+      # The portable .zip (uploaded above) is the must-have; the installer is
+      # built on top of it. With Inno Setup guaranteed by the step above, this
+      # now produces setup.exe on every run. continue-on-error is kept so an
+      # unexpected ISCC failure still ships the .zip rather than failing the cell.
       - name: Build setup.exe installer (Inno Setup)
         if: steps.presence.outputs.exists == '1'
         shell: cmd
@@ -684,11 +700,7 @@ jobs:
         run: |
           set "ISCC=C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
           if not exist "%ISCC%" (
-            echo Inno Setup not found; attempting install via chocolatey...
-            choco install innosetup -y --no-progress || echo WARNING: choco install innosetup failed
-          )
-          if not exist "%ISCC%" (
-            echo ::warning::Inno Setup unavailable on this runner; skipping setup.exe. Portable .zip already uploaded.
+            echo ::warning::Inno Setup unexpectedly absent after install step; skipping setup.exe. Portable .zip already uploaded.
             exit /b 0
           )
           set "PKG=c2pool-${{ matrix.coin }}-${{ steps.ver.outputs.version }}-windows-x86_64"


### PR DESCRIPTION
The Windows release cells have never produced the `setup.exe` installer — only the portable `.zip`. The installer step tried `choco install innosetup`, but choco is broken on the `c2pool-windows-217` (VM217) self-hosted runner (cannot write `C:\ProgramData\chocolatey\lib-bad`), so it always warned-and-skipped.

**Fix:** a dedicated `pwsh` step silently installs the official Inno Setup 6 from `jrsoftware.org` (`is.exe`, latest 6.x) when `ISCC.exe` is absent. The self-hosted runner persists the install across jobs, so after the first run it is a fast no-op. The build step keeps `continue-on-error` so an unexpected ISCC failure still ships the `.zip`.

Effect: every Windows cell now emits `c2pool-<coin>-<ver>-windows-x86_64-setup.exe` alongside the portable `.zip`. `.dmg` (macOS) was already produced.