### PR TITLE
ci(build): wire zero-test guard into the linux Run tests step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,7 +225,11 @@ jobs:
         shell: bash          # pipefail: a failing ctest must fail the step
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/ci-logs"
-          ctest --output-on-failure -j8 --exclude-regex "LiveTest\." 2>&1 | tee "${GITHUB_WORKSPACE}/ci-logs/run-tests.log"
+          # --no-tests=error: ctest itself fails a zero-test run (belt).
+          # --output-junit: emit the per-case report the floor guard reads.
+          ctest --output-on-failure --no-tests=error --output-junit "${GITHUB_WORKSPACE}/ci-logs/ctest-linux.xml" -j8 --exclude-regex "LiveTest\." 2>&1 | tee "${GITHUB_WORKSPACE}/ci-logs/run-tests.log"
+          # Suspenders: reject a hollow green where the report has < floor cases.
+          bash "${GITHUB_WORKSPACE}/scripts/ci/test_floor_guard.sh" linux "${GITHUB_WORKSPACE}/ci-logs/ctest-linux.xml"
 
       - name: Package release
         if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
Follow-up to #1211 (zero-test guard merged 8d122b76). The guard script shipped but no live ctest step called it, so a lane whose `-R` set collapses to empty still greens over an empty set.

This wires the **main linux Run tests** lane end-to-end:
- `ctest --no-tests=error` — ctest fails a zero-case run itself (belt)
- `ctest --output-junit` — emit the per-case report the guard reads
- `scripts/ci/test_floor_guard.sh linux` — reject a report below the linux floor (10)

**Pilot lane only, on purpose.** This PR CI run is the evidence that the self-hosted linux runner has `jq`, that ctest emits the junit, and that the linux floor clears green on a real matrix — before I fan the same pattern out to the coin-bch / dash-bls / linux-asan lanes (each already keyed in test-floors.json).

Held at merge gate for operator push-approval.