### PR TITLE
dash/mempool: port dashd blockMinFeeRate early-return + nConsecutiveFailed cutoff (#133)

### DIFF
--- a/src/impl/dash/coin/mempool.hpp
+++ b/src/impl/dash/coin/mempool.hpp
@@ -65,6 +65,7 @@
 #include <core/coin/utxo_view_cache.hpp>
 
 #include <atomic>
+#include <cmath>                 // block_min_fee_for_size: dashd CFeeRate::GetFee std::ceil
 #include <functional>
 #include <cstdint>
 #include <ctime>
@@ -132,6 +133,19 @@ public:
     static constexpr size_t DEFAULT_MAX_BYTES   = 300ULL * 1024 * 1024;
     static constexpr time_t DEFAULT_EXPIRY_SECS = 14 * 24 * 3600;
 
+    /// dashd DEFAULT_BLOCK_MIN_TX_FEE (src/policy/policy.h:25) — the minimum
+    /// ancestor-package feerate, in duffs per 1000 bytes, below which
+    /// BlockAssembler::addPackageTxs stops adding transactions (miner.cpp:69,
+    /// blockMinFeeRate = CFeeRate(DEFAULT_BLOCK_MIN_TX_FEE)). This is the
+    /// canonical dashd default: keeping it here makes the embedded selection
+    /// terminate at the SAME floor as dashd's own miner out of the box.
+    static constexpr int64_t DEFAULT_BLOCK_MIN_TX_FEE = 1000;
+
+    /// dashd BlockAssembler MAX_CONSECUTIVE_FAILURES (src/node/miner.cpp:490):
+    /// once this many packages in a row fail the byte/sigop caps AND the block
+    /// is within 1000 bytes of full, addPackageTxs gives up scanning.
+    static constexpr int64_t MAX_CONSECUTIVE_FAILURES = 1000;
+
     explicit Mempool(size_t max_bytes  = DEFAULT_MAX_BYTES,
                      time_t expiry_sec = DEFAULT_EXPIRY_SECS)
         : m_max_bytes(max_bytes)
@@ -142,6 +156,23 @@ public:
     Mempool& operator=(const Mempool&) = delete;
 
     void set_utxo(::core::coin::UTXOViewCache* u) { m_utxo.store(u); }
+
+    /// blockmintxfee-equivalent knob (dashd -blockmintxfee / BlockAssembler
+    /// Options::blockMinFeeRate, miner.cpp:100). Sets the min ancestor-package
+    /// feerate in duffs/kB used by the blockMinFeeRate early-return in
+    /// get_sorted_txs_with_fees. DEFAULT_BLOCK_MIN_TX_FEE (1000) matches
+    /// canonical dashd; callers may lower it (e.g. 0 to disable the floor) or
+    /// raise it. Locked because the selector reads it under m_mutex.
+    void set_block_min_tx_fee(int64_t duff_per_k)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_block_min_tx_fee = duff_per_k;
+    }
+    int64_t block_min_tx_fee() const
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_block_min_tx_fee;
+    }
 
     /// ── PINNED-LOCAL-TX include gate (donation-dust consolidation lane) ────
     /// A pinned tx is an operator-supplied, externally-signed, ZERO-fee
@@ -764,6 +795,11 @@ public:
         // re-scored mapModifiedTx (mod_score) — scored on the SAME min-of-two
         // basis (FeeKey::operator<), so a CPFP descendant re-competes at its
         // lighter remaining-package feerate once an ancestor is included.
