### PR TITLE
dash(mempool): tx-selection byte-parity vs dashd

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -2124,6 +2124,33 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // never coincide) and blind to a strict SUBSET that contains an invalid
     // transaction, which is exactly the case that costs a whole block.
     node_coin_state.set_serve_mempool_txs(embedded_serve_mempool_txs);
+    // ── IS/CL MINING-SAFETY HOLD arming (dashd TestPackageTransactions) ─────
+    // dashd's miner refuses any not-yet-islocked tx with vins younger than 10
+    // minutes when spork2 (InstantSend) AND spork3 (RejectConflictingBlocks)
+    // are active (node/miner.cpp:374-391; WAIT_FOR_ISLOCK_TIMEOUT,
+    // chainlock/handler.cpp:35) — its defence against mining a tx that then
+    // LOSES to a conflicting islock (conflict-tx-lock block reject). Mirror
+    // the SAME spork gate: derive the arm-bit from the coin-P2P SporkState
+    // (assume-active mainnet seed, refined by verified spork messages),
+    // recomputed on the io thread — the spork map's writer thread — whenever a
+    // verified spork applies, and pushed into the mempool as an atomic. The
+    // hold additionally self-gates on isdlock-feed LIVENESS inside the mempool
+    // (mempool.hpp ISLOCK_FEED_FRESH_SECS), so a dark isdlock leg degrades to
+    // the pre-hold include-immediately behaviour instead of holding every
+    // young tx for 10 minutes. No coin-P2P arm => no isdlock feed => the
+    // arm-bit below is never set and the hold stays OFF.
+    if (coin_p2p) {
+        auto arm_is_hold = [&cp = *coin_p2p, &ncs = node_coin_state]() {
+            const int64_t now = static_cast<int64_t>(std::time(nullptr));
+            const auto& ss = cp.spork_state();
+            ncs.mempool().set_instantsend_mining_hold(
+                ss.is_active(dash::coin::SPORK_2_INSTANTSEND_ENABLED, now)
+                && ss.is_active(dash::coin::SPORK_3_INSTANTSEND_BLOCK_FILTERING,
+                                now));
+        };
+        arm_is_hold();   // seed posture now (mainnet seed: both active)
+        coin_p2p->set_spork_change_callback(arm_is_hold);
+    }
     // #107 PHASE 2 (--embedded-accrue-asset-locks): DEFAULT OFF. When ON the
     // embedded CbTx creditPoolBalance accrues the pending type-8 asset-lock term
     // dashd commits, so the gbt-xcheck-modulo-special-explained swap stops
@@ -3526,6 +3553,14 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         // for viability; enriches the assembled template.
         coin_feed_subs.push_back(
             c2pool::dash::wire_mempool_ingest(coin_state, *maintainer));
+        // Leg 1b (islock relay): new_islock -> maintainer.on_islock ->
+        // Mempool::add_islock. Activates the ALREADY-MERGED G4
+        // conflict-tx-lock selection guard (#1110, feed-less until now) and
+        // the IS mining-safety hold's IsLocked short-circuit. Fee-affecting
+        // only, never validity: an islock can only EXCLUDE a tx from the
+        // embedded template / evict a conflicting pool entry.
+        coin_feed_subs.push_back(
+            c2pool::dash::wire_islock_ingest(coin_state, *maintainer));
         // Leg 2 (tip advance): Node::new_tip -> maintainer.on_new_tip. The
         // new_tip event is FIRED by the tip-changed callback below (off the
         // header chain), NOT the raw wire.

--- a/src/impl/bitcoin_family/coin/base_p2p_messages.hpp
+++ b/src/impl/bitcoin_family/coin/base_p2p_messages.hpp
@@ -117,6 +117,7 @@ struct inventory_type
         // enum GetDataMsg). Only the ones we actually request are listed.
         quorum_final_commitment = 21,   // MSG_QUORUM_FINAL_COMMITMENT
         clsig           = 29,           // MSG_CLSIG (dashcore protocol.h:522)
+        isdlock         = 31,           // MSG_ISDLOCK (dashcore protocol.h:524)
         witness_tx      = 0x40000001,   // MSG_WITNESS_TX (BIP 144)
         witness_block   = 0x40000002,   // MSG_WITNESS_BLOCK (BIP 144)
     };

--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -1000,8 +1000,11 @@ public:
     /// entry immediately and keeps the outpoints excluded from template
     /// selection (Mempool::add_islock, incl. the documented residual race).
     /// FEED: the coin-P2P isdlock parse leg (dashd-peer relay, same source
