### PR TITLE
dash(mnlist): A1-cursor-base — gapless follower / daemonless reseed

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -5104,7 +5104,13 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 // the state needed to build tip+1. Incremental off the last
                 // synced base (ZERO after a reorg = full snapshot); the
                 // new_mnlistdiff subscription advances sml_base on acceptance.
-                if (cp) cp->send_getmnlistd(*sml_base, new_tip);
+                // A1: base = the APPLIED cursor (maintainer->sml_current_hash()),
+                // the block the SML is actually current at — the single source of
+                // truth. A prior overlapping/leaked/base-rejected reply can no
+                // longer strand the request base ahead of the cursor (the
+                // reception-time sml_base tracker's latch); the next advance
+                // re-requests the same contiguous span and is accepted.
+                if (cp && m) cp->send_getmnlistd(m->sml_current_hash(), new_tip);
                 // #739 + stale-payee window close: event-driven stale-work
                 // notify. INVALIDATE the template cache FIRST (mirrors the
                 // #770/#772 fire_refresh trio: invalidate + bump + notify) so the
@@ -5223,7 +5229,11 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 // handshake, target ZERO too — the first tip-change re-requests.
                 auto tip_entry = hc->tip();
                 const uint256 tip = tip_entry ? tip_entry->hash : uint256::ZERO;
-                cp->send_getmnlistd(*sml_base, tip);
+                // A1: base = the APPLIED cursor (single source of truth). At
+                // handshake the maintainer is cold (cursor == ZERO) so this is
+                // the full cold snapshot; a reconnect after some sync re-requests
+                // from exactly what the SML has applied, never a stranded base.
+                cp->send_getmnlistd(maint ? maint->sml_current_hash() : uint256::ZERO, tip);
                 // E-SUPERBLOCK: prime the governance object/vote sync (triggers
                 // + funding votes) so a superblock height can be served
                 // daemonlessly. Zero nProp + empty filter => request all.

--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -127,6 +127,17 @@ public:
     CoinStateMaintainer(const CoinStateMaintainer&) = delete;
     CoinStateMaintainer& operator=(const CoinStateMaintainer&) = delete;
 
+    /// The block hash the applied SML cursor is actually current at — the ONE
+    /// source of truth for the getmnlistd request base. on_mnlistdiff advances
+    /// this (via set_sml_current_hash) only after an accepted, base-contiguous
+    /// apply (:719); on_sml_reorg zeroes it (:865). The tip-advance and
+    /// handshake send paths request base = this hash so base -> target is always
+    /// contiguous with what the SML has actually applied: an overlapping,
+    /// leaked, or base-rejected reply can never strand the request base ahead of
+    /// the cursor (the reception-time tracker's failure mode). Passthrough to
+    /// NodeCoinState::sml_current_hash().
+    const uint256& sml_current_hash() const { return m_state.sml_current_hash(); }
+
     // ── E-SUPERBLOCK: daemonless governance object/vote ingestion ─────────
 
     /// The node-owned governance object/vote store (daemonless superblock payee

--- a/test/test_dash_coin_state_maintainer.cpp
+++ b/test/test_dash_coin_state_maintainer.cpp
@@ -786,6 +786,106 @@ TEST(DashCoinStateMaintainer, MnlistdiffBaseContinuityRejectsMismatchedBase) {
     EXPECT_EQ(st.sml().size(), 3u);
 }
 
