### PR TITLE
build(windows): wire secp256k1 recovery module/header so the Windows release builds (#133 follow-up)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1431,7 +1431,13 @@ jobs:
             Remove-Item -Recurse -Force secp256k1-src -ErrorAction SilentlyContinue
             Start-Sleep -Seconds ($i * 5)
           }
-          cmake -B secp256k1-src/build -S secp256k1-src -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${env:GITHUB_WORKSPACE}/secp256k1" -DSECP256K1_BUILD_TESTS=OFF -DSECP256K1_BUILD_EXHAUSTIVE_TESTS=OFF -DSECP256K1_BUILD_BENCHMARK=OFF -DSECP256K1_BUILD_EXAMPLES=OFF
+          # -DSECP256K1_ENABLE_MODULE_RECOVERY=ON: upstream defaults this module
+          # OFF, and with it off the recovery header (secp256k1_recovery.h) is
+          # NOT installed and the recovery symbols are NOT compiled. Linux/macOS
+          # get it from their distro packages (libsecp256k1-dev / brew secp256k1);
+          # this source build must enable it explicitly so spork.hpp's
+          # <secp256k1_recovery.h> resolves and secp256k1_ecdsa_recover* link.
+          cmake -B secp256k1-src/build -S secp256k1-src -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${env:GITHUB_WORKSPACE}/secp256k1" -DSECP256K1_ENABLE_MODULE_RECOVERY=ON -DSECP256K1_BUILD_TESTS=OFF -DSECP256K1_BUILD_EXHAUSTIVE_TESTS=OFF -DSECP256K1_BUILD_BENCHMARK=OFF -DSECP256K1_BUILD_EXAMPLES=OFF
           cmake --build secp256k1-src/build --config Release
           cmake --install secp256k1-src/build --config Release
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -603,7 +603,13 @@ jobs:
             Remove-Item -Recurse -Force secp256k1-src -ErrorAction SilentlyContinue
             Start-Sleep -Seconds ($i * 5)
           }
-          cmake -B secp256k1-src/build -S secp256k1-src -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${env:GITHUB_WORKSPACE}/secp256k1" -DSECP256K1_BUILD_TESTS=OFF -DSECP256K1_BUILD_EXHAUSTIVE_TESTS=OFF -DSECP256K1_BUILD_BENCHMARK=OFF -DSECP256K1_BUILD_EXAMPLES=OFF
+          # -DSECP256K1_ENABLE_MODULE_RECOVERY=ON: upstream defaults this module
+          # OFF, and with it off the recovery header (secp256k1_recovery.h) is
+          # NOT installed and the recovery symbols are NOT compiled. Linux/macOS
+          # get it from their distro packages (libsecp256k1-dev / brew secp256k1);
+          # this source build must enable it explicitly so spork.hpp's
+          # <secp256k1_recovery.h> resolves and secp256k1_ecdsa_recover* link.
+          cmake -B secp256k1-src/build -S secp256k1-src -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="${env:GITHUB_WORKSPACE}/secp256k1" -DSECP256K1_ENABLE_MODULE_RECOVERY=ON -DSECP256K1_BUILD_TESTS=OFF -DSECP256K1_BUILD_EXHAUSTIVE_TESTS=OFF -DSECP256K1_BUILD_BENCHMARK=OFF -DSECP256K1_BUILD_EXAMPLES=OFF
           cmake --build secp256k1-src/build --config Release
           cmake --install secp256k1-src/build --config Release
 


### PR DESCRIPTION
## Root cause

Release run 31473307585 failed on **every Windows coin cell** (Linux + macOS all pass) with:

```
src/impl/dash/coin/spork.hpp(57,10): error C1083: Cannot open include file: 'secp256k1_recovery.h'
```

The Windows CI/release jobs build secp256k1 **from source** (`bitcoin-core/secp256k1`), not from a package. That source build did not enable the recovery module:

- Upstream `CMakeLists.txt:50` — `option(SECP256K1_ENABLE_MODULE_RECOVERY ... OFF)` — the recovery module defaults **OFF**.
- Upstream `src/CMakeLists.txt:47-49` — only *when* that flag is ON is `include/secp256k1_recovery.h` added to the target's `PUBLIC_HEADER` (so installed) **and** `ENABLE_MODULE_RECOVERY=1` set (so the recovery symbols are compiled).
- The base `secp256k1.h` is an **unconditional** `PUBLIC_HEADER`, so `<secp256k1.h>` always resolves — which is exactly why the base include worked on Windows but the recovery header did not.

The Windows configure line was missing the flag:
- `.github/workflows/release.yml:606` (and the identical `.github/workflows/build.yml:1434`) ran `cmake ... -DSECP256K1_BUILD_TESTS=OFF ...` with **no** `-DSECP256K1_ENABLE_MODULE_RECOVERY=ON`.

Linux (`libsecp256k1-dev`, release.yml:114) and macOS (`brew install secp256k1`, release.yml:337) get the recovery module + header from their distro packages, so both compile and link. That is the divergence.

`spork.hpp:213-219` uses `secp256k1_ecdsa_recoverable_signature`, `secp256k1_ecdsa_recoverable_signature_parse_compact`, and `secp256k1_ecdsa_recover` — so without the flag Windows would also **fail at link** even if the header were present. This fix addresses both.

## The fix

Add `-DSECP256K1_ENABLE_MODULE_RECOVERY=ON` to the Windows `Build secp256k1` configure step in **both** `release.yml` and `build.yml`. `spork.hpp` is unchanged — the code was correct; the build wiring was the defect.

## Verified locally (Linux; the MSVC build can only be confirmed by the Windows CI cell)

Built upstream `bitcoin-core/secp256k1` both ways with the exact same options the workflow uses:

- **Recovery OFF (current Windows state):** `secp256k1_recovery.h` is **not** installed to the prefix, and `nm -D` shows **zero** `ecdsa_recover` symbols in the library → reproduces both the C1083 and the latent link failure.
- **Recovery ON (this fix):** `secp256k1_recovery.h` **is** installed, and the library exports `secp256k1_ecdsa_recover`, `secp256k1_ecdsa_recoverable_signature_parse_compact`, `secp256k1_ecdsa_recoverable_signature_convert`, `secp256k1_ecdsa_recoverable_signature_serialize_compact`.
- Confirmed the Linux host's `libsecp256k1-dev` ships `/usr/include/secp256k1_recovery.h`, explaining why Linux/macOS were never affected.

Only the actual MSVC/x64 compile+link of the dash target on the Windows CI runner can give final confirmation.

## Risk to Linux/macOS

None. The change touches only the Windows source-build configure lines. Linux and macOS consume secp256k1 from distro packages (untouched) that already include the recovery module. Enabling a module only adds a header + symbols; it removes nothing.