-    /// invariant as on_mempool_tx); until that leg lands nothing calls this
-    /// in a live node and selection behaviour is unchanged (empty map).
+    /// invariant as on_mempool_tx): inv(MSG_ISDLOCK) → isdlock handler →
+    /// Node::new_islock → wire_islock_ingest → here. Also drives the IS
+    /// mining-safety hold's IsLocked short-circuit (mempool.hpp). On an
+    /// un-wired node (no coin-P2P) nothing calls this and selection
+    /// behaviour is unchanged (empty map, hold self-disarmed).
     void on_islock(const uint256& locked_txid,
                    const std::vector<std::pair<uint256, uint32_t>>& inputs) {
         m_state.mempool().add_islock(locked_txid, inputs);

--- a/src/impl/dash/coin/embedded_gbt.hpp
+++ b/src/impl/dash/coin/embedded_gbt.hpp
@@ -541,7 +541,17 @@ inline DashWorkData build_embedded_workdata(
     // UPPER BOUND (every configured pin, before the admission gate runs); the
     // gate can only shrink it, so deducting the bound is conservative and can
     // never let the block exceed the cap.
-    constexpr uint32_t MAX_BLOCK_BYTES   = 1'990'000;  // leave headroom for cb
+    // DELIBERATE ~9 KB conservative divergence from dashd (audited, kept):
+    // dashd's effective ceiling is nBlockMaxSize = MaxBlockSize(2,000,000) -
+    // 1000 = 1,999,000 (miner.cpp:212) against a 1000-byte coinbase reserve —
+    // its coinbase pays ONE output. OURS pays the whole PPLNS window (dozens
+    // to hundreds of miner outputs, kilobytes), so the extra headroom is
+    // load-bearing against bad-blk-length on a won block (the block-2517855
+    // loss class). Cost: byte-parity with dashd can break ONLY when the
+    // mempool backlog fills blocks to within ~9 KB of the cap — set/merkle
+    // divergence in the consensus-safe (smaller) direction. Do NOT raise this
+    // to 1,999,000 without sizing the REAL coinbase into reserved_bytes.
+    constexpr uint32_t MAX_BLOCK_BYTES   = 1'990'000;
     constexpr uint32_t kCoinbaseReserve  = 1'000;      // dashd node/miner.cpp:115
     uint64_t reserved_bytes = kCoinbaseReserve;
     if (qc_commitments != nullptr) {
@@ -573,12 +583,19 @@ inline DashWorkData build_embedded_workdata(
     // vin spending a UTXO coinbase younger than 100 confs AT THIS HEIGHT is
     // refused (bad-txns-premature-spend-of-coinbase). Selection is also
     // topological (G1) and sigop-capped (G2) — see mempool.hpp.
+    // lock_time_cutoff=mtp_at_tip threads dashd's TestPackageTransactions
+    // finality re-check (IsFinalTx at nHeight/MTP(prev), miner.cpp:377) into
+    // selection — the reorg-edge closure of the bad-txns-nonfinal
+    // N-A-by-invariant row. The IS mining-safety hold (WAIT_FOR_ISLOCK_
+    // TIMEOUT) also runs inside selection; its arming is pushed separately
+    // (Mempool::set_instantsend_mining_hold + the isdlock feed liveness).
     auto [selected, total_fees] =
         suppress_mempool_txs
             ? std::pair<std::vector<Mempool::SelectedTx>, uint64_t>{{}, 0ull}
             : mempool.get_sorted_txs_with_fees(selection_budget,
                                                /*exclude_special=*/true,
-                                               /*next_height=*/w.m_height);
+                                               /*next_height=*/w.m_height,
+                                               /*lock_time_cutoff=*/mtp_at_tip);
     // MN-collateral spend filter (sml_projection.hpp, FINDING-2). The C-3
     // special-tx cut above is NOT sufficient: dashd's verifier removes a
     // masternode from the list when ANY block tx — special or not — spends
@@ -628,7 +645,8 @@ inline DashWorkData build_embedded_workdata(
             // served more than selection_budget even with serving enabled.
             mempool.get_sorted_txs_with_fees(selection_budget,
                                              /*exclude_special=*/true,
-                                             /*next_height=*/w.m_height);
+                                             /*next_height=*/w.m_height,
+                                             /*lock_time_cutoff=*/mtp_at_tip);
         (void)cand_fees;
         w.m_txset_candidates.reserve(cand.size());
         w.m_txset_candidate_fees.reserve(cand.size());

--- a/src/impl/dash/coin/mempool.hpp
+++ b/src/impl/dash/coin/mempool.hpp
@@ -146,6 +146,31 @@ public:
     /// is within 1000 bytes of full, addPackageTxs gives up scanning.
     static constexpr int64_t MAX_CONSECUTIVE_FAILURES = 1000;
 
+    /// dashd WAIT_FOR_ISLOCK_TIMEOUT (src/chainlock/handler.cpp:35, 10min) —
+    /// the IS/CL MINING-SAFETY HOLD. On mainnet (spork2 InstantSend + spork3
+    /// RejectConflictingBlocks active) dashd's BlockAssembler REFUSES any
+    /// package member with vins that is not islocked AND whose first-seen age
+    /// is under this bound (TestPackageTransactions, miner.cpp:374-391 →
+    /// ChainlockHandler::IsTxSafeForMining, handler.cpp:204-215). It is the
+    /// miner-side defence against the islock-formation race: mine a tx whose
+    /// outpoints then get islocked to a CONFLICTING spend and the won block
+    /// dies conflict-tx-lock (validation.cpp). MempoolEntry::time_added is our
+    /// txFirstSeenTime; a tx with a KNOWN islock (m_islock_txids) is safe
+    /// immediately, exactly dashd's IsLocked(txid) short-circuit.
+    static constexpr time_t WAIT_FOR_ISLOCK_TIMEOUT_SECS = 600;
+
+    /// c2pool-side LIVENESS GATE on the hold (NO dashd equivalent — dashd
+    /// trusts its own islock db to be alive). Our islock knowledge rides the
+    /// coin-P2P isdlock leg; if that leg goes dark (the qrinfo-#1077 silent-
+    /// registry failure class) an armed hold would quietly hold EVERY young tx
+    /// for 10 minutes — far WORSE template parity than no hold at all. So the
+    /// hold is active only while an islock has been seen this recently; a dark
+    /// feed degrades to the pre-hold include-immediately behaviour (reward-
+    /// safe: the #1218 gbt-xcheck fails closed to dashd on any divergence
+    /// while the fallback arm exists). Mainnet forms an islock for most txs,
+    /// so a healthy feed ticks many times per block interval.
+    static constexpr time_t ISLOCK_FEED_FRESH_SECS = 600;
+
     explicit Mempool(size_t max_bytes  = DEFAULT_MAX_BYTES,
                      time_t expiry_sec = DEFAULT_EXPIRY_SECS)
         : m_max_bytes(max_bytes)
@@ -172,6 +197,23 @@ public:
     {
         std::lock_guard<std::mutex> lock(m_mutex);
         return m_block_min_tx_fee;
+    }
+
+    /// Arm/disarm the IS/CL mining-safety hold. The caller (main_dash, off the
+    /// coin-P2P SporkState on its io thread) pushes the spork2+spork3
+    /// conjunction here — dashd's own gate: TestPackageTransactions skips the
+    /// hold entirely when !RejectConflictingBlocks() || !IsInstantSendEnabled()
+    /// (miner.cpp:382). Atomic because the selection path reads it from the
+    /// serve executor. DEFAULT OFF so unit tests and un-wired callers keep the
+    /// pre-hold selection behaviour bit-for-bit; even when armed, the hold
+    /// additionally self-gates on isdlock-feed liveness (ISLOCK_FEED_FRESH_SECS).
+    void set_instantsend_mining_hold(bool armed)
+    {
+        m_is_hold_armed.store(armed, std::memory_order_relaxed);
+    }
+    bool instantsend_mining_hold() const
+    {
+        return m_is_hold_armed.load(std::memory_order_relaxed);
     }
 
     /// ── PINNED-LOCAL-TX include gate (donation-dust consolidation lane) ────
@@ -471,8 +513,13 @@ public:
 
         // G4: an outpoint spent by a CONFIRMED tx is resolved — whatever
         // islock claimed it is now enforced (or moot) by the chain itself, so
-        // the tracking entry has done its job. Prune it.
+        // the tracking entry has done its job. Prune it. Same for the
+        // locked-TXID index: a confirmed tx no longer needs its islock to
+        // bypass the mining-safety hold (it left the pool). Stale txids left
+        // behind in m_islock_txid_order are harmless — the FIFO eviction in
+        // add_islock erases them from the (already-pruned) set as it pops.
         for (const auto& mtx : block.m_txs) {
+            m_islock_txids.erase(dash_txid(mtx));
             for (const auto& vin : mtx.vin) {
                 m_islock_outpoints.erase(
                     std::make_pair(vin.prevout.hash, vin.prevout.index));
@@ -510,13 +557,31 @@ public:
     /// full extent of what any miner can do.
     ///
     /// FEED: dashd-peer relay (the sole-ingestion-path invariant covers
-    /// islocks too — they arrive from the same relay peers as the txs).
-    /// Until the coin-P2P isdlock parse leg lands, this map stays empty and
-    /// selection behaves exactly as before (empty map = no exclusions).
+    /// islocks too — they arrive from the same relay peers as the txs), via
+    /// the coin-P2P isdlock leg: inv(MSG_ISDLOCK=31) → getdata → isdlock →
+    /// Node::new_islock → CoinStateMaintainer::on_islock → here. The BLS sig
+    /// is NOT yet verified (see the trust-posture note on message_isdlock,
+    /// p2p_messages.hpp), which is why every consumer of this map sits in the
+    /// fee-only-safe direction. An un-wired node (no coin-P2P) keeps the map
+    /// empty and selection behaves exactly as before (empty map = no
+    /// exclusions, hold self-disarmed by the liveness gate).
     void add_islock(const uint256& locked_txid,
                     const std::vector<std::pair<uint256, uint32_t>>& inputs)
     {
         std::lock_guard<std::mutex> lock(m_mutex);
+        // Locked-TXID index — dashd's IsLocked(txid) equivalent for the IS
+        // mining-safety hold: a tx WITH a known islock is safe to mine
+        // immediately (TestPackageTransactions skips the 10-min hold for it).
+        // Bounded FIFO like the outpoint map below (relay is untrusted input).
+        while (m_islock_txid_order.size() >= MAX_ISLOCK_OUTPOINTS
+               && !m_islock_txid_order.empty()) {
+            m_islock_txids.erase(m_islock_txid_order.front());
+            m_islock_txid_order.pop_front();
+        }
+        if (m_islock_txids.insert(locked_txid).second)
+            m_islock_txid_order.push_back(locked_txid);
+        // Feed-liveness tick for the hold's ISLOCK_FEED_FRESH_SECS gate.
+        m_last_islock_seen = std::time(nullptr);
         for (const auto& in : inputs) {
             // Bound the tracking map (relay is untrusted input): evict the
             // oldest registration once over cap. 100k outpoints ≈ a few MB.
@@ -573,6 +638,9 @@ public:
         m_feerate_index.clear();
         m_islock_outpoints.clear();
         m_islock_order.clear();
+        m_islock_txids.clear();
+        m_islock_txid_order.clear();
+        m_last_islock_seen = 0;
         m_total_bytes = 0;
     }
 
@@ -744,9 +812,16 @@ public:
     // true (safe-minimal: the creditPool accrual then reduces to the platform-
     // reward term only). Default false preserves the mempool's general pricing +
     // selection capability (including the asset-unlock fee path) unchanged.
+    // lock_time_cutoff: dashd m_lock_time_cutoff = MTP(pindexPrev)
+    // (miner.cpp:223) for the per-member IsFinalTx re-check
+    // (TestPackageTransactions, miner.cpp:377). 0 (legacy/test callers) skips
+    // the check, preserving the sole-ingestion-path N-A argument unchanged;
+    // the embedded GBT passes the tip MTP, which closes that argument's reorg
+    // edge (height/MTP can REGRESS across a reorg while the tx stays pooled).
     std::pair<std::vector<SelectedTx>, uint64_t>
     get_sorted_txs_with_fees(uint32_t max_bytes, bool exclude_special = false,
-                             uint32_t next_height = 0) const
+                             uint32_t next_height = 0,
+                             int64_t lock_time_cutoff = 0) const
     {
         std::lock_guard<std::mutex> lock(m_mutex);
         std::vector<SelectedTx> result;
@@ -755,6 +830,18 @@ public:
         uint32_t total_bytes  = 0;
         uint32_t total_sigops = DASH_COINBASE_SIGOPS_RESERVE;   // G2
         auto* utxo = m_utxo.load();
+
+        // IS/CL mining-safety hold (dashd TestPackageTransactions): active
+        // only when ARMED (spork2+spork3 via set_instantsend_mining_hold —
+        // dashd's !RejectConflictingBlocks()/!IsInstantSendEnabled() skip)
+        // AND the isdlock feed is demonstrably ALIVE (c2pool-side liveness
+        // gate, see ISLOCK_FEED_FRESH_SECS — a dark feed must degrade to the
+        // pre-hold behaviour, never hold every young tx for 10 minutes).
+        const time_t now_ts = std::time(nullptr);
+        const bool is_hold_active =
+            m_is_hold_armed.load(std::memory_order_relaxed)
+            && m_last_islock_seen != 0
+            && now_ts - m_last_islock_seen <= ISLOCK_FEED_FRESH_SECS;
 
         // ── D1: static ancestor closure + LOCAL ancestor-score index ─────────
         // The persistent m_feerate_index (keyed by standalone feerate) is left
@@ -866,9 +953,9 @@ public:
             //     rate". min-fee is POLICY, not consensus: the worst case of
             //     over-including (floor set too low) is a valid, fee-suboptimal
             //     block, never an invalid/orphaned one.
+            uint64_t fee_wa;
+            uint32_t size_wa;
             {
-                uint64_t fee_wa;
-                uint32_t size_wa;
                 if (using_mod) {
                     const ModEntry& me = mod_by_txid.at(txid);
                     fee_wa  = me.mod_modfee_wa;
@@ -881,6 +968,37 @@ public:
                         < block_min_fee_for_size(m_block_min_tx_fee, size_wa)) {
                     return {std::move(result), total_fees};
                 }
+            }
+
+            // (d.6) dashd TestPackage BYTE leg, IN dashd's position (miner.cpp
+            //     :592-604 calls TestPackage on packageSize — the ancestor-
+            //     score totals, exactly our size_wa — BEFORE the package is
+            //     even collected and BEFORE any member-level check), with
+            //     dashd's boundary: nBlockSize + packageSize >= nBlockMaxSize
+            //     fails AT the cap (miner.cpp:361, `>=`, not the old `>`).
+            //     This is the counter-parity half of the audit's ordering
+            //     divergence: a package failing BOTH the byte cap and a
+            //     member-level check must bump nConsecutiveFailed (dashd bumps
+            //     at TestPackage, before TestPackageTransactions ever runs).
+            //     size_wa == the collected package's byte remainder whenever
+            //     the package is admittable (any mismatch implies a
+            //     fee-unknown member, which block (f) drops regardless).
+            //     The sigop half of TestPackage stays in (g): dashd tests a
+            //     CACHED sigops-with-ancestors we do not maintain (ours is
+            //     computed during member validation); a package failing ONLY
+            //     the sigop cap still bumps there, so the residual counter
+            //     divergence is the dual-fail (sigop-cap AND member-check)
+            //     package — vanishingly rare at DASH's 40k-sigop cap.
+            if (static_cast<uint64_t>(total_bytes) + size_wa
+                    >= static_cast<uint64_t>(max_bytes)) {
+                if (using_mod) { erase_mod(txid); failed.insert(txid); }
+                ++nConsecutiveFailed;
+                if (nConsecutiveFailed > MAX_CONSECUTIVE_FAILURES
+                    && static_cast<int64_t>(total_bytes)
+                           > static_cast<int64_t>(max_bytes) - 1000) {
+                    break;
+                }
+                continue;
             }
 
             // (e) BUILD PACKAGE. collect_package_locked stays the AUTHORITATIVE
@@ -915,6 +1033,40 @@ public:
             for (const auto* e : package) {
                 if (!e->fee_known) { ok = false; break; }
                 if (exclude_special && e->tx.type != 0) { ok = false; break; }
+
+                // ── dashd TestPackageTransactions (node/miner.cpp:374-391),
+                // member-level; either failure drops the WHOLE package and —
+                // like dashd — does NOT bump nConsecutiveFailed. ────────────
+                //
+                // (1) IsFinalTx(tx, nHeight, MTP(prev)): the selection-time
+                //     finality re-check. Steady-state this is a no-op (the
+                //     sole-ingestion-path invariant: relay-admitted txs are
+                //     final at admission and finality is monotonic), but
+                //     across a REORG next-height/MTP can regress while the tx
+                //     stays pooled — this closes that documented edge.
+                //     lock_time_cutoff==0 (legacy/test callers) skips.
+                if (lock_time_cutoff != 0 && next_height != 0
+                    && !is_final_tx(e->tx, next_height, lock_time_cutoff)) {
+                    ok = false;
+                    break;
+                }
+                // (2) IS/CL mining-safety hold (WAIT_FOR_ISLOCK_TIMEOUT): a
+                //     member WITH vins, with NO known islock, first seen less
+                //     than 10 minutes ago is not yet safe to mine — the
+                //     islock that eventually forms may lock a CONFLICTING
+                //     spend, and a won block carrying this tx then dies
+                //     conflict-tx-lock. vin-less members (type-9 asset
+                //     unlocks) are exempt exactly as in dashd
+                //     (!it->GetTx().vin.empty(), miner.cpp:386). An UNKNOWN
+                //     first-seen in dashd yields age 0 => held; time_added is
+                //     always set here, so the same posture holds by
+                //     construction.
+                if (is_hold_active && !e->tx.vin.empty()
+                    && !m_islock_txids.count(e->txid)
+                    && now_ts - e->time_added < WAIT_FOR_ISLOCK_TIMEOUT_SECS) {
+                    ok = false;
+                    break;
+                }
 
                 // G2: legacy sigops (every scriptSig + every scriptPubKey,
                 // multisig = 20), exactly dashd GetLegacySigOpCount.
@@ -1001,13 +1153,17 @@ public:
                 if (using_mod) { erase_mod(txid); failed.insert(txid); }
                 continue;
             }
-            (void)pkg_fees;   // accounted below via per-entry e->fee
+            (void)pkg_fees;    // accounted below via per-entry e->fee
+            (void)pkg_bytes;   // byte cap now tested pre-collect on size_wa,
+                               // dashd TestPackage's position — see (d.6)
 
-            // ── (g) Caps. Byte cap strict `>`, sigop cap `>=` (reject AT the
-            // cap). Each cap failure is one dashd TestPackage() failure
-            // (miner.cpp:359-368 tests byte AND sigop caps together): only a
-            // mapModifiedTx pick is erased+failed (dashd :590-596); a mapTx pick
-            // already had `mi` advanced.
+            // ── (g) Sigop cap, `>=` (reject AT the cap). The byte half of
+            // dashd TestPackage moved to (d.6); this half stays here because
+            // dashd tests a CACHED sigops-with-ancestors and ours is computed
+            // during the member walk above. Each failure is one dashd
+            // TestPackage() failure: only a mapModifiedTx pick is
+            // erased+failed (dashd :590-596); a mapTx pick already had `mi`
+            // advanced.
             //
             // PORT 2: nConsecutiveFailed cutoff (dashd miner.cpp:598-603). Each
             // cap-fail bumps the counter; once >1000 consecutive fails AND the
@@ -1018,16 +1174,6 @@ public:
             // give-up test uses int64 arithmetic so `max_bytes - 1000` cannot
             // underflow when max_bytes < 1000 (dashd's nBlockMaxSize is clamped
             // >=1000, miner.cpp:212; ours is a caller-supplied param).
-            if (total_bytes + pkg_bytes > max_bytes) {
-                if (using_mod) { erase_mod(txid); failed.insert(txid); }
-                ++nConsecutiveFailed;
-                if (nConsecutiveFailed > MAX_CONSECUTIVE_FAILURES
-                    && static_cast<int64_t>(total_bytes)
-                           > static_cast<int64_t>(max_bytes) - 1000) {
-                    break;
-                }
-                continue;
-            }
             if (total_sigops + pkg_sigops >= DASH_MAX_BLOCK_SIGOPS) {
                 if (using_mod) { erase_mod(txid); failed.insert(txid); }
                 ++nConsecutiveFailed;
@@ -1113,6 +1259,17 @@ private:
     // insertion order for bounded eviction.
     std::map<std::pair<uint256, uint32_t>, uint256>    m_islock_outpoints;
     std::deque<std::pair<uint256, uint32_t>>           m_islock_order;
+    // IS mining-safety hold: txids holding a known islock (dashd
+    // IsLocked(txid)) — such a tx bypasses the 10-minute hold. Same bounded-
+    // FIFO posture as the outpoint map (relay is untrusted input).
+    std::set<uint256>                                  m_islock_txids;
+    std::deque<uint256>                                m_islock_txid_order;
+    // Feed-liveness tick (last add_islock wall time; 0 = never) — the hold's
+    // ISLOCK_FEED_FRESH_SECS self-disarm reads this under m_mutex.
+    time_t                                             m_last_islock_seen{0};
+    // Hold arm-bit (spork2+spork3, pushed from the io thread via
+    // set_instantsend_mining_hold; read on the serve executor). DEFAULT OFF.
+    std::atomic<bool>                                  m_is_hold_armed{false};
     size_t                                             m_total_bytes{0};
     size_t                                             m_max_bytes;
     time_t                                             m_expiry_sec;
@@ -1228,6 +1385,29 @@ private:
             else if (sat_per_k < 0) n_fee = -1;
         }
         return n_fee;
+    }
+
+    /// dashd IsFinalTx (src/consensus/tx_verify.cpp), exact port over
+    /// MutableTransaction: locktime==0 => final; locktime below its
+    /// height/time threshold cutoff => final; otherwise final only if EVERY
+    /// vin carries SEQUENCE_FINAL (the nLockTime-disable sentinel). Called at
+    /// selection with (next_height, MTP(prev)) — dashd's exact
+    /// TestPackageTransactions arguments (nHeight, m_lock_time_cutoff).
+    static bool is_final_tx(const MutableTransaction& tx, uint32_t block_height,
+                            int64_t block_time)
+    {
+        constexpr int64_t  LOCKTIME_THRESHOLD = 500000000;   // consensus.h
+        constexpr uint32_t SEQUENCE_FINAL     = 0xffffffff;  // CTxIn
+        if (tx.locktime == 0) return true;
+        const int64_t lt = static_cast<int64_t>(tx.locktime);
+        if (lt < (lt < LOCKTIME_THRESHOLD
+                      ? static_cast<int64_t>(block_height) : block_time)) {
+            return true;
+        }
+        for (const auto& vin : tx.vin) {
+            if (vin.sequence != SEQUENCE_FINAL) return false;
+        }
+        return true;
     }
 
     static FeeKey anc_score_key(uint64_t self_fee, uint32_t self_size,

--- a/src/impl/dash/coin/mempool_ingest.hpp
+++ b/src/impl/dash/coin/mempool_ingest.hpp
@@ -65,4 +65,23 @@ wire_mempool_ingest(::dash::interfaces::Node& node,
         });
 }
 
+// Leg 1b (islock relay): subscribe `maint` to `node.new_islock` — every
+// peer-relayed InstantSend lock (coin-P2P isdlock leg) is folded into the
+// mempool's islock tracking via on_islock -> Mempool::add_islock. This is the
+// feed that makes the ALREADY-MERGED G4 conflict-tx-lock selection guard
+// (#1110) live, and the IsLocked short-circuit of the IS mining-safety hold.
+// Fee-affecting only, never validity: an islock can only EXCLUDE a tx from
+// the embedded template / evict a conflicting pool entry — it can never add
+// one. Same lifetime rules as wire_mempool_ingest above.
+inline std::shared_ptr<EventDisposable>
+wire_islock_ingest(::dash::interfaces::Node& node,
+                   ::dash::coin::CoinStateMaintainer& maint)
+{
+    return node.new_islock.subscribe(
+        [&maint](const ::dash::interfaces::Node::IslockSeen& lk)
+        {
+            maint.on_islock(lk.txid, lk.inputs);
+        });
+}
+
 } // namespace c2pool::dash

--- a/src/impl/dash/coin/node_interface.hpp
+++ b/src/impl/dash/coin/node_interface.hpp
@@ -163,6 +163,21 @@ struct Node
     // (dkg_commitments.hpp): structural admission now, BLS verification
     // (Phase L) before any template inclusion.
     Event<coin::vendor::CFinalCommitment> new_qfcommit;
+
+    // G4 feed (conflict-tx-lock + IS mining-safety hold): fires when the
+    // coin-P2P client parses an `isdlock` (DIP-0010 InstantSend lock,
+    // inv MSG_ISDLOCK=31 → getdata). Carries the locked txid plus the locked
+    // outpoints, exactly what Mempool::add_islock consumes (via
+    // CoinStateMaintainer::on_islock — wire_islock_ingest subscribes). The
+    // BLS signature is deliberately NOT carried: it is unverified in this
+    // slice, so consumers are restricted to the fee-only-safe directions —
+    // see the trust-posture note on message_isdlock (p2p_messages.hpp).
+    struct IslockSeen {
+        uint256                                       txid;
+        std::vector<std::pair<uint256, uint32_t>>     inputs;   // locked outpoints
+    };
+    Event<IslockSeen> new_islock;
+
     // ── E-SUPERBLOCK: daemonless governance feed (govsync) ────────────────
     // Reception path: fires when the coin-P2P client parses a `govobj`
     // (MNGOVERNANCEOBJECT) message. Carries the object hash (dashcore

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -680,6 +680,10 @@ private:
     // ID from dashd chainparams; overridable only by the test seam below.
     SporkState m_spork_state;
     std::array<uint8_t, 20> m_spork_pubkey_id{MAINNET_SPORK_PUBKEY_ID};
+    // IS/CL mining-safety hold seam (set_spork_change_callback): fired on the
+    // io thread whenever a verified spork applies, so the hold's spork2+spork3
+    // arm-bit is recomputed on the SAME thread that owns m_spork_state.
+    std::function<void()> m_spork_change_cb;
 
     // ── Lost-body watchdog state (see BODY_REREQUEST_* above) ────────────
     // One slot per tracked outstanding getdata(block); disarmed by the block
@@ -842,6 +846,18 @@ public:
         m_max_peers = std::clamp<std::size_t>(n, 1, POOL_PEERS_HARD_CAP);
     }
     std::size_t max_peers() const { return m_max_peers; }
+
+    /// IS/CL mining-safety hold seam: invoked on the io thread after every
+    /// VERIFIED spork APPLIES to SporkState (never for stale/bad-signature
+    /// messages). main_dash uses it to recompute the spork2+spork3 conjunction
+    /// and push the result into the mempool's hold arm-bit (an atomic), so the
+    /// hold tracks live spork flips exactly as dashd's TestPackageTransactions
+    /// does (IsInstantSendEnabled / RejectConflictingBlocks). Set once at
+    /// wiring time, before the io loop runs; optional (unset = no-op).
+    void set_spork_change_callback(std::function<void()> cb)
+    {
+        m_spork_change_cb = std::move(cb);
+    }
 
     /// Dial the given targets with automatic reconnection (30s interval,
     /// round-robin over the target list on each retry).
@@ -2477,6 +2493,37 @@ private:
         }
     }
 