+// A1 cursor-derived getmnlistd base: the tip-advance / handshake send paths
+// (main_dash.cpp:5107 / :5226) now derive the getmnlistd request base from
+// CoinStateMaintainer::sml_current_hash() — the block the SML is ACTUALLY
+// current at — instead of the reception-time `sml_base` tracker that advanced
+// on EVERY received diff (accepted or not). This regression-pins the
+// in-flight-overlap latch closed.
+//
+// Scenario (the design's root divergence, no demux leak needed): two tip
+// advances overlap in flight and both request base = cursor0 (ZERO, cold).
+// reply1 (base ZERO -> tip1) is accepted (cursor -> tip1). reply2 (base ZERO
+// -> tip2) BASE-REJECTS at the maintainer because have_at is now tip1 — but a
+// reception-time tracker would still write tip2, stranding the request base
+// AHEAD of the applied cursor. Every later request off that stranded base then
+// re-trips base-continuity and the cursor never moves again (latch).
+//
+// With the base derived from sml_current_hash(): after the rejected reply2 the
+// base source is still tip1 (the applied cursor), so the next advance requests
+// base == tip1 -> a contiguous span that is accepted and advances the cursor.
+TEST(DashCoinStateMaintainer, CursorDerivedBaseSurvivesInFlightOverlapLatch) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+
+    const uint256 TIP1 = raw256(0xA0);
+    const uint256 TIP2 = raw256(0xB0);
+    const uint256 TIP3 = raw256(0xC0);
+
+    // A fake coin_p2p capturing send_getmnlistd(base, target). The captured
+    // base mirrors the FIXED send site exactly: base = m.sml_current_hash().
+    std::vector<std::pair<uint256, uint256>> reqs;
+    auto request = [&](const uint256& target) {
+        const uint256 base = m.sml_current_hash();   // A1 send-site derivation
+        reqs.emplace_back(base, target);
+        return base;
+    };
+    // A model of the RETIRED reception-time tracker: advances on every received
+    // diff regardless of acceptance. Kept only to demonstrate it would strand.
+    uint256 reception_base = uint256::ZERO;
+    auto on_reply = [&](const uint256& base, const uint256& block) {
+        CSimplifiedMNListDiff d;
+        d.baseBlockHash = base;
+        d.blockHash     = block;
+        d.mnList = {sml_entry(0x40)};
+        m.on_mnlistdiff(d);
+        reception_base = block;   // reception-time tracker: writes unconditionally
+    };
+
+    // Two advances overlap in flight: both derive base from the cold cursor
+    // (ZERO) BEFORE either reply lands.
+    ASSERT_EQ(request(TIP1), uint256::ZERO);
+    ASSERT_EQ(request(TIP2), uint256::ZERO);
+
+    // reply1: base ZERO -> tip1, accepted; cursor advances to tip1.
+    on_reply(uint256::ZERO, TIP1);
+    ASSERT_EQ(m.sml_current_hash(), TIP1);
+
+    // reply2: base ZERO -> tip2, BASE-REJECTS (have_at is tip1 now). The cursor
+    // must NOT advance to the stranded reception hash.
+    on_reply(uint256::ZERO, TIP2);
+    EXPECT_EQ(m.sml_current_hash(), TIP1)
+        << "a base-rejected overlapping reply must not advance the applied cursor";
+    // The retired reception-time tracker WOULD have stranded ahead of the
+    // cursor — this is exactly the latch the fix removes.
+    EXPECT_EQ(reception_base, TIP2);
+    EXPECT_NE(reception_base, m.sml_current_hash());
+
+    // Next advance: the FIXED send site derives base from the applied cursor
+    // (tip1), NOT the stranded reception hash (tip2).
+    const uint256 next_base = request(TIP3);
+    EXPECT_EQ(next_base, m.sml_current_hash());
+    EXPECT_EQ(next_base, TIP1) << "base must be the applied cursor, not the stranded reception hash";
+    EXPECT_NE(next_base, reception_base);
+
+    // A diff off that cursor-derived base (tip1 -> tip3) is contiguous and
+    // accepted: the cursor advances, the latch is broken.
+    on_reply(next_base, TIP3);
+    EXPECT_EQ(m.sml_current_hash(), TIP3)
+        << "cursor-derived base yields a contiguous span the maintainer accepts";
+
+    // Counter-model: had the send site used the stranded reception base (tip2),
+    // the same reply would base-reject and the cursor would stay wedged.
+    {
+        NodeCoinState st2;
+        CoinStateMaintainer m2(st2);
+        CSimplifiedMNListDiff cold;
+        cold.baseBlockHash = uint256::ZERO;
+        cold.blockHash     = TIP1;
+        cold.mnList = {sml_entry(0x40)};
+        m2.on_mnlistdiff(cold);
+        ASSERT_EQ(m2.sml_current_hash(), TIP1);
+        CSimplifiedMNListDiff stranded;
+        stranded.baseBlockHash = TIP2;   // the reception-time tracker's stranded base
+        stranded.blockHash     = TIP3;
+        stranded.mnList = {sml_entry(0x41)};
+        m2.on_mnlistdiff(stranded);
+        EXPECT_EQ(m2.sml_current_hash(), TIP1)
+            << "reception-time base (tip2) base-rejects at the maintainer -> the "
+               "cursor stays wedged: this is the latch the A1 fix removes";
+    }
+}
+
 // C-2 chainlock: on_new_chainlock adopts a fresher ChainLock as the CCbTx
 // bestCL* and fires the state-dirty sink; a non-advancing height is ignored.
 TEST(DashCoinStateMaintainer, OnNewChainlockAdoptsForwardOnlyAndFiresDirty) {


### PR DESCRIPTION
## A1-cursor-base — one source of truth for the getmnlistd request base

**Increment key:** `A1-cursor-base` (first, highest-leverage lever of the gapless-follower / daemonless-reseed design).

### Root cause
The daemonless coin-P2P arm keeps the deterministic MN list by a forward-contiguous apply cursor. The steady-state `getmnlistd` request base was derived from a **reception-time** tracker `sml_base` that advances on *every* received mnlistdiff (`main_dash.cpp:3685-3688` writes `*sml_base = d.blockHash` unconditionally) — a second source of truth that can diverge from the applied cursor `NodeCoinState::m_sml_current_hash` (which moves only after an accepted, base-contiguous apply, `coin_state_maintainer.hpp:719`).

Two tip advances overlapping in flight both request `base=cursor0`. reply1 is accepted (cursor and `sml_base` → tip1); reply2 base-rejects at the maintainer, **but its `blockHash` is still written to `sml_base`** — stranding the request base *ahead* of the applied cursor. Every later `send_getmnlistd(*sml_base, …)` then asks a base the cursor is not at, re-trips the base-continuity guard (`:528-541`), and the cursor never advances until a reorg, full resync, or the bounded resync watchdog intervenes.

### Fix (this PR)
Make the request base the applied cursor — the single source of truth:
- add public `CoinStateMaintainer::sml_current_hash()` passthrough to `NodeCoinState::sml_current_hash()`;
- the tip-advance send site (`main_dash.cpp:5107`) and the handshake send site (`:5226`) now derive base from the maintainer cursor instead of `*sml_base`. Both lambdas already capture the maintainer.

**Relaxes no guard; strictly fail-closed.** A rejected diff still declines. The base can no longer be stranded ahead of the cursor, so the next advance re-requests the same contiguous span and is accepted. `sml_base` retains its reorg/handshake/resync writers (retiring it fully is the separate A2 increment, not in scope here).

### Test
`DashCoinStateMaintainer.CursorDerivedBaseSurvivesInFlightOverlapLatch` — fires two overlapping tip advances so reply2 base-rejects; asserts the applied cursor does not advance to the stranded reception hash, that the next request base `== sml_current_hash()`, and that a contiguous diff off it is accepted and advances the cursor. A counter-model asserts the retired reception-time base wedges the cursor.

### Verified locally
- Built `test_dash_coin_state_maintainer` (gcc, conan toolchain) and ran it: **53/53 pass**, including the new test. Runtime logs confirm the exact mechanism (reply2 rejected, cursor stays at tip1, cursor-derived base then accepted).
- AI-attribution scan of the diff and commit message: clean.

Do not merge / no auto-merge — review requested.