+        // PORT 2 (dashd miner.cpp:491): consecutive cap-failure counter — the
+        // give-up heuristic that stops scanning once the block is nearly full
+        // and nothing is fitting. Reset to 0 on each admitted package (:625).
+        int64_t nConsecutiveFailed = 0;
+
         auto mi = anc_index.begin();
         while (mi != anc_index.end() || !mod_by_txid.empty()) {
             // (a) SKIP GUARD (dashd :507-514): a mapTx entry already staged in
@@ -801,6 +837,50 @@ public:
             if (selected.count(txid) || m_pool.find(txid) == m_pool.end()) {
                 if (using_mod) erase_mod(txid);
                 continue;
+            }
+
+            // (d.5) PORT 1: blockMinFeeRate EARLY-RETURN (dashd
+            //     miner.cpp:576-587). Take the winning candidate's
+            //     WHOLE-ancestor-package feerate — dashd's packageFees =
+            //     GetModFeesWithAncestors(), packageSize = GetSizeWithAncestors()
+            //     (the modified totals when the pick came from mapModifiedTx) —
+            //     and stop the WHOLE loop once it drops below the min feerate.
+            //
+            //     SOURCE-OF-FEE/SIZE (money-path, get this exactly right): use
+            //     the SAME ancestor tables that KEYED the ancestor_score index —
+            //       * mapTx pick : anc.modfee_wa/anc.size_wa (full static totals)
+            //       * mod pick   : the ModEntry's mod_modfee_wa/mod_size_wa
+            //         (static-minus-in-block-ancestors, dashd nModFeesWithAncestors)
+            //     NOT collect_package_locked's pkg_fees/pkg_bytes remainder: that
+            //     is only the UNSELECTED-ancestor subset, a higher feerate, and
+            //     gating on it would drop higher-fee txs = revenue loss.
+            //
+            //     WHOLE-package feerate, NOT the min-of-two anc_score key: dashd
+            //     SORTS by min(self, ancestor-package) but GATES on the whole
+            //     ancestor-package feerate. We mirror that split exactly.
+            //
+            //     `return`, NEVER `continue`: both candidate indices are sorted
+            //     by ancestor score descending and `txid` is the best of the two,
+            //     so once this pick is sub-floor everything remaining is too —
+            //     dashd's "Everything else we might consider has a lower fee
+            //     rate". min-fee is POLICY, not consensus: the worst case of
+            //     over-including (floor set too low) is a valid, fee-suboptimal
+            //     block, never an invalid/orphaned one.
+            {
+                uint64_t fee_wa;
+                uint32_t size_wa;
+                if (using_mod) {
+                    const ModEntry& me = mod_by_txid.at(txid);
+                    fee_wa  = me.mod_modfee_wa;
+                    size_wa = me.mod_size_wa;
+                } else {
+                    fee_wa  = anc.modfee_wa.at(txid);
+                    size_wa = anc.size_wa.at(txid);
+                }
+                if (static_cast<int64_t>(fee_wa)
+                        < block_min_fee_for_size(m_block_min_tx_fee, size_wa)) {
+                    return {std::move(result), total_fees};
+                }
             }
 
             // (e) BUILD PACKAGE. collect_package_locked stays the AUTHORITATIVE
@@ -923,18 +1003,39 @@ public:
             }
             (void)pkg_fees;   // accounted below via per-entry e->fee
 
-            // ── (g) Caps — LIFTED UNCHANGED. Byte cap strict `>`, sigop cap
-            // `>=` (reject AT the cap). `continue` never `break`: a later,
-            // smaller candidate may still fit (superset-safe scan; dashd's
-            // nConsecutiveFailed>1000 cutoff is deliberately NOT ported —
-            // design-review RC5). Only a mapModifiedTx pick is erased+failed
-            // (dashd :590-596); a mapTx pick already had `mi` advanced. ──────
+            // ── (g) Caps. Byte cap strict `>`, sigop cap `>=` (reject AT the
+            // cap). Each cap failure is one dashd TestPackage() failure
+            // (miner.cpp:359-368 tests byte AND sigop caps together): only a
+            // mapModifiedTx pick is erased+failed (dashd :590-596); a mapTx pick
+            // already had `mi` advanced.
+            //
+            // PORT 2: nConsecutiveFailed cutoff (dashd miner.cpp:598-603). Each
+            // cap-fail bumps the counter; once >1000 consecutive fails AND the
+            // block is within 1000 bytes of the cap, dashd stops scanning
+            // (`break`) — nothing more will fit. `continue` otherwise (a later,
+            // smaller candidate may still fit — superset-safe). Near-no-op for
+            // DASH's block sizes but ported for exact addPackageTxs parity. The
+            // give-up test uses int64 arithmetic so `max_bytes - 1000` cannot
+            // underflow when max_bytes < 1000 (dashd's nBlockMaxSize is clamped
+            // >=1000, miner.cpp:212; ours is a caller-supplied param).
             if (total_bytes + pkg_bytes > max_bytes) {
                 if (using_mod) { erase_mod(txid); failed.insert(txid); }
+                ++nConsecutiveFailed;
+                if (nConsecutiveFailed > MAX_CONSECUTIVE_FAILURES
+                    && static_cast<int64_t>(total_bytes)
+                           > static_cast<int64_t>(max_bytes) - 1000) {
+                    break;
+                }
                 continue;
             }
             if (total_sigops + pkg_sigops >= DASH_MAX_BLOCK_SIGOPS) {
                 if (using_mod) { erase_mod(txid); failed.insert(txid); }
+                ++nConsecutiveFailed;
+                if (nConsecutiveFailed > MAX_CONSECUTIVE_FAILURES
+                    && static_cast<int64_t>(total_bytes)
+                           > static_cast<int64_t>(max_bytes) - 1000) {
+                    break;
+                }
                 continue;
             }
 