+    ADD_P2P_HANDLER(isdlock)
+    {
+        // DIP-0010 InstantSend lock — the G4 conflict-tx-lock guard's feed and
+        // the IS mining-safety hold's IsLocked short-circuit. Reached via the
+        // inv(MSG_ISDLOCK=31)→getdata leg (inv_type_is_pulled). The BLS sig is
+        // NOT verified in this slice; consumers are restricted to the
+        // fee-only-safe directions — see the trust-posture note on
+        // message_isdlock (p2p_messages.hpp). Version-gate defensively: dashd
+        // CURRENT_VERSION==1 (deterministic islock); anything else is a layout
+        // we have not pinned, so drop it rather than mis-map outpoints.
+        if (msg->m_version != 1) {
+            LOG_DEBUG_COIND << "[" << m_chain_label << "] isdlock DROPPED"
+                            << " cause=unknown-version v="
+                            << static_cast<int>(msg->m_version);
+            return;
+        }
+        ::dash::interfaces::Node::IslockSeen ev;
+        ev.txid = msg->m_txid;
+        ev.inputs.reserve(msg->m_inputs.size());
+        for (const auto& in : msg->m_inputs)
+            ev.inputs.emplace_back(in.hash, in.index);
+        // DEBUG, not INFO: mainnet forms an islock for most transactions, so
+        // this is tx-relay-cadence traffic (the mempool's own counters are the
+        // observability surface).
+        LOG_DEBUG_COIND << "[" << m_chain_label << "] isdlock from "
+                        << (m_active ? m_active->key : std::string("?"))
+                        << ": txid=" << msg->m_txid.GetHex().substr(0, 16)
+                        << " inputs=" << msg->m_inputs.size();
+        m_coin->new_islock.happened(ev);
+    }
+
     ADD_P2P_HANDLER(qfcommit)
     {
         // E1 Phase-L sourcing leg: a peer-relayed DKG final commitment — the
@@ -2653,6 +2700,9 @@ private:
                      << m_spork_state.active_count(now_sec()) << "/"
                      << m_spork_state.known_count() << ", listener-refined "
                      << m_spork_state.listener_refined_count();
+            // A spork actually CHANGED state: let the IS mining-safety hold
+            // re-derive its spork2+spork3 arm-bit (same thread as the map).
+            if (m_spork_change_cb) m_spork_change_cb();
             break;
         case SporkIngest::Stale:
             LOG_DEBUG_COIND << "[SPORK] " << spork_name(id) << " id=" << id

--- a/src/impl/dash/coin/p2p_messages.hpp
+++ b/src/impl/dash/coin/p2p_messages.hpp
@@ -154,6 +154,45 @@ BEGIN_MESSAGE(clsig)
     }
 END_MESSAGE()
 
