### PR TITLE
dash(serve): fix serve-loop intermittent freeze under tx-serving load

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -6433,8 +6433,10 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // socket timeout + m_rpc_mutex bound this thread). Declared here (after rpc /
     // work_source / stratum_server) so its explicit stop()+join() after the run
     // loop -- and its destructor -- happen BEFORE those objects unwind: no
-    // background probe is ever mid-flight against freed state. Only created on
-    // the fallback arm; null on the embedded arm (legacy inline path unchanged).
+    // background probe is ever mid-flight against freed state. Created on ANY
+    // arm with a dashd rpc armed (#139: see the executor wiring below); the
+    // rpc-less pure-daemonless arm keeps the legacy inline path, which is
+    // non-blocking there (no dashd RPC exists to block on).
     // The opt-in ZMQ subscriber (declared here for the same teardown ordering)
     // only posts onto ioc; when unconfigured/uncompiled the poll is the whole
     // mechanism -- byte-identical to the poll-only #770/#781 behavior.
@@ -6442,19 +6444,50 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     std::unique_ptr<dash::coin::ZmqHashblockSubscriber> zmq_sub;
 #endif
     std::shared_ptr<boost::asio::thread_pool> rpc_pool;
-    if (!coin_p2p && rpc && stratum_server) {
+    if (rpc && stratum_server) {
         rpc_pool = std::make_shared<boost::asio::thread_pool>(1);
 
         // Non-blocking template re-source: cached_work() hands the blocking
-        // select_work()/GBT to rpc_pool as a single-flight background job
-        // instead of blocking the io thread on every stale/generation miss (the
-        // per-share ~15-30 s GBT block). The io thread serves the cached template
-        // immediately; the pool updates it and the next notify picks it up.
+        // GBT to rpc_pool as a single-flight background job instead of blocking
+        // the io thread on every stale/generation miss (the per-share ~15-30 s
+        // GBT block). The io thread serves the cached template immediately; the
+        // pool updates it and the next notify picks it up.
+        //
+        // #139 SERVE-FREEZE FIX: this wiring used to sit under `!coin_p2p`,
+        // so the coin-p2p arm ran the LEGACY INLINE path -- and with --coin-rpc
+        // kept, EVERY template re-source ran a blocking dashd getblocktemplate
+        // (the gbt-xcheck at work_source.cpp:949 plus the embedded-decline
+        // fallback) on the ONE ioc.run() thread that is simultaneously the
+        // stratum server, the coin-P2P ingest (incl. MSG_TX), the web server,
+        // and every tip-recovery clock (lost-body watchdog, tip-body-overdue
+        // demote). Under tx-serving mempool load the handler queue grew faster
+        // than it drained: the served height fell 4->11->13 blocks behind and
+        // self-cleared only when the mempool wave subsided (canary 9f4a424d,
+        // both episodes, NRestarts=0).
+        //
+        // THREAD CONTRACT (#1134/#1150) -- why this is safe on the coin-p2p arm:
+        // cached_work() resolves EVERY NodeCoinState read on the io thread via
+        // resolve_coin_state_arm() and hands the posted job a self-contained
+        // VALUE; resource_template_now(arm) never names coin_state_ (pinned by
+        // test/test_dash_work_source_ownership.cpp). Only the blocking dashd
+        // RPC moves off ioc. Off-io readers of NodeCoinState stay ZERO -- this
+        // does NOT reintroduce the pre-#1150 arm-exclusivity dependency.
+        //
+        // Gated on `rpc` alone (not the arm): without an rpc there is no
+        // blocking call to decouple -- the inline path is already non-blocking
+        // (dashd_fallback returns the empty set-gap immediately, gbt_xcheck_
+        // is off via set_gbt_xcheck(xcheck_wanted && rpc)).
         work_source->set_refresh_executor(
             [rpc_pool](std::function<void()> job) {
                 boost::asio::post(*rpc_pool, std::move(job));
             });
+    }
 
+    // Fallback-arm-only tip machinery (poll / ZMQ / bestblock announce /
+    // reconnect probe): on the coin-p2p arm the tip edge comes from header
+    // ingest (set_on_tip_changed -> invalidate+bump+notify), so none of this
+    // is wired there. rpc_pool above IS shared with it on the fallback arm.
+    if (!coin_p2p && rpc && stratum_server) {
         // Shared last-seen-tip dedup — the poll AND the ZMQ subscriber consult
         // it, so if both observe the same new block only the first fires the
         // refresh trio (the second is_new_tip() returns false → no-op).

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -609,8 +609,13 @@ public:
     // the dedicated rpc_pool). When set, cached_work() NEVER blocks the caller
     // on a dashd GBT: it serves the (possibly stale) cache immediately and hands
     // the blocking re-source to this executor as a SINGLE-FLIGHT background job.
-    // Set once at startup before the io loop runs. Only wired on the dashd-
-    // fallback arm; unset -> the legacy inline-blocking path (embedded/tests).
+    // Set once at startup before the io loop runs. Wired on EVERY arm with a
+    // dashd rpc armed (#139: the coin-p2p arm used to take the inline path and
+    // starved the io thread under tx-serving load); unset -> the legacy
+    // inline-blocking path (rpc-less pure-daemonless / tests), which never
+    // blocks on dashd because no rpc exists there. Safe off-io by the #1134
+    // ownership handoff: the posted job receives a by-value CoinStateArm and
+    // resource_template_now(arm) names no coin state.
     void set_refresh_executor(std::function<void(std::function<void()>)> fn)
     { refresh_executor_ = std::move(fn); }
 


### PR DESCRIPTION
## Problem (#139 canary serve-loop intermittent stall)

On the coin-p2p arm with `--coin-rpc` kept, the tx-serving canary (9f4a424d era) intermittently froze its served tip for ~15 min to 1 h and self-cleared with no restart (NRestarts=0). Root cause: the non-blocking template re-source executor was gated on `!coin_p2p`, so the coin-p2p arm ran the LEGACY INLINE path — every template re-source executed a blocking dashd `getblocktemplate` (gbt-xcheck at `work_source.cpp:949` plus the embedded-decline fallback at `:908`, serialized through `NodeRPC::m_rpc_mutex` with 12 s socket deadlines) on the ONE `ioc.run()` thread that is simultaneously the stratum server, the coin-P2P ingest (incl. MSG_TX), the web server, and every tip-recovery clock (lost-body watchdog, 30 s tip-body-overdue demote). Under a mempool wave the handler queue grew faster than it drained: served height fell 4→11→13 blocks behind and recovered only when the wave subsided.

## Fix (minimal — one gate split, zero new mechanism)

Split the single `if (!coin_p2p && rpc && stratum_server)` block in `src/c2pool/main_dash.cpp`:

- **Executor wiring** now gated on `rpc && stratum_server` alone: the dedicated 1-thread `rpc_pool` + `set_refresh_executor` are installed on ANY arm with a dashd rpc armed. `cached_work()` then takes the already-proven #1134 path on the coin-p2p arm too: serve the (possibly stale) cache immediately, hand the blocking GBT to `rpc_pool` as a single-flight background job. The io thread stays free, so header-ingest tip edges (`set_on_tip_changed` → invalidate + generation bump + notify) and all tip-recovery clocks drain promptly — a new tip ALWAYS re-pulls under tx-serving load.
- **Fallback-arm-only tip machinery** (poll / ZMQ / bestblock announce / reconnect probe) stays under the original `!coin_p2p` gate — on the coin-p2p arm the tip edge comes from header ingest, none of this is wired there.

`src/impl/dash/stratum/work_source.hpp` changes are comment-only (contract text for `set_refresh_executor`).

Gating on `rpc` (not unconditional): on a pure daemonless node there is nothing blocking to decouple — `gbt_xcheck_` is off (`set_gbt_xcheck(xcheck_wanted && rpc)`) and `dashd_fallback` returns the empty set-gap immediately, so the rpc-less inline path is already non-blocking and stays byte-identical.

## Thread safety (the #1150 arm-exclusivity concern)

Off-io readers of `NodeCoinState` remain ZERO — this does NOT reintroduce the pre-#1150 dependency:

- `cached_work()` resolves EVERY coin-state read on the io thread via `resolve_coin_state_arm()` (`work_source.cpp:1697`) and posts a self-contained by-value `CoinStateArm` (`DashWorkData` deep-copied; the only pointer, `pin_txs`, targets load-time-immutable pin storage — its only mutator call site is the startup `--pin-local-tx` file load, pre-`ioc.run()`).
- The posted job runs `resource_template_now(arm)`, which never names `coin_state_` — machine-pinned by `test/test_dash_work_source_ownership.cpp` (greps the function body AND enumerates every `coin_state_` access in the file).
- `select_work()`'s fallback closure inside the resolve is a documented no-op, so no dashd RPC runs on the io thread from the resolve, and no coin-state read runs on the pool thread from the source.
- Single-flight (`template_refresh_inflight_` claimed under `template_mutex_`, cleared in the posted job) collapses ~26 concurrent session triggers to one in-flight re-source; the cache store stamps the pre-source generation, so a tip bump racing the GBT leaves the snapshot one generation behind and the next request re-sources — no stale-store latch.
- Teardown was already arm-agnostic: `rpc_pool` stop()+join() runs right after `ioc.run()` returns and BEFORE `stratum_server` / `work_source` / `rpc` unwind; declaration order keeps the posted job's `this` alive past the worker join.

## Deliberately left out (follow-up)

The equal-height gates on the three gbt-xcheck swap branches (`work_source.cpp:954/:1026/:1116`) that make the reward-safety swap unreachable once the serve tip lags. With the starvation site removed the lag state that exposes them stops occurring; relaxing a reward-path swap gate is not minimal and needs its own review with a caller-side lock trace.

## Verification

- Full configure + build of `c2pool-dash` succeeded (rc=0) on this tree.
- `test_dash_node_coin_state` 103/103 PASSED (incl. `RefreshExecutorArmGuardSupersededByCoinStateOwnership`, which pins exactly one `set_refresh_executor` install site and the ownership handoff, not the old arm guard).
- `test_dash_stratum_work_source` 115/115 PASSED (single-flight + executor-path + staleness suites).
- No test pins the old `!coin_p2p` gate (grep-verified; comments only).

## Acceptance before undraft

Canary redeploy with `--coin-rpc` kept and `--embedded-serve-mempool-txs` on; acceptance = no served-height lag episode across a mempool wave, and the #1134 single-flight log shape observed on the coin-p2p arm.