@@ -942,6 +1043,11 @@ public:
             // re-orders the SAME members before emit → within-package
             // hashMerkleRoot parity. This vector order flows unchanged into
             // embedded_gbt.hpp's vtx. ────────────────────────────────────────
+            //
+            // PORT 2: this package makes it in — reset the consecutive-failure
+            // counter ONCE per admitted PACKAGE (dashd miner.cpp:625, before
+            // SortForBlock), not per-tx.
+            nConsecutiveFailed = 0;
             sort_package_for_block(package, anc);
             for (const auto* e : package) {
                 selected.insert(e->txid);
@@ -1010,6 +1116,11 @@ private:
     size_t                                             m_total_bytes{0};
     size_t                                             m_max_bytes;
     time_t                                             m_expiry_sec;
+    // PORT 1: blockmintxfee-equivalent floor (duff/kB) for the blockMinFeeRate
+    // early-return in get_sorted_txs_with_fees. Default = canonical dashd
+    // DEFAULT_BLOCK_MIN_TX_FEE. Read under m_mutex (selector holds it); written
+    // via set_block_min_tx_fee (also under the lock).
+    int64_t                                            m_block_min_tx_fee{DEFAULT_BLOCK_MIN_TX_FEE};
     std::atomic<::core::coin::UTXOViewCache*>          m_utxo{nullptr};
     // Second-source coin lookup for the PINNED-TX gate only (see
     // set_external_coin_lookup). Set once at wiring time, before any template
@@ -1100,6 +1211,25 @@ private:
     /// (txmempool.h:297-311): return the (fee,size) of the SMALLER feerate of
     /// {self, whole-ancestor-package}, using the same division-free
     /// cross-multiply as FeeKey::operator< (no pre-divided double).
+    /// dashd CFeeRate::GetFee (src/policy/feerate.cpp:23-37): the minimum fee,
+    /// in duffs, that `num_bytes` must pay at `sat_per_k` duff/kB. Reproduces
+    /// dashd EXACTLY: ceil of the double quotient (nSatoshisPerK*nSize/1000.0),
+    /// plus the round-up-to-1 floor when a nonzero size would otherwise truncate
+    /// to a zero fee. The int64 product matches dashd's `nSatoshisPerK * nSize`
+    /// (evaluated before the /1000.0 promotes to double); block sizes keep it
+    /// far from int64 overflow.
+    static int64_t block_min_fee_for_size(int64_t sat_per_k, uint64_t num_bytes)
+    {
+        const int64_t n_size = static_cast<int64_t>(num_bytes);
+        int64_t n_fee = static_cast<int64_t>(
+            std::ceil(static_cast<double>(sat_per_k * n_size) / 1000.0));
+        if (n_fee == 0 && n_size != 0) {
+            if (sat_per_k > 0) n_fee = 1;
+            else if (sat_per_k < 0) n_fee = -1;
+        }
+        return n_fee;
+    }
+
     static FeeKey anc_score_key(uint64_t self_fee, uint32_t self_size,
                                 uint64_t modfee_wa, uint32_t size_wa,
                                 const uint256& txid)

--- a/test/test_dash_mempool.cpp
+++ b/test/test_dash_mempool.cpp
@@ -27,6 +27,7 @@
 #include <core/coin/utxo_view_cache.hpp>
 
 #include <algorithm>
+#include <cmath>       // gate #133 KATs: independent dashd CFeeRate::GetFee ceil reference
 #include <cstdint>
 #include <set>
 #include <vector>
@@ -1399,4 +1400,268 @@ TEST(DashMempoolSelectionFidelity, K8_CapsBoundariesPreserved)
         EXPECT_EQ(sel.size(), 1u)
             << "sigop cap `>=` at 40'000 must stop selection at one such tx";
     }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Gate #133 — the two remaining dashd BlockAssembler::addPackageTxs residuals