+// ── DIP-0010 InstantSend lock (isdlock) ────────────────────────────────────
+// dashcore instantsend/lock.h InstantSendLock wire layout: nVersion(u8) +
+// vector<COutPoint> inputs + txid(32B) + cycleHash(32B) + sig(96B BLS blob).
+// Announced by inv MSG_ISDLOCK=31 and served only on getdata (net_processing
+// relays only VERIFIED islocks), so the inv→getdata leg in inv_type_is_pulled
+// below is what makes this message reachable at all — the same registry rule
+// as clsig/qfcommit.
+//
+// ⚠ TRUST POSTURE (deliberate, documented): the 96-byte recovered threshold
+// signature is CARRIED but NOT BLS-verified in this slice — verifying it needs
+// the DIP-24 rotated SIGNING-quorum selection (GetRequestId + cycleHash →
+// quorum), which is not yet ported. The consumers are therefore restricted to
+// the FEE-ONLY-SAFE directions (Mempool::add_islock): an islock can EXCLUDE a
+// conflicting tx from the embedded template / evict it from the pool (worst
+// case = forgone fees, never an invalid block), and it SHORT-CIRCUITS the
+// 10-minute IS mining-safety hold for the locked txid itself (dashd
+// IsLocked(txid) — strictly no worse than the pre-hold behaviour, which
+// included EVERY young tx immediately). Honest dashd peers relay only islocks
+// they themselves BLS-verified, the same SPV-style trust the tx feed already
+// rides (sole-ingestion-path invariant, mempool.hpp). Full BLS verify is the
+// named follow-up before islock knowledge is treated as authoritative.
+BEGIN_MESSAGE(isdlock)
+    MESSAGE_FIELDS
+    (
+        (uint8_t,                  m_version),
+        (std::vector<TxPrevOut>,   m_inputs),      // COutPoint wire twin (hash+index)
+        (uint256,                  m_txid),
+        (uint256,                  m_cycle_hash),
+        (std::vector<uint8_t>,     m_sig)
+    )
+    {
+        READWRITE(obj.m_version);
+        READWRITE(obj.m_inputs);
+        READWRITE(obj.m_txid);
+        READWRITE(obj.m_cycle_hash);
+        READWRITE(Using<ArrayType<DefaultFormat, 96>>(obj.m_sig));
+    }
+END_MESSAGE()
+
 /// The inv-announcement sourcing policy: which inv types the DASH coin-P2P
 /// client answers with a getdata for the object itself.
 ///
@@ -167,13 +206,17 @@ END_MESSAGE()
 ///   MSG_QUORUM_FINAL_COMMITMENT = 21 — relayed DKG final commitments
 ///                                      (Phase-L MineableCommitmentCache)
 ///   MSG_CLSIG                   = 29 — ChainLocks (dashcore protocol.h:522)
+///   MSG_ISDLOCK                 = 31 — InstantSend locks (protocol.h:524),
+///                                      the G4 conflict-tx-lock guard's feed +
+///                                      the IS mining-safety hold's IsLocked
 ///
 /// Block invs are deliberately NOT here: they take the getheaders-then-block
 /// path in the inv handler, not a bare getdata.
 inline bool inv_type_is_pulled(inventory_type::inv_type t)
 {
     return t == inventory_type::quorum_final_commitment
-        || t == inventory_type::clsig;
+        || t == inventory_type::clsig
+        || t == inventory_type::isdlock;
 }
 
 // ── Phase C-SML step 4: Simplified MN List sync messages ──────────────
@@ -433,6 +476,11 @@ using Handler = MessageHandler<
     message_getblocktxn,
     message_blocktxn,
     message_clsig,
+    // ⚠ ISDLOCK lane — same registry rule as the DIP-24 pair below (#1077): a
+    // handler that exists but whose message type is absent from this list can
+    // never run; the payload dies on the unhandled-command path at DEBUG, and
+    // the G4 islock guard + the IS mining-safety hold silently stay feed-less.
+    message_isdlock,
     message_qfcommit,
     message_getmnlistd,
     message_mnlistdiff,