+// ported into get_sorted_txs_with_fees:
+//   PORT 1  blockMinFeeRate early-return   (dashd src/node/miner.cpp:584-587)
+//   PORT 2  nConsecutiveFailed cutoff       (dashd src/node/miner.cpp:490-491,
+//                                            598-603, 625)
+//
+// Expected values are derived ONLY from dashd source constants:
+//   DEFAULT_BLOCK_MIN_TX_FEE = 1000   (src/policy/policy.h:25)
+//   CFeeRate::GetFee(size)   = ceil(sat_per_k * size / 1000.0), rounded up to 1
+//                              for a nonzero size (src/policy/feerate.cpp:23-37)
+//   MAX_CONSECUTIVE_FAILURES = 1000   (src/node/miner.cpp:490)
+// ════════════════════════════════════════════════════════════════════════════
+
+// Independent KAT reference for dashd CFeeRate::GetFee — a SECOND, hand-written
+// implementation (never a call into the header under test) so a regression in
+// mempool.hpp's own copy cannot mask itself.
+static int64_t kat_min_fee(int64_t sat_per_k, uint64_t num_bytes) {
+    const int64_t n = static_cast<int64_t>(num_bytes);
+    int64_t fee = static_cast<int64_t>(
+        std::ceil(static_cast<double>(sat_per_k * n) / 1000.0));
+    if (fee == 0 && n != 0 && sat_per_k > 0) fee = 1;
+    return fee;
+}
+
+// Add a plain 1-in/1-out tx paying EXACTLY `fee` duffs. Seeds a fresh confirmed
+// coin (100'000'000) for the input so the fee is KNOWN. `seed` must be unique
+// within a test. Returns the txid. (The value magnitude never changes the
+// serialized size — TxOut.value is a fixed-width field — so `fee` is free to
+// vary independently of the base size the floor is computed from.)
+static uint256 add_priced(Mempool& mp, UTXOViewCache& utxo, uint32_t seed,
+                          int64_t fee) {
+    uint256 prev = mint_hash(seed);
+    utxo.add_coin(Outpoint(prev, 0), Coin(100'000'000, {}, 1, false));
+    auto tx = make_spend(prev, 0, 100'000'000 - fee, /*salt=*/seed);
+    EXPECT_TRUE(mp.add_tx(tx));
+    return dash_txid(tx);
+}
+
+// Serialized base size of a plain 1-in/1-out make_spend tx, measured at runtime.
+static uint32_t one_in_one_out_size() {
+    UTXOViewCache utxo(nullptr);
+    Mempool mp; mp.set_utxo(&utxo);
+    uint256 tid = add_priced(mp, utxo, /*seed=*/40'000, /*fee=*/1'000);
+    return mp.get_entry(tid)->base_size;
+}
+
+// ── PORT 1: blockMinFeeRate ──────────────────────────────────────────────────
+
+TEST(DashMempoolBlockMinFeeRate, DefaultFloorIsCanonicalDashd1000)
+{
+    {
+        UTXOViewCache utxo(nullptr); Mempool mp; mp.set_utxo(&utxo);
+        EXPECT_EQ(mp.block_min_tx_fee(), 1000)
+            << "the knob must default to dashd DEFAULT_BLOCK_MIN_TX_FEE";
+    }
+    EXPECT_EQ(Mempool::DEFAULT_BLOCK_MIN_TX_FEE, 1000);
+
+    const uint32_t S = one_in_one_out_size();
+    const int64_t floor = kat_min_fee(1000, S);        // == S at perK 1000
+    ASSERT_EQ(floor, static_cast<int64_t>(S));
+
+    // fee == floor : INCLUDED (the gate is strict `<`, not `<=`).
+    {
+        UTXOViewCache utxo(nullptr); Mempool mp; mp.set_utxo(&utxo);
+        uint256 tid = add_priced(mp, utxo, 41'000, /*fee=*/floor);
+        EXPECT_EQ(sel_set(mp, 1u << 20).count(tid), 1u)
+            << "a package paying EXACTLY the floor must be included";
+    }
+    // fee == floor-1 : EXCLUDED, and selection returns empty.
+    {
+        UTXOViewCache utxo(nullptr); Mempool mp; mp.set_utxo(&utxo);
+        uint256 tid = add_priced(mp, utxo, 41'001, /*fee=*/floor - 1);
+        auto got = sel_set(mp, 1u << 20);
+        EXPECT_EQ(got.count(tid), 0u)
+            << "a sub-floor package must be excluded by blockMinFeeRate";
+        EXPECT_TRUE(got.empty()) << "the sub-floor best candidate must RETURN (empty block)";
+    }
+}
+
+TEST(DashMempoolBlockMinFeeRate, CeilBoundaryMatchesDashdGetFee)
+{
+    const uint32_t S = one_in_one_out_size();
+    ASSERT_NE(S % 1000u, 0u) << "test-size assumption for the ceil probe";
+    const int64_t perK = 1001;                          // forces a fractional GetFee
+    const int64_t floor = kat_min_fee(perK, S);         // ceil(1001*S/1000)
+    const int64_t trunc = (perK * static_cast<int64_t>(S)) / 1000;   // floor division
+    ASSERT_EQ(floor, trunc + 1) << "GetFee must ROUND UP here, not truncate";
+
+    // fee == floor-1 (== the truncated value): EXCLUDED — proves CEIL, not floor.
+    {
+        UTXOViewCache utxo(nullptr); Mempool mp; mp.set_utxo(&utxo);
+        mp.set_block_min_tx_fee(perK);
+        uint256 tid = add_priced(mp, utxo, 42'000, /*fee=*/floor - 1);
+        EXPECT_EQ(sel_set(mp, 1u << 20).count(tid), 0u)
+            << "fee one below ceil(perK*size/1000) must be excluded";
+    }
+    // fee == floor : INCLUDED.
+    {
+        UTXOViewCache utxo(nullptr); Mempool mp; mp.set_utxo(&utxo);
+        mp.set_block_min_tx_fee(perK);
+        uint256 tid = add_priced(mp, utxo, 42'001, /*fee=*/floor);
+        EXPECT_EQ(sel_set(mp, 1u << 20).count(tid), 1u)
+            << "fee exactly at the ceil floor must be included";
+    }
+}
+
+TEST(DashMempoolBlockMinFeeRate, KnobRaisesFloorAndExcludes)
+{
+    const uint32_t S = one_in_one_out_size();
+    const int64_t at_default_floor = kat_min_fee(1000, S);   // == S
+
+    // Included at the default floor...
+    {
+        UTXOViewCache utxo(nullptr); Mempool mp; mp.set_utxo(&utxo);
+        uint256 tid = add_priced(mp, utxo, 43'000, /*fee=*/at_default_floor);
+        EXPECT_EQ(sel_set(mp, 1u << 20).count(tid), 1u);
+    }
+    // ...excluded once the knob raises the floor above its feerate.
+    {
+        UTXOViewCache utxo(nullptr); Mempool mp; mp.set_utxo(&utxo);
+        mp.set_block_min_tx_fee(1'000'000);                  // 1000 duff/byte
+        uint256 tid = add_priced(mp, utxo, 43'001, /*fee=*/at_default_floor);
+        EXPECT_EQ(sel_set(mp, 1u << 20).count(tid), 0u)
+            << "raising blockmintxfee must exclude a now-sub-floor tx";
+    }
+}
+
+TEST(DashMempoolBlockMinFeeRate, GatesOnWholeAncestorPackageFeerateNotSelf)
+{
+    // CPFP: a big cheap PARENT + a small CHILD whose SELF feerate is far above
+    // the floor but whose WHOLE ancestor-package feerate (parent+child) is
+    // BELOW it. dashd gates on GetModFeesWithAncestors/GetSizeWithAncestors —
+    // the whole package — so the child is dropped, and because it is the best
+    // remaining candidate the loop RETURNS with an empty block. Gating on the
+    // child's SELF feerate (or on collect_package_locked's unselected-ancestor
+    // remainder) would instead admit BOTH. Default floor perK=1000 →
+    // floor(size)=size duffs.
+    UTXOViewCache utxo(nullptr); Mempool mp; mp.set_utxo(&utxo);
+    uint256 coinP = mint_hash(44'000);
+    utxo.add_coin(Outpoint(coinP, 0), Coin(100'000'000, {}, 1, false));
+
+    // Parent: padded ~2 KB, fee only 50 → deeply sub-floor on its own.
+    auto parent = make_spend_padded(coinP, 0, 100'000'000 - 50, /*salt=*/44'000, /*pad=*/2000);
+    ASSERT_TRUE(mp.add_tx(parent));
+    const uint32_t Sp = mp.get_entry(dash_txid(parent))->base_size;
+
+    // Child spends parent:0; small 1-in/1-out with a HIGH self fee (500).
+    auto child = make_spend(dash_txid(parent), 0, (100'000'000 - 50) - 500, /*salt=*/44'001);
+    ASSERT_TRUE(mp.add_tx(child));
+    const uint32_t Sc = mp.get_entry(dash_txid(child))->base_size;
+
+    // Pin the intended regime from the MEASURED sizes:
+    ASSERT_GE(int64_t(500), kat_min_fee(1000, Sc))            // child SELF >= its own floor
+        << "child self feerate must be ABOVE the floor";
+    ASSERT_LT(int64_t(50 + 500), kat_min_fee(1000, Sp + Sc))  // package < package floor
+        << "whole (parent+child) package feerate must be BELOW the floor";
+
+    EXPECT_TRUE(sel_set(mp, 1u << 20).empty())
+        << "child gated on WHOLE-package feerate (sub-floor) → dropped; as the "
+           "best candidate its verdict RETURNS an empty selection. A self- or "
+           "remainder-feerate gate would wrongly admit {parent, child}.";
+}
+
+// ── PORT 2: nConsecutiveFailed ───────────────────────────────────────────────
+
+TEST(DashMempoolConsecutiveFailed, BreaksAfter1000FailuresNearCap)
+{
+    // Isolate the cutoff from the fee floor (perK=0 → floor never fires). One
+    // high-fee FILL takes the block within <1000 bytes of the cap; >1000
+    // higher-priority fillers then each overflow the byte cap (continue +
+    // ++nConsecutiveFailed) until the cutoff BREAKS the loop — so a later,
+    // lowest-fee tx that WOULD fit is never reached.
+    UTXOViewCache utxo(nullptr); Mempool mp; mp.set_utxo(&utxo);
+    mp.set_block_min_tx_fee(0);
+
+    uint256 coinF = mint_hash(50'000);
+    utxo.add_coin(Outpoint(coinF, 0), Coin(100'000'000, {}, 1, false));
+    auto FILL = make_spend_padded(coinF, 0, 100'000'000 - 5'000'000, /*salt=*/50'000, /*pad=*/4200);
+    ASSERT_TRUE(mp.add_tx(FILL));
+    const uint32_t Sf = mp.get_entry(dash_txid(FILL))->base_size;
+    const uint32_t max_bytes = Sf + 700;              // 700B room after FILL: <1000 (near cap)
+
+    for (uint32_t i = 0; i < 1002; ++i) {             // >1000 fillers, each ~1KB > 700B room
+        uint256 prev = mint_hash(50'010 + i);
+        utxo.add_coin(Outpoint(prev, 0), Coin(100'000'000, {}, 1, false));
+        auto f = make_spend_padded(prev, 0, 100'000'000 - 100'000, /*salt=*/50'010 + i, /*pad=*/950);
+        ASSERT_TRUE(mp.add_tx(f));
+    }
+    uint256 finalTid = add_priced(mp, utxo, 52'000, /*fee=*/50);   // tiny, LOWEST feerate
+
+    auto got = sel_set(mp, max_bytes);
+    EXPECT_EQ(got.count(dash_txid(FILL)), 1u);
+    EXPECT_EQ(got.count(finalTid), 0u)
+        << "nConsecutiveFailed>1000 within 1000B of the cap must BREAK before "
+           "the later fitting tx is reached";
+    EXPECT_EQ(got.size(), 1u)
+        << "only FILL fits; fillers overflow, FINAL is cut off by the break";
+}
+
+TEST(DashMempoolConsecutiveFailed, NoBreakWhenNotNearCapSigopFailures)
+{
+    // >1000 consecutive failures that are NOT byte-cap failures: each filler
+    // alone exceeds the 40'000 sigop cap. Because total_bytes stays far below
+    // max_bytes-1000, the give-up guard is FALSE and the loop does NOT break —
+    // a later low-sigop tx is still reached and selected.
+    UTXOViewCache utxo(nullptr); Mempool mp; mp.set_utxo(&utxo);
+    mp.set_block_min_tx_fee(0);
+    const uint32_t max_bytes = 8u << 20;              // 8 MB: byte room always ample
+
+    for (uint32_t i = 0; i < 1002; ++i) {
+        uint256 prev = mint_hash(60'000 + i);
+        utxo.add_coin(Outpoint(prev, 0), Coin(100'000'000, {}, 1, false));
+        auto f = make_spend(prev, 0, 100'000'000 - 100'000, /*salt=*/60'000 + i);
+        f.vout[0].scriptPubKey.m_data.assign(2'000, 0xae);   // 2'000×20 = 40'000 legacy sigops
+        ASSERT_TRUE(mp.add_tx(f));
+    }
+    uint256 finalTid = add_priced(mp, utxo, 61'100, /*fee=*/50);   // 0-sigop, LOWEST feerate
+
+    auto got = sel_set(mp, max_bytes);
+    EXPECT_EQ(got.count(finalTid), 1u)
+        << "sigop-cap failures far from the byte cap must NOT trigger the "
+           "near-cap break: the later fitting tx is still selected";
+    EXPECT_EQ(got.size(), 1u)
+        << "every sigop-stuffed filler is rejected AT the cap; only FINAL admits";
+}
+
+TEST(DashMempoolConsecutiveFailed, ResetPerAdmittedPackagePreventsBreak)
+{
+    // The counter resets on every ADMITTED package. Two runs of 600 byte-cap
+    // failures each (1200 > 1000 total) are separated by ONE admitted tx that
+    // resets the counter — so it never reaches 1001 IN A ROW and the loop does
+    // NOT break: a final fitting tx is still selected. Without the reset the
+    // 1200 cumulative failures near the cap would break and cut it off.
+    UTXOViewCache utxo(nullptr); Mempool mp; mp.set_utxo(&utxo);
+    mp.set_block_min_tx_fee(0);
+
+    uint256 coinF = mint_hash(55'000);
+    utxo.add_coin(Outpoint(coinF, 0), Coin(100'000'000, {}, 1, false));
+    auto FILL = make_spend_padded(coinF, 0, 100'000'000 - 9'000'000, /*salt=*/55'000, /*pad=*/4200);
+    ASSERT_TRUE(mp.add_tx(FILL));
+    const uint32_t Sf = mp.get_entry(dash_txid(FILL))->base_size;
+    const uint32_t max_bytes = Sf + 700;              // near cap (room 700B < 1000)
+
+    // Big fillers ~1KB (> room → byte-cap fail). Feerate tiers pick-order the
+    // run as: FILL, [tierA 600], MID(fits→reset), [tierB 600], FINAL(fits).
+    auto add_big = [&](uint32_t seed, int64_t fee) {
+        uint256 prev = mint_hash(seed);
+        utxo.add_coin(Outpoint(prev, 0), Coin(100'000'000, {}, 1, false));
+        auto f = make_spend_padded(prev, 0, 100'000'000 - fee, /*salt=*/seed, /*pad=*/950);
+        ASSERT_TRUE(mp.add_tx(f));
+    };
+    for (uint32_t i = 0; i < 600; ++i) add_big(55'010 + i, /*fee=*/310'000);   // tierA: ~299/B
+    uint256 midTid = add_priced(mp, utxo, 55'700, /*fee=*/17'000);             // MID: 200/B, fits
+    for (uint32_t i = 0; i < 600; ++i) add_big(56'000 + i, /*fee=*/100'000);   // tierB: ~96/B
+    uint256 finalTid = add_priced(mp, utxo, 56'800, /*fee=*/50);               // FINAL: lowest
+
+    auto got = sel_set(mp, max_bytes);
+    EXPECT_EQ(got.count(midTid), 1u)   << "MID admits and resets the failure counter";
+    EXPECT_EQ(got.count(finalTid), 1u)
+        << "with the per-package reset, 600+600 non-consecutive failures never "
+           "reach 1001 in a row → no break → FINAL is still selected";
 }


### PR DESCRIPTION
Gate #133. Ports the two remaining dashd `BlockAssembler::addPackageTxs` mempool residuals into the embedded tx selector `get_sorted_txs_with_fees` (`src/impl/dash/coin/mempool.hpp`), completing the addPackageTxs parity begun in #131 (D1/D2/D3). Money-path change: correctness prioritised over cleverness; byte-parity with dashd where in doubt.

## PORT 1 — blockMinFeeRate early-return
dashd anchor: `src/node/miner.cpp:576-587`
```cpp
uint64_t packageSize = iter->GetSizeWithAncestors();
CAmount  packageFees = iter->GetModFeesWithAncestors();
if (fUsingModified) { packageSize = modit->nSizeWithAncestors; packageFees = modit->nModFeesWithAncestors; }
if (packageFees < blockMinFeeRate.GetFee(packageSize)) return;   // everything else is lower feerate
```
After the pick-better-of-two resolves the winning candidate (and after the vanished/already-selected discard guard), the candidate's **whole-ancestor-package** feerate is compared against a min-fee floor; below it the whole loop terminates with `return` (never `continue`).

**anc-score source, NOT the remainder (the load-bearing caveat).** `packageFees`/`packageSize` are taken from the same ancestor tables that keyed the `ancestor_score` index:
- mapTx pick → `anc.modfee_wa.at(txid)` / `anc.size_wa.at(txid)` (full static `GetModFeesWithAncestors`/`GetSizeWithAncestors`);
- mapModifiedTx pick → the `ModEntry`'s `mod_modfee_wa`/`mod_size_wa` (static-minus-in-block-ancestors = dashd `nModFeesWithAncestors`).

They are deliberately **not** `collect_package_locked`'s `pkg_fees`/`pkg_bytes` remainder, which is only the *unselected-ancestor subset* — a strictly higher feerate that would let sub-floor higher-fee packages slip the gate and drop revenue.

**Whole-package feerate, not the sort key.** dashd *sorts* the index by `min(self, ancestor-package)` feerate but *gates* on the whole ancestor-package feerate. This port mirrors that split exactly.

**Ceil arithmetic.** The floor is `CFeeRate::GetFee` reproduced exactly from `src/policy/feerate.cpp:23-37`: `ceil(sat_per_k * size / 1000.0)` with the round-up-to-1 for a nonzero size.

**Configurable knob, canonical default.** `perK` is exposed as `set_block_min_tx_fee(int64_t)` / `block_min_tx_fee()` and defaults to `DEFAULT_BLOCK_MIN_TX_FEE = 1000` (dashd `src/policy/policy.h:25`), so behaviour matches canonical dashd out of the box.

**Policy, not consensus.** Min-fee is a policy floor. The worst case of setting it too low is a valid, fee-suboptimal block — never an invalid or orphaned one (no orphan risk; the served set is at worst a superset of dashd's).

## PORT 2 — nConsecutiveFailed cutoff
dashd anchors: `src/node/miner.cpp:490-491` (init, `MAX_CONSECUTIVE_FAILURES = 1000`), `:598-603` (`++` + break), `:625` (reset).
- `int64_t nConsecutiveFailed = 0;` before the loop.
- `++nConsecutiveFailed;` on each cap-fail branch (byte cap and sigop cap — together they are dashd's single `TestPackage`, `miner.cpp:359-368`).
- `if (nConsecutiveFailed > 1000 && total_bytes > max_bytes - 1000) break;` — the near-cap give-up guard, written with int64 casts so `max_bytes - 1000` cannot underflow for small caps (dashd's `nBlockMaxSize` is clamped ≥1000; ours is a caller-supplied param).
- Reset `nConsecutiveFailed = 0;` once per admitted **package** at the admit site, not per-tx.

A near-no-op for DASH block sizes, ported for exact addPackageTxs parity.

## Tests
7 gtest KATs added to `test/test_dash_mempool.cpp`; expected values derived from dashd constants only (`DEFAULT_BLOCK_MIN_TX_FEE=1000`, ceil `GetFee`, `MAX_CONSECUTIVE_FAILURES=1000`) via a hand-written second reference (`kat_min_fee`) that never calls the code under test:

- `DefaultFloorIsCanonicalDashd1000` — knob defaults to 1000; fee `== floor` included, `floor-1` excluded (strict `<`).
- `CeilBoundaryMatchesDashdGetFee` — `perK=1001`; `floor-1` excluded, `floor` included → proves **ceil**, not truncation.
- `KnobRaisesFloorAndExcludes` — the same tx is included at the default floor, excluded once the knob is raised.
- `GatesOnWholeAncestorPackageFeerateNotSelf` — CPFP where child self-feerate is above floor but the whole package is below: selection is empty → proves the gate uses the **whole-package** fee/size (not self / remainder) **and** that a sub-floor best candidate **returns**.
- `BreaksAfter1000FailuresNearCap` — a later fitting tx is cut off once >1000 byte-cap failures occur within 1000 B of the cap.
- `NoBreakWhenNotNearCapSigopFailures` — >1000 sigop-cap failures far from the byte cap do **not** break; the later fitting tx is still selected.
- `ResetPerAdmittedPackagePreventsBreak` — 600+600 failures split by one admitted tx never reach 1001 in a row → no break → the final tx is still selected.

**Build + run (local, incremental):** `cmake --build build --target test_dash_mempool` on this branch at 9f35f808 built clean; `./build/test/test_dash_mempool` → **61/61 pass** (54 pre-existing + 7 new). No regressions in the D1/D2/D3, caps, maturity, or islock tests.

## Out of scope
Capturing live-dashd RC4/RC5 `BlockAssembler` byte-parity goldens is a **separate bench** (needs a running dashd) and is **not** in this PR. TODO: add that golden capture once a dashd RC4/RC5 instance is available, to pin end-to-end template byte-parity across a real mempool.