--- a/test/test_dash_mempool.cpp
+++ b/test/test_dash_mempool.cpp
@@ -1014,6 +1014,98 @@ TEST(DashMempoolAuditGaps, G4_IslockConflictEvictedAndNeverSelected)
            "tracking entry must be pruned";
 }
 
+// ── dashd TestPackageTransactions member-level surface (miner.cpp:374-391) ──
+
+TEST(DashMempoolAuditGaps, TPT_FinalityRecheckDropsNonFinalTx)
+{
+    // The reorg edge of the sole-ingestion-path invariant: a tx admitted as
+    // final can become NON-final when next_height regresses across a reorg
+    // while it stays pooled. dashd re-checks IsFinalTx(tx, nHeight, MTP(prev))
+    // at selection (TestPackageTransactions, miner.cpp:377) — so must we.
+    UTXOViewCache utxo(nullptr);
+    uint256 prev = mint_hash(700);
+    utxo.add_coin(Outpoint(prev, 0), Coin(100'000, {}, 1, false));
+    Mempool mp;
+    mp.set_utxo(&utxo);
+    auto tx = make_spend(prev, 0, 90'000, /*salt=*/0);
+    tx.locktime = 5'000;            // height-locked (below LOCKTIME_THRESHOLD)
+    tx.vin[0].sequence = 0;         // nLockTime ENFORCED (not SEQUENCE_FINAL)
+    ASSERT_TRUE(mp.add_tx(tx));
+
+    // next_height == locktime: IsFinalTx needs locktime < nHeight → NOT final.
+    EXPECT_TRUE(mp.get_sorted_txs_with_fees(1u << 20, false,
+                    /*next_height=*/5'000,
+                    /*lock_time_cutoff=*/1'700'000'000).first.empty())
+        << "TPT: a height-locked tx at next_height == locktime is non-final "
+           "and must be dropped at selection (post-reorg template validity)";
+    // One block later it is final again.
+    EXPECT_EQ(mp.get_sorted_txs_with_fees(1u << 20, false,
+                  /*next_height=*/5'001,
+                  /*lock_time_cutoff=*/1'700'000'000).first.size(), 1u);
+    // SEQUENCE_FINAL on every vin disables nLockTime (dashd IsFinalTx tail).
+    auto tx2 = make_spend(prev, 0, 89'000, /*salt=*/1);
+    tx2.locktime = 5'000;           // sequence stays 0xffffffff from the helper
+    Mempool mp2;
+    mp2.set_utxo(&utxo);
+    ASSERT_TRUE(mp2.add_tx(tx2));
+    EXPECT_EQ(mp2.get_sorted_txs_with_fees(1u << 20, false,
+                  /*next_height=*/5'000,
+                  /*lock_time_cutoff=*/1'700'000'000).first.size(), 1u)
+        << "TPT: SEQUENCE_FINAL vins disable nLockTime — final at any height";
+    // Legacy callers (lock_time_cutoff omitted) keep the pre-port shape.
+    EXPECT_EQ(mp.get_sorted_txs_with_fees(1u << 20, false,
+                  /*next_height=*/5'000).first.size(), 1u)
+        << "TPT: cutoff==0 must skip the re-check (sole-ingestion-path N-A)";
+}
+
+TEST(DashMempoolAuditGaps, TPT_InstantSendMiningHold)
+{
+    // dashd IsTxSafeForMining (WAIT_FOR_ISLOCK_TIMEOUT): armed with spork2+
+    // spork3 and a LIVE isdlock feed, a vin-carrying tx with NO known islock,
+    // first seen under 10 minutes, is REFUSED; its own islock lifts the hold
+    // immediately (IsLocked short-circuit).
+    UTXOViewCache utxo(nullptr);
+    uint256 prev = mint_hash(710);
+    utxo.add_coin(Outpoint(prev, 0), Coin(100'000, {}, 1, false));
+    Mempool mp;
+    mp.set_utxo(&utxo);
+    auto tx = make_spend(prev, 0, 90'000, /*salt=*/711);
+    ASSERT_TRUE(mp.add_tx(tx));
+
+    // Unarmed (spork gate off): pre-hold behaviour — included immediately.
+    EXPECT_EQ(mp.get_sorted_txs_with_fees(1u << 20).first.size(), 1u);
+
+    // Armed but feed NEVER seen: the liveness gate keeps the hold DISARMED
+    // (a dark isdlock leg must not hold every young tx for 10 minutes).
+    mp.set_instantsend_mining_hold(true);
+    EXPECT_EQ(mp.get_sorted_txs_with_fees(1u << 20).first.size(), 1u)
+        << "hold must self-disarm while the isdlock feed has never ticked";
+
+    // Armed + LIVE feed (an unrelated islock ticks liveness): the young
+    // un-islocked vin-carrying tx is HELD.
+    mp.add_islock(mint_hash(712), {{mint_hash(713), 0}});
+    EXPECT_TRUE(mp.get_sorted_txs_with_fees(1u << 20).first.empty())
+        << "TPT: young tx with vins and no islock must be held 10 minutes";
+
+    // Its own islock arrives: safe to mine immediately.
+    mp.add_islock(dash_txid(tx), {{prev, 0}});
+    EXPECT_EQ(mp.get_sorted_txs_with_fees(1u << 20).first.size(), 1u)
+        << "TPT: a KNOWN islock lifts the hold (dashd IsLocked short-circuit)";
+
+    // vin-less members (type-9 asset unlocks) are exempt — dashd checks
+    // !GetTx().vin.empty() (miner.cpp:386). A vin-less tx has no UTXO inputs,
+    // so give it an explicit zero fee via the empty shape used elsewhere.
+    auto bare = make_empty(714);
+    Mempool mp3;
+    mp3.set_utxo(&utxo);
+    mp3.set_block_min_tx_fee(0);
+    ASSERT_TRUE(mp3.add_tx(bare));
+    mp3.set_instantsend_mining_hold(true);
+    mp3.add_islock(mint_hash(715), {{mint_hash(716), 0}});   // live feed
+    EXPECT_EQ(mp3.get_sorted_txs_with_fees(1u << 20).first.size(), 1u)
+        << "TPT: vin-less txs are exempt from the mining-safety hold";
+}
+
 // ════════════════════════════════════════════════════════════════════════════
 // D1/D2/D3 — dashd BlockAssembler::addPackageTxs SELECTION-FIDELITY parity KATs
 // ════════════════════════════════════════════════════════════════════════════
@@ -1188,7 +1280,9 @@ TEST(DashMempoolSelectionFidelity, K3_D2_MapModifiedRescoreNearCap)
     auto szC1 = mp.get_entry(dash_txid(C1))->base_size;
     auto szC2 = mp.get_entry(dash_txid(C2))->base_size;
     // Cap = P + C1 + one small tx (C1, C2 and D share the same shape/size).
-    uint32_t cap = szP + szC1 + szC2;
+    // +1 because the byte cap now fails AT the cap (dashd TestPackage
+    // miner.cpp:361 `>=`): an exactly-full block needs max_bytes = size + 1.
+    uint32_t cap = szP + szC1 + szC2 + 1;
 
     auto got = sel_set(mp, cap);
     // dashd admits D (ancestor-score 22.2 outranks the {P,Ci} packages at 13.9)


### PR DESCRIPTION
## What

Closes the remaining **code** (non-soak) divergences between the embedded template's tx selection and dashd's `BlockAssembler`, verified line-by-line against dashd source (`node/miner.cpp`, `chainlock/handler.cpp`, `instantsend/lock.h`, `protocol.h`). Four items, shipped as one unit because two of them are only safe together:

### 1. `isdlock` intake leg (the enabling fix)
- `MSG_ISDLOCK=31` added to the inv-pull set (`inv_type_is_pulled`) and to `inventory_type`.
- New `isdlock` wire message: `u8 version + vector<COutPoint> + txid(32) + cycleHash(32) + 96B BLS sig`, matching dashcore `instantsend/lock.h` byte-for-byte; version-gated to `CURRENT_VERSION==1` (unknown layouts are dropped, not mis-mapped).
- Handler registered in the `Handler` message list (the #1077 dead-handler failure class is called out at the registry edit), fires `Node::new_islock`, wired via `wire_islock_ingest` -> `CoinStateMaintainer::on_islock` -> `Mempool::add_islock`.
- This makes the **already-merged but feed-less G4 conflict-tx-lock selection guard (#1110) live**: at HEAD `on_islock` had zero callers.

### 2. IS/CL mining-safety hold (dashd `TestPackageTransactions`)
- Exact port of the 10-minute hold (`WAIT_FOR_ISLOCK_TIMEOUT`, `chainlock/handler.cpp:35`; `miner.cpp:374-391`): a package member **with vins**, with **no known islock**, first seen **< 600 s** ago is refused; the whole package drops and — like dashd — does **not** bump `nConsecutiveFailed`.
- `IsLocked(txid)` short-circuit via a new bounded-FIFO locked-txid index fed by the isdlock leg; vin-less members (type-9 asset unlocks) exempt exactly as dashd (`!vin.empty()`).
- Spork gate mirrored: arm-bit = spork2 (InstantSend) AND spork3 (RejectConflictingBlocks), recomputed on the coin-P2P io thread (the spork map's writer thread) via a new `set_spork_change_callback` seam, pushed into the mempool as an atomic. **Default OFF**; never set without coin-P2P.
- c2pool-only liveness gate (`ISLOCK_FEED_FRESH_SECS=600`, no dashd equivalent — dashd trusts its own islock db): if the isdlock feed goes dark, the hold self-disarms and selection degrades to the pre-patch include-immediately behaviour instead of holding every young tx for 10 minutes. **Ordering rationale: the hold without the feed would be anti-parity** (dashd includes a tx seconds after its islock forms), which is why 1+2 ship together.

### 3. `IsFinalTx` selection-time re-check (reorg edge)
- Exact port of `consensus/tx_verify.cpp` `IsFinalTx`, threaded as `lock_time_cutoff = MTP(tip)` from `embedded_gbt` (dashd's `m_lock_time_cutoff`, `miner.cpp:223,377`). Default `0` skips for legacy/test callers, preserving the sole-ingestion-path invariant argument unchanged; the embedded GBT closes that argument's reorg edge (height/MTP can regress across a reorg while the tx stays pooled).

### 4. `TestPackage` byte-cap boundary + ordering
- Byte cap moved to dashd's position: **before** package collection, on the ancestor-score totals (`size_wa` == dashd `packageSize`), with dashd's `>=`-at-the-cap boundary (`miner.cpp:361`) and correct `nConsecutiveFailed` bumping (dashd bumps at `TestPackage`, before `TestPackageTransactions` runs).
- Sigop half stays post-member-walk: dashd tests a cached sigops-with-ancestors we do not maintain. Residual counter divergence = dual-fail (sigop-cap AND member-check) packages — negligible at the 40k cap.
- Overfill is structurally impossible: a passing check gives `total + size_wa < max`, and any admitted package is a subset of the static ancestor closure, so `pkg_bytes <= size_wa`.

## Deliberately NOT changed (audited, kept)
- `MAX_BLOCK_BYTES = 1'990'000` (~9 KB under dashd's 1,999,000): dashd's coinbase pays one output, ours pays the whole PPLNS window (kilobytes) — the headroom is load-bearing against `bad-blk-length` on a won block (the block-2517855 loss class). Documented in-code; do not raise without sizing the real coinbase into `reserved_bytes`.
- `exclude_special` + creditpool/EHF gates (task #140 fallback-only ceiling) and the MN-collateral-spend exclusion (consensus-clean).

## Trust posture (deliberate, documented in-code)
The isdlock BLS signature is **carried but not verified** (verification needs the unported DIP-24 rotated signing-quorum selection). Every consumer is restricted to the fee-only-safe direction: an islock can only EXCLUDE a tx from the template / evict a conflicting pool entry (worst case = forgone fees, never an invalid block), and the `IsLocked` hold-bypass is strictly no worse than master's include-everything-immediately. Full BLS verify is the named follow-up and a hard gate before islock knowledge is treated as authoritative post-cut.

## Safety envelope
- Hold default-OFF; arm-bit only ever set when coin-P2P is wired; liveness gate needs a first islock before the hold can act.
- Every new mechanism is exclusion-only — nothing can ADD a tx, so no new invalid-block class exists.
- The #1218 gbt-xcheck still fails closed to dashd on any divergence while the `--coin-rpc` fallback arm exists; this patch strictly narrows today's divergence and orphan exposure.

## Verification done
- Diff verified line-by-line against dashd source; `git apply` reverse-check clean against baseline `6147ef22`.
- `g++ -fsyntax-only -std=c++20` clean on every touched header AND on `main_dash.cpp` (instantiates `CoinClient<dash::Config>` and its `std::visit` dispatch, proving handler+registry consistency).
- Test survival traced: `test_dash_mempool.cpp` protected by the `lock_time_cutoff=0` default; `test_dash_embedded_gbt.cpp` locktimes sit far below its H/MTP; the G1 byte-cap-boundary test traces to the same outcome under the relocated `>=` check.
- Independently re-verified by three adversarial review lenses (code-vs-soak classification, reward-path tx-set safety incl. caller-side lock trace, no-regression vs #1131/#1163): all safe.

## Required before merge (draft until then)
1. **isdlock wire KAT** pinned from a real mainnet capture, including a registry-membership test (like `test_dash_qrinfo_wire`) — the #1077 failure class.
2. **Red/green unit tests** for the hold (young-unlocked held / islocked bypass / >10 min bypass / feed-dark disarm / spork-off disarm) and for `is_final_tx`.
3. **Soak with the gbt-xcheck armed** to measure the predicted swap-rate drop: the pre-islock-seconds merkle-divergence class should disappear from the xcheck cause histogram.

## Known caveats to price in soak
- `ISLOCK_FEED_FRESH_SECS` self-disarm is a deliberate c2pool-only divergence: during quiet windows with no islock for >10 min the hold flaps OFF and we include young txs dashd would hold — reward-safe direction, but expect it in the soak histogram.
- The relocated byte cap now trusts the `size_with_ancestors` bookkeeping (overfill provably impossible today; future edits to ancestor accounting inherit cap-correctness duty).
- Unverified isdlock = a bounded fee-grief lever from relay peers (evict/exclude via fake islocks); acceptable while the xcheck + fallback exist, must be re-reviewed at the dashd cut.